### PR TITLE
Use latest charm.v6-unstable to fix JSON RPC serialization issues.

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -39,7 +39,7 @@ gopkg.in/amz.v3	git	bff3a097c4108da57bb8cbe3aad2990d74d23676	2015-08-20T12:28:33
 gopkg.in/check.v1	git	b3d3430320d4260e5fea99841af984b3badcea63	2015-06-26T10:50:28Z
 gopkg.in/errgo.v1	git	15098963088579c1cd9eb1a7da285831e548390b	2015-07-07T18:34:45Z
 gopkg.in/goose.v1	git	be6030ce33a6d77f5e9c63b7698030e6431d5343	2015-08-24T15:19:40Z
-gopkg.in/juju/charm.v6-unstable	git	1e471da773d8f6cf11c689e4a303c2211bdb6f21	2015-09-22T09:50:16Z
+gopkg.in/juju/charm.v6-unstable	git	df4f3d493649ae0abf547e87a1149b4db713ddb1	2015-10-05T09:54:00Z
 gopkg.in/juju/charmrepo.v1	git	8677b12d9772a2a596a99e65b7e6f642fceb6c40	2015-09-14T13:26:00Z
 gopkg.in/juju/charmstore.v5-unstable	git	475920bf612769da77969237ed511a921fb785be	2015-09-16T09:44:01Z
 gopkg.in/juju/environschema.v1	git	16cc59268c09c22870cb4de8eb6248652535f315	2015-08-24T13:22:26Z


### PR DESCRIPTION
Fixes LP:#1501563

(Review request: http://reviews.vapour.ws/r/2847/)