### PR TITLE
Changed logging leves in the dependency engine

### DIFF
--- a/worker/dependency/engine_test.go
+++ b/worker/dependency/engine_test.go
@@ -513,3 +513,20 @@ func (s *EngineSuite) TestValidateComplexManifolds(c *gc.C) {
 	err = dependency.Validate(manifolds)
 	c.Check(err, gc.ErrorMatches, "cycle detected at .*")
 }
+
+func (s *EngineSuite) TestTracedErrMissing(c *gc.C) {
+
+	// Install a worker with an unmet dependency, check it doesn't start
+	// (because the implementation returns ErrMissing).
+	mh1 := newTracedManifoldHarness("later-task")
+	err := s.engine.Install("some-task", mh1.Manifold())
+	c.Assert(err, jc.ErrorIsNil)
+	mh1.AssertNoStart(c)
+
+	// Install its dependency; check both start.
+	mh2 := newTracedManifoldHarness()
+	err = s.engine.Install("later-task", mh2.Manifold())
+	c.Assert(err, jc.ErrorIsNil)
+	mh2.AssertOneStart(c)
+	mh1.AssertOneStart(c)
+}

--- a/worker/dependency/resource.go
+++ b/worker/dependency/resource.go
@@ -40,7 +40,7 @@ func (rg *resourceGetter) expire() {
 // getResource is intended for use as the GetResourceFunc passed into the Start
 // func of the client manifold.
 func (rg *resourceGetter) getResource(resourceName string, out interface{}) error {
-	logger.Debugf("%q manifold requested %q resource", rg.clientName, resourceName)
+	logger.Tracef("%q manifold requested %q resource", rg.clientName, resourceName)
 	select {
 	case <-rg.expired:
 		return errors.New("expired resourceGetter: cannot be used outside Start func")


### PR DESCRIPTION
Warning and error reports in logs looked pretty scary even though they were reporting
on a normal work flow of the dependency engine.

(Review request: http://reviews.vapour.ws/r/2769/)