### PR TITLE
all: migration from gopkg.in/yaml.v1 to gopkg.in/yaml.v2

### DIFF
--- a/agent/format-1.16.go
+++ b/agent/format-1.16.go
@@ -10,7 +10,7 @@ import (
 	"strconv"
 
 	"github.com/juju/names"
-	goyaml "gopkg.in/yaml.v1"
+	goyaml "gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/version"

--- a/agent/format-1.18.go
+++ b/agent/format-1.18.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/names"
-	goyaml "gopkg.in/yaml.v1"
+	goyaml "gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state/multiwatcher"

--- a/apiserver/client/status.go
+++ b/apiserver/client/status.go
@@ -657,7 +657,7 @@ func (context *statusContext) processUnit(unit *state.Unit, serviceCharm string)
 		// Usually this indicates that no addresses have been set on the
 		// machine yet.
 		addr = network.Address{}
-		logger.Warningf("error fetching public address: %q", err)
+		logger.Warningf("error fetching public address: %v", err)
 	}
 	result.PublicAddress = addr.Value
 	unitPorts, _ := unit.OpenedPorts()

--- a/cloudconfig/cloudinit/cloudinit_centos.go
+++ b/cloudconfig/cloudinit/cloudinit_centos.go
@@ -11,7 +11,7 @@ import (
 	"github.com/juju/utils/packaging"
 	"github.com/juju/utils/packaging/config"
 	"github.com/juju/utils/proxy"
-	"gopkg.in/yaml.v1"
+	"gopkg.in/yaml.v2"
 )
 
 // centOSCloudConfig is the cloudconfig type specific to CentOS machines.

--- a/cloudconfig/cloudinit/cloudinit_ubuntu.go
+++ b/cloudconfig/cloudinit/cloudinit_ubuntu.go
@@ -12,7 +12,7 @@ import (
 	"github.com/juju/utils/packaging"
 	"github.com/juju/utils/packaging/config"
 	"github.com/juju/utils/proxy"
-	"gopkg.in/yaml.v1"
+	"gopkg.in/yaml.v2"
 )
 
 // ubuntuCloudConfig is the cloudconfig type specific to Ubuntu machines

--- a/cloudconfig/containerinit/container_userdata_test.go
+++ b/cloudconfig/containerinit/container_userdata_test.go
@@ -11,7 +11,7 @@ import (
 
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-	"gopkg.in/yaml.v1"
+	"gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/cloudconfig/cloudinit"
 	"github.com/juju/juju/cloudconfig/containerinit"

--- a/cloudconfig/providerinit/providerinit_test.go
+++ b/cloudconfig/providerinit/providerinit_test.go
@@ -14,7 +14,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
-	goyaml "gopkg.in/yaml.v1"
+	goyaml "gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/api"

--- a/cloudconfig/userdatacfg_test.go
+++ b/cloudconfig/userdatacfg_test.go
@@ -17,7 +17,7 @@ import (
 	pacconf "github.com/juju/utils/packaging/config"
 	"github.com/juju/utils/set"
 	gc "gopkg.in/check.v1"
-	goyaml "gopkg.in/yaml.v1"
+	goyaml "gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/api"

--- a/cloudconfig/userdatacfg_unix.go
+++ b/cloudconfig/userdatacfg_unix.go
@@ -22,7 +22,7 @@ import (
 	"github.com/juju/utils/os"
 	"github.com/juju/utils/proxy"
 	"github.com/juju/utils/series"
-	goyaml "gopkg.in/yaml.v1"
+	goyaml "gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/cloudconfig/cloudinit"
 	"github.com/juju/juju/environs/config"

--- a/cmd/juju/action/common.go
+++ b/cmd/juju/action/common.go
@@ -8,7 +8,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names"
-	"gopkg.in/yaml.v1"
+	"gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/apiserver/params"
 )

--- a/cmd/juju/action/defined_test.go
+++ b/cmd/juju/action/defined_test.go
@@ -12,7 +12,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v6-unstable"
-	"gopkg.in/yaml.v1"
+	"gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/cmd/juju/action"
 	"github.com/juju/juju/state"

--- a/cmd/juju/action/do.go
+++ b/cmd/juju/action/do.go
@@ -11,7 +11,7 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/names"
-	yaml "gopkg.in/yaml.v1"
+	yaml "gopkg.in/yaml.v2"
 	"launchpad.net/gnuflag"
 
 	"github.com/juju/juju/apiserver/params"

--- a/cmd/juju/action/do_test.go
+++ b/cmd/juju/action/do_test.go
@@ -13,7 +13,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
-	"gopkg.in/yaml.v1"
+	"gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
@@ -232,17 +232,17 @@ func (s *DoSuite) TestRun(c *gc.C) {
 		withArgs: []string{validUnitId, "some-action",
 			"--params", s.dir + "/" + "invalidParams.yml",
 		},
-		expectedErr: "YAML error: line 3: mapping values are not allowed in this context",
+		expectedErr: "yaml: line 3: mapping values are not allowed in this context",
 	}, {
 		should: "fail with invalid UTF in file",
 		withArgs: []string{validUnitId, "some-action",
 			"--params", s.dir + "/" + "invalidUTF.yml",
 		},
-		expectedErr: "YAML error: invalid leading UTF-8 octet",
+		expectedErr: "yaml: invalid leading UTF-8 octet",
 	}, {
 		should:      "fail with invalid YAML passed as arg and no --string-args",
 		withArgs:    []string{validUnitId, "some-action", "foo.bar=\""},
-		expectedErr: "YAML error: found unexpected end of stream",
+		expectedErr: "yaml: found unexpected end of stream",
 	}, {
 		should:   "enqueue a basic action with no params",
 		withArgs: []string{validUnitId, "some-action"},

--- a/cmd/juju/commands/ensureavailability_test.go
+++ b/cmd/juju/commands/ensureavailability_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/juju/cmd"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-	goyaml "gopkg.in/yaml.v1"
+	goyaml "gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"

--- a/cmd/juju/commands/get_test.go
+++ b/cmd/juju/commands/get_test.go
@@ -10,7 +10,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v6-unstable"
-	goyaml "gopkg.in/yaml.v1"
+	goyaml "gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/cmd/envcmd"
 	"github.com/juju/juju/juju/testing"

--- a/cmd/juju/environment/jenv.go
+++ b/cmd/juju/environment/jenv.go
@@ -12,7 +12,7 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/names"
-	"gopkg.in/yaml.v1"
+	"gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/cmd/envcmd"
 	"github.com/juju/juju/environs/configstore"

--- a/cmd/juju/environment/jenv_test.go
+++ b/cmd/juju/environment/jenv_test.go
@@ -12,7 +12,7 @@ import (
 	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-	"gopkg.in/yaml.v1"
+	"gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/cmd/envcmd"
 	"github.com/juju/juju/cmd/juju/environment"
@@ -97,7 +97,7 @@ var jenvFileContentErrorsTests = []struct {
 }, {
 	about:    "invalid YAML",
 	contents: []byte(":"),
-	err:      "invalid jenv file .*: cannot unmarshal jenv data: YAML error: .*",
+	err:      "invalid jenv file .*: cannot unmarshal jenv data: yaml: .*",
 }, {
 	about:    "missing field",
 	contents: makeJenvContents("myuser", "mypasswd", "env-uuid", "", "1.2.3.4:17070"),

--- a/cmd/juju/service/get_test.go
+++ b/cmd/juju/service/get_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/juju/cmd"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-	goyaml "gopkg.in/yaml.v1"
+	goyaml "gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/cmd/envcmd"
 	"github.com/juju/juju/cmd/juju/service"

--- a/cmd/juju/status/status_test.go
+++ b/cmd/juju/status/status_test.go
@@ -16,7 +16,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v6-unstable"
-	goyaml "gopkg.in/yaml.v1"
+	goyaml "gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/envcmd"

--- a/cmd/juju/storage/filesystemlist_test.go
+++ b/cmd/juju/storage/filesystemlist_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-	goyaml "gopkg.in/yaml.v1"
+	goyaml "gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/envcmd"

--- a/cmd/juju/storage/poollist_test.go
+++ b/cmd/juju/storage/poollist_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/juju/cmd"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-	goyaml "gopkg.in/yaml.v1"
+	goyaml "gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/envcmd"

--- a/cmd/juju/storage/volumelist_test.go
+++ b/cmd/juju/storage/volumelist_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-	goyaml "gopkg.in/yaml.v1"
+	goyaml "gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/envcmd"

--- a/cmd/juju/system/createenvironment.go
+++ b/cmd/juju/system/createenvironment.go
@@ -12,7 +12,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/names"
 	"github.com/juju/utils/keyvalues"
-	"gopkg.in/yaml.v1"
+	"gopkg.in/yaml.v2"
 	"launchpad.net/gnuflag"
 
 	"github.com/juju/juju/apiserver/params"

--- a/cmd/juju/system/createenvironment_test.go
+++ b/cmd/juju/system/createenvironment_test.go
@@ -13,7 +13,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
-	"gopkg.in/yaml.v1"
+	"gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/envcmd"
@@ -234,7 +234,7 @@ func (s *createSuite) TestConfigFileFormatError(c *gc.C) {
 	file.Close()
 
 	_, err = s.run(c, "test", "--config", file.Name())
-	c.Assert(err, gc.ErrorMatches, `unable to parse config file: YAML error: .*`)
+	c.Assert(err, gc.ErrorMatches, `unable to parse config file: yaml: .*`)
 }
 
 func (s *createSuite) TestConfigFileDoesntExist(c *gc.C) {

--- a/cmd/juju/system/login.go
+++ b/cmd/juju/system/login.go
@@ -8,7 +8,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/names"
 	"github.com/juju/utils"
-	goyaml "gopkg.in/yaml.v1"
+	goyaml "gopkg.in/yaml.v2"
 	"launchpad.net/gnuflag"
 
 	"github.com/juju/juju/api"

--- a/cmd/juju/system/login_test.go
+++ b/cmd/juju/system/login_test.go
@@ -109,7 +109,7 @@ func (s *LoginSuite) TestBadServerFile(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	_, err = s.run(c, "foo", "--server", serverFilePath)
-	c.Assert(err, gc.ErrorMatches, "YAML error: did not find expected alphabetic or numeric character")
+	c.Assert(err, gc.ErrorMatches, "yaml: did not find expected alphabetic or numeric character")
 }
 
 func (s *LoginSuite) TestBadUser(c *gc.C) {

--- a/cmd/juju/user/user_test.go
+++ b/cmd/juju/user/user_test.go
@@ -9,7 +9,7 @@ import (
 
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-	goyaml "gopkg.in/yaml.v1"
+	goyaml "gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/cmd/envcmd"
 	"github.com/juju/juju/cmd/juju/user"

--- a/cmd/jujud/bootstrap.go
+++ b/cmd/jujud/bootstrap.go
@@ -20,7 +20,7 @@ import (
 	"github.com/juju/names"
 	"github.com/juju/utils"
 	"github.com/juju/utils/series"
-	goyaml "gopkg.in/yaml.v1"
+	goyaml "gopkg.in/yaml.v2"
 	"launchpad.net/gnuflag"
 
 	"github.com/juju/juju/agent"

--- a/cmd/jujud/bootstrap_test.go
+++ b/cmd/jujud/bootstrap_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/juju/utils/set"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/mgo.v2"
-	goyaml "gopkg.in/yaml.v1"
+	goyaml "gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/agent"
 	agenttools "github.com/juju/juju/agent/tools"

--- a/cmd/plugins/juju-restore/restore.go
+++ b/cmd/plugins/juju-restore/restore.go
@@ -21,7 +21,7 @@ import (
 	"github.com/juju/loggo"
 	"github.com/juju/names"
 	"github.com/juju/utils"
-	goyaml "gopkg.in/yaml.v1"
+	goyaml "gopkg.in/yaml.v2"
 	"launchpad.net/gnuflag"
 
 	"github.com/juju/juju/api"

--- a/constraints/constraints.go
+++ b/constraints/constraints.go
@@ -440,7 +440,7 @@ func (v *Value) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	values := map[interface{}]interface{}{}
 	err := unmarshal(&values)
 	if err != nil {
-		return err
+		return errors.Trace(err)
 	}
 	for k, val := range values {
 		vstr := fmt.Sprintf("%v", val)
@@ -466,7 +466,7 @@ func (v *Value) UnmarshalYAML(unmarshal func(interface{}) error) error {
 			var spaces *[]string
 			spaces, err = parseYamlStrings("spaces", val)
 			if err != nil {
-				return err
+				return errors.Trace(err)
 			}
 			err = v.validateSpaces(spaces)
 			if err == nil {
@@ -476,7 +476,7 @@ func (v *Value) UnmarshalYAML(unmarshal func(interface{}) error) error {
 			var networks *[]string
 			networks, err = parseYamlStrings("networks", val)
 			if err != nil {
-				return err
+				return errors.Trace(err)
 			}
 			err = v.validateNetworks(networks)
 			if err == nil {
@@ -486,7 +486,7 @@ func (v *Value) UnmarshalYAML(unmarshal func(interface{}) error) error {
 			return errors.Errorf("unknown constraint value: %v", k)
 		}
 		if err != nil {
-			return err
+			return errors.Trace(err)
 		}
 	}
 	return nil

--- a/constraints/constraints.go
+++ b/constraints/constraints.go
@@ -431,19 +431,19 @@ func (v *Value) setRaw(raw string) error {
 	return nil
 }
 
-// SetYAML is required to unmarshall a constraints.Value object
+// UnmarshalYAML is required to unmarshal a constraints.Value object
 // to ensure the container attribute is correctly handled when it is empty.
 // Because ContainerType is an alias for string, Go's reflect logic used in the
 // YAML decode determines that *string and *ContainerType are not assignable so
 // the container value of "" in the YAML is ignored.
-func (v *Value) SetYAML(tag string, value interface{}) bool {
-	values, ok := value.(map[interface{}]interface{})
-	if !ok {
-		return false
+func (v *Value) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	values := map[interface{}]interface{}{}
+	err := unmarshal(&values)
+	if err != nil {
+		return err
 	}
 	for k, val := range values {
 		vstr := fmt.Sprintf("%v", val)
-		var err error
 		switch k {
 		case Arch:
 			v.Arch = &vstr
@@ -466,7 +466,7 @@ func (v *Value) SetYAML(tag string, value interface{}) bool {
 			var spaces *[]string
 			spaces, err = parseYamlStrings("spaces", val)
 			if err != nil {
-				return false
+				return err
 			}
 			err = v.validateSpaces(spaces)
 			if err == nil {
@@ -476,20 +476,20 @@ func (v *Value) SetYAML(tag string, value interface{}) bool {
 			var networks *[]string
 			networks, err = parseYamlStrings("networks", val)
 			if err != nil {
-				return false
+				return err
 			}
 			err = v.validateNetworks(networks)
 			if err == nil {
 				v.Networks = networks
 			}
 		default:
-			return false
+			return errors.Errorf("unknown constraint value: %v", k)
 		}
 		if err != nil {
-			return false
+			return err
 		}
 	}
-	return true
+	return nil
 }
 
 func (v *Value) setContainer(str string) error {

--- a/constraints/constraints_test.go
+++ b/constraints/constraints_test.go
@@ -11,7 +11,7 @@ import (
 
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-	goyaml "gopkg.in/yaml.v1"
+	goyaml "gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/instance"

--- a/container/lxc/lxc_test.go
+++ b/container/lxc/lxc_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/juju/utils/set"
 	"github.com/juju/utils/symlink"
 	gc "gopkg.in/check.v1"
-	goyaml "gopkg.in/yaml.v1"
+	goyaml "gopkg.in/yaml.v2"
 	"launchpad.net/golxc"
 
 	"github.com/juju/juju/agent"

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -50,6 +50,7 @@ gopkg.in/mgo.v2	git	3569c88678d88179dcbd68d02ab081cbca3cd4d0	2015-06-04T15:26:27
 gopkg.in/natefinch/lumberjack.v2	git	588a21fb0fa0ebdfde42670fa214576b6f0f22df	2015-05-21T01:59:18Z
 gopkg.in/natefinch/npipe.v2	git	e562d4ae5c2f838f9e7e406f7d9890d5b02467a9	2014-08-11T16:19:00Z
 gopkg.in/yaml.v1	git	9f9df34309c04878acc86042b16630b0f696e1de	2014-09-24T16:16:07Z
+gopkg.in/yaml.v2	git	7ad95dd0798a40da1ccdff6dff35fd177b5edf40	2015-06-24T10:29:02Z
 launchpad.net/gnuflag	bzr	roger.peppe@canonical.com-20140716064605-pk32dnmfust02yab	13
 launchpad.net/golxc	bzr	ian.booth@canonical.com-20141121040613-ztm1q0iy9rune3zt	13
 launchpad.net/gomaasapi	bzr	michael.foord@canonical.com-20150703101140-oo7493pkzlzg7l6u	63

--- a/environs/config.go
+++ b/environs/config.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
-	goyaml "gopkg.in/yaml.v1"
+	goyaml "gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/juju/osenv"

--- a/environs/config_test.go
+++ b/environs/config_test.go
@@ -48,7 +48,7 @@ var invalidConfigTests = []struct {
 	env string
 	err string
 }{
-	{"'", "YAML error:.*"},
+	{"'", "yaml:.*"},
 	{`
 default: unknown
 environments:

--- a/environs/configstore/cachefile.go
+++ b/environs/configstore/cachefile.go
@@ -8,7 +8,7 @@ import (
 	"os"
 
 	"github.com/juju/errors"
-	goyaml "gopkg.in/yaml.v1"
+	goyaml "gopkg.in/yaml.v2"
 )
 
 // CacheFile represents the YAML structure of the file

--- a/environs/configstore/disk.go
+++ b/environs/configstore/disk.go
@@ -16,7 +16,7 @@ import (
 	"github.com/juju/utils/featureflag"
 	"github.com/juju/utils/fslock"
 	"github.com/juju/utils/set"
-	goyaml "gopkg.in/yaml.v1"
+	goyaml "gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/feature"
 	"github.com/juju/juju/juju/osenv"

--- a/featuretests/cmd_juju_system_test.go
+++ b/featuretests/cmd_juju_system_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-	goyaml "gopkg.in/yaml.v1"
+	goyaml "gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/environmentmanager"

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -19,7 +19,7 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v6-unstable"
 	"gopkg.in/juju/charmrepo.v1"
-	goyaml "gopkg.in/yaml.v1"
+	goyaml "gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/api"

--- a/provider/common/state.go
+++ b/provider/common/state.go
@@ -10,7 +10,7 @@ import (
 	"io/ioutil"
 
 	"github.com/juju/errors"
-	goyaml "gopkg.in/yaml.v1"
+	goyaml "gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/storage"

--- a/provider/common/state_test.go
+++ b/provider/common/state_test.go
@@ -12,7 +12,7 @@ import (
 
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-	goyaml "gopkg.in/yaml.v1"
+	goyaml "gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/storage"

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -21,7 +21,7 @@ import (
 	"gopkg.in/amz.v3/ec2/ec2test"
 	"gopkg.in/amz.v3/s3/s3test"
 	gc "gopkg.in/check.v1"
-	goyaml "gopkg.in/yaml.v1"
+	goyaml "gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs"

--- a/provider/maas/environ_whitebox_test.go
+++ b/provider/maas/environ_whitebox_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/juju/utils/arch"
 	"github.com/juju/utils/set"
 	gc "gopkg.in/check.v1"
-	goyaml "gopkg.in/yaml.v1"
+	goyaml "gopkg.in/yaml.v2"
 	"launchpad.net/gomaasapi"
 
 	"github.com/juju/juju/cloudconfig/cloudinit"

--- a/provider/maas/util.go
+++ b/provider/maas/util.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/utils"
-	goyaml "gopkg.in/yaml.v1"
+	goyaml "gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/cloudconfig/cloudinit"
 	"github.com/juju/juju/environs/config"

--- a/provider/maas/util_test.go
+++ b/provider/maas/util_test.go
@@ -8,7 +8,7 @@ import (
 
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-	goyaml "gopkg.in/yaml.v1"
+	goyaml "gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/cloudconfig/cloudinit"
 	"github.com/juju/juju/instance"

--- a/upgrades/agentconfig_test.go
+++ b/upgrades/agentconfig_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-	goyaml "gopkg.in/yaml.v1"
+	goyaml "gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/environs/config"

--- a/version/version.go
+++ b/version/version.go
@@ -127,23 +127,24 @@ func (vp *Binary) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// GetYAML implements goyaml.Getter
-func (v Binary) GetYAML() (tag string, value interface{}) {
-	return "", v.String()
+// MarshalYAML implements yaml.v2.Marshaller interface
+func (v Binary) MarshalYAML() (interface{}, error) {
+	return v.String(), nil
 }
 
-// SetYAML implements goyaml.Setter
-func (vp *Binary) SetYAML(tag string, value interface{}) bool {
-	vstr := fmt.Sprintf("%v", value)
-	if vstr == "" {
-		return false
+// UnmarshalYAML implements the yaml.Unmarshaller interface
+func (vp *Binary) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var vstr string
+	err := unmarshal(&vstr)
+	if err != nil {
+		return err
 	}
 	v, err := ParseBinary(vstr)
 	if err != nil {
-		return false
+		return err
 	}
 	*vp = v
-	return true
+	return nil
 }
 
 var (
@@ -304,23 +305,24 @@ func (vp *Number) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// GetYAML implements goyaml.Getter
-func (v Number) GetYAML() (tag string, value interface{}) {
-	return "", v.String()
+// MarshalYAML implements yaml.v2.Marshaller interface
+func (v Number) MarshalYAML() (interface{}, error) {
+	return v.String(), nil
 }
 
-// SetYAML implements goyaml.Setter
-func (vp *Number) SetYAML(tag string, value interface{}) bool {
-	vstr := fmt.Sprintf("%v", value)
-	if vstr == "" {
-		return false
+// UnmarshalYAML implements the yaml.Unmarshaller interface
+func (vp *Number) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var vstr string
+	err := unmarshal(&vstr)
+	if err != nil {
+		return err
 	}
 	v, err := Parse(vstr)
 	if err != nil {
-		return false
+		return err
 	}
 	*vp = v
-	return true
+	return nil
 }
 
 func isOdd(x int) bool {

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -11,7 +11,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/mgo.v2/bson"
-	goyaml "gopkg.in/yaml.v1"
+	goyaml "gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/version"

--- a/worker/localstorage/config.go
+++ b/worker/localstorage/config.go
@@ -4,7 +4,7 @@
 package localstorage
 
 import (
-	goyaml "gopkg.in/yaml.v1"
+	goyaml "gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/agent"
 )

--- a/worker/localstorage/config_test.go
+++ b/worker/localstorage/config_test.go
@@ -8,7 +8,7 @@ import (
 
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-	goyaml "gopkg.in/yaml.v1"
+	goyaml "gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/worker/localstorage"
 )

--- a/worker/uniter/runner/debug/client.go
+++ b/worker/uniter/runner/debug/client.go
@@ -7,7 +7,7 @@ import (
 	"encoding/base64"
 	"strings"
 
-	goyaml "gopkg.in/yaml.v1"
+	goyaml "gopkg.in/yaml.v2"
 )
 
 type hookArgs struct {

--- a/worker/uniter/runner/debug/server.go
+++ b/worker/uniter/runner/debug/server.go
@@ -11,7 +11,7 @@ import (
 	"os/exec"
 
 	"github.com/juju/utils/set"
-	goyaml "gopkg.in/yaml.v1"
+	goyaml "gopkg.in/yaml.v2"
 )
 
 // ServerSession represents a "juju debug-hooks" session.

--- a/worker/uniter/runner/jujuc/config-get_test.go
+++ b/worker/uniter/runner/jujuc/config-get_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/juju/cmd"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-	goyaml "gopkg.in/yaml.v1"
+	goyaml "gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"

--- a/worker/uniter/runner/jujuc/relation-set.go
+++ b/worker/uniter/runner/jujuc/relation-set.go
@@ -11,7 +11,7 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/utils/keyvalues"
-	goyaml "gopkg.in/yaml.v1"
+	goyaml "gopkg.in/yaml.v2"
 	"launchpad.net/gnuflag"
 )
 
@@ -89,27 +89,6 @@ func (c *RelationSetCommand) readSettings(in io.Reader) (map[string]string, erro
 	data, err := ioutil.ReadAll(in)
 	if err != nil {
 		return nil, errors.Trace(err)
-	}
-
-	skipValidation := false // for debugging
-	if !skipValidation {
-		// Can this validation be done more simply or efficiently?
-
-		var scalar string
-		if err := goyaml.Unmarshal(data, &scalar); err != nil {
-			return nil, errors.Trace(err)
-		}
-		if scalar != "" {
-			return nil, errors.Errorf("expected YAML map, got %q", scalar)
-		}
-
-		var sequence []string
-		if err := goyaml.Unmarshal(data, &sequence); err != nil {
-			return nil, errors.Trace(err)
-		}
-		if len(sequence) != 0 {
-			return nil, errors.Errorf("expected YAML map, got %#v", sequence)
-		}
 	}
 
 	kvs := make(map[string]string)

--- a/worker/uniter/runner/jujuc/relation-set_test.go
+++ b/worker/uniter/runner/jujuc/relation-set_test.go
@@ -260,22 +260,22 @@ var relationSetInitTests = []relationSetInitTest{
 		summary: "accidental same format as command-line",
 		args:    []string{"--file", "spam"},
 		content: "foo=bar ham=eggs good=bad",
-		err:     `expected YAML map, got .*`,
+		err:     "yaml: unmarshal errors:\n  line 1: cannot unmarshal !!str `foo=bar...` into map.*",
 	}, {
 		summary: "scalar instead of map",
 		args:    []string{"--file", "spam"},
 		content: "haha",
-		err:     `expected YAML map, got "haha"`,
+		err:     "yaml: unmarshal errors:\n  line 1: cannot unmarshal !!str `haha` into map.*",
 	}, {
 		summary: "sequence instead of map",
 		args:    []string{"--file", "spam"},
 		content: "[haha]",
-		err:     `expected YAML map, got \[]string{"haha"}`,
+		err:     "yaml: unmarshal errors:\n  line 1: cannot unmarshal !!seq into map.*",
 	}, {
 		summary: "multiple maps",
 		args:    []string{"--file", "spam"},
 		content: "{a: b}\n{c: d}",
-		err:     `.*YAML error: .*`,
+		err:     `.*yaml: .*`,
 	}, {
 		summary:  "value with a space",
 		args:     []string{"--file", "spam"},

--- a/worker/uniter/runner/jujuc/status-get_test.go
+++ b/worker/uniter/runner/jujuc/status-get_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/juju/cmd"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-	goyaml "gopkg.in/yaml.v1"
+	goyaml "gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"

--- a/worker/uniter/runner/jujuc/storage-get_test.go
+++ b/worker/uniter/runner/jujuc/storage-get_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/juju/cmd"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-	goyaml "gopkg.in/yaml.v1"
+	goyaml "gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"

--- a/worker/uniter/runner/jujuc/storage-list_test.go
+++ b/worker/uniter/runner/jujuc/storage-list_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/juju/cmd"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-	goyaml "gopkg.in/yaml.v1"
+	goyaml "gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"

--- a/worker/uniter/util_test.go
+++ b/worker/uniter/util_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/juju/utils/proxy"
 	gc "gopkg.in/check.v1"
 	corecharm "gopkg.in/juju/charm.v6-unstable"
-	goyaml "gopkg.in/yaml.v1"
+	goyaml "gopkg.in/yaml.v2"
 
 	apiuniter "github.com/juju/juju/api/uniter"
 	"github.com/juju/juju/apiserver/params"


### PR DESCRIPTION
This migrates core from yaml.v1 to yaml.v2. It does not cover the use of yaml.v1 in any of cores dependencies.

(Review request: http://reviews.vapour.ws/r/2883/)