### PR TITLE
Use updated charm.v6-unstable in chicago-cubs.

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -37,12 +37,11 @@ gopkg.in/amz.v3	git	bff3a097c4108da57bb8cbe3aad2990d74d23676	2015-08-20T12:28:33
 gopkg.in/check.v1	git	b3d3430320d4260e5fea99841af984b3badcea63	2015-06-26T10:50:28Z
 gopkg.in/errgo.v1	git	15098963088579c1cd9eb1a7da285831e548390b	2015-07-07T18:34:45Z
 gopkg.in/goose.v1	git	be6030ce33a6d77f5e9c63b7698030e6431d5343	2015-08-24T15:19:40Z
-gopkg.in/juju/charm.v6-unstable	git	15a30d22682843bc21a9d1aa2334b144fd3ae0fc	2015-08-28T17:11:30Z
+gopkg.in/juju/charm.v6-unstable	git	49f6312f83592ab73309a9de5987d49a789c806c	2015-09-02T21:57:54Z
 gopkg.in/juju/charmrepo.v1	git	1a22c8b1f984c5c98f3b9e7a0e8f7c3fba9ba2af	2015-08-28T06:40:30Z
 gopkg.in/juju/charmstore.v5-unstable	git	a921c6c69d74361c38a99a95d2aceec76533038d	2015-08-27T20:19:40Z
 gopkg.in/juju/environschema.v1	git	16cc59268c09c22870cb4de8eb6248652535f315	2015-08-24T13:22:26Z
 gopkg.in/juju/jujusvg.v1	git	3eedb1c722ece2b66d62508368ca3e8b7f916569	2015-05-20T11:48:32Z
-gopkg.in/macaroon-bakery.v0	git	7ab5879cabb9f9853941f0a0b3b7ff6ac4c4b292	2015-04-17T07:41:59Z
 gopkg.in/macaroon-bakery.v1	git	4f24997a6660b73733950bc0ea55c020784f6bcf	2015-08-31T21:54:40Z
 gopkg.in/macaroon.v1	git	ab3940c6c16510a850e1c2dd628b919f0f3f1464	2015-01-21T11:42:31Z
 gopkg.in/mgo.v2	git	f4923a569136442e900b8cf5c1a706c0a8b0883c	2015-08-21T15:31:23Z


### PR DESCRIPTION


(Review request: http://reviews.vapour.ws/r/2582/)