### PR TITLE
state: filter nil values from initial settings

### DIFF
--- a/state/state.go
+++ b/state/state.go
@@ -1156,6 +1156,11 @@ func (st *State) AddService(
 		NeverSet: true,
 	}
 
+	// When creating the settings, we ignore nils.  In other circumstances, nil
+	// means to delete the value (reset to default), so creating with nil should
+	// mean to use the default, i.e. don't set the value.
+	removeNils(settings)
+
 	ops := []txn.Op{
 		env.assertAliveOp(),
 		createConstraintsOp(st, svc.globalKey(), constraints.Value{}),
@@ -1206,6 +1211,15 @@ func (st *State) AddService(
 		return nil, errors.Trace(err)
 	}
 	return svc, nil
+}
+
+// removeNils removes any keys with nil values from the given map.
+func removeNils(m map[string]interface{}) {
+	for k, v := range m {
+		if v == nil {
+			delete(m, k)
+		}
+	}
 }
 
 // AddIPAddress creates and returns a new IP address. It can return an

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -1938,6 +1938,24 @@ func (s *StateSuite) TestAddServiceNonExistentUser(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `cannot add service "wordpress": environment user "notAuser@local" not found`)
 }
 
+func (s *StateSuite) TestAddServiceSettingsNilValue(c *gc.C) {
+	insettings := charm.Settings{
+		"tuning": nil,
+		"fork":   "spoon",
+	}
+
+	ch := s.AddTestingCharm(c, "dummy")
+	wordpress, err := s.State.AddService("wordpress", s.Owner.String(), ch, nil, nil, insettings)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(wordpress.Name(), gc.Equals, "wordpress")
+	outsettings, err := wordpress.ConfigSettings()
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Settings with nil values should be pruned from the settings.
+	delete(insettings, "tuning")
+	c.Assert(outsettings, gc.DeepEquals, insettings)
+}
+
 func (s *StateSuite) TestAllServices(c *gc.C) {
 	charm := s.AddTestingCharm(c, "dummy")
 	services, err := s.State.AllServices()


### PR DESCRIPTION
Based on http://reviews.vapour.ws/r/2680. Make sure
we don't set nil values when recording service
settings initially, giving us comparable behaviour
when starting with no settings and calling the
UpdateConfigSettings method, as we used to.

Fixes https://bugs.launchpad.net/juju-core/+bug/1498481

(Review request: http://reviews.vapour.ws/r/2745/)