### PR TITLE
cmd/jujud/agent/testing: refactor PrimeAgent helper

### DIFF
--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -224,7 +224,7 @@ func (s *commonMachineSuite) configureMachine(c *gc.C, machineId string, vers ve
 		err = s.State.SetStateServingInfo(ssi)
 		c.Assert(err, jc.ErrorIsNil)
 	} else {
-		agentConfig, tools = s.PrimeAgent(c, tag, initialMachinePassword, vers)
+		agentConfig, tools = s.PrimeAgentVersion(c, tag, initialMachinePassword, vers)
 	}
 	err = agentConfig.Write()
 	c.Assert(err, jc.ErrorIsNil)

--- a/cmd/jujud/agent/testing/agent.go
+++ b/cmd/jujud/agent/testing/agent.go
@@ -11,6 +11,8 @@ import (
 	"github.com/juju/names"
 	"github.com/juju/replicaset"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/arch"
+	"github.com/juju/utils/series"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/mgo.v2"
 
@@ -105,10 +107,22 @@ type AgentSuite struct {
 	testing.JujuConnSuite
 }
 
-// PrimeAgent writes the configuration file and tools with version vers
-// for an agent with the given entity name.  It returns the agent's
+// PrimeAgentVersion writes the configuration file and tools for an agent
+// with the given entity name. It returns the agent's configuration and the
+// current tools.
+func (s *AgentSuite) PrimeAgent(c *gc.C, tag names.Tag, password string) (agent.ConfigSetterWriter, *coretools.Tools) {
+	vers := version.Binary{
+		Number: version.Current.Number,
+		Arch:   arch.HostArch(),
+		Series: series.HostSeries(),
+	}
+	return s.PrimeAgentVersion(c, tag, password, vers)
+}
+
+// PrimeAgentVersion writes the configuration file and tools with version
+// vers for an agent with the given entity name. It returns the agent's
 // configuration and the current tools.
-func (s *AgentSuite) PrimeAgent(c *gc.C, tag names.Tag, password string, vers version.Binary) (agent.ConfigSetterWriter, *coretools.Tools) {
+func (s *AgentSuite) PrimeAgentVersion(c *gc.C, tag names.Tag, password string, vers version.Binary) (agent.ConfigSetterWriter, *coretools.Tools) {
 	c.Logf("priming agent %s", tag.String())
 	stor, err := filestorage.NewFileStorageWriter(c.MkDir())
 	c.Assert(err, jc.ErrorIsNil)

--- a/cmd/jujud/agent/unit_test.go
+++ b/cmd/jujud/agent/unit_test.go
@@ -82,7 +82,7 @@ func (s *UnitSuite) primeAgent(c *gc.C) (*state.Machine, *state.Unit, agent.Conf
 	inst, md := jujutesting.AssertStartInstance(c, s.Environ, id)
 	err = machine.SetProvisioned(inst.Id(), agent.BootstrapNonce, md)
 	c.Assert(err, jc.ErrorIsNil)
-	conf, tools := s.PrimeAgent(c, unit.Tag(), initialUnitPassword, version.Current)
+	conf, tools := s.PrimeAgent(c, unit.Tag(), initialUnitPassword)
 	return machine, unit, conf, tools
 }
 
@@ -296,8 +296,7 @@ func (s *UnitSuite) TestOpenAPIState(c *gc.C) {
 }
 
 func (s *UnitSuite) TestOpenAPIStateWithBadCredsTerminates(c *gc.C) {
-	conf, _ := s.PrimeAgent(c, names.NewUnitTag("missing/0"), "no-password", version.Current)
-
+	conf, _ := s.PrimeAgent(c, names.NewUnitTag("missing/0"), "no-password")
 	_, _, err := apicaller.OpenAPIState(fakeConfAgent{conf: conf})
 	c.Assert(err, gc.Equals, worker.ErrTerminateAgent)
 }

--- a/container/kvm/live_test.go
+++ b/container/kvm/live_test.go
@@ -138,7 +138,7 @@ func dummyConfig(c *gc.C) *config.Config {
 	testConfig, err = testConfig.Apply(map[string]interface{}{
 		"type":          "dummy",
 		"state-server":  false,
-		"agent-version": version.Current.Number.String(),
+		"agent-version": version.Current.String(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	return testConfig

--- a/featuretests/dblog_test.go
+++ b/featuretests/dblog_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/juju/juju/state"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/testing/factory"
-	"github.com/juju/juju/version"
 	"github.com/juju/juju/worker/logsender"
 	"github.com/juju/juju/worker/peergrouper"
 )
@@ -89,7 +88,7 @@ func (s *dblogSuite) runMachineAgentTest(c *gc.C) bool {
 		Nonce: agent.BootstrapNonce,
 	})
 
-	s.PrimeAgent(c, m.Tag(), password, version.Current)
+	s.PrimeAgent(c, m.Tag(), password)
 	agentConf := agentcmd.NewAgentConf(s.DataDir())
 	agentConf.ReadConfig(m.Tag().String())
 	logsCh, err := logsender.InstallBufferedLogWriter(1000)
@@ -110,7 +109,7 @@ func (s *dblogSuite) runMachineAgentTest(c *gc.C) bool {
 func (s *dblogSuite) runUnitAgentTest(c *gc.C) bool {
 	// Create a unit and an agent for it.
 	u, password := s.Factory.MakeUnitReturningPassword(c, nil)
-	s.PrimeAgent(c, u.Tag(), password, version.Current)
+	s.PrimeAgent(c, u.Tag(), password)
 	logsCh, err := logsender.InstallBufferedLogWriter(1000)
 	c.Assert(err, jc.ErrorIsNil)
 	a := agentcmd.NewUnitAgent(nil, logsCh)


### PR DESCRIPTION
This PR will make it easier to land my followup that changes the defintion of
version.Current from a version.Binary to a version.Number.

(Review request: http://reviews.vapour.ws/r/2905/)