### PR TITLE
Added OS X El Capitan to recognised versions.

### DIFF
--- a/version/osversion.go
+++ b/version/osversion.go
@@ -121,6 +121,7 @@ func macOSXSeriesFromKernelVersion(getKernelVersion func() (string, error)) (str
 // macOSXSeries maps from the Darwin Kernel Major Version to the Mac OSX
 // series.
 var macOSXSeries = map[int]string{
+	15: "elcapitan",
 	14: "yosemite",
 	13: "mavericks",
 	12: "mountainlion",

--- a/version/osversion_test.go
+++ b/version/osversion_test.go
@@ -182,7 +182,8 @@ func (*kernelVersionSuite) TestMacOSXSeries(c *gc.C) {
 		{version: 13, series: "mavericks"},
 		{version: 12, series: "mountainlion"},
 		{version: 14, series: "yosemite"},
-		{version: 15, series: "unknown", err: `unknown series ""`},
+		{version: 15, series: "elcapitan"},
+		{version: 16, series: "unknown", err: `unknown series ""`},
 		{version: 4, series: "unknown", err: `unknown series ""`},
 		{version: 0, series: "unknown", err: `unknown series ""`},
 	}


### PR DESCRIPTION
As predicted in https://bugs.launchpad.net/juju-core/+bug/1465317 The Juju client fails on OS X El Capitan. Users who upgrade will be broken. I have a patch for homebrew based on this branch to ensure 1.24.6 will work (https://github.com/Homebrew/homebrew/pull/44285). While we don't intend to release a 1.24.7, we should apply this just in case.

Juju 1.25+ is already fixed as a part of the rethink to detect OS series.


(Review request: http://reviews.vapour.ws/r/2771/)