### PR TITLE
storage: remove persistent as pool configuration

### DIFF
--- a/apiserver/storage/storage.go
+++ b/apiserver/storage/storage.go
@@ -234,17 +234,10 @@ func (api *API) isPersistent(si state.StorageInstance) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	// If the volume is not provisioned, we read its config attributes.
-	if params, ok := volume.Params(); ok {
-		_, cfg, err := common.StoragePoolConfig(params.Pool, api.poolManager)
-		if err != nil {
-			return false, err
-		}
-		return cfg.IsPersistent(), nil
-	}
-	// If the volume is provisioned, we look at its provisioning info.
 	info, err := volume.Info()
-	if err != nil {
+	if errors.IsNotProvisioned(err) {
+		return false, nil
+	} else if err != nil {
 		return false, err
 	}
 	return info.Persistent, nil

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -974,7 +974,7 @@ func (e *environ) StartInstance(args environs.StartInstanceParams) (*environs.St
 	// Simulate creating volumes when requested.
 	volumes := make([]storage.Volume, len(args.Volumes))
 	for iv, v := range args.Volumes {
-		persistent, _ := v.Attributes[storage.Persistent].(bool)
+		persistent, _ := v.Attributes["persistent"].(bool)
 		volumes[iv] = storage.Volume{
 			Tag: names.NewVolumeTag(strconv.Itoa(iv + 1)),
 			VolumeInfo: storage.VolumeInfo{

--- a/provider/ec2/ebs.go
+++ b/provider/ec2/ebs.go
@@ -112,7 +112,6 @@ type ebsProvider struct{}
 var _ storage.Provider = (*ebsProvider)(nil)
 
 var ebsConfigFields = schema.Fields{
-	storage.Persistent: schema.Bool(),
 	EBS_VolumeType: schema.OneOf(
 		schema.Const(volumeTypeMagnetic),
 		schema.Const(volumeTypeSsd),
@@ -128,15 +127,13 @@ var ebsConfigFields = schema.Fields{
 var ebsConfigChecker = schema.FieldMap(
 	ebsConfigFields,
 	schema.Defaults{
-		storage.Persistent: false,
-		EBS_VolumeType:     volumeTypeMagnetic,
-		EBS_IOPS:           schema.Omit,
-		EBS_Encrypted:      false,
+		EBS_VolumeType: volumeTypeMagnetic,
+		EBS_IOPS:       schema.Omit,
+		EBS_Encrypted:  false,
 	},
 )
 
 type ebsConfig struct {
-	persistent bool
 	volumeType string
 	iops       int
 	encrypted  bool
@@ -151,7 +148,6 @@ func newEbsConfig(attrs map[string]interface{}) (*ebsConfig, error) {
 	iops, _ := coerced[EBS_IOPS].(int)
 	volumeType := coerced[EBS_VolumeType].(string)
 	ebsConfig := &ebsConfig{
-		persistent: coerced[storage.Persistent].(bool),
 		volumeType: volumeType,
 		iops:       iops,
 		encrypted:  coerced[EBS_Encrypted].(bool),

--- a/storage/config.go
+++ b/storage/config.go
@@ -19,43 +19,32 @@ const (
 	// should not be relied upon until a storage source is
 	// constructed.
 	ConfigStorageDir = "storage-dir"
-
-	// Persistent is true if storage survives the lifecycle of the
-	// machine to which it is attached.
-	Persistent = "persistent"
 )
 
 // Config defines the configuration for a storage source.
 type Config struct {
-	name       string
-	provider   ProviderType
-	attrs      map[string]interface{}
-	persistent bool
+	name     string
+	provider ProviderType
+	attrs    map[string]interface{}
 }
 
-var fields = schema.Fields{
-	Persistent: schema.Bool(),
-}
+var fields = schema.Fields{}
 
 var configChecker = schema.FieldMap(
 	fields,
-	schema.Defaults{
-		Persistent: false,
-	},
+	schema.Defaults{},
 )
 
 // NewConfig creates a new Config for instantiating a storage source.
 func NewConfig(name string, provider ProviderType, attrs map[string]interface{}) (*Config, error) {
-	out, err := configChecker.Coerce(attrs, nil)
+	_, err := configChecker.Coerce(attrs, nil)
 	if err != nil {
 		return nil, errors.Annotate(err, "validating common storage config")
 	}
-	coerced := out.(map[string]interface{})
 	return &Config{
-		name:       name,
-		provider:   provider,
-		attrs:      attrs,
-		persistent: coerced[Persistent].(bool),
+		name:     name,
+		provider: provider,
+		attrs:    attrs,
 	}, nil
 }
 
@@ -86,9 +75,4 @@ func (c *Config) Attrs() map[string]interface{} {
 func (c *Config) ValueString(name string) (string, bool) {
 	v, ok := c.attrs[name].(string)
 	return v, ok
-}
-
-// IsPersistent returns true if config has persistent set to true.
-func (c *Config) IsPersistent() bool {
-	return c.persistent
 }

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -177,12 +177,6 @@ type VolumeParams struct {
 	Attachment *VolumeAttachmentParams
 }
 
-// IsPersistent returns true if the params has persistent set to true.
-func (p *VolumeParams) IsPersistent() bool {
-	v, _ := p.Attributes[Persistent].(bool)
-	return v
-}
-
 // VolumeAttachmentParams is a set of parameters for volume attachment or
 // detachment.
 type VolumeAttachmentParams struct {

--- a/storage/provider/common.go
+++ b/storage/provider/common.go
@@ -23,8 +23,5 @@ func CommonProviders() map[storage.ProviderType]storage.Provider {
 // ValidateConfig performs storage provider config validation, including
 // any common validation.
 func ValidateConfig(p storage.Provider, cfg *storage.Config) error {
-	if p.Scope() == storage.ScopeMachine && cfg.IsPersistent() {
-		return errors.Errorf("machine scoped storage provider %q does not support persistent storage", cfg.Name())
-	}
 	return p.ValidateConfig(cfg)
 }


### PR DESCRIPTION
It no longer makes sense to have "persistent" as
a pool configuration attribute. Instead, providers
create persistent storage if they support it, or
otherwise don't (there *could* be provider-specific
config for this, but so far it has been unnecessary).

Later we'll have the ability to manage the lifecycle
binding of storage, which will cause persistent
storage to live beyond attachments.

(Review request: http://reviews.vapour.ws/r/2574/)