### PR TITLE
juju/series: remove dependency on the juju/testing package

### DIFF
--- a/juju/series/series_linux_test.go
+++ b/juju/series/series_linux_test.go
@@ -7,15 +7,15 @@ import (
 	"io/ioutil"
 	"path/filepath"
 
+	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/juju/series"
-	"github.com/juju/juju/testing"
 )
 
 type linuxVersionSuite struct {
-	testing.BaseSuite
+	testing.CleanupSuite
 }
 
 var futureReleaseFileContents = `NAME="Ubuntu"
@@ -34,6 +34,8 @@ var distroInfoContents = `version,codename,series,created,release,eol,eol-server
 var _ = gc.Suite(&linuxVersionSuite{})
 
 func (s *linuxVersionSuite) SetUpTest(c *gc.C) {
+	s.CleanupSuite.SetUpTest(c)
+
 	cleanup := series.SetSeriesVersions(make(map[string]string))
 	s.AddCleanup(func(*gc.C) { cleanup() })
 }
@@ -126,7 +128,7 @@ VERSION_ID="9.10"
 }
 
 type readSeriesSuite struct {
-	testing.BaseSuite
+	testing.CleanupSuite
 }
 
 var _ = gc.Suite(&readSeriesSuite{})

--- a/juju/series/series_test.go
+++ b/juju/series/series_test.go
@@ -6,15 +6,15 @@ package series_test
 import (
 	"fmt"
 
+	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/juju/series"
-	"github.com/juju/juju/testing"
 )
 
 type kernelVersionSuite struct {
-	testing.BaseSuite
+	testing.LoggingSuite
 }
 
 var _ = gc.Suite(&kernelVersionSuite{})

--- a/juju/series/series_windows_test.go
+++ b/juju/series/series_windows_test.go
@@ -7,17 +7,17 @@ package series_test
 import (
 	"fmt"
 
+	"github.com/juju/testing"
 	"github.com/juju/utils"
 
 	"github.com/gabriel-samfira/sys/windows/registry"
 	"github.com/juju/juju/juju/series"
-	"github.com/juju/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 )
 
 type windowsSeriesSuite struct {
-	testing.BaseSuite
+	testing.CleanupSuite
 }
 
 var _ = gc.Suite(&windowsSeriesSuite{})
@@ -77,7 +77,7 @@ var versionTests = []struct {
 }
 
 func (s *windowsSeriesSuite) SetUpTest(c *gc.C) {
-	s.BaseSuite.SetUpTest(c)
+	s.CleanupSuite.SetUpTest(c)
 	salt, err := utils.RandomPassword()
 	c.Assert(err, jc.ErrorIsNil)
 	regKey := fmt.Sprintf(`SOFTWARE\JUJU\%s`, salt)

--- a/juju/series/supportedseries.go
+++ b/juju/series/supportedseries.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 
 	"github.com/juju/errors"
-	jujuos "github.com/juju/utils/os"
+	"github.com/juju/utils/os"
 )
 
 type unknownOSForSeriesError string
@@ -116,30 +116,30 @@ var windowsVersions = map[string]string{
 
 // GetOSFromSeries will return the operating system based
 // on the series that is passed to it
-func GetOSFromSeries(series string) (jujuos.OSType, error) {
+func GetOSFromSeries(series string) (os.OSType, error) {
 	if series == "" {
-		return jujuos.Unknown, errors.NotValidf("series %q", series)
+		return os.Unknown, errors.NotValidf("series %q", series)
 	}
 	if _, ok := ubuntuSeries[series]; ok {
-		return jujuos.Ubuntu, nil
+		return os.Ubuntu, nil
 	}
 	if _, ok := centosSeries[series]; ok {
-		return jujuos.CentOS, nil
+		return os.CentOS, nil
 	}
 	if _, ok := archSeries[series]; ok {
-		return jujuos.Arch, nil
+		return os.Arch, nil
 	}
 	for _, val := range windowsVersions {
 		if val == series {
-			return jujuos.Windows, nil
+			return os.Windows, nil
 		}
 	}
 	for _, val := range macOSXSeries {
 		if val == series {
-			return jujuos.OSX, nil
+			return os.OSX, nil
 		}
 	}
-	return jujuos.Unknown, errors.Trace(unknownOSForSeriesError(series))
+	return os.Unknown, errors.Trace(unknownOSForSeriesError(series))
 }
 
 var (
@@ -178,7 +178,7 @@ func SupportedSeries() []string {
 
 // OSSupportedSeries returns the series of the specified OS on which we
 // can run Juju workloads.
-func OSSupportedSeries(os jujuos.OSType) []string {
+func OSSupportedSeries(os os.OSType) []string {
 	var osSeries []string
 	for _, series := range SupportedSeries() {
 		seriesOS, err := GetOSFromSeries(series)

--- a/juju/series/supportedseries_test.go
+++ b/juju/series/supportedseries_test.go
@@ -4,27 +4,24 @@
 package series_test
 
 import (
+	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/os"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/juju/series"
-	"github.com/juju/juju/testing"
 )
 
 type supportedSeriesSuite struct {
-	testing.BaseSuite
-	cleanup func()
+	testing.CleanupSuite
 }
 
 var _ = gc.Suite(&supportedSeriesSuite{})
 
 func (s *supportedSeriesSuite) SetUpTest(c *gc.C) {
-	s.cleanup = series.SetSeriesVersions(make(map[string]string))
-}
-
-func (s *supportedSeriesSuite) TearDownTest(c *gc.C) {
-	s.cleanup()
+	s.CleanupSuite.SetUpTest(c)
+	cleanup := series.SetSeriesVersions(make(map[string]string))
+	s.AddCleanup(func(*gc.C) { cleanup() })
 }
 
 var getOSFromSeriesTests = []struct {

--- a/juju/series/supportedseries_windows_test.go
+++ b/juju/series/supportedseries_windows_test.go
@@ -11,11 +11,9 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/juju/series"
-	"github.com/juju/juju/testing"
 )
 
 type supportedSeriesWindowsSuite struct {
-	testing.BaseSuite
 }
 
 var _ = gc.Suite(&supportedSeriesWindowsSuite{})


### PR DESCRIPTION
In preparation for moving juju/series to the utils repo, remove an
unneccessary dependency on github.com/juju/juju/testing. All the suites
in this package either need no base suite, or only require the basic
PatchValue/AddCleanup services offered by github.com/juju/testing.

(Review request: http://reviews.vapour.ws/r/2723/)