### PR TITLE
apiserver: prepare for non-websocket macaroon authentication

### DIFF
--- a/api/networker/networker_test.go
+++ b/api/networker/networker_test.go
@@ -183,7 +183,10 @@ func (s *networkerSuite) TestMachineNetworkConfigNameChange(c *gc.C) {
 		if !called {
 			called = true
 			c.Assert(request, gc.Equals, "MachineNetworkConfig")
-			return &params.Error{"MachineNetworkConfig", params.CodeNotImplemented}
+			return &params.Error{
+				Message: "MachineNetworkConfig",
+				Code:    params.CodeNotImplemented,
+			}
 		}
 		c.Assert(request, gc.Equals, "MachineNetworkInfo")
 		expected := params.Entities{

--- a/api/state.go
+++ b/api/state.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/names"
+	"gopkg.in/macaroon.v1"
 
 	"github.com/juju/juju/api/addresser"
 	"github.com/juju/juju/api/agent"
@@ -90,7 +91,7 @@ func (st *State) loginV2(tag names.Tag, password, nonce string) error {
 		if err != nil {
 			return errors.Annotate(err, "failed to obtain the macaroon discharge")
 		}
-		request.Macaroons = discharge
+		request.Macaroons = []macaroon.Slice{discharge}
 		err = st.APICall("Admin", 2, "", "Login", request, &result)
 		if err != nil {
 			return errors.Trace(err)

--- a/api/uniter/unit_test.go
+++ b/api/uniter/unit_test.go
@@ -919,7 +919,7 @@ func (s *unitMetricBatchesSuite) TestSendMetricBatchNotImplemented(c *gc.C) {
 		case "AddMetricBatches":
 			result := response.(*params.ErrorResults)
 			result.Results = make([]params.ErrorResult, 1)
-			return &params.Error{"not implemented", params.CodeNotImplemented}
+			return &params.Error{Message: "not implemented", Code: params.CodeNotImplemented}
 		case "AddMetrics":
 			called = true
 			result := response.(*params.ErrorResults)

--- a/apiserver/admin.go
+++ b/apiserver/admin.go
@@ -84,7 +84,7 @@ func (a *admin) doLogin(req params.LoginRequest, loginVersion int) (params.Login
 
 	serverOnlyLogin := loginVersion > 1 && a.root.envUUID == ""
 
-	entity, lastConnection, err := doCheckCreds(a.root.state, req, !serverOnlyLogin, a.srv.AuthenticatorForTag)
+	entity, lastConnection, err := doCheckCreds(a.root.state, req, !serverOnlyLogin, a.srv.authCtxt.authenticatorForTag)
 	if err != nil {
 		if err, ok := errors.Cause(err).(*authentication.DischargeRequiredError); ok {
 			loginResult := params.LoginResultV1{
@@ -195,7 +195,7 @@ func (a *admin) doLogin(req params.LoginRequest, loginVersion int) (params.Login
 // run API workers for that environment to do things like provisioning
 // machines.
 func (a *admin) checkCredsOfStateServerMachine(req params.LoginRequest) (state.Entity, error) {
-	entity, _, err := doCheckCreds(a.srv.state, req, false, a.srv.AuthenticatorForTag)
+	entity, _, err := doCheckCreds(a.srv.state, req, false, a.srv.authCtxt.authenticatorForTag)
 	if err != nil {
 		return nil, err
 	}

--- a/apiserver/admin_test.go
+++ b/apiserver/admin_test.go
@@ -12,8 +12,6 @@ import (
 	"time"
 
 	"github.com/juju/errors"
-	"github.com/juju/juju/environs/config"
-	"github.com/juju/juju/mongo"
 	"github.com/juju/loggo"
 	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
@@ -25,7 +23,9 @@ import (
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/apiserver"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/environs/config"
 	jujutesting "github.com/juju/juju/juju/testing"
+	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
 	coretesting "github.com/juju/juju/testing"

--- a/apiserver/authcontext.go
+++ b/apiserver/authcontext.go
@@ -1,0 +1,51 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package apiserver
+
+import (
+	"github.com/juju/names"
+	"gopkg.in/macaroon-bakery.v1/bakery"
+	"gopkg.in/macaroon.v1"
+
+	"github.com/juju/juju/apiserver/authentication"
+	"github.com/juju/juju/apiserver/common"
+)
+
+// authContext holds authentication context shared
+// between all API endpoints.
+type authContext struct {
+	// bakeryService holds the service that is
+	// used to verify macaroon authorization.
+	// It will be nil if no identity URL has been configured.
+	bakeryService *bakery.Service
+
+	// macaroon guards macaroon-authentication-based access
+	// to the APIs.
+	macaroon *macaroon.Macaroon
+
+	// identityURL holds the URL of the trusted third party
+	// that is used to address the is-authenticated-user
+	// third party caveat to.
+	identityURL string
+}
+
+// authenticatorForTag returns the authenticator appropriate
+// to use for a login with the given possibly-nil tag.
+func (ctxt *authContext) authenticatorForTag(tag names.Tag) (authentication.EntityAuthenticator, error) {
+	if tag == nil {
+		return &authentication.MacaroonAuthenticator{
+			Service:          ctxt.bakeryService,
+			Macaroon:         ctxt.macaroon,
+			IdentityLocation: ctxt.identityURL,
+		}, nil
+	}
+
+	switch tag.Kind() {
+	case names.UnitTagKind, names.MachineTagKind:
+		return &authentication.AgentAuthenticator{}, nil
+	case names.UserTagKind:
+		return &authentication.UserAuthenticator{}, nil
+	}
+	return nil, common.ErrBadRequest
+}

--- a/apiserver/authentication/agent.go
+++ b/apiserver/authentication/agent.go
@@ -5,11 +5,11 @@ package authentication
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/names"
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
-	"github.com/juju/names"
 )
 
 // AgentIdentityProvider performs authentication for machine and unit agents.

--- a/apiserver/authentication/interfaces.go
+++ b/apiserver/authentication/interfaces.go
@@ -4,9 +4,10 @@
 package authentication
 
 import (
+	"github.com/juju/names"
+
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
-	"github.com/juju/names"
 )
 
 // EntityAuthenticator is the interface all entity authenticators need to implement

--- a/apiserver/authentication/user.go
+++ b/apiserver/authentication/user.go
@@ -7,12 +7,12 @@ import (
 	"time"
 
 	"github.com/juju/errors"
-	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/names"
 	"gopkg.in/macaroon-bakery.v1/bakery"
 	"gopkg.in/macaroon-bakery.v1/bakery/checkers"
 	"gopkg.in/macaroon.v1"
 
+	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
 )
@@ -37,23 +37,20 @@ func (u *UserAuthenticator) Authenticate(entityFinder EntityFinder, tag names.Ta
 // DischargeRequiredError is the error returned when a macaroon requires discharging
 // to complete authentication.
 type DischargeRequiredError struct {
+	Cause    error
 	Macaroon *macaroon.Macaroon
 }
 
 // Error implements the error interface.
 func (e *DischargeRequiredError) Error() string {
-	return "discharge required"
+	return e.Cause.Error()
 }
 
 // MacaroonAuthenticator performs authentication for users using macaroons.
-// Issue a macaroon or return pre-generated macaroon -> return ErrDischareReq
-//       TODO (mattyw, mhilton) - where should macaroons be stored? they shouldn't, except in mem (default bakery).
-//       - when should they be created?
-//       - root key generated on server startup. not reused among replica servers.
-//       - macaroon issued on demand, reuse same root key
-//       - how do we choose user tag coming in?
-//       - special username? placeholder? empty username. need to return with
-//         resolved entity in state so some refactoring of authenticators reqd?
+// If the authentication fails because provided macaroons are invalid,
+// and macaroon authentiction is enabled, it will return a
+// httpbakery.DischargeRequiredError holding a macaroon to be
+// discharged.
 type MacaroonAuthenticator struct {
 	Service          *bakery.Service
 	Macaroon         *macaroon.Macaroon
@@ -62,9 +59,9 @@ type MacaroonAuthenticator struct {
 
 var _ EntityAuthenticator = (*MacaroonAuthenticator)(nil)
 
-func (m *MacaroonAuthenticator) newDischargeRequiredError() error {
+func (m *MacaroonAuthenticator) newDischargeRequiredError(cause error) error {
 	if m.Service == nil || m.Macaroon == nil {
-		return errors.New("macaroon authentication not configured")
+		return errors.Trace(cause)
 	}
 	mac := m.Macaroon.Clone()
 	err := m.Service.AddCaveat(mac, checkers.TimeBeforeCaveat(time.Now().Add(time.Hour)))
@@ -81,21 +78,19 @@ func (m *MacaroonAuthenticator) newDischargeRequiredError() error {
 	if err != nil {
 		return errors.Annotatef(err, "cannot create macaroon")
 	}
-	return &DischargeRequiredError{mac}
+	return &DischargeRequiredError{
+		Cause:    cause,
+		Macaroon: mac,
+	}
 }
 
 // Authenticate authenticates the provided entity. If there is no macaroon provided, it will
 // return a *DischargeRequiredError containing a macaroon that can be used to grant access.
 func (m *MacaroonAuthenticator) Authenticate(entityFinder EntityFinder, _ names.Tag, req params.LoginRequest) (state.Entity, error) {
-	if len(req.Macaroons) == 0 {
-		return nil, m.newDischargeRequiredError()
+	declared, err := m.Service.CheckAny(req.Macaroons, nil, checkers.New(checkers.TimeBefore))
+	if err != nil {
+		return nil, m.newDischargeRequiredError(err)
 	}
-
-	declared := checkers.InferDeclared(req.Macaroons)
-	err := m.Service.Check(req.Macaroons, checkers.New(
-		declared,
-		checkers.TimeBefore,
-	))
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/apiserver/authenticator_test.go
+++ b/apiserver/authenticator_test.go
@@ -8,6 +8,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/apiserver"
 	"github.com/juju/juju/apiserver/authentication"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/juju/testing"
@@ -33,7 +34,7 @@ func (s *agentAuthenticatorSuite) TestAuthenticatorForTag(c *gc.C) {
 	user := fact.MakeUser(c, &factory.UserParams{Password: "password"})
 	srv := newServer(c, s.State)
 	defer srv.Stop()
-	authenticator, err := srv.AuthenticatorForTag(user.Tag())
+	authenticator, err := apiserver.ServerAuthenticatorForTag(srv, user.Tag())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(authenticator, gc.NotNil)
 	userFinder := userFinder{user}
@@ -49,7 +50,7 @@ func (s *agentAuthenticatorSuite) TestAuthenticatorForTag(c *gc.C) {
 func (s *agentAuthenticatorSuite) TestAuthenticatorForTagGetsMacaroonAuthenticator(c *gc.C) {
 	srv := newServer(c, s.State)
 	defer srv.Stop()
-	authenticator, err := srv.AuthenticatorForTag(nil)
+	authenticator, err := apiserver.ServerAuthenticatorForTag(srv, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	_, ok := authenticator.(*authentication.MacaroonAuthenticator)
 	c.Assert(ok, jc.IsTrue)
@@ -58,7 +59,7 @@ func (s *agentAuthenticatorSuite) TestAuthenticatorForTagGetsMacaroonAuthenticat
 func (s *agentAuthenticatorSuite) TestMachineGetsAgentAuthentictor(c *gc.C) {
 	srv := newServer(c, s.State)
 	defer srv.Stop()
-	authenticator, err := srv.AuthenticatorForTag(names.NewMachineTag("0"))
+	authenticator, err := apiserver.ServerAuthenticatorForTag(srv, names.NewMachineTag("0"))
 	c.Assert(err, jc.ErrorIsNil)
 	_, ok := authenticator.(*authentication.AgentAuthenticator)
 	c.Assert(ok, jc.IsTrue)
@@ -66,7 +67,7 @@ func (s *agentAuthenticatorSuite) TestMachineGetsAgentAuthentictor(c *gc.C) {
 func (s *agentAuthenticatorSuite) TestUnitGetsAgentAuthentictor(c *gc.C) {
 	srv := newServer(c, s.State)
 	defer srv.Stop()
-	authenticator, err := srv.AuthenticatorForTag(names.NewUnitTag("wordpress/0"))
+	authenticator, err := apiserver.ServerAuthenticatorForTag(srv, names.NewUnitTag("wordpress/0"))
 	c.Assert(err, jc.ErrorIsNil)
 	_, ok := authenticator.(*authentication.AgentAuthenticator)
 	c.Assert(ok, jc.IsTrue)
@@ -74,7 +75,7 @@ func (s *agentAuthenticatorSuite) TestUnitGetsAgentAuthentictor(c *gc.C) {
 func (s *agentAuthenticatorSuite) TestNotSupportedTag(c *gc.C) {
 	srv := newServer(c, s.State)
 	defer srv.Stop()
-	authenticator, err := srv.AuthenticatorForTag(names.NewServiceTag("not-support"))
+	authenticator, err := apiserver.ServerAuthenticatorForTag(srv, names.NewServiceTag("not-support"))
 	c.Assert(err, gc.ErrorMatches, "invalid request")
 	c.Assert(authenticator, gc.IsNil)
 }

--- a/apiserver/backup.go
+++ b/apiserver/backup.go
@@ -33,18 +33,13 @@ type backupHandler struct {
 func (h *backupHandler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 	// Validate before authenticate because the authentication is dependent
 	// on the state connection that is determined during the validation.
-	stateWrapper, err := h.ctxt.validateEnvironUUID(req)
+	st, _, err := h.ctxt.stateForRequestAuthenticatedUser(req)
 	if err != nil {
 		h.sendError(resp, err)
 		return
 	}
 
-	if err := stateWrapper.authenticateUser(req); err != nil {
-		h.sendError(resp, errUnauthorized)
-		return
-	}
-
-	backups, closer := newBackups(stateWrapper.state)
+	backups, closer := newBackups(st)
 	defer closer.Close()
 
 	switch req.Method {

--- a/apiserver/backup_test.go
+++ b/apiserver/backup_test.go
@@ -71,13 +71,13 @@ type backupsSuite struct {
 var _ = gc.Suite(&backupsSuite{})
 
 func (s *backupsSuite) TestRequiresAuth(c *gc.C) {
-	resp, err := s.sendRequest(c, "", "", "GET", s.backupURL(c), "", nil)
+	resp, err := s.sendRequest(c, httpRequestParams{method: "GET", url: s.backupURL(c)})
 	c.Assert(err, jc.ErrorIsNil)
-	s.checkErrorResponse(c, resp, http.StatusUnauthorized, "unauthorized")
+	s.checkErrorResponse(c, resp, http.StatusUnauthorized, "no authorization header found")
 }
 
 func (s *backupsSuite) checkInvalidMethod(c *gc.C, method, url string) {
-	resp, err := s.authRequest(c, method, url, "", nil)
+	resp, err := s.authRequest(c, httpRequestParams{method: method, url: url})
 	c.Assert(err, jc.ErrorIsNil)
 	s.checkErrorResponse(c, resp, http.StatusMethodNotAllowed, `unsupported method: "`+method+`"`)
 }
@@ -101,12 +101,18 @@ func (s *backupsSuite) TestAuthRequiresClientNotMachine(c *gc.C) {
 	err = machine.SetPassword(password)
 	c.Assert(err, jc.ErrorIsNil)
 
-	resp, err := s.sendRequest(c, machine.Tag().String(), password, "GET", s.backupURL(c), "", nil)
+	resp, err := s.sendRequest(c, httpRequestParams{
+		tag:      machine.Tag().String(),
+		password: password,
+		method:   "GET",
+		url:      s.backupURL(c),
+		nonce:    "fake_nonce",
+	})
 	c.Assert(err, jc.ErrorIsNil)
-	s.checkErrorResponse(c, resp, http.StatusUnauthorized, "unauthorized")
+	s.checkErrorResponse(c, resp, http.StatusUnauthorized, "invalid entity name or password")
 
 	// Now try a user login.
-	resp, err = s.authRequest(c, "POST", s.backupURL(c), "", nil)
+	resp, err = s.authRequest(c, httpRequestParams{method: "POST", url: s.backupURL(c)})
 	c.Assert(err, jc.ErrorIsNil)
 	s.checkErrorResponse(c, resp, http.StatusMethodNotAllowed, `unsupported method: "POST"`)
 }
@@ -137,7 +143,7 @@ func (s *backupsDownloadSuite) sendValid(c *gc.C) *http.Response {
 
 	ctype := apihttp.CTypeJSON
 	body := s.newBody(c, meta.ID())
-	resp, err := s.authRequest(c, "GET", s.backupURL(c), ctype, body)
+	resp, err := s.authRequest(c, httpRequestParams{method: "GET", url: s.backupURL(c), contentType: ctype, body: body})
 	c.Assert(err, jc.ErrorIsNil)
 	return resp
 }
@@ -211,7 +217,7 @@ func (s *backupsUploadSuite) sendValid(c *gc.C, id string) *http.Response {
 
 	// Send the request.
 	ctype := writer.FormDataContentType()
-	resp, err := s.authRequest(c, "PUT", s.backupURL(c), ctype, &parts)
+	resp, err := s.authRequest(c, httpRequestParams{method: "PUT", url: s.backupURL(c), contentType: ctype, body: &parts})
 	c.Assert(err, jc.ErrorIsNil)
 	return resp
 }

--- a/apiserver/charms.go
+++ b/apiserver/charms.go
@@ -39,100 +39,125 @@ type charmsHandler struct {
 
 // bundleContentSenderFunc functions are responsible for sending a
 // response related to a charm bundle.
-type bundleContentSenderFunc func(w http.ResponseWriter, r *http.Request, bundle *charm.CharmArchive)
+type bundleContentSenderFunc func(w http.ResponseWriter, r *http.Request, bundle *charm.CharmArchive) error
 
 func (h *charmsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	stateWrapper, err := h.ctxt.validateEnvironUUID(r)
-	if err != nil {
-		h.sendError(w, err)
-		return
-	}
-
+	var err error
 	switch r.Method {
 	case "POST":
-		if err := stateWrapper.authenticateUser(r); err != nil {
-			h.sendError(w, errUnauthorized)
-			return
-		}
-		// Add a local charm to the store provider.
-		// Requires a "series" query specifying the series to use for the charm.
-		charmURL, err := h.processPost(r, stateWrapper.state)
-		if err != nil {
-			h.sendError(w, errors.NewBadRequest(err, ""))
-			return
-		}
-		sendStatusAndJSON(w, http.StatusOK, &params.CharmsResponse{CharmURL: charmURL.String()})
+		err = h.servePost(w, r)
 	case "GET":
-		// Retrieve or list charm files.
-		// Requires "url" (charm URL) and an optional "file" (the path to the
-		// charm file) to be included in the query.
-		if charmArchivePath, filePath, err := h.processGet(r, stateWrapper.state); err != nil {
-			// An error occurred retrieving the charm bundle.
-			if errors.IsNotFound(err) {
-				h.sendError(w, err)
-			} else {
-				h.sendError(w, errors.NewBadRequest(err, ""))
-			}
-		} else if filePath == "" {
-			// The client requested the list of charm files.
-			sendBundleContent(w, r, charmArchivePath, h.manifestSender)
-		} else if filePath == "*" {
-			// The client requested the archive.
-			sendBundleContent(w, r, charmArchivePath, h.archiveSender)
-		} else {
-			// The client requested a specific file.
-			sendBundleContent(w, r, charmArchivePath, h.archiveEntrySender(filePath))
-		}
+		err = h.serveGet(w, r)
 	default:
-		h.sendError(w, errors.MethodNotAllowedf("unsupported method: %q", r.Method))
+		err = errors.MethodNotAllowedf("unsupported method: %q", r.Method)
 	}
+	if err != nil {
+		logger.Errorf("returning error from %s /charms: %s", r.Method, errors.Details(err))
+		h.sendError(w, err)
+	}
+}
+
+func (h *charmsHandler) servePost(w http.ResponseWriter, r *http.Request) error {
+	st, _, err := h.ctxt.stateForRequestAuthenticatedUser(r)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	// Add a local charm to the store provider.
+	// Requires a "series" query specifying the series to use for the charm.
+	charmURL, err := h.processPost(r, st)
+	if err != nil {
+		return errors.NewBadRequest(err, "")
+	}
+	sendStatusAndJSON(w, http.StatusOK, &params.CharmsResponse{CharmURL: charmURL.String()})
+	return nil
+}
+
+func (h *charmsHandler) serveGet(w http.ResponseWriter, r *http.Request) error {
+	// TODO (bug #1499338 2015/09/24) authenticate this.
+	st, err := h.ctxt.stateForRequestUnauthenticated(r)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	// Retrieve or list charm files.
+	// Requires "url" (charm URL) and an optional "file" (the path to the
+	// charm file) to be included in the query.
+	charmArchivePath, filePath, err := h.processGet(r, st)
+	if err != nil {
+		// An error occurred retrieving the charm bundle.
+		if errors.IsNotFound(err) {
+			return errors.Trace(err)
+		}
+		return errors.NewBadRequest(err, "")
+	}
+	var sender bundleContentSenderFunc
+	switch filePath {
+	case "":
+		// The client requested the list of charm files.
+		sender = h.manifestSender
+	case "*":
+		// The client requested the archive.
+		sender = h.archiveSender
+	default:
+		// The client requested a specific file.
+		sender = h.archiveEntrySender(filePath)
+	}
+	if err := h.sendBundleContent(w, r, charmArchivePath, sender); err != nil {
+		return errors.Trace(err)
+	}
+	return nil
+}
+
+// sendError sends a JSON-encoded error response.
+// Note the difference from the error response sent by
+// the sendError function - the error is encoded in the
+// Error field as a string, not an Error object.
+func (h *charmsHandler) sendError(w http.ResponseWriter, err error) {
+	perr, status := common.ServerErrorAndStatus(err)
+	sendStatusAndJSON(w, status, &params.CharmsResponse{
+		Error:     perr.Message,
+		ErrorCode: perr.Code,
+	})
 }
 
 // sendBundleContent uses the given bundleContentSenderFunc to send a response
 // related to the charm archive located in the given archivePath.
-func sendBundleContent(w http.ResponseWriter, r *http.Request, archivePath string, sender bundleContentSenderFunc) {
+func (h *charmsHandler) sendBundleContent(w http.ResponseWriter, r *http.Request, archivePath string, sender bundleContentSenderFunc) error {
 	bundle, err := charm.ReadCharmArchive(archivePath)
 	if err != nil {
-		http.Error(
-			w, fmt.Sprintf("unable to read archive in %q: %v", archivePath, err),
-			http.StatusInternalServerError)
-		return
+		return errors.Annotatef(err, "unable to read archive in %q", archivePath)
 	}
 	// The bundleContentSenderFunc will set up and send an appropriate response.
-	sender(w, r, bundle)
+	if err := sender(w, r, bundle); err != nil {
+		return errors.Trace(err)
+	}
+	return nil
 }
 
 // manifestSender sends a JSON-encoded response to the client including the
 // list of files contained in the charm bundle.
-func (h *charmsHandler) manifestSender(w http.ResponseWriter, r *http.Request, bundle *charm.CharmArchive) {
+func (h *charmsHandler) manifestSender(w http.ResponseWriter, r *http.Request, bundle *charm.CharmArchive) error {
 	manifest, err := bundle.Manifest()
 	if err != nil {
-		http.Error(
-			w, fmt.Sprintf("unable to read archive in %q: %v", bundle.Path, err),
-			http.StatusInternalServerError)
-		return
+		return errors.Annotatef(err, "unable to read manifest in %q", bundle.Path)
 	}
 	sendStatusAndJSON(w, http.StatusOK, &params.CharmsResponse{
 		Files: manifest.SortedValues(),
 	})
-
+	return nil
 }
 
 // archiveEntrySender returns a bundleContentSenderFunc which is responsible for
 // sending the contents of filePath included in the given charm bundle. If filePath
 // does not identify a file or a symlink, a 403 forbidden error is returned.
 func (h *charmsHandler) archiveEntrySender(filePath string) bundleContentSenderFunc {
-	return func(w http.ResponseWriter, r *http.Request, bundle *charm.CharmArchive) {
+	return func(w http.ResponseWriter, r *http.Request, bundle *charm.CharmArchive) error {
 		// TODO(fwereade) 2014-01-27 bug #1285685
 		// This doesn't handle symlinks helpfully, and should be talking in
 		// terms of bundles rather than zip readers; but this demands thought
 		// and design and is not amenable to a quick fix.
 		zipReader, err := zip.OpenReader(bundle.Path)
 		if err != nil {
-			http.Error(
-				w, fmt.Sprintf("unable to read charm: %v", err),
-				http.StatusInternalServerError)
-			return
+			return errors.Annotatef(err, "unable to read charm")
 		}
 		defer zipReader.Close()
 		for _, file := range zipReader.File {
@@ -141,15 +166,14 @@ func (h *charmsHandler) archiveEntrySender(filePath string) bundleContentSenderF
 			}
 			fileInfo := file.FileInfo()
 			if fileInfo.IsDir() {
-				http.Error(w, "directory listing not allowed", http.StatusForbidden)
-				return
+				return &params.Error{
+					Message: "directory listing not allowed",
+					Code:    params.CodeForbidden,
+				}
 			}
 			contents, err := file.Open()
 			if err != nil {
-				http.Error(
-					w, fmt.Sprintf("unable to read file %q: %v", filePath, err),
-					http.StatusInternalServerError)
-				return
+				return errors.Annotatef(err, "unable to read file %q", filePath)
 			}
 			defer contents.Close()
 			ctype := mime.TypeByExtension(filepath.Ext(filePath))
@@ -159,30 +183,23 @@ func (h *charmsHandler) archiveEntrySender(filePath string) bundleContentSenderF
 			w.Header().Set("Content-Length", strconv.FormatInt(fileInfo.Size(), 10))
 			w.WriteHeader(http.StatusOK)
 			io.Copy(w, contents)
-			return
+			return nil
 		}
-		http.NotFound(w, r)
-		return
+		return errors.NotFoundf("charm")
 	}
 }
 
 // archiveSender is a bundleContentSenderFunc which is responsible for sending
 // the contents of the given charm bundle.
-func (h *charmsHandler) archiveSender(w http.ResponseWriter, r *http.Request, bundle *charm.CharmArchive) {
+func (h *charmsHandler) archiveSender(w http.ResponseWriter, r *http.Request, bundle *charm.CharmArchive) error {
+	// Note that http.ServeFile's error responses are not our standard JSON
+	// responses (they are the usual textual error messages as produced
+	// by http.Error), but there's not a great deal we can do about that,
+	// except accept non-JSON error responses in the client, because
+	// http.ServeFile does not provide a way of customizing its
+	// error responses.
 	http.ServeFile(w, r, bundle.Path)
-}
-
-// sendError sends a JSON-encoded error response.
-// Note the difference from the error response sent by
-// the sendError function - the error is encoded in the
-// Error field as a string, not an Error object.
-func (h *charmsHandler) sendError(w http.ResponseWriter, err error) {
-	err, status := common.ServerErrorAndStatus(err)
-	// Unfortunately there's no way to send the error code back.
-	sendStatusAndJSON(w, status, &params.CharmsResponse{
-		Error: err.Error(),
-	})
-
+	return nil
 }
 
 // processPost handles a charm upload POST request after authentication.

--- a/apiserver/common/errors.go
+++ b/apiserver/common/errors.go
@@ -141,6 +141,8 @@ func ServerErrorAndStatus(err error) (*params.Error, int) {
 		// This should really be http.StatusForbidden but earlier versions
 		// of juju clients rely on the 400 status, so we leave it like that.
 		status = http.StatusBadRequest
+	case params.CodeForbidden:
+		status = http.StatusForbidden
 	}
 	return err1, status
 }

--- a/apiserver/debuglog_test.go
+++ b/apiserver/debuglog_test.go
@@ -30,13 +30,13 @@ func (s *debugLogBaseSuite) TestBadParams(c *gc.C) {
 
 func (s *debugLogBaseSuite) TestWithHTTP(c *gc.C) {
 	uri := s.logURL(c, "http", nil).String()
-	_, err := s.sendRequest(c, "", "", "GET", uri, "", nil)
+	_, err := s.sendRequest(c, httpRequestParams{method: "GET", url: uri})
 	c.Assert(err, gc.ErrorMatches, `.*malformed HTTP response.*`)
 }
 
 func (s *debugLogBaseSuite) TestWithHTTPS(c *gc.C) {
 	uri := s.logURL(c, "https", nil).String()
-	response, err := s.sendRequest(c, "", "", "GET", uri, "", nil)
+	response, err := s.sendRequest(c, httpRequestParams{method: "GET", url: uri})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(response.StatusCode, gc.Equals, http.StatusBadRequest)
 }
@@ -46,7 +46,7 @@ func (s *debugLogBaseSuite) TestNoAuth(c *gc.C) {
 	defer conn.Close()
 	reader := bufio.NewReader(conn)
 
-	assertJSONError(c, reader, "auth failed: invalid request format")
+	assertJSONError(c, reader, "no authorization header found")
 	s.assertWebsocketClosed(c, reader)
 }
 
@@ -60,7 +60,7 @@ func (s *debugLogBaseSuite) TestAgentLoginsRejected(c *gc.C) {
 	defer conn.Close()
 	reader := bufio.NewReader(conn)
 
-	assertJSONError(c, reader, "auth failed: invalid entity name or password")
+	assertJSONError(c, reader, "invalid entity name or password")
 	s.assertWebsocketClosed(c, reader)
 }
 

--- a/apiserver/diskmanager/diskmanager_test.go
+++ b/apiserver/diskmanager/diskmanager_test.go
@@ -84,9 +84,9 @@ func (s *DiskManagerSuite) TestSetMachineBlockDevicesInvalidTags(c *gc.C) {
 		Results: []params.ErrorResult{{
 			Error: nil,
 		}, {
-			Error: &params.Error{"permission denied", "unauthorized access"},
+			Error: &params.Error{Message: "permission denied", Code: "unauthorized access"},
 		}, {
-			Error: &params.Error{"permission denied", "unauthorized access"},
+			Error: &params.Error{Message: "permission denied", Code: "unauthorized access"},
 		}},
 	})
 	c.Assert(s.st.calls, gc.Equals, 1)
@@ -102,7 +102,7 @@ func (s *DiskManagerSuite) TestSetMachineBlockDevicesStateError(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{{
-			Error: &params.Error{"boom", ""},
+			Error: &params.Error{Message: "boom", Code: ""},
 		}},
 	})
 }

--- a/apiserver/export_test.go
+++ b/apiserver/export_test.go
@@ -33,15 +33,19 @@ var (
 )
 
 func ServerMacaroon(srv *Server) *macaroon.Macaroon {
-	return srv.macaroon
+	return srv.authCtxt.macaroon
 }
 
 func ServerBakeryService(srv *Server) *bakery.Service {
-	return srv.bakeryService
+	return srv.authCtxt.bakeryService
 }
 
 func ApiHandlerWithEntity(entity state.Entity) *apiHandler {
 	return &apiHandler{entity: entity}
+}
+
+func ServerAuthenticatorForTag(srv *Server, tag names.Tag) (authentication.EntityAuthenticator, error) {
+	return srv.authCtxt.authenticatorForTag(tag)
 }
 
 const LoginRateLimit = loginRateLimit

--- a/apiserver/images.go
+++ b/apiserver/images.go
@@ -31,14 +31,14 @@ type imagesDownloadHandler struct {
 }
 
 func (h *imagesDownloadHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	stateWrapper, err := h.ctxt.validateEnvironUUID(r)
+	st, err := h.ctxt.stateForRequestUnauthenticated(r)
 	if err != nil {
 		sendError(w, err)
 		return
 	}
 	switch r.Method {
 	case "GET":
-		err := h.processGet(r, w, stateWrapper.state)
+		err := h.processGet(r, w, st)
 		if err != nil {
 			logger.Errorf("GET(%s) failed: %v", r.URL, err)
 			sendError(w, err)

--- a/apiserver/images_test.go
+++ b/apiserver/images_test.go
@@ -240,7 +240,7 @@ func (s *imageSuite) testDownload(c *gc.C, resp *http.Response) []byte {
 }
 
 func (s *imageSuite) downloadRequest(c *gc.C, url *url.URL) (*http.Response, error) {
-	return s.sendRequest(c, "", "", "GET", url.String(), "", nil)
+	return s.sendRequest(c, httpRequestParams{method: "GET", url: url.String()})
 }
 
 func (s *imageSuite) storeFakeImage(c *gc.C, st *state.State, kind, series, arch string) {

--- a/apiserver/logsink_test.go
+++ b/apiserver/logsink_test.go
@@ -66,7 +66,7 @@ func (s *logsinkSuite) TestRejectsBadEnvironUUID(c *gc.C) {
 }
 
 func (s *logsinkSuite) TestNoAuth(c *gc.C) {
-	s.checkAuthFails(c, nil, "invalid request format")
+	s.checkAuthFails(c, nil, "no authorization header found")
 }
 
 func (s *logsinkSuite) TestRejectsUserLogins(c *gc.C) {
@@ -95,7 +95,7 @@ func (s *logsinkSuite) checkAuthFails(c *gc.C, header http.Header, message strin
 	conn := s.dialWebsocketInternal(c, header)
 	defer conn.Close()
 	reader := bufio.NewReader(conn)
-	assertJSONError(c, reader, "auth failed: "+message)
+	assertJSONError(c, reader, message)
 	s.assertWebsocketClosed(c, reader)
 }
 

--- a/apiserver/machinemanager/machinemanager_test.go
+++ b/apiserver/machinemanager/machinemanager_test.go
@@ -112,7 +112,7 @@ func (s *MachineManagerSuite) TestAddMachinesStateError(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.AddMachinesResults{
 		Machines: []params.AddMachinesResult{{
-			Error: &params.Error{"boom", ""},
+			Error: &params.Error{Message: "boom", Code: ""},
 		}},
 	})
 	c.Assert(s.st.calls, gc.Equals, 1)

--- a/apiserver/params/apierror.go
+++ b/apiserver/params/apierror.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/juju/errors"
+	"gopkg.in/macaroon.v1"
 
 	"github.com/juju/juju/rpc"
 )
@@ -15,6 +16,28 @@ import (
 type Error struct {
 	Message string
 	Code    string
+	Info    *ErrorInfo `json:",omitempty"`
+}
+
+// ErrorInfo holds additional information provided by an error.
+// Note that although these fields are compatible with the
+// same fields in httpbakery.ErrorInfo, the Juju API server does
+// not implement endpoints directly compatible with that protocol
+// because the error response format varies according to
+// the endpoint.
+type ErrorInfo struct {
+	// Macaroon may hold a macaroon that, when
+	// discharged, may allow access to the juju API.
+	// This field is associated with the ErrDischargeRequired
+	// error code.
+	Macaroon *macaroon.Macaroon `json:",omitempty"`
+
+	// MacaroonPath holds the URL path to be associated
+	// with the macaroon. The macaroon is potentially
+	// valid for all URLs under the given path.
+	// If it is empty, the macaroon will be associated with
+	// the original URL from which the error was returned.
+	MacaroonPath string `json:",omitempty"`
 }
 
 func (e *Error) Error() string {
@@ -30,7 +53,7 @@ var _ rpc.ErrorCoder = (*Error)(nil)
 // GoString implements fmt.GoStringer.  It means that a *Error shows its
 // contents correctly when printed with %#v.
 func (e Error) GoString() string {
-	return fmt.Sprintf("&params.Error{%q, %q}", e.Code, e.Message)
+	return fmt.Sprintf("&params.Error{Message: %q, Code:  %q}", e.Code, e.Message)
 }
 
 // The Code constants hold error codes for some kinds of error.
@@ -58,6 +81,8 @@ const (
 	CodeNotSupported              = "not supported"
 	CodeBadRequest                = "bad request"
 	CodeMethodNotAllowed          = "method not allowed"
+	CodeForbidden                 = "forbidden"
+	CodeDischargeRequired         = "macaroon discharge required"
 )
 
 // ErrCode returns the error code associated with

--- a/apiserver/params/internal.go
+++ b/apiserver/params/internal.go
@@ -512,9 +512,15 @@ type MachineStorageIdsWatchResults struct {
 
 // CharmsResponse is the server response to charm upload or GET requests.
 type CharmsResponse struct {
-	Error    string   `json:",omitempty"`
-	CharmURL string   `json:",omitempty"`
-	Files    []string `json:",omitempty"`
+	Error string `json:",omitempty"`
+
+	// ErrorCode holds the code associated with the error.
+	// Ideally, Error would hold an Error object and the
+	// code would be in that, but for backward compatibility,
+	// we cannot do that.
+	ErrorCode string   `json:",omitempty"`
+	CharmURL  string   `json:",omitempty"`
+	Files     []string `json:",omitempty"`
 }
 
 // RunParams is used to provide the parameters to the Run method.

--- a/apiserver/params/network_test.go
+++ b/apiserver/params/network_test.go
@@ -36,7 +36,7 @@ func (s *NetworkSuite) TestPortsResults(c *gc.C) {
 	mkPortsResult := func(msg, code string, ports ...P) params.PortsResult {
 		pr := params.PortsResult{}
 		if msg != "" {
-			pr.Error = &params.Error{msg, code}
+			pr.Error = &params.Error{Message: msg, Code: code}
 		}
 		for _, p := range ports {
 			pr.Ports = append(pr.Ports, params.Port{p.prot, p.num})

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -357,14 +357,16 @@ type Creds struct {
 
 // LoginRequest holds credentials for identifying an entity to the Login v1
 // facade. AuthTag holds the tag of the user to connect as. If it is empty,
-// then the provided Macaroons will be used for authentication. These may be
-// empty, in which case LoginResponse will contain a macaroon that when
+// then the provided macaroon slices will be used for authentication (if
+// any one is valid, the authentication succeeds). If there are no
+// valid macaroons and macaroon authentication is configured,
+// the LoginResponse will contain a macaroon that when
 // discharged, may allow access.
 type LoginRequest struct {
-	AuthTag     string         `json:"auth-tag"`
-	Credentials string         `json:"credentials"`
-	Nonce       string         `json:"nonce"`
-	Macaroons   macaroon.Slice `json:"macaroons"`
+	AuthTag     string           `json:"auth-tag"`
+	Credentials string           `json:"credentials"`
+	Nonce       string           `json:"nonce"`
+	Macaroons   []macaroon.Slice `json:"macaroons"`
 }
 
 // LoginRequestCompat holds credentials for identifying an entity to the Login v1

--- a/apiserver/server_test.go
+++ b/apiserver/server_test.go
@@ -19,6 +19,10 @@ import (
 	jc "github.com/juju/testing/checkers"
 	"golang.org/x/net/websocket"
 	gc "gopkg.in/check.v1"
+	"gopkg.in/macaroon-bakery.v1/bakery"
+	"gopkg.in/macaroon-bakery.v1/bakery/checkers"
+	"gopkg.in/macaroon-bakery.v1/bakerytest"
+	"gopkg.in/macaroon-bakery.v1/httpbakery"
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/apiserver"
@@ -33,10 +37,6 @@ import (
 	"github.com/juju/juju/state/presence"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/testing/factory"
-	"gopkg.in/macaroon-bakery.v1/bakery"
-	"gopkg.in/macaroon-bakery.v1/bakery/checkers"
-	"gopkg.in/macaroon-bakery.v1/bakerytest"
-	"gopkg.in/macaroon-bakery.v1/httpbakery"
 )
 
 func TestAll(t *stdtesting.T) {

--- a/apiserver/service/service_test.go
+++ b/apiserver/service/service_test.go
@@ -130,7 +130,7 @@ func (s *serviceSuite) TestSetMetricCredentials(c *gc.C) {
 			}},
 			params.ErrorResults{[]params.ErrorResult{
 				{Error: nil},
-				{Error: &params.Error{`service "not-a-service" not found`, "not found"}},
+				{Error: &params.Error{Message: `service "not-a-service" not found`, Code: "not found"}},
 			}},
 		},
 	}

--- a/apiserver/storageprovisioner/storageprovisioner_test.go
+++ b/apiserver/storageprovisioner/storageprovisioner_test.go
@@ -191,8 +191,8 @@ func (s *provisionerSuite) TestVolumesMachine(c *gc.C) {
 					Persistent: true,
 				},
 			}},
-			{Error: &params.Error{"permission denied", "unauthorized access"}},
-			{Error: &params.Error{"permission denied", "unauthorized access"}},
+			{Error: &params.Error{Message: "permission denied", Code: "unauthorized access"}},
+			{Error: &params.Error{Message: "permission denied", Code: "unauthorized access"}},
 		},
 	})
 }
@@ -212,7 +212,7 @@ func (s *provisionerSuite) TestVolumesEnviron(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.VolumeResults{
 		Results: []params.VolumeResult{
-			{Error: &params.Error{"permission denied", "unauthorized access"}},
+			{Error: &params.Error{Message: "permission denied", Code: "unauthorized access"}},
 			{Error: common.ServerError(errors.NotProvisionedf(`volume "1"`))},
 			{Result: params.Volume{
 				VolumeTag: "volume-2",
@@ -222,7 +222,7 @@ func (s *provisionerSuite) TestVolumesEnviron(c *gc.C) {
 					Size:       4096,
 				},
 			}},
-			{Error: &params.Error{"permission denied", "unauthorized access"}},
+			{Error: &params.Error{Message: "permission denied", Code: "unauthorized access"}},
 		},
 	})
 }
@@ -248,7 +248,7 @@ func (s *provisionerSuite) TestFilesystems(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, jc.DeepEquals, params.FilesystemResults{
 		Results: []params.FilesystemResult{
-			{Error: &params.Error{"permission denied", "unauthorized access"}},
+			{Error: &params.Error{Message: "permission denied", Code: "unauthorized access"}},
 			{Error: common.ServerError(errors.NotProvisionedf(`filesystem "1"`))},
 			{Result: params.Filesystem{
 				FilesystemTag: "filesystem-2",
@@ -257,7 +257,7 @@ func (s *provisionerSuite) TestFilesystems(c *gc.C) {
 					Size:         4096,
 				},
 			}},
-			{Error: &params.Error{"permission denied", "unauthorized access"}},
+			{Error: &params.Error{Message: "permission denied", Code: "unauthorized access"}},
 		},
 	})
 }
@@ -299,7 +299,7 @@ func (s *provisionerSuite) TestVolumeAttachments(c *gc.C) {
 				Code:    params.CodeNotProvisioned,
 				Message: `volume attachment "2" on "0" not provisioned`,
 			}},
-			{Error: &params.Error{"permission denied", "unauthorized access"}},
+			{Error: &params.Error{Message: "permission denied", Code: "unauthorized access"}},
 		},
 	})
 }
@@ -345,7 +345,7 @@ func (s *provisionerSuite) TestFilesystemAttachments(c *gc.C) {
 				Code:    params.CodeNotProvisioned,
 				Message: `filesystem attachment "2" on "0" not provisioned`,
 			}},
-			{Error: &params.Error{"permission denied", "unauthorized access"}},
+			{Error: &params.Error{Message: "permission denied", Code: "unauthorized access"}},
 		},
 	})
 }
@@ -406,7 +406,7 @@ func (s *provisionerSuite) TestVolumeParams(c *gc.C) {
 					ReadOnly:   true,
 				},
 			}},
-			{Error: &params.Error{"permission denied", "unauthorized access"}},
+			{Error: &params.Error{Message: "permission denied", Code: "unauthorized access"}},
 		},
 	})
 }
@@ -441,7 +441,7 @@ func (s *provisionerSuite) TestFilesystemParams(c *gc.C) {
 					tags.JujuEnv: testing.EnvironmentTag.Id(),
 				},
 			}},
-			{Error: &params.Error{"permission denied", "unauthorized access"}},
+			{Error: &params.Error{Message: "permission denied", Code: "unauthorized access"}},
 		},
 	})
 }
@@ -513,7 +513,7 @@ func (s *provisionerSuite) TestVolumeAttachmentParams(c *gc.C) {
 				VolumeTag:  "volume-4",
 				Provider:   "environscoped",
 			}},
-			{Error: &params.Error{"permission denied", "unauthorized access"}},
+			{Error: &params.Error{Message: "permission denied", Code: "unauthorized access"}},
 		},
 	})
 }
@@ -576,7 +576,7 @@ func (s *provisionerSuite) TestFilesystemAttachmentParams(c *gc.C) {
 				FilesystemTag: "filesystem-3",
 				Provider:      "environscoped",
 			}},
-			{Error: &params.Error{"permission denied", "unauthorized access"}},
+			{Error: &params.Error{Message: "permission denied", Code: "unauthorized access"}},
 		},
 	})
 }
@@ -622,9 +622,9 @@ func (s *provisionerSuite) TestSetVolumeAttachmentInfo(c *gc.C) {
 	c.Assert(results, jc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{
 			{},
-			{Error: &params.Error{`cannot set info for volume attachment 1:0: volume "1" not provisioned`, "not provisioned"}},
-			{Error: &params.Error{`cannot set info for volume attachment 4:2: machine 2 not provisioned`, "not provisioned"}},
-			{Error: &params.Error{"permission denied", "unauthorized access"}},
+			{Error: &params.Error{Message: `cannot set info for volume attachment 1:0: volume "1" not provisioned`, Code: "not provisioned"}},
+			{Error: &params.Error{Message: `cannot set info for volume attachment 4:2: machine 2 not provisioned`, Code: "not provisioned"}},
+			{Error: &params.Error{Message: "permission denied", Code: "unauthorized access"}},
 		},
 	})
 }
@@ -670,9 +670,9 @@ func (s *provisionerSuite) TestSetFilesystemAttachmentInfo(c *gc.C) {
 	c.Assert(results, jc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{
 			{},
-			{Error: &params.Error{`cannot set info for filesystem attachment 1:0: filesystem "1" not provisioned`, "not provisioned"}},
-			{Error: &params.Error{`cannot set info for filesystem attachment 3:2: machine 2 not provisioned`, "not provisioned"}},
-			{Error: &params.Error{"permission denied", "unauthorized access"}},
+			{Error: &params.Error{Message: `cannot set info for filesystem attachment 1:0: filesystem "1" not provisioned`, Code: "not provisioned"}},
+			{Error: &params.Error{Message: `cannot set info for filesystem attachment 3:2: machine 2 not provisioned`, Code: "not provisioned"}},
+			{Error: &params.Error{Message: "permission denied", Code: "unauthorized access"}},
 		},
 	})
 }
@@ -1009,7 +1009,7 @@ func (s *provisionerSuite) TestAttachmentLife(c *gc.C) {
 			{Life: params.Alive},
 			{Life: params.Alive},
 			{Life: params.Alive},
-			{Error: &params.Error{"permission denied", "unauthorized access"}},
+			{Error: &params.Error{Message: "permission denied", Code: "unauthorized access"}},
 		},
 	})
 }
@@ -1077,12 +1077,12 @@ func (s *provisionerSuite) TestRemoveVolumesEnvironManager(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{
-			{Error: &params.Error{"permission denied", "unauthorized access"}},
+			{Error: &params.Error{Message: "permission denied", Code: "unauthorized access"}},
 			{Error: nil},
 			{Error: &params.Error{Message: "removing volume 2: volume is not dead"}},
 			{Error: nil},
 			{Error: &params.Error{Message: `"volume-invalid" is not a valid volume tag`}},
-			{Error: &params.Error{"permission denied", "unauthorized access"}},
+			{Error: &params.Error{Message: "permission denied", Code: "unauthorized access"}},
 		},
 	})
 }
@@ -1105,12 +1105,12 @@ func (s *provisionerSuite) TestRemoveFilesystemsEnvironManager(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{
-			{Error: &params.Error{"permission denied", "unauthorized access"}},
+			{Error: &params.Error{Message: "permission denied", Code: "unauthorized access"}},
 			{Error: nil},
 			{Error: &params.Error{Message: "removing filesystem 2: filesystem is not dead"}},
 			{Error: nil},
 			{Error: &params.Error{Message: `"filesystem-invalid" is not a valid filesystem tag`}},
-			{Error: &params.Error{"permission denied", "unauthorized access"}},
+			{Error: &params.Error{Message: "permission denied", Code: "unauthorized access"}},
 		},
 	})
 }
@@ -1136,9 +1136,9 @@ func (s *provisionerSuite) TestRemoveVolumesMachineAgent(c *gc.C) {
 		Results: []params.ErrorResult{
 			{Error: nil},
 			{Error: nil},
-			{Error: &params.Error{"permission denied", "unauthorized access"}},
+			{Error: &params.Error{Message: "permission denied", Code: "unauthorized access"}},
 			{Error: &params.Error{Message: `"volume-invalid" is not a valid volume tag`}},
-			{Error: &params.Error{"permission denied", "unauthorized access"}},
+			{Error: &params.Error{Message: "permission denied", Code: "unauthorized access"}},
 		},
 	})
 }
@@ -1164,9 +1164,9 @@ func (s *provisionerSuite) TestRemoveFilesystemsMachineAgent(c *gc.C) {
 		Results: []params.ErrorResult{
 			{Error: nil},
 			{Error: nil},
-			{Error: &params.Error{"permission denied", "unauthorized access"}},
+			{Error: &params.Error{Message: "permission denied", Code: "unauthorized access"}},
 			{Error: &params.Error{Message: `"filesystem-invalid" is not a valid filesystem tag`}},
-			{Error: &params.Error{"permission denied", "unauthorized access"}},
+			{Error: &params.Error{Message: "permission denied", Code: "unauthorized access"}},
 		},
 	})
 }
@@ -1198,8 +1198,8 @@ func (s *provisionerSuite) TestRemoveVolumeAttachments(c *gc.C) {
 		Results: []params.ErrorResult{
 			{Error: &params.Error{Message: "removing attachment of volume 0/0 from machine 0: volume attachment is not dying"}},
 			{Error: nil},
-			{Error: &params.Error{"permission denied", "unauthorized access"}},
-			{Error: &params.Error{`removing attachment of volume 42 from machine 0: volume "42" on machine "0" not found`, "not found"}},
+			{Error: &params.Error{Message: "permission denied", Code: "unauthorized access"}},
+			{Error: &params.Error{Message: `removing attachment of volume 42 from machine 0: volume "42" on machine "0" not found`, Code: "not found"}},
 		},
 	})
 }
@@ -1231,8 +1231,8 @@ func (s *provisionerSuite) TestRemoveFilesystemAttachments(c *gc.C) {
 		Results: []params.ErrorResult{
 			{Error: &params.Error{Message: "removing attachment of filesystem 0/0 from machine 0: filesystem attachment is not dying"}},
 			{Error: nil},
-			{Error: &params.Error{"permission denied", "unauthorized access"}},
-			{Error: &params.Error{`removing attachment of filesystem 42 from machine 0: filesystem "42" on machine "0" not found`, "not found"}},
+			{Error: &params.Error{Message: "permission denied", Code: "unauthorized access"}},
+			{Error: &params.Error{Message: `removing attachment of filesystem 42 from machine 0: filesystem "42" on machine "0" not found`, Code: "not found"}},
 		},
 	})
 }

--- a/apiserver/utils_test.go
+++ b/apiserver/utils_test.go
@@ -25,12 +25,12 @@ func (s *utilsSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *utilsSuite) TestValidateEmpty(c *gc.C) {
-	st, err := validateEnvironUUID(
+	uuid, err := validateEnvironUUID(
 		validateArgs{
 			statePool: s.pool,
 		})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(st.EnvironUUID(), gc.Equals, s.State.EnvironUUID())
+	c.Assert(uuid, gc.Equals, s.State.EnvironUUID())
 }
 
 func (s *utilsSuite) TestValidateEmptyStrict(c *gc.C) {
@@ -43,24 +43,24 @@ func (s *utilsSuite) TestValidateEmptyStrict(c *gc.C) {
 }
 
 func (s *utilsSuite) TestValidateStateServer(c *gc.C) {
-	st, err := validateEnvironUUID(
+	uuid, err := validateEnvironUUID(
 		validateArgs{
 			statePool: s.pool,
 			envUUID:   s.State.EnvironUUID(),
 		})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(st.EnvironUUID(), gc.Equals, s.State.EnvironUUID())
+	c.Assert(uuid, gc.Equals, s.State.EnvironUUID())
 }
 
 func (s *utilsSuite) TestValidateStateServerStrict(c *gc.C) {
-	st, err := validateEnvironUUID(
+	uuid, err := validateEnvironUUID(
 		validateArgs{
 			statePool: s.pool,
 			envUUID:   s.State.EnvironUUID(),
 			strict:    true,
 		})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(st.EnvironUUID(), gc.Equals, s.State.EnvironUUID())
+	c.Assert(uuid, gc.Equals, s.State.EnvironUUID())
 }
 
 func (s *utilsSuite) TestValidateBadEnvUUID(c *gc.C) {
@@ -76,14 +76,13 @@ func (s *utilsSuite) TestValidateOtherEnvironment(c *gc.C) {
 	envState := s.Factory.MakeEnvironment(c, nil)
 	defer envState.Close()
 
-	st, err := validateEnvironUUID(
+	uuid, err := validateEnvironUUID(
 		validateArgs{
 			statePool: s.pool,
 			envUUID:   envState.EnvironUUID(),
 		})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(st.EnvironUUID(), gc.Equals, envState.EnvironUUID())
-	st.Close()
+	c.Assert(uuid, gc.Equals, envState.EnvironUUID())
 }
 
 func (s *utilsSuite) TestValidateOtherEnvironmentStateServerOnly(c *gc.C) {

--- a/cmd/juju/commands/deploy_test.go
+++ b/cmd/juju/commands/deploy_test.go
@@ -654,7 +654,10 @@ func (s *DeploySuite) TestAddMetricCredentialsHttp(c *gc.C) {
 func (s *DeploySuite) TestDeployCharmsEndpointNotImplemented(c *gc.C) {
 
 	s.PatchValue(&registerMeteredCharm, func(r string, s api.Connection, j *cookiejar.Jar, c string, sv, e string) error {
-		return &params.Error{"IsMetered", params.CodeNotImplemented}
+		return &params.Error{
+			Message: "IsMetered",
+			Code:    params.CodeNotImplemented,
+		}
 	})
 
 	testcharms.Repo.ClonedDirPath(s.SeriesPath, "dummy")

--- a/cmd/juju/machine/add_test.go
+++ b/cmd/juju/machine/add_test.go
@@ -250,7 +250,7 @@ func (f *fakeAddMachineAPI) AddMachines(args []params.AddMachineParams) ([]param
 		} else {
 			results = append(results, params.AddMachinesResult{
 				Machine: string(i),
-				Error:   &params.Error{"something went wrong", "1"},
+				Error:   &params.Error{Message: "something went wrong", Code: "1"},
 			})
 		}
 		f.currentOp++

--- a/cmd/juju/system/destroy_test.go
+++ b/cmd/juju/system/destroy_test.go
@@ -226,7 +226,7 @@ func (s *DestroySuite) TestDestroyEnvironmentGetFails(c *gc.C) {
 }
 
 func (s *DestroySuite) TestDestroyFallsBackToClient(c *gc.C) {
-	s.api.err = &params.Error{"DestroyEnvironment", params.CodeNotImplemented}
+	s.api.err = &params.Error{Message: "DestroyEnvironment", Code: params.CodeNotImplemented}
 	_, err := s.runDestroyCommand(c, "test1", "-y")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.clientapi.destroycalled, jc.IsTrue)
@@ -234,7 +234,7 @@ func (s *DestroySuite) TestDestroyFallsBackToClient(c *gc.C) {
 }
 
 func (s *DestroySuite) TestEnvironmentGetFallsBackToClient(c *gc.C) {
-	s.api.err = &params.Error{"EnvironmentGet", params.CodeNotImplemented}
+	s.api.err = &params.Error{Message: "EnvironmentGet", Code: params.CodeNotImplemented}
 	s.clientapi.env = createBootstrapInfo(c, "test3")
 	_, err := s.runDestroyCommand(c, "test3", "-y")
 	c.Assert(err, jc.ErrorIsNil)

--- a/cmd/juju/system/kill_test.go
+++ b/cmd/juju/system/kill_test.go
@@ -114,7 +114,7 @@ func (s *KillSuite) TestKillEnvironmentGetFailsWithAPIConnection(c *gc.C) {
 }
 
 func (s *KillSuite) TestKillFallsBackToClient(c *gc.C) {
-	s.api.err = &params.Error{"DestroySystem", params.CodeNotImplemented}
+	s.api.err = &params.Error{Message: "DestroySystem", Code: params.CodeNotImplemented}
 	_, err := s.runKillCommand(c, "test1", "-y")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.clientapi.destroycalled, jc.IsTrue)
@@ -122,7 +122,7 @@ func (s *KillSuite) TestKillFallsBackToClient(c *gc.C) {
 }
 
 func (s *KillSuite) TestClientKillDestroysSystemWithAPIError(c *gc.C) {
-	s.api.err = &params.Error{"DestroySystem", params.CodeNotImplemented}
+	s.api.err = &params.Error{Message: "DestroySystem", Code: params.CodeNotImplemented}
 	s.clientapi.err = errors.New("some destroy error")
 	ctx, err := s.runKillCommand(c, "test1", "-y")
 	c.Assert(err, jc.ErrorIsNil)

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -44,7 +44,7 @@ gopkg.in/juju/charmrepo.v1	git	8677b12d9772a2a596a99e65b7e6f642fceb6c40	2015-09-
 gopkg.in/juju/charmstore.v5-unstable	git	a921c6c69d74361c38a99a95d2aceec76533038d	2015-08-27T20:19:40Z
 gopkg.in/juju/environschema.v1	git	16cc59268c09c22870cb4de8eb6248652535f315	2015-08-24T13:22:26Z
 gopkg.in/juju/jujusvg.v1	git	3eedb1c722ece2b66d62508368ca3e8b7f916569	2015-05-20T11:48:32Z
-gopkg.in/macaroon-bakery.v1	git	4ef12b7e1bf76f499808a230a099019fe9b7f192	2015-09-03T21:38:03Z
+gopkg.in/macaroon-bakery.v1	git	6026426dd8f67594d00f5b5348ac92bf71741b98	2015-09-24T17:23:52Z
 gopkg.in/macaroon.v1	git	ab3940c6c16510a850e1c2dd628b919f0f3f1464	2015-01-21T11:42:31Z
 gopkg.in/mgo.v2	git	3569c88678d88179dcbd68d02ab081cbca3cd4d0	2015-06-04T15:26:27Z
 gopkg.in/natefinch/lumberjack.v2	git	588a21fb0fa0ebdfde42670fa214576b6f0f22df	2015-05-21T01:59:18Z


### PR DESCRIPTION
Mostly this is just refactoring apiserver, but there are a few
places we've prepared for macaroon authentication too.

In apiserver, we change the validateEnvironUUID function
so that it just validates the environ UUID and doesn't return
a *state.State, and instead we add methods that explicitly
return the state (stateForRequestUnauthenticated etc)
and also authenticate as appropriate, which means we don't
need the vaguely-named httpStateWrapper any more.

We needed another parameter to sendRequest (the machine nonce)
because the original test (charmsSuite.TestAuthRequiresUser) was not
testing what it was intending to test, so we took the opportunity
to make a struct type for its parameters, which makes other
tests clearer too.

We no longer just return an "unauthorized" error message from
the HTTP endpoints when authorization is denied, but the
actual message from the error (this was what exposed the
above problem).

We add Error.Info that can hold a macaroon for discharge when
macaroon auth is enabled.

We make the Login request take a slice of macaroon.Slice
so that it's the same as an HTTP endpoint, thus potentially
making it straightforward for clients to store the macaroons as cookies.

We add an apiserver.authContext that holds authorization context
in common with both websocket and HTTP endpoints.


(Review request: http://reviews.vapour.ws/r/2758/)