### PR TITLE
apiserver: implement macaroon auth for charms endpoint

### DIFF
--- a/apiserver/authhttp_test.go
+++ b/apiserver/authhttp_test.go
@@ -9,18 +9,23 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
 
 	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/testing/httptesting"
 	"github.com/juju/utils"
 	"golang.org/x/net/websocket"
 	gc "gopkg.in/check.v1"
+	"gopkg.in/macaroon-bakery.v1/bakery/checkers"
+	"gopkg.in/macaroon-bakery.v1/bakerytest"
+	"gopkg.in/macaroon-bakery.v1/httpbakery"
 
-	apihttp "github.com/juju/juju/apiserver/http"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/environs/config"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/testing"
@@ -29,13 +34,54 @@ import (
 
 // authHttpSuite provides helpers for testing HTTP "streaming" style APIs.
 type authHttpSuite struct {
+	// macaroonAuthEnabled may be set by a test suite
+	// before SetUpTest is called. If it is true, macaroon
+	// authentication will be enabled for the duration
+	// of the suite.
+	macaroonAuthEnabled bool
+
 	jujutesting.JujuConnSuite
 	envUUID string
+
+	// userTag and password hold the user tag and password
+	// to use in authRequest.
+	userTag  names.UserTag
+	password string
+
+	// discharger holds the macaroon discharger.
+	// It will only be non-nil if macaroonAuthEnabled is true.
+	discharger *bakerytest.Discharger
+
+	// checker is used by the above discharger to
+	// check third party caveats. It must be set
+	// before any caveats are discharged.
+	checker func(cond, arg string) ([]checkers.Caveat, error)
 }
 
 func (s *authHttpSuite) SetUpTest(c *gc.C) {
+	if s.macaroonAuthEnabled {
+		s.discharger = bakerytest.NewDischarger(nil, func(req *http.Request, cond, arg string) ([]checkers.Caveat, error) {
+			return s.checker(cond, arg)
+		})
+		s.JujuConnSuite.ConfigAttrs = map[string]interface{}{
+			config.IdentityURL: s.discharger.Location(),
+		}
+	}
+
 	s.JujuConnSuite.SetUpTest(c)
 	s.envUUID = s.State.EnvironUUID()
+
+	// Make a user in the state.
+	s.password = "password"
+	user := s.Factory.MakeUser(c, &factory.UserParams{Password: s.password})
+	s.userTag = user.UserTag()
+}
+
+func (s *authHttpSuite) TearDownTest(c *gc.C) {
+	if s.discharger != nil {
+		s.discharger.Close()
+	}
+	s.JujuConnSuite.TearDownTest(c)
 }
 
 func (s *authHttpSuite) baseURL(c *gc.C) *url.URL {
@@ -45,11 +91,6 @@ func (s *authHttpSuite) baseURL(c *gc.C) *url.URL {
 		Host:   info.Addrs[0],
 		Path:   "",
 	}
-}
-
-func (s *authHttpSuite) assertErrorResponse(c *gc.C, resp *http.Response, expCode int, expError string) {
-	body := assertResponse(c, resp, expCode, apihttp.CTypeJSON)
-	c.Check(jsonCharmsResponse(c, body).Error, gc.Matches, expError)
 }
 
 func (s *authHttpSuite) dialWebsocketFromURL(c *gc.C, server string, header http.Header) *websocket.Conn {
@@ -87,38 +128,21 @@ func (s *authHttpSuite) makeURL(c *gc.C, scheme, path string, queryParams url.Va
 	return url
 }
 
-// userAuthHttpSuite extends authHttpSuite with helpers for testing
-// HTTP "streaming" style APIs which only accept user logins (not
-// agents).
-type userAuthHttpSuite struct {
-	authHttpSuite
-	userTag            names.UserTag
-	password           string
-	archiveContentType string
-}
-
-func (s *userAuthHttpSuite) SetUpTest(c *gc.C) {
-	s.authHttpSuite.SetUpTest(c)
-	s.password = "password"
-	user := s.Factory.MakeUser(c, &factory.UserParams{Password: s.password})
-	s.userTag = user.UserTag()
-}
-
-func (s *userAuthHttpSuite) setupOtherEnvironment(c *gc.C) *state.State {
-	envState := s.Factory.MakeEnvironment(c, nil)
-	s.AddCleanup(func(*gc.C) { envState.Close() })
-	user := s.Factory.MakeUser(c, nil)
-	_, err := envState.AddEnvironmentUser(user.UserTag(), s.userTag, "")
-	c.Assert(err, jc.ErrorIsNil)
-	s.userTag = user.UserTag()
-	s.password = "password"
-	s.envUUID = envState.EnvironUUID()
-	return envState
-}
-
 // httpRequestParams holds parameters for the authRequest and sendRequest
 // methods.
 type httpRequestParams struct {
+	// do is used to make the HTTP request.
+	// If it is nil, utils.GetNonValidatingHTTPClient().Do will be used.
+	// If the body reader implements io.Seeker,
+	// req.Body will also implement that interface.
+	do func(req *http.Request) (*http.Response, error)
+
+	// expectError holds the error regexp to match
+	// against the error returned from the HTTP Do
+	// request. If it is empty, the error is expected to be
+	// nil.
+	expectError string
+
 	// tag holds the tag to authenticate as.
 	tag string
 
@@ -141,38 +165,81 @@ type httpRequestParams struct {
 	nonce string
 }
 
-func (s *userAuthHttpSuite) sendRequest(c *gc.C, p httpRequestParams) (*http.Response, error) {
+func (s *authHttpSuite) sendRequest(c *gc.C, p httpRequestParams) *http.Response {
 	c.Logf("sendRequest: %s", p.url)
-	req, err := http.NewRequest(p.method, p.url, p.body)
-	c.Assert(err, jc.ErrorIsNil)
-	if p.tag != "" && p.password != "" {
-		req.SetBasicAuth(p.tag, p.password)
+	hp := httptesting.DoRequestParams{
+		Do:          p.do,
+		Method:      p.method,
+		URL:         p.url,
+		Body:        p.body,
+		Header:      make(http.Header),
+		Username:    p.tag,
+		Password:    p.password,
+		ExpectError: p.expectError,
 	}
 	if p.contentType != "" {
-		req.Header.Set("Content-Type", p.contentType)
+		hp.Header.Set("Content-Type", p.contentType)
 	}
 	if p.nonce != "" {
-		req.Header.Set("X-Juju-Nonce", p.nonce)
+		hp.Header.Set("X-Juju-Nonce", p.nonce)
 	}
-	return utils.GetNonValidatingHTTPClient().Do(req)
+	if hp.Do == nil {
+		hp.Do = utils.GetNonValidatingHTTPClient().Do
+	}
+	return httptesting.Do(c, hp)
+}
+
+// bakeryDo provides a function suitable for using in httpRequestParams.Do
+// that will use the given http client (or utils.GetNonValidatingHTTPClient()
+// if client is nil) and use the given getBakeryError function
+// to translate errors in responses.
+func bakeryDo(client *http.Client, getBakeryError func(*http.Response) error) func(*http.Request) (*http.Response, error) {
+	bclient := httpbakery.NewClient()
+	if client != nil {
+		bclient.Client = client
+	} else {
+		// Configure the default client to skip verification/
+		bclient.Client.Transport = utils.NewHttpTLSTransport(&tls.Config{
+			InsecureSkipVerify: true,
+		})
+	}
+	return func(req *http.Request) (*http.Response, error) {
+		var body io.ReadSeeker
+		if req.Body != nil {
+			body = req.Body.(io.ReadSeeker)
+			req.Body = nil
+		}
+		return bclient.DoWithBodyAndCustomError(req, body, getBakeryError)
+	}
 }
 
 // authRequest is like sendRequest but fills out p.tag and p.password
 // from the userTag and password fields in the suite.
-func (s *userAuthHttpSuite) authRequest(c *gc.C, p httpRequestParams) (*http.Response, error) {
+func (s *authHttpSuite) authRequest(c *gc.C, p httpRequestParams) *http.Response {
 	p.tag = s.userTag.String()
 	p.password = s.password
 	return s.sendRequest(c, p)
 }
 
-func (s *userAuthHttpSuite) uploadRequest(c *gc.C, uri string, asZip bool, path string) (*http.Response, error) {
-	contentType := apihttp.CTypeRaw
-	if asZip {
-		contentType = s.archiveContentType
-	}
+func (s *authHttpSuite) setupOtherEnvironment(c *gc.C) *state.State {
+	envState := s.Factory.MakeEnvironment(c, nil)
+	s.AddCleanup(func(*gc.C) { envState.Close() })
+	user := s.Factory.MakeUser(c, nil)
+	_, err := envState.AddEnvironmentUser(user.UserTag(), s.userTag, "")
+	c.Assert(err, jc.ErrorIsNil)
+	s.userTag = user.UserTag()
+	s.password = "password"
+	s.envUUID = envState.EnvironUUID()
+	return envState
+}
 
+func (s *authHttpSuite) uploadRequest(c *gc.C, uri string, contentType, path string) *http.Response {
 	if path == "" {
-		return s.authRequest(c, httpRequestParams{method: "POST", url: uri, contentType: contentType})
+		return s.authRequest(c, httpRequestParams{
+			method:      "POST",
+			url:         uri,
+			contentType: contentType,
+		})
 	}
 
 	file, err := os.Open(path)
@@ -203,4 +270,14 @@ func readJSONErrorLine(c *gc.C, reader *bufio.Reader) params.ErrorResult {
 	err = json.Unmarshal(line, &errResult)
 	c.Assert(err, jc.ErrorIsNil)
 	return errResult
+}
+
+func assertResponse(c *gc.C, resp *http.Response, expHTTPStatus int, expContentType string) []byte {
+	body, err := ioutil.ReadAll(resp.Body)
+	resp.Body.Close()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(resp.StatusCode, gc.Equals, expHTTPStatus, gc.Commentf("body: %s", body))
+	ctype := resp.Header.Get("Content-Type")
+	c.Assert(ctype, gc.Equals, expContentType)
+	return body
 }

--- a/apiserver/charms_test.go
+++ b/apiserver/charms_test.go
@@ -14,10 +14,13 @@ import (
 	"path/filepath"
 	"runtime"
 
+	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v6-unstable"
+	"gopkg.in/macaroon-bakery.v1/bakery/checkers"
+	"gopkg.in/macaroon-bakery.v1/httpbakery"
 
 	apihttp "github.com/juju/juju/apiserver/http"
 	"github.com/juju/juju/apiserver/params"
@@ -26,8 +29,63 @@ import (
 	"github.com/juju/juju/testcharms"
 )
 
+// charmsCommonSuite wraps authHttpSuite and adds
+// some helper methods suitable for working with the
+// charms endpoint.
+type charmsCommonSuite struct {
+	authHttpSuite
+}
+
+func (s *charmsCommonSuite) charmsURL(c *gc.C, query string) *url.URL {
+	uri := s.baseURL(c)
+	if s.envUUID == "" {
+		uri.Path = "/charms"
+	} else {
+		uri.Path = fmt.Sprintf("/environment/%s/charms", s.envUUID)
+	}
+	uri.RawQuery = query
+	return uri
+}
+
+func (s *charmsCommonSuite) charmsURI(c *gc.C, query string) string {
+	if query != "" && query[0] == '?' {
+		query = query[1:]
+	}
+	return s.charmsURL(c, query).String()
+}
+
+func (s *charmsCommonSuite) assertUploadResponse(c *gc.C, resp *http.Response, expCharmURL string) {
+	charmResponse := s.assertResponse(c, resp, http.StatusOK)
+	c.Check(charmResponse.Error, gc.Equals, "")
+	c.Check(charmResponse.CharmURL, gc.Equals, expCharmURL)
+}
+
+func (s *charmsCommonSuite) assertGetFileResponse(c *gc.C, resp *http.Response, expBody, expContentType string) {
+	body := assertResponse(c, resp, http.StatusOK, expContentType)
+	c.Check(string(body), gc.Equals, expBody)
+}
+
+func (s *charmsCommonSuite) assertGetFileListResponse(c *gc.C, resp *http.Response, expFiles []string) {
+	charmResponse := s.assertResponse(c, resp, http.StatusOK)
+	c.Check(charmResponse.Error, gc.Equals, "")
+	c.Check(charmResponse.Files, gc.DeepEquals, expFiles)
+}
+
+func (s *charmsCommonSuite) assertErrorResponse(c *gc.C, resp *http.Response, expCode int, expError string) {
+	charmResponse := s.assertResponse(c, resp, expCode)
+	c.Check(charmResponse.Error, gc.Matches, expError)
+}
+
+func (s *charmsCommonSuite) assertResponse(c *gc.C, resp *http.Response, expStatus int) params.CharmsResponse {
+	body := assertResponse(c, resp, expStatus, apihttp.CTypeJSON)
+	var charmResponse params.CharmsResponse
+	err := json.Unmarshal(body, &charmResponse)
+	c.Assert(err, jc.ErrorIsNil, gc.Commentf("body: %s", body))
+	return charmResponse
+}
+
 type charmsSuite struct {
-	userAuthHttpSuite
+	charmsCommonSuite
 }
 
 var _ = gc.Suite(&charmsSuite{})
@@ -37,32 +95,31 @@ func (s *charmsSuite) SetUpSuite(c *gc.C) {
 	if runtime.GOOS == "windows" {
 		c.Skip("bug 1403084: Skipping this on windows for now")
 	}
-	s.userAuthHttpSuite.SetUpSuite(c)
-	s.archiveContentType = "application/zip"
+	s.charmsCommonSuite.SetUpSuite(c)
 }
 
 func (s *charmsSuite) TestCharmsServedSecurely(c *gc.C) {
 	info := s.APIInfo(c)
 	uri := "http://" + info.Addrs[0] + "/charms"
-	_, err := s.sendRequest(c, httpRequestParams{method: "GET", url: uri})
-	c.Assert(err, gc.ErrorMatches, `.*malformed HTTP response.*`)
+	s.sendRequest(c, httpRequestParams{
+		method:      "GET",
+		url:         uri,
+		expectError: `.*malformed HTTP response.*`,
+	})
 }
 
 func (s *charmsSuite) TestPOSTRequiresAuth(c *gc.C) {
-	resp, err := s.sendRequest(c, httpRequestParams{method: "POST", url: s.charmsURI(c, "")})
-	c.Assert(err, jc.ErrorIsNil)
+	resp := s.sendRequest(c, httpRequestParams{method: "POST", url: s.charmsURI(c, "")})
 	s.assertErrorResponse(c, resp, http.StatusUnauthorized, "no authorization header found")
 }
 
 func (s *charmsSuite) TestGETDoesNotRequireAuth(c *gc.C) {
-	resp, err := s.sendRequest(c, httpRequestParams{method: "GET", url: s.charmsURI(c, "")})
-	c.Assert(err, jc.ErrorIsNil)
+	resp := s.sendRequest(c, httpRequestParams{method: "GET", url: s.charmsURI(c, "")})
 	s.assertErrorResponse(c, resp, http.StatusBadRequest, "expected url=CharmURL query argument")
 }
 
 func (s *charmsSuite) TestRequiresPOSTorGET(c *gc.C) {
-	resp, err := s.authRequest(c, httpRequestParams{method: "PUT", url: s.charmsURI(c, "")})
-	c.Assert(err, jc.ErrorIsNil)
+	resp := s.authRequest(c, httpRequestParams{method: "PUT", url: s.charmsURI(c, "")})
 	s.assertErrorResponse(c, resp, http.StatusMethodNotAllowed, `unsupported method: "PUT"`)
 }
 
@@ -77,25 +134,22 @@ func (s *charmsSuite) TestAuthRequiresUser(c *gc.C) {
 	err = machine.SetPassword(password)
 	c.Assert(err, jc.ErrorIsNil)
 
-	resp, err := s.sendRequest(c, httpRequestParams{
+	resp := s.sendRequest(c, httpRequestParams{
 		tag:      machine.Tag().String(),
 		password: password,
 		method:   "POST",
 		url:      s.charmsURI(c, ""),
 		nonce:    "fake_nonce",
 	})
-	c.Assert(err, jc.ErrorIsNil)
 	s.assertErrorResponse(c, resp, http.StatusUnauthorized, "invalid entity name or password")
 
 	// Now try a user login.
-	resp, err = s.authRequest(c, httpRequestParams{method: "POST", url: s.charmsURI(c, "")})
-	c.Assert(err, jc.ErrorIsNil)
+	resp = s.authRequest(c, httpRequestParams{method: "POST", url: s.charmsURI(c, "")})
 	s.assertErrorResponse(c, resp, http.StatusBadRequest, "expected series=URL argument")
 }
 
 func (s *charmsSuite) TestUploadRequiresSeries(c *gc.C) {
-	resp, err := s.authRequest(c, httpRequestParams{method: "POST", url: s.charmsURI(c, "")})
-	c.Assert(err, jc.ErrorIsNil)
+	resp := s.authRequest(c, httpRequestParams{method: "POST", url: s.charmsURI(c, "")})
 	s.assertErrorResponse(c, resp, http.StatusBadRequest, "expected series=URL argument")
 }
 
@@ -106,13 +160,11 @@ func (s *charmsSuite) TestUploadFailsWithInvalidZip(c *gc.C) {
 
 	// Pretend we upload a zip by setting the Content-Type, so we can
 	// check the error at extraction time later.
-	resp, err := s.uploadRequest(c, s.charmsURI(c, "?series=quantal"), true, tempFile.Name())
-	c.Assert(err, jc.ErrorIsNil)
+	resp := s.uploadRequest(c, s.charmsURI(c, "?series=quantal"), "application/zip", tempFile.Name())
 	s.assertErrorResponse(c, resp, http.StatusBadRequest, "cannot open charm archive: zip: not a valid zip file")
 
 	// Now try with the default Content-Type.
-	resp, err = s.uploadRequest(c, s.charmsURI(c, "?series=quantal"), false, tempFile.Name())
-	c.Assert(err, jc.ErrorIsNil)
+	resp = s.uploadRequest(c, s.charmsURI(c, "?series=quantal"), "application/octet-stream", tempFile.Name())
 	s.assertErrorResponse(c, resp, http.StatusBadRequest, "expected Content-Type: application/zip, got: application/octet-stream")
 }
 
@@ -127,8 +179,7 @@ func (s *charmsSuite) TestUploadBumpsRevision(c *gc.C) {
 
 	// Now try uploading the same revision and verify it gets bumped,
 	// and the BundleSha256 is calculated.
-	resp, err := s.uploadRequest(c, s.charmsURI(c, "?series=quantal"), true, ch.Path)
-	c.Assert(err, jc.ErrorIsNil)
+	resp := s.uploadRequest(c, s.charmsURI(c, "?series=quantal"), "application/zip", ch.Path)
 	expectedURL := charm.MustParseURL("local:quantal/dummy-2")
 	s.assertUploadResponse(c, resp, expectedURL.String())
 	sch, err := s.State.Charm(expectedURL)
@@ -154,8 +205,7 @@ func (s *charmsSuite) TestUploadRespectsLocalRevision(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Now try uploading it and ensure the revision persists.
-	resp, err := s.uploadRequest(c, s.charmsURI(c, "?series=quantal"), true, tempFile.Name())
-	c.Assert(err, jc.ErrorIsNil)
+	resp := s.uploadRequest(c, s.charmsURI(c, "?series=quantal"), "application/zip", tempFile.Name())
 	expectedURL := charm.MustParseURL("local:quantal/dummy-123")
 	s.assertUploadResponse(c, resp, expectedURL.String())
 	sch, err := s.State.Charm(expectedURL)
@@ -189,8 +239,7 @@ func (s *charmsSuite) TestUploadAllowsTopLevelPath(c *gc.C) {
 	// https://host:port/charms
 	url := s.charmsURL(c, "series=quantal")
 	url.Path = "/charms"
-	resp, err := s.uploadRequest(c, url.String(), true, ch.Path)
-	c.Assert(err, jc.ErrorIsNil)
+	resp := s.uploadRequest(c, url.String(), "application/zip", ch.Path)
 	expectedURL := charm.MustParseURL("local:quantal/dummy-1")
 	s.assertUploadResponse(c, resp, expectedURL.String())
 }
@@ -200,8 +249,7 @@ func (s *charmsSuite) TestUploadAllowsEnvUUIDPath(c *gc.C) {
 	ch := testcharms.Repo.CharmArchive(c.MkDir(), "dummy")
 	url := s.charmsURL(c, "series=quantal")
 	url.Path = fmt.Sprintf("/environment/%s/charms", s.envUUID)
-	resp, err := s.uploadRequest(c, url.String(), true, ch.Path)
-	c.Assert(err, jc.ErrorIsNil)
+	resp := s.uploadRequest(c, url.String(), "application/zip", ch.Path)
 	expectedURL := charm.MustParseURL("local:quantal/dummy-1")
 	s.assertUploadResponse(c, resp, expectedURL.String())
 }
@@ -212,8 +260,7 @@ func (s *charmsSuite) TestUploadAllowsOtherEnvUUIDPath(c *gc.C) {
 	ch := testcharms.Repo.CharmArchive(c.MkDir(), "dummy")
 	url := s.charmsURL(c, "series=quantal")
 	url.Path = fmt.Sprintf("/environment/%s/charms", envState.EnvironUUID())
-	resp, err := s.uploadRequest(c, url.String(), true, ch.Path)
-	c.Assert(err, jc.ErrorIsNil)
+	resp := s.uploadRequest(c, url.String(), "application/zip", ch.Path)
 	expectedURL := charm.MustParseURL("local:quantal/dummy-1")
 	s.assertUploadResponse(c, resp, expectedURL.String())
 }
@@ -222,8 +269,7 @@ func (s *charmsSuite) TestUploadRejectsWrongEnvUUIDPath(c *gc.C) {
 	// Check that we cannot upload charms to https://host:port/BADENVUUID/charms
 	url := s.charmsURL(c, "series=quantal")
 	url.Path = "/environment/dead-beef-123456/charms"
-	resp, err := s.authRequest(c, httpRequestParams{method: "POST", url: url.String()})
-	c.Assert(err, jc.ErrorIsNil)
+	resp := s.authRequest(c, httpRequestParams{method: "POST", url: url.String()})
 	s.assertErrorResponse(c, resp, http.StatusNotFound, `unknown environment: "dead-beef-123456"`)
 }
 
@@ -248,8 +294,7 @@ func (s *charmsSuite) TestUploadRepackagesNestedArchives(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `archive file "metadata.yaml" not found`)
 
 	// Now try uploading it - should succeeed and be repackaged.
-	resp, err := s.uploadRequest(c, s.charmsURI(c, "?series=quantal"), true, tempFile.Name())
-	c.Assert(err, jc.ErrorIsNil)
+	resp := s.uploadRequest(c, s.charmsURI(c, "?series=quantal"), "application/zip", tempFile.Name())
 	expectedURL := charm.MustParseURL("local:quantal/dummy-1")
 	s.assertUploadResponse(c, resp, expectedURL.String())
 	sch, err := s.State.Charm(expectedURL)
@@ -284,8 +329,7 @@ func (s *charmsSuite) TestUploadRepackagesNestedArchives(c *gc.C) {
 
 func (s *charmsSuite) TestGetRequiresCharmURL(c *gc.C) {
 	uri := s.charmsURI(c, "?file=hooks/install")
-	resp, err := s.authRequest(c, httpRequestParams{method: "GET", url: uri})
-	c.Assert(err, jc.ErrorIsNil)
+	resp := s.authRequest(c, httpRequestParams{method: "GET", url: uri})
 	s.assertErrorResponse(
 		c, resp, http.StatusBadRequest,
 		"expected url=CharmURL query argument",
@@ -294,8 +338,7 @@ func (s *charmsSuite) TestGetRequiresCharmURL(c *gc.C) {
 
 func (s *charmsSuite) TestGetFailsWithInvalidCharmURL(c *gc.C) {
 	uri := s.charmsURI(c, "?url=local:precise/no-such")
-	resp, err := s.authRequest(c, httpRequestParams{method: "GET", url: uri})
-	c.Assert(err, jc.ErrorIsNil)
+	resp := s.authRequest(c, httpRequestParams{method: "GET", url: uri})
 	s.assertErrorResponse(
 		c, resp, http.StatusNotFound,
 		`unable to retrieve and save the charm: cannot get charm from state: charm "local:precise/no-such" not found`,
@@ -305,9 +348,7 @@ func (s *charmsSuite) TestGetFailsWithInvalidCharmURL(c *gc.C) {
 func (s *charmsSuite) TestGetReturnsNotFoundWhenMissing(c *gc.C) {
 	// Add the dummy charm.
 	ch := testcharms.Repo.CharmArchive(c.MkDir(), "dummy")
-	_, err := s.uploadRequest(
-		c, s.charmsURI(c, "?series=quantal"), true, ch.Path)
-	c.Assert(err, jc.ErrorIsNil)
+	s.uploadRequest(c, s.charmsURI(c, "?series=quantal"), "application/zip", ch.Path)
 
 	// Ensure a 404 is returned for files not included in the charm.
 	for i, file := range []string{
@@ -315,8 +356,7 @@ func (s *charmsSuite) TestGetReturnsNotFoundWhenMissing(c *gc.C) {
 	} {
 		c.Logf("test %d: %s", i, file)
 		uri := s.charmsURI(c, "?url=local:quantal/dummy-1&file="+file)
-		resp, err := s.authRequest(c, httpRequestParams{method: "GET", url: uri})
-		c.Assert(err, jc.ErrorIsNil)
+		resp := s.authRequest(c, httpRequestParams{method: "GET", url: uri})
 		c.Assert(resp.StatusCode, gc.Equals, http.StatusNotFound)
 	}
 }
@@ -324,23 +364,18 @@ func (s *charmsSuite) TestGetReturnsNotFoundWhenMissing(c *gc.C) {
 func (s *charmsSuite) TestGetReturnsForbiddenWithDirectory(c *gc.C) {
 	// Add the dummy charm.
 	ch := testcharms.Repo.CharmArchive(c.MkDir(), "dummy")
-	_, err := s.uploadRequest(
-		c, s.charmsURI(c, "?series=quantal"), true, ch.Path)
-	c.Assert(err, jc.ErrorIsNil)
+	s.uploadRequest(c, s.charmsURI(c, "?series=quantal"), "application/zip", ch.Path)
 
 	// Ensure a 403 is returned if the requested file is a directory.
 	uri := s.charmsURI(c, "?url=local:quantal/dummy-1&file=hooks")
-	resp, err := s.authRequest(c, httpRequestParams{method: "GET", url: uri})
-	c.Assert(err, jc.ErrorIsNil)
+	resp := s.authRequest(c, httpRequestParams{method: "GET", url: uri})
 	c.Assert(resp.StatusCode, gc.Equals, http.StatusForbidden)
 }
 
 func (s *charmsSuite) TestGetReturnsFileContents(c *gc.C) {
 	// Add the dummy charm.
 	ch := testcharms.Repo.CharmArchive(c.MkDir(), "dummy")
-	_, err := s.uploadRequest(
-		c, s.charmsURI(c, "?series=quantal"), true, ch.Path)
-	c.Assert(err, jc.ErrorIsNil)
+	s.uploadRequest(c, s.charmsURI(c, "?series=quantal"), "application/zip", ch.Path)
 
 	// Ensure the file contents are properly returned.
 	for i, t := range []struct {
@@ -363,8 +398,7 @@ func (s *charmsSuite) TestGetReturnsFileContents(c *gc.C) {
 	} {
 		c.Logf("test %d: %s", i, t.summary)
 		uri := s.charmsURI(c, "?url=local:quantal/dummy-1&file="+t.file)
-		resp, err := s.authRequest(c, httpRequestParams{method: "GET", url: uri})
-		c.Assert(err, jc.ErrorIsNil)
+		resp := s.authRequest(c, httpRequestParams{method: "GET", url: uri})
 		s.assertGetFileResponse(c, resp, t.response, "text/plain; charset=utf-8")
 	}
 }
@@ -372,16 +406,13 @@ func (s *charmsSuite) TestGetReturnsFileContents(c *gc.C) {
 func (s *charmsSuite) TestGetStarReturnsArchiveBytes(c *gc.C) {
 	// Add the dummy charm.
 	ch := testcharms.Repo.CharmArchive(c.MkDir(), "dummy")
-	_, err := s.uploadRequest(
-		c, s.charmsURI(c, "?series=quantal"), true, ch.Path)
-	c.Assert(err, jc.ErrorIsNil)
+	s.uploadRequest(c, s.charmsURI(c, "?series=quantal"), "application/zip", ch.Path)
 
 	data, err := ioutil.ReadFile(ch.Path)
 	c.Assert(err, jc.ErrorIsNil)
 
 	uri := s.charmsURI(c, "?url=local:quantal/dummy-1&file=*")
-	resp, err := s.authRequest(c, httpRequestParams{method: "GET", url: uri})
-	c.Assert(err, jc.ErrorIsNil)
+	resp := s.authRequest(c, httpRequestParams{method: "GET", url: uri})
 	s.assertGetFileResponse(c, resp, string(data), "application/zip")
 }
 
@@ -389,25 +420,19 @@ func (s *charmsSuite) TestGetAllowsTopLevelPath(c *gc.C) {
 	// Backwards compatibility check, that we can GET from charms at
 	// https://host:port/charms
 	ch := testcharms.Repo.CharmArchive(c.MkDir(), "dummy")
-	_, err := s.uploadRequest(
-		c, s.charmsURI(c, "?series=quantal"), true, ch.Path)
-	c.Assert(err, jc.ErrorIsNil)
+	s.uploadRequest(c, s.charmsURI(c, "?series=quantal"), "application/zip", ch.Path)
 	url := s.charmsURL(c, "url=local:quantal/dummy-1&file=revision")
 	url.Path = "/charms"
-	resp, err := s.authRequest(c, httpRequestParams{method: "GET", url: url.String()})
-	c.Assert(err, jc.ErrorIsNil)
+	resp := s.authRequest(c, httpRequestParams{method: "GET", url: url.String()})
 	s.assertGetFileResponse(c, resp, "1", "text/plain; charset=utf-8")
 }
 
 func (s *charmsSuite) TestGetAllowsEnvUUIDPath(c *gc.C) {
 	ch := testcharms.Repo.CharmArchive(c.MkDir(), "dummy")
-	_, err := s.uploadRequest(
-		c, s.charmsURI(c, "?series=quantal"), true, ch.Path)
-	c.Assert(err, jc.ErrorIsNil)
+	s.uploadRequest(c, s.charmsURI(c, "?series=quantal"), "application/zip", ch.Path)
 	url := s.charmsURL(c, "url=local:quantal/dummy-1&file=revision")
 	url.Path = fmt.Sprintf("/environment/%s/charms", s.envUUID)
-	resp, err := s.authRequest(c, httpRequestParams{method: "GET", url: url.String()})
-	c.Assert(err, jc.ErrorIsNil)
+	resp := s.authRequest(c, httpRequestParams{method: "GET", url: url.String()})
 	s.assertGetFileResponse(c, resp, "1", "text/plain; charset=utf-8")
 }
 
@@ -415,35 +440,28 @@ func (s *charmsSuite) TestGetAllowsOtherEnvironment(c *gc.C) {
 	envState := s.setupOtherEnvironment(c)
 
 	ch := testcharms.Repo.CharmArchive(c.MkDir(), "dummy")
-	_, err := s.uploadRequest(
-		c, s.charmsURI(c, "?series=quantal"), true, ch.Path)
-	c.Assert(err, jc.ErrorIsNil)
+	s.uploadRequest(c, s.charmsURI(c, "?series=quantal"), "application/zip", ch.Path)
 	url := s.charmsURL(c, "url=local:quantal/dummy-1&file=revision")
 	url.Path = fmt.Sprintf("/environment/%s/charms", envState.EnvironUUID())
-	resp, err := s.authRequest(c, httpRequestParams{method: "GET", url: url.String()})
-	c.Assert(err, jc.ErrorIsNil)
+	resp := s.authRequest(c, httpRequestParams{method: "GET", url: url.String()})
 	s.assertGetFileResponse(c, resp, "1", "text/plain; charset=utf-8")
 }
 
 func (s *charmsSuite) TestGetRejectsWrongEnvUUIDPath(c *gc.C) {
 	url := s.charmsURL(c, "url=local:quantal/dummy-1&file=revision")
 	url.Path = "/environment/dead-beef-123456/charms"
-	resp, err := s.authRequest(c, httpRequestParams{method: "GET", url: url.String()})
-	c.Assert(err, jc.ErrorIsNil)
+	resp := s.authRequest(c, httpRequestParams{method: "GET", url: url.String()})
 	s.assertErrorResponse(c, resp, http.StatusNotFound, `unknown environment: "dead-beef-123456"`)
 }
 
 func (s *charmsSuite) TestGetReturnsManifest(c *gc.C) {
 	// Add the dummy charm.
 	ch := testcharms.Repo.CharmArchive(c.MkDir(), "dummy")
-	_, err := s.uploadRequest(
-		c, s.charmsURI(c, "?series=quantal"), true, ch.Path)
-	c.Assert(err, jc.ErrorIsNil)
+	s.uploadRequest(c, s.charmsURI(c, "?series=quantal"), "application/zip", ch.Path)
 
 	// Ensure charm files are properly listed.
 	uri := s.charmsURI(c, "?url=local:quantal/dummy-1")
-	resp, err := s.authRequest(c, httpRequestParams{method: "GET", url: uri})
-	c.Assert(err, jc.ErrorIsNil)
+	resp := s.authRequest(c, httpRequestParams{method: "GET", url: uri})
 	manifest, err := ch.Manifest()
 	c.Assert(err, jc.ErrorIsNil)
 	expectedFiles := manifest.SortedValues()
@@ -474,60 +492,94 @@ func (s *charmsSuite) TestGetUsesCache(c *gc.C) {
 
 	// Ensure the cached contents are properly retrieved.
 	uri := s.charmsURI(c, "?url=local:trusty/django-42&file=utils.js")
-	resp, err := s.authRequest(c, httpRequestParams{method: "GET", url: uri})
-	c.Assert(err, jc.ErrorIsNil)
+	resp := s.authRequest(c, httpRequestParams{method: "GET", url: uri})
 	s.assertGetFileResponse(c, resp, contents, "application/javascript")
 }
 
-func (s *charmsSuite) charmsURL(c *gc.C, query string) *url.URL {
-	uri := s.baseURL(c)
-	if s.envUUID == "" {
-		uri.Path = "/charms"
-	} else {
-		uri.Path = fmt.Sprintf("/environment/%s/charms", s.envUUID)
+type charmsWithMacaroonsSuite struct {
+	charmsCommonSuite
+}
+
+var _ = gc.Suite(&charmsWithMacaroonsSuite{})
+
+func (s *charmsWithMacaroonsSuite) SetUpTest(c *gc.C) {
+	s.macaroonAuthEnabled = true
+	s.authHttpSuite.SetUpTest(c)
+}
+
+func (s *charmsWithMacaroonsSuite) TestWithNoBasicAuthReturnsDischargeRequiredError(c *gc.C) {
+	resp := s.sendRequest(c, httpRequestParams{
+		method: "POST",
+		url:    s.charmsURI(c, ""),
+	})
+
+	charmResponse := s.assertResponse(c, resp, http.StatusUnauthorized)
+	c.Assert(charmResponse.Error, gc.Equals, "verification failed: no macaroons")
+	c.Assert(charmResponse.ErrorCode, gc.Equals, params.CodeDischargeRequired)
+	c.Assert(charmResponse.ErrorInfo, gc.NotNil)
+	c.Assert(charmResponse.ErrorInfo.Macaroon, gc.NotNil)
+}
+
+func (s *charmsWithMacaroonsSuite) TestCanPostWithDischargedMacaroon(c *gc.C) {
+	checkCount := 0
+	s.checker = func(cond, arg string) ([]checkers.Caveat, error) {
+		if cond != "is-authenticated-user" {
+			return nil, errors.Errorf("unrecognized caveat %q", cond)
+		}
+		checkCount++
+		return []checkers.Caveat{
+			checkers.DeclaredCaveat("username", s.userTag.Id()),
+		}, nil
 	}
-	uri.RawQuery = query
-	return uri
+	resp := s.sendRequest(c, httpRequestParams{
+		do:     s.doer(),
+		method: "POST",
+		url:    s.charmsURI(c, ""),
+	})
+	s.assertErrorResponse(c, resp, http.StatusBadRequest, "expected series=URL argument")
+	c.Assert(checkCount, gc.Equals, 1)
 }
 
-func (s *charmsSuite) charmsURI(c *gc.C, query string) string {
-	if query != "" && query[0] == '?' {
-		query = query[1:]
+// doer returns a Do function that can make a bakery request
+// appropriate for a charms endpoint.
+func (s *charmsWithMacaroonsSuite) doer() func(*http.Request) (*http.Response, error) {
+	return bakeryDo(nil, charmsBakeryGetError)
+}
+
+// charmsBakeryGetError implements a getError function
+// appropriate for passing to httpbakery.Client.DoWithBodyAndCustomError
+// for the charms endpoint.
+func charmsBakeryGetError(resp *http.Response) error {
+	if resp.StatusCode != http.StatusUnauthorized {
+		return nil
 	}
-	return s.charmsURL(c, query).String()
-}
-
-func (s *charmsSuite) assertUploadResponse(c *gc.C, resp *http.Response, expCharmURL string) {
-	body := assertResponse(c, resp, http.StatusOK, apihttp.CTypeJSON)
-	charmResponse := jsonCharmsResponse(c, body)
-	c.Check(charmResponse.Error, gc.Equals, "")
-	c.Check(charmResponse.CharmURL, gc.Equals, expCharmURL)
-}
-
-func (s *charmsSuite) assertGetFileResponse(c *gc.C, resp *http.Response, expBody, expContentType string) {
-	body := assertResponse(c, resp, http.StatusOK, expContentType)
-	c.Check(string(body), gc.Equals, expBody)
-}
-
-func (s *charmsSuite) assertGetFileListResponse(c *gc.C, resp *http.Response, expFiles []string) {
-	body := assertResponse(c, resp, http.StatusOK, apihttp.CTypeJSON)
-	charmResponse := jsonCharmsResponse(c, body)
-	c.Check(charmResponse.Error, gc.Equals, "")
-	c.Check(charmResponse.Files, gc.DeepEquals, expFiles)
-}
-
-func assertResponse(c *gc.C, resp *http.Response, expCode int, expContentType string) []byte {
-	body, err := ioutil.ReadAll(resp.Body)
-	resp.Body.Close()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Check(resp.StatusCode, gc.Equals, expCode, gc.Commentf("body: %s", body))
-	ctype := resp.Header.Get("Content-Type")
-	c.Assert(ctype, gc.Equals, expContentType)
-	return body
-}
-
-func jsonCharmsResponse(c *gc.C, body []byte) (jsonResponse params.CharmsResponse) {
-	err := json.Unmarshal(body, &jsonResponse)
-	c.Assert(err, jc.ErrorIsNil, gc.Commentf("body: %s", body))
-	return
+	data, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return errors.Annotatef(err, "cannot read body")
+	}
+	var charmResp params.CharmsResponse
+	if err := json.Unmarshal(data, &charmResp); err != nil {
+		return errors.Annotatef(err, "cannot unmarshal body")
+	}
+	errResp := &params.Error{
+		Message: charmResp.Error,
+		Code:    charmResp.ErrorCode,
+		Info:    charmResp.ErrorInfo,
+	}
+	if errResp.Code != params.CodeDischargeRequired {
+		return errResp
+	}
+	if errResp.Info == nil {
+		return errors.Annotatef(err, "no error info found in discharge-required response error")
+	}
+	// It's a discharge-required error, so make an appropriate httpbakery
+	// error from it.
+	return &httpbakery.Error{
+		Message: errResp.Message,
+		Code:    httpbakery.ErrDischargeRequired,
+		Info: &httpbakery.ErrorInfo{
+			Macaroon:     errResp.Info.Macaroon,
+			MacaroonPath: errResp.Info.MacaroonPath,
+		},
+	}
 }

--- a/apiserver/debuglog_test.go
+++ b/apiserver/debuglog_test.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"net/url"
 
-	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
 	"golang.org/x/net/websocket"
 	gc "gopkg.in/check.v1"
@@ -19,7 +18,7 @@ import (
 // debugLogBaseSuite has tests that should be run for both the file
 // and DB based variants of debuglog, as well as some test helpers.
 type debugLogBaseSuite struct {
-	userAuthHttpSuite
+	authHttpSuite
 }
 
 func (s *debugLogBaseSuite) TestBadParams(c *gc.C) {
@@ -30,14 +29,16 @@ func (s *debugLogBaseSuite) TestBadParams(c *gc.C) {
 
 func (s *debugLogBaseSuite) TestWithHTTP(c *gc.C) {
 	uri := s.logURL(c, "http", nil).String()
-	_, err := s.sendRequest(c, httpRequestParams{method: "GET", url: uri})
-	c.Assert(err, gc.ErrorMatches, `.*malformed HTTP response.*`)
+	s.sendRequest(c, httpRequestParams{
+		method:      "GET",
+		url:         uri,
+		expectError: `.*malformed HTTP response.*`,
+	})
 }
 
 func (s *debugLogBaseSuite) TestWithHTTPS(c *gc.C) {
 	uri := s.logURL(c, "https", nil).String()
-	response, err := s.sendRequest(c, httpRequestParams{method: "GET", url: uri})
-	c.Assert(err, jc.ErrorIsNil)
+	response := s.sendRequest(c, httpRequestParams{method: "GET", url: uri})
 	c.Assert(response.StatusCode, gc.Equals, http.StatusBadRequest)
 }
 

--- a/apiserver/images_test.go
+++ b/apiserver/images_test.go
@@ -29,20 +29,18 @@ import (
 	coretesting "github.com/juju/juju/testing"
 )
 
+const testImageData = "abc"
+
+var testImageChecksum = fmt.Sprintf("%x", sha256.Sum256([]byte(testImageData)))
+
 type imageSuite struct {
-	userAuthHttpSuite
-	archiveContentType string
-	imageData          string
-	imageChecksum      string
+	authHttpSuite
 }
 
 var _ = gc.Suite(&imageSuite{})
 
 func (s *imageSuite) SetUpSuite(c *gc.C) {
-	s.userAuthHttpSuite.SetUpSuite(c)
-	s.archiveContentType = "application/x-tar-gz"
-	s.imageData = "abc"
-	s.imageChecksum = "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+	s.authHttpSuite.SetUpSuite(c)
 	testRoundTripper.RegisterForScheme("test")
 }
 
@@ -53,8 +51,7 @@ func (s *imageSuite) TestDownloadMissingEnvUUIDPath(c *gc.C) {
 	url := s.imageURL(c, "lxc", "trusty", "amd64")
 	c.Assert(url.Path, jc.HasPrefix, "/environment//images")
 
-	response, err := s.downloadRequest(c, url)
-	c.Assert(err, jc.ErrorIsNil)
+	response := s.downloadRequest(c, url)
 	s.testDownload(c, response)
 }
 
@@ -64,8 +61,7 @@ func (s *imageSuite) TestDownloadEnvironmentPath(c *gc.C) {
 	url := s.imageURL(c, "lxc", "trusty", "amd64")
 	c.Assert(url.Path, jc.HasPrefix, fmt.Sprintf("/environment/%s/", s.State.EnvironUUID()))
 
-	response, err := s.downloadRequest(c, url)
-	c.Assert(err, jc.ErrorIsNil)
+	response := s.downloadRequest(c, url)
 	s.testDownload(c, response)
 }
 
@@ -76,17 +72,14 @@ func (s *imageSuite) TestDownloadOtherEnvironmentPath(c *gc.C) {
 	url := s.imageURL(c, "lxc", "trusty", "amd64")
 	c.Assert(url.Path, jc.HasPrefix, fmt.Sprintf("/environment/%s/", envState.EnvironUUID()))
 
-	response, err := s.downloadRequest(c, url)
-	c.Assert(err, jc.ErrorIsNil)
+	response := s.downloadRequest(c, url)
 	s.testDownload(c, response)
 }
 
 func (s *imageSuite) TestDownloadRejectsWrongEnvUUIDPath(c *gc.C) {
 	s.envUUID = "dead-beef-123456"
 	url := s.imageURL(c, "lxc", "trusty", "amd64")
-	response, err := s.downloadRequest(c, url)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(err, gc.IsNil)
+	response := s.downloadRequest(c, url)
 	s.assertErrorResponse(c, response, http.StatusNotFound, `unknown environment: "dead-beef-123456"`)
 }
 
@@ -118,8 +111,8 @@ func (s *imageSuite) TestDownloadFetchesAndCaches(c *gc.C) {
 	// Set up some image data for a fake server.
 	testing.PatchExecutable(c, s, "ubuntu-cloudimg-query", containertesting.FakeLxcURLScript)
 	useTestImageData(map[string]string{
-		"/trusty-released-amd64-root.tar.gz": s.imageData,
-		"/SHA256SUMS":                        s.imageChecksum + " *trusty-released-amd64-root.tar.gz",
+		"/trusty-released-amd64-root.tar.gz": testImageData,
+		"/SHA256SUMS":                        testImageChecksum + " *trusty-released-amd64-root.tar.gz",
 	})
 	defer func() {
 		useTestImageData(nil)
@@ -129,15 +122,14 @@ func (s *imageSuite) TestDownloadFetchesAndCaches(c *gc.C) {
 	// the API server to search for the image on cloud-images, fetches it,
 	// and then cache it in imagestorage.
 	url := s.imageURL(c, "lxc", "trusty", "amd64")
-	response, err := s.downloadRequest(c, url)
-	c.Assert(err, jc.ErrorIsNil)
+	response := s.downloadRequest(c, url)
 	data := s.testDownload(c, response)
 
 	metadata, cachedData := s.getImageFromStorage(c, s.State, "lxc", "trusty", "amd64")
-	c.Assert(metadata.Size, gc.Equals, int64(len(s.imageData)))
-	c.Assert(metadata.SHA256, gc.Equals, s.imageChecksum)
+	c.Assert(metadata.Size, gc.Equals, int64(len(testImageData)))
+	c.Assert(metadata.SHA256, gc.Equals, testImageChecksum)
 	c.Assert(metadata.SourceURL, gc.Equals, "test://cloud-images/trusty-released-amd64-root.tar.gz")
-	c.Assert(string(data), gc.Equals, string(s.imageData))
+	c.Assert(string(data), gc.Equals, string(testImageData))
 	c.Assert(string(data), gc.Equals, string(cachedData))
 }
 
@@ -145,8 +137,8 @@ func (s *imageSuite) TestDownloadFetchesAndCachesConcurrent(c *gc.C) {
 	// Set up some image data for a fake server.
 	testing.PatchExecutable(c, s, "ubuntu-cloudimg-query", containertesting.FakeLxcURLScript)
 	useTestImageData(map[string]string{
-		"/trusty-released-amd64-root.tar.gz": s.imageData,
-		"/SHA256SUMS":                        s.imageChecksum + " *trusty-released-amd64-root.tar.gz",
+		"/trusty-released-amd64-root.tar.gz": testImageData,
+		"/SHA256SUMS":                        testImageChecksum + " *trusty-released-amd64-root.tar.gz",
 	})
 	defer func() {
 		useTestImageData(nil)
@@ -162,10 +154,9 @@ func (s *imageSuite) TestDownloadFetchesAndCachesConcurrent(c *gc.C) {
 			go func() {
 				defer wg.Done()
 				url := s.imageURL(c, "lxc", "trusty", "amd64")
-				response, err := s.downloadRequest(c, url)
-				c.Assert(err, jc.ErrorIsNil)
+				response := s.downloadRequest(c, url)
 				data := s.testDownload(c, response)
-				c.Assert(string(data), gc.Equals, string(s.imageData))
+				c.Assert(string(data), gc.Equals, string(testImageData))
 			}()
 		}
 		wg.Wait()
@@ -182,26 +173,25 @@ func (s *imageSuite) TestDownloadFetchesAndCachesConcurrent(c *gc.C) {
 
 	// Check that the image is correctly cached.
 	metadata, cachedData := s.getImageFromStorage(c, s.State, "lxc", "trusty", "amd64")
-	c.Assert(metadata.Size, gc.Equals, int64(len(s.imageData)))
-	c.Assert(metadata.SHA256, gc.Equals, s.imageChecksum)
+	c.Assert(metadata.Size, gc.Equals, int64(len(testImageData)))
+	c.Assert(metadata.SHA256, gc.Equals, testImageChecksum)
 	c.Assert(metadata.SourceURL, gc.Equals, "test://cloud-images/trusty-released-amd64-root.tar.gz")
-	c.Assert(s.imageData, gc.Equals, string(cachedData))
+	c.Assert(testImageData, gc.Equals, string(cachedData))
 }
 
 func (s *imageSuite) TestDownloadFetchChecksumMismatch(c *gc.C) {
 	// Set up some image data for a fake server.
 	testing.PatchExecutable(c, s, "ubuntu-cloudimg-query", containertesting.FakeLxcURLScript)
 	useTestImageData(map[string]string{
-		"/trusty-released-amd64-root.tar.gz": s.imageData,
+		"/trusty-released-amd64-root.tar.gz": testImageData,
 		"/SHA256SUMS":                        "different-checksum *trusty-released-amd64-root.tar.gz",
 	})
 	defer func() {
 		useTestImageData(nil)
 	}()
 
-	resp, err := s.downloadRequest(c, s.imageURL(c, "lxc", "trusty", "amd64"))
+	resp := s.downloadRequest(c, s.imageURL(c, "lxc", "trusty", "amd64"))
 	defer resp.Body.Close()
-	c.Assert(err, gc.IsNil)
 	s.assertErrorResponse(c, resp, http.StatusInternalServerError, ".* download checksum mismatch .*")
 }
 
@@ -209,37 +199,36 @@ func (s *imageSuite) TestDownloadFetchNoSHA256File(c *gc.C) {
 	// Set up some image data for a fake server.
 	testing.PatchExecutable(c, s, "ubuntu-cloudimg-query", containertesting.FakeLxcURLScript)
 	useTestImageData(map[string]string{
-		"/trusty-released-amd64-root.tar.gz": s.imageData,
+		"/trusty-released-amd64-root.tar.gz": testImageData,
 	})
 	defer func() {
 		useTestImageData(nil)
 	}()
 
-	resp, err := s.downloadRequest(c, s.imageURL(c, "lxc", "trusty", "amd64"))
+	resp := s.downloadRequest(c, s.imageURL(c, "lxc", "trusty", "amd64"))
 	defer resp.Body.Close()
-	c.Assert(err, gc.IsNil)
 	s.assertErrorResponse(c, resp, http.StatusInternalServerError, ".* cannot find sha256 checksum .*")
 }
 
 func (s *imageSuite) testDownload(c *gc.C, resp *http.Response) []byte {
 	c.Check(resp.StatusCode, gc.Equals, http.StatusOK)
-	c.Check(resp.Header.Get("Digest"), gc.Equals, string(apihttp.DigestSHA)+"="+s.imageChecksum)
-	c.Check(resp.Header.Get("Content-Type"), gc.Equals, s.archiveContentType)
-	c.Check(resp.Header.Get("Content-Length"), gc.Equals, fmt.Sprintf("%v", len(s.imageData)))
+	c.Check(resp.Header.Get("Digest"), gc.Equals, string(apihttp.DigestSHA)+"="+testImageChecksum)
+	c.Check(resp.Header.Get("Content-Type"), gc.Equals, "application/x-tar-gz")
+	c.Check(resp.Header.Get("Content-Length"), gc.Equals, fmt.Sprintf("%v", len(testImageData)))
 
 	defer resp.Body.Close()
 	data, err := ioutil.ReadAll(resp.Body)
 	c.Assert(err, gc.IsNil)
 
-	c.Assert(data, gc.HasLen, len(s.imageData))
+	c.Assert(data, gc.HasLen, len(testImageData))
 
 	hash := sha256.New()
 	hash.Write(data)
-	c.Assert(fmt.Sprintf("%x", hash.Sum(nil)), gc.Equals, s.imageChecksum)
+	c.Assert(fmt.Sprintf("%x", hash.Sum(nil)), gc.Equals, testImageChecksum)
 	return data
 }
 
-func (s *imageSuite) downloadRequest(c *gc.C, url *url.URL) (*http.Response, error) {
+func (s *imageSuite) downloadRequest(c *gc.C, url *url.URL) *http.Response {
 	return s.sendRequest(c, httpRequestParams{method: "GET", url: url.String()})
 }
 
@@ -250,11 +239,11 @@ func (s *imageSuite) storeFakeImage(c *gc.C, st *state.State, kind, series, arch
 		Kind:      kind,
 		Series:    series,
 		Arch:      arch,
-		Size:      int64(len(s.imageData)),
-		SHA256:    s.imageChecksum,
+		Size:      int64(len(testImageData)),
+		SHA256:    testImageChecksum,
 		SourceURL: "http://path",
 	}
-	err := storage.AddImage(strings.NewReader(s.imageData), metadata)
+	err := storage.AddImage(strings.NewReader(testImageData), metadata)
 	c.Assert(err, gc.IsNil)
 }
 

--- a/apiserver/logsink_test.go
+++ b/apiserver/logsink_test.go
@@ -175,7 +175,7 @@ func (s *logsinkSuite) TestLogging(c *gc.C) {
 	}
 	for a := shortAttempt.Start(); a.Next(); {
 		for _, log := range s.logs.Log() {
-			c.Assert(log, jc.LessThan, loggo.ERROR)
+			c.Assert(log.Level, jc.LessThan, loggo.ERROR)
 		}
 	}
 

--- a/apiserver/tools_test.go
+++ b/apiserver/tools_test.go
@@ -32,19 +32,18 @@ import (
 )
 
 type toolsSuite struct {
-	userAuthHttpSuite
+	authHttpSuite
 	commontesting.BlockHelper
 }
 
 var _ = gc.Suite(&toolsSuite{})
 
 func (s *toolsSuite) SetUpSuite(c *gc.C) {
-	s.userAuthHttpSuite.SetUpSuite(c)
-	s.archiveContentType = "application/x-tar-gz"
+	s.authHttpSuite.SetUpSuite(c)
 }
 
 func (s *toolsSuite) SetUpTest(c *gc.C) {
-	s.userAuthHttpSuite.SetUpTest(c)
+	s.authHttpSuite.SetUpTest(c)
 	s.BlockHelper = commontesting.NewBlockHelper(s.APIState)
 	s.AddCleanup(func(*gc.C) { s.BlockHelper.Close() })
 }
@@ -52,19 +51,20 @@ func (s *toolsSuite) SetUpTest(c *gc.C) {
 func (s *toolsSuite) TestToolsUploadedSecurely(c *gc.C) {
 	info := s.APIInfo(c)
 	uri := "http://" + info.Addrs[0] + "/tools"
-	_, err := s.sendRequest(c, httpRequestParams{method: "PUT", url: uri})
-	c.Assert(err, gc.ErrorMatches, `.*malformed HTTP response.*`)
+	s.sendRequest(c, httpRequestParams{
+		method:      "PUT",
+		url:         uri,
+		expectError: `.*malformed HTTP response.*`,
+	})
 }
 
 func (s *toolsSuite) TestRequiresAuth(c *gc.C) {
-	resp, err := s.sendRequest(c, httpRequestParams{method: "GET", url: s.toolsURI(c, "")})
-	c.Assert(err, jc.ErrorIsNil)
+	resp := s.sendRequest(c, httpRequestParams{method: "GET", url: s.toolsURI(c, "")})
 	s.assertErrorResponse(c, resp, http.StatusUnauthorized, "no authorization header found")
 }
 
 func (s *toolsSuite) TestRequiresPOST(c *gc.C) {
-	resp, err := s.authRequest(c, httpRequestParams{method: "PUT", url: s.toolsURI(c, "")})
-	c.Assert(err, jc.ErrorIsNil)
+	resp := s.authRequest(c, httpRequestParams{method: "PUT", url: s.toolsURI(c, "")})
 	s.assertErrorResponse(c, resp, http.StatusMethodNotAllowed, `unsupported method: "PUT"`)
 }
 
@@ -79,19 +79,16 @@ func (s *toolsSuite) TestAuthRequiresUser(c *gc.C) {
 	err = machine.SetPassword(password)
 	c.Assert(err, jc.ErrorIsNil)
 
-	resp, err := s.sendRequest(c, httpRequestParams{tag: machine.Tag().String(), password: password, method: "POST", url: s.toolsURI(c, "")})
-	c.Assert(err, jc.ErrorIsNil)
+	resp := s.sendRequest(c, httpRequestParams{tag: machine.Tag().String(), password: password, method: "POST", url: s.toolsURI(c, "")})
 	s.assertErrorResponse(c, resp, http.StatusUnauthorized, "machine 0 not provisioned")
 
 	// Now try a user login.
-	resp, err = s.authRequest(c, httpRequestParams{method: "POST", url: s.toolsURI(c, "")})
-	c.Assert(err, jc.ErrorIsNil)
+	resp = s.authRequest(c, httpRequestParams{method: "POST", url: s.toolsURI(c, "")})
 	s.assertErrorResponse(c, resp, http.StatusBadRequest, "expected binaryVersion argument")
 }
 
 func (s *toolsSuite) TestUploadRequiresVersion(c *gc.C) {
-	resp, err := s.authRequest(c, httpRequestParams{method: "POST", url: s.toolsURI(c, "")})
-	c.Assert(err, jc.ErrorIsNil)
+	resp := s.authRequest(c, httpRequestParams{method: "POST", url: s.toolsURI(c, "")})
 	s.assertErrorResponse(c, resp, http.StatusBadRequest, "expected binaryVersion argument")
 }
 
@@ -100,8 +97,7 @@ func (s *toolsSuite) TestUploadFailsWithNoTools(c *gc.C) {
 	tempFile, err := ioutil.TempFile(c.MkDir(), "tools")
 	c.Assert(err, jc.ErrorIsNil)
 
-	resp, err := s.uploadRequest(c, s.toolsURI(c, "?binaryVersion=1.18.0-quantal-amd64"), true, tempFile.Name())
-	c.Assert(err, jc.ErrorIsNil)
+	resp := s.uploadRequest(c, s.toolsURI(c, "?binaryVersion=1.18.0-quantal-amd64"), "application/x-tar-gz", tempFile.Name())
 	s.assertErrorResponse(c, resp, http.StatusBadRequest, "no tools uploaded")
 }
 
@@ -111,8 +107,7 @@ func (s *toolsSuite) TestUploadFailsWithInvalidContentType(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Now try with the default Content-Type.
-	resp, err := s.uploadRequest(c, s.toolsURI(c, "?binaryVersion=1.18.0-quantal-amd64"), false, tempFile.Name())
-	c.Assert(err, jc.ErrorIsNil)
+	resp := s.uploadRequest(c, s.toolsURI(c, "?binaryVersion=1.18.0-quantal-amd64"), "application/octet-stream", tempFile.Name())
 	s.assertErrorResponse(
 		c, resp, http.StatusBadRequest, "expected Content-Type: application/x-tar-gz, got: application/octet-stream")
 }
@@ -130,9 +125,8 @@ func (s *toolsSuite) TestUpload(c *gc.C) {
 	// Make some fake tools.
 	expectedTools, vers, toolPath := s.setupToolsForUpload(c)
 	// Now try uploading them.
-	resp, err := s.uploadRequest(
-		c, s.toolsURI(c, "?binaryVersion="+vers.String()), true, toolPath)
-	c.Assert(err, jc.ErrorIsNil)
+	resp := s.uploadRequest(
+		c, s.toolsURI(c, "?binaryVersion="+vers.String()), "application/x-tar-gz", toolPath)
 
 	// Check the response.
 	expectedTools[0].URL = fmt.Sprintf("%s/environment/%s/tools/%s", s.baseURL(c), s.State.EnvironUUID(), vers)
@@ -151,9 +145,8 @@ func (s *toolsSuite) TestBlockUpload(c *gc.C) {
 	// Block all changes.
 	s.BlockAllChanges(c, "TestUpload")
 	// Now try uploading them.
-	resp, err := s.uploadRequest(
-		c, s.toolsURI(c, "?binaryVersion="+vers.String()), true, toolPath)
-	c.Assert(err, jc.ErrorIsNil)
+	resp := s.uploadRequest(
+		c, s.toolsURI(c, "?binaryVersion="+vers.String()), "application/x-tar-gz", toolPath)
 	problem := s.assertErrorResponse(c, resp, http.StatusBadRequest, "TestUpload")
 	s.AssertBlocked(c, problem, "TestUpload")
 
@@ -171,8 +164,7 @@ func (s *toolsSuite) TestUploadAllowsTopLevelPath(c *gc.C) {
 	expectedTools, vers, toolPath := s.setupToolsForUpload(c)
 	url := s.toolsURL(c, "binaryVersion="+vers.String())
 	url.Path = "/tools"
-	resp, err := s.uploadRequest(c, url.String(), true, toolPath)
-	c.Assert(err, jc.ErrorIsNil)
+	resp := s.uploadRequest(c, url.String(), "application/x-tar-gz", toolPath)
 	// Check the response.
 	expectedTools[0].URL = fmt.Sprintf("%s/environment/%s/tools/%s", s.baseURL(c), s.State.EnvironUUID(), vers)
 	s.assertUploadResponse(c, resp, expectedTools[0])
@@ -183,8 +175,7 @@ func (s *toolsSuite) TestUploadAllowsEnvUUIDPath(c *gc.C) {
 	expectedTools, vers, toolPath := s.setupToolsForUpload(c)
 	url := s.toolsURL(c, "binaryVersion="+vers.String())
 	url.Path = fmt.Sprintf("/environment/%s/tools", s.State.EnvironUUID())
-	resp, err := s.uploadRequest(c, url.String(), true, toolPath)
-	c.Assert(err, jc.ErrorIsNil)
+	resp := s.uploadRequest(c, url.String(), "application/x-tar-gz", toolPath)
 	// Check the response.
 	expectedTools[0].URL = fmt.Sprintf("%s/environment/%s/tools/%s", s.baseURL(c), s.State.EnvironUUID(), vers)
 	s.assertUploadResponse(c, resp, expectedTools[0])
@@ -196,8 +187,7 @@ func (s *toolsSuite) TestUploadAllowsOtherEnvUUIDPath(c *gc.C) {
 	expectedTools, vers, toolPath := s.setupToolsForUpload(c)
 	url := s.toolsURL(c, "binaryVersion="+vers.String())
 	url.Path = fmt.Sprintf("/environment/%s/tools", envState.EnvironUUID())
-	resp, err := s.uploadRequest(c, url.String(), true, toolPath)
-	c.Assert(err, jc.ErrorIsNil)
+	resp := s.uploadRequest(c, url.String(), "application/x-tar-gz", toolPath)
 	// Check the response.
 	expectedTools[0].URL = fmt.Sprintf("%s/environment/%s/tools/%s", s.baseURL(c), envState.EnvironUUID(), vers)
 	s.assertUploadResponse(c, resp, expectedTools[0])
@@ -207,8 +197,7 @@ func (s *toolsSuite) TestUploadRejectsWrongEnvUUIDPath(c *gc.C) {
 	// Check that we cannot access the tools at https://host:port/BADENVUUID/tools
 	url := s.toolsURL(c, "")
 	url.Path = "/environment/dead-beef-123456/tools"
-	resp, err := s.authRequest(c, httpRequestParams{method: "POST", url: url.String()})
-	c.Assert(err, jc.ErrorIsNil)
+	resp := s.authRequest(c, httpRequestParams{method: "POST", url: url.String()})
 	s.assertErrorResponse(c, resp, http.StatusNotFound, `unknown environment: "dead-beef-123456"`)
 }
 
@@ -218,8 +207,7 @@ func (s *toolsSuite) TestUploadSeriesExpanded(c *gc.C) {
 	// Now try uploading them. The tools will be cloned for
 	// each additional series specified.
 	params := "?binaryVersion=" + vers.String() + "&series=quantal,precise"
-	resp, err := s.uploadRequest(c, s.toolsURI(c, params), true, toolPath)
-	c.Assert(err, jc.ErrorIsNil)
+	resp := s.uploadRequest(c, s.toolsURI(c, params), "application/x-tar-gz", toolPath)
 	c.Assert(resp.StatusCode, gc.Equals, http.StatusOK)
 
 	// Check the response.
@@ -303,8 +291,7 @@ func (s *toolsSuite) TestDownloadFetchesAndVerifiesSize(c *gc.C) {
 	err := stor.Put(envtools.StorageName(tools.Version, "released"), strings.NewReader("!"), 1)
 	c.Assert(err, jc.ErrorIsNil)
 
-	resp, err := s.downloadRequest(c, tools.Version, "")
-	c.Assert(err, jc.ErrorIsNil)
+	resp := s.downloadRequest(c, tools.Version, "")
 	s.assertErrorResponse(c, resp, http.StatusBadRequest, "error fetching tools: size mismatch for .*")
 	s.assertToolsNotStored(c, tools.Version)
 }
@@ -319,8 +306,7 @@ func (s *toolsSuite) TestDownloadFetchesAndVerifiesHash(c *gc.C) {
 	err := stor.Put(envtools.StorageName(tools.Version, "released"), strings.NewReader(sameSize), tools.Size)
 	c.Assert(err, jc.ErrorIsNil)
 
-	resp, err := s.downloadRequest(c, tools.Version, "")
-	c.Assert(err, jc.ErrorIsNil)
+	resp := s.downloadRequest(c, tools.Version, "")
 	s.assertErrorResponse(c, resp, http.StatusBadRequest, "error fetching tools: hash mismatch for .*")
 	s.assertToolsNotStored(c, tools.Version)
 }
@@ -359,8 +345,7 @@ func (s *toolsSuite) assertToolsNotStored(c *gc.C, vers version.Binary) {
 }
 
 func (s *toolsSuite) testDownload(c *gc.C, tools *coretools.Tools, uuid string) []byte {
-	resp, err := s.downloadRequest(c, tools.Version, uuid)
-	c.Assert(err, jc.ErrorIsNil)
+	resp := s.downloadRequest(c, tools.Version, uuid)
 	defer resp.Body.Close()
 	data, err := ioutil.ReadAll(resp.Body)
 	c.Assert(err, jc.ErrorIsNil)
@@ -373,8 +358,7 @@ func (s *toolsSuite) testDownload(c *gc.C, tools *coretools.Tools, uuid string) 
 }
 
 func (s *toolsSuite) TestDownloadRejectsWrongEnvUUIDPath(c *gc.C) {
-	resp, err := s.downloadRequest(c, version.Current, "dead-beef-123456")
-	c.Assert(err, jc.ErrorIsNil)
+	resp := s.downloadRequest(c, version.Current, "dead-beef-123456")
 	s.assertErrorResponse(c, resp, http.StatusNotFound, `unknown environment: "dead-beef-123456"`)
 }
 
@@ -392,7 +376,7 @@ func (s *toolsSuite) toolsURI(c *gc.C, query string) string {
 	return s.toolsURL(c, query).String()
 }
 
-func (s *toolsSuite) downloadRequest(c *gc.C, version version.Binary, uuid string) (*http.Response, error) {
+func (s *toolsSuite) downloadRequest(c *gc.C, version version.Binary, uuid string) *http.Response {
 	url := s.toolsURL(c, "")
 	if uuid == "" {
 		url.Path = fmt.Sprintf("/tools/%s", version)
@@ -424,6 +408,6 @@ func (s *toolsSuite) assertErrorResponse(c *gc.C, resp *http.Response, expCode i
 
 func jsonToolsResponse(c *gc.C, body []byte) (jsonResponse params.ToolsResult) {
 	err := json.Unmarshal(body, &jsonResponse)
-	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(err, jc.ErrorIsNil, gc.Commentf("body: %s", body))
 	return
 }

--- a/cmd/juju/system/login.go
+++ b/cmd/juju/system/login.go
@@ -123,6 +123,7 @@ func (c *loginCommand) Run(ctx *cmd.Context) error {
 	if c.loginAPIOpen == nil {
 		c.loginAPIOpen = c.JujuCommandBase.APIOpen
 	}
+
 	// TODO(thumper): as we support the user and address
 	// change this check here.
 	if c.Server.Path == "" {
@@ -167,7 +168,12 @@ func (c *loginCommand) Run(ctx *cmd.Context) error {
 	if serverDetails.Password == "" || serverDetails.Username == "" {
 		info.UseMacaroons = true
 	}
-
+	if c == nil {
+		panic("nil c")
+	}
+	if c.loginAPIOpen == nil {
+		panic("no loginAPIOpen")
+	}
 	apiState, err := c.loginAPIOpen(&info, api.DefaultDialOpts())
 	if err != nil {
 		return errors.Trace(err)

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -25,9 +25,9 @@ github.com/juju/ratelimit	git	aa5bb718d4d435629821789cb90970319f57bfe5	2015-03-3
 github.com/juju/replicaset	git	fb7294cf57a1e2f08a57691f1246d129a87ab7e8	2015-05-08T02:21:43Z
 github.com/juju/schema	git	afe1151cb49d1d7ed3c75592dfc6f38703f2e988	2015-08-07T07:58:08Z
 github.com/juju/syslog	git	6be94e8b718766e9ff7a37342157fe4795da7cfa	2015-02-05T15:59:36Z
-github.com/juju/testing	git	31ee64312c3c64cc94a5b41ea7a200b42e0f9767	2015-09-02T15:44:51Z
+github.com/juju/testing	git	c037f3a0fdf849ffcaa30f88d7b94f93e0a01eb8	2015-09-29T11:36:52Z
 github.com/juju/txn	git	99ec629d0066a4d73c54d8e021a7fc1dc07df614	2015-06-09T16:58:27Z
-github.com/juju/utils	git	49519612df1b9156f8a42862c4ec2c47a041fff2	2015-09-10T03:07:18Z
+github.com/juju/utils	git	49519612df1b9156f8a42862c4ec2c47a041fff2	2015-09-18T10:18:29Z
 github.com/juju/xml	git	eb759a627588d35166bc505fceb51b88500e291e	2015-04-13T13:11:21Z
 github.com/julienschmidt/httprouter	git	109e267447e95ad1bb48b758e40dd7453eb7b039	2015-09-05T17:25:33Z
 golang.org/x/crypto	git	aedad9a179ec1ea11b7064c57cbc6dc30d7724ec	2015-08-30T18:06:42Z
@@ -44,7 +44,7 @@ gopkg.in/juju/charmrepo.v1	git	8677b12d9772a2a596a99e65b7e6f642fceb6c40	2015-09-
 gopkg.in/juju/charmstore.v5-unstable	git	a921c6c69d74361c38a99a95d2aceec76533038d	2015-08-27T20:19:40Z
 gopkg.in/juju/environschema.v1	git	16cc59268c09c22870cb4de8eb6248652535f315	2015-08-24T13:22:26Z
 gopkg.in/juju/jujusvg.v1	git	3eedb1c722ece2b66d62508368ca3e8b7f916569	2015-05-20T11:48:32Z
-gopkg.in/macaroon-bakery.v1	git	6026426dd8f67594d00f5b5348ac92bf71741b98	2015-09-24T17:23:52Z
+gopkg.in/macaroon-bakery.v1	git	90436b1313cd9f4923a26319ef46eaabe3aeb756	2015-09-29T09:13:38Z
 gopkg.in/macaroon.v1	git	ab3940c6c16510a850e1c2dd628b919f0f3f1464	2015-01-21T11:42:31Z
 gopkg.in/mgo.v2	git	3569c88678d88179dcbd68d02ab081cbca3cd4d0	2015-06-04T15:26:27Z
 gopkg.in/natefinch/lumberjack.v2	git	588a21fb0fa0ebdfde42670fa214576b6f0f22df	2015-05-21T01:59:18Z


### PR DESCRIPTION
We combine userAuthHttpSuite into authHttpSuite and add functionality for macaroon auth. This means that we can have a common charms suite that can use either macaroon or normal auth.

We also make use of httptesting.Do to make requests rather than duplicate more of its functionality here.

We change authRequest and sendRequest to not return an error (matching httptesting.Do) but have an expectError instead. Since almost all of the calls to these methods expected a nil error, this is a win.

We also change a couple of suite instance variables to constants because things are simpler that way.

(Review request: http://reviews.vapour.ws/r/2794/)