### PR TITLE
fwport: Enable GCE provider on windows

### DIFF
--- a/provider/gce/environ_broker_test.go
+++ b/provider/gce/environ_broker_test.go
@@ -4,8 +4,11 @@
 package gce_test
 
 import (
+	"errors"
+
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/arch"
+	jujuos "github.com/juju/utils/os"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/params"
@@ -166,22 +169,54 @@ func (s *environBrokerSuite) TestNewRawInstance(c *gc.C) {
 	c.Check(inst, gc.DeepEquals, s.BaseInstance)
 }
 
-func (s *environBrokerSuite) TestGetMetadata(c *gc.C) {
-	metadata, err := gce.GetMetadata(s.StartInstArgs)
+func (s *environBrokerSuite) TestGetMetadataUbuntu(c *gc.C) {
+	metadata, err := gce.GetMetadata(s.StartInstArgs, jujuos.Ubuntu)
 
 	c.Assert(err, jc.ErrorIsNil)
-	c.Check(metadata, gc.DeepEquals, s.Metadata)
+	c.Check(metadata, gc.DeepEquals, s.UbuntuMetadata)
+
+}
+
+func (s *environBrokerSuite) TestGetMetadataWindows(c *gc.C) {
+	metadata, err := gce.GetMetadata(s.StartInstArgs, jujuos.Windows)
+
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(metadata["windows-startup-script-ps1"], gc.Equals, s.WindowsMetadata["windows-startup-script-ps1"])
+	c.Check(metadata["sysprep-specialize-script-ps1"], gc.Matches, s.WindowsMetadata["sysprep-specialize-script-ps1"])
+}
+
+func (s *environBrokerSuite) TestGetMetadataOSNotSupported(c *gc.C) {
+	metadata, err := gce.GetMetadata(s.StartInstArgs, jujuos.Arch)
+
+	c.Assert(metadata, gc.IsNil)
+	c.Assert(err, gc.ErrorMatches, "cannot pack metadata for os Arch on the gce provider")
+}
+
+var getDisksTests = []struct {
+	OS       jujuos.OSType
+	basePath string
+	error    error
+}{
+	{jujuos.Ubuntu, gce.UbuntuImageBasePath, nil},
+	{jujuos.Windows, gce.WindowsImageBasePath, nil},
+	{jujuos.Arch, "", errors.New("os Arch is not supported on the gce provider")},
 }
 
 func (s *environBrokerSuite) TestGetDisks(c *gc.C) {
-	diskSpecs := gce.GetDisks(s.spec, s.StartInstArgs.Constraints)
+	for _, test := range getDisksTests {
+		diskSpecs, err := gce.GetDisks(s.spec, s.StartInstArgs.Constraints, test.OS)
+		if test.error != nil {
+			c.Assert(err, gc.Equals, err)
+		} else {
+			c.Assert(err, jc.ErrorIsNil)
+			c.Assert(diskSpecs, gc.HasLen, 1)
 
-	c.Assert(diskSpecs, gc.HasLen, 1)
+			diskSpec := diskSpecs[0]
 
-	diskSpec := diskSpecs[0]
-
-	c.Check(diskSpec.SizeHintGB, gc.Equals, uint64(8))
-	c.Check(diskSpec.ImageURL, gc.Equals, "projects/ubuntu-os-cloud/global/images/ubuntu-1404-trusty-v20141212")
+			c.Check(diskSpec.SizeHintGB, gc.Equals, uint64(8))
+			c.Check(diskSpec.ImageURL, gc.Equals, test.basePath+s.spec.Image.Id)
+		}
+	}
 }
 
 func (s *environBrokerSuite) TestGetHardwareCharacteristics(c *gc.C) {

--- a/provider/gce/export_test.go
+++ b/provider/gce/export_test.go
@@ -12,12 +12,14 @@ import (
 )
 
 var (
-	Provider          environs.EnvironProvider = providerInstance
-	NewInstance                                = newInstance
-	CheckInstanceType                          = checkInstanceType
-	GetMetadata                                = getMetadata
-	GetDisks                                   = getDisks
-	ConfigImmutable                            = configImmutableFields
+	Provider             environs.EnvironProvider = providerInstance
+	NewInstance                                   = newInstance
+	CheckInstanceType                             = checkInstanceType
+	GetMetadata                                   = getMetadata
+	GetDisks                                      = getDisks
+	ConfigImmutable                               = configImmutableFields
+	UbuntuImageBasePath                           = ubuntuImageBasePath
+	WindowsImageBasePath                          = windowsImageBasePath
 )
 
 func ExposeInstBase(inst *environInstance) *google.Instance {

--- a/provider/gce/gce.go
+++ b/provider/gce/gce.go
@@ -17,8 +17,10 @@ const (
 	// http://bazaar.launchpad.net/~cloud-init-dev/cloud-init/trunk/view/head:/cloudinit/sources/DataSourceGCE.py
 	// http://cloudinit.readthedocs.org/en/latest/
 	// https://cloud.google.com/compute/docs/metadata
-	metadataKeyCloudInit = "user-data"
-	metadataKeyEncoding  = "user-data-encoding"
+	metadataKeyCloudInit       = "user-data"
+	metadataKeyEncoding        = "user-data-encoding"
+	metadataKeyWindowsUserdata = "windows-startup-script-ps1"
+	metadataKeyWindowsSysprep  = "sysprep-specialize-script-ps1"
 	// GCE uses this specific key for authentication (*handwaving*)
 	// https://cloud.google.com/compute/docs/instances#sshkeys
 	metadataKeySSHKeys = "sshKeys"
@@ -34,7 +36,8 @@ const (
 	// See https://cloud.google.com/compute/docs/operating-systems/linux-os#ubuntu
 	// TODO(ericsnow) Should this be handled in cloud-images (i.e.
 	// simplestreams)?
-	imageBasePath = "projects/ubuntu-os-cloud/global/images/"
+	ubuntuImageBasePath  = "projects/ubuntu-os-cloud/global/images/"
+	windowsImageBasePath = "projects/windows-cloud/global/images/"
 )
 
 var (

--- a/provider/gce/userdata.go
+++ b/provider/gce/userdata.go
@@ -18,7 +18,21 @@ func (GCERenderer) EncodeUserdata(udata []byte, os jujuos.OSType) ([]byte, error
 	switch os {
 	case jujuos.Ubuntu, jujuos.CentOS:
 		return renderers.ToBase64(utils.Gzip(udata)), nil
+	case jujuos.Windows:
+		return renderers.WinEmbedInScript(udata), nil
 	default:
 		return nil, errors.Errorf("Cannot encode userdata for OS: %s", os.String())
 	}
 }
+
+// The hostname on windows GCE instances is taken from
+// the instance id. This is bad because windows only
+// uses the first 15 characters in certain instances,
+// which are not unique for the GCE provider.
+// As a result, we have to send this small script as
+// a sysprep script, to change the hostname inside
+// the sysprep step, simplyfing the userdata and
+// saving a reboot
+var winSetHostnameScript = `
+Rename-Computer %q
+`

--- a/provider/gce/userdata_test.go
+++ b/provider/gce/userdata_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/utils/os"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cloudconfig/providerinit/renderers"
 	"github.com/juju/juju/provider/gce"
 	"github.com/juju/juju/testing"
 )
@@ -37,9 +38,17 @@ func (s *UserdataSuite) TestGCEUnix(c *gc.C) {
 	c.Assert(string(result), jc.DeepEquals, expected)
 }
 
+func (s *UserdataSuite) TestAzureWindows(c *gc.C) {
+	renderer := gce.GCERenderer{}
+	data := []byte("test")
+	result, err := renderer.EncodeUserdata(data, os.Windows)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, jc.DeepEquals, renderers.WinEmbedInScript(data))
+}
+
 func (s *UserdataSuite) TestGCEUnknownOS(c *gc.C) {
 	renderer := gce.GCERenderer{}
-	result, err := renderer.EncodeUserdata(nil, os.Windows)
+	result, err := renderer.EncodeUserdata(nil, os.Arch)
 	c.Assert(result, gc.IsNil)
-	c.Assert(err, gc.ErrorMatches, "Cannot encode userdata for OS: Windows")
+	c.Assert(err, gc.ErrorMatches, "Cannot encode userdata for OS: Arch")
 }


### PR DESCRIPTION
Forward port of https://github.com/juju/juju/pull/3284

gce support might come in a later version of 1.25, so I'll leave that branch up as well for now, but we need it in master anyway.

It's mostly a straight cherry-pick (with modifications for the new series and os packages) so nothing fancy.

(Review request: http://reviews.vapour.ws/r/2772/)