### PR TITLE
provider/ec2: increas root disk tagging timeout (1.25)

### DIFF
--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -707,7 +707,7 @@ func tagRootDisk(e *ec2.EC2, tags map[string]string, inst *ec2.Instance) error {
 	volumeId := findVolumeId(inst)
 	waitRootDiskAttempt := utils.AttemptStrategy{
 		Total: 5 * time.Minute,
-		Delay: 200 * time.Millisecond,
+		Delay: 5 * time.Second,
 	}
 	for a := waitRootDiskAttempt.Start(); volumeId == "" && a.Next(); {
 		resp, err := e.Instances([]string{inst.InstanceId}, nil)

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -705,7 +705,11 @@ func tagRootDisk(e *ec2.EC2, tags map[string]string, inst *ec2.Instance) error {
 	// Wait until the instance has an associated EBS volume in the
 	// block-device-mapping.
 	volumeId := findVolumeId(inst)
-	for a := shortAttempt.Start(); volumeId == "" && a.Next(); {
+	waitRootDiskAttempt := utils.AttemptStrategy{
+		Total: 5 * time.Minute,
+		Delay: 200 * time.Millisecond,
+	}
+	for a := waitRootDiskAttempt.Start(); volumeId == "" && a.Next(); {
 		resp, err := e.Instances([]string{inst.InstanceId}, nil)
 		if err != nil {
 			return err


### PR DESCRIPTION
Back-port.

When we start instances in ec2, we tag the root disk with the environment
UUID, machine ID, etc. This will sometimes fail if the root disk does not
attach quickly enough. Increase the timeout from 5 seconds to 5 minutes.

Fixes https://bugs.launchpad.net/juju-core/+bug/1501559

(Review request: http://reviews.vapour.ws/r/2804/)