### PR TITLE
WatchStorageAttachment watches block devices: 1.25

### DIFF
--- a/apiserver/common/storage.go
+++ b/apiserver/common/storage.go
@@ -41,12 +41,16 @@ type StorageInterface interface {
 	WatchStorageAttachment(names.StorageTag, names.UnitTag) state.NotifyWatcher
 
 	// WatchFilesystemAttachment watches for changes to the filesystem
-	// attachment corresponding to the identfified machien and filesystem.
+	// attachment corresponding to the identfified machine and filesystem.
 	WatchFilesystemAttachment(names.MachineTag, names.FilesystemTag) state.NotifyWatcher
 
 	// WatchVolumeAttachment watches for changes to the volume attachment
-	// corresponding to the identfified machien and volume.
+	// corresponding to the identfified machine and volume.
 	WatchVolumeAttachment(names.MachineTag, names.VolumeTag) state.NotifyWatcher
+
+	// WatchBlockDevices watches for changes to block devices associated
+	// with the specified machine.
+	WatchBlockDevices(names.MachineTag) state.NotifyWatcher
 
 	// BlockDevices returns information about block devices published
 	// for the specified machine.
@@ -56,6 +60,10 @@ type StorageInterface interface {
 // StorageAttachmentInfo returns the StorageAttachmentInfo for the specified
 // StorageAttachment by gathering information from related entities (volumes,
 // filesystems).
+//
+// StorageAttachmentInfo returns an error satisfying errors.IsNotProvisioned
+// if the storage attachment is not yet fully provisioned and ready for use
+// by a charm.
 func StorageAttachmentInfo(
 	st StorageInterface,
 	att state.StorageAttachment,
@@ -96,18 +104,28 @@ func volumeStorageAttachmentInfo(
 	if err != nil {
 		return nil, errors.Annotate(err, "getting volume attachment info")
 	}
-	devicePath, err := volumeAttachmentDevicePath(
-		st,
+	blockDevices, err := st.BlockDevices(machineTag)
+	if err != nil {
+		return nil, errors.Annotate(err, "getting block devices")
+	}
+	blockDevice, ok := MatchingBlockDevice(
+		blockDevices,
 		volumeInfo,
 		volumeAttachmentInfo,
-		machineTag,
 	)
-	if err == errNoBlockDevice {
-		// We don't have enough information to describe the storage
-		// attachment yet, so we must say that it is not provisioned
-		// to prevent feeding clients with partial information.
+	if !ok {
+		// We must not say that a block-kind storage attachment is
+		// provisioned until its block device has shown up on the
+		// machine, otherwise the charm may attempt to use it and
+		// fail.
 		return nil, errors.NotProvisionedf("%v", names.ReadableString(storageTag))
-	} else if err != nil {
+	}
+	devicePath, err := volumeAttachmentDevicePath(
+		volumeInfo,
+		volumeAttachmentInfo,
+		*blockDevice,
+	)
+	if err != nil {
 		return nil, errors.Trace(err)
 	}
 	return &storage.StorageAttachmentInfo{
@@ -141,8 +159,8 @@ func filesystemStorageAttachmentInfo(
 }
 
 // WatchStorageAttachment returns a state.NotifyWatcher that reacts to changes
-// to the VolumeAttachmentInfo or FilesystemAttachmentInfo corresponding to the tags
-// specified.
+// to the VolumeAttachmentInfo or FilesystemAttachmentInfo corresponding to the
+// tags specified.
 func WatchStorageAttachment(
 	st StorageInterface,
 	storageTag names.StorageTag,
@@ -153,42 +171,53 @@ func WatchStorageAttachment(
 	if err != nil {
 		return nil, errors.Annotate(err, "getting storage instance")
 	}
-	var w state.NotifyWatcher
+	var watchers []state.NotifyWatcher
 	switch storageInstance.Kind() {
 	case state.StorageKindBlock:
 		volume, err := st.StorageInstanceVolume(storageTag)
 		if err != nil {
 			return nil, errors.Annotate(err, "getting storage volume")
 		}
-		w = st.WatchVolumeAttachment(machineTag, volume.VolumeTag())
+		// We need to watch both the volume attachment, and the
+		// machine's block devices. A volume attachment's block
+		// device could change (most likely, become present).
+		watchers = []state.NotifyWatcher{
+			st.WatchVolumeAttachment(machineTag, volume.VolumeTag()),
+			// TODO(axw) 2015-09-30 #1501203
+			// We should filter the events to only those relevant
+			// to the volume attachment. This means we would need
+			// to either start th block device watcher after we
+			// have provisioned the volume attachment (cleaner?),
+			// or have the filter ignore changes until the volume
+			// attachment is provisioned.
+			st.WatchBlockDevices(machineTag),
+		}
 	case state.StorageKindFilesystem:
 		filesystem, err := st.StorageInstanceFilesystem(storageTag)
 		if err != nil {
 			return nil, errors.Annotate(err, "getting storage filesystem")
 		}
-		w = st.WatchFilesystemAttachment(machineTag, filesystem.FilesystemTag())
+		watchers = []state.NotifyWatcher{
+			st.WatchFilesystemAttachment(machineTag, filesystem.FilesystemTag()),
+		}
 	default:
 		return nil, errors.Errorf("invalid storage kind %v", storageInstance.Kind())
 	}
-	w2 := st.WatchStorageAttachment(storageTag, unitTag)
-	return newMultiNotifyWatcher(w, w2), nil
+	watchers = append(watchers, st.WatchStorageAttachment(storageTag, unitTag))
+	return newMultiNotifyWatcher(watchers...), nil
 }
-
-var errNoBlockDevice = errors.New("cannot determine device path: no matching block device found")
 
 // volumeAttachmentDevicePath returns the absolute device path for
 // a volume attachment. The value is only meaningful in the context
 // of the machine that the volume is attached to.
 func volumeAttachmentDevicePath(
-	st StorageInterface,
 	volumeInfo state.VolumeInfo,
 	volumeAttachmentInfo state.VolumeAttachmentInfo,
-	machineTag names.MachineTag,
+	blockDevice state.BlockDeviceInfo,
 ) (string, error) {
 	if volumeInfo.HardwareId != "" || volumeAttachmentInfo.DeviceName != "" || volumeAttachmentInfo.DeviceLink != "" {
-		// The storage provider has enough information to determine
-		// the device path, so use that rather than enquiring about
-		// block devices.
+		// Prefer the volume attachment's information over what is
+		// in the published block device information.
 		var deviceLinks []string
 		if volumeAttachmentInfo.DeviceLink != "" {
 			deviceLinks = []string{volumeAttachmentInfo.DeviceLink}
@@ -199,19 +228,7 @@ func volumeAttachmentDevicePath(
 			DeviceLinks: deviceLinks,
 		})
 	}
-	blockDevices, err := st.BlockDevices(machineTag)
-	if err != nil {
-		return "", errors.Annotate(err, "getting block devices")
-	}
-	blockDevice, ok := MatchingBlockDevice(
-		blockDevices,
-		volumeInfo,
-		volumeAttachmentInfo,
-	)
-	if !ok {
-		return "", errNoBlockDevice
-	}
-	return storage.BlockDevicePath(BlockDeviceFromState(*blockDevice))
+	return storage.BlockDevicePath(BlockDeviceFromState(blockDevice))
 }
 
 // MaybeAssignedStorageInstance calls the provided function to get a

--- a/apiserver/common/storage_test.go
+++ b/apiserver/common/storage_test.go
@@ -8,17 +8,16 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/names"
-	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/state"
+	statetesting "github.com/juju/juju/state/testing"
 	"github.com/juju/juju/storage"
 )
 
 type storageAttachmentInfoSuite struct {
-	testing.Stub
 	machineTag        names.MachineTag
 	volumeTag         names.VolumeTag
 	storageTag        names.StorageTag
@@ -55,7 +54,11 @@ func (s *storageAttachmentInfoSuite) SetUpTest(c *gc.C) {
 	s.volumeAttachment = &fakeVolumeAttachment{
 		info: &state.VolumeAttachmentInfo{},
 	}
-	s.blockDevices = nil
+	s.blockDevices = []state.BlockDeviceInfo{{
+		DeviceName:  "sda",
+		DeviceLinks: []string{"/dev/disk/by-id/verbatim"},
+		HardwareId:  "whatever",
+	}}
 	s.st = &fakeStorage{
 		storageInstance: func(tag names.StorageTag) (state.StorageInstance, error) {
 			return s.storageInstance, nil
@@ -76,18 +79,28 @@ func (s *storageAttachmentInfoSuite) TestStorageAttachmentInfoPersistentDeviceNa
 	s.volumeAttachment.info.DeviceName = "sda"
 	info, err := common.StorageAttachmentInfo(s.st, s.storageAttachment, s.machineTag)
 	c.Assert(err, jc.ErrorIsNil)
-	s.st.CheckCallNames(c, "StorageInstance", "StorageInstanceVolume", "VolumeAttachment")
+	s.st.CheckCallNames(c, "StorageInstance", "StorageInstanceVolume", "VolumeAttachment", "BlockDevices")
 	c.Assert(info, jc.DeepEquals, &storage.StorageAttachmentInfo{
 		Kind:     storage.StorageKindBlock,
 		Location: filepath.FromSlash("/dev/sda"),
 	})
 }
 
+func (s *storageAttachmentInfoSuite) TestStorageAttachmentInfoMissingBlockDevice(c *gc.C) {
+	// If the block device has not shown up yet,
+	// then we should get a NotProvisioned error.
+	s.blockDevices = nil
+	s.volumeAttachment.info.DeviceName = "sda"
+	_, err := common.StorageAttachmentInfo(s.st, s.storageAttachment, s.machineTag)
+	c.Assert(err, jc.Satisfies, errors.IsNotProvisioned)
+	s.st.CheckCallNames(c, "StorageInstance", "StorageInstanceVolume", "VolumeAttachment", "BlockDevices")
+}
+
 func (s *storageAttachmentInfoSuite) TestStorageAttachmentInfoPersistentDeviceLink(c *gc.C) {
 	s.volumeAttachment.info.DeviceLink = "/dev/disk/by-id/verbatim"
 	info, err := common.StorageAttachmentInfo(s.st, s.storageAttachment, s.machineTag)
 	c.Assert(err, jc.ErrorIsNil)
-	s.st.CheckCallNames(c, "StorageInstance", "StorageInstanceVolume", "VolumeAttachment")
+	s.st.CheckCallNames(c, "StorageInstance", "StorageInstanceVolume", "VolumeAttachment", "BlockDevices")
 	c.Assert(info, jc.DeepEquals, &storage.StorageAttachmentInfo{
 		Kind:     storage.StorageKindBlock,
 		Location: "/dev/disk/by-id/verbatim",
@@ -98,7 +111,7 @@ func (s *storageAttachmentInfoSuite) TestStorageAttachmentInfoPersistentHardware
 	s.volume.info.HardwareId = "whatever"
 	info, err := common.StorageAttachmentInfo(s.st, s.storageAttachment, s.machineTag)
 	c.Assert(err, jc.ErrorIsNil)
-	s.st.CheckCallNames(c, "StorageInstance", "StorageInstanceVolume", "VolumeAttachment")
+	s.st.CheckCallNames(c, "StorageInstance", "StorageInstanceVolume", "VolumeAttachment", "BlockDevices")
 	c.Assert(info, jc.DeepEquals, &storage.StorageAttachmentInfo{
 		Kind:     storage.StorageKindBlock,
 		Location: filepath.FromSlash("/dev/disk/by-id/whatever"),
@@ -133,4 +146,96 @@ func (s *storageAttachmentInfoSuite) TestStorageAttachmentInfoNoBlockDevice(c *g
 	_, err := common.StorageAttachmentInfo(s.st, s.storageAttachment, s.machineTag)
 	c.Assert(err, jc.Satisfies, errors.IsNotProvisioned)
 	s.st.CheckCallNames(c, "StorageInstance", "StorageInstanceVolume", "VolumeAttachment", "BlockDevices")
+}
+
+type watchStorageAttachmentSuite struct {
+	storageTag               names.StorageTag
+	machineTag               names.MachineTag
+	unitTag                  names.UnitTag
+	st                       *fakeStorage
+	storageInstance          *fakeStorageInstance
+	volume                   *fakeVolume
+	volumeAttachmentWatcher  *fakeNotifyWatcher
+	blockDevicesWatcher      *fakeNotifyWatcher
+	storageAttachmentWatcher *fakeNotifyWatcher
+}
+
+var _ = gc.Suite(&watchStorageAttachmentSuite{})
+
+func (s *watchStorageAttachmentSuite) SetUpTest(c *gc.C) {
+	s.storageTag = names.NewStorageTag("osd-devices/0")
+	s.machineTag = names.NewMachineTag("0")
+	s.unitTag = names.NewUnitTag("ceph/0")
+	s.storageInstance = &fakeStorageInstance{
+		tag:   s.storageTag,
+		owner: s.machineTag,
+		kind:  state.StorageKindBlock,
+	}
+	s.volume = &fakeVolume{tag: names.NewVolumeTag("0")}
+	s.volumeAttachmentWatcher = &fakeNotifyWatcher{changes: make(chan struct{}, 1)}
+	s.blockDevicesWatcher = &fakeNotifyWatcher{changes: make(chan struct{}, 1)}
+	s.storageAttachmentWatcher = &fakeNotifyWatcher{changes: make(chan struct{}, 1)}
+	s.volumeAttachmentWatcher.changes <- struct{}{}
+	s.blockDevicesWatcher.changes <- struct{}{}
+	s.storageAttachmentWatcher.changes <- struct{}{}
+	s.st = &fakeStorage{
+		storageInstance: func(tag names.StorageTag) (state.StorageInstance, error) {
+			return s.storageInstance, nil
+		},
+		storageInstanceVolume: func(tag names.StorageTag) (state.Volume, error) {
+			return s.volume, nil
+		},
+		watchVolumeAttachment: func(names.MachineTag, names.VolumeTag) state.NotifyWatcher {
+			return s.volumeAttachmentWatcher
+		},
+		watchBlockDevices: func(names.MachineTag) state.NotifyWatcher {
+			return s.blockDevicesWatcher
+		},
+		watchStorageAttachment: func(names.StorageTag, names.UnitTag) state.NotifyWatcher {
+			return s.storageAttachmentWatcher
+		},
+	}
+}
+
+func (s *watchStorageAttachmentSuite) TestWatchStorageAttachmentVolumeAttachmentChanges(c *gc.C) {
+	s.testWatchBlockStorageAttachment(c, func() {
+		s.volumeAttachmentWatcher.changes <- struct{}{}
+	})
+}
+
+func (s *watchStorageAttachmentSuite) TestWatchStorageAttachmentStorageAttachmentChanges(c *gc.C) {
+	s.testWatchBlockStorageAttachment(c, func() {
+		s.storageAttachmentWatcher.changes <- struct{}{}
+	})
+}
+
+func (s *watchStorageAttachmentSuite) TestWatchStorageAttachmentBlockDevicesChange(c *gc.C) {
+	s.testWatchBlockStorageAttachment(c, func() {
+		s.blockDevicesWatcher.changes <- struct{}{}
+	})
+}
+
+func (s *watchStorageAttachmentSuite) testWatchBlockStorageAttachment(c *gc.C, change func()) {
+	s.testWatchStorageAttachment(c, change)
+	s.st.CheckCallNames(c,
+		"StorageInstance",
+		"StorageInstanceVolume",
+		"WatchVolumeAttachment",
+		"WatchBlockDevices",
+		"WatchStorageAttachment",
+	)
+}
+
+func (s *watchStorageAttachmentSuite) testWatchStorageAttachment(c *gc.C, change func()) {
+	w, err := common.WatchStorageAttachment(
+		s.st,
+		s.storageTag,
+		s.machineTag,
+		s.unitTag,
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	wc := statetesting.NewNotifyWatcherC(c, nopSyncStarter{}, w)
+	wc.AssertOneChange()
+	change()
+	wc.AssertOneChange()
 }

--- a/apiserver/common/storagemock_test.go
+++ b/apiserver/common/storagemock_test.go
@@ -17,10 +17,13 @@ import (
 type fakeStorage struct {
 	testing.Stub
 	common.StorageInterface
-	storageInstance       func(names.StorageTag) (state.StorageInstance, error)
-	storageInstanceVolume func(names.StorageTag) (state.Volume, error)
-	volumeAttachment      func(names.MachineTag, names.VolumeTag) (state.VolumeAttachment, error)
-	blockDevices          func(names.MachineTag) ([]state.BlockDeviceInfo, error)
+	storageInstance        func(names.StorageTag) (state.StorageInstance, error)
+	storageInstanceVolume  func(names.StorageTag) (state.Volume, error)
+	volumeAttachment       func(names.MachineTag, names.VolumeTag) (state.VolumeAttachment, error)
+	blockDevices           func(names.MachineTag) ([]state.BlockDeviceInfo, error)
+	watchVolumeAttachment  func(names.MachineTag, names.VolumeTag) state.NotifyWatcher
+	watchBlockDevices      func(names.MachineTag) state.NotifyWatcher
+	watchStorageAttachment func(names.StorageTag, names.UnitTag) state.NotifyWatcher
 }
 
 func (s *fakeStorage) StorageInstance(tag names.StorageTag) (state.StorageInstance, error) {
@@ -41,6 +44,21 @@ func (s *fakeStorage) VolumeAttachment(m names.MachineTag, v names.VolumeTag) (s
 func (s *fakeStorage) BlockDevices(m names.MachineTag) ([]state.BlockDeviceInfo, error) {
 	s.MethodCall(s, "BlockDevices", m)
 	return s.blockDevices(m)
+}
+
+func (s *fakeStorage) WatchVolumeAttachment(m names.MachineTag, v names.VolumeTag) state.NotifyWatcher {
+	s.MethodCall(s, "WatchVolumeAttachment", m, v)
+	return s.watchVolumeAttachment(m, v)
+}
+
+func (s *fakeStorage) WatchBlockDevices(m names.MachineTag) state.NotifyWatcher {
+	s.MethodCall(s, "WatchBlockDevices", m)
+	return s.watchBlockDevices(m)
+}
+
+func (s *fakeStorage) WatchStorageAttachment(st names.StorageTag, u names.UnitTag) state.NotifyWatcher {
+	s.MethodCall(s, "WatchStorageAttachment", st, u)
+	return s.watchStorageAttachment(st, u)
 }
 
 type fakeStorageInstance struct {

--- a/apiserver/storage/package_test.go
+++ b/apiserver/storage/package_test.go
@@ -270,6 +270,7 @@ type mockState struct {
 	watchStorageAttachment              func(names.StorageTag, names.UnitTag) state.NotifyWatcher
 	watchFilesystemAttachment           func(names.MachineTag, names.FilesystemTag) state.NotifyWatcher
 	watchVolumeAttachment               func(names.MachineTag, names.VolumeTag) state.NotifyWatcher
+	watchBlockDevices                   func(names.MachineTag) state.NotifyWatcher
 	envName                             string
 	volume                              func(tag names.VolumeTag) (state.Volume, error)
 	machineVolumeAttachments            func(machine names.MachineTag) ([]state.VolumeAttachment, error)
@@ -322,6 +323,10 @@ func (st *mockState) WatchFilesystemAttachment(mtag names.MachineTag, f names.Fi
 
 func (st *mockState) WatchVolumeAttachment(mtag names.MachineTag, v names.VolumeTag) state.NotifyWatcher {
 	return st.watchVolumeAttachment(mtag, v)
+}
+
+func (st *mockState) WatchBlockDevices(mtag names.MachineTag) state.NotifyWatcher {
+	return st.watchBlockDevices(mtag)
 }
 
 func (st *mockState) EnvName() (string, error) {

--- a/apiserver/storage/state.go
+++ b/apiserver/storage/state.go
@@ -44,6 +44,9 @@ type storageAccess interface {
 	// WatchVolumeAttachment is required for storage functionality.
 	WatchVolumeAttachment(names.MachineTag, names.VolumeTag) state.NotifyWatcher
 
+	// WatchBlockDevices is required for storage functionality.
+	WatchBlockDevices(names.MachineTag) state.NotifyWatcher
+
 	// BlockDevices is required for storage functionality.
 	BlockDevices(names.MachineTag) ([]state.BlockDeviceInfo, error)
 

--- a/apiserver/uniter/state.go
+++ b/apiserver/uniter/state.go
@@ -25,6 +25,7 @@ type storageStateInterface interface {
 	WatchStorageAttachment(names.StorageTag, names.UnitTag) state.NotifyWatcher
 	WatchFilesystemAttachment(names.MachineTag, names.FilesystemTag) state.NotifyWatcher
 	WatchVolumeAttachment(names.MachineTag, names.VolumeTag) state.NotifyWatcher
+	WatchBlockDevices(names.MachineTag) state.NotifyWatcher
 	AddStorageForUnit(tag names.UnitTag, name string, cons state.StorageConstraints) error
 	UnitStorageConstraints(u names.UnitTag) (map[string]state.StorageConstraints, error)
 	BlockDevices(names.MachineTag) ([]state.BlockDeviceInfo, error)


### PR DESCRIPTION
Back-port

The unit agent needs to know when storage attachments
are provisioned and ready for use. A block-kind storage
attachment is not available until there is a block device
visible on the machine, so the uniter needs to be informed
of changes to block devices on the machine.

Fixes https://bugs.launchpad.net/juju-core/+bug/1501173

(Review request: http://reviews.vapour.ws/r/2805/)