### PR TITLE
{api/apiserver}/storage: update StorageDetails to match model

### DIFF
--- a/api/storage/client.go
+++ b/api/storage/client.go
@@ -29,7 +29,7 @@ func NewClient(st base.APICallCloser) *Client {
 }
 
 // Show retrieves information about desired storage instances.
-func (c *Client) Show(tags []names.StorageTag) ([]params.StorageDetails, error) {
+func (c *Client) Show(tags []names.StorageTag) ([]params.StorageDetailsResult, error) {
 	found := params.StorageDetailsResults{}
 	entities := make([]params.Entity, len(tags))
 	for i, tag := range tags {
@@ -38,20 +38,7 @@ func (c *Client) Show(tags []names.StorageTag) ([]params.StorageDetails, error) 
 	if err := c.facade.FacadeCall("Show", params.Entities{Entities: entities}, &found); err != nil {
 		return nil, errors.Trace(err)
 	}
-	return c.convert(found.Results)
-}
-
-func (c *Client) convert(found []params.StorageDetailsResult) ([]params.StorageDetails, error) {
-	var storages []params.StorageDetails
-	var allErr params.ErrorResults
-	for _, result := range found {
-		if result.Error != nil {
-			allErr.Results = append(allErr.Results, params.ErrorResult{result.Error})
-			continue
-		}
-		storages = append(storages, result.Result)
-	}
-	return storages, allErr.Combine()
+	return found.Results, nil
 }
 
 // List lists all storage.

--- a/api/storage/client.go
+++ b/api/storage/client.go
@@ -55,8 +55,8 @@ func (c *Client) convert(found []params.StorageDetailsResult) ([]params.StorageD
 }
 
 // List lists all storage.
-func (c *Client) List() ([]params.StorageInfo, error) {
-	found := params.StorageInfosResult{}
+func (c *Client) List() ([]params.StorageDetailsResult, error) {
+	found := params.StorageDetailsResults{}
 	if err := c.facade.FacadeCall("List", nil, &found); err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/api/storage/client.go
+++ b/api/storage/client.go
@@ -89,13 +89,13 @@ func (c *Client) CreatePool(pname, provider string, attrs map[string]interface{}
 
 // ListVolumes lists volumes for desired machines.
 // If no machines provided, a list of all volumes is returned.
-func (c *Client) ListVolumes(machines []string) ([]params.VolumeItem, error) {
+func (c *Client) ListVolumes(machines []string) ([]params.VolumeDetailsResult, error) {
 	tags := make([]string, len(machines))
 	for i, one := range machines {
 		tags[i] = names.NewMachineTag(one).String()
 	}
 	args := params.VolumeFilter{Machines: tags}
-	found := params.VolumeItemsResult{}
+	found := params.VolumeDetailsResults{}
 	if err := c.facade.FacadeCall("ListVolumes", args, &found); err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/api/storage/client_test.go
+++ b/api/storage/client_test.go
@@ -317,15 +317,15 @@ func (s *storageMockSuite) TestListVolumes(c *gc.C) {
 			args := a.(params.VolumeFilter)
 			c.Assert(args.Machines, gc.HasLen, 2)
 
-			c.Assert(result, gc.FitsTypeOf, &params.VolumeItemsResult{})
-			results := result.(*params.VolumeItemsResult)
+			c.Assert(result, gc.FitsTypeOf, &params.VolumeDetailsResults{})
+			results := result.(*params.VolumeDetailsResults)
 			attachments := make([]params.VolumeAttachment, len(args.Machines))
 			for i, m := range args.Machines {
 				attachments[i] = params.VolumeAttachment{
 					MachineTag: m}
 			}
-			results.Results = []params.VolumeItem{
-				params.VolumeItem{Attachments: attachments},
+			results.Results = []params.VolumeDetailsResult{
+				params.VolumeDetailsResult{LegacyAttachments: attachments},
 			}
 			return nil
 		})
@@ -334,9 +334,9 @@ func (s *storageMockSuite) TestListVolumes(c *gc.C) {
 	c.Assert(called, jc.IsTrue)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(found, gc.HasLen, 1)
-	c.Assert(found[0].Attachments, gc.HasLen, len(machines))
-	c.Assert(machineTags.Contains(found[0].Attachments[0].MachineTag), jc.IsTrue)
-	c.Assert(machineTags.Contains(found[0].Attachments[1].MachineTag), jc.IsTrue)
+	c.Assert(found[0].LegacyAttachments, gc.HasLen, len(machines))
+	c.Assert(machineTags.Contains(found[0].LegacyAttachments[0].MachineTag), jc.IsTrue)
+	c.Assert(machineTags.Contains(found[0].LegacyAttachments[1].MachineTag), jc.IsTrue)
 }
 
 func (s *storageMockSuite) TestListVolumesEmptyFilter(c *gc.C) {
@@ -357,10 +357,10 @@ func (s *storageMockSuite) TestListVolumesEmptyFilter(c *gc.C) {
 			args := a.(params.VolumeFilter)
 			c.Assert(args.IsEmpty(), jc.IsTrue)
 
-			c.Assert(result, gc.FitsTypeOf, &params.VolumeItemsResult{})
-			results := result.(*params.VolumeItemsResult)
-			results.Results = []params.VolumeItem{
-				{Volume: params.VolumeInstance{VolumeTag: tag}},
+			c.Assert(result, gc.FitsTypeOf, &params.VolumeDetailsResults{})
+			results := result.(*params.VolumeDetailsResults)
+			results.Results = []params.VolumeDetailsResult{
+				{LegacyVolume: &params.LegacyVolumeDetails{VolumeTag: tag}},
 			}
 			return nil
 		})
@@ -369,7 +369,7 @@ func (s *storageMockSuite) TestListVolumesEmptyFilter(c *gc.C) {
 	c.Assert(called, jc.IsTrue)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(found, gc.HasLen, 1)
-	c.Assert(found[0].Volume.VolumeTag, gc.Equals, tag)
+	c.Assert(found[0].LegacyVolume.VolumeTag, gc.Equals, tag)
 }
 
 func (s *storageMockSuite) TestListVolumesFacadeCallError(c *gc.C) {

--- a/api/storage/client_test.go
+++ b/api/storage/client_test.go
@@ -50,16 +50,20 @@ func (s *storageMockSuite) TestShow(c *gc.C) {
 			if results, k := result.(*params.StorageDetailsResults); k {
 				instances := []params.StorageDetailsResult{
 					params.StorageDetailsResult{
-						Result: params.StorageDetails{StorageTag: oneTag.String()},
+						Result: &params.StorageDetails{StorageTag: oneTag.String()},
 					},
 					params.StorageDetailsResult{
-						Result: params.StorageDetails{
+						Result: &params.StorageDetails{
 							StorageTag: twoTag.String(),
-							Status:     "attached",
+							Status: params.EntityStatus{
+								Status: "attached",
+							},
 							Persistent: true,
 						},
 					},
-					params.StorageDetailsResult{Error: common.ServerError(errors.New(msg))},
+					params.StorageDetailsResult{
+						Error: common.ServerError(errors.New(msg)),
+					},
 				}
 				results.Results = instances
 			}
@@ -69,10 +73,11 @@ func (s *storageMockSuite) TestShow(c *gc.C) {
 	storageClient := storage.NewClient(apiCaller)
 	tags := []names.StorageTag{oneTag, twoTag}
 	found, err := storageClient.Show(tags)
-	c.Check(errors.Cause(err), gc.ErrorMatches, msg)
-	c.Assert(found, gc.HasLen, 2)
-	c.Assert(expected.Contains(found[0].StorageTag), jc.IsTrue)
-	c.Assert(expected.Contains(found[1].StorageTag), jc.IsTrue)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(found, gc.HasLen, 3)
+	c.Assert(expected.Contains(found[0].Result.StorageTag), jc.IsTrue)
+	c.Assert(expected.Contains(found[1].Result.StorageTag), jc.IsTrue)
+	c.Assert(found[2].Error, gc.ErrorMatches, msg)
 }
 
 func (s *storageMockSuite) TestShowFacadeCallError(c *gc.C) {
@@ -99,10 +104,7 @@ func (s *storageMockSuite) TestShowFacadeCallError(c *gc.C) {
 }
 
 func (s *storageMockSuite) TestList(c *gc.C) {
-	one := "shared-fs/0"
-	oneTag := names.NewStorageTag(one)
-	two := "db-dir/1000"
-	twoTag := names.NewStorageTag(two)
+	storageTag := names.NewStorageTag("db-dir/1000")
 	msg := "call failure"
 
 	apiCaller := basetesting.APICallerFunc(
@@ -118,15 +120,15 @@ func (s *storageMockSuite) TestList(c *gc.C) {
 
 			if results, k := result.(*params.StorageDetailsResults); k {
 				instances := []params.StorageDetailsResult{{
-					params.StorageDetails{StorageTag: oneTag.String()},
-					common.ServerError(errors.New(msg)),
+					Error: common.ServerError(errors.New(msg)),
 				}, {
-					params.StorageDetails{
-						StorageTag: twoTag.String(),
-						Status:     "attached",
+					Result: &params.StorageDetails{
+						StorageTag: storageTag.String(),
+						Status: params.EntityStatus{
+							Status: "attached",
+						},
 						Persistent: true,
 					},
-					nil,
 				}}
 				results.Results = instances
 			}
@@ -138,16 +140,15 @@ func (s *storageMockSuite) TestList(c *gc.C) {
 	c.Check(err, jc.ErrorIsNil)
 	c.Assert(found, gc.HasLen, 2)
 	expected := []params.StorageDetailsResult{{
-		params.StorageDetails{
-			StorageTag: "storage-shared-fs-0"},
-		&params.Error{Message: msg},
+		Error: &params.Error{Message: msg},
 	}, {
-		params.StorageDetails{
+		Result: &params.StorageDetails{
 			StorageTag: "storage-db-dir-1000",
-			Status:     "attached",
+			Status: params.EntityStatus{
+				Status: "attached",
+			},
 			Persistent: true,
 		},
-		nil,
 	}}
 
 	c.Assert(found, jc.DeepEquals, expected)

--- a/api/storage/client_test.go
+++ b/api/storage/client_test.go
@@ -116,21 +116,18 @@ func (s *storageMockSuite) TestList(c *gc.C) {
 			c.Check(request, gc.Equals, "List")
 			c.Check(a, gc.IsNil)
 
-			if results, k := result.(*params.StorageInfosResult); k {
-				instances := []params.StorageInfo{
-					params.StorageInfo{
-						params.StorageDetails{StorageTag: oneTag.String()},
-						common.ServerError(errors.New(msg)),
+			if results, k := result.(*params.StorageDetailsResults); k {
+				instances := []params.StorageDetailsResult{{
+					params.StorageDetails{StorageTag: oneTag.String()},
+					common.ServerError(errors.New(msg)),
+				}, {
+					params.StorageDetails{
+						StorageTag: twoTag.String(),
+						Status:     "attached",
+						Persistent: true,
 					},
-					params.StorageInfo{
-						params.StorageDetails{
-							StorageTag: twoTag.String(),
-							Status:     "attached",
-							Persistent: true,
-						},
-						nil,
-					},
-				}
+					nil,
+				}}
 				results.Results = instances
 			}
 
@@ -140,19 +137,18 @@ func (s *storageMockSuite) TestList(c *gc.C) {
 	found, err := storageClient.List()
 	c.Check(err, jc.ErrorIsNil)
 	c.Assert(found, gc.HasLen, 2)
-	expected := []params.StorageInfo{
-		params.StorageInfo{
-			StorageDetails: params.StorageDetails{
-				StorageTag: "storage-shared-fs-0"},
-			Error: &params.Error{Message: msg},
+	expected := []params.StorageDetailsResult{{
+		params.StorageDetails{
+			StorageTag: "storage-shared-fs-0"},
+		&params.Error{Message: msg},
+	}, {
+		params.StorageDetails{
+			StorageTag: "storage-db-dir-1000",
+			Status:     "attached",
+			Persistent: true,
 		},
-		params.StorageInfo{
-			params.StorageDetails{
-				StorageTag: "storage-db-dir-1000",
-				Status:     "attached",
-				Persistent: true},
-			nil},
-	}
+		nil,
+	}}
 
 	c.Assert(found, jc.DeepEquals, expected)
 }

--- a/apiserver/common/volumes.go
+++ b/apiserver/common/volumes.go
@@ -129,13 +129,18 @@ func VolumeFromState(v state.Volume) (params.Volume, error) {
 	}
 	return params.Volume{
 		v.VolumeTag().String(),
-		params.VolumeInfo{
-			info.VolumeId,
-			info.HardwareId,
-			info.Size,
-			info.Persistent,
-		},
+		VolumeInfoFromState(info),
 	}, nil
+}
+
+// VolumeInfoFromState converts a state.VolumeInfo to params.VolumeInfo.
+func VolumeInfoFromState(info state.VolumeInfo) params.VolumeInfo {
+	return params.VolumeInfo{
+		info.VolumeId,
+		info.HardwareId,
+		info.Size,
+		info.Persistent,
+	}
 }
 
 // VolumeAttachmentFromState converts a state.VolumeAttachment to params.VolumeAttachment.
@@ -147,12 +152,17 @@ func VolumeAttachmentFromState(v state.VolumeAttachment) (params.VolumeAttachmen
 	return params.VolumeAttachment{
 		v.Volume().String(),
 		v.Machine().String(),
-		params.VolumeAttachmentInfo{
-			info.DeviceName,
-			info.BusAddress,
-			info.ReadOnly,
-		},
+		VolumeAttachmentInfoFromState(info),
 	}, nil
+}
+
+// VolumeAttachmentInfoFromState converts a state.VolumeAttachmentInfo to params.VolumeAttachmentInfo.
+func VolumeAttachmentInfoFromState(info state.VolumeAttachmentInfo) params.VolumeAttachmentInfo {
+	return params.VolumeAttachmentInfo{
+		info.DeviceName,
+		info.BusAddress,
+		info.ReadOnly,
+	}
 }
 
 // VolumeAttachmentInfosToState converts a map of volume tags to

--- a/apiserver/params/storage.go
+++ b/apiserver/params/storage.go
@@ -391,7 +391,33 @@ type FilesystemAttachmentParamsResults struct {
 
 // StorageDetails holds information about storage.
 type StorageDetails struct {
+	// StorageTag holds tag for this storage.
+	StorageTag string `json:"storagetag"`
 
+	// OwnerTag holds tag for the owner of this storage, unit or service.
+	OwnerTag string `json:"ownertag"`
+
+	// Kind holds what kind of storage this instance is.
+	Kind StorageKind `json:"kind"`
+
+	// Status contains the status of the storage instance.
+	Status EntityStatus `json:"status"`
+
+	// Persistent reports whether or not the underlying volume or
+	// filesystem is persistent; i.e. whether or not it outlives
+	// the machine that it is attached to.
+	Persistent bool
+
+	// Attachments contains a mapping from unit tag to
+	// storage attachment details.
+	Attachments map[string]StorageAttachmentDetails `json:"attachments,omitempty"`
+}
+
+// LegacyStorageDetails holds information about storage.
+//
+// NOTE(axw): this is for backwards compatibility only. This struct
+// should not be changed!
+type LegacyStorageDetails struct {
 	// StorageTag holds tag for this storage.
 	StorageTag string `json:"storagetag"`
 
@@ -417,13 +443,30 @@ type StorageDetails struct {
 // StorageDetailsResult holds information about a storage instance
 // or error related to its retrieval.
 type StorageDetailsResult struct {
-	Result StorageDetails `json:"result"`
-	Error  *Error         `json:"error,omitempty"`
+	Result *StorageDetails      `json:"details,omitempty"`
+	Legacy LegacyStorageDetails `json:"result"`
+	Error  *Error               `json:"error,omitempty"`
 }
 
 // StorageDetailsResults holds results for storage details or related storage error.
 type StorageDetailsResults struct {
 	Results []StorageDetailsResult `json:"results,omitempty"`
+}
+
+// StorageAttachmentDetails holds detailed information about a storage attachment.
+type StorageAttachmentDetails struct {
+	// StorageTag is the tag of the storage instance.
+	StorageTag string `json:"storagetag"`
+
+	// UnitTag is the tag of the unit attached to the storage instance.
+	UnitTag string `json:"unittag"`
+
+	// MachineTag is the tag of the machine that the attached unit is assigned to.
+	MachineTag string `json:"machinetag"`
+
+	// Location holds location (mount point/device path) of
+	// the attached storage.
+	Location string `json:"location,omitempty"`
 }
 
 // StoragePool holds data for a pool instance.
@@ -504,7 +547,7 @@ type VolumeDetails struct {
 // specific to the volume model, whereas LegacyVolumeDetails is intended
 // to contain complete information about a volume.
 //
-// NOTE: this is for backwards compatibility only. This struct
+// NOTE(axw): this is for backwards compatibility only. This struct
 // should not be changed!
 type LegacyVolumeDetails struct {
 
@@ -545,7 +588,7 @@ type VolumeDetailsResult struct {
 
 	// LegacyVolume describes the volume in detail.
 	//
-	// NOTE: VolumeDetails contains redundant and nonsensical
+	// NOTE(axw): VolumeDetails contains redundant and nonsensical
 	// information. Use Details if it is available, and only use
 	// this for backwards-compatibility.
 	LegacyVolume *LegacyVolumeDetails `json:"volume,omitempty"`
@@ -553,7 +596,7 @@ type VolumeDetailsResult struct {
 	// LegacyAttachments describes the attachments of the volume to
 	// machines.
 	//
-	// NOTE: this should have gone into VolumeDetails, but it's too
+	// NOTE(axw): this should have gone into VolumeDetails, but it's too
 	// late for that now. We'll continue to populate it, and use it
 	// if it's defined but Volume.Attachments is not. Please do not
 	// copy this structure.

--- a/apiserver/params/storage.go
+++ b/apiserver/params/storage.go
@@ -426,18 +426,6 @@ type StorageDetailsResults struct {
 	Results []StorageDetailsResult `json:"results,omitempty"`
 }
 
-// StorageInfo contains information about a storage as well as
-// potentially an error related to information retrieval.
-type StorageInfo struct {
-	StorageDetails `json:"result"`
-	Error          *Error `json:"error,omitempty"`
-}
-
-// StorageInfosResult holds storage details.
-type StorageInfosResult struct {
-	Results []StorageInfo `json:"results,omitempty"`
-}
-
 // StoragePool holds data for a pool instance.
 type StoragePool struct {
 

--- a/apiserver/params/storage.go
+++ b/apiserver/params/storage.go
@@ -477,27 +477,51 @@ func (f *VolumeFilter) IsEmpty() bool {
 	return len(f.Machines) == 0
 }
 
-// VolumeInstance describes a storage volume in the environment
+// VolumeDetails describes a storage volume in the environment
 // for the purpose of volume CLI commands.
-// It is kept separate from Volume which is primarily used in uniter
-// and may answer different concerns as well as serve different purposes.
-type VolumeInstance struct {
+//
+// This is kept separate from Volume which contains only information
+// specific to the volume model, whereas VolumeDetails is intended
+// to contain complete information about a volume and related
+// information (status, attachments, storage).
+type VolumeDetails struct {
+
+	// VolumeTag is the tag for the volume.
+	VolumeTag string `json:"volumetag"`
+
+	// Info contains information about the volume.
+	Info VolumeInfo `json:"info"`
+
+	// Status contains the status of the volume.
+	Status EntityStatus `json:"status"`
+
+	// MachineAttachments contains a mapping from
+	// machine tag to volume attachment information.
+	MachineAttachments map[string]VolumeAttachmentInfo `json:"machineattachments,omitempty"`
+
+	// StorageTag is the tag of the storage instance
+	// that the volume is assigned to, if any.
+	StorageTag string `json:"storagetag,omitempty"`
+
+	// StorageOwnerTag is the tag of the entity that
+	// owns the volume's assigned storage instance,
+	// if any.
+	StorageOwnerTag string `json:"ownertag,omitempty"`
+}
+
+// LegacyVolumeDetails describes a storage volume in the environment
+// for the purpose of volume CLI commands.
+//
+// This is kept separate from Volume which contains only information
+// specific to the volume model, whereas LegacyVolumeDetails is intended
+// to contain complete information about a volume.
+//
+// NOTE: this is for backwards compatibility only. This struct
+// should not be changed!
+type LegacyVolumeDetails struct {
 
 	// VolumeTag is tag for this volume instance.
 	VolumeTag string `json:"volumetag"`
-
-	// VolumeId is a unique provider-supplied ID for the volume.
-	VolumeId string `json:"volumeid"`
-
-	// HardwareId is the volume's hardware ID.
-	HardwareId string `json:"hardwareid,omitempty"`
-
-	// Size is the size of the volume in MiB.
-	Size uint64 `json:"size"`
-
-	// Persistent reflects whether the volume is destroyed with the
-	// machine to which it is attached.
-	Persistent bool `json:"persistent"`
 
 	// StorageInstance returns the tag of the storage instance that this
 	// volume is assigned to, if any.
@@ -507,26 +531,53 @@ type VolumeInstance struct {
 	// for this volume.
 	UnitTag string `json:"unit,omitempty"`
 
+	// VolumeId is a unique provider-supplied ID for the volume.
+	VolumeId string `json:"volumeid,omitempty"`
+
+	// HardwareId is the volume's hardware ID.
+	HardwareId string `json:"hardwareid,omitempty"`
+
+	// Size is the size of the volume in MiB.
+	Size uint64 `json:"size,omitempty"`
+
+	// Persistent reflects whether the volume is destroyed with the
+	// machine to which it is attached.
+	Persistent bool `json:"persistent"`
+
 	// Status contains the current status of the volume.
 	Status EntityStatus `json:"status"`
 }
 
-// VolumeItem contain volume, its attachments
-// and retrieval error.
-type VolumeItem struct {
-	// Volume is storage volume.
-	Volume VolumeInstance `json:"volume,omitempty"`
+// VolumeDetailsResult contains details about a volume, its attachments or
+// an error preventing retrieving those details.
+type VolumeDetailsResult struct {
 
-	// Attachments are storage volume attachments.
-	Attachments []VolumeAttachment `json:"attachments,omitempty"`
+	// Details describes the volume in detail.
+	Details *VolumeDetails `json:"details,omitempty"`
+
+	// LegacyVolume describes the volume in detail.
+	//
+	// NOTE: VolumeDetails contains redundant and nonsensical
+	// information. Use Details if it is available, and only use
+	// this for backwards-compatibility.
+	LegacyVolume *LegacyVolumeDetails `json:"volume,omitempty"`
+
+	// LegacyAttachments describes the attachments of the volume to
+	// machines.
+	//
+	// NOTE: this should have gone into VolumeDetails, but it's too
+	// late for that now. We'll continue to populate it, and use it
+	// if it's defined but Volume.Attachments is not. Please do not
+	// copy this structure.
+	LegacyAttachments []VolumeAttachment `json:"attachments,omitempty"`
 
 	// Error contains volume retrieval error.
 	Error *Error `json:"error,omitempty"`
 }
 
-// VolumeItemsResult holds volumes.
-type VolumeItemsResult struct {
-	Results []VolumeItem `json:"results,omitempty"`
+// VolumeDetailsResults holds volume details.
+type VolumeDetailsResults struct {
+	Results []VolumeDetailsResult `json:"results,omitempty"`
 }
 
 // StorageConstraints contains constraints for storage instance.

--- a/apiserver/storage/export_test.go
+++ b/apiserver/storage/export_test.go
@@ -4,18 +4,9 @@
 package storage
 
 var (
-	IsValidPoolListFilter      = (*API).isValidPoolListFilter
-	ValidateNames              = (*API).isValidNameCriteria
-	ValidateProviders          = (*API).isValidProviderCriteria
-	CreateVolumeItem           = (*API).createVolumeItem
-	GetVolumeItems             = (*API).getVolumeItems
-	FilterVolumes              = (*API).filterVolumes
-	VolumeAttachments          = (*API).volumeAttachments
-	ListVolumeAttachments      = (*API).listVolumeAttachments
-	ConvertStateVolumeToParams = (*API).convertStateVolumeToParams
+	IsValidPoolListFilter = (*API).isValidPoolListFilter
+	ValidateNames         = (*API).isValidNameCriteria
+	ValidateProviders     = (*API).isValidProviderCriteria
 
-	CreateAPI                             = createAPI
-	GroupAttachmentsByVolume              = groupAttachmentsByVolume
-	ConvertStateVolumeAttachmentToParams  = convertStateVolumeAttachmentToParams
-	ConvertStateVolumeAttachmentsToParams = convertStateVolumeAttachmentsToParams
+	CreateAPI = createAPI
 )

--- a/apiserver/storage/package_test.go
+++ b/apiserver/storage/package_test.go
@@ -40,8 +40,8 @@ type baseStorageSuite struct {
 	machineTag      names.MachineTag
 
 	volumeTag        names.VolumeTag
-	volume           state.Volume
-	volumeAttachment state.VolumeAttachment
+	volume           *mockVolume
+	volumeAttachment *mockVolumeAttachment
 	calls            []string
 
 	poolManager *mockPoolManager
@@ -360,6 +360,7 @@ type mockVolume struct {
 	tag          names.VolumeTag
 	storage      names.StorageTag
 	hasNoStorage bool
+	info         *state.VolumeInfo
 }
 
 func (m *mockVolume) StorageInstance() (names.StorageTag, error) {
@@ -381,6 +382,9 @@ func (m *mockVolume) Params() (state.VolumeParams, bool) {
 }
 
 func (m *mockVolume) Info() (state.VolumeInfo, error) {
+	if m.info != nil {
+		return *m.info, nil
+	}
 	return state.VolumeInfo{}, errors.NotProvisionedf("%v", m.tag)
 }
 
@@ -453,6 +457,7 @@ func (m *mockStorageAttachment) Unit() names.UnitTag {
 type mockVolumeAttachment struct {
 	VolumeTag  names.VolumeTag
 	MachineTag names.MachineTag
+	info       *state.VolumeAttachmentInfo
 }
 
 func (va *mockVolumeAttachment) Volume() names.VolumeTag {
@@ -468,7 +473,10 @@ func (va *mockVolumeAttachment) Life() state.Life {
 }
 
 func (va *mockVolumeAttachment) Info() (state.VolumeAttachmentInfo, error) {
-	return state.VolumeAttachmentInfo{}, errors.New("not interested yet")
+	if va.info != nil {
+		return *va.info, nil
+	}
+	return state.VolumeAttachmentInfo{}, errors.NotProvisionedf("volume attachment")
 }
 
 func (va *mockVolumeAttachment) Params() (state.VolumeAttachmentParams, bool) {

--- a/apiserver/storage/storage.go
+++ b/apiserver/storage/storage.go
@@ -396,184 +396,162 @@ func (a *API) CreatePool(p params.StoragePool) error {
 	return err
 }
 
-func (a *API) ListVolumes(filter params.VolumeFilter) (params.VolumeItemsResult, error) {
-	if !filter.IsEmpty() {
-		return params.VolumeItemsResult{Results: a.filterVolumes(filter)}, nil
-	}
-	volumes, err := a.listVolumeAttachments()
+func (a *API) ListVolumes(filter params.VolumeFilter) (params.VolumeDetailsResults, error) {
+	volumes, volumeAttachments, err := filterVolumes(a.storage, filter)
 	if err != nil {
-		return params.VolumeItemsResult{}, common.ServerError(err)
+		return params.VolumeDetailsResults{}, common.ServerError(err)
 	}
-	return params.VolumeItemsResult{Results: volumes}, nil
+	results := createVolumeDetailsResults(a.storage, volumes, volumeAttachments)
+	return params.VolumeDetailsResults{Results: results}, nil
 }
 
-func (a *API) listVolumeAttachments() ([]params.VolumeItem, error) {
-	all, err := a.storage.AllVolumes()
+func filterVolumes(
+	st storageAccess,
+	f params.VolumeFilter,
+) ([]state.Volume, map[names.VolumeTag][]state.VolumeAttachment, error) {
+	if f.IsEmpty() {
+		// No filter was specified: get all volumes, and all attachments.
+		volumes, err := st.AllVolumes()
+		if err != nil {
+			return nil, nil, errors.Trace(err)
+		}
+		volumeAttachments := make(map[names.VolumeTag][]state.VolumeAttachment)
+		for _, v := range volumes {
+			attachments, err := st.VolumeAttachments(v.VolumeTag())
+			if err != nil {
+				return nil, nil, errors.Trace(err)
+			}
+			volumeAttachments[v.VolumeTag()] = attachments
+		}
+		return volumes, volumeAttachments, nil
+	}
+	volumesByTag := make(map[names.VolumeTag]state.Volume)
+	volumeAttachments := make(map[names.VolumeTag][]state.VolumeAttachment)
+	for _, machine := range f.Machines {
+		machineTag, err := names.ParseMachineTag(machine)
+		if err != nil {
+			return nil, nil, errors.Trace(err)
+		}
+		attachments, err := st.MachineVolumeAttachments(machineTag)
+		if err != nil {
+			return nil, nil, errors.Trace(err)
+		}
+		for _, attachment := range attachments {
+			volumeTag := attachment.Volume()
+			volumesByTag[volumeTag] = nil
+			volumeAttachments[volumeTag] = append(volumeAttachments[volumeTag], attachment)
+		}
+	}
+	for volumeTag := range volumesByTag {
+		volume, err := st.Volume(volumeTag)
+		if err != nil {
+			return nil, nil, errors.Trace(err)
+		}
+		volumesByTag[volumeTag] = volume
+	}
+	volumes := make([]state.Volume, 0, len(volumesByTag))
+	for _, volume := range volumesByTag {
+		volumes = append(volumes, volume)
+	}
+	return volumes, volumeAttachments, nil
+}
+
+func createVolumeDetailsResults(
+	st storageAccess,
+	volumes []state.Volume,
+	attachments map[names.VolumeTag][]state.VolumeAttachment,
+) []params.VolumeDetailsResult {
+
+	if len(volumes) == 0 {
+		return nil
+	}
+
+	results := make([]params.VolumeDetailsResult, len(volumes))
+	for i, v := range volumes {
+		details, err := createVolumeDetails(st, v, attachments[v.VolumeTag()])
+		if err != nil {
+			results[i].Error = common.ServerError(err)
+			continue
+		}
+		result := params.VolumeDetailsResult{
+			Details: details,
+		}
+
+		// We need to populate the legacy fields for old clients.
+		if len(details.MachineAttachments) > 0 {
+			result.LegacyAttachments = make([]params.VolumeAttachment, 0, len(details.MachineAttachments))
+			for machineTag, attachmentInfo := range details.MachineAttachments {
+				result.LegacyAttachments = append(result.LegacyAttachments, params.VolumeAttachment{
+					VolumeTag:  details.VolumeTag,
+					MachineTag: machineTag,
+					Info:       attachmentInfo,
+				})
+			}
+		}
+		result.LegacyVolume = &params.LegacyVolumeDetails{
+			VolumeTag:  details.VolumeTag,
+			StorageTag: details.StorageTag,
+			VolumeId:   details.Info.VolumeId,
+			HardwareId: details.Info.HardwareId,
+			Size:       details.Info.Size,
+			Persistent: details.Info.Persistent,
+			Status:     details.Status,
+		}
+		if details.StorageOwnerTag != "" {
+			kind, err := names.TagKind(details.StorageOwnerTag)
+			if err != nil {
+				results[i].Error = common.ServerError(err)
+				continue
+			}
+			if kind == names.UnitTagKind {
+				result.LegacyVolume.UnitTag = details.StorageOwnerTag
+			}
+		}
+		results[i] = result
+	}
+	return results
+}
+
+func createVolumeDetails(
+	st storageAccess, v state.Volume, attachments []state.VolumeAttachment,
+) (*params.VolumeDetails, error) {
+
+	details := &params.VolumeDetails{
+		VolumeTag: v.VolumeTag().String(),
+	}
+
+	if info, err := v.Info(); err == nil {
+		details.Info = common.VolumeInfoFromState(info)
+	}
+
+	if len(attachments) > 0 {
+		details.MachineAttachments = make(map[string]params.VolumeAttachmentInfo, len(attachments))
+		for _, attachment := range attachments {
+			stateInfo, err := attachment.Info()
+			var info params.VolumeAttachmentInfo
+			if err == nil {
+				info = common.VolumeAttachmentInfoFromState(stateInfo)
+			}
+			details.MachineAttachments[attachment.Machine().String()] = info
+		}
+	}
+
+	status, err := v.Status()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return a.volumeAttachments(all), nil
-}
+	details.Status = common.EntityStatusFromState(status)
 
-func (a *API) volumeAttachments(all []state.Volume) []params.VolumeItem {
-	if all == nil || len(all) == 0 {
-		return nil
-	}
-
-	result := make([]params.VolumeItem, len(all))
-	for i, v := range all {
-		volume, err := a.convertStateVolumeToParams(v)
+	if storageTag, err := v.StorageInstance(); err == nil {
+		details.StorageTag = storageTag.String()
+		storageInstance, err := st.StorageInstance(storageTag)
 		if err != nil {
-			result[i] = params.VolumeItem{
-				Error: common.ServerError(errors.Trace(err)),
-			}
-			continue
+			return nil, errors.Trace(err)
 		}
-		result[i] = params.VolumeItem{Volume: volume}
-		atts, err := a.storage.VolumeAttachments(v.VolumeTag())
-		if err != nil {
-			result[i].Error = common.ServerError(errors.Annotatef(
-				err, "attachments for volume %v", v.VolumeTag()))
-			continue
-		}
-		result[i].Attachments = convertStateVolumeAttachmentsToParams(atts)
-	}
-	return result
-}
-
-func (a *API) filterVolumes(f params.VolumeFilter) []params.VolumeItem {
-	var attachments []state.VolumeAttachment
-	var errs []params.VolumeItem
-
-	addErr := func(err error) {
-		errs = append(errs,
-			params.VolumeItem{Error: common.ServerError(err)})
+		details.StorageOwnerTag = storageInstance.Owner().String()
 	}
 
-	for _, machine := range f.Machines {
-		tag, err := names.ParseMachineTag(machine)
-		if err != nil {
-			addErr(errors.Annotatef(err, "parsing machine tag %v", machine))
-		}
-		machineAttachments, err := a.storage.MachineVolumeAttachments(tag)
-		if err != nil {
-			addErr(errors.Annotatef(err,
-				"getting volume attachments for machine %v",
-				machine))
-		}
-		attachments = append(attachments, machineAttachments...)
-	}
-	return append(errs, a.getVolumeItems(attachments)...)
-}
-
-func (a *API) convertStateVolumeToParams(st state.Volume) (params.VolumeInstance, error) {
-	volume := params.VolumeInstance{VolumeTag: st.VolumeTag().String()}
-
-	if storage, err := st.StorageInstance(); err == nil {
-		volume.StorageTag = storage.String()
-		storageInstance, err := a.storage.StorageInstance(storage)
-		if err != nil {
-			err = errors.Annotatef(err,
-				"getting storage instance %v for volume %v",
-				storage, volume.VolumeTag)
-			return params.VolumeInstance{}, err
-		}
-		owner := storageInstance.Owner()
-		// only interested in Unit for now
-		if unitTag, ok := owner.(names.UnitTag); ok {
-			volume.UnitTag = unitTag.String()
-		}
-	}
-	if info, err := st.Info(); err == nil {
-		volume.HardwareId = info.HardwareId
-		volume.Size = info.Size
-		volume.Persistent = info.Persistent
-		volume.VolumeId = info.VolumeId
-	}
-	status, err := st.Status()
-	if err != nil {
-		return params.VolumeInstance{}, errors.Trace(err)
-	}
-	volume.Status = common.EntityStatusFromState(status)
-	return volume, nil
-}
-
-func convertStateVolumeAttachmentsToParams(all []state.VolumeAttachment) []params.VolumeAttachment {
-	if len(all) == 0 {
-		return nil
-	}
-	result := make([]params.VolumeAttachment, len(all))
-	for i, one := range all {
-		result[i] = convertStateVolumeAttachmentToParams(one)
-	}
-	return result
-}
-
-func convertStateVolumeAttachmentToParams(attachment state.VolumeAttachment) params.VolumeAttachment {
-	result := params.VolumeAttachment{
-		VolumeTag:  attachment.Volume().String(),
-		MachineTag: attachment.Machine().String()}
-	if info, err := attachment.Info(); err == nil {
-		result.Info = params.VolumeAttachmentInfo{
-			info.DeviceName,
-			info.BusAddress,
-			info.ReadOnly,
-		}
-	}
-	return result
-}
-
-func (a *API) getVolumeItems(all []state.VolumeAttachment) []params.VolumeItem {
-	group := groupAttachmentsByVolume(all)
-
-	if len(group) == 0 {
-		return nil
-	}
-
-	result := make([]params.VolumeItem, len(group))
-	i := 0
-	for volumeTag, attachments := range group {
-		result[i] = a.createVolumeItem(volumeTag, attachments)
-		i++
-	}
-	return result
-}
-
-func (a *API) createVolumeItem(volumeTag string, attachments []params.VolumeAttachment) params.VolumeItem {
-	result := params.VolumeItem{Attachments: attachments}
-
-	tag, err := names.ParseVolumeTag(volumeTag)
-	if err != nil {
-		result.Error = common.ServerError(errors.Annotatef(err, "parsing volume tag %v", volumeTag))
-		return result
-	}
-	st, err := a.storage.Volume(tag)
-	if err != nil {
-		result.Error = common.ServerError(errors.Annotatef(err, "getting volume for tag %v", tag))
-		return result
-	}
-	volume, err := a.convertStateVolumeToParams(st)
-	if err != nil {
-		result.Error = common.ServerError(errors.Trace(err))
-		return result
-	}
-	result.Volume = volume
-	return result
-}
-
-// groupAttachmentsByVolume constructs map of attachments grouped by volumeTag
-func groupAttachmentsByVolume(all []state.VolumeAttachment) map[string][]params.VolumeAttachment {
-	if len(all) == 0 {
-		return nil
-	}
-	group := make(map[string][]params.VolumeAttachment)
-	for _, one := range all {
-		attachment := convertStateVolumeAttachmentToParams(one)
-		group[attachment.VolumeTag] = append(
-			group[attachment.VolumeTag],
-			attachment)
-	}
-	return group
+	return details, nil
 }
 
 // AddToUnit validates and creates additional storage instances for units.

--- a/apiserver/storage/storage.go
+++ b/apiserver/storage/storage.go
@@ -88,17 +88,17 @@ func (api *API) Show(entities params.Entities) (params.StorageDetailsResults, er
 // List returns all currently known storage. Unlike Show(),
 // if errors encountered while retrieving a particular
 // storage, this error is treated as part of the returned storage detail.
-func (api *API) List() (params.StorageInfosResult, error) {
+func (api *API) List() (params.StorageDetailsResults, error) {
 	stateInstances, err := api.storage.AllStorageInstances()
 	if err != nil {
-		return params.StorageInfosResult{}, common.ServerError(err)
+		return params.StorageDetailsResults{}, common.ServerError(err)
 	}
-	var infos []params.StorageInfo
+	var infos []params.StorageDetailsResult
 	for _, stateInstance := range stateInstances {
 		storageTag := stateInstance.StorageTag()
 		persistent, err := api.isPersistent(stateInstance)
 		if err != nil {
-			return params.StorageInfosResult{}, err
+			return params.StorageDetailsResults{}, err
 		}
 		instance := createParamsStorageInstance(stateInstance, persistent)
 
@@ -109,11 +109,11 @@ func (api *API) List() (params.StorageInfosResult, error) {
 		// as another valid property, i.e. augment storage details.
 		attachments := api.createStorageDetailsResult(storageTag, instance)
 		for _, one := range attachments {
-			aParam := params.StorageInfo{one.Result, one.Error}
+			aParam := params.StorageDetailsResult{one.Result, one.Error}
 			infos = append(infos, aParam)
 		}
 	}
-	return params.StorageInfosResult{Results: infos}, nil
+	return params.StorageDetailsResults{Results: infos}, nil
 }
 
 func (api *API) createStorageDetailsResult(

--- a/apiserver/storage/storage.go
+++ b/apiserver/storage/storage.go
@@ -4,7 +4,10 @@
 package storage
 
 import (
+	"time"
+
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	"github.com/juju/names"
 	"github.com/juju/utils/set"
 
@@ -15,6 +18,8 @@ import (
 	"github.com/juju/juju/storage/poolmanager"
 	"github.com/juju/juju/storage/provider/registry"
 )
+
+var logger = loggo.GetLogger("juju.apiserver.storage")
 
 func init() {
 	common.RegisterStandardFacade("Storage", 1, NewAPI)
@@ -63,26 +68,21 @@ func poolManager(st *state.State) poolmanager.PoolManager {
 // identified by supplied tags. If specified storage cannot be retrieved,
 // individual error is returned instead of storage information.
 func (api *API) Show(entities params.Entities) (params.StorageDetailsResults, error) {
-	var all []params.StorageDetailsResult
-	for _, entity := range entities.Entities {
+	results := make([]params.StorageDetailsResult, len(entities.Entities))
+	for i, entity := range entities.Entities {
 		storageTag, err := names.ParseStorageTag(entity.Tag)
 		if err != nil {
-			all = append(all, params.StorageDetailsResult{
-				Error: common.ServerError(err),
-			})
+			results[i].Error = common.ServerError(err)
 			continue
 		}
-		found, instance, serverErr := api.getStorageInstance(storageTag)
+		storageInstance, err := api.storage.StorageInstance(storageTag)
 		if err != nil {
-			all = append(all, params.StorageDetailsResult{Error: serverErr})
+			results[i].Error = common.ServerError(err)
 			continue
 		}
-		if found {
-			results := api.createStorageDetailsResult(storageTag, instance)
-			all = append(all, results...)
-		}
+		results[i] = api.createStorageDetailsResult(storageInstance)
 	}
-	return params.StorageDetailsResults{Results: all}, nil
+	return params.StorageDetailsResults{Results: results}, nil
 }
 
 // List returns all currently known storage. Unlike Show(),
@@ -93,161 +93,124 @@ func (api *API) List() (params.StorageDetailsResults, error) {
 	if err != nil {
 		return params.StorageDetailsResults{}, common.ServerError(err)
 	}
-	var infos []params.StorageDetailsResult
-	for _, stateInstance := range stateInstances {
-		storageTag := stateInstance.StorageTag()
-		persistent, err := api.isPersistent(stateInstance)
-		if err != nil {
-			return params.StorageDetailsResults{}, err
-		}
-		instance := createParamsStorageInstance(stateInstance, persistent)
-
-		// It is possible to encounter errors here related to getting individual
-		// storage details such as getting attachments, getting machine from the unit,
-		// etc.
-		// Current approach is to do what status command does - treat error
-		// as another valid property, i.e. augment storage details.
-		attachments := api.createStorageDetailsResult(storageTag, instance)
-		for _, one := range attachments {
-			aParam := params.StorageDetailsResult{one.Result, one.Error}
-			infos = append(infos, aParam)
-		}
+	results := make([]params.StorageDetailsResult, len(stateInstances))
+	for i, stateInstance := range stateInstances {
+		results[i] = api.createStorageDetailsResult(stateInstance)
 	}
-	return params.StorageDetailsResults{Results: infos}, nil
+	return params.StorageDetailsResults{Results: results}, nil
 }
 
-func (api *API) createStorageDetailsResult(
-	storageTag names.StorageTag,
-	instance params.StorageDetails,
-) []params.StorageDetailsResult {
-	attachments, err := api.getStorageAttachments(storageTag, instance)
+func (api *API) createStorageDetailsResult(si state.StorageInstance) params.StorageDetailsResult {
+	details, err := api.createStorageDetails(si)
 	if err != nil {
-		return []params.StorageDetailsResult{params.StorageDetailsResult{Result: instance, Error: err}}
+		return params.StorageDetailsResult{Error: common.ServerError(err)}
 	}
-	if len(attachments) > 0 {
-		// If any attachments were found for this storage instance,
-		// return them instead.
-		result := make([]params.StorageDetailsResult, len(attachments))
-		for i, attachment := range attachments {
-			result[i] = params.StorageDetailsResult{Result: attachment}
+
+	legacy := params.LegacyStorageDetails{
+		details.StorageTag,
+		details.OwnerTag,
+		details.Kind,
+		string(details.Status.Status),
+		"", // unit tag set below
+		"", // location set below
+		details.Persistent,
+	}
+	if len(details.Attachments) == 1 {
+		for unitTag, attachmentDetails := range details.Attachments {
+			legacy.UnitTag = unitTag
+			legacy.Location = attachmentDetails.Location
 		}
-		return result
 	}
-	// If we are here then this storage instance is unattached.
-	return []params.StorageDetailsResult{params.StorageDetailsResult{Result: instance}}
+
+	return params.StorageDetailsResult{Result: details, Legacy: legacy}
 }
 
-func (api *API) getStorageAttachments(
-	storageTag names.StorageTag,
-	instance params.StorageDetails,
-) ([]params.StorageDetails, *params.Error) {
-	serverError := func(err error) *params.Error {
-		return common.ServerError(errors.Annotatef(err, "getting attachments for storage %v", storageTag.Id()))
-	}
-	stateAttachments, err := api.storage.StorageAttachments(storageTag)
-	if err != nil {
-		return nil, serverError(err)
-	}
-	result := make([]params.StorageDetails, len(stateAttachments))
-	for i, one := range stateAttachments {
-		paramsStorageAttachment, err := api.createParamsStorageAttachment(instance, one)
-		if err != nil {
-			return nil, serverError(err)
-		}
-		result[i] = paramsStorageAttachment
-	}
-	return result, nil
-}
-
-func (api *API) createParamsStorageAttachment(si params.StorageDetails, sa state.StorageAttachment) (params.StorageDetails, error) {
-	result := params.StorageDetails{Status: "pending"}
-	result.StorageTag = sa.StorageInstance().String()
-	if result.StorageTag != si.StorageTag {
-		panic("attachment does not belong to storage instance")
-	}
-	result.UnitTag = sa.Unit().String()
-	result.OwnerTag = si.OwnerTag
-	result.Kind = si.Kind
-	result.Persistent = si.Persistent
-	// TODO(axw) set status according to whether storage has been provisioned.
-
-	// This is only for provisioned attachments
-	machineTag, err := api.storage.UnitAssignedMachine(sa.Unit())
-	if err != nil {
-		return params.StorageDetails{}, errors.Annotate(err, "getting unit for storage attachment")
-	}
-	info, err := common.StorageAttachmentInfo(api.storage, sa, machineTag)
-	if err != nil {
-		if errors.IsNotProvisioned(err) {
-			// If Info returns an error, then the storage has not yet been provisioned.
-			return result, nil
-		}
-		return params.StorageDetails{}, errors.Annotate(err, "getting storage attachment info")
-	}
-	result.Location = info.Location
-	if result.Location != "" {
-		result.Status = "attached"
-	}
-	return result, nil
-}
-
-func (api *API) getStorageInstance(tag names.StorageTag) (bool, params.StorageDetails, *params.Error) {
-	nothing := params.StorageDetails{}
-	serverError := func(err error) *params.Error {
-		return common.ServerError(errors.Annotatef(err, "getting %v", tag))
-	}
-	stateInstance, err := api.storage.StorageInstance(tag)
-	if err != nil {
-		if errors.IsNotFound(err) {
-			return false, nothing, nil
-		}
-		return false, nothing, serverError(err)
-	}
-	persistent, err := api.isPersistent(stateInstance)
-	if err != nil {
-		return false, nothing, serverError(err)
-	}
-	return true, createParamsStorageInstance(stateInstance, persistent), nil
-}
-
-func createParamsStorageInstance(si state.StorageInstance, persistent bool) params.StorageDetails {
-	result := params.StorageDetails{
-		OwnerTag:   si.Owner().String(),
-		StorageTag: si.Tag().String(),
-		Kind:       params.StorageKind(si.Kind()),
-		Status:     "pending",
-		Persistent: persistent,
-	}
-	return result
-}
-
-// TODO(axw) move this and createParamsStorageInstance to
-// apiserver/common/storage.go, alongside StorageAttachmentInfo.
-func (api *API) isPersistent(si state.StorageInstance) (bool, error) {
+func (api *API) createStorageDetails(si state.StorageInstance) (*params.StorageDetails, error) {
+	// Get information from underlying volume or filesystem.
+	var persistent bool
+	var entityStatus params.EntityStatus
 	if si.Kind() != state.StorageKindBlock {
 		// TODO(axw) when we support persistent filesystems,
-		// e.g. CephFS, we'll need to do the same thing as
-		// we do for volumes for filesystems.
-		return false, nil
-	}
-	volume, err := api.storage.StorageInstanceVolume(si.StorageTag())
-	if err != nil {
-		return false, err
-	}
-	// If the volume is not provisioned, we read its config attributes.
-	if params, ok := volume.Params(); ok {
-		_, cfg, err := common.StoragePoolConfig(params.Pool, api.poolManager)
+		// e.g. CephFS, we'll need to do set "persistent"
+		// here too.
+		nowUTC := time.Now().UTC()
+		entityStatus.Status = params.StatusUnknown
+		entityStatus.Since = &nowUTC
+	} else {
+		volume, err := api.storage.StorageInstanceVolume(si.StorageTag())
 		if err != nil {
-			return false, err
+			return nil, errors.Trace(err)
 		}
-		return cfg.IsPersistent(), nil
+		if info, err := volume.Info(); err == nil {
+			persistent = info.Persistent
+		}
+		status, err := volume.Status()
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		entityStatus = common.EntityStatusFromState(status)
 	}
-	// If the volume is provisioned, we look at its provisioning info.
-	info, err := volume.Info()
+
+	// Get unit storage attachments.
+	var storageAttachmentDetails map[string]params.StorageAttachmentDetails
+	storageAttachments, err := api.storage.StorageAttachments(si.StorageTag())
 	if err != nil {
-		return false, err
+		return nil, errors.Trace(err)
 	}
-	return info.Persistent, nil
+	if len(storageAttachments) > 0 {
+		storageAttachmentDetails = make(map[string]params.StorageAttachmentDetails)
+		for _, a := range storageAttachments {
+			machineTag, location, err := api.storageAttachmentInfo(a)
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			details := params.StorageAttachmentDetails{
+				a.StorageInstance().String(),
+				a.Unit().String(),
+				machineTag.String(),
+				location,
+			}
+			storageAttachmentDetails[a.Unit().String()] = details
+		}
+	}
+
+	// Hack to set filesystem status.
+	//
+	// TODO(axw) we can undo this in 1.26,
+	// where we have proper filesystem status.
+	if entityStatus.Status == params.StatusUnknown {
+		entityStatus.Status = params.StatusPending
+		for _, details := range storageAttachmentDetails {
+			if details.Location != "" {
+				entityStatus.Status = params.StatusAttached
+			}
+		}
+	}
+
+	return &params.StorageDetails{
+		StorageTag:  si.Tag().String(),
+		OwnerTag:    si.Owner().String(),
+		Kind:        params.StorageKind(si.Kind()),
+		Status:      entityStatus,
+		Persistent:  persistent,
+		Attachments: storageAttachmentDetails,
+	}, nil
+}
+
+func (api *API) storageAttachmentInfo(a state.StorageAttachment) (_ names.MachineTag, location string, _ error) {
+	machineTag, err := api.storage.UnitAssignedMachine(a.Unit())
+	if errors.IsNotAssigned(err) {
+		return names.MachineTag{}, "", nil
+	} else if err != nil {
+		return names.MachineTag{}, "", errors.Trace(err)
+	}
+	info, err := common.StorageAttachmentInfo(api.storage, a, machineTag)
+	if errors.IsNotProvisioned(err) {
+		return machineTag, "", nil
+	} else if err != nil {
+		return names.MachineTag{}, "", errors.Trace(err)
+	}
+	return machineTag, info.Location, nil
 }
 
 // ListPools returns a list of pools.

--- a/apiserver/storage/storage_test.go
+++ b/apiserver/storage/storage_test.go
@@ -48,8 +48,8 @@ func (s *storageSuite) TestStorageListFilesystem(c *gc.C) {
 	s.assertCalls(c, expectedCalls)
 
 	c.Assert(found.Results, gc.HasLen, 1)
-	wantedDetails := s.createTestStorageInfo()
-	wantedDetails.UnitTag = s.unitTag.String()
+	wantedDetails := s.createTestStorageDetailsResult()
+	wantedDetails.Result.UnitTag = s.unitTag.String()
 	s.assertInstanceInfoError(c, found.Results[0], wantedDetails, "")
 }
 
@@ -69,9 +69,9 @@ func (s *storageSuite) TestStorageListVolume(c *gc.C) {
 	s.assertCalls(c, expectedCalls)
 
 	c.Assert(found.Results, gc.HasLen, 1)
-	wantedDetails := s.createTestStorageInfo()
-	wantedDetails.Kind = params.StorageKindBlock
-	wantedDetails.UnitTag = s.unitTag.String()
+	wantedDetails := s.createTestStorageDetailsResult()
+	wantedDetails.Result.Kind = params.StorageKindBlock
+	wantedDetails.Result.UnitTag = s.unitTag.String()
 	s.assertInstanceInfoError(c, found.Results[0], wantedDetails, "")
 }
 
@@ -111,7 +111,7 @@ func (s *storageSuite) TestStorageListInstanceError(c *gc.C) {
 	}
 	s.assertCalls(c, expectedCalls)
 	c.Assert(found.Results, gc.HasLen, 1)
-	wanted := s.createTestStorageInfoWithError("",
+	wanted := s.createTestStorageDetailsResultWithError("",
 		fmt.Sprintf("getting storage attachment info: getting storage instance: %v", msg))
 	s.assertInstanceInfoError(c, found.Results[0], wanted, msg)
 }
@@ -133,7 +133,7 @@ func (s *storageSuite) TestStorageListAttachmentError(c *gc.C) {
 	s.assertCalls(c, expectedCalls)
 	c.Assert(found.Results, gc.HasLen, 1)
 	expectedErr := "list test error"
-	wanted := s.createTestStorageInfoWithError("", expectedErr)
+	wanted := s.createTestStorageDetailsResultWithError("", expectedErr)
 	s.assertInstanceInfoError(c, found.Results[0], wanted, expectedErr)
 }
 
@@ -155,7 +155,7 @@ func (s *storageSuite) TestStorageListMachineError(c *gc.C) {
 	}
 	s.assertCalls(c, expectedCalls)
 	c.Assert(found.Results, gc.HasLen, 1)
-	wanted := s.createTestStorageInfoWithError("",
+	wanted := s.createTestStorageDetailsResultWithError("",
 		fmt.Sprintf("getting unit for storage attachment: %v", msg))
 	s.assertInstanceInfoError(c, found.Results[0], wanted, msg)
 }
@@ -180,7 +180,7 @@ func (s *storageSuite) TestStorageListFilesystemError(c *gc.C) {
 	}
 	s.assertCalls(c, expectedCalls)
 	c.Assert(found.Results, gc.HasLen, 1)
-	wanted := s.createTestStorageInfoWithError("",
+	wanted := s.createTestStorageDetailsResultWithError("",
 		fmt.Sprintf("getting storage attachment info: getting filesystem: %v", msg))
 	s.assertInstanceInfoError(c, found.Results[0], wanted, msg)
 }
@@ -203,20 +203,20 @@ func (s *storageSuite) TestStorageListFilesystemAttachmentError(c *gc.C) {
 	}
 	s.assertCalls(c, expectedCalls)
 	c.Assert(found.Results, gc.HasLen, 1)
-	wanted := s.createTestStorageInfoWithError("",
+	wanted := s.createTestStorageDetailsResultWithError("",
 		fmt.Sprintf("getting unit for storage attachment: %v", msg))
 	s.assertInstanceInfoError(c, found.Results[0], wanted, msg)
 }
 
-func (s *storageSuite) createTestStorageInfoWithError(code, msg string) params.StorageInfo {
-	wanted := s.createTestStorageInfo()
+func (s *storageSuite) createTestStorageDetailsResultWithError(code, msg string) params.StorageDetailsResult {
+	wanted := s.createTestStorageDetailsResult()
 	wanted.Error = &params.Error{Code: code,
 		Message: fmt.Sprintf("getting attachments for storage data/0: %v", msg)}
 	return wanted
 }
 
-func (s *storageSuite) createTestStorageInfo() params.StorageInfo {
-	return params.StorageInfo{
+func (s *storageSuite) createTestStorageDetailsResult() params.StorageDetailsResult {
+	return params.StorageDetailsResult{
 		params.StorageDetails{
 			StorageTag: s.storageTag.String(),
 			OwnerTag:   s.unitTag.String(),
@@ -227,7 +227,7 @@ func (s *storageSuite) createTestStorageInfo() params.StorageInfo {
 	}
 }
 
-func (s *storageSuite) assertInstanceInfoError(c *gc.C, obtained params.StorageInfo, wanted params.StorageInfo, expected string) {
+func (s *storageSuite) assertInstanceInfoError(c *gc.C, obtained params.StorageDetailsResult, wanted params.StorageDetailsResult, expected string) {
 	if expected != "" {
 		c.Assert(errors.Cause(obtained.Error), gc.ErrorMatches, fmt.Sprintf(".*%v.*", expected))
 	} else {

--- a/apiserver/storage/storage_test.go
+++ b/apiserver/storage/storage_test.go
@@ -49,7 +49,9 @@ func (s *storageSuite) TestStorageListFilesystem(c *gc.C) {
 
 	c.Assert(found.Results, gc.HasLen, 1)
 	wantedDetails := s.createTestStorageDetailsResult()
-	wantedDetails.Result.UnitTag = s.unitTag.String()
+
+	c.Assert(found.Results[0].Result.Status.Since, gc.NotNil)
+	found.Results[0].Result.Status.Since = nil
 	s.assertInstanceInfoError(c, found.Results[0], wantedDetails, "")
 }
 
@@ -71,7 +73,9 @@ func (s *storageSuite) TestStorageListVolume(c *gc.C) {
 	c.Assert(found.Results, gc.HasLen, 1)
 	wantedDetails := s.createTestStorageDetailsResult()
 	wantedDetails.Result.Kind = params.StorageKindBlock
-	wantedDetails.Result.UnitTag = s.unitTag.String()
+	wantedDetails.Result.Status.Status = params.StatusAttached
+	wantedDetails.Legacy.Kind = params.StorageKindBlock
+	wantedDetails.Legacy.Status = "attached"
 	s.assertInstanceInfoError(c, found.Results[0], wantedDetails, "")
 }
 
@@ -96,7 +100,7 @@ func (s *storageSuite) TestStorageListInstanceError(c *gc.C) {
 	msg := "list test error"
 	s.state.storageInstance = func(sTag names.StorageTag) (state.StorageInstance, error) {
 		s.calls = append(s.calls, storageInstanceCall)
-		c.Assert(sTag, gc.DeepEquals, s.storageTag)
+		c.Assert(sTag, jc.DeepEquals, s.storageTag)
 		return nil, errors.Errorf(msg)
 	}
 
@@ -119,7 +123,7 @@ func (s *storageSuite) TestStorageListInstanceError(c *gc.C) {
 func (s *storageSuite) TestStorageListAttachmentError(c *gc.C) {
 	s.state.storageInstanceAttachments = func(tag names.StorageTag) ([]state.StorageAttachment, error) {
 		s.calls = append(s.calls, storageInstanceAttachmentsCall)
-		c.Assert(tag, gc.DeepEquals, s.storageTag)
+		c.Assert(tag, jc.DeepEquals, s.storageTag)
 		return []state.StorageAttachment{}, errors.Errorf("list test error")
 	}
 
@@ -141,7 +145,7 @@ func (s *storageSuite) TestStorageListMachineError(c *gc.C) {
 	msg := "list test error"
 	s.state.unitAssignedMachine = func(u names.UnitTag) (names.MachineTag, error) {
 		s.calls = append(s.calls, unitAssignedMachineCall)
-		c.Assert(u, gc.DeepEquals, s.unitTag)
+		c.Assert(u, jc.DeepEquals, s.unitTag)
 		return names.MachineTag{}, errors.Errorf(msg)
 	}
 
@@ -164,7 +168,7 @@ func (s *storageSuite) TestStorageListFilesystemError(c *gc.C) {
 	msg := "list test error"
 	s.state.storageInstanceFilesystem = func(sTag names.StorageTag) (state.Filesystem, error) {
 		s.calls = append(s.calls, storageInstanceFilesystemCall)
-		c.Assert(sTag, gc.DeepEquals, s.storageTag)
+		c.Assert(sTag, jc.DeepEquals, s.storageTag)
 		return nil, errors.Errorf(msg)
 	}
 
@@ -189,7 +193,7 @@ func (s *storageSuite) TestStorageListFilesystemAttachmentError(c *gc.C) {
 	msg := "list test error"
 	s.state.unitAssignedMachine = func(u names.UnitTag) (names.MachineTag, error) {
 		s.calls = append(s.calls, unitAssignedMachineCall)
-		c.Assert(u, gc.DeepEquals, s.unitTag)
+		c.Assert(u, jc.DeepEquals, s.unitTag)
 		return s.machineTag, errors.Errorf(msg)
 	}
 
@@ -217,9 +221,26 @@ func (s *storageSuite) createTestStorageDetailsResultWithError(code, msg string)
 
 func (s *storageSuite) createTestStorageDetailsResult() params.StorageDetailsResult {
 	return params.StorageDetailsResult{
-		params.StorageDetails{
+		&params.StorageDetails{
 			StorageTag: s.storageTag.String(),
 			OwnerTag:   s.unitTag.String(),
+			Kind:       params.StorageKindFilesystem,
+			Status: params.EntityStatus{
+				Status: "pending",
+			},
+			Attachments: map[string]params.StorageAttachmentDetails{
+				s.unitTag.String(): params.StorageAttachmentDetails{
+					s.storageTag.String(),
+					s.unitTag.String(),
+					s.machineTag.String(),
+					"", // location
+				},
+			},
+		},
+		params.LegacyStorageDetails{
+			StorageTag: s.storageTag.String(),
+			OwnerTag:   s.unitTag.String(),
+			UnitTag:    s.unitTag.String(),
 			Kind:       params.StorageKindFilesystem,
 			Status:     "pending",
 		},
@@ -230,10 +251,12 @@ func (s *storageSuite) createTestStorageDetailsResult() params.StorageDetailsRes
 func (s *storageSuite) assertInstanceInfoError(c *gc.C, obtained params.StorageDetailsResult, wanted params.StorageDetailsResult, expected string) {
 	if expected != "" {
 		c.Assert(errors.Cause(obtained.Error), gc.ErrorMatches, fmt.Sprintf(".*%v.*", expected))
+		c.Assert(obtained.Result, gc.IsNil)
+		c.Assert(obtained.Legacy, jc.DeepEquals, params.LegacyStorageDetails{})
 	} else {
 		c.Assert(obtained.Error, gc.IsNil)
+		c.Assert(obtained, jc.DeepEquals, wanted)
 	}
-	c.Assert(obtained, gc.DeepEquals, wanted)
 }
 
 func (s *storageSuite) TestShowStorageEmpty(c *gc.C) {
@@ -264,10 +287,21 @@ func (s *storageSuite) TestShowStorage(c *gc.C) {
 		StorageTag: s.storageTag.String(),
 		OwnerTag:   s.unitTag.String(),
 		Kind:       params.StorageKindFilesystem,
-		UnitTag:    s.unitTag.String(),
-		Status:     "pending",
+		Status: params.EntityStatus{
+			Status: "pending",
+		},
+		Attachments: map[string]params.StorageAttachmentDetails{
+			s.unitTag.String(): params.StorageAttachmentDetails{
+				s.storageTag.String(),
+				s.unitTag.String(),
+				s.machineTag.String(),
+				"",
+			},
+		},
 	}
-	c.Assert(one.Result, gc.DeepEquals, expected)
+	c.Assert(one.Result.Status.Since, gc.NotNil)
+	one.Result.Status.Since = nil
+	c.Assert(one.Result, jc.DeepEquals, &expected)
 }
 
 func (s *storageSuite) TestShowStorageInvalidId(c *gc.C) {
@@ -277,10 +311,5 @@ func (s *storageSuite) TestShowStorageInvalidId(c *gc.C) {
 	found, err := s.api.Show(params.Entities{Entities: []params.Entity{entity}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(found.Results, gc.HasLen, 1)
-
-	instance := found.Results[0]
-	c.Assert(instance.Error, gc.ErrorMatches, `"foo" is not a valid tag`)
-
-	expected := params.StorageDetails{Kind: params.StorageKindUnknown}
-	c.Assert(instance.Result, gc.DeepEquals, expected)
+	s.assertInstanceInfoError(c, found.Results[0], params.StorageDetailsResult{}, `"foo" is not a valid tag`)
 }

--- a/apiserver/storage/volumelist_test.go
+++ b/apiserver/storage/volumelist_test.go
@@ -5,12 +5,10 @@ package storage_test
 
 import (
 	"github.com/juju/errors"
-	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/params"
-	"github.com/juju/juju/apiserver/storage"
 	"github.com/juju/juju/state"
 )
 
@@ -20,260 +18,113 @@ type volumeSuite struct {
 
 var _ = gc.Suite(&volumeSuite{})
 
-func (s *volumeSuite) TestGroupAttachmentsByVolumeEmpty(c *gc.C) {
-	c.Assert(storage.GroupAttachmentsByVolume(nil), gc.IsNil)
-	c.Assert(storage.GroupAttachmentsByVolume([]state.VolumeAttachment{}), gc.IsNil)
-}
-
-func (s *volumeSuite) TestGroupAttachmentsByVolume(c *gc.C) {
-	volumeTag1 := names.NewVolumeTag("0")
-	volumeTag2 := names.NewVolumeTag("0/1")
-	machineTag := names.NewMachineTag("0")
-	attachments := []state.VolumeAttachment{
-		&mockVolumeAttachment{VolumeTag: volumeTag1, MachineTag: machineTag},
-		&mockVolumeAttachment{VolumeTag: volumeTag2, MachineTag: machineTag},
-		&mockVolumeAttachment{VolumeTag: volumeTag2, MachineTag: machineTag},
-	}
-	expected := map[string][]params.VolumeAttachment{
-		volumeTag1.String(): {
-			storage.ConvertStateVolumeAttachmentToParams(attachments[0])},
-		volumeTag2.String(): {
-			storage.ConvertStateVolumeAttachmentToParams(attachments[1]),
-			storage.ConvertStateVolumeAttachmentToParams(attachments[2]),
+func (s *volumeSuite) expectedVolumeDetailsResult() params.VolumeDetailsResult {
+	return params.VolumeDetailsResult{
+		Details: &params.VolumeDetails{
+			VolumeTag:       s.volumeTag.String(),
+			StorageTag:      "storage-data-0",
+			StorageOwnerTag: "unit-mysql-0",
+			Status: params.EntityStatus{
+				Status: "attached",
+			},
+			MachineAttachments: map[string]params.VolumeAttachmentInfo{
+				s.machineTag.String(): params.VolumeAttachmentInfo{},
+			},
 		},
+		LegacyVolume: &params.LegacyVolumeDetails{
+			VolumeTag:  s.volumeTag.String(),
+			StorageTag: "storage-data-0",
+			UnitTag:    "unit-mysql-0",
+			Status: params.EntityStatus{
+				Status: "attached",
+			},
+		},
+		LegacyAttachments: []params.VolumeAttachment{{
+			VolumeTag:  s.volumeTag.String(),
+			MachineTag: s.machineTag.String(),
+		}},
 	}
-	c.Assert(
-		storage.GroupAttachmentsByVolume(attachments),
-		jc.DeepEquals,
-		expected)
-}
-
-func (s *volumeSuite) TestCreateVolumeItemInvalidTag(c *gc.C) {
-	found := storage.CreateVolumeItem(s.api, "666", nil)
-	c.Assert(found.Error, gc.ErrorMatches, ".*not a valid tag.*")
-}
-
-func (s *volumeSuite) TestCreateVolumeItemNonexistingVolume(c *gc.C) {
-	s.state.volume = func(tag names.VolumeTag) (state.Volume, error) {
-		return s.volume, errors.Errorf("not volume for tag %v", tag)
-	}
-	found := storage.CreateVolumeItem(s.api, names.NewVolumeTag("666").String(), nil)
-	c.Assert(found.Error, gc.ErrorMatches, ".*volume for tag.*")
-}
-
-func (s *volumeSuite) TestCreateVolumeItemNoUnit(c *gc.C) {
-	s.storageInstance.owner = names.NewServiceTag("test-service")
-	found := storage.CreateVolumeItem(s.api, s.volumeTag.String(), nil)
-	c.Assert(found.Error, gc.IsNil)
-	c.Assert(found.Error, gc.IsNil)
-	expected, err := storage.ConvertStateVolumeToParams(s.api, s.volume)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(found.Volume, gc.DeepEquals, expected)
-}
-
-func (s *volumeSuite) TestCreateVolumeItemNoStorageInstance(c *gc.C) {
-	s.volume = &mockVolume{tag: s.volumeTag, hasNoStorage: true}
-	found := storage.CreateVolumeItem(s.api, s.volumeTag.String(), nil)
-	c.Assert(found.Error, gc.IsNil)
-	c.Assert(found.Error, gc.IsNil)
-	expected, err := storage.ConvertStateVolumeToParams(s.api, s.volume)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(found.Volume, gc.DeepEquals, expected)
-}
-
-func (s *volumeSuite) TestCreateVolumeItem(c *gc.C) {
-	found := storage.CreateVolumeItem(s.api, s.volumeTag.String(), nil)
-	c.Assert(found.Error, gc.IsNil)
-	c.Assert(found.Error, gc.IsNil)
-	expected, err := storage.ConvertStateVolumeToParams(s.api, s.volume)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(found.Volume, gc.DeepEquals, expected)
-}
-
-func (s *volumeSuite) TestGetVolumeItemsEmpty(c *gc.C) {
-	c.Assert(storage.GetVolumeItems(s.api, nil), gc.IsNil)
-	c.Assert(storage.GetVolumeItems(s.api, []state.VolumeAttachment{}), gc.IsNil)
-}
-
-func (s *volumeSuite) TestGetVolumeItems(c *gc.C) {
-	machineTag := names.NewMachineTag("0")
-	attachments := []state.VolumeAttachment{
-		&mockVolumeAttachment{VolumeTag: s.volumeTag, MachineTag: machineTag},
-		&mockVolumeAttachment{VolumeTag: s.volumeTag, MachineTag: machineTag},
-	}
-	expectedVolume, err := storage.ConvertStateVolumeToParams(s.api, s.volume)
-	c.Assert(err, jc.ErrorIsNil)
-	expected := []params.VolumeItem{
-		params.VolumeItem{
-			Volume:      expectedVolume,
-			Attachments: storage.ConvertStateVolumeAttachmentsToParams(attachments)},
-	}
-	c.Assert(
-		storage.GetVolumeItems(s.api, attachments),
-		jc.DeepEquals,
-		expected)
-}
-
-func (s *volumeSuite) TestFilterVolumesNoItems(c *gc.C) {
-	s.state.machineVolumeAttachments =
-		func(machine names.MachineTag) ([]state.VolumeAttachment, error) {
-			return nil, nil
-		}
-	filter := params.VolumeFilter{
-		Machines: []string{s.machineTag.String()}}
-
-	c.Assert(storage.FilterVolumes(s.api, filter), gc.IsNil)
-}
-
-func (s *volumeSuite) TestFilterVolumesErrorMachineAttachments(c *gc.C) {
-	s.state.machineVolumeAttachments =
-		func(machine names.MachineTag) ([]state.VolumeAttachment, error) {
-			return nil, errors.Errorf("not for machine %v", machine)
-		}
-	filter := params.VolumeFilter{
-		Machines: []string{s.machineTag.String()}}
-
-	found := storage.FilterVolumes(s.api, filter)
-	c.Assert(found, gc.HasLen, 1)
-	c.Assert(found[0].Error, gc.ErrorMatches, ".*for machine.*")
-}
-
-func (s *volumeSuite) TestFilterVolumes(c *gc.C) {
-	filter := params.VolumeFilter{
-		Machines: []string{s.machineTag.String()}}
-
-	expectedVolume, err := storage.ConvertStateVolumeToParams(s.api, s.volume)
-	c.Assert(err, jc.ErrorIsNil)
-	expected := params.VolumeItem{
-		Volume: expectedVolume,
-		Attachments: storage.ConvertStateVolumeAttachmentsToParams(
-			[]state.VolumeAttachment{s.volumeAttachment},
-		),
-	}
-	found := storage.FilterVolumes(s.api, filter)
-	c.Assert(found, gc.HasLen, 1)
-	c.Assert(found[0], gc.DeepEquals, expected)
-}
-
-func (s *volumeSuite) TestVolumeAttachments(c *gc.C) {
-	expectedVolume, err := storage.ConvertStateVolumeToParams(s.api, s.volume)
-	c.Assert(err, jc.ErrorIsNil)
-	expected := params.VolumeItem{
-		Volume: expectedVolume,
-		Attachments: storage.ConvertStateVolumeAttachmentsToParams(
-			[]state.VolumeAttachment{s.volumeAttachment},
-		),
-	}
-
-	found := storage.VolumeAttachments(s.api, []state.Volume{s.volume})
-	c.Assert(found, gc.HasLen, 1)
-	c.Assert(found[0], gc.DeepEquals, expected)
-}
-
-func (s *volumeSuite) TestVolumeAttachmentsEmpty(c *gc.C) {
-	s.state.volumeAttachments =
-		func(volume names.VolumeTag) ([]state.VolumeAttachment, error) {
-			return nil, nil
-		}
-	expectedVolume, err := storage.ConvertStateVolumeToParams(s.api, s.volume)
-	c.Assert(err, jc.ErrorIsNil)
-	expected := params.VolumeItem{
-		Volume: expectedVolume,
-	}
-
-	found := storage.VolumeAttachments(s.api, []state.Volume{s.volume})
-	c.Assert(found, gc.HasLen, 1)
-	c.Assert(found[0], gc.DeepEquals, expected)
-}
-
-func (s *volumeSuite) TestVolumeAttachmentsError(c *gc.C) {
-	s.state.volumeAttachments =
-		func(volume names.VolumeTag) ([]state.VolumeAttachment, error) {
-			return nil, errors.Errorf("not for volume %v", volume)
-		}
-
-	found := storage.VolumeAttachments(s.api, []state.Volume{s.volume})
-	c.Assert(found, gc.HasLen, 1)
-	c.Assert(found[0].Error, gc.ErrorMatches, ".*for volume.*")
-}
-
-func (s *volumeSuite) TestListVolumeAttachmentsEmpty(c *gc.C) {
-	s.state.allVolumes =
-		func() ([]state.Volume, error) {
-			return nil, nil
-		}
-	items, err := storage.ListVolumeAttachments(s.api)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(items, gc.IsNil)
-}
-
-func (s *volumeSuite) TestListVolumeAttachmentsError(c *gc.C) {
-	msg := "inventing error"
-	s.state.allVolumes =
-		func() ([]state.Volume, error) {
-			return nil, errors.New(msg)
-		}
-	items, err := storage.ListVolumeAttachments(s.api)
-	c.Assert(errors.Cause(err), gc.ErrorMatches, msg)
-	c.Assert(items, gc.IsNil)
-}
-
-func (s *volumeSuite) TestListVolumeAttachments(c *gc.C) {
-	expectedVolume, err := storage.ConvertStateVolumeToParams(s.api, s.volume)
-	c.Assert(err, jc.ErrorIsNil)
-	expected := params.VolumeItem{
-		Volume: expectedVolume,
-		Attachments: storage.ConvertStateVolumeAttachmentsToParams(
-			[]state.VolumeAttachment{s.volumeAttachment},
-		),
-	}
-
-	items, err := storage.ListVolumeAttachments(s.api)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(items, gc.HasLen, 1)
-	c.Assert(items[0], gc.DeepEquals, expected)
 }
 
 func (s *volumeSuite) TestListVolumesEmptyFilter(c *gc.C) {
-	expectedVolume, err := storage.ConvertStateVolumeToParams(s.api, s.volume)
-	c.Assert(err, jc.ErrorIsNil)
-	expected := params.VolumeItem{
-		Volume: expectedVolume,
-		Attachments: storage.ConvertStateVolumeAttachmentsToParams(
-			[]state.VolumeAttachment{s.volumeAttachment},
-		),
-	}
 	found, err := s.api.ListVolumes(params.VolumeFilter{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(found.Results, gc.HasLen, 1)
-	c.Assert(found.Results[0], gc.DeepEquals, expected)
+	c.Assert(found.Results[0], gc.DeepEquals, s.expectedVolumeDetailsResult())
 }
 
 func (s *volumeSuite) TestListVolumesError(c *gc.C) {
 	msg := "inventing error"
-	s.state.allVolumes =
-		func() ([]state.Volume, error) {
-			return nil, errors.New(msg)
-		}
+	s.state.allVolumes = func() ([]state.Volume, error) {
+		return nil, errors.New(msg)
+	}
+	_, err := s.api.ListVolumes(params.VolumeFilter{})
+	c.Assert(err, gc.ErrorMatches, msg)
+}
 
-	items, err := s.api.ListVolumes(params.VolumeFilter{})
-	c.Assert(errors.Cause(err), gc.ErrorMatches, msg)
-	c.Assert(items, gc.DeepEquals, params.VolumeItemsResult{})
+func (s *volumeSuite) TestListVolumesNoVolumes(c *gc.C) {
+	s.state.allVolumes = func() ([]state.Volume, error) {
+		return nil, nil
+	}
+	results, err := s.api.ListVolumes(params.VolumeFilter{})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results.Results, gc.HasLen, 0)
 }
 
 func (s *volumeSuite) TestListVolumesFilter(c *gc.C) {
-	expectedVolume, err := storage.ConvertStateVolumeToParams(s.api, s.volume)
-	c.Assert(err, jc.ErrorIsNil)
-	expected := params.VolumeItem{
-		Volume: expectedVolume,
-		Attachments: storage.ConvertStateVolumeAttachmentsToParams(
-			[]state.VolumeAttachment{s.volumeAttachment},
-		),
-	}
 	filter := params.VolumeFilter{
-		Machines: []string{s.machineTag.String()}}
+		Machines: []string{s.machineTag.String()},
+	}
 	found, err := s.api.ListVolumes(filter)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(found.Results, gc.HasLen, 1)
-	c.Assert(found.Results[0], gc.DeepEquals, expected)
+	c.Assert(found.Results[0], jc.DeepEquals, s.expectedVolumeDetailsResult())
+}
+
+func (s *volumeSuite) TestListVolumesFilterNonMatching(c *gc.C) {
+	filter := params.VolumeFilter{
+		Machines: []string{"machine-42"},
+	}
+	found, err := s.api.ListVolumes(filter)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(found.Results, gc.HasLen, 0)
+}
+
+func (s *volumeSuite) TestListVolumesVolumeInfo(c *gc.C) {
+	s.volume.info = &state.VolumeInfo{
+		Size:       123,
+		HardwareId: "abc",
+		Persistent: true,
+	}
+	expected := s.expectedVolumeDetailsResult()
+	expected.Details.Info.Size = 123
+	expected.Details.Info.HardwareId = "abc"
+	expected.Details.Info.Persistent = true
+	expected.LegacyVolume.Size = 123
+	expected.LegacyVolume.HardwareId = "abc"
+	expected.LegacyVolume.Persistent = true
+	found, err := s.api.ListVolumes(params.VolumeFilter{})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(found.Results, gc.HasLen, 1)
+	c.Assert(found.Results[0], jc.DeepEquals, expected)
+}
+
+func (s *volumeSuite) TestListVolumesAttachmentInfo(c *gc.C) {
+	s.volumeAttachment.info = &state.VolumeAttachmentInfo{
+		DeviceName: "xvdf1",
+		ReadOnly:   true,
+	}
+	expected := s.expectedVolumeDetailsResult()
+	expected.Details.MachineAttachments[s.machineTag.String()] = params.VolumeAttachmentInfo{
+		DeviceName: "xvdf1",
+		ReadOnly:   true,
+	}
+	expected.LegacyAttachments[0].Info = params.VolumeAttachmentInfo{
+		DeviceName: "xvdf1",
+		ReadOnly:   true,
+	}
+	found, err := s.api.ListVolumes(params.VolumeFilter{})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(found.Results, gc.HasLen, 1)
+	c.Assert(found.Results[0], jc.DeepEquals, expected)
 }

--- a/cmd/juju/storage/list.go
+++ b/cmd/juju/storage/list.go
@@ -70,7 +70,7 @@ func (c *ListCommand) Run(ctx *cmd.Context) (err error) {
 	var valid []params.StorageDetails
 	for _, one := range found {
 		if one.Error == nil {
-			valid = append(valid, one.StorageDetails)
+			valid = append(valid, one.Result)
 			continue
 		}
 		// display individual error
@@ -93,7 +93,7 @@ var (
 // StorageAPI defines the API methods that the storage commands use.
 type StorageListAPI interface {
 	Close() error
-	List() ([]params.StorageInfo, error)
+	List() ([]params.StorageDetailsResult, error)
 }
 
 func (c *ListCommand) getStorageListAPI() (StorageListAPI, error) {

--- a/cmd/juju/storage/list.go
+++ b/cmd/juju/storage/list.go
@@ -67,10 +67,12 @@ func (c *ListCommand) Run(ctx *cmd.Context) (err error) {
 		return err
 	}
 	// filter out valid output, if any
-	var valid []params.StorageDetails
+	var valid []params.LegacyStorageDetails
 	for _, one := range found {
 		if one.Error == nil {
-			valid = append(valid, one.Result)
+			// TODO(axw) use non-legacy if available,
+			// convert from legacy otherwise.
+			valid = append(valid, one.Legacy)
 			continue
 		}
 		// display individual error

--- a/cmd/juju/storage/list_test.go
+++ b/cmd/juju/storage/list_test.go
@@ -137,15 +137,15 @@ func (s mockListAPI) Close() error {
 	return nil
 }
 
-func (s mockListAPI) List() ([]params.StorageInfo, error) {
-	result := []params.StorageInfo{}
+func (s mockListAPI) List() ([]params.StorageDetailsResult, error) {
+	result := []params.StorageDetailsResult{}
 	result = append(result, getTestAttachments(s.lexicalChaos)...)
 	result = append(result, getTestInstances(s.lexicalChaos)...)
 	return result, nil
 }
 
-func getTestAttachments(chaos bool) []params.StorageInfo {
-	results := []params.StorageInfo{{
+func getTestAttachments(chaos bool) []params.StorageDetailsResult {
+	results := []params.StorageDetailsResult{{
 		params.StorageDetails{
 			StorageTag: "storage-shared-fs-0",
 			OwnerTag:   "service-transcode",
@@ -165,7 +165,7 @@ func getTestAttachments(chaos bool) []params.StorageInfo {
 		}, nil}}
 
 	if chaos {
-		last := params.StorageInfo{
+		last := params.StorageDetailsResult{
 			params.StorageDetails{
 				StorageTag: "storage-shared-fs-5",
 				OwnerTag:   "service-transcode",
@@ -174,7 +174,7 @@ func getTestAttachments(chaos bool) []params.StorageInfo {
 				Location:   "nowhere",
 				Status:     "pending",
 			}, nil}
-		second := params.StorageInfo{
+		second := params.StorageDetailsResult{
 			params.StorageDetails{
 				StorageTag: "storage-db-dir-1010",
 				OwnerTag:   "unit-transcode-1",
@@ -183,7 +183,7 @@ func getTestAttachments(chaos bool) []params.StorageInfo {
 				Location:   "",
 				Status:     "pending",
 			}, &params.Error{Message: "error for storage-db-dir-1010"}}
-		first := params.StorageInfo{
+		first := params.StorageDetailsResult{
 			params.StorageDetails{
 				StorageTag: "storage-db-dir-1000",
 				OwnerTag:   "unit-transcode-1",
@@ -199,9 +199,9 @@ func getTestAttachments(chaos bool) []params.StorageInfo {
 	return results
 }
 
-func getTestInstances(chaos bool) []params.StorageInfo {
+func getTestInstances(chaos bool) []params.StorageDetailsResult {
 
-	results := []params.StorageInfo{
+	results := []params.StorageDetailsResult{
 		{
 			params.StorageDetails{
 				StorageTag: "storage-shared-fs-0",
@@ -243,7 +243,7 @@ func getTestInstances(chaos bool) []params.StorageInfo {
 			}, nil}}
 
 	if chaos {
-		last := params.StorageInfo{
+		last := params.StorageDetailsResult{
 			params.StorageDetails{
 				StorageTag: "storage-shared-fs-5",
 				OwnerTag:   "service-transcode",
@@ -251,14 +251,14 @@ func getTestInstances(chaos bool) []params.StorageInfo {
 				Kind:       params.StorageKindUnknown,
 				Status:     "pending",
 			}, nil}
-		second := params.StorageInfo{
+		second := params.StorageDetailsResult{
 			params.StorageDetails{
 				StorageTag: "storage-db-dir-1010",
 				UnitTag:    "unit-transcode-1",
 				Kind:       params.StorageKindBlock,
 				Status:     "pending",
 			}, &params.Error{Message: "error for test storage-db-dir-1010"}}
-		first := params.StorageInfo{
+		first := params.StorageDetailsResult{
 			params.StorageDetails{
 				StorageTag: "storage-db-dir-1000",
 				UnitTag:    "unit-transcode-1",
@@ -266,7 +266,7 @@ func getTestInstances(chaos bool) []params.StorageInfo {
 				Status:     "pending",
 				Persistent: true,
 			}, nil}
-		zero := params.StorageInfo{
+		zero := params.StorageDetailsResult{
 			params.StorageDetails{
 				StorageTag: "storage-db-dir-1100",
 				UnitTag:    "unit-postgresql-0",

--- a/cmd/juju/storage/list_test.go
+++ b/cmd/juju/storage/list_test.go
@@ -146,15 +146,16 @@ func (s mockListAPI) List() ([]params.StorageDetailsResult, error) {
 
 func getTestAttachments(chaos bool) []params.StorageDetailsResult {
 	results := []params.StorageDetailsResult{{
-		params.StorageDetails{
+		Legacy: params.LegacyStorageDetails{
 			StorageTag: "storage-shared-fs-0",
 			OwnerTag:   "service-transcode",
 			UnitTag:    "unit-transcode-0",
 			Kind:       params.StorageKindBlock,
 			Location:   "here",
 			Status:     "attached",
-		}, nil}, {
-		params.StorageDetails{
+		},
+	}, {
+		Legacy: params.LegacyStorageDetails{
 			StorageTag: "storage-db-dir-1000",
 			OwnerTag:   "unit-transcode-0",
 			UnitTag:    "unit-transcode-0",
@@ -162,36 +163,33 @@ func getTestAttachments(chaos bool) []params.StorageDetailsResult {
 			Location:   "there",
 			Status:     "provisioned",
 			Persistent: true,
-		}, nil}}
+		},
+	}}
 
 	if chaos {
 		last := params.StorageDetailsResult{
-			params.StorageDetails{
+			Legacy: params.LegacyStorageDetails{
 				StorageTag: "storage-shared-fs-5",
 				OwnerTag:   "service-transcode",
 				UnitTag:    "unit-transcode-0",
 				Kind:       params.StorageKindUnknown,
 				Location:   "nowhere",
 				Status:     "pending",
-			}, nil}
+			},
+		}
 		second := params.StorageDetailsResult{
-			params.StorageDetails{
-				StorageTag: "storage-db-dir-1010",
-				OwnerTag:   "unit-transcode-1",
-				UnitTag:    "unit-transcode-1",
-				Kind:       params.StorageKindBlock,
-				Location:   "",
-				Status:     "pending",
-			}, &params.Error{Message: "error for storage-db-dir-1010"}}
+			Error: &params.Error{Message: "error for storage-db-dir-1010"},
+		}
 		first := params.StorageDetailsResult{
-			params.StorageDetails{
+			Legacy: params.LegacyStorageDetails{
 				StorageTag: "storage-db-dir-1000",
 				OwnerTag:   "unit-transcode-1",
 				UnitTag:    "unit-transcode-1",
 				Kind:       params.StorageKindFilesystem,
 				Status:     "attached",
 				Persistent: true,
-			}, nil}
+			},
+		}
 		results = append(results, last)
 		results = append(results, second)
 		results = append(results, first)
@@ -201,78 +199,77 @@ func getTestAttachments(chaos bool) []params.StorageDetailsResult {
 
 func getTestInstances(chaos bool) []params.StorageDetailsResult {
 
-	results := []params.StorageDetailsResult{
-		{
-			params.StorageDetails{
-				StorageTag: "storage-shared-fs-0",
-				OwnerTag:   "service-transcode",
-				UnitTag:    "unit-transcode-0",
-				Kind:       params.StorageKindUnknown,
-				Status:     "pending",
-			}, nil},
-		{
-			params.StorageDetails{
-				StorageTag: "storage-shared-fs-0",
-				OwnerTag:   "service-transcode",
-				UnitTag:    "unit-transcode-1",
-				Kind:       params.StorageKindUnknown,
-				Status:     "pending",
-			}, nil},
-		{
-			params.StorageDetails{
-				StorageTag: "storage-db-dir-1100",
-				UnitTag:    "unit-postgresql-0",
-				Kind:       params.StorageKindFilesystem,
-				Status:     "pending",
-			}, nil},
-		{
-			params.StorageDetails{
-				StorageTag: "storage-db-dir-1100",
-				UnitTag:    "unit-transcode-0",
-				Kind:       params.StorageKindFilesystem,
-				Status:     "pending",
-			}, nil},
-		{
-			params.StorageDetails{
-				StorageTag: "storage-db-dir-1000",
-				OwnerTag:   "unit-transcode-0",
-				UnitTag:    "unit-transcode-0",
-				Kind:       params.StorageKindBlock,
-				Status:     "pending",
-				Persistent: true,
-			}, nil}}
+	results := []params.StorageDetailsResult{{
+		Legacy: params.LegacyStorageDetails{
+			StorageTag: "storage-shared-fs-0",
+			OwnerTag:   "service-transcode",
+			UnitTag:    "unit-transcode-0",
+			Kind:       params.StorageKindUnknown,
+			Status:     "pending",
+		},
+	}, {
+		Legacy: params.LegacyStorageDetails{
+			StorageTag: "storage-shared-fs-0",
+			OwnerTag:   "service-transcode",
+			UnitTag:    "unit-transcode-1",
+			Kind:       params.StorageKindUnknown,
+			Status:     "pending",
+		},
+	}, {
+		Legacy: params.LegacyStorageDetails{
+			StorageTag: "storage-db-dir-1100",
+			UnitTag:    "unit-postgresql-0",
+			Kind:       params.StorageKindFilesystem,
+			Status:     "pending",
+		},
+	}, {
+		Legacy: params.LegacyStorageDetails{
+			StorageTag: "storage-db-dir-1100",
+			UnitTag:    "unit-transcode-0",
+			Kind:       params.StorageKindFilesystem,
+			Status:     "pending",
+		},
+	}, {
+		Legacy: params.LegacyStorageDetails{
+			StorageTag: "storage-db-dir-1000",
+			OwnerTag:   "unit-transcode-0",
+			UnitTag:    "unit-transcode-0",
+			Kind:       params.StorageKindBlock,
+			Status:     "pending",
+			Persistent: true,
+		},
+	}}
 
 	if chaos {
 		last := params.StorageDetailsResult{
-			params.StorageDetails{
+			Legacy: params.LegacyStorageDetails{
 				StorageTag: "storage-shared-fs-5",
 				OwnerTag:   "service-transcode",
 				UnitTag:    "unit-transcode-0",
 				Kind:       params.StorageKindUnknown,
 				Status:     "pending",
-			}, nil}
+			},
+		}
 		second := params.StorageDetailsResult{
-			params.StorageDetails{
-				StorageTag: "storage-db-dir-1010",
-				UnitTag:    "unit-transcode-1",
-				Kind:       params.StorageKindBlock,
-				Status:     "pending",
-			}, &params.Error{Message: "error for test storage-db-dir-1010"}}
+			Error: &params.Error{Message: "error for test storage-db-dir-1010"},
+		}
 		first := params.StorageDetailsResult{
-			params.StorageDetails{
+			Legacy: params.LegacyStorageDetails{
 				StorageTag: "storage-db-dir-1000",
 				UnitTag:    "unit-transcode-1",
 				Kind:       params.StorageKindFilesystem,
 				Status:     "pending",
 				Persistent: true,
-			}, nil}
+			},
+		}
 		zero := params.StorageDetailsResult{
-			params.StorageDetails{
+			Legacy: params.LegacyStorageDetails{
 				StorageTag: "storage-db-dir-1100",
 				UnitTag:    "unit-postgresql-0",
 				Kind:       params.StorageKindFilesystem,
 				Status:     "pending",
-			}, nil}
+			},
+		}
 		results = append(results, last)
 		results = append(results, second)
 		results = append(results, zero)

--- a/cmd/juju/storage/show_test.go
+++ b/cmd/juju/storage/show_test.go
@@ -130,31 +130,33 @@ func (s mockShowAPI) Close() error {
 	return nil
 }
 
-func (s mockShowAPI) Show(tags []names.StorageTag) ([]params.StorageDetails, error) {
+func (s mockShowAPI) Show(tags []names.StorageTag) ([]params.StorageDetailsResult, error) {
 	if s.noMatch {
 		return nil, nil
 	}
-	all := make([]params.StorageDetails, len(tags))
+	all := make([]params.StorageDetailsResult, len(tags))
 	for i, tag := range tags {
-		all[i] = params.StorageDetails{
+		all[i].Legacy = params.LegacyStorageDetails{
 			StorageTag: tag.String(),
 			UnitTag:    "unit-postgresql-0",
 			Kind:       params.StorageKindBlock,
 			Status:     "pending",
 		}
 		if i == 1 {
-			all[i].Persistent = true
+			all[i].Legacy.Persistent = true
 		}
 	}
 	for _, tag := range tags {
 		if strings.Contains(tag.String(), "shared") {
-			all = append(all, params.StorageDetails{
-				StorageTag: tag.String(),
-				OwnerTag:   "unit-transcode-0",
-				UnitTag:    "unit-transcode-0",
-				Kind:       params.StorageKindFilesystem,
-				Location:   "a location",
-				Status:     "attached",
+			all = append(all, params.StorageDetailsResult{
+				Legacy: params.LegacyStorageDetails{
+					StorageTag: tag.String(),
+					OwnerTag:   "unit-transcode-0",
+					UnitTag:    "unit-transcode-0",
+					Kind:       params.StorageKindFilesystem,
+					Location:   "a location",
+					Status:     "attached",
+				},
 			})
 		}
 	}

--- a/cmd/juju/storage/storage.go
+++ b/cmd/juju/storage/storage.go
@@ -66,9 +66,9 @@ type StorageInfo struct {
 	Location    string `yaml:"location,omitempty" json:"location,omitempty"`
 }
 
-// formatStorageDetails takes a set of StorageDetail and creates a
+// formatStorageDetails takes a set of LegacyStorageDetail and creates a
 // mapping keyed on unit and storage id.
-func formatStorageDetails(storages []params.StorageDetails) (map[string]map[string]StorageInfo, error) {
+func formatStorageDetails(storages []params.LegacyStorageDetails) (map[string]map[string]StorageInfo, error) {
 	if len(storages) == 0 {
 		return nil, nil
 	}

--- a/cmd/juju/storage/volumelist.go
+++ b/cmd/juju/storage/volumelist.go
@@ -71,7 +71,7 @@ func (c *VolumeListCommand) Run(ctx *cmd.Context) (err error) {
 		return err
 	}
 	// filter out valid output, if any
-	var valid []params.VolumeItem
+	var valid []params.VolumeDetailsResult
 	for _, one := range found {
 		if one.Error == nil {
 			valid = append(valid, one)
@@ -95,7 +95,7 @@ var getVolumeListAPI = (*VolumeListCommand).getVolumeListAPI
 // VolumeListAPI defines the API methods that the volume list command use.
 type VolumeListAPI interface {
 	Close() error
-	ListVolumes(machines []string) ([]params.VolumeItem, error)
+	ListVolumes(machines []string) ([]params.VolumeDetailsResult, error)
 }
 
 func (c *VolumeListCommand) getVolumeListAPI() (VolumeListAPI, error) {

--- a/cmd/juju/storage/volumelist_test.go
+++ b/cmd/juju/storage/volumelist_test.go
@@ -243,96 +243,81 @@ func (s mockVolumeListAPI) Close() error {
 	return nil
 }
 
-func (s mockVolumeListAPI) ListVolumes(machines []string) ([]params.VolumeItem, error) {
+func (s mockVolumeListAPI) ListVolumes(machines []string) ([]params.VolumeDetailsResult, error) {
 	if s.errOut != "" {
 		return nil, errors.New(s.errOut)
 	}
 	if s.listEmpty {
 		return nil, nil
 	}
-	result := []params.VolumeItem{}
+	result := []params.VolumeDetailsResult{}
 	if s.addErrItem {
-		result = append(result, params.VolumeItem{
+		result = append(result, params.VolumeDetailsResult{
 			Error: common.ServerError(errors.New("volume item error"))})
 	}
 	if s.listAll {
 		machines = []string{"25", "42"}
 		//unattached
-		result = append(result, s.createTestVolumeItem(
+		result = append(result, s.createTestVolumeDetailsResult(
 			"3/4", true, "db-dir/1000", "abc/0", nil,
 			createTestStatus(params.StatusDestroying, ""),
 		))
-		result = append(result, s.createTestVolumeItem(
+		result = append(result, s.createTestVolumeDetailsResult(
 			"3/3", false, "", "", nil,
 			createTestStatus(params.StatusDestroying, ""),
 		))
 	}
-	result = append(result, s.createTestVolumeItem(
+	result = append(result, s.createTestVolumeDetailsResult(
 		"0/1", true, "shared-fs/0", "postgresql/0", machines,
 		createTestStatus(params.StatusAttaching, "failed to attach"),
 	))
-	result = append(result, s.createTestVolumeItem(
+	result = append(result, s.createTestVolumeDetailsResult(
 		"0/abc/0/88", false, "shared-fs/0", "", machines,
 		createTestStatus(params.StatusAttached, ""),
 	))
 	return result, nil
 }
 
-func (s mockVolumeListAPI) createTestVolumeItem(
+func (s mockVolumeListAPI) createTestVolumeDetailsResult(
 	id string,
 	persistent bool,
 	storageid, unitid string,
 	machines []string,
 	status params.EntityStatus,
-) params.VolumeItem {
+) params.VolumeDetailsResult {
+
 	volume := s.createTestVolume(id, persistent, storageid, unitid, status)
-
-	// Create unattached volume
-	if len(machines) == 0 {
-		return params.VolumeItem{Volume: volume}
-	}
-
-	// Create volume attachments
-	attachments := make([]params.VolumeAttachment, len(machines))
+	volume.MachineAttachments = make(map[string]params.VolumeAttachmentInfo)
 	for i, machine := range machines {
-		attachments[i] = s.createTestAttachment(volume.VolumeTag, machine, i%2 == 0)
+		info := params.VolumeAttachmentInfo{
+			ReadOnly: i%2 == 0,
+		}
+		if s.fillDeviceName {
+			info.DeviceName = "testdevice"
+		}
+		machineTag := names.NewMachineTag(machine).String()
+		volume.MachineAttachments[machineTag] = info
 	}
-
-	return params.VolumeItem{
-		Volume:      volume,
-		Attachments: attachments,
-	}
+	return params.VolumeDetailsResult{Details: volume}
 }
 
-func (s mockVolumeListAPI) createTestVolume(id string, persistent bool, storageid, unitid string, status params.EntityStatus) params.VolumeInstance {
+func (s mockVolumeListAPI) createTestVolume(id string, persistent bool, storageid, unitid string, status params.EntityStatus) *params.VolumeDetails {
 	tag := names.NewVolumeTag(id)
-	result := params.VolumeInstance{
-		VolumeTag:  tag.String(),
-		VolumeId:   "provider-supplied-" + tag.Id(),
-		HardwareId: "serial blah blah",
-		Persistent: persistent,
-		Size:       uint64(1024),
-		Status:     status,
+	result := &params.VolumeDetails{
+		VolumeTag: tag.String(),
+		Info: params.VolumeInfo{
+			VolumeId:   "provider-supplied-" + tag.Id(),
+			HardwareId: "serial blah blah",
+			Persistent: persistent,
+			Size:       uint64(1024),
+		},
+		Status: status,
 	}
 	if storageid != "" {
 		result.StorageTag = names.NewStorageTag(storageid).String()
 	}
 	if unitid != "" {
-		result.UnitTag = names.NewUnitTag(unitid).String()
-	}
-	return result
-}
-
-func (s mockVolumeListAPI) createTestAttachment(volumeTag, machine string, readonly bool) params.VolumeAttachment {
-	result := params.VolumeAttachment{
-		VolumeTag:  volumeTag,
-		MachineTag: names.NewMachineTag(machine).String(),
-		Info: params.VolumeAttachmentInfo{
-			ReadOnly: readonly,
-		},
-	}
-	if s.fillDeviceName {
-		result.Info.DeviceName = "testdevice"
+		result.StorageOwnerTag = names.NewUnitTag(unitid).String()
 	}
 	return result
 }

--- a/featuretests/storage_test.go
+++ b/featuretests/storage_test.go
@@ -392,12 +392,10 @@ func runVolumeList(c *gc.C, args ...string) *cmd.Context {
 }
 
 func (s *cmdStorageSuite) TestListVolumeInvalidMachine(c *gc.C) {
-	context := runVolumeList(c, "abc", "--format", "yaml")
-	c.Assert(testing.Stdout(context), gc.Equals, "")
-	c.Assert(testing.Stderr(context),
-		gc.Matches,
-		`parsing machine tag machine-abc: "machine-abc" is not a valid machine tag
-`)
+	_, err := testing.RunCommand(
+		c, envcmd.Wrap(&cmdstorage.VolumeListCommand{}), "abc",
+	)
+	c.Assert(err, gc.ErrorMatches, `"machine-abc" is not a valid machine tag`)
 }
 
 func (s *cmdStorageSuite) TestListVolumeTabularFilterMatch(c *gc.C) {


### PR DESCRIPTION
(NOTE: the first commit is a cherry-pick from master, fixing up the VolumeDetails params struct. There were no conflicts, this does not need to be reviewed. I suggest reviewing the individual commits, rather than the full diff on RB.)

The second commit is a drive-by cleanup, removing a redundant type (params.StorageInfo).

The third commit is where the meat is. This is the first in a series of changes to fix the "storage" API facade and storage CLI commands to better reflect the model. This is necessary to cater for future changes, to support shared storage.

This change in particular renames the existing apiserver/params.StorageDetails to LegacyStorageDetails, and introduces a new StorageDetails. On the server we always populate both legacy and new. A follow-up will change the CLI to use the new details structure, falling back to legacy if
the new one is not available (i.e. old server).

(Review request: http://reviews.vapour.ws/r/2653/)