### PR TITLE
worker/uniter: preserve local state between loops

### DIFF
--- a/worker/uniter/resolver/export_test.go
+++ b/worker/uniter/resolver/export_test.go
@@ -10,7 +10,10 @@ type ResolverOpFactory struct {
 }
 
 func NewResolverOpFactory(f operation.Factory) ResolverOpFactory {
-	return ResolverOpFactory{&resolverOpFactory{Factory: f}}
+	return ResolverOpFactory{&resolverOpFactory{
+		Factory:    f,
+		LocalState: &LocalState{},
+	}}
 }
 
 var UpdateCharmDir = updateCharmDir

--- a/worker/uniter/resolver/loop_test.go
+++ b/worker/uniter/resolver/loop_test.go
@@ -48,16 +48,19 @@ func (s *LoopSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *LoopSuite) loop() (resolver.LocalState, error) {
-	return resolver.Loop(resolver.LoopConfig{
+	localState := resolver.LocalState{
+		CharmURL: s.charmURL,
+	}
+	err := resolver.Loop(resolver.LoopConfig{
 		Resolver:       s.resolver,
 		Factory:        s.opFactory,
 		Watcher:        s.watcher,
 		Executor:       s.executor,
-		CharmURL:       s.charmURL,
 		Dying:          s.dying,
 		OnIdle:         s.onIdle,
 		CharmDirLocker: &mockCharmDirLocker{},
-	})
+	}, &localState)
+	return localState, err
 }
 
 func (s *LoopSuite) TestDying(c *gc.C) {
@@ -137,8 +140,7 @@ func (s *LoopSuite) TestInitialFinalLocalState(c *gc.C) {
 	lastLocal, err := s.loop()
 	c.Assert(err, gc.Equals, tomb.ErrDying)
 	c.Assert(local, jc.DeepEquals, resolver.LocalState{
-		CharmURL:         s.charmURL,
-		CompletedActions: map[string]struct{}{},
+		CharmURL: s.charmURL,
 	})
 	c.Assert(lastLocal, jc.DeepEquals, local)
 }

--- a/worker/uniter/resolver/opfactory.go
+++ b/worker/uniter/resolver/opfactory.go
@@ -28,7 +28,7 @@ var logger = loggo.GetLogger("juju.worker.uniter.resolver")
 type resolverOpFactory struct {
 	operation.Factory
 
-	LocalState  LocalState
+	LocalState  *LocalState
 	RemoteState remotestate.Snapshot
 }
 
@@ -78,6 +78,9 @@ func (s *resolverOpFactory) NewAction(id string) (operation.Operation, error) {
 		return nil, errors.Trace(err)
 	}
 	f := func() {
+		if s.LocalState.CompletedActions == nil {
+			s.LocalState.CompletedActions = make(map[string]struct{})
+		}
 		s.LocalState.CompletedActions[id] = struct{}{}
 		s.LocalState.CompletedActions = trimCompletedActions(s.RemoteState.Actions, s.LocalState.CompletedActions)
 	}

--- a/worker/uniter/resolver/opfactory_test.go
+++ b/worker/uniter/resolver/opfactory_test.go
@@ -32,7 +32,7 @@ func (s *ResolverOpFactorySuite) SetUpTest(c *gc.C) {
 
 func (s *ResolverOpFactorySuite) TestInitialState(c *gc.C) {
 	f := resolver.NewResolverOpFactory(s.opFactory)
-	c.Assert(f.LocalState, jc.DeepEquals, resolver.LocalState{})
+	c.Assert(f.LocalState, jc.DeepEquals, &resolver.LocalState{})
 	c.Assert(f.RemoteState, jc.DeepEquals, remotestate.Snapshot{})
 }
 

--- a/worker/uniter/uniter_test.go
+++ b/worker/uniter/uniter_test.go
@@ -244,7 +244,6 @@ func (s *UniterSuite) TestNoUniterUpdateStatusHookInError(c *gc.C) {
 
 			// Resolve and hook should run.
 			resolveError{state.ResolvedNoHooks},
-			waitHooks{"config-changed"},
 			waitUnitAgent{
 				status: params.StatusIdle,
 			},


### PR DESCRIPTION
When the uniter observes a hook error (among other
scenarios), the local state is being thrown away.
This can cause spurious hooks. Preserve local state
between loops, and only reset local state upon
upgrading and recreating the remote state watcher.

There is one test change: we used to run config-
changed after started, even if we ran config-changed
before started. We now only run it before, and when
config actually changes, or after an agent restart.
Because none of these are true anymore, the test
needed to be changed.

(Review request: http://reviews.vapour.ws/r/2747/)