### PR TITLE
Fix Bug 1493016

### DIFF
--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -1593,6 +1593,9 @@ func MigrateLastLoginAndLastConnection(st *State) error {
 	var lastConnectionDocs []interface{}
 
 	for _, oldUser := range oldUserDocs {
+		if oldUser.LastLogin == nil {
+			continue
+		}
 		lastLoginDocs = append(lastLoginDocs, userLastLoginDoc{
 			oldUser.DocID,
 			oldUser.EnvUUID,
@@ -1601,6 +1604,9 @@ func MigrateLastLoginAndLastConnection(st *State) error {
 	}
 
 	for _, oldEnvUser := range oldEnvUserDocs {
+		if oldEnvUser.LastConnection == nil {
+			continue
+		}
 		lastConnectionDocs = append(lastConnectionDocs, envUserLastConnectionDoc{
 			oldEnvUser.DocID,
 			oldEnvUser.EnvUUID,

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -3228,31 +3228,49 @@ func (s *upgradesSuite) removeEnvCountDoc(c *gc.C) {
 
 func (s *upgradesSuite) TestMigrateLastLoginAndLastConnection(c *gc.C) {
 	t := time.Now().Round(time.Second)
-	user := names.NewUserTag("foobar")
+	fooUser := names.NewUserTag("foobar")
+	barUser := names.NewUserTag("barfoo")
 
-	s.addUsersForLastLoginAndConnection(c, t, user)
+	s.addUsersForLastLoginAndConnection(c, &t, fooUser)
+	s.addUsersForLastLoginAndConnection(c, nil, barUser)
 
 	err := MigrateLastLoginAndLastConnection(s.state)
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.assertLastLoginAndConnectionMigration(c, t, user)
+	s.assertLastLoginAndConnectionMigration(c, t, fooUser)
+
+	// assert that no documents were added for a user who has never logged in
+	// or connected.
+	_, err = s.getDocMap(c, barUser.Id(), "userLastLogin")
+	c.Assert(err, gc.Equals, mgo.ErrNotFound)
+	_, err = s.getDocMap(c, envUserID(barUser), "envUserLastConnection")
+	c.Assert(err, gc.Equals, mgo.ErrNotFound)
 }
 
 func (s *upgradesSuite) TestMigrateLastLoginAndLastConnectionIdempotent(c *gc.C) {
 	t := time.Now().Round(time.Second)
-	user := names.NewUserTag("foobar")
+	fooUser := names.NewUserTag("foobar")
+	barUser := names.NewUserTag("barfoo")
 
-	s.addUsersForLastLoginAndConnection(c, t, user)
+	s.addUsersForLastLoginAndConnection(c, &t, fooUser)
+	s.addUsersForLastLoginAndConnection(c, nil, barUser)
 
 	err := MigrateLastLoginAndLastConnection(s.state)
 	c.Assert(err, jc.ErrorIsNil)
 	err = MigrateLastLoginAndLastConnection(s.state)
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.assertLastLoginAndConnectionMigration(c, t, user)
+	s.assertLastLoginAndConnectionMigration(c, t, fooUser)
+
+	// assert that no documents were added for a user who has never logged in
+	// or connected.
+	_, err = s.getDocMap(c, barUser.Id(), "userLastLogin")
+	c.Assert(err, gc.Equals, mgo.ErrNotFound)
+	_, err = s.getDocMap(c, envUserID(barUser), "envUserLastConnection")
+	c.Assert(err, gc.Equals, mgo.ErrNotFound)
 }
 
-func (s *upgradesSuite) addUsersForLastLoginAndConnection(c *gc.C, t time.Time, user names.UserTag) {
+func (s *upgradesSuite) addUsersForLastLoginAndConnection(c *gc.C, t *time.Time, user names.UserTag) {
 	userID := user.Id()
 	oldEnvUserID := envUserID(user)
 
@@ -3301,17 +3319,20 @@ func (s *upgradesSuite) assertLastLoginAndConnectionMigration(c *gc.C, t time.Ti
 	oldEnvUserID := envUserID(user)
 
 	// check to see if lastlogin field is removed
-	userMap := s.getDocMap(c, userID, "users")
+	userMap, err := s.getDocMap(c, userID, "users")
+	c.Assert(err, jc.ErrorIsNil)
 	_, keyExists := userMap["lastlogin"]
 	c.Assert(keyExists, jc.IsFalse)
 
 	// check to see if lastconnection field is removed
-	envUserMap := s.getDocMap(c, oldEnvUserID, "envusers")
+	envUserMap, err := s.getDocMap(c, oldEnvUserID, "envusers")
+	c.Assert(err, jc.ErrorIsNil)
 	_, keyExists = envUserMap["lastconnection"]
 	c.Assert(keyExists, jc.IsFalse)
 
 	// check to see if lastlogin doc is added
-	lastLoginMap := s.getDocMap(c, userID, "userLastLogin")
+	lastLoginMap, err := s.getDocMap(c, userID, "userLastLogin")
+	c.Assert(err, jc.ErrorIsNil)
 	lastLogin, keyExists := lastLoginMap["last-login"]
 	c.Assert(keyExists, jc.IsTrue)
 	c.Assert(lastLogin.(time.Time).UTC(), gc.Equals, t.UTC())
@@ -3320,7 +3341,8 @@ func (s *upgradesSuite) assertLastLoginAndConnectionMigration(c *gc.C, t time.Ti
 	c.Assert(envUUID, gc.Equals, "envuuid456")
 
 	// check to see if lastconnection doc is added
-	lastConnMap := s.getDocMap(c, oldEnvUserID, "envUserLastConnection")
+	lastConnMap, err := s.getDocMap(c, oldEnvUserID, "envUserLastConnection")
+	c.Assert(err, jc.ErrorIsNil)
 	lastConn, keyExists := lastConnMap["last-connection"]
 	c.Assert(keyExists, jc.IsTrue)
 	c.Assert(lastConn.(time.Time).UTC(), gc.Equals, t.UTC())
@@ -3332,13 +3354,12 @@ func (s *upgradesSuite) assertLastLoginAndConnectionMigration(c *gc.C, t time.Ti
 	c.Assert(username, gc.Equals, "username@local")
 }
 
-func (s *upgradesSuite) getDocMap(c *gc.C, docID, collection string) map[string]interface{} {
+func (s *upgradesSuite) getDocMap(c *gc.C, docID, collection string) (map[string]interface{}, error) {
 	docMap := map[string]interface{}{}
 	coll, closer := s.state.getRawCollection(collection)
 	defer closer()
 	err := coll.Find(bson.D{{"_id", docID}}).One(&docMap)
-	c.Assert(err, jc.ErrorIsNil)
-	return docMap
+	return docMap, err
 }
 
 func (s *upgradesSuite) TestAddMissingEnvUUIDOnStatuses(c *gc.C) {


### PR DESCRIPTION
Check that LastLogin and LastConnection are not nil before attempting
to insert lastLogin / lastConnection docs for the user.
    
Manually tested on a trusty VM. Successfully upgraded from 1.22.6 to
1.26-alpha1.1

(Review request: http://reviews.vapour.ws/r/2603/)