### PR TITLE
WIP: Metadata search path.

### DIFF
--- a/cmd/jujud/bootstrap.go
+++ b/cmd/jujud/bootstrap.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net"
-	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -242,12 +241,6 @@ func (c *BootstrapCommand) Run(_ *cmd.Context) error {
 		if err := c.saveCustomImageMetadata(st); err != nil {
 			return err
 		}
-
-		// TODO (anastasiamac 2015-09-24) Remove this once search path is updated..
-		stor := newStateStorage(st.EnvironUUID(), st.MongoSession())
-		if err := c.storeCustomImageMetadata(stor); err != nil {
-			return err
-		}
 	}
 
 	// Populate the storage pools.
@@ -367,33 +360,6 @@ func (c *BootstrapCommand) populateTools(st *state.State, env environs.Environ) 
 		}
 	}
 	return nil
-}
-
-// storeCustomImageMetadata reads the custom image metadata from disk,
-// and stores the files in environment storage with the same relative
-// paths.
-func (c *BootstrapCommand) storeCustomImageMetadata(stor storage.Storage) error {
-	logger.Debugf("storing custom image metadata from %q", c.ImageMetadataDir)
-	return filepath.Walk(c.ImageMetadataDir, func(abspath string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-		if !info.Mode().IsRegular() {
-			return nil
-		}
-		relpath, err := filepath.Rel(c.ImageMetadataDir, abspath)
-		if err != nil {
-			return err
-		}
-		f, err := os.Open(abspath)
-		if err != nil {
-			return err
-		}
-		defer f.Close()
-		relpath = filepath.ToSlash(relpath)
-		logger.Debugf("storing %q in environment storage (%d bytes)", relpath, info.Size())
-		return stor.Put(relpath, f, info.Size())
-	})
 }
 
 // Override for testing.

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -267,14 +267,6 @@ func setPrivateMetadataSources(env environs.Environ, metadataDir string) ([]*ima
 	if err != nil && !errors.IsNotFound(err) {
 		return nil, errors.Annotate(err, "cannot read image metadata")
 	}
-
-	// Add an image metadata datasource for constraint validation, etc.
-	// TODO (anastasiamac 2015-09-26) Delete when search path is modified to look
-	// into state first.
-	environs.RegisterUserImageDataSourceFunc("bootstrap metadata", func(environs.Environ) (simplestreams.DataSource, error) {
-		return datasource, nil
-	})
-	logger.Infof("custom image metadata added to search path")
 	return existingMetadata, nil
 }
 

--- a/provider/azure/azure_test.go
+++ b/provider/azure/azure_test.go
@@ -26,7 +26,8 @@ func TestAzureProvider(t *stdtesting.T) {
 }
 
 type providerSuite struct {
-	testing.BaseSuite
+	testing.FakeJujuHomeSuite
+
 	envtesting.ToolsFixture
 	restoreTimeouts func()
 }
@@ -41,18 +42,18 @@ func init() {
 }
 
 func (s *providerSuite) SetUpSuite(c *gc.C) {
-	s.BaseSuite.SetUpSuite(c)
+	s.FakeJujuHomeSuite.SetUpSuite(c)
 	s.restoreTimeouts = envtesting.PatchAttemptStrategies()
 	s.UploadArches = []string{arch.AMD64}
 }
 
 func (s *providerSuite) TearDownSuite(c *gc.C) {
 	s.restoreTimeouts()
-	s.BaseSuite.TearDownSuite(c)
+	s.FakeJujuHomeSuite.TearDownSuite(c)
 }
 
 func (s *providerSuite) SetUpTest(c *gc.C) {
-	s.BaseSuite.SetUpTest(c)
+	s.FakeJujuHomeSuite.SetUpTest(c)
 	s.ToolsFixture.SetUpTest(c)
 	s.PatchValue(&imagemetadata.DefaultBaseURL, "test:")
 	s.PatchValue(&signedImageDataOnly, false)
@@ -71,7 +72,7 @@ func (s *providerSuite) SetUpTest(c *gc.C) {
 
 func (s *providerSuite) TearDownTest(c *gc.C) {
 	s.ToolsFixture.TearDownTest(c)
-	s.BaseSuite.TearDownTest(c)
+	s.FakeJujuHomeSuite.TearDownTest(c)
 }
 
 func (s *providerSuite) makeTestMetadata(c *gc.C, ser, location string, im []*imagemetadata.ImageMetadata) {

--- a/provider/azure/instancetype.go
+++ b/provider/azure/instancetype.go
@@ -4,7 +4,6 @@
 package azure
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/juju/errors"
@@ -12,10 +11,10 @@ import (
 	"launchpad.net/gwacl"
 
 	"github.com/juju/juju/constraints"
-	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/imagemetadata"
 	"github.com/juju/juju/environs/instances"
 	"github.com/juju/juju/environs/simplestreams"
+	"github.com/juju/juju/provider/common"
 )
 
 const defaultMem = 1 * gwacl.GB
@@ -82,14 +81,9 @@ func findMatchingImages(e *azureEnviron, location, series string, arches []strin
 		Arches:    arches,
 		Stream:    e.Config().ImageStream(),
 	})
-	sources, err := environs.ImageMetadataSources(e)
+
+	images, _, err := common.FindImageMetadata(e, constraint, signedImageDataOnly)
 	if err != nil {
-		return nil, err
-	}
-	images, _, err := imagemetadata.Fetch(sources, constraint, signedImageDataOnly)
-	if len(images) == 0 || errors.IsNotFound(err) {
-		return nil, fmt.Errorf("no OS images found for location %q, series %q, architectures %q (and endpoint: %q)", location, series, arches, endpoint)
-	} else if err != nil {
 		return nil, err
 	}
 	return images, nil

--- a/provider/azure/instancetype_test.go
+++ b/provider/azure/instancetype_test.go
@@ -133,7 +133,7 @@ func (s *instanceTypeSuite) TestFindMatchingImagesReturnsErrorIfNoneFound(c *gc.
 	env := s.setupEnvWithDummyMetadata(c)
 	_, err := findMatchingImages(env, "West US", "saucy", []string{"amd64"})
 	c.Assert(err, gc.NotNil)
-	c.Assert(err, gc.ErrorMatches, "no OS images found for location .*")
+	c.Assert(err, gc.ErrorMatches, "image metadata for .* not found.*")
 }
 
 func (s *instanceTypeSuite) TestFindMatchingImagesReturnsReleasedImages(c *gc.C) {
@@ -299,7 +299,7 @@ func (s *instanceTypeSuite) TestFindInstanceSpecFailsImpossibleRequest(c *gc.C) 
 	env := s.setupEnvWithDummyMetadata(c)
 	_, err := findInstanceSpec(env, impossibleConstraint)
 	c.Assert(err, gc.NotNil)
-	c.Check(err, gc.ErrorMatches, "no OS images found for .*")
+	c.Check(err, gc.ErrorMatches, "image metadata for .* not found")
 }
 
 var findInstanceSpecTests = []struct {

--- a/provider/cloudsigma/environinstance.go
+++ b/provider/cloudsigma/environinstance.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/juju/environs/imagemetadata"
 	"github.com/juju/juju/environs/simplestreams"
 	"github.com/juju/juju/instance"
+	"github.com/juju/juju/provider/common"
 	"github.com/juju/juju/tools"
 )
 
@@ -21,18 +22,9 @@ import (
 //
 
 var findInstanceImage = func(env *environ, ic *imagemetadata.ImageConstraint) (*imagemetadata.ImageMetadata, error) {
-
-	sources, err := environs.ImageMetadataSources(env)
+	matchingImages, _, err := common.FindImageMetadata(env, ic, false)
 	if err != nil {
 		return nil, err
-	}
-
-	matchingImages, _, err := imagemetadata.Fetch(sources, ic, false)
-	if err != nil {
-		return nil, err
-	}
-	if len(matchingImages) == 0 {
-		return nil, errors.New("no matching image meta data")
 	}
 
 	return matchingImages[0], nil

--- a/provider/common/export_test.go
+++ b/provider/common/export_test.go
@@ -7,4 +7,5 @@ var (
 	ConnectSSH                          = &connectSSH
 	WaitSSH                             = waitSSH
 	InternalAvailabilityZoneAllocations = &internalAvailabilityZoneAllocations
+	MetadataAPI                         = &metadataAPI
 )

--- a/provider/common/imagemetadata.go
+++ b/provider/common/imagemetadata.go
@@ -1,0 +1,100 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package common
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/utils/series"
+
+	apimetadata "github.com/juju/juju/api/imagemetadata"
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/imagemetadata"
+	"github.com/juju/juju/environs/simplestreams"
+	"github.com/juju/juju/juju"
+)
+
+// FindImageMetadata looks for image metadata in state.
+// If none are found, we fall back on original image search in simple streams.
+func FindImageMetadata(env environs.Environ, imageConstraint *imagemetadata.ImageConstraint, signedOnly bool) ([]*imagemetadata.ImageMetadata, *simplestreams.ResolveInfo, error) {
+	stateMetadata, stateInfo, err := imageMetadataFromState(env, imageConstraint, signedOnly)
+	if err != nil && !errors.IsNotFound(err) {
+		return nil, nil, errors.Trace(err)
+	}
+
+	// No need to look in data sources if found in state?
+	if len(stateMetadata) != 0 {
+		return stateMetadata, stateInfo, nil
+	}
+
+	// If none are found, fall back to original simple stream impl.
+	// Currently, an image metadata worker picks up this metadata periodically (daily),
+	// and stores it in state. So potentially, this collection could be different
+	// to what is in state.
+	dsMetadata, dsInfo, err := imageMetadataFromDataSources(env, imageConstraint, signedOnly)
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			return nil, nil, errors.Trace(err)
+		}
+	}
+
+	// If still none found, complain
+	if len(dsMetadata) == 0 {
+		return nil, nil, errors.NotFoundf("image metadata for series %v, architectures %v", imageConstraint.Series, imageConstraint.Arches)
+	}
+
+	return dsMetadata, dsInfo, nil
+}
+
+var metadataAPI = func(env environs.Environ) (*apimetadata.Client, error) {
+	api, err := juju.NewAPIFromName(env.Config().Name())
+	if err != nil {
+		return nil, errors.Annotate(err, "could not connect to api")
+	}
+	return apimetadata.NewClient(api), nil
+}
+
+func imageMetadataFromState(env environs.Environ, ic *imagemetadata.ImageConstraint, signedOnly bool) ([]*imagemetadata.ImageMetadata, *simplestreams.ResolveInfo, error) {
+	metadataAPI, err := metadataAPI(env)
+	if err != nil {
+		return nil, nil, errors.Trace(err)
+	}
+
+	stored, err := metadataAPI.List(ic.Stream, ic.Region, ic.Series, ic.Arches, "", "")
+	if err != nil {
+		return nil, nil, errors.Annotate(err, "could not list image metadata from state server")
+	}
+
+	// Convert to common format.
+	images := make([]*imagemetadata.ImageMetadata, len(stored))
+	for i, one := range stored {
+		m := &imagemetadata.ImageMetadata{
+			Storage:    one.RootStorageType,
+			Id:         one.ImageId,
+			VirtType:   one.VirtType,
+			Arch:       one.Arch,
+			RegionName: one.Region,
+			Stream:     one.Stream,
+		}
+		m.Version, _ = series.SeriesVersion(one.Series)
+		images[i] = m
+	}
+
+	info := &simplestreams.ResolveInfo{}
+	info.Source = "state server"
+	// This is currently ignored for image metadata that is stored in state
+	// since when stored, both signed and unsigned metadata are written,
+	// but whether it was signed or not is not.
+	info.Signed = signedOnly
+	return images, info, nil
+}
+
+// imageMetadataFromDataSources finds image metadata using
+// existing data sources.
+func imageMetadataFromDataSources(env environs.Environ, constraint *imagemetadata.ImageConstraint, signedOnly bool) ([]*imagemetadata.ImageMetadata, *simplestreams.ResolveInfo, error) {
+	sources, err := environs.ImageMetadataSources(env)
+	if err != nil {
+		return nil, nil, err
+	}
+	return imagemetadata.Fetch(sources, constraint, signedOnly)
+}

--- a/provider/common/imagemetadata_test.go
+++ b/provider/common/imagemetadata_test.go
@@ -1,0 +1,131 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package common_test
+
+import (
+	"fmt"
+
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/series"
+	gc "gopkg.in/check.v1"
+
+	basetesting "github.com/juju/juju/api/base/testing"
+	apimetadata "github.com/juju/juju/api/imagemetadata"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/imagemetadata"
+	"github.com/juju/juju/environs/simplestreams"
+	"github.com/juju/juju/provider/common"
+	coretesting "github.com/juju/juju/testing"
+)
+
+type metadataSuite struct {
+	coretesting.FakeJujuHomeSuite
+}
+
+var _ = gc.Suite(&metadataSuite{})
+
+func (s *metadataSuite) TestMetadataNone(c *gc.C) {
+	env, ic, _ := s.setupSimpleStreamData(c, nil)
+
+	metadata, info, err := common.FindImageMetadata(env, ic, false)
+	c.Assert(err, gc.ErrorMatches, ".*not found.*")
+	c.Assert(info, gc.IsNil)
+	c.Assert(metadata, gc.HasLen, 0)
+}
+
+func (s *metadataSuite) TestMetadataNotInStateButInDataSources(c *gc.C) {
+	arch := "ppc64el"
+	env, ic, setupInfo := s.setupSimpleStreamData(c, []string{arch})
+
+	metadata, info, err := common.FindImageMetadata(env, ic, false)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(info, gc.DeepEquals, setupInfo)
+	c.Assert(metadata, gc.DeepEquals, []*imagemetadata.ImageMetadata{&imagemetadata.ImageMetadata{
+		Id:         "image-id",
+		Arch:       arch,
+		RegionName: "Region",
+		Version:    "12.04",
+		Endpoint:   "https://endpoint/",
+	}})
+}
+
+var stateResolveInfo = &simplestreams.ResolveInfo{Source: "state server"}
+
+func (s *metadataSuite) TestMetadataFromState(c *gc.C) {
+	env, ic, _ := s.setupSimpleStreamData(c, nil)
+
+	stored := params.CloudImageMetadata{
+		ImageId: "image_id",
+		Region:  "region",
+		Series:  "trusty",
+		Arch:    "ppc64el",
+	}
+	s.patchMetadataAPI(c, "", stored)
+
+	metadata, info, err := common.FindImageMetadata(env, ic, false)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// This should have pulled image metadata from state server
+	c.Assert(info, gc.DeepEquals, stateResolveInfo)
+	c.Assert(metadata, gc.DeepEquals, []*imagemetadata.ImageMetadata{convertMetadataFromParams(stored)})
+}
+
+func (s *metadataSuite) TestMetadataStateError(c *gc.C) {
+	env, ic, _ := s.setupSimpleStreamData(c, []string{"amd64"})
+
+	msg := "fail"
+	s.patchMetadataAPI(c, msg)
+
+	metadata, info, err := common.FindImageMetadata(env, ic, false)
+	c.Assert(err, gc.ErrorMatches, fmt.Sprintf(".*%v.*", msg))
+	c.Assert(info, gc.IsNil)
+	c.Assert(metadata, gc.HasLen, 0)
+}
+
+func (s *metadataSuite) patchMetadataAPI(c *gc.C, errMsg string, m ...params.CloudImageMetadata) {
+	apiCaller := basetesting.APICallerFunc(
+		func(objType string, version int, id, request string, a, result interface{}) error {
+			if errMsg != "" {
+				return errors.New(errMsg)
+			}
+			if results, k := result.(*params.ListCloudImageMetadataResult); k {
+				results.Result = append(results.Result, m...)
+			}
+			return nil
+		})
+	mockAPI := apimetadata.NewClient(apiCaller)
+
+	s.PatchValue(common.MetadataAPI, func(env environs.Environ) (*apimetadata.Client, error) {
+		return mockAPI, nil
+	})
+	s.AddCleanup(func(*gc.C) {
+		mockAPI.Close()
+	})
+}
+
+func (s *metadataSuite) setupSimpleStreamData(c *gc.C, arches []string) (environs.Environ, *imagemetadata.ImageConstraint, *simplestreams.ResolveInfo) {
+	dsId := "metadataSuite"
+	env, cloudSpec, fileUrl := setupMetadataWithDataSource(c, s.FakeJujuHomeSuite, dsId, arches)
+	ic := imagemetadata.NewImageConstraint(simplestreams.LookupParams{
+		CloudSpec: cloudSpec,
+	})
+
+	info := &simplestreams.ResolveInfo{
+		Source:   dsId,
+		IndexURL: fmt.Sprintf("%v%v", fileUrl, "/streams/v1/index.json"),
+	}
+	return env, ic, info
+}
+
+func convertMetadataFromParams(p params.CloudImageMetadata) *imagemetadata.ImageMetadata {
+	m := &imagemetadata.ImageMetadata{
+		Id:         p.ImageId,
+		Arch:       p.Arch,
+		RegionName: p.Region,
+	}
+	m.Version, _ = series.SeriesVersion(p.Series)
+	return m
+}

--- a/provider/common/supportedarchitectures.go
+++ b/provider/common/supportedarchitectures.go
@@ -4,6 +4,7 @@
 package common
 
 import (
+	"github.com/juju/errors"
 	"github.com/juju/utils/set"
 
 	"github.com/juju/juju/environs"
@@ -12,13 +13,11 @@ import (
 
 // SupportedArchitectures returns all the image architectures for env matching the constraints.
 func SupportedArchitectures(env environs.Environ, imageConstraint *imagemetadata.ImageConstraint) ([]string, error) {
-	sources, err := environs.ImageMetadataSources(env)
+	matchingImages, _, err := FindImageMetadata(env, imageConstraint, false)
 	if err != nil {
-		return nil, err
-	}
-	matchingImages, _, err := imagemetadata.Fetch(sources, imageConstraint, false)
-	if err != nil {
-		return nil, err
+		if !errors.IsNotFound(err) {
+			return nil, err
+		}
 	}
 	var arches = set.NewStrings()
 	for _, im := range matchingImages {

--- a/provider/common/supportedarchitectures_test.go
+++ b/provider/common/supportedarchitectures_test.go
@@ -21,7 +21,12 @@ type archSuite struct {
 
 var _ = gc.Suite(&archSuite{})
 
-func (s *archSuite) setupMetadata(c *gc.C, arches []string) (environs.Environ, simplestreams.CloudSpec) {
+func setupMetadata(c *gc.C, s coretesting.FakeJujuHomeSuite, arches []string) (environs.Environ, simplestreams.CloudSpec) {
+	env, spec, _ := setupMetadataWithDataSource(c, s, "SupportedArchitectures", arches)
+	return env, spec
+}
+
+func setupMetadataWithDataSource(c *gc.C, s coretesting.FakeJujuHomeSuite, dsId string, arches []string) (environs.Environ, simplestreams.CloudSpec, string) {
 	s.PatchValue(&imagemetadata.DefaultBaseURL, "")
 	env := &mockEnviron{
 		config: configGetter(c),
@@ -54,19 +59,19 @@ func (s *archSuite) setupMetadata(c *gc.C, arches []string) (environs.Environ, s
 	err = imagemetadata.MergeAndWriteMetadata("precise", images, &cloudSpec, stor)
 	c.Assert(err, jc.ErrorIsNil)
 
-	id := "SupportedArchitectures"
-	environs.RegisterImageDataSourceFunc(id, func(environs.Environ) (simplestreams.DataSource, error) {
-		return simplestreams.NewURLDataSource(id, "file://"+metadataDir+"/images", false), nil
+	fileURL := "file://" + metadataDir + "/images"
+	environs.RegisterImageDataSourceFunc(dsId, func(environs.Environ) (simplestreams.DataSource, error) {
+		return simplestreams.NewURLDataSource(dsId, fileURL, false), nil
 	})
 	s.AddCleanup(func(*gc.C) {
-		environs.UnregisterImageDataSourceFunc(id)
+		environs.UnregisterImageDataSourceFunc(dsId)
 	})
 
-	return env, cloudSpec
+	return env, cloudSpec, fileURL
 }
 
 func (s *archSuite) TestSupportedArchitecturesNone(c *gc.C) {
-	env, cloudSpec := s.setupMetadata(c, nil)
+	env, cloudSpec := setupMetadata(c, s.FakeJujuHomeSuite, nil)
 	imageConstraint := imagemetadata.NewImageConstraint(simplestreams.LookupParams{
 		CloudSpec: cloudSpec,
 	})
@@ -76,7 +81,7 @@ func (s *archSuite) TestSupportedArchitecturesNone(c *gc.C) {
 }
 
 func (s *archSuite) TestSupportedArchitecturesOne(c *gc.C) {
-	env, cloudSpec := s.setupMetadata(c, []string{"ppc64el"})
+	env, cloudSpec := setupMetadata(c, s.FakeJujuHomeSuite, []string{"ppc64el"})
 	imageConstraint := imagemetadata.NewImageConstraint(simplestreams.LookupParams{
 		CloudSpec: cloudSpec,
 	})
@@ -86,7 +91,7 @@ func (s *archSuite) TestSupportedArchitecturesOne(c *gc.C) {
 }
 
 func (s *archSuite) TestSupportedArchitecturesMany(c *gc.C) {
-	env, cloudSpec := s.setupMetadata(c, []string{"ppc64el", "amd64"})
+	env, cloudSpec := setupMetadata(c, s.FakeJujuHomeSuite, []string{"ppc64el", "amd64"})
 	imageConstraint := imagemetadata.NewImageConstraint(simplestreams.LookupParams{
 		CloudSpec: cloudSpec,
 	})

--- a/provider/ec2/ebs_test.go
+++ b/provider/ec2/ebs_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 type storageSuite struct {
-	testing.BaseSuite
+	testing.FakeJujuHomeSuite
 }
 
 var _ = gc.Suite(&storageSuite{})
@@ -53,7 +53,7 @@ func (s *storageSuite) TestSupports(c *gc.C) {
 var _ = gc.Suite(&ebsVolumeSuite{})
 
 type ebsVolumeSuite struct {
-	testing.BaseSuite
+	testing.FakeJujuHomeSuite
 	jujutest.Tests
 	srv                localServer
 	restoreEC2Patching func()
@@ -67,11 +67,11 @@ func (s *ebsVolumeSuite) SetUpSuite(c *gc.C) {
 	s.UploadArches = []string{arch.AMD64, arch.I386}
 	s.TestConfig = localConfigAttrs
 	s.restoreEC2Patching = patchEC2ForTesting()
-	s.BaseSuite.SetUpSuite(c)
+	s.FakeJujuHomeSuite.SetUpSuite(c)
 }
 
 func (s *ebsVolumeSuite) TearDownSuite(c *gc.C) {
-	s.BaseSuite.TearDownSuite(c)
+	s.FakeJujuHomeSuite.TearDownSuite(c)
 	s.restoreEC2Patching()
 }
 
@@ -81,7 +81,7 @@ func (s *ebsVolumeSuite) SetUpTest(c *gc.C) {
 		Series: testing.FakeDefaultSeries,
 		Arch:   arch.AMD64,
 	})
-	s.BaseSuite.SetUpTest(c)
+	s.FakeJujuHomeSuite.SetUpTest(c)
 	s.srv.startServer(c)
 	s.Tests.SetUpTest(c)
 	s.PatchValue(&ec2.DestroyVolumeAttempt.Delay, time.Duration(0))
@@ -90,7 +90,7 @@ func (s *ebsVolumeSuite) SetUpTest(c *gc.C) {
 func (s *ebsVolumeSuite) TearDownTest(c *gc.C) {
 	s.Tests.TearDownTest(c)
 	s.srv.stopServer(c)
-	s.BaseSuite.TearDownTest(c)
+	s.FakeJujuHomeSuite.TearDownTest(c)
 }
 
 func (s *ebsVolumeSuite) volumeSource(c *gc.C, cfg *storage.Config) storage.VolumeSource {

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -518,13 +518,9 @@ func (e *environ) StartInstance(args environs.StartInstanceParams) (_ *environs.
 		return nil, errors.New("starting instances with networks is not supported yet")
 	}
 	arches := args.Tools.Arches()
-	sources, err := environs.ImageMetadataSources(e)
-	if err != nil {
-		return nil, err
-	}
 
 	series := args.Tools.OneSeries()
-	spec, err := findInstanceSpec(sources, e.Config().ImageStream(), &instances.InstanceConstraint{
+	spec, err := findInstanceSpec(e, e.Config().ImageStream(), &instances.InstanceConstraint{
 		Region:      e.ecfg().region(),
 		Series:      series,
 		Arches:      arches,

--- a/provider/ec2/image.go
+++ b/provider/ec2/image.go
@@ -6,9 +6,11 @@ package ec2
 import (
 	"fmt"
 
+	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/imagemetadata"
 	"github.com/juju/juju/environs/instances"
 	"github.com/juju/juju/environs/simplestreams"
+	"github.com/juju/juju/provider/common"
 )
 
 // signedImageDataOnly is defined here to allow tests to override the content.
@@ -44,8 +46,7 @@ func filterImages(images []*imagemetadata.ImageMetadata, ic *instances.InstanceC
 }
 
 // findInstanceSpec returns an InstanceSpec satisfying the supplied instanceConstraint.
-func findInstanceSpec(
-	sources []simplestreams.DataSource, stream string, ic *instances.InstanceConstraint) (*instances.InstanceSpec, error) {
+func findInstanceSpec(e environs.Environ, stream string, ic *instances.InstanceConstraint) (*instances.InstanceSpec, error) {
 
 	// If the instance type is set, don't also set a default CPU power
 	// as this is implied.
@@ -60,7 +61,7 @@ func findInstanceSpec(
 		Arches:    ic.Arches,
 		Stream:    stream,
 	})
-	matchingImages, _, err := imagemetadata.Fetch(sources, imageConstraint, signedImageDataOnly)
+	matchingImages, _, err := common.FindImageMetadata(e, imageConstraint, signedImageDataOnly)
 	if err != nil {
 		return nil, err
 	}

--- a/provider/ec2/live_test.go
+++ b/provider/ec2/live_test.go
@@ -69,7 +69,7 @@ func registerAmazonTests() {
 // LiveTests contains tests that can be run against the Amazon servers.
 // Each test runs using the same ec2 connection.
 type LiveTests struct {
-	coretesting.BaseSuite
+	coretesting.FakeJujuHomeSuite
 	jujutest.LiveTests
 }
 
@@ -77,28 +77,28 @@ func (t *LiveTests) SetUpSuite(c *gc.C) {
 	// Upload arches that ec2 supports; add to this
 	// as ec2 coverage expands.
 	t.UploadArches = []string{arch.AMD64, arch.I386}
-	t.BaseSuite.SetUpSuite(c)
+	t.FakeJujuHomeSuite.SetUpSuite(c)
 	t.LiveTests.SetUpSuite(c)
 }
 
 func (t *LiveTests) TearDownSuite(c *gc.C) {
 	t.LiveTests.TearDownSuite(c)
-	t.BaseSuite.TearDownSuite(c)
+	t.FakeJujuHomeSuite.TearDownSuite(c)
 }
 
 func (t *LiveTests) SetUpTest(c *gc.C) {
-	t.BaseSuite.PatchValue(&version.Current, version.Binary{
+	t.FakeJujuHomeSuite.PatchValue(&version.Current, version.Binary{
 		Number: coretesting.FakeVersionNumber,
 		Series: coretesting.FakeDefaultSeries,
 		Arch:   arch.AMD64,
 	})
-	t.BaseSuite.SetUpTest(c)
+	t.FakeJujuHomeSuite.SetUpTest(c)
 	t.LiveTests.SetUpTest(c)
 }
 
 func (t *LiveTests) TearDownTest(c *gc.C) {
 	t.LiveTests.TearDownTest(c)
-	t.BaseSuite.TearDownTest(c)
+	t.FakeJujuHomeSuite.TearDownTest(c)
 }
 
 // TODO(niemeyer): Looks like many of those tests should be moved to jujutest.LiveTests.

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -171,7 +171,7 @@ func (srv *localServer) stopServer(c *gc.C) {
 // accessed by using the "test" region, which is changed to point to the
 // network address of the local server.
 type localServerSuite struct {
-	coretesting.BaseSuite
+	coretesting.FakeJujuHomeSuite
 	jujutest.Tests
 	srv                localServer
 	restoreEC2Patching func()
@@ -183,12 +183,12 @@ func (t *localServerSuite) SetUpSuite(c *gc.C) {
 	t.UploadArches = []string{arch.AMD64, arch.I386}
 	t.TestConfig = localConfigAttrs
 	t.restoreEC2Patching = patchEC2ForTesting()
-	t.BaseSuite.SetUpSuite(c)
+	t.FakeJujuHomeSuite.SetUpSuite(c)
 	t.srv.createRootDisks = true
 }
 
 func (t *localServerSuite) TearDownSuite(c *gc.C) {
-	t.BaseSuite.TearDownSuite(c)
+	t.FakeJujuHomeSuite.TearDownSuite(c)
 	t.restoreEC2Patching()
 }
 
@@ -198,7 +198,7 @@ func (t *localServerSuite) SetUpTest(c *gc.C) {
 		Series: coretesting.FakeDefaultSeries,
 		Arch:   arch.AMD64,
 	})
-	t.BaseSuite.SetUpTest(c)
+	t.FakeJujuHomeSuite.SetUpTest(c)
 	t.SetFeatureFlags(feature.AddressAllocation)
 	t.srv.startServer(c)
 	t.Tests.SetUpTest(c)
@@ -207,7 +207,7 @@ func (t *localServerSuite) SetUpTest(c *gc.C) {
 func (t *localServerSuite) TearDownTest(c *gc.C) {
 	t.Tests.TearDownTest(c)
 	t.srv.stopServer(c)
-	t.BaseSuite.TearDownTest(c)
+	t.FakeJujuHomeSuite.TearDownTest(c)
 }
 
 func (t *localServerSuite) prepareEnviron(c *gc.C) environs.NetworkingEnviron {

--- a/provider/gce/environ_broker.go
+++ b/provider/gce/environ_broker.go
@@ -135,11 +135,6 @@ var findInstanceSpec = func(env *environ, stream string, ic *instances.InstanceC
 // initial data for the spec. However, it does include fetching the
 // correct simplestreams image data.
 func (env *environ) findInstanceSpec(stream string, ic *instances.InstanceConstraint) (*instances.InstanceSpec, error) {
-	sources, err := environs.ImageMetadataSources(env)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
 	imageConstraint := imagemetadata.NewImageConstraint(simplestreams.LookupParams{
 		CloudSpec: env.cloudSpec(ic.Region),
 		Series:    []string{ic.Series},
@@ -148,7 +143,7 @@ func (env *environ) findInstanceSpec(stream string, ic *instances.InstanceConstr
 	})
 
 	signedImageDataOnly := false
-	matchingImages, _, err := imageMetadataFetch(sources, imageConstraint, signedImageDataOnly)
+	matchingImages, _, err := imageMetadataFetch(env, imageConstraint, signedImageDataOnly)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -158,7 +153,7 @@ func (env *environ) findInstanceSpec(stream string, ic *instances.InstanceConstr
 	return spec, errors.Trace(err)
 }
 
-var imageMetadataFetch = imagemetadata.Fetch
+var imageMetadataFetch = common.FindImageMetadata
 
 // newRawInstance is where the new physical instance is actually
 // provisioned, relative to the provided args and spec. Info for that

--- a/provider/gce/testing_test.go
+++ b/provider/gce/testing_test.go
@@ -415,7 +415,7 @@ type fakeImages struct {
 	ResolveInfo *simplestreams.ResolveInfo
 }
 
-func (fi *fakeImages) ImageMetadataFetch(sources []simplestreams.DataSource, cons *imagemetadata.ImageConstraint, onlySigned bool) ([]*imagemetadata.ImageMetadata, *simplestreams.ResolveInfo, error) {
+func (fi *fakeImages) ImageMetadataFetch(env environs.Environ, cons *imagemetadata.ImageConstraint, onlySigned bool) ([]*imagemetadata.ImageMetadata, *simplestreams.ResolveInfo, error) {
 	return fi.Metadata, fi.ResolveInfo, fi.err()
 }
 

--- a/provider/joyent/environ_instance.go
+++ b/provider/joyent/environ_instance.go
@@ -360,12 +360,8 @@ func (env *joyentEnviron) FindInstanceSpec(ic *instances.InstanceConstraint) (*i
 		Series:    []string{ic.Series},
 		Arches:    ic.Arches,
 	})
-	sources, err := environs.ImageMetadataSources(env)
-	if err != nil {
-		return nil, err
-	}
 
-	matchingImages, _, err := imagemetadata.Fetch(sources, imageConstraint, signedImageDataOnly)
+	matchingImages, _, err := common.FindImageMetadata(env, imageConstraint, signedImageDataOnly)
 	if err != nil {
 		return nil, err
 	}

--- a/provider/joyent/local_test.go
+++ b/provider/joyent/local_test.go
@@ -354,7 +354,7 @@ func (s *localServerSuite) TestFindImageBadDefaultImage(c *gc.C) {
 	env := s.Prepare(c)
 	// An error occurs if no suitable image is found.
 	_, err := joyent.FindInstanceSpec(env, "saucy", "amd64", "mem=4G")
-	c.Assert(err, gc.ErrorMatches, `no "saucy" images in some-region with arches \[amd64\]`)
+	c.Assert(err, gc.ErrorMatches, `image metadata for series \[saucy\], architectures \[amd64\] not found`)
 }
 
 func (s *localServerSuite) TestValidateImageMetadata(c *gc.C) {

--- a/provider/openstack/image.go
+++ b/provider/openstack/image.go
@@ -4,10 +4,10 @@
 package openstack
 
 import (
-	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/imagemetadata"
 	"github.com/juju/juju/environs/instances"
 	"github.com/juju/juju/environs/simplestreams"
+	"github.com/juju/juju/provider/common"
 )
 
 // findInstanceSpec returns an image and instance type satisfying the constraint.
@@ -39,12 +39,8 @@ func findInstanceSpec(e *environ, ic *instances.InstanceConstraint) (*instances.
 		Arches:    ic.Arches,
 		Stream:    e.Config().ImageStream(),
 	})
-	sources, err := environs.ImageMetadataSources(e)
-	if err != nil {
-		return nil, err
-	}
 	// TODO (wallyworld): use an env parameter (default true) to mandate use of only signed image metadata.
-	matchingImages, _, err := imagemetadata.Fetch(sources, imageConstraint, false)
+	matchingImages, _, err := common.FindImageMetadata(e, imageConstraint, false)
 	if err != nil {
 		return nil, err
 	}

--- a/provider/openstack/live_test.go
+++ b/provider/openstack/live_test.go
@@ -78,14 +78,14 @@ func registerLiveTests(cred *identity.Credentials) {
 // The deployment can be a real live instance or service doubles.
 // Each test runs using the same connection.
 type LiveTests struct {
-	coretesting.BaseSuite
+	coretesting.FakeJujuHomeSuite
 	jujutest.LiveTests
 	cred            *identity.Credentials
 	metadataStorage storage.Storage
 }
 
 func (t *LiveTests) SetUpSuite(c *gc.C) {
-	t.BaseSuite.SetUpSuite(c)
+	t.FakeJujuHomeSuite.SetUpSuite(c)
 	// Update some Config items now that we have services running.
 	// This is setting the simplestreams urls and auth-url because that
 	// information is set during startup of the localLiveSuite
@@ -118,17 +118,17 @@ func (t *LiveTests) TearDownSuite(c *gc.C) {
 		envtesting.RemoveFakeToolsMetadata(c, t.metadataStorage)
 	}
 	t.LiveTests.TearDownSuite(c)
-	t.BaseSuite.TearDownSuite(c)
+	t.FakeJujuHomeSuite.TearDownSuite(c)
 }
 
 func (t *LiveTests) SetUpTest(c *gc.C) {
-	t.BaseSuite.SetUpTest(c)
+	t.FakeJujuHomeSuite.SetUpTest(c)
 	t.LiveTests.SetUpTest(c)
 }
 
 func (t *LiveTests) TearDownTest(c *gc.C) {
 	t.LiveTests.TearDownTest(c)
-	t.BaseSuite.TearDownTest(c)
+	t.FakeJujuHomeSuite.TearDownTest(c)
 }
 
 func (t *LiveTests) TestEnsureGroupSetsGroupId(c *gc.C) {


### PR DESCRIPTION
This PR changes image metadata search path  to look into state server before looking into simplestreams.

Most interesting changes are in provider/common/imagemetadata files and bootstrap files.

WIP because I am unsure:

1. Is behavior around bootstrap correct? 

2. environs/tools/simplestreams.go currently uses Fetch and GetMetadata with datasource... This will now by-pass state.. Is this still a desired behaviour?

3. provider/vsphere/image_metadata.go currently uses GetMetadata with datasource... This will now by-pass state.. Is this still a desired behaviour?

4. environs/tools/validation.go currently uses Fetch with datasource... This will now by-pass state.. Is this still a desired behaviour? It is used in exported ValidateToolsMetadata which is called in production code of cmd/plugins/juju-metadata/validatetoolsmetadata.go

5. environs/imagemetadata/generate.go currently uses Fetch with datasource... It is used in exported MergeAndWriteMetadata func used in production[1] and test[2] code. This will now by-pass state.. Is this still a desired behaviour?
[1] 
[cmd/plugins/juju-metadata/imagemetadata.go,
cmd/plugins/juju-metadata/toolsmetadata.go,
cmd/plugins/juju-metadata/validatemetadata_test.go,
environs/sync/sync.go,
environs/tools/simplestreams.go] 
[2]
[cmd/juju/commands/bootstrap_test.go, 
cmd/jujud/agent/testing/agent.go,
environs/bootstrap/bootstrap_test.go,
environs/testing/tools.go,
environs/tools/simplestreams _test,
environs/tools/testing/testing.go,
provider/common/supportedarchitectures_test.go,
worker/upgrader/upgrader_test.go]

6. Do I need to worry about updates/upgrades?

7. Need to do manual testing.

