### PR TITLE
Only run upsate-status hook after start hook

### DIFF
--- a/worker/uniter/resolver.go
+++ b/worker/uniter/resolver.go
@@ -213,7 +213,7 @@ func (s *uniterResolver) nextOp(
 	}
 
 	// UpdateStatus hook runs if nothing else needs to.
-	if localState.UpdateStatusVersion != remoteState.UpdateStatusVersion {
+	if localState.Started && localState.UpdateStatusVersion != remoteState.UpdateStatusVersion {
 		return opFactory.NewRunHook(hook.Info{Kind: hooks.UpdateStatus})
 	}
 


### PR DESCRIPTION
Only run the update-status hook after the uniter has finished the start hook

(Review request: http://reviews.vapour.ws/r/2590/)