### PR TITLE
apiserver: fix data race in shutdown

### DIFF
--- a/apiserver/admin.go
+++ b/apiserver/admin.go
@@ -5,6 +5,7 @@ package apiserver
 
 import (
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/juju/errors"
@@ -310,7 +311,7 @@ func checkForValidMachineAgent(entity state.Entity, req params.LoginRequest) err
 // machinePinger wraps a presence.Pinger.
 type machinePinger struct {
 	*presence.Pinger
-	mongoUnavailable *bool
+	mongoUnavailable *uint32
 }
 
 // Stop implements Pinger.Stop() as Pinger.Kill(), needed at
@@ -319,7 +320,7 @@ func (p *machinePinger) Stop() error {
 	if err := p.Pinger.Stop(); err != nil {
 		return err
 	}
-	if *p.mongoUnavailable {
+	if atomic.LoadUint32(p.mongoUnavailable) > 0 {
 		// Kill marks the agent as not-present. If the
 		// Mongo server is known to be unavailable, then
 		// we do not perform this operation; the agent

--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -48,7 +48,7 @@ type Server struct {
 	limiter           utils.Limiter
 	validator         LoginValidator
 	adminApiFactories map[int]adminApiFactory
-	mongoUnavailable  bool
+	mongoUnavailable  uint32 // non zero if mongoUnavailable
 
 	mu          sync.Mutex // protects the fields that follow
 	environUUID string
@@ -315,7 +315,7 @@ func (srv *Server) run(lis net.Listener) {
 		// Mongo is unavailable. API handlers can use this to decide
 		// not to perform non-critical Mongo-related operations when
 		// tearing down.
-		srv.mongoUnavailable = true
+		atomic.AddUint32(&srv.mongoUnavailable, 1)
 		srv.tomb.Kill(err)
 		srv.wg.Done()
 	}()

--- a/apiserver/root.go
+++ b/apiserver/root.go
@@ -46,7 +46,7 @@ type apiHandler struct {
 	rpcConn          *rpc.Conn
 	resources        *common.Resources
 	entity           state.Entity
-	mongoUnavailable *bool
+	mongoUnavailable *uint32
 	// An empty envUUID means that the user has logged in through the
 	// root of the API server rather than the /environment/:env-uuid/api
 	// path, logins processed with v2 or later will only offer the


### PR DESCRIPTION
Fixes LP 1500283.

Fixes data race in any test using mongo/state which was introduced in 5cec732d.

(Review request: http://reviews.vapour.ws/r/2764/)