### PR TITLE
provider/gce: set HardwareId, not DeviceName

### DIFF
--- a/provider/gce/disks_test.go
+++ b/provider/gce/disks_test.go
@@ -133,9 +133,10 @@ func (s *volumeSourceSuite) TestCreateVolumes(c *gc.C) {
 	// Volume was created
 	c.Assert(res[0].Error, jc.ErrorIsNil)
 	c.Assert(res[0].Volume.VolumeId, gc.Equals, s.BaseDisk.Name)
+	c.Assert(res[0].Volume.HardwareId, gc.Equals, "scsi-0Google_PersistentDisk_home-zone-1234567")
 
 	// Volume was also attached as indicated by Attachment in params.
-	c.Assert(res[0].VolumeAttachment.DeviceName, gc.Equals, "home-zone-1234567")
+	c.Assert(res[0].VolumeAttachment.DeviceName, gc.Equals, "")
 	c.Assert(res[0].VolumeAttachment.Machine.String(), gc.Equals, "machine-0")
 	c.Assert(res[0].VolumeAttachment.ReadOnly, jc.IsFalse)
 	c.Assert(res[0].VolumeAttachment.Volume.String(), gc.Equals, "volume-0")


### PR DESCRIPTION
The gce storage provider was setting VolumeAttachmentInfo.DeviceName
to an invalid value. When we create volumes, we specify a device
name to include in the /dev/disk/by/id path. This is stable across
attachments, so we can use that in the VolumeInfo.HardwareId field.

Fixes https://bugs.launchpad.net/juju-core/+bug/1500703

(Review request: http://reviews.vapour.ws/r/2776/)