### PR TITLE
lp 1485784: Retry lxc container creation / clone

### DIFF
--- a/container/lxc/lxc_test.go
+++ b/container/lxc/lxc_test.go
@@ -662,9 +662,9 @@ func (s *LxcSuite) TestCreateContainer(c *gc.C) {
 	c.Assert(location, gc.Equals, expectedTarget)
 }
 
-func (s *LxcSuite) TestCreateContainerFailsWithInjectedError(c *gc.C) {
+func (s *LxcSuite) TestCreateContainerFailsWithInjectedStartError(c *gc.C) {
 	errorChannel := make(chan error, 1)
-	cleanup := mock.PatchTransientErrorInjectionChannel(errorChannel)
+	cleanup := mock.PatchStartTransientErrorInjectionChannel(errorChannel)
 	defer cleanup()
 
 	// One injected error means the container creation will fail
@@ -677,13 +677,54 @@ func (s *LxcSuite) TestCreateContainerFailsWithInjectedError(c *gc.C) {
 	c.Assert(err, gc.NotNil)
 
 	// this should be a retryable error
-	isRetryable := instance.IsRetryableCreationError(errors.Cause(err))
+	retryErr, isRetryable := instance.GetRetryableCreationError(errors.Cause(err))
 	c.Assert(isRetryable, jc.IsTrue)
+	c.Assert(retryErr.RetryCount(), gc.Equals, 1)
+	c.Assert(retryErr.RetryDelay(), gc.Equals, 0)
+}
+
+func (s *LxcSuite) TestCreateContainerFailsWithInjectedCreateError(c *gc.C) {
+	errorChannel := make(chan error, 1)
+	cleanup := mock.PatchCreateTransientErrorInjectionChannel(errorChannel)
+	defer cleanup()
+
+	errorChannel <- errors.New("lxc-create error")
+
+	manager := s.makeManager(c, "test")
+	_, err := containertesting.CreateContainerTest(c, manager, "1/lxc/0")
+	c.Assert(err, gc.NotNil)
+
+	// this should be a retryable error
+	retryErr, isRetryable := instance.GetRetryableCreationError(errors.Cause(err))
+	c.Assert(isRetryable, jc.IsTrue)
+	c.Assert(retryErr.RetryCount(), gc.Equals, 3)
+	c.Assert(retryErr.RetryDelay(), gc.Equals, 10)
+	c.Assert(retryErr, gc.ErrorMatches, "lxc container creation failed.*")
+}
+
+func (s *LxcSuite) TestCreateContainerFailsWithInjectedCloneError(c *gc.C) {
+	errorChannel := make(chan error, 1)
+	cleanup := mock.PatchCloneTransientErrorInjectionChannel(errorChannel)
+	defer cleanup()
+
+	errorChannel <- errors.New("lxc-clone error")
+
+	s.createTemplate(c)
+	s.PatchValue(&s.useClone, true)
+	manager := s.makeManager(c, "test")
+	_, err := containertesting.CreateContainerTest(c, manager, "1")
+
+	// this should be a retryable error
+	retryErr, isRetryable := instance.GetRetryableCreationError(errors.Cause(err))
+	c.Assert(isRetryable, jc.IsTrue)
+	c.Assert(retryErr.RetryCount(), gc.Equals, 3)
+	c.Assert(retryErr.RetryDelay(), gc.Equals, 10)
+	c.Assert(retryErr, gc.ErrorMatches, "lxc container cloning failed.*")
 }
 
 func (s *LxcSuite) TestCreateContainerWithInjectedErrorDestroyFails(c *gc.C) {
 	errorChannel := make(chan error, 2)
-	cleanup := mock.PatchTransientErrorInjectionChannel(errorChannel)
+	cleanup := mock.PatchStartTransientErrorInjectionChannel(errorChannel)
 	defer cleanup()
 
 	// Two injected errors mean that the container creation and subsequent

--- a/container/lxc/mock/mock-lxc.go
+++ b/container/lxc/mock/mock-lxc.go
@@ -26,13 +26,31 @@ var logger = loggo.GetLogger("juju.container.lxc.mock")
 
 type Action int
 
-var transientErrorInjection chan error
+var (
+	startTransientErrorInjection  chan error
+	createTransientErrorInjection chan error
+	cloneTransientErrorInjection  chan error
+)
 
-// PatchTransientErrorInjectionChannel sets the transientInjectionError
+// PatchStartTransientErrorInjectionChannel sets the startTransientInjectionError
 // channel which can be used to inject errors into Start function for
-// testing purposes
-func PatchTransientErrorInjectionChannel(c chan error) func() {
-	return testing.PatchValue(&transientErrorInjection, c)
+// testing purposes.
+func PatchStartTransientErrorInjectionChannel(c chan error) func() {
+	return testing.PatchValue(&startTransientErrorInjection, c)
+}
+
+// PatchCreateTransientErrorInjectionChannel sets the createTransientInjectionError
+// channel which can be used to inject errors into Create function for
+// testing purposes.
+func PatchCreateTransientErrorInjectionChannel(c chan error) func() {
+	return testing.PatchValue(&createTransientErrorInjection, c)
+}
+
+// PatchCloneTransientErrorInjectionChannel sets the cloneTransientInjectionError
+// channel which can be used to inject errors into Clone function for
+// testing purposes.
+func PatchCloneTransientErrorInjectionChannel(c chan error) func() {
+	return testing.PatchValue(&cloneTransientErrorInjection, c)
 }
 
 const (
@@ -125,6 +143,12 @@ func (mock *mockContainer) configFilename() string {
 
 // Create creates a new container based on the given template.
 func (mock *mockContainer) Create(configFile, template string, extraArgs []string, templateArgs []string, envArgs []string) error {
+	select {
+	case injectedError := <-createTransientErrorInjection:
+		return injectedError
+	default:
+	}
+
 	if mock.getState() != golxc.StateUnknown {
 		return fmt.Errorf("container is already created")
 	}
@@ -145,7 +169,7 @@ func (mock *mockContainer) Create(configFile, template string, extraArgs []strin
 // Start runs the container as a daemon.
 func (mock *mockContainer) Start(configFile, consoleFile string) error {
 	select {
-	case injectedError := <-transientErrorInjection:
+	case injectedError := <-startTransientErrorInjection:
 		return injectedError
 	default:
 	}
@@ -179,6 +203,12 @@ func (mock *mockContainer) Stop() error {
 
 // Clone creates a copy of the container, giving the copy the specified name.
 func (mock *mockContainer) Clone(name string, extraArgs []string, templateArgs []string) (golxc.Container, error) {
+	select {
+	case injectedError := <-cloneTransientErrorInjection:
+		return nil, injectedError
+	default:
+	}
+
 	state := mock.getState()
 	if state == golxc.StateUnknown {
 		return nil, fmt.Errorf("container has not been created")
@@ -220,7 +250,7 @@ func (mock *mockContainer) Unfreeze() error {
 // Destroy stops and removes the container.
 func (mock *mockContainer) Destroy() error {
 	select {
-	case injectedError := <-transientErrorInjection:
+	case injectedError := <-startTransientErrorInjection:
 		return injectedError
 	default:
 	}

--- a/instance/instance.go
+++ b/instance/instance.go
@@ -74,13 +74,32 @@ func uintStr(i uint64) string {
 // that it is safe to restart instance creation
 type RetryableCreationError struct {
 	message string
+
+	// retryCount is the number of follow on attempts that should be
+	// made to create the instance.
+	retryCount int
+
+	// retryDelay is the delay, in seconds, between retry attempts.
+	retryDelay int
 }
 
-// Returns the error message
+// Error returns the error message.
 func (e RetryableCreationError) Error() string { return e.message }
 
-func NewRetryableCreationError(errorMessage string) *RetryableCreationError {
-	return &RetryableCreationError{errorMessage}
+// RetryCount returns the retryCount.
+func (e RetryableCreationError) RetryCount() int { return e.retryCount }
+
+// RetryDelay returns the retryDelay.
+func (e RetryableCreationError) RetryDelay() int { return e.retryDelay }
+
+// NewRetryableCreationError returns a new RetryableCreationError with
+// the message, retry count and retry delay as specified.
+func NewRetryableCreationError(errorMessage string, count int, delay int) *RetryableCreationError {
+	return &RetryableCreationError{
+		message:    errorMessage,
+		retryCount: count,
+		retryDelay: delay,
+	}
 }
 
 // IsRetryableCreationError returns true if the given error is
@@ -88,6 +107,17 @@ func NewRetryableCreationError(errorMessage string) *RetryableCreationError {
 func IsRetryableCreationError(err error) bool {
 	_, ok := err.(*RetryableCreationError)
 	return ok
+}
+
+// GetRetryableCreationError returns the RetryableCreationError wrapped
+// in the specified error, and a bool indicating whether or not the error
+// was a *RetryableCreationError.
+func GetRetryableCreationError(err error) (*RetryableCreationError, bool) {
+	retryErr, ok := err.(*RetryableCreationError)
+	if !ok {
+		return nil, false
+	}
+	return retryErr, true
 }
 
 func (hc HardwareCharacteristics) String() string {

--- a/instance/instance_test.go
+++ b/instance/instance_test.go
@@ -12,9 +12,9 @@ import (
 	"github.com/juju/juju/instance"
 )
 
-type HardwareSuite struct{}
+type instanceSuite struct{}
 
-var _ = gc.Suite(&HardwareSuite{})
+var _ = gc.Suite(&instanceSuite{})
 
 type parseHardwareTestSpec struct {
 	summary string
@@ -273,25 +273,21 @@ var parseHardwareTests = []parseHardwareTestSpec{
 	},
 }
 
-func (s *HardwareSuite) TestParseHardware(c *gc.C) {
+func (s *instanceSuite) TestParseHardware(c *gc.C) {
 	for i, t := range parseHardwareTests {
 		c.Logf("test %d: %s", i, t.summary)
 		t.check(c)
 	}
 }
 
-type RetryErrSuite struct{}
-
-var _ = gc.Suite(&RetryErrSuite{})
-
-func (s *RetryErrSuite) TestNewRetryErr(c *gc.C) {
+func (s *instanceSuite) TestNewRetryErr(c *gc.C) {
 	retErr := instance.NewRetryableCreationError("test error message", 10, 20)
 	c.Check(retErr.Error(), gc.Equals, "test error message")
 	c.Check(retErr.RetryCount(), gc.Equals, 10)
 	c.Check(retErr.RetryDelay(), gc.Equals, 20)
 }
 
-func (s *RetryErrSuite) TestRetryErrCheckers(c *gc.C) {
+func (s *instanceSuite) TestRetryErrCheckers(c *gc.C) {
 	retErr := instance.NewRetryableCreationError("test error message", 10, 20)
 	err := errors.New("non-retryable error")
 	c.Check(instance.IsRetryableCreationError(retErr), jc.IsTrue)

--- a/worker/provisioner/export_test.go
+++ b/worker/provisioner/export_test.go
@@ -44,6 +44,7 @@ var (
 	MaybeOverrideDefaultLXCNet = maybeOverrideDefaultLXCNet
 	EtcDefaultLXCNetPath       = &etcDefaultLXCNetPath
 	EtcDefaultLXCNet           = etcDefaultLXCNet
+	MaxInstanceRetryDelay      = &maxInstanceRetryDelay
 )
 
 const (

--- a/worker/provisioner/provisioner_task.go
+++ b/worker/provisioner/provisioner_task.go
@@ -694,7 +694,8 @@ func (task *provisionerTask) startMachine(
 ) error {
 	result, err := task.broker.StartInstance(startInstanceParams)
 	if err != nil {
-		// If this is a retryable error, we retry as requested.
+		// If the broker has indicated that the error encountered is temporary and
+		// subsequent attempts may succeed, then retry as requested.
 		retryErr, ok := instance.GetRetryableCreationError(errors.Cause(err))
 		if !ok || retryErr.RetryCount() <= 0 {
 			// Not a retryable error. Set the state to error, so the
@@ -720,7 +721,8 @@ func (task *provisionerTask) startMachine(
 			result, err = task.broker.StartInstance(startInstanceParams)
 			if err == nil {
 				break
-			} else if !instance.IsRetryableCreationError(errors.Cause(err)) || count == 1 {
+			}
+			if !instance.IsRetryableCreationError(errors.Cause(err)) || count == 1 {
 				// If we encountered a non-retryable error, or this is our last attempt,
 				// report that starting the instance failed.
 				return task.setErrorStatus("cannot start instance for machine after a retry %q: %v", machine, err)

--- a/worker/provisioner/provisioner_test.go
+++ b/worker/provisioner/provisioner_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/juju/utils"
 	"github.com/juju/utils/set"
 	gc "gopkg.in/check.v1"
+	"launchpad.net/tomb"
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/api"
@@ -622,9 +623,10 @@ func (s *ProvisionerSuite) TestProvisionerFailedStartInstanceWithInjectedCreatio
 	cleanup := dummy.PatchTransientErrorInjectionChannel(errorInjectionChannel)
 	defer cleanup()
 
-	retryableError := instance.NewRetryableCreationError("container failed to start and was destroyed")
+	retryableError := instance.NewRetryableCreationError("container failed to start and was destroyed", 3, 0)
 	destroyError := errors.New("container failed to start and failed to destroy: manual cleanup of containers needed")
-	// send the error message TWICE, because the provisioner will retry only ONCE
+	// Send both error messages to make sure that the provisioner gives up retrying
+	// once a non-retryable error is returned.
 	errorInjectionChannel <- retryableError
 	errorInjectionChannel <- destroyError
 
@@ -644,9 +646,9 @@ func (s *ProvisionerSuite) TestProvisionerFailedStartInstanceWithInjectedCreatio
 		c.Assert(statusInfo.Status, gc.Equals, state.StatusError)
 		// check that the status matches the error message
 		c.Assert(statusInfo.Message, gc.Equals, destroyError.Error())
-		break
+		return
 	}
-
+	c.Fatal("Test took too long to complete")
 }
 
 func (s *ProvisionerSuite) TestProvisionerSucceedStartInstanceWithInjectedRetryableCreationError(c *gc.C) {
@@ -663,7 +665,7 @@ func (s *ProvisionerSuite) TestProvisionerSucceedStartInstanceWithInjectedRetrya
 
 	// send the error message once
 	// - instance creation should succeed
-	retryableError := instance.NewRetryableCreationError("container failed to start and was destroyed")
+	retryableError := instance.NewRetryableCreationError("container failed to start and was destroyed", 3, 0)
 	errorInjectionChannel <- retryableError
 
 	m, err := s.addMachine()
@@ -685,7 +687,7 @@ func (s *ProvisionerSuite) TestProvisionerSucceedStartInstanceWithInjectedWrappe
 
 	// send the error message once
 	// - instance creation should succeed
-	retryableError := errors.Wrap(errors.New(""), instance.NewRetryableCreationError("container failed to start and was destroyed"))
+	retryableError := errors.Wrap(errors.New(""), instance.NewRetryableCreationError("container failed to start and was destroyed", 1, 0))
 	errorInjectionChannel <- retryableError
 
 	m, err := s.addMachine()
@@ -726,8 +728,150 @@ func (s *ProvisionerSuite) TestProvisionerFailStartInstanceWithInjectedNonRetrya
 		c.Assert(statusInfo.Status, gc.Equals, state.StatusError)
 		// check that the status matches the error message
 		c.Assert(statusInfo.Message, gc.Equals, nonRetryableError.Error())
-		break
+		return
 	}
+	c.Fatal("Test took too long to complete")
+}
+
+func (s *ProvisionerSuite) TestProvisionerNoRetriesForZeroRetryCount(c *gc.C) {
+	// create the error injection channel
+	errorInjectionChannel := make(chan error, 1)
+
+	p := s.newEnvironProvisioner(c)
+	defer stop(c, p)
+
+	// patch the dummy provider error injection channel
+	cleanup := dummy.PatchTransientErrorInjectionChannel(errorInjectionChannel)
+	defer cleanup()
+
+	retryableError := instance.NewRetryableCreationError("not really a retryable error", 0, 0)
+	errorInjectionChannel <- retryableError
+
+	m, err := s.addMachine()
+	c.Assert(err, jc.ErrorIsNil)
+	s.checkNoOperations(c)
+
+	t0 := time.Now()
+	for time.Since(t0) < coretesting.LongWait {
+		// And check the machine status is set to error.
+		statusInfo, err := m.Status()
+		c.Assert(err, jc.ErrorIsNil)
+		if statusInfo.Status == state.StatusPending {
+			time.Sleep(coretesting.ShortWait)
+			continue
+		}
+		c.Assert(statusInfo.Status, gc.Equals, state.StatusError)
+		// check that the status matches the error message
+		c.Assert(statusInfo.Message, gc.Equals, "not really a retryable error")
+		return
+	}
+	c.Fatal("Test took too long to complete")
+}
+
+func (s *ProvisionerSuite) TestProvisionerRetryableErrorTriggersMultipleAttempts(c *gc.C) {
+	// Create the error injection channel.  Inject 7 errors to
+	// verify that we give up after the max number of retries (5).
+	errorInjectionChannel := make(chan error, 7)
+
+	p := s.newEnvironProvisioner(c)
+	defer stop(c, p)
+
+	// patch the dummy provider error injection channel
+	cleanup := dummy.PatchTransientErrorInjectionChannel(errorInjectionChannel)
+	defer cleanup()
+
+	for i := 0; i < 7; i++ {
+		msg := fmt.Sprintf("failure: %d", i)
+		retryableError := instance.NewRetryableCreationError(msg, 10, 0)
+		errorInjectionChannel <- retryableError
+	}
+
+	m, err := s.addMachine()
+	c.Assert(err, jc.ErrorIsNil)
+	s.checkNoOperations(c)
+
+	t0 := time.Now()
+	for time.Since(t0) < coretesting.LongWait {
+		// And check the machine status is set to error.
+		statusInfo, err := m.Status()
+		c.Assert(err, jc.ErrorIsNil)
+		if statusInfo.Status == state.StatusPending {
+			time.Sleep(coretesting.ShortWait)
+			continue
+		}
+		c.Assert(statusInfo.Status, gc.Equals, state.StatusError)
+		// check that the status matches the error message
+		c.Assert(statusInfo.Message, gc.Equals, "failure: 5")
+		return
+	}
+	c.Fatal("Test took too long to complete")
+}
+
+func (s *ProvisionerSuite) TestProvisionerRetryableErrorMultipleAttemptsHonorsMaxDelay(c *gc.C) {
+	// Create the error injection channel.
+	errorInjectionChannel := make(chan error, 1)
+
+	p := s.newEnvironProvisioner(c)
+	defer stop(c, p)
+
+	// patch the dummy provider error injection channel
+	cleanup := dummy.PatchTransientErrorInjectionChannel(errorInjectionChannel)
+	defer cleanup()
+
+	retryableError := instance.NewRetryableCreationError("retry with long delay error", 1, 600)
+	errorInjectionChannel <- retryableError
+
+	m, err := s.addMachine()
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.PatchValue(provisioner.MaxInstanceRetryDelay, 10)
+
+	t0 := time.Now()
+	for time.Since(t0) < (30 * time.Second) {
+		// Check if the machine has been provisioned.
+		_, err := m.InstanceId()
+		if errors.IsNotProvisioned(err) {
+			continue
+		}
+		c.Assert(err, jc.ErrorIsNil)
+
+		// Check that we delayed at least 10 seconds.
+		elapsed := time.Since(t0)
+		c.Assert(elapsed, jc.GreaterThan, (10 * time.Second))
+		s.checkStartInstanceNoSecureConnection(c, m)
+		return
+	}
+	c.Fatal("Test took too long to complete")
+}
+
+func (s *ProvisionerSuite) TestProvisionerStopRetryingIfDying(c *gc.C) {
+	// Create the error injection channel and inject
+	// a retryable error
+	errorInjectionChannel := make(chan error, 1)
+
+	p := s.newEnvironProvisioner(c)
+	// Don't refer the stop.  We will manually stop and verify the result.
+
+	// patch the dummy provider error injection channel
+	cleanup := dummy.PatchTransientErrorInjectionChannel(errorInjectionChannel)
+	defer cleanup()
+
+	// Inject a retry error with a delay longer than coretesting.LongWait
+	retryableError := instance.NewRetryableCreationError("retryable error", 10, 30)
+	errorInjectionChannel <- retryableError
+
+	m, err := s.addMachine()
+	c.Assert(err, jc.ErrorIsNil)
+	s.checkNoOperations(c)
+
+	time.Sleep(coretesting.ShortWait)
+
+	stop(c, p)
+	statusInfo, err := m.Status()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(statusInfo.Status, gc.Equals, state.StatusError)
+	// check that the status matches the error message
+	c.Assert(statusInfo.Message, gc.Equals, tomb.ErrDying.Error())
 }
 
 func (s *ProvisionerSuite) TestProvisioningDoesNotOccurForLXC(c *gc.C) {


### PR DESCRIPTION
If an error is returned from lxc-create or lxc-clone,
treat it as a transient error and retry with a slight
delay.

(Review request: http://reviews.vapour.ws/r/2729/)