### PR TITLE
mongo: Disable reduntant package manager call checks in test

### DIFF
--- a/mongo/mongo_test.go
+++ b/mongo/mongo_test.go
@@ -516,21 +516,6 @@ func (s *MongoSuite) TestInstallMongodServiceExists(c *gc.C) {
 
 	c.Check(s.data.Installed(), gc.HasLen, 0)
 	s.data.CheckCallNames(c, "Installed", "Exists", "Running")
-
-	if pm.PackageManager == "yum" {
-		expectedEpelRelease := append(expectedArgs.YumBase, "epel-release")
-		testing.AssertEchoArgs(c, "yum", expectedEpelRelease...)
-
-		expectedMongodbServer := append(expectedArgs.YumBase, "mongodb-server")
-		testing.AssertEchoArgs(c, "yum", expectedMongodbServer...)
-
-		testing.AssertEchoArgs(c, "chcon", expectedArgs.Chcon...)
-
-		testing.AssertEchoArgs(c, "semanage", expectedArgs.Semanage...)
-	} else {
-		expectedJujuMongodb := append(expectedArgs.AptGetBase, "juju-mongodb")
-		testing.AssertEchoArgs(c, "apt-get", expectedJujuMongodb...)
-	}
 }
 
 func (s *MongoSuite) TestNewServiceWithReplSet(c *gc.C) {


### PR DESCRIPTION
I'm not completely sure on this one.

For some reason it seems we still try to install mongod even if the service exists. Previously the test did this: https://github.com/juju/juju/blob/1.25/mongo/mongo_test.go#L362. Which is the equivalent of 'some command was executed', but there's no such functionality in the testing package and the tests were refactored to use that.

I see 3 ways forward:
1. What I did here which is just delete the calls to check if the package manager was called. There are enough places where we do verify it is called correctly.
2. Actually find out why we do still try to install mongo and if it's nothing important just refactor the original function so that we don't.
3. Implement some functionality in testing to make the test behave as before(just check the command was executed)

(Review request: http://reviews.vapour.ws/r/2557/)