### PR TITLE
api: add tests for charm upload with macaroon authentication

### DIFF
--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -80,7 +80,11 @@ type state struct {
 	// closed is a channel that gets closed when State.Close is called.
 	closed chan struct{}
 
+	// loggedIn holds whether the client has successfully logged in.
+	loggedIn bool
+
 	// tag and password and nonce hold the cached login credentials.
+	// These are only valid if loggedIn is true.
 	tag      string
 	password string
 	nonce    string
@@ -278,6 +282,9 @@ func tlsConfigForCACert(caCert string) (*tls.Config, error) {
 
 // ConnectStream implements Connection.ConnectStream.
 func (st *state) ConnectStream(path string, attrs url.Values) (base.Stream, error) {
+	if !st.loggedIn {
+		return nil, errors.New("cannot use ConnectStream without logging in")
+	}
 	// We use the standard "macaraq" macaroon authentication dance here.
 	// That is, we attach any macaroons we have to the initial request,
 	// and if that succeeds, all's good. If it fails with a DischargeRequired

--- a/api/backups/client.go
+++ b/api/backups/client.go
@@ -4,10 +4,10 @@
 package backups
 
 import (
-	"github.com/juju/loggo"
-
 	"github.com/juju/errors"
 	"github.com/juju/httprequest"
+	"github.com/juju/loggo"
+
 	"github.com/juju/juju/api/base"
 )
 

--- a/api/backups/download.go
+++ b/api/backups/download.go
@@ -8,8 +8,8 @@ import (
 	"net/http"
 
 	"github.com/juju/errors"
-
 	"github.com/juju/httprequest"
+
 	"github.com/juju/juju/apiserver/params"
 )
 

--- a/api/client_macaroon_test.go
+++ b/api/client_macaroon_test.go
@@ -1,0 +1,78 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package api_test
+
+import (
+	"fmt"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/charm.v6-unstable"
+
+	"github.com/juju/juju/api"
+	apitesting "github.com/juju/juju/api/testing"
+	"github.com/juju/juju/testcharms"
+)
+
+var _ = gc.Suite(&clientMacaroonSuite{})
+
+// clientMacaroonSuite tests that Client endpoints that are
+// independent of the RPC-based API work with
+// macaroon authentication.
+type clientMacaroonSuite struct {
+	apitesting.MacaroonSuite
+	client    *api.Client
+	cookieJar *apitesting.ClearableCookieJar
+}
+
+func (s *clientMacaroonSuite) SetUpTest(c *gc.C) {
+	s.MacaroonSuite.SetUpTest(c)
+	s.AddUser(c, "testuser")
+	s.cookieJar = apitesting.NewClearableCookieJar()
+	s.DischargerLogin = func() string { return "testuser" }
+	s.client = s.OpenAPI(c, nil, s.cookieJar).Client()
+
+	// Even though we've logged into the API, we want
+	// the tests below to exercise the discharging logic
+	// so we clear the cookies.
+	s.cookieJar.Clear()
+}
+
+func (s *clientMacaroonSuite) TearDownTest(c *gc.C) {
+	s.client.Close()
+	s.MacaroonSuite.TearDownTest(c)
+}
+
+func (s *clientMacaroonSuite) TestAddLocalCharmWithFailedDischarge(c *gc.C) {
+	s.DischargerLogin = func() string { return "" }
+	charmArchive := testcharms.Repo.CharmArchive(c.MkDir(), "dummy")
+	curl := charm.MustParseURL(
+		fmt.Sprintf("local:quantal/%s-%d", charmArchive.Meta().Name, charmArchive.Revision()),
+	)
+	savedURL, err := s.client.AddLocalCharm(curl, charmArchive)
+	c.Assert(err, gc.ErrorMatches, `POST https://.*/environment/deadbeef-0bad-400d-8000-4b1d0d06f00d/charms\?series=quantal: cannot get discharge from "https://.*": third party refused discharge: cannot discharge: login denied by discharger`)
+	c.Assert(savedURL, gc.IsNil)
+}
+
+func (s *clientMacaroonSuite) TestAddLocalCharmSuccess(c *gc.C) {
+	charmArchive := testcharms.Repo.CharmArchive(c.MkDir(), "dummy")
+	curl := charm.MustParseURL(
+		fmt.Sprintf("local:quantal/%s-%d", charmArchive.Meta().Name, charmArchive.Revision()),
+	)
+	// Upload an archive with its original revision.
+	savedURL, err := s.client.AddLocalCharm(curl, charmArchive)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(savedURL.String(), gc.Equals, curl.String())
+}
+
+func (s *clientMacaroonSuite) TestAddLocalCharmUnauthorized(c *gc.C) {
+	s.DischargerLogin = func() string { return "baduser" }
+	charmArchive := testcharms.Repo.CharmArchive(c.MkDir(), "dummy")
+	curl := charm.MustParseURL(
+		fmt.Sprintf("local:quantal/%s-%d", charmArchive.Meta().Name, charmArchive.Revision()),
+	)
+	// Upload an archive with its original revision.
+	_, err := s.client.AddLocalCharm(curl, charmArchive)
+	c.Assert(err, gc.ErrorMatches, `POST https://.*/environment/deadbeef-0bad-400d-8000-4b1d0d06f00d/charms\?series=quantal: invalid entity name or password`)
+}

--- a/api/http.go
+++ b/api/http.go
@@ -18,6 +18,9 @@ import (
 
 // HTTPClient implements Connection.APICaller.HTTPClient.
 func (s *state) HTTPClient() (*httprequest.Client, error) {
+	if !s.loggedIn {
+		return nil, errors.New("no HTTP client available without logging in")
+	}
 	baseURL, err := s.apiEndpoint("/", "")
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/api/state.go
+++ b/api/state.go
@@ -197,6 +197,7 @@ func (st *state) setLoginResult(tag names.Tag, environTag, serverTag string, ser
 	for _, facade := range facades {
 		st.facadeVersions[facade.Name] = facade.Versions
 	}
+	st.loggedIn = true
 	return nil
 }
 

--- a/api/subnets/subnets_test.go
+++ b/api/subnets/subnets_test.go
@@ -6,6 +6,7 @@ package subnets_test
 import (
 	"errors"
 
+	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -15,7 +16,6 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/network"
 	coretesting "github.com/juju/juju/testing"
-	"github.com/juju/names"
 )
 
 // SubnetsSuite tests the client side subnets API

--- a/api/testing/macaroonsuite.go
+++ b/api/testing/macaroonsuite.go
@@ -1,0 +1,137 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package testing
+
+import (
+	"net/http"
+	"net/http/cookiejar"
+	"net/url"
+
+	"github.com/juju/errors"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/macaroon-bakery.v1/bakery/checkers"
+	"gopkg.in/macaroon-bakery.v1/bakerytest"
+	"gopkg.in/macaroon-bakery.v1/httpbakery"
+
+	"github.com/juju/juju/api"
+	"github.com/juju/juju/environs/config"
+	jujutesting "github.com/juju/juju/juju/testing"
+	"github.com/juju/juju/testing/factory"
+)
+
+// MacaroonSuite wraps a JujuConnSuite with macaroon authentication
+// enabled.
+type MacaroonSuite struct {
+	jujutesting.JujuConnSuite
+
+	// discharger holds the third-party discharger used
+	// for authentication.
+	discharger *bakerytest.Discharger
+
+	// DischargerLogin is called by the discharger when an
+	// API macaroon is discharged. It should either return
+	// the chosen username or an empty string, in which case
+	// the discharge is denied.
+	// If this is nil, func() {return ""} is implied.
+	DischargerLogin func() string
+}
+
+func (s *MacaroonSuite) SetUpTest(c *gc.C) {
+	s.discharger = bakerytest.NewDischarger(nil, func(req *http.Request, cond, arg string) ([]checkers.Caveat, error) {
+		if cond != "is-authenticated-user" {
+			return nil, errors.New("unknown caveat")
+		}
+		var username string
+		if s.DischargerLogin != nil {
+			username = s.DischargerLogin()
+		}
+		if username == "" {
+			return nil, errors.New("login denied by discharger")
+		}
+		return []checkers.Caveat{checkers.DeclaredCaveat("username", username)}, nil
+	})
+	s.JujuConnSuite.ConfigAttrs = map[string]interface{}{
+		config.IdentityURL: s.discharger.Location(),
+	}
+	s.JujuConnSuite.SetUpTest(c)
+}
+
+func (s *MacaroonSuite) TearDownTest(c *gc.C) {
+	s.discharger.Close()
+	s.JujuConnSuite.TearDownTest(c)
+}
+
+// AddUser adds a new user to the user database.
+func (s *MacaroonSuite) AddUser(c *gc.C, name string) {
+	s.Factory.MakeUser(c, &factory.UserParams{
+		Name: name,
+	})
+}
+
+// OpenAPI opens a connection to the API using the given information.
+// and empty DialOpts. If info is nil, s.APIInfo(c) is used.
+// If jar is non-nil, it will be used as the store for the cookies created
+// as a result of API interaction.
+func (s *MacaroonSuite) OpenAPI(c *gc.C, info *api.Info, jar http.CookieJar) api.Connection {
+	if info == nil {
+		info = s.APIInfo(c)
+	}
+	bakeryClient := httpbakery.NewClient()
+	if jar != nil {
+		bakeryClient.Client.Jar = jar
+	}
+	conn, err := api.Open(info, api.DialOpts{
+		BakeryClient: bakeryClient,
+	})
+	c.Assert(err, gc.IsNil)
+	return conn
+}
+
+// APIInfo returns API connection info suitable for
+// connecting to the API using macaroon authentication.
+func (s *MacaroonSuite) APIInfo(c *gc.C) *api.Info {
+	info := s.JujuConnSuite.APIInfo(c)
+	info.Tag = nil
+	info.Password = ""
+	info.UseMacaroons = true
+	return info
+}
+
+// NewClearableCookieJar returns a new ClearableCookieJar.
+func NewClearableCookieJar() *ClearableCookieJar {
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		panic(err)
+	}
+	return &ClearableCookieJar{
+		jar: jar,
+	}
+}
+
+// ClearableCookieJar implements a cookie jar
+// that can be cleared of all cookies for testing purposes.
+type ClearableCookieJar struct {
+	jar http.CookieJar
+}
+
+// Clear clears all the cookies in the jar.
+// It is not OK to call Clear concurrently
+// with the other methods.
+func (jar *ClearableCookieJar) Clear() {
+	newJar, err := cookiejar.New(nil)
+	if err != nil {
+		panic(err)
+	}
+	jar.jar = newJar
+}
+
+// Cookies implements http.CookieJar.Cookies.
+func (jar *ClearableCookieJar) Cookies(u *url.URL) []*http.Cookie {
+	return jar.jar.Cookies(u)
+}
+
+// Cookies implements http.CookieJar.SetCookies.
+func (jar *ClearableCookieJar) SetCookies(u *url.URL, cookies []*http.Cookie) {
+	jar.jar.SetCookies(u, cookies)
+}


### PR DESCRIPTION
We also ensure that ConnectStream and HTTPClient cannot be
used when the API connection hasn't been logged in,
and factor out a test suite to make it easy to test macaroon
authentication in other places.


(Review request: http://reviews.vapour.ws/r/2852/)