### PR TITLE
Minimal fix for lp:1493850.

### DIFF
--- a/worker/uniter/resolver.go
+++ b/worker/uniter/resolver.go
@@ -194,7 +194,7 @@ func (s *uniterResolver) nextOp(
 
 	// Now that storage hooks have run at least once, before anything else,
 	// we need to run the install hook.
-	if !localState.Installed {
+	if !localState.Installed && !localState.Started {
 		return opFactory.NewRunHook(hook.Info{Kind: hooks.Install})
 	}
 


### PR DESCRIPTION
Determined that the install hook is firing after unit agent upgrade,
because the "installed" flag did not get persisted.

Need to follow up with a proper fix for the local operation state
upgrade. This, however, should fix the broken CI tests and get
everything moving again.

(Review request: http://reviews.vapour.ws/r/2617/)