### PR TITLE
State: separate collections for LastLogin and LastConnection

### DIFF
--- a/apiserver/admin_test.go
+++ b/apiserver/admin_test.go
@@ -947,12 +947,16 @@ func (s *loginSuite) TestLoginUpdatesLastLoginAndConnection(c *gc.C) {
 	// The user now has last login updated.
 	err = user.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(user.LastLogin(), gc.NotNil)
-	c.Assert(user.LastLogin().After(startTime), jc.IsTrue)
+	lastLogin, err := user.LastLogin()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(lastLogin, gc.NotNil)
+	c.Assert(lastLogin.After(startTime), jc.IsTrue)
 
 	// The env user is also updated.
 	envUser, err := s.State.EnvironmentUser(user.UserTag())
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(envUser.LastConnection(), gc.NotNil)
-	c.Assert(envUser.LastConnection().After(startTime), jc.IsTrue)
+	when, err := envUser.LastConnection()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(when, gc.NotNil)
+	c.Assert(when.After(startTime), jc.IsTrue)
 }

--- a/apiserver/adminv2_test.go
+++ b/apiserver/adminv2_test.go
@@ -76,7 +76,9 @@ func (s *loginV2Suite) TestClientLoginToServerNoAccessToStateServerEnv(c *gc.C) 
 	// The user now has last login updated.
 	err = user.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(user.LastLogin(), gc.NotNil)
+	lastLogin, err := user.LastLogin()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(lastLogin, gc.NotNil)
 }
 
 func (s *loginV2Suite) TestClientLoginToRootOldClient(c *gc.C) {

--- a/apiserver/client/client.go
+++ b/apiserver/client/client.go
@@ -6,6 +6,7 @@ package client
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
@@ -829,13 +830,22 @@ func (c *Client) EnvUserInfo() (params.EnvUserInfoResults, error) {
 	}
 
 	for _, user := range users {
+		var lastConn *time.Time
+		userLastConn, err := user.LastConnection()
+		if err != nil {
+			if !state.IsNeverConnectedError(err) {
+				return results, errors.Trace(err)
+			}
+		} else {
+			lastConn = &userLastConn
+		}
 		results.Results = append(results.Results, params.EnvUserInfoResult{
 			Result: &params.EnvUserInfo{
 				UserName:       user.UserName(),
 				DisplayName:    user.DisplayName(),
 				CreatedBy:      user.CreatedBy(),
 				DateCreated:    user.DateCreated(),
-				LastConnection: user.LastConnection(),
+				LastConnection: lastConn,
 			},
 		})
 	}

--- a/apiserver/client/client_test.go
+++ b/apiserver/client/client_test.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/juju/errors"
 	"github.com/juju/names"
@@ -134,54 +135,63 @@ func (s *serverSuite) TestEnvUsersInfo(c *gc.C) {
 
 	results, err := s.client.EnvUserInfo()
 	c.Assert(err, jc.ErrorIsNil)
-	expected := params.EnvUserInfoResults{
-		Results: []params.EnvUserInfoResult{
-			{
-				Result: &params.EnvUserInfo{
-					UserName:       owner.UserName(),
-					DisplayName:    owner.DisplayName(),
-					CreatedBy:      owner.UserName(),
-					DateCreated:    owner.DateCreated(),
-					LastConnection: owner.LastConnection(),
-				},
-			}, {
-				Result: &params.EnvUserInfo{
-					UserName:       "ralphdoe@local",
-					DisplayName:    "Ralph Doe",
-					CreatedBy:      owner.UserName(),
-					DateCreated:    localUser1.DateCreated(),
-					LastConnection: localUser1.LastConnection(),
-				},
-			}, {
-				Result: &params.EnvUserInfo{
-					UserName:       "samsmith@local",
-					DisplayName:    "Sam Smith",
-					CreatedBy:      owner.UserName(),
-					DateCreated:    localUser2.DateCreated(),
-					LastConnection: localUser2.LastConnection(),
-				},
-			}, {
-				Result: &params.EnvUserInfo{
-					UserName:       "bobjohns@ubuntuone",
-					DisplayName:    "Bob Johns",
-					CreatedBy:      owner.UserName(),
-					DateCreated:    remoteUser1.DateCreated(),
-					LastConnection: remoteUser1.LastConnection(),
-				},
-			}, {
-				Result: &params.EnvUserInfo{
-					UserName:       "nicshaw@idprovider",
-					DisplayName:    "Nic Shaw",
-					CreatedBy:      owner.UserName(),
-					DateCreated:    remoteUser2.DateCreated(),
-					LastConnection: remoteUser2.LastConnection(),
-				},
-			}},
+	var expected params.EnvUserInfoResults
+	for _, r := range []struct {
+		user *state.EnvironmentUser
+		info *params.EnvUserInfo
+	}{
+		{
+			owner,
+			&params.EnvUserInfo{
+				UserName:    owner.UserName(),
+				DisplayName: owner.DisplayName(),
+			},
+		}, {
+			localUser1,
+			&params.EnvUserInfo{
+				UserName:    "ralphdoe@local",
+				DisplayName: "Ralph Doe",
+			},
+		}, {
+			localUser2,
+			&params.EnvUserInfo{
+				UserName:    "samsmith@local",
+				DisplayName: "Sam Smith",
+			},
+		}, {
+			remoteUser1,
+			&params.EnvUserInfo{
+				UserName:    "bobjohns@ubuntuone",
+				DisplayName: "Bob Johns",
+			},
+		}, {
+			remoteUser2,
+			&params.EnvUserInfo{
+				UserName:    "nicshaw@idprovider",
+				DisplayName: "Nic Shaw",
+			},
+		},
+	} {
+		r.info.CreatedBy = owner.UserName()
+		r.info.DateCreated = r.user.DateCreated()
+		r.info.LastConnection = lastConnPointer(c, r.user)
+		expected.Results = append(expected.Results, params.EnvUserInfoResult{Result: r.info})
 	}
 
 	sort.Sort(ByUserName(expected.Results))
 	sort.Sort(ByUserName(results.Results))
 	c.Assert(results, jc.DeepEquals, expected)
+}
+
+func lastConnPointer(c *gc.C, envUser *state.EnvironmentUser) *time.Time {
+	lastConn, err := envUser.LastConnection()
+	if err != nil {
+		if state.IsNeverConnectedError(err) {
+			return nil
+		}
+		c.Fatal(err)
+	}
+	return &lastConn
 }
 
 // ByUserName implements sort.Interface for []params.EnvUserInfoResult based on
@@ -273,7 +283,9 @@ func (s *serverSuite) TestShareEnvironmentAddLocalUser(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(envUser.UserName(), gc.Equals, user.UserTag().Username())
 	c.Assert(envUser.CreatedBy(), gc.Equals, dummy.AdminUserTag().Username())
-	c.Assert(envUser.LastConnection(), gc.IsNil)
+	lastConn, err := envUser.LastConnection()
+	c.Assert(err, jc.Satisfies, state.IsNeverConnectedError)
+	c.Assert(lastConn, gc.Equals, time.Time{})
 }
 
 func (s *serverSuite) TestShareEnvironmentAddRemoteUser(c *gc.C) {
@@ -294,7 +306,9 @@ func (s *serverSuite) TestShareEnvironmentAddRemoteUser(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(envUser.UserName(), gc.Equals, user.Username())
 	c.Assert(envUser.CreatedBy(), gc.Equals, dummy.AdminUserTag().Username())
-	c.Assert(envUser.LastConnection(), gc.IsNil)
+	lastConn, err := envUser.LastConnection()
+	c.Assert(err, jc.Satisfies, state.IsNeverConnectedError)
+	c.Assert(lastConn.IsZero(), jc.IsTrue)
 }
 
 func (s *serverSuite) TestShareEnvironmentAddUserTwice(c *gc.C) {

--- a/apiserver/environmentmanager/environmentmanager.go
+++ b/apiserver/environmentmanager/environmentmanager.go
@@ -6,6 +6,8 @@
 package environmentmanager
 
 import (
+	"time"
+
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names"
@@ -354,13 +356,22 @@ func (em *EnvironmentManagerAPI) ListEnvironments(user params.Entity) (params.Us
 	}
 
 	for _, env := range environments {
+		var lastConn *time.Time
+		userLastConn, err := env.LastConnection()
+		if err != nil {
+			if !state.IsNeverConnectedError(err) {
+				return result, errors.Trace(err)
+			}
+		} else {
+			lastConn = &userLastConn
+		}
 		result.UserEnvironments = append(result.UserEnvironments, params.UserEnvironment{
 			Environment: params.Environment{
 				Name:     env.Name(),
 				UUID:     env.UUID(),
 				OwnerTag: env.Owner().String(),
 			},
-			LastConnection: env.LastConnection,
+			LastConnection: lastConn,
 		})
 		logger.Debugf("list env: %s, %s, %s", env.Name(), env.UUID(), env.Owner())
 	}

--- a/apiserver/systemmanager/systemmanager.go
+++ b/apiserver/systemmanager/systemmanager.go
@@ -93,6 +93,10 @@ func (s *SystemManagerAPI) AllEnvironments() (params.UserEnvironmentList, error)
 	}
 	visibleEnvironments := set.NewStrings()
 	for _, env := range environments {
+		lastConn, err := env.LastConnection()
+		if err != nil && !state.IsNeverConnectedError(err) {
+			return result, errors.Trace(err)
+		}
 		visibleEnvironments.Add(env.UUID())
 		result.UserEnvironments = append(result.UserEnvironments, params.UserEnvironment{
 			Environment: params.Environment{
@@ -100,7 +104,7 @@ func (s *SystemManagerAPI) AllEnvironments() (params.UserEnvironmentList, error)
 				UUID:     env.UUID(),
 				OwnerTag: env.Owner().String(),
 			},
-			LastConnection: env.LastConnection,
+			LastConnection: &lastConn,
 		})
 	}
 

--- a/featuretests/cmd_juju_environment_test.go
+++ b/featuretests/cmd_juju_environment_test.go
@@ -49,7 +49,9 @@ func (s *cmdEnvironmentSuite) TestEnvironmentShareCmdStack(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(envUser.UserName(), gc.Equals, user.Username())
 	c.Assert(envUser.CreatedBy(), gc.Equals, s.AdminUserTag(c).Username())
-	c.Assert(envUser.LastConnection(), gc.IsNil)
+	lastConn, err := envUser.LastConnection()
+	c.Assert(err, jc.Satisfies, state.IsNeverConnectedError)
+	c.Assert(lastConn.IsZero(), jc.IsTrue)
 }
 
 func (s *cmdEnvironmentSuite) TestEnvironmentUnshareCmdStack(c *gc.C) {

--- a/mongo/collections.go
+++ b/mongo/collections.go
@@ -44,6 +44,8 @@ type WriteCollection interface {
 
 	// All other methods act as documented for *mgo.Collection.
 	Insert(docs ...interface{}) error
+	Upsert(selector interface{}, update interface{}) (info *mgo.ChangeInfo, err error)
+	UpsertId(id interface{}, update interface{}) (info *mgo.ChangeInfo, err error)
 	Update(selector interface{}, update interface{}) error
 	UpdateId(id interface{}, update interface{}) error
 	Remove(sel interface{}) error

--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -101,6 +101,12 @@ func allCollections() collectionSchema {
 			}},
 		},
 
+		// This collection holds the last time the user connected to the API server.
+		userLastLoginC: {
+			global:    true,
+			rawAccess: true,
+		},
+
 		// This collection is used as a unique key restraint. The _id field is
 		// a concatenation of multiple fields that form a compound index,
 		// allowing us to ensure users cannot have the same name for two
@@ -133,6 +139,12 @@ func allCollections() collectionSchema {
 		// references the global records of the users allowed access to a
 		// given collection.
 		envUsersC: {},
+
+		// This collection holds the last time the environment user connected
+		// to the environment.
+		envUserLastConnectionC: {
+			rawAccess: true,
+		},
 
 		// This collection contains governors that prevent certain kinds of
 		// changes from being accepted.
@@ -372,6 +384,8 @@ const (
 	upgradeInfoC           = "upgradeInfo"
 	userenvnameC           = "userenvname"
 	usersC                 = "users"
+	userLastLoginC         = "userLastLogin"
+	envUserLastConnectionC = "envUserLastConnection"
 	volumeAttachmentsC     = "volumeattachments"
 	volumesC               = "volumes"
 )

--- a/state/envuser.go
+++ b/state/envuser.go
@@ -31,13 +31,18 @@ type envUserDoc struct {
 	DisplayName string    `bson:"displayname"`
 	CreatedBy   string    `bson:"createdby"`
 	DateCreated time.Time `bson:"datecreated"`
-	// LastConnection is updated by the apiserver whenever the user
-	// connects over the API. This update is not done using mgo.txn
-	// so this value could well change underneath a normal transaction
-	// and as such, it should NEVER appear in any transaction asserts.
-	// It is really informational only as far as everyone except the
-	// api server is concerned.
-	LastConnection *time.Time `bson:"lastconnection"`
+}
+
+// envUserLastConnectionDoc is updated by the apiserver whenever the user
+// connects over the API. This update is not done using mgo.txn so the values
+// could well change underneath a normal transaction and as such, it should
+// NEVER appear in any transaction asserts. It is really informational only as
+// far as everyone except the api server is concerned.
+type envUserLastConnectionDoc struct {
+	ID             string    `bson:"_id"`
+	EnvUUID        string    `bson:"env-uuid"`
+	UserName       string    `bson:"user"`
+	LastConnection time.Time `bson:"last-connection"`
 }
 
 // ID returns the ID of the environment user.
@@ -75,41 +80,61 @@ func (e *EnvironmentUser) DateCreated() time.Time {
 	return e.doc.DateCreated.UTC()
 }
 
-// LastLogin returns when this EnvironmentUser last connected through the API
+// LastConnection returns when this EnvironmentUser last connected through the API
 // in UTC. The resulting time will be nil if the user has never logged in.
-func (e *EnvironmentUser) LastConnection() *time.Time {
-	when := e.doc.LastConnection
-	if when == nil {
-		return nil
+func (e *EnvironmentUser) LastConnection() (time.Time, error) {
+	lastConnections, closer := e.st.getRawCollection(envUserLastConnectionC)
+	defer closer()
+
+	username := strings.ToLower(e.UserName())
+	var lastConn envUserLastConnectionDoc
+	err := lastConnections.FindId(e.st.docID(username)).Select(bson.D{{"last-connection", 1}}).One(&lastConn)
+	if err != nil {
+		if err == mgo.ErrNotFound {
+			err = errors.Wrap(err, NeverConnectedError(e.UserName()))
+		}
+		return time.Time{}, errors.Trace(err)
 	}
-	result := when.UTC()
-	return &result
+
+	return lastConn.LastConnection.UTC(), nil
+}
+
+// NeverConnectedError is used to indicate that a user has never connected to
+// an environment.
+type NeverConnectedError string
+
+// Error returns the error string for a user who has never connected to an
+// environment.
+func (e NeverConnectedError) Error() string {
+	return `never connected: "` + string(e) + `"`
+}
+
+// IsNeverConnectedError returns true if err is of type NeverConnectedError.
+func IsNeverConnectedError(err error) bool {
+	_, ok := errors.Cause(err).(NeverConnectedError)
+	return ok
 }
 
 // UpdateLastConnection updates the last connection time of the environment user.
 func (e *EnvironmentUser) UpdateLastConnection() error {
-	envUsers, closer := e.st.getCollection(envUsersC)
+	lastConnections, closer := e.st.getCollection(envUserLastConnectionC)
 	defer closer()
-	// XXX(fwereade): 2015-06-19 this is anything but safe: we must not mix
-	// txn and non-txn operations in the same collection without clear and
-	// detailed reasoning for so doing.
-	envUsersW := envUsers.Writeable()
 
-	// Update the safe mode of the underlying session to be not require
+	lastConnectionsW := lastConnections.Writeable()
+
+	// Update the safe mode of the underlying session to not require
 	// write majority, nor sync to disk.
-	session := envUsersW.Underlying().Database.Session
+	session := lastConnectionsW.Underlying().Database.Session
 	session.SetSafe(&mgo.Safe{})
 
-	timestamp := nowToTheSecond()
-	update := bson.D{{"$set", bson.D{{"lastconnection", timestamp}}}}
-
-	id := strings.ToLower(e.UserName())
-	if err := envUsersW.UpdateId(id, update); err != nil {
-		return errors.Annotatef(err, "cannot update last connection timestamp for envuser %q", e.ID())
+	lastConn := envUserLastConnectionDoc{
+		ID:             e.st.docID(strings.ToLower(e.UserName())),
+		EnvUUID:        e.EnvironmentTag().Id(),
+		UserName:       e.UserName(),
+		LastConnection: nowToTheSecond(),
 	}
-
-	e.doc.LastConnection = &timestamp
-	return nil
+	_, err := lastConnectionsW.UpsertId(lastConn.ID, lastConn)
+	return errors.Trace(err)
 }
 
 // EnvironmentUser returns the environment user.
@@ -205,11 +230,26 @@ func (st *State) RemoveEnvironmentUser(user names.UserTag) error {
 }
 
 // UserEnvironment contains information about an environment that a
-// user has access to, along with the last time the user has connected
-// to the environment.
+// user has access to.
 type UserEnvironment struct {
 	*Environment
-	LastConnection *time.Time
+	User names.UserTag
+}
+
+// LastConnection returns the last time the user has connected to the
+// environment.
+func (e *UserEnvironment) LastConnection() (time.Time, error) {
+	lastConnections, lastConnCloser := e.st.getRawCollection(envUserLastConnectionC)
+	defer lastConnCloser()
+
+	lastConnDoc := envUserLastConnectionDoc{}
+	id := ensureEnvUUID(e.EnvironTag().Id(), strings.ToLower(e.User.Username()))
+	err := lastConnections.FindId(id).Select(bson.D{{"last-connection", 1}}).One(&lastConnDoc)
+	if (err != nil && err != mgo.ErrNotFound) || lastConnDoc.LastConnection.IsZero() {
+		return time.Time{}, errors.Trace(NeverConnectedError(e.User.Username()))
+	}
+
+	return lastConnDoc.LastConnection, nil
 }
 
 // EnvironmentsForUser returns a list of enviroments that the user
@@ -224,7 +264,7 @@ func (st *State) EnvironmentsForUser(user names.UserTag) ([]*UserEnvironment, er
 
 	// TODO: consider adding an index to the envUsers collection on the username.
 	var userSlice []envUserDoc
-	err := envUsers.Find(bson.D{{"user", user.Username()}}).All(&userSlice)
+	err := envUsers.Find(bson.D{{"user", user.Username()}}).Select(bson.D{{"env-uuid", 1}, {"_id", 1}}).All(&userSlice)
 	if err != nil {
 		return nil, err
 	}
@@ -236,7 +276,8 @@ func (st *State) EnvironmentsForUser(user names.UserTag) ([]*UserEnvironment, er
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		result = append(result, &UserEnvironment{Environment: env, LastConnection: doc.LastConnection})
+
+		result = append(result, &UserEnvironment{Environment: env, User: user})
 	}
 
 	return result, nil

--- a/state/envuser_test.go
+++ b/state/envuser_test.go
@@ -37,7 +37,9 @@ func (s *EnvUserSuite) TestAddEnvironmentUser(c *gc.C) {
 	c.Assert(envUser.DisplayName(), gc.Equals, user.DisplayName())
 	c.Assert(envUser.CreatedBy(), gc.Equals, "createdby@local")
 	c.Assert(envUser.DateCreated().Equal(now) || envUser.DateCreated().After(now), jc.IsTrue)
-	c.Assert(envUser.LastConnection(), gc.IsNil)
+	when, err := envUser.LastConnection()
+	c.Assert(err, jc.Satisfies, state.IsNeverConnectedError)
+	c.Assert(when.IsZero(), jc.IsTrue)
 
 	envUser, err = s.State.EnvironmentUser(user.UserTag())
 	c.Assert(err, jc.ErrorIsNil)
@@ -47,7 +49,9 @@ func (s *EnvUserSuite) TestAddEnvironmentUser(c *gc.C) {
 	c.Assert(envUser.DisplayName(), gc.Equals, user.DisplayName())
 	c.Assert(envUser.CreatedBy(), gc.Equals, "createdby@local")
 	c.Assert(envUser.DateCreated().Equal(now) || envUser.DateCreated().After(now), jc.IsTrue)
-	c.Assert(envUser.LastConnection(), gc.IsNil)
+	when, err = envUser.LastConnection()
+	c.Assert(err, jc.Satisfies, state.IsNeverConnectedError)
+	c.Assert(when.IsZero(), jc.IsTrue)
 }
 
 func (s *EnvUserSuite) TestCaseSensitiveEnvUserErrors(c *gc.C) {
@@ -137,10 +141,49 @@ func (s *EnvUserSuite) TestUpdateLastConnection(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = envUser.UpdateLastConnection()
 	c.Assert(err, jc.ErrorIsNil)
+	when, err := envUser.LastConnection()
+	c.Assert(err, jc.ErrorIsNil)
 	// It is possible that the update is done over a second boundary, so we need
 	// to check for after now as well as equal.
-	c.Assert(envUser.LastConnection().After(now) ||
-		envUser.LastConnection().Equal(now), jc.IsTrue)
+	c.Assert(when.After(now) || when.Equal(now), jc.IsTrue)
+}
+
+func (s *EnvUserSuite) TestUpdateLastConnectionTwoEnvUsers(c *gc.C) {
+	now := state.NowToTheSecond()
+
+	// Create a user and add them to the inital environment.
+	createdBy := s.Factory.MakeUser(c, &factory.UserParams{Name: "createdby"})
+	user := s.Factory.MakeUser(c, &factory.UserParams{Name: "validusername", Creator: createdBy.Tag()})
+	envUser, err := s.State.EnvironmentUser(user.UserTag())
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Create a second environment and add the same user to this.
+	st2 := s.Factory.MakeEnvironment(c, nil)
+	defer st2.Close()
+	envUser2, err := st2.AddEnvironmentUser(user.UserTag(), createdBy.UserTag(), "ignored")
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Now we have two environment users with the same username. Ensure we get
+	// separate last connections.
+
+	// Connect envUser and get last connection.
+	err = envUser.UpdateLastConnection()
+	c.Assert(err, jc.ErrorIsNil)
+	when, err := envUser.LastConnection()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(when.After(now) || when.Equal(now), jc.IsTrue)
+
+	// Try to get last connection for envUser2. As they have never connected,
+	// we expect to get an error.
+	_, err = envUser2.LastConnection()
+	c.Assert(err, gc.ErrorMatches, `never connected: "validusername@local"`)
+
+	// Connect envUser2 and get last connection.
+	err = envUser2.UpdateLastConnection()
+	c.Assert(err, jc.ErrorIsNil)
+	when, err = envUser2.LastConnection()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(when.After(now) || when.Equal(now), jc.IsTrue)
 }
 
 func (s *EnvUserSuite) TestEnvironmentsForUserNone(c *gc.C) {
@@ -163,6 +206,9 @@ func (s *EnvUserSuite) TestEnvironmentsForUser(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(environments, gc.HasLen, 1)
 	c.Assert(environments[0].UUID(), gc.Equals, s.State.EnvironUUID())
+	when, err := environments[0].LastConnection()
+	c.Assert(err, jc.Satisfies, state.IsNeverConnectedError)
+	c.Assert(when.IsZero(), jc.IsTrue)
 }
 
 func (s *EnvUserSuite) newEnvWithOwner(c *gc.C, name string, owner names.UserTag) *state.Environment {

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -308,6 +308,10 @@ func GetRawCollection(st *State, name string) (*mgo.Collection, func()) {
 	return st.getRawCollection(name)
 }
 
+func HasRawAccess(collectionName string) bool {
+	return allCollections()[collectionName].rawAccess
+}
+
 func MultiEnvCollections() []string {
 	var result []string
 	for name, info := range allCollections() {

--- a/state/state.go
+++ b/state/state.go
@@ -138,11 +138,17 @@ func (st *State) RemoveAllEnvironDocs() error {
 			return errors.Trace(err)
 		}
 		for _, id := range ids {
-			ops = append(ops, txn.Op{
-				C:      name,
-				Id:     id["_id"],
-				Remove: true,
-			})
+			if info.rawAccess {
+				if err := coll.Writeable().RemoveId(id["_id"]); err != nil {
+					return errors.Trace(err)
+				}
+			} else {
+				ops = append(ops, txn.Op{
+					C:      name,
+					Id:     id["_id"],
+					Remove: true,
+				})
+			}
 		}
 	}
 

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -2782,10 +2782,21 @@ func (s *StateSuite) TestRemoveAllEnvironDocs(c *gc.C) {
 		if collName == "constraints" || collName == "envusers" || collName == "settings" {
 			continue
 		}
-		ops = append(ops, mgotxn.Op{
-			C:      collName,
-			Id:     state.DocID(st, "arbitraryid"),
-			Insert: bson.M{"env-uuid": st.EnvironUUID()}})
+		if state.HasRawAccess(collName) {
+			coll, closer := state.GetRawCollection(st, collName)
+			defer closer()
+
+			err := coll.Insert(bson.M{
+				"_id":      state.DocID(st, "arbitraryid"),
+				"env-uuid": st.EnvironUUID(),
+			})
+			c.Assert(err, jc.ErrorIsNil)
+		} else {
+			ops = append(ops, mgotxn.Op{
+				C:      collName,
+				Id:     state.DocID(st, "arbitraryid"),
+				Insert: bson.M{"env-uuid": st.EnvironUUID()}})
+		}
 	}
 	err := state.RunTransaction(st, ops)
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -15,6 +15,7 @@ import (
 	"github.com/juju/utils"
 	"github.com/juju/utils/set"
 	"gopkg.in/juju/charm.v5"
+	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
 
@@ -1565,6 +1566,124 @@ func SetHostedEnvironCount(st *State) error {
 	}
 
 	return st.runTransaction([]txn.Op{op})
+}
+
+type oldUserDoc struct {
+	DocID     string     `bson:"_id"`
+	EnvUUID   string     `bson:"env-uuid"`
+	LastLogin *time.Time `bson:"lastlogin"`
+}
+
+type oldEnvUserDoc struct {
+	DocID          string     `bson:"_id"`
+	EnvUUID        string     `bson:"env-uuid"`
+	UserName       string     `bson:"user"`
+	LastConnection *time.Time `bson:"lastconnection"`
+}
+
+// MigrateLastLoginAndLastConnection is an upgrade step that separates out
+// LastLogin from the userDoc into its own collection and removes the
+// lastlogin field from the userDoc. It does the same for LastConnection in
+// the envUserDoc.
+func MigrateLastLoginAndLastConnection(st *State) error {
+	err := st.ResumeTransactions()
+	if err != nil {
+		return err
+	}
+
+	// 0. setup
+	users, closer := st.getRawCollection(usersC)
+	defer closer()
+	envUsers, closer := st.getRawCollection(envUsersC)
+	defer closer()
+	userLastLogins, closer := st.getRawCollection(userLastLoginC)
+	defer closer()
+	envUserLastConnections, closer := st.getRawCollection(envUserLastConnectionC)
+	defer closer()
+
+	var oldUserDocs []oldUserDoc
+	if err = users.Find(bson.D{{
+		"lastlogin", bson.D{{"$exists", true}}}}).All(&oldUserDocs); err != nil {
+		return err
+	}
+
+	var oldEnvUserDocs []oldEnvUserDoc
+	if err = envUsers.Find(bson.D{{
+		"lastconnection", bson.D{{"$exists", true}}}}).All(&oldEnvUserDocs); err != nil {
+		return err
+	}
+
+	// 1. collect data we need to move
+	var lastLoginDocs []interface{}
+	var lastConnectionDocs []interface{}
+
+	for _, oldUser := range oldUserDocs {
+		lastLoginDocs = append(lastLoginDocs, userLastLoginDoc{
+			oldUser.DocID,
+			oldUser.EnvUUID,
+			*oldUser.LastLogin,
+		})
+	}
+
+	for _, oldEnvUser := range oldEnvUserDocs {
+		lastConnectionDocs = append(lastConnectionDocs, envUserLastConnectionDoc{
+			oldEnvUser.DocID,
+			oldEnvUser.EnvUUID,
+			oldEnvUser.UserName,
+			*oldEnvUser.LastConnection,
+		})
+	}
+
+	// 2. raw-write all that data to the new collections, overwriting
+	// everything.
+	//
+	// If a user accesses the API during the upgrade, a lastLoginDoc could
+	// already exist. In this is the case, we hit a duplicate key error, which
+	// we ignore. The insert becomes a no-op, keeping the new lastLoginDoc
+	// which will be more up-to-date than what's read in through the usersC
+	// collection.
+	if len(lastLoginDocs) > 0 {
+		if err := userLastLogins.Insert(lastLoginDocs...); err != nil && !mgo.IsDup(err) {
+			return err
+		}
+	}
+
+	if len(lastConnectionDocs) > 0 {
+		if err := envUserLastConnections.Insert(lastConnectionDocs...); err != nil && !mgo.IsDup(err) {
+			return err
+		}
+	}
+
+	// 3. run txn operations to remove the old unwanted fields
+	ops := []txn.Op{}
+
+	for _, oldUser := range oldUserDocs {
+		upgradesLogger.Debugf("updating lastlogin for user %q", oldUser.DocID)
+		ops = append(ops,
+			txn.Op{
+				C:      usersC,
+				Id:     oldUser.DocID,
+				Assert: txn.DocExists,
+				Update: bson.D{
+					{"$unset", bson.D{{"lastlogin", nil}}},
+				},
+			})
+	}
+
+	for _, oldEnvUser := range oldEnvUserDocs {
+		upgradesLogger.Debugf("updating lastconnection for environment user %q", oldEnvUser.DocID)
+
+		ops = append(ops,
+			txn.Op{
+				C:      envUsersC,
+				Id:     oldEnvUser.DocID,
+				Assert: txn.DocExists,
+				Update: bson.D{
+					{"$unset", bson.D{{"lastconnection", nil}}},
+				},
+			})
+	}
+	return st.runRawTransaction(ops)
 }
 
 // AddMissingEnvUUIDOnStatuses populates the env-uuid field where it

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -62,9 +62,6 @@ func (s *upgradesSuite) TestLastLoginMigrate(c *gc.C) {
 
 	err = MigrateUserLastConnectionToLastLogin(s.state)
 	c.Assert(err, jc.ErrorIsNil)
-	user, err := s.state.User(names.NewLocalUserTag(userId))
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(*user.LastLogin(), gc.Equals, now)
 
 	// check to see if _id_ field is removed
 	userMap := map[string]interface{}{}
@@ -74,6 +71,10 @@ func (s *upgradesSuite) TestLastLoginMigrate(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	_, keyExists := userMap["_id_"]
 	c.Assert(keyExists, jc.IsFalse)
+
+	lastLogin, keyExists := userMap["lastlogin"]
+	c.Assert(keyExists, jc.IsTrue)
+	c.Assert(now.Equal(lastLogin.(time.Time)), jc.IsTrue)
 }
 
 func (s *upgradesSuite) TestLowerCaseEnvUsersID(c *gc.C) {
@@ -3330,6 +3331,121 @@ func (s *upgradesSuite) removeEnvCountDoc(c *gc.C) {
 		Remove: true,
 	}})
 	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *upgradesSuite) TestMigrateLastLoginAndLastConnection(c *gc.C) {
+	t := time.Now().Round(time.Second)
+	user := names.NewUserTag("foobar")
+
+	s.addUsersForLastLoginAndConnection(c, t, user)
+
+	err := MigrateLastLoginAndLastConnection(s.state)
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.assertLastLoginAndConnectionMigration(c, t, user)
+}
+
+func (s *upgradesSuite) TestMigrateLastLoginAndLastConnectionIdempotent(c *gc.C) {
+	t := time.Now().Round(time.Second)
+	user := names.NewUserTag("foobar")
+
+	s.addUsersForLastLoginAndConnection(c, t, user)
+
+	err := MigrateLastLoginAndLastConnection(s.state)
+	c.Assert(err, jc.ErrorIsNil)
+	err = MigrateLastLoginAndLastConnection(s.state)
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.assertLastLoginAndConnectionMigration(c, t, user)
+}
+
+func (s *upgradesSuite) addUsersForLastLoginAndConnection(c *gc.C, t time.Time, user names.UserTag) {
+	userID := user.Id()
+	oldEnvUserID := envUserID(user)
+
+	oldUserDoc := bson.M{
+		"_id":          userID,
+		"env-uuid":     "envuuid456",
+		"displayname":  "foo bar",
+		"deactivated":  false,
+		"passwordhash": "hash",
+		"passwordsalt": "salt",
+		"createdby":    "creator",
+		"datecreated":  t,
+		"lastlogin":    t,
+	}
+
+	oldEnvUserDoc := bson.M{
+		"_id":            oldEnvUserID,
+		"env-uuid":       "envuuid123",
+		"user":           "username@local",
+		"displayname":    "ignored",
+		"createdby":      "ignored@local",
+		"datecreated":    t,
+		"lastconnection": t,
+	}
+
+	ops := []txn.Op{
+		{
+			C:      "users",
+			Id:     userID,
+			Assert: txn.DocMissing,
+			Insert: oldUserDoc,
+		},
+		{
+			C:      "envusers",
+			Id:     oldEnvUserID,
+			Assert: txn.DocMissing,
+			Insert: oldEnvUserDoc,
+		},
+	}
+	err := s.state.runRawTransaction(ops)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *upgradesSuite) assertLastLoginAndConnectionMigration(c *gc.C, t time.Time, user names.UserTag) {
+	userID := user.Id()
+	oldEnvUserID := envUserID(user)
+
+	// check to see if lastlogin field is removed
+	userMap := s.getDocMap(c, userID, "users")
+	_, keyExists := userMap["lastlogin"]
+	c.Assert(keyExists, jc.IsFalse)
+
+	// check to see if lastconnection field is removed
+	envUserMap := s.getDocMap(c, oldEnvUserID, "envusers")
+	_, keyExists = envUserMap["lastconnection"]
+	c.Assert(keyExists, jc.IsFalse)
+
+	// check to see if lastlogin doc is added
+	lastLoginMap := s.getDocMap(c, userID, "userLastLogin")
+	lastLogin, keyExists := lastLoginMap["last-login"]
+	c.Assert(keyExists, jc.IsTrue)
+	c.Assert(lastLogin.(time.Time).UTC(), gc.Equals, t.UTC())
+	envUUID, keyExists := lastLoginMap["env-uuid"]
+	c.Assert(keyExists, jc.IsTrue)
+	c.Assert(envUUID, gc.Equals, "envuuid456")
+
+	// check to see if lastconnection doc is added
+	lastConnMap := s.getDocMap(c, oldEnvUserID, "envUserLastConnection")
+	lastConn, keyExists := lastConnMap["last-connection"]
+	c.Assert(keyExists, jc.IsTrue)
+	c.Assert(lastConn.(time.Time).UTC(), gc.Equals, t.UTC())
+	envUUID, keyExists = lastConnMap["env-uuid"]
+	c.Assert(keyExists, jc.IsTrue)
+	c.Assert(envUUID, gc.Equals, "envuuid123")
+	username, keyExists := lastConnMap["user"]
+	c.Assert(keyExists, jc.IsTrue)
+	c.Assert(username, gc.Equals, "username@local")
+}
+
+func (s *upgradesSuite) getDocMap(c *gc.C, docID, collection string) map[string]interface{} {
+	docMap := map[string]interface{}{}
+	coll, closer := s.state.getRawCollection(collection)
+	defer closer()
+	err := coll.Find(bson.D{{"_id", docID}}).One(&docMap)
+	c.Assert(err, jc.ErrorIsNil)
+	return docMap
 }
 
 func (s *upgradesSuite) TestAddMissingEnvUUIDOnStatuses(c *gc.C) {

--- a/state/user.go
+++ b/state/user.go
@@ -152,8 +152,9 @@ func (st *State) AllUsers(includeDeactivated bool) ([]*User, error) {
 
 // User represents a local user in the database.
 type User struct {
-	st  *State
-	doc userDoc
+	st           *State
+	doc          userDoc
+	lastLoginDoc userLastLoginDoc
 }
 
 type userDoc struct {
@@ -166,13 +167,18 @@ type userDoc struct {
 	PasswordSalt string    `bson:"passwordsalt"`
 	CreatedBy    string    `bson:"createdby"`
 	DateCreated  time.Time `bson:"datecreated"`
+}
+
+type userLastLoginDoc struct {
+	DocID   string `bson:"_id"`
+	EnvUUID string `bson:"env-uuid"`
 	// LastLogin is updated by the apiserver whenever the user
 	// connects over the API. This update is not done using mgo.txn
 	// so this value could well change underneath a normal transaction
 	// and as such, it should NEVER appear in any transaction asserts.
 	// It is really informational only as far as everyone except the
 	// api server is concerned.
-	LastLogin *time.Time `bson:"lastlogin"`
+	LastLogin time.Time `bson:"last-login"`
 }
 
 // String returns "<name>@local" where <name> is the Name of the user.
@@ -220,13 +226,20 @@ func (u *User) UserTag() names.UserTag {
 // The resulting time will be nil if the user has never logged in.  In the
 // normal case, the LastLogin is the last time that the user connected through
 // the API server.
-func (u *User) LastLogin() *time.Time {
-	when := u.doc.LastLogin
-	if when == nil {
-		return nil
+func (u *User) LastLogin() (time.Time, error) {
+	lastLogins, closer := u.st.getRawCollection(userLastLoginC)
+	defer closer()
+
+	var lastLogin userLastLoginDoc
+	err := lastLogins.FindId(u.doc.DocID).Select(bson.D{{"last-login", 1}}).One(&lastLogin)
+	if err != nil {
+		if err == mgo.ErrNotFound {
+			err = errors.Wrap(err, NeverLoggedInError(u.UserTag().Name()))
+		}
+		return time.Time{}, errors.Trace(err)
 	}
-	result := when.UTC()
-	return &result
+
+	return lastLogin.LastLogin.UTC(), nil
 }
 
 // nowToTheSecond returns the current time in UTC to the nearest second.
@@ -238,30 +251,42 @@ func (u *User) LastLogin() *time.Time {
 // to package.
 var nowToTheSecond = func() time.Time { return time.Now().Round(time.Second).UTC() }
 
+// NeverLoggedInError is used to indicate that a user has never logged in.
+type NeverLoggedInError string
+
+// Error returns the error string for a user who has never logged
+// in.
+func (e NeverLoggedInError) Error() string {
+	return `never logged in: "` + string(e) + `"`
+}
+
+// IsNeverLoggedInError returns true if err is of type NeverLoggedInError.
+func IsNeverLoggedInError(err error) bool {
+	_, ok := errors.Cause(err).(NeverLoggedInError)
+	return ok
+}
+
 // UpdateLastLogin sets the LastLogin time of the user to be now (to the
 // nearest second).
-func (u *User) UpdateLastLogin() error {
-	users, closer := u.st.getCollection(usersC)
+func (u *User) UpdateLastLogin() (err error) {
+	lastLogins, closer := u.st.getCollection(userLastLoginC)
 	defer closer()
-	// XXX(fwereade): 2015-06-19 this is anything but safe: we must not mix
-	// txn and non-txn operations in the same collection without clear and
-	// detailed reasoning for so doing.
-	usersW := users.Writeable()
 
-	// Update the safe mode of the underlying session to be not require
+	lastLoginsW := lastLogins.Writeable()
+
+	// Update the safe mode of the underlying session to not require
 	// write majority, nor sync to disk.
-	session := usersW.Underlying().Database.Session
+	session := lastLoginsW.Underlying().Database.Session
 	session.SetSafe(&mgo.Safe{})
 
-	timestamp := nowToTheSecond()
-	update := bson.D{{"$set", bson.D{{"lastlogin", timestamp}}}}
-
-	if err := usersW.UpdateId(u.Name(), update); err != nil {
-		return errors.Annotatef(err, "cannot update last login timestamp for user %q", u.Name())
+	lastLogin := userLastLoginDoc{
+		DocID:     u.doc.DocID,
+		EnvUUID:   u.st.EnvironUUID(),
+		LastLogin: nowToTheSecond(),
 	}
 
-	u.doc.LastLogin = &timestamp
-	return nil
+	_, err = lastLoginsW.UpsertId(lastLogin.DocID, lastLogin)
+	return errors.Trace(err)
 }
 
 // SetPassword sets the password associated with the User.

--- a/state/user_test.go
+++ b/state/user_test.go
@@ -57,7 +57,9 @@ func (s *UserSuite) TestAddUser(c *gc.C) {
 	c.Assert(user.CreatedBy(), gc.Equals, creator)
 	c.Assert(user.DateCreated().After(now) ||
 		user.DateCreated().Equal(now), jc.IsTrue)
-	c.Assert(user.LastLogin(), gc.IsNil)
+	lastLogin, err := user.LastLogin()
+	c.Assert(err, jc.Satisfies, state.IsNeverLoggedInError)
+	c.Assert(lastLogin, gc.DeepEquals, time.Time{})
 
 	user, err = s.State.User(user.UserTag())
 	c.Assert(err, jc.ErrorIsNil)
@@ -68,7 +70,9 @@ func (s *UserSuite) TestAddUser(c *gc.C) {
 	c.Assert(user.CreatedBy(), gc.Equals, creator)
 	c.Assert(user.DateCreated().After(now) ||
 		user.DateCreated().Equal(now), jc.IsTrue)
-	c.Assert(user.LastLogin(), gc.IsNil)
+	lastLogin, err = user.LastLogin()
+	c.Assert(err, jc.Satisfies, state.IsNeverLoggedInError)
+	c.Assert(lastLogin, gc.DeepEquals, time.Time{})
 }
 
 func (s *UserSuite) TestCheckUserExists(c *gc.C) {
@@ -91,8 +95,10 @@ func (s *UserSuite) TestUpdateLastLogin(c *gc.C) {
 	user := s.Factory.MakeUser(c, nil)
 	err := user.UpdateLastLogin()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(user.LastLogin().After(now) ||
-		user.LastLogin().Equal(now), jc.IsTrue)
+	lastLogin, err := user.LastLogin()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(lastLogin.After(now) ||
+		lastLogin.Equal(now), jc.IsTrue)
 }
 
 func (s *UserSuite) TestSetPassword(c *gc.C) {

--- a/testing/factory/factory_test.go
+++ b/testing/factory/factory_test.go
@@ -48,8 +48,13 @@ func (s *factorySuite) TestMakeUserNil(c *gc.C) {
 	c.Assert(saved.DisplayName(), gc.Equals, user.DisplayName())
 	c.Assert(saved.CreatedBy(), gc.Equals, user.CreatedBy())
 	c.Assert(saved.DateCreated(), gc.Equals, user.DateCreated())
-	c.Assert(saved.LastLogin(), gc.Equals, user.LastLogin())
 	c.Assert(saved.IsDisabled(), gc.Equals, user.IsDisabled())
+
+	savedLastLogin, err := saved.LastLogin()
+	c.Assert(err, jc.Satisfies, state.IsNeverLoggedInError)
+	lastLogin, err := user.LastLogin()
+	c.Assert(err, jc.Satisfies, state.IsNeverLoggedInError)
+	c.Assert(savedLastLogin, gc.Equals, lastLogin)
 }
 
 func (s *factorySuite) TestMakeUserParams(c *gc.C) {
@@ -76,8 +81,13 @@ func (s *factorySuite) TestMakeUserParams(c *gc.C) {
 	c.Assert(saved.DisplayName(), gc.Equals, user.DisplayName())
 	c.Assert(saved.CreatedBy(), gc.Equals, user.CreatedBy())
 	c.Assert(saved.DateCreated(), gc.Equals, user.DateCreated())
-	c.Assert(saved.LastLogin(), gc.Equals, user.LastLogin())
 	c.Assert(saved.IsDisabled(), gc.Equals, user.IsDisabled())
+
+	savedLastLogin, err := saved.LastLogin()
+	c.Assert(err, jc.Satisfies, state.IsNeverLoggedInError)
+	lastLogin, err := user.LastLogin()
+	c.Assert(err, jc.Satisfies, state.IsNeverLoggedInError)
+	c.Assert(savedLastLogin, gc.Equals, lastLogin)
 
 	_, err = s.State.EnvironmentUser(user.UserTag())
 	c.Assert(err, jc.ErrorIsNil)

--- a/upgrades/steps125.go
+++ b/upgrades/steps125.go
@@ -100,6 +100,12 @@ func stateStepsFor125() []Step {
 				return upgradeEnvironConfig(st, st, environs.GlobalProviderRegistry())
 			},
 		},
+		&upgradeStep{
+			description: "move lastlogin and last connection to their own collections",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return state.MigrateLastLoginAndLastConnection(context.State())
+			}},
 	}
 }
 

--- a/upgrades/steps125_test.go
+++ b/upgrades/steps125_test.go
@@ -36,6 +36,7 @@ func (s *steps125Suite) TestStateStepsFor125(c *gc.C) {
 		"add status to volume",
 		"add preferred addresses to machines",
 		"upgrade environment config",
+		"move lastlogin and last connection to their own collections",
 	}
 	assertStateSteps(c, version.MustParse("1.25.0"), expected)
 }


### PR DESCRIPTION
Separate out LastLogin from the userDoc into it's own collection.
Operate directly on docs in this collection without using txns. Do the
same for LastConnection in the envUserDoc. No tests where added as
existing behaviour should remain the same and is already covered.

Conflicts:
	upgrades/steps125.go
	upgrades/steps125_test.go

(Review request: http://reviews.vapour.ws/r/2815/)