### PR TITLE
Fwport fix for 1483672 from 1.25

### DIFF
--- a/apiserver/params/internal.go
+++ b/apiserver/params/internal.go
@@ -347,7 +347,7 @@ type EntityStatus struct {
 	Since  *time.Time
 }
 
-// EntityStatus holds parameters for setting the status of a single entity.
+// EntityStatusArgs holds parameters for setting the status of a single entity.
 type EntityStatusArgs struct {
 	Tag    string
 	Status Status

--- a/worker/uniter/runner/context.go
+++ b/worker/uniter/runner/context.go
@@ -275,11 +275,12 @@ func (ctx *HookContext) ServiceStatus() (jujuc.ServiceStatusInfo, error) {
 func (ctx *HookContext) SetUnitStatus(status jujuc.StatusInfo) error {
 	ctx.hasRunStatusSet = true
 	logger.Debugf("[WORKLOAD-STATUS] %s: %s", status.Status, status.Info)
-	return ctx.unit.SetUnitStatus(
+	err := ctx.unit.SetUnitStatus(
 		params.Status(status.Status),
 		status.Info,
 		status.Data,
 	)
+	return errors.Annotatef(err, "could not set status %q with info %q and data: %v", status.Status, status.Info, status.Data)
 }
 
 // SetServiceStatus will set the given status to the service to which this

--- a/worker/uniter/runner/jujuc/relation-set.go
+++ b/worker/uniter/runner/jujuc/relation-set.go
@@ -78,38 +78,46 @@ func (c *RelationSetCommand) Init(args []string) error {
 	return nil
 }
 
-func (c *RelationSetCommand) readSettings(in io.Reader) (map[string]string, error) {
-	data, err := ioutil.ReadAll(in)
-	if err != nil {
+// ensureYamlIsMap will check that the passed data fits a hash of strings
+// structure (and not a simple string or array) and will return the
+// hashmap, a bool indicating if there was validation issues and an
+// error representing either a validation error or an actual error
+// in the process.
+func ensureYamlIsMap(data []byte) (map[string]string, error) {
+	// Can this validation be done more simply or efficiently?
+	var scalar string
+	if err := goyaml.Unmarshal(data, &scalar); err != nil {
 		return nil, errors.Trace(err)
 	}
+	if scalar != "" {
+		return nil, errors.Errorf("expected YAML map, got %q", scalar)
+	}
 
-	skipValidation := false // for debugging
-	if !skipValidation {
-		// Can this validation be done more simply or efficiently?
-
-		var scalar string
-		if err := goyaml.Unmarshal(data, &scalar); err != nil {
-			return nil, errors.Trace(err)
-		}
-		if scalar != "" {
-			return nil, errors.Errorf("expected YAML map, got %q", scalar)
-		}
-
-		var sequence []string
-		if err := goyaml.Unmarshal(data, &sequence); err != nil {
-			return nil, errors.Trace(err)
-		}
-		if len(sequence) != 0 {
-			return nil, errors.Errorf("expected YAML map, got %#v", sequence)
-		}
+	var sequence []string
+	if err := goyaml.Unmarshal(data, &sequence); err != nil {
+		return nil, errors.Trace(err)
+	}
+	if len(sequence) != 0 {
+		return nil, errors.Errorf("expected YAML map, got %#v", sequence)
 	}
 
 	kvs := make(map[string]string)
 	if err := goyaml.Unmarshal(data, kvs); err != nil {
 		return nil, errors.Trace(err)
 	}
+	return kvs, nil
+}
 
+func (c *RelationSetCommand) readSettings(in io.Reader) (map[string]string, error) {
+	data, err := ioutil.ReadAll(in)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	var kvs map[string]string
+	if kvs, err = ensureYamlIsMap(data); err != nil {
+		return nil, errors.Trace(err)
+	}
 	return kvs, nil
 }
 

--- a/worker/uniter/runner/jujuc/status-set.go
+++ b/worker/uniter/runner/jujuc/status-set.go
@@ -17,6 +17,7 @@ type StatusSetCommand struct {
 	ctx     Context
 	status  string
 	message string
+	data    map[string]interface{}
 	service bool
 }
 
@@ -33,7 +34,7 @@ status and message are the same as what's already set.
 `
 	return &cmd.Info{
 		Name:    "status-set",
-		Args:    "<maintenance | blocked | waiting | active> [message]",
+		Args:    "<maintenance | blocked | waiting | active> [message] [data]",
 		Purpose: "set status information",
 		Doc:     doc,
 	}
@@ -50,9 +51,24 @@ func (c *StatusSetCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.BoolVar(&c.service, "service", false, "set this status for the service to which the unit belongs if the unit is the leader")
 }
 
+func (c *StatusSetCommand) parseData(data string) error {
+	// So far we only accept maps as data.
+	var err error
+	var yamlMap map[string]string
+	if yamlMap, err = ensureYamlIsMap([]byte(data)); err != nil {
+		return errors.Trace(err)
+	}
+	c.data = make(map[string]interface{}, len(yamlMap))
+	for k, v := range yamlMap {
+		c.data[k] = v
+	}
+
+	return nil
+}
+
 func (c *StatusSetCommand) Init(args []string) error {
 	if len(args) < 1 {
-		return errors.Errorf("invalid args, require <status> [message]")
+		return errors.Errorf("invalid args, require <status> [message] [data]")
 	}
 	valid := false
 	for _, s := range validStatus {
@@ -65,9 +81,15 @@ func (c *StatusSetCommand) Init(args []string) error {
 		return errors.Errorf("invalid status %q, expected one of %v", args[0], validStatus)
 	}
 	c.status = args[0]
+
 	if len(args) > 1 {
 		c.message = args[1]
-		return cmd.CheckEmpty(args[2:])
+	}
+	if len(args) > 2 {
+		if err := c.parseData(args[2]); err != nil {
+			return errors.Annotate(err, "cannot parse data to set status")
+		}
+		return cmd.CheckEmpty(args[3:])
 	}
 	return nil
 }
@@ -76,6 +98,7 @@ func (c *StatusSetCommand) Run(ctx *cmd.Context) error {
 	statusInfo := StatusInfo{
 		Status: c.status,
 		Info:   c.message,
+		Data:   c.data,
 	}
 	if c.service {
 		return c.ctx.SetServiceStatus(statusInfo)


### PR DESCRIPTION
status-set context command now support a data positional parameter that allows to attach yaml to a status.

(Review request: http://reviews.vapour.ws/r/2598/)