### PR TITLE
store the charm settings in the same transaction that adds the service

### DIFF
--- a/apiserver/charmrevisionupdater/testing/suite.go
+++ b/apiserver/charmrevisionupdater/testing/suite.go
@@ -98,7 +98,7 @@ func (s *CharmSuite) AddService(c *gc.C, charmName, serviceName string, networks
 	ch, ok := s.charms[charmName]
 	c.Assert(ok, jc.IsTrue)
 	owner := s.jcSuite.AdminUserTag(c)
-	_, err := s.jcSuite.State.AddService(serviceName, owner.String(), ch, networks, nil)
+	_, err := s.jcSuite.State.AddService(serviceName, owner.String(), ch, networks, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/apiserver/client/run_test.go
+++ b/apiserver/client/run_test.go
@@ -76,22 +76,22 @@ func (s *runSuite) addUnit(c *gc.C, service *state.Service) *state.Unit {
 func (s *runSuite) TestGetAllUnitNames(c *gc.C) {
 	charm := s.AddTestingCharm(c, "dummy")
 	owner := s.AdminUserTag(c)
-	magic, err := s.State.AddService("magic", owner.String(), charm, nil, nil)
+	magic, err := s.State.AddService("magic", owner.String(), charm, nil, nil, nil)
 	s.addUnit(c, magic)
 	s.addUnit(c, magic)
 
-	notAssigned, err := s.State.AddService("not-assigned", owner.String(), charm, nil, nil)
+	notAssigned, err := s.State.AddService("not-assigned", owner.String(), charm, nil, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = notAssigned.AddUnit()
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = s.State.AddService("no-units", owner.String(), charm, nil, nil)
+	_, err = s.State.AddService("no-units", owner.String(), charm, nil, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
-	wordpress, err := s.State.AddService("wordpress", owner.String(), s.AddTestingCharm(c, "wordpress"), nil, nil)
+	wordpress, err := s.State.AddService("wordpress", owner.String(), s.AddTestingCharm(c, "wordpress"), nil, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	wordpress0 := s.addUnit(c, wordpress)
-	_, err = s.State.AddService("logging", owner.String(), s.AddTestingCharm(c, "logging"), nil, nil)
+	_, err = s.State.AddService("logging", owner.String(), s.AddTestingCharm(c, "logging"), nil, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	eps, err := s.State.InferEndpoints("logging", "wordpress")
@@ -276,7 +276,7 @@ func (s *runSuite) TestRunMachineAndService(c *gc.C) {
 
 	charm := s.AddTestingCharm(c, "dummy")
 	owner := s.Factory.MakeUser(c, nil).Tag()
-	magic, err := s.State.AddService("magic", owner.String(), charm, nil, nil)
+	magic, err := s.State.AddService("magic", owner.String(), charm, nil, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	s.addUnit(c, magic)
 	s.addUnit(c, magic)
@@ -323,7 +323,7 @@ func (s *runSuite) TestBlockRunMachineAndService(c *gc.C) {
 
 	charm := s.AddTestingCharm(c, "dummy")
 	owner := s.Factory.MakeUser(c, nil).Tag()
-	magic, err := s.State.AddService("magic", owner.String(), charm, nil, nil)
+	magic, err := s.State.AddService("magic", owner.String(), charm, nil, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	s.addUnit(c, magic)
 	s.addUnit(c, magic)

--- a/cmd/juju/status_test.go
+++ b/cmd/juju/status_test.go
@@ -2423,7 +2423,7 @@ type addService struct {
 func (as addService) step(c *gc.C, ctx *context) {
 	ch, ok := ctx.charms[as.charm]
 	c.Assert(ok, jc.IsTrue)
-	svc, err := ctx.st.AddService(as.name, ctx.adminUserTag, ch, as.networks, nil)
+	svc, err := ctx.st.AddService(as.name, ctx.adminUserTag, ch, as.networks, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	if svc.IsPrincipal() {
 		err = svc.SetConstraints(as.cons)

--- a/environs/jujutest/livetests.go
+++ b/environs/jujutest/livetests.go
@@ -462,7 +462,7 @@ func (t *LiveTests) TestBootstrapAndDeploy(c *gc.C) {
 	url := testcharms.Repo.ClonedURL(repoDir, mtools0.Version.Series, "dummy")
 	sch, err := jujutesting.PutCharm(st, url, &charmrepo.LocalRepository{Path: repoDir}, false)
 	c.Assert(err, jc.ErrorIsNil)
-	svc, err := st.AddService("dummy", owner.String(), sch, nil, nil)
+	svc, err := st.AddService("dummy", owner.String(), sch, nil, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	units, err := juju.AddUnits(st, svc, 1, "")
 	c.Assert(err, jc.ErrorIsNil)

--- a/juju/deploy.go
+++ b/juju/deploy.go
@@ -82,14 +82,10 @@ func DeployService(st *state.State, args DeployServiceParams) (*state.Service, e
 		args.Charm,
 		args.Networks,
 		stateStorageConstraints(args.Storage),
+		settings,
 	)
 	if err != nil {
 		return nil, err
-	}
-	if len(settings) > 0 {
-		if err := service.UpdateConfigSettings(settings); err != nil {
-			return nil, err
-		}
 	}
 	if args.Charm.Meta().Subordinate {
 		return service, nil

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -576,7 +576,7 @@ func (s *JujuConnSuite) AddTestingService(c *gc.C, name string, ch *state.Charm)
 
 func (s *JujuConnSuite) AddTestingServiceWithStorage(c *gc.C, name string, ch *state.Charm, storage map[string]state.StorageConstraints) *state.Service {
 	owner := s.AdminUserTag(c).String()
-	service, err := s.State.AddService(name, owner, ch, nil, storage)
+	service, err := s.State.AddService(name, owner, ch, nil, storage, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	return service
 }
@@ -584,7 +584,7 @@ func (s *JujuConnSuite) AddTestingServiceWithStorage(c *gc.C, name string, ch *s
 func (s *JujuConnSuite) AddTestingServiceWithNetworks(c *gc.C, name string, ch *state.Charm, networks []string) *state.Service {
 	c.Assert(s.State, gc.NotNil)
 	owner := s.AdminUserTag(c).String()
-	service, err := s.State.AddService(name, owner, ch, networks, nil)
+	service, err := s.State.AddService(name, owner, ch, networks, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	return service
 }

--- a/state/compat_test.go
+++ b/state/compat_test.go
@@ -52,7 +52,7 @@ func (s *compatSuite) TestEnvironAssertAlive(c *gc.C) {
 func (s *compatSuite) TestGetServiceWithoutNetworksIsOK(c *gc.C) {
 	charm := addCharm(c, s.state, "quantal", testcharms.Repo.CharmDir("mysql"))
 	owner := s.env.Owner()
-	service, err := s.state.AddService("mysql", owner.String(), charm, nil, nil)
+	service, err := s.state.AddService("mysql", owner.String(), charm, nil, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	// In 1.17.7+ all services have associated document in the
 	// requested networks collection. We remove it here to test

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -126,7 +126,7 @@ func AddTestingServiceWithStorage(c *gc.C, st *State, name string, ch *Charm, ow
 
 func addTestingService(c *gc.C, st *State, name string, ch *Charm, owner names.UserTag, networks []string, storage map[string]StorageConstraints) *Service {
 	c.Assert(ch, gc.NotNil)
-	service, err := st.AddService(name, owner.String(), ch, networks, storage)
+	service, err := st.AddService(name, owner.String(), ch, networks, storage, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	return service
 }

--- a/state/filesystem_test.go
+++ b/state/filesystem_test.go
@@ -27,7 +27,7 @@ func (s *FilesystemStateSuite) TestAddServiceInvalidPool(c *gc.C) {
 	storage := map[string]state.StorageConstraints{
 		"data": makeStorageCons("invalid-pool", 1024, 1),
 	}
-	_, err := s.State.AddService("storage-filesystem", s.Owner.String(), ch, nil, storage)
+	_, err := s.State.AddService("storage-filesystem", s.Owner.String(), ch, nil, storage, nil)
 	c.Assert(err, gc.ErrorMatches, `.* pool "invalid-pool" not found`)
 }
 
@@ -36,7 +36,7 @@ func (s *FilesystemStateSuite) TestAddServiceNoPool(c *gc.C) {
 	storage := map[string]state.StorageConstraints{
 		"data": makeStorageCons("", 1024, 1),
 	}
-	svc, err := s.State.AddService("storage-filesystem", s.Owner.String(), ch, nil, storage)
+	svc, err := s.State.AddService("storage-filesystem", s.Owner.String(), ch, nil, storage, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	cons, err := svc.StorageConstraints()
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/state.go
+++ b/state/state.go
@@ -1059,7 +1059,7 @@ func (st *State) addPeerRelationsOps(serviceName string, peers map[string]charm.
 // supplied name (which must be unique). If the charm defines peer relations,
 // they will be created automatically.
 func (st *State) AddService(
-	name, owner string, ch *Charm, networks []string, storage map[string]StorageConstraints,
+	name, owner string, ch *Charm, networks []string, storage map[string]StorageConstraints, settings charm.Settings,
 ) (service *Service, err error) {
 	defer errors.DeferredAnnotatef(&err, "cannot add service %q", name)
 	ownerTag, err := names.ParseUserTag(owner)
@@ -1135,7 +1135,7 @@ func (st *State) AddService(
 		// and known before setting them.
 		createRequestedNetworksOp(st, svc.globalKey(), networks),
 		createStorageConstraintsOp(svc.globalKey(), storage),
-		createSettingsOp(st, svc.settingsKey(), nil),
+		createSettingsOp(st, svc.settingsKey(), map[string]interface{}(settings)),
 		addLeadershipSettingsOp(svc.Tag().Id()),
 		createStatusOp(st, svc.globalKey(), statusDoc),
 		{
@@ -1152,6 +1152,7 @@ func (st *State) AddService(
 			Insert: svcDoc,
 		},
 	}
+
 	// Collect peer relation addition operations.
 	peerOps, err := st.addPeerRelationsOps(name, peers)
 	if err != nil {

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -1776,19 +1776,19 @@ func (s *StateSuite) TestAllNetworks(c *gc.C) {
 
 func (s *StateSuite) TestAddService(c *gc.C) {
 	charm := s.AddTestingCharm(c, "dummy")
-	_, err := s.State.AddService("haha/borken", s.Owner.String(), charm, nil, nil)
+	_, err := s.State.AddService("haha/borken", s.Owner.String(), charm, nil, nil, nil)
 	c.Assert(err, gc.ErrorMatches, `cannot add service "haha/borken": invalid name`)
 	_, err = s.State.Service("haha/borken")
 	c.Assert(err, gc.ErrorMatches, `"haha/borken" is not a valid service name`)
 
 	// set that a nil charm is handled correctly
-	_, err = s.State.AddService("umadbro", s.Owner.String(), nil, nil, nil)
+	_, err = s.State.AddService("umadbro", s.Owner.String(), nil, nil, nil, nil)
 	c.Assert(err, gc.ErrorMatches, `cannot add service "umadbro": charm is nil`)
 
-	wordpress, err := s.State.AddService("wordpress", s.Owner.String(), charm, nil, nil)
+	wordpress, err := s.State.AddService("wordpress", s.Owner.String(), charm, nil, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(wordpress.Name(), gc.Equals, "wordpress")
-	mysql, err := s.State.AddService("mysql", s.Owner.String(), charm, nil, nil)
+	mysql, err := s.State.AddService("mysql", s.Owner.String(), charm, nil, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(mysql.Name(), gc.Equals, "mysql")
 
@@ -1815,7 +1815,7 @@ func (s *StateSuite) TestAddServiceEnvironmentDying(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = env.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = s.State.AddService("s1", s.Owner.String(), charm, nil, nil)
+	_, err = s.State.AddService("s1", s.Owner.String(), charm, nil, nil, nil)
 	c.Assert(err, gc.ErrorMatches, `cannot add service "s1": environment is no longer alive`)
 }
 
@@ -1830,7 +1830,7 @@ func (s *StateSuite) TestAddServiceEnvironmentDyingAfterInitial(c *gc.C) {
 		c.Assert(env.Life(), gc.Equals, state.Alive)
 		c.Assert(env.Destroy(), gc.IsNil)
 	}).Check()
-	_, err = s.State.AddService("s1", s.Owner.String(), charm, nil, nil)
+	_, err = s.State.AddService("s1", s.Owner.String(), charm, nil, nil, nil)
 	c.Assert(err, gc.ErrorMatches, `cannot add service "s1": environment is no longer alive`)
 }
 
@@ -1842,19 +1842,19 @@ func (s *StateSuite) TestServiceNotFound(c *gc.C) {
 
 func (s *StateSuite) TestAddServiceNoTag(c *gc.C) {
 	charm := s.AddTestingCharm(c, "dummy")
-	_, err := s.State.AddService("wordpress", "admin", charm, nil, nil)
+	_, err := s.State.AddService("wordpress", "admin", charm, nil, nil, nil)
 	c.Assert(err, gc.ErrorMatches, "cannot add service \"wordpress\": Invalid ownertag admin: \"admin\" is not a valid tag")
 }
 
 func (s *StateSuite) TestAddServiceNotUserTag(c *gc.C) {
 	charm := s.AddTestingCharm(c, "dummy")
-	_, err := s.State.AddService("wordpress", "machine-3", charm, nil, nil)
+	_, err := s.State.AddService("wordpress", "machine-3", charm, nil, nil, nil)
 	c.Assert(err, gc.ErrorMatches, "cannot add service \"wordpress\": Invalid ownertag machine-3: \"machine-3\" is not a valid user tag")
 }
 
 func (s *StateSuite) TestAddServiceNonExistentUser(c *gc.C) {
 	charm := s.AddTestingCharm(c, "dummy")
-	_, err := s.State.AddService("wordpress", "user-notAuser", charm, nil, nil)
+	_, err := s.State.AddService("wordpress", "user-notAuser", charm, nil, nil, nil)
 	c.Assert(err, gc.ErrorMatches, `cannot add service "wordpress": environment user "notAuser@local" not found`)
 }
 
@@ -1865,13 +1865,13 @@ func (s *StateSuite) TestAllServices(c *gc.C) {
 	c.Assert(len(services), gc.Equals, 0)
 
 	// Check that after adding services the result is ok.
-	_, err = s.State.AddService("wordpress", s.Owner.String(), charm, nil, nil)
+	_, err = s.State.AddService("wordpress", s.Owner.String(), charm, nil, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	services, err = s.State.AllServices()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(len(services), gc.Equals, 1)
 
-	_, err = s.State.AddService("mysql", s.Owner.String(), charm, nil, nil)
+	_, err = s.State.AddService("mysql", s.Owner.String(), charm, nil, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	services, err = s.State.AllServices()
 	c.Assert(err, jc.ErrorIsNil)
@@ -3463,7 +3463,7 @@ func (s *StateSuite) TestSetEnvironAgentVersionErrors(c *gc.C) {
 	// Add a service and 4 units: one with a different version, one
 	// with an empty version, one with the current version, and one
 	// with the new version.
-	service, err := s.State.AddService("wordpress", s.Owner.String(), s.AddTestingCharm(c, "wordpress"), nil, nil)
+	service, err := s.State.AddService("wordpress", s.Owner.String(), s.AddTestingCharm(c, "wordpress"), nil, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	unit0, err := service.AddUnit()
 	c.Assert(err, jc.ErrorIsNil)
@@ -3513,7 +3513,7 @@ func (s *StateSuite) prepareAgentVersionTests(c *gc.C) (*config.Config, string) 
 	// Add a machine and a unit with the current version.
 	machine, err := s.State.AddMachine("series", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
-	service, err := s.State.AddService("wordpress", s.Owner.String(), s.AddTestingCharm(c, "wordpress"), nil, nil)
+	service, err := s.State.AddService("wordpress", s.Owner.String(), s.AddTestingCharm(c, "wordpress"), nil, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	unit, err := service.AddUnit()
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -1775,8 +1775,8 @@ func (s *StateSuite) TestAllNetworks(c *gc.C) {
 }
 
 func (s *StateSuite) TestAddService(c *gc.C) {
-	charm := s.AddTestingCharm(c, "dummy")
-	_, err := s.State.AddService("haha/borken", s.Owner.String(), charm, nil, nil, nil)
+	ch := s.AddTestingCharm(c, "dummy")
+	_, err := s.State.AddService("haha/borken", s.Owner.String(), ch, nil, nil, nil)
 	c.Assert(err, gc.ErrorMatches, `cannot add service "haha/borken": invalid name`)
 	_, err = s.State.Service("haha/borken")
 	c.Assert(err, gc.ErrorMatches, `"haha/borken" is not a valid service name`)
@@ -1785,10 +1785,16 @@ func (s *StateSuite) TestAddService(c *gc.C) {
 	_, err = s.State.AddService("umadbro", s.Owner.String(), nil, nil, nil, nil)
 	c.Assert(err, gc.ErrorMatches, `cannot add service "umadbro": charm is nil`)
 
-	wordpress, err := s.State.AddService("wordpress", s.Owner.String(), charm, nil, nil, nil)
+	insettings := charm.Settings{"tuning": "optimized"}
+
+	wordpress, err := s.State.AddService("wordpress", s.Owner.String(), ch, nil, nil, insettings)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(wordpress.Name(), gc.Equals, "wordpress")
-	mysql, err := s.State.AddService("mysql", s.Owner.String(), charm, nil, nil, nil)
+	outsettings, err := wordpress.ConfigSettings()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(outsettings, gc.DeepEquals, insettings)
+
+	mysql, err := s.State.AddService("mysql", s.Owner.String(), ch, nil, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(mysql.Name(), gc.Equals, "mysql")
 
@@ -1796,15 +1802,15 @@ func (s *StateSuite) TestAddService(c *gc.C) {
 	wordpress, err = s.State.Service("wordpress")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(wordpress.Name(), gc.Equals, "wordpress")
-	ch, _, err := wordpress.Charm()
+	ch, _, err = wordpress.Charm()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(ch.URL(), gc.DeepEquals, charm.URL())
+	c.Assert(ch.URL(), gc.DeepEquals, ch.URL())
 	mysql, err = s.State.Service("mysql")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(mysql.Name(), gc.Equals, "mysql")
 	ch, _, err = mysql.Charm()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(ch.URL(), gc.DeepEquals, charm.URL())
+	c.Assert(ch.URL(), gc.DeepEquals, ch.URL())
 }
 
 func (s *StateSuite) TestAddServiceEnvironmentDying(c *gc.C) {

--- a/state/storage_dynamicadd_test.go
+++ b/state/storage_dynamicadd_test.go
@@ -32,7 +32,7 @@ func (s *storageAddSuite) setupMultipleStoragesForAdd(c *gc.C) *state.Unit {
 		"multi1to10": makeStorageCons("loop", 0, 3),
 	}
 	charm := s.AddTestingCharm(c, "storage-block2")
-	service, err := s.State.AddService("storage-block2", "user-test-admin@local", charm, nil, storageCons)
+	service, err := s.State.AddService("storage-block2", "user-test-admin@local", charm, nil, storageCons, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	u, err := service.AddUnit()
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/storage_test.go
+++ b/state/storage_test.go
@@ -107,7 +107,7 @@ func makeStorageCons(pool string, size, count uint64) state.StorageConstraints {
 
 func (s *StorageStateSuite) TestAddServiceStorageConstraintsDefault(c *gc.C) {
 	ch := s.AddTestingCharm(c, "storage-block")
-	storageBlock, err := s.State.AddService("storage-block", "user-test-admin@local", ch, nil, nil)
+	storageBlock, err := s.State.AddService("storage-block", "user-test-admin@local", ch, nil, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	constraints, err := storageBlock.StorageConstraints()
 	c.Assert(err, jc.ErrorIsNil)
@@ -125,7 +125,7 @@ func (s *StorageStateSuite) TestAddServiceStorageConstraintsDefault(c *gc.C) {
 	})
 
 	ch = s.AddTestingCharm(c, "storage-filesystem")
-	storageFilesystem, err := s.State.AddService("storage-filesystem", "user-test-admin@local", ch, nil, nil)
+	storageFilesystem, err := s.State.AddService("storage-filesystem", "user-test-admin@local", ch, nil, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	constraints, err = storageFilesystem.StorageConstraints()
 	c.Assert(err, jc.ErrorIsNil)
@@ -141,7 +141,7 @@ func (s *StorageStateSuite) TestAddServiceStorageConstraintsDefault(c *gc.C) {
 func (s *StorageStateSuite) TestAddServiceStorageConstraintsValidation(c *gc.C) {
 	ch := s.AddTestingCharm(c, "storage-block2")
 	addService := func(storage map[string]state.StorageConstraints) (*state.Service, error) {
-		return s.State.AddService("storage-block2", "user-test-admin@local", ch, nil, storage)
+		return s.State.AddService("storage-block2", "user-test-admin@local", ch, nil, storage, nil)
 	}
 	assertErr := func(storage map[string]state.StorageConstraints, expect string) {
 		_, err := addService(storage)
@@ -173,7 +173,7 @@ func (s *StorageStateSuite) assertAddServiceStorageConstraintsDefaults(c *gc.C, 
 		c.Assert(err, jc.ErrorIsNil)
 	}
 	ch := s.AddTestingCharm(c, "storage-block")
-	service, err := s.State.AddService("storage-block2", "user-test-admin@local", ch, nil, cons)
+	service, err := s.State.AddService("storage-block2", "user-test-admin@local", ch, nil, cons, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	savedCons, err := service.StorageConstraints()
 	c.Assert(err, jc.ErrorIsNil)
@@ -245,7 +245,7 @@ func (s *StorageStateSuite) TestAddServiceStorageConstraintsDefaultSizeFromCharm
 		"multi2up":   makeStorageCons("loop", 2048, 2),
 	}
 	ch := s.AddTestingCharm(c, "storage-block2")
-	service, err := s.State.AddService("storage-block2", "user-test-admin@local", ch, nil, storageCons)
+	service, err := s.State.AddService("storage-block2", "user-test-admin@local", ch, nil, storageCons, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	savedCons, err := service.StorageConstraints()
 	c.Assert(err, jc.ErrorIsNil)
@@ -255,7 +255,7 @@ func (s *StorageStateSuite) TestAddServiceStorageConstraintsDefaultSizeFromCharm
 func (s *StorageStateSuite) TestProviderFallbackToType(c *gc.C) {
 	ch := s.AddTestingCharm(c, "storage-block")
 	addService := func(storage map[string]state.StorageConstraints) (*state.Service, error) {
-		return s.State.AddService("storage-block", "user-test-admin@local", ch, nil, storage)
+		return s.State.AddService("storage-block", "user-test-admin@local", ch, nil, storage, nil)
 	}
 	storageCons := map[string]state.StorageConstraints{
 		"data": makeStorageCons("loop", 1024, 1),

--- a/state/volume_test.go
+++ b/state/volume_test.go
@@ -84,7 +84,7 @@ func (s *VolumeStateSuite) TestAddServiceInvalidPool(c *gc.C) {
 	storage := map[string]state.StorageConstraints{
 		"data": makeStorageCons("invalid-pool", 1024, 1),
 	}
-	_, err := s.State.AddService("storage-block", s.Owner.String(), ch, nil, storage)
+	_, err := s.State.AddService("storage-block", s.Owner.String(), ch, nil, storage, nil)
 	c.Assert(err, gc.ErrorMatches, `.* pool "invalid-pool" not found`)
 }
 
@@ -93,7 +93,7 @@ func (s *VolumeStateSuite) TestAddServiceNoUserDefaultPool(c *gc.C) {
 	storage := map[string]state.StorageConstraints{
 		"data": makeStorageCons("", 1024, 1),
 	}
-	service, err := s.State.AddService("storage-block", s.Owner.String(), ch, nil, storage)
+	service, err := s.State.AddService("storage-block", s.Owner.String(), ch, nil, storage, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	cons, err := service.StorageConstraints()
 	c.Assert(err, jc.ErrorIsNil)

--- a/testing/factory/factory.go
+++ b/testing/factory/factory.go
@@ -332,7 +332,7 @@ func (factory *Factory) MakeService(c *gc.C, params *ServiceParams) *state.Servi
 		params.Creator = creator.Tag()
 	}
 	_ = params.Creator.(names.UserTag)
-	service, err := factory.st.AddService(params.Name, params.Creator.String(), params.Charm, nil, nil)
+	service, err := factory.st.AddService(params.Name, params.Creator.String(), params.Charm, nil, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	if params.Status != nil {


### PR DESCRIPTION
This fixes part of https://bugs.launchpad.net/juju-core/+bug/1486553 **i/o timeout errors can cause non-atomic service deploys** - the part about settings not getting set atomically when the service is added, so you can have a service added without the settings set correctly.

Now the setting and service add are done in the same transaction, so if there's a service, it has the right settings, period.

This does not fix the second part of the problem, where the units may not get assigned, that can still happen (so if you deploy a service with non-zero units, you might get a service with zero units).


(Review request: http://reviews.vapour.ws/r/2639/)