### PR TITLE
(lp:1495681) Filter out nil config settings when adding a service.

### DIFF
--- a/state/service.go
+++ b/state/service.go
@@ -949,13 +949,7 @@ func (s *Service) UpdateConfigSettings(changes charm.Settings) error {
 	if err != nil {
 		return err
 	}
-	for name, value := range changes {
-		if value == nil {
-			node.Delete(name)
-		} else {
-			node.Set(name, value)
-		}
-	}
+	node.apply(changes)
 	_, err = node.Write()
 	return err
 }

--- a/state/service_test.go
+++ b/state/service_test.go
@@ -319,7 +319,7 @@ func (s *ServiceSuite) TestSetCharmConfig(c *gc.C) {
 func (s *ServiceSuite) TestInitSettings(c *gc.C) {
 	ch := s.AddTestingCharm(c, "dummy")
 
-	check := func(settings charm.Settings) (charm.Settings, charm.Settings) {
+	check := func(settings charm.Settings) {
 		svcA, err := s.State.AddService("svc-a", s.Owner.String(), ch, nil, nil, nil)
 		c.Assert(err, jc.ErrorIsNil)
 		if len(settings) > 0 {
@@ -337,23 +337,29 @@ func (s *ServiceSuite) TestInitSettings(c *gc.C) {
 		defer svcB.Destroy()
 
 		c.Check(settingsA, jc.DeepEquals, settingsB)
-		return settingsA, settingsB
+		if settings == nil {
+			c.Check(settingsA, gc.HasLen, 0)
+			c.Check(settingsB, gc.HasLen, 0)
+		} else {
+			c.Check(settingsA, jc.DeepEquals, settings)
+			c.Check(settingsB, jc.DeepEquals, settings)
+		}
 	}
 
-	check(nil)
-	for i, settings := range []charm.Settings{{
-	// "username" default = "admin001"
-	}, {
-		"title": "a service",
-		// "username" default = "admin001"
-	}, {
-		"title":    "a service",
-		"username": "a service",
-	}} {
+	for i, settings := range []charm.Settings{
+		nil,
+		{},
+		{
+			"title": "a service",
+			// "username" default = "admin001"
+		},
+		{
+			"title":    "a service",
+			"username": "a service",
+		},
+	} {
 		c.Logf("- test #%d", i)
-		settingsA, settingsB := check(settings)
-		c.Check(settingsA, jc.DeepEquals, settings)
-		c.Check(settingsB, jc.DeepEquals, settings)
+		check(settings)
 	}
 }
 

--- a/state/service_test.go
+++ b/state/service_test.go
@@ -357,6 +357,10 @@ func (s *ServiceSuite) TestInitSettings(c *gc.C) {
 			"title":    "a service",
 			"username": "a service",
 		},
+		{
+			"title":    "a service",
+			"username": "",
+		},
 	} {
 		c.Logf("- test #%d", i)
 		check(settings)

--- a/state/service_test.go
+++ b/state/service_test.go
@@ -341,8 +341,14 @@ func (s *ServiceSuite) TestInitSettings(c *gc.C) {
 			c.Check(settingsA, gc.HasLen, 0)
 			c.Check(settingsB, gc.HasLen, 0)
 		} else {
-			c.Check(settingsA, jc.DeepEquals, settings)
-			c.Check(settingsB, jc.DeepEquals, settings)
+			expected := make(charm.Settings)
+			for k, v := range settings {
+				if v != nil {
+					expected[k] = v
+				}
+			}
+			c.Check(settingsA, jc.DeepEquals, expected)
+			c.Check(settingsB, jc.DeepEquals, expected)
 		}
 	}
 
@@ -360,6 +366,10 @@ func (s *ServiceSuite) TestInitSettings(c *gc.C) {
 		{
 			"title":    "a service",
 			"username": "",
+		},
+		{
+			"title":    "a service",
+			"username": nil,
 		},
 	} {
 		c.Logf("- test #%d", i)

--- a/state/settings.go
+++ b/state/settings.go
@@ -118,6 +118,18 @@ func (c *Settings) Delete(key string) {
 	delete(c.core, key)
 }
 
+// apply updates the Settings with the provided changes. Any requested
+// setting with a nil value will be removed.
+func (c *Settings) apply(changes map[string]interface{}) {
+	for name, value := range changes {
+		if value == nil {
+			c.Delete(name)
+		} else {
+			c.Set(name, value)
+		}
+	}
+}
+
 // cacheKeys returns the keys of all caches as a key=>true map.
 func cacheKeys(caches ...map[string]interface{}) map[string]bool {
 	keys := make(map[string]bool)


### PR DESCRIPTION
(fixes https://bugs.launchpad.net/juju-core/+bug/1495681)

For backward compatibility reasons, the API converts empty string config setting values into nil values, indicating that the value should not be set.  This case was already handled properly by state.Service.UpdateConfigSettings().

The change in 629fc0507c4b updated state.State.AddService to take the initial settings for the service, replacing a subsequent non-atomic call to Service.UpdateConfigSettings.  However, the corner case with the API was not obvious and State.AddService did not get changed to emulate the full semantics of Service.UpdateConfigSettings.  This resulted in "spooky action at a distance" errors in some situations, e.g. using quickstart to deploy a bundle with a config setting set to the empty string.

This patch fixes that situation by more strictly duplicating the semantics of UpdateConfigSettings in AddService.  A test is also added to ensure that parity.

(Review request: http://reviews.vapour.ws/r/2679/)