### PR TITLE
simplestreams: Ensure HTTP resp.Body will always get closed

### DIFF
--- a/environs/simplestreams/datasource.go
+++ b/environs/simplestreams/datasource.go
@@ -79,12 +79,15 @@ func (h *urlDataSource) Fetch(path string) (io.ReadCloser, string, error) {
 		return nil, dataURL, errors.NotFoundf("invalid URL %q", dataURL)
 	}
 	if resp.StatusCode == http.StatusNotFound {
+		resp.Body.Close()
 		return nil, dataURL, errors.NotFoundf("cannot find URL %q", dataURL)
 	}
 	if resp.StatusCode == http.StatusUnauthorized {
+		resp.Body.Close()
 		return nil, dataURL, errors.Unauthorizedf("unauthorised access to URL %q", dataURL)
 	}
 	if resp.StatusCode != http.StatusOK {
+		resp.Body.Close()
 		return nil, dataURL, fmt.Errorf("cannot access URL %q, %q", dataURL, resp.Status)
 	}
 	return resp.Body, dataURL, nil


### PR DESCRIPTION
In some cases (explicit StatusCode handling) the HTTP/GET resp.Body in
Fetch() does not always get closed leading to file descriptor leaks.

It is unfortunate that we do the opening in Fetch() and the Close()
somewhere else (i.e., the caller). It would be much better if we could
rely on a single `defer resp.Body.Close()'.

To fix this I'm ensuring we close the body in those particular cases
where we introspect StatusCode and choose to return an error instead of
the response.

The documentation for http.client.Get() explicitly calls this out:

  // Caller should close resp.Body when done ...

Fixes [LP:#1496750](https://bugs.launchpad.net/juju-core/+bug/1496750)

(Review request: http://reviews.vapour.ws/r/2708/)