### PR TITLE
Fix for http://pad.lv/1489142.

### DIFF
--- a/provider/ec2/image.go
+++ b/provider/ec2/image.go
@@ -47,7 +47,10 @@ func filterImages(images []*imagemetadata.ImageMetadata, ic *instances.InstanceC
 func findInstanceSpec(
 	sources []simplestreams.DataSource, stream string, ic *instances.InstanceConstraint) (*instances.InstanceSpec, error) {
 
-	if ic.Constraints.CpuPower == nil {
+	// If the instance type is set, don't also set a default CPU power
+	// as this is implied.
+	cons := ic.Constraints
+	if cons.CpuPower == nil && (cons.InstanceType == nil || *cons.InstanceType == "") {
 		ic.Constraints.CpuPower = instances.CpuPower(defaultCpuPower)
 	}
 	ec2Region := allRegions[ic.Region]

--- a/provider/ec2/image_test.go
+++ b/provider/ec2/image_test.go
@@ -173,6 +173,23 @@ func (s *specSuite) TestFindInstanceSpec(c *gc.C) {
 	}
 }
 
+func (s *specSuite) TestFindInstanceSpecNotSetCpuPowerWhenInstanceTypeSet(c *gc.C) {
+
+	source := []simplestreams.DataSource{
+		simplestreams.NewURLDataSource("test", "test:", utils.VerifySSLHostnames),
+	}
+	instanceConstraint := &instances.InstanceConstraint{
+		Region:      "test",
+		Series:      testing.FakeDefaultSeries,
+		Constraints: constraints.MustParse("instance-type=t2.medium"),
+	}
+
+	c.Check(instanceConstraint.Constraints.CpuPower, gc.IsNil)
+	findInstanceSpec(source, "released", instanceConstraint)
+
+	c.Check(instanceConstraint.Constraints.CpuPower, gc.IsNil)
+}
+
 var findInstanceSpecErrorTests = []struct {
 	series string
 	arches []string


### PR DESCRIPTION
If instance type is specified as a constraint, we want that to trump all other constraints. Currently, CPU Power will be set to the default constraint regardless of whether instance-type is set.

(Review request: http://reviews.vapour.ws/r/2638/)