### PR TITLE
Reintroduce storage feature flag for 1.24

### DIFF
--- a/apiserver/service/service_test.go
+++ b/apiserver/service/service_test.go
@@ -6,11 +6,13 @@ package service_test
 import (
 	"fmt"
 	"io"
+	"os"
 	"sync"
 
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
+	"github.com/juju/utils/featureflag"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v5"
 	"gopkg.in/juju/charmstore.v4/csclient"
@@ -22,6 +24,8 @@ import (
 	"github.com/juju/juju/apiserver/service"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/constraints"
+	"github.com/juju/juju/feature"
+	"github.com/juju/juju/juju/osenv"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/state"
 	statestorage "github.com/juju/juju/state/storage"
@@ -64,6 +68,7 @@ func (s *serviceSuite) SetUpTest(c *gc.C) {
 
 	s.CharmStoreSuite.Session = s.JujuConnSuite.Session
 	s.CharmStoreSuite.SetUpTest(c)
+	enableStorageFeature()
 
 	s.service = s.Factory.MakeService(c, nil)
 
@@ -78,6 +83,13 @@ func (s *serviceSuite) SetUpTest(c *gc.C) {
 func (s *serviceSuite) TearDownTest(c *gc.C) {
 	s.CharmStoreSuite.TearDownTest(c)
 	s.JujuConnSuite.TearDownTest(c)
+}
+
+func enableStorageFeature() {
+	if err := os.Setenv(osenv.JujuFeatureFlagEnvKey, feature.Storage); err != nil {
+		panic(err)
+	}
+	featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
 }
 
 func (s *serviceSuite) TestSetMetricCredentials(c *gc.C) {

--- a/apiserver/uniter/storage_test.go
+++ b/apiserver/uniter/storage_test.go
@@ -5,15 +5,19 @@ package uniter_test
 
 import (
 	"errors"
+	"os"
 
 	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/featureflag"
 	gc "gopkg.in/check.v1"
 	"launchpad.net/tomb"
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/apiserver/uniter"
+	"github.com/juju/juju/feature"
+	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/testing"
 )
@@ -24,6 +28,18 @@ type storageSuite struct {
 }
 
 var _ = gc.Suite(&storageSuite{})
+
+func (s *storageSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+	enableStorageFeature()
+}
+
+func enableStorageFeature() {
+	if err := os.Setenv(osenv.JujuFeatureFlagEnvKey, feature.Storage); err != nil {
+		panic(err)
+	}
+	featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
+}
 
 func (s *storageSuite) TestWatchUnitStorageAttachments(c *gc.C) {
 	resources := common.NewResources()

--- a/apiserver/uniter/uniter_v2_test.go
+++ b/apiserver/uniter/uniter_v2_test.go
@@ -29,6 +29,7 @@ var _ = gc.Suite(&uniterV2Suite{})
 
 func (s *uniterV2Suite) SetUpTest(c *gc.C) {
 	s.uniterBaseSuite.setUpTest(c)
+	enableStorageFeature()
 
 	uniterAPIV2, err := uniter.NewUniterAPIV2(
 		s.State,

--- a/cmd/juju/deploy.go
+++ b/cmd/juju/deploy.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/names"
+	"github.com/juju/utils/featureflag"
 	"gopkg.in/juju/charm.v5"
 	"launchpad.net/gnuflag"
 
@@ -20,6 +21,7 @@ import (
 	"github.com/juju/juju/cmd/juju/block"
 	"github.com/juju/juju/cmd/juju/service"
 	"github.com/juju/juju/constraints"
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/storage"
 )
@@ -135,7 +137,9 @@ func (c *DeployCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.Var(constraints.ConstraintsValue{Target: &c.Constraints}, "constraints", "set service constraints")
 	f.StringVar(&c.Networks, "networks", "", "bind the service to specific networks")
 	f.StringVar(&c.RepoPath, "repository", os.Getenv(osenv.JujuRepositoryEnvKey), "local charm repository")
-	f.Var(storageFlag{&c.Storage}, "storage", "charm storage constraints")
+	if featureflag.Enabled(feature.Storage) {
+		f.Var(storageFlag{&c.Storage}, "storage", "charm storage constraints")
+	}
 }
 
 func (c *DeployCommand) Init(args []string) error {

--- a/cmd/juju/deploy_test.go
+++ b/cmd/juju/deploy_test.go
@@ -218,6 +218,8 @@ func (s *DeploySuite) TestNetworks(c *gc.C) {
 // TODO(wallyworld) - add another test that deploy with storage fails for older environments
 // (need deploy client to be refactored to use API stub)
 func (s *DeploySuite) TestStorage(c *gc.C) {
+	setFeatureFlags("storage")
+
 	pm := poolmanager.New(state.NewStateSettings(s.State))
 	_, err := pm.Create("loop-pool", provider.LoopProviderType, map[string]interface{}{"foo": "bar"})
 	c.Assert(err, jc.ErrorIsNil)
@@ -242,6 +244,11 @@ func (s *DeploySuite) TestStorage(c *gc.C) {
 			Size:  1024,
 		},
 	})
+}
+
+func (s *DeploySuite) TestStorageDisabled(c *gc.C) {
+	err := runDeploy(c, "local:storage-block", "--storage", "data=loop-pool,1G")
+	c.Assert(err, gc.ErrorMatches, "flag provided but not defined: --storage")
 }
 
 func (s *DeploySuite) TestSubordinateConstraints(c *gc.C) {

--- a/cmd/juju/storage/storage_test.go
+++ b/cmd/juju/storage/storage_test.go
@@ -4,9 +4,16 @@
 package storage_test
 
 import (
+	"os"
+
+	"github.com/juju/cmd"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cmd/juju/storage"
+	"github.com/juju/juju/feature"
+	"github.com/juju/juju/juju/osenv"
+	"github.com/juju/juju/testing"
+	"github.com/juju/utils/featureflag"
 )
 
 var expectedSubCommmandNames = []string{
@@ -25,6 +32,26 @@ type storageSuite struct {
 var _ = gc.Suite(&storageSuite{})
 
 func (s *storageSuite) TestHelp(c *gc.C) {
+	enableStorageFeature()
 	s.command = storage.NewSuperCommand().(*storage.Command)
 	s.assertHelp(c, expectedSubCommmandNames)
+}
+
+func (s *storageSuite) TestDisabled(c *gc.C) {
+	storageCommand := storage.NewSuperCommand()
+	ctx := testing.Context(c)
+	code := cmd.Main(storageCommand, ctx, nil)
+	c.Assert(testing.Stderr(ctx), gc.Equals, `
+Enable experimental storage support by setting JUJU_DEV_FEATURE_FLAGS=storage.
+
+error: storage is disabled
+`[1:])
+	c.Assert(code, gc.Equals, 1)
+}
+
+func enableStorageFeature() {
+	if err := os.Setenv(osenv.JujuFeatureFlagEnvKey, feature.Storage); err != nil {
+		panic(err)
+	}
+	featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
 }

--- a/feature/flags.go
+++ b/feature/flags.go
@@ -48,3 +48,6 @@ const CloudSigma = "cloudsigma"
 
 // VSphereProvider enables the generic vmware provider.
 const VSphereProvider = "vsphere-provider"
+
+// Storage enables storage support.
+const Storage = "storage"

--- a/featuretests/storage_test.go
+++ b/featuretests/storage_test.go
@@ -4,16 +4,20 @@
 package featuretests
 
 import (
+	"os"
 	"strings"
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/featureflag"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cmd/envcmd"
 	cmdstorage "github.com/juju/juju/cmd/juju/storage"
+	"github.com/juju/juju/feature"
+	"github.com/juju/juju/juju/osenv"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/provider/ec2"
 	"github.com/juju/juju/state"
@@ -29,6 +33,11 @@ const (
 )
 
 func setupTestStorageSupport(c *gc.C, s *state.State) {
+	if err := os.Setenv(osenv.JujuFeatureFlagEnvKey, feature.Storage); err != nil {
+		panic(err)
+	}
+	featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
+
 	stsetts := state.NewStateSettings(s)
 	poolManager := poolmanager.New(stsetts)
 	_, err := poolManager.Create(testPool, provider.LoopProviderType, map[string]interface{}{"it": "works"})

--- a/state/conn_test.go
+++ b/state/conn_test.go
@@ -10,6 +10,7 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/mgo.v2"
 
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/state"
 	statetesting "github.com/juju/juju/state/testing"
 	"github.com/juju/juju/testing"
@@ -45,6 +46,7 @@ func (cs *ConnSuite) SetUpTest(c *gc.C) {
 	cs.StateSuite.Policy = &cs.policy
 
 	cs.StateSuite.SetUpTest(c)
+	setFeatureFlags(feature.Storage)
 
 	cs.envTag = cs.State.EnvironTag()
 	cs.factory = factory.NewFactory(cs.State)

--- a/worker/uniter/filter/filter_test.go
+++ b/worker/uniter/filter/filter_test.go
@@ -5,11 +5,13 @@ package filter_test
 
 import (
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
+	"github.com/juju/utils/featureflag"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v5"
 	"launchpad.net/tomb"
@@ -17,6 +19,8 @@ import (
 	"github.com/juju/juju/api"
 	apiuniter "github.com/juju/juju/api/uniter"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/feature"
+	"github.com/juju/juju/juju/osenv"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
@@ -42,6 +46,12 @@ var _ = gc.Suite(&FilterSuite{})
 
 func (s *FilterSuite) SetUpTest(c *gc.C) {
 	s.JujuConnSuite.SetUpTest(c)
+
+	if err := os.Setenv(osenv.JujuFeatureFlagEnvKey, feature.Storage); err != nil {
+		panic(err)
+	}
+	featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
+
 	s.wpcharm = s.AddTestingCharm(c, "wordpress")
 	s.wordpress = s.AddTestingService(c, "wordpress", s.wpcharm)
 	var err error

--- a/worker/uniter/runner/factory_test.go
+++ b/worker/uniter/runner/factory_test.go
@@ -46,6 +46,7 @@ func (fakeTracker) ServiceName() string {
 
 func (s *FactorySuite) SetUpTest(c *gc.C) {
 	s.HookContextSuite.SetUpTest(c)
+	enableStorageFeature()
 	s.paths = NewRealPaths(c)
 	s.membership = map[int][]string{}
 	factory, err := runner.NewFactory(

--- a/worker/uniter/runner/unitStorage_test.go
+++ b/worker/uniter/runner/unitStorage_test.go
@@ -4,13 +4,18 @@
 package runner_test
 
 import (
+	"os"
+
 	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
+	"github.com/juju/utils/featureflag"
 	"github.com/juju/utils/set"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/feature"
+	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/provider/ec2"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/storage/poolmanager"
@@ -135,6 +140,8 @@ func (s *unitStorageSuite) TestAddUnitStorageAccumulatedSame(c *gc.C) {
 }
 
 func setupTestStorageSupport(c *gc.C, s *state.State) {
+	enableStorageFeature()
+
 	stsetts := state.NewStateSettings(s)
 	poolManager := poolmanager.New(stsetts)
 	_, err := poolManager.Create(testPool, provider.LoopProviderType, map[string]interface{}{"it": "works"})
@@ -144,6 +151,13 @@ func setupTestStorageSupport(c *gc.C, s *state.State) {
 
 	registry.RegisterEnvironStorageProviders("dummy", ec2.EBS_ProviderType)
 	registry.RegisterEnvironStorageProviders("dummyenv", ec2.EBS_ProviderType)
+}
+
+func enableStorageFeature() {
+	if err := os.Setenv(osenv.JujuFeatureFlagEnvKey, feature.Storage); err != nil {
+		panic(err)
+	}
+	featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
 }
 
 func (s *unitStorageSuite) createStorageEnabledUnit(c *gc.C) {

--- a/worker/uniter/uniter_test.go
+++ b/worker/uniter/uniter_test.go
@@ -18,11 +18,14 @@ import (
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	ft "github.com/juju/testing/filetesting"
+	"github.com/juju/utils/featureflag"
 	gc "gopkg.in/check.v1"
 	corecharm "gopkg.in/juju/charm.v5"
 
 	"github.com/juju/juju/agent/tools"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/feature"
+	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/lease"
@@ -88,9 +91,17 @@ func (s *UniterSuite) TearDownSuite(c *gc.C) {
 func (s *UniterSuite) SetUpTest(c *gc.C) {
 	s.GitSuite.SetUpTest(c)
 	s.JujuConnSuite.SetUpTest(c)
+	enableStorageFeature()
 	s.ticker = uniter.NewManualTicker()
 	s.PatchValue(uniter.ActiveMetricsTimer, s.ticker.ReturnTimer)
 	s.PatchValue(uniter.IdleWaitTime, 1*time.Millisecond)
+}
+
+func enableStorageFeature() {
+	if err := os.Setenv(osenv.JujuFeatureFlagEnvKey, feature.Storage); err != nil {
+		panic(err)
+	}
+	featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
 }
 
 func (s *UniterSuite) TearDownTest(c *gc.C) {


### PR DESCRIPTION
Storage was classified as experimental in 1.24, and has been found to be
problematic. Since storage is used implicitly by charms with default
stores, we should disable it to prevent breaking deployments.

Fixes https://bugs.launchpad.net/juju-core/+bug/1503740

(Review request: http://reviews.vapour.ws/r/2841/)