### PR TITLE
juju/series: new package

### DIFF
--- a/agent/tools/tools_test.go
+++ b/agent/tools/tools_test.go
@@ -39,7 +39,7 @@ func (t *ToolsSuite) TestPackageDependencies(c *gc.C) {
 	// resulting slice has that prefix removed to keep the output short.
 	c.Assert(testing.FindJujuCoreImports(c, "github.com/juju/juju/agent/tools"),
 		gc.DeepEquals,
-		[]string{"juju/arch", "juju/os", "tools", "version"})
+		[]string{"juju/arch", "juju/os", "juju/series", "tools", "version"})
 }
 
 const toolsFile = "downloaded-tools.txt"

--- a/cloudconfig/cloudinit/interface.go
+++ b/cloudconfig/cloudinit/interface.go
@@ -16,7 +16,7 @@ import (
 	"github.com/juju/utils/shell"
 
 	"github.com/juju/juju/juju/os"
-	"github.com/juju/juju/version"
+	"github.com/juju/juju/juju/series"
 )
 
 // CloudConfig is the interface of all cloud-init cloudconfig options.
@@ -379,8 +379,8 @@ type AdvancedPackagingConfig interface {
 }
 
 // New returns a new Config with no options set.
-func New(series string) (CloudConfig, error) {
-	seriesos, err := version.GetOSFromSeries(series)
+func New(ser string) (CloudConfig, error) {
+	seriesos, err := series.GetOSFromSeries(ser)
 	if err != nil {
 		return nil, err
 	}
@@ -389,7 +389,7 @@ func New(series string) (CloudConfig, error) {
 		renderer, _ := shell.NewRenderer("powershell")
 		return &windowsCloudConfig{
 			&cloudConfig{
-				series:   series,
+				series:   ser,
 				renderer: renderer,
 				attrs:    make(map[string]interface{}),
 			},
@@ -398,9 +398,9 @@ func New(series string) (CloudConfig, error) {
 		renderer, _ := shell.NewRenderer("bash")
 		return &ubuntuCloudConfig{
 			&cloudConfig{
-				series:    series,
+				series:    ser,
 				paccmder:  commands.NewAptPackageCommander(),
-				pacconfer: config.NewAptPackagingConfigurer(series),
+				pacconfer: config.NewAptPackagingConfigurer(ser),
 				renderer:  renderer,
 				attrs:     make(map[string]interface{}),
 			},
@@ -409,15 +409,15 @@ func New(series string) (CloudConfig, error) {
 		renderer, _ := shell.NewRenderer("bash")
 		return &centOSCloudConfig{
 			&cloudConfig{
-				series:    series,
+				series:    ser,
 				paccmder:  commands.NewYumPackageCommander(),
-				pacconfer: config.NewYumPackagingConfigurer(series),
+				pacconfer: config.NewYumPackagingConfigurer(ser),
 				renderer:  renderer,
 				attrs:     make(map[string]interface{}),
 			},
 		}, nil
 	default:
-		return nil, errors.NotFoundf("cloudconfig for series %q", series)
+		return nil, errors.NotFoundf("cloudconfig for series %q", ser)
 	}
 }
 

--- a/cloudconfig/userdatacfg.go
+++ b/cloudconfig/userdatacfg.go
@@ -15,7 +15,7 @@ import (
 	"github.com/juju/juju/cloudconfig/cloudinit"
 	"github.com/juju/juju/cloudconfig/instancecfg"
 	"github.com/juju/juju/juju/os"
-	"github.com/juju/juju/version"
+	"github.com/juju/juju/juju/series"
 )
 
 const (
@@ -49,7 +49,7 @@ type UserdataConfig interface {
 func NewUserdataConfig(icfg *instancecfg.InstanceConfig, conf cloudinit.CloudConfig) (UserdataConfig, error) {
 	// TODO(ericsnow) bug #1426217
 	// Protect icfg and conf better.
-	operatingSystem, err := version.GetOSFromSeries(icfg.Series)
+	operatingSystem, err := series.GetOSFromSeries(icfg.Series)
 	if err != nil {
 		return nil, err
 	}
@@ -122,7 +122,7 @@ func (c *baseConfigure) addMachineAgentToBoot() error {
 	svcName := c.icfg.MachineAgentServiceName
 	// TODO (gsamfira): This is temporary until we find a cleaner way to fix
 	// cloudinit.LogProgressCmd to not add >&9 on Windows.
-	targetOS, err := version.GetOSFromSeries(c.icfg.Series)
+	targetOS, err := series.GetOSFromSeries(c.icfg.Series)
 	if err != nil {
 		return err
 	}

--- a/cloudconfig/userdatacfg_unix.go
+++ b/cloudconfig/userdatacfg_unix.go
@@ -26,10 +26,10 @@ import (
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/imagemetadata"
 	"github.com/juju/juju/juju/os"
+	"github.com/juju/juju/juju/series"
 	"github.com/juju/juju/service"
 	"github.com/juju/juju/service/systemd"
 	"github.com/juju/juju/service/upstart"
-	"github.com/juju/juju/version"
 )
 
 const (
@@ -139,7 +139,7 @@ func (w *unixConfigure) addCleanShutdownJob(initSystem string) {
 }
 
 func (w *unixConfigure) setDataDirPermissions() string {
-	seriesos, _ := version.GetOSFromSeries(w.icfg.Series)
+	seriesos, _ := series.GetOSFromSeries(w.icfg.Series)
 	var user string
 	switch seriesos {
 	case os.CentOS:

--- a/cmd/juju/commands/upgradejuju.go
+++ b/cmd/juju/commands/upgradejuju.go
@@ -21,6 +21,7 @@ import (
 	"github.com/juju/juju/cmd/juju/block"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/sync"
+	"github.com/juju/juju/juju/series"
 	coretools "github.com/juju/juju/tools"
 	"github.com/juju/juju/version"
 )
@@ -329,7 +330,7 @@ func (context *upgradeContext) uploadTools() (err error) {
 		return err
 	}
 	defer f.Close()
-	additionalSeries := version.OSSupportedSeries(builtTools.Version.OS)
+	additionalSeries := series.OSSupportedSeries(builtTools.Version.OS)
 	uploaded, err = context.apiClient.UploadTools(f, builtTools.Version, additionalSeries...)
 	if err != nil {
 		return err

--- a/cmd/juju/commands/upgradejuju_test.go
+++ b/cmd/juju/commands/upgradejuju_test.go
@@ -24,6 +24,7 @@ import (
 	envtesting "github.com/juju/juju/environs/testing"
 	"github.com/juju/juju/environs/tools"
 	toolstesting "github.com/juju/juju/environs/tools/testing"
+	"github.com/juju/juju/juju/series"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/network"
 	_ "github.com/juju/juju/provider/dummy"
@@ -544,7 +545,7 @@ upgrade to this version by running
 		for i, v := range test.tools {
 			versions[i], err = version.ParseBinary(v)
 			if err != nil {
-				c.Assert(err, jc.Satisfies, version.IsUnknownOSForSeriesError)
+				c.Assert(err, jc.Satisfies, series.IsUnknownOSForSeriesError)
 			}
 		}
 		if len(versions) > 0 {

--- a/cmd/jujud/bootstrap.go
+++ b/cmd/jujud/bootstrap.go
@@ -29,6 +29,7 @@ import (
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/instance"
+	"github.com/juju/juju/juju/series"
 	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
@@ -330,10 +331,10 @@ func (c *BootstrapCommand) populateTools(st *state.State, env environs.Environ) 
 	var toolsVersions []version.Binary
 	if strings.HasPrefix(tools.URL, "file://") {
 		// Tools were uploaded: clone for each series of the same OS.
-		osSeries := version.OSSupportedSeries(tools.Version.OS)
-		for _, series := range osSeries {
+		osSeries := series.OSSupportedSeries(tools.Version.OS)
+		for _, ser := range osSeries {
 			toolsVersion := tools.Version
-			toolsVersion.Series = series
+			toolsVersion.Series = ser
 			toolsVersions = append(toolsVersions, toolsVersion)
 		}
 	} else {

--- a/cmd/jujud/bootstrap_test.go
+++ b/cmd/jujud/bootstrap_test.go
@@ -39,6 +39,7 @@ import (
 	envtesting "github.com/juju/juju/environs/testing"
 	envtools "github.com/juju/juju/environs/tools"
 	"github.com/juju/juju/instance"
+	"github.com/juju/juju/juju/series"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/network"
@@ -579,13 +580,13 @@ func (s *BootstrapSuite) testToolsMetadata(c *gc.C, exploded bool) {
 	defer st.Close()
 	expectedSeries := make(set.Strings)
 	if exploded {
-		for _, series := range version.SupportedSeries() {
-			os, err := version.GetOSFromSeries(series)
+		for _, ser := range series.SupportedSeries() {
+			os, err := series.GetOSFromSeries(ser)
 			c.Assert(err, jc.ErrorIsNil)
-			hostos, err := version.GetOSFromSeries(version.Current.Series)
+			hostos, err := series.GetOSFromSeries(version.Current.Series)
 			c.Assert(err, jc.ErrorIsNil)
 			if os == hostos {
-				expectedSeries.Add(series)
+				expectedSeries.Add(ser)
 			}
 		}
 	} else {

--- a/container/lxc/lxc.go
+++ b/container/lxc/lxc.go
@@ -32,8 +32,8 @@ import (
 	"github.com/juju/juju/container/lxc/lxcutils"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/juju/arch"
+	"github.com/juju/juju/juju/series"
 	"github.com/juju/juju/storage/looputil"
-	"github.com/juju/juju/version"
 )
 
 var logger = loggo.GetLogger("juju.container.lxc")
@@ -164,7 +164,7 @@ func NewContainerManager(
 
 // releaseVersion is a function that returns a string representing the
 // DISTRIB_RELEASE from the /etc/lsb-release file.
-var releaseVersion = version.ReleaseVersion
+var releaseVersion = series.ReleaseVersion
 
 // preferFastLXC returns true if the host is capable of
 // LXC cloning from a template.

--- a/environs/bootstrap/tools.go
+++ b/environs/bootstrap/tools.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/juju/environs"
 	envtools "github.com/juju/juju/environs/tools"
 	"github.com/juju/juju/juju/arch"
+	"github.com/juju/juju/juju/series"
 	coretools "github.com/juju/juju/tools"
 	"github.com/juju/juju/version"
 )
@@ -115,13 +116,13 @@ func findAvailableTools(env environs.Environ, vers *version.Number, arch *string
 // locallyBuildableTools returns the list of tools that
 // can be built locally, for series of the same OS.
 func locallyBuildableTools() (buildable coretools.List) {
-	for _, series := range version.SupportedSeries() {
-		if os, err := version.GetOSFromSeries(series); err != nil || os != version.Current.OS {
+	for _, ser := range series.SupportedSeries() {
+		if os, err := series.GetOSFromSeries(ser); err != nil || os != version.Current.OS {
 			continue
 		}
 		binary := version.Binary{
 			Number: version.Current.Number,
-			Series: series,
+			Series: ser,
 			Arch:   arch.HostArch(),
 			OS:     version.Current.OS,
 		}

--- a/environs/bootstrap/tools_test.go
+++ b/environs/bootstrap/tools_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/bootstrap"
 	"github.com/juju/juju/juju/arch"
+	"github.com/juju/juju/juju/series"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/tools"
 	"github.com/juju/juju/version"
@@ -257,7 +258,7 @@ func (s *toolsSuite) TestFindAvailableToolsCompleteNoValidate(c *gc.C) {
 	s.PatchValue(&arch.HostArch, func() string { return arch.AMD64 })
 
 	var allTools tools.List
-	for _, series := range version.SupportedSeries() {
+	for _, series := range series.SupportedSeries() {
 		binary := version.Binary{
 			Number: version.Current.Number,
 			Series: series,

--- a/environs/imagemetadata/generate.go
+++ b/environs/imagemetadata/generate.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/juju/juju/environs/simplestreams"
 	"github.com/juju/juju/environs/storage"
-	"github.com/juju/juju/version"
+	"github.com/juju/juju/juju/series"
 )
 
 // IndexStoragePath returns the storage path for the image metadata index file.
@@ -28,14 +28,14 @@ func ProductMetadataStoragePath() string {
 
 // MergeAndWriteMetadata reads the existing metadata from storage (if any),
 // and merges it with supplied metadata, writing the resulting metadata is written to storage.
-func MergeAndWriteMetadata(series string, metadata []*ImageMetadata, cloudSpec *simplestreams.CloudSpec,
+func MergeAndWriteMetadata(ser string, metadata []*ImageMetadata, cloudSpec *simplestreams.CloudSpec,
 	metadataStore storage.Storage) error {
 
 	existingMetadata, err := readMetadata(metadataStore)
 	if err != nil {
 		return err
 	}
-	seriesVersion, err := version.SeriesVersion(series)
+	seriesVersion, err := series.SeriesVersion(ser)
 	if err != nil {
 		return err
 	}

--- a/environs/imagemetadata/simplestreams.go
+++ b/environs/imagemetadata/simplestreams.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/juju/juju/environs/simplestreams"
 	"github.com/juju/juju/juju/arch"
-	"github.com/juju/juju/version"
+	"github.com/juju/juju/juju/series"
 )
 
 func init() {
@@ -114,7 +114,7 @@ type ImageConstraint struct {
 
 func NewImageConstraint(params simplestreams.LookupParams) *ImageConstraint {
 	if len(params.Series) == 0 {
-		params.Series = version.SupportedSeries()
+		params.Series = series.SupportedSeries()
 	}
 	if len(params.Arches) == 0 {
 		params.Arches = arch.AllSupportedArches
@@ -150,8 +150,8 @@ func (ic *ImageConstraint) ProductIds() ([]string, error) {
 	nrSeries := len(ic.Series)
 	ids := make([]string, nrArches*nrSeries)
 	for i, arch := range ic.Arches {
-		for j, series := range ic.Series {
-			version, err := version.SeriesVersion(series)
+		for j, ser := range ic.Series {
+			version, err := series.SeriesVersion(ser)
 			if err != nil {
 				return nil, err
 			}

--- a/environs/simplestreams/testing/testing.go
+++ b/environs/simplestreams/testing/testing.go
@@ -14,8 +14,8 @@ import (
 
 	"github.com/juju/juju/environs/jujutest"
 	"github.com/juju/juju/environs/simplestreams"
+	"github.com/juju/juju/juju/series"
 	"github.com/juju/juju/testing"
-	"github.com/juju/juju/version"
 )
 
 var PrivateKeyPassphrase = "12345"
@@ -598,7 +598,7 @@ func (tc *testConstraint) IndexIds() []string {
 }
 
 func (tc *testConstraint) ProductIds() ([]string, error) {
-	version, err := version.SeriesVersion(tc.Series[0])
+	version, err := series.SeriesVersion(tc.Series[0])
 	if err != nil {
 		return nil, err
 	}

--- a/environs/sync/sync.go
+++ b/environs/sync/sync.go
@@ -19,6 +19,7 @@ import (
 	"github.com/juju/juju/environs/simplestreams"
 	"github.com/juju/juju/environs/storage"
 	envtools "github.com/juju/juju/environs/tools"
+	jujuseries "github.com/juju/juju/juju/series"
 	coretools "github.com/juju/juju/tools"
 	"github.com/juju/juju/version"
 )
@@ -253,7 +254,7 @@ func cloneToolsForSeries(toolsInfo *BuiltTools, stream string, series ...string)
 	}
 	logger.Debugf("generating tarballs for %v", series)
 	for _, series := range series {
-		_, err := version.SeriesVersion(series)
+		_, err := jujuseries.SeriesVersion(series)
 		if err != nil {
 			return err
 		}

--- a/environs/tools/marshal.go
+++ b/environs/tools/marshal.go
@@ -14,7 +14,7 @@ import (
 	"github.com/juju/utils/set"
 
 	"github.com/juju/juju/environs/simplestreams"
-	"github.com/juju/juju/version"
+	"github.com/juju/juju/juju/series"
 )
 
 // ToolsContentId returns the tools content id for the given stream.
@@ -56,7 +56,7 @@ func marshalToolsMetadataIndexJSON(streamMetadata map[string][]*ToolsMetadata, u
 		for _, t := range metadata {
 			id, err := t.productId()
 			if err != nil {
-				if version.IsUnknownSeriesVersionError(err) {
+				if series.IsUnknownSeriesVersionError(err) {
 					logger.Infof("ignoring tools metadata with unknown series %q", t.Release)
 					continue
 				}
@@ -105,7 +105,7 @@ func MarshalToolsMetadataProductsJSON(
 		for _, t := range metadata {
 			id, err := t.productId()
 			if err != nil {
-				if version.IsUnknownSeriesVersionError(err) {
+				if series.IsUnknownSeriesVersionError(err) {
 					continue
 				}
 				return nil, err

--- a/environs/tools/simplestreams.go
+++ b/environs/tools/simplestreams.go
@@ -25,6 +25,7 @@ import (
 	"github.com/juju/juju/environs/simplestreams"
 	"github.com/juju/juju/environs/storage"
 	"github.com/juju/juju/juju/arch"
+	"github.com/juju/juju/juju/series"
 	coretools "github.com/juju/juju/tools"
 	"github.com/juju/juju/version"
 )
@@ -153,8 +154,8 @@ func (tc *ToolsConstraint) IndexIds() []string {
 // ProductIds generates a string array representing product ids formed similarly to an ISCSI qualified name (IQN).
 func (tc *ToolsConstraint) ProductIds() ([]string, error) {
 	var allIds []string
-	for _, series := range tc.Series {
-		version, err := version.SeriesVersion(series)
+	for _, ser := range tc.Series {
+		version, err := series.SeriesVersion(ser)
 		if err != nil {
 			return nil, err
 		}
@@ -195,8 +196,8 @@ func (t *ToolsMetadata) binary() (version.Binary, error) {
 	if err != nil {
 		return version.Binary{}, errors.Trace(err)
 	}
-	toolsOS, err := version.GetOSFromSeries(t.Release)
-	if err != nil && !version.IsUnknownOSForSeriesError(err) {
+	toolsOS, err := series.GetOSFromSeries(t.Release)
+	if err != nil && !series.IsUnknownOSForSeriesError(err) {
 		return version.Binary{}, errors.Trace(err)
 	}
 	return version.Binary{
@@ -208,7 +209,7 @@ func (t *ToolsMetadata) binary() (version.Binary, error) {
 }
 
 func (t *ToolsMetadata) productId() (string, error) {
-	seriesVersion, err := version.SeriesVersion(t.Release)
+	seriesVersion, err := series.SeriesVersion(t.Release)
 	if err != nil {
 		return "", err
 	}

--- a/environs/tools/simplestreams_test.go
+++ b/environs/tools/simplestreams_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/juju/juju/environs/storage"
 	"github.com/juju/juju/environs/tools"
 	toolstesting "github.com/juju/juju/environs/tools/testing"
+	"github.com/juju/juju/juju/series"
 	coretesting "github.com/juju/juju/testing"
 	coretools "github.com/juju/juju/tools"
 	"github.com/juju/juju/version"
@@ -358,7 +359,7 @@ func (s *simplestreamsSuite) TestWriteMetadataNoFetch(c *gc.C) {
 	// Add tools with an unknown series. Do not add an entry in the
 	// expected list as these tools should be ignored.
 	vers, err := version.ParseBinary("3.2.1-xuanhuaceratops-amd64")
-	c.Assert(err, jc.Satisfies, version.IsUnknownOSForSeriesError)
+	c.Assert(err, jc.Satisfies, series.IsUnknownOSForSeriesError)
 	toolsList = append(toolsList, &coretools.Tools{
 		Version: vers,
 		Size:    456,

--- a/environs/tools/testing/testing.go
+++ b/environs/tools/testing/testing.go
@@ -27,6 +27,7 @@ import (
 	"github.com/juju/juju/environs/sync"
 	"github.com/juju/juju/environs/tools"
 	"github.com/juju/juju/juju/names"
+	"github.com/juju/juju/juju/series"
 	coretesting "github.com/juju/juju/testing"
 	coretools "github.com/juju/juju/tools"
 	"github.com/juju/juju/version"
@@ -87,7 +88,7 @@ func makeTools(c *gc.C, metadataDir, stream string, versionStrings []string, wit
 	for _, versionString := range versionStrings {
 		binary, err := version.ParseBinary(versionString)
 		if err != nil {
-			c.Assert(err, jc.Satisfies, version.IsUnknownOSForSeriesError)
+			c.Assert(err, jc.Satisfies, series.IsUnknownOSForSeriesError)
 		}
 		path := filepath.Join(toolsDir, fmt.Sprintf("juju-%s.tgz", binary))
 		data := binary.String()
@@ -166,9 +167,9 @@ func ParseMetadataFromStorage(c *gc.C, stor storage.StorageReader, stream string
 				toolsMetadata := item.(*tools.ToolsMetadata)
 				toolsMetadataMap[key] = toolsMetadata
 				toolsVersions.Add(key)
-				seriesVersion, err := version.SeriesVersion(toolsMetadata.Release)
+				seriesVersion, err := series.SeriesVersion(toolsMetadata.Release)
 				if err != nil {
-					c.Assert(err, jc.Satisfies, version.IsUnknownSeriesVersionError)
+					c.Assert(err, jc.Satisfies, series.IsUnknownSeriesVersionError)
 				}
 				productId := fmt.Sprintf("com.ubuntu.juju:%s:%s", seriesVersion, toolsMetadata.Arch)
 				expectedProductIds.Add(productId)

--- a/environs/tools/tools.go
+++ b/environs/tools/tools.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/simplestreams"
 	"github.com/juju/juju/juju/arch"
+	"github.com/juju/juju/juju/series"
 	coretools "github.com/juju/juju/tools"
 	"github.com/juju/juju/version"
 )
@@ -53,7 +54,7 @@ func makeToolsConstraint(cloudSpec simplestreams.CloudSpec, stream string, major
 	if filter.Series != "" {
 		seriesToSearch = []string{filter.Series}
 	} else {
-		seriesToSearch = version.SupportedSeries()
+		seriesToSearch = series.SupportedSeries()
 		logger.Tracef("no series specified when finding tools, looking for %v", seriesToSearch)
 	}
 	toolsConstraint.Series = seriesToSearch

--- a/juju/paths/paths.go
+++ b/juju/paths/paths.go
@@ -7,7 +7,7 @@ import (
 	"github.com/juju/errors"
 
 	jujuos "github.com/juju/juju/juju/os"
-	"github.com/juju/juju/version"
+	"github.com/juju/juju/juju/series"
 )
 
 type osVarType int
@@ -51,8 +51,8 @@ var winVals = map[osVarType]string{
 // osVal will lookup the value of the key valname
 // in the apropriate map, based on the series. This will
 // help reduce boilerplate code
-func osVal(series string, valname osVarType) (string, error) {
-	os, err := version.GetOSFromSeries(series)
+func osVal(ser string, valname osVarType) (string, error) {
+	os, err := series.GetOSFromSeries(ser)
 	if err != nil {
 		return "", err
 	}

--- a/juju/series/export_linux_test.go
+++ b/juju/series/export_linux_test.go
@@ -1,7 +1,7 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package version
+package series
 
 var (
 	DistroInfo    = &distroInfo

--- a/juju/series/export_test.go
+++ b/juju/series/export_test.go
@@ -1,7 +1,7 @@
 // Copyright 2014 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package version
+package series
 
 var (
 	KernelToMajor                 = kernelToMajor

--- a/juju/series/export_windows_test.go
+++ b/juju/series/export_windows_test.go
@@ -2,9 +2,9 @@
 // Copyright 2015 Cloudbase Solutions SRL
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package version
+package series
 
 var (
 	CurrentVersionKey = &currentVersionKey
-	OSVersion         = osVersion
+	ReadSeries        = readSeries
 )

--- a/juju/series/package_test.go
+++ b/juju/series/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2013 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package series_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/juju/series/series_darwin.go
+++ b/juju/series/series_darwin.go
@@ -1,7 +1,7 @@
 // Copyright 2014 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package version
+package series
 
 import (
 	"syscall"
@@ -11,7 +11,7 @@ func sysctlVersion() (string, error) {
 	return syscall.Sysctl("kern.osrelease")
 }
 
-// osVersion returns the best approximation to what version this machine is.
-func osVersion() (string, error) {
+// readSeries returns the best approximation to what version this machine is.
+func readSeries() (string, error) {
 	return macOSXSeriesFromKernelVersion(sysctlVersion)
 }

--- a/juju/series/series_darwin_test.go
+++ b/juju/series/series_darwin_test.go
@@ -1,7 +1,7 @@
 // Copyright 2014 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package version
+package series
 
 import (
 	jc "github.com/juju/testing/checkers"
@@ -9,23 +9,23 @@ import (
 	gc "gopkg.in/check.v1"
 )
 
-type macOSXVersionSuite struct{}
+type macOSXSeriesSuite struct{}
 
-var _ = gc.Suite(&macOSXVersionSuite{})
+var _ = gc.Suite(&macOSXSeriesSuite{})
 
-func (*macOSXVersionSuite) TestGetSysctlVersionPlatform(c *gc.C) {
+func (*macOSXSeriesSuite) TestGetSysctlVersionPlatform(c *gc.C) {
 	// Test that sysctlVersion returns something that looks like a dotted revision number
 	releaseVersion, err := sysctlVersion()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(releaseVersion, gc.Matches, `\d+\..*`)
 }
 
-func (s *macOSXVersionSuite) TestOSVersion(c *gc.C) {
+func (s *macOSXSeriesSuite) TestOSVersion(c *gc.C) {
 	knownSeries := make(set.Strings)
 	for _, series := range macOSXSeries {
 		knownSeries.Add(series)
 	}
-	version, err := osVersion()
+	version, err := readSeries()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(version, jc.Satisfies, knownSeries.Contains)
 }

--- a/juju/series/series_linux.go
+++ b/juju/series/series_linux.go
@@ -1,23 +1,24 @@
-// Copyright 2014 Canonical Ltd.
+// Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package version
+package series
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"strings"
 
-	"github.com/juju/errors"
-
 	jujuos "github.com/juju/juju/juju/os"
 )
 
-func osVersion() (string, error) {
-	return readSeries()
-}
+var (
+	// osReleaseFile is the name of the file that is read in order to determine
+	// the linux type release version.
+	osReleaseFile = "/etc/os-release"
+)
 
 func readSeries() (string, error) {
 	values, err := jujuos.ReadOSRelease(osReleaseFile)

--- a/juju/series/series_linux_test.go
+++ b/juju/series/series_linux_test.go
@@ -1,7 +1,7 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package version_test
+package series_test
 
 import (
 	"io/ioutil"
@@ -10,8 +10,8 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/juju/series"
 	"github.com/juju/juju/testing"
-	"github.com/juju/juju/version"
 )
 
 type linuxVersionSuite struct {
@@ -34,7 +34,7 @@ var distroInfoContents = `version,codename,series,created,release,eol,eol-server
 var _ = gc.Suite(&linuxVersionSuite{})
 
 func (s *linuxVersionSuite) SetUpTest(c *gc.C) {
-	cleanup := version.SetSeriesVersions(make(map[string]string))
+	cleanup := series.SetSeriesVersions(make(map[string]string))
 	s.AddCleanup(func(*gc.C) { cleanup() })
 }
 
@@ -42,7 +42,7 @@ func (s *linuxVersionSuite) TestOSVersion(c *gc.C) {
 	// Set up fake /etc/os-release file from the future.
 	d := c.MkDir()
 	release := filepath.Join(d, "future-release")
-	s.PatchValue(version.OSReleaseFile, release)
+	s.PatchValue(series.OSReleaseFile, release)
 	err := ioutil.WriteFile(release, []byte(futureReleaseFileContents), 0666)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -50,11 +50,11 @@ func (s *linuxVersionSuite) TestOSVersion(c *gc.C) {
 	distroInfo := filepath.Join(d, "ubuntu.csv")
 	err = ioutil.WriteFile(distroInfo, []byte(distroInfoContents), 0644)
 	c.Assert(err, jc.ErrorIsNil)
-	s.PatchValue(version.DistroInfo, distroInfo)
+	s.PatchValue(series.DistroInfo, distroInfo)
 
 	// Ensure the future series can be read even though Juju doesn't
 	// know about it.
-	version, err := version.ReadSeries()
+	version, err := series.ReadSeries()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(version, gc.Equals, "spock")
 }
@@ -115,12 +115,12 @@ VERSION_ID="9.10"
 	}} {
 		c.Logf("%v: %v", i, test.message)
 		filename := filepath.Join(c.MkDir(), "os-release")
-		s.PatchValue(version.OSReleaseFile, filename)
+		s.PatchValue(series.OSReleaseFile, filename)
 		if test.releaseContent != "" {
 			err := ioutil.WriteFile(filename, []byte(test.releaseContent+"\n"), 0644)
 			c.Assert(err, jc.ErrorIsNil)
 		}
-		value := version.ReleaseVersion()
+		value := series.ReleaseVersion()
 		c.Assert(value, gc.Equals, test.expected)
 	}
 }
@@ -212,12 +212,12 @@ VERSION_ID="12"
 func (s *readSeriesSuite) TestReadSeries(c *gc.C) {
 	d := c.MkDir()
 	f := filepath.Join(d, "foo")
-	s.PatchValue(version.OSReleaseFile, f)
+	s.PatchValue(series.OSReleaseFile, f)
 	for i, t := range readSeriesTests {
 		c.Logf("test %d", i)
 		err := ioutil.WriteFile(f, []byte(t.contents), 0666)
 		c.Assert(err, jc.ErrorIsNil)
-		series, err := version.ReadSeries()
+		series, err := series.ReadSeries()
 		if t.err == "" {
 			c.Assert(err, jc.ErrorIsNil)
 		} else {

--- a/juju/series/series_nonlinux.go
+++ b/juju/series/series_nonlinux.go
@@ -3,7 +3,7 @@
 
 // +build !linux
 
-package version
+package series
 
 // TODO(ericsnow) Refactor dependents so we can remove this for non-linux.
 

--- a/juju/series/series_test.go
+++ b/juju/series/series_test.go
@@ -1,7 +1,7 @@
 // Copyright 2014 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package version_test
+package series_test
 
 import (
 	"fmt"
@@ -9,8 +9,8 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/juju/series"
 	"github.com/juju/juju/testing"
-	"github.com/juju/juju/version"
 )
 
 type kernelVersionSuite struct {
@@ -29,19 +29,19 @@ func sysctlError() (string, error) {
 }
 
 func (*kernelVersionSuite) TestKernelToMajorVersion(c *gc.C) {
-	majorVersion, err := version.KernelToMajor(sysctlMacOS10dot9dot2)
+	majorVersion, err := series.KernelToMajor(sysctlMacOS10dot9dot2)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(majorVersion, gc.Equals, 13)
 }
 
 func (*kernelVersionSuite) TestKernelToMajorVersionError(c *gc.C) {
-	majorVersion, err := version.KernelToMajor(sysctlError)
+	majorVersion, err := series.KernelToMajor(sysctlError)
 	c.Assert(err, gc.ErrorMatches, "no such syscall")
 	c.Check(majorVersion, gc.Equals, 0)
 }
 
 func (*kernelVersionSuite) TestKernelToMajorVersionNoDots(c *gc.C) {
-	majorVersion, err := version.KernelToMajor(func() (string, error) {
+	majorVersion, err := series.KernelToMajor(func() (string, error) {
 		return "1234", nil
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -49,7 +49,7 @@ func (*kernelVersionSuite) TestKernelToMajorVersionNoDots(c *gc.C) {
 }
 
 func (*kernelVersionSuite) TestKernelToMajorVersionNotInt(c *gc.C) {
-	majorVersion, err := version.KernelToMajor(func() (string, error) {
+	majorVersion, err := series.KernelToMajor(func() (string, error) {
 		return "a.b.c", nil
 	})
 	c.Assert(err, gc.ErrorMatches, `strconv.ParseInt: parsing "a": invalid syntax`)
@@ -57,7 +57,7 @@ func (*kernelVersionSuite) TestKernelToMajorVersionNotInt(c *gc.C) {
 }
 
 func (*kernelVersionSuite) TestKernelToMajorVersionEmpty(c *gc.C) {
-	majorVersion, err := version.KernelToMajor(func() (string, error) {
+	majorVersion, err := series.KernelToMajor(func() (string, error) {
 		return "", nil
 	})
 	c.Assert(err, gc.ErrorMatches, `strconv.ParseInt: parsing "": invalid syntax`)
@@ -65,7 +65,7 @@ func (*kernelVersionSuite) TestKernelToMajorVersionEmpty(c *gc.C) {
 }
 
 func (*kernelVersionSuite) TestMacOSXSeriesFromKernelVersion(c *gc.C) {
-	series, err := version.MacOSXSeriesFromKernelVersion(sysctlMacOS10dot9dot2)
+	series, err := series.MacOSXSeriesFromKernelVersion(sysctlMacOS10dot9dot2)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(series, gc.Equals, "mavericks")
 }
@@ -73,10 +73,10 @@ func (*kernelVersionSuite) TestMacOSXSeriesFromKernelVersion(c *gc.C) {
 func (*kernelVersionSuite) TestMacOSXSeriesFromKernelVersionError(c *gc.C) {
 	// We suppress the actual error in favor of returning "unknown", but we
 	// do log the error
-	series, err := version.MacOSXSeriesFromKernelVersion(sysctlError)
+	series, err := series.MacOSXSeriesFromKernelVersion(sysctlError)
 	c.Assert(err, gc.ErrorMatches, "no such syscall")
 	c.Assert(series, gc.Equals, "unknown")
-	c.Check(c.GetTestLog(), gc.Matches, ".* juju.version unable to determine OS version: no such syscall\n")
+	c.Check(c.GetTestLog(), gc.Matches, ".* juju.juju.series unable to determine OS version: no such syscall\n")
 }
 
 func (*kernelVersionSuite) TestMacOSXSeries(c *gc.C) {
@@ -94,7 +94,7 @@ func (*kernelVersionSuite) TestMacOSXSeries(c *gc.C) {
 		{version: 0, series: "unknown", err: `unknown series ""`},
 	}
 	for _, test := range tests {
-		series, err := version.MacOSXSeriesFromMajorVersion(test.version)
+		series, err := series.MacOSXSeriesFromMajorVersion(test.version)
 		if test.err != "" {
 			c.Assert(err, gc.ErrorMatches, test.err)
 		} else {

--- a/juju/series/series_windows.go
+++ b/juju/series/series_windows.go
@@ -2,7 +2,7 @@
 // Copyright 2015 Cloudbase Solutions SRL
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package version
+package series
 
 import (
 	"strings"
@@ -29,7 +29,7 @@ func getVersionFromRegistry() (string, error) {
 	return s, nil
 }
 
-func osVersion() (string, error) {
+func readSeries() (string, error) {
 	ver, err := getVersionFromRegistry()
 	if err != nil {
 		return "unknown", err

--- a/juju/series/series_windows_test.go
+++ b/juju/series/series_windows_test.go
@@ -2,25 +2,25 @@
 // Copyright 2015 Cloudbase Solutions SRL
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package version_test
+package series_test
 
 import (
 	"fmt"
 
-	"github.com/juju/juju/version"
 	"github.com/juju/utils"
 
 	"github.com/gabriel-samfira/sys/windows/registry"
+	"github.com/juju/juju/juju/series"
 	"github.com/juju/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 )
 
-type windowsVersionSuite struct {
+type windowsSeriesSuite struct {
 	testing.BaseSuite
 }
 
-var _ = gc.Suite(&windowsVersionSuite{})
+var _ = gc.Suite(&windowsSeriesSuite{})
 
 var versionTests = []struct {
 	version string
@@ -76,27 +76,27 @@ var versionTests = []struct {
 	},
 }
 
-func (s *windowsVersionSuite) SetUpTest(c *gc.C) {
+func (s *windowsSeriesSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 	salt, err := utils.RandomPassword()
 	c.Assert(err, jc.ErrorIsNil)
 	regKey := fmt.Sprintf(`SOFTWARE\JUJU\%s`, salt)
-	s.PatchValue(version.CurrentVersionKey, regKey)
+	s.PatchValue(series.CurrentVersionKey, regKey)
 
-	k, _, err := registry.CreateKey(registry.LOCAL_MACHINE, *version.CurrentVersionKey, registry.ALL_ACCESS)
+	k, _, err := registry.CreateKey(registry.LOCAL_MACHINE, *series.CurrentVersionKey, registry.ALL_ACCESS)
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = k.Close()
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.AddCleanup(func(*gc.C) {
-		registry.DeleteKey(registry.LOCAL_MACHINE, *version.CurrentVersionKey)
+		registry.DeleteKey(registry.LOCAL_MACHINE, *series.CurrentVersionKey)
 	})
 }
 
-func (s *windowsVersionSuite) TestOSVersion(c *gc.C) {
+func (s *windowsSeriesSuite) TestReadSeries(c *gc.C) {
 	for _, value := range versionTests {
-		k, err := registry.OpenKey(registry.LOCAL_MACHINE, *version.CurrentVersionKey, registry.ALL_ACCESS)
+		k, err := registry.OpenKey(registry.LOCAL_MACHINE, *series.CurrentVersionKey, registry.ALL_ACCESS)
 		c.Assert(err, jc.ErrorIsNil)
 
 		err = k.SetStringValue("ProductName", value.version)
@@ -105,7 +105,7 @@ func (s *windowsVersionSuite) TestOSVersion(c *gc.C) {
 		err = k.Close()
 		c.Assert(err, jc.ErrorIsNil)
 
-		ver, err := version.OSVersion()
+		ver, err := series.ReadSeries()
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(ver, gc.Equals, value.want)
 	}

--- a/juju/series/supportedseries.go
+++ b/juju/series/supportedseries.go
@@ -1,7 +1,7 @@
 // Copyright 2014 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package version
+package series
 
 import (
 	"sync"

--- a/juju/series/supportedseries_linux_test.go
+++ b/juju/series/supportedseries_linux_test.go
@@ -1,7 +1,7 @@
 // Copyright 2013 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package version_test
+package series_test
 
 import (
 	"io/ioutil"
@@ -12,7 +12,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/juju/os"
-	"github.com/juju/juju/version"
+	"github.com/juju/juju/juju/series"
 )
 
 func (s *supportedSeriesSuite) TestSeriesVersion(c *gc.C) {
@@ -20,7 +20,7 @@ func (s *supportedSeriesSuite) TestSeriesVersion(c *gc.C) {
 	if os.HostOS() != os.Ubuntu {
 		c.Skip("This test is only relevant on Ubuntu.")
 	}
-	vers, err := version.SeriesVersion("precise")
+	vers, err := series.SeriesVersion("precise")
 	if err != nil && err.Error() == `invalid series "precise"` {
 		c.Fatalf(`Unable to lookup series "precise", you may need to: apt-get install distro-info`)
 	}
@@ -33,10 +33,10 @@ func (s *supportedSeriesSuite) TestSupportedSeries(c *gc.C) {
 	filename := filepath.Join(d, "ubuntu.csv")
 	err := ioutil.WriteFile(filename, []byte(distInfoData), 0644)
 	c.Assert(err, jc.ErrorIsNil)
-	s.PatchValue(version.DistroInfo, filename)
+	s.PatchValue(series.DistroInfo, filename)
 
 	expectedSeries := []string{"precise", "quantal", "raring", "saucy"}
-	series := version.SupportedSeries()
+	series := series.SupportedSeries()
 	sort.Strings(series)
 	c.Assert(series, gc.DeepEquals, expectedSeries)
 }

--- a/juju/series/supportedseries_test.go
+++ b/juju/series/supportedseries_test.go
@@ -1,15 +1,15 @@
 // Copyright 2013 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package version_test
+package series_test
 
 import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/juju/os"
+	"github.com/juju/juju/juju/series"
 	"github.com/juju/juju/testing"
-	"github.com/juju/juju/version"
 )
 
 type supportedSeriesSuite struct {
@@ -20,7 +20,7 @@ type supportedSeriesSuite struct {
 var _ = gc.Suite(&supportedSeriesSuite{})
 
 func (s *supportedSeriesSuite) SetUpTest(c *gc.C) {
-	s.cleanup = version.SetSeriesVersions(make(map[string]string))
+	s.cleanup = series.SetSeriesVersions(make(map[string]string))
 }
 
 func (s *supportedSeriesSuite) TearDownTest(c *gc.C) {
@@ -54,7 +54,7 @@ var getOSFromSeriesTests = []struct {
 
 func (s *supportedSeriesSuite) TestGetOSFromSeries(c *gc.C) {
 	for _, t := range getOSFromSeriesTests {
-		got, err := version.GetOSFromSeries(t.series)
+		got, err := series.GetOSFromSeries(t.series)
 		if t.err != "" {
 			c.Assert(err, gc.ErrorMatches, t.err)
 		} else {
@@ -65,13 +65,13 @@ func (s *supportedSeriesSuite) TestGetOSFromSeries(c *gc.C) {
 }
 
 func (s *supportedSeriesSuite) TestUnknownOSFromSeries(c *gc.C) {
-	_, err := version.GetOSFromSeries("Xuanhuaceratops")
-	c.Assert(err, jc.Satisfies, version.IsUnknownOSForSeriesError)
+	_, err := series.GetOSFromSeries("Xuanhuaceratops")
+	c.Assert(err, jc.Satisfies, series.IsUnknownOSForSeriesError)
 	c.Assert(err, gc.ErrorMatches, `unknown OS for series: "Xuanhuaceratops"`)
 }
 
 func (s *supportedSeriesSuite) TestOSSupportedSeries(c *gc.C) {
-	version.SetSeriesVersions(map[string]string{
+	series.SetSeriesVersions(map[string]string{
 		"trusty":  "14.04",
 		"utopic":  "14.10",
 		"win7":    "win7",
@@ -79,12 +79,12 @@ func (s *supportedSeriesSuite) TestOSSupportedSeries(c *gc.C) {
 		"centos7": "centos7",
 		"arch":    "rolling",
 	})
-	series := version.OSSupportedSeries(os.Ubuntu)
-	c.Assert(series, jc.SameContents, []string{"trusty", "utopic"})
-	series = version.OSSupportedSeries(os.Windows)
-	c.Assert(series, jc.SameContents, []string{"win7", "win81"})
-	series = version.OSSupportedSeries(os.CentOS)
-	c.Assert(series, jc.SameContents, []string{"centos7"})
-	series = version.OSSupportedSeries(os.Arch)
-	c.Assert(series, jc.SameContents, []string{"arch"})
+	supported := series.OSSupportedSeries(os.Ubuntu)
+	c.Assert(supported, jc.SameContents, []string{"trusty", "utopic"})
+	supported = series.OSSupportedSeries(os.Windows)
+	c.Assert(supported, jc.SameContents, []string{"win7", "win81"})
+	supported = series.OSSupportedSeries(os.CentOS)
+	c.Assert(supported, jc.SameContents, []string{"centos7"})
+	supported = series.OSSupportedSeries(os.Arch)
+	c.Assert(supported, jc.SameContents, []string{"arch"})
 }

--- a/juju/series/supportedseries_windows_test.go
+++ b/juju/series/supportedseries_windows_test.go
@@ -2,7 +2,7 @@
 // Copyright 2014 Cloudbase Solutions SRL
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package version_test
+package series_test
 
 import (
 	"sort"
@@ -10,8 +10,8 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/juju/series"
 	"github.com/juju/juju/testing"
-	"github.com/juju/juju/version"
 )
 
 type supportedSeriesWindowsSuite struct {
@@ -21,7 +21,7 @@ type supportedSeriesWindowsSuite struct {
 var _ = gc.Suite(&supportedSeriesWindowsSuite{})
 
 func (s *supportedSeriesWindowsSuite) TestSeriesVersion(c *gc.C) {
-	vers, err := version.SeriesVersion("win8")
+	vers, err := series.SeriesVersion("win8")
 	if err != nil {
 		c.Assert(err, gc.Not(gc.ErrorMatches), `invalid series "win8"`, gc.Commentf(`unable to lookup series "win8"`))
 	} else {
@@ -51,7 +51,7 @@ func (s *supportedSeriesWindowsSuite) TestSupportedSeries(c *gc.C) {
 		"win8",
 		"win81",
 	}
-	series := version.SupportedSeries()
+	series := series.SupportedSeries()
 	sort.Strings(series)
 	c.Assert(series, gc.DeepEquals, expectedSeries)
 }

--- a/provider/azure/azure_test.go
+++ b/provider/azure/azure_test.go
@@ -17,8 +17,8 @@ import (
 	"github.com/juju/juju/environs/simplestreams"
 	envtesting "github.com/juju/juju/environs/testing"
 	"github.com/juju/juju/juju/arch"
+	"github.com/juju/juju/juju/series"
 	"github.com/juju/juju/testing"
-	"github.com/juju/juju/version"
 )
 
 func TestAzureProvider(t *stdtesting.T) {
@@ -74,13 +74,13 @@ func (s *providerSuite) TearDownTest(c *gc.C) {
 	s.BaseSuite.TearDownTest(c)
 }
 
-func (s *providerSuite) makeTestMetadata(c *gc.C, series, location string, im []*imagemetadata.ImageMetadata) {
+func (s *providerSuite) makeTestMetadata(c *gc.C, ser, location string, im []*imagemetadata.ImageMetadata) {
 	cloudSpec := simplestreams.CloudSpec{
 		Region:   location,
 		Endpoint: "https://management.core.windows.net/",
 	}
 
-	seriesVersion, err := version.SeriesVersion(series)
+	seriesVersion, err := series.SeriesVersion(ser)
 	c.Assert(err, jc.ErrorIsNil)
 	for _, im := range im {
 		im.Version = seriesVersion

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -33,11 +33,11 @@ import (
 	"github.com/juju/juju/environs/storage"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/juju/os"
+	"github.com/juju/juju/juju/series"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/provider/common"
 	"github.com/juju/juju/state/multiwatcher"
 	"github.com/juju/juju/tools"
-	"github.com/juju/juju/version"
 	"github.com/juju/names"
 )
 
@@ -1185,8 +1185,8 @@ func setupJujuNetworking() (string, error) {
 
 // newCloudinitConfig creates a cloudinit.Config structure
 // suitable as a base for initialising a MAAS node.
-func (environ *maasEnviron) newCloudinitConfig(hostname, primaryIface, series string) (cloudinit.CloudConfig, error) {
-	cloudcfg, err := cloudinit.New(series)
+func (environ *maasEnviron) newCloudinitConfig(hostname, primaryIface, ser string) (cloudinit.CloudConfig, error) {
+	cloudcfg, err := cloudinit.New(ser)
 	if err != nil {
 		return nil, err
 	}
@@ -1197,7 +1197,7 @@ func (environ *maasEnviron) newCloudinitConfig(hostname, primaryIface, series st
 		return nil, errors.Trace(err)
 	}
 
-	operatingSystem, err := version.GetOSFromSeries(series)
+	operatingSystem, err := series.GetOSFromSeries(ser)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/juju/juju/environs/tools"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/juju/arch"
+	"github.com/juju/juju/juju/series"
 	"github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/provider/common"
@@ -369,7 +370,7 @@ func (s *localServerSuite) TestStartInstanceHardwareCharacteristics(c *gc.C) {
 	// Ensure amd64 tools are available, to ensure an amd64 image.
 	amd64Version := version.Current
 	amd64Version.Arch = arch.AMD64
-	for _, series := range version.SupportedSeries() {
+	for _, series := range series.SupportedSeries() {
 		amd64Version.Series = series
 		envtesting.AssertUploadFakeToolsVersions(
 			c, s.toolsMetadataStorage, s.env.Config().AgentStream(), s.env.Config().AgentStream(), amd64Version)

--- a/service/discovery.go
+++ b/service/discovery.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/juju/juju/feature"
 	"github.com/juju/juju/juju/os"
+	"github.com/juju/juju/juju/series"
 	"github.com/juju/juju/service/common"
 	"github.com/juju/juju/service/systemd"
 	"github.com/juju/juju/service/upstart"
@@ -67,10 +68,10 @@ func VersionInitSystem(series string) (string, error) {
 	return initName, nil
 }
 
-func versionInitSystem(series string) (string, error) {
-	seriesos, err := version.GetOSFromSeries(series)
+func versionInitSystem(ser string) (string, error) {
+	seriesos, err := series.GetOSFromSeries(ser)
 	if err != nil {
-		notFound := errors.NotFoundf("init system for series %q", series)
+		notFound := errors.NotFoundf("init system for series %q", ser)
 		return "", errors.Wrap(err, notFound)
 	}
 
@@ -78,7 +79,7 @@ func versionInitSystem(series string) (string, error) {
 	case os.Windows:
 		return InitSystemWindows, nil
 	case os.Ubuntu:
-		switch series {
+		switch ser {
 		case "precise", "quantal", "raring", "saucy", "trusty", "utopic":
 			return InitSystemUpstart, nil
 		default:
@@ -91,7 +92,7 @@ func versionInitSystem(series string) (string, error) {
 	case os.CentOS:
 		return InitSystemSystemd, nil
 	}
-	return "", errors.NotFoundf("unknown os %q (from series %q), init system", seriesos, series)
+	return "", errors.NotFoundf("unknown os %q (from series %q), init system", seriesos, ser)
 }
 
 type discoveryCheck struct {

--- a/testing/base.go
+++ b/testing/base.go
@@ -19,6 +19,7 @@ import (
 	"github.com/juju/juju/juju/arch"
 	jujuos "github.com/juju/juju/juju/os"
 	"github.com/juju/juju/juju/osenv"
+	"github.com/juju/juju/juju/series"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/version"
 	"github.com/juju/juju/wrench"
@@ -227,7 +228,7 @@ type PackageManagerStruct struct {
 }
 
 func GetPackageManager() (s PackageManagerStruct, err error) {
-	os, err := version.GetOSFromSeries(version.Current.Series)
+	os, err := series.GetOSFromSeries(version.Current.Series)
 	if err != nil {
 		return s, err
 	}

--- a/version/current_test.go
+++ b/version/current_test.go
@@ -10,6 +10,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/juju/os"
+	"github.com/juju/juju/juju/series"
 	"github.com/juju/juju/version"
 )
 
@@ -33,7 +34,7 @@ func (*CurrentSuite) TestCurrentSeries(c *gc.C) {
 		case "windows":
 			c.Check(s, gc.Matches, `win2012hvr2|win2012hv|win2012|win2012r2|win8|win81|win7`)
 		default:
-			current_os, err := version.GetOSFromSeries(s)
+			current_os, err := series.GetOSFromSeries(s)
 			c.Assert(err, gc.IsNil)
 			if s != "n/a" {
 				// There is no lsb_release command on CentOS.

--- a/version/version.go
+++ b/version/version.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/juju/juju/juju/arch"
 	jujuos "github.com/juju/juju/juju/os"
+	"github.com/juju/juju/juju/series"
 )
 
 // The presence and format of this constant is very important.
@@ -34,16 +35,14 @@ var switchOverVersion = MustParse("1.19.9")
 // the linux type release version.
 var osReleaseFile = "/etc/os-release"
 
-var osVers = mustOSVersion()
-
 // Current gives the current version of the system.  If the file
 // "FORCE-VERSION" is present in the same directory as the running
 // binary, it will override this.
 var Current = Binary{
 	Number: MustParse(version),
-	Series: osVers,
+	Series: series.HostSeries(),
 	Arch:   arch.HostArch(),
-	OS:     MustOSFromSeries(osVers),
+	OS:     series.MustOSFromSeries(series.HostSeries()),
 }
 
 var Compiler = runtime.Compiler
@@ -193,7 +192,7 @@ func ParseBinary(s string) (Binary, error) {
 	v.Series = m[7]
 	v.Arch = m[8]
 	var err error
-	v.OS, err = GetOSFromSeries(v.Series)
+	v.OS, err = series.GetOSFromSeries(v.Series)
 	return v, err
 }
 

--- a/worker/imagemetadataworker/metadataupdater.go
+++ b/worker/imagemetadataworker/metadataupdater.go
@@ -15,7 +15,7 @@ import (
 	"github.com/juju/juju/environs"
 	environsmetadata "github.com/juju/juju/environs/imagemetadata"
 	"github.com/juju/juju/environs/simplestreams"
-	"github.com/juju/juju/version"
+	"github.com/juju/juju/juju/series"
 	"github.com/juju/juju/worker"
 )
 
@@ -101,13 +101,14 @@ var convertToParams = func(published []*environsmetadata.ImageMetadata) []params
 	return metadata
 }
 
-var seriesVersion = version.SeriesVersion
+// TODO(dfc) why is this like this ?
+var seriesVersion = series.SeriesVersion
 
 func versionSeries(v string) string {
 	if v == "" {
 		return v
 	}
-	for _, s := range version.SupportedSeries() {
+	for _, s := range series.SupportedSeries() {
 		sv, err := seriesVersion(s)
 		if err != nil {
 			logger.Errorf("cannot determine version for series %v: %v", s, err)

--- a/worker/provisioner/container_initialisation_test.go
+++ b/worker/provisioner/container_initialisation_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/juju/juju/juju/arch"
 	jujuos "github.com/juju/juju/juju/os"
 	"github.com/juju/juju/juju/osenv"
+	"github.com/juju/juju/juju/series"
 	"github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/state"
 	coretesting "github.com/juju/juju/testing"
@@ -293,19 +294,19 @@ func (s *ContainerSetupSuite) assertContainerInitialised(c *gc.C, cont Container
 	}
 	s.PatchValue(&provisioner.StartProvisioner, startProvisionerWorker)
 
-	var series string
+	var ser string
 	var expected_initial []string
 
-	current_os, err := version.GetOSFromSeries(version.Current.Series)
+	current_os, err := series.GetOSFromSeries(series.HostSeries())
 	c.Assert(err, jc.ErrorIsNil)
 
 	switch current_os {
 	case jujuos.CentOS:
-		series = "centos7"
+		ser = "centos7"
 		expected_initial = []string{
 			"yum", "--assumeyes", "--debuglevel=1", "install"}
 	default:
-		series = "precise"
+		ser = "precise"
 		expected_initial = []string{
 			"apt-get", "--option=Dpkg::Options::=--force-confold",
 			"--option=Dpkg::options::=--force-unsafe-io", "--assume-yes", "--quiet",
@@ -314,7 +315,7 @@ func (s *ContainerSetupSuite) assertContainerInitialised(c *gc.C, cont Container
 
 	// create a machine to host the container.
 	m, err := s.BackingState.AddOneMachine(state.MachineTemplate{
-		Series:      series, // precise requires special apt parameters, so we use that series here.
+		Series:      ser, // precise requires special apt parameters, so we use that series here.
 		Jobs:        []state.MachineJob{state.JobHostUnits},
 		Constraints: s.defaultConstraints,
 	})
@@ -524,7 +525,7 @@ func (s *AddressableContainerSetupSuite) TestContainerInitialised(c *gc.C) {
 }
 
 func getContainerInstance() (cont []ContainerInstance, err error) {
-	current_os, err := version.GetOSFromSeries(version.Current.Series)
+	current_os, err := series.GetOSFromSeries(series.HostSeries())
 
 	if err != nil {
 		return nil, err

--- a/worker/proxyupdater/proxyupdater.go
+++ b/worker/proxyupdater/proxyupdater.go
@@ -18,6 +18,7 @@ import (
 	"github.com/juju/juju/api/environment"
 	"github.com/juju/juju/api/watcher"
 	"github.com/juju/juju/juju/os"
+	"github.com/juju/juju/juju/series"
 	"github.com/juju/juju/version"
 	"github.com/juju/juju/worker"
 )
@@ -135,7 +136,7 @@ func (w *proxyWorker) writeEnvironmentToRegistry() error {
 
 func (w *proxyWorker) writeEnvironment() error {
 	// TODO(dfc) this should be replace with a switch on os.HostOS()
-	osystem, err := version.GetOSFromSeries(version.Current.Series)
+	osystem, err := series.GetOSFromSeries(version.Current.Series)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Introduce juju/series package, move supported series and other series
logic from version to juju/series.

The following CL will replace uses of version.Current.Series with
series.HostSeries().

version now has 87% coverage and only handles version.Binary numbers
juju/series has 89% coverage, and some duplication with juju/os which will be handled in a following CL.

(Review request: http://reviews.vapour.ws/r/2615/)