### PR TITLE
storageprovisioner: don't bounce on bad params

### DIFF
--- a/worker/storageprovisioner/mock_test.go
+++ b/worker/storageprovisioner/mock_test.go
@@ -493,7 +493,7 @@ func (p *dummyProvider) Dynamic() bool {
 }
 
 func (s *dummyVolumeSource) ValidateVolumeParams(params storage.VolumeParams) error {
-	if s.provider.validateVolumeParamsFunc != nil {
+	if s.provider != nil && s.provider.validateVolumeParamsFunc != nil {
 		return s.provider.validateVolumeParamsFunc(params)
 	}
 	return nil

--- a/worker/storageprovisioner/mock_test.go
+++ b/worker/storageprovisioner/mock_test.go
@@ -452,13 +452,14 @@ type dummyProvider struct {
 	storage.Provider
 	dynamic bool
 
-	volumeSourceFunc      func(*config.Config, *storage.Config) (storage.VolumeSource, error)
-	filesystemSourceFunc  func(*config.Config, *storage.Config) (storage.FilesystemSource, error)
-	createVolumesFunc     func([]storage.VolumeParams) ([]storage.CreateVolumesResult, error)
-	attachVolumesFunc     func([]storage.VolumeAttachmentParams) ([]storage.AttachVolumesResult, error)
-	detachVolumesFunc     func([]storage.VolumeAttachmentParams) ([]error, error)
-	detachFilesystemsFunc func([]storage.FilesystemAttachmentParams) error
-	destroyVolumesFunc    func([]string) ([]error, error)
+	volumeSourceFunc         func(*config.Config, *storage.Config) (storage.VolumeSource, error)
+	filesystemSourceFunc     func(*config.Config, *storage.Config) (storage.FilesystemSource, error)
+	createVolumesFunc        func([]storage.VolumeParams) ([]storage.CreateVolumesResult, error)
+	attachVolumesFunc        func([]storage.VolumeAttachmentParams) ([]storage.AttachVolumesResult, error)
+	detachVolumesFunc        func([]storage.VolumeAttachmentParams) ([]error, error)
+	detachFilesystemsFunc    func([]storage.FilesystemAttachmentParams) error
+	destroyVolumesFunc       func([]string) ([]error, error)
+	validateVolumeParamsFunc func(storage.VolumeParams) error
 }
 
 type dummyVolumeSource struct {
@@ -491,7 +492,10 @@ func (p *dummyProvider) Dynamic() bool {
 	return p.dynamic
 }
 
-func (*dummyVolumeSource) ValidateVolumeParams(params storage.VolumeParams) error {
+func (s *dummyVolumeSource) ValidateVolumeParams(params storage.VolumeParams) error {
+	if s.provider.validateVolumeParamsFunc != nil {
+		return s.provider.validateVolumeParamsFunc(params)
+	}
 	return nil
 }
 


### PR DESCRIPTION
If the storage provisioner is handed invalid volume
parameters it should inform the user by setting the
volume's status to "error". This will prevent bad
parameters from preventing other volumes from being
created. In theory this should be unnecessary once
lp:1501709 is fixed, but the extra paranoia here
protects us from similar bugs in validation.

Fixes https://bugs.launchpad.net/juju-core/+bug/1501710

(Review request: http://reviews.vapour.ws/r/2817/)