### PR TITLE
storage: forward-port storage API/CLI changes

### DIFF
--- a/api/storage/client.go
+++ b/api/storage/client.go
@@ -29,7 +29,7 @@ func NewClient(st base.APICallCloser) *Client {
 }
 
 // Show retrieves information about desired storage instances.
-func (c *Client) Show(tags []names.StorageTag) ([]params.StorageDetails, error) {
+func (c *Client) Show(tags []names.StorageTag) ([]params.StorageDetailsResult, error) {
 	found := params.StorageDetailsResults{}
 	entities := make([]params.Entity, len(tags))
 	for i, tag := range tags {
@@ -38,20 +38,7 @@ func (c *Client) Show(tags []names.StorageTag) ([]params.StorageDetails, error) 
 	if err := c.facade.FacadeCall("Show", params.Entities{Entities: entities}, &found); err != nil {
 		return nil, errors.Trace(err)
 	}
-	return c.convert(found.Results)
-}
-
-func (c *Client) convert(found []params.StorageDetailsResult) ([]params.StorageDetails, error) {
-	var storages []params.StorageDetails
-	var allErr params.ErrorResults
-	for _, result := range found {
-		if result.Error != nil {
-			allErr.Results = append(allErr.Results, params.ErrorResult{result.Error})
-			continue
-		}
-		storages = append(storages, result.Result)
-	}
-	return storages, allErr.Combine()
+	return found.Results, nil
 }
 
 // List lists all storage.

--- a/api/storage/client.go
+++ b/api/storage/client.go
@@ -55,8 +55,8 @@ func (c *Client) convert(found []params.StorageDetailsResult) ([]params.StorageD
 }
 
 // List lists all storage.
-func (c *Client) List() ([]params.StorageInfo, error) {
-	found := params.StorageInfosResult{}
+func (c *Client) List() ([]params.StorageDetailsResult, error) {
+	found := params.StorageDetailsResults{}
 	if err := c.facade.FacadeCall("List", nil, &found); err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/api/storage/client_test.go
+++ b/api/storage/client_test.go
@@ -50,16 +50,20 @@ func (s *storageMockSuite) TestShow(c *gc.C) {
 			if results, k := result.(*params.StorageDetailsResults); k {
 				instances := []params.StorageDetailsResult{
 					params.StorageDetailsResult{
-						Result: params.StorageDetails{StorageTag: oneTag.String()},
+						Result: &params.StorageDetails{StorageTag: oneTag.String()},
 					},
 					params.StorageDetailsResult{
-						Result: params.StorageDetails{
+						Result: &params.StorageDetails{
 							StorageTag: twoTag.String(),
-							Status:     "attached",
+							Status: params.EntityStatus{
+								Status: "attached",
+							},
 							Persistent: true,
 						},
 					},
-					params.StorageDetailsResult{Error: common.ServerError(errors.New(msg))},
+					params.StorageDetailsResult{
+						Error: common.ServerError(errors.New(msg)),
+					},
 				}
 				results.Results = instances
 			}
@@ -69,10 +73,11 @@ func (s *storageMockSuite) TestShow(c *gc.C) {
 	storageClient := storage.NewClient(apiCaller)
 	tags := []names.StorageTag{oneTag, twoTag}
 	found, err := storageClient.Show(tags)
-	c.Check(errors.Cause(err), gc.ErrorMatches, msg)
-	c.Assert(found, gc.HasLen, 2)
-	c.Assert(expected.Contains(found[0].StorageTag), jc.IsTrue)
-	c.Assert(expected.Contains(found[1].StorageTag), jc.IsTrue)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(found, gc.HasLen, 3)
+	c.Assert(expected.Contains(found[0].Result.StorageTag), jc.IsTrue)
+	c.Assert(expected.Contains(found[1].Result.StorageTag), jc.IsTrue)
+	c.Assert(found[2].Error, gc.ErrorMatches, msg)
 }
 
 func (s *storageMockSuite) TestShowFacadeCallError(c *gc.C) {
@@ -99,10 +104,7 @@ func (s *storageMockSuite) TestShowFacadeCallError(c *gc.C) {
 }
 
 func (s *storageMockSuite) TestList(c *gc.C) {
-	one := "shared-fs/0"
-	oneTag := names.NewStorageTag(one)
-	two := "db-dir/1000"
-	twoTag := names.NewStorageTag(two)
+	storageTag := names.NewStorageTag("db-dir/1000")
 	msg := "call failure"
 
 	apiCaller := basetesting.APICallerFunc(
@@ -118,15 +120,15 @@ func (s *storageMockSuite) TestList(c *gc.C) {
 
 			if results, k := result.(*params.StorageDetailsResults); k {
 				instances := []params.StorageDetailsResult{{
-					params.StorageDetails{StorageTag: oneTag.String()},
-					common.ServerError(errors.New(msg)),
+					Error: common.ServerError(errors.New(msg)),
 				}, {
-					params.StorageDetails{
-						StorageTag: twoTag.String(),
-						Status:     "attached",
+					Result: &params.StorageDetails{
+						StorageTag: storageTag.String(),
+						Status: params.EntityStatus{
+							Status: "attached",
+						},
 						Persistent: true,
 					},
-					nil,
 				}}
 				results.Results = instances
 			}
@@ -138,16 +140,15 @@ func (s *storageMockSuite) TestList(c *gc.C) {
 	c.Check(err, jc.ErrorIsNil)
 	c.Assert(found, gc.HasLen, 2)
 	expected := []params.StorageDetailsResult{{
-		params.StorageDetails{
-			StorageTag: "storage-shared-fs-0"},
-		&params.Error{Message: msg},
+		Error: &params.Error{Message: msg},
 	}, {
-		params.StorageDetails{
+		Result: &params.StorageDetails{
 			StorageTag: "storage-db-dir-1000",
-			Status:     "attached",
+			Status: params.EntityStatus{
+				Status: "attached",
+			},
 			Persistent: true,
 		},
-		nil,
 	}}
 
 	c.Assert(found, jc.DeepEquals, expected)

--- a/api/storage/client_test.go
+++ b/api/storage/client_test.go
@@ -116,21 +116,18 @@ func (s *storageMockSuite) TestList(c *gc.C) {
 			c.Check(request, gc.Equals, "List")
 			c.Check(a, gc.IsNil)
 
-			if results, k := result.(*params.StorageInfosResult); k {
-				instances := []params.StorageInfo{
-					params.StorageInfo{
-						params.StorageDetails{StorageTag: oneTag.String()},
-						common.ServerError(errors.New(msg)),
+			if results, k := result.(*params.StorageDetailsResults); k {
+				instances := []params.StorageDetailsResult{{
+					params.StorageDetails{StorageTag: oneTag.String()},
+					common.ServerError(errors.New(msg)),
+				}, {
+					params.StorageDetails{
+						StorageTag: twoTag.String(),
+						Status:     "attached",
+						Persistent: true,
 					},
-					params.StorageInfo{
-						params.StorageDetails{
-							StorageTag: twoTag.String(),
-							Status:     "attached",
-							Persistent: true,
-						},
-						nil,
-					},
-				}
+					nil,
+				}}
 				results.Results = instances
 			}
 
@@ -140,19 +137,18 @@ func (s *storageMockSuite) TestList(c *gc.C) {
 	found, err := storageClient.List()
 	c.Check(err, jc.ErrorIsNil)
 	c.Assert(found, gc.HasLen, 2)
-	expected := []params.StorageInfo{
-		params.StorageInfo{
-			StorageDetails: params.StorageDetails{
-				StorageTag: "storage-shared-fs-0"},
-			Error: &params.Error{Message: msg},
+	expected := []params.StorageDetailsResult{{
+		params.StorageDetails{
+			StorageTag: "storage-shared-fs-0"},
+		&params.Error{Message: msg},
+	}, {
+		params.StorageDetails{
+			StorageTag: "storage-db-dir-1000",
+			Status:     "attached",
+			Persistent: true,
 		},
-		params.StorageInfo{
-			params.StorageDetails{
-				StorageTag: "storage-db-dir-1000",
-				Status:     "attached",
-				Persistent: true},
-			nil},
-	}
+		nil,
+	}}
 
 	c.Assert(found, jc.DeepEquals, expected)
 }

--- a/apiserver/params/storage.go
+++ b/apiserver/params/storage.go
@@ -426,18 +426,6 @@ type StorageDetailsResults struct {
 	Results []StorageDetailsResult `json:"results,omitempty"`
 }
 
-// StorageInfo contains information about a storage as well as
-// potentially an error related to information retrieval.
-type StorageInfo struct {
-	StorageDetails `json:"result"`
-	Error          *Error `json:"error,omitempty"`
-}
-
-// StorageInfosResult holds storage details.
-type StorageInfosResult struct {
-	Results []StorageInfo `json:"results,omitempty"`
-}
-
 // StoragePool holds data for a pool instance.
 type StoragePool struct {
 

--- a/apiserver/params/storage.go
+++ b/apiserver/params/storage.go
@@ -541,21 +541,9 @@ type VolumeDetails struct {
 	// machine tag to volume attachment information.
 	MachineAttachments map[string]VolumeAttachmentInfo `json:"machineattachments,omitempty"`
 
-	// NOTE(axw): below should really be StorageDetails,
-	// but StorageDetails is pretty broken at the moment.
-	// StorageDetails is really *StorageAttachmentDetails*,
-	// but also includes information about the storage
-	// instance. We need to rev the storage API and fix
-	// this all up in one go.
-
-	// StorageTag is the tag of the storage instance
+	// Storage contains details about the storage instance
 	// that the volume is assigned to, if any.
-	StorageTag string `json:"storagetag,omitempty"`
-
-	// StorageOwnerTag is the tag of the entity that
-	// owns the volume's assigned storage instance,
-	// if any.
-	StorageOwnerTag string `json:"ownertag,omitempty"`
+	Storage *StorageDetails `json:"storage,omitempty"`
 }
 
 // LegacyVolumeDetails describes a storage volume in the environment

--- a/apiserver/params/storage.go
+++ b/apiserver/params/storage.go
@@ -391,7 +391,33 @@ type FilesystemAttachmentParamsResults struct {
 
 // StorageDetails holds information about storage.
 type StorageDetails struct {
+	// StorageTag holds tag for this storage.
+	StorageTag string `json:"storagetag"`
 
+	// OwnerTag holds tag for the owner of this storage, unit or service.
+	OwnerTag string `json:"ownertag"`
+
+	// Kind holds what kind of storage this instance is.
+	Kind StorageKind `json:"kind"`
+
+	// Status contains the status of the storage instance.
+	Status EntityStatus `json:"status"`
+
+	// Persistent reports whether or not the underlying volume or
+	// filesystem is persistent; i.e. whether or not it outlives
+	// the machine that it is attached to.
+	Persistent bool
+
+	// Attachments contains a mapping from unit tag to
+	// storage attachment details.
+	Attachments map[string]StorageAttachmentDetails `json:"attachments,omitempty"`
+}
+
+// LegacyStorageDetails holds information about storage.
+//
+// NOTE(axw): this is for backwards compatibility only. This struct
+// should not be changed!
+type LegacyStorageDetails struct {
 	// StorageTag holds tag for this storage.
 	StorageTag string `json:"storagetag"`
 
@@ -417,13 +443,30 @@ type StorageDetails struct {
 // StorageDetailsResult holds information about a storage instance
 // or error related to its retrieval.
 type StorageDetailsResult struct {
-	Result StorageDetails `json:"result"`
-	Error  *Error         `json:"error,omitempty"`
+	Result *StorageDetails      `json:"details,omitempty"`
+	Legacy LegacyStorageDetails `json:"result"`
+	Error  *Error               `json:"error,omitempty"`
 }
 
 // StorageDetailsResults holds results for storage details or related storage error.
 type StorageDetailsResults struct {
 	Results []StorageDetailsResult `json:"results,omitempty"`
+}
+
+// StorageAttachmentDetails holds detailed information about a storage attachment.
+type StorageAttachmentDetails struct {
+	// StorageTag is the tag of the storage instance.
+	StorageTag string `json:"storagetag"`
+
+	// UnitTag is the tag of the unit attached to the storage instance.
+	UnitTag string `json:"unittag"`
+
+	// MachineTag is the tag of the machine that the attached unit is assigned to.
+	MachineTag string `json:"machinetag"`
+
+	// Location holds location (mount point/device path) of
+	// the attached storage.
+	Location string `json:"location,omitempty"`
 }
 
 // StoragePool holds data for a pool instance.

--- a/apiserver/storage/storage.go
+++ b/apiserver/storage/storage.go
@@ -102,7 +102,7 @@ func (api *API) List() (params.StorageDetailsResults, error) {
 }
 
 func (api *API) createStorageDetailsResult(si state.StorageInstance) params.StorageDetailsResult {
-	details, err := api.createStorageDetails(si)
+	details, err := createStorageDetails(api.storage, si)
 	if err != nil {
 		return params.StorageDetailsResult{Error: common.ServerError(err)}
 	}
@@ -126,7 +126,7 @@ func (api *API) createStorageDetailsResult(si state.StorageInstance) params.Stor
 	return params.StorageDetailsResult{Result: details, Legacy: legacy}
 }
 
-func (api *API) createStorageDetails(si state.StorageInstance) (*params.StorageDetails, error) {
+func createStorageDetails(st storageAccess, si state.StorageInstance) (*params.StorageDetails, error) {
 	// Get information from underlying volume or filesystem.
 	var persistent bool
 	var statusEntity state.StatusGetter
@@ -134,13 +134,13 @@ func (api *API) createStorageDetails(si state.StorageInstance) (*params.StorageD
 		// TODO(axw) when we support persistent filesystems,
 		// e.g. CephFS, we'll need to do set "persistent"
 		// here too.
-		filesystem, err := api.storage.StorageInstanceFilesystem(si.StorageTag())
+		filesystem, err := st.StorageInstanceFilesystem(si.StorageTag())
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
 		statusEntity = filesystem
 	} else {
-		volume, err := api.storage.StorageInstanceVolume(si.StorageTag())
+		volume, err := st.StorageInstanceVolume(si.StorageTag())
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -156,14 +156,14 @@ func (api *API) createStorageDetails(si state.StorageInstance) (*params.StorageD
 
 	// Get unit storage attachments.
 	var storageAttachmentDetails map[string]params.StorageAttachmentDetails
-	storageAttachments, err := api.storage.StorageAttachments(si.StorageTag())
+	storageAttachments, err := st.StorageAttachments(si.StorageTag())
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 	if len(storageAttachments) > 0 {
 		storageAttachmentDetails = make(map[string]params.StorageAttachmentDetails)
 		for _, a := range storageAttachments {
-			machineTag, location, err := api.storageAttachmentInfo(a)
+			machineTag, location, err := storageAttachmentInfo(st, a)
 			if err != nil {
 				return nil, errors.Trace(err)
 			}
@@ -187,14 +187,14 @@ func (api *API) createStorageDetails(si state.StorageInstance) (*params.StorageD
 	}, nil
 }
 
-func (api *API) storageAttachmentInfo(a state.StorageAttachment) (_ names.MachineTag, location string, _ error) {
-	machineTag, err := api.storage.UnitAssignedMachine(a.Unit())
+func storageAttachmentInfo(st storageAccess, a state.StorageAttachment) (_ names.MachineTag, location string, _ error) {
+	machineTag, err := st.UnitAssignedMachine(a.Unit())
 	if errors.IsNotAssigned(err) {
 		return names.MachineTag{}, "", nil
 	} else if err != nil {
 		return names.MachineTag{}, "", errors.Trace(err)
 	}
-	info, err := storagecommon.StorageAttachmentInfo(api.storage, a, machineTag)
+	info, err := storagecommon.StorageAttachmentInfo(st, a, machineTag)
 	if errors.IsNotProvisioned(err) {
 		return machineTag, "", nil
 	} else if err != nil {
@@ -443,21 +443,21 @@ func createVolumeDetailsResults(
 		}
 		result.LegacyVolume = &params.LegacyVolumeDetails{
 			VolumeTag:  details.VolumeTag,
-			StorageTag: details.StorageTag,
 			VolumeId:   details.Info.VolumeId,
 			HardwareId: details.Info.HardwareId,
 			Size:       details.Info.Size,
 			Persistent: details.Info.Persistent,
 			Status:     details.Status,
 		}
-		if details.StorageOwnerTag != "" {
-			kind, err := names.TagKind(details.StorageOwnerTag)
+		if details.Storage != nil {
+			result.LegacyVolume.StorageTag = details.Storage.StorageTag
+			kind, err := names.TagKind(details.Storage.OwnerTag)
 			if err != nil {
 				results[i].Error = common.ServerError(err)
 				continue
 			}
 			if kind == names.UnitTagKind {
-				result.LegacyVolume.UnitTag = details.StorageOwnerTag
+				result.LegacyVolume.UnitTag = details.Storage.OwnerTag
 			}
 		}
 		results[i] = result
@@ -496,12 +496,15 @@ func createVolumeDetails(
 	details.Status = common.EntityStatusFromState(status)
 
 	if storageTag, err := v.StorageInstance(); err == nil {
-		details.StorageTag = storageTag.String()
 		storageInstance, err := st.StorageInstance(storageTag)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		details.StorageOwnerTag = storageInstance.Owner().String()
+		storageDetails, err := createStorageDetails(st, storageInstance)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		details.Storage = storageDetails
 	}
 
 	return details, nil

--- a/apiserver/storage/storage.go
+++ b/apiserver/storage/storage.go
@@ -7,6 +7,7 @@ package storage
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	"github.com/juju/names"
 	"github.com/juju/utils/set"
 
@@ -18,6 +19,8 @@ import (
 	"github.com/juju/juju/storage/poolmanager"
 	"github.com/juju/juju/storage/provider/registry"
 )
+
+var logger = loggo.GetLogger("juju.apiserver.storage")
 
 func init() {
 	common.RegisterStandardFacade("Storage", 1, NewAPI)
@@ -66,26 +69,21 @@ func poolManager(st *state.State) poolmanager.PoolManager {
 // identified by supplied tags. If specified storage cannot be retrieved,
 // individual error is returned instead of storage information.
 func (api *API) Show(entities params.Entities) (params.StorageDetailsResults, error) {
-	var all []params.StorageDetailsResult
-	for _, entity := range entities.Entities {
+	results := make([]params.StorageDetailsResult, len(entities.Entities))
+	for i, entity := range entities.Entities {
 		storageTag, err := names.ParseStorageTag(entity.Tag)
 		if err != nil {
-			all = append(all, params.StorageDetailsResult{
-				Error: common.ServerError(err),
-			})
+			results[i].Error = common.ServerError(err)
 			continue
 		}
-		found, instance, serverErr := api.getStorageInstance(storageTag)
+		storageInstance, err := api.storage.StorageInstance(storageTag)
 		if err != nil {
-			all = append(all, params.StorageDetailsResult{Error: serverErr})
+			results[i].Error = common.ServerError(err)
 			continue
 		}
-		if found {
-			results := api.createStorageDetailsResult(storageTag, instance)
-			all = append(all, results...)
-		}
+		results[i] = api.createStorageDetailsResult(storageInstance)
 	}
-	return params.StorageDetailsResults{Results: all}, nil
+	return params.StorageDetailsResults{Results: results}, nil
 }
 
 // List returns all currently known storage. Unlike Show(),
@@ -96,154 +94,113 @@ func (api *API) List() (params.StorageDetailsResults, error) {
 	if err != nil {
 		return params.StorageDetailsResults{}, common.ServerError(err)
 	}
-	var infos []params.StorageDetailsResult
-	for _, stateInstance := range stateInstances {
-		storageTag := stateInstance.StorageTag()
-		persistent, err := api.isPersistent(stateInstance)
-		if err != nil {
-			return params.StorageDetailsResults{}, err
-		}
-		instance := createParamsStorageInstance(stateInstance, persistent)
-
-		// It is possible to encounter errors here related to getting individual
-		// storage details such as getting attachments, getting machine from the unit,
-		// etc.
-		// Current approach is to do what status command does - treat error
-		// as another valid property, i.e. augment storage details.
-		attachments := api.createStorageDetailsResult(storageTag, instance)
-		for _, one := range attachments {
-			aParam := params.StorageDetailsResult{one.Result, one.Error}
-			infos = append(infos, aParam)
-		}
+	results := make([]params.StorageDetailsResult, len(stateInstances))
+	for i, stateInstance := range stateInstances {
+		results[i] = api.createStorageDetailsResult(stateInstance)
 	}
-	return params.StorageDetailsResults{Results: infos}, nil
+	return params.StorageDetailsResults{Results: results}, nil
 }
 
-func (api *API) createStorageDetailsResult(
-	storageTag names.StorageTag,
-	instance params.StorageDetails,
-) []params.StorageDetailsResult {
-	attachments, err := api.getStorageAttachments(storageTag, instance)
+func (api *API) createStorageDetailsResult(si state.StorageInstance) params.StorageDetailsResult {
+	details, err := api.createStorageDetails(si)
 	if err != nil {
-		return []params.StorageDetailsResult{params.StorageDetailsResult{Result: instance, Error: err}}
+		return params.StorageDetailsResult{Error: common.ServerError(err)}
 	}
-	if len(attachments) > 0 {
-		// If any attachments were found for this storage instance,
-		// return them instead.
-		result := make([]params.StorageDetailsResult, len(attachments))
-		for i, attachment := range attachments {
-			result[i] = params.StorageDetailsResult{Result: attachment}
+
+	legacy := params.LegacyStorageDetails{
+		details.StorageTag,
+		details.OwnerTag,
+		details.Kind,
+		string(details.Status.Status),
+		"", // unit tag set below
+		"", // location set below
+		details.Persistent,
+	}
+	if len(details.Attachments) == 1 {
+		for unitTag, attachmentDetails := range details.Attachments {
+			legacy.UnitTag = unitTag
+			legacy.Location = attachmentDetails.Location
 		}
-		return result
 	}
-	// If we are here then this storage instance is unattached.
-	return []params.StorageDetailsResult{params.StorageDetailsResult{Result: instance}}
+
+	return params.StorageDetailsResult{Result: details, Legacy: legacy}
 }
 
-func (api *API) getStorageAttachments(
-	storageTag names.StorageTag,
-	instance params.StorageDetails,
-) ([]params.StorageDetails, *params.Error) {
-	serverError := func(err error) *params.Error {
-		return common.ServerError(errors.Annotatef(err, "getting attachments for storage %v", storageTag.Id()))
-	}
-	stateAttachments, err := api.storage.StorageAttachments(storageTag)
-	if err != nil {
-		return nil, serverError(err)
-	}
-	result := make([]params.StorageDetails, len(stateAttachments))
-	for i, one := range stateAttachments {
-		paramsStorageAttachment, err := api.createParamsStorageAttachment(instance, one)
-		if err != nil {
-			return nil, serverError(err)
-		}
-		result[i] = paramsStorageAttachment
-	}
-	return result, nil
-}
-
-func (api *API) createParamsStorageAttachment(si params.StorageDetails, sa state.StorageAttachment) (params.StorageDetails, error) {
-	result := params.StorageDetails{Status: "pending"}
-	result.StorageTag = sa.StorageInstance().String()
-	if result.StorageTag != si.StorageTag {
-		panic("attachment does not belong to storage instance")
-	}
-	result.UnitTag = sa.Unit().String()
-	result.OwnerTag = si.OwnerTag
-	result.Kind = si.Kind
-	result.Persistent = si.Persistent
-	// TODO(axw) set status according to whether storage has been provisioned.
-
-	// This is only for provisioned attachments
-	machineTag, err := api.storage.UnitAssignedMachine(sa.Unit())
-	if err != nil {
-		return params.StorageDetails{}, errors.Annotate(err, "getting unit for storage attachment")
-	}
-	info, err := storagecommon.StorageAttachmentInfo(api.storage, sa, machineTag)
-	if err != nil {
-		if errors.IsNotProvisioned(err) {
-			// If Info returns an error, then the storage has not yet been provisioned.
-			return result, nil
-		}
-		return params.StorageDetails{}, errors.Annotate(err, "getting storage attachment info")
-	}
-	result.Location = info.Location
-	if result.Location != "" {
-		result.Status = "attached"
-	}
-	return result, nil
-}
-
-func (api *API) getStorageInstance(tag names.StorageTag) (bool, params.StorageDetails, *params.Error) {
-	nothing := params.StorageDetails{}
-	serverError := func(err error) *params.Error {
-		return common.ServerError(errors.Annotatef(err, "getting %v", tag))
-	}
-	stateInstance, err := api.storage.StorageInstance(tag)
-	if err != nil {
-		if errors.IsNotFound(err) {
-			return false, nothing, nil
-		}
-		return false, nothing, serverError(err)
-	}
-	persistent, err := api.isPersistent(stateInstance)
-	if err != nil {
-		return false, nothing, serverError(err)
-	}
-	return true, createParamsStorageInstance(stateInstance, persistent), nil
-}
-
-func createParamsStorageInstance(si state.StorageInstance, persistent bool) params.StorageDetails {
-	result := params.StorageDetails{
-		OwnerTag:   si.Owner().String(),
-		StorageTag: si.Tag().String(),
-		Kind:       params.StorageKind(si.Kind()),
-		Status:     "pending",
-		Persistent: persistent,
-	}
-	return result
-}
-
-// TODO(axw) move this and createParamsStorageInstance to
-// apiserver/common/storage.go, alongside StorageAttachmentInfo.
-func (api *API) isPersistent(si state.StorageInstance) (bool, error) {
+func (api *API) createStorageDetails(si state.StorageInstance) (*params.StorageDetails, error) {
+	// Get information from underlying volume or filesystem.
+	var persistent bool
+	var statusEntity state.StatusGetter
 	if si.Kind() != state.StorageKindBlock {
 		// TODO(axw) when we support persistent filesystems,
-		// e.g. CephFS, we'll need to do the same thing as
-		// we do for volumes for filesystems.
-		return false, nil
+		// e.g. CephFS, we'll need to do set "persistent"
+		// here too.
+		filesystem, err := api.storage.StorageInstanceFilesystem(si.StorageTag())
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		statusEntity = filesystem
+	} else {
+		volume, err := api.storage.StorageInstanceVolume(si.StorageTag())
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		if info, err := volume.Info(); err == nil {
+			persistent = info.Persistent
+		}
+		statusEntity = volume
 	}
-	volume, err := api.storage.StorageInstanceVolume(si.StorageTag())
+	status, err := statusEntity.Status()
 	if err != nil {
-		return false, err
+		return nil, errors.Trace(err)
 	}
-	info, err := volume.Info()
-	if errors.IsNotProvisioned(err) {
-		return false, nil
+
+	// Get unit storage attachments.
+	var storageAttachmentDetails map[string]params.StorageAttachmentDetails
+	storageAttachments, err := api.storage.StorageAttachments(si.StorageTag())
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if len(storageAttachments) > 0 {
+		storageAttachmentDetails = make(map[string]params.StorageAttachmentDetails)
+		for _, a := range storageAttachments {
+			machineTag, location, err := api.storageAttachmentInfo(a)
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			details := params.StorageAttachmentDetails{
+				a.StorageInstance().String(),
+				a.Unit().String(),
+				machineTag.String(),
+				location,
+			}
+			storageAttachmentDetails[a.Unit().String()] = details
+		}
+	}
+
+	return &params.StorageDetails{
+		StorageTag:  si.Tag().String(),
+		OwnerTag:    si.Owner().String(),
+		Kind:        params.StorageKind(si.Kind()),
+		Status:      common.EntityStatusFromState(status),
+		Persistent:  persistent,
+		Attachments: storageAttachmentDetails,
+	}, nil
+}
+
+func (api *API) storageAttachmentInfo(a state.StorageAttachment) (_ names.MachineTag, location string, _ error) {
+	machineTag, err := api.storage.UnitAssignedMachine(a.Unit())
+	if errors.IsNotAssigned(err) {
+		return names.MachineTag{}, "", nil
 	} else if err != nil {
-		return false, err
+		return names.MachineTag{}, "", errors.Trace(err)
 	}
-	return info.Persistent, nil
+	info, err := storagecommon.StorageAttachmentInfo(api.storage, a, machineTag)
+	if errors.IsNotProvisioned(err) {
+		return machineTag, "", nil
+	} else if err != nil {
+		return names.MachineTag{}, "", errors.Trace(err)
+	}
+	return machineTag, info.Location, nil
 }
 
 // ListPools returns a list of pools.

--- a/apiserver/storage/storage.go
+++ b/apiserver/storage/storage.go
@@ -7,7 +7,6 @@ package storage
 
 import (
 	"github.com/juju/errors"
-	"github.com/juju/loggo"
 	"github.com/juju/names"
 	"github.com/juju/utils/set"
 
@@ -19,8 +18,6 @@ import (
 	"github.com/juju/juju/storage/poolmanager"
 	"github.com/juju/juju/storage/provider/registry"
 )
-
-var logger = loggo.GetLogger("juju.apiserver.storage")
 
 func init() {
 	common.RegisterStandardFacade("Storage", 1, NewAPI)

--- a/apiserver/storage/storage.go
+++ b/apiserver/storage/storage.go
@@ -91,17 +91,17 @@ func (api *API) Show(entities params.Entities) (params.StorageDetailsResults, er
 // List returns all currently known storage. Unlike Show(),
 // if errors encountered while retrieving a particular
 // storage, this error is treated as part of the returned storage detail.
-func (api *API) List() (params.StorageInfosResult, error) {
+func (api *API) List() (params.StorageDetailsResults, error) {
 	stateInstances, err := api.storage.AllStorageInstances()
 	if err != nil {
-		return params.StorageInfosResult{}, common.ServerError(err)
+		return params.StorageDetailsResults{}, common.ServerError(err)
 	}
-	var infos []params.StorageInfo
+	var infos []params.StorageDetailsResult
 	for _, stateInstance := range stateInstances {
 		storageTag := stateInstance.StorageTag()
 		persistent, err := api.isPersistent(stateInstance)
 		if err != nil {
-			return params.StorageInfosResult{}, err
+			return params.StorageDetailsResults{}, err
 		}
 		instance := createParamsStorageInstance(stateInstance, persistent)
 
@@ -112,11 +112,11 @@ func (api *API) List() (params.StorageInfosResult, error) {
 		// as another valid property, i.e. augment storage details.
 		attachments := api.createStorageDetailsResult(storageTag, instance)
 		for _, one := range attachments {
-			aParam := params.StorageInfo{one.Result, one.Error}
+			aParam := params.StorageDetailsResult{one.Result, one.Error}
 			infos = append(infos, aParam)
 		}
 	}
-	return params.StorageInfosResult{Results: infos}, nil
+	return params.StorageDetailsResults{Results: infos}, nil
 }
 
 func (api *API) createStorageDetailsResult(

--- a/apiserver/storage/storage_test.go
+++ b/apiserver/storage/storage_test.go
@@ -48,8 +48,8 @@ func (s *storageSuite) TestStorageListFilesystem(c *gc.C) {
 	s.assertCalls(c, expectedCalls)
 
 	c.Assert(found.Results, gc.HasLen, 1)
-	wantedDetails := s.createTestStorageInfo()
-	wantedDetails.UnitTag = s.unitTag.String()
+	wantedDetails := s.createTestStorageDetailsResult()
+	wantedDetails.Result.UnitTag = s.unitTag.String()
 	s.assertInstanceInfoError(c, found.Results[0], wantedDetails, "")
 }
 
@@ -69,9 +69,9 @@ func (s *storageSuite) TestStorageListVolume(c *gc.C) {
 	s.assertCalls(c, expectedCalls)
 
 	c.Assert(found.Results, gc.HasLen, 1)
-	wantedDetails := s.createTestStorageInfo()
-	wantedDetails.Kind = params.StorageKindBlock
-	wantedDetails.UnitTag = s.unitTag.String()
+	wantedDetails := s.createTestStorageDetailsResult()
+	wantedDetails.Result.Kind = params.StorageKindBlock
+	wantedDetails.Result.UnitTag = s.unitTag.String()
 	s.assertInstanceInfoError(c, found.Results[0], wantedDetails, "")
 }
 
@@ -111,7 +111,7 @@ func (s *storageSuite) TestStorageListInstanceError(c *gc.C) {
 	}
 	s.assertCalls(c, expectedCalls)
 	c.Assert(found.Results, gc.HasLen, 1)
-	wanted := s.createTestStorageInfoWithError("",
+	wanted := s.createTestStorageDetailsResultWithError("",
 		fmt.Sprintf("getting storage attachment info: getting storage instance: %v", msg))
 	s.assertInstanceInfoError(c, found.Results[0], wanted, msg)
 }
@@ -133,7 +133,7 @@ func (s *storageSuite) TestStorageListAttachmentError(c *gc.C) {
 	s.assertCalls(c, expectedCalls)
 	c.Assert(found.Results, gc.HasLen, 1)
 	expectedErr := "list test error"
-	wanted := s.createTestStorageInfoWithError("", expectedErr)
+	wanted := s.createTestStorageDetailsResultWithError("", expectedErr)
 	s.assertInstanceInfoError(c, found.Results[0], wanted, expectedErr)
 }
 
@@ -155,7 +155,7 @@ func (s *storageSuite) TestStorageListMachineError(c *gc.C) {
 	}
 	s.assertCalls(c, expectedCalls)
 	c.Assert(found.Results, gc.HasLen, 1)
-	wanted := s.createTestStorageInfoWithError("",
+	wanted := s.createTestStorageDetailsResultWithError("",
 		fmt.Sprintf("getting unit for storage attachment: %v", msg))
 	s.assertInstanceInfoError(c, found.Results[0], wanted, msg)
 }
@@ -180,7 +180,7 @@ func (s *storageSuite) TestStorageListFilesystemError(c *gc.C) {
 	}
 	s.assertCalls(c, expectedCalls)
 	c.Assert(found.Results, gc.HasLen, 1)
-	wanted := s.createTestStorageInfoWithError("",
+	wanted := s.createTestStorageDetailsResultWithError("",
 		fmt.Sprintf("getting storage attachment info: getting filesystem: %v", msg))
 	s.assertInstanceInfoError(c, found.Results[0], wanted, msg)
 }
@@ -203,20 +203,20 @@ func (s *storageSuite) TestStorageListFilesystemAttachmentError(c *gc.C) {
 	}
 	s.assertCalls(c, expectedCalls)
 	c.Assert(found.Results, gc.HasLen, 1)
-	wanted := s.createTestStorageInfoWithError("",
+	wanted := s.createTestStorageDetailsResultWithError("",
 		fmt.Sprintf("getting unit for storage attachment: %v", msg))
 	s.assertInstanceInfoError(c, found.Results[0], wanted, msg)
 }
 
-func (s *storageSuite) createTestStorageInfoWithError(code, msg string) params.StorageInfo {
-	wanted := s.createTestStorageInfo()
+func (s *storageSuite) createTestStorageDetailsResultWithError(code, msg string) params.StorageDetailsResult {
+	wanted := s.createTestStorageDetailsResult()
 	wanted.Error = &params.Error{Code: code,
 		Message: fmt.Sprintf("getting attachments for storage data/0: %v", msg)}
 	return wanted
 }
 
-func (s *storageSuite) createTestStorageInfo() params.StorageInfo {
-	return params.StorageInfo{
+func (s *storageSuite) createTestStorageDetailsResult() params.StorageDetailsResult {
+	return params.StorageDetailsResult{
 		params.StorageDetails{
 			StorageTag: s.storageTag.String(),
 			OwnerTag:   s.unitTag.String(),
@@ -227,7 +227,7 @@ func (s *storageSuite) createTestStorageInfo() params.StorageInfo {
 	}
 }
 
-func (s *storageSuite) assertInstanceInfoError(c *gc.C, obtained params.StorageInfo, wanted params.StorageInfo, expected string) {
+func (s *storageSuite) assertInstanceInfoError(c *gc.C, obtained params.StorageDetailsResult, wanted params.StorageDetailsResult, expected string) {
 	if expected != "" {
 		c.Assert(errors.Cause(obtained.Error), gc.ErrorMatches, fmt.Sprintf(".*%v.*", expected))
 	} else {

--- a/apiserver/storage/volumelist_test.go
+++ b/apiserver/storage/volumelist_test.go
@@ -21,14 +21,27 @@ var _ = gc.Suite(&volumeSuite{})
 func (s *volumeSuite) expectedVolumeDetailsResult() params.VolumeDetailsResult {
 	return params.VolumeDetailsResult{
 		Details: &params.VolumeDetails{
-			VolumeTag:       s.volumeTag.String(),
-			StorageTag:      "storage-data-0",
-			StorageOwnerTag: "unit-mysql-0",
+			VolumeTag: s.volumeTag.String(),
 			Status: params.EntityStatus{
 				Status: "attached",
 			},
 			MachineAttachments: map[string]params.VolumeAttachmentInfo{
 				s.machineTag.String(): params.VolumeAttachmentInfo{},
+			},
+			Storage: &params.StorageDetails{
+				StorageTag: "storage-data-0",
+				OwnerTag:   "unit-mysql-0",
+				Kind:       params.StorageKindFilesystem,
+				Status: params.EntityStatus{
+					Status: "attached",
+				},
+				Attachments: map[string]params.StorageAttachmentDetails{
+					"unit-mysql-0": params.StorageAttachmentDetails{
+						StorageTag: "storage-data-0",
+						UnitTag:    "unit-mysql-0",
+						MachineTag: "machine-66",
+					},
+				},
 			},
 		},
 		LegacyVolume: &params.LegacyVolumeDetails{

--- a/cmd/juju/storage/list.go
+++ b/cmd/juju/storage/list.go
@@ -70,7 +70,7 @@ func (c *ListCommand) Run(ctx *cmd.Context) (err error) {
 	var valid []params.StorageDetails
 	for _, one := range found {
 		if one.Error == nil {
-			valid = append(valid, one.StorageDetails)
+			valid = append(valid, one.Result)
 			continue
 		}
 		// display individual error
@@ -93,7 +93,7 @@ var (
 // StorageAPI defines the API methods that the storage commands use.
 type StorageListAPI interface {
 	Close() error
-	List() ([]params.StorageInfo, error)
+	List() ([]params.StorageDetailsResult, error)
 }
 
 func (c *ListCommand) getStorageListAPI() (StorageListAPI, error) {

--- a/cmd/juju/storage/list.go
+++ b/cmd/juju/storage/list.go
@@ -67,10 +67,12 @@ func (c *ListCommand) Run(ctx *cmd.Context) (err error) {
 		return err
 	}
 	// filter out valid output, if any
-	var valid []params.StorageDetails
+	var valid []params.LegacyStorageDetails
 	for _, one := range found {
 		if one.Error == nil {
-			valid = append(valid, one.Result)
+			// TODO(axw) use non-legacy if available,
+			// convert from legacy otherwise.
+			valid = append(valid, one.Legacy)
 			continue
 		}
 		// display individual error

--- a/cmd/juju/storage/list_test.go
+++ b/cmd/juju/storage/list_test.go
@@ -137,15 +137,15 @@ func (s mockListAPI) Close() error {
 	return nil
 }
 
-func (s mockListAPI) List() ([]params.StorageInfo, error) {
-	result := []params.StorageInfo{}
+func (s mockListAPI) List() ([]params.StorageDetailsResult, error) {
+	result := []params.StorageDetailsResult{}
 	result = append(result, getTestAttachments(s.lexicalChaos)...)
 	result = append(result, getTestInstances(s.lexicalChaos)...)
 	return result, nil
 }
 
-func getTestAttachments(chaos bool) []params.StorageInfo {
-	results := []params.StorageInfo{{
+func getTestAttachments(chaos bool) []params.StorageDetailsResult {
+	results := []params.StorageDetailsResult{{
 		params.StorageDetails{
 			StorageTag: "storage-shared-fs-0",
 			OwnerTag:   "service-transcode",
@@ -165,7 +165,7 @@ func getTestAttachments(chaos bool) []params.StorageInfo {
 		}, nil}}
 
 	if chaos {
-		last := params.StorageInfo{
+		last := params.StorageDetailsResult{
 			params.StorageDetails{
 				StorageTag: "storage-shared-fs-5",
 				OwnerTag:   "service-transcode",
@@ -174,7 +174,7 @@ func getTestAttachments(chaos bool) []params.StorageInfo {
 				Location:   "nowhere",
 				Status:     "pending",
 			}, nil}
-		second := params.StorageInfo{
+		second := params.StorageDetailsResult{
 			params.StorageDetails{
 				StorageTag: "storage-db-dir-1010",
 				OwnerTag:   "unit-transcode-1",
@@ -183,7 +183,7 @@ func getTestAttachments(chaos bool) []params.StorageInfo {
 				Location:   "",
 				Status:     "pending",
 			}, &params.Error{Message: "error for storage-db-dir-1010"}}
-		first := params.StorageInfo{
+		first := params.StorageDetailsResult{
 			params.StorageDetails{
 				StorageTag: "storage-db-dir-1000",
 				OwnerTag:   "unit-transcode-1",
@@ -199,9 +199,9 @@ func getTestAttachments(chaos bool) []params.StorageInfo {
 	return results
 }
 
-func getTestInstances(chaos bool) []params.StorageInfo {
+func getTestInstances(chaos bool) []params.StorageDetailsResult {
 
-	results := []params.StorageInfo{
+	results := []params.StorageDetailsResult{
 		{
 			params.StorageDetails{
 				StorageTag: "storage-shared-fs-0",
@@ -243,7 +243,7 @@ func getTestInstances(chaos bool) []params.StorageInfo {
 			}, nil}}
 
 	if chaos {
-		last := params.StorageInfo{
+		last := params.StorageDetailsResult{
 			params.StorageDetails{
 				StorageTag: "storage-shared-fs-5",
 				OwnerTag:   "service-transcode",
@@ -251,14 +251,14 @@ func getTestInstances(chaos bool) []params.StorageInfo {
 				Kind:       params.StorageKindUnknown,
 				Status:     "pending",
 			}, nil}
-		second := params.StorageInfo{
+		second := params.StorageDetailsResult{
 			params.StorageDetails{
 				StorageTag: "storage-db-dir-1010",
 				UnitTag:    "unit-transcode-1",
 				Kind:       params.StorageKindBlock,
 				Status:     "pending",
 			}, &params.Error{Message: "error for test storage-db-dir-1010"}}
-		first := params.StorageInfo{
+		first := params.StorageDetailsResult{
 			params.StorageDetails{
 				StorageTag: "storage-db-dir-1000",
 				UnitTag:    "unit-transcode-1",
@@ -266,7 +266,7 @@ func getTestInstances(chaos bool) []params.StorageInfo {
 				Status:     "pending",
 				Persistent: true,
 			}, nil}
-		zero := params.StorageInfo{
+		zero := params.StorageDetailsResult{
 			params.StorageDetails{
 				StorageTag: "storage-db-dir-1100",
 				UnitTag:    "unit-postgresql-0",

--- a/cmd/juju/storage/list_test.go
+++ b/cmd/juju/storage/list_test.go
@@ -146,15 +146,16 @@ func (s mockListAPI) List() ([]params.StorageDetailsResult, error) {
 
 func getTestAttachments(chaos bool) []params.StorageDetailsResult {
 	results := []params.StorageDetailsResult{{
-		params.StorageDetails{
+		Legacy: params.LegacyStorageDetails{
 			StorageTag: "storage-shared-fs-0",
 			OwnerTag:   "service-transcode",
 			UnitTag:    "unit-transcode-0",
 			Kind:       params.StorageKindBlock,
 			Location:   "here",
 			Status:     "attached",
-		}, nil}, {
-		params.StorageDetails{
+		},
+	}, {
+		Legacy: params.LegacyStorageDetails{
 			StorageTag: "storage-db-dir-1000",
 			OwnerTag:   "unit-transcode-0",
 			UnitTag:    "unit-transcode-0",
@@ -162,36 +163,33 @@ func getTestAttachments(chaos bool) []params.StorageDetailsResult {
 			Location:   "there",
 			Status:     "provisioned",
 			Persistent: true,
-		}, nil}}
+		},
+	}}
 
 	if chaos {
 		last := params.StorageDetailsResult{
-			params.StorageDetails{
+			Legacy: params.LegacyStorageDetails{
 				StorageTag: "storage-shared-fs-5",
 				OwnerTag:   "service-transcode",
 				UnitTag:    "unit-transcode-0",
 				Kind:       params.StorageKindUnknown,
 				Location:   "nowhere",
 				Status:     "pending",
-			}, nil}
+			},
+		}
 		second := params.StorageDetailsResult{
-			params.StorageDetails{
-				StorageTag: "storage-db-dir-1010",
-				OwnerTag:   "unit-transcode-1",
-				UnitTag:    "unit-transcode-1",
-				Kind:       params.StorageKindBlock,
-				Location:   "",
-				Status:     "pending",
-			}, &params.Error{Message: "error for storage-db-dir-1010"}}
+			Error: &params.Error{Message: "error for storage-db-dir-1010"},
+		}
 		first := params.StorageDetailsResult{
-			params.StorageDetails{
+			Legacy: params.LegacyStorageDetails{
 				StorageTag: "storage-db-dir-1000",
 				OwnerTag:   "unit-transcode-1",
 				UnitTag:    "unit-transcode-1",
 				Kind:       params.StorageKindFilesystem,
 				Status:     "attached",
 				Persistent: true,
-			}, nil}
+			},
+		}
 		results = append(results, last)
 		results = append(results, second)
 		results = append(results, first)
@@ -201,78 +199,77 @@ func getTestAttachments(chaos bool) []params.StorageDetailsResult {
 
 func getTestInstances(chaos bool) []params.StorageDetailsResult {
 
-	results := []params.StorageDetailsResult{
-		{
-			params.StorageDetails{
-				StorageTag: "storage-shared-fs-0",
-				OwnerTag:   "service-transcode",
-				UnitTag:    "unit-transcode-0",
-				Kind:       params.StorageKindUnknown,
-				Status:     "pending",
-			}, nil},
-		{
-			params.StorageDetails{
-				StorageTag: "storage-shared-fs-0",
-				OwnerTag:   "service-transcode",
-				UnitTag:    "unit-transcode-1",
-				Kind:       params.StorageKindUnknown,
-				Status:     "pending",
-			}, nil},
-		{
-			params.StorageDetails{
-				StorageTag: "storage-db-dir-1100",
-				UnitTag:    "unit-postgresql-0",
-				Kind:       params.StorageKindFilesystem,
-				Status:     "pending",
-			}, nil},
-		{
-			params.StorageDetails{
-				StorageTag: "storage-db-dir-1100",
-				UnitTag:    "unit-transcode-0",
-				Kind:       params.StorageKindFilesystem,
-				Status:     "pending",
-			}, nil},
-		{
-			params.StorageDetails{
-				StorageTag: "storage-db-dir-1000",
-				OwnerTag:   "unit-transcode-0",
-				UnitTag:    "unit-transcode-0",
-				Kind:       params.StorageKindBlock,
-				Status:     "pending",
-				Persistent: true,
-			}, nil}}
+	results := []params.StorageDetailsResult{{
+		Legacy: params.LegacyStorageDetails{
+			StorageTag: "storage-shared-fs-0",
+			OwnerTag:   "service-transcode",
+			UnitTag:    "unit-transcode-0",
+			Kind:       params.StorageKindUnknown,
+			Status:     "pending",
+		},
+	}, {
+		Legacy: params.LegacyStorageDetails{
+			StorageTag: "storage-shared-fs-0",
+			OwnerTag:   "service-transcode",
+			UnitTag:    "unit-transcode-1",
+			Kind:       params.StorageKindUnknown,
+			Status:     "pending",
+		},
+	}, {
+		Legacy: params.LegacyStorageDetails{
+			StorageTag: "storage-db-dir-1100",
+			UnitTag:    "unit-postgresql-0",
+			Kind:       params.StorageKindFilesystem,
+			Status:     "pending",
+		},
+	}, {
+		Legacy: params.LegacyStorageDetails{
+			StorageTag: "storage-db-dir-1100",
+			UnitTag:    "unit-transcode-0",
+			Kind:       params.StorageKindFilesystem,
+			Status:     "pending",
+		},
+	}, {
+		Legacy: params.LegacyStorageDetails{
+			StorageTag: "storage-db-dir-1000",
+			OwnerTag:   "unit-transcode-0",
+			UnitTag:    "unit-transcode-0",
+			Kind:       params.StorageKindBlock,
+			Status:     "pending",
+			Persistent: true,
+		},
+	}}
 
 	if chaos {
 		last := params.StorageDetailsResult{
-			params.StorageDetails{
+			Legacy: params.LegacyStorageDetails{
 				StorageTag: "storage-shared-fs-5",
 				OwnerTag:   "service-transcode",
 				UnitTag:    "unit-transcode-0",
 				Kind:       params.StorageKindUnknown,
 				Status:     "pending",
-			}, nil}
+			},
+		}
 		second := params.StorageDetailsResult{
-			params.StorageDetails{
-				StorageTag: "storage-db-dir-1010",
-				UnitTag:    "unit-transcode-1",
-				Kind:       params.StorageKindBlock,
-				Status:     "pending",
-			}, &params.Error{Message: "error for test storage-db-dir-1010"}}
+			Error: &params.Error{Message: "error for test storage-db-dir-1010"},
+		}
 		first := params.StorageDetailsResult{
-			params.StorageDetails{
+			Legacy: params.LegacyStorageDetails{
 				StorageTag: "storage-db-dir-1000",
 				UnitTag:    "unit-transcode-1",
 				Kind:       params.StorageKindFilesystem,
 				Status:     "pending",
 				Persistent: true,
-			}, nil}
+			},
+		}
 		zero := params.StorageDetailsResult{
-			params.StorageDetails{
+			Legacy: params.LegacyStorageDetails{
 				StorageTag: "storage-db-dir-1100",
 				UnitTag:    "unit-postgresql-0",
 				Kind:       params.StorageKindFilesystem,
 				Status:     "pending",
-			}, nil}
+			},
+		}
 		results = append(results, last)
 		results = append(results, second)
 		results = append(results, zero)

--- a/cmd/juju/storage/listformatters.go
+++ b/cmd/juju/storage/listformatters.go
@@ -111,31 +111,53 @@ func (s bySuffixNaturally) Swap(a, b int) {
 }
 
 func (s bySuffixNaturally) Less(a, b int) bool {
-	sa := strings.SplitN(s[a], "/", 2)
-	sb := strings.SplitN(s[b], "/", 2)
-	if sa[0] < sb[0] {
-		return true
+	return naturalCompare(s[a], s[b]) == -1
+}
+
+// naturalCompares a with b, first the string before "/",
+// and then the integer or string after. Empty strings
+// are sorted after all others.
+func naturalCompare(a, b string) int {
+	switch {
+	case a == "" && b == "":
+		return 0
+	case a == "":
+		return 1
+	case b == "":
+		return -1
 	}
-	altReturn := sa[0] == sb[0] && sa[1] < sb[1]
+
+	sa := strings.SplitN(a, "/", 2)
+	sb := strings.SplitN(b, "/", 2)
+	if sa[0] < sb[0] {
+		return -1
+	}
+	if sa[0] > sb[0] {
+		return 1
+	}
 
 	getInt := func(suffix string) (bool, int) {
 		num, err := strconv.Atoi(suffix)
 		if err != nil {
-			// It's possible that we are not looking at numeric suffix
-			logger.Infof("parsing a non-numeric %v: %v", suffix, err)
 			return false, 0
 		}
-		fmt.Printf("parsing a non-numeric %v: %v", suffix, err)
 		return true, num
 	}
 
 	naIsNumeric, na := getInt(sa[1])
 	if !naIsNumeric {
-		return altReturn
+		return strings.Compare(sa[1], sb[1])
 	}
 	nbIsNumeric, nb := getInt(sb[1])
 	if !nbIsNumeric {
-		return altReturn
+		return strings.Compare(sa[1], sb[1])
 	}
-	return sa[0] == sb[0] && na < nb
+
+	switch {
+	case na < nb:
+		return -1
+	case na == nb:
+		return 0
+	}
+	return 1
 }

--- a/cmd/juju/storage/listformatters.go
+++ b/cmd/juju/storage/listformatters.go
@@ -70,7 +70,7 @@ func formatListTabular(value interface{}) ([]byte, error) {
 	for unit := range byUnit {
 		units = append(units, unit)
 	}
-	sort.Strings(bySuffixNaturally(units))
+	sort.Strings(slashSeparatedIds(units))
 
 	for _, unit := range units {
 		// Then sort by storage ids
@@ -79,7 +79,7 @@ func formatListTabular(value interface{}) ([]byte, error) {
 		for storageId := range byStorage {
 			storageIds = append(storageIds, storageId)
 		}
-		sort.Strings(bySuffixNaturally(storageIds))
+		sort.Strings(slashSeparatedIds(storageIds))
 
 		for _, storageId := range storageIds {
 			info := byStorage[storageId]
@@ -100,24 +100,24 @@ type storageAttachmentInfo struct {
 	status     EntityStatus
 }
 
-type bySuffixNaturally []string
+type slashSeparatedIds []string
 
-func (s bySuffixNaturally) Len() int {
+func (s slashSeparatedIds) Len() int {
 	return len(s)
 }
 
-func (s bySuffixNaturally) Swap(a, b int) {
+func (s slashSeparatedIds) Swap(a, b int) {
 	s[a], s[b] = s[b], s[a]
 }
 
-func (s bySuffixNaturally) Less(a, b int) bool {
-	return naturalCompare(s[a], s[b]) == -1
+func (s slashSeparatedIds) Less(a, b int) bool {
+	return compareSlashSeparated(s[a], s[b]) == -1
 }
 
-// naturalCompares a with b, first the string before "/",
-// and then the integer or string after. Empty strings
-// are sorted after all others.
-func naturalCompare(a, b string) int {
+// compareSlashSeparated compares a with b, first the string before
+// "/", and then the integer or string after. Empty strings are sorted
+// after all others.
+func compareSlashSeparated(a, b string) int {
 	switch {
 	case a == "" && b == "":
 		return 0

--- a/cmd/juju/storage/listformatters.go
+++ b/cmd/juju/storage/listformatters.go
@@ -146,11 +146,11 @@ func compareSlashSeparated(a, b string) int {
 
 	naIsNumeric, na := getInt(sa[1])
 	if !naIsNumeric {
-		return strings.Compare(sa[1], sb[1])
+		return compareStrings(sa[1], sb[1])
 	}
 	nbIsNumeric, nb := getInt(sb[1])
 	if !nbIsNumeric {
-		return strings.Compare(sa[1], sb[1])
+		return compareStrings(sa[1], sb[1])
 	}
 
 	switch {
@@ -158,6 +158,18 @@ func compareSlashSeparated(a, b string) int {
 		return -1
 	case na == nb:
 		return 0
+	}
+	return 1
+}
+
+// compareStrings does what strings.Compare does, but without using
+// strings.Compare as it does not exist in Go 1.2.
+func compareStrings(a, b string) int {
+	if a == b {
+		return 0
+	}
+	if a < b {
+		return -1
 	}
 	return 1
 }

--- a/cmd/juju/storage/show.go
+++ b/cmd/juju/storage/show.go
@@ -78,15 +78,17 @@ func (c *ShowCommand) Run(ctx *cmd.Context) (err error) {
 	}
 
 	var errs params.ErrorResults
-	var valid []params.LegacyStorageDetails
+	var valid []params.StorageDetails
 	for _, result := range results {
 		if result.Error != nil {
 			errs.Results = append(errs.Results, params.ErrorResult{result.Error})
 			continue
 		}
-		// TODO(axw) use non-legacy if available,
-		// convert from legacy otherwise.
-		valid = append(valid, result.Legacy)
+		if result.Result != nil {
+			valid = append(valid, *result.Result)
+		} else {
+			valid = append(valid, storageDetailsFromLegacy(result.Legacy))
+		}
 	}
 	if len(errs.Results) > 0 {
 		return errs.Combine()

--- a/cmd/juju/storage/show_test.go
+++ b/cmd/juju/storage/show_test.go
@@ -5,6 +5,7 @@ package storage_test
 
 import (
 	"strings"
+	"time"
 
 	"github.com/juju/cmd"
 	"github.com/juju/names"
@@ -17,6 +18,11 @@ import (
 	_ "github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/testing"
 )
+
+// epoch is the time we use for "since" in statuses. The time
+// is always shown as a local time, so we override the local
+// location to be UTC+8.
+var epoch = time.Unix(0, 0)
 
 type ShowSuite struct {
 	SubStorageSuite
@@ -32,6 +38,7 @@ func (s *ShowSuite) SetUpTest(c *gc.C) {
 	s.PatchValue(storage.GetStorageShowAPI, func(c *storage.ShowCommand) (storage.StorageShowAPI, error) {
 		return s.mockAPI, nil
 	})
+	s.PatchValue(&time.Local, time.FixedZone("Australia/Perth", 3600*8))
 
 }
 
@@ -56,19 +63,20 @@ func (s *ShowSuite) TestShow(c *gc.C) {
 		[]string{"shared-fs/0"},
 		// Default format is yaml
 		`
-postgresql/0:
-  shared-fs/0:
-    storage: shared-fs
-    kind: block
-    status: pending
-    persistent: false
-transcode/0:
-  shared-fs/0:
-    storage: shared-fs
-    kind: filesystem
-    status: attached
-    persistent: false
-    location: a location
+shared-fs/0:
+  kind: filesystem
+  status:
+    current: attached
+    since: 01 Jan 1970 08:00:00\+08:00
+  persistent: true
+  attachments:
+    units:
+      transcode/0:
+        machine: \"1\"
+        location: a location
+      transcode/1:
+        machine: \"2\"
+        location: b location
 `[1:],
 	)
 }
@@ -82,7 +90,7 @@ func (s *ShowSuite) TestShowJSON(c *gc.C) {
 	s.assertValidShow(
 		c,
 		[]string{"shared-fs/0", "--format", "json"},
-		`{"postgresql/0":{"shared-fs/0":{"storage":"shared-fs","kind":"block","status":"pending","persistent":false}},"transcode/0":{"shared-fs/0":{"storage":"shared-fs","kind":"filesystem","status":"attached","persistent":false,"location":"a location"}}}
+		`{"shared-fs/0":{"kind":"filesystem","status":{"current":"attached","since":"01 Jan 1970 08:00:00\+08:00"},"persistent":true,"attachments":{"units":{"transcode/0":{"machine":"1","location":"a location"},"transcode/1":{"machine":"2","location":"b location"}}}}}
 `,
 	)
 }
@@ -92,24 +100,29 @@ func (s *ShowSuite) TestShowMultipleReturn(c *gc.C) {
 		c,
 		[]string{"shared-fs/0", "db-dir/1000"},
 		`
-postgresql/0:
-  db-dir/1000:
-    storage: db-dir
-    kind: block
-    status: pending
-    persistent: true
-  shared-fs/0:
-    storage: shared-fs
-    kind: block
-    status: pending
-    persistent: false
-transcode/0:
-  shared-fs/0:
-    storage: shared-fs
-    kind: filesystem
-    status: attached
-    persistent: false
-    location: a location
+db-dir/1000:
+  kind: block
+  status:
+    current: pending
+    since: .*
+  persistent: true
+  attachments:
+    units:
+      postgresql/0: {}
+shared-fs/0:
+  kind: filesystem
+  status:
+    current: attached
+    since: 01 Jan 1970 08:00:00\+08:00
+  persistent: true
+  attachments:
+    units:
+      transcode/0:
+        machine: \"1\"
+        location: a location
+      transcode/1:
+        machine: \"2\"
+        location: b location
 `[1:],
 	)
 }
@@ -119,7 +132,7 @@ func (s *ShowSuite) assertValidShow(c *gc.C, args []string, expected string) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	obtained := testing.Stdout(context)
-	c.Assert(obtained, gc.Equals, expected)
+	c.Assert(obtained, gc.Matches, expected)
 }
 
 type mockShowAPI struct {
@@ -136,28 +149,37 @@ func (s mockShowAPI) Show(tags []names.StorageTag) ([]params.StorageDetailsResul
 	}
 	all := make([]params.StorageDetailsResult, len(tags))
 	for i, tag := range tags {
-		all[i].Legacy = params.LegacyStorageDetails{
-			StorageTag: tag.String(),
-			UnitTag:    "unit-postgresql-0",
-			Kind:       params.StorageKindBlock,
-			Status:     "pending",
-		}
-		if i == 1 {
-			all[i].Legacy.Persistent = true
-		}
-	}
-	for _, tag := range tags {
 		if strings.Contains(tag.String(), "shared") {
-			all = append(all, params.StorageDetailsResult{
-				Legacy: params.LegacyStorageDetails{
-					StorageTag: tag.String(),
-					OwnerTag:   "unit-transcode-0",
-					UnitTag:    "unit-transcode-0",
-					Kind:       params.StorageKindFilesystem,
-					Location:   "a location",
-					Status:     "attached",
+			all[i].Result = &params.StorageDetails{
+				StorageTag: tag.String(),
+				OwnerTag:   "service-transcode",
+				Kind:       params.StorageKindFilesystem,
+				Status: params.EntityStatus{
+					Status: "attached",
+					Since:  &epoch,
 				},
-			})
+				Persistent: true,
+				Attachments: map[string]params.StorageAttachmentDetails{
+					"unit-transcode-0": params.StorageAttachmentDetails{
+						MachineTag: "machine-1",
+						Location:   "a location",
+					},
+					"unit-transcode-1": params.StorageAttachmentDetails{
+						MachineTag: "machine-2",
+						Location:   "b location",
+					},
+				},
+			}
+		} else {
+			all[i].Legacy = params.LegacyStorageDetails{
+				StorageTag: tag.String(),
+				UnitTag:    "unit-postgresql-0",
+				Kind:       params.StorageKindBlock,
+				Status:     "pending",
+			}
+			if i == 1 {
+				all[i].Legacy.Persistent = true
+			}
 		}
 	}
 	return all, nil

--- a/cmd/juju/storage/show_test.go
+++ b/cmd/juju/storage/show_test.go
@@ -130,31 +130,33 @@ func (s mockShowAPI) Close() error {
 	return nil
 }
 
-func (s mockShowAPI) Show(tags []names.StorageTag) ([]params.StorageDetails, error) {
+func (s mockShowAPI) Show(tags []names.StorageTag) ([]params.StorageDetailsResult, error) {
 	if s.noMatch {
 		return nil, nil
 	}
-	all := make([]params.StorageDetails, len(tags))
+	all := make([]params.StorageDetailsResult, len(tags))
 	for i, tag := range tags {
-		all[i] = params.StorageDetails{
+		all[i].Legacy = params.LegacyStorageDetails{
 			StorageTag: tag.String(),
 			UnitTag:    "unit-postgresql-0",
 			Kind:       params.StorageKindBlock,
 			Status:     "pending",
 		}
 		if i == 1 {
-			all[i].Persistent = true
+			all[i].Legacy.Persistent = true
 		}
 	}
 	for _, tag := range tags {
 		if strings.Contains(tag.String(), "shared") {
-			all = append(all, params.StorageDetails{
-				StorageTag: tag.String(),
-				OwnerTag:   "unit-transcode-0",
-				UnitTag:    "unit-transcode-0",
-				Kind:       params.StorageKindFilesystem,
-				Location:   "a location",
-				Status:     "attached",
+			all = append(all, params.StorageDetailsResult{
+				Legacy: params.LegacyStorageDetails{
+					StorageTag: tag.String(),
+					OwnerTag:   "unit-transcode-0",
+					UnitTag:    "unit-transcode-0",
+					Kind:       params.StorageKindFilesystem,
+					Location:   "a location",
+					Status:     "attached",
+				},
 			})
 		}
 	}

--- a/cmd/juju/storage/storage.go
+++ b/cmd/juju/storage/storage.go
@@ -70,9 +70,9 @@ type StorageInfo struct {
 	Location    string `yaml:"location,omitempty" json:"location,omitempty"`
 }
 
-// formatStorageDetails takes a set of StorageDetail and creates a
+// formatStorageDetails takes a set of LegacyStorageDetail and creates a
 // mapping keyed on unit and storage id.
-func formatStorageDetails(storages []params.StorageDetails) (map[string]map[string]StorageInfo, error) {
+func formatStorageDetails(storages []params.LegacyStorageDetails) (map[string]map[string]StorageInfo, error) {
 	if len(storages) == 0 {
 		return nil, nil
 	}

--- a/cmd/juju/storage/storage.go
+++ b/cmd/juju/storage/storage.go
@@ -7,6 +7,8 @@
 package storage
 
 import (
+	"time"
+
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
@@ -15,6 +17,7 @@ import (
 	"github.com/juju/juju/api/storage"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/envcmd"
+	"github.com/juju/juju/cmd/juju/common"
 )
 
 var logger = loggo.GetLogger("juju.cmd.juju.storage")
@@ -63,48 +66,105 @@ func (c *StorageCommandBase) NewStorageAPI() (*storage.Client, error) {
 
 // StorageInfo defines the serialization behaviour of the storage information.
 type StorageInfo struct {
-	StorageName string `yaml:"storage" json:"storage"`
-	Kind        string `yaml:"kind" json:"kind"`
-	Status      string `yaml:"status,omitempty" json:"status,omitempty"`
-	Persistent  bool   `yaml:"persistent" json:"persistent"`
-	Location    string `yaml:"location,omitempty" json:"location,omitempty"`
+	Kind        string              `yaml:"kind" json:"kind"`
+	Status      EntityStatus        `yaml:"status" json:"status"`
+	Persistent  bool                `yaml:"persistent" json:"persistent"`
+	Attachments *StorageAttachments `yaml:"attachments" json:"attachments"`
 }
 
-// formatStorageDetails takes a set of LegacyStorageDetail and creates a
-// mapping keyed on unit and storage id.
-func formatStorageDetails(storages []params.LegacyStorageDetails) (map[string]map[string]StorageInfo, error) {
+// StorageAttachments contains details about all attachments to a storage
+// instance.
+type StorageAttachments struct {
+	// Units is a mapping from unit ID to unit storage attachment details.
+	Units map[string]UnitStorageAttachment `yaml:"units" json:"units"`
+}
+
+// UnitStorageAttachment contains details of a unit storage attachment.
+type UnitStorageAttachment struct {
+	// MachineId is the ID of the machine that the unit is assigned to.
+	//
+	// This is omitempty to cater for legacy results, where the machine
+	// information is not available.
+	MachineId string `yaml:"machine,omitempty" json:"machine,omitempty"`
+
+	// Location is the location of the storage attachment.
+	Location string `yaml:"location,omitempty" json:"location,omitempty"`
+}
+
+// formatStorageDetails takes a set of StorageDetail and
+// creates a mapping from storage ID to storage details.
+func formatStorageDetails(storages []params.StorageDetails) (map[string]StorageInfo, error) {
 	if len(storages) == 0 {
 		return nil, nil
 	}
-	output := make(map[string]map[string]StorageInfo)
-	for _, one := range storages {
-		storageTag, err := names.ParseStorageTag(one.StorageTag)
+	output := make(map[string]StorageInfo)
+	for _, details := range storages {
+		storageTag, err := names.ParseStorageTag(details.StorageTag)
 		if err != nil {
 			return nil, errors.Annotate(err, "invalid storage tag")
 		}
-		unitTag, err := names.ParseTag(one.UnitTag)
-		if err != nil {
-			return nil, errors.Annotate(err, "invalid unit tag")
+
+		info := StorageInfo{
+			Kind: details.Kind.String(),
+			Status: EntityStatus{
+				details.Status.Status,
+				details.Status.Info,
+				// TODO(axw) we should support formatting as ISO time
+				common.FormatTime(details.Status.Since, false),
+			},
+			Persistent: details.Persistent,
 		}
 
-		storageName, err := names.StorageName(storageTag.Id())
-		if err != nil {
-			panic(err) // impossible
+		if len(details.Attachments) > 0 {
+			unitStorageAttachments := make(map[string]UnitStorageAttachment)
+			for unitTagString, attachmentDetails := range details.Attachments {
+				unitTag, err := names.ParseUnitTag(unitTagString)
+				if err != nil {
+					return nil, errors.Trace(err)
+				}
+				var machineId string
+				if attachmentDetails.MachineTag != "" {
+					machineTag, err := names.ParseMachineTag(attachmentDetails.MachineTag)
+					if err != nil {
+						return nil, errors.Trace(err)
+					}
+					machineId = machineTag.Id()
+				}
+				unitStorageAttachments[unitTag.Id()] = UnitStorageAttachment{
+					machineId,
+					attachmentDetails.Location,
+				}
+			}
+			info.Attachments = &StorageAttachments{unitStorageAttachments}
 		}
-		si := StorageInfo{
-			StorageName: storageName,
-			Kind:        one.Kind.String(),
-			Status:      one.Status,
-			Location:    one.Location,
-			Persistent:  one.Persistent,
-		}
-		unit := unitTag.Id()
-		unitColl, ok := output[unit]
-		if !ok {
-			unitColl = map[string]StorageInfo{}
-			output[unit] = unitColl
-		}
-		unitColl[storageTag.Id()] = si
+
+		output[storageTag.Id()] = info
 	}
 	return output, nil
+}
+
+func storageDetailsFromLegacy(legacy params.LegacyStorageDetails) params.StorageDetails {
+	nowUTC := time.Now().UTC()
+	details := params.StorageDetails{
+		legacy.StorageTag,
+		legacy.OwnerTag,
+		legacy.Kind,
+		params.EntityStatus{
+			Status: params.Status(legacy.Status),
+			Since:  &nowUTC,
+		},
+		legacy.Persistent,
+		nil,
+	}
+	if legacy.UnitTag != "" {
+		details.Attachments = map[string]params.StorageAttachmentDetails{
+			legacy.UnitTag: params.StorageAttachmentDetails{
+				legacy.StorageTag,
+				legacy.UnitTag,
+				"", // machine is unknown in legacy
+				legacy.Location,
+			},
+		}
+	}
+	return details
 }

--- a/cmd/juju/storage/volumelist.go
+++ b/cmd/juju/storage/volumelist.go
@@ -83,9 +83,18 @@ func (c *VolumeListCommand) Run(ctx *cmd.Context) (err error) {
 	if len(valid) == 0 {
 		return nil
 	}
-	output, err := convertToVolumeInfo(valid)
+
+	info, err := convertToVolumeInfo(valid)
 	if err != nil {
 		return err
+	}
+
+	var output interface{}
+	switch c.out.Name() {
+	case "json", "yaml":
+		output = map[string]map[string]VolumeInfo{"volumes": info}
+	default:
+		output = info
 	}
 	return c.out.Write(ctx, output)
 }

--- a/cmd/juju/storage/volumelist_test.go
+++ b/cmd/juju/storage/volumelist_test.go
@@ -4,18 +4,15 @@
 package storage_test
 
 import (
-	"bytes"
 	"encoding/json"
 	"time"
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
-	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	goyaml "gopkg.in/yaml.v1"
 
-	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/envcmd"
 	"github.com/juju/juju/cmd/juju/storage"
@@ -32,7 +29,7 @@ var _ = gc.Suite(&volumeListSuite{})
 func (s *volumeListSuite) SetUpTest(c *gc.C) {
 	s.SubStorageSuite.SetUpTest(c)
 
-	s.mockAPI = &mockVolumeListAPI{fillDeviceName: true, addErrItem: true}
+	s.mockAPI = &mockVolumeListAPI{}
 	s.PatchValue(storage.GetVolumeListAPI,
 		func(c *storage.VolumeListCommand) (storage.VolumeListAPI, error) {
 			return s.mockAPI, nil
@@ -40,47 +37,46 @@ func (s *volumeListSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *volumeListSuite) TestVolumeListEmpty(c *gc.C) {
-	s.mockAPI.listEmpty = true
+	s.mockAPI.listVolumes = func([]string) ([]params.VolumeDetailsResult, error) {
+		return nil, nil
+	}
 	s.assertValidList(
 		c,
 		[]string{"--format", "yaml"},
-		"",
 		"",
 	)
 }
 
 func (s *volumeListSuite) TestVolumeListError(c *gc.C) {
-	s.mockAPI.errOut = "just my luck"
-
+	s.mockAPI.listVolumes = func([]string) ([]params.VolumeDetailsResult, error) {
+		return nil, errors.New("just my luck")
+	}
 	context, err := runVolumeList(c, "--format", "yaml")
-	c.Assert(errors.Cause(err), gc.ErrorMatches, s.mockAPI.errOut)
+	c.Assert(errors.Cause(err), gc.ErrorMatches, "just my luck")
 	s.assertUserFacingOutput(c, context, "", "")
 }
 
-func (s *volumeListSuite) TestVolumeListAll(c *gc.C) {
-	s.mockAPI.listAll = true
-	s.assertUnmarshalledOutput(
+func (s *volumeListSuite) TestVolumeListArgs(c *gc.C) {
+	var called bool
+	expectedArgs := []string{"a", "b", "c"}
+	s.mockAPI.listVolumes = func(arg []string) ([]params.VolumeDetailsResult, error) {
+		c.Assert(arg, jc.DeepEquals, expectedArgs)
+		called = true
+		return nil, nil
+	}
+	s.assertValidList(
 		c,
-		goyaml.Unmarshal,
-		// mock will ignore any value here, as listAll flag above has precedence
+		append([]string{"--format", "yaml"}, expectedArgs...),
 		"",
-		"--format", "yaml")
+	)
+	c.Assert(called, jc.IsTrue)
 }
 
 func (s *volumeListSuite) TestVolumeListYaml(c *gc.C) {
 	s.assertUnmarshalledOutput(
 		c,
 		goyaml.Unmarshal,
-		"2",
-		"--format", "yaml")
-}
-
-func (s *volumeListSuite) TestVolumeListYamlNoDeviceName(c *gc.C) {
-	s.mockAPI.fillDeviceName = false
-	s.assertUnmarshalledOutput(
-		c,
-		goyaml.Unmarshal,
-		"2",
+		"", // no error
 		"--format", "yaml")
 }
 
@@ -88,98 +84,80 @@ func (s *volumeListSuite) TestVolumeListJSON(c *gc.C) {
 	s.assertUnmarshalledOutput(
 		c,
 		json.Unmarshal,
-		"2",
+		"", // no error
 		"--format", "json")
+}
+
+func (s *volumeListSuite) TestVolumeListWithErrorResults(c *gc.C) {
+	s.mockAPI.listVolumes = func([]string) ([]params.VolumeDetailsResult, error) {
+		results, _ := mockVolumeListAPI{}.ListVolumes(nil)
+		results = append(results, params.VolumeDetailsResult{
+			Error: &params.Error{Message: "bad"},
+		})
+		results = append(results, params.VolumeDetailsResult{
+			Error: &params.Error{Message: "ness"},
+		})
+		return results, nil
+	}
+	// we should see the error in stderr, but it should not
+	// otherwise affect the rendering of valid results.
+	s.assertUnmarshalledOutput(c, json.Unmarshal, "bad\nness\n", "--format", "json")
+	s.assertUnmarshalledOutput(c, goyaml.Unmarshal, "bad\nness\n", "--format", "yaml")
 }
 
 func (s *volumeListSuite) TestVolumeListTabular(c *gc.C) {
 	s.assertValidList(
 		c,
-		[]string{"2"},
-		// Default format is tabular
+		[]string{}, // ignored by default mock
 		`
-MACHINE  UNIT          STORAGE      DEVICE      VOLUME      ID                            SIZE    STATE      MESSAGE
-2        postgresql/0  shared-fs/0  testdevice  0/1         provider-supplied-0/1         1.0GiB  attaching  failed to attach
-2        unattached    shared-fs/0  testdevice  0/abc/0/88  provider-supplied-0/abc/0/88  1.0GiB  attached   
+MACHINE  UNIT         STORAGE      ID  PROVIDER-ID                 DEVICE      SIZE    STATE       MESSAGE
+0        abc/0        db-dir/1000  0   provider-supplied-volume-0  testdevice  1.0GiB  destroying  
+0        transcode/0  shared-fs/0  3   provider-supplied-volume-3  loop0       1.0GiB  attached    
+0                                  1   provider-supplied-volume-1              2.0GiB  attaching   failed to attach, will retry
+1        transcode/1  shared-fs/0  3   provider-supplied-volume-3  loop1       1.0GiB  attached    
+1                                  2                                           42MiB   pending     
 
-`[1:],
-		`
-volume item error
-`[1:],
-	)
-}
-
-func (s *volumeListSuite) TestVolumeListTabularSort(c *gc.C) {
-	s.assertValidList(
-		c,
-		[]string{"2", "3"},
-		// Default format is tabular
-		`
-MACHINE  UNIT          STORAGE      DEVICE      VOLUME      ID                            SIZE    STATE      MESSAGE
-2        postgresql/0  shared-fs/0  testdevice  0/1         provider-supplied-0/1         1.0GiB  attaching  failed to attach
-2        unattached    shared-fs/0  testdevice  0/abc/0/88  provider-supplied-0/abc/0/88  1.0GiB  attached   
-3        postgresql/0  shared-fs/0  testdevice  0/1         provider-supplied-0/1         1.0GiB  attaching  failed to attach
-3        unattached    shared-fs/0  testdevice  0/abc/0/88  provider-supplied-0/abc/0/88  1.0GiB  attached   
-
-`[1:],
-		`
-volume item error
-`[1:],
-	)
-}
-
-func (s *volumeListSuite) TestVolumeListTabularSortWithUnattached(c *gc.C) {
-	s.mockAPI.listAll = true
-	s.assertValidList(
-		c,
-		[]string{"2", "3"},
-		// Default format is tabular
-		`
-MACHINE     UNIT          STORAGE      DEVICE      VOLUME      ID                            SIZE    STATE       MESSAGE
-25          postgresql/0  shared-fs/0  testdevice  0/1         provider-supplied-0/1         1.0GiB  attaching   failed to attach
-25          unattached    shared-fs/0  testdevice  0/abc/0/88  provider-supplied-0/abc/0/88  1.0GiB  attached    
-42          postgresql/0  shared-fs/0  testdevice  0/1         provider-supplied-0/1         1.0GiB  attaching   failed to attach
-42          unattached    shared-fs/0  testdevice  0/abc/0/88  provider-supplied-0/abc/0/88  1.0GiB  attached    
-unattached  abc/0         db-dir/1000              3/4         provider-supplied-3/4         1.0GiB  destroying  
-unattached  unattached    unassigned               3/3         provider-supplied-3/3         1.0GiB  destroying  
-
-`[1:],
-		`
-volume item error
-`[1:],
-	)
-}
-
-func (s *volumeListSuite) assertUnmarshalledOutput(c *gc.C, unmarshall unmarshaller, machine string, args ...string) {
-	all := []string{machine}
-	context, err := runVolumeList(c, append(all, args...)...)
-	c.Assert(err, jc.ErrorIsNil)
-	var result map[string]map[string]map[string]storage.VolumeInfo
-	err = unmarshall(context.Stdout.(*bytes.Buffer).Bytes(), &result)
-	c.Assert(err, jc.ErrorIsNil)
-	expected := s.expect(c, []string{machine})
-	c.Assert(result, jc.DeepEquals, expected)
-
-	obtainedErr := testing.Stderr(context)
-	c.Assert(obtainedErr, gc.Equals, `
-volume item error
 `[1:])
 }
 
-func (s *volumeListSuite) expect(c *gc.C, machines []string) map[string]map[string]map[string]storage.VolumeInfo {
-	//no need for this element as we are building output on out stream not err
-	s.mockAPI.addErrItem = false
+func (s *volumeListSuite) assertUnmarshalledOutput(c *gc.C, unmarshal unmarshaller, expectedErr string, args ...string) {
+	context, err := runVolumeList(c, args...)
+	c.Assert(err, jc.ErrorIsNil)
+
+	var result struct {
+		Volumes map[string]storage.VolumeInfo
+	}
+	err = unmarshal([]byte(testing.Stdout(context)), &result)
+	c.Assert(err, jc.ErrorIsNil)
+
+	expected := s.expect(c, nil)
+	c.Assert(result.Volumes, jc.DeepEquals, expected)
+
+	obtainedErr := testing.Stderr(context)
+	c.Assert(obtainedErr, gc.Equals, expectedErr)
+}
+
+// expect returns the VolumeInfo mapping we should expect to unmarshal
+// from rendered YAML or JSON.
+func (s *volumeListSuite) expect(c *gc.C, machines []string) map[string]storage.VolumeInfo {
 	all, err := s.mockAPI.ListVolumes(machines)
 	c.Assert(err, jc.ErrorIsNil)
-	result, err := storage.ConvertToVolumeInfo(all)
+
+	var valid []params.VolumeDetailsResult
+	for _, result := range all {
+		if result.Error == nil {
+			valid = append(valid, result)
+		}
+	}
+	result, err := storage.ConvertToVolumeInfo(valid)
 	c.Assert(err, jc.ErrorIsNil)
 	return result
 }
 
-func (s *volumeListSuite) assertValidList(c *gc.C, args []string, expectedOut, expectedErr string) {
+func (s *volumeListSuite) assertValidList(c *gc.C, args []string, expectedOut string) {
 	context, err := runVolumeList(c, args...)
 	c.Assert(err, jc.ErrorIsNil)
-	s.assertUserFacingOutput(c, context, expectedOut, expectedErr)
+	s.assertUserFacingOutput(c, context, expectedOut, "")
 }
 
 func runVolumeList(c *gc.C, args ...string) (*cmd.Context, error) {
@@ -197,8 +175,7 @@ func (s *volumeListSuite) assertUserFacingOutput(c *gc.C, context *cmd.Context, 
 }
 
 type mockVolumeListAPI struct {
-	listAll, listEmpty, fillDeviceName, addErrItem bool
-	errOut                                         string
+	listVolumes func([]string) ([]params.VolumeDetailsResult, error)
 }
 
 func (s mockVolumeListAPI) Close() error {
@@ -206,82 +183,106 @@ func (s mockVolumeListAPI) Close() error {
 }
 
 func (s mockVolumeListAPI) ListVolumes(machines []string) ([]params.VolumeDetailsResult, error) {
-	if s.errOut != "" {
-		return nil, errors.New(s.errOut)
+	if s.listVolumes != nil {
+		return s.listVolumes(machines)
 	}
-	if s.listEmpty {
-		return nil, nil
-	}
-	result := []params.VolumeDetailsResult{}
-	if s.addErrItem {
-		result = append(result, params.VolumeDetailsResult{
-			Error: common.ServerError(errors.New("volume item error"))})
-	}
-	if s.listAll {
-		machines = []string{"25", "42"}
-		//unattached
-		result = append(result, s.createTestVolumeDetailsResult(
-			"3/4", true, "db-dir/1000", "abc/0", nil,
-			createTestStatus(params.StatusDestroying, ""),
-		))
-		result = append(result, s.createTestVolumeDetailsResult(
-			"3/3", false, "", "", nil,
-			createTestStatus(params.StatusDestroying, ""),
-		))
-	}
-	result = append(result, s.createTestVolumeDetailsResult(
-		"0/1", true, "shared-fs/0", "postgresql/0", machines,
-		createTestStatus(params.StatusAttaching, "failed to attach"),
-	))
-	result = append(result, s.createTestVolumeDetailsResult(
-		"0/abc/0/88", false, "shared-fs/0", "", machines,
-		createTestStatus(params.StatusAttached, ""),
-	))
-	return result, nil
-}
-
-func (s mockVolumeListAPI) createTestVolumeDetailsResult(
-	id string,
-	persistent bool,
-	storageid, unitid string,
-	machines []string,
-	status params.EntityStatus,
-) params.VolumeDetailsResult {
-
-	volume := s.createTestVolume(id, persistent, storageid, unitid, status)
-	volume.MachineAttachments = make(map[string]params.VolumeAttachmentInfo)
-	for i, machine := range machines {
-		info := params.VolumeAttachmentInfo{
-			ReadOnly: i%2 == 0,
-		}
-		if s.fillDeviceName {
-			info.DeviceName = "testdevice"
-		}
-		machineTag := names.NewMachineTag(machine).String()
-		volume.MachineAttachments[machineTag] = info
-	}
-	return params.VolumeDetailsResult{Details: volume}
-}
-
-func (s mockVolumeListAPI) createTestVolume(id string, persistent bool, storageid, unitid string, status params.EntityStatus) *params.VolumeDetails {
-	tag := names.NewVolumeTag(id)
-	result := &params.VolumeDetails{
-		VolumeTag: tag.String(),
-		Info: params.VolumeInfo{
-			VolumeId:   "provider-supplied-" + tag.Id(),
-			HardwareId: "serial blah blah",
-			Persistent: persistent,
-			Size:       uint64(1024),
+	results := []params.VolumeDetailsResult{{
+		// volume 0 is attached to machine 0, assigned to
+		// storage db-dir/1000, which is attached to unit
+		// abc/0.
+		//
+		// Use Legacy and LegacyAttachment here to test
+		// backwards compatibility.
+		LegacyVolume: &params.LegacyVolumeDetails{
+			VolumeTag:  "volume-0",
+			StorageTag: "storage-db-dir-1000",
+			UnitTag:    "unit-abc-0",
+			VolumeId:   "provider-supplied-volume-0",
+			Size:       1024,
+			Persistent: false,
+			Status:     createTestStatus(params.StatusDestroying, ""),
 		},
-		Status: status,
-	}
-	if storageid != "" {
-		result.StorageTag = names.NewStorageTag(storageid).String()
-	}
-	if unitid != "" {
-		result.StorageOwnerTag = names.NewUnitTag(unitid).String()
-	}
-	return result
+		LegacyAttachments: []params.VolumeAttachment{{
+			VolumeTag:  "volume-0",
+			MachineTag: "machine-0",
+			Info: params.VolumeAttachmentInfo{
+				DeviceName: "testdevice",
+				ReadOnly:   true,
+			},
+		}},
+	}, {
+		// volume 1 is attaching to machine 0, but is not assigned
+		// to any storage.
+		Details: &params.VolumeDetails{
+			VolumeTag: "volume-1",
+			Info: params.VolumeInfo{
+				VolumeId:   "provider-supplied-volume-1",
+				HardwareId: "serial blah blah",
+				Persistent: true,
+				Size:       2048,
+			},
+			Status: createTestStatus(params.StatusAttaching, "failed to attach, will retry"),
+			MachineAttachments: map[string]params.VolumeAttachmentInfo{
+				"machine-0": params.VolumeAttachmentInfo{},
+			},
+		},
+	}, {
+		// volume 2 is due to be attached to machine 1, but is not
+		// assigned to any storage and has not yet been provisioned.
+		Details: &params.VolumeDetails{
+			VolumeTag: "volume-2",
+			Info: params.VolumeInfo{
+				Size: 42,
+			},
+			Status: createTestStatus(params.StatusPending, ""),
+			MachineAttachments: map[string]params.VolumeAttachmentInfo{
+				"machine-1": params.VolumeAttachmentInfo{},
+			},
+		},
+	}, {
+		// volume 3 is attached to machines 0 and 1, and is assigned
+		// to shared storage.
+		Details: &params.VolumeDetails{
+			VolumeTag: "volume-3",
+			Info: params.VolumeInfo{
+				VolumeId:   "provider-supplied-volume-3",
+				Persistent: true,
+				Size:       1024,
+			},
+			Status: createTestStatus(params.StatusAttached, ""),
+			MachineAttachments: map[string]params.VolumeAttachmentInfo{
+				"machine-0": params.VolumeAttachmentInfo{
+					DeviceName: "loop0",
+					ReadOnly:   true,
+				},
+				"machine-1": params.VolumeAttachmentInfo{
+					DeviceName: "loop1",
+					ReadOnly:   true,
+				},
+			},
+			Storage: &params.StorageDetails{
+				StorageTag: "storage-shared-fs-0",
+				OwnerTag:   "service-transcode",
+				Kind:       params.StorageKindBlock,
+				Status:     createTestStatus(params.StatusAttached, ""),
+				Attachments: map[string]params.StorageAttachmentDetails{
+					"unit-transcode-0": params.StorageAttachmentDetails{
+						StorageTag: "storage-shared-fs-0",
+						UnitTag:    "unit-transcode-0",
+						MachineTag: "machine-0",
+						Location:   "/mnt/bits",
+					},
+					"unit-transcode-1": params.StorageAttachmentDetails{
+						StorageTag: "storage-shared-fs-0",
+						UnitTag:    "unit-transcode-1",
+						MachineTag: "machine-1",
+						Location:   "/mnt/pieces",
+					},
+				},
+			},
+		},
+	}}
+	return results, nil
 }
 
 func createTestStatus(status params.Status, message string) params.EntityStatus {

--- a/cmd/juju/storage/volumelistformatters.go
+++ b/cmd/juju/storage/volumelistformatters.go
@@ -6,24 +6,24 @@ package storage
 import (
 	"bytes"
 	"fmt"
+	"sort"
 	"strings"
 	"text/tabwriter"
 
 	"github.com/dustin/go-humanize"
 	"github.com/juju/errors"
-	"github.com/juju/utils/set"
 )
 
 // formatVolumeListTabular returns a tabular summary of volume instances.
 func formatVolumeListTabular(value interface{}) ([]byte, error) {
-	infos, ok := value.(map[string]map[string]map[string]VolumeInfo)
+	infos, ok := value.(map[string]VolumeInfo)
 	if !ok {
 		return nil, errors.Errorf("expected value of type %T, got %T", infos, value)
 	}
 	return formatVolumeListTabularTyped(infos), nil
 }
 
-func formatVolumeListTabularTyped(infos map[string]map[string]map[string]VolumeInfo) []byte {
+func formatVolumeListTabularTyped(infos map[string]VolumeInfo) []byte {
 	var out bytes.Buffer
 	const (
 		// To format things into columns.
@@ -38,49 +38,98 @@ func formatVolumeListTabularTyped(infos map[string]map[string]map[string]VolumeI
 	print := func(values ...string) {
 		fmt.Fprintln(tw, strings.Join(values, "\t"))
 	}
-	print("MACHINE", "UNIT", "STORAGE", "DEVICE", "VOLUME", "ID", "SIZE", "STATE", "MESSAGE")
+	print("MACHINE", "UNIT", "STORAGE", "ID", "PROVIDER-ID", "DEVICE", "SIZE", "STATE", "MESSAGE")
 
-	// 1. sort by machines
-	machines := set.NewStrings()
-	for machine := range infos {
-		if !machines.Contains(machine) {
-			machines.Add(machine)
+	volumeAttachmentInfos := make(volumeAttachmentInfos, 0, len(infos))
+	for volumeId, info := range infos {
+		volumeAttachmentInfo := volumeAttachmentInfo{
+			VolumeId:   volumeId,
+			VolumeInfo: info,
 		}
-	}
-	for _, machine := range machines.SortedValues() {
-		machineUnits := infos[machine]
-
-		// 2. sort by unit
-		units := set.NewStrings()
-		for unit := range machineUnits {
-			if !units.Contains(unit) {
-				units.Add(unit)
-			}
+		if info.Attachments == nil {
+			volumeAttachmentInfos = append(volumeAttachmentInfos, volumeAttachmentInfo)
+			continue
 		}
-		for _, unit := range units.SortedValues() {
-			unitStorages := machineUnits[unit]
-
-			// 3. sort by storage
-			storages := set.NewStrings()
-			for storage := range unitStorages {
-				if !storages.Contains(storage) {
-					storages.Add(storage)
+		// Each unit attachment must have a corresponding volume
+		// attachment. Enumerate each of the volume attachments,
+		// and locate the corresponding unit attachment if any.
+		// Each volume attachment has at most one corresponding
+		// unit attachment.
+		for machineId, machineInfo := range info.Attachments.Machines {
+			volumeAttachmentInfo := volumeAttachmentInfo
+			volumeAttachmentInfo.MachineId = machineId
+			volumeAttachmentInfo.MachineVolumeAttachment = machineInfo
+			for unitId, unitInfo := range info.Attachments.Units {
+				if unitInfo.MachineId == machineId {
+					volumeAttachmentInfo.UnitId = unitId
+					volumeAttachmentInfo.UnitStorageAttachment = unitInfo
+					break
 				}
 			}
-			for _, storage := range storages.SortedValues() {
-				info := unitStorages[storage]
-				var size string
-				if info.Size > 0 {
-					size = humanize.IBytes(info.Size * humanize.MiByte)
-				}
-				print(
-					machine, unit, storage, info.DeviceName,
-					info.Volume, info.VolumeId, size,
-					string(info.Status.Current), info.Status.Message,
-				)
-			}
+			volumeAttachmentInfos = append(volumeAttachmentInfos, volumeAttachmentInfo)
 		}
 	}
+	sort.Sort(volumeAttachmentInfos)
+
+	for _, info := range volumeAttachmentInfos {
+		var size string
+		if info.Size > 0 {
+			size = humanize.IBytes(info.Size * humanize.MiByte)
+		}
+		print(
+			info.MachineId, info.UnitId, info.Storage,
+			info.VolumeId, info.ProviderVolumeId,
+			info.DeviceName, size,
+			string(info.Status.Current), info.Status.Message,
+		)
+	}
+
 	tw.Flush()
 	return out.Bytes()
+}
+
+type volumeAttachmentInfo struct {
+	VolumeId string
+	VolumeInfo
+
+	MachineId string
+	MachineVolumeAttachment
+
+	UnitId string
+	UnitStorageAttachment
+}
+
+type volumeAttachmentInfos []volumeAttachmentInfo
+
+func (v volumeAttachmentInfos) Len() int {
+	return len(v)
+}
+
+func (v volumeAttachmentInfos) Swap(i, j int) {
+	v[i], v[j] = v[j], v[i]
+}
+
+func (v volumeAttachmentInfos) Less(i, j int) bool {
+	switch strings.Compare(v[i].MachineId, v[j].MachineId) {
+	case -1:
+		return true
+	case 1:
+		return false
+	}
+
+	switch naturalCompare(v[i].UnitId, v[j].UnitId) {
+	case -1:
+		return true
+	case 1:
+		return false
+	}
+
+	switch naturalCompare(v[i].Storage, v[j].Storage) {
+	case -1:
+		return true
+	case 1:
+		return false
+	}
+
+	return v[i].VolumeId < v[j].VolumeId
 }

--- a/cmd/juju/storage/volumelistformatters.go
+++ b/cmd/juju/storage/volumelistformatters.go
@@ -117,14 +117,14 @@ func (v volumeAttachmentInfos) Less(i, j int) bool {
 		return false
 	}
 
-	switch naturalCompare(v[i].UnitId, v[j].UnitId) {
+	switch compareSlashSeparated(v[i].UnitId, v[j].UnitId) {
 	case -1:
 		return true
 	case 1:
 		return false
 	}
 
-	switch naturalCompare(v[i].Storage, v[j].Storage) {
+	switch compareSlashSeparated(v[i].Storage, v[j].Storage) {
 	case -1:
 		return true
 	case 1:

--- a/cmd/juju/storage/volumelistformatters.go
+++ b/cmd/juju/storage/volumelistformatters.go
@@ -110,7 +110,7 @@ func (v volumeAttachmentInfos) Swap(i, j int) {
 }
 
 func (v volumeAttachmentInfos) Less(i, j int) bool {
-	switch strings.Compare(v[i].MachineId, v[j].MachineId) {
+	switch compareStrings(v[i].MachineId, v[j].MachineId) {
 	case -1:
 		return true
 	case 1:

--- a/featuretests/storage_test.go
+++ b/featuretests/storage_test.go
@@ -85,14 +85,18 @@ func (s *cmdStorageSuite) TestStorageShow(c *gc.C) {
 
 	context := runShow(c, "data/0")
 	expected := `
-storage-block/0:
-  data/0:
-    storage: data
-    kind: block
-    status: pending
-    persistent: false
+data/0:
+  kind: block
+  status:
+    current: pending
+    since: .*
+  persistent: false
+  attachments:
+    units:
+      storage-block/0:
+        machine: "0"
 `[1:]
-	c.Assert(testing.Stdout(context), gc.Equals, expected)
+	c.Assert(testing.Stdout(context), gc.Matches, expected)
 }
 
 func (s *cmdStorageSuite) TestStorageShowOneInvalid(c *gc.C) {
@@ -125,8 +129,8 @@ func (s *cmdStorageSuite) TestStorageList(c *gc.C) {
 	context := runList(c)
 	expected := `
 [Storage]       
-UNIT            ID     LOCATION STATUS  PERSISTENT 
-storage-block/0 data/0          pending false      
+UNIT            ID     LOCATION STATUS  MESSAGE 
+storage-block/0 data/0          pending         
 
 `[1:]
 	c.Assert(testing.Stdout(context), gc.Equals, expected)
@@ -140,8 +144,8 @@ func (s *cmdStorageSuite) TestStorageListPersistent(c *gc.C) {
 	context := runList(c)
 	expected := `
 [Storage]       
-UNIT            ID     LOCATION STATUS  PERSISTENT 
-storage-block/0 data/0          pending false      
+UNIT            ID     LOCATION STATUS  MESSAGE 
+storage-block/0 data/0          pending         
 
 `[1:]
 	c.Assert(testing.Stdout(context), gc.Equals, expected)
@@ -160,14 +164,18 @@ func (s *cmdStorageSuite) TestStoragePersistentProvisioned(c *gc.C) {
 
 	context := runShow(c, "data/0")
 	expected := `
-storage-block/0:
-  data/0:
-    storage: data
-    kind: block
-    status: pending
-    persistent: true
+data/0:
+  kind: block
+  status:
+    current: pending
+    since: .*
+  persistent: true
+  attachments:
+    units:
+      storage-block/0:
+        machine: "0"
 `[1:]
-	c.Assert(testing.Stdout(context), gc.Equals, expected)
+	c.Assert(testing.Stdout(context), gc.Matches, expected)
 }
 
 func (s *cmdStorageSuite) TestStoragePersistentUnprovisioned(c *gc.C) {
@@ -177,14 +185,18 @@ func (s *cmdStorageSuite) TestStoragePersistentUnprovisioned(c *gc.C) {
 	// will be persistent until it has been provisioned.
 	context := runShow(c, "data/0")
 	expected := `
-storage-block/0:
-  data/0:
-    storage: data
-    kind: block
-    status: pending
-    persistent: false
+data/0:
+  kind: block
+  status:
+    current: pending
+    since: .*
+  persistent: false
+  attachments:
+    units:
+      storage-block/0:
+        machine: "0"
 `[1:]
-	c.Assert(testing.Stdout(context), gc.Equals, expected)
+	c.Assert(testing.Stdout(context), gc.Matches, expected)
 }
 
 func runPoolList(c *gc.C, args ...string) *cmd.Context {
@@ -455,8 +467,8 @@ func (s *cmdStorageSuite) TestStorageAddToUnitHasVolumes(c *gc.C) {
 	context := runList(c)
 	c.Assert(testing.Stdout(context), gc.Equals, `
 [Storage]            
-UNIT                 ID     LOCATION STATUS  PERSISTENT 
-storage-filesystem/0 data/0          pending false      
+UNIT                 ID     LOCATION STATUS  MESSAGE 
+storage-filesystem/0 data/0          pending         
 
 `[1:])
 	c.Assert(testing.Stderr(context), gc.Equals, "")
@@ -476,9 +488,9 @@ storage-filesystem/0 data/0          pending false
 	context = runList(c)
 	c.Assert(testing.Stdout(context), gc.Equals, `
 [Storage]            
-UNIT                 ID     LOCATION STATUS  PERSISTENT 
-storage-filesystem/0 data/0          pending false      
-storage-filesystem/0 data/1          pending false      
+UNIT                 ID     LOCATION STATUS  MESSAGE 
+storage-filesystem/0 data/0          pending         
+storage-filesystem/0 data/1          pending         
 
 `[1:])
 	c.Assert(testing.Stderr(context), gc.Equals, "")

--- a/featuretests/storage_test.go
+++ b/featuretests/storage_test.go
@@ -402,8 +402,8 @@ func (s *cmdStorageSuite) TestListVolumeTabularFilterMatch(c *gc.C) {
 	createUnitWithStorage(c, &s.JujuConnSuite, testPool)
 	context := runVolumeList(c, "0")
 	expected := `
-MACHINE  UNIT             STORAGE  DEVICE  VOLUME  ID  SIZE  STATE    MESSAGE
-0        storage-block/0  data/0           0/0               pending  
+MACHINE  UNIT             STORAGE  ID   PROVIDER-ID  DEVICE  SIZE  STATE    MESSAGE
+0        storage-block/0  data/0   0/0                             pending  
 
 `[1:]
 	c.Assert(testing.Stdout(context), gc.Equals, expected)

--- a/featuretests/storage_test.go
+++ b/featuretests/storage_test.go
@@ -95,25 +95,17 @@ storage-block/0:
 	c.Assert(testing.Stdout(context), gc.Equals, expected)
 }
 
-func (s *cmdStorageSuite) TestStorageShowOneMatchingFilter(c *gc.C) {
+func (s *cmdStorageSuite) TestStorageShowOneInvalid(c *gc.C) {
 	createUnitWithStorage(c, &s.JujuConnSuite, testPool)
 
-	context := runShow(c, "data/0", "fluff/0")
-	expected := `
-storage-block/0:
-  data/0:
-    storage: data
-    kind: block
-    status: pending
-    persistent: false
-`[1:]
-	c.Assert(testing.Stdout(context), gc.Equals, expected)
+	_, err := testing.RunCommand(c, envcmd.Wrap(&cmdstorage.ShowCommand{}), "data/0", "fluff/0")
+	c.Assert(err, gc.ErrorMatches, "storage instance \"fluff/0\" not found")
 }
 
 func (s *cmdStorageSuite) TestStorageShowNoMatch(c *gc.C) {
 	createUnitWithStorage(c, &s.JujuConnSuite, testPool)
-	context := runShow(c, "fluff/0")
-	c.Assert(testing.Stdout(context), gc.Equals, "{}\n")
+	_, err := testing.RunCommand(c, envcmd.Wrap(&cmdstorage.ShowCommand{}), "data/0", "fluff/0")
+	c.Assert(err, gc.ErrorMatches, "storage instance \"fluff/0\" not found")
 }
 
 func runList(c *gc.C) *cmd.Context {
@@ -143,6 +135,8 @@ storage-block/0 data/0          pending false
 func (s *cmdStorageSuite) TestStorageListPersistent(c *gc.C) {
 	createUnitWithStorage(c, &s.JujuConnSuite, testPool)
 
+	// There are currently no guarantees about whether storage
+	// will be persistent until it has been provisioned.
 	context := runList(c)
 	expected := `
 [Storage]       
@@ -179,6 +173,8 @@ storage-block/0:
 func (s *cmdStorageSuite) TestStoragePersistentUnprovisioned(c *gc.C) {
 	createUnitWithStorage(c, &s.JujuConnSuite, testPool)
 
+	// There are currently no guarantees about whether storage
+	// will be persistent until it has been provisioned.
 	context := runShow(c, "data/0")
 	expected := `
 storage-block/0:


### PR DESCRIPTION
Forward-port from 1.25. Simple conflicts,
so the only commit that really needs review
is the last one, which is new.

While running tests I saw weird errors being
repored by gocheck, and yet all tests supposedly
passed. Turns out that a gc.C was being used
improperly (captured in SetUpTest, used in
Asserts during test run.)

Fixes http://pad.lv/1495338

(Review request: http://reviews.vapour.ws/r/2687/)