### PR TITLE
provider: Implement windows support for GCE

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -28,7 +28,7 @@ github.com/juju/schema	git	afe1151cb49d1d7ed3c75592dfc6f38703f2e988	2015-08-07T0
 github.com/juju/syslog	git	6be94e8b718766e9ff7a37342157fe4795da7cfa	2015-02-05T15:59:36Z
 github.com/juju/testing	git	f521911d9a79aeb62c051fe18e689796369c5564	2015-05-29T04:40:43Z
 github.com/juju/txn	git	99ec629d0066a4d73c54d8e021a7fc1dc07df614	2015-06-09T16:58:27Z
-github.com/juju/utils	git	6f48322bb574b8578e8ecccf689220eac7edad9d	2015-08-10T03:07:18Z
+github.com/juju/utils	git	a8a6b302e967fa0ab41dd762256cab18bf20f90a	2015-09-22T08:36:00Z
 github.com/juju/xml	git	eb759a627588d35166bc505fceb51b88500e291e	2015-04-13T13:11:21Z
 golang.org/x/crypto	git	c57d4a71915a248dbad846d60825145062b4c18e	2015-03-27T05:11:19Z
 golang.org/x/net	git	bb64f4dc73d4ab97978d5e1cb34515dcc570361b	2015-05-18T01:39:50Z

--- a/provider/gce/environ_broker.go
+++ b/provider/gce/environ_broker.go
@@ -4,7 +4,10 @@
 package gce
 
 import (
+	"fmt"
+
 	"github.com/juju/errors"
+	"github.com/juju/utils"
 
 	"github.com/juju/juju/cloudconfig/instancecfg"
 	"github.com/juju/juju/cloudconfig/providerinit"
@@ -19,6 +22,7 @@ import (
 	"github.com/juju/juju/provider/gce/google"
 	"github.com/juju/juju/state/multiwatcher"
 	"github.com/juju/juju/tools"
+	"github.com/juju/juju/version"
 )
 
 func isStateServer(icfg *instancecfg.InstanceConfig) bool {
@@ -161,7 +165,12 @@ var imageMetadataFetch = imagemetadata.Fetch
 func (env *environ) newRawInstance(args environs.StartInstanceParams, spec *instances.InstanceSpec) (*google.Instance, error) {
 	machineID := common.MachineFullName(env, args.InstanceConfig.MachineId)
 
-	metadata, err := getMetadata(args)
+	os, err := version.GetOSFromSeries(args.InstanceConfig.Series)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	metadata, err := getMetadata(args, os)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -169,6 +178,11 @@ func (env *environ) newRawInstance(args environs.StartInstanceParams, spec *inst
 		env.globalFirewallName(),
 		machineID,
 	}
+	disks, err := getDisks(spec, args.Constraints, args.InstanceConfig.Series)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
 	// TODO(ericsnow) Use the env ID for the network name (instead of default)?
 	// TODO(ericsnow) Make the network name configurable?
 	// TODO(ericsnow) Support multiple networks?
@@ -176,7 +190,7 @@ func (env *environ) newRawInstance(args environs.StartInstanceParams, spec *inst
 	instSpec := google.InstanceSpec{
 		ID:                machineID,
 		Type:              spec.InstanceType.Name,
-		Disks:             getDisks(spec, args.Constraints, args.InstanceConfig.Series),
+		Disks:             disks,
 		NetworkInterfaces: []string{"ExternalNAT"},
 		Metadata:          metadata,
 		Tags:              tags,
@@ -194,32 +208,46 @@ func (env *environ) newRawInstance(args environs.StartInstanceParams, spec *inst
 
 // getMetadata builds the raw "user-defined" metadata for the new
 // instance (relative to the provided args) and returns it.
-func getMetadata(args environs.StartInstanceParams) (map[string]string, error) {
+func getMetadata(args environs.StartInstanceParams, os version.OSType) (map[string]string, error) {
 	userData, err := providerinit.ComposeUserData(args.InstanceConfig, nil, GCERenderer{})
 	if err != nil {
 		return nil, errors.Annotate(err, "cannot make user data")
 	}
 	logger.Debugf("GCE user data; %d bytes", len(userData))
 
-	authKeys, err := google.FormatAuthorizedKeys(args.InstanceConfig.AuthorizedKeys, "ubuntu")
-	if err != nil {
-		return nil, errors.Trace(err)
+	metadata := make(map[string]string)
+	if isStateServer(args.InstanceConfig) {
+		metadata[metadataKeyIsState] = metadataValueTrue
+	} else {
+		metadata[metadataKeyIsState] = metadataValueFalse
 	}
-
-	metadata := map[string]string{
-		metadataKeyIsState: metadataValueFalse,
+	switch os {
+	case version.Ubuntu:
 		// We store a gz snapshop of information that is used by
 		// cloud-init and unpacked in to the /var/lib/cloud/instances folder
 		// for the instance. Due to a limitation with GCE and binary blobs
 		// we base64 encode the data before storing it.
-		metadataKeyCloudInit: string(userData),
+		metadata[metadataKeyCloudInit] = string(userData)
 		// Valid encoding values are determined by the cloudinit GCE data source.
 		// See: http://cloudinit.readthedocs.org
-		metadataKeyEncoding: "base64",
-		metadataKeySSHKeys:  authKeys,
-	}
-	if isStateServer(args.InstanceConfig) {
-		metadata[metadataKeyIsState] = metadataValueTrue
+		metadata[metadataKeyEncoding] = "base64"
+
+		authKeys, err := google.FormatAuthorizedKeys(args.InstanceConfig.AuthorizedKeys, "ubuntu")
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+
+		metadata[metadataKeySSHKeys] = authKeys
+	case version.Windows:
+		metadata[metadataKeyWindowsUserdata] = string(userData)
+
+		validChars := append(utils.UpperAlpha, append(utils.LowerAlpha, utils.Digits...)...)
+
+		// The hostname must have maximum 15 characters
+		winHostname := "juju" + utils.RandomString(11, validChars)
+		metadata[metadataKeyWindowsSysprep] = fmt.Sprintf(winSetHostnameScript, winHostname)
+	default:
+		return nil, errors.Errorf("cannot pack metadata for os %s on the gce provider", os.String())
 	}
 
 	return metadata, nil
@@ -229,14 +257,27 @@ func getMetadata(args environs.StartInstanceParams) (map[string]string, error) {
 // the new instances and returns it. This will always include a root
 // disk with characteristics determined by the provides args and
 // constraints.
-func getDisks(spec *instances.InstanceSpec, cons constraints.Value, series string) []google.DiskSpec {
+func getDisks(spec *instances.InstanceSpec, cons constraints.Value, series string) ([]google.DiskSpec, error) {
 	size := common.MinRootDiskSizeGiB(series)
 	if cons.RootDisk != nil && *cons.RootDisk > size {
 		size = common.MiBToGiB(*cons.RootDisk)
 	}
+	var imageURL string
+	os, err := version.GetOSFromSeries(series)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	switch os {
+	case version.Ubuntu:
+		imageURL = ubuntuImageBasePath
+	case version.Windows:
+		imageURL = windowsImageBasePath
+	default:
+		return nil, errors.Errorf("os %s is not supported on the gce provider", os.String())
+	}
 	dSpec := google.DiskSpec{
 		SizeHintGB: size,
-		ImageURL:   imageBasePath + spec.Image.Id,
+		ImageURL:   imageURL + spec.Image.Id,
 		Boot:       true,
 		AutoDelete: true,
 	}
@@ -244,7 +285,7 @@ func getDisks(spec *instances.InstanceSpec, cons constraints.Value, series strin
 		msg := "Ignoring root-disk constraint of %dM because it is smaller than the GCE image size of %dG"
 		logger.Infof(msg, *cons.RootDisk, google.MinDiskSizeGB)
 	}
-	return []google.DiskSpec{dSpec}
+	return []google.DiskSpec{dSpec}, nil
 }
 
 // getHardwareCharacteristics compiles hardware-related details about

--- a/provider/gce/export_test.go
+++ b/provider/gce/export_test.go
@@ -12,12 +12,14 @@ import (
 )
 
 var (
-	Provider          environs.EnvironProvider = providerInstance
-	NewInstance                                = newInstance
-	CheckInstanceType                          = checkInstanceType
-	GetMetadata                                = getMetadata
-	GetDisks                                   = getDisks
-	ConfigImmutable                            = configImmutableFields
+	Provider             environs.EnvironProvider = providerInstance
+	NewInstance                                   = newInstance
+	CheckInstanceType                             = checkInstanceType
+	GetMetadata                                   = getMetadata
+	GetDisks                                      = getDisks
+	ConfigImmutable                               = configImmutableFields
+	UbuntuImageBasePath                           = ubuntuImageBasePath
+	WindowsImageBasePath                          = windowsImageBasePath
 )
 
 func ExposeInstBase(inst *environInstance) *google.Instance {

--- a/provider/gce/gce.go
+++ b/provider/gce/gce.go
@@ -17,8 +17,10 @@ const (
 	// http://bazaar.launchpad.net/~cloud-init-dev/cloud-init/trunk/view/head:/cloudinit/sources/DataSourceGCE.py
 	// http://cloudinit.readthedocs.org/en/latest/
 	// https://cloud.google.com/compute/docs/metadata
-	metadataKeyCloudInit = "user-data"
-	metadataKeyEncoding  = "user-data-encoding"
+	metadataKeyCloudInit       = "user-data"
+	metadataKeyEncoding        = "user-data-encoding"
+	metadataKeyWindowsUserdata = "windows-startup-script-ps1"
+	metadataKeyWindowsSysprep  = "sysprep-specialize-script-ps1"
 	// GCE uses this specific key for authentication (*handwaving*)
 	// https://cloud.google.com/compute/docs/instances#sshkeys
 	metadataKeySSHKeys = "sshKeys"
@@ -34,7 +36,8 @@ const (
 	// See https://cloud.google.com/compute/docs/operating-systems/linux-os#ubuntu
 	// TODO(ericsnow) Should this be handled in cloud-images (i.e.
 	// simplestreams)?
-	imageBasePath = "projects/ubuntu-os-cloud/global/images/"
+	ubuntuImageBasePath  = "projects/ubuntu-os-cloud/global/images/"
+	windowsImageBasePath = "projects/windows-cloud/global/images/"
 )
 
 var (

--- a/provider/gce/userdata.go
+++ b/provider/gce/userdata.go
@@ -18,7 +18,21 @@ func (GCERenderer) EncodeUserdata(udata []byte, vers version.OSType) ([]byte, er
 	switch vers {
 	case version.Ubuntu, version.CentOS:
 		return renderers.ToBase64(utils.Gzip(udata)), nil
+	case version.Windows:
+		return renderers.WinEmbedInScript(udata), nil
 	default:
 		return nil, errors.Errorf("Cannot encode userdata for OS: %s", vers)
 	}
 }
+
+// The hostname on windows GCE instances is taken from
+// the instance id. This is bad because windows only
+// uses the first 15 characters in certain instances,
+// which are not unique for the GCE provider.
+// As a result, we have to send this small script as
+// a sysprep script, to change the hostname inside
+// the sysprep step, simplyfing the userdata and
+// saving a reboot
+var winSetHostnameScript = `
+Rename-Computer %q
+`

--- a/provider/gce/userdata_test.go
+++ b/provider/gce/userdata_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cloudconfig/providerinit/renderers"
 	"github.com/juju/juju/provider/gce"
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/version"
@@ -37,9 +38,17 @@ func (s *UserdataSuite) TestGCEUnix(c *gc.C) {
 	c.Assert(string(result), jc.DeepEquals, expected)
 }
 
+func (s *UserdataSuite) TestAzureWindows(c *gc.C) {
+	renderer := gce.GCERenderer{}
+	data := []byte("test")
+	result, err := renderer.EncodeUserdata(data, version.Windows)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, jc.DeepEquals, renderers.WinEmbedInScript(data))
+}
+
 func (s *UserdataSuite) TestGCEUnknownOS(c *gc.C) {
 	renderer := gce.GCERenderer{}
-	result, err := renderer.EncodeUserdata(nil, version.Windows)
+	result, err := renderer.EncodeUserdata(nil, version.Arch)
 	c.Assert(result, gc.IsNil)
-	c.Assert(err, gc.ErrorMatches, "Cannot encode userdata for OS: Windows")
+	c.Assert(err, gc.ErrorMatches, "Cannot encode userdata for OS: Arch")
 }


### PR DESCRIPTION
Relatively small PR, only refactorings needed are sending the userdata differently on windows and adding a image path. gwacl was used to provide a random hostname, I couldn't find a similar function in utils(needs to return a number of random alphanumeric characters).

(Review request: http://reviews.vapour.ws/r/2665/)