### PR TITLE
lp 1497297 Properly patch HostSeries

### DIFF
--- a/apiserver/common/tools_test.go
+++ b/apiserver/common/tools_test.go
@@ -206,6 +206,7 @@ func (s *toolsSuite) TestFindToolsExactInStorage(c *gc.C) {
 	}
 
 	s.PatchValue(&arch.HostArch, func() string { return arch.AMD64 })
+	s.PatchValue(&series.HostSeries, func() string { return "trusty" })
 	s.PatchValue(&version.Current, version.MustParseBinary("1.22-beta1-trusty-amd64"))
 	s.testFindToolsExact(c, mockToolsStorage, true, true)
 	s.PatchValue(&version.Current, version.MustParseBinary("1.22.0-trusty-amd64"))


### PR DESCRIPTION
TestFindToolsExactInStorage fails because it doesn't
patch out series.HostSeries()

(Review request: http://reviews.vapour.ws/r/2714/)