### PR TITLE
Forward port of issue 1435283

### DIFF
--- a/apiserver/client/client.go
+++ b/apiserver/client/client.go
@@ -173,24 +173,30 @@ func (c *Client) PublicAddress(p params.PublicAddress) (results params.PublicAdd
 		if err != nil {
 			return results, err
 		}
-		addr := network.SelectPublicAddress(machine.Addresses())
-		if addr == "" {
-			return results, fmt.Errorf("machine %q has no public address", machine)
+		addr, err := machine.PublicAddress()
+		if err != nil {
+			return results, errors.Annotatef(err, "machine %q has no public address", machine)
 		}
-		return params.PublicAddressResults{PublicAddress: addr}, nil
+		if addr.Value == "" {
+			return results, errors.Errorf("machine %q has no public address", machine)
+		}
+		return params.PublicAddressResults{PublicAddress: addr.Value}, nil
 
 	case names.IsValidUnit(p.Target):
 		unit, err := c.api.state.Unit(p.Target)
 		if err != nil {
 			return results, err
 		}
-		addr, ok := unit.PublicAddress()
-		if !ok {
-			return results, fmt.Errorf("unit %q has no public address", unit)
+		addr, err := unit.PublicAddress()
+		if err != nil {
+			return results, errors.Annotatef(err, "unit %q has no public address", unit)
 		}
-		return params.PublicAddressResults{PublicAddress: addr}, nil
+		if addr.Value == "" {
+			return results, errors.Errorf("unit %q has no public address", unit)
+		}
+		return params.PublicAddressResults{PublicAddress: addr.Value}, nil
 	}
-	return results, fmt.Errorf("unknown unit or machine %q", p.Target)
+	return results, errors.Errorf("unknown unit or machine %q", p.Target)
 }
 
 // PrivateAddress implements the server side of Client.PrivateAddress.
@@ -201,22 +207,28 @@ func (c *Client) PrivateAddress(p params.PrivateAddress) (results params.Private
 		if err != nil {
 			return results, err
 		}
-		addr := network.SelectInternalAddress(machine.Addresses(), false)
-		if addr == "" {
-			return results, fmt.Errorf("machine %q has no internal address", machine)
+		addr, err := machine.PrivateAddress()
+		if err != nil {
+			return results, errors.Annotatef(err, "machine %q has no internal address", machine)
 		}
-		return params.PrivateAddressResults{PrivateAddress: addr}, nil
+		if addr.Value == "" {
+			return results, errors.Errorf("machine %q has no internal address", machine)
+		}
+		return params.PrivateAddressResults{PrivateAddress: addr.Value}, nil
 
 	case names.IsValidUnit(p.Target):
 		unit, err := c.api.state.Unit(p.Target)
 		if err != nil {
 			return results, err
 		}
-		addr, ok := unit.PrivateAddress()
-		if !ok {
-			return results, fmt.Errorf("unit %q has no internal address", unit)
+		addr, err := unit.PrivateAddress()
+		if err != nil {
+			return results, errors.Annotatef(err, "unit %q has no internal address", unit)
 		}
-		return params.PrivateAddressResults{PrivateAddress: addr}, nil
+		if addr.Value == "" {
+			return results, errors.Errorf("unit %q has no internal address", unit)
+		}
+		return params.PrivateAddressResults{PrivateAddress: addr.Value}, nil
 	}
 	return results, fmt.Errorf("unknown unit or machine %q", p.Target)
 }

--- a/apiserver/client/client_test.go
+++ b/apiserver/client/client_test.go
@@ -2582,6 +2582,7 @@ func (s *clientSuite) TestClientPublicAddressErrors(c *gc.C) {
 
 func (s *clientSuite) TestClientPublicAddressMachine(c *gc.C) {
 	s.setUpScenario(c)
+	network.ResetGlobalPreferIPv6()
 
 	// Internally, network.SelectPublicAddress is used; the "most public"
 	// address is returned.
@@ -2624,6 +2625,7 @@ func (s *clientSuite) TestClientPrivateAddressErrors(c *gc.C) {
 
 func (s *clientSuite) TestClientPrivateAddress(c *gc.C) {
 	s.setUpScenario(c)
+	network.ResetGlobalPreferIPv6()
 
 	// Internally, network.SelectInternalAddress is used; the public
 	// address if no cloud-local one is available.

--- a/apiserver/client/filtering.go
+++ b/apiserver/client/filtering.go
@@ -166,12 +166,18 @@ func unitMatchExposure(u *state.Unit, patterns []string) (bool, bool, error) {
 }
 
 func unitMatchSubnet(u *state.Unit, patterns []string) (bool, bool, error) {
-	pub, pubOK := u.PublicAddress()
-	priv, privOK := u.PrivateAddress()
-	if !pubOK && !privOK {
+	pub, err := u.PublicAddress()
+	if err != nil {
+		return true, false, errors.Trace(err)
+	}
+	priv, err := u.PrivateAddress()
+	if err != nil {
+		return true, false, errors.Trace(err)
+	}
+	if pub.Value == "" && priv.Value == "" {
 		return true, false, nil
 	}
-	return matchSubnet(patterns, pub, priv)
+	return matchSubnet(patterns, pub.Value, priv.Value)
 }
 
 func unitMatchPort(u *state.Unit, patterns []string) (bool, bool, error) {

--- a/apiserver/client/run.go
+++ b/apiserver/client/run.go
@@ -28,7 +28,7 @@ import (
 // by the function that actually tries to execute the command.
 func remoteParamsForMachine(machine *state.Machine, command string, timeout time.Duration) *RemoteExec {
 	// magic boolean parameters are bad :-(
-	address := network.SelectInternalAddress(machine.Addresses(), false)
+	address := network.SelectInternalAddress(machine.Addresses(), false).Value
 	execParams := &RemoteExec{
 		ExecParams: ssh.ExecParams{
 			Command: command,

--- a/apiserver/uniter/uniter_base.go
+++ b/apiserver/uniter/uniter_base.go
@@ -137,9 +137,9 @@ func (u *uniterBaseAPI) PublicAddress(args params.Entities) (params.StringResult
 			var unit *state.Unit
 			unit, err = u.getUnit(tag)
 			if err == nil {
-				address, ok := unit.PublicAddress()
-				if ok {
-					result.Results[i].Result = address
+				address, addrErr := unit.PublicAddress()
+				if addrErr == nil && address.Value != "" {
+					result.Results[i].Result = address.Value
 				} else {
 					err = common.NoAddressSetError(tag, "public")
 				}
@@ -170,9 +170,9 @@ func (u *uniterBaseAPI) PrivateAddress(args params.Entities) (params.StringResul
 			var unit *state.Unit
 			unit, err = u.getUnit(tag)
 			if err == nil {
-				address, ok := unit.PrivateAddress()
-				if ok {
-					result.Results[i].Result = address
+				address, addrErr := unit.PrivateAddress()
+				if addrErr == nil && address.Value != "" {
+					result.Results[i].Result = address.Value
 				} else {
 					err = common.NoAddressSetError(tag, "private")
 				}
@@ -1025,7 +1025,7 @@ func (u *uniterBaseAPI) EnterScope(args params.RelationUnits) (params.ErrorResul
 			// private address (we already know it).
 			privateAddress, _ := relUnit.PrivateAddress()
 			settings := map[string]interface{}{
-				"private-address": privateAddress,
+				"private-address": privateAddress.Value,
 			}
 			err = relUnit.EnterScope(settings)
 		}

--- a/apiserver/uniter/uniter_base_test.go
+++ b/apiserver/uniter/uniter_base_test.go
@@ -442,9 +442,9 @@ func (s *uniterBaseSuite) testPublicAddress(
 		network.NewScopedAddress("1.2.3.4", network.ScopePublic),
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	address, ok := s.wordpressUnit.PublicAddress()
-	c.Assert(address, gc.Equals, "1.2.3.4")
-	c.Assert(ok, jc.IsTrue)
+	address, err := s.wordpressUnit.PublicAddress()
+	c.Assert(address.Value, gc.Equals, "1.2.3.4")
+	c.Assert(err, jc.ErrorIsNil)
 
 	result, err = facade.PublicAddress(args)
 	c.Assert(err, jc.ErrorIsNil)
@@ -487,9 +487,9 @@ func (s *uniterBaseSuite) testPrivateAddress(
 		network.NewScopedAddress("1.2.3.4", network.ScopeCloudLocal),
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	address, ok := s.wordpressUnit.PrivateAddress()
-	c.Assert(address, gc.Equals, "1.2.3.4")
-	c.Assert(ok, jc.IsTrue)
+	address, err := s.wordpressUnit.PrivateAddress()
+	c.Assert(address.Value, gc.Equals, "1.2.3.4")
+	c.Assert(err, jc.ErrorIsNil)
 
 	result, err = facade.PrivateAddress(args)
 	c.Assert(err, jc.ErrorIsNil)

--- a/cmd/jujud/bootstrap_test.go
+++ b/cmd/jujud/bootstrap_test.go
@@ -668,7 +668,7 @@ func (s *BootstrapSuite) makeTestEnv(c *gc.C) {
 
 	addresses, err := inst.Addresses()
 	c.Assert(err, jc.ErrorIsNil)
-	s.bootstrapName = network.SelectPublicAddress(addresses)
+	s.bootstrapName = network.SelectPublicAddress(addresses).Value
 	s.envcfg = env.Config()
 	s.b64yamlEnvcfg = b64yaml(s.envcfg.AllAttrs()).encode()
 }

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -78,7 +78,7 @@ func IsMaster(session *mgo.Session, obj WithAddresses) (bool, error) {
 // SelectPeerAddress returns the address to use as the
 // mongo replica set peer address by selecting it from the given addresses.
 func SelectPeerAddress(addrs []network.Address) string {
-	return network.SelectInternalAddress(addrs, false)
+	return network.SelectInternalAddress(addrs, false).Value
 }
 
 // SelectPeerHostPort returns the HostPort to use as the

--- a/network/address.go
+++ b/network/address.go
@@ -29,10 +29,10 @@ var (
 // bootstrap, agent startup, before any CLI command).
 var globalPreferIPv6 bool = false
 
-// ResetGobalPreferIPv6 resets the global variable back to the default,
+// ResetGlobalPreferIPv6 resets the global variable back to the default,
 // and is called only from the isolation test suite to make sure we have
 // a clean environment.
-func ResetGobalPreferIPv6() {
+func ResetGlobalPreferIPv6() {
 	globalPreferIPv6 = false
 }
 
@@ -203,17 +203,32 @@ func deriveScope(addr Address) Scope {
 	return addr.Scope
 }
 
+// ExactScopeMatch checks if an address exactly matches any of the specified
+// scopes. An address will not match if globalPreferIPv6 is set and it isn't an
+// IPv6 address.
+func ExactScopeMatch(addr Address, addrScopes ...Scope) bool {
+	if globalPreferIPv6 && addr.Type != IPv6Address {
+		return false
+	}
+	for _, scope := range addrScopes {
+		if addr.Scope == scope {
+			return true
+		}
+	}
+	return false
+}
+
 // SelectPublicAddress picks one address from a slice that would be
 // appropriate to display as a publicly accessible endpoint. If there
-// are no suitable addresses, the empty string is returned.
-func SelectPublicAddress(addresses []Address) string {
+// are no suitable addresses, an empty address is returned.
+func SelectPublicAddress(addresses []Address) Address {
 	index := bestAddressIndex(len(addresses), globalPreferIPv6, func(i int) Address {
 		return addresses[i]
 	}, publicMatch)
 	if index < 0 {
-		return ""
+		return Address{}
 	}
-	return addresses[index].Value
+	return addresses[index]
 }
 
 // SelectPublicHostPort picks one HostPort from a slice that would be
@@ -231,15 +246,15 @@ func SelectPublicHostPort(hps []HostPort) string {
 
 // SelectInternalAddress picks one address from a slice that can be
 // used as an endpoint for juju internal communication. If there are
-// no suitable addresses, the empty string is returned.
-func SelectInternalAddress(addresses []Address, machineLocal bool) string {
+// no suitable addresses, an empty address is returned.
+func SelectInternalAddress(addresses []Address, machineLocal bool) Address {
 	index := bestAddressIndex(len(addresses), globalPreferIPv6, func(i int) Address {
 		return addresses[i]
 	}, internalAddressMatcher(machineLocal))
 	if index < 0 {
-		return ""
+		return Address{}
 	}
-	return addresses[index].Value
+	return addresses[index]
 }
 
 // SelectInternalHostPort picks one HostPort from a slice that can be

--- a/network/address_test.go
+++ b/network/address_test.go
@@ -216,11 +216,11 @@ type selectTest struct {
 }
 
 // expected returns the expected address for the test.
-func (t selectTest) expected() string {
+func (t selectTest) expected() network.Address {
 	if t.expectedIndex == -1 {
-		return ""
+		return network.Address{}
 	}
-	return t.addresses[t.expectedIndex].Value
+	return t.addresses[t.expectedIndex]
 }
 
 var selectPublicTests = []selectTest{{
@@ -738,4 +738,46 @@ func (*AddressSuite) TestDecimalToIPv4(c *gc.C) {
 
 	addr = network.DecimalToIPv4(uint32(3232235777))
 	c.Assert(addr.String(), gc.Equals, "192.168.1.1")
+}
+
+func (*AddressSuite) TestExactScopeMatch(c *gc.C) {
+	network.SetPreferIPv6(false)
+	addr := network.NewScopedAddress("10.0.0.2", network.ScopeCloudLocal)
+	match := network.ExactScopeMatch(addr, network.ScopeCloudLocal)
+	c.Assert(match, jc.IsTrue)
+	match = network.ExactScopeMatch(addr, network.ScopePublic)
+	c.Assert(match, jc.IsFalse)
+
+	addr = network.NewScopedAddress("8.8.8.8", network.ScopePublic)
+	match = network.ExactScopeMatch(addr, network.ScopeCloudLocal)
+	c.Assert(match, jc.IsFalse)
+	match = network.ExactScopeMatch(addr, network.ScopePublic)
+	c.Assert(match, jc.IsTrue)
+}
+
+func (*AddressSuite) TestExactScopeMatchHonoursPreferIPv6(c *gc.C) {
+	network.SetPreferIPv6(true)
+	addr := network.NewScopedAddress("10.0.0.2", network.ScopeCloudLocal)
+	match := network.ExactScopeMatch(addr, network.ScopeCloudLocal)
+	c.Assert(match, jc.IsFalse)
+	match = network.ExactScopeMatch(addr, network.ScopePublic)
+	c.Assert(match, jc.IsFalse)
+
+	addr = network.NewScopedAddress("8.8.8.8", network.ScopePublic)
+	match = network.ExactScopeMatch(addr, network.ScopeCloudLocal)
+	c.Assert(match, jc.IsFalse)
+	match = network.ExactScopeMatch(addr, network.ScopePublic)
+	c.Assert(match, jc.IsFalse)
+
+	addr = network.NewScopedAddress("2001:db8::ff00:42:8329", network.ScopePublic)
+	match = network.ExactScopeMatch(addr, network.ScopeCloudLocal)
+	c.Assert(match, jc.IsFalse)
+	match = network.ExactScopeMatch(addr, network.ScopePublic)
+	c.Assert(match, jc.IsTrue)
+
+	addr = network.NewScopedAddress("fc00::1", network.ScopeCloudLocal)
+	match = network.ExactScopeMatch(addr, network.ScopeCloudLocal)
+	c.Assert(match, jc.IsTrue)
+	match = network.ExactScopeMatch(addr, network.ScopePublic)
+	c.Assert(match, jc.IsFalse)
 }

--- a/provider/openstack/export_test.go
+++ b/provider/openstack/export_test.go
@@ -60,7 +60,7 @@ func MetadataStorage(e environs.Environ) envstorage.Storage {
 }
 
 func InstanceAddress(publicIP string, addresses map[string][]nova.IPAddress) string {
-	return network.SelectPublicAddress(convertNovaAddresses(publicIP, addresses))
+	return network.SelectPublicAddress(convertNovaAddresses(publicIP, addresses)).Value
 }
 
 func InstanceServerDetail(inst instance.Instance) *nova.ServerDetail {

--- a/state/address.go
+++ b/state/address.go
@@ -50,7 +50,7 @@ func (st *State) stateServerAddresses() ([]string, error) {
 	apiAddrs := make([]string, 0, len(allAddresses))
 	for _, addrs := range allAddresses {
 		naddrs := networkAddresses(addrs.Addresses)
-		addr := network.SelectInternalAddress(naddrs, false)
+		addr := network.SelectInternalAddress(naddrs, false).Value
 		if addr != "" {
 			apiAddrs = append(apiAddrs, addr)
 		}

--- a/state/allwatcher.go
+++ b/state/allwatcher.go
@@ -338,7 +338,7 @@ func (u *backingUnit) updated(st *State, store *multiwatcherStore, id string) er
 // getUnitAddresses returns the public and private addresses on a given unit.
 // As of 1.18, the addresses are stored on the assigned machine but we retain
 // this approach for backwards compatibility.
-func getUnitAddresses(st *State, unitName string) (publicAddress, privateAddress string, err error) {
+func getUnitAddresses(st *State, unitName string) (string, string, error) {
 	u, err := st.Unit(unitName)
 	if errors.IsNotFound(err) {
 		// Not found, so there won't be any addresses.
@@ -346,9 +346,15 @@ func getUnitAddresses(st *State, unitName string) (publicAddress, privateAddress
 	} else if err != nil {
 		return "", "", err
 	}
-	publicAddress, _ = u.PublicAddress()
-	privateAddress, _ = u.PrivateAddress()
-	return publicAddress, privateAddress, nil
+	publicAddress, err := u.PublicAddress()
+	if err != nil {
+		logger.Warningf("getting a public address for unit %q failed: %q", u.Name(), err)
+	}
+	privateAddress, err := u.PrivateAddress()
+	if err != nil {
+		logger.Warningf("getting a private address for unit %q failed: %q", u.Name(), err)
+	}
+	return publicAddress.Value, privateAddress.Value, nil
 }
 
 func (u *backingUnit) removed(store *multiwatcherStore, envUUID, id string, _ *State) error {

--- a/state/backups/restore.go
+++ b/state/backups/restore.go
@@ -161,7 +161,7 @@ func updateAllMachines(privateAddress string, machines []*state.Machine) error {
 		machineUpdating.Add(1)
 		go func() {
 			defer machineUpdating.Done()
-			err := runMachineUpdate(machine.Addresses(), setAgentAddressScript(privateAddress))
+			err := runMachineUpdate(machine, setAgentAddressScript(privateAddress))
 			logger.Errorf("failed updating machine: %v", err)
 		}()
 	}
@@ -181,7 +181,7 @@ for agent in *
 do
 	status  jujud-$agent| grep -q "^jujud-$agent start" > /dev/null
 	if [ $? -eq 0 ]; then
-		initctl stop jujud-$agent 
+		initctl stop jujud-$agent
 	fi
 	sed -i.old -r "/^(stateaddresses|apiaddresses):/{
 		n
@@ -218,12 +218,15 @@ func setAgentAddressScript(stateAddr string) string {
 }
 
 // runMachineUpdate connects via ssh to the machine and runs the update script.
-func runMachineUpdate(allAddr []network.Address, sshArg string) error {
-	addr := network.SelectPublicAddress(allAddr)
-	if addr == "" {
+func runMachineUpdate(machine *state.Machine, sshArg string) error {
+	addr, err := machine.PublicAddress()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if addr.Value == "" {
 		return errors.Errorf("no appropriate public address found")
 	}
-	return runViaSSH(addr, sshArg)
+	return runViaSSH(addr.Value, sshArg)
 }
 
 // sshCommand hods ssh.Command type for testing purposes.

--- a/state/relationunit.go
+++ b/state/relationunit.go
@@ -15,6 +15,8 @@ import (
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
+
+	"github.com/juju/juju/network"
 )
 
 // RelationUnit holds information about a single unit in a relation, and
@@ -38,8 +40,8 @@ func (ru *RelationUnit) Endpoint() Endpoint {
 	return ru.endpoint
 }
 
-// PrivateAddress returns the private address of the unit and whether it is valid.
-func (ru *RelationUnit) PrivateAddress() (string, bool) {
+// PrivateAddress returns the private address of the unit.
+func (ru *RelationUnit) PrivateAddress() (network.Address, error) {
 	return ru.unit.PrivateAddress()
 }
 

--- a/state/unit.go
+++ b/state/unit.go
@@ -731,34 +731,24 @@ func (u *Unit) machine() (*Machine, error) {
 	return m, nil
 }
 
-// addressesOfMachine returns Addresses of the related machine if present.
-func (u *Unit) addressesOfMachine() []network.Address {
+// PublicAddress returns the public address of the unit.
+func (u *Unit) PublicAddress() (network.Address, error) {
 	m, err := u.machine()
 	if err != nil {
 		unitLogger.Errorf("%v", err)
-		return nil
+		return network.Address{}, errors.Trace(err)
 	}
-	return m.Addresses()
+	return m.PublicAddress()
 }
 
-// PublicAddress returns the public address of the unit and whether it is valid.
-func (u *Unit) PublicAddress() (string, bool) {
-	var publicAddress string
-	addresses := u.addressesOfMachine()
-	if len(addresses) > 0 {
-		publicAddress = network.SelectPublicAddress(addresses)
+// PrivateAddress returns the private address of the unit.
+func (u *Unit) PrivateAddress() (network.Address, error) {
+	m, err := u.machine()
+	if err != nil {
+		unitLogger.Errorf("%v", err)
+		return network.Address{}, errors.Trace(err)
 	}
-	return publicAddress, publicAddress != ""
-}
-
-// PrivateAddress returns the private address of the unit and whether it is valid.
-func (u *Unit) PrivateAddress() (string, bool) {
-	var privateAddress string
-	addresses := u.addressesOfMachine()
-	if len(addresses) > 0 {
-		privateAddress = network.SelectInternalAddress(addresses, false)
-	}
-	return privateAddress, privateAddress != ""
+	return m.PrivateAddress()
 }
 
 // AvailabilityZone returns the name of the availability zone into which

--- a/state/unit_test.go
+++ b/state/unit_test.go
@@ -196,13 +196,14 @@ func (s *UnitSuite) setAssignedMachineAddresses(c *gc.C, u *state.Unit) {
 
 func (s *UnitSuite) TestPublicAddressSubordinate(c *gc.C) {
 	subUnit := s.addSubordinateUnit(c)
-	_, ok := subUnit.PublicAddress()
-	c.Assert(ok, jc.IsFalse)
+	address, err := subUnit.PublicAddress()
+	c.Assert(err, gc.Not(gc.IsNil))
+	c.Assert(address.Value, gc.Equals, "")
 
 	s.setAssignedMachineAddresses(c, s.unit)
-	address, ok := subUnit.PublicAddress()
-	c.Assert(ok, jc.IsTrue)
-	c.Assert(address, gc.Equals, "public.address.example.com")
+	address, err = subUnit.PublicAddress()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(address.Value, gc.Equals, "public.address.example.com")
 }
 
 func (s *UnitSuite) TestPublicAddress(c *gc.C) {
@@ -211,9 +212,9 @@ func (s *UnitSuite) TestPublicAddress(c *gc.C) {
 	err = s.unit.AssignToMachine(machine)
 	c.Assert(err, jc.ErrorIsNil)
 
-	address, ok := s.unit.PublicAddress()
-	c.Check(address, gc.Equals, "")
-	c.Assert(ok, jc.IsFalse)
+	address, err := s.unit.PublicAddress()
+	c.Check(address.Value, gc.Equals, "")
+	c.Assert(err, jc.ErrorIsNil)
 
 	public := network.NewScopedAddress("8.8.8.8", network.ScopePublic)
 	private := network.NewScopedAddress("127.0.0.1", network.ScopeCloudLocal)
@@ -221,9 +222,59 @@ func (s *UnitSuite) TestPublicAddress(c *gc.C) {
 	err = machine.SetProviderAddresses(public, private)
 	c.Assert(err, jc.ErrorIsNil)
 
-	address, ok = s.unit.PublicAddress()
-	c.Check(address, gc.Equals, "8.8.8.8")
-	c.Assert(ok, jc.IsTrue)
+	address, err = s.unit.PublicAddress()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(address.Value, gc.Equals, "8.8.8.8")
+}
+
+func (s *UnitSuite) TestStablePrivateAddress(c *gc.C) {
+	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.unit.AssignToMachine(machine)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = machine.SetMachineAddresses(network.NewAddress("10.0.0.2"))
+	c.Assert(err, jc.ErrorIsNil)
+
+	// We need to fetch the address to set the default.
+	addr, err := s.unit.PrivateAddress()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(addr.Value, gc.Equals, "10.0.0.2")
+
+	// Now add an address that would previously have sorted before the
+	// default.
+	err = machine.SetMachineAddresses(network.NewAddress("10.0.0.1"), network.NewAddress("10.0.0.2"))
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Assert the address is unchanged.
+	addr, err = s.unit.PrivateAddress()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(addr.Value, gc.Equals, "10.0.0.2")
+}
+
+func (s *UnitSuite) TestStablePublicAddress(c *gc.C) {
+	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.unit.AssignToMachine(machine)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = machine.SetProviderAddresses(network.NewAddress("8.8.8.8"))
+	c.Assert(err, jc.ErrorIsNil)
+
+	// We need to fetch the address to set the default.
+	addr, err := s.unit.PublicAddress()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(addr.Value, gc.Equals, "8.8.8.8")
+
+	// Now add an address that would previously have sorted before the
+	// default.
+	err = machine.SetProviderAddresses(network.NewAddress("8.8.4.4"), network.NewAddress("8.8.8.8"))
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Assert the address is unchanged.
+	addr, err = s.unit.PublicAddress()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(addr.Value, gc.Equals, "8.8.8.8")
 }
 
 func (s *UnitSuite) TestPublicAddressMachineAddresses(c *gc.C) {
@@ -240,26 +291,27 @@ func (s *UnitSuite) TestPublicAddressMachineAddresses(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = machine.SetMachineAddresses(privateMachine)
 	c.Assert(err, jc.ErrorIsNil)
-	address, ok := s.unit.PublicAddress()
-	c.Check(address, gc.Equals, "127.0.0.1")
-	c.Assert(ok, jc.IsTrue)
+	address, err := s.unit.PublicAddress()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(address.Value, gc.Equals, "127.0.0.1")
 
 	err = machine.SetProviderAddresses(publicProvider, privateProvider)
 	c.Assert(err, jc.ErrorIsNil)
-	address, ok = s.unit.PublicAddress()
-	c.Check(address, gc.Equals, "8.8.8.8")
-	c.Assert(ok, jc.IsTrue)
+	address, err = s.unit.PublicAddress()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(address.Value, gc.Equals, "8.8.8.8")
 }
 
 func (s *UnitSuite) TestPrivateAddressSubordinate(c *gc.C) {
 	subUnit := s.addSubordinateUnit(c)
-	_, ok := subUnit.PrivateAddress()
-	c.Assert(ok, jc.IsFalse)
+	address, err := subUnit.PrivateAddress()
+	c.Assert(err, gc.Not(gc.IsNil))
+	c.Assert(address.Value, gc.Equals, "")
 
 	s.setAssignedMachineAddresses(c, s.unit)
-	address, ok := subUnit.PrivateAddress()
-	c.Assert(ok, jc.IsTrue)
-	c.Assert(address, gc.Equals, "private.address.example.com")
+	address, err = subUnit.PrivateAddress()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(address.Value, gc.Equals, "private.address.example.com")
 }
 
 func (s *UnitSuite) TestPrivateAddress(c *gc.C) {
@@ -268,9 +320,9 @@ func (s *UnitSuite) TestPrivateAddress(c *gc.C) {
 	err = s.unit.AssignToMachine(machine)
 	c.Assert(err, jc.ErrorIsNil)
 
-	address, ok := s.unit.PrivateAddress()
-	c.Check(address, gc.Equals, "")
-	c.Assert(ok, jc.IsFalse)
+	address, err := s.unit.PrivateAddress()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(address.Value, gc.Equals, "")
 
 	public := network.NewScopedAddress("8.8.8.8", network.ScopePublic)
 	private := network.NewScopedAddress("127.0.0.1", network.ScopeCloudLocal)
@@ -278,9 +330,9 @@ func (s *UnitSuite) TestPrivateAddress(c *gc.C) {
 	err = machine.SetProviderAddresses(public, private)
 	c.Assert(err, jc.ErrorIsNil)
 
-	address, ok = s.unit.PrivateAddress()
-	c.Check(address, gc.Equals, "127.0.0.1")
-	c.Assert(ok, jc.IsTrue)
+	address, err = s.unit.PrivateAddress()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(address.Value, gc.Equals, "127.0.0.1")
 }
 
 type destroyMachineTestCase struct {

--- a/testing/base.go
+++ b/testing/base.go
@@ -151,7 +151,7 @@ func (s *BaseSuite) SetUpTest(c *gc.C) {
 	// We can't always just use IsolationSuite because we still need
 	// PATH and possibly a couple other envars.
 	s.PatchEnvironment("BASH_ENV", "")
-	network.ResetGobalPreferIPv6()
+	network.ResetGlobalPreferIPv6()
 }
 
 func (s *BaseSuite) TearDownTest(c *gc.C) {

--- a/worker/uniter/runner/util_test.go
+++ b/worker/uniter/runner/util_test.go
@@ -296,15 +296,15 @@ func (s *HookContextSuite) AssertCoreContext(c *gc.C, ctx runner.Context) {
 	c.Assert(ctx.UnitName(), gc.Equals, "u/0")
 	c.Assert(runner.ContextMachineTag(ctx), jc.DeepEquals, names.NewMachineTag("0"))
 
-	expect, expectOK := s.unit.PrivateAddress()
+	expect, _ := s.unit.PrivateAddress()
 	actual, actualOK := ctx.PrivateAddress()
-	c.Assert(actual, gc.Equals, expect)
-	c.Assert(actualOK, gc.Equals, expectOK)
+	c.Assert(actual, gc.Equals, expect.Value)
+	c.Assert(actualOK, gc.Equals, expect.Value != "")
 
-	expect, expectOK = s.unit.PublicAddress()
+	expect, _ = s.unit.PublicAddress()
 	actual, actualOK = ctx.PublicAddress()
-	c.Assert(actual, gc.Equals, expect)
-	c.Assert(actualOK, gc.Equals, expectOK)
+	c.Assert(actual, gc.Equals, expect.Value)
+	c.Assert(actualOK, gc.Equals, expect.Value != "")
 
 	env, err := s.State.Environment()
 	c.Assert(err, jc.ErrorIsNil)

--- a/worker/uniter/util_test.go
+++ b/worker/uniter/util_test.go
@@ -436,11 +436,11 @@ func (waitAddresses) step(c *gc.C, ctx *context) {
 			// GZ 2013-07-10: Hardcoded values from dummy environ
 			//                special cased here, questionable.
 			private, _ := ctx.unit.PrivateAddress()
-			if private != "private.address.example.com" {
+			if private.Value != "private.address.example.com" {
 				continue
 			}
 			public, _ := ctx.unit.PublicAddress()
-			if public != "public.address.example.com" {
+			if public.Value != "public.address.example.com" {
 				continue
 			}
 			return


### PR DESCRIPTION
Unit/machine reported public and private address can change. Now we store a default public and private address, and so long as that remains available and the best match on scope we always return the same address.

(Review request: http://reviews.vapour.ws/r/2609/)