### PR TITLE
Win10 support

### DIFF
--- a/version/supportedseries.go
+++ b/version/supportedseries.go
@@ -56,6 +56,7 @@ var seriesVersions = map[string]string{
 	"win7":        "win7",
 	"win8":        "win8",
 	"win81":       "win81",
+	"win10":       "win10",
 	"centos7":     "centos7",
 }
 
@@ -88,6 +89,7 @@ var windowsVersionMatchOrder = []string{
 	"Windows 7",
 	"Windows 8.1",
 	"Windows 8",
+	"Windows 10",
 }
 
 // windowsVersions is a mapping consisting of the output from
@@ -102,6 +104,7 @@ var windowsVersions = map[string]string{
 	"Windows 7":                      "win7",
 	"Windows 8.1":                    "win81",
 	"Windows 8":                      "win8",
+	"Windows 10":                     "win10",
 }
 
 var distroInfo = "/usr/share/distro-info/ubuntu.csv"

--- a/version/supportedseries_windows_test.go
+++ b/version/supportedseries_windows_test.go
@@ -41,6 +41,7 @@ func (s *supportedSeriesWindowsSuite) TestSupportedSeries(c *gc.C) {
 		"trusty",
 		"utopic",
 		"vivid",
+		"win10",
 		"win2012",
 		"win2012hv",
 		"win2012hvr2",


### PR DESCRIPTION
Add win 10 support in 1.24 as well.

Fixes https://github.com/juju/juju/issues/3179

(Review request: http://reviews.vapour.ws/r/2602/)