### PR TITLE
Structured image metadata list cli and var name clarity.

### DIFF
--- a/api/imagemetadata/client.go
+++ b/api/imagemetadata/client.go
@@ -31,14 +31,14 @@ func NewClient(st base.APICallCloser) *Client {
 func (c *Client) List(
 	stream, region string,
 	series, arches []string,
-	virtualType, rootStorageType string,
+	virtType, rootStorageType string,
 ) ([]params.CloudImageMetadata, error) {
 	in := params.ImageMetadataFilter{
 		Region:          region,
 		Series:          series,
 		Arches:          arches,
 		Stream:          stream,
-		VirtualType:     virtualType,
+		VirtType:        virtType,
 		RootStorageType: rootStorageType,
 	}
 	out := params.ListCloudImageMetadataResult{}

--- a/api/imagemetadata/client_test.go
+++ b/api/imagemetadata/client_test.go
@@ -27,7 +27,7 @@ func (s *imagemetadataSuite) TestList(c *gc.C) {
 	region := "region"
 	series := "series"
 	arch := "arch"
-	virtualType := "virtual-type"
+	virtType := "virt-type"
 	rootStorageType := "root-storage-type"
 	rootStorageSize := uint64(1024)
 	source := "source"
@@ -55,7 +55,7 @@ func (s *imagemetadataSuite) TestList(c *gc.C) {
 						Region:          args.Region,
 						Series:          args.Series[0],
 						Arch:            args.Arches[0],
-						VirtualType:     args.VirtualType,
+						VirtType:        args.VirtType,
 						RootStorageType: args.RootStorageType,
 						RootStorageSize: &rootStorageSize,
 						Source:          source,
@@ -70,7 +70,7 @@ func (s *imagemetadataSuite) TestList(c *gc.C) {
 	found, err := client.List(
 		stream, region,
 		[]string{series}, []string{arch},
-		virtualType, rootStorageType,
+		virtType, rootStorageType,
 	)
 	c.Check(err, jc.ErrorIsNil)
 
@@ -82,7 +82,7 @@ func (s *imagemetadataSuite) TestList(c *gc.C) {
 			Region:          region,
 			Series:          series,
 			Arch:            arch,
-			VirtualType:     virtualType,
+			VirtType:        virtType,
 			RootStorageType: rootStorageType,
 			RootStorageSize: &rootStorageSize,
 			Source:          source,

--- a/apiserver/imagemetadata/metadata.go
+++ b/apiserver/imagemetadata/metadata.go
@@ -67,7 +67,7 @@ func (api *API) List(filter params.ImageMetadataFilter) (params.ListCloudImageMe
 		Series:          filter.Series,
 		Arches:          filter.Arches,
 		Stream:          filter.Stream,
-		VirtualType:     filter.VirtualType,
+		VirtType:        filter.VirtType,
 		RootStorageType: filter.RootStorageType,
 	})
 	if err != nil {
@@ -109,7 +109,7 @@ func parseMetadataToParams(p cloudimagemetadata.Metadata) params.CloudImageMetad
 		Region:          p.Region,
 		Series:          p.Series,
 		Arch:            p.Arch,
-		VirtualType:     p.VirtualType,
+		VirtType:        p.VirtType,
 		RootStorageType: p.RootStorageType,
 		RootStorageSize: p.RootStorageSize,
 		Source:          string(p.Source),
@@ -136,7 +136,7 @@ func parseMetadataFromParams(p params.CloudImageMetadata) cloudimagemetadata.Met
 			Region:          p.Region,
 			Series:          p.Series,
 			Arch:            p.Arch,
-			VirtualType:     p.VirtualType,
+			VirtType:        p.VirtType,
 			RootStorageType: p.RootStorageType,
 			RootStorageSize: p.RootStorageSize,
 			Source:          parseSource(p.Source),
@@ -204,7 +204,7 @@ var convertToParams = func(published []*envmetadata.ImageMetadata) params.Metada
 			Stream:          p.Stream,
 			Region:          p.RegionName,
 			Arch:            p.Arch,
-			VirtualType:     p.VirtType,
+			VirtType:        p.VirtType,
 			RootStorageType: p.Storage,
 		}
 		// Translate version (eg.14.04) to a series (eg. "trusty")

--- a/apiserver/imagemetadata/updatefrompublished_test.go
+++ b/apiserver/imagemetadata/updatefrompublished_test.go
@@ -153,7 +153,7 @@ func (s *imageMetadataUpdateSuite) TestUpdateFromPublishedImages(c *gc.C) {
 		cloudimagemetadata.Metadata{
 			cloudimagemetadata.MetadataAttributes{
 				RootStorageType: "ebs",
-				VirtualType:     "pv",
+				VirtType:        "pv",
 				Arch:            "amd64",
 				Series:          "trusty",
 				Region:          "nz-east-1",
@@ -164,7 +164,7 @@ func (s *imageMetadataUpdateSuite) TestUpdateFromPublishedImages(c *gc.C) {
 		cloudimagemetadata.Metadata{
 			cloudimagemetadata.MetadataAttributes{
 				RootStorageType: "ebs",
-				VirtualType:     "pv",
+				VirtType:        "pv",
 				Arch:            "amd64",
 				Series:          "precise",
 				Region:          "au-east-2",

--- a/apiserver/params/image_metadata.go
+++ b/apiserver/params/image_metadata.go
@@ -21,8 +21,8 @@ type ImageMetadataFilter struct {
 	// simplestreams metadata supports.
 	Stream string `json:"stream,omitempty"`
 
-	// VirtualType stores virtual type.
-	VirtualType string `json:"virtual_type,omitempty"`
+	// VirtType stores virtualisation type.
+	VirtType string `json:"virt_type,omitempty"`
 
 	// RootStorageType stores storage type.
 	RootStorageType string `json:"root-storage-type,omitempty"`
@@ -46,8 +46,8 @@ type CloudImageMetadata struct {
 	// Arch is the architecture for this cloud image, for e.g. "amd64"
 	Arch string `json:"arch"`
 
-	// VirtualType contains the type of the cloud image, for e.g. "pv", "hvm". "kvm".
-	VirtualType string `json:"virtual_type,omitempty"`
+	// VirtType contains the virtualisation type of the cloud image, for e.g. "pv", "hvm". "kvm".
+	VirtType string `json:"virt_type,omitempty"`
 
 	// RootStorageType contains type of root storage, for e.g. "ebs", "instance".
 	RootStorageType string `json:"root_storage_type,omitempty"`

--- a/cmd/jujud/bootstrap.go
+++ b/cmd/jujud/bootstrap.go
@@ -425,7 +425,7 @@ func (c *BootstrapCommand) saveCustomImageMetadata(st *state.State) error {
 				Stream:          one.Stream,
 				Region:          one.RegionName,
 				Arch:            one.Arch,
-				VirtualType:     one.VirtType,
+				VirtType:        one.VirtType,
 				RootStorageType: one.Storage,
 				Source:          "custom",
 			},

--- a/cmd/jujud/bootstrap_test.go
+++ b/cmd/jujud/bootstrap_test.go
@@ -672,7 +672,7 @@ func createImageMetadata(c *gc.C) (string, cloudimagemetadata.Metadata) {
 			Region:          "region",
 			Series:          "trusty",
 			Arch:            "amd64",
-			VirtualType:     "virtualType",
+			VirtType:        "virtType",
 			RootStorageType: "rootStore",
 			Source:          cloudimagemetadata.Custom},
 		ImageId: "imageId"}
@@ -684,7 +684,7 @@ func createImageMetadata(c *gc.C) (string, cloudimagemetadata.Metadata) {
 		content: fmt.Sprintf(indexContent, metadata.Source, metadata.Region, metadata.Arch),
 	}, {
 		path:    "streams/v1/products.json",
-		content: fmt.Sprintf(productContent, metadata.Arch, metadata.Arch, metadata.ImageId, metadata.ImageId, metadata.RootStorageType, metadata.VirtualType, metadata.Region, metadata.Source),
+		content: fmt.Sprintf(productContent, metadata.Arch, metadata.Arch, metadata.ImageId, metadata.ImageId, metadata.RootStorageType, metadata.VirtType, metadata.Region, metadata.Source),
 	}, {
 		path:    "wayward/file.txt",
 		content: "ghi",

--- a/cmd/plugins/juju-metadata/cloudimagemetadata.go
+++ b/cmd/plugins/juju-metadata/cloudimagemetadata.go
@@ -1,0 +1,41 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package main
+
+import (
+	"launchpad.net/gnuflag"
+
+	"github.com/juju/juju/api/imagemetadata"
+)
+
+type CloudImageMetadataCommandBase struct {
+	ImageMetadataCommandBase
+}
+
+// SetFlags implements Command.SetFlags.
+func (c *CloudImageMetadataCommandBase) SetFlags(f *gnuflag.FlagSet) {
+	c.ImageMetadataCommandBase.SetFlags(f)
+}
+
+// NewImageMetadataAPI returns a image metadata api for the root api endpoint
+// that the environment command returns.
+func (c *CloudImageMetadataCommandBase) NewImageMetadataAPI() (*imagemetadata.Client, error) {
+	root, err := c.NewAPIRoot()
+	if err != nil {
+		return nil, err
+	}
+	return imagemetadata.NewClient(root), nil
+}
+
+// MetadataInfo defines the serialization behaviour of image metadata information.
+type MetadataInfo struct {
+	Source          string `yaml:"source" json:"source"`
+	Series          string `yaml:"series" json:"series"`
+	Arch            string `yaml:"arch" json:"arch"`
+	Region          string `yaml:"region" json:"region"`
+	ImageId         string `yaml:"image_id" json:"image_id"`
+	Stream          string `yaml:"stream" json:"stream"`
+	VirtType        string `yaml:"virt_type" json:"virt_type"`
+	RootStorageType string `yaml:"storage_type" json:"storage_type"`
+}

--- a/cmd/plugins/juju-metadata/cloudimagemetadata.go
+++ b/cmd/plugins/juju-metadata/cloudimagemetadata.go
@@ -34,8 +34,8 @@ type MetadataInfo struct {
 	Series          string `yaml:"series" json:"series"`
 	Arch            string `yaml:"arch" json:"arch"`
 	Region          string `yaml:"region" json:"region"`
-	ImageId         string `yaml:"image_id" json:"image_id"`
+	ImageId         string `yaml:"image-id" json:"image-id"`
 	Stream          string `yaml:"stream" json:"stream"`
-	VirtType        string `yaml:"virt_type" json:"virt_type"`
-	RootStorageType string `yaml:"storage_type" json:"storage_type"`
+	VirtType        string `yaml:"virt-type,omitempty" json:"virt-type,omitempty"`
+	RootStorageType string `yaml:"storage-type,omitempty" json:"storage-type,omitempty"`
 }

--- a/cmd/plugins/juju-metadata/listformatter.go
+++ b/cmd/plugins/juju-metadata/listformatter.go
@@ -36,7 +36,7 @@ func formatMetadataTabular(metadata []MetadataInfo) ([]byte, error) {
 	print := func(values ...string) {
 		fmt.Fprintln(tw, strings.Join(values, "\t"))
 	}
-	print("SOURCE", "SERIES", "ARCH", "REGION", "IMAGE_ID", "STREAM", "VIRT_TYPE", "STORAGE_TYPE")
+	print("SOURCE", "SERIES", "ARCH", "REGION", "IMAGE-ID", "STREAM", "VIRT-TYPE", "STORAGE-TYPE")
 
 	for _, m := range metadata {
 		print(m.Source, m.Series, m.Arch, m.Region, m.ImageId, m.Stream, m.VirtType, m.RootStorageType)

--- a/cmd/plugins/juju-metadata/listformatter.go
+++ b/cmd/plugins/juju-metadata/listformatter.go
@@ -1,0 +1,47 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/juju/errors"
+)
+
+func formatMetadataListTabular(value interface{}) ([]byte, error) {
+	metadata, ok := value.([]MetadataInfo)
+	if !ok {
+		return nil, errors.Errorf("expected value of type %T, got %T", metadata, value)
+	}
+	return formatMetadataTabular(metadata)
+}
+
+// formatMetadataTabular returns a tabular summary of cloud image metadata.
+func formatMetadataTabular(metadata []MetadataInfo) ([]byte, error) {
+	var out bytes.Buffer
+
+	const (
+		// To format things into columns.
+		minwidth = 0
+		tabwidth = 1
+		padding  = 2
+		padchar  = ' '
+		flags    = 0
+	)
+	tw := tabwriter.NewWriter(&out, minwidth, tabwidth, padding, padchar, flags)
+	print := func(values ...string) {
+		fmt.Fprintln(tw, strings.Join(values, "\t"))
+	}
+	print("SOURCE", "SERIES", "ARCH", "REGION", "IMAGE_ID", "STREAM", "VIRT_TYPE", "STORAGE_TYPE")
+
+	for _, m := range metadata {
+		print(m.Source, m.Series, m.Arch, m.Region, m.ImageId, m.Stream, m.VirtType, m.RootStorageType)
+	}
+	tw.Flush()
+
+	return out.Bytes(), nil
+}

--- a/cmd/plugins/juju-metadata/listimages.go
+++ b/cmd/plugins/juju-metadata/listimages.go
@@ -79,7 +79,7 @@ func (c *ListImagesCommand) Init(args []string) (err error) {
 func (c *ListImagesCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "list-images",
-		Purpose: "lists image metadata for environment",
+		Purpose: "lists cloud image metadata used when choosing an image to start",
 		Doc:     ListCommandDoc,
 	}
 }

--- a/cmd/plugins/juju-metadata/listimages.go
+++ b/cmd/plugins/juju-metadata/listimages.go
@@ -204,10 +204,10 @@ func (m metadataInfos) Swap(i, j int) {
 }
 
 type minMetadataInfo struct {
-	ImageId         string `yaml:"image_id" json:"image_id"`
+	ImageId         string `yaml:"image-id" json:"image-id"`
 	Stream          string `yaml:"stream" json:"stream"`
-	VirtType        string `yaml:"virt_type" json:"virt_type"`
-	RootStorageType string `yaml:"storage_type" json:"storage_type"`
+	VirtType        string `yaml:"virt-type,omitempty" json:"virt-type,omitempty"`
+	RootStorageType string `yaml:"storage-type,omitempty" json:"storage-type,omitempty"`
 }
 
 // groupMetadata constructs map representation of metadata

--- a/cmd/plugins/juju-metadata/listimages.go
+++ b/cmd/plugins/juju-metadata/listimages.go
@@ -37,9 +37,9 @@ options:
 --arch
    comma separated list of architectures
 --virt-type
-   virtualisation type, e.g. pv
+   virtualisation type [provider specific], e.g. hvm
 --storage-type
-   root storage type, e.g. ebs
+   root storage type [provider specific], e.g. ebs
 `
 
 // ListImagesCommand returns stored image metadata.

--- a/cmd/plugins/juju-metadata/listimages.go
+++ b/cmd/plugins/juju-metadata/listimages.go
@@ -34,10 +34,10 @@ options:
    comma separated list of series
 --arch
    comma separated list of architectures
---virtType
+--virt-type
    virtualisation type, e.g. pv
---storageType
-   root storage type, e.g. ebs   
+--storage-type
+   root storage type, e.g. ebs
 `
 
 // ListImagesCommand returns stored image metadata.
@@ -46,12 +46,12 @@ type ListImagesCommand struct {
 
 	out cmd.Output
 
-	Stream         string
-	Region         string
-	Series         []string
-	Arches         []string
-	VirtType       string
-	RooStorageType string
+	Stream          string
+	Region          string
+	Series          []string
+	Arches          []string
+	VirtType        string
+	RootStorageType string
 }
 
 // Init implements Command.Init.
@@ -92,8 +92,8 @@ func (c *ListImagesCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.Var(cmd.NewAppendStringsValue(&c.Series), "series", "only show cloud image metadata for these series")
 	f.Var(cmd.NewAppendStringsValue(&c.Arches), "arch", "only show cloud image metadata for these architectures")
 
-	f.StringVar(&c.VirtType, "virtType", "", "image metadata virtualisation type")
-	f.StringVar(&c.RooStorageType, "storageType", "", "image metadata root storage type")
+	f.StringVar(&c.VirtType, "virt-type", "", "image metadata virtualisation type")
+	f.StringVar(&c.RootStorageType, "storage-type", "", "image metadata root storage type")
 
 	c.out.AddFlags(f, "tabular", map[string]cmd.Formatter{
 		"yaml":    cmd.FormatYaml,
@@ -110,7 +110,7 @@ func (c *ListImagesCommand) Run(ctx *cmd.Context) (err error) {
 	}
 	defer api.Close()
 
-	found, err := api.List(c.Stream, c.Region, c.Series, c.Arches, c.VirtType, c.RooStorageType)
+	found, err := api.List(c.Stream, c.Region, c.Series, c.Arches, c.VirtType, c.RootStorageType)
 	if err != nil {
 		return err
 	}
@@ -235,9 +235,6 @@ func groupMetadata(metadata []MetadataInfo) map[string]map[string]map[string]map
 			seriesMap[m.Arch] = archMap
 		}
 
-		if len(archMap[m.Region]) == 0 {
-			archMap[m.Region] = []minMetadataInfo{}
-		}
 		archMap[m.Region] = append(archMap[m.Region], minMetadataInfo{m.ImageId, m.Stream, m.VirtType, m.RootStorageType})
 	}
 

--- a/cmd/plugins/juju-metadata/listimages.go
+++ b/cmd/plugins/juju-metadata/listimages.go
@@ -17,6 +17,8 @@ const ListCommandDoc = `
 List information about image metadata stored in Juju environment.
 This list can be filtered using various filters as described below.
 
+More than one filter can be specified. Result will contain metadata that matches all filters in combination.
+
 If no filters are supplied, all stored image metadata will be listed.
 
 options:

--- a/cmd/plugins/juju-metadata/listimages.go
+++ b/cmd/plugins/juju-metadata/listimages.go
@@ -185,7 +185,10 @@ func (m metadataInfos) Len() int {
 // latest series are at the beginning of the collection.
 func (m metadataInfos) Less(i, j int) bool {
 	if m[i].Source != m[j].Source {
-		// alphabetical order
+		// Alphabetical order here is incidentally does what we want:
+		// we want "custom" metadata to precede
+		// "public" metadata.
+		// This may need to b revisited if more meatadata sources will be discovered.
 		return m[i].Source < m[j].Source
 	}
 	if m[i].Series != m[j].Series {

--- a/cmd/plugins/juju-metadata/listimages.go
+++ b/cmd/plugins/juju-metadata/listimages.go
@@ -1,0 +1,245 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package main
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/juju/cmd"
+	"launchpad.net/gnuflag"
+
+	"github.com/juju/juju/apiserver/params"
+)
+
+const ListCommandDoc = `
+List information about image metadata stored in Juju environment.
+This list can be filtered using various filters as described below.
+
+If no filters are supplied, all stored image metadata will be listed.
+
+options:
+-e, --environment (= "")
+   juju environment to operate in
+-o, --output (= "")
+   specify an output file
+--format (= tabular)
+   specify output format (json|tabular|yaml)
+--stream
+   image stream
+--region
+   cloud region
+--series
+   comma separated list of series
+--arch
+   comma separated list of architectures
+--virtType
+   virtualisation type, e.g. pv
+--storageType
+   root storage type, e.g. ebs   
+`
+
+// ListImagesCommand returns stored image metadata.
+type ListImagesCommand struct {
+	CloudImageMetadataCommandBase
+
+	out cmd.Output
+
+	Stream         string
+	Region         string
+	Series         []string
+	Arches         []string
+	VirtType       string
+	RooStorageType string
+}
+
+// Init implements Command.Init.
+func (c *ListImagesCommand) Init(args []string) (err error) {
+	if len(c.Series) > 0 {
+		result := []string{}
+		for _, one := range c.Series {
+			result = append(result, strings.Split(one, ",")...)
+		}
+		c.Series = result
+	}
+	if len(c.Arches) > 0 {
+		result := []string{}
+		for _, one := range c.Arches {
+			result = append(result, strings.Split(one, ",")...)
+		}
+		c.Arches = result
+	}
+	return nil
+}
+
+// Info implements Command.Info.
+func (c *ListImagesCommand) Info() *cmd.Info {
+	return &cmd.Info{
+		Name:    "list-images",
+		Purpose: "lists image metadata for environment",
+		Doc:     ListCommandDoc,
+	}
+}
+
+// SetFlags implements Command.SetFlags.
+func (c *ListImagesCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.CloudImageMetadataCommandBase.SetFlags(f)
+
+	f.StringVar(&c.Stream, "stream", "", "image metadata stream")
+	f.StringVar(&c.Region, "region", "", "image metadata cloud region")
+
+	f.Var(cmd.NewAppendStringsValue(&c.Series), "series", "only show cloud image metadata for these series")
+	f.Var(cmd.NewAppendStringsValue(&c.Arches), "arch", "only show cloud image metadata for these architectures")
+
+	f.StringVar(&c.VirtType, "virtType", "", "image metadata virtualisation type")
+	f.StringVar(&c.RooStorageType, "storageType", "", "image metadata root storage type")
+
+	c.out.AddFlags(f, "tabular", map[string]cmd.Formatter{
+		"yaml":    cmd.FormatYaml,
+		"json":    cmd.FormatJson,
+		"tabular": formatMetadataListTabular,
+	})
+}
+
+// Run implements Command.Run.
+func (c *ListImagesCommand) Run(ctx *cmd.Context) (err error) {
+	api, err := getImageMetadataListAPI(c)
+	if err != nil {
+		return err
+	}
+	defer api.Close()
+
+	found, err := api.List(c.Stream, c.Region, c.Series, c.Arches, c.VirtType, c.RooStorageType)
+	if err != nil {
+		return err
+	}
+	if len(found) == 0 {
+		return nil
+	}
+
+	info := convertDetailsToInfo(found)
+	var output interface{}
+	switch c.out.Name() {
+	case "yaml", "json":
+		output = groupMetadata(info)
+	default:
+		{
+			sort.Sort(metadataInfos(info))
+			output = info
+		}
+	}
+	return c.out.Write(ctx, output)
+}
+
+var getImageMetadataListAPI = (*ListImagesCommand).getImageMetadataListAPI
+
+// MetadataListAPI defines the API methods that list image metadata command uses.
+type MetadataListAPI interface {
+	Close() error
+	List(stream, region string, series, arches []string, virtType, rootStorageType string) ([]params.CloudImageMetadata, error)
+}
+
+func (c *ListImagesCommand) getImageMetadataListAPI() (MetadataListAPI, error) {
+	return c.NewImageMetadataAPI()
+}
+
+// convertDetailsToInfo converts cloud image metadata received from api to
+// structure native to CLI and sort it.
+func convertDetailsToInfo(details []params.CloudImageMetadata) []MetadataInfo {
+	if len(details) == 0 {
+		return nil
+	}
+
+	info := make([]MetadataInfo, len(details))
+	for i, one := range details {
+		info[i] = MetadataInfo{
+			Source:          one.Source,
+			Series:          one.Series,
+			Arch:            one.Arch,
+			Region:          one.Region,
+			ImageId:         one.ImageId,
+			Stream:          one.Stream,
+			VirtType:        one.VirtType,
+			RootStorageType: one.RootStorageType,
+		}
+	}
+	return info
+}
+
+// metadataInfos is a convenience type enabling to sort
+// a collection of MetadataInfo
+type metadataInfos []MetadataInfo
+
+// Implements sort.Interface
+func (m metadataInfos) Len() int {
+	return len(m)
+}
+
+// Implements sort.Interface and sort image metadata
+// by source, series, arch and region.
+// All properties are sorted in alphabetical order
+// except for series which is reversed -
+// latest series are at the beginning of the collection.
+func (m metadataInfos) Less(i, j int) bool {
+	if m[i].Source != m[j].Source {
+		// alphabetical order
+		return m[i].Source < m[j].Source
+	}
+	if m[i].Series != m[j].Series {
+		// reverse order
+		return m[i].Series > m[j].Series
+	}
+	if m[i].Arch != m[j].Arch {
+		// alphabetical order
+		return m[i].Arch < m[j].Arch
+	}
+	// alphabetical order
+	return m[i].Region < m[j].Region
+}
+
+// Implements sort.Interface
+func (m metadataInfos) Swap(i, j int) {
+	m[i], m[j] = m[j], m[i]
+}
+
+type minMetadataInfo struct {
+	ImageId         string `yaml:"image_id" json:"image_id"`
+	Stream          string `yaml:"stream" json:"stream"`
+	VirtType        string `yaml:"virt_type" json:"virt_type"`
+	RootStorageType string `yaml:"storage_type" json:"storage_type"`
+}
+
+// groupMetadata constructs map representation of metadata
+// grouping individual items by source, series, arch and region
+// to be served to Yaml and JSON output for readability.
+func groupMetadata(metadata []MetadataInfo) map[string]map[string]map[string]map[string][]minMetadataInfo {
+	result := map[string]map[string]map[string]map[string][]minMetadataInfo{}
+
+	for _, m := range metadata {
+		sourceMap, ok := result[m.Source]
+		if !ok {
+			sourceMap = map[string]map[string]map[string][]minMetadataInfo{}
+			result[m.Source] = sourceMap
+		}
+
+		seriesMap, ok := sourceMap[m.Series]
+		if !ok {
+			seriesMap = map[string]map[string][]minMetadataInfo{}
+			sourceMap[m.Series] = seriesMap
+		}
+
+		archMap, ok := seriesMap[m.Arch]
+		if !ok {
+			archMap = map[string][]minMetadataInfo{}
+			seriesMap[m.Arch] = archMap
+		}
+
+		if len(archMap[m.Region]) == 0 {
+			archMap[m.Region] = []minMetadataInfo{}
+		}
+		archMap[m.Region] = append(archMap[m.Region], minMetadataInfo{m.ImageId, m.Stream, m.VirtType, m.RootStorageType})
+	}
+
+	return result
+}

--- a/cmd/plugins/juju-metadata/listimages_test.go
+++ b/cmd/plugins/juju-metadata/listimages_test.go
@@ -1,0 +1,328 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/envcmd"
+	"github.com/juju/juju/environs/configstore"
+	"github.com/juju/juju/juju/osenv"
+	"github.com/juju/juju/testing"
+)
+
+type ListSuite struct {
+	testing.BaseSuite
+	mockAPI *mockListAPI
+}
+
+var _ = gc.Suite(&ListSuite{})
+
+func (s *ListSuite) SetUpTest(c *gc.C) {
+	s.setupBaseSuite(c)
+
+	s.mockAPI = &mockListAPI{}
+	s.mockAPI.list = func(stream, region string, ser, arch []string, virtType, rootStorageType string) ([]params.CloudImageMetadata, error) {
+		return testData, nil
+	}
+	s.PatchValue(&getImageMetadataListAPI, func(c *ListImagesCommand) (MetadataListAPI, error) {
+		return s.mockAPI, nil
+	})
+}
+
+func runList(c *gc.C, args []string) (*cmd.Context, error) {
+	return testing.RunCommand(c, envcmd.Wrap(&ListImagesCommand{}), args...)
+}
+
+func (s *ListSuite) TestListDefault(c *gc.C) {
+	// Default format is tabular
+	s.assertValidList(c, `
+SOURCE  SERIES  ARCH   REGION  IMAGE_ID  STREAM    VIRT_TYPE  STORAGE_TYPE
+custom  vivid   amd64  asia    im-21     released  kvm        ebs
+custom  vivid   amd64  europe  im-21     released  kvm        ebs
+custom  vivid   amd64  us      im-21     released  kvm        ebs
+custom  trusty  amd64  europe  im-21     released  kvm        ebs
+custom  trusty  i386   asia    im-21     released  kvm        ebs
+custom  trusty  i386   europe  im-21     released  kvm        ebs
+public  vivid   amd64  europe  im-21     released  kvm        ebs
+public  trusty  i386   europe  im-21     released  kvm        ebs
+public  trusty  i386   europe  im-42     devel     kvm        ebs
+
+`[1:], "")
+}
+
+func (s *ListSuite) TestListYAML(c *gc.C) {
+	s.assertValidList(c, `
+custom:
+  trusty:
+    amd64:
+      europe:
+      - image_id: im-21
+        stream: released
+        virt_type: kvm
+        storage_type: ebs
+    i386:
+      asia:
+      - image_id: im-21
+        stream: released
+        virt_type: kvm
+        storage_type: ebs
+      europe:
+      - image_id: im-21
+        stream: released
+        virt_type: kvm
+        storage_type: ebs
+  vivid:
+    amd64:
+      asia:
+      - image_id: im-21
+        stream: released
+        virt_type: kvm
+        storage_type: ebs
+      europe:
+      - image_id: im-21
+        stream: released
+        virt_type: kvm
+        storage_type: ebs
+      us:
+      - image_id: im-21
+        stream: released
+        virt_type: kvm
+        storage_type: ebs
+public:
+  trusty:
+    i386:
+      europe:
+      - image_id: im-21
+        stream: released
+        virt_type: kvm
+        storage_type: ebs
+      - image_id: im-42
+        stream: devel
+        virt_type: kvm
+        storage_type: ebs
+  vivid:
+    amd64:
+      europe:
+      - image_id: im-21
+        stream: released
+        virt_type: kvm
+        storage_type: ebs
+`[1:], "", "--format", "yaml")
+}
+
+func (s *ListSuite) TestListMetadataFailed(c *gc.C) {
+	msg := "failed"
+	s.mockAPI.list = func(stream, region string, ser, arch []string, virtType, rootStorageType string) ([]params.CloudImageMetadata, error) {
+		return nil, errors.New(msg)
+	}
+
+	_, err := runList(c, nil)
+	c.Assert(err, gc.ErrorMatches, fmt.Sprintf(".*%v.*", msg))
+}
+
+func (s *ListSuite) TestListMetadataFilterStream(c *gc.C) {
+	msg := "stream"
+	s.mockAPI.list = func(stream, region string, ser, arch []string, virtType, rootStorageType string) ([]params.CloudImageMetadata, error) {
+		c.Assert(stream, gc.DeepEquals, msg)
+		return nil, nil
+	}
+	s.assertValidList(c, "", "", "--stream", msg)
+}
+
+func (s *ListSuite) TestListMetadataFilterRegion(c *gc.C) {
+	msg := "region"
+	s.mockAPI.list = func(stream, region string, ser, arch []string, virtType, rootStorageType string) ([]params.CloudImageMetadata, error) {
+		c.Assert(region, gc.DeepEquals, msg)
+		return nil, nil
+	}
+	s.assertValidList(c, "", "", "--region", msg)
+}
+
+func (s *ListSuite) TestListMetadataFilterSeries(c *gc.C) {
+	all := []string{"series1", "series2"}
+	msg := strings.Join(all, ",")
+	s.mockAPI.list = func(stream, region string, ser, arch []string, virtType, rootStorageType string) ([]params.CloudImageMetadata, error) {
+		c.Assert(ser, gc.DeepEquals, all)
+		return nil, nil
+	}
+	s.assertValidList(c, "", "", "--series", msg)
+}
+
+func (s *ListSuite) TestListMetadataFilterArches(c *gc.C) {
+	all := []string{"arch1", "barch2"}
+	msg := strings.Join(all, ",")
+	s.mockAPI.list = func(stream, region string, ser, arch []string, virtType, rootStorageType string) ([]params.CloudImageMetadata, error) {
+		c.Assert(arch, gc.DeepEquals, all)
+		return nil, nil
+	}
+	s.assertValidList(c, "", "", "--arch", msg)
+}
+
+func (s *ListSuite) TestListMetadataFilterVirtType(c *gc.C) {
+	msg := "virtType"
+	s.mockAPI.list = func(stream, region string, ser, arch []string, virtType, rootStorageType string) ([]params.CloudImageMetadata, error) {
+		c.Assert(virtType, gc.DeepEquals, msg)
+		return nil, nil
+	}
+	s.assertValidList(c, "", "", "--virtType", msg)
+}
+
+func (s *ListSuite) TestListMetadataFilterStorageType(c *gc.C) {
+	msg := "storagetype"
+	s.mockAPI.list = func(stream, region string, ser, arch []string, virtType, rootStorageType string) ([]params.CloudImageMetadata, error) {
+		c.Assert(rootStorageType, gc.DeepEquals, msg)
+		return nil, nil
+	}
+	s.assertValidList(c, "", "", "--storageType", msg)
+}
+
+func (s *ListSuite) assertValidList(c *gc.C, expectedValid, expectedErr string, args ...string) {
+	context, err := runList(c, args)
+	c.Assert(err, jc.ErrorIsNil)
+
+	obtainedErr := testing.Stderr(context)
+	c.Assert(obtainedErr, gc.Matches, expectedErr)
+
+	obtainedValid := testing.Stdout(context)
+	c.Assert(obtainedValid, gc.Matches, expectedValid)
+}
+
+type mockListAPI struct {
+	list func(stream, region string, ser, arch []string, virtType, rootStorageType string) ([]params.CloudImageMetadata, error)
+}
+
+func (s mockListAPI) Close() error {
+	return nil
+}
+
+func (s mockListAPI) List(stream, region string, ser, arch []string, virtType, rootStorageType string) ([]params.CloudImageMetadata, error) {
+	return s.list(stream, region, ser, arch, virtType, rootStorageType)
+}
+
+func (s *ListSuite) setupBaseSuite(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+
+	memstore := configstore.NewMem()
+	s.PatchValue(&configstore.Default, func() (configstore.Storage, error) {
+		return memstore, nil
+	})
+	os.Setenv(osenv.JujuEnvEnvKey, "testing")
+	info := memstore.CreateInfo("testing")
+	info.SetBootstrapConfig(map[string]interface{}{"random": "extra data"})
+	info.SetAPIEndpoint(configstore.APIEndpoint{
+		Addresses:   []string{"127.0.0.1:12345"},
+		Hostnames:   []string{"localhost:12345"},
+		CACert:      testing.CACert,
+		EnvironUUID: "env-uuid",
+	})
+	info.SetAPICredentials(configstore.APICredentials{
+		User:     "user-test",
+		Password: "password",
+	})
+	err := info.Write()
+	c.Assert(err, jc.ErrorIsNil)
+
+}
+
+var testData = []params.CloudImageMetadata{
+	params.CloudImageMetadata{
+		Source:          "custom",
+		Series:          "vivid",
+		Arch:            "amd64",
+		Region:          "asia",
+		ImageId:         "im-21",
+		Stream:          "released",
+		VirtType:        "kvm",
+		RootStorageType: "ebs",
+	},
+	params.CloudImageMetadata{
+		Source:          "custom",
+		Series:          "vivid",
+		Arch:            "amd64",
+		Region:          "us",
+		ImageId:         "im-21",
+		Stream:          "released",
+		VirtType:        "kvm",
+		RootStorageType: "ebs",
+	},
+	params.CloudImageMetadata{
+		Source:          "custom",
+		Series:          "vivid",
+		Arch:            "amd64",
+		Region:          "europe",
+		ImageId:         "im-21",
+		Stream:          "released",
+		VirtType:        "kvm",
+		RootStorageType: "ebs",
+	},
+	params.CloudImageMetadata{
+		Source:          "public",
+		Series:          "vivid",
+		Arch:            "amd64",
+		Region:          "europe",
+		ImageId:         "im-21",
+		Stream:          "released",
+		VirtType:        "kvm",
+		RootStorageType: "ebs",
+	},
+	params.CloudImageMetadata{
+		Source:          "custom",
+		Series:          "trusty",
+		Arch:            "amd64",
+		Region:          "europe",
+		ImageId:         "im-21",
+		Stream:          "released",
+		VirtType:        "kvm",
+		RootStorageType: "ebs",
+	},
+	params.CloudImageMetadata{
+		Source:          "custom",
+		Series:          "trusty",
+		Arch:            "i386",
+		Region:          "europe",
+		ImageId:         "im-21",
+		Stream:          "released",
+		VirtType:        "kvm",
+		RootStorageType: "ebs",
+	},
+	params.CloudImageMetadata{
+		Source:          "custom",
+		Series:          "trusty",
+		Arch:            "i386",
+		Region:          "asia",
+		ImageId:         "im-21",
+		Stream:          "released",
+		VirtType:        "kvm",
+		RootStorageType: "ebs",
+	},
+	params.CloudImageMetadata{
+		Source:          "public",
+		Series:          "trusty",
+		Arch:            "i386",
+		Region:          "europe",
+		ImageId:         "im-21",
+		Stream:          "released",
+		VirtType:        "kvm",
+		RootStorageType: "ebs",
+	},
+	params.CloudImageMetadata{
+		Source:          "public",
+		Series:          "trusty",
+		Arch:            "i386",
+		Region:          "europe",
+		ImageId:         "im-42",
+		Stream:          "devel",
+		VirtType:        "kvm",
+		RootStorageType: "ebs",
+	},
+}

--- a/cmd/plugins/juju-metadata/listimages_test.go
+++ b/cmd/plugins/juju-metadata/listimages_test.go
@@ -174,7 +174,7 @@ func (s *ListSuite) TestListMetadataFilterVirtType(c *gc.C) {
 		c.Assert(virtType, gc.DeepEquals, msg)
 		return nil, nil
 	}
-	s.assertValidList(c, "", "", "--virtType", msg)
+	s.assertValidList(c, "", "", "--virt-type", msg)
 }
 
 func (s *ListSuite) TestListMetadataFilterStorageType(c *gc.C) {
@@ -183,7 +183,7 @@ func (s *ListSuite) TestListMetadataFilterStorageType(c *gc.C) {
 		c.Assert(rootStorageType, gc.DeepEquals, msg)
 		return nil, nil
 	}
-	s.assertValidList(c, "", "", "--storageType", msg)
+	s.assertValidList(c, "", "", "--storage-type", msg)
 }
 
 func (s *ListSuite) assertValidList(c *gc.C, expectedValid, expectedErr string, args ...string) {

--- a/cmd/plugins/juju-metadata/listimages_test.go
+++ b/cmd/plugins/juju-metadata/listimages_test.go
@@ -78,7 +78,7 @@ func runList(c *gc.C, args []string) (*cmd.Context, error) {
 func (s *ListSuite) TestListDefault(c *gc.C) {
 	// Default format is tabular
 	s.assertValidList(c, `
-SOURCE  SERIES  ARCH   REGION  IMAGE_ID  STREAM    VIRT_TYPE  STORAGE_TYPE
+SOURCE  SERIES  ARCH   REGION  IMAGE-ID  STREAM    VIRT-TYPE  STORAGE-TYPE
 custom  vivid   amd64  asia    im-21     released  kvm        ebs
 custom  vivid   amd64  europe  im-21     released  kvm        ebs
 custom  vivid   amd64  us      im-21     released  kvm        ebs
@@ -227,6 +227,32 @@ func (s *ListSuite) TestListMetadataFilterStorageType(c *gc.C) {
 		return nil, nil
 	}
 	s.assertValidList(c, "", "", "--storage-type", msg)
+}
+
+func (s *ListSuite) TestListMetadataNoFilter(c *gc.C) {
+	s.mockAPI.list = func(stream, region string, ser, arch []string, virtType, rootStorageType string) ([]params.CloudImageMetadata, error) {
+		c.Assert(rootStorageType, gc.DeepEquals, "")
+		c.Assert(virtType, gc.DeepEquals, "")
+		c.Assert(region, gc.DeepEquals, "")
+		c.Assert(stream, gc.DeepEquals, "")
+		c.Assert(ser, gc.IsNil)
+		c.Assert(arch, gc.IsNil)
+		return nil, nil
+	}
+	s.assertValidList(c, "", "")
+}
+
+func (s *ListSuite) TestListMetadataFewFilters(c *gc.C) {
+	streamValue := "streamValue"
+	regionValue := "regionValue"
+	typeValue := "typeValue"
+	s.mockAPI.list = func(stream, region string, ser, arch []string, virtType, rootStorageType string) ([]params.CloudImageMetadata, error) {
+		c.Assert(stream, gc.DeepEquals, streamValue)
+		c.Assert(region, gc.DeepEquals, regionValue)
+		c.Assert(virtType, gc.DeepEquals, typeValue)
+		return nil, nil
+	}
+	s.assertValidList(c, "", "", "--stream", streamValue, "--region", regionValue, "--virt-type", typeValue)
 }
 
 func (s *ListSuite) assertValidList(c *gc.C, expectedValid, expectedErr string, args ...string) {

--- a/cmd/plugins/juju-metadata/listimages_test.go
+++ b/cmd/plugins/juju-metadata/listimages_test.go
@@ -88,6 +88,9 @@ custom  trusty  i386   europe  im-21     released  kvm        ebs
 public  vivid   amd64  europe  im-21     released  kvm        ebs
 public  trusty  i386   europe  im-21     released  kvm        ebs
 public  trusty  i386   europe  im-42     devel     kvm        ebs
+public  trusty  i386   europe  im-42     devel                ebs
+public  trusty  i386   europe  im-42     devel     kvm        
+public  trusty  i386   europe  im-42     devel                
 
 `[1:], "")
 }
@@ -98,57 +101,65 @@ custom:
   trusty:
     amd64:
       europe:
-      - image_id: im-21
+      - image-id: im-21
         stream: released
-        virt_type: kvm
-        storage_type: ebs
+        virt-type: kvm
+        storage-type: ebs
     i386:
       asia:
-      - image_id: im-21
+      - image-id: im-21
         stream: released
-        virt_type: kvm
-        storage_type: ebs
+        virt-type: kvm
+        storage-type: ebs
       europe:
-      - image_id: im-21
+      - image-id: im-21
         stream: released
-        virt_type: kvm
-        storage_type: ebs
+        virt-type: kvm
+        storage-type: ebs
   vivid:
     amd64:
       asia:
-      - image_id: im-21
+      - image-id: im-21
         stream: released
-        virt_type: kvm
-        storage_type: ebs
+        virt-type: kvm
+        storage-type: ebs
       europe:
-      - image_id: im-21
+      - image-id: im-21
         stream: released
-        virt_type: kvm
-        storage_type: ebs
+        virt-type: kvm
+        storage-type: ebs
       us:
-      - image_id: im-21
+      - image-id: im-21
         stream: released
-        virt_type: kvm
-        storage_type: ebs
+        virt-type: kvm
+        storage-type: ebs
 public:
   trusty:
     i386:
       europe:
-      - image_id: im-21
+      - image-id: im-21
         stream: released
-        virt_type: kvm
-        storage_type: ebs
-      - image_id: im-42
+        virt-type: kvm
+        storage-type: ebs
+      - image-id: im-42
         stream: devel
-        virt_type: kvm
-        storage_type: ebs
+        virt-type: kvm
+        storage-type: ebs
+      - image-id: im-42
+        stream: devel
+        storage-type: ebs
+      - image-id: im-42
+        stream: devel
+        virt-type: kvm
+      - image-id: im-42
+        stream: devel
   vivid:
     amd64:
       europe:
-      - image_id: im-21
+      - image-id: im-21
         stream: released
-        virt_type: kvm
-        storage_type: ebs
+        virt-type: kvm
+        storage-type: ebs
 `[1:], "", "--format", "yaml")
 }
 
@@ -331,5 +342,31 @@ var testData = []params.CloudImageMetadata{
 		Stream:          "devel",
 		VirtType:        "kvm",
 		RootStorageType: "ebs",
+	},
+	params.CloudImageMetadata{
+		Source:          "public",
+		Series:          "trusty",
+		Arch:            "i386",
+		Region:          "europe",
+		ImageId:         "im-42",
+		Stream:          "devel",
+		RootStorageType: "ebs",
+	},
+	params.CloudImageMetadata{
+		Source:   "public",
+		Series:   "trusty",
+		Arch:     "i386",
+		Region:   "europe",
+		ImageId:  "im-42",
+		Stream:   "devel",
+		VirtType: "kvm",
+	},
+	params.CloudImageMetadata{
+		Source:  "public",
+		Series:  "trusty",
+		Arch:    "i386",
+		Region:  "europe",
+		ImageId: "im-42",
+		Stream:  "devel",
 	},
 }

--- a/cmd/plugins/juju-metadata/metadata.go
+++ b/cmd/plugins/juju-metadata/metadata.go
@@ -47,6 +47,7 @@ func Main(args []string) {
 	metadatacmd.Register(envcmd.Wrap(&ToolsMetadataCommand{}))
 	metadatacmd.Register(envcmd.Wrap(&ValidateToolsMetadataCommand{}))
 	metadatacmd.Register(&SignMetadataCommand{})
+	metadatacmd.Register(envcmd.Wrap(&ListImagesCommand{}))
 
 	os.Exit(cmd.Main(metadatacmd, ctx, args[1:]))
 }

--- a/cmd/plugins/juju-metadata/metadataplugin_test.go
+++ b/cmd/plugins/juju-metadata/metadataplugin_test.go
@@ -31,6 +31,7 @@ var metadataCommandNames = []string{
 	"generate-image",
 	"generate-tools",
 	"help",
+	"list-images",
 	"sign",
 	"validate-images",
 	"validate-tools",
@@ -93,4 +94,8 @@ func (s *MetadataSuite) TestHelpValidateTools(c *gc.C) {
 
 func (s *MetadataSuite) TestHelpGenerateImage(c *gc.C) {
 	s.assertHelpOutput(c, "generate-image")
+}
+
+func (s *MetadataSuite) TestHelpListImage(c *gc.C) {
+	s.assertHelpOutput(c, "list-images")
 }

--- a/featuretests/cloudimagemetadata_test.go
+++ b/featuretests/cloudimagemetadata_test.go
@@ -51,7 +51,7 @@ func (s *cloudImageMetadataSuite) TestSaveAndFindMetadata(c *gc.C) {
 		Region:          "region",
 		Series:          "series",
 		Arch:            "arch",
-		VirtualType:     "virtType",
+		VirtType:        "virtType",
 		RootStorageType: "rootStorageType",
 		ImageId:         "1",
 	}

--- a/state/cloudimagemetadata/functions_test.go
+++ b/state/cloudimagemetadata/functions_test.go
@@ -48,10 +48,10 @@ func (s *funcMetadataSuite) TestSearchCriteriaWithArch(c *gc.C) {
 		bson.D{{"arch", bson.D{{"$in", []string{"arch-value"}}}}})
 }
 
-func (s *funcMetadataSuite) TestSearchCriteriaWithVirtualType(c *gc.C) {
+func (s *funcMetadataSuite) TestSearchCriteriaWithVirtType(c *gc.C) {
 	s.assertSearchCriteriaBuilt(c,
-		cloudimagemetadata.MetadataFilter{VirtualType: "vtype-value"},
-		bson.D{{"virtual_type", "vtype-value"}})
+		cloudimagemetadata.MetadataFilter{VirtType: "vtype-value"},
+		bson.D{{"virt_type", "vtype-value"}})
 }
 
 func (s *funcMetadataSuite) TestSearchCriteriaWithStorageType(c *gc.C) {
@@ -69,7 +69,7 @@ func (s *funcMetadataSuite) TestSearchCriteriaAll(c *gc.C) {
 			Stream:          "stream-value",
 			Region:          "region-value",
 			Arches:          []string{"arch-value", "arch-value-two"},
-			VirtualType:     "vtype-value",
+			VirtType:        "vtype-value",
 		},
 		// This is in order in which it is built.
 		bson.D{
@@ -77,7 +77,7 @@ func (s *funcMetadataSuite) TestSearchCriteriaAll(c *gc.C) {
 			{"region", "region-value"},
 			{"series", bson.D{{"$in", []string{"series-value", "series-value-two"}}}},
 			{"arch", bson.D{{"$in", []string{"arch-value", "arch-value-two"}}}},
-			{"virtual_type", "vtype-value"},
+			{"virt_type", "vtype-value"},
 			{"root_storage_type", "rootstorage-value"},
 		})
 }

--- a/state/cloudimagemetadata/image.go
+++ b/state/cloudimagemetadata/image.go
@@ -114,8 +114,8 @@ type imagesMetadataDoc struct {
 	// Arch is the architecture for this cloud image, for e.g. "amd64"
 	Arch string `bson:"arch"`
 
-	// VirtualType contains the type of the cloud image, for e.g. "pv", "hvm". "kvm".
-	VirtualType string `bson:"virtual_type,omitempty"`
+	// VirtType contains virtualisation type of the cloud image, for e.g. "pv", "hvm". "kvm".
+	VirtType string `bson:"virt_type,omitempty"`
 
 	// RootStorageType contains type of root storage, for e.g. "ebs", "instance".
 	RootStorageType string `bson:"root_storage_type,omitempty"`
@@ -150,7 +150,7 @@ func (m imagesMetadataDoc) metadata() Metadata {
 			Series:          m.Series,
 			Arch:            m.Arch,
 			RootStorageType: m.RootStorageType,
-			VirtualType:     m.VirtualType,
+			VirtType:        m.VirtType,
 		},
 		m.ImageId,
 	}
@@ -168,7 +168,7 @@ func (s *storage) mongoDoc(m Metadata) imagesMetadataDoc {
 		Region:          m.Region,
 		Series:          m.Series,
 		Arch:            m.Arch,
-		VirtualType:     m.VirtualType,
+		VirtType:        m.VirtType,
 		RootStorageType: m.RootStorageType,
 		ImageId:         m.ImageId,
 		DateCreated:     time.Now().UnixNano(),
@@ -186,7 +186,7 @@ func buildKey(m Metadata) string {
 		m.Region,
 		m.Series,
 		m.Arch,
-		m.VirtualType,
+		m.VirtType,
 		m.RootStorageType,
 		m.Source)
 }
@@ -233,8 +233,8 @@ func buildSearchClauses(criteria MetadataFilter) bson.D {
 		all = append(all, bson.DocElem{"arch", bson.D{{"$in", criteria.Arches}}})
 	}
 
-	if criteria.VirtualType != "" {
-		all = append(all, bson.DocElem{"virtual_type", criteria.VirtualType})
+	if criteria.VirtType != "" {
+		all = append(all, bson.DocElem{"virt_type", criteria.VirtType})
 	}
 
 	if criteria.RootStorageType != "" {
@@ -265,8 +265,8 @@ type MetadataFilter struct {
 	// simplestreams metadata supports.
 	Stream string `json:"stream,omitempty"`
 
-	// VirtualType stores virtual type.
-	VirtualType string `json:"virtual_type,omitempty"`
+	// VirtType stores virtualisation type.
+	VirtType string `json:"virt_type,omitempty"`
 
 	// RootStorageType stores storage type.
 	RootStorageType string `json:"root-storage-type,omitempty"`

--- a/state/cloudimagemetadata/image_test.go
+++ b/state/cloudimagemetadata/image_test.go
@@ -45,7 +45,7 @@ func (s *cloudImageMetadataSuite) TestSaveMetadata(c *gc.C) {
 		Region:          "region-test",
 		Series:          "series",
 		Arch:            "arch",
-		VirtualType:     "virtType-test",
+		VirtType:        "virtType-test",
 		RootStorageType: "rootStorageType-test"}
 
 	added := cloudimagemetadata.Metadata{attrs, "1"}
@@ -68,7 +68,7 @@ func (s *cloudImageMetadataSuite) TestFindMetadataNotFound(c *gc.C) {
 		Region:          "region",
 		Series:          "series",
 		Arch:            "arch",
-		VirtualType:     "virtualType",
+		VirtType:        "virtType",
 		RootStorageType: "rootStorageType"}
 	m := cloudimagemetadata.Metadata{attrs, "1"}
 	s.assertRecordMetadata(c, m)
@@ -87,7 +87,7 @@ func buildAttributesFilter(attrs cloudimagemetadata.MetadataAttributes) cloudima
 	filter := cloudimagemetadata.MetadataFilter{
 		Stream:          attrs.Stream,
 		Region:          attrs.Region,
-		VirtualType:     attrs.VirtualType,
+		VirtType:        attrs.VirtType,
 		RootStorageType: attrs.RootStorageType}
 	if attrs.Series != "" {
 		filter.Series = []string{attrs.Series}
@@ -104,7 +104,7 @@ func (s *cloudImageMetadataSuite) TestFindMetadata(c *gc.C) {
 		Region:          "region",
 		Series:          "series",
 		Arch:            "arch",
-		VirtualType:     "virtualType",
+		VirtType:        "virtType",
 		RootStorageType: "rootStorageType"}
 
 	m := cloudimagemetadata.Metadata{attrs, "1"}

--- a/state/cloudimagemetadata/interface.go
+++ b/state/cloudimagemetadata/interface.go
@@ -24,8 +24,8 @@ type MetadataAttributes struct {
 	// Arch is the architecture for this cloud image, for e.g. "amd64"
 	Arch string
 
-	// VirtualType contains the type of the cloud image, for e.g. "pv", "hvm". "kvm".
-	VirtualType string
+	// VirtType contains virtualisation type of the cloud image, for e.g. "pv", "hvm". "kvm".
+	VirtType string
 
 	// RootStorageType contains type of root storage, for e.g. "ebs", "instance".
 	RootStorageType string


### PR DESCRIPTION
This is list CLI for image metadata stored in state. For now, we are adding it to the juju-metadata plugin so that the users can run 
`juju metadata list-images` 
with or without filters to peruse what images are known to Juju environment.

VirtualType is misnamed - we really mean "virtualisation" type. However, this name is too long.. Abbreviating to VirtType :D

(Review request: http://reviews.vapour.ws/r/2783/)