### PR TITLE
Provider default constraints

### DIFF
--- a/provider/common/disk.go
+++ b/provider/common/disk.go
@@ -20,7 +20,7 @@ func MinRootDiskSizeGiB(ser string) uint64 {
 		return 8
 	case jujuos.Windows:
 		return 40
-	// On default we just return a "sane" default, since the error will just
+	// By default we just return a "sane" default, since the error will just
 	// be returned by the api and seen in juju status
 	default:
 		return 8

--- a/provider/common/disk.go
+++ b/provider/common/disk.go
@@ -3,13 +3,29 @@
 
 package common
 
-const (
-	// MinRootDiskSizeGiB is the minimum size for the root disk of an
-	// instance, in Gigabytes. This value accommodates the anticipated
-	// size of the initial image, any updates, and future application
-	// data.
-	MinRootDiskSizeGiB uint64 = 8
+import (
+	jujuos "github.com/juju/utils/os"
+	"github.com/juju/utils/series"
 )
+
+// MinRootDiskSizeGiB is the minimum size for the root disk of an
+// instance, in Gigabytes. This value accommodates the anticipated
+// size of the initial image, any updates, and future application
+// data.
+func MinRootDiskSizeGiB(ser string) uint64 {
+	// See comment below that explains why we're ignoring the error
+	os, _ := series.GetOSFromSeries(ser)
+	switch os {
+	case jujuos.Ubuntu, jujuos.CentOS:
+		return 8
+	case jujuos.Windows:
+		return 40
+	// On default we just return a "sane" default, since the error will just
+	// be returned by the api and seen in juju status
+	default:
+		return 8
+	}
+}
 
 // MiBToGiB converts the provided megabytes (base-2) into the nearest
 // gigabytes (base-2), rounding up. This is useful for providers that

--- a/provider/common/disk_test.go
+++ b/provider/common/disk_test.go
@@ -1,0 +1,30 @@
+// Copyright 2013 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package common_test
+
+import (
+	"github.com/juju/juju/provider/common"
+	gc "gopkg.in/check.v1"
+)
+
+type DiskSuite struct{}
+
+var _ = gc.Suite(&DiskSuite{})
+
+var diskTests = []struct {
+	series       string
+	expectedSize uint64
+}{
+	{"trusty", 8},
+	{"win2012r2", 40},
+	{"centos7", 8},
+	{"arch", 8},
+}
+
+func (s *DiskSuite) TestMinRootDiskSizeGiB(c *gc.C) {
+	for _, t := range diskTests {
+		actualSize := common.MinRootDiskSizeGiB(t.series)
+		c.Assert(t.expectedSize, gc.Equals, actualSize)
+	}
+}

--- a/provider/common/disk_test.go
+++ b/provider/common/disk_test.go
@@ -12,17 +12,16 @@ type DiskSuite struct{}
 
 var _ = gc.Suite(&DiskSuite{})
 
-var diskTests = []struct {
-	series       string
-	expectedSize uint64
-}{
-	{"trusty", 8},
-	{"win2012r2", 40},
-	{"centos7", 8},
-	{"arch", 8},
-}
-
 func (s *DiskSuite) TestMinRootDiskSizeGiB(c *gc.C) {
+	var diskTests = []struct {
+		series       string
+		expectedSize uint64
+	}{
+		{"trusty", 8},
+		{"win2012r2", 40},
+		{"centos7", 8},
+		{"fake-series", 8},
+	}
 	for _, t := range diskTests {
 		actualSize := common.MinRootDiskSizeGiB(t.series)
 		c.Assert(t.expectedSize, gc.Equals, actualSize)

--- a/provider/ec2/ebs_test.go
+++ b/provider/ec2/ebs_test.go
@@ -669,8 +669,7 @@ func (*blockDeviceMappingSuite) TestBlockDeviceNamer(c *gc.C) {
 }
 
 func (*blockDeviceMappingSuite) TestGetBlockDeviceMappings(c *gc.C) {
-	mapping, err := ec2.GetBlockDeviceMappings(constraints.Value{})
-	c.Assert(err, jc.ErrorIsNil)
+	mapping := ec2.GetBlockDeviceMappings(constraints.Value{}, "trusty")
 	c.Assert(mapping, gc.DeepEquals, []awsec2.BlockDeviceMapping{{
 		VolumeSize: 8,
 		DeviceName: "/dev/sda1",

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -523,10 +523,9 @@ func (e *environ) StartInstance(args environs.StartInstanceParams) (_ *environs.
 		return nil, err
 	}
 
-	series := args.Tools.OneSeries()
 	spec, err := findInstanceSpec(sources, e.Config().ImageStream(), &instances.InstanceConstraint{
 		Region:      e.ecfg().region(),
-		Series:      series,
+		Series:      args.InstanceConfig.Series,
 		Arches:      arches,
 		Constraints: args.Constraints,
 		Storage:     []string{ssdStorage, ebsStorage},
@@ -556,10 +555,7 @@ func (e *environ) StartInstance(args environs.StartInstanceParams) (_ *environs.
 	}
 	var instResp *ec2.RunInstancesResp
 
-	blockDeviceMappings, err := getBlockDeviceMappings(args.Constraints)
-	if err != nil {
-		return nil, errors.Annotate(err, "cannot create block device mappings")
-	}
+	blockDeviceMappings := getBlockDeviceMappings(args.Constraints, args.InstanceConfig.Series)
 	rootDiskSize := uint64(blockDeviceMappings[0].VolumeSize) * 1024
 
 	for _, availZone := range availabilityZones {

--- a/provider/ec2/environ_test.go
+++ b/provider/ec2/environ_test.go
@@ -36,58 +36,49 @@ var commonInstanceStoreDisks = []amzec2.BlockDeviceMapping{{
 	VirtualName: "ephemeral3",
 }}
 
-var rootDiskTests = []RootDiskTest{
-	{
+func (*Suite) TestRootDiskBlockDeviceMapping(c *gc.C) {
+	var rootDiskTests = []RootDiskTest{{
 		"trusty",
 		"nil constraint ubuntu",
 		nil,
 		amzec2.BlockDeviceMapping{VolumeSize: 8, DeviceName: "/dev/sda1"},
-	},
-	{
+	}, {
 		"trusty",
 		"too small constraint ubuntu",
 		pInt(4000),
 		amzec2.BlockDeviceMapping{VolumeSize: 8, DeviceName: "/dev/sda1"},
-	},
-	{
+	}, {
 		"trusty",
 		"big constraint ubuntu",
 		pInt(20 * 1024),
 		amzec2.BlockDeviceMapping{VolumeSize: 20, DeviceName: "/dev/sda1"},
-	},
-	{
+	}, {
 		"trusty",
 		"round up constraint ubuntu",
 		pInt(20*1024 + 1),
 		amzec2.BlockDeviceMapping{VolumeSize: 21, DeviceName: "/dev/sda1"},
-	},
-	{
+	}, {
 		"win2012r2",
 		"nil constraint windows",
 		nil,
 		amzec2.BlockDeviceMapping{VolumeSize: 40, DeviceName: "/dev/sda1"},
-	},
-	{
+	}, {
 		"win2012r2",
 		"too small constraint windows",
 		pInt(30 * 1024),
 		amzec2.BlockDeviceMapping{VolumeSize: 40, DeviceName: "/dev/sda1"},
-	},
-	{
+	}, {
 		"win2012r2",
 		"big constraint windows",
 		pInt(50 * 1024),
 		amzec2.BlockDeviceMapping{VolumeSize: 50, DeviceName: "/dev/sda1"},
-	},
-	{
+	}, {
 		"win2012r2",
 		"round up constraint windows",
 		pInt(50*1024 + 1),
 		amzec2.BlockDeviceMapping{VolumeSize: 51, DeviceName: "/dev/sda1"},
-	},
-}
+	}}
 
-func (*Suite) TestRootDiskBlockDeviceMapping(c *gc.C) {
 	for _, t := range rootDiskTests {
 		c.Logf("Test %s", t.name)
 		cons := constraints.Value{RootDisk: t.constraint}

--- a/provider/ec2/environ_test.go
+++ b/provider/ec2/environ_test.go
@@ -4,7 +4,6 @@
 package ec2
 
 import (
-	jc "github.com/juju/testing/checkers"
 	amzec2 "gopkg.in/amz.v3/ec2"
 	gc "gopkg.in/check.v1"
 
@@ -17,9 +16,9 @@ type Suite struct{}
 var _ = gc.Suite(&Suite{})
 
 type RootDiskTest struct {
+	series     string
 	name       string
 	constraint *uint64
-	disksize   uint64
 	device     amzec2.BlockDeviceMapping
 }
 
@@ -39,28 +38,52 @@ var commonInstanceStoreDisks = []amzec2.BlockDeviceMapping{{
 
 var rootDiskTests = []RootDiskTest{
 	{
-		"nil constraint",
+		"trusty",
+		"nil constraint ubuntu",
 		nil,
-		8192,
 		amzec2.BlockDeviceMapping{VolumeSize: 8, DeviceName: "/dev/sda1"},
 	},
 	{
-		"too small constraint",
+		"trusty",
+		"too small constraint ubuntu",
 		pInt(4000),
-		8192,
 		amzec2.BlockDeviceMapping{VolumeSize: 8, DeviceName: "/dev/sda1"},
 	},
 	{
-		"big constraint",
+		"trusty",
+		"big constraint ubuntu",
 		pInt(20 * 1024),
-		20 * 1024,
 		amzec2.BlockDeviceMapping{VolumeSize: 20, DeviceName: "/dev/sda1"},
 	},
 	{
-		"round up constraint",
+		"trusty",
+		"round up constraint ubuntu",
 		pInt(20*1024 + 1),
-		21 * 1024,
 		amzec2.BlockDeviceMapping{VolumeSize: 21, DeviceName: "/dev/sda1"},
+	},
+	{
+		"win2012r2",
+		"nil constraint windows",
+		nil,
+		amzec2.BlockDeviceMapping{VolumeSize: 40, DeviceName: "/dev/sda1"},
+	},
+	{
+		"win2012r2",
+		"too small constraint windows",
+		pInt(30 * 1024),
+		amzec2.BlockDeviceMapping{VolumeSize: 40, DeviceName: "/dev/sda1"},
+	},
+	{
+		"win2012r2",
+		"big constraint windows",
+		pInt(50 * 1024),
+		amzec2.BlockDeviceMapping{VolumeSize: 50, DeviceName: "/dev/sda1"},
+	},
+	{
+		"win2012r2",
+		"round up constraint windows",
+		pInt(50*1024 + 1),
+		amzec2.BlockDeviceMapping{VolumeSize: 51, DeviceName: "/dev/sda1"},
 	},
 }
 
@@ -68,8 +91,7 @@ func (*Suite) TestRootDiskBlockDeviceMapping(c *gc.C) {
 	for _, t := range rootDiskTests {
 		c.Logf("Test %s", t.name)
 		cons := constraints.Value{RootDisk: t.constraint}
-		mappings, err := getBlockDeviceMappings(cons)
-		c.Assert(err, jc.ErrorIsNil)
+		mappings := getBlockDeviceMappings(cons, t.series)
 		expected := append([]amzec2.BlockDeviceMapping{t.device}, commonInstanceStoreDisks...)
 		c.Assert(mappings, gc.DeepEquals, expected)
 	}

--- a/provider/gce/google/conn_disks_test.go
+++ b/provider/gce/google/conn_disks_test.go
@@ -4,7 +4,6 @@
 package google_test
 
 import (
-	//"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	"google.golang.org/api/compute/v1"
 	gc "gopkg.in/check.v1"
@@ -16,6 +15,7 @@ const fakeVolName = "home-zone--c930380d-8337-4bf5-b07a-9dbb5ae771e4"
 
 func fakeDiskAndSpec() (google.DiskSpec, *compute.Disk, error) {
 	spec := google.DiskSpec{
+		Series:             "trusty",
 		SizeHintGB:         1,
 		Name:               fakeVolName,
 		PersistentDiskType: google.DiskPersistentSSD,

--- a/provider/gce/google/disk.go
+++ b/provider/gce/google/disk.go
@@ -5,6 +5,8 @@ package google
 
 import (
 	"github.com/juju/errors"
+	jujuos "github.com/juju/utils/os"
+	"github.com/juju/utils/series"
 	"google.golang.org/api/compute/v1"
 )
 
@@ -46,11 +48,24 @@ const (
 // GCE disks.
 //
 // Note: GCE does not currently have an official minimum disk size.
-// However, in testing we found the minimum size to be 10 GB due to
-// the image size. See gceapi messsage.
+// However, in testing we found the minimum size to be 10 GB for ubuntu
+// and 50 GB for windows due to the image size. See gceapi message.
 //
 // gceapi: Requested disk size cannot be smaller than the image size (10 GB)
-const MinDiskSizeGB uint64 = 10
+func MinDiskSizeGB(ser string) uint64 {
+	// See comment below that explains why we're ignoring the error
+	os, _ := series.GetOSFromSeries(ser)
+	switch os {
+	case jujuos.Ubuntu:
+		return 10
+	case jujuos.Windows:
+		return 50
+	// On default we just return a "sane" default since the error
+	// will be propagated through the api and appear in juju status anyway
+	default:
+		return 10
+	}
+}
 
 // gibToMib converts gibibytes to mebibytes.
 func gibToMib(g int64) uint64 {
@@ -61,6 +76,8 @@ func gibToMib(g int64) uint64 {
 // Some fields are used only for attached disks (i.e. in association
 // with instances).
 type DiskSpec struct {
+	// series is the OS series on which the disk size depends
+	Series string
 	// SizeHintGB is the requested disk size in Gigabytes. It must be
 	// greater than 0.
 	SizeHintGB uint64
@@ -94,7 +111,7 @@ type DiskSpec struct {
 // TooSmall checks the spec's size hint and indicates whether or not
 // it is smaller than the minimum disk size.
 func (ds *DiskSpec) TooSmall() bool {
-	return ds.SizeHintGB < MinDiskSizeGB
+	return ds.SizeHintGB < MinDiskSizeGB(ds.Series)
 }
 
 // SizeGB returns the disk size to use for a new disk. The size hint
@@ -103,7 +120,7 @@ func (ds *DiskSpec) TooSmall() bool {
 func (ds *DiskSpec) SizeGB() uint64 {
 	size := ds.SizeHintGB
 	if ds.TooSmall() {
-		size = MinDiskSizeGB
+		size = MinDiskSizeGB(ds.Series)
 	}
 	return size
 }

--- a/provider/gce/google/disk.go
+++ b/provider/gce/google/disk.go
@@ -76,7 +76,7 @@ func gibToMib(g int64) uint64 {
 // Some fields are used only for attached disks (i.e. in association
 // with instances).
 type DiskSpec struct {
-	// series is the OS series on which the disk size depends
+	// Series is the OS series on which the disk size depends
 	Series string
 	// SizeHintGB is the requested disk size in Gigabytes. It must be
 	// greater than 0.

--- a/provider/gce/google/disk_test.go
+++ b/provider/gce/google/disk_test.go
@@ -36,8 +36,24 @@ func (s *diskSuite) TestDiskSpecSizeGB(c *gc.C) {
 	c.Check(size, gc.Equals, uint64(15))
 }
 
-func (s *diskSuite) TestDiskSpecSizeGBMin(c *gc.C) {
+func (s *diskSuite) TestDiskSpecSizeGBMinUbuntu(c *gc.C) {
 	s.DiskSpec.SizeHintGB = 0
+	size := s.DiskSpec.SizeGB()
+
+	c.Check(size, gc.Equals, uint64(10))
+}
+
+func (s *diskSuite) TestDiskSpecSizeGBMinWindows(c *gc.C) {
+	s.DiskSpec.SizeHintGB = 0
+	s.DiskSpec.Series = "win2012r2"
+	size := s.DiskSpec.SizeGB()
+
+	c.Check(size, gc.Equals, uint64(50))
+}
+
+func (s *diskSuite) TestDiskSpecSizeGBMinUnknown(c *gc.C) {
+	s.DiskSpec.SizeHintGB = 0
+	s.DiskSpec.Series = "arch"
 	size := s.DiskSpec.SizeGB()
 
 	c.Check(size, gc.Equals, uint64(10))

--- a/provider/gce/google/testing_test.go
+++ b/provider/gce/google/testing_test.go
@@ -63,6 +63,7 @@ func (s *BaseSuite) SetUpTest(c *gc.C) {
 	s.FakeConn = fake
 
 	s.DiskSpec = DiskSpec{
+		Series:     "trusty",
 		SizeHintGB: 15,
 		ImageURL:   "some/image/path",
 		Boot:       true,

--- a/provider/gce/testing_test.go
+++ b/provider/gce/testing_test.go
@@ -212,6 +212,7 @@ func (s *BaseSuiteUnpatched) UpdateConfig(c *gc.C, attrs map[string]interface{})
 
 func (s *BaseSuiteUnpatched) NewBaseInstance(c *gc.C, id string) *google.Instance {
 	diskSpec := google.DiskSpec{
+		Series:     "trusty",
 		SizeHintGB: 15,
 		ImageURL:   "some/image/path",
 		Boot:       true,

--- a/provider/vsphere/environ_broker.go
+++ b/provider/vsphere/environ_broker.go
@@ -98,7 +98,7 @@ func (env *environ) newRawInstance(args environs.StartInstanceParams, img *OvaFi
 	}
 	logger.Debugf("Vmware user data; %d bytes", len(userData))
 
-	rootDisk := common.MinRootDiskSizeGiB * 1024
+	rootDisk := common.MinRootDiskSizeGiB(args.InstanceConfig.Series) * 1024
 	if args.Constraints.RootDisk != nil && *args.Constraints.RootDisk > rootDisk {
 		rootDisk = *args.Constraints.RootDisk
 	}

--- a/provider/vsphere/environ_broker_test.go
+++ b/provider/vsphere/environ_broker_test.go
@@ -126,7 +126,7 @@ func (s *environBrokerSuite) TestStartInstanceDefaultConstraintsApplied(c *gc.C)
 	c.Assert(*res.Hardware.CpuCores, gc.Equals, vsphere.DefaultCpuCores)
 	c.Assert(*res.Hardware.CpuPower, gc.Equals, vsphere.DefaultCpuPower)
 	c.Assert(*res.Hardware.Mem, gc.Equals, vsphere.DefaultMemMb)
-	c.Assert(*res.Hardware.RootDisk, gc.Equals, common.MinRootDiskSizeGiB*1024)
+	c.Assert(*res.Hardware.RootDisk, gc.Equals, common.MinRootDiskSizeGiB("trusty")*uint64(1024))
 }
 
 func (s *environBrokerSuite) TestStartInstanceCustomConstraintsApplied(c *gc.C) {
@@ -167,7 +167,7 @@ func (s *environBrokerSuite) TestStartInstanceDefaultDiskSizeIsUsedForSmallConst
 	startInstArgs.Constraints.RootDisk = &rootDisk
 	res, err := s.Env.StartInstance(startInstArgs)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(*res.Hardware.RootDisk, gc.Equals, common.MinRootDiskSizeGiB*1024)
+	c.Assert(*res.Hardware.RootDisk, gc.Equals, common.MinRootDiskSizeGiB("trusty")*uint64(1024))
 }
 
 func (s *environBrokerSuite) TestStartInstanceInvalidPlacement(c *gc.C) {


### PR DESCRIPTION
So when the gce provider was implemented, we've got some new functionality in common such as minRootDiskSize, which wasn't yet used in the rest.

This PR mainly implements minRootDiskSize for windows, but also makes ec2 use the common code.

The only "sketchy" part of the pr is returning a default value, which is explained in the comments and was mostly done to try to not propagate errors everywhere, since it turns out most of the functions using the old constants do not return errors and it becomes really tedious after a while, all while being not that necessary.

A next PR should follow up that will test all unknown OS's in the provider functions instead of just one.

Also, this depends on series and not on OS, since windows nano will probably come up soon and we will need to have size-based constraints for that.

(Review request: http://reviews.vapour.ws/r/2824/)