### PR TITLE
Fix speling errors: envrionment -> environment

### DIFF
--- a/cmd/juju/commands/destroyenvironment.go
+++ b/cmd/juju/commands/destroyenvironment.go
@@ -232,6 +232,6 @@ If the environment is unusable, then you may run
 
 to forcefully destroy the environment. Upon doing so, review
 your environment provider console for any resources that need
-to be cleaned up. Using force will also by-pass destroy-envrionment block.
+to be cleaned up. Using force will also by-pass destroy-environment block.
 
 `

--- a/cmd/juju/system/useenvironment.go
+++ b/cmd/juju/system/useenvironment.go
@@ -204,7 +204,7 @@ func (c *UseEnvironmentCommand) Run(ctx *cmd.Context) error {
 	if err == nil {
 		// We have an existing environment with the same name. If it is the
 		// same environment with the same user, then this is fine, and we just
-		// change the current envrionment.
+		// change the current environment.
 		endpoint := existing.APIEndpoint()
 		existingCreds := existing.APICredentials()
 		// Need to make sure we check the username of the credentials,

--- a/state/logs.go
+++ b/state/logs.go
@@ -534,7 +534,7 @@ func getCollectionMB(coll *mgo.Collection) (int, error) {
 	return result["size"].(int), nil
 }
 
-// getEnvsInLogs returns the unique envrionment UUIDs that exist in
+// getEnvsInLogs returns the unique environment UUIDs that exist in
 // the logs collection. This uses the one of the indexes on the
 // collection and should be fast.
 func getEnvsInLogs(coll *mgo.Collection) ([]string, error) {


### PR DESCRIPTION
Signed-off-by: Michael McCracken <mike.mccracken@canonical.com>