### PR TITLE
instance: drop Instance.Refresh()

### DIFF
--- a/environs/testing/bootstrap.go
+++ b/environs/testing/bootstrap.go
@@ -23,7 +23,7 @@ var logger = loggo.GetLogger("juju.environs.testing")
 // do not attempt to SSH to non-existent machines. The result is a function
 // that restores finishBootstrap.
 func DisableFinishBootstrap() func() {
-	f := func(environs.BootstrapContext, ssh.Client, instance.Instance, *instancecfg.InstanceConfig) error {
+	f := func(environs.BootstrapContext, ssh.Client, environs.Environ, instance.Instance, *instancecfg.InstanceConfig) error {
 		logger.Warningf("provider/common.FinishBootstrap is disabled")
 		return nil
 	}

--- a/instance/instance.go
+++ b/instance/instance.go
@@ -28,9 +28,6 @@ type Instance interface {
 	// Status returns the provider-specific status for the instance.
 	Status() string
 
-	// Refresh refreshes local knowledge of the instance from the provider.
-	Refresh() error
-
 	// Addresses returns a list of hostnames or ip addresses
 	// associated with the instance.
 	Addresses() ([]network.Address, error)

--- a/provider/cloudsigma/instance.go
+++ b/provider/cloudsigma/instance.go
@@ -33,16 +33,6 @@ func (i sigmaInstance) Status() string {
 	return status
 }
 
-// Refresh refreshes local knowledge of the instance from the provider.
-func (i sigmaInstance) Refresh() error {
-	if i.server == nil {
-		return errors.New("invalid instance")
-	}
-	err := i.server.Refresh()
-	logger.Tracef("sigmaInstance.Refresh: %s", err)
-	return err
-}
-
 // Addresses returns a list of hostnames or ip addresses
 // associated with the instance. This will supercede DNSName
 // which can be implemented by selecting a preferred address.

--- a/provider/cloudsigma/instance_test.go
+++ b/provider/cloudsigma/instance_test.go
@@ -74,17 +74,6 @@ func (s *instanceSuite) TestInstanceStatus(c *gc.C) {
 	c.Check(s.inst.Status(), gc.Equals, "running")
 }
 
-func (s *instanceSuite) TestInstanceRefresh(c *gc.C) {
-	c.Check(s.inst.Status(), gc.Equals, "running")
-
-	mock.SetServerStatus("f4ec5097-121e-44a7-a207-75bc02163260", "stopped")
-
-	err := s.inst.Refresh()
-	c.Check(err, gc.IsNil)
-
-	c.Check(s.inst.Status(), gc.Equals, "stopped")
-}
-
 func (s *instanceSuite) TestInstanceAddresses(c *gc.C) {
 	addrs, err := s.inst.Addresses()
 	c.Check(addrs, gc.HasLen, 1)

--- a/provider/gce/google/instance.go
+++ b/provider/gce/google/instance.go
@@ -168,25 +168,6 @@ func (gi Instance) Status() string {
 	return gi.InstanceSummary.Status
 }
 
-// InstGetter exposes the Connection functionality needed by refresh.
-type InstGetter interface {
-	// Instance gets the up-to-date info about the given instance
-	// and returns it.
-	Instance(id, zone string) (Instance, error)
-}
-
-// Refresh updates the instance with its current data, utilizing the
-// provided connection to request it.
-func (gi *Instance) Refresh(conn InstGetter) error {
-	updated, err := conn.Instance(gi.ID, gi.ZoneName)
-	if err != nil {
-		return errors.Trace(err)
-	}
-
-	gi.InstanceSummary = updated.InstanceSummary
-	return nil
-}
-
 // Addresses identifies information about the network addresses
 // associated with the instance and returns it.
 func (gi Instance) Addresses() []network.Address {

--- a/provider/gce/google/instance_test.go
+++ b/provider/gce/google/instance_test.go
@@ -62,35 +62,6 @@ func (s *instanceSuite) TestInstanceStatusDown(c *gc.C) {
 	c.Check(status, gc.Equals, google.StatusDown)
 }
 
-func (s *instanceSuite) TestInstanceRefresh(c *gc.C) {
-	s.FakeConn.Instance = &s.RawInstanceFull
-
-	specBefore := google.GetInstanceSpec(&s.Instance)
-	err := s.Instance.Refresh(s.Conn)
-	c.Assert(err, jc.ErrorIsNil)
-	specAfter := google.GetInstanceSpec(&s.Instance)
-
-	c.Check(s.Instance.ID, gc.Equals, "spam")
-	c.Check(s.Instance.ZoneName, gc.Equals, "a-zone")
-	c.Check(s.Instance.Status(), gc.Equals, google.StatusRunning)
-	c.Check(s.Instance.Metadata(), jc.DeepEquals, s.Metadata)
-	c.Check(s.Instance.Addresses(), jc.DeepEquals, s.Addresses)
-	c.Check(specAfter, gc.Equals, specBefore)
-}
-
-func (s *instanceSuite) TestInstanceRefreshAPI(c *gc.C) {
-	s.FakeConn.Instance = &s.RawInstanceFull
-
-	err := s.Instance.Refresh(s.Conn)
-	c.Assert(err, jc.ErrorIsNil)
-
-	c.Check(s.FakeConn.Calls, gc.HasLen, 1)
-	c.Check(s.FakeConn.Calls[0].FuncName, gc.Equals, "GetInstance")
-	c.Check(s.FakeConn.Calls[0].ProjectID, gc.Equals, "spam")
-	c.Check(s.FakeConn.Calls[0].ZoneName, gc.Equals, "a-zone")
-	c.Check(s.FakeConn.Calls[0].ID, gc.Equals, "spam")
-}
-
 func (s *instanceSuite) TestInstanceAddresses(c *gc.C) {
 	addresses := s.Instance.Addresses()
 

--- a/provider/gce/instance.go
+++ b/provider/gce/instance.go
@@ -36,13 +36,6 @@ func (inst *environInstance) Status() string {
 	return inst.base.Status()
 }
 
-// Refresh implements instance.Instance.
-func (inst *environInstance) Refresh() error {
-	env := inst.env.getSnapshot()
-	err := inst.base.Refresh(env.gce)
-	return errors.Trace(err)
-}
-
 // Addresses implements instance.Instance.
 func (inst *environInstance) Addresses() ([]network.Address, error) {
 	return inst.base.Addresses(), nil

--- a/provider/gce/instance_test.go
+++ b/provider/gce/instance_test.go
@@ -40,18 +40,6 @@ func (s *instanceSuite) TestStatus(c *gc.C) {
 	s.CheckNoAPI(c)
 }
 
-func (s *instanceSuite) TestRefreshAPI(c *gc.C) {
-	s.FakeConn.Inst = s.BaseInstance
-
-	err := s.Instance.Refresh()
-	c.Assert(err, jc.ErrorIsNil)
-
-	c.Check(s.FakeConn.Calls, gc.HasLen, 1)
-	c.Check(s.FakeConn.Calls[0].FuncName, gc.Equals, "Instance")
-	c.Check(s.FakeConn.Calls[0].ID, gc.Equals, "spam")
-	c.Check(s.FakeConn.Calls[0].ZoneName, gc.Equals, "home-zone")
-}
-
 func (s *instanceSuite) TestAddresses(c *gc.C) {
 	addresses, err := s.Instance.Addresses()
 	c.Assert(err, jc.ErrorIsNil)

--- a/provider/joyent/instance.go
+++ b/provider/joyent/instance.go
@@ -25,10 +25,6 @@ func (inst *joyentInstance) Status() string {
 	return inst.machine.State
 }
 
-func (inst *joyentInstance) Refresh() error {
-	return nil
-}
-
 func (inst *joyentInstance) Addresses() ([]network.Address, error) {
 	addresses := make([]network.Address, 0, len(inst.machine.IPs))
 	for _, ip := range inst.machine.IPs {

--- a/provider/local/instance.go
+++ b/provider/local/instance.go
@@ -29,10 +29,6 @@ func (inst *localInstance) Status() string {
 	return ""
 }
 
-func (*localInstance) Refresh() error {
-	return nil
-}
-
 func (inst *localInstance) Addresses() ([]network.Address, error) {
 	if inst.id == bootstrapInstanceId {
 		addrs := []network.Address{{

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -933,7 +933,7 @@ func (environ *maasEnviron) StartInstance(args environs.StartInstanceParams) (
 		return nil, errors.Errorf("cannot run instances: %v", err)
 	}
 
-	inst := &maasInstance{maasObject: node, environ: environ}
+	inst := &maasInstance{node}
 	defer func() {
 		if err != nil {
 			if err := environ.StopInstances(inst.Id()); err != nil {
@@ -1322,10 +1322,7 @@ func (environ *maasEnviron) instances(filter url.Values) ([]instance.Instance, e
 		if err != nil {
 			return nil, err
 		}
-		instances[index] = &maasInstance{
-			maasObject: &node,
-			environ:    environ,
-		}
+		instances[index] = &maasInstance{&node}
 	}
 	return instances, nil
 }

--- a/provider/maas/environ_whitebox_test.go
+++ b/provider/maas/environ_whitebox_test.go
@@ -551,7 +551,7 @@ func (*environSuite) TestConvertNetworks(c *gc.C) {
 func (suite *environSuite) getInstance(systemId string) *maasInstance {
 	input := fmt.Sprintf(`{"system_id": %q}`, systemId)
 	node := suite.testMAASObject.TestServer.NewNode(input)
-	return &maasInstance{maasObject: &node, environ: suite.makeEnviron()}
+	return &maasInstance{&node}
 }
 
 func (suite *environSuite) getNetwork(name string, id int, vlanTag int) *gomaasapi.MAASObject {
@@ -959,7 +959,8 @@ func (suite *environSuite) TestGetInstanceNetworkInterfaces(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	suite.testMAASObject.TestServer.AddNodeDetails("testInstance", lshwXML)
-	interfaces, primaryIface, err := inst.environ.getInstanceNetworkInterfaces(inst)
+	env := suite.makeEnviron()
+	interfaces, primaryIface, err := env.getInstanceNetworkInterfaces(inst)
 	c.Assert(err, jc.ErrorIsNil)
 	// Both wlan0 and eth0 are disabled in lshw output.
 	c.Check(primaryIface, gc.Equals, "vnet1")

--- a/provider/maas/instance_test.go
+++ b/provider/maas/instance_test.go
@@ -22,7 +22,7 @@ func (s *instanceTest) TestId(c *gc.C) {
 	jsonValue := `{"system_id": "system_id", "test": "test"}`
 	obj := s.testMAASObject.TestServer.NewNode(jsonValue)
 	resourceURI, _ := obj.GetField("resource_uri")
-	instance := maasInstance{maasObject: &obj, environ: s.makeEnviron()}
+	instance := maasInstance{&obj}
 
 	c.Check(string(instance.Id()), gc.Equals, resourceURI)
 }
@@ -30,7 +30,7 @@ func (s *instanceTest) TestId(c *gc.C) {
 func (s *instanceTest) TestString(c *gc.C) {
 	jsonValue := `{"hostname": "thethingintheplace", "system_id": "system_id", "test": "test"}`
 	obj := s.testMAASObject.TestServer.NewNode(jsonValue)
-	instance := &maasInstance{maasObject: &obj, environ: s.makeEnviron()}
+	instance := &maasInstance{&obj}
 	hostname, err := instance.hostname()
 	c.Assert(err, jc.ErrorIsNil)
 	expected := hostname + ":" + string(instance.Id())
@@ -41,25 +41,11 @@ func (s *instanceTest) TestStringWithoutHostname(c *gc.C) {
 	// For good measure, test what happens if we don't have a hostname.
 	jsonValue := `{"system_id": "system_id", "test": "test"}`
 	obj := s.testMAASObject.TestServer.NewNode(jsonValue)
-	instance := &maasInstance{maasObject: &obj, environ: s.makeEnviron()}
+	instance := &maasInstance{&obj}
 	_, err := instance.hostname()
 	c.Assert(err, gc.NotNil)
 	expected := fmt.Sprintf("<DNSName failed: %q>", err) + ":" + string(instance.Id())
 	c.Assert(fmt.Sprint(instance), gc.Equals, expected)
-}
-
-func (s *instanceTest) TestRefreshInstance(c *gc.C) {
-	jsonValue := `{"system_id": "system_id", "test": "test"}`
-	obj := s.testMAASObject.TestServer.NewNode(jsonValue)
-	s.testMAASObject.TestServer.ChangeNode("system_id", "test2", "test2")
-	instance := maasInstance{maasObject: &obj, environ: s.makeEnviron()}
-
-	err := instance.Refresh()
-
-	c.Check(err, jc.ErrorIsNil)
-	testField, err := (*instance.maasObject).GetField("test2")
-	c.Check(err, jc.ErrorIsNil)
-	c.Check(testField, gc.Equals, "test2")
 }
 
 func (s *instanceTest) TestAddresses(c *gc.C) {
@@ -69,7 +55,7 @@ func (s *instanceTest) TestAddresses(c *gc.C) {
 			"ip_addresses": [ "1.2.3.4", "fe80::d806:dbff:fe23:1199" ]
 		}`
 	obj := s.testMAASObject.TestServer.NewNode(jsonValue)
-	inst := maasInstance{maasObject: &obj, environ: s.makeEnviron()}
+	inst := maasInstance{&obj}
 
 	expected := []network.Address{
 		network.NewScopedAddress("testing.invalid", network.ScopePublic),
@@ -92,7 +78,7 @@ func (s *instanceTest) TestAddressesMissing(c *gc.C) {
 		"system_id": "system_id"
 		}`
 	obj := s.testMAASObject.TestServer.NewNode(jsonValue)
-	inst := maasInstance{maasObject: &obj, environ: s.makeEnviron()}
+	inst := maasInstance{&obj}
 
 	addr, err := inst.Addresses()
 	c.Assert(err, jc.ErrorIsNil)
@@ -109,7 +95,7 @@ func (s *instanceTest) TestAddressesInvalid(c *gc.C) {
 		"ip_addresses": "incompatible"
 		}`
 	obj := s.testMAASObject.TestServer.NewNode(jsonValue)
-	inst := maasInstance{maasObject: &obj, environ: s.makeEnviron()}
+	inst := maasInstance{&obj}
 
 	_, err := inst.Addresses()
 	c.Assert(err, gc.NotNil)
@@ -122,7 +108,7 @@ func (s *instanceTest) TestAddressesInvalidContents(c *gc.C) {
 		"ip_addresses": [42]
 		}`
 	obj := s.testMAASObject.TestServer.NewNode(jsonValue)
-	inst := maasInstance{maasObject: &obj, environ: s.makeEnviron()}
+	inst := maasInstance{&obj}
 
 	_, err := inst.Addresses()
 	c.Assert(err, gc.NotNil)
@@ -136,7 +122,7 @@ func (s *instanceTest) TestHardwareCharacteristics(c *gc.C) {
         "memory": 16384
 	}`
 	obj := s.testMAASObject.TestServer.NewNode(jsonValue)
-	inst := maasInstance{maasObject: &obj, environ: s.makeEnviron()}
+	inst := maasInstance{&obj}
 	hc, err := inst.hardwareCharacteristics()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(hc, gc.NotNil)
@@ -152,7 +138,7 @@ func (s *instanceTest) TestHardwareCharacteristicsWithTags(c *gc.C) {
         "tag_names": ["a", "b"]
 	}`
 	obj := s.testMAASObject.TestServer.NewNode(jsonValue)
-	inst := maasInstance{maasObject: &obj, environ: s.makeEnviron()}
+	inst := maasInstance{&obj}
 	hc, err := inst.hardwareCharacteristics()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(hc, gc.NotNil)
@@ -172,7 +158,7 @@ func (s *instanceTest) TestHardwareCharacteristicsMissing(c *gc.C) {
 
 func (s *instanceTest) testHardwareCharacteristicsMissing(c *gc.C, json, expect string) {
 	obj := s.testMAASObject.TestServer.NewNode(json)
-	inst := maasInstance{maasObject: &obj, environ: s.makeEnviron()}
+	inst := maasInstance{&obj}
 	_, err := inst.hardwareCharacteristics()
 	c.Assert(err, gc.ErrorMatches, expect)
 }

--- a/provider/maas/volumes.go
+++ b/provider/maas/volumes.go
@@ -168,13 +168,13 @@ func (mi *maasInstance) volumes(
 	var volumes []storage.Volume
 	var attachments []storage.VolumeAttachment
 
-	deviceInfo, ok := mi.getMaasObject().GetMap()["physicalblockdevice_set"]
+	deviceInfo, ok := mi.maasObject.GetMap()["physicalblockdevice_set"]
 	// Older MAAS servers don't support storage.
 	if !ok || deviceInfo.IsNil() {
 		return volumes, attachments, nil
 	}
 
-	labelsMap, ok := mi.getMaasObject().GetMap()["constraint_map"]
+	labelsMap, ok := mi.maasObject.GetMap()["constraint_map"]
 	if !ok || labelsMap.IsNil() {
 		return nil, nil, errors.NotFoundf("constraint map field")
 	}

--- a/provider/maas/volumes_test.go
+++ b/provider/maas/volumes_test.go
@@ -74,7 +74,7 @@ func (s *volumeSuite) TestBuildMAASVolumeParametersWithTags(c *gc.C) {
 
 func (s *volumeSuite) TestInstanceVolumes(c *gc.C) {
 	obj := s.testMAASObject.TestServer.NewNode(validVolumeJson)
-	instance := maasInstance{maasObject: &obj, environ: s.makeEnviron()}
+	instance := maasInstance{&obj}
 	mTag := names.NewMachineTag("1")
 	volumes, attachments, err := instance.volumes(mTag, []names.VolumeTag{
 		names.NewVolumeTag("1"),
@@ -128,7 +128,7 @@ func (s *volumeSuite) TestInstanceVolumes(c *gc.C) {
 
 func (s *volumeSuite) TestInstanceVolumesOldMass(c *gc.C) {
 	obj := s.testMAASObject.TestServer.NewNode(`{"system_id": "node0"}`)
-	instance := maasInstance{maasObject: &obj, environ: s.makeEnviron()}
+	instance := maasInstance{&obj}
 	volumes, attachments, err := instance.volumes(names.NewMachineTag("1"), []names.VolumeTag{
 		names.NewVolumeTag("1"),
 		names.NewVolumeTag("2"),

--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -282,7 +282,13 @@ func (s *localServerSuite) TestBootstrapFailsWhenPublicIPError(c *gc.C) {
 func (s *localServerSuite) TestAddressesWithPublicIP(c *gc.C) {
 	// Floating IP address is 10.0.0.1
 	bootstrapFinished := false
-	s.PatchValue(&common.FinishBootstrap, func(ctx environs.BootstrapContext, client ssh.Client, inst instance.Instance, instanceConfig *instancecfg.InstanceConfig) error {
+	s.PatchValue(&common.FinishBootstrap, func(
+		ctx environs.BootstrapContext,
+		client ssh.Client,
+		env environs.Environ,
+		inst instance.Instance,
+		instanceConfig *instancecfg.InstanceConfig,
+	) error {
 		addr, err := inst.Addresses()
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(addr, jc.SameContents, []network.Address{
@@ -310,7 +316,13 @@ func (s *localServerSuite) TestAddressesWithPublicIP(c *gc.C) {
 
 func (s *localServerSuite) TestAddressesWithoutPublicIP(c *gc.C) {
 	bootstrapFinished := false
-	s.PatchValue(&common.FinishBootstrap, func(ctx environs.BootstrapContext, client ssh.Client, inst instance.Instance, instanceConfig *instancecfg.InstanceConfig) error {
+	s.PatchValue(&common.FinishBootstrap, func(
+		ctx environs.BootstrapContext,
+		client ssh.Client,
+		env environs.Environ,
+		inst instance.Instance,
+		instanceConfig *instancecfg.InstanceConfig,
+	) error {
 		addr, err := inst.Addresses()
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(addr, jc.SameContents, []network.Address{

--- a/provider/vsphere/instance.go
+++ b/provider/vsphere/instance.go
@@ -38,13 +38,6 @@ func (inst *environInstance) Status() string {
 	return ""
 }
 
-// Refresh implements instance.Instance.
-func (inst *environInstance) Refresh() error {
-	env := inst.env.getSnapshot()
-	err := env.client.Refresh(inst.base)
-	return errors.Trace(err)
-}
-
 // Addresses implements instance.Instance.
 func (inst *environInstance) Addresses() ([]network.Address, error) {
 	if inst.base.Guest == nil || inst.base.Guest.IpAddress == "" {


### PR DESCRIPTION
Drop the Instance.Refresh() method. It's used in
exactly one place, which is bootstrap, to refresh
addresses. This is unnecessary; the bootstrap code
can just call env.Instances() to get a new snapshot.

(Review request: http://reviews.vapour.ws/r/2706/)