### PR TITLE
api: implement macaroon authentication on streaming endpoints

### DIFF
--- a/api/client_test.go
+++ b/api/client_test.go
@@ -6,7 +6,6 @@ package api_test
 import (
 	"bufio"
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -608,13 +607,10 @@ func (r *badReader) Read(p []byte) (n int, err error) {
 }
 
 func echoURL(c *gc.C) func(*websocket.Config) (base.Stream, error) {
-	response := &params.ErrorResult{}
-	message, err := json.Marshal(response)
-	c.Assert(err, jc.ErrorIsNil)
 	return func(config *websocket.Config) (base.Stream, error) {
 		pr, pw := io.Pipe()
 		go func() {
-			fmt.Fprintf(pw, "%s\n", message)
+			fmt.Fprintf(pw, "null\n")
 			fmt.Fprintf(pw, "%s\n", config.Location)
 		}()
 		return fakeStreamReader{pr}, nil

--- a/apiserver/admin.go
+++ b/apiserver/admin.go
@@ -88,8 +88,10 @@ func (a *admin) doLogin(req params.LoginRequest, loginVersion int) (params.Login
 	if err != nil {
 		if err, ok := errors.Cause(err).(*common.DischargeRequiredError); ok {
 			loginResult := params.LoginResultV1{
-				DischargeRequired: err.Macaroon,
+				DischargeRequired:       err.Macaroon,
+				DischargeRequiredReason: err.Error(),
 			}
+			logger.Infof("login failed with discharge-required error: %v", err)
 			return loginResult, nil
 		}
 		if a.maintenanceInProgress() {

--- a/apiserver/admin_test.go
+++ b/apiserver/admin_test.go
@@ -1030,7 +1030,7 @@ func (s *macaroonLoginSuite) TestFailedToObtainDischargeLogin(c *gc.C) {
 		return nil, errors.New("unknown caveat")
 	}
 	err := s.client.Login(nil, "", "")
-	c.Assert(err, gc.ErrorMatches, "failed to obtain the macaroon discharge.*cannot discharge: unknown caveat")
+	c.Assert(err, gc.ErrorMatches, `cannot get discharge from "https://.*": third party refused discharge: cannot discharge: unknown caveat`)
 }
 
 func (s *macaroonLoginSuite) TestUnknownUserLogin(c *gc.C) {

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -626,6 +626,10 @@ type LoginResultV1 struct {
 	// here.
 	DischargeRequired *macaroon.Macaroon `json:"discharge-required,omitempty"`
 
+	// DischargeRequiredReason holds the reason that the above discharge was
+	// required.
+	DischargeRequiredReason string `json:"discharge-required-error,omitempty"`
+
 	// Servers is the list of API server addresses.
 	Servers [][]HostPort `json:"servers,omitempty"`
 

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -42,7 +42,7 @@ gopkg.in/goose.v1	git	be6030ce33a6d77f5e9c63b7698030e6431d5343	2015-08-24T15:19:
 gopkg.in/juju/charm.v6-unstable	git	49f6312f83592ab73309a9de5987d49a789c806c	2015-09-02T21:57:54Z
 gopkg.in/juju/charmrepo.v1	git	8677b12d9772a2a596a99e65b7e6f642fceb6c40	2015-09-14T13:26:00Z
 gopkg.in/juju/charmstore.v5-unstable	git	a921c6c69d74361c38a99a95d2aceec76533038d	2015-08-27T20:19:40Z
-gopkg.in/juju/environschema.v1	git	16cc59268c09c22870cb4de8eb6248652535f315	2015-08-24T13:22:26Z
+gopkg.in/juju/environschema.v1	git	e2de5f6100c8cdd6f631983b1774b290ab076d88	2015-09-28T14:16:13Z
 gopkg.in/juju/jujusvg.v1	git	3eedb1c722ece2b66d62508368ca3e8b7f916569	2015-05-20T11:48:32Z
 gopkg.in/macaroon-bakery.v1	git	f058441861bbd00d8dea526e9f2e8869fbba1448	2015-10-05T11:20:23Z
 gopkg.in/macaroon.v1	git	ab3940c6c16510a850e1c2dd628b919f0f3f1464	2015-01-21T11:42:31Z
@@ -50,6 +50,7 @@ gopkg.in/mgo.v2	git	3569c88678d88179dcbd68d02ab081cbca3cd4d0	2015-06-04T15:26:27
 gopkg.in/natefinch/lumberjack.v2	git	588a21fb0fa0ebdfde42670fa214576b6f0f22df	2015-05-21T01:59:18Z
 gopkg.in/natefinch/npipe.v2	git	e562d4ae5c2f838f9e7e406f7d9890d5b02467a9	2014-08-11T16:19:00Z
 gopkg.in/yaml.v1	git	9f9df34309c04878acc86042b16630b0f696e1de	2014-09-24T16:16:07Z
+gopkg.in/yaml.v2	git	7ad95dd0798a40da1ccdff6dff35fd177b5edf40	2015-06-24T10:29:02Z
 launchpad.net/gnuflag	bzr	roger.peppe@canonical.com-20140716064605-pk32dnmfust02yab	13
 launchpad.net/golxc	bzr	ian.booth@canonical.com-20141121040613-ztm1q0iy9rune3zt	13
 launchpad.net/gomaasapi	bzr	michael.foord@canonical.com-20150703101140-oo7493pkzlzg7l6u	63


### PR DESCRIPTION
We also make sure that we store API server macaroons as cookies
so that we don't need to discharge them twice, once when we connect
to the websocket API and once again when we connect to any other
endpoint.

(Review request: http://reviews.vapour.ws/r/2838/)