### PR TITLE
LP 1486254: Convert nested YAML maps

### DIFF
--- a/cmd/juju/action/common.go
+++ b/cmd/juju/action/common.go
@@ -15,51 +15,6 @@ import (
 
 var logger = loggo.GetLogger("juju.cmd.juju.action")
 
-// conform ensures all keys of any nested maps are strings.  This is
-// necessary because YAML unmarshals map[interface{}]interface{} in nested
-// maps, which cannot be serialized by bson. Also, handle []interface{}.
-// cf. gopkg.in/juju/charm.v4/actions.go cleanse
-func conform(input interface{}) (interface{}, error) {
-	switch typedInput := input.(type) {
-
-	case map[string]interface{}:
-		newMap := make(map[string]interface{})
-		for key, value := range typedInput {
-			newValue, err := conform(value)
-			if err != nil {
-				return nil, err
-			}
-			newMap[key] = newValue
-		}
-		return newMap, nil
-
-	case map[interface{}]interface{}:
-		newMap := make(map[string]interface{})
-		for key, value := range typedInput {
-			typedKey, ok := key.(string)
-			if !ok {
-				return nil, errors.New("map keyed with non-string value")
-			}
-			newMap[typedKey] = value
-		}
-		return conform(newMap)
-
-	case []interface{}:
-		newSlice := make([]interface{}, len(typedInput))
-		for i, sliceValue := range typedInput {
-			newSliceValue, err := conform(sliceValue)
-			if err != nil {
-				return nil, errors.New("map keyed with non-string value")
-			}
-			newSlice[i] = newSliceValue
-		}
-		return newSlice, nil
-
-	default:
-		return input, nil
-	}
-}
-
 // displayActionResult returns any error from an ActionResult and displays
 // its response values otherwise.
 func displayActionResult(result params.ActionResult, ctx *cmd.Context, out cmd.Output) error {

--- a/cmd/juju/action/common_test.go
+++ b/cmd/juju/action/common_test.go
@@ -1,119 +1,18 @@
 // Copyright 2014-2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-// This is necessary since it must test a recursive unexported function,
-// i.e., the function cannot be exported via a var
-package action
+package action_test
 
 import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/cmd/juju/action"
 )
 
 type CommonSuite struct{}
 
 var _ = gc.Suite(&CommonSuite{})
-
-func (s *CommonSuite) TestConform(c *gc.C) {
-	var goodInterfaceTests = []struct {
-		description       string
-		inputInterface    interface{}
-		expectedInterface map[string]interface{}
-		expectedError     string
-	}{{
-		description: "An interface requiring no changes.",
-		inputInterface: map[string]interface{}{
-			"key1": "value1",
-			"key2": "value2",
-			"key3": map[string]interface{}{
-				"foo1": "val1",
-				"foo2": "val2"}},
-		expectedInterface: map[string]interface{}{
-			"key1": "value1",
-			"key2": "value2",
-			"key3": map[string]interface{}{
-				"foo1": "val1",
-				"foo2": "val2"}},
-	}, {
-		description: "Substitute a single inner map[i]i.",
-		inputInterface: map[string]interface{}{
-			"key1": "value1",
-			"key2": "value2",
-			"key3": map[interface{}]interface{}{
-				"foo1": "val1",
-				"foo2": "val2"}},
-		expectedInterface: map[string]interface{}{
-			"key1": "value1",
-			"key2": "value2",
-			"key3": map[string]interface{}{
-				"foo1": "val1",
-				"foo2": "val2"}},
-	}, {
-		description: "Substitute nested inner map[i]i.",
-		inputInterface: map[string]interface{}{
-			"key1a": "val1a",
-			"key2a": "val2a",
-			"key3a": map[interface{}]interface{}{
-				"key1b": "val1b",
-				"key2b": map[interface{}]interface{}{
-					"key1c": "val1c"}}},
-		expectedInterface: map[string]interface{}{
-			"key1a": "val1a",
-			"key2a": "val2a",
-			"key3a": map[string]interface{}{
-				"key1b": "val1b",
-				"key2b": map[string]interface{}{
-					"key1c": "val1c"}}},
-	}, {
-		description: "Substitute nested map[i]i within []i.",
-		inputInterface: map[string]interface{}{
-			"key1a": "val1a",
-			"key2a": []interface{}{5, "foo", map[string]interface{}{
-				"key1b": "val1b",
-				"key2b": map[interface{}]interface{}{
-					"key1c": "val1c"}}}},
-		expectedInterface: map[string]interface{}{
-			"key1a": "val1a",
-			"key2a": []interface{}{5, "foo", map[string]interface{}{
-				"key1b": "val1b",
-				"key2b": map[string]interface{}{
-					"key1c": "val1c"}}}},
-	}, {
-		description: "An inner map[interface{}]interface{} with an int key.",
-		inputInterface: map[string]interface{}{
-			"key1": "value1",
-			"key2": "value2",
-			"key3": map[interface{}]interface{}{
-				"foo1": "val1",
-				5:      "val2"}},
-		expectedError: "map keyed with non-string value",
-	}, {
-		description: "An inner []interface{} containing a map[i]i with an int key.",
-		inputInterface: map[string]interface{}{
-			"key1a": "val1b",
-			"key2a": "val2b",
-			"key3a": []interface{}{"foo1", 5, map[interface{}]interface{}{
-				"key1b": "val1b",
-				"key2b": map[interface{}]interface{}{
-					"key1c": "val1c",
-					5:       "val2c"}}}},
-		expectedError: "map keyed with non-string value",
-	}}
-
-	for i, test := range goodInterfaceTests {
-		c.Logf("test %d: %s", i, test.description)
-		input := test.inputInterface
-		cleansedInterfaceMap, err := conform(input)
-		if test.expectedError == "" {
-			if !c.Check(err, jc.ErrorIsNil) {
-				continue
-			}
-			c.Check(cleansedInterfaceMap, gc.DeepEquals, test.expectedInterface)
-		} else {
-			c.Check(err, gc.ErrorMatches, test.expectedError)
-		}
-	}
-}
 
 type insertSliceValue struct {
 	valuePath []string
@@ -158,7 +57,7 @@ func (s *CommonSuite) TestAddValueToMap(c *gc.C) {
 	}} {
 		c.Logf("test %d: should %s", i, t.should)
 		for _, sVal := range t.insertSlices {
-			addValueToMap(sVal.valuePath, sVal.value, t.startingMap)
+			action.AddValueToMap(sVal.valuePath, sVal.value, t.startingMap)
 		}
 		// note addValueToMap mutates target.
 		c.Check(t.startingMap, jc.DeepEquals, t.expectedMap)

--- a/cmd/juju/action/do.go
+++ b/cmd/juju/action/do.go
@@ -15,6 +15,7 @@ import (
 	"launchpad.net/gnuflag"
 
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/juju/common"
 )
 
 var keyRule = regexp.MustCompile("^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$")
@@ -181,7 +182,7 @@ func (c *DoCommand) Run(ctx *cmd.Context) error {
 			return err
 		}
 
-		conformantParams, err := conform(actionParams)
+		conformantParams, err := common.ConformYAML(actionParams)
 		if err != nil {
 			return err
 		}
@@ -211,7 +212,7 @@ func (c *DoCommand) Run(ctx *cmd.Context) error {
 		addValueToMap(keys, cleansedValue, actionParams)
 	}
 
-	conformantParams, err := conform(actionParams)
+	conformantParams, err := common.ConformYAML(actionParams)
 	if err != nil {
 		return err
 	}

--- a/cmd/juju/action/export_test.go
+++ b/cmd/juju/action/export_test.go
@@ -11,6 +11,7 @@ import (
 
 var (
 	NewActionAPIClient = &newAPIClient
+	AddValueToMap      = addValueToMap
 )
 
 func (c *DefinedCommand) ServiceTag() names.ServiceTag {

--- a/cmd/juju/common/format.go
+++ b/cmd/juju/common/format.go
@@ -3,7 +3,11 @@
 
 package common
 
-import "time"
+import (
+	"time"
+
+	"github.com/juju/errors"
+)
 
 // FormatTime returns a string with the local time formatted
 // in an arbitrary format used for status or and localized tz
@@ -20,4 +24,49 @@ func FormatTime(t *time.Time, formatISO bool) string {
 	}
 	// Otherwise use local time.
 	return t.Local().Format("02 Jan 2006 15:04:05Z07:00")
+}
+
+// ConformYAML ensures all keys of any nested maps are strings.  This is
+// necessary because YAML unmarshals map[interface{}]interface{} in nested
+// maps, which cannot be serialized by bson. Also, handle []interface{}.
+// cf. gopkg.in/juju/charm.v4/actions.go cleanse
+func ConformYAML(input interface{}) (interface{}, error) {
+	switch typedInput := input.(type) {
+
+	case map[string]interface{}:
+		newMap := make(map[string]interface{})
+		for key, value := range typedInput {
+			newValue, err := ConformYAML(value)
+			if err != nil {
+				return nil, err
+			}
+			newMap[key] = newValue
+		}
+		return newMap, nil
+
+	case map[interface{}]interface{}:
+		newMap := make(map[string]interface{})
+		for key, value := range typedInput {
+			typedKey, ok := key.(string)
+			if !ok {
+				return nil, errors.New("map keyed with non-string value")
+			}
+			newMap[typedKey] = value
+		}
+		return ConformYAML(newMap)
+
+	case []interface{}:
+		newSlice := make([]interface{}, len(typedInput))
+		for i, sliceValue := range typedInput {
+			newSliceValue, err := ConformYAML(sliceValue)
+			if err != nil {
+				return nil, errors.New("map keyed with non-string value")
+			}
+			newSlice[i] = newSliceValue
+		}
+		return newSlice, nil
+
+	default:
+		return input, nil
+	}
 }

--- a/cmd/juju/common/format_test.go
+++ b/cmd/juju/common/format_test.go
@@ -1,0 +1,116 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package common_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/cmd/juju/common"
+)
+
+type ConformSuite struct{}
+
+var _ = gc.Suite(&ConformSuite{})
+
+func (s *ConformSuite) TestConformYAML(c *gc.C) {
+	var goodInterfaceTests = []struct {
+		description       string
+		inputInterface    interface{}
+		expectedInterface map[string]interface{}
+		expectedError     string
+	}{{
+		description: "An interface requiring no changes.",
+		inputInterface: map[string]interface{}{
+			"key1": "value1",
+			"key2": "value2",
+			"key3": map[string]interface{}{
+				"foo1": "val1",
+				"foo2": "val2"}},
+		expectedInterface: map[string]interface{}{
+			"key1": "value1",
+			"key2": "value2",
+			"key3": map[string]interface{}{
+				"foo1": "val1",
+				"foo2": "val2"}},
+	}, {
+		description: "Substitute a single inner map[i]i.",
+		inputInterface: map[string]interface{}{
+			"key1": "value1",
+			"key2": "value2",
+			"key3": map[interface{}]interface{}{
+				"foo1": "val1",
+				"foo2": "val2"}},
+		expectedInterface: map[string]interface{}{
+			"key1": "value1",
+			"key2": "value2",
+			"key3": map[string]interface{}{
+				"foo1": "val1",
+				"foo2": "val2"}},
+	}, {
+		description: "Substitute nested inner map[i]i.",
+		inputInterface: map[string]interface{}{
+			"key1a": "val1a",
+			"key2a": "val2a",
+			"key3a": map[interface{}]interface{}{
+				"key1b": "val1b",
+				"key2b": map[interface{}]interface{}{
+					"key1c": "val1c"}}},
+		expectedInterface: map[string]interface{}{
+			"key1a": "val1a",
+			"key2a": "val2a",
+			"key3a": map[string]interface{}{
+				"key1b": "val1b",
+				"key2b": map[string]interface{}{
+					"key1c": "val1c"}}},
+	}, {
+		description: "Substitute nested map[i]i within []i.",
+		inputInterface: map[string]interface{}{
+			"key1a": "val1a",
+			"key2a": []interface{}{5, "foo", map[string]interface{}{
+				"key1b": "val1b",
+				"key2b": map[interface{}]interface{}{
+					"key1c": "val1c"}}}},
+		expectedInterface: map[string]interface{}{
+			"key1a": "val1a",
+			"key2a": []interface{}{5, "foo", map[string]interface{}{
+				"key1b": "val1b",
+				"key2b": map[string]interface{}{
+					"key1c": "val1c"}}}},
+	}, {
+		description: "An inner map[interface{}]interface{} with an int key.",
+		inputInterface: map[string]interface{}{
+			"key1": "value1",
+			"key2": "value2",
+			"key3": map[interface{}]interface{}{
+				"foo1": "val1",
+				5:      "val2"}},
+		expectedError: "map keyed with non-string value",
+	}, {
+		description: "An inner []interface{} containing a map[i]i with an int key.",
+		inputInterface: map[string]interface{}{
+			"key1a": "val1b",
+			"key2a": "val2b",
+			"key3a": []interface{}{"foo1", 5, map[interface{}]interface{}{
+				"key1b": "val1b",
+				"key2b": map[interface{}]interface{}{
+					"key1c": "val1c",
+					5:       "val2c"}}}},
+		expectedError: "map keyed with non-string value",
+	}}
+
+	for i, test := range goodInterfaceTests {
+		c.Logf("test %d: %s", i, test.description)
+		input := test.inputInterface
+		cleansedInterfaceMap, err := common.ConformYAML(input)
+		if test.expectedError == "" {
+			if !c.Check(err, jc.ErrorIsNil) {
+				continue
+			}
+			c.Check(cleansedInterfaceMap, gc.DeepEquals, test.expectedInterface)
+		} else {
+			c.Check(err, gc.ErrorMatches, test.expectedError)
+		}
+	}
+}

--- a/cmd/juju/system/createenvironment_test.go
+++ b/cmd/juju/system/createenvironment_test.go
@@ -165,6 +165,29 @@ func (s *createSuite) TestConfigFileValuesPassedThrough(c *gc.C) {
 	c.Assert(s.fake.config["cloud"], gc.Equals, "9")
 }
 
+func (s *createSuite) TestConfigFileWithNestedMaps(c *gc.C) {
+	nestedConfig := map[string]interface{}{
+		"account": "magic",
+		"cloud":   "9",
+	}
+	config := map[string]interface{}{
+		"foo":    "bar",
+		"nested": nestedConfig,
+	}
+
+	bytes, err := yaml.Marshal(config)
+	c.Assert(err, jc.ErrorIsNil)
+	file, err := ioutil.TempFile(c.MkDir(), "")
+	c.Assert(err, jc.ErrorIsNil)
+	file.Write(bytes)
+	file.Close()
+
+	_, err = s.run(c, "test", "--config", file.Name())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s.fake.config["foo"], gc.Equals, "bar")
+	c.Assert(s.fake.config["nested"], jc.DeepEquals, nestedConfig)
+}
+
 func (s *createSuite) TestConfigFileFormatError(c *gc.C) {
 	file, err := ioutil.TempFile(c.MkDir(), "")
 	c.Assert(err, jc.ErrorIsNil)

--- a/cmd/juju/system/createenvironment_test.go
+++ b/cmd/juju/system/createenvironment_test.go
@@ -26,6 +26,7 @@ import (
 type createSuite struct {
 	testing.FakeJujuHomeSuite
 	fake       *fakeCreateClient
+	parser     func(interface{}) (interface{}, error)
 	store      configstore.Storage
 	serverUUID string
 	server     configstore.EnvironInfo
@@ -37,6 +38,7 @@ func (s *createSuite) SetUpTest(c *gc.C) {
 	s.FakeJujuHomeSuite.SetUpTest(c)
 	s.SetFeatureFlags(feature.JES)
 	s.fake = &fakeCreateClient{}
+	s.parser = nil
 	store := configstore.Default
 	s.AddCleanup(func(*gc.C) {
 		configstore.Default = store
@@ -65,7 +67,7 @@ func (s *createSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *createSuite) run(c *gc.C, args ...string) (*cmd.Context, error) {
-	command := system.NewCreateEnvironmentCommand(s.fake)
+	command := system.NewCreateEnvironmentCommand(s.fake, s.parser)
 	return testing.RunCommand(c, envcmd.WrapSystem(command), args...)
 }
 
@@ -188,6 +190,43 @@ func (s *createSuite) TestConfigFileWithNestedMaps(c *gc.C) {
 	c.Assert(s.fake.config["nested"], jc.DeepEquals, nestedConfig)
 }
 
+func (s *createSuite) TestConfigFileFailsToConform(c *gc.C) {
+	nestedConfig := map[int]interface{}{
+		9: "9",
+	}
+	config := map[string]interface{}{
+		"foo":    "bar",
+		"nested": nestedConfig,
+	}
+	bytes, err := yaml.Marshal(config)
+	c.Assert(err, jc.ErrorIsNil)
+	file, err := ioutil.TempFile(c.MkDir(), "")
+	c.Assert(err, jc.ErrorIsNil)
+	file.Write(bytes)
+	file.Close()
+
+	_, err = s.run(c, "test", "--config", file.Name())
+	c.Assert(err, gc.ErrorMatches, `unable to parse config file: map keyed with non-string value`)
+}
+
+func (s *createSuite) TestConfigFileFailsWithUnknownType(c *gc.C) {
+	config := map[string]interface{}{
+		"account": "magic",
+		"cloud":   "9",
+	}
+
+	bytes, err := yaml.Marshal(config)
+	c.Assert(err, jc.ErrorIsNil)
+	file, err := ioutil.TempFile(c.MkDir(), "")
+	c.Assert(err, jc.ErrorIsNil)
+	file.Write(bytes)
+	file.Close()
+
+	s.parser = func(interface{}) (interface{}, error) { return "not a map", nil }
+	_, err = s.run(c, "test", "--config", file.Name())
+	c.Assert(err, gc.ErrorMatches, `config must contain a YAML map with string keys`)
+}
+
 func (s *createSuite) TestConfigFileFormatError(c *gc.C) {
 	file, err := ioutil.TempFile(c.MkDir(), "")
 	c.Assert(err, jc.ErrorIsNil)
@@ -195,7 +234,7 @@ func (s *createSuite) TestConfigFileFormatError(c *gc.C) {
 	file.Close()
 
 	_, err = s.run(c, "test", "--config", file.Name())
-	c.Assert(err, gc.ErrorMatches, `YAML error: .*`)
+	c.Assert(err, gc.ErrorMatches, `unable to parse config file: YAML error: .*`)
 }
 
 func (s *createSuite) TestConfigFileDoesntExist(c *gc.C) {

--- a/cmd/juju/system/export_test.go
+++ b/cmd/juju/system/export_test.go
@@ -23,9 +23,10 @@ func NewListCommand(cfgStore configstore.Storage) *ListCommand {
 }
 
 // NewCreateEnvironmentCommand returns a CreateEnvironmentCommand with the api provided as specified.
-func NewCreateEnvironmentCommand(api CreateEnvironmentAPI) *CreateEnvironmentCommand {
+func NewCreateEnvironmentCommand(api CreateEnvironmentAPI, parser func(interface{}) (interface{}, error)) *CreateEnvironmentCommand {
 	return &CreateEnvironmentCommand{
-		api: api,
+		api:          api,
+		configParser: parser,
 	}
 }
 


### PR DESCRIPTION
Moved the conform() function from cmd/juju/action into the
common directory for commands so that the system create-env
command can also use it to convert nested maps into the proper
map[string]interface{} format.

Previously reviewed: http://reviews.vapour.ws/r/2642/

(Review request: http://reviews.vapour.ws/r/2692/)