### PR TITLE
provider/ec2: don't use numbers in device names

### DIFF
--- a/provider/ec2/ebs_test.go
+++ b/provider/ec2/ebs_test.go
@@ -606,9 +606,7 @@ func (*blockDeviceMappingSuite) TestBlockDeviceNamer(c *gc.C) {
 	}
 
 	// First without numbers.
-	nextName = ec2.BlockDeviceNamer(awsec2.Instance{
-		VirtType: "hvm",
-	})
+	nextName = ec2.BlockDeviceNamer(false)
 	expect("/dev/sdf", "xvdf")
 	expect("/dev/sdg", "xvdg")
 	expect("/dev/sdh", "xvdh")
@@ -623,9 +621,7 @@ func (*blockDeviceMappingSuite) TestBlockDeviceNamer(c *gc.C) {
 	expectErr("too many EBS volumes to attach")
 
 	// Now with numbers.
-	nextName = ec2.BlockDeviceNamer(awsec2.Instance{
-		VirtType: "paravirtual",
-	})
+	nextName = ec2.BlockDeviceNamer(true)
 	expect("/dev/sdf1", "xvdf1")
 	expect("/dev/sdf2", "xvdf2")
 	expect("/dev/sdf3", "xvdf3")


### PR DESCRIPTION
When assigning device names to block devices,
don't use number suffixes. Doing this confuses
some applications, such as Ceph. This reduces
the number of volumes we have available, so
if it is of value we can introduce an pool
configuration to enable adding suffixes.

Fixes https://bugs.launchpad.net/juju-core/+bug/1500721

(Review request: http://reviews.vapour.ws/r/2777/)