### PR TITLE
api: consolidate client websocket implementation

### DIFF
--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -4,10 +4,13 @@
 package api
 
 import (
+	"bufio"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/json"
+	"fmt"
 	"io"
-	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -19,6 +22,7 @@ import (
 	"golang.org/x/net/websocket"
 	"gopkg.in/macaroon-bakery.v1/httpbakery"
 
+	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/rpc"
@@ -32,7 +36,8 @@ var logger = loggo.GetLogger("juju.api")
 // will run. It's a variable so it can be changed in tests.
 var PingPeriod = 1 * time.Minute
 
-type State struct {
+// state is the internal implementation of the Connection interface.
+type state struct {
 	client *rpc.Conn
 	conn   *websocket.Conn
 
@@ -70,9 +75,10 @@ type State struct {
 	// closed is a channel that gets closed when State.Close is called.
 	closed chan struct{}
 
-	// tag and password hold the cached login credentials.
+	// tag and password and nonce hold the cached login credentials.
 	tag      string
 	password string
+	nonce    string
 
 	// serverRootAddress holds the cached API server address and port used
 	// to login.
@@ -96,19 +102,19 @@ type State struct {
 //
 // See Connect for details of the connection mechanics.
 func Open(info *Info, opts DialOpts) (Connection, error) {
-	return open(info, opts, (*State).Login)
+	return open(info, opts, (*state).Login)
 }
 
 // This unexported open method is used both directly above in the Open
 // function, and also the OpenWithVersion function below to explicitly cause
 // the API server to think that the client is older than it really is.
-func open(info *Info, opts DialOpts, loginFunc func(st *State, tag names.Tag, pwd, nonce string) error) (Connection, error) {
+func open(info *Info, opts DialOpts, loginFunc func(st *state, tag names.Tag, pwd, nonce string) error) (Connection, error) {
 	if info.UseMacaroons {
 		if info.Tag != nil || info.Password != "" {
 			return nil, errors.New("open should specifiy UseMacaroons or a username & password. Not both")
 		}
 	}
-	conn, err := Connect(info, "", nil, opts)
+	conn, err := connectWebsocket(info, opts)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -120,7 +126,7 @@ func open(info *Info, opts DialOpts, loginFunc func(st *State, tag names.Tag, pw
 
 	client := rpc.NewConn(jsoncodec.NewWebsocket(conn), nil)
 	client.Start()
-	st := &State{
+	st := &state{
 		client:            client,
 		conn:              conn,
 		addr:              conn.Config().Location.Host,
@@ -130,6 +136,7 @@ func open(info *Info, opts DialOpts, loginFunc func(st *State, tag names.Tag, pw
 		// state structure BEFORE login ?!?
 		tag:          tagToString(info.Tag),
 		password:     info.Password,
+		nonce:        info.Nonce,
 		certPool:     conn.Config().TlsConfig.RootCAs,
 		bakeryClient: bakeryClient,
 	}
@@ -149,47 +156,43 @@ func open(info *Info, opts DialOpts, loginFunc func(st *State, tag names.Tag, pw
 // on. This allows the caller to pretend to be an older client, and is used
 // only in testing.
 func OpenWithVersion(info *Info, opts DialOpts, loginVersion int) (Connection, error) {
-	var loginFunc func(st *State, tag names.Tag, pwd, nonce string) error
+	var loginFunc func(st *state, tag names.Tag, pwd, nonce string) error
 	switch loginVersion {
 	case 0:
-		loginFunc = (*State).loginV0
+		loginFunc = (*state).loginV0
 	case 1:
-		loginFunc = (*State).loginV1
+		loginFunc = (*state).loginV1
 	case 2:
-		loginFunc = (*State).loginV2
+		loginFunc = (*state).loginV2
 	default:
 		return nil, errors.NotSupportedf("loginVersion %d", loginVersion)
 	}
 	return open(info, opts, loginFunc)
 }
 
-// Connect establishes a websocket connection to the API server using
-// the Info, API path tail and (optional) request headers provided. If
-// multiple API addresses are provided in Info they will be tried
-// concurrently - the first successful connection wins.
-//
-// The path tail may be blank, in which case the default value will be
-// used. Otherwise, it must start with a "/".
-func Connect(info *Info, pathTail string, header http.Header, opts DialOpts) (*websocket.Conn, error) {
+// connectWebsocket establishes a websocket connection to the RPC
+// API websocket on the API server using Info. If multiple API addresses
+// are provided in Info they will be tried concurrently - the first successful
+// connection wins.
+func connectWebsocket(info *Info, opts DialOpts) (*websocket.Conn, error) {
 	if len(info.Addrs) == 0 {
 		return nil, errors.New("no API addresses to connect to")
 	}
-	if pathTail != "" && !strings.HasPrefix(pathTail, "/") {
-		return nil, errors.New(`path tail must start with "/"`)
-	}
-
 	pool, err := CreateCertPool(info.CACert)
 	if err != nil {
 		return nil, errors.Annotate(err, "cert pool creation failed")
 	}
 
-	path := makeAPIPath(info.EnvironTag.Id(), pathTail)
+	path := "/"
+	if info.EnvironTag.Id() != "" {
+		path = apiPath(info.EnvironTag, "/api")
+	}
 
 	// Dial all addresses at reasonable intervals.
 	try := parallel.NewTry(0, nil)
 	defer try.Kill()
 	for _, addr := range info.Addrs {
-		err := dialWebsocket(addr, path, header, opts, pool, try)
+		err := dialWebsocket(addr, path, opts, pool, try)
 		if err == parallel.ErrStopped {
 			break
 		}
@@ -211,19 +214,105 @@ func Connect(info *Info, pathTail string, header http.Header, opts DialOpts) (*w
 	return conn, nil
 }
 
-// makeAPIPath builds the path to connect to based on the tail given
-// and whether the environment UUID is set.
-func makeAPIPath(envUUID, tail string) string {
-	if envUUID == "" {
-		if tail == "" {
-			tail = "/"
+// ConnectStream implements Connection.ConnectStream.
+func (st *state) ConnectStream(path string, attrs url.Values) (base.Stream, error) {
+	if !strings.HasPrefix(path, "/") {
+		return nil, errors.New(`path must start with "/"`)
+	}
+	if _, ok := st.ServerVersion(); ok {
+		// If the server version is set, then we know the server is capable of
+		// serving streams at the environment path. We also fully expect
+		// that the server has returned a valid environment tag.
+		envTag, err := st.EnvironTag()
+		if err != nil {
+			return nil, errors.Annotate(err, "cannot get environment tag, perhaps connected to system not environment")
 		}
-		return tail
+		path = apiPath(envTag, path)
 	}
-	if tail == "" {
-		tail = "/api"
+	target := url.URL{
+		Scheme:   "wss",
+		Host:     st.addr,
+		Path:     path,
+		RawQuery: attrs.Encode(),
 	}
-	return "/environment/" + envUUID + tail
+	cfg, err := websocket.NewConfig(target.String(), "http://localhost/")
+	cfg.Header = utils.BasicAuthHeader(st.tag, st.password)
+	if st.nonce != "" {
+		cfg.Header.Set(params.MachineNonceHeader, st.nonce)
+	}
+	cfg.TlsConfig = &tls.Config{
+		RootCAs:    st.certPool,
+		ServerName: "juju-apiserver",
+	}
+	connection, err := websocketDialConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+	if err := readInitialStreamError(connection); err != nil {
+		return nil, errors.Trace(err)
+	}
+	return connection, nil
+}
+
+// readInitialStreamError reads the initial error response
+// from a stream connection and returns it.
+func readInitialStreamError(conn io.Reader) error {
+	// We can use bufio here because the websocket guarantees that a
+	// single read will not read more than a single frame; there is
+	// no guarantee that a single read might not read less than the
+	// whole frame though, so using a single Read call is not
+	// correct. By using ReadSlice rather than ReadBytes, we
+	// guarantee that the error can't be too big (>4096 bytes).
+	line, err := bufio.NewReader(conn).ReadSlice('\n')
+	if err != nil {
+		return errors.Annotate(err, "unable to read initial response")
+	}
+	var errResult params.ErrorResult
+	if err := json.Unmarshal(line, &errResult); err != nil {
+		return errors.Annotate(err, "unable to unmarshal initial response")
+	}
+	if errResult.Error != nil {
+		return errResult.Error
+	}
+	return nil
+}
+
+// apiEndpoint returns a URL that refers to the given API slash-prefixed
+// endpoint path and query parameters. Note that the caller
+// is responsible for ensuring that the path *is* prefixed with a slash.
+func (st *state) apiEndpoint(path, query string) (*url.URL, error) {
+	if _, err := st.ServerTag(); err == nil {
+		// The server tag is set, so the agent version is >= 1.23,
+		// so we can use the environment endpoint.
+		envTag, err := st.EnvironTag()
+		if err != nil {
+			return nil, errors.Annotate(err, "cannot get API endpoint address")
+		}
+		path = apiPath(envTag, path)
+	}
+	return &url.URL{
+		Scheme:   st.serverScheme,
+		Host:     st.Addr(),
+		Path:     path,
+		RawQuery: query,
+	}, nil
+}
+
+// apiPath returns the given API endpoint path relative
+// to the given environment tag. The caller is responsible
+// for ensuring that the environment tag is valid and
+// that the path is slash-prefixed.
+func apiPath(envTag names.EnvironTag, path string) string {
+	if !strings.HasPrefix(path, "/") {
+		panic(fmt.Sprintf("apiPath called with non-slash-prefixed path %q", path))
+	}
+	if envTag.Id() == "" {
+		panic("apiPath called with empty environment tag")
+	}
+	if envUUID := envTag.Id(); envUUID != "" {
+		return "/environment/" + envUUID + path
+	}
+	return path
 }
 
 // tagToString returns the value of a tag's String method, or "" if the tag is nil.
@@ -234,15 +323,15 @@ func tagToString(tag names.Tag) string {
 	return tag.String()
 }
 
-func dialWebsocket(addr, path string, header http.Header, opts DialOpts, rootCAs *x509.CertPool, try *parallel.Try) error {
-	cfg, err := setUpWebsocket(addr, path, header, rootCAs)
+func dialWebsocket(addr, path string, opts DialOpts, rootCAs *x509.CertPool, try *parallel.Try) error {
+	cfg, err := setUpWebsocket(addr, path, rootCAs)
 	if err != nil {
 		return err
 	}
 	return try.Start(newWebsocketDialer(cfg, opts))
 }
 
-func setUpWebsocket(addr, path string, header http.Header, rootCAs *x509.CertPool) (*websocket.Config, error) {
+func setUpWebsocket(addr, path string, rootCAs *x509.CertPool) (*websocket.Config, error) {
 	// origin is required by the WebSocket API, used for "origin policy"
 	// in websockets. We pass localhost to satisfy the API; it is
 	// inconsequential to us.
@@ -255,7 +344,6 @@ func setUpWebsocket(addr, path string, header http.Header, rootCAs *x509.CertPoo
 		RootCAs:    rootCAs,
 		ServerName: "juju-apiserver",
 	}
-	cfg.Header = header
 	return cfg, nil
 }
 
@@ -284,14 +372,14 @@ func createWebsocketDialer(cfg *websocket.Config, opts DialOpts) func(<-chan str
 				logger.Debugf("error dialing %q, will retry: %v", cfg.Location, err)
 			} else {
 				logger.Infof("error dialing %q: %v", cfg.Location, err)
-				return nil, errors.Errorf("unable to connect to %q", cfg.Location)
+				return nil, errors.Annotatef(err, "unable to connect to API")
 			}
 		}
 		panic("unreachable")
 	}
 }
 
-func (s *State) heartbeatMonitor() {
+func (s *state) heartbeatMonitor() {
 	for {
 		if err := s.Ping(); err != nil {
 			close(s.broken)
@@ -304,7 +392,7 @@ func (s *State) heartbeatMonitor() {
 	}
 }
 
-func (s *State) Ping() error {
+func (s *state) Ping() error {
 	return s.APICall("Pinger", s.BestFacadeVersion("Pinger"), "", "Ping", nil, nil)
 }
 
@@ -313,7 +401,7 @@ func (s *State) Ping() error {
 // This fills out the rpc.Request on the given facade, version for a given
 // object id, and the specific RPC method. It marshalls the Arguments, and will
 // unmarshall the result into the response object that is supplied.
-func (s *State) APICall(facade string, version int, id, method string, args, response interface{}) error {
+func (s *state) APICall(facade string, version int, id, method string, args, response interface{}) error {
 	err := s.client.Call(rpc.Request{
 		Type:    facade,
 		Version: version,
@@ -323,7 +411,7 @@ func (s *State) APICall(facade string, version int, id, method string, args, res
 	return params.ClientError(err)
 }
 
-func (s *State) Close() error {
+func (s *state) Close() error {
 	err := s.client.Close()
 	select {
 	case <-s.closed:
@@ -335,29 +423,29 @@ func (s *State) Close() error {
 }
 
 // Broken returns a channel that's closed when the connection is broken.
-func (s *State) Broken() <-chan struct{} {
+func (s *state) Broken() <-chan struct{} {
 	return s.broken
 }
 
 // RPCClient returns the RPC client for the state, so that testing
 // functions can tickle parts of the API that the conventional entry
 // points don't reach. This is exported for testing purposes only.
-func (s *State) RPCClient() *rpc.Conn {
+func (s *state) RPCClient() *rpc.Conn {
 	return s.client
 }
 
 // Addr returns the address used to connect to the API server.
-func (s *State) Addr() string {
+func (s *state) Addr() string {
 	return s.addr
 }
 
 // EnvironTag returns the tag of the environment we are connected to.
-func (s *State) EnvironTag() (names.EnvironTag, error) {
+func (s *state) EnvironTag() (names.EnvironTag, error) {
 	return names.ParseEnvironTag(s.environTag)
 }
 
 // ServerTag returns the tag of the server we are connected to.
-func (s *State) ServerTag() (names.EnvironTag, error) {
+func (s *state) ServerTag() (names.EnvironTag, error) {
 	return names.ParseEnvironTag(s.serverTag)
 }
 
@@ -369,7 +457,7 @@ func (s *State) ServerTag() (names.EnvironTag, error) {
 // Juju CLI, all addresses must be attempted, as the CLI may
 // be invoked both within and outside the environment (think
 // private clouds).
-func (s *State) APIHostPorts() [][]network.HostPort {
+func (s *state) APIHostPorts() [][]network.HostPort {
 	// NOTE: We're making a copy of s.hostPorts before returning it,
 	// for safety.
 	hostPorts := make([][]network.HostPort, len(s.hostPorts))
@@ -380,7 +468,7 @@ func (s *State) APIHostPorts() [][]network.HostPort {
 }
 
 // AllFacadeVersions returns what versions we know about for all facades
-func (s *State) AllFacadeVersions() map[string][]int {
+func (s *state) AllFacadeVersions() map[string][]int {
 	facades := make(map[string][]int, len(s.facadeVersions))
 	for name, versions := range s.facadeVersions {
 		facades[name] = append([]int{}, versions...)
@@ -394,12 +482,12 @@ func (s *State) AllFacadeVersions() map[string][]int {
 // TODO(jam) this is the eventual implementation of what version of a given
 // Facade we will want to use. It needs to line up the versions that the server
 // reports to us, with the versions that our client knows how to use.
-func (s *State) BestFacadeVersion(facade string) int {
+func (s *state) BestFacadeVersion(facade string) int {
 	return bestVersion(facadeVersions[facade], s.facadeVersions[facade])
 }
 
 // serverRoot returns the cached API server address and port used
 // to login, prefixed with "<URI scheme>://" (usually https).
-func (s *State) serverRoot() string {
+func (s *state) serverRoot() string {
 	return s.serverScheme + "://" + s.serverRootAddress
 }

--- a/api/apiclient_test.go
+++ b/api/apiclient_test.go
@@ -4,7 +4,6 @@
 package api_test
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -12,7 +11,6 @@ import (
 
 	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/utils"
 	"github.com/juju/utils/parallel"
 	"golang.org/x/net/websocket"
 	gc "gopkg.in/check.v1"
@@ -37,53 +35,24 @@ func (s *apiclientSuite) TestOpenFailsIfUsernameAndUseMacaroon(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "open should specifiy UseMacaroons or a username & password. Not both")
 }
 
-func (s *apiclientSuite) TestConnectToEnv(c *gc.C) {
+func (s *apiclientSuite) TestConnectWebsocketToEnv(c *gc.C) {
 	info := s.APIInfo(c)
-	conn, err := api.Connect(info, "", nil, api.DialOpts{})
+	conn, err := api.ConnectWebsocket(info, api.DialOpts{})
 	c.Assert(err, jc.ErrorIsNil)
 	defer conn.Close()
 	assertConnAddrForEnv(c, conn, info.Addrs[0], s.State.EnvironUUID(), "/api")
 }
 
-func (s *apiclientSuite) TestConnectToEnvWithPathTail(c *gc.C) {
-	info := s.APIInfo(c)
-	conn, err := api.Connect(info, "/log", nil, api.DialOpts{})
-	c.Assert(err, jc.ErrorIsNil)
-	defer conn.Close()
-	assertConnAddrForEnv(c, conn, info.Addrs[0], s.State.EnvironUUID(), "/log")
-}
-
-func (s *apiclientSuite) TestConnectToRoot(c *gc.C) {
+func (s *apiclientSuite) TestConnectWebsocketToRoot(c *gc.C) {
 	info := s.APIInfo(c)
 	info.EnvironTag = names.NewEnvironTag("")
-	conn, err := api.Connect(info, "", nil, api.DialOpts{})
+	conn, err := api.ConnectWebsocket(info, api.DialOpts{})
 	c.Assert(err, jc.ErrorIsNil)
 	defer conn.Close()
 	assertConnAddrForRoot(c, conn, info.Addrs[0])
 }
 
-func (s *apiclientSuite) TestConnectWithHeader(c *gc.C) {
-	var seenCfg *websocket.Config
-	fakeNewDialer := func(cfg *websocket.Config, _ api.DialOpts) func(<-chan struct{}) (io.Closer, error) {
-		seenCfg = cfg
-		return func(<-chan struct{}) (io.Closer, error) {
-			return nil, errors.New("fake")
-		}
-	}
-	s.PatchValue(api.NewWebsocketDialerPtr, fakeNewDialer)
-
-	header := utils.BasicAuthHeader("foo", "bar")
-	api.Connect(s.APIInfo(c), "", header, api.DialOpts{}) // Return values not important here
-	c.Assert(seenCfg, gc.NotNil)
-	c.Assert(seenCfg.Header, gc.DeepEquals, header)
-}
-
-func (s *apiclientSuite) TestConnectRequiresTailStartsWithSlash(c *gc.C) {
-	_, err := api.Connect(s.APIInfo(c), "foo", nil, api.DialOpts{})
-	c.Assert(err, gc.ErrorMatches, `path tail must start with "/"`)
-}
-
-func (s *apiclientSuite) TestConnectPrefersLocalhostIfPresent(c *gc.C) {
+func (s *apiclientSuite) TestConnectWebsocketPrefersLocalhostIfPresent(c *gc.C) {
 	// Create a socket that proxies to the API server though our localhost address.
 	info := s.APIInfo(c)
 	serverAddr := info.Addrs[0]
@@ -114,13 +83,13 @@ func (s *apiclientSuite) TestConnectPrefersLocalhostIfPresent(c *gc.C) {
 	c.Check(err, jc.ErrorIsNil)
 	expectedHostPort := fmt.Sprintf("localhost:%d", portNum)
 	info.Addrs = []string{"fakeAddress:1", "fakeAddress:1", expectedHostPort}
-	conn, err := api.Connect(info, "/api", nil, api.DialOpts{})
+	conn, err := api.ConnectWebsocket(info, api.DialOpts{})
 	c.Assert(err, jc.ErrorIsNil)
 	defer conn.Close()
 	assertConnAddrForEnv(c, conn, expectedHostPort, s.State.EnvironUUID(), "/api")
 }
 
-func (s *apiclientSuite) TestConnectMultiple(c *gc.C) {
+func (s *apiclientSuite) TestConnectWebsocketMultiple(c *gc.C) {
 	// Create a socket that proxies to the API server.
 	info := s.APIInfo(c)
 	serverAddr := info.Addrs[0]
@@ -144,7 +113,7 @@ func (s *apiclientSuite) TestConnectMultiple(c *gc.C) {
 	// Check that we can use the proxy to connect.
 	proxyAddr := listener.Addr().String()
 	info.Addrs = []string{proxyAddr}
-	conn, err := api.Connect(info, "/api", nil, api.DialOpts{})
+	conn, err := api.ConnectWebsocket(info, api.DialOpts{})
 	c.Assert(err, jc.ErrorIsNil)
 	conn.Close()
 	assertConnAddrForEnv(c, conn, proxyAddr, s.State.EnvironUUID(), "/api")
@@ -153,13 +122,13 @@ func (s *apiclientSuite) TestConnectMultiple(c *gc.C) {
 	// is successfully connected to.
 	info.Addrs = []string{proxyAddr, serverAddr}
 	listener.Close()
-	conn, err = api.Connect(info, "/api", nil, api.DialOpts{})
+	conn, err = api.ConnectWebsocket(info, api.DialOpts{})
 	c.Assert(err, jc.ErrorIsNil)
 	conn.Close()
 	assertConnAddrForEnv(c, conn, serverAddr, s.State.EnvironUUID(), "/api")
 }
 
-func (s *apiclientSuite) TestConnectMultipleError(c *gc.C) {
+func (s *apiclientSuite) TestConnectWebsocketMultipleError(c *gc.C) {
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	c.Assert(err, jc.ErrorIsNil)
 	defer listener.Close()
@@ -175,8 +144,8 @@ func (s *apiclientSuite) TestConnectMultipleError(c *gc.C) {
 	info := s.APIInfo(c)
 	addr := listener.Addr().String()
 	info.Addrs = []string{addr, addr, addr}
-	_, err = api.Connect(info, "/api", nil, api.DialOpts{})
-	c.Assert(err, gc.ErrorMatches, `unable to connect to "wss://.*/environment/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}/api"`)
+	_, err = api.ConnectWebsocket(info, api.DialOpts{})
+	c.Assert(err, gc.ErrorMatches, `unable to connect to API: websocket.Dial wss://.*/environment/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}/api: .*`)
 }
 
 func (s *apiclientSuite) TestOpen(c *gc.C) {

--- a/api/base/caller.go
+++ b/api/base/caller.go
@@ -4,6 +4,9 @@
 package base
 
 import (
+	"io"
+	"net/url"
+
 	"github.com/juju/names"
 )
 
@@ -21,6 +24,34 @@ type APICaller interface {
 	// EnvironTag returns the tag of the environment the client is
 	// connected to.
 	EnvironTag() (names.EnvironTag, error)
+
+	StreamConnector
+}
+
+// StreamConnector is implemented by the client-facing State object.
+type StreamConnector interface {
+	// ConnectStream connects to the given HTTP websocket
+	// endpoint path (interpreted relative to the receiver's
+	// environment) and returns the resulting connection.
+	// The given parameters are used as URL query values
+	// when making the initial HTTP request.
+	//
+	// The path must start with a "/".
+	ConnectStream(path string, attrs url.Values) (Stream, error)
+}
+
+// Stream represents a streaming connection to the API.
+type Stream interface {
+	io.ReadWriteCloser
+
+	// WriteJSON encodes the given value as JSON
+	// and writes it to the connection.
+	WriteJSON(v interface{}) error
+
+	// ReadJSON reads a JSON value from the stream
+	// and decodes it into the element pointed to by
+	// the given value, which should be a pointer.
+	ReadJSON(v interface{}) error
 }
 
 // FacadeCaller is a wrapper for the common paradigm that a given client just

--- a/api/base/testing/apicaller.go
+++ b/api/base/testing/apicaller.go
@@ -4,6 +4,9 @@
 package testing
 
 import (
+	"net/url"
+
+	"github.com/juju/errors"
 	"github.com/juju/names"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -29,6 +32,10 @@ func (APICallerFunc) EnvironTag() (names.EnvironTag, error) {
 
 func (APICallerFunc) Close() error {
 	return nil
+}
+
+func (APICallerFunc) ConnectStream(path string, attrs url.Values) (base.Stream, error) {
+	return nil, errors.New("stream connection unimplemented")
 }
 
 // CheckArgs holds the possible arguments to CheckingAPICaller(). Any

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -25,6 +25,7 @@ import (
 	"gopkg.in/juju/charm.v6-unstable"
 
 	"github.com/juju/juju/api"
+	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/apiserver/params"
 	jujunames "github.com/juju/juju/juju/names"
 	jujutesting "github.com/juju/juju/juju/testing"
@@ -386,49 +387,50 @@ func (s *clientSuite) TestWatchDebugLogConnected(c *gc.C) {
 	c.Assert(reader, gc.IsNil)
 }
 
-func (s *clientSuite) TestConnectionErrorBadConnection(c *gc.C) {
-	s.PatchValue(api.WebsocketDialConfig, func(_ *websocket.Config) (io.ReadCloser, error) {
+func (s *clientSuite) TestConnectStreamRequiresSlashPathPrefix(c *gc.C) {
+	reader, err := s.APIState.ConnectStream("foo", nil)
+	c.Assert(err, gc.ErrorMatches, `path must start with "/"`)
+	c.Assert(reader, gc.Equals, nil)
+}
+
+func (s *clientSuite) TestConnectStreamErrorBadConnection(c *gc.C) {
+	s.PatchValue(api.WebsocketDialConfig, func(_ *websocket.Config) (base.Stream, error) {
 		return nil, fmt.Errorf("bad connection")
 	})
-	client := s.APIState.Client()
-	reader, err := client.WatchDebugLog(api.DebugLogParams{})
+	reader, err := s.APIState.ConnectStream("/", nil)
 	c.Assert(err, gc.ErrorMatches, "bad connection")
 	c.Assert(reader, gc.IsNil)
 }
 
-func (s *clientSuite) TestConnectionErrorNoData(c *gc.C) {
-	s.PatchValue(api.WebsocketDialConfig, func(_ *websocket.Config) (io.ReadCloser, error) {
-		return ioutil.NopCloser(&bytes.Buffer{}), nil
+func (s *clientSuite) TestConnectStreamErrorNoData(c *gc.C) {
+	s.PatchValue(api.WebsocketDialConfig, func(_ *websocket.Config) (base.Stream, error) {
+		return fakeStreamReader{&bytes.Buffer{}}, nil
 	})
-	client := s.APIState.Client()
-	reader, err := client.WatchDebugLog(api.DebugLogParams{})
+	reader, err := s.APIState.ConnectStream("/", nil)
 	c.Assert(err, gc.ErrorMatches, "unable to read initial response: EOF")
 	c.Assert(reader, gc.IsNil)
 }
 
-func (s *clientSuite) TestConnectionErrorBadData(c *gc.C) {
-	s.PatchValue(api.WebsocketDialConfig, func(_ *websocket.Config) (io.ReadCloser, error) {
-		junk := strings.NewReader("junk\n")
-		return ioutil.NopCloser(junk), nil
+func (s *clientSuite) TestConnectStreamErrorBadData(c *gc.C) {
+	s.PatchValue(api.WebsocketDialConfig, func(_ *websocket.Config) (base.Stream, error) {
+		return fakeStreamReader{strings.NewReader("junk\n")}, nil
 	})
-	client := s.APIState.Client()
-	reader, err := client.WatchDebugLog(api.DebugLogParams{})
+	reader, err := s.APIState.ConnectStream("/", nil)
 	c.Assert(err, gc.ErrorMatches, "unable to unmarshal initial response: .*")
 	c.Assert(reader, gc.IsNil)
 }
 
-func (s *clientSuite) TestConnectionErrorReadError(c *gc.C) {
-	s.PatchValue(api.WebsocketDialConfig, func(_ *websocket.Config) (io.ReadCloser, error) {
+func (s *clientSuite) TestConnectStreamErrorReadError(c *gc.C) {
+	s.PatchValue(api.WebsocketDialConfig, func(_ *websocket.Config) (base.Stream, error) {
 		err := fmt.Errorf("bad read")
-		return ioutil.NopCloser(&badReader{err}), nil
+		return fakeStreamReader{&badReader{err}}, nil
 	})
-	client := s.APIState.Client()
-	reader, err := client.WatchDebugLog(api.DebugLogParams{})
+	reader, err := s.APIState.ConnectStream("/", nil)
 	c.Assert(err, gc.ErrorMatches, "unable to read initial response: bad read")
 	c.Assert(reader, gc.IsNil)
 }
 
-func (s *clientSuite) TestParamsEncoded(c *gc.C) {
+func (s *clientSuite) TestWatchDebugLogParamsEncoded(c *gc.C) {
 	s.PatchValue(api.WebsocketDialConfig, echoURL(c))
 
 	params := api.DebugLogParams{
@@ -460,22 +462,22 @@ func (s *clientSuite) TestParamsEncoded(c *gc.C) {
 	})
 }
 
-func (s *clientSuite) TestDebugLogRootPath(c *gc.C) {
+func (s *clientSuite) TestConnectStreamRootPath(c *gc.C) {
 	s.PatchValue(api.WebsocketDialConfig, echoURL(c))
 
-	// If the server is old, we log at "/log"
+	// If the server is old, we connect to /path.
 	info := s.APIInfo(c)
 	info.EnvironTag = names.NewEnvironTag("")
 	apistate, err := api.OpenWithVersion(info, api.DialOpts{}, 1)
 	c.Assert(err, jc.ErrorIsNil)
 	defer apistate.Close()
-	reader, err := apistate.Client().WatchDebugLog(api.DebugLogParams{})
+	reader, err := apistate.ConnectStream("/path", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	connectURL := connectURLFromReader(c, reader)
-	c.Assert(connectURL.Path, gc.Matches, "/log")
+	c.Assert(connectURL.Path, gc.Matches, "/path")
 }
 
-func (s *clientSuite) TestDebugLogAtUUIDLogPath(c *gc.C) {
+func (s *clientSuite) TestConnectStreamAtUUIDPath(c *gc.C) {
 	s.PatchValue(api.WebsocketDialConfig, echoURL(c))
 	// If the server supports it, we should log at "/environment/UUID/log"
 	environ, err := s.State.Environment()
@@ -485,10 +487,10 @@ func (s *clientSuite) TestDebugLogAtUUIDLogPath(c *gc.C) {
 	apistate, err := api.Open(info, api.DialOpts{})
 	c.Assert(err, jc.ErrorIsNil)
 	defer apistate.Close()
-	reader, err := apistate.Client().WatchDebugLog(api.DebugLogParams{})
+	reader, err := apistate.ConnectStream("/path", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	connectURL := connectURLFromReader(c, reader)
-	c.Assert(connectURL.Path, gc.Matches, fmt.Sprintf("/environment/%s/log", environ.UUID()))
+	c.Assert(connectURL.Path, gc.Matches, fmt.Sprintf("/environment/%s/path", environ.UUID()))
 }
 
 func (s *clientSuite) TestOpenUsesEnvironUUIDPaths(c *gc.C) {
@@ -605,17 +607,17 @@ func (r *badReader) Read(p []byte) (n int, err error) {
 	return 0, r.err
 }
 
-func echoURL(c *gc.C) func(*websocket.Config) (io.ReadCloser, error) {
+func echoURL(c *gc.C) func(*websocket.Config) (base.Stream, error) {
 	response := &params.ErrorResult{}
 	message, err := json.Marshal(response)
 	c.Assert(err, jc.ErrorIsNil)
-	return func(config *websocket.Config) (io.ReadCloser, error) {
+	return func(config *websocket.Config) (base.Stream, error) {
 		pr, pw := io.Pipe()
 		go func() {
 			fmt.Fprintf(pw, "%s\n", message)
 			fmt.Fprintf(pw, "%s\n", config.Location)
 		}()
-		return pr, nil
+		return fakeStreamReader{pr}, nil
 	}
 }
 
@@ -627,4 +629,27 @@ func connectURLFromReader(c *gc.C, rc io.ReadCloser) *url.URL {
 	c.Assert(err, jc.ErrorIsNil)
 	rc.Close()
 	return connectURL
+}
+
+type fakeStreamReader struct {
+	io.Reader
+}
+
+func (s fakeStreamReader) Close() error {
+	if c, ok := s.Reader.(io.Closer); ok {
+		return c.Close()
+	}
+	return nil
+}
+
+func (s fakeStreamReader) Write([]byte) (int, error) {
+	panic("not implemented")
+}
+
+func (s fakeStreamReader) ReadJSON(v interface{}) error {
+	panic("not implemented")
+}
+
+func (s fakeStreamReader) WriteJSON(v interface{}) error {
+	panic("not implemented")
 }

--- a/api/export_test.go
+++ b/api/export_test.go
@@ -17,6 +17,7 @@ var (
 	BestVersion           = bestVersion
 	FacadeVersions        = &facadeVersions
 	NewHTTPClient         = &newHTTPClient
+	ConnectWebsocket      = connectWebsocket
 )
 
 // SetServerAddress allows changing the URL to the internal API server
@@ -29,16 +30,6 @@ func SetServerAddress(c *Client, scheme, addr string) {
 // ServerRoot is exported so that we can test the built URL.
 func ServerRoot(c *Client) string {
 	return c.st.serverRoot()
-}
-
-// PatchEnvironTag patches the value of the environment tag.
-// It returns a function that reverts the change.
-func PatchEnvironTag(st *State, envTag string) func() {
-	originalTag := st.environTag
-	st.environTag = envTag
-	return func() {
-		st.environTag = originalTag
-	}
 }
 
 // TestingStateParams is the parameters for NewTestingState, so that you can
@@ -55,8 +46,8 @@ type TestingStateParams struct {
 // NewTestingState creates an api.State object that can be used for testing. It
 // isn't backed onto an actual API server, so actual RPC methods can't be
 // called on it. But it can be used for testing general behavior.
-func NewTestingState(params TestingStateParams) *State {
-	st := &State{
+func NewTestingState(params TestingStateParams) Connection {
+	st := &state{
 		addr:              params.Address,
 		environTag:        params.EnvironTag,
 		hostPorts:         params.APIHostPorts,

--- a/api/http.go
+++ b/api/http.go
@@ -21,7 +21,7 @@ var newHTTPClient = func(s Connection) apihttp.HTTPClient {
 }
 
 // NewHTTPClient returns an HTTP client initialized based on State.
-func (s *State) NewHTTPClient() *http.Client {
+func (s *state) NewHTTPClient() *http.Client {
 	httpclient := utils.GetValidatingHTTPClient()
 	tlsconfig := tls.Config{
 		RootCAs: s.certPool,
@@ -34,7 +34,7 @@ func (s *State) NewHTTPClient() *http.Client {
 }
 
 // NewHTTPRequest returns a new API-supporting HTTP request based on State.
-func (s *State) NewHTTPRequest(method, path string) (*http.Request, error) {
+func (s *state) NewHTTPRequest(method, path string) (*http.Request, error) {
 	baseURL, err := url.Parse(s.serverRoot())
 	if err != nil {
 		return nil, errors.Annotatef(err, "while parsing base URL (%s)", s.serverRoot())
@@ -51,7 +51,7 @@ func (s *State) NewHTTPRequest(method, path string) (*http.Request, error) {
 }
 
 // SendHTTPRequest sends a GET request using the HTTP client derived from State.
-func (s *State) SendHTTPRequest(path string, args interface{}) (*http.Request, *http.Response, error) {
+func (s *state) SendHTTPRequest(path string, args interface{}) (*http.Request, *http.Response, error) {
 	req, err := s.NewHTTPRequest("GET", path)
 	if err != nil {
 		return nil, nil, errors.Trace(err)
@@ -76,7 +76,7 @@ func (s *State) SendHTTPRequest(path string, args interface{}) (*http.Request, *
 // identifies the attached data's part in the multi-part data. That name
 // doesn't have any semantic significance in juju, so the provided value
 // is strictly informational.
-func (s *State) SendHTTPRequestReader(path string, attached io.Reader, meta interface{}, name string) (*http.Request, *http.Response, error) {
+func (s *state) SendHTTPRequestReader(path string, attached io.Reader, meta interface{}, name string) (*http.Request, *http.Response, error) {
 	req, err := s.NewHTTPRequest("PUT", path)
 	if err != nil {
 		return nil, nil, errors.Trace(err)

--- a/api/interface.go
+++ b/api/interface.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/juju/juju/api/addresser"
 	"github.com/juju/juju/api/agent"
+	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/api/charmrevisionupdater"
 	"github.com/juju/juju/api/cleaner"
 	"github.com/juju/juju/api/deployer"
@@ -111,6 +112,8 @@ type OpenFunc func(*Info, DialOpts) (Connection, error)
 // Connection exists purely to make api-opening funcs mockable. It's just a
 // dumb copy of all the methods on api.Connection; we can and should be extracting
 // smaller and more relevant interfaces (and dropping some of them too).
+
+// Connection represents a connection to a Juju API server.
 type Connection interface {
 
 	// This first block of methods is pretty close to a sane Connection interface.
@@ -124,12 +127,14 @@ type Connection interface {
 	Login(name names.Tag, password, nonce string) error
 	ServerVersion() (version.Number, bool)
 
-	// These are either part of base.APICaller or look like they probably should
-	// be (ServerTag in particular). It's fine and good for Connection to be an
-	// APICaller.
-	APICall(facade string, version int, id, method string, args, response interface{}) error
-	BestFacadeVersion(string) int
-	EnvironTag() (names.EnvironTag, error)
+	// APICaller provides the facility to make API calls directly.
+	// This should not be used outside the api/* packages or tests.
+	base.APICaller
+
+	// ServerTag returns the environment tag of the state server
+	// (as opposed to the environment tag of the currently connected
+	// environment inside that state server).
+	// This could be defined on base.APICaller.
 	ServerTag() (names.EnvironTag, error)
 
 	// These HTTP methods should probably be separated out somehow.

--- a/api/logsender/logsender.go
+++ b/api/logsender/logsender.go
@@ -1,0 +1,63 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Package logsender implements the API for storing log
+// messages on the API server.
+package logsender
+
+import (
+	"io"
+
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/apiserver/params"
+)
+
+// LogWriter is the interface that allows sending log
+// messages to the server for storage.
+type LogWriter interface {
+	// WriteLog writes the given log record.
+	WriteLog(*params.LogRecord) error
+
+	io.Closer
+}
+
+// API provides access to the LogSender API.
+type API struct {
+	connector base.StreamConnector
+}
+
+// NewAPI creates a new client-side logsender API.
+func NewAPI(connector base.StreamConnector) *API {
+	return &API{connector: connector}
+}
+
+// LogWriter returns a new log writer interface value
+// which must be closed when finished with.
+func (api *API) LogWriter() (LogWriter, error) {
+	conn, err := api.connector.ConnectStream("/logsink", nil)
+	if err != nil {
+		return nil, errors.Annotatef(err, "cannot connect to /logsink")
+	}
+	return writer{conn}, nil
+}
+
+type writer struct {
+	conn base.Stream
+}
+
+func (w writer) WriteLog(m *params.LogRecord) error {
+	// Note: due to the fire-and-forget nature of the
+	// logsink API, it is possible that when the
+	// connection dies, any logs that were "in-flight"
+	// will not be recorded on the server side.
+	if err := w.conn.WriteJSON(m); err != nil {
+		return errors.Annotatef(err, "cannot send log message")
+	}
+	return nil
+}
+
+func (w writer) Close() error {
+	return w.conn.Close()
+}

--- a/api/logsender/logsender_test.go
+++ b/api/logsender/logsender_test.go
@@ -1,0 +1,118 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package logsender_test
+
+import (
+	"errors"
+	"net/url"
+
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/api/logsender"
+	"github.com/juju/juju/apiserver/params"
+	coretesting "github.com/juju/juju/testing"
+)
+
+type LogSenderSuite struct {
+	coretesting.BaseSuite
+}
+
+var _ = gc.Suite(&LogSenderSuite{})
+
+func (s *LogSenderSuite) TestNewAPI(c *gc.C) {
+	conn := &mockConnector{
+		c: c,
+	}
+	a := logsender.NewAPI(conn)
+	w, err := a.LogWriter()
+	c.Assert(err, gc.IsNil)
+
+	msg := new(params.LogRecord)
+	err = w.WriteLog(msg)
+	c.Assert(err, gc.IsNil)
+
+	c.Assert(conn.written, gc.HasLen, 1)
+	c.Assert(conn.written[0], gc.Equals, msg)
+
+	err = w.Close()
+	c.Assert(err, gc.IsNil)
+	c.Assert(conn.closeCount, gc.Equals, 1)
+}
+
+func (s *LogSenderSuite) TestNewAPIWriteLogError(c *gc.C) {
+	conn := &mockConnector{
+		c:            c,
+		connectError: errors.New("foo"),
+	}
+	a := logsender.NewAPI(conn)
+	w, err := a.LogWriter()
+	c.Assert(err, gc.ErrorMatches, "cannot connect to /logsink: foo")
+	c.Assert(w, gc.Equals, nil)
+}
+
+func (s *LogSenderSuite) TestNewAPIWriteError(c *gc.C) {
+	conn := &mockConnector{
+		c:          c,
+		writeError: errors.New("foo"),
+	}
+	a := logsender.NewAPI(conn)
+	w, err := a.LogWriter()
+	c.Assert(err, gc.IsNil)
+
+	err = w.WriteLog(new(params.LogRecord))
+	c.Assert(err, gc.ErrorMatches, "cannot send log message: foo")
+	c.Assert(conn.written, gc.HasLen, 0)
+}
+
+type mockConnector struct {
+	c *gc.C
+
+	connectError error
+	writeError   error
+	written      []interface{}
+
+	closeCount int
+}
+
+func (c *mockConnector) ConnectStream(path string, values url.Values) (base.Stream, error) {
+	c.c.Assert(path, gc.Equals, "/logsink")
+	c.c.Assert(values, gc.HasLen, 0)
+	if c.connectError != nil {
+		return nil, c.connectError
+	}
+	return mockStream{c}, nil
+}
+
+type mockStream struct {
+	conn *mockConnector
+}
+
+func (s mockStream) WriteJSON(v interface{}) error {
+	if s.conn.writeError != nil {
+		return s.conn.writeError
+	}
+	s.conn.written = append(s.conn.written, v)
+	return nil
+}
+
+func (s mockStream) ReadJSON(v interface{}) error {
+	s.conn.c.Errorf("ReadJSON called unexpectedly")
+	return nil
+}
+
+func (s mockStream) Read([]byte) (int, error) {
+	s.conn.c.Errorf("Read called unexpectedly")
+	return 0, nil
+}
+
+func (s mockStream) Write([]byte) (int, error) {
+	s.conn.c.Errorf("Write called unexpectedly")
+	return 0, nil
+}
+
+func (s mockStream) Close() error {
+	s.conn.closeCount++
+	return nil
+}

--- a/api/logsender/package_test.go
+++ b/api/logsender/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package logsender_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/api/state.go
+++ b/api/state.go
@@ -42,7 +42,7 @@ import (
 // Subsequent requests on the state will act as that entity.  This
 // method is usually called automatically by Open. The machine nonce
 // should be empty unless logging in as a machine agent.
-func (st *State) Login(tag names.Tag, password, nonce string) error {
+func (st *state) Login(tag names.Tag, password, nonce string) error {
 	err := st.loginV2(tag, password, nonce)
 	if params.IsCodeNotImplemented(err) {
 		err = st.loginV1(tag, password, nonce)
@@ -54,7 +54,7 @@ func (st *State) Login(tag names.Tag, password, nonce string) error {
 	return err
 }
 
-func (st *State) loginV2(tag names.Tag, password, nonce string) error {
+func (st *state) loginV2(tag names.Tag, password, nonce string) error {
 	var result params.LoginResultV1
 	request := &params.LoginRequest{
 		AuthTag:     tagToString(tag),
@@ -110,7 +110,7 @@ func (st *State) loginV2(tag names.Tag, password, nonce string) error {
 	return nil
 }
 
-func (st *State) loginV1(tag names.Tag, password, nonce string) error {
+func (st *state) loginV1(tag names.Tag, password, nonce string) error {
 	var result struct {
 		// TODO (cmars): remove once we can drop 1.18 login compatibility
 		params.LoginResult
@@ -164,7 +164,7 @@ func (st *State) loginV1(tag names.Tag, password, nonce string) error {
 	return nil
 }
 
-func (st *State) setLoginResult(tag names.Tag, environTag, serverTag string, servers [][]network.HostPort, facades []params.FacadeVersions) error {
+func (st *state) setLoginResult(tag names.Tag, environTag, serverTag string, servers [][]network.HostPort, facades []params.FacadeVersions) error {
 	st.authTag = tag
 	st.environTag = environTag
 	st.serverTag = serverTag
@@ -185,7 +185,7 @@ func (st *State) setLoginResult(tag names.Tag, environTag, serverTag string, ser
 	return nil
 }
 
-func (st *State) loginV0(tag names.Tag, password, nonce string) error {
+func (st *state) loginV0(tag names.Tag, password, nonce string) error {
 	var result params.LoginResult
 	err := st.APICall("Admin", 0, "", "Login", &params.Creds{
 		AuthTag:  tagToString(tag),
@@ -247,38 +247,38 @@ func addAddress(servers [][]network.HostPort, addr string) ([][]network.HostPort
 
 // Client returns an object that can be used
 // to access client-specific functionality.
-func (st *State) Client() *Client {
+func (st *state) Client() *Client {
 	frontend, backend := base.NewClientFacade(st, "Client")
 	return &Client{ClientFacade: frontend, facade: backend, st: st}
 }
 
 // Machiner returns a version of the state that provides functionality
 // required by the machiner worker.
-func (st *State) Machiner() *machiner.State {
+func (st *state) Machiner() *machiner.State {
 	return machiner.NewState(st)
 }
 
 // Resumer returns a version of the state that provides functionality
 // required by the resumer worker.
-func (st *State) Resumer() *resumer.API {
+func (st *state) Resumer() *resumer.API {
 	return resumer.NewAPI(st)
 }
 
 // Networker returns a version of the state that provides functionality
 // required by the networker worker.
-func (st *State) Networker() networker.State {
+func (st *state) Networker() networker.State {
 	return networker.NewState(st)
 }
 
 // Provisioner returns a version of the state that provides functionality
 // required by the provisioner worker.
-func (st *State) Provisioner() *provisioner.State {
+func (st *state) Provisioner() *provisioner.State {
 	return provisioner.NewState(st)
 }
 
 // Uniter returns a version of the state that provides functionality
 // required by the uniter worker.
-func (st *State) Uniter() (*uniter.State, error) {
+func (st *state) Uniter() (*uniter.State, error) {
 	unitTag, ok := st.authTag.(names.UnitTag)
 	if !ok {
 		return nil, errors.Errorf("expected UnitTag, got %T %v", st.authTag, st.authTag)
@@ -288,7 +288,7 @@ func (st *State) Uniter() (*uniter.State, error) {
 
 // DiskManager returns a version of the state that provides functionality
 // required by the diskmanager worker.
-func (st *State) DiskManager() (*diskmanager.State, error) {
+func (st *state) DiskManager() (*diskmanager.State, error) {
 	machineTag, ok := st.authTag.(names.MachineTag)
 	if !ok {
 		return nil, errors.Errorf("expected MachineTag, got %#v", st.authTag)
@@ -302,29 +302,29 @@ func (st *State) DiskManager() (*diskmanager.State, error) {
 // either attached directly to a specified machine (machine scoped),
 // or provisioned on the underlying cloud for use by any machine in a
 // specified environment (environ scoped).
-func (st *State) StorageProvisioner(scope names.Tag) *storageprovisioner.State {
+func (st *state) StorageProvisioner(scope names.Tag) *storageprovisioner.State {
 	return storageprovisioner.NewState(st, scope)
 }
 
 // Firewaller returns a version of the state that provides functionality
 // required by the firewaller worker.
-func (st *State) Firewaller() *firewaller.State {
+func (st *state) Firewaller() *firewaller.State {
 	return firewaller.NewState(st)
 }
 
 // Agent returns a version of the state that provides
 // functionality required by the agent code.
-func (st *State) Agent() *agent.State {
+func (st *state) Agent() *agent.State {
 	return agent.NewState(st)
 }
 
 // Upgrader returns access to the Upgrader API
-func (st *State) Upgrader() *upgrader.State {
+func (st *state) Upgrader() *upgrader.State {
 	return upgrader.NewState(st)
 }
 
 // Reboot returns access to the Reboot API
-func (st *State) Reboot() (*reboot.State, error) {
+func (st *state) Reboot() (*reboot.State, error) {
 	switch tag := st.authTag.(type) {
 	case names.MachineTag:
 		return reboot.NewState(st, tag), nil
@@ -334,47 +334,47 @@ func (st *State) Reboot() (*reboot.State, error) {
 }
 
 // Deployer returns access to the Deployer API
-func (st *State) Deployer() *deployer.State {
+func (st *state) Deployer() *deployer.State {
 	return deployer.NewState(st)
 }
 
 // Addresser returns access to the Addresser API.
-func (st *State) Addresser() *addresser.API {
+func (st *state) Addresser() *addresser.API {
 	return addresser.NewAPI(st)
 }
 
 // Environment returns access to the Environment API
-func (st *State) Environment() *environment.Facade {
+func (st *state) Environment() *environment.Facade {
 	return environment.NewFacade(st)
 }
 
 // Logger returns access to the Logger API
-func (st *State) Logger() *apilogger.State {
+func (st *state) Logger() *apilogger.State {
 	return apilogger.NewState(st)
 }
 
 // KeyUpdater returns access to the KeyUpdater API
-func (st *State) KeyUpdater() *keyupdater.State {
+func (st *state) KeyUpdater() *keyupdater.State {
 	return keyupdater.NewState(st)
 }
 
 // InstancePoller returns access to the InstancePoller API
-func (st *State) InstancePoller() *instancepoller.API {
+func (st *state) InstancePoller() *instancepoller.API {
 	return instancepoller.NewAPI(st)
 }
 
 // CharmRevisionUpdater returns access to the CharmRevisionUpdater API
-func (st *State) CharmRevisionUpdater() *charmrevisionupdater.State {
+func (st *state) CharmRevisionUpdater() *charmrevisionupdater.State {
 	return charmrevisionupdater.NewState(st)
 }
 
 // Cleaner returns a version of the state that provides access to the cleaner API
-func (st *State) Cleaner() *cleaner.API {
+func (st *state) Cleaner() *cleaner.API {
 	return cleaner.NewAPI(st)
 }
 
 // Rsyslog returns access to the Rsyslog API
-func (st *State) Rsyslog() *rsyslog.State {
+func (st *state) Rsyslog() *rsyslog.State {
 	return rsyslog.NewState(st)
 }
 
@@ -382,11 +382,11 @@ func (st *State) Rsyslog() *rsyslog.State {
 // It is possible that this version is Zero if the server does not report this
 // during login. The second result argument indicates if the version number is
 // set.
-func (st *State) ServerVersion() (version.Number, bool) {
+func (st *state) ServerVersion() (version.Number, bool) {
 	return st.serverVersion, st.serverVersion != version.Zero
 }
 
 // MetadataUpdater returns access to the imageMetadata API
-func (st *State) MetadataUpdater() *imagemetadata.Client {
+func (st *state) MetadataUpdater() *imagemetadata.Client {
 	return imagemetadata.NewClient(st)
 }

--- a/apiserver/admin.go
+++ b/apiserver/admin.go
@@ -210,7 +210,7 @@ func (a *admin) checkCredsOfStateServerMachine(req params.LoginRequest) (state.E
 	}
 	// The machine does exist in the state server environment, but it
 	// doesn't manage environments, so reject it.
-	return nil, common.ErrBadCreds
+	return nil, errors.Trace(common.ErrBadCreds)
 }
 
 func (a *admin) maintenanceInProgress() bool {

--- a/apiserver/admin_test.go
+++ b/apiserver/admin_test.go
@@ -681,11 +681,8 @@ func (s *baseLoginSuite) setupServerForEnvironmentWithValidator(c *gc.C, envTag 
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	if s.setAdminApi != nil {
-		s.setAdminApi(srv)
-	} else {
-		panic(nil)
-	}
+	c.Assert(s.setAdminApi, gc.NotNil)
+	s.setAdminApi(srv)
 	info := &api.Info{
 		Tag:        nil,
 		Password:   "",

--- a/apiserver/authentication/agent.go
+++ b/apiserver/authentication/agent.go
@@ -27,17 +27,17 @@ type taggedAuthenticator interface {
 func (*AgentAuthenticator) Authenticate(entityFinder EntityFinder, tag names.Tag, req params.LoginRequest) (state.Entity, error) {
 	entity, err := entityFinder.FindEntity(tag)
 	if errors.IsNotFound(err) {
-		return nil, common.ErrBadCreds
+		return nil, errors.Trace(common.ErrBadCreds)
 	}
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 	authenticator, ok := entity.(taggedAuthenticator)
 	if !ok {
-		return nil, common.ErrBadRequest
+		return nil, errors.Trace(common.ErrBadRequest)
 	}
 	if !authenticator.PasswordValid(req.Credentials) {
-		return nil, common.ErrBadCreds
+		return nil, errors.Trace(common.ErrBadCreds)
 	}
 
 	// If this is a machine agent connecting, we need to check the

--- a/apiserver/authentication/user.go
+++ b/apiserver/authentication/user.go
@@ -87,7 +87,7 @@ func (m *MacaroonAuthenticator) Authenticate(entityFinder EntityFinder, _ names.
 	}
 	entity, err := entityFinder.FindEntity(names.NewUserTag(declared[usernameKey]))
 	if errors.IsNotFound(err) {
-		return nil, common.ErrBadCreds
+		return nil, errors.Trace(common.ErrBadCreds)
 	} else if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/apiserver/authhttp_test.go
+++ b/apiserver/authhttp_test.go
@@ -189,7 +189,7 @@ func (s *authHttpSuite) sendRequest(c *gc.C, p httpRequestParams) *http.Response
 		hp.Header.Set("Content-Type", p.contentType)
 	}
 	if p.nonce != "" {
-		hp.Header.Set("X-Juju-Nonce", p.nonce)
+		hp.Header.Set(params.MachineNonceHeader, p.nonce)
 	}
 	if hp.Do == nil {
 		hp.Do = utils.GetNonValidatingHTTPClient().Do

--- a/apiserver/charms.go
+++ b/apiserver/charms.go
@@ -52,8 +52,7 @@ func (h *charmsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		err = errors.MethodNotAllowedf("unsupported method: %q", r.Method)
 	}
 	if err != nil {
-		logger.Errorf("returning error from %s /charms: %s", r.Method, errors.Details(err))
-		h.sendError(w, err)
+		h.sendError(w, r, err)
 	}
 }
 
@@ -111,7 +110,8 @@ func (h *charmsHandler) serveGet(w http.ResponseWriter, r *http.Request) error {
 // Note the difference from the error response sent by
 // the sendError function - the error is encoded in the
 // Error field as a string, not an Error object.
-func (h *charmsHandler) sendError(w http.ResponseWriter, err error) {
+func (h *charmsHandler) sendError(w http.ResponseWriter, req *http.Request, err error) {
+	logger.Errorf("returning error from %s %s: %s", req.Method, req.URL, errors.Details(err))
 	perr, status := common.ServerErrorAndStatus(err)
 	sendStatusAndJSON(w, status, &params.CharmsResponse{
 		Error:     perr.Message,

--- a/apiserver/debuglog_test.go
+++ b/apiserver/debuglog_test.go
@@ -12,6 +12,7 @@ import (
 	"golang.org/x/net/websocket"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/testing/factory"
 )
 
@@ -56,7 +57,7 @@ func (s *debugLogBaseSuite) TestAgentLoginsRejected(c *gc.C) {
 		Nonce: "foo-nonce",
 	})
 	header := utils.BasicAuthHeader(m.Tag().String(), password)
-	header.Add("X-Juju-Nonce", "foo-nonce")
+	header.Add(params.MachineNonceHeader, "foo-nonce")
 	conn := s.dialWebsocketInternal(c, nil, header)
 	defer conn.Close()
 	reader := bufio.NewReader(conn)

--- a/apiserver/httpcontext.go
+++ b/apiserver/httpcontext.go
@@ -78,7 +78,7 @@ func (ctxt *httpContext) stateForRequestAuthenticated(r *http.Request) (*state.S
 		if !common.IsDischargeRequiredError(err) {
 			err = errors.NewUnauthorized(err, "")
 		}
-		return nil, nil, err
+		return nil, nil, errors.Trace(err)
 	}
 	return st, entity, nil
 }
@@ -94,7 +94,7 @@ func (ctxt *httpContext) stateForRequestAuthenticatedUser(r *http.Request) (*sta
 	case names.UserTag:
 		return st, entity, nil
 	default:
-		return nil, nil, common.ErrBadCreds
+		return nil, nil, errors.Trace(common.ErrBadCreds)
 	}
 }
 
@@ -109,7 +109,8 @@ func (ctxt *httpContext) stateForRequestAuthenticatedAgent(r *http.Request) (*st
 	case names.MachineTag, names.UnitTag:
 		return st, entity, nil
 	default:
-		return nil, nil, common.ErrBadCreds
+		logger.Errorf("attempt to log in as an agent by %v", entity.Tag())
+		return nil, nil, errors.Trace(common.ErrBadCreds)
 	}
 }
 
@@ -143,12 +144,12 @@ func (ctxt *httpContext) loginRequest(r *http.Request) (params.LoginRequest, err
 	// Ensure that a sensible tag was passed.
 	_, err = names.ParseTag(tagPass[0])
 	if err != nil {
-		return params.LoginRequest{}, common.ErrBadCreds
+		return params.LoginRequest{}, errors.Trace(common.ErrBadCreds)
 	}
 	return params.LoginRequest{
 		AuthTag:     tagPass[0],
 		Credentials: tagPass[1],
-		Nonce:       r.Header.Get("X-Juju-Nonce"),
+		Nonce:       r.Header.Get(params.MachineNonceHeader),
 	}, nil
 }
 

--- a/apiserver/logsink_test.go
+++ b/apiserver/logsink_test.go
@@ -21,7 +21,7 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/mgo.v2/bson"
 
-	"github.com/juju/juju/apiserver"
+	"github.com/juju/juju/apiserver/params"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/testing/factory"
 )
@@ -77,13 +77,13 @@ func (s *logsinkSuite) TestRejectsUserLogins(c *gc.C) {
 
 func (s *logsinkSuite) TestRejectsBadPassword(c *gc.C) {
 	header := utils.BasicAuthHeader(s.machineTag.String(), "wrong")
-	header.Add("X-Juju-Nonce", s.nonce)
+	header.Add(params.MachineNonceHeader, s.nonce)
 	s.checkAuthFailsWithEntityError(c, header)
 }
 
 func (s *logsinkSuite) TestRejectsIncorrectNonce(c *gc.C) {
 	header := utils.BasicAuthHeader(s.machineTag.String(), s.password)
-	header.Add("X-Juju-Nonce", "wrong")
+	header.Add(params.MachineNonceHeader, "wrong")
 	s.checkAuthFails(c, header, "machine 0 not provisioned")
 }
 
@@ -109,7 +109,7 @@ func (s *logsinkSuite) TestLogging(c *gc.C) {
 	c.Assert(errResult.Error, gc.IsNil)
 
 	t0 := time.Date(2015, time.June, 1, 23, 2, 1, 0, time.UTC)
-	err := websocket.JSON.Send(conn, &apiserver.LogMessage{
+	err := websocket.JSON.Send(conn, &params.LogRecord{
 		Time:     t0,
 		Module:   "some.where",
 		Location: "foo.go:42",
@@ -119,7 +119,7 @@ func (s *logsinkSuite) TestLogging(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	t1 := time.Date(2015, time.June, 1, 23, 2, 2, 0, time.UTC)
-	err = websocket.JSON.Send(conn, &apiserver.LogMessage{
+	err = websocket.JSON.Send(conn, &params.LogRecord{
 		Time:     t1,
 		Module:   "else.where",
 		Location: "bar.go:99",
@@ -175,7 +175,7 @@ func (s *logsinkSuite) TestLogging(c *gc.C) {
 	}
 	for a := shortAttempt.Start(); a.Next(); {
 		for _, log := range s.logs.Log() {
-			c.Assert(log.Level, jc.LessThan, loggo.ERROR)
+			c.Assert(log.Level, jc.LessThan, loggo.ERROR, gc.Commentf("log: %#v", log))
 		}
 	}
 
@@ -216,7 +216,7 @@ func (s *logsinkSuite) openWebsocketCustomPath(c *gc.C, path string) *bufio.Read
 
 func (s *logsinkSuite) makeAuthHeader() http.Header {
 	header := utils.BasicAuthHeader(s.machineTag.String(), s.password)
-	header.Add("X-Juju-Nonce", s.nonce)
+	header.Add(params.MachineNonceHeader, s.nonce)
 	return header
 }
 

--- a/apiserver/params/constants.go
+++ b/apiserver/params/constants.go
@@ -30,3 +30,5 @@ const (
 	ResolvedRetryHooks ResolvedMode = "retry-hooks"
 	ResolvedNoHooks    ResolvedMode = "no-hooks"
 )
+
+const MachineNonceHeader = "X-Juju-Nonce"

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	"github.com/juju/utils/proxy"
 	"gopkg.in/juju/charm.v6-unstable"
 	"gopkg.in/macaroon.v1"
@@ -753,4 +754,15 @@ type RebootActionResults struct {
 type RebootActionResult struct {
 	Result RebootAction `json:"result,omitempty"`
 	Error  *Error       `json:"error,omitempty"`
+}
+
+// LogRecord is used to transmit log messages to the logsink API
+// endpoint.  Single character field names are used for serialisation
+// to keep the size down. These messages are going to be sent a lot.
+type LogRecord struct {
+	Time     time.Time   `json:"t"`
+	Module   string      `json:"m"`
+	Location string      `json:"l"`
+	Level    loggo.Level `json:"v"`
+	Message  string      `json:"x"`
 }

--- a/apiserver/service/service_test.go
+++ b/apiserver/service/service_test.go
@@ -432,7 +432,7 @@ func (s *serviceSuite) TestAddCharmWithAuthorization(c *gc.C) {
 	// Try to add a charm to the environment without authorization.
 	s.DischargeUser = ""
 	err = s.APIState.Client().AddCharm(curl)
-	c.Assert(err, gc.ErrorMatches, `cannot retrieve charm "cs:~restricted/precise/wordpress-3": cannot get archive: cannot get discharge from ".*": third party refused discharge: cannot discharge: discharge denied`)
+	c.Assert(err, gc.ErrorMatches, `cannot retrieve charm "cs:~restricted/precise/wordpress-3": cannot get archive: GET http://.*/v4/~restricted/precise/wordpress-3/archive failed: cannot get discharge from "https://.*": third party refused discharge: cannot discharge: discharge denied`)
 
 	tryAs := func(user string) error {
 		client := csclient.New(csclient.Params{

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -35,6 +35,7 @@ import (
 	"github.com/juju/juju/api"
 	apiagent "github.com/juju/juju/api/agent"
 	apideployer "github.com/juju/juju/api/deployer"
+	apilogsender "github.com/juju/juju/api/logsender"
 	"github.com/juju/juju/api/metricsmanager"
 	apiupgrader "github.com/juju/juju/api/upgrader"
 	"github.com/juju/juju/apiserver"
@@ -78,7 +79,6 @@ import (
 	"github.com/juju/juju/worker/diskmanager"
 	"github.com/juju/juju/worker/envworkermanager"
 	"github.com/juju/juju/worker/firewaller"
-	"github.com/juju/juju/worker/gate"
 	"github.com/juju/juju/worker/imagemetadataworker"
 	"github.com/juju/juju/worker/instancepoller"
 	"github.com/juju/juju/worker/localstorage"
@@ -728,7 +728,7 @@ func (a *MachineAgent) postUpgradeAPIWorker(
 
 	if feature.IsDbLogEnabled() {
 		runner.StartWorker("logsender", func() (worker.Worker, error) {
-			return logsender.New(a.bufferedLogs, gate.AlreadyUnlocked{}, a), nil
+			return logsender.New(a.bufferedLogs, apilogsender.NewAPI(st)), nil
 		})
 	}
 

--- a/cmd/jujud/agent/unit/manifolds.go
+++ b/cmd/jujud/agent/unit/manifolds.go
@@ -82,9 +82,8 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 		// API server, when configured so to do. We should only need one of
 		// these in a consolidated agent.
 		LogSenderName: logsender.Manifold(logsender.ManifoldConfig{
-			AgentName:       AgentName,
-			APIInfoGateName: APIInfoGateName,
-			LogSource:       config.LogSource,
+			LogSource:     config.LogSource,
+			APICallerName: APICallerName,
 		}),
 
 		// The rsyslog config updater is a leaf worker that causes rsyslog

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -44,7 +44,7 @@ gopkg.in/juju/charmrepo.v1	git	8677b12d9772a2a596a99e65b7e6f642fceb6c40	2015-09-
 gopkg.in/juju/charmstore.v5-unstable	git	a921c6c69d74361c38a99a95d2aceec76533038d	2015-08-27T20:19:40Z
 gopkg.in/juju/environschema.v1	git	16cc59268c09c22870cb4de8eb6248652535f315	2015-08-24T13:22:26Z
 gopkg.in/juju/jujusvg.v1	git	3eedb1c722ece2b66d62508368ca3e8b7f916569	2015-05-20T11:48:32Z
-gopkg.in/macaroon-bakery.v1	git	90436b1313cd9f4923a26319ef46eaabe3aeb756	2015-09-29T09:13:38Z
+gopkg.in/macaroon-bakery.v1	git	f058441861bbd00d8dea526e9f2e8869fbba1448	2015-10-05T11:20:23Z
 gopkg.in/macaroon.v1	git	ab3940c6c16510a850e1c2dd628b919f0f3f1464	2015-01-21T11:42:31Z
 gopkg.in/mgo.v2	git	3569c88678d88179dcbd68d02ab081cbca3cd4d0	2015-06-04T15:26:27Z
 gopkg.in/natefinch/lumberjack.v2	git	588a21fb0fa0ebdfde42670fa214576b6f0f22df	2015-05-21T01:59:18Z

--- a/upgrades/upgrade_test.go
+++ b/upgrades/upgrade_test.go
@@ -619,7 +619,7 @@ func (s *upgradeSuite) TestApiStepsGetRestrictedContext(c *gc.C) {
 func (s *upgradeSuite) checkContextRestriction(c *gc.C, expectedPanic string) {
 	fromVersion := version.MustParse("1.20.0")
 	type fakeAgentConfigSetter struct{ agent.ConfigSetter }
-	ctx := upgrades.NewContext(fakeAgentConfigSetter{}, new(api.State), new(state.State))
+	ctx := upgrades.NewContext(fakeAgentConfigSetter{}, nil, new(state.State))
 	c.Assert(
 		func() { upgrades.PerformUpgrade(fromVersion, targets(upgrades.StateServer), ctx) },
 		gc.PanicMatches, expectedPanic,

--- a/worker/logsender/worker.go
+++ b/worker/logsender/worker.go
@@ -4,21 +4,14 @@
 package logsender
 
 import (
-	"encoding/json"
 	"fmt"
-	"time"
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
-	"github.com/juju/utils"
-	"golang.org/x/net/websocket"
 
-	"github.com/juju/juju/agent"
-	"github.com/juju/juju/api"
-	"github.com/juju/juju/apiserver"
+	"github.com/juju/juju/api/logsender"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/worker"
-	"github.com/juju/juju/worker/gate"
 )
 
 const loggerName = "juju.worker.logsender"
@@ -27,27 +20,23 @@ var logger = loggo.GetLogger(loggerName)
 
 // New starts a logsender worker which reads log message structs from
 // a channel and sends them to the JES via the logsink API.
-func New(logs LogRecordCh, apiInfoGate gate.Waiter, agent agent.Agent) worker.Worker {
+func New(logs LogRecordCh, logSenderAPI *logsender.API) worker.Worker {
 	loop := func(stop <-chan struct{}) error {
-		logger.Debugf("started log-sender worker; waiting for api info")
-		select {
-		case <-apiInfoGate.Unlocked():
-		case <-stop:
-			return nil
-		}
-
-		logger.Debugf("dialing log-sender connection")
-		apiInfo := agent.CurrentConfig().APIInfo()
-		conn, err := dialLogsinkAPI(apiInfo)
+		logWriter, err := logSenderAPI.LogWriter()
 		if err != nil {
 			return errors.Annotate(err, "logsender dial failed")
 		}
-		defer conn.Close()
-
+		defer logWriter.Close()
 		for {
 			select {
 			case rec := <-logs:
-				err := sendLogRecord(conn, rec.Time, rec.Module, rec.Location, rec.Level, rec.Message)
+				err := logWriter.WriteLog(&params.LogRecord{
+					Time:     rec.Time,
+					Module:   rec.Module,
+					Location: rec.Location,
+					Level:    rec.Level,
+					Message:  rec.Message,
+				})
 				if err != nil {
 					return errors.Trace(err)
 				}
@@ -67,8 +56,12 @@ func New(logs LogRecordCh, apiInfoGate gate.Waiter, agent agent.Agent) worker.Wo
 					// periods. The maximum in-memory log buffer is
 					// quite large (see the InstallBufferedLogWriter
 					// call in jujuDMain).
-					err := sendLogRecord(conn, rec.Time, loggerName, "", loggo.WARNING,
-						fmt.Sprintf("%d log messages dropped due to lack of API connectivity", rec.DroppedAfter))
+					err := logWriter.WriteLog(&params.LogRecord{
+						Time:    rec.Time,
+						Module:  loggerName,
+						Level:   loggo.WARNING,
+						Message: fmt.Sprintf("%d log messages dropped due to lack of API connectivity", rec.DroppedAfter),
+					})
 					if err != nil {
 						return errors.Trace(err)
 					}
@@ -80,51 +73,4 @@ func New(logs LogRecordCh, apiInfoGate gate.Waiter, agent agent.Agent) worker.Wo
 		}
 	}
 	return worker.NewSimpleWorker(loop)
-}
-
-func dialLogsinkAPI(apiInfo *api.Info) (*websocket.Conn, error) {
-	// TODO(mjs) Most of this should be extracted to be shared for
-	// connections to both /log (debuglog) and /logsink.
-	header := utils.BasicAuthHeader(apiInfo.Tag.String(), apiInfo.Password)
-	header.Set("X-Juju-Nonce", apiInfo.Nonce)
-	conn, err := api.Connect(apiInfo, "/logsink", header, api.DialOpts{})
-	if err != nil {
-		return nil, errors.Annotate(err, "failed to connect to logsink API")
-	}
-
-	// Read the initial error and translate to a real error.
-	// Read up to the first new line character. We can't use bufio here as it
-	// reads too much from the reader.
-	line := make([]byte, 4096)
-	n, err := conn.Read(line)
-	if err != nil {
-		return nil, errors.Annotate(err, "unable to read initial response")
-	}
-	line = line[0:n]
-
-	var errResult params.ErrorResult
-	err = json.Unmarshal(line, &errResult)
-	if err != nil {
-		return nil, errors.Annotate(err, "unable to unmarshal initial response")
-	}
-	if errResult.Error != nil {
-		return nil, errors.Annotatef(errResult.Error, "initial server error")
-	}
-
-	return conn, nil
-}
-
-func sendLogRecord(conn *websocket.Conn, ts time.Time, module, location string, level loggo.Level, msg string) error {
-	err := websocket.JSON.Send(conn, &apiserver.LogMessage{
-		Time:     ts,
-		Module:   module,
-		Location: location,
-		Level:    level,
-		Message:  msg,
-	})
-	// Note: due to the fire-and-forget nature of the
-	// logsink API, it is possible that when the
-	// connection dies, any logs that were "in-flight"
-	// will not be recorded on the server side.
-	return errors.Annotate(err, "logsink connection failed")
 }

--- a/worker/logsender/worker_test.go
+++ b/worker/logsender/worker_test.go
@@ -8,22 +8,29 @@ import (
 	"time"
 
 	"github.com/juju/loggo"
+	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/mgo.v2/bson"
 
-	"github.com/juju/juju/agent"
 	"github.com/juju/juju/api"
+	apilogsender "github.com/juju/juju/api/logsender"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/testing/factory"
-	"github.com/juju/juju/worker/gate"
 	"github.com/juju/juju/worker/logsender"
 )
 
 type workerSuite struct {
 	jujutesting.JujuConnSuite
-	apiInfo *api.Info
+
+	// machineTag holds the tag of a machine created
+	// for the test.
+	machineTag names.Tag
+
+	// APIState holds an API connection authenticated
+	// as the above machine.
+	APIState api.Connection
 }
 
 var _ = gc.Suite(&workerSuite{})
@@ -36,37 +43,23 @@ func (s *workerSuite) SetUpTest(c *gc.C) {
 	nonce := "some-nonce"
 	machine, password := s.Factory.MakeMachineReturningPassword(c,
 		&factory.MachineParams{Nonce: nonce})
-	s.apiInfo = s.APIInfo(c)
-	s.apiInfo.Tag = machine.Tag()
-	s.apiInfo.Password = password
-	s.apiInfo.Nonce = nonce
+	apiInfo := s.APIInfo(c)
+	apiInfo.Tag = machine.Tag()
+	apiInfo.Password = password
+	apiInfo.Nonce = nonce
+	st, err := api.Open(apiInfo, api.DefaultDialOpts())
+	c.Assert(err, gc.IsNil)
+	s.APIState = st
+	s.machineTag = machine.Tag()
 }
 
-func (s *workerSuite) agent() agent.Agent {
-	return &mockAgent{apiInfo: s.apiInfo}
+func (s *workerSuite) TearDownTest(c *gc.C) {
+	s.APIState.Close()
+	s.JujuConnSuite.TearDownTest(c)
 }
 
-func (s *workerSuite) TestLockedGate(c *gc.C) {
-
-	// Set a bad password to induce an error if we connect.
-	s.apiInfo.Password = "lol-borken"
-
-	// Run a logsender worker.
-	logsCh := make(chan *logsender.LogRecord)
-	worker := logsender.New(logsCh, lockedGate{}, s.agent())
-
-	// At the end of the test, make sure we never tried to connect.
-	defer func() {
-		worker.Kill()
-		c.Check(worker.Wait(), jc.ErrorIsNil)
-	}()
-
-	// Give it a chance to ignore the gate and read the log channel.
-	select {
-	case <-time.After(testing.ShortWait):
-	case logsCh <- &logsender.LogRecord{}:
-		c.Fatalf("read log channel without waiting for gate")
-	}
+func (s *workerSuite) logSenderAPI() *apilogsender.API {
+	return apilogsender.NewAPI(s.APIState)
 }
 
 func (s *workerSuite) TestLogSending(c *gc.C) {
@@ -74,7 +67,7 @@ func (s *workerSuite) TestLogSending(c *gc.C) {
 	logsCh := make(chan *logsender.LogRecord, logCount)
 
 	// Start the logsender worker.
-	worker := logsender.New(logsCh, gate.AlreadyUnlocked{}, s.agent())
+	worker := logsender.New(logsCh, s.logSenderAPI())
 	defer func() {
 		worker.Kill()
 		c.Check(worker.Wait(), jc.ErrorIsNil)
@@ -99,7 +92,7 @@ func (s *workerSuite) TestLogSending(c *gc.C) {
 		expectedDocs = append(expectedDocs, bson.M{
 			"t": ts,
 			"e": s.State.EnvironUUID(),
-			"n": s.apiInfo.Tag.String(),
+			"n": s.machineTag.String(),
 			"m": "logsender-test",
 			"l": location,
 			"v": int(loggo.INFO),
@@ -131,7 +124,7 @@ func (s *workerSuite) TestDroppedLogs(c *gc.C) {
 	logsCh := make(logsender.LogRecordCh)
 
 	// Start the logsender worker.
-	worker := logsender.New(logsCh, gate.AlreadyUnlocked{}, s.agent())
+	worker := logsender.New(logsCh, s.logSenderAPI())
 	defer func() {
 		worker.Kill()
 		c.Check(worker.Wait(), jc.ErrorIsNil)
@@ -181,31 +174,11 @@ func (s *workerSuite) TestDroppedLogs(c *gc.C) {
 	c.Assert(docs[1], gc.DeepEquals, bson.M{
 		"t": ts, // Should share timestamp with previous message.
 		"e": s.State.EnvironUUID(),
-		"n": s.apiInfo.Tag.String(),
+		"n": s.machineTag.String(),
 		"m": "juju.worker.logsender",
 		"l": "",
 		"v": int(loggo.WARNING),
 		"x": "42 log messages dropped due to lack of API connectivity",
 	})
 	c.Assert(docs[2]["x"], gc.Equals, "message1")
-}
-
-type mockAgent struct {
-	agent.Agent
-	agent.Config
-	apiInfo *api.Info
-}
-
-func (a *mockAgent) CurrentConfig() agent.Config {
-	return a
-}
-
-func (a *mockAgent) APIInfo() *api.Info {
-	return a.apiInfo
-}
-
-type lockedGate struct{}
-
-func (lockedGate) Unlocked() <-chan struct{} {
-	return nil
 }

--- a/worker/metrics/sender/manifold_test.go
+++ b/worker/metrics/sender/manifold_test.go
@@ -4,6 +4,8 @@
 package sender_test
 
 import (
+	"net/url"
+
 	"github.com/juju/names"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -80,6 +82,8 @@ func (s *ManifoldSuite) setupWorkerTest(c *gc.C) worker.Worker {
 	return worker
 }
 
+var _ base.APICaller = (*stubAPICaller)(nil)
+
 type stubAPICaller struct {
 	*testing.Stub
 }
@@ -97,4 +101,8 @@ func (s *stubAPICaller) BestFacadeVersion(facade string) int {
 func (s *stubAPICaller) EnvironTag() (names.EnvironTag, error) {
 	s.MethodCall(s, "EnvironTag")
 	return names.NewEnvironTag("foobar"), nil
+}
+
+func (s *stubAPICaller) ConnectStream(string, url.Values) (base.Stream, error) {
+	panic("should not be called")
 }


### PR DESCRIPTION
The protocol used by logsink and log is the same,
so make the code the same too. We expose a
new abstraction inside the api package, Stream,
which represents a streaming websocket connection
that uses the "first-line-is-error" connection protocol.

We implement an api/logsender package to
hide the low level API protocol details from the worker/logsender
package.

We also unexport the api.State type as it is entirely superceded
by api.Connection and only confusing to expose in the godoc.

Now that we have the websocket protocols consolidated,
we will be able to implement macaroon authentication
in one place.

(Review request: http://reviews.vapour.ws/r/2828/)