### PR TITLE
apiserver/common: handle DischargeRequiredError in ServerError

### DIFF
--- a/apiserver/admin.go
+++ b/apiserver/admin.go
@@ -86,7 +86,7 @@ func (a *admin) doLogin(req params.LoginRequest, loginVersion int) (params.Login
 
 	entity, lastConnection, err := doCheckCreds(a.root.state, req, !serverOnlyLogin, a.srv.authCtxt.authenticatorForTag)
 	if err != nil {
-		if err, ok := errors.Cause(err).(*authentication.DischargeRequiredError); ok {
+		if err, ok := errors.Cause(err).(*common.DischargeRequiredError); ok {
 			loginResult := params.LoginResultV1{
 				DischargeRequired: err.Macaroon,
 			}

--- a/apiserver/adminv2_test.go
+++ b/apiserver/adminv2_test.go
@@ -4,46 +4,17 @@
 package apiserver_test
 
 import (
-	"net"
-	"net/http"
-
 	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-	"gopkg.in/macaroon-bakery.v1/bakery/checkers"
-	"gopkg.in/macaroon-bakery.v1/bakerytest"
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/apiserver"
-	jujutesting "github.com/juju/juju/juju/testing"
-	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/testing/factory"
 )
 
 type loginV2Suite struct {
 	loginSuite
-}
-
-type loginV2MacaroonSuite struct {
-	jujutesting.JujuConnSuite
-	discharger *bakerytest.Discharger
-	username   string
-}
-
-func (s *loginV2MacaroonSuite) SetUpTest(c *gc.C) {
-	s.JujuConnSuite.SetUpTest(c)
-	s.discharger = bakerytest.NewDischarger(nil, s.Checker)
-}
-
-func (s *loginV2MacaroonSuite) TearDownTest(c *gc.C) {
-	if s.discharger != nil {
-		s.discharger.Close()
-	}
-	s.JujuConnSuite.TearDownTest(c)
-}
-
-func (s *loginV2MacaroonSuite) Checker(req *http.Request, cond, arg string) ([]checkers.Caveat, error) {
-	return []checkers.Caveat{checkers.DeclaredCaveat("username", s.username)}, nil
 }
 
 var _ = gc.Suite(&loginV2Suite{
@@ -55,7 +26,6 @@ var _ = gc.Suite(&loginV2Suite{
 		},
 	},
 })
-var _ = gc.Suite(&loginV2MacaroonSuite{})
 
 func (s *loginV2Suite) TestClientLoginToEnvironment(c *gc.C) {
 	_, cleanup := s.setupServerWithValidator(c, nil)
@@ -124,16 +94,4 @@ func (s *loginV2Suite) TestClientLoginToRootOldClient(c *gc.C) {
 	client := apiState.Client()
 	_, err = client.GetEnvironmentConstraints()
 	c.Assert(err, jc.ErrorIsNil)
-}
-
-func (s *loginV2MacaroonSuite) newServer(c *gc.C) *apiserver.Server {
-	listener, err := net.Listen("tcp", ":0")
-	c.Assert(err, jc.ErrorIsNil)
-	srv, err := apiserver.NewServer(s.State, listener, apiserver.ServerConfig{
-		Cert: []byte(coretesting.ServerCert),
-		Key:  []byte(coretesting.ServerKey),
-		Tag:  names.NewMachineTag("0"),
-	})
-	c.Assert(err, jc.ErrorIsNil)
-	return srv
 }

--- a/apiserver/authentication/user.go
+++ b/apiserver/authentication/user.go
@@ -34,22 +34,10 @@ func (u *UserAuthenticator) Authenticate(entityFinder EntityFinder, tag names.Ta
 	return u.AgentAuthenticator.Authenticate(entityFinder, tag, req)
 }
 
-// DischargeRequiredError is the error returned when a macaroon requires discharging
-// to complete authentication.
-type DischargeRequiredError struct {
-	Cause    error
-	Macaroon *macaroon.Macaroon
-}
-
-// Error implements the error interface.
-func (e *DischargeRequiredError) Error() string {
-	return e.Cause.Error()
-}
-
 // MacaroonAuthenticator performs authentication for users using macaroons.
 // If the authentication fails because provided macaroons are invalid,
 // and macaroon authentiction is enabled, it will return a
-// httpbakery.DischargeRequiredError holding a macaroon to be
+// *common.DischargeRequiredError holding a macaroon to be
 // discharged.
 type MacaroonAuthenticator struct {
 	Service          *bakery.Service
@@ -78,7 +66,7 @@ func (m *MacaroonAuthenticator) newDischargeRequiredError(cause error) error {
 	if err != nil {
 		return errors.Annotatef(err, "cannot create macaroon")
 	}
-	return &DischargeRequiredError{
+	return &common.DischargeRequiredError{
 		Cause:    cause,
 		Macaroon: mac,
 	}

--- a/apiserver/authentication/user_test.go
+++ b/apiserver/authentication/user_test.go
@@ -17,6 +17,7 @@ import (
 	"gopkg.in/macaroon.v1"
 
 	"github.com/juju/juju/apiserver/authentication"
+	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/state"
@@ -177,7 +178,7 @@ func (s *macaroonAuthenticatorSuite) TestReturnDischargeRequiredErrorIfNoMacaroo
 	}
 	_, err = authenticator.Authenticate(nil, user.Tag(), params.LoginRequest{})
 	c.Assert(err, gc.ErrorMatches, "verification failed: no macaroons")
-	dischargeErr, ok := err.(*authentication.DischargeRequiredError)
+	dischargeErr, ok := err.(*common.DischargeRequiredError)
 	if !ok {
 		c.Fatalf("DischargeRequiredError expected")
 	}
@@ -209,7 +210,7 @@ func (s *macaroonAuthenticatorSuite) TestAuthenticateSuccess(c *gc.C) {
 		Nonce:       "",
 		Macaroons:   nil,
 	})
-	dischargeErr := err.(*authentication.DischargeRequiredError)
+	dischargeErr := err.(*common.DischargeRequiredError)
 	client := httpbakery.NewClient()
 	ms, err := client.DischargeAll(dischargeErr.Macaroon)
 	c.Assert(err, jc.ErrorIsNil)
@@ -243,7 +244,7 @@ func (s *macaroonAuthenticatorSuite) TestAuthenticateFailsWithNonExistentUser(c 
 		Macaroon:         mac,
 	}
 	_, err = authenticator.Authenticate(nil, user.Tag(), params.LoginRequest{})
-	dischargeErr := err.(*authentication.DischargeRequiredError)
+	dischargeErr := err.(*common.DischargeRequiredError)
 	client := httpbakery.NewClient()
 	ms, err := client.DischargeAll(dischargeErr.Macaroon)
 	c.Assert(err, jc.ErrorIsNil)
@@ -276,7 +277,7 @@ func (s *macaroonAuthenticatorSuite) TestInvalidUserName(c *gc.C) {
 		Macaroon:         mac,
 	}
 	_, err = authenticator.Authenticate(nil, user.Tag(), params.LoginRequest{})
-	dischargeErr := err.(*authentication.DischargeRequiredError)
+	dischargeErr := err.(*common.DischargeRequiredError)
 	client := httpbakery.NewClient()
 	ms, err := client.DischargeAll(dischargeErr.Macaroon)
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/charms.go
+++ b/apiserver/charms.go
@@ -116,6 +116,7 @@ func (h *charmsHandler) sendError(w http.ResponseWriter, err error) {
 	sendStatusAndJSON(w, status, &params.CharmsResponse{
 		Error:     perr.Message,
 		ErrorCode: perr.Code,
+		ErrorInfo: perr.Info,
 	})
 }
 

--- a/apiserver/params/internal.go
+++ b/apiserver/params/internal.go
@@ -518,9 +518,14 @@ type CharmsResponse struct {
 	// Ideally, Error would hold an Error object and the
 	// code would be in that, but for backward compatibility,
 	// we cannot do that.
-	ErrorCode string   `json:",omitempty"`
-	CharmURL  string   `json:",omitempty"`
-	Files     []string `json:",omitempty"`
+	ErrorCode string `json:",omitempty"`
+
+	// ErrorInfo holds extra information associated with the error.
+	// Like ErrorCode, this should really be in an Error object.
+	ErrorInfo *ErrorInfo
+
+	CharmURL string   `json:",omitempty"`
+	Files    []string `json:",omitempty"`
 }
 
 // RunParams is used to provide the parameters to the Run method.


### PR DESCRIPTION
We return an http.StatusUnauthorized error in this case.

We needed to move DischargeRequiredError from apiserver/authentication to avoid an import cycle.

Also clean up various places where we used a hack to get around
the immutable identity-url attribute to make macaroon-related
tests and use the new JujuConnSuite functionality instead.

(Review request: http://reviews.vapour.ws/r/2774/)