### PR TITLE
apiserver: don't Kill presence if mongo is dead

### DIFF
--- a/apiserver/admin.go
+++ b/apiserver/admin.go
@@ -310,6 +310,7 @@ func checkForValidMachineAgent(entity state.Entity, req params.LoginRequest) err
 // machinePinger wraps a presence.Pinger.
 type machinePinger struct {
 	*presence.Pinger
+	mongoUnavailable *bool
 }
 
 // Stop implements Pinger.Stop() as Pinger.Kill(), needed at
@@ -318,7 +319,15 @@ func (p *machinePinger) Stop() error {
 	if err := p.Pinger.Stop(); err != nil {
 		return err
 	}
-	return p.Pinger.Kill()
+	if !*p.mongoUnavailable {
+		// Kill marks the agent as not-present. If the
+		// Mongo server is known to be unavailable, then
+		// we do not perform this operation; the agent
+		// will naturally become "not present" when its
+		// presence expires.
+		return p.Pinger.Kill()
+	}
+	return nil
 }
 
 func startPingerIfAgent(root *apiHandler, entity state.Entity) error {
@@ -336,7 +345,7 @@ func startPingerIfAgent(root *apiHandler, entity state.Entity) error {
 		return err
 	}
 
-	root.getResources().Register(&machinePinger{pinger})
+	root.getResources().Register(&machinePinger{pinger, root.mongoUnavailable})
 	action := func() {
 		if err := root.getRpcConn().Close(); err != nil {
 			logger.Errorf("error closing the RPC connection: %v", err)

--- a/apiserver/admin.go
+++ b/apiserver/admin.go
@@ -319,15 +319,15 @@ func (p *machinePinger) Stop() error {
 	if err := p.Pinger.Stop(); err != nil {
 		return err
 	}
-	if !*p.mongoUnavailable {
+	if *p.mongoUnavailable {
 		// Kill marks the agent as not-present. If the
 		// Mongo server is known to be unavailable, then
 		// we do not perform this operation; the agent
 		// will naturally become "not present" when its
 		// presence expires.
-		return p.Pinger.Kill()
+		return nil
 	}
-	return nil
+	return p.Pinger.Kill()
 }
 
 func startPingerIfAgent(root *apiHandler, entity state.Entity) error {

--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -48,6 +48,7 @@ type Server struct {
 	limiter           utils.Limiter
 	validator         LoginValidator
 	adminApiFactories map[int]adminApiFactory
+	mongoUnavailable  bool
 
 	mu          sync.Mutex // protects the fields that follow
 	environUUID string
@@ -310,6 +311,11 @@ func (srv *Server) run(lis net.Listener) {
 	srv.wg.Add(1)
 	go func() {
 		err := srv.mongoPinger()
+		// Before killing the tomb, inform the API handlers that
+		// Mongo is unavailable. API handlers can use this to decide
+		// not to perform non-critical Mongo-related operations when
+		// tearing down.
+		srv.mongoUnavailable = true
 		srv.tomb.Kill(err)
 		srv.wg.Done()
 	}()

--- a/apiserver/root.go
+++ b/apiserver/root.go
@@ -42,10 +42,11 @@ type objectKey struct {
 // after it has logged in. It contains an rpc.MethodFinder which it
 // uses to dispatch Api calls appropriately.
 type apiHandler struct {
-	state     *state.State
-	rpcConn   *rpc.Conn
-	resources *common.Resources
-	entity    state.Entity
+	state            *state.State
+	rpcConn          *rpc.Conn
+	resources        *common.Resources
+	entity           state.Entity
+	mongoUnavailable *bool
 	// An empty envUUID means that the user has logged in through the
 	// root of the API server rather than the /environment/:env-uuid/api
 	// path, logins processed with v2 or later will only offer the
@@ -58,10 +59,11 @@ var _ = (*apiHandler)(nil)
 // newApiHandler returns a new apiHandler.
 func newApiHandler(srv *Server, st *state.State, rpcConn *rpc.Conn, reqNotifier *requestNotifier, envUUID string) (*apiHandler, error) {
 	r := &apiHandler{
-		state:     st,
-		resources: common.NewResources(),
-		rpcConn:   rpcConn,
-		envUUID:   envUUID,
+		state:            st,
+		resources:        common.NewResources(),
+		rpcConn:          rpcConn,
+		envUUID:          envUUID,
+		mongoUnavailable: &srv.mongoUnavailable,
 	}
 	if err := r.resources.RegisterNamed("machineID", common.StringResource(srv.tag.Id())); err != nil {
 		return nil, errors.Trace(err)


### PR DESCRIPTION
When mongo is unavailable/unreachable, don't attempt
to "kill" the agent presence. Presence is informational,
and so updating it should not block connection termination
when Mongo is unreachable.

Fixes https://bugs.launchpad.net/juju-core/+bug/1497229

(Review request: http://reviews.vapour.ws/r/2711/)