### PR TITLE
Meter status manifold and worker.

### DIFF
--- a/api/meterstatus/client.go
+++ b/api/meterstatus/client.go
@@ -25,7 +25,7 @@ type MeterStatusClient interface {
 }
 
 // NewClient creates a new client for accessing the MeterStatus API.
-func NewClient(caller base.APICaller, tag names.UnitTag) *Client {
+func NewClient(caller base.APICaller, tag names.UnitTag) MeterStatusClient {
 	return &Client{
 		facade: base.NewFacadeCaller(caller, "MeterStatus"),
 		tag:    tag,

--- a/cmd/jujud/agent/unit/manifolds.go
+++ b/cmd/jujud/agent/unit/manifolds.go
@@ -17,6 +17,7 @@ import (
 	"github.com/juju/juju/worker/logger"
 	"github.com/juju/juju/worker/logsender"
 	"github.com/juju/juju/worker/machinelock"
+	"github.com/juju/juju/worker/meterstatus"
 	"github.com/juju/juju/worker/metrics/collect"
 	"github.com/juju/juju/worker/metrics/sender"
 	"github.com/juju/juju/worker/metrics/spool"
@@ -175,6 +176,15 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 			CharmDirName:    CharmDirName,
 		}),
 
+		// The meter status worker executes the meter-status-changed hook when it detects
+		// that the meter status has changed.
+		MeterStatusName: meterstatus.Manifold(meterstatus.ManifoldConfig{
+			AgentName:       AgentName,
+			APICallerName:   APICallerName,
+			MachineLockName: MachineLockName,
+		}),
+
+		// The metric sender worker periodically sends accumulated metrics to the state server.
 		MetricSenderName: sender.Manifold(sender.ManifoldConfig{
 			APICallerName:   APICallerName,
 			MetricSpoolName: MetricSpoolName,
@@ -197,6 +207,7 @@ const (
 	UpgraderName             = "upgrader"
 	MetricSpoolName          = "metric-spool"
 	CharmDirName             = "charm-dir"
+	MeterStatusName          = "meter-status"
 	MetricCollectName        = "metric-collect"
 	MetricSenderName         = "metric-sender"
 )

--- a/cmd/jujud/agent/unit/manifolds_test.go
+++ b/cmd/jujud/agent/unit/manifolds_test.go
@@ -62,6 +62,7 @@ func (s *ManifoldsSuite) TestManifoldNames(c *gc.C) {
 		unit.UpgraderName,
 		unit.MetricSpoolName,
 		unit.MetricCollectName,
+		unit.MeterStatusName,
 		unit.MetricSenderName,
 		unit.CharmDirName,
 	}

--- a/featuretests/api_meterstatus_test.go
+++ b/featuretests/api_meterstatus_test.go
@@ -20,7 +20,7 @@ import (
 type meterStatusIntegrationSuite struct {
 	jujutesting.JujuConnSuite
 
-	status *meterstatus.Client
+	status meterstatus.MeterStatusClient
 	unit   *state.Unit
 }
 

--- a/worker/meterstatus/context.go
+++ b/worker/meterstatus/context.go
@@ -1,0 +1,87 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package meterstatus
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+	"time"
+
+	"github.com/juju/juju/worker/uniter/runner/context"
+	"github.com/juju/juju/worker/uniter/runner/jujuc"
+)
+
+type limitedContext struct {
+	jujuc.RestrictedContext
+
+	env map[string]string
+
+	unitName string
+	id       string
+}
+
+// NewLimitedContext creates a new context that implements just the bare minimum
+// of the jujuc.Context interface.
+func NewLimitedContext(unitName string) *limitedContext {
+	id := fmt.Sprintf("%s-%s-%d", unitName, "meter-status", rand.New(rand.NewSource(time.Now().Unix())).Int63())
+	return &limitedContext{unitName: unitName, id: id}
+}
+
+// HookVars implements runner.Context.
+func (ctx *limitedContext) HookVars(paths context.Paths) ([]string, error) {
+	vars := []string{
+		"JUJU_CHARM_DIR=" + paths.GetCharmDir(),
+		"JUJU_CONTEXT_ID=" + ctx.id,
+		"JUJU_AGENT_SOCKET=" + paths.GetJujucSocket(),
+		"JUJU_UNIT_NAME=" + ctx.unitName,
+	}
+	for key, val := range ctx.env {
+		vars = append(vars, fmt.Sprintf("%s=%s", key, val))
+	}
+	return append(vars, context.OSDependentEnvVars(paths)...), nil
+}
+
+// SetEnvVars sets additional environment variables to be exported by the context.
+func (ctx *limitedContext) SetEnvVars(vars map[string]string) {
+	if ctx.env == nil {
+		ctx.env = vars
+		return
+	}
+	for key, val := range vars {
+		ctx.env[key] = val
+	}
+}
+
+// UnitName implements runner.Context.
+func (ctx *limitedContext) UnitName() string {
+	return ctx.unitName
+}
+
+// SetProcess implements runner.Context.
+func (ctx *limitedContext) SetProcess(process *os.Process) {}
+
+// ActionData implements runner.Context.
+func (ctx *limitedContext) ActionData() (*context.ActionData, error) {
+	return nil, jujuc.ErrRestrictedContext
+}
+
+// Flush implementes runner.Context.
+func (ctx *limitedContext) Flush(_ string, err error) error {
+	return err
+}
+
+// HasExecutionSetUnitStatus implements runner.Context.
+func (ctx *limitedContext) HasExecutionSetUnitStatus() bool { return false }
+
+// ResetExecutionSetUnitStatus implements runner.Context.
+func (ctx *limitedContext) ResetExecutionSetUnitStatus() {}
+
+// Id implements runner.Context.
+func (ctx *limitedContext) Id() string { return ctx.id }
+
+// Prepare implements runner.Context.
+func (ctx *limitedContext) Prepare() error {
+	return jujuc.ErrRestrictedContext
+}

--- a/worker/meterstatus/context_test.go
+++ b/worker/meterstatus/context_test.go
@@ -1,0 +1,60 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package meterstatus_test
+
+import (
+	"runtime"
+
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/keyvalues"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/worker/meterstatus"
+)
+
+type ContextSuite struct{}
+
+var _ = gc.Suite(&ContextSuite{})
+
+type dummyPaths struct{}
+
+func (*dummyPaths) GetToolsDir() string        { return "/dummy/tools" }
+func (*dummyPaths) GetCharmDir() string        { return "/dummy/charm" }
+func (*dummyPaths) GetJujucSocket() string     { return "/dummy/jujuc.sock" }
+func (*dummyPaths) GetMetricsSpoolDir() string { return "/dummy/spool" }
+
+func (s *ContextSuite) TestHookContextEnv(c *gc.C) {
+	ctx := meterstatus.NewLimitedContext("u/0")
+	paths := &dummyPaths{}
+	vars, err := ctx.HookVars(paths)
+	c.Assert(err, jc.ErrorIsNil)
+	varMap, err := keyvalues.Parse(vars, true)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(varMap["JUJU_AGENT_SOCKET"], gc.Equals, "/dummy/jujuc.sock")
+	c.Assert(varMap["JUJU_UNIT_NAME"], gc.Equals, "u/0")
+	key := "PATH"
+	if runtime.GOOS == "windows" {
+		key = "Path"
+	}
+	c.Assert(varMap[key], gc.Not(gc.Equals), "")
+}
+
+func (s *ContextSuite) TestHookContextSetEnv(c *gc.C) {
+	ctx := meterstatus.NewLimitedContext("u/0")
+	setVars := map[string]string{
+		"somekey":    "somevalue",
+		"anotherkey": "anothervalue",
+	}
+	ctx.SetEnvVars(setVars)
+	paths := &dummyPaths{}
+	vars, err := ctx.HookVars(paths)
+	c.Assert(err, jc.ErrorIsNil)
+	varMap, err := keyvalues.Parse(vars, true)
+	c.Assert(err, jc.ErrorIsNil)
+	for key, value := range setVars {
+		c.Assert(varMap[key], gc.Equals, value)
+	}
+	c.Assert(varMap["JUJU_AGENT_SOCKET"], gc.Equals, "/dummy/jujuc.sock")
+	c.Assert(varMap["JUJU_UNIT_NAME"], gc.Equals, "u/0")
+}

--- a/worker/meterstatus/export_test.go
+++ b/worker/meterstatus/export_test.go
@@ -1,0 +1,22 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package meterstatus
+
+import (
+	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/uniter/runner"
+)
+
+var (
+	NewMeterStatusClient = &newMeterStatusClient
+	NewRunner            = &newRunner
+)
+
+// Ensure hookContext is a runner.Context.
+var _ runner.Context = (*limitedContext)(nil)
+
+func PatchInit(w worker.Worker, init func()) {
+	aw := w.(*activeStatusWorker)
+	aw.init = init
+}

--- a/worker/meterstatus/manifold.go
+++ b/worker/meterstatus/manifold.go
@@ -1,0 +1,224 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Package meterstatus provides a worker that executes the meter-status-changed hook
+// periodically.
+package meterstatus
+
+import (
+	"fmt"
+	"path"
+
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	"github.com/juju/names"
+	"github.com/juju/utils/fslock"
+	"gopkg.in/juju/charm.v6-unstable/hooks"
+	"launchpad.net/tomb"
+
+	"github.com/juju/juju/agent"
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/api/meterstatus"
+	"github.com/juju/juju/state/watcher"
+	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/dependency"
+	"github.com/juju/juju/worker/uniter"
+	"github.com/juju/juju/worker/uniter/runner"
+)
+
+var (
+	logger               = loggo.GetLogger("juju.worker.meterstatus")
+	newMeterStatusClient = meterstatus.NewClient
+	newRunner            = runner.NewRunner
+)
+
+// ManifoldConfig identifies the resource names upon which the status manifold depends.
+type ManifoldConfig struct {
+	AgentName       string
+	APICallerName   string
+	MachineLockName string
+}
+
+// Manifold returns a status manifold.
+func Manifold(config ManifoldConfig) dependency.Manifold {
+	return dependency.Manifold{
+		Inputs: []string{
+			config.AgentName,
+			config.APICallerName,
+			config.MachineLockName,
+		},
+		Start: func(getResource dependency.GetResourceFunc) (worker.Worker, error) {
+			return newStatusWorker(config, getResource)
+		},
+	}
+}
+
+func newStatusWorker(config ManifoldConfig, getResource dependency.GetResourceFunc) (worker.Worker, error) {
+	var agent agent.Agent
+	if err := getResource(config.AgentName, &agent); err != nil {
+		return nil, err
+	}
+
+	var machineLock *fslock.Lock
+	if err := getResource(config.MachineLockName, &machineLock); err != nil {
+		return nil, err
+	}
+
+	var apiCaller base.APICaller
+	err := getResource(config.APICallerName, &apiCaller)
+	if err != nil {
+		return nil, err
+	}
+
+	return newActiveStatusWorker(agent, apiCaller, machineLock)
+
+}
+
+type activeStatusWorker struct {
+	tomb tomb.Tomb
+
+	status      meterstatus.MeterStatusClient
+	stateFile   *StateFile
+	config      agent.Config
+	machineLock *fslock.Lock
+	tag         names.UnitTag
+
+	init func()
+}
+
+func newActiveStatusWorker(agent agent.Agent, apiCaller base.APICaller, machineLock *fslock.Lock) (worker.Worker, error) {
+	tag := agent.CurrentConfig().Tag()
+	unitTag, ok := tag.(names.UnitTag)
+	if !ok {
+		return nil, errors.Errorf("expected a unit tag, got %v", tag)
+	}
+	status := newMeterStatusClient(apiCaller, unitTag)
+
+	config := agent.CurrentConfig()
+	stateFile := NewStateFile(path.Join(config.DataDir(), "meter-status.yaml"))
+
+	w := &activeStatusWorker{
+		config:      config,
+		status:      status,
+		stateFile:   stateFile,
+		machineLock: machineLock,
+		tag:         unitTag,
+	}
+	go func() {
+		defer w.tomb.Done()
+		w.tomb.Kill(w.loop())
+	}()
+	return w, nil
+}
+
+func (w *activeStatusWorker) Kill() {
+	w.tomb.Kill(nil)
+}
+
+func (w *activeStatusWorker) Wait() error {
+	return w.tomb.Wait()
+}
+
+// acquireExecutionLock acquires the machine-level execution lock and returns a function to be used
+// to unlock it.
+func (w *activeStatusWorker) acquireExecutionLock() (func() error, error) {
+	message := "running meter-status-changed hook"
+	logger.Tracef("lock: %v", message)
+	checkTomb := func() error {
+		select {
+		case <-w.tomb.Dying():
+			return tomb.ErrDying
+		default:
+			return nil
+		}
+	}
+	message = fmt.Sprintf("%s: %s", w.tag.String(), message)
+	if err := w.machineLock.LockWithFunc(message, checkTomb); err != nil {
+		return nil, err
+	}
+	return func() error {
+		logger.Tracef("unlock: %v", message)
+		return w.machineLock.Unlock()
+	}, nil
+}
+
+func (w *activeStatusWorker) loop() error {
+	code, info, err := w.stateFile.Read()
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	// Check current meter status before entering loop.
+	currentCode, currentInfo, err := w.status.MeterStatus()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if code != currentCode || info != currentInfo {
+		err = w.runHook(currentCode, currentInfo)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		code, info = currentCode, currentInfo
+	}
+
+	watch, err := w.status.WatchMeterStatus()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	defer watcher.Stop(watch, &w.tomb)
+
+	// This function is used in tests to signal entering the worker loop.
+	if w.init != nil {
+		w.init()
+	}
+	for {
+		select {
+		case _, ok := <-watch.Changes():
+			logger.Debugf("got meter status change")
+			if !ok {
+				return watcher.EnsureErr(watch)
+			}
+			currentCode, currentInfo, err := w.status.MeterStatus()
+			if err != nil {
+				return errors.Trace(err)
+			}
+			if currentCode == code && currentInfo == info {
+				continue
+			}
+			err = w.runHook(currentCode, currentInfo)
+			if err != nil {
+				return errors.Trace(err)
+			}
+			code, info = currentCode, currentInfo
+		case <-w.tomb.Dying():
+			return tomb.ErrDying
+		}
+	}
+}
+
+func (w *activeStatusWorker) runHook(code, info string) (runErr error) {
+	unitTag := w.tag
+	paths := uniter.NewPaths(w.config.DataDir(), unitTag)
+	ctx := NewLimitedContext(unitTag.String())
+	ctx.SetEnvVars(map[string]string{
+		"JUJU_METER_STATUS": code,
+		"JUJU_METER_INFO":   info,
+	})
+	r := newRunner(ctx, paths)
+	unlock, err := w.acquireExecutionLock()
+	if err != nil {
+		return errors.Annotate(err, "failed to acquire machine lock")
+	}
+	defer func() {
+		unlockErr := unlock()
+		if unlockErr != nil {
+			logger.Criticalf("hook run resulted in error %v; error overridden by unlock failure error", runErr)
+			runErr = unlockErr
+		}
+	}()
+	err = r.RunHook(string(hooks.MeterStatusChanged))
+	if err != nil {
+		return errors.Annotatef(err, "error running 'meter-status-changed' hook")
+	}
+	return errors.Trace(w.stateFile.Write(code, info))
+}

--- a/worker/meterstatus/manifold_test.go
+++ b/worker/meterstatus/manifold_test.go
@@ -1,0 +1,303 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package meterstatus_test
+
+import (
+	"time"
+
+	"github.com/juju/names"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/fslock"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/agent"
+	"github.com/juju/juju/api/base"
+	msapi "github.com/juju/juju/api/meterstatus"
+	"github.com/juju/juju/api/watcher"
+	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/worker/dependency"
+	dt "github.com/juju/juju/worker/dependency/testing"
+	"github.com/juju/juju/worker/meterstatus"
+	"github.com/juju/juju/worker/uniter/runner"
+	"github.com/juju/juju/worker/uniter/runner/context"
+)
+
+type ManifoldSuite struct {
+	coretesting.BaseSuite
+
+	stub *testing.Stub
+
+	dataDir  string
+	oldLcAll string
+
+	manifoldConfig meterstatus.ManifoldConfig
+	manifold       dependency.Manifold
+	dummyResources dt.StubResources
+	getResource    dependency.GetResourceFunc
+}
+
+var _ = gc.Suite(&ManifoldSuite{})
+
+func (s *ManifoldSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+	s.stub = &testing.Stub{}
+
+	s.manifoldConfig = meterstatus.ManifoldConfig{
+		AgentName:       "agent-name",
+		APICallerName:   "apicaller-name",
+		MachineLockName: "machine-lock-name",
+	}
+	s.manifold = meterstatus.Manifold(s.manifoldConfig)
+	s.dataDir = c.MkDir()
+
+	locksDir := c.MkDir()
+	lock, err := fslock.NewLock(locksDir, "machine-lock")
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.dummyResources = dt.StubResources{
+		"agent-name":        dt.StubResource{Output: &dummyAgent{dataDir: s.dataDir}},
+		"apicaller-name":    dt.StubResource{Output: &dummyAPICaller{}},
+		"machine-lock-name": dt.StubResource{Output: lock},
+	}
+	s.getResource = dt.StubGetResource(s.dummyResources)
+}
+
+// TestInputs ensures the collect manifold has the expected defined inputs.
+func (s *ManifoldSuite) TestInputs(c *gc.C) {
+	c.Check(s.manifold.Inputs, jc.DeepEquals, []string{
+		"agent-name", "apicaller-name", "machine-lock-name",
+	})
+}
+
+// TestStartMissingDeps ensures that the manifold correctly handles a missing
+// resource dependency.
+func (s *ManifoldSuite) TestStartMissingDeps(c *gc.C) {
+	for _, missingDep := range []string{
+		"agent-name", "apicaller-name", "machine-lock-name",
+	} {
+		testResources := dt.StubResources{}
+		for k, v := range s.dummyResources {
+			if k == missingDep {
+				testResources[k] = dt.StubResource{Error: dependency.ErrMissing}
+			} else {
+				testResources[k] = v
+			}
+		}
+		getResource := dt.StubGetResource(testResources)
+		worker, err := s.manifold.Start(getResource)
+		c.Check(worker, gc.IsNil)
+		c.Check(err, gc.Equals, dependency.ErrMissing)
+	}
+}
+
+// TestStatusWorkerStarts ensures that the manifold correctly sets up the worker.
+func (s *ManifoldSuite) TestStatusWorkerStarts(c *gc.C) {
+	msClient := &stubMeterStatusClient{stub: s.stub, changes: make(chan struct{})}
+	s.PatchValue(meterstatus.NewMeterStatusClient,
+		func(_ base.APICaller, _ names.UnitTag) msapi.MeterStatusClient {
+			return msClient
+		})
+	s.PatchValue(meterstatus.NewRunner,
+		func(_ runner.Context, _ context.Paths) runner.Runner {
+			return &stubRunner{stub: s.stub}
+		})
+
+	getResource := dt.StubGetResource(s.dummyResources)
+	worker, err := s.manifold.Start(getResource)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(worker, gc.NotNil)
+	worker.Kill()
+	err = worker.Wait()
+	c.Assert(err, jc.ErrorIsNil)
+	s.stub.CheckCallNames(c, "MeterStatus", "RunHook", "WatchMeterStatus")
+}
+
+// TestStatusWorkerStarts ensures that the manifold correctly sets up the worker.
+func (s *ManifoldSuite) TestStatusWorkerDoesNotRerunNoChange(c *gc.C) {
+	msClient := &stubMeterStatusClient{stub: s.stub, changes: make(chan struct{})}
+	s.PatchValue(meterstatus.NewMeterStatusClient,
+		func(_ base.APICaller, _ names.UnitTag) msapi.MeterStatusClient {
+			return msClient
+		})
+	s.PatchValue(meterstatus.NewRunner,
+		func(_ runner.Context, _ context.Paths) runner.Runner {
+			return &stubRunner{stub: s.stub}
+		})
+
+	getResource := dt.StubGetResource(s.dummyResources)
+	worker, err := s.manifold.Start(getResource)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(worker, gc.NotNil)
+
+	running := make(chan struct{})
+	meterstatus.PatchInit(worker, func() { close(running) })
+
+	select {
+	case <-running:
+	case <-time.After(coretesting.LongWait):
+		c.Fatal("timed out waiting for signal")
+	}
+
+	msClient.changes <- struct{}{}
+
+	worker.Kill()
+	err = worker.Wait()
+	c.Assert(err, jc.ErrorIsNil)
+	s.stub.CheckCallNames(c, "MeterStatus", "RunHook", "WatchMeterStatus", "MeterStatus")
+}
+
+func (s *ManifoldSuite) TestStatusWorkerRunsHookOnChanges(c *gc.C) {
+	msClient := &stubMeterStatusClient{stub: s.stub, changes: make(chan struct{})}
+	s.PatchValue(meterstatus.NewMeterStatusClient,
+		func(_ base.APICaller, _ names.UnitTag) msapi.MeterStatusClient {
+			return msClient
+		})
+	s.PatchValue(meterstatus.NewRunner,
+		func(_ runner.Context, _ context.Paths) runner.Runner {
+			return &stubRunner{stub: s.stub}
+		})
+
+	getResource := dt.StubGetResource(s.dummyResources)
+
+	worker, err := s.manifold.Start(getResource)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(worker, gc.NotNil)
+
+	running := make(chan struct{})
+	meterstatus.PatchInit(worker, func() { close(running) })
+
+	select {
+	case <-running:
+	case <-time.After(coretesting.LongWait):
+		c.Fatal("timed out waiting for signal")
+	}
+	msClient.changes <- struct{}{}
+	msClient.code = "RED"
+
+	worker.Kill()
+	err = worker.Wait()
+	c.Assert(err, jc.ErrorIsNil)
+	s.stub.CheckCallNames(c, "MeterStatus", "RunHook", "WatchMeterStatus", "MeterStatus", "RunHook")
+
+}
+
+func (s *ManifoldSuite) TestStatusWorkerDoesNotRerunAfterRestart(c *gc.C) {
+	msClient := &stubMeterStatusClient{stub: s.stub, changes: make(chan struct{})}
+	s.PatchValue(meterstatus.NewMeterStatusClient,
+		func(_ base.APICaller, _ names.UnitTag) msapi.MeterStatusClient {
+			return msClient
+		})
+	s.PatchValue(meterstatus.NewRunner,
+		func(_ runner.Context, _ context.Paths) runner.Runner {
+			return &stubRunner{stub: s.stub}
+		})
+
+	getResource := dt.StubGetResource(s.dummyResources)
+	worker, err := s.manifold.Start(getResource)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(worker, gc.NotNil)
+
+	msClient.changes <- struct{}{}
+
+	// Kill worker.
+	worker.Kill()
+	err = worker.Wait()
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Restart it.
+	worker, err = s.manifold.Start(getResource)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(worker, gc.NotNil)
+
+	running := make(chan struct{})
+	meterstatus.PatchInit(worker, func() { close(running) })
+
+	select {
+	case <-running:
+	case <-time.After(coretesting.LongWait):
+		c.Fatal("timed out waiting for signal")
+	}
+
+	worker.Kill()
+	err = worker.Wait()
+
+	s.stub.CheckCallNames(c, "MeterStatus", "RunHook", "WatchMeterStatus", "MeterStatus", "MeterStatus", "WatchMeterStatus")
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+type dummyAgent struct {
+	agent.Agent
+	dataDir string
+}
+
+func (a dummyAgent) CurrentConfig() agent.Config {
+	return &dummyAgentConfig{dataDir: a.dataDir}
+}
+
+type dummyAgentConfig struct {
+	agent.Config
+	dataDir string
+}
+
+// Tag implements agent.AgentConfig.
+func (ac dummyAgentConfig) Tag() names.Tag {
+	return names.NewUnitTag("u/0")
+}
+
+// DataDir implements agent.AgentConfig.
+func (ac dummyAgentConfig) DataDir() string {
+	return ac.dataDir
+}
+
+type dummyAPICaller struct {
+	base.APICaller
+}
+
+func (dummyAPICaller) BestFacadeVersion(facade string) int {
+	return 42
+}
+
+type stubMeterStatusClient struct {
+	stub    *testing.Stub
+	changes chan struct{}
+	code    string
+}
+
+func (s *stubMeterStatusClient) MeterStatus() (string, string, error) {
+	s.stub.MethodCall(s, "MeterStatus")
+	if s.code == "" {
+		return "GREEN", "", nil
+	} else {
+		return s.code, "", nil
+	}
+
+}
+
+func (s *stubMeterStatusClient) WatchMeterStatus() (watcher.NotifyWatcher, error) {
+	s.stub.MethodCall(s, "WatchMeterStatus")
+	return s, nil
+}
+
+func (s *stubMeterStatusClient) Changes() <-chan struct{} {
+	return s.changes
+}
+
+func (s *stubMeterStatusClient) Stop() error {
+	return nil
+}
+
+func (s *stubMeterStatusClient) Err() error {
+	return nil
+}
+
+type stubRunner struct {
+	runner.Runner
+	stub *testing.Stub
+}
+
+func (r *stubRunner) RunHook(name string) error {
+	r.stub.MethodCall(r, "RunHook", name)
+	return r.stub.NextErr()
+}

--- a/worker/meterstatus/package_test.go
+++ b/worker/meterstatus/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package meterstatus_test
+
+import (
+	stdtesting "testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *stdtesting.T) {
+	gc.TestingT(t)
+}

--- a/worker/meterstatus/state.go
+++ b/worker/meterstatus/state.go
@@ -1,0 +1,48 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package meterstatus
+
+import (
+	"os"
+
+	"github.com/juju/errors"
+	"github.com/juju/utils"
+)
+
+// StateFile holds the meter status on disk.
+type StateFile struct {
+	path string
+}
+
+// NewStateFile creates a new file for persistent storage of
+// the meter status.
+func NewStateFile(path string) *StateFile {
+	return &StateFile{path: path}
+}
+
+type state struct {
+	Code string `yaml:"status-code"`
+	Info string `yaml:"status-info"`
+}
+
+// Read reads the current meter status information from disk.
+func (f *StateFile) Read() (string, string, error) {
+	var st state
+	if err := utils.ReadYaml(f.path, &st); err != nil {
+		if os.IsNotExist(err) {
+			return "", "", nil
+		}
+		return "", "", errors.Trace(err)
+	}
+	return st.Code, st.Info, nil
+}
+
+// Write stores the supplied status information to disk.
+func (f *StateFile) Write(code, info string) error {
+	st := state{
+		Code: code,
+		Info: info,
+	}
+	return errors.Trace(utils.WriteYaml(f.path, st))
+}

--- a/worker/meterstatus/state_test.go
+++ b/worker/meterstatus/state_test.go
@@ -1,0 +1,44 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package meterstatus_test
+
+import (
+	"path"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/worker/meterstatus"
+)
+
+type StateFileSuite struct {
+	path  string
+	state *meterstatus.StateFile
+}
+
+var _ = gc.Suite(&StateFileSuite{})
+
+func (t *StateFileSuite) SetUpTest(c *gc.C) {
+	t.path = path.Join(c.MkDir(), "state.yaml")
+	t.state = meterstatus.NewStateFile(t.path)
+}
+
+func (t *StateFileSuite) TestReadNonExist(c *gc.C) {
+	code, info, err := t.state.Read()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(code, gc.Equals, "")
+	c.Assert(info, gc.Equals, "")
+}
+
+func (t *StateFileSuite) TestWriteRead(c *gc.C) {
+	code := "GREEN"
+	info := "some message"
+	err := t.state.Write(code, info)
+	c.Assert(err, jc.ErrorIsNil)
+
+	rCode, rInfo, err := t.state.Read()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(rCode, gc.Equals, code)
+	c.Assert(rInfo, gc.Equals, info)
+}


### PR DESCRIPTION
The meter status manifold will be used to control workers that run the meter-status-changed hook.

This branch currently depends on http://reviews.vapour.ws/r/2756/ 

(Review request: http://reviews.vapour.ws/r/2796/)