### PR TITLE
uniter: add optional filtering to storage-list

### DIFF
--- a/worker/uniter/runner/jujuc/storage-list.go
+++ b/worker/uniter/runner/jujuc/storage-list.go
@@ -6,6 +6,7 @@ package jujuc
 import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
+	"github.com/juju/names"
 	"launchpad.net/gnuflag"
 )
 
@@ -14,8 +15,9 @@ import (
 // StorageListCommand implements cmd.Command.
 type StorageListCommand struct {
 	cmd.CommandBase
-	ctx Context
-	out cmd.Output
+	ctx         Context
+	out         cmd.Output
+	storageName string
 }
 
 func NewStorageListCommand(ctx Context) (cmd.Command, error) {
@@ -27,9 +29,13 @@ func (c *StorageListCommand) Info() *cmd.Info {
 storage-list will list the names of all storage instances
 attached to the unit. These names can be passed to storage-get
 via the "-s" flag to query the storage attributes.
+
+A storage name may be specified, in which case only storage
+instances for that named storage will be returned.
 `
 	return &cmd.Info{
 		Name:    "storage-list",
+		Args:    "[<storage-name>]",
 		Purpose: "list storage attached to the unit",
 		Doc:     doc,
 	}
@@ -40,7 +46,12 @@ func (c *StorageListCommand) SetFlags(f *gnuflag.FlagSet) {
 }
 
 func (c *StorageListCommand) Init(args []string) (err error) {
-	return cmd.CheckEmpty(args)
+	storageName, err := cmd.ZeroOrOneArgs(args)
+	if err != nil {
+		return err
+	}
+	c.storageName = storageName
+	return nil
 }
 
 func (c *StorageListCommand) Run(ctx *cmd.Context) error {
@@ -48,9 +59,19 @@ func (c *StorageListCommand) Run(ctx *cmd.Context) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	names := make([]string, len(tags))
-	for i, tag := range tags {
-		names[i] = tag.Id()
+	ids := make([]string, 0, len(tags))
+	for _, tag := range tags {
+		id := tag.Id()
+		if c.storageName != "" {
+			storageName, err := names.StorageName(id)
+			if err != nil {
+				return errors.Trace(err)
+			}
+			if storageName != c.storageName {
+				continue
+			}
+		}
+		ids = append(ids, id)
 	}
-	return c.out.Write(ctx, names)
+	return c.out.Write(ctx, ids)
 }


### PR DESCRIPTION
Enhance storage-list to accept an optional storage name
argument, so that the results can be constrained to only
those matching the specified storage name.

(Review request: http://reviews.vapour.ws/r/2733/)