### PR TITLE
storage: add BusAddress to BlockAddress

### DIFF
--- a/apiserver/common/blockdevices.go
+++ b/apiserver/common/blockdevices.go
@@ -16,6 +16,7 @@ func BlockDeviceFromState(in state.BlockDeviceInfo) storage.BlockDevice {
 		in.Label,
 		in.UUID,
 		in.HardwareId,
+		in.BusAddress,
 		in.Size,
 		in.FilesystemType,
 		in.InUse,
@@ -33,6 +34,10 @@ func MatchingBlockDevice(
 	for _, dev := range blockDevices {
 		if volumeInfo.HardwareId != "" {
 			if volumeInfo.HardwareId == dev.HardwareId {
+				return &dev, true
+			}
+		} else if attachmentInfo.BusAddress != "" {
+			if attachmentInfo.BusAddress == dev.BusAddress {
 				return &dev, true
 			}
 		} else if attachmentInfo.DeviceName == dev.DeviceName {

--- a/apiserver/common/volumes.go
+++ b/apiserver/common/volumes.go
@@ -143,6 +143,7 @@ func VolumeAttachmentFromState(v state.VolumeAttachment) (params.VolumeAttachmen
 		v.Machine().String(),
 		params.VolumeAttachmentInfo{
 			info.DeviceName,
+			info.BusAddress,
 			info.ReadOnly,
 		},
 	}, nil
@@ -183,6 +184,7 @@ func VolumeAttachmentToState(in params.VolumeAttachment) (names.MachineTag, name
 func VolumeAttachmentInfoToState(in params.VolumeAttachmentInfo) state.VolumeAttachmentInfo {
 	return state.VolumeAttachmentInfo{
 		in.DeviceName,
+		in.BusAddress,
 		in.ReadOnly,
 	}
 }

--- a/apiserver/diskmanager/diskmanager.go
+++ b/apiserver/diskmanager/diskmanager.go
@@ -100,6 +100,7 @@ func stateBlockDeviceInfo(devices []storage.BlockDevice) []state.BlockDeviceInfo
 			dev.Label,
 			dev.UUID,
 			dev.HardwareId,
+			dev.BusAddress,
 			dev.Size,
 			dev.FilesystemType,
 			dev.InUse,

--- a/apiserver/params/storage.go
+++ b/apiserver/params/storage.go
@@ -192,6 +192,7 @@ type VolumeAttachment struct {
 // VolumeAttachmentInfo describes a volume attachment.
 type VolumeAttachmentInfo struct {
 	DeviceName string `json:"devicename,omitempty"`
+	BusAddress string `json:"busaddress,omitempty"`
 	ReadOnly   bool   `json:"read-only,omitempty"`
 }
 

--- a/apiserver/provisioner/provisioner.go
+++ b/apiserver/provisioner/provisioner.go
@@ -654,6 +654,7 @@ func volumeAttachmentsToState(in []params.VolumeAttachment) (map[names.VolumeTag
 		}
 		m[volumeTag] = state.VolumeAttachmentInfo{
 			v.Info.DeviceName,
+			v.Info.BusAddress,
 			v.Info.ReadOnly,
 		}
 	}

--- a/apiserver/storage/storage.go
+++ b/apiserver/storage/storage.go
@@ -511,6 +511,7 @@ func convertStateVolumeAttachmentToParams(attachment state.VolumeAttachment) par
 	if info, err := attachment.Info(); err == nil {
 		result.Info = params.VolumeAttachmentInfo{
 			info.DeviceName,
+			info.BusAddress,
 			info.ReadOnly,
 		}
 	}

--- a/state/blockdevices.go
+++ b/state/blockdevices.go
@@ -35,6 +35,7 @@ type BlockDeviceInfo struct {
 	Label          string `bson:"label,omitempty"`
 	UUID           string `bson:"uuid,omitempty"`
 	HardwareId     string `bson:"hardwareid,omitempty"`
+	BusAddress     string `bson:"busaddress,omitempty"`
 	Size           uint64 `bson:"size"`
 	FilesystemType string `bson:"fstype,omitempty"`
 	InUse          bool   `bson:"inuse"`

--- a/state/volume.go
+++ b/state/volume.go
@@ -122,6 +122,7 @@ type VolumeInfo struct {
 // VolumeAttachmentInfo describes information about a volume attachment.
 type VolumeAttachmentInfo struct {
 	DeviceName string `bson:"devicename,omitempty"`
+	BusAddress string `bson:"busaddress,omitempty"`
 	ReadOnly   bool   `bson:"read-only"`
 }
 

--- a/storage/blockdevice.go
+++ b/storage/blockdevice.go
@@ -30,6 +30,15 @@ type BlockDevice struct {
 	// name, as the hardware ID is immutable.
 	HardwareId string `yaml:"hardwareid,omitempty"`
 
+	// BusAddress is the bus address: where the block device is attached
+	// to the machine. This is currently only populated for disks attached
+	// to the SCSI bus.
+	//
+	// The format for this is <bus>@<bus-specific-address> as according to
+	// "lshw -businfo". For example, for a SCSI disk with Host=1, Bus=2,
+	// Target=3, Lun=4, we populate this field with "scsi@1:2.3.4".
+	BusAddress string `yaml:"busaddress,omitempty"`
+
 	// Size is the size of the block device, in MiB.
 	Size uint64 `yaml:"size"`
 

--- a/storage/volume.go
+++ b/storage/volume.go
@@ -56,6 +56,13 @@ type VolumeAttachmentInfo struct {
 	// field must be left blank.
 	DeviceName string
 
+	// BusAddress is the bus address, where the volume is attached to
+	// the machine.
+	//
+	// The format of this field must match the field of the same name
+	// in BlockDevice.
+	BusAddress string
+
 	// ReadOnly signifies whether the volume is read only or writable.
 	ReadOnly bool
 }

--- a/worker/provisioner/provisioner_task.go
+++ b/worker/provisioner/provisioner_task.go
@@ -771,6 +771,7 @@ func volumeAttachmentsToApiserver(attachments []storage.VolumeAttachment) map[st
 	for _, a := range attachments {
 		result[a.Volume.String()] = params.VolumeAttachmentInfo{
 			a.DeviceName,
+			a.BusAddress,
 			a.ReadOnly,
 		}
 	}

--- a/worker/storageprovisioner/volumes.go
+++ b/worker/storageprovisioner/volumes.go
@@ -550,6 +550,7 @@ func volumeAttachmentsFromStorage(in []storage.VolumeAttachment) []params.Volume
 			v.Machine.String(),
 			params.VolumeAttachmentInfo{
 				v.DeviceName,
+				v.BusAddress,
 				v.ReadOnly,
 			},
 		}
@@ -587,6 +588,7 @@ func volumeAttachmentFromParams(in params.VolumeAttachment) (storage.VolumeAttac
 		machineTag,
 		storage.VolumeAttachmentInfo{
 			in.Info.DeviceName,
+			in.Info.BusAddress,
 			in.Info.ReadOnly,
 		},
 	}, nil


### PR DESCRIPTION
Add the BusAddress field to BlockAddress and
VolumeAttachmentInfo here and in the state
representation and API params structs. Also,
update worker/diskmanager to discover this
as well as the HardwareId field, which was
previously unpopulated.

(Review request: http://reviews.vapour.ws/r/2543/)