### PR TITLE
Fix status history and add unit tests

### DIFF
--- a/apiserver/client/export_test.go
+++ b/apiserver/client/export_test.go
@@ -3,6 +3,8 @@
 
 package client
 
+import "github.com/juju/juju/state"
+
 var (
 	RemoteParamsForMachine = remoteParamsForMachine
 	GetAllUnitNames        = getAllUnitNames
@@ -21,3 +23,18 @@ var (
 )
 
 type MachineAndContainers machineAndContainers
+
+// Status history exports
+type StateInterface stateInterface
+
+var GetState = getState
+
+type Patcher interface {
+	PatchValue(ptr, value interface{})
+}
+
+func PatchState(p Patcher, st StateInterface) {
+	p.PatchValue(&getState, func(*state.State) stateInterface {
+		return st
+	})
+}

--- a/apiserver/client/export_test.go
+++ b/apiserver/client/export_test.go
@@ -27,8 +27,6 @@ type MachineAndContainers machineAndContainers
 // Status history exports
 type StateInterface stateInterface
 
-var GetState = getState
-
 type Patcher interface {
 	PatchValue(ptr, value interface{})
 }

--- a/apiserver/client/get.go
+++ b/apiserver/client/get.go
@@ -12,7 +12,7 @@ import (
 
 // ServiceGet returns the configuration for a service.
 func (c *Client) ServiceGet(args params.ServiceGet) (params.ServiceGetResults, error) {
-	service, err := c.api.state.Service(args.ServiceName)
+	service, err := c.api.stateAccessor.Service(args.ServiceName)
 	if err != nil {
 		return params.ServiceGetResults{}, err
 	}
@@ -63,7 +63,7 @@ func describe(settings charm.Settings, config *charm.Config) map[string]interfac
 // ServiceGetCharmURL returns the charm URL the given service is
 // running at present.
 func (c *Client) ServiceGetCharmURL(args params.ServiceGet) (params.StringResult, error) {
-	service, err := c.api.state.Service(args.ServiceName)
+	service, err := c.api.stateAccessor.Service(args.ServiceName)
 	if err != nil {
 		return params.StringResult{}, err
 	}

--- a/apiserver/client/run.go
+++ b/apiserver/client/run.go
@@ -44,7 +44,7 @@ func remoteParamsForMachine(machine *state.Machine, command string, timeout time
 
 // getAllUnitNames returns a sequence of valid Unit objects from state. If any
 // of the service names or unit names are not found, an error is returned.
-func getAllUnitNames(st stateInterface, units, services []string) (result []*state.Unit, err error) {
+func getAllUnitNames(st *state.State, units, services []string) (result []*state.Unit, err error) {
 	unitsSet := set.NewStrings(units...)
 	for _, name := range services {
 		service, err := st.Service(name)
@@ -87,7 +87,7 @@ func (c *Client) Run(run params.RunParams) (results params.RunResults, err error
 	if err := c.check.ChangeAllowed(); err != nil {
 		return params.RunResults{}, errors.Trace(err)
 	}
-	units, err := getAllUnitNames(c.api.stateAccessor, run.Units, run.Services)
+	units, err := getAllUnitNames(c.api.state(), run.Units, run.Services)
 	if err != nil {
 		return results, err
 	}

--- a/apiserver/client/run.go
+++ b/apiserver/client/run.go
@@ -44,7 +44,7 @@ func remoteParamsForMachine(machine *state.Machine, command string, timeout time
 
 // getAllUnitNames returns a sequence of valid Unit objects from state. If any
 // of the service names or unit names are not found, an error is returned.
-func getAllUnitNames(st *state.State, units, services []string) (result []*state.Unit, err error) {
+func getAllUnitNames(st stateInterface, units, services []string) (result []*state.Unit, err error) {
 	unitsSet := set.NewStrings(units...)
 	for _, name := range services {
 		service, err := st.Service(name)
@@ -87,7 +87,7 @@ func (c *Client) Run(run params.RunParams) (results params.RunResults, err error
 	if err := c.check.ChangeAllowed(); err != nil {
 		return params.RunResults{}, errors.Trace(err)
 	}
-	units, err := getAllUnitNames(c.api.state, run.Units, run.Services)
+	units, err := getAllUnitNames(c.api.stateAccessor, run.Units, run.Services)
 	if err != nil {
 		return results, err
 	}
@@ -101,7 +101,7 @@ func (c *Client) Run(run params.RunParams) (results params.RunResults, err error
 		// We know that the unit is both a principal unit, and that it has an
 		// assigned machine.
 		machineId, _ := unit.AssignedMachineId()
-		machine, err := c.api.state.Machine(machineId)
+		machine, err := c.api.stateAccessor.Machine(machineId)
 		if err != nil {
 			return results, err
 		}
@@ -111,7 +111,7 @@ func (c *Client) Run(run params.RunParams) (results params.RunResults, err error
 		params = append(params, execParam)
 	}
 	for _, machineId := range run.Machines {
-		machine, err := c.api.state.Machine(machineId)
+		machine, err := c.api.stateAccessor.Machine(machineId)
 		if err != nil {
 			return results, err
 		}
@@ -127,7 +127,7 @@ func (c *Client) RunOnAllMachines(run params.RunParams) (params.RunResults, erro
 	if err := c.check.ChangeAllowed(); err != nil {
 		return params.RunResults{}, errors.Trace(err)
 	}
-	machines, err := c.api.state.AllMachines()
+	machines, err := c.api.stateAccessor.AllMachines()
 	if err != nil {
 		return params.RunResults{}, err
 	}

--- a/apiserver/client/run_test.go
+++ b/apiserver/client/run_test.go
@@ -145,7 +145,7 @@ func (s *runSuite) TestGetAllUnitNames(c *gc.C) {
 		expected: []string{"magic/0", "magic/1"},
 	}} {
 		c.Logf("%v: %s", i, test.message)
-		result, err := client.GetAllUnitNames(s.State, test.units, test.services)
+		result, err := client.GetAllUnitNames(client.GetState(s.State), test.units, test.services)
 		if test.error == "" {
 			c.Check(err, jc.ErrorIsNil)
 			var units []string

--- a/apiserver/client/run_test.go
+++ b/apiserver/client/run_test.go
@@ -145,7 +145,7 @@ func (s *runSuite) TestGetAllUnitNames(c *gc.C) {
 		expected: []string{"magic/0", "magic/1"},
 	}} {
 		c.Logf("%v: %s", i, test.message)
-		result, err := client.GetAllUnitNames(client.GetState(s.State), test.units, test.services)
+		result, err := client.GetAllUnitNames(s.State, test.units, test.services)
 		if test.error == "" {
 			c.Check(err, jc.ErrorIsNil)
 			var units []string

--- a/apiserver/client/state.go
+++ b/apiserver/client/state.go
@@ -1,0 +1,80 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package client
+
+import (
+	"github.com/juju/names"
+	"gopkg.in/juju/charm.v5"
+
+	"github.com/juju/juju/constraints"
+	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/instance"
+	"github.com/juju/juju/network"
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/version"
+)
+
+// HistoricalUnit represents a state.Unit instance that
+// can fetch its status history.
+type HistoricalUnit interface {
+	state.StatusHistoryGetter
+	AgentHistoryGetter() state.StatusHistoryGetter
+}
+
+// stateInterface contains the state.State methods used in this package,
+// allowing stubs to ve created for testing.
+type stateInterface interface {
+	FindEntity(names.Tag) (state.Entity, error)
+	Unit(string) (*state.Unit, error)
+	HistoricalUnit(string) (HistoricalUnit, error)
+	Service(string) (*state.Service, error)
+	Machine(string) (*state.Machine, error)
+	AllMachines() ([]*state.Machine, error)
+	AllServices() ([]*state.Service, error)
+	AllRelations() ([]*state.Relation, error)
+	AllNetworks() ([]*state.Network, error)
+	AddOneMachine(state.MachineTemplate) (*state.Machine, error)
+	AddMachineInsideMachine(state.MachineTemplate, string, instance.ContainerType) (*state.Machine, error)
+	AddMachineInsideNewMachine(template, parentTemplate state.MachineTemplate, containerType instance.ContainerType) (*state.Machine, error)
+	EnvironConstraints() (constraints.Value, error)
+	EnvironConfig() (*config.Config, error)
+	UpdateEnvironConfig(map[string]interface{}, []string, state.ValidateConfigFunc) error
+	SetEnvironConstraints(constraints.Value) error
+	EnvironUUID() string
+	EnvironTag() names.EnvironTag
+	Environment() (*state.Environment, error)
+	SetEnvironAgentVersion(version.Number) error
+	SetAnnotations(state.GlobalEntity, map[string]string) error
+	Annotations(state.GlobalEntity) (map[string]string, error)
+	InferEndpoints(...string) ([]state.Endpoint, error)
+	EndpointsRelation(...state.Endpoint) (*state.Relation, error)
+	Charm(*charm.URL) (*state.Charm, error)
+	LatestPlaceholderCharm(*charm.URL) (*state.Charm, error)
+	AddRelation(...state.Endpoint) (*state.Relation, error)
+	AddEnvironmentUser(user, createdBy names.UserTag, displayName string) (*state.EnvironmentUser, error)
+	RemoveEnvironmentUser(names.UserTag) error
+	Watch() *state.Multiwatcher
+	AbortCurrentUpgrade() error
+	APIHostPorts() ([][]network.HostPort, error)
+}
+
+type stateShim struct {
+	*state.State
+}
+
+func (s *stateShim) HistoricalUnit(name string) (HistoricalUnit, error) {
+	u, err := s.Unit(name)
+	if err != nil {
+		return nil, err
+	}
+	return &historicalUnit{u}, nil
+}
+
+type historicalUnit struct {
+	*state.Unit
+}
+
+func (h *historicalUnit) AgentHistoryGetter() state.StatusHistoryGetter {
+	return h.Agent()
+}

--- a/apiserver/client/status.go
+++ b/apiserver/client/status.go
@@ -53,7 +53,7 @@ func (c *Client) UnitStatusHistory(args params.StatusHistory) (params.UnitStatus
 	if args.Size < 1 {
 		return params.UnitStatusHistory{}, errors.Errorf("invalid history size: %d", args.Size)
 	}
-	unit, err := c.api.stateAccessor.HistoricalUnit(args.Name)
+	unit, err := c.api.stateAccessor.Unit(args.Name)
 	if err != nil {
 		return params.UnitStatusHistory{}, errors.Trace(err)
 	}
@@ -66,8 +66,7 @@ func (c *Client) UnitStatusHistory(args params.StatusHistory) (params.UnitStatus
 		statuses.Statuses = append(statuses.Statuses, agentStatusFromStatusInfo(unitStatuses, params.KindWorkload)...)
 	}
 	if args.Kind == params.KindCombined || args.Kind == params.KindAgent {
-		agent := unit.AgentHistoryGetter()
-		agentStatuses, err := agent.StatusHistory(args.Size)
+		agentStatuses, err := unit.AgentHistory().StatusHistory(args.Size)
 		if err != nil {
 			return params.UnitStatusHistory{}, errors.Trace(err)
 		}

--- a/apiserver/client/status.go
+++ b/apiserver/client/status.go
@@ -48,45 +48,29 @@ func (s sortableStatuses) Less(i, j int) bool {
 	return s[i].Since.Before(*s[j].Since)
 }
 
-// TODO(perrito666) this client method requires more testing, only its parts are unittested.
 // UnitStatusHistory returns a slice of past statuses for a given unit.
 func (c *Client) UnitStatusHistory(args params.StatusHistory) (params.UnitStatusHistory, error) {
-	size := args.Size - 1
-	if size < 1 {
+	if args.Size < 1 {
 		return params.UnitStatusHistory{}, errors.Errorf("invalid history size: %d", args.Size)
 	}
-	unit, err := c.api.state.Unit(args.Name)
+	unit, err := c.api.stateAccessor.HistoricalUnit(args.Name)
 	if err != nil {
 		return params.UnitStatusHistory{}, errors.Trace(err)
 	}
 	statuses := params.UnitStatusHistory{}
 	if args.Kind == params.KindCombined || args.Kind == params.KindWorkload {
-		unitStatuses, err := unit.StatusHistory(size)
+		unitStatuses, err := unit.StatusHistory(args.Size)
 		if err != nil {
 			return params.UnitStatusHistory{}, errors.Trace(err)
 		}
-
-		current, err := unit.Status()
-		if err != nil {
-			return params.UnitStatusHistory{}, errors.Trace(err)
-		}
-		unitStatuses = append(unitStatuses, current)
-
 		statuses.Statuses = append(statuses.Statuses, agentStatusFromStatusInfo(unitStatuses, params.KindWorkload)...)
 	}
 	if args.Kind == params.KindCombined || args.Kind == params.KindAgent {
-		agent := unit.Agent()
-		agentStatuses, err := agent.StatusHistory(size)
+		agent := unit.AgentHistoryGetter()
+		agentStatuses, err := agent.StatusHistory(args.Size)
 		if err != nil {
 			return params.UnitStatusHistory{}, errors.Trace(err)
 		}
-
-		current, err := agent.Status()
-		if err != nil {
-			return params.UnitStatusHistory{}, errors.Trace(err)
-		}
-		agentStatuses = append(agentStatuses, current)
-
 		statuses.Statuses = append(statuses.Statuses, agentStatusFromStatusInfo(agentStatuses, params.KindAgent)...)
 	}
 
@@ -103,20 +87,20 @@ func (c *Client) UnitStatusHistory(args params.StatusHistory) (params.UnitStatus
 
 // FullStatus gives the information needed for juju status over the api
 func (c *Client) FullStatus(args params.StatusParams) (params.FullStatus, error) {
-	cfg, err := c.api.state.EnvironConfig()
+	cfg, err := c.api.stateAccessor.EnvironConfig()
 	if err != nil {
 		return params.FullStatus{}, errors.Annotate(err, "could not get environ config")
 	}
 	var noStatus params.FullStatus
 	var context statusContext
 	if context.services, context.units, context.latestCharms, err =
-		fetchAllServicesAndUnits(c.api.state, len(args.Patterns) <= 0); err != nil {
+		fetchAllServicesAndUnits(c.api.stateAccessor, len(args.Patterns) <= 0); err != nil {
 		return noStatus, errors.Annotate(err, "could not fetch services and units")
-	} else if context.machines, err = fetchMachines(c.api.state, nil); err != nil {
+	} else if context.machines, err = fetchMachines(c.api.stateAccessor, nil); err != nil {
 		return noStatus, errors.Annotate(err, "could not fetch machines")
-	} else if context.relations, err = fetchRelations(c.api.state); err != nil {
+	} else if context.relations, err = fetchRelations(c.api.stateAccessor); err != nil {
 		return noStatus, errors.Annotate(err, "could not fetch relations")
-	} else if context.networks, err = fetchNetworks(c.api.state); err != nil {
+	} else if context.networks, err = fetchNetworks(c.api.stateAccessor); err != nil {
 		return noStatus, errors.Annotate(err, "could not fetch networks")
 	}
 
@@ -235,7 +219,7 @@ type statusContext struct {
 // machine and machines[1..n] are any containers (including nested ones).
 //
 // If machineIds is non-nil, only machines whose IDs are in the set are returned.
-func fetchMachines(st *state.State, machineIds set.Strings) (map[string][]*state.Machine, error) {
+func fetchMachines(st stateInterface, machineIds set.Strings) (map[string][]*state.Machine, error) {
 	v := make(map[string][]*state.Machine)
 	machines, err := st.AllMachines()
 	if err != nil {
@@ -266,7 +250,7 @@ func fetchMachines(st *state.State, machineIds set.Strings) (map[string][]*state
 // fetchAllServicesAndUnits returns a map from service name to service,
 // a map from service name to unit name to unit, and a map from base charm URL to latest URL.
 func fetchAllServicesAndUnits(
-	st *state.State,
+	st stateInterface,
 	matchAny bool,
 ) (map[string]*state.Service, map[string]map[string]*state.Unit, map[charm.URL]string, error) {
 
@@ -338,7 +322,7 @@ func fetchUnitMachineIds(units map[string]map[string]*state.Unit) (set.Strings, 
 // to have the relations for each service. Reading them once here
 // avoids the repeated DB hits to retrieve the relations for each
 // service that used to happen in processServiceRelations().
-func fetchRelations(st *state.State) (map[string][]*state.Relation, error) {
+func fetchRelations(st stateInterface) (map[string][]*state.Relation, error) {
 	relations, err := st.AllRelations()
 	if err != nil {
 		return nil, err
@@ -353,7 +337,7 @@ func fetchRelations(st *state.State) (map[string][]*state.Relation, error) {
 }
 
 // fetchNetworks returns a map from network name to network.
-func fetchNetworks(st *state.State) (map[string]*state.Network, error) {
+func fetchNetworks(st stateInterface) (map[string]*state.Network, error) {
 	networks, err := st.AllNetworks()
 	if err != nil {
 		return nil, err

--- a/apiserver/client/statushistory_test.go
+++ b/apiserver/client/statushistory_test.go
@@ -1,0 +1,217 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package client_test
+
+import (
+	"time"
+
+	"github.com/juju/errors"
+	"github.com/juju/names"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/client"
+	"github.com/juju/juju/apiserver/params"
+	apiservertesting "github.com/juju/juju/apiserver/testing"
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/testing"
+)
+
+var _ = gc.Suite(&statusHistoryTestSuite{})
+
+type statusHistoryTestSuite struct {
+	testing.BaseSuite
+	st  *mockState
+	api *client.Client
+}
+
+func (s *statusHistoryTestSuite) SetUpTest(c *gc.C) {
+	s.st = &mockState{}
+	client.PatchState(s, s.st)
+	tag := names.NewUserTag("user")
+	authorizer := &apiservertesting.FakeAuthorizer{Tag: tag}
+	var err error
+	s.api, err = client.NewClient(nil, nil, authorizer)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func statusInfoWithDates(si []state.StatusInfo) []state.StatusInfo {
+	// Add timestamps to input status info records.
+	// Timestamps will be in descending order so that we can
+	// check that sorting has occurred and the output should
+	// be in ascending order.
+	result := make([]state.StatusInfo, len(si))
+	for i, s := range si {
+		t := time.Unix(int64(1000-i), 0)
+		s.Since = &t
+		result[i] = s
+	}
+	return result
+}
+
+func reverseStatusInfo(si []state.StatusInfo) []state.StatusInfo {
+	result := make([]state.StatusInfo, len(si))
+	for i, s := range si {
+		result[len(si)-i-1] = s
+	}
+	return result
+}
+
+func checkStatusInfo(c *gc.C, obtained []params.AgentStatus, expected []state.StatusInfo) {
+	c.Assert(len(obtained), gc.Equals, len(expected))
+	lastTimestamp := int64(0)
+	for i, obtainedInfo := range obtained {
+		thisTimeStamp := obtainedInfo.Since.Unix()
+		c.Assert(thisTimeStamp >= lastTimestamp, jc.IsTrue)
+		lastTimestamp = thisTimeStamp
+		obtainedInfo.Since = nil
+		c.Assert(obtainedInfo.Status, gc.Equals, params.Status(expected[i].Status))
+		c.Assert(obtainedInfo.Info, gc.Equals, expected[i].Message)
+	}
+}
+
+func (s *statusHistoryTestSuite) TestSizeRequired(c *gc.C) {
+	_, err := s.api.UnitStatusHistory(params.StatusHistory{
+		Name: "unit",
+		Kind: params.KindCombined,
+		Size: 0,
+	})
+	c.Assert(err, gc.ErrorMatches, "invalid history size: 0")
+}
+
+func (s *statusHistoryTestSuite) TestStatusHistoryUnitOnly(c *gc.C) {
+	s.st.unitHistory = statusInfoWithDates([]state.StatusInfo{
+		{
+			Status:  state.StatusMaintenance,
+			Message: "working",
+		},
+		{
+			Status:  state.StatusActive,
+			Message: "running",
+		},
+	})
+	s.st.agentHistory = statusInfoWithDates([]state.StatusInfo{
+		{
+			Status: state.StatusIdle,
+		},
+	})
+	h, err := s.api.UnitStatusHistory(params.StatusHistory{
+		Name: "unit/0",
+		Kind: params.KindWorkload,
+		Size: 10,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	checkStatusInfo(c, h.Statuses, reverseStatusInfo(s.st.unitHistory))
+}
+
+func (s *statusHistoryTestSuite) TestStatusHistoryAgentOnly(c *gc.C) {
+	s.st.unitHistory = statusInfoWithDates([]state.StatusInfo{
+		{
+			Status:  state.StatusMaintenance,
+			Message: "working",
+		},
+		{
+			Status:  state.StatusActive,
+			Message: "running",
+		},
+	})
+	s.st.agentHistory = statusInfoWithDates([]state.StatusInfo{
+		{
+			Status: state.StatusExecuting,
+		},
+		{
+			Status: state.StatusIdle,
+		},
+	})
+	h, err := s.api.UnitStatusHistory(params.StatusHistory{
+		Name: "unit/0",
+		Kind: params.KindAgent,
+		Size: 10,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	checkStatusInfo(c, h.Statuses, reverseStatusInfo(s.st.agentHistory))
+}
+
+func (s *statusHistoryTestSuite) TestStatusHistoryCombined(c *gc.C) {
+	s.st.unitHistory = statusInfoWithDates([]state.StatusInfo{
+		{
+			Status:  state.StatusMaintenance,
+			Message: "working",
+		},
+		{
+			Status:  state.StatusActive,
+			Message: "running",
+		},
+		{
+			Status:  state.StatusBlocked,
+			Message: "waiting",
+		},
+	})
+	s.st.agentHistory = statusInfoWithDates([]state.StatusInfo{
+		{
+			Status: state.StatusExecuting,
+		},
+		{
+			Status: state.StatusIdle,
+		},
+	})
+	h, err := s.api.UnitStatusHistory(params.StatusHistory{
+		Name: "unit/0",
+		Kind: params.KindCombined,
+		Size: 3,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	expected := make([]state.StatusInfo, 3)
+	expected[0] = s.st.agentHistory[1]
+	expected[1] = s.st.unitHistory[0]
+	expected[2] = s.st.agentHistory[0]
+	checkStatusInfo(c, h.Statuses, expected)
+}
+
+type mockState struct {
+	client.StateInterface
+	unitHistory  []state.StatusInfo
+	agentHistory []state.StatusInfo
+}
+
+func (m *mockState) EnvironUUID() string {
+	return "uuid"
+}
+
+func (m *mockState) HistoricalUnit(name string) (client.HistoricalUnit, error) {
+	if name != "unit/0" {
+		return nil, errors.NotFoundf("%v", name)
+	}
+	return &mockUnit{
+		m.unitHistory,
+		&mockUnitAgent{m.agentHistory},
+	}, nil
+}
+
+type mockUnit struct {
+	history []state.StatusInfo
+	agent   *mockUnitAgent
+}
+
+func (m *mockUnit) StatusHistory(size int) ([]state.StatusInfo, error) {
+	if size > len(m.history) {
+		size = len(m.history)
+	}
+	return m.history[:size], nil
+}
+
+func (m *mockUnit) AgentHistoryGetter() state.StatusHistoryGetter {
+	return m.agent
+}
+
+type mockUnitAgent struct {
+	history []state.StatusInfo
+}
+
+func (m *mockUnitAgent) StatusHistory(size int) ([]state.StatusInfo, error) {
+	if size > len(m.history) {
+		size = len(m.history)
+	}
+	return m.history[:size], nil
+}

--- a/state/status_model.go
+++ b/state/status_model.go
@@ -33,6 +33,11 @@ type StatusGetter interface {
 	Status() (StatusInfo, error)
 }
 
+// StatusHistoryGetter instances can fetch their status history.
+type StatusHistoryGetter interface {
+	StatusHistory(size int) ([]StatusInfo, error)
+}
+
 // Status values common to machine and unit agents.
 const (
 

--- a/state/unit.go
+++ b/state/unit.go
@@ -794,6 +794,12 @@ func (u *Unit) Agent() *UnitAgent {
 	return newUnitAgent(u.st, u.Tag(), u.Name())
 }
 
+// AgentHistory returns an StatusHistoryGetter which can
+//be used to query the status history of the unit's agent.
+func (u *Unit) AgentHistory() StatusHistoryGetter {
+	return u.Agent()
+}
+
 // SetAgentStatus calls SetStatus for this unit's agent, this call
 // is equivalent to the former call to SetStatus when Agent and Unit
 // where not separate entities.

--- a/state/unit.go
+++ b/state/unit.go
@@ -112,6 +112,7 @@ type Unit struct {
 	st  *State
 	doc unitDoc
 	presence.Presencer
+	StatusHistoryGetter
 }
 
 func newUnit(st *State, udoc *unitDoc) *Unit {

--- a/state/unitagent.go
+++ b/state/unitagent.go
@@ -13,6 +13,7 @@ type UnitAgent struct {
 	st   *State
 	tag  names.Tag
 	name string
+	StatusHistoryGetter
 }
 
 func newUnitAgent(st *State, tag names.Tag, name string) *UnitAgent {

--- a/worker/uniter/operation/runhook.go
+++ b/worker/uniter/operation/runhook.go
@@ -168,6 +168,7 @@ func (rh *runHook) afterHook(state State) (bool, error) {
 		if hasRunStatusSet {
 			break
 		}
+		logger.Debugf("unit %v has started but has not yet set status", ctx.UnitName())
 		// We've finished the start hook and the charm has not updated its
 		// own status so we'll set it to unknown.
 		err = rh.runner.Context().SetUnitStatus(jujuc.StatusInfo{

--- a/worker/uniter/operation/util_test.go
+++ b/worker/uniter/operation/util_test.go
@@ -313,6 +313,10 @@ func (mock *MockContext) SetUnitStatus(status jujuc.StatusInfo) error {
 	return nil
 }
 
+func (mock *MockContext) UnitName() string {
+	return "unit/0"
+}
+
 func (mock *MockContext) UnitStatus() (*jujuc.StatusInfo, error) {
 	return &mock.status, nil
 }


### PR DESCRIPTION
Status history was showing duplicates for the most recent history items for workload and agents. It was due to a refactoring done to unit/service status outside the maltese-falcon branch. 

This fix repairs the problem and also does some refactroring to how the client apiserver instance uses state to allow some unit tests to be added (without perpetuating the use of JujuConnSuite). This also means that in the future, exiting unit tests can be ported across.

(Review request: http://reviews.vapour.ws/r/2599/)