### PR TITLE
1494476 maas 1.9 bootstrap issue - forward port

### DIFF
--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -1137,8 +1137,10 @@ isStatic() {
 }
 
 unAuto() {
+    # Remove the line auto starting the primary interface. \s*$ matches
+    # whitespace and the end of the line to avoid mangling aliases.
     grep -q "auto ${PRIMARY_IFACE}\s*$" {{.Config}} && \
-    sed -i "s/auto ${PRIMARY_IFACE}//" {{.Config}}
+    sed -i "s/auto ${PRIMARY_IFACE}\s*$//" {{.Config}}
 }
 
 # Change the config to make $PRIMARY_IFACE manual instead of DHCP,
@@ -1178,7 +1180,13 @@ PRIMARY_IFACE=$(ip route list exact 0/0 | egrep -o 'dev [^ ]+' | cut -b5-)
 # If $PRIMARY_IFACE is empty, there's nothing to do.
 [ -z "$PRIMARY_IFACE" ] && exit 0
 
+# Log the contents of /etc/network/interfaces prior to modifying
+echo "Contents of /etc/network/interfaces before changes"
+cat /etc/network/interfaces
 {{.Script}}
+# Log the contents of /etc/network/interfaces after modifying
+echo "Contents of /etc/network/interfaces after changes"
+cat /etc/network/interfaces
 # Stop $PRIMARY_IFACE and start the bridge instead.
 ifdown -v ${PRIMARY_IFACE} ; ifup -v {{.Bridge}}
 

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -1126,21 +1126,26 @@ func (environ *maasEnviron) selectNode(args selectNodeArgs) (*gomaasapi.MAASObje
 	return &node, nil
 }
 
-const bridgeConfigTemplate = `
-# In case we already created the bridge, don't do it again.
-grep -q "iface {{.Bridge}} inet dhcp" && exit 0
+const modifyEtcNetworkInterfaces = `isDHCP() {
+    grep -q "iface ${PRIMARY_IFACE} inet dhcp" {{.Config}}
+    return $?
+}
 
-# Discover primary interface at run-time using the default route (if set)
-PRIMARY_IFACE=$(ip route list exact 0/0 | egrep -o 'dev [^ ]+' | cut -b5-)
+isStatic() {
+    grep -q "iface ${PRIMARY_IFACE} inet static" {{.Config}}
+    return $?
+}
 
-# If $PRIMARY_IFACE is empty, there's nothing to do.
-[ -z "$PRIMARY_IFACE" ] && exit 0
+unAuto() {
+    grep -q "auto ${PRIMARY_IFACE}\s*$" {{.Config}} && \
+    sed -i "s/auto ${PRIMARY_IFACE}//" {{.Config}}
+}
 
 # Change the config to make $PRIMARY_IFACE manual instead of DHCP,
 # then create the bridge and enslave $PRIMARY_IFACE into it.
-grep -q "iface ${PRIMARY_IFACE} inet dhcp" {{.Config}} && \
-sed -i "s/iface ${PRIMARY_IFACE} inet dhcp//" {{.Config}} && \
-cat >> {{.Config}} << EOF
+if isDHCP; then
+    sed -i "s/iface ${PRIMARY_IFACE} inet dhcp//" {{.Config}}
+    cat >> {{.Config}} << EOF
 
 # Primary interface (defining the default route)
 iface ${PRIMARY_IFACE} inet manual
@@ -1150,11 +1155,30 @@ auto {{.Bridge}}
 iface {{.Bridge}} inet dhcp
     bridge_ports ${PRIMARY_IFACE}
 EOF
+    # Make the primary interface not auto-starting.
+    unAuto
+elif isStatic
+then
+    sed -i "s/iface ${PRIMARY_IFACE} inet static/iface {{.Bridge}} inet static\n    bridge_ports ${PRIMARY_IFACE}/" {{.Config}}
+    sed -i "s/auto ${PRIMARY_IFACE}\s*$/auto {{.Bridge}}/" {{.Config}}
+    cat >> {{.Config}} << EOF
 
-# Make the primary interface not auto-starting.
-grep -q "auto ${PRIMARY_IFACE}" {{.Config}} && \
-sed -i "s/auto ${PRIMARY_IFACE}//" {{.Config}}
+# Primary interface (defining the default route)
+iface ${PRIMARY_IFACE} inet manual
+EOF
+fi`
 
+const bridgeConfigTemplate = `
+# In case we already created the bridge, don't do it again.
+grep -q "iface {{.Bridge}} inet dhcp" {{.Config}} && exit 0
+
+# Discover primary interface at run-time using the default route (if set)
+PRIMARY_IFACE=$(ip route list exact 0/0 | egrep -o 'dev [^ ]+' | cut -b5-)
+
+# If $PRIMARY_IFACE is empty, there's nothing to do.
+[ -z "$PRIMARY_IFACE" ] && exit 0
+
+{{.Script}}
 # Stop $PRIMARY_IFACE and start the bridge instead.
 ifdown -v ${PRIMARY_IFACE} ; ifup -v {{.Bridge}}
 
@@ -1167,16 +1191,36 @@ ip route flush dev $PRIMARY_IFACE scope link proto kernel || true
 // setupJujuNetworking returns a string representing the script to run
 // in order to prepare the Juju-specific networking config on a node.
 func setupJujuNetworking() (string, error) {
+	modifyConfigScript, err := renderEtcNetworkInterfacesScript("/etc/network/interfaces", instancecfg.DefaultBridgeName)
+	if err != nil {
+		return "", err
+	}
 	parsedTemplate := template.Must(
 		template.New("BridgeConfig").Parse(bridgeConfigTemplate),
 	)
 	var buf bytes.Buffer
-	err := parsedTemplate.Execute(&buf, map[string]interface{}{
+	err = parsedTemplate.Execute(&buf, map[string]interface{}{
 		"Config": "/etc/network/interfaces",
 		"Bridge": instancecfg.DefaultBridgeName,
+		"Script": modifyConfigScript,
 	})
 	if err != nil {
 		return "", errors.Annotate(err, "bridge config template error")
+	}
+	return buf.String(), nil
+}
+
+func renderEtcNetworkInterfacesScript(config, bridge string) (string, error) {
+	parsedTemplate := template.Must(
+		template.New("ModifyConfigScript").Parse(modifyEtcNetworkInterfaces),
+	)
+	var buf bytes.Buffer
+	err := parsedTemplate.Execute(&buf, map[string]interface{}{
+		"Config": config,
+		"Bridge": bridge,
+	})
+	if err != nil {
+		return "", errors.Annotate(err, "modify /etc/network/interfaces script template error")
 	}
 	return buf.String(), nil
 }

--- a/provider/maas/environ_test.go
+++ b/provider/maas/environ_test.go
@@ -210,9 +210,9 @@ var expectedCloudinitConfigWithBridge = []string{
 	"mkdir -p '/var/lib/juju'\ncat > '/var/lib/juju/MAASmachine.txt' << 'EOF'\n'hostname: testing.invalid\n'\nEOF\nchmod 0755 '/var/lib/juju/MAASmachine.txt'",
 }
 
-var expectedCloudinitConfigWithBridgeScriptPreamble = "\n# In case we already created the bridge, don't do it again.\ngrep -q \"iface juju-br0 inet dhcp\" /etc/network/interfaces && exit 0\n\n# Discover primary interface at run-time using the default route (if set)\nPRIMARY_IFACE=$(ip route list exact 0/0 | egrep -o 'dev [^ ]+' | cut -b5-)\n\n# If $PRIMARY_IFACE is empty, there's nothing to do.\n[ -z \"$PRIMARY_IFACE\" ] && exit 0\n\n"
+var expectedCloudinitConfigWithBridgeScriptPreamble = "\n# In case we already created the bridge, don't do it again.\ngrep -q \"iface juju-br0 inet dhcp\" /etc/network/interfaces && exit 0\n\n# Discover primary interface at run-time using the default route (if set)\nPRIMARY_IFACE=$(ip route list exact 0/0 | egrep -o 'dev [^ ]+' | cut -b5-)\n\n# If $PRIMARY_IFACE is empty, there's nothing to do.\n[ -z \"$PRIMARY_IFACE\" ] && exit 0\n\n# Log the contents of /etc/network/interfaces prior to modifying\necho \"Contents of /etc/network/interfaces before changes\"\ncat /etc/network/interfaces\n"
 
-var expectedCloudinitConfigWithBridgeScriptPostamble = "\n# Stop $PRIMARY_IFACE and start the bridge instead.\nifdown -v ${PRIMARY_IFACE} ; ifup -v juju-br0\n\n# Finally, remove the route using $PRIMARY_IFACE (if any) so it won't\n# clash with the same automatically added route for juju-br0 (except\n# for the device name).\nip route flush dev $PRIMARY_IFACE scope link proto kernel || true\n"
+var expectedCloudinitConfigWithBridgeScriptPostamble = "\n# Log the contents of /etc/network/interfaces after modifying\necho \"Contents of /etc/network/interfaces after changes\"\ncat /etc/network/interfaces\n# Stop $PRIMARY_IFACE and start the bridge instead.\nifdown -v ${PRIMARY_IFACE} ; ifup -v juju-br0\n\n# Finally, remove the route using $PRIMARY_IFACE (if any) so it won't\n# clash with the same automatically added route for juju-br0 (except\n# for the device name).\nip route flush dev $PRIMARY_IFACE scope link proto kernel || true\n"
 
 var networkStaticInitial = `auto lo
 iface lo inet loopback
@@ -301,6 +301,45 @@ iface eth0:1 inet static
 # Primary interface (defining the default route)
 iface eth0 inet manual
 `
+var networkDHCPWithAliasInitial = `auto lo
+iface lo inet loopback
+
+auto eth0
+iface eth0 inet static
+    gateway 10.14.0.1
+    address 10.14.0.102/24
+
+auto eth0:1
+iface eth0:1 inet static
+    address 10.14.0.103/24
+
+auto eth0:2
+iface eth0:2 inet static
+    address 10.14.0.100/24
+
+dns-nameserver 192.168.1.142`
+
+var networkDHCPWithAliasFinal = `auto lo
+iface lo inet loopback
+
+auto juju-br0
+iface juju-br0 inet static
+    bridge_ports eth0
+    gateway 10.14.0.1
+    address 10.14.0.102/24
+
+auto eth0:1
+iface eth0:1 inet static
+    address 10.14.0.103/24
+
+auto eth0:2
+iface eth0:2 inet static
+    address 10.14.0.100/24
+
+dns-nameserver 192.168.1.142
+# Primary interface (defining the default route)
+iface eth0 inet manual
+`
 
 func writeNetworkScripts(c *gc.C, initialScript string) (string, string) {
 	tempDir := c.MkDir()
@@ -375,6 +414,10 @@ func (s *environSuite) TestRenderNetworkInterfacesScriptMultiple(c *gc.C) {
 
 func (s *environSuite) TestRenderNetworkInterfacesScriptWithAlias(c *gc.C) {
 	s.assertNetworkScript(c, networkWithAliasInitial, networkWithAliasFinal)
+}
+
+func (s *environSuite) TestRenderNetworkInterfacesScriptDHCPWithAlias(c *gc.C) {
+	s.assertNetworkScript(c, networkDHCPWithAliasInitial, networkDHCPWithAliasFinal)
 }
 
 func (*environSuite) TestNewCloudinitConfigWithDisabledNetworkManagement(c *gc.C) {

--- a/provider/maas/export_test.go
+++ b/provider/maas/export_test.go
@@ -33,6 +33,8 @@ func NewCloudinitConfig(env environs.Environ, hostname, iface, series string) (c
 	return env.(*maasEnviron).newCloudinitConfig(hostname, iface, series)
 }
 
+var RenderEtcNetworkInterfacesScript = renderEtcNetworkInterfacesScript
+
 var indexData = `
 {
  "index": {


### PR DESCRIPTION
Fix cloud init to handle the static network configuration used by maas 1.9. Also separate out that part of the cloud init so that it can be unit tested on its own.

(Review request: http://reviews.vapour.ws/r/2894/)