### PR TITLE
1494476 maas 1.9 bootstrap issue - backport

### DIFF
--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -1099,21 +1099,26 @@ func (environ *maasEnviron) selectNode(args selectNodeArgs) (*gomaasapi.MAASObje
 	return &node, nil
 }
 
-const bridgeConfigTemplate = `
-# In case we already created the bridge, don't do it again.
-grep -q "iface {{.Bridge}} inet dhcp" && exit 0
+const modifyEtcNetworkInterfaces = `isDHCP() {
+    grep -q "iface ${PRIMARY_IFACE} inet dhcp" {{.Config}}
+    return $?
+}
 
-# Discover primary interface at run-time using the default route (if set)
-PRIMARY_IFACE=$(ip route list exact 0/0 | egrep -o 'dev [^ ]+' | cut -b5-)
+isStatic() {
+    grep -q "iface ${PRIMARY_IFACE} inet static" {{.Config}}
+    return $?
+}
 
-# If $PRIMARY_IFACE is empty, there's nothing to do.
-[ -z "$PRIMARY_IFACE" ] && exit 0
+unAuto() {
+    grep -q "auto ${PRIMARY_IFACE}\s*$" {{.Config}} && \
+    sed -i "s/auto ${PRIMARY_IFACE}//" {{.Config}}
+}
 
 # Change the config to make $PRIMARY_IFACE manual instead of DHCP,
 # then create the bridge and enslave $PRIMARY_IFACE into it.
-grep -q "iface ${PRIMARY_IFACE} inet dhcp" {{.Config}} && \
-sed -i "s/iface ${PRIMARY_IFACE} inet dhcp//" {{.Config}} && \
-cat >> {{.Config}} << EOF
+if isDHCP; then
+    sed -i "s/iface ${PRIMARY_IFACE} inet dhcp//" {{.Config}}
+    cat >> {{.Config}} << EOF
 
 # Primary interface (defining the default route)
 iface ${PRIMARY_IFACE} inet manual
@@ -1123,11 +1128,30 @@ auto {{.Bridge}}
 iface {{.Bridge}} inet dhcp
     bridge_ports ${PRIMARY_IFACE}
 EOF
+    # Make the primary interface not auto-starting.
+    unAuto
+elif isStatic
+then
+    sed -i "s/iface ${PRIMARY_IFACE} inet static/iface {{.Bridge}} inet static\n    bridge_ports ${PRIMARY_IFACE}/" {{.Config}}
+    sed -i "s/auto ${PRIMARY_IFACE}\s*$/auto {{.Bridge}}/" {{.Config}}
+    cat >> {{.Config}} << EOF
 
-# Make the primary interface not auto-starting.
-grep -q "auto ${PRIMARY_IFACE}" {{.Config}} && \
-sed -i "s/auto ${PRIMARY_IFACE}//" {{.Config}}
+# Primary interface (defining the default route)
+iface ${PRIMARY_IFACE} inet manual
+EOF
+fi`
 
+const bridgeConfigTemplate = `
+# In case we already created the bridge, don't do it again.
+grep -q "iface {{.Bridge}} inet dhcp" {{.Config}} && exit 0
+
+# Discover primary interface at run-time using the default route (if set)
+PRIMARY_IFACE=$(ip route list exact 0/0 | egrep -o 'dev [^ ]+' | cut -b5-)
+
+# If $PRIMARY_IFACE is empty, there's nothing to do.
+[ -z "$PRIMARY_IFACE" ] && exit 0
+
+{{.Script}}
 # Stop $PRIMARY_IFACE and start the bridge instead.
 ifdown -v ${PRIMARY_IFACE} ; ifup -v {{.Bridge}}
 
@@ -1140,16 +1164,36 @@ ip route flush dev $PRIMARY_IFACE scope link proto kernel || true
 // setupJujuNetworking returns a string representing the script to run
 // in order to prepare the Juju-specific networking config on a node.
 func setupJujuNetworking() (string, error) {
+	modifyConfigScript, err := renderEtcNetworkInterfacesScript("/etc/network/interfaces", instancecfg.DefaultBridgeName)
+	if err != nil {
+		return "", err
+	}
 	parsedTemplate := template.Must(
 		template.New("BridgeConfig").Parse(bridgeConfigTemplate),
 	)
 	var buf bytes.Buffer
-	err := parsedTemplate.Execute(&buf, map[string]interface{}{
+	err = parsedTemplate.Execute(&buf, map[string]interface{}{
 		"Config": "/etc/network/interfaces",
 		"Bridge": instancecfg.DefaultBridgeName,
+		"Script": modifyConfigScript,
 	})
 	if err != nil {
 		return "", errors.Annotate(err, "bridge config template error")
+	}
+	return buf.String(), nil
+}
+
+func renderEtcNetworkInterfacesScript(config, bridge string) (string, error) {
+	parsedTemplate := template.Must(
+		template.New("ModifyConfigScript").Parse(modifyEtcNetworkInterfaces),
+	)
+	var buf bytes.Buffer
+	err := parsedTemplate.Execute(&buf, map[string]interface{}{
+		"Config": config,
+		"Bridge": bridge,
+	})
+	if err != nil {
+		return "", errors.Annotate(err, "modify /etc/network/interfaces script template error")
 	}
 	return buf.String(), nil
 }

--- a/provider/maas/environ_test.go
+++ b/provider/maas/environ_test.go
@@ -4,6 +4,10 @@
 package maas_test
 
 import (
+	"io/ioutil"
+	"os/exec"
+	"path/filepath"
+	"runtime"
 	stdtesting "testing"
 
 	jc "github.com/juju/testing/checkers"
@@ -204,7 +208,112 @@ var expectedCloudinitConfig = []string{
 var expectedCloudinitConfigWithBridge = []string{
 	"set -xe",
 	"mkdir -p '/var/lib/juju'\ncat > '/var/lib/juju/MAASmachine.txt' << 'EOF'\n'hostname: testing.invalid\n'\nEOF\nchmod 0755 '/var/lib/juju/MAASmachine.txt'",
-	"\n# In case we already created the bridge, don't do it again.\ngrep -q \"iface juju-br0 inet dhcp\" && exit 0\n\n# Discover primary interface at run-time using the default route (if set)\nPRIMARY_IFACE=$(ip route list exact 0/0 | egrep -o 'dev [^ ]+' | cut -b5-)\n\n# If $PRIMARY_IFACE is empty, there's nothing to do.\n[ -z \"$PRIMARY_IFACE\" ] && exit 0\n\n# Change the config to make $PRIMARY_IFACE manual instead of DHCP,\n# then create the bridge and enslave $PRIMARY_IFACE into it.\ngrep -q \"iface ${PRIMARY_IFACE} inet dhcp\" /etc/network/interfaces && \\\nsed -i \"s/iface ${PRIMARY_IFACE} inet dhcp//\" /etc/network/interfaces && \\\ncat >> /etc/network/interfaces << EOF\n\n# Primary interface (defining the default route)\niface ${PRIMARY_IFACE} inet manual\n\n# Bridge to use for LXC/KVM containers\nauto juju-br0\niface juju-br0 inet dhcp\n    bridge_ports ${PRIMARY_IFACE}\nEOF\n\n# Make the primary interface not auto-starting.\ngrep -q \"auto ${PRIMARY_IFACE}\" /etc/network/interfaces && \\\nsed -i \"s/auto ${PRIMARY_IFACE}//\" /etc/network/interfaces\n\n# Stop $PRIMARY_IFACE and start the bridge instead.\nifdown -v ${PRIMARY_IFACE} ; ifup -v juju-br0\n\n# Finally, remove the route using $PRIMARY_IFACE (if any) so it won't\n# clash with the same automatically added route for juju-br0 (except\n# for the device name).\nip route flush dev $PRIMARY_IFACE scope link proto kernel || true\n",
+}
+
+var expectedCloudinitConfigWithBridgeScriptPreamble = "\n# In case we already created the bridge, don't do it again.\ngrep -q \"iface juju-br0 inet dhcp\" /etc/network/interfaces && exit 0\n\n# Discover primary interface at run-time using the default route (if set)\nPRIMARY_IFACE=$(ip route list exact 0/0 | egrep -o 'dev [^ ]+' | cut -b5-)\n\n# If $PRIMARY_IFACE is empty, there's nothing to do.\n[ -z \"$PRIMARY_IFACE\" ] && exit 0\n\n"
+
+var expectedCloudinitConfigWithBridgeScriptPostamble = "\n# Stop $PRIMARY_IFACE and start the bridge instead.\nifdown -v ${PRIMARY_IFACE} ; ifup -v juju-br0\n\n# Finally, remove the route using $PRIMARY_IFACE (if any) so it won't\n# clash with the same automatically added route for juju-br0 (except\n# for the device name).\nip route flush dev $PRIMARY_IFACE scope link proto kernel || true\n"
+
+var networkStaticInitial = `auto lo
+iface lo inet loopback
+
+auto eth0
+iface eth0 inet static
+    address 1.2.3.4
+    netmask 255.255.255.0
+    gateway 4.3.2.1`
+
+var networkStaticFinal = `auto lo
+iface lo inet loopback
+
+auto juju-br0
+iface juju-br0 inet static
+    bridge_ports eth0
+    address 1.2.3.4
+    netmask 255.255.255.0
+    gateway 4.3.2.1
+# Primary interface (defining the default route)
+iface eth0 inet manual
+`
+
+var networkDHCPInitial = `auto lo
+iface lo inet loopback
+
+auto eth0
+iface eth0 inet dhcp`
+
+var networkDHCPFinal = `auto lo
+iface lo inet loopback
+
+
+
+# Primary interface (defining the default route)
+iface eth0 inet manual
+
+# Bridge to use for LXC/KVM containers
+auto juju-br0
+iface juju-br0 inet dhcp
+    bridge_ports eth0
+`
+
+var networkMultipleInitial = networkStaticInitial + `
+auto eth1
+iface eth1 inet static
+    address 1.2.3.5
+    netmask 255.255.255.0
+    gateway 4.3.2.1`
+
+var networkMultipleFinal = `auto lo
+iface lo inet loopback
+
+auto juju-br0
+iface juju-br0 inet static
+    bridge_ports eth0
+    address 1.2.3.4
+    netmask 255.255.255.0
+    gateway 4.3.2.1
+auto eth1
+iface eth1 inet static
+    address 1.2.3.5
+    netmask 255.255.255.0
+    gateway 4.3.2.1
+# Primary interface (defining the default route)
+iface eth0 inet manual
+`
+
+var networkWithAliasInitial = networkStaticInitial + `
+auto eth0:1
+iface eth0:1 inet static
+    address 1.2.3.5`
+
+var networkWithAliasFinal = `auto lo
+iface lo inet loopback
+
+auto juju-br0
+iface juju-br0 inet static
+    bridge_ports eth0
+    address 1.2.3.4
+    netmask 255.255.255.0
+    gateway 4.3.2.1
+auto eth0:1
+iface eth0:1 inet static
+    address 1.2.3.5
+# Primary interface (defining the default route)
+iface eth0 inet manual
+`
+
+func writeNetworkScripts(c *gc.C, initialScript string) (string, string) {
+	tempDir := c.MkDir()
+	initialScriptPath := filepath.Join(tempDir, "foobar")
+	testScriptPath := filepath.Join(tempDir, "script")
+	err := ioutil.WriteFile(initialScriptPath, []byte(initialScript), 0666)
+	c.Assert(err, jc.ErrorIsNil)
+	script, err := maas.RenderEtcNetworkInterfacesScript(initialScriptPath, "juju-br0")
+	c.Assert(err, jc.ErrorIsNil)
+	fullScript := "PRIMARY_IFACE=\"eth0\"\n" + script
+	err = ioutil.WriteFile(testScriptPath, []byte(fullScript), 0755)
+	c.Assert(err, jc.ErrorIsNil)
+	return testScriptPath, initialScriptPath
 }
 
 func (*environSuite) TestNewCloudinitConfigWithFeatureFlag(c *gc.C) {
@@ -232,7 +341,40 @@ func (s *environSuite) TestNewCloudinitConfigNoFeatureFlag(c *gc.C) {
 
 	// Now test with the flag off.
 	s.SetFeatureFlags() // clear the flags.
+	modifyNetworkScript, err := maas.RenderEtcNetworkInterfacesScript("/etc/network/interfaces", "juju-br0")
+	c.Assert(err, jc.ErrorIsNil)
+	expectedCloudinitConfigWithBridgeScript := expectedCloudinitConfigWithBridgeScriptPreamble + modifyNetworkScript + expectedCloudinitConfigWithBridgeScriptPostamble
+	expectedCloudinitConfigWithBridge = append(expectedCloudinitConfigWithBridge, expectedCloudinitConfigWithBridgeScript)
 	testCase(expectedCloudinitConfigWithBridge)
+}
+
+func (s *environSuite) assertNetworkScript(c *gc.C, initial, final string) {
+	if runtime.GOOS == "windows" {
+		c.Skip("Tests relevant only on *nix systems")
+	}
+	scriptPath, resultPath := writeNetworkScripts(c, initial)
+	cmd := exec.Command("/bin/sh", scriptPath)
+	err := cmd.Run()
+	c.Assert(err, jc.ErrorIsNil)
+	data, err := ioutil.ReadFile(resultPath)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(string(data), jc.DeepEquals, final)
+}
+
+func (s *environSuite) TestRenderNetworkInterfacesScriptDHCP(c *gc.C) {
+	s.assertNetworkScript(c, networkDHCPInitial, networkDHCPFinal)
+}
+
+func (s *environSuite) TestRenderNetworkInterfacesScriptStatic(c *gc.C) {
+	s.assertNetworkScript(c, networkStaticInitial, networkStaticFinal)
+}
+
+func (s *environSuite) TestRenderNetworkInterfacesScriptMultiple(c *gc.C) {
+	s.assertNetworkScript(c, networkMultipleInitial, networkMultipleFinal)
+}
+
+func (s *environSuite) TestRenderNetworkInterfacesScriptWithAlias(c *gc.C) {
+	s.assertNetworkScript(c, networkWithAliasInitial, networkWithAliasFinal)
 }
 
 func (*environSuite) TestNewCloudinitConfigWithDisabledNetworkManagement(c *gc.C) {

--- a/provider/maas/export_test.go
+++ b/provider/maas/export_test.go
@@ -33,6 +33,8 @@ func NewCloudinitConfig(env environs.Environ, hostname, iface, series string) (c
 	return env.(*maasEnviron).newCloudinitConfig(hostname, iface, series)
 }
 
+var RenderEtcNetworkInterfacesScript = renderEtcNetworkInterfacesScript
+
 var indexData = `
 {
  "index": {


### PR DESCRIPTION
 Fix cloud init to handle the static network configuration used by maas 1.9. Also separate out that part of the cloud init so that it can be unit tested on its own.

(Review request: http://reviews.vapour.ws/r/2895/)