### PR TITLE
Remove now unused version import in diskmanager

### DIFF
--- a/worker/diskmanager/diskmanager_unsupported.go
+++ b/worker/diskmanager/diskmanager_unsupported.go
@@ -9,7 +9,6 @@ import (
 	"runtime"
 
 	"github.com/juju/juju/storage"
-	"github.com/juju/juju/version"
 )
 
 var blockDeviceInUse = func(storage.BlockDevice) (bool, error) {


### PR DESCRIPTION
File is only compiled on windows, but breaks the build there
as go is strict about redundant imports.

(Review request: http://reviews.vapour.ws/r/2782/)