### PR TITLE
apiserver/common: fix StorageAttachmentInfo

### DIFF
--- a/apiserver/common/storage.go
+++ b/apiserver/common/storage.go
@@ -4,8 +4,6 @@
 package common
 
 import (
-	"path"
-
 	"github.com/juju/errors"
 	"github.com/juju/names"
 
@@ -49,6 +47,10 @@ type StorageInterface interface {
 	// WatchVolumeAttachment watches for changes to the volume attachment
 	// corresponding to the identfified machien and volume.
 	WatchVolumeAttachment(names.MachineTag, names.VolumeTag) state.NotifyWatcher
+
+	// BlockDevices returns information about block devices published
+	// for the specified machine.
+	BlockDevices(names.MachineTag) ([]state.BlockDeviceInfo, error)
 }
 
 // StorageAttachmentInfo returns the StorageAttachmentInfo for the specified
@@ -95,10 +97,17 @@ func volumeStorageAttachmentInfo(
 		return nil, errors.Annotate(err, "getting volume attachment info")
 	}
 	devicePath, err := volumeAttachmentDevicePath(
+		st,
 		volumeInfo,
 		volumeAttachmentInfo,
+		machineTag,
 	)
-	if err != nil {
+	if err == errNoBlockDevice {
+		// We don't have enough information to describe the storage
+		// attachment yet, so we must say that it is not provisioned
+		// to prevent feeding clients with partial information.
+		return nil, errors.NotProvisionedf("%v", names.ReadableString(storageTag))
+	} else if err != nil {
 		return nil, errors.Trace(err)
 	}
 	return &storage.StorageAttachmentInfo{
@@ -165,21 +174,38 @@ func WatchStorageAttachment(
 	return newMultiNotifyWatcher(w, w2), nil
 }
 
-var errNoDevicePath = errors.New("cannot determine device path: no serial or persistent device name")
+var errNoBlockDevice = errors.New("cannot determine device path: no matching block device found")
 
 // volumeAttachmentDevicePath returns the absolute device path for
 // a volume attachment. The value is only meaningful in the context
 // of the machine that the volume is attached to.
 func volumeAttachmentDevicePath(
+	st StorageInterface,
 	volumeInfo state.VolumeInfo,
 	volumeAttachmentInfo state.VolumeAttachmentInfo,
+	machineTag names.MachineTag,
 ) (string, error) {
-	if volumeInfo.HardwareId != "" {
-		return path.Join("/dev/disk/by-id", volumeInfo.HardwareId), nil
-	} else if volumeAttachmentInfo.DeviceName != "" {
-		return path.Join("/dev", volumeAttachmentInfo.DeviceName), nil
+	if volumeInfo.HardwareId != "" || volumeAttachmentInfo.DeviceName != "" {
+		// The storage provider has enough information
+		// to determine the device path.
+		return storage.BlockDevicePath(storage.BlockDevice{
+			HardwareId: volumeInfo.HardwareId,
+			DeviceName: volumeAttachmentInfo.DeviceName,
+		})
 	}
-	return "", errNoDevicePath
+	blockDevices, err := st.BlockDevices(machineTag)
+	if err != nil {
+		return "", errors.Annotate(err, "getting block devices")
+	}
+	blockDevice, ok := MatchingBlockDevice(
+		blockDevices,
+		volumeInfo,
+		volumeAttachmentInfo,
+	)
+	if !ok {
+		return "", errNoBlockDevice
+	}
+	return storage.BlockDevicePath(BlockDeviceFromState(*blockDevice))
 }
 
 // MaybeAssignedStorageInstance calls the provided function to get a

--- a/apiserver/storage/state.go
+++ b/apiserver/storage/state.go
@@ -44,6 +44,9 @@ type storageAccess interface {
 	// WatchVolumeAttachment is required for storage functionality.
 	WatchVolumeAttachment(names.MachineTag, names.VolumeTag) state.NotifyWatcher
 
+	// BlockDevices is required for storage functionality.
+	BlockDevices(names.MachineTag) ([]state.BlockDeviceInfo, error)
+
 	// EnvName is required for pool functionality.
 	EnvName() (string, error)
 

--- a/apiserver/storage/volumelist_test.go
+++ b/apiserver/storage/volumelist_test.go
@@ -5,6 +5,7 @@ package storage_test
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -150,5 +151,59 @@ func (s *volumeSuite) TestListVolumesAttachmentInfo(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(found.Results, gc.HasLen, 1)
 	s.assertAndClearStorageStatus(c, found.Results[0].Details)
+	c.Assert(found.Results[0], jc.DeepEquals, expected)
+}
+
+func (s *volumeSuite) TestListVolumesStorageLocationNoBlockDevice(c *gc.C) {
+	s.storageInstance.kind = state.StorageKindBlock
+	s.volume.info = &state.VolumeInfo{}
+	s.volumeAttachment.info = &state.VolumeAttachmentInfo{
+		ReadOnly: true,
+	}
+	expected := s.expectedVolumeDetailsResult()
+	expected.Details.Storage.Kind = params.StorageKindBlock
+	expected.Details.Storage.Status.Status = params.StatusAttached
+	expected.Details.MachineAttachments[s.machineTag.String()] = params.VolumeAttachmentInfo{
+		ReadOnly: true,
+	}
+	expected.LegacyAttachments[0].Info = params.VolumeAttachmentInfo{
+		ReadOnly: true,
+	}
+	found, err := s.api.ListVolumes(params.VolumeFilter{})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(found.Results, gc.HasLen, 1)
+	c.Assert(found.Results[0], jc.DeepEquals, expected)
+}
+
+func (s *volumeSuite) TestListVolumesStorageLocationBlockDevicePath(c *gc.C) {
+	s.state.blockDevices = func(names.MachineTag) ([]state.BlockDeviceInfo, error) {
+		return []state.BlockDeviceInfo{{
+			BusAddress: "bus-addr",
+			DeviceName: "sdd",
+		}}, nil
+	}
+	s.storageInstance.kind = state.StorageKindBlock
+	s.volume.info = &state.VolumeInfo{}
+	s.volumeAttachment.info = &state.VolumeAttachmentInfo{
+		BusAddress: "bus-addr",
+		ReadOnly:   true,
+	}
+	expected := s.expectedVolumeDetailsResult()
+	expected.Details.Storage.Kind = params.StorageKindBlock
+	expected.Details.Storage.Status.Status = params.StatusAttached
+	storageAttachmentDetails := expected.Details.Storage.Attachments["unit-mysql-0"]
+	storageAttachmentDetails.Location = "/dev/sdd"
+	expected.Details.Storage.Attachments["unit-mysql-0"] = storageAttachmentDetails
+	expected.Details.MachineAttachments[s.machineTag.String()] = params.VolumeAttachmentInfo{
+		BusAddress: "bus-addr",
+		ReadOnly:   true,
+	}
+	expected.LegacyAttachments[0].Info = params.VolumeAttachmentInfo{
+		BusAddress: "bus-addr",
+		ReadOnly:   true,
+	}
+	found, err := s.api.ListVolumes(params.VolumeFilter{})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(found.Results, gc.HasLen, 1)
 	c.Assert(found.Results[0], jc.DeepEquals, expected)
 }

--- a/apiserver/uniter/state.go
+++ b/apiserver/uniter/state.go
@@ -27,6 +27,7 @@ type storageStateInterface interface {
 	WatchVolumeAttachment(names.MachineTag, names.VolumeTag) state.NotifyWatcher
 	AddStorageForUnit(tag names.UnitTag, name string, cons state.StorageConstraints) error
 	UnitStorageConstraints(u names.UnitTag) (map[string]state.StorageConstraints, error)
+	BlockDevices(names.MachineTag) ([]state.BlockDeviceInfo, error)
 }
 
 type storageStateShim struct {


### PR DESCRIPTION
StorageAttachmentInfo was failing for block-kind
storage created by the Azure provider. This is
due to the fact that the only information we have
to identify disks is the SCSI LUN/bus address.
Rather than relying on the volume/attachment info
alone to identify the storage location, we find
the matching block device and return its path.

Fixes https://bugs.launchpad.net/juju-core/+bug/1498746

(Review request: http://reviews.vapour.ws/r/2736/)