### PR TITLE
version: remove version.Binary.OS

### DIFF
--- a/cmd/juju/commands/upgradejuju.go
+++ b/cmd/juju/commands/upgradejuju.go
@@ -318,7 +318,7 @@ func (context *upgradeContext) uploadTools() (err error) {
 
 	builtTools, err := sync.BuildToolsTarball(&context.chosen, "upgrade")
 	if err != nil {
-		return err
+		return errors.Trace(err)
 	}
 	defer os.RemoveAll(builtTools.Dir)
 
@@ -327,13 +327,17 @@ func (context *upgradeContext) uploadTools() (err error) {
 	logger.Infof("uploading tools %v (%dkB) to Juju state server", builtTools.Version, (builtTools.Size+512)/1024)
 	f, err := os.Open(toolsPath)
 	if err != nil {
-		return err
+		return errors.Trace(err)
 	}
 	defer f.Close()
-	additionalSeries := series.OSSupportedSeries(builtTools.Version.OS)
+	os, err := series.GetOSFromSeries(builtTools.Version.Series)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	additionalSeries := series.OSSupportedSeries(os)
 	uploaded, err = context.apiClient.UploadTools(f, builtTools.Version, additionalSeries...)
 	if err != nil {
-		return err
+		return errors.Trace(err)
 	}
 	context.tools = coretools.List{uploaded}
 	return nil

--- a/environs/bootstrap/tools.go
+++ b/environs/bootstrap/tools.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/utils/arch"
+	jujuos "github.com/juju/utils/os"
 	"github.com/juju/utils/series"
 	"github.com/juju/utils/set"
 
@@ -117,14 +118,13 @@ func findAvailableTools(env environs.Environ, vers *version.Number, arch *string
 // can be built locally, for series of the same OS.
 func locallyBuildableTools() (buildable coretools.List) {
 	for _, ser := range series.SupportedSeries() {
-		if os, err := series.GetOSFromSeries(ser); err != nil || os != version.Current.OS {
+		if os, err := series.GetOSFromSeries(ser); err != nil || os != jujuos.HostOS() {
 			continue
 		}
 		binary := version.Binary{
 			Number: version.Current.Number,
 			Series: ser,
 			Arch:   arch.HostArch(),
-			OS:     version.Current.OS,
 		}
 		// Increment the build number so we know it's a development build.
 		binary.Build++

--- a/environs/bootstrap/tools_test.go
+++ b/environs/bootstrap/tools_test.go
@@ -263,7 +263,6 @@ func (s *toolsSuite) TestFindAvailableToolsCompleteNoValidate(c *gc.C) {
 			Number: version.Current.Number,
 			Series: series,
 			Arch:   arch.HostArch(),
-			OS:     version.Current.OS,
 		}
 		allTools = append(allTools, &tools.Tools{
 			Version: binary,

--- a/environs/manual/provisioner_test.go
+++ b/environs/manual/provisioner_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/juju/juju/juju/testing"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/version"
-	jujuos "github.com/juju/utils/os"
 )
 
 type provisionerSuite struct {
@@ -47,7 +46,6 @@ func (s *provisionerSuite) getArgs(c *gc.C) manual.ProvisionMachineArgs {
 func (s *provisionerSuite) TestProvisionMachine(c *gc.C) {
 	const series = coretesting.FakeDefaultSeries
 	const arch = "amd64"
-	const operatingSystem = jujuos.Ubuntu
 
 	args := s.getArgs(c)
 	hostname := args.Host
@@ -70,7 +68,11 @@ func (s *provisionerSuite) TestProvisionMachine(c *gc.C) {
 	cfg := s.Environ.Config()
 	number, ok := cfg.AgentVersion()
 	c.Assert(ok, jc.IsTrue)
-	binVersion := version.Binary{number, series, arch, operatingSystem}
+	binVersion := version.Binary{
+		Number: number,
+		Series: series,
+		Arch:   arch,
+	}
 	envtesting.AssertUploadFakeToolsVersions(c, s.DefaultToolsStorage, "released", "released", binVersion)
 	envtools.DefaultBaseURL = defaultToolsURL
 

--- a/environs/tools/simplestreams.go
+++ b/environs/tools/simplestreams.go
@@ -190,21 +190,16 @@ func (t *ToolsMetadata) sortString() string {
 }
 
 // binary returns the tools metadata's binary version, which may be used for
-// map lookup. It is possible for a binary to have an unkown OS.
+// map lookup.
 func (t *ToolsMetadata) binary() (version.Binary, error) {
 	num, err := version.Parse(t.Version)
 	if err != nil {
-		return version.Binary{}, errors.Trace(err)
-	}
-	toolsOS, err := series.GetOSFromSeries(t.Release)
-	if err != nil && !series.IsUnknownOSForSeriesError(err) {
 		return version.Binary{}, errors.Trace(err)
 	}
 	return version.Binary{
 		Number: num,
 		Series: t.Release,
 		Arch:   t.Arch,
-		OS:     toolsOS,
 	}, nil
 }
 

--- a/provider/local/environprovider_test.go
+++ b/provider/local/environprovider_test.go
@@ -246,7 +246,7 @@ Acquire::magic::Proxy "";
 		c.Assert(envConfig.FtpProxy(), gc.Equals, test.expectedProxy.Ftp)
 		c.Assert(envConfig.NoProxy(), gc.Equals, test.expectedProxy.NoProxy)
 
-		if os.HostOS() == os.Ubuntu {
+		if jujuos.HostOS() == jujuos.Ubuntu {
 			c.Assert(envConfig.AptHttpProxy(), gc.Equals, test.expectedAptProxy.Http)
 			c.Assert(envConfig.AptHttpsProxy(), gc.Equals, test.expectedAptProxy.Https)
 			c.Assert(envConfig.AptFtpProxy(), gc.Equals, test.expectedAptProxy.Ftp)

--- a/provider/local/environprovider_test.go
+++ b/provider/local/environprovider_test.go
@@ -246,7 +246,7 @@ Acquire::magic::Proxy "";
 		c.Assert(envConfig.FtpProxy(), gc.Equals, test.expectedProxy.Ftp)
 		c.Assert(envConfig.NoProxy(), gc.Equals, test.expectedProxy.NoProxy)
 
-		if jujuos.HostOS() == jujuos.Ubuntu {
+		if os.HostOS() == os.Ubuntu {
 			c.Assert(envConfig.AptHttpProxy(), gc.Equals, test.expectedAptProxy.Http)
 			c.Assert(envConfig.AptHttpsProxy(), gc.Equals, test.expectedAptProxy.Https)
 			c.Assert(envConfig.AptFtpProxy(), gc.Equals, test.expectedAptProxy.Ftp)

--- a/service/discovery_test.go
+++ b/service/discovery_test.go
@@ -14,6 +14,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/exec"
 	"github.com/juju/utils/featureflag"
+	jujuos "github.com/juju/utils/os"
 	"github.com/juju/utils/series"
 	gc "gopkg.in/check.v1"
 
@@ -25,7 +26,6 @@ import (
 	"github.com/juju/juju/service/upstart"
 	"github.com/juju/juju/service/windows"
 	"github.com/juju/juju/version"
-	jujuos "github.com/juju/utils/os"
 )
 
 var maybeSystemd = service.InitSystemSystemd
@@ -46,7 +46,6 @@ type discoveryTest struct {
 
 func (dt discoveryTest) version() version.Binary {
 	return version.Binary{
-		OS:     dt.os,
 		Series: dt.series,
 	}
 }
@@ -186,7 +185,7 @@ func (s *discoverySuite) TestDiscoverServiceLocalHost(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 
 	test := discoveryTest{
-		os:       version.Current.OS,
+		os:       jujuos.HostOS(),
 		series:   series.HostSeries(),
 		expected: localInitSystem,
 	}

--- a/version/version.go
+++ b/version/version.go
@@ -17,7 +17,6 @@ import (
 	"strings"
 
 	"github.com/juju/utils/arch"
-	jujuos "github.com/juju/utils/os"
 	"github.com/juju/utils/series"
 	"gopkg.in/mgo.v2/bson"
 )
@@ -41,7 +40,6 @@ var Current = Binary{
 	Number: MustParse(version),
 	Series: series.HostSeries(),
 	Arch:   arch.HostArch(),
-	OS:     series.MustOSFromSeries(series.HostSeries()),
 }
 
 var Compiler = runtime.Compiler
@@ -84,7 +82,6 @@ type Binary struct {
 	Number
 	Series string
 	Arch   string
-	OS     jujuos.OSType
 }
 
 func (v Binary) String() string {
@@ -190,8 +187,7 @@ func ParseBinary(s string) (Binary, error) {
 	}
 	v.Series = m[7]
 	v.Arch = m[8]
-	var err error
-	v.OS, err = series.GetOSFromSeries(v.Series)
+	_, err := series.GetOSFromSeries(v.Series)
 	return v, err
 }
 

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/utils/os"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/mgo.v2/bson"
 	goyaml "gopkg.in/yaml.v1"
@@ -167,7 +166,6 @@ func binaryVersion(major, minor, patch, build int, tag, series, arch string) ver
 		},
 		Series: series,
 		Arch:   arch,
-		OS:     os.Ubuntu,
 	}
 }
 
@@ -221,7 +219,6 @@ func (*suite) TestParseBinary(c *gc.C) {
 			Number: test.expect,
 			Series: "trusty",
 			Arch:   "amd64",
-			OS:     os.Ubuntu,
 		}
 		if test.err != "" {
 			c.Assert(err, gc.ErrorMatches, strings.Replace(test.err, "version", "binary version", 1))


### PR DESCRIPTION
`version.Binary.OS` is only used in two contexts, the first as the value `version.Current.OS`. The second for tools sorting and bootstrapping.

In the first case `version.Current.OS` will be identical to `os.HostOS()`, so replace all the calls to the former with the latter.

In the second case, `version.Binary.OS` is _always_ deducible from `version.Binary.Series` using `version.GetOSFromSeries`, so do that, then we can drop the field altogether.

(Review request: http://reviews.vapour.ws/r/2588/)