### PR TITLE
Run the uniter upgrade step during the start of the uniter.

### DIFF
--- a/cmd/jujud/agent/unit.go
+++ b/cmd/jujud/agent/unit.go
@@ -24,6 +24,7 @@ import (
 	"github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/dependency"
 	"github.com/juju/juju/worker/logsender"
+	"github.com/juju/juju/worker/uniter"
 )
 
 var (
@@ -122,12 +123,41 @@ func (a *UnitAgent) Run(ctx *cmd.Context) error {
 	if flags := featureflag.String(); flags != "" {
 		logger.Warningf("developer feature flags enabled: %s", flags)
 	}
-
 	network.InitializeFromConfig(agentConfig)
+
+	// Sometimes there are upgrade steps that are needed for each unit.
+	// There are plans afoot to unify the unit and machine agents. When
+	// this happens, there will be a simple helper function for the upgrade
+	// steps to run something for each unit on the machine. Until then, we
+	// need to have the uniter do it, as the overhead of getting a full
+	// upgrade process in the unit agent out weights the current benefits.
+	// So.. since the upgrade steps are all idempotent, we will just call
+	// the upgrade steps when we start the uniter. To be clear, these
+	// should move back to the upgrade package when we do unify the agents.
+	runUpgrades(agentConfig.Tag(), agentConfig.DataDir())
+
 	a.runner.StartWorker("api", a.APIWorkers)
 	err := cmdutil.AgentDone(logger, a.runner.Wait())
 	a.tomb.Kill(err)
 	return err
+}
+
+// runUpgrades is a temporary fix to deal with upgrade steps that need
+// to be run for each unit. This function cannot fail. Errors in the
+// upgrade steps are logged, but the uniter will attempt to continue.
+// Worst case, we are no worse off than we are today, best case, things
+// actually work properly. Only simple upgrade steps that don't use the API
+// are available now. If we need really complex steps using the API, there
+// should be significant steps to unify the agents first.
+func runUpgrades(tag names.Tag, dataDir string) {
+	unitTag, ok := tag.(names.UnitTag)
+	if !ok {
+		logger.Errorf("unit agent tag not a unit tag: %v", tag)
+		return
+	}
+	if err := uniter.AddStoppedFieldToUniterState(unitTag, dataDir); err != nil {
+		logger.Errorf("Upgrade step failed - add Stopped field to uniter state: %v", err)
+	}
 }
 
 // APIWorkers returns a dependency.Engine running the unit agent's responsibilities.

--- a/upgrades/steps123.go
+++ b/upgrades/steps123.go
@@ -4,10 +4,7 @@
 package upgrades
 
 import (
-	"github.com/juju/names"
-
 	"github.com/juju/juju/state"
-	"github.com/juju/juju/worker/uniter"
 )
 
 // stateStepsFor123 returns upgrade steps for Juju 1.23 that manipulate state directly.
@@ -86,19 +83,6 @@ func stepsFor123() []Step {
 			description: "add environment UUID to agent config",
 			targets:     []Target{AllMachines},
 			run:         addEnvironmentUUIDToAgentConfig,
-		},
-		&upgradeStep{
-			description: "add Stopped field to uniter state",
-			targets:     []Target{AllMachines},
-			run: func(context Context) error {
-				config := context.AgentConfig()
-				tag, ok := config.Tag().(names.UnitTag)
-				if !ok {
-					// not a Unit; skipping
-					return nil
-				}
-				return uniter.AddStoppedFieldToUniterState(tag, config.DataDir())
-			},
 		},
 	}
 }

--- a/upgrades/steps123_test.go
+++ b/upgrades/steps123_test.go
@@ -35,7 +35,6 @@ func (s *steps123Suite) TestStateStepsFor123(c *gc.C) {
 func (s *steps123Suite) TestStepsFor123(c *gc.C) {
 	expected := []string{
 		"add environment UUID to agent config",
-		"add Stopped field to uniter state",
 	}
 	assertSteps(c, version.MustParse("1.23.0"), expected)
 }

--- a/worker/uniter/uniter.go
+++ b/worker/uniter/uniter.go
@@ -128,16 +128,6 @@ func NewUniter(uniterParams *UniterParams) *Uniter {
 		updateStatusAt:       uniterParams.UpdateStatusSignal,
 		newOperationExecutor: uniterParams.NewOperationExecutor,
 	}
-	// Sometimes there are upgrade steps that are needed for each unit.
-	// There are plans afoot to unify the unit and machine agents. When
-	// this happens, there will be a simple helper function for the upgrade
-	// steps to run something for each unit on the machine. Until then, we
-	// need to have the uniter do it, as the overhead of getting a full
-	// upgrade process in the unit agent out weights the current benefits.
-	// So.. since the upgrade steps are all idempotent, we will just call
-	// the upgrade steps when we start the uniter. To be clear, these
-	// should move back to the upgrade package when we do unify the agents.
-	runUpgrades(uniterParams.UnitTag, uniterParams.DataDir)
 	go func() {
 		defer u.tomb.Done()
 		defer u.runCleanups()
@@ -459,15 +449,4 @@ func (u *Uniter) acquireExecutionLock(message string) (func() error, error) {
 		return nil, err
 	}
 	return func() error { return u.hookLock.Unlock() }, nil
-}
-
-// runUpgrades is a temporary fix to deal with upgrade steps that need
-// to be run for each unit. This function cannot fail. Errors in the
-// upgrade steps are logged, but the uniter will attempt to continue.
-// Worst case, we are no worse off than we are today, best case, things
-// actually work properly.
-func runUpgrades(tag names.UnitTag, dataDir string) {
-	if err := AddStoppedFieldToUniterState(tag, dataDir); err != nil {
-		logger.Errorf("Upgrade step failed - add Stopped field to uniter state: %v", err)
-	}
 }

--- a/worker/uniter/upgrade123.go
+++ b/worker/uniter/upgrade123.go
@@ -23,7 +23,7 @@ func AddStoppedFieldToUniterState(tag names.UnitTag, dataDir string) error {
 	case nil:
 		return performUpgrade(opsFile, state)
 	case operation.ErrNoStateFile:
-		logger.Warningf("no uniter state file found for unit %s, skipping uniter upgrade step", tag)
+		logger.Debugf("no uniter state file found for unit %s, skipping uniter upgrade step", tag)
 		return nil
 	default:
 		return err


### PR DESCRIPTION
This is a temporary(ish) solution to dealing with unit based steps until we unify the agents.

(Review request: http://reviews.vapour.ws/r/2672/)