### PR TITLE
version: make version.Current a version.Number

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -55,7 +55,7 @@ var agentConfigTests = []struct {
 	params: agent.AgentConfigParams{
 		Paths:             agent.Paths{DataDir: "/data/dir"},
 		Tag:               names.NewMachineTag("1"),
-		UpgradedToVersion: version.Current.Number,
+		UpgradedToVersion: version.Current,
 	},
 	checkErr: "password not found in configuration",
 }, {
@@ -63,7 +63,7 @@ var agentConfigTests = []struct {
 	params: agent.AgentConfigParams{
 		Paths:             agent.Paths{DataDir: "/data/dir"},
 		Tag:               names.NewMachineTag("1"),
-		UpgradedToVersion: version.Current.Number,
+		UpgradedToVersion: version.Current,
 		Password:          "sekrit",
 	},
 	checkErr: "environment not found in configuration",
@@ -72,7 +72,7 @@ var agentConfigTests = []struct {
 	params: agent.AgentConfigParams{
 		Paths:             agent.Paths{DataDir: "/data/dir"},
 		Tag:               names.NewMachineTag("1"),
-		UpgradedToVersion: version.Current.Number,
+		UpgradedToVersion: version.Current,
 		Password:          "sekrit",
 		Environment:       names.NewEnvironTag("uuid"),
 	},
@@ -82,7 +82,7 @@ var agentConfigTests = []struct {
 	params: agent.AgentConfigParams{
 		Paths:             agent.Paths{DataDir: "/data/dir"},
 		Tag:               names.NewMachineTag("1"),
-		UpgradedToVersion: version.Current.Number,
+		UpgradedToVersion: version.Current,
 		Password:          "sekrit",
 		Environment:       testing.EnvironmentTag,
 	},
@@ -92,7 +92,7 @@ var agentConfigTests = []struct {
 	params: agent.AgentConfigParams{
 		Paths:             agent.Paths{DataDir: "/data/dir"},
 		Tag:               names.NewMachineTag("1"),
-		UpgradedToVersion: version.Current.Number,
+		UpgradedToVersion: version.Current,
 		Password:          "sekrit",
 		CACert:            "ca cert",
 		Environment:       testing.EnvironmentTag,
@@ -103,7 +103,7 @@ var agentConfigTests = []struct {
 	params: agent.AgentConfigParams{
 		Paths:             agent.Paths{DataDir: "/data/dir"},
 		Tag:               names.NewMachineTag("1"),
-		UpgradedToVersion: version.Current.Number,
+		UpgradedToVersion: version.Current,
 		Password:          "sekrit",
 		CACert:            "ca cert",
 		Environment:       testing.EnvironmentTag,
@@ -115,7 +115,7 @@ var agentConfigTests = []struct {
 	params: agent.AgentConfigParams{
 		Paths:             agent.Paths{DataDir: "/data/dir"},
 		Tag:               names.NewMachineTag("1"),
-		UpgradedToVersion: version.Current.Number,
+		UpgradedToVersion: version.Current,
 		Password:          "sekrit",
 		CACert:            "ca cert",
 		Environment:       testing.EnvironmentTag,
@@ -127,7 +127,7 @@ var agentConfigTests = []struct {
 	params: agent.AgentConfigParams{
 		Paths:             agent.Paths{DataDir: "/data/dir"},
 		Tag:               names.NewMachineTag("1"),
-		UpgradedToVersion: version.Current.Number,
+		UpgradedToVersion: version.Current,
 		Password:          "sekrit",
 		CACert:            "ca cert",
 		Environment:       testing.EnvironmentTag,
@@ -138,7 +138,7 @@ var agentConfigTests = []struct {
 	params: agent.AgentConfigParams{
 		Paths:             agent.Paths{DataDir: "/data/dir"},
 		Tag:               names.NewMachineTag("1"),
-		UpgradedToVersion: version.Current.Number,
+		UpgradedToVersion: version.Current,
 		Password:          "sekrit",
 		CACert:            "ca cert",
 		Environment:       testing.EnvironmentTag,
@@ -149,7 +149,7 @@ var agentConfigTests = []struct {
 	params: agent.AgentConfigParams{
 		Paths:             agent.Paths{DataDir: "/data/dir"},
 		Tag:               names.NewMachineTag("1"),
-		UpgradedToVersion: version.Current.Number,
+		UpgradedToVersion: version.Current,
 		Password:          "sekrit",
 		CACert:            "ca cert",
 		Environment:       testing.EnvironmentTag,
@@ -162,7 +162,7 @@ var agentConfigTests = []struct {
 		Paths:             agent.Paths{DataDir: "/data/dir"},
 		Tag:               names.NewMachineTag("1"),
 		Password:          "sekrit",
-		UpgradedToVersion: version.Current.Number,
+		UpgradedToVersion: version.Current,
 		CACert:            "ca cert",
 		Environment:       testing.EnvironmentTag,
 		StateAddresses:    []string{"localhost:1234"},
@@ -175,7 +175,7 @@ var agentConfigTests = []struct {
 		Paths:             agent.Paths{DataDir: "/data/dir"},
 		Tag:               names.NewMachineTag("1"),
 		Password:          "sekrit",
-		UpgradedToVersion: version.Current.Number,
+		UpgradedToVersion: version.Current,
 		CACert:            "ca cert",
 		Environment:       testing.EnvironmentTag,
 		StateAddresses:    []string{"localhost:1234"},
@@ -191,7 +191,7 @@ var agentConfigTests = []struct {
 		Paths:             agent.Paths{DataDir: "/data/dir"},
 		Tag:               names.NewMachineTag("1"),
 		Password:          "sekrit",
-		UpgradedToVersion: version.Current.Number,
+		UpgradedToVersion: version.Current,
 		CACert:            "ca cert",
 		Environment:       testing.EnvironmentTag,
 		StateAddresses:    []string{"localhost:1234"},
@@ -210,7 +210,7 @@ var agentConfigTests = []struct {
 		},
 		Tag:               names.NewMachineTag("1"),
 		Password:          "sekrit",
-		UpgradedToVersion: version.Current.Number,
+		UpgradedToVersion: version.Current,
 		CACert:            "ca cert",
 		Environment:       testing.EnvironmentTag,
 		StateAddresses:    []string{"localhost:1234"},
@@ -225,7 +225,7 @@ var agentConfigTests = []struct {
 	params: agent.AgentConfigParams{
 		Paths:             agent.Paths{DataDir: "/data/dir"},
 		Tag:               names.NewUserTag("admin"), // this is a joke, the admin user is nil.
-		UpgradedToVersion: version.Current.Number,
+		UpgradedToVersion: version.Current,
 		Password:          "sekrit",
 	},
 	checkErr: "entity tag must be MachineTag or UnitTag, got names.UserTag",
@@ -235,7 +235,7 @@ var agentConfigTests = []struct {
 		Paths:             agent.Paths{DataDir: "/data/dir"},
 		Tag:               names.NewUnitTag("ubuntu/1"),
 		Password:          "sekrit",
-		UpgradedToVersion: version.Current.Number,
+		UpgradedToVersion: version.Current,
 		Environment:       testing.EnvironmentTag,
 		CACert:            "ca cert",
 		StateAddresses:    []string{"localhost:1234"},
@@ -250,7 +250,7 @@ var agentConfigTests = []struct {
 		Paths:             agent.Paths{DataDir: "/data/dir"},
 		Tag:               names.NewMachineTag("1"),
 		Password:          "sekrit",
-		UpgradedToVersion: version.Current.Number,
+		UpgradedToVersion: version.Current,
 		CACert:            "ca cert",
 		Environment:       testing.EnvironmentTag,
 		StateAddresses:    []string{"localhost:1234"},
@@ -267,7 +267,7 @@ var agentConfigTests = []struct {
 		Paths:             agent.Paths{DataDir: "/data/dir"},
 		Tag:               names.NewMachineTag("1"),
 		Password:          "sekrit",
-		UpgradedToVersion: version.Current.Number,
+		UpgradedToVersion: version.Current,
 		CACert:            "ca cert",
 		Environment:       testing.EnvironmentTag,
 		StateAddresses:    []string{"localhost:1234"},
@@ -506,7 +506,7 @@ var attributeParams = agent.AgentConfigParams{
 		DataDir: "/data/dir",
 	},
 	Tag:               names.NewMachineTag("1"),
-	UpgradedToVersion: version.Current.Number,
+	UpgradedToVersion: version.Current,
 	Password:          "sekrit",
 	CACert:            "ca cert",
 	StateAddresses:    []string{"localhost:1234"},
@@ -525,7 +525,7 @@ func (*suite) TestAttributes(c *gc.C) {
 	c.Assert(conf.Tag(), gc.Equals, names.NewMachineTag("1"))
 	c.Assert(conf.Dir(), gc.Equals, "/data/dir/agents/machine-1")
 	c.Assert(conf.Nonce(), gc.Equals, "a nonce")
-	c.Assert(conf.UpgradedToVersion(), jc.DeepEquals, version.Current.Number)
+	c.Assert(conf.UpgradedToVersion(), jc.DeepEquals, version.Current)
 }
 
 func (*suite) TestStateServingInfo(c *gc.C) {
@@ -723,7 +723,7 @@ func (*suite) TestSetUpgradedToVersion(c *gc.C) {
 	conf, err := agent.NewAgentConfig(attributeParams)
 	c.Assert(err, jc.ErrorIsNil)
 
-	c.Assert(conf.UpgradedToVersion(), gc.Equals, version.Current.Number)
+	c.Assert(conf.UpgradedToVersion(), gc.Equals, version.Current)
 
 	expectVers := version.MustParse("3.4.5")
 	conf.SetUpgradedToVersion(expectVers)

--- a/agent/bootstrap_test.go
+++ b/agent/bootstrap_test.go
@@ -89,7 +89,7 @@ LXC_BRIDGE="ignored"`[1:])
 	configParams := agent.AgentConfigParams{
 		Paths:             agent.Paths{DataDir: dataDir},
 		Tag:               names.NewMachineTag("0"),
-		UpgradedToVersion: version.Current.Number,
+		UpgradedToVersion: version.Current,
 		StateAddresses:    []string{s.mgoInst.Addr()},
 		CACert:            testing.CACert,
 		Password:          pwHash,
@@ -136,7 +136,7 @@ LXC_BRIDGE="ignored"`[1:])
 		filteredAddrs = append([]network.Address{}, initialAddrs...)
 	}
 	envAttrs := dummy.SampleConfig().Delete("admin-secret").Merge(testing.Attrs{
-		"agent-version": version.Current.Number.String(),
+		"agent-version": version.Current.String(),
 		"state-id":      "1", // needed so policy can Open config
 	})
 	envCfg, err := config.New(config.NoDefaults, envAttrs)
@@ -222,7 +222,7 @@ func (s *bootstrapSuite) TestInitializeStateWithStateServingInfoNotAvailable(c *
 	configParams := agent.AgentConfigParams{
 		Paths:             agent.Paths{DataDir: c.MkDir()},
 		Tag:               names.NewMachineTag("0"),
-		UpgradedToVersion: version.Current.Number,
+		UpgradedToVersion: version.Current,
 		StateAddresses:    []string{s.mgoInst.Addr()},
 		CACert:            testing.CACert,
 		Password:          "fake",
@@ -247,7 +247,7 @@ func (s *bootstrapSuite) TestInitializeStateFailsSecondTime(c *gc.C) {
 	configParams := agent.AgentConfigParams{
 		Paths:             agent.Paths{DataDir: dataDir},
 		Tag:               names.NewMachineTag("0"),
-		UpgradedToVersion: version.Current.Number,
+		UpgradedToVersion: version.Current,
 		StateAddresses:    []string{s.mgoInst.Addr()},
 		CACert:            testing.CACert,
 		Password:          pwHash,
@@ -272,7 +272,7 @@ func (s *bootstrapSuite) TestInitializeStateFailsSecondTime(c *gc.C) {
 		Characteristics: expectHW,
 	}
 	envAttrs := dummy.SampleConfig().Delete("admin-secret").Merge(testing.Attrs{
-		"agent-version": version.Current.Number.String(),
+		"agent-version": version.Current.String(),
 		"state-id":      "1", // needed so policy can Open config
 	})
 	envCfg, err := config.New(config.NoDefaults, envAttrs)

--- a/agent/format_whitebox_test.go
+++ b/agent/format_whitebox_test.go
@@ -30,7 +30,7 @@ var _ = gc.Suite(&formatSuite{})
 // located here for easy reuse.
 var agentParams = AgentConfigParams{
 	Tag:               names.NewMachineTag("1"),
-	UpgradedToVersion: version.Current.Number,
+	UpgradedToVersion: version.Current,
 	Jobs:              []multiwatcher.MachineJob{multiwatcher.JobHostUnits},
 	Password:          "sekrit",
 	CACert:            "ca cert",

--- a/agent/identity_test.go
+++ b/agent/identity_test.go
@@ -28,7 +28,7 @@ var _ = gc.Suite(&identitySuite{})
 
 var attributeParams = AgentConfigParams{
 	Tag:               names.NewMachineTag("1"),
-	UpgradedToVersion: version.Current.Number,
+	UpgradedToVersion: version.Current,
 	Password:          "sekrit",
 	CACert:            "ca cert",
 	StateAddresses:    []string{"localhost:1234"},

--- a/api/apiclient_test.go
+++ b/api/apiclient_test.go
@@ -112,7 +112,7 @@ func (s *apiclientSuite) TestOpen(c *gc.C) {
 
 	remoteVersion, versionSet := st.ServerVersion()
 	c.Assert(versionSet, jc.IsTrue)
-	c.Assert(remoteVersion, gc.Equals, version.Current.Number)
+	c.Assert(remoteVersion, gc.Equals, version.Current)
 }
 
 func (s *apiclientSuite) TestOpenHonorsEnvironTag(c *gc.C) {

--- a/api/provisioner/provisioner_test.go
+++ b/api/provisioner/provisioner_test.go
@@ -806,7 +806,12 @@ func (s *provisionerSuite) TestFindToolsLogicError(c *gc.C) {
 }
 
 func (s *provisionerSuite) testFindTools(c *gc.C, matchArch bool, apiError, logicError error) {
-	var toolsList = coretools.List{&coretools.Tools{Version: version.Current}}
+	current := version.Binary{
+		Number: version.Current,
+		Arch:   arch.HostArch(),
+		Series: series.HostSeries(),
+	}
+	var toolsList = coretools.List{&coretools.Tools{Version: current}}
 	var called bool
 	var a string
 	if matchArch {
@@ -819,7 +824,7 @@ func (s *provisionerSuite) testFindTools(c *gc.C, matchArch bool, apiError, logi
 		called = true
 		c.Assert(request, gc.Equals, "FindTools")
 		expected := params.FindToolsParams{
-			Number:       version.Current.Number,
+			Number:       version.Current,
 			Series:       series.HostSeries(),
 			Arch:         a,
 			MinorVersion: -1,
@@ -833,7 +838,7 @@ func (s *provisionerSuite) testFindTools(c *gc.C, matchArch bool, apiError, logi
 		}
 		return apiError
 	})
-	apiList, err := s.provisioner.FindTools(version.Current.Number, series.HostSeries(), a)
+	apiList, err := s.provisioner.FindTools(version.Current, series.HostSeries(), a)
 	c.Assert(called, jc.IsTrue)
 	if apiError != nil {
 		c.Assert(err, gc.Equals, apiError)

--- a/api/upgrader/upgrader_test.go
+++ b/api/upgrader/upgrader_test.go
@@ -56,28 +56,27 @@ func (s *machineUpgraderSuite) TestNew(c *gc.C) {
 }
 
 func (s *machineUpgraderSuite) TestSetVersionWrongMachine(c *gc.C) {
-	err := s.st.SetVersion("machine-42", version.Current)
+	err := s.st.SetVersion("machine-42", current)
 	c.Assert(err, gc.ErrorMatches, "permission denied")
 	c.Assert(err, jc.Satisfies, params.IsCodeUnauthorized)
 }
 
 func (s *machineUpgraderSuite) TestSetVersionNotMachine(c *gc.C) {
-	err := s.st.SetVersion("foo-42", version.Current)
+	err := s.st.SetVersion("foo-42", current)
 	c.Assert(err, gc.ErrorMatches, "permission denied")
 	c.Assert(err, jc.Satisfies, params.IsCodeUnauthorized)
 }
 
 func (s *machineUpgraderSuite) TestSetVersion(c *gc.C) {
-	cur := version.Current
 	agentTools, err := s.rawMachine.AgentTools()
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 	c.Assert(agentTools, gc.IsNil)
-	err = s.st.SetVersion(s.rawMachine.Tag().String(), cur)
+	err = s.st.SetVersion(s.rawMachine.Tag().String(), current)
 	c.Assert(err, jc.ErrorIsNil)
 	s.rawMachine.Refresh()
 	agentTools, err = s.rawMachine.AgentTools()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Check(agentTools.Version, gc.Equals, cur)
+	c.Check(agentTools.Version, gc.Equals, current)
 }
 
 func (s *machineUpgraderSuite) TestToolsWrongMachine(c *gc.C) {
@@ -95,17 +94,16 @@ func (s *machineUpgraderSuite) TestToolsNotMachine(c *gc.C) {
 }
 
 func (s *machineUpgraderSuite) TestTools(c *gc.C) {
-	cur := version.Current
-	curTools := &tools.Tools{Version: cur, URL: ""}
+	curTools := &tools.Tools{Version: current, URL: ""}
 	curTools.Version.Minor++
-	s.rawMachine.SetAgentVersion(cur)
+	s.rawMachine.SetAgentVersion(current)
 	// Upgrader.Tools returns the *desired* set of tools, not the currently
 	// running set. We want to be upgraded to cur.Version
 	stateTools, err := s.st.Tools(s.rawMachine.Tag().String())
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(stateTools.Version, gc.Equals, cur)
+	c.Assert(stateTools.Version, gc.Equals, current)
 	url := fmt.Sprintf("https://%s/environment/%s/tools/%s",
-		s.stateAPI.Addr(), coretesting.EnvironmentTag.Id(), cur)
+		s.stateAPI.Addr(), coretesting.EnvironmentTag.Id(), current)
 	c.Assert(stateTools.URL, gc.Equals, url)
 }
 
@@ -134,13 +132,12 @@ func (s *machineUpgraderSuite) TestWatchAPIVersion(c *gc.C) {
 }
 
 func (s *machineUpgraderSuite) TestDesiredVersion(c *gc.C) {
-	cur := version.Current
-	curTools := &tools.Tools{Version: cur, URL: ""}
+	curTools := &tools.Tools{Version: current, URL: ""}
 	curTools.Version.Minor++
-	s.rawMachine.SetAgentVersion(cur)
+	s.rawMachine.SetAgentVersion(current)
 	// Upgrader.DesiredVersion returns the *desired* set of tools, not the
 	// currently running set. We want to be upgraded to cur.Version
 	stateVersion, err := s.st.DesiredVersion(s.rawMachine.Tag().String())
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(stateVersion, gc.Equals, cur.Number)
+	c.Assert(stateVersion, gc.Equals, current.Number)
 }

--- a/apiserver/admin.go
+++ b/apiserver/admin.go
@@ -168,7 +168,7 @@ func (a *admin) doLogin(req params.LoginRequest, loginVersion int) (params.Login
 		ServerTag:     environ.ServerTag().String(),
 		Facades:       DescribeFacades(),
 		UserInfo:      maybeUserInfo,
-		ServerVersion: version.Current.Number.String(),
+		ServerVersion: version.Current.String(),
 	}
 
 	// For sufficiently modern login versions, stop serving the

--- a/apiserver/client/client.go
+++ b/apiserver/client/client.go
@@ -926,7 +926,7 @@ func (c *Client) SetAnnotations(args params.SetAnnotations) error {
 
 // AgentVersion returns the current version that the API server is running.
 func (c *Client) AgentVersion() (params.AgentVersionResult, error) {
-	return params.AgentVersionResult{Version: version.Current.Number}, nil
+	return params.AgentVersionResult{Version: version.Current}, nil
 }
 
 // EnvironmentGet implements the server-side part of the

--- a/apiserver/client/client_test.go
+++ b/apiserver/client/client_test.go
@@ -3416,7 +3416,7 @@ func (s *clientSuite) TestAPIHostPorts(c *gc.C) {
 
 func (s *clientSuite) TestClientAgentVersion(c *gc.C) {
 	current := version.MustParse("1.2.0")
-	s.PatchValue(&version.Current.Number, current)
+	s.PatchValue(&version.Current, current)
 	result, err := s.APIState.Client().AgentVersion()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.Equals, current)

--- a/apiserver/client/perm_test.go
+++ b/apiserver/client/perm_test.go
@@ -446,7 +446,7 @@ func opClientSetEnvironAgentVersion(c *gc.C, st api.Connection, mst *state.State
 	if err != nil {
 		return func() {}, err
 	}
-	err = st.Client().SetEnvironAgentVersion(version.Current.Number)
+	err = st.Client().SetEnvironAgentVersion(version.Current)
 	if err != nil {
 		return func() {}, err
 	}

--- a/apiserver/environmentmanager/environmentmanager.go
+++ b/apiserver/environmentmanager/environmentmanager.go
@@ -170,7 +170,7 @@ func (em *EnvironmentManagerAPI) checkVersion(cfg map[string]interface{}) error 
 	// otherwise we need to check for tools
 	value, found := cfg["agent-version"]
 	if !found {
-		cfg["agent-version"] = version.Current.Number.String()
+		cfg["agent-version"] = version.Current.String()
 		return nil
 	}
 	valuestr, ok := value.(string)
@@ -181,8 +181,8 @@ func (em *EnvironmentManagerAPI) checkVersion(cfg map[string]interface{}) error 
 	if err != nil {
 		return errors.Trace(err)
 	}
-	if comp := num.Compare(version.Current.Number); comp > 0 {
-		return errors.Errorf("agent-version cannot be greater than the server: %s", version.Current.Number)
+	if comp := num.Compare(version.Current); comp > 0 {
+		return errors.Errorf("agent-version cannot be greater than the server: %s", version.Current)
 	} else if comp < 0 {
 		// Look to see if we have tools available for that version.
 		// Obviously if the version is the same, we have the tools available.

--- a/apiserver/environmentmanager/environmentmanager_test.go
+++ b/apiserver/environmentmanager/environmentmanager_test.go
@@ -270,7 +270,7 @@ func (s *envManagerSuite) TestCreateEnvironmentBadConfig(c *gc.C) {
 func (s *envManagerSuite) TestCreateEnvironmentSameAgentVersion(c *gc.C) {
 	admin := s.AdminUserTag(c)
 	s.setAPIUser(c, admin)
-	args := s.createArgsForVersion(c, admin, version.Current.Number.String())
+	args := s.createArgsForVersion(c, admin, version.Current.String())
 	_, err := s.envmanager.CreateEnvironment(args)
 	c.Assert(err, jc.ErrorIsNil)
 }
@@ -279,10 +279,10 @@ func (s *envManagerSuite) TestCreateEnvironmentBadAgentVersion(c *gc.C) {
 	admin := s.AdminUserTag(c)
 	s.setAPIUser(c, admin)
 
-	bigger := version.Current.Number
+	bigger := version.Current
 	bigger.Minor += 1
 
-	smaller := version.Current.Number
+	smaller := version.Current
 	smaller.Minor -= 1
 
 	for i, test := range []struct {

--- a/apiserver/upgrader/upgrader.go
+++ b/apiserver/upgrader/upgrader.go
@@ -160,7 +160,7 @@ func (u *UpgraderAPI) DesiredVersion(args params.Entities) (params.VersionResult
 		return params.VersionResults{}, common.ServerError(err)
 	}
 	// Is the desired version greater than the current API server version?
-	isNewerVersion := agentVersion.Compare(version.Current.Number) > 0
+	isNewerVersion := agentVersion.Compare(version.Current) > 0
 	for i, entity := range args.Entities {
 		tag, err := names.ParseTag(entity.Tag)
 		if err != nil {
@@ -182,8 +182,8 @@ func (u *UpgraderAPI) DesiredVersion(args params.Entities) (params.VersionResult
 			if !isNewerVersion || u.entityIsManager(tag) {
 				results[i].Version = &agentVersion
 			} else {
-				logger.Debugf("desired version is %s, but current version is %s and agent is not a manager node", agentVersion, version.Current.Number)
-				results[i].Version = &version.Current.Number
+				logger.Debugf("desired version is %s, but current version is %s and agent is not a manager node", agentVersion, version.Current)
+				results[i].Version = &version.Current
 			}
 			err = nil
 		}

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -155,7 +155,7 @@ func (c *bootstrapCommand) Init(args []string) (err error) {
 		}
 	}
 	if c.NoAutoUpgrade {
-		vers := version.Current.Number
+		vers := version.Current
 		c.AgentVersion = &vers
 	} else if c.AgentVersionParam != "" {
 		if vers, err := version.ParseBinary(c.AgentVersionParam); err == nil {

--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -240,7 +240,7 @@ type versionDeprecation struct {
 // If the current version is after the deprecate version number,
 // the command is deprecated and the replacement should be used.
 func (v *versionDeprecation) Deprecated() (bool, string) {
-	if version.Current.Number.Compare(v.deprecate) > 0 {
+	if version.Current.Compare(v.deprecate) > 0 {
 		return true, v.replacement
 	}
 	return false, ""
@@ -250,7 +250,7 @@ func (v *versionDeprecation) Deprecated() (bool, string) {
 // If the current version is after the obsolete version number,
 // the command is obsolete and shouldn't be registered.
 func (v *versionDeprecation) Obsolete() bool {
-	return version.Current.Number.Compare(v.obsolete) > 0
+	return version.Current.Compare(v.obsolete) > 0
 }
 
 func twoDotOhDeprecation(replacement string) cmd.DeprecationCheck {

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -12,7 +12,9 @@ import (
 
 	"github.com/juju/cmd"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/arch"
 	"github.com/juju/utils/featureflag"
+	"github.com/juju/utils/series"
 	"github.com/juju/utils/set"
 	gc "gopkg.in/check.v1"
 
@@ -142,10 +144,14 @@ func (s *MainSuite) TestRunMain(c *gc.C) {
 		code:    0,
 		out:     syncToolsHelpText(),
 	}, {
-		summary: "check version command registered properly",
+		summary: "check version command returns a fully qualified version string",
 		args:    []string{"version"},
 		code:    0,
-		out:     version.Current.String() + "\n",
+		out: version.Binary{
+			Number: version.Current,
+			Arch:   arch.HostArch(),
+			Series: series.HostSeries(),
+		}.String() + "\n",
 	}, {
 		summary: "check block command registered properly",
 		args:    []string{"block", "-h"},
@@ -450,19 +456,19 @@ func (s *MainSuite) TestTwoDotOhDeprecation(c *gc.C) {
 	check := twoDotOhDeprecation("the replacement")
 
 	// first check pre-2.0
-	s.PatchValue(&version.Current.Number, version.MustParse("1.26.4"))
+	s.PatchValue(&version.Current, version.MustParse("1.26.4"))
 	deprecated, replacement := check.Deprecated()
 	c.Check(deprecated, jc.IsFalse)
 	c.Check(replacement, gc.Equals, "")
 	c.Check(check.Obsolete(), jc.IsFalse)
 
-	s.PatchValue(&version.Current.Number, version.MustParse("2.0-alpha1"))
+	s.PatchValue(&version.Current, version.MustParse("2.0-alpha1"))
 	deprecated, replacement = check.Deprecated()
 	c.Check(deprecated, jc.IsTrue)
 	c.Check(replacement, gc.Equals, "the replacement")
 	c.Check(check.Obsolete(), jc.IsFalse)
 
-	s.PatchValue(&version.Current.Number, version.MustParse("3.0-alpha1"))
+	s.PatchValue(&version.Current, version.MustParse("3.0-alpha1"))
 	deprecated, replacement = check.Deprecated()
 	c.Check(deprecated, jc.IsTrue)
 	c.Check(replacement, gc.Equals, "the replacement")
@@ -489,7 +495,7 @@ var obsoleteCommandNames = []string{
 
 func (s *MainSuite) TestObsoleteRegistration(c *gc.C) {
 	var commands commands
-	s.PatchValue(&version.Current.Number, version.MustParse("3.0-alpha1"))
+	s.PatchValue(&version.Current, version.MustParse("3.0-alpha1"))
 	registerCommands(&commands, testing.Context(c))
 
 	cmdSet := set.NewStrings(obsoleteCommandNames...)

--- a/cmd/juju/commands/synctools_test.go
+++ b/cmd/juju/commands/synctools_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/juju/loggo"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
+	"github.com/juju/utils/arch"
+	"github.com/juju/utils/series"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/common"
@@ -247,17 +249,22 @@ func (s *syncToolsSuite) TestAPIAdapterFindToolsAPIError(c *gc.C) {
 
 func (s *syncToolsSuite) TestAPIAdapterUploadTools(c *gc.C) {
 	uploadToolsErr := errors.New("uh oh")
+	current := version.Binary{
+		Number: version.Current,
+		Arch:   arch.HostArch(),
+		Series: series.HostSeries(),
+	}
 	fake := fakeSyncToolsAPI{
 		uploadTools: func(r io.Reader, v version.Binary, additionalSeries ...string) (*coretools.Tools, error) {
 			data, err := ioutil.ReadAll(r)
 			c.Assert(err, jc.ErrorIsNil)
 			c.Assert(string(data), gc.Equals, "abc")
-			c.Assert(v, gc.Equals, version.Current)
+			c.Assert(v, gc.Equals, current)
 			return nil, uploadToolsErr
 		},
 	}
 	a := syncToolsAPIAdapter{&fake}
-	err := a.UploadTools("released", "released", &coretools.Tools{Version: version.Current}, []byte("abc"))
+	err := a.UploadTools("released", "released", &coretools.Tools{Version: current}, []byte("abc"))
 	c.Assert(err, gc.Equals, uploadToolsErr)
 }
 

--- a/cmd/juju/commands/upgradejuju.go
+++ b/cmd/juju/commands/upgradejuju.go
@@ -256,7 +256,7 @@ func (c *upgradeJujuCommand) initVersions(client upgradeJujuAPI, cfg *config.Con
 	if c.Version == agent {
 		return nil, errUpToDate
 	}
-	clientVersion := version.Current.Number
+	clientVersion := version.Current
 	findResult, err := client.FindTools(clientVersion.Major, -1, "", "")
 	if err != nil {
 		return nil, err

--- a/cmd/juju/status/status_test.go
+++ b/cmd/juju/status/status_test.go
@@ -34,13 +34,11 @@ import (
 	"github.com/juju/juju/version"
 )
 
-func defineNextVersion() version.Number {
-	ver := version.Current.Number
+func nextVersion() version.Number {
+	ver := version.Current
 	ver.Patch++
 	return ver
 }
-
-var nextVersion = defineNextVersion()
 
 func runStatus(c *gc.C, args ...string) (code int, stdout, stderr []byte) {
 	ctx := coretesting.Context(c)
@@ -2307,7 +2305,7 @@ var statusTests = []testCase{
 			M{
 				"environment": "dummyenv",
 				"environment-status": M{
-					"upgrade-available": nextVersion.String(),
+					"upgrade-available": nextVersion().String(),
 				},
 				"machines": M{},
 				"services": M{},
@@ -2821,7 +2819,7 @@ type setToolsUpgradeAvailable struct{}
 func (ua setToolsUpgradeAvailable) step(c *gc.C, ctx *context) {
 	env, err := ctx.st.Environment()
 	c.Assert(err, jc.ErrorIsNil)
-	err = env.UpdateLatestToolsVersion(nextVersion)
+	err = env.UpdateLatestToolsVersion(nextVersion())
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -3227,7 +3225,7 @@ ID         STATE   VERSION DNS            INS-ID     SERIES  HARDWARE
 2          started         dummyenv-2.dns dummyenv-2 quantal arch=amd64 cpu-cores=1 mem=1024M root-disk=8192M 
 
 `
-	nextVersionStr := nextVersion.String()
+	nextVersionStr := nextVersion().String()
 	spaces := strings.Repeat(" ", len("UPGRADE-AVAILABLE")-len(nextVersionStr)+1)
 	c.Assert(string(stdout), gc.Equals, fmt.Sprintf(expected[1:], nextVersionStr+spaces))
 }

--- a/cmd/jujud/agent/testing/agent.go
+++ b/cmd/jujud/agent/testing/agent.go
@@ -112,7 +112,7 @@ type AgentSuite struct {
 // current tools.
 func (s *AgentSuite) PrimeAgent(c *gc.C, tag names.Tag, password string) (agent.ConfigSetterWriter, *coretools.Tools) {
 	vers := version.Binary{
-		Number: version.Current.Number,
+		Number: version.Current,
 		Arch:   arch.HostArch(),
 		Series: series.HostSeries(),
 	}

--- a/cmd/jujud/agent/unit_test.go
+++ b/cmd/jujud/agent/unit_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/arch"
+	"github.com/juju/utils/series"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/natefinch/lumberjack.v2"
 
@@ -191,7 +193,11 @@ func (s *UnitSuite) TestRunStop(c *gc.C) {
 func (s *UnitSuite) TestUpgrade(c *gc.C) {
 	machine, unit, _, currentTools := s.primeAgent(c)
 	agent := s.newAgent(c, unit)
-	newVers := version.Current
+	newVers := version.Binary{
+		Number: version.Current,
+		Arch:   arch.HostArch(),
+		Series: series.HostSeries(),
+	}
 	newVers.Patch++
 	envtesting.AssertUploadFakeToolsVersions(
 		c, s.DefaultToolsStorage, s.Environ.Config().AgentStream(), s.Environ.Config().AgentStream(), newVers)
@@ -223,7 +229,11 @@ func (s *UnitSuite) TestUpgrade(c *gc.C) {
 func (s *UnitSuite) TestUpgradeFailsWithoutTools(c *gc.C) {
 	machine, unit, _, _ := s.primeAgent(c)
 	agent := s.newAgent(c, unit)
-	newVers := version.Current
+	newVers := version.Binary{
+		Number: version.Current,
+		Arch:   arch.HostArch(),
+		Series: series.HostSeries(),
+	}
 	newVers.Patch++
 	err := machine.SetAgentVersion(newVers)
 	c.Assert(err, jc.ErrorIsNil)
@@ -355,8 +365,12 @@ func (s *UnitSuite) TestRsyslogConfigWorker(c *gc.C) {
 
 func (s *UnitSuite) TestAgentSetsToolsVersion(c *gc.C) {
 	_, unit, _, _ := s.primeAgent(c)
-	vers := version.Current
-	vers.Minor = version.Current.Minor + 1
+	vers := version.Binary{
+		Number: version.Current,
+		Arch:   arch.HostArch(),
+		Series: series.HostSeries(),
+	}
+	vers.Minor++
 	err := unit.SetAgentVersion(vers)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -377,7 +391,12 @@ func (s *UnitSuite) TestAgentSetsToolsVersion(c *gc.C) {
 			if agentTools.Version.Minor != version.Current.Minor {
 				continue
 			}
-			c.Assert(agentTools.Version, gc.DeepEquals, version.Current)
+			current := version.Binary{
+				Number: version.Current,
+				Arch:   arch.HostArch(),
+				Series: series.HostSeries(),
+			}
+			c.Assert(agentTools.Version, gc.DeepEquals, current)
 			done = true
 		}
 	}

--- a/cmd/jujud/agent/upgrade.go
+++ b/cmd/jujud/agent/upgrade.go
@@ -84,12 +84,12 @@ func (c *upgradeWorkerContext) InitializeUsingAgent(a upgradingMachineAgent) err
 	return a.ChangeConfig(func(agentConfig agent.ConfigSetter) error {
 		if !upgrades.AreUpgradesDefined(agentConfig.UpgradedToVersion()) {
 			logger.Infof("no upgrade steps required or upgrade steps for %v "+
-				"have already been run.", version.Current.Number)
+				"have already been run.", version.Current)
 			close(c.UpgradeComplete)
 
 			// Even if no upgrade is required the version number in
 			// the agent's config still needs to be bumped.
-			agentConfig.SetUpgradedToVersion(version.Current.Number)
+			agentConfig.SetUpgradedToVersion(version.Current)
 		}
 		return nil
 	})
@@ -144,7 +144,7 @@ func (c *upgradeWorkerContext) run(stop <-chan struct{}) error {
 	c.agentConfig = c.agent.CurrentConfig()
 
 	c.fromVersion = c.agentConfig.UpgradedToVersion()
-	c.toVersion = version.Current.Number
+	c.toVersion = version.Current
 	if c.fromVersion == c.toVersion {
 		logger.Infof("upgrade to %v already completed.", c.toVersion)
 		close(c.UpgradeComplete)

--- a/cmd/jujud/reboot/reboot_test.go
+++ b/cmd/jujud/reboot/reboot_test.go
@@ -56,7 +56,7 @@ func (s *RebootSuite) SetUpTest(c *gc.C) {
 	configParams := agent.AgentConfigParams{
 		Paths:             agent.Paths{DataDir: c.MkDir()},
 		Tag:               names.NewMachineTag("0"),
-		UpgradedToVersion: version.Current.Number,
+		UpgradedToVersion: version.Current,
 		StateAddresses:    []string{s.mgoInst.Addr()},
 		CACert:            coretesting.CACert,
 		Password:          "fake",

--- a/cmd/plugins/juju-metadata/toolsmetadata_test.go
+++ b/cmd/plugins/juju-metadata/toolsmetadata_test.go
@@ -55,9 +55,9 @@ func (s *ToolsMetadataSuite) SetUpTest(c *gc.C) {
 
 var currentVersionStrings = []string{
 	// only these ones will make it into the JSON files.
-	version.Current.Number.String() + "-quantal-amd64",
-	version.Current.Number.String() + "-quantal-armhf",
-	version.Current.Number.String() + "-quantal-i386",
+	version.Current.String() + "-quantal-amd64",
+	version.Current.String() + "-quantal-armhf",
+	version.Current.String() + "-quantal-i386",
 }
 
 var versionStrings = append([]string{
@@ -302,7 +302,7 @@ func (s *ToolsMetadataSuite) TestNoTools(c *gc.C) {
 }
 
 func (s *ToolsMetadataSuite) TestPatchLevels(c *gc.C) {
-	currentVersion := version.Current.Number
+	currentVersion := version.Current
 	currentVersion.Build = 0
 	versionStrings := []string{
 		currentVersion.String() + "-precise-amd64",

--- a/cmd/plugins/juju-metadata/validatetoolsmetadata.go
+++ b/cmd/plugins/juju-metadata/validatetoolsmetadata.go
@@ -136,7 +136,7 @@ func (c *validateToolsMetadataCommand) Init(args []string) error {
 		}
 	}
 	if c.exactVersion == "current" {
-		c.exactVersion = version.Current.Number.String()
+		c.exactVersion = version.Current.String()
 	}
 	if c.partVersion != "" {
 		var err error

--- a/cmd/plugins/juju-metadata/validatetoolsmetadata_test.go
+++ b/cmd/plugins/juju-metadata/validatetoolsmetadata_test.go
@@ -208,7 +208,7 @@ func (s *ValidateToolsMetadataSuite) TestOpenstackLocalMetadataNoMatch(c *gc.C) 
 }
 
 func (s *ValidateToolsMetadataSuite) TestDefaultVersion(c *gc.C) {
-	s.makeLocalMetadata(c, "released", version.Current.Number.String(), "region-2", "raring", "some-auth-url")
+	s.makeLocalMetadata(c, "released", version.Current.String(), "region-2", "raring", "some-auth-url")
 	ctx := coretesting.Context(c)
 	code := cmd.Main(
 		newValidateToolsMetadataCommand(), ctx, []string{
@@ -222,7 +222,7 @@ func (s *ValidateToolsMetadataSuite) TestDefaultVersion(c *gc.C) {
 }
 
 func (s *ValidateToolsMetadataSuite) TestStream(c *gc.C) {
-	s.makeLocalMetadata(c, "proposed", version.Current.Number.String(), "region-2", "raring", "some-auth-url")
+	s.makeLocalMetadata(c, "proposed", version.Current.String(), "region-2", "raring", "some-auth-url")
 	ctx := coretesting.Context(c)
 	code := cmd.Main(
 		newValidateToolsMetadataCommand(), ctx, []string{
@@ -264,7 +264,7 @@ func (s *ValidateToolsMetadataSuite) TestMajorMinorVersionMatch(c *gc.C) {
 }
 
 func (s *ValidateToolsMetadataSuite) TestJustDirectory(c *gc.C) {
-	s.makeLocalMetadata(c, "released", version.Current.Number.String(), "region-2", "raring", "some-auth-url")
+	s.makeLocalMetadata(c, "released", version.Current.String(), "region-2", "raring", "some-auth-url")
 	ctx := coretesting.Context(c)
 	code := cmd.Main(
 		newValidateToolsMetadataCommand(), ctx, []string{"-s", "raring", "-d", s.metadataDir},

--- a/cmd/supercommand.go
+++ b/cmd/supercommand.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/juju/cmd"
 	"github.com/juju/loggo"
+	"github.com/juju/utils/arch"
+	"github.com/juju/utils/series"
 
 	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/version"
@@ -31,7 +33,16 @@ func NewSuperCommand(p cmd.SuperCommandParams) *cmd.SuperCommand {
 	p.Log = &cmd.Log{
 		DefaultConfig: os.Getenv(osenv.JujuLoggingConfigEnvKey),
 	}
-	p.Version = version.Current.String()
+	current := version.Binary{
+		Number: version.Current,
+		Arch:   arch.HostArch(),
+		Series: series.HostSeries(),
+	}
+
+	// p.Version should be a version.Binary, but juju/cmd does not
+	// import juju/juju/version so this cannot happen. We have
+	// tests to assert that this string value is correct.
+	p.Version = current.String()
 	p.NotifyRun = runNotifier
 	return cmd.NewSuperCommand(p)
 }

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -117,12 +117,12 @@ func Bootstrap(ctx environs.BootstrapContext, environ environs.Environ, args Boo
 	// agent-version set anyway, to appease FinishInstanceConfig.
 	// In the latter case, setBootstrapTools will later set
 	// agent-version to the correct thing.
-	agentVersion := version.Current.Number.String()
+	agentVersion := version.Current
 	if args.AgentVersion != nil {
-		agentVersion = args.AgentVersion.String()
+		agentVersion = *args.AgentVersion
 	}
 	if cfg, err = cfg.Apply(map[string]interface{}{
-		"agent-version": agentVersion,
+		"agent-version": agentVersion.String(),
 	}); err != nil {
 		return err
 	}
@@ -206,12 +206,12 @@ func setBootstrapTools(environ environs.Environ, possibleTools coretools.List) (
 	// We should only ever bootstrap the exact same version as the client,
 	// or we risk bootstrap incompatibility. We still set agent-version to
 	// the newest version, so the agent will immediately upgrade itself.
-	if !isCompatibleVersion(newVersion, version.Current.Number) {
-		compatibleVersion, compatibleTools := findCompatibleTools(possibleTools, version.Current.Number)
+	if !isCompatibleVersion(newVersion, version.Current) {
+		compatibleVersion, compatibleTools := findCompatibleTools(possibleTools, version.Current)
 		if len(compatibleTools) == 0 {
 			logger.Warningf(
 				"failed to find %s tools, will attempt to use %s",
-				version.Current.Number, newVersion,
+				version.Current, newVersion,
 			)
 		} else {
 			bootstrapVersion, toolsList = compatibleVersion, compatibleTools

--- a/environs/bootstrap/bootstrap_test.go
+++ b/environs/bootstrap/bootstrap_test.go
@@ -56,7 +56,7 @@ func (s *bootstrapSuite) SetUpTest(c *gc.C) {
 	s.PatchValue(&envtools.DefaultBaseURL, storageDir)
 	stor, err := filestorage.NewFileStorageWriter(storageDir)
 	c.Assert(err, jc.ErrorIsNil)
-	s.PatchValue(&version.Current.Number, coretesting.FakeVersionNumber)
+	s.PatchValue(&version.Current, coretesting.FakeVersionNumber)
 	envtesting.UploadFakeTools(c, stor, "released", "released")
 }
 
@@ -204,7 +204,7 @@ func (s *bootstrapSuite) TestSetBootstrapTools(c *gc.C) {
 		c.Assert(err, jc.ErrorIsNil)
 		err = env.SetConfig(cfg)
 		c.Assert(err, jc.ErrorIsNil)
-		s.PatchValue(&version.Current.Number, t.currentVersion)
+		s.PatchValue(&version.Current, t.currentVersion)
 		bootstrapTools, err := bootstrap.SetBootstrapTools(env, availableTools)
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(bootstrapTools.Version.Number, gc.Equals, t.expectedTools)
@@ -283,14 +283,10 @@ func (s *bootstrapSuite) TestBootstrapMetadataImagesMissing(c *gc.C) {
 	c.Assert(datasources[0].Description(), gc.Equals, "default cloud images")
 }
 
-func (s *bootstrapSuite) setupBootstrapSpecificVersion(
-	c *gc.C, clientMajor, clientMinor int, toolsVersion *version.Number,
-) (error, int, version.Number) {
+func (s *bootstrapSuite) setupBootstrapSpecificVersion(c *gc.C, clientMajor, clientMinor int, toolsVersion *version.Number) (error, int, version.Number) {
 	currentVersion := version.Current
 	currentVersion.Major = clientMajor
 	currentVersion.Minor = clientMinor
-	currentVersion.Series = "incorrect" // callers should be consulting series.HostSeries
-	currentVersion.Arch = "amd64"
 	currentVersion.Tag = ""
 	s.PatchValue(&version.Current, currentVersion)
 	s.PatchValue(&series.HostSeries, func() string { return "trusty" })

--- a/environs/bootstrap/tools.go
+++ b/environs/bootstrap/tools.go
@@ -122,7 +122,7 @@ func locallyBuildableTools() (buildable coretools.List) {
 			continue
 		}
 		binary := version.Binary{
-			Number: version.Current.Number,
+			Number: version.Current,
 			Series: ser,
 			Arch:   arch.HostArch(),
 		}
@@ -139,7 +139,7 @@ func locallyBuildableTools() (buildable coretools.List) {
 // all tools matching the current major.minor version are chosen.
 func findBootstrapTools(env environs.Environ, vers *version.Number, arch *string) (list coretools.List, err error) {
 	// Construct a tools filter.
-	cliVersion := version.Current.Number
+	cliVersion := version.Current
 	var filter coretools.Filter
 	if arch != nil {
 		filter.Arch = *arch

--- a/environs/bootstrap/tools_test.go
+++ b/environs/bootstrap/tools_test.go
@@ -169,7 +169,7 @@ func (s *toolsSuite) TestFindAvailableToolsForceUpload(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(uploadedTools, gc.Not(gc.HasLen), 0)
 	c.Assert(findToolsCalled, gc.Equals, 0)
-	expectedVersion := version.Current.Number
+	expectedVersion := version.Current
 	expectedVersion.Build++
 	for _, tools := range uploadedTools {
 		c.Assert(tools.Version.Number, gc.Equals, expectedVersion)
@@ -193,10 +193,14 @@ func (s *toolsSuite) TestFindAvailableToolsForceUploadInvalidArch(c *gc.C) {
 }
 
 func (s *toolsSuite) TestFindAvailableToolsSpecificVersion(c *gc.C) {
-	currentVersion := version.Current
+	currentVersion := version.Binary{
+		Number: version.Current,
+		Arch:   arch.HostArch(),
+		Series: series.HostSeries(),
+	}
 	currentVersion.Major = 2
 	currentVersion.Minor = 3
-	s.PatchValue(&version.Current, currentVersion)
+	s.PatchValue(&version.Current, currentVersion.Number)
 	var findToolsCalled int
 	s.PatchValue(bootstrap.FindTools, func(_ environs.Environ, major, minor int, stream string, f tools.Filter) (tools.List, error) {
 		c.Assert(f.Number.Major, gc.Equals, 10)
@@ -240,7 +244,7 @@ func (s *toolsSuite) TestFindAvailableToolsAutoUpload(c *gc.C) {
 	c.Assert(len(availableTools), jc.GreaterThan, 1)
 	c.Assert(env.supportedArchitecturesCount, gc.Equals, 1)
 	var trustyToolsFound int
-	expectedVersion := version.Current.Number
+	expectedVersion := version.Current
 	expectedVersion.Build++
 	for _, tools := range availableTools {
 		if tools == trustyTools {
@@ -260,7 +264,7 @@ func (s *toolsSuite) TestFindAvailableToolsCompleteNoValidate(c *gc.C) {
 	var allTools tools.List
 	for _, series := range series.SupportedSeries() {
 		binary := version.Binary{
-			Number: version.Current.Number,
+			Number: version.Current,
 			Series: series,
 			Arch:   arch.HostArch(),
 		}

--- a/environs/jujutest/tests.go
+++ b/environs/jujutest/tests.go
@@ -78,7 +78,7 @@ func (t *Tests) TearDownTest(c *gc.C) {
 func (t *Tests) TestStartStop(c *gc.C) {
 	e := t.Prepare(c)
 	cfg, err := e.Config().Apply(map[string]interface{}{
-		"agent-version": version.Current.Number.String(),
+		"agent-version": version.Current.String(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	err = e.SetConfig(cfg)

--- a/environs/open_test.go
+++ b/environs/open_test.go
@@ -39,7 +39,7 @@ func (s *OpenSuite) TearDownTest(c *gc.C) {
 }
 
 func (s *OpenSuite) TestNewDummyEnviron(c *gc.C) {
-	s.PatchValue(&version.Current.Number, testing.FakeVersionNumber)
+	s.PatchValue(&version.Current, testing.FakeVersionNumber)
 	// matches *Settings.Map()
 	cfg, err := config.New(config.NoDefaults, dummySampleConfig())
 	c.Assert(err, jc.ErrorIsNil)

--- a/environs/sync/sync.go
+++ b/environs/sync/sync.go
@@ -93,7 +93,7 @@ func SyncTools(syncContext *SyncContext) error {
 		// We now store the tools in a directory named after their stream, but the
 		// legacy behaviour is to store all tools in a single "releases" directory.
 		toolsDir = envtools.LegacyReleaseDirectory
-		syncContext.Stream = envtools.PreferredStream(&version.Current.Number, false, syncContext.Stream)
+		syncContext.Stream = envtools.PreferredStream(&version.Current, false, syncContext.Stream)
 	}
 	sourceTools, err := envtools.FindToolsForCloud(
 		[]simplestreams.DataSource{sourceDataSource}, simplestreams.CloudSpec{},

--- a/environs/testing/tools.go
+++ b/environs/testing/tools.go
@@ -69,8 +69,10 @@ func (s *ToolsFixture) UploadFakeTools(c *gc.C, stor storage.Storage, toolsDir, 
 	}
 	var versions []version.Binary
 	for _, arch := range arches {
-		v := version.Current
-		v.Arch = arch
+		v := version.Binary{
+			Number: version.Current,
+			Arch:   arch,
+		}
 		for _, series := range toolsLtsSeries {
 			v.Series = series
 			versions = append(versions, v)
@@ -221,8 +223,11 @@ func uploadFakeTools(stor storage.Storage, toolsDir, stream string) error {
 	toolsSeries.Add(series.HostSeries())
 	var versions []version.Binary
 	for _, series := range toolsSeries.Values() {
-		vers := version.Current
-		vers.Series = series
+		vers := version.Binary{
+			Number: version.Current,
+			Arch:   arch.HostArch(),
+			Series: series,
+		}
 		versions = append(versions, vers)
 	}
 	if _, err := UploadFakeToolsVersions(stor, toolsDir, stream, versions...); err != nil {
@@ -250,7 +255,11 @@ func MustUploadFakeTools(stor storage.Storage, toolsDir, stream string) {
 // RemoveFakeTools deletes the fake tools from the supplied storage.
 func RemoveFakeTools(c *gc.C, stor storage.Storage, toolsDir string) {
 	c.Logf("removing fake tools")
-	toolsVersion := version.Current
+	toolsVersion := version.Binary{
+		Number: version.Current,
+		Arch:   arch.HostArch(),
+		Series: series.HostSeries(),
+	}
 	name := envtools.StorageName(toolsVersion, toolsDir)
 	err := stor.Remove(name)
 	c.Check(err, jc.ErrorIsNil)

--- a/environs/tools/testing/testing.go
+++ b/environs/tools/testing/testing.go
@@ -18,6 +18,7 @@ import (
 
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
+	"github.com/juju/utils/arch"
 	"github.com/juju/utils/series"
 	"github.com/juju/utils/set"
 	gc "gopkg.in/check.v1"
@@ -34,13 +35,17 @@ import (
 )
 
 func GetMockBundleTools(c *gc.C) tools.BundleToolsFunc {
-	return func(w io.Writer, forceVersion *version.Number) (vers version.Binary, sha256Hash string, err error) {
-		vers = version.Current
+	return func(w io.Writer, forceVersion *version.Number) (version.Binary, string, error) {
+		vers := version.Binary{
+			Number: version.Current,
+			Arch:   arch.HostArch(),
+			Series: series.HostSeries(),
+		}
 		if forceVersion != nil {
 			vers.Number = *forceVersion
 		}
-		sha256Hash = fmt.Sprintf("%x", sha256.New().Sum(nil))
-		return vers, sha256Hash, err
+		sha256Hash := fmt.Sprintf("%x", sha256.New().Sum(nil))
+		return vers, sha256Hash, nil
 	}
 }
 
@@ -48,7 +53,11 @@ func GetMockBundleTools(c *gc.C) tools.BundleToolsFunc {
 // a fake tools tarball.
 func GetMockBuildTools(c *gc.C) sync.BuildToolsTarballFunc {
 	return func(forceVersion *version.Number, stream string) (*sync.BuiltTools, error) {
-		vers := version.Current
+		vers := version.Binary{
+			Number: version.Current,
+			Arch:   arch.HostArch(),
+			Series: series.HostSeries(),
+		}
 		if forceVersion != nil {
 			vers.Number = *forceVersion
 		}

--- a/environs/tools/tools.go
+++ b/environs/tools/tools.go
@@ -217,7 +217,7 @@ func PreferredStream(vers *version.Number, forceDevel bool, stream string) strin
 	// If we're not upgrading from a known version, we use the
 	// currently running version.
 	if vers == nil {
-		vers = &version.Current.Number
+		vers = &version.Current
 	}
 	// Devel versions are alpha or beta etc as defined by the version tag.
 	// The user can also force the use of devel streams via config.

--- a/environs/tools/tools_test.go
+++ b/environs/tools/tools_test.go
@@ -30,7 +30,7 @@ type SimpleStreamsToolsSuite struct {
 	env environs.Environ
 	coretesting.BaseSuite
 	envtesting.ToolsFixture
-	origCurrentVersion version.Binary
+	origCurrentVersion version.Number
 	customToolsDir     string
 	publicToolsDir     string
 }
@@ -159,7 +159,7 @@ func (s *SimpleStreamsToolsSuite) TestFindTools(c *gc.C) {
 		s.reset(c, nil)
 		custom := s.uploadCustom(c, test.custom...)
 		public := s.uploadPublic(c, test.public...)
-		stream := envtools.PreferredStream(&version.Current.Number, s.env.Config().Development(), s.env.Config().AgentStream())
+		stream := envtools.PreferredStream(&version.Current, s.env.Config().Development(), s.env.Config().AgentStream())
 		actual, err := envtools.FindTools(s.env, test.major, test.minor, stream, coretools.Filter{})
 		if test.err != nil {
 			if len(actual) > 0 {
@@ -313,8 +313,7 @@ var preferredStreamTests = []struct {
 func (s *SimpleStreamsToolsSuite) TestPreferredStream(c *gc.C) {
 	for i, test := range preferredStreamTests {
 		c.Logf("\ntest %d", i)
-		origVers := version.Current
-		version.Current.Number = version.MustParse(test.currentVers)
+		s.PatchValue(&version.Current, version.MustParse(test.currentVers))
 		var vers *version.Number
 		if test.explicitVers != "" {
 			v := version.MustParse(test.explicitVers)
@@ -322,7 +321,6 @@ func (s *SimpleStreamsToolsSuite) TestPreferredStream(c *gc.C) {
 		}
 		obtained := envtools.PreferredStream(vers, test.forceDevel, test.streamInConfig)
 		c.Check(obtained, gc.Equals, test.expected)
-		version.Current = origVers
 	}
 }
 

--- a/environs/tools/validation.go
+++ b/environs/tools/validation.go
@@ -28,7 +28,7 @@ func ValidateToolsMetadata(params *ToolsMetadataLookupParams) ([]string, *simple
 		return nil, nil, fmt.Errorf("required parameter sources not specified")
 	}
 	if params.Version == "" && params.Major == 0 {
-		params.Version = version.Current.Number.String()
+		params.Version = version.Current.String()
 	}
 	var toolsConstraint *ToolsConstraint
 	if params.Version == "" {

--- a/juju/api_test.go
+++ b/juju/api_test.go
@@ -66,7 +66,7 @@ func (cs *NewAPIStateSuite) TearDownTest(c *gc.C) {
 }
 
 func (cs *NewAPIStateSuite) TestNewAPIState(c *gc.C) {
-	cs.PatchValue(&version.Current.Number, coretesting.FakeVersionNumber)
+	cs.PatchValue(&version.Current, coretesting.FakeVersionNumber)
 	cfg, err := config.New(config.NoDefaults, dummy.SampleConfig())
 	c.Assert(err, jc.ErrorIsNil)
 	ctx := envtesting.BootstrapContext(c)
@@ -185,7 +185,7 @@ func (s *NewAPIClientSuite) TestNameDefault(c *gc.C) {
 	// and checking that the connection happens within that
 	// time.
 	s.PatchValue(juju.ProviderConnectDelay, coretesting.LongWait)
-	s.PatchValue(&version.Current.Number, coretesting.FakeVersionNumber)
+	s.PatchValue(&version.Current, coretesting.FakeVersionNumber)
 	s.bootstrapEnv(c, coretesting.SampleEnvName, defaultConfigStore(c))
 
 	startTime := time.Now()
@@ -201,7 +201,7 @@ func (s *NewAPIClientSuite) TestNameDefault(c *gc.C) {
 func (s *NewAPIClientSuite) TestNameNotDefault(c *gc.C) {
 	envName := coretesting.SampleCertName + "-2"
 	coretesting.WriteEnvironments(c, coretesting.MultipleEnvConfig, envName)
-	s.PatchValue(&version.Current.Number, coretesting.FakeVersionNumber)
+	s.PatchValue(&version.Current, coretesting.FakeVersionNumber)
 	s.bootstrapEnv(c, envName, defaultConfigStore(c))
 	apiclient, err := juju.NewAPIClientFromName(envName, nil)
 	c.Assert(err, jc.ErrorIsNil)
@@ -248,7 +248,7 @@ func (s *NewAPIClientSuite) TestWithInfoOnly(c *gc.C) {
 
 func (s *NewAPIClientSuite) TestWithConfigAndNoInfo(c *gc.C) {
 	c.Skip("not really possible now that there is no defined admin user")
-	s.PatchValue(&version.Current.Number, coretesting.FakeVersionNumber)
+	s.PatchValue(&version.Current, coretesting.FakeVersionNumber)
 	coretesting.MakeSampleJujuHome(c)
 
 	store := newConfigStore(coretesting.SampleEnvName, &environInfo{
@@ -520,7 +520,7 @@ func (s *NewAPIClientSuite) TestWithInfoAPIOpenError(c *gc.C) {
 }
 
 func (s *NewAPIClientSuite) TestWithSlowInfoConnect(c *gc.C) {
-	s.PatchValue(&version.Current.Number, coretesting.FakeVersionNumber)
+	s.PatchValue(&version.Current, coretesting.FakeVersionNumber)
 	coretesting.MakeSampleJujuHome(c)
 	store := configstore.NewMem()
 	s.bootstrapEnv(c, coretesting.SampleEnvName, store)
@@ -606,7 +606,7 @@ func setEndpointAddressAndHostname(c *gc.C, store configstore.Storage, envName s
 }
 
 func (s *NewAPIClientSuite) TestWithSlowConfigConnect(c *gc.C) {
-	s.PatchValue(&version.Current.Number, coretesting.FakeVersionNumber)
+	s.PatchValue(&version.Current, coretesting.FakeVersionNumber)
 	coretesting.MakeSampleJujuHome(c)
 
 	store := configstore.NewMem()
@@ -677,7 +677,7 @@ func (s *NewAPIClientSuite) TestWithSlowConfigConnect(c *gc.C) {
 }
 
 func (s *NewAPIClientSuite) TestBothError(c *gc.C) {
-	s.PatchValue(&version.Current.Number, coretesting.FakeVersionNumber)
+	s.PatchValue(&version.Current, coretesting.FakeVersionNumber)
 	coretesting.MakeSampleJujuHome(c)
 	store := configstore.NewMem()
 	s.bootstrapEnv(c, coretesting.SampleEnvName, store)
@@ -702,7 +702,7 @@ func defaultConfigStore(c *gc.C) configstore.Storage {
 }
 
 func (s *NewAPIClientSuite) TestWithBootstrapConfigAndNoEnvironmentsFile(c *gc.C) {
-	s.PatchValue(&version.Current.Number, coretesting.FakeVersionNumber)
+	s.PatchValue(&version.Current, coretesting.FakeVersionNumber)
 	coretesting.MakeSampleJujuHome(c)
 	store := configstore.NewMem()
 	s.bootstrapEnv(c, coretesting.SampleEnvName, store)
@@ -723,7 +723,7 @@ func (s *NewAPIClientSuite) TestWithBootstrapConfigAndNoEnvironmentsFile(c *gc.C
 }
 
 func (s *NewAPIClientSuite) TestWithBootstrapConfigTakesPrecedence(c *gc.C) {
-	s.PatchValue(&version.Current.Number, coretesting.FakeVersionNumber)
+	s.PatchValue(&version.Current, coretesting.FakeVersionNumber)
 	// We want to make sure that the code is using the bootstrap
 	// config rather than information from environments.yaml,
 	// even when there is an entry in environments.yaml

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -16,6 +16,8 @@ import (
 	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
+	"github.com/juju/utils/arch"
+	"github.com/juju/utils/series"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v6-unstable"
 	"gopkg.in/juju/charmrepo.v1"
@@ -244,8 +246,17 @@ func (s *JujuConnSuite) setUpConn(c *gc.C) {
 	s.LogDir = c.MkDir()
 	s.PatchValue(&dummy.LogDir, s.LogDir)
 
-	versions := PreferredDefaultVersions(environ.Config(), version.Binary{Number: version.Current.Number, Series: "precise", Arch: "amd64"})
-	versions = append(versions, version.Current)
+	versions := PreferredDefaultVersions(environ.Config(), version.Binary{
+		Number: version.Current,
+		Arch:   "amd64",
+		Series: "precise",
+	})
+	current := version.Binary{
+		Number: version.Current,
+		Arch:   arch.HostArch(),
+		Series: series.HostSeries(),
+	}
+	versions = append(versions, current)
 
 	// Upload tools for both preferred and fake default series
 	s.DefaultToolsStorageDir = c.MkDir()
@@ -321,10 +332,18 @@ func (s *JujuConnSuite) AddToolsToState(c *gc.C, versions ...version.Binary) {
 // The preferred series is default-series if specified,
 // otherwise the latest LTS.
 func (s *JujuConnSuite) AddDefaultToolsToState(c *gc.C) {
-	preferredVersion := version.Current
-	preferredVersion.Arch = "amd64"
+	preferredVersion := version.Binary{
+		Number: version.Current,
+		Arch:   "amd64",
+		Series: series.HostSeries(),
+	}
+	current := version.Binary{
+		Number: version.Current,
+		Arch:   arch.HostArch(),
+		Series: series.HostSeries(),
+	}
 	versions := PreferredDefaultVersions(s.Environ.Config(), preferredVersion)
-	versions = append(versions, version.Current)
+	versions = append(versions, current)
 	s.AddToolsToState(c, versions...)
 }
 
@@ -481,7 +500,7 @@ func (s *JujuConnSuite) writeSampleConfig(c *gc.C, path string) {
 	}
 	attrs := s.DummyConfig.Merge(testing.Attrs{
 		"admin-secret":  AdminSecret,
-		"agent-version": version.Current.Number.String(),
+		"agent-version": version.Current.String(),
 	}).Delete("name")
 	// Add any custom attributes required.
 	for attr, val := range s.ConfigAttrs {
@@ -610,7 +629,7 @@ func (s *JujuConnSuite) AgentConfigForTag(c *gc.C, tag names.Tag) agent.ConfigSe
 		agent.AgentConfigParams{
 			Paths:             paths,
 			Tag:               tag,
-			UpgradedToVersion: version.Current.Number,
+			UpgradedToVersion: version.Current,
 			Password:          password,
 			Nonce:             "nonce",
 			StateAddresses:    s.MongoInfo(c).Addrs,

--- a/provider/azure/environ_test.go
+++ b/provider/azure/environ_test.go
@@ -1696,7 +1696,7 @@ func (s *environSuite) TestConstraintsMerge(c *gc.C) {
 }
 
 func (s *environSuite) TestBootstrapReusesAffinityGroupAndVNet(c *gc.C) {
-	s.PatchValue(&version.Current.Number, coretesting.FakeVersionNumber)
+	s.PatchValue(&version.Current, coretesting.FakeVersionNumber)
 	storageDir := c.MkDir()
 	stor, err := filestorage.NewFileStorageWriter(storageDir)
 	c.Assert(err, jc.ErrorIsNil)

--- a/provider/common/destroy_test.go
+++ b/provider/common/destroy_test.go
@@ -84,7 +84,7 @@ func (s *DestroySuite) TestSuccessWhenStorageErrors(c *gc.C) {
 }
 
 func (s *DestroySuite) TestSuccess(c *gc.C) {
-	s.PatchValue(&version.Current.Number, testing.FakeVersionNumber)
+	s.PatchValue(&version.Current, testing.FakeVersionNumber)
 	stor := newStorage(s, c)
 	err := stor.Put("somewhere", strings.NewReader("stuff"), 5)
 	c.Assert(err, jc.ErrorIsNil)
@@ -113,7 +113,7 @@ func (s *DestroySuite) TestSuccess(c *gc.C) {
 }
 
 func (s *DestroySuite) TestSuccessWhenNoInstances(c *gc.C) {
-	s.PatchValue(&version.Current.Number, testing.FakeVersionNumber)
+	s.PatchValue(&version.Current, testing.FakeVersionNumber)
 	stor := newStorage(s, c)
 	err := stor.Put("elsewhere", strings.NewReader("stuff"), 5)
 	c.Assert(err, jc.ErrorIsNil)

--- a/provider/dummy/environs_test.go
+++ b/provider/dummy/environs_test.go
@@ -98,7 +98,7 @@ func (s *suite) TearDownSuite(c *gc.C) {
 func (s *suite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 	s.SetFeatureFlags(feature.AddressAllocation)
-	s.PatchValue(&version.Current.Number, testing.FakeVersionNumber)
+	s.PatchValue(&version.Current, testing.FakeVersionNumber)
 	s.MgoSuite.SetUpTest(c)
 	s.Tests.SetUpTest(c)
 }

--- a/provider/ec2/ebs_test.go
+++ b/provider/ec2/ebs_test.go
@@ -77,7 +77,7 @@ func (s *ebsVolumeSuite) TearDownSuite(c *gc.C) {
 }
 
 func (s *ebsVolumeSuite) SetUpTest(c *gc.C) {
-	s.BaseSuite.PatchValue(&version.Current.Number, testing.FakeVersionNumber)
+	s.BaseSuite.PatchValue(&version.Current, testing.FakeVersionNumber)
 	s.BaseSuite.PatchValue(&arch.HostArch, func() string { return arch.AMD64 })
 	s.BaseSuite.PatchValue(&series.HostSeries, func() string { return testing.FakeDefaultSeries })
 	s.BaseSuite.SetUpTest(c)

--- a/provider/ec2/live_test.go
+++ b/provider/ec2/live_test.go
@@ -88,7 +88,7 @@ func (t *LiveTests) TearDownSuite(c *gc.C) {
 }
 
 func (t *LiveTests) SetUpTest(c *gc.C) {
-	t.BaseSuite.PatchValue(&version.Current.Number, coretesting.FakeVersionNumber)
+	t.BaseSuite.PatchValue(&version.Current, coretesting.FakeVersionNumber)
 	t.BaseSuite.PatchValue(&arch.HostArch, func() string { return arch.AMD64 })
 	t.BaseSuite.PatchValue(&series.HostSeries, func() string { return coretesting.FakeDefaultSeries })
 	t.BaseSuite.SetUpTest(c)

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -194,7 +194,7 @@ func (t *localServerSuite) TearDownSuite(c *gc.C) {
 }
 
 func (t *localServerSuite) SetUpTest(c *gc.C) {
-	t.BaseSuite.PatchValue(&version.Current.Number, coretesting.FakeVersionNumber)
+	t.BaseSuite.PatchValue(&version.Current, coretesting.FakeVersionNumber)
 	t.BaseSuite.PatchValue(&arch.HostArch, func() string { return arch.AMD64 })
 	t.BaseSuite.PatchValue(&series.HostSeries, func() string { return coretesting.FakeDefaultSeries })
 	t.BaseSuite.SetUpTest(c)

--- a/provider/joyent/local_test.go
+++ b/provider/joyent/local_test.go
@@ -120,7 +120,7 @@ func (s *localLiveSuite) TearDownSuite(c *gc.C) {
 }
 
 func (s *localLiveSuite) SetUpTest(c *gc.C) {
-	s.PatchValue(&version.Current.Number, coretesting.FakeVersionNumber)
+	s.PatchValue(&version.Current, coretesting.FakeVersionNumber)
 	s.providerSuite.SetUpTest(c)
 	creds := joyent.MakeCredentials(c, s.TestConfig)
 	joyent.UseExternalTestImageMetadata(creds)
@@ -154,7 +154,7 @@ func (s *localServerSuite) SetUpSuite(c *gc.C) {
 func (s *localServerSuite) SetUpTest(c *gc.C) {
 	s.providerSuite.SetUpTest(c)
 
-	s.PatchValue(&version.Current.Number, coretesting.FakeVersionNumber)
+	s.PatchValue(&version.Current, coretesting.FakeVersionNumber)
 	s.cSrv = &localCloudAPIServer{}
 	s.mSrv = &localMantaServer{}
 	s.cSrv.setupServer(c)

--- a/provider/local/environ_test.go
+++ b/provider/local/environ_test.go
@@ -116,7 +116,9 @@ type localJujuTestSuite struct {
 
 func (s *localJujuTestSuite) SetUpTest(c *gc.C) {
 	s.baseProviderSuite.SetUpTest(c)
-	s.PatchValue(&version.Current.Number, testing.FakeVersionNumber)
+	s.PatchValue(&version.Current, testing.FakeVersionNumber)
+	s.PatchValue(&arch.HostArch, func() string { return arch.AMD64 })
+	s.PatchValue(&series.HostSeries, func() string { return testing.FakeDefaultSeries })
 	// Construct the directories first.
 	err := local.CreateDirs(c, minimalConfig(c))
 	c.Assert(err, jc.ErrorIsNil)
@@ -179,7 +181,7 @@ func (s *localJujuTestSuite) testBootstrap(c *gc.C, cfg *config.Config) environs
 	c.Assert(err, jc.ErrorIsNil)
 	availableTools := coretools.List{&coretools.Tools{
 		Version: version.Binary{
-			Number: version.Current.Number,
+			Number: version.Current,
 			Arch:   arch.HostArch(),
 			Series: series.HostSeries(),
 		},

--- a/provider/local/environprovider.go
+++ b/provider/local/environprovider.go
@@ -113,7 +113,7 @@ func (p environProvider) PrepareForBootstrap(ctx environs.BootstrapContext, cfg 
 		"proxy-ssh": false,
 	}
 	if _, ok := cfg.AgentVersion(); !ok {
-		attrs["agent-version"] = version.Current.Number.String()
+		attrs["agent-version"] = version.Current.String()
 	}
 	if namespace, _ := cfg.UnknownAttrs()["namespace"].(string); namespace == "" {
 		username := os.Getenv("USER")

--- a/provider/maas/environ_whitebox_test.go
+++ b/provider/maas/environ_whitebox_test.go
@@ -737,7 +737,7 @@ func (suite *environSuite) TestBootstrapFailsIfNoTools(c *gc.C) {
 	env := suite.makeEnviron()
 	// Disable auto-uploading by setting the agent version.
 	cfg, err := env.Config().Apply(map[string]interface{}{
-		"agent-version": version.Current.Number.String(),
+		"agent-version": version.Current.String(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	err = env.SetConfig(cfg)

--- a/provider/maas/maas_test.go
+++ b/provider/maas/maas_test.go
@@ -15,6 +15,8 @@ import (
 	"github.com/juju/juju/feature"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/version"
+	"github.com/juju/utils/arch"
+	"github.com/juju/utils/series"
 )
 
 // Ensure maasEnviron supports environs.NetworkingEnviron.
@@ -44,7 +46,9 @@ func (s *providerSuite) SetUpSuite(c *gc.C) {
 }
 
 func (s *providerSuite) SetUpTest(c *gc.C) {
-	s.PatchValue(&version.Current.Number, coretesting.FakeVersionNumber)
+	s.PatchValue(&version.Current, coretesting.FakeVersionNumber)
+	s.PatchValue(&arch.HostArch, func() string { return arch.AMD64 })
+	s.PatchValue(&series.HostSeries, func() string { return coretesting.FakeDefaultSeries })
 	s.FakeJujuHomeSuite.SetUpTest(c)
 	s.ToolsFixture.SetUpTest(c)
 	s.SetFeatureFlags(feature.AddressAllocation)

--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -230,7 +230,7 @@ func (s *localServerSuite) SetUpTest(c *gc.C) {
 		"image-metadata-url": containerURL + "/juju-dist-test",
 		"auth-url":           s.cred.URL,
 	})
-	s.PatchValue(&version.Current.Number, coretesting.FakeVersionNumber)
+	s.PatchValue(&version.Current, coretesting.FakeVersionNumber)
 	s.Tests.SetUpTest(c)
 	// For testing, we create a storage instance to which is uploaded tools and image metadata.
 	s.env = s.Prepare(c)
@@ -380,8 +380,10 @@ func (s *localServerSuite) TestStartInstanceWithoutPublicIP(c *gc.C) {
 
 func (s *localServerSuite) TestStartInstanceHardwareCharacteristics(c *gc.C) {
 	// Ensure amd64 tools are available, to ensure an amd64 image.
-	amd64Version := version.Current
-	amd64Version.Arch = arch.AMD64
+	amd64Version := version.Binary{
+		Number: version.Current,
+		Arch:   arch.AMD64,
+	}
 	for _, series := range series.SupportedSeries() {
 		amd64Version.Series = series
 		envtesting.AssertUploadFakeToolsVersions(
@@ -1159,7 +1161,7 @@ func (s *localHTTPSServerSuite) createConfigAttrs(c *gc.C) map[string]interface{
 
 func (s *localHTTPSServerSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
-	s.PatchValue(&version.Current.Number, coretesting.FakeVersionNumber)
+	s.PatchValue(&version.Current, coretesting.FakeVersionNumber)
 	s.srv.UseTLS = true
 	cred := &identity.Credentials{
 		User:       "fred",
@@ -1772,7 +1774,7 @@ func (s *noSwiftSuite) SetUpTest(c *gc.C) {
 		"agent-version":   coretesting.FakeVersionNumber.String(),
 		"authorized-keys": "fakekey",
 	})
-	s.PatchValue(&version.Current.Number, coretesting.FakeVersionNumber)
+	s.PatchValue(&version.Current, coretesting.FakeVersionNumber)
 	// Serve fake tools and image metadata using "filestorage",
 	// rather than Swift as the rest of the tests do.
 	storageDir := c.MkDir()

--- a/state/backups/metadata.go
+++ b/state/backups/metadata.go
@@ -71,7 +71,7 @@ func NewMetadata() *Metadata {
 		FileMetadata: filestorage.NewMetadata(),
 		Started:      time.Now().UTC(),
 		Origin: Origin{
-			Version: version.Current.Number,
+			Version: version.Current,
 		},
 	}
 }

--- a/state/backups/restore_test.go
+++ b/state/backups/restore_test.go
@@ -181,7 +181,7 @@ func (r *RestoreSuite) TestNewDialInfo(c *gc.C) {
 			DataDir: dataDir,
 			LogDir:  logDir,
 		},
-		UpgradedToVersion: version.Current.Number,
+		UpgradedToVersion: version.Current,
 		Tag:               machineTag,
 		Environment:       coretesting.EnvironmentTag,
 		Password:          "dummyPassword",

--- a/state/state.go
+++ b/state/state.go
@@ -430,10 +430,10 @@ func IsUpgradeInProgressError(err error) bool {
 // running the current version). If this is a hosted environment, newVersion
 // cannot be higher than the state server version.
 func (st *State) SetEnvironAgentVersion(newVersion version.Number) (err error) {
-	if newVersion.Compare(version.Current.Number) > 0 && !st.IsStateServer() {
+	if newVersion.Compare(version.Current) > 0 && !st.IsStateServer() {
 		return errors.Errorf("a hosted environment cannot have a higher version than the server environment: %s > %s",
 			newVersion.String(),
-			version.Current.Number,
+			version.Current,
 		)
 	}
 

--- a/state/toolstorage/tools.go
+++ b/state/toolstorage/tools.go
@@ -182,10 +182,8 @@ func (s *toolsStorage) toolsMetadata(v version.Binary) (toolsMetadataDoc, error)
 	err := s.metadataCollection.Find(bson.D{{"_id", v.String()}}).One(&doc)
 	if err == mgo.ErrNotFound {
 		return doc, errors.NotFoundf("%v tools metadata", v)
-	} else if err != nil {
-		return doc, err
 	}
-	return doc, nil
+	return doc, err
 }
 
 func (s *toolsStorage) toolsTarball(path string) (io.ReadCloser, error) {

--- a/upgrades/operations.go
+++ b/upgrades/operations.go
@@ -92,11 +92,11 @@ type opsIterator struct {
 }
 
 func newStateUpgradeOpsIterator(from version.Number) *opsIterator {
-	return newOpsIterator(from, version.Current.Number, stateUpgradeOperations())
+	return newOpsIterator(from, version.Current, stateUpgradeOperations())
 }
 
 func newUpgradeOpsIterator(from version.Number) *opsIterator {
-	return newOpsIterator(from, version.Current.Number, upgradeOperations())
+	return newOpsIterator(from, version.Current, upgradeOperations())
 }
 
 func newOpsIterator(from, to version.Number, ops []Operation) *opsIterator {

--- a/upgrades/upgrade_test.go
+++ b/upgrades/upgrade_test.go
@@ -362,9 +362,7 @@ func (s *upgradeSuite) TestAreUpgradesDefined(c *gc.C) {
 		if test.toVersion != "" {
 			toVersion = version.MustParse(test.toVersion)
 		}
-		vers := version.Current
-		vers.Number = toVersion
-		s.PatchValue(&version.Current, vers)
+		s.PatchValue(&version.Current, toVersion)
 		result := upgrades.AreUpgradesDefined(fromVersion)
 		c.Check(result, gc.Equals, test.expected)
 	}
@@ -550,9 +548,7 @@ func (s *upgradeSuite) TestPerformUpgrade(c *gc.C) {
 		if test.toVersion != "" {
 			toVersion = version.MustParse(test.toVersion)
 		}
-		vers := version.Current
-		vers.Number = toVersion
-		s.PatchValue(&version.Current, vers)
+		s.PatchValue(&version.Current, toVersion)
 		err := upgrades.PerformUpgrade(fromVersion, test.targets, ctx)
 		if test.err == "" {
 			c.Check(err, jc.ErrorIsNil)

--- a/version/version.go
+++ b/version/version.go
@@ -16,7 +16,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/juju/utils/arch"
 	"github.com/juju/utils/series"
 	"gopkg.in/mgo.v2/bson"
 )
@@ -36,11 +35,7 @@ var osReleaseFile = "/etc/os-release"
 // Current gives the current version of the system.  If the file
 // "FORCE-VERSION" is present in the same directory as the running
 // binary, it will override this.
-var Current = Binary{
-	Number: MustParse(version),
-	Series: series.HostSeries(),
-	Arch:   arch.HostArch(),
-}
+var Current = MustParse(version)
 
 var Compiler = runtime.Compiler
 
@@ -53,7 +48,7 @@ func init() {
 		}
 		return
 	}
-	Current.Number = MustParse(strings.TrimSpace(string(v)))
+	Current = MustParse(strings.TrimSpace(string(v)))
 }
 
 // Number represents a juju version.  When bugs are fixed the patch number is

--- a/worker/deployer/simple.go
+++ b/worker/deployer/simple.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/names"
+	"github.com/juju/utils/arch"
+	"github.com/juju/utils/series"
 	"github.com/juju/utils/shell"
 
 	"github.com/juju/juju/agent"
@@ -108,7 +110,12 @@ func (ctx *SimpleContext) DeployUnit(unitName, initialPassword string) (err erro
 	tag := names.NewUnitTag(unitName)
 	dataDir := ctx.agentConfig.DataDir()
 	logDir := ctx.agentConfig.LogDir()
-	_, err = tools.ChangeAgentTools(dataDir, tag.String(), version.Current)
+	current := version.Binary{
+		Number: version.Current,
+		Arch:   arch.HostArch(),
+		Series: series.HostSeries(),
+	}
+	_, err = tools.ChangeAgentTools(dataDir, tag.String(), current)
 	toolsDir := tools.ToolsDir(dataDir, tag.String())
 	defer removeOnErr(&err, toolsDir)
 
@@ -127,7 +134,7 @@ func (ctx *SimpleContext) DeployUnit(unitName, initialPassword string) (err erro
 				LogDir:          logDir,
 				MetricsSpoolDir: agent.DefaultPaths.MetricsSpoolDir,
 			},
-			UpgradedToVersion: version.Current.Number,
+			UpgradedToVersion: version.Current,
 			Tag:               tag,
 			Password:          initialPassword,
 			Nonce:             "unused",

--- a/worker/deployer/simple_test.go
+++ b/worker/deployer/simple_test.go
@@ -14,6 +14,8 @@ import (
 
 	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/arch"
+	"github.com/juju/utils/series"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/agent"
@@ -156,14 +158,19 @@ var fakeJujud = "#!/bin/bash --norc\n# fake-jujud\nexit 0\n"
 func (fix *SimpleToolsFixture) SetUp(c *gc.C, dataDir string) {
 	fix.dataDir = dataDir
 	fix.logDir = c.MkDir()
-	toolsDir := tools.SharedToolsDir(fix.dataDir, version.Current)
+	current := version.Binary{
+		Number: version.Current,
+		Arch:   arch.HostArch(),
+		Series: series.HostSeries(),
+	}
+	toolsDir := tools.SharedToolsDir(fix.dataDir, current)
 	err := os.MkdirAll(toolsDir, 0755)
 	c.Assert(err, jc.ErrorIsNil)
 	jujudPath := filepath.Join(toolsDir, "jujud")
 	err = ioutil.WriteFile(jujudPath, []byte(fakeJujud), 0755)
 	c.Assert(err, jc.ErrorIsNil)
 	toolsPath := filepath.Join(toolsDir, "downloaded-tools.txt")
-	testTools := coretools.Tools{Version: version.Current, URL: "http://testing.invalid/tools"}
+	testTools := coretools.Tools{Version: current, URL: "http://testing.invalid/tools"}
 	data, err := json.Marshal(testTools)
 	c.Assert(err, jc.ErrorIsNil)
 	err = ioutil.WriteFile(toolsPath, data, 0644)

--- a/worker/provisioner/container_initialisation_test.go
+++ b/worker/provisioner/container_initialisation_test.go
@@ -182,7 +182,12 @@ func (s *ContainerSetupSuite) TestContainerProvisionerStarted(c *gc.C) {
 		c.Assert(err, jc.ErrorIsNil)
 		err = m.SetSupportedContainers([]instance.ContainerType{instance.LXC, instance.KVM})
 		c.Assert(err, jc.ErrorIsNil)
-		err = m.SetAgentVersion(version.Current)
+		current := version.Binary{
+			Number: version.Current,
+			Arch:   arch.HostArch(),
+			Series: series.HostSeries(),
+		}
+		err = m.SetAgentVersion(current)
 		c.Assert(err, jc.ErrorIsNil)
 		s.assertContainerProvisionerStarted(c, m, ctype)
 	}
@@ -208,10 +213,11 @@ func (s *ContainerSetupSuite) testContainerConstraintsArch(c *gc.C, containerTyp
 		return toolsFinderFunc(func(v version.Number, series string, arch string) (tools.List, error) {
 			called = true
 			c.Assert(arch, gc.Equals, expectArch)
-			result := version.Current
-			result.Number = v
-			result.Series = series
-			result.Arch = arch
+			result := version.Binary{
+				Number: v,
+				Arch:   arch,
+				Series: series,
+			}
 			return tools.List{{Version: result}}, nil
 		})
 	})
@@ -219,7 +225,7 @@ func (s *ContainerSetupSuite) testContainerConstraintsArch(c *gc.C, containerTyp
 	s.PatchValue(&provisioner.StartProvisioner, func(runner worker.Runner, containerType instance.ContainerType,
 		pr *apiprovisioner.State, cfg agent.Config, broker environs.InstanceBroker,
 		toolsFinder provisioner.ToolsFinder) error {
-		toolsFinder.FindTools(version.Current.Number, series.HostSeries(), arch.AMD64)
+		toolsFinder.FindTools(version.Current, series.HostSeries(), arch.AMD64)
 		return nil
 	})
 
@@ -232,7 +238,12 @@ func (s *ContainerSetupSuite) testContainerConstraintsArch(c *gc.C, containerTyp
 	c.Assert(err, jc.ErrorIsNil)
 	err = m.SetSupportedContainers([]instance.ContainerType{containerType})
 	c.Assert(err, jc.ErrorIsNil)
-	err = m.SetAgentVersion(version.Current)
+	current := version.Binary{
+		Number: version.Current,
+		Arch:   arch.HostArch(),
+		Series: series.HostSeries(),
+	}
+	err = m.SetAgentVersion(current)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.createContainer(c, m, containerType)
@@ -250,7 +261,12 @@ func (s *ContainerSetupSuite) TestLxcContainerUsesImageURL(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = m.SetSupportedContainers([]instance.ContainerType{instance.LXC, instance.KVM})
 	c.Assert(err, jc.ErrorIsNil)
-	err = m.SetAgentVersion(version.Current)
+	current := version.Binary{
+		Number: version.Current,
+		Arch:   arch.HostArch(),
+		Series: series.HostSeries(),
+	}
+	err = m.SetAgentVersion(current)
 	c.Assert(err, jc.ErrorIsNil)
 
 	brokerCalled := false
@@ -321,7 +337,12 @@ func (s *ContainerSetupSuite) assertContainerInitialised(c *gc.C, cont Container
 	c.Assert(err, jc.ErrorIsNil)
 	err = m.SetSupportedContainers([]instance.ContainerType{instance.LXC, instance.KVM})
 	c.Assert(err, jc.ErrorIsNil)
-	err = m.SetAgentVersion(version.Current)
+	current := version.Binary{
+		Number: version.Current,
+		Arch:   arch.HostArch(),
+		Series: series.HostSeries(),
+	}
+	err = m.SetAgentVersion(current)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Before starting /etc/default/lxc-net should be missing.
@@ -366,7 +387,12 @@ func (s *ContainerSetupSuite) TestContainerInitLockError(c *gc.C) {
 		Constraints: s.defaultConstraints,
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	err = m.SetAgentVersion(version.Current)
+	current := version.Binary{
+		Number: version.Current,
+		Arch:   arch.HostArch(),
+		Series: series.HostSeries(),
+	}
+	err = m.SetAgentVersion(current)
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = os.RemoveAll(s.initLockDir)
@@ -583,7 +609,12 @@ func (s *LXCDefaultMTUSuite) TestDefaultMTUPropagatedToNewLXCBroker(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = m.SetSupportedContainers([]instance.ContainerType{instance.LXC, instance.KVM})
 	c.Assert(err, jc.ErrorIsNil)
-	err = m.SetAgentVersion(version.Current)
+	current := version.Binary{
+		Number: version.Current,
+		Arch:   arch.HostArch(),
+		Series: series.HostSeries(),
+	}
+	err = m.SetAgentVersion(current)
 	c.Assert(err, jc.ErrorIsNil)
 
 	brokerCalled := false

--- a/worker/provisioner/kvm-broker_test.go
+++ b/worker/provisioner/kvm-broker_test.go
@@ -84,7 +84,7 @@ func (s *kvmBrokerSuite) SetUpTest(c *gc.C) {
 		agent.AgentConfigParams{
 			Paths:             agent.NewPathsWithDefaults(agent.Paths{DataDir: "/not/used/here"}),
 			Tag:               names.NewUnitTag("ubuntu/1"),
-			UpgradedToVersion: version.Current.Number,
+			UpgradedToVersion: version.Current,
 			Password:          "dummy-secret",
 			Nonce:             "nonce",
 			APIAddresses:      []string{"10.0.0.1:1234"},

--- a/worker/provisioner/lxc-broker_test.go
+++ b/worker/provisioner/lxc-broker_test.go
@@ -91,7 +91,7 @@ func (s *lxcBrokerSuite) SetUpTest(c *gc.C) {
 		agent.AgentConfigParams{
 			Paths:             agent.NewPathsWithDefaults(agent.Paths{DataDir: "/not/used/here"}),
 			Tag:               names.NewMachineTag("1"),
-			UpgradedToVersion: version.Current.Number,
+			UpgradedToVersion: version.Current,
 			Password:          "dummy-secret",
 			Nonce:             "nonce",
 			APIAddresses:      []string{"10.0.0.1:1234"},

--- a/worker/provisioner/provisioner_task.go
+++ b/worker/provisioner/provisioner_task.go
@@ -616,7 +616,7 @@ func (task *provisionerTask) startMachines(machines []*apiprovisioner.Machine) e
 		}
 
 		possibleTools, err := task.toolsFinder.FindTools(
-			version.Current.Number,
+			version.Current,
 			pInfo.Series,
 			arch,
 		)

--- a/worker/provisioner/provisioner_test.go
+++ b/worker/provisioner/provisioner_test.go
@@ -14,6 +14,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
 	"github.com/juju/utils/arch"
+	"github.com/juju/utils/series"
 	"github.com/juju/utils/set"
 	gc "gopkg.in/check.v1"
 
@@ -145,7 +146,12 @@ func (s *CommonProvisionerSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(machine.Id(), gc.Equals, "0")
 
-	err = machine.SetAgentVersion(version.Current)
+	current := version.Binary{
+		Number: version.Current,
+		Arch:   arch.HostArch(),
+		Series: series.HostSeries(),
+	}
+	err = machine.SetAgentVersion(current)
 	c.Assert(err, jc.ErrorIsNil)
 
 	password, err := utils.RandomPassword()
@@ -508,7 +514,9 @@ func (s *ProvisionerSuite) TestPossibleTools(c *gc.C) {
 	// Set a current version that does not match the
 	// agent-version in the environ config.
 	currentVersion := version.MustParseBinary("1.2.3-quantal-arm64")
-	s.PatchValue(&version.Current, currentVersion)
+	s.PatchValue(&arch.HostArch, func() string { return currentVersion.Arch })
+	s.PatchValue(&series.HostSeries, func() string { return currentVersion.Series })
+	s.PatchValue(&version.Current, currentVersion.Number)
 
 	// Upload some plausible matches, and some that should be filtered out.
 	compatibleVersion := version.MustParseBinary("1.2.3-quantal-amd64")

--- a/worker/uniter/runner/jujuc/tools_test.go
+++ b/worker/uniter/runner/jujuc/tools_test.go
@@ -11,6 +11,8 @@ import (
 
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
+	"github.com/juju/utils/arch"
+	"github.com/juju/utils/series"
 	"github.com/juju/utils/symlink"
 	gc "gopkg.in/check.v1"
 
@@ -28,7 +30,11 @@ var _ = gc.Suite(&ToolsSuite{})
 
 func (s *ToolsSuite) SetUpTest(c *gc.C) {
 	s.dataDir = c.MkDir()
-	s.toolsDir = tools.SharedToolsDir(s.dataDir, version.Current)
+	s.toolsDir = tools.SharedToolsDir(s.dataDir, version.Binary{
+		Number: version.Current,
+		Arch:   arch.HostArch(),
+		Series: series.HostSeries(),
+	})
 	err := os.MkdirAll(s.toolsDir, 0755)
 	c.Assert(err, jc.ErrorIsNil)
 	err = symlink.New(s.toolsDir, tools.ToolsDir(s.dataDir, "unit-u-123"))

--- a/worker/upgrader/upgrader_test.go
+++ b/worker/upgrader/upgrader_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
+	"github.com/juju/utils/arch"
+	"github.com/juju/utils/series"
 	"github.com/juju/utils/symlink"
 	gc "gopkg.in/check.v1"
 
@@ -66,6 +68,12 @@ func (s *UpgraderSuite) SetUpTest(c *gc.C) {
 	s.agentUpgradeComplete = make(chan struct{})
 }
 
+func (s *UpgraderSuite) patchVersion(v version.Binary) {
+	s.PatchValue(&arch.HostArch, func() string { return v.Arch })
+	s.PatchValue(&series.HostSeries, func() string { return v.Series })
+	s.PatchValue(&version.Current, v.Number)
+}
+
 type mockConfig struct {
 	agent.Config
 	tag     names.Tag
@@ -104,7 +112,7 @@ func (s *UpgraderSuite) TestUpgraderSetsTools(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	stor := s.DefaultToolsStorage
 	agentTools := envtesting.PrimeTools(c, stor, s.DataDir(), s.Environ.Config().AgentStream(), vers)
-	s.PatchValue(&version.Current, agentTools.Version)
+	s.patchVersion(agentTools.Version)
 	err = envtools.MergeAndWriteMetadata(stor, "released", "released", coretools.List{agentTools}, envtools.DoNotWriteMirrors)
 	_, err = s.machine.AgentTools()
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
@@ -121,7 +129,7 @@ func (s *UpgraderSuite) TestUpgraderSetsTools(c *gc.C) {
 func (s *UpgraderSuite) TestUpgraderSetVersion(c *gc.C) {
 	vers := version.MustParseBinary("5.4.3-precise-amd64")
 	agentTools := envtesting.PrimeTools(c, s.DefaultToolsStorage, s.DataDir(), s.Environ.Config().AgentStream(), vers)
-	s.PatchValue(&version.Current, agentTools.Version)
+	s.patchVersion(agentTools.Version)
 	err := os.RemoveAll(filepath.Join(s.DataDir(), "tools"))
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -136,7 +144,7 @@ func (s *UpgraderSuite) TestUpgraderSetVersion(c *gc.C) {
 	s.machine.Refresh()
 	gotTools, err := s.machine.AgentTools()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(gotTools, gc.DeepEquals, &coretools.Tools{Version: version.Current})
+	c.Assert(gotTools, gc.DeepEquals, &coretools.Tools{Version: vers})
 }
 
 func (s *UpgraderSuite) expectUpgradeChannelClosed(c *gc.C) {
@@ -158,7 +166,7 @@ func (s *UpgraderSuite) expectUpgradeChannelNotClosed(c *gc.C) {
 func (s *UpgraderSuite) TestUpgraderUpgradesImmediately(c *gc.C) {
 	stor := s.DefaultToolsStorage
 	oldTools := envtesting.PrimeTools(c, stor, s.DataDir(), s.Environ.Config().AgentStream(), version.MustParseBinary("5.4.3-precise-amd64"))
-	s.PatchValue(&version.Current, oldTools.Version)
+	s.patchVersion(oldTools.Version)
 	newTools := envtesting.AssertUploadFakeToolsVersions(
 		c, stor, s.Environ.Config().AgentStream(), s.Environ.Config().AgentStream(), version.MustParseBinary("5.4.5-precise-amd64"))[0]
 	err := statetesting.SetAgentVersion(s.State, newTools.Version.Number)
@@ -188,7 +196,7 @@ func (s *UpgraderSuite) TestUpgraderUpgradesImmediately(c *gc.C) {
 func (s *UpgraderSuite) TestUpgraderRetryAndChanged(c *gc.C) {
 	stor := s.DefaultToolsStorage
 	oldTools := envtesting.PrimeTools(c, stor, s.DataDir(), s.Environ.Config().AgentStream(), version.MustParseBinary("5.4.3-precise-amd64"))
-	s.PatchValue(&version.Current, oldTools.Version)
+	s.patchVersion(oldTools.Version)
 	newTools := envtesting.AssertUploadFakeToolsVersions(
 		c, stor, s.Environ.Config().AgentStream(), s.Environ.Config().AgentStream(), version.MustParseBinary("5.4.5-precise-amd64"))[0]
 	err := statetesting.SetAgentVersion(s.State, newTools.Version.Number)
@@ -247,7 +255,7 @@ func (s *UpgraderSuite) TestChangeAgentTools(c *gc.C) {
 	stor := s.DefaultToolsStorage
 	newToolsBinary := "5.4.3-precise-amd64"
 	newTools := envtesting.PrimeTools(c, stor, s.DataDir(), s.Environ.Config().AgentStream(), version.MustParseBinary(newToolsBinary))
-	s.PatchValue(&version.Current, newTools.Version)
+	s.patchVersion(newTools.Version)
 	err := envtools.MergeAndWriteMetadata(stor, "released", "released", coretools.List{newTools}, envtools.DoNotWriteMirrors)
 	c.Assert(err, jc.ErrorIsNil)
 	ugErr := &upgrader.UpgradeReadyError{
@@ -266,7 +274,7 @@ func (s *UpgraderSuite) TestChangeAgentTools(c *gc.C) {
 
 func (s *UpgraderSuite) TestUsesAlreadyDownloadedToolsIfAvailable(c *gc.C) {
 	oldVersion := version.MustParseBinary("1.2.3-quantal-amd64")
-	s.PatchValue(&version.Current, oldVersion)
+	s.patchVersion(oldVersion)
 
 	newVersion := version.MustParseBinary("5.4.3-quantal-amd64")
 	err := statetesting.SetAgentVersion(s.State, newVersion.Number)
@@ -292,7 +300,7 @@ func (s *UpgraderSuite) TestUsesAlreadyDownloadedToolsIfAvailable(c *gc.C) {
 func (s *UpgraderSuite) TestUpgraderRefusesToDowngradeMinorVersions(c *gc.C) {
 	stor := s.DefaultToolsStorage
 	origTools := envtesting.PrimeTools(c, stor, s.DataDir(), s.Environ.Config().AgentStream(), version.MustParseBinary("5.4.3-precise-amd64"))
-	s.PatchValue(&version.Current, origTools.Version)
+	s.patchVersion(origTools.Version)
 	downgradeTools := envtesting.AssertUploadFakeToolsVersions(
 		c, stor, s.Environ.Config().AgentStream(), s.Environ.Config().AgentStream(), version.MustParseBinary("5.3.3-precise-amd64"))[0]
 	err := statetesting.SetAgentVersion(s.State, downgradeTools.Version.Number)
@@ -314,7 +322,7 @@ func (s *UpgraderSuite) TestUpgraderRefusesToDowngradeMinorVersions(c *gc.C) {
 func (s *UpgraderSuite) TestUpgraderAllowsDowngradingPatchVersions(c *gc.C) {
 	stor := s.DefaultToolsStorage
 	origTools := envtesting.PrimeTools(c, stor, s.DataDir(), s.Environ.Config().AgentStream(), version.MustParseBinary("5.4.3-precise-amd64"))
-	s.PatchValue(&version.Current, origTools.Version)
+	s.patchVersion(origTools.Version)
 	downgradeTools := envtesting.AssertUploadFakeToolsVersions(
 		c, stor, s.Environ.Config().AgentStream(), s.Environ.Config().AgentStream(), version.MustParseBinary("5.4.2-precise-amd64"))[0]
 	err := statetesting.SetAgentVersion(s.State, downgradeTools.Version.Number)
@@ -346,7 +354,7 @@ func (s *UpgraderSuite) TestUpgraderAllowsDowngradeToOrigVersionIfUpgradeInProgr
 
 	stor := s.DefaultToolsStorage
 	origTools := envtesting.PrimeTools(c, stor, s.DataDir(), s.Environ.Config().AgentStream(), version.MustParseBinary("5.4.3-precise-amd64"))
-	s.PatchValue(&version.Current, origTools.Version)
+	s.patchVersion(origTools.Version)
 	downgradeTools := envtesting.AssertUploadFakeToolsVersions(
 		c, stor, s.Environ.Config().AgentStream(), s.Environ.Config().AgentStream(), downgradeVersion)[0]
 	err := statetesting.SetAgentVersion(s.State, downgradeVersion.Number)
@@ -377,7 +385,7 @@ func (s *UpgraderSuite) TestUpgraderRefusesDowngradeToOrigVersionIfUpgradeNotInP
 
 	stor := s.DefaultToolsStorage
 	origTools := envtesting.PrimeTools(c, stor, s.DataDir(), s.Environ.Config().AgentStream(), version.MustParseBinary("5.4.3-precise-amd64"))
-	s.PatchValue(&version.Current, origTools.Version)
+	s.patchVersion(origTools.Version)
 	envtesting.AssertUploadFakeToolsVersions(
 		c, stor, s.Environ.Config().AgentStream(), s.Environ.Config().AgentStream(), downgradeVersion)
 	err := statetesting.SetAgentVersion(s.State, downgradeVersion.Number)


### PR DESCRIPTION
This PR converts version.Current to a type version.Number. The values
previously captured by version.Current, namely the host's architecture
and series, are available via their respective helpers, arch.HostArch and
series.HostSeries.

(Review request: http://reviews.vapour.ws/r/2915/)