### PR TITLE
Structured metadata cli: add-image.

### DIFF
--- a/cmd/plugins/juju-metadata/addimage.go
+++ b/cmd/plugins/juju-metadata/addimage.go
@@ -14,7 +14,7 @@ import (
 )
 
 const AddImageCommandDoc = `
-Add image metadata to Juju environment. 
+Add image metadata to Juju environment.
 
 Image metadata properties vary between providers. Consequently, some properties
 are optional for this command but they may still be needed by your provider.
@@ -27,11 +27,11 @@ options:
 --region
    cloud region
 --series
-   comma separated list of series
+   image series
 --arch
-   comma separated list of architectures
+   image architectures
 --virt-type
-   virtualisation type [provider specific], e.g. pv
+   virtualisation type [provider specific], e.g. hmv
 --storage-type
    root storage type [provider specific], e.g. ebs
 --storage-size
@@ -58,9 +58,6 @@ type AddImageMetadataCommand struct {
 func (c *AddImageMetadataCommand) Init(args []string) (err error) {
 	// Check all mandatory properties supplied.
 	if err := checkArgumentSet(c.ImageId, "image id"); err != nil {
-		return err
-	}
-	if err := checkArgumentSet(c.Region, "region"); err != nil {
 		return err
 	}
 	if err := checkArgumentSet(c.Series, "series"); err != nil {

--- a/cmd/plugins/juju-metadata/addimage.go
+++ b/cmd/plugins/juju-metadata/addimage.go
@@ -1,0 +1,159 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+	"launchpad.net/gnuflag"
+
+	"github.com/juju/juju/apiserver/params"
+)
+
+const AddImageCommandDoc = `
+Add image metadata to Juju environment. 
+
+Image metadata properties vary between providers. Consequently, some properties
+are optional for this command but they may still be needed by your provider.
+
+options:
+-e, --environment (= "")
+   juju environment to operate in
+--image-id
+   image identifier
+--region
+   cloud region
+--series
+   comma separated list of series
+--arch
+   comma separated list of architectures
+--virt-type
+   virtualisation type [provider specific], e.g. pv
+--storage-type
+   root storage type [provider specific], e.g. ebs
+--storage-size
+   root storage size [provider specific]
+--stream
+   image stream [optional]
+`
+
+// AddImageMetadataCommand stores image metadata in Juju environment.
+type AddImageMetadataCommand struct {
+	CloudImageMetadataCommandBase
+
+	ImageId         string
+	Region          string
+	Series          string
+	Arch            string
+	VirtType        string
+	RootStorageType string
+	RootStorageSize uint64
+	Stream          string
+}
+
+// Init implements Command.Init.
+func (c *AddImageMetadataCommand) Init(args []string) (err error) {
+	// Check all mandatory properties supplied.
+	if err := checkArgumentSet(c.ImageId, "image id"); err != nil {
+		return err
+	}
+	if err := checkArgumentSet(c.Region, "region"); err != nil {
+		return err
+	}
+	if err := checkArgumentSet(c.Series, "series"); err != nil {
+		return err
+	}
+	if err := checkArgumentSet(c.Arch, "architecture"); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Info implements Command.Info.
+func (c *AddImageMetadataCommand) Info() *cmd.Info {
+	return &cmd.Info{
+		Name:    "add-image",
+		Purpose: "adds image metadata to environment",
+		Doc:     AddImageCommandDoc,
+	}
+}
+
+// SetFlags implements Command.SetFlags.
+func (c *AddImageMetadataCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.CloudImageMetadataCommandBase.SetFlags(f)
+
+	f.StringVar(&c.ImageId, "image-id", "", "metadata image id")
+	f.StringVar(&c.Region, "region", "", "image cloud region")
+	f.StringVar(&c.Series, "series", "", "image series")
+	f.StringVar(&c.Arch, "arch", "", "image architecture")
+	f.StringVar(&c.VirtType, "virt-type", "", "image metadata virtualisation type")
+	f.StringVar(&c.RootStorageType, "storage-type", "", "image metadata root storage type")
+
+	f.Uint64Var(&c.RootStorageSize, "storage-size", 0, "image metadata root storage size")
+	f.StringVar(&c.Stream, "stream", "", "image metadata stream")
+}
+
+// Run implements Command.Run.
+func (c *AddImageMetadataCommand) Run(ctx *cmd.Context) (err error) {
+	api, err := getImageMetadataAddAPI(c)
+	if err != nil {
+		return err
+	}
+	defer api.Close()
+
+	m := c.constructMetadataParam()
+	found, err := api.Save([]params.CloudImageMetadata{m})
+	if err != nil {
+		return err
+	}
+	if len(found) == 0 {
+		return nil
+	}
+	if len(found) > 1 {
+		return errors.New(fmt.Sprintf("expected one result, got %d", len(found)))
+	}
+	if found[0].Error != nil {
+		return errors.New(found[0].Error.GoString())
+	}
+	return nil
+}
+
+// MetadataAddAPI defines the API methods that add image metadata command uses.
+type MetadataAddAPI interface {
+	Close() error
+	Save(metadata []params.CloudImageMetadata) ([]params.ErrorResult, error)
+}
+
+var getImageMetadataAddAPI = (*AddImageMetadataCommand).getImageMetadataAddAPI
+
+func (c *AddImageMetadataCommand) getImageMetadataAddAPI() (MetadataAddAPI, error) {
+	return c.NewImageMetadataAPI()
+}
+
+func checkArgumentSet(arg, name string) (err error) {
+	if arg == "" {
+		return errors.New(fmt.Sprintf("%v must be supplied when adding an image metadata", name))
+	}
+	return nil
+}
+
+// constructMetadataParam returns cloud image metadata as a param.
+func (c *AddImageMetadataCommand) constructMetadataParam() params.CloudImageMetadata {
+	info := params.CloudImageMetadata{
+		ImageId:         c.ImageId,
+		Region:          c.Region,
+		Series:          c.Series,
+		Arch:            c.Arch,
+		VirtType:        c.VirtType,
+		RootStorageType: c.RootStorageType,
+		Stream:          c.Stream,
+		Source:          "custom",
+	}
+	if c.RootStorageSize != 0 {
+		info.RootStorageSize = &c.RootStorageSize
+	}
+	return info
+}

--- a/cmd/plugins/juju-metadata/addimage.go
+++ b/cmd/plugins/juju-metadata/addimage.go
@@ -26,9 +26,9 @@ options:
    image identifier
 --region
    cloud region
---series
+--series (= "trusty")
    image series
---arch
+--arch (= "amd64")
    image architectures
 --virt-type
    virtualisation type [provider specific], e.g. hmv
@@ -36,8 +36,8 @@ options:
    root storage type [provider specific], e.g. ebs
 --storage-size
    root storage size [provider specific]
---stream
-   image stream [optional]
+--stream (= "released")
+   image stream
 `
 
 // AddImageMetadataCommand stores image metadata in Juju environment.
@@ -56,14 +56,7 @@ type AddImageMetadataCommand struct {
 
 // Init implements Command.Init.
 func (c *AddImageMetadataCommand) Init(args []string) (err error) {
-	// Check all mandatory properties supplied.
 	if err := checkArgumentSet(c.ImageId, "image id"); err != nil {
-		return err
-	}
-	if err := checkArgumentSet(c.Series, "series"); err != nil {
-		return err
-	}
-	if err := checkArgumentSet(c.Arch, "architecture"); err != nil {
 		return err
 	}
 	return nil
@@ -84,13 +77,14 @@ func (c *AddImageMetadataCommand) SetFlags(f *gnuflag.FlagSet) {
 
 	f.StringVar(&c.ImageId, "image-id", "", "metadata image id")
 	f.StringVar(&c.Region, "region", "", "image cloud region")
-	f.StringVar(&c.Series, "series", "", "image series")
-	f.StringVar(&c.Arch, "arch", "", "image architecture")
+	// TODO (anastasiamac 2015-09-30) Ideally default should be latest LTS.
+	// Hard-coding "trusty" for now.
+	f.StringVar(&c.Series, "series", "trusty", "image series")
+	f.StringVar(&c.Arch, "arch", "amd64", "image architecture")
 	f.StringVar(&c.VirtType, "virt-type", "", "image metadata virtualisation type")
 	f.StringVar(&c.RootStorageType, "storage-type", "", "image metadata root storage type")
-
 	f.Uint64Var(&c.RootStorageSize, "storage-size", 0, "image metadata root storage size")
-	f.StringVar(&c.Stream, "stream", "", "image metadata stream")
+	f.StringVar(&c.Stream, "stream", "released", "image metadata stream")
 }
 
 // Run implements Command.Run.

--- a/cmd/plugins/juju-metadata/addimage_test.go
+++ b/cmd/plugins/juju-metadata/addimage_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/juju/juju/testing"
 )
 
-type AddImageSuite struct {
+type addImageSuite struct {
 	BaseClouImageMetadataSuite
 
 	data []params.CloudImageMetadata
@@ -25,11 +25,11 @@ type AddImageSuite struct {
 	mockAPI *mockAddAPI
 }
 
-var _ = gc.Suite(&AddImageSuite{})
+var _ = gc.Suite(&addImageSuite{})
 
 var emptyMetadata = []params.CloudImageMetadata{}
 
-func (s *AddImageSuite) SetUpTest(c *gc.C) {
+func (s *addImageSuite) SetUpTest(c *gc.C) {
 	s.BaseClouImageMetadataSuite.SetUpTest(c)
 
 	s.data = emptyMetadata
@@ -44,24 +44,30 @@ func (s *AddImageSuite) SetUpTest(c *gc.C) {
 	})
 }
 
-func (s *AddImageSuite) TestAddImageMetadata(c *gc.C) {
+func (s *addImageSuite) TestAddImageMetadata(c *gc.C) {
 	s.assertValidAddImageMetadata(c, "", "", constructTestImageMetadata())
 }
 
-func (s *AddImageSuite) TestAddImageMetadataWithStream(c *gc.C) {
+func (s *addImageSuite) TestAddImageMetadataWithStream(c *gc.C) {
 	m := constructTestImageMetadata()
 	m.Stream = "streamV"
 	s.assertValidAddImageMetadata(c, "", "", m)
 }
 
-func (s *AddImageSuite) TestAddImageMetadataAWS(c *gc.C) {
+func (s *addImageSuite) TestAddImageMetadataWithRegion(c *gc.C) {
+	m := constructTestImageMetadata()
+	m.Region = "region"
+	s.assertValidAddImageMetadata(c, "", "", m)
+}
+
+func (s *addImageSuite) TestAddImageMetadataAWS(c *gc.C) {
 	m := constructTestImageMetadata()
 	m.VirtType = "vType"
 	m.RootStorageType = "sType"
 	s.assertValidAddImageMetadata(c, "", "", m)
 }
 
-func (s *AddImageSuite) TestAddImageMetadataAWSWithSize(c *gc.C) {
+func (s *addImageSuite) TestAddImageMetadataAWSWithSize(c *gc.C) {
 	m := constructTestImageMetadata()
 	m.VirtType = "vType"
 	m.RootStorageType = "sType"
@@ -72,7 +78,7 @@ func (s *AddImageSuite) TestAddImageMetadataAWSWithSize(c *gc.C) {
 	s.assertValidAddImageMetadata(c, "", "", m)
 }
 
-func (s *AddImageSuite) TestAddImageMetadataFailed(c *gc.C) {
+func (s *addImageSuite) TestAddImageMetadataFailed(c *gc.C) {
 	msg := "failed"
 	s.mockAPI.add = func(metadata []params.CloudImageMetadata) ([]params.ErrorResult, error) {
 		return nil, errors.New(msg)
@@ -81,7 +87,7 @@ func (s *AddImageSuite) TestAddImageMetadataFailed(c *gc.C) {
 	s.assertAddImageMetadataErr(c, constructTestImageMetadata(), msg)
 }
 
-func (s *AddImageSuite) TestAddImageMetadataError(c *gc.C) {
+func (s *addImageSuite) TestAddImageMetadataError(c *gc.C) {
 	msg := "failed"
 
 	s.mockAPI.add = func(metadata []params.CloudImageMetadata) ([]params.ErrorResult, error) {
@@ -95,35 +101,28 @@ func (s *AddImageSuite) TestAddImageMetadataError(c *gc.C) {
 	s.assertAddImageMetadataErr(c, constructTestImageMetadata(), msg)
 }
 
-func (s *AddImageSuite) TestAddImageMetadataNoImageId(c *gc.C) {
+func (s *addImageSuite) TestAddImageMetadataNoImageId(c *gc.C) {
 	m := constructTestImageMetadata()
 	m.ImageId = ""
 
 	s.assertAddImageMetadataErr(c, m, "image id must be supplied when adding an image metadata")
 }
 
-func (s *AddImageSuite) TestAddImageMetadataNoRegion(c *gc.C) {
-	m := constructTestImageMetadata()
-	m.Region = ""
-
-	s.assertAddImageMetadataErr(c, m, "region must be supplied when adding an image metadata")
-}
-
-func (s *AddImageSuite) TestAddImageMetadataNoSeries(c *gc.C) {
+func (s *addImageSuite) TestAddImageMetadataNoSeries(c *gc.C) {
 	m := constructTestImageMetadata()
 	m.Series = ""
 
 	s.assertAddImageMetadataErr(c, m, "series must be supplied when adding an image metadata")
 }
 
-func (s *AddImageSuite) TestAddImageMetadataNoArch(c *gc.C) {
+func (s *addImageSuite) TestAddImageMetadataNoArch(c *gc.C) {
 	m := constructTestImageMetadata()
 	m.Arch = ""
 
 	s.assertAddImageMetadataErr(c, m, "architecture must be supplied when adding an image metadata")
 }
 
-func (s *AddImageSuite) assertValidAddImageMetadata(c *gc.C, expectedValid, expectedErr string, m params.CloudImageMetadata) {
+func (s *addImageSuite) assertValidAddImageMetadata(c *gc.C, expectedValid, expectedErr string, m params.CloudImageMetadata) {
 	args := getAddImageMetadataCmdFlags(m)
 	context, err := runAddImageMetadata(c, args...)
 	c.Assert(err, jc.ErrorIsNil)
@@ -141,7 +140,7 @@ func runAddImageMetadata(c *gc.C, args ...string) (*cmd.Context, error) {
 	return testing.RunCommand(c, envcmd.Wrap(&AddImageMetadataCommand{}), args...)
 }
 
-func (s *AddImageSuite) assertAddImageMetadataErr(c *gc.C, m params.CloudImageMetadata, msg string) {
+func (s *addImageSuite) assertAddImageMetadataErr(c *gc.C, m params.CloudImageMetadata, msg string) {
 	args := getAddImageMetadataCmdFlags(m)
 	_, err := runAddImageMetadata(c, args...)
 	c.Assert(err, gc.ErrorMatches, fmt.Sprintf(".*%v.*", msg))
@@ -151,7 +150,6 @@ func (s *AddImageSuite) assertAddImageMetadataErr(c *gc.C, m params.CloudImageMe
 func constructTestImageMetadata() params.CloudImageMetadata {
 	return params.CloudImageMetadata{
 		ImageId: "im-33333",
-		Region:  "region",
 		Series:  "series",
 		Arch:    "arch",
 		Source:  "custom",

--- a/cmd/plugins/juju-metadata/addimage_test.go
+++ b/cmd/plugins/juju-metadata/addimage_test.go
@@ -1,0 +1,194 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/envcmd"
+	"github.com/juju/juju/testing"
+)
+
+type AddImageSuite struct {
+	BaseClouImageMetadataSuite
+
+	data []params.CloudImageMetadata
+
+	mockAPI *mockAddAPI
+}
+
+var _ = gc.Suite(&AddImageSuite{})
+
+var emptyMetadata = []params.CloudImageMetadata{}
+
+func (s *AddImageSuite) SetUpTest(c *gc.C) {
+	s.BaseClouImageMetadataSuite.SetUpTest(c)
+
+	s.data = emptyMetadata
+
+	s.mockAPI = &mockAddAPI{}
+	s.mockAPI.add = func(metadata []params.CloudImageMetadata) ([]params.ErrorResult, error) {
+		s.data = append(s.data, metadata...)
+		return make([]params.ErrorResult, len(metadata)), nil
+	}
+	s.PatchValue(&getImageMetadataAddAPI, func(c *AddImageMetadataCommand) (MetadataAddAPI, error) {
+		return s.mockAPI, nil
+	})
+}
+
+func (s *AddImageSuite) TestAddImageMetadata(c *gc.C) {
+	s.assertValidAddImageMetadata(c, "", "", constructTestImageMetadata())
+}
+
+func (s *AddImageSuite) TestAddImageMetadataWithStream(c *gc.C) {
+	m := constructTestImageMetadata()
+	m.Stream = "streamV"
+	s.assertValidAddImageMetadata(c, "", "", m)
+}
+
+func (s *AddImageSuite) TestAddImageMetadataAWS(c *gc.C) {
+	m := constructTestImageMetadata()
+	m.VirtType = "vType"
+	m.RootStorageType = "sType"
+	s.assertValidAddImageMetadata(c, "", "", m)
+}
+
+func (s *AddImageSuite) TestAddImageMetadataAWSWithSize(c *gc.C) {
+	m := constructTestImageMetadata()
+	m.VirtType = "vType"
+	m.RootStorageType = "sType"
+
+	size := uint64(100)
+	m.RootStorageSize = &size
+
+	s.assertValidAddImageMetadata(c, "", "", m)
+}
+
+func (s *AddImageSuite) TestAddImageMetadataFailed(c *gc.C) {
+	msg := "failed"
+	s.mockAPI.add = func(metadata []params.CloudImageMetadata) ([]params.ErrorResult, error) {
+		return nil, errors.New(msg)
+	}
+
+	s.assertAddImageMetadataErr(c, constructTestImageMetadata(), msg)
+}
+
+func (s *AddImageSuite) TestAddImageMetadataError(c *gc.C) {
+	msg := "failed"
+
+	s.mockAPI.add = func(metadata []params.CloudImageMetadata) ([]params.ErrorResult, error) {
+		errs := make([]params.ErrorResult, len(metadata))
+		for i, _ := range metadata {
+			errs[i] = params.ErrorResult{Error: common.ServerError(errors.New(msg))}
+		}
+		return errs, nil
+	}
+
+	s.assertAddImageMetadataErr(c, constructTestImageMetadata(), msg)
+}
+
+func (s *AddImageSuite) TestAddImageMetadataNoImageId(c *gc.C) {
+	m := constructTestImageMetadata()
+	m.ImageId = ""
+
+	s.assertAddImageMetadataErr(c, m, "image id must be supplied when adding an image metadata")
+}
+
+func (s *AddImageSuite) TestAddImageMetadataNoRegion(c *gc.C) {
+	m := constructTestImageMetadata()
+	m.Region = ""
+
+	s.assertAddImageMetadataErr(c, m, "region must be supplied when adding an image metadata")
+}
+
+func (s *AddImageSuite) TestAddImageMetadataNoSeries(c *gc.C) {
+	m := constructTestImageMetadata()
+	m.Series = ""
+
+	s.assertAddImageMetadataErr(c, m, "series must be supplied when adding an image metadata")
+}
+
+func (s *AddImageSuite) TestAddImageMetadataNoArch(c *gc.C) {
+	m := constructTestImageMetadata()
+	m.Arch = ""
+
+	s.assertAddImageMetadataErr(c, m, "architecture must be supplied when adding an image metadata")
+}
+
+func (s *AddImageSuite) assertValidAddImageMetadata(c *gc.C, expectedValid, expectedErr string, m params.CloudImageMetadata) {
+	args := getAddImageMetadataCmdFlags(m)
+	context, err := runAddImageMetadata(c, args...)
+	c.Assert(err, jc.ErrorIsNil)
+
+	obtainedErr := testing.Stderr(context)
+	c.Assert(obtainedErr, gc.Matches, expectedErr)
+
+	obtainedValid := testing.Stdout(context)
+	c.Assert(obtainedValid, gc.Matches, expectedValid)
+
+	c.Assert(s.data, gc.DeepEquals, []params.CloudImageMetadata{m})
+}
+
+func runAddImageMetadata(c *gc.C, args ...string) (*cmd.Context, error) {
+	return testing.RunCommand(c, envcmd.Wrap(&AddImageMetadataCommand{}), args...)
+}
+
+func (s *AddImageSuite) assertAddImageMetadataErr(c *gc.C, m params.CloudImageMetadata, msg string) {
+	args := getAddImageMetadataCmdFlags(m)
+	_, err := runAddImageMetadata(c, args...)
+	c.Assert(err, gc.ErrorMatches, fmt.Sprintf(".*%v.*", msg))
+	c.Assert(s.data, gc.DeepEquals, emptyMetadata)
+}
+
+func constructTestImageMetadata() params.CloudImageMetadata {
+	return params.CloudImageMetadata{
+		ImageId: "im-33333",
+		Region:  "region",
+		Series:  "series",
+		Arch:    "arch",
+		Source:  "custom",
+	}
+}
+
+func getAddImageMetadataCmdFlags(data params.CloudImageMetadata) []string {
+	args := []string{}
+
+	addFlag := func(flag, value string) {
+		if value != "" {
+			args = append(args, flag, value)
+		}
+	}
+
+	addFlag("--image-id", data.ImageId)
+	addFlag("--region", data.Region)
+	addFlag("--series", data.Series)
+	addFlag("--arch", data.Arch)
+	addFlag("--virt-type", data.VirtType)
+	addFlag("--storage-type", data.RootStorageType)
+	addFlag("--stream", data.Stream)
+
+	if data.RootStorageSize != nil {
+		args = append(args, "--storage-size", fmt.Sprintf("%d", *data.RootStorageSize))
+	}
+	return args
+}
+
+type mockAddAPI struct {
+	add func(metadata []params.CloudImageMetadata) ([]params.ErrorResult, error)
+}
+
+func (s mockAddAPI) Close() error {
+	return nil
+}
+
+func (s mockAddAPI) Save(metadata []params.CloudImageMetadata) ([]params.ErrorResult, error) {
+	return s.add(metadata)
+}

--- a/cmd/plugins/juju-metadata/listimages.go
+++ b/cmd/plugins/juju-metadata/listimages.go
@@ -147,7 +147,7 @@ func (c *ListImagesCommand) getImageMetadataListAPI() (MetadataListAPI, error) {
 }
 
 // convertDetailsToInfo converts cloud image metadata received from api to
-// structure native to CLI and sort it.
+// structure native to CLI.
 func convertDetailsToInfo(details []params.CloudImageMetadata) []MetadataInfo {
 	if len(details) == 0 {
 		return nil

--- a/cmd/plugins/juju-metadata/metadata.go
+++ b/cmd/plugins/juju-metadata/metadata.go
@@ -48,6 +48,7 @@ func Main(args []string) {
 	metadatacmd.Register(envcmd.Wrap(&ValidateToolsMetadataCommand{}))
 	metadatacmd.Register(&SignMetadataCommand{})
 	metadatacmd.Register(envcmd.Wrap(&ListImagesCommand{}))
+	metadatacmd.Register(envcmd.Wrap(&AddImageMetadataCommand{}))
 
 	os.Exit(cmd.Main(metadatacmd, ctx, args[1:]))
 }

--- a/cmd/plugins/juju-metadata/metadataplugin_test.go
+++ b/cmd/plugins/juju-metadata/metadataplugin_test.go
@@ -28,6 +28,7 @@ type MetadataSuite struct {
 var _ = gc.Suite(&MetadataSuite{})
 
 var metadataCommandNames = []string{
+	"add-image",
 	"generate-image",
 	"generate-tools",
 	"help",
@@ -96,6 +97,10 @@ func (s *MetadataSuite) TestHelpGenerateImage(c *gc.C) {
 	s.assertHelpOutput(c, "generate-image")
 }
 
-func (s *MetadataSuite) TestHelpListImage(c *gc.C) {
+func (s *MetadataSuite) TestHelpListImages(c *gc.C) {
 	s.assertHelpOutput(c, "list-images")
+}
+
+func (s *MetadataSuite) TestHelpAddImage(c *gc.C) {
+	s.assertHelpOutput(c, "add-image")
 }


### PR DESCRIPTION
Add image metadata command.

Image metadata properties are passed to command explicitly using respective flags.


(Review request: http://reviews.vapour.ws/r/2790/)