### PR TITLE
agent: SetAPIHostPorts now uses all candidate addresses for each server (1.24)

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -500,10 +500,7 @@ func (c *configInternal) SetAPIHostPorts(servers [][]network.HostPort) {
 	}
 	var addrs []string
 	for _, serverHostPorts := range servers {
-		addr := network.SelectInternalHostPort(serverHostPorts, false)
-		if addr != "" {
-			addrs = append(addrs, addr)
-		}
+		addrs = append(addrs, network.SelectInternalHostPorts(serverHostPorts, false)...)
 	}
 	c.apiDetails.addresses = addrs
 }

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -682,27 +682,42 @@ func (*suite) TestSetAPIHostPorts(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(addrs, gc.DeepEquals, attributeParams.APIAddresses)
 
-	// The first cloud-local address for each server is used,
-	// else if there are none then the first public- or unknown-
-	// scope address.
+	// All the best candidate addresses for each server are
+	// used. Cloud-local addresses are preferred.  Otherwise the first
+	// public or unknown scope addresses are used.
 	//
 	// If a server has only machine-local addresses, or none
 	// at all, then it will be excluded.
-	server1 := network.NewAddresses("0.1.2.3", "0.1.2.4", "zeroonetwothree")
+	server1 := network.NewAddresses("0.1.0.1", "0.1.0.2", "host.com")
 	server1[0].Scope = network.ScopeCloudLocal
 	server1[1].Scope = network.ScopeCloudLocal
 	server1[2].Scope = network.ScopePublic
-	server2 := network.NewAddresses("127.0.0.1")
-	server2[0].Scope = network.ScopeMachineLocal
-	server3 := network.NewAddresses("0.1.2.5", "zeroonetwofive")
-	server3[0].Scope = network.ScopeUnknown
-	server3[1].Scope = network.ScopeUnknown
+
+	server2 := network.NewAddresses("0.2.0.1", "0.2.0.2")
+	server2[0].Scope = network.ScopePublic
+	server2[1].Scope = network.ScopePublic
+
+	server3 := network.NewAddresses("127.0.0.1")
+	server3[0].Scope = network.ScopeMachineLocal
+
+	server4 := network.NewAddresses("0.4.0.1", "elsewhere.net")
+	server4[0].Scope = network.ScopeUnknown
+	server4[1].Scope = network.ScopeUnknown
+
 	conf.SetAPIHostPorts([][]network.HostPort{
-		network.AddressesWithPort(server1, 123),
-		network.AddressesWithPort(server2, 124),
-		network.AddressesWithPort(server3, 125),
+		network.AddressesWithPort(server1, 1111),
+		network.AddressesWithPort(server2, 2222),
+		network.AddressesWithPort(server3, 3333),
+		network.AddressesWithPort(server4, 4444),
 	})
 	addrs, err = conf.APIAddresses()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(addrs, gc.DeepEquals, []string{"0.1.2.3:123", "0.1.2.5:125"})
+	c.Assert(addrs, gc.DeepEquals, []string{
+		"0.1.0.1:1111",
+		"0.1.0.2:1111",
+		"0.2.0.1:2222",
+		"0.2.0.2:2222",
+		"0.4.0.1:4444",
+		"elsewhere.net:4444",
+	})
 }

--- a/network/address.go
+++ b/network/address.go
@@ -248,7 +248,7 @@ func SelectPublicHostPort(hps []HostPort) string {
 // SelectInternalAddress picks one address from a slice that can be
 // used as an endpoint for juju internal communication. If there are
 // are no suitable addresses, then ok is false (and an empty address is
-// returned). If a suitable address is then ok is true.
+// returned). If a suitable address was found then ok is true.
 func SelectInternalAddress(addresses []Address, machineLocal bool) (Address, bool) {
 	index := bestAddressIndex(len(addresses), globalPreferIPv6, func(i int) Address {
 		return addresses[i]
@@ -271,6 +271,22 @@ func SelectInternalHostPort(hps []HostPort, machineLocal bool) string {
 		return ""
 	}
 	return hps[index].NetAddr()
+}
+
+// SelectInternalHostPorts picks the best matching HostPorts from a
+// slice that can be used as an endpoint for juju internal
+// communication and returns them in NetAddr form. If there are no
+// suitable addresses, an empty slice is returned.
+func SelectInternalHostPorts(hps []HostPort, machineLocal bool) []string {
+	indexes := bestAddressIndexes(len(hps), globalPreferIPv6, func(i int) Address {
+		return hps[i].Address
+	}, internalAddressMatcher(machineLocal))
+
+	out := make([]string, 0, len(indexes))
+	for _, index := range indexes {
+		out = append(out, hps[index].NetAddr())
+	}
+	return out
 }
 
 func publicMatch(addr Address, preferIPv6 bool) scopeMatch {
@@ -335,61 +351,43 @@ const (
 	mismatchedTypeFallbackScope
 )
 
-// bestAddressIndex returns the index of the first address
-// with an exactly matching scope, or the first address with
-// a matching fallback scope if there are no exact matches, or
-// a matching scope but mismatched type when preferIPv6 is true.
-// If there are no suitable addresses, -1 is returned.
+// bestAddressIndexes returns the indexes of the addresses with the
+// best matching scope (according to the match func). An empty slice
+// is returned if there were no suitable addresses.
 func bestAddressIndex(numAddr int, preferIPv6 bool, getAddr func(i int) Address, match func(addr Address, preferIPv6 bool) scopeMatch) int {
-	fallbackAddressIndex := -1
-	mismatchedTypeFallbackIndex := -1
-	mismatchedTypeExactIndex := -1
+	indexes := bestAddressIndexes(numAddr, preferIPv6, getAddr, match)
+	if len(indexes) > 0 {
+		return indexes[0]
+	}
+	return -1
+}
+
+// bestAddressIndexes returns the indexes of the addresses with the
+// best matching scope and type (according to the match func). An
+// empty slice is returned if there were no suitable addresses.
+func bestAddressIndexes(numAddr int, preferIPv6 bool, getAddr func(i int) Address, match func(addr Address, preferIPv6 bool) scopeMatch) []int {
+	// Categorise addresses by scope and type matching quality.
+	matches := make(map[scopeMatch][]int)
 	for i := 0; i < numAddr; i++ {
-		addr := getAddr(i)
-		switch match(addr, preferIPv6) {
-		case exactScope:
-			logger.Tracef("exactScope match: index=%d,fallback=%d,mismatchedExact=%d,mismatchedFallback=%d,preferIPv6=%v", i, fallbackAddressIndex, mismatchedTypeExactIndex, mismatchedTypeFallbackIndex, preferIPv6)
-			return i
-		case fallbackScope:
-			logger.Tracef("fallbackScope match: index=%d,fallback=%d,mismatchedExact=%d,mismatchedFallback=%d,preferIPv6=%v", i, fallbackAddressIndex, mismatchedTypeExactIndex, mismatchedTypeFallbackIndex, preferIPv6)
-			// Use the first fallback address if there are no exact matches.
-			if fallbackAddressIndex == -1 {
-				fallbackAddressIndex = i
-			}
-		case mismatchedTypeExactScope:
-			logger.Tracef("mismatchedTypeExactScope match: index=%d,fallback=%d,mismatchedExact=%d,mismatchedFallback=%d,preferIPv6=%v", i, fallbackAddressIndex, mismatchedTypeExactIndex, mismatchedTypeFallbackIndex, preferIPv6)
-			// We have an exact scope match, but the type does not
-			// match, so save the first index as this is the best
-			// match so far.
-			if mismatchedTypeExactIndex == -1 {
-				mismatchedTypeExactIndex = i
-			}
-		case mismatchedTypeFallbackScope:
-			logger.Tracef("mismatchedTypeFallbackScope match: index=%d,fallback=%d,mismatchedExact=%d,mismatchedFallback=%d,preferIPv6=%v", i, fallbackAddressIndex, mismatchedTypeExactIndex, mismatchedTypeFallbackIndex, preferIPv6)
-			// We have a fallback scope match, but the type does not
-			// match, so we save the first index in case this is the
-			// best match so far.
-			if mismatchedTypeFallbackIndex == -1 {
-				mismatchedTypeFallbackIndex = i
-			}
+		matchType := match(getAddr(i), preferIPv6)
+		switch matchType {
+		case exactScope, fallbackScope, mismatchedTypeExactScope, mismatchedTypeFallbackScope:
+			matches[matchType] = append(matches[matchType], i)
 		}
 	}
+
+	// Retrieve the indexes of the addresses with the best scope and type match.
+	allowedMatchTypes := []scopeMatch{exactScope, fallbackScope}
 	if preferIPv6 {
-		if fallbackAddressIndex != -1 {
-			// Prefer an IPv6 fallback to a IPv4 mismatch.
-			logger.Tracef("fallbackScope return: index=%d,fallback=%d,mismatchedExact=%d,mismatchedFallback=%d,preferIPv6=%v", fallbackAddressIndex, fallbackAddressIndex, mismatchedTypeExactIndex, mismatchedTypeFallbackIndex, preferIPv6)
-			return fallbackAddressIndex
-		}
-		if mismatchedTypeExactIndex != -1 {
-			// Prefer an exact IPv4 match to a fallback.
-			logger.Tracef("mismatchedTypeExactScope return: index=%d,fallback=%d,mismatchedExact=%d,mismatchedFallback=%d,preferIPv6=%v", mismatchedTypeExactIndex, fallbackAddressIndex, mismatchedTypeExactIndex, mismatchedTypeFallbackIndex, preferIPv6)
-			return mismatchedTypeExactIndex
-		}
-		logger.Tracef("mismatchedTypeFallbackScope return: index=%d,fallback=%d,mismatchedExact=%d,mismatchedFallback=%d,preferIPv6=%v", mismatchedTypeFallbackIndex, fallbackAddressIndex, mismatchedTypeExactIndex, mismatchedTypeFallbackIndex, preferIPv6)
-		return mismatchedTypeFallbackIndex
+		allowedMatchTypes = append(allowedMatchTypes, mismatchedTypeExactScope, mismatchedTypeFallbackScope)
 	}
-	logger.Tracef("fallbackScope return: index=%d,fallback=%d,mismatchedExact=%d,mismatchedFallback=%d,preferIPv6=%v", fallbackAddressIndex, fallbackAddressIndex, mismatchedTypeExactIndex, mismatchedTypeFallbackIndex, preferIPv6)
-	return fallbackAddressIndex
+	for _, matchType := range allowedMatchTypes {
+		indexes, ok := matches[matchType]
+		if ok && len(indexes) > 0 {
+			return indexes
+		}
+	}
+	return []int{}
 }
 
 // sortOrder calculates the "weight" of the address when sorting,


### PR DESCRIPTION
network: added SelectInternalHostPorts

This is like SelectInternalHostPort but selects all the best candidate addresses, instead of just one of them. The logic for selecting the best matching addresses has been cleaned up and reworked in terms of selecting multiple addresses.

---

agent: SetAPIHostPorts now uses all candidate addresses for each server

SetAPIHostPorts used to pick just one address for each API server. It now writes all best-matched addresses (using the new SelectInternalHostPorts).

Fixes LP #1497094.

(Review request: http://reviews.vapour.ws/r/2853/)