### PR TITLE
provider/ec2: don't use numbers in device names

### DIFF
--- a/provider/ec2/ebs.go
+++ b/provider/ec2/ebs.go
@@ -558,16 +558,16 @@ func (v *ebsVolumeSource) AttachVolumes(attachParams []storage.VolumeAttachmentP
 	results := make([]storage.AttachVolumesResult, len(attachParams))
 	for i, params := range attachParams {
 		instId := string(params.InstanceId)
-		if err := instances.update(v.ec2, instId); err != nil {
-			results[i].Error = err
-			continue
-		}
-		inst, err := instances.get(instId)
-		if err != nil {
-			results[i].Error = err
-			continue
-		}
-		nextDeviceName := blockDeviceNamer(inst)
+		// By default we should allocate device names without the
+		// trailing number. Block devices with a trailing number are
+		// not liked by some applications, e.g. Ceph, which want full
+		// disks.
+		//
+		// TODO(axw) introduce a configuration option if and when
+		// someone asks for it to enable use of numbers. This option
+		// must error if used with an "hvm" instance type.
+		const numbers = false
+		nextDeviceName := blockDeviceNamer(numbers)
 		_, deviceName, err := v.attachOneVolume(nextDeviceName, params.VolumeId, instId)
 		if err != nil {
 			results[i].Error = err
@@ -771,7 +771,7 @@ var errTooManyVolumes = errors.New("too many EBS volumes to attach")
 // will appear on the machine.
 //
 // See http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/block-device-mapping-concepts.html
-func blockDeviceNamer(inst ec2.Instance) func() (requestName, actualName string, err error) {
+func blockDeviceNamer(numbers bool) func() (requestName, actualName string, err error) {
 	const (
 		// deviceLetterMin is the first letter to use for EBS block device names.
 		deviceLetterMin = 'f'
@@ -782,7 +782,6 @@ func blockDeviceNamer(inst ec2.Instance) func() (requestName, actualName string,
 	)
 	var n int
 	letterRepeats := 1
-	numbers := inst.VirtType == "paravirtual"
 	if numbers {
 		letterRepeats = deviceNumMax
 	}

--- a/provider/ec2/ebs_test.go
+++ b/provider/ec2/ebs_test.go
@@ -606,9 +606,7 @@ func (*blockDeviceMappingSuite) TestBlockDeviceNamer(c *gc.C) {
 	}
 
 	// First without numbers.
-	nextName = ec2.BlockDeviceNamer(awsec2.Instance{
-		VirtType: "hvm",
-	})
+	nextName = ec2.BlockDeviceNamer(false)
 	expect("/dev/sdf", "xvdf")
 	expect("/dev/sdg", "xvdg")
 	expect("/dev/sdh", "xvdh")
@@ -623,9 +621,7 @@ func (*blockDeviceMappingSuite) TestBlockDeviceNamer(c *gc.C) {
 	expectErr("too many EBS volumes to attach")
 
 	// Now with numbers.
-	nextName = ec2.BlockDeviceNamer(awsec2.Instance{
-		VirtType: "paravirtual",
-	})
+	nextName = ec2.BlockDeviceNamer(true)
 	expect("/dev/sdf1", "xvdf1")
 	expect("/dev/sdf2", "xvdf2")
 	expect("/dev/sdf3", "xvdf3")


### PR DESCRIPTION
Back port.

When assigning device names to block devices,
don't use number suffixes. Doing this confuses
some applications, such as Ceph. This reduces
the number of volumes we have available, so
if it is of value we can introduce an pool
configuration to enable adding suffixes.

Fixes https://bugs.launchpad.net/juju-core/+bug/1500721

(Review request: http://reviews.vapour.ws/r/2787/)