### PR TITLE
Ported the "spaces not supported" error message back to 1.25.

### DIFF
--- a/api/spaces/spaces.go
+++ b/api/spaces/spaces.go
@@ -53,11 +53,14 @@ func makeCreateSpaceParams(name string, subnetIds []string, public bool) params.
 // specified subnets with it (optional; can be empty).
 func (api *API) CreateSpace(name string, subnetIds []string, public bool) error {
 	var response params.ErrorResults
-	params := params.CreateSpacesParams{
+	createSpacesParams := params.CreateSpacesParams{
 		Spaces: []params.CreateSpaceParams{makeCreateSpaceParams(name, subnetIds, public)},
 	}
-	err := api.facade.FacadeCall("CreateSpaces", params, &response)
+	err := api.facade.FacadeCall("CreateSpaces", createSpacesParams, &response)
 	if err != nil {
+		if params.IsCodeNotSupported(err) {
+			return errors.NewNotSupported(nil, err.Error())
+		}
 		return errors.Trace(err)
 	}
 	return response.OneError()
@@ -67,5 +70,8 @@ func (api *API) CreateSpace(name string, subnetIds []string, public bool) error 
 func (api *API) ListSpaces() ([]params.Space, error) {
 	var response params.ListSpacesResults
 	err := api.facade.FacadeCall("ListSpaces", nil, &response)
+	if params.IsCodeNotSupported(err) {
+		return response.Results, errors.NewNotSupported(nil, err.Error())
+	}
 	return response.Results, err
 }

--- a/cmd/juju/space/create.go
+++ b/cmd/juju/space/create.go
@@ -57,6 +57,9 @@ func (c *CreateCommand) Run(ctx *cmd.Context) error {
 		// TODO(dimitern): Accept --public|--private and pass it here.
 		err := api.CreateSpace(c.Name, subnetIds, true)
 		if err != nil {
+			if errors.IsNotSupported(err) {
+				ctx.Infof("cannot create space %q: %v", c.Name, err)
+			}
 			return errors.Annotatef(err, "cannot create space %q", c.Name)
 		}
 

--- a/cmd/juju/space/create_test.go
+++ b/cmd/juju/space/create_test.go
@@ -5,6 +5,7 @@ package space_test
 
 import (
 	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cmd/juju/space"
@@ -45,6 +46,19 @@ func (s *CreateSuite) TestRunWithSubnetsSucceeds(c *gc.C) {
 		0, "CreateSpace",
 		"myspace", s.Strings("10.1.2.0/24", "4.3.2.0/28"), true,
 	)
+}
+
+func (s *CreateSuite) TestRunWhenSpacesNotSupported(c *gc.C) {
+	s.api.SetErrors(errors.NewNotSupported(nil, "spaces not supported"))
+
+	err := s.AssertRunSpacesNotSupported(c,
+		`cannot create space "foo": spaces not supported`,
+		"foo", "10.1.2.0/24",
+	)
+	c.Assert(err, jc.Satisfies, errors.IsNotSupported)
+
+	s.api.CheckCallNames(c, "CreateSpace", "Close")
+	s.api.CheckCall(c, 0, "CreateSpace", "foo", s.Strings("10.1.2.0/24"), true)
 }
 
 func (s *CreateSuite) TestRunWhenSpacesAPIFails(c *gc.C) {

--- a/cmd/juju/space/list.go
+++ b/cmd/juju/space/list.go
@@ -67,6 +67,9 @@ func (c *ListCommand) Run(ctx *cmd.Context) error {
 	return c.RunWithAPI(ctx, func(api SpaceAPI, ctx *cmd.Context) error {
 		spaces, err := api.ListSpaces()
 		if err != nil {
+			if errors.IsNotSupported(err) {
+				ctx.Infof("cannot list spaces: %v", err)
+			}
 			return errors.Annotate(err, "cannot list spaces")
 		}
 		if len(spaces) == 0 {

--- a/cmd/juju/space/list_test.go
+++ b/cmd/juju/space/list_test.go
@@ -263,11 +263,20 @@ func (s *ListSuite) TestRunWhenNoSpacesExistSucceeds(c *gc.C) {
 	s.api.CheckCall(c, 0, "ListSpaces")
 }
 
-func (s *ListSuite) TestRunWhenSpacesAPIFails(c *gc.C) {
-	s.api.SetErrors(errors.NewNotSupported(nil, "spaces not supported by the provider"))
+func (s *ListSuite) TestRunWhenSpacesNotSupported(c *gc.C) {
+	s.api.SetErrors(errors.NewNotSupported(nil, "spaces not supported"))
 
-	err := s.AssertRunFails(c, "cannot list spaces: spaces not supported by the provider")
+	err := s.AssertRunSpacesNotSupported(c, "cannot list spaces: spaces not supported")
 	c.Assert(err, jc.Satisfies, errors.IsNotSupported)
+
+	s.api.CheckCallNames(c, "ListSpaces", "Close")
+	s.api.CheckCall(c, 0, "ListSpaces")
+}
+
+func (s *ListSuite) TestRunWhenSpacesAPIFails(c *gc.C) {
+	s.api.SetErrors(errors.New("boom"))
+
+	s.AssertRunFails(c, "cannot list spaces: boom")
 
 	s.api.CheckCallNames(c, "ListSpaces", "Close")
 	s.api.CheckCall(c, 0, "ListSpaces")

--- a/cmd/juju/space/package_test.go
+++ b/cmd/juju/space/package_test.go
@@ -86,6 +86,17 @@ func (s *BaseSpaceSuite) RunSubCommand(c *gc.C, args ...string) (string, string,
 	return "", "", err
 }
 
+// AssertRunSpacesNotSupported is a shortcut for calling RunSubCommand with the
+// passed args then asserting the output is empty and the error is the
+// spaces not supported, finally returning the error.
+func (s *BaseSpaceSuite) AssertRunSpacesNotSupported(c *gc.C, expectErr string, args ...string) error {
+	stdout, stderr, err := s.RunSubCommand(c, args...)
+	c.Assert(err, gc.ErrorMatches, expectErr)
+	c.Assert(stdout, gc.Equals, "")
+	c.Assert(stderr, gc.Equals, expectErr+"\n")
+	return err
+}
+
 // AssertRunFails is a shortcut for calling RunSubCommand with the
 // passed args then asserting the output is empty and the error is as
 // expected, finally returning the error.

--- a/provider/dummy/environs_test.go
+++ b/provider/dummy/environs_test.go
@@ -185,15 +185,15 @@ func (s *suite) TestSupportsSpaces(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Now turn it off.
-	current := e.(testing.SpacesEnabler).SetSupportsSpaces(false)
-	c.Assert(current, jc.IsTrue)
+	isEnabled := dummy.SetSupportsSpaces(false)
+	c.Assert(isEnabled, jc.IsTrue)
 	ok, err = e.SupportsSpaces()
 	c.Assert(ok, jc.IsFalse)
 	c.Assert(err, jc.Satisfies, errors.IsNotSupported)
 
 	// And finally turn it on again.
-	current = e.(testing.SpacesEnabler).SetSupportsSpaces(current)
-	c.Assert(current, jc.IsFalse)
+	isEnabled = dummy.SetSupportsSpaces(true)
+	c.Assert(isEnabled, jc.IsFalse)
 	ok, err = e.SupportsSpaces()
 	c.Assert(ok, jc.IsTrue)
 	c.Assert(err, jc.ErrorIsNil)

--- a/testing/environ.go
+++ b/testing/environ.go
@@ -180,8 +180,3 @@ func WriteEnvironments(c *gc.C, envConfig string, certNames ...string) {
 		c.Assert(err, jc.ErrorIsNil)
 	}
 }
-
-// SpacesEnabler allows to call SetSupportsSpaces on the dummy environment.
-type SpacesEnabler interface {
-	SetSupportsSpaces(bool) bool
-}


### PR DESCRIPTION
Master already has the changes for server and client, 1.25 so far only the one for the server. This PR backported the master changes to the client (and some providers) back to 1.25.

(Review request: http://reviews.vapour.ws/r/2694/)