### PR TITLE
apiserver: do not access state in NewServer - fixes-1504578

### DIFF
--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -435,24 +435,16 @@ func tagToString(tag names.Tag) string {
 }
 
 func dialWebsocket(addr, path string, opts DialOpts, tlsConfig *tls.Config, try *parallel.Try) error {
-	cfg, err := setUpWebsocket(addr, path, tlsConfig)
-	if err != nil {
-		return err
-	}
-	return try.Start(newWebsocketDialer(cfg, opts))
-}
-
-func setUpWebsocket(addr, path string, tlsConfig *tls.Config) (*websocket.Config, error) {
 	// origin is required by the WebSocket API, used for "origin policy"
 	// in websockets. We pass localhost to satisfy the API; it is
 	// inconsequential to us.
 	const origin = "http://localhost/"
 	cfg, err := websocket.NewConfig("wss://"+addr+path, origin)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return errors.Trace(err)
 	}
 	cfg.TlsConfig = tlsConfig
-	return cfg, nil
+	return try.Start(newWebsocketDialer(cfg, opts))
 }
 
 // newWebsocketDialer returns a function that

--- a/api/apiclient_test.go
+++ b/api/apiclient_test.go
@@ -4,12 +4,11 @@
 package api_test
 
 import (
-	"fmt"
-	"io"
 	"net"
-	"strconv"
+	"sync/atomic"
 
 	"github.com/juju/names"
+	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/parallel"
 	"golang.org/x/net/websocket"
@@ -52,76 +51,24 @@ func (s *apiclientSuite) TestConnectWebsocketToRoot(c *gc.C) {
 	assertConnAddrForRoot(c, conn, info.Addrs[0])
 }
 
-func (s *apiclientSuite) TestConnectWebsocketPrefersLocalhostIfPresent(c *gc.C) {
-	// Create a socket that proxies to the API server though our localhost address.
-	info := s.APIInfo(c)
-	serverAddr := info.Addrs[0]
-	server, err := net.Dial("tcp", serverAddr)
-	c.Assert(err, jc.ErrorIsNil)
-	defer server.Close()
-	listener, err := net.Listen("tcp", "localhost:0")
-	c.Assert(err, jc.ErrorIsNil)
-	defer listener.Close()
-	go func() {
-		for {
-			client, err := listener.Accept()
-			if err != nil {
-				return
-			}
-			go io.Copy(client, server)
-			go io.Copy(server, client)
-		}
-	}()
-
-	// Check that we are using our working address to connect
-	listenerAddress := listener.Addr().String()
-	// listenAddress contains the actual IP address, but APIHostPorts
-	// is going to report localhost, so just find the port
-	_, port, err := net.SplitHostPort(listenerAddress)
-	c.Check(err, jc.ErrorIsNil)
-	portNum, err := strconv.Atoi(port)
-	c.Check(err, jc.ErrorIsNil)
-	expectedHostPort := fmt.Sprintf("localhost:%d", portNum)
-	info.Addrs = []string{"fakeAddress:1", "fakeAddress:1", expectedHostPort}
-	conn, _, err := api.ConnectWebsocket(info, api.DialOpts{})
-	c.Assert(err, jc.ErrorIsNil)
-	defer conn.Close()
-	assertConnAddrForEnv(c, conn, expectedHostPort, s.State.EnvironUUID(), "/api")
-}
-
 func (s *apiclientSuite) TestConnectWebsocketMultiple(c *gc.C) {
 	// Create a socket that proxies to the API server.
 	info := s.APIInfo(c)
 	serverAddr := info.Addrs[0]
-	server, err := net.Dial("tcp", serverAddr)
-	c.Assert(err, jc.ErrorIsNil)
-	defer server.Close()
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
-	c.Assert(err, jc.ErrorIsNil)
-	defer listener.Close()
-	go func() {
-		for {
-			client, err := listener.Accept()
-			if err != nil {
-				return
-			}
-			go io.Copy(client, server)
-			go io.Copy(server, client)
-		}
-	}()
+	proxy := testing.NewTCPProxy(c, serverAddr)
+	defer proxy.Close()
 
 	// Check that we can use the proxy to connect.
-	proxyAddr := listener.Addr().String()
-	info.Addrs = []string{proxyAddr}
+	info.Addrs = []string{proxy.Addr()}
 	conn, _, err := api.ConnectWebsocket(info, api.DialOpts{})
 	c.Assert(err, jc.ErrorIsNil)
 	conn.Close()
-	assertConnAddrForEnv(c, conn, proxyAddr, s.State.EnvironUUID(), "/api")
+	assertConnAddrForEnv(c, conn, proxy.Addr(), s.State.EnvironUUID(), "/api")
 
 	// Now break Addrs[0], and ensure that Addrs[1]
 	// is successfully connected to.
-	info.Addrs = []string{proxyAddr, serverAddr}
-	listener.Close()
+	proxy.Close()
+	info.Addrs = []string{proxy.Addr(), serverAddr}
 	conn, _, err = api.ConnectWebsocket(info, api.DialOpts{})
 	c.Assert(err, jc.ErrorIsNil)
 	conn.Close()
@@ -132,12 +79,15 @@ func (s *apiclientSuite) TestConnectWebsocketMultipleError(c *gc.C) {
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	c.Assert(err, jc.ErrorIsNil)
 	defer listener.Close()
+	// count holds the number of times we've accepted a connection.
+	var count int32
 	go func() {
 		for {
 			client, err := listener.Accept()
 			if err != nil {
 				return
 			}
+			atomic.AddInt32(&count, 1)
 			client.Close()
 		}
 	}()
@@ -146,6 +96,7 @@ func (s *apiclientSuite) TestConnectWebsocketMultipleError(c *gc.C) {
 	info.Addrs = []string{addr, addr, addr}
 	_, _, err = api.ConnectWebsocket(info, api.DialOpts{})
 	c.Assert(err, gc.ErrorMatches, `unable to connect to API: websocket.Dial wss://.*/environment/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}/api: .*`)
+	c.Assert(count, gc.Equals, int32(3))
 }
 
 func (s *apiclientSuite) TestOpen(c *gc.C) {

--- a/api/state.go
+++ b/api/state.go
@@ -48,10 +48,10 @@ func (st *state) Login(tag names.Tag, password, nonce string) error {
 		err = st.loginV1(tag, password, nonce)
 		if params.IsCodeNotImplemented(err) {
 			// TODO (cmars): remove fallback once we can drop v0 compatibility
-			return st.loginV0(tag, password, nonce)
+			return errors.Trace(st.loginV0(tag, password, nonce))
 		}
 	}
-	return err
+	return errors.Trace(err)
 }
 
 func (st *state) loginV2(tag names.Tag, password, nonce string) error {

--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -19,9 +19,6 @@ import (
 	"github.com/juju/names"
 	"github.com/juju/utils"
 	"golang.org/x/net/websocket"
-	"gopkg.in/macaroon-bakery.v1/bakery"
-	"gopkg.in/macaroon-bakery.v1/httpbakery"
-	"gopkg.in/macaroon.v1"
 	"launchpad.net/tomb"
 
 	"github.com/juju/juju/apiserver/common"
@@ -52,24 +49,8 @@ type Server struct {
 	validator         LoginValidator
 	adminApiFactories map[int]adminApiFactory
 	mongoUnavailable  uint32 // non zero if mongoUnavailable
-
-	// bakeryService holds the service that is
-	// used to verify macaroon authorization. It
-	// stores a key for the single macaroon below.
-	// It will be nil if no identity URL has been configured.
-	bakeryService *bakery.Service
-
-	// macaroon is created when the server is created
-	// and guards macaroon-authentication-based access
-	// to the APIs.
-	macaroon *macaroon.Macaroon
-
-	// identityURL to address discharge macaroons to.
-	identityURL string
-
-	authCtxt authContext
-
-	environUUID string
+	environUUID       string
+	authCtxt          *authContext
 }
 
 // LoginValidator functions are used to decide whether login requests
@@ -175,19 +156,28 @@ func (cl *changeCertListener) updateCertificate(cert, key []byte) {
 // NewServer serves the given state by accepting requests on the given
 // listener, using the given certificate and key (in PEM format) for
 // authentication.
+//
+// The Server will close the listener when it exits, even if returns an error.
 func NewServer(s *state.State, lis net.Listener, cfg ServerConfig) (*Server, error) {
+	// Important note:
+	// Do not manipulate the state within NewServer as the API
+	// server needs to run before mongo upgrades have happened and
+	// any state manipulation may be be relying on features of the
+	// database added by upgrades. Here be dragons.
 	l, ok := lis.(*net.TCPListener)
 	if !ok {
 		return nil, errors.Errorf("listener is not of type *net.TCPListener: %T", lis)
 	}
-	return newServer(s, l, cfg)
+	srv, err := newServer(s, l, cfg)
+	if err != nil {
+		// There is no running server around to close the listener.
+		lis.Close()
+		return nil, errors.Trace(err)
+	}
+	return srv, nil
 }
 
-func newServer(s *state.State, lis *net.TCPListener, cfg ServerConfig) (*Server, error) {
-	envCfg, err := s.EnvironConfig()
-	if err != nil {
-		return nil, errors.Annotate(err, "cannot get environment config")
-	}
+func newServer(s *state.State, lis *net.TCPListener, cfg ServerConfig) (_ *Server, err error) {
 	logger.Infof("listening on %q", lis.Addr())
 	srv := &Server{
 		state:     s,
@@ -204,36 +194,7 @@ func newServer(s *state.State, lis *net.TCPListener, cfg ServerConfig) (*Server,
 			2: newAdminApiV2,
 		},
 	}
-	idURL := envCfg.IdentityURL()
-	if idURL != "" {
-		// The identity server has been configured,
-		// so configure the bakery service appropriately.
-		idPK := envCfg.IdentityPublicKey()
-		if idPK == nil {
-			// No public key supplied - retrieve it from the identity manager.
-			idPK, err = httpbakery.PublicKeyForLocation(http.DefaultClient, idURL)
-			if err != nil {
-				return nil, errors.Annotate(err, "cannot get identity public key")
-			}
-		}
-		svc, err := bakery.NewService(
-			bakery.NewServiceParams{
-				Location: "juju environment " + s.EnvironUUID(),
-				Locator: bakery.PublicKeyLocatorMap{
-					idURL: idPK,
-				},
-			},
-		)
-		if err != nil {
-			return nil, errors.Annotate(err, "cannot make bakery service")
-		}
-		srv.authCtxt.bakeryService = svc
-		srv.authCtxt.macaroon, err = svc.NewMacaroon("api-login", nil, nil)
-		if err != nil {
-			return nil, errors.Annotate(err, "cannot make macaroon")
-		}
-		srv.authCtxt.identityURL = idURL
-	}
+	srv.authCtxt = newAuthContext(srv)
 	tlsCert, err := tls.X509KeyPair(cfg.Cert, cfg.Key)
 	if err != nil {
 		return nil, err
@@ -379,8 +340,7 @@ func (srv *Server) run(lis net.Listener) {
 
 	srvDying := srv.tomb.Dying()
 	httpCtxt := httpContext{
-		statePool: srv.statePool,
-		authCtxt:  &srv.authCtxt,
+		srv: srv,
 	}
 	if feature.IsDbLogEnabled() {
 		handleAll(mux, "/environment/:envuuid/logsink",
@@ -562,5 +522,3 @@ func serverError(err error) error {
 	}
 	return nil
 }
-
-var logRequests = true

--- a/apiserver/authcontext.go
+++ b/apiserver/authcontext.go
@@ -4,48 +4,127 @@
 package apiserver
 
 import (
+	"github.com/juju/errors"
 	"github.com/juju/names"
 	"gopkg.in/macaroon-bakery.v1/bakery"
-	"gopkg.in/macaroon.v1"
+	"gopkg.in/macaroon-bakery.v1/httpbakery"
+	"net/http"
+	"sync"
 
 	"github.com/juju/juju/apiserver/authentication"
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/state"
 )
 
 // authContext holds authentication context shared
 // between all API endpoints.
 type authContext struct {
-	// bakeryService holds the service that is
-	// used to verify macaroon authorization.
-	// It will be nil if no identity URL has been configured.
-	bakeryService *bakery.Service
+	srv *Server
 
-	// macaroon guards macaroon-authentication-based access
-	// to the APIs.
-	macaroon *macaroon.Macaroon
+	agentAuth authentication.AgentAuthenticator
+	userAuth  authentication.UserAuthenticator
 
-	// identityURL holds the URL of the trusted third party
-	// that is used to address the is-authenticated-user
-	// third party caveat to.
-	identityURL string
+	// macaroonAuthOnce guards the fields below it.
+	macaroonAuthOnce   sync.Once
+	_macaroonAuth      *authentication.MacaroonAuthenticator
+	_macaroonAuthError error
+}
+
+// newAuthContext creates a new authentication context for srv.
+func newAuthContext(srv *Server) *authContext {
+	return &authContext{
+		srv: srv,
+	}
+}
+
+// Authenticate implements authentication.EntityAuthenticator
+// by choosing the right kind of authentication for the given
+// tag.
+func (ctxt *authContext) Authenticate(entityFinder authentication.EntityFinder, tag names.Tag, req params.LoginRequest) (state.Entity, error) {
+	auth, err := ctxt.authenticatorForTag(tag)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return auth.Authenticate(entityFinder, tag, req)
 }
 
 // authenticatorForTag returns the authenticator appropriate
 // to use for a login with the given possibly-nil tag.
 func (ctxt *authContext) authenticatorForTag(tag names.Tag) (authentication.EntityAuthenticator, error) {
 	if tag == nil {
-		return &authentication.MacaroonAuthenticator{
-			Service:          ctxt.bakeryService,
-			Macaroon:         ctxt.macaroon,
-			IdentityLocation: ctxt.identityURL,
-		}, nil
+		auth, err := ctxt.macaroonAuth()
+		if errors.Cause(err) == errMacaroonAuthNotConfigured {
+			// Make a friendlier error message.
+			err = errors.New("no credentials provided")
+		}
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		return auth, nil
 	}
-
 	switch tag.Kind() {
 	case names.UnitTagKind, names.MachineTagKind:
-		return &authentication.AgentAuthenticator{}, nil
+		return &ctxt.agentAuth, nil
 	case names.UserTagKind:
-		return &authentication.UserAuthenticator{}, nil
+		return &ctxt.userAuth, nil
+	default:
+		return nil, errors.Annotatef(common.ErrBadRequest, "unexpected login entity tag")
 	}
-	return nil, common.ErrBadRequest
+}
+
+// macaroonAuth returns an authenticator that can authenticate macaroon-based
+// logins. If it fails once, it will always fail.
+func (ctxt *authContext) macaroonAuth() (authentication.EntityAuthenticator, error) {
+	ctxt.macaroonAuthOnce.Do(func() {
+		ctxt._macaroonAuth, ctxt._macaroonAuthError = newMacaroonAuth(ctxt.srv.statePool.SystemState())
+	})
+	if ctxt._macaroonAuth == nil {
+		return nil, errors.Trace(ctxt._macaroonAuthError)
+	}
+	return ctxt._macaroonAuth, nil
+}
+
+var errMacaroonAuthNotConfigured = errors.New("macaroon authentication is not configured")
+
+// newMacaroonAuth returns an authenticator that can authenticate
+// macaroon-based logins. This is just a helper function for authCtxt.macaroonAuth.
+func newMacaroonAuth(st *state.State) (*authentication.MacaroonAuthenticator, error) {
+	envCfg, err := st.EnvironConfig()
+	if err != nil {
+		return nil, errors.Annotate(err, "cannot get environment config")
+	}
+	idURL := envCfg.IdentityURL()
+	if idURL == "" {
+		return nil, errMacaroonAuthNotConfigured
+	}
+	// The identity server has been configured,
+	// so configure the bakery service appropriately.
+	idPK := envCfg.IdentityPublicKey()
+	if idPK == nil {
+		// No public key supplied - retrieve it from the identity manager.
+		idPK, err = httpbakery.PublicKeyForLocation(http.DefaultClient, idURL)
+		if err != nil {
+			return nil, errors.Annotate(err, "cannot get identity public key")
+		}
+	}
+	svc, err := bakery.NewService(
+		bakery.NewServiceParams{
+			Location: "juju environment " + st.EnvironUUID(),
+			Locator: bakery.PublicKeyLocatorMap{
+				idURL: idPK,
+			},
+		},
+	)
+	if err != nil {
+		return nil, errors.Annotate(err, "cannot make bakery service")
+	}
+	var auth authentication.MacaroonAuthenticator
+	auth.Service = svc
+	auth.Macaroon, err = svc.NewMacaroon("api-login", nil, nil)
+	if err != nil {
+		return nil, errors.Annotate(err, "cannot make macaroon")
+	}
+	auth.IdentityLocation = idURL
+	return &auth, nil
 }

--- a/apiserver/authentication/user.go
+++ b/apiserver/authentication/user.go
@@ -40,8 +40,18 @@ func (u *UserAuthenticator) Authenticate(entityFinder EntityFinder, tag names.Ta
 // *common.DischargeRequiredError holding a macaroon to be
 // discharged.
 type MacaroonAuthenticator struct {
-	Service          *bakery.Service
-	Macaroon         *macaroon.Macaroon
+	// Service holds the service that is
+	// used to verify macaroon authorization.
+	Service *bakery.Service
+
+	// Macaroon guards macaroon-authentication-based access
+	// to the APIs. Appropriate caveats will be added before
+	// sending it to a client.
+	Macaroon *macaroon.Macaroon
+
+	// IdentityLocation holds the URL of the trusted third party
+	// that is used to address the is-authenticated-user
+	// third party caveat to.
 	IdentityLocation string
 }
 

--- a/apiserver/authenticator_test.go
+++ b/apiserver/authenticator_test.go
@@ -47,16 +47,7 @@ func (s *agentAuthenticatorSuite) TestAuthenticatorForTag(c *gc.C) {
 	c.Assert(entity, gc.DeepEquals, user)
 }
 
-func (s *agentAuthenticatorSuite) TestAuthenticatorForTagGetsMacaroonAuthenticator(c *gc.C) {
-	srv := newServer(c, s.State)
-	defer srv.Stop()
-	authenticator, err := apiserver.ServerAuthenticatorForTag(srv, nil)
-	c.Assert(err, jc.ErrorIsNil)
-	_, ok := authenticator.(*authentication.MacaroonAuthenticator)
-	c.Assert(ok, jc.IsTrue)
-}
-
-func (s *agentAuthenticatorSuite) TestMachineGetsAgentAuthentictor(c *gc.C) {
+func (s *agentAuthenticatorSuite) TestMachineGetsAgentAuthenticator(c *gc.C) {
 	srv := newServer(c, s.State)
 	defer srv.Stop()
 	authenticator, err := apiserver.ServerAuthenticatorForTag(srv, names.NewMachineTag("0"))
@@ -64,7 +55,8 @@ func (s *agentAuthenticatorSuite) TestMachineGetsAgentAuthentictor(c *gc.C) {
 	_, ok := authenticator.(*authentication.AgentAuthenticator)
 	c.Assert(ok, jc.IsTrue)
 }
-func (s *agentAuthenticatorSuite) TestUnitGetsAgentAuthentictor(c *gc.C) {
+
+func (s *agentAuthenticatorSuite) TestUnitGetsAgentAuthenticator(c *gc.C) {
 	srv := newServer(c, s.State)
 	defer srv.Stop()
 	authenticator, err := apiserver.ServerAuthenticatorForTag(srv, names.NewUnitTag("wordpress/0"))
@@ -72,10 +64,11 @@ func (s *agentAuthenticatorSuite) TestUnitGetsAgentAuthentictor(c *gc.C) {
 	_, ok := authenticator.(*authentication.AgentAuthenticator)
 	c.Assert(ok, jc.IsTrue)
 }
+
 func (s *agentAuthenticatorSuite) TestNotSupportedTag(c *gc.C) {
 	srv := newServer(c, s.State)
 	defer srv.Stop()
 	authenticator, err := apiserver.ServerAuthenticatorForTag(srv, names.NewServiceTag("not-support"))
-	c.Assert(err, gc.ErrorMatches, "invalid request")
+	c.Assert(err, gc.ErrorMatches, "unexpected login entity tag: invalid request")
 	c.Assert(authenticator, gc.IsNil)
 }

--- a/apiserver/backup_test.go
+++ b/apiserver/backup_test.go
@@ -74,7 +74,7 @@ var _ = gc.Suite(&backupsSuite{})
 
 func (s *backupsSuite) TestRequiresAuth(c *gc.C) {
 	resp := s.sendRequest(c, httpRequestParams{method: "GET", url: s.backupURL(c)})
-	s.assertErrorResponse(c, resp, http.StatusUnauthorized, "no authorization header found")
+	s.assertErrorResponse(c, resp, http.StatusUnauthorized, "no credentials provided")
 }
 
 func (s *backupsSuite) checkInvalidMethod(c *gc.C, method, url string) {

--- a/apiserver/charms_test.go
+++ b/apiserver/charms_test.go
@@ -109,7 +109,7 @@ func (s *charmsSuite) TestCharmsServedSecurely(c *gc.C) {
 
 func (s *charmsSuite) TestPOSTRequiresAuth(c *gc.C) {
 	resp := s.sendRequest(c, httpRequestParams{method: "POST", url: s.charmsURI(c, "")})
-	s.assertErrorResponse(c, resp, http.StatusUnauthorized, "no authorization header found")
+	s.assertErrorResponse(c, resp, http.StatusUnauthorized, "no credentials provided")
 }
 
 func (s *charmsSuite) TestGETDoesNotRequireAuth(c *gc.C) {

--- a/apiserver/debuglog_test.go
+++ b/apiserver/debuglog_test.go
@@ -48,7 +48,7 @@ func (s *debugLogBaseSuite) TestNoAuth(c *gc.C) {
 	defer conn.Close()
 	reader := bufio.NewReader(conn)
 
-	assertJSONError(c, reader, "no authorization header found")
+	assertJSONError(c, reader, "no credentials provided")
 	s.assertWebsocketClosed(c, reader)
 }
 

--- a/apiserver/logsink_test.go
+++ b/apiserver/logsink_test.go
@@ -66,7 +66,7 @@ func (s *logsinkSuite) TestRejectsBadEnvironUUID(c *gc.C) {
 }
 
 func (s *logsinkSuite) TestNoAuth(c *gc.C) {
-	s.checkAuthFails(c, nil, "no authorization header found")
+	s.checkAuthFails(c, nil, "no credentials provided")
 }
 
 func (s *logsinkSuite) TestRejectsUserLogins(c *gc.C) {

--- a/apiserver/tools_test.go
+++ b/apiserver/tools_test.go
@@ -112,7 +112,7 @@ func (s *toolsSuite) TestToolsUploadedSecurely(c *gc.C) {
 
 func (s *toolsSuite) TestRequiresAuth(c *gc.C) {
 	resp := s.sendRequest(c, httpRequestParams{method: "GET", url: s.toolsURI(c, "")})
-	s.assertErrorResponse(c, resp, http.StatusUnauthorized, "no authorization header found")
+	s.assertErrorResponse(c, resp, http.StatusUnauthorized, "no credentials provided")
 }
 
 func (s *toolsSuite) TestRequiresPOST(c *gc.C) {

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -455,7 +455,7 @@ func (a *MachineAgent) Run(*cmd.Context) error {
 	// At this point, all workers will have been configured to start
 	close(a.workersStarted)
 	err := a.runner.Wait()
-	switch err {
+	switch errors.Cause(err) {
 	case worker.ErrTerminateAgent:
 		err = a.uninstallAgent(agentConfig)
 	case worker.ErrRebootMachine:
@@ -639,7 +639,7 @@ func (a *MachineAgent) stateStarter(stopch <-chan struct{}) error {
 func (a *MachineAgent) APIWorker() (_ worker.Worker, err error) {
 	st, entity, err := apicaller.OpenAPIState(a)
 	if err != nil {
-		return nil, err
+		return nil, errors.Trace(err)
 	}
 	reportOpenedAPI(st)
 
@@ -1685,6 +1685,7 @@ func (a *MachineAgent) createJujuRun(dataDir string) error {
 }
 
 func (a *MachineAgent) uninstallAgent(agentConfig agent.Config) error {
+	logger.Infof("machine agent uninstalling itself")
 	var errors []error
 	agentServiceName := agentConfig.Value(agent.AgentServiceName)
 	if agentServiceName == "" {

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -25,9 +25,9 @@ github.com/juju/ratelimit	git	aa5bb718d4d435629821789cb90970319f57bfe5	2015-03-3
 github.com/juju/replicaset	git	fb7294cf57a1e2f08a57691f1246d129a87ab7e8	2015-05-08T02:21:43Z
 github.com/juju/schema	git	afe1151cb49d1d7ed3c75592dfc6f38703f2e988	2015-08-07T07:58:08Z
 github.com/juju/syslog	git	6be94e8b718766e9ff7a37342157fe4795da7cfa	2015-02-05T15:59:36Z
-github.com/juju/testing	git	c037f3a0fdf849ffcaa30f88d7b94f93e0a01eb8	2015-09-29T11:36:52Z
+github.com/juju/testing	git	ad6f815f49f8209a27a3b7efb6d44876493e5939	2015-10-12T16:09:06Z
 github.com/juju/txn	git	99ec629d0066a4d73c54d8e021a7fc1dc07df614	2015-06-09T16:58:27Z
-github.com/juju/utils	git	5f4ce83eb1440ceb90f8089520aa035b1281282b	2015-10-01T18:18:32Z
+github.com/juju/utils	git	5f4ce83eb1440ceb90f8089520aa035b1281282b	2015-10-01T16:18:32Z
 github.com/juju/xml	git	eb759a627588d35166bc505fceb51b88500e291e	2015-04-13T13:11:21Z
 github.com/julienschmidt/httprouter	git	109e267447e95ad1bb48b758e40dd7453eb7b039	2015-09-05T17:25:33Z
 golang.org/x/crypto	git	aedad9a179ec1ea11b7064c57cbc6dc30d7724ec	2015-08-30T18:06:42Z
@@ -39,9 +39,9 @@ gopkg.in/amz.v3	git	bff3a097c4108da57bb8cbe3aad2990d74d23676	2015-08-20T12:28:33
 gopkg.in/check.v1	git	b3d3430320d4260e5fea99841af984b3badcea63	2015-06-26T10:50:28Z
 gopkg.in/errgo.v1	git	66cb46252b94c1f3d65646f54ee8043ab38d766c	2015-10-07T15:31:57Z
 gopkg.in/goose.v1	git	be6030ce33a6d77f5e9c63b7698030e6431d5343	2015-08-24T15:19:40Z
+gopkg.in/juju/charm.v6-unstable	git	1e471da773d8f6cf11c689e4a303c2211bdb6f21	2015-09-22T09:50:16Z
 gopkg.in/juju/charmrepo.v1	git	8677b12d9772a2a596a99e65b7e6f642fceb6c40	2015-09-14T13:26:00Z
 gopkg.in/juju/charmstore.v5-unstable	git	475920bf612769da77969237ed511a921fb785be	2015-09-16T09:44:01Z
-gopkg.in/juju/charm.v6-unstable	git	1e471da773d8f6cf11c689e4a303c2211bdb6f21	2015-09-22T09:50:16Z
 gopkg.in/juju/environschema.v1	git	e2de5f6100c8cdd6f631983b1774b290ab076d88	2015-09-28T14:16:13Z
 gopkg.in/juju/jujusvg.v1	git	3eedb1c722ece2b66d62508368ca3e8b7f916569	2015-05-20T11:48:32Z
 gopkg.in/macaroon-bakery.v1	git	0c5d05edc860c3ba6ce56b3c5330b0585f2f3c1c	2015-10-07T15:38:28Z


### PR DESCRIPTION
We also ensure that the listener is closed when NewServer fails and that we allow an agent login without requiring the environment configuration (that's also potentially problematic if the user database needs a migration but not something we can easily sort out now).

We also remove apiclientSuite.TestConnectWebsocketPrefersLocalhostIfPresent because the logic it was supposed be testing has long been removed and didn't actually test that logic in the first place.

Fixes https://bugs.launchpad.net/juju-core/+bug/1504578.
fixes-1504578
['fixes-1504578']

(Review request: http://reviews.vapour.ws/r/2878/)
