### PR TITLE
Fixes http://pad.lv/1373516.

### DIFF
--- a/provider/ec2/image.go
+++ b/provider/ec2/image.go
@@ -16,9 +16,11 @@ var (
 	// If true, only inline PGP signed image metadata will be used.
 	signedImageDataOnly = true
 
-	// defaultType is the default EC2 instance we'd like to use if no
-	// constraints are specified.
-	defaultInstanceType = findInstanceTypeWithName("m3.medium", allInstanceTypes...)
+	// defaultInstanceTypeRef is the default EC2 instance we'd like to
+	// use as a reference when specifying default CpuPower and Mem
+	// constraints. This is only referenced if InstanceType is not
+	// specified.
+	defaultInstanceTypeRef = findInstanceTypeWithName("m3.medium", allInstanceTypes...)
 )
 
 // filterImages returns only that subset of the input (in the same order) that
@@ -52,10 +54,10 @@ func findInstanceSpec(
 	cons := ic.Constraints
 	if cons.InstanceType == nil || *cons.InstanceType == "" {
 		if cons.CpuPower == nil {
-			cons.CpuPower = defaultInstanceType.CpuPower
+			cons.CpuPower = defaultInstanceTypeRef.CpuPower
 		}
 		if cons.Mem == nil {
-			cons.Mem = &defaultInstanceType.Mem
+			cons.Mem = &defaultInstanceTypeRef.Mem
 		}
 	}
 

--- a/provider/ec2/instancetype.go
+++ b/provider/ec2/instancetype.go
@@ -24,6 +24,15 @@ var (
 // allRegions is defined here to allow tests to override the content.
 var allRegions = aws.Regions
 
+func findInstanceTypeWithName(name string, instanceTypes ...instances.InstanceType) *instances.InstanceType {
+	for _, i := range instanceTypes {
+		if i.Name == name {
+			return &i
+		}
+	}
+	return nil
+}
+
 // allInstanceTypes holds the relevant attributes of every known
 // instance type.
 //


### PR DESCRIPTION
In this patch we coerce Juju into using a more modern instance type, m3.medium. This is a bit of a hack, but a more comprehensive fix is underway for a future version.

(Review request: http://reviews.vapour.ws/r/2720/)