### PR TITLE
cmd/juju/storage: rework volume list format

### DIFF
--- a/apiserver/params/storage.go
+++ b/apiserver/params/storage.go
@@ -530,14 +530,9 @@ type VolumeDetails struct {
 	// machine tag to volume attachment information.
 	MachineAttachments map[string]VolumeAttachmentInfo `json:"machineattachments,omitempty"`
 
-	// StorageTag is the tag of the storage instance
+	// Storage contains details about the storage instance
 	// that the volume is assigned to, if any.
-	StorageTag string `json:"storagetag,omitempty"`
-
-	// StorageOwnerTag is the tag of the entity that
-	// owns the volume's assigned storage instance,
-	// if any.
-	StorageOwnerTag string `json:"ownertag,omitempty"`
+	Storage *StorageDetails `json:"storage,omitempty"`
 }
 
 // LegacyVolumeDetails describes a storage volume in the environment

--- a/apiserver/storage/volumelist_test.go
+++ b/apiserver/storage/volumelist_test.go
@@ -21,14 +21,27 @@ var _ = gc.Suite(&volumeSuite{})
 func (s *volumeSuite) expectedVolumeDetailsResult() params.VolumeDetailsResult {
 	return params.VolumeDetailsResult{
 		Details: &params.VolumeDetails{
-			VolumeTag:       s.volumeTag.String(),
-			StorageTag:      "storage-data-0",
-			StorageOwnerTag: "unit-mysql-0",
+			VolumeTag: s.volumeTag.String(),
 			Status: params.EntityStatus{
 				Status: "attached",
 			},
 			MachineAttachments: map[string]params.VolumeAttachmentInfo{
 				s.machineTag.String(): params.VolumeAttachmentInfo{},
+			},
+			Storage: &params.StorageDetails{
+				StorageTag: "storage-data-0",
+				OwnerTag:   "unit-mysql-0",
+				Kind:       params.StorageKindFilesystem,
+				Status: params.EntityStatus{
+					Status: "pending",
+				},
+				Attachments: map[string]params.StorageAttachmentDetails{
+					"unit-mysql-0": params.StorageAttachmentDetails{
+						StorageTag: "storage-data-0",
+						UnitTag:    "unit-mysql-0",
+						MachineTag: "machine-66",
+					},
+				},
 			},
 		},
 		LegacyVolume: &params.LegacyVolumeDetails{
@@ -50,6 +63,8 @@ func (s *volumeSuite) TestListVolumesEmptyFilter(c *gc.C) {
 	found, err := s.api.ListVolumes(params.VolumeFilter{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(found.Results, gc.HasLen, 1)
+	c.Assert(found.Results[0].Details.Storage.Status.Since, gc.NotNil)
+	found.Results[0].Details.Storage.Status.Since = nil
 	c.Assert(found.Results[0], gc.DeepEquals, s.expectedVolumeDetailsResult())
 }
 
@@ -78,6 +93,8 @@ func (s *volumeSuite) TestListVolumesFilter(c *gc.C) {
 	found, err := s.api.ListVolumes(filter)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(found.Results, gc.HasLen, 1)
+	c.Assert(found.Results[0].Details.Storage.Status.Since, gc.NotNil)
+	found.Results[0].Details.Storage.Status.Since = nil
 	c.Assert(found.Results[0], jc.DeepEquals, s.expectedVolumeDetailsResult())
 }
 
@@ -106,6 +123,8 @@ func (s *volumeSuite) TestListVolumesVolumeInfo(c *gc.C) {
 	found, err := s.api.ListVolumes(params.VolumeFilter{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(found.Results, gc.HasLen, 1)
+	c.Assert(found.Results[0].Details.Storage.Status.Since, gc.NotNil)
+	found.Results[0].Details.Storage.Status.Since = nil
 	c.Assert(found.Results[0], jc.DeepEquals, expected)
 }
 
@@ -126,5 +145,7 @@ func (s *volumeSuite) TestListVolumesAttachmentInfo(c *gc.C) {
 	found, err := s.api.ListVolumes(params.VolumeFilter{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(found.Results, gc.HasLen, 1)
+	c.Assert(found.Results[0].Details.Storage.Status.Since, gc.NotNil)
+	found.Results[0].Details.Storage.Status.Since = nil
 	c.Assert(found.Results[0], jc.DeepEquals, expected)
 }

--- a/apiserver/storage/volumelist_test.go
+++ b/apiserver/storage/volumelist_test.go
@@ -59,12 +59,18 @@ func (s *volumeSuite) expectedVolumeDetailsResult() params.VolumeDetailsResult {
 	}
 }
 
+// TODO(axw) drop this in 1.26. This exists only because we don't have
+// Filesystem.Status, and so we use time.Now() to get Status.Since.
+func (s *volumeSuite) assertAndClearStorageStatus(c *gc.C, details *params.VolumeDetails) {
+	c.Assert(details.Storage.Status.Since, gc.NotNil)
+	details.Storage.Status.Since = nil
+}
+
 func (s *volumeSuite) TestListVolumesEmptyFilter(c *gc.C) {
 	found, err := s.api.ListVolumes(params.VolumeFilter{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(found.Results, gc.HasLen, 1)
-	c.Assert(found.Results[0].Details.Storage.Status.Since, gc.NotNil)
-	found.Results[0].Details.Storage.Status.Since = nil
+	s.assertAndClearStorageStatus(c, found.Results[0].Details)
 	c.Assert(found.Results[0], gc.DeepEquals, s.expectedVolumeDetailsResult())
 }
 
@@ -93,8 +99,7 @@ func (s *volumeSuite) TestListVolumesFilter(c *gc.C) {
 	found, err := s.api.ListVolumes(filter)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(found.Results, gc.HasLen, 1)
-	c.Assert(found.Results[0].Details.Storage.Status.Since, gc.NotNil)
-	found.Results[0].Details.Storage.Status.Since = nil
+	s.assertAndClearStorageStatus(c, found.Results[0].Details)
 	c.Assert(found.Results[0], jc.DeepEquals, s.expectedVolumeDetailsResult())
 }
 
@@ -123,8 +128,7 @@ func (s *volumeSuite) TestListVolumesVolumeInfo(c *gc.C) {
 	found, err := s.api.ListVolumes(params.VolumeFilter{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(found.Results, gc.HasLen, 1)
-	c.Assert(found.Results[0].Details.Storage.Status.Since, gc.NotNil)
-	found.Results[0].Details.Storage.Status.Since = nil
+	s.assertAndClearStorageStatus(c, found.Results[0].Details)
 	c.Assert(found.Results[0], jc.DeepEquals, expected)
 }
 
@@ -145,7 +149,6 @@ func (s *volumeSuite) TestListVolumesAttachmentInfo(c *gc.C) {
 	found, err := s.api.ListVolumes(params.VolumeFilter{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(found.Results, gc.HasLen, 1)
-	c.Assert(found.Results[0].Details.Storage.Status.Since, gc.NotNil)
-	found.Results[0].Details.Storage.Status.Since = nil
+	s.assertAndClearStorageStatus(c, found.Results[0].Details)
 	c.Assert(found.Results[0], jc.DeepEquals, expected)
 }

--- a/cmd/juju/storage/listformatters.go
+++ b/cmd/juju/storage/listformatters.go
@@ -111,31 +111,53 @@ func (s bySuffixNaturally) Swap(a, b int) {
 }
 
 func (s bySuffixNaturally) Less(a, b int) bool {
-	sa := strings.SplitN(s[a], "/", 2)
-	sb := strings.SplitN(s[b], "/", 2)
-	if sa[0] < sb[0] {
-		return true
+	return naturalCompare(s[a], s[b]) == -1
+}
+
+// naturalCompares a with b, first the string before "/",
+// and then the integer or string after. Empty strings
+// are sorted after all others.
+func naturalCompare(a, b string) int {
+	switch {
+	case a == "" && b == "":
+		return 0
+	case a == "":
+		return 1
+	case b == "":
+		return -1
 	}
-	altReturn := sa[0] == sb[0] && sa[1] < sb[1]
+
+	sa := strings.SplitN(a, "/", 2)
+	sb := strings.SplitN(b, "/", 2)
+	if sa[0] < sb[0] {
+		return -1
+	}
+	if sa[0] > sb[0] {
+		return 1
+	}
 
 	getInt := func(suffix string) (bool, int) {
 		num, err := strconv.Atoi(suffix)
 		if err != nil {
-			// It's possible that we are not looking at numeric suffix
-			logger.Infof("parsing a non-numeric %v: %v", suffix, err)
 			return false, 0
 		}
-		fmt.Printf("parsing a non-numeric %v: %v", suffix, err)
 		return true, num
 	}
 
 	naIsNumeric, na := getInt(sa[1])
 	if !naIsNumeric {
-		return altReturn
+		return strings.Compare(sa[1], sb[1])
 	}
 	nbIsNumeric, nb := getInt(sb[1])
 	if !nbIsNumeric {
-		return altReturn
+		return strings.Compare(sa[1], sb[1])
 	}
-	return sa[0] == sb[0] && na < nb
+
+	switch {
+	case na < nb:
+		return -1
+	case na == nb:
+		return 0
+	}
+	return 1
 }

--- a/cmd/juju/storage/listformatters.go
+++ b/cmd/juju/storage/listformatters.go
@@ -70,7 +70,7 @@ func formatListTabular(value interface{}) ([]byte, error) {
 	for unit := range byUnit {
 		units = append(units, unit)
 	}
-	sort.Strings(bySuffixNaturally(units))
+	sort.Strings(slashSeparatedIds(units))
 
 	for _, unit := range units {
 		// Then sort by storage ids
@@ -79,7 +79,7 @@ func formatListTabular(value interface{}) ([]byte, error) {
 		for storageId := range byStorage {
 			storageIds = append(storageIds, storageId)
 		}
-		sort.Strings(bySuffixNaturally(storageIds))
+		sort.Strings(slashSeparatedIds(storageIds))
 
 		for _, storageId := range storageIds {
 			info := byStorage[storageId]
@@ -100,24 +100,24 @@ type storageAttachmentInfo struct {
 	status     EntityStatus
 }
 
-type bySuffixNaturally []string
+type slashSeparatedIds []string
 
-func (s bySuffixNaturally) Len() int {
+func (s slashSeparatedIds) Len() int {
 	return len(s)
 }
 
-func (s bySuffixNaturally) Swap(a, b int) {
+func (s slashSeparatedIds) Swap(a, b int) {
 	s[a], s[b] = s[b], s[a]
 }
 
-func (s bySuffixNaturally) Less(a, b int) bool {
-	return naturalCompare(s[a], s[b]) == -1
+func (s slashSeparatedIds) Less(a, b int) bool {
+	return compareSlashSeparated(s[a], s[b]) == -1
 }
 
-// naturalCompares a with b, first the string before "/",
-// and then the integer or string after. Empty strings
-// are sorted after all others.
-func naturalCompare(a, b string) int {
+// compareSlashSeparated compares a with b, first the string before
+// "/", and then the integer or string after. Empty strings are sorted
+// after all others.
+func compareSlashSeparated(a, b string) int {
 	switch {
 	case a == "" && b == "":
 		return 0

--- a/cmd/juju/storage/listformatters.go
+++ b/cmd/juju/storage/listformatters.go
@@ -146,11 +146,11 @@ func compareSlashSeparated(a, b string) int {
 
 	naIsNumeric, na := getInt(sa[1])
 	if !naIsNumeric {
-		return strings.Compare(sa[1], sb[1])
+		return compareStrings(sa[1], sb[1])
 	}
 	nbIsNumeric, nb := getInt(sb[1])
 	if !nbIsNumeric {
-		return strings.Compare(sa[1], sb[1])
+		return compareStrings(sa[1], sb[1])
 	}
 
 	switch {
@@ -158,6 +158,18 @@ func compareSlashSeparated(a, b string) int {
 		return -1
 	case na == nb:
 		return 0
+	}
+	return 1
+}
+
+// compareStrings does what strings.Compare does, but without using
+// strings.Compare as it does not exist in Go 1.2.
+func compareStrings(a, b string) int {
+	if a == b {
+		return 0
+	}
+	if a < b {
+		return -1
 	}
 	return 1
 }

--- a/cmd/juju/storage/storage.go
+++ b/cmd/juju/storage/storage.go
@@ -85,6 +85,8 @@ type UnitStorageAttachment struct {
 
 	// Location is the location of the storage attachment.
 	Location string `yaml:"location,omitempty" json:"location,omitempty"`
+
+	// TODO(axw) per-unit status when we have it in state.
 }
 
 // formatStorageDetails takes a set of StorageDetail and
@@ -95,48 +97,56 @@ func formatStorageDetails(storages []params.StorageDetails) (map[string]StorageI
 	}
 	output := make(map[string]StorageInfo)
 	for _, details := range storages {
-		storageTag, err := names.ParseStorageTag(details.StorageTag)
+		storageTag, storageInfo, err := createStorageInfo(details)
 		if err != nil {
-			return nil, errors.Annotate(err, "invalid storage tag")
+			return nil, errors.Trace(err)
 		}
-
-		info := StorageInfo{
-			Kind: details.Kind.String(),
-			Status: EntityStatus{
-				details.Status.Status,
-				details.Status.Info,
-				// TODO(axw) we should support formatting as ISO time
-				common.FormatTime(details.Status.Since, false),
-			},
-			Persistent: details.Persistent,
-		}
-
-		if len(details.Attachments) > 0 {
-			unitStorageAttachments := make(map[string]UnitStorageAttachment)
-			for unitTagString, attachmentDetails := range details.Attachments {
-				unitTag, err := names.ParseUnitTag(unitTagString)
-				if err != nil {
-					return nil, errors.Trace(err)
-				}
-				var machineId string
-				if attachmentDetails.MachineTag != "" {
-					machineTag, err := names.ParseMachineTag(attachmentDetails.MachineTag)
-					if err != nil {
-						return nil, errors.Trace(err)
-					}
-					machineId = machineTag.Id()
-				}
-				unitStorageAttachments[unitTag.Id()] = UnitStorageAttachment{
-					machineId,
-					attachmentDetails.Location,
-				}
-			}
-			info.Attachments = &StorageAttachments{unitStorageAttachments}
-		}
-
-		output[storageTag.Id()] = info
+		output[storageTag.Id()] = storageInfo
 	}
 	return output, nil
+}
+
+func createStorageInfo(details params.StorageDetails) (names.StorageTag, StorageInfo, error) {
+	storageTag, err := names.ParseStorageTag(details.StorageTag)
+	if err != nil {
+		return names.StorageTag{}, StorageInfo{}, errors.Trace(err)
+	}
+
+	info := StorageInfo{
+		Kind: details.Kind.String(),
+		Status: EntityStatus{
+			details.Status.Status,
+			details.Status.Info,
+			// TODO(axw) we should support formatting as ISO time
+			common.FormatTime(details.Status.Since, false),
+		},
+		Persistent: details.Persistent,
+	}
+
+	if len(details.Attachments) > 0 {
+		unitStorageAttachments := make(map[string]UnitStorageAttachment)
+		for unitTagString, attachmentDetails := range details.Attachments {
+			unitTag, err := names.ParseUnitTag(unitTagString)
+			if err != nil {
+				return names.StorageTag{}, StorageInfo{}, errors.Trace(err)
+			}
+			var machineId string
+			if attachmentDetails.MachineTag != "" {
+				machineTag, err := names.ParseMachineTag(attachmentDetails.MachineTag)
+				if err != nil {
+					return names.StorageTag{}, StorageInfo{}, errors.Trace(err)
+				}
+				machineId = machineTag.Id()
+			}
+			unitStorageAttachments[unitTag.Id()] = UnitStorageAttachment{
+				machineId,
+				attachmentDetails.Location,
+			}
+		}
+		info.Attachments = &StorageAttachments{unitStorageAttachments}
+	}
+
+	return storageTag, info, nil
 }
 
 func storageDetailsFromLegacy(legacy params.LegacyStorageDetails) params.StorageDetails {

--- a/cmd/juju/storage/volume.go
+++ b/cmd/juju/storage/volume.go
@@ -42,10 +42,17 @@ type VolumeCommandBase struct {
 // VolumeInfo defines the serialization behaviour for storage volume.
 type VolumeInfo struct {
 	// from params.Volume. This is provider-supplied unique volume id.
-	VolumeId string `yaml:"id" json:"id"`
+	ProviderVolumeId string `yaml:"provider-id,omitempty" json:"provider-id,omitempty"`
+
+	// Storage is the ID of the storage instance that the volume is
+	// assigned to, if any.
+	Storage string `yaml:"storage,omitempty" json:"storage,omitempty"`
+
+	// Attachments is the set of entities attached to the volume.
+	Attachments *VolumeAttachments `yaml:"attachments,omitempty" json:"attachments,omitempty"`
 
 	// from params.Volume
-	HardwareId string `yaml:"hardwareid" json:"hardwareid"`
+	HardwareId string `yaml:"hardware-id,omitempty" json:"hardware-id,omitempty"`
 
 	// from params.Volume
 	Size uint64 `yaml:"size" json:"size"`
@@ -53,16 +60,6 @@ type VolumeInfo struct {
 	// from params.Volume
 	Persistent bool `yaml:"persistent" json:"persistent"`
 
-	// from params.VolumeAttachments
-	DeviceName string `yaml:"device,omitempty" json:"device,omitempty"`
-
-	// from params.VolumeAttachments
-	ReadOnly bool `yaml:"read-only" json:"read-only"`
-
-	// from params.Volume. This is juju volume id.
-	Volume string `yaml:"volume,omitempty" json:"volume,omitempty"`
-
-	// from params.Volume.
 	Status EntityStatus `yaml:"status,omitempty" json:"status,omitempty"`
 }
 
@@ -72,33 +69,30 @@ type EntityStatus struct {
 	Since   string        `json:"since,omitempty" yaml:"since,omitempty"`
 }
 
-// convertToVolumeInfo returns map of maps with volume info
-// keyed first on machine ID and then on volume ID.
-func convertToVolumeInfo(all []params.VolumeDetailsResult) (map[string]map[string]map[string]VolumeInfo, error) {
-	result := map[string]map[string]map[string]VolumeInfo{}
-	for _, one := range all {
-		if err := convertVolumeDetailsResult(one, result); err != nil {
-			return nil, errors.Trace(err)
-		}
-	}
-	return result, nil
+type VolumeAttachments struct {
+	Machines map[string]MachineVolumeAttachment `yaml:"machines,omitempty" json:"machines,omitempty"`
+	Units    map[string]UnitStorageAttachment   `yaml:"units,omitempty" json:"units,omitempty"`
 }
 
-func convertVolumeDetailsResult(item params.VolumeDetailsResult, all map[string]map[string]map[string]VolumeInfo) error {
-	info, attachments, storage, storageOwner := createVolumeInfo(item)
-	for machineTag, attachmentInfo := range attachments {
-		machineId, err := idFromTag(machineTag)
+type MachineVolumeAttachment struct {
+	DeviceName string `yaml:"device,omitempty" json:"device,omitempty"`
+	BusAddress string `yaml:"bus-address,omitempty" json:"bus-address,omitempty"`
+	ReadOnly   bool   `yaml:"read-only" json:"read-only"`
+	// TODO(axw) add machine volume attachment status when we have it
+}
+
+// convertToVolumeInfo returns map of maps with volume info
+// keyed first on machine ID and then on volume ID.
+func convertToVolumeInfo(all []params.VolumeDetailsResult) (map[string]VolumeInfo, error) {
+	result := make(map[string]VolumeInfo)
+	for _, one := range all {
+		volumeTag, info, err := createVolumeInfo(one)
 		if err != nil {
-			return errors.Trace(err)
+			return nil, errors.Trace(err)
 		}
-		info.DeviceName = attachmentInfo.DeviceName
-		info.ReadOnly = attachmentInfo.ReadOnly
-		addOneToAll(machineId, storage, storageOwner, info, all)
+		result[volumeTag.Id()] = info
 	}
-	if len(attachments) == 0 {
-		addOneToAll("unattached", storage, storageOwner, info, all)
-	}
-	return nil
+	return result, nil
 }
 
 var idFromTag = func(s string) (string, error) {
@@ -109,38 +103,19 @@ var idFromTag = func(s string) (string, error) {
 	return tag.Id(), nil
 }
 
-func convertVolumeAttachments(item params.VolumeDetailsResult, all map[string]map[string]map[string]VolumeInfo) error {
-	return nil
-}
-
-func addOneToAll(machineId, storageId, storageOwnerId string, item VolumeInfo, all map[string]map[string]map[string]VolumeInfo) {
-	machineVolumes, ok := all[machineId]
-	if !ok {
-		machineVolumes = map[string]map[string]VolumeInfo{}
-		all[machineId] = machineVolumes
-	}
-	storageOwnerVolumes, ok := machineVolumes[storageOwnerId]
-	if !ok {
-		storageOwnerVolumes = map[string]VolumeInfo{}
-		machineVolumes[storageOwnerId] = storageOwnerVolumes
-	}
-	storageOwnerVolumes[storageId] = item
-}
-
-// TODO(axw) there are a lot of ignored errors in here, which are *probably*
-// nil, but we should report them up the stack to be safe.
-func createVolumeInfo(result params.VolumeDetailsResult) (
-	info VolumeInfo,
-	attachments map[string]params.VolumeAttachmentInfo,
-	storageId string,
-	storageOwnerId string,
-) {
+func createVolumeInfo(result params.VolumeDetailsResult) (names.VolumeTag, VolumeInfo, error) {
 	details := result.Details
 	if details == nil {
 		details = volumeDetailsFromLegacy(result)
 	}
 
-	info.VolumeId = details.Info.VolumeId
+	volumeTag, err := names.ParseVolumeTag(details.VolumeTag)
+	if err != nil {
+		return names.VolumeTag{}, VolumeInfo{}, errors.Trace(err)
+	}
+
+	var info VolumeInfo
+	info.ProviderVolumeId = details.Info.VolumeId
 	info.HardwareId = details.Info.HardwareId
 	info.Size = details.Info.Size
 	info.Persistent = details.Info.Persistent
@@ -150,21 +125,37 @@ func createVolumeInfo(result params.VolumeDetailsResult) (
 		// TODO(axw) we should support formatting as ISO time
 		common.FormatTime(details.Status.Since, false),
 	}
-	if v, err := idFromTag(details.VolumeTag); err == nil {
-		info.Volume = v
+
+	if len(details.MachineAttachments) > 0 {
+		machineAttachments := make(map[string]MachineVolumeAttachment)
+		for machineTag, attachment := range details.MachineAttachments {
+			machineId, err := idFromTag(machineTag)
+			if err != nil {
+				return names.VolumeTag{}, VolumeInfo{}, errors.Trace(err)
+			}
+			machineAttachments[machineId] = MachineVolumeAttachment{
+				attachment.DeviceName,
+				attachment.BusAddress,
+				attachment.ReadOnly,
+			}
+		}
+		info.Attachments = &VolumeAttachments{
+			Machines: machineAttachments,
+		}
 	}
-	var err error
-	if storageId, err = idFromTag(details.StorageTag); err != nil {
-		// volume is not assigned to a storage instance
-		storageId = "unassigned"
+
+	if details.Storage != nil {
+		storageTag, storageInfo, err := createStorageInfo(*details.Storage)
+		if err != nil {
+			return names.VolumeTag{}, VolumeInfo{}, errors.Trace(err)
+		}
+		info.Storage = storageTag.Id()
+		if storageInfo.Attachments != nil {
+			info.Attachments.Units = storageInfo.Attachments.Units
+		}
 	}
-	if storageOwnerId, err = idFromTag(details.StorageOwnerTag); err != nil {
-		// volume is not assigned to a storage instance,
-		// or storage instance is not attached to a unit (legacy)
-		storageOwnerId = "unattached"
-	}
-	attachments = details.MachineAttachments
-	return info, attachments, storageId, storageOwnerId
+
+	return volumeTag, info, nil
 }
 
 // volumeDetailsFromLegacy converts from legacy data structures
@@ -172,23 +163,43 @@ func createVolumeInfo(result params.VolumeDetailsResult) (
 // compatibility. Please think long and hard before changing it.
 func volumeDetailsFromLegacy(result params.VolumeDetailsResult) *params.VolumeDetails {
 	details := &params.VolumeDetails{
-		VolumeTag:  result.LegacyVolume.VolumeTag,
-		StorageTag: result.LegacyVolume.StorageTag,
-		Status:     result.LegacyVolume.Status,
+		VolumeTag: result.LegacyVolume.VolumeTag,
+		Status:    result.LegacyVolume.Status,
 	}
 	details.Info.VolumeId = result.LegacyVolume.VolumeId
 	details.Info.HardwareId = result.LegacyVolume.HardwareId
 	details.Info.Size = result.LegacyVolume.Size
 	details.Info.Persistent = result.LegacyVolume.Persistent
-	if result.LegacyVolume.UnitTag != "" {
-		details.StorageOwnerTag = result.LegacyVolume.UnitTag
-	}
 	if len(result.LegacyAttachments) > 0 {
 		attachments := make(map[string]params.VolumeAttachmentInfo)
 		for _, attachment := range result.LegacyAttachments {
 			attachments[attachment.MachineTag] = attachment.Info
 		}
 		details.MachineAttachments = attachments
+	}
+	if result.LegacyVolume.StorageTag != "" {
+		details.Storage = &params.StorageDetails{
+			StorageTag: result.LegacyVolume.StorageTag,
+			Status:     details.Status,
+		}
+		if result.LegacyVolume.UnitTag != "" {
+			// Servers with legacy storage do not support shared
+			// storage, so there will only be one attachment, and
+			// the owner is always a unit.
+			details.Storage.OwnerTag = result.LegacyVolume.UnitTag
+			if len(result.LegacyAttachments) == 1 {
+				details.Storage.Attachments = map[string]params.StorageAttachmentDetails{
+					result.LegacyVolume.UnitTag: params.StorageAttachmentDetails{
+						StorageTag: result.LegacyVolume.StorageTag,
+						UnitTag:    result.LegacyVolume.UnitTag,
+						MachineTag: result.LegacyAttachments[0].MachineTag,
+						// Don't set Location, because we can't infer that
+						// from the legacy volume details.
+						Location: "",
+					},
+				}
+			}
+		}
 	}
 	return details
 }

--- a/cmd/juju/storage/volumelist.go
+++ b/cmd/juju/storage/volumelist.go
@@ -83,9 +83,18 @@ func (c *VolumeListCommand) Run(ctx *cmd.Context) (err error) {
 	if len(valid) == 0 {
 		return nil
 	}
-	output, err := convertToVolumeInfo(valid)
+
+	info, err := convertToVolumeInfo(valid)
 	if err != nil {
 		return err
+	}
+
+	var output interface{}
+	switch c.out.Name() {
+	case "json", "yaml":
+		output = map[string]map[string]VolumeInfo{"volumes": info}
+	default:
+		output = info
 	}
 	return c.out.Write(ctx, output)
 }

--- a/cmd/juju/storage/volumelist_test.go
+++ b/cmd/juju/storage/volumelist_test.go
@@ -4,20 +4,15 @@
 package storage_test
 
 import (
-	"bytes"
 	"encoding/json"
 	"time"
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
-	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	goyaml "gopkg.in/yaml.v1"
 
-	"fmt"
-
-	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/envcmd"
 	"github.com/juju/juju/cmd/juju/storage"
@@ -34,7 +29,7 @@ var _ = gc.Suite(&volumeListSuite{})
 func (s *volumeListSuite) SetUpTest(c *gc.C) {
 	s.SubStorageSuite.SetUpTest(c)
 
-	s.mockAPI = &mockVolumeListAPI{fillDeviceName: true, addErrItem: true}
+	s.mockAPI = &mockVolumeListAPI{}
 	s.PatchValue(storage.GetVolumeListAPI,
 		func(c *storage.VolumeListCommand) (storage.VolumeListAPI, error) {
 			return s.mockAPI, nil
@@ -42,47 +37,46 @@ func (s *volumeListSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *volumeListSuite) TestVolumeListEmpty(c *gc.C) {
-	s.mockAPI.listEmpty = true
+	s.mockAPI.listVolumes = func([]string) ([]params.VolumeDetailsResult, error) {
+		return nil, nil
+	}
 	s.assertValidList(
 		c,
 		[]string{"--format", "yaml"},
-		"",
 		"",
 	)
 }
 
 func (s *volumeListSuite) TestVolumeListError(c *gc.C) {
-	s.mockAPI.errOut = "just my luck"
-
+	s.mockAPI.listVolumes = func([]string) ([]params.VolumeDetailsResult, error) {
+		return nil, errors.New("just my luck")
+	}
 	context, err := runVolumeList(c, "--format", "yaml")
-	c.Assert(errors.Cause(err), gc.ErrorMatches, s.mockAPI.errOut)
+	c.Assert(errors.Cause(err), gc.ErrorMatches, "just my luck")
 	s.assertUserFacingOutput(c, context, "", "")
 }
 
-func (s *volumeListSuite) TestVolumeListAll(c *gc.C) {
-	s.mockAPI.listAll = true
-	s.assertUnmarshalledOutput(
+func (s *volumeListSuite) TestVolumeListArgs(c *gc.C) {
+	var called bool
+	expectedArgs := []string{"a", "b", "c"}
+	s.mockAPI.listVolumes = func(arg []string) ([]params.VolumeDetailsResult, error) {
+		c.Assert(arg, jc.DeepEquals, expectedArgs)
+		called = true
+		return nil, nil
+	}
+	s.assertValidList(
 		c,
-		goyaml.Unmarshal,
-		// mock will ignore any value here, as listAll flag above has precedence
+		append([]string{"--format", "yaml"}, expectedArgs...),
 		"",
-		"--format", "yaml")
+	)
+	c.Assert(called, jc.IsTrue)
 }
 
 func (s *volumeListSuite) TestVolumeListYaml(c *gc.C) {
 	s.assertUnmarshalledOutput(
 		c,
 		goyaml.Unmarshal,
-		"2",
-		"--format", "yaml")
-}
-
-func (s *volumeListSuite) TestVolumeListYamlNoDeviceName(c *gc.C) {
-	s.mockAPI.fillDeviceName = false
-	s.assertUnmarshalledOutput(
-		c,
-		goyaml.Unmarshal,
-		"2",
+		"", // no error
 		"--format", "yaml")
 }
 
@@ -90,134 +84,80 @@ func (s *volumeListSuite) TestVolumeListJSON(c *gc.C) {
 	s.assertUnmarshalledOutput(
 		c,
 		json.Unmarshal,
-		"2",
+		"", // no error
 		"--format", "json")
+}
+
+func (s *volumeListSuite) TestVolumeListWithErrorResults(c *gc.C) {
+	s.mockAPI.listVolumes = func([]string) ([]params.VolumeDetailsResult, error) {
+		results, _ := mockVolumeListAPI{}.ListVolumes(nil)
+		results = append(results, params.VolumeDetailsResult{
+			Error: &params.Error{Message: "bad"},
+		})
+		results = append(results, params.VolumeDetailsResult{
+			Error: &params.Error{Message: "ness"},
+		})
+		return results, nil
+	}
+	// we should see the error in stderr, but it should not
+	// otherwise affect the rendering of valid results.
+	s.assertUnmarshalledOutput(c, json.Unmarshal, "bad\nness\n", "--format", "json")
+	s.assertUnmarshalledOutput(c, goyaml.Unmarshal, "bad\nness\n", "--format", "yaml")
 }
 
 func (s *volumeListSuite) TestVolumeListTabular(c *gc.C) {
 	s.assertValidList(
 		c,
-		[]string{"2"},
-		// Default format is tabular
+		[]string{}, // ignored by default mock
 		`
-MACHINE  UNIT          STORAGE      DEVICE      VOLUME      ID                            SIZE    STATE      MESSAGE
-2        postgresql/0  shared-fs/0  testdevice  0/1         provider-supplied-0/1         1.0GiB  attaching  failed to attach
-2        unattached    shared-fs/0  testdevice  0/abc/0/88  provider-supplied-0/abc/0/88  1.0GiB  attached   
+MACHINE  UNIT         STORAGE      ID  PROVIDER-ID                 DEVICE      SIZE    STATE       MESSAGE
+0        abc/0        db-dir/1000  0   provider-supplied-volume-0  testdevice  1.0GiB  destroying  
+0        transcode/0  shared-fs/0  3   provider-supplied-volume-3  loop0       1.0GiB  attached    
+0                                  1   provider-supplied-volume-1              2.0GiB  attaching   failed to attach, will retry
+1        transcode/1  shared-fs/0  3   provider-supplied-volume-3  loop1       1.0GiB  attached    
+1                                  2                                           42MiB   pending     
 
-`[1:],
-		`
-volume item error
-`[1:],
-	)
-}
-
-func (s *volumeListSuite) TestVolumeListTabularSort(c *gc.C) {
-	s.assertValidList(
-		c,
-		[]string{"2", "3"},
-		// Default format is tabular
-		`
-MACHINE  UNIT          STORAGE      DEVICE      VOLUME      ID                            SIZE    STATE      MESSAGE
-2        postgresql/0  shared-fs/0  testdevice  0/1         provider-supplied-0/1         1.0GiB  attaching  failed to attach
-2        unattached    shared-fs/0  testdevice  0/abc/0/88  provider-supplied-0/abc/0/88  1.0GiB  attached   
-3        postgresql/0  shared-fs/0  testdevice  0/1         provider-supplied-0/1         1.0GiB  attaching  failed to attach
-3        unattached    shared-fs/0  testdevice  0/abc/0/88  provider-supplied-0/abc/0/88  1.0GiB  attached   
-
-`[1:],
-		`
-volume item error
-`[1:],
-	)
-}
-
-func (s *volumeListSuite) TestVolumeListTabularSortWithUnattached(c *gc.C) {
-	s.mockAPI.listAll = true
-	s.assertValidList(
-		c,
-		[]string{"2", "3"},
-		// Default format is tabular
-		`
-MACHINE     UNIT          STORAGE      DEVICE      VOLUME      ID                            SIZE    STATE       MESSAGE
-25          postgresql/0  shared-fs/0  testdevice  0/1         provider-supplied-0/1         1.0GiB  attaching   failed to attach
-25          unattached    shared-fs/0  testdevice  0/abc/0/88  provider-supplied-0/abc/0/88  1.0GiB  attached    
-42          postgresql/0  shared-fs/0  testdevice  0/1         provider-supplied-0/1         1.0GiB  attaching   failed to attach
-42          unattached    shared-fs/0  testdevice  0/abc/0/88  provider-supplied-0/abc/0/88  1.0GiB  attached    
-unattached  abc/0         db-dir/1000              3/4         provider-supplied-3/4         1.0GiB  destroying  
-unattached  unattached    unassigned               3/3         provider-supplied-3/3         1.0GiB  destroying  
-
-`[1:],
-		`
-volume item error
-`[1:],
-	)
-}
-
-func (s *volumeListSuite) assertUnmarshalledOutput(c *gc.C, unmarshall unmarshaller, machine string, args ...string) {
-	all := []string{machine}
-	context, err := runVolumeList(c, append(all, args...)...)
-	c.Assert(err, jc.ErrorIsNil)
-	var result map[string]map[string]map[string]storage.VolumeInfo
-	err = unmarshall(context.Stdout.(*bytes.Buffer).Bytes(), &result)
-	c.Assert(err, jc.ErrorIsNil)
-	expected := s.expect(c, []string{machine})
-	// This comparison cannot rely on gc.DeepEquals as
-	// json.Unmarshal unmarshalls the number as a float64,
-	// rather than an int
-	s.assertSameVolumeInfos(c, result, expected)
-
-	obtainedErr := testing.Stderr(context)
-	c.Assert(obtainedErr, gc.Equals, `
-volume item error
 `[1:])
 }
 
-func (s *volumeListSuite) expect(c *gc.C, machines []string) map[string]map[string]map[string]storage.VolumeInfo {
-	//no need for this element as we are building output on out stream not err
-	s.mockAPI.addErrItem = false
+func (s *volumeListSuite) assertUnmarshalledOutput(c *gc.C, unmarshal unmarshaller, expectedErr string, args ...string) {
+	context, err := runVolumeList(c, args...)
+	c.Assert(err, jc.ErrorIsNil)
+
+	var result struct {
+		Volumes map[string]storage.VolumeInfo
+	}
+	err = unmarshal([]byte(testing.Stdout(context)), &result)
+	c.Assert(err, jc.ErrorIsNil)
+
+	expected := s.expect(c, nil)
+	c.Assert(result.Volumes, jc.DeepEquals, expected)
+
+	obtainedErr := testing.Stderr(context)
+	c.Assert(obtainedErr, gc.Equals, expectedErr)
+}
+
+// expect returns the VolumeInfo mapping we should expect to unmarshal
+// from rendered YAML or JSON.
+func (s *volumeListSuite) expect(c *gc.C, machines []string) map[string]storage.VolumeInfo {
 	all, err := s.mockAPI.ListVolumes(machines)
 	c.Assert(err, jc.ErrorIsNil)
-	result, err := storage.ConvertToVolumeInfo(all)
+
+	var valid []params.VolumeDetailsResult
+	for _, result := range all {
+		if result.Error == nil {
+			valid = append(valid, result)
+		}
+	}
+	result, err := storage.ConvertToVolumeInfo(valid)
 	c.Assert(err, jc.ErrorIsNil)
 	return result
 }
 
-func (s *volumeListSuite) assertSameVolumeInfos(c *gc.C, one, two map[string]map[string]map[string]storage.VolumeInfo) {
-	c.Assert(len(one), gc.Equals, len(two))
-
-	propertyCompare := func(a, b interface{}) {
-		// As some types may have been unmarshalled incorrectly, for example
-		// int versus float64, compare values' string representations
-		c.Assert(fmt.Sprintf("%v", a), jc.DeepEquals, fmt.Sprintf("%v", b))
-
-	}
-	for machineKey, machineVolumes1 := range one {
-		machineVolumes2, ok := two[machineKey]
-		c.Assert(ok, jc.IsTrue)
-		// these are maps
-		c.Assert(len(machineVolumes1), gc.Equals, len(machineVolumes2))
-		for unitKey, units1 := range machineVolumes1 {
-			units2, ok := machineVolumes2[unitKey]
-			c.Assert(ok, jc.IsTrue)
-			// these are maps
-			c.Assert(len(units1), gc.Equals, len(units2))
-			for storageKey, info1 := range units1 {
-				info2, ok := units2[storageKey]
-				c.Assert(ok, jc.IsTrue)
-				propertyCompare(info1.VolumeId, info2.VolumeId)
-				propertyCompare(info1.HardwareId, info2.HardwareId)
-				propertyCompare(info1.Size, info2.Size)
-				propertyCompare(info1.Persistent, info2.Persistent)
-				propertyCompare(info1.DeviceName, info2.DeviceName)
-				propertyCompare(info1.ReadOnly, info2.ReadOnly)
-			}
-		}
-	}
-}
-
-func (s *volumeListSuite) assertValidList(c *gc.C, args []string, expectedOut, expectedErr string) {
+func (s *volumeListSuite) assertValidList(c *gc.C, args []string, expectedOut string) {
 	context, err := runVolumeList(c, args...)
 	c.Assert(err, jc.ErrorIsNil)
-	s.assertUserFacingOutput(c, context, expectedOut, expectedErr)
+	s.assertUserFacingOutput(c, context, expectedOut, "")
 }
 
 func runVolumeList(c *gc.C, args ...string) (*cmd.Context, error) {
@@ -235,8 +175,7 @@ func (s *volumeListSuite) assertUserFacingOutput(c *gc.C, context *cmd.Context, 
 }
 
 type mockVolumeListAPI struct {
-	listAll, listEmpty, fillDeviceName, addErrItem bool
-	errOut                                         string
+	listVolumes func([]string) ([]params.VolumeDetailsResult, error)
 }
 
 func (s mockVolumeListAPI) Close() error {
@@ -244,82 +183,106 @@ func (s mockVolumeListAPI) Close() error {
 }
 
 func (s mockVolumeListAPI) ListVolumes(machines []string) ([]params.VolumeDetailsResult, error) {
-	if s.errOut != "" {
-		return nil, errors.New(s.errOut)
+	if s.listVolumes != nil {
+		return s.listVolumes(machines)
 	}
-	if s.listEmpty {
-		return nil, nil
-	}
-	result := []params.VolumeDetailsResult{}
-	if s.addErrItem {
-		result = append(result, params.VolumeDetailsResult{
-			Error: common.ServerError(errors.New("volume item error"))})
-	}
-	if s.listAll {
-		machines = []string{"25", "42"}
-		//unattached
-		result = append(result, s.createTestVolumeDetailsResult(
-			"3/4", true, "db-dir/1000", "abc/0", nil,
-			createTestStatus(params.StatusDestroying, ""),
-		))
-		result = append(result, s.createTestVolumeDetailsResult(
-			"3/3", false, "", "", nil,
-			createTestStatus(params.StatusDestroying, ""),
-		))
-	}
-	result = append(result, s.createTestVolumeDetailsResult(
-		"0/1", true, "shared-fs/0", "postgresql/0", machines,
-		createTestStatus(params.StatusAttaching, "failed to attach"),
-	))
-	result = append(result, s.createTestVolumeDetailsResult(
-		"0/abc/0/88", false, "shared-fs/0", "", machines,
-		createTestStatus(params.StatusAttached, ""),
-	))
-	return result, nil
-}
-
-func (s mockVolumeListAPI) createTestVolumeDetailsResult(
-	id string,
-	persistent bool,
-	storageid, unitid string,
-	machines []string,
-	status params.EntityStatus,
-) params.VolumeDetailsResult {
-
-	volume := s.createTestVolume(id, persistent, storageid, unitid, status)
-	volume.MachineAttachments = make(map[string]params.VolumeAttachmentInfo)
-	for i, machine := range machines {
-		info := params.VolumeAttachmentInfo{
-			ReadOnly: i%2 == 0,
-		}
-		if s.fillDeviceName {
-			info.DeviceName = "testdevice"
-		}
-		machineTag := names.NewMachineTag(machine).String()
-		volume.MachineAttachments[machineTag] = info
-	}
-	return params.VolumeDetailsResult{Details: volume}
-}
-
-func (s mockVolumeListAPI) createTestVolume(id string, persistent bool, storageid, unitid string, status params.EntityStatus) *params.VolumeDetails {
-	tag := names.NewVolumeTag(id)
-	result := &params.VolumeDetails{
-		VolumeTag: tag.String(),
-		Info: params.VolumeInfo{
-			VolumeId:   "provider-supplied-" + tag.Id(),
-			HardwareId: "serial blah blah",
-			Persistent: persistent,
-			Size:       uint64(1024),
+	results := []params.VolumeDetailsResult{{
+		// volume 0 is attached to machine 0, assigned to
+		// storage db-dir/1000, which is attached to unit
+		// abc/0.
+		//
+		// Use Legacy and LegacyAttachment here to test
+		// backwards compatibility.
+		LegacyVolume: &params.LegacyVolumeDetails{
+			VolumeTag:  "volume-0",
+			StorageTag: "storage-db-dir-1000",
+			UnitTag:    "unit-abc-0",
+			VolumeId:   "provider-supplied-volume-0",
+			Size:       1024,
+			Persistent: false,
+			Status:     createTestStatus(params.StatusDestroying, ""),
 		},
-		Status: status,
-	}
-	if storageid != "" {
-		result.StorageTag = names.NewStorageTag(storageid).String()
-	}
-	if unitid != "" {
-		result.StorageOwnerTag = names.NewUnitTag(unitid).String()
-	}
-	return result
+		LegacyAttachments: []params.VolumeAttachment{{
+			VolumeTag:  "volume-0",
+			MachineTag: "machine-0",
+			Info: params.VolumeAttachmentInfo{
+				DeviceName: "testdevice",
+				ReadOnly:   true,
+			},
+		}},
+	}, {
+		// volume 1 is attaching to machine 0, but is not assigned
+		// to any storage.
+		Details: &params.VolumeDetails{
+			VolumeTag: "volume-1",
+			Info: params.VolumeInfo{
+				VolumeId:   "provider-supplied-volume-1",
+				HardwareId: "serial blah blah",
+				Persistent: true,
+				Size:       2048,
+			},
+			Status: createTestStatus(params.StatusAttaching, "failed to attach, will retry"),
+			MachineAttachments: map[string]params.VolumeAttachmentInfo{
+				"machine-0": params.VolumeAttachmentInfo{},
+			},
+		},
+	}, {
+		// volume 2 is due to be attached to machine 1, but is not
+		// assigned to any storage and has not yet been provisioned.
+		Details: &params.VolumeDetails{
+			VolumeTag: "volume-2",
+			Info: params.VolumeInfo{
+				Size: 42,
+			},
+			Status: createTestStatus(params.StatusPending, ""),
+			MachineAttachments: map[string]params.VolumeAttachmentInfo{
+				"machine-1": params.VolumeAttachmentInfo{},
+			},
+		},
+	}, {
+		// volume 3 is attached to machines 0 and 1, and is assigned
+		// to shared storage.
+		Details: &params.VolumeDetails{
+			VolumeTag: "volume-3",
+			Info: params.VolumeInfo{
+				VolumeId:   "provider-supplied-volume-3",
+				Persistent: true,
+				Size:       1024,
+			},
+			Status: createTestStatus(params.StatusAttached, ""),
+			MachineAttachments: map[string]params.VolumeAttachmentInfo{
+				"machine-0": params.VolumeAttachmentInfo{
+					DeviceName: "loop0",
+					ReadOnly:   true,
+				},
+				"machine-1": params.VolumeAttachmentInfo{
+					DeviceName: "loop1",
+					ReadOnly:   true,
+				},
+			},
+			Storage: &params.StorageDetails{
+				StorageTag: "storage-shared-fs-0",
+				OwnerTag:   "service-transcode",
+				Kind:       params.StorageKindBlock,
+				Status:     createTestStatus(params.StatusAttached, ""),
+				Attachments: map[string]params.StorageAttachmentDetails{
+					"unit-transcode-0": params.StorageAttachmentDetails{
+						StorageTag: "storage-shared-fs-0",
+						UnitTag:    "unit-transcode-0",
+						MachineTag: "machine-0",
+						Location:   "/mnt/bits",
+					},
+					"unit-transcode-1": params.StorageAttachmentDetails{
+						StorageTag: "storage-shared-fs-0",
+						UnitTag:    "unit-transcode-1",
+						MachineTag: "machine-1",
+						Location:   "/mnt/pieces",
+					},
+				},
+			},
+		},
+	}}
+	return results, nil
 }
 
 func createTestStatus(status params.Status, message string) params.EntityStatus {

--- a/cmd/juju/storage/volumelistformatters.go
+++ b/cmd/juju/storage/volumelistformatters.go
@@ -107,7 +107,7 @@ func (v volumeAttachmentInfos) Swap(i, j int) {
 }
 
 func (v volumeAttachmentInfos) Less(i, j int) bool {
-	switch strings.Compare(v[i].MachineId, v[j].MachineId) {
+	switch compareStrings(v[i].MachineId, v[j].MachineId) {
 	case -1:
 		return true
 	case 1:

--- a/cmd/juju/storage/volumelistformatters.go
+++ b/cmd/juju/storage/volumelistformatters.go
@@ -114,14 +114,14 @@ func (v volumeAttachmentInfos) Less(i, j int) bool {
 		return false
 	}
 
-	switch naturalCompare(v[i].UnitId, v[j].UnitId) {
+	switch compareSlashSeparated(v[i].UnitId, v[j].UnitId) {
 	case -1:
 		return true
 	case 1:
 		return false
 	}
 
-	switch naturalCompare(v[i].Storage, v[j].Storage) {
+	switch compareSlashSeparated(v[i].Storage, v[j].Storage) {
 	case -1:
 		return true
 	case 1:

--- a/cmd/juju/storage/volumelistformatters.go
+++ b/cmd/juju/storage/volumelistformatters.go
@@ -3,24 +3,24 @@ package storage
 import (
 	"bytes"
 	"fmt"
+	"sort"
 	"strings"
 	"text/tabwriter"
 
 	"github.com/dustin/go-humanize"
 	"github.com/juju/errors"
-	"github.com/juju/utils/set"
 )
 
 // formatVolumeListTabular returns a tabular summary of volume instances.
 func formatVolumeListTabular(value interface{}) ([]byte, error) {
-	infos, ok := value.(map[string]map[string]map[string]VolumeInfo)
+	infos, ok := value.(map[string]VolumeInfo)
 	if !ok {
 		return nil, errors.Errorf("expected value of type %T, got %T", infos, value)
 	}
 	return formatVolumeListTabularTyped(infos), nil
 }
 
-func formatVolumeListTabularTyped(infos map[string]map[string]map[string]VolumeInfo) []byte {
+func formatVolumeListTabularTyped(infos map[string]VolumeInfo) []byte {
 	var out bytes.Buffer
 	const (
 		// To format things into columns.
@@ -35,49 +35,98 @@ func formatVolumeListTabularTyped(infos map[string]map[string]map[string]VolumeI
 	print := func(values ...string) {
 		fmt.Fprintln(tw, strings.Join(values, "\t"))
 	}
-	print("MACHINE", "UNIT", "STORAGE", "DEVICE", "VOLUME", "ID", "SIZE", "STATE", "MESSAGE")
+	print("MACHINE", "UNIT", "STORAGE", "ID", "PROVIDER-ID", "DEVICE", "SIZE", "STATE", "MESSAGE")
 
-	// 1. sort by machines
-	machines := set.NewStrings()
-	for machine := range infos {
-		if !machines.Contains(machine) {
-			machines.Add(machine)
+	volumeAttachmentInfos := make(volumeAttachmentInfos, 0, len(infos))
+	for volumeId, info := range infos {
+		volumeAttachmentInfo := volumeAttachmentInfo{
+			VolumeId:   volumeId,
+			VolumeInfo: info,
 		}
-	}
-	for _, machine := range machines.SortedValues() {
-		machineUnits := infos[machine]
-
-		// 2. sort by unit
-		units := set.NewStrings()
-		for unit := range machineUnits {
-			if !units.Contains(unit) {
-				units.Add(unit)
-			}
+		if info.Attachments == nil {
+			volumeAttachmentInfos = append(volumeAttachmentInfos, volumeAttachmentInfo)
+			continue
 		}
-		for _, unit := range units.SortedValues() {
-			unitStorages := machineUnits[unit]
-
-			// 3. sort by storage
-			storages := set.NewStrings()
-			for storage := range unitStorages {
-				if !storages.Contains(storage) {
-					storages.Add(storage)
+		// Each unit attachment must have a corresponding volume
+		// attachment. Enumerate each of the volume attachments,
+		// and locate the corresponding unit attachment if any.
+		// Each volume attachment has at most one corresponding
+		// unit attachment.
+		for machineId, machineInfo := range info.Attachments.Machines {
+			volumeAttachmentInfo := volumeAttachmentInfo
+			volumeAttachmentInfo.MachineId = machineId
+			volumeAttachmentInfo.MachineVolumeAttachment = machineInfo
+			for unitId, unitInfo := range info.Attachments.Units {
+				if unitInfo.MachineId == machineId {
+					volumeAttachmentInfo.UnitId = unitId
+					volumeAttachmentInfo.UnitStorageAttachment = unitInfo
+					break
 				}
 			}
-			for _, storage := range storages.SortedValues() {
-				info := unitStorages[storage]
-				var size string
-				if info.Size > 0 {
-					size = humanize.IBytes(info.Size * humanize.MiByte)
-				}
-				print(
-					machine, unit, storage, info.DeviceName,
-					info.Volume, info.VolumeId, size,
-					string(info.Status.Current), info.Status.Message,
-				)
-			}
+			volumeAttachmentInfos = append(volumeAttachmentInfos, volumeAttachmentInfo)
 		}
 	}
+	sort.Sort(volumeAttachmentInfos)
+
+	for _, info := range volumeAttachmentInfos {
+		var size string
+		if info.Size > 0 {
+			size = humanize.IBytes(info.Size * humanize.MiByte)
+		}
+		print(
+			info.MachineId, info.UnitId, info.Storage,
+			info.VolumeId, info.ProviderVolumeId,
+			info.DeviceName, size,
+			string(info.Status.Current), info.Status.Message,
+		)
+	}
+
 	tw.Flush()
 	return out.Bytes()
+}
+
+type volumeAttachmentInfo struct {
+	VolumeId string
+	VolumeInfo
+
+	MachineId string
+	MachineVolumeAttachment
+
+	UnitId string
+	UnitStorageAttachment
+}
+
+type volumeAttachmentInfos []volumeAttachmentInfo
+
+func (v volumeAttachmentInfos) Len() int {
+	return len(v)
+}
+
+func (v volumeAttachmentInfos) Swap(i, j int) {
+	v[i], v[j] = v[j], v[i]
+}
+
+func (v volumeAttachmentInfos) Less(i, j int) bool {
+	switch strings.Compare(v[i].MachineId, v[j].MachineId) {
+	case -1:
+		return true
+	case 1:
+		return false
+	}
+
+	switch naturalCompare(v[i].UnitId, v[j].UnitId) {
+	case -1:
+		return true
+	case 1:
+		return false
+	}
+
+	switch naturalCompare(v[i].Storage, v[j].Storage) {
+	case -1:
+		return true
+	case 1:
+		return false
+	}
+
+	return v[i].VolumeId < v[j].VolumeId
 }

--- a/featuretests/storage_test.go
+++ b/featuretests/storage_test.go
@@ -410,8 +410,8 @@ func (s *cmdStorageSuite) TestListVolumeTabularFilterMatch(c *gc.C) {
 	createUnitWithStorage(c, &s.JujuConnSuite, testPersistentPool)
 	context := runVolumeList(c, "0")
 	expected := `
-MACHINE  UNIT             STORAGE  DEVICE  VOLUME  ID  SIZE  STATE    MESSAGE
-0        storage-block/0  data/0           0                 pending  
+MACHINE  UNIT             STORAGE  ID  PROVIDER-ID  DEVICE  SIZE  STATE    MESSAGE
+0        storage-block/0  data/0   0                              pending  
 
 `[1:]
 	c.Assert(testing.Stdout(context), gc.Equals, expected)


### PR DESCRIPTION
This PR changes the "juju storage volume list"
format, to make it clearer, more complete, and
more correct w.r.t. the underlying model. The
format looks like (e.g.):

```
volumes:
  1/0:
    provider-id: volume-1-0
    storage: filesystem/0
    attachments:
      machines:
        "1":
          device: loop0
          read-only: false
      units:
        storagetest/0:
          machine: "1"
          location: /srv/filesystem/0
    size: 1024
    persistent: false
    status:
      current: attached
      since: 15 Sep 2015 19:13:50+08:00
  2/1:
    provider-id: volume-2-1
    storage: filesystem/1
    attachments:
      machines:
        "2":
          device: loop1
          read-only: false
      units:
        storagetest/1:
          machine: "2"
    size: 1024
    persistent: false
    status:
      current: attached
      since: 15 Sep 2015 19:14:02+08:00
```

We now embed StorageDetails in VolumeDetails
in the API, so we get unit attachment info for
volumes.

(Review request: http://reviews.vapour.ws/r/2663/)