### PR TITLE
testing: use less convoluted method to find the host package manager

### DIFF
--- a/testing/base.go
+++ b/testing/base.go
@@ -19,9 +19,7 @@ import (
 	"github.com/juju/juju/juju/arch"
 	jujuos "github.com/juju/juju/juju/os"
 	"github.com/juju/juju/juju/osenv"
-	"github.com/juju/juju/juju/series"
 	"github.com/juju/juju/network"
-	"github.com/juju/juju/version"
 	"github.com/juju/juju/wrench"
 )
 
@@ -227,12 +225,7 @@ type PackageManagerStruct struct {
 }
 
 func GetPackageManager() (s PackageManagerStruct, err error) {
-	os, err := series.GetOSFromSeries(version.Current.Series)
-	if err != nil {
-		return s, err
-	}
-
-	switch os {
+	switch jujuos.HostOS() {
 	case jujuos.CentOS:
 		s.PackageManager = "yum"
 		s.PackageQuery = "yum"


### PR DESCRIPTION
Use a less convoluted method to find the package manager for this host,
which also removes one dependency between testing and version.

(Review request: http://reviews.vapour.ws/r/2614/)