### PR TITLE
apiserver/storage: refactor ListVolumes code

### DIFF
--- a/api/storage/client.go
+++ b/api/storage/client.go
@@ -89,13 +89,13 @@ func (c *Client) CreatePool(pname, provider string, attrs map[string]interface{}
 
 // ListVolumes lists volumes for desired machines.
 // If no machines provided, a list of all volumes is returned.
-func (c *Client) ListVolumes(machines []string) ([]params.VolumeItem, error) {
+func (c *Client) ListVolumes(machines []string) ([]params.VolumeDetailsResult, error) {
 	tags := make([]string, len(machines))
 	for i, one := range machines {
 		tags[i] = names.NewMachineTag(one).String()
 	}
 	args := params.VolumeFilter{Machines: tags}
-	found := params.VolumeItemsResult{}
+	found := params.VolumeDetailsResults{}
 	if err := c.facade.FacadeCall("ListVolumes", args, &found); err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/api/storage/client_test.go
+++ b/api/storage/client_test.go
@@ -317,15 +317,15 @@ func (s *storageMockSuite) TestListVolumes(c *gc.C) {
 			args := a.(params.VolumeFilter)
 			c.Assert(args.Machines, gc.HasLen, 2)
 
-			c.Assert(result, gc.FitsTypeOf, &params.VolumeItemsResult{})
-			results := result.(*params.VolumeItemsResult)
+			c.Assert(result, gc.FitsTypeOf, &params.VolumeDetailsResults{})
+			results := result.(*params.VolumeDetailsResults)
 			attachments := make([]params.VolumeAttachment, len(args.Machines))
 			for i, m := range args.Machines {
 				attachments[i] = params.VolumeAttachment{
 					MachineTag: m}
 			}
-			results.Results = []params.VolumeItem{
-				params.VolumeItem{Attachments: attachments},
+			results.Results = []params.VolumeDetailsResult{
+				params.VolumeDetailsResult{Attachments: attachments},
 			}
 			return nil
 		})
@@ -357,10 +357,10 @@ func (s *storageMockSuite) TestListVolumesEmptyFilter(c *gc.C) {
 			args := a.(params.VolumeFilter)
 			c.Assert(args.IsEmpty(), jc.IsTrue)
 
-			c.Assert(result, gc.FitsTypeOf, &params.VolumeItemsResult{})
-			results := result.(*params.VolumeItemsResult)
-			results.Results = []params.VolumeItem{
-				{Volume: params.VolumeInstance{VolumeTag: tag}},
+			c.Assert(result, gc.FitsTypeOf, &params.VolumeDetailsResults{})
+			results := result.(*params.VolumeDetailsResults)
+			results.Results = []params.VolumeDetailsResult{
+				{Volume: params.VolumeDetails{VolumeTag: tag}},
 			}
 			return nil
 		})

--- a/api/storage/client_test.go
+++ b/api/storage/client_test.go
@@ -325,7 +325,7 @@ func (s *storageMockSuite) TestListVolumes(c *gc.C) {
 					MachineTag: m}
 			}
 			results.Results = []params.VolumeDetailsResult{
-				params.VolumeDetailsResult{Attachments: attachments},
+				params.VolumeDetailsResult{LegacyAttachments: attachments},
 			}
 			return nil
 		})
@@ -334,9 +334,9 @@ func (s *storageMockSuite) TestListVolumes(c *gc.C) {
 	c.Assert(called, jc.IsTrue)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(found, gc.HasLen, 1)
-	c.Assert(found[0].Attachments, gc.HasLen, len(machines))
-	c.Assert(machineTags.Contains(found[0].Attachments[0].MachineTag), jc.IsTrue)
-	c.Assert(machineTags.Contains(found[0].Attachments[1].MachineTag), jc.IsTrue)
+	c.Assert(found[0].LegacyAttachments, gc.HasLen, len(machines))
+	c.Assert(machineTags.Contains(found[0].LegacyAttachments[0].MachineTag), jc.IsTrue)
+	c.Assert(machineTags.Contains(found[0].LegacyAttachments[1].MachineTag), jc.IsTrue)
 }
 
 func (s *storageMockSuite) TestListVolumesEmptyFilter(c *gc.C) {
@@ -360,7 +360,7 @@ func (s *storageMockSuite) TestListVolumesEmptyFilter(c *gc.C) {
 			c.Assert(result, gc.FitsTypeOf, &params.VolumeDetailsResults{})
 			results := result.(*params.VolumeDetailsResults)
 			results.Results = []params.VolumeDetailsResult{
-				{Volume: params.VolumeDetails{VolumeTag: tag}},
+				{LegacyVolume: &params.LegacyVolumeDetails{VolumeTag: tag}},
 			}
 			return nil
 		})
@@ -369,7 +369,7 @@ func (s *storageMockSuite) TestListVolumesEmptyFilter(c *gc.C) {
 	c.Assert(called, jc.IsTrue)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(found, gc.HasLen, 1)
-	c.Assert(found[0].Volume.VolumeTag, gc.Equals, tag)
+	c.Assert(found[0].LegacyVolume.VolumeTag, gc.Equals, tag)
 }
 
 func (s *storageMockSuite) TestListVolumesFacadeCallError(c *gc.C) {

--- a/apiserver/common/volumes.go
+++ b/apiserver/common/volumes.go
@@ -129,13 +129,18 @@ func VolumeFromState(v state.Volume) (params.Volume, error) {
 	}
 	return params.Volume{
 		v.VolumeTag().String(),
-		params.VolumeInfo{
-			info.VolumeId,
-			info.HardwareId,
-			info.Size,
-			info.Persistent,
-		},
+		VolumeInfoFromState(info),
 	}, nil
+}
+
+// VolumeInfoFromState converts a state.VolumeInfo to params.VolumeInfo.
+func VolumeInfoFromState(info state.VolumeInfo) params.VolumeInfo {
+	return params.VolumeInfo{
+		info.VolumeId,
+		info.HardwareId,
+		info.Size,
+		info.Persistent,
+	}
 }
 
 // VolumeAttachmentFromState converts a state.VolumeAttachment to params.VolumeAttachment.
@@ -147,12 +152,17 @@ func VolumeAttachmentFromState(v state.VolumeAttachment) (params.VolumeAttachmen
 	return params.VolumeAttachment{
 		v.Volume().String(),
 		v.Machine().String(),
-		params.VolumeAttachmentInfo{
-			info.DeviceName,
-			info.BusAddress,
-			info.ReadOnly,
-		},
+		VolumeAttachmentInfoFromState(info),
 	}, nil
+}
+
+// VolumeAttachmentInfoFromState converts a state.VolumeAttachmentInfo to params.VolumeAttachmentInfo.
+func VolumeAttachmentInfoFromState(info state.VolumeAttachmentInfo) params.VolumeAttachmentInfo {
+	return params.VolumeAttachmentInfo{
+		info.DeviceName,
+		info.BusAddress,
+		info.ReadOnly,
+	}
 }
 
 // VolumeAttachmentInfosToState converts a map of volume tags to

--- a/apiserver/params/storage.go
+++ b/apiserver/params/storage.go
@@ -479,21 +479,23 @@ func (f *VolumeFilter) IsEmpty() bool {
 
 // VolumeInstance describes a storage volume in the environment
 // for the purpose of volume CLI commands.
-// It is kept separate from Volume which is primarily used in uniter
-// and may answer different concerns as well as serve different purposes.
-type VolumeInstance struct {
+//
+// This is kept separate from Volume which contains only information
+// specific to the volume model, whereas VolumeDetails is intended
+// to contain complete information about a volume.
+type VolumeDetails struct {
 
 	// VolumeTag is tag for this volume instance.
 	VolumeTag string `json:"volumetag"`
 
 	// VolumeId is a unique provider-supplied ID for the volume.
-	VolumeId string `json:"volumeid"`
+	VolumeId string `json:"volumeid,omitempty"`
 
 	// HardwareId is the volume's hardware ID.
 	HardwareId string `json:"hardwareid,omitempty"`
 
 	// Size is the size of the volume in MiB.
-	Size uint64 `json:"size"`
+	Size uint64 `json:"size,omitempty"`
 
 	// Persistent reflects whether the volume is destroyed with the
 	// machine to which it is attached.
@@ -511,22 +513,22 @@ type VolumeInstance struct {
 	Status EntityStatus `json:"status"`
 }
 
-// VolumeItem contain volume, its attachments
-// and retrieval error.
-type VolumeItem struct {
-	// Volume is storage volume.
-	Volume VolumeInstance `json:"volume,omitempty"`
+// VolumeDetailsResult contains details about a volume, its attachments or
+// an error preventing retrieving those details.
+type VolumeDetailsResult struct {
+	// Volume describes the volume in detail.
+	Volume VolumeDetails `json:"volume"`
 
-	// Attachments are storage volume attachments.
+	// Attachments describes the attachments of the volume to machines.
 	Attachments []VolumeAttachment `json:"attachments,omitempty"`
 
 	// Error contains volume retrieval error.
 	Error *Error `json:"error,omitempty"`
 }
 
-// VolumeItemsResult holds volumes.
-type VolumeItemsResult struct {
-	Results []VolumeItem `json:"results,omitempty"`
+// VolumeDetailsResults holds volume details.
+type VolumeDetailsResults struct {
+	Results []VolumeDetailsResult `json:"results,omitempty"`
 }
 
 // StorageConstraints contains constraints for storage instance.

--- a/apiserver/storage/export_test.go
+++ b/apiserver/storage/export_test.go
@@ -4,18 +4,9 @@
 package storage
 
 var (
-	IsValidPoolListFilter      = (*API).isValidPoolListFilter
-	ValidateNames              = (*API).isValidNameCriteria
-	ValidateProviders          = (*API).isValidProviderCriteria
-	CreateVolumeDetailsResult  = (*API).createVolumeDetailsResult
-	GetVolumeDetailsResults    = (*API).getVolumeDetailsResults
-	FilterVolumes              = (*API).filterVolumes
-	VolumeAttachments          = (*API).volumeAttachments
-	ListVolumeAttachments      = (*API).listVolumeAttachments
-	ConvertStateVolumeToParams = (*API).convertStateVolumeToParams
+	IsValidPoolListFilter = (*API).isValidPoolListFilter
+	ValidateNames         = (*API).isValidNameCriteria
+	ValidateProviders     = (*API).isValidProviderCriteria
 
-	CreateAPI                             = createAPI
-	GroupAttachmentsByVolume              = groupAttachmentsByVolume
-	ConvertStateVolumeAttachmentToParams  = convertStateVolumeAttachmentToParams
-	ConvertStateVolumeAttachmentsToParams = convertStateVolumeAttachmentsToParams
+	CreateAPI = createAPI
 )

--- a/apiserver/storage/export_test.go
+++ b/apiserver/storage/export_test.go
@@ -7,8 +7,8 @@ var (
 	IsValidPoolListFilter      = (*API).isValidPoolListFilter
 	ValidateNames              = (*API).isValidNameCriteria
 	ValidateProviders          = (*API).isValidProviderCriteria
-	CreateVolumeItem           = (*API).createVolumeItem
-	GetVolumeItems             = (*API).getVolumeItems
+	CreateVolumeDetailsResult  = (*API).createVolumeDetailsResult
+	GetVolumeDetailsResults    = (*API).getVolumeDetailsResults
 	FilterVolumes              = (*API).filterVolumes
 	VolumeAttachments          = (*API).volumeAttachments
 	ListVolumeAttachments      = (*API).listVolumeAttachments

--- a/apiserver/storage/package_test.go
+++ b/apiserver/storage/package_test.go
@@ -40,8 +40,8 @@ type baseStorageSuite struct {
 	machineTag      names.MachineTag
 
 	volumeTag        names.VolumeTag
-	volume           state.Volume
-	volumeAttachment state.VolumeAttachment
+	volume           *mockVolume
+	volumeAttachment *mockVolumeAttachment
 	calls            []string
 
 	poolManager *mockPoolManager
@@ -360,6 +360,7 @@ type mockVolume struct {
 	tag          names.VolumeTag
 	storage      names.StorageTag
 	hasNoStorage bool
+	info         *state.VolumeInfo
 }
 
 func (m *mockVolume) StorageInstance() (names.StorageTag, error) {
@@ -381,6 +382,9 @@ func (m *mockVolume) Params() (state.VolumeParams, bool) {
 }
 
 func (m *mockVolume) Info() (state.VolumeInfo, error) {
+	if m.info != nil {
+		return *m.info, nil
+	}
 	return state.VolumeInfo{}, errors.NotProvisionedf("%v", m.tag)
 }
 
@@ -453,6 +457,7 @@ func (m *mockStorageAttachment) Unit() names.UnitTag {
 type mockVolumeAttachment struct {
 	VolumeTag  names.VolumeTag
 	MachineTag names.MachineTag
+	info       *state.VolumeAttachmentInfo
 }
 
 func (va *mockVolumeAttachment) Volume() names.VolumeTag {
@@ -468,7 +473,10 @@ func (va *mockVolumeAttachment) Life() state.Life {
 }
 
 func (va *mockVolumeAttachment) Info() (state.VolumeAttachmentInfo, error) {
-	return state.VolumeAttachmentInfo{}, errors.New("not interested yet")
+	if va.info != nil {
+		return *va.info, nil
+	}
+	return state.VolumeAttachmentInfo{}, errors.NotProvisionedf("volume attachment")
 }
 
 func (va *mockVolumeAttachment) Params() (state.VolumeAttachmentParams, bool) {

--- a/apiserver/storage/storage.go
+++ b/apiserver/storage/storage.go
@@ -390,183 +390,161 @@ func (a *API) CreatePool(p params.StoragePool) error {
 }
 
 func (a *API) ListVolumes(filter params.VolumeFilter) (params.VolumeDetailsResults, error) {
-	if !filter.IsEmpty() {
-		return params.VolumeDetailsResults{Results: a.filterVolumes(filter)}, nil
-	}
-	volumes, err := a.listVolumeAttachments()
+	volumes, volumeAttachments, err := filterVolumes(a.storage, filter)
 	if err != nil {
 		return params.VolumeDetailsResults{}, common.ServerError(err)
 	}
-	return params.VolumeDetailsResults{Results: volumes}, nil
+	results := createVolumeDetailsResults(a.storage, volumes, volumeAttachments)
+	return params.VolumeDetailsResults{Results: results}, nil
 }
 
-func (a *API) listVolumeAttachments() ([]params.VolumeDetailsResult, error) {
-	all, err := a.storage.AllVolumes()
+func filterVolumes(
+	st storageAccess,
+	f params.VolumeFilter,
+) ([]state.Volume, map[names.VolumeTag][]state.VolumeAttachment, error) {
+	if f.IsEmpty() {
+		// No filter was specified: get all volumes, and all attachments.
+		volumes, err := st.AllVolumes()
+		if err != nil {
+			return nil, nil, errors.Trace(err)
+		}
+		volumeAttachments := make(map[names.VolumeTag][]state.VolumeAttachment)
+		for _, v := range volumes {
+			attachments, err := st.VolumeAttachments(v.VolumeTag())
+			if err != nil {
+				return nil, nil, errors.Trace(err)
+			}
+			volumeAttachments[v.VolumeTag()] = attachments
+		}
+		return volumes, volumeAttachments, nil
+	}
+	volumesByTag := make(map[names.VolumeTag]state.Volume)
+	volumeAttachments := make(map[names.VolumeTag][]state.VolumeAttachment)
+	for _, machine := range f.Machines {
+		machineTag, err := names.ParseMachineTag(machine)
+		if err != nil {
+			return nil, nil, errors.Trace(err)
+		}
+		attachments, err := st.MachineVolumeAttachments(machineTag)
+		if err != nil {
+			return nil, nil, errors.Trace(err)
+		}
+		for _, attachment := range attachments {
+			volumeTag := attachment.Volume()
+			volumesByTag[volumeTag] = nil
+			volumeAttachments[volumeTag] = append(volumeAttachments[volumeTag], attachment)
+		}
+	}
+	for volumeTag := range volumesByTag {
+		volume, err := st.Volume(volumeTag)
+		if err != nil {
+			return nil, nil, errors.Trace(err)
+		}
+		volumesByTag[volumeTag] = volume
+	}
+	volumes := make([]state.Volume, 0, len(volumesByTag))
+	for _, volume := range volumesByTag {
+		volumes = append(volumes, volume)
+	}
+	return volumes, volumeAttachments, nil
+}
+
+func createVolumeDetailsResults(
+	st storageAccess,
+	volumes []state.Volume,
+	attachments map[names.VolumeTag][]state.VolumeAttachment,
+) []params.VolumeDetailsResult {
+
+	if len(volumes) == 0 {
+		return nil
+	}
+
+	results := make([]params.VolumeDetailsResult, len(volumes))
+	for i, v := range volumes {
+		details, err := createVolumeDetails(st, v, attachments[v.VolumeTag()])
+		if err != nil {
+			results[i].Error = common.ServerError(err)
+			continue
+		}
+		result := params.VolumeDetailsResult{
+			Details: details,
+		}
+
+		// We need to populate the legacy fields for old clients.
+		if len(details.MachineAttachments) > 0 {
+			result.LegacyAttachments = make([]params.VolumeAttachment, 0, len(details.MachineAttachments))
+			for machineTag, attachmentInfo := range details.MachineAttachments {
+				result.LegacyAttachments = append(result.LegacyAttachments, params.VolumeAttachment{
+					VolumeTag:  details.VolumeTag,
+					MachineTag: machineTag,
+					Info:       attachmentInfo,
+				})
+			}
+		}
+		result.LegacyVolume = &params.LegacyVolumeDetails{
+			VolumeTag:  details.VolumeTag,
+			StorageTag: details.StorageTag,
+			VolumeId:   details.Info.VolumeId,
+			HardwareId: details.Info.HardwareId,
+			Size:       details.Info.Size,
+			Persistent: details.Info.Persistent,
+			Status:     details.Status,
+		}
+		if details.StorageOwnerTag != "" {
+			kind, err := names.TagKind(details.StorageOwnerTag)
+			if err != nil {
+				results[i].Error = common.ServerError(err)
+				continue
+			}
+			if kind == names.UnitTagKind {
+				result.LegacyVolume.UnitTag = details.StorageOwnerTag
+			}
+		}
+		results[i] = result
+	}
+	return results
+}
+
+func createVolumeDetails(
+	st storageAccess, v state.Volume, attachments []state.VolumeAttachment,
+) (*params.VolumeDetails, error) {
+
+	details := &params.VolumeDetails{
+		VolumeTag: v.VolumeTag().String(),
+	}
+
+	if info, err := v.Info(); err == nil {
+		details.Info = common.VolumeInfoFromState(info)
+	}
+
+	if len(attachments) > 0 {
+		details.MachineAttachments = make(map[string]params.VolumeAttachmentInfo, len(attachments))
+		for _, attachment := range attachments {
+			stateInfo, err := attachment.Info()
+			var info params.VolumeAttachmentInfo
+			if err == nil {
+				info = common.VolumeAttachmentInfoFromState(stateInfo)
+			}
+			details.MachineAttachments[attachment.Machine().String()] = info
+		}
+	}
+
+	status, err := v.Status()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return a.volumeAttachments(all), nil
-}
+	details.Status = common.EntityStatusFromState(status)
 
-func (a *API) volumeAttachments(all []state.Volume) []params.VolumeDetailsResult {
-	if all == nil || len(all) == 0 {
-		return nil
-	}
-
-	result := make([]params.VolumeDetailsResult, len(all))
-	for i, v := range all {
-		volume, err := a.convertStateVolumeToParams(v)
+	if storageTag, err := v.StorageInstance(); err == nil {
+		details.StorageTag = storageTag.String()
+		storageInstance, err := st.StorageInstance(storageTag)
 		if err != nil {
-			result[i] = params.VolumeDetailsResult{
-				Error: common.ServerError(errors.Trace(err)),
-			}
-			continue
+			return nil, errors.Trace(err)
 		}
-		result[i] = params.VolumeDetailsResult{Volume: volume}
-		atts, err := a.storage.VolumeAttachments(v.VolumeTag())
-		if err != nil {
-			result[i].Error = common.ServerError(errors.Annotatef(
-				err, "attachments for volume %v", v.VolumeTag()))
-			continue
-		}
-		result[i].Attachments = convertStateVolumeAttachmentsToParams(atts)
-	}
-	return result
-}
-
-func (a *API) filterVolumes(f params.VolumeFilter) []params.VolumeDetailsResult {
-	var attachments []state.VolumeAttachment
-	var errs []params.VolumeDetailsResult
-
-	addErr := func(err error) {
-		errs = append(errs,
-			params.VolumeDetailsResult{Error: common.ServerError(err)})
+		details.StorageOwnerTag = storageInstance.Owner().String()
 	}
 
-	for _, machine := range f.Machines {
-		tag, err := names.ParseMachineTag(machine)
-		if err != nil {
-			addErr(errors.Annotatef(err, "parsing machine tag %v", machine))
-		}
-		machineAttachments, err := a.storage.MachineVolumeAttachments(tag)
-		if err != nil {
-			addErr(errors.Annotatef(err,
-				"getting volume attachments for machine %v",
-				machine))
-		}
-		attachments = append(attachments, machineAttachments...)
-	}
-	return append(errs, a.getVolumeDetailsResults(attachments)...)
-}
-
-func (a *API) convertStateVolumeToParams(st state.Volume) (params.VolumeDetails, error) {
-	volume := params.VolumeDetails{VolumeTag: st.VolumeTag().String()}
-
-	if storage, err := st.StorageInstance(); err == nil {
-		volume.StorageTag = storage.String()
-		storageInstance, err := a.storage.StorageInstance(storage)
-		if err != nil {
-			err = errors.Annotatef(err,
-				"getting storage instance %v for volume %v",
-				storage, volume.VolumeTag)
-			return params.VolumeDetails{}, err
-		}
-		owner := storageInstance.Owner()
-		// only interested in Unit for now
-		if unitTag, ok := owner.(names.UnitTag); ok {
-			volume.UnitTag = unitTag.String()
-		}
-	}
-	if info, err := st.Info(); err == nil {
-		volume.HardwareId = info.HardwareId
-		volume.Size = info.Size
-		volume.Persistent = info.Persistent
-		volume.VolumeId = info.VolumeId
-	}
-	status, err := st.Status()
-	if err != nil {
-		return params.VolumeDetails{}, errors.Trace(err)
-	}
-	volume.Status = common.EntityStatusFromState(status)
-	return volume, nil
-}
-
-func convertStateVolumeAttachmentsToParams(all []state.VolumeAttachment) []params.VolumeAttachment {
-	if len(all) == 0 {
-		return nil
-	}
-	result := make([]params.VolumeAttachment, len(all))
-	for i, one := range all {
-		result[i] = convertStateVolumeAttachmentToParams(one)
-	}
-	return result
-}
-
-func convertStateVolumeAttachmentToParams(attachment state.VolumeAttachment) params.VolumeAttachment {
-	result := params.VolumeAttachment{
-		VolumeTag:  attachment.Volume().String(),
-		MachineTag: attachment.Machine().String()}
-	if info, err := attachment.Info(); err == nil {
-		result.Info = params.VolumeAttachmentInfo{
-			info.DeviceName,
-			info.BusAddress,
-			info.ReadOnly,
-		}
-	}
-	return result
-}
-
-func (a *API) getVolumeDetailsResults(all []state.VolumeAttachment) []params.VolumeDetailsResult {
-	group := groupAttachmentsByVolume(all)
-
-	if len(group) == 0 {
-		return nil
-	}
-
-	result := make([]params.VolumeDetailsResult, len(group))
-	i := 0
-	for volumeTag, attachments := range group {
-		result[i] = a.createVolumeDetailsResult(volumeTag, attachments)
-		i++
-	}
-	return result
-}
-
-func (a *API) createVolumeDetailsResult(volumeTag string, attachments []params.VolumeAttachment) params.VolumeDetailsResult {
-	result := params.VolumeDetailsResult{Attachments: attachments}
-
-	tag, err := names.ParseVolumeTag(volumeTag)
-	if err != nil {
-		result.Error = common.ServerError(errors.Annotatef(err, "parsing volume tag %v", volumeTag))
-		return result
-	}
-	st, err := a.storage.Volume(tag)
-	if err != nil {
-		result.Error = common.ServerError(errors.Annotatef(err, "getting volume for tag %v", tag))
-		return result
-	}
-	volume, err := a.convertStateVolumeToParams(st)
-	if err != nil {
-		result.Error = common.ServerError(errors.Trace(err))
-		return result
-	}
-	result.Volume = volume
-	return result
-}
-
-// groupAttachmentsByVolume constructs map of attachments grouped by volumeTag
-func groupAttachmentsByVolume(all []state.VolumeAttachment) map[string][]params.VolumeAttachment {
-	if len(all) == 0 {
-		return nil
-	}
-	group := make(map[string][]params.VolumeAttachment)
-	for _, one := range all {
-		attachment := convertStateVolumeAttachmentToParams(one)
-		group[attachment.VolumeTag] = append(
-			group[attachment.VolumeTag],
-			attachment)
-	}
-	return group
+	return details, nil
 }
 
 // AddToUnit validates and creates additional storage instances for units.

--- a/apiserver/storage/volumelist_test.go
+++ b/apiserver/storage/volumelist_test.go
@@ -48,22 +48,22 @@ func (s *volumeSuite) TestGroupAttachmentsByVolume(c *gc.C) {
 		expected)
 }
 
-func (s *volumeSuite) TestCreateVolumeItemInvalidTag(c *gc.C) {
-	found := storage.CreateVolumeItem(s.api, "666", nil)
+func (s *volumeSuite) TestCreateVolumeDetailsResultInvalidTag(c *gc.C) {
+	found := storage.CreateVolumeDetailsResult(s.api, "666", nil)
 	c.Assert(found.Error, gc.ErrorMatches, ".*not a valid tag.*")
 }
 
-func (s *volumeSuite) TestCreateVolumeItemNonexistingVolume(c *gc.C) {
+func (s *volumeSuite) TestCreateVolumeDetailsResultNonexistingVolume(c *gc.C) {
 	s.state.volume = func(tag names.VolumeTag) (state.Volume, error) {
 		return s.volume, errors.Errorf("not volume for tag %v", tag)
 	}
-	found := storage.CreateVolumeItem(s.api, names.NewVolumeTag("666").String(), nil)
+	found := storage.CreateVolumeDetailsResult(s.api, names.NewVolumeTag("666").String(), nil)
 	c.Assert(found.Error, gc.ErrorMatches, ".*volume for tag.*")
 }
 
-func (s *volumeSuite) TestCreateVolumeItemNoUnit(c *gc.C) {
+func (s *volumeSuite) TestCreateVolumeDetailsResultNoUnit(c *gc.C) {
 	s.storageInstance.owner = names.NewServiceTag("test-service")
-	found := storage.CreateVolumeItem(s.api, s.volumeTag.String(), nil)
+	found := storage.CreateVolumeDetailsResult(s.api, s.volumeTag.String(), nil)
 	c.Assert(found.Error, gc.IsNil)
 	c.Assert(found.Error, gc.IsNil)
 	expected, err := storage.ConvertStateVolumeToParams(s.api, s.volume)
@@ -71,9 +71,9 @@ func (s *volumeSuite) TestCreateVolumeItemNoUnit(c *gc.C) {
 	c.Assert(found.Volume, gc.DeepEquals, expected)
 }
 
-func (s *volumeSuite) TestCreateVolumeItemNoStorageInstance(c *gc.C) {
+func (s *volumeSuite) TestCreateVolumeDetailsResultNoStorageInstance(c *gc.C) {
 	s.volume = &mockVolume{tag: s.volumeTag, hasNoStorage: true}
-	found := storage.CreateVolumeItem(s.api, s.volumeTag.String(), nil)
+	found := storage.CreateVolumeDetailsResult(s.api, s.volumeTag.String(), nil)
 	c.Assert(found.Error, gc.IsNil)
 	c.Assert(found.Error, gc.IsNil)
 	expected, err := storage.ConvertStateVolumeToParams(s.api, s.volume)
@@ -81,8 +81,8 @@ func (s *volumeSuite) TestCreateVolumeItemNoStorageInstance(c *gc.C) {
 	c.Assert(found.Volume, gc.DeepEquals, expected)
 }
 
-func (s *volumeSuite) TestCreateVolumeItem(c *gc.C) {
-	found := storage.CreateVolumeItem(s.api, s.volumeTag.String(), nil)
+func (s *volumeSuite) TestCreateVolumeDetailsResult(c *gc.C) {
+	found := storage.CreateVolumeDetailsResult(s.api, s.volumeTag.String(), nil)
 	c.Assert(found.Error, gc.IsNil)
 	c.Assert(found.Error, gc.IsNil)
 	expected, err := storage.ConvertStateVolumeToParams(s.api, s.volume)
@@ -90,12 +90,12 @@ func (s *volumeSuite) TestCreateVolumeItem(c *gc.C) {
 	c.Assert(found.Volume, gc.DeepEquals, expected)
 }
 
-func (s *volumeSuite) TestGetVolumeItemsEmpty(c *gc.C) {
-	c.Assert(storage.GetVolumeItems(s.api, nil), gc.IsNil)
-	c.Assert(storage.GetVolumeItems(s.api, []state.VolumeAttachment{}), gc.IsNil)
+func (s *volumeSuite) TestGetVolumeDetailsResultsEmpty(c *gc.C) {
+	c.Assert(storage.GetVolumeDetailsResults(s.api, nil), gc.IsNil)
+	c.Assert(storage.GetVolumeDetailsResults(s.api, []state.VolumeAttachment{}), gc.IsNil)
 }
 
-func (s *volumeSuite) TestGetVolumeItems(c *gc.C) {
+func (s *volumeSuite) TestGetVolumeDetailsResults(c *gc.C) {
 	machineTag := names.NewMachineTag("0")
 	attachments := []state.VolumeAttachment{
 		&mockVolumeAttachment{VolumeTag: s.volumeTag, MachineTag: machineTag},
@@ -103,13 +103,13 @@ func (s *volumeSuite) TestGetVolumeItems(c *gc.C) {
 	}
 	expectedVolume, err := storage.ConvertStateVolumeToParams(s.api, s.volume)
 	c.Assert(err, jc.ErrorIsNil)
-	expected := []params.VolumeItem{
-		params.VolumeItem{
+	expected := []params.VolumeDetailsResult{
+		params.VolumeDetailsResult{
 			Volume:      expectedVolume,
 			Attachments: storage.ConvertStateVolumeAttachmentsToParams(attachments)},
 	}
 	c.Assert(
-		storage.GetVolumeItems(s.api, attachments),
+		storage.GetVolumeDetailsResults(s.api, attachments),
 		jc.DeepEquals,
 		expected)
 }
@@ -144,7 +144,7 @@ func (s *volumeSuite) TestFilterVolumes(c *gc.C) {
 
 	expectedVolume, err := storage.ConvertStateVolumeToParams(s.api, s.volume)
 	c.Assert(err, jc.ErrorIsNil)
-	expected := params.VolumeItem{
+	expected := params.VolumeDetailsResult{
 		Volume: expectedVolume,
 		Attachments: storage.ConvertStateVolumeAttachmentsToParams(
 			[]state.VolumeAttachment{s.volumeAttachment},
@@ -158,7 +158,7 @@ func (s *volumeSuite) TestFilterVolumes(c *gc.C) {
 func (s *volumeSuite) TestVolumeAttachments(c *gc.C) {
 	expectedVolume, err := storage.ConvertStateVolumeToParams(s.api, s.volume)
 	c.Assert(err, jc.ErrorIsNil)
-	expected := params.VolumeItem{
+	expected := params.VolumeDetailsResult{
 		Volume: expectedVolume,
 		Attachments: storage.ConvertStateVolumeAttachmentsToParams(
 			[]state.VolumeAttachment{s.volumeAttachment},
@@ -177,7 +177,7 @@ func (s *volumeSuite) TestVolumeAttachmentsEmpty(c *gc.C) {
 		}
 	expectedVolume, err := storage.ConvertStateVolumeToParams(s.api, s.volume)
 	c.Assert(err, jc.ErrorIsNil)
-	expected := params.VolumeItem{
+	expected := params.VolumeDetailsResult{
 		Volume: expectedVolume,
 	}
 
@@ -221,7 +221,7 @@ func (s *volumeSuite) TestListVolumeAttachmentsError(c *gc.C) {
 func (s *volumeSuite) TestListVolumeAttachments(c *gc.C) {
 	expectedVolume, err := storage.ConvertStateVolumeToParams(s.api, s.volume)
 	c.Assert(err, jc.ErrorIsNil)
-	expected := params.VolumeItem{
+	expected := params.VolumeDetailsResult{
 		Volume: expectedVolume,
 		Attachments: storage.ConvertStateVolumeAttachmentsToParams(
 			[]state.VolumeAttachment{s.volumeAttachment},
@@ -237,7 +237,7 @@ func (s *volumeSuite) TestListVolumeAttachments(c *gc.C) {
 func (s *volumeSuite) TestListVolumesEmptyFilter(c *gc.C) {
 	expectedVolume, err := storage.ConvertStateVolumeToParams(s.api, s.volume)
 	c.Assert(err, jc.ErrorIsNil)
-	expected := params.VolumeItem{
+	expected := params.VolumeDetailsResult{
 		Volume: expectedVolume,
 		Attachments: storage.ConvertStateVolumeAttachmentsToParams(
 			[]state.VolumeAttachment{s.volumeAttachment},
@@ -256,15 +256,15 @@ func (s *volumeSuite) TestListVolumesError(c *gc.C) {
 			return nil, errors.New(msg)
 		}
 
-	items, err := s.api.ListVolumes(params.VolumeFilter{})
+	results, err := s.api.ListVolumes(params.VolumeFilter{})
 	c.Assert(errors.Cause(err), gc.ErrorMatches, msg)
-	c.Assert(items, gc.DeepEquals, params.VolumeItemsResult{})
+	c.Assert(results, gc.DeepEquals, params.VolumeDetailsResults{})
 }
 
 func (s *volumeSuite) TestListVolumesFilter(c *gc.C) {
 	expectedVolume, err := storage.ConvertStateVolumeToParams(s.api, s.volume)
 	c.Assert(err, jc.ErrorIsNil)
-	expected := params.VolumeItem{
+	expected := params.VolumeDetailsResult{
 		Volume: expectedVolume,
 		Attachments: storage.ConvertStateVolumeAttachmentsToParams(
 			[]state.VolumeAttachment{s.volumeAttachment},

--- a/apiserver/storage/volumelist_test.go
+++ b/apiserver/storage/volumelist_test.go
@@ -5,12 +5,10 @@ package storage_test
 
 import (
 	"github.com/juju/errors"
-	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/params"
-	"github.com/juju/juju/apiserver/storage"
 	"github.com/juju/juju/state"
 )
 
@@ -20,260 +18,113 @@ type volumeSuite struct {
 
 var _ = gc.Suite(&volumeSuite{})
 
-func (s *volumeSuite) TestGroupAttachmentsByVolumeEmpty(c *gc.C) {
-	c.Assert(storage.GroupAttachmentsByVolume(nil), gc.IsNil)
-	c.Assert(storage.GroupAttachmentsByVolume([]state.VolumeAttachment{}), gc.IsNil)
-}
-
-func (s *volumeSuite) TestGroupAttachmentsByVolume(c *gc.C) {
-	volumeTag1 := names.NewVolumeTag("0")
-	volumeTag2 := names.NewVolumeTag("0/1")
-	machineTag := names.NewMachineTag("0")
-	attachments := []state.VolumeAttachment{
-		&mockVolumeAttachment{VolumeTag: volumeTag1, MachineTag: machineTag},
-		&mockVolumeAttachment{VolumeTag: volumeTag2, MachineTag: machineTag},
-		&mockVolumeAttachment{VolumeTag: volumeTag2, MachineTag: machineTag},
-	}
-	expected := map[string][]params.VolumeAttachment{
-		volumeTag1.String(): {
-			storage.ConvertStateVolumeAttachmentToParams(attachments[0])},
-		volumeTag2.String(): {
-			storage.ConvertStateVolumeAttachmentToParams(attachments[1]),
-			storage.ConvertStateVolumeAttachmentToParams(attachments[2]),
+func (s *volumeSuite) expectedVolumeDetailsResult() params.VolumeDetailsResult {
+	return params.VolumeDetailsResult{
+		Details: &params.VolumeDetails{
+			VolumeTag:       s.volumeTag.String(),
+			StorageTag:      "storage-data-0",
+			StorageOwnerTag: "unit-mysql-0",
+			Status: params.EntityStatus{
+				Status: "attached",
+			},
+			MachineAttachments: map[string]params.VolumeAttachmentInfo{
+				s.machineTag.String(): params.VolumeAttachmentInfo{},
+			},
 		},
+		LegacyVolume: &params.LegacyVolumeDetails{
+			VolumeTag:  s.volumeTag.String(),
+			StorageTag: "storage-data-0",
+			UnitTag:    "unit-mysql-0",
+			Status: params.EntityStatus{
+				Status: "attached",
+			},
+		},
+		LegacyAttachments: []params.VolumeAttachment{{
+			VolumeTag:  s.volumeTag.String(),
+			MachineTag: s.machineTag.String(),
+		}},
 	}
-	c.Assert(
-		storage.GroupAttachmentsByVolume(attachments),
-		jc.DeepEquals,
-		expected)
-}
-
-func (s *volumeSuite) TestCreateVolumeDetailsResultInvalidTag(c *gc.C) {
-	found := storage.CreateVolumeDetailsResult(s.api, "666", nil)
-	c.Assert(found.Error, gc.ErrorMatches, ".*not a valid tag.*")
-}
-
-func (s *volumeSuite) TestCreateVolumeDetailsResultNonexistingVolume(c *gc.C) {
-	s.state.volume = func(tag names.VolumeTag) (state.Volume, error) {
-		return s.volume, errors.Errorf("not volume for tag %v", tag)
-	}
-	found := storage.CreateVolumeDetailsResult(s.api, names.NewVolumeTag("666").String(), nil)
-	c.Assert(found.Error, gc.ErrorMatches, ".*volume for tag.*")
-}
-
-func (s *volumeSuite) TestCreateVolumeDetailsResultNoUnit(c *gc.C) {
-	s.storageInstance.owner = names.NewServiceTag("test-service")
-	found := storage.CreateVolumeDetailsResult(s.api, s.volumeTag.String(), nil)
-	c.Assert(found.Error, gc.IsNil)
-	c.Assert(found.Error, gc.IsNil)
-	expected, err := storage.ConvertStateVolumeToParams(s.api, s.volume)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(found.Volume, gc.DeepEquals, expected)
-}
-
-func (s *volumeSuite) TestCreateVolumeDetailsResultNoStorageInstance(c *gc.C) {
-	s.volume = &mockVolume{tag: s.volumeTag, hasNoStorage: true}
-	found := storage.CreateVolumeDetailsResult(s.api, s.volumeTag.String(), nil)
-	c.Assert(found.Error, gc.IsNil)
-	c.Assert(found.Error, gc.IsNil)
-	expected, err := storage.ConvertStateVolumeToParams(s.api, s.volume)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(found.Volume, gc.DeepEquals, expected)
-}
-
-func (s *volumeSuite) TestCreateVolumeDetailsResult(c *gc.C) {
-	found := storage.CreateVolumeDetailsResult(s.api, s.volumeTag.String(), nil)
-	c.Assert(found.Error, gc.IsNil)
-	c.Assert(found.Error, gc.IsNil)
-	expected, err := storage.ConvertStateVolumeToParams(s.api, s.volume)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(found.Volume, gc.DeepEquals, expected)
-}
-
-func (s *volumeSuite) TestGetVolumeDetailsResultsEmpty(c *gc.C) {
-	c.Assert(storage.GetVolumeDetailsResults(s.api, nil), gc.IsNil)
-	c.Assert(storage.GetVolumeDetailsResults(s.api, []state.VolumeAttachment{}), gc.IsNil)
-}
-
-func (s *volumeSuite) TestGetVolumeDetailsResults(c *gc.C) {
-	machineTag := names.NewMachineTag("0")
-	attachments := []state.VolumeAttachment{
-		&mockVolumeAttachment{VolumeTag: s.volumeTag, MachineTag: machineTag},
-		&mockVolumeAttachment{VolumeTag: s.volumeTag, MachineTag: machineTag},
-	}
-	expectedVolume, err := storage.ConvertStateVolumeToParams(s.api, s.volume)
-	c.Assert(err, jc.ErrorIsNil)
-	expected := []params.VolumeDetailsResult{
-		params.VolumeDetailsResult{
-			Volume:      expectedVolume,
-			Attachments: storage.ConvertStateVolumeAttachmentsToParams(attachments)},
-	}
-	c.Assert(
-		storage.GetVolumeDetailsResults(s.api, attachments),
-		jc.DeepEquals,
-		expected)
-}
-
-func (s *volumeSuite) TestFilterVolumesNoItems(c *gc.C) {
-	s.state.machineVolumeAttachments =
-		func(machine names.MachineTag) ([]state.VolumeAttachment, error) {
-			return nil, nil
-		}
-	filter := params.VolumeFilter{
-		Machines: []string{s.machineTag.String()}}
-
-	c.Assert(storage.FilterVolumes(s.api, filter), gc.IsNil)
-}
-
-func (s *volumeSuite) TestFilterVolumesErrorMachineAttachments(c *gc.C) {
-	s.state.machineVolumeAttachments =
-		func(machine names.MachineTag) ([]state.VolumeAttachment, error) {
-			return nil, errors.Errorf("not for machine %v", machine)
-		}
-	filter := params.VolumeFilter{
-		Machines: []string{s.machineTag.String()}}
-
-	found := storage.FilterVolumes(s.api, filter)
-	c.Assert(found, gc.HasLen, 1)
-	c.Assert(found[0].Error, gc.ErrorMatches, ".*for machine.*")
-}
-
-func (s *volumeSuite) TestFilterVolumes(c *gc.C) {
-	filter := params.VolumeFilter{
-		Machines: []string{s.machineTag.String()}}
-
-	expectedVolume, err := storage.ConvertStateVolumeToParams(s.api, s.volume)
-	c.Assert(err, jc.ErrorIsNil)
-	expected := params.VolumeDetailsResult{
-		Volume: expectedVolume,
-		Attachments: storage.ConvertStateVolumeAttachmentsToParams(
-			[]state.VolumeAttachment{s.volumeAttachment},
-		),
-	}
-	found := storage.FilterVolumes(s.api, filter)
-	c.Assert(found, gc.HasLen, 1)
-	c.Assert(found[0], gc.DeepEquals, expected)
-}
-
-func (s *volumeSuite) TestVolumeAttachments(c *gc.C) {
-	expectedVolume, err := storage.ConvertStateVolumeToParams(s.api, s.volume)
-	c.Assert(err, jc.ErrorIsNil)
-	expected := params.VolumeDetailsResult{
-		Volume: expectedVolume,
-		Attachments: storage.ConvertStateVolumeAttachmentsToParams(
-			[]state.VolumeAttachment{s.volumeAttachment},
-		),
-	}
-
-	found := storage.VolumeAttachments(s.api, []state.Volume{s.volume})
-	c.Assert(found, gc.HasLen, 1)
-	c.Assert(found[0], gc.DeepEquals, expected)
-}
-
-func (s *volumeSuite) TestVolumeAttachmentsEmpty(c *gc.C) {
-	s.state.volumeAttachments =
-		func(volume names.VolumeTag) ([]state.VolumeAttachment, error) {
-			return nil, nil
-		}
-	expectedVolume, err := storage.ConvertStateVolumeToParams(s.api, s.volume)
-	c.Assert(err, jc.ErrorIsNil)
-	expected := params.VolumeDetailsResult{
-		Volume: expectedVolume,
-	}
-
-	found := storage.VolumeAttachments(s.api, []state.Volume{s.volume})
-	c.Assert(found, gc.HasLen, 1)
-	c.Assert(found[0], gc.DeepEquals, expected)
-}
-
-func (s *volumeSuite) TestVolumeAttachmentsError(c *gc.C) {
-	s.state.volumeAttachments =
-		func(volume names.VolumeTag) ([]state.VolumeAttachment, error) {
-			return nil, errors.Errorf("not for volume %v", volume)
-		}
-
-	found := storage.VolumeAttachments(s.api, []state.Volume{s.volume})
-	c.Assert(found, gc.HasLen, 1)
-	c.Assert(found[0].Error, gc.ErrorMatches, ".*for volume.*")
-}
-
-func (s *volumeSuite) TestListVolumeAttachmentsEmpty(c *gc.C) {
-	s.state.allVolumes =
-		func() ([]state.Volume, error) {
-			return nil, nil
-		}
-	items, err := storage.ListVolumeAttachments(s.api)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(items, gc.IsNil)
-}
-
-func (s *volumeSuite) TestListVolumeAttachmentsError(c *gc.C) {
-	msg := "inventing error"
-	s.state.allVolumes =
-		func() ([]state.Volume, error) {
-			return nil, errors.New(msg)
-		}
-	items, err := storage.ListVolumeAttachments(s.api)
-	c.Assert(errors.Cause(err), gc.ErrorMatches, msg)
-	c.Assert(items, gc.IsNil)
-}
-
-func (s *volumeSuite) TestListVolumeAttachments(c *gc.C) {
-	expectedVolume, err := storage.ConvertStateVolumeToParams(s.api, s.volume)
-	c.Assert(err, jc.ErrorIsNil)
-	expected := params.VolumeDetailsResult{
-		Volume: expectedVolume,
-		Attachments: storage.ConvertStateVolumeAttachmentsToParams(
-			[]state.VolumeAttachment{s.volumeAttachment},
-		),
-	}
-
-	items, err := storage.ListVolumeAttachments(s.api)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(items, gc.HasLen, 1)
-	c.Assert(items[0], gc.DeepEquals, expected)
 }
 
 func (s *volumeSuite) TestListVolumesEmptyFilter(c *gc.C) {
-	expectedVolume, err := storage.ConvertStateVolumeToParams(s.api, s.volume)
-	c.Assert(err, jc.ErrorIsNil)
-	expected := params.VolumeDetailsResult{
-		Volume: expectedVolume,
-		Attachments: storage.ConvertStateVolumeAttachmentsToParams(
-			[]state.VolumeAttachment{s.volumeAttachment},
-		),
-	}
 	found, err := s.api.ListVolumes(params.VolumeFilter{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(found.Results, gc.HasLen, 1)
-	c.Assert(found.Results[0], gc.DeepEquals, expected)
+	c.Assert(found.Results[0], gc.DeepEquals, s.expectedVolumeDetailsResult())
 }
 
 func (s *volumeSuite) TestListVolumesError(c *gc.C) {
 	msg := "inventing error"
-	s.state.allVolumes =
-		func() ([]state.Volume, error) {
-			return nil, errors.New(msg)
-		}
+	s.state.allVolumes = func() ([]state.Volume, error) {
+		return nil, errors.New(msg)
+	}
+	_, err := s.api.ListVolumes(params.VolumeFilter{})
+	c.Assert(err, gc.ErrorMatches, msg)
+}
 
+func (s *volumeSuite) TestListVolumesNoVolumes(c *gc.C) {
+	s.state.allVolumes = func() ([]state.Volume, error) {
+		return nil, nil
+	}
 	results, err := s.api.ListVolumes(params.VolumeFilter{})
-	c.Assert(errors.Cause(err), gc.ErrorMatches, msg)
-	c.Assert(results, gc.DeepEquals, params.VolumeDetailsResults{})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results.Results, gc.HasLen, 0)
 }
 
 func (s *volumeSuite) TestListVolumesFilter(c *gc.C) {
-	expectedVolume, err := storage.ConvertStateVolumeToParams(s.api, s.volume)
-	c.Assert(err, jc.ErrorIsNil)
-	expected := params.VolumeDetailsResult{
-		Volume: expectedVolume,
-		Attachments: storage.ConvertStateVolumeAttachmentsToParams(
-			[]state.VolumeAttachment{s.volumeAttachment},
-		),
-	}
 	filter := params.VolumeFilter{
-		Machines: []string{s.machineTag.String()}}
+		Machines: []string{s.machineTag.String()},
+	}
 	found, err := s.api.ListVolumes(filter)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(found.Results, gc.HasLen, 1)
-	c.Assert(found.Results[0], gc.DeepEquals, expected)
+	c.Assert(found.Results[0], jc.DeepEquals, s.expectedVolumeDetailsResult())
+}
+
+func (s *volumeSuite) TestListVolumesFilterNonMatching(c *gc.C) {
+	filter := params.VolumeFilter{
+		Machines: []string{"machine-42"},
+	}
+	found, err := s.api.ListVolumes(filter)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(found.Results, gc.HasLen, 0)
+}
+
+func (s *volumeSuite) TestListVolumesVolumeInfo(c *gc.C) {
+	s.volume.info = &state.VolumeInfo{
+		Size:       123,
+		HardwareId: "abc",
+		Persistent: true,
+	}
+	expected := s.expectedVolumeDetailsResult()
+	expected.Details.Info.Size = 123
+	expected.Details.Info.HardwareId = "abc"
+	expected.Details.Info.Persistent = true
+	expected.LegacyVolume.Size = 123
+	expected.LegacyVolume.HardwareId = "abc"
+	expected.LegacyVolume.Persistent = true
+	found, err := s.api.ListVolumes(params.VolumeFilter{})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(found.Results, gc.HasLen, 1)
+	c.Assert(found.Results[0], jc.DeepEquals, expected)
+}
+
+func (s *volumeSuite) TestListVolumesAttachmentInfo(c *gc.C) {
+	s.volumeAttachment.info = &state.VolumeAttachmentInfo{
+		DeviceName: "xvdf1",
+		ReadOnly:   true,
+	}
+	expected := s.expectedVolumeDetailsResult()
+	expected.Details.MachineAttachments[s.machineTag.String()] = params.VolumeAttachmentInfo{
+		DeviceName: "xvdf1",
+		ReadOnly:   true,
+	}
+	expected.LegacyAttachments[0].Info = params.VolumeAttachmentInfo{
+		DeviceName: "xvdf1",
+		ReadOnly:   true,
+	}
+	found, err := s.api.ListVolumes(params.VolumeFilter{})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(found.Results, gc.HasLen, 1)
+	c.Assert(found.Results[0], jc.DeepEquals, expected)
 }

--- a/cmd/juju/storage/volume.go
+++ b/cmd/juju/storage/volume.go
@@ -73,18 +73,18 @@ type EntityStatus struct {
 }
 
 // convertToVolumeInfo returns map of maps with volume info
-// keyed first on machine_id and then on volume_id.
-func convertToVolumeInfo(all []params.VolumeItem) (map[string]map[string]map[string]VolumeInfo, error) {
+// keyed first on machine ID and then on volume ID.
+func convertToVolumeInfo(all []params.VolumeDetailsResult) (map[string]map[string]map[string]VolumeInfo, error) {
 	result := map[string]map[string]map[string]VolumeInfo{}
 	for _, one := range all {
-		if err := convertVolumeItem(one, result); err != nil {
+		if err := convertVolumeDetailsResult(one, result); err != nil {
 			return nil, errors.Trace(err)
 		}
 	}
 	return result, nil
 }
 
-func convertVolumeItem(item params.VolumeItem, all map[string]map[string]map[string]VolumeInfo) error {
+func convertVolumeDetailsResult(item params.VolumeDetailsResult, all map[string]map[string]map[string]VolumeInfo) error {
 	if len(item.Attachments) != 0 {
 		// add info for volume attachments
 		return convertVolumeAttachments(item, all)
@@ -102,7 +102,7 @@ var idFromTag = func(s string) (string, error) {
 	return tag.Id(), nil
 }
 
-func convertVolumeAttachments(item params.VolumeItem, all map[string]map[string]map[string]VolumeInfo) error {
+func convertVolumeAttachments(item params.VolumeDetailsResult, all map[string]map[string]map[string]VolumeInfo) error {
 	for _, one := range item.Attachments {
 		machine, err := idFromTag(one.MachineTag)
 		if err != nil {
@@ -131,7 +131,7 @@ func addOneToAll(machineId, unitId, storageId string, item VolumeInfo, all map[s
 	unitVolumes[storageId] = item
 }
 
-func createInfo(volume params.VolumeInstance) (info VolumeInfo, unit, storage string) {
+func createInfo(volume params.VolumeDetails) (info VolumeInfo, unit, storage string) {
 	info.VolumeId = volume.VolumeId
 	info.HardwareId = volume.HardwareId
 	info.Size = volume.Size

--- a/cmd/juju/storage/volume.go
+++ b/cmd/juju/storage/volume.go
@@ -85,12 +85,19 @@ func convertToVolumeInfo(all []params.VolumeDetailsResult) (map[string]map[strin
 }
 
 func convertVolumeDetailsResult(item params.VolumeDetailsResult, all map[string]map[string]map[string]VolumeInfo) error {
-	if len(item.Attachments) != 0 {
-		// add info for volume attachments
-		return convertVolumeAttachments(item, all)
+	info, attachments, storage, storageOwner := createVolumeInfo(item)
+	for machineTag, attachmentInfo := range attachments {
+		machineId, err := idFromTag(machineTag)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		info.DeviceName = attachmentInfo.DeviceName
+		info.ReadOnly = attachmentInfo.ReadOnly
+		addOneToAll(machineId, storage, storageOwner, info, all)
 	}
-	unattached, unit, storage := createInfo(item.Volume)
-	addOneToAll("unattached", unit, storage, unattached, all)
+	if len(attachments) == 0 {
+		addOneToAll("unattached", storage, storageOwner, info, all)
+	}
 	return nil
 }
 
@@ -103,55 +110,85 @@ var idFromTag = func(s string) (string, error) {
 }
 
 func convertVolumeAttachments(item params.VolumeDetailsResult, all map[string]map[string]map[string]VolumeInfo) error {
-	for _, one := range item.Attachments {
-		machine, err := idFromTag(one.MachineTag)
-		if err != nil {
-			return errors.Trace(err)
-		}
-		info, unit, storage := createInfo(item.Volume)
-		info.DeviceName = one.Info.DeviceName
-		info.ReadOnly = one.Info.ReadOnly
-
-		addOneToAll(machine, unit, storage, info, all)
-	}
 	return nil
 }
 
-func addOneToAll(machineId, unitId, storageId string, item VolumeInfo, all map[string]map[string]map[string]VolumeInfo) {
+func addOneToAll(machineId, storageId, storageOwnerId string, item VolumeInfo, all map[string]map[string]map[string]VolumeInfo) {
 	machineVolumes, ok := all[machineId]
 	if !ok {
 		machineVolumes = map[string]map[string]VolumeInfo{}
 		all[machineId] = machineVolumes
 	}
-	unitVolumes, ok := machineVolumes[unitId]
+	storageOwnerVolumes, ok := machineVolumes[storageOwnerId]
 	if !ok {
-		unitVolumes = map[string]VolumeInfo{}
-		machineVolumes[unitId] = unitVolumes
+		storageOwnerVolumes = map[string]VolumeInfo{}
+		machineVolumes[storageOwnerId] = storageOwnerVolumes
 	}
-	unitVolumes[storageId] = item
+	storageOwnerVolumes[storageId] = item
 }
 
-func createInfo(volume params.VolumeDetails) (info VolumeInfo, unit, storage string) {
-	info.VolumeId = volume.VolumeId
-	info.HardwareId = volume.HardwareId
-	info.Size = volume.Size
-	info.Persistent = volume.Persistent
-	info.Status = EntityStatus{
-		volume.Status.Status,
-		volume.Status.Info,
-		// TODO(axw) we should support formatting as ISO time
-		common.FormatTime(volume.Status.Since, false),
+// TODO(axw) there are a lot of ignored errors in here, which are *probably*
+// nil, but we should report them up the stack to be safe.
+func createVolumeInfo(result params.VolumeDetailsResult) (
+	info VolumeInfo,
+	attachments map[string]params.VolumeAttachmentInfo,
+	storageId string,
+	storageOwnerId string,
+) {
+	details := result.Details
+	if details == nil {
+		details = volumeDetailsFromLegacy(result)
 	}
 
-	if v, err := idFromTag(volume.VolumeTag); err == nil {
+	info.VolumeId = details.Info.VolumeId
+	info.HardwareId = details.Info.HardwareId
+	info.Size = details.Info.Size
+	info.Persistent = details.Info.Persistent
+	info.Status = EntityStatus{
+		details.Status.Status,
+		details.Status.Info,
+		// TODO(axw) we should support formatting as ISO time
+		common.FormatTime(details.Status.Since, false),
+	}
+	if v, err := idFromTag(details.VolumeTag); err == nil {
 		info.Volume = v
 	}
 	var err error
-	if storage, err = idFromTag(volume.StorageTag); err != nil {
-		storage = "unassigned"
+	if storageId, err = idFromTag(details.StorageTag); err != nil {
+		// volume is not assigned to a storage instance
+		storageId = "unassigned"
 	}
-	if unit, err = idFromTag(volume.UnitTag); err != nil {
-		unit = "unattached"
+	if storageOwnerId, err = idFromTag(details.StorageOwnerTag); err != nil {
+		// volume is not assigned to a storage instance,
+		// or storage instance is not attached to a unit (legacy)
+		storageOwnerId = "unattached"
 	}
-	return
+	attachments = details.MachineAttachments
+	return info, attachments, storageId, storageOwnerId
+}
+
+// volumeDetailsFromLegacy converts from legacy data structures
+// to params.VolumeDetails. This exists only for backwards-
+// compatibility. Please think long and hard before changing it.
+func volumeDetailsFromLegacy(result params.VolumeDetailsResult) *params.VolumeDetails {
+	details := &params.VolumeDetails{
+		VolumeTag:  result.LegacyVolume.VolumeTag,
+		StorageTag: result.LegacyVolume.StorageTag,
+		Status:     result.LegacyVolume.Status,
+	}
+	details.Info.VolumeId = result.LegacyVolume.VolumeId
+	details.Info.HardwareId = result.LegacyVolume.HardwareId
+	details.Info.Size = result.LegacyVolume.Size
+	details.Info.Persistent = result.LegacyVolume.Persistent
+	if result.LegacyVolume.UnitTag != "" {
+		details.StorageOwnerTag = result.LegacyVolume.UnitTag
+	}
+	if len(result.LegacyAttachments) > 0 {
+		attachments := make(map[string]params.VolumeAttachmentInfo)
+		for _, attachment := range result.LegacyAttachments {
+			attachments[attachment.MachineTag] = attachment.Info
+		}
+		details.MachineAttachments = attachments
+	}
+	return details
 }

--- a/cmd/juju/storage/volumelist.go
+++ b/cmd/juju/storage/volumelist.go
@@ -71,7 +71,7 @@ func (c *VolumeListCommand) Run(ctx *cmd.Context) (err error) {
 		return err
 	}
 	// filter out valid output, if any
-	var valid []params.VolumeItem
+	var valid []params.VolumeDetailsResult
 	for _, one := range found {
 		if one.Error == nil {
 			valid = append(valid, one)
@@ -95,7 +95,7 @@ var getVolumeListAPI = (*VolumeListCommand).getVolumeListAPI
 // VolumeListAPI defines the API methods that the volume list command use.
 type VolumeListAPI interface {
 	Close() error
-	ListVolumes(machines []string) ([]params.VolumeItem, error)
+	ListVolumes(machines []string) ([]params.VolumeDetailsResult, error)
 }
 
 func (c *VolumeListCommand) getVolumeListAPI() (VolumeListAPI, error) {

--- a/cmd/juju/storage/volumelist_test.go
+++ b/cmd/juju/storage/volumelist_test.go
@@ -243,53 +243,53 @@ func (s mockVolumeListAPI) Close() error {
 	return nil
 }
 
-func (s mockVolumeListAPI) ListVolumes(machines []string) ([]params.VolumeItem, error) {
+func (s mockVolumeListAPI) ListVolumes(machines []string) ([]params.VolumeDetailsResult, error) {
 	if s.errOut != "" {
 		return nil, errors.New(s.errOut)
 	}
 	if s.listEmpty {
 		return nil, nil
 	}
-	result := []params.VolumeItem{}
+	result := []params.VolumeDetailsResult{}
 	if s.addErrItem {
-		result = append(result, params.VolumeItem{
+		result = append(result, params.VolumeDetailsResult{
 			Error: common.ServerError(errors.New("volume item error"))})
 	}
 	if s.listAll {
 		machines = []string{"25", "42"}
 		//unattached
-		result = append(result, s.createTestVolumeItem(
+		result = append(result, s.createTestVolumeDetailsResult(
 			"3/4", true, "db-dir/1000", "abc/0", nil,
 			createTestStatus(params.StatusDestroying, ""),
 		))
-		result = append(result, s.createTestVolumeItem(
+		result = append(result, s.createTestVolumeDetailsResult(
 			"3/3", false, "", "", nil,
 			createTestStatus(params.StatusDestroying, ""),
 		))
 	}
-	result = append(result, s.createTestVolumeItem(
+	result = append(result, s.createTestVolumeDetailsResult(
 		"0/1", true, "shared-fs/0", "postgresql/0", machines,
 		createTestStatus(params.StatusAttaching, "failed to attach"),
 	))
-	result = append(result, s.createTestVolumeItem(
+	result = append(result, s.createTestVolumeDetailsResult(
 		"0/abc/0/88", false, "shared-fs/0", "", machines,
 		createTestStatus(params.StatusAttached, ""),
 	))
 	return result, nil
 }
 
-func (s mockVolumeListAPI) createTestVolumeItem(
+func (s mockVolumeListAPI) createTestVolumeDetailsResult(
 	id string,
 	persistent bool,
 	storageid, unitid string,
 	machines []string,
 	status params.EntityStatus,
-) params.VolumeItem {
+) params.VolumeDetailsResult {
 	volume := s.createTestVolume(id, persistent, storageid, unitid, status)
 
 	// Create unattached volume
 	if len(machines) == 0 {
-		return params.VolumeItem{Volume: volume}
+		return params.VolumeDetailsResult{Volume: volume}
 	}
 
 	// Create volume attachments
@@ -298,15 +298,15 @@ func (s mockVolumeListAPI) createTestVolumeItem(
 		attachments[i] = s.createTestAttachment(volume.VolumeTag, machine, i%2 == 0)
 	}
 
-	return params.VolumeItem{
+	return params.VolumeDetailsResult{
 		Volume:      volume,
 		Attachments: attachments,
 	}
 }
 
-func (s mockVolumeListAPI) createTestVolume(id string, persistent bool, storageid, unitid string, status params.EntityStatus) params.VolumeInstance {
+func (s mockVolumeListAPI) createTestVolume(id string, persistent bool, storageid, unitid string, status params.EntityStatus) params.VolumeDetails {
 	tag := names.NewVolumeTag(id)
-	result := params.VolumeInstance{
+	result := params.VolumeDetails{
 		VolumeTag:  tag.String(),
 		VolumeId:   "provider-supplied-" + tag.Id(),
 		HardwareId: "serial blah blah",

--- a/featuretests/storage_test.go
+++ b/featuretests/storage_test.go
@@ -384,12 +384,10 @@ func runVolumeList(c *gc.C, args ...string) *cmd.Context {
 }
 
 func (s *cmdStorageSuite) TestListVolumeInvalidMachine(c *gc.C) {
-	context := runVolumeList(c, "abc", "--format", "yaml")
-	c.Assert(testing.Stdout(context), gc.Equals, "")
-	c.Assert(testing.Stderr(context),
-		gc.Matches,
-		`parsing machine tag machine-abc: "machine-abc" is not a valid machine tag
-`)
+	_, err := testing.RunCommand(
+		c, envcmd.Wrap(&cmdstorage.VolumeListCommand{}), "abc",
+	)
+	c.Assert(err, gc.ErrorMatches, `"machine-abc" is not a valid machine tag`)
 }
 
 func (s *cmdStorageSuite) TestListVolumeTabularFilterMatch(c *gc.C) {


### PR DESCRIPTION
Renamed and restructured some params structs
so that they have slightly meaningful names,
better structure/reuse of existing types, and
fixed up an erroneous assumptions about the
volume/unit relationship.

Dropped unnecessary white-box tests in the
apiserver/storage package, added some more
black-box tests and improved coverage. The
code for ListVolumes was refactored and
made (IMO) more readable/understandable.

(Review request: http://reviews.vapour.ws/r/2591/)