### PR TITLE
apiserver/common: fix StorageAttachmentInfo

### DIFF
--- a/apiserver/storage/base_test.go
+++ b/apiserver/storage/base_test.go
@@ -83,6 +83,7 @@ const (
 	allFilesystemsCall                      = "allFilesystems"
 	addStorageForUnitCall                   = "addStorageForUnit"
 	getBlockForTypeCall                     = "getBlockForType"
+	volumeAttachmentCall                    = "volumeAttachment"
 )
 
 func (s *baseStorageSuite) constructState() *mockState {
@@ -154,6 +155,10 @@ func (s *baseStorageSuite) constructState() *mockState {
 				return s.volume, nil
 			}
 			return nil, errors.NotFoundf("%s", names.ReadableString(t))
+		},
+		volumeAttachment: func(names.MachineTag, names.VolumeTag) (state.VolumeAttachment, error) {
+			s.calls = append(s.calls, volumeAttachmentCall)
+			return s.volumeAttachment, nil
 		},
 		unitAssignedMachine: func(u names.UnitTag) (names.MachineTag, error) {
 			s.calls = append(s.calls, unitAssignedMachineCall)

--- a/apiserver/storage/mock_test.go
+++ b/apiserver/storage/mock_test.go
@@ -41,7 +41,7 @@ type mockState struct {
 	storageInstanceAttachments          func(names.StorageTag) ([]state.StorageAttachment, error)
 	unitAssignedMachine                 func(u names.UnitTag) (names.MachineTag, error)
 	storageInstanceVolume               func(names.StorageTag) (state.Volume, error)
-	storageInstanceVolumeAttachment     func(names.MachineTag, names.VolumeTag) (state.VolumeAttachment, error)
+	volumeAttachment                    func(names.MachineTag, names.VolumeTag) (state.VolumeAttachment, error)
 	storageInstanceFilesystem           func(names.StorageTag) (state.Filesystem, error)
 	storageInstanceFilesystemAttachment func(m names.MachineTag, f names.FilesystemTag) (state.FilesystemAttachment, error)
 	watchStorageAttachment              func(names.StorageTag, names.UnitTag) state.NotifyWatcher
@@ -58,6 +58,7 @@ type mockState struct {
 	allFilesystems                      func() ([]state.Filesystem, error)
 	addStorageForUnit                   func(u names.UnitTag, name string, cons state.StorageConstraints) error
 	getBlockForType                     func(t state.BlockType) (state.Block, bool, error)
+	blockDevices                        func(names.MachineTag) ([]state.BlockDeviceInfo, error)
 }
 
 func (st *mockState) StorageInstance(s names.StorageTag) (state.StorageInstance, error) {
@@ -89,7 +90,7 @@ func (st *mockState) StorageInstanceVolume(s names.StorageTag) (state.Volume, er
 }
 
 func (st *mockState) VolumeAttachment(m names.MachineTag, v names.VolumeTag) (state.VolumeAttachment, error) {
-	return st.storageInstanceVolumeAttachment(m, v)
+	return st.volumeAttachment(m, v)
 }
 
 func (st *mockState) WatchStorageAttachment(s names.StorageTag, u names.UnitTag) state.NotifyWatcher {
@@ -146,6 +147,13 @@ func (st *mockState) AddStorageForUnit(u names.UnitTag, name string, cons state.
 
 func (st *mockState) GetBlockForType(t state.BlockType) (state.Block, bool, error) {
 	return st.getBlockForType(t)
+}
+
+func (st *mockState) BlockDevices(m names.MachineTag) ([]state.BlockDeviceInfo, error) {
+	if st.blockDevices != nil {
+		return st.blockDevices(m)
+	}
+	return []state.BlockDeviceInfo{}, nil
 }
 
 type mockNotifyWatcher struct {

--- a/apiserver/storage/state.go
+++ b/apiserver/storage/state.go
@@ -44,6 +44,9 @@ type storageAccess interface {
 	// WatchVolumeAttachment is required for storage functionality.
 	WatchVolumeAttachment(names.MachineTag, names.VolumeTag) state.NotifyWatcher
 
+	// BlockDevices is required for storage functionality.
+	BlockDevices(names.MachineTag) ([]state.BlockDeviceInfo, error)
+
 	// EnvName is required for pool functionality.
 	EnvName() (string, error)
 

--- a/apiserver/storage/volumelist_test.go
+++ b/apiserver/storage/volumelist_test.go
@@ -5,6 +5,7 @@ package storage_test
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -134,6 +135,60 @@ func (s *volumeSuite) TestListVolumesAttachmentInfo(c *gc.C) {
 	}
 	expected.LegacyAttachments[0].Info = params.VolumeAttachmentInfo{
 		DeviceName: "xvdf1",
+		ReadOnly:   true,
+	}
+	found, err := s.api.ListVolumes(params.VolumeFilter{})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(found.Results, gc.HasLen, 1)
+	c.Assert(found.Results[0], jc.DeepEquals, expected)
+}
+
+func (s *volumeSuite) TestListVolumesStorageLocationNoBlockDevice(c *gc.C) {
+	s.storageInstance.kind = state.StorageKindBlock
+	s.volume.info = &state.VolumeInfo{}
+	s.volumeAttachment.info = &state.VolumeAttachmentInfo{
+		ReadOnly: true,
+	}
+	expected := s.expectedVolumeDetailsResult()
+	expected.Details.Storage.Kind = params.StorageKindBlock
+	expected.Details.Storage.Status.Status = params.StatusAttached
+	expected.Details.MachineAttachments[s.machineTag.String()] = params.VolumeAttachmentInfo{
+		ReadOnly: true,
+	}
+	expected.LegacyAttachments[0].Info = params.VolumeAttachmentInfo{
+		ReadOnly: true,
+	}
+	found, err := s.api.ListVolumes(params.VolumeFilter{})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(found.Results, gc.HasLen, 1)
+	c.Assert(found.Results[0], jc.DeepEquals, expected)
+}
+
+func (s *volumeSuite) TestListVolumesStorageLocationBlockDevicePath(c *gc.C) {
+	s.state.blockDevices = func(names.MachineTag) ([]state.BlockDeviceInfo, error) {
+		return []state.BlockDeviceInfo{{
+			BusAddress: "bus-addr",
+			DeviceName: "sdd",
+		}}, nil
+	}
+	s.storageInstance.kind = state.StorageKindBlock
+	s.volume.info = &state.VolumeInfo{}
+	s.volumeAttachment.info = &state.VolumeAttachmentInfo{
+		BusAddress: "bus-addr",
+		ReadOnly:   true,
+	}
+	expected := s.expectedVolumeDetailsResult()
+	expected.Details.Storage.Kind = params.StorageKindBlock
+	expected.Details.Storage.Status.Status = params.StatusAttached
+	storageAttachmentDetails := expected.Details.Storage.Attachments["unit-mysql-0"]
+	storageAttachmentDetails.Location = "/dev/sdd"
+	expected.Details.Storage.Attachments["unit-mysql-0"] = storageAttachmentDetails
+	expected.Details.MachineAttachments[s.machineTag.String()] = params.VolumeAttachmentInfo{
+		BusAddress: "bus-addr",
+		ReadOnly:   true,
+	}
+	expected.LegacyAttachments[0].Info = params.VolumeAttachmentInfo{
+		BusAddress: "bus-addr",
 		ReadOnly:   true,
 	}
 	found, err := s.api.ListVolumes(params.VolumeFilter{})

--- a/apiserver/uniter/state.go
+++ b/apiserver/uniter/state.go
@@ -27,6 +27,7 @@ type storageStateInterface interface {
 	WatchVolumeAttachment(names.MachineTag, names.VolumeTag) state.NotifyWatcher
 	AddStorageForUnit(tag names.UnitTag, name string, cons state.StorageConstraints) error
 	UnitStorageConstraints(u names.UnitTag) (map[string]state.StorageConstraints, error)
+	BlockDevices(names.MachineTag) ([]state.BlockDeviceInfo, error)
 }
 
 type storageStateShim struct {


### PR DESCRIPTION
(Forward port)

StorageAttachmentInfo was failing for block-kind
storage created by the Azure provider. This is
due to the fact that the only information we have
to identify disks is the SCSI LUN/bus address.
Rather than relying on the volume/attachment info
alone to identify the storage location, we find
the matching block device and return its path.

Fixes https://bugs.launchpad.net/juju-core/+bug/1498746

(Review request: http://reviews.vapour.ws/r/2750/)