### PR TITLE
Only run update-status hook after everything else and when no error

### DIFF
--- a/cmd/jujud/run_test.go
+++ b/cmd/jujud/run_test.go
@@ -313,7 +313,7 @@ func (s *RunTestSuite) runListenerForAgent(c *gc.C, agent string) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(listener, gc.NotNil)
 	s.AddCleanup(func(*gc.C) {
-		listener.Close()
+		c.Assert(listener.Close(), jc.ErrorIsNil)
 	})
 }
 

--- a/worker/dependency/engine.go
+++ b/worker/dependency/engine.go
@@ -473,7 +473,7 @@ func (engine *engine) gotStopped(name string, err error, resourceLog []resourceA
 			// anyway).
 		default:
 			// Something went wrong but we don't know what. Try again soon.
-			logger.Debugf("%q manifold worker returned unexpected error: %v", err)
+			logger.Debugf("%q manifold worker returned unexpected error: %v", name, err)
 			engine.requestStart(name, engine.config.ErrorDelay)
 		}
 	}

--- a/worker/uniter/hook/hook.go
+++ b/worker/uniter/hook/hook.go
@@ -47,7 +47,8 @@ func (hi Info) Validate() error {
 			return fmt.Errorf("%q hook requires a remote unit", hi.Kind)
 		}
 		fallthrough
-	case hooks.Install, hooks.Start, hooks.ConfigChanged, hooks.UpgradeCharm, hooks.Stop, hooks.RelationBroken, hooks.CollectMetrics, hooks.MeterStatusChanged, hooks.UpdateStatus:
+	case hooks.Install, hooks.Start, hooks.ConfigChanged, hooks.UpgradeCharm, hooks.Stop, hooks.RelationBroken,
+		hooks.CollectMetrics, hooks.MeterStatusChanged, hooks.UpdateStatus:
 		return nil
 	case hooks.Action:
 		return fmt.Errorf("hooks.Kind Action is deprecated")

--- a/worker/uniter/remotestate/snapshot.go
+++ b/worker/uniter/remotestate/snapshot.go
@@ -48,6 +48,9 @@ type Snapshot struct {
 	// version of the leader settings for the service.
 	LeaderSettingsVersion int
 
+	// UpdateStatusRequired indicates if an UpdateStatus hook should run.
+	UpdateStatusRequired bool
+
 	// Actions is the list of pending actions to
 	// be peformed by this unit.
 	Actions []string

--- a/worker/uniter/remotestate/snapshot.go
+++ b/worker/uniter/remotestate/snapshot.go
@@ -48,8 +48,9 @@ type Snapshot struct {
 	// version of the leader settings for the service.
 	LeaderSettingsVersion int
 
-	// UpdateStatusRequired indicates if an UpdateStatus hook should run.
-	UpdateStatusRequired bool
+	// UpdateStatusVersion increments each time an
+	// update-status hook is supposed to run.
+	UpdateStatusVersion int
 
 	// Actions is the list of pending actions to
 	// be peformed by this unit.

--- a/worker/uniter/remotestate/watcher.go
+++ b/worker/uniter/remotestate/watcher.go
@@ -125,10 +125,6 @@ func (w *RemoteStateWatcher) Snapshot() Snapshot {
 	for i, action := range w.current.Actions {
 		snapshot.Actions[i] = action
 	}
-	// We return a snapshot with the current UpdateStatusRequired value.
-	// We reset it so that subsequent snapshots wait until the timer is
-	// triggered again before setting the value again.
-	w.current.UpdateStatusRequired = false
 	return snapshot
 }
 
@@ -400,7 +396,7 @@ func (w *RemoteStateWatcher) loop(unitTag names.UnitTag) (err error) {
 // updateStatusChanged is called when the update status timer expires.
 func (w *RemoteStateWatcher) updateStatusChanged() error {
 	w.mu.Lock()
-	w.current.UpdateStatusRequired = true
+	w.current.UpdateStatusVersion++
 	w.mu.Unlock()
 	return nil
 }

--- a/worker/uniter/resolver.go
+++ b/worker/uniter/resolver.go
@@ -207,5 +207,15 @@ func (s *uniterResolver) nextOp(
 		return opFactory.NewRunHook(hook.Info{Kind: hooks.ConfigChanged})
 	}
 
-	return s.relationsResolver.NextOp(localState, remoteState, opFactory)
+	op, err := s.relationsResolver.NextOp(localState, remoteState, opFactory)
+	if errors.Cause(err) != resolver.ErrNoOperation {
+		return op, err
+	}
+
+	// UpdateStatus hook runs if nothing else needs to.
+	if remoteState.UpdateStatusRequired {
+		return opFactory.NewRunHook(hook.Info{Kind: hooks.UpdateStatus})
+	}
+
+	return nil, resolver.ErrNoOperation
 }

--- a/worker/uniter/resolver.go
+++ b/worker/uniter/resolver.go
@@ -213,7 +213,7 @@ func (s *uniterResolver) nextOp(
 	}
 
 	// UpdateStatus hook runs if nothing else needs to.
-	if remoteState.UpdateStatusRequired {
+	if localState.UpdateStatusVersion != remoteState.UpdateStatusVersion {
 		return opFactory.NewRunHook(hook.Info{Kind: hooks.UpdateStatus})
 	}
 

--- a/worker/uniter/resolver/interface.go
+++ b/worker/uniter/resolver/interface.go
@@ -66,6 +66,10 @@ type LocalState struct {
 	// at the earliest opportunity.
 	Restart bool
 
+	// UpdateStatusVersion is the version of update status from remotestate.Snapshot
+	// for which an update-status hook has been committed.
+	UpdateStatusVersion int
+
 	// ConfigVersion is the version of config from remotestate.Snapshot
 	// for which a config-changed hook has been committed.
 	ConfigVersion int

--- a/worker/uniter/resolver/loop.go
+++ b/worker/uniter/resolver/loop.go
@@ -16,15 +16,15 @@ import (
 
 // LoopConfig contains configuration parameters for the resolver loop.
 type LoopConfig struct {
-	Resolver            Resolver
-	Watcher             remotestate.Watcher
-	Executor            operation.Executor
-	Factory             operation.Factory
-	CharmURL            *charm.URL
-	Conflicted          bool
-	Dying               <-chan struct{}
-	OnIdle              func() error
-	CharmDirLocker      charmdir.Locker
+	Resolver       Resolver
+	Watcher        remotestate.Watcher
+	Executor       operation.Executor
+	Factory        operation.Factory
+	CharmURL       *charm.URL
+	Conflicted     bool
+	Dying          <-chan struct{}
+	OnIdle         func() error
+	CharmDirLocker charmdir.Locker
 }
 
 // Loop repeatedly waits for remote state changes, feeding the local and

--- a/worker/uniter/resolver/loop_test.go
+++ b/worker/uniter/resolver/loop_test.go
@@ -53,10 +53,6 @@ func (s *LoopSuite) loop() (resolver.LocalState, error) {
 		Factory:  s.opFactory,
 		Watcher:  s.watcher,
 		Executor: s.executor,
-		UpdateStatusChannel: func() <-chan time.Time {
-			// TODO(axw) test update status channel
-			return nil
-		},
 		CharmURL:       s.charmURL,
 		Dying:          s.dying,
 		OnIdle:         s.onIdle,

--- a/worker/uniter/resolver/loop_test.go
+++ b/worker/uniter/resolver/loop_test.go
@@ -49,10 +49,10 @@ func (s *LoopSuite) SetUpTest(c *gc.C) {
 
 func (s *LoopSuite) loop() (resolver.LocalState, error) {
 	return resolver.Loop(resolver.LoopConfig{
-		Resolver: s.resolver,
-		Factory:  s.opFactory,
-		Watcher:  s.watcher,
-		Executor: s.executor,
+		Resolver:       s.resolver,
+		Factory:        s.opFactory,
+		Watcher:        s.watcher,
+		Executor:       s.executor,
 		CharmURL:       s.charmURL,
 		Dying:          s.dying,
 		OnIdle:         s.onIdle,

--- a/worker/uniter/resolver/opfactory.go
+++ b/worker/uniter/resolver/opfactory.go
@@ -104,26 +104,24 @@ func (s *resolverOpFactory) wrapUpgradeOp(op operation.Operation, charmURL *char
 }
 
 func (s *resolverOpFactory) wrapHookOp(op operation.Operation, info hook.Info) operation.Operation {
-	// No matter what has finished running, we reset the UpdateStatusVersion so that
-	// the update-status hook only fires after the next timer.
-	updateStatusVersion := s.RemoteState.UpdateStatusVersion
 	switch info.Kind {
 	case hooks.ConfigChanged:
 		v := s.RemoteState.ConfigVersion
 		op = onCommitWrapper{op, func() {
 			s.LocalState.ConfigVersion = v
-			s.LocalState.UpdateStatusVersion = updateStatusVersion
 		}}
 	case hooks.LeaderSettingsChanged:
 		v := s.RemoteState.LeaderSettingsVersion
 		op = onCommitWrapper{op, func() {
 			s.LocalState.LeaderSettingsVersion = v
-			s.LocalState.UpdateStatusVersion = updateStatusVersion
 		}}
-	default:
-		op = onCommitWrapper{op, func() { s.LocalState.UpdateStatusVersion = updateStatusVersion }}
 	}
-	return op
+	// No matter what has finished running, we reset the UpdateStatusVersion so that
+	// the update-status hook only fires after the next timer.
+	v := s.RemoteState.UpdateStatusVersion
+	return onCommitWrapper{op, func() {
+		s.LocalState.UpdateStatusVersion = v
+	}}
 }
 
 type onCommitWrapper struct {
@@ -136,6 +134,13 @@ func (op onCommitWrapper) Commit(state operation.State) (*operation.State, error
 	if err != nil {
 		return nil, err
 	}
-	op.f()
+	onCommit(op)
 	return st, nil
+}
+
+func onCommit(op operation.Operation) {
+	if wrapper, ok := op.(onCommitWrapper); ok {
+		wrapper.f()
+		onCommit(wrapper.Operation)
+	}
 }

--- a/worker/uniter/runlistener.go
+++ b/worker/uniter/runlistener.go
@@ -39,7 +39,7 @@ type CommandRunner interface {
 }
 
 // RunListener is responsible for listening on the network connection and
-// seting up the rpc server on that net connection. Also starts the go routine
+// setting up the rpc server on that net connection. Also starts the go routine
 // that listens and hands off the work.
 type RunListener struct {
 	listener net.Listener
@@ -122,9 +122,11 @@ func (s *RunListener) Run() (err error) {
 
 // Close immediately stops accepting connections, and blocks until all existing
 // connections have been closed.
-func (s *RunListener) Close() {
+func (s *RunListener) Close() error {
+	defer func() {
+		<-s.closed
+		logger.Debugf("juju-run listener stopped")
+	}()
 	close(s.closing)
-	s.listener.Close()
-	<-s.closed
-	logger.Debugf("juju-run listener stopped")
+	return s.listener.Close()
 }

--- a/worker/uniter/runlistener_test.go
+++ b/worker/uniter/runlistener_test.go
@@ -42,7 +42,7 @@ func (s *ListenerSuite) NewRunListener(c *gc.C) *uniter.RunListener {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(listener, gc.NotNil)
 	s.AddCleanup(func(*gc.C) {
-		listener.Close()
+		c.Assert(listener.Close(), jc.ErrorIsNil)
 	})
 	return listener
 }
@@ -56,7 +56,7 @@ func (s *ListenerSuite) TestNewRunListenerOnExistingSocketRemovesItAndSucceeds(c
 	listener, err := uniter.NewRunListener(&mockRunner{}, s.socketPath)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(listener, gc.NotNil)
-	listener.Close()
+	c.Assert(listener.Close(), jc.ErrorIsNil)
 }
 
 func (s *ListenerSuite) TestClientCall(c *gc.C) {

--- a/worker/uniter/uniter.go
+++ b/worker/uniter/uniter.go
@@ -265,15 +265,15 @@ func (u *Uniter) loop(unitTag names.UnitTag) (err error) {
 		var localState resolver.LocalState
 		for err == nil {
 			localState, err = resolver.Loop(resolver.LoopConfig{
-				Resolver:            uniterResolver,
-				Watcher:             watcher,
-				Executor:            u.operationExecutor,
-				Factory:             u.operationFactory,
-				CharmURL:            charmURL,
-				Conflicted:          conflicted,
-				Dying:               u.tomb.Dying(),
-				OnIdle:              onIdle,
-				CharmDirLocker:      u.charmDirLocker,
+				Resolver:       uniterResolver,
+				Watcher:        watcher,
+				Executor:       u.operationExecutor,
+				Factory:        u.operationFactory,
+				CharmURL:       charmURL,
+				Conflicted:     conflicted,
+				Dying:          u.tomb.Dying(),
+				OnIdle:         onIdle,
+				CharmDirLocker: u.charmDirLocker,
 			})
 			switch cause := errors.Cause(err); cause {
 			case nil:

--- a/worker/uniter/uniter_test.go
+++ b/worker/uniter/uniter_test.go
@@ -233,6 +233,28 @@ func (s *UniterSuite) TestUniterUpdateStatusHook(c *gc.C) {
 	})
 }
 
+func (s *UniterSuite) TestNoUniterUpdateStatusHookInError(c *gc.C) {
+	s.runUniterTests(c, []uniterTest{
+		ut(
+			"update status hook doesn't run if in error",
+			startupError{"start"},
+			waitHooks{},
+			updateStatusHookTick{},
+			waitHooks{},
+
+			// Resolve and hook should run.
+			resolveError{state.ResolvedNoHooks},
+			waitHooks{"config-changed"},
+			waitUnitAgent{
+				status: params.StatusIdle,
+			},
+			waitHooks{},
+			updateStatusHookTick{},
+			waitHooks{"update-status"},
+		),
+	})
+}
+
 func (s *UniterSuite) TestUniterStartHook(c *gc.C) {
 	s.runUniterTests(c, []uniterTest{
 		ut(


### PR DESCRIPTION
The update status trigger is moved to remote state watcher.
It triggers after everything else and when not in error.
Also some minor refactoring to fix a todo.

(Review request: http://reviews.vapour.ws/r/2573/)