### PR TITLE
Make the error match not look for linux specific error.

### DIFF
--- a/worker/metrics/sender/sender_test.go
+++ b/worker/metrics/sender/sender_test.go
@@ -127,7 +127,7 @@ func (s *senderSuite) TestNoSpoolDirectory(c *gc.C) {
 	metricSender := sender.NewSender(apiSender, metricfactory)
 	stopCh := make(chan struct{})
 	err := metricSender.Do(stopCh)
-	c.Assert(err, gc.ErrorMatches, `failed to open spool directory "/some/random/spool/dir": stat /some/random/spool/dir: no such file or directory`)
+	c.Assert(err, gc.ErrorMatches, `failed to open spool directory "/some/random/spool/dir": .*`)
 
 	c.Assert(apiSender.batches, gc.HasLen, 0)
 }


### PR DESCRIPTION
An exact error match was being checked causing a failure on windows.

Fixes lp:1494913

(Review request: http://reviews.vapour.ws/r/2650/)