### PR TITLE
state: consolidate low level multi-environment functions

### DIFF
--- a/state/collection_test.go
+++ b/state/collection_test.go
@@ -260,20 +260,19 @@ func (s *collectionSuite) TestEnvStateCollection(c *gc.C) {
 			expectedCount: 1,
 		},
 		{
+			label: "Find works with maps",
+			test: func() (int, error) {
+				return machines0.Find(map[string]string{"_id": m0.Id()}).Count()
+			},
+			expectedCount: 1,
+		},
+		{
 			label: "Find panics if env-uuid is included",
 			test: func() (int, error) {
 				machines0.Find(bson.D{{"env-uuid", "whatever"}})
 				return 0, nil
 			},
 			expectedPanic: "env-uuid is added automatically and should not be provided",
-		},
-		{
-			label: "Find panics if query type is unsupported",
-			test: func() (int, error) {
-				machines0.Find(map[string]string{"foo": "bar"})
-				return 0, nil
-			},
-			expectedPanic: "query must be bson.D, bson.M, or nil",
 		},
 		{
 			label: "FindId adds env UUID prefix",
@@ -365,7 +364,7 @@ func (s *collectionSuite) TestEnvStateCollection(c *gc.C) {
 				})
 				return 0, err
 			},
-			expectedError: "insert env-uuid is not correct: .+",
+			expectedError: "bad \"env-uuid\" value: .+",
 		},
 		{
 			label: "Remove adds env UUID prefix to _id",
@@ -469,14 +468,6 @@ func (s *collectionSuite) TestEnvStateCollection(c *gc.C) {
 				return 0, nil
 			},
 			expectedPanic: "env-uuid is added automatically and should not be provided",
-		},
-		{
-			label: "RemoveAll panics if query type is unsupported",
-			test: func() (int, error) {
-				machines0.Writeable().RemoveAll(map[string]string{"foo": "bar"})
-				return 0, nil
-			},
-			expectedPanic: "query must be bson.D, bson.M, or nil",
 		},
 		{
 			label: "Update",

--- a/state/multienv.go
+++ b/state/multienv.go
@@ -1,0 +1,39 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import "strings"
+
+// This file contains utility functions related to documents and
+// collections that contain data for multiple environments.
+
+// ensureEnvUUID returns an environment UUID prefixed document ID. The
+// prefix is only added if it isn't already there.
+func ensureEnvUUID(envUUID, id string) string {
+	prefix := envUUID + ":"
+	if strings.HasPrefix(id, prefix) {
+		return id
+	}
+	return prefix + id
+}
+
+// ensureEnvUUIDIfString will call ensureEnvUUID, but only if the id
+// is a string. The id will be left untouched otherwise.
+func ensureEnvUUIDIfString(envUUID string, id interface{}) interface{} {
+	if id, ok := id.(string); ok {
+		return ensureEnvUUID(envUUID, id)
+	}
+	return id
+}
+
+// splitDocID returns the 2 parts of environment UUID prefixed
+// document ID. If the id is not in the expected format the final
+// return value will be false.
+func splitDocID(id string) (string, string, bool) {
+	parts := strings.SplitN(id, ":", 2)
+	if len(parts) != 2 {
+		return "", "", false
+	}
+	return parts[0], parts[1], true
+}

--- a/state/state.go
+++ b/state/state.go
@@ -1483,27 +1483,6 @@ func (st *State) strictLocalID(ID string) (string, error) {
 	return localID, nil
 }
 
-// ensureEnvUUID returns an environment UUID prefixed document ID. The
-// prefix is only added if it isn't already there.
-func ensureEnvUUID(envUUID, id string) string {
-	prefix := envUUID + ":"
-	if strings.HasPrefix(id, prefix) {
-		return id
-	}
-	return prefix + id
-}
-
-// splitDocID returns the 2 parts of environment UUID prefixed
-// document ID. If the id is not in the expected format the final
-// return value will be false.
-func splitDocID(id string) (string, string, bool) {
-	parts := strings.SplitN(id, ":", 2)
-	if len(parts) != 2 {
-		return "", "", false
-	}
-	return parts[0], parts[1], true
-}
-
 // InferEndpoints returns the endpoints corresponding to the supplied names.
 // There must be 1 or 2 supplied names, of the form <service>[:<relation>].
 // If the supplied names uniquely specify a possible relation, or if they

--- a/state/txns.go
+++ b/state/txns.go
@@ -126,22 +126,16 @@ func (r *multiEnvRunner) updateOps(ops []txn.Op) ([]txn.Op, error) {
 		}
 		outOp := op
 		if !collInfo.global {
-			var docID interface{}
-			if id, ok := op.Id.(string); ok {
-				docID = ensureEnvUUID(r.envUUID, id)
-				outOp.Id = docID
-			} else {
-				docID = op.Id
-			}
+			outOp.Id = ensureEnvUUIDIfString(r.envUUID, op.Id)
 			if op.Insert != nil {
-				newInsert, err := r.mungeInsert(op.Insert, docID)
+				newInsert, err := r.mungeInsert(op.Insert)
 				if err != nil {
 					return nil, errors.Annotatef(err, "cannot insert into %q", op.C)
 				}
 				outOp.Insert = newInsert
 			}
 			if op.Update != nil {
-				newUpdate, err := r.mungeUpdate(op.Update, docID)
+				newUpdate, err := r.mungeUpdate(op.Update)
 				if err != nil {
 					return nil, errors.Annotatef(err, "cannot update %q", op.C)
 				}
@@ -156,19 +150,17 @@ func (r *multiEnvRunner) updateOps(ops []txn.Op) ([]txn.Op, error) {
 
 // mungeInsert takes the value of an txn.Op Insert field and modifies
 // it to be multi-environment safe, returning the modified document.
-func (r *multiEnvRunner) mungeInsert(doc interface{}, docID interface{}) (bson.D, error) {
+func (r *multiEnvRunner) mungeInsert(doc interface{}) (bson.D, error) {
 	bDoc, err := toBsonD(doc)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 
-	idSeen := false
 	envUUIDSeen := false
 	for i, elem := range bDoc {
 		switch elem.Name {
 		case "_id":
-			idSeen = true
-			bDoc[i].Value = docID
+			bDoc[i].Value = ensureEnvUUIDIfString(r.envUUID, elem.Value)
 		case "env-uuid":
 			envUUIDSeen = true
 			if elem.Value == "" {
@@ -178,9 +170,6 @@ func (r *multiEnvRunner) mungeInsert(doc interface{}, docID interface{}) (bson.D
 			}
 		}
 	}
-	if !idSeen {
-		bDoc = append(bDoc, bson.DocElem{"_id", docID})
-	}
 	if !envUUIDSeen {
 		bDoc = append(bDoc, bson.DocElem{"env-uuid", r.envUUID})
 	}
@@ -189,12 +178,12 @@ func (r *multiEnvRunner) mungeInsert(doc interface{}, docID interface{}) (bson.D
 
 // mungeUpdate takes the value of an txn.Op Update field and modifies
 // it to be multi-environment safe, returning the modified document.
-func (r *multiEnvRunner) mungeUpdate(updateDoc, docID interface{}) (interface{}, error) {
+func (r *multiEnvRunner) mungeUpdate(updateDoc interface{}) (interface{}, error) {
 	switch doc := updateDoc.(type) {
 	case bson.D:
-		return r.mungeBsonDUpdate(doc, docID)
+		return r.mungeBsonDUpdate(doc)
 	case bson.M:
-		return r.mungeBsonMUpdate(doc, docID)
+		return r.mungeBsonMUpdate(doc)
 	default:
 		return nil, errors.Errorf("don't know how to handle %T", updateDoc)
 	}
@@ -204,11 +193,11 @@ func (r *multiEnvRunner) mungeUpdate(updateDoc, docID interface{}) (interface{},
 // as a bson.D and attempts to make it multi-environment safe.
 //
 // Currently, only $set operations are munged.
-func (r *multiEnvRunner) mungeBsonDUpdate(updateDoc bson.D, docID interface{}) (bson.D, error) {
+func (r *multiEnvRunner) mungeBsonDUpdate(updateDoc bson.D) (bson.D, error) {
 	outDoc := make(bson.D, 0, len(updateDoc))
 	for _, elem := range updateDoc {
 		if elem.Name == "$set" {
-			newSetDoc, err := r.mungeSetUpdate(elem.Value, docID)
+			newSetDoc, err := r.mungeSetUpdate(elem.Value)
 			if err != nil {
 				return nil, errors.Trace(err)
 			}
@@ -223,12 +212,12 @@ func (r *multiEnvRunner) mungeBsonDUpdate(updateDoc bson.D, docID interface{}) (
 // as a bson.M and attempts to make it multi-environment safe.
 //
 // Currently, only $set operations are munged.
-func (r *multiEnvRunner) mungeBsonMUpdate(updateDoc bson.M, docID interface{}) (bson.M, error) {
+func (r *multiEnvRunner) mungeBsonMUpdate(updateDoc bson.M) (bson.M, error) {
 	outDoc := make(bson.M)
 	for name, elem := range updateDoc {
 		if name == "$set" {
 			var err error
-			elem, err = r.mungeSetUpdate(elem, docID)
+			elem, err = r.mungeSetUpdate(elem)
 			if err != nil {
 				return nil, errors.Trace(err)
 			}
@@ -241,7 +230,7 @@ func (r *multiEnvRunner) mungeBsonMUpdate(updateDoc bson.M, docID interface{}) (
 // mungeSetUpdate updates an arbitrary document provided to the $set
 // Update operator to make it multi-environment safe. The output is a
 // bson.D regardless of the input type.
-func (r *multiEnvRunner) mungeSetUpdate(doc interface{}, docID interface{}) (bson.D, error) {
+func (r *multiEnvRunner) mungeSetUpdate(doc interface{}) (bson.D, error) {
 	bDoc, err := toBsonD(doc)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -250,7 +239,7 @@ func (r *multiEnvRunner) mungeSetUpdate(doc interface{}, docID interface{}) (bso
 	for i, elem := range bDoc {
 		switch elem.Name {
 		case "_id":
-			bDoc[i].Value = docID
+			bDoc[i].Value = ensureEnvUUIDIfString(r.envUUID, elem.Value)
 		case "env-uuid":
 			if elem.Value == "" {
 				bDoc[i].Value = r.envUUID

--- a/state/txns_test.go
+++ b/state/txns_test.go
@@ -102,24 +102,6 @@ func getTestCases() []multiEnvRunnerTestCase {
 				},
 			},
 		}, {
-			"_id added to doc if missing",
-			txn.Op{
-				C:  machinesC,
-				Id: "1",
-				Insert: &testDoc{
-					Id: "1",
-				},
-			},
-			txn.Op{
-				C:  machinesC,
-				Id: "uuid:1",
-				Insert: bson.D{
-					{"_id", "uuid:1"},
-					{"thingid", "1"},
-					{"env-uuid", "uuid"},
-				},
-			},
-		}, {
 			"fields matched by struct tag, not field name",
 			txn.Op{
 				C:  machinesC,
@@ -162,7 +144,7 @@ func getTestCases() []multiEnvRunnerTestCase {
 			txn.Op{
 				C:      machinesC,
 				Id:     "4",
-				Insert: bson.D{},
+				Insert: bson.D{{"_id", "4"}},
 			},
 			txn.Op{
 				C:  machinesC,
@@ -177,7 +159,7 @@ func getTestCases() []multiEnvRunnerTestCase {
 			txn.Op{
 				C:      machinesC,
 				Id:     "5",
-				Insert: bson.M{},
+				Insert: bson.M{"_id": "5"},
 			},
 			txn.Op{
 				C:  machinesC,
@@ -198,7 +180,6 @@ func getTestCases() []multiEnvRunnerTestCase {
 				C:  machinesC,
 				Id: "uuid:5",
 				Insert: bson.D{
-					{"_id", "uuid:5"},
 					{"env-uuid", "uuid"},
 				},
 			},
@@ -208,7 +189,8 @@ func getTestCases() []multiEnvRunnerTestCase {
 				C:  machinesC,
 				Id: "1",
 				Update: bson.D{{"$set", &testDoc{
-					Id: "1",
+					DocID: "1",
+					Id:    "1",
 				}}},
 			},
 			txn.Op{
@@ -252,7 +234,7 @@ func getTestCases() []multiEnvRunnerTestCase {
 				C:  machinesC,
 				Id: "1",
 				Update: bson.M{
-					"$set": &testDoc{Id: "1"},
+					"$set": bson.M{"_id": "1"},
 					"$foo": "bar",
 				},
 			},
@@ -260,11 +242,7 @@ func getTestCases() []multiEnvRunnerTestCase {
 				C:  machinesC,
 				Id: "uuid:1",
 				Update: bson.M{
-					"$set": bson.D{
-						{"_id", "uuid:1"},
-						{"thingid", "1"},
-						{"env-uuid", "uuid"},
-					},
+					"$set": bson.D{{"_id", "uuid:1"}},
 					"$foo": "bar",
 				},
 			},


### PR DESCRIPTION
state: started moving multi-env utilities to a new file

A number of other functions will be added here.

---

state: multiEnvRunner no longer adds _id unnecessarily

There is no need to add _id to a document if it isn't present because lower layers will add the correct _id anyway. This allows simplification of the code.

---

state: consolidate multi-env munging functionality

The document munging methods of envStateCollection and multiEnvRunner have been extracted and combined into a shared function. This results in a signifcant net reduction in code.


(Review request: http://reviews.vapour.ws/r/2552/)