### PR TITLE
Fix 1476918: switch with no environments.yaml

### DIFF
--- a/cmd/juju/commands/switch_test.go
+++ b/cmd/juju/commands/switch_test.go
@@ -23,17 +23,36 @@ type SwitchSimpleSuite struct {
 
 var _ = gc.Suite(&SwitchSimpleSuite{})
 
-func (*SwitchSimpleSuite) TestNoEnvironment(c *gc.C) {
+func (s *SwitchSimpleSuite) TestNoEnvironmentReadsConfigStore(c *gc.C) {
 	envPath := gitjujutesting.HomePath(".juju", "environments.yaml")
 	err := os.Remove(envPath)
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = testing.RunCommand(c, &SwitchCommand{})
-	c.Assert(err, gc.ErrorMatches, "couldn't read the environment")
+	s.addTestSystem(c)
+	context, err := testing.RunCommand(c, &SwitchCommand{}, "--list")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(testing.Stdout(context), gc.Equals, "a-system (system)\n")
+}
+
+func (s *SwitchSimpleSuite) TestErrorReadingEnvironmentsFile(c *gc.C) {
+	envPath := gitjujutesting.HomePath(".juju", "environments.yaml")
+	err := os.Chmod(envPath, 0)
+	c.Assert(err, jc.ErrorIsNil)
+	s.addTestSystem(c)
+	_, err = testing.RunCommand(c, &SwitchCommand{}, "--list")
+	c.Assert(err, gc.ErrorMatches, "couldn't read the environment: open .*: permission denied")
 }
 
 func (*SwitchSimpleSuite) TestNoDefault(c *gc.C) {
 	testing.WriteEnvironments(c, testing.MultipleEnvConfigNoDefault)
 	_, err := testing.RunCommand(c, &SwitchCommand{})
+	c.Assert(err, gc.ErrorMatches, "no currently specified environment")
+}
+
+func (*SwitchSimpleSuite) TestNoDefaultNoEnvironmentsFile(c *gc.C) {
+	envPath := gitjujutesting.HomePath(".juju", "environments.yaml")
+	err := os.Remove(envPath)
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = testing.RunCommand(c, &SwitchCommand{})
 	c.Assert(err, gc.ErrorMatches, "no currently specified environment")
 }
 


### PR DESCRIPTION
This fixes the switch command to function even if
there is no environments.yaml file (which could be
the case when sharing environments).

If no environments.yaml file exists, switch will
read from the config store to get information
about known environments.

(Review request: http://reviews.vapour.ws/r/2657/)