### PR TITLE
Allow users to override where the cloud-image base url query comes from.

### DIFF
--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -363,10 +363,12 @@ func (srv *Server) run(lis net.Listener) {
 		}},
 	)
 	handleAll(mux, "/environment/:envuuid/api", http.HandlerFunc(srv.apiHandler))
+
 	handleAll(mux, "/environment/:envuuid/images/:kind/:series/:arch/:filename",
 		&imagesDownloadHandler{
 			httpHandler: httpHandler{statePool: srv.statePool},
-			dataDir:     srv.dataDir},
+			dataDir:     srv.dataDir,
+			state:       srv.state},
 	)
 	// For backwards compatibility we register all the old paths
 

--- a/apiserver/images.go
+++ b/apiserver/images.go
@@ -31,6 +31,7 @@ import (
 type imagesDownloadHandler struct {
 	httpHandler
 	dataDir string
+	state   *state.State
 }
 
 func (h *imagesDownloadHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -137,7 +138,11 @@ func (h *imagesDownloadHandler) loadImage(st *state.State, envuuid, kind, series
 // fetchAndCacheLxcImage fetches an lxc image tarball from http://cloud-images.ubuntu.com
 // and caches it in the state blobstore.
 func (h *imagesDownloadHandler) fetchAndCacheLxcImage(storage imagestorage.Storage, envuuid, series, arch string) error {
-	imageURL, err := container.ImageDownloadURL(instance.LXC, series, arch)
+	cfg, err := h.state.EnvironConfig()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	imageURL, err := container.ImageDownloadURL(instance.LXC, series, arch, cfg.CloudImageBaseURL())
 	if err != nil {
 		return errors.Annotatef(err, "cannot determine LXC image URL: %v", err)
 	}

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -988,7 +988,13 @@ func (a *MachineAgent) updateSupportedContainers(
 		if err != nil {
 			return errors.Annotate(err, "unable to get environ config")
 		}
-		imageURLGetter = container.NewImageURLGetter(st.Addr(), envUUID.Id(), []byte(agentConfig.CACert()), cfg.CloudImageBaseURL())
+		imageURLGetter = container.NewImageURLGetter(
+			// Explicitly call the non-named constructor so if anyone
+			// adds additional fields, this fails.
+			container.ImageURLGetterConfig{
+				st.Addr(), envUUID.Id(), []byte(agentConfig.CACert()),
+				cfg.CloudImageBaseURL(), container.ImageDownloadURL,
+			})
 	}
 	params := provisioner.ContainerSetupParams{
 		Runner:              runner,

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -984,7 +984,11 @@ func (a *MachineAgent) updateSupportedContainers(
 	// use an image URL getter if there's a private key.
 	var imageURLGetter container.ImageURLGetter
 	if agentConfig.Value(agent.AllowsSecureConnection) == "true" {
-		imageURLGetter = container.NewImageURLGetter(st.Addr(), envUUID.Id(), []byte(agentConfig.CACert()))
+		cfg, err := pr.EnvironConfig()
+		if err != nil {
+			return errors.Annotate(err, "unable to get environ config")
+		}
+		imageURLGetter = container.NewImageURLGetter(st.Addr(), envUUID.Id(), []byte(agentConfig.CACert()), cfg.CloudImageBaseURL())
 	}
 	params := provisioner.ContainerSetupParams{
 		Runner:              runner,

--- a/container/image_test.go
+++ b/container/image_test.go
@@ -26,7 +26,7 @@ func (s *imageURLSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *imageURLSuite) TestImageURL(c *gc.C) {
-	imageURLGetter := container.NewImageURLGetter("host:port", "12345", []byte("cert"))
+	imageURLGetter := container.NewImageURLGetter("host:port", "12345", []byte("cert"), "")
 	imageURL, err := imageURLGetter.ImageURL(instance.LXC, "trusty", "amd64")
 	c.Assert(err, gc.IsNil)
 	c.Assert(imageURL, gc.Equals, "https://host:port/environment/12345/images/lxc/trusty/amd64/trusty-released-amd64-root.tar.gz")
@@ -34,12 +34,12 @@ func (s *imageURLSuite) TestImageURL(c *gc.C) {
 }
 
 func (s *imageURLSuite) TestImageDownloadURL(c *gc.C) {
-	imageDownloadURL, err := container.ImageDownloadURL(instance.LXC, "trusty", "amd64")
+	imageDownloadURL, err := container.ImageDownloadURL(instance.LXC, "trusty", "amd64", "")
 	c.Assert(err, gc.IsNil)
 	c.Assert(imageDownloadURL, gc.Equals, "test://cloud-images/trusty-released-amd64-root.tar.gz")
 }
 
 func (s *imageURLSuite) TestImageDownloadURLUnsupportedContainer(c *gc.C) {
-	_, err := container.ImageDownloadURL(instance.KVM, "trusty", "amd64")
+	_, err := container.ImageDownloadURL(instance.KVM, "trusty", "amd64", "")
 	c.Assert(err, gc.ErrorMatches, "unsupported container .*")
 }

--- a/container/image_test.go
+++ b/container/image_test.go
@@ -39,6 +39,12 @@ func (s *imageURLSuite) TestImageDownloadURL(c *gc.C) {
 	c.Assert(imageDownloadURL, gc.Equals, "test://cloud-images/trusty-released-amd64-root.tar.gz")
 }
 
+func (s *imageURLSuite) TestImageDownloadURLOtherBase(c *gc.C) {
+	imageDownloadURL, err := container.ImageDownloadURL(instance.LXC, "trusty", "amd64", "other://cloud-images")
+	c.Assert(err, gc.IsNil)
+	c.Assert(imageDownloadURL, gc.Equals, "other://cloud-images/trusty-released-amd64-root.tar.gz")
+}
+
 func (s *imageURLSuite) TestImageDownloadURLUnsupportedContainer(c *gc.C) {
 	_, err := container.ImageDownloadURL(instance.KVM, "trusty", "amd64", "")
 	c.Assert(err, gc.ErrorMatches, "unsupported container .*")

--- a/container/testing/common.go
+++ b/container/testing/common.go
@@ -138,7 +138,8 @@ func CreateContainerTest(c *gc.C, manager container.Manager, machineId string) (
 
 // FakeLxcURLScript is used to replace ubuntu-cloudimg-query in tests.
 var FakeLxcURLScript = `#!/bin/bash
-echo -n test://cloud-images/$1-$2-$3.tar.gz`
+baseurl="${UBUNTU_CLOUDIMG_QUERY_BASEURL:-test://cloud-images}"
+echo -n ${baseurl}/$1-$2-$3.tar.gz`
 
 // MockURLGetter implements ImageURLGetter.
 type MockURLGetter struct{}

--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -171,6 +171,11 @@ const (
 	// interfaces created for LXC containers. See also bug #1442257.
 	LXCDefaultMTU = "lxc-default-mtu"
 
+	// CloudImageBaseURL allows a user to override the default url that the
+	// 'ubuntu-cloudimg-query' executable uses to find container images. This
+	// is primarily for enabling Juju to work cleanly in a closed network.
+	CloudImageBaseURL = "cloudimg-base-url"
+
 	//
 	// Deprecated Settings Attributes
 	//
@@ -1163,6 +1168,13 @@ func (c *Config) AllowLXCLoopMounts() (bool, bool) {
 	return v, ok
 }
 
+// CloudImageBaseURL returns the specified override url that the 'ubuntu-
+// cloudimg-query' executable uses to find container images. The empty string
+// means that the default URL is used.
+func (c *Config) CloudImageBaseURL() string {
+	return c.asString(CloudImageBaseURL)
+}
+
 // ResourceTags returns a set of tags to set on environment resources
 // that Juju creates and manages, if the provider supports them. These
 // tags have no special meaning to Juju, but may be used for existing
@@ -1274,6 +1286,7 @@ var alwaysOptional = schema.Defaults{
 	SetNumaControlPolicyKey:      DefaultNumaControlPolicy,
 	AllowLXCLoopMounts:           false,
 	ResourceTagsKey:              schema.Omit,
+	CloudImageBaseURL:            schema.Omit,
 
 	// Storage related config.
 	// Environ providers will specify their own defaults.
@@ -1635,6 +1648,11 @@ var configSchema = environschema.Fields{
 	"ca-private-key-path": {
 		Description: "Path to file containing CA private key",
 		Type:        environschema.Tstring,
+	},
+	CloudImageBaseURL: {
+		Description: "A URL to use instead of the default 'https://cloud-images.ubuntu.com/query' that the 'ubuntu-cloudimg-query' executable uses to find container images. This is primarily for enabling Juju to work cleanly in a closed network.",
+		Type:        environschema.Tstring,
+		Group:       environschema.EnvironGroup,
 	},
 	"default-series": {
 		Description: "The default series of Ubuntu to use for deploying charms",

--- a/environs/config/config_test.go
+++ b/environs/config/config_test.go
@@ -1701,6 +1701,19 @@ func (s *ConfigSuite) TestLoggingConfigFromEnvironment(c *gc.C) {
 	c.Assert(config.LoggingConfig(), gc.Equals, "<root>=INFO;unit=DEBUG")
 }
 
+func (s *ConfigSuite) TestCloudImageBaseURL(c *gc.C) {
+	s.addJujuFiles(c)
+	config := newTestConfig(c, testing.Attrs{})
+	c.Assert(config.CloudImageBaseURL(), gc.Equals, "")
+}
+
+func (s *ConfigSuite) TestCloudImageBaseURLSet(c *gc.C) {
+	s.addJujuFiles(c)
+	config := newTestConfig(c, testing.Attrs{
+		"cloudimg-base-url": "http://local.foo/query"})
+	c.Assert(config.CloudImageBaseURL(), gc.Equals, "http://local.foo/query")
+}
+
 func (s *ConfigSuite) TestProxyValuesWithFallback(c *gc.C) {
 	s.addJujuFiles(c)
 

--- a/provider/local/environ.go
+++ b/provider/local/environ.go
@@ -269,7 +269,15 @@ func (env *localEnviron) SetConfig(cfg *config.Config) error {
 				caCert = []byte(cert)
 			}
 			baseUrl := ecfg.CloudImageBaseURL()
-			imageURLGetter = container.NewImageURLGetter(ecfg.stateServerAddr(), uuid, caCert, baseUrl)
+
+			imageURLGetter = container.NewImageURLGetter(
+				// Explicitly call the non-named constructor so if anyone
+				// adds additional fields, this fails.
+				container.ImageURLGetterConfig{
+					ecfg.stateServerAddr(), uuid, caCert, baseUrl,
+					container.ImageDownloadURL,
+				})
+
 		}
 	}
 	env.containerManager, err = factory.NewContainerManager(

--- a/provider/local/environ.go
+++ b/provider/local/environ.go
@@ -268,7 +268,8 @@ func (env *localEnviron) SetConfig(cfg *config.Config) error {
 			if cert, ok := cfg.CACert(); ok {
 				caCert = []byte(cert)
 			}
-			imageURLGetter = container.NewImageURLGetter(ecfg.stateServerAddr(), uuid, caCert)
+			baseUrl := ecfg.CloudImageBaseURL()
+			imageURLGetter = container.NewImageURLGetter(ecfg.stateServerAddr(), uuid, caCert, baseUrl)
 		}
 	}
 	env.containerManager, err = factory.NewContainerManager(


### PR DESCRIPTION
Allows the lxc containers to be cached behind a closed network.

(Review request: http://reviews.vapour.ws/r/2863/)