### PR TITLE
storage/provider: fix managedfs

### DIFF
--- a/storage/provider/managedfs.go
+++ b/storage/provider/managedfs.go
@@ -6,6 +6,7 @@ package provider
 import (
 	"path"
 	"path/filepath"
+	"unicode"
 
 	"github.com/juju/errors"
 	"github.com/juju/names"
@@ -83,7 +84,16 @@ func (s *managedFilesystemSource) createFilesystem(arg storage.FilesystemParams)
 	if err != nil {
 		return storage.Filesystem{}, errors.Trace(err)
 	}
-	devicePath := s.devicePath(blockDevice)
+	devicePath := devicePath(blockDevice)
+	if isDiskDevice(devicePath) {
+		if err := destroyPartitions(s.run, devicePath); err != nil {
+			return storage.Filesystem{}, errors.Trace(err)
+		}
+		if err := createPartition(s.run, devicePath); err != nil {
+			return storage.Filesystem{}, errors.Trace(err)
+		}
+		devicePath = partitionDevicePath(devicePath)
+	}
 	if err := createFilesystem(s.run, devicePath); err != nil {
 		return storage.Filesystem{}, errors.Trace(err)
 	}
@@ -97,11 +107,12 @@ func (s *managedFilesystemSource) createFilesystem(arg storage.FilesystemParams)
 	}, nil
 }
 
-func (s *managedFilesystemSource) devicePath(dev storage.BlockDevice) string {
-	if dev.DeviceName != "" {
-		return path.Join("/dev", dev.DeviceName)
-	}
-	return path.Join("/dev/disk/by-id", dev.HardwareId)
+// DestroyFilesystems is defined on storage.FilesystemSource.
+func (s *managedFilesystemSource) DestroyFilesystems(filesystemIds []string) []error {
+	// DestroyFilesystems is a no-op; there is nothing to destroy,
+	// since the filesystem is just data on a volume. The volume
+	// is destroyed separately.
+	return make([]error, len(filesystemIds))
 }
 
 // AttachFilesystems is defined on storage.FilesystemSource.
@@ -126,7 +137,10 @@ func (s *managedFilesystemSource) attachFilesystem(arg storage.FilesystemAttachm
 	if err != nil {
 		return storage.FilesystemAttachment{}, errors.Trace(err)
 	}
-	devicePath := s.devicePath(blockDevice)
+	devicePath := devicePath(blockDevice)
+	if isDiskDevice(devicePath) {
+		devicePath = partitionDevicePath(devicePath)
+	}
 	if err := mountFilesystem(s.run, s.dirFuncs, devicePath, arg.Path, arg.ReadOnly); err != nil {
 		return storage.FilesystemAttachment{}, errors.Trace(err)
 	}
@@ -146,12 +160,30 @@ func (s *managedFilesystemSource) DetachFilesystems(args []storage.FilesystemAtt
 	return errors.NotImplementedf("DetachFilesystems")
 }
 
+func destroyPartitions(run runCommandFunc, devicePath string) error {
+	logger.Debugf("destroying partitions on %q", devicePath)
+	if _, err := run("sgdisk", "--zap-all", devicePath); err != nil {
+		return errors.Annotate(err, "sgdisk failed")
+	}
+	return nil
+}
+
+// createPartition creates a single partition (1) on the disk with the
+// specified device path.
+func createPartition(run runCommandFunc, devicePath string) error {
+	logger.Debugf("creating partition on %q", devicePath)
+	if _, err := run("sgdisk", "-n", "1:0:-1", devicePath); err != nil {
+		return errors.Annotate(err, "sgdisk failed")
+	}
+	return nil
+}
+
 func createFilesystem(run runCommandFunc, devicePath string) error {
 	logger.Debugf("attempting to create filesystem on %q", devicePath)
 	mkfscmd := "mkfs." + defaultFilesystemType
 	_, err := run(mkfscmd, devicePath)
 	if err != nil {
-		return errors.Annotatef(err, "%s failed (%q)", mkfscmd)
+		return errors.Annotatef(err, "%s failed", mkfscmd)
 	}
 	logger.Infof("created filesystem on %q", devicePath)
 	return nil
@@ -186,4 +218,26 @@ func mountFilesystem(run runCommandFunc, dirFuncs dirFuncs, devicePath, mountPoi
 	}
 	logger.Infof("mounted filesystem on %q at %q", devicePath, mountPoint)
 	return nil
+}
+
+// devicePath returns the device path for the given block device.
+func devicePath(dev storage.BlockDevice) string {
+	return path.Join("/dev", dev.DeviceName)
+}
+
+// partitionDevicePath returns the device path for the first (and only)
+// partition of the disk with the specified device path.
+func partitionDevicePath(devicePath string) string {
+	return devicePath + "1"
+}
+
+// isDiskDevice reports whether or not the device is a full disk, as opposed
+// to a partition or a loop device. We create a partition on disks to contain
+// filesystems.
+func isDiskDevice(devicePath string) bool {
+	var last rune
+	for _, r := range devicePath {
+		last = r
+	}
+	return !unicode.IsDigit(last)
 }

--- a/storage/provider/managedfs_test.go
+++ b/storage/provider/managedfs_test.go
@@ -52,8 +52,14 @@ func (s *managedfsSuite) initSource(c *gc.C) storage.FilesystemSource {
 
 func (s *managedfsSuite) TestCreateFilesystems(c *gc.C) {
 	source := s.initSource(c)
-	s.commands.expect("mkfs.ext4", "/dev/sda")
-	s.commands.expect("mkfs.ext4", "/dev/disk/by-id/weetbix")
+	// sda is (re)partitioned and the filesystem created
+	// on the partition.
+	s.commands.expect("sgdisk", "--zap-all", "/dev/sda")
+	s.commands.expect("sgdisk", "-n", "1:0:-1", "/dev/sda")
+	s.commands.expect("mkfs.ext4", "/dev/sda1")
+	// xvdf1 is assumed to not require a partition, on
+	// account of ending with a digit.
+	s.commands.expect("mkfs.ext4", "/dev/xvdf1")
 
 	s.blockDevices[names.NewVolumeTag("0")] = storage.BlockDevice{
 		DeviceName: "sda",
@@ -61,6 +67,7 @@ func (s *managedfsSuite) TestCreateFilesystems(c *gc.C) {
 		Size:       2,
 	}
 	s.blockDevices[names.NewVolumeTag("1")] = storage.BlockDevice{
+		DeviceName: "xvdf1",
 		HardwareId: "weetbix",
 		Size:       3,
 	}
@@ -128,7 +135,7 @@ func (s *managedfsSuite) testAttachFilesystems(c *gc.C, readOnly, reattach bool)
 		if readOnly {
 			args = append(args, "-o", "ro")
 		}
-		args = append(args, "/dev/sda", testMountPoint)
+		args = append(args, "/dev/sda1", testMountPoint)
 		s.commands.expect("mount", args...)
 	}
 


### PR DESCRIPTION
(back-port from 1.25)

Modify managedfs to partition disks if necessary, and then create the
filesystem on the partition.

(Review request: http://reviews.vapour.ws/r/2542/)