### PR TITLE
lp1501381 - update utils in dependencies.tsv

### DIFF
--- a/apiserver/imagemetadata/metadata.go
+++ b/apiserver/imagemetadata/metadata.go
@@ -210,7 +210,7 @@ var convertToParams = func(published []*envmetadata.ImageMetadata) params.Metada
 		// Translate version (eg.14.04) to a series (eg. "trusty")
 		s, err := series.VersionSeries(p.Version)
 		if err != nil {
-			logger.Warningf("could not determine series %v", err)
+			logger.Warningf("could not determine series for image id %s: %v", p.Id, err)
 			continue
 		}
 		metadata[i].Series = s

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -27,7 +27,7 @@ github.com/juju/schema	git	afe1151cb49d1d7ed3c75592dfc6f38703f2e988	2015-08-07T0
 github.com/juju/syslog	git	6be94e8b718766e9ff7a37342157fe4795da7cfa	2015-02-05T15:59:36Z
 github.com/juju/testing	git	31ee64312c3c64cc94a5b41ea7a200b42e0f9767	2015-09-02T15:44:51Z
 github.com/juju/txn	git	99ec629d0066a4d73c54d8e021a7fc1dc07df614	2015-06-09T16:58:27Z
-github.com/juju/utils	git	d4796e2159e8bf8457d4e79b616dc523452b3560	
+github.com/juju/utils	git	c52ab0f27edd9a226d14b71852d1a48a72cbea15	2015-09-30T20:04:42Z
 github.com/juju/xml	git	eb759a627588d35166bc505fceb51b88500e291e	2015-04-13T13:11:21Z
 github.com/julienschmidt/httprouter	git	8c199fb6259ffc1af525cc3ad52ee60ba8359669	2015-04-21T17:00:07Z
 golang.org/x/crypto	git	c57d4a71915a248dbad846d60825145062b4c18e	2015-03-27T05:11:19Z

--- a/mongo/mongo_test.go
+++ b/mongo/mongo_test.go
@@ -708,7 +708,7 @@ func (s *MongoSuite) TestAddPPAInQuantal(c *gc.C) {
 
 	match := []string{
 		"--yes",
-		"\"ppa:juju/stable\"",
+		"ppa:juju/stable",
 	}
 
 	testing.AssertEchoArgs(c, "add-apt-repository", match...)


### PR DESCRIPTION
This commit also fixes tests in juju/juju/mongo/mongo_test.go
that were broken with juju/utils commit
a72d3e172d493f8802a7815f747ead06911886a2

and updates convertToParams to log the Id of the image in
simplestreams which is being ignored due to invalid version.

(Review request: http://reviews.vapour.ws/r/2798/)