### PR TITLE
Fix certupdater panic 1493123

### DIFF
--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -1048,7 +1048,7 @@ func (a *MachineAgent) StateWorker() (worker.Worker, error) {
 			// to the agent to close it rather than any one of the
 			// workers.
 			//
-			// For now we simply do not close the channel.
+			// TODO(ericsnow) For now we simply do not close the channel.
 			certChangedChan := make(chan params.StateServingInfo, 1)
 			runner.StartWorker("apiserver", a.apiserverWorkerStarter(st, certChangedChan))
 			var stateServingSetter certupdater.StateServingInfoSetter = func(info params.StateServingInfo, done <-chan struct{}) error {

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -1043,6 +1043,12 @@ func (a *MachineAgent) StateWorker() (worker.Worker, error) {
 			a.startWorkerAfterUpgrade(runner, "restore", func() (worker.Worker, error) {
 				return a.newRestoreStateWatcherWorker(st)
 			})
+
+			// certChangedChan is shared by multiple workers it's up
+			// to the agent to close it rather than any one of the
+			// workers.
+			//
+			// For now we simply do not close the channel.
 			certChangedChan := make(chan params.StateServingInfo, 1)
 			runner.StartWorker("apiserver", a.apiserverWorkerStarter(st, certChangedChan))
 			var stateServingSetter certupdater.StateServingInfoSetter = func(info params.StateServingInfo, done <-chan struct{}) error {

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -1064,7 +1064,7 @@ func (a *MachineAgent) StateWorker() (worker.Worker, error) {
 				})
 			}
 			a.startWorkerAfterUpgrade(runner, "certupdater", func() (worker.Worker, error) {
-				return newCertificateUpdater(m, agentConfig, st, st, stateServingSetter, certChangedChan), nil
+				return newCertificateUpdater(m, agentConfig, st, st, stateServingSetter), nil
 			})
 
 			if feature.IsDbLogEnabled() {

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -1560,7 +1560,7 @@ func (s *MachineSuite) TestMachineAgentRunsEnvironStorageWorker(c *gc.C) {
 func (s *MachineSuite) TestMachineAgentRunsCertificateUpdateWorkerForStateServer(c *gc.C) {
 	started := make(chan struct{})
 	newUpdater := func(certupdater.AddressWatcher, certupdater.StateServingInfoGetter, certupdater.EnvironConfigGetter,
-		certupdater.APIHostPortsGetter, certupdater.StateServingInfoSetter, chan params.StateServingInfo,
+		certupdater.APIHostPortsGetter, certupdater.StateServingInfoSetter,
 	) worker.Worker {
 		close(started)
 		return worker.NewNoOpWorker()
@@ -1584,7 +1584,7 @@ func (s *MachineSuite) TestMachineAgentRunsCertificateUpdateWorkerForStateServer
 func (s *MachineSuite) TestMachineAgentDoesNotRunsCertificateUpdateWorkerForNonStateServer(c *gc.C) {
 	started := make(chan struct{})
 	newUpdater := func(certupdater.AddressWatcher, certupdater.StateServingInfoGetter, certupdater.EnvironConfigGetter,
-		certupdater.APIHostPortsGetter, certupdater.StateServingInfoSetter, chan params.StateServingInfo,
+		certupdater.APIHostPortsGetter, certupdater.StateServingInfoSetter,
 	) worker.Worker {
 		close(started)
 		return worker.NewNoOpWorker()
@@ -1643,7 +1643,7 @@ func (s *MachineSuite) TestCertificateUpdateWorkerUpdatesCertificate(c *gc.C) {
 func (s *MachineSuite) TestCertificateDNSUpdated(c *gc.C) {
 	// Disable the certificate work so it doesn't update the certificate.
 	newUpdater := func(certupdater.AddressWatcher, certupdater.StateServingInfoGetter, certupdater.EnvironConfigGetter,
-		certupdater.APIHostPortsGetter, certupdater.StateServingInfoSetter, chan params.StateServingInfo,
+		certupdater.APIHostPortsGetter, certupdater.StateServingInfoSetter,
 	) worker.Worker {
 		return worker.NewNoOpWorker()
 	}

--- a/worker/certupdater/certupdater.go
+++ b/worker/certupdater/certupdater.go
@@ -201,11 +201,13 @@ func updateRequired(serverCert string, newAddrs []string) ([]string, bool, error
 
 // TearDown is defined on the NotifyWatchHandler interface.
 func (c *CertificateUpdater) TearDown() error {
-	select {
-	case <-c.certChanged:
-		// already closed
-	default:
-		close(c.certChanged)
-	}
+	// (lp:1493123) We do *not* close c.certChanged here because a call
+	// to Handle() after TearDown() would result in a panic. That
+	// sequence of calls happens when CertificateUpdater is wrapped in
+	// NotifyWorker, that worker errors out and gets restarted by
+	// a runner. In effect, CertificateUpdater doesn't properly "own"
+	// the channel (c.certChanged). If it were refactored to correct
+	// that then closing the channel here would be appropriate under
+	// some conditions, like when NotifyWorker.Kill is called.
 	return nil
 }

--- a/worker/certupdater/certupdater.go
+++ b/worker/certupdater/certupdater.go
@@ -32,7 +32,6 @@ type CertificateUpdater struct {
 	setter          StateServingInfoSetter
 	configGetter    EnvironConfigGetter
 	hostPortsGetter APIHostPortsGetter
-	certChanged     chan params.StateServingInfo
 	addresses       []network.Address
 }
 
@@ -70,7 +69,6 @@ type APIHostPortsGetter interface {
 // addresses in the certificate's SAN value.
 func NewCertificateUpdater(addressWatcher AddressWatcher, getter StateServingInfoGetter,
 	configGetter EnvironConfigGetter, hostPortsGetter APIHostPortsGetter, setter StateServingInfoSetter,
-	certChanged chan params.StateServingInfo,
 ) worker.Worker {
 	return worker.NewNotifyWorker(&CertificateUpdater{
 		addressWatcher:  addressWatcher,
@@ -78,7 +76,6 @@ func NewCertificateUpdater(addressWatcher AddressWatcher, getter StateServingInf
 		hostPortsGetter: hostPortsGetter,
 		getter:          getter,
 		setter:          setter,
-		certChanged:     certChanged,
 	})
 }
 
@@ -201,13 +198,5 @@ func updateRequired(serverCert string, newAddrs []string) ([]string, bool, error
 
 // TearDown is defined on the NotifyWatchHandler interface.
 func (c *CertificateUpdater) TearDown() error {
-	// (lp:1493123) We do *not* close c.certChanged here because a call
-	// to Handle() after TearDown() would result in a panic. That
-	// sequence of calls happens when CertificateUpdater is wrapped in
-	// NotifyWorker, that worker errors out and gets restarted by
-	// a runner. In effect, CertificateUpdater doesn't properly "own"
-	// the channel (c.certChanged). If it were refactored to correct
-	// that then closing the channel here would be appropriate under
-	// some conditions, like when NotifyWorker.Kill is called.
 	return nil
 }

--- a/worker/certupdater/certupdater_test.go
+++ b/worker/certupdater/certupdater_test.go
@@ -122,9 +122,8 @@ func (s *CertUpdaterSuite) TestStartStop(c *gc.C) {
 		return nil
 	}
 	changes := make(chan struct{})
-	certChangedChan := make(chan params.StateServingInfo)
 	worker := certupdater.NewCertificateUpdater(
-		&mockMachine{changes}, s, &mockConfigGetter{}, &mockAPIHostGetter{}, setter, certChangedChan,
+		&mockMachine{changes}, s, &mockConfigGetter{}, &mockAPIHostGetter{}, setter,
 	)
 	worker.Kill()
 	c.Assert(worker.Wait(), gc.IsNil)
@@ -151,9 +150,8 @@ func (s *CertUpdaterSuite) TestAddressChange(c *gc.C) {
 		return nil
 	}
 	changes := make(chan struct{})
-	certChangedChan := make(chan params.StateServingInfo)
 	worker := certupdater.NewCertificateUpdater(
-		&mockMachine{changes}, s, &mockConfigGetter{}, &mockAPIHostGetter{}, setter, certChangedChan,
+		&mockMachine{changes}, s, &mockConfigGetter{}, &mockAPIHostGetter{}, setter,
 	)
 	defer func() { c.Assert(worker.Wait(), gc.IsNil) }()
 	defer worker.Kill()
@@ -193,9 +191,8 @@ func (s *CertUpdaterSuite) TestAddressChangeNoCAKey(c *gc.C) {
 		return nil
 	}
 	changes := make(chan struct{})
-	certChangedChan := make(chan params.StateServingInfo)
 	worker := certupdater.NewCertificateUpdater(
-		&mockMachine{changes}, &mockStateServingGetterNoCAKey{}, &mockConfigGetter{}, &mockAPIHostGetter{}, setter, certChangedChan,
+		&mockMachine{changes}, &mockStateServingGetterNoCAKey{}, &mockConfigGetter{}, &mockAPIHostGetter{}, setter,
 	)
 	defer func() { c.Assert(worker.Wait(), gc.IsNil) }()
 	defer worker.Kill()


### PR DESCRIPTION
(fixes https://bugs.launchpad.net/juju-core/+bug/1493123)

This patch addresses a corner case where a shared channel is improperly closed, leading to a panic. See the bug report for more info. For now we are just going to not close the channel. I have thoughts on how we can facilitate closing it when the machine agent is stopped. However, that can wait; basically the channel will be open for the duration of the jujud process anyway. I'd still like to fix that, but it's not critical.

(Review request: http://reviews.vapour.ws/r/2644/)