### PR TITLE
Meter status API client and facade.

### DIFF
--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -41,6 +41,7 @@ var facadeVersions = map[string]int{
 	"MachineManager":               1,
 	"Machiner":                     0,
 	"MetricsManager":               0,
+	"MeterStatus":                  1,
 	"MetricsAdder":                 1,
 	"Networker":                    0,
 	"NotifyWatcher":                0,

--- a/api/meterstatus/client.go
+++ b/api/meterstatus/client.go
@@ -1,0 +1,82 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Package meterstatus contains an implementation of the api facade to
+// watch the meter status of a unit for changes and return the current meter status.
+package meterstatus
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/names"
+
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/api/watcher"
+	"github.com/juju/juju/apiserver/params"
+)
+
+// MeterStatusClient defines the methods on the MeterStatus API end point.
+type MeterStatusClient interface {
+	// MeterStatus returns the meter status and additional information for the
+	// API client.
+	MeterStatus() (string, string, error)
+	// WatchMeterStatus returns a watcher for observing changes to the unit's meter
+	// status.
+	WatchMeterStatus() (watcher.NotifyWatcher, error)
+}
+
+// NewClient creates a new client for accessing the MeterStatus API.
+func NewClient(caller base.APICaller, tag names.UnitTag) *Client {
+	return &Client{
+		facade: base.NewFacadeCaller(caller, "MeterStatus"),
+		tag:    tag,
+	}
+}
+
+var _ MeterStatusClient = (*Client)(nil)
+
+// Client provides access to the meter status API.
+type Client struct {
+	facade base.FacadeCaller
+	tag    names.UnitTag
+}
+
+// MeterStatus is part of the MeterStatusClient interface.
+func (c *Client) MeterStatus() (statusCode, statusInfo string, rErr error) {
+	var results params.MeterStatusResults
+	args := params.Entities{
+		Entities: []params.Entity{{Tag: c.tag.String()}},
+	}
+	err := c.facade.FacadeCall("GetMeterStatus", args, &results)
+	if err != nil {
+		return "", "", errors.Trace(err)
+	}
+	if len(results.Results) != 1 {
+		return "", "", errors.Errorf("expected 1 result, got %d", len(results.Results))
+	}
+	result := results.Results[0]
+	if result.Error != nil {
+		return "", "", errors.Trace(result.Error)
+	}
+	return result.Code, result.Info, nil
+}
+
+// WatchMeterStatus is part of the MeterStatusClient interface.
+func (c *Client) WatchMeterStatus() (watcher.NotifyWatcher, error) {
+	var results params.NotifyWatchResults
+	args := params.Entities{
+		Entities: []params.Entity{{Tag: c.tag.String()}},
+	}
+	err := c.facade.FacadeCall("WatchMeterStatus", args, &results)
+	if err != nil {
+		return nil, err
+	}
+	if len(results.Results) != 1 {
+		return nil, errors.Errorf("expected 1 result, got %d", len(results.Results))
+	}
+	result := results.Results[0]
+	if result.Error != nil {
+		return nil, result.Error
+	}
+	w := watcher.NewNotifyWatcher(c.facade.RawAPICaller(), result)
+	return w, nil
+}

--- a/api/meterstatus/client_test.go
+++ b/api/meterstatus/client_test.go
@@ -1,0 +1,221 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package meterstatus_test
+
+import (
+	"fmt"
+
+	"github.com/juju/names"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/api/base/testing"
+	"github.com/juju/juju/api/meterstatus"
+	"github.com/juju/juju/apiserver/params"
+	coretesting "github.com/juju/juju/testing"
+)
+
+type meterStatusSuite struct {
+	coretesting.BaseSuite
+}
+
+var _ = gc.Suite(&meterStatusSuite{})
+
+func (s *meterStatusSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+}
+
+func (s *meterStatusSuite) TestGetMeterStatus(c *gc.C) {
+	tag := names.NewUnitTag("wp/1")
+	var called bool
+	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, response interface{}) error {
+		c.Check(objType, gc.Equals, "MeterStatus")
+		c.Check(version, gc.Equals, 0)
+		c.Check(id, gc.Equals, "")
+		c.Check(request, gc.Equals, "GetMeterStatus")
+		c.Check(arg, gc.DeepEquals, params.Entities{
+			Entities: []params.Entity{{Tag: tag.String()}},
+		})
+		c.Assert(response, gc.FitsTypeOf, &params.MeterStatusResults{})
+		result := response.(*params.MeterStatusResults)
+		result.Results = []params.MeterStatusResult{{
+			Code: "GREEN",
+			Info: "All ok.",
+		}}
+		called = true
+		return nil
+	})
+	status := meterstatus.NewClient(apiCaller, tag)
+	c.Assert(status, gc.NotNil)
+
+	statusCode, statusInfo, err := status.MeterStatus()
+	c.Assert(called, jc.IsTrue)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(statusCode, gc.Equals, "GREEN")
+	c.Assert(statusInfo, gc.Equals, "All ok.")
+}
+
+func (s *meterStatusSuite) TestGetMeterStatusResultError(c *gc.C) {
+	tag := names.NewUnitTag("wp/1")
+	var called bool
+	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, response interface{}) error {
+		c.Check(objType, gc.Equals, "MeterStatus")
+		c.Check(version, gc.Equals, 0)
+		c.Check(id, gc.Equals, "")
+		c.Check(request, gc.Equals, "GetMeterStatus")
+		c.Check(arg, gc.DeepEquals, params.Entities{
+			Entities: []params.Entity{{Tag: tag.String()}},
+		})
+		c.Assert(response, gc.FitsTypeOf, &params.MeterStatusResults{})
+		result := response.(*params.MeterStatusResults)
+		result.Results = []params.MeterStatusResult{{
+			Error: &params.Error{
+				Message: "An error in the meter status.",
+				Code:    params.CodeNotAssigned,
+			},
+		}}
+		called = true
+		return nil
+	})
+	status := meterstatus.NewClient(apiCaller, tag)
+	c.Assert(status, gc.NotNil)
+
+	statusCode, statusInfo, err := status.MeterStatus()
+	c.Assert(called, jc.IsTrue)
+	c.Assert(err, gc.ErrorMatches, "An error in the meter status.")
+	c.Assert(statusCode, gc.Equals, "")
+	c.Assert(statusInfo, gc.Equals, "")
+}
+
+func (s *meterStatusSuite) TestGetMeterStatusReturnsError(c *gc.C) {
+	tag := names.NewUnitTag("wp/1")
+	var called bool
+	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, response interface{}) error {
+		c.Check(objType, gc.Equals, "MeterStatus")
+		c.Check(version, gc.Equals, 0)
+		c.Check(id, gc.Equals, "")
+		c.Check(request, gc.Equals, "GetMeterStatus")
+		c.Check(arg, gc.DeepEquals, params.Entities{
+			Entities: []params.Entity{{Tag: tag.String()}},
+		})
+		c.Assert(response, gc.FitsTypeOf, &params.MeterStatusResults{})
+		called = true
+		return fmt.Errorf("could not retrieve meter status")
+	})
+	status := meterstatus.NewClient(apiCaller, tag)
+	c.Assert(status, gc.NotNil)
+
+	statusCode, statusInfo, err := status.MeterStatus()
+	c.Assert(called, jc.IsTrue)
+	c.Assert(err, gc.ErrorMatches, "could not retrieve meter status")
+	c.Assert(statusCode, gc.Equals, "")
+	c.Assert(statusInfo, gc.Equals, "")
+}
+
+func (s *meterStatusSuite) TestGetMeterStatusMoreResults(c *gc.C) {
+	tag := names.NewUnitTag("wp/1")
+	var called bool
+	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, response interface{}) error {
+		c.Check(objType, gc.Equals, "MeterStatus")
+		c.Check(version, gc.Equals, 0)
+		c.Check(id, gc.Equals, "")
+		c.Check(request, gc.Equals, "GetMeterStatus")
+		c.Check(arg, gc.DeepEquals, params.Entities{
+			Entities: []params.Entity{{Tag: tag.String()}},
+		})
+		c.Assert(response, gc.FitsTypeOf, &params.MeterStatusResults{})
+		result := response.(*params.MeterStatusResults)
+		result.Results = make([]params.MeterStatusResult, 2)
+		called = true
+		return nil
+	})
+	status := meterstatus.NewClient(apiCaller, tag)
+	c.Assert(status, gc.NotNil)
+	statusCode, statusInfo, err := status.MeterStatus()
+	c.Assert(called, jc.IsTrue)
+	c.Assert(err, gc.ErrorMatches, "expected 1 result, got 2")
+	c.Assert(statusCode, gc.Equals, "")
+	c.Assert(statusInfo, gc.Equals, "")
+}
+
+func (s *meterStatusSuite) TestWatchMeterStatusError(c *gc.C) {
+	tag := names.NewUnitTag("wp/1")
+	var called bool
+	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, response interface{}) error {
+		c.Check(objType, gc.Equals, "MeterStatus")
+		c.Check(version, gc.Equals, 0)
+		c.Check(id, gc.Equals, "")
+		c.Check(request, gc.Equals, "WatchMeterStatus")
+		c.Check(arg, gc.DeepEquals, params.Entities{
+			Entities: []params.Entity{{Tag: tag.String()}},
+		})
+		c.Assert(response, gc.FitsTypeOf, &params.NotifyWatchResults{})
+		result := response.(*params.NotifyWatchResults)
+		result.Results = make([]params.NotifyWatchResult, 1)
+		called = true
+		return fmt.Errorf("could not retrieve meter status watcher")
+	})
+	status := meterstatus.NewClient(apiCaller, tag)
+	c.Assert(status, gc.NotNil)
+	w, err := status.WatchMeterStatus()
+	c.Assert(called, jc.IsTrue)
+	c.Assert(err, gc.ErrorMatches, "could not retrieve meter status watcher")
+	c.Assert(w, gc.IsNil)
+}
+
+func (s *meterStatusSuite) TestWatchMeterStatusMoreResults(c *gc.C) {
+	tag := names.NewUnitTag("wp/1")
+	var called bool
+	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, response interface{}) error {
+		c.Check(objType, gc.Equals, "MeterStatus")
+		c.Check(version, gc.Equals, 0)
+		c.Check(id, gc.Equals, "")
+		c.Check(request, gc.Equals, "WatchMeterStatus")
+		c.Check(arg, gc.DeepEquals, params.Entities{
+			Entities: []params.Entity{{Tag: tag.String()}},
+		})
+		c.Assert(response, gc.FitsTypeOf, &params.NotifyWatchResults{})
+		result := response.(*params.NotifyWatchResults)
+		result.Results = make([]params.NotifyWatchResult, 2)
+		called = true
+		return nil
+	})
+	status := meterstatus.NewClient(apiCaller, tag)
+	c.Assert(status, gc.NotNil)
+	w, err := status.WatchMeterStatus()
+	c.Assert(called, jc.IsTrue)
+	c.Assert(err, gc.ErrorMatches, "expected 1 result, got 2")
+	c.Assert(w, gc.IsNil)
+}
+
+func (s *meterStatusSuite) TestWatchMeterStatusResultError(c *gc.C) {
+	tag := names.NewUnitTag("wp/1")
+	var called bool
+	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, response interface{}) error {
+		c.Check(objType, gc.Equals, "MeterStatus")
+		c.Check(version, gc.Equals, 0)
+		c.Check(id, gc.Equals, "")
+		c.Check(request, gc.Equals, "WatchMeterStatus")
+		c.Check(arg, gc.DeepEquals, params.Entities{
+			Entities: []params.Entity{{Tag: tag.String()}},
+		})
+		c.Assert(response, gc.FitsTypeOf, &params.NotifyWatchResults{})
+		result := response.(*params.NotifyWatchResults)
+		result.Results = []params.NotifyWatchResult{{
+			Error: &params.Error{
+				Message: "error",
+				Code:    params.CodeNotAssigned,
+			},
+		}}
+
+		called = true
+		return nil
+	})
+	status := meterstatus.NewClient(apiCaller, tag)
+	c.Assert(status, gc.NotNil)
+	w, err := status.WatchMeterStatus()
+	c.Assert(called, jc.IsTrue)
+	c.Assert(err, gc.ErrorMatches, "error")
+	c.Assert(w, gc.IsNil)
+}

--- a/api/meterstatus/export_test.go
+++ b/api/meterstatus/export_test.go
@@ -1,0 +1,15 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package meterstatus
+
+import (
+	"github.com/juju/juju/api/base/testing"
+)
+
+// PatchFacadeCall patches the State's facade such that
+// FacadeCall method calls are diverted to the provided
+// function.
+func PatchFacadeCall(p testing.Patcher, client *Client, f func(request string, params, response interface{}) error) {
+	testing.PatchFacadeCall(p, &client.facade, f)
+}

--- a/api/meterstatus/package_test.go
+++ b/api/meterstatus/package_test.go
@@ -1,4 +1,4 @@
-// Copyright 2014 Canonical Ltd.
+// Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 package meterstatus_test
@@ -6,9 +6,9 @@ package meterstatus_test
 import (
 	stdtesting "testing"
 
-	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/testing"
 )
 
 func TestAll(t *stdtesting.T) {
-	coretesting.MgoTestPackage(t)
+	testing.MgoTestPackage(t)
 }

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -30,6 +30,7 @@ import (
 	_ "github.com/juju/juju/apiserver/logger"
 	_ "github.com/juju/juju/apiserver/machine"
 	_ "github.com/juju/juju/apiserver/machinemanager"
+	_ "github.com/juju/juju/apiserver/meterstatus"
 	_ "github.com/juju/juju/apiserver/metricsadder"
 	_ "github.com/juju/juju/apiserver/metricsmanager"
 	_ "github.com/juju/juju/apiserver/networker"

--- a/apiserver/meterstatus/meterstatus.go
+++ b/apiserver/meterstatus/meterstatus.go
@@ -1,30 +1,127 @@
 // Copyright 2013 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-// Package meterstatus provides functions for getting meterstatus information
-// about units.
+// Package meterstatus provides the meter status API facade.
 package meterstatus
 
 import (
-	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	"github.com/juju/names"
 
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/state/watcher"
 )
 
-// MeterStatusWrapper takes a MeterStatus and converts it into an 'api friendly' form where
-// Not Set and Not Available (which are important distinctions in state) are converted
-// into Amber and Red respecitvely in the api.
-func MeterStatusWrapper(getter func() (state.MeterStatus, error)) (state.MeterStatus, error) {
-	status, err := getter()
-	if err != nil {
-		return state.MeterStatus{}, errors.Trace(err)
-	}
-	if status.Code == state.MeterNotSet {
-		return state.MeterStatus{state.MeterAmber, "not set"}, nil
-	}
-	if status.Code == state.MeterNotAvailable {
+var (
+	logger = loggo.GetLogger("juju.apiserver.meterstatus")
+)
 
-		return state.MeterStatus{state.MeterRed, "not available"}, nil
+func init() {
+	common.RegisterStandardFacade("MeterStatus", 1, NewMeterStatusAPI)
+}
+
+// MeterStatus defines the methods exported by the meter status API facade.
+type MeterStatus interface {
+	GetMeterStatus(args params.Entities) (params.MeterStatusResults, error)
+	WatchMeterStatus(args params.Entities) (params.NotifyWatchResults, error)
+}
+
+// MeterStatusAPI implements the MeterStatus interface and is the concrete implementation
+// of the API endpoint.
+type MeterStatusAPI struct {
+	state      *state.State
+	accessUnit common.GetAuthFunc
+	resources  *common.Resources
+}
+
+var _ MeterStatus = (*MeterStatusAPI)(nil)
+
+// NewMeterStatusAPI creates a new API endpoint for dealing with unit meter status.
+func NewMeterStatusAPI(
+	st *state.State,
+	resources *common.Resources,
+	authorizer common.Authorizer,
+) (*MeterStatusAPI, error) {
+	if !authorizer.AuthUnitAgent() {
+		return nil, common.ErrPerm
 	}
-	return status, nil
+	return &MeterStatusAPI{
+		state: st,
+		accessUnit: func() (common.AuthFunc, error) {
+			return authorizer.AuthOwner, nil
+		},
+		resources: resources,
+	}, nil
+}
+
+// WatchMeterStatus returns a NotifyWatcher for observing changes
+// to each unit's meter status.
+func (m *MeterStatusAPI) WatchMeterStatus(args params.Entities) (params.NotifyWatchResults, error) {
+	result := params.NotifyWatchResults{
+		Results: make([]params.NotifyWatchResult, len(args.Entities)),
+	}
+	canAccess, err := m.accessUnit()
+	if err != nil {
+		return params.NotifyWatchResults{}, err
+	}
+	for i, entity := range args.Entities {
+		tag, err := names.ParseUnitTag(entity.Tag)
+		if err != nil {
+			result.Results[i].Error = common.ServerError(common.ErrPerm)
+			continue
+		}
+		err = common.ErrPerm
+		watcherId := ""
+		if canAccess(tag) {
+			watcherId, err = m.watchOneUnitMeterStatus(tag)
+		}
+		result.Results[i].NotifyWatcherId = watcherId
+		result.Results[i].Error = common.ServerError(err)
+	}
+	return result, nil
+}
+
+func (m *MeterStatusAPI) watchOneUnitMeterStatus(tag names.UnitTag) (string, error) {
+	unit, err := m.state.Unit(tag.Id())
+	if err != nil {
+		return "", err
+	}
+	watch := unit.WatchMeterStatus()
+	if _, ok := <-watch.Changes(); ok {
+		return m.resources.Register(watch), nil
+	}
+	return "", watcher.EnsureErr(watch)
+}
+
+// GetMeterStatus returns meter status information for each unit.
+func (m *MeterStatusAPI) GetMeterStatus(args params.Entities) (params.MeterStatusResults, error) {
+	result := params.MeterStatusResults{
+		Results: make([]params.MeterStatusResult, len(args.Entities)),
+	}
+	canAccess, err := m.accessUnit()
+	if err != nil {
+		return params.MeterStatusResults{}, common.ErrPerm
+	}
+	for i, entity := range args.Entities {
+		unitTag, err := names.ParseUnitTag(entity.Tag)
+		if err != nil {
+			result.Results[i].Error = common.ServerError(common.ErrPerm)
+			continue
+		}
+		err = common.ErrPerm
+		var status state.MeterStatus
+		if canAccess(unitTag) {
+			var unit *state.Unit
+			unit, err = m.state.Unit(unitTag.Id())
+			if err == nil {
+				status, err = MeterStatusWrapper(unit.GetMeterStatus)
+			}
+			result.Results[i].Code = status.Code.String()
+			result.Results[i].Info = status.Info
+		}
+		result.Results[i].Error = common.ServerError(err)
+	}
+	return result, nil
 }

--- a/apiserver/meterstatus/meterstatus_test.go
+++ b/apiserver/meterstatus/meterstatus_test.go
@@ -1,81 +1,99 @@
-// Copyright 2013 Canonical Ltd.
+// Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 package meterstatus_test
 
 import (
-	"errors"
-
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/meterstatus"
+	meterstatustesting "github.com/juju/juju/apiserver/meterstatus/testing"
+	"github.com/juju/juju/apiserver/params"
+	apiservertesting "github.com/juju/juju/apiserver/testing"
+	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/state"
+	jujufactory "github.com/juju/juju/testing/factory"
 )
-
-type meterStatusSuite struct{}
 
 var _ = gc.Suite(&meterStatusSuite{})
 
-func (s *meterStatusSuite) TestError(c *gc.C) {
-	_, err := meterstatus.MeterStatusWrapper(ErrorGetter)
-	c.Assert(err, gc.ErrorMatches, "an error")
+type meterStatusSuite struct {
+	jujutesting.JujuConnSuite
+
+	authorizer apiservertesting.FakeAuthorizer
+	resources  *common.Resources
+
+	factory *jujufactory.Factory
+
+	unit *state.Unit
+
+	status meterstatus.MeterStatus
 }
 
-func (s *meterStatusSuite) TestWrapper(c *gc.C) {
-	tests := []struct {
-		about          string
-		input          func() (state.MeterStatus, error)
-		expectedOutput state.MeterStatus
-	}{{
-		about:          "notset in, amber out",
-		input:          NotSetGetter,
-		expectedOutput: state.MeterStatus{state.MeterAmber, "not set"},
-	}, {
-		about:          "notavailable in, red out",
-		input:          NotAvailableGetter,
-		expectedOutput: state.MeterStatus{state.MeterRed, "not available"},
-	}, {
-		about:          "red in, red out",
-		input:          RedGetter,
-		expectedOutput: state.MeterStatus{state.MeterRed, "info"},
-	}, {
-		about:          "green in, green out",
-		input:          GreenGetter,
-		expectedOutput: state.MeterStatus{state.MeterGreen, "info"},
-	}, {
-		about:          "amber in, amber out",
-		input:          AmberGetter,
-		expectedOutput: state.MeterStatus{state.MeterAmber, "info"},
-	}}
-	for i, test := range tests {
-		c.Logf("test %d: %s", i, test.about)
-		status, err := meterstatus.MeterStatusWrapper(test.input)
-		c.Assert(err, jc.ErrorIsNil)
-		c.Assert(status.Code, gc.Equals, test.expectedOutput.Code)
-		c.Assert(status.Info, gc.Equals, test.expectedOutput.Info)
+func (s *meterStatusSuite) SetUpTest(c *gc.C) {
+	s.JujuConnSuite.SetUpTest(c)
+
+	s.factory = jujufactory.NewFactory(s.State)
+	s.unit = s.factory.MakeUnit(c, nil)
+
+	// Create a FakeAuthorizer so we can check permissions,
+	// set up assuming unit 0 has logged in.
+	s.authorizer = apiservertesting.FakeAuthorizer{
+		Tag: s.unit.UnitTag(),
+	}
+
+	// Create the resource registry separately to track invocations to
+	// Register.
+	s.resources = common.NewResources()
+	s.AddCleanup(func(_ *gc.C) { s.resources.StopAll() })
+
+	status, err := meterstatus.NewMeterStatusAPI(s.State, s.resources, s.authorizer)
+	c.Assert(err, jc.ErrorIsNil)
+	s.status = status
+}
+
+func (s *meterStatusSuite) TestGetMeterStatusUnauthenticated(c *gc.C) {
+	service, err := s.unit.Service()
+	c.Assert(err, jc.ErrorIsNil)
+	otherunit := s.factory.MakeUnit(c, &jujufactory.UnitParams{Service: service})
+	args := params.Entities{Entities: []params.Entity{{otherunit.Tag().String()}}}
+	result, err := s.status.GetMeterStatus(args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.Results, gc.HasLen, 1)
+	c.Assert(result.Results[0].Error, gc.ErrorMatches, "permission denied")
+	c.Assert(result.Results[0].Code, gc.Equals, "")
+	c.Assert(result.Results[0].Info, gc.Equals, "")
+}
+
+func (s *meterStatusSuite) TestGetMeterStatusBadTag(c *gc.C) {
+	tags := []string{
+		"user-admin",
+		"unit-nosuchunit",
+		"thisisnotatag",
+		"machine-0",
+		"environment-blah",
+	}
+	args := params.Entities{Entities: make([]params.Entity, len(tags))}
+	for i, tag := range tags {
+		args.Entities[i] = params.Entity{Tag: tag}
+	}
+	result, err := s.status.GetMeterStatus(args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.Results, gc.HasLen, len(tags))
+	for i, result := range result.Results {
+		c.Logf("checking result %d", i)
+		c.Assert(result.Code, gc.Equals, "")
+		c.Assert(result.Info, gc.Equals, "")
+		c.Assert(result.Error, gc.ErrorMatches, "permission denied")
 	}
 }
 
-func ErrorGetter() (state.MeterStatus, error) {
-	return state.MeterStatus{}, errors.New("an error")
+func (s *meterStatusSuite) TestGetMeterStatus(c *gc.C) {
+	meterstatustesting.TestGetMeterStatus(c, s.status, s.unit)
 }
 
-func NotAvailableGetter() (state.MeterStatus, error) {
-	return state.MeterStatus{state.MeterNotAvailable, ""}, nil
-}
-
-func NotSetGetter() (state.MeterStatus, error) {
-	return state.MeterStatus{state.MeterNotSet, ""}, nil
-}
-
-func RedGetter() (state.MeterStatus, error) {
-	return state.MeterStatus{state.MeterRed, "info"}, nil
-}
-
-func GreenGetter() (state.MeterStatus, error) {
-	return state.MeterStatus{state.MeterGreen, "info"}, nil
-}
-func AmberGetter() (state.MeterStatus, error) {
-	return state.MeterStatus{state.MeterAmber, "info"}, nil
+func (s *meterStatusSuite) TestWatchMeterStatus(c *gc.C) {
+	meterstatustesting.TestWatchMeterStatus(c, s.status, s.unit, s.State, s.resources)
 }

--- a/apiserver/meterstatus/testing/tests.go
+++ b/apiserver/meterstatus/testing/tests.go
@@ -1,0 +1,72 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package testing
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/meterstatus"
+	"github.com/juju/juju/apiserver/params"
+	apiservertesting "github.com/juju/juju/apiserver/testing"
+	jujustate "github.com/juju/juju/state"
+	statetesting "github.com/juju/juju/state/testing"
+)
+
+// TestGetMeterStatus tests unit meter status retrieval.
+func TestGetMeterStatus(c *gc.C, status meterstatus.MeterStatus, unit *jujustate.Unit) {
+	args := params.Entities{Entities: []params.Entity{{Tag: unit.Tag().String()}}}
+	result, err := status.GetMeterStatus(args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.Results, gc.HasLen, 1)
+	c.Assert(result.Results[0].Error, gc.IsNil)
+	c.Assert(result.Results[0].Code, gc.Equals, "AMBER")
+	c.Assert(result.Results[0].Info, gc.Equals, "not set")
+
+	newCode := "GREEN"
+	newInfo := "All is ok."
+
+	err = unit.SetMeterStatus(newCode, newInfo)
+	c.Assert(err, jc.ErrorIsNil)
+
+	result, err = status.GetMeterStatus(args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.Results, gc.HasLen, 1)
+	c.Assert(result.Results[0].Error, gc.IsNil)
+	c.Assert(result.Results[0].Code, gc.DeepEquals, newCode)
+	c.Assert(result.Results[0].Info, gc.DeepEquals, newInfo)
+}
+
+// TestWatchMeterStatus tests the meter status watcher functionality.
+func TestWatchMeterStatus(c *gc.C, status meterstatus.MeterStatus, unit *jujustate.Unit, state *jujustate.State, resources *common.Resources) {
+	c.Assert(resources.Count(), gc.Equals, 0)
+
+	args := params.Entities{Entities: []params.Entity{
+		{Tag: unit.UnitTag().String()},
+		{Tag: "unit-foo-42"},
+	}}
+	result, err := status.WatchMeterStatus(args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, gc.DeepEquals, params.NotifyWatchResults{
+		Results: []params.NotifyWatchResult{
+			{NotifyWatcherId: "1"},
+			{Error: apiservertesting.ErrUnauthorized},
+		},
+	})
+
+	// Verify the resource was registered and stop when done
+	c.Assert(resources.Count(), gc.Equals, 1)
+	resource := resources.Get("1")
+	defer statetesting.AssertStop(c, resource)
+
+	// Check that the Watch has consumed the initial event ("returned" in
+	// the Watch call)
+	wc := statetesting.NewNotifyWatcherC(c, state, resource.(jujustate.NotifyWatcher))
+	wc.AssertNoChange()
+
+	err = unit.SetMeterStatus("GREEN", "No additional information.")
+	c.Assert(err, jc.ErrorIsNil)
+	wc.AssertOneChange()
+}

--- a/apiserver/meterstatus/wrapper.go
+++ b/apiserver/meterstatus/wrapper.go
@@ -1,0 +1,28 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package meterstatus
+
+import (
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/state"
+)
+
+// MeterStatusWrapper takes a MeterStatus and converts it into an 'api friendly' form where
+// Not Set and Not Available (which are important distinctions in state) are converted
+// into Amber and Red respectively in the api.
+func MeterStatusWrapper(getter func() (state.MeterStatus, error)) (state.MeterStatus, error) {
+	status, err := getter()
+	if err != nil {
+		return state.MeterStatus{}, errors.Trace(err)
+	}
+	if status.Code == state.MeterNotSet {
+		return state.MeterStatus{state.MeterAmber, "not set"}, nil
+	}
+	if status.Code == state.MeterNotAvailable {
+
+		return state.MeterStatus{state.MeterRed, "not available"}, nil
+	}
+	return status, nil
+}

--- a/apiserver/meterstatus/wrapper_test.go
+++ b/apiserver/meterstatus/wrapper_test.go
@@ -1,0 +1,81 @@
+// Copyright 2013 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package meterstatus_test
+
+import (
+	"errors"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/meterstatus"
+	"github.com/juju/juju/state"
+)
+
+type meterStatusWrapperSuite struct{}
+
+var _ = gc.Suite(&meterStatusWrapperSuite{})
+
+func (s *meterStatusWrapperSuite) TestError(c *gc.C) {
+	_, err := meterstatus.MeterStatusWrapper(ErrorGetter)
+	c.Assert(err, gc.ErrorMatches, "an error")
+}
+
+func (s *meterStatusWrapperSuite) TestWrapper(c *gc.C) {
+	tests := []struct {
+		about          string
+		input          func() (state.MeterStatus, error)
+		expectedOutput state.MeterStatus
+	}{{
+		about:          "notset in, amber out",
+		input:          NotSetGetter,
+		expectedOutput: state.MeterStatus{state.MeterAmber, "not set"},
+	}, {
+		about:          "notavailable in, red out",
+		input:          NotAvailableGetter,
+		expectedOutput: state.MeterStatus{state.MeterRed, "not available"},
+	}, {
+		about:          "red in, red out",
+		input:          RedGetter,
+		expectedOutput: state.MeterStatus{state.MeterRed, "info"},
+	}, {
+		about:          "green in, green out",
+		input:          GreenGetter,
+		expectedOutput: state.MeterStatus{state.MeterGreen, "info"},
+	}, {
+		about:          "amber in, amber out",
+		input:          AmberGetter,
+		expectedOutput: state.MeterStatus{state.MeterAmber, "info"},
+	}}
+	for i, test := range tests {
+		c.Logf("test %d: %s", i, test.about)
+		status, err := meterstatus.MeterStatusWrapper(test.input)
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(status.Code, gc.Equals, test.expectedOutput.Code)
+		c.Assert(status.Info, gc.Equals, test.expectedOutput.Info)
+	}
+}
+
+func ErrorGetter() (state.MeterStatus, error) {
+	return state.MeterStatus{}, errors.New("an error")
+}
+
+func NotAvailableGetter() (state.MeterStatus, error) {
+	return state.MeterStatus{state.MeterNotAvailable, ""}, nil
+}
+
+func NotSetGetter() (state.MeterStatus, error) {
+	return state.MeterStatus{state.MeterNotSet, ""}, nil
+}
+
+func RedGetter() (state.MeterStatus, error) {
+	return state.MeterStatus{state.MeterRed, "info"}, nil
+}
+
+func GreenGetter() (state.MeterStatus, error) {
+	return state.MeterStatus{state.MeterGreen, "info"}, nil
+}
+func AmberGetter() (state.MeterStatus, error) {
+	return state.MeterStatus{state.MeterAmber, "info"}, nil
+}

--- a/apiserver/uniter/export_test.go
+++ b/apiserver/uniter/export_test.go
@@ -3,10 +3,15 @@
 
 package uniter
 
-import "github.com/juju/juju/apiserver/common"
+import (
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/meterstatus"
+)
 
 var (
 	GetZone = &getZone
+
+	_ meterstatus.MeterStatus = (*uniterBaseAPI)(nil)
 )
 
 type StorageStateInterface storageStateInterface

--- a/apiserver/uniter/uniter_base_test.go
+++ b/apiserver/uniter/uniter_base_test.go
@@ -2165,29 +2165,6 @@ type getMeterStatus interface {
 	GetMeterStatus(args params.Entities) (params.MeterStatusResults, error)
 }
 
-func (s *uniterBaseSuite) testGetMeterStatus(c *gc.C, facade getMeterStatus) {
-	args := params.Entities{Entities: []params.Entity{{Tag: s.wordpressUnit.Tag().String()}}}
-	result, err := facade.GetMeterStatus(args)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(result.Results, gc.HasLen, 1)
-	c.Assert(result.Results[0].Error, gc.IsNil)
-	c.Assert(result.Results[0].Code, gc.Equals, "AMBER")
-	c.Assert(result.Results[0].Info, gc.Equals, "not set")
-
-	newCode := "GREEN"
-	newInfo := "All is ok."
-
-	err = s.wordpressUnit.SetMeterStatus(newCode, newInfo)
-	c.Assert(err, jc.ErrorIsNil)
-
-	result, err = facade.GetMeterStatus(args)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(result.Results, gc.HasLen, 1)
-	c.Assert(result.Results[0].Error, gc.IsNil)
-	c.Assert(result.Results[0].Code, gc.DeepEquals, newCode)
-	c.Assert(result.Results[0].Info, gc.DeepEquals, newInfo)
-}
-
 func (s *uniterBaseSuite) testGetMeterStatusUnauthenticated(c *gc.C, facade getMeterStatus) {
 	args := params.Entities{Entities: []params.Entity{{s.mysqlUnit.Tag().String()}}}
 	result, err := facade.GetMeterStatus(args)
@@ -2219,44 +2196,6 @@ func (s *uniterBaseSuite) testGetMeterStatusBadTag(c *gc.C, facade getMeterStatu
 		c.Assert(result.Info, gc.Equals, "")
 		c.Assert(result.Error, gc.ErrorMatches, "permission denied")
 	}
-}
-
-func (s *uniterBaseSuite) testWatchMeterStatus(
-	c *gc.C,
-	facade interface {
-		WatchMeterStatus(args params.Entities) (params.NotifyWatchResults, error)
-	},
-) {
-	c.Assert(s.resources.Count(), gc.Equals, 0)
-
-	args := params.Entities{Entities: []params.Entity{
-		{Tag: "unit-mysql-0"},
-		{Tag: "unit-wordpress-0"},
-		{Tag: "unit-foo-42"},
-	}}
-	result, err := facade.WatchMeterStatus(args)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(result, gc.DeepEquals, params.NotifyWatchResults{
-		Results: []params.NotifyWatchResult{
-			{Error: apiservertesting.ErrUnauthorized},
-			{NotifyWatcherId: "1"},
-			{Error: apiservertesting.ErrUnauthorized},
-		},
-	})
-
-	// Verify the resource was registered and stop when done
-	c.Assert(s.resources.Count(), gc.Equals, 1)
-	resource := s.resources.Get("1")
-	defer statetesting.AssertStop(c, resource)
-
-	// Check that the Watch has consumed the initial event ("returned" in
-	// the Watch call)
-	wc := statetesting.NewNotifyWatcherC(c, s.State, resource.(state.NotifyWatcher))
-	wc.AssertNoChange()
-
-	err = s.wordpressUnit.SetMeterStatus("GREEN", "No additional information.")
-	c.Assert(err, jc.ErrorIsNil)
-	wc.AssertOneChange()
 }
 
 func (s *uniterBaseSuite) assertOneStringsWatcher(c *gc.C, result params.StringsWatchResults, err error) {

--- a/apiserver/uniter/uniter_v0_test.go
+++ b/apiserver/uniter/uniter_v0_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/juju/juju/apiserver/common"
 	commontesting "github.com/juju/juju/apiserver/common/testing"
+	meterstatustesting "github.com/juju/juju/apiserver/meterstatus/testing"
 	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/apiserver/uniter"
@@ -289,7 +290,7 @@ func (s *uniterV0Suite) TestWatchUnitAddresses(c *gc.C) {
 }
 
 func (s *uniterV0Suite) TestGetMeterStatus(c *gc.C) {
-	s.testGetMeterStatus(c, s.uniter)
+	meterstatustesting.TestGetMeterStatus(c, s.uniter, s.wordpressUnit)
 }
 
 func (s *uniterV0Suite) TestGetMeterStatusUnauthenticated(c *gc.C) {
@@ -301,7 +302,7 @@ func (s *uniterV0Suite) TestGetMeterStatusBadTag(c *gc.C) {
 }
 
 func (s *uniterV0Suite) TestWatchMeterStatus(c *gc.C) {
-	s.testWatchMeterStatus(c, s.uniter)
+	meterstatustesting.TestWatchMeterStatus(c, s.uniter, s.wordpressUnit, s.State, s.resources)
 }
 
 func (s *uniterV0Suite) TestGetOwnerTag(c *gc.C) {

--- a/apiserver/uniter/uniter_v1_test.go
+++ b/apiserver/uniter/uniter_v1_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/juju/juju/apiserver/common"
 	commontesting "github.com/juju/juju/apiserver/common/testing"
+	meterstatustesting "github.com/juju/juju/apiserver/meterstatus/testing"
 	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/apiserver/uniter"
@@ -293,7 +294,7 @@ func (s *uniterV1Suite) TestWatchUnitAddresses(c *gc.C) {
 }
 
 func (s *uniterV1Suite) TestGetMeterStatus(c *gc.C) {
-	s.testGetMeterStatus(c, s.uniter)
+	meterstatustesting.TestGetMeterStatus(c, s.uniter, s.wordpressUnit)
 }
 
 func (s *uniterV1Suite) TestGetMeterStatusUnauthenticated(c *gc.C) {
@@ -305,7 +306,7 @@ func (s *uniterV1Suite) TestGetMeterStatusBadTag(c *gc.C) {
 }
 
 func (s *uniterV1Suite) TestWatchMeterStatus(c *gc.C) {
-	s.testWatchMeterStatus(c, s.uniter)
+	meterstatustesting.TestWatchMeterStatus(c, s.uniter, s.wordpressUnit, s.State, s.resources)
 }
 
 func (s *uniterV1Suite) TestGetOwnerTagV1NotImplemented(c *gc.C) {

--- a/featuretests/api_meterstatus_test.go
+++ b/featuretests/api_meterstatus_test.go
@@ -1,0 +1,91 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package featuretests
+
+import (
+	"time"
+
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/api/meterstatus"
+	jujutesting "github.com/juju/juju/juju/testing"
+	"github.com/juju/juju/state"
+	statetesting "github.com/juju/juju/state/testing"
+	factory "github.com/juju/juju/testing/factory"
+)
+
+type meterStatusIntegrationSuite struct {
+	jujutesting.JujuConnSuite
+
+	status *meterstatus.Client
+	unit   *state.Unit
+}
+
+var _ = gc.Suite(&meterStatusIntegrationSuite{})
+
+func (s *meterStatusIntegrationSuite) SetUpTest(c *gc.C) {
+	s.JujuConnSuite.SetUpTest(c)
+	f := factory.NewFactory(s.State)
+	s.unit = f.MakeUnit(c, nil)
+
+	password, err := utils.RandomPassword()
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.unit.SetPassword(password)
+	c.Assert(err, jc.ErrorIsNil)
+	state := s.OpenAPIAs(c, s.unit.UnitTag(), password)
+	s.status = meterstatus.NewClient(state, s.unit.UnitTag())
+	c.Assert(s.status, gc.NotNil)
+}
+
+func (s *meterStatusIntegrationSuite) TestMeterStatus(c *gc.C) {
+	code, info, err := s.status.MeterStatus()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(code, gc.Equals, "AMBER")
+	c.Assert(info, gc.Equals, "not set")
+
+	err = s.unit.SetMeterStatus("RED", "some status")
+	c.Assert(err, jc.ErrorIsNil)
+
+	code, info, err = s.status.MeterStatus()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(code, gc.Equals, "RED")
+	c.Assert(info, gc.Equals, "some status")
+}
+
+func (s *meterStatusIntegrationSuite) TestWatchMeterStatus(c *gc.C) {
+	w, err := s.status.WatchMeterStatus()
+	c.Assert(err, jc.ErrorIsNil)
+	defer statetesting.AssertStop(c, w)
+	wc := statetesting.NewNotifyWatcherC(c, s.State, w)
+
+	wc.AssertOneChange()
+
+	err = s.unit.SetMeterStatus("GREEN", "ok")
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.unit.SetMeterStatus("AMBER", "ok")
+	c.Assert(err, jc.ErrorIsNil)
+	wc.AssertOneChange()
+
+	// Non-change is not reported.
+	err = s.unit.SetMeterStatus("AMBER", "ok")
+	c.Assert(err, jc.ErrorIsNil)
+	wc.AssertNoChange()
+
+	mm, err := s.State.MetricsManager()
+	c.Assert(err, jc.ErrorIsNil)
+	err = mm.SetLastSuccessfulSend(time.Now())
+	c.Assert(err, jc.ErrorIsNil)
+	for i := 0; i < 3; i++ {
+		err := mm.IncrementConsecutiveErrors()
+		c.Assert(err, jc.ErrorIsNil)
+	}
+	status := mm.MeterStatus()
+	c.Assert(status.Code, gc.Equals, state.MeterAmber) // Confirm meter status has changed
+	wc.AssertOneChange()
+
+	statetesting.AssertStop(c, w)
+	wc.AssertClosed()
+}


### PR DESCRIPTION
Moving meter status related functionality to a separate facade.

(Review request: http://reviews.vapour.ws/r/2756/)