### PR TITLE
Get juju compiling again on Windows.

### DIFF
--- a/juju/os/os_linux.go
+++ b/juju/os/os_linux.go
@@ -50,6 +50,9 @@ func updateOS(f string) (OSType, error) {
 	}
 }
 
+// ReadOSRelease parsed the information in the os-release file.
+//
+// See http://www.freedesktop.org/software/systemd/man/os-release.html.
 func ReadOSRelease(f string) (map[string]string, error) {
 	contents, err := ioutil.ReadFile(f)
 	if err != nil {

--- a/juju/os/os_linux.go
+++ b/juju/os/os_linux.go
@@ -50,7 +50,7 @@ func updateOS(f string) (OSType, error) {
 	}
 }
 
-// ReadOSRelease parsed the information in the os-release file.
+// ReadOSRelease parses the information in the os-release file.
 //
 // See http://www.freedesktop.org/software/systemd/man/os-release.html.
 func ReadOSRelease(f string) (map[string]string, error) {

--- a/version/export_linux_test.go
+++ b/version/export_linux_test.go
@@ -1,0 +1,10 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package version
+
+var (
+	DistroInfo    = &distroInfo
+	ReadSeries    = readSeries
+	OSReleaseFile = &osReleaseFile
+)

--- a/version/export_test.go
+++ b/version/export_test.go
@@ -4,12 +4,9 @@
 package version
 
 var (
-	DistroInfo                    = &distroInfo
-	ReadSeries                    = readSeries
 	KernelToMajor                 = kernelToMajor
 	MacOSXSeriesFromKernelVersion = macOSXSeriesFromKernelVersion
 	MacOSXSeriesFromMajorVersion  = macOSXSeriesFromMajorVersion
-	OSReleaseFile                 = &osReleaseFile
 )
 
 func SetSeriesVersions(value map[string]string) func() {

--- a/version/osversion.go
+++ b/version/osversion.go
@@ -4,7 +4,6 @@
 package version
 
 import (
-	"fmt"
 	"strconv"
 	"strings"
 
@@ -37,34 +36,6 @@ func MustOSFromSeries(series string) os.OSType {
 		panic("osVersion reported an error: " + err.Error())
 	}
 	return operatingSystem
-}
-
-func getValue(from map[string]string, val string) (string, error) {
-	for serie, ver := range from {
-		if ver == val {
-			return serie, nil
-		}
-	}
-	return "unknown", errors.New("Could not determine series")
-}
-
-func readSeries() (string, error) {
-	values, err := os.ReadOSRelease(osReleaseFile)
-	if err != nil {
-		return "unknown", err
-	}
-	updateSeriesVersions()
-	switch values["ID"] {
-	case strings.ToLower(os.Ubuntu.String()):
-		return getValue(ubuntuSeries, values["VERSION_ID"])
-	case strings.ToLower(os.Arch.String()):
-		return getValue(archSeries, values["VERSION_ID"])
-	case strings.ToLower(os.CentOS.String()):
-		codename := fmt.Sprintf("%s%s", values["ID"], values["VERSION_ID"])
-		return getValue(centosSeries, codename)
-	default:
-		return "unknown", nil
-	}
 }
 
 // kernelToMajor takes a dotted version and returns just the Major portion

--- a/version/osversion_linux.go
+++ b/version/osversion_linux.go
@@ -62,15 +62,10 @@ func ReleaseVersion() string {
 	return release["VERSION_ID"]
 }
 
-var updatedseriesVersions bool
-
-func updateSeriesVersions() {
-	if !updatedseriesVersions {
-		err := updateDistroInfo()
-		if err != nil {
-			logger.Warningf("failed to update distro info: %v", err)
-		}
-		updatedseriesVersions = true
+func updateLocalSeriesVersions() {
+	err := updateDistroInfo()
+	if err != nil {
+		logger.Warningf("failed to update distro info: %v", err)
 	}
 }
 

--- a/version/osversion_linux.go
+++ b/version/osversion_linux.go
@@ -4,12 +4,15 @@
 package version
 
 import (
+	"bufio"
 	"fmt"
+	"io"
+	"os"
 	"strings"
 
 	"github.com/juju/errors"
 
-	"github.com/juju/juju/juju/os"
+	jujuos "github.com/juju/juju/juju/os"
 )
 
 func osVersion() (string, error) {
@@ -17,7 +20,7 @@ func osVersion() (string, error) {
 }
 
 func readSeries() (string, error) {
-	values, err := os.ReadOSRelease(osReleaseFile)
+	values, err := jujuos.ReadOSRelease(osReleaseFile)
 	if err != nil {
 		return "unknown", err
 	}
@@ -27,11 +30,11 @@ func readSeries() (string, error) {
 
 func seriesFromOSRelease(values map[string]string) (string, error) {
 	switch values["ID"] {
-	case strings.ToLower(os.Ubuntu.String()):
+	case strings.ToLower(jujuos.Ubuntu.String()):
 		return getValue(ubuntuSeries, values["VERSION_ID"])
-	case strings.ToLower(os.Arch.String()):
+	case strings.ToLower(jujuos.Arch.String()):
 		return getValue(archSeries, values["VERSION_ID"])
-	case strings.ToLower(os.CentOS.String()):
+	case strings.ToLower(jujuos.CentOS.String()):
 		codename := fmt.Sprintf("%s%s", values["ID"], values["VERSION_ID"])
 		return getValue(centosSeries, codename)
 	default:
@@ -52,9 +55,66 @@ func getValue(from map[string]string, val string) (string, error) {
 // the os-release.  If the value is not found, the file is not found, or
 // an error occurs reading the file, an empty string is returned.
 func ReleaseVersion() string {
-	release, err := os.ReadOSRelease(osReleaseFile)
+	release, err := jujuos.ReadOSRelease(osReleaseFile)
 	if err != nil {
 		return ""
 	}
 	return release["VERSION_ID"]
+}
+
+var updatedseriesVersions bool
+
+func updateSeriesVersions() {
+	if !updatedseriesVersions {
+		err := updateDistroInfo()
+		if err != nil {
+			logger.Warningf("failed to update distro info: %v", err)
+		}
+		updatedseriesVersions = true
+	}
+}
+
+var distroInfo = "/usr/share/distro-info/ubuntu.csv"
+
+// updateDistroInfo updates seriesVersions from /usr/share/distro-info/ubuntu.csv if possible..
+func updateDistroInfo() error {
+	// We need to find the series version eg 12.04 from the series eg precise. Use the information found in
+	// /usr/share/distro-info/ubuntu.csv provided by distro-info-data package.
+	f, err := os.Open(distroInfo)
+	if err != nil {
+		// On non-Ubuntu systems this file won't exist but that's expected.
+		return nil
+	}
+	defer f.Close()
+	bufRdr := bufio.NewReader(f)
+	// Only find info for precise or later.
+	// TODO: only add in series that are supported (i.e. before end of life)
+	preciseOrLaterFound := false
+	for {
+		line, err := bufRdr.ReadString('\n')
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("reading distro info file file: %v", err)
+		}
+		// lines are of the form: "12.04 LTS,Precise Pangolin,precise,2011-10-13,2012-04-26,2017-04-26"
+		parts := strings.Split(line, ",")
+		// Ignore any malformed lines.
+		if len(parts) < 3 {
+			continue
+		}
+		series := parts[2]
+		if series == "precise" {
+			preciseOrLaterFound = true
+		}
+		if series != "precise" && !preciseOrLaterFound {
+			continue
+		}
+		// the numeric version may contain a LTS moniker so strip that out.
+		seriesInfo := strings.Split(parts[0], " ")
+		seriesVersions[series] = seriesInfo[0]
+		ubuntuSeries[series] = seriesInfo[0]
+	}
+	return nil
 }

--- a/version/osversion_linux.go
+++ b/version/osversion_linux.go
@@ -4,11 +4,44 @@
 package version
 
 import (
+	"fmt"
+	"strings"
+
+	"github.com/juju/errors"
+
 	"github.com/juju/juju/juju/os"
 )
 
 func osVersion() (string, error) {
 	return readSeries()
+}
+
+func readSeries() (string, error) {
+	values, err := os.ReadOSRelease(osReleaseFile)
+	if err != nil {
+		return "unknown", err
+	}
+	updateSeriesVersions()
+	switch values["ID"] {
+	case strings.ToLower(os.Ubuntu.String()):
+		return getValue(ubuntuSeries, values["VERSION_ID"])
+	case strings.ToLower(os.Arch.String()):
+		return getValue(archSeries, values["VERSION_ID"])
+	case strings.ToLower(os.CentOS.String()):
+		codename := fmt.Sprintf("%s%s", values["ID"], values["VERSION_ID"])
+		return getValue(centosSeries, codename)
+	default:
+		return "unknown", nil
+	}
+}
+
+func getValue(from map[string]string, val string) (string, error) {
+	for serie, ver := range from {
+		if ver == val {
+			return serie, nil
+		}
+	}
+	return "unknown", errors.New("Could not determine series")
 }
 
 // ReleaseVersion looks for the value of VERSION_ID in the content of

--- a/version/osversion_linux.go
+++ b/version/osversion_linux.go
@@ -22,6 +22,10 @@ func readSeries() (string, error) {
 		return "unknown", err
 	}
 	updateSeriesVersions()
+	return seriesFromOSRelease(values)
+}
+
+func seriesFromOSRelease(values map[string]string) (string, error) {
 	switch values["ID"] {
 	case strings.ToLower(os.Ubuntu.String()):
 		return getValue(ubuntuSeries, values["VERSION_ID"])

--- a/version/osversion_linux.go
+++ b/version/osversion_linux.go
@@ -3,6 +3,21 @@
 
 package version
 
+import (
+	"github.com/juju/juju/juju/os"
+)
+
 func osVersion() (string, error) {
 	return readSeries()
+}
+
+// ReleaseVersion looks for the value of VERSION_ID in the content of
+// the os-release.  If the value is not found, the file is not found, or
+// an error occurs reading the file, an empty string is returned.
+func ReleaseVersion() string {
+	release, err := os.ReadOSRelease(osReleaseFile)
+	if err != nil {
+		return ""
+	}
+	return release["VERSION_ID"]
 }

--- a/version/osversion_linux_test.go
+++ b/version/osversion_linux_test.go
@@ -124,3 +124,106 @@ VERSION_ID="9.10"
 		c.Assert(value, gc.Equals, test.expected)
 	}
 }
+
+type readSeriesSuite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&readSeriesSuite{})
+
+var readSeriesTests = []struct {
+	contents string
+	series   string
+	err      string
+}{{
+	`NAME="Ubuntu"
+VERSION="12.04.5 LTS, Precise Pangolin"
+ID=ubuntu
+ID_LIKE=debian
+PRETTY_NAME="Ubuntu precise (12.04.5 LTS)"
+VERSION_ID="12.04"
+`,
+	"precise",
+	"",
+}, {
+	`NAME="Ubuntu"
+ID=ubuntu
+VERSION_ID= "12.04" `,
+	"precise",
+	"",
+}, {
+	`NAME='Ubuntu'
+ID='ubuntu'
+VERSION_ID='12.04'
+`,
+	"precise",
+	"",
+}, {
+	`NAME="CentOS Linux"
+ID="centos"
+VERSION_ID="7"
+`,
+	"centos7",
+	"",
+}, {
+	`NAME="Arch Linux"
+ID=arch
+PRETTY_NAME="Arch Linux"
+ANSI_COLOR="0;36"
+HOME_URL="https://www.archlinux.org/"
+SUPPORT_URL="https://bbs.archlinux.org/"
+BUG_REPORT_URL="https://bugs.archlinux.org/"
+`,
+	"arch",
+	"",
+}, {
+	`NAME="Ubuntu"
+VERSION="14.04.1 LTS, Trusty Tahr"
+ID=ubuntu
+ID_LIKE=debian
+PRETTY_NAME="Ubuntu 14.04.1 LTS"
+VERSION_ID="14.04"
+HOME_URL="http://www.ubuntu.com/"
+SUPPORT_URL="http://help.ubuntu.com/"
+BUG_REPORT_URL="http://bugs.launchpad.net/ubuntu/"
+`,
+	"trusty",
+	"",
+}, {
+	"",
+	"unknown",
+	"OS release file is missing ID",
+}, {
+	`NAME="CentOS Linux"
+ID="centos"
+`,
+	"unknown",
+	"OS release file is missing VERSION_ID",
+}, {
+	`NAME="SuSE Linux"
+ID="SuSE"
+VERSION_ID="12"
+`,
+	"unknown",
+	"",
+},
+}
+
+func (s *readSeriesSuite) TestReadSeries(c *gc.C) {
+	d := c.MkDir()
+	f := filepath.Join(d, "foo")
+	s.PatchValue(version.OSReleaseFile, f)
+	for i, t := range readSeriesTests {
+		c.Logf("test %d", i)
+		err := ioutil.WriteFile(f, []byte(t.contents), 0666)
+		c.Assert(err, jc.ErrorIsNil)
+		series, err := version.ReadSeries()
+		if t.err == "" {
+			c.Assert(err, jc.ErrorIsNil)
+		} else {
+			c.Assert(err, gc.ErrorMatches, t.err)
+		}
+
+		c.Assert(series, gc.Equals, t.series)
+	}
+}

--- a/version/osversion_nonlinux.go
+++ b/version/osversion_nonlinux.go
@@ -9,7 +9,6 @@ package version
 
 // ReleaseVersion is a function that has no meaning except on linux.
 func ReleaseVersion() string {
-	// TODO(ericsnow) Panic?
 	return ""
 }
 

--- a/version/osversion_nonlinux.go
+++ b/version/osversion_nonlinux.go
@@ -12,5 +12,5 @@ func ReleaseVersion() string {
 	return ""
 }
 
-func updateSeriesVersions() {
+func updateLocalSeriesVersions() {
 }

--- a/version/osversion_nonlinux.go
+++ b/version/osversion_nonlinux.go
@@ -1,0 +1,14 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// +build !linux
+
+package version
+
+// TODO(ericsnow) Refactor dependents so we can remove this for non-linux.
+
+// ReleaseVersion is a function that has no meaning except on linux.
+func ReleaseVersion() string {
+	// TODO(ericsnow) Panic?
+	return ""
+}

--- a/version/osversion_nonlinux.go
+++ b/version/osversion_nonlinux.go
@@ -12,3 +12,6 @@ func ReleaseVersion() string {
 	// TODO(ericsnow) Panic?
 	return ""
 }
+
+func updateSeriesVersions() {
+}

--- a/version/osversion_test.go
+++ b/version/osversion_test.go
@@ -5,8 +5,6 @@ package version_test
 
 import (
 	"fmt"
-	"io/ioutil"
-	"path/filepath"
 
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -15,114 +13,11 @@ import (
 	"github.com/juju/juju/version"
 )
 
-type readSeriesSuite struct {
-	testing.BaseSuite
-}
-
-var _ = gc.Suite(&readSeriesSuite{})
-
 type kernelVersionSuite struct {
 	testing.BaseSuite
 }
 
 var _ = gc.Suite(&kernelVersionSuite{})
-
-var readSeriesTests = []struct {
-	contents string
-	series   string
-	err      string
-}{{
-	`NAME="Ubuntu"
-VERSION="12.04.5 LTS, Precise Pangolin"
-ID=ubuntu
-ID_LIKE=debian
-PRETTY_NAME="Ubuntu precise (12.04.5 LTS)"
-VERSION_ID="12.04"
-`,
-	"precise",
-	"",
-}, {
-	`NAME="Ubuntu"
-ID=ubuntu
-VERSION_ID= "12.04" `,
-	"precise",
-	"",
-}, {
-	`NAME='Ubuntu'
-ID='ubuntu'
-VERSION_ID='12.04'
-`,
-	"precise",
-	"",
-}, {
-	`NAME="CentOS Linux"
-ID="centos"
-VERSION_ID="7"
-`,
-	"centos7",
-	"",
-}, {
-	`NAME="Arch Linux"
-ID=arch
-PRETTY_NAME="Arch Linux"
-ANSI_COLOR="0;36"
-HOME_URL="https://www.archlinux.org/"
-SUPPORT_URL="https://bbs.archlinux.org/"
-BUG_REPORT_URL="https://bugs.archlinux.org/"
-`,
-	"arch",
-	"",
-}, {
-	`NAME="Ubuntu"
-VERSION="14.04.1 LTS, Trusty Tahr"
-ID=ubuntu
-ID_LIKE=debian
-PRETTY_NAME="Ubuntu 14.04.1 LTS"
-VERSION_ID="14.04"
-HOME_URL="http://www.ubuntu.com/"
-SUPPORT_URL="http://help.ubuntu.com/"
-BUG_REPORT_URL="http://bugs.launchpad.net/ubuntu/"
-`,
-	"trusty",
-	"",
-}, {
-	"",
-	"unknown",
-	"OS release file is missing ID",
-}, {
-	`NAME="CentOS Linux"
-ID="centos"
-`,
-	"unknown",
-	"OS release file is missing VERSION_ID",
-}, {
-	`NAME="SuSE Linux"
-ID="SuSE"
-VERSION_ID="12"
-`,
-	"unknown",
-	"",
-},
-}
-
-func (s *readSeriesSuite) TestReadSeries(c *gc.C) {
-	d := c.MkDir()
-	f := filepath.Join(d, "foo")
-	s.PatchValue(version.OSReleaseFile, f)
-	for i, t := range readSeriesTests {
-		c.Logf("test %d", i)
-		err := ioutil.WriteFile(f, []byte(t.contents), 0666)
-		c.Assert(err, jc.ErrorIsNil)
-		series, err := version.ReadSeries()
-		if t.err == "" {
-			c.Assert(err, jc.ErrorIsNil)
-		} else {
-			c.Assert(err, gc.ErrorMatches, t.err)
-		}
-
-		c.Assert(series, gc.Equals, t.series)
-	}
-}
 
 func sysctlMacOS10dot9dot2() (string, error) {
 	// My 10.9.2 Mac gives "13.1.0" as the kernel version

--- a/version/supportedseries.go
+++ b/version/supportedseries.go
@@ -189,3 +189,12 @@ func OSSupportedSeries(os jujuos.OSType) []string {
 	}
 	return osSeries
 }
+
+var updatedseriesVersions bool
+
+func updateSeriesVersions() {
+	if !updatedseriesVersions {
+		updateLocalSeriesVersions()
+		updatedseriesVersions = true
+	}
+}

--- a/version/supportedseries.go
+++ b/version/supportedseries.go
@@ -4,11 +4,6 @@
 package version
 
 import (
-	"bufio"
-	"fmt"
-	"io"
-	"os"
-	"strings"
 	"sync"
 
 	"github.com/juju/errors"
@@ -119,8 +114,6 @@ var windowsVersions = map[string]string{
 	"Windows 10":                     "win10",
 }
 
-var distroInfo = "/usr/share/distro-info/ubuntu.csv"
-
 // GetOSFromSeries will return the operating system based
 // on the series that is passed to it
 func GetOSFromSeries(series string) (jujuos.OSType, error) {
@@ -150,8 +143,7 @@ func GetOSFromSeries(series string) (jujuos.OSType, error) {
 }
 
 var (
-	seriesVersionsMutex   sync.Mutex
-	updatedseriesVersions bool
+	seriesVersionsMutex sync.Mutex
 )
 
 // SeriesVersion returns the version for the specified series.
@@ -196,57 +188,4 @@ func OSSupportedSeries(os jujuos.OSType) []string {
 		osSeries = append(osSeries, series)
 	}
 	return osSeries
-}
-
-func updateSeriesVersions() {
-	if !updatedseriesVersions {
-		err := updateDistroInfo()
-		if err != nil {
-			logger.Warningf("failed to update distro info: %v", err)
-		}
-		updatedseriesVersions = true
-	}
-}
-
-// updateDistroInfo updates seriesVersions from /usr/share/distro-info/ubuntu.csv if possible..
-func updateDistroInfo() error {
-	// We need to find the series version eg 12.04 from the series eg precise. Use the information found in
-	// /usr/share/distro-info/ubuntu.csv provided by distro-info-data package.
-	f, err := os.Open(distroInfo)
-	if err != nil {
-		// On non-Ubuntu systems this file won't exist but that's expected.
-		return nil
-	}
-	defer f.Close()
-	bufRdr := bufio.NewReader(f)
-	// Only find info for precise or later.
-	// TODO: only add in series that are supported (i.e. before end of life)
-	preciseOrLaterFound := false
-	for {
-		line, err := bufRdr.ReadString('\n')
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			return fmt.Errorf("reading distro info file file: %v", err)
-		}
-		// lines are of the form: "12.04 LTS,Precise Pangolin,precise,2011-10-13,2012-04-26,2017-04-26"
-		parts := strings.Split(line, ",")
-		// Ignore any malformed lines.
-		if len(parts) < 3 {
-			continue
-		}
-		series := parts[2]
-		if series == "precise" {
-			preciseOrLaterFound = true
-		}
-		if series != "precise" && !preciseOrLaterFound {
-			continue
-		}
-		// the numeric version may contain a LTS moniker so strip that out.
-		seriesInfo := strings.Split(parts[0], " ")
-		seriesVersions[series] = seriesInfo[0]
-		ubuntuSeries[series] = seriesInfo[0]
-	}
-	return nil
 }

--- a/version/version.go
+++ b/version/version.go
@@ -344,17 +344,6 @@ func (v Number) IsDev() bool {
 	return v.Tag != "" || v.Build > 0
 }
 
-// ReleaseVersion looks for the value of VERSION_ID in the content of
-// the os-release.  If the value is not found, the file is not found, or
-// an error occurs reading the file, an empty string is returned.
-func ReleaseVersion() string {
-	release, err := jujuos.ReadOSRelease(osReleaseFile)
-	if err != nil {
-		return ""
-	}
-	return release["VERSION_ID"]
-}
-
 // ParseMajorMinor takes an argument of the form "major.minor" and returns ints major and minor.
 func ParseMajorMinor(vers string) (int, int, error) {
 	parts := strings.Split(vers, ".")

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -5,8 +5,6 @@ package version_test
 
 import (
 	"encoding/json"
-	"io/ioutil"
-	"path/filepath"
 	"runtime"
 	"strings"
 
@@ -323,72 +321,6 @@ func (*suite) TestParseMajorMinor(c *gc.C) {
 			c.Check(major, gc.Equals, test.expectMajor)
 			c.Check(minor, gc.Equals, test.expectMinor)
 		}
-	}
-}
-
-func (s *suite) TestUseFastLXC(c *gc.C) {
-	for i, test := range []struct {
-		message        string
-		releaseContent string
-		expected       string
-	}{{
-		message: "missing release file",
-	}, {
-		message:        "OS release file is missing ID",
-		releaseContent: "some junk\nand more junk",
-	}, {
-		message: "precise release",
-		releaseContent: `
-NAME="Ubuntu"
-VERSION="12.04 LTS, Precise"
-ID=ubuntu
-ID_LIKE=debian
-PRETTY_NAME="Ubuntu 12.04.3 LTS"
-VERSION_ID="12.04"
-`,
-		expected: "12.04",
-	}, {
-		message: "trusty release",
-		releaseContent: `
-NAME="Ubuntu"
-VERSION="14.04.1 LTS, Trusty Tahr"
-ID=ubuntu
-ID_LIKE=debian
-PRETTY_NAME="Ubuntu 14.04.1 LTS"
-VERSION_ID="14.04"
-`,
-		expected: "14.04",
-	}, {
-		message: "minimal trusty release",
-		releaseContent: `
-ID=ubuntu
-VERSION_ID="14.04"
-`,
-		expected: "14.04",
-	}, {
-		message: "minimal unstable unicorn",
-		releaseContent: `
-ID=ubuntu
-VERSION_ID="14.10"
-`,
-		expected: "14.10",
-	}, {
-		message: "minimal jaunty",
-		releaseContent: `
-ID=ubuntu
-VERSION_ID="9.10"
-`,
-		expected: "9.10",
-	}} {
-		c.Logf("%v: %v", i, test.message)
-		filename := filepath.Join(c.MkDir(), "os-release")
-		s.PatchValue(version.OSReleaseFile, filename)
-		if test.releaseContent != "" {
-			err := ioutil.WriteFile(filename, []byte(test.releaseContent+"\n"), 0644)
-			c.Assert(err, jc.ErrorIsNil)
-		}
-		value := version.ReleaseVersion()
-		c.Assert(value, gc.Equals, test.expected)
 	}
 }
 


### PR DESCRIPTION
(https://bugs.launchpad.net/juju-core/+bug/1491923)

The merge at af1504b78c1c4c0cf83851e0c71eb287719dbb5c broke Juju compilation under Windows (and anything else non-linux).  This patch moves the linux-localhost-specific bits in the version package to compile only under linux.  Pretty much this amounts to moving code around.

(Review request: http://reviews.vapour.ws/r/2587/)