### PR TITLE
worker/uniter/remotestate: fix data race in test

### DIFF
--- a/worker/uniter/remotestate/watcher.go
+++ b/worker/uniter/remotestate/watcher.go
@@ -84,6 +84,14 @@ func NewWatcher(config WatcherConfig) (*RemoteStateWatcher, error) {
 		err := w.loop(config.UnitTag)
 		logger.Errorf("remote state watcher exited: %v", err)
 		w.tomb.Kill(errors.Cause(err))
+
+		// Stop all remaining sub-watchers.
+		for _, w := range w.storageAttachmentWatchers {
+			watcher.Stop(w, &w.tomb)
+		}
+		for _, w := range w.relations {
+			watcher.Stop(w, &w.tomb)
+		}
 	}()
 	return w, nil
 }

--- a/worker/uniter/remotestate/watcher_test.go
+++ b/worker/uniter/remotestate/watcher_test.go
@@ -186,25 +186,12 @@ func (s *WatcherSuite) TestRemoteStateChanged(c *gc.C) {
 }
 
 func (s *WatcherSuite) TestActionsReceived(c *gc.C) {
-	statusTicker := func() <-chan time.Time {
-		// Duration is arbitrary, we'll trigger the ticker
-		// by advancing the clock past the duration.
-		return s.clock.After(statusTickDuration)
-	}
-	config := remotestate.WatcherConfig{
-		State:               &s.st,
-		LeadershipTracker:   &s.leadership,
-		UnitTag:             s.st.unit.tag,
-		UpdateStatusChannel: statusTicker,
-	}
-	w, err := remotestate.NewWatcher(config)
-	c.Assert(err, jc.ErrorIsNil)
-	defer func() { c.Assert(w.Stop(), jc.ErrorIsNil) }()
 	signalAll(&s.st, &s.leadership)
-	assertNotifyEvent(c, w.RemoteStateChanged(), "waiting for remote state change")
+	assertNotifyEvent(c, s.watcher.RemoteStateChanged(), "waiting for remote state change")
+
 	s.st.unit.actionWatcher.changes <- []string{"an-action"}
-	assertNotifyEvent(c, w.RemoteStateChanged(), "waiting for remote state change")
-	c.Assert(w.Snapshot().Actions, gc.DeepEquals, []string{"an-action"})
+	assertNotifyEvent(c, s.watcher.RemoteStateChanged(), "waiting for remote state change")
+	c.Assert(s.watcher.Snapshot().Actions, gc.DeepEquals, []string{"an-action"})
 }
 
 func (s *WatcherSuite) TestClearResolvedMode(c *gc.C) {


### PR DESCRIPTION
TestStorageUnattachedChanged has a data race: at the
end of the test we remove the storage attachment, but
we had previously signalled the storage attachment
watcher. The watcher may therefore be inspecting the
map at the same time.

Fixes https://bugs.launchpad.net/juju-core/+bug/1494121

(Review request: http://reviews.vapour.ws/r/2625/)