### PR TITLE
cmd/juju/storage: update to new StorageDetails

### DIFF
--- a/cmd/juju/storage/show.go
+++ b/cmd/juju/storage/show.go
@@ -78,15 +78,17 @@ func (c *ShowCommand) Run(ctx *cmd.Context) (err error) {
 	}
 
 	var errs params.ErrorResults
-	var valid []params.LegacyStorageDetails
+	var valid []params.StorageDetails
 	for _, result := range results {
 		if result.Error != nil {
 			errs.Results = append(errs.Results, params.ErrorResult{result.Error})
 			continue
 		}
-		// TODO(axw) use non-legacy if available,
-		// convert from legacy otherwise.
-		valid = append(valid, result.Legacy)
+		if result.Result != nil {
+			valid = append(valid, *result.Result)
+		} else {
+			valid = append(valid, storageDetailsFromLegacy(result.Legacy))
+		}
 	}
 	if len(errs.Results) > 0 {
 		return errs.Combine()

--- a/cmd/juju/storage/show_test.go
+++ b/cmd/juju/storage/show_test.go
@@ -5,6 +5,7 @@ package storage_test
 
 import (
 	"strings"
+	"time"
 
 	"github.com/juju/cmd"
 	"github.com/juju/names"
@@ -17,6 +18,11 @@ import (
 	_ "github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/testing"
 )
+
+// epoch is the time we use for "since" in statuses. The time
+// is always shown as a local time, so we override the local
+// location to be UTC+8.
+var epoch = time.Unix(0, 0)
 
 type ShowSuite struct {
 	SubStorageSuite
@@ -32,6 +38,7 @@ func (s *ShowSuite) SetUpTest(c *gc.C) {
 	s.PatchValue(storage.GetStorageShowAPI, func(c *storage.ShowCommand) (storage.StorageShowAPI, error) {
 		return s.mockAPI, nil
 	})
+	s.PatchValue(&time.Local, time.FixedZone("Australia/Perth", 3600*8))
 
 }
 
@@ -56,19 +63,20 @@ func (s *ShowSuite) TestShow(c *gc.C) {
 		[]string{"shared-fs/0"},
 		// Default format is yaml
 		`
-postgresql/0:
-  shared-fs/0:
-    storage: shared-fs
-    kind: block
-    status: pending
-    persistent: false
-transcode/0:
-  shared-fs/0:
-    storage: shared-fs
-    kind: filesystem
-    status: attached
-    persistent: false
-    location: a location
+shared-fs/0:
+  kind: filesystem
+  status:
+    current: attached
+    since: 01 Jan 1970 08:00:00\+08:00
+  persistent: true
+  attachments:
+    units:
+      transcode/0:
+        machine: \"1\"
+        location: a location
+      transcode/1:
+        machine: \"2\"
+        location: b location
 `[1:],
 	)
 }
@@ -82,7 +90,7 @@ func (s *ShowSuite) TestShowJSON(c *gc.C) {
 	s.assertValidShow(
 		c,
 		[]string{"shared-fs/0", "--format", "json"},
-		`{"postgresql/0":{"shared-fs/0":{"storage":"shared-fs","kind":"block","status":"pending","persistent":false}},"transcode/0":{"shared-fs/0":{"storage":"shared-fs","kind":"filesystem","status":"attached","persistent":false,"location":"a location"}}}
+		`{"shared-fs/0":{"kind":"filesystem","status":{"current":"attached","since":"01 Jan 1970 08:00:00\+08:00"},"persistent":true,"attachments":{"units":{"transcode/0":{"machine":"1","location":"a location"},"transcode/1":{"machine":"2","location":"b location"}}}}}
 `,
 	)
 }
@@ -92,24 +100,29 @@ func (s *ShowSuite) TestShowMultipleReturn(c *gc.C) {
 		c,
 		[]string{"shared-fs/0", "db-dir/1000"},
 		`
-postgresql/0:
-  db-dir/1000:
-    storage: db-dir
-    kind: block
-    status: pending
-    persistent: true
-  shared-fs/0:
-    storage: shared-fs
-    kind: block
-    status: pending
-    persistent: false
-transcode/0:
-  shared-fs/0:
-    storage: shared-fs
-    kind: filesystem
-    status: attached
-    persistent: false
-    location: a location
+db-dir/1000:
+  kind: block
+  status:
+    current: pending
+    since: .*
+  persistent: true
+  attachments:
+    units:
+      postgresql/0: {}
+shared-fs/0:
+  kind: filesystem
+  status:
+    current: attached
+    since: 01 Jan 1970 08:00:00\+08:00
+  persistent: true
+  attachments:
+    units:
+      transcode/0:
+        machine: \"1\"
+        location: a location
+      transcode/1:
+        machine: \"2\"
+        location: b location
 `[1:],
 	)
 }
@@ -119,7 +132,7 @@ func (s *ShowSuite) assertValidShow(c *gc.C, args []string, expected string) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	obtained := testing.Stdout(context)
-	c.Assert(obtained, gc.Equals, expected)
+	c.Assert(obtained, gc.Matches, expected)
 }
 
 type mockShowAPI struct {
@@ -136,28 +149,37 @@ func (s mockShowAPI) Show(tags []names.StorageTag) ([]params.StorageDetailsResul
 	}
 	all := make([]params.StorageDetailsResult, len(tags))
 	for i, tag := range tags {
-		all[i].Legacy = params.LegacyStorageDetails{
-			StorageTag: tag.String(),
-			UnitTag:    "unit-postgresql-0",
-			Kind:       params.StorageKindBlock,
-			Status:     "pending",
-		}
-		if i == 1 {
-			all[i].Legacy.Persistent = true
-		}
-	}
-	for _, tag := range tags {
 		if strings.Contains(tag.String(), "shared") {
-			all = append(all, params.StorageDetailsResult{
-				Legacy: params.LegacyStorageDetails{
-					StorageTag: tag.String(),
-					OwnerTag:   "unit-transcode-0",
-					UnitTag:    "unit-transcode-0",
-					Kind:       params.StorageKindFilesystem,
-					Location:   "a location",
-					Status:     "attached",
+			all[i].Result = &params.StorageDetails{
+				StorageTag: tag.String(),
+				OwnerTag:   "service-transcode",
+				Kind:       params.StorageKindFilesystem,
+				Status: params.EntityStatus{
+					Status: "attached",
+					Since:  &epoch,
 				},
-			})
+				Persistent: true,
+				Attachments: map[string]params.StorageAttachmentDetails{
+					"unit-transcode-0": params.StorageAttachmentDetails{
+						MachineTag: "machine-1",
+						Location:   "a location",
+					},
+					"unit-transcode-1": params.StorageAttachmentDetails{
+						MachineTag: "machine-2",
+						Location:   "b location",
+					},
+				},
+			}
+		} else {
+			all[i].Legacy = params.LegacyStorageDetails{
+				StorageTag: tag.String(),
+				UnitTag:    "unit-postgresql-0",
+				Kind:       params.StorageKindBlock,
+				Status:     "pending",
+			}
+			if i == 1 {
+				all[i].Legacy.Persistent = true
+			}
 		}
 	}
 	return all, nil

--- a/featuretests/storage_test.go
+++ b/featuretests/storage_test.go
@@ -88,14 +88,18 @@ func (s *cmdStorageSuite) TestStorageShow(c *gc.C) {
 
 	context := runShow(c, "data/0")
 	expected := `
-storage-block/0:
-  data/0:
-    storage: data
-    kind: block
-    status: pending
-    persistent: false
+data/0:
+  kind: block
+  status:
+    current: pending
+    since: .*
+  persistent: false
+  attachments:
+    units:
+      storage-block/0:
+        machine: "0"
 `[1:]
-	c.Assert(testing.Stdout(context), gc.Equals, expected)
+	c.Assert(testing.Stdout(context), gc.Matches, expected)
 }
 
 func (s *cmdStorageSuite) TestStorageShowOneInvalid(c *gc.C) {
@@ -128,8 +132,8 @@ func (s *cmdStorageSuite) TestStorageList(c *gc.C) {
 	context := runList(c)
 	expected := `
 [Storage]       
-UNIT            ID     LOCATION STATUS  PERSISTENT 
-storage-block/0 data/0          pending false      
+UNIT            ID     LOCATION STATUS  MESSAGE 
+storage-block/0 data/0          pending         
 
 `[1:]
 	c.Assert(testing.Stdout(context), gc.Equals, expected)
@@ -143,8 +147,8 @@ func (s *cmdStorageSuite) TestStorageListPersistent(c *gc.C) {
 	context := runList(c)
 	expected := `
 [Storage]       
-UNIT            ID     LOCATION STATUS  PERSISTENT 
-storage-block/0 data/0          pending false      
+UNIT            ID     LOCATION STATUS  MESSAGE 
+storage-block/0 data/0          pending         
 
 `[1:]
 	c.Assert(testing.Stdout(context), gc.Equals, expected)
@@ -163,14 +167,18 @@ func (s *cmdStorageSuite) TestStoragePersistentProvisioned(c *gc.C) {
 
 	context := runShow(c, "data/0")
 	expected := `
-storage-block/0:
-  data/0:
-    storage: data
-    kind: block
-    status: pending
-    persistent: true
+data/0:
+  kind: block
+  status:
+    current: pending
+    since: .*
+  persistent: true
+  attachments:
+    units:
+      storage-block/0:
+        machine: "0"
 `[1:]
-	c.Assert(testing.Stdout(context), gc.Equals, expected)
+	c.Assert(testing.Stdout(context), gc.Matches, expected)
 }
 
 func (s *cmdStorageSuite) TestStoragePersistentUnprovisioned(c *gc.C) {
@@ -180,14 +188,18 @@ func (s *cmdStorageSuite) TestStoragePersistentUnprovisioned(c *gc.C) {
 	// will be persistent until it has been provisioned.
 	context := runShow(c, "data/0")
 	expected := `
-storage-block/0:
-  data/0:
-    storage: data
-    kind: block
-    status: pending
-    persistent: false
+data/0:
+  kind: block
+  status:
+    current: pending
+    since: .*
+  persistent: false
+  attachments:
+    units:
+      storage-block/0:
+        machine: "0"
 `[1:]
-	c.Assert(testing.Stdout(context), gc.Equals, expected)
+	c.Assert(testing.Stdout(context), gc.Matches, expected)
 }
 
 func runPoolList(c *gc.C, args ...string) *cmd.Context {
@@ -463,8 +475,8 @@ func (s *cmdStorageSuite) TestStorageAddToUnitHasVolumes(c *gc.C) {
 	context := runList(c)
 	c.Assert(testing.Stdout(context), gc.Equals, `
 [Storage]            
-UNIT                 ID     LOCATION STATUS  PERSISTENT 
-storage-filesystem/0 data/0          pending false      
+UNIT                 ID     LOCATION STATUS  MESSAGE 
+storage-filesystem/0 data/0          pending         
 
 `[1:])
 	c.Assert(testing.Stderr(context), gc.Equals, "")
@@ -484,9 +496,9 @@ storage-filesystem/0 data/0          pending false
 	context = runList(c)
 	c.Assert(testing.Stdout(context), gc.Equals, `
 [Storage]            
-UNIT                 ID     LOCATION STATUS  PERSISTENT 
-storage-filesystem/0 data/0          pending false      
-storage-filesystem/0 data/1          pending false      
+UNIT                 ID     LOCATION STATUS  MESSAGE 
+storage-filesystem/0 data/0          pending         
+storage-filesystem/0 data/1          pending         
 
 `[1:])
 	c.Assert(testing.Stderr(context), gc.Equals, "")


### PR DESCRIPTION
Update to use the new StorageDetails type, falling
back to LegacyStorageDetails if the new type is not
populated in the API response.

We also update the "storage list" and "storage show"
output format, as follows:
 - "list" output contains a top-level "storage" element
   to make it more obvious what the IDs are
 - PERSISTENT is removed from the tabular format, as
   it's not that something you want to know about all
   the time; it can be viewed through detailed JSON/YAML
   output
 - add the MESSAGE field to tabular format, which contains
   a status message (if any)
 - clearer YAML/JSON structure, with storage IDs at the
   top-level, then storage details, and then attachments
   under an "attachments" heading

Tidied up some tests, which were difficult to follow,
and contained unrealistic examples.

(Review request: http://reviews.vapour.ws/r/2660/)