### PR TITLE
Set preferred addresses on machine creation

### DIFF
--- a/state/addmachine.go
+++ b/state/addmachine.go
@@ -440,6 +440,10 @@ func (st *State) addMachineInsideNewMachineOps(template, parentTemplate MachineT
 }
 
 func (st *State) machineDocForTemplate(template MachineTemplate, id string) *machineDoc {
+	// We ignore the error from Select*Address as an error indicates
+	// no address is available, in which case the empty address is returned
+	// and setting the preferred address to an empty one is the correct
+	// thing to do when none is available.
 	privateAddr, _ := network.SelectInternalAddress(template.Addresses, false)
 	publicAddr, _ := network.SelectPublicAddress(template.Addresses)
 	return &machineDoc{

--- a/state/addmachine.go
+++ b/state/addmachine.go
@@ -440,19 +440,23 @@ func (st *State) addMachineInsideNewMachineOps(template, parentTemplate MachineT
 }
 
 func (st *State) machineDocForTemplate(template MachineTemplate, id string) *machineDoc {
+	privateAddr, _ := network.SelectInternalAddress(template.Addresses, false)
+	publicAddr, _ := network.SelectPublicAddress(template.Addresses)
 	return &machineDoc{
-		DocID:      st.docID(id),
-		Id:         id,
-		EnvUUID:    st.EnvironUUID(),
-		Series:     template.Series,
-		Jobs:       template.Jobs,
-		Clean:      !template.Dirty,
-		Principals: template.principals,
-		Life:       Alive,
-		Nonce:      template.Nonce,
-		Addresses:  fromNetworkAddresses(template.Addresses),
-		NoVote:     template.NoVote,
-		Placement:  template.Placement,
+		DocID:                   st.docID(id),
+		Id:                      id,
+		EnvUUID:                 st.EnvironUUID(),
+		Series:                  template.Series,
+		Jobs:                    template.Jobs,
+		Clean:                   !template.Dirty,
+		Principals:              template.principals,
+		Life:                    Alive,
+		Nonce:                   template.Nonce,
+		Addresses:               fromNetworkAddresses(template.Addresses),
+		PreferredPrivateAddress: fromNetworkAddress(privateAddr),
+		PreferredPublicAddress:  fromNetworkAddress(publicAddr),
+		NoVote:                  template.NoVote,
+		Placement:               template.Placement,
 	}
 }
 

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -1985,6 +1985,30 @@ func (s *MachineSuite) TestSetProviderAddressesInvalidateMemory(c *gc.C) {
 	c.Assert(machine.Addresses(), jc.SameContents, []network.Address{addr0})
 }
 
+func (s *MachineSuite) TestPublicAddressSetOnNewMachines(c *gc.C) {
+	m, err := s.State.AddOneMachine(state.MachineTemplate{
+		Series:    "quantal",
+		Jobs:      []state.MachineJob{state.JobHostUnits},
+		Addresses: network.NewAddresses("10.0.0.1", "8.8.8.8"),
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	addr, err := m.PublicAddress()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(addr, jc.DeepEquals, network.NewAddress("8.8.8.8"))
+}
+
+func (s *MachineSuite) TestPrivateAddressSetOnNewMachines(c *gc.C) {
+	m, err := s.State.AddOneMachine(state.MachineTemplate{
+		Series:    "quantal",
+		Jobs:      []state.MachineJob{state.JobHostUnits},
+		Addresses: network.NewAddresses("10.0.0.1", "8.8.8.8"),
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	addr, err := m.PrivateAddress()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(addr, jc.DeepEquals, network.NewAddress("10.0.0.1"))
+}
+
 func (s *MachineSuite) TestPublicAddressEmptyAddresses(c *gc.C) {
 	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -1985,7 +1985,7 @@ func (s *MachineSuite) TestSetProviderAddressesInvalidateMemory(c *gc.C) {
 	c.Assert(machine.Addresses(), jc.SameContents, []network.Address{addr0})
 }
 
-func (s *MachineSuite) TestPublicAddressSetOnNewMachines(c *gc.C) {
+func (s *MachineSuite) TestPublicAddressSetOnNewMachine(c *gc.C) {
 	m, err := s.State.AddOneMachine(state.MachineTemplate{
 		Series:    "quantal",
 		Jobs:      []state.MachineJob{state.JobHostUnits},
@@ -1997,7 +1997,7 @@ func (s *MachineSuite) TestPublicAddressSetOnNewMachines(c *gc.C) {
 	c.Assert(addr, jc.DeepEquals, network.NewAddress("8.8.8.8"))
 }
 
-func (s *MachineSuite) TestPrivateAddressSetOnNewMachines(c *gc.C) {
+func (s *MachineSuite) TestPrivateAddressSetOnNewMachine(c *gc.C) {
 	m, err := s.State.AddOneMachine(state.MachineTemplate{
 		Series:    "quantal",
 		Jobs:      []state.MachineJob{state.JobHostUnits},


### PR DESCRIPTION
Fix for issue #1499571 

Newly created machines now have preferred addresses set from the provided template.

(Review request: http://reviews.vapour.ws/r/2835/)