### PR TITLE
LP: 1465844 action-set keys can't have underscores

### DIFF
--- a/worker/uniter/runner/jujuc/action-set.go
+++ b/worker/uniter/runner/jujuc/action-set.go
@@ -30,7 +30,9 @@ func NewActionSetCommand(ctx Context) cmd.Command {
 func (c *ActionSetCommand) Info() *cmd.Info {
 	doc := `
 action-set adds the given values to the results map of the Action.  This map
-is returned to the user after the completion of the Action.
+is returned to the user after the completion of the Action.  Keys must start
+and end with lowercase alphanumeric, and contain only lowercase alphanumeric,
+hyphens and periods.
 
 Example usage:
  action-set outfile.size=10G
@@ -73,7 +75,7 @@ func (c *ActionSetCommand) Init(args []string) error {
 		// check each key for validity
 		for _, key := range keySlice {
 			if valid := keyRule.MatchString(key); !valid {
-				return fmt.Errorf("key %q must start and end with lowercase alphanumeric, and contain only lowercase alphanumeric and hyphens", key)
+				return fmt.Errorf("key %q must start and end with lowercase alphanumeric, and contain only lowercase alphanumeric, hyphens and periods", key)
 			}
 		}
 		// [key, key, key, key, value]

--- a/worker/uniter/runner/jujuc/action-set_test.go
+++ b/worker/uniter/runner/jujuc/action-set_test.go
@@ -69,7 +69,7 @@ func (s *ActionSetSuite) TestActionSet(c *gc.C) {
 	}, {
 		summary: "invalid keys are an error",
 		command: []string{"result-Value=5"},
-		errMsg:  "error: key \"result-Value\" must start and end with lowercase alphanumeric, and contain only lowercase alphanumeric and hyphens\n",
+		errMsg:  "error: key \"result-Value\" must start and end with lowercase alphanumeric, and contain only lowercase alphanumeric, hyphens and periods\n",
 		code:    2,
 	}, {
 		summary: "empty values are not an error",
@@ -147,7 +147,9 @@ func (s *ActionSetSuite) TestHelp(c *gc.C) {
 purpose: set action results
 
 action-set adds the given values to the results map of the Action.  This map
-is returned to the user after the completion of the Action.
+is returned to the user after the completion of the Action.  Keys must start
+and end with lowercase alphanumeric, and contain only lowercase alphanumeric,
+hyphens and periods.
 
 Example usage:
  action-set outfile.size=10G


### PR DESCRIPTION
Update the help doc for action-set to indicate that
keys cannot contain underscores.

(Review request: http://reviews.vapour.ws/r/2690/)