### PR TITLE
make it more explicit that we're removing nils during createSettingsOp

### DIFF
--- a/state/service.go
+++ b/state/service.go
@@ -949,7 +949,15 @@ func (s *Service) UpdateConfigSettings(changes charm.Settings) error {
 	if err != nil {
 		return err
 	}
-	node.apply(changes)
+	for name, value := range changes {
+		// a nil value in the case of service settings indicates we should
+		// delete the value (reset to default).
+		if value == nil {
+			node.Delete(name)
+		} else {
+			node.Set(name, value)
+		}
+	}
 	_, err = node.Write()
 	return err
 }

--- a/state/state.go
+++ b/state/state.go
@@ -1059,7 +1059,7 @@ func (st *State) addPeerRelationsOps(serviceName string, peers map[string]charm.
 // supplied name (which must be unique). If the charm defines peer relations,
 // they will be created automatically.
 func (st *State) AddService(
-	name, owner string, ch *Charm, networks []string, storage map[string]StorageConstraints, settingValues charm.Settings,
+	name, owner string, ch *Charm, networks []string, storage map[string]StorageConstraints, settings charm.Settings,
 ) (service *Service, err error) {
 	defer errors.DeferredAnnotatef(&err, "cannot add service %q", name)
 	ownerTag, err := names.ParseUserTag(owner)
@@ -1098,9 +1098,6 @@ func (st *State) AddService(
 	if err := validateStorageConstraints(st, storage, ch.Meta()); err != nil {
 		return nil, errors.Trace(err)
 	}
-
-	settings := newSettings(nil, "")
-	settings.apply(settingValues)
 
 	serviceID := st.docID(name)
 	// Create the service addition operations.
@@ -1141,7 +1138,7 @@ func (st *State) AddService(
 		// and known before setting them.
 		createRequestedNetworksOp(st, svc.globalKey(), networks),
 		createStorageConstraintsOp(svc.globalKey(), storage),
-		createSettingsOp(st, svc.settingsKey(), settings.Map()),
+		createSettingsOp(st, svc.settingsKey(), settings),
 		addLeadershipSettingsOp(svc.Tag().Id()),
 		createStatusOp(st, svc.globalKey(), statusDoc),
 		{

--- a/state/state.go
+++ b/state/state.go
@@ -1129,6 +1129,11 @@ func (st *State) AddService(
 		NeverSet: true,
 	}
 
+	// when creating the settings, we ignore nils.  In other circumstances, nil
+	// means to delete the value (reset to default), so creating with nil should
+	// mean to use the default, i.e. don't set the value.
+	settings = removeNils(settings)
+
 	ops := []txn.Op{
 		env.assertAliveOp(),
 		createConstraintsOp(st, svc.globalKey(), constraints.Value{}),
@@ -1179,6 +1184,18 @@ func (st *State) AddService(
 		return nil, errors.Trace(err)
 	}
 	return svc, nil
+}
+
+// removeNils removes any nil values from the given map and returns an updated
+// map.
+func removeNils(m map[string]interface{}) map[string]interface{} {
+	out := map[string]interface{}{}
+	for k, v := range m {
+		if v != nil {
+			out[k] = v
+		}
+	}
+	return out
 }
 
 // AddIPAddress creates and returns a new IP address. It can return an


### PR DESCRIPTION
This is a much more explicit fix for https://bugs.launchpad.net/juju-core/+bug/1495681

Nil values should not be set during create, since at all other times, a nil value means to delete the value (and use the default).  This change makes createSettingsOp explicitly remove nils itself, rather than relying on callers to do so themselves.  This simplifies the caller's code, and makes for better separation of concerns.  It's also more obvious than running the settings through the state.Settings value just to get a side effect of deleting nil values.

(Review request: http://reviews.vapour.ws/r/2680/)