### PR TITLE
 API: Undertaker

### DIFF
--- a/api/undertaker/package_test.go
+++ b/api/undertaker/package_test.go
@@ -1,0 +1,22 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package undertaker_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+
+	coretesting "github.com/juju/juju/testing"
+)
+
+func TestAll(t *testing.T) {
+	gc.TestingT(t)
+}
+
+type undertakerSuite struct {
+	coretesting.BaseSuite
+}
+
+var _ = gc.Suite(&undertakerSuite{})

--- a/api/undertaker/undertaker.go
+++ b/api/undertaker/undertaker.go
@@ -1,0 +1,69 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package undertaker
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/apiserver/params"
+)
+
+// Client provides access to the undertaker API
+type Client struct {
+	base.ClientFacade
+	st     base.APICallCloser
+	facade base.FacadeCaller
+}
+
+// UndertakerClient defines the methods on the undertaker API end point.
+type UndertakerClient interface {
+	EnvironInfo() (params.UndertakerEnvironInfoResult, error)
+	ProcessDyingEnviron() error
+	RemoveEnviron() error
+}
+
+// NewClient creates a new client for accessing the undertaker API.
+func NewClient(st base.APICallCloser) *Client {
+	frontend, backend := base.NewClientFacade(st, "Undertaker")
+	return &Client{ClientFacade: frontend, st: st, facade: backend}
+}
+
+// EnvironInfo returns information on the environment needed by the undertaker worker.
+func (c *Client) EnvironInfo() (params.UndertakerEnvironInfoResult, error) {
+	result := params.UndertakerEnvironInfoResult{}
+	p, err := c.params()
+	if err != nil {
+		return params.UndertakerEnvironInfoResult{}, errors.Trace(err)
+	}
+	err = c.facade.FacadeCall("EnvironInfo", p, &result)
+	return result, errors.Trace(err)
+}
+
+// ProcessDyingEnviron checks if a dying environment has any machines or services.
+// If there are none, the environment's life is changed from dying to dead.
+func (c *Client) ProcessDyingEnviron() error {
+	p, err := c.params()
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	return c.facade.FacadeCall("ProcessDyingEnviron", p, nil)
+}
+
+// RemoveEnviron removes any records of this environment from Juju.
+func (c *Client) RemoveEnviron() error {
+	p, err := c.params()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return c.facade.FacadeCall("RemoveEnviron", p, nil)
+}
+
+func (c *Client) params() (params.Entities, error) {
+	envTag, err := c.st.EnvironTag()
+	if err != nil {
+		return params.Entities{}, errors.Trace(err)
+	}
+	return params.Entities{Entities: []params.Entity{{envTag.String()}}}, nil
+}

--- a/api/undertaker/undertaker_test.go
+++ b/api/undertaker/undertaker_test.go
@@ -1,0 +1,74 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package undertaker_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	basetesting "github.com/juju/juju/api/base/testing"
+	"github.com/juju/juju/api/undertaker"
+	"github.com/juju/juju/apiserver/params"
+)
+
+var _ undertaker.UndertakerClient = (*undertaker.Client)(nil)
+
+func (s *undertakerSuite) TestEnvironInfo(c *gc.C) {
+	var called bool
+	client := s.mockClient(c, "EnvironInfo", func(response interface{}) {
+		called = true
+		result := response.(*params.UndertakerEnvironInfoResult)
+		result.Result = params.UndertakerEnvironInfo{}
+	})
+
+	result, err := client.EnvironInfo()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(called, jc.IsTrue)
+	c.Assert(result, gc.Equals, params.UndertakerEnvironInfoResult{})
+}
+
+func (s *undertakerSuite) TestProcessDyingEnviron(c *gc.C) {
+	var called bool
+	client := s.mockClient(c, "ProcessDyingEnviron", func(response interface{}) {
+		called = true
+		c.Assert(response, gc.IsNil)
+	})
+
+	c.Assert(client.ProcessDyingEnviron(), jc.ErrorIsNil)
+	c.Assert(called, jc.IsTrue)
+}
+
+func (s *undertakerSuite) TestRemoveEnviron(c *gc.C) {
+	var called bool
+	client := s.mockClient(c, "RemoveEnviron", func(response interface{}) {
+		called = true
+		c.Assert(response, gc.IsNil)
+	})
+
+	err := client.RemoveEnviron()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(called, jc.IsTrue)
+}
+
+func (s *undertakerSuite) mockClient(c *gc.C, expectedRequest string, callback func(response interface{})) *undertaker.Client {
+	apiCaller := basetesting.APICallerFunc(
+		func(objType string,
+			version int,
+			id, request string,
+			args, response interface{},
+		) error {
+			c.Check(objType, gc.Equals, "Undertaker")
+			c.Check(id, gc.Equals, "")
+			c.Check(request, gc.Equals, expectedRequest)
+
+			a, ok := args.(params.Entities)
+			c.Assert(ok, jc.IsTrue)
+			c.Assert(a.Entities, gc.DeepEquals, []params.Entity{{Tag: "environment-"}})
+
+			callback(response)
+			return nil
+		})
+
+	return undertaker.NewClient(apiCaller)
+}

--- a/apiserver/undertaker/undertaker.go
+++ b/apiserver/undertaker/undertaker.go
@@ -63,5 +63,12 @@ func (u *UndertakerAPI) ProcessDyingEnviron() error {
 
 // RemoveEnviron removes any records of this environment from Juju.
 func (u *UndertakerAPI) RemoveEnviron() error {
-	return u.st.RemoveAllEnvironDocs()
+	err := u.st.RemoveAllEnvironDocs()
+	if err != nil {
+		// TODO(waigani) Return a human friendly error for now. The proper fix
+		// is to run a buildTxn within state.RemoveAllEnvironDocs, so we
+		// can return better errors than "transaction aborted".
+		return errors.New("an error occurred, unable to remove environment")
+	}
+	return nil
 }

--- a/apiserver/undertaker/undertaker_test.go
+++ b/apiserver/undertaker/undertaker_test.go
@@ -115,7 +115,7 @@ func (s *undertakerSuite) TestRemoveAliveEnviron(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = hostedAPI.RemoveEnviron()
-	c.Assert(err, gc.ErrorMatches, "transaction aborted")
+	c.Assert(err, gc.ErrorMatches, "an error occurred, unable to remove environment")
 }
 
 func (s *undertakerSuite) TestRemoveDyingEnviron(c *gc.C) {
@@ -128,7 +128,7 @@ func (s *undertakerSuite) TestRemoveDyingEnviron(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = hostedAPI.RemoveEnviron()
-	c.Assert(err, gc.ErrorMatches, "transaction aborted")
+	c.Assert(err, gc.ErrorMatches, "an error occurred, unable to remove environment")
 }
 
 func (s *undertakerSuite) TestDeadRemoveEnviron(c *gc.C) {

--- a/featuretests/api_undertaker_test.go
+++ b/featuretests/api_undertaker_test.go
@@ -1,0 +1,175 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package featuretests
+
+import (
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/api"
+	"github.com/juju/juju/api/undertaker"
+	"github.com/juju/juju/apiserver/params"
+	jujutesting "github.com/juju/juju/juju/testing"
+	"github.com/juju/juju/state"
+	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/testing/factory"
+)
+
+type undertakerSuite struct {
+	jujutesting.JujuConnSuite
+}
+
+func (s *undertakerSuite) TestPermDenied(c *gc.C) {
+	nonManagerMachine, _ := s.OpenAPIAsNewMachine(c, state.JobHostUnits)
+	for _, conn := range []api.Connection{
+		nonManagerMachine,
+		s.APIState,
+	} {
+		undertakerClient := undertaker.NewClient(conn)
+		c.Assert(undertakerClient, gc.NotNil)
+
+		_, err := undertakerClient.EnvironInfo()
+		c.Assert(err, gc.ErrorMatches, "permission denied")
+	}
+}
+
+func (s *undertakerSuite) TestStateEnvionInfo(c *gc.C) {
+	st, _ := s.OpenAPIAsNewMachine(c, state.JobManageEnviron)
+	undertakerClient := undertaker.NewClient(st)
+	c.Assert(undertakerClient, gc.NotNil)
+
+	result, err := undertakerClient.EnvironInfo()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, gc.NotNil)
+	c.Assert(result.Error, gc.IsNil)
+	info := result.Result
+	c.Assert(info.UUID, gc.Equals, coretesting.EnvironmentTag.Id())
+	c.Assert(info.Name, gc.Equals, "dummyenv")
+	c.Assert(info.GlobalName, gc.Equals, "user-dummy-admin@local/dummyenv")
+	c.Assert(info.IsSystem, jc.IsTrue)
+	c.Assert(info.Life, gc.Equals, params.Alive)
+	c.Assert(info.TimeOfDeath.IsZero(), jc.IsTrue)
+}
+
+func (s *undertakerSuite) TestStateProcessDyingEnviron(c *gc.C) {
+	st, _ := s.OpenAPIAsNewMachine(c, state.JobManageEnviron)
+	undertakerClient := undertaker.NewClient(st)
+	c.Assert(undertakerClient, gc.NotNil)
+
+	err := undertakerClient.ProcessDyingEnviron()
+	c.Assert(err, gc.ErrorMatches, "environment is not dying")
+
+	env, err := s.State.Environment()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(env.Destroy(), jc.ErrorIsNil)
+	c.Assert(env.Refresh(), jc.ErrorIsNil)
+	c.Assert(env.Life(), gc.Equals, state.Dying)
+
+	err = undertakerClient.ProcessDyingEnviron()
+	c.Assert(err, gc.ErrorMatches, `environment not empty, found 1 machine\(s\)`)
+}
+
+func (s *undertakerSuite) TestStateRemoveEnvironFails(c *gc.C) {
+	st, _ := s.OpenAPIAsNewMachine(c, state.JobManageEnviron)
+	undertakerClient := undertaker.NewClient(st)
+	c.Assert(undertakerClient, gc.NotNil)
+	c.Assert(undertakerClient.RemoveEnviron(), gc.ErrorMatches, "an error occurred, unable to remove environment")
+}
+
+func (s *undertakerSuite) TestHostedEnvironInfo(c *gc.C) {
+	undertakerClient, otherSt := s.hostedAPI(c)
+	defer otherSt.Close()
+
+	result, err := undertakerClient.EnvironInfo()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, gc.NotNil)
+	c.Assert(result.Error, gc.IsNil)
+	envInfo := result.Result
+	c.Assert(envInfo.UUID, gc.Equals, otherSt.EnvironUUID())
+	c.Assert(envInfo.Name, gc.Equals, "hosted_env")
+	c.Assert(envInfo.GlobalName, gc.Equals, "user-dummy-admin@local/hosted_env")
+	c.Assert(envInfo.IsSystem, jc.IsFalse)
+	c.Assert(envInfo.Life, gc.Equals, params.Alive)
+	c.Assert(envInfo.TimeOfDeath.IsZero(), jc.IsTrue)
+}
+
+func (s *undertakerSuite) TestHostedProcessDyingEnviron(c *gc.C) {
+	undertakerClient, otherSt := s.hostedAPI(c)
+	defer otherSt.Close()
+
+	err := undertakerClient.ProcessDyingEnviron()
+	c.Assert(err, gc.ErrorMatches, "environment is not dying")
+
+	env, err := otherSt.Environment()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(env.Destroy(), jc.ErrorIsNil)
+	c.Assert(env.Refresh(), jc.ErrorIsNil)
+	c.Assert(env.Life(), gc.Equals, state.Dying)
+
+	c.Assert(undertakerClient.ProcessDyingEnviron(), jc.ErrorIsNil)
+
+	c.Assert(env.Refresh(), jc.ErrorIsNil)
+	c.Assert(env.Life(), gc.Equals, state.Dead)
+
+	result, err := undertakerClient.EnvironInfo()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, gc.NotNil)
+	c.Assert(result.Error, gc.IsNil)
+	info := result.Result
+	c.Assert(info.TimeOfDeath.IsZero(), jc.IsFalse)
+}
+
+func (s *undertakerSuite) TestHostedRemoveEnviron(c *gc.C) {
+	undertakerClient, otherSt := s.hostedAPI(c)
+	defer otherSt.Close()
+
+	// Aborts on alive environ.
+	err := undertakerClient.RemoveEnviron()
+	c.Assert(err, gc.ErrorMatches, "an error occurred, unable to remove environment")
+
+	env, err := otherSt.Environment()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(env.Destroy(), jc.ErrorIsNil)
+
+	// TODO(waigani) see todo in state/state.go:123. This test will pass
+	// before landing in master.
+
+	// Aborts on dying environ.
+	// err = undertakerClient.RemoveEnviron()
+	// c.Assert(err, gc.ErrorMatches, "an error occurred, unable to remove environment")
+
+	c.Assert(undertakerClient.ProcessDyingEnviron(), jc.ErrorIsNil)
+
+	c.Assert(undertakerClient.RemoveEnviron(), jc.ErrorIsNil)
+	c.Assert(otherSt.EnsureEnvironmentRemoved(), jc.ErrorIsNil)
+}
+
+func (s *undertakerSuite) hostedAPI(c *gc.C) (*undertaker.Client, *state.State) {
+	otherState := s.Factory.MakeEnvironment(c, &factory.EnvParams{Name: "hosted_env"})
+
+	password, err := utils.RandomPassword()
+	c.Assert(err, jc.ErrorIsNil)
+
+	machine := s.Factory.MakeMachine(c, &factory.MachineParams{
+		Jobs:     []state.MachineJob{state.JobManageEnviron},
+		Password: password,
+		Nonce:    "fake_nonce",
+	})
+
+	// Connect to hosted environ from state server.
+	info := s.APIInfo(c)
+	info.Tag = machine.Tag()
+	info.Password = password
+	info.Nonce = "fake_nonce"
+	info.EnvironTag = otherState.EnvironTag()
+
+	otherAPIState, err := api.Open(info, api.DefaultDialOpts())
+	c.Assert(err, jc.ErrorIsNil)
+
+	undertakerClient := undertaker.NewClient(otherAPIState)
+	c.Assert(undertakerClient, gc.NotNil)
+
+	return undertakerClient, otherState
+}

--- a/featuretests/package_test.go
+++ b/featuretests/package_test.go
@@ -34,6 +34,7 @@ func init() {
 	gc.Suite(&cloudImageMetadataSuite{})
 	gc.Suite(&cmdSpaceSuite{})
 	gc.Suite(&cmdSubnetSuite{})
+	gc.Suite(&undertakerSuite{})
 }
 
 func Test(t *testing.T) {


### PR DESCRIPTION
Introduce the Undertaker API to talk to the Undertaker facade on the
APIServer. Tests use a mock client. A "feature test" asserts that the
api > apiserver > state code paths are wired up correctly.

(Review request: http://reviews.vapour.ws/r/2670/)