### PR TITLE
Moved translation from version to series to utils.

### DIFF
--- a/apiserver/imagemetadata/export_test.go
+++ b/apiserver/imagemetadata/export_test.go
@@ -6,7 +6,5 @@ package imagemetadata
 var (
 	CreateAPI               = createAPI
 	ParseMetadataFromParams = parseMetadataFromParams
-	VersionSeries           = versionSeries
-	SeriesVersion           = &seriesVersion
 	ProcessErrors           = processErrors
 )

--- a/apiserver/imagemetadata/functions_test.go
+++ b/apiserver/imagemetadata/functions_test.go
@@ -5,9 +5,7 @@ package imagemetadata_test
 
 import (
 	"fmt"
-	"strings"
 
-	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -83,35 +81,6 @@ type funcMetadataSuite struct {
 }
 
 var _ = gc.Suite(&funcMetadataSuite{})
-
-func (s *funcMetadataSuite) TestVersionSeriesValid(c *gc.C) {
-	s.assertSeriesForVersion(c, "14.04", "trusty")
-}
-
-func (s *funcMetadataSuite) TestVersionSeriesEmpty(c *gc.C) {
-	s.assertSeriesForVersion(c, "", "")
-}
-
-func (s *funcMetadataSuite) TestVersionSeriesInvalid(c *gc.C) {
-	s.assertSeriesForVersion(c, "73655", "73655")
-}
-
-func (s *funcMetadataSuite) assertSeriesForVersion(c *gc.C, version, series string) {
-	c.Assert(series, gc.DeepEquals, imagemetadata.VersionSeries(version))
-}
-
-func (s *funcMetadataSuite) TestVersionSeriesError(c *gc.C) {
-	// Patch to return err
-	patchErr := func(series string) (string, error) {
-		return "", errors.New("oops")
-	}
-	s.PatchValue(imagemetadata.SeriesVersion, patchErr)
-
-	s.assertSeriesForVersion(c, "73655", "73655")
-	// warning displayed
-	logOutputText := strings.Replace(c.GetTestLog(), "\n", "", -1)
-	c.Assert(logOutputText, gc.Matches, ".*cannot determine version for series.*")
-}
 
 func (s *funcMetadataSuite) TestProcessErrorsNil(c *gc.C) {
 	s.assertProcessErrorsNone(c, nil)

--- a/apiserver/imagemetadata/metadata.go
+++ b/apiserver/imagemetadata/metadata.go
@@ -208,29 +208,15 @@ var convertToParams = func(published []*envmetadata.ImageMetadata) params.Metada
 			RootStorageType: p.Storage,
 		}
 		// Translate version (eg.14.04) to a series (eg. "trusty")
-		metadata[i].Series = versionSeries(p.Version)
+		s, err := series.VersionSeries(p.Version)
+		if err != nil {
+			logger.Warningf("could not determine series %v", err)
+			continue
+		}
+		metadata[i].Series = s
 	}
 
 	return params.MetadataSaveParams{Metadata: metadata}
-}
-
-// TODO(dfc) why is this like this ?
-var seriesVersion = series.SeriesVersion
-
-func versionSeries(v string) string {
-	if v == "" {
-		return v
-	}
-	for _, s := range series.SupportedSeries() {
-		sv, err := seriesVersion(s)
-		if err != nil {
-			logger.Errorf("cannot determine version for series %v: %v", s, err)
-		}
-		if v == sv {
-			return s
-		}
-	}
-	return v
 }
 
 func processErrors(errs []params.ErrorResult) error {

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -27,7 +27,7 @@ github.com/juju/schema	git	afe1151cb49d1d7ed3c75592dfc6f38703f2e988	2015-08-07T0
 github.com/juju/syslog	git	6be94e8b718766e9ff7a37342157fe4795da7cfa	2015-02-05T15:59:36Z
 github.com/juju/testing	git	31ee64312c3c64cc94a5b41ea7a200b42e0f9767	2015-09-02T15:44:51Z
 github.com/juju/txn	git	99ec629d0066a4d73c54d8e021a7fc1dc07df614	2015-06-09T16:58:27Z
-github.com/juju/utils	git	2624f04c7f82c92814346afe69e06219da3ef0fe	2015-09-24T01:30:00Z
+github.com/juju/utils	git	d4796e2159e8bf8457d4e79b616dc523452b3560	
 github.com/juju/xml	git	eb759a627588d35166bc505fceb51b88500e291e	2015-04-13T13:11:21Z
 github.com/julienschmidt/httprouter	git	8c199fb6259ffc1af525cc3ad52ee60ba8359669	2015-04-21T17:00:07Z
 golang.org/x/crypto	git	c57d4a71915a248dbad846d60825145062b4c18e	2015-03-27T05:11:19Z


### PR DESCRIPTION
Originally, this is the first place that needed this translation since, in files, image metadata has versions
but whereas we are storing series in structured image metadata.

Moved this code to juju/utils/series where it belongs :D

(Review request: http://reviews.vapour.ws/r/2754/)