### PR TITLE
upgrades: introduce environ config upgrades

### DIFF
--- a/environs/boilerplate_config.go
+++ b/environs/boilerplate_config.go
@@ -96,7 +96,11 @@ func randomKey() string {
 func BoilerplateConfig() string {
 	configBuff := new(bytes.Buffer)
 	configBuff.WriteString(configHeader)
-	for name, p := range providers {
+	for _, name := range GlobalProviderRegistry().RegisteredProviders() {
+		p, err := GlobalProviderRegistry().Provider(name)
+		if err != nil {
+			panic(err)
+		}
 		t, err := parseTemplate(p.BoilerplateConfig())
 		if err != nil {
 			panic(fmt.Errorf("cannot parse boilerplate from %s: %v", name, err))

--- a/environs/config.go
+++ b/environs/config.go
@@ -172,8 +172,16 @@ func (envs *Environs) logDeprecatedWarnings(attrs, newAttrs map[string]interface
 // ProviderRegistry is an interface that provides methods for registering
 // and obtaining environment providers by provider name.
 type ProviderRegistry interface {
+	// RegisterProvider registers a new environment provider with the given
+	// name, and zero or more aliases. If a provider already exists with the
+	// given name or alias, an error will be returned.
 	RegisterProvider(p EnvironProvider, providerType string, providerTypeAliases ...string) error
+
+	// RegisteredProviders returns the names of the registered environment
+	// providers.
 	RegisteredProviders() []string
+
+	// Provider returns the environment provider with the specified name.
 	Provider(providerType string) (EnvironProvider, error)
 }
 

--- a/environs/config.go
+++ b/environs/config.go
@@ -169,16 +169,64 @@ func (envs *Environs) logDeprecatedWarnings(attrs, newAttrs map[string]interface
 	}
 }
 
-// providers maps from provider type to EnvironProvider for
-// each registered provider type.
-//
-// providers should not typically be used directly; the
-// Provider function will handle provider type aliases,
-// and should be used instead.
-var providers = make(map[string]EnvironProvider)
+// ProviderRegistry is an interface that provides methods for registering
+// and obtaining environment providers by provider name.
+type ProviderRegistry interface {
+	RegisterProvider(p EnvironProvider, providerType string, providerTypeAliases ...string) error
+	RegisteredProviders() []string
+	Provider(providerType string) (EnvironProvider, error)
+}
 
-// providerAliases is a map of provider type aliases.
-var providerAliases = make(map[string]string)
+// GlobalProviderRegistry returns the global provider registry.
+func GlobalProviderRegistry() ProviderRegistry {
+	return globalProviders
+}
+
+type globalProviderRegistry struct {
+	// providers maps from provider type to EnvironProvider for
+	// each registered provider type.
+	providers map[string]EnvironProvider
+	// providerAliases is a map of provider type aliases.
+	aliases map[string]string
+}
+
+var globalProviders = &globalProviderRegistry{
+	providers: map[string]EnvironProvider{},
+	aliases:   map[string]string{},
+}
+
+func (r *globalProviderRegistry) RegisterProvider(p EnvironProvider, providerType string, providerTypeAliases ...string) error {
+	if r.providers[providerType] != nil || r.aliases[providerType] != "" {
+		return errors.Errorf("duplicate provider name %q", providerType)
+	}
+	r.providers[providerType] = p
+	for _, alias := range providerTypeAliases {
+		if r.providers[alias] != nil || r.aliases[alias] != "" {
+			return errors.Errorf("duplicate provider alias %q", alias)
+		}
+		r.aliases[alias] = providerType
+	}
+	return nil
+}
+
+func (r *globalProviderRegistry) RegisteredProviders() []string {
+	var p []string
+	for k := range r.providers {
+		p = append(p, k)
+	}
+	return p
+}
+
+func (r *globalProviderRegistry) Provider(providerType string) (EnvironProvider, error) {
+	if alias, ok := r.aliases[providerType]; ok {
+		providerType = alias
+	}
+	p, ok := r.providers[providerType]
+	if !ok {
+		return nil, errors.Errorf("no registered provider for %q", providerType)
+	}
+	return p, nil
+}
 
 // RegisterProvider registers a new environment provider. Name gives the name
 // of the provider, and p the interface to that provider.
@@ -186,37 +234,19 @@ var providerAliases = make(map[string]string)
 // RegisterProvider will panic if the provider name or any of the aliases
 // are registered more than once.
 func RegisterProvider(name string, p EnvironProvider, alias ...string) {
-	if providers[name] != nil || providerAliases[name] != "" {
-		panic(errors.Errorf("juju: duplicate provider name %q", name))
-	}
-	providers[name] = p
-	for _, alias := range alias {
-		if providers[alias] != nil || providerAliases[alias] != "" {
-			panic(errors.Errorf("juju: duplicate provider alias %q", alias))
-		}
-		providerAliases[alias] = name
+	if err := GlobalProviderRegistry().RegisterProvider(p, name, alias...); err != nil {
+		panic(fmt.Errorf("juju: %v", err))
 	}
 }
 
 // RegisteredProviders enumerate all the environ providers which have been registered.
 func RegisteredProviders() []string {
-	var p []string
-	for k := range providers {
-		p = append(p, k)
-	}
-	return p
+	return GlobalProviderRegistry().RegisteredProviders()
 }
 
 // Provider returns the previously registered provider with the given type.
 func Provider(providerType string) (EnvironProvider, error) {
-	if alias, ok := providerAliases[providerType]; ok {
-		providerType = alias
-	}
-	p, ok := providers[providerType]
-	if !ok {
-		return nil, errors.Errorf("no registered provider for %q", providerType)
-	}
-	return p, nil
+	return GlobalProviderRegistry().Provider(providerType)
 }
 
 // ReadEnvironsBytes parses the contents of an environments.yaml file

--- a/environs/export_test.go
+++ b/environs/export_test.go
@@ -4,8 +4,8 @@
 package environs
 
 var (
-	Providers       = &providers
-	ProviderAliases = &providerAliases
+	Providers       = &globalProviders.providers
+	ProviderAliases = &globalProviders.aliases
 )
 
 func UpdateEnvironAttrs(envs *Environs, name string, newAttrs map[string]interface{}) {

--- a/environs/interface.go
+++ b/environs/interface.go
@@ -69,8 +69,8 @@ type EnvironProvider interface {
 // EnvironConfigUpgrader is an interface that an EnvironProvider may
 // implement in order to modify environment configuration on agent upgrade.
 type EnvironConfigUpgrader interface {
-	// UpgradeConfig returns the attributes to update and remove attributes
-	// from the environment configuration. UpgradeConfig must be idempotent,
+	// UpgradeConfig upgrades an old environment configuration by adding,
+	// updating or removing attributes. UpgradeConfig must be idempotent,
 	// as it may be called multiple times in the event of a partial upgrade.
 	//
 	// NOTE(axw) this is currently only called when upgrading to 1.25.

--- a/environs/interface.go
+++ b/environs/interface.go
@@ -66,6 +66,20 @@ type EnvironProvider interface {
 	SecretAttrs(cfg *config.Config) (map[string]string, error)
 }
 
+// EnvironConfigUpgrader is an interface that an EnvironProvider may
+// implement in order to modify environment configuration on agent upgrade.
+type EnvironConfigUpgrader interface {
+	// UpgradeConfig returns the attributes to update and remove attributes
+	// from the environment configuration. UpgradeConfig must be idempotent,
+	// as it may be called multiple times in the event of a partial upgrade.
+	//
+	// NOTE(axw) this is currently only called when upgrading to 1.25.
+	// We should update the upgrade machinery to call this for every
+	// version upgrade, so the upgrades package is not tightly coupled
+	// to provider upgrades.
+	UpgradeConfig(cfg *config.Config) (*config.Config, error)
+}
+
 // EnvironStorage implements storage access for an environment.
 type EnvironStorage interface {
 	// Storage returns storage specific to the environment.

--- a/provider/gce/disks.go
+++ b/provider/gce/disks.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	GCEProviderType = storage.ProviderType("gce")
+	storageProviderType = storage.ProviderType("gce")
 )
 
 func init() {

--- a/provider/gce/disks_test.go
+++ b/provider/gce/disks_test.go
@@ -84,7 +84,7 @@ func (s *volumeSourceSuite) SetUpTest(c *gc.C) {
 	s.instId = inst.Id()
 	s.attachmentParams = &storage.VolumeAttachmentParams{
 		AttachmentParams: storage.AttachmentParams{
-			Provider:   gce.GCEProviderType,
+			Provider:   "gce",
 			Machine:    mTag,
 			InstanceId: s.instId,
 		},
@@ -94,7 +94,7 @@ func (s *volumeSourceSuite) SetUpTest(c *gc.C) {
 	s.params = []storage.VolumeParams{{
 		Tag:        vTag,
 		Size:       1024,
-		Provider:   gce.GCEProviderType,
+		Provider:   "gce",
 		Attachment: s.attachmentParams,
 	}}
 

--- a/provider/gce/init.go
+++ b/provider/gce/init.go
@@ -16,8 +16,8 @@ func init() {
 	environs.RegisterProvider(providerType, providerInstance)
 
 	// Register the GCE specific providers.
-	registry.RegisterProvider(GCEProviderType, &storageProvider{})
+	registry.RegisterProvider(storageProviderType, &storageProvider{})
 
 	// Inform the storage provider registry about the GCE providers.
-	registry.RegisterEnvironStorageProviders(providerType, GCEProviderType)
+	registry.RegisterEnvironStorageProviders(providerType, storageProviderType)
 }

--- a/provider/gce/provider.go
+++ b/provider/gce/provider.go
@@ -40,8 +40,25 @@ func (p environProvider) PrepareForBootstrap(ctx environs.BootstrapContext, cfg 
 }
 
 // PrepareForCreateEnvironment is specified in the EnvironProvider interface.
-func (environProvider) PrepareForCreateEnvironment(cfg *config.Config) (*config.Config, error) {
-	return cfg, nil
+func (p environProvider) PrepareForCreateEnvironment(cfg *config.Config) (*config.Config, error) {
+	return configWithDefaults(cfg)
+}
+
+// UpgradeEnvironConfig is specified in the EnvironConfigUpgrader interface.
+func (environProvider) UpgradeConfig(cfg *config.Config) (*config.Config, error) {
+	return configWithDefaults(cfg)
+}
+
+func configWithDefaults(cfg *config.Config) (*config.Config, error) {
+	defaults := make(map[string]interface{})
+	if _, ok := cfg.StorageDefaultBlockSource(); !ok {
+		// Set the default block source.
+		defaults[config.StorageDefaultBlockSourceKey] = storageProviderType
+	}
+	if len(defaults) == 0 {
+		return cfg, nil
+	}
+	return cfg.Apply(defaults)
 }
 
 // RestrictedConfigAttributes is specified in the EnvironProvider interface.

--- a/provider/gce/provider_test.go
+++ b/provider/gce/provider_test.go
@@ -105,3 +105,17 @@ gce:
 `[1:]
 	c.Assert(s.provider.BoilerplateConfig(), gc.Equals, boilerplateConfig)
 }
+
+func (s *providerSuite) TestUpgradeConfig(c *gc.C) {
+	c.Assert(s.provider, gc.Implements, new(environs.EnvironConfigUpgrader))
+	upgrader := s.provider.(environs.EnvironConfigUpgrader)
+
+	_, ok := s.Config.StorageDefaultBlockSource()
+	c.Assert(ok, jc.IsFalse)
+
+	outConfig, err := upgrader.UpgradeConfig(s.Config)
+	c.Assert(err, jc.ErrorIsNil)
+	source, ok := outConfig.StorageDefaultBlockSource()
+	c.Assert(ok, jc.IsTrue)
+	c.Assert(source, gc.Equals, "gce")
+}

--- a/upgrades/environconfig.go
+++ b/upgrades/environconfig.go
@@ -1,0 +1,65 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades
+
+import (
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/state"
+)
+
+// environConfigUpdater is an interface used atomically write environment
+// config changes to the global state.
+type environConfigUpdater interface {
+	// UpdateEnvironConfig atomically updates and removes environment
+	// config attributes to the global state.
+	UpdateEnvironConfig(map[string]interface{}, []string, state.ValidateConfigFunc) error
+}
+
+// environConfigReader is an interface used to read the current environment
+// config from global state.
+type environConfigReader interface {
+	// EnvironConfig reads the current environment config from global
+	// state.
+	EnvironConfig() (*config.Config, error)
+}
+
+func upgradeEnvironConfig(
+	reader environConfigReader,
+	updater environConfigUpdater,
+	registry environs.ProviderRegistry,
+) error {
+	cfg, err := reader.EnvironConfig()
+	if err != nil {
+		return errors.Annotate(err, "reading environment config")
+	}
+	provider, err := registry.Provider(cfg.Type())
+	if err != nil {
+		return errors.Annotate(err, "getting provider")
+	}
+
+	upgrader, ok := provider.(environs.EnvironConfigUpgrader)
+	if !ok {
+		logger.Debugf("provider %q has no upgrades", cfg.Type())
+		return nil
+	}
+	newCfg, err := upgrader.UpgradeConfig(cfg)
+	if err != nil {
+		return errors.Annotate(err, "upgrading config")
+	}
+
+	newAttrs := newCfg.AllAttrs()
+	var removedAttrs []string
+	for key := range cfg.AllAttrs() {
+		if _, ok := newAttrs[key]; !ok {
+			removedAttrs = append(removedAttrs, key)
+		}
+	}
+	if err := updater.UpdateEnvironConfig(newAttrs, removedAttrs, nil); err != nil {
+		return errors.Annotate(err, "updating config in state")
+	}
+	return nil
+}

--- a/upgrades/environconfig_test.go
+++ b/upgrades/environconfig_test.go
@@ -1,0 +1,171 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades_test
+
+import (
+	"errors"
+
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/state"
+	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/upgrades"
+)
+
+type upgradeEnvironConfigSuite struct {
+	coretesting.BaseSuite
+	stub     testing.Stub
+	cfg      *config.Config
+	reader   upgrades.EnvironConfigReader
+	updater  upgrades.EnvironConfigUpdater
+	registry *mockProviderRegistry
+}
+
+var _ = gc.Suite(&upgradeEnvironConfigSuite{})
+
+func (s *upgradeEnvironConfigSuite) SetUpSuite(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+}
+
+func (s *upgradeEnvironConfigSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+
+	s.stub = testing.Stub{}
+	s.cfg = coretesting.EnvironConfig(c)
+	s.registry = &mockProviderRegistry{
+		providers: make(map[string]environs.EnvironProvider),
+	}
+
+	s.reader = environConfigFunc(func() (*config.Config, error) {
+		s.stub.AddCall("EnvironConfig")
+		return s.cfg, s.stub.NextErr()
+	})
+
+	s.updater = updateEnvironConfigFunc(func(
+		update map[string]interface{}, remove []string, validate state.ValidateConfigFunc,
+	) error {
+		s.stub.AddCall("UpdateEnvironConfig", update, remove, validate)
+		return s.stub.NextErr()
+	})
+}
+
+func (s *upgradeEnvironConfigSuite) TestUpgradeEnvironConfigEnvironConfigError(c *gc.C) {
+	s.stub.SetErrors(errors.New("cannot read environ config"))
+	err := upgrades.UpgradeEnvironConfig(s.reader, s.updater, s.registry)
+	c.Assert(err, gc.ErrorMatches, "reading environment config: cannot read environ config")
+	s.stub.CheckCallNames(c, "EnvironConfig")
+}
+
+func (s *upgradeEnvironConfigSuite) TestUpgradeEnvironConfigProviderNotRegistered(c *gc.C) {
+	s.registry.SetErrors(errors.New(`no registered provider for "someprovider"`))
+	err := upgrades.UpgradeEnvironConfig(s.reader, s.updater, s.registry)
+	c.Assert(err, gc.ErrorMatches, `getting provider: no registered provider for "someprovider"`)
+	s.stub.CheckCallNames(c, "EnvironConfig")
+}
+
+func (s *upgradeEnvironConfigSuite) TestUpgradeEnvironConfigProviderNotConfigUpgrader(c *gc.C) {
+	s.registry.providers["someprovider"] = &mockEnvironProvider{}
+	err := upgrades.UpgradeEnvironConfig(s.reader, s.updater, s.registry)
+	c.Assert(err, jc.ErrorIsNil)
+	s.registry.CheckCalls(c, []testing.StubCall{{
+		FuncName: "Provider", Args: []interface{}{"someprovider"},
+	}})
+	s.stub.CheckCallNames(c, "EnvironConfig")
+}
+
+func (s *upgradeEnvironConfigSuite) TestUpgradeEnvironConfigProviderConfigUpgrader(c *gc.C) {
+	var err error
+	s.cfg, err = s.cfg.Apply(map[string]interface{}{"test-key": "test-value"})
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.registry.providers["someprovider"] = &mockEnvironConfigUpgrader{
+		upgradeConfig: func(cfg *config.Config) (*config.Config, error) {
+			return cfg.Remove([]string{"test-key"})
+		},
+	}
+	err = upgrades.UpgradeEnvironConfig(s.reader, s.updater, s.registry)
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.stub.CheckCallNames(c, "EnvironConfig", "UpdateEnvironConfig")
+	updateCall := s.stub.Calls()[1]
+	expectedAttrs := s.cfg.AllAttrs()
+	delete(expectedAttrs, "test-key")
+	c.Assert(updateCall.Args, gc.HasLen, 3)
+	c.Assert(updateCall.Args[0], jc.DeepEquals, expectedAttrs)
+	c.Assert(updateCall.Args[1], jc.SameContents, []string{"test-key"})
+	c.Assert(updateCall.Args[2], gc.IsNil)
+}
+
+func (s *upgradeEnvironConfigSuite) TestUpgradeEnvironConfigUpgradeConfigError(c *gc.C) {
+	s.registry.providers["someprovider"] = &mockEnvironConfigUpgrader{
+		upgradeConfig: func(cfg *config.Config) (*config.Config, error) {
+			return nil, errors.New("cannot upgrade config")
+		},
+	}
+	err := upgrades.UpgradeEnvironConfig(s.reader, s.updater, s.registry)
+	c.Assert(err, gc.ErrorMatches, "upgrading config: cannot upgrade config")
+	s.stub.CheckCallNames(c, "EnvironConfig")
+}
+
+func (s *upgradeEnvironConfigSuite) TestUpgradeEnvironConfigUpdateConfigError(c *gc.C) {
+	s.stub.SetErrors(nil, errors.New("cannot update environ config"))
+	s.registry.providers["someprovider"] = &mockEnvironConfigUpgrader{
+		upgradeConfig: func(cfg *config.Config) (*config.Config, error) {
+			return cfg, nil
+		},
+	}
+	err := upgrades.UpgradeEnvironConfig(s.reader, s.updater, s.registry)
+	c.Assert(err, gc.ErrorMatches, "updating config in state: cannot update environ config")
+
+	s.stub.CheckCallNames(c, "EnvironConfig", "UpdateEnvironConfig")
+	updateCall := s.stub.Calls()[1]
+	c.Assert(updateCall.Args, gc.HasLen, 3)
+	c.Assert(updateCall.Args[0], jc.DeepEquals, s.cfg.AllAttrs())
+	c.Assert(updateCall.Args[1], gc.IsNil)
+	c.Assert(updateCall.Args[2], gc.IsNil)
+}
+
+type environConfigFunc func() (*config.Config, error)
+
+func (f environConfigFunc) EnvironConfig() (*config.Config, error) {
+	return f()
+}
+
+type updateEnvironConfigFunc func(map[string]interface{}, []string, state.ValidateConfigFunc) error
+
+func (f updateEnvironConfigFunc) UpdateEnvironConfig(
+	update map[string]interface{}, remove []string, validate state.ValidateConfigFunc,
+) error {
+	return f(update, remove, validate)
+}
+
+type mockProviderRegistry struct {
+	environs.ProviderRegistry
+	testing.Stub
+	providers map[string]environs.EnvironProvider
+}
+
+func (r *mockProviderRegistry) Provider(name string) (environs.EnvironProvider, error) {
+	r.MethodCall(r, "Provider", name)
+	return r.providers[name], r.NextErr()
+}
+
+type mockEnvironProvider struct {
+	testing.Stub
+	environs.EnvironProvider
+}
+
+type mockEnvironConfigUpgrader struct {
+	mockEnvironProvider
+	upgradeConfig func(*config.Config) (*config.Config, error)
+}
+
+func (u *mockEnvironConfigUpgrader) UpgradeConfig(cfg *config.Config) (*config.Config, error) {
+	u.MethodCall(u, "UpgradeConfig", cfg)
+	return u.upgradeConfig(cfg)
+}

--- a/upgrades/export_test.go
+++ b/upgrades/export_test.go
@@ -3,6 +3,8 @@
 
 package upgrades
 
+import "github.com/juju/juju/environs"
+
 var (
 	UpgradeOperations         = &upgradeOperations
 	StateUpgradeOperations    = &stateUpgradeOperations
@@ -54,3 +56,14 @@ var (
 	RemoveJujudpass = removeJujudpass
 	AddJujuRegKey   = addJujuRegKey
 )
+
+type EnvironConfigUpdater environConfigUpdater
+type EnvironConfigReader environConfigReader
+
+func UpgradeEnvironConfig(
+	reader EnvironConfigReader,
+	updater EnvironConfigUpdater,
+	registry environs.ProviderRegistry,
+) error {
+	return upgradeEnvironConfig(reader, updater, registry)
+}

--- a/upgrades/steps125.go
+++ b/upgrades/steps125.go
@@ -96,6 +96,16 @@ func stateStepsFor125() []Step {
 			run: func(context Context) error {
 				return state.MigrateLastLoginAndLastConnection(context.State())
 			}},
+		&upgradeStep{
+			description: "upgrade environment config",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				// TODO(axw) updateEnvironConfig should be
+				// called for all upgrades, to decouple this
+				// package from provider-specific upgrades.
+				st := context.State()
+				return upgradeEnvironConfig(st, st, environs.GlobalProviderRegistry())
+			}},
 	}
 }
 

--- a/upgrades/steps125_test.go
+++ b/upgrades/steps125_test.go
@@ -36,6 +36,7 @@ func (s *steps125Suite) TestStateStepsFor125(c *gc.C) {
 		"add binding to filesystem",
 		"add status to volume",
 		"move lastlogin and last connection to their own collections",
+		"upgrade environment config",
 	}
 	assertStateSteps(c, version.MustParse("1.25.0"), expected)
 }

--- a/upgrades/steps126.go
+++ b/upgrades/steps126.go
@@ -4,6 +4,7 @@
 package upgrades
 
 import (
+	"github.com/juju/juju/environs"
 	"github.com/juju/juju/state"
 )
 
@@ -27,6 +28,17 @@ func stateStepsFor126() []Step {
 			targets:     []Target{DatabaseMaster},
 			run: func(context Context) error {
 				return state.AddFilesystemStatus(context.State())
+			},
+		},
+		&upgradeStep{
+			description: "upgrade environment config",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				// TODO(axw) updateEnvironConfig should be
+				// called for all upgrades, to decouple this
+				// package from provider-specific upgrades.
+				st := context.State()
+				return upgradeEnvironConfig(st, st, environs.GlobalProviderRegistry())
 			},
 		},
 	}

--- a/upgrades/steps126_test.go
+++ b/upgrades/steps126_test.go
@@ -25,6 +25,7 @@ func (s *steps126Suite) TestStateStepsFor126(c *gc.C) {
 	expected := []string{
 		"add the version field to all settings docs",
 		"add status to filesystem",
+		"upgrade environment config",
 	}
 	assertStateSteps(c, version.MustParse("1.26.0"), expected)
 }


### PR DESCRIPTION
Introduce a new interface, environs.EnvironConfigUpgrader,
which an EnvironProvider can implement to provide it an
opportunity to alter environment config on upgrade. This
is currently only run on upgrade to 1.25, but the intention
is to have it run on any version upgrade when we need to
use it again. This should replace any use of Validate to
upgrade config.

Provider registration has been extracted into another new
interface, environs.ProviderRegistry, with the existing
functions redirected to a global provider registry object.
This was done to simplify testing of code that involves
environment provider lookup.

The GCE provider is modified to set the default block
source on bootstrap, and also on upgrade.

Fixes https://bugs.launchpad.net/juju-core/+bug/1500769

(Review request: http://reviews.vapour.ws/r/2795/)