### PR TITLE
apiserver/common: infer HTTP status from error

### DIFF
--- a/apiserver/common/errors_test.go
+++ b/apiserver/common/errors_test.go
@@ -5,6 +5,7 @@ package common_test
 
 import (
 	stderrors "errors"
+	"net/http"
 
 	"github.com/juju/errors"
 	"github.com/juju/names"
@@ -28,112 +29,150 @@ var _ = gc.Suite(&errorsSuite{})
 var errorTransformTests = []struct {
 	err        error
 	code       string
+	status     int
 	helperFunc func(error) bool
 }{{
 	err:        errors.NotFoundf("hello"),
 	code:       params.CodeNotFound,
+	status:     http.StatusNotFound,
 	helperFunc: params.IsCodeNotFound,
 }, {
 	err:        errors.Unauthorizedf("hello"),
 	code:       params.CodeUnauthorized,
+	status:     http.StatusUnauthorized,
 	helperFunc: params.IsCodeUnauthorized,
 }, {
 	err:        state.ErrCannotEnterScopeYet,
 	code:       params.CodeCannotEnterScopeYet,
+	status:     http.StatusInternalServerError,
 	helperFunc: params.IsCodeCannotEnterScopeYet,
 }, {
 	err:        state.ErrCannotEnterScope,
 	code:       params.CodeCannotEnterScope,
+	status:     http.StatusInternalServerError,
 	helperFunc: params.IsCodeCannotEnterScope,
 }, {
 	err:        state.ErrDead,
 	code:       params.CodeDead,
+	status:     http.StatusInternalServerError,
 	helperFunc: params.IsCodeDead,
 }, {
 	err:        txn.ErrExcessiveContention,
 	code:       params.CodeExcessiveContention,
+	status:     http.StatusInternalServerError,
 	helperFunc: params.IsCodeExcessiveContention,
 }, {
 	err:        state.ErrUnitHasSubordinates,
 	code:       params.CodeUnitHasSubordinates,
+	status:     http.StatusInternalServerError,
 	helperFunc: params.IsCodeUnitHasSubordinates,
 }, {
 	err:        common.ErrBadId,
 	code:       params.CodeNotFound,
+	status:     http.StatusNotFound,
 	helperFunc: params.IsCodeNotFound,
 }, {
 	err:        common.NoAddressSetError(names.NewUnitTag("mysql/0"), "public"),
 	code:       params.CodeNoAddressSet,
+	status:     http.StatusInternalServerError,
 	helperFunc: params.IsCodeNoAddressSet,
 }, {
 	err:        common.ErrBadCreds,
 	code:       params.CodeUnauthorized,
+	status:     http.StatusUnauthorized,
 	helperFunc: params.IsCodeUnauthorized,
 }, {
 	err:        common.ErrPerm,
 	code:       params.CodeUnauthorized,
+	status:     http.StatusUnauthorized,
 	helperFunc: params.IsCodeUnauthorized,
 }, {
 	err:        common.ErrNotLoggedIn,
 	code:       params.CodeUnauthorized,
+	status:     http.StatusUnauthorized,
 	helperFunc: params.IsCodeUnauthorized,
 }, {
 	err:        errors.NotProvisionedf("machine 0"),
 	code:       params.CodeNotProvisioned,
+	status:     http.StatusInternalServerError,
 	helperFunc: params.IsCodeNotProvisioned,
 }, {
 	err:        errors.AlreadyExistsf("blah"),
 	code:       params.CodeAlreadyExists,
+	status:     http.StatusInternalServerError,
 	helperFunc: params.IsCodeAlreadyExists,
 }, {
 	err:        common.ErrUnknownWatcher,
 	code:       params.CodeNotFound,
+	status:     http.StatusNotFound,
 	helperFunc: params.IsCodeNotFound,
 }, {
 	err:        errors.NotAssignedf("unit mysql/0"),
 	code:       params.CodeNotAssigned,
+	status:     http.StatusInternalServerError,
 	helperFunc: params.IsCodeNotAssigned,
 }, {
 	err:        common.ErrStoppedWatcher,
 	code:       params.CodeStopped,
+	status:     http.StatusInternalServerError,
 	helperFunc: params.IsCodeStopped,
 }, {
 	err:        &state.HasAssignedUnitsError{"42", []string{"a"}},
 	code:       params.CodeHasAssignedUnits,
+	status:     http.StatusInternalServerError,
 	helperFunc: params.IsCodeHasAssignedUnits,
 }, {
 	err:        common.ErrTryAgain,
 	code:       params.CodeTryAgain,
+	status:     http.StatusInternalServerError,
 	helperFunc: params.IsCodeTryAgain,
 }, {
 	err:        state.UpgradeInProgressError,
 	code:       params.CodeUpgradeInProgress,
+	status:     http.StatusInternalServerError,
 	helperFunc: params.IsCodeUpgradeInProgress,
 }, {
 	err:        leadership.ErrClaimDenied,
 	code:       params.CodeLeadershipClaimDenied,
+	status:     http.StatusInternalServerError,
 	helperFunc: params.IsCodeLeadershipClaimDenied,
 }, {
 	err:        common.ErrOperationBlocked("test"),
 	code:       params.CodeOperationBlocked,
+	status:     http.StatusInternalServerError,
 	helperFunc: params.IsCodeOperationBlocked,
 }, {
 	err:        errors.NotSupportedf("needed feature"),
 	code:       params.CodeNotSupported,
+	status:     http.StatusInternalServerError,
 	helperFunc: params.IsCodeNotSupported,
 }, {
-	err:  stderrors.New("an error"),
-	code: "",
+	err:        errors.BadRequestf("something"),
+	code:       params.CodeBadRequest,
+	status:     http.StatusBadRequest,
+	helperFunc: params.IsBadRequest,
 }, {
-	err:  unhashableError{"foo"},
-	code: "",
+	err:        errors.MethodNotAllowedf("something"),
+	code:       params.CodeMethodNotAllowed,
+	status:     http.StatusMethodNotAllowed,
+	helperFunc: params.IsMethodNotAllowed,
+}, {
+	err:    stderrors.New("an error"),
+	status: http.StatusInternalServerError,
+	code:   "",
+}, {
+	err:    unhashableError{"foo"},
+	status: http.StatusInternalServerError,
+	code:   "",
 }, {
 	err:        common.UnknownEnvironmentError("dead-beef-123456"),
 	code:       params.CodeNotFound,
+	status:     http.StatusNotFound,
 	helperFunc: params.IsCodeNotFound,
 }, {
-	err:  nil,
-	code: "",
+	err:    nil,
+	code:   "",
+	status: http.StatusOK,
 }}
 
 type unhashableError []string
@@ -143,16 +182,24 @@ func (err unhashableError) Error() string {
 }
 
 func (s *errorsSuite) TestErrorTransform(c *gc.C) {
-	for _, t := range errorTransformTests {
-		err1 := common.ServerError(t.err)
+	for i, t := range errorTransformTests {
+		c.Logf("test %d: %#v", i, t.err)
+		err1, status := common.ServerErrorAndStatus(t.err)
+
+		// Sanity check that ServerError returns the same thing.
+		err2 := common.ServerError(t.err)
+		c.Assert(err2, gc.DeepEquals, err1)
+		c.Assert(status, gc.Equals, t.status)
+
 		if t.err == nil {
 			c.Assert(err1, gc.IsNil)
-		} else {
-			c.Assert(err1.Message, gc.Equals, t.err.Error())
-			c.Assert(err1.Code, gc.Equals, t.code)
-			if t.helperFunc != nil {
-				c.Assert(err1, jc.Satisfies, t.helperFunc)
-			}
+			c.Assert(status, gc.Equals, http.StatusOK)
+			continue
+		}
+		c.Assert(err1.Message, gc.Equals, t.err.Error())
+		c.Assert(err1.Code, gc.Equals, t.code)
+		if t.helperFunc != nil {
+			c.Assert(err1, jc.Satisfies, t.helperFunc)
 		}
 	}
 }

--- a/apiserver/params/apierror.go
+++ b/apiserver/params/apierror.go
@@ -56,6 +56,8 @@ const (
 	CodeOperationBlocked          = "operation is blocked"
 	CodeLeadershipClaimDenied     = "leadership claim denied"
 	CodeNotSupported              = "not supported"
+	CodeBadRequest                = "bad request"
+	CodeMethodNotAllowed          = "method not allowed"
 )
 
 // ErrCode returns the error code associated with
@@ -177,4 +179,12 @@ func IsCodeLeadershipClaimDenied(err error) bool {
 
 func IsCodeNotSupported(err error) bool {
 	return ErrCode(err) == CodeNotSupported
+}
+
+func IsBadRequest(err error) bool {
+	return ErrCode(err) == CodeBadRequest
+}
+
+func IsMethodNotAllowed(err error) bool {
+	return ErrCode(err) == CodeMethodNotAllowed
 }

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -3,6 +3,7 @@ github.com/altoros/gosigma	git	31228935eec685587914528585da4eb9b073c76d	2015-04-
 github.com/bmizerany/pat	git	48be7df2c27e1cec821a3284a683ce6ef90d9052	2014-04-29T04:34:05Z
 github.com/coreos/go-systemd	git	2d21675230a81a503f4363f4aa3490af06d52bb8	2015-01-26T19:09:17Z
 github.com/dustin/go-humanize	git	145fabdb1ab757076a70a886d092a3af27f66f4c	2014-12-28T07:11:48Z
+github.com/gabriel-samfira/sys	git	9ddc60d56b511544223adecea68da1e4f2153beb	2015-06-08T13:21:19Z
 github.com/godbus/dbus	git	88765d85c0fdadcd98a54e30694fa4e4f5b51133	2015-01-22T18:02:51Z
 github.com/joyent/gocommon	git	40c7818502f7c1ebbb13dab185a26e77b746ff40	2014-05-24T00:08:47Z
 github.com/joyent/gomanta	git	cabd97b029d931836571f00b7e48c331809a30b7	2014-05-24T00:09:46Z
@@ -10,7 +11,7 @@ github.com/joyent/gosdc	git	2f11feadd2d9891e92296a1077c3e2e56939547d	2014-05-24T
 github.com/joyent/gosign	git	0da0d5f1342065321c97812b1f4ac0c2b0bab56c	2014-05-24T00:07:34Z
 github.com/juju/blobstore	git	337aa7d5d712728d181dbda2547a6556d4189626	2015-05-08T07:43:36Z
 github.com/juju/cmd	git	4a5e8abce36462f89d92d28bd69b54c7845db818	2015-08-20T13:46:44Z
-github.com/juju/errors	git	4567a5e69fd3130ca0d89f69478e7ac025b67452	2015-03-27T19:24:31Z
+github.com/juju/errors	git	1b5e39b83d1835fa480e0c2ddefb040ee82d58b3	2015-09-16T12:56:42Z
 github.com/juju/gojsonpointer	git	afe8b77aa08f272b49e01b82de78510c11f61500	2015-02-04T19:46:29Z
 github.com/juju/gojsonreference	git	f0d24ac5ee330baa21721cdff56d45e4ee42628e	2015-02-04T19:46:33Z
 github.com/juju/gojsonschema	git	e1ad140384f254c82f89450d9a7c8dd38a632838	2015-03-12T17:00:16Z


### PR DESCRIPTION
We want to use this to make error handling more consistent in  the HTTP
handlers in apiserver.


(Review request: http://reviews.vapour.ws/r/2675/)