### PR TITLE
Fix windows run tests.

### DIFF
--- a/worker/uniter/util_test.go
+++ b/worker/uniter/util_test.go
@@ -1391,15 +1391,19 @@ func (cmds asyncRunCommands) step(c *gc.C, ctx *context) {
 		defer ctx.wg.Done()
 		// make sure the socket exists
 		client, err := sockets.Dial(socketPath)
-		c.Assert(err, jc.ErrorIsNil)
+		// Don't use asserts in go routines.
+		if !c.Check(err, jc.ErrorIsNil) {
+			return
+		}
 		defer client.Close()
 
 		var result utilexec.ExecResponse
 		err = client.Call(uniter.JujuRunEndpoint, args, &result)
-		c.Assert(err, jc.ErrorIsNil)
-		c.Check(result.Code, gc.Equals, 0)
-		c.Check(string(result.Stdout), gc.Equals, "")
-		c.Check(string(result.Stderr), gc.Equals, "")
+		if c.Check(err, jc.ErrorIsNil) {
+			c.Check(result.Code, gc.Equals, 0)
+			c.Check(string(result.Stdout), gc.Equals, "")
+			c.Check(string(result.Stderr), gc.Equals, "")
+		}
 	}()
 }
 

--- a/worker/uniter/util_windows_test.go
+++ b/worker/uniter/util_windows_test.go
@@ -150,6 +150,7 @@ func (s *UniterSuite) TestRunCommand(c *gc.C) {
 			quickStart{},
 			asyncRunCommands{echoUnitNameToFile("run.output")},
 			verifyFile{testFile("run.output"), "juju run u/0\r\n"},
+			waitContextWaitGroup{},
 		), ut(
 			"run commands: waits for lock",
 			quickStart{},
@@ -158,6 +159,7 @@ func (s *UniterSuite) TestRunCommand(c *gc.C) {
 			verifyNoFile{testFile("wait.output")},
 			releaseHookSyncLock,
 			verifyFile{testFile("wait.output"), "juju run u/0\r\n"},
+			waitContextWaitGroup{},
 		),
 	})
 }


### PR DESCRIPTION
The windows tests weren't waiting for the context manager in order to make sure all the go routines were done.

(Review request: http://reviews.vapour.ws/r/2741/)