### PR TITLE
cloudconfig: Windows internationalization

### DIFF
--- a/cloudconfig/powershell_helpers.go
+++ b/cloudconfig/powershell_helpers.go
@@ -69,7 +69,11 @@ function create-account ([string]$accountName, [string]$accountDescription, [str
 	$User.UserFlags[0] = $User.UserFlags[0] -bor 0x10000
 	$user.SetInfo()
 
-	$objOU = [ADSI]"WinNT://$hostname/Administrators,group"
+	# This gets the Administrator group name that is localized on different windows versions. 
+	# However the SID S-1-5-32-544 is the same on all versions.
+	$adminGroup = (New-Object System.Security.Principal.SecurityIdentifier("S-1-5-32-544")).Translate([System.Security.Principal.NTAccount]).Value.Split("\")[1]
+
+	$objOU = [ADSI]"WinNT://$hostname/$adminGroup,group"
 	$objOU.add("WinNT://$hostname/$accountName")
 }
 


### PR DESCRIPTION
This patch includes some fixes to internationalization on windows.

With these fixes we could deploy windows instances with other languages on aws.

(Review request: http://reviews.vapour.ws/r/2535/)