### PR TITLE
storage: update filesystem API/CLI

### DIFF
--- a/apiserver/params/storage.go
+++ b/apiserver/params/storage.go
@@ -643,21 +643,9 @@ type FilesystemDetails struct {
 	// machine tag to filesystem attachment information.
 	MachineAttachments map[string]FilesystemAttachmentInfo `json:"machineattachments,omitempty"`
 
-	// NOTE(axw): below should really be StorageDetails, but
-	// StorageDetails is pretty broken at the moment.
-	// StorageDetails is really *StorageAttachmentDetails*,
-	// but also includes information about the storage
-	// instance. We need to rev the storage API and fix
-	// this all up in one go.
-
-	// StorageTag is the tag of the storage instance
-	// that the filesystem is assigned to, if any.
-	StorageTag string `json:"storagetag,omitempty"`
-
-	// StorageOwnerTag is the tag of the entity that
-	// owns the filesystem's assigned storage instance,
-	// if any.
-	StorageOwnerTag string `json:"ownertag,omitempty"`
+	// Storage contains details about the storage instance
+	// that the volume is assigned to, if any.
+	Storage *StorageDetails `json:"storage,omitempty"`
 }
 
 // FilesystemDetailsResult contains details about a filesystem, its attachments or

--- a/apiserver/storage/filesystemlist_test.go
+++ b/apiserver/storage/filesystemlist_test.go
@@ -21,14 +21,27 @@ var _ = gc.Suite(&filesystemSuite{})
 func (s *filesystemSuite) expectedFilesystemDetailsResult() params.FilesystemDetailsResult {
 	return params.FilesystemDetailsResult{
 		Result: &params.FilesystemDetails{
-			FilesystemTag:   s.filesystemTag.String(),
-			StorageTag:      "storage-data-0",
-			StorageOwnerTag: "unit-mysql-0",
+			FilesystemTag: s.filesystemTag.String(),
 			Status: params.EntityStatus{
 				Status: "attached",
 			},
 			MachineAttachments: map[string]params.FilesystemAttachmentInfo{
 				s.machineTag.String(): params.FilesystemAttachmentInfo{},
+			},
+			Storage: &params.StorageDetails{
+				StorageTag: "storage-data-0",
+				OwnerTag:   "unit-mysql-0",
+				Kind:       params.StorageKindFilesystem,
+				Status: params.EntityStatus{
+					Status: "attached",
+				},
+				Attachments: map[string]params.StorageAttachmentDetails{
+					"unit-mysql-0": params.StorageAttachmentDetails{
+						StorageTag: "storage-data-0",
+						UnitTag:    "unit-mysql-0",
+						MachineTag: "machine-66",
+					},
+				},
 			},
 		},
 	}
@@ -100,6 +113,9 @@ func (s *filesystemSuite) TestListFilesystemsAttachmentInfo(c *gc.C) {
 		MountPoint: "/tmp",
 		ReadOnly:   true,
 	}
+	expectedStorageAttachmentDetails := expected.Result.Storage.Attachments["unit-mysql-0"]
+	expectedStorageAttachmentDetails.Location = "/tmp"
+	expected.Result.Storage.Attachments["unit-mysql-0"] = expectedStorageAttachmentDetails
 	found, err := s.api.ListFilesystems(params.FilesystemFilter{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(found.Results, gc.HasLen, 1)

--- a/apiserver/storage/storage.go
+++ b/apiserver/storage/storage.go
@@ -627,12 +627,15 @@ func createFilesystemDetails(
 	details.Status = common.EntityStatusFromState(status)
 
 	if storageTag, err := f.Storage(); err == nil {
-		details.StorageTag = storageTag.String()
 		storageInstance, err := st.StorageInstance(storageTag)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		details.StorageOwnerTag = storageInstance.Owner().String()
+		storageDetails, err := createStorageDetails(st, storageInstance)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		details.Storage = storageDetails
 	}
 
 	return details, nil

--- a/cmd/juju/storage/filesystem.go
+++ b/cmd/juju/storage/filesystem.go
@@ -6,6 +6,7 @@ package storage
 import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
+	"github.com/juju/names"
 
 	"github.com/juju/juju/apiserver/params"
 	jujucmd "github.com/juju/juju/cmd"
@@ -41,116 +42,101 @@ type FilesystemCommandBase struct {
 // FilesystemInfo defines the serialization behaviour for storage filesystem.
 type FilesystemInfo struct {
 	// from params.Filesystem. This is provider-supplied unique filesystem id.
-	FilesystemId string `yaml:"id,omitempty" json:"id,omitempty"`
+	ProviderFilesystemId string `yaml:"provider-id,omitempty" json:"provider-id,omitempty"`
+
+	// Volume is the ID of the volume that the filesystem is backed by, if any.
+	Volume string
+
+	// Storage is the ID of the storage instance that the filesystem is
+	// assigned to, if any.
+	Storage string
+
+	// Attachments is the set of entities attached to the filesystem.
+	Attachments *FilesystemAttachments
 
 	// from params.FilesystemInfo
 	Size uint64 `yaml:"size" json:"size"`
-
-	// from params.FilesystemAttachmentInfo
-	MountPoint string `yaml:"mountpoint,omitempty" json:"mountpoint,omitempty"`
-
-	// from params.FilesystemAttachmentInfo
-	ReadOnly bool `yaml:"read-only" json:"read-only"`
-
-	// from params.FilesystemInfo. This is juju-supplied filesystem ID.
-	Filesystem string `yaml:"filesystem" json:"filesystem"`
-
-	// from params.FilesystemDetails. This is the juju-supplied ID of the
-	// volume backing the filesystem if any.
-	Volume string `yaml:"volume,omitempty" json:"volume,omitempty"`
 
 	// from params.FilesystemInfo.
 	Status EntityStatus `yaml:"status,omitempty" json:"status,omitempty"`
 }
 
-// convertToFilesystemInfo returns map of maps with filesystem info
-// keyed first on machine ID and then on filesystem ID.
-func convertToFilesystemInfo(all []params.FilesystemDetailsResult) (map[string]map[string]map[string]FilesystemInfo, error) {
-	result := map[string]map[string]map[string]FilesystemInfo{}
+type FilesystemAttachments struct {
+	Machines map[string]MachineFilesystemAttachment `yaml:"machines,omitempty" json:"machines,omitempty"`
+	Units    map[string]UnitStorageAttachment       `yaml:"units,omitempty" json:"units,omitempty"`
+}
+
+type MachineFilesystemAttachment struct {
+	MountPoint string `yaml:"mount-point" json:"mount-point"`
+	ReadOnly   bool   `yaml:"read-only" json:"read-only"`
+}
+
+// convertToFilesystemInfo returns a map of filesystem IDs to filesystem info.
+func convertToFilesystemInfo(all []params.FilesystemDetailsResult) (map[string]FilesystemInfo, error) {
+	result := make(map[string]FilesystemInfo)
 	for _, one := range all {
-		if err := convertFilesystemDetailsResult(one, result); err != nil {
+		filesystemTag, info, err := createFilesystemInfo(one)
+		if err != nil {
 			return nil, errors.Trace(err)
 		}
+		result[filesystemTag.Id()] = info
 	}
 	return result, nil
 }
 
-func convertFilesystemDetailsResult(item params.FilesystemDetailsResult, all map[string]map[string]map[string]FilesystemInfo) error {
-	info, attachments, storage, storageOwner, err := createFilesystemInfo(item)
+func createFilesystemInfo(result params.FilesystemDetailsResult) (names.FilesystemTag, FilesystemInfo, error) {
+	details := result.Result
+
+	filesystemTag, err := names.ParseFilesystemTag(details.FilesystemTag)
 	if err != nil {
-		return errors.Trace(err)
+		return names.FilesystemTag{}, FilesystemInfo{}, errors.Trace(err)
 	}
-	for machineTag, attachmentInfo := range attachments {
-		machineId, err := idFromTag(machineTag)
-		if err != nil {
-			return errors.Trace(err)
-		}
-		info.MountPoint = attachmentInfo.MountPoint
-		info.ReadOnly = attachmentInfo.ReadOnly
-		addOneFilesystemToAll(machineId, storage, storageOwner, info, all)
-	}
-	if len(attachments) == 0 {
-		addOneFilesystemToAll("unattached", storage, storageOwner, info, all)
-	}
-	return nil
-}
 
-func addOneFilesystemToAll(machineId, storageId, storageOwnerId string, item FilesystemInfo, all map[string]map[string]map[string]FilesystemInfo) {
-	machineFilesystems, ok := all[machineId]
-	if !ok {
-		machineFilesystems = map[string]map[string]FilesystemInfo{}
-		all[machineId] = machineFilesystems
-	}
-	storageOwnerFilesystems, ok := machineFilesystems[storageOwnerId]
-	if !ok {
-		storageOwnerFilesystems = map[string]FilesystemInfo{}
-		machineFilesystems[storageOwnerId] = storageOwnerFilesystems
-	}
-	storageOwnerFilesystems[storageId] = item
-}
-
-func createFilesystemInfo(result params.FilesystemDetailsResult) (
-	info FilesystemInfo,
-	attachments map[string]params.FilesystemAttachmentInfo,
-	storageId string,
-	storageOwnerId string,
-	err error,
-) {
-	info.FilesystemId = result.Result.Info.FilesystemId
-	info.Size = result.Result.Info.Size
+	var info FilesystemInfo
+	info.ProviderFilesystemId = details.Info.FilesystemId
+	info.Size = details.Info.Size
 	info.Status = EntityStatus{
-		result.Result.Status.Status,
-		result.Result.Status.Info,
+		details.Status.Status,
+		details.Status.Info,
 		// TODO(axw) we should support formatting as ISO time
-		common.FormatTime(result.Result.Status.Since, false),
+		common.FormatTime(details.Status.Since, false),
 	}
 
-	if f, err := idFromTag(result.Result.FilesystemTag); err != nil {
-		return FilesystemInfo{}, nil, "", "", errors.Trace(err)
-	} else {
-		info.Filesystem = f
+	if details.VolumeTag != "" {
+		volumeId, err := idFromTag(details.VolumeTag)
+		if err != nil {
+			return names.FilesystemTag{}, FilesystemInfo{}, errors.Trace(err)
+		}
+		info.Volume = volumeId
 	}
 
-	if result.Result.VolumeTag != "" {
-		if v, err := idFromTag(result.Result.VolumeTag); err == nil {
-			info.Volume = v
+	if len(details.MachineAttachments) > 0 {
+		machineAttachments := make(map[string]MachineFilesystemAttachment)
+		for machineTag, attachment := range details.MachineAttachments {
+			machineId, err := idFromTag(machineTag)
+			if err != nil {
+				return names.FilesystemTag{}, FilesystemInfo{}, errors.Trace(err)
+			}
+			machineAttachments[machineId] = MachineFilesystemAttachment{
+				attachment.MountPoint,
+				attachment.ReadOnly,
+			}
+		}
+		info.Attachments = &FilesystemAttachments{
+			Machines: machineAttachments,
 		}
 	}
 
-	storageId = "unassigned"
-	if result.Result.StorageTag != "" {
-		if storageId, err = idFromTag(result.Result.StorageTag); err != nil {
-			return FilesystemInfo{}, nil, "", "", errors.Trace(err)
+	if details.Storage != nil {
+		storageTag, storageInfo, err := createStorageInfo(*details.Storage)
+		if err != nil {
+			return names.FilesystemTag{}, FilesystemInfo{}, errors.Trace(err)
+		}
+		info.Storage = storageTag.Id()
+		if storageInfo.Attachments != nil {
+			info.Attachments.Units = storageInfo.Attachments.Units
 		}
 	}
 
-	storageOwnerId = "unattached"
-	if result.Result.StorageOwnerTag != "" {
-		if storageOwnerId, err = idFromTag(result.Result.StorageOwnerTag); err != nil {
-			return FilesystemInfo{}, nil, "", "", errors.Trace(err)
-		}
-	}
-
-	attachments = result.Result.MachineAttachments
-	return info, attachments, storageId, storageOwnerId, nil
+	return filesystemTag, info, nil
 }

--- a/cmd/juju/storage/filesystemlist.go
+++ b/cmd/juju/storage/filesystemlist.go
@@ -83,9 +83,17 @@ func (c *FilesystemListCommand) Run(ctx *cmd.Context) (err error) {
 	if len(valid) == 0 {
 		return nil
 	}
-	output, err := convertToFilesystemInfo(valid)
+	info, err := convertToFilesystemInfo(valid)
 	if err != nil {
 		return err
+	}
+
+	var output interface{}
+	switch c.out.Name() {
+	case "json", "yaml":
+		output = map[string]map[string]FilesystemInfo{"filesystems": info}
+	default:
+		output = info
 	}
 	return c.out.Write(ctx, output)
 }

--- a/cmd/juju/storage/volume.go
+++ b/cmd/juju/storage/volume.go
@@ -82,8 +82,7 @@ type MachineVolumeAttachment struct {
 	// TODO(axw) add machine volume attachment status when we have it
 }
 
-// convertToVolumeInfo returns map of maps with volume info
-// keyed first on machine ID and then on volume ID.
+// convertToVolumeInfo returns a map of volume IDs to volume info.
 func convertToVolumeInfo(all []params.VolumeDetailsResult) (map[string]VolumeInfo, error) {
 	result := make(map[string]VolumeInfo)
 	for _, one := range all {


### PR DESCRIPTION
This commit changs the FilesystemDetails structure
to be like VolumeDetails, embedding a StorageDetails
with the storage and unit-attachment information.
This is then used in the updated CLI to display
attachment information in a way that will work with
shared storage in the future.

Primary difference to volume listing is that there
is no legacy structure for filesystem details, as
filesystem listing does not exist in 1.25 or earlier.

Fixes https://bugs.launchpad.net/juju-core/+bug/1495338

(Review request: http://reviews.vapour.ws/r/2699/)