### PR TITLE
Closed session - bug 1497829.

### DIFF
--- a/api/imagemetadata/client.go
+++ b/api/imagemetadata/client.go
@@ -62,8 +62,6 @@ func (c *Client) Save(metadata []params.CloudImageMetadata) ([]params.ErrorResul
 // updates stored ones accordingly.
 // This method is primarily intended for a worker.
 func (c *Client) UpdateFromPublishedImages() error {
-	// TODO(wallyworld) - this is a temp "fix" to unblock master lp:1495542
-	return nil
-	//	return errors.Trace(
-	//		c.facade.FacadeCall("UpdateFromPublishedImages", nil, nil))
+	return errors.Trace(
+		c.facade.FacadeCall("UpdateFromPublishedImages", nil, nil))
 }

--- a/api/imagemetadata/client_test.go
+++ b/api/imagemetadata/client_test.go
@@ -178,7 +178,6 @@ func (s *imagemetadataSuite) TestSaveFacadeCallError(c *gc.C) {
 }
 
 func (s *imagemetadataSuite) TestUpdateFromPublishedImages(c *gc.C) {
-	c.Skip("temp disable to unblock master - lp:1495542")
 	called := false
 
 	apiCaller := testing.APICallerFunc(
@@ -201,7 +200,6 @@ func (s *imagemetadataSuite) TestUpdateFromPublishedImages(c *gc.C) {
 }
 
 func (s *imagemetadataSuite) TestUpdateFromPublishedImagesFacadeCallError(c *gc.C) {
-	c.Skip("temp disable to unblock master - lp:1495542")
 	called := false
 	msg := "facade failure"
 	apiCaller := testing.APICallerFunc(

--- a/apiserver/imagemetadata/package_test.go
+++ b/apiserver/imagemetadata/package_test.go
@@ -41,7 +41,7 @@ func (s *baseImageMetadataSuite) SetUpTest(c *gc.C) {
 	s.authorizer = testing.FakeAuthorizer{names.NewUserTag("testuser"), true}
 
 	s.calls = []string{}
-	s.state = s.constructState(c)
+	s.state = s.constructState()
 
 	var err error
 	s.api, err = imagemetadata.CreateAPI(s.state, s.resources, s.authorizer)
@@ -58,7 +58,7 @@ const (
 	environConfig = "environConfig"
 )
 
-func (s *baseImageMetadataSuite) constructState(c *gc.C) *mockState {
+func (s *baseImageMetadataSuite) constructState() *mockState {
 	return &mockState{
 		findMetadata: func(f cloudimagemetadata.MetadataFilter) (map[cloudimagemetadata.SourceType][]cloudimagemetadata.Metadata, error) {
 			s.calls = append(s.calls, findMetadata)

--- a/cmd/jujud/agent/agent_test.go
+++ b/cmd/jujud/agent/agent_test.go
@@ -16,11 +16,11 @@ import (
 	"github.com/juju/juju/agent"
 	agenttools "github.com/juju/juju/agent/tools"
 	apienvironment "github.com/juju/juju/api/environment"
-	"github.com/juju/juju/api/imagemetadata"
 	"github.com/juju/juju/apiserver/params"
 	agenttesting "github.com/juju/juju/cmd/jujud/agent/testing"
 	cmdutil "github.com/juju/juju/cmd/jujud/util"
 	"github.com/juju/juju/environs/filestorage"
+	"github.com/juju/juju/environs/imagemetadata"
 	envtesting "github.com/juju/juju/environs/testing"
 	"github.com/juju/juju/juju/paths"
 	"github.com/juju/juju/mongo"
@@ -99,9 +99,7 @@ func (s *AgentSuite) SetUpTest(c *gc.C) {
 	s.PatchValue(&proxyupdater.New, func(*apienvironment.Facade, bool) worker.Worker {
 		return newDummyWorker()
 	})
-	s.PatchValue(&newMetadataUpdater, func(cl *imagemetadata.Client) worker.Worker {
-		return worker.NewNoOpWorker()
-	})
+	imagemetadata.DefaultBaseURL = ""
 }
 
 func (s *AgentSuite) primeAPIHostPorts(c *gc.C) {

--- a/cmd/jujud/agent/agent_test.go
+++ b/cmd/jujud/agent/agent_test.go
@@ -99,6 +99,8 @@ func (s *AgentSuite) SetUpTest(c *gc.C) {
 	s.PatchValue(&proxyupdater.New, func(*apienvironment.Facade, bool) worker.Worker {
 		return newDummyWorker()
 	})
+
+	// Tests should not try to use internet. Ensure base url is empty.
 	imagemetadata.DefaultBaseURL = ""
 }
 

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -1090,18 +1090,18 @@ func (a *MachineAgent) StateWorker() (worker.Worker, error) {
 			logger.Warningf("ignoring unknown job %q", job)
 		}
 	}
-	return cmdutil.NewCloseWorker(logger, runner, stateWorkerCloser{st, stor}), nil
+	return cmdutil.NewCloseWorker(logger, runner, stateWorkerCloser{st}), nil
 }
 
 type stateWorkerCloser struct {
 	stateCloser io.Closer
-	storage     statestorage.Storage
 }
 
 func (s stateWorkerCloser) Close() error {
-	// (anastasiamac 2015-09-21) Bug#1497829
-	// Un-register state dependent data source before closing state.
-	unregisterSimplestreamsDataSource(s.storage)
+	// Bug#1497829
+	// This state-dependent data source will be useless once state is closed -
+	// un-register it before closing state.
+	unregisterSimplestreamsDataSource()
 	return s.stateCloser.Close()
 }
 

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -1098,7 +1098,6 @@ type stateWorkerCloser struct {
 }
 
 func (s stateWorkerCloser) Close() error {
-	// Bug#1497829
 	// This state-dependent data source will be useless once state is closed -
 	// un-register it before closing state.
 	unregisterSimplestreamsDataSource()

--- a/cmd/jujud/agent/simplestreams.go
+++ b/cmd/jujud/agent/simplestreams.go
@@ -16,6 +16,11 @@ import (
 	"github.com/juju/juju/state/storage"
 )
 
+const (
+	storageDataSourceId          = "environment storage"
+	storageDataSourceDescription = storageDataSourceId
+)
+
 // environmentStorageDataSource is a simplestreams.DataSource that
 // retrieves simplestreams metadata from environment storage.
 type environmentStorageDataSource struct {
@@ -30,7 +35,7 @@ func NewEnvironmentStorageDataSource(stor storage.Storage) simplestreams.DataSou
 
 // Description is defined in simplestreams.DataSource.
 func (d environmentStorageDataSource) Description() string {
-	return storageDataStoreDescription
+	return storageDataSourceDescription
 }
 
 // Fetch is defined in simplestreams.DataSource.
@@ -68,9 +73,7 @@ func registerSimplestreamsDataSource(stor storage.Storage) {
 	})
 }
 
-const storageDataStoreDescription = "environment storage"
-
 // unregisterSimplestreamsDataSource de-registers an environmentStorageDataSource.
 func unregisterSimplestreamsDataSource() {
-	environs.UnregisterImageDataSourceFunc(storageDataStoreDescription)
+	environs.UnregisterImageDataSourceFunc(storageDataSourceDescription)
 }

--- a/cmd/jujud/agent/simplestreams.go
+++ b/cmd/jujud/agent/simplestreams.go
@@ -16,10 +16,7 @@ import (
 	"github.com/juju/juju/state/storage"
 )
 
-const (
-	storageDataSourceId          = "environment storage"
-	storageDataSourceDescription = storageDataSourceId
-)
+const storageDataSourceDescription = "environment storage"
 
 // environmentStorageDataSource is a simplestreams.DataSource that
 // retrieves simplestreams metadata from environment storage.

--- a/cmd/jujud/agent/simplestreams.go
+++ b/cmd/jujud/agent/simplestreams.go
@@ -67,3 +67,9 @@ func registerSimplestreamsDataSource(stor storage.Storage) {
 		return ds, nil
 	})
 }
+
+// unregisterSimplestreamsDataSource de-registers an environmentStorageDataSource.
+func unregisterSimplestreamsDataSource(stor storage.Storage) {
+	ds := NewEnvironmentStorageDataSource(stor)
+	environs.UnregisterImageDataSourceFunc(ds.Description())
+}

--- a/cmd/jujud/agent/simplestreams.go
+++ b/cmd/jujud/agent/simplestreams.go
@@ -16,7 +16,10 @@ import (
 	"github.com/juju/juju/state/storage"
 )
 
-const storageDataSourceDescription = "environment storage"
+const (
+	storageDataSourceId          = "environment storage"
+	storageDataSourceDescription = storageDataSourceId
+)
 
 // environmentStorageDataSource is a simplestreams.DataSource that
 // retrieves simplestreams metadata from environment storage.
@@ -65,12 +68,12 @@ func (d environmentStorageDataSource) SetAllowRetry(allow bool) {
 // registerSimplestreamsDataSource registers a environmentStorageDataSource.
 func registerSimplestreamsDataSource(stor storage.Storage) {
 	ds := NewEnvironmentStorageDataSource(stor)
-	environs.RegisterUserImageDataSourceFunc(ds.Description(), func(environs.Environ) (simplestreams.DataSource, error) {
+	environs.RegisterUserImageDataSourceFunc(storageDataSourceId, func(environs.Environ) (simplestreams.DataSource, error) {
 		return ds, nil
 	})
 }
 
 // unregisterSimplestreamsDataSource de-registers an environmentStorageDataSource.
 func unregisterSimplestreamsDataSource() {
-	environs.UnregisterImageDataSourceFunc(storageDataSourceDescription)
+	environs.UnregisterImageDataSourceFunc(storageDataSourceId)
 }

--- a/cmd/jujud/agent/simplestreams.go
+++ b/cmd/jujud/agent/simplestreams.go
@@ -30,7 +30,7 @@ func NewEnvironmentStorageDataSource(stor storage.Storage) simplestreams.DataSou
 
 // Description is defined in simplestreams.DataSource.
 func (d environmentStorageDataSource) Description() string {
-	return "environment storage"
+	return storageDataStoreDescription
 }
 
 // Fetch is defined in simplestreams.DataSource.
@@ -68,8 +68,9 @@ func registerSimplestreamsDataSource(stor storage.Storage) {
 	})
 }
 
+const storageDataStoreDescription = "environment storage"
+
 // unregisterSimplestreamsDataSource de-registers an environmentStorageDataSource.
-func unregisterSimplestreamsDataSource(stor storage.Storage) {
-	ds := NewEnvironmentStorageDataSource(stor)
-	environs.UnregisterImageDataSourceFunc(ds.Description())
+func unregisterSimplestreamsDataSource() {
+	environs.UnregisterImageDataSourceFunc(storageDataStoreDescription)
 }

--- a/cmd/jujud/agent/upgrade.go
+++ b/cmd/jujud/agent/upgrade.go
@@ -180,7 +180,6 @@ func (c *upgradeWorkerContext) run(stop <-chan struct{}) error {
 		stor := storage.NewStorage(c.st.EnvironUUID(), c.st.MongoSession())
 		registerSimplestreamsDataSource(stor)
 
-		// Bug#1497829
 		// This state-dependent data source will be useless
 		// once state is closed in previous defer - un-register it.
 		defer unregisterSimplestreamsDataSource()

--- a/cmd/jujud/agent/upgrade.go
+++ b/cmd/jujud/agent/upgrade.go
@@ -171,6 +171,7 @@ func (c *upgradeWorkerContext) run(stop <-chan struct{}) error {
 		if c.st, err = openStateForUpgrade(c.agent, c.agentConfig); err != nil {
 			return err
 		}
+		defer c.st.Close()
 
 		if c.isMaster, err = isMachineMaster(c.st, c.machineId); err != nil {
 			return errors.Trace(err)
@@ -179,13 +180,10 @@ func (c *upgradeWorkerContext) run(stop <-chan struct{}) error {
 		stor := storage.NewStorage(c.st.EnvironUUID(), c.st.MongoSession())
 		registerSimplestreamsDataSource(stor)
 
-		// (anastasiamac 2015-09-21) moved the defer until after
-		// storage is defined as data source needs to be un-registered
-		// before state is closed - Bug#1497829
-		defer func() {
-			unregisterSimplestreamsDataSource(stor)
-			c.st.Close()
-		}()
+		// Bug#1497829
+		// This state-dependent data source will be useless
+		// once state is closed in previous defer - un-register it.
+		defer unregisterSimplestreamsDataSource()
 	}
 	if err := c.runUpgrades(); err != nil {
 		// Only return an error from the worker if the connection to

--- a/environs/imagemetadata.go
+++ b/environs/imagemetadata.go
@@ -47,21 +47,6 @@ func RegisterUserImageDataSourceFunc(id string, f ImageDataSourceFunc) {
 	datasourceFuncs = append([]datasourceFuncId{datasourceFuncId{id, f}}, datasourceFuncs...)
 }
 
-// UnregisterUserImageDataSourceFunc unregisters an ImageDataSourceFunc
-// with the specified id.
-func UnregisterUserImageDataSourceFunc(id string) {
-	datasourceFuncsMu.Lock()
-	defer datasourceFuncsMu.Unlock()
-	for i, f := range datasourceFuncs {
-		if f.id == id {
-			head := datasourceFuncs[:i]
-			tail := datasourceFuncs[i+1:]
-			datasourceFuncs = append(head, tail...)
-			return
-		}
-	}
-}
-
 // RegisterImageDataSourceFunc registers an ImageDataSourceFunc
 // with the specified id, overwriting any function previously registered
 // with the same id.

--- a/environs/imagemetadata.go
+++ b/environs/imagemetadata.go
@@ -35,32 +35,14 @@ type ImageDataSourceFunc func(Environ) (simplestreams.DataSource, error)
 // with the specified id at the start of the search path, overwriting
 // any function previously registered with the same id.
 func RegisterUserImageDataSourceFunc(id string, f ImageDataSourceFunc) {
-	datasourceFuncsMu.Lock()
-	defer datasourceFuncsMu.Unlock()
-	for i := range datasourceFuncs {
-		if datasourceFuncs[i].id == id {
-			datasourceFuncs[i].f = f
-			return
-		}
-	}
-	logger.Debugf("new user image datasource registered: %v", id)
-	datasourceFuncs = append([]datasourceFuncId{datasourceFuncId{id, f}}, datasourceFuncs...)
+	register(id, f, "user")
 }
 
 // RegisterImageDataSourceFunc registers an ImageDataSourceFunc
 // with the specified id, overwriting any function previously registered
 // with the same id.
 func RegisterImageDataSourceFunc(id string, f ImageDataSourceFunc) {
-	datasourceFuncsMu.Lock()
-	defer datasourceFuncsMu.Unlock()
-	for i := range datasourceFuncs {
-		if datasourceFuncs[i].id == id {
-			datasourceFuncs[i].f = f
-			return
-		}
-	}
-	logger.Debugf("new environment image datasource registered: %v", id)
-	datasourceFuncs = append(datasourceFuncs, datasourceFuncId{id, f})
+	register(id, f, "environment")
 }
 
 // UnregisterImageDataSourceFunc unregisters an ImageDataSourceFunc
@@ -132,4 +114,19 @@ func environmentDataSources(env Environ) ([]simplestreams.DataSource, error) {
 		datasources = append(datasources, datasource)
 	}
 	return datasources, nil
+}
+
+// register registers an ImageDataSourceFunc with the specified id,
+// overwriting any function previously registered with the same id.
+func register(id string, f ImageDataSourceFunc, msg string) {
+	datasourceFuncsMu.Lock()
+	defer datasourceFuncsMu.Unlock()
+	for i := range datasourceFuncs {
+		if datasourceFuncs[i].id == id {
+			datasourceFuncs[i].f = f
+			return
+		}
+	}
+	logger.Debugf("new %v image datasource registered: %v", msg, id)
+	datasourceFuncs = append([]datasourceFuncId{datasourceFuncId{id, f}}, datasourceFuncs...)
 }

--- a/worker/imagemetadataworker/metadataupdater_test.go
+++ b/worker/imagemetadataworker/metadataupdater_test.go
@@ -20,7 +20,6 @@ type imageMetadataUpdateSuite struct {
 }
 
 func (s *imageMetadataUpdateSuite) TestWorker(c *gc.C) {
-	c.Skip("temp disable to unblock master - lp:1495542")
 	done := make(chan struct{})
 	client := s.ImageClient(done)
 


### PR DESCRIPTION
This proposal ensures that previously registered state-dependent data sources are unregistered before state is closed. This bug was affecting agent machine state worker and state server upgrades.

As a result of the fix, previously skipped related tests are now longer skipped.

Drive-bys:
1. Removed gc.C from test setup as it is not the same as used during tests. Consequently, some unexpected and unwanted behavior may occur.
2. Instead of patching worker for tests, set metadata default base URL to empty string.

(Review request: http://reviews.vapour.ws/r/2724/)