### PR TITLE
Fix metrics manifolds.

### DIFF
--- a/apiserver/metricsadder/metricsadder.go
+++ b/apiserver/metricsadder/metricsadder.go
@@ -40,7 +40,9 @@ func NewMetricsAdderAPI(
 	resources *common.Resources,
 	authorizer common.Authorizer,
 ) (*MetricsAdderAPI, error) {
-	if !authorizer.AuthMachineAgent() {
+	// TODO(cmars): remove unit agent auth, once worker/metrics/sender manifold
+	// can be righteously relocated to machine agent.
+	if !authorizer.AuthMachineAgent() && !authorizer.AuthUnitAgent() {
 		return nil, common.ErrPerm
 	}
 	return &MetricsAdderAPI{

--- a/apiserver/metricsadder/metricsadder_test.go
+++ b/apiserver/metricsadder/metricsadder_test.go
@@ -209,13 +209,16 @@ func (s *metricsAdderSuite) TestAddMetricsBatchDiffTag(c *gc.C) {
 	}
 }
 
-func (s *metricsAdderSuite) TestNewMetricsAdderAPIRefusesNonMachine(c *gc.C) {
+func (s *metricsAdderSuite) TestNewMetricsAdderAPIRefusesNonAgent(c *gc.C) {
 	tests := []struct {
 		tag            names.Tag
 		environManager bool
 		expectedError  string
 	}{
-		{names.NewUnitTag("mysql/0"), true, "permission denied"},
+		// TODO(cmars): unit agent should get permission denied when callers are
+		// moved to machine agent.
+		{names.NewUnitTag("mysql/0"), false, ""},
+
 		{names.NewLocalUserTag("admin"), true, "permission denied"},
 		{names.NewMachineTag("0"), false, ""},
 		{names.NewMachineTag("0"), true, ""},

--- a/cmd/jujud/agent/unit/manifolds.go
+++ b/cmd/jujud/agent/unit/manifolds.go
@@ -18,6 +18,7 @@ import (
 	"github.com/juju/juju/worker/logsender"
 	"github.com/juju/juju/worker/machinelock"
 	"github.com/juju/juju/worker/metrics/collect"
+	"github.com/juju/juju/worker/metrics/sender"
 	"github.com/juju/juju/worker/metrics/spool"
 	"github.com/juju/juju/worker/proxyupdater"
 	"github.com/juju/juju/worker/rsyslog"
@@ -173,6 +174,11 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 			MetricSpoolName: MetricSpoolName,
 			CharmDirName:    CharmDirName,
 		}),
+
+		MetricSenderName: sender.Manifold(sender.ManifoldConfig{
+			APICallerName:   APICallerName,
+			MetricSpoolName: MetricSpoolName,
+		}),
 	}
 }
 
@@ -192,4 +198,5 @@ const (
 	MetricSpoolName          = "metric-spool"
 	CharmDirName             = "charm-dir"
 	MetricCollectName        = "metric-collect"
+	MetricSenderName         = "metric-sender"
 )

--- a/cmd/jujud/agent/unit/manifolds_test.go
+++ b/cmd/jujud/agent/unit/manifolds_test.go
@@ -47,7 +47,7 @@ func (s *ManifoldsSuite) TestManifoldNames(c *gc.C) {
 	}
 
 	manifolds := unit.Manifolds(config)
-	c.Assert(manifolds, gc.HasLen, 15)
+	c.Assert(manifolds, gc.HasLen, 16)
 	expectedKeys := []string{
 		unit.AgentName,
 		unit.APIAdddressUpdaterName,
@@ -63,6 +63,7 @@ func (s *ManifoldsSuite) TestManifoldNames(c *gc.C) {
 		unit.UpgraderName,
 		unit.MetricSpoolName,
 		unit.MetricCollectName,
+		unit.MetricSenderName,
 		unit.CharmDirName,
 	}
 	keys := make([]string, len(manifolds))

--- a/cmd/jujud/agent/unit/manifolds_test.go
+++ b/cmd/jujud/agent/unit/manifolds_test.go
@@ -47,7 +47,6 @@ func (s *ManifoldsSuite) TestManifoldNames(c *gc.C) {
 	}
 
 	manifolds := unit.Manifolds(config)
-	c.Assert(manifolds, gc.HasLen, 16)
 	expectedKeys := []string{
 		unit.AgentName,
 		unit.APIAdddressUpdaterName,
@@ -66,11 +65,9 @@ func (s *ManifoldsSuite) TestManifoldNames(c *gc.C) {
 		unit.MetricSenderName,
 		unit.CharmDirName,
 	}
-	keys := make([]string, len(manifolds))
-	i := 0
-	for k, _ := range manifolds {
-		keys[i] = k
-		i++
+	keys := make([]string, 0, len(manifolds))
+	for k := range manifolds {
+		keys = append(keys, k)
 	}
 	c.Assert(expectedKeys, jc.SameContents, keys)
 }

--- a/worker/metrics/collect/context.go
+++ b/worker/metrics/collect/context.go
@@ -31,8 +31,13 @@ func newHookContext(unitName string, recorder spool.MetricRecorder) *hookContext
 
 // HookVars implements runner.Context.
 func (ctx *hookContext) HookVars(paths context.Paths) ([]string, error) {
-	// TODO(cmars): Provide restricted hook context vars.
-	return nil, nil
+	vars := []string{
+		"JUJU_CHARM_DIR=" + paths.GetCharmDir(),
+		"JUJU_CONTEXT_ID=" + ctx.id,
+		"JUJU_AGENT_SOCKET=" + paths.GetJujucSocket(),
+		"JUJU_UNIT_NAME=" + ctx.unitName,
+	}
+	return append(vars, context.OSDependentEnvVars(paths)...), nil
 }
 
 // UnitName implements runner.Context.

--- a/worker/metrics/collect/context_test.go
+++ b/worker/metrics/collect/context_test.go
@@ -1,0 +1,66 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package collect_test
+
+import (
+	"time"
+
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/keyvalues"
+	gc "gopkg.in/check.v1"
+	corecharm "gopkg.in/juju/charm.v5"
+
+	"github.com/juju/juju/worker/metrics/collect"
+)
+
+type ContextSuite struct {
+	recorder *dummyRecorder
+}
+
+var _ = gc.Suite(&ContextSuite{})
+
+func (s *ContextSuite) SetUpTest(c *gc.C) {
+	s.recorder = &dummyRecorder{
+		charmURL: "local:quantal/metered-1",
+		unitTag:  "u/0",
+		metrics: map[string]corecharm.Metric{
+			"pings": corecharm.Metric{
+				Type:        corecharm.MetricTypeGauge,
+				Description: "pings-desc",
+			},
+		},
+	}
+}
+
+func (s *ContextSuite) TestCtxDeclaredMetric(c *gc.C) {
+	ctx := collect.NewHookContext("u/0", s.recorder)
+	err := ctx.AddMetric("pings", "1", time.Now())
+	c.Assert(err, jc.ErrorIsNil)
+	err = ctx.Flush("", nil)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s.recorder.closed, jc.IsTrue)
+	c.Assert(s.recorder.batches, gc.HasLen, 1)
+	c.Assert(s.recorder.batches[0].Metrics, gc.HasLen, 1)
+	c.Assert(s.recorder.batches[0].Metrics[0].Key, gc.Equals, "pings")
+	c.Assert(s.recorder.batches[0].Metrics[0].Value, gc.Equals, "1")
+}
+
+type dummyPaths struct{}
+
+func (*dummyPaths) GetToolsDir() string        { return "/dummy/tools" }
+func (*dummyPaths) GetCharmDir() string        { return "/dummy/charm" }
+func (*dummyPaths) GetJujucSocket() string     { return "/dummy/jujuc.sock" }
+func (*dummyPaths) GetMetricsSpoolDir() string { return "/dummy/spool" }
+
+func (s *ContextSuite) TestHookContextEnv(c *gc.C) {
+	ctx := collect.NewHookContext("u/0", s.recorder)
+	paths := &dummyPaths{}
+	vars, err := ctx.HookVars(paths)
+	c.Assert(err, jc.ErrorIsNil)
+	varMap, err := keyvalues.Parse(vars, true)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(varMap["JUJU_AGENT_SOCKET"], gc.Equals, "/dummy/jujuc.sock")
+	c.Assert(varMap["JUJU_UNIT_NAME"], gc.Equals, "u/0")
+	c.Assert(varMap["PATH"], gc.Not(gc.Equals), "")
+}

--- a/worker/metrics/collect/manifold_test.go
+++ b/worker/metrics/collect/manifold_test.go
@@ -172,29 +172,6 @@ func (s *ManifoldSuite) TestNoMetricsDeclared(c *gc.C) {
 	c.Assert(recorder.batches, gc.HasLen, 0)
 }
 
-func (s *ManifoldSuite) TestCtxDeclaredMetric(c *gc.C) {
-	recorder := &dummyRecorder{
-		charmURL: "local:quantal/metered-1",
-		unitTag:  "u/0",
-		metrics: map[string]corecharm.Metric{
-			"pings": corecharm.Metric{
-				Type:        corecharm.MetricTypeGauge,
-				Description: "pings-desc",
-			},
-		},
-	}
-	ctx := collect.NewHookContext("u/0", recorder)
-	err := ctx.AddMetric("pings", "1", time.Now())
-	c.Assert(err, jc.ErrorIsNil)
-	err = ctx.Flush("", nil)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(recorder.closed, jc.IsTrue)
-	c.Assert(recorder.batches, gc.HasLen, 1)
-	c.Assert(recorder.batches[0].Metrics, gc.HasLen, 1)
-	c.Assert(recorder.batches[0].Metrics[0].Key, gc.Equals, "pings")
-	c.Assert(recorder.batches[0].Metrics[0].Value, gc.Equals, "1")
-}
-
 type dummyAgent struct {
 	agent.Agent
 	dataDir string

--- a/worker/metrics/sender/manifold_test.go
+++ b/worker/metrics/sender/manifold_test.go
@@ -42,8 +42,8 @@ func (s *ManifoldSuite) SetUpTest(c *gc.C) {
 	s.PatchValue(&sender.NewMetricAdderClient, testAPIClient)
 
 	s.manifold = sender.Manifold(sender.ManifoldConfig{
-		APICallerName:    "api-caller",
-		MetricsSpoolName: "metric-spool",
+		APICallerName:   "api-caller",
+		MetricSpoolName: "metric-spool",
 	})
 	s.getResource = dt.StubGetResource(dt.StubResources{
 		"api-caller":   dt.StubResource{Output: &stubAPICaller{&testing.Stub{}}},

--- a/worker/uniter/resolver/export_test.go
+++ b/worker/uniter/resolver/export_test.go
@@ -12,3 +12,5 @@ type ResolverOpFactory struct {
 func NewResolverOpFactory(f operation.Factory) ResolverOpFactory {
 	return ResolverOpFactory{&resolverOpFactory{Factory: f}}
 }
+
+var UpdateCharmDir = updateCharmDir

--- a/worker/uniter/resolver/locker_test.go
+++ b/worker/uniter/resolver/locker_test.go
@@ -1,0 +1,65 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package resolver_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/charm.v5/hooks"
+
+	"github.com/juju/juju/worker/uniter/hook"
+	"github.com/juju/juju/worker/uniter/operation"
+	"github.com/juju/juju/worker/uniter/resolver"
+)
+
+type LockerSuite struct {
+	locker *mockCharmDirLocker
+}
+
+var _ = gc.Suite(&LockerSuite{})
+
+func (s *LockerSuite) SetUpTest(c *gc.C) {
+	s.locker = &mockCharmDirLocker{}
+}
+
+func (s *LockerSuite) TestNotAvailable(c *gc.C) {
+	resolver.UpdateCharmDir(operation.State{}, s.locker)
+	resolver.UpdateCharmDir(operation.State{Started: false}, s.locker)
+	resolver.UpdateCharmDir(operation.State{Started: true, Stopped: true}, s.locker)
+	resolver.UpdateCharmDir(operation.State{Started: false}, s.locker)
+	resolver.UpdateCharmDir(operation.State{Started: true, Stopped: false, Kind: operation.Install}, s.locker)
+	resolver.UpdateCharmDir(operation.State{Started: true, Stopped: false, Kind: operation.Upgrade}, s.locker)
+	resolver.UpdateCharmDir(operation.State{
+		Started: true,
+		Stopped: false,
+		Kind:    operation.RunHook,
+		Hook: &hook.Info{
+			Kind: hooks.UpgradeCharm,
+		},
+	}, s.locker)
+
+	c.Assert(s.locker.Calls(), gc.HasLen, 7)
+	for _, call := range s.locker.Calls() {
+		c.Assert(call.Args, jc.SameContents, []interface{}{false})
+	}
+}
+
+func (s *LockerSuite) TestAvailable(c *gc.C) {
+	resolver.UpdateCharmDir(operation.State{Started: true, Stopped: false}, s.locker)
+	resolver.UpdateCharmDir(operation.State{Started: true, Stopped: false, Kind: operation.Continue}, s.locker)
+	resolver.UpdateCharmDir(operation.State{Started: true, Stopped: false, Kind: operation.RunAction}, s.locker)
+	resolver.UpdateCharmDir(operation.State{
+		Started: true,
+		Stopped: false,
+		Kind:    operation.RunHook,
+		Hook: &hook.Info{
+			Kind: hooks.ConfigChanged,
+		},
+	}, s.locker)
+
+	c.Assert(s.locker.Calls(), gc.HasLen, 4)
+	for _, call := range s.locker.Calls() {
+		c.Assert(call.Args, jc.SameContents, []interface{}{true})
+	}
+}

--- a/worker/uniter/resolver/loop.go
+++ b/worker/uniter/resolver/loop.go
@@ -63,6 +63,10 @@ func Loop(cfg LoopConfig) (LocalState, error) {
 			CompletedActions: map[string]struct{}{},
 		},
 	}
+
+	// Initialize charmdir availability before entering the loop in case we're recovering from a restart.
+	UpdateCharmDir(cfg.Executor.State(), cfg.CharmDirLocker)
+
 	for {
 		// TODO(axw) move update status to the watcher.
 		updateStatus := cfg.UpdateStatusChannel()

--- a/worker/uniter/resolver/loop_test.go
+++ b/worker/uniter/resolver/loop_test.go
@@ -57,9 +57,10 @@ func (s *LoopSuite) loop() (resolver.LocalState, error) {
 			// TODO(axw) test update status channel
 			return nil
 		},
-		CharmURL: s.charmURL,
-		Dying:    s.dying,
-		OnIdle:   s.onIdle,
+		CharmURL:       s.charmURL,
+		Dying:          s.dying,
+		OnIdle:         s.onIdle,
+		CharmDirLocker: &mockCharmDirLocker{},
 	})
 }
 

--- a/worker/uniter/resolver/loop_test.go
+++ b/worker/uniter/resolver/loop_test.go
@@ -178,8 +178,8 @@ func (s *LoopSuite) TestLoop(c *gc.C) {
 	_, err := s.loop()
 	c.Assert(err, gc.Equals, tomb.ErrDying)
 	c.Assert(resolverCalls, gc.Equals, 3)
-	s.executor.CheckCallNames(c, "State", "Run", "State", "State")
-	c.Assert(s.executor.Calls()[1].Args, jc.SameContents, []interface{}{theOp})
+	s.executor.CheckCallNames(c, "State", "State", "Run", "State", "State")
+	c.Assert(s.executor.Calls()[2].Args, jc.SameContents, []interface{}{theOp})
 }
 
 func (s *LoopSuite) TestRunFails(c *gc.C) {

--- a/worker/uniter/resolver/mock_test.go
+++ b/worker/uniter/resolver/mock_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/juju/testing"
 	"gopkg.in/juju/charm.v5"
 
+	"github.com/juju/juju/worker/charmdir"
 	"github.com/juju/juju/worker/uniter/hook"
 	"github.com/juju/juju/worker/uniter/operation"
 	"github.com/juju/juju/worker/uniter/remotestate"
@@ -88,4 +89,14 @@ func (op mockOp) Commit(st operation.State) (*operation.State, error) {
 		return op.commit(st)
 	}
 	return &st, nil
+}
+
+type mockCharmDirLocker struct {
+	charmdir.Locker
+	testing.Stub
+	commit func(operation.State) (*operation.State, error)
+}
+
+func (l *mockCharmDirLocker) SetAvailable(available bool) {
+	l.MethodCall(l, "SetAvailable", available)
 }

--- a/worker/uniter/runner/context/context.go
+++ b/worker/uniter/runner/context/context.go
@@ -529,7 +529,7 @@ func (context *HookContext) HookVars(paths Paths) ([]string, error) {
 			"JUJU_ACTION_TAG="+context.actionData.Tag.String(),
 		)
 	}
-	return append(vars, osDependentEnvVars(paths)...), nil
+	return append(vars, OSDependentEnvVars(paths)...), nil
 }
 
 func (ctx *HookContext) handleReboot(err *error) {

--- a/worker/uniter/runner/context/env.go
+++ b/worker/uniter/runner/context/env.go
@@ -10,7 +10,9 @@ import (
 	"github.com/juju/juju/version"
 )
 
-func osDependentEnvVars(paths Paths) []string {
+// OSDependentEnvVars returns the OS-dependent environment variables that
+// should be set for a hook context.
+func OSDependentEnvVars(paths Paths) []string {
 	switch version.Current.OS {
 	case version.Windows:
 		return windowsEnv(paths)

--- a/worker/uniter/runner/context/env_test.go
+++ b/worker/uniter/runner/context/env_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/names"
 	envtesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/keyvalues"
 	"github.com/juju/utils/proxy"
 	gc "gopkg.in/check.v1"
 
@@ -90,6 +91,14 @@ func (s *EnvSuite) setRelation(ctx *context.HookContext) (expectVars []string) {
 		"JUJU_RELATION_ID=an-endpoint:22",
 		"JUJU_REMOTE_UNIT=that-unit/456",
 	}
+}
+
+func (s *EnvSuite) TestEnvSetsPath(c *gc.C) {
+	paths := context.OSDependentEnvVars(MockEnvPaths{})
+	c.Assert(paths, gc.Not(gc.HasLen), 0)
+	vars, err := keyvalues.Parse(paths, true)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(vars["PATH"], gc.Not(gc.Equals), "")
 }
 
 func (s *EnvSuite) TestEnvWindows(c *gc.C) {

--- a/worker/uniter/uniter.go
+++ b/worker/uniter/uniter.go
@@ -564,10 +564,6 @@ func (u *Uniter) runOperation(creator creator) (err error) {
 	errorMessage = op.String()
 	before := u.operationState()
 
-	// If we're about to execute an upgrade operation, ensure that
-	// the charmdir is not available for concurrent workers.
-	resolver.UpdateCharmDir(before, u.charmDirLocker)
-
 	defer func() {
 		after := u.operationState()
 
@@ -579,8 +575,6 @@ func (u *Uniter) runOperation(creator creator) (err error) {
 			// TODO(axw)
 			//u.f.WantLeaderSettingsEvents(before.Leader)
 		}
-
-		resolver.UpdateCharmDir(after, u.charmDirLocker)
 	}()
 	return u.operationExecutor.Run(op)
 }


### PR DESCRIPTION
Fixes from end-to-end verification with a live deployed unit agent:

- Add metrics/sender to unit agent manifold.
- Provisionally allow unit agent auth to metricsadder API.
- Set up hook environment for restricted metrics/collect context.
- Fix charmdir coordination in uniter to update from resolver loop.
- Various logging improvements, TODOs, etc.

(Review request: http://reviews.vapour.ws/r/2568/)