### PR TITLE
UnitAssigner worker

### DIFF
--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -60,6 +60,7 @@ var facadeVersions = map[string]int{
 	"StringsWatcher":               0,
 	"SystemManager":                1,
 	"Upgrader":                     0,
+	"UnitAssigner":                 0,
 	"Uniter":                       2,
 	"UserManager":                  0,
 	"VolumeAttachmentsWatcher":     1,

--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -60,7 +60,7 @@ var facadeVersions = map[string]int{
 	"StringsWatcher":               0,
 	"SystemManager":                1,
 	"Upgrader":                     0,
-	"UnitAssigner":                 0,
+	"UnitAssigner":                 1,
 	"Uniter":                       2,
 	"UserManager":                  0,
 	"VolumeAttachmentsWatcher":     1,

--- a/api/facadeversions_test.go
+++ b/api/facadeversions_test.go
@@ -6,6 +6,7 @@ package api_test
 import (
 	"strings"
 
+	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/set"
 	gc "gopkg.in/check.v1"
 
@@ -43,7 +44,7 @@ func (s *facadeVersionSuite) TestFacadeVersionsMatchServerVersions(c *gc.C) {
 	c.Check(serverFacadeNames.Difference(clientFacadeNames).SortedValues(), gc.HasLen, 0)
 	c.Check(clientFacadeNames.Difference(serverFacadeNames).SortedValues(), gc.HasLen, 0)
 	// Next check that the best versions match
-	c.Check(*api.FacadeVersions, gc.DeepEquals, serverFacadeBestVersions)
+	c.Check(*api.FacadeVersions, jc.DeepEquals, serverFacadeBestVersions)
 }
 
 func checkBestVersion(c *gc.C, desiredVersion int, versions []int, expectedVersion int) {

--- a/api/interface.go
+++ b/api/interface.go
@@ -29,6 +29,7 @@ import (
 	"github.com/juju/juju/api/resumer"
 	"github.com/juju/juju/api/rsyslog"
 	"github.com/juju/juju/api/storageprovisioner"
+	"github.com/juju/juju/api/unitassigner"
 	"github.com/juju/juju/api/uniter"
 	"github.com/juju/juju/api/upgrader"
 	"github.com/juju/juju/network"
@@ -182,4 +183,5 @@ type Connection interface {
 	Cleaner() *cleaner.API
 	Rsyslog() *rsyslog.State
 	MetadataUpdater() *imagemetadata.Client
+	UnitAssigner() unitassigner.API
 }

--- a/api/state.go
+++ b/api/state.go
@@ -277,7 +277,7 @@ func (st *state) Machiner() *machiner.State {
 
 // UnitAssigner returns a version of the state that provides functionality
 // required by the unitassigner worker.
-func (st *State) UnitAssigner() unitassigner.API {
+func (st *state) UnitAssigner() unitassigner.API {
 	return unitassigner.New(st)
 }
 

--- a/api/state.go
+++ b/api/state.go
@@ -31,6 +31,7 @@ import (
 	"github.com/juju/juju/api/resumer"
 	"github.com/juju/juju/api/rsyslog"
 	"github.com/juju/juju/api/storageprovisioner"
+	"github.com/juju/juju/api/unitassigner"
 	"github.com/juju/juju/api/uniter"
 	"github.com/juju/juju/api/upgrader"
 	"github.com/juju/juju/apiserver/params"
@@ -272,6 +273,12 @@ func (st *state) Client() *Client {
 // required by the machiner worker.
 func (st *state) Machiner() *machiner.State {
 	return machiner.NewState(st)
+}
+
+// UnitAssigner returns a version of the state that provides functionality
+// required by the unitassigner worker.
+func (st *State) UnitAssigner() unitassigner.API {
+	return unitassigner.New(st)
 }
 
 // Resumer returns a version of the state that provides functionality

--- a/api/unitassigner/package_test.go
+++ b/api/unitassigner/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package unitassigner
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/api/unitassigner/unitassigner.go
+++ b/api/unitassigner/unitassigner.go
@@ -26,6 +26,8 @@ func New(caller base.APICaller) API {
 }
 
 // AssignUnits tells the state server to run whatever unit assignments it has.
+// Unit assignments for units that no longer exist will return an error that
+// satisfies errors.IsNotFound.
 func (a API) AssignUnits(tags []names.UnitTag) ([]error, error) {
 	entities := make([]params.Entity, len(tags))
 	for i, tag := range tags {
@@ -46,7 +48,7 @@ func (a API) AssignUnits(tags []names.UnitTag) ([]error, error) {
 	return errs, nil
 }
 
-// convertNotFound converts param notfound errors into normal notfound errors.
+// convertNotFound converts param notfound errors into errors.notfound values.
 func convertNotFound(err error) error {
 	if params.IsCodeNotFound(err) {
 		return errors.NewNotFound(err, "")

--- a/api/unitassigner/unitassigner.go
+++ b/api/unitassigner/unitassigner.go
@@ -1,0 +1,56 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package unitassigner
+
+import (
+	"fmt"
+
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/api/watcher"
+	"github.com/juju/juju/apiserver/params"
+)
+
+const uaFacade = "UnitAssigner"
+
+// API provides access to the UnitAssigner API facade.
+type API struct {
+	facade base.FacadeCaller
+}
+
+// New creates a new client-side UnitAssigner facade.
+func New(caller base.APICaller) API {
+	fc := base.NewFacadeCaller(caller, uaFacade)
+	return API{facade: fc}
+}
+
+// AssignUnits tells the state server to run whatever unit assignments it has.
+func (a API) AssignUnits() error {
+	var result params.AssignUnitsResult
+	if err := a.facade.FacadeCall("AssignUnits", nil, &result); err != nil {
+		return err
+	}
+	if result.Error != nil {
+		return result.Error
+	}
+	return nil
+}
+
+// WatchUnitAssignments watches the server for new unit assignments to be
+// created.
+func (a API) WatchUnitAssignments() (watcher.NotifyWatcher, error) {
+	var results params.NotifyWatchResults
+	err := a.facade.FacadeCall("WatchUnitAssignments", nil, &results)
+	if err != nil {
+		return nil, err
+	}
+	if len(results.Results) != 1 {
+		return nil, fmt.Errorf("expected 1 result, got %d", len(results.Results))
+	}
+	result := results.Results[0]
+	if result.Error != nil {
+		return nil, result.Error
+	}
+	w := watcher.NewNotifyWatcher(a.facade.RawAPICaller(), result)
+	return w, nil
+}

--- a/api/unitassigner/unitassigner.go
+++ b/api/unitassigner/unitassigner.go
@@ -23,15 +23,12 @@ func New(caller base.APICaller) API {
 }
 
 // AssignUnits tells the state server to run whatever unit assignments it has.
-func (a API) AssignUnits() error {
-	var result params.AssignUnitsResult
+func (a API) AssignUnits() (params.AssignUnitsResults, error) {
+	var result params.AssignUnitsResults
 	if err := a.facade.FacadeCall("AssignUnits", nil, &result); err != nil {
-		return err
+		return result, err
 	}
-	if result.Error != nil {
-		return result.Error
-	}
-	return nil
+	return result, nil
 }
 
 // WatchUnitAssignments watches the server for new unit assignments to be

--- a/api/unitassigner/unitassigner.go
+++ b/api/unitassigner/unitassigner.go
@@ -23,9 +23,10 @@ func New(caller base.APICaller) API {
 }
 
 // AssignUnits tells the state server to run whatever unit assignments it has.
-func (a API) AssignUnits() (params.AssignUnitsResults, error) {
+func (a API) AssignUnits(ids []string) (params.AssignUnitsResults, error) {
+	args := params.AssignUnitsParams{IDs: ids}
 	var result params.AssignUnitsResults
-	if err := a.facade.FacadeCall("AssignUnits", nil, &result); err != nil {
+	if err := a.facade.FacadeCall("AssignUnits", args, &result); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -33,8 +34,8 @@ func (a API) AssignUnits() (params.AssignUnitsResults, error) {
 
 // WatchUnitAssignments watches the server for new unit assignments to be
 // created.
-func (a API) WatchUnitAssignments() (watcher.NotifyWatcher, error) {
-	var result params.NotifyWatchResult
+func (a API) WatchUnitAssignments() (watcher.StringsWatcher, error) {
+	var result params.StringsWatchResult
 	err := a.facade.FacadeCall("WatchUnitAssignments", nil, &result)
 	if err != nil {
 		return nil, err
@@ -42,6 +43,6 @@ func (a API) WatchUnitAssignments() (watcher.NotifyWatcher, error) {
 	if result.Error != nil {
 		return nil, result.Error
 	}
-	w := watcher.NewNotifyWatcher(a.facade.RawAPICaller(), result)
+	w := watcher.NewStringsWatcher(a.facade.RawAPICaller(), result)
 	return w, nil
 }

--- a/api/unitassigner/unitassigner.go
+++ b/api/unitassigner/unitassigner.go
@@ -4,8 +4,6 @@
 package unitassigner
 
 import (
-	"fmt"
-
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/api/watcher"
 	"github.com/juju/juju/apiserver/params"
@@ -39,15 +37,11 @@ func (a API) AssignUnits() error {
 // WatchUnitAssignments watches the server for new unit assignments to be
 // created.
 func (a API) WatchUnitAssignments() (watcher.NotifyWatcher, error) {
-	var results params.NotifyWatchResults
-	err := a.facade.FacadeCall("WatchUnitAssignments", nil, &results)
+	var result params.NotifyWatchResult
+	err := a.facade.FacadeCall("WatchUnitAssignments", nil, &result)
 	if err != nil {
 		return nil, err
 	}
-	if len(results.Results) != 1 {
-		return nil, fmt.Errorf("expected 1 result, got %d", len(results.Results))
-	}
-	result := results.Results[0]
 	if result.Error != nil {
 		return nil, result.Error
 	}

--- a/api/unitassigner/unitassigner_test.go
+++ b/api/unitassigner/unitassigner_test.go
@@ -1,0 +1,64 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package unitassigner
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/apiserver/params"
+)
+
+var _ = gc.Suite(testsuite{})
+
+type testsuite struct{}
+
+func (testsuite) TestAssignUnits(c *gc.C) {
+	f := &fakeAPICaller{}
+	api := New(f)
+	ids := []string{"foo", "bar"}
+	res, err := api.AssignUnits(ids)
+	c.Assert(f.request, gc.Equals, "AssignUnits")
+	c.Assert(f.params, gc.DeepEquals, params.AssignUnitsParams{IDs: ids})
+	c.Assert(err, jc.ErrorIsNil)
+	if r, ok := f.response.(*params.AssignUnitsResults); !ok {
+		c.Errorf("Expected &params.AssignUnitsResults, got %#v", f.response)
+	} else {
+		c.Assert(res, gc.DeepEquals, *r)
+	}
+}
+
+func (testsuite) TestWatchUnitAssignment(c *gc.C) {
+	f := &fakeAPICaller{}
+	api := New(f)
+	w, err := api.WatchUnitAssignments()
+	c.Assert(f.request, gc.Equals, "WatchUnitAssignments")
+	c.Assert(f.params, gc.IsNil)
+	c.Assert(err, jc.ErrorIsNil)
+	if _, ok := f.response.(*params.StringsWatchResult); !ok {
+		c.Errorf("Expected &params.StringsWatchResult, got %#v", f.response)
+	}
+	c.Assert(w, gc.NotNil)
+}
+
+type fakeAPICaller struct {
+	base.APICaller
+	request  string
+	params   interface{}
+	response interface{}
+	err      error
+}
+
+func (f *fakeAPICaller) APICall(objType string, version int, id, request string, params, response interface{}) error {
+	f.request = request
+	f.params = params
+	f.response = response
+	return f.err
+
+}
+
+func (fakeAPICaller) BestFacadeVersion(facade string) int {
+	return 0
+}

--- a/api/unitassigner/unitassigner_test.go
+++ b/api/unitassigner/unitassigner_test.go
@@ -36,7 +36,10 @@ func (testsuite) TestAssignUnits(c *gc.C) {
 }
 
 func (testsuite) TestWatchUnitAssignment(c *gc.C) {
-	f := &fakeWatchCaller{c: c}
+	f := &fakeWatchCaller{
+		c:        c,
+		response: params.StringsWatchResult{},
+	}
 	api := New(f)
 	w, err := api.WatchUnitAssignments()
 	c.Assert(f.request, gc.Equals, "WatchUnitAssignments")

--- a/api/unitassigner/unitassigner_test.go
+++ b/api/unitassigner/unitassigner_test.go
@@ -4,6 +4,7 @@
 package unitassigner
 
 import (
+	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -22,7 +23,7 @@ func (testsuite) TestAssignUnits(c *gc.C) {
 			{},
 		}}}
 	api := New(f)
-	ids := []string{"mysql/0", "mysql/1"}
+	ids := []names.UnitTag{names.NewUnitTag("mysql/0"), names.NewUnitTag("mysql/1")}
 	errs, err := api.AssignUnits(ids)
 	c.Assert(f.request, gc.Equals, "AssignUnits")
 	c.Assert(f.params, gc.DeepEquals,
@@ -33,14 +34,6 @@ func (testsuite) TestAssignUnits(c *gc.C) {
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(errs, gc.DeepEquals, []error{nil, nil})
-}
-
-func (testsuite) TestAssignBadUnit(c *gc.C) {
-	f := &fakeAssignCaller{c: c}
-	api := New(f)
-	ids := []string{"foo", "bar"}
-	_, err := api.AssignUnits(ids)
-	c.Assert(err, gc.ErrorMatches, `"foo" is not a valid unit id`)
 }
 
 func (testsuite) TestWatchUnitAssignment(c *gc.C) {

--- a/api/unitassigner/unitassigner_test.go
+++ b/api/unitassigner/unitassigner_test.go
@@ -35,6 +35,14 @@ func (testsuite) TestAssignUnits(c *gc.C) {
 	c.Assert(errs, gc.DeepEquals, []error{nil, nil})
 }
 
+func (testsuite) TestAssignBadUnit(c *gc.C) {
+	f := &fakeAssignCaller{c: c}
+	api := New(f)
+	ids := []string{"foo", "bar"}
+	_, err := api.AssignUnits(ids)
+	c.Assert(err, gc.ErrorMatches, `"foo" is not a valid unit id`)
+}
+
 func (testsuite) TestWatchUnitAssignment(c *gc.C) {
 	f := &fakeWatchCaller{
 		c:        c,

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -45,6 +45,7 @@ import (
 	_ "github.com/juju/juju/apiserver/storageprovisioner"
 	_ "github.com/juju/juju/apiserver/subnets"
 	_ "github.com/juju/juju/apiserver/systemmanager"
+	_ "github.com/juju/juju/apiserver/unitassigner"
 	_ "github.com/juju/juju/apiserver/uniter"
 	_ "github.com/juju/juju/apiserver/upgrader"
 	_ "github.com/juju/juju/apiserver/usermanager"

--- a/apiserver/charmrevisionupdater/testing/suite.go
+++ b/apiserver/charmrevisionupdater/testing/suite.go
@@ -109,7 +109,7 @@ func (s *CharmSuite) AddService(c *gc.C, charmName, serviceName string, networks
 	ch, ok := s.charms[charmName]
 	c.Assert(ok, jc.IsTrue)
 	owner := s.jcSuite.AdminUserTag(c)
-	_, err := s.jcSuite.State.AddService(serviceName, owner.String(), ch, networks, nil, nil)
+	_, err := s.jcSuite.State.AddService(state.AddServiceArgs{Name: serviceName, Owner: owner.String(), Charm: ch, Networks: networks})
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/apiserver/charmrevisionupdater/testing/suite.go
+++ b/apiserver/charmrevisionupdater/testing/suite.go
@@ -109,7 +109,7 @@ func (s *CharmSuite) AddService(c *gc.C, charmName, serviceName string, networks
 	ch, ok := s.charms[charmName]
 	c.Assert(ok, jc.IsTrue)
 	owner := s.jcSuite.AdminUserTag(c)
-	_, err := s.jcSuite.State.AddService(serviceName, owner.String(), ch, networks, nil)
+	_, err := s.jcSuite.State.AddService(serviceName, owner.String(), ch, networks, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/apiserver/client/client_test.go
+++ b/apiserver/client/client_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/juju/juju/apiserver/service"
 	"github.com/juju/juju/apiserver/testing"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
-	cmdutil "github.com/juju/juju/cmd/jujud/util"
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/manual"
@@ -40,8 +39,6 @@ import (
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/testing/factory"
 	"github.com/juju/juju/version"
-	"github.com/juju/juju/worker"
-	"github.com/juju/juju/worker/unitassigner"
 )
 
 type Killer interface {
@@ -1622,12 +1619,6 @@ func (s *clientRepoSuite) SetUpTest(c *gc.C) {
 	s.CharmStoreSuite.SetUpTest(c)
 
 	c.Assert(s.APIState, gc.NotNil)
-
-	runner := worker.NewRunner(func(error) bool { return false }, cmdutil.MoreImportant)
-	runner.StartWorker("unitassigner", func() (worker.Worker, error) {
-		c.Assert(s.APIState, gc.NotNil)
-		return unitassigner.New(s.APIState.UnitAssigner()), nil
-	})
 }
 
 func (s *clientRepoSuite) TearDownTest(c *gc.C) {

--- a/apiserver/client/client_test.go
+++ b/apiserver/client/client_test.go
@@ -1791,35 +1791,19 @@ func (s *clientRepoSuite) TestClientServiceDeployToMachine(c *gc.C) {
 	c.Assert(charm.Meta(), gc.DeepEquals, ch.Meta())
 	c.Assert(charm.Config(), gc.DeepEquals, ch.Config())
 
-	retry(func(last bool) bool {
+	for a := coretesting.LongAttempt.Start(); a.Next(); {
 		units, err := service.AllUnits()
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(units, gc.HasLen, 1)
 
 		mid, err := units[0].AssignedMachineId()
-		if last {
+		if !a.HasNext() {
 			c.Assert(err, jc.ErrorIsNil)
 		} else if err != nil {
-			return false // we'll retry
+			continue // we'll retry
 		}
 		c.Assert(mid, gc.Equals, machine.Id())
-		return true
-	})
-}
-
-// retry is a helper that will retry the given function until it returns true
-// for up to 3 seconds.  The last time it is run it'll pass in true to the
-// function.
-func retry(f func(last bool) bool) {
-	x := 0
-	for ; x < 30; x++ {
-		if f(false) {
-			break
-		}
-		<-time.After(100 * time.Millisecond)
-	}
-	if x == 30 {
-		f(true)
+		break
 	}
 }
 

--- a/apiserver/client/run_test.go
+++ b/apiserver/client/run_test.go
@@ -76,22 +76,22 @@ func (s *runSuite) addUnit(c *gc.C, service *state.Service) *state.Unit {
 func (s *runSuite) TestGetAllUnitNames(c *gc.C) {
 	charm := s.AddTestingCharm(c, "dummy")
 	owner := s.AdminUserTag(c)
-	magic, err := s.State.AddService("magic", owner.String(), charm, nil, nil, nil)
+	magic, err := s.State.AddService(state.AddServiceArgs{Name: "magic", Owner: owner.String(), Charm: charm})
 	s.addUnit(c, magic)
 	s.addUnit(c, magic)
 
-	notAssigned, err := s.State.AddService("not-assigned", owner.String(), charm, nil, nil, nil)
+	notAssigned, err := s.State.AddService(state.AddServiceArgs{Name: "not-assigned", Owner: owner.String(), Charm: charm})
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = notAssigned.AddUnit()
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = s.State.AddService("no-units", owner.String(), charm, nil, nil, nil)
+	_, err = s.State.AddService(state.AddServiceArgs{Name: "no-units", Owner: owner.String(), Charm: charm})
 	c.Assert(err, jc.ErrorIsNil)
 
-	wordpress, err := s.State.AddService("wordpress", owner.String(), s.AddTestingCharm(c, "wordpress"), nil, nil, nil)
+	wordpress, err := s.State.AddService(state.AddServiceArgs{Name: "wordpress", Owner: owner.String(), Charm: s.AddTestingCharm(c, "wordpress")})
 	c.Assert(err, jc.ErrorIsNil)
 	wordpress0 := s.addUnit(c, wordpress)
-	_, err = s.State.AddService("logging", owner.String(), s.AddTestingCharm(c, "logging"), nil, nil, nil)
+	_, err = s.State.AddService(state.AddServiceArgs{Name: "logging", Owner: owner.String(), Charm: s.AddTestingCharm(c, "logging")})
 	c.Assert(err, jc.ErrorIsNil)
 
 	eps, err := s.State.InferEndpoints("logging", "wordpress")
@@ -276,7 +276,7 @@ func (s *runSuite) TestRunMachineAndService(c *gc.C) {
 
 	charm := s.AddTestingCharm(c, "dummy")
 	owner := s.Factory.MakeUser(c, nil).Tag()
-	magic, err := s.State.AddService("magic", owner.String(), charm, nil, nil, nil)
+	magic, err := s.State.AddService(state.AddServiceArgs{Name: "magic", Owner: owner.String(), Charm: charm})
 	c.Assert(err, jc.ErrorIsNil)
 	s.addUnit(c, magic)
 	s.addUnit(c, magic)
@@ -323,7 +323,7 @@ func (s *runSuite) TestBlockRunMachineAndService(c *gc.C) {
 
 	charm := s.AddTestingCharm(c, "dummy")
 	owner := s.Factory.MakeUser(c, nil).Tag()
-	magic, err := s.State.AddService("magic", owner.String(), charm, nil, nil, nil)
+	magic, err := s.State.AddService(state.AddServiceArgs{Name: "magic", Owner: owner.String(), Charm: charm})
 	c.Assert(err, jc.ErrorIsNil)
 	s.addUnit(c, magic)
 	s.addUnit(c, magic)

--- a/apiserver/client/run_test.go
+++ b/apiserver/client/run_test.go
@@ -76,22 +76,22 @@ func (s *runSuite) addUnit(c *gc.C, service *state.Service) *state.Unit {
 func (s *runSuite) TestGetAllUnitNames(c *gc.C) {
 	charm := s.AddTestingCharm(c, "dummy")
 	owner := s.AdminUserTag(c)
-	magic, err := s.State.AddService("magic", owner.String(), charm, nil, nil)
+	magic, err := s.State.AddService("magic", owner.String(), charm, nil, nil, nil)
 	s.addUnit(c, magic)
 	s.addUnit(c, magic)
 
-	notAssigned, err := s.State.AddService("not-assigned", owner.String(), charm, nil, nil)
+	notAssigned, err := s.State.AddService("not-assigned", owner.String(), charm, nil, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = notAssigned.AddUnit()
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = s.State.AddService("no-units", owner.String(), charm, nil, nil)
+	_, err = s.State.AddService("no-units", owner.String(), charm, nil, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
-	wordpress, err := s.State.AddService("wordpress", owner.String(), s.AddTestingCharm(c, "wordpress"), nil, nil)
+	wordpress, err := s.State.AddService("wordpress", owner.String(), s.AddTestingCharm(c, "wordpress"), nil, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	wordpress0 := s.addUnit(c, wordpress)
-	_, err = s.State.AddService("logging", owner.String(), s.AddTestingCharm(c, "logging"), nil, nil)
+	_, err = s.State.AddService("logging", owner.String(), s.AddTestingCharm(c, "logging"), nil, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	eps, err := s.State.InferEndpoints("logging", "wordpress")
@@ -276,7 +276,7 @@ func (s *runSuite) TestRunMachineAndService(c *gc.C) {
 
 	charm := s.AddTestingCharm(c, "dummy")
 	owner := s.Factory.MakeUser(c, nil).Tag()
-	magic, err := s.State.AddService("magic", owner.String(), charm, nil, nil)
+	magic, err := s.State.AddService("magic", owner.String(), charm, nil, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	s.addUnit(c, magic)
 	s.addUnit(c, magic)
@@ -323,7 +323,7 @@ func (s *runSuite) TestBlockRunMachineAndService(c *gc.C) {
 
 	charm := s.AddTestingCharm(c, "dummy")
 	owner := s.Factory.MakeUser(c, nil).Tag()
-	magic, err := s.State.AddService("magic", owner.String(), charm, nil, nil)
+	magic, err := s.State.AddService("magic", owner.String(), charm, nil, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	s.addUnit(c, magic)
 	s.addUnit(c, magic)

--- a/apiserver/common/registry.go
+++ b/apiserver/common/registry.go
@@ -184,7 +184,7 @@ func (f *FacadeRegistry) Register(name string, version int, factory FacadeFactor
 	} else {
 		f.facades[name] = versions{version: record}
 	}
-	logger.Debugf("Registered facade %q v%d", name, version)
+	logger.Tracef("Registered facade %q v%d", name, version)
 	return nil
 }
 

--- a/apiserver/common/registry.go
+++ b/apiserver/common/registry.go
@@ -184,6 +184,7 @@ func (f *FacadeRegistry) Register(name string, version int, factory FacadeFactor
 	} else {
 		f.facades[name] = versions{version: record}
 	}
+	logger.Debugf("Registered facade %q v%d", name, version)
 	return nil
 }
 

--- a/apiserver/common/setstatus.go
+++ b/apiserver/common/setstatus.go
@@ -228,12 +228,12 @@ func (s *StatusSetter) UpdateStatus(args params.SetStatus) (params.ErrorResults,
 	return result, nil
 }
 
-// UnitAgentFinder is a state.EntityFinder that finds units.
+// UnitAgentFinder is a state.EntityFinder that finds unit agents.
 type UnitAgentFinder struct {
 	state.EntityFinder
 }
 
-// FindEntity implements state.EntityFinder and returns units.
+// FindEntity implements state.EntityFinder and returns unit agents.
 func (ua *UnitAgentFinder) FindEntity(tag names.Tag) (state.Entity, error) {
 	_, ok := tag.(names.UnitTag)
 	if !ok {
@@ -243,5 +243,11 @@ func (ua *UnitAgentFinder) FindEntity(tag names.Tag) (state.Entity, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return entity.(*state.Unit).Agent(), nil
+	// this returns a state.Unit, but for testing we just cast to the minimal
+	// interface we need.
+	return entity.(hasAgent).Agent(), nil
+}
+
+type hasAgent interface {
+	Agent() *state.UnitAgent
 }

--- a/apiserver/common/setstatus.go
+++ b/apiserver/common/setstatus.go
@@ -227,3 +227,21 @@ func (s *StatusSetter) UpdateStatus(args params.SetStatus) (params.ErrorResults,
 	}
 	return result, nil
 }
+
+// UnitAgentFinder is a state.EntityFinder that finds units.
+type UnitAgentFinder struct {
+	state.EntityFinder
+}
+
+// FindEntity implements state.EntityFinder and returns units.
+func (ua *UnitAgentFinder) FindEntity(tag names.Tag) (state.Entity, error) {
+	_, ok := tag.(names.UnitTag)
+	if !ok {
+		return nil, errors.Errorf("unsupported tag %T", tag)
+	}
+	entity, err := ua.EntityFinder.FindEntity(tag)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return entity.(*state.Unit).Agent(), nil
+}

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -759,7 +759,6 @@ type RebootActionResult struct {
 	Result RebootAction `json:"result,omitempty"`
 	Error  *Error       `json:"error,omitempty"`
 }
-
 // LogRecord is used to transmit log messages to the logsink API
 // endpoint.  Single character field names are used for serialisation
 // to keep the size down. These messages are going to be sent a lot.
@@ -801,19 +800,3 @@ type BundleChangesChange struct {
 	Requires []string `json:"requires"`
 }
 
-// AssignUnitsParams holds the list of staged unit assignments to run.
-type AssignUnitsParams struct {
-	IDs []string
-}
-
-// AssignUnitsResult holds the results of a call to UnitAssigner.Assign.
-type AssignUnitsResults struct {
-	Results []AssignUnitsResult
-	Error   *Error
-}
-
-// AssignUnitsResult is a single result of assigning a single unut.
-type AssignUnitsResult struct {
-	Unit  string
-	Error *Error
-}

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -801,7 +801,14 @@ type BundleChangesChange struct {
 	Requires []string `json:"requires"`
 }
 
-// AssignUnitsResult holds the result of a call to UnitAssigner.Assign.
+// AssignUnitsResult holds the results of a call to UnitAssigner.Assign.
+type AssignUnitsResults struct {
+	Results []AssignUnitsResult
+	Error   *Error
+}
+
+// AssignUnitsResult is a single result of assigning a single unut.
 type AssignUnitsResult struct {
+	Unit  string
 	Error *Error
 }

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -800,3 +800,8 @@ type BundleChangesChange struct {
 	// before this change is applied.
 	Requires []string `json:"requires"`
 }
+
+// AssignUnitsResult holds the result of a call to UnitAssigner.Assign.
+type AssignUnitsResult struct {
+	Error *Error
+}

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -801,6 +801,11 @@ type BundleChangesChange struct {
 	Requires []string `json:"requires"`
 }
 
+// AssignUnitsParams holds the list of staged unit assignments to run.
+type AssignUnitsParams struct {
+	IDs []string
+}
+
 // AssignUnitsResult holds the results of a call to UnitAssigner.Assign.
 type AssignUnitsResults struct {
 	Results []AssignUnitsResult

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -759,6 +759,7 @@ type RebootActionResult struct {
 	Result RebootAction `json:"result,omitempty"`
 	Error  *Error       `json:"error,omitempty"`
 }
+
 // LogRecord is used to transmit log messages to the logsink API
 // endpoint.  Single character field names are used for serialisation
 // to keep the size down. These messages are going to be sent a lot.
@@ -799,4 +800,3 @@ type BundleChangesChange struct {
 	// before this change is applied.
 	Requires []string `json:"requires"`
 }
-

--- a/apiserver/service/service_test.go
+++ b/apiserver/service/service_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/apiserver/service"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
-	cmdutil "github.com/juju/juju/cmd/jujud/util"
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/instance"
 	jujutesting "github.com/juju/juju/juju/testing"
@@ -33,8 +32,6 @@ import (
 	"github.com/juju/juju/storage/provider/registry"
 	"github.com/juju/juju/testcharms"
 	"github.com/juju/juju/testing/factory"
-	"github.com/juju/juju/worker"
-	"github.com/juju/juju/worker/unitassigner"
 )
 
 type serviceSuite struct {
@@ -79,13 +76,6 @@ func (s *serviceSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(s.APIState, gc.NotNil)
-
-	runner := worker.NewRunner(func(error) bool { return false }, cmdutil.MoreImportant)
-	runner.StartWorker("unitassigner", func() (worker.Worker, error) {
-		c.Assert(s.APIState, gc.NotNil)
-		return unitassigner.New(s.APIState.UnitAssigner()), nil
-	})
-
 }
 
 func (s *serviceSuite) TearDownTest(c *gc.C) {

--- a/apiserver/service/service_test.go
+++ b/apiserver/service/service_test.go
@@ -74,8 +74,6 @@ func (s *serviceSuite) SetUpTest(c *gc.C) {
 	var err error
 	s.serviceApi, err = service.NewAPI(s.State, nil, s.authorizer)
 	c.Assert(err, jc.ErrorIsNil)
-
-	c.Assert(s.APIState, gc.NotNil)
 }
 
 func (s *serviceSuite) TearDownTest(c *gc.C) {

--- a/apiserver/unitassigner/package_test.go
+++ b/apiserver/unitassigner/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package unitassigner
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/apiserver/unitassigner/unitassigner.go
+++ b/apiserver/unitassigner/unitassigner.go
@@ -1,6 +1,7 @@
 package unitassigner
 
 import (
+	"github.com/juju/errors"
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
@@ -41,7 +42,27 @@ func (a *API) AssignUnits(args params.AssignUnitsParams) (params.AssignUnitsResu
 		result.Results[i].Unit = r.Unit
 		result.Results[i].Error = common.ServerError(r.Error)
 	}
+
+	for _, id := range args.IDs {
+		if !resContains(result.Results, id) {
+			result.Results = append(result.Results,
+				params.AssignUnitsResult{
+					Unit:  id,
+					Error: common.ServerError(errors.NotFoundf("unit %q", id)),
+				})
+		}
+	}
+
 	return result, nil
+}
+
+func resContains(res []params.AssignUnitsResult, id string) bool {
+	for _, r := range res {
+		if r.Unit == id {
+			return true
+		}
+	}
+	return false
 }
 
 // WatchUnitAssignments returns a strings watcher that is notified when new unit

--- a/apiserver/unitassigner/unitassigner.go
+++ b/apiserver/unitassigner/unitassigner.go
@@ -1,0 +1,48 @@
+package unitassigner
+
+import (
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/state/watcher"
+)
+
+func init() {
+	common.RegisterStandardFacade("UnitAssigner", 1, New)
+}
+
+// st defines the state methods this facade needs, so they can be mocked
+// for testing.
+type st interface {
+	WatchForUnitAssignment() state.NotifyWatcher
+	AssignStagedUnits() error
+}
+
+// API implements the functionality for assigning units to machines.
+type API struct {
+	st   st
+	res  *common.Resources
+	auth common.Authorizer
+}
+
+func New(st *state.State, res *common.Resources, auth common.Authorizer) (*API, error) {
+	return &API{st: st, res: res, auth: auth}, nil
+}
+
+func (a API) AssignUnits() (params.AssignUnitsResult, error) {
+	var result params.AssignUnitsResult
+	if err := a.st.AssignStagedUnits(); err != nil {
+		result.Error = common.ServerError(err)
+	}
+	return result, nil
+}
+
+func (a API) WatchUnitAssignments() (params.NotifyWatchResult, error) {
+	watch := a.st.WatchForUnitAssignment()
+	if _, ok := <-watch.Changes(); ok {
+		return params.NotifyWatchResult{
+			NotifyWatcherId: a.res.Register(watch),
+		}, nil
+	}
+	return params.NotifyWatchResult{}, watcher.EnsureErr(watch)
+}

--- a/apiserver/unitassigner/unitassigner.go
+++ b/apiserver/unitassigner/unitassigner.go
@@ -21,11 +21,15 @@ type assignerState interface {
 	AssignStagedUnits(ids []string) ([]state.UnitAssignmentResult, error)
 }
 
+type statusSetter interface {
+	SetStatus(args params.SetStatus) (params.ErrorResults, error)
+}
+
 // API implements the functionality for assigning units to machines.
 type API struct {
 	st           assignerState
 	res          *common.Resources
-	statusSetter *common.StatusSetter
+	statusSetter statusSetter
 }
 
 // New returns a new unitAssigner api instance.

--- a/apiserver/unitassigner/unitassigner.go
+++ b/apiserver/unitassigner/unitassigner.go
@@ -39,7 +39,7 @@ func (a *API) AssignUnits(args params.Entities) (params.ErrorResults, error) {
 
 	// state uses ids, but the API uses Tags, so we have to convert back and
 	// forth (whee!).  The list of ids is (crucially) in the same order as the
-	// list of tags.  This is the same order as the list of errors we return?
+	// list of tags.  This is the same order as the list of errors we return.
 	ids := make([]string, len(args.Entities))
 	for i, e := range args.Entities {
 		tag, err := names.ParseUnitTag(e.Tag)

--- a/apiserver/unitassigner/unitassigner.go
+++ b/apiserver/unitassigner/unitassigner.go
@@ -11,7 +11,7 @@ import (
 )
 
 func init() {
-	common.RegisterStandardFacade("UnitAssigner", 0, New)
+	common.RegisterStandardFacade("UnitAssigner", 1, New)
 }
 
 // st defines the state methods this facade needs, so they can be mocked

--- a/apiserver/unitassigner/unitassigner.go
+++ b/apiserver/unitassigner/unitassigner.go
@@ -8,7 +8,7 @@ import (
 )
 
 func init() {
-	common.RegisterStandardFacade("UnitAssigner", 1, New)
+	common.RegisterStandardFacade("UnitAssigner", 0, New)
 }
 
 // st defines the state methods this facade needs, so they can be mocked
@@ -29,7 +29,7 @@ func New(st *state.State, res *common.Resources, auth common.Authorizer) (*API, 
 	return &API{st: st, res: res, auth: auth}, nil
 }
 
-func (a API) AssignUnits() (params.AssignUnitsResult, error) {
+func (a *API) AssignUnits() (params.AssignUnitsResult, error) {
 	var result params.AssignUnitsResult
 	if err := a.st.AssignStagedUnits(); err != nil {
 		result.Error = common.ServerError(err)
@@ -37,7 +37,7 @@ func (a API) AssignUnits() (params.AssignUnitsResult, error) {
 	return result, nil
 }
 
-func (a API) WatchUnitAssignments() (params.NotifyWatchResult, error) {
+func (a *API) WatchUnitAssignments() (params.NotifyWatchResult, error) {
 	watch := a.st.WatchForUnitAssignment()
 	if _, ok := <-watch.Changes(); ok {
 		return params.NotifyWatchResult{

--- a/apiserver/unitassigner/unitassigner.go
+++ b/apiserver/unitassigner/unitassigner.go
@@ -14,16 +14,16 @@ func init() {
 	common.RegisterStandardFacade("UnitAssigner", 1, New)
 }
 
-// st defines the state methods this facade needs, so they can be mocked
+// assignerState defines the state methods this facade needs, so they can be mocked
 // for testing.
-type st interface {
+type assignerState interface {
 	WatchForUnitAssignment() state.StringsWatcher
 	AssignStagedUnits(ids []string) ([]state.UnitAssignmentResult, error)
 }
 
 // API implements the functionality for assigning units to machines.
 type API struct {
-	st  st
+	st  assignerState
 	res *common.Resources
 }
 

--- a/apiserver/unitassigner/unitassigner.go
+++ b/apiserver/unitassigner/unitassigner.go
@@ -20,15 +20,16 @@ type st interface {
 
 // API implements the functionality for assigning units to machines.
 type API struct {
-	st   st
-	res  *common.Resources
-	auth common.Authorizer
+	st  st
+	res *common.Resources
 }
 
-func New(st *state.State, res *common.Resources, auth common.Authorizer) (*API, error) {
-	return &API{st: st, res: res, auth: auth}, nil
+// New returns a new unitAssigner api instance.
+func New(st *state.State, res *common.Resources, _ common.Authorizer) (*API, error) {
+	return &API{st: st, res: res}, nil
 }
 
+//  AssignUnits assigns the units with the given ids to the correct machine.
 func (a *API) AssignUnits(args params.AssignUnitsParams) (params.AssignUnitsResults, error) {
 	var result params.AssignUnitsResults
 	res, err := a.st.AssignStagedUnits(args.IDs)
@@ -43,6 +44,8 @@ func (a *API) AssignUnits(args params.AssignUnitsParams) (params.AssignUnitsResu
 	return result, nil
 }
 
+// WatchUnitAssignments returns a strings watcher that is notified when new unit
+// assignments are added to the db.
 func (a *API) WatchUnitAssignments() (params.StringsWatchResult, error) {
 	watch := a.st.WatchForUnitAssignment()
 	if changes, ok := <-watch.Changes(); ok {

--- a/apiserver/unitassigner/unitassigner_test.go
+++ b/apiserver/unitassigner/unitassigner_test.go
@@ -40,6 +40,21 @@ func (testsuite) TestWatchUnitAssignment(c *gc.C) {
 	c.Assert(res.Changes, gc.DeepEquals, f.ids)
 }
 
+func (testsuite) TestSetStatus(c *gc.C) {
+	f := &fakeStatusSetter{
+		res: params.ErrorResults{
+			Results: []params.ErrorResult{
+				{Error: &params.Error{Message: "boo"}}}}}
+	api := API{statusSetter: f}
+	args := params.SetStatus{
+		Entities: []params.EntityStatusArgs{{Tag: "foo/0"}},
+	}
+	res, err := api.SetAgentStatus(args)
+	c.Assert(args, jc.DeepEquals, f.args)
+	c.Assert(res, jc.DeepEquals, f.res)
+	c.Assert(err, gc.Equals, f.err)
+}
+
 type fakeState struct {
 	watchCalled bool
 	ids         []string
@@ -73,3 +88,14 @@ func (fakeWatcher) Wait() error { return nil }
 func (fakeWatcher) Stop() error { return nil }
 
 func (fakeWatcher) Err() error { return nil }
+
+type fakeStatusSetter struct {
+	args params.SetStatus
+	res  params.ErrorResults
+	err  error
+}
+
+func (f *fakeStatusSetter) SetStatus(args params.SetStatus) (params.ErrorResults, error) {
+	f.args = args
+	return f.res, f.err
+}

--- a/apiserver/unitassigner/unitassigner_test.go
+++ b/apiserver/unitassigner/unitassigner_test.go
@@ -1,0 +1,76 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package unitassigner
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/state"
+)
+
+var _ = gc.Suite(testsuite{})
+
+type testsuite struct{}
+
+func (testsuite) TestAssignUnits(c *gc.C) {
+	f := &fakeState{}
+	f.results = []state.UnitAssignmentResult{{Unit: "foo"}}
+	api := API{st: f, res: common.NewResources()}
+	args := params.AssignUnitsParams{IDs: []string{"foo", "bar"}}
+	res, err := api.AssignUnits(args)
+	c.Assert(f.ids, gc.DeepEquals, args.IDs)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(res.Results, gc.HasLen, 1)
+	c.Assert(res.Error, gc.IsNil)
+	c.Assert(res.Results, gc.HasLen, 1)
+	c.Assert(res.Results[0].Error, gc.IsNil)
+	c.Assert(res.Results[0].Unit, gc.Equals, "foo")
+}
+
+func (testsuite) TestWatchUnitAssignment(c *gc.C) {
+	f := &fakeState{}
+	api := API{st: f, res: common.NewResources()}
+	f.ids = []string{"boo", "far"}
+	res, err := api.WatchUnitAssignments()
+	c.Assert(f.watchCalled, jc.IsTrue)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(res.Changes, gc.DeepEquals, f.ids)
+}
+
+type fakeState struct {
+	watchCalled bool
+	ids         []string
+	results     []state.UnitAssignmentResult
+	err         error
+}
+
+func (f *fakeState) WatchForUnitAssignment() state.StringsWatcher {
+	f.watchCalled = true
+	return fakeWatcher{f.ids}
+}
+
+func (f *fakeState) AssignStagedUnits(ids []string) ([]state.UnitAssignmentResult, error) {
+	f.ids = ids
+	return f.results, f.err
+}
+
+type fakeWatcher struct {
+	changes []string
+}
+
+func (f fakeWatcher) Changes() <-chan []string {
+	changes := make(chan []string, 1)
+	changes <- f.changes
+	return changes
+}
+func (fakeWatcher) Kill() {}
+
+func (fakeWatcher) Wait() error { return nil }
+
+func (fakeWatcher) Stop() error { return nil }
+
+func (fakeWatcher) Err() error { return nil }

--- a/apiserver/unitassigner/unitassigner_test.go
+++ b/apiserver/unitassigner/unitassigner_test.go
@@ -18,19 +18,16 @@ type testsuite struct{}
 
 func (testsuite) TestAssignUnits(c *gc.C) {
 	f := &fakeState{}
-	f.results = []state.UnitAssignmentResult{{Unit: "foo"}}
+	f.results = []state.UnitAssignmentResult{{Unit: "foo/0"}}
 	api := API{st: f, res: common.NewResources()}
-	args := params.AssignUnitsParams{IDs: []string{"foo", "bar"}}
+	args := params.Entities{Entities: []params.Entity{{Tag: "unit-foo-0"}, {Tag: "unit-bar-1"}}}
 	res, err := api.AssignUnits(args)
-	c.Assert(f.ids, gc.DeepEquals, args.IDs)
+	c.Assert(f.ids, gc.DeepEquals, []string{"foo/0", "bar/1"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(res.Results, gc.HasLen, 2)
-	c.Assert(res.Error, gc.IsNil)
 	c.Assert(res.Results, gc.HasLen, 2)
 	c.Assert(res.Results[0].Error, gc.IsNil)
-	c.Assert(res.Results[0].Unit, gc.Equals, "foo")
-	c.Assert(res.Results[1].Error, gc.ErrorMatches, `unit "bar" not found`)
-	c.Assert(res.Results[1].Unit, gc.Equals, "bar")
+	c.Assert(res.Results[1].Error, gc.ErrorMatches, `unit "unit-bar-1" not found`)
 }
 
 func (testsuite) TestWatchUnitAssignment(c *gc.C) {

--- a/apiserver/unitassigner/unitassigner_test.go
+++ b/apiserver/unitassigner/unitassigner_test.go
@@ -24,11 +24,13 @@ func (testsuite) TestAssignUnits(c *gc.C) {
 	res, err := api.AssignUnits(args)
 	c.Assert(f.ids, gc.DeepEquals, args.IDs)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(res.Results, gc.HasLen, 1)
+	c.Assert(res.Results, gc.HasLen, 2)
 	c.Assert(res.Error, gc.IsNil)
-	c.Assert(res.Results, gc.HasLen, 1)
+	c.Assert(res.Results, gc.HasLen, 2)
 	c.Assert(res.Results[0].Error, gc.IsNil)
 	c.Assert(res.Results[0].Unit, gc.Equals, "foo")
+	c.Assert(res.Results[1].Error, gc.ErrorMatches, `unit "bar" not found`)
+	c.Assert(res.Results[1].Unit, gc.Equals, "bar")
 }
 
 func (testsuite) TestWatchUnitAssignment(c *gc.C) {

--- a/apiserver/uniter/status.go
+++ b/apiserver/uniter/status.go
@@ -4,9 +4,6 @@
 package uniter
 
 import (
-	"github.com/juju/errors"
-	"github.com/juju/names"
-
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
@@ -24,22 +21,6 @@ type StatusAPI struct {
 	getCanModify  common.GetAuthFunc
 }
 
-type unitAgentFinder struct {
-	state.EntityFinder
-}
-
-func (ua *unitAgentFinder) FindEntity(tag names.Tag) (state.Entity, error) {
-	_, ok := tag.(names.UnitTag)
-	if !ok {
-		return nil, errors.Errorf("unsupported tag %T", tag)
-	}
-	entity, err := ua.EntityFinder.FindEntity(tag)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	return entity.(*state.Unit).Agent(), nil
-}
-
 // NewStatusAPI creates a new server-side Status setter API facade.
 func NewStatusAPI(st *state.State, getCanModify common.GetAuthFunc) *StatusAPI {
 	// TODO(fwereade): so *all* of these have exactly the same auth
@@ -48,7 +29,7 @@ func NewStatusAPI(st *state.State, getCanModify common.GetAuthFunc) *StatusAPI {
 	unitGetter := common.NewStatusGetter(st, getCanModify)
 	serviceSetter := common.NewServiceStatusSetter(st, getCanModify)
 	serviceGetter := common.NewServiceStatusGetter(st, getCanModify)
-	agentSetter := common.NewStatusSetter(&unitAgentFinder{st}, getCanModify)
+	agentSetter := common.NewStatusSetter(&common.UnitAgentFinder{st}, getCanModify)
 	return &StatusAPI{
 		agentSetter:   agentSetter,
 		unitSetter:    unitSetter,

--- a/cmd/juju/commands/bundle_test.go
+++ b/cmd/juju/commands/bundle_test.go
@@ -291,7 +291,7 @@ func (s *deployRepoCharmStoreSuite) TestDeployBundleInvalidSeries(c *gc.C) {
             1:
                 series: trusty
     `)
-	c.Assert(err, gc.ErrorMatches, `cannot deploy bundle: cannot add unit for service "django": cannot assign unit "django/0" to machine 0: series does not match`)
+	c.Assert(err, gc.ErrorMatches, `cannot deploy bundle: cannot add unit for service "django": adding new machine to host unit "django/0": cannot assign unit "django/0" to machine 0: series does not match`)
 }
 
 func (s *deployRepoCharmStoreSuite) TestDeployBundleWatcherTimeout(c *gc.C) {

--- a/cmd/juju/commands/deploy_test.go
+++ b/cmd/juju/commands/deploy_test.go
@@ -249,7 +249,6 @@ func (s *DeploySuite) TestPlacement(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	for a := coretesting.LongAttempt.Start(); a.Next(); {
-
 		units, err := svc.AllUnits()
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(units, gc.HasLen, 1)
@@ -339,7 +338,6 @@ func (s *DeploySuite) TestForceMachineNewContainer(c *gc.C) {
 	s.assertForceMachine(c, machine.Id()+"/lxc/0")
 
 	for a := coretesting.LongAttempt.Start(); a.Next(); {
-
 		machines, err := s.State.AllMachines()
 		c.Assert(err, jc.ErrorIsNil)
 		if !a.HasNext() {

--- a/cmd/juju/commands/removeunit_test.go
+++ b/cmd/juju/commands/removeunit_test.go
@@ -26,6 +26,7 @@ func (s *RemoveUnitSuite) SetUpTest(c *gc.C) {
 	s.CmdBlockHelper = NewCmdBlockHelper(s.APIState)
 	c.Assert(s.CmdBlockHelper, gc.NotNil)
 	s.AddCleanup(func(*gc.C) { s.CmdBlockHelper.Close() })
+
 }
 
 var _ = gc.Suite(&RemoveUnitSuite{})

--- a/cmd/juju/commands/removeunit_test.go
+++ b/cmd/juju/commands/removeunit_test.go
@@ -26,7 +26,6 @@ func (s *RemoveUnitSuite) SetUpTest(c *gc.C) {
 	s.CmdBlockHelper = NewCmdBlockHelper(s.APIState)
 	c.Assert(s.CmdBlockHelper, gc.NotNil)
 	s.AddCleanup(func(*gc.C) { s.CmdBlockHelper.Close() })
-
 }
 
 var _ = gc.Suite(&RemoveUnitSuite{})

--- a/cmd/juju/status/status_test.go
+++ b/cmd/juju/status/status_test.go
@@ -2486,7 +2486,7 @@ type addService struct {
 func (as addService) step(c *gc.C, ctx *context) {
 	ch, ok := ctx.charms[as.charm]
 	c.Assert(ok, jc.IsTrue)
-	svc, err := ctx.st.AddService(as.name, ctx.adminUserTag, ch, as.networks, nil, nil)
+	svc, err := ctx.st.AddService(state.AddServiceArgs{Name: as.name, Owner: ctx.adminUserTag, Charm: ch, Networks: as.networks})
 	c.Assert(err, jc.ErrorIsNil)
 	if svc.IsPrincipal() {
 		err = svc.SetConstraints(as.cons)

--- a/cmd/juju/status/status_test.go
+++ b/cmd/juju/status/status_test.go
@@ -2486,7 +2486,7 @@ type addService struct {
 func (as addService) step(c *gc.C, ctx *context) {
 	ch, ok := ctx.charms[as.charm]
 	c.Assert(ok, jc.IsTrue)
-	svc, err := ctx.st.AddService(as.name, ctx.adminUserTag, ch, as.networks, nil)
+	svc, err := ctx.st.AddService(as.name, ctx.adminUserTag, ch, as.networks, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	if svc.IsPrincipal() {
 		err = svc.SetConstraints(as.cons)

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -786,9 +786,11 @@ func (a *MachineAgent) postUpgradeAPIWorker(
 		addressUpdater := agent.APIHostPortsSetter{a}
 		return apiaddressupdater.NewAPIAddressUpdater(st.Machiner(), addressUpdater), nil
 	})
+
 	runner.StartWorker("unitassigner", func() (worker.Worker, error) {
 		return unitassigner.New(st.UnitAssigner()), nil
 	})
+
 	runner.StartWorker("logger", func() (worker.Worker, error) {
 		return workerlogger.NewLogger(st.Logger(), agentConfig), nil
 	})

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -100,6 +100,7 @@ import (
 	"github.com/juju/juju/worker/terminationworker"
 	"github.com/juju/juju/worker/toolsversionchecker"
 	"github.com/juju/juju/worker/txnpruner"
+	"github.com/juju/juju/worker/unitassigner"
 	"github.com/juju/juju/worker/upgrader"
 )
 
@@ -784,6 +785,9 @@ func (a *MachineAgent) postUpgradeAPIWorker(
 	runner.StartWorker("apiaddressupdater", func() (worker.Worker, error) {
 		addressUpdater := agent.APIHostPortsSetter{a}
 		return apiaddressupdater.NewAPIAddressUpdater(st.Machiner(), addressUpdater), nil
+	})
+	runner.StartWorker("unitassigner", func() (worker.Worker, error) {
+		return unitassigner.New(st.UnitAssigner()), nil
 	})
 	runner.StartWorker("logger", func() (worker.Worker, error) {
 		return workerlogger.NewLogger(st.Logger(), agentConfig), nil

--- a/environs/jujutest/livetests.go
+++ b/environs/jujutest/livetests.go
@@ -468,7 +468,7 @@ func (t *LiveTests) TestBootstrapAndDeploy(c *gc.C) {
 	url := testcharms.Repo.ClonedURL(repoDir, mtools0.Version.Series, "dummy")
 	sch, err := jujutesting.PutCharm(st, url, &charmrepo.LocalRepository{Path: repoDir}, false)
 	c.Assert(err, jc.ErrorIsNil)
-	svc, err := st.AddService("dummy", owner.String(), sch, nil, nil, nil)
+	svc, err := st.AddService(state.AddServiceArgs{Name: "dummy", Owner: owner.String(), Charm: sch})
 	c.Assert(err, jc.ErrorIsNil)
 	units, err := juju.AddUnits(st, svc, 1, "")
 	c.Assert(err, jc.ErrorIsNil)

--- a/environs/jujutest/livetests.go
+++ b/environs/jujutest/livetests.go
@@ -468,7 +468,7 @@ func (t *LiveTests) TestBootstrapAndDeploy(c *gc.C) {
 	url := testcharms.Repo.ClonedURL(repoDir, mtools0.Version.Series, "dummy")
 	sch, err := jujutesting.PutCharm(st, url, &charmrepo.LocalRepository{Path: repoDir}, false)
 	c.Assert(err, jc.ErrorIsNil)
-	svc, err := st.AddService("dummy", owner.String(), sch, nil, nil)
+	svc, err := st.AddService("dummy", owner.String(), sch, nil, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	units, err := juju.AddUnits(st, svc, 1, "")
 	c.Assert(err, jc.ErrorIsNil)

--- a/juju/deploy.go
+++ b/juju/deploy.go
@@ -79,14 +79,10 @@ func DeployService(st *state.State, args DeployServiceParams) (*state.Service, e
 		args.Charm,
 		args.Networks,
 		stateStorageConstraints(args.Storage),
+		settings,
 	)
 	if err != nil {
 		return nil, err
-	}
-	if len(settings) > 0 {
-		if err := service.UpdateConfigSettings(settings); err != nil {
-			return nil, err
-		}
 	}
 	if args.Charm.Meta().Subordinate {
 		return service, nil

--- a/juju/deploy.go
+++ b/juju/deploy.go
@@ -40,8 +40,13 @@ type DeployServiceParams struct {
 	Storage  map[string]storage.Constraints
 }
 
+type ServiceDeployer interface {
+	Environment() (*state.Environment, error)
+	AddService(state.AddServiceArgs) (*state.Service, error)
+}
+
 // DeployService takes a charm and various parameters and deploys it.
-func DeployService(st *state.State, args DeployServiceParams) (*state.Service, error) {
+func DeployService(st ServiceDeployer, args DeployServiceParams) (*state.Service, error) {
 	if args.NumUnits > 1 && len(args.Placement) == 0 && args.ToMachineSpec != "" {
 		return nil, fmt.Errorf("cannot use --num-units with --to")
 	}

--- a/juju/deploy_test.go
+++ b/juju/deploy_test.go
@@ -69,8 +69,8 @@ func (s *DeployLocalSuite) TestDeployMinimal(c *gc.C) {
 	s.assertCharm(c, service, s.charm.URL())
 	s.assertSettings(c, service, charm.Settings{})
 	s.assertConstraints(c, service, constraints.Value{})
-	s.assertMachines(c, service, constraints.Value{})
 	c.Assert(service.GetOwnerTag(), gc.Equals, s.AdminUserTag(c).String())
+	s.assertMachines(c, service, constraints.Value{})
 }
 
 func (s *DeployLocalSuite) TestDeployOwnerTag(c *gc.C) {
@@ -131,10 +131,10 @@ func (s *DeployLocalSuite) TestDeployConstraints(c *gc.C) {
 }
 
 func (s *DeployLocalSuite) TestDeployNumUnits(c *gc.C) {
-	err := s.State.SetEnvironConstraints(constraints.MustParse("mem=2G"))
-	c.Assert(err, jc.ErrorIsNil)
+	f := &fakeDeployer{State: s.State}
+
 	serviceCons := constraints.MustParse("cpu-cores=2")
-	service, err := juju.DeployService(s.State,
+	_, err := juju.DeployService(f,
 		juju.DeployServiceParams{
 			ServiceName: "bob",
 			Charm:       s.charm,
@@ -142,8 +142,11 @@ func (s *DeployLocalSuite) TestDeployNumUnits(c *gc.C) {
 			NumUnits:    2,
 		})
 	c.Assert(err, jc.ErrorIsNil)
-	s.assertConstraints(c, service, serviceCons)
-	s.assertMachines(c, service, constraints.MustParse("mem=2G cpu-cores=2"), "0", "1")
+
+	c.Assert(f.args.Name, gc.Equals, "bob")
+	c.Assert(f.args.Charm, gc.DeepEquals, s.charm)
+	c.Assert(f.args.Constraints, gc.DeepEquals, serviceCons)
+	c.Assert(f.args.NumUnits, gc.Equals, 2)
 }
 
 func (s *DeployLocalSuite) TestDeployWithForceMachineRejectsTooManyUnits(c *gc.C) {
@@ -161,13 +164,10 @@ func (s *DeployLocalSuite) TestDeployWithForceMachineRejectsTooManyUnits(c *gc.C
 }
 
 func (s *DeployLocalSuite) TestDeployForceMachineId(c *gc.C) {
-	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(machine.Id(), gc.Equals, "0")
-	err = s.State.SetEnvironConstraints(constraints.MustParse("mem=2G"))
-	c.Assert(err, jc.ErrorIsNil)
+	f := &fakeDeployer{State: s.State}
+
 	serviceCons := constraints.MustParse("cpu-cores=2")
-	service, err := juju.DeployService(s.State,
+	_, err := juju.DeployService(f,
 		juju.DeployServiceParams{
 			ServiceName:   "bob",
 			Charm:         s.charm,
@@ -176,19 +176,20 @@ func (s *DeployLocalSuite) TestDeployForceMachineId(c *gc.C) {
 			ToMachineSpec: "0",
 		})
 	c.Assert(err, jc.ErrorIsNil)
-	s.assertConstraints(c, service, serviceCons)
-	s.assertMachines(c, service, constraints.Value{}, "0")
+
+	c.Assert(f.args.Name, gc.Equals, "bob")
+	c.Assert(f.args.Charm, gc.DeepEquals, s.charm)
+	c.Assert(f.args.Constraints, gc.DeepEquals, serviceCons)
+	c.Assert(f.args.NumUnits, gc.Equals, 1)
+	c.Assert(f.args.Placement, gc.HasLen, 1)
+	c.Assert(*f.args.Placement[0], gc.Equals, instance.Placement{Scope: instance.MachineScope, Directive: "0"})
 }
 
 func (s *DeployLocalSuite) TestDeployForceMachineIdWithContainer(c *gc.C) {
-	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(machine.Id(), gc.Equals, "0")
-	envCons := constraints.MustParse("mem=2G")
-	err = s.State.SetEnvironConstraints(envCons)
-	c.Assert(err, jc.ErrorIsNil)
+	f := &fakeDeployer{State: s.State}
+
 	serviceCons := constraints.MustParse("cpu-cores=2")
-	service, err := juju.DeployService(s.State,
+	_, err := juju.DeployService(f,
 		juju.DeployServiceParams{
 			ServiceName:   "bob",
 			Charm:         s.charm,
@@ -197,79 +198,59 @@ func (s *DeployLocalSuite) TestDeployForceMachineIdWithContainer(c *gc.C) {
 			ToMachineSpec: fmt.Sprintf("%s:0", instance.LXC),
 		})
 	c.Assert(err, jc.ErrorIsNil)
-	s.assertConstraints(c, service, serviceCons)
-	units, err := service.AllUnits()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(units, gc.HasLen, 1)
-
-	// The newly created container will use the constraints.
-	id, err := units[0].AssignedMachineId()
-	c.Assert(err, jc.ErrorIsNil)
-	machine, err = s.State.Machine(id)
-	c.Assert(err, jc.ErrorIsNil)
-	machineCons, err := machine.Constraints()
-	c.Assert(err, jc.ErrorIsNil)
-	unitCons, err := units[0].Constraints()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(machineCons, gc.DeepEquals, *unitCons)
+	c.Assert(f.args.Name, gc.Equals, "bob")
+	c.Assert(f.args.Charm, gc.DeepEquals, s.charm)
+	c.Assert(f.args.Constraints, gc.DeepEquals, serviceCons)
+	c.Assert(f.args.NumUnits, gc.Equals, 1)
+	c.Assert(f.args.Placement, gc.HasLen, 1)
+	c.Assert(*f.args.Placement[0], gc.Equals, instance.Placement{Scope: string(instance.LXC), Directive: "0"})
 }
 
 func (s *DeployLocalSuite) TestDeployWithPlacement(c *gc.C) {
-	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(machine.Id(), gc.Equals, "0")
-	err = s.State.SetEnvironConstraints(constraints.MustParse("mem=2G"))
-	c.Assert(err, jc.ErrorIsNil)
+	f := &fakeDeployer{State: s.State}
+
 	serviceCons := constraints.MustParse("cpu-cores=2")
-	service, err := juju.DeployService(s.State,
+	placement := []*instance.Placement{
+		{Scope: s.State.EnvironUUID(), Directive: "valid"},
+		{Scope: "#", Directive: "0"},
+		{Scope: "lxc", Directive: "1"},
+	}
+	_, err := juju.DeployService(f,
 		juju.DeployServiceParams{
-			ServiceName: "bob",
-			Charm:       s.charm,
-			Constraints: serviceCons,
-			NumUnits:    3,
-			Placement: []*instance.Placement{
-				{Scope: s.State.EnvironUUID(), Directive: "valid"},
-				{Scope: "#", Directive: "0"},
-				{Scope: "lxc", Directive: "1"},
-			},
+			ServiceName:   "bob",
+			Charm:         s.charm,
+			Constraints:   serviceCons,
+			NumUnits:      3,
+			Placement:     placement,
 			ToMachineSpec: "will be ignored",
 		})
 	c.Assert(err, jc.ErrorIsNil)
-	s.assertConstraints(c, service, serviceCons)
-	units, err := service.AllUnits()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(units, gc.HasLen, 3)
 
-	// Check each of the newly added units.
-	s.assertAssignedUnit(c, units[0], "1", constraints.MustParse("mem=2G cpu-cores=2"))
-	s.assertAssignedUnit(c, units[1], "0", constraints.Value{})
-	s.assertAssignedUnit(c, units[2], "1/lxc/0", constraints.MustParse("mem=2G cpu-cores=2"))
+	c.Assert(f.args.Name, gc.Equals, "bob")
+	c.Assert(f.args.Charm, gc.DeepEquals, s.charm)
+	c.Assert(f.args.Constraints, gc.DeepEquals, serviceCons)
+	c.Assert(f.args.NumUnits, gc.Equals, 3)
+	c.Assert(f.args.Placement, gc.DeepEquals, placement)
 }
 
 func (s *DeployLocalSuite) TestDeployWithFewerPlacement(c *gc.C) {
-	err := s.State.SetEnvironConstraints(constraints.MustParse("mem=2G"))
-	c.Assert(err, jc.ErrorIsNil)
+	f := &fakeDeployer{State: s.State}
 	serviceCons := constraints.MustParse("cpu-cores=2")
-	service, err := juju.DeployService(s.State,
+	placement := []*instance.Placement{{Scope: s.State.EnvironUUID(), Directive: "valid"}}
+	_, err := juju.DeployService(f,
 		juju.DeployServiceParams{
 			ServiceName: "bob",
 			Charm:       s.charm,
 			Constraints: serviceCons,
 			NumUnits:    3,
-			Placement: []*instance.Placement{
-				{Scope: s.State.EnvironUUID(), Directive: "valid"},
-			},
+			Placement:   placement,
 		})
 	c.Assert(err, jc.ErrorIsNil)
-	s.assertConstraints(c, service, serviceCons)
-	units, err := service.AllUnits()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(units, gc.HasLen, 3)
-
-	// Check each of the newly added units.
-	s.assertAssignedUnit(c, units[0], "0", constraints.MustParse("mem=2G cpu-cores=2"))
-	s.assertAssignedUnit(c, units[1], "1", constraints.MustParse("mem=2G cpu-cores=2"))
-	s.assertAssignedUnit(c, units[2], "2", constraints.MustParse("mem=2G cpu-cores=2"))
+	c.Assert(f.args.Name, gc.Equals, "bob")
+	c.Assert(f.args.Charm, gc.DeepEquals, s.charm)
+	c.Assert(f.args.Constraints, gc.DeepEquals, serviceCons)
+	c.Assert(f.args.NumUnits, gc.Equals, 3)
+	c.Assert(f.args.Placement, gc.DeepEquals, placement)
 }
 
 func (s *DeployLocalSuite) assertAssignedUnit(c *gc.C, u *state.Unit, mId string, cons constraints.Value) {
@@ -304,6 +285,19 @@ func (s *DeployLocalSuite) assertMachines(c *gc.C, service *state.Service, expec
 	units, err := service.AllUnits()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(units, gc.HasLen, len(expectIds))
+	// first manually tell state to assign all the units
+	for _, unit := range units {
+		id := unit.Tag().Id()
+		res, err := s.State.AssignStagedUnits([]string{id})
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(res[0].Error, jc.ErrorIsNil)
+		c.Assert(res[0].Unit, gc.Equals, id)
+	}
+
+	// refresh the list of units from state
+	units, err = service.AllUnits()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(units, gc.HasLen, len(expectIds))
 	unseenIds := set.NewStrings(expectIds...)
 	for _, unit := range units {
 		id, err := unit.AssignedMachineId()
@@ -316,4 +310,14 @@ func (s *DeployLocalSuite) assertMachines(c *gc.C, service *state.Service, expec
 		c.Assert(cons, gc.DeepEquals, expectCons)
 	}
 	c.Assert(unseenIds, gc.DeepEquals, set.NewStrings())
+}
+
+type fakeDeployer struct {
+	*state.State
+	args state.AddServiceArgs
+}
+
+func (f *fakeDeployer) AddService(args state.AddServiceArgs) (*state.Service, error) {
+	f.args = args
+	return nil, nil
 }

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -93,6 +93,7 @@ type JujuConnSuite struct {
 	oldJujuHome  string
 	DummyConfig  testing.Attrs
 	Factory      *factory.Factory
+	runner       worker.Runner
 }
 
 const AdminSecret = "dummy-secret"
@@ -117,8 +118,8 @@ func (s *JujuConnSuite) SetUpTest(c *gc.C) {
 
 	// we need to manually run the unit assigner so that units which get
 	// deployed will get assigned to machines.
-	runner := worker.NewRunner(func(error) bool { return false }, cmdutil.MoreImportant)
-	runner.StartWorker("unitassigner", func() (worker.Worker, error) {
+	s.runner = worker.NewRunner(func(error) bool { return false }, cmdutil.MoreImportant)
+	s.runner.StartWorker("unitassigner", func() (worker.Worker, error) {
 		c.Assert(s.APIState, gc.NotNil)
 		return unitassigner.New(s.APIState.UnitAssigner()), nil
 	})
@@ -129,6 +130,7 @@ func (s *JujuConnSuite) TearDownTest(c *gc.C) {
 	s.ToolsFixture.TearDownTest(c)
 	s.FakeJujuHomeSuite.TearDownTest(c)
 	s.MgoSuite.TearDownTest(c)
+	s.runner.Kill()
 }
 
 // Reset returns environment state to that which existed at the start of

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -26,6 +26,7 @@ import (
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/cmd/envcmd"
+	cmdutil "github.com/juju/juju/cmd/jujud/util"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/bootstrap"
 	"github.com/juju/juju/environs/config"
@@ -45,6 +46,8 @@ import (
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/testing/factory"
 	"github.com/juju/juju/version"
+	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/unitassigner"
 )
 
 // JujuConnSuite provides a freshly bootstrapped juju.Conn
@@ -111,6 +114,14 @@ func (s *JujuConnSuite) SetUpTest(c *gc.C) {
 	s.PatchValue(&configstore.DefaultAdminUsername, dummy.AdminUserTag().Name())
 	s.setUpConn(c)
 	s.Factory = factory.NewFactory(s.State)
+
+	// we need to manually run the unit assigner so that units which get
+	// deployed will get assigned to machines.
+	runner := worker.NewRunner(func(error) bool { return false }, cmdutil.MoreImportant)
+	runner.StartWorker("unitassigner", func() (worker.Worker, error) {
+		c.Assert(s.APIState, gc.NotNil)
+		return unitassigner.New(s.APIState.UnitAssigner()), nil
+	})
 }
 
 func (s *JujuConnSuite) TearDownTest(c *gc.C) {

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -607,7 +607,7 @@ func (s *JujuConnSuite) AddTestingService(c *gc.C, name string, ch *state.Charm)
 
 func (s *JujuConnSuite) AddTestingServiceWithStorage(c *gc.C, name string, ch *state.Charm, storage map[string]state.StorageConstraints) *state.Service {
 	owner := s.AdminUserTag(c).String()
-	service, err := s.State.AddService(name, owner, ch, nil, storage)
+	service, err := s.State.AddService(name, owner, ch, nil, storage, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	return service
 }
@@ -615,7 +615,7 @@ func (s *JujuConnSuite) AddTestingServiceWithStorage(c *gc.C, name string, ch *s
 func (s *JujuConnSuite) AddTestingServiceWithNetworks(c *gc.C, name string, ch *state.Charm, networks []string) *state.Service {
 	c.Assert(s.State, gc.NotNil)
 	owner := s.AdminUserTag(c).String()
-	service, err := s.State.AddService(name, owner, ch, networks, nil)
+	service, err := s.State.AddService(name, owner, ch, networks, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	return service
 }

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -607,7 +607,7 @@ func (s *JujuConnSuite) AddTestingService(c *gc.C, name string, ch *state.Charm)
 
 func (s *JujuConnSuite) AddTestingServiceWithStorage(c *gc.C, name string, ch *state.Charm, storage map[string]state.StorageConstraints) *state.Service {
 	owner := s.AdminUserTag(c).String()
-	service, err := s.State.AddService(name, owner, ch, nil, storage, nil)
+	service, err := s.State.AddService(state.AddServiceArgs{Name: name, Owner: owner, Charm: ch, Storage: storage})
 	c.Assert(err, jc.ErrorIsNil)
 	return service
 }
@@ -615,7 +615,7 @@ func (s *JujuConnSuite) AddTestingServiceWithStorage(c *gc.C, name string, ch *s
 func (s *JujuConnSuite) AddTestingServiceWithNetworks(c *gc.C, name string, ch *state.Charm, networks []string) *state.Service {
 	c.Assert(s.State, gc.NotNil)
 	owner := s.AdminUserTag(c).String()
-	service, err := s.State.AddService(name, owner, ch, networks, nil, nil)
+	service, err := s.State.AddService(state.AddServiceArgs{Name: name, Owner: owner, Charm: ch, Networks: networks})
 	c.Assert(err, jc.ErrorIsNil)
 	return service
 }

--- a/juju/testing/repo.go
+++ b/juju/testing/repo.go
@@ -88,23 +88,14 @@ func (s *RepoSuite) AssertService(c *gc.C, name string, expectCurl *charm.URL, u
 	c.Assert(ch.URL(), gc.DeepEquals, expectCurl)
 	s.AssertCharmUploaded(c, expectCurl)
 
-	var rels []*state.Relation
-
-	for a := coretesting.LongAttempt.Start(); a.Next(); {
-		units, err := svc.AllUnits()
-		c.Logf("Service units: %+v", units)
-		c.Assert(err, jc.ErrorIsNil)
-		if !a.HasNext() {
-			c.Assert(units, gc.HasLen, unitCount)
-		} else if len(units) != unitCount {
-			continue
-		}
-		s.AssertUnitMachines(c, units)
-		rels, err = svc.Relations()
-		c.Assert(err, jc.ErrorIsNil)
-		c.Assert(rels, gc.HasLen, relCount)
-		break
-	}
+	units, err := svc.AllUnits()
+	c.Logf("Service units: %+v", units)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(units, gc.HasLen, unitCount)
+	s.AssertUnitMachines(c, units)
+	rels, err := svc.Relations()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(rels, gc.HasLen, relCount)
 	return svc, rels
 }
 

--- a/juju/testing/repo.go
+++ b/juju/testing/repo.go
@@ -136,6 +136,8 @@ func (s *RepoSuite) AssertUnitMachines(c *gc.C, units []*state.Unit) {
 			if !a.HasNext() {
 				c.Assert(mUnits, gc.HasLen, 1)
 			} else if len(mUnits) != 1 {
+				// not all units have been assigned to machines yet.
+				// wait a bit longer
 				continue
 			}
 			unitNames = append(unitNames, mUnits[0].Name())

--- a/state/action_test.go
+++ b/state/action_test.go
@@ -615,7 +615,7 @@ func (s *ActionSuite) TestMergeIds(c *gc.C) {
 		expected := sliceify(test.expected)
 
 		c.Log(fmt.Sprintf("test number %d %#v", ix, test))
-		err := state.WatcherMergeIds(s.State, &changes, updates)
+		err := state.WatcherMergeIds(s.State, &changes, updates, state.ActionNotificationIdToActionId)
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(changes, jc.SameContents, expected)
 	}
@@ -639,7 +639,7 @@ func (s *ActionSuite) TestMergeIdsErrors(c *gc.C) {
 		changes, updates := []string{}, map[interface{}]bool{}
 
 		updates[test.key] = true
-		err := state.WatcherMergeIds(s.State, &changes, updates)
+		err := state.WatcherMergeIds(s.State, &changes, updates, state.ActionNotificationIdToActionId)
 
 		if test.ok {
 			c.Assert(err, jc.ErrorIsNil)

--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -186,6 +186,11 @@ func allCollections() collectionSchema {
 		},
 		minUnitsC: {},
 
+		// This collection holds documents that indicate units which are queued
+		// to be assigned to machines. It is used exclusively by the
+		// AssignUnitWorker.
+		assignUnitC: {},
+
 		// meterStatusC is the collection used to store meter status information.
 		meterStatusC:  {},
 		settingsrefsC: {},
@@ -337,6 +342,7 @@ const (
 	actionresultsC         = "actionresults"
 	actionsC               = "actions"
 	annotationsC           = "annotations"
+	assignUnitC            = "assignUnits"
 	blockDevicesC          = "blockdevices"
 	blocksC                = "blocks"
 	charmsC                = "charms"

--- a/state/compat_test.go
+++ b/state/compat_test.go
@@ -52,7 +52,7 @@ func (s *compatSuite) TestEnvironAssertAlive(c *gc.C) {
 func (s *compatSuite) TestGetServiceWithoutNetworksIsOK(c *gc.C) {
 	charm := addCharm(c, s.state, "quantal", testcharms.Repo.CharmDir("mysql"))
 	owner := s.env.Owner()
-	service, err := s.state.AddService("mysql", owner.String(), charm, nil, nil, nil)
+	service, err := s.state.AddService(AddServiceArgs{Name: "mysql", Owner: owner.String(), Charm: charm})
 	c.Assert(err, jc.ErrorIsNil)
 	// In 1.17.7+ all services have associated document in the
 	// requested networks collection. We remove it here to test

--- a/state/compat_test.go
+++ b/state/compat_test.go
@@ -52,7 +52,7 @@ func (s *compatSuite) TestEnvironAssertAlive(c *gc.C) {
 func (s *compatSuite) TestGetServiceWithoutNetworksIsOK(c *gc.C) {
 	charm := addCharm(c, s.state, "quantal", testcharms.Repo.CharmDir("mysql"))
 	owner := s.env.Owner()
-	service, err := s.state.AddService("mysql", owner.String(), charm, nil, nil)
+	service, err := s.state.AddService("mysql", owner.String(), charm, nil, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	// In 1.17.7+ all services have associated document in the
 	// requested networks collection. We remove it here to test

--- a/state/constraints.go
+++ b/state/constraints.go
@@ -95,7 +95,6 @@ func readConstraints(st *State, id string) (constraints.Value, error) {
 
 	doc := constraintsDoc{}
 	if err := constraintsCollection.FindId(id).One(&doc); err == mgo.ErrNotFound {
-		panic("can't find constraints")
 		return constraints.Value{}, errors.NotFoundf("constraints")
 	} else if err != nil {
 		return constraints.Value{}, err

--- a/state/constraints.go
+++ b/state/constraints.go
@@ -95,6 +95,7 @@ func readConstraints(st *State, id string) (constraints.Value, error) {
 
 	doc := constraintsDoc{}
 	if err := constraintsCollection.FindId(id).One(&doc); err == mgo.ErrNotFound {
+		panic("can't find constraints")
 		return constraints.Value{}, errors.NotFoundf("constraints")
 	} else if err != nil {
 		return constraints.Value{}, err

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -128,7 +128,7 @@ func AddTestingServiceWithStorage(c *gc.C, st *State, name string, ch *Charm, ow
 
 func addTestingService(c *gc.C, st *State, name string, ch *Charm, owner names.UserTag, networks []string, storage map[string]StorageConstraints) *Service {
 	c.Assert(ch, gc.NotNil)
-	service, err := st.AddService(name, owner.String(), ch, networks, storage)
+	service, err := st.AddService(name, owner.String(), ch, networks, storage, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	return service
 }

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -246,8 +246,8 @@ func CheckUserExists(st *State, name string) (bool, error) {
 	return st.checkUserExists(name)
 }
 
-func WatcherMergeIds(st *State, changeset *[]string, updates map[interface{}]bool) error {
-	return mergeIds(st, changeset, updates)
+func WatcherMergeIds(st *State, changeset *[]string, updates map[interface{}]bool, idconv func(string) string) error {
+	return mergeIds(st, changeset, updates, idconv)
 }
 
 func WatcherEnsureSuffixFn(marker string) func(string) string {
@@ -427,3 +427,5 @@ func MakeLogDoc(
 func SpaceDoc(s *Space) spaceDoc {
 	return s.doc
 }
+
+var ActionNotificationIdToActionId = actionNotificationIdToActionId

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -128,7 +128,7 @@ func AddTestingServiceWithStorage(c *gc.C, st *State, name string, ch *Charm, ow
 
 func addTestingService(c *gc.C, st *State, name string, ch *Charm, owner names.UserTag, networks []string, storage map[string]StorageConstraints) *Service {
 	c.Assert(ch, gc.NotNil)
-	service, err := st.AddService(name, owner.String(), ch, networks, storage, nil)
+	service, err := st.AddService(AddServiceArgs{Name: name, Owner: owner.String(), Charm: ch, Networks: networks, Storage: storage})
 	c.Assert(err, jc.ErrorIsNil)
 	return service
 }

--- a/state/filesystem_test.go
+++ b/state/filesystem_test.go
@@ -25,7 +25,7 @@ func (s *FilesystemStateSuite) TestAddServiceInvalidPool(c *gc.C) {
 	storage := map[string]state.StorageConstraints{
 		"data": makeStorageCons("invalid-pool", 1024, 1),
 	}
-	_, err := s.State.AddService("storage-filesystem", s.Owner.String(), ch, nil, storage)
+	_, err := s.State.AddService("storage-filesystem", s.Owner.String(), ch, nil, storage, nil)
 	c.Assert(err, gc.ErrorMatches, `.* pool "invalid-pool" not found`)
 }
 
@@ -49,7 +49,7 @@ func (s *FilesystemStateSuite) testAddServiceDefaultPool(c *gc.C, expectedPool s
 	storage := map[string]state.StorageConstraints{
 		"data": makeStorageCons("", 1024, 1),
 	}
-	svc, err := s.State.AddService("storage-filesystem", s.Owner.String(), ch, nil, storage)
+	svc, err := s.State.AddService("storage-filesystem", s.Owner.String(), ch, nil, storage, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	cons, err := svc.StorageConstraints()
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/filesystem_test.go
+++ b/state/filesystem_test.go
@@ -25,7 +25,7 @@ func (s *FilesystemStateSuite) TestAddServiceInvalidPool(c *gc.C) {
 	storage := map[string]state.StorageConstraints{
 		"data": makeStorageCons("invalid-pool", 1024, 1),
 	}
-	_, err := s.State.AddService("storage-filesystem", s.Owner.String(), ch, nil, storage, nil)
+	_, err := s.State.AddService(state.AddServiceArgs{Name: "storage-filesystem", Owner: s.Owner.String(), Charm: ch, Storage: storage})
 	c.Assert(err, gc.ErrorMatches, `.* pool "invalid-pool" not found`)
 }
 
@@ -49,7 +49,7 @@ func (s *FilesystemStateSuite) testAddServiceDefaultPool(c *gc.C, expectedPool s
 	storage := map[string]state.StorageConstraints{
 		"data": makeStorageCons("", 1024, 1),
 	}
-	svc, err := s.State.AddService("storage-filesystem", s.Owner.String(), ch, nil, storage, nil)
+	svc, err := s.State.AddService(state.AddServiceArgs{Name: "storage-filesystem", Owner: s.Owner.String(), Charm: ch, Storage: storage})
 	c.Assert(err, jc.ErrorIsNil)
 	cons, err := svc.StorageConstraints()
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/service.go
+++ b/state/service.go
@@ -679,7 +679,7 @@ func (s *Service) addUnitOps(principalName string, asserts bson.D) (string, []tx
 	if err == nil {
 		// we verify the service is alive
 		asserts = append(isAliveDoc, asserts...)
-		ops = append(ops, s.incCountOp(asserts))
+		ops = append(ops, s.incUnitCountOp(asserts))
 	}
 	return names, ops, err
 }
@@ -689,7 +689,7 @@ func (s *Service) addUnitOps(principalName string, asserts bson.D) (string, []tx
 func (s *Service) addServiceUnitOps(principalName string, asserts bson.D, cons constraints.Value) (string, []txn.Op, error) {
 	names, ops, err := s.addUnitOpsWithCons(principalName, cons)
 	if err == nil {
-		ops = append(ops, s.incCountOp(asserts))
+		ops = append(ops, s.incUnitCountOp(asserts))
 	}
 	return names, ops, err
 }
@@ -775,8 +775,8 @@ func (s *Service) addUnitOpsWithCons(principalName string, cons constraints.Valu
 	return name, ops, nil
 }
 
-// unitCountOp returns the operation to increment the service's unit count.
-func (s *Service) incCountOp(asserts bson.D) txn.Op {
+// incUnitCountOp returns the operation to increment the service's unit count.
+func (s *Service) incUnitCountOp(asserts bson.D) txn.Op {
 	op := txn.Op{
 		C:      servicesC,
 		Id:     s.doc.DocID,

--- a/state/service.go
+++ b/state/service.go
@@ -644,14 +644,6 @@ func (s *Service) Refresh() error {
 
 // newUnitName returns the next unit name.
 func (s *Service) newUnitName() (string, error) {
-	services, closer := s.st.getCollection(servicesC)
-	defer closer()
-
-	result := &serviceDoc{}
-	if err := services.FindId(s.doc.DocID).One(&result); err == mgo.ErrNotFound {
-		return "", errors.NotFoundf("service %q", s)
-	}
-
 	unitSeq, err := s.st.sequence(s.Tag().String())
 	if err != nil {
 		return "", errors.Trace(err)

--- a/state/service.go
+++ b/state/service.go
@@ -673,6 +673,9 @@ func (s *Service) addUnitOps(principalName string, asserts bson.D) (string, []tx
 	var cons constraints.Value
 	if !s.doc.Subordinate {
 		scons, err := s.Constraints()
+		if errors.IsNotFound(err) {
+			return "", nil, errors.NotFoundf("service %q", s.Name())
+		}
 		if err != nil {
 			return "", nil, err
 		}

--- a/state/service.go
+++ b/state/service.go
@@ -777,12 +777,15 @@ func (s *Service) addUnitOpsWithCons(principalName string, cons constraints.Valu
 
 // unitCountOp returns the operation to increment the service's unit count.
 func (s *Service) incCountOp(asserts bson.D) txn.Op {
-	return txn.Op{
+	op := txn.Op{
 		C:      servicesC,
 		Id:     s.doc.DocID,
 		Update: bson.D{{"$inc", bson.D{{"unitcount", 1}}}},
-		Assert: asserts,
 	}
+	if len(asserts) > 0 {
+		op.Assert = asserts
+	}
+	return op
 }
 
 // unitStorageOps returns operations for creating storage

--- a/state/service.go
+++ b/state/service.go
@@ -644,14 +644,13 @@ func (s *Service) Refresh() error {
 
 // newUnitName returns the next unit name.
 func (s *Service) newUnitName() (string, error) {
-	// services, closer := s.st.getCollection(servicesC)
-	// defer closer()
+	services, closer := s.st.getCollection(servicesC)
+	defer closer()
 
-	// result := &serviceDoc{}
-	// if err := services.FindId(s.doc.DocID).One(&result); err == mgo.ErrNotFound {
-	// 	panic("Can't find service " + s.Name())
-	// 	return "", errors.NotFoundf("service %q", s)
-	// }
+	result := &serviceDoc{}
+	if err := services.FindId(s.doc.DocID).One(&result); err == mgo.ErrNotFound {
+		return "", errors.NotFoundf("service %q", s)
+	}
 
 	unitSeq, err := s.st.sequence(s.Tag().String())
 	if err != nil {

--- a/state/service.go
+++ b/state/service.go
@@ -634,7 +634,6 @@ func (s *Service) Refresh() error {
 
 	err := services.FindId(s.doc.DocID).One(&s.doc)
 	if err == mgo.ErrNotFound {
-		panic("Can't find service " + s.Name())
 		return errors.NotFoundf("service %q", s)
 	}
 	if err != nil {

--- a/state/service.go
+++ b/state/service.go
@@ -676,11 +676,12 @@ func (s *Service) addUnitOps(principalName string, asserts bson.D) (string, []tx
 		}
 	}
 	names, ops, err := s.addUnitOpsWithCons(principalName, cons)
-	if err == nil {
-		// we verify the service is alive
-		asserts = append(isAliveDoc, asserts...)
-		ops = append(ops, s.incUnitCountOp(asserts))
+	if err != nil {
+		return names, ops, err
 	}
+	// we verify the service is alive
+	asserts = append(isAliveDoc, asserts...)
+	ops = append(ops, s.incUnitCountOp(asserts))
 	return names, ops, err
 }
 

--- a/state/state.go
+++ b/state/state.go
@@ -1294,11 +1294,6 @@ func (st *State) AssignStagedUnits(ids []string) ([]UnitAssignmentResult, error)
 		results[i].Unit = doc.Unit
 		results[i].Error = err
 	}
-	for _, id := range ids {
-		if !resContains(results, id) {
-			results = append(results, UnitAssignmentResult{Unit: id, Error: errors.NotFoundf("unit %q", id)})
-		}
-	}
 	return results, nil
 }
 
@@ -1308,15 +1303,6 @@ func removeStagedAssignmentOp(id string) txn.Op {
 		Id:     id,
 		Remove: true,
 	}
-}
-
-func resContains(res []UnitAssignmentResult, id string) bool {
-	for _, r := range res {
-		if r.Unit == id {
-			return true
-		}
-	}
-	return false
 }
 
 func (st *State) assignStagedUnit(doc assignUnitDoc) error {

--- a/state/state.go
+++ b/state/state.go
@@ -1585,7 +1585,6 @@ func (st *State) Service(name string) (service *Service, err error) {
 	sdoc := &serviceDoc{}
 	err = services.FindId(name).One(sdoc)
 	if err == mgo.ErrNotFound {
-		panic("Can't find service " + name)
 		return nil, errors.NotFoundf("service %q", name)
 	}
 	if err != nil {

--- a/state/state.go
+++ b/state/state.go
@@ -8,7 +8,9 @@ package state
 
 import (
 	"fmt"
+	"log"
 	"net"
+	"os"
 	"regexp"
 	"sort"
 	"strconv"
@@ -1221,6 +1223,12 @@ func (st *State) AddService(args AddServiceArgs) (service *Service, err error) {
 	}
 	// At the last moment before inserting the service, prime status history.
 	probablyUpdateStatusHistory(st, svc.globalKey(), statusDoc)
+
+	mgo.SetDebug(true)
+
+	var aLogger *log.Logger
+	aLogger = log.New(os.Stderr, "", log.LstdFlags)
+	mgo.SetLogger(aLogger)
 
 	if err := st.runTransaction(ops); err == txn.ErrAborted {
 		if err := checkEnvLife(st); err != nil {

--- a/state/state.go
+++ b/state/state.go
@@ -1291,13 +1291,6 @@ func (st *State) AssignStagedUnits(ids []string) ([]UnitAssignmentResult, error)
 	results := make([]UnitAssignmentResult, len(docs))
 	for i, doc := range docs {
 		err := st.assignStagedUnit(doc)
-		if err == nil || errors.IsNotFound(err) {
-			err = st.runTransaction([]txn.Op{{
-				C:      assignUnitC,
-				Id:     doc.DocId,
-				Remove: true,
-			}})
-		}
 		results[i].Unit = doc.Unit
 		results[i].Error = err
 	}
@@ -1307,6 +1300,14 @@ func (st *State) AssignStagedUnits(ids []string) ([]UnitAssignmentResult, error)
 		}
 	}
 	return results, nil
+}
+
+func removeStagedAssignmentOp(id string) txn.Op {
+	return txn.Op{
+		C:      assignUnitC,
+		Id:     id,
+		Remove: true,
+	}
 }
 
 func resContains(res []UnitAssignmentResult, id string) bool {

--- a/state/state.go
+++ b/state/state.go
@@ -1199,7 +1199,7 @@ func (st *State) AddService(args AddServiceArgs) (service *Service, err error) {
 		// and known before setting them.
 		createRequestedNetworksOp(st, svc.globalKey(), args.Networks),
 		createStorageConstraintsOp(svc.globalKey(), args.Storage),
-		createSettingsOp(st, svc.settingsKey(), map[string]interface{}(args.Settings)),
+		createSettingsOp(svc.settingsKey(), map[string]interface{}(args.Settings)),
 		addLeadershipSettingsOp(svc.Tag().Id()),
 		createStatusOp(st, svc.globalKey(), statusDoc),
 		{

--- a/state/state.go
+++ b/state/state.go
@@ -1345,6 +1345,9 @@ func (st *State) assignStagedUnit(doc assignUnitDoc) error {
 // AssignUnitWithPlacement chooses a machine using the given placement directive
 // and then assigns the unit to it.
 func (st *State) AssignUnitWithPlacement(unit *Unit, placement *instance.Placement, networks []string) error {
+	// TODO(natefinch) this should be done as a single transaction, not two.
+	// Mark https://launchpad.net/bugs/1506994 fixed when done.
+
 	m, err := st.addMachineWithPlacement(unit, placement, networks)
 	if err != nil {
 		return errors.Trace(err)
@@ -1412,6 +1415,9 @@ func (st *State) addMachineWithPlacement(unit *Unit, placement *instance.Placeme
 
 	// Create any new machine marked as dirty so that
 	// nothing else will grab it before we assign the unit to it.
+	// TODO(natefinch) fix this when we put assignment in the same
+	// transaction as adding a machine.  See bug
+	// https://launchpad.net/bugs/1506994
 
 	switch data.placementType() {
 	case containerPlacement:

--- a/state/state.go
+++ b/state/state.go
@@ -1258,8 +1258,7 @@ func (st *State) AddService(args AddServiceArgs) (service *Service, err error) {
 // UnitAssigner worker.
 func assignUnitOps(st *State, unit string, placement instance.Placement) []txn.Op {
 	udoc := assignUnitDoc{
-		DocId:     st.docID(utils.MustNewUUID().String()),
-		Unit:      unit,
+		DocId:     unit,
 		Scope:     placement.Scope,
 		Directive: placement.Directive,
 	}
@@ -1291,7 +1290,7 @@ func (st *State) AssignStagedUnits(ids []string) ([]UnitAssignmentResult, error)
 	results := make([]UnitAssignmentResult, len(docs))
 	for i, doc := range docs {
 		err := st.assignStagedUnit(doc)
-		results[i].Unit = doc.Unit
+		results[i].Unit = doc.DocId
 		results[i].Error = err
 	}
 	return results, nil
@@ -1306,7 +1305,7 @@ func removeStagedAssignmentOp(id string) txn.Op {
 }
 
 func (st *State) assignStagedUnit(doc assignUnitDoc) error {
-	u, err := st.Unit(doc.Unit)
+	u, err := st.Unit(st.localID(doc.DocId))
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/state/state.go
+++ b/state/state.go
@@ -1095,7 +1095,7 @@ func (st *State) addPeerRelationsOps(serviceName string, peers map[string]charm.
 // supplied name (which must be unique). If the charm defines peer relations,
 // they will be created automatically.
 func (st *State) AddService(
-	name, owner string, ch *Charm, networks []string, storage map[string]StorageConstraints,
+	name, owner string, ch *Charm, networks []string, storage map[string]StorageConstraints, settings charm.Settings,
 ) (service *Service, err error) {
 	defer errors.DeferredAnnotatef(&err, "cannot add service %q", name)
 	ownerTag, err := names.ParseUserTag(owner)
@@ -1171,7 +1171,7 @@ func (st *State) AddService(
 		// and known before setting them.
 		createRequestedNetworksOp(st, svc.globalKey(), networks),
 		createStorageConstraintsOp(svc.globalKey(), storage),
-		createSettingsOp(svc.settingsKey(), nil),
+		createSettingsOp(st, svc.settingsKey(), map[string]interface{}(settings)),
 		addLeadershipSettingsOp(svc.Tag().Id()),
 		createStatusOp(st, svc.globalKey(), statusDoc),
 		{
@@ -1188,6 +1188,7 @@ func (st *State) AddService(
 			Insert: svcDoc,
 		},
 	}
+
 	// Collect peer relation addition operations.
 	peerOps, err := st.addPeerRelationsOps(name, peers)
 	if err != nil {

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -1851,20 +1851,26 @@ func (s *StateSuite) TestAllNetworks(c *gc.C) {
 }
 
 func (s *StateSuite) TestAddService(c *gc.C) {
-	charm := s.AddTestingCharm(c, "dummy")
-	_, err := s.State.AddService("haha/borken", s.Owner.String(), charm, nil, nil)
+	ch := s.AddTestingCharm(c, "dummy")
+	_, err := s.State.AddService("haha/borken", s.Owner.String(), ch, nil, nil, nil)
 	c.Assert(err, gc.ErrorMatches, `cannot add service "haha/borken": invalid name`)
 	_, err = s.State.Service("haha/borken")
 	c.Assert(err, gc.ErrorMatches, `"haha/borken" is not a valid service name`)
 
 	// set that a nil charm is handled correctly
-	_, err = s.State.AddService("umadbro", s.Owner.String(), nil, nil, nil)
+	_, err = s.State.AddService("umadbro", s.Owner.String(), nil, nil, nil, nil)
 	c.Assert(err, gc.ErrorMatches, `cannot add service "umadbro": charm is nil`)
 
-	wordpress, err := s.State.AddService("wordpress", s.Owner.String(), charm, nil, nil)
+	insettings := charm.Settings{"tuning": "optimized"}
+
+	wordpress, err := s.State.AddService("wordpress", s.Owner.String(), ch, nil, nil, insettings)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(wordpress.Name(), gc.Equals, "wordpress")
-	mysql, err := s.State.AddService("mysql", s.Owner.String(), charm, nil, nil)
+	outsettings, err := wordpress.ConfigSettings()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(outsettings, gc.DeepEquals, insettings)
+
+	mysql, err := s.State.AddService("mysql", s.Owner.String(), ch, nil, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(mysql.Name(), gc.Equals, "mysql")
 
@@ -1872,15 +1878,15 @@ func (s *StateSuite) TestAddService(c *gc.C) {
 	wordpress, err = s.State.Service("wordpress")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(wordpress.Name(), gc.Equals, "wordpress")
-	ch, _, err := wordpress.Charm()
+	ch, _, err = wordpress.Charm()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(ch.URL(), gc.DeepEquals, charm.URL())
+	c.Assert(ch.URL(), gc.DeepEquals, ch.URL())
 	mysql, err = s.State.Service("mysql")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(mysql.Name(), gc.Equals, "mysql")
 	ch, _, err = mysql.Charm()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(ch.URL(), gc.DeepEquals, charm.URL())
+	c.Assert(ch.URL(), gc.DeepEquals, ch.URL())
 }
 
 func (s *StateSuite) TestAddServiceEnvironmentDying(c *gc.C) {
@@ -1891,7 +1897,7 @@ func (s *StateSuite) TestAddServiceEnvironmentDying(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = env.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = s.State.AddService("s1", s.Owner.String(), charm, nil, nil)
+	_, err = s.State.AddService("s1", s.Owner.String(), charm, nil, nil, nil)
 	c.Assert(err, gc.ErrorMatches, `cannot add service "s1": environment is no longer alive`)
 }
 
@@ -1906,7 +1912,7 @@ func (s *StateSuite) TestAddServiceEnvironmentDyingAfterInitial(c *gc.C) {
 		c.Assert(env.Life(), gc.Equals, state.Alive)
 		c.Assert(env.Destroy(), gc.IsNil)
 	}).Check()
-	_, err = s.State.AddService("s1", s.Owner.String(), charm, nil, nil)
+	_, err = s.State.AddService("s1", s.Owner.String(), charm, nil, nil, nil)
 	c.Assert(err, gc.ErrorMatches, `cannot add service "s1": environment is no longer alive`)
 }
 
@@ -1918,19 +1924,19 @@ func (s *StateSuite) TestServiceNotFound(c *gc.C) {
 
 func (s *StateSuite) TestAddServiceNoTag(c *gc.C) {
 	charm := s.AddTestingCharm(c, "dummy")
-	_, err := s.State.AddService("wordpress", "admin", charm, nil, nil)
+	_, err := s.State.AddService("wordpress", "admin", charm, nil, nil, nil)
 	c.Assert(err, gc.ErrorMatches, "cannot add service \"wordpress\": Invalid ownertag admin: \"admin\" is not a valid tag")
 }
 
 func (s *StateSuite) TestAddServiceNotUserTag(c *gc.C) {
 	charm := s.AddTestingCharm(c, "dummy")
-	_, err := s.State.AddService("wordpress", "machine-3", charm, nil, nil)
+	_, err := s.State.AddService("wordpress", "machine-3", charm, nil, nil, nil)
 	c.Assert(err, gc.ErrorMatches, "cannot add service \"wordpress\": Invalid ownertag machine-3: \"machine-3\" is not a valid user tag")
 }
 
 func (s *StateSuite) TestAddServiceNonExistentUser(c *gc.C) {
 	charm := s.AddTestingCharm(c, "dummy")
-	_, err := s.State.AddService("wordpress", "user-notAuser", charm, nil, nil)
+	_, err := s.State.AddService("wordpress", "user-notAuser", charm, nil, nil, nil)
 	c.Assert(err, gc.ErrorMatches, `cannot add service "wordpress": environment user "notAuser@local" not found`)
 }
 
@@ -1941,13 +1947,13 @@ func (s *StateSuite) TestAllServices(c *gc.C) {
 	c.Assert(len(services), gc.Equals, 0)
 
 	// Check that after adding services the result is ok.
-	_, err = s.State.AddService("wordpress", s.Owner.String(), charm, nil, nil)
+	_, err = s.State.AddService("wordpress", s.Owner.String(), charm, nil, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	services, err = s.State.AllServices()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(len(services), gc.Equals, 1)
 
-	_, err = s.State.AddService("mysql", s.Owner.String(), charm, nil, nil)
+	_, err = s.State.AddService("mysql", s.Owner.String(), charm, nil, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	services, err = s.State.AllServices()
 	c.Assert(err, jc.ErrorIsNil)
@@ -3564,7 +3570,7 @@ func (s *StateSuite) TestSetEnvironAgentVersionErrors(c *gc.C) {
 	// Add a service and 4 units: one with a different version, one
 	// with an empty version, one with the current version, and one
 	// with the new version.
-	service, err := s.State.AddService("wordpress", s.Owner.String(), s.AddTestingCharm(c, "wordpress"), nil, nil)
+	service, err := s.State.AddService("wordpress", s.Owner.String(), s.AddTestingCharm(c, "wordpress"), nil, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	unit0, err := service.AddUnit()
 	c.Assert(err, jc.ErrorIsNil)
@@ -3614,7 +3620,7 @@ func (s *StateSuite) prepareAgentVersionTests(c *gc.C, st *state.State) (*config
 	// Add a machine and a unit with the current version.
 	machine, err := st.AddMachine("series", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
-	service, err := st.AddService("wordpress", s.Owner.String(), s.AddTestingCharm(c, "wordpress"), nil, nil)
+	service, err := st.AddService("wordpress", s.Owner.String(), s.AddTestingCharm(c, "wordpress"), nil, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	unit, err := service.AddUnit()
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -1852,25 +1852,25 @@ func (s *StateSuite) TestAllNetworks(c *gc.C) {
 
 func (s *StateSuite) TestAddService(c *gc.C) {
 	ch := s.AddTestingCharm(c, "dummy")
-	_, err := s.State.AddService("haha/borken", s.Owner.String(), ch, nil, nil, nil)
+	_, err := s.State.AddService(state.AddServiceArgs{Name: "haha/borken", Owner: s.Owner.String(), Charm: ch})
 	c.Assert(err, gc.ErrorMatches, `cannot add service "haha/borken": invalid name`)
 	_, err = s.State.Service("haha/borken")
 	c.Assert(err, gc.ErrorMatches, `"haha/borken" is not a valid service name`)
 
 	// set that a nil charm is handled correctly
-	_, err = s.State.AddService("umadbro", s.Owner.String(), nil, nil, nil, nil)
+	_, err = s.State.AddService(state.AddServiceArgs{Name: "umadbro", Owner: s.Owner.String()})
 	c.Assert(err, gc.ErrorMatches, `cannot add service "umadbro": charm is nil`)
 
 	insettings := charm.Settings{"tuning": "optimized"}
 
-	wordpress, err := s.State.AddService("wordpress", s.Owner.String(), ch, nil, nil, insettings)
+	wordpress, err := s.State.AddService(state.AddServiceArgs{Name: "wordpress", Owner: s.Owner.String(), Charm: ch, Settings:insettings})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(wordpress.Name(), gc.Equals, "wordpress")
 	outsettings, err := wordpress.ConfigSettings()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(outsettings, gc.DeepEquals, insettings)
 
-	mysql, err := s.State.AddService("mysql", s.Owner.String(), ch, nil, nil, nil)
+	mysql, err := s.State.AddService(state.AddServiceArgs{Name: "mysql", Owner: s.Owner.String(), Charm: ch})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(mysql.Name(), gc.Equals, "mysql")
 
@@ -1897,7 +1897,7 @@ func (s *StateSuite) TestAddServiceEnvironmentDying(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = env.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = s.State.AddService("s1", s.Owner.String(), charm, nil, nil, nil)
+	_, err = s.State.AddService(state.AddServiceArgs{Name: "s1", Owner: s.Owner.String(), Charm: charm})
 	c.Assert(err, gc.ErrorMatches, `cannot add service "s1": environment is no longer alive`)
 }
 
@@ -1912,7 +1912,7 @@ func (s *StateSuite) TestAddServiceEnvironmentDyingAfterInitial(c *gc.C) {
 		c.Assert(env.Life(), gc.Equals, state.Alive)
 		c.Assert(env.Destroy(), gc.IsNil)
 	}).Check()
-	_, err = s.State.AddService("s1", s.Owner.String(), charm, nil, nil, nil)
+	_, err = s.State.AddService(state.AddServiceArgs{Name: "s1", Owner: s.Owner.String(), Charm: charm})
 	c.Assert(err, gc.ErrorMatches, `cannot add service "s1": environment is no longer alive`)
 }
 
@@ -1924,19 +1924,19 @@ func (s *StateSuite) TestServiceNotFound(c *gc.C) {
 
 func (s *StateSuite) TestAddServiceNoTag(c *gc.C) {
 	charm := s.AddTestingCharm(c, "dummy")
-	_, err := s.State.AddService("wordpress", "admin", charm, nil, nil, nil)
+	_, err := s.State.AddService(state.AddServiceArgs{Name: "wordpress", Owner: "admin", Charm: charm})
 	c.Assert(err, gc.ErrorMatches, "cannot add service \"wordpress\": Invalid ownertag admin: \"admin\" is not a valid tag")
 }
 
 func (s *StateSuite) TestAddServiceNotUserTag(c *gc.C) {
 	charm := s.AddTestingCharm(c, "dummy")
-	_, err := s.State.AddService("wordpress", "machine-3", charm, nil, nil, nil)
+	_, err := s.State.AddService(state.AddServiceArgs{Name: "wordpress", Owner: "machine-3", Charm: charm})
 	c.Assert(err, gc.ErrorMatches, "cannot add service \"wordpress\": Invalid ownertag machine-3: \"machine-3\" is not a valid user tag")
 }
 
 func (s *StateSuite) TestAddServiceNonExistentUser(c *gc.C) {
 	charm := s.AddTestingCharm(c, "dummy")
-	_, err := s.State.AddService("wordpress", "user-notAuser", charm, nil, nil, nil)
+	_, err := s.State.AddService(state.AddServiceArgs{Name: "wordpress", Owner: "user-notAuser", Charm: charm})
 	c.Assert(err, gc.ErrorMatches, `cannot add service "wordpress": environment user "notAuser@local" not found`)
 }
 
@@ -1947,13 +1947,13 @@ func (s *StateSuite) TestAllServices(c *gc.C) {
 	c.Assert(len(services), gc.Equals, 0)
 
 	// Check that after adding services the result is ok.
-	_, err = s.State.AddService("wordpress", s.Owner.String(), charm, nil, nil, nil)
+	_, err = s.State.AddService(state.AddServiceArgs{Name: "wordpress", Owner: s.Owner.String(), Charm: charm})
 	c.Assert(err, jc.ErrorIsNil)
 	services, err = s.State.AllServices()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(len(services), gc.Equals, 1)
 
-	_, err = s.State.AddService("mysql", s.Owner.String(), charm, nil, nil, nil)
+	_, err = s.State.AddService(state.AddServiceArgs{Name: "mysql", Owner: s.Owner.String(), Charm: charm})
 	c.Assert(err, jc.ErrorIsNil)
 	services, err = s.State.AllServices()
 	c.Assert(err, jc.ErrorIsNil)
@@ -3570,7 +3570,7 @@ func (s *StateSuite) TestSetEnvironAgentVersionErrors(c *gc.C) {
 	// Add a service and 4 units: one with a different version, one
 	// with an empty version, one with the current version, and one
 	// with the new version.
-	service, err := s.State.AddService("wordpress", s.Owner.String(), s.AddTestingCharm(c, "wordpress"), nil, nil, nil)
+	service, err := s.State.AddService(state.AddServiceArgs{Name: "wordpress", Owner: s.Owner.String(), Charm: s.AddTestingCharm(c, "wordpress")})
 	c.Assert(err, jc.ErrorIsNil)
 	unit0, err := service.AddUnit()
 	c.Assert(err, jc.ErrorIsNil)
@@ -3620,7 +3620,7 @@ func (s *StateSuite) prepareAgentVersionTests(c *gc.C, st *state.State) (*config
 	// Add a machine and a unit with the current version.
 	machine, err := st.AddMachine("series", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
-	service, err := st.AddService("wordpress", s.Owner.String(), s.AddTestingCharm(c, "wordpress"), nil, nil, nil)
+	service, err := st.AddService(state.AddServiceArgs{Name: "wordpress", Owner: s.Owner.String(), Charm: s.AddTestingCharm(c, "wordpress")})
 	c.Assert(err, jc.ErrorIsNil)
 	unit, err := service.AddUnit()
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -1863,7 +1863,7 @@ func (s *StateSuite) TestAddService(c *gc.C) {
 
 	insettings := charm.Settings{"tuning": "optimized"}
 
-	wordpress, err := s.State.AddService(state.AddServiceArgs{Name: "wordpress", Owner: s.Owner.String(), Charm: ch, Settings:insettings})
+	wordpress, err := s.State.AddService(state.AddServiceArgs{Name: "wordpress", Owner: s.Owner.String(), Charm: ch, Settings: insettings})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(wordpress.Name(), gc.Equals, "wordpress")
 	outsettings, err := wordpress.ConfigSettings()

--- a/state/storage_dynamicadd_test.go
+++ b/state/storage_dynamicadd_test.go
@@ -30,7 +30,7 @@ func (s *storageAddSuite) setupMultipleStoragesForAdd(c *gc.C) *state.Unit {
 		"multi1to10": makeStorageCons("loop", 0, 3),
 	}
 	charm := s.AddTestingCharm(c, "storage-block2")
-	service, err := s.State.AddService("storage-block2", "user-test-admin@local", charm, nil, storageCons)
+	service, err := s.State.AddService("storage-block2", "user-test-admin@local", charm, nil, storageCons, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	u, err := service.AddUnit()
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/storage_dynamicadd_test.go
+++ b/state/storage_dynamicadd_test.go
@@ -30,7 +30,7 @@ func (s *storageAddSuite) setupMultipleStoragesForAdd(c *gc.C) *state.Unit {
 		"multi1to10": makeStorageCons("loop", 0, 3),
 	}
 	charm := s.AddTestingCharm(c, "storage-block2")
-	service, err := s.State.AddService("storage-block2", "user-test-admin@local", charm, nil, storageCons, nil)
+	service, err := s.State.AddService(state.AddServiceArgs{Name: "storage-block2", Owner: "user-test-admin@local", Charm: charm, Storage: storageCons})
 	c.Assert(err, jc.ErrorIsNil)
 	u, err := service.AddUnit()
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/storage_test.go
+++ b/state/storage_test.go
@@ -369,7 +369,7 @@ func makeStorageCons(pool string, size, count uint64) state.StorageConstraints {
 
 func (s *StorageStateSuite) TestAddServiceStorageConstraintsDefault(c *gc.C) {
 	ch := s.AddTestingCharm(c, "storage-block")
-	storageBlock, err := s.State.AddService("storage-block", "user-test-admin@local", ch, nil, nil, nil)
+	storageBlock, err := s.State.AddService(state.AddServiceArgs{Name: "storage-block", Owner: "user-test-admin@local", Charm: ch})
 	c.Assert(err, jc.ErrorIsNil)
 	constraints, err := storageBlock.StorageConstraints()
 	c.Assert(err, jc.ErrorIsNil)
@@ -387,7 +387,7 @@ func (s *StorageStateSuite) TestAddServiceStorageConstraintsDefault(c *gc.C) {
 	})
 
 	ch = s.AddTestingCharm(c, "storage-filesystem")
-	storageFilesystem, err := s.State.AddService("storage-filesystem", "user-test-admin@local", ch, nil, nil, nil)
+	storageFilesystem, err := s.State.AddService(state.AddServiceArgs{Name: "storage-filesystem", Owner: "user-test-admin@local", Charm: ch})
 	c.Assert(err, jc.ErrorIsNil)
 	constraints, err = storageFilesystem.StorageConstraints()
 	c.Assert(err, jc.ErrorIsNil)
@@ -403,7 +403,7 @@ func (s *StorageStateSuite) TestAddServiceStorageConstraintsDefault(c *gc.C) {
 func (s *StorageStateSuite) TestAddServiceStorageConstraintsValidation(c *gc.C) {
 	ch := s.AddTestingCharm(c, "storage-block2")
 	addService := func(storage map[string]state.StorageConstraints) (*state.Service, error) {
-		return s.State.AddService("storage-block2", "user-test-admin@local", ch, nil, storage, nil)
+		return s.State.AddService(state.AddServiceArgs{Name: "storage-block2", Owner: "user-test-admin@local", Charm: ch, Storage: storage})
 	}
 	assertErr := func(storage map[string]state.StorageConstraints, expect string) {
 		_, err := addService(storage)
@@ -435,7 +435,7 @@ func (s *StorageStateSuite) assertAddServiceStorageConstraintsDefaults(c *gc.C, 
 		c.Assert(err, jc.ErrorIsNil)
 	}
 	ch := s.AddTestingCharm(c, "storage-block")
-	service, err := s.State.AddService("storage-block2", "user-test-admin@local", ch, nil, cons, nil)
+	service, err := s.State.AddService(state.AddServiceArgs{Name: "storage-block2", Owner: "user-test-admin@local", Charm: ch, Storage: cons})
 	c.Assert(err, jc.ErrorIsNil)
 	savedCons, err := service.StorageConstraints()
 	c.Assert(err, jc.ErrorIsNil)
@@ -507,7 +507,7 @@ func (s *StorageStateSuite) TestAddServiceStorageConstraintsDefaultSizeFromCharm
 		"multi2up":   makeStorageCons("loop", 2048, 2),
 	}
 	ch := s.AddTestingCharm(c, "storage-block2")
-	service, err := s.State.AddService("storage-block2", "user-test-admin@local", ch, nil, storageCons, nil)
+	service, err := s.State.AddService(state.AddServiceArgs{Name: "storage-block2", Owner: "user-test-admin@local", Charm: ch, Storage: storageCons})
 	c.Assert(err, jc.ErrorIsNil)
 	savedCons, err := service.StorageConstraints()
 	c.Assert(err, jc.ErrorIsNil)
@@ -517,7 +517,7 @@ func (s *StorageStateSuite) TestAddServiceStorageConstraintsDefaultSizeFromCharm
 func (s *StorageStateSuite) TestProviderFallbackToType(c *gc.C) {
 	ch := s.AddTestingCharm(c, "storage-block")
 	addService := func(storage map[string]state.StorageConstraints) (*state.Service, error) {
-		return s.State.AddService("storage-block", "user-test-admin@local", ch, nil, storage, nil)
+		return s.State.AddService(state.AddServiceArgs{Name: "storage-block", Owner: "user-test-admin@local", Charm: ch, Storage: storage})
 	}
 	storageCons := map[string]state.StorageConstraints{
 		"data": makeStorageCons("loop", 1024, 1),

--- a/state/storage_test.go
+++ b/state/storage_test.go
@@ -369,7 +369,7 @@ func makeStorageCons(pool string, size, count uint64) state.StorageConstraints {
 
 func (s *StorageStateSuite) TestAddServiceStorageConstraintsDefault(c *gc.C) {
 	ch := s.AddTestingCharm(c, "storage-block")
-	storageBlock, err := s.State.AddService("storage-block", "user-test-admin@local", ch, nil, nil)
+	storageBlock, err := s.State.AddService("storage-block", "user-test-admin@local", ch, nil, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	constraints, err := storageBlock.StorageConstraints()
 	c.Assert(err, jc.ErrorIsNil)
@@ -387,7 +387,7 @@ func (s *StorageStateSuite) TestAddServiceStorageConstraintsDefault(c *gc.C) {
 	})
 
 	ch = s.AddTestingCharm(c, "storage-filesystem")
-	storageFilesystem, err := s.State.AddService("storage-filesystem", "user-test-admin@local", ch, nil, nil)
+	storageFilesystem, err := s.State.AddService("storage-filesystem", "user-test-admin@local", ch, nil, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	constraints, err = storageFilesystem.StorageConstraints()
 	c.Assert(err, jc.ErrorIsNil)
@@ -403,7 +403,7 @@ func (s *StorageStateSuite) TestAddServiceStorageConstraintsDefault(c *gc.C) {
 func (s *StorageStateSuite) TestAddServiceStorageConstraintsValidation(c *gc.C) {
 	ch := s.AddTestingCharm(c, "storage-block2")
 	addService := func(storage map[string]state.StorageConstraints) (*state.Service, error) {
-		return s.State.AddService("storage-block2", "user-test-admin@local", ch, nil, storage)
+		return s.State.AddService("storage-block2", "user-test-admin@local", ch, nil, storage, nil)
 	}
 	assertErr := func(storage map[string]state.StorageConstraints, expect string) {
 		_, err := addService(storage)
@@ -435,7 +435,7 @@ func (s *StorageStateSuite) assertAddServiceStorageConstraintsDefaults(c *gc.C, 
 		c.Assert(err, jc.ErrorIsNil)
 	}
 	ch := s.AddTestingCharm(c, "storage-block")
-	service, err := s.State.AddService("storage-block2", "user-test-admin@local", ch, nil, cons)
+	service, err := s.State.AddService("storage-block2", "user-test-admin@local", ch, nil, cons, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	savedCons, err := service.StorageConstraints()
 	c.Assert(err, jc.ErrorIsNil)
@@ -507,7 +507,7 @@ func (s *StorageStateSuite) TestAddServiceStorageConstraintsDefaultSizeFromCharm
 		"multi2up":   makeStorageCons("loop", 2048, 2),
 	}
 	ch := s.AddTestingCharm(c, "storage-block2")
-	service, err := s.State.AddService("storage-block2", "user-test-admin@local", ch, nil, storageCons)
+	service, err := s.State.AddService("storage-block2", "user-test-admin@local", ch, nil, storageCons, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	savedCons, err := service.StorageConstraints()
 	c.Assert(err, jc.ErrorIsNil)
@@ -517,7 +517,7 @@ func (s *StorageStateSuite) TestAddServiceStorageConstraintsDefaultSizeFromCharm
 func (s *StorageStateSuite) TestProviderFallbackToType(c *gc.C) {
 	ch := s.AddTestingCharm(c, "storage-block")
 	addService := func(storage map[string]state.StorageConstraints) (*state.Service, error) {
-		return s.State.AddService("storage-block", "user-test-admin@local", ch, nil, storage)
+		return s.State.AddService("storage-block", "user-test-admin@local", ch, nil, storage, nil)
 	}
 	storageCons := map[string]state.StorageConstraints{
 		"data": makeStorageCons("loop", 1024, 1),

--- a/state/unit.go
+++ b/state/unit.go
@@ -1220,7 +1220,9 @@ func (u *Unit) assignToMachineOps(m *Machine, unused bool) ([]txn.Op, error) {
 		Id:     m.doc.DocID,
 		Assert: massert,
 		Update: bson.D{{"$addToSet", bson.D{{"principals", u.doc.Name}}}, {"$set", bson.D{{"clean", false}}}},
-	}}
+	},
+		removeStagedAssignmentOp(u.doc.DocID),
+	}
 	ops = append(ops, storageOps...)
 	return ops, nil
 }

--- a/state/unit_assignment.go
+++ b/state/unit_assignment.go
@@ -7,11 +7,9 @@ package state
 // information created during srevice creation until the unitassigner worker can
 // come along and use it.
 type assignUnitDoc struct {
-	// DocId is the unique id of the document.
+	// DocId is the unique id of the document, which is also the unit id of the
+	// unit to be assigned.
 	DocId string `bson:"_id"`
-
-	// Unit is the if of the unit to assign to a machine.
-	Unit string `bson:"unit"`
 
 	// Scope is the placement scope to apply to the unit.
 	Scope string `bson:"scope`

--- a/state/unit_assignment.go
+++ b/state/unit_assignment.go
@@ -10,9 +10,6 @@ type assignUnitDoc struct {
 	// DocId is the unique id of the document.
 	DocId string `bson:"_id"`
 
-	// EnvUUID is the environment identifier.
-	EnvUUID string `bson:"env-uuid"`
-
 	// Unit is the if of the unit to assign to a machine.
 	Unit string `bson:"unit"`
 

--- a/state/unit_assignment.go
+++ b/state/unit_assignment.go
@@ -22,3 +22,9 @@ type assignUnitDoc struct {
 	// Directive is the placement directive to apply to the unit.
 	Directive string `bson:"scope`
 }
+
+// UnitAssignmentResult is the result of running a staged unit assignment.
+type UnitAssignmentResult struct {
+	Unit  string
+	Error error
+}

--- a/state/unit_assignment.go
+++ b/state/unit_assignment.go
@@ -1,0 +1,24 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+// assignUnitDoc is a document that temporarily stores unit assignment
+// information created during srevice creation until the unitassigner worker can
+// come along and use it.
+type assignUnitDoc struct {
+	// DocId is the unique id of the document.
+	DocId string `bson:"_id"`
+
+	// EnvUUID is the environment identifier.
+	EnvUUID string `bson:"env-uuid"`
+
+	// Unit is the if of the unit to assign to a machine.
+	Unit string `bson:"unit"`
+
+	// Scope is the placement scope to apply to the unit.
+	Scope string `bson:"scope`
+
+	// Directive is the placement directive to apply to the unit.
+	Directive string `bson:"scope`
+}

--- a/state/volume_test.go
+++ b/state/volume_test.go
@@ -83,7 +83,7 @@ func (s *VolumeStateSuite) TestAddServiceInvalidPool(c *gc.C) {
 	storage := map[string]state.StorageConstraints{
 		"data": makeStorageCons("invalid-pool", 1024, 1),
 	}
-	_, err := s.State.AddService("storage-block", s.Owner.String(), ch, nil, storage, nil)
+	_, err := s.State.AddService(state.AddServiceArgs{Name: "storage-block", Owner: s.Owner.String(), Charm: ch, Storage: storage})
 	c.Assert(err, gc.ErrorMatches, `.* pool "invalid-pool" not found`)
 }
 
@@ -92,7 +92,7 @@ func (s *VolumeStateSuite) TestAddServiceNoUserDefaultPool(c *gc.C) {
 	storage := map[string]state.StorageConstraints{
 		"data": makeStorageCons("", 1024, 1),
 	}
-	service, err := s.State.AddService("storage-block", s.Owner.String(), ch, nil, storage, nil)
+	service, err := s.State.AddService(state.AddServiceArgs{Name: "storage-block", Owner: s.Owner.String(), Charm: ch, Storage: storage})
 	c.Assert(err, jc.ErrorIsNil)
 	cons, err := service.StorageConstraints()
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/volume_test.go
+++ b/state/volume_test.go
@@ -83,7 +83,7 @@ func (s *VolumeStateSuite) TestAddServiceInvalidPool(c *gc.C) {
 	storage := map[string]state.StorageConstraints{
 		"data": makeStorageCons("invalid-pool", 1024, 1),
 	}
-	_, err := s.State.AddService("storage-block", s.Owner.String(), ch, nil, storage)
+	_, err := s.State.AddService("storage-block", s.Owner.String(), ch, nil, storage, nil)
 	c.Assert(err, gc.ErrorMatches, `.* pool "invalid-pool" not found`)
 }
 
@@ -92,7 +92,7 @@ func (s *VolumeStateSuite) TestAddServiceNoUserDefaultPool(c *gc.C) {
 	storage := map[string]state.StorageConstraints{
 		"data": makeStorageCons("", 1024, 1),
 	}
-	service, err := s.State.AddService("storage-block", s.Owner.String(), ch, nil, storage)
+	service, err := s.State.AddService("storage-block", s.Owner.String(), ch, nil, storage, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	cons, err := service.StorageConstraints()
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -1431,6 +1431,12 @@ func (st *State) WatchForEnvironConfigChanges() NotifyWatcher {
 	return newEntityWatcher(st, settingsC, st.docID(environGlobalKey))
 }
 
+// WatchForUnitAssignment watches for new services that request units to be
+// assigned to machines.
+func (st *State) WatchForUnitAssignment() NotifyWatcher {
+	return newEntityWatcher(st, assignUnitC, st.docID(environGlobalKey))
+}
+
 // WatchAPIHostPorts returns a NotifyWatcher that notifies
 // when the set of API addresses changes.
 func (st *State) WatchAPIHostPorts() NotifyWatcher {

--- a/testing/factory/factory.go
+++ b/testing/factory/factory.go
@@ -335,7 +335,7 @@ func (factory *Factory) MakeService(c *gc.C, params *ServiceParams) *state.Servi
 		params.Creator = creator.Tag()
 	}
 	_ = params.Creator.(names.UserTag)
-	service, err := factory.st.AddService(params.Name, params.Creator.String(), params.Charm, nil, nil)
+	service, err := factory.st.AddService(params.Name, params.Creator.String(), params.Charm, nil, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	if params.Status != nil {

--- a/testing/factory/factory.go
+++ b/testing/factory/factory.go
@@ -335,7 +335,7 @@ func (factory *Factory) MakeService(c *gc.C, params *ServiceParams) *state.Servi
 		params.Creator = creator.Tag()
 	}
 	_ = params.Creator.(names.UserTag)
-	service, err := factory.st.AddService(params.Name, params.Creator.String(), params.Charm, nil, nil, nil)
+	service, err := factory.st.AddService(state.AddServiceArgs{Name: params.Name, Owner: params.Creator.String(), Charm: params.Charm})
 	c.Assert(err, jc.ErrorIsNil)
 
 	if params.Status != nil {

--- a/worker/unitassigner/package_test.go
+++ b/worker/unitassigner/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package unitassigner
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/worker/unitassigner/unitassigner.go
+++ b/worker/unitassigner/unitassigner.go
@@ -10,26 +10,29 @@ import (
 )
 
 type UnitAssigner interface {
-	AssignUnits() (params.AssignUnitsResults, error)
-	WatchUnitAssignments() (watcher.NotifyWatcher, error)
+	AssignUnits(ids []string) (params.AssignUnitsResults, error)
+	WatchUnitAssignments() (watcher.StringsWatcher, error)
 }
 
 func New(ua UnitAssigner) worker.Worker {
-	return worker.NewNotifyWorker(unitAssigner{api: ua})
+	return worker.NewStringsWorker(unitAssigner{api: ua})
 }
 
 type unitAssigner struct {
 	api UnitAssigner
 }
 
-func (u unitAssigner) SetUp() (watcher.NotifyWatcher, error) {
+func (u unitAssigner) SetUp() (watcher.StringsWatcher, error) {
 	return u.api.WatchUnitAssignments()
 }
 
-func (u unitAssigner) Handle(_ <-chan struct{}) error {
+func (u unitAssigner) Handle(changes []string) error {
+	if len(changes) == 0 {
+		return nil
+	}
 	// ignore the actual results for now, they'll have been logged on the server
 	// side.
-	_, err := u.api.AssignUnits()
+	_, err := u.api.AssignUnits(changes)
 	return err
 }
 func (unitAssigner) TearDown() error {

--- a/worker/unitassigner/unitassigner.go
+++ b/worker/unitassigner/unitassigner.go
@@ -5,11 +5,12 @@ package unitassigner
 
 import (
 	"github.com/juju/juju/api/watcher"
+	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/worker"
 )
 
 type UnitAssigner interface {
-	AssignUnits() error
+	AssignUnits() (params.AssignUnitsResults, error)
 	WatchUnitAssignments() (watcher.NotifyWatcher, error)
 }
 
@@ -26,7 +27,10 @@ func (u unitAssigner) SetUp() (watcher.NotifyWatcher, error) {
 }
 
 func (u unitAssigner) Handle(_ <-chan struct{}) error {
-	return u.api.AssignUnits()
+	// ignore the actual results for now, they'll have been logged on the server
+	// side.
+	_, err := u.api.AssignUnits()
+	return err
 }
 func (unitAssigner) TearDown() error {
 	return nil

--- a/worker/unitassigner/unitassigner.go
+++ b/worker/unitassigner/unitassigner.go
@@ -1,0 +1,33 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package unitassigner
+
+import (
+	"github.com/juju/juju/api/watcher"
+	"github.com/juju/juju/worker"
+)
+
+type UnitAssigner interface {
+	AssignUnits() error
+	WatchUnitAssignments() (watcher.NotifyWatcher, error)
+}
+
+func New(ua UnitAssigner) worker.Worker {
+	return worker.NewNotifyWorker(unitAssigner{api: ua})
+}
+
+type unitAssigner struct {
+	api UnitAssigner
+}
+
+func (u unitAssigner) SetUp() (watcher.NotifyWatcher, error) {
+	return u.api.WatchUnitAssignments()
+}
+
+func (u unitAssigner) Handle(_ <-chan struct{}) error {
+	return u.api.AssignUnits()
+}
+func (unitAssigner) TearDown() error {
+	return nil
+}

--- a/worker/unitassigner/unitassigner.go
+++ b/worker/unitassigner/unitassigner.go
@@ -7,7 +7,10 @@ import (
 	"github.com/juju/juju/api/watcher"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/worker"
+	"github.com/juju/loggo"
 )
+
+var logger = loggo.GetLogger("juju.worker.unitassigner")
 
 type UnitAssigner interface {
 	AssignUnits(ids []string) (params.AssignUnitsResults, error)
@@ -27,14 +30,18 @@ func (u unitAssigner) SetUp() (watcher.StringsWatcher, error) {
 }
 
 func (u unitAssigner) Handle(changes []string) error {
+	logger.Tracef("Handling unit assignmewnts: %q", changes)
 	if len(changes) == 0 {
 		return nil
 	}
 	// ignore the actual results for now, they'll have been logged on the server
 	// side.
-	_, err := u.api.AssignUnits(changes)
+	res, err := u.api.AssignUnits(changes)
+	logger.Tracef("Unit assignment results: %q", res.Results)
+
 	return err
 }
+
 func (unitAssigner) TearDown() error {
 	return nil
 }

--- a/worker/unitassigner/unitassigner_test.go
+++ b/worker/unitassigner/unitassigner_test.go
@@ -1,0 +1,59 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package unitassigner
+
+import (
+	"errors"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/api/watcher"
+	"github.com/juju/juju/apiserver/params"
+)
+
+var _ = gc.Suite(testsuite{})
+
+type testsuite struct{}
+
+func (testsuite) TestSetup(c *gc.C) {
+	f := &fakeAPI{}
+	ua := unitAssigner{api: f}
+	_, err := ua.SetUp()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(f.calledWatch, jc.IsTrue)
+
+	f.err = errors.New("boo")
+	_, err = ua.SetUp()
+	c.Assert(err, gc.Equals, f.err)
+}
+
+func (testsuite) TestHandle(c *gc.C) {
+	f := &fakeAPI{}
+	ua := unitAssigner{api: f}
+	ids := []string{"foo", "bar"}
+	err := ua.Handle(ids)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(f.assignIds, gc.DeepEquals, ids)
+
+	f.err = errors.New("boo")
+	err = ua.Handle(ids)
+	c.Assert(err, gc.Equals, f.err)
+}
+
+type fakeAPI struct {
+	calledWatch bool
+	assignIds   []string
+	err         error
+}
+
+func (f *fakeAPI) AssignUnits(ids []string) (params.AssignUnitsResults, error) {
+	f.assignIds = ids
+	return params.AssignUnitsResults{}, f.err
+}
+
+func (f *fakeAPI) WatchUnitAssignments() (watcher.StringsWatcher, error) {
+	f.calledWatch = true
+	return nil, f.err
+}

--- a/worker/unitassigner/unitassigner_test.go
+++ b/worker/unitassigner/unitassigner_test.go
@@ -10,7 +10,6 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/api/watcher"
-	"github.com/juju/juju/apiserver/params"
 )
 
 var _ = gc.Suite(testsuite{})
@@ -48,9 +47,9 @@ type fakeAPI struct {
 	err         error
 }
 
-func (f *fakeAPI) AssignUnits(ids []string) (params.AssignUnitsResults, error) {
+func (f *fakeAPI) AssignUnits(ids []string) ([]error, error) {
 	f.assignIds = ids
-	return params.AssignUnitsResults{}, f.err
+	return nil, f.err
 }
 
 func (f *fakeAPI) WatchUnitAssignments() (watcher.StringsWatcher, error) {


### PR DESCRIPTION
This PR moves unit assignment during service deployment into a worker.  Thus, when you deploy a service, we don't immediately create machines and assign units to them.  Instead, we record what you'd like to have happen, and have the worker do that.  This makes service deployment atomic, and allows for retrying of unit assignment as needed.  However, it complicates tests, because now the assignment is not synchronous, so there's some changes to tests to poll for the expected units/machines while we wait for the worker to do its thing.

(Review request: http://reviews.vapour.ws/r/2814/)