### PR TITLE
WatchStorageAttachment watches block devices

### DIFF
--- a/apiserver/common/storagecommon/storage_test.go
+++ b/apiserver/common/storagecommon/storage_test.go
@@ -8,17 +8,16 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/names"
-	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/common/storagecommon"
 	"github.com/juju/juju/state"
+	statetesting "github.com/juju/juju/state/testing"
 	"github.com/juju/juju/storage"
 )
 
 type storageAttachmentInfoSuite struct {
-	testing.Stub
 	machineTag        names.MachineTag
 	volumeTag         names.VolumeTag
 	storageTag        names.StorageTag
@@ -55,7 +54,11 @@ func (s *storageAttachmentInfoSuite) SetUpTest(c *gc.C) {
 	s.volumeAttachment = &fakeVolumeAttachment{
 		info: &state.VolumeAttachmentInfo{},
 	}
-	s.blockDevices = nil
+	s.blockDevices = []state.BlockDeviceInfo{{
+		DeviceName:  "sda",
+		DeviceLinks: []string{"/dev/disk/by-id/verbatim"},
+		HardwareId:  "whatever",
+	}}
 	s.st = &fakeStorage{
 		storageInstance: func(tag names.StorageTag) (state.StorageInstance, error) {
 			return s.storageInstance, nil
@@ -76,18 +79,28 @@ func (s *storageAttachmentInfoSuite) TestStorageAttachmentInfoPersistentDeviceNa
 	s.volumeAttachment.info.DeviceName = "sda"
 	info, err := storagecommon.StorageAttachmentInfo(s.st, s.storageAttachment, s.machineTag)
 	c.Assert(err, jc.ErrorIsNil)
-	s.st.CheckCallNames(c, "StorageInstance", "StorageInstanceVolume", "VolumeAttachment")
+	s.st.CheckCallNames(c, "StorageInstance", "StorageInstanceVolume", "VolumeAttachment", "BlockDevices")
 	c.Assert(info, jc.DeepEquals, &storage.StorageAttachmentInfo{
 		Kind:     storage.StorageKindBlock,
 		Location: filepath.FromSlash("/dev/sda"),
 	})
 }
 
+func (s *storageAttachmentInfoSuite) TestStorageAttachmentInfoMissingBlockDevice(c *gc.C) {
+	// If the block device has not shown up yet,
+	// then we should get a NotProvisioned error.
+	s.blockDevices = nil
+	s.volumeAttachment.info.DeviceName = "sda"
+	_, err := storagecommon.StorageAttachmentInfo(s.st, s.storageAttachment, s.machineTag)
+	c.Assert(err, jc.Satisfies, errors.IsNotProvisioned)
+	s.st.CheckCallNames(c, "StorageInstance", "StorageInstanceVolume", "VolumeAttachment", "BlockDevices")
+}
+
 func (s *storageAttachmentInfoSuite) TestStorageAttachmentInfoPersistentDeviceLink(c *gc.C) {
 	s.volumeAttachment.info.DeviceLink = "/dev/disk/by-id/verbatim"
 	info, err := storagecommon.StorageAttachmentInfo(s.st, s.storageAttachment, s.machineTag)
 	c.Assert(err, jc.ErrorIsNil)
-	s.st.CheckCallNames(c, "StorageInstance", "StorageInstanceVolume", "VolumeAttachment")
+	s.st.CheckCallNames(c, "StorageInstance", "StorageInstanceVolume", "VolumeAttachment", "BlockDevices")
 	c.Assert(info, jc.DeepEquals, &storage.StorageAttachmentInfo{
 		Kind:     storage.StorageKindBlock,
 		Location: "/dev/disk/by-id/verbatim",
@@ -98,7 +111,7 @@ func (s *storageAttachmentInfoSuite) TestStorageAttachmentInfoPersistentHardware
 	s.volume.info.HardwareId = "whatever"
 	info, err := storagecommon.StorageAttachmentInfo(s.st, s.storageAttachment, s.machineTag)
 	c.Assert(err, jc.ErrorIsNil)
-	s.st.CheckCallNames(c, "StorageInstance", "StorageInstanceVolume", "VolumeAttachment")
+	s.st.CheckCallNames(c, "StorageInstance", "StorageInstanceVolume", "VolumeAttachment", "BlockDevices")
 	c.Assert(info, jc.DeepEquals, &storage.StorageAttachmentInfo{
 		Kind:     storage.StorageKindBlock,
 		Location: filepath.FromSlash("/dev/disk/by-id/whatever"),
@@ -133,4 +146,96 @@ func (s *storageAttachmentInfoSuite) TestStorageAttachmentInfoNoBlockDevice(c *g
 	_, err := storagecommon.StorageAttachmentInfo(s.st, s.storageAttachment, s.machineTag)
 	c.Assert(err, jc.Satisfies, errors.IsNotProvisioned)
 	s.st.CheckCallNames(c, "StorageInstance", "StorageInstanceVolume", "VolumeAttachment", "BlockDevices")
+}
+
+type watchStorageAttachmentSuite struct {
+	storageTag               names.StorageTag
+	machineTag               names.MachineTag
+	unitTag                  names.UnitTag
+	st                       *fakeStorage
+	storageInstance          *fakeStorageInstance
+	volume                   *fakeVolume
+	volumeAttachmentWatcher  *fakeNotifyWatcher
+	blockDevicesWatcher      *fakeNotifyWatcher
+	storageAttachmentWatcher *fakeNotifyWatcher
+}
+
+var _ = gc.Suite(&watchStorageAttachmentSuite{})
+
+func (s *watchStorageAttachmentSuite) SetUpTest(c *gc.C) {
+	s.storageTag = names.NewStorageTag("osd-devices/0")
+	s.machineTag = names.NewMachineTag("0")
+	s.unitTag = names.NewUnitTag("ceph/0")
+	s.storageInstance = &fakeStorageInstance{
+		tag:   s.storageTag,
+		owner: s.machineTag,
+		kind:  state.StorageKindBlock,
+	}
+	s.volume = &fakeVolume{tag: names.NewVolumeTag("0")}
+	s.volumeAttachmentWatcher = &fakeNotifyWatcher{ch: make(chan struct{}, 1)}
+	s.blockDevicesWatcher = &fakeNotifyWatcher{ch: make(chan struct{}, 1)}
+	s.storageAttachmentWatcher = &fakeNotifyWatcher{ch: make(chan struct{}, 1)}
+	s.volumeAttachmentWatcher.ch <- struct{}{}
+	s.blockDevicesWatcher.ch <- struct{}{}
+	s.storageAttachmentWatcher.ch <- struct{}{}
+	s.st = &fakeStorage{
+		storageInstance: func(tag names.StorageTag) (state.StorageInstance, error) {
+			return s.storageInstance, nil
+		},
+		storageInstanceVolume: func(tag names.StorageTag) (state.Volume, error) {
+			return s.volume, nil
+		},
+		watchVolumeAttachment: func(names.MachineTag, names.VolumeTag) state.NotifyWatcher {
+			return s.volumeAttachmentWatcher
+		},
+		watchBlockDevices: func(names.MachineTag) state.NotifyWatcher {
+			return s.blockDevicesWatcher
+		},
+		watchStorageAttachment: func(names.StorageTag, names.UnitTag) state.NotifyWatcher {
+			return s.storageAttachmentWatcher
+		},
+	}
+}
+
+func (s *watchStorageAttachmentSuite) TestWatchStorageAttachmentVolumeAttachmentChanges(c *gc.C) {
+	s.testWatchBlockStorageAttachment(c, func() {
+		s.volumeAttachmentWatcher.ch <- struct{}{}
+	})
+}
+
+func (s *watchStorageAttachmentSuite) TestWatchStorageAttachmentStorageAttachmentChanges(c *gc.C) {
+	s.testWatchBlockStorageAttachment(c, func() {
+		s.storageAttachmentWatcher.ch <- struct{}{}
+	})
+}
+
+func (s *watchStorageAttachmentSuite) TestWatchStorageAttachmentBlockDevicesChange(c *gc.C) {
+	s.testWatchBlockStorageAttachment(c, func() {
+		s.blockDevicesWatcher.ch <- struct{}{}
+	})
+}
+
+func (s *watchStorageAttachmentSuite) testWatchBlockStorageAttachment(c *gc.C, change func()) {
+	s.testWatchStorageAttachment(c, change)
+	s.st.CheckCallNames(c,
+		"StorageInstance",
+		"StorageInstanceVolume",
+		"WatchVolumeAttachment",
+		"WatchBlockDevices",
+		"WatchStorageAttachment",
+	)
+}
+
+func (s *watchStorageAttachmentSuite) testWatchStorageAttachment(c *gc.C, change func()) {
+	w, err := storagecommon.WatchStorageAttachment(
+		s.st,
+		s.storageTag,
+		s.machineTag,
+		s.unitTag,
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	wc := statetesting.NewNotifyWatcherC(c, nopSyncStarter{}, w)
+	wc.AssertOneChange()
+	change()
+	wc.AssertOneChange()
 }

--- a/apiserver/storage/mock_test.go
+++ b/apiserver/storage/mock_test.go
@@ -47,6 +47,7 @@ type mockState struct {
 	watchStorageAttachment              func(names.StorageTag, names.UnitTag) state.NotifyWatcher
 	watchFilesystemAttachment           func(names.MachineTag, names.FilesystemTag) state.NotifyWatcher
 	watchVolumeAttachment               func(names.MachineTag, names.VolumeTag) state.NotifyWatcher
+	watchBlockDevices                   func(names.MachineTag) state.NotifyWatcher
 	envName                             string
 	volume                              func(tag names.VolumeTag) (state.Volume, error)
 	machineVolumeAttachments            func(machine names.MachineTag) ([]state.VolumeAttachment, error)
@@ -103,6 +104,10 @@ func (st *mockState) WatchFilesystemAttachment(mtag names.MachineTag, f names.Fi
 
 func (st *mockState) WatchVolumeAttachment(mtag names.MachineTag, v names.VolumeTag) state.NotifyWatcher {
 	return st.watchVolumeAttachment(mtag, v)
+}
+
+func (st *mockState) WatchBlockDevices(mtag names.MachineTag) state.NotifyWatcher {
+	return st.watchBlockDevices(mtag)
 }
 
 func (st *mockState) EnvName() (string, error) {

--- a/apiserver/storage/state.go
+++ b/apiserver/storage/state.go
@@ -44,6 +44,9 @@ type storageAccess interface {
 	// WatchVolumeAttachment is required for storage functionality.
 	WatchVolumeAttachment(names.MachineTag, names.VolumeTag) state.NotifyWatcher
 
+	// WatchBlockDevices is required for storage functionality.
+	WatchBlockDevices(names.MachineTag) state.NotifyWatcher
+
 	// BlockDevices is required for storage functionality.
 	BlockDevices(names.MachineTag) ([]state.BlockDeviceInfo, error)
 

--- a/apiserver/uniter/state.go
+++ b/apiserver/uniter/state.go
@@ -25,6 +25,7 @@ type storageStateInterface interface {
 	WatchStorageAttachment(names.StorageTag, names.UnitTag) state.NotifyWatcher
 	WatchFilesystemAttachment(names.MachineTag, names.FilesystemTag) state.NotifyWatcher
 	WatchVolumeAttachment(names.MachineTag, names.VolumeTag) state.NotifyWatcher
+	WatchBlockDevices(names.MachineTag) state.NotifyWatcher
 	AddStorageForUnit(tag names.UnitTag, name string, cons state.StorageConstraints) error
 	UnitStorageConstraints(u names.UnitTag) (map[string]state.StorageConstraints, error)
 	BlockDevices(names.MachineTag) ([]state.BlockDeviceInfo, error)


### PR DESCRIPTION
The unit agent needs to know when storage attachments are provisioned and
ready for use. A block-kind storage attachment is not available until there
is a block device visible on the machine, so the uniter needs to be
informed of changes to block devices on the machine.

Fixes https://bugs.launchpad.net/juju-core/+bug/1501173

(Review request: http://reviews.vapour.ws/r/2791/)