### PR TITLE
lp 1485784: Retry lxc container creation / clone

### DIFF
--- a/container/lxc/lxc_test.go
+++ b/container/lxc/lxc_test.go
@@ -662,9 +662,9 @@ func (s *LxcSuite) TestCreateContainer(c *gc.C) {
 	c.Assert(location, gc.Equals, expectedTarget)
 }
 
-func (s *LxcSuite) TestCreateContainerFailsWithInjectedError(c *gc.C) {
+func (s *LxcSuite) TestCreateContainerFailsWithInjectedStartError(c *gc.C) {
 	errorChannel := make(chan error, 1)
-	cleanup := mock.PatchTransientErrorInjectionChannel(errorChannel)
+	cleanup := mock.PatchStartTransientErrorInjectionChannel(errorChannel)
 	defer cleanup()
 
 	// One injected error means the container creation will fail
@@ -677,13 +677,54 @@ func (s *LxcSuite) TestCreateContainerFailsWithInjectedError(c *gc.C) {
 	c.Assert(err, gc.NotNil)
 
 	// this should be a retryable error
-	isRetryable := instance.IsRetryableCreationError(errors.Cause(err))
+	retryErr, isRetryable := instance.GetRetryableCreationError(errors.Cause(err))
 	c.Assert(isRetryable, jc.IsTrue)
+	c.Assert(retryErr.RetryCount(), gc.Equals, 1)
+	c.Assert(retryErr.RetryDelay(), gc.Equals, 0)
+}
+
+func (s *LxcSuite) TestCreateContainerFailsWithInjectedCreateError(c *gc.C) {
+	errorChannel := make(chan error, 1)
+	cleanup := mock.PatchCreateTransientErrorInjectionChannel(errorChannel)
+	defer cleanup()
+
+	errorChannel <- errors.New("lxc-create error")
+
+	manager := s.makeManager(c, "test")
+	_, err := containertesting.CreateContainerTest(c, manager, "1/lxc/0")
+	c.Assert(err, gc.NotNil)
+
+	// this should be a retryable error
+	retryErr, isRetryable := instance.GetRetryableCreationError(errors.Cause(err))
+	c.Assert(isRetryable, jc.IsTrue)
+	c.Assert(retryErr.RetryCount(), gc.Equals, 3)
+	c.Assert(retryErr.RetryDelay(), gc.Equals, 10)
+	c.Assert(retryErr, gc.ErrorMatches, "lxc container creation failed.*")
+}
+
+func (s *LxcSuite) TestCreateContainerFailsWithInjectedCloneError(c *gc.C) {
+	errorChannel := make(chan error, 1)
+	cleanup := mock.PatchCloneTransientErrorInjectionChannel(errorChannel)
+	defer cleanup()
+
+	errorChannel <- errors.New("lxc-clone error")
+
+	s.createTemplate(c)
+	s.PatchValue(&s.useClone, true)
+	manager := s.makeManager(c, "test")
+	_, err := containertesting.CreateContainerTest(c, manager, "1")
+
+	// this should be a retryable error
+	retryErr, isRetryable := instance.GetRetryableCreationError(errors.Cause(err))
+	c.Assert(isRetryable, jc.IsTrue)
+	c.Assert(retryErr.RetryCount(), gc.Equals, 3)
+	c.Assert(retryErr.RetryDelay(), gc.Equals, 10)
+	c.Assert(retryErr, gc.ErrorMatches, "lxc container cloning failed.*")
 }
 
 func (s *LxcSuite) TestCreateContainerWithInjectedErrorDestroyFails(c *gc.C) {
 	errorChannel := make(chan error, 2)
-	cleanup := mock.PatchTransientErrorInjectionChannel(errorChannel)
+	cleanup := mock.PatchStartTransientErrorInjectionChannel(errorChannel)
 	defer cleanup()
 
 	// Two injected errors mean that the container creation and subsequent

--- a/container/lxc/mock/mock-lxc.go
+++ b/container/lxc/mock/mock-lxc.go
@@ -26,13 +26,31 @@ var logger = loggo.GetLogger("juju.container.lxc.mock")
 
 type Action int
 
-var transientErrorInjection chan error
+var (
+	startTransientErrorInjection  chan error
+	createTransientErrorInjection chan error
+	cloneTransientErrorInjection  chan error
+)
 
-// PatchTransientErrorInjectionChannel sets the transientInjectionError
+// PatchStartTransientErrorInjectionChannel sets the startTransientInjectionError
 // channel which can be used to inject errors into Start function for
-// testing purposes
-func PatchTransientErrorInjectionChannel(c chan error) func() {
-	return testing.PatchValue(&transientErrorInjection, c)
+// testing purposes.
+func PatchStartTransientErrorInjectionChannel(c chan error) func() {
+	return testing.PatchValue(&startTransientErrorInjection, c)
+}
+
+// PatchCreateTransientErrorInjectionChannel sets the createTransientInjectionError
+// channel which can be used to inject errors into Create function for
+// testing purposes.
+func PatchCreateTransientErrorInjectionChannel(c chan error) func() {
+	return testing.PatchValue(&createTransientErrorInjection, c)
+}
+
+// PatchCloneTransientErrorInjectionChannel sets the cloneTransientInjectionError
+// channel which can be used to inject errors into Clone function for
+// testing purposes.
+func PatchCloneTransientErrorInjectionChannel(c chan error) func() {
+	return testing.PatchValue(&cloneTransientErrorInjection, c)
 }
 
 const (
@@ -125,6 +143,12 @@ func (mock *mockContainer) configFilename() string {
 
 // Create creates a new container based on the given template.
 func (mock *mockContainer) Create(configFile, template string, extraArgs []string, templateArgs []string, envArgs []string) error {
+	select {
+	case injectedError := <-createTransientErrorInjection:
+		return injectedError
+	default:
+	}
+
 	if mock.getState() != golxc.StateUnknown {
 		return fmt.Errorf("container is already created")
 	}
@@ -145,7 +169,7 @@ func (mock *mockContainer) Create(configFile, template string, extraArgs []strin
 // Start runs the container as a daemon.
 func (mock *mockContainer) Start(configFile, consoleFile string) error {
 	select {
-	case injectedError := <-transientErrorInjection:
+	case injectedError := <-startTransientErrorInjection:
 		return injectedError
 	default:
 	}
@@ -179,6 +203,12 @@ func (mock *mockContainer) Stop() error {
 
 // Clone creates a copy of the container, giving the copy the specified name.
 func (mock *mockContainer) Clone(name string, extraArgs []string, templateArgs []string) (golxc.Container, error) {
+	select {
+	case injectedError := <-cloneTransientErrorInjection:
+		return nil, injectedError
+	default:
+	}
+
 	state := mock.getState()
 	if state == golxc.StateUnknown {
 		return nil, fmt.Errorf("container has not been created")
@@ -220,7 +250,7 @@ func (mock *mockContainer) Unfreeze() error {
 // Destroy stops and removes the container.
 func (mock *mockContainer) Destroy() error {
 	select {
-	case injectedError := <-transientErrorInjection:
+	case injectedError := <-startTransientErrorInjection:
 		return injectedError
 	default:
 	}

--- a/instance/instance.go
+++ b/instance/instance.go
@@ -71,13 +71,32 @@ func uintStr(i uint64) string {
 // that it is safe to restart instance creation
 type RetryableCreationError struct {
 	message string
+
+	// retryCount is the number of follow on attempts that should be
+	// made to create the instance.
+	retryCount int
+
+	// retryDelay is the delay, in seconds, between retry attempts.
+	retryDelay int
 }
 
-// Returns the error message
+// Error returns the error message.
 func (e RetryableCreationError) Error() string { return e.message }
 
-func NewRetryableCreationError(errorMessage string) *RetryableCreationError {
-	return &RetryableCreationError{errorMessage}
+// RetryCount returns the retryCount.
+func (e RetryableCreationError) RetryCount() int { return e.retryCount }
+
+// RetryDelay returns the retryDelay.
+func (e RetryableCreationError) RetryDelay() int { return e.retryDelay }
+
+// NewRetryableCreationError returns a new RetryableCreationError with
+// the message, retry count and retry delay as specified.
+func NewRetryableCreationError(errorMessage string, count int, delay int) *RetryableCreationError {
+	return &RetryableCreationError{
+		message:    errorMessage,
+		retryCount: count,
+		retryDelay: delay,
+	}
 }
 
 // IsRetryableCreationError returns true if the given error is
@@ -85,6 +104,17 @@ func NewRetryableCreationError(errorMessage string) *RetryableCreationError {
 func IsRetryableCreationError(err error) bool {
 	_, ok := err.(*RetryableCreationError)
 	return ok
+}
+
+// GetRetryableCreationError returns the RetryableCreationError wrapped
+// in the specified error, and a bool indicating whether or not the error
+// was a *RetryableCreationError.
+func GetRetryableCreationError(err error) (*RetryableCreationError, bool) {
+	retryErr, ok := err.(*RetryableCreationError)
+	if !ok {
+		return nil, false
+	}
+	return retryErr, true
 }
 
 func (hc HardwareCharacteristics) String() string {

--- a/instance/instance_test.go
+++ b/instance/instance_test.go
@@ -12,9 +12,9 @@ import (
 	"github.com/juju/juju/instance"
 )
 
-type HardwareSuite struct{}
+type instanceSuite struct{}
 
-var _ = gc.Suite(&HardwareSuite{})
+var _ = gc.Suite(&instanceSuite{})
 
 type parseHardwareTestSpec struct {
 	summary string
@@ -273,25 +273,21 @@ var parseHardwareTests = []parseHardwareTestSpec{
 	},
 }
 
-func (s *HardwareSuite) TestParseHardware(c *gc.C) {
+func (s *instanceSuite) TestParseHardware(c *gc.C) {
 	for i, t := range parseHardwareTests {
 		c.Logf("test %d: %s", i, t.summary)
 		t.check(c)
 	}
 }
 
-type RetryErrSuite struct{}
-
-var _ = gc.Suite(&RetryErrSuite{})
-
-func (s *RetryErrSuite) TestNewRetryErr(c *gc.C) {
+func (s *instanceSuite) TestNewRetryErr(c *gc.C) {
 	retErr := instance.NewRetryableCreationError("test error message", 10, 20)
 	c.Check(retErr.Error(), gc.Equals, "test error message")
 	c.Check(retErr.RetryCount(), gc.Equals, 10)
 	c.Check(retErr.RetryDelay(), gc.Equals, 20)
 }
 
-func (s *RetryErrSuite) TestRetryErrCheckers(c *gc.C) {
+func (s *instanceSuite) TestRetryErrCheckers(c *gc.C) {
 	retErr := instance.NewRetryableCreationError("test error message", 10, 20)
 	err := errors.New("non-retryable error")
 	c.Check(instance.IsRetryableCreationError(retErr), jc.IsTrue)

--- a/worker/provisioner/export_test.go
+++ b/worker/provisioner/export_test.go
@@ -44,6 +44,7 @@ var (
 	MaybeOverrideDefaultLXCNet = maybeOverrideDefaultLXCNet
 	EtcDefaultLXCNetPath       = &etcDefaultLXCNetPath
 	EtcDefaultLXCNet           = etcDefaultLXCNet
+	MaxInstanceRetryDelay      = &maxInstanceRetryDelay
 )
 
 const (

--- a/worker/provisioner/provisioner_task.go
+++ b/worker/provisioner/provisioner_task.go
@@ -57,6 +57,11 @@ type ToolsFinder interface {
 	FindTools(version version.Number, series string, arch string) (coretools.List, error)
 }
 
+var (
+	maxInstanceRetryDelay = 60
+	maxInstanceRetryCount = 5
+)
+
 var _ MachineGetter = (*apiprovisioner.State)(nil)
 var _ ToolsFinder = (*apiprovisioner.State)(nil)
 
@@ -681,26 +686,51 @@ func (task *provisionerTask) prepareNetworkAndInterfaces(networkInfo []network.I
 	return networks, ifaces, nil
 }
 
+func min(a, b int) int {
+	if a <= b {
+		return a
+	}
+	return b
+}
+
 func (task *provisionerTask) startMachine(
 	machine *apiprovisioner.Machine,
 	provisioningInfo *params.ProvisioningInfo,
 	startInstanceParams environs.StartInstanceParams,
 ) error {
-
 	result, err := task.broker.StartInstance(startInstanceParams)
 	if err != nil {
-		// If this is a retryable error, we retry once
-		if instance.IsRetryableCreationError(errors.Cause(err)) {
-			logger.Infof("retryable error received on start instance - retrying instance creation")
+		// If this is a retryable error, we retry as requested.
+		retryErr, ok := instance.GetRetryableCreationError(errors.Cause(err))
+		if !ok || retryErr.RetryCount() <= 0 {
+			// Not a retryable error. Set the state to error, so the
+			// machine will be skipped next time until the error is
+			// resolved, but don't return an error; just keep going with
+			// the other machines.
+			return task.setErrorStatus("cannot start instance for machine %q: %v", machine, err)
+		}
+
+		count := min(retryErr.RetryCount(), maxInstanceRetryCount)
+		delay := min(retryErr.RetryDelay(), maxInstanceRetryDelay)
+
+		logger.Infof("retryable error received on start instance - retrying instance creation %d times with a %ds delay", count, delay)
+		for ; count > 0; count-- {
+			if delay > 0 {
+				select {
+				case <-task.tomb.Dying():
+					return task.setErrorStatus("cannot start instance for machine %q: %v", machine, tomb.ErrDying)
+				case <-time.After(time.Duration(delay) * time.Second):
+				}
+
+			}
 			result, err = task.broker.StartInstance(startInstanceParams)
-			if err != nil {
+			if err == nil {
+				break
+			} else if !instance.IsRetryableCreationError(errors.Cause(err)) || count == 1 {
+				// If we encountered a non-retryable error, or this is our last attempt,
+				// report that starting the instance failed.
 				return task.setErrorStatus("cannot start instance for machine after a retry %q: %v", machine, err)
 			}
-		} else {
-			// Set the state to error, so the machine will be skipped next
-			// time until the error is resolved, but don't return an
-			// error; just keep going with the other machines.
-			return task.setErrorStatus("cannot start instance for machine %q: %v", machine, err)
 		}
 	}
 


### PR DESCRIPTION
Cherry pick forward port of https://github.com/juju/juju/pull/3345

If an error is returned from lxc-create or lxc-clone,
treat it as a transient error and retry with a slight
delay.

(Review request: http://reviews.vapour.ws/r/2761/)