### PR TITLE
Use new bundlechanges API.

### DIFF
--- a/apiserver/client/bundles.go
+++ b/apiserver/client/bundles.go
@@ -38,10 +38,10 @@ func (c *Client) GetBundleChanges(args params.GetBundleChangesParams) (params.Ge
 	results.Changes = make([]*params.BundleChangesChange, len(changes))
 	for i, c := range changes {
 		results.Changes[i] = &params.BundleChangesChange{
-			Id:       c.Id,
-			Method:   c.Method,
-			Args:     c.Args,
-			Requires: c.Requires,
+			Id:       c.Id(),
+			Method:   c.Method(),
+			Args:     c.GUIArgs(),
+			Requires: c.Requires(),
 		}
 	}
 	return results, nil

--- a/apiserver/client/bundles_test.go
+++ b/apiserver/client/bundles_test.go
@@ -64,7 +64,7 @@ func (s *serverSuite) TestGetBundleChangesSuccess(c *gc.C) {
 		Method: "addCharm",
 		Args:   []interface{}{"django"},
 	}, {
-		Id:       "addService-1",
+		Id:       "deploy-1",
 		Method:   "deploy",
 		Args:     []interface{}{"django", "django", map[string]interface{}{"debug": true}},
 		Requires: []string{"addCharm-0"},
@@ -73,15 +73,15 @@ func (s *serverSuite) TestGetBundleChangesSuccess(c *gc.C) {
 		Method: "addCharm",
 		Args:   []interface{}{"cs:trusty/haproxy-42"},
 	}, {
-		Id:       "addService-3",
+		Id:       "deploy-3",
 		Method:   "deploy",
 		Args:     []interface{}{"cs:trusty/haproxy-42", "haproxy", map[string]interface{}{}},
 		Requires: []string{"addCharm-2"},
 	}, {
 		Id:       "addRelation-4",
 		Method:   "addRelation",
-		Args:     []interface{}{"$addService-1:web", "$addService-3:web"},
-		Requires: []string{"addService-1", "addService-3"},
+		Args:     []interface{}{"$deploy-1:web", "$deploy-3:web"},
+		Requires: []string{"deploy-1", "deploy-3"},
 	}})
 	c.Assert(r.Errors, gc.IsNil)
 }

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -10,7 +10,7 @@ github.com/joyent/gomanta	git	cabd97b029d931836571f00b7e48c331809a30b7	2014-05-2
 github.com/joyent/gosdc	git	2f11feadd2d9891e92296a1077c3e2e56939547d	2014-05-24T00:08:15Z
 github.com/joyent/gosign	git	0da0d5f1342065321c97812b1f4ac0c2b0bab56c	2014-05-24T00:07:34Z
 github.com/juju/blobstore	git	337aa7d5d712728d181dbda2547a6556d4189626	2015-05-08T07:43:36Z
-github.com/juju/bundlechanges	git	6945950a8af88af10dc54061b3446d40c8584ebe	2015-08-25T08:27:54Z
+github.com/juju/bundlechanges	git	8e9d2ac9777ce7575e2b74cd33dc77094981910e	2015-09-03T19:46:11Z
 github.com/juju/cmd	git	a7964f7cbac96484d1a9ba25e37bd32b7fa3cd90	2015-06-12T00:20:39Z
 github.com/juju/errors	git	4567a5e69fd3130ca0d89f69478e7ac025b67452	2015-03-27T19:24:31Z
 github.com/juju/gojsonpointer	git	afe8b77aa08f272b49e01b82de78510c11f61500	2015-02-04T19:46:29Z


### PR DESCRIPTION
The new bundlechanges API returns changes as interfaces rather than concrete structs. This branch reflects this new behavior.

(Review request: http://reviews.vapour.ws/r/2585/)