### PR TITLE
Make use of a local data dir for plugin data.

### DIFF
--- a/component/all/workload.go
+++ b/component/all/workload.go
@@ -55,7 +55,7 @@ func (c workloads) registerHookContext(addEvents func(...workload.Event) error) 
 		func(config runner.ComponentConfig) (jujuc.ContextComponent, error) {
 			hctxClient := c.newHookContextAPIClient(config.APICaller)
 			// TODO(ericsnow) Pass the unit's tag through to the component?
-			component, err := context.NewContextAPI(hctxClient, addEvents)
+			component, err := context.NewContextAPI(hctxClient, config.DataDir, addEvents)
 			if err != nil {
 				return nil, errors.Trace(err)
 			}
@@ -186,7 +186,7 @@ func (c workloads) registerUnitWorkers() func(...workload.Event) error {
 		manifold := util.AgentApiManifold(apiConfig, func(unitAgent agent.Agent, caller base.APICaller) (worker.Worker, error) {
 			apiClient := c.newHookContextAPIClient(caller)
 			config := unitAgent.CurrentConfig()
-			dataDir := agent.Dir(config.DataDir(), config.Tag())
+			dataDir := workload.DataDir(agent.Dir(config.DataDir(), config.Tag()))
 			unitHandlers.Reset(apiClient, dataDir)
 			return unitHandlers.StartEngine()
 		})

--- a/component/all/workload.go
+++ b/component/all/workload.go
@@ -52,8 +52,8 @@ func (c workloads) registerHookContext(addEvents func(...workload.Event) error) 
 	}
 
 	runner.RegisterComponentFunc(workload.ComponentName,
-		func(unit string, caller base.APICaller) (jujuc.ContextComponent, error) {
-			hctxClient := c.newHookContextAPIClient(caller)
+		func(config runner.ComponentConfig) (jujuc.ContextComponent, error) {
+			hctxClient := c.newHookContextAPIClient(config.APICaller)
 			// TODO(ericsnow) Pass the unit's tag through to the component?
 			component, err := context.NewContextAPI(hctxClient, addEvents)
 			if err != nil {

--- a/service/upstart/upstart.go
+++ b/service/upstart/upstart.go
@@ -50,7 +50,7 @@ func IsRunning() (bool, error) {
 	}
 
 	msg := fmt.Sprintf("exec %q failed", initctlPath)
-	if utils.IsNotFound(err) {
+	if utils.IsCmdNotFoundErr(err) {
 		return false, nil
 	}
 	// Note: initctl will fail if upstart is installed but not running.

--- a/service/upstart/upstart.go
+++ b/service/upstart/upstart.go
@@ -19,6 +19,7 @@ import (
 	"github.com/juju/utils/shell"
 
 	"github.com/juju/juju/service/common"
+	"github.com/juju/juju/utils"
 )
 
 var (
@@ -49,15 +50,8 @@ func IsRunning() (bool, error) {
 	}
 
 	msg := fmt.Sprintf("exec %q failed", initctlPath)
-	if os.IsNotExist(err) {
-		// Executable could not be found, go 1.3 and later
+	if utils.IsNotFound(err) {
 		return false, nil
-	}
-	if execErr, ok := err.(*exec.Error); ok {
-		// Executable could not be found, go 1.2
-		if os.IsNotExist(execErr.Err) || execErr.Err == exec.ErrNotFound {
-			return false, nil
-		}
 	}
 	// Note: initctl will fail if upstart is installed but not running.
 	// The error message will be:

--- a/utils/exec.go
+++ b/utils/exec.go
@@ -28,9 +28,9 @@ func RunCommand(cmd string, args ...string) error {
 	return errors.Annotatef(err, "error executing %q", cmd)
 }
 
-// IsNotFound returns true if the provided error indicates that the
+// IsCmdNotFoundErr returns true if the provided error indicates that the
 // command passed to exec.LookPath or exec.Command was not found.
-func IsNotFound(err error) bool {
+func IsCmdNotFoundErr(err error) bool {
 	err = errors.Cause(err)
 	if os.IsNotExist(err) {
 		// Executable could not be found, go 1.3 and later

--- a/utils/exec.go
+++ b/utils/exec.go
@@ -4,12 +4,14 @@
 package utils
 
 import (
+	"os"
 	"os/exec"
 	"strings"
 
 	"github.com/juju/errors"
 )
 
+// RunCommand execs the provided command.
 func RunCommand(cmd string, args ...string) error {
 	command := exec.Command(cmd, args...)
 	out, err := command.CombinedOutput()
@@ -24,4 +26,24 @@ func RunCommand(cmd string, args ...string) error {
 		)
 	}
 	return errors.Annotatef(err, "error executing %q", cmd)
+}
+
+// IsNotFound returns true if the provided error indicates that the
+// command passed to exec.LookPath or exec.Command was not found.
+func IsNotFound(err error) bool {
+	err = errors.Cause(err)
+	if os.IsNotExist(err) {
+		// Executable could not be found, go 1.3 and later
+		return true
+	}
+	if err == exec.ErrNotFound {
+		return true
+	}
+	if execErr, ok := err.(*exec.Error); ok {
+		// Executable could not be found, go 1.2
+		if os.IsNotExist(execErr.Err) || execErr.Err == exec.ErrNotFound {
+			return true
+		}
+	}
+	return false
 }

--- a/worker/uniter/paths.go
+++ b/worker/uniter/paths.go
@@ -53,6 +53,12 @@ func (paths Paths) GetMetricsSpoolDir() string {
 	return paths.State.MetricsSpoolDir
 }
 
+// ComponentDir returns the filesystem path to the directory
+// containing all data files for a component.
+func (paths Paths) ComponentDir(name string) string {
+	return filepath.Join(paths.State.BaseDir, name)
+}
+
 // RuntimePaths represents the set of paths that are relevant at runtime.
 type RuntimePaths struct {
 
@@ -68,6 +74,9 @@ type RuntimePaths struct {
 // StatePaths represents the set of paths that hold persistent local state for
 // the uniter.
 type StatePaths struct {
+
+	// BaseDir is the unit agent's base directory.
+	BaseDir string
 
 	// CharmDir is the directory to which the charm the uniter runs is deployed.
 	CharmDir string
@@ -123,6 +132,7 @@ func NewPaths(dataDir string, unitTag names.UnitTag) Paths {
 			JujucServerSocket: socket("agent", true),
 		},
 		State: StatePaths{
+			BaseDir:         baseDir,
 			CharmDir:        join(baseDir, "charm"),
 			OperationsFile:  join(stateDir, "uniter"),
 			RelationsDir:    join(stateDir, "relations"),

--- a/worker/uniter/paths_test.go
+++ b/worker/uniter/paths_test.go
@@ -44,6 +44,7 @@ func (s *PathsSuite) TestWindows(c *gc.C) {
 			JujucServerSocket: `\\.\pipe\unit-some-service-323-agent`,
 		},
 		State: uniter.StatePaths{
+			BaseDir:         relAgent(),
 			CharmDir:        relAgent("charm"),
 			OperationsFile:  relAgent("state", "uniter"),
 			RelationsDir:    relAgent("state", "relations"),
@@ -71,6 +72,7 @@ func (s *PathsSuite) TestOther(c *gc.C) {
 			JujucServerSocket: "@" + relAgent("agent.socket"),
 		},
 		State: uniter.StatePaths{
+			BaseDir:         relAgent(),
 			CharmDir:        relAgent("charm"),
 			OperationsFile:  relAgent("state", "uniter"),
 			RelationsDir:    relAgent("state", "relations"),

--- a/worker/uniter/runner/contextfactory.go
+++ b/worker/uniter/runner/contextfactory.go
@@ -138,6 +138,7 @@ func (f *contextFactory) coreContext() (*HookContext, error) {
 		definedMetrics:     nil,
 		pendingPorts:       make(map[PortRange]PortRangeInfo),
 		storage:            f.storage,
+		componentDir:       f.paths.ComponentDir,
 		componentFuncs:     registeredComponentFuncs,
 	}
 	if err := f.updateContext(ctx); err != nil {

--- a/worker/uniter/runner/runner.go
+++ b/worker/uniter/runner/runner.go
@@ -68,6 +68,10 @@ type Paths interface {
 	// GetMetricsSpoolDir returns the path to a metrics spool dir, used
 	// to store metrics recorded during a single hook run.
 	GetMetricsSpoolDir() string
+
+	// ComponentDir returns the filesystem path to the directory
+	// containing all data files for a component.
+	ComponentDir(name string) string
 }
 
 // NewRunner returns a Runner backed by the supplied context and paths.

--- a/workload/context/context.go
+++ b/workload/context/context.go
@@ -64,13 +64,11 @@ type Context struct {
 // NewContext returns a new jujuc.ContextComponent for workloads.
 func NewContext(api APIClient, addEvents func(...workload.Event) error) *Context {
 	return &Context{
-		api:       api,
-		workloads: make(map[string]workload.Info),
-		updates:   make(map[string]workload.Info),
-		addEvents: addEvents,
-		FindPlugin: func(ptype string) (workload.Plugin, error) {
-			return plugin.Find(ptype)
-		},
+		api:        api,
+		workloads:  make(map[string]workload.Info),
+		updates:    make(map[string]workload.Info),
+		addEvents:  addEvents,
+		FindPlugin: plugin.Find,
 	}
 }
 

--- a/workload/context/context.go
+++ b/workload/context/context.go
@@ -51,6 +51,7 @@ var _ Component = (*Context)(nil)
 // Context is the workload portion of the hook context.
 type Context struct {
 	api       APIClient
+	dataDir   string
 	plugin    workload.Plugin
 	workloads map[string]workload.Info
 	updates   map[string]workload.Info
@@ -58,13 +59,14 @@ type Context struct {
 	addEvents func(...workload.Event) error
 	// FindPlugin is the function used to find the plugin for the given
 	// plugin name.
-	FindPlugin func(pluginName, agentDir string) (workload.Plugin, error)
+	FindPlugin func(pluginName, dataDir string) (workload.Plugin, error)
 }
 
 // NewContext returns a new jujuc.ContextComponent for workloads.
-func NewContext(api APIClient, addEvents func(...workload.Event) error) *Context {
+func NewContext(api APIClient, dataDir string, addEvents func(...workload.Event) error) *Context {
 	return &Context{
 		api:        api,
+		dataDir:    dataDir,
 		workloads:  make(map[string]workload.Info),
 		updates:    make(map[string]workload.Info),
 		addEvents:  addEvents,
@@ -73,13 +75,13 @@ func NewContext(api APIClient, addEvents func(...workload.Event) error) *Context
 }
 
 // NewContextAPI returns a new jujuc.ContextComponent for workloads.
-func NewContextAPI(api APIClient, addEvents func(...workload.Event) error) (*Context, error) {
+func NewContextAPI(api APIClient, dataDir string, addEvents func(...workload.Event) error) (*Context, error) {
 	workloads, err := api.List()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 
-	ctx := NewContext(api, addEvents)
+	ctx := NewContext(api, dataDir, addEvents)
 	for _, wl := range workloads {
 		ctx.workloads[wl.ID()] = wl
 	}

--- a/workload/context/context.go
+++ b/workload/context/context.go
@@ -58,7 +58,7 @@ type Context struct {
 	addEvents func(...workload.Event) error
 	// FindPlugin is the function used to find the plugin for the given
 	// plugin name.
-	FindPlugin func(pluginName string) (workload.Plugin, error)
+	FindPlugin func(pluginName, agentDir string) (workload.Plugin, error)
 }
 
 // NewContext returns a new jujuc.ContextComponent for workloads.
@@ -114,7 +114,7 @@ func (c *Context) Plugin(info *workload.Info) (workload.Plugin, error) {
 		return c.plugin, nil
 	}
 
-	plugin, err := c.FindPlugin(info.Type)
+	plugin, err := c.FindPlugin(info.Type, "") // XXX
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/workload/context/context.go
+++ b/workload/context/context.go
@@ -116,7 +116,7 @@ func (c *Context) Plugin(info *workload.Info) (workload.Plugin, error) {
 		return c.plugin, nil
 	}
 
-	plugin, err := c.FindPlugin(info.Type, "") // XXX
+	plugin, err := c.FindPlugin(info.Type, c.dataDir)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/workload/context/context_test.go
+++ b/workload/context/context_test.go
@@ -19,6 +19,7 @@ type contextSuite struct {
 	baseSuite
 	compCtx   *context.Context
 	apiClient *stubAPIClient
+	dataDir   string
 }
 
 var _ = gc.Suite(&contextSuite{})
@@ -27,13 +28,14 @@ func (s *contextSuite) SetUpTest(c *gc.C) {
 	s.baseSuite.SetUpTest(c)
 
 	s.apiClient = newStubAPIClient(s.Stub)
-	s.compCtx = context.NewContext(s.apiClient, s.addEvents)
+	s.dataDir = "some-data-dir"
+	s.compCtx = context.NewContext(s.apiClient, s.dataDir, s.addEvents)
 
 	context.AddWorkloads(s.compCtx, s.workload)
 }
 
 func (s *contextSuite) newContext(c *gc.C, workloads ...workload.Info) *context.Context {
-	ctx := context.NewContext(s.apiClient, s.addEvents)
+	ctx := context.NewContext(s.apiClient, s.dataDir, s.addEvents)
 	for _, wl := range workloads {
 		c.Logf("adding workload: %s", wl.ID())
 		context.AddWorkload(ctx, wl.ID(), wl)
@@ -50,7 +52,7 @@ func (s *contextSuite) addEvents(events ...workload.Event) error {
 }
 
 func (s *contextSuite) TestNewContextEmpty(c *gc.C) {
-	ctx := context.NewContext(s.apiClient, s.addEvents)
+	ctx := context.NewContext(s.apiClient, s.dataDir, s.addEvents)
 	workloads, err := ctx.Workloads()
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -82,7 +84,7 @@ func (s *contextSuite) TestNewContextPrePopulated(c *gc.C) {
 func (s *contextSuite) TestNewContextAPIOkay(c *gc.C) {
 	expected := s.apiClient.setNew("A/xyx123")
 
-	ctx, err := context.NewContextAPI(s.apiClient, s.addEvents)
+	ctx, err := context.NewContextAPI(s.apiClient, s.dataDir, s.addEvents)
 	c.Assert(err, jc.ErrorIsNil)
 
 	workloads, err := ctx.Workloads()
@@ -94,14 +96,14 @@ func (s *contextSuite) TestNewContextAPIOkay(c *gc.C) {
 func (s *contextSuite) TestNewContextAPICalls(c *gc.C) {
 	s.apiClient.setNew("A/xyz123")
 
-	_, err := context.NewContextAPI(s.apiClient, s.addEvents)
+	_, err := context.NewContextAPI(s.apiClient, s.dataDir, s.addEvents)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.Stub.CheckCallNames(c, "List")
 }
 
 func (s *contextSuite) TestNewContextAPIEmpty(c *gc.C) {
-	ctx, err := context.NewContextAPI(s.apiClient, s.addEvents)
+	ctx, err := context.NewContextAPI(s.apiClient, s.dataDir, s.addEvents)
 	c.Assert(err, jc.ErrorIsNil)
 
 	workloads, err := ctx.Workloads()
@@ -114,7 +116,7 @@ func (s *contextSuite) TestNewContextAPIError(c *gc.C) {
 	expected := errors.Errorf("<failed>")
 	s.Stub.SetErrors(expected)
 
-	_, err := context.NewContextAPI(s.apiClient, s.addEvents)
+	_, err := context.NewContextAPI(s.apiClient, s.dataDir, s.addEvents)
 
 	c.Check(errors.Cause(err), gc.Equals, expected)
 	s.Stub.CheckCallNames(c, "List")
@@ -122,7 +124,7 @@ func (s *contextSuite) TestNewContextAPIError(c *gc.C) {
 
 func (s *contextSuite) TestContextComponentOkay(c *gc.C) {
 	hctx, info := s.NewHookContext()
-	expected := context.NewContext(s.apiClient, s.addEvents)
+	expected := context.NewContext(s.apiClient, s.dataDir, s.addEvents)
 	info.SetComponent(workload.ComponentName, expected)
 
 	compCtx, err := context.ContextComponent(hctx)
@@ -180,7 +182,7 @@ func (s *contextSuite) TestWorkloadsOkay(c *gc.C) {
 func (s *contextSuite) TestWorkloadsAPI(c *gc.C) {
 	expected := s.apiClient.setNew("A/spam", "B/eggs", "C/ham")
 
-	ctx := context.NewContext(s.apiClient, s.addEvents)
+	ctx := context.NewContext(s.apiClient, s.dataDir, s.addEvents)
 	context.AddWorkload(ctx, "A/spam", s.apiClient.workloads["A/spam"])
 	context.AddWorkload(ctx, "B/eggs", s.apiClient.workloads["B/eggs"])
 	context.AddWorkload(ctx, "C/ham", s.apiClient.workloads["C/ham"])
@@ -193,7 +195,7 @@ func (s *contextSuite) TestWorkloadsAPI(c *gc.C) {
 }
 
 func (s *contextSuite) TestWorkloadsEmpty(c *gc.C) {
-	ctx := context.NewContext(s.apiClient, s.addEvents)
+	ctx := context.NewContext(s.apiClient, s.dataDir, s.addEvents)
 	workloads, err := ctx.Workloads()
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -225,7 +227,7 @@ func (s *contextSuite) TestWorkloadsOverrides(c *gc.C) {
 	infoC := s.newWorkload("C", "myplugin", "xyz789", "okay")
 	expected = append(expected[:1], infoB, infoC)
 
-	ctx := context.NewContext(s.apiClient, s.addEvents)
+	ctx := context.NewContext(s.apiClient, s.dataDir, s.addEvents)
 	context.AddWorkload(ctx, "A/xyz123", s.apiClient.workloads["A/xyz123"])
 	context.AddWorkload(ctx, "B/xyz456", infoB)
 	ctx.Track(infoB)
@@ -269,7 +271,7 @@ func (s *contextSuite) TestGetOverride(c *gc.C) {
 }
 
 func (s *contextSuite) TestGetNotFound(c *gc.C) {
-	ctx := context.NewContext(s.apiClient, s.addEvents)
+	ctx := context.NewContext(s.apiClient, s.dataDir, s.addEvents)
 	_, err := ctx.Get("A/spam")
 
 	c.Check(err, jc.Satisfies, errors.IsNotFound)
@@ -277,7 +279,7 @@ func (s *contextSuite) TestGetNotFound(c *gc.C) {
 
 func (s *contextSuite) TestSetOkay(c *gc.C) {
 	info := s.newWorkload("A", "myplugin", "spam", "okay")
-	ctx := context.NewContext(s.apiClient, s.addEvents)
+	ctx := context.NewContext(s.apiClient, s.dataDir, s.addEvents)
 	before, err := ctx.Workloads()
 	c.Assert(err, jc.ErrorIsNil)
 	err = ctx.Track(info)
@@ -310,7 +312,7 @@ func (s *contextSuite) TestFlushDirty(c *gc.C) {
 		return &stubPlugin{stub: s.Stub}, nil
 	}
 
-	ctx := context.NewContext(s.apiClient, s.addEvents)
+	ctx := context.NewContext(s.apiClient, s.dataDir, s.addEvents)
 	ctx.FindPlugin = findPlugin
 	err := ctx.Track(info)
 	c.Assert(err, jc.ErrorIsNil)
@@ -332,7 +334,7 @@ func (s *contextSuite) TestFlushNotDirty(c *gc.C) {
 }
 
 func (s *contextSuite) TestFlushEmpty(c *gc.C) {
-	ctx := context.NewContext(s.apiClient, s.addEvents)
+	ctx := context.NewContext(s.apiClient, s.dataDir, s.addEvents)
 	err := ctx.Flush()
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -345,7 +347,7 @@ func (s *contextSuite) TestUntrackOkay(c *gc.C) {
 	}
 
 	info := s.newWorkload("A", "myplugin", "spam", "okay")
-	ctx := context.NewContext(s.apiClient, s.addEvents)
+	ctx := context.NewContext(s.apiClient, s.dataDir, s.addEvents)
 	ctx.FindPlugin = findPlugin
 	err := ctx.Track(info)
 	c.Assert(err, jc.ErrorIsNil)
@@ -367,7 +369,7 @@ func (s *contextSuite) TestUntrackOkay(c *gc.C) {
 
 func (s *contextSuite) TestUntrackNoMatch(c *gc.C) {
 	info := s.newWorkload("A", "myplugin", "spam", "okay")
-	ctx := context.NewContext(s.apiClient, s.addEvents)
+	ctx := context.NewContext(s.apiClient, s.dataDir, s.addEvents)
 	err := ctx.Track(info)
 	c.Assert(err, jc.ErrorIsNil)
 	before, err := ctx.Workloads()

--- a/workload/context/context_test.go
+++ b/workload/context/context_test.go
@@ -306,7 +306,7 @@ func (s *contextSuite) TestSetOverwrite(c *gc.C) {
 
 func (s *contextSuite) TestFlushDirty(c *gc.C) {
 	info := s.newWorkload("A", "myplugin", "xyz123", "okay")
-	findPlugin := func(ptype string) (workload.Plugin, error) {
+	findPlugin := func(ptype, agentDir string) (workload.Plugin, error) {
 		return &stubPlugin{stub: s.Stub}, nil
 	}
 
@@ -340,7 +340,7 @@ func (s *contextSuite) TestFlushEmpty(c *gc.C) {
 }
 
 func (s *contextSuite) TestUntrackOkay(c *gc.C) {
-	findPlugin := func(ptype string) (workload.Plugin, error) {
+	findPlugin := func(ptype, agentDir string) (workload.Plugin, error) {
 		return &stubPlugin{stub: s.Stub}, nil
 	}
 

--- a/workload/context/launch.go
+++ b/workload/context/launch.go
@@ -5,6 +5,7 @@ package context
 
 import (
 	"os"
+	"path/filepath"
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
@@ -56,8 +57,7 @@ func (c *WorkloadLaunchCommand) Run(ctx *cmd.Context) error {
 	}
 
 	// TODO(ericsnow) Move OS env info into the plugin.
-	// TODO(ericsnow) Fix this to support Windows.
-	envPath := ctx.Getenv("PATH") + ":" + os.Getenv("PATH")
+	envPath := ctx.Getenv("PATH") + string(filepath.ListSeparator) + os.Getenv("PATH")
 	if err := os.Setenv("PATH", envPath); err != nil {
 		return errors.Trace(err)
 	}

--- a/workload/event.go
+++ b/workload/event.go
@@ -3,28 +3,12 @@
 
 package workload
 
-import (
-	"gopkg.in/juju/charm.v5"
-)
-
 // The kinds of events.
 const (
 	EventKindNoop      = ""
 	EventKindTracked   = "tracked"
 	EventKindUntracked = "untracked"
 )
-
-// Plugin represents the functionality of a workload plugin.
-type Plugin interface {
-	// Launch runs the plugin's "launch" command, passing the provided
-	// workload definition. The output is converted to a Details.
-	Launch(definition charm.Workload) (Details, error)
-	// Destroy runs the plugin's "destroy" command for the given ID.
-	Destroy(id string) error
-	// Status runs the plugin's "status" command. The output is
-	// converted to a PluginStatus.
-	Status(id string) (PluginStatus, error)
-}
 
 // Event describes something that happened for a workload.
 type Event struct {

--- a/workload/paths.go
+++ b/workload/paths.go
@@ -1,0 +1,14 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package workload
+
+import (
+	"path/filepath"
+)
+
+// DataDir returns the path to the top-level data directory for
+// workloads relative to the provided base directory.
+func DataDir(baseDataDir string) string {
+	return filepath.Join(baseDataDir, ComponentName)
+}

--- a/workload/paths_test.go
+++ b/workload/paths_test.go
@@ -1,0 +1,23 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package workload_test
+
+import (
+	"path/filepath"
+
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/workload"
+)
+
+type pathsSuite struct{}
+
+var _ = gc.Suite(&pathsSuite{})
+
+func (*pathsSuite) TestDataDir(c *gc.C) {
+	base := filepath.Join("some", "base", "path")
+	dataDir := workload.DataDir(base)
+
+	c.Check(dataDir, gc.Equals, filepath.Join(base, "workloads"))
+}

--- a/workload/plugin.go
+++ b/workload/plugin.go
@@ -1,0 +1,20 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package workload
+
+import (
+	"gopkg.in/juju/charm.v5"
+)
+
+// Plugin represents the functionality of a workload plugin.
+type Plugin interface {
+	// Launch runs the plugin's "launch" command, passing the provided
+	// workload definition. The output is converted to a Details.
+	Launch(definition charm.Workload) (Details, error)
+	// Destroy runs the plugin's "destroy" command for the given ID.
+	Destroy(id string) error
+	// Status runs the plugin's "status" command. The output is
+	// converted to a PluginStatus.
+	Status(id string) (PluginStatus, error)
+}

--- a/workload/plugin.go
+++ b/workload/plugin.go
@@ -12,8 +12,10 @@ type Plugin interface {
 	// Launch runs the plugin's "launch" command, passing the provided
 	// workload definition. The output is converted to a Details.
 	Launch(definition charm.Workload) (Details, error)
+
 	// Destroy runs the plugin's "destroy" command for the given ID.
 	Destroy(id string) error
+
 	// Status runs the plugin's "status" command. The output is
 	// converted to a PluginStatus.
 	Status(id string) (PluginStatus, error)

--- a/workload/plugin/executable.go
+++ b/workload/plugin/executable.go
@@ -76,7 +76,7 @@ func findExecutablePlugin(name string, paths pluginPaths, lookPath func(string) 
 	if errors.IsNotFound(err) {
 		executableName := executablePrefix + name
 		absPath, err = lookPath(executableName)
-		if utils.IsNotFound(err) {
+		if utils.IsCmdNotFoundErr(err) {
 			return nil, errors.NotFoundf("plugin %q", name)
 		}
 		if err != nil {

--- a/workload/plugin/executable.go
+++ b/workload/plugin/executable.go
@@ -1,0 +1,181 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package plugin
+
+import (
+	"bytes"
+	"encoding/json"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/juju/deputy"
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	"gopkg.in/juju/charm.v5"
+
+	"github.com/juju/juju/workload"
+)
+
+const executablePrefix = "juju-workload-"
+
+var executableLogger = loggo.GetLogger("juju.workload.plugin.executable")
+
+// ExecutablePlugin represents a provider for launching, destroying, and
+// introspecting workloads via a specific technology such as
+// Docker or systemd.
+//
+// Plugins of this type are expected to handle three commands: launch,
+// status, and stop. See the functions of the same name for more
+// information about each command.
+//
+// If the plugin command completes successfully, the plugin should exit
+// with a 0 exit code. If there is a problem completing the command, the
+// plugin should print the error details to stdout and return a non-zero
+// exit code.
+//
+// Any information written to stderr will be piped to the unit log.
+type ExecutablePlugin struct {
+	// Name is the name of the plugin.
+	Name string
+	// Executable is the filename disk where the plugin executable resides.
+	Executable string
+}
+
+// FindExecutablePlugin returns the plugin for the given name.
+func FindExecutablePlugin(name string) (*ExecutablePlugin, error) {
+	return findExecutablePlugin(name, exec.LookPath)
+}
+
+func findExecutablePlugin(name string, lookPath func(string) (string, error)) (*ExecutablePlugin, error) {
+	path, err := lookPath(executablePrefix + name)
+	if err == exec.ErrNotFound {
+		return nil, errors.NotFoundf("plugin %q", name)
+	}
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	return &ExecutablePlugin{
+		Name:       name,
+		Executable: absPath,
+	}, nil
+}
+
+// Launch runs the given plugin, passing it the "launch" command, with the
+// workload definition passed as json to launch as an argument:
+//
+//		<plugin> launch <workload-definition>
+//
+// Workload definition is the serialization of the Workload struct from
+// github.com/juju/charm, for example:
+//
+//		{
+//			"name" : "procname",
+//			"description" : "desc",
+//			"type" : "proctype",
+//			"typeOptions" : {
+//				"key1" : "val1"
+//			},
+//			"command" : "cmd",
+//			"image" : "img",
+//			"ports" : [ { "internal" : 80, "external" : 8080 } ]
+//			"volumes" : [{"externalmount" : "mnt", "internalmount" : "extmnt", "mode" : "rw", "name" : "name"}]
+//			"envvars" : {
+//				"key1" : "val1"
+//			}
+//		}
+//
+// The plugin is expected to start the image as a new workload, and write json
+// output to stdout.  The form of the output is expected to conform to the
+// workload.Details struct.
+//
+//		{
+//			"id" : "some-id", # unique id of the workload
+//			"status" : "details" # plugin-specific metadata about the started workload
+//		}
+//
+// The id should be a unique identifier of the workload that the plugin can use
+// later to introspect the workload and/or stop it. The contents of status can
+// be whatever information the plugin thinks might be relevant to see in the
+// service's status output.
+func (p ExecutablePlugin) Launch(proc charm.Workload) (workload.Details, error) {
+	var details workload.Details
+	b, err := json.Marshal(proc)
+	if err != nil {
+		return details, errors.Annotate(err, "can't convert charm.Workload to json")
+	}
+	out, err := p.run("launch", string(b))
+	if err != nil {
+		return details, errors.Trace(err)
+	}
+	return workload.UnmarshalDetails(out)
+}
+
+// Destroy runs the given plugin, passing it the "destroy" command, with the id of the
+// workload to destroy as an argument.
+//
+//		<plugin> destroy <id>
+func (p ExecutablePlugin) Destroy(id string) error {
+	_, err := p.run("destroy", id)
+	return errors.Trace(err)
+}
+
+// Status runs the given plugin, passing it the "status" command, with the id of
+// the workload to get status about.
+//
+//		<plugin> status <id>
+//
+// The plugin is expected to write raw-string status output to stdout if
+// successful.
+func (p ExecutablePlugin) Status(id string) (workload.PluginStatus, error) {
+	out, err := p.run("status", id)
+	var status workload.PluginStatus
+	if err != nil {
+		return status, errors.Trace(err)
+	}
+	if err := json.Unmarshal(out, &status); err != nil {
+		return status, errors.Annotatef(err, "error parsing data returned from %q", p.Name)
+	}
+	if err := status.Validate(); err != nil {
+		return status, errors.Annotatef(err, "invalid details returned by plugin %q", p.Name)
+	}
+	return status, nil
+}
+
+// run runs the given subcommand of the plugin with the given args.
+func (p ExecutablePlugin) run(subcommand string, args ...string) ([]byte, error) {
+	executableLogger.Debugf("running %s %s %s", p.Executable, subcommand, args)
+	cmd := exec.Command(p.Executable, append([]string{subcommand}, args...)...)
+	return runCmd(p.Name, cmd)
+}
+
+// runCmd runs the executable at path with the subcommand as the first argument
+// and any args in args as further arguments.  It logs to loggo using the name
+// as a namespace.
+var runCmd = func(name string, cmd *exec.Cmd) ([]byte, error) {
+	log := getLogger("juju.workload.plugin." + name)
+	stdout := &bytes.Buffer{}
+	cmd.Stdout = stdout
+	err := deputy.Deputy{
+		Errors:    deputy.FromStdout,
+		StderrLog: func(b []byte) { log.Infof(string(b)) },
+	}.Run(cmd)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return stdout.Bytes(), nil
+}
+
+type infoLogger interface {
+	Infof(s string, args ...interface{})
+}
+
+var getLogger = func(name string) infoLogger {
+	return loggo.GetLogger(name)
+}

--- a/workload/plugin/executable.go
+++ b/workload/plugin/executable.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/loggo"
 	"gopkg.in/juju/charm.v5"
 
+	"github.com/juju/juju/utils"
 	"github.com/juju/juju/workload"
 )
 
@@ -73,8 +74,9 @@ type pluginPaths interface {
 func findExecutablePlugin(name string, paths pluginPaths, lookPath func(string) (string, error)) (*ExecutablePlugin, error) {
 	absPath, err := paths.Executable()
 	if errors.IsNotFound(err) {
-		absPath, err = lookPath(executablePrefix + name)
-		if err == exec.ErrNotFound {
+		executableName := executablePrefix + name
+		absPath, err = lookPath(executableName)
+		if utils.IsNotFound(err) {
 			return nil, errors.NotFoundf("plugin %q", name)
 		}
 		if err != nil {

--- a/workload/plugin/executable.go
+++ b/workload/plugin/executable.go
@@ -60,8 +60,8 @@ func newExecutablePlugin(name, executable string) *ExecutablePlugin {
 }
 
 // FindExecutablePlugin returns the plugin for the given name.
-func FindExecutablePlugin(name, agentDir string) (*ExecutablePlugin, error) {
-	paths := NewPaths(agentDir, name)
+func FindExecutablePlugin(name, dataDir string) (*ExecutablePlugin, error) {
+	paths := NewPaths(dataDir, name)
 	return findExecutablePlugin(name, paths, lookPath)
 }
 

--- a/workload/plugin/executable_test.go
+++ b/workload/plugin/executable_test.go
@@ -1,0 +1,295 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package plugin
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	stdtesting "testing"
+
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/charm.v5"
+
+	"github.com/juju/juju/testing"
+	"github.com/juju/juju/workload"
+)
+
+type executableSuite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&executableSuite{})
+
+const exitstatus1 = "exit status 1: "
+
+func (s *executableSuite) TestFindExecutablePluginOkay(c *gc.C) {
+	lookPath := func(name string) (string, error) {
+		return filepath.Join("some", "dir", "juju-workload-a-plugin"), nil
+	}
+
+	plugin, err := findExecutablePlugin("a-plugin", lookPath)
+	c.Assert(err, jc.ErrorIsNil)
+
+	expected, err := filepath.Abs(filepath.Join("some", "dir", "juju-workload-a-plugin"))
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(plugin, jc.DeepEquals, &ExecutablePlugin{
+		Name:       "a-plugin",
+		Executable: expected,
+	})
+}
+
+func (s *executableSuite) TestFindExecutablePluginNotFound(c *gc.C) {
+	lookPath := func(name string) (string, error) {
+		return "", exec.ErrNotFound
+	}
+
+	_, err := findExecutablePlugin("spam", lookPath)
+
+	c.Check(err, jc.Satisfies, errors.IsNotFound)
+}
+
+func (s *executableSuite) TestPluginInterface(c *gc.C) {
+	var _ workload.Plugin = (*ExecutablePlugin)(nil)
+}
+
+func (s *executableSuite) TestLaunch(c *gc.C) {
+	f := &fakeRunner{
+		out: []byte(`{ "id" : "foo", "status": { "state" : "bar" } }`),
+	}
+	s.PatchValue(&runCmd, f.runCmd)
+
+	p := ExecutablePlugin{"Name", "Path"}
+	proc := charm.Workload{Image: "img"}
+
+	pd, err := p.Launch(proc)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(pd, gc.Equals, workload.Details{
+		ID: "foo",
+		Status: workload.PluginStatus{
+			State: "bar",
+		},
+	})
+
+	c.Assert(f.name, gc.DeepEquals, p.Name)
+	c.Assert(f.cmd.Path, gc.Equals, p.Executable)
+	c.Assert(f.cmd.Args[1], gc.Equals, "launch")
+	c.Assert(f.cmd.Args[2:], gc.HasLen, 1)
+	// fix this to be more stringent when we fix json serialization for charm.Workload
+	c.Assert(f.cmd.Args[2], gc.Matches, `.*"Image":"img".*`)
+}
+
+func (s *executableSuite) TestLaunchBadOutput(c *gc.C) {
+	f := &fakeRunner{
+		out: []byte(`not json`),
+	}
+	s.PatchValue(&runCmd, f.runCmd)
+
+	p := ExecutablePlugin{"Name", "Path"}
+	proc := charm.Workload{Image: "img"}
+
+	_, err := p.Launch(proc)
+	c.Assert(err, gc.ErrorMatches, `error parsing data for workload details.*`)
+}
+
+func (s *executableSuite) TestLaunchNoId(c *gc.C) {
+	f := &fakeRunner{
+		out: []byte(`{ "status" : { "status" : "bar" } }`),
+	}
+	s.PatchValue(&runCmd, f.runCmd)
+
+	p := ExecutablePlugin{"Name", "Path"}
+	proc := charm.Workload{Image: "img"}
+
+	_, err := p.Launch(proc)
+	c.Assert(err, jc.Satisfies, errors.IsNotValid)
+}
+
+func (s *executableSuite) TestLaunchNoStatus(c *gc.C) {
+	f := &fakeRunner{
+		out: []byte(`{ "id" : "foo" }`),
+	}
+	s.PatchValue(&runCmd, f.runCmd)
+
+	p := ExecutablePlugin{"Name", "Path"}
+	proc := charm.Workload{Image: "img"}
+
+	_, err := p.Launch(proc)
+	c.Assert(err, jc.Satisfies, errors.IsNotValid)
+}
+
+func (s *executableSuite) TestLaunchErr(c *gc.C) {
+	f := &fakeRunner{
+		err: errors.New("foo"),
+	}
+	s.PatchValue(&runCmd, f.runCmd)
+
+	p := ExecutablePlugin{"Name", "Path"}
+	proc := charm.Workload{Image: "img"}
+
+	_, err := p.Launch(proc)
+	c.Assert(errors.Cause(err), gc.Equals, f.err)
+}
+
+func (s *executableSuite) TestStatus(c *gc.C) {
+	f := &fakeRunner{
+		out: []byte(`{ "state" : "status!" }`),
+	}
+	s.PatchValue(&runCmd, f.runCmd)
+
+	p := ExecutablePlugin{"Name", "Path"}
+
+	status, err := p.Status("id")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(status, gc.Equals, workload.PluginStatus{
+		State: "status!",
+	})
+	c.Assert(f.name, gc.DeepEquals, p.Name)
+	c.Assert(f.cmd.Path, gc.Equals, p.Executable)
+	c.Assert(f.cmd.Args[1], gc.Equals, "status")
+	c.Assert(f.cmd.Args[2:], gc.DeepEquals, []string{"id"})
+}
+
+func (s *executableSuite) TestStatusErr(c *gc.C) {
+	f := &fakeRunner{
+		err: errors.New("foo"),
+	}
+	s.PatchValue(&runCmd, f.runCmd)
+
+	p := ExecutablePlugin{"Name", "Path"}
+
+	_, err := p.Status("id")
+	c.Assert(errors.Cause(err), gc.Equals, f.err)
+}
+
+func (s *executableSuite) TestDestroy(c *gc.C) {
+	f := &fakeRunner{}
+	s.PatchValue(&runCmd, f.runCmd)
+
+	p := ExecutablePlugin{"Name", "Path"}
+
+	err := p.Destroy("id")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(f.name, gc.DeepEquals, p.Name)
+	c.Assert(f.cmd.Path, gc.Equals, p.Executable)
+	c.Assert(f.cmd.Args[1], gc.Equals, "destroy")
+	c.Assert(f.cmd.Args[2:], gc.DeepEquals, []string{"id"})
+}
+
+func (s *executableSuite) TestDestroyErr(c *gc.C) {
+	f := &fakeRunner{
+		err: errors.New("foo"),
+	}
+	s.PatchValue(&runCmd, f.runCmd)
+
+	p := ExecutablePlugin{"Name", "Path"}
+
+	err := p.Destroy("id")
+	c.Assert(errors.Cause(err), gc.Equals, f.err)
+}
+
+func (s *executableSuite) TestRunCmd(c *gc.C) {
+	f := &fakeLogger{c: c}
+	s.PatchValue(&getLogger, f.getLogger)
+	m := maker{
+		stdout: "foo!",
+		stderr: "bar!\nbaz!",
+	}
+	cmd := m.make()
+	out, err := runCmd("name", cmd)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(strings.TrimSpace(string(out)), gc.DeepEquals, m.stdout)
+	c.Assert(f.name, gc.Equals, "juju.workload.plugin.name")
+	c.Assert(f.logs, gc.DeepEquals, []string{"bar!", "baz!"})
+}
+
+func (s *executableSuite) TestRunCmdErr(c *gc.C) {
+	f := &fakeLogger{c: c}
+	s.PatchValue(&getLogger, f.getLogger)
+	m := maker{
+		exit:   1,
+		stdout: "foo!",
+	}
+	cmd := m.make()
+	_, err := runCmd("name", cmd)
+	c.Assert(err, gc.ErrorMatches, "exit status 1: foo!")
+}
+
+type fakeLogger struct {
+	logs []string
+	name string
+	c    *gc.C
+}
+
+func (f *fakeLogger) getLogger(name string) infoLogger {
+	f.name = name
+	return f
+}
+
+func (f *fakeLogger) Infof(s string, args ...interface{}) {
+	f.logs = append(f.logs, s)
+	f.c.Assert(args, gc.IsNil)
+}
+
+type fakeRunner struct {
+	name string
+	cmd  *exec.Cmd
+	out  []byte
+	err  error
+}
+
+func (f *fakeRunner) runCmd(name string, cmd *exec.Cmd) ([]byte, error) {
+	f.name = name
+	f.cmd = cmd
+	return f.out, f.err
+}
+
+const (
+	isHelperProc = "GO_HELPER_PROCESS_OK"
+	helperStdout = "GO_HELPER_PROCESS_STDOUT"
+	helperStderr = "GO_HELPER_PROCESS_STDERR"
+	helperExit   = "GO_HELPER_PROCESS_EXIT_CODE"
+)
+
+type maker struct {
+	stdout string
+	stderr string
+	exit   int
+}
+
+func (m maker) make() *exec.Cmd {
+	cmd := exec.Command(os.Args[0], "-test.run=TestHelperWorkload")
+	cmd.Env = []string{
+		fmt.Sprintf("%s=%s", isHelperProc, "1"),
+		fmt.Sprintf("%s=%s", helperStdout, m.stdout),
+		fmt.Sprintf("%s=%s", helperStderr, m.stderr),
+		fmt.Sprintf("%s=%d", helperExit, m.exit),
+	}
+	return cmd
+}
+
+func TestHelperWorkload(*stdtesting.T) {
+	if os.Getenv(isHelperProc) != "1" {
+		return
+	}
+	exit, err := strconv.Atoi(os.Getenv(helperExit))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error converting exit code: %s", err)
+		os.Exit(2)
+	}
+	defer os.Exit(exit)
+
+	if stderr := os.Getenv(helperStderr); stderr != "" {
+		fmt.Fprint(os.Stderr, stderr)
+	}
+
+	if stdout := os.Getenv(helperStdout); stdout != "" {
+		fmt.Fprint(os.Stdout, stdout)
+	}
+}

--- a/workload/plugin/export_test.go
+++ b/workload/plugin/export_test.go
@@ -1,0 +1,9 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package plugin
+
+var (
+	TestFindExecutablePlugin = findExecutablePlugin
+	RunCmd                   = runCmd
+)

--- a/workload/plugin/paths.go
+++ b/workload/plugin/paths.go
@@ -1,0 +1,101 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package plugin
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/workload"
+)
+
+// FileOps exposes all the filesystem operations needed by plugins.
+type FileOps interface {
+	// MkdirAll provides the functionality of os.MkdirAll.
+	MkdirAll(path string, perm os.FileMode) error
+	// ReadFile provides the functionality of ioutil.ReadFile.
+	ReadFile(filename string) ([]byte, error)
+	// WriteFile provides the functionality of ioutil.WriteFile.
+	WriteFile(filename string, data []byte, perm os.FileMode) error
+}
+
+// Paths provides the paths related to a plugin.
+type Paths struct {
+	// Plugin is the name of the plugin.
+	Plugin string
+	// DataDir is the path to the plugin's data dir.
+	DataDir string
+	// ExecutablePathFile is the location of the file where the path
+	// to the plugin's executable is stored.
+	ExecutablePathFile string
+
+	// Fops provides the filesystem operations used by Paths.
+	Fops FileOps
+}
+
+// NewPaths returns a new Paths for the named plugin, relative to the
+// given data dir.
+func NewPaths(baseDataDir, name string) Paths {
+	baseDir := workload.DataDir(baseDataDir)
+	p := Paths{
+		Plugin:  name,
+		DataDir: filepath.Join(baseDir, "plugins", name),
+		Fops:    &fileOps{},
+	}
+	p.ExecutablePathFile = p.resolve(".executable")
+	return p
+}
+
+// resolve returns the path composed of the provided parts, relative
+// to the plugin's data dir.
+func (p Paths) resolve(parts ...string) string {
+	return filepath.Join(append([]string{p.DataDir}, parts...)...)
+}
+
+// Init initializes the plugin's data directory.
+func (p Paths) Init(executable string) error {
+	if err := p.Fops.MkdirAll(p.DataDir, 0755); err != nil {
+		return errors.Trace(err)
+	}
+
+	if err := p.Fops.WriteFile(p.ExecutablePathFile, []byte(executable), 0644); err != nil {
+		return errors.Trace(err)
+	}
+
+	return nil
+}
+
+// Executable returns the path to the plugin's executable file.
+func (p Paths) Executable() (string, error) {
+	data, err := p.Fops.ReadFile(p.ExecutablePathFile)
+	if os.IsNotExist(err) {
+		return "", errors.NotFoundf(p.ExecutablePathFile)
+	}
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	return string(data), nil
+}
+
+// TODO(ericsnow) fileOps should move to the utils repo.
+
+type fileOps struct{}
+
+// MkdirAll implements FileOps.
+func (fileOps) MkdirAll(path string, perm os.FileMode) error {
+	return os.MkdirAll(path, perm)
+}
+
+// ReadFile implements FileOps.
+func (fileOps) ReadFile(filename string) ([]byte, error) {
+	return ioutil.ReadFile(filename)
+}
+
+// WriteFile implements FileOps.
+func (fileOps) WriteFile(filename string, data []byte, perm os.FileMode) error {
+	return ioutil.WriteFile(filename, data, perm)
+}

--- a/workload/plugin/paths.go
+++ b/workload/plugin/paths.go
@@ -9,8 +9,6 @@ import (
 	"path/filepath"
 
 	"github.com/juju/errors"
-
-	"github.com/juju/juju/workload"
 )
 
 // FileOps exposes all the filesystem operations needed by plugins.
@@ -40,10 +38,9 @@ type Paths struct {
 // NewPaths returns a new Paths for the named plugin, relative to the
 // given data dir.
 func NewPaths(baseDataDir, name string) Paths {
-	baseDir := workload.DataDir(baseDataDir)
 	p := Paths{
 		Plugin:  name,
-		DataDir: filepath.Join(baseDir, "plugins", name),
+		DataDir: filepath.Join(baseDataDir, "plugins", name),
 		Fops:    &fileOps{},
 	}
 	p.ExecutablePathFile = p.resolve(".executable")

--- a/workload/plugin/paths_test.go
+++ b/workload/plugin/paths_test.go
@@ -1,0 +1,121 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package plugin_test
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/workload/plugin"
+)
+
+type pathsSuite struct {
+	testing.IsolationSuite
+
+	stub *testing.Stub
+}
+
+var _ = gc.Suite(&pathsSuite{})
+
+func (s *pathsSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+
+	s.stub = &testing.Stub{}
+}
+
+func (s *pathsSuite) TestNewPaths(c *gc.C) {
+	p := plugin.NewPaths("some-base-dir", "a-plugin")
+
+	c.Check(p, jc.DeepEquals, plugin.Paths{
+		Plugin:             "a-plugin",
+		DataDir:            filepath.Join("some-base-dir", "workloads", "plugins", "a-plugin"),
+		ExecutablePathFile: filepath.Join("some-base-dir", "workloads", "plugins", "a-plugin", ".executable"),
+		Fops:               p.Fops,
+	})
+}
+
+func (s *pathsSuite) TestExecutable(c *gc.C) {
+	executablePathFile := filepath.Join("some-base-dir", "workloads", "plugins", "a-plugin", ".executable")
+	expected := filepath.Join("some", "dir", "juju-workload-a-plugin")
+	fops := &stubFops{stub: s.stub}
+	fops.dataOut = expected
+
+	p := plugin.NewPaths("some-base-dir", "a-plugin")
+	p.Fops = fops
+	exePath, err := p.Executable()
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(exePath, gc.Equals, expected)
+	s.stub.CheckCalls(c, []testing.StubCall{{
+		FuncName: "ReadFile",
+		Args: []interface{}{
+			executablePathFile,
+		},
+	}})
+}
+
+func (s *pathsSuite) TestInit(c *gc.C) {
+	executablePathFile := filepath.Join("some-base-dir", "workloads", "plugins", "a-plugin", ".executable")
+	dataDir := filepath.Join("some-base-dir", "workloads", "plugins", "a-plugin")
+	fops := &stubFops{stub: s.stub}
+
+	p := plugin.NewPaths("some-base-dir", "a-plugin")
+	p.Fops = fops
+	exePath := filepath.Join("some", "dir", "juju-workload-a-plugin")
+	err := p.Init(exePath)
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.stub.CheckCalls(c, []testing.StubCall{{
+		FuncName: "MkdirAll",
+		Args: []interface{}{
+			dataDir,
+			os.FileMode(0755),
+		},
+	}, {
+		FuncName: "WriteFile",
+		Args: []interface{}{
+			executablePathFile,
+			[]byte(exePath),
+			os.FileMode(0644),
+		},
+	}})
+}
+
+type stubFops struct {
+	stub *testing.Stub
+
+	dataOut string
+}
+
+func (s *stubFops) MkdirAll(path string, perm os.FileMode) error {
+	s.stub.AddCall("MkdirAll", path, perm)
+	if err := s.stub.NextErr(); err != nil {
+		return errors.Trace(err)
+	}
+
+	return nil
+}
+
+func (s *stubFops) ReadFile(filename string) ([]byte, error) {
+	s.stub.AddCall("ReadFile", filename)
+	if err := s.stub.NextErr(); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	return []byte(s.dataOut), nil
+}
+
+func (s *stubFops) WriteFile(filename string, data []byte, perm os.FileMode) error {
+	s.stub.AddCall("WriteFile", filename, data, perm)
+	if err := s.stub.NextErr(); err != nil {
+		return errors.Trace(err)
+	}
+
+	return nil
+}

--- a/workload/plugin/paths_test.go
+++ b/workload/plugin/paths_test.go
@@ -35,14 +35,14 @@ func (s *pathsSuite) TestNewPaths(c *gc.C) {
 
 	c.Check(p, jc.DeepEquals, plugin.Paths{
 		Plugin:             "a-plugin",
-		DataDir:            filepath.Join("some-base-dir", "workloads", "plugins", "a-plugin"),
-		ExecutablePathFile: filepath.Join("some-base-dir", "workloads", "plugins", "a-plugin", ".executable"),
+		DataDir:            filepath.Join("some-base-dir", "plugins", "a-plugin"),
+		ExecutablePathFile: filepath.Join("some-base-dir", "plugins", "a-plugin", ".executable"),
 		Fops:               p.Fops,
 	})
 }
 
 func (s *pathsSuite) TestExecutable(c *gc.C) {
-	executablePathFile := filepath.Join("some-base-dir", "workloads", "plugins", "a-plugin", ".executable")
+	executablePathFile := filepath.Join("some-base-dir", "plugins", "a-plugin", ".executable")
 	expected := filepath.Join("some", "dir", "juju-workload-a-plugin")
 	fops := &stubFops{stub: s.stub}
 	fops.dataOut = expected
@@ -62,8 +62,8 @@ func (s *pathsSuite) TestExecutable(c *gc.C) {
 }
 
 func (s *pathsSuite) TestInit(c *gc.C) {
-	executablePathFile := filepath.Join("some-base-dir", "workloads", "plugins", "a-plugin", ".executable")
-	dataDir := filepath.Join("some-base-dir", "workloads", "plugins", "a-plugin")
+	executablePathFile := filepath.Join("some-base-dir", "plugins", "a-plugin", ".executable")
+	dataDir := filepath.Join("some-base-dir", "plugins", "a-plugin")
 	fops := &stubFops{stub: s.stub}
 
 	p := plugin.NewPaths("some-base-dir", "a-plugin")

--- a/workload/plugin/paths_test.go
+++ b/workload/plugin/paths_test.go
@@ -5,6 +5,7 @@ package plugin_test
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 
 	"github.com/juju/errors"
@@ -91,6 +92,8 @@ type stubFops struct {
 	stub *testing.Stub
 
 	dataOut string
+	found   string
+	abs     string
 }
 
 func (s *stubFops) MkdirAll(path string, perm os.FileMode) error {
@@ -118,4 +121,28 @@ func (s *stubFops) WriteFile(filename string, data []byte, perm os.FileMode) err
 	}
 
 	return nil
+}
+
+func (s *stubFops) LookPath(name string) (string, error) {
+	s.stub.AddCall("LookPath", name)
+	if err := s.stub.NextErr(); err != nil {
+		return "", errors.Trace(err)
+	}
+
+	if s.found == "" {
+		return "", exec.ErrNotFound
+	}
+	return s.found, nil
+}
+
+func (s *stubFops) Abs(path string) (string, error) {
+	s.stub.AddCall("Abs", path)
+	if err := s.stub.NextErr(); err != nil {
+		return "", errors.Trace(err)
+	}
+
+	if s.abs == "" {
+		return path, nil
+	}
+	return s.abs, nil
 }

--- a/workload/plugin/plugin.go
+++ b/workload/plugin/plugin.go
@@ -15,8 +15,8 @@ import (
 var logger = loggo.GetLogger("juju.workload.plugin")
 
 // Find returns the plugin for the given name.
-func Find(name, agentDir string) (workload.Plugin, error) {
-	plugin, err := FindExecutablePlugin(name, agentDir)
+func Find(name, dataDir string) (workload.Plugin, error) {
+	plugin, err := FindExecutablePlugin(name, dataDir)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/workload/plugin/plugin.go
+++ b/workload/plugin/plugin.go
@@ -16,7 +16,7 @@ var logger = loggo.GetLogger("juju.workload.plugin")
 
 // Find returns the plugin for the given name.
 func Find(name, agentDir string) (workload.Plugin, error) {
-	plugin, err := FindExecutablePlugin(name)
+	plugin, err := FindExecutablePlugin(name, agentDir)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/workload/plugin/plugin.go
+++ b/workload/plugin/plugin.go
@@ -15,7 +15,7 @@ import (
 var logger = loggo.GetLogger("juju.workload.plugin")
 
 // Find returns the plugin for the given name.
-func Find(name string) (workload.Plugin, error) {
+func Find(name, agentDir string) (workload.Plugin, error) {
 	plugin, err := FindExecutablePlugin(name)
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/workload/plugin/plugin.go
+++ b/workload/plugin/plugin.go
@@ -2,170 +2,24 @@
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 // Package plugin contains the code that interfaces with plugins for workload
-// workload technologies such as Docker, Rocket, or systemd.
-//
-// Plugins of this type are expected to handle three commands: launch, status,
-// and stop.  See the functions of the same name for more information about each
-// command.
-//
-// If the plugin command completes successfully, the plugin should exit with a
-// 0 exit code. If there is a problem completing the command, the plugin should
-// print the error details to stdout and return a non-zero exit code.
-//
-// Any information written to stderr will be piped to the unit log.
+// technologies such as Docker, Rocket, or systemd.
 package plugin
 
 import (
-	"bytes"
-	"encoding/json"
-	"os/exec"
-	"path/filepath"
-
-	"github.com/juju/deputy"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
-	"gopkg.in/juju/charm.v5"
 
 	"github.com/juju/juju/workload"
 )
 
-const pluginPrefix = "juju-workload-"
-
 var logger = loggo.GetLogger("juju.workload.plugin")
 
-// Plugin represents a provider for launching, destroying, and introspecting
-// workload via a specific technology such as Docker or systemd.
-type Plugin struct {
-	// Name is the name of the plugin.
-	Name string
-	// Executable is the filename disk where the plugin executable resides.
-	Executable string
-}
-
 // Find returns the plugin for the given name.
-func Find(name string) (*Plugin, error) {
-	path, err := exec.LookPath(pluginPrefix + name)
+func Find(name string) (workload.Plugin, error) {
+	plugin, err := FindExecutablePlugin(name)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 
-	absPath, err := filepath.Abs(path)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	return &Plugin{Name: name, Executable: absPath}, nil
-}
-
-// Launch runs the given plugin, passing it the "launch" command, with the
-// workload definition passed as json to launch as an argument:
-//
-//		<plugin> launch <workload-definition>
-//
-// Workload definition is the serialization of the Workload struct from
-// github.com/juju/charm, for example:
-//
-//		{
-//			"name" : "workloadname",
-//			"description" : "desc",
-//			"type" : "workloadtype",
-//			"typeOptions" : {
-//				"key1" : "val1"
-//			},
-//			"command" : "cmd",
-//			"image" : "img",
-//			"ports" : [ { "internal" : 80, "external" : 8080 } ]
-//			"volumes" : [{"externalmount" : "mnt", "internalmount" : "extmnt", "mode" : "rw", "name" : "name"}]
-//			"envvars" : {
-//				"key1" : "val1"
-//			}
-//		}
-//
-// The plugin is expected to start the image as a new Workload, and write json
-// output to stdout.  The form of the output is expected to conform to the
-// workload.Details struct.
-//
-//		{
-//			"id" : "some-id", # unique id of the Workload
-//			"status" : "details" # plugin-specific metadata about the started workload
-//		}
-//
-// The id should be a unique identifier of the workload that the plugin can use
-// later to introspect the workload and/or stop it. The contents of status can
-// be whatever information the plugin thinks might be relevant to see in the
-// service's status output.
-func (p Plugin) Launch(wl charm.Workload) (workload.Details, error) {
-	var details workload.Details
-	b, err := json.Marshal(wl)
-	if err != nil {
-		return details, errors.Annotate(err, "can't convert charm.Workload to json")
-	}
-	out, err := p.run("launch", string(b))
-	if err != nil {
-		return details, errors.Trace(err)
-	}
-	return workload.UnmarshalDetails(out)
-}
-
-// Destroy runs the given plugin, passing it the "destroy" command, with the id of the
-// workload to destroy as an argument.
-//
-//		<plugin> destroy <id>
-func (p Plugin) Destroy(id string) error {
-	_, err := p.run("destroy", id)
-	return errors.Trace(err)
-}
-
-// Status runs the given plugin, passing it the "status" command, with the id of
-// the workload to get status about.
-//
-//		<plugin> status <id>
-//
-// The plugin is expected to write raw-string status output to stdout if
-// successful.
-func (p Plugin) Status(id string) (workload.PluginStatus, error) {
-	out, err := p.run("status", id)
-	var status workload.PluginStatus
-	if err != nil {
-		return status, errors.Trace(err)
-	}
-	if err := json.Unmarshal(out, &status); err != nil {
-		return status, errors.Annotatef(err, "error parsing data returned from %q", p.Name)
-	}
-	if err := status.Validate(); err != nil {
-		return status, errors.Annotatef(err, "invalid details returned by plugin %q", p.Name)
-	}
-	return status, nil
-}
-
-// run runs the given subcommand of the plugin with the given args.
-func (p Plugin) run(subcommand string, args ...string) ([]byte, error) {
-	logger.Debugf("running %s %s %s", p.Executable, subcommand, args)
-	cmd := exec.Command(p.Executable, append([]string{subcommand}, args...)...)
-	return runCmd(p.Name, cmd)
-}
-
-// runCmd runs the executable at path with the subcommand as the first argument
-// and any args in args as further arguments.  It logs to loggo using the name
-// as a namespace.
-var runCmd = func(name string, cmd *exec.Cmd) ([]byte, error) {
-	log := getLogger("juju.workload.plugin." + name)
-	stdout := &bytes.Buffer{}
-	cmd.Stdout = stdout
-	err := deputy.Deputy{
-		Errors:    deputy.FromStdout,
-		StderrLog: func(b []byte) { log.Infof(string(b)) },
-	}.Run(cmd)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	return stdout.Bytes(), nil
-}
-
-type infoLogger interface {
-	Infof(s string, args ...interface{})
-}
-
-var getLogger = func(name string) infoLogger {
-	return loggo.GetLogger(name)
+	return plugin, nil
 }

--- a/workload/plugin/plugin_test.go
+++ b/workload/plugin/plugin_test.go
@@ -25,7 +25,7 @@ func (s *pluginSuite) TestFindOkay(c *gc.C) {
 	}
 	for name, expected := range known {
 		c.Logf("trying %q", name)
-		plugin, err := plugin.Find(name)
+		plugin, err := plugin.Find(name, "")
 		c.Assert(err, jc.ErrorIsNil)
 
 		c.Check(plugin, gc.FitsTypeOf, expected)

--- a/workload/plugin/plugin_test.go
+++ b/workload/plugin/plugin_test.go
@@ -1,261 +1,33 @@
-package plugin
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package plugin_test
 
 import (
-	"fmt"
-	"os"
-	"os/exec"
-	"strconv"
-	"strings"
-	stdtesting "testing"
-
-	"github.com/juju/errors"
+	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-	"gopkg.in/juju/charm.v5"
 
-	"github.com/juju/juju/testing"
 	"github.com/juju/juju/workload"
+	"github.com/juju/juju/workload/plugin"
 )
 
-type suite struct {
-	testing.BaseSuite
+type pluginSuite struct {
+	testing.IsolationSuite
 }
 
-var _ = gc.Suite(&suite{})
+var _ = gc.Suite(&pluginSuite{})
 
-const exitstatus1 = "exit status 1: "
-
-func (s *suite) TestLaunch(c *gc.C) {
-	f := &fakeRunner{
-		out: []byte(`{ "id" : "foo", "status": { "state" : "bar" } }`),
+func (s *pluginSuite) TestFindOkay(c *gc.C) {
+	c.Skip("currently this is barely a wrapper around FindExecutablePlugin")
+	known := map[string]workload.Plugin{
+	// TODO(ericsnow) Fill this in...
 	}
-	s.PatchValue(&runCmd, f.runCmd)
+	for name, expected := range known {
+		c.Logf("trying %q", name)
+		plugin, err := plugin.Find(name)
+		c.Assert(err, jc.ErrorIsNil)
 
-	p := Plugin{"Name", "Path"}
-	wl := charm.Workload{Image: "img"}
-
-	pd, err := p.Launch(wl)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(pd, gc.Equals, workload.Details{
-		ID: "foo",
-		Status: workload.PluginStatus{
-			State: "bar",
-		},
-	})
-
-	c.Assert(f.name, gc.DeepEquals, p.Name)
-	c.Assert(f.cmd.Path, gc.Equals, p.Executable)
-	c.Assert(f.cmd.Args[1], gc.Equals, "launch")
-	c.Assert(f.cmd.Args[2:], gc.HasLen, 1)
-	// fix this to be more stringent when we fix json serialization for charm.Workload
-	c.Assert(f.cmd.Args[2], gc.Matches, `.*"Image":"img".*`)
-}
-
-func (s *suite) TestLaunchBadOutput(c *gc.C) {
-	f := &fakeRunner{
-		out: []byte(`not json`),
-	}
-	s.PatchValue(&runCmd, f.runCmd)
-
-	p := Plugin{"Name", "Path"}
-	wl := charm.Workload{Image: "img"}
-
-	_, err := p.Launch(wl)
-	c.Assert(err, gc.ErrorMatches, `error parsing data for workload details.*`)
-}
-
-func (s *suite) TestLaunchNoId(c *gc.C) {
-	f := &fakeRunner{
-		out: []byte(`{ "status" : { "status" : "bar" } }`),
-	}
-	s.PatchValue(&runCmd, f.runCmd)
-
-	p := Plugin{"Name", "Path"}
-	wl := charm.Workload{Image: "img"}
-
-	_, err := p.Launch(wl)
-	c.Assert(err, jc.Satisfies, errors.IsNotValid)
-}
-
-func (s *suite) TestLaunchNoStatus(c *gc.C) {
-	f := &fakeRunner{
-		out: []byte(`{ "id" : "foo" }`),
-	}
-	s.PatchValue(&runCmd, f.runCmd)
-
-	p := Plugin{"Name", "Path"}
-	wl := charm.Workload{Image: "img"}
-
-	_, err := p.Launch(wl)
-	c.Assert(err, jc.Satisfies, errors.IsNotValid)
-}
-
-func (s *suite) TestLaunchErr(c *gc.C) {
-	f := &fakeRunner{
-		err: errors.New("foo"),
-	}
-	s.PatchValue(&runCmd, f.runCmd)
-
-	p := Plugin{"Name", "Path"}
-	wl := charm.Workload{Image: "img"}
-
-	_, err := p.Launch(wl)
-	c.Assert(errors.Cause(err), gc.Equals, f.err)
-}
-
-func (s *suite) TestStatus(c *gc.C) {
-	f := &fakeRunner{
-		out: []byte(`{ "state" : "status!" }`),
-	}
-	s.PatchValue(&runCmd, f.runCmd)
-
-	p := Plugin{"Name", "Path"}
-
-	status, err := p.Status("id")
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(status, gc.Equals, workload.PluginStatus{
-		State: "status!",
-	})
-	c.Assert(f.name, gc.DeepEquals, p.Name)
-	c.Assert(f.cmd.Path, gc.Equals, p.Executable)
-	c.Assert(f.cmd.Args[1], gc.Equals, "status")
-	c.Assert(f.cmd.Args[2:], gc.DeepEquals, []string{"id"})
-}
-
-func (s *suite) TestStatusErr(c *gc.C) {
-	f := &fakeRunner{
-		err: errors.New("foo"),
-	}
-	s.PatchValue(&runCmd, f.runCmd)
-
-	p := Plugin{"Name", "Path"}
-
-	_, err := p.Status("id")
-	c.Assert(errors.Cause(err), gc.Equals, f.err)
-}
-
-func (s *suite) TestDestroy(c *gc.C) {
-	f := &fakeRunner{}
-	s.PatchValue(&runCmd, f.runCmd)
-
-	p := Plugin{"Name", "Path"}
-
-	err := p.Destroy("id")
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(f.name, gc.DeepEquals, p.Name)
-	c.Assert(f.cmd.Path, gc.Equals, p.Executable)
-	c.Assert(f.cmd.Args[1], gc.Equals, "destroy")
-	c.Assert(f.cmd.Args[2:], gc.DeepEquals, []string{"id"})
-}
-
-func (s *suite) TestDestroyErr(c *gc.C) {
-	f := &fakeRunner{
-		err: errors.New("foo"),
-	}
-	s.PatchValue(&runCmd, f.runCmd)
-
-	p := Plugin{"Name", "Path"}
-
-	err := p.Destroy("id")
-	c.Assert(errors.Cause(err), gc.Equals, f.err)
-}
-
-func (s *suite) TestRunCmd(c *gc.C) {
-	f := &fakeLogger{c: c}
-	s.PatchValue(&getLogger, f.getLogger)
-	m := maker{
-		stdout: "foo!",
-		stderr: "bar!\nbaz!",
-	}
-	cmd := m.make()
-	out, err := runCmd("name", cmd)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(strings.TrimSpace(string(out)), gc.DeepEquals, m.stdout)
-	c.Assert(f.name, gc.Equals, "juju.workload.plugin.name")
-	c.Assert(f.logs, gc.DeepEquals, []string{"bar!", "baz!"})
-}
-
-func (s *suite) TestRunCmdErr(c *gc.C) {
-	f := &fakeLogger{c: c}
-	s.PatchValue(&getLogger, f.getLogger)
-	m := maker{
-		exit:   1,
-		stdout: "foo!",
-	}
-	cmd := m.make()
-	_, err := runCmd("name", cmd)
-	c.Assert(err, gc.ErrorMatches, "exit status 1: foo!")
-}
-
-type fakeLogger struct {
-	logs []string
-	name string
-	c    *gc.C
-}
-
-func (f *fakeLogger) getLogger(name string) infoLogger {
-	f.name = name
-	return f
-}
-
-func (f *fakeLogger) Infof(s string, args ...interface{}) {
-	f.logs = append(f.logs, s)
-	f.c.Assert(args, gc.IsNil)
-}
-
-type fakeRunner struct {
-	name string
-	cmd  *exec.Cmd
-	out  []byte
-	err  error
-}
-
-func (f *fakeRunner) runCmd(name string, cmd *exec.Cmd) ([]byte, error) {
-	f.name = name
-	f.cmd = cmd
-	return f.out, f.err
-}
-
-const (
-	isHelperProc = "GO_HELPER_PROCESS_OK"
-	helperStdout = "GO_HELPER_PROCESS_STDOUT"
-	helperStderr = "GO_HELPER_PROCESS_STDERR"
-	helperExit   = "GO_HELPER_PROCESS_EXIT_CODE"
-)
-
-type maker struct {
-	stdout string
-	stderr string
-	exit   int
-}
-
-func (m maker) make() *exec.Cmd {
-	cmd := exec.Command(os.Args[0], "-test.run=TestHelperWorkload")
-	cmd.Env = []string{
-		fmt.Sprintf("%s=%s", isHelperProc, "1"),
-		fmt.Sprintf("%s=%s", helperStdout, m.stdout),
-		fmt.Sprintf("%s=%s", helperStderr, m.stderr),
-		fmt.Sprintf("%s=%d", helperExit, m.exit),
-	}
-	return cmd
-}
-
-func TestHelperWorkload(*stdtesting.T) {
-	if os.Getenv(isHelperProc) != "1" {
-		return
-	}
-	exit, err := strconv.Atoi(os.Getenv(helperExit))
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "error converting exit code: %s", err)
-		os.Exit(2)
-	}
-	defer os.Exit(exit)
-
-	if stderr := os.Getenv(helperStderr); stderr != "" {
-		fmt.Fprint(os.Stderr, stderr)
-	}
-
-	if stdout := os.Getenv(helperStdout); stdout != "" {
-		fmt.Fprint(os.Stdout, stdout)
+		c.Check(plugin, gc.FitsTypeOf, expected)
 	}
 }

--- a/workload/workers/event.go
+++ b/workload/workers/event.go
@@ -83,18 +83,18 @@ type EventHandlers struct {
 func NewEventHandlers() *EventHandlers {
 	logger.Debugf("new event handler created")
 	eh := EventHandlers{
-		data: newEventHandlersData(nil),
+		data: newEventHandlersData(nil, ""),
 	}
 	return &eh
 }
 
 // Reset resets the event handlers.
-func (eh *EventHandlers) Reset(apiClient context.APIClient) error {
+func (eh *EventHandlers) Reset(apiClient context.APIClient, agentDir string) error {
 	if err := eh.data.Close(); err != nil {
 		return errors.Trace(err)
 	}
 	handlers := eh.data.Handlers
-	eh.data = newEventHandlersData(apiClient)
+	eh.data = newEventHandlersData(apiClient, agentDir)
 	eh.data.Handlers = handlers
 	return nil
 }
@@ -304,13 +304,15 @@ type eventHandlersData struct {
 	Events   *Events
 	Handlers []func([]workload.Event, context.APIClient, Runner) error
 
+	AgentDir  string
 	APIClient context.APIClient
 	Engine    *eventHandlersEngine
 }
 
-func newEventHandlersData(apiClient context.APIClient) eventHandlersData {
+func newEventHandlersData(apiClient context.APIClient, agentDir string) eventHandlersData {
 	data := eventHandlersData{
 		Events:    NewEvents(),
+		AgentDir:  agentDir,
 		APIClient: apiClient,
 	}
 	return data

--- a/workload/workers/event.go
+++ b/workload/workers/event.go
@@ -283,8 +283,6 @@ func InitialEvents(apiClient context.APIClient, dataDir string) ([]workload.Even
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		// TODO(wwitzel3) (Upgrade/Restart broken) during a restart of the
-		// worker, the Plugin loses its absPath for the executable.
 		plugin, err := hctx.Plugin(info)
 		if err != nil {
 			return nil, errors.Trace(err)

--- a/workload/workers/event_test.go
+++ b/workload/workers/event_test.go
@@ -111,7 +111,7 @@ func (s *eventHandlerSuite) TestNewEventHandlers(c *gc.C) {
 	data := workers.ExposeEventHandlers(eh)
 	checkUnhandledEvents(c, data.Events)
 	c.Check(data.APIClient, gc.IsNil)
-	c.Check(data.AgentDir, gc.Equals, "")
+	c.Check(data.DataDir, gc.Equals, "")
 	c.Check(data.Engine, gc.IsNil)
 }
 
@@ -126,7 +126,7 @@ func (s *eventHandlerSuite) TestResetOkay(c *gc.C) {
 	data := workers.ExposeEventHandlers(eh)
 	checkUnhandledEvents(c, data.Events)
 	c.Check(data.APIClient, gc.Equals, s.apiClient)
-	c.Check(data.AgentDir, gc.Equals, s.agentDir)
+	c.Check(data.DataDir, gc.Equals, s.agentDir)
 	c.Check(data.Engine, gc.IsNil)
 	s.stub.CheckCalls(c, nil)
 }
@@ -153,7 +153,7 @@ func (s *eventHandlerSuite) TestCloseFresh(c *gc.C) {
 	data := workers.ExposeEventHandlers(eh)
 	checkUnhandledEvents(c, data.Events)
 	c.Check(data.APIClient, gc.IsNil)
-	c.Check(data.AgentDir, gc.Equals, "")
+	c.Check(data.DataDir, gc.Equals, "")
 	c.Check(data.Engine, gc.IsNil)
 	s.stub.CheckCalls(c, nil)
 }
@@ -171,7 +171,7 @@ func (s *eventHandlerSuite) TestCloseIdempotent(c *gc.C) {
 	data := workers.ExposeEventHandlers(eh)
 	checkUnhandledEvents(c, data.Events)
 	c.Check(data.APIClient, gc.IsNil)
-	c.Check(data.AgentDir, gc.Equals, "")
+	c.Check(data.DataDir, gc.Equals, "")
 	c.Check(data.Engine, gc.IsNil)
 }
 

--- a/workload/workers/event_test.go
+++ b/workload/workers/event_test.go
@@ -70,6 +70,7 @@ type eventHandlerSuite struct {
 
 	stub      *gitjujutesting.Stub
 	apiClient *stubAPIClient
+	agentDir  string
 }
 
 var _ = gc.Suite(&eventHandlerSuite{})
@@ -79,6 +80,7 @@ func (s *eventHandlerSuite) SetUpTest(c *gc.C) {
 
 	s.stub = &gitjujutesting.Stub{}
 	s.apiClient = &stubAPIClient{stub: s.stub}
+	s.agentDir = "a-data-dir"
 }
 
 func (s *eventHandlerSuite) handler(events []workload.Event, apiClient context.APIClient, runner workers.Runner) error {
@@ -109,13 +111,14 @@ func (s *eventHandlerSuite) TestNewEventHandlers(c *gc.C) {
 	data := workers.ExposeEventHandlers(eh)
 	checkUnhandledEvents(c, data.Events)
 	c.Check(data.APIClient, gc.IsNil)
+	c.Check(data.AgentDir, gc.Equals, "")
 	c.Check(data.Engine, gc.IsNil)
 }
 
 func (s *eventHandlerSuite) TestResetOkay(c *gc.C) {
 	eh := workers.NewEventHandlers()
 	c.Assert(eh, gc.NotNil)
-	err := eh.Reset(s.apiClient)
+	err := eh.Reset(s.apiClient, s.agentDir)
 	c.Assert(err, jc.ErrorIsNil)
 	eh.Close()
 
@@ -123,6 +126,7 @@ func (s *eventHandlerSuite) TestResetOkay(c *gc.C) {
 	data := workers.ExposeEventHandlers(eh)
 	checkUnhandledEvents(c, data.Events)
 	c.Check(data.APIClient, gc.Equals, s.apiClient)
+	c.Check(data.AgentDir, gc.Equals, s.agentDir)
 	c.Check(data.Engine, gc.IsNil)
 	s.stub.CheckCalls(c, nil)
 }
@@ -131,7 +135,7 @@ func (s *eventHandlerSuite) TestResetHandlersNotChanged(c *gc.C) {
 	eh := workers.NewEventHandlers()
 	c.Assert(eh, gc.NotNil)
 	eh.RegisterHandler(s.handler)
-	err := eh.Reset(s.apiClient)
+	err := eh.Reset(s.apiClient, s.agentDir)
 	c.Assert(err, jc.ErrorIsNil)
 	eh.Close()
 
@@ -149,6 +153,7 @@ func (s *eventHandlerSuite) TestCloseFresh(c *gc.C) {
 	data := workers.ExposeEventHandlers(eh)
 	checkUnhandledEvents(c, data.Events)
 	c.Check(data.APIClient, gc.IsNil)
+	c.Check(data.AgentDir, gc.Equals, "")
 	c.Check(data.Engine, gc.IsNil)
 	s.stub.CheckCalls(c, nil)
 }
@@ -166,6 +171,7 @@ func (s *eventHandlerSuite) TestCloseIdempotent(c *gc.C) {
 	data := workers.ExposeEventHandlers(eh)
 	checkUnhandledEvents(c, data.Events)
 	c.Check(data.APIClient, gc.IsNil)
+	c.Check(data.AgentDir, gc.Equals, "")
 	c.Check(data.Engine, gc.IsNil)
 }
 
@@ -184,7 +190,7 @@ func (s *eventHandlerSuite) TestStartEngine(c *gc.C) {
 	}}
 
 	eh := workers.NewEventHandlers()
-	eh.Reset(s.apiClient)
+	eh.Reset(s.apiClient, s.agentDir)
 	eh.RegisterHandler(s.handler)
 	engine, err := eh.StartEngine()
 	c.Assert(err, jc.ErrorIsNil)

--- a/workload/workers/status_test.go
+++ b/workload/workers/status_test.go
@@ -13,7 +13,6 @@ import (
 	workertesting "github.com/juju/juju/worker/testing"
 	"github.com/juju/juju/workload"
 	"github.com/juju/juju/workload/context"
-	"github.com/juju/juju/workload/plugin"
 	"github.com/juju/juju/workload/workers"
 )
 
@@ -109,7 +108,7 @@ func (s statusWorkerAPIStub) SetStatus(status workload.Status, pluginStatus work
 }
 
 type statusPluginStub struct {
-	plugin.Plugin
+	workload.Plugin
 	stub *gitjujutesting.Stub
 
 	pluginStatus string


### PR DESCRIPTION
Without some form of data persistence the status worker is not able to locate plugins upon restart.  This patch resolves that by supporting a per-component-per-unit data directory.

(Review request: http://reviews.vapour.ws/r/2541/)