### PR TITLE
Fix issue with status update watcher firing too many times

### DIFF
--- a/worker/uniter/operation/deploy_test.go
+++ b/worker/uniter/operation/deploy_test.go
@@ -326,11 +326,10 @@ func (s *DeploySuite) TestPrepareSuccess_Upgrade_PreserveNoHook(c *gc.C) {
 			newDeploy,
 			overwriteState,
 			operation.State{
-				Kind:             operation.Upgrade,
-				Step:             operation.Pending,
-				CharmURL:         curl("cs:quantal/nyancat-4"),
-				Started:          true,
-				UpdateStatusTime: 1234567,
+				Kind:     operation.Upgrade,
+				Step:     operation.Pending,
+				CharmURL: curl("cs:quantal/nyancat-4"),
+				Started:  true,
 			},
 		)
 	}
@@ -527,11 +526,10 @@ func (s *DeploySuite) TestExecuteSuccess_Upgrade_PreserveNoHook(c *gc.C) {
 			newDeploy,
 			overwriteState,
 			operation.State{
-				Kind:             operation.Upgrade,
-				Step:             operation.Done,
-				CharmURL:         curl("cs:quantal/lol-1"),
-				Started:          true,
-				UpdateStatusTime: 1234567,
+				Kind:     operation.Upgrade,
+				Step:     operation.Done,
+				CharmURL: curl("cs:quantal/lol-1"),
+				Started:  true,
 			},
 		)
 	}

--- a/worker/uniter/operation/runaction_test.go
+++ b/worker/uniter/operation/runaction_test.go
@@ -172,12 +172,11 @@ func (s *RunActionSuite) TestPrepareSuccessDirtyState(c *gc.C) {
 	newState, err := op.Prepare(overwriteState)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(newState, jc.DeepEquals, &operation.State{
-		Kind:             operation.RunAction,
-		Step:             operation.Pending,
-		ActionId:         &someActionId,
-		Started:          true,
-		UpdateStatusTime: 1234567,
-		Hook:             &hook.Info{Kind: hooks.Install},
+		Kind:     operation.RunAction,
+		Step:     operation.Pending,
+		ActionId: &someActionId,
+		Started:  true,
+		Hook:     &hook.Info{Kind: hooks.Install},
 	})
 	c.Assert(*runnerFactory.MockNewActionRunner.gotActionId, gc.Equals, someActionId)
 }
@@ -198,12 +197,11 @@ func (s *RunActionSuite) TestExecuteSuccess(c *gc.C) {
 		description: "preserves appropriate fields",
 		before:      overwriteState,
 		after: operation.State{
-			Kind:             operation.RunAction,
-			Step:             operation.Done,
-			ActionId:         &someActionId,
-			Hook:             &hook.Info{Kind: hooks.Install},
-			Started:          true,
-			UpdateStatusTime: 1234567,
+			Kind:     operation.RunAction,
+			Step:     operation.Done,
+			ActionId: &someActionId,
+			Hook:     &hook.Info{Kind: hooks.Install},
+			Started:  true,
 		},
 	}}
 
@@ -243,36 +241,32 @@ func (s *RunActionSuite) TestCommit(c *gc.C) {
 	}, {
 		description: "preserves only appropriate fields, no hook",
 		before: operation.State{
-			Kind:             operation.Continue,
-			Step:             operation.Pending,
-			Started:          true,
-			UpdateStatusTime: 1234567,
-			CharmURL:         curl("cs:quantal/wordpress-2"),
-			ActionId:         &randomActionId,
+			Kind:     operation.Continue,
+			Step:     operation.Pending,
+			Started:  true,
+			CharmURL: curl("cs:quantal/wordpress-2"),
+			ActionId: &randomActionId,
 		},
 		after: operation.State{
-			Kind:             operation.Continue,
-			Step:             operation.Pending,
-			Started:          true,
-			UpdateStatusTime: 1234567,
+			Kind:    operation.Continue,
+			Step:    operation.Pending,
+			Started: true,
 		},
 	}, {
 		description: "preserves only appropriate fields, with hook",
 		before: operation.State{
-			Kind:             operation.Continue,
-			Step:             operation.Pending,
-			Started:          true,
-			UpdateStatusTime: 1234567,
-			CharmURL:         curl("cs:quantal/wordpress-2"),
-			ActionId:         &randomActionId,
-			Hook:             &hook.Info{Kind: hooks.Install},
+			Kind:     operation.Continue,
+			Step:     operation.Pending,
+			Started:  true,
+			CharmURL: curl("cs:quantal/wordpress-2"),
+			ActionId: &randomActionId,
+			Hook:     &hook.Info{Kind: hooks.Install},
 		},
 		after: operation.State{
-			Kind:             operation.RunHook,
-			Step:             operation.Pending,
-			Hook:             &hook.Info{Kind: hooks.Install},
-			Started:          true,
-			UpdateStatusTime: 1234567,
+			Kind:    operation.RunHook,
+			Step:    operation.Pending,
+			Hook:    &hook.Info{Kind: hooks.Install},
+			Started: true,
 		},
 	}}
 

--- a/worker/uniter/operation/runhook.go
+++ b/worker/uniter/operation/runhook.go
@@ -5,7 +5,6 @@ package operation
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/juju/errors"
 	"gopkg.in/juju/charm.v5/hooks"
@@ -221,8 +220,6 @@ func (rh *runHook) Commit(state State) (*State, error) {
 		newState.Started = true
 	case hooks.Stop:
 		newState.Stopped = true
-	case hooks.UpdateStatus:
-		newState.UpdateStatusTime = time.Now().Unix()
 	}
 
 	return newState, nil

--- a/worker/uniter/operation/runhook_test.go
+++ b/worker/uniter/operation/runhook_test.go
@@ -4,8 +4,6 @@
 package operation_test
 
 import (
-	"time"
-
 	"github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -172,11 +170,10 @@ func (s *RunHookSuite) TestPrepareSuccess_Preserve(c *gc.C) {
 		(operation.Factory).NewRunHook,
 		overwriteState,
 		operation.State{
-			Started:          true,
-			UpdateStatusTime: 1234567,
-			Kind:             operation.RunHook,
-			Step:             operation.Pending,
-			Hook:             &hook.Info{Kind: hooks.ConfigChanged},
+			Started: true,
+			Kind:    operation.RunHook,
+			Step:    operation.Pending,
+			Hook:    &hook.Info{Kind: hooks.ConfigChanged},
 		},
 	)
 }
@@ -307,12 +304,11 @@ func (s *RunHookSuite) TestExecuteSuccess_Preserve(c *gc.C) {
 	s.testExecuteSuccess(c,
 		overwriteState,
 		operation.State{
-			Started:          true,
-			UpdateStatusTime: 1234567,
-			Kind:             operation.RunHook,
-			Step:             operation.Done,
-			Hook:             &hook.Info{Kind: hooks.ConfigChanged},
-			StatusSet:        true,
+			Started:   true,
+			Kind:      operation.RunHook,
+			Step:      operation.Done,
+			Hook:      &hook.Info{Kind: hooks.ConfigChanged},
+			StatusSet: true,
 		},
 		true,
 	)
@@ -399,12 +395,11 @@ func (s *RunHookSuite) testExecuteHookWithSetStatus(c *gc.C, kind hooks.Kind, se
 	s.testExecuteThenCharmStatus(c,
 		overwriteState,
 		operation.State{
-			Started:          true,
-			UpdateStatusTime: 1234567,
-			Kind:             operation.RunHook,
-			Step:             operation.Done,
-			Hook:             &hook.Info{Kind: kind},
-			StatusSet:        setStatusCalled,
+			Started:   true,
+			Kind:      operation.RunHook,
+			Step:      operation.Done,
+			Hook:      &hook.Info{Kind: kind},
+			StatusSet: setStatusCalled,
 		},
 		kind,
 		setStatusCalled,
@@ -487,10 +482,9 @@ func (s *RunHookSuite) TestCommitSuccess_ConfigChanged_Preserve(c *gc.C) {
 			hook.Info{Kind: hooks.ConfigChanged},
 			overwriteState,
 			operation.State{
-				Started:          true,
-				UpdateStatusTime: 1234567,
-				Kind:             operation.Continue,
-				Step:             operation.Pending,
+				Started: true,
+				Kind:    operation.Continue,
+				Step:    operation.Pending,
 			},
 		)
 	}
@@ -526,10 +520,9 @@ func (s *RunHookSuite) TestCommitSuccess_Start_Preserve(c *gc.C) {
 			hook.Info{Kind: hooks.Start},
 			overwriteState,
 			operation.State{
-				Started:          true,
-				UpdateStatusTime: 1234567,
-				Kind:             operation.Continue,
-				Step:             operation.Pending,
+				Started: true,
+				Kind:    operation.Continue,
+				Step:    operation.Pending,
 			},
 		)
 	}
@@ -580,12 +573,11 @@ func (s *RunHookSuite) testQueueHook_Preserve(c *gc.C, cause hooks.Kind) {
 			hook.Info{Kind: cause},
 			overwriteState,
 			operation.State{
-				Kind:             operation.RunHook,
-				Step:             operation.Queued,
-				Started:          true,
-				Stopped:          cause == hooks.Stop,
-				Hook:             hi,
-				UpdateStatusTime: 1234567,
+				Kind:    operation.RunHook,
+				Step:    operation.Queued,
+				Started: true,
+				Stopped: cause == hooks.Stop,
+				Hook:    hi,
 			},
 		)
 	}
@@ -630,12 +622,11 @@ func (s *RunHookSuite) testQueueNothing_Preserve(c *gc.C, hookInfo hook.Info) {
 			hookInfo,
 			overwriteState,
 			operation.State{
-				Kind:             operation.Continue,
-				Step:             operation.Pending,
-				Installed:        hookInfo.Kind == hooks.Install,
-				Started:          true,
-				Stopped:          hookInfo.Kind == hooks.Stop,
-				UpdateStatusTime: 1234567,
+				Kind:      operation.Continue,
+				Step:      operation.Pending,
+				Installed: hookInfo.Kind == hooks.Install,
+				Started:   true,
+				Stopped:   hookInfo.Kind == hooks.Stop,
 			},
 		)
 	}
@@ -717,43 +708,6 @@ func (s *RunHookSuite) TestQueueNothing_RelationBroken_Preserve(c *gc.C) {
 	s.testQueueNothing_Preserve(c, hook.Info{
 		Kind: hooks.RelationBroken,
 	})
-}
-
-func (s *RunHookSuite) testCommitSuccess_UpdateStatusTime(c *gc.C, newHook newHook) {
-	callbacks := &CommitHookCallbacks{
-		MockCommitHook: &MockCommitHook{},
-	}
-	factory := operation.NewFactory(operation.FactoryParams{
-		Callbacks: callbacks,
-	})
-	op, err := newHook(factory, hook.Info{Kind: hooks.UpdateStatus})
-	c.Assert(err, jc.ErrorIsNil)
-
-	nowBefore := time.Now().Unix()
-	newState, err := op.Commit(overwriteState)
-	c.Assert(err, jc.ErrorIsNil)
-
-	nowAfter := time.Now().Unix()
-	nowWritten := newState.UpdateStatusTime
-	c.Logf("%d <= %d <= %d", nowBefore, nowWritten, nowAfter)
-	c.Check(nowBefore <= nowWritten, jc.IsTrue)
-	c.Check(nowWritten <= nowAfter, jc.IsTrue)
-
-	// Check the other fields match.
-	newState.UpdateStatusTime = 0
-	c.Check(newState, gc.DeepEquals, &operation.State{
-		Started: true,
-		Kind:    operation.Continue,
-		Step:    operation.Pending,
-	})
-}
-
-func (s *RunHookSuite) TestCommitSuccess_UpdateStatusTime_Run(c *gc.C) {
-	s.testCommitSuccess_UpdateStatusTime(c, (operation.Factory).NewRunHook)
-}
-
-func (s *RunHookSuite) TestCommitSuccess_UpdateStatusTime_Skip(c *gc.C) {
-	s.testCommitSuccess_UpdateStatusTime(c, (operation.Factory).NewSkipHook)
 }
 
 func (s *RunHookSuite) testNeedsGlobalMachineLock(c *gc.C, newHook newHook, expected bool) {

--- a/worker/uniter/operation/state.go
+++ b/worker/uniter/operation/state.go
@@ -93,10 +93,6 @@ type State struct {
 	// Charm describes the charm being deployed by an Install or Upgrade
 	// operation, and is otherwise blank.
 	CharmURL *charm.URL `yaml:"charm,omitempty"`
-
-	// UpdateStatusTime records the time the update status hook was last run.
-	// It's set to nil if the hook was not run at all.
-	UpdateStatusTime int64 `yaml:"updatestatustime,omitempty"`
 }
 
 // validate returns an error if the state violates expectations.

--- a/worker/uniter/operation/util_test.go
+++ b/worker/uniter/operation/util_test.go
@@ -458,13 +458,12 @@ var curl = corecharm.MustParseURL
 var someActionId = "f47ac10b-58cc-4372-a567-0e02b2c3d479"
 var randomActionId = "9f484882-2f18-4fd2-967d-db9663db7bea"
 var overwriteState = operation.State{
-	Kind:             operation.Continue,
-	Step:             operation.Pending,
-	Started:          true,
-	UpdateStatusTime: 1234567,
-	CharmURL:         curl("cs:quantal/wordpress-2"),
-	ActionId:         &randomActionId,
-	Hook:             &hook.Info{Kind: hooks.Install},
+	Kind:     operation.Continue,
+	Step:     operation.Pending,
+	Started:  true,
+	CharmURL: curl("cs:quantal/wordpress-2"),
+	ActionId: &randomActionId,
+	Hook:     &hook.Info{Kind: hooks.Install},
 }
 var someCommandArgs = operation.CommandArgs{
 	Commands:        "do something",

--- a/worker/uniter/remotestate/watcher.go
+++ b/worker/uniter/remotestate/watcher.go
@@ -51,10 +51,6 @@ type WatcherConfig struct {
 	UnitTag             names.UnitTag
 }
 
-// TimedSignal is the signature of a function used to generate a
-// hook signal.
-type TimedSignal func(now, lastSignal time.Time, interval time.Duration) <-chan time.Time
-
 // NewWatcher returns a RemoteStateWatcher that handles state changes pertaining to the
 // supplied unit.
 func NewWatcher(config WatcherConfig) (*RemoteStateWatcher, error) {

--- a/worker/uniter/timer.go
+++ b/worker/uniter/timer.go
@@ -12,17 +12,12 @@ const (
 	statusPollInterval = 5 * time.Minute
 )
 
-// Signal is the signature of a function used to generate a
-// hook signal.
-type TimedSignal func(now, lastSignal time.Time, interval time.Duration) <-chan time.Time
-
 // updateStatusSignal returns a time channel that fires after a given interval.
-func updateStatusSignal(now, lastSignal time.Time, interval time.Duration) <-chan time.Time {
-	waitDuration := interval - now.Sub(lastSignal)
-	return time.After(waitDuration)
+func updateStatusSignal() <-chan time.Time {
+	return time.After(statusPollInterval)
 }
 
 // NewUpdateStatusTimer returns a timed signal suitable for update-status hook.
-func NewUpdateStatusTimer() TimedSignal {
+func NewUpdateStatusTimer() func() <-chan time.Time {
 	return updateStatusSignal
 }

--- a/worker/uniter/util_test.go
+++ b/worker/uniter/util_test.go
@@ -1828,8 +1828,8 @@ func (t *manualTicker) Tick() error {
 	return nil
 }
 
-// ReturnTimer can be used to replace the metrics signal generator.
-func (t *manualTicker) ReturnTimer(now, lastRun time.Time, interval time.Duration) <-chan time.Time {
+// ReturnTimer can be used to replace the update status signal generator.
+func (t *manualTicker) ReturnTimer() <-chan time.Time {
 	return t.c
 }
 


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/juju-core/+bug/1494356

The update status hook was firing too often. Instead of porting the original implementation using the timer used for metrics, we introduce a simpler approach. Fire the timer every poll interval without accounting for the last time the timer was fired; we simply use a counter to record the trigger and when the uniter is otherwise idle, run the update status hook if the counters differ.

(Review request: http://reviews.vapour.ws/r/2652/)