### PR TITLE
uniter: add optional filtering to storage-list

### DIFF
--- a/worker/uniter/runner/jujuc/storage-list.go
+++ b/worker/uniter/runner/jujuc/storage-list.go
@@ -5,6 +5,8 @@ package jujuc
 
 import (
 	"github.com/juju/cmd"
+	"github.com/juju/errors"
+	"github.com/juju/names"
 	"launchpad.net/gnuflag"
 )
 
@@ -13,8 +15,9 @@ import (
 // StorageListCommand implements cmd.Command.
 type StorageListCommand struct {
 	cmd.CommandBase
-	ctx Context
-	out cmd.Output
+	ctx         Context
+	out         cmd.Output
+	storageName string
 }
 
 func NewStorageListCommand(ctx Context) cmd.Command {
@@ -26,9 +29,13 @@ func (c *StorageListCommand) Info() *cmd.Info {
 storage-list will list the names of all storage instances
 attached to the unit. These names can be passed to storage-get
 via the "-s" flag to query the storage attributes.
+
+A storage name may be specified, in which case only storage
+instances for that named storage will be returned.
 `
 	return &cmd.Info{
 		Name:    "storage-list",
+		Args:    "[<storage-name>]",
 		Purpose: "list storage attached to the unit",
 		Doc:     doc,
 	}
@@ -39,14 +46,29 @@ func (c *StorageListCommand) SetFlags(f *gnuflag.FlagSet) {
 }
 
 func (c *StorageListCommand) Init(args []string) (err error) {
-	return cmd.CheckEmpty(args)
+	storageName, err := cmd.ZeroOrOneArgs(args)
+	if err != nil {
+		return err
+	}
+	c.storageName = storageName
+	return nil
 }
 
 func (c *StorageListCommand) Run(ctx *cmd.Context) error {
 	tags := c.ctx.StorageTags()
-	names := make([]string, len(tags))
-	for i, tag := range tags {
-		names[i] = tag.Id()
+	ids := make([]string, 0, len(tags))
+	for _, tag := range tags {
+		id := tag.Id()
+		if c.storageName != "" {
+			storageName, err := names.StorageName(id)
+			if err != nil {
+				return errors.Trace(err)
+			}
+			if storageName != c.storageName {
+				continue
+			}
+		}
+		ids = append(ids, id)
 	}
-	return c.out.Write(ctx, names)
+	return c.out.Write(ctx, ids)
 }


### PR DESCRIPTION
Backport to 1.25.

Enhance storage-list to accept an optional storage name
argument, so that the results can be constrained to only
those matching the specified storage name.

(Review request: http://reviews.vapour.ws/r/2738/)