### PR TITLE
Upgrade step adding preferred addresses to machines

### DIFF
--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -629,6 +629,28 @@ func AddNameFieldLowerCaseIdOfUsers(st *State) error {
 	return st.runRawTransaction(ops)
 }
 
+func AddPreferredAddressesToMachines(st *State) error {
+	machines, err := st.AllMachines()
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	for _, machine := range machines {
+		// Setting the addresses is enough to trigger setting the preferred
+		// addresses.
+		err := machine.SetProviderAddresses(machine.ProviderAddresses()...)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		err = machine.SetMachineAddresses(machine.MachineAddresses()...)
+		if err != nil {
+			return errors.Trace(err)
+		}
+
+	}
+	return nil
+}
+
 func LowerCaseEnvUsersID(st *State) error {
 	users, closer := st.getRawCollection(envUsersC)
 	defer closer()

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -636,6 +636,9 @@ func AddPreferredAddressesToMachines(st *State) error {
 	}
 
 	for _, machine := range machines {
+		if machine.Life() == Dead {
+			continue
+		}
 		// Setting the addresses is enough to trigger setting the preferred
 		// addresses.
 		err := machine.SetProviderAddresses(machine.ProviderAddresses()...)

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -2482,6 +2482,7 @@ func (s *upgradesSuite) createMachinesWithAddresses(c *gc.C) []*Machine {
 		{Series: "quantal", Jobs: []MachineJob{JobHostUnits}},
 		{Series: "quantal", Jobs: []MachineJob{JobHostUnits}},
 	}...)
+	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(machines, gc.HasLen, 4)
 
 	m1 := machines[0]

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -2448,20 +2448,29 @@ func (s *upgradesSuite) TestAddPreferredAddressesToMachines(c *gc.C) {
 		{Series: "quantal", Jobs: []MachineJob{JobHostUnits}},
 		{Series: "quantal", Jobs: []MachineJob{JobHostUnits}},
 		{Series: "quantal", Jobs: []MachineJob{JobHostUnits}},
+		{Series: "quantal", Jobs: []MachineJob{JobHostUnits}},
 	}...)
 
 	ms, err := s.state.AllMachines()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(ms, gc.HasLen, 3)
+	c.Assert(ms, gc.HasLen, 4)
 
 	m1 := machines[0]
 	m2 := machines[1]
 	m3 := machines[2]
+	m4 := machines[3]
 	err = m1.SetProviderAddresses(network.NewAddress("8.8.8.8"))
 	c.Assert(err, jc.ErrorIsNil)
 	err = m2.SetMachineAddresses(network.NewAddress("10.0.0.1"))
 	c.Assert(err, jc.ErrorIsNil)
 	err = m2.SetProviderAddresses(network.NewAddress("8.8.4.4"))
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Attempting to set the addresses of a dead machine will fail, so we
+	// include a dead machine to make sure the upgrade step can cope.
+	err = m4.SetProviderAddresses(network.NewAddress("8.8.8.8"))
+	c.Assert(err, jc.ErrorIsNil)
+	err = m4.EnsureDead()
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Delete the preferred address fields.

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -2450,10 +2450,7 @@ func (s *upgradesSuite) TestAddPreferredAddressesToMachines(c *gc.C) {
 		{Series: "quantal", Jobs: []MachineJob{JobHostUnits}},
 		{Series: "quantal", Jobs: []MachineJob{JobHostUnits}},
 	}...)
-
-	ms, err := s.state.AllMachines()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(ms, gc.HasLen, 4)
+	c.Assert(machines, gc.HasLen, 4)
 
 	m1 := machines[0]
 	m2 := machines[1]

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -2476,12 +2476,15 @@ func assertMachineAddresses(c *gc.C, machine *Machine, publicAddress, privateAdd
 }
 
 func (s *upgradesSuite) createMachinesWithAddresses(c *gc.C) []*Machine {
-	machines, err := s.state.AddMachines([]MachineTemplate{
-		{Series: "quantal", Jobs: []MachineJob{JobHostUnits}},
+	_, err := s.state.AddMachine("quantal", JobManageEnviron)
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = s.state.AddMachines([]MachineTemplate{
 		{Series: "quantal", Jobs: []MachineJob{JobHostUnits}},
 		{Series: "quantal", Jobs: []MachineJob{JobHostUnits}},
 		{Series: "quantal", Jobs: []MachineJob{JobHostUnits}},
 	}...)
+	c.Assert(err, jc.ErrorIsNil)
+	machines, err := s.state.AllMachines()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(machines, gc.HasLen, 4)
 

--- a/upgrades/steps124.go
+++ b/upgrades/steps124.go
@@ -60,6 +60,13 @@ func stateStepsFor124() []Step {
 				return state.ChangeStatusUpdatedType(context.State())
 			},
 		},
+		&upgradeStep{
+			description: "add preferred addresses to machines",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return state.AddPreferredAddressesToMachines(context.State())
+			},
+		},
 	}
 }
 

--- a/upgrades/steps124_test.go
+++ b/upgrades/steps124_test.go
@@ -32,6 +32,7 @@ func (s *steps124Suite) TestStateStepsFor124(c *gc.C) {
 		"change entityid field on status history to globalkey",
 		"change updated field on statushistory from time to int",
 		"change updated field on status from time to int",
+		"add preferred addresses to machines",
 	}
 	assertStateSteps(c, version.MustParse("1.24.0"), expected)
 }


### PR DESCRIPTION
An upgrade step that adds the preferred public and private addresses to machine records.

(Review request: http://reviews.vapour.ws/r/2775/)