### PR TITLE
Minimal fix for lp:1493850.

### DIFF
--- a/worker/uniter/export_test.go
+++ b/worker/uniter/export_test.go
@@ -1,0 +1,7 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package uniter
+
+// NewUniterResolver returns a new aggregate uniter resolver.
+var NewUniterResolver = newUniterResolver

--- a/worker/uniter/mock_test.go
+++ b/worker/uniter/mock_test.go
@@ -1,0 +1,31 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package uniter_test
+
+import (
+	"github.com/juju/names"
+
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/worker/uniter/hook"
+	"github.com/juju/juju/worker/uniter/relation"
+	"github.com/juju/juju/worker/uniter/remotestate"
+	"github.com/juju/juju/worker/uniter/resolver"
+	"github.com/juju/juju/worker/uniter/storage"
+)
+
+type dummyRelations struct {
+	relation.Relations
+}
+
+func (*dummyRelations) NextHook(_ resolver.LocalState, _ remotestate.Snapshot) (hook.Info, error) {
+	return hook.Info{}, resolver.ErrNoOperation
+}
+
+type dummyStorageAccessor struct {
+	storage.StorageAccessor
+}
+
+func (*dummyStorageAccessor) UnitStorageAttachments(_ names.UnitTag) ([]params.StorageAttachmentId, error) {
+	return nil, nil
+}

--- a/worker/uniter/resolver.go
+++ b/worker/uniter/resolver.go
@@ -25,6 +25,26 @@ type uniterResolver struct {
 	storageResolver    resolver.Resolver
 }
 
+func newUniterResolver(
+	clearResolved func() error,
+	reportHookError func(hook.Info) error,
+	fixDeployer func() error,
+	leadershipResolver resolver.Resolver,
+	actionsResolver resolver.Resolver,
+	relationsResolver resolver.Resolver,
+	storageResolver resolver.Resolver,
+) *uniterResolver {
+	return &uniterResolver{
+		clearResolved:      clearResolved,
+		reportHookError:    reportHookError,
+		fixDeployer:        fixDeployer,
+		leadershipResolver: leadershipResolver,
+		actionsResolver:    actionsResolver,
+		relationsResolver:  relationsResolver,
+		storageResolver:    storageResolver,
+	}
+}
+
 func (s *uniterResolver) NextOp(
 	localState resolver.LocalState,
 	remoteState remotestate.Snapshot,
@@ -194,7 +214,9 @@ func (s *uniterResolver) nextOp(
 
 	// Now that storage hooks have run at least once, before anything else,
 	// we need to run the install hook.
-	if !localState.Installed {
+	// TODO(cmars): remove !localState.Started. It's here as a temporary
+	// measure because unit agent upgrades aren't being performed yet.
+	if !localState.Installed && !localState.Started {
 		return opFactory.NewRunHook(hook.Info{Kind: hooks.Install})
 	}
 

--- a/worker/uniter/resolver_test.go
+++ b/worker/uniter/resolver_test.go
@@ -1,0 +1,84 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package uniter_test
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/names"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/charm.v5"
+
+	"github.com/juju/juju/worker/uniter"
+	uniteractions "github.com/juju/juju/worker/uniter/actions"
+	"github.com/juju/juju/worker/uniter/hook"
+	"github.com/juju/juju/worker/uniter/leadership"
+	"github.com/juju/juju/worker/uniter/operation"
+	"github.com/juju/juju/worker/uniter/relation"
+	"github.com/juju/juju/worker/uniter/remotestate"
+	"github.com/juju/juju/worker/uniter/resolver"
+	"github.com/juju/juju/worker/uniter/storage"
+)
+
+type resolverSuite struct {
+	charmURL    *charm.URL
+	remoteState remotestate.Snapshot
+	opFactory   operation.Factory
+	resolver    resolver.Resolver
+}
+
+var _ = gc.Suite(&resolverSuite{})
+
+func (s *resolverSuite) SetUpTest(c *gc.C) {
+	s.charmURL = charm.MustParseURL("cs:precise/mysql-2")
+	s.remoteState = remotestate.Snapshot{
+		CharmURL: s.charmURL,
+	}
+	s.opFactory = operation.NewFactory(operation.FactoryParams{})
+
+	attachments, err := storage.NewAttachments(&dummyStorageAccessor{}, names.NewUnitTag("u/0"), c.MkDir(), nil)
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.resolver = uniter.NewUniterResolver(
+		func() error { return errors.New("unexpected resolved") },
+		func(_ hook.Info) error { return errors.New("unexpected report hook error") },
+		func() error { return nil },
+		uniteractions.NewResolver(),
+		leadership.NewResolver(),
+		relation.NewRelationsResolver(&dummyRelations{}),
+		storage.NewResolver(attachments),
+	)
+}
+
+// TestStartedNotInstalled tests whether the Started flag overrides the
+// Installed flag being unset, in the event of an unexpected inconsistency in
+// local state.
+func (s *resolverSuite) TestStartedNotInstalled(c *gc.C) {
+	localState := resolver.LocalState{
+		CharmURL: s.charmURL,
+		State: operation.State{
+			Kind:      operation.Continue,
+			Installed: false,
+			Started:   true,
+		},
+	}
+	_, err := s.resolver.NextOp(localState, s.remoteState, s.opFactory)
+	c.Assert(err, gc.Equals, resolver.ErrNoOperation)
+}
+
+// TestNotStartedNotInstalled tests whether the next operation for an
+// uninstalled local state is an install hook operation.
+func (s *resolverSuite) TestNotStartedNotInstalled(c *gc.C) {
+	localState := resolver.LocalState{
+		CharmURL: s.charmURL,
+		State: operation.State{
+			Kind:      operation.Continue,
+			Installed: false,
+			Started:   false,
+		},
+	}
+	op, err := s.resolver.NextOp(localState, s.remoteState, s.opFactory)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(op.String(), gc.Equals, "run install hook")
+}


### PR DESCRIPTION
Determined that the install hook is firing after unit agent upgrade, because the installed flag did not get persisted. After further investigation, I've determined that unit agent upgrades aren't been applied (and likely never have been).

Will follow this up with a proper fix for applying unit agent upgrades. In the meantime, I've added a workaround (with test coverage) that assumes a workload is "installed" if it's "started", which is not an unreasonable assumption to make, in the event of such an unexpected local state.

(Review request: http://reviews.vapour.ws/r/2620/)