### PR TITLE
agent: SetAPIHostPorts now uses all candidate addresses for each server (1.25)

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -542,10 +542,7 @@ func (c *configInternal) SetAPIHostPorts(servers [][]network.HostPort) {
 	}
 	var addrs []string
 	for _, serverHostPorts := range servers {
-		addr := network.SelectInternalHostPort(serverHostPorts, false)
-		if addr != "" {
-			addrs = append(addrs, addr)
-		}
+		addrs = append(addrs, network.SelectInternalHostPorts(serverHostPorts, false)...)
 	}
 	c.apiDetails.addresses = addrs
 }

--- a/network/address.go
+++ b/network/address.go
@@ -248,7 +248,7 @@ func SelectPublicHostPort(hps []HostPort) string {
 // SelectInternalAddress picks one address from a slice that can be
 // used as an endpoint for juju internal communication. If there are
 // are no suitable addresses, then ok is false (and an empty address is
-// returned). If a suitable address is then ok is true.
+// returned). If a suitable address was found then ok is true.
 func SelectInternalAddress(addresses []Address, machineLocal bool) (Address, bool) {
 	index := bestAddressIndex(len(addresses), globalPreferIPv6, func(i int) Address {
 		return addresses[i]
@@ -271,6 +271,22 @@ func SelectInternalHostPort(hps []HostPort, machineLocal bool) string {
 		return ""
 	}
 	return hps[index].NetAddr()
+}
+
+// SelectInternalHostPorts picks the best matching HostPorts from a
+// slice that can be used as an endpoint for juju internal
+// communication and returns them in NetAddr form. If there are no
+// suitable addresses, an empty slice is returned.
+func SelectInternalHostPorts(hps []HostPort, machineLocal bool) []string {
+	indexes := bestAddressIndexes(len(hps), globalPreferIPv6, func(i int) Address {
+		return hps[i].Address
+	}, internalAddressMatcher(machineLocal))
+
+	out := make([]string, 0, len(indexes))
+	for _, index := range indexes {
+		out = append(out, hps[index].NetAddr())
+	}
+	return out
 }
 
 func publicMatch(addr Address, preferIPv6 bool) scopeMatch {
@@ -335,61 +351,43 @@ const (
 	mismatchedTypeFallbackScope
 )
 
-// bestAddressIndex returns the index of the first address
-// with an exactly matching scope, or the first address with
-// a matching fallback scope if there are no exact matches, or
-// a matching scope but mismatched type when preferIPv6 is true.
-// If there are no suitable addresses, -1 is returned.
+// bestAddressIndexes returns the indexes of the addresses with the
+// best matching scope (according to the match func). An empty slice
+// is returned if there were no suitable addresses.
 func bestAddressIndex(numAddr int, preferIPv6 bool, getAddr func(i int) Address, match func(addr Address, preferIPv6 bool) scopeMatch) int {
-	fallbackAddressIndex := -1
-	mismatchedTypeFallbackIndex := -1
-	mismatchedTypeExactIndex := -1
+	indexes := bestAddressIndexes(numAddr, preferIPv6, getAddr, match)
+	if len(indexes) > 0 {
+		return indexes[0]
+	}
+	return -1
+}
+
+// bestAddressIndexes returns the indexes of the addresses with the
+// best matching scope and type (according to the match func). An
+// empty slice is returned if there were no suitable addresses.
+func bestAddressIndexes(numAddr int, preferIPv6 bool, getAddr func(i int) Address, match func(addr Address, preferIPv6 bool) scopeMatch) []int {
+	// Categorise addresses by scope and type matching quality.
+	matches := make(map[scopeMatch][]int)
 	for i := 0; i < numAddr; i++ {
-		addr := getAddr(i)
-		switch match(addr, preferIPv6) {
-		case exactScope:
-			logger.Tracef("exactScope match: index=%d,fallback=%d,mismatchedExact=%d,mismatchedFallback=%d,preferIPv6=%v", i, fallbackAddressIndex, mismatchedTypeExactIndex, mismatchedTypeFallbackIndex, preferIPv6)
-			return i
-		case fallbackScope:
-			logger.Tracef("fallbackScope match: index=%d,fallback=%d,mismatchedExact=%d,mismatchedFallback=%d,preferIPv6=%v", i, fallbackAddressIndex, mismatchedTypeExactIndex, mismatchedTypeFallbackIndex, preferIPv6)
-			// Use the first fallback address if there are no exact matches.
-			if fallbackAddressIndex == -1 {
-				fallbackAddressIndex = i
-			}
-		case mismatchedTypeExactScope:
-			logger.Tracef("mismatchedTypeExactScope match: index=%d,fallback=%d,mismatchedExact=%d,mismatchedFallback=%d,preferIPv6=%v", i, fallbackAddressIndex, mismatchedTypeExactIndex, mismatchedTypeFallbackIndex, preferIPv6)
-			// We have an exact scope match, but the type does not
-			// match, so save the first index as this is the best
-			// match so far.
-			if mismatchedTypeExactIndex == -1 {
-				mismatchedTypeExactIndex = i
-			}
-		case mismatchedTypeFallbackScope:
-			logger.Tracef("mismatchedTypeFallbackScope match: index=%d,fallback=%d,mismatchedExact=%d,mismatchedFallback=%d,preferIPv6=%v", i, fallbackAddressIndex, mismatchedTypeExactIndex, mismatchedTypeFallbackIndex, preferIPv6)
-			// We have a fallback scope match, but the type does not
-			// match, so we save the first index in case this is the
-			// best match so far.
-			if mismatchedTypeFallbackIndex == -1 {
-				mismatchedTypeFallbackIndex = i
-			}
+		matchType := match(getAddr(i), preferIPv6)
+		switch matchType {
+		case exactScope, fallbackScope, mismatchedTypeExactScope, mismatchedTypeFallbackScope:
+			matches[matchType] = append(matches[matchType], i)
 		}
 	}
+
+	// Retrieve the indexes of the addresses with the best scope and type match.
+	allowedMatchTypes := []scopeMatch{exactScope, fallbackScope}
 	if preferIPv6 {
-		if fallbackAddressIndex != -1 {
-			// Prefer an IPv6 fallback to a IPv4 mismatch.
-			logger.Tracef("fallbackScope return: index=%d,fallback=%d,mismatchedExact=%d,mismatchedFallback=%d,preferIPv6=%v", fallbackAddressIndex, fallbackAddressIndex, mismatchedTypeExactIndex, mismatchedTypeFallbackIndex, preferIPv6)
-			return fallbackAddressIndex
-		}
-		if mismatchedTypeExactIndex != -1 {
-			// Prefer an exact IPv4 match to a fallback.
-			logger.Tracef("mismatchedTypeExactScope return: index=%d,fallback=%d,mismatchedExact=%d,mismatchedFallback=%d,preferIPv6=%v", mismatchedTypeExactIndex, fallbackAddressIndex, mismatchedTypeExactIndex, mismatchedTypeFallbackIndex, preferIPv6)
-			return mismatchedTypeExactIndex
-		}
-		logger.Tracef("mismatchedTypeFallbackScope return: index=%d,fallback=%d,mismatchedExact=%d,mismatchedFallback=%d,preferIPv6=%v", mismatchedTypeFallbackIndex, fallbackAddressIndex, mismatchedTypeExactIndex, mismatchedTypeFallbackIndex, preferIPv6)
-		return mismatchedTypeFallbackIndex
+		allowedMatchTypes = append(allowedMatchTypes, mismatchedTypeExactScope, mismatchedTypeFallbackScope)
 	}
-	logger.Tracef("fallbackScope return: index=%d,fallback=%d,mismatchedExact=%d,mismatchedFallback=%d,preferIPv6=%v", fallbackAddressIndex, fallbackAddressIndex, mismatchedTypeExactIndex, mismatchedTypeFallbackIndex, preferIPv6)
-	return fallbackAddressIndex
+	for _, matchType := range allowedMatchTypes {
+		indexes, ok := matches[matchType]
+		if ok && len(indexes) > 0 {
+			return indexes
+		}
+	}
+	return []int{}
 }
 
 // sortOrder calculates the "weight" of the address when sorting,


### PR DESCRIPTION
network: added SelectInternalHostPorts

This is like SelectInternalHostPort but selects all the best candidate addresses, instead of just one of them. The logic for selecting the best matching addresses has been cleaned up and reworked in terms of selecting multiple addresses.

---

agent: SetAPIHostPorts now uses all candidate addresses for each server

SetAPIHostPorts used to pick just one address for each API server. It now writes all best-matched addresses (using the new SelectInternalHostPorts).

Fixes LP #1497094.

(Review request: http://reviews.vapour.ws/r/2855/)