### PR TITLE
lp1501432 - patch HostOS for bootstrap tests

### DIFF
--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -16,6 +16,7 @@ import (
 	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/arch"
+	jujuos "github.com/juju/utils/os"
 	"github.com/juju/utils/series"
 	gc "gopkg.in/check.v1"
 
@@ -68,6 +69,7 @@ func (s *BootstrapSuite) SetUpTest(c *gc.C) {
 	// will make tools available. Individual tests may
 	// override this.
 	s.PatchValue(&version.Current, v100p64)
+	s.PatchValue(&jujuos.HostOS, func() jujuos.OSType { return jujuos.Ubuntu })
 
 	// Set up a local source with tools.
 	sourceDir := createToolsSource(c, vAll)


### PR DESCRIPTION
To locate tools properly, HostOS needs to be
patched.  I tested this change by first recreating
the same test failures through modifying HostOS to
always return os.CentOS.  Then I verified that
patching HostOS during SetUpTest resolved all
the observed test failures.

(Review request: http://reviews.vapour.ws/r/2800/)