### PR TITLE
apiserver: allow external users to validate using macaroon authentication

### DIFF
--- a/api/client_macaroon_test.go
+++ b/api/client_macaroon_test.go
@@ -28,9 +28,9 @@ type clientMacaroonSuite struct {
 
 func (s *clientMacaroonSuite) SetUpTest(c *gc.C) {
 	s.MacaroonSuite.SetUpTest(c)
-	s.AddUser(c, "testuser")
+	s.AddEnvUser(c, "testuser@somewhere")
 	s.cookieJar = apitesting.NewClearableCookieJar()
-	s.DischargerLogin = func() string { return "testuser" }
+	s.DischargerLogin = func() string { return "testuser@somewhere" }
 	s.client = s.OpenAPI(c, nil, s.cookieJar).Client()
 
 	// Even though we've logged into the API, we want

--- a/api/state_macaroon_test.go
+++ b/api/state_macaroon_test.go
@@ -18,9 +18,11 @@ type macaroonLoginSuite struct {
 	client api.Connection
 }
 
+const testUserName = "testuser@somewhere"
+
 func (s *macaroonLoginSuite) SetUpTest(c *gc.C) {
 	s.MacaroonSuite.SetUpTest(c)
-	s.AddUser(c, "testuser")
+	s.AddEnvUser(c, testUserName)
 	info := s.APIInfo(c)
 	// Don't log in.
 	info.UseMacaroons = false
@@ -33,7 +35,7 @@ func (s *macaroonLoginSuite) TearDownTest(c *gc.C) {
 }
 
 func (s *macaroonLoginSuite) TestSuccessfulLogin(c *gc.C) {
-	s.DischargerLogin = func() string { return "testuser" }
+	s.DischargerLogin = func() string { return testUserName }
 	err := s.client.Login(nil, "", "")
 	c.Assert(err, jc.ErrorIsNil)
 }
@@ -57,7 +59,7 @@ func (s *macaroonLoginSuite) TestConnectStream(c *gc.C) {
 	dischargeCount := 0
 	s.DischargerLogin = func() string {
 		dischargeCount++
-		return "testuser"
+		return testUserName
 	}
 	// First log into the regular API.
 	err := s.client.Login(nil, "", "")
@@ -92,7 +94,7 @@ func (s *macaroonLoginSuite) TestConnectStreamFailedDischarge(c *gc.C) {
 		if dischargeError {
 			return ""
 		}
-		return "testuser"
+		return testUserName
 	}
 
 	// Make an API connection that uses a cookie jar

--- a/api/testing/macaroonsuite.go
+++ b/api/testing/macaroonsuite.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 
 	"github.com/juju/errors"
+	"github.com/juju/names"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/macaroon-bakery.v1/bakery/checkers"
 	"gopkg.in/macaroon-bakery.v1/bakerytest"
@@ -62,10 +63,15 @@ func (s *MacaroonSuite) TearDownTest(c *gc.C) {
 	s.JujuConnSuite.TearDownTest(c)
 }
 
-// AddUser adds a new user to the user database.
-func (s *MacaroonSuite) AddUser(c *gc.C, name string) {
-	s.Factory.MakeUser(c, &factory.UserParams{
-		Name: name,
+// AddEnvUser is a convenience function that adds an external
+// user to the current environment. It will panic
+// if the user name is local.
+func (s *MacaroonSuite) AddEnvUser(c *gc.C, username string) {
+	if names.NewUserTag(username).IsLocal() {
+		panic("cannot use MacaroonSuite.AddEnvUser to add a local name")
+	}
+	s.Factory.MakeEnvUser(c, &factory.EnvUserParams{
+		User: username,
 	})
 }
 

--- a/apiserver/backup_test.go
+++ b/apiserver/backup_test.go
@@ -17,7 +17,6 @@ import (
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
-	"gopkg.in/macaroon-bakery.v1/bakery/checkers"
 	"gopkg.in/macaroon-bakery.v1/httpbakery"
 
 	"github.com/juju/juju/apiserver"
@@ -141,14 +140,9 @@ func (s *backupsWithMacaroonsSuite) TestWithNoBasicAuthReturnsDischargeRequiredE
 
 func (s *backupsWithMacaroonsSuite) TestCanGetWithDischargedMacaroon(c *gc.C) {
 	checkCount := 0
-	s.checker = func(cond, arg string) ([]checkers.Caveat, error) {
-		if cond != "is-authenticated-user" {
-			return nil, errors.Errorf("unrecognized caveat %q", cond)
-		}
+	s.DischargerLogin = func() string {
 		checkCount++
-		return []checkers.Caveat{
-			checkers.DeclaredCaveat("username", s.userTag.Id()),
-		}, nil
+		return s.userTag.Id()
 	}
 	s.fake.Error = errors.New("failed!")
 	resp := s.sendRequest(c, httpRequestParams{

--- a/apiserver/charms_test.go
+++ b/apiserver/charms_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v6-unstable"
-	"gopkg.in/macaroon-bakery.v1/bakery/checkers"
 	"gopkg.in/macaroon-bakery.v1/httpbakery"
 
 	"github.com/juju/juju/apiserver/params"
@@ -521,14 +520,9 @@ func (s *charmsWithMacaroonsSuite) TestWithNoBasicAuthReturnsDischargeRequiredEr
 
 func (s *charmsWithMacaroonsSuite) TestCanPostWithDischargedMacaroon(c *gc.C) {
 	checkCount := 0
-	s.checker = func(cond, arg string) ([]checkers.Caveat, error) {
-		if cond != "is-authenticated-user" {
-			return nil, errors.Errorf("unrecognized caveat %q", cond)
-		}
+	s.DischargerLogin = func() string {
 		checkCount++
-		return []checkers.Caveat{
-			checkers.DeclaredCaveat("username", s.userTag.Id()),
-		}, nil
+		return s.userTag.Id()
 	}
 	resp := s.sendRequest(c, httpRequestParams{
 		do:     s.doer(),

--- a/apiserver/tools_test.go
+++ b/apiserver/tools_test.go
@@ -17,7 +17,6 @@ import (
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
-	"gopkg.in/macaroon-bakery.v1/bakery/checkers"
 
 	commontesting "github.com/juju/juju/apiserver/common/testing"
 	"github.com/juju/juju/apiserver/params"
@@ -441,14 +440,9 @@ func (s *toolsWithMacaroonsSuite) TestWithNoBasicAuthReturnsDischargeRequiredErr
 
 func (s *toolsWithMacaroonsSuite) TestCanPostWithDischargedMacaroon(c *gc.C) {
 	checkCount := 0
-	s.checker = func(cond, arg string) ([]checkers.Caveat, error) {
-		if cond != "is-authenticated-user" {
-			return nil, errors.Errorf("unrecognized caveat %q", cond)
-		}
+	s.DischargerLogin = func() string {
 		checkCount++
-		return []checkers.Caveat{
-			checkers.DeclaredCaveat("username", s.userTag.Id()),
-		}, nil
+		return s.userTag.Id()
 	}
 	resp := s.sendRequest(c, httpRequestParams{
 		do:     s.doer(),

--- a/apiserver/usermanager/usermanager.go
+++ b/apiserver/usermanager/usermanager.go
@@ -21,15 +21,6 @@ func init() {
 	common.RegisterStandardFacade("UserManager", 0, NewUserManagerAPI)
 }
 
-// UserManager defines the methods on the usermanager API end point.
-type UserManager interface {
-	AddUser(args params.AddUsers) (params.AddUserResults, error)
-	DisableUser(args params.Entities) (params.ErrorResults, error)
-	EnableUser(args params.Entities) (params.ErrorResults, error)
-	SetPassword(args params.EntityPasswords) (params.ErrorResults, error)
-	UserInfo(args params.UserInfoRequest) (params.UserInfoResults, error)
-}
-
 // UserManagerAPI implements the user manager interface and is the concrete
 // implementation of the api end point.
 type UserManagerAPI struct {
@@ -37,8 +28,6 @@ type UserManagerAPI struct {
 	authorizer common.Authorizer
 	check      *common.BlockChecker
 }
-
-var _ UserManager = (*UserManagerAPI)(nil)
 
 func NewUserManagerAPI(
 	st *state.State,

--- a/testing/factory/factory.go
+++ b/testing/factory/factory.go
@@ -39,6 +39,7 @@ func NewFactory(st *state.State) *Factory {
 	return &Factory{st: st}
 }
 
+// UserParams defines the parameters for creating a user with MakeUser.
 type UserParams struct {
 	Name        string
 	DisplayName string
@@ -136,6 +137,8 @@ func uniqueString(prefix string) string {
 // For attributes of UserParams that are the default empty values,
 // some meaningful valid values are used instead.
 // If params is not specified, defaults are used.
+// If params.NoEnvUser is false, the user will also be created
+// in the current environment.
 func (factory *Factory) MakeUser(c *gc.C, params *UserParams) *state.User {
 	if params == nil {
 		params = &UserParams{}


### PR DESCRIPTION
We don't allow an external macaroon discharger to speak for any
locally created user. Since existing implementations do return
usernames with no domains, we automatically append a "@external"
suffix in that case so we can continue to work with them.


(Review request: http://reviews.vapour.ws/r/2909/)