### PR TITLE
Added NewWorkerPaths constructor

### DIFF
--- a/worker/metrics/collect/manifold.go
+++ b/worker/metrics/collect/manifold.go
@@ -8,8 +8,6 @@
 package collect
 
 import (
-	"fmt"
-	"path/filepath"
 	"time"
 
 	"github.com/juju/errors"
@@ -19,16 +17,15 @@ import (
 	"gopkg.in/juju/charm.v6-unstable/hooks"
 
 	"github.com/juju/juju/agent"
-	"github.com/juju/juju/agent/tools"
 	"github.com/juju/juju/api/base"
 	uniterapi "github.com/juju/juju/api/uniter"
 	"github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/charmdir"
 	"github.com/juju/juju/worker/dependency"
 	"github.com/juju/juju/worker/metrics/spool"
+	"github.com/juju/juju/worker/uniter"
 	"github.com/juju/juju/worker/uniter/runner"
 	"github.com/juju/juju/worker/uniter/runner/context"
-	"github.com/juju/utils/os"
 )
 
 const defaultPeriod = 5 * time.Minute
@@ -170,34 +167,6 @@ func (w *collect) Do(stop <-chan struct{}) error {
 	return err
 }
 
-type collectPaths struct {
-	dataDir string
-	unitTag names.UnitTag
-}
-
-func (p *collectPaths) GetToolsDir() string {
-	return filepath.FromSlash(tools.ToolsDir(p.dataDir, p.unitTag.String()))
-}
-
-func (p *collectPaths) GetCharmDir() string {
-	return filepath.Join(p.baseDir(), "charm")
-}
-
-func (p *collectPaths) GetJujucSocket() string {
-	if os.HostOS() == os.Windows {
-		return fmt.Sprintf(`\\.\pipe\%s-metrics`, p.unitTag)
-	}
-	return filepath.Join(p.baseDir(), "metrics.socket@")
-}
-
-func (p *collectPaths) GetMetricsSpoolDir() string {
-	return ""
-}
-
-func (p *collectPaths) baseDir() string {
-	return filepath.Join(p.dataDir, "agents", p.unitTag.String())
-}
-
 func (w *collect) do() error {
 	logger.Tracef("recording metrics")
 
@@ -207,7 +176,7 @@ func (w *collect) do() error {
 	if !ok {
 		return errors.Errorf("expected a unit tag, got %v", tag)
 	}
-	paths := &collectPaths{dataDir: config.DataDir(), unitTag: unitTag}
+	paths := uniter.NewWorkerPaths(config.DataDir(), unitTag, "metrics-collect")
 
 	recorder, err := newRecorder(unitTag, paths, w.unitCharmLookup, w.metricFactory)
 	if errors.Cause(err) == errMetricsNotDefined {

--- a/worker/uniter/paths_test.go
+++ b/worker/uniter/paths_test.go
@@ -55,6 +55,34 @@ func (s *PathsSuite) TestWindows(c *gc.C) {
 	})
 }
 
+func (s *PathsSuite) TestWorkerPathsWindows(c *gc.C) {
+	s.PatchValue(&os.HostOS, func() os.OSType { return os.Windows })
+
+	dataDir := c.MkDir()
+	unitTag := names.NewUnitTag("some-service/323")
+	worker := "some-worker"
+	paths := uniter.NewWorkerPaths(dataDir, unitTag, worker)
+
+	relData := relPathFunc(dataDir)
+	relAgent := relPathFunc(relData("agents", "unit-some-service-323"))
+	c.Assert(paths, jc.DeepEquals, uniter.Paths{
+		ToolsDir: relData("tools/unit-some-service-323"),
+		Runtime: uniter.RuntimePaths{
+			JujuRunSocket:     `\\.\pipe\unit-some-service-323-some-worker-run`,
+			JujucServerSocket: `\\.\pipe\unit-some-service-323-some-worker-agent`,
+		},
+		State: uniter.StatePaths{
+			CharmDir:        relAgent("charm"),
+			OperationsFile:  relAgent("state", "uniter"),
+			RelationsDir:    relAgent("state", "relations"),
+			BundlesDir:      relAgent("state", "bundles"),
+			DeployerDir:     relAgent("state", "deployer"),
+			StorageDir:      relAgent("state", "storage"),
+			MetricsSpoolDir: relAgent("state", "spool", "metrics"),
+		},
+	})
+}
+
 func (s *PathsSuite) TestOther(c *gc.C) {
 	s.PatchValue(&os.HostOS, func() os.OSType { return os.Unknown })
 
@@ -69,6 +97,34 @@ func (s *PathsSuite) TestOther(c *gc.C) {
 		Runtime: uniter.RuntimePaths{
 			JujuRunSocket:     relAgent("run.socket"),
 			JujucServerSocket: "@" + relAgent("agent.socket"),
+		},
+		State: uniter.StatePaths{
+			CharmDir:        relAgent("charm"),
+			OperationsFile:  relAgent("state", "uniter"),
+			RelationsDir:    relAgent("state", "relations"),
+			BundlesDir:      relAgent("state", "bundles"),
+			DeployerDir:     relAgent("state", "deployer"),
+			StorageDir:      relAgent("state", "storage"),
+			MetricsSpoolDir: relAgent("state", "spool", "metrics"),
+		},
+	})
+}
+
+func (s *PathsSuite) TestWorkerPaths(c *gc.C) {
+	s.PatchValue(&os.HostOS, func() os.OSType { return os.Unknown })
+
+	dataDir := c.MkDir()
+	unitTag := names.NewUnitTag("some-service/323")
+	worker := "worker-id"
+	paths := uniter.NewWorkerPaths(dataDir, unitTag, worker)
+
+	relData := relPathFunc(dataDir)
+	relAgent := relPathFunc(relData("agents", "unit-some-service-323"))
+	c.Assert(paths, jc.DeepEquals, uniter.Paths{
+		ToolsDir: relData("tools/unit-some-service-323"),
+		Runtime: uniter.RuntimePaths{
+			JujuRunSocket:     relAgent(worker + "-run.socket"),
+			JujucServerSocket: "@" + relAgent(worker+"-agent.socket"),
 		},
 		State: uniter.StatePaths{
 			CharmDir:        relAgent("charm"),


### PR DESCRIPTION
Added NewWorkerPaths constructor that creates paths with worker-specific socket locations.

(Review request: http://reviews.vapour.ws/r/2826/)