### PR TITLE
Bundle deployment: handle adding service relations.

### DIFF
--- a/cmd/juju/commands/bundle.go
+++ b/cmd/juju/commands/bundle.go
@@ -194,11 +194,11 @@ func upgradeCharm(client *api.Client, log deploymentLogger, service, id string) 
 		log.Infof("reusing service %s (charm: %s)", service, id)
 		return nil
 	}
-	url, err := charm.ParseReference(id)
+	url, err := charm.ParseURL(id)
 	if err != nil {
 		return errors.Annotatef(err, "cannot parse charm URL %q", id)
 	}
-	if (url.Name != existing.Name) || (url.User != existing.User) {
+	if url.WithRevision(-1).Path() != existing.WithRevision(-1).Path() {
 		return errors.Errorf("bundle charm %q is incompatible with existing charm %q", id, existing)
 	}
 	if err := client.ServiceSetCharm(service, id, false); err != nil {
@@ -228,6 +228,9 @@ func setServiceOptions(client *api.Client, service string, options map[string]in
 // string indicating the action type ("deploy", "addRelation" etc.), followed
 // by a unique incremental number.
 func resolve(placeholder string, results map[string]string) string {
+	if !strings.HasPrefix(placeholder, "$") {
+		panic(`placeholder does not start with "$"`)
+	}
 	id := placeholder[1:]
 	return results[id]
 }

--- a/cmd/juju/commands/bundle.go
+++ b/cmd/juju/commands/bundle.go
@@ -120,9 +120,9 @@ func (h *bundleHandler) addService(id string, p bundlechanges.AddServiceParams) 
 	numUnits, configYAML, cons, toMachineSpec := 0, "", constraints.Value{}, ""
 	if err := h.client.ServiceDeploy(ch, p.Service, numUnits, configYAML, cons, toMachineSpec); err == nil {
 		h.log.Infof("service %s deployed (charm: %s)", p.Service, ch)
-		// TODO frankban: do this check using the cause rather than the string,
-		// when a specific cause is available for this error case.
-	} else if strings.Contains(err.Error(), "service already exists") {
+		// TODO frankban (bug 1495952): do this check using the cause rather
+		// than the string when a specific cause is available.
+	} else if strings.HasSuffix(err.Error(), "service already exists") {
 		// The service is already deployed in the environment: check that its
 		// charm is compatible with the one declared in the bundle. If it is,
 		// reuse the existing service or upgrade to a specified revision.
@@ -159,9 +159,9 @@ func (h *bundleHandler) addRelation(id string, p bundlechanges.AddRelationParams
 		h.log.Infof("related %s and %s", ep1, ep2)
 		return nil
 	}
-	// TODO frankban: do this check using the cause rather than the string,
-	// when a specific cause is available for this error case.
-	if strings.Contains(err.Error(), "relation already exists") {
+	// TODO frankban (bug 1495952): do this check using the cause rather than
+	// the string when a specific cause is available.
+	if strings.HasSuffix(err.Error(), "relation already exists") {
 		// The relation is already present in the environment.
 		h.log.Infof("%s and %s are already related", ep1, ep2)
 		return nil

--- a/cmd/juju/commands/bundle_test.go
+++ b/cmd/juju/commands/bundle_test.go
@@ -415,7 +415,7 @@ func (s *deployRepoCharmStoreSuite) TestDeployBundleServiceUpgradeFailure(c *gc.
                 charm: vivid/wordpress
                 num_units: 1
     `)
-	c.Assert(err, gc.ErrorMatches, `cannot deploy bundle: cannot upgrade service "wordpress": cannot upgrade charm to "cs:vivid/wordpress-42": cannot change a service's series`)
+	c.Assert(err, gc.ErrorMatches, `cannot deploy bundle: cannot upgrade service "wordpress": bundle charm "cs:vivid/wordpress-42" is incompatible with existing charm "local:quantal/wordpress-3"`)
 }
 
 func (s *deployRepoCharmStoreSuite) TestDeployBundleMultipleRelations(c *gc.C) {

--- a/cmd/juju/commands/bundle_test.go
+++ b/cmd/juju/commands/bundle_test.go
@@ -43,11 +43,11 @@ func (s *DeployCharmStoreSuite) TestDeployBundleSuccess(c *gc.C) {
 	output, err := runDeployCommand(c, "bundle/wordpress-simple")
 	c.Assert(err, jc.ErrorIsNil)
 	expectedOutput := `
-adding charm cs:trusty/mysql-42
-deploying service mysql (charm: cs:trusty/mysql-42)
-adding charm cs:trusty/wordpress-47
-deploying service wordpress (charm: cs:trusty/wordpress-47)
-relating wordpress:db and mysql:server
+added charm cs:trusty/mysql-42
+service mysql deployed (charm: cs:trusty/mysql-42)
+added charm cs:trusty/wordpress-47
+service wordpress deployed (charm: cs:trusty/wordpress-47)
+related wordpress:db and mysql:server
 deployment of bundle "cs:bundle/wordpress-simple-1" completed`
 	c.Assert(output, gc.Equals, strings.TrimSpace(expectedOutput))
 	s.assertCharmsUplodaded(c, "cs:trusty/mysql-42", "cs:trusty/wordpress-47")
@@ -67,9 +67,9 @@ func (s *DeployCharmStoreSuite) TestDeployBundleTwice(c *gc.C) {
 	output, err := runDeployCommand(c, "bundle/wordpress-simple")
 	c.Assert(err, jc.ErrorIsNil)
 	expectedOutput := `
-adding charm cs:trusty/mysql-42
+added charm cs:trusty/mysql-42
 reusing service mysql (charm: cs:trusty/mysql-42)
-adding charm cs:trusty/wordpress-47
+added charm cs:trusty/wordpress-47
 reusing service wordpress (charm: cs:trusty/wordpress-47)
 wordpress:db and mysql:server are already related
 deployment of bundle "cs:bundle/wordpress-simple-1" completed`
@@ -239,11 +239,11 @@ func (s *deployRepoCharmStoreSuite) TestDeployBundleLocalDeployment(c *gc.C) {
     `)
 	c.Assert(err, jc.ErrorIsNil)
 	expectedOutput := `
-adding charm local:trusty/mysql-1
-deploying service mysql (charm: local:trusty/mysql-1)
-adding charm local:trusty/wordpress-3
-deploying service wordpress (charm: local:trusty/wordpress-3)
-relating wordpress:db and mysql:server
+added charm local:trusty/mysql-1
+service mysql deployed (charm: local:trusty/mysql-1)
+added charm local:trusty/wordpress-3
+service wordpress deployed (charm: local:trusty/wordpress-3)
+related wordpress:db and mysql:server
 deployment of bundle "local:bundle/example-0" completed`
 	c.Assert(output, gc.Equals, strings.TrimSpace(expectedOutput))
 	s.assertCharmsUplodaded(c, "local:trusty/mysql-1", "local:trusty/wordpress-3")
@@ -270,11 +270,11 @@ func (s *deployRepoCharmStoreSuite) TestDeployBundleLocalAndCharmStoreCharms(c *
     `)
 	c.Assert(err, jc.ErrorIsNil)
 	expectedOutput := `
-adding charm local:trusty/mysql-1
-deploying service mysql (charm: local:trusty/mysql-1)
-adding charm cs:trusty/wordpress-42
-deploying service wordpress (charm: cs:trusty/wordpress-42)
-relating wordpress:db and mysql:server
+added charm local:trusty/mysql-1
+service mysql deployed (charm: local:trusty/mysql-1)
+added charm cs:trusty/wordpress-42
+service wordpress deployed (charm: cs:trusty/wordpress-42)
+related wordpress:db and mysql:server
 deployment of bundle "local:bundle/example-0" completed`
 	c.Assert(output, gc.Equals, strings.TrimSpace(expectedOutput))
 	s.assertCharmsUplodaded(c, "local:trusty/mysql-1", "cs:trusty/wordpress-42")
@@ -304,12 +304,12 @@ func (s *deployRepoCharmStoreSuite) TestDeployBundleServiceOptions(c *gc.C) {
     `)
 	c.Assert(err, jc.ErrorIsNil)
 	expectedOutput := `
-adding charm cs:precise/dummy-0
-deploying service customized (charm: cs:precise/dummy-0)
-configuring service customized
-adding charm cs:trusty/wordpress-42
-deploying service wordpress (charm: cs:trusty/wordpress-42)
-configuring service wordpress
+added charm cs:precise/dummy-0
+service customized deployed (charm: cs:precise/dummy-0)
+service customized configured
+added charm cs:trusty/wordpress-42
+service wordpress deployed (charm: cs:trusty/wordpress-42)
+service wordpress configured
 deployment of bundle "local:bundle/example-0" completed`
 	c.Assert(output, gc.Equals, strings.TrimSpace(expectedOutput))
 	s.assertCharmsUplodaded(c, "cs:precise/dummy-0", "cs:trusty/wordpress-42")
@@ -344,11 +344,11 @@ func (s *deployRepoCharmStoreSuite) TestDeployBundleServiceUpgrade(c *gc.C) {
     `)
 	c.Assert(err, jc.ErrorIsNil)
 	expectedOutput := `
-adding charm cs:vivid/upgrade-1
-deploying service up (charm: cs:vivid/upgrade-1)
-adding charm cs:trusty/wordpress-42
-deploying service wordpress (charm: cs:trusty/wordpress-42)
-configuring service wordpress
+added charm cs:vivid/upgrade-1
+service up deployed (charm: cs:vivid/upgrade-1)
+added charm cs:trusty/wordpress-42
+service wordpress deployed (charm: cs:trusty/wordpress-42)
+service wordpress configured
 deployment of bundle "local:bundle/example-0" completed`
 	c.Assert(output, gc.Equals, strings.TrimSpace(expectedOutput))
 	s.assertCharmsUplodaded(c, "cs:vivid/upgrade-1", "cs:trusty/wordpress-42")
@@ -367,11 +367,11 @@ deployment of bundle "local:bundle/example-0" completed`
     `)
 	c.Assert(err, jc.ErrorIsNil)
 	expectedOutput = `
-adding charm cs:vivid/upgrade-2
-upgrading charm for existing service up (from cs:vivid/upgrade-1 to cs:vivid/upgrade-2)
-adding charm cs:trusty/wordpress-42
+added charm cs:vivid/upgrade-2
+upgraded charm for existing service up (from cs:vivid/upgrade-1 to cs:vivid/upgrade-2)
+added charm cs:trusty/wordpress-42
 reusing service wordpress (charm: cs:trusty/wordpress-42)
-configuring service wordpress
+service wordpress configured
 deployment of bundle "local:bundle/example-0" completed`
 	c.Assert(output, gc.Equals, strings.TrimSpace(expectedOutput))
 	s.assertCharmsUplodaded(c, "cs:vivid/upgrade-1", "cs:vivid/upgrade-2", "cs:trusty/wordpress-42")
@@ -444,17 +444,17 @@ func (s *deployRepoCharmStoreSuite) TestDeployBundleMultipleRelations(c *gc.C) {
     `)
 	c.Assert(err, jc.ErrorIsNil)
 	expectedOutput := `
-adding charm cs:trusty/mysql-1
-deploying service mysql (charm: cs:trusty/mysql-1)
-adding charm cs:trusty/postgres-2
-deploying service pgres (charm: cs:trusty/postgres-2)
-adding charm cs:trusty/varnish-3
-deploying service varnish (charm: cs:trusty/varnish-3)
-adding charm cs:trusty/wordpress-0
-deploying service wp (charm: cs:trusty/wordpress-0)
-relating wp:db and mysql:server
-relating wp:db and pgres:server
-relating varnish:webcache and wp:cache
+added charm cs:trusty/mysql-1
+service mysql deployed (charm: cs:trusty/mysql-1)
+added charm cs:trusty/postgres-2
+service pgres deployed (charm: cs:trusty/postgres-2)
+added charm cs:trusty/varnish-3
+service varnish deployed (charm: cs:trusty/varnish-3)
+added charm cs:trusty/wordpress-0
+service wp deployed (charm: cs:trusty/wordpress-0)
+related wp:db and mysql:server
+related wp:db and pgres:server
+related varnish:webcache and wp:cache
 deployment of bundle "local:bundle/example-0" completed`
 	c.Assert(output, gc.Equals, strings.TrimSpace(expectedOutput))
 	s.assertRelationsEstablished(c, "wp:db mysql:server", "wp:db pgres:server", "wp:cache varnish:webcache")
@@ -497,14 +497,14 @@ func (s *deployRepoCharmStoreSuite) TestDeployBundleNewRelations(c *gc.C) {
     `)
 	c.Assert(err, jc.ErrorIsNil)
 	expectedOutput := `
-adding charm cs:trusty/mysql-1
+added charm cs:trusty/mysql-1
 reusing service mysql (charm: cs:trusty/mysql-1)
-adding charm cs:trusty/varnish-3
+added charm cs:trusty/varnish-3
 reusing service varnish (charm: cs:trusty/varnish-3)
-adding charm cs:trusty/wordpress-0
+added charm cs:trusty/wordpress-0
 reusing service wp (charm: cs:trusty/wordpress-0)
 wp:db and mysql:server are already related
-relating varnish:webcache and wp:cache
+related varnish:webcache and wp:cache
 deployment of bundle "local:bundle/example-0" completed`
 	c.Assert(output, gc.Equals, strings.TrimSpace(expectedOutput))
 	s.assertRelationsEstablished(c, "wp:db mysql:server", "wp:cache varnish:webcache")

--- a/cmd/juju/commands/bundle_test.go
+++ b/cmd/juju/commands/bundle_test.go
@@ -395,7 +395,7 @@ func (s *deployRepoCharmStoreSuite) TestDeployBundleServiceUpgradeFailure(c *gc.
                 charm: trusty/incompatible-42
                 num_units: 1
     `)
-	c.Assert(err, gc.ErrorMatches, `cannot deploy bundle: cannot upgrade charm for service "wordpress": charm "cs:trusty/incompatible-42" is incompatible with charm "local:quantal/wordpress-3"`)
+	c.Assert(err, gc.ErrorMatches, `cannot deploy bundle: cannot upgrade service "wordpress": bundle charm "cs:trusty/incompatible-42" is incompatible with existing charm "local:quantal/wordpress-3"`)
 
 	// Try upgrading to a different user.
 	testcharms.UploadCharm(c, s.client, "~who/trusty/wordpress-42", "wordpress")
@@ -405,7 +405,7 @@ func (s *deployRepoCharmStoreSuite) TestDeployBundleServiceUpgradeFailure(c *gc.
                 charm: cs:~who/trusty/wordpress-42
                 num_units: 1
     `)
-	c.Assert(err, gc.ErrorMatches, `cannot deploy bundle: cannot upgrade charm for service "wordpress": charm "cs:~who/trusty/wordpress-42" is incompatible with charm "local:quantal/wordpress-3"`)
+	c.Assert(err, gc.ErrorMatches, `cannot deploy bundle: cannot upgrade service "wordpress": bundle charm "cs:~who/trusty/wordpress-42" is incompatible with existing charm "local:quantal/wordpress-3"`)
 
 	// Try upgrading to a different series.
 	testcharms.UploadCharm(c, s.client, "vivid/wordpress-42", "wordpress")
@@ -415,7 +415,7 @@ func (s *deployRepoCharmStoreSuite) TestDeployBundleServiceUpgradeFailure(c *gc.
                 charm: vivid/wordpress
                 num_units: 1
     `)
-	c.Assert(err, gc.ErrorMatches, `cannot deploy bundle: cannot upgrade charm for service "wordpress": cannot change a service's series`)
+	c.Assert(err, gc.ErrorMatches, `cannot deploy bundle: cannot upgrade service "wordpress": cannot upgrade charm to "cs:vivid/wordpress-42": cannot change a service's series`)
 }
 
 func (s *deployRepoCharmStoreSuite) TestDeployBundleMultipleRelations(c *gc.C) {

--- a/cmd/juju/commands/deploy_test.go
+++ b/cmd/juju/commands/deploy_test.go
@@ -449,11 +449,11 @@ var deployAuthorizationTests = []struct {
 	uploadURL: "cs:~bob/bundle/wordpress-simple1-42",
 	deployURL: "cs:~bob/bundle/wordpress-simple1",
 	expectOutput: `
-adding charm cs:trusty/mysql-0
-deploying service mysql (charm: cs:trusty/mysql-0)
-adding charm cs:trusty/wordpress-1
-deploying service wordpress (charm: cs:trusty/wordpress-1)
-relating wordpress:db and mysql:server
+added charm cs:trusty/mysql-0
+service mysql deployed (charm: cs:trusty/mysql-0)
+added charm cs:trusty/wordpress-1
+service wordpress deployed (charm: cs:trusty/wordpress-1)
+related wordpress:db and mysql:server
 deployment of bundle "cs:~bob/bundle/wordpress-simple1-42" completed`,
 }, {
 	about:        "non-public bundle, success",
@@ -461,9 +461,9 @@ deployment of bundle "cs:~bob/bundle/wordpress-simple1-42" completed`,
 	deployURL:    "cs:~bob/bundle/wordpress-simple2-0",
 	readPermUser: clientUserName,
 	expectOutput: `
-adding charm cs:trusty/mysql-0
+added charm cs:trusty/mysql-0
 reusing service mysql (charm: cs:trusty/mysql-0)
-adding charm cs:trusty/wordpress-1
+added charm cs:trusty/wordpress-1
 reusing service wordpress (charm: cs:trusty/wordpress-1)
 wordpress:db and mysql:server are already related
 deployment of bundle "cs:~bob/bundle/wordpress-simple2-0" completed`,

--- a/cmd/juju/commands/deploy_test.go
+++ b/cmd/juju/commands/deploy_test.go
@@ -453,6 +453,7 @@ adding charm cs:trusty/mysql-0
 deploying service mysql (charm: cs:trusty/mysql-0)
 adding charm cs:trusty/wordpress-1
 deploying service wordpress (charm: cs:trusty/wordpress-1)
+relating wordpress:db and mysql:server
 deployment of bundle "cs:~bob/bundle/wordpress-simple1-42" completed`,
 }, {
 	about:        "non-public bundle, success",
@@ -464,6 +465,7 @@ adding charm cs:trusty/mysql-0
 reusing service mysql (charm: cs:trusty/mysql-0)
 adding charm cs:trusty/wordpress-1
 reusing service wordpress (charm: cs:trusty/wordpress-1)
+wordpress:db and mysql:server are already related
 deployment of bundle "cs:~bob/bundle/wordpress-simple2-0" completed`,
 }, {
 	about:        "non-public bundle, access denied",
@@ -641,6 +643,17 @@ func (s *charmStoreSuite) assertServicesDeployed(c *gc.C, info map[string]servic
 		}
 	}
 	c.Assert(deployed, jc.DeepEquals, info)
+}
+
+// assertRelationsEstablished checks that the given relations have been set.
+func (s *charmStoreSuite) assertRelationsEstablished(c *gc.C, relations ...string) {
+	rs, err := s.State.AllRelations()
+	c.Assert(err, jc.ErrorIsNil)
+	established := make([]string, len(rs))
+	for i, r := range rs {
+		established[i] = r.String()
+	}
+	c.Assert(established, jc.SameContents, relations)
 }
 
 type testMetricCredentialsSetter struct {


### PR DESCRIPTION
Add relations between services if not already established.
Note that this is proposed to be merged against the `guibundles` feature branch.

(Review request: http://reviews.vapour.ws/r/2633/)