### PR TITLE
storage: update FilesystemSource API

### DIFF
--- a/storage/interface.go
+++ b/storage/interface.go
@@ -117,11 +117,11 @@ type FilesystemSource interface {
 	ValidateFilesystemParams(params FilesystemParams) error
 
 	// CreateFilesystems creates filesystems with the specified size, in MiB.
-	CreateFilesystems(params []FilesystemParams) ([]Filesystem, error)
+	CreateFilesystems(params []FilesystemParams) ([]CreateFilesystemsResult, error)
 
 	// DestroyFilesystems destroys the filesystems with the specified
 	// providerd filesystem IDs.
-	DestroyFilesystems(fsIds []string) []error
+	DestroyFilesystems(fsIds []string) ([]error, error)
 
 	// AttachFilesystems attaches filesystems to machines.
 	//
@@ -133,12 +133,12 @@ type FilesystemSource interface {
 	// recording in state. For example, the ec2 provider must reject
 	// an attempt to attach a volume to an instance if they are in
 	// different availability zones.
-	AttachFilesystems(params []FilesystemAttachmentParams) ([]FilesystemAttachment, error)
+	AttachFilesystems(params []FilesystemAttachmentParams) ([]AttachFilesystemsResult, error)
 
 	// DetachFilesystems detaches the filesystems with the specified
 	// provider filesystem IDs from the instances with the corresponding
 	// index.
-	DetachFilesystems(params []FilesystemAttachmentParams) error
+	DetachFilesystems(params []FilesystemAttachmentParams) ([]error, error)
 }
 
 // VolumeParams is a fully specified set of parameters for volume creation,
@@ -284,4 +284,25 @@ type DescribeVolumesResult struct {
 type AttachVolumesResult struct {
 	VolumeAttachment *VolumeAttachment
 	Error            error
+}
+
+// CreateFilesystemsResult contains the result of a FilesystemSource.CreateFilesystems call
+// for one filesystem. Filesystem should only be used if Error is nil.
+type CreateFilesystemsResult struct {
+	Filesystem *Filesystem
+	Error      error
+}
+
+// DescribeFilesystemsResult contains the result of a FilesystemSource.DescribeFilesystems call
+// for one filesystem. Filesystem should only be used if Error is nil.
+type DescribeFilesystemsResult struct {
+	FilesystemInfo *FilesystemInfo
+	Error          error
+}
+
+// AttachFilesystemsResult contains the result of a FilesystemSource.AttachFilesystems call
+// for one filesystem. FilesystemAttachment should only be used if Error is nil.
+type AttachFilesystemsResult struct {
+	FilesystemAttachment *FilesystemAttachment
+	Error                error
 }

--- a/storage/provider/common_test.go
+++ b/storage/provider/common_test.go
@@ -47,7 +47,7 @@ func testDetachFilesystems(c *gc.C, commands *mockRunCommand, source storage.Fil
 		cmd.respond("headers\n/same/as/rootfs", nil)
 	}
 
-	err := source.DetachFilesystems([]storage.FilesystemAttachmentParams{{
+	results, err := source.DetachFilesystems([]storage.FilesystemAttachmentParams{{
 		Filesystem:   names.NewFilesystemTag("0/0"),
 		FilesystemId: "filesystem-0-0",
 		AttachmentParams: storage.AttachmentParams{
@@ -57,4 +57,6 @@ func testDetachFilesystems(c *gc.C, commands *mockRunCommand, source storage.Fil
 		Path: testMountPoint,
 	}})
 	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, gc.HasLen, 1)
+	c.Assert(results[0], jc.ErrorIsNil)
 }

--- a/storage/provider/managedfs_test.go
+++ b/storage/provider/managedfs_test.go
@@ -70,7 +70,7 @@ func (s *managedfsSuite) TestCreateFilesystems(c *gc.C) {
 		HardwareId: "weetbix",
 		Size:       3,
 	}
-	filesystems, err := source.CreateFilesystems([]storage.FilesystemParams{{
+	results, err := source.CreateFilesystems([]storage.FilesystemParams{{
 		Tag:    names.NewFilesystemTag("0/0"),
 		Volume: names.NewVolumeTag("0"),
 		Size:   2,
@@ -80,31 +80,36 @@ func (s *managedfsSuite) TestCreateFilesystems(c *gc.C) {
 		Size:   3,
 	}})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(filesystems, jc.DeepEquals, []storage.Filesystem{{
-		names.NewFilesystemTag("0/0"),
-		names.NewVolumeTag("0"),
-		storage.FilesystemInfo{
-			FilesystemId: "filesystem-0-0",
-			Size:         2,
+	c.Assert(results, jc.DeepEquals, []storage.CreateFilesystemsResult{{
+		Filesystem: &storage.Filesystem{
+			names.NewFilesystemTag("0/0"),
+			names.NewVolumeTag("0"),
+			storage.FilesystemInfo{
+				FilesystemId: "filesystem-0-0",
+				Size:         2,
+			},
 		},
 	}, {
-		names.NewFilesystemTag("0/1"),
-		names.NewVolumeTag("1"),
-		storage.FilesystemInfo{
-			FilesystemId: "filesystem-0-1",
-			Size:         3,
+		Filesystem: &storage.Filesystem{
+			names.NewFilesystemTag("0/1"),
+			names.NewVolumeTag("1"),
+			storage.FilesystemInfo{
+				FilesystemId: "filesystem-0-1",
+				Size:         3,
+			},
 		},
 	}})
 }
 
 func (s *managedfsSuite) TestCreateFilesystemsNoBlockDevice(c *gc.C) {
 	source := s.initSource(c)
-	_, err := source.CreateFilesystems([]storage.FilesystemParams{{
+	results, err := source.CreateFilesystems([]storage.FilesystemParams{{
 		Tag:    names.NewFilesystemTag("0/0"),
 		Volume: names.NewVolumeTag("0"),
 		Size:   2,
 	}})
-	c.Assert(err, gc.ErrorMatches, "creating filesystem 0/0: backing-volume 0 is not yet attached")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results[0].Error, gc.ErrorMatches, "backing-volume 0 is not yet attached")
 }
 
 func (s *managedfsSuite) TestAttachFilesystems(c *gc.C) {
@@ -148,7 +153,7 @@ func (s *managedfsSuite) testAttachFilesystems(c *gc.C, readOnly, reattach bool)
 		Volume: names.NewVolumeTag("0"),
 	}
 
-	filesystemAttachments, err := source.AttachFilesystems([]storage.FilesystemAttachmentParams{{
+	results, err := source.AttachFilesystems([]storage.FilesystemAttachmentParams{{
 		Filesystem:   names.NewFilesystemTag("0/0"),
 		FilesystemId: "filesystem-0-0",
 		AttachmentParams: storage.AttachmentParams{
@@ -159,12 +164,14 @@ func (s *managedfsSuite) testAttachFilesystems(c *gc.C, readOnly, reattach bool)
 		Path: testMountPoint,
 	}})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(filesystemAttachments, jc.DeepEquals, []storage.FilesystemAttachment{{
-		names.NewFilesystemTag("0/0"),
-		names.NewMachineTag("0"),
-		storage.FilesystemAttachmentInfo{
-			Path:     testMountPoint,
-			ReadOnly: readOnly,
+	c.Assert(results, jc.DeepEquals, []storage.AttachFilesystemsResult{{
+		FilesystemAttachment: &storage.FilesystemAttachment{
+			names.NewFilesystemTag("0/0"),
+			names.NewMachineTag("0"),
+			storage.FilesystemAttachmentInfo{
+				Path:     testMountPoint,
+				ReadOnly: readOnly,
+			},
 		},
 	}})
 }

--- a/worker/storageprovisioner/storageprovisioner_test.go
+++ b/worker/storageprovisioner/storageprovisioner_test.go
@@ -1100,12 +1100,12 @@ func (s *storageProvisionerSuite) TestDetachFilesystems(c *gc.C) {
 	}
 
 	detached := make(chan interface{})
-	s.provider.detachFilesystemsFunc = func(args []storage.FilesystemAttachmentParams) error {
+	s.provider.detachFilesystemsFunc = func(args []storage.FilesystemAttachmentParams) ([]error, error) {
 		c.Assert(args, gc.HasLen, 1)
 		c.Assert(args[0].Machine.String(), gc.Equals, expectedAttachmentIds[0].MachineTag)
 		c.Assert(args[0].Filesystem.String(), gc.Equals, expectedAttachmentIds[0].AttachmentTag)
 		defer close(detached)
-		return nil
+		return make([]error, len(args)), nil
 	}
 
 	removed := make(chan interface{})


### PR DESCRIPTION
This PR updates the FilesystemSource API to be more like VolumeSource;
individual errors are communicated through a slice of results in the
fashion of apiserver result structs.

At the same time we update worker/storageprovisioner to the new API,
but without changing behaviour. Once this is in, we'll change the
worker to set status and reschedule filesystem operations based on
individual errors.

(Review request: http://reviews.vapour.ws/r/2545/)