### PR TITLE
Refactoring cmd/juju

### DIFF
--- a/cmd/envcmd/base.go
+++ b/cmd/envcmd/base.go
@@ -1,0 +1,91 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package envcmd
+
+import (
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+	"launchpad.net/gnuflag"
+
+	"github.com/juju/juju/api"
+	"github.com/juju/juju/juju"
+)
+
+var errNoNameSpecified = errors.New("no name specified")
+
+// CommandBase extends cmd.Command with a setAPIContext method.
+type CommandBase interface {
+	cmd.Command
+
+	setAPIContext(ctx *apiContext)
+}
+
+// JujuCommandBase is a convenience type for embedding that need
+// an API connection.
+type JujuCommandBase struct {
+	cmd.CommandBase
+	*apiContext
+}
+
+func (c *JujuCommandBase) setAPIContext(ctx *apiContext) {
+	c.apiContext = ctx
+}
+
+// WrapBase wraps the specified CommandBase, returning a Command
+// that proxies to each of the CommandBase methods.
+func WrapBase(c CommandBase) cmd.Command {
+	return &baseCommandWrapper{
+		CommandBase: c,
+	}
+}
+
+type baseCommandWrapper struct {
+	CommandBase
+}
+
+// Run implements Command.Run.
+func (w *baseCommandWrapper) Run(ctx *cmd.Context) error {
+	w.CommandBase.setAPIContext(&apiContext{})
+	return w.CommandBase.Run(ctx)
+}
+
+// SetFlags implements Command.SetFlags.
+func (w *baseCommandWrapper) SetFlags(f *gnuflag.FlagSet) {
+	w.CommandBase.SetFlags(f)
+}
+
+// Init implements Command.Init.
+func (w *baseCommandWrapper) Init(args []string) error {
+	return w.CommandBase.Init(args)
+}
+
+// apiContext is a convenience type that can be embedded wherever
+// we need an API connection.
+type apiContext struct {
+}
+
+// APIOpen establishes a connection to the API server using the
+// the give api.Info and api.DialOpts.
+func (ctx *apiContext) APIOpen(info *api.Info, opts api.DialOpts) (api.Connection, error) {
+	return api.Open(info, opts)
+}
+
+// NewAPIRoot establishes a connection to the API server for
+// the named environment.
+func (ctx *apiContext) NewAPIRoot(name string) (api.Connection, error) {
+	if name == "" {
+		return nil, errors.Trace(errNoNameSpecified)
+	}
+	return juju.NewAPIFromName(name)
+}
+
+// NewAPIClient returns an api.Client connecte to the API server
+// for the named environment.
+func (ctx *apiContext) NewAPIClient(name string) (*api.Client, error) {
+	root, err := ctx.NewAPIRoot(name)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return root.Client(), nil
+}

--- a/cmd/envcmd/environmentcommand.go
+++ b/cmd/envcmd/environmentcommand.go
@@ -17,7 +17,6 @@ import (
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/configstore"
-	"github.com/juju/juju/juju"
 	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/version"
 )
@@ -68,12 +67,19 @@ type EnvironCommand interface {
 	// with the active environment name. The environment name is guaranteed
 	// to be non-empty at entry of Init.
 	SetEnvName(envName string)
+
+	// EnvName returns the name of the environment.
+	EnvName() string
+
+	setAPIContext(ctx *apiContext)
 }
 
 // EnvCommandBase is a convenience type for embedding in commands
 // that wish to implement EnvironCommand.
 type EnvCommandBase struct {
 	cmd.CommandBase
+	*apiContext
+
 	// EnvName will very soon be package visible only as we want to be able
 	// to specify an environment in multiple ways, and not always referencing
 	// a file on disk based on the EnvName or the environemnts.yaml file.
@@ -87,8 +93,19 @@ type EnvCommandBase struct {
 	envGetterErr    error
 }
 
+// setAPIContext implements the EvnironCommand interface.
+func (c *EnvCommandBase) setAPIContext(ctx *apiContext) {
+	c.apiContext = ctx
+}
+
+// SetEnvName implements the EnvironCommand interface.
 func (c *EnvCommandBase) SetEnvName(envName string) {
 	c.envName = envName
+}
+
+// EnvName implements the EnvironCommand interface.
+func (c *EnvCommandBase) EnvName() string {
+	return c.envName
 }
 
 func (c *EnvCommandBase) NewAPIClient() (*api.Client, error) {
@@ -120,7 +137,7 @@ func (c *EnvCommandBase) NewAPIRoot() (api.Connection, error) {
 	if c.envName == "" {
 		return nil, errors.Trace(ErrNoEnvironmentSpecified)
 	}
-	return juju.NewAPIFromName(c.envName)
+	return c.apiContext.NewAPIRoot(c.envName)
 }
 
 // Config returns the configuration for the environment; obtaining bootstrap
@@ -282,34 +299,74 @@ func (c *EnvCommandBase) ConnectionName() string {
 	return c.envName
 }
 
+// WrapSystemOption sets various parameters of the
+// EnvironCommand wrapper.
+type WrapEnvOption func(*environCommandWrapper)
+
+// EnvSkipFlags instructs the wrapper to skip --e and
+// --environment flag definition.
+func EnvSkipFlags(w *environCommandWrapper) {
+	w.setFlags = false
+}
+
+// EnvSkipDefault instructs the wrapper not to
+// use the default environment.
+func EnvSkipDefault(w *environCommandWrapper) {
+	w.useDefaultEnvironment = false
+}
+
 // Wrap wraps the specified EnvironCommand, returning a Command
 // that proxies to each of the EnvironCommand methods.
-func Wrap(c EnvironCommand) cmd.Command {
-	return &environCommandWrapper{EnvironCommand: c}
+// Any provided options are applied to the wrapped command
+// before it is returned.
+func Wrap(c EnvironCommand, options ...WrapEnvOption) cmd.Command {
+	wrapper := &environCommandWrapper{
+		EnvironCommand:        c,
+		setFlags:              true,
+		useDefaultEnvironment: true,
+	}
+	for _, option := range options {
+		option(wrapper)
+	}
+	return wrapper
 }
 
 type environCommandWrapper struct {
 	EnvironCommand
-	envName string
+	setFlags              bool
+	useDefaultEnvironment bool
+	envName               string
 }
 
 func (w *environCommandWrapper) SetFlags(f *gnuflag.FlagSet) {
-	f.StringVar(&w.envName, "e", "", "juju environment to operate in")
-	f.StringVar(&w.envName, "environment", "", "")
+	if w.setFlags {
+		f.StringVar(&w.envName, "e", "", "juju environment to operate in")
+		f.StringVar(&w.envName, "environment", "", "")
+	}
 	w.EnvironCommand.SetFlags(f)
 }
 
 func (w *environCommandWrapper) Init(args []string) error {
-	if w.envName == "" {
-		// Look for the default.
-		defaultEnv, err := GetDefaultEnvironment()
-		if err != nil {
-			return err
+	if w.setFlags {
+		if w.envName == "" && w.useDefaultEnvironment {
+			// Look for the default.
+			defaultEnv, err := GetDefaultEnvironment()
+			if err != nil {
+				return err
+			}
+			w.envName = defaultEnv
 		}
-		w.envName = defaultEnv
+		if w.envName == "" && !w.useDefaultEnvironment {
+			return ErrNoEnvironmentSpecified
+		}
 	}
 	w.SetEnvName(w.envName)
 	return w.EnvironCommand.Init(args)
+}
+
+func (w *environCommandWrapper) Run(ctx *cmd.Context) error {
+	w.EnvironCommand.setAPIContext(&apiContext{})
+	return w.EnvironCommand.Run(ctx)
 }
 
 type bootstrapContext struct {

--- a/cmd/envcmd/environmentcommand_test.go
+++ b/cmd/envcmd/environmentcommand_test.go
@@ -148,6 +148,13 @@ func (s *EnvironmentCommandSuite) TestCompatVersionInvalid(c *gc.C) {
 	c.Assert(cmd.CompatVersion(), gc.Equals, 1)
 }
 
+func (s *EnvironmentCommandSuite) TestWrapWithoutFlags(c *gc.C) {
+	cmd := new(testCommand)
+	wrapped := envcmd.Wrap(cmd, envcmd.EnvSkipFlags)
+	err := cmdtesting.InitCommand(wrapped, []string{"-e", "testenv"})
+	c.Assert(err, gc.ErrorMatches, "flag provided but not defined: -e")
+}
+
 type testCommand struct {
 	envcmd.EnvCommandBase
 }

--- a/cmd/envcmd/systemcommand.go
+++ b/cmd/envcmd/systemcommand.go
@@ -13,7 +13,6 @@ import (
 	"github.com/juju/juju/api/systemmanager"
 	"github.com/juju/juju/api/usermanager"
 	"github.com/juju/juju/environs/configstore"
-	"github.com/juju/juju/juju"
 )
 
 // ErrNoSystemSpecified is returned by commands that operate on
@@ -28,28 +27,37 @@ type SystemCommand interface {
 
 	// SetSystemName is called prior to the wrapped command's Init method with
 	// the active system name. The system name is guaranteed to be non-empty
-	// at entry of Init.
+	// at entry of Init. It records the current environment name in the
+	// SysCommandBase.
 	SetSystemName(systemName string)
 
 	// SystemName returns the name of the system or environment used to
 	// determine that API end point.
 	SystemName() string
+
+	setAPIContext(ctx *apiContext)
 }
 
 // SysCommandBase is a convenience type for embedding in commands
 // that wish to implement SystemCommand.
 type SysCommandBase struct {
 	cmd.CommandBase
+	*apiContext
+
 	systemName string
 }
 
-// SetSystemName records the current environment name in the SysCommandBase
+// setAPIContext implements the EvnironCommand interface.
+func (c *SysCommandBase) setAPIContext(ctx *apiContext) {
+	c.apiContext = ctx
+}
+
+// SetSystemName implements the SystemCommand interface.
 func (c *SysCommandBase) SetSystemName(systemName string) {
 	c.systemName = systemName
 }
 
-// SystemName returns the name of the system or environment used to determine
-// that API end point.
+// SystemName implements the SystemCommand interface.
 func (c *SysCommandBase) SystemName() string {
 	return c.systemName
 }
@@ -91,7 +99,7 @@ func (c *SysCommandBase) newAPIRoot() (api.Connection, error) {
 	if c.systemName == "" {
 		return nil, errors.Trace(ErrNoSystemSpecified)
 	}
-	return juju.NewAPIFromName(c.systemName)
+	return c.NewAPIRoot(c.systemName)
 }
 
 // ConnectionCredentials returns the credentials used to connect to the API for
@@ -134,21 +142,49 @@ func (c *SysCommandBase) ConnectionInfo() (configstore.EnvironInfo, error) {
 	return info, nil
 }
 
-// Wrap wraps the specified SystemCommand, returning a Command
+// WrapSystemOption sets various parameters of the
+// SystemCommand wrapper.
+type WrapSystemOption func(*sysCommandWrapper)
+
+// SystemSkipFlags instructs the wrapper to skip --s
+// and --system flag definition.
+func SystemSkipFlags(w *sysCommandWrapper) {
+	w.setFlags = false
+}
+
+// SystemSkipDefault instructs the wrapper not to
+// use the default system name.
+func SystemSkipDefault(w *sysCommandWrapper) {
+	w.useDefaultSystemName = false
+}
+
+// WrapSystem wraps the specified SystemCommand, returning a Command
 // that proxies to each of the SystemCommand methods.
-func WrapSystem(c SystemCommand) cmd.Command {
-	return &sysCommandWrapper{SystemCommand: c}
+func WrapSystem(c SystemCommand, options ...WrapSystemOption) cmd.Command {
+	wrapper := &sysCommandWrapper{
+		SystemCommand:        c,
+		setFlags:             true,
+		useDefaultSystemName: true,
+	}
+	for _, option := range options {
+		option(wrapper)
+	}
+	return wrapper
 }
 
 type sysCommandWrapper struct {
 	SystemCommand
-	systemName string
+	setFlags             bool
+	useDefaultSystemName bool
+	systemName           string
 }
 
 // SetFlags implements Command.SetFlags, then calls the wrapped command's SetFlags.
 func (w *sysCommandWrapper) SetFlags(f *gnuflag.FlagSet) {
-	f.StringVar(&w.systemName, "s", "", "juju system to operate in")
-	f.StringVar(&w.systemName, "system", "", "")
+	if w.setFlags {
+		f.StringVar(&w.systemName, "s", "", "juju system to operate in")
+		f.StringVar(&w.systemName, "system", "", "")
+	}
 	w.SystemCommand.SetFlags(f)
 }
 
@@ -168,13 +204,23 @@ func (w *sysCommandWrapper) getDefaultSystemName() (string, error) {
 
 // Init implements Command.Init, then calls the wrapped command's Init.
 func (w *sysCommandWrapper) Init(args []string) error {
-	if w.systemName == "" {
-		name, err := w.getDefaultSystemName()
-		if err != nil {
-			return errors.Trace(err)
+	if w.setFlags {
+		if w.systemName == "" && w.useDefaultSystemName {
+			name, err := w.getDefaultSystemName()
+			if err != nil {
+				return errors.Trace(err)
+			}
+			w.systemName = name
 		}
-		w.systemName = name
+		if w.systemName == "" && !w.useDefaultSystemName {
+			return ErrNoSystemSpecified
+		}
 	}
 	w.SetSystemName(w.systemName)
 	return w.SystemCommand.Init(args)
+}
+
+func (w *sysCommandWrapper) Run(ctx *cmd.Context) error {
+	w.SystemCommand.setAPIContext(&apiContext{})
+	return w.SystemCommand.Run(ctx)
 }

--- a/cmd/envcmd/systemcommand_test.go
+++ b/cmd/envcmd/systemcommand_test.go
@@ -60,6 +60,13 @@ func (s *SystemCommandSuite) TestSystemCommandInitExplicit(c *gc.C) {
 	testEnsureSystemName(c, "explicit", "--system", "explicit")
 }
 
+func (s *SystemCommandSuite) TestWrapWithoutFlags(c *gc.C) {
+	cmd := new(testSystemCommand)
+	wrapped := envcmd.WrapSystem(cmd, envcmd.SystemSkipFlags)
+	err := cmdtesting.InitCommand(wrapped, []string{"-s", "testsys"})
+	c.Assert(err, gc.ErrorMatches, "flag provided but not defined: -s")
+}
+
 type testSystemCommand struct {
 	envcmd.SysCommandBase
 }

--- a/cmd/juju/action/action.go
+++ b/cmd/juju/action/action.go
@@ -32,10 +32,10 @@ func NewSuperCommand() cmd.Command {
 			UsagePrefix: "juju",
 			Purpose:     actionPurpose,
 		})
-	actionCmd.Register(envcmd.Wrap(&DefinedCommand{}))
-	actionCmd.Register(envcmd.Wrap(&DoCommand{}))
-	actionCmd.Register(envcmd.Wrap(&FetchCommand{}))
-	actionCmd.Register(envcmd.Wrap(&StatusCommand{}))
+	actionCmd.Register(newDefinedCommand())
+	actionCmd.Register(newDoCommand())
+	actionCmd.Register(newFetchCommand())
+	actionCmd.Register(newStatusCommand())
 	return actionCmd
 }
 

--- a/cmd/juju/action/defined.go
+++ b/cmd/juju/action/defined.go
@@ -10,10 +10,15 @@ import (
 	"launchpad.net/gnuflag"
 
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/envcmd"
 )
 
-// DefinedCommand lists actions defined by the charm of a given service.
-type DefinedCommand struct {
+func newDefinedCommand() cmd.Command {
+	return envcmd.Wrap(&definedCommand{})
+}
+
+// definedCommand lists actions defined by the charm of a given service.
+type definedCommand struct {
 	ActionCommandBase
 	serviceTag names.ServiceTag
 	fullSchema bool
@@ -28,12 +33,12 @@ For more information, see also the 'do' subcommand, which executes actions.
 `
 
 // Set up the output.
-func (c *DefinedCommand) SetFlags(f *gnuflag.FlagSet) {
+func (c *definedCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.out.AddFlags(f, "smart", cmd.DefaultFormatters)
 	f.BoolVar(&c.fullSchema, "schema", false, "display the full action schema")
 }
 
-func (c *DefinedCommand) Info() *cmd.Info {
+func (c *definedCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "defined",
 		Args:    "<service name>",
@@ -43,7 +48,7 @@ func (c *DefinedCommand) Info() *cmd.Info {
 }
 
 // Init validates the service name and any other options.
-func (c *DefinedCommand) Init(args []string) error {
+func (c *definedCommand) Init(args []string) error {
 	switch len(args) {
 	case 0:
 		return errors.New("no service name specified")
@@ -61,7 +66,7 @@ func (c *DefinedCommand) Init(args []string) error {
 
 // Run grabs the Actions spec from the api.  It then sets up a sensible
 // output format for the map.
-func (c *DefinedCommand) Run(ctx *cmd.Context) error {
+func (c *definedCommand) Run(ctx *cmd.Context) error {
 	api, err := c.NewActionAPIClient()
 	if err != nil {
 		return err

--- a/cmd/juju/action/do.go
+++ b/cmd/juju/action/do.go
@@ -15,13 +15,18 @@ import (
 	"launchpad.net/gnuflag"
 
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/envcmd"
 )
 
 var keyRule = regexp.MustCompile("^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$")
 
-// DoCommand enqueues an Action for running on the given unit with given
+func newDoCommand() cmd.Command {
+	return envcmd.Wrap(&doCommand{})
+}
+
+// doCommand enqueues an Action for running on the given unit with given
 // params
-type DoCommand struct {
+type doCommand struct {
 	ActionCommandBase
 	unitTag      names.UnitTag
 	actionName   string
@@ -99,17 +104,17 @@ $ juju action do sleeper/0 pause --string-args time=1000
 The value for the "time" param will be the string literal "1000".
 `
 
-// actionNameRule describes the format an action name must match to be valid.
-var actionNameRule = regexp.MustCompile("^[a-z](?:[a-z-]*[a-z])?$")
+// ActionNameRule describes the format an action name must match to be valid.
+var ActionNameRule = regexp.MustCompile("^[a-z](?:[a-z-]*[a-z])?$")
 
 // SetFlags offers an option for YAML output.
-func (c *DoCommand) SetFlags(f *gnuflag.FlagSet) {
+func (c *doCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.out.AddFlags(f, "smart", cmd.DefaultFormatters)
 	f.Var(&c.paramsYAML, "params", "path to yaml-formatted params file")
 	f.BoolVar(&c.parseStrings, "string-args", false, "use raw string values of CLI args")
 }
 
-func (c *DoCommand) Info() *cmd.Info {
+func (c *doCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "do",
 		Args:    "<unit> <action name> [key.key.key...=value]",
@@ -119,7 +124,7 @@ func (c *DoCommand) Info() *cmd.Info {
 }
 
 // Init gets the unit tag, and checks for other correct args.
-func (c *DoCommand) Init(args []string) error {
+func (c *doCommand) Init(args []string) error {
 	switch len(args) {
 	case 0:
 		return errors.New("no unit specified")
@@ -131,12 +136,12 @@ func (c *DoCommand) Init(args []string) error {
 		if !names.IsValidUnit(unitName) {
 			return errors.Errorf("invalid unit name %q", unitName)
 		}
-		actionName := args[1]
-		if valid := actionNameRule.MatchString(actionName); !valid {
-			return fmt.Errorf("invalid action name %q", actionName)
+		ActionName := args[1]
+		if valid := ActionNameRule.MatchString(ActionName); !valid {
+			return fmt.Errorf("invalid action name %q", ActionName)
 		}
 		c.unitTag = names.NewUnitTag(unitName)
-		c.actionName = actionName
+		c.actionName = ActionName
 		if len(args) == 2 {
 			return nil
 		}
@@ -161,7 +166,7 @@ func (c *DoCommand) Init(args []string) error {
 	}
 }
 
-func (c *DoCommand) Run(ctx *cmd.Context) error {
+func (c *doCommand) Run(ctx *cmd.Context) error {
 	api, err := c.NewActionAPIClient()
 	if err != nil {
 		return err

--- a/cmd/juju/action/export_test.go
+++ b/cmd/juju/action/export_test.go
@@ -4,21 +4,21 @@
 package action
 
 import (
+	"github.com/juju/cmd"
 	"github.com/juju/names"
 
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/envcmd"
 )
 
 var (
 	NewActionAPIClient = &newAPIClient
+	NewFetchCommand    = newFetchCommand
+	NewStatusCommand   = newStatusCommand
 )
 
-func (c *DefinedCommand) ServiceTag() names.ServiceTag {
-	return c.serviceTag
-}
-
-func (c *DefinedCommand) FullSchema() bool {
-	return c.fullSchema
+type DoCommand struct {
+	*doCommand
 }
 
 func (c *DoCommand) UnitTag() names.UnitTag {
@@ -29,18 +29,39 @@ func (c *DoCommand) ActionName() string {
 	return c.actionName
 }
 
-func (c *DoCommand) ParamsYAMLPath() string {
-	return c.paramsYAML.Path
-}
-
-func (c *DoCommand) KeyValueDoArgs() [][]string {
-	return c.args
-}
-
 func (c *DoCommand) ParseStrings() bool {
 	return c.parseStrings
 }
 
+func (c *DoCommand) ParamsYAML() cmd.FileVar {
+	return c.paramsYAML
+}
+
+func (c *DoCommand) Args() [][]string {
+	return c.args
+}
+
+type DefinedCommand struct {
+	*definedCommand
+}
+
+func (c *DefinedCommand) ServiceTag() names.ServiceTag {
+	return c.serviceTag
+}
+
+func (c *DefinedCommand) FullSchema() bool {
+	return c.fullSchema
+}
+
+func NewDefinedCommand() (cmd.Command, *DefinedCommand) {
+	c := &definedCommand{}
+	return envcmd.Wrap(c, envcmd.EnvSkipDefault), &DefinedCommand{c}
+}
+
+func NewDoCommand() (cmd.Command, *DoCommand) {
+	c := &doCommand{}
+	return envcmd.Wrap(c, envcmd.EnvSkipDefault), &DoCommand{c}
+}
 func ActionResultsToMap(results []params.ActionResult) map[string]interface{} {
 	return resultsToMap(results)
 }

--- a/cmd/juju/action/fetch.go
+++ b/cmd/juju/action/fetch.go
@@ -12,10 +12,15 @@ import (
 	"launchpad.net/gnuflag"
 
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/envcmd"
 )
 
-// FetchCommand fetches the results of an action by ID.
-type FetchCommand struct {
+func newFetchCommand() cmd.Command {
+	return envcmd.Wrap(&fetchCommand{})
+}
+
+// fetchCommand fetches the results of an action by ID.
+type fetchCommand struct {
 	ActionCommandBase
 	out         cmd.Output
 	requestedId string
@@ -35,12 +40,12 @@ displayed.  This is also the behavior when any negative time is given.
 `
 
 // Set up the output.
-func (c *FetchCommand) SetFlags(f *gnuflag.FlagSet) {
+func (c *fetchCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.out.AddFlags(f, "smart", cmd.DefaultFormatters)
 	f.StringVar(&c.wait, "wait", "-1s", "wait for results")
 }
 
-func (c *FetchCommand) Info() *cmd.Info {
+func (c *fetchCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "fetch",
 		Args:    "<action ID>",
@@ -50,7 +55,7 @@ func (c *FetchCommand) Info() *cmd.Info {
 }
 
 // Init validates the action ID and any other options.
-func (c *FetchCommand) Init(args []string) error {
+func (c *fetchCommand) Init(args []string) error {
 	switch len(args) {
 	case 0:
 		return errors.New("no action ID specified")
@@ -63,7 +68,7 @@ func (c *FetchCommand) Init(args []string) error {
 }
 
 // Run issues the API call to get Actions by ID.
-func (c *FetchCommand) Run(ctx *cmd.Context) error {
+func (c *fetchCommand) Run(ctx *cmd.Context) error {
 	// Check whether units were left off our time string.
 	r := regexp.MustCompile("[a-zA-Z]")
 	matches := r.FindStringSubmatch(c.wait[len(c.wait)-1:])

--- a/cmd/juju/action/fetch_test.go
+++ b/cmd/juju/action/fetch_test.go
@@ -19,7 +19,6 @@ import (
 
 type FetchSuite struct {
 	BaseActionSuite
-	subcommand *action.FetchCommand
 }
 
 var _ = gc.Suite(&FetchSuite{})
@@ -29,7 +28,8 @@ func (s *FetchSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *FetchSuite) TestHelp(c *gc.C) {
-	s.checkHelp(c, s.subcommand)
+	cmd := action.NewFetchCommand()
+	s.checkHelp(c, cmd)
 }
 
 func (s *FetchSuite) TestInit(c *gc.C) {
@@ -50,7 +50,9 @@ func (s *FetchSuite) TestInit(c *gc.C) {
 	for i, t := range tests {
 		c.Logf("test %d: it should %s: juju actions fetch %s", i,
 			t.should, strings.Join(t.args, " "))
-		err := testing.InitCommand(&action.FetchCommand{}, t.args)
+		cmd := action.NewFetchCommand()
+		args := append([]string{"-e", "dummyenv"}, t.args...)
+		err := testing.InitCommand(cmd, args)
 		if t.expectError != "" {
 			c.Check(err, gc.ErrorMatches, t.expectError)
 		}
@@ -290,12 +292,13 @@ timing:
 func testRunHelper(c *gc.C, s *FetchSuite, client *fakeAPIClient, expectedErr, expectedOutput, wait, query string) {
 	unpatch := s.BaseActionSuite.patchAPIClient(client)
 	defer unpatch()
-	args := []string{query}
+	args := append([]string{"-e", "dummyenv"}, []string{query}...)
 	if wait != "" {
 		args = append(args, "--wait")
 		args = append(args, wait)
 	}
-	ctx, err := testing.RunCommand(c, &action.FetchCommand{}, args...)
+	cmd := action.NewFetchCommand()
+	ctx, err := testing.RunCommand(c, cmd, args...)
 	if expectedErr != "" {
 		c.Check(err, gc.ErrorMatches, expectedErr)
 	} else {

--- a/cmd/juju/action/status.go
+++ b/cmd/juju/action/status.go
@@ -10,10 +10,15 @@ import (
 	"launchpad.net/gnuflag"
 
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/envcmd"
 )
 
-// StatusCommand shows the status of an Action by ID.
-type StatusCommand struct {
+func newStatusCommand() cmd.Command {
+	return envcmd.Wrap(&statusCommand{})
+}
+
+// statusCommand shows the status of an Action by ID.
+type statusCommand struct {
 	ActionCommandBase
 	out         cmd.Output
 	requestedId string
@@ -24,11 +29,11 @@ Show the status of Actions matching given ID, partial ID prefix, or all Actions 
 `
 
 // Set up the output.
-func (c *StatusCommand) SetFlags(f *gnuflag.FlagSet) {
+func (c *statusCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.out.AddFlags(f, "smart", cmd.DefaultFormatters)
 }
 
-func (c *StatusCommand) Info() *cmd.Info {
+func (c *statusCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "status",
 		Args:    "[<action ID>|<action ID prefix>]",
@@ -37,7 +42,7 @@ func (c *StatusCommand) Info() *cmd.Info {
 	}
 }
 
-func (c *StatusCommand) Init(args []string) error {
+func (c *statusCommand) Init(args []string) error {
 	switch len(args) {
 	case 0:
 		c.requestedId = ""
@@ -50,7 +55,7 @@ func (c *StatusCommand) Init(args []string) error {
 	}
 }
 
-func (c *StatusCommand) Run(ctx *cmd.Context) error {
+func (c *statusCommand) Run(ctx *cmd.Context) error {
 	api, err := c.NewActionAPIClient()
 	if err != nil {
 		return err

--- a/cmd/juju/action/status_test.go
+++ b/cmd/juju/action/status_test.go
@@ -25,7 +25,7 @@ var _ = gc.Suite(&StatusSuite{})
 
 func (s *StatusSuite) SetUpTest(c *gc.C) {
 	s.BaseActionSuite.SetUpTest(c)
-	s.subcommand = &action.StatusCommand{}
+	s.subcommand = action.NewStatusCommand()
 }
 
 func (s *StatusSuite) TestHelp(c *gc.C) {
@@ -82,12 +82,13 @@ func (s *StatusSuite) runTestCase(c *gc.C, tc statusTestCase) {
 	restore := s.patchAPIClient(fakeClient)
 	defer restore()
 
-	s.subcommand = &action.StatusCommand{}
-	ctx, err := testing.RunCommand(c, s.subcommand, tc.args...)
+	s.subcommand = action.NewStatusCommand()
+	args := append([]string{"-e", "dummyenv"}, tc.args...)
+	ctx, err := testing.RunCommand(c, s.subcommand, args...)
 	if tc.expectError == "" {
-		c.Check(err, jc.ErrorIsNil)
+		c.Assert(err, jc.ErrorIsNil)
 	} else {
-		c.Check(err, gc.ErrorMatches, tc.expectError)
+		c.Assert(err, gc.ErrorMatches, tc.expectError)
 	}
 	if len(tc.results) > 0 {
 		buf, err := cmd.DefaultFormatters["yaml"](action.ActionResultsToMap(tc.results))

--- a/cmd/juju/backups/backups.go
+++ b/cmd/juju/backups/backups.go
@@ -55,13 +55,13 @@ func NewCommand() cmd.Command {
 			},
 		),
 	}
-	backupsCmd.Register(envcmd.Wrap(&CreateCommand{}))
-	backupsCmd.Register(envcmd.Wrap(&InfoCommand{}))
-	backupsCmd.Register(envcmd.Wrap(&ListCommand{}))
-	backupsCmd.Register(envcmd.Wrap(&DownloadCommand{}))
-	backupsCmd.Register(envcmd.Wrap(&UploadCommand{}))
-	backupsCmd.Register(envcmd.Wrap(&RemoveCommand{}))
-	backupsCmd.Register(envcmd.Wrap(&RestoreCommand{}))
+	backupsCmd.Register(newCreateCommand())
+	backupsCmd.Register(newInfoCommand())
+	backupsCmd.Register(newListCommand())
+	backupsCmd.Register(newDownloadCommand())
+	backupsCmd.Register(newUploadCommand())
+	backupsCmd.Register(newRemoveCommand())
+	backupsCmd.Register(newRestoreCommand())
 	return &backupsCmd
 }
 

--- a/cmd/juju/backups/create.go
+++ b/cmd/juju/backups/create.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/errors"
 	"launchpad.net/gnuflag"
 
+	"github.com/juju/juju/cmd/envcmd"
 	"github.com/juju/juju/state/backups"
 )
 
@@ -42,8 +43,12 @@ This local copy can then be used to restore an environment even if that
 environment was already destroyed or is otherwise unavailable.
 `
 
-// CreateCommand is the sub-command for creating a new backup.
-type CreateCommand struct {
+func newCreateCommand() cmd.Command {
+	return envcmd.Wrap(&createCommand{})
+}
+
+// createCommand is the sub-command for creating a new backup.
+type createCommand struct {
 	CommandBase
 	// Quiet indicates that the full metadata should not be dumped.
 	Quiet bool
@@ -56,7 +61,7 @@ type CreateCommand struct {
 }
 
 // Info implements Command.Info.
-func (c *CreateCommand) Info() *cmd.Info {
+func (c *createCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "create",
 		Args:    "[<notes>]",
@@ -66,14 +71,14 @@ func (c *CreateCommand) Info() *cmd.Info {
 }
 
 // SetFlags implements Command.SetFlags.
-func (c *CreateCommand) SetFlags(f *gnuflag.FlagSet) {
+func (c *createCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.BoolVar(&c.Quiet, "quiet", false, "do not print the metadata")
 	f.BoolVar(&c.NoDownload, "no-download", false, "do not download the archive")
 	f.StringVar(&c.Filename, "filename", notset, "download to this file")
 }
 
 // Init implements Command.Init.
-func (c *CreateCommand) Init(args []string) error {
+func (c *createCommand) Init(args []string) error {
 	notes, err := cmd.ZeroOrOneArgs(args)
 	if err != nil {
 		return err
@@ -91,7 +96,7 @@ func (c *CreateCommand) Init(args []string) error {
 }
 
 // Run implements Command.Run.
-func (c *CreateCommand) Run(ctx *cmd.Context) error {
+func (c *createCommand) Run(ctx *cmd.Context) error {
 	client, err := c.NewAPIClient()
 	if err != nil {
 		return errors.Trace(err)
@@ -123,7 +128,7 @@ func (c *CreateCommand) Run(ctx *cmd.Context) error {
 	return nil
 }
 
-func (c *CreateCommand) decideFilename(ctx *cmd.Context, filename string, timestamp time.Time) string {
+func (c *createCommand) decideFilename(ctx *cmd.Context, filename string, timestamp time.Time) string {
 	if filename != notset {
 		return filename
 	}
@@ -135,7 +140,7 @@ func (c *CreateCommand) decideFilename(ctx *cmd.Context, filename string, timest
 	return timestamp.Format(backups.FilenameTemplate)
 }
 
-func (c *CreateCommand) download(ctx *cmd.Context, id string, filename string) error {
+func (c *createCommand) download(ctx *cmd.Context, id string, filename string) error {
 	fmt.Fprintln(ctx.Stdout, "downloading to "+filename)
 
 	// TODO(ericsnow) lp-1399722 This needs further investigation:

--- a/cmd/juju/backups/create_test.go
+++ b/cmd/juju/backups/create_test.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/juju/cmd"
-	"github.com/juju/cmd/cmdtesting"
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -19,20 +18,21 @@ import (
 
 type createSuite struct {
 	BaseBackupsSuite
-	subcommand *backups.CreateCommand
+	wrappedCommand  cmd.Command
+	command         *backups.CreateCommand
+	defaultFilename string
 }
 
 var _ = gc.Suite(&createSuite{})
 
 func (s *createSuite) SetUpTest(c *gc.C) {
 	s.BaseBackupsSuite.SetUpTest(c)
-	s.subcommand = &backups.CreateCommand{}
-	s.subcommand.Filename = "juju-backup-<date>-<time>.tar.gz"
+	s.wrappedCommand, s.command = backups.NewCreateCommand()
+	s.defaultFilename = "juju-backup-<date>-<time>.tar.gz"
 }
 
 func (s *createSuite) setDownload() *fakeAPIClient {
 	client := s.BaseBackupsSuite.setDownload()
-	s.subcommand.Quiet = true
 	return client
 }
 
@@ -40,7 +40,7 @@ func (s *createSuite) checkDownloadStd(c *gc.C, ctx *cmd.Context) {
 	c.Check(ctx.Stderr.(*bytes.Buffer).String(), gc.Equals, "")
 
 	out := ctx.Stdout.(*bytes.Buffer).String()
-	if !s.subcommand.Quiet {
+	if !s.command.Quiet {
 		parts := strings.Split(out, MetaResultString)
 		c.Assert(parts, gc.HasLen, 2)
 		c.Assert(parts[0], gc.Equals, "")
@@ -66,22 +66,12 @@ func (s *createSuite) checkDownload(c *gc.C, ctx *cmd.Context) {
 }
 
 func (s *createSuite) TestHelp(c *gc.C) {
-	ctx, err := testing.RunCommand(c, s.command, "create", "--help")
-	c.Assert(err, jc.ErrorIsNil)
-
-	info := s.subcommand.Info()
-	expected := "(?sm)usage: juju backups create [options] " + info.Args + "$.*"
-	expected = strings.Replace(expected, "[", `\[`, -1)
-	c.Check(testing.Stdout(ctx), gc.Matches, expected)
-	expected = "(?sm).*^purpose: " + info.Purpose + "$.*"
-	c.Check(testing.Stdout(ctx), gc.Matches, expected)
-	expected = "(?sm).*^" + info.Doc + "$.*"
-	c.Check(testing.Stdout(ctx), gc.Matches, expected)
+	s.checkHelp(c, s.wrappedCommand)
 }
 
 func (s *createSuite) TestNoArgs(c *gc.C) {
 	client := s.BaseBackupsSuite.setDownload()
-	_, err := testing.RunCommand(c, s.command, "create")
+	_, err := testing.RunCommand(c, s.wrappedCommand, "--quiet")
 	c.Assert(err, jc.ErrorIsNil)
 
 	client.Check(c, s.metaresult.ID, "", "Create", "Download")
@@ -89,20 +79,17 @@ func (s *createSuite) TestNoArgs(c *gc.C) {
 
 func (s *createSuite) TestDefaultDownload(c *gc.C) {
 	s.setDownload()
-	ctx := cmdtesting.Context(c)
-	err := s.subcommand.Run(ctx)
+	ctx, err := testing.RunCommand(c, s.wrappedCommand, "--quiet", "--filename", s.defaultFilename)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.checkDownload(c, ctx)
-	c.Check(s.filename, gc.Not(gc.Equals), "")
-	c.Check(s.subcommand.Filename, gc.Equals, backups.NotSet)
+	c.Check(s.command.Filename, gc.Not(gc.Equals), "")
+	c.Check(s.command.Filename, gc.Equals, backups.NotSet)
 }
 
 func (s *createSuite) TestQuiet(c *gc.C) {
 	client := s.BaseBackupsSuite.setDownload()
-	s.subcommand.Quiet = true
-	ctx := cmdtesting.Context(c)
-	err := s.subcommand.Run(ctx)
+	ctx, err := testing.RunCommand(c, s.wrappedCommand, "--quiet")
 	c.Assert(err, jc.ErrorIsNil)
 
 	client.Check(c, s.metaresult.ID, "", "Create", "Download")
@@ -116,7 +103,7 @@ func (s *createSuite) TestQuiet(c *gc.C) {
 
 func (s *createSuite) TestNotes(c *gc.C) {
 	client := s.BaseBackupsSuite.setDownload()
-	_, err := testing.RunCommand(c, s.command, "create", "spam")
+	_, err := testing.RunCommand(c, s.wrappedCommand, "spam", "--quiet")
 	c.Assert(err, jc.ErrorIsNil)
 
 	client.Check(c, s.metaresult.ID, "spam", "Create", "Download")
@@ -124,40 +111,35 @@ func (s *createSuite) TestNotes(c *gc.C) {
 
 func (s *createSuite) TestFilename(c *gc.C) {
 	client := s.setDownload()
-	s.subcommand.Filename = "backup.tgz"
-	ctx := cmdtesting.Context(c)
-	err := s.subcommand.Run(ctx)
+	ctx, err := testing.RunCommand(c, s.wrappedCommand, "--filename", "backup.tgz", "--quiet")
 	c.Assert(err, jc.ErrorIsNil)
 
 	client.Check(c, s.metaresult.ID, "", "Create", "Download")
 	s.checkDownload(c, ctx)
-	c.Check(s.subcommand.Filename, gc.Equals, s.filename)
+	c.Check(s.command.Filename, gc.Equals, "backup.tgz")
 }
 
 func (s *createSuite) TestNoDownload(c *gc.C) {
 	client := s.setSuccess()
-	s.subcommand.NoDownload = true
-	ctx := cmdtesting.Context(c)
-	err := s.subcommand.Run(ctx)
+	ctx, err := testing.RunCommand(c, s.wrappedCommand, "--no-download")
 	c.Assert(err, jc.ErrorIsNil)
 
 	client.Check(c, "", "", "Create")
 	out := MetaResultString + s.metaresult.ID + "\n"
 	s.checkStd(c, ctx, out, backups.DownloadWarning+"\n")
-	c.Check(s.subcommand.Filename, gc.Equals, backups.NotSet)
+	c.Check(s.command.Filename, gc.Equals, backups.NotSet)
 }
 
 func (s *createSuite) TestFilenameAndNoDownload(c *gc.C) {
 	s.setSuccess()
-	_, err := testing.RunCommand(c, s.command, "create", "--no-download", "--filename", "backup.tgz")
+	_, err := testing.RunCommand(c, s.wrappedCommand, "--no-download", "--filename", "backup.tgz")
 
 	c.Check(err, gc.ErrorMatches, "cannot mix --no-download and --filename")
 }
 
 func (s *createSuite) TestError(c *gc.C) {
 	s.setFailure("failed!")
-	ctx := cmdtesting.Context(c)
-	err := s.subcommand.Run(ctx)
+	_, err := testing.RunCommand(c, s.wrappedCommand)
 
 	c.Check(errors.Cause(err), gc.ErrorMatches, "failed!")
 }

--- a/cmd/juju/backups/download.go
+++ b/cmd/juju/backups/download.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/errors"
 	"launchpad.net/gnuflag"
 
+	"github.com/juju/juju/cmd/envcmd"
 	"github.com/juju/juju/state/backups"
 )
 
@@ -22,8 +23,12 @@ If --filename is not used, the archive is downloaded to a temporary
 location and the filename is printed to stdout.
 `
 
-// DownloadCommand is the sub-command for downloading a backup archive.
-type DownloadCommand struct {
+func newDownloadCommand() cmd.Command {
+	return envcmd.Wrap(&downloadCommand{})
+}
+
+// downloadCommand is the sub-command for downloading a backup archive.
+type downloadCommand struct {
 	CommandBase
 	// Filename is where to save the downloaded archive.
 	Filename string
@@ -32,7 +37,7 @@ type DownloadCommand struct {
 }
 
 // Info implements Command.Info.
-func (c *DownloadCommand) Info() *cmd.Info {
+func (c *downloadCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "download",
 		Args:    "<ID>",
@@ -42,12 +47,12 @@ func (c *DownloadCommand) Info() *cmd.Info {
 }
 
 // SetFlags implements Command.SetFlags.
-func (c *DownloadCommand) SetFlags(f *gnuflag.FlagSet) {
+func (c *downloadCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.StringVar(&c.Filename, "filename", "", "download target")
 }
 
 // Init implements Command.Init.
-func (c *DownloadCommand) Init(args []string) error {
+func (c *downloadCommand) Init(args []string) error {
 	if len(args) == 0 {
 		return errors.New("missing ID")
 	}
@@ -60,7 +65,7 @@ func (c *DownloadCommand) Init(args []string) error {
 }
 
 // Run implements Command.Run.
-func (c *DownloadCommand) Run(ctx *cmd.Context) error {
+func (c *downloadCommand) Run(ctx *cmd.Context) error {
 	client, err := c.NewAPIClient()
 	if err != nil {
 		return errors.Trace(err)
@@ -94,7 +99,7 @@ func (c *DownloadCommand) Run(ctx *cmd.Context) error {
 }
 
 // ResolveFilename returns the filename used by the command.
-func (c *DownloadCommand) ResolveFilename() string {
+func (c *downloadCommand) ResolveFilename() string {
 	filename := c.Filename
 	if filename == "" {
 		filename = backups.FilenamePrefix + c.ID + ".tar.gz"

--- a/cmd/juju/backups/export_test.go
+++ b/cmd/juju/backups/export_test.go
@@ -3,6 +3,12 @@
 
 package backups
 
+import (
+	"github.com/juju/cmd"
+
+	"github.com/juju/juju/cmd/envcmd"
+)
+
 const (
 	NotSet          = notset
 	DownloadWarning = downloadWarning
@@ -10,4 +16,28 @@ const (
 
 var (
 	NewAPIClient = &newAPIClient
+
+	NewInfoCommand    = newInfoCommand
+	NewListCommand    = newListCommand
+	NewUploadCommand  = newUploadCommand
+	NewRemoveCommand  = newRemoveCommand
+	NewRestoreCommand = newRestoreCommand
 )
+
+type CreateCommand struct {
+	*createCommand
+}
+
+type DownloadCommand struct {
+	*downloadCommand
+}
+
+func NewCreateCommand() (cmd.Command, *CreateCommand) {
+	c := &createCommand{}
+	return envcmd.Wrap(c), &CreateCommand{c}
+}
+
+func NewDownloadCommand() (cmd.Command, *DownloadCommand) {
+	c := &downloadCommand{}
+	return envcmd.Wrap(c), &DownloadCommand{c}
+}

--- a/cmd/juju/backups/info.go
+++ b/cmd/juju/backups/info.go
@@ -6,21 +6,27 @@ package backups
 import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
+
+	"github.com/juju/juju/cmd/envcmd"
 )
 
 const infoDoc = `
 "info" provides the metadata associated with a backup.
 `
 
-// InfoCommand is the sub-command for creating a new backup.
-type InfoCommand struct {
+func newInfoCommand() cmd.Command {
+	return envcmd.Wrap(&infoCommand{})
+}
+
+// infoCommand is the sub-command for creating a new backup.
+type infoCommand struct {
 	CommandBase
 	// ID is the backup ID to get.
 	ID string
 }
 
 // Info implements Command.Info.
-func (c *InfoCommand) Info() *cmd.Info {
+func (c *infoCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "info",
 		Args:    "<ID>",
@@ -30,7 +36,7 @@ func (c *InfoCommand) Info() *cmd.Info {
 }
 
 // Init implements Command.Init.
-func (c *InfoCommand) Init(args []string) error {
+func (c *infoCommand) Init(args []string) error {
 	if len(args) == 0 {
 		return errors.New("missing ID")
 	}
@@ -43,7 +49,7 @@ func (c *InfoCommand) Init(args []string) error {
 }
 
 // Run implements Command.Run.
-func (c *InfoCommand) Run(ctx *cmd.Context) error {
+func (c *infoCommand) Run(ctx *cmd.Context) error {
 	client, err := c.NewAPIClient()
 	if err != nil {
 		return errors.Trace(err)

--- a/cmd/juju/backups/info_test.go
+++ b/cmd/juju/backups/info_test.go
@@ -4,9 +4,7 @@
 package backups_test
 
 import (
-	"strings"
-
-	"github.com/juju/cmd/cmdtesting"
+	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -17,34 +15,23 @@ import (
 
 type infoSuite struct {
 	BaseBackupsSuite
-	subcommand *backups.InfoCommand
+	subcommand cmd.Command
 }
 
 var _ = gc.Suite(&infoSuite{})
 
 func (s *infoSuite) SetUpTest(c *gc.C) {
 	s.BaseBackupsSuite.SetUpTest(c)
-	s.subcommand = &backups.InfoCommand{}
+	s.subcommand = backups.NewInfoCommand()
 }
 
 func (s *infoSuite) TestHelp(c *gc.C) {
-	ctx, err := testing.RunCommand(c, s.command, "info", "--help")
-	c.Assert(err, jc.ErrorIsNil)
-
-	info := s.subcommand.Info()
-	expected := "(?sm)usage: juju backups info [options] " + info.Args + "$.*"
-	expected = strings.Replace(expected, "[", `\[`, -1)
-	c.Check(testing.Stdout(ctx), gc.Matches, expected)
-	expected = "(?sm).*^purpose: " + info.Purpose + "$.*"
-	c.Check(testing.Stdout(ctx), gc.Matches, expected)
-	expected = "(?sm).*^" + info.Doc + "$.*"
-	c.Check(testing.Stdout(ctx), gc.Matches, expected)
+	s.checkHelp(c, s.subcommand)
 }
 
 func (s *infoSuite) TestOkay(c *gc.C) {
 	s.setSuccess()
-	ctx := cmdtesting.Context(c)
-	err := s.subcommand.Run(ctx)
+	ctx, err := testing.RunCommand(c, s.subcommand, s.metaresult.ID)
 	c.Check(err, jc.ErrorIsNil)
 
 	out := MetaResultString
@@ -53,8 +40,6 @@ func (s *infoSuite) TestOkay(c *gc.C) {
 
 func (s *infoSuite) TestError(c *gc.C) {
 	s.setFailure("failed!")
-	ctx := cmdtesting.Context(c)
-	err := s.subcommand.Run(ctx)
-
+	_, err := testing.RunCommand(c, s.subcommand, s.metaresult.ID)
 	c.Check(errors.Cause(err), gc.ErrorMatches, "failed!")
 }

--- a/cmd/juju/backups/list.go
+++ b/cmd/juju/backups/list.go
@@ -9,21 +9,27 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"launchpad.net/gnuflag"
+
+	"github.com/juju/juju/cmd/envcmd"
 )
 
 const listDoc = `
 "list" provides the metadata associated with all backups.
 `
 
-// ListCommand is the sub-command for listing all available backups.
-type ListCommand struct {
+func newListCommand() cmd.Command {
+	return envcmd.Wrap(&listCommand{})
+}
+
+// listCommand is the sub-command for listing all available backups.
+type listCommand struct {
 	CommandBase
 	// Brief means only IDs will be printed.
 	Brief bool
 }
 
 // Info implements Command.Info.
-func (c *ListCommand) Info() *cmd.Info {
+func (c *listCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "list",
 		Args:    "",
@@ -33,12 +39,12 @@ func (c *ListCommand) Info() *cmd.Info {
 }
 
 // SetFlags implements Command.SetFlags.
-func (c *ListCommand) SetFlags(f *gnuflag.FlagSet) {
+func (c *listCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.BoolVar(&c.Brief, "brief", false, "only print IDs")
 }
 
 // Init implements Command.Init.
-func (c *ListCommand) Init(args []string) error {
+func (c *listCommand) Init(args []string) error {
 	if err := cmd.CheckEmpty(args); err != nil {
 		return errors.Trace(err)
 	}
@@ -46,7 +52,7 @@ func (c *ListCommand) Init(args []string) error {
 }
 
 // Run implements Command.Run.
-func (c *ListCommand) Run(ctx *cmd.Context) error {
+func (c *listCommand) Run(ctx *cmd.Context) error {
 	client, err := c.NewAPIClient()
 	if err != nil {
 		return errors.Trace(err)

--- a/cmd/juju/backups/list_test.go
+++ b/cmd/juju/backups/list_test.go
@@ -4,8 +4,7 @@
 package backups_test
 
 import (
-	"strings"
-
+	"github.com/juju/cmd"
 	"github.com/juju/cmd/cmdtesting"
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
@@ -17,28 +16,18 @@ import (
 
 type listSuite struct {
 	BaseBackupsSuite
-	subcommand *backups.ListCommand
+	subcommand cmd.Command
 }
 
 var _ = gc.Suite(&listSuite{})
 
 func (s *listSuite) SetUpTest(c *gc.C) {
 	s.BaseBackupsSuite.SetUpTest(c)
-	s.subcommand = &backups.ListCommand{}
+	s.subcommand = backups.NewListCommand()
 }
 
 func (s *listSuite) TestHelp(c *gc.C) {
-	ctx, err := testing.RunCommand(c, s.command, "list", "--help")
-	c.Assert(err, jc.ErrorIsNil)
-
-	info := s.subcommand.Info()
-	expected := "(?sm)usage: juju backups list [options]$.*"
-	expected = strings.Replace(expected, "[", `\[`, -1)
-	c.Check(testing.Stdout(ctx), gc.Matches, expected)
-	expected = "(?sm).*^purpose: " + info.Purpose + "$.*"
-	c.Check(testing.Stdout(ctx), gc.Matches, expected)
-	expected = "(?sm).*^" + info.Doc + "$.*"
-	c.Check(testing.Stdout(ctx), gc.Matches, expected)
+	s.checkHelp(c, s.subcommand)
 }
 
 func (s *listSuite) TestOkay(c *gc.C) {
@@ -53,19 +42,14 @@ func (s *listSuite) TestOkay(c *gc.C) {
 
 func (s *listSuite) TestBrief(c *gc.C) {
 	s.setSuccess()
-	s.subcommand.Brief = true
-	ctx := cmdtesting.Context(c)
-	err := s.subcommand.Run(ctx)
-	c.Check(err, jc.ErrorIsNil)
-
+	ctx, err := testing.RunCommand(c, s.subcommand, []string{"--brief"}...)
+	c.Assert(err, jc.ErrorIsNil)
 	out := s.metaresult.ID + "\n"
 	s.checkStd(c, ctx, out, "")
 }
 
 func (s *listSuite) TestError(c *gc.C) {
 	s.setFailure("failed!")
-	ctx := cmdtesting.Context(c)
-	err := s.subcommand.Run(ctx)
-
+	_, err := testing.RunCommand(c, s.subcommand)
 	c.Check(errors.Cause(err), gc.ErrorMatches, "failed!")
 }

--- a/cmd/juju/backups/package_test.go
+++ b/cmd/juju/backups/package_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"regexp"
 	"testing"
 
 	"github.com/juju/cmd"
@@ -71,6 +72,29 @@ func (s *BaseBackupsSuite) TearDownTest(c *gc.C) {
 	}
 
 	s.FakeJujuHomeSuite.TearDownTest(c)
+}
+
+func (s *BaseBackupsSuite) checkHelp(c *gc.C, subcmd cmd.Command) {
+	ctx, err := jujutesting.RunCommand(c, s.command, subcmd.Info().Name, "--help")
+	c.Assert(err, gc.IsNil)
+
+	var expected string
+	if subcmd.Info().Args != "" {
+		expected = "(?sm).*^usage: juju backups " +
+			regexp.QuoteMeta(subcmd.Info().Name) +
+			` \[options\] ` + regexp.QuoteMeta(subcmd.Info().Args) + ".+"
+	} else {
+		expected = "(?sm).*^usage: juju backups " +
+			regexp.QuoteMeta(subcmd.Info().Name) +
+			` \[options\].+`
+	}
+	c.Check(jujutesting.Stdout(ctx), gc.Matches, expected)
+
+	expected = "(?sm).*^purpose: " + regexp.QuoteMeta(subcmd.Info().Purpose) + "$.*"
+	c.Check(jujutesting.Stdout(ctx), gc.Matches, expected)
+
+	expected = "(?sm).*^" + regexp.QuoteMeta(subcmd.Info().Doc) + "$.*"
+	c.Check(jujutesting.Stdout(ctx), gc.Matches, expected)
 }
 
 func (s *BaseBackupsSuite) patchAPIClient(client backups.APIClient) {

--- a/cmd/juju/backups/remove.go
+++ b/cmd/juju/backups/remove.go
@@ -8,21 +8,26 @@ import (
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
+
+	"github.com/juju/juju/cmd/envcmd"
 )
 
 const removeDoc = `
 "remove" removes a backup from remote storage.
 `
 
-// CreateCommand is the sub-command for creating a new backup.
-type RemoveCommand struct {
+func newRemoveCommand() cmd.Command {
+	return envcmd.Wrap(&removeCommand{})
+}
+
+type removeCommand struct {
 	CommandBase
 	// ID refers to the backup to be removed.
 	ID string
 }
 
 // Info implements Command.Info.
-func (c *RemoveCommand) Info() *cmd.Info {
+func (c *removeCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "remove",
 		Args:    "<ID>",
@@ -32,7 +37,7 @@ func (c *RemoveCommand) Info() *cmd.Info {
 }
 
 // Init implements Command.Init.
-func (c *RemoveCommand) Init(args []string) error {
+func (c *removeCommand) Init(args []string) error {
 	if len(args) == 0 {
 		return errors.New("missing ID")
 	}
@@ -45,7 +50,7 @@ func (c *RemoveCommand) Init(args []string) error {
 }
 
 // Run implements Command.Run.
-func (c *RemoveCommand) Run(ctx *cmd.Context) error {
+func (c *removeCommand) Run(ctx *cmd.Context) error {
 	client, err := c.NewAPIClient()
 	if err != nil {
 		return errors.Trace(err)
@@ -57,6 +62,7 @@ func (c *RemoveCommand) Run(ctx *cmd.Context) error {
 		return errors.Trace(err)
 	}
 
-	fmt.Fprintln(ctx.Stdout, "successfully removed:", c.ID)
+	output := fmt.Sprintf("successfully removed: %v\n", c.ID)
+	ctx.Stdout.Write([]byte(output))
 	return nil
 }

--- a/cmd/juju/backups/remove_test.go
+++ b/cmd/juju/backups/remove_test.go
@@ -4,9 +4,7 @@
 package backups_test
 
 import (
-	"strings"
-
-	"github.com/juju/cmd/cmdtesting"
+	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -17,35 +15,23 @@ import (
 
 type removeSuite struct {
 	BaseBackupsSuite
-	subcommand *backups.RemoveCommand
+	command cmd.Command
 }
 
 var _ = gc.Suite(&removeSuite{})
 
 func (s *removeSuite) SetUpTest(c *gc.C) {
 	s.BaseBackupsSuite.SetUpTest(c)
-	s.subcommand = &backups.RemoveCommand{}
+	s.command = backups.NewRemoveCommand()
 }
 
 func (s *removeSuite) TestHelp(c *gc.C) {
-	ctx, err := testing.RunCommand(c, s.command, "remove", "--help")
-	c.Assert(err, jc.ErrorIsNil)
-
-	info := s.subcommand.Info()
-	expected := "(?sm)usage: juju backups remove [options] " + info.Args + "$.*"
-	expected = strings.Replace(expected, "[", `\[`, -1)
-	c.Check(testing.Stdout(ctx), gc.Matches, expected)
-	expected = "(?sm).*^purpose: " + info.Purpose + "$.*"
-	c.Check(testing.Stdout(ctx), gc.Matches, expected)
-	expected = "(?sm).*^" + info.Doc + "$.*"
-	c.Check(testing.Stdout(ctx), gc.Matches, expected)
+	s.checkHelp(c, s.command)
 }
 
 func (s *removeSuite) TestOkay(c *gc.C) {
 	s.setSuccess()
-	s.subcommand.ID = "spam"
-	ctx := cmdtesting.Context(c)
-	err := s.subcommand.Run(ctx)
+	ctx, err := testing.RunCommand(c, s.command, "spam")
 	c.Check(err, jc.ErrorIsNil)
 
 	out := "successfully removed: spam\n"
@@ -54,8 +40,6 @@ func (s *removeSuite) TestOkay(c *gc.C) {
 
 func (s *removeSuite) TestError(c *gc.C) {
 	s.setFailure("failed!")
-	ctx := cmdtesting.Context(c)
-	err := s.subcommand.Run(ctx)
-
+	_, err := testing.RunCommand(c, s.command, "spam")
 	c.Check(errors.Cause(err), gc.ErrorMatches, "failed!")
 }

--- a/cmd/juju/backups/restore.go
+++ b/cmd/juju/backups/restore.go
@@ -21,9 +21,13 @@ import (
 	"github.com/juju/juju/environs/configstore"
 )
 
-// RestoreCommand is a subcommand of backups that implement the restore behaior
+func newRestoreCommand() cmd.Command {
+	return envcmd.Wrap(&restoreCommand{})
+}
+
+// restoreCommand is a subcommand of backups that implement the restore behaior
 // it is invoked with "juju backups restore".
-type RestoreCommand struct {
+type restoreCommand struct {
 	CommandBase
 	constraints constraints.Value
 	filename    string
@@ -50,7 +54,7 @@ to that effect.
 `
 
 // Info returns the content for --help.
-func (c *RestoreCommand) Info() *cmd.Info {
+func (c *restoreCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "restore",
 		Purpose: "restore from a backup archive to a new state server",
@@ -60,7 +64,7 @@ func (c *RestoreCommand) Info() *cmd.Info {
 }
 
 // SetFlags handles known option flags.
-func (c *RestoreCommand) SetFlags(f *gnuflag.FlagSet) {
+func (c *restoreCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.Var(constraints.ConstraintsValue{Target: &c.constraints},
 		"constraints", "set environment constraints")
 
@@ -70,7 +74,7 @@ func (c *RestoreCommand) SetFlags(f *gnuflag.FlagSet) {
 }
 
 // Init is where the preconditions for this commands can be checked.
-func (c *RestoreCommand) Init(args []string) error {
+func (c *restoreCommand) Init(args []string) error {
 	if c.filename == "" && c.backupId == "" {
 		return errors.Errorf("you must specify either a file or a backup id.")
 	}
@@ -95,7 +99,7 @@ const restoreAPIIncompatibility = "server version not compatible for " +
 
 // runRestore will implement the actual calls to the different Client parts
 // of restore.
-func (c *RestoreCommand) runRestore(ctx *cmd.Context) error {
+func (c *restoreCommand) runRestore(ctx *cmd.Context) error {
 	client, closer, err := c.newClient()
 	if err != nil {
 		return errors.Trace(err)
@@ -129,7 +133,7 @@ func (c *RestoreCommand) runRestore(ctx *cmd.Context) error {
 
 // rebootstrap will bootstrap a new server in safe-mode (not killing any other agent)
 // if there is no current server available to restore to.
-func (c *RestoreCommand) rebootstrap(ctx *cmd.Context) error {
+func (c *restoreCommand) rebootstrap(ctx *cmd.Context) error {
 	store, err := configstore.Default()
 	if err != nil {
 		return errors.Trace(err)
@@ -173,7 +177,7 @@ func (c *RestoreCommand) rebootstrap(ctx *cmd.Context) error {
 	return nil
 }
 
-func (c *RestoreCommand) newClient() (*backups.Client, func() error, error) {
+func (c *restoreCommand) newClient() (*backups.Client, func() error, error) {
 	client, err := c.NewAPIClient()
 	if err != nil {
 		return nil, nil, errors.Trace(err)
@@ -186,7 +190,7 @@ func (c *RestoreCommand) newClient() (*backups.Client, func() error, error) {
 }
 
 // Run is the entry point for this command.
-func (c *RestoreCommand) Run(ctx *cmd.Context) error {
+func (c *restoreCommand) Run(ctx *cmd.Context) error {
 	if c.bootstrap {
 		if err := c.rebootstrap(ctx); err != nil {
 			return errors.Trace(err)

--- a/cmd/juju/backups/restore_test.go
+++ b/cmd/juju/backups/restore_test.go
@@ -4,7 +4,7 @@
 package backups_test
 
 import (
-	//jc "github.com/juju/testing/checkers"
+	"github.com/juju/cmd"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cmd/juju/backups"
@@ -13,14 +13,14 @@ import (
 
 type restoreSuite struct {
 	BaseBackupsSuite
-	subcommand *backups.RestoreCommand
+	command cmd.Command
 }
 
 var _ = gc.Suite(&restoreSuite{})
 
 func (s *restoreSuite) SetUpTest(c *gc.C) {
 	s.BaseBackupsSuite.SetUpTest(c)
-	s.subcommand = &backups.RestoreCommand{}
+	s.command = backups.NewRestoreCommand()
 }
 
 func (s *restoreSuite) TestRestoreArgs(c *gc.C) {

--- a/cmd/juju/backups/upload.go
+++ b/cmd/juju/backups/upload.go
@@ -11,14 +11,19 @@ import (
 	"launchpad.net/gnuflag"
 
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/envcmd"
 )
 
 const uploadDoc = `
 "upload" sends a backup archive file to remote storage.
 `
 
-// UploadCommand is the sub-command for uploading a backup archive.
-type UploadCommand struct {
+func newUploadCommand() cmd.Command {
+	return envcmd.Wrap(&uploadCommand{})
+}
+
+// uploadCommand is the sub-command for uploading a backup archive.
+type uploadCommand struct {
 	CommandBase
 	// Filename is where to find the archive to upload.
 	Filename string
@@ -29,13 +34,13 @@ type UploadCommand struct {
 }
 
 // SetFlags implements Command.SetFlags.
-func (c *UploadCommand) SetFlags(f *gnuflag.FlagSet) {
+func (c *uploadCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.BoolVar(&c.ShowMeta, "verbose", false, "show the uploaded metadata")
 	f.BoolVar(&c.Quiet, "quiet", false, "do not print the new backup ID")
 }
 
 // Info implements Command.Info.
-func (c *UploadCommand) Info() *cmd.Info {
+func (c *uploadCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "upload",
 		Args:    "<filename>",
@@ -45,7 +50,7 @@ func (c *UploadCommand) Info() *cmd.Info {
 }
 
 // Init implements Command.Init.
-func (c *UploadCommand) Init(args []string) error {
+func (c *uploadCommand) Init(args []string) error {
 	if len(args) == 0 {
 		return errors.New("backup filename not specified")
 	}
@@ -58,7 +63,7 @@ func (c *UploadCommand) Init(args []string) error {
 }
 
 // Run implements Command.Run.
-func (c *UploadCommand) Run(ctx *cmd.Context) error {
+func (c *uploadCommand) Run(ctx *cmd.Context) error {
 	client, err := c.NewAPIClient()
 	if err != nil {
 		return errors.Trace(err)
@@ -98,7 +103,7 @@ func (c *UploadCommand) Run(ctx *cmd.Context) error {
 	return nil
 }
 
-func (c *UploadCommand) getStoredMetadata(id string) (*params.BackupsMetadataResult, error) {
+func (c *uploadCommand) getStoredMetadata(id string) (*params.BackupsMetadataResult, error) {
 	// TODO(ericsnow) lp-1399722 This should be addressed.
 	// There is at least anecdotal evidence that we cannot use an API
 	// client for more than a single request. So we use a new client

--- a/cmd/juju/block/block.go
+++ b/cmd/juju/block/block.go
@@ -57,8 +57,12 @@ var getBlockClientAPI = func(p *BaseBlockCommand) (BlockClientAPI, error) {
 	return getBlockAPI(&p.EnvCommandBase)
 }
 
-// DestroyCommand blocks destroy environment.
-type DestroyCommand struct {
+func newDestroyCommand() cmd.Command {
+	return envcmd.Wrap(&destroyCommand{})
+}
+
+// destroyCommand blocks destroy environment.
+type destroyCommand struct {
 	BaseBlockCommand
 }
 
@@ -79,7 +83,7 @@ Examples:
 
 // Info provides information about command.
 // Satisfying Command interface.
-func (c *DestroyCommand) Info() *cmd.Info {
+func (c *destroyCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "destroy-environment",
 		Purpose: "block an operation that would destroy Juju environment",
@@ -88,12 +92,16 @@ func (c *DestroyCommand) Info() *cmd.Info {
 }
 
 // Satisfying Command interface.
-func (c *DestroyCommand) Run(_ *cmd.Context) error {
+func (c *destroyCommand) Run(_ *cmd.Context) error {
 	return c.internalRun(c.Info().Name)
 }
 
-// RemoveCommand blocks commands that remove juju objects.
-type RemoveCommand struct {
+func newRemoveCommand() cmd.Command {
+	return envcmd.Wrap(&removeCommand{})
+}
+
+// removeCommand blocks commands that remove juju objects.
+type removeCommand struct {
 	BaseBlockCommand
 }
 
@@ -120,7 +128,7 @@ Examples:
 
 // Info provides information about command.
 // Satisfying Command interface.
-func (c *RemoveCommand) Info() *cmd.Info {
+func (c *removeCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "remove-object",
 		Purpose: "block an operation that would remove an object",
@@ -129,12 +137,16 @@ func (c *RemoveCommand) Info() *cmd.Info {
 }
 
 // Satisfying Command interface.
-func (c *RemoveCommand) Run(_ *cmd.Context) error {
+func (c *removeCommand) Run(_ *cmd.Context) error {
 	return c.internalRun(c.Info().Name)
 }
 
-// ChangeCommand blocks commands that may change environment.
-type ChangeCommand struct {
+func newChangeCommand() cmd.Command {
+	return envcmd.Wrap(&changeCommand{})
+}
+
+// changeCommand blocks commands that may change environment.
+type changeCommand struct {
 	BaseBlockCommand
 }
 
@@ -186,7 +198,7 @@ Examples:
 
 // Info provides information about command.
 // Satisfying Command interface.
-func (c *ChangeCommand) Info() *cmd.Info {
+func (c *changeCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "all-changes",
 		Purpose: "block operations that could change Juju environment",
@@ -195,6 +207,6 @@ func (c *ChangeCommand) Info() *cmd.Info {
 }
 
 // Satisfying Command interface.
-func (c *ChangeCommand) Run(_ *cmd.Context) error {
+func (c *changeCommand) Run(_ *cmd.Context) error {
 	return c.internalRun(c.Info().Name)
 }

--- a/cmd/juju/block/block_test.go
+++ b/cmd/juju/block/block_test.go
@@ -12,7 +12,6 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/common"
-	"github.com/juju/juju/cmd/envcmd"
 	"github.com/juju/juju/cmd/juju/block"
 	"github.com/juju/juju/testing"
 )
@@ -39,7 +38,7 @@ func (s *BlockCommandSuite) assertBlock(c *gc.C, operation, message string) {
 }
 
 func (s *BlockCommandSuite) TestBlockCmdMoreArgs(c *gc.C) {
-	_, err := testing.RunCommand(c, envcmd.Wrap(&block.DestroyCommand{}), "change", "too much")
+	_, err := testing.RunCommand(c, block.NewDestroyCommand(), "change", "too much")
 	c.Assert(
 		err,
 		gc.ErrorMatches,
@@ -47,29 +46,29 @@ func (s *BlockCommandSuite) TestBlockCmdMoreArgs(c *gc.C) {
 }
 
 func (s *BlockCommandSuite) TestBlockCmdNoMessage(c *gc.C) {
-	command := block.DestroyCommand{}
-	_, err := testing.RunCommand(c, envcmd.Wrap(&command))
+	command := block.NewDestroyCommand()
+	_, err := testing.RunCommand(c, command)
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertBlock(c, command.Info().Name, "")
 }
 
 func (s *BlockCommandSuite) TestBlockDestroyOperations(c *gc.C) {
-	command := block.DestroyCommand{}
-	_, err := testing.RunCommand(c, envcmd.Wrap(&command), "TestBlockDestroyOperations")
+	command := block.NewDestroyCommand()
+	_, err := testing.RunCommand(c, command, "TestBlockDestroyOperations")
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertBlock(c, command.Info().Name, "TestBlockDestroyOperations")
 }
 
 func (s *BlockCommandSuite) TestBlockRemoveOperations(c *gc.C) {
-	command := block.RemoveCommand{}
-	_, err := testing.RunCommand(c, envcmd.Wrap(&command), "TestBlockRemoveOperations")
+	command := block.NewRemoveCommand()
+	_, err := testing.RunCommand(c, command, "TestBlockRemoveOperations")
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertBlock(c, command.Info().Name, "TestBlockRemoveOperations")
 }
 
 func (s *BlockCommandSuite) TestBlockChangeOperations(c *gc.C) {
-	command := block.ChangeCommand{}
-	_, err := testing.RunCommand(c, envcmd.Wrap(&command), "TestBlockChangeOperations")
+	command := block.NewChangeCommand()
+	_, err := testing.RunCommand(c, command, "TestBlockChangeOperations")
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertBlock(c, command.Info().Name, "TestBlockChangeOperations")
 }

--- a/cmd/juju/block/blocksuper.go
+++ b/cmd/juju/block/blocksuper.go
@@ -5,8 +5,6 @@ package block
 
 import (
 	"github.com/juju/cmd"
-
-	"github.com/juju/juju/cmd/envcmd"
 )
 
 const superBlockCmdDoc = `
@@ -39,9 +37,9 @@ func NewSuperBlockCommand() cmd.Command {
 				UsagePrefix: "juju",
 				Purpose:     superBlockCmdPurpose,
 			})}
-	blockcmd.Register(envcmd.Wrap(&DestroyCommand{}))
-	blockcmd.Register(envcmd.Wrap(&RemoveCommand{}))
-	blockcmd.Register(envcmd.Wrap(&ChangeCommand{}))
-	blockcmd.Register(envcmd.Wrap(&ListCommand{}))
+	blockcmd.Register(newDestroyCommand())
+	blockcmd.Register(newRemoveCommand())
+	blockcmd.Register(newChangeCommand())
+	blockcmd.Register(newListCommand())
 	return &blockcmd
 }

--- a/cmd/juju/block/export_test.go
+++ b/cmd/juju/block/export_test.go
@@ -9,6 +9,11 @@ var (
 	BlockClient   = &getBlockClientAPI
 	UnblockClient = &getUnblockClientAPI
 	ListClient    = &getBlockListAPI
+
+	NewDestroyCommand = newDestroyCommand
+	NewRemoveCommand  = newRemoveCommand
+	NewChangeCommand  = newChangeCommand
+	NewListCommand    = newListCommand
 )
 
 type MockBlockClient struct {

--- a/cmd/juju/block/list.go
+++ b/cmd/juju/block/list.go
@@ -16,25 +16,29 @@ import (
 	"github.com/juju/juju/cmd/envcmd"
 )
 
+func newListCommand() cmd.Command {
+	return envcmd.Wrap(&listCommand{})
+}
+
 const listCommandDoc = `
 List blocks for Juju environment.
 This command shows if each block type is enabled. 
 For enabled blocks, block message is shown if it was specified.
 `
 
-// ListCommand list blocks.
-type ListCommand struct {
+// listCommand list blocks.
+type listCommand struct {
 	envcmd.EnvCommandBase
 	out cmd.Output
 }
 
 // Init implements Command.Init.
-func (c *ListCommand) Init(args []string) (err error) {
+func (c *listCommand) Init(args []string) (err error) {
 	return nil
 }
 
 // Info implements Command.Info.
-func (c *ListCommand) Info() *cmd.Info {
+func (c *listCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "list",
 		Purpose: "list juju blocks",
@@ -43,7 +47,7 @@ func (c *ListCommand) Info() *cmd.Info {
 }
 
 // SetFlags implements Command.SetFlags.
-func (c *ListCommand) SetFlags(f *gnuflag.FlagSet) {
+func (c *listCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.EnvCommandBase.SetFlags(f)
 	c.out.AddFlags(f, "blocks", map[string]cmd.Formatter{
 		"yaml":   cmd.FormatYaml,
@@ -53,8 +57,8 @@ func (c *ListCommand) SetFlags(f *gnuflag.FlagSet) {
 }
 
 // Run implements Command.Run.
-func (c *ListCommand) Run(ctx *cmd.Context) (err error) {
-	api, err := getBlockListAPI(c)
+func (c *listCommand) Run(ctx *cmd.Context) (err error) {
+	api, err := getBlockListAPI(&c.EnvCommandBase)
 	if err != nil {
 		return err
 	}
@@ -73,8 +77,8 @@ type BlockListAPI interface {
 	List() ([]params.Block, error)
 }
 
-var getBlockListAPI = func(p *ListCommand) (BlockListAPI, error) {
-	return getBlockAPI(&p.EnvCommandBase)
+var getBlockListAPI = func(cmd *envcmd.EnvCommandBase) (BlockListAPI, error) {
+	return getBlockAPI(cmd)
 }
 
 // BlockInfo defines the serialization behaviour of the block information.

--- a/cmd/juju/block/list_test.go
+++ b/cmd/juju/block/list_test.go
@@ -21,7 +21,7 @@ type listCommandSuite struct {
 func (s *listCommandSuite) SetUpTest(c *gc.C) {
 	s.FakeJujuHomeSuite.SetUpTest(c)
 	s.mockClient = &block.MockBlockClient{}
-	s.PatchValue(block.ListClient, func(p *block.ListCommand) (block.BlockListAPI, error) {
+	s.PatchValue(block.ListClient, func(_ *envcmd.EnvCommandBase) (block.BlockListAPI, error) {
 		return s.mockClient, nil
 	})
 }
@@ -29,7 +29,7 @@ func (s *listCommandSuite) SetUpTest(c *gc.C) {
 var _ = gc.Suite(&listCommandSuite{})
 
 func (s *listCommandSuite) TestListEmpty(c *gc.C) {
-	ctx, err := testing.RunCommand(c, envcmd.Wrap(&block.ListCommand{}))
+	ctx, err := testing.RunCommand(c, block.NewListCommand())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(testing.Stdout(ctx), gc.Equals, `
 destroy-environment  =off
@@ -40,7 +40,7 @@ all-changes          =off
 
 func (s *listCommandSuite) TestList(c *gc.C) {
 	s.mockClient.SwitchBlockOn(string(multiwatcher.BlockRemove), "Test this one")
-	ctx, err := testing.RunCommand(c, envcmd.Wrap(&block.ListCommand{}))
+	ctx, err := testing.RunCommand(c, block.NewListCommand())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(testing.Stdout(ctx), gc.Equals, `
 destroy-environment  =off
@@ -51,7 +51,7 @@ all-changes          =off
 
 func (s *listCommandSuite) TestListYaml(c *gc.C) {
 	s.mockClient.SwitchBlockOn(string(multiwatcher.BlockRemove), "Test this one")
-	ctx, err := testing.RunCommand(c, envcmd.Wrap(&block.ListCommand{}), "--format", "yaml")
+	ctx, err := testing.RunCommand(c, block.NewListCommand(), "--format", "yaml")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(testing.Stdout(ctx), gc.Equals, `
 - block: destroy-environment
@@ -66,7 +66,7 @@ func (s *listCommandSuite) TestListYaml(c *gc.C) {
 
 func (s *listCommandSuite) TestListJson(c *gc.C) {
 	s.mockClient.SwitchBlockOn(string(multiwatcher.BlockRemove), "Test this one")
-	ctx, err := testing.RunCommand(c, envcmd.Wrap(&block.ListCommand{}), "--format", "json")
+	ctx, err := testing.RunCommand(c, block.NewListCommand(), "--format", "json")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(testing.Stdout(ctx), gc.Equals, `[{"block":"destroy-environment","enabled":false},{"block":"remove-object","enabled":true,"message":"Test this one"},{"block":"all-changes","enabled":false}]
 `)

--- a/cmd/juju/cachedimages/cachedimages.go
+++ b/cmd/juju/cachedimages/cachedimages.go
@@ -26,8 +26,8 @@ func NewSuperCommand() cmd.Command {
 		UsagePrefix: "juju",
 		Purpose:     cachedImagesCommandPurpose,
 	})
-	usercmd.Register(envcmd.Wrap(&DeleteCommand{}))
-	usercmd.Register(envcmd.Wrap(&ListCommand{}))
+	usercmd.Register(newDeleteCommand())
+	usercmd.Register(newListCommand())
 	return usercmd
 }
 

--- a/cmd/juju/cachedimages/delete.go
+++ b/cmd/juju/cachedimages/delete.go
@@ -7,9 +7,11 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"launchpad.net/gnuflag"
+
+	"github.com/juju/juju/cmd/envcmd"
 )
 
-const DeleteCommandDoc = `
+const deleteCommandDoc = `
 Delete cached os images in the Juju environment.
 
 Images are identified by:
@@ -23,23 +25,27 @@ Examples:
   juju cache-images delete --kind lxc --series trusty --arch amd64
 `
 
-// DeleteCommand shows the images in the Juju server.
-type DeleteCommand struct {
+func newDeleteCommand() cmd.Command {
+	return envcmd.Wrap(&deleteCommand{})
+}
+
+// deleteCommand shows the images in the Juju server.
+type deleteCommand struct {
 	CachedImagesCommandBase
 	Kind, Series, Arch string
 }
 
 // Info implements Command.Info.
-func (c *DeleteCommand) Info() *cmd.Info {
+func (c *deleteCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "delete",
 		Purpose: "delete cached os images",
-		Doc:     DeleteCommandDoc,
+		Doc:     deleteCommandDoc,
 	}
 }
 
 // SetFlags implements Command.SetFlags.
-func (c *DeleteCommand) SetFlags(f *gnuflag.FlagSet) {
+func (c *deleteCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.CachedImagesCommandBase.SetFlags(f)
 	f.StringVar(&c.Kind, "kind", "", "the image kind to delete eg lxc")
 	f.StringVar(&c.Series, "series", "", "the series of the image to delete eg trusty")
@@ -47,7 +53,7 @@ func (c *DeleteCommand) SetFlags(f *gnuflag.FlagSet) {
 }
 
 // Init implements Command.Init.
-func (c *DeleteCommand) Init(args []string) (err error) {
+func (c *deleteCommand) Init(args []string) (err error) {
 	if c.Kind == "" {
 		return errors.New("image kind must be specified")
 	}
@@ -66,13 +72,13 @@ type DeleteImageAPI interface {
 	Close() error
 }
 
-var getDeleteImageAPI = func(p *DeleteCommand) (DeleteImageAPI, error) {
+var getDeleteImageAPI = func(p *CachedImagesCommandBase) (DeleteImageAPI, error) {
 	return p.NewImagesManagerClient()
 }
 
 // Run implements Command.Run.
-func (c *DeleteCommand) Run(ctx *cmd.Context) (err error) {
-	client, err := getDeleteImageAPI(c)
+func (c *deleteCommand) Run(ctx *cmd.Context) (err error) {
+	client, err := getDeleteImageAPI(&c.CachedImagesCommandBase)
 	if err != nil {
 		return err
 	}

--- a/cmd/juju/cachedimages/delete_test.go
+++ b/cmd/juju/cachedimages/delete_test.go
@@ -8,7 +8,6 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/cmd/envcmd"
 	"github.com/juju/juju/cmd/juju/cachedimages"
 	"github.com/juju/juju/testing"
 )
@@ -40,13 +39,13 @@ func (f *fakeImageDeleteAPI) DeleteImage(kind, series, arch string) error {
 func (s *deleteImageCommandSuite) SetUpTest(c *gc.C) {
 	s.FakeJujuHomeSuite.SetUpTest(c)
 	s.mockAPI = &fakeImageDeleteAPI{}
-	s.PatchValue(cachedimages.GetDeleteImageAPI, func(c *cachedimages.DeleteCommand) (cachedimages.DeleteImageAPI, error) {
+	s.PatchValue(cachedimages.GetDeleteImageAPI, func(_ *cachedimages.CachedImagesCommandBase) (cachedimages.DeleteImageAPI, error) {
 		return s.mockAPI, nil
 	})
 }
 
 func runDeleteCommand(c *gc.C, args ...string) (*cmd.Context, error) {
-	return testing.RunCommand(c, envcmd.Wrap(&cachedimages.DeleteCommand{}), args...)
+	return testing.RunCommand(c, cachedimages.NewDeleteCommand(), args...)
 }
 
 func (s *deleteImageCommandSuite) TestDeleteImage(c *gc.C) {

--- a/cmd/juju/cachedimages/export_test.go
+++ b/cmd/juju/cachedimages/export_test.go
@@ -6,4 +6,7 @@ package cachedimages
 var (
 	GetListImagesAPI  = &getListImagesAPI
 	GetDeleteImageAPI = &getDeleteImageAPI
+
+	NewDeleteCommand = newDeleteCommand
+	NewListCommand   = newListCommand
 )

--- a/cmd/juju/cachedimages/list.go
+++ b/cmd/juju/cachedimages/list.go
@@ -11,9 +11,10 @@ import (
 	"launchpad.net/gnuflag"
 
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/envcmd"
 )
 
-const ListCommandDoc = `
+const listCommandDoc = `
 List cached os images in the Juju environment.
 
 Images can be filtered on:
@@ -34,24 +35,28 @@ Examples:
   juju cache-images list --kind lxc --series trusty --arch amd64
 `
 
-// ListCommand shows the images in the Juju server.
-type ListCommand struct {
+func newListCommand() cmd.Command {
+	return envcmd.Wrap(&listCommand{})
+}
+
+// listCommand shows the images in the Juju server.
+type listCommand struct {
 	CachedImagesCommandBase
 	out                cmd.Output
 	Kind, Series, Arch string
 }
 
 // Info implements Command.Info.
-func (c *ListCommand) Info() *cmd.Info {
+func (c *listCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "list",
 		Purpose: "shows cached os images",
-		Doc:     ListCommandDoc,
+		Doc:     listCommandDoc,
 	}
 }
 
 // SetFlags implements Command.SetFlags.
-func (c *ListCommand) SetFlags(f *gnuflag.FlagSet) {
+func (c *listCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.CachedImagesCommandBase.SetFlags(f)
 	f.StringVar(&c.Kind, "kind", "", "the image kind to list eg lxc")
 	f.StringVar(&c.Series, "series", "", "the series of the image to list eg trusty")
@@ -63,7 +68,7 @@ func (c *ListCommand) SetFlags(f *gnuflag.FlagSet) {
 }
 
 // Init implements Command.Init.
-func (c *ListCommand) Init(args []string) (err error) {
+func (c *listCommand) Init(args []string) (err error) {
 	return cmd.CheckEmpty(args)
 }
 
@@ -73,7 +78,7 @@ type ListImagesAPI interface {
 	Close() error
 }
 
-var getListImagesAPI = func(p *ListCommand) (ListImagesAPI, error) {
+var getListImagesAPI = func(p *CachedImagesCommandBase) (ListImagesAPI, error) {
 	return p.NewImagesManagerClient()
 }
 
@@ -86,7 +91,7 @@ type ImageInfo struct {
 	Created   string `yaml:"created" json:"created"`
 }
 
-func (c *ListCommand) imageMetadataToImageInfo(images []params.ImageMetadata) []ImageInfo {
+func (c *listCommand) imageMetadataToImageInfo(images []params.ImageMetadata) []ImageInfo {
 	var output []ImageInfo
 	for _, metadata := range images {
 		imageInfo := ImageInfo{
@@ -102,8 +107,8 @@ func (c *ListCommand) imageMetadataToImageInfo(images []params.ImageMetadata) []
 }
 
 // Run implements Command.Run.
-func (c *ListCommand) Run(ctx *cmd.Context) (err error) {
-	client, err := getListImagesAPI(c)
+func (c *listCommand) Run(ctx *cmd.Context) (err error) {
+	client, err := getListImagesAPI(&c.CachedImagesCommandBase)
 	if err != nil {
 		return err
 	}

--- a/cmd/juju/cachedimages/list_test.go
+++ b/cmd/juju/cachedimages/list_test.go
@@ -11,7 +11,6 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/params"
-	"github.com/juju/juju/cmd/envcmd"
 	"github.com/juju/juju/cmd/juju/cachedimages"
 	"github.com/juju/juju/testing"
 )
@@ -48,13 +47,13 @@ func (f *fakeImagesListAPI) ListImages(kind, series, arch string) ([]params.Imag
 func (s *listImagesCommandSuite) SetUpTest(c *gc.C) {
 	s.FakeJujuHomeSuite.SetUpTest(c)
 	s.mockAPI = &fakeImagesListAPI{}
-	s.PatchValue(cachedimages.GetListImagesAPI, func(c *cachedimages.ListCommand) (cachedimages.ListImagesAPI, error) {
+	s.PatchValue(cachedimages.GetListImagesAPI, func(_ *cachedimages.CachedImagesCommandBase) (cachedimages.ListImagesAPI, error) {
 		return s.mockAPI, nil
 	})
 }
 
 func runListCommand(c *gc.C, args ...string) (*cmd.Context, error) {
-	return testing.RunCommand(c, envcmd.Wrap(&cachedimages.ListCommand{}), args...)
+	return testing.RunCommand(c, cachedimages.NewListCommand(), args...)
 }
 
 func (*listImagesCommandSuite) TestListImagesNone(c *gc.C) {

--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -131,11 +131,11 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 	r.Register(&DestroyEnvironmentCommand{})
 
 	// Reporting commands.
-	r.Register(wrapEnvCommand(&status.StatusCommand{}))
+	r.Register(status.NewStatusCommand())
 	r.Register(&SwitchCommand{})
 	r.Register(wrapEnvCommand(&EndpointCommand{}))
 	r.Register(wrapEnvCommand(&APIInfoCommand{}))
-	r.Register(wrapEnvCommand(&status.StatusHistoryCommand{}))
+	r.Register(status.NewStatusHistoryCommand())
 
 	// Error resolution and debugging commands.
 	r.Register(wrapEnvCommand(&RunCommand{}))
@@ -147,9 +147,9 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 
 	// Configuration commands.
 	r.Register(&InitCommand{})
-	r.RegisterDeprecated(wrapEnvCommand(&common.GetConstraintsCommand{}),
+	r.RegisterDeprecated(common.NewGetConstraintsCommand(),
 		twoDotOhDeprecation("environment get-constraints or service get-constraints"))
-	r.RegisterDeprecated(wrapEnvCommand(&common.SetConstraintsCommand{}),
+	r.RegisterDeprecated(common.NewSetConstraintsCommand(),
 		twoDotOhDeprecation("environment set-constraints or service set-constraints"))
 	r.Register(wrapEnvCommand(&ExposeCommand{}))
 	r.Register(wrapEnvCommand(&SyncToolsCommand{}))

--- a/cmd/juju/common/constraints.go
+++ b/cmd/juju/common/constraints.go
@@ -49,6 +49,12 @@ See Also:
    juju help add-unit
 `
 
+// NewGetConstraintsCommand return a new command that returns a
+// list of constraints that have been set on the environment.
+func NewGetConstraintsCommand() cmd.Command {
+	return envcmd.Wrap(&GetConstraintsCommand{})
+}
+
 // GetConstraintsCommand shows the constraints for a service or environment.
 type GetConstraintsCommand struct {
 	envcmd.EnvCommandBase
@@ -122,6 +128,14 @@ func (c *GetConstraintsCommand) Run(ctx *cmd.Context) error {
 		return err
 	}
 	return c.out.Write(ctx, cons)
+}
+
+// NewSetConstraintsCommands returns a new command that sets machine
+// constraints on the system, which are used as the default
+// constraints for all new machines provisioned in the environment
+// (unless overridden).
+func NewSetConstraintsCommand() cmd.Command {
+	return envcmd.Wrap(&SetConstraintsCommand{})
 }
 
 // SetConstraintsCommand shows the constraints for a service or environment.

--- a/cmd/juju/common/constraints_test.go
+++ b/cmd/juju/common/constraints_test.go
@@ -14,10 +14,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/common"
-	"github.com/juju/juju/cmd/envcmd"
-	// TODO(dimitern): Don't ever import "." unless there's a GOOD
-	// reason to do it.
-	. "github.com/juju/juju/cmd/juju/common"
+	cmdcommon "github.com/juju/juju/cmd/juju/common"
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/testing"
 )
@@ -101,8 +98,8 @@ func uint64p(val uint64) *uint64 {
 }
 
 func (s *ConstraintsCommandsSuite) assertSet(c *gc.C, args ...string) {
-	command := NewSetConstraintsCommand(s.fake)
-	rcode, rstdout, rstderr := runCmdLine(c, envcmd.Wrap(command), args...)
+	command := cmdcommon.NewSetConstraintsCommandWithAPI(s.fake)
+	rcode, rstdout, rstderr := runCmdLine(c, command, args...)
 
 	c.Assert(rcode, gc.Equals, 0)
 	c.Assert(rstdout, gc.Equals, "")
@@ -110,8 +107,8 @@ func (s *ConstraintsCommandsSuite) assertSet(c *gc.C, args ...string) {
 }
 
 func (s *ConstraintsCommandsSuite) assertSetBlocked(c *gc.C, args ...string) {
-	command := NewSetConstraintsCommand(s.fake)
-	rcode, _, _ := runCmdLine(c, envcmd.Wrap(command), args...)
+	command := cmdcommon.NewSetConstraintsCommandWithAPI(s.fake)
+	rcode, _, _ := runCmdLine(c, command, args...)
 
 	c.Assert(rcode, gc.Equals, 1)
 
@@ -176,8 +173,8 @@ func (s *ConstraintsCommandsSuite) TestBlockSetService(c *gc.C) {
 }
 
 func (s *ConstraintsCommandsSuite) assertSetError(c *gc.C, code int, stderr string, args ...string) {
-	command := NewSetConstraintsCommand(s.fake)
-	rcode, rstdout, rstderr := runCmdLine(c, envcmd.Wrap(command), args...)
+	command := cmdcommon.NewSetConstraintsCommandWithAPI(s.fake)
+	rcode, rstdout, rstderr := runCmdLine(c, command, args...)
 	c.Assert(rcode, gc.Equals, code)
 	c.Assert(rstdout, gc.Equals, "")
 	c.Assert(rstderr, gc.Matches, "error: "+stderr+"\n")
@@ -191,8 +188,8 @@ func (s *ConstraintsCommandsSuite) TestSetErrors(c *gc.C) {
 }
 
 func (s *ConstraintsCommandsSuite) assertGet(c *gc.C, stdout string, args ...string) {
-	command := NewGetConstraintsCommand(s.fake)
-	rcode, rstdout, rstderr := runCmdLine(c, envcmd.Wrap(command), args...)
+	command := cmdcommon.NewGetConstraintsCommandWithAPI(s.fake)
+	rcode, rstdout, rstderr := runCmdLine(c, command, args...)
 	c.Assert(rcode, gc.Equals, 0)
 	c.Assert(rstdout, gc.Equals, stdout)
 	c.Assert(rstderr, gc.Equals, "")
@@ -228,8 +225,8 @@ func (s *ConstraintsCommandsSuite) TestGetFormats(c *gc.C) {
 }
 
 func (s *ConstraintsCommandsSuite) assertGetError(c *gc.C, code int, stderr string, args ...string) {
-	command := NewGetConstraintsCommand(s.fake)
-	rcode, rstdout, rstderr := runCmdLine(c, envcmd.Wrap(command), args...)
+	command := cmdcommon.NewGetConstraintsCommandWithAPI(s.fake)
+	rcode, rstdout, rstderr := runCmdLine(c, command, args...)
 	c.Assert(rcode, gc.Equals, code)
 	c.Assert(rstdout, gc.Equals, "")
 	c.Assert(rstderr, gc.Matches, "error: "+stderr+"\n")

--- a/cmd/juju/common/export_test.go
+++ b/cmd/juju/common/export_test.go
@@ -3,16 +3,22 @@
 
 package common
 
+import (
+	"github.com/juju/cmd"
+
+	"github.com/juju/juju/cmd/envcmd"
+)
+
 // NewGetConstraintsCommand returns a GetCommand with the api provided as specified.
-func NewGetConstraintsCommand(api ConstraintsAPI) *GetConstraintsCommand {
-	return &GetConstraintsCommand{
+func NewGetConstraintsCommandWithAPI(api ConstraintsAPI) cmd.Command {
+	return envcmd.Wrap(&GetConstraintsCommand{
 		api: api,
-	}
+	})
 }
 
 // NewGetConstraintsCommand returns a GetCommand with the api provided as specified.
-func NewSetConstraintsCommand(api ConstraintsAPI) *SetConstraintsCommand {
-	return &SetConstraintsCommand{
+func NewSetConstraintsCommandWithAPI(api ConstraintsAPI) cmd.Command {
+	return envcmd.Wrap(&SetConstraintsCommand{
 		api: api,
-	}
+	})
 }

--- a/cmd/juju/space/create.go
+++ b/cmd/juju/space/create.go
@@ -10,10 +10,16 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/utils/set"
+
+	"github.com/juju/juju/cmd/envcmd"
 )
 
-// CreateCommand calls the API to create a new network space.
-type CreateCommand struct {
+func newCreateCommand() cmd.Command {
+	return envcmd.Wrap(&createCommand{})
+}
+
+// createCommand calls the API to create a new network space.
+type createCommand struct {
 	SpaceCommandBase
 	Name  string
 	CIDRs set.Strings
@@ -24,7 +30,7 @@ Creates a new space with the given name and associates the given
 (optional) list of existing subnet CIDRs with it.`
 
 // Info is defined on the cmd.Command interface.
-func (c *CreateCommand) Info() *cmd.Info {
+func (c *createCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "create",
 		Args:    "<name> [<CIDR1> <CIDR2> ...]",
@@ -35,14 +41,14 @@ func (c *CreateCommand) Info() *cmd.Info {
 
 // Init is defined on the cmd.Command interface. It checks the
 // arguments for sanity and sets up the command to run.
-func (c *CreateCommand) Init(args []string) error {
+func (c *createCommand) Init(args []string) error {
 	var err error
 	c.Name, c.CIDRs, err = ParseNameAndCIDRs(args, true)
 	return errors.Trace(err)
 }
 
 // Run implements Command.Run.
-func (c *CreateCommand) Run(ctx *cmd.Context) error {
+func (c *createCommand) Run(ctx *cmd.Context) error {
 	return c.RunWithAPI(ctx, func(api SpaceAPI, ctx *cmd.Context) error {
 		// Prepare a nicer message and proper arguments to use in case
 		// there are not CIDRs given.

--- a/cmd/juju/space/create_test.go
+++ b/cmd/juju/space/create_test.go
@@ -58,13 +58,3 @@ func (s *CreateSuite) TestRunWhenSpacesAPIFails(c *gc.C) {
 	s.api.CheckCallNames(c, "CreateSpace", "Close")
 	s.api.CheckCall(c, 0, "CreateSpace", "foo", s.Strings("10.1.2.0/24"), true)
 }
-
-func (s *CreateSuite) TestRunAPIConnectFails(c *gc.C) {
-	s.command = space.NewCreateCommand(nil)
-	s.AssertRunFails(c,
-		"cannot connect to the API server: no environment specified",
-		"myspace", "10.20.30.0/24",
-	)
-	// No API calls recoreded.
-	s.api.CheckCallNames(c)
-}

--- a/cmd/juju/space/export_test.go
+++ b/cmd/juju/space/export_test.go
@@ -3,36 +3,63 @@
 
 package space
 
-func NewCreateCommand(api SpaceAPI) *CreateCommand {
-	createCmd := &CreateCommand{}
-	createCmd.api = api
-	return createCmd
+import (
+	"github.com/juju/cmd"
+
+	"github.com/juju/juju/cmd/envcmd"
+)
+
+func NewCreateCommand(api SpaceAPI) cmd.Command {
+	createCmd := &createCommand{
+		SpaceCommandBase: SpaceCommandBase{api: api},
+	}
+	return envcmd.Wrap(createCmd)
 }
 
-func NewRemoveCommand(api SpaceAPI) *RemoveCommand {
-	removeCmd := &RemoveCommand{}
-	removeCmd.api = api
-	return removeCmd
+type RemoveCommand struct {
+	*removeCommand
 }
 
-func NewUpdateCommand(api SpaceAPI) *UpdateCommand {
-	updateCmd := &UpdateCommand{}
-	updateCmd.api = api
-	return updateCmd
+func (c *RemoveCommand) Name() string {
+	return c.name
 }
 
-func NewRenameCommand(api SpaceAPI) *RenameCommand {
-	renameCmd := &RenameCommand{}
-	renameCmd.api = api
-	return renameCmd
+func NewRemoveCommand(api SpaceAPI) (cmd.Command, *RemoveCommand) {
+	removeCmd := &removeCommand{
+		SpaceCommandBase: SpaceCommandBase{api: api},
+	}
+	return envcmd.Wrap(removeCmd), &RemoveCommand{removeCmd}
 }
 
-func NewListCommand(api SpaceAPI) *ListCommand {
-	listCmd := &ListCommand{}
-	listCmd.api = api
-	return listCmd
+func NewUpdateCommand(api SpaceAPI) cmd.Command {
+	updateCmd := &updateCommand{
+		SpaceCommandBase: SpaceCommandBase{api: api},
+	}
+	return envcmd.Wrap(updateCmd)
 }
 
-func ListFormat(cmd *ListCommand) string {
-	return cmd.out.Name()
+type RenameCommand struct {
+	*renameCommand
+}
+
+func NewRenameCommand(api SpaceAPI) (cmd.Command, *RenameCommand) {
+	renameCmd := &renameCommand{
+		SpaceCommandBase: SpaceCommandBase{api: api},
+	}
+	return envcmd.Wrap(renameCmd), &RenameCommand{renameCmd}
+}
+
+type ListCommand struct {
+	*listCommand
+}
+
+func (c *ListCommand) ListFormat() string {
+	return c.out.Name()
+}
+
+func NewListCommand(api SpaceAPI) (cmd.Command, *ListCommand) {
+	listCmd := &listCommand{
+		SpaceCommandBase: SpaceCommandBase{api: api},
+	}
+	return envcmd.Wrap(listCmd), &ListCommand{listCmd}
 }

--- a/cmd/juju/space/list.go
+++ b/cmd/juju/space/list.go
@@ -9,15 +9,20 @@ import (
 	"net"
 	"strings"
 
-	"launchpad.net/gnuflag"
-
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
+	"launchpad.net/gnuflag"
+
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/envcmd"
 )
 
-// ListCommand displays a list of all spaces known to Juju.
-type ListCommand struct {
+func newListCommand() cmd.Command {
+	return envcmd.Wrap(&listCommand{})
+}
+
+// listCommand displays a list of all spaces known to Juju.
+type listCommand struct {
 	SpaceCommandBase
 	Short bool
 	out   cmd.Output
@@ -31,7 +36,7 @@ their subnets are displayed, otherwise just a list of spaces. The
 output to be redirected to a file. `
 
 // Info is defined on the cmd.Command interface.
-func (c *ListCommand) Info() *cmd.Info {
+func (c *listCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "list",
 		Args:    "[--short] [--format yaml|json] [--output <path>]",
@@ -41,7 +46,7 @@ func (c *ListCommand) Info() *cmd.Info {
 }
 
 // SetFlags is defined on the cmd.Command interface.
-func (c *ListCommand) SetFlags(f *gnuflag.FlagSet) {
+func (c *listCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.SpaceCommandBase.SetFlags(f)
 	c.out.AddFlags(f, "yaml", map[string]cmd.Formatter{
 		"yaml": cmd.FormatYaml,
@@ -53,7 +58,7 @@ func (c *ListCommand) SetFlags(f *gnuflag.FlagSet) {
 
 // Init is defined on the cmd.Command interface. It checks the
 // arguments for sanity and sets up the command to run.
-func (c *ListCommand) Init(args []string) error {
+func (c *listCommand) Init(args []string) error {
 	// No arguments are accepted, just flags.
 	if err := cmd.CheckEmpty(args); err != nil {
 		return errors.Trace(err)
@@ -63,7 +68,7 @@ func (c *ListCommand) Init(args []string) error {
 }
 
 // Run implements Command.Run.
-func (c *ListCommand) Run(ctx *cmd.Context) error {
+func (c *listCommand) Run(ctx *cmd.Context) error {
 	return c.RunWithAPI(ctx, func(api SpaceAPI, ctx *cmd.Context) error {
 		spaces, err := api.ListSpaces()
 		if err != nil {

--- a/cmd/juju/space/list_test.go
+++ b/cmd/juju/space/list_test.go
@@ -27,7 +27,7 @@ var _ = gc.Suite(&ListSuite{})
 
 func (s *ListSuite) SetUpTest(c *gc.C) {
 	s.BaseSpaceSuite.SetUpTest(c)
-	s.command = space.NewListCommand(s.api)
+	s.command, _ = space.NewListCommand(s.api)
 	c.Assert(s.command, gc.NotNil)
 }
 
@@ -71,14 +71,14 @@ func (s *ListSuite) TestInit(c *gc.C) {
 		// Create a new instance of the subcommand for each test, but
 		// since we're not running the command no need to use
 		// envcmd.Wrap().
-		command := space.NewListCommand(s.api)
-		err := coretesting.InitCommand(command, test.args)
+		wrappedCommand, command := space.NewListCommand(s.api)
+		err := coretesting.InitCommand(wrappedCommand, test.args)
 		if test.expectErr != "" {
 			c.Check(err, gc.ErrorMatches, test.expectErr)
 		} else {
 			c.Check(err, jc.ErrorIsNil)
 		}
-		c.Check(space.ListFormat(command), gc.Equals, test.expectFormat)
+		c.Check(command.ListFormat(), gc.Equals, test.expectFormat)
 		c.Check(command.Short, gc.Equals, test.expectShort)
 
 		// No API calls should be recorded at this stage.
@@ -271,13 +271,4 @@ func (s *ListSuite) TestRunWhenSpacesAPIFails(c *gc.C) {
 
 	s.api.CheckCallNames(c, "ListSpaces", "Close")
 	s.api.CheckCall(c, 0, "ListSpaces")
-}
-
-func (s *ListSuite) TestRunAPIConnectFails(c *gc.C) {
-	s.command = space.NewListCommand(nil)
-	s.AssertRunFails(c,
-		"cannot connect to the API server: no environment specified",
-	)
-	// No API calls recoreded.
-	s.api.CheckCallNames(c)
 }

--- a/cmd/juju/space/remove.go
+++ b/cmd/juju/space/remove.go
@@ -9,12 +9,18 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/names"
+
+	"github.com/juju/juju/cmd/envcmd"
 )
 
-// RemoveCommand calls the API to remove an existing network space.
-type RemoveCommand struct {
+func newRemoveCommand() cmd.Command {
+	return envcmd.Wrap(&removeCommand{})
+}
+
+// removeCommand calls the API to remove an existing network space.
+type removeCommand struct {
 	SpaceCommandBase
-	Name string
+	name string
 }
 
 const removeCommandDoc = `
@@ -23,7 +29,7 @@ associated with the space will be transfered to the default space.
 `
 
 // Info is defined on the cmd.Command interface.
-func (c *RemoveCommand) Info() *cmd.Info {
+func (c *removeCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "remove",
 		Args:    "<name>",
@@ -34,7 +40,7 @@ func (c *RemoveCommand) Info() *cmd.Info {
 
 // Init is defined on the cmd.Command interface. It checks the
 // arguments for sanity and sets up the command to run.
-func (c *RemoveCommand) Init(args []string) (err error) {
+func (c *removeCommand) Init(args []string) (err error) {
 	defer errors.DeferredAnnotatef(&err, "invalid arguments specified")
 
 	// Validate given name.
@@ -45,20 +51,20 @@ func (c *RemoveCommand) Init(args []string) (err error) {
 	if !names.IsValidSpace(givenName) {
 		return errors.Errorf("%q is not a valid space name", givenName)
 	}
-	c.Name = givenName
+	c.name = givenName
 
 	return cmd.CheckEmpty(args[1:])
 }
 
 // Run implements Command.Run.
-func (c *RemoveCommand) Run(ctx *cmd.Context) error {
+func (c *removeCommand) Run(ctx *cmd.Context) error {
 	return c.RunWithAPI(ctx, func(api SpaceAPI, ctx *cmd.Context) error {
 		// Remove the space.
-		err := api.RemoveSpace(c.Name)
+		err := api.RemoveSpace(c.name)
 		if err != nil {
-			return errors.Annotatef(err, "cannot remove space %q", c.Name)
+			return errors.Annotatef(err, "cannot remove space %q", c.name)
 		}
-		ctx.Infof("removed space %q", c.Name)
+		ctx.Infof("removed space %q", c.name)
 		return nil
 	})
 }

--- a/cmd/juju/space/remove_test.go
+++ b/cmd/juju/space/remove_test.go
@@ -22,7 +22,7 @@ var _ = gc.Suite(&RemoveSuite{})
 func (s *RemoveSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetFeatureFlags(feature.PostNetCLIMVP)
 	s.BaseSpaceSuite.SetUpTest(c)
-	s.command = space.NewRemoveCommand(s.api)
+	s.command, _ = space.NewRemoveCommand(s.api)
 	c.Assert(s.command, gc.NotNil)
 }
 
@@ -53,15 +53,15 @@ func (s *RemoveSuite) TestInit(c *gc.C) {
 		// Create a new instance of the subcommand for each test, but
 		// since we're not running the command no need to use
 		// envcmd.Wrap().
-		command := space.NewRemoveCommand(s.api)
-		err := coretesting.InitCommand(command, test.args)
+		wrappedCommand, command := space.NewRemoveCommand(s.api)
+		err := coretesting.InitCommand(wrappedCommand, test.args)
 		if test.expectErr != "" {
 			prefixedErr := "invalid arguments specified: " + test.expectErr
 			c.Check(err, gc.ErrorMatches, prefixedErr)
 		} else {
 			c.Check(err, jc.ErrorIsNil)
 		}
-		c.Check(command.Name, gc.Equals, test.expectName)
+		c.Check(command.Name(), gc.Equals, test.expectName)
 		// No API calls should be recorded at this stage.
 		s.api.CheckCallNames(c)
 	}
@@ -88,14 +88,4 @@ func (s *RemoveSuite) TestRunWhenSpacesAPIFails(c *gc.C) {
 
 	s.api.CheckCallNames(c, "RemoveSpace", "Close")
 	s.api.CheckCall(c, 0, "RemoveSpace", "myspace")
-}
-
-func (s *RemoveSuite) TestRunAPIConnectFails(c *gc.C) {
-	s.command = space.NewRemoveCommand(nil)
-	s.AssertRunFails(c,
-		"cannot connect to the API server: no environment specified",
-		"myname", // Drop the args once RunWitnAPI is called internally.
-	)
-	// No API calls recoreded.
-	s.api.CheckCallNames(c)
 }

--- a/cmd/juju/space/rename.go
+++ b/cmd/juju/space/rename.go
@@ -10,38 +10,44 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/names"
 	"launchpad.net/gnuflag"
+
+	"github.com/juju/juju/cmd/envcmd"
 )
 
-// RenameCommand calls the API to rename an existing network space.
-type RenameCommand struct {
+func newRenameCommand() cmd.Command {
+	return envcmd.Wrap(&renameCommand{})
+}
+
+// renameCommand calls the API to rename an existing network space.
+type renameCommand struct {
 	SpaceCommandBase
 	Name    string
 	NewName string
 }
 
-const RenameCommandDoc = `
+const renameCommandDoc = `
 Renames an existing space from "old-name" to "new-name". Does not change the
 associated subnets and "new-name" must not match another existing space.
 `
 
-func (c *RenameCommand) SetFlags(f *gnuflag.FlagSet) {
+func (c *renameCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.SpaceCommandBase.SetFlags(f)
 	f.StringVar(&c.NewName, "rename", "", "the new name for the network space")
 }
 
 // Info is defined on the cmd.Command interface.
-func (c *RenameCommand) Info() *cmd.Info {
+func (c *renameCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "rename",
 		Args:    "<old-name> <new-name>",
 		Purpose: "rename a network space",
-		Doc:     strings.TrimSpace(RenameCommandDoc),
+		Doc:     strings.TrimSpace(renameCommandDoc),
 	}
 }
 
 // Init is defined on the cmd.Command interface. It checks the
 // arguments for sanity and sets up the command to run.
-func (c *RenameCommand) Init(args []string) (err error) {
+func (c *renameCommand) Init(args []string) (err error) {
 	defer errors.DeferredAnnotatef(&err, "invalid arguments specified")
 
 	switch len(args) {
@@ -66,7 +72,7 @@ func (c *RenameCommand) Init(args []string) (err error) {
 }
 
 // Run implements Command.Run.
-func (c *RenameCommand) Run(ctx *cmd.Context) error {
+func (c *renameCommand) Run(ctx *cmd.Context) error {
 	return c.RunWithAPI(ctx, func(api SpaceAPI, ctx *cmd.Context) error {
 		err := api.RenameSpace(c.Name, c.NewName)
 		if err != nil {

--- a/cmd/juju/space/rename_test.go
+++ b/cmd/juju/space/rename_test.go
@@ -22,7 +22,7 @@ var _ = gc.Suite(&RenameSuite{})
 func (s *RenameSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetFeatureFlags(feature.PostNetCLIMVP)
 	s.BaseSpaceSuite.SetUpTest(c)
-	s.command = space.NewRenameCommand(s.api)
+	s.command, _ = space.NewRenameCommand(s.api)
 	c.Assert(s.command, gc.NotNil)
 }
 
@@ -78,8 +78,8 @@ func (s *RenameSuite) TestInit(c *gc.C) {
 		// Create a new instance of the subcommand for each test, but
 		// since we're not running the command no need to use
 		// envcmd.Wrap().
-		command := space.NewRenameCommand(s.api) // surely can use s.command??
-		err := coretesting.InitCommand(command, test.args)
+		wrappedCommand, command := space.NewRenameCommand(s.api) // surely can use s.command??
+		err := coretesting.InitCommand(wrappedCommand, test.args)
 		if test.expectErr != "" {
 			prefixedErr := "invalid arguments specified: " + test.expectErr
 			c.Check(err, gc.ErrorMatches, prefixedErr)
@@ -114,14 +114,4 @@ func (s *RenameSuite) TestRunWhenSpacesAPIFails(c *gc.C) {
 
 	s.api.CheckCallNames(c, "RenameSpace", "Close")
 	s.api.CheckCall(c, 0, "RenameSpace", "foo", "bar")
-}
-
-func (s *RenameSuite) TestRunAPIConnectFails(c *gc.C) {
-	s.command = space.NewRenameCommand(nil)
-	s.AssertRunFails(c,
-		"cannot connect to the API server: no environment specified",
-		"myname", "newname", // Drop the args once RunWitnAPI is called internally.
-	)
-	// No API calls recoreded.
-	s.api.CheckCallNames(c)
 }

--- a/cmd/juju/space/space.go
+++ b/cmd/juju/space/space.go
@@ -101,13 +101,13 @@ func NewSuperCommand() cmd.Command {
 		UsagePrefix: "juju",
 		Purpose:     "manage network spaces",
 	})
-	spaceCmd.Register(envcmd.Wrap(&CreateCommand{}))
-	spaceCmd.Register(envcmd.Wrap(&ListCommand{}))
+	spaceCmd.Register(newCreateCommand())
+	spaceCmd.Register(newListCommand())
 	if featureflag.Enabled(feature.PostNetCLIMVP) {
 		// The following commands are not part of the MVP.
-		spaceCmd.Register(envcmd.Wrap(&RemoveCommand{}))
-		spaceCmd.Register(envcmd.Wrap(&UpdateCommand{}))
-		spaceCmd.Register(envcmd.Wrap(&RenameCommand{}))
+		spaceCmd.Register(newRemoveCommand())
+		spaceCmd.Register(newUpdateCommand())
+		spaceCmd.Register(newRenameCommand())
 	}
 
 	return spaceCmd

--- a/cmd/juju/space/update.go
+++ b/cmd/juju/space/update.go
@@ -10,10 +10,16 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/utils/set"
 	"launchpad.net/gnuflag"
+
+	"github.com/juju/juju/cmd/envcmd"
 )
 
-// UpdateCommand calls the API to update an existing network space.
-type UpdateCommand struct {
+func newUpdateCommand() cmd.Command {
+	return envcmd.Wrap(&updateCommand{})
+}
+
+// updateCommand calls the API to update an existing network space.
+type updateCommand struct {
 	SpaceCommandBase
 	Name  string
 	CIDRs set.Strings
@@ -25,12 +31,12 @@ can only be part of a single space, all specified subnets (using their
 CIDRs) "leave" their current space and "enter" the one we're updating.
 `
 
-func (c *UpdateCommand) SetFlags(f *gnuflag.FlagSet) {
+func (c *updateCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.SpaceCommandBase.SetFlags(f)
 }
 
 // Info is defined on the cmd.Command interface.
-func (c *UpdateCommand) Info() *cmd.Info {
+func (c *updateCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "update",
 		Args:    "<name> <CIDR1> [ <CIDR2> ...]",
@@ -41,14 +47,14 @@ func (c *UpdateCommand) Info() *cmd.Info {
 
 // Init is defined on the cmd.Command interface. It checks the
 // arguments for sanity and sets up the command to run.
-func (c *UpdateCommand) Init(args []string) error {
+func (c *updateCommand) Init(args []string) error {
 	var err error
 	c.Name, c.CIDRs, err = ParseNameAndCIDRs(args, false)
 	return errors.Trace(err)
 }
 
 // Run implements Command.Run.
-func (c *UpdateCommand) Run(ctx *cmd.Context) error {
+func (c *updateCommand) Run(ctx *cmd.Context) error {
 	return c.RunWithAPI(ctx, func(api SpaceAPI, ctx *cmd.Context) error {
 		// Update the space.
 		err := api.UpdateSpace(c.Name, c.CIDRs.SortedValues())

--- a/cmd/juju/space/update_test.go
+++ b/cmd/juju/space/update_test.go
@@ -49,13 +49,3 @@ func (s *UpdateSuite) TestRunWhenSpacesAPIFails(c *gc.C) {
 	s.api.CheckCallNames(c, "UpdateSpace", "Close")
 	s.api.CheckCall(c, 0, "UpdateSpace", "foo", s.Strings("10.1.2.0/24"))
 }
-
-func (s *UpdateSuite) TestRunAPIConnectFails(c *gc.C) {
-	s.command = space.NewUpdateCommand(nil)
-	s.AssertRunFails(c,
-		"cannot connect to the API server: no environment specified",
-		"myname", "10.0.0.0/8", // Drop the args once RunWitnAPI is called internally.
-	)
-	// No API calls recoreded.
-	s.api.CheckCallNames(c)
-}

--- a/cmd/juju/status/history.go
+++ b/cmd/juju/status/history.go
@@ -18,7 +18,11 @@ import (
 	"github.com/juju/juju/juju/osenv"
 )
 
-type StatusHistoryCommand struct {
+func NewStatusHistoryCommand() cmd.Command {
+	return envcmd.Wrap(statusHistoryCommand{})
+}
+
+type statusHistoryCommand struct {
 	envcmd.EnvCommandBase
 	out           cmd.Output
 	outputContent string
@@ -38,7 +42,7 @@ The statuses for the unit workload and/or agent are available.
  and sorted by time of occurrence.
 `
 
-func (c *StatusHistoryCommand) Info() *cmd.Info {
+func (c *statusHistoryCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "status-history",
 		Args:    "[-n N] <unit>",
@@ -47,13 +51,13 @@ func (c *StatusHistoryCommand) Info() *cmd.Info {
 	}
 }
 
-func (c *StatusHistoryCommand) SetFlags(f *gnuflag.FlagSet) {
+func (c *statusHistoryCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.StringVar(&c.outputContent, "type", "combined", "type of statuses to be displayed [agent|workload|combined].")
 	f.IntVar(&c.backlogSize, "n", 20, "size of logs backlog.")
 	f.BoolVar(&c.isoTime, "utc", false, "display time as UTC in RFC3339 format")
 }
 
-func (c *StatusHistoryCommand) Init(args []string) error {
+func (c *statusHistoryCommand) Init(args []string) error {
 	switch {
 	case len(args) > 1:
 		return errors.Errorf("unexpected arguments after unit name.")
@@ -82,7 +86,7 @@ func (c *StatusHistoryCommand) Init(args []string) error {
 	return errors.Errorf("unexpected status type %q", c.outputContent)
 }
 
-func (c *StatusHistoryCommand) Run(ctx *cmd.Context) error {
+func (c *statusHistoryCommand) Run(ctx *cmd.Context) error {
 	apiclient, err := c.NewAPIClient()
 	if err != nil {
 		return fmt.Errorf(connectionError, c.ConnectionName(), err)

--- a/cmd/juju/status/status.go
+++ b/cmd/juju/status/status.go
@@ -20,11 +20,23 @@ import (
 
 var logger = loggo.GetLogger("juju.cmd.juju.status")
 
-type StatusCommand struct {
+type statusAPI interface {
+	Status(patterns []string) (*params.FullStatus, error)
+	Close() error
+}
+
+// NewStatusCommand returns a new command, which reports on the
+// runtime state of various system entities.
+func NewStatusCommand() cmd.Command {
+	return envcmd.Wrap(&statusCommand{})
+}
+
+type statusCommand struct {
 	envcmd.EnvCommandBase
 	out      cmd.Output
 	patterns []string
 	isoTime  bool
+	api      statusAPI
 }
 
 var statusDoc = `
@@ -58,7 +70,7 @@ of characters. For example, 'nova-*' will match any service whose name begins
 with 'nova-': 'nova-compute', 'nova-volume', etc.
 `
 
-func (c *StatusCommand) Info() *cmd.Info {
+func (c *statusCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "status",
 		Args:    "[pattern ...]",
@@ -68,7 +80,7 @@ func (c *StatusCommand) Info() *cmd.Info {
 	}
 }
 
-func (c *StatusCommand) SetFlags(f *gnuflag.FlagSet) {
+func (c *statusCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.BoolVar(&c.isoTime, "utc", false, "display time as UTC in RFC3339 format")
 
 	oneLineFormatter := FormatOneline
@@ -89,7 +101,7 @@ func (c *StatusCommand) SetFlags(f *gnuflag.FlagSet) {
 	})
 }
 
-func (c *StatusCommand) Init(args []string) error {
+func (c *statusCommand) Init(args []string) error {
 	c.patterns = args
 	// If use of ISO time not specified on command line,
 	// check env var.
@@ -112,20 +124,14 @@ Error details:
 %v
 `
 
-type statusAPI interface {
-	Status(patterns []string) (*params.FullStatus, error)
-	Close() error
-}
-
-var newApiClientForStatus = func(c *StatusCommand) (statusAPI, error) {
+var newApiClientForStatus = func(c *statusCommand) (statusAPI, error) {
 	return c.NewAPIClient()
 }
 
-func (c *StatusCommand) Run(ctx *cmd.Context) error {
-
+func (c *statusCommand) Run(ctx *cmd.Context) error {
 	apiclient, err := newApiClientForStatus(c)
 	if err != nil {
-		return errors.Errorf(connectionError, c.ConnectionName(), err)
+
 	}
 	defer apiclient.Close()
 

--- a/cmd/juju/status/status_test.go
+++ b/cmd/juju/status/status_test.go
@@ -44,7 +44,7 @@ var nextVersion = defineNextVersion()
 
 func runStatus(c *gc.C, args ...string) (code int, stdout, stderr []byte) {
 	ctx := coretesting.Context(c)
-	code = cmd.Main(envcmd.Wrap(&StatusCommand{}), ctx, args)
+	code = cmd.Main(NewStatusCommand(), ctx, args)
 	stdout = ctx.Stdout.(*bytes.Buffer).Bytes()
 	stderr = ctx.Stderr.(*bytes.Buffer).Bytes()
 	return
@@ -2938,7 +2938,7 @@ func (s *StatusSuite) TestStatusWithPreRelationsServer(c *gc.C) {
 		Networks: map[string]params.NetworkStatus{},
 		// Relations field intentionally not set
 	})
-	s.PatchValue(&newApiClientForStatus, func(_ *StatusCommand) (statusAPI, error) {
+	s.PatchValue(&newApiClientForStatus, func(_ *statusCommand) (statusAPI, error) {
 		return &client, nil
 	})
 
@@ -3320,7 +3320,7 @@ func (s *StatusSuite) TestStatusWithNilStatusApi(c *gc.C) {
 	s.PatchValue(&status, func(_ []string) (*params.FullStatus, error) {
 		return nil, nil
 	})
-	s.PatchValue(&newApiClientForStatus, func(_ *StatusCommand) (statusAPI, error) {
+	s.PatchValue(&newApiClientForStatus, func(_ *statusCommand) (statusAPI, error) {
 		return &client, nil
 	})
 
@@ -3647,8 +3647,8 @@ func (s *StatusSuite) TestSummaryStatusWithUnresolvableDns(c *gc.C) {
 	// Test should not panic.
 }
 
-func initStatusCommand(args ...string) (*StatusCommand, error) {
-	com := &StatusCommand{}
+func initStatusCommand(args ...string) (*statusCommand, error) {
+	com := &statusCommand{}
 	return com, coretesting.InitCommand(envcmd.Wrap(com), args)
 }
 

--- a/cmd/juju/storage/export_test.go
+++ b/cmd/juju/storage/export_test.go
@@ -3,15 +3,36 @@
 
 package storage
 
+import (
+	"github.com/juju/cmd"
+
+	"github.com/juju/juju/cmd/envcmd"
+)
+
 var (
 	GetStorageShowAPI    = &getStorageShowAPI
 	GetStorageListAPI    = &getStorageListAPI
-	GetPoolListAPI       = &getPoolListAPI
-	GetPoolCreateAPI     = &getPoolCreateAPI
-	GetVolumeListAPI     = &getVolumeListAPI
 	GetFilesystemListAPI = &getFilesystemListAPI
 
 	ConvertToVolumeInfo     = convertToVolumeInfo
 	ConvertToFilesystemInfo = convertToFilesystemInfo
 	GetStorageAddAPI        = &getStorageAddAPI
+
+	NewPoolSuperCommand   = newPoolSuperCommand
+	NewVolumeSuperCommand = newVolumeSuperCommand
 )
+
+func NewPoolListCommand(api PoolListAPI) cmd.Command {
+	cmd := &poolListCommand{api: api}
+	return envcmd.Wrap(cmd)
+}
+
+func NewPoolCreateCommand(api PoolCreateAPI) cmd.Command {
+	cmd := &poolCreateCommand{api: api}
+	return envcmd.Wrap(cmd)
+}
+
+func NewVolumeListCommand(api VolumeListAPI) cmd.Command {
+	cmd := &volumeListCommand{api: api}
+	return envcmd.Wrap(cmd)
+}

--- a/cmd/juju/storage/pool.go
+++ b/cmd/juju/storage/pool.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/juju/juju/apiserver/params"
 	jujucmd "github.com/juju/juju/cmd"
-	"github.com/juju/juju/cmd/envcmd"
 )
 
 const poolCmdDoc = `
@@ -18,17 +17,17 @@ const poolCmdDoc = `
 
 const poolCmdPurpose = "manage storage pools"
 
-// NewPoolSuperCommand creates the storage pool super subcommand and
+// newPoolSuperCommand creates the storage pool super subcommand and
 // registers the subcommands that it supports.
-func NewPoolSuperCommand() cmd.Command {
+func newPoolSuperCommand() cmd.Command {
 	poolcmd := jujucmd.NewSubSuperCommand(cmd.SuperCommandParams{
 		Name:        "pool",
 		Doc:         poolCmdDoc,
 		UsagePrefix: "juju storage",
 		Purpose:     poolCmdPurpose,
 	})
-	poolcmd.Register(envcmd.Wrap(&PoolListCommand{}))
-	poolcmd.Register(envcmd.Wrap(&PoolCreateCommand{}))
+	poolcmd.Register(newPoolListCommand())
+	poolcmd.Register(newPoolCreateCommand())
 	return poolcmd
 }
 

--- a/cmd/juju/storage/poolcreate_test.go
+++ b/cmd/juju/storage/poolcreate_test.go
@@ -8,7 +8,6 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/cmd/envcmd"
 	"github.com/juju/juju/cmd/juju/storage"
 	_ "github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/testing"
@@ -25,57 +24,54 @@ func (s *PoolCreateSuite) SetUpTest(c *gc.C) {
 	s.SubStorageSuite.SetUpTest(c)
 
 	s.mockAPI = &mockPoolCreateAPI{}
-	s.PatchValue(storage.GetPoolCreateAPI, func(c *storage.PoolCreateCommand) (storage.PoolCreateAPI, error) {
-		return s.mockAPI, nil
-	})
 }
 
-func runPoolCreate(c *gc.C, args []string) (*cmd.Context, error) {
-	return testing.RunCommand(c, envcmd.Wrap(&storage.PoolCreateCommand{}), args...)
+func (s *PoolCreateSuite) runPoolCreate(c *gc.C, args []string) (*cmd.Context, error) {
+	return testing.RunCommand(c, storage.NewPoolCreateCommand(s.mockAPI), args...)
 }
 
 func (s *PoolCreateSuite) TestPoolCreateOneArg(c *gc.C) {
-	_, err := runPoolCreate(c, []string{"sunshine"})
+	_, err := s.runPoolCreate(c, []string{"sunshine"})
 	c.Check(err, gc.ErrorMatches, "pool creation requires names, provider type and attrs for configuration")
 }
 
 func (s *PoolCreateSuite) TestPoolCreateNoArgs(c *gc.C) {
-	_, err := runPoolCreate(c, []string{""})
+	_, err := s.runPoolCreate(c, []string{""})
 	c.Check(err, gc.ErrorMatches, "pool creation requires names, provider type and attrs for configuration")
 }
 
 func (s *PoolCreateSuite) TestPoolCreateTwoArgs(c *gc.C) {
-	_, err := runPoolCreate(c, []string{"sunshine", "lollypop"})
+	_, err := s.runPoolCreate(c, []string{"sunshine", "lollypop"})
 	c.Check(err, gc.ErrorMatches, "pool creation requires names, provider type and attrs for configuration")
 }
 
 func (s *PoolCreateSuite) TestPoolCreateAttrMissingKey(c *gc.C) {
-	_, err := runPoolCreate(c, []string{"sunshine", "lollypop", "=too"})
+	_, err := s.runPoolCreate(c, []string{"sunshine", "lollypop", "=too"})
 	c.Check(err, gc.ErrorMatches, `expected "key=value", got "=too"`)
 }
 
 func (s *PoolCreateSuite) TestPoolCreateAttrMissingValue(c *gc.C) {
-	_, err := runPoolCreate(c, []string{"sunshine", "lollypop", "something="})
+	_, err := s.runPoolCreate(c, []string{"sunshine", "lollypop", "something="})
 	c.Check(err, gc.ErrorMatches, `expected "key=value", got "something="`)
 }
 
 func (s *PoolCreateSuite) TestPoolCreateAttrEmptyValue(c *gc.C) {
-	_, err := runPoolCreate(c, []string{"sunshine", "lollypop", `something=""`})
+	_, err := s.runPoolCreate(c, []string{"sunshine", "lollypop", `something=""`})
 	c.Check(err, jc.ErrorIsNil)
 }
 
 func (s *PoolCreateSuite) TestPoolCreateOneAttr(c *gc.C) {
-	_, err := runPoolCreate(c, []string{"sunshine", "lollypop", "something=too"})
+	_, err := s.runPoolCreate(c, []string{"sunshine", "lollypop", "something=too"})
 	c.Check(err, jc.ErrorIsNil)
 }
 
 func (s *PoolCreateSuite) TestPoolCreateEmptyAttr(c *gc.C) {
-	_, err := runPoolCreate(c, []string{"sunshine", "lollypop", ""})
+	_, err := s.runPoolCreate(c, []string{"sunshine", "lollypop", ""})
 	c.Check(err, gc.ErrorMatches, `expected "key=value", got ""`)
 }
 
 func (s *PoolCreateSuite) TestPoolCreateManyAttrs(c *gc.C) {
-	_, err := runPoolCreate(c, []string{"sunshine", "lollypop", "something=too", "another=one"})
+	_, err := s.runPoolCreate(c, []string{"sunshine", "lollypop", "something=too", "another=one"})
 	c.Check(err, jc.ErrorIsNil)
 }
 

--- a/cmd/juju/storage/poollist_test.go
+++ b/cmd/juju/storage/poollist_test.go
@@ -14,7 +14,6 @@ import (
 	goyaml "gopkg.in/yaml.v1"
 
 	"github.com/juju/juju/apiserver/params"
-	"github.com/juju/juju/cmd/envcmd"
 	"github.com/juju/juju/cmd/juju/storage"
 	_ "github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/testing"
@@ -33,16 +32,11 @@ func (s *poolListSuite) SetUpTest(c *gc.C) {
 	s.mockAPI = &mockPoolListAPI{
 		attrs: map[string]interface{}{"key": "value", "one": "1", "two": 2},
 	}
-	s.PatchValue(storage.GetPoolListAPI,
-		func(c *storage.PoolListCommand) (storage.PoolListAPI, error) {
-			return s.mockAPI, nil
-		})
-
 }
 
-func runPoolList(c *gc.C, args []string) (*cmd.Context, error) {
-	return testing.RunCommand(c,
-		envcmd.Wrap(&storage.PoolListCommand{}), args...)
+func (s *poolListSuite) runPoolList(c *gc.C, args []string) (*cmd.Context, error) {
+	args = append(args, []string{"-e", "dummyenv"}...)
+	return testing.RunCommand(c, storage.NewPoolListCommand(s.mockAPI), args...)
 }
 
 func (s *poolListSuite) TestPoolListEmpty(c *gc.C) {
@@ -119,7 +113,7 @@ type unmarshaller func(in []byte, out interface{}) (err error)
 
 func (s *poolListSuite) assertUnmarshalledOutput(c *gc.C, unmarshall unmarshaller, args ...string) {
 
-	context, err := runPoolList(c, args)
+	context, err := s.runPoolList(c, args)
 	c.Assert(err, jc.ErrorIsNil)
 	var result map[string]storage.PoolInfo
 	err = unmarshall(context.Stdout.(*bytes.Buffer).Bytes(), &result)
@@ -166,7 +160,7 @@ func (s poolListSuite) expect(c *gc.C, types, names []string) map[string]storage
 }
 
 func (s *poolListSuite) assertValidList(c *gc.C, args []string, expected string) {
-	context, err := runPoolList(c, args)
+	context, err := s.runPoolList(c, args)
 	c.Assert(err, jc.ErrorIsNil)
 
 	obtained := testing.Stdout(context)

--- a/cmd/juju/storage/storage.go
+++ b/cmd/juju/storage/storage.go
@@ -39,8 +39,8 @@ func NewSuperCommand() cmd.Command {
 	storagecmd.Register(envcmd.Wrap(&ShowCommand{}))
 	storagecmd.Register(envcmd.Wrap(&ListCommand{}))
 	storagecmd.Register(envcmd.Wrap(&AddCommand{}))
-	storagecmd.Register(NewPoolSuperCommand())
-	storagecmd.Register(NewVolumeSuperCommand())
+	storagecmd.Register(newPoolSuperCommand())
+	storagecmd.Register(newVolumeSuperCommand())
 	storagecmd.Register(NewFilesystemSuperCommand())
 	return storagecmd
 }

--- a/cmd/juju/storage/volume.go
+++ b/cmd/juju/storage/volume.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/juju/juju/apiserver/params"
 	jujucmd "github.com/juju/juju/cmd"
-	"github.com/juju/juju/cmd/envcmd"
 	"github.com/juju/juju/cmd/juju/common"
 )
 
@@ -21,16 +20,16 @@ const volumeCmdDoc = `
 
 const volumeCmdPurpose = "manage storage volumes"
 
-// NewVolumeSuperCommand creates the storage volume super subcommand and
+// newVolumeSuperCommand creates the storage volume super subcommand and
 // registers the subcommands that it supports.
-func NewVolumeSuperCommand() cmd.Command {
+func newVolumeSuperCommand() cmd.Command {
 	supercmd := jujucmd.NewSubSuperCommand(cmd.SuperCommandParams{
 		Name:        "volume",
 		Doc:         volumeCmdDoc,
 		UsagePrefix: "juju storage",
 		Purpose:     volumeCmdPurpose,
 	})
-	supercmd.Register(envcmd.Wrap(&VolumeListCommand{}))
+	supercmd.Register(newVolumeListCommand())
 	return supercmd
 }
 

--- a/cmd/juju/storage/volumelist.go
+++ b/cmd/juju/storage/volumelist.go
@@ -10,9 +10,16 @@ import (
 	"launchpad.net/gnuflag"
 
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/envcmd"
 )
 
-const VolumeListCommandDoc = `
+// VolumeListAPI defines the API methods that the volume list command use.
+type VolumeListAPI interface {
+	Close() error
+	ListVolumes(machines []string) ([]params.VolumeDetailsResult, error)
+}
+
+const volumeListCommandDoc = `
 List volumes (disks) in the environment.
 
 options:
@@ -25,30 +32,35 @@ options:
 
 `
 
-// VolumeListCommand lists storage volumes.
-type VolumeListCommand struct {
+func newVolumeListCommand() cmd.Command {
+	return envcmd.Wrap(&volumeListCommand{})
+}
+
+// volumeListCommand lists storage volumes.
+type volumeListCommand struct {
 	VolumeCommandBase
+	api VolumeListAPI
 	Ids []string
 	out cmd.Output
 }
 
 // Init implements Command.Init.
-func (c *VolumeListCommand) Init(args []string) (err error) {
+func (c *volumeListCommand) Init(args []string) (err error) {
 	c.Ids = args
 	return nil
 }
 
 // Info implements Command.Info.
-func (c *VolumeListCommand) Info() *cmd.Info {
+func (c *volumeListCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "list",
 		Purpose: "list storage volumes",
-		Doc:     VolumeListCommandDoc,
+		Doc:     volumeListCommandDoc,
 	}
 }
 
 // SetFlags implements Command.SetFlags.
-func (c *VolumeListCommand) SetFlags(f *gnuflag.FlagSet) {
+func (c *volumeListCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.StorageCommandBase.SetFlags(f)
 
 	c.out.AddFlags(f, "tabular", map[string]cmd.Formatter{
@@ -59,14 +71,17 @@ func (c *VolumeListCommand) SetFlags(f *gnuflag.FlagSet) {
 }
 
 // Run implements Command.Run.
-func (c *VolumeListCommand) Run(ctx *cmd.Context) (err error) {
-	api, err := getVolumeListAPI(c)
-	if err != nil {
-		return err
+func (c *volumeListCommand) Run(ctx *cmd.Context) (err error) {
+	if c.api == nil {
+		api, err := c.NewStorageAPI()
+		if err != nil {
+			return err
+		}
+		defer api.Close()
+		c.api = api
 	}
-	defer api.Close()
 
-	found, err := api.ListVolumes(c.Ids)
+	found, err := c.api.ListVolumes(c.Ids)
 	if err != nil {
 		return err
 	}
@@ -88,16 +103,4 @@ func (c *VolumeListCommand) Run(ctx *cmd.Context) (err error) {
 		return err
 	}
 	return c.out.Write(ctx, output)
-}
-
-var getVolumeListAPI = (*VolumeListCommand).getVolumeListAPI
-
-// VolumeListAPI defines the API methods that the volume list command use.
-type VolumeListAPI interface {
-	Close() error
-	ListVolumes(machines []string) ([]params.VolumeDetailsResult, error)
-}
-
-func (c *VolumeListCommand) getVolumeListAPI() (VolumeListAPI, error) {
-	return c.NewStorageAPI()
 }

--- a/cmd/juju/subnet/add.go
+++ b/cmd/juju/subnet/add.go
@@ -10,10 +10,16 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/juju/network"
 	"github.com/juju/names"
+
+	"github.com/juju/juju/cmd/envcmd"
 )
 
-// AddCommand calls the API to add an existing subnet to Juju.
-type AddCommand struct {
+func newAddCommand() cmd.Command {
+	return envcmd.Wrap(&addCommand{})
+}
+
+// addCommand calls the API to add an existing subnet to Juju.
+type addCommand struct {
 	SubnetCommandBase
 
 	CIDR       names.SubnetTag
@@ -42,7 +48,7 @@ zone(s) is required.
 `
 
 // Info is defined on the cmd.Command interface.
-func (c *AddCommand) Info() *cmd.Info {
+func (c *addCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "add",
 		Args:    "<CIDR>|<provider-id> <space> [<zone1> <zone2> ...]",
@@ -53,7 +59,7 @@ func (c *AddCommand) Info() *cmd.Info {
 
 // Init is defined on the cmd.Command interface. It checks the
 // arguments for sanity and sets up the command to run.
-func (c *AddCommand) Init(args []string) (err error) {
+func (c *addCommand) Init(args []string) (err error) {
 	defer errors.DeferredAnnotatef(&err, "invalid arguments specified")
 
 	// Ensure we have 2 or more arguments.
@@ -88,7 +94,7 @@ func (c *AddCommand) Init(args []string) (err error) {
 }
 
 // Run implements Command.Run.
-func (c *AddCommand) Run(ctx *cmd.Context) error {
+func (c *addCommand) Run(ctx *cmd.Context) error {
 	return c.RunWithAPI(ctx, func(api SubnetAPI, ctx *cmd.Context) error {
 		if c.CIDR.Id() != "" && c.RawCIDR != c.CIDR.Id() {
 			ctx.Infof(

--- a/cmd/juju/subnet/add_test.go
+++ b/cmd/juju/subnet/add_test.go
@@ -25,7 +25,7 @@ var _ = gc.Suite(&AddSuite{})
 
 func (s *AddSuite) SetUpTest(c *gc.C) {
 	s.BaseSubnetSuite.SetUpTest(c)
-	s.command = subnet.NewAddCommand(s.api)
+	s.command, _ = subnet.NewAddCommand(s.api)
 	c.Assert(s.command, gc.NotNil)
 }
 
@@ -94,8 +94,8 @@ func (s *AddSuite) TestInit(c *gc.C) {
 		// Create a new instance of the subcommand for each test, but
 		// since we're not running the command no need to use
 		// envcmd.Wrap().
-		command := subnet.NewAddCommand(s.api)
-		err := coretesting.InitCommand(command, test.args)
+		wrappedCommand, command := subnet.NewAddCommand(s.api)
+		err := coretesting.InitCommand(wrappedCommand, test.args)
 		if test.expectErr != "" {
 			prefixedErr := "invalid arguments specified: " + test.expectErr
 			c.Check(err, gc.ErrorMatches, prefixedErr)
@@ -236,16 +236,4 @@ func (s *AddSuite) TestRunWithAmbiguousCIDRDisplaysError(c *gc.C) {
 		names.NewSpaceTag("space"),
 		s.Strings("zone1", "zone2"),
 	)
-}
-
-func (s *AddSuite) TestRunAPIConnectFails(c *gc.C) {
-	// TODO(dimitern): Change this once API is implemented.
-	s.command = subnet.NewAddCommand(nil)
-	s.AssertRunFails(c,
-		"cannot connect to the API server: no environment specified",
-		"10.10.0.0/24", "space",
-	)
-
-	// No API calls recoreded.
-	s.api.CheckCallNames(c)
 }

--- a/cmd/juju/subnet/create.go
+++ b/cmd/juju/subnet/create.go
@@ -12,10 +12,16 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/names"
 	"github.com/juju/utils/set"
+
+	"github.com/juju/juju/cmd/envcmd"
 )
 
-// CreateCommand calls the API to create a new subnet.
-type CreateCommand struct {
+func newCreateCommand() cmd.Command {
+	return envcmd.Wrap(&createCommand{})
+}
+
+// createCommand calls the API to create a new subnet.
+type createCommand struct {
 	SubnetCommandBase
 
 	CIDR      names.SubnetTag
@@ -55,7 +61,7 @@ supported.
 `
 
 // Info is defined on the cmd.Command interface.
-func (c *CreateCommand) Info() *cmd.Info {
+func (c *createCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "create",
 		Args:    "<CIDR> <space> <zone1> [<zone2> <zone3> ...] [--public|--private]",
@@ -65,7 +71,7 @@ func (c *CreateCommand) Info() *cmd.Info {
 }
 
 // SetFlags is defined on the cmd.Command interface.
-func (c *CreateCommand) SetFlags(f *gnuflag.FlagSet) {
+func (c *createCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.SubnetCommandBase.SetFlags(f)
 	f.BoolVar(&c.IsPublic, "public", false, "enable public access with shadow addresses")
 	f.BoolVar(&c.IsPrivate, "private", true, "disable public access with shadow addresses")
@@ -79,7 +85,7 @@ func (c *CreateCommand) SetFlags(f *gnuflag.FlagSet) {
 
 // Init is defined on the cmd.Command interface. It checks the
 // arguments for sanity and sets up the command to run.
-func (c *CreateCommand) Init(args []string) error {
+func (c *createCommand) Init(args []string) error {
 	// Ensure we have at least 3 arguments.
 	// TODO:(mfoord) we need to support VLANTag as an additional optional
 	// argument.
@@ -135,7 +141,7 @@ func (c *CreateCommand) Init(args []string) error {
 }
 
 // Run implements Command.Run.
-func (c *CreateCommand) Run(ctx *cmd.Context) error {
+func (c *createCommand) Run(ctx *cmd.Context) error {
 	return c.RunWithAPI(ctx, func(api SubnetAPI, ctx *cmd.Context) error {
 		if !c.Zones.IsEmpty() {
 			// Fetch all zones to validate the given zones.

--- a/cmd/juju/subnet/create_test.go
+++ b/cmd/juju/subnet/create_test.go
@@ -23,7 +23,7 @@ var _ = gc.Suite(&CreateSuite{})
 func (s *CreateSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetFeatureFlags(feature.PostNetCLIMVP)
 	s.BaseSubnetSuite.SetUpTest(c)
-	s.command = subnet.NewCreateCommand(s.api)
+	s.command, _ = subnet.NewCreateCommand(s.api)
 	c.Assert(s.command, gc.NotNil)
 }
 
@@ -125,8 +125,8 @@ func (s *CreateSuite) TestInit(c *gc.C) {
 		// Create a new instance of the subcommand for each test, but
 		// since we're not running the command no need to use
 		// envcmd.Wrap().
-		command := subnet.NewCreateCommand(s.api)
-		err := coretesting.InitCommand(command, test.args)
+		wrappedCommand, command := subnet.NewCreateCommand(s.api)
+		err := coretesting.InitCommand(wrappedCommand, test.args)
 		if test.expectErr != "" {
 			c.Check(err, gc.ErrorMatches, test.expectErr)
 		} else {
@@ -231,16 +231,4 @@ func (s *CreateSuite) TestRunWithUnknownZonesFails(c *gc.C) {
 	)
 
 	s.api.CheckCallNames(c, "AllZones", "Close")
-}
-
-func (s *CreateSuite) TestRunAPIConnectFails(c *gc.C) {
-	// TODO(dimitern): Change this once API is implemented.
-	s.command = subnet.NewCreateCommand(nil)
-	s.AssertRunFails(c,
-		"cannot connect to the API server: no environment specified",
-		"10.10.0.0/24", "space", "zone1",
-	)
-
-	// No API calls recoreded.
-	s.api.CheckCallNames(c)
 }

--- a/cmd/juju/subnet/export_test.go
+++ b/cmd/juju/subnet/export_test.go
@@ -3,30 +3,52 @@
 
 package subnet
 
-func NewCreateCommand(api SubnetAPI) *CreateCommand {
-	createCmd := &CreateCommand{}
-	createCmd.api = api
-	return createCmd
+import (
+	"github.com/juju/cmd"
+
+	"github.com/juju/juju/cmd/envcmd"
+)
+
+type CreateCommand struct {
+	*createCommand
 }
 
-func NewAddCommand(api SubnetAPI) *AddCommand {
-	addCmd := &AddCommand{}
-	addCmd.api = api
-	return addCmd
+func NewCreateCommand(api SubnetAPI) (cmd.Command, *CreateCommand) {
+	cmd := &createCommand{
+		SubnetCommandBase: SubnetCommandBase{api: api},
+	}
+	return envcmd.Wrap(cmd), &CreateCommand{cmd}
 }
 
-func NewRemoveCommand(api SubnetAPI) *RemoveCommand {
-	removeCmd := &RemoveCommand{}
-	removeCmd.api = api
-	return removeCmd
+type AddCommand struct {
+	*addCommand
 }
 
-func NewListCommand(api SubnetAPI) *ListCommand {
-	listCmd := &ListCommand{}
-	listCmd.api = api
-	return listCmd
+func NewAddCommand(api SubnetAPI) (cmd.Command, *AddCommand) {
+	cmd := &addCommand{
+		SubnetCommandBase: SubnetCommandBase{api: api},
+	}
+	return envcmd.Wrap(cmd), &AddCommand{cmd}
 }
 
-func ListFormat(cmd *ListCommand) string {
-	return cmd.out.Name()
+type RemoveCommand struct {
+	*removeCommand
+}
+
+func NewRemoveCommand(api SubnetAPI) (cmd.Command, *RemoveCommand) {
+	removeCmd := &removeCommand{
+		SubnetCommandBase: SubnetCommandBase{api: api},
+	}
+	return envcmd.Wrap(removeCmd), &RemoveCommand{removeCmd}
+}
+
+type ListCommand struct {
+	*listCommand
+}
+
+func NewListCommand(api SubnetAPI) (cmd.Command, *ListCommand) {
+	cmd := &listCommand{
+		SubnetCommandBase: SubnetCommandBase{api: api},
+	}
+	return envcmd.Wrap(cmd), &ListCommand{cmd}
 }

--- a/cmd/juju/subnet/list.go
+++ b/cmd/juju/subnet/list.go
@@ -14,10 +14,16 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/names"
+
+	"github.com/juju/juju/cmd/envcmd"
 )
 
-// ListCommand displays a list of all subnets known to Juju
-type ListCommand struct {
+func newListCommand() cmd.Command {
+	return envcmd.Wrap(&listCommand{})
+}
+
+// listCommand displays a list of all subnets known to Juju
+type listCommand struct {
 	SubnetCommandBase
 
 	SpaceName string
@@ -25,7 +31,7 @@ type ListCommand struct {
 
 	spaceTag *names.SpaceTag
 
-	out cmd.Output
+	Out cmd.Output
 }
 
 const listCommandDoc = `
@@ -40,7 +46,7 @@ output to a file, use --output.
 `
 
 // Info is defined on the cmd.Command interface.
-func (c *ListCommand) Info() *cmd.Info {
+func (c *listCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "list",
 		Args:    "[--space <name>] [--zone <name>] [--format yaml|json] [--output <path>]",
@@ -50,9 +56,9 @@ func (c *ListCommand) Info() *cmd.Info {
 }
 
 // SetFlags is defined on the cmd.Command interface.
-func (c *ListCommand) SetFlags(f *gnuflag.FlagSet) {
+func (c *listCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.SubnetCommandBase.SetFlags(f)
-	c.out.AddFlags(f, "yaml", map[string]cmd.Formatter{
+	c.Out.AddFlags(f, "yaml", map[string]cmd.Formatter{
 		"yaml": cmd.FormatYaml,
 		"json": cmd.FormatJson,
 	})
@@ -63,7 +69,7 @@ func (c *ListCommand) SetFlags(f *gnuflag.FlagSet) {
 
 // Init is defined on the cmd.Command interface. It checks the
 // arguments for sanity and sets up the command to run.
-func (c *ListCommand) Init(args []string) error {
+func (c *listCommand) Init(args []string) error {
 	// No arguments are accepted, just flags.
 	err := cmd.CheckEmpty(args)
 	if err != nil {
@@ -84,7 +90,7 @@ func (c *ListCommand) Init(args []string) error {
 }
 
 // Run implements Command.Run.
-func (c *ListCommand) Run(ctx *cmd.Context) error {
+func (c *listCommand) Run(ctx *cmd.Context) error {
 	return c.RunWithAPI(ctx, func(api SubnetAPI, ctx *cmd.Context) error {
 		// Validate space and/or zone, if given to display a nicer error
 		// message.
@@ -141,7 +147,7 @@ func (c *ListCommand) Run(ctx *cmd.Context) error {
 			result.Subnets[sub.CIDR] = subResult
 		}
 
-		return c.out.Write(ctx, result)
+		return c.Out.Write(ctx, result)
 	})
 }
 

--- a/cmd/juju/subnet/list_test.go
+++ b/cmd/juju/subnet/list_test.go
@@ -25,7 +25,7 @@ var _ = gc.Suite(&ListSuite{})
 
 func (s *ListSuite) SetUpTest(c *gc.C) {
 	s.BaseSubnetSuite.SetUpTest(c)
-	s.command = subnet.NewListCommand(s.api)
+	s.command, _ = subnet.NewListCommand(s.api)
 	c.Assert(s.command, gc.NotNil)
 }
 
@@ -86,8 +86,8 @@ func (s *ListSuite) TestInit(c *gc.C) {
 		// Create a new instance of the subcommand for each test, but
 		// since we're not running the command no need to use
 		// envcmd.Wrap().
-		command := subnet.NewListCommand(s.api)
-		err := coretesting.InitCommand(command, test.args)
+		wrappedCommand, command := subnet.NewListCommand(s.api)
+		err := coretesting.InitCommand(wrappedCommand, test.args)
 		if test.expectErr != "" {
 			c.Check(err, gc.ErrorMatches, test.expectErr)
 		} else {
@@ -95,7 +95,7 @@ func (s *ListSuite) TestInit(c *gc.C) {
 		}
 		c.Check(command.SpaceName, gc.Equals, test.expectSpace)
 		c.Check(command.ZoneName, gc.Equals, test.expectZone)
-		c.Check(subnet.ListFormat(command), gc.Equals, test.expectFormat)
+		c.Check(command.Out.Name(), gc.Equals, test.expectFormat)
 
 		// No API calls should be recorded at this stage.
 		s.api.CheckCallNames(c)
@@ -329,15 +329,4 @@ func (s *ListSuite) TestRunWhenASubnetHasInvalidSpaceFails(c *gc.C) {
 
 	s.api.CheckCallNames(c, "ListSubnets", "Close")
 	s.api.CheckCall(c, 0, "ListSubnets", nil, "")
-}
-
-func (s *ListSuite) TestRunAPIConnectFails(c *gc.C) {
-	// TODO(dimitern): Change this once API is implemented.
-	s.command = subnet.NewListCommand(nil)
-	s.AssertRunFails(c,
-		"cannot connect to the API server: no environment specified",
-	)
-
-	// No API calls recoreded.
-	s.api.CheckCallNames(c)
 }

--- a/cmd/juju/subnet/remove.go
+++ b/cmd/juju/subnet/remove.go
@@ -9,11 +9,17 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/names"
+
+	"github.com/juju/juju/cmd/envcmd"
 )
 
-// RemoveCommand calls the API to remove an existing, unused subnet
+func newRemoveCommand() cmd.Command {
+	return envcmd.Wrap(&removeCommand{})
+}
+
+// removeCommand calls the API to remove an existing, unused subnet
 // from Juju.
-type RemoveCommand struct {
+type removeCommand struct {
 	SubnetCommandBase
 
 	CIDR names.SubnetTag
@@ -34,7 +40,7 @@ until all related entites are cleaned up (e.g. allocated addresses).
 `
 
 // Info is defined on the cmd.Command interface.
-func (c *RemoveCommand) Info() *cmd.Info {
+func (c *removeCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "remove",
 		Args:    "<CIDR>",
@@ -45,7 +51,7 @@ func (c *RemoveCommand) Info() *cmd.Info {
 
 // Init is defined on the cmd.Command interface. It checks the
 // arguments for sanity and sets up the command to run.
-func (c *RemoveCommand) Init(args []string) error {
+func (c *removeCommand) Init(args []string) error {
 	// Ensure we have exactly 1 argument.
 	err := c.CheckNumArgs(args, []error{errNoCIDR})
 	if err != nil {
@@ -62,7 +68,7 @@ func (c *RemoveCommand) Init(args []string) error {
 }
 
 // Run implements Command.Run.
-func (c *RemoveCommand) Run(ctx *cmd.Context) error {
+func (c *removeCommand) Run(ctx *cmd.Context) error {
 	return c.RunWithAPI(ctx, func(api SubnetAPI, ctx *cmd.Context) error {
 		// Try removing the subnet.
 		if err := api.RemoveSubnet(c.CIDR); err != nil {

--- a/cmd/juju/subnet/remove_test.go
+++ b/cmd/juju/subnet/remove_test.go
@@ -23,7 +23,7 @@ var _ = gc.Suite(&RemoveSuite{})
 func (s *RemoveSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetFeatureFlags(feature.PostNetCLIMVP)
 	s.BaseSubnetSuite.SetUpTest(c)
-	s.command = subnet.NewRemoveCommand(s.api)
+	s.command, _ = subnet.NewRemoveCommand(s.api)
 	c.Assert(s.command, gc.NotNil)
 }
 
@@ -54,8 +54,8 @@ func (s *RemoveSuite) TestInit(c *gc.C) {
 		// Create a new instance of the subcommand for each test, but
 		// since we're not running the command no need to use
 		// envcmd.Wrap().
-		command := subnet.NewRemoveCommand(s.api)
-		err := coretesting.InitCommand(command, test.args)
+		wrappedCommand, command := subnet.NewRemoveCommand(s.api)
+		err := coretesting.InitCommand(wrappedCommand, test.args)
 		if test.expectErr != "" {
 			c.Check(err, gc.ErrorMatches, test.expectErr)
 		} else {
@@ -113,16 +113,4 @@ func (s *RemoveSuite) TestRunWithSubnetInUseFails(c *gc.C) {
 
 	s.api.CheckCallNames(c, "RemoveSubnet", "Close")
 	s.api.CheckCall(c, 0, "RemoveSubnet", names.NewSubnetTag("10.10.0.0/24"))
-}
-
-func (s *RemoveSuite) TestRunAPIConnectFails(c *gc.C) {
-	// TODO(dimitern): Change this once API is implemented.
-	s.command = subnet.NewRemoveCommand(nil)
-	s.AssertRunFails(c,
-		"cannot connect to the API server: no environment specified",
-		"10.10.0.0/24",
-	)
-
-	// No API calls recoreded.
-	s.api.CheckCallNames(c)
 }

--- a/cmd/juju/subnet/subnet.go
+++ b/cmd/juju/subnet/subnet.go
@@ -94,12 +94,12 @@ func NewSuperCommand() cmd.Command {
 		UsagePrefix: "juju",
 		Purpose:     "manage subnets",
 	})
-	subnetCmd.Register(envcmd.Wrap(&AddCommand{}))
-	subnetCmd.Register(envcmd.Wrap(&ListCommand{}))
+	subnetCmd.Register(newAddCommand())
+	subnetCmd.Register(newListCommand())
 	if featureflag.Enabled(feature.PostNetCLIMVP) {
 		// The following commands are not part of the MVP.
-		subnetCmd.Register(envcmd.Wrap(&CreateCommand{}))
-		subnetCmd.Register(envcmd.Wrap(&RemoveCommand{}))
+		subnetCmd.Register(newCreateCommand())
+		subnetCmd.Register(newRemoveCommand())
 	}
 
 	return subnetCmd

--- a/cmd/juju/system/createenvironment.go
+++ b/cmd/juju/system/createenvironment.go
@@ -22,15 +22,19 @@ import (
 	localProvider "github.com/juju/juju/provider/local"
 )
 
-// CreateEnvironmentCommand calls the API to create a new environment.
-type CreateEnvironmentCommand struct {
+func newCreateEnvironmentCommand() cmd.Command {
+	return envcmd.WrapSystem(&createEnvironmentCommand{})
+}
+
+// createEnvironmentCommand calls the API to create a new environment.
+type createEnvironmentCommand struct {
 	envcmd.SysCommandBase
 	api CreateEnvironmentAPI
 
-	name       string
-	owner      string
-	configFile cmd.FileVar
-	confValues map[string]string
+	Name       string
+	Owner      string
+	ConfigFile cmd.FileVar
+	ConfValues map[string]string
 }
 
 const createEnvHelpDoc = `
@@ -53,7 +57,7 @@ See Also:
     juju help environment share
 `
 
-func (c *CreateEnvironmentCommand) Info() *cmd.Info {
+func (c *createEnvironmentCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "create-environment",
 		Args:    "<name> [key=[value] ...]",
@@ -63,25 +67,25 @@ func (c *CreateEnvironmentCommand) Info() *cmd.Info {
 	}
 }
 
-func (c *CreateEnvironmentCommand) SetFlags(f *gnuflag.FlagSet) {
-	f.StringVar(&c.owner, "owner", "", "the owner of the new environment if not the current user")
-	f.Var(&c.configFile, "config", "path to yaml-formatted file containing environment config values")
+func (c *createEnvironmentCommand) SetFlags(f *gnuflag.FlagSet) {
+	f.StringVar(&c.Owner, "owner", "", "the owner of the new environment if not the current user")
+	f.Var(&c.ConfigFile, "config", "path to yaml-formatted file containing environment config values")
 }
 
-func (c *CreateEnvironmentCommand) Init(args []string) error {
+func (c *createEnvironmentCommand) Init(args []string) error {
 	if len(args) == 0 {
 		return errors.New("environment name is required")
 	}
-	c.name, args = args[0], args[1:]
+	c.Name, args = args[0], args[1:]
 
 	values, err := keyvalues.Parse(args, true)
 	if err != nil {
 		return err
 	}
-	c.confValues = values
+	c.ConfValues = values
 
-	if c.owner != "" && !names.IsValidUser(c.owner) {
-		return errors.Errorf("%q is not a valid user", c.owner)
+	if c.Owner != "" && !names.IsValidUser(c.Owner) {
+		return errors.Errorf("%q is not a valid user", c.Owner)
 	}
 
 	return nil
@@ -93,14 +97,14 @@ type CreateEnvironmentAPI interface {
 	CreateEnvironment(owner string, account, config map[string]interface{}) (params.Environment, error)
 }
 
-func (c *CreateEnvironmentCommand) getAPI() (CreateEnvironmentAPI, error) {
+func (c *createEnvironmentCommand) getAPI() (CreateEnvironmentAPI, error) {
 	if c.api != nil {
 		return c.api, nil
 	}
 	return c.NewEnvironmentManagerAPIClient()
 }
 
-func (c *CreateEnvironmentCommand) Run(ctx *cmd.Context) (return_err error) {
+func (c *createEnvironmentCommand) Run(ctx *cmd.Context) (return_err error) {
 	client, err := c.getAPI()
 	if err != nil {
 		return err
@@ -114,17 +118,17 @@ func (c *CreateEnvironmentCommand) Run(ctx *cmd.Context) (return_err error) {
 
 	creatingForSelf := true
 	envOwner := creds.User
-	if c.owner != "" {
-		owner := names.NewUserTag(c.owner)
+	if c.Owner != "" {
+		owner := names.NewUserTag(c.Owner)
 		user := names.NewUserTag(creds.User)
 		creatingForSelf = owner == user
-		envOwner = c.owner
+		envOwner = c.Owner
 	}
 
 	var info configstore.EnvironInfo
 	var endpoint configstore.APIEndpoint
 	if creatingForSelf {
-		logger.Debugf("create cache entry for %q", c.name)
+		logger.Debugf("create cache entry for %q", c.Name)
 		// Create the configstore entry and write it to disk, as this will error
 		// if one with the same name already exists.
 		endpoint, err = c.ConnectionEndpoint()
@@ -136,12 +140,12 @@ func (c *CreateEnvironmentCommand) Run(ctx *cmd.Context) (return_err error) {
 		if err != nil {
 			return errors.Trace(err)
 		}
-		info = store.CreateInfo(c.name)
+		info = store.CreateInfo(c.Name)
 		info.SetAPICredentials(creds)
 		endpoint.EnvironUUID = ""
 		if err := info.Write(); err != nil {
 			if errors.Cause(err) == configstore.ErrEnvironInfoAlreadyExists {
-				newErr := errors.AlreadyExistsf("environment %q", c.name)
+				newErr := errors.AlreadyExistsf("environment %q", c.Name)
 				return errors.Wrap(err, newErr)
 			}
 			return errors.Trace(err)
@@ -156,7 +160,7 @@ func (c *CreateEnvironmentCommand) Run(ctx *cmd.Context) (return_err error) {
 			}
 		}()
 	} else {
-		logger.Debugf("skipping cache entry for %q as owned %q", c.name, c.owner)
+		logger.Debugf("skipping cache entry for %q as owned %q", c.Name, c.Owner)
 	}
 
 	serverSkeleton, err := client.ConfigSkeleton("", "")
@@ -182,22 +186,22 @@ func (c *CreateEnvironmentCommand) Run(ctx *cmd.Context) (return_err error) {
 		if err := info.Write(); err != nil {
 			return errors.Trace(err)
 		}
-		ctx.Infof("created environment %q", c.name)
-		return envcmd.SetCurrentEnvironment(ctx, c.name)
+		ctx.Infof("created environment %q", c.Name)
+		return envcmd.SetCurrentEnvironment(ctx, c.Name)
 	} else {
-		ctx.Infof("created environment %q for %q", c.name, c.owner)
+		ctx.Infof("created environment %q for %q", c.Name, c.Owner)
 	}
 
 	return nil
 }
 
-func (c *CreateEnvironmentCommand) getConfigValues(ctx *cmd.Context, serverSkeleton params.EnvironConfig) (map[string]interface{}, error) {
+func (c *createEnvironmentCommand) getConfigValues(ctx *cmd.Context, serverSkeleton params.EnvironConfig) (map[string]interface{}, error) {
 	// The reading of the config YAML is done in the Run
 	// method because the Read method requires the cmd Context
 	// for the current directory.
 	fileConfig := make(map[string]interface{})
-	if c.configFile.Path != "" {
-		configYAML, err := c.configFile.Read(ctx)
+	if c.ConfigFile.Path != "" {
+		configYAML, err := c.ConfigFile.Read(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -214,12 +218,12 @@ func (c *CreateEnvironmentCommand) getConfigValues(ctx *cmd.Context, serverSkele
 	for key, value := range fileConfig {
 		configValues[key] = value
 	}
-	for key, value := range c.confValues {
+	for key, value := range c.ConfValues {
 		configValues[key] = value
 	}
-	configValues["name"] = c.name
+	configValues["name"] = c.Name
 
-	if err := setConfigSpecialCaseDefaults(c.name, configValues); err != nil {
+	if err := setConfigSpecialCaseDefaults(c.Name, configValues); err != nil {
 		return nil, errors.Trace(err)
 	}
 	// TODO: allow version to be specified on the command line and add here.

--- a/cmd/juju/system/createenvironment_test.go
+++ b/cmd/juju/system/createenvironment_test.go
@@ -65,8 +65,8 @@ func (s *createSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *createSuite) run(c *gc.C, args ...string) (*cmd.Context, error) {
-	command := system.NewCreateEnvironmentCommand(s.fake)
-	return testing.RunCommand(c, envcmd.WrapSystem(command), args...)
+	cmd, _ := system.NewCreateEnvironmentCommand(s.fake)
+	return testing.RunCommand(c, cmd, args...)
 }
 
 func (s *createSuite) TestInit(c *gc.C) {
@@ -108,23 +108,23 @@ func (s *createSuite) TestInit(c *gc.C) {
 		},
 	} {
 		c.Logf("test %d", i)
-		create := &system.CreateEnvironmentCommand{}
-		err := testing.InitCommand(create, test.args)
+		wrappedCommand, command := system.NewCreateEnvironmentCommand(nil)
+		err := testing.InitCommand(wrappedCommand, test.args)
 		if test.err != "" {
 			c.Assert(err, gc.ErrorMatches, test.err)
 			continue
 		}
 
 		c.Assert(err, jc.ErrorIsNil)
-		c.Assert(create.Name(), gc.Equals, test.name)
-		c.Assert(create.Owner(), gc.Equals, test.owner)
-		c.Assert(create.ConfigFile().Path, gc.Equals, test.path)
+		c.Assert(command.Name, gc.Equals, test.name)
+		c.Assert(command.Owner, gc.Equals, test.owner)
+		c.Assert(command.ConfigFile.Path, gc.Equals, test.path)
 		// The config value parse method returns an empty map
 		// if there were no values
 		if len(test.values) == 0 {
-			c.Assert(create.ConfValues(), gc.HasLen, 0)
+			c.Assert(command.ConfValues, gc.HasLen, 0)
 		} else {
-			c.Assert(create.ConfValues(), jc.DeepEquals, test.values)
+			c.Assert(command.ConfValues, jc.DeepEquals, test.values)
 		}
 	}
 }

--- a/cmd/juju/system/destroy.go
+++ b/cmd/juju/system/destroy.go
@@ -25,9 +25,16 @@ import (
 	"github.com/juju/juju/juju"
 )
 
-// DestroyCommand destroys the specified system.
-type DestroyCommand struct {
-	DestroyCommandBase
+func newDestroyCommand() cmd.Command {
+	return envcmd.WrapSystem(
+		&destroyCommand{},
+		envcmd.SystemSkipFlags,
+		envcmd.SystemSkipDefault)
+}
+
+// destroyCommand destroys the specified system.
+type destroyCommand struct {
+	destroyCommandBase
 	destroyEnvs bool
 }
 
@@ -56,7 +63,7 @@ type destroyClientAPI interface {
 }
 
 // Info implements Command.Info.
-func (c *DestroyCommand) Info() *cmd.Info {
+func (c *destroyCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "destroy",
 		Args:    "<system name>",
@@ -66,12 +73,12 @@ func (c *DestroyCommand) Info() *cmd.Info {
 }
 
 // SetFlags implements Command.SetFlags.
-func (c *DestroyCommand) SetFlags(f *gnuflag.FlagSet) {
+func (c *destroyCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.BoolVar(&c.destroyEnvs, "destroy-all-environments", false, "destroy all hosted environments on the system")
-	c.DestroyCommandBase.SetFlags(f)
+	c.destroyCommandBase.SetFlags(f)
 }
 
-func (c *DestroyCommand) getSystemAPI() (destroySystemAPI, error) {
+func (c *destroyCommand) getSystemAPI() (destroySystemAPI, error) {
 	if c.api != nil {
 		return c.api, c.apierr
 	}
@@ -84,7 +91,7 @@ func (c *DestroyCommand) getSystemAPI() (destroySystemAPI, error) {
 }
 
 // Run implements Command.Run
-func (c *DestroyCommand) Run(ctx *cmd.Context) error {
+func (c *destroyCommand) Run(ctx *cmd.Context) error {
 	store, err := configstore.Default()
 	if err != nil {
 		return errors.Annotate(err, "cannot open system info storage")
@@ -137,7 +144,7 @@ func (c *DestroyCommand) Run(ctx *cmd.Context) error {
 
 // destroySystemViaClient attempts to destroy the system using the client
 // endpoint for older juju systems which do not implement systemmanager.DestroySystem
-func (c *DestroyCommand) destroySystemViaClient(ctx *cmd.Context, info configstore.EnvironInfo, systemEnviron environs.Environ, store configstore.Storage) error {
+func (c *destroyCommand) destroySystemViaClient(ctx *cmd.Context, info configstore.EnvironInfo, systemEnviron environs.Environ, store configstore.Storage) error {
 	api, err := c.getClientAPI()
 	if err != nil {
 		return c.ensureUserFriendlyErrorLog(errors.Annotate(err, "cannot connect to API"), ctx, nil)
@@ -154,7 +161,7 @@ func (c *DestroyCommand) destroySystemViaClient(ctx *cmd.Context, info configsto
 
 // ensureUserFriendlyErrorLog ensures that error will be logged and displayed
 // in a user-friendly manner with readable and digestable error message.
-func (c *DestroyCommand) ensureUserFriendlyErrorLog(destroyErr error, ctx *cmd.Context, api destroySystemAPI) error {
+func (c *destroyCommand) ensureUserFriendlyErrorLog(destroyErr error, ctx *cmd.Context, api destroySystemAPI) error {
 	if destroyErr == nil {
 		return nil
 	}
@@ -230,9 +237,9 @@ func blocksToStr(blocks []string) string {
 	return result
 }
 
-// DestroyCommandBase provides common attributes and methods that both the system
+// destroyCommandBase provides common attributes and methods that both the system
 // destroy and system kill commands require.
-type DestroyCommandBase struct {
+type destroyCommandBase struct {
 	envcmd.SysCommandBase
 	systemName string
 	assumeYes  bool
@@ -244,7 +251,7 @@ type DestroyCommandBase struct {
 	clientapi destroyClientAPI
 }
 
-func (c *DestroyCommandBase) getClientAPI() (destroyClientAPI, error) {
+func (c *destroyCommandBase) getClientAPI() (destroyClientAPI, error) {
 	if c.clientapi != nil {
 		return c.clientapi, nil
 	}
@@ -256,13 +263,13 @@ func (c *DestroyCommandBase) getClientAPI() (destroyClientAPI, error) {
 }
 
 // SetFlags implements Command.SetFlags.
-func (c *DestroyCommandBase) SetFlags(f *gnuflag.FlagSet) {
+func (c *destroyCommandBase) SetFlags(f *gnuflag.FlagSet) {
 	f.BoolVar(&c.assumeYes, "y", false, "Do not ask for confirmation")
 	f.BoolVar(&c.assumeYes, "yes", false, "")
 }
 
 // Init implements Command.Init.
-func (c *DestroyCommandBase) Init(args []string) error {
+func (c *destroyCommandBase) Init(args []string) error {
 	switch len(args) {
 	case 0:
 		return errors.New("no system specified")
@@ -277,7 +284,7 @@ func (c *DestroyCommandBase) Init(args []string) error {
 // getSystemEnviron gets the bootstrap information required to destroy the environment
 // by first checking the config store, then querying the API if the information is not
 // in the store.
-func (c *DestroyCommandBase) getSystemEnviron(info configstore.EnvironInfo, sysAPI destroySystemAPI) (_ environs.Environ, err error) {
+func (c *destroyCommandBase) getSystemEnviron(info configstore.EnvironInfo, sysAPI destroySystemAPI) (_ environs.Environ, err error) {
 	bootstrapCfg := info.BootstrapConfig()
 	if bootstrapCfg == nil {
 		if sysAPI == nil {

--- a/cmd/juju/system/destroy_test.go
+++ b/cmd/juju/system/destroy_test.go
@@ -146,7 +146,7 @@ func (s *DestroySuite) runDestroyCommand(c *gc.C, args ...string) (*cmd.Context,
 	return testing.RunCommand(c, cmd, args...)
 }
 
-func (s *DestroySuite) newDestroyCommand() *system.DestroyCommand {
+func (s *DestroySuite) newDestroyCommand() cmd.Command {
 	return system.NewDestroyCommand(s.api, s.clientapi, s.apierror)
 }
 

--- a/cmd/juju/system/environments.go
+++ b/cmd/juju/system/environments.go
@@ -19,9 +19,13 @@ import (
 	"github.com/juju/juju/environs/configstore"
 )
 
-// EnvironmentsCommand returns the list of all the environments the
+func newEnvironmentsCommand() cmd.Command {
+	return envcmd.WrapSystem(&environmentsCommand{})
+}
+
+// environmentsCommand returns the list of all the environments the
 // current user can access on the current system.
-type EnvironmentsCommand struct {
+type environmentsCommand struct {
 	envcmd.SysCommandBase
 	out       cmd.Output
 	all       bool
@@ -62,7 +66,7 @@ type EnvironmentsSysAPI interface {
 }
 
 // Info implements Command.Info
-func (c *EnvironmentsCommand) Info() *cmd.Info {
+func (c *environmentsCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "environments",
 		Purpose: "list all environments the user can access on the current system",
@@ -70,21 +74,21 @@ func (c *EnvironmentsCommand) Info() *cmd.Info {
 	}
 }
 
-func (c *EnvironmentsCommand) getEnvAPI() (EnvironmentsEnvAPI, error) {
+func (c *environmentsCommand) getEnvAPI() (EnvironmentsEnvAPI, error) {
 	if c.envAPI != nil {
 		return c.envAPI, nil
 	}
 	return c.NewEnvironmentManagerAPIClient()
 }
 
-func (c *EnvironmentsCommand) getSysAPI() (EnvironmentsSysAPI, error) {
+func (c *environmentsCommand) getSysAPI() (EnvironmentsSysAPI, error) {
 	if c.sysAPI != nil {
 		return c.sysAPI, nil
 	}
 	return c.NewSystemManagerAPIClient()
 }
 
-func (c *EnvironmentsCommand) getConnectionCredentials() (configstore.APICredentials, error) {
+func (c *environmentsCommand) getConnectionCredentials() (configstore.APICredentials, error) {
 	if c.userCreds != nil {
 		return *c.userCreds, nil
 	}
@@ -92,7 +96,7 @@ func (c *EnvironmentsCommand) getConnectionCredentials() (configstore.APICredent
 }
 
 // SetFlags implements Command.SetFlags.
-func (c *EnvironmentsCommand) SetFlags(f *gnuflag.FlagSet) {
+func (c *environmentsCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.StringVar(&c.user, "user", "", "the user to list environments for (administrative users only)")
 	f.BoolVar(&c.all, "all", false, "show all environments  (administrative users only)")
 	f.BoolVar(&c.listUUID, "uuid", false, "display UUID for environments")
@@ -113,7 +117,7 @@ type UserEnvironment struct {
 }
 
 // Run implements Command.Run
-func (c *EnvironmentsCommand) Run(ctx *cmd.Context) error {
+func (c *environmentsCommand) Run(ctx *cmd.Context) error {
 	if c.user == "" {
 		creds, err := c.getConnectionCredentials()
 		if err != nil {
@@ -147,7 +151,7 @@ func (c *EnvironmentsCommand) Run(ctx *cmd.Context) error {
 	return c.out.Write(ctx, output)
 }
 
-func (c *EnvironmentsCommand) getAllEnvironments() ([]base.UserEnvironment, error) {
+func (c *environmentsCommand) getAllEnvironments() ([]base.UserEnvironment, error) {
 	client, err := c.getSysAPI()
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -156,7 +160,7 @@ func (c *EnvironmentsCommand) getAllEnvironments() ([]base.UserEnvironment, erro
 	return client.AllEnvironments()
 }
 
-func (c *EnvironmentsCommand) getUserEnvironments() ([]base.UserEnvironment, error) {
+func (c *environmentsCommand) getUserEnvironments() ([]base.UserEnvironment, error) {
 	client, err := c.getEnvAPI()
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -166,7 +170,7 @@ func (c *EnvironmentsCommand) getUserEnvironments() ([]base.UserEnvironment, err
 }
 
 // formatTabular takes an interface{} to adhere to the cmd.Formatter interface
-func (c *EnvironmentsCommand) formatTabular(value interface{}) ([]byte, error) {
+func (c *environmentsCommand) formatTabular(value interface{}) ([]byte, error) {
 	envs, ok := value.([]UserEnvironment)
 	if !ok {
 		return nil, errors.Errorf("expected value of type %T, got %T", envs, value)

--- a/cmd/juju/system/environments_test.go
+++ b/cmd/juju/system/environments_test.go
@@ -85,8 +85,7 @@ func (s *EnvironmentsSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *EnvironmentsSuite) newCommand() cmd.Command {
-	command := system.NewEnvironmentsCommand(s.api, s.api, s.creds)
-	return envcmd.WrapSystem(command)
+	return system.NewEnvironmentsCommand(s.api, s.api, s.creds)
 }
 
 func (s *EnvironmentsSuite) checkSuccess(c *gc.C, user string, args ...string) {

--- a/cmd/juju/system/export_test.go
+++ b/cmd/juju/system/export_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/juju/cmd"
 
 	"github.com/juju/juju/api"
+	"github.com/juju/juju/cmd/envcmd"
 	"github.com/juju/juju/environs/configstore"
 )
 
@@ -16,106 +17,102 @@ var (
 )
 
 // NewListCommand returns a ListCommand with the configstore provided as specified.
-func NewListCommand(cfgStore configstore.Storage) *ListCommand {
-	return &ListCommand{
+func NewListCommand(cfgStore configstore.Storage) *listCommand {
+	return &listCommand{
 		cfgStore: cfgStore,
 	}
 }
 
+type CreateEnvironmentCommand struct {
+	*createEnvironmentCommand
+}
+
 // NewCreateEnvironmentCommand returns a CreateEnvironmentCommand with the api provided as specified.
-func NewCreateEnvironmentCommand(api CreateEnvironmentAPI) *CreateEnvironmentCommand {
-	return &CreateEnvironmentCommand{
+func NewCreateEnvironmentCommand(api CreateEnvironmentAPI) (cmd.Command, *CreateEnvironmentCommand) {
+	c := &createEnvironmentCommand{
 		api: api,
 	}
+	return envcmd.WrapSystem(c), &CreateEnvironmentCommand{c}
 }
 
 // NewEnvironmentsCommand returns a EnvironmentsCommand with the API and userCreds
 // provided as specified.
-func NewEnvironmentsCommand(envAPI EnvironmentsEnvAPI, sysAPI EnvironmentsSysAPI, userCreds *configstore.APICredentials) *EnvironmentsCommand {
-	return &EnvironmentsCommand{
+func NewEnvironmentsCommand(envAPI EnvironmentsEnvAPI, sysAPI EnvironmentsSysAPI, userCreds *configstore.APICredentials) cmd.Command {
+	return envcmd.WrapSystem(&environmentsCommand{
 		envAPI:    envAPI,
 		sysAPI:    sysAPI,
 		userCreds: userCreds,
-	}
+	})
 }
 
 // NewLoginCommand returns a LoginCommand with the function used to open
 // the API connection mocked out.
-func NewLoginCommand(apiOpen api.OpenFunc, getUserManager GetUserManagerFunc) *LoginCommand {
-	return &LoginCommand{
-		apiOpen:        apiOpen,
-		getUserManager: getUserManager,
+func NewLoginCommand(apiOpen api.OpenFunc, getUserManager GetUserManagerFunc) *loginCommand {
+	return &loginCommand{
+		loginAPIOpen:   apiOpen,
+		GetUserManager: getUserManager,
 	}
+}
+
+type UseEnvironmentCommand struct {
+	*useEnvironmentCommand
 }
 
 // NewUseEnvironmentCommand returns a UseEnvironmentCommand with the API and
 // userCreds provided as specified.
-func NewUseEnvironmentCommand(api UseEnvironmentAPI, userCreds *configstore.APICredentials, endpoint *configstore.APIEndpoint) *UseEnvironmentCommand {
-	return &UseEnvironmentCommand{
+func NewUseEnvironmentCommand(api UseEnvironmentAPI, userCreds *configstore.APICredentials, endpoint *configstore.APIEndpoint) (cmd.Command, *UseEnvironmentCommand) {
+	c := &useEnvironmentCommand{
 		api:       api,
 		userCreds: userCreds,
 		endpoint:  endpoint,
 	}
+	return envcmd.WrapSystem(c), &UseEnvironmentCommand{c}
 }
 
 // NewRemoveBlocksCommand returns a RemoveBlocksCommand with the function used
 // to open the API connection mocked out.
-func NewRemoveBlocksCommand(api removeBlocksAPI) *RemoveBlocksCommand {
-	return &RemoveBlocksCommand{
+func NewRemoveBlocksCommand(api removeBlocksAPI) cmd.Command {
+	return envcmd.WrapSystem(&removeBlocksCommand{
 		api: api,
-	}
-}
-
-// Name makes the private name attribute accessible for tests.
-func (c *CreateEnvironmentCommand) Name() string {
-	return c.name
-}
-
-// Owner makes the private name attribute accessible for tests.
-func (c *CreateEnvironmentCommand) Owner() string {
-	return c.owner
-}
-
-// ConfigFile makes the private configFile attribute accessible for tests.
-func (c *CreateEnvironmentCommand) ConfigFile() cmd.FileVar {
-	return c.configFile
-}
-
-// ConfValues makes the private confValues attribute accessible for tests.
-func (c *CreateEnvironmentCommand) ConfValues() map[string]string {
-	return c.confValues
+	})
 }
 
 // NewDestroyCommand returns a DestroyCommand with the systemmanager and client
 // endpoints mocked out.
-func NewDestroyCommand(api destroySystemAPI, clientapi destroyClientAPI, apierr error) *DestroyCommand {
-	return &DestroyCommand{
-		DestroyCommandBase: DestroyCommandBase{
+func NewDestroyCommand(api destroySystemAPI, clientapi destroyClientAPI, apierr error) cmd.Command {
+	return envcmd.WrapSystem(&destroyCommand{
+		destroyCommandBase: destroyCommandBase{
 			api:       api,
 			clientapi: clientapi,
 			apierr:    apierr,
 		},
-	}
+	},
+		envcmd.SystemSkipFlags,
+		envcmd.SystemSkipDefault,
+	)
 }
 
-// NewKillCommand returns a KillCommand with the systemmanager and client
+// NewKillCommand returns a killCommand with the systemmanager and client
 // endpoints mocked out.
-func NewKillCommand(api destroySystemAPI, clientapi destroyClientAPI, apierr error, dialFunc func(string) (api.Connection, error)) *KillCommand {
-	return &KillCommand{
-		DestroyCommandBase{
+func NewKillCommand(api destroySystemAPI, clientapi destroyClientAPI, apierr error, dialFunc func(string) (api.Connection, error)) cmd.Command {
+	return envcmd.WrapSystem(&killCommand{
+		destroyCommandBase{
 			api:       api,
 			clientapi: clientapi,
 			apierr:    apierr,
 		},
 		dialFunc,
-	}
+	},
+		envcmd.SystemSkipFlags,
+		envcmd.SystemSkipDefault,
+	)
 }
 
 // NewListBlocksCommand returns a ListBlocksCommand with the systemmanager
 // endpoint mocked out.
-func NewListBlocksCommand(api listBlocksAPI, apierr error) *ListBlocksCommand {
-	return &ListBlocksCommand{
+func NewListBlocksCommand(api listBlocksAPI, apierr error) cmd.Command {
+	return envcmd.WrapSystem(&listBlocksCommand{
 		api:    api,
 		apierr: apierr,
-	}
+	})
 }

--- a/cmd/juju/system/kill_test.go
+++ b/cmd/juju/system/kill_test.go
@@ -37,7 +37,7 @@ func (s *KillSuite) runKillCommand(c *gc.C, args ...string) (*cmd.Context, error
 	return testing.RunCommand(c, cmd, args...)
 }
 
-func (s *KillSuite) newKillCommand() *system.KillCommand {
+func (s *KillSuite) newKillCommand() cmd.Command {
 	return system.NewKillCommand(s.api, s.clientapi, s.apierror, juju.NewAPIFromName)
 }
 
@@ -54,12 +54,6 @@ func (s *KillSuite) TestKillBadFlags(c *gc.C) {
 func (s *KillSuite) TestKillUnknownArgument(c *gc.C) {
 	_, err := s.runKillCommand(c, "environment", "whoops")
 	c.Assert(err, gc.ErrorMatches, `unrecognized args: \["whoops"\]`)
-}
-
-func (s *KillSuite) TestKillNoDialer(c *gc.C) {
-	cmd := system.NewKillCommand(nil, nil, nil, nil)
-	_, err := testing.RunCommand(c, cmd, "test1", "-y")
-	c.Assert(err, gc.ErrorMatches, "no api dialer specified")
 }
 
 func (s *KillSuite) TestKillUnknownSystem(c *gc.C) {

--- a/cmd/juju/system/list.go
+++ b/cmd/juju/system/list.go
@@ -10,13 +10,18 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 
+	"github.com/juju/juju/cmd/envcmd"
 	"github.com/juju/juju/environs/configstore"
 )
 
-// ListCommand returns the list of all systems the user is
+func newListCommand() cmd.Command {
+	return envcmd.WrapBase(&listCommand{})
+}
+
+// listCommand returns the list of all systems the user is
 // currently logged in to on the current machine.
-type ListCommand struct {
-	cmd.CommandBase
+type listCommand struct {
+	envcmd.JujuCommandBase
 	cfgStore configstore.Storage
 }
 
@@ -35,7 +40,7 @@ See Also:
 `
 
 // Info implements Command.Info
-func (c *ListCommand) Info() *cmd.Info {
+func (c *listCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "list",
 		Purpose: "list all systems logged in to on the current machine",
@@ -43,7 +48,7 @@ func (c *ListCommand) Info() *cmd.Info {
 	}
 }
 
-func (c *ListCommand) getConfigstore() (configstore.Storage, error) {
+func (c *listCommand) getConfigstore() (configstore.Storage, error) {
 	if c.cfgStore != nil {
 		return c.cfgStore, nil
 	}
@@ -51,7 +56,7 @@ func (c *ListCommand) getConfigstore() (configstore.Storage, error) {
 }
 
 // Run implements Command.Run
-func (c *ListCommand) Run(ctx *cmd.Context) error {
+func (c *listCommand) Run(ctx *cmd.Context) error {
 	store, err := c.getConfigstore()
 
 	if err != nil {

--- a/cmd/juju/system/listblocks.go
+++ b/cmd/juju/system/listblocks.go
@@ -12,8 +12,12 @@ import (
 	"github.com/juju/juju/cmd/envcmd"
 )
 
-// ListBlocksCommand lists all blocks for environments within the system.
-type ListBlocksCommand struct {
+func newListBlocksCommand() cmd.Command {
+	return envcmd.WrapSystem(&listBlocksCommand{})
+}
+
+// listBlocksCommand lists all blocks for environments within the system.
+type listBlocksCommand struct {
 	envcmd.SysCommandBase
 	out    cmd.Output
 	api    listBlocksAPI
@@ -30,7 +34,7 @@ type listBlocksAPI interface {
 }
 
 // Info implements Command.Info.
-func (c *ListBlocksCommand) Info() *cmd.Info {
+func (c *listBlocksCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "list-blocks",
 		Purpose: "list all blocks within the system",
@@ -39,7 +43,7 @@ func (c *ListBlocksCommand) Info() *cmd.Info {
 }
 
 // SetFlags implements Command.SetFlags.
-func (c *ListBlocksCommand) SetFlags(f *gnuflag.FlagSet) {
+func (c *listBlocksCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.out.AddFlags(f, "tabular", map[string]cmd.Formatter{
 		"yaml":    cmd.FormatYaml,
 		"json":    cmd.FormatJson,
@@ -47,7 +51,7 @@ func (c *ListBlocksCommand) SetFlags(f *gnuflag.FlagSet) {
 	})
 }
 
-func (c *ListBlocksCommand) getAPI() (listBlocksAPI, error) {
+func (c *listBlocksCommand) getAPI() (listBlocksAPI, error) {
 	if c.api != nil {
 		return c.api, c.apierr
 	}
@@ -55,7 +59,7 @@ func (c *ListBlocksCommand) getAPI() (listBlocksAPI, error) {
 }
 
 // Run implements Command.Run
-func (c *ListBlocksCommand) Run(ctx *cmd.Context) error {
+func (c *listBlocksCommand) Run(ctx *cmd.Context) error {
 	api, err := c.getAPI()
 	if err != nil {
 		return errors.Annotate(err, "cannot connect to the API")

--- a/cmd/juju/system/listblocks_test.go
+++ b/cmd/juju/system/listblocks_test.go
@@ -63,6 +63,7 @@ func (s *ListBlocksSuite) SetUpTest(c *gc.C) {
 
 func (s *ListBlocksSuite) runListBlocksCommand(c *gc.C, args ...string) (*cmd.Context, error) {
 	cmd := system.NewListBlocksCommand(s.api, s.apierror)
+	args = append(args, []string{"-s", "dummysys"}...)
 	return testing.RunCommand(c, cmd, args...)
 }
 

--- a/cmd/juju/system/login.go
+++ b/cmd/juju/system/login.go
@@ -19,16 +19,20 @@ import (
 	"github.com/juju/juju/network"
 )
 
+func newLoginCommand() cmd.Command {
+	return envcmd.WrapBase(&loginCommand{})
+}
+
 // GetUserManagerFunc defines a function that takes an api connection
 // and returns the (locally defined) UserManager interface.
 type GetUserManagerFunc func(conn api.Connection) (UserManager, error)
 
-// LoginCommand logs in to a Juju system and caches the connection
+// loginCommand logs in to a Juju system and caches the connection
 // information.
-type LoginCommand struct {
-	cmd.CommandBase
-	apiOpen        api.OpenFunc
-	getUserManager GetUserManagerFunc
+type loginCommand struct {
+	envcmd.JujuCommandBase
+	loginAPIOpen   api.OpenFunc
+	GetUserManager GetUserManagerFunc
 	// TODO (thumper): when we support local cert definitions
 	// allow the use to specify the user and server address.
 	// user      string
@@ -71,7 +75,7 @@ See Also:
 `
 
 // Info implements Command.Info
-func (c *LoginCommand) Info() *cmd.Info {
+func (c *loginCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name: "login",
 		// TODO(thumper): support user and address options
@@ -83,18 +87,18 @@ func (c *LoginCommand) Info() *cmd.Info {
 }
 
 // SetFlags implements Command.SetFlags.
-func (c *LoginCommand) SetFlags(f *gnuflag.FlagSet) {
+func (c *loginCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.Var(&c.Server, "server", "path to yaml-formatted server file")
 	f.BoolVar(&c.KeepPassword, "keep-password", false, "do not generate a new random password")
 }
 
 // SetFlags implements Command.Init.
-func (c *LoginCommand) Init(args []string) error {
-	if c.apiOpen == nil {
-		c.apiOpen = apiOpen
+func (c *loginCommand) Init(args []string) error {
+	if c.loginAPIOpen == nil {
+		c.loginAPIOpen = c.JujuCommandBase.APIOpen
 	}
-	if c.getUserManager == nil {
-		c.getUserManager = getUserManager
+	if c.GetUserManager == nil {
+		c.GetUserManager = getUserManager
 	}
 	if len(args) == 0 {
 		return errors.New("no name specified")
@@ -105,7 +109,7 @@ func (c *LoginCommand) Init(args []string) error {
 }
 
 // Run implements Command.Run
-func (c *LoginCommand) Run(ctx *cmd.Context) error {
+func (c *loginCommand) Run(ctx *cmd.Context) error {
 	// TODO(thumper): as we support the user and address
 	// change this check here.
 	if c.Server.Path == "" {
@@ -142,7 +146,7 @@ func (c *LoginCommand) Run(ctx *cmd.Context) error {
 		Password: serverDetails.Password,
 	}
 
-	apiState, err := c.apiOpen(&info, api.DefaultDialOpts())
+	apiState, err := c.loginAPIOpen(&info, api.DefaultDialOpts())
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -170,7 +174,7 @@ func (c *LoginCommand) Run(ctx *cmd.Context) error {
 	return errors.Trace(envcmd.SetCurrentSystem(ctx, c.Name))
 }
 
-func (c *LoginCommand) cacheConnectionInfo(serverDetails envcmd.ServerFile, apiState api.Connection) (configstore.EnvironInfo, error) {
+func (c *loginCommand) cacheConnectionInfo(serverDetails envcmd.ServerFile, apiState api.Connection) (configstore.EnvironInfo, error) {
 	store, err := configstore.Default()
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -215,13 +219,13 @@ func (c *LoginCommand) cacheConnectionInfo(serverDetails envcmd.ServerFile, apiS
 	return serverInfo, nil
 }
 
-func (c *LoginCommand) updatePassword(ctx *cmd.Context, conn api.Connection, userTag names.UserTag, serverInfo configstore.EnvironInfo) error {
+func (c *loginCommand) updatePassword(ctx *cmd.Context, conn api.Connection, userTag names.UserTag, serverInfo configstore.EnvironInfo) error {
 	password, err := utils.RandomPassword()
 	if err != nil {
 		return errors.Annotate(err, "failed to generate random password")
 	}
 
-	userManager, err := c.getUserManager(conn)
+	userManager, err := c.GetUserManager(conn)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -236,10 +240,6 @@ func (c *LoginCommand) updatePassword(ctx *cmd.Context, conn api.Connection, use
 		return errors.Trace(err)
 	}
 	return nil
-}
-
-func apiOpen(info *api.Info, opts api.DialOpts) (api.Connection, error) {
-	return api.Open(info, opts)
 }
 
 // UserManager defines the calls that the Login command makes to the user

--- a/cmd/juju/system/removeblocks.go
+++ b/cmd/juju/system/removeblocks.go
@@ -10,9 +10,13 @@ import (
 	"github.com/juju/juju/cmd/envcmd"
 )
 
-// RemoveBlocksCommand returns the list of all systems the user is
+func newRemoveBlocksCommand() cmd.Command {
+	return envcmd.WrapSystem(&removeBlocksCommand{})
+}
+
+// removeBlocksCommand returns the list of all systems the user is
 // currently logged in to on the current machine.
-type RemoveBlocksCommand struct {
+type removeBlocksCommand struct {
 	envcmd.SysCommandBase
 	api removeBlocksAPI
 }
@@ -34,7 +38,7 @@ See Also:
 `
 
 // Info implements Command.Info
-func (c *RemoveBlocksCommand) Info() *cmd.Info {
+func (c *removeBlocksCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "remove-blocks",
 		Purpose: "remove all blocks in the Juju system",
@@ -42,7 +46,7 @@ func (c *RemoveBlocksCommand) Info() *cmd.Info {
 	}
 }
 
-func (c *RemoveBlocksCommand) getAPI() (removeBlocksAPI, error) {
+func (c *removeBlocksCommand) getAPI() (removeBlocksAPI, error) {
 	if c.api != nil {
 		return c.api, nil
 	}
@@ -50,7 +54,7 @@ func (c *RemoveBlocksCommand) getAPI() (removeBlocksAPI, error) {
 }
 
 // Run implements Command.Run
-func (c *RemoveBlocksCommand) Run(ctx *cmd.Context) error {
+func (c *removeBlocksCommand) Run(ctx *cmd.Context) error {
 	client, err := c.getAPI()
 	if err != nil {
 		return errors.Trace(err)

--- a/cmd/juju/system/removeblocks_test.go
+++ b/cmd/juju/system/removeblocks_test.go
@@ -31,8 +31,7 @@ func (s *removeBlocksSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *removeBlocksSuite) newCommand() cmd.Command {
-	command := system.NewRemoveBlocksCommand(s.api)
-	return envcmd.WrapSystem(command)
+	return system.NewRemoveBlocksCommand(s.api)
 }
 
 func (s *removeBlocksSuite) TestRemove(c *gc.C) {

--- a/cmd/juju/system/system.go
+++ b/cmd/juju/system/system.go
@@ -6,9 +6,6 @@ package system
 import (
 	"github.com/juju/cmd"
 	"github.com/juju/loggo"
-
-	"github.com/juju/juju/cmd/envcmd"
-	"github.com/juju/juju/juju"
 )
 
 var logger = loggo.GetLogger("juju.cmd.juju.system")
@@ -40,15 +37,15 @@ func NewSuperCommand() cmd.Command {
 		Purpose:     "manage systems",
 	})
 
-	systemCmd.Register(&ListCommand{})
-	systemCmd.Register(&LoginCommand{})
-	systemCmd.Register(&DestroyCommand{})
-	systemCmd.Register(&KillCommand{apiDialerFunc: juju.NewAPIFromName})
-	systemCmd.Register(envcmd.WrapSystem(&ListBlocksCommand{}))
-	systemCmd.Register(envcmd.WrapSystem(&EnvironmentsCommand{}))
-	systemCmd.Register(envcmd.WrapSystem(&CreateEnvironmentCommand{}))
-	systemCmd.Register(envcmd.WrapSystem(&RemoveBlocksCommand{}))
-	systemCmd.Register(envcmd.WrapSystem(&UseEnvironmentCommand{}))
+	systemCmd.Register(newListCommand())
+	systemCmd.Register(newLoginCommand())
+	systemCmd.Register(newDestroyCommand())
+	systemCmd.Register(newKillCommand())
+	systemCmd.Register(newListBlocksCommand())
+	systemCmd.Register(newEnvironmentsCommand())
+	systemCmd.Register(newCreateEnvironmentCommand())
+	systemCmd.Register(newRemoveBlocksCommand())
+	systemCmd.Register(newUseEnvironmentCommand())
 
 	return systemCmd
 }

--- a/cmd/juju/system/useenvironment.go
+++ b/cmd/juju/system/useenvironment.go
@@ -17,9 +17,13 @@ import (
 	"github.com/juju/juju/environs/configstore"
 )
 
-// UseEnvironmentCommand returns the list of all the environments the
+func newUseEnvironmentCommand() cmd.Command {
+	return envcmd.WrapSystem(&useEnvironmentCommand{})
+}
+
+// useEnvironmentCommand returns the list of all the environments the
 // current user can access on the current system.
-type UseEnvironmentCommand struct {
+type useEnvironmentCommand struct {
 	envcmd.SysCommandBase
 
 	apiOpen   api.OpenFunc
@@ -88,7 +92,7 @@ See Also:
 `
 
 // Info implements Command.Info
-func (c *UseEnvironmentCommand) Info() *cmd.Info {
+func (c *useEnvironmentCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "use-environment",
 		Purpose: "use an environment that you have access to on this machine",
@@ -97,21 +101,21 @@ func (c *UseEnvironmentCommand) Info() *cmd.Info {
 	}
 }
 
-func (c *UseEnvironmentCommand) getAPI() (UseEnvironmentAPI, error) {
+func (c *useEnvironmentCommand) getAPI() (UseEnvironmentAPI, error) {
 	if c.api != nil {
 		return c.api, nil
 	}
 	return c.NewEnvironmentManagerAPIClient()
 }
 
-func (c *UseEnvironmentCommand) getConnectionCredentials() (configstore.APICredentials, error) {
+func (c *useEnvironmentCommand) getConnectionCredentials() (configstore.APICredentials, error) {
 	if c.userCreds != nil {
 		return *c.userCreds, nil
 	}
 	return c.ConnectionCredentials()
 }
 
-func (c *UseEnvironmentCommand) getConnectionEndpoint() (configstore.APIEndpoint, error) {
+func (c *useEnvironmentCommand) getConnectionEndpoint() (configstore.APIEndpoint, error) {
 	if c.endpoint != nil {
 		return *c.endpoint, nil
 	}
@@ -119,14 +123,14 @@ func (c *UseEnvironmentCommand) getConnectionEndpoint() (configstore.APIEndpoint
 }
 
 // SetFlags implements Command.SetFlags.
-func (c *UseEnvironmentCommand) SetFlags(f *gnuflag.FlagSet) {
+func (c *useEnvironmentCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.StringVar(&c.LocalName, "name", "", "the local name for this environment")
 }
 
 // SetFlags implements Command.Init.
-func (c *UseEnvironmentCommand) Init(args []string) error {
+func (c *useEnvironmentCommand) Init(args []string) error {
 	if c.apiOpen == nil {
-		c.apiOpen = apiOpen
+		c.apiOpen = c.APIOpen
 	}
 	if len(args) == 0 || strings.TrimSpace(args[0]) == "" {
 		return errors.New("no environment supplied")
@@ -162,7 +166,7 @@ func (c *UseEnvironmentCommand) Init(args []string) error {
 }
 
 // Run implements Command.Run
-func (c *UseEnvironmentCommand) Run(ctx *cmd.Context) error {
+func (c *useEnvironmentCommand) Run(ctx *cmd.Context) error {
 	client, err := c.getAPI()
 	if err != nil {
 		return errors.Trace(err)
@@ -226,7 +230,7 @@ func (c *UseEnvironmentCommand) Run(ctx *cmd.Context) error {
 	return envcmd.SetCurrentEnvironment(ctx, c.LocalName)
 }
 
-func (c *UseEnvironmentCommand) updateCachedInfo(info configstore.EnvironInfo, envUUID string, creds configstore.APICredentials, endpoint configstore.APIEndpoint) error {
+func (c *useEnvironmentCommand) updateCachedInfo(info configstore.EnvironInfo, envUUID string, creds configstore.APICredentials, endpoint configstore.APIEndpoint) error {
 	info.SetAPICredentials(creds)
 	// Specify the environment UUID. The server UUID will be the same as the
 	// endpoint that we have just connected to, as will be the CACert, addresses
@@ -236,7 +240,7 @@ func (c *UseEnvironmentCommand) updateCachedInfo(info configstore.EnvironInfo, e
 	return errors.Trace(info.Write())
 }
 
-func (c *UseEnvironmentCommand) findMatchingEnvironment(ctx *cmd.Context, client UseEnvironmentAPI, creds configstore.APICredentials) (base.UserEnvironment, error) {
+func (c *useEnvironmentCommand) findMatchingEnvironment(ctx *cmd.Context, client UseEnvironmentAPI, creds configstore.APICredentials) (base.UserEnvironment, error) {
 
 	var empty base.UserEnvironment
 

--- a/cmd/juju/system/useenvironment_test.go
+++ b/cmd/juju/system/useenvironment_test.go
@@ -74,8 +74,8 @@ func (s *UseEnvironmentSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *UseEnvironmentSuite) run(c *gc.C, args ...string) (*cmd.Context, error) {
-	command := system.NewUseEnvironmentCommand(s.api, &s.creds, &s.endpoint)
-	return testing.RunCommand(c, envcmd.WrapSystem(command), args...)
+	wrappedCommand, _ := system.NewUseEnvironmentCommand(s.api, &s.creds, &s.endpoint)
+	return testing.RunCommand(c, wrappedCommand, args...)
 }
 
 func (s *UseEnvironmentSuite) TestInit(c *gc.C) {
@@ -122,8 +122,8 @@ func (s *UseEnvironmentSuite) TestInit(c *gc.C) {
 		envUUID: env1UUID,
 	}} {
 		c.Logf("test %d", i)
-		command := &system.UseEnvironmentCommand{}
-		err := testing.InitCommand(command, test.args)
+		wrappedCommand, command := system.NewUseEnvironmentCommand(nil, nil, nil)
+		err := testing.InitCommand(wrappedCommand, test.args)
 		if test.errorString == "" {
 			c.Check(command.LocalName, gc.Equals, test.localName)
 			c.Check(command.EnvName, gc.Equals, test.envName)

--- a/cmd/juju/user/add.go
+++ b/cmd/juju/user/add.go
@@ -12,10 +12,11 @@ import (
 	"github.com/juju/utils"
 	"launchpad.net/gnuflag"
 
+	"github.com/juju/juju/cmd/envcmd"
 	"github.com/juju/juju/cmd/juju/block"
 )
 
-const userAddCommandDoc = `
+const useraddCommandDoc = `
 Add users to an existing environment.
 
 The user information is stored within an existing environment, and will be
@@ -38,8 +39,12 @@ type AddUserAPI interface {
 	Close() error
 }
 
-// AddCommand adds new users into a Juju Server.
-type AddCommand struct {
+func newAddCommand() cmd.Command {
+	return envcmd.WrapSystem(&addCommand{})
+}
+
+// addCommand adds new users into a Juju Server.
+type addCommand struct {
 	UserCommandBase
 	api         AddUserAPI
 	User        string
@@ -48,23 +53,23 @@ type AddCommand struct {
 }
 
 // Info implements Command.Info.
-func (c *AddCommand) Info() *cmd.Info {
+func (c *addCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "add",
 		Args:    "<username> [<display name>]",
 		Purpose: "adds a user",
-		Doc:     userAddCommandDoc,
+		Doc:     useraddCommandDoc,
 	}
 }
 
 // SetFlags implements Command.SetFlags.
-func (c *AddCommand) SetFlags(f *gnuflag.FlagSet) {
+func (c *addCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.StringVar(&c.OutPath, "o", "", "specify the environment file for new user")
 	f.StringVar(&c.OutPath, "output", "", "")
 }
 
 // Init implements Command.Init.
-func (c *AddCommand) Init(args []string) error {
+func (c *addCommand) Init(args []string) error {
 	if len(args) == 0 {
 		return fmt.Errorf("no username supplied")
 	}
@@ -79,7 +84,7 @@ func (c *AddCommand) Init(args []string) error {
 }
 
 // Run implements Command.Run.
-func (c *AddCommand) Run(ctx *cmd.Context) error {
+func (c *addCommand) Run(ctx *cmd.Context) error {
 	if c.api == nil {
 		api, err := c.NewUserManagerAPIClient()
 		if err != nil {

--- a/cmd/juju/user/add_test.go
+++ b/cmd/juju/user/add_test.go
@@ -13,7 +13,6 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/common"
-	"github.com/juju/juju/cmd/envcmd"
 	"github.com/juju/juju/cmd/juju/user"
 	"github.com/juju/juju/testing"
 )
@@ -43,7 +42,7 @@ func (s *UserAddCommandSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *UserAddCommandSuite) run(c *gc.C, args ...string) (*cmd.Context, error) {
-	addCommand := envcmd.WrapSystem(user.NewAddCommand(s.mockAPI))
+	addCommand, _ := user.NewAddCommand(s.mockAPI)
 	return testing.RunCommand(c, addCommand, args...)
 }
 
@@ -80,12 +79,12 @@ func (s *UserAddCommandSuite) TestInit(c *gc.C) {
 		},
 	} {
 		c.Logf("test %d", i)
-		addUserCmd := &user.AddCommand{}
-		err := testing.InitCommand(addUserCmd, test.args)
+		wrappedCommand, command := user.NewAddCommand(s.mockAPI)
+		err := testing.InitCommand(wrappedCommand, test.args)
 		if test.errorString == "" {
-			c.Check(addUserCmd.User, gc.Equals, test.user)
-			c.Check(addUserCmd.DisplayName, gc.Equals, test.displayname)
-			c.Check(addUserCmd.OutPath, gc.Equals, test.outPath)
+			c.Check(command.User, gc.Equals, test.user)
+			c.Check(command.DisplayName, gc.Equals, test.displayname)
+			c.Check(command.OutPath, gc.Equals, test.outPath)
 		} else {
 			c.Check(err, gc.ErrorMatches, test.errorString)
 		}

--- a/cmd/juju/user/change_password.go
+++ b/cmd/juju/user/change_password.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/utils/readpass"
 	"launchpad.net/gnuflag"
 
+	"github.com/juju/juju/cmd/envcmd"
 	"github.com/juju/juju/cmd/juju/block"
 	"github.com/juju/juju/environs/configstore"
 )
@@ -35,8 +36,12 @@ Examples:
 
 `
 
-// ChangePasswordCommand changes the password for a user.
-type ChangePasswordCommand struct {
+func newChangePasswordCommand() cmd.Command {
+	return envcmd.WrapSystem(&changePasswordCommand{})
+}
+
+// changePasswordCommand changes the password for a user.
+type changePasswordCommand struct {
 	UserCommandBase
 	api      ChangePasswordAPI
 	writer   EnvironInfoCredsWriter
@@ -46,7 +51,7 @@ type ChangePasswordCommand struct {
 }
 
 // Info implements Command.Info.
-func (c *ChangePasswordCommand) Info() *cmd.Info {
+func (c *changePasswordCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "change-password",
 		Args:    "[username]",
@@ -56,14 +61,14 @@ func (c *ChangePasswordCommand) Info() *cmd.Info {
 }
 
 // SetFlags implements Command.SetFlags.
-func (c *ChangePasswordCommand) SetFlags(f *gnuflag.FlagSet) {
+func (c *changePasswordCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.BoolVar(&c.Generate, "generate", false, "generate a new strong password")
 	f.StringVar(&c.OutPath, "o", "", "specifies the path of the generated user environment file")
 	f.StringVar(&c.OutPath, "output", "", "")
 }
 
 // Init implements Command.Init.
-func (c *ChangePasswordCommand) Init(args []string) error {
+func (c *changePasswordCommand) Init(args []string) error {
 	var err error
 	c.User, err = cmd.ZeroOrOneArgs(args)
 	if c.User == "" && c.OutPath != "" {
@@ -94,7 +99,7 @@ type EnvironInfoCredsWriter interface {
 }
 
 // Run implements Command.Run.
-func (c *ChangePasswordCommand) Run(ctx *cmd.Context) error {
+func (c *changePasswordCommand) Run(ctx *cmd.Context) error {
 	if c.api == nil {
 		api, err := c.NewUserManagerAPIClient()
 		if err != nil {
@@ -157,7 +162,7 @@ func (c *ChangePasswordCommand) Run(ctx *cmd.Context) error {
 
 var readPassword = readpass.ReadPassword
 
-func (*ChangePasswordCommand) generateOrReadPassword(ctx *cmd.Context, generate bool) (string, error) {
+func (*changePasswordCommand) generateOrReadPassword(ctx *cmd.Context, generate bool) (string, error) {
 	if generate {
 		password, err := utils.RandomPassword()
 		if err != nil {

--- a/cmd/juju/user/change_password_test.go
+++ b/cmd/juju/user/change_password_test.go
@@ -11,7 +11,6 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/cmd/envcmd"
 	"github.com/juju/juju/cmd/juju/user"
 	"github.com/juju/juju/environs/configstore"
 	"github.com/juju/juju/testing"
@@ -44,7 +43,7 @@ func (s *ChangePasswordCommandSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *ChangePasswordCommandSuite) run(c *gc.C, args ...string) (*cmd.Context, error) {
-	changePasswordCommand := envcmd.WrapSystem(user.NewChangePasswordCommand(s.mockAPI, s.mockEnvironInfo))
+	changePasswordCommand, _ := user.NewChangePasswordCommand(s.mockAPI, s.mockEnvironInfo)
 	return testing.RunCommand(c, changePasswordCommand, args...)
 }
 
@@ -88,8 +87,8 @@ func (s *ChangePasswordCommandSuite) TestInit(c *gc.C) {
 		},
 	} {
 		c.Logf("test %d", i)
-		command := &user.ChangePasswordCommand{}
-		err := testing.InitCommand(command, test.args)
+		wrappedCommand, command := user.NewChangePasswordCommand(nil, nil)
+		err := testing.InitCommand(wrappedCommand, test.args)
 		if test.errorString == "" {
 			c.Check(command.User, gc.Equals, test.user)
 			c.Check(command.OutPath, gc.Equals, test.outPath)

--- a/cmd/juju/user/credentials.go
+++ b/cmd/juju/user/credentials.go
@@ -10,6 +10,8 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/names"
 	"launchpad.net/gnuflag"
+
+	"github.com/juju/juju/cmd/envcmd"
 )
 
 const userCredentialsDoc = `
@@ -30,14 +32,18 @@ See Also:
     juju system login
 `
 
-// CredentialsCommand changes the password for a user.
-type CredentialsCommand struct {
+func newCredentialsCommand() cmd.Command {
+	return envcmd.WrapSystem(&credentialsCommand{})
+}
+
+// credentialsCommand changes the password for a user.
+type credentialsCommand struct {
 	UserCommandBase
 	OutPath string
 }
 
 // Info implements Command.Info.
-func (c *CredentialsCommand) Info() *cmd.Info {
+func (c *credentialsCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "credentials",
 		Purpose: "save the credentials and server details to a file",
@@ -46,13 +52,13 @@ func (c *CredentialsCommand) Info() *cmd.Info {
 }
 
 // SetFlags implements Command.SetFlags.
-func (c *CredentialsCommand) SetFlags(f *gnuflag.FlagSet) {
+func (c *credentialsCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.StringVar(&c.OutPath, "o", "", "specifies the path of the generated file")
 	f.StringVar(&c.OutPath, "output", "", "")
 }
 
 // Run implements Command.Run.
-func (c *CredentialsCommand) Run(ctx *cmd.Context) error {
+func (c *credentialsCommand) Run(ctx *cmd.Context) error {
 	creds, err := c.ConnectionCredentials()
 	if err != nil {
 		return errors.Trace(err)

--- a/cmd/juju/user/credentials_test.go
+++ b/cmd/juju/user/credentials_test.go
@@ -8,7 +8,6 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/cmd/envcmd"
 	"github.com/juju/juju/cmd/juju/user"
 	"github.com/juju/juju/testing"
 )
@@ -29,8 +28,8 @@ func (s *CredentialsCommandSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *CredentialsCommandSuite) run(c *gc.C, args ...string) (*cmd.Context, error) {
-	command := envcmd.WrapSystem(&user.CredentialsCommand{})
-	return testing.RunCommand(c, command, args...)
+	wrappedCommand, _ := user.NewCredentialsCommand()
+	return testing.RunCommand(c, wrappedCommand, args...)
 }
 
 func (s *CredentialsCommandSuite) TestInit(c *gc.C) {
@@ -53,8 +52,8 @@ func (s *CredentialsCommandSuite) TestInit(c *gc.C) {
 		},
 	} {
 		c.Logf("test %d", i)
-		command := &user.CredentialsCommand{}
-		err := testing.InitCommand(command, test.args)
+		wrappedCommand, command := user.NewCredentialsCommand()
+		err := testing.InitCommand(wrappedCommand, test.args)
 		if test.errorString == "" {
 			c.Check(command.OutPath, gc.Equals, test.outPath)
 		} else {

--- a/cmd/juju/user/disenable.go
+++ b/cmd/juju/user/disenable.go
@@ -7,6 +7,7 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 
+	"github.com/juju/juju/cmd/envcmd"
 	"github.com/juju/juju/cmd/juju/block"
 )
 
@@ -34,25 +35,33 @@ See Also:
   juju help user disable
 `
 
-// DisenableUserBase common code for enable/disable user commands
-type DisenableUserBase struct {
+// disenableUserBase common code for enable/disable user commands
+type disenableUserBase struct {
 	UserCommandBase
-	api  DisenableUserAPI
+	api  disenableUserAPI
 	User string
 }
 
-// DisableCommand disables users.
-type DisableCommand struct {
-	DisenableUserBase
+func newDisableCommand() cmd.Command {
+	return envcmd.WrapSystem(&disableCommand{})
 }
 
-// EnableCommand enables users.
-type EnableCommand struct {
-	DisenableUserBase
+// disableCommand disables users.
+type disableCommand struct {
+	disenableUserBase
+}
+
+func newEnableCommand() cmd.Command {
+	return envcmd.WrapSystem(&enableCommand{})
+}
+
+// enableCommand enables users.
+type enableCommand struct {
+	disenableUserBase
 }
 
 // Info implements Command.Info.
-func (c *DisableCommand) Info() *cmd.Info {
+func (c *disableCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "disable",
 		Args:    "<username>",
@@ -62,7 +71,7 @@ func (c *DisableCommand) Info() *cmd.Info {
 }
 
 // Info implements Command.Info.
-func (c *EnableCommand) Info() *cmd.Info {
+func (c *enableCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "enable",
 		Args:    "<username>",
@@ -72,7 +81,7 @@ func (c *EnableCommand) Info() *cmd.Info {
 }
 
 // Init implements Command.Init.
-func (c *DisenableUserBase) Init(args []string) error {
+func (c *disenableUserBase) Init(args []string) error {
 	if len(args) == 0 {
 		return errors.New("no username supplied")
 	}
@@ -83,28 +92,28 @@ func (c *DisenableUserBase) Init(args []string) error {
 }
 
 // Username is here entirely for testing purposes to allow both the
-// DisableCommand and EnableCommand to support a common interface that is able
+// disableCommand and enableCommand to support a common interface that is able
 // to ask for the command line supplied username.
-func (c *DisenableUserBase) Username() string {
+func (c *disenableUserBase) Username() string {
 	return c.User
 }
 
-// DisenableUserAPI defines the API methods that the disable and enable
+// disenableUserAPI defines the API methods that the disable and enable
 // commands use.
-type DisenableUserAPI interface {
+type disenableUserAPI interface {
 	EnableUser(username string) error
 	DisableUser(username string) error
 	Close() error
 }
 
-func (c *DisenableUserBase) getDisableUserAPI() (DisenableUserAPI, error) {
+func (c *disenableUserBase) getDisableUserAPI() (disenableUserAPI, error) {
 	return c.NewUserManagerAPIClient()
 }
 
-var getDisableUserAPI = (*DisenableUserBase).getDisableUserAPI
+var getDisableUserAPI = (*disenableUserBase).getDisableUserAPI
 
 // Run implements Command.Run.
-func (c *DisableCommand) Run(ctx *cmd.Context) error {
+func (c *disableCommand) Run(ctx *cmd.Context) error {
 	if c.api == nil {
 		api, err := c.NewUserManagerAPIClient()
 		if err != nil {
@@ -122,7 +131,7 @@ func (c *DisableCommand) Run(ctx *cmd.Context) error {
 }
 
 // Run implements Command.Run.
-func (c *EnableCommand) Run(ctx *cmd.Context) error {
+func (c *enableCommand) Run(ctx *cmd.Context) error {
 	if c.api == nil {
 		api, err := c.NewUserManagerAPIClient()
 		if err != nil {

--- a/cmd/juju/user/export_test.go
+++ b/cmd/juju/user/export_test.go
@@ -3,6 +3,12 @@
 
 package user
 
+import (
+	"github.com/juju/cmd"
+
+	"github.com/juju/juju/cmd/envcmd"
+)
+
 var (
 	RandomPasswordNotify = &randomPasswordNotify
 	ReadPassword         = &readPassword
@@ -10,56 +16,77 @@ var (
 	WriteServerFile      = writeServerFile
 )
 
-// NewAddCommand returns an AddCommand with the api provided as specified.
-func NewAddCommand(api AddUserAPI) *AddCommand {
-	return &AddCommand{
-		api: api,
-	}
+type AddCommand struct {
+	*addCommand
+}
+
+type CredentialsCommand struct {
+	*credentialsCommand
+}
+
+type ChangePasswordCommand struct {
+	*changePasswordCommand
+}
+
+type DisenableUserBase struct {
+	*disenableUserBase
+}
+
+func NewAddCommand(api AddUserAPI) (cmd.Command, *AddCommand) {
+	c := &addCommand{api: api}
+	return envcmd.WrapSystem(c), &AddCommand{c}
+}
+
+func NewInfoCommand(api UserInfoAPI) cmd.Command {
+	return envcmd.WrapSystem(&infoCommand{
+		infoCommandBase: infoCommandBase{
+			api: api,
+		}})
+}
+
+func NewCredentialsCommand() (cmd.Command, *CredentialsCommand) {
+	c := &credentialsCommand{}
+	return envcmd.WrapSystem(c), &CredentialsCommand{c}
 }
 
 // NewChangePasswordCommand returns a ChangePasswordCommand with the api
 // and writer provided as specified.
-func NewChangePasswordCommand(api ChangePasswordAPI, writer EnvironInfoCredsWriter) *ChangePasswordCommand {
-	return &ChangePasswordCommand{
+func NewChangePasswordCommand(api ChangePasswordAPI, writer EnvironInfoCredsWriter) (cmd.Command, *ChangePasswordCommand) {
+	c := &changePasswordCommand{
 		api:    api,
 		writer: writer,
 	}
+	return envcmd.WrapSystem(c), &ChangePasswordCommand{c}
 }
 
 // NewDisableCommand returns a DisableCommand with the api provided as
 // specified.
-func NewDisableCommand(api DisenableUserAPI) *DisableCommand {
-	return &DisableCommand{
-		DisenableUserBase{
+func NewDisableCommand(api disenableUserAPI) (cmd.Command, *DisenableUserBase) {
+	c := &disableCommand{
+		disenableUserBase{
 			api: api,
 		},
 	}
+	return envcmd.WrapSystem(c), &DisenableUserBase{&c.disenableUserBase}
 }
 
 // NewEnableCommand returns a EnableCommand with the api provided as
 // specified.
-func NewEnableCommand(api DisenableUserAPI) *EnableCommand {
-	return &EnableCommand{
-		DisenableUserBase{
+func NewEnableCommand(api disenableUserAPI) (cmd.Command, *DisenableUserBase) {
+	c := &enableCommand{
+		disenableUserBase{
 			api: api,
 		},
 	}
-}
-
-// NewInfoCommand returns an InfoCommand with the api provided as specified.
-func NewInfoCommand(api UserInfoAPI) *InfoCommand {
-	return &InfoCommand{
-		InfoCommandBase: InfoCommandBase{
-			api: api,
-		},
-	}
+	return envcmd.WrapSystem(c), &DisenableUserBase{&c.disenableUserBase}
 }
 
 // NewListCommand returns a ListCommand with the api provided as specified.
-func NewListCommand(api UserInfoAPI) *ListCommand {
-	return &ListCommand{
-		InfoCommandBase: InfoCommandBase{
+func NewListCommand(api UserInfoAPI) cmd.Command {
+	c := &listCommand{
+		infoCommandBase: infoCommandBase{
 			api: api,
 		},
 	}
+	return envcmd.WrapSystem(c)
 }

--- a/cmd/juju/user/info_test.go
+++ b/cmd/juju/user/info_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/juju/juju/api/usermanager"
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
-	"github.com/juju/juju/cmd/envcmd"
 	"github.com/juju/juju/cmd/juju/user"
 	"github.com/juju/juju/testing"
 )
@@ -36,7 +35,7 @@ var (
 )
 
 func newUserInfoCommand() cmd.Command {
-	return envcmd.WrapSystem(user.NewInfoCommand(&fakeUserInfoAPI{}))
+	return user.NewInfoCommand(&fakeUserInfoAPI{})
 }
 
 type fakeUserInfoAPI struct{}

--- a/cmd/juju/user/list.go
+++ b/cmd/juju/user/list.go
@@ -13,34 +13,39 @@ import (
 	"launchpad.net/gnuflag"
 
 	"github.com/juju/juju/api/usermanager"
+	"github.com/juju/juju/cmd/envcmd"
 )
 
-const ListCommandDoc = `
+const listCommandDoc = `
 List all the current users in the Juju server.
 
 See Also:
    juju help user info
 `
 
-// ListCommand shows all the users in the Juju server.
-type ListCommand struct {
-	InfoCommandBase
-	all bool
+func newListCommand() cmd.Command {
+	return envcmd.WrapSystem(&listCommand{})
+}
+
+// listCommand shows all the users in the Juju server.
+type listCommand struct {
+	infoCommandBase
+	All bool
 }
 
 // Info implements Command.Info.
-func (c *ListCommand) Info() *cmd.Info {
+func (c *listCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "list",
 		Purpose: "shows all users",
-		Doc:     ListCommandDoc,
+		Doc:     listCommandDoc,
 	}
 }
 
 // SetFlags implements Command.SetFlags.
-func (c *ListCommand) SetFlags(f *gnuflag.FlagSet) {
-	c.InfoCommandBase.SetFlags(f)
-	f.BoolVar(&c.all, "all", false, "include disabled users in the listing")
+func (c *listCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.infoCommandBase.SetFlags(f)
+	f.BoolVar(&c.All, "all", false, "include disabled users in the listing")
 	c.out.AddFlags(f, "tabular", map[string]cmd.Formatter{
 		"yaml":    cmd.FormatYaml,
 		"json":    cmd.FormatJson,
@@ -49,7 +54,7 @@ func (c *ListCommand) SetFlags(f *gnuflag.FlagSet) {
 }
 
 // Run implements Command.Run.
-func (c *ListCommand) Run(ctx *cmd.Context) (err error) {
+func (c *listCommand) Run(ctx *cmd.Context) (err error) {
 	// Note: the InfoCommandBase and the UserInfo struct are defined
 	// in info.go.
 	client, err := c.getUserInfoAPI()
@@ -58,7 +63,7 @@ func (c *ListCommand) Run(ctx *cmd.Context) (err error) {
 	}
 	defer client.Close()
 
-	result, err := client.UserInfo(nil, usermanager.IncludeDisabled(c.all))
+	result, err := client.UserInfo(nil, usermanager.IncludeDisabled(c.All))
 	if err != nil {
 		return err
 	}
@@ -66,7 +71,7 @@ func (c *ListCommand) Run(ctx *cmd.Context) (err error) {
 	return c.out.Write(ctx, c.apiUsersToUserInfoSlice(result))
 }
 
-func (c *ListCommand) formatTabular(value interface{}) ([]byte, error) {
+func (c *listCommand) formatTabular(value interface{}) ([]byte, error) {
 	users, valueConverted := value.([]UserInfo)
 	if !valueConverted {
 		return nil, errors.Errorf("expected value of type %T, got %T", users, value)

--- a/cmd/juju/user/list_test.go
+++ b/cmd/juju/user/list_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/juju/juju/api/usermanager"
 	"github.com/juju/juju/apiserver/params"
-	"github.com/juju/juju/cmd/envcmd"
 	"github.com/juju/juju/cmd/juju/user"
 	"github.com/juju/juju/testing"
 )
@@ -27,7 +26,7 @@ type UserListCommandSuite struct {
 var _ = gc.Suite(&UserListCommandSuite{})
 
 func newUserListCommand() cmd.Command {
-	return envcmd.WrapSystem(user.NewListCommand(&fakeUserListAPI{}))
+	return user.NewListCommand(&fakeUserListAPI{})
 }
 
 type fakeUserListAPI struct{}

--- a/cmd/juju/user/user.go
+++ b/cmd/juju/user/user.go
@@ -31,13 +31,13 @@ func NewSuperCommand() cmd.Command {
 		UsagePrefix: "juju",
 		Purpose:     userCommandPurpose,
 	})
-	usercmd.Register(envcmd.WrapSystem(&AddCommand{}))
-	usercmd.Register(envcmd.WrapSystem(&ChangePasswordCommand{}))
-	usercmd.Register(envcmd.WrapSystem(&CredentialsCommand{}))
-	usercmd.Register(envcmd.WrapSystem(&InfoCommand{}))
-	usercmd.Register(envcmd.WrapSystem(&DisableCommand{}))
-	usercmd.Register(envcmd.WrapSystem(&EnableCommand{}))
-	usercmd.Register(envcmd.WrapSystem(&ListCommand{}))
+	usercmd.Register(newAddCommand())
+	usercmd.Register(newChangePasswordCommand())
+	usercmd.Register(newCredentialsCommand())
+	usercmd.Register(newInfoCommand())
+	usercmd.Register(newDisableCommand())
+	usercmd.Register(newEnableCommand())
+	usercmd.Register(newListCommand())
 	return usercmd
 }
 

--- a/featuretests/cmd_juju_subnet_test.go
+++ b/featuretests/cmd_juju_subnet_test.go
@@ -8,7 +8,6 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/cmd/envcmd"
 	cmdsubnet "github.com/juju/juju/cmd/juju/subnet"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/state"
@@ -50,12 +49,19 @@ func (s *cmdSubnetSuite) RunSuper(c *gc.C, expectedError string, args ...string)
 	return s.Run(c, cmdsubnet.NewSuperCommand(), expectedError, args...)
 }
 
-func (s *cmdSubnetSuite) RunAdd(c *gc.C, expectedError string, args ...string) *cmd.Context {
-	// To capture subcommand errors, we must *NOT* to run it through
-	// the supercommand, otherwise there error is logged and
-	// swallowed!
-	addCommand := envcmd.Wrap(&cmdsubnet.AddCommand{})
-	return s.Run(c, addCommand, expectedError, args...)
+func (s *cmdSubnetSuite) RunAdd(c *gc.C, expectedError string, args ...string) (string, string, error) {
+	cmdArgs := append([]string{"subnet", "add"}, args...)
+	ctx, err := runJujuCommand(c, cmdArgs...)
+	stdout, stderr := "", ""
+	if ctx != nil {
+		stdout = testing.Stdout(ctx)
+		stderr = testing.Stderr(ctx)
+	}
+	if expectedError != "" {
+		c.Assert(err, gc.NotNil)
+		c.Assert(stderr, jc.Contains, expectedError)
+	}
+	return stdout, stderr, err
 }
 
 func (s *cmdSubnetSuite) AssertOutput(c *gc.C, context *cmd.Context, expectedOut, expectedErr string) {

--- a/featuretests/storage_test.go
+++ b/featuretests/storage_test.go
@@ -8,11 +8,13 @@ import (
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cmd/envcmd"
+	jujucmd "github.com/juju/juju/cmd/juju/commands"
 	cmdstorage "github.com/juju/juju/cmd/juju/storage"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/provider/ec2"
@@ -191,14 +193,32 @@ storage-block/0:
 	c.Assert(testing.Stdout(context), gc.Equals, expected)
 }
 
-func runPoolList(c *gc.C, args ...string) *cmd.Context {
-	context, err := testing.RunCommand(c, envcmd.Wrap(&cmdstorage.PoolListCommand{}), args...)
+func runJujuCommand(c *gc.C, args ...string) (*cmd.Context, error) {
+	// NOTE (alesstimec): Writers need to be reset, because
+	// they are set globally in the juju/cmd package and will
+	// return an error if we attempt to run two commands in the
+	// same test.
+	loggo.RemoveWriter("warning")
+	ctx, err := cmd.DefaultContext()
 	c.Assert(err, jc.ErrorIsNil)
-	return context
+	command := jujucmd.NewJujuCommand(ctx)
+	return testing.RunCommand(c, command, args...)
+}
+
+func runPoolList(c *gc.C, args ...string) (string, string, error) {
+	cmdArgs := append([]string{"storage", "pool", "list"}, args...)
+	ctx, err := runJujuCommand(c, cmdArgs...)
+	stdout, stderr := "", ""
+	if ctx != nil {
+		stdout = testing.Stdout(ctx)
+		stderr = testing.Stderr(ctx)
+	}
+	return stdout, stderr, err
 }
 
 func (s *cmdStorageSuite) TestListPools(c *gc.C) {
-	context := runPoolList(c)
+	stdout, _, err := runPoolList(c)
+	c.Assert(err, jc.ErrorIsNil)
 	expected := `
 block:
   provider: loop
@@ -213,11 +233,12 @@ rootfs:
 tmpfs:
   provider: tmpfs
 `[1:]
-	c.Assert(testing.Stdout(context), gc.Equals, expected)
+	c.Assert(stdout, gc.Equals, expected)
 }
 
 func (s *cmdStorageSuite) TestListPoolsTabular(c *gc.C) {
-	context := runPoolList(c, "--format", "tabular")
+	stdout, _, err := runPoolList(c, "--format", "tabular")
+	c.Assert(err, jc.ErrorIsNil)
 	expected := `
 NAME    PROVIDER  ATTRS
 block   loop      it=works
@@ -227,32 +248,37 @@ rootfs  rootfs
 tmpfs   tmpfs     
 
 `[1:]
-	c.Assert(testing.Stdout(context), gc.Equals, expected)
+	c.Assert(stdout, gc.Equals, expected)
 }
 
 func (s *cmdStorageSuite) TestListPoolsName(c *gc.C) {
-	context := runPoolList(c, "--name", "block")
+	stdout, _, err := runPoolList(c, "--name", "block")
+	c.Assert(err, jc.ErrorIsNil)
 	expected := `
 block:
   provider: loop
   attrs:
     it: works
 `[1:]
-	c.Assert(testing.Stdout(context), gc.Equals, expected)
+	c.Assert(stdout, gc.Equals, expected)
 }
 
 func (s *cmdStorageSuite) TestListPoolsNameNoMatch(c *gc.C) {
-	context := runPoolList(c, "--name", "cranky")
-	c.Assert(testing.Stdout(context), gc.Equals, "")
+	stdout, stderr, err := runPoolList(c, "--name", "cranky")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(stderr, gc.Equals, "")
+	c.Assert(stdout, gc.Equals, "")
 }
 
 func (s *cmdStorageSuite) TestListPoolsNameInvalid(c *gc.C) {
-	_, err := testing.RunCommand(c, envcmd.Wrap(&cmdstorage.PoolListCommand{}), "--name", "9oops")
-	c.Assert(errors.Cause(err), gc.ErrorMatches, ".*not valid.*")
+	_, stderr, err := runPoolList(c, "--name", "9oops")
+	c.Assert(err, gc.NotNil)
+	c.Assert(stderr, jc.Contains, `ERROR pool name "9oops" not valid`)
 }
 
 func (s *cmdStorageSuite) TestListPoolsProvider(c *gc.C) {
-	context := runPoolList(c, "--provider", "loop")
+	stdout, _, err := runPoolList(c, "--provider", "loop")
+	c.Assert(err, jc.ErrorIsNil)
 	expected := `
 block:
   provider: loop
@@ -261,7 +287,7 @@ block:
 loop:
   provider: loop
 `[1:]
-	c.Assert(testing.Stdout(context), gc.Equals, expected)
+	c.Assert(stdout, gc.Equals, expected)
 }
 
 func (s *cmdStorageSuite) registerTmpProviderType(c *gc.C) {
@@ -272,85 +298,105 @@ func (s *cmdStorageSuite) registerTmpProviderType(c *gc.C) {
 
 func (s *cmdStorageSuite) TestListPoolsProviderNoMatch(c *gc.C) {
 	s.registerTmpProviderType(c)
-	context := runPoolList(c, "--provider", string(provider.TmpfsProviderType))
+	stdout, _, err := runPoolList(c, "--provider", string(provider.TmpfsProviderType))
+	c.Assert(err, jc.ErrorIsNil)
 	expected := `
 tmpfs:
   provider: tmpfs
 `[1:]
-	c.Assert(testing.Stdout(context), gc.Equals, expected)
+	c.Assert(stdout, gc.Equals, expected)
 }
 
 func (s *cmdStorageSuite) TestListPoolsProviderUnregistered(c *gc.C) {
-	_, err := testing.RunCommand(c, envcmd.Wrap(&cmdstorage.PoolListCommand{}), "--provider", "oops")
-	c.Assert(errors.Cause(err), gc.ErrorMatches, ".*not supported.*")
+	_, stderr, err := runPoolList(c, "--provider", "oops")
+	c.Assert(err, gc.NotNil)
+	c.Assert(stderr, jc.Contains, `"oops" for environment "dummyenv" not supported`)
 }
 
 func (s *cmdStorageSuite) TestListPoolsNameAndProvider(c *gc.C) {
-	context := runPoolList(c, "--name", "block", "--provider", "loop")
+	stdout, _, err := runPoolList(c, "--name", "block", "--provider", "loop")
+	c.Assert(err, jc.ErrorIsNil)
 	expected := `
 block:
   provider: loop
   attrs:
     it: works
 `[1:]
-	c.Assert(testing.Stdout(context), gc.Equals, expected)
+	c.Assert(stdout, gc.Equals, expected)
 }
 
 func (s *cmdStorageSuite) TestListPoolsProviderAndNotName(c *gc.C) {
-	context := runPoolList(c, "--name", "fluff", "--provider", "ebs")
+	stdout, _, err := runPoolList(c, "--name", "fluff", "--provider", "ebs")
+	c.Assert(err, jc.ErrorIsNil)
 	// there is no pool that matches this name AND type
-	c.Assert(testing.Stdout(context), gc.Equals, "")
+	c.Assert(stdout, gc.Equals, "")
 }
 
 func (s *cmdStorageSuite) TestListPoolsNameAndNotProvider(c *gc.C) {
 	s.registerTmpProviderType(c)
-	context := runPoolList(c, "--name", "block", "--provider", string(provider.TmpfsProviderType))
+	stdout, _, err := runPoolList(c, "--name", "block", "--provider", string(provider.TmpfsProviderType))
+	c.Assert(err, jc.ErrorIsNil)
 	// no pool matches this name and this provider
-	c.Assert(testing.Stdout(context), gc.Equals, "")
+	c.Assert(stdout, gc.Equals, "")
 }
 
 func (s *cmdStorageSuite) TestListPoolsNotNameAndNotProvider(c *gc.C) {
 	s.registerTmpProviderType(c)
-	context := runPoolList(c, "--name", "fluff", "--provider", string(provider.TmpfsProviderType))
-	c.Assert(testing.Stdout(context), gc.Equals, "")
+	stdout, _, err := runPoolList(c, "--name", "fluff", "--provider", string(provider.TmpfsProviderType))
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(stdout, gc.Equals, "")
 }
 
-func runPoolCreate(c *gc.C, args ...string) *cmd.Context {
-	context, err := testing.RunCommand(c, envcmd.Wrap(&cmdstorage.PoolCreateCommand{}), args...)
-	c.Assert(err, jc.ErrorIsNil)
-	return context
+func runPoolCreate(c *gc.C, args ...string) (string, string, error) {
+	cmdArgs := append([]string{"storage", "pool", "create"}, args...)
+	ctx, err := runJujuCommand(c, cmdArgs...)
+	stdout, stderr := "", ""
+	if ctx != nil {
+		stdout = testing.Stdout(ctx)
+		stderr = testing.Stderr(ctx)
+	}
+	return stdout, stderr, err
+
 }
 
 func (s *cmdStorageSuite) TestCreatePool(c *gc.C) {
 	pname := "ftPool"
-	context := runPoolCreate(c, pname, "loop", "smth=one")
-	c.Assert(testing.Stdout(context), gc.Equals, "")
+	stdout, _, err := runPoolCreate(c, pname, "loop", "smth=one")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(stdout, gc.Equals, "")
 	assertPoolExists(c, s.State, pname, "loop", "smth=one")
 }
 
-func (s *cmdStorageSuite) assertCreatePoolError(c *gc.C, expected string, args ...string) {
-	_, err := testing.RunCommand(c, envcmd.Wrap(&cmdstorage.PoolCreateCommand{}), args...)
-	c.Assert(errors.Cause(err), gc.ErrorMatches, expected)
+func (s *cmdStorageSuite) assertCreatePoolError(c *gc.C, errString, expected string, args ...string) {
+	_, stderr, err := runPoolCreate(c, args...)
+	if errString != "" {
+		c.Assert(err, gc.ErrorMatches, errString)
+	} else {
+		c.Assert(err, gc.NotNil)
+	}
+
+	c.Assert(stderr, jc.Contains, expected)
 }
 
 func (s *cmdStorageSuite) TestCreatePoolErrorNoAttrs(c *gc.C) {
-	s.assertCreatePoolError(c, ".*pool creation requires names, provider type and attrs for configuration.*", "loop", "ftPool")
+	s.assertCreatePoolError(c, "pool creation requires names, provider type and attrs for configuration", "", "loop", "ftPool")
 }
 
 func (s *cmdStorageSuite) TestCreatePoolErrorNoProvider(c *gc.C) {
-	s.assertCreatePoolError(c, ".*pool creation requires names, provider type and attrs for configuration.*", "oops provider", "smth=one")
+	s.assertCreatePoolError(c, "pool creation requires names, provider type and attrs for configuration", "", "oops provider", "smth=one")
 }
 
 func (s *cmdStorageSuite) TestCreatePoolErrorProviderType(c *gc.C) {
-	s.assertCreatePoolError(c, ".*not found.*", "loop", "ftPool", "smth=one")
+	s.assertCreatePoolError(c, "", "not found", "loop", "ftPool", "smth=one")
 }
 
 func (s *cmdStorageSuite) TestCreatePoolDuplicateName(c *gc.C) {
 	pname := "ftPool"
-	context := runPoolCreate(c, pname, "loop", "smth=one")
-	c.Assert(testing.Stdout(context), gc.Equals, "")
+	stdout, _, err := runPoolCreate(c, pname, "loop", "smth=one")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(stdout, gc.Equals, "")
 	assertPoolExists(c, s.State, pname, "loop", "smth=one")
-	s.assertCreatePoolError(c, ".*cannot overwrite existing settings*", pname, "loop", "smth=one")
+	s.assertCreatePoolError(c, "", "cannot overwrite existing settings", pname, "loop", "smth=one")
 }
 
 func assertPoolExists(c *gc.C, st *state.State, pname, provider, attr string) {
@@ -376,30 +422,28 @@ func assertPoolExists(c *gc.C, st *state.State, pname, provider, attr string) {
 	c.Assert(exists, jc.IsTrue)
 }
 
-func runVolumeList(c *gc.C, args ...string) *cmd.Context {
-	context, err := testing.RunCommand(c,
-		envcmd.Wrap(&cmdstorage.VolumeListCommand{}), args...)
-	c.Assert(err, jc.ErrorIsNil)
-	return context
+func runVolumeList(c *gc.C, args ...string) (string, string, error) {
+	cmdArgs := append([]string{"storage", "volume", "list"}, args...)
+	ctx, err := runJujuCommand(c, cmdArgs...)
+	return testing.Stdout(ctx), testing.Stderr(ctx), err
 }
 
 func (s *cmdStorageSuite) TestListVolumeInvalidMachine(c *gc.C) {
-	_, err := testing.RunCommand(
-		c, envcmd.Wrap(&cmdstorage.VolumeListCommand{}), "abc",
-	)
-	c.Assert(err, gc.ErrorMatches, `"machine-abc" is not a valid machine tag`)
+	_, stderr, err := runVolumeList(c, "abc")
+	c.Assert(err, gc.ErrorMatches, "cmd: error out silently")
+	c.Assert(stderr, jc.Contains, `"machine-abc" is not a valid machine tag`)
 }
 
 func (s *cmdStorageSuite) TestListVolumeTabularFilterMatch(c *gc.C) {
 	createUnitWithStorage(c, &s.JujuConnSuite, testPool)
-	context := runVolumeList(c, "0")
+	stdout, _, err := runVolumeList(c, "0")
+	c.Assert(err, jc.ErrorIsNil)
 	expected := `
 MACHINE  UNIT             STORAGE  DEVICE  VOLUME  ID  SIZE  STATE    MESSAGE
 0        storage-block/0  data/0           0/0               pending  
 
 `[1:]
-	c.Assert(testing.Stdout(context), gc.Equals, expected)
-	c.Assert(testing.Stderr(context), gc.Equals, "")
+	c.Assert(stdout, gc.Equals, expected)
 }
 
 func runAddToUnit(c *gc.C, args ...string) *cmd.Context {


### PR DESCRIPTION
Working on the "Chicago Cubs" branch, we found a few problems with out CLI commands.

After a discussion with rogpeppe, jam and fwereade, it was decided, that our command unit
tests should be testing s "wrapped" commands (using either the environment or system command
wrapper).

To enable macaroon based login mechanism in the "Chicago Cubs" branch, those wrappers were
used to initialize httpbakery Client (including loading macaroons from a persistent cookiejar)
and each command that needs an API connection will need to be wrapped, as wrapped initialize
an "apiContext" structure, which can then be used to initialize an API connection.

This is the first part of changes moving slowly towards that goal.

(Review request: http://reviews.vapour.ws/r/2635/)