### PR TITLE
Closed session fix - bug 1497829.

### DIFF
--- a/apiserver/imagemetadata/package_test.go
+++ b/apiserver/imagemetadata/package_test.go
@@ -39,7 +39,7 @@ func (s *baseImageMetadataSuite) SetUpTest(c *gc.C) {
 	s.authorizer = testing.FakeAuthorizer{names.NewUserTag("testuser"), true}
 
 	s.calls = []string{}
-	s.state = s.constructState(c)
+	s.state = s.constructState()
 
 	var err error
 	s.api, err = imagemetadata.CreateAPI(s.state, s.resources, s.authorizer)
@@ -55,7 +55,7 @@ const (
 	saveMetadata = "saveMetadata"
 )
 
-func (s *baseImageMetadataSuite) constructState(c *gc.C) *mockState {
+func (s *baseImageMetadataSuite) constructState() *mockState {
 	return &mockState{
 		findMetadata: func(f cloudimagemetadata.MetadataFilter) (map[cloudimagemetadata.SourceType][]cloudimagemetadata.Metadata, error) {
 			s.calls = append(s.calls, findMetadata)

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -1086,7 +1086,18 @@ func (a *MachineAgent) StateWorker() (worker.Worker, error) {
 			logger.Warningf("ignoring unknown job %q", job)
 		}
 	}
-	return cmdutil.NewCloseWorker(logger, runner, st), nil
+	return cmdutil.NewCloseWorker(logger, runner, stateWorkerCloser{st}), nil
+}
+
+type stateWorkerCloser struct {
+	stateCloser io.Closer
+}
+
+func (s stateWorkerCloser) Close() error {
+	// This state-dependent data source will be useless once state is closed -
+	// un-register it before closing state.
+	unregisterSimplestreamsDataSource()
+	return s.stateCloser.Close()
 }
 
 // startEnvWorkers starts state server workers that need to run per

--- a/cmd/jujud/agent/simplestreams.go
+++ b/cmd/jujud/agent/simplestreams.go
@@ -16,6 +16,11 @@ import (
 	"github.com/juju/juju/state/storage"
 )
 
+const (
+	storageDataSourceId          = "environment storage"
+	storageDataSourceDescription = storageDataSourceId
+)
+
 // environmentStorageDataSource is a simplestreams.DataSource that
 // retrieves simplestreams metadata from environment storage.
 type environmentStorageDataSource struct {
@@ -30,7 +35,7 @@ func NewEnvironmentStorageDataSource(stor storage.Storage) simplestreams.DataSou
 
 // Description is defined in simplestreams.DataSource.
 func (d environmentStorageDataSource) Description() string {
-	return "environment storage"
+	return storageDataSourceDescription
 }
 
 // Fetch is defined in simplestreams.DataSource.
@@ -63,7 +68,12 @@ func (d environmentStorageDataSource) SetAllowRetry(allow bool) {
 // registerSimplestreamsDataSource registers a environmentStorageDataSource.
 func registerSimplestreamsDataSource(stor storage.Storage) {
 	ds := NewEnvironmentStorageDataSource(stor)
-	environs.RegisterUserImageDataSourceFunc(ds.Description(), func(environs.Environ) (simplestreams.DataSource, error) {
+	environs.RegisterUserImageDataSourceFunc(storageDataSourceId, func(environs.Environ) (simplestreams.DataSource, error) {
 		return ds, nil
 	})
+}
+
+// unregisterSimplestreamsDataSource de-registers an environmentStorageDataSource.
+func unregisterSimplestreamsDataSource() {
+	environs.UnregisterImageDataSourceFunc(storageDataSourceId)
 }

--- a/cmd/jujud/agent/upgrade.go
+++ b/cmd/jujud/agent/upgrade.go
@@ -179,6 +179,10 @@ func (c *upgradeWorkerContext) run(stop <-chan struct{}) error {
 
 		stor := storage.NewStorage(c.st.EnvironUUID(), c.st.MongoSession())
 		registerSimplestreamsDataSource(stor)
+
+		// This state-dependent data source will be useless
+		// once state is closed in previous defer - un-register it.
+		defer unregisterSimplestreamsDataSource()
 	}
 	if err := c.runUpgrades(); err != nil {
 		// Only return an error from the worker if the connection to


### PR DESCRIPTION
This is a backport of PR 3341 from master.

This proposal ensures that previously registered state-dependent data sources are unregistered before state is closed. This bug was affecting agent machine state worker and state server upgrades.

As a result of the fix, previously skipped related tests are now longer skipped.

Drive-bys:
1. Removed gc.C from test setup as it is not the same as used during tests. Consequently, some unexpected and unwanted behavior may occur.
2. Instead of patching worker for tests, set metadata default base URL to empty string.

(Review request: http://reviews.vapour.ws/r/2861/)