### PR TITLE
all: remove unnecessary testing.BaseSuite (part 1)

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -23,9 +23,7 @@ import (
 	"github.com/juju/juju/version"
 )
 
-type suite struct {
-	testing.BaseSuite
-}
+type suite struct{}
 
 var _ = gc.Suite(&suite{})
 

--- a/agent/bootstrap_test.go
+++ b/agent/bootstrap_test.go
@@ -31,14 +31,16 @@ import (
 )
 
 type bootstrapSuite struct {
-	testing.BaseSuite
-	mgoInst gitjujutesting.MgoInstance
+	gitjujutesting.CleanupSuite
+	gitjujutesting.LoggingSuite // quench mongo output
+	mgoInst                     gitjujutesting.MgoInstance
 }
 
 var _ = gc.Suite(&bootstrapSuite{})
 
 func (s *bootstrapSuite) SetUpTest(c *gc.C) {
-	s.BaseSuite.SetUpTest(c)
+	s.CleanupSuite.SetUpTest(c)
+	s.LoggingSuite.SetUpTest(c)
 	// Don't use MgoSuite, because we need to ensure
 	// we have a fresh mongo for each test case.
 	s.mgoInst.EnableAuth = true
@@ -48,7 +50,8 @@ func (s *bootstrapSuite) SetUpTest(c *gc.C) {
 
 func (s *bootstrapSuite) TearDownTest(c *gc.C) {
 	s.mgoInst.Destroy()
-	s.BaseSuite.TearDownTest(c)
+	s.LoggingSuite.TearDownTest(c)
+	s.CleanupSuite.TearDownTest(c)
 }
 
 func (s *bootstrapSuite) TestInitializeState(c *gc.C) {

--- a/agent/format-1.18_whitebox_test.go
+++ b/agent/format-1.18_whitebox_test.go
@@ -16,13 +16,10 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/state/multiwatcher"
-	"github.com/juju/juju/testing"
 	"github.com/juju/juju/version"
 )
 
-type format_1_18Suite struct {
-	testing.BaseSuite
-}
+type format_1_18Suite struct{}
 
 var _ = gc.Suite(&format_1_18Suite{})
 

--- a/agent/format_whitebox_test.go
+++ b/agent/format_whitebox_test.go
@@ -20,9 +20,7 @@ import (
 	"github.com/juju/juju/version"
 )
 
-type formatSuite struct {
-	testing.BaseSuite
-}
+type formatSuite struct{}
 
 var _ = gc.Suite(&formatSuite{})
 

--- a/agent/identity_test.go
+++ b/agent/identity_test.go
@@ -19,7 +19,6 @@ import (
 )
 
 type identitySuite struct {
-	testing.BaseSuite
 	mongodConfigPath string
 	mongodPath       string
 }

--- a/api/addresser/addresser_test.go
+++ b/api/addresser/addresser_test.go
@@ -6,6 +6,7 @@ package addresser_test
 import (
 	"errors"
 
+	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -14,12 +15,11 @@ import (
 	apitesting "github.com/juju/juju/api/base/testing"
 	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
-	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/watcher"
 )
 
 type AddresserSuite struct {
-	coretesting.BaseSuite
+	testing.CleanupSuite
 }
 
 var _ = gc.Suite(&AddresserSuite{})

--- a/api/annotations/client_test.go
+++ b/api/annotations/client_test.go
@@ -8,13 +8,11 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/api/annotations"
-	basetesting "github.com/juju/juju/api/base/testing"
+	"github.com/juju/juju/api/base/testing"
 	"github.com/juju/juju/apiserver/params"
-	coretesting "github.com/juju/juju/testing"
 )
 
 type annotationsMockSuite struct {
-	coretesting.BaseSuite
 	annotationsClient *annotations.Client
 }
 
@@ -28,7 +26,7 @@ func (s *annotationsMockSuite) TestSetEntitiesAnnotation(c *gc.C) {
 		"charmA":   annts,
 		"serviceB": annts2,
 	}
-	apiCaller := basetesting.APICallerFunc(
+	apiCaller := testing.APICallerFunc(
 		func(objType string,
 			version int,
 			id, request string,
@@ -60,7 +58,7 @@ func (s *annotationsMockSuite) TestSetEntitiesAnnotation(c *gc.C) {
 
 func (s *annotationsMockSuite) TestGetEntitiesAnnotations(c *gc.C) {
 	var called bool
-	apiCaller := basetesting.APICallerFunc(
+	apiCaller := testing.APICallerFunc(
 		func(
 			objType string,
 			version int,

--- a/apiserver/network_test.go
+++ b/apiserver/network_test.go
@@ -7,14 +7,13 @@ import (
 	"time"
 
 	"github.com/juju/errors"
+	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-
-	"github.com/juju/juju/testing"
 )
 
 type networkSuite struct {
-	testing.BaseSuite
+	testing.CleanupSuite
 }
 
 var _ = gc.Suite(&networkSuite{})

--- a/cloudconfig/cloudinit/cloudinit_test.go
+++ b/cloudconfig/cloudinit/cloudinit_test.go
@@ -14,14 +14,12 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cloudconfig/cloudinit"
-	coretesting "github.com/juju/juju/testing"
+	sshtesting "github.com/juju/juju/utils/ssh/testing"
 )
 
 // TODO integration tests, but how?
 
-type S struct {
-	coretesting.BaseSuite
-}
+type S struct{}
 
 var _ = gc.Suite(S{})
 

--- a/container/directory_test.go
+++ b/container/directory_test.go
@@ -7,15 +7,15 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/container"
-	"github.com/juju/juju/testing"
 )
 
 type DirectorySuite struct {
-	testing.BaseSuite
+	testing.CleanupSuite
 	containerDir string
 	removedDir   string
 }
@@ -23,7 +23,7 @@ type DirectorySuite struct {
 var _ = gc.Suite(&DirectorySuite{})
 
 func (s *DirectorySuite) SetUpTest(c *gc.C) {
-	s.BaseSuite.SetUpTest(c)
+	s.CleanupSuite.SetUpTest(c)
 	s.containerDir = c.MkDir()
 	s.PatchValue(&container.ContainerDir, s.containerDir)
 	s.removedDir = c.MkDir()

--- a/container/factory/factory_test.go
+++ b/container/factory/factory_test.go
@@ -10,12 +10,9 @@ import (
 	"github.com/juju/juju/container"
 	"github.com/juju/juju/container/factory"
 	"github.com/juju/juju/instance"
-	"github.com/juju/juju/testing"
 )
 
-type factorySuite struct {
-	testing.BaseSuite
-}
+type factorySuite struct{}
 
 var _ = gc.Suite(&factorySuite{})
 

--- a/container/image_test.go
+++ b/container/image_test.go
@@ -12,16 +12,16 @@ import (
 	"github.com/juju/juju/container"
 	containertesting "github.com/juju/juju/container/testing"
 	"github.com/juju/juju/instance"
-	coretesting "github.com/juju/juju/testing"
 )
 
 type imageURLSuite struct {
-	coretesting.BaseSuite
+	testing.CleanupSuite
 }
 
 var _ = gc.Suite(&imageURLSuite{})
 
 func (s *imageURLSuite) SetUpTest(c *gc.C) {
+	s.CleanupSuite.SetUpTest(c)
 	testing.PatchExecutable(c, s, "ubuntu-cloudimg-query", containertesting.FakeLxcURLScript)
 }
 

--- a/downloader/downloader_test.go
+++ b/downloader/downloader_test.go
@@ -20,28 +20,7 @@ import (
 )
 
 type suite struct {
-	testing.BaseSuite
 	gitjujutesting.HTTPSuite
-}
-
-func (s *suite) SetUpSuite(c *gc.C) {
-	s.BaseSuite.SetUpSuite(c)
-	s.HTTPSuite.SetUpSuite(c)
-}
-
-func (s *suite) TearDownSuite(c *gc.C) {
-	s.HTTPSuite.TearDownSuite(c)
-	s.BaseSuite.TearDownSuite(c)
-}
-
-func (s *suite) SetUpTest(c *gc.C) {
-	s.BaseSuite.SetUpTest(c)
-	s.HTTPSuite.SetUpTest(c)
-}
-
-func (s *suite) TearDownTest(c *gc.C) {
-	s.HTTPSuite.TearDownTest(c)
-	s.BaseSuite.TearDownTest(c)
 }
 
 var _ = gc.Suite(&suite{})

--- a/environs/bootstrap/tools_test.go
+++ b/environs/bootstrap/tools_test.go
@@ -5,6 +5,7 @@ package bootstrap_test
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/arch"
 	"github.com/juju/utils/os"
@@ -13,13 +14,13 @@ import (
 
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/bootstrap"
-	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/juju/series"
 	"github.com/juju/juju/tools"
 	"github.com/juju/juju/version"
 )
 
 type toolsSuite struct {
-	coretesting.BaseSuite
+	testing.CleanupSuite
 }
 
 var _ = gc.Suite(&toolsSuite{})

--- a/environs/config/authkeys_test.go
+++ b/environs/config/authkeys_test.go
@@ -9,24 +9,25 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
 	"github.com/juju/utils/ssh"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/environs/config"
-	"github.com/juju/juju/testing"
+	"github.com/juju/juju/utils/ssh"
 )
 
 type AuthKeysSuite struct {
-	testing.BaseSuite
+	testing.CleanupSuite
 	dotssh string // ~/.ssh
 }
 
 var _ = gc.Suite(&AuthKeysSuite{})
 
 func (s *AuthKeysSuite) SetUpTest(c *gc.C) {
-	s.BaseSuite.SetUpTest(c)
+	s.CleanupSuite.SetUpTest(c)
 	old := utils.Home()
 	newhome := c.MkDir()
 	utils.SetHome(newhome)
@@ -38,7 +39,7 @@ func (s *AuthKeysSuite) SetUpTest(c *gc.C) {
 
 func (s *AuthKeysSuite) TearDownTest(c *gc.C) {
 	ssh.ClearClientKeys()
-	s.BaseSuite.TearDownTest(c)
+	s.CleanupSuite.TearDownTest(c)
 }
 
 func (s *AuthKeysSuite) TestReadAuthorizedKeysErrors(c *gc.C) {

--- a/network/address_test.go
+++ b/network/address_test.go
@@ -12,12 +12,9 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/network"
-	"github.com/juju/juju/testing"
 )
 
-type AddressSuite struct {
-	testing.BaseSuite
-}
+type AddressSuite struct{}
 
 var _ = gc.Suite(&AddressSuite{})
 

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"path/filepath"
 
+	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -86,7 +87,7 @@ func (s *InterfaceInfoSuite) TestSortInterfaceInfo(c *gc.C) {
 }
 
 type NetworkSuite struct {
-	testing.BaseSuite
+	gitjujutesting.CleanupSuite
 }
 
 var _ = gc.Suite(&NetworkSuite{})

--- a/network/portrange_test.go
+++ b/network/portrange_test.go
@@ -8,12 +8,9 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/network"
-	"github.com/juju/juju/testing"
 )
 
-type PortRangeSuite struct {
-	testing.BaseSuite
-}
+type PortRangeSuite struct{}
 
 var _ = gc.Suite(&PortRangeSuite{})
 

--- a/network/portset_test.go
+++ b/network/portset_test.go
@@ -10,12 +10,9 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/network"
-	"github.com/juju/juju/testing"
 )
 
 type PortSetSuite struct {
-	testing.BaseSuite
-
 	portRange1 network.PortRange
 	portRange2 network.PortRange
 	portRange3 network.PortRange
@@ -25,8 +22,6 @@ type PortSetSuite struct {
 var _ = gc.Suite(&PortSetSuite{})
 
 func (s *PortSetSuite) SetUpTest(c *gc.C) {
-	s.BaseSuite.SetUpTest(c)
-
 	portRange1, err := network.ParsePortRange("8000-8099/tcp")
 	c.Assert(err, jc.ErrorIsNil)
 	portRange2, err := network.ParsePortRange("80/tcp")

--- a/provider/azure/config_test.go
+++ b/provider/azure/config_test.go
@@ -5,13 +5,13 @@ package azure_test
 
 import (
 	"github.com/Azure/azure-sdk-for-go/Godeps/_workspace/src/github.com/Azure/go-autorest/autorest/mocks"
+	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/provider/azure"
-	"github.com/juju/juju/testing"
+	coretesting "github.com/juju/juju/testing"
 )
 
 const (
@@ -23,9 +23,29 @@ const (
 )
 
 type configSuite struct {
-	testing.BaseSuite
+	testing.CleanupSuite
+	testing.LoggingSuite // quench warnings
+}
 
-	provider environs.EnvironProvider
+func (s *configSuite) SetUpSuite(c *gc.C) {
+	s.CleanupSuite.SetUpSuite(c)
+	s.LoggingSuite.SetUpSuite(c)
+}
+
+func (s *configSuite) TearDownSuite(c *gc.C) {
+	s.LoggingSuite.TearDownSuite(c)
+	s.CleanupSuite.TearDownSuite(c)
+}
+
+var _ = gc.Suite(&configSuite{})
+
+// makeConfigMap creates a minimal map of standard configuration items,
+// adds the given extra items to that and returns it.
+func makeConfigMap(extra map[string]interface{}) map[string]interface{} {
+	return coretesting.FakeConfig().Merge(coretesting.Attrs{
+		"name": "testenv",
+		"type": "azure",
+	}).Merge(extra)
 }
 
 var _ = gc.Suite(&configSuite{})

--- a/rpc/jsoncodec/codec_test.go
+++ b/rpc/jsoncodec/codec_test.go
@@ -1,3 +1,6 @@
+// Copyright 2012, 2013 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
 package jsoncodec_test
 
 import (

--- a/rpc/reflect_test.go
+++ b/rpc/reflect_test.go
@@ -10,15 +10,12 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/rpc/rpcreflect"
-	"github.com/juju/juju/testing"
 )
 
 // We test rpcreflect in this package, so that the
 // tests can all share the same testing Root type.
 
-type reflectSuite struct {
-	testing.BaseSuite
-}
+type reflectSuite struct{}
 
 var _ = gc.Suite(&reflectSuite{})
 

--- a/rpc/rpc_test.go
+++ b/rpc/rpc_test.go
@@ -15,19 +15,19 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
+	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/rpc"
 	"github.com/juju/juju/rpc/jsoncodec"
 	"github.com/juju/juju/rpc/rpcreflect"
-	"github.com/juju/juju/testing"
 )
 
 var logger = loggo.GetLogger("juju.rpc")
 
 type rpcSuite struct {
-	testing.BaseSuite
+	testing.LoggingSuite // quench output
 }
 
 var _ = gc.Suite(&rpcSuite{})

--- a/state/backups/archive_test.go
+++ b/state/backups/archive_test.go
@@ -8,12 +8,9 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/state/backups"
-	"github.com/juju/juju/testing"
 )
 
-type archiveSuite struct {
-	testing.BaseSuite
-}
+type archiveSuite struct{}
 
 var _ = gc.Suite(&archiveSuite{})
 

--- a/storage/constraints_test.go
+++ b/storage/constraints_test.go
@@ -4,15 +4,15 @@
 package storage_test
 
 import (
+	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/storage"
-	"github.com/juju/juju/testing"
 )
 
 type ConstraintsSuite struct {
-	testing.BaseSuite
+	testing.LoggingSuite // quench warnings to console
 }
 
 var _ = gc.Suite(&ConstraintsSuite{})

--- a/storage/looputil/loop_test.go
+++ b/storage/looputil/loop_test.go
@@ -11,12 +11,9 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/storage/looputil"
-	"github.com/juju/juju/testing"
 )
 
-type LoopUtilSuite struct {
-	testing.BaseSuite
-}
+type LoopUtilSuite struct{}
 
 var _ = gc.Suite(&LoopUtilSuite{})
 

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -12,13 +12,10 @@ import (
 	"gopkg.in/mgo.v2/bson"
 	goyaml "gopkg.in/yaml.v2"
 
-	"github.com/juju/juju/testing"
 	"github.com/juju/juju/version"
 )
 
-type suite struct {
-	testing.BaseSuite
-}
+type suite struct{}
 
 var _ = gc.Suite(&suite{})
 


### PR DESCRIPTION
All of these tests imported testing.BaseSuite unnecessarily, many
need no suite at all. For the ones that use PatchValue, or rely on
a side effect of changing the logging level, import the necessary
suites as required.

(Review request: http://reviews.vapour.ws/r/2734/)