### PR TITLE
provider/...: refactor version.Current patching

### DIFF
--- a/provider/ec2/ebs_test.go
+++ b/provider/ec2/ebs_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/arch"
+	"github.com/juju/utils/series"
 	awsec2 "gopkg.in/amz.v3/ec2"
 	"gopkg.in/amz.v3/ec2/ec2test"
 	gc "gopkg.in/check.v1"
@@ -76,11 +77,9 @@ func (s *ebsVolumeSuite) TearDownSuite(c *gc.C) {
 }
 
 func (s *ebsVolumeSuite) SetUpTest(c *gc.C) {
-	s.PatchValue(&version.Current, version.Binary{
-		Number: testing.FakeVersionNumber,
-		Series: testing.FakeDefaultSeries,
-		Arch:   arch.AMD64,
-	})
+	s.BaseSuite.PatchValue(&version.Current.Number, testing.FakeVersionNumber)
+	s.BaseSuite.PatchValue(&arch.HostArch, func() string { return arch.AMD64 })
+	s.BaseSuite.PatchValue(&series.HostSeries, func() string { return testing.FakeDefaultSeries })
 	s.BaseSuite.SetUpTest(c)
 	s.srv.startServer(c)
 	s.Tests.SetUpTest(c)

--- a/provider/ec2/live_test.go
+++ b/provider/ec2/live_test.go
@@ -11,6 +11,7 @@ import (
 
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/arch"
+	"github.com/juju/utils/series"
 	amzec2 "gopkg.in/amz.v3/ec2"
 	gc "gopkg.in/check.v1"
 
@@ -87,11 +88,9 @@ func (t *LiveTests) TearDownSuite(c *gc.C) {
 }
 
 func (t *LiveTests) SetUpTest(c *gc.C) {
-	t.BaseSuite.PatchValue(&version.Current, version.Binary{
-		Number: coretesting.FakeVersionNumber,
-		Series: coretesting.FakeDefaultSeries,
-		Arch:   arch.AMD64,
-	})
+	t.BaseSuite.PatchValue(&version.Current.Number, coretesting.FakeVersionNumber)
+	t.BaseSuite.PatchValue(&arch.HostArch, func() string { return arch.AMD64 })
+	t.BaseSuite.PatchValue(&series.HostSeries, func() string { return coretesting.FakeDefaultSeries })
 	t.BaseSuite.SetUpTest(c)
 	t.LiveTests.SetUpTest(c)
 }

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -15,6 +15,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
 	"github.com/juju/utils/arch"
+	"github.com/juju/utils/series"
 	"github.com/juju/utils/set"
 	"gopkg.in/amz.v3/aws"
 	amzec2 "gopkg.in/amz.v3/ec2"
@@ -193,11 +194,9 @@ func (t *localServerSuite) TearDownSuite(c *gc.C) {
 }
 
 func (t *localServerSuite) SetUpTest(c *gc.C) {
-	t.PatchValue(&version.Current, version.Binary{
-		Number: coretesting.FakeVersionNumber,
-		Series: coretesting.FakeDefaultSeries,
-		Arch:   arch.AMD64,
-	})
+	t.BaseSuite.PatchValue(&version.Current.Number, coretesting.FakeVersionNumber)
+	t.BaseSuite.PatchValue(&arch.HostArch, func() string { return arch.AMD64 })
+	t.BaseSuite.PatchValue(&series.HostSeries, func() string { return coretesting.FakeDefaultSeries })
 	t.BaseSuite.SetUpTest(c)
 	t.SetFeatureFlags(feature.AddressAllocation)
 	t.srv.startServer(c)

--- a/provider/local/environ_test.go
+++ b/provider/local/environ_test.go
@@ -13,6 +13,7 @@ import (
 
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/arch"
+	"github.com/juju/utils/series"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/agent"
@@ -177,8 +178,12 @@ func (s *localJujuTestSuite) testBootstrap(c *gc.C, cfg *config.Config) environs
 	environ, err := local.Provider.PrepareForBootstrap(ctx, cfg)
 	c.Assert(err, jc.ErrorIsNil)
 	availableTools := coretools.List{&coretools.Tools{
-		Version: version.Current,
-		URL:     "http://testing.invalid/tools.tar.gz",
+		Version: version.Binary{
+			Number: version.Current.Number,
+			Arch:   arch.HostArch(),
+			Series: series.HostSeries(),
+		},
+		URL: "http://testing.invalid/tools.tar.gz",
 	}}
 	_, _, finalizer, err := environ.Bootstrap(ctx, environs.BootstrapParams{
 		AvailableTools: availableTools,


### PR DESCRIPTION
This PR will make it easier to land my followup that changes the defintion of
version.Current from a version.Binary to a version.Number.

(Review request: http://reviews.vapour.ws/r/2904/)