### PR TITLE
APIServer: New Undertaker Facade

### DIFF
--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -61,6 +61,7 @@ var facadeVersions = map[string]int{
 	"Uniter":                       2,
 	"UserManager":                  0,
 	"VolumeAttachmentsWatcher":     1,
+	"Undertaker":                   1,
 }
 
 // bestVersion tries to find the newest version in the version list that we can

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -43,6 +43,7 @@ import (
 	_ "github.com/juju/juju/apiserver/storageprovisioner"
 	_ "github.com/juju/juju/apiserver/subnets"
 	_ "github.com/juju/juju/apiserver/systemmanager"
+	_ "github.com/juju/juju/apiserver/undertaker"
 	_ "github.com/juju/juju/apiserver/uniter"
 	_ "github.com/juju/juju/apiserver/upgrader"
 	_ "github.com/juju/juju/apiserver/usermanager"

--- a/apiserver/params/undertaker.go
+++ b/apiserver/params/undertaker.go
@@ -1,0 +1,25 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package params
+
+import (
+	"time"
+)
+
+// UndertakerEnvironInfo returns information on an environment needed by the undertaker worker.
+type UndertakerEnvironInfo struct {
+	UUID        string
+	Name        string
+	GlobalName  string
+	IsSystem    bool
+	Life        Life
+	TimeOfDeath *time.Time
+}
+
+// UndertakerEnvironInfoResult holds the result of an API call that returns an
+// UndertakerEnvironInfoResult or an error.
+type UndertakerEnvironInfoResult struct {
+	Error  *Error
+	Result UndertakerEnvironInfo
+}

--- a/apiserver/undertaker/export_test.go
+++ b/apiserver/undertaker/export_test.go
@@ -1,0 +1,6 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package undertaker
+
+var NewUndertaker = newUndertakerAPI

--- a/apiserver/undertaker/mock_test.go
+++ b/apiserver/undertaker/mock_test.go
@@ -1,0 +1,105 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package undertaker_test
+
+import (
+	"time"
+
+	"github.com/juju/errors"
+	"github.com/juju/names"
+
+	"github.com/juju/juju/apiserver/undertaker"
+	"github.com/juju/juju/state"
+)
+
+// mockState implements State interface and allows inspection of called
+// methods.
+type mockState struct {
+	env      *mockEnvironment
+	removed  bool
+	isSystem bool
+}
+
+var _ undertaker.State = (*mockState)(nil)
+
+func newMockState(envOwner names.UserTag, envName string, isSystem bool) *mockState {
+	env := mockEnvironment{
+		owner: envOwner,
+		name:  envName,
+		life:  state.Alive,
+	}
+	m := &mockState{
+		env:      &env,
+		isSystem: isSystem,
+	}
+	return m
+}
+
+func (m *mockState) EnsureEnvironmentRemoved() error {
+	if !m.removed {
+		return errors.New("found documents for environment")
+	}
+	return nil
+}
+
+func (m *mockState) RemoveAllEnvironDocs() error {
+	if m.env.life != state.Dead {
+		return errors.New("transaction aborted")
+	}
+	m.removed = true
+	return nil
+}
+
+func (m *mockState) ProcessDyingEnviron() error {
+	if m.env.life != state.Dying {
+		return errors.New("environment is not dying")
+	}
+	m.env.life = state.Dead
+	return nil
+}
+
+func (m *mockState) IsStateServer() bool {
+	return m.isSystem
+}
+
+func (m *mockState) Environment() (undertaker.Environment, error) {
+	return m.env, nil
+}
+
+// mockEnvironment implements Environment interface and allows inspection of called
+// methods.
+type mockEnvironment struct {
+	tod   time.Time
+	owner names.UserTag
+	life  state.Life
+	name  string
+	uuid  string
+}
+
+var _ undertaker.Environment = (*mockEnvironment)(nil)
+
+func (m *mockEnvironment) TimeOfDeath() time.Time {
+	return m.tod
+}
+
+func (m *mockEnvironment) Owner() names.UserTag {
+	return m.owner
+}
+
+func (m *mockEnvironment) Life() state.Life {
+	return m.life
+}
+
+func (m *mockEnvironment) Name() string {
+	return m.name
+}
+
+func (m *mockEnvironment) UUID() string {
+	return m.uuid
+}
+
+func (m *mockEnvironment) Destroy() error {
+	m.life = state.Dying
+	return nil
+}

--- a/apiserver/undertaker/package_test.go
+++ b/apiserver/undertaker/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package undertaker_test
+
+import (
+	stdtesting "testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestAll(t *stdtesting.T) {
+	gc.TestingT(t)
+}

--- a/apiserver/undertaker/state.go
+++ b/apiserver/undertaker/state.go
@@ -1,0 +1,65 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package undertaker
+
+import (
+	"time"
+
+	"github.com/juju/names"
+
+	"github.com/juju/juju/state"
+)
+
+// State defines the needed methods of state.State
+// for the work of the undertaker API.
+type State interface {
+
+	// Environment returns the environment entity.
+	Environment() (Environment, error)
+
+	// IsStateServer returns true if this state instance has the bootstrap
+	// environment UUID.
+	IsStateServer() bool
+
+	// ProcessDyingEnviron checks if there are any machines or services left in
+	// state. If there are none, the environment's life is changed from dying to dead.
+	ProcessDyingEnviron() (err error)
+
+	// RemoveAllEnvironDocs removes all documents from multi-environment
+	// collections.
+	RemoveAllEnvironDocs() error
+}
+
+type stateShim struct {
+	*state.State
+}
+
+func (s *stateShim) Environment() (Environment, error) {
+	return s.State.Environment()
+}
+
+// Environment defines the needed methods of state.Environment for
+// the work of the undertaker API.
+type Environment interface {
+
+	// TimeOfDeath returns when the environment Life was set to Dead.
+	TimeOfDeath() time.Time
+
+	// Owner returns tag representing the owner of the environment.
+	// The owner is the user that created the environment.
+	Owner() names.UserTag
+
+	// Life returns whether the environment is Alive, Dying or Dead.
+	Life() state.Life
+
+	// Name returns the human friendly name of the environment.
+	Name() string
+
+	// UUID returns the universally unique identifier of the environment.
+	UUID() string
+
+	// Destroy sets the environment's lifecycle to Dying, preventing
+	// addition of services or machines to state.
+	Destroy() error
+}

--- a/apiserver/undertaker/undertaker_test.go
+++ b/apiserver/undertaker/undertaker_test.go
@@ -1,0 +1,149 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package undertaker_test
+
+import (
+	"github.com/juju/names"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/params"
+	apiservertesting "github.com/juju/juju/apiserver/testing"
+	"github.com/juju/juju/apiserver/undertaker"
+	"github.com/juju/juju/state"
+	coretesting "github.com/juju/juju/testing"
+)
+
+type undertakerSuite struct {
+	coretesting.BaseSuite
+}
+
+var _ = gc.Suite(&undertakerSuite{})
+
+func (s *undertakerSuite) setupStateAndAPI(c *gc.C, isSystem bool, envName string) (*mockState, *undertaker.UndertakerAPI) {
+	machineNo := "1"
+	if isSystem {
+		machineNo = "0"
+	}
+
+	authorizer := apiservertesting.FakeAuthorizer{
+		Tag:            names.NewMachineTag(machineNo),
+		EnvironManager: true,
+	}
+
+	st := newMockState(names.NewUserTag("dummy-admin"), envName, isSystem)
+	api, err := undertaker.NewUndertaker(st, nil, authorizer)
+	c.Assert(err, jc.ErrorIsNil)
+	return st, api
+}
+
+func (s *undertakerSuite) TestNoPerms(c *gc.C) {
+	for _, authorizer := range []apiservertesting.FakeAuthorizer{
+		apiservertesting.FakeAuthorizer{
+			Tag: names.NewMachineTag("0"),
+		},
+		apiservertesting.FakeAuthorizer{
+			Tag:            names.NewUserTag("bob"),
+			EnvironManager: true,
+		},
+	} {
+		st := newMockState(names.NewUserTag("dummy-admin"), "dummyenv", true)
+		_, err := undertaker.NewUndertaker(
+			st,
+			nil,
+			authorizer,
+		)
+		c.Assert(err, gc.ErrorMatches, "permission denied")
+	}
+}
+
+func (s *undertakerSuite) TestEnvironInfo(c *gc.C) {
+	otherSt, hostedAPI := s.setupStateAndAPI(c, false, "hostedenv")
+	st, api := s.setupStateAndAPI(c, true, "dummyenv")
+	for _, test := range []struct {
+		st       *mockState
+		api      *undertaker.UndertakerAPI
+		isSystem bool
+		envName  string
+	}{
+		{otherSt, hostedAPI, false, "hostedenv"},
+		{st, api, true, "dummyenv"},
+	} {
+		env, err := test.st.Environment()
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(env.Destroy(), jc.ErrorIsNil)
+
+		result, err := test.api.EnvironInfo()
+		c.Assert(err, jc.ErrorIsNil)
+
+		info := result.Result
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(result.Error, gc.IsNil)
+
+		c.Assert(info.UUID, gc.Equals, env.UUID())
+		c.Assert(info.GlobalName, gc.Equals, "user-dummy-admin/"+test.envName)
+		c.Assert(info.Name, gc.Equals, test.envName)
+		c.Assert(info.IsSystem, gc.Equals, test.isSystem)
+		c.Assert(info.Life, gc.Equals, params.Dying)
+		c.Assert(*info.TimeOfDeath, gc.Equals, env.TimeOfDeath())
+	}
+}
+
+func (s *undertakerSuite) TestProcessDyingEnviron(c *gc.C) {
+	otherSt, hostedAPI := s.setupStateAndAPI(c, false, "hostedenv")
+	env, err := otherSt.Environment()
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = hostedAPI.ProcessDyingEnviron()
+	c.Assert(err, gc.ErrorMatches, "environment is not dying")
+	c.Assert(env.Life(), gc.Equals, state.Alive)
+
+	err = env.Destroy()
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(env.Life(), gc.Equals, state.Dying)
+
+	err = hostedAPI.ProcessDyingEnviron()
+	c.Assert(err, gc.IsNil)
+	c.Assert(env.Life(), gc.Equals, state.Dead)
+}
+
+func (s *undertakerSuite) TestRemoveAliveEnviron(c *gc.C) {
+	otherSt, hostedAPI := s.setupStateAndAPI(c, false, "hostedenv")
+	_, err := otherSt.Environment()
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = hostedAPI.RemoveEnviron()
+	c.Assert(err, gc.ErrorMatches, "transaction aborted")
+}
+
+func (s *undertakerSuite) TestRemoveDyingEnviron(c *gc.C) {
+	otherSt, hostedAPI := s.setupStateAndAPI(c, false, "hostedenv")
+	env, err := otherSt.Environment()
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Set env to dying
+	err = env.Destroy()
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = hostedAPI.RemoveEnviron()
+	c.Assert(err, gc.ErrorMatches, "transaction aborted")
+}
+
+func (s *undertakerSuite) TestDeadRemoveEnviron(c *gc.C) {
+	otherSt, hostedAPI := s.setupStateAndAPI(c, false, "hostedenv")
+	env, err := otherSt.Environment()
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Set env to dead
+	err = env.Destroy()
+	c.Assert(err, jc.ErrorIsNil)
+	err = hostedAPI.ProcessDyingEnviron()
+	c.Assert(err, gc.IsNil)
+
+	err = hostedAPI.RemoveEnviron()
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(otherSt.removed, jc.IsTrue)
+}

--- a/state/environ_test.go
+++ b/state/environ_test.go
@@ -95,7 +95,7 @@ func (s *EnvironSuite) TestNewEnvironmentSameUserSameNameFails(c *gc.C) {
 	// Destroy only sets the environment to dying and RemoveAllEnvironDocs can
 	// only be called on a dead environment. Normally, the environ's lifecycle
 	// would be set to dead after machines and services have been cleaned up.
-	err = state.SetEnvLifeDying(st1, env1.EnvironTag().Id())
+	err = state.SetEnvLifeDead(st1, env1.EnvironTag().Id())
 	c.Assert(err, jc.ErrorIsNil)
 	err = st1.RemoveAllEnvironDocs()
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -339,11 +339,11 @@ func RemoveEnvironment(st *State, uuid string) error {
 	return st.runTransaction(ops)
 }
 
-func SetEnvLifeDying(st *State, envUUID string) error {
+func SetEnvLifeDead(st *State, envUUID string) error {
 	ops := []txn.Op{{
 		C:      environmentsC,
 		Id:     envUUID,
-		Update: bson.D{{"$set", bson.D{{"life", Dying}}}},
+		Update: bson.D{{"$set", bson.D{{"life", Dead}}}},
 	}}
 	return st.runTransaction(ops)
 }

--- a/state/state.go
+++ b/state/state.go
@@ -118,9 +118,13 @@ func (st *State) RemoveAllEnvironDocs() error {
 		Id:     id,
 		Remove: true,
 	}, {
-		C:      environmentsC,
-		Id:     st.EnvironUUID(),
-		Assert: bson.D{{"life", Dying}},
+		C:  environmentsC,
+		Id: st.EnvironUUID(),
+		// TODO(waigani) assert dead only before landing in master.
+		Assert: bson.D{{"$or", []bson.D{
+			bson.D{{"life", Dying}},
+			bson.D{{"life", Dead}},
+		}}},
 		Remove: true,
 	}}
 

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -2796,7 +2796,7 @@ func (s *StateSuite) TestRemoveAllEnvironDocs(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(n, gc.Equals, 1)
 
-	err = state.SetEnvLifeDying(st, st.EnvironUUID())
+	err = state.SetEnvLifeDead(st, st.EnvironUUID())
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = st.RemoveAllEnvironDocs()


### PR DESCRIPTION
Introduce the undertaker facade, used by the undertaker worker (to be
introduced in a follow up PR), to manage the take-down and removal of a
dying environment.

(Review request: http://reviews.vapour.ws/r/2649/)