### PR TITLE
Add explicit versioning to settings documents

### DIFF
--- a/state/allwatcher.go
+++ b/state/allwatcher.go
@@ -776,7 +776,6 @@ func (s *backingSettings) updated(st *State, store *multiwatcherStore, id string
 			break
 		}
 		newInfo := *info
-		cleanSettingsMap(s.Settings)
 		newInfo.Config = s.Settings
 		info0 = &newInfo
 	default:
@@ -798,7 +797,6 @@ func (s *backingSettings) removed(store *multiwatcherStore, envUUID, id string, 
 			return nil
 		}
 		newInfo := *info
-		cleanSettingsMap(s.Settings)
 		newInfo.Config = s.Settings
 		parent = &newInfo
 		store.Update(parent)

--- a/state/allwatcher.go
+++ b/state/allwatcher.go
@@ -754,7 +754,7 @@ func (c *backingConstraints) mongoId() string {
 	panic("cannot find mongo id from constraints document")
 }
 
-type backingSettings map[string]interface{}
+type backingSettings settingsDoc
 
 func (s *backingSettings) updated(st *State, store *multiwatcherStore, id string) error {
 	parentID, url, ok := backingEntityIdForSettingsKey(st.EnvironUUID(), id)
@@ -776,8 +776,8 @@ func (s *backingSettings) updated(st *State, store *multiwatcherStore, id string
 			break
 		}
 		newInfo := *info
-		cleanSettingsMap(*s)
-		newInfo.Config = *s
+		cleanSettingsMap(s.Settings)
+		newInfo.Config = s.Settings
 		info0 = &newInfo
 	default:
 		return nil
@@ -798,8 +798,8 @@ func (s *backingSettings) removed(store *multiwatcherStore, envUUID, id string, 
 			return nil
 		}
 		newInfo := *info
-		cleanSettingsMap(*s)
-		newInfo.Config = *s
+		cleanSettingsMap(s.Settings)
+		newInfo.Config = s.Settings
 		parent = &newInfo
 		store.Update(parent)
 	}

--- a/state/allwatcher.go
+++ b/state/allwatcher.go
@@ -444,11 +444,11 @@ func (svc *backingService) updated(st *State, store *multiwatcherStore, id strin
 		}
 	}
 	if needConfig {
-		var err error
-		info.Config, _, err = readSettingsDoc(st, serviceSettingsKey(svc.Name, svc.CharmURL))
+		doc, err := readSettingsDoc(st, serviceSettingsKey(svc.Name, svc.CharmURL))
 		if err != nil {
 			return errors.Trace(err)
 		}
+		info.Config = doc.Settings
 	}
 	store.Update(info)
 	return nil

--- a/state/annotations.go
+++ b/state/annotations.go
@@ -41,10 +41,10 @@ func (st *State) SetAnnotations(entity GlobalEntity, annotations map[string]stri
 			return fmt.Errorf("invalid key %q", key)
 		}
 		if value == "" {
-			toRemove["annotations."+key] = true
+			toRemove[key] = true
 		} else {
 			toInsert[key] = value
-			toUpdate["annotations."+key] = value
+			toUpdate[key] = value
 		}
 	}
 	// Set up and call the necessary transactions - if the document does not
@@ -143,7 +143,7 @@ func updateAnnotations(st *State, entity GlobalEntity, toUpdate, toRemove bson.M
 		C:      annotationsC,
 		Id:     st.docID(entity.globalKey()),
 		Assert: txn.DocExists,
-		Update: setUnsetUpdate(toUpdate, toRemove),
+		Update: setUnsetUpdate(toUpdate, toRemove, "annotations"),
 	}}
 }
 

--- a/state/annotations.go
+++ b/state/annotations.go
@@ -143,7 +143,7 @@ func updateAnnotations(st *State, entity GlobalEntity, toUpdate, toRemove bson.M
 		C:      annotationsC,
 		Id:     st.docID(entity.globalKey()),
 		Assert: txn.DocExists,
-		Update: setUnsetUpdate(toUpdate, toRemove, "annotations"),
+		Update: setUnsetUpdateAnnotations(toUpdate, toRemove),
 	}}
 }
 
@@ -155,4 +155,22 @@ func annotationRemoveOp(st *State, id string) txn.Op {
 		Id:     st.docID(id),
 		Remove: true,
 	}
+}
+
+// setUnsetUpdateAnnotations returns a bson.D for use
+// in an annotationsC txn.Op's Update field, containing $set and
+// $unset operators if the corresponding operands
+// are non-empty.
+func setUnsetUpdateAnnotations(set, unset bson.M) bson.D {
+	var update bson.D
+	replace := inSubdocReplacer("annotations")
+	if len(set) > 0 {
+		set = bson.M(copyMap(map[string]interface{}(set), replace))
+		update = append(update, bson.DocElem{"$set", set})
+	}
+	if len(unset) > 0 {
+		unset = bson.M(copyMap(map[string]interface{}(unset), replace))
+		update = append(update, bson.DocElem{"$unset", unset})
+	}
+	return update
 }

--- a/state/leadership.go
+++ b/state/leadership.go
@@ -5,33 +5,21 @@ import (
 
 	"github.com/juju/errors"
 	jujutxn "github.com/juju/txn"
-	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
 
 	"github.com/juju/juju/leadership"
 )
 
-const settingsKey = "s#%s#leader"
-
 func addLeadershipSettingsOp(serviceId string) txn.Op {
-	return txn.Op{
-		C:      settingsC,
-		Id:     leadershipSettingsDocId(serviceId),
-		Insert: bson.D{},
-		Assert: txn.DocMissing,
-	}
+	return createSettingsOp(leadershipSettingsKey(serviceId), nil)
 }
 
 func removeLeadershipSettingsOp(serviceId string) txn.Op {
-	return txn.Op{
-		C:      settingsC,
-		Id:     leadershipSettingsDocId(serviceId),
-		Remove: true,
-	}
+	return removeSettingsOp(leadershipSettingsKey(serviceId))
 }
 
-func leadershipSettingsDocId(serviceId string) string {
-	return fmt.Sprintf(settingsKey, serviceId)
+func leadershipSettingsKey(serviceId string) string {
+	return fmt.Sprintf("s#%s#leader", serviceId)
 }
 
 // LeadershipClaimer returns a leadership.Claimer for units and services in the

--- a/state/open.go
+++ b/state/open.go
@@ -189,7 +189,7 @@ func (st *State) envSetupOps(cfg *config.Config, envUUID, serverUUID string, own
 	envUserOp := createEnvUserOp(envUUID, owner, owner, owner.Name())
 	ops := []txn.Op{
 		createConstraintsOp(st, environGlobalKey, constraints.Value{}),
-		createSettingsOp(st, environGlobalKey, cfg.AllAttrs()),
+		createSettingsOp(environGlobalKey, cfg.AllAttrs()),
 		incHostedEnvironCountOp(),
 		createEnvironmentOp(st, owner, cfg.Name(), envUUID, serverUUID),
 		createUniqueOwnerEnvNameOp(owner, cfg.Name()),

--- a/state/relationunit.go
+++ b/state/relationunit.go
@@ -113,7 +113,7 @@ func (ru *RelationUnit) EnterScope(settings map[string]interface{}) error {
 	if count, err := settingsColl.FindId(ruKey).Count(); err != nil {
 		return err
 	} else if count == 0 {
-		ops = append(ops, createSettingsOp(ru.st, ruKey, settings))
+		ops = append(ops, createSettingsOp(ruKey, settings))
 	} else {
 		var rop txn.Op
 		rop, settingsChanged, err = replaceSettingsOp(ru.st, ruKey, settings)

--- a/state/service.go
+++ b/state/service.go
@@ -1038,8 +1038,8 @@ func (s *Service) UpdateLeaderSettings(token leadership.Token, updates map[strin
 
 	buildTxn := func(_ int) ([]txn.Op, error) {
 		// Read the current document state so we can abort if there's
-		// no actual change; and the txn-revno so we can assert on it
-		// and prevent these settings from landing late.
+		// no actual change; and the version number so we can assert
+		// on it and prevent these settings from landing late.
 		doc, err := readSettingsDoc(s.st, key)
 		if cause := errors.Cause(err); cause == mgo.ErrNotFound {
 			return nil, errors.NotFoundf("service")

--- a/state/service.go
+++ b/state/service.go
@@ -979,7 +979,7 @@ func (s *Service) LeaderSettings() (map[string]string, error) {
 	// type getting even more cluttered.
 
 	doc, err := readSettingsDoc(s.st, leadershipSettingsKey(s.doc.Name))
-	if cause := errors.Cause(err); cause == mgo.ErrNotFound {
+	if errors.IsNotFound(err) {
 		return nil, errors.NotFoundf("service")
 	} else if err != nil {
 		return nil, errors.Trace(err)
@@ -1041,7 +1041,7 @@ func (s *Service) UpdateLeaderSettings(token leadership.Token, updates map[strin
 		// no actual change; and the version number so we can assert
 		// on it and prevent these settings from landing late.
 		doc, err := readSettingsDoc(s.st, key)
-		if cause := errors.Cause(err); cause == mgo.ErrNotFound {
+		if errors.IsNotFound(err) {
 			return nil, errors.NotFoundf("service")
 		} else if err != nil {
 			return nil, errors.Trace(err)

--- a/state/settings.go
+++ b/state/settings.go
@@ -32,17 +32,20 @@ const (
 	ItemDeleted
 )
 
+// settingsDoc is the mongo document representation for
+// a settings.
 type settingsDoc struct {
 	DocID    string `bson:"_id"`
 	EnvUUID  string `bson:"env-uuid"`
 	TxnRevno int64  `bson:"txn-revno"`
 
+	// Settings contains the settings. This must not be
+	// omitempty, or migration cannot work correctly.
+	Settings map[string]interface{} `bson:"settings"`
+
 	// Version is a version number for the settings,
 	// and is increased every time the settings change.
 	Version int64 `bson:"version"`
-
-	// Settings contains the settings.
-	Settings map[string]interface{}
 }
 
 // ItemChange represents the change of an item in a settings.

--- a/state/settings_test.go
+++ b/state/settings_test.go
@@ -71,14 +71,13 @@ func (s *SettingsSuite) TestUpdateWithWrite(c *gc.C) {
 
 	// Check MongoDB state.
 	var mgoData struct {
-		Settings map[string]interface{}
+		Settings settingsMap
 	}
 	settings, closer := s.state.getCollection(settingsC)
 	defer closer()
 	err = settings.FindId(s.key).One(&mgoData)
 	c.Assert(err, jc.ErrorIsNil)
-	cleanSettingsMap(mgoData.Settings)
-	c.Assert(mgoData.Settings, gc.DeepEquals, options)
+	c.Assert(map[string]interface{}(mgoData.Settings), gc.DeepEquals, options)
 }
 
 func (s *SettingsSuite) TestConflictOnSet(c *gc.C) {
@@ -157,14 +156,13 @@ func (s *SettingsSuite) TestSetItem(c *gc.C) {
 	c.Assert(node.Map(), gc.DeepEquals, options)
 	// Check MongoDB state.
 	var mgoData struct {
-		Settings map[string]interface{}
+		Settings settingsMap
 	}
 	settings, closer := s.state.getCollection(settingsC)
 	defer closer()
 	err = settings.FindId(s.key).One(&mgoData)
 	c.Assert(err, jc.ErrorIsNil)
-	cleanSettingsMap(mgoData.Settings)
-	c.Assert(mgoData.Settings, gc.DeepEquals, options)
+	c.Assert(map[string]interface{}(mgoData.Settings), gc.DeepEquals, options)
 }
 
 func (s *SettingsSuite) TestSetItemEscape(c *gc.C) {

--- a/state/settings_test.go
+++ b/state/settings_test.go
@@ -70,13 +70,15 @@ func (s *SettingsSuite) TestUpdateWithWrite(c *gc.C) {
 	c.Assert(node.Map(), gc.DeepEquals, options)
 
 	// Check MongoDB state.
-	mgoData := make(map[string]interface{}, 0)
+	var mgoData struct {
+		Settings map[string]interface{}
+	}
 	settings, closer := s.state.getCollection(settingsC)
 	defer closer()
 	err = settings.FindId(s.key).One(&mgoData)
 	c.Assert(err, jc.ErrorIsNil)
-	cleanSettingsMap(mgoData)
-	c.Assert(mgoData, gc.DeepEquals, options)
+	cleanSettingsMap(mgoData.Settings)
+	c.Assert(mgoData.Settings, gc.DeepEquals, options)
 }
 
 func (s *SettingsSuite) TestConflictOnSet(c *gc.C) {
@@ -154,13 +156,15 @@ func (s *SettingsSuite) TestSetItem(c *gc.C) {
 	// Check local state.
 	c.Assert(node.Map(), gc.DeepEquals, options)
 	// Check MongoDB state.
-	mgoData := make(map[string]interface{}, 0)
+	var mgoData struct {
+		Settings map[string]interface{}
+	}
 	settings, closer := s.state.getCollection(settingsC)
 	defer closer()
 	err = settings.FindId(s.key).One(&mgoData)
 	c.Assert(err, jc.ErrorIsNil)
-	cleanSettingsMap(mgoData)
-	c.Assert(mgoData, gc.DeepEquals, options)
+	cleanSettingsMap(mgoData.Settings)
+	c.Assert(mgoData.Settings, gc.DeepEquals, options)
 }
 
 func (s *SettingsSuite) TestSetItemEscape(c *gc.C) {
@@ -181,13 +185,15 @@ func (s *SettingsSuite) TestSetItemEscape(c *gc.C) {
 
 	// Check MongoDB state.
 	mgoOptions := map[string]interface{}{"\uff04bar": 1, "foo\uff0ealpha": "beta"}
-	mgoData := make(map[string]interface{}, 0)
+	var mgoData struct {
+		Settings map[string]interface{}
+	}
 	settings, closer := s.state.getCollection(settingsC)
 	defer closer()
 	err = settings.FindId(s.key).One(&mgoData)
 	c.Assert(err, jc.ErrorIsNil)
-	cleanMgoSettings(mgoData)
-	c.Assert(mgoData, gc.DeepEquals, mgoOptions)
+	cleanMgoSettings(mgoData.Settings)
+	c.Assert(mgoData.Settings, gc.DeepEquals, mgoOptions)
 
 	// Now get another state by reading from the database instance and
 	// check read state has replaced '.' and '$' after fetching from
@@ -220,13 +226,15 @@ func (s *SettingsSuite) TestReplaceSettingsEscape(c *gc.C) {
 
 	// Check MongoDB state.
 	mgoOptions := map[string]interface{}{"\uff04baz": 1, "foo\uff0ebar": "beta"}
-	mgoData := make(map[string]interface{}, 0)
+	var mgoData struct {
+		Settings map[string]interface{}
+	}
 	settings, closer := s.state.getCollection(settingsC)
 	defer closer()
 	err = settings.FindId(s.key).One(&mgoData)
 	c.Assert(err, jc.ErrorIsNil)
-	cleanMgoSettings(mgoData)
-	c.Assert(mgoData, gc.DeepEquals, mgoOptions)
+	cleanMgoSettings(mgoData.Settings)
+	c.Assert(mgoData.Settings, gc.DeepEquals, mgoOptions)
 }
 
 func (s *SettingsSuite) TestcreateSettingsEscape(c *gc.C) {
@@ -240,13 +248,16 @@ func (s *SettingsSuite) TestcreateSettingsEscape(c *gc.C) {
 
 	// Check MongoDB state.
 	mgoOptions := map[string]interface{}{"\uff04baz": 1, "foo\uff0ebar": "beta"}
-	mgoData := make(map[string]interface{}, 0)
+	var mgoData struct {
+		Settings map[string]interface{}
+	}
 	settings, closer := s.state.getCollection(settingsC)
 	defer closer()
+
 	err = settings.FindId(s.key).One(&mgoData)
 	c.Assert(err, jc.ErrorIsNil)
-	cleanMgoSettings(mgoData)
-	c.Assert(mgoData, gc.DeepEquals, mgoOptions)
+	cleanMgoSettings(mgoData.Settings)
+	c.Assert(mgoData.Settings, gc.DeepEquals, mgoOptions)
 }
 
 func (s *SettingsSuite) TestMultipleReads(c *gc.C) {
@@ -397,12 +408,14 @@ func (s *SettingsSuite) TestMultipleWritesAreStable(c *gc.C) {
 	_, err = node.Write()
 	c.Assert(err, jc.ErrorIsNil)
 
-	mgoData := make(map[string]interface{})
+	var mgoData struct {
+		Settings map[string]interface{}
+	}
 	settings, closer := s.state.getCollection(settingsC)
 	defer closer()
 	err = settings.FindId(s.key).One(&mgoData)
 	c.Assert(err, jc.ErrorIsNil)
-	version := mgoData["version"]
+	version := mgoData.Settings["version"]
 	for i := 0; i < 100; i++ {
 		node.Set("value", i)
 		node.Set("foo", "bar")
@@ -411,10 +424,10 @@ func (s *SettingsSuite) TestMultipleWritesAreStable(c *gc.C) {
 		_, err := node.Write()
 		c.Assert(err, jc.ErrorIsNil)
 	}
-	mgoData = make(map[string]interface{})
+	mgoData.Settings = make(map[string]interface{})
 	err = settings.FindId(s.key).One(&mgoData)
 	c.Assert(err, jc.ErrorIsNil)
-	newVersion := mgoData["version"]
+	newVersion := mgoData.Settings["version"]
 	c.Assert(version, gc.Equals, newVersion)
 }
 

--- a/state/settings_test.go
+++ b/state/settings_test.go
@@ -192,7 +192,6 @@ func (s *SettingsSuite) TestSetItemEscape(c *gc.C) {
 	defer closer()
 	err = settings.FindId(s.key).One(&mgoData)
 	c.Assert(err, jc.ErrorIsNil)
-	cleanMgoSettings(mgoData.Settings)
 	c.Assert(mgoData.Settings, gc.DeepEquals, mgoOptions)
 
 	// Now get another state by reading from the database instance and
@@ -233,7 +232,6 @@ func (s *SettingsSuite) TestReplaceSettingsEscape(c *gc.C) {
 	defer closer()
 	err = settings.FindId(s.key).One(&mgoData)
 	c.Assert(err, jc.ErrorIsNil)
-	cleanMgoSettings(mgoData.Settings)
 	c.Assert(mgoData.Settings, gc.DeepEquals, mgoOptions)
 }
 
@@ -256,7 +254,6 @@ func (s *SettingsSuite) TestcreateSettingsEscape(c *gc.C) {
 
 	err = settings.FindId(s.key).One(&mgoData)
 	c.Assert(err, jc.ErrorIsNil)
-	cleanMgoSettings(mgoData.Settings)
 	c.Assert(mgoData.Settings, gc.DeepEquals, mgoOptions)
 }
 
@@ -478,13 +475,4 @@ func (s *SettingsSuite) TestList(c *gc.C) {
 		"key#1": {"foo1": "bar1"},
 		"key#2": {"foo2": "bar2"},
 	})
-}
-
-// cleanMgoSettings will remove MongoDB-specific settings but not unescape any
-// keys, as opposed to cleanSettingsMap which does unescape keys.
-func cleanMgoSettings(in map[string]interface{}) {
-	delete(in, "_id")
-	delete(in, "env-uuid")
-	delete(in, "txn-revno")
-	delete(in, "txn-queue")
 }

--- a/state/state.go
+++ b/state/state.go
@@ -468,7 +468,7 @@ func (st *State) SetEnvironAgentVersion(newVersion version.Number) (err error) {
 			}, {
 				C:      settingsC,
 				Id:     st.docID(environGlobalKey),
-				Assert: bson.D{{"txn-revno", settings.txnRevno}},
+				Assert: bson.D{{"version", settings.version}},
 				Update: bson.D{
 					{"$set", bson.D{{"settings.agent-version", newVersion.String()}}},
 				},

--- a/state/state.go
+++ b/state/state.go
@@ -470,7 +470,7 @@ func (st *State) SetEnvironAgentVersion(newVersion version.Number) (err error) {
 				Id:     st.docID(environGlobalKey),
 				Assert: bson.D{{"txn-revno", settings.txnRevno}},
 				Update: bson.D{
-					{"$set", bson.D{{"agent-version", newVersion.String()}}},
+					{"$set", bson.D{{"settings.agent-version", newVersion.String()}}},
 				},
 			},
 		}
@@ -1171,7 +1171,7 @@ func (st *State) AddService(
 		// and known before setting them.
 		createRequestedNetworksOp(st, svc.globalKey(), networks),
 		createStorageConstraintsOp(svc.globalKey(), storage),
-		createSettingsOp(st, svc.settingsKey(), nil),
+		createSettingsOp(svc.settingsKey(), nil),
 		addLeadershipSettingsOp(svc.Tag().Id()),
 		createStatusOp(st, svc.globalKey(), statusDoc),
 		{

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -2907,7 +2907,7 @@ func (s *StateSuite) TestWatchEnvironConfigCorruptConfig(c *gc.C) {
 
 	// Corrupt the environment configuration.
 	settings := s.Session.DB("juju").C("settings")
-	err = settings.UpdateId(state.DocID(s.State, "e"), bson.D{{"$unset", bson.D{{"name", 1}}}})
+	err = settings.UpdateId(state.DocID(s.State, "e"), bson.D{{"$unset", bson.D{{"settings.name", 1}}}})
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.State.StartSync()
@@ -2939,7 +2939,7 @@ func (s *StateSuite) TestWatchEnvironConfigCorruptConfig(c *gc.C) {
 	}
 
 	// Fix the configuration.
-	err = settings.UpdateId(state.DocID(s.State, "e"), bson.D{{"$set", bson.D{{"name", "foo"}}}})
+	err = settings.UpdateId(state.DocID(s.State, "e"), bson.D{{"$set", bson.D{{"settings.name", "foo"}}}})
 	c.Assert(err, jc.ErrorIsNil)
 	fixed := cfg.AllAttrs()
 	err = s.State.UpdateEnvironConfig(fixed, nil, nil)

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -2199,3 +2199,98 @@ func upgradingFilesystemStatus(st *State, filesystem Filesystem) (Status, error)
 	}
 	return StatusAttached, nil
 }
+
+// MigrateSettingsSchema migrates the schema of the settings collection,
+// moving non-reserved keys at the top-level into a subdoc, and introducing
+// a top-level "version" field with the initial value matching txn-revno.
+//
+// This migration takes place both before and after env-uuid migration,
+// to get the correct txn-revno value.
+func MigrateSettingsSchema(st *State) error {
+	coll, closer := st.getRawCollection(settingsC)
+	defer closer()
+
+	upgradesLogger.Debugf("migrating schema of the %s collection", settingsC)
+	iter := coll.Find(nil).Iter()
+	defer iter.Close()
+
+	var ops []txn.Op
+	var doc bson.M
+	for iter.Next(&doc) {
+		if !settingsDocNeedsMigration(doc) {
+			continue
+		}
+
+		id := doc["_id"]
+		txnRevno := doc["txn-revno"].(int64)
+
+		// Remove reserved attributes; we'll move the remaining
+		// ones to the "settings" subdoc.
+		delete(doc, "env-uuid")
+		delete(doc, "_id")
+		delete(doc, "txn-revno")
+		delete(doc, "txn-queue")
+
+		// If there exists a setting by the name "settings",
+		// we must remove it first, or it will collide with
+		// the dotted-notation $sets.
+		if _, ok := doc["settings"]; ok {
+			ops = append(ops, txn.Op{
+				C:      settingsC,
+				Id:     id,
+				Assert: txn.DocExists,
+				Update: bson.D{{"$unset", bson.D{{"settings", 1}}}},
+			})
+		}
+
+		var update bson.D
+		for key, value := range doc {
+			if key != "settings" && key != "version" {
+				// Don't try to unset these fields,
+				// as we've unset "settings" above
+				// already, and we'll overwrite
+				// "version" below.
+				update = append(update, bson.DocElem{
+					"$unset", bson.D{{key, 1}},
+				})
+			}
+			update = append(update, bson.DocElem{
+				"$set", bson.D{{"settings." + key, value}},
+			})
+		}
+		if len(update) == 0 {
+			// If there are no settings, then we need
+			// to add an empty "settings" map so we
+			// can tell for next time that migration
+			// is complete, and don't move the "version"
+			// field we add.
+			update = bson.D{{
+				"$set", bson.D{{"settings", bson.M{}}},
+			}}
+		}
+		update = append(update, bson.DocElem{
+			"$set", bson.D{{"version", txnRevno}},
+		})
+
+		ops = append(ops, txn.Op{
+			C:      settingsC,
+			Id:     id,
+			Assert: txn.DocExists,
+			Update: update,
+		})
+	}
+	if err := iter.Err(); err != nil {
+		return errors.Trace(err)
+	}
+	return st.runRawTransaction(ops)
+}
+
+func settingsDocNeedsMigration(doc bson.M) bool {
+	// It is not possible for there to exist a settings value
+	// with type bson.M, so we know that it is the new settings
+	// field and not just a setting with the name "settings".
+	if _, ok := doc["settings"].(bson.M); ok {
+		return false
+	}
+	return true
+}

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -2850,7 +2850,7 @@ func (s *upgradesSuite) prepareEnvsForLeadership(c *gc.C, envs map[string][]stri
 			"name":     name,
 		})
 		c.Assert(err, jc.ErrorIsNil)
-		expectedDocIDs = append(expectedDocIDs, envUUID+":"+leadershipSettingsDocId(name))
+		expectedDocIDs = append(expectedDocIDs, envUUID+":"+leadershipSettingsKey(name))
 	}
 
 	// Use the helpers to set up the environments.

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -4217,7 +4217,7 @@ func (s *upgradesSuite) TestMigrateSettingsSchema(c *gc.C) {
 			{"env-uuid", "env-uuid"},
 			{"txn-revno", int64(99)},
 			{"txn-queue", []string{}},
-			{"setting", int64(123)},
+			{"settings", int64(123)},
 			{"version", "onetwothree"},
 		},
 		bson.D{
@@ -4231,7 +4231,7 @@ func (s *upgradesSuite) TestMigrateSettingsSchema(c *gc.C) {
 			{"_id", "4"},
 			{"txn-revno", int64(99)},
 			{"txn-queue", []string{}},
-			{"setting", int64(123)},
+			{"settings", int64(123)},
 			{"version", "onetwothree"},
 		},
 		bson.D{
@@ -4251,7 +4251,7 @@ func (s *upgradesSuite) TestMigrateSettingsSchema(c *gc.C) {
 			{"txn-queue", []string{}},
 			{"version", int64(98)},
 			{"settings", bson.D{
-				{"setting", int64(123)},
+				{"settings", int64(123)},
 				{"version", "onetwothree"},
 			}},
 		},
@@ -4268,10 +4268,10 @@ func (s *upgradesSuite) TestMigrateSettingsSchema(c *gc.C) {
 	}, {
 		"_id":       "2",
 		"env-uuid":  "env-uuid",
-		"txn-revno": int64(100),
+		"txn-revno": int64(101),
 		"settings": bson.M{
-			"setting": int64(123),
-			"version": "onetwothree",
+			"settings": int64(123),
+			"version":  "onetwothree",
 		},
 		"version": int64(99),
 	}, {
@@ -4281,10 +4281,10 @@ func (s *upgradesSuite) TestMigrateSettingsSchema(c *gc.C) {
 		"version":   int64(99),
 	}, {
 		"_id":       "4",
-		"txn-revno": int64(100),
+		"txn-revno": int64(101),
 		"settings": bson.M{
-			"setting": int64(123),
-			"version": "onetwothree",
+			"settings": int64(123),
+			"version":  "onetwothree",
 		},
 		"version": int64(99),
 	}, {
@@ -4299,8 +4299,8 @@ func (s *upgradesSuite) TestMigrateSettingsSchema(c *gc.C) {
 		"txn-revno": int64(99),
 		"version":   int64(98),
 		"settings": bson.M{
-			"setting": int64(123),
-			"version": "onetwothree",
+			"settings": int64(123),
+			"version":  "onetwothree",
 		},
 	}}
 

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -4196,3 +4196,124 @@ func (s *upgradesSuite) TestChangeEntityIdToGlobalKey(c *gc.C) {
 		c.Assert(globalKey, gc.Equals, fmt.Sprintf("global%d", i))
 	}
 }
+
+func (s *upgradesSuite) TestMigrateSettingsSchema(c *gc.C) {
+	// Insert test documents.
+	settingsColl, closer := s.state.getRawCollection(settingsC)
+	defer closer()
+	err := settingsColl.Insert(
+		bson.D{
+			// Post-env-uuid migration, with no settings.
+			{"_id", "1"},
+			{"env-uuid", "env-uuid"},
+			{"txn-revno", int64(99)},
+			{"txn-queue", []string{}},
+		},
+		bson.D{
+			// Post-env-uuid migration, with settings. One
+			// of the settings is called "settings", and
+			// one "version".
+			{"_id", "2"},
+			{"env-uuid", "env-uuid"},
+			{"txn-revno", int64(99)},
+			{"txn-queue", []string{}},
+			{"setting", int64(123)},
+			{"version", "onetwothree"},
+		},
+		bson.D{
+			// Pre-env-uuid migration, with no settings.
+			{"_id", "3"},
+			{"txn-revno", int64(99)},
+			{"txn-queue", []string{}},
+		},
+		bson.D{
+			// Pre-env-uuid migration, with settings.
+			{"_id", "4"},
+			{"txn-revno", int64(99)},
+			{"txn-queue", []string{}},
+			{"setting", int64(123)},
+			{"version", "onetwothree"},
+		},
+		bson.D{
+			// Already migrated, with no settings.
+			{"_id", "5"},
+			{"env-uuid", "env-uuid"},
+			{"txn-revno", int64(99)},
+			{"txn-queue", []string{}},
+			{"version", int64(98)},
+			{"settings", map[string]interface{}{}},
+		},
+		bson.D{
+			// Already migrated, with settings.
+			{"_id", "6"},
+			{"env-uuid", "env-uuid"},
+			{"txn-revno", int64(99)},
+			{"txn-queue", []string{}},
+			{"version", int64(98)},
+			{"settings", bson.D{
+				{"setting", int64(123)},
+				{"version", "onetwothree"},
+			}},
+		},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Expected docs, excluding txn-queu which we cannot predict.
+	expected := []bson.M{{
+		"_id":       "1",
+		"env-uuid":  "env-uuid",
+		"txn-revno": int64(100),
+		"settings":  bson.M{},
+		"version":   int64(99),
+	}, {
+		"_id":       "2",
+		"env-uuid":  "env-uuid",
+		"txn-revno": int64(100),
+		"settings": bson.M{
+			"setting": int64(123),
+			"version": "onetwothree",
+		},
+		"version": int64(99),
+	}, {
+		"_id":       "3",
+		"txn-revno": int64(100),
+		"settings":  bson.M{},
+		"version":   int64(99),
+	}, {
+		"_id":       "4",
+		"txn-revno": int64(100),
+		"settings": bson.M{
+			"setting": int64(123),
+			"version": "onetwothree",
+		},
+		"version": int64(99),
+	}, {
+		"_id":       "5",
+		"env-uuid":  "env-uuid",
+		"txn-revno": int64(99),
+		"version":   int64(98),
+		"settings":  bson.M{},
+	}, {
+		"_id":       "6",
+		"env-uuid":  "env-uuid",
+		"txn-revno": int64(99),
+		"version":   int64(98),
+		"settings": bson.M{
+			"setting": int64(123),
+			"version": "onetwothree",
+		},
+	}}
+
+	// Two rounds to check idempotency.
+	for i := 0; i < 2; i++ {
+		err = MigrateSettingsSchema(s.state)
+		c.Assert(err, jc.ErrorIsNil)
+
+		var docs []bson.M
+		err = settingsColl.Find(
+			bson.D{{"env-uuid", bson.D{{"$ne", s.state.EnvironUUID()}}}},
+		).Sort("_id").Select(bson.M{"txn-queue": 0}).All(&docs)
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(docs, jc.DeepEquals, expected)
+	}
+}

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -1379,7 +1379,7 @@ func (s *Service) Watch() NotifyWatcher {
 // WatchLeaderSettings returns a watcher for observing changed to a service's
 // leader settings.
 func (s *Service) WatchLeaderSettings() NotifyWatcher {
-	docId := s.st.docID(leadershipSettingsDocId(s.Name()))
+	docId := s.st.docID(leadershipSettingsKey(s.Name()))
 	return newEntityWatcher(s.st, settingsC, docId)
 }
 

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -1002,16 +1002,10 @@ func (w *relationUnitsWatcher) loop() (err error) {
 			if !ok {
 				logger.Warningf("ignoring bad relation scope id: %#v", c.Id)
 			}
-			revno, err := w.mergeSettings(&changes, id)
-			if err != nil {
+			if _, err := w.mergeSettings(&changes, id); err != nil {
 				return err
 			}
-			if true || revno == c.Revno {
-				// Only send if we read the revno we were notified
-				// about. If we read a newer revno, wait until the
-				// next notification before sending.
-				out = w.out
-			}
+			out = w.out
 		case out <- changes:
 			sentInitial = true
 			changes = multiwatcher.RelationUnitsChange{}

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -1003,7 +1003,7 @@ func (w *relationUnitsWatcher) loop() (err error) {
 			if err != nil {
 				return err
 			}
-			if revno == c.Revno {
+			if true || revno == c.Revno {
 				// Only send if we read the revno we were notified
 				// about. If we read a newer revno, wait until the
 				// next notification before sending.

--- a/upgrades/steps118.go
+++ b/upgrades/steps118.go
@@ -3,9 +3,18 @@
 
 package upgrades
 
+import "github.com/juju/juju/state"
+
 // stateStepsFor118 returns upgrade steps form Juju 1.18 that manipulate state directly.
 func stateStepsFor118() []Step {
 	return []Step{
+		&upgradeStep{
+			description: "add the version field to all settings docs",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return state.MigrateSettingsSchema(context.State())
+			},
+		},
 		&upgradeStep{
 			description: "update rsyslog port",
 			targets:     []Target{StateServer},

--- a/upgrades/steps118_test.go
+++ b/upgrades/steps118_test.go
@@ -18,6 +18,7 @@ var _ = gc.Suite(&steps118Suite{})
 
 func (s *steps118Suite) TestStateStepsFor118(c *gc.C) {
 	expected := []string{
+		"add the version field to all settings docs",
 		"update rsyslog port",
 		"remove deprecated environment config settings",
 		"migrate local provider agent config",

--- a/upgrades/steps121.go
+++ b/upgrades/steps121.go
@@ -11,6 +11,14 @@ import (
 func stateStepsFor121() []Step {
 	return []Step{
 		&upgradeStep{
+			description: "add the version field to all settings docs",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return state.MigrateSettingsSchema(context.State())
+			},
+		},
+
+		&upgradeStep{
 			description: "add environment uuid to state server doc",
 			targets:     []Target{DatabaseMaster},
 			run: func(context Context) error {

--- a/upgrades/steps121_test.go
+++ b/upgrades/steps121_test.go
@@ -18,8 +18,9 @@ var _ = gc.Suite(&steps121Suite{})
 
 func (s *steps121Suite) TestStateStepsFor121(c *gc.C) {
 	expected := []string{
-		// Environment UUID related migrations should come first as
-		// other upgrade steps may rely on them.
+		// Settings, and then environment UUID, related migrations should
+		// come first as other upgrade steps may rely on them.
+		"add the version field to all settings docs",
 		"add environment uuid to state server doc",
 		"set environment owner and server uuid",
 		// It is important to keep the order of the following three steps:

--- a/upgrades/steps122.go
+++ b/upgrades/steps122.go
@@ -11,6 +11,13 @@ import (
 func stateStepsFor122() []Step {
 	return []Step{
 		&upgradeStep{
+			description: "add the version field to all settings docs",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return state.MigrateSettingsSchema(context.State())
+			},
+		},
+		&upgradeStep{
 			description: "prepend the environment UUID to the ID of all charm docs",
 			targets:     []Target{DatabaseMaster},
 			run: func(context Context) error {

--- a/upgrades/steps122_test.go
+++ b/upgrades/steps122_test.go
@@ -18,8 +18,9 @@ var _ = gc.Suite(&steps122Suite{})
 
 func (s *steps122Suite) TestStateStepsFor122(c *gc.C) {
 	expected := []string{
-		// Environment UUID related migrations should come first as
-		// other upgrade steps may rely on them.
+		// Settings, and then environment UUID related, migrations
+		// should come first as other upgrade steps may rely on them.
+		"add the version field to all settings docs",
 		"prepend the environment UUID to the ID of all charm docs",
 		"prepend the environment UUID to the ID of all settings docs",
 		"prepend the environment UUID to the ID of all settingsRefs docs",

--- a/upgrades/steps123.go
+++ b/upgrades/steps123.go
@@ -14,6 +14,13 @@ import (
 func stateStepsFor123() []Step {
 	return []Step{
 		&upgradeStep{
+			description: "add the version field to all settings docs",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return state.MigrateSettingsSchema(context.State())
+			},
+		},
+		&upgradeStep{
 			description: "add default storage pools",
 			targets:     []Target{DatabaseMaster},
 			run: func(context Context) error {

--- a/upgrades/steps123_test.go
+++ b/upgrades/steps123_test.go
@@ -18,6 +18,7 @@ var _ = gc.Suite(&steps123Suite{})
 
 func (s *steps123Suite) TestStateStepsFor123(c *gc.C) {
 	expected := []string{
+		"add the version field to all settings docs",
 		"add default storage pools",
 		"drop old mongo indexes",
 		"migrate envuuid to env-uuid in envUsersC",

--- a/upgrades/steps124.go
+++ b/upgrades/steps124.go
@@ -17,6 +17,13 @@ import (
 func stateStepsFor124() []Step {
 	return []Step{
 		&upgradeStep{
+			description: "add the version field to all settings docs",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return state.MigrateSettingsSchema(context.State())
+			},
+		},
+		&upgradeStep{
 			description: "add block device documents for existing machines",
 			targets:     []Target{DatabaseMaster},
 			run: func(context Context) error {

--- a/upgrades/steps124_test.go
+++ b/upgrades/steps124_test.go
@@ -25,6 +25,7 @@ var _ = gc.Suite(&steps124Suite{})
 
 func (s *steps124Suite) TestStateStepsFor124(c *gc.C) {
 	expected := []string{
+		"add the version field to all settings docs",
 		"add block device documents for existing machines",
 		"move service.UnitSeq to sequence collection",
 		"add instance id field to IP addresses",

--- a/upgrades/steps125.go
+++ b/upgrades/steps125.go
@@ -19,6 +19,13 @@ import (
 func stateStepsFor125() []Step {
 	return []Step{
 		&upgradeStep{
+			description: "add the version field to all settings docs",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return state.MigrateSettingsSchema(context.State())
+			},
+		},
+		&upgradeStep{
 			description: "set hosted environment count to number of hosted environments",
 			targets:     []Target{DatabaseMaster},
 			run: func(context Context) error {

--- a/upgrades/steps125_test.go
+++ b/upgrades/steps125_test.go
@@ -27,6 +27,7 @@ var _ = gc.Suite(&steps125Suite{})
 
 func (s *steps125Suite) TestStateStepsFor125(c *gc.C) {
 	expected := []string{
+		"add the version field to all settings docs",
 		"set hosted environment count to number of hosted environments",
 		"tag machine instances",
 		"add missing env-uuid to statuses",

--- a/upgrades/steps126.go
+++ b/upgrades/steps126.go
@@ -33,6 +33,13 @@ func stepsFor126() []Step {
 func stateStepsFor126() []Step {
 	return []Step{
 		&upgradeStep{
+			description: "add the version field to all settings docs",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return state.MigrateSettingsSchema(context.State())
+			},
+		},
+		&upgradeStep{
 			description: "add status to filesystem",
 			targets:     []Target{DatabaseMaster},
 			run: func(context Context) error {

--- a/upgrades/steps126_test.go
+++ b/upgrades/steps126_test.go
@@ -25,6 +25,7 @@ func (s *steps126Suite) TestStepsFor126(c *gc.C) {
 
 func (s *steps126Suite) TestStateStepsFor126(c *gc.C) {
 	expected := []string{
+		"add the version field to all settings docs",
 		"add status to filesystem",
 	}
 	assertStateSteps(c, version.MustParse("1.26.0"), expected)


### PR DESCRIPTION
Up until now we have been leaking txn-revno from state through the relation-units watcher, exposed as the relation-unit settings version. Due to recent changes in the uniter, it was uncovered that there was a bug introduced some time ago relating to this: when env-uuid migration occurs, settings documents are removed and re-added, resetting the txn-revno. Due to a change in how we compared the version (!= to >, under the assumption that the version was only increasing), this bug manifests with much greater probability than before.

The fix is to add an explicit version field to settings documents. This involves moving all setting into a sub-document, and reserving the top-level fields for meta-information such as the version. The schema is changed thus, and an upgrade method is introduced. Because many upgrade steps rely on settings (namely environment settings), the upgrade step has been added to the front of every existing version, to be conservative.

Fixes https://bugs.launchpad.net/juju-core/+bug/1496652

(Review request: http://reviews.vapour.ws/r/2685/)