### PR TITLE
Fix timing issue in collect manifold test.

### DIFF
--- a/worker/metrics/collect/manifold_test.go
+++ b/worker/metrics/collect/manifold_test.go
@@ -87,6 +87,17 @@ func (s *ManifoldSuite) TestStartMissingDeps(c *gc.C) {
 
 // TestCollectWorkerStarts ensures that the manifold correctly sets up the worker.
 func (s *ManifoldSuite) TestCollectWorkerStarts(c *gc.C) {
+	s.PatchValue(collect.NewRecorder,
+		func(_ names.UnitTag, _ context.Paths, _ collect.UnitCharmLookup, _ spool.MetricFactory) (spool.MetricRecorder, error) {
+			// Return a dummyRecorder here, because otherwise a real one
+			// *might* get instantiated and error out, if the periodic worker
+			// happens to fire before the worker shuts down (as seen in
+			// LP:#1497355).
+			return &dummyRecorder{
+				charmURL: "cs:ubuntu-1",
+				unitTag:  "ubuntu/0",
+			}, nil
+		})
 	getResource := dt.StubGetResource(s.dummyResources)
 	worker, err := s.manifold.Start(getResource)
 	c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
Because this manifold starts a periodic worker, that worker may show an
error exit if not set up with a mock.

(Review request: http://reviews.vapour.ws/r/2719/)