### PR TITLE
storage: add BlockDevice.DeviceLinks (1.25)

### DIFF
--- a/apiserver/common/blockdevices.go
+++ b/apiserver/common/blockdevices.go
@@ -13,6 +13,7 @@ import (
 func BlockDeviceFromState(in state.BlockDeviceInfo) storage.BlockDevice {
 	return storage.BlockDevice{
 		in.DeviceName,
+		in.DeviceLinks,
 		in.Label,
 		in.UUID,
 		in.HardwareId,
@@ -36,11 +37,23 @@ func MatchingBlockDevice(
 			if volumeInfo.HardwareId == dev.HardwareId {
 				return &dev, true
 			}
-		} else if attachmentInfo.BusAddress != "" {
+			continue
+		}
+		if attachmentInfo.BusAddress != "" {
 			if attachmentInfo.BusAddress == dev.BusAddress {
 				return &dev, true
 			}
-		} else if attachmentInfo.DeviceName == dev.DeviceName {
+			continue
+		}
+		if attachmentInfo.DeviceLink != "" {
+			for _, link := range dev.DeviceLinks {
+				if attachmentInfo.DeviceLink == link {
+					return &dev, true
+				}
+			}
+			continue
+		}
+		if attachmentInfo.DeviceName == dev.DeviceName {
 			return &dev, true
 		}
 	}

--- a/apiserver/common/storage.go
+++ b/apiserver/common/storage.go
@@ -185,12 +185,18 @@ func volumeAttachmentDevicePath(
 	volumeAttachmentInfo state.VolumeAttachmentInfo,
 	machineTag names.MachineTag,
 ) (string, error) {
-	if volumeInfo.HardwareId != "" || volumeAttachmentInfo.DeviceName != "" {
-		// The storage provider has enough information
-		// to determine the device path.
+	if volumeInfo.HardwareId != "" || volumeAttachmentInfo.DeviceName != "" || volumeAttachmentInfo.DeviceLink != "" {
+		// The storage provider has enough information to determine
+		// the device path, so use that rather than enquring about
+		// block devices.
+		var deviceLinks []string
+		if volumeAttachmentInfo.DeviceLink != "" {
+			deviceLinks = []string{volumeAttachmentInfo.DeviceLink}
+		}
 		return storage.BlockDevicePath(storage.BlockDevice{
-			HardwareId: volumeInfo.HardwareId,
-			DeviceName: volumeAttachmentInfo.DeviceName,
+			HardwareId:  volumeInfo.HardwareId,
+			DeviceName:  volumeAttachmentInfo.DeviceName,
+			DeviceLinks: deviceLinks,
 		})
 	}
 	blockDevices, err := st.BlockDevices(machineTag)

--- a/apiserver/common/storage.go
+++ b/apiserver/common/storage.go
@@ -187,7 +187,7 @@ func volumeAttachmentDevicePath(
 ) (string, error) {
 	if volumeInfo.HardwareId != "" || volumeAttachmentInfo.DeviceName != "" || volumeAttachmentInfo.DeviceLink != "" {
 		// The storage provider has enough information to determine
-		// the device path, so use that rather than enquring about
+		// the device path, so use that rather than enquiring about
 		// block devices.
 		var deviceLinks []string
 		if volumeAttachmentInfo.DeviceLink != "" {

--- a/apiserver/common/storage_test.go
+++ b/apiserver/common/storage_test.go
@@ -4,20 +4,133 @@
 package common_test
 
 import (
-	"github.com/juju/juju/state"
+	"path/filepath"
+
+	"github.com/juju/errors"
 	"github.com/juju/names"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/storage"
 )
 
-type fakeStorageInstance struct {
-	state.StorageInstance
-	tag   names.StorageTag
-	owner names.Tag
+type storageAttachmentInfoSuite struct {
+	testing.Stub
+	machineTag        names.MachineTag
+	volumeTag         names.VolumeTag
+	storageTag        names.StorageTag
+	st                *fakeStorage
+	storageInstance   *fakeStorageInstance
+	storageAttachment *fakeStorageAttachment
+	volume            *fakeVolume
+	volumeAttachment  *fakeVolumeAttachment
+	blockDevices      []state.BlockDeviceInfo
 }
 
-func (i *fakeStorageInstance) Tag() names.Tag {
-	return i.tag
+var _ = gc.Suite(&storageAttachmentInfoSuite{})
+
+func (s *storageAttachmentInfoSuite) SetUpTest(c *gc.C) {
+	s.machineTag = names.NewMachineTag("0")
+	s.volumeTag = names.NewVolumeTag("0")
+	s.storageTag = names.NewStorageTag("osd-devices/0")
+	s.storageInstance = &fakeStorageInstance{
+		tag:   s.storageTag,
+		owner: s.machineTag,
+		kind:  state.StorageKindBlock,
+	}
+	s.storageAttachment = &fakeStorageAttachment{
+		storageTag: s.storageTag,
+	}
+	s.volume = &fakeVolume{
+		tag: s.volumeTag,
+		info: &state.VolumeInfo{
+			VolumeId: "vol-ume",
+			Pool:     "radiance",
+			Size:     1024,
+		},
+	}
+	s.volumeAttachment = &fakeVolumeAttachment{
+		info: &state.VolumeAttachmentInfo{},
+	}
+	s.blockDevices = nil
+	s.st = &fakeStorage{
+		storageInstance: func(tag names.StorageTag) (state.StorageInstance, error) {
+			return s.storageInstance, nil
+		},
+		storageInstanceVolume: func(tag names.StorageTag) (state.Volume, error) {
+			return s.volume, nil
+		},
+		volumeAttachment: func(m names.MachineTag, v names.VolumeTag) (state.VolumeAttachment, error) {
+			return s.volumeAttachment, nil
+		},
+		blockDevices: func(m names.MachineTag) ([]state.BlockDeviceInfo, error) {
+			return s.blockDevices, nil
+		},
+	}
 }
 
-func (i *fakeStorageInstance) Owner() names.Tag {
-	return i.owner
+func (s *storageAttachmentInfoSuite) TestStorageAttachmentInfoPersistentDeviceName(c *gc.C) {
+	s.volumeAttachment.info.DeviceName = "sda"
+	info, err := common.StorageAttachmentInfo(s.st, s.storageAttachment, s.machineTag)
+	c.Assert(err, jc.ErrorIsNil)
+	s.st.CheckCallNames(c, "StorageInstance", "StorageInstanceVolume", "VolumeAttachment")
+	c.Assert(info, jc.DeepEquals, &storage.StorageAttachmentInfo{
+		Kind:     storage.StorageKindBlock,
+		Location: filepath.FromSlash("/dev/sda"),
+	})
+}
+
+func (s *storageAttachmentInfoSuite) TestStorageAttachmentInfoPersistentDeviceLink(c *gc.C) {
+	s.volumeAttachment.info.DeviceLink = "/dev/disk/by-id/verbatim"
+	info, err := common.StorageAttachmentInfo(s.st, s.storageAttachment, s.machineTag)
+	c.Assert(err, jc.ErrorIsNil)
+	s.st.CheckCallNames(c, "StorageInstance", "StorageInstanceVolume", "VolumeAttachment")
+	c.Assert(info, jc.DeepEquals, &storage.StorageAttachmentInfo{
+		Kind:     storage.StorageKindBlock,
+		Location: "/dev/disk/by-id/verbatim",
+	})
+}
+
+func (s *storageAttachmentInfoSuite) TestStorageAttachmentInfoPersistentHardwareId(c *gc.C) {
+	s.volume.info.HardwareId = "whatever"
+	info, err := common.StorageAttachmentInfo(s.st, s.storageAttachment, s.machineTag)
+	c.Assert(err, jc.ErrorIsNil)
+	s.st.CheckCallNames(c, "StorageInstance", "StorageInstanceVolume", "VolumeAttachment")
+	c.Assert(info, jc.DeepEquals, &storage.StorageAttachmentInfo{
+		Kind:     storage.StorageKindBlock,
+		Location: filepath.FromSlash("/dev/disk/by-id/whatever"),
+	})
+}
+
+func (s *storageAttachmentInfoSuite) TestStorageAttachmentInfoMatchingBlockDevice(c *gc.C) {
+	// The bus address alone is not enough to produce a path to the block
+	// device; we need to find a published block device with the matching
+	// bus address.
+	s.volumeAttachment.info.BusAddress = "scsi@1:2.3.4"
+	s.blockDevices = []state.BlockDeviceInfo{{
+		DeviceName: "sda",
+	}, {
+		DeviceName: "sdb",
+		BusAddress: s.volumeAttachment.info.BusAddress,
+	}}
+	info, err := common.StorageAttachmentInfo(s.st, s.storageAttachment, s.machineTag)
+	c.Assert(err, jc.ErrorIsNil)
+	s.st.CheckCallNames(c, "StorageInstance", "StorageInstanceVolume", "VolumeAttachment", "BlockDevices")
+	c.Assert(info, jc.DeepEquals, &storage.StorageAttachmentInfo{
+		Kind:     storage.StorageKindBlock,
+		Location: filepath.FromSlash("/dev/sdb"),
+	})
+}
+
+func (s *storageAttachmentInfoSuite) TestStorageAttachmentInfoNoBlockDevice(c *gc.C) {
+	// Neither the volume nor the volume attachment has enough information
+	// to persistently identify the path, so we must enquire about block
+	// devices; there are none (yet), so NotProvisioned is returned.
+	s.volumeAttachment.info.BusAddress = "scsi@1:2.3.4"
+	_, err := common.StorageAttachmentInfo(s.st, s.storageAttachment, s.machineTag)
+	c.Assert(err, jc.Satisfies, errors.IsNotProvisioned)
+	s.st.CheckCallNames(c, "StorageInstance", "StorageInstanceVolume", "VolumeAttachment", "BlockDevices")
 }

--- a/apiserver/common/storagemock_test.go
+++ b/apiserver/common/storagemock_test.go
@@ -1,0 +1,125 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package common_test
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/names"
+	"github.com/juju/testing"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/storage"
+	"github.com/juju/juju/storage/poolmanager"
+)
+
+type fakeStorage struct {
+	testing.Stub
+	common.StorageInterface
+	storageInstance       func(names.StorageTag) (state.StorageInstance, error)
+	storageInstanceVolume func(names.StorageTag) (state.Volume, error)
+	volumeAttachment      func(names.MachineTag, names.VolumeTag) (state.VolumeAttachment, error)
+	blockDevices          func(names.MachineTag) ([]state.BlockDeviceInfo, error)
+}
+
+func (s *fakeStorage) StorageInstance(tag names.StorageTag) (state.StorageInstance, error) {
+	s.MethodCall(s, "StorageInstance", tag)
+	return s.storageInstance(tag)
+}
+
+func (s *fakeStorage) StorageInstanceVolume(tag names.StorageTag) (state.Volume, error) {
+	s.MethodCall(s, "StorageInstanceVolume", tag)
+	return s.storageInstanceVolume(tag)
+}
+
+func (s *fakeStorage) VolumeAttachment(m names.MachineTag, v names.VolumeTag) (state.VolumeAttachment, error) {
+	s.MethodCall(s, "VolumeAttachment", m, v)
+	return s.volumeAttachment(m, v)
+}
+
+func (s *fakeStorage) BlockDevices(m names.MachineTag) ([]state.BlockDeviceInfo, error) {
+	s.MethodCall(s, "BlockDevices", m)
+	return s.blockDevices(m)
+}
+
+type fakeStorageInstance struct {
+	state.StorageInstance
+	tag   names.StorageTag
+	owner names.Tag
+	kind  state.StorageKind
+}
+
+func (i *fakeStorageInstance) StorageTag() names.StorageTag {
+	return i.tag
+}
+
+func (i *fakeStorageInstance) Tag() names.Tag {
+	return i.tag
+}
+
+func (i *fakeStorageInstance) Owner() names.Tag {
+	return i.owner
+}
+
+func (i *fakeStorageInstance) Kind() state.StorageKind {
+	return i.kind
+}
+
+type fakeStorageAttachment struct {
+	state.StorageAttachment
+	storageTag names.StorageTag
+}
+
+func (a *fakeStorageAttachment) StorageInstance() names.StorageTag {
+	return a.storageTag
+}
+
+type fakeVolume struct {
+	state.Volume
+	tag    names.VolumeTag
+	params *state.VolumeParams
+	info   *state.VolumeInfo
+}
+
+func (v *fakeVolume) VolumeTag() names.VolumeTag {
+	return v.tag
+}
+
+func (v *fakeVolume) Tag() names.Tag {
+	return v.tag
+}
+
+func (v *fakeVolume) Params() (state.VolumeParams, bool) {
+	if v.params == nil {
+		return state.VolumeParams{}, false
+	}
+	return *v.params, true
+}
+
+func (v *fakeVolume) Info() (state.VolumeInfo, error) {
+	if v.info == nil {
+		return state.VolumeInfo{}, errors.NotProvisionedf("volume %v", v.tag.Id())
+	}
+	return *v.info, nil
+}
+
+type fakeVolumeAttachment struct {
+	state.VolumeAttachment
+	info *state.VolumeAttachmentInfo
+}
+
+func (v *fakeVolumeAttachment) Info() (state.VolumeAttachmentInfo, error) {
+	if v.info == nil {
+		return state.VolumeAttachmentInfo{}, errors.NotProvisionedf("volume attachment")
+	}
+	return *v.info, nil
+}
+
+type fakePoolManager struct {
+	poolmanager.PoolManager
+}
+
+func (pm *fakePoolManager) Get(name string) (*storage.Config, error) {
+	return nil, errors.NotFoundf("pool")
+}

--- a/apiserver/common/volumes.go
+++ b/apiserver/common/volumes.go
@@ -160,6 +160,7 @@ func VolumeAttachmentFromState(v state.VolumeAttachment) (params.VolumeAttachmen
 func VolumeAttachmentInfoFromState(info state.VolumeAttachmentInfo) params.VolumeAttachmentInfo {
 	return params.VolumeAttachmentInfo{
 		info.DeviceName,
+		info.DeviceLink,
 		info.BusAddress,
 		info.ReadOnly,
 	}
@@ -200,6 +201,7 @@ func VolumeAttachmentToState(in params.VolumeAttachment) (names.MachineTag, name
 func VolumeAttachmentInfoToState(in params.VolumeAttachmentInfo) state.VolumeAttachmentInfo {
 	return state.VolumeAttachmentInfo{
 		in.DeviceName,
+		in.DeviceLink,
 		in.BusAddress,
 		in.ReadOnly,
 	}

--- a/apiserver/common/volumes_test.go
+++ b/apiserver/common/volumes_test.go
@@ -4,7 +4,6 @@
 package common_test
 
 import (
-	"github.com/juju/errors"
 	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -13,8 +12,6 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/environs/tags"
 	"github.com/juju/juju/state"
-	"github.com/juju/juju/storage"
-	"github.com/juju/juju/storage/poolmanager"
 	"github.com/juju/juju/testing"
 )
 
@@ -22,56 +19,24 @@ type volumesSuite struct{}
 
 var _ = gc.Suite(&volumesSuite{})
 
-type fakeVolume struct {
-	state.Volume
-	tag         names.Tag
-	provisioned bool
-}
-
-func (v *fakeVolume) Tag() names.Tag {
-	return v.tag
-}
-
-func (v *fakeVolume) Params() (state.VolumeParams, bool) {
-	if v.provisioned {
-		return state.VolumeParams{}, false
-	}
-	return state.VolumeParams{
-		Pool: "loop",
-		Size: 1024,
-	}, true
-}
-
-func (v *fakeVolume) Info() (state.VolumeInfo, error) {
-	if !v.provisioned {
-		return state.VolumeInfo{}, errors.NotProvisionedf("volume %v", v.tag.Id())
-	}
-	return state.VolumeInfo{
-		Pool: "loop",
-		Size: 1024,
-	}, nil
-}
-
-type fakePoolManager struct {
-	poolmanager.PoolManager
-}
-
-func (pm *fakePoolManager) Get(name string) (*storage.Config, error) {
-	return nil, errors.NotFoundf("pool")
-}
-
 func (s *volumesSuite) TestVolumeParams(c *gc.C) {
-	s.testVolumeParams(c, false)
+	s.testVolumeParams(c, &state.VolumeParams{
+		Pool: "loop",
+		Size: 1024,
+	}, nil)
 }
 
 func (s *volumesSuite) TestVolumeParamsAlreadyProvisioned(c *gc.C) {
-	s.testVolumeParams(c, false)
+	s.testVolumeParams(c, nil, &state.VolumeInfo{
+		Pool: "loop",
+		Size: 1024,
+	})
 }
 
-func (*volumesSuite) testVolumeParams(c *gc.C, provisioned bool) {
+func (*volumesSuite) testVolumeParams(c *gc.C, volumeParams *state.VolumeParams, info *state.VolumeInfo) {
 	tag := names.NewVolumeTag("100")
 	p, err := common.VolumeParams(
-		&fakeVolume{tag: tag, provisioned: provisioned},
+		&fakeVolume{tag: tag, params: volumeParams, info: info},
 		nil, // StorageInstance
 		testing.CustomEnvironConfig(c, testing.Attrs{
 			"resource-tags": "a=b c=",
@@ -96,7 +61,9 @@ func (*volumesSuite) TestVolumeParamsStorageTags(c *gc.C) {
 	storageTag := names.NewStorageTag("mystore/0")
 	unitTag := names.NewUnitTag("mysql/123")
 	p, err := common.VolumeParams(
-		&fakeVolume{tag: volumeTag},
+		&fakeVolume{tag: volumeTag, params: &state.VolumeParams{
+			Pool: "loop", Size: 1024,
+		}},
 		&fakeStorageInstance{tag: storageTag, owner: unitTag},
 		testing.CustomEnvironConfig(c, nil),
 		&fakePoolManager{},

--- a/apiserver/diskmanager/diskmanager.go
+++ b/apiserver/diskmanager/diskmanager.go
@@ -97,6 +97,7 @@ func stateBlockDeviceInfo(devices []storage.BlockDevice) []state.BlockDeviceInfo
 	for i, dev := range devices {
 		result[i] = state.BlockDeviceInfo{
 			dev.DeviceName,
+			dev.DeviceLinks,
 			dev.Label,
 			dev.UUID,
 			dev.HardwareId,

--- a/apiserver/params/storage.go
+++ b/apiserver/params/storage.go
@@ -192,6 +192,7 @@ type VolumeAttachment struct {
 // VolumeAttachmentInfo describes a volume attachment.
 type VolumeAttachmentInfo struct {
 	DeviceName string `json:"devicename,omitempty"`
+	DeviceLink string `json:"devicelink,omitempty"`
 	BusAddress string `json:"busaddress,omitempty"`
 	ReadOnly   bool   `json:"read-only,omitempty"`
 }

--- a/apiserver/provisioner/provisioner.go
+++ b/apiserver/provisioner/provisioner.go
@@ -654,6 +654,7 @@ func volumeAttachmentsToState(in []params.VolumeAttachment) (map[names.VolumeTag
 		}
 		m[volumeTag] = state.VolumeAttachmentInfo{
 			v.Info.DeviceName,
+			v.Info.DeviceLink,
 			v.Info.BusAddress,
 			v.Info.ReadOnly,
 		}

--- a/cmd/juju/storage/volume.go
+++ b/cmd/juju/storage/volume.go
@@ -76,6 +76,7 @@ type VolumeAttachments struct {
 
 type MachineVolumeAttachment struct {
 	DeviceName string `yaml:"device,omitempty" json:"device,omitempty"`
+	DeviceLink string `yaml:"device-link,omitempty" json:"device-link,omitempty"`
 	BusAddress string `yaml:"bus-address,omitempty" json:"bus-address,omitempty"`
 	ReadOnly   bool   `yaml:"read-only" json:"read-only"`
 	// TODO(axw) add machine volume attachment status when we have it
@@ -135,6 +136,7 @@ func createVolumeInfo(result params.VolumeDetailsResult) (names.VolumeTag, Volum
 			}
 			machineAttachments[machineId] = MachineVolumeAttachment{
 				attachment.DeviceName,
+				attachment.DeviceLink,
 				attachment.BusAddress,
 				attachment.ReadOnly,
 			}

--- a/provider/gce/disks.go
+++ b/provider/gce/disks.go
@@ -222,24 +222,18 @@ func (v *volumeSource) createOneVolume(p storage.VolumeParams, instances instanc
 			VolumeId:   gceDisk.Name,
 			Size:       gceDisk.Size,
 			Persistent: true,
-			HardwareId: fmt.Sprintf(
-				// TODO(axw) 2015-09-29 #1500803
-				//
-				// This should be "google-%s", but we currently
-				// only record a single /dev/disk/by-id path
-				// against block devices, and it happens to be
-				// the one below. We should record them all,
-				// and allow any of them to match.
-				"scsi-0Google_PersistentDisk_%s",
-				attachedDisk.DeviceName,
-			),
 		},
 	}
 
 	volumeAttachment = &storage.VolumeAttachment{
 		p.Tag,
 		p.Attachment.Machine,
-		storage.VolumeAttachmentInfo{},
+		storage.VolumeAttachmentInfo{
+			DeviceLink: fmt.Sprintf(
+				"/dev/disk/by-id/google-%s",
+				attachedDisk.DeviceName,
+			),
+		},
 	}
 
 	return volume, volumeAttachment, nil

--- a/provider/gce/disks_test.go
+++ b/provider/gce/disks_test.go
@@ -133,10 +133,11 @@ func (s *volumeSourceSuite) TestCreateVolumes(c *gc.C) {
 	// Volume was created
 	c.Assert(res[0].Error, jc.ErrorIsNil)
 	c.Assert(res[0].Volume.VolumeId, gc.Equals, s.BaseDisk.Name)
-	c.Assert(res[0].Volume.HardwareId, gc.Equals, "scsi-0Google_PersistentDisk_home-zone-1234567")
+	c.Assert(res[0].Volume.HardwareId, gc.Equals, "")
 
 	// Volume was also attached as indicated by Attachment in params.
 	c.Assert(res[0].VolumeAttachment.DeviceName, gc.Equals, "")
+	c.Assert(res[0].VolumeAttachment.DeviceLink, gc.Equals, "/dev/disk/by-id/google-home-zone-1234567")
 	c.Assert(res[0].VolumeAttachment.Machine.String(), gc.Equals, "machine-0")
 	c.Assert(res[0].VolumeAttachment.ReadOnly, jc.IsFalse)
 	c.Assert(res[0].VolumeAttachment.Volume.String(), gc.Equals, "volume-0")

--- a/state/blockdevices.go
+++ b/state/blockdevices.go
@@ -4,6 +4,8 @@
 package state
 
 import (
+	"reflect"
+
 	"github.com/juju/errors"
 	"github.com/juju/names"
 	jujutxn "github.com/juju/txn"
@@ -31,15 +33,16 @@ type blockDevicesDoc struct {
 
 // BlockDeviceInfo describes information about a block device.
 type BlockDeviceInfo struct {
-	DeviceName     string `bson:"devicename"`
-	Label          string `bson:"label,omitempty"`
-	UUID           string `bson:"uuid,omitempty"`
-	HardwareId     string `bson:"hardwareid,omitempty"`
-	BusAddress     string `bson:"busaddress,omitempty"`
-	Size           uint64 `bson:"size"`
-	FilesystemType string `bson:"fstype,omitempty"`
-	InUse          bool   `bson:"inuse"`
-	MountPoint     string `bson:"mountpoint,omitempty"`
+	DeviceName     string   `bson:"devicename"`
+	DeviceLinks    []string `bson:"devicelinks,omitempty"`
+	Label          string   `bson:"label,omitempty"`
+	UUID           string   `bson:"uuid,omitempty"`
+	HardwareId     string   `bson:"hardwareid,omitempty"`
+	BusAddress     string   `bson:"busaddress,omitempty"`
+	Size           uint64   `bson:"size"`
+	FilesystemType string   `bson:"fstype,omitempty"`
+	InUse          bool     `bson:"inuse"`
+	MountPoint     string   `bson:"mountpoint,omitempty"`
 }
 
 // WatchBlockDevices returns a new NotifyWatcher watching for
@@ -118,7 +121,7 @@ func blockDevicesChanged(oldDevices, newDevices []BlockDeviceInfo) bool {
 	for _, o := range oldDevices {
 		var found bool
 		for _, n := range newDevices {
-			if o == n {
+			if reflect.DeepEqual(o, n) {
 				found = true
 				break
 			}

--- a/state/volume.go
+++ b/state/volume.go
@@ -130,6 +130,7 @@ type VolumeInfo struct {
 // VolumeAttachmentInfo describes information about a volume attachment.
 type VolumeAttachmentInfo struct {
 	DeviceName string `bson:"devicename,omitempty"`
+	DeviceLink string `bson:"devicelink,omitempty"`
 	BusAddress string `bson:"busaddress,omitempty"`
 	ReadOnly   bool   `bson:"read-only"`
 }

--- a/storage/blockdevice.go
+++ b/storage/blockdevice.go
@@ -8,6 +8,12 @@ type BlockDevice struct {
 	// DeviceName is the block device's OS-specific name (e.g. "sdb").
 	DeviceName string `yaml:"devicename,omitempty"`
 
+	// DeviceLinks is a collection of symlinks to the block device
+	// that the OS maintains (e.g. "/dev/disk/by-id/..."). Storage
+	// provisioners can match volume attachments to device links if
+	// they know ahead of time how the OS will name them.
+	DeviceLinks []string `yaml:"devicelinks,omitempty"`
+
 	// Label is the label for the filesystem on the block device.
 	//
 	// This will be empty if the block device does not have a filesystem,

--- a/storage/path.go
+++ b/storage/path.go
@@ -15,11 +15,16 @@ const (
 )
 
 // BlockDevicePath returns the path to a block device, or an error if a path
-// cannot be determined. The path is based on the hardware ID, if available,
-// otherwise the device name.
+// cannot be determined. The path is based on the hardware ID, if available;
+// the first value in device.DeviceLinks, if non-empty; otherwise the device
+// name.
 func BlockDevicePath(device BlockDevice) (string, error) {
 	if device.HardwareId != "" {
 		return filepath.Join(diskByID, device.HardwareId), nil
+	}
+	if len(device.DeviceLinks) > 0 {
+		// return the first device link in the list
+		return device.DeviceLinks[0], nil
 	}
 	if device.DeviceName != "" {
 		return filepath.Join(diskByDeviceName, device.DeviceName), nil

--- a/storage/volume.go
+++ b/storage/volume.go
@@ -56,6 +56,13 @@ type VolumeAttachmentInfo struct {
 	// field must be left blank.
 	DeviceName string
 
+	// DeviceLink is an OS-specific device link that must exactly match
+	// one of the block device's links when attached.
+	//
+	// If no device link is known, or it may change (e.g. on machine
+	// restart), then this field must be left blank.
+	DeviceLink string
+
 	// BusAddress is the bus address, where the volume is attached to
 	// the machine.
 	//

--- a/worker/diskmanager/lsblk_test.go
+++ b/worker/diskmanager/lsblk_test.go
@@ -48,7 +48,7 @@ EOF`)
 
 	devices, err := diskmanager.ListBlockDevices()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(devices, jc.SameContents, []storage.BlockDevice{{
+	c.Assert(devices, jc.DeepEquals, []storage.BlockDevice{{
 		DeviceName: "sda",
 		Size:       228936,
 	}, {
@@ -89,6 +89,16 @@ func (s *ListBlockDevicesSuite) TestListBlockDevicesHardwareId(c *gc.C) {
 ID_BUS=ata
 ID_SERIAL=0980978987987
 `, storage.BlockDevice{HardwareId: "ata-0980978987987"})
+}
+
+func (s *ListBlockDevicesSuite) TestListBlockDevicesDeviceLinks(c *gc.C) {
+	// Values from DEVLINKS should be split by space, and entered into
+	// DeviceLinks verbatim.
+	s.testListBlockDevicesExtended(c, `
+DEVLINKS=/dev/disk/by-id/abc /dev/disk/by-id/def
+`, storage.BlockDevice{
+		DeviceLinks: []string{"/dev/disk/by-id/abc", "/dev/disk/by-id/def"},
+	})
 }
 
 func (s *ListBlockDevicesSuite) TestListBlockDevicesAll(c *gc.C) {
@@ -158,7 +168,7 @@ EOF`)
 	// to prevent it from being used, but no error will be returned.
 	devices, err := diskmanager.ListBlockDevices()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(devices, jc.SameContents, []storage.BlockDevice{{
+	c.Assert(devices, jc.DeepEquals, []storage.BlockDevice{{
 		DeviceName: "sda",
 		Size:       228936,
 		InUse:      true,
@@ -176,7 +186,7 @@ EOF`)
 
 	devices, err := diskmanager.ListBlockDevices()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(devices, jc.SameContents, []storage.BlockDevice{{
+	c.Assert(devices, jc.DeepEquals, []storage.BlockDevice{{
 		DeviceName: "sda",
 		Size:       0,
 	}, {
@@ -212,7 +222,7 @@ EOF`)
 
 	devices, err := diskmanager.ListBlockDevices()
 	c.Assert(err, gc.IsNil)
-	c.Assert(devices, jc.SameContents, []storage.BlockDevice{{
+	c.Assert(devices, jc.DeepEquals, []storage.BlockDevice{{
 		DeviceName: "sda",
 		Size:       228936,
 	}, {

--- a/worker/provisioner/provisioner_task.go
+++ b/worker/provisioner/provisioner_task.go
@@ -817,6 +817,7 @@ func volumeAttachmentsToApiserver(attachments []storage.VolumeAttachment) map[st
 	for _, a := range attachments {
 		result[a.Volume.String()] = params.VolumeAttachmentInfo{
 			a.DeviceName,
+			a.DeviceLink,
 			a.BusAddress,
 			a.ReadOnly,
 		}

--- a/worker/storageprovisioner/volumes.go
+++ b/worker/storageprovisioner/volumes.go
@@ -404,6 +404,7 @@ func volumeAttachmentsFromStorage(in []storage.VolumeAttachment) []params.Volume
 			v.Machine.String(),
 			params.VolumeAttachmentInfo{
 				v.DeviceName,
+				v.DeviceLink,
 				v.BusAddress,
 				v.ReadOnly,
 			},


### PR DESCRIPTION
Back port.

Add DeviceLinks to the BlockDevice and volume attachment info models. The
DeviceLinks field captures the OS (udev) maintained symlinks to the block
device, which a volume provider can match on.

Update the GCE storage provider to populate the DeviceLink field instead of
HardwareId, adhering to the documented method of identifying disks.

https://bugs.launchpad.net/juju-core/+bug/1500803

(Review request: http://reviews.vapour.ws/r/2792/)