### PR TITLE
bundle deployment: update to use newer bundlechanges.

### DIFF
--- a/apiserver/client/bundles_test.go
+++ b/apiserver/client/bundles_test.go
@@ -84,7 +84,7 @@ func (s *serverSuite) TestGetBundleChangesSuccess(c *gc.C) {
 	}, {
 		Id:       "deploy-1",
 		Method:   "deploy",
-		Args:     []interface{}{"django", "django", map[string]interface{}{"debug": true}},
+		Args:     []interface{}{"$addCharm-0", "django", map[string]interface{}{"debug": true}, ""},
 		Requires: []string{"addCharm-0"},
 	}, {
 		Id:     "addCharm-2",
@@ -93,7 +93,7 @@ func (s *serverSuite) TestGetBundleChangesSuccess(c *gc.C) {
 	}, {
 		Id:       "deploy-3",
 		Method:   "deploy",
-		Args:     []interface{}{"cs:trusty/haproxy-42", "haproxy", map[string]interface{}{}},
+		Args:     []interface{}{"$addCharm-2", "haproxy", map[string]interface{}{}, ""},
 		Requires: []string{"addCharm-2"},
 	}, {
 		Id:       "addRelation-4",

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -10,7 +10,7 @@ github.com/joyent/gomanta	git	cabd97b029d931836571f00b7e48c331809a30b7	2014-05-2
 github.com/joyent/gosdc	git	2f11feadd2d9891e92296a1077c3e2e56939547d	2014-05-24T00:08:15Z
 github.com/joyent/gosign	git	0da0d5f1342065321c97812b1f4ac0c2b0bab56c	2014-05-24T00:07:34Z
 github.com/juju/blobstore	git	337aa7d5d712728d181dbda2547a6556d4189626	2015-05-08T07:43:36Z
-github.com/juju/bundlechanges	git	4a00e08ecbec1cf5a90f20980842dd0f388ed39a	2015-09-23T07:52:40Z
+github.com/juju/bundlechanges	git	b2d0b097c9a98f88cd85b964c7c096b83bd1346b	2015-10-13T13:38:12Z
 github.com/juju/cmd	git	4a5e8abce36462f89d92d28bd69b54c7845db818	2015-08-20T13:46:44Z
 github.com/juju/errors	git	4567a5e69fd3130ca0d89f69478e7ac025b67452	2015-03-27T19:24:31Z
 github.com/juju/gojsonpointer	git	afe8b77aa08f272b49e01b82de78510c11f61500	2015-02-04T19:46:29Z


### PR DESCRIPTION
As a consequence, now service constraints are properly handled.
Also correctly use the charm placeholder when deploying services.

(Review request: http://reviews.vapour.ws/r/2892/)