### PR TITLE
apiserver: refactor part 1

### DIFF
--- a/apiserver/authhttp_test.go
+++ b/apiserver/authhttp_test.go
@@ -49,7 +49,7 @@ func (s *authHttpSuite) baseURL(c *gc.C) *url.URL {
 
 func (s *authHttpSuite) assertErrorResponse(c *gc.C, resp *http.Response, expCode int, expError string) {
 	body := assertResponse(c, resp, expCode, apihttp.CTypeJSON)
-	c.Check(jsonResponse(c, body).Error, gc.Matches, expError)
+	c.Check(jsonCharmsResponse(c, body).Error, gc.Matches, expError)
 }
 
 func (s *authHttpSuite) dialWebsocketFromURL(c *gc.C, server string, header http.Header) *websocket.Conn {

--- a/apiserver/backup_test.go
+++ b/apiserver/backup_test.go
@@ -61,7 +61,7 @@ func (s *baseBackupsSuite) checkErrorResponse(c *gc.C, resp *http.Response, stat
 	var failure params.Error
 	err = json.Unmarshal(body, &failure)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Check(&failure, gc.ErrorMatches, msg)
+	c.Check(&failure, gc.ErrorMatches, msg, gc.Commentf("body: %s", body))
 }
 
 type backupsSuite struct {

--- a/apiserver/charms_test.go
+++ b/apiserver/charms_test.go
@@ -493,7 +493,7 @@ func (s *charmsSuite) charmsURI(c *gc.C, query string) string {
 
 func (s *charmsSuite) assertUploadResponse(c *gc.C, resp *http.Response, expCharmURL string) {
 	body := assertResponse(c, resp, http.StatusOK, apihttp.CTypeJSON)
-	charmResponse := jsonResponse(c, body)
+	charmResponse := jsonCharmsResponse(c, body)
 	c.Check(charmResponse.Error, gc.Equals, "")
 	c.Check(charmResponse.CharmURL, gc.Equals, expCharmURL)
 }
@@ -505,7 +505,7 @@ func (s *charmsSuite) assertGetFileResponse(c *gc.C, resp *http.Response, expBod
 
 func (s *charmsSuite) assertGetFileListResponse(c *gc.C, resp *http.Response, expFiles []string) {
 	body := assertResponse(c, resp, http.StatusOK, apihttp.CTypeJSON)
-	charmResponse := jsonResponse(c, body)
+	charmResponse := jsonCharmsResponse(c, body)
 	c.Check(charmResponse.Error, gc.Equals, "")
 	c.Check(charmResponse.Files, gc.DeepEquals, expFiles)
 }
@@ -520,8 +520,8 @@ func assertResponse(c *gc.C, resp *http.Response, expCode int, expContentType st
 	return body
 }
 
-func jsonResponse(c *gc.C, body []byte) (jsonResponse params.CharmsResponse) {
+func jsonCharmsResponse(c *gc.C, body []byte) (jsonResponse params.CharmsResponse) {
 	err := json.Unmarshal(body, &jsonResponse)
-	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(err, jc.ErrorIsNil, gc.Commentf("body: %s", body))
 	return
 }

--- a/apiserver/debuglog.go
+++ b/apiserver/debuglog.go
@@ -40,12 +40,12 @@ type debugLogHandlerFunc func(
 ) error
 
 func newDebugLogHandler(
-	statePool *state.StatePool,
+	ctxt httpContext,
 	stop <-chan struct{},
 	handle debugLogHandlerFunc,
 ) *debugLogHandler {
 	return &debugLogHandler{
-		ctxt:   httpContext{statePool: statePool},
+		ctxt:   ctxt,
 		stop:   stop,
 		handle: handle,
 	}

--- a/apiserver/debuglog_db.go
+++ b/apiserver/debuglog_db.go
@@ -13,8 +13,8 @@ import (
 	"github.com/juju/juju/state"
 )
 
-func newDebugLogDBHandler(statePool *state.StatePool, stop <-chan struct{}) http.Handler {
-	return newDebugLogHandler(statePool, stop, handleDebugLogDBRequest)
+func newDebugLogDBHandler(ctxt httpContext, stop <-chan struct{}) http.Handler {
+	return newDebugLogHandler(ctxt, stop, handleDebugLogDBRequest)
 }
 
 func handleDebugLogDBRequest(

--- a/apiserver/debuglog_file.go
+++ b/apiserver/debuglog_file.go
@@ -19,9 +19,9 @@ import (
 	"github.com/juju/juju/state"
 )
 
-func newDebugLogFileHandler(statePool *state.StatePool, stop <-chan struct{}, logDir string) http.Handler {
+func newDebugLogFileHandler(ctxt httpContext, stop <-chan struct{}, logDir string) http.Handler {
 	fileHandler := &debugLogFileHandler{logDir: logDir}
-	return newDebugLogHandler(statePool, stop, fileHandler.handle)
+	return newDebugLogHandler(ctxt, stop, fileHandler.handle)
 }
 
 // debugLogFileHandler handles requests to watch all-machines.log.


### PR DESCRIPTION
No semantic changes as yet.

We standardise on a single sendError method, losing sendExistingError.
We consolidate the four slightly different versions of sendJSON
into a single implementation in httpContext.
We move some code so that type definitions are closer to their methods.

Unfortunately we cannot standardise on a single implementation of
sendError because there are at least four different and incompatible
ways of returning an error from an HTTP request, but we will
attempt to improve things in the next installment.


(Review request: http://reviews.vapour.ws/r/2678/)