### PR TITLE
juju/os: new package

### DIFF
--- a/agent/tools/tools_test.go
+++ b/agent/tools/tools_test.go
@@ -39,7 +39,7 @@ func (t *ToolsSuite) TestPackageDependencies(c *gc.C) {
 	// resulting slice has that prefix removed to keep the output short.
 	c.Assert(testing.FindJujuCoreImports(c, "github.com/juju/juju/agent/tools"),
 		gc.DeepEquals,
-		[]string{"juju/arch", "tools", "version"})
+		[]string{"juju/arch", "juju/os", "tools", "version"})
 }
 
 const toolsFile = "downloaded-tools.txt"

--- a/cloudconfig/cloudinit/interface.go
+++ b/cloudconfig/cloudinit/interface.go
@@ -15,6 +15,7 @@ import (
 	"github.com/juju/utils/proxy"
 	"github.com/juju/utils/shell"
 
+	"github.com/juju/juju/juju/os"
 	"github.com/juju/juju/version"
 )
 
@@ -379,12 +380,12 @@ type AdvancedPackagingConfig interface {
 
 // New returns a new Config with no options set.
 func New(series string) (CloudConfig, error) {
-	os, err := version.GetOSFromSeries(series)
+	seriesos, err := version.GetOSFromSeries(series)
 	if err != nil {
 		return nil, err
 	}
-	switch os {
-	case version.Windows:
+	switch seriesos {
+	case os.Windows:
 		renderer, _ := shell.NewRenderer("powershell")
 		return &windowsCloudConfig{
 			&cloudConfig{
@@ -393,7 +394,7 @@ func New(series string) (CloudConfig, error) {
 				attrs:    make(map[string]interface{}),
 			},
 		}, nil
-	case version.Ubuntu:
+	case os.Ubuntu:
 		renderer, _ := shell.NewRenderer("bash")
 		return &ubuntuCloudConfig{
 			&cloudConfig{
@@ -404,7 +405,7 @@ func New(series string) (CloudConfig, error) {
 				attrs:     make(map[string]interface{}),
 			},
 		}, nil
-	case version.CentOS:
+	case os.CentOS:
 		renderer, _ := shell.NewRenderer("bash")
 		return &centOSCloudConfig{
 			&cloudConfig{

--- a/cloudconfig/userdatacfg.go
+++ b/cloudconfig/userdatacfg.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/cloudconfig/cloudinit"
 	"github.com/juju/juju/cloudconfig/instancecfg"
+	"github.com/juju/juju/juju/os"
 	"github.com/juju/juju/version"
 )
 
@@ -61,11 +62,11 @@ func NewUserdataConfig(icfg *instancecfg.InstanceConfig, conf cloudinit.CloudCon
 	}
 
 	switch operatingSystem {
-	case version.Ubuntu:
+	case os.Ubuntu:
 		return &unixConfigure{base}, nil
-	case version.CentOS:
+	case os.CentOS:
 		return &unixConfigure{base}, nil
-	case version.Windows:
+	case os.Windows:
 		return &windowsConfigure{base}, nil
 	default:
 		return nil, errors.NotSupportedf("OS %s", icfg.Series)
@@ -76,7 +77,7 @@ type baseConfigure struct {
 	tag  names.Tag
 	icfg *instancecfg.InstanceConfig
 	conf cloudinit.CloudConfig
-	os   version.OSType
+	os   os.OSType
 }
 
 // addAgentInfo adds agent-required information to the agent's directory
@@ -125,7 +126,7 @@ func (c *baseConfigure) addMachineAgentToBoot() error {
 	if err != nil {
 		return err
 	}
-	if targetOS != version.Windows {
+	if targetOS != os.Windows {
 		c.conf.AddRunCmd(cloudinit.LogProgressCmd("Starting Juju machine agent (%s)", svcName))
 	}
 	c.conf.AddScripts(cmds...)
@@ -137,7 +138,7 @@ func (c *baseConfigure) addMachineAgentToBoot() error {
 
 func (c *baseConfigure) toolsSymlinkCommand(toolsDir string) string {
 	switch c.os {
-	case version.Windows:
+	case os.Windows:
 		return fmt.Sprintf(
 			`cmd.exe /C mklink /D %s %v`,
 			c.conf.ShellRenderer().FromSlash(toolsDir),

--- a/cloudconfig/userdatacfg_unix.go
+++ b/cloudconfig/userdatacfg_unix.go
@@ -25,6 +25,7 @@ import (
 	"github.com/juju/juju/cloudconfig/cloudinit"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/imagemetadata"
+	"github.com/juju/juju/juju/os"
 	"github.com/juju/juju/service"
 	"github.com/juju/juju/service/systemd"
 	"github.com/juju/juju/service/upstart"
@@ -90,7 +91,7 @@ func (w *unixConfigure) ConfigureBasic() error {
 		"set -xe", // ensure we run all the scripts or abort.
 	)
 	switch w.os {
-	case version.Ubuntu:
+	case os.Ubuntu:
 		w.conf.AddSSHAuthorizedKeys(w.icfg.AuthorizedKeys)
 		if w.icfg.Tools != nil {
 			initSystem, err := service.VersionInitSystem(w.icfg.Series)
@@ -104,7 +105,7 @@ func (w *unixConfigure) ConfigureBasic() error {
 	// on having an ubuntu user there.
 	// Hopefully in the future we are going to move all the distirbutions to
 	// having a "juju" user
-	case version.CentOS:
+	case os.CentOS:
 		script := fmt.Sprintf(initUbuntuScript, utils.ShQuote(w.icfg.AuthorizedKeys))
 		w.conf.AddScripts(script)
 		w.conf.AddScripts("systemctl stop firewalld")
@@ -138,10 +139,10 @@ func (w *unixConfigure) addCleanShutdownJob(initSystem string) {
 }
 
 func (w *unixConfigure) setDataDirPermissions() string {
-	os, _ := version.GetOSFromSeries(w.icfg.Series)
+	seriesos, _ := version.GetOSFromSeries(w.icfg.Series)
 	var user string
-	switch os {
-	case version.CentOS:
+	switch seriesos {
+	case os.CentOS:
 		user = "root"
 	default:
 		user = "syslog"

--- a/cmd/jujud/bootstrap_test.go
+++ b/cmd/jujud/bootstrap_test.go
@@ -580,7 +580,9 @@ func (s *BootstrapSuite) testToolsMetadata(c *gc.C, exploded bool) {
 		for _, series := range version.SupportedSeries() {
 			os, err := version.GetOSFromSeries(series)
 			c.Assert(err, jc.ErrorIsNil)
-			if os == version.Current.OS {
+			hostos, err := version.GetOSFromSeries(version.Current.Series)
+			c.Assert(err, jc.ErrorIsNil)
+			if os == hostos {
 				expectedSeries.Add(series)
 			}
 		}

--- a/cmd/jujud/run.go
+++ b/cmd/jujud/run.go
@@ -17,8 +17,8 @@ import (
 
 	"github.com/juju/juju/agent"
 	cmdutil "github.com/juju/juju/cmd/jujud/util"
+	jujuos "github.com/juju/juju/juju/os"
 	"github.com/juju/juju/juju/sockets"
-	"github.com/juju/juju/version"
 	"github.com/juju/juju/worker/uniter"
 )
 
@@ -161,8 +161,8 @@ func (c *RunCommand) executeInUnitContext() (*exec.ExecResponse, error) {
 // application specific settings (proxy settings in firefox ignore
 // registry values on Windows).
 func (c *RunCommand) appendProxyToCommands() string {
-	switch version.Current.OS {
-	case version.Ubuntu:
+	switch jujuos.HostOS() {
+	case jujuos.Ubuntu:
 		return `[ -f "/home/ubuntu/.juju-proxy" ] && . "/home/ubuntu/.juju-proxy"` + "\n" + c.commands
 	default:
 		return c.commands

--- a/cmd/jujud/run_test.go
+++ b/cmd/jujud/run_test.go
@@ -21,8 +21,8 @@ import (
 	gc "gopkg.in/check.v1"
 
 	cmdutil "github.com/juju/juju/cmd/jujud/util"
+	jujuos "github.com/juju/juju/juju/os"
 	"github.com/juju/juju/testing"
-	"github.com/juju/juju/version"
 	"github.com/juju/juju/worker/uniter"
 )
 
@@ -303,8 +303,8 @@ func (s *RunTestSuite) runListenerForAgent(c *gc.C, agent string) {
 	err := os.MkdirAll(agentDir, 0755)
 	c.Assert(err, jc.ErrorIsNil)
 	var socketPath string
-	switch version.Current.OS {
-	case version.Windows:
+	switch jujuos.HostOS() {
+	case jujuos.Windows:
 		socketPath = fmt.Sprintf(`\\.\pipe\%s-run`, agent)
 	default:
 		socketPath = fmt.Sprintf("%s/run.socket", agentDir)

--- a/environs/manual/provisioner_test.go
+++ b/environs/manual/provisioner_test.go
@@ -20,6 +20,7 @@ import (
 	envtesting "github.com/juju/juju/environs/testing"
 	envtools "github.com/juju/juju/environs/tools"
 	"github.com/juju/juju/instance"
+	jujuos "github.com/juju/juju/juju/os"
 	"github.com/juju/juju/juju/testing"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/version"
@@ -46,7 +47,7 @@ func (s *provisionerSuite) getArgs(c *gc.C) manual.ProvisionMachineArgs {
 func (s *provisionerSuite) TestProvisionMachine(c *gc.C) {
 	const series = coretesting.FakeDefaultSeries
 	const arch = "amd64"
-	const operatingSystem = version.Ubuntu
+	const operatingSystem = jujuos.Ubuntu
 
 	args := s.getArgs(c)
 	hostname := args.Host

--- a/juju/os/os.go
+++ b/juju/os/os.go
@@ -1,0 +1,34 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Package os provides access to operating system related configuration.
+package os
+
+var HostOS = hostOS // for monkey patching
+
+type OSType int
+
+const (
+	Unknown OSType = iota
+	Ubuntu
+	Windows
+	OSX
+	CentOS
+	Arch
+)
+
+func (t OSType) String() string {
+	switch t {
+	case Ubuntu:
+		return "Ubuntu"
+	case Windows:
+		return "Windows"
+	case OSX:
+		return "OSX"
+	case CentOS:
+		return "CentOS"
+	case Arch:
+		return "Arch"
+	}
+	return "Unknown"
+}

--- a/juju/os/os_darwin.go
+++ b/juju/os/os_darwin.go
@@ -1,0 +1,8 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package os
+
+func hostOS() OSType {
+	return OSX
+}

--- a/juju/os/os_linux.go
+++ b/juju/os/os_linux.go
@@ -1,0 +1,78 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package os
+
+import (
+	"errors"
+	"io/ioutil"
+	"strings"
+	"sync"
+)
+
+var (
+	// osReleaseFile is the name of the file that is read in order to determine
+	// the linux type release version.
+	osReleaseFile = "/etc/os-release"
+	osOnce        sync.Once
+	os            OSType // filled in by the first call to hostOS
+)
+
+func hostOS() OSType {
+	osOnce.Do(func() {
+		var err error
+		os, err = updateOS(osReleaseFile)
+		if err != nil {
+			panic("unable to read " + osReleaseFile + ": " + err.Error())
+		}
+	})
+	return os
+}
+
+var defaultVersionIDs = map[string]string{
+	"arch": "rolling",
+}
+
+func updateOS(f string) (OSType, error) {
+	values, err := ReadOSRelease(f)
+	if err != nil {
+		return Unknown, err
+	}
+	switch values["ID"] {
+	case strings.ToLower(Ubuntu.String()):
+		return Ubuntu, nil
+	case strings.ToLower(Arch.String()):
+		return Arch, nil
+	case strings.ToLower(CentOS.String()):
+		return CentOS, nil
+	default:
+		return Unknown, nil
+	}
+}
+
+func ReadOSRelease(f string) (map[string]string, error) {
+	contents, err := ioutil.ReadFile(f)
+	if err != nil {
+		return nil, err
+	}
+	values := make(map[string]string)
+	releaseDetails := strings.Split(string(contents), "\n")
+	for _, val := range releaseDetails {
+		c := strings.SplitN(val, "=", 2)
+		if len(c) != 2 {
+			continue
+		}
+		values[c[0]] = strings.Trim(c[1], "\t '\"")
+	}
+	id, ok := values["ID"]
+	if !ok {
+		return nil, errors.New("OS release file is missing ID")
+	}
+	if _, ok := values["VERSION_ID"]; !ok {
+		values["VERSION_ID"], ok = defaultVersionIDs[id]
+		if !ok {
+			return nil, errors.New("OS release file is missing VERSION_ID")
+		}
+	}
+	return values, nil
+}

--- a/juju/os/os_test.go
+++ b/juju/os/os_test.go
@@ -1,0 +1,31 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package os
+
+import (
+	"runtime"
+
+	gc "gopkg.in/check.v1"
+)
+
+type osSuite struct {
+}
+
+var _ = gc.Suite(&osSuite{})
+
+func (s *osSuite) TestHostOS(c *gc.C) {
+	os := HostOS()
+	switch runtime.GOOS {
+	case "windows":
+		c.Assert(os, gc.Equals, Windows)
+	case "darwin":
+		c.Assert(os, gc.Equals, OSX)
+	case "linux":
+		if os != Ubuntu && os != CentOS && os != Arch {
+			c.Fatalf("unknown linux version: %v", os)
+		}
+	default:
+		c.Fatalf("unsupported operating system: %v", runtime.GOOS)
+	}
+}

--- a/juju/os/os_unknown.go
+++ b/juju/os/os_unknown.go
@@ -1,0 +1,10 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// +build !windows,!darwin,!linux
+
+package os
+
+func hostOS() OSType {
+	return Unknown
+}

--- a/juju/os/os_windows.go
+++ b/juju/os/os_windows.go
@@ -1,0 +1,8 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package os
+
+func hostOS() OSType {
+	return Windows
+}

--- a/juju/os/package_test.go
+++ b/juju/os/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package os
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/juju/paths/paths.go
+++ b/juju/paths/paths.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/juju/errors"
 
+	jujuos "github.com/juju/juju/juju/os"
 	"github.com/juju/juju/version"
 )
 
@@ -50,7 +51,7 @@ func osVal(series string, valname osVarType) (string, error) {
 		return "", err
 	}
 	switch os {
-	case version.Windows:
+	case jujuos.Windows:
 		return winVals[valname], nil
 	default:
 		return nixVals[valname], nil

--- a/provider/local/environprovider.go
+++ b/provider/local/environprovider.go
@@ -23,6 +23,7 @@ import (
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/instance"
+	jujuos "github.com/juju/juju/juju/os"
 	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/version"
 )
@@ -145,7 +146,7 @@ func (p environProvider) PrepareForBootstrap(ctx environs.BootstrapContext, cfg 
 		setIfNotBlank(config.FtpProxyKey, proxySettings.Ftp)
 		setIfNotBlank(config.NoProxyKey, proxySettings.NoProxy)
 	}
-	if version.Current.OS == version.Ubuntu {
+	if jujuos.HostOS() == jujuos.Ubuntu {
 		if cfg.AptHttpProxy() == "" &&
 			cfg.AptHttpsProxy() == "" &&
 			cfg.AptFtpProxy() == "" {

--- a/provider/local/environprovider_test.go
+++ b/provider/local/environprovider_test.go
@@ -20,10 +20,10 @@ import (
 	"github.com/juju/juju/environs/config"
 	envtesting "github.com/juju/juju/environs/testing"
 	"github.com/juju/juju/instance"
+	jujuos "github.com/juju/juju/juju/os"
 	"github.com/juju/juju/provider"
 	"github.com/juju/juju/provider/local"
 	coretesting "github.com/juju/juju/testing"
-	"github.com/juju/juju/version"
 )
 
 type baseProviderSuite struct {
@@ -246,7 +246,7 @@ Acquire::magic::Proxy "";
 		c.Assert(envConfig.FtpProxy(), gc.Equals, test.expectedProxy.Ftp)
 		c.Assert(envConfig.NoProxy(), gc.Equals, test.expectedProxy.NoProxy)
 
-		if version.Current.OS == version.Ubuntu {
+		if jujuos.HostOS() == jujuos.Ubuntu {
 			c.Assert(envConfig.AptHttpProxy(), gc.Equals, test.expectedAptProxy.Http)
 			c.Assert(envConfig.AptHttpsProxy(), gc.Equals, test.expectedAptProxy.Https)
 			c.Assert(envConfig.AptFtpProxy(), gc.Equals, test.expectedAptProxy.Ftp)

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -32,6 +32,7 @@ import (
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/storage"
 	"github.com/juju/juju/instance"
+	"github.com/juju/juju/juju/os"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/provider/common"
 	"github.com/juju/juju/state/multiwatcher"
@@ -1196,9 +1197,9 @@ func (environ *maasEnviron) newCloudinitConfig(hostname, primaryIface, series st
 		return nil, errors.Trace(err)
 	}
 	switch operatingSystem {
-	case version.Windows:
+	case os.Windows:
 		cloudcfg.AddScripts(runCmd)
-	case version.Ubuntu:
+	case os.Ubuntu:
 		cloudcfg.SetSystemUpdate(true)
 		cloudcfg.AddScripts("set -xe", runCmd)
 		// Only create the default bridge if we're not using static

--- a/service/discovery.go
+++ b/service/discovery.go
@@ -9,6 +9,7 @@ import (
 	"github.com/juju/utils/shell"
 
 	"github.com/juju/juju/feature"
+	"github.com/juju/juju/juju/os"
 	"github.com/juju/juju/service/common"
 	"github.com/juju/juju/service/systemd"
 	"github.com/juju/juju/service/upstart"
@@ -67,16 +68,16 @@ func VersionInitSystem(series string) (string, error) {
 }
 
 func versionInitSystem(series string) (string, error) {
-	os, err := version.GetOSFromSeries(series)
+	seriesos, err := version.GetOSFromSeries(series)
 	if err != nil {
 		notFound := errors.NotFoundf("init system for series %q", series)
 		return "", errors.Wrap(err, notFound)
 	}
 
-	switch os {
-	case version.Windows:
+	switch seriesos {
+	case os.Windows:
 		return InitSystemWindows, nil
-	case version.Ubuntu:
+	case os.Ubuntu:
 		switch series {
 		case "precise", "quantal", "raring", "saucy", "trusty", "utopic":
 			return InitSystemUpstart, nil
@@ -87,10 +88,10 @@ func versionInitSystem(series string) (string, error) {
 			}
 			return InitSystemSystemd, nil
 		}
-	case version.CentOS:
+	case os.CentOS:
 		return InitSystemSystemd, nil
 	}
-	return "", errors.NotFoundf("unknown os %q (from series %q), init system", os, series)
+	return "", errors.NotFoundf("unknown os %q (from series %q), init system", seriesos, series)
 }
 
 type discoveryCheck struct {

--- a/service/discovery_test.go
+++ b/service/discovery_test.go
@@ -17,6 +17,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/feature"
+	jujuos "github.com/juju/juju/juju/os"
 	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/service"
 	"github.com/juju/juju/service/common"
@@ -37,7 +38,7 @@ func init() {
 const unknownExecutable = "/sbin/unknown/init/system"
 
 type discoveryTest struct {
-	os       version.OSType
+	os       jujuos.OSType
 	series   string
 	expected string
 }
@@ -58,7 +59,7 @@ func (dt discoveryTest) disableLocalDiscovery(c *gc.C, s *discoverySuite) {
 }
 
 func (dt discoveryTest) disableVersionDiscovery(s *discoverySuite) {
-	dt.os = version.Unknown
+	dt.os = jujuos.Unknown
 	dt.setVersion(s)
 }
 
@@ -113,31 +114,31 @@ func (dt discoveryTest) checkInitSystem(c *gc.C, name string, err error) {
 }
 
 var discoveryTests = []discoveryTest{{
-	os:       version.Windows,
+	os:       jujuos.Windows,
 	series:   "win2012",
 	expected: service.InitSystemWindows,
 }, {
-	os:       version.Ubuntu,
+	os:       jujuos.Ubuntu,
 	series:   "oneiric",
 	expected: "",
 }, {
-	os:       version.Ubuntu,
+	os:       jujuos.Ubuntu,
 	series:   "precise",
 	expected: service.InitSystemUpstart,
 }, {
-	os:       version.Ubuntu,
+	os:       jujuos.Ubuntu,
 	series:   "utopic",
 	expected: service.InitSystemUpstart,
 }, {
-	os:       version.Ubuntu,
+	os:       jujuos.Ubuntu,
 	series:   "vivid",
 	expected: maybeSystemd,
 }, {
-	os:       version.CentOS,
+	os:       jujuos.CentOS,
 	series:   "centos7",
 	expected: service.InitSystemSystemd,
 }, {
-	os:       version.Unknown,
+	os:       jujuos.Unknown,
 	expected: "",
 }}
 
@@ -220,7 +221,7 @@ func (s *discoverySuite) TestVersionInitSystem(c *gc.C) {
 func (s *discoverySuite) TestVersionInitSystemLegacyUpstart(c *gc.C) {
 	s.setLegacyUpstart(c)
 	test := discoveryTest{
-		os:       version.Ubuntu,
+		os:       jujuos.Ubuntu,
 		series:   "vivid",
 		expected: service.InitSystemUpstart,
 	}
@@ -234,7 +235,7 @@ func (s *discoverySuite) TestVersionInitSystemLegacyUpstart(c *gc.C) {
 func (s *discoverySuite) TestVersionInitSystemNoLegacyUpstart(c *gc.C) {
 	s.unsetLegacyUpstart(c)
 	test := discoveryTest{
-		os:       version.Ubuntu,
+		os:       jujuos.Ubuntu,
 		series:   "vivid",
 		expected: service.InitSystemSystemd,
 	}

--- a/service/systemd/conf.go
+++ b/service/systemd/conf.go
@@ -14,8 +14,8 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/utils/shell"
 
+	"github.com/juju/juju/juju/os"
 	"github.com/juju/juju/service/common"
-	"github.com/juju/juju/version"
 )
 
 var limitMap = map[string]string{
@@ -43,15 +43,12 @@ type confRenderer interface {
 }
 
 func syslogUserGroup() (string, string) {
-	var user, group string
-	switch version.Current.OS {
-	case version.CentOS:
-		user, group = "root", "adm"
+	switch os.HostOS() {
+	case os.CentOS:
+		return "root", "adm"
 	default:
-		user, group = "syslog", "syslog"
+		return "syslog", "syslog"
 	}
-
-	return user, group
 }
 
 // normalize adjusts the conf to more standardized content and

--- a/testing/base.go
+++ b/testing/base.go
@@ -17,6 +17,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/juju/arch"
+	jujuos "github.com/juju/juju/juju/os"
 	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/version"
@@ -227,17 +228,16 @@ type PackageManagerStruct struct {
 
 func GetPackageManager() (s PackageManagerStruct, err error) {
 	os, err := version.GetOSFromSeries(version.Current.Series)
-
 	if err != nil {
 		return s, err
 	}
 
 	switch os {
-	case version.CentOS:
+	case jujuos.CentOS:
 		s.PackageManager = "yum"
 		s.PackageQuery = "yum"
 		s.RepositoryManager = "yum-config-manager --add-repo"
-	case version.Ubuntu:
+	case jujuos.Ubuntu:
 		s.PackageManager = "apt-get"
 		s.PackageQuery = "dpkg-query"
 		s.RepositoryManager = "add-apt-repository"
@@ -246,6 +246,5 @@ func GetPackageManager() (s PackageManagerStruct, err error) {
 		s.PackageQuery = "dpkg-query"
 		s.RepositoryManager = "add-apt-repository"
 	}
-
 	return s, nil
 }

--- a/upgrades/steps125.go
+++ b/upgrades/steps125.go
@@ -9,9 +9,9 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/juju/cloudconfig"
 	"github.com/juju/juju/environs"
+	"github.com/juju/juju/juju/os"
 	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/state"
-	"github.com/juju/juju/version"
 	"github.com/juju/utils/exec"
 )
 
@@ -111,7 +111,7 @@ func stepsFor125() []Step {
 // The Jujud.pass file was created during cloud init before
 // so we know it's location for sure in case it exists
 func removeJujudpass(context Context) error {
-	if version.Current.OS == version.Windows {
+	if os.HostOS() == os.Windows {
 		fileLocation := "C:\\Juju\\Jujud.pass"
 		if err := osRemove(fileLocation); err != nil {
 			// Don't fail the step if we can't get rid of the old files.
@@ -129,7 +129,7 @@ var execRunCommands = exec.RunCommands
 // Since support for ACL's in golang is quite disastrous at the moment, and they're
 // not especially easy to use, this is done using the exact same steps used in cloudinit
 func addJujuRegKey(context Context) error {
-	if version.Current.OS == version.Windows {
+	if os.HostOS() == os.Windows {
 		cmds := cloudconfig.CreateJujuRegistryKeyCmds()
 		_, err := execRunCommands(exec.RunParams{
 			Commands: strings.Join(cmds, "\n"),

--- a/upgrades/steps125_test.go
+++ b/upgrades/steps125_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/utils/exec"
 
 	"github.com/juju/juju/cloudconfig"
+	"github.com/juju/juju/juju/os"
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/upgrades"
 	"github.com/juju/juju/version"
@@ -63,22 +64,22 @@ func (m *mockOSRemove) osRemove(path string) error {
 }
 
 var removeFileTests = []struct {
-	os           version.OSType
+	os           os.OSType
 	callExpected bool
 	shouldFail   bool
 }{
 	{
-		os:           version.Ubuntu,
+		os:           os.Ubuntu,
 		callExpected: false,
 		shouldFail:   false,
 	},
 	{
-		os:           version.Windows,
+		os:           os.Windows,
 		callExpected: true,
 		shouldFail:   false,
 	},
 	{
-		os:           version.Windows,
+		os:           os.Windows,
 		callExpected: true,
 		shouldFail:   true,
 	},
@@ -88,7 +89,7 @@ func (s *steps125Suite) TestRemoveJujudPass(c *gc.C) {
 	for _, t := range removeFileTests {
 		mock := &mockOSRemove{shouldFail: t.shouldFail}
 		s.PatchValue(upgrades.OsRemove, mock.osRemove)
-		s.PatchValue(&version.Current.OS, t.os)
+		s.PatchValue(&os.HostOS, func() os.OSType { return t.os })
 		err := upgrades.RemoveJujudpass(nil)
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(mock.called, gc.Equals, t.callExpected)
@@ -112,23 +113,23 @@ func (m *mockRunCmds) runCommands(params exec.RunParams) (*exec.ExecResponse, er
 }
 
 var addRegKeyTests = []struct {
-	os           version.OSType
+	os           os.OSType
 	callExpected bool
 	shouldFail   bool
 	errMessage   string
 }{
 	{
-		os:           version.Ubuntu,
+		os:           os.Ubuntu,
 		callExpected: false,
 		shouldFail:   false,
 	},
 	{
-		os:           version.Windows,
+		os:           os.Windows,
 		callExpected: true,
 		shouldFail:   false,
 	},
 	{
-		os:           version.Windows,
+		os:           os.Windows,
 		callExpected: true,
 		shouldFail:   true,
 		errMessage:   "could not create juju registry key: derp",
@@ -139,7 +140,7 @@ func (s *steps125Suite) TestAddJujuRegKey(c *gc.C) {
 	for _, t := range addRegKeyTests {
 		mock := &mockRunCmds{shouldFail: t.shouldFail, c: c}
 		s.PatchValue(upgrades.ExecRunCommands, mock.runCommands)
-		s.PatchValue(&version.Current.OS, t.os)
+		s.PatchValue(&os.HostOS, func() os.OSType { return t.os })
 		err := upgrades.AddJujuRegKey(nil)
 		if t.shouldFail {
 			c.Assert(err, gc.ErrorMatches, t.errMessage)

--- a/version/current_test.go
+++ b/version/current_test.go
@@ -9,6 +9,7 @@ import (
 
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/juju/os"
 	"github.com/juju/juju/version"
 )
 
@@ -36,7 +37,7 @@ func (*CurrentSuite) TestCurrentSeries(c *gc.C) {
 			c.Assert(err, gc.IsNil)
 			if s != "n/a" {
 				// There is no lsb_release command on CentOS.
-				if current_os == version.CentOS {
+				if current_os == os.CentOS {
 					c.Check(s, gc.Matches, `centos7`)
 				}
 			}

--- a/version/osversion.go
+++ b/version/osversion.go
@@ -5,12 +5,13 @@ package version
 
 import (
 	"fmt"
-	"io/ioutil"
 	"strconv"
 	"strings"
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
+
+	"github.com/juju/juju/juju/os"
 )
 
 var logger = loggo.GetLogger("juju.version")
@@ -30,40 +31,12 @@ func mustOSVersion() string {
 
 // MustOSFromSeries will panic if the series represents an "unknown"
 // operating system
-func MustOSFromSeries(series string) OSType {
+func MustOSFromSeries(series string) os.OSType {
 	operatingSystem, err := GetOSFromSeries(series)
 	if err != nil {
 		panic("osVersion reported an error: " + err.Error())
 	}
 	return operatingSystem
-}
-
-func readOSRelease() (map[string]string, error) {
-	values := map[string]string{}
-
-	contents, err := ioutil.ReadFile(osReleaseFile)
-	if err != nil {
-		return values, err
-	}
-	releaseDetails := strings.Split(string(contents), "\n")
-	for _, val := range releaseDetails {
-		c := strings.SplitN(val, "=", 2)
-		if len(c) != 2 {
-			continue
-		}
-		values[c[0]] = strings.Trim(c[1], "\t '\"")
-	}
-	id, ok := values["ID"]
-	if !ok {
-		return values, errors.New("OS release file is missing ID")
-	}
-	if _, ok := values["VERSION_ID"]; !ok {
-		values["VERSION_ID"], ok = defaultVersionIDs[id]
-		if !ok {
-			return values, errors.New("OS release file is missing VERSION_ID")
-		}
-	}
-	return values, nil
 }
 
 func getValue(from map[string]string, val string) (string, error) {
@@ -76,17 +49,17 @@ func getValue(from map[string]string, val string) (string, error) {
 }
 
 func readSeries() (string, error) {
-	values, err := readOSRelease()
+	values, err := os.ReadOSRelease(osReleaseFile)
 	if err != nil {
 		return "unknown", err
 	}
 	updateSeriesVersions()
 	switch values["ID"] {
-	case strings.ToLower(Ubuntu.String()):
+	case strings.ToLower(os.Ubuntu.String()):
 		return getValue(ubuntuSeries, values["VERSION_ID"])
-	case strings.ToLower(Arch.String()):
+	case strings.ToLower(os.Arch.String()):
 		return getValue(archSeries, values["VERSION_ID"])
-	case strings.ToLower(CentOS.String()):
+	case strings.ToLower(os.CentOS.String()):
 		codename := fmt.Sprintf("%s%s", values["ID"], values["VERSION_ID"])
 		return getValue(centosSeries, codename)
 	default:

--- a/version/supportedseries.go
+++ b/version/supportedseries.go
@@ -12,34 +12,8 @@ import (
 	"sync"
 
 	"github.com/juju/errors"
+	jujuos "github.com/juju/juju/juju/os"
 )
-
-type OSType int
-
-const (
-	Unknown OSType = iota
-	Ubuntu
-	Windows
-	OSX
-	CentOS
-	Arch
-)
-
-func (t OSType) String() string {
-	switch t {
-	case Ubuntu:
-		return "Ubuntu"
-	case Windows:
-		return "Windows"
-	case OSX:
-		return "OSX"
-	case CentOS:
-		return "CentOS"
-	case Arch:
-		return "Arch"
-	}
-	return "Unknown"
-}
 
 type unknownOSForSeriesError string
 
@@ -149,30 +123,30 @@ var distroInfo = "/usr/share/distro-info/ubuntu.csv"
 
 // GetOSFromSeries will return the operating system based
 // on the series that is passed to it
-func GetOSFromSeries(series string) (OSType, error) {
+func GetOSFromSeries(series string) (jujuos.OSType, error) {
 	if series == "" {
-		return Unknown, errors.NotValidf("series %q", series)
+		return jujuos.Unknown, errors.NotValidf("series %q", series)
 	}
 	if _, ok := ubuntuSeries[series]; ok {
-		return Ubuntu, nil
+		return jujuos.Ubuntu, nil
 	}
 	if _, ok := centosSeries[series]; ok {
-		return CentOS, nil
+		return jujuos.CentOS, nil
 	}
 	if _, ok := archSeries[series]; ok {
-		return Arch, nil
+		return jujuos.Arch, nil
 	}
 	for _, val := range windowsVersions {
 		if val == series {
-			return Windows, nil
+			return jujuos.Windows, nil
 		}
 	}
 	for _, val := range macOSXSeries {
 		if val == series {
-			return OSX, nil
+			return jujuos.OSX, nil
 		}
 	}
-	return Unknown, errors.Trace(unknownOSForSeriesError(series))
+	return jujuos.Unknown, errors.Trace(unknownOSForSeriesError(series))
 }
 
 var (
@@ -212,7 +186,7 @@ func SupportedSeries() []string {
 
 // OSSupportedSeries returns the series of the specified OS on which we
 // can run Juju workloads.
-func OSSupportedSeries(os OSType) []string {
+func OSSupportedSeries(os jujuos.OSType) []string {
 	var osSeries []string
 	for _, series := range SupportedSeries() {
 		seriesOS, err := GetOSFromSeries(series)

--- a/version/supportedseries_linux_test.go
+++ b/version/supportedseries_linux_test.go
@@ -11,12 +11,13 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/juju/os"
 	"github.com/juju/juju/version"
 )
 
 func (s *supportedSeriesSuite) TestSeriesVersion(c *gc.C) {
 	// There is no distro-info on Windows or CentOS.
-	if version.Current.OS != version.Ubuntu {
+	if os.HostOS() != os.Ubuntu {
 		c.Skip("This test is only relevant on Ubuntu.")
 	}
 	vers, err := version.SeriesVersion("precise")

--- a/version/supportedseries_test.go
+++ b/version/supportedseries_test.go
@@ -7,6 +7,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/juju/os"
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/version"
 )
@@ -28,23 +29,23 @@ func (s *supportedSeriesSuite) TearDownTest(c *gc.C) {
 
 var getOSFromSeriesTests = []struct {
 	series string
-	want   version.OSType
+	want   os.OSType
 	err    string
 }{{
 	series: "precise",
-	want:   version.Ubuntu,
+	want:   os.Ubuntu,
 }, {
 	series: "win2012r2",
-	want:   version.Windows,
+	want:   os.Windows,
 }, {
 	series: "mountainlion",
-	want:   version.OSX,
+	want:   os.OSX,
 }, {
 	series: "centos7",
-	want:   version.CentOS,
+	want:   os.CentOS,
 }, {
 	series: "arch",
-	want:   version.Arch,
+	want:   os.Arch,
 }, {
 	series: "",
 	err:    "series \"\" not valid",
@@ -78,12 +79,12 @@ func (s *supportedSeriesSuite) TestOSSupportedSeries(c *gc.C) {
 		"centos7": "centos7",
 		"arch":    "rolling",
 	})
-	series := version.OSSupportedSeries(version.Ubuntu)
+	series := version.OSSupportedSeries(os.Ubuntu)
 	c.Assert(series, jc.SameContents, []string{"trusty", "utopic"})
-	series = version.OSSupportedSeries(version.Windows)
+	series = version.OSSupportedSeries(os.Windows)
 	c.Assert(series, jc.SameContents, []string{"win7", "win81"})
-	series = version.OSSupportedSeries(version.CentOS)
+	series = version.OSSupportedSeries(os.CentOS)
 	c.Assert(series, jc.SameContents, []string{"centos7"})
-	series = version.OSSupportedSeries(version.Arch)
+	series = version.OSSupportedSeries(os.Arch)
 	c.Assert(series, jc.SameContents, []string{"arch"})
 }

--- a/version/version.go
+++ b/version/version.go
@@ -19,6 +19,7 @@ import (
 	"gopkg.in/mgo.v2/bson"
 
 	"github.com/juju/juju/juju/arch"
+	jujuos "github.com/juju/juju/juju/os"
 )
 
 // The presence and format of this constant is very important.
@@ -85,7 +86,7 @@ type Binary struct {
 	Number
 	Series string
 	Arch   string
-	OS     OSType
+	OS     jujuos.OSType
 }
 
 func (v Binary) String() string {
@@ -347,7 +348,7 @@ func (v Number) IsDev() bool {
 // the os-release.  If the value is not found, the file is not found, or
 // an error occurs reading the file, an empty string is returned.
 func ReleaseVersion() string {
-	release, err := readOSRelease()
+	release, err := jujuos.ReadOSRelease(osReleaseFile)
 	if err != nil {
 		return ""
 	}

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -15,6 +15,7 @@ import (
 	"gopkg.in/mgo.v2/bson"
 	goyaml "gopkg.in/yaml.v1"
 
+	"github.com/juju/juju/juju/os"
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/version"
 )
@@ -168,7 +169,7 @@ func binaryVersion(major, minor, patch, build int, tag, series, arch string) ver
 		},
 		Series: series,
 		Arch:   arch,
-		OS:     version.Ubuntu,
+		OS:     os.Ubuntu,
 	}
 }
 
@@ -222,7 +223,7 @@ func (*suite) TestParseBinary(c *gc.C) {
 			Number: test.expect,
 			Series: "trusty",
 			Arch:   "amd64",
-			OS:     version.Ubuntu,
+			OS:     os.Ubuntu,
 		}
 		if test.err != "" {
 			c.Assert(err, gc.ErrorMatches, strings.Replace(test.err, "version", "binary version", 1))

--- a/worker/authenticationworker/worker.go
+++ b/worker/authenticationworker/worker.go
@@ -15,8 +15,8 @@ import (
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/api/keyupdater"
 	"github.com/juju/juju/api/watcher"
+	"github.com/juju/juju/juju/os"
 	"github.com/juju/juju/utils/ssh"
-	"github.com/juju/juju/version"
 	"github.com/juju/juju/worker"
 )
 
@@ -43,7 +43,7 @@ var _ worker.NotifyWatchHandler = (*keyupdaterWorker)(nil)
 // the machine's authorised ssh keys and ensures the
 // ~/.ssh/authorized_keys file is up to date.
 func NewWorker(st *keyupdater.State, agentConfig agent.Config) worker.Worker {
-	if version.Current.OS == version.Windows {
+	if os.HostOS() == os.Windows {
 		return worker.NewNoOpWorker()
 	}
 	kw := &keyupdaterWorker{st: st, tag: agentConfig.Tag().(names.MachineTag)}

--- a/worker/provisioner/container_initialisation_test.go
+++ b/worker/provisioner/container_initialisation_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/juju/juju/feature"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/juju/arch"
+	jujuos "github.com/juju/juju/juju/os"
 	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/state"
@@ -299,7 +300,7 @@ func (s *ContainerSetupSuite) assertContainerInitialised(c *gc.C, cont Container
 	c.Assert(err, jc.ErrorIsNil)
 
 	switch current_os {
-	case version.CentOS:
+	case jujuos.CentOS:
 		series = "centos7"
 		expected_initial = []string{
 			"yum", "--assumeyes", "--debuglevel=1", "install"}
@@ -530,7 +531,7 @@ func getContainerInstance() (cont []ContainerInstance, err error) {
 	}
 
 	switch current_os {
-	case version.CentOS:
+	case jujuos.CentOS:
 		cont = []ContainerInstance{
 			{instance.LXC, [][]string{
 				{"lxc"},

--- a/worker/proxyupdater/proxyupdater.go
+++ b/worker/proxyupdater/proxyupdater.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/juju/juju/api/environment"
 	"github.com/juju/juju/api/watcher"
+	"github.com/juju/juju/juju/os"
 	"github.com/juju/juju/version"
 	"github.com/juju/juju/worker"
 )
@@ -133,12 +134,13 @@ func (w *proxyWorker) writeEnvironmentToRegistry() error {
 }
 
 func (w *proxyWorker) writeEnvironment() error {
+	// TODO(dfc) this should be replace with a switch on os.HostOS()
 	osystem, err := version.GetOSFromSeries(version.Current.Series)
 	if err != nil {
 		return err
 	}
 	switch osystem {
-	case version.Windows:
+	case os.Windows:
 		return w.writeEnvironmentToRegistry()
 	default:
 		return w.writeEnvironmentFile()

--- a/worker/rsyslog/worker.go
+++ b/worker/rsyslog/worker.go
@@ -26,8 +26,8 @@ import (
 	apirsyslog "github.com/juju/juju/api/rsyslog"
 	"github.com/juju/juju/api/watcher"
 	"github.com/juju/juju/cert"
+	jujuos "github.com/juju/juju/juju/os"
 	"github.com/juju/juju/utils/syslog"
-	"github.com/juju/juju/version"
 	"github.com/juju/juju/worker"
 )
 
@@ -80,15 +80,12 @@ type certPair struct {
 var _ worker.NotifyWatchHandler = (*RsyslogConfigHandler)(nil)
 
 func syslogUser() string {
-	var user string
-	switch version.Current.OS {
-	case version.CentOS:
-		user = "root"
+	switch jujuos.HostOS() {
+	case jujuos.CentOS:
+		return "root"
 	default:
-		user = "syslog"
+		return "syslog"
 	}
-
-	return user
 }
 
 var NewRsyslogConfigWorker = newRsyslogConfigWorker
@@ -98,7 +95,7 @@ var NewRsyslogConfigWorker = newRsyslogConfigWorker
 // on changes. The worker will remove the configuration file
 // on teardown.
 func newRsyslogConfigWorker(st *apirsyslog.State, mode RsyslogMode, tag names.Tag, namespace string, stateServerAddrs []string, jujuConfigDir string) (worker.Worker, error) {
-	if version.Current.OS == version.Windows && mode == RsyslogModeAccumulate {
+	if jujuos.HostOS() == jujuos.Windows && mode == RsyslogModeAccumulate {
 		return worker.NewNoOpWorker(), nil
 	}
 	handler, err := newRsyslogConfigHandler(st, mode, tag, namespace, stateServerAddrs, jujuConfigDir)

--- a/worker/uniter/paths.go
+++ b/worker/uniter/paths.go
@@ -11,7 +11,7 @@ import (
 	"github.com/juju/names"
 
 	"github.com/juju/juju/agent/tools"
-	"github.com/juju/juju/version"
+	"github.com/juju/juju/juju/os"
 )
 
 // Paths represents the set of filesystem paths a uniter worker has reason to
@@ -105,7 +105,7 @@ func NewPaths(dataDir string, unitTag names.UnitTag) Paths {
 	stateDir := join(baseDir, "state")
 
 	socket := func(name string, abstract bool) string {
-		if version.Current.OS == version.Windows {
+		if os.HostOS() == os.Windows {
 			return fmt.Sprintf(`\\.\pipe\%s-%s`, unitTag, name)
 		}
 		path := join(baseDir, name+".socket")

--- a/worker/uniter/paths_test.go
+++ b/worker/uniter/paths_test.go
@@ -11,7 +11,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/version"
+	"github.com/juju/juju/juju/os"
 	"github.com/juju/juju/worker/uniter"
 )
 
@@ -29,7 +29,7 @@ func relPathFunc(base string) func(parts ...string) string {
 }
 
 func (s *PathsSuite) TestWindows(c *gc.C) {
-	s.PatchValue(&version.Current.OS, version.Windows)
+	s.PatchValue(&os.HostOS, func() os.OSType { return os.Windows })
 
 	dataDir := c.MkDir()
 	unitTag := names.NewUnitTag("some-service/323")
@@ -56,7 +56,7 @@ func (s *PathsSuite) TestWindows(c *gc.C) {
 }
 
 func (s *PathsSuite) TestOther(c *gc.C) {
-	s.PatchValue(&version.Current.OS, version.OSType(-1))
+	s.PatchValue(&os.HostOS, func() os.OSType { return os.Unknown })
 
 	dataDir := c.MkDir()
 	unitTag := names.NewUnitTag("some-service/323")

--- a/worker/uniter/runner/args.go
+++ b/worker/uniter/runner/args.go
@@ -10,7 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/juju/juju/version"
+	jujuos "github.com/juju/juju/juju/os"
 )
 
 var windowsSuffixOrder = []string{
@@ -37,7 +37,7 @@ func lookPath(hook string) (string, error) {
 // being default.
 func searchHook(charmDir, hook string) (string, error) {
 	hookFile := filepath.Join(charmDir, hook)
-	if version.Current.OS != version.Windows {
+	if jujuos.HostOS() != jujuos.Windows {
 		// we are not running on windows,
 		// there is no need to look for suffixed hooks
 		return lookPath(hookFile)
@@ -64,7 +64,7 @@ func searchHook(charmDir, hook string) (string, error) {
 // and propagate error levels (-File). .cmd and .bat files can be run
 // directly.
 func hookCommand(hook string) []string {
-	if version.Current.OS != version.Windows {
+	if jujuos.HostOS() != jujuos.Windows {
 		// we are not running on windows,
 		// just return the hook name
 		return []string{hook}

--- a/worker/uniter/runner/args_test.go
+++ b/worker/uniter/runner/args_test.go
@@ -11,7 +11,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/version"
+	"github.com/juju/juju/juju/os"
 	"github.com/juju/juju/worker/uniter/runner"
 )
 
@@ -20,7 +20,7 @@ type WindowsHookSuite struct{}
 var _ = gc.Suite(&WindowsHookSuite{})
 
 func (s *WindowsHookSuite) TestHookCommandPowerShellScript(c *gc.C) {
-	restorer := envtesting.PatchValue(&version.Current.OS, version.Windows)
+	restorer := envtesting.PatchValue(&os.HostOS, func() os.OSType { return os.Windows })
 	defer restorer()
 
 	hookname := "powerShellScript.ps1"
@@ -37,7 +37,7 @@ func (s *WindowsHookSuite) TestHookCommandPowerShellScript(c *gc.C) {
 }
 
 func (s *WindowsHookSuite) TestHookCommandNotPowerShellScripts(c *gc.C) {
-	restorer := envtesting.PatchValue(&version.Current.OS, version.Windows)
+	restorer := envtesting.PatchValue(&os.HostOS, func() os.OSType { return os.Windows })
 	defer restorer()
 
 	cmdhook := "somehook.cmd"
@@ -51,7 +51,7 @@ func (s *WindowsHookSuite) TestSearchHookUbuntu(c *gc.C) {
 	if runtime.GOOS == "windows" {
 		c.Skip("Cannot search for executables without extension on windows")
 	}
-	restorer := envtesting.PatchValue(&version.Current.OS, version.Ubuntu)
+	restorer := envtesting.PatchValue(&os.HostOS, func() os.OSType { return os.Ubuntu })
 	defer restorer()
 
 	charmDir := c.MkDir()
@@ -69,7 +69,7 @@ func (s *WindowsHookSuite) TestSearchHookUbuntu(c *gc.C) {
 }
 
 func (s *WindowsHookSuite) TestSearchHookWindows(c *gc.C) {
-	restorer := envtesting.PatchValue(&version.Current.OS, version.Windows)
+	restorer := envtesting.PatchValue(&os.HostOS, func() os.OSType { return os.Windows })
 	defer restorer()
 
 	charmDir := c.MkDir()
@@ -85,7 +85,7 @@ func (s *WindowsHookSuite) TestSearchHookWindows(c *gc.C) {
 }
 
 func (s *WindowsHookSuite) TestSearchHookWindowsError(c *gc.C) {
-	restorer := envtesting.PatchValue(&version.Current.OS, version.Windows)
+	restorer := envtesting.PatchValue(&os.HostOS, func() os.OSType { return os.Windows })
 	defer restorer()
 
 	charmDir := c.MkDir()

--- a/worker/uniter/runner/env.go
+++ b/worker/uniter/runner/env.go
@@ -8,16 +8,16 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/juju/juju/version"
+	jujuos "github.com/juju/juju/juju/os"
 )
 
 func osDependentEnvVars(paths Paths) []string {
-	switch version.Current.OS {
-	case version.Windows:
+	switch jujuos.HostOS() {
+	case jujuos.Windows:
 		return windowsEnv(paths)
-	case version.Ubuntu:
+	case jujuos.Ubuntu:
 		return ubuntuEnv(paths)
-	case version.CentOS:
+	case jujuos.CentOS:
 		return centosEnv(paths)
 	}
 	return nil

--- a/worker/uniter/runner/env_test.go
+++ b/worker/uniter/runner/env_test.go
@@ -9,13 +9,13 @@ import (
 	"sort"
 	"strings"
 
+	jujuos "github.com/juju/juju/juju/os"
 	"github.com/juju/names"
 	envtesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/proxy"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/version"
 	"github.com/juju/juju/worker/uniter/runner"
 )
 
@@ -140,7 +140,7 @@ func (s *EnvSuite) setRelation(ctx *runner.HookContext) (expectVars []string) {
 }
 
 func (s *EnvSuite) TestEnvWindows(c *gc.C) {
-	s.PatchValue(&version.Current.OS, version.Windows)
+	s.PatchValue(&jujuos.HostOS, func() jujuos.OSType { return jujuos.Windows })
 	os.Setenv("Path", "foo;bar")
 	os.Setenv("PSModulePath", "ping;pong")
 	windowsVars := []string{
@@ -159,7 +159,7 @@ func (s *EnvSuite) TestEnvWindows(c *gc.C) {
 }
 
 func (s *EnvSuite) TestEnvUbuntu(c *gc.C) {
-	s.PatchValue(&version.Current.OS, version.Ubuntu)
+	s.PatchValue(&jujuos.HostOS, func() jujuos.OSType { return jujuos.Ubuntu })
 	os.Setenv("PATH", "foo:bar")
 	ubuntuVars := []string{
 		"PATH=path-to-tools:foo:bar",

--- a/worker/uniter/runner/runner.go
+++ b/worker/uniter/runner/runner.go
@@ -14,7 +14,7 @@ import (
 	"github.com/juju/loggo"
 	utilexec "github.com/juju/utils/exec"
 
-	"github.com/juju/juju/version"
+	jujuos "github.com/juju/juju/juju/os"
 	"github.com/juju/juju/worker/uniter/runner/debug"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
 )
@@ -132,7 +132,7 @@ func (runner *runner) runCharmHookWithLocation(hookName, charmLocation string) e
 	defer srv.Close()
 
 	env := runner.context.HookVars(runner.paths)
-	if version.Current.OS == version.Windows {
+	if jujuos.HostOS() == jujuos.Windows {
 		// TODO(fwereade): somehow consolidate with utils/exec?
 		// We don't do this on the other code path, which uses exec.RunCommands,
 		// because that already has handling for windows environment requirements.

--- a/worker/uniter/uniter.go
+++ b/worker/uniter/uniter.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/juju/juju/api/uniter"
 	"github.com/juju/juju/apiserver/params"
-	"github.com/juju/juju/version"
+	jujuos "github.com/juju/juju/juju/os"
 	"github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/leadership"
 	"github.com/juju/juju/worker/uniter/charm"
@@ -296,7 +296,7 @@ func (u *Uniter) init(unitTag names.UnitTag) (err error) {
 		return nil
 	})
 	// The socket needs to have permissions 777 in order for other users to use it.
-	if version.Current.OS != version.Windows {
+	if jujuos.HostOS() != jujuos.Windows {
 		return os.Chmod(u.paths.Runtime.JujuRunSocket, 0777)
 	}
 	return nil


### PR DESCRIPTION
Introduce new package, `juju/os`, which is analogous to `juju/arch`.

The goal of `juju/os` is to isolate the use of `version.Current.OS` which is used in relatively few places in the code, and never part of tool bootstrapping.

A subsequent PR will remove the `version.Binary.OS` field and replace it with a call to `os.HostOS()`, or derive the value from `version.Binary.Series`.

(Review request: http://reviews.vapour.ws/r/2571/)