### PR TITLE
Guard the uniter watcher cleanup.

### DIFF
--- a/worker/uniter/uniter.go
+++ b/worker/uniter/uniter.go
@@ -205,7 +205,10 @@ func (u *Uniter) loop(unitTag names.UnitTag) (err error) {
 
 	// watcher may be replaced, so use a closure.
 	u.addCleanup(func() error {
-		return watcher.Stop()
+		if watcher != nil {
+			return watcher.Stop()
+		}
+		return nil
 	})
 
 	onIdle := func() error {


### PR DESCRIPTION
If the watcher fails to start, the cleanup is still called, but watcher is nil.

(Review request: http://reviews.vapour.ws/r/2671/)