### PR TITLE
Extend ZonedEnviron for subnets

### DIFF
--- a/provider/common/availabilityzones.go
+++ b/provider/common/availabilityzones.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/instance"
+	"github.com/juju/juju/network"
 )
 
 // AvailabilityZone describes a provider availability zone.
@@ -31,6 +32,12 @@ type ZonedEnviron interface {
 	// zones for the specified instances. The error returned follows the same
 	// rules as Environ.Instances.
 	InstanceAvailabilityZoneNames(ids []instance.Id) ([]string, error)
+
+	// SubnetsAvailabilityZoneNames returns the names of the
+	// availability zones for the provider-specific subnet IDs.
+	// The error returned follows the same rules as
+	// Environ.Instances.
+	SubnetsAvailabilityZoneNames(subnetIds []network.Id) ([]string, error)
 }
 
 // AvailabilityZoneInstances describes an availability zone and

--- a/provider/common/mock_test.go
+++ b/provider/common/mock_test.go
@@ -90,11 +90,13 @@ func (env *mockEnviron) GetToolsSources() ([]simplestreams.DataSource, error) {
 
 type availabilityZonesFunc func() ([]common.AvailabilityZone, error)
 type instanceAvailabilityZoneNamesFunc func([]instance.Id) ([]string, error)
+type subnetsAvailabilityZoneNamesFunc func([]network.Id) ([]string, error)
 
 type mockZonedEnviron struct {
 	mockEnviron
 	availabilityZones             availabilityZonesFunc
 	instanceAvailabilityZoneNames instanceAvailabilityZoneNamesFunc
+	subnetsAvailabilityZoneNames  subnetsAvailabilityZoneNamesFunc
 }
 
 func (env *mockZonedEnviron) AvailabilityZones() ([]common.AvailabilityZone, error) {
@@ -103,6 +105,10 @@ func (env *mockZonedEnviron) AvailabilityZones() ([]common.AvailabilityZone, err
 
 func (env *mockZonedEnviron) InstanceAvailabilityZoneNames(ids []instance.Id) ([]string, error) {
 	return env.instanceAvailabilityZoneNames(ids)
+}
+
+func (env *mockZonedEnviron) SubnetsAvailabilityZoneNames(subnetIds []network.Id) ([]string, error) {
+	return env.subnetsAvailabilityZoneNames(subnetIds)
 }
 
 type mockInstance struct {

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -1482,3 +1482,9 @@ func ec2ErrCode(err error) string {
 	}
 	return ec2err.Code
 }
+
+// SubnetsAvailabilityZoneNames returns the names of the availability
+// zones for the given provider-specific subnet IDs.
+func (env *environ) SubnetsAvailabilityZoneNames(subnetIds []network.Id) ([]string, error) {
+	return nil, nil
+}

--- a/provider/gce/environ_availzones.go
+++ b/provider/gce/environ_availzones.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/instance"
+	"github.com/juju/juju/network"
 	"github.com/juju/juju/provider/common"
 	"github.com/juju/juju/provider/gce/google"
 )
@@ -123,4 +124,10 @@ func (env *environ) parseAvailabilityZones(args environs.StartInstanceParams) ([
 	}
 
 	return zoneNames, nil
+}
+
+// SubnetsAvailabilityZoneNames returns the names of the availability
+// zones for the given provider-specific subnet IDs.
+func (env *environ) SubnetsAvailabilityZoneNames(subnetIds []network.Id) ([]string, error) {
+	return nil, nil
 }

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -2020,3 +2020,9 @@ func extractInterfaces(inst instance.Instance, lshwXML []byte) (map[string]iface
 	err := processNodes(lshw.Nodes)
 	return interfaces, primaryIface, err
 }
+
+// SubnetsAvailabilityZoneNames returns the names of the availability
+// zones for the given provider-specific subnet IDs.
+func (env *maasEnviron) SubnetsAvailabilityZoneNames(subnetIds []network.Id) ([]string, error) {
+	return nil, nil
+}

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -1676,3 +1676,9 @@ func (e *environ) TagInstance(id instance.Id, tags map[string]string) error {
 	}
 	return nil
 }
+
+// SubnetsAvailabilityZoneNames returns the names of the availability
+// zones for the given provider-specific subnet IDs.
+func (env *environ) SubnetsAvailabilityZoneNames(subnetIds []network.Id) ([]string, error) {
+	return nil, nil
+}

--- a/provider/vsphere/environ_availzones.go
+++ b/provider/vsphere/environ_availzones.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/instance"
+	"github.com/juju/juju/network"
 	"github.com/juju/juju/provider/common"
 )
 
@@ -127,4 +128,10 @@ func (env *environ) parseAvailabilityZones(args environs.StartInstanceParams) ([
 	}
 
 	return zoneNames, nil
+}
+
+// SubnetsAvailabilityZoneNames returns the names of the availability
+// zones for the given provider-specific subnet IDs.
+func (env *environ) SubnetsAvailabilityZoneNames(subnetIds []network.Id) ([]string, error) {
+	return nil, nil
 }


### PR DESCRIPTION
This commit extends ZonedEnviron to be subnet aware. Each of the
providers now have a stub entry for the new method which returns no
error and a nil slice for the available subnets. Follow-up commits will
add implementations for the dummy provider and EC2.

(Review request: http://reviews.vapour.ws/r/2616/)