### PR TITLE
Temp disable UpdateFromPublishedImages

### DIFF
--- a/api/imagemetadata/client.go
+++ b/api/imagemetadata/client.go
@@ -62,6 +62,8 @@ func (c *Client) Save(metadata []params.CloudImageMetadata) ([]params.ErrorResul
 // updates stored ones accordingly.
 // This method is primarily intended for a worker.
 func (c *Client) UpdateFromPublishedImages() error {
-	return errors.Trace(
-		c.facade.FacadeCall("UpdateFromPublishedImages", nil, nil))
+	// TODO(wallyworld) - this is a temp "fix" to unblock master lp:1495542
+	return nil
+	//	return errors.Trace(
+	//		c.facade.FacadeCall("UpdateFromPublishedImages", nil, nil))
 }

--- a/api/imagemetadata/client_test.go
+++ b/api/imagemetadata/client_test.go
@@ -178,6 +178,7 @@ func (s *imagemetadataSuite) TestSaveFacadeCallError(c *gc.C) {
 }
 
 func (s *imagemetadataSuite) TestUpdateFromPublishedImages(c *gc.C) {
+	c.Skip("temp disable to unblock master - lp:1495542")
 	called := false
 
 	apiCaller := testing.APICallerFunc(
@@ -200,6 +201,7 @@ func (s *imagemetadataSuite) TestUpdateFromPublishedImages(c *gc.C) {
 }
 
 func (s *imagemetadataSuite) TestUpdateFromPublishedImagesFacadeCallError(c *gc.C) {
+	c.Skip("temp disable to unblock master - lp:1495542")
 	called := false
 	msg := "facade failure"
 	apiCaller := testing.APICallerFunc(

--- a/worker/imagemetadataworker/metadataupdater_test.go
+++ b/worker/imagemetadataworker/metadataupdater_test.go
@@ -20,6 +20,7 @@ type imageMetadataUpdateSuite struct {
 }
 
 func (s *imageMetadataUpdateSuite) TestWorker(c *gc.C) {
+	c.Skip("temp disable to unblock master - lp:1495542")
 	done := make(chan struct{})
 	client := s.ImageClient(done)
 


### PR DESCRIPTION
DIsable functionality that causes 1.22 -> 1.26 upgrades to fail.

(Review request: http://reviews.vapour.ws/r/2669/)