### PR TITLE
Delete unneeded json and yaml spaces cmd methods

### DIFF
--- a/cmd/juju/space/list.go
+++ b/cmd/juju/space/list.go
@@ -4,7 +4,6 @@
 package space
 
 import (
-	"encoding/json"
 	"fmt"
 	"net"
 	"strings"
@@ -149,37 +148,9 @@ type formattedShortList struct {
 	Spaces []string `json:"spaces" yaml:"spaces"`
 }
 
-// A goyaml bug means we can't declare these types locally to the
-// GetYAML methods.
-type formattedListNoMethods formattedList
-
-// MarshalJSON is defined on json.Marshaller.
-func (l formattedList) MarshalJSON() ([]byte, error) {
-	return json.Marshal(formattedListNoMethods(l))
-}
-
-// GetYAML is defined on yaml.Getter.
-func (l formattedList) GetYAML() (tag string, value interface{}) {
-	return "", formattedListNoMethods(l)
-}
-
 type formattedSubnet struct {
 	Type       string   `json:"type" yaml:"type"`
 	ProviderId string   `json:"provider-id,omitempty" yaml:"provider-id,omitempty"`
 	Status     string   `json:"status,omitempty" yaml:"status,omitempty"`
 	Zones      []string `json:"zones" yaml:"zones"`
-}
-
-// A goyaml bug means we can't declare these types locally to the
-// GetYAML methods.
-type formattedSubnetNoMethods formattedSubnet
-
-// MarshalJSON is defined on json.Marshaller.
-func (s formattedSubnet) MarshalJSON() ([]byte, error) {
-	return json.Marshal(formattedSubnetNoMethods(s))
-}
-
-// GetYAML is defined on yaml.Getter.
-func (s formattedSubnet) GetYAML() (tag string, value interface{}) {
-	return "", formattedSubnetNoMethods(s)
 }


### PR DESCRIPTION
The spaces yaml and json marshalling methods do not seem to
actually be required. Deleting them causes no spaces cmd
tests to fail.

(Review request: http://reviews.vapour.ws/r/2875/)