### PR TITLE
apiserver: add tests for macaroon authentication on backup endpoint

### DIFF
--- a/apiserver/authhttp_test.go
+++ b/apiserver/authhttp_test.go
@@ -162,6 +162,12 @@ type httpRequestParams struct {
 	// body holds the body of the request.
 	body io.Reader
 
+	// jsonBody holds an object to be marshaled as JSON
+	// as the body of the request. If this is specified, body will
+	// be ignored and the Content-Type header will
+	// be set to application/json.
+	jsonBody interface{}
+
 	// nonce holds the machine nonce to provide in the header.
 	nonce string
 }
@@ -173,6 +179,7 @@ func (s *authHttpSuite) sendRequest(c *gc.C, p httpRequestParams) *http.Response
 		Method:      p.method,
 		URL:         p.url,
 		Body:        p.body,
+		JSONBody:    p.jsonBody,
 		Header:      make(http.Header),
 		Username:    p.tag,
 		Password:    p.password,

--- a/apiserver/backup_test.go
+++ b/apiserver/backup_test.go
@@ -17,6 +17,8 @@ import (
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
+	"gopkg.in/macaroon-bakery.v1/bakery/checkers"
+	"gopkg.in/macaroon-bakery.v1/httpbakery"
 
 	"github.com/juju/juju/apiserver"
 	apiserverbackups "github.com/juju/juju/apiserver/backups"
@@ -27,12 +29,12 @@ import (
 	backupstesting "github.com/juju/juju/state/backups/testing"
 )
 
-type baseBackupsSuite struct {
+type backupsCommonSuite struct {
 	authHttpSuite
 	fake *backupstesting.FakeBackups
 }
 
-func (s *baseBackupsSuite) SetUpTest(c *gc.C) {
+func (s *backupsCommonSuite) SetUpTest(c *gc.C) {
 	s.authHttpSuite.SetUpTest(c)
 
 	s.fake = &backupstesting.FakeBackups{}
@@ -43,7 +45,7 @@ func (s *baseBackupsSuite) SetUpTest(c *gc.C) {
 	)
 }
 
-func (s *baseBackupsSuite) backupURL(c *gc.C) string {
+func (s *backupsCommonSuite) backupURL(c *gc.C) string {
 	environ, err := s.State.Environment()
 	c.Assert(err, jc.ErrorIsNil)
 	uri := s.baseURL(c)
@@ -51,33 +53,34 @@ func (s *baseBackupsSuite) backupURL(c *gc.C) string {
 	return uri.String()
 }
 
-func (s *baseBackupsSuite) checkErrorResponse(c *gc.C, resp *http.Response, statusCode int, msg string) {
+func (s *backupsCommonSuite) assertErrorResponse(c *gc.C, resp *http.Response, statusCode int, msg string) *params.Error {
 	body, err := ioutil.ReadAll(resp.Body)
 	c.Assert(err, jc.ErrorIsNil)
 
-	c.Check(resp.StatusCode, gc.Equals, statusCode, gc.Commentf("body: %s", body))
-	c.Check(resp.Header.Get("Content-Type"), gc.Equals, apihttp.CTypeJSON)
+	c.Assert(resp.StatusCode, gc.Equals, statusCode, gc.Commentf("body: %s", body))
+	c.Assert(resp.Header.Get("Content-Type"), gc.Equals, apihttp.CTypeJSON)
 
 	var failure params.Error
 	err = json.Unmarshal(body, &failure)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Check(&failure, gc.ErrorMatches, msg, gc.Commentf("body: %s", body))
+	c.Assert(&failure, gc.ErrorMatches, msg, gc.Commentf("body: %s", body))
+	return &failure
 }
 
 type backupsSuite struct {
-	baseBackupsSuite
+	backupsCommonSuite
 }
 
 var _ = gc.Suite(&backupsSuite{})
 
 func (s *backupsSuite) TestRequiresAuth(c *gc.C) {
 	resp := s.sendRequest(c, httpRequestParams{method: "GET", url: s.backupURL(c)})
-	s.checkErrorResponse(c, resp, http.StatusUnauthorized, "no authorization header found")
+	s.assertErrorResponse(c, resp, http.StatusUnauthorized, "no authorization header found")
 }
 
 func (s *backupsSuite) checkInvalidMethod(c *gc.C, method, url string) {
 	resp := s.authRequest(c, httpRequestParams{method: method, url: url})
-	s.checkErrorResponse(c, resp, http.StatusMethodNotAllowed, `unsupported method: "`+method+`"`)
+	s.assertErrorResponse(c, resp, http.StatusMethodNotAllowed, `unsupported method: "`+method+`"`)
 }
 
 func (s *backupsSuite) TestInvalidHTTPMethods(c *gc.C) {
@@ -106,44 +109,127 @@ func (s *backupsSuite) TestAuthRequiresClientNotMachine(c *gc.C) {
 		url:      s.backupURL(c),
 		nonce:    "fake_nonce",
 	})
-	s.checkErrorResponse(c, resp, http.StatusUnauthorized, "invalid entity name or password")
+	s.assertErrorResponse(c, resp, http.StatusUnauthorized, "invalid entity name or password")
 
 	// Now try a user login.
 	resp = s.authRequest(c, httpRequestParams{method: "POST", url: s.backupURL(c)})
-	s.checkErrorResponse(c, resp, http.StatusMethodNotAllowed, `unsupported method: "POST"`)
+	s.assertErrorResponse(c, resp, http.StatusMethodNotAllowed, `unsupported method: "POST"`)
+}
+
+type backupsWithMacaroonsSuite struct {
+	backupsCommonSuite
+}
+
+var _ = gc.Suite(&backupsWithMacaroonsSuite{})
+
+func (s *backupsWithMacaroonsSuite) SetUpTest(c *gc.C) {
+	s.macaroonAuthEnabled = true
+	s.backupsCommonSuite.SetUpTest(c)
+}
+
+func (s *backupsWithMacaroonsSuite) TestWithNoBasicAuthReturnsDischargeRequiredError(c *gc.C) {
+	resp := s.sendRequest(c, httpRequestParams{
+		method:   "GET",
+		jsonBody: &params.BackupsDownloadArgs{"bad-id"},
+		url:      s.backupURL(c),
+	})
+
+	errResp := s.assertErrorResponse(c, resp, http.StatusUnauthorized, "verification failed: no macaroons")
+	c.Assert(errResp.Code, gc.Equals, params.CodeDischargeRequired)
+	c.Assert(errResp.Info, gc.NotNil)
+	c.Assert(errResp.Info.Macaroon, gc.NotNil)
+}
+
+func (s *backupsWithMacaroonsSuite) TestCanGetWithDischargedMacaroon(c *gc.C) {
+	checkCount := 0
+	s.checker = func(cond, arg string) ([]checkers.Caveat, error) {
+		if cond != "is-authenticated-user" {
+			return nil, errors.Errorf("unrecognized caveat %q", cond)
+		}
+		checkCount++
+		return []checkers.Caveat{
+			checkers.DeclaredCaveat("username", s.userTag.Id()),
+		}, nil
+	}
+	s.fake.Error = errors.New("failed!")
+	resp := s.sendRequest(c, httpRequestParams{
+		do:       s.doer(),
+		method:   "GET",
+		jsonBody: &params.BackupsDownloadArgs{"bad-id"},
+		url:      s.backupURL(c),
+	})
+	s.assertErrorResponse(c, resp, http.StatusInternalServerError, "failed!")
+	c.Assert(checkCount, gc.Equals, 1)
+}
+
+// doer returns a Do function that can make a bakery request
+// appropriate for a backups endpoint.
+func (s *backupsWithMacaroonsSuite) doer() func(*http.Request) (*http.Response, error) {
+	return bakeryDo(nil, backupsBakeryGetError)
+}
+
+// backupsBakeryGetError implements a getError function
+// appropriate for passing to httpbakery.Client.DoWithBodyAndCustomError
+// for the backups endpoint.
+func backupsBakeryGetError(resp *http.Response) error {
+	if resp.StatusCode != http.StatusUnauthorized {
+		return nil
+	}
+	data, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return errors.Annotatef(err, "cannot read body")
+	}
+	var errResp params.Error
+	if err := json.Unmarshal(data, &errResp); err != nil {
+		return errors.Annotatef(err, "cannot unmarshal body")
+	}
+	if errResp.Code != params.CodeDischargeRequired {
+		return &errResp
+	}
+	if errResp.Info == nil {
+		return errors.Annotatef(err, "no error info found in discharge-required response error")
+	}
+	// It's a discharge-required error, so make an appropriate httpbakery
+	// error from it.
+	return &httpbakery.Error{
+		Message: errResp.Message,
+		Code:    httpbakery.ErrDischargeRequired,
+		Info: &httpbakery.ErrorInfo{
+			Macaroon:     errResp.Info.Macaroon,
+			MacaroonPath: errResp.Info.MacaroonPath,
+		},
+	}
 }
 
 type backupsDownloadSuite struct {
-	baseBackupsSuite
-	body []byte
+	backupsCommonSuite
 }
 
 var _ = gc.Suite(&backupsDownloadSuite{})
 
-func (s *backupsDownloadSuite) newBody(c *gc.C, id string) *bytes.Buffer {
-	args := params.BackupsDownloadArgs{
-		ID: id,
-	}
-	body, err := json.Marshal(args)
-	c.Assert(err, jc.ErrorIsNil)
-	return bytes.NewBuffer(body)
-}
-
-func (s *backupsDownloadSuite) sendValid(c *gc.C) *http.Response {
+// sendValid sends a valid GET request to the backups endpoint
+// and returns the response and the expected contents of the
+// archive if the request succeeds.
+func (s *backupsDownloadSuite) sendValidGet(c *gc.C) (resp *http.Response, archiveBytes []byte) {
 	meta := backupstesting.NewMetadata()
 	archive, err := backupstesting.NewArchiveBasic(meta)
 	c.Assert(err, jc.ErrorIsNil)
+	archiveBytes = archive.Bytes()
 	s.fake.Meta = meta
 	s.fake.Archive = ioutil.NopCloser(archive)
-	s.body = archive.Bytes()
 
-	ctype := apihttp.CTypeJSON
-	body := s.newBody(c, meta.ID())
-	return s.authRequest(c, httpRequestParams{method: "GET", url: s.backupURL(c), contentType: ctype, body: body})
+	return s.authRequest(c, httpRequestParams{
+		method:      "GET",
+		url:         s.backupURL(c),
+		contentType: apihttp.CTypeJSON,
+		jsonBody: params.BackupsDownloadArgs{
+			ID: meta.ID(),
+		},
+	}), archiveBytes
 }
 
 func (s *backupsDownloadSuite) TestCalls(c *gc.C) {
-	resp := s.sendValid(c)
+	resp, _ := s.sendValidGet(c)
 	defer resp.Body.Close()
 
 	c.Check(s.fake.Calls, gc.DeepEquals, []string{"Get"})
@@ -151,7 +237,7 @@ func (s *backupsDownloadSuite) TestCalls(c *gc.C) {
 }
 
 func (s *backupsDownloadSuite) TestResponse(c *gc.C) {
-	resp := s.sendValid(c)
+	resp, _ := s.sendValidGet(c)
 	defer resp.Body.Close()
 	meta := s.fake.Meta
 
@@ -161,24 +247,24 @@ func (s *backupsDownloadSuite) TestResponse(c *gc.C) {
 }
 
 func (s *backupsDownloadSuite) TestBody(c *gc.C) {
-	resp := s.sendValid(c)
+	resp, archiveBytes := s.sendValidGet(c)
 	defer resp.Body.Close()
 
 	body, err := ioutil.ReadAll(resp.Body)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Check(body, jc.DeepEquals, s.body)
+	c.Check(body, jc.DeepEquals, archiveBytes)
 }
 
 func (s *backupsDownloadSuite) TestErrorWhenGetFails(c *gc.C) {
 	s.fake.Error = errors.New("failed!")
-	resp := s.sendValid(c)
+	resp, _ := s.sendValidGet(c)
 	defer resp.Body.Close()
 
-	s.checkErrorResponse(c, resp, http.StatusInternalServerError, "failed!")
+	s.assertErrorResponse(c, resp, http.StatusInternalServerError, "failed!")
 }
 
 type backupsUploadSuite struct {
-	baseBackupsSuite
+	backupsCommonSuite
 	meta *backups.Metadata
 }
 
@@ -248,5 +334,5 @@ func (s *backupsUploadSuite) TestErrorWhenGetFails(c *gc.C) {
 	resp := s.sendValid(c, "<a new backup ID>")
 	defer resp.Body.Close()
 
-	s.checkErrorResponse(c, resp, http.StatusInternalServerError, "failed!")
+	s.assertErrorResponse(c, resp, http.StatusInternalServerError, "failed!")
 }

--- a/apiserver/params/apierror.go
+++ b/apiserver/params/apierror.go
@@ -12,7 +12,7 @@ import (
 	"github.com/juju/juju/rpc"
 )
 
-// Error is the type of error returned by any call to the state API
+// Error is the type of error returned by any call to the state API.
 type Error struct {
 	Message string
 	Code    string


### PR DESCRIPTION
Also make the backup tests somewhat more consistent with other
similar suites.


(Review request: http://reviews.vapour.ws/r/2822/)