### PR TITLE
apiserver: rename httpHandler to httpContext

### DIFF
--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -396,7 +396,7 @@ func (srv *Server) run(lis net.Listener) {
 
 	if feature.IsDbLogEnabled() {
 		handleAll(mux, "/environment/:envuuid/logsink",
-			newLogSinkHandler(httpHandler{statePool: srv.statePool}, srv.logDir))
+			newLogSinkHandler(httpContext{statePool: srv.statePool}, srv.logDir))
 		handleAll(mux, "/environment/:envuuid/log",
 			newDebugLogDBHandler(srv.statePool, srvDying))
 	} else {
@@ -405,8 +405,8 @@ func (srv *Server) run(lis net.Listener) {
 	}
 	handleAll(mux, "/environment/:envuuid/charms",
 		&charmsHandler{
-			httpHandler: httpHandler{statePool: srv.statePool},
-			dataDir:     srv.dataDir},
+			ctxt:    httpContext{statePool: srv.statePool},
+			dataDir: srv.dataDir},
 	)
 	// TODO: We can switch from handleAll to mux.Post/Get/etc for entries
 	// where we only want to support specific request methods. However, our
@@ -414,16 +414,16 @@ func (srv *Server) run(lis net.Listener) {
 	// pat only does "text/plain" responses.
 	handleAll(mux, "/environment/:envuuid/tools",
 		&toolsUploadHandler{toolsHandler{
-			httpHandler{statePool: srv.statePool},
+			httpContext{statePool: srv.statePool},
 		}},
 	)
 	handleAll(mux, "/environment/:envuuid/tools/:version",
 		&toolsDownloadHandler{toolsHandler{
-			httpHandler{statePool: srv.statePool},
+			httpContext{statePool: srv.statePool},
 		}},
 	)
 	handleAll(mux, "/environment/:envuuid/backups",
-		&backupHandler{httpHandler{
+		&backupHandler{httpContext{
 			statePool:          srv.statePool,
 			strictValidation:   true,
 			stateServerEnvOnly: true,
@@ -432,8 +432,8 @@ func (srv *Server) run(lis net.Listener) {
 	handleAll(mux, "/environment/:envuuid/api", http.HandlerFunc(srv.apiHandler))
 	handleAll(mux, "/environment/:envuuid/images/:kind/:series/:arch/:filename",
 		&imagesDownloadHandler{
-			httpHandler: httpHandler{statePool: srv.statePool},
-			dataDir:     srv.dataDir},
+			ctxt:    httpContext{statePool: srv.statePool},
+			dataDir: srv.dataDir},
 	)
 	// For backwards compatibility we register all the old paths
 
@@ -445,18 +445,18 @@ func (srv *Server) run(lis net.Listener) {
 
 	handleAll(mux, "/charms",
 		&charmsHandler{
-			httpHandler: httpHandler{statePool: srv.statePool},
-			dataDir:     srv.dataDir,
+			ctxt:    httpContext{statePool: srv.statePool},
+			dataDir: srv.dataDir,
 		},
 	)
 	handleAll(mux, "/tools",
 		&toolsUploadHandler{toolsHandler{
-			httpHandler{statePool: srv.statePool},
+			httpContext{statePool: srv.statePool},
 		}},
 	)
 	handleAll(mux, "/tools/:version",
 		&toolsDownloadHandler{toolsHandler{
-			httpHandler{statePool: srv.statePool},
+			httpContext{statePool: srv.statePool},
 		}},
 	)
 	handleAll(mux, "/", http.HandlerFunc(srv.apiHandler))

--- a/apiserver/backup.go
+++ b/apiserver/backup.go
@@ -26,20 +26,20 @@ var newBackups = func(st *state.State) (backups.Backups, io.Closer) {
 
 // backupHandler handles backup requests.
 type backupHandler struct {
-	httpHandler
+	ctxt httpContext
 }
 
 func (h *backupHandler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 	// Validate before authenticate because the authentication is dependent
 	// on the state connection that is determined during the validation.
-	stateWrapper, err := h.validateEnvironUUID(req)
+	stateWrapper, err := h.ctxt.validateEnvironUUID(req)
 	if err != nil {
 		h.sendError(resp, http.StatusNotFound, err.Error())
 		return
 	}
 
 	if err := stateWrapper.authenticateUser(req); err != nil {
-		h.authError(resp, h)
+		h.ctxt.authError(resp, h)
 		return
 	}
 

--- a/apiserver/charms.go
+++ b/apiserver/charms.go
@@ -34,7 +34,7 @@ import (
 
 // charmsHandler handles charm upload through HTTPS in the API server.
 type charmsHandler struct {
-	httpHandler
+	ctxt    httpContext
 	dataDir string
 }
 
@@ -43,7 +43,7 @@ type charmsHandler struct {
 type bundleContentSenderFunc func(w http.ResponseWriter, r *http.Request, bundle *charm.CharmArchive)
 
 func (h *charmsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	stateWrapper, err := h.validateEnvironUUID(r)
+	stateWrapper, err := h.ctxt.validateEnvironUUID(r)
 	if err != nil {
 		h.sendError(w, http.StatusNotFound, err.Error())
 		return
@@ -52,7 +52,7 @@ func (h *charmsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case "POST":
 		if err := stateWrapper.authenticateUser(r); err != nil {
-			h.authError(w, h)
+			h.ctxt.authError(w, h)
 			return
 		}
 		// Add a local charm to the store provider.

--- a/apiserver/debuglog.go
+++ b/apiserver/debuglog.go
@@ -27,7 +27,7 @@ import (
 // variants. The supplied handle func allows for varied handling of
 // requests.
 type debugLogHandler struct {
-	httpHandler
+	ctxt   httpContext
 	stop   <-chan struct{}
 	handle debugLogHandlerFunc
 }
@@ -45,9 +45,9 @@ func newDebugLogHandler(
 	handle debugLogHandlerFunc,
 ) *debugLogHandler {
 	return &debugLogHandler{
-		httpHandler: httpHandler{statePool: statePool},
-		stop:        stop,
-		handle:      handle,
+		ctxt:   httpContext{statePool: statePool},
+		stop:   stop,
+		handle: handle,
 	}
 }
 
@@ -79,7 +79,7 @@ func (h *debugLogHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 			// Validate before authenticate because the authentication is
 			// dependent on the state connection that is determined during the
 			// validation.
-			stateWrapper, err := h.validateEnvironUUID(req)
+			stateWrapper, err := h.ctxt.validateEnvironUUID(req)
 			if err != nil {
 				socket.sendError(err)
 				return

--- a/apiserver/httpcontext.go
+++ b/apiserver/httpcontext.go
@@ -22,8 +22,8 @@ type errorSender interface {
 	sendError(w http.ResponseWriter, statusCode int, message string)
 }
 
-// httpHandler handles http requests through HTTPS in the API server.
-type httpHandler struct {
+// httpContext provides context for HTTP handlers.
+type httpContext struct {
 	// A cache of State instances for different environments.
 	statePool *state.StatePool
 	// strictValidation means that empty envUUID values are not valid.
@@ -37,17 +37,17 @@ type httpStateWrapper struct {
 	state *state.State
 }
 
-func (h *httpHandler) getEnvironUUID(r *http.Request) string {
+func (h *httpContext) getEnvironUUID(r *http.Request) string {
 	return r.URL.Query().Get(":envuuid")
 }
 
 // authError sends an unauthorized error.
-func (h *httpHandler) authError(w http.ResponseWriter, sender errorSender) {
+func (h *httpContext) authError(w http.ResponseWriter, sender errorSender) {
 	w.Header().Set("WWW-Authenticate", `Basic realm="juju"`)
 	sender.sendError(w, http.StatusUnauthorized, "unauthorized")
 }
 
-func (h *httpHandler) validateEnvironUUID(r *http.Request) (*httpStateWrapper, error) {
+func (h *httpContext) validateEnvironUUID(r *http.Request) (*httpStateWrapper, error) {
 	envUUID := h.getEnvironUUID(r)
 	envState, err := validateEnvironUUID(validateArgs{
 		statePool:          h.statePool,

--- a/apiserver/images.go
+++ b/apiserver/images.go
@@ -29,12 +29,12 @@ import (
 
 // imagesDownloadHandler handles image download through HTTPS in the API server.
 type imagesDownloadHandler struct {
-	httpHandler
+	ctxt    httpContext
 	dataDir string
 }
 
 func (h *imagesDownloadHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	stateWrapper, err := h.validateEnvironUUID(r)
+	stateWrapper, err := h.ctxt.validateEnvironUUID(r)
 	if err != nil {
 		h.sendError(w, http.StatusNotFound, err.Error())
 		return

--- a/apiserver/tools.go
+++ b/apiserver/tools.go
@@ -31,7 +31,7 @@ import (
 // toolsHandler is the base type for uploading and downloading
 // tools over HTTPS via the API server.
 type toolsHandler struct {
-	httpHandler
+	ctxt httpContext
 }
 
 // toolsHandler handles tool upload through HTTPS in the API server.
@@ -45,7 +45,7 @@ type toolsDownloadHandler struct {
 }
 
 func (h *toolsDownloadHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	stateWrapper, err := h.validateEnvironUUID(r)
+	stateWrapper, err := h.ctxt.validateEnvironUUID(r)
 	if err != nil {
 		h.sendExistingError(w, http.StatusNotFound, err)
 		return
@@ -68,14 +68,14 @@ func (h *toolsDownloadHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 func (h *toolsUploadHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Validate before authenticate because the authentication is dependent
 	// on the state connection that is determined during the validation.
-	stateWrapper, err := h.validateEnvironUUID(r)
+	stateWrapper, err := h.ctxt.validateEnvironUUID(r)
 	if err != nil {
 		h.sendExistingError(w, http.StatusNotFound, err)
 		return
 	}
 
 	if err := stateWrapper.authenticateUser(r); err != nil {
-		h.authError(w, h)
+		h.ctxt.authError(w, h)
 		return
 	}
 


### PR DESCRIPTION
The httpHandler type does not "handle" anything - it provides
some context for HTTP handlers. This PR renames
it accordingly, laying the foundations for some
more work in this area.

(Review request: http://reviews.vapour.ws/r/2667/)