### PR TITLE
apiserver: rationalize error handling

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -832,6 +832,7 @@ func (c *Client) UploadTools(r io.Reader, vers version.Binary, additionalSeries 
 		return nil, errors.Annotate(err, "cannot read tools upload response")
 	}
 	if resp.StatusCode != http.StatusOK {
+		// TODO (2015/09/15, bug #1499277) parse as JSON not as text.
 		message := fmt.Sprintf("%s", bytes.TrimSpace(body))
 		if resp.StatusCode == http.StatusBadRequest && strings.Contains(message, params.CodeOperationBlocked) {
 			// Operation Blocked errors must contain correct error code and message.

--- a/apiserver/backup_test.go
+++ b/apiserver/backup_test.go
@@ -52,11 +52,11 @@ func (s *baseBackupsSuite) backupURL(c *gc.C) string {
 }
 
 func (s *baseBackupsSuite) checkErrorResponse(c *gc.C, resp *http.Response, statusCode int, msg string) {
-	c.Check(resp.StatusCode, gc.Equals, statusCode)
-	c.Check(resp.Header.Get("Content-Type"), gc.Equals, apihttp.CTypeJSON)
-
 	body, err := ioutil.ReadAll(resp.Body)
 	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(resp.StatusCode, gc.Equals, statusCode, gc.Commentf("body: %s", body))
+	c.Check(resp.Header.Get("Content-Type"), gc.Equals, apihttp.CTypeJSON)
 
 	var failure params.Error
 	err = json.Unmarshal(body, &failure)

--- a/apiserver/charms_test.go
+++ b/apiserver/charms_test.go
@@ -511,10 +511,10 @@ func (s *charmsSuite) assertGetFileListResponse(c *gc.C, resp *http.Response, ex
 }
 
 func assertResponse(c *gc.C, resp *http.Response, expCode int, expContentType string) []byte {
-	c.Check(resp.StatusCode, gc.Equals, expCode)
 	body, err := ioutil.ReadAll(resp.Body)
-	defer resp.Body.Close()
+	resp.Body.Close()
 	c.Assert(err, jc.ErrorIsNil)
+	c.Check(resp.StatusCode, gc.Equals, expCode, gc.Commentf("body: %s", body))
 	ctype := resp.Header.Get("Content-Type")
 	c.Assert(ctype, gc.Equals, expContentType)
 	return body

--- a/apiserver/common/block.go
+++ b/apiserver/common/block.go
@@ -63,7 +63,7 @@ func (c *BlockChecker) checkBlock(blockType state.BlockType) error {
 		return errors.Trace(err)
 	}
 	if isEnabled {
-		return ErrOperationBlocked(aBlock.Message())
+		return OperationBlockedError(aBlock.Message())
 	}
 	return nil
 }

--- a/apiserver/common/errors.go
+++ b/apiserver/common/errors.go
@@ -76,17 +76,20 @@ var (
 	ErrBadRequest         = stderrors.New("invalid request")
 	ErrTryAgain           = stderrors.New("try again")
 	ErrActionNotAvailable = stderrors.New("action no longer available")
-
-	ErrOperationBlocked = func(msg string) *params.Error {
-		if msg == "" {
-			msg = "The operation has been blocked."
-		}
-		return &params.Error{
-			Code:    params.CodeOperationBlocked,
-			Message: msg,
-		}
-	}
 )
+
+// OperationBlockedError returns an error which signifies that
+// an operation has been blocked; the message should describe
+// what has been blocked.
+func OperationBlockedError(msg string) error {
+	if msg == "" {
+		msg = "the operation has been blocked"
+	}
+	return &params.Error{
+		Code:    params.CodeOperationBlocked,
+		Message: msg,
+	}
+}
 
 var singletonErrorCodes = map[error]string{
 	state.ErrCannotEnterScopeYet: params.CodeCannotEnterScopeYet,
@@ -134,6 +137,10 @@ func ServerErrorAndStatus(err error) (*params.Error, int) {
 		status = http.StatusBadRequest
 	case params.CodeMethodNotAllowed:
 		status = http.StatusMethodNotAllowed
+	case params.CodeOperationBlocked:
+		// This should really be http.StatusForbidden but earlier versions
+		// of juju clients rely on the 400 status, so we leave it like that.
+		status = http.StatusBadRequest
 	}
 	return err1, status
 }

--- a/apiserver/common/errors_test.go
+++ b/apiserver/common/errors_test.go
@@ -137,9 +137,9 @@ var errorTransformTests = []struct {
 	status:     http.StatusInternalServerError,
 	helperFunc: params.IsCodeLeadershipClaimDenied,
 }, {
-	err:        common.ErrOperationBlocked("test"),
+	err:        common.OperationBlockedError("test"),
 	code:       params.CodeOperationBlocked,
-	status:     http.StatusInternalServerError,
+	status:     http.StatusBadRequest,
 	helperFunc: params.IsCodeOperationBlocked,
 }, {
 	err:        errors.NotSupportedf("needed feature"),

--- a/apiserver/common/testing/block.go
+++ b/apiserver/common/testing/block.go
@@ -66,6 +66,6 @@ func (s BlockHelper) BlockDestroyEnvironment(c *gc.C, msg string) {
 // AssertBlocked checks if given error is
 // related to switched block.
 func (s BlockHelper) AssertBlocked(c *gc.C, err error, msg string) {
-	c.Assert(params.IsCodeOperationBlocked(err), jc.IsTrue)
+	c.Assert(params.IsCodeOperationBlocked(err), jc.IsTrue, gc.Commentf("error: %#v", err))
 	c.Assert(err, gc.ErrorMatches, msg)
 }

--- a/apiserver/debuglog_db.go
+++ b/apiserver/debuglog_db.go
@@ -28,9 +28,7 @@ func handleDebugLogDBRequest(
 	defer tailer.Stop()
 
 	// Indicate that all is well.
-	if err := socket.sendOk(); err != nil {
-		return errors.Trace(err)
-	}
+	socket.sendOk()
 
 	var lineCount uint
 	for {

--- a/apiserver/debuglog_db_internal_test.go
+++ b/apiserver/debuglog_db_internal_test.go
@@ -234,14 +234,12 @@ type fakeDebugLogSocket struct {
 	writes chan string
 }
 
-func (s *fakeDebugLogSocket) sendOk() error {
+func (s *fakeDebugLogSocket) sendOk() {
 	s.writes <- "ok"
-	return nil
 }
 
-func (s *fakeDebugLogSocket) sendError(err error) error {
+func (s *fakeDebugLogSocket) sendError(err error) {
 	s.writes <- fmt.Sprintf("err: %v", err)
-	return nil
 }
 
 func (s *fakeDebugLogSocket) Write(buf []byte) (int, error) {

--- a/apiserver/debuglog_file.go
+++ b/apiserver/debuglog_file.go
@@ -52,9 +52,7 @@ func (h *debugLogFileHandler) handle(
 	}
 
 	// If we get to here, no more errors to report.
-	if err := socket.sendOk(); err != nil {
-		return err
-	}
+	socket.sendOk()
 
 	stream.start(logFile, socket)
 	return stream.wait(stop)

--- a/apiserver/images.go
+++ b/apiserver/images.go
@@ -16,9 +16,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/utils/fslock"
 
-	"github.com/juju/juju/apiserver/common"
 	apihttp "github.com/juju/juju/apiserver/http"
-	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/container"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/state"
@@ -35,7 +33,7 @@ type imagesDownloadHandler struct {
 func (h *imagesDownloadHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	stateWrapper, err := h.ctxt.validateEnvironUUID(r)
 	if err != nil {
-		h.sendError(w, http.StatusNotFound, err)
+		sendError(w, err)
 		return
 	}
 	switch r.Method {
@@ -43,20 +41,12 @@ func (h *imagesDownloadHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 		err := h.processGet(r, w, stateWrapper.state)
 		if err != nil {
 			logger.Errorf("GET(%s) failed: %v", r.URL, err)
-			h.sendError(w, http.StatusInternalServerError, err)
+			sendError(w, err)
 			return
 		}
 	default:
-		h.sendError(w, http.StatusMethodNotAllowed, errors.Errorf("unsupported method: %q", r.Method))
+		sendError(w, errors.MethodNotAllowedf("unsupported method: %q", r.Method))
 	}
-}
-
-// sendError sends a JSON-encoded error response.
-func (h *imagesDownloadHandler) sendError(w http.ResponseWriter, statusCode int, err error) {
-	logger.Debugf("sending error: %v %v", statusCode, err)
-	h.ctxt.sendJSON(w, statusCode, &params.ErrorResult{
-		Error: common.ServerError(err),
-	})
 }
 
 // processGet handles an image GET request.

--- a/apiserver/systemmanager/systemmanager.go
+++ b/apiserver/systemmanager/systemmanager.go
@@ -203,7 +203,7 @@ func (s *SystemManagerAPI) DestroySystem(args params.DestroySystemArgs) error {
 	}
 	if len(blocks) > 0 {
 		if !args.IgnoreBlocks {
-			return common.ErrOperationBlocked("found blocks in system environments")
+			return common.OperationBlockedError("found blocks in system environments")
 		}
 
 		err := s.state.RemoveAllBlocksForSystem()

--- a/cmd/juju/block/block_test.go
+++ b/cmd/juju/block/block_test.go
@@ -85,8 +85,8 @@ func (s *BlockCommandSuite) processErrorTest(c *gc.C, tstError error, blockType 
 }
 
 func (s *BlockCommandSuite) TestProcessErrOperationBlocked(c *gc.C) {
-	s.processErrorTest(c, common.ErrOperationBlocked("operations that remove"), block.BlockRemove, cmd.ErrSilent, ".*operations that remove.*")
-	s.processErrorTest(c, common.ErrOperationBlocked("destroy-environment operation has been blocked"), block.BlockDestroy, cmd.ErrSilent, ".*destroy-environment operation has been blocked.*")
+	s.processErrorTest(c, common.OperationBlockedError("operations that remove"), block.BlockRemove, cmd.ErrSilent, ".*operations that remove.*")
+	s.processErrorTest(c, common.OperationBlockedError("destroy-environment operation has been blocked"), block.BlockDestroy, cmd.ErrSilent, ".*destroy-environment operation has been blocked.*")
 }
 
 func (s *BlockCommandSuite) TestProcessErrNil(c *gc.C) {

--- a/cmd/juju/commands/ensureavailability_test.go
+++ b/cmd/juju/commands/ensureavailability_test.go
@@ -117,7 +117,7 @@ func (s *EnsureAvailabilitySuite) TestEnsureAvailability(c *gc.C) {
 }
 
 func (s *EnsureAvailabilitySuite) TestBlockEnsureAvailability(c *gc.C) {
-	s.fake.err = common.ErrOperationBlocked("TestBlockEnsureAvailability")
+	s.fake.err = common.OperationBlockedError("TestBlockEnsureAvailability")
 	_, err := s.runEnsureAvailability(c, "-n", "1")
 	c.Assert(err, gc.ErrorMatches, cmd.ErrSilent.Error())
 

--- a/cmd/juju/commands/run_test.go
+++ b/cmd/juju/commands/run_test.go
@@ -443,7 +443,7 @@ func (m *mockRunAPI) RunOnAllMachines(commands string, timeout time.Duration) ([
 	var result []params.RunResult
 
 	if m.block {
-		return result, common.ErrOperationBlocked("The operation has been blocked.")
+		return result, common.OperationBlockedError("the operation has been blocked")
 	}
 	sortedMachineIds := make([]string, 0, len(m.machines))
 	for machineId := range m.machines {
@@ -467,7 +467,7 @@ func (m *mockRunAPI) Run(runParams params.RunParams) ([]params.RunResult, error)
 	var result []params.RunResult
 
 	if m.block {
-		return result, common.ErrOperationBlocked("The operation has been blocked.")
+		return result, common.OperationBlockedError("the operation has been blocked")
 	}
 	// Just add in ids that match in order.
 	for _, id := range runParams.Machines {

--- a/cmd/juju/commands/synctools_test.go
+++ b/cmd/juju/commands/synctools_test.go
@@ -264,7 +264,7 @@ func (s *syncToolsSuite) TestAPIAdapterUploadTools(c *gc.C) {
 func (s *syncToolsSuite) TestAPIAdapterBlockUploadTools(c *gc.C) {
 	syncTools = func(sctx *sync.SyncContext) error {
 		// Block operation
-		return common.ErrOperationBlocked("TestAPIAdapterBlockUploadTools")
+		return common.OperationBlockedError("TestAPIAdapterBlockUploadTools")
 	}
 	_, err := runSyncToolsCommand(c, "-e", "test-target", "--destination", c.MkDir(), "--stream", "released")
 	c.Assert(err, gc.ErrorMatches, cmd.ErrSilent.Error())

--- a/cmd/juju/commands/upgradejuju_test.go
+++ b/cmd/juju/commands/upgradejuju_test.go
@@ -603,7 +603,7 @@ func (s *UpgradeJujuSuite) TestUpgradeInProgress(c *gc.C) {
 
 func (s *UpgradeJujuSuite) TestBlockUpgradeInProgress(c *gc.C) {
 	fakeAPI := NewFakeUpgradeJujuAPI(c, s.State)
-	fakeAPI.setVersionErr = common.ErrOperationBlocked("The operation has been blocked.")
+	fakeAPI.setVersionErr = common.OperationBlockedError("the operation has been blocked")
 	fakeAPI.patch(s)
 	cmd := &upgradeJujuCommand{}
 	err := coretesting.InitCommand(envcmd.Wrap(cmd), []string{})

--- a/cmd/juju/common/constraints_test.go
+++ b/cmd/juju/common/constraints_test.go
@@ -141,7 +141,7 @@ func (s *ConstraintsCommandsSuite) TestSetEnviron(c *gc.C) {
 
 func (s *ConstraintsCommandsSuite) TestBlockSetEnviron(c *gc.C) {
 	// Block operation
-	s.fake.err = common.ErrOperationBlocked("TestBlockSetEnviron")
+	s.fake.err = common.OperationBlockedError("TestBlockSetEnviron")
 	// Set constraints.
 	s.assertSetBlocked(c, "mem=4G", "cpu-power=250")
 }
@@ -167,7 +167,7 @@ func (s *ConstraintsCommandsSuite) TestBlockSetService(c *gc.C) {
 	s.fake.addTestingService("svc")
 
 	// Block operation
-	s.fake.err = common.ErrOperationBlocked("TestBlockSetService")
+	s.fake.err = common.OperationBlockedError("TestBlockSetService")
 	// Set constraints.
 	s.assertSetBlocked(c, "-s", "svc", "mem=4G", "cpu-power=250")
 }

--- a/cmd/juju/environment/retryprovisioning_test.go
+++ b/cmd/juju/environment/retryprovisioning_test.go
@@ -143,7 +143,7 @@ func (s *retryProvisioningSuite) TestRetryProvisioning(c *gc.C) {
 }
 
 func (s *retryProvisioningSuite) TestBlockRetryProvisioning(c *gc.C) {
-	s.fake.err = common.ErrOperationBlocked("TestBlockRetryProvisioning")
+	s.fake.err = common.OperationBlockedError("TestBlockRetryProvisioning")
 	command := environment.NewRetryProvisioningCommand(s.fake)
 
 	for i, t := range resolvedMachineTests {

--- a/cmd/juju/environment/set_test.go
+++ b/cmd/juju/environment/set_test.go
@@ -68,7 +68,7 @@ func (s *SetSuite) TestSettingKnownValue(c *gc.C) {
 }
 
 func (s *SetSuite) TestBlockedError(c *gc.C) {
-	s.fake.err = common.ErrOperationBlocked("TestBlockedError")
+	s.fake.err = common.OperationBlockedError("TestBlockedError")
 	_, err := s.run(c, "special=extra")
 	c.Assert(err, gc.Equals, cmd.ErrSilent)
 	// msg is logged

--- a/cmd/juju/environment/unset_test.go
+++ b/cmd/juju/environment/unset_test.go
@@ -50,7 +50,7 @@ func (s *UnsetSuite) TestUnsettingKnownValue(c *gc.C) {
 }
 
 func (s *UnsetSuite) TestBlockedError(c *gc.C) {
-	s.fake.err = common.ErrOperationBlocked("TestBlockedError")
+	s.fake.err = common.OperationBlockedError("TestBlockedError")
 	_, err := s.run(c, "special")
 	c.Assert(err, gc.Equals, cmd.ErrSilent)
 	// msg is logged

--- a/cmd/juju/machine/add_test.go
+++ b/cmd/juju/machine/add_test.go
@@ -181,7 +181,7 @@ failed to create 2 machines
 }
 
 func (s *AddMachineSuite) TestBlockedError(c *gc.C) {
-	s.fakeAddMachine.addError = common.ErrOperationBlocked("TestBlockedError")
+	s.fakeAddMachine.addError = common.OperationBlockedError("TestBlockedError")
 	_, err := s.run(c)
 	c.Assert(err, gc.Equals, cmd.ErrSilent)
 	// msg is logged

--- a/cmd/juju/machine/remove_test.go
+++ b/cmd/juju/machine/remove_test.go
@@ -91,7 +91,7 @@ func (s *RemoveMachineSuite) TestRemoveForce(c *gc.C) {
 }
 
 func (s *RemoveMachineSuite) TestBlockedError(c *gc.C) {
-	s.fake.removeError = common.ErrOperationBlocked("TestBlockedError")
+	s.fake.removeError = common.OperationBlockedError("TestBlockedError")
 	_, err := s.run(c, "1")
 	c.Assert(err, gc.Equals, cmd.ErrSilent)
 	c.Assert(s.fake.forced, jc.IsFalse)
@@ -101,7 +101,7 @@ func (s *RemoveMachineSuite) TestBlockedError(c *gc.C) {
 }
 
 func (s *RemoveMachineSuite) TestForceBlockedError(c *gc.C) {
-	s.fake.removeError = common.ErrOperationBlocked("TestForceBlockedError")
+	s.fake.removeError = common.OperationBlockedError("TestForceBlockedError")
 	_, err := s.run(c, "--force", "1")
 	c.Assert(err, gc.Equals, cmd.ErrSilent)
 	c.Assert(s.fake.forced, jc.IsTrue)

--- a/cmd/juju/service/addunit_test.go
+++ b/cmd/juju/service/addunit_test.go
@@ -165,7 +165,7 @@ func (s *AddUnitSuite) TestAddUnitWithPlacement(c *gc.C) {
 
 func (s *AddUnitSuite) TestBlockAddUnit(c *gc.C) {
 	// Block operation
-	s.fake.err = common.ErrOperationBlocked("TestBlockAddUnit")
+	s.fake.err = common.OperationBlockedError("TestBlockAddUnit")
 	s.runAddUnit(c, "some-service-name")
 
 	// msg is logged

--- a/cmd/juju/service/set_test.go
+++ b/cmd/juju/service/set_test.go
@@ -142,7 +142,7 @@ func (s *SetSuite) TestSetConfig(c *gc.C) {
 
 func (s *SetSuite) TestBlockSetConfig(c *gc.C) {
 	// Block operation
-	s.fake.err = common.ErrOperationBlocked("TestBlockSetConfig")
+	s.fake.err = common.OperationBlockedError("TestBlockSetConfig")
 	ctx := coretesting.ContextForDir(c, s.dir)
 	code := cmd.Main(service.NewSetCommandWithAPI(s.fake), ctx, []string{
 		"dummy-service",

--- a/cmd/juju/service/unset_test.go
+++ b/cmd/juju/service/unset_test.go
@@ -50,7 +50,7 @@ func (s *UnsetSuite) TestUnsetOptionOneByOneSuccess(c *gc.C) {
 
 func (s *UnsetSuite) TestBlockUnset(c *gc.C) {
 	// Block operation
-	s.fake.err = common.ErrOperationBlocked("TestBlockUnset")
+	s.fake.err = common.OperationBlockedError("TestBlockUnset")
 	ctx := coretesting.ContextForDir(c, s.dir)
 	code := cmd.Main(service.NewUnsetCommand(s.fake), ctx, []string{
 		"dummy-service",

--- a/cmd/juju/user/add_test.go
+++ b/cmd/juju/user/add_test.go
@@ -149,7 +149,7 @@ type mockAddUserAPI struct {
 
 func (m *mockAddUserAPI) AddUser(username, displayname, password string) (names.UserTag, error) {
 	if m.blocked {
-		return names.UserTag{}, common.ErrOperationBlocked("The operation has been blocked.")
+		return names.UserTag{}, common.OperationBlockedError("the operation has been blocked")
 	}
 
 	m.username = username


### PR DESCRIPTION
We derive HTTP status codes from errors and consolidate as much of the
error response handling as we can.

The only semantic change in this branch is that the CodeOperationBlocked
error now returns an http.StatusForbidden status code rather than
StatusBadRequest.  Given that http status codes are ignored other than
for success/failure, this should have no impact.

In passing, we also change common.ErrOperationBlocked to OperationBlockedError,
because that is the idiomatic form for functions that return new errors,




(Review request: http://reviews.vapour.ws/r/2689/)