### PR TITLE
state,upgrades: add status to Filesystem

### DIFF
--- a/state/status_filesystem_test.go
+++ b/state/status_filesystem_test.go
@@ -1,0 +1,157 @@
+// Copyright 2012-2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/state"
+)
+
+type FilesystemStatusSuite struct {
+	StorageStateSuiteBase
+	machine    *state.Machine
+	filesystem state.Filesystem
+}
+
+var _ = gc.Suite(&FilesystemStatusSuite{})
+
+func (s *FilesystemStatusSuite) SetUpTest(c *gc.C) {
+	s.StorageStateSuiteBase.SetUpTest(c)
+
+	machine, err := s.State.AddOneMachine(state.MachineTemplate{
+		Series: "quantal",
+		Jobs:   []state.MachineJob{state.JobHostUnits},
+		Filesystems: []state.MachineFilesystemParams{{
+			Filesystem: state.FilesystemParams{
+				Pool: "environscoped", Size: 1024,
+			},
+		}},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	filesystemAttachments, err := s.State.MachineFilesystemAttachments(machine.MachineTag())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(filesystemAttachments, gc.HasLen, 1)
+
+	filesystem, err := s.State.Filesystem(filesystemAttachments[0].Filesystem())
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.machine = machine
+	s.filesystem = filesystem
+}
+
+func (s *FilesystemStatusSuite) TestInitialStatus(c *gc.C) {
+	s.checkInitialStatus(c)
+}
+
+func (s *FilesystemStatusSuite) checkInitialStatus(c *gc.C) {
+	statusInfo, err := s.filesystem.Status()
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(statusInfo.Status, gc.Equals, state.StatusPending)
+	c.Check(statusInfo.Message, gc.Equals, "")
+	c.Check(statusInfo.Data, gc.HasLen, 0)
+	c.Check(statusInfo.Since, gc.NotNil)
+}
+
+func (s *FilesystemStatusSuite) TestSetErrorStatusWithoutInfo(c *gc.C) {
+	err := s.filesystem.SetStatus(state.StatusError, "", nil)
+	c.Check(err, gc.ErrorMatches, `cannot set status "error" without info`)
+
+	s.checkInitialStatus(c)
+}
+
+func (s *FilesystemStatusSuite) TestSetUnknownStatus(c *gc.C) {
+	err := s.filesystem.SetStatus(state.Status("vliegkat"), "orville", nil)
+	c.Assert(err, gc.ErrorMatches, `cannot set invalid status "vliegkat"`)
+
+	s.checkInitialStatus(c)
+}
+
+func (s *FilesystemStatusSuite) TestSetOverwritesData(c *gc.C) {
+	err := s.filesystem.SetStatus(state.StatusAttaching, "blah", map[string]interface{}{
+		"pew.pew": "zap",
+	})
+	c.Check(err, jc.ErrorIsNil)
+
+	s.checkGetSetStatus(c)
+}
+
+func (s *FilesystemStatusSuite) TestGetSetStatusAlive(c *gc.C) {
+	s.checkGetSetStatus(c)
+}
+
+func (s *FilesystemStatusSuite) checkGetSetStatus(c *gc.C) {
+	err := s.filesystem.SetStatus(state.StatusAttaching, "blah", map[string]interface{}{
+		"$foo.bar.baz": map[string]interface{}{
+			"pew.pew": "zap",
+		},
+	})
+	c.Check(err, jc.ErrorIsNil)
+
+	filesystem, err := s.State.Filesystem(s.filesystem.FilesystemTag())
+	c.Assert(err, jc.ErrorIsNil)
+
+	statusInfo, err := filesystem.Status()
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(statusInfo.Status, gc.Equals, state.StatusAttaching)
+	c.Check(statusInfo.Message, gc.Equals, "blah")
+	c.Check(statusInfo.Data, jc.DeepEquals, map[string]interface{}{
+		"$foo.bar.baz": map[string]interface{}{
+			"pew.pew": "zap",
+		},
+	})
+	c.Check(statusInfo.Since, gc.NotNil)
+}
+
+func (s *FilesystemStatusSuite) TestGetSetStatusDying(c *gc.C) {
+	err := s.State.DestroyFilesystem(s.filesystem.FilesystemTag())
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.checkGetSetStatus(c)
+}
+
+func (s *FilesystemStatusSuite) TestGetSetStatusDead(c *gc.C) {
+	err := s.State.DestroyFilesystem(s.filesystem.FilesystemTag())
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.State.DetachFilesystem(s.machine.MachineTag(), s.filesystem.FilesystemTag())
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.State.RemoveFilesystemAttachment(s.machine.MachineTag(), s.filesystem.FilesystemTag())
+	c.Assert(err, jc.ErrorIsNil)
+
+	filesystem, err := s.State.Filesystem(s.filesystem.FilesystemTag())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(filesystem.Life(), gc.Equals, state.Dead)
+
+	// NOTE: it would be more technically correct to reject status updates
+	// while Dead, but it's easier and clearer, not to mention more efficient,
+	// to just depend on status doc existence.
+	s.checkGetSetStatus(c)
+}
+
+func (s *FilesystemStatusSuite) TestGetSetStatusGone(c *gc.C) {
+	s.obliterateFilesystem(c, s.filesystem.FilesystemTag())
+
+	err := s.filesystem.SetStatus(state.StatusAttaching, "not really", nil)
+	c.Check(err, gc.ErrorMatches, `cannot set status: filesystem not found`)
+
+	statusInfo, err := s.filesystem.Status()
+	c.Check(err, gc.ErrorMatches, `cannot get status: filesystem not found`)
+	c.Check(statusInfo, gc.DeepEquals, state.StatusInfo{})
+}
+
+func (s *FilesystemStatusSuite) TestSetStatusPendingUnprovisioned(c *gc.C) {
+	err := s.filesystem.SetStatus(state.StatusPending, "still", nil)
+	c.Check(err, jc.ErrorIsNil)
+}
+
+func (s *FilesystemStatusSuite) TestSetStatusPendingProvisioned(c *gc.C) {
+	err := s.State.SetFilesystemInfo(s.filesystem.FilesystemTag(), state.FilesystemInfo{
+		FilesystemId: "fs-id",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.filesystem.SetStatus(state.StatusPending, "", nil)
+	c.Check(err, gc.ErrorMatches, `cannot set status "pending"`)
+}

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -1983,10 +1983,6 @@ func AddVolumeStatus(st *State) error {
 			if !errors.IsNotFound(err) {
 				return errors.Annotate(err, "getting status")
 			}
-			// If the volume has not been provisioned, then
-			// it should be Pending; if it has been provisioned,
-			// but there is an unprovisioned attachment, then
-			// it should be Attaching; otherwise it is Attached.
 			status, err := upgradingVolumeStatus(st, volume)
 			if err != nil {
 				return errors.Annotate(err, "deciding volume status")
@@ -2003,6 +1999,9 @@ func AddVolumeStatus(st *State) error {
 	})
 }
 
+// If the volume has not been provisioned, then it should be Pending;
+// if it has been provisioned, but there is an unprovisioned attachment,
+// then it should be Attaching; otherwise it is Attached.
 func upgradingVolumeStatus(st *State, volume Volume) (Status, error) {
 	if _, err := volume.Info(); errors.IsNotProvisioned(err) {
 		return StatusPending, nil
@@ -2036,10 +2035,6 @@ func AddFilesystemStatus(st *State) error {
 			if !errors.IsNotFound(err) {
 				return errors.Annotate(err, "getting status")
 			}
-			// If the filesystem has not been provisioned, then
-			// it should be Pending; if it has been provisioned,
-			// but there is an unprovisioned attachment, then
-			// it should be Attaching; otherwise it is Attached.
 			status, err := upgradingFilesystemStatus(st, filesystem)
 			if err != nil {
 				return errors.Annotate(err, "deciding filesystem status")
@@ -2056,6 +2051,9 @@ func AddFilesystemStatus(st *State) error {
 	})
 }
 
+// If the filesystem has not been provisioned, then it should be Pending;
+// if it has been provisioned, but there is an unprovisioned attachment, then
+// it should be Attaching; otherwise it is Attached.
 func upgradingFilesystemStatus(st *State, filesystem Filesystem) (Status, error) {
 	if _, err := filesystem.Info(); errors.IsNotProvisioned(err) {
 		return StatusPending, nil

--- a/state/volume.go
+++ b/state/volume.go
@@ -1032,7 +1032,7 @@ func (st *State) VolumeStatus(tag names.VolumeTag) (StatusInfo, error) {
 // SetVolumeStatus sets the status of the specified volume.
 func (st *State) SetVolumeStatus(tag names.VolumeTag, status Status, info string, data map[string]interface{}) error {
 	switch status {
-	case StatusAttaching, StatusAttached, StatusDetaching, StatusDestroying:
+	case StatusAttaching, StatusAttached, StatusDetaching, StatusDetached, StatusDestroying:
 	case StatusError:
 		if info == "" {
 			return errors.Errorf("cannot set status %q without info", status)

--- a/upgrades/operations.go
+++ b/upgrades/operations.go
@@ -43,6 +43,10 @@ var stateUpgradeOperations = func() []Operation {
 			version.MustParse("1.25.0"),
 			stateStepsFor125(),
 		},
+		upgradeToVersion{
+			version.MustParse("1.26.0"),
+			stateStepsFor126(),
+		},
 	}
 	return steps
 }

--- a/upgrades/steps126.go
+++ b/upgrades/steps126.go
@@ -1,0 +1,18 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades
+
+import "github.com/juju/juju/state"
+
+// stateStepsFor126 returns upgrade steps for Juju 1.26 that manipulate state directly.
+func stateStepsFor126() []Step {
+	return []Step{
+		&upgradeStep{
+			description: "add status to filesystem",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return state.AddFilesystemStatus(context.State())
+			}},
+	}
+}

--- a/upgrades/steps126_test.go
+++ b/upgrades/steps126_test.go
@@ -1,0 +1,24 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades_test
+
+import (
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/testing"
+	"github.com/juju/juju/version"
+)
+
+type steps126Suite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&steps126Suite{})
+
+func (s *steps126Suite) TestStateStepsFor126(c *gc.C) {
+	expected := []string{
+		"add status to filesystem",
+	}
+	assertStateSteps(c, version.MustParse("1.26.0"), expected)
+}

--- a/upgrades/upgrade_test.go
+++ b/upgrades/upgrade_test.go
@@ -672,7 +672,7 @@ func (s *upgradeSuite) TestUpgradeOperationsOrdered(c *gc.C) {
 func (s *upgradeSuite) TestStateUpgradeOperationsVersions(c *gc.C) {
 	versions := extractUpgradeVersions(c, (*upgrades.StateUpgradeOperations)())
 	c.Assert(versions, gc.DeepEquals, []string{
-		"1.18.0", "1.21.0", "1.22.0", "1.23.0", "1.24.0", "1.24.4", "1.25.0",
+		"1.18.0", "1.21.0", "1.22.0", "1.23.0", "1.24.0", "1.24.4", "1.25.0", "1.26.0",
 	})
 }
 


### PR DESCRIPTION
The state.Filesystem type now embeds StatusGetter
and StatusSetter. There is an upgrade step for 1.26
that adds status to existing filesystems, in the
same way we did for volumes in 1.25.

(Review request: http://reviews.vapour.ws/r/2530/)