### PR TITLE
cmd/juju/commands: fix deploy tests under windows

### DIFF
--- a/cmd/juju/commands/deploy.go
+++ b/cmd/juju/commands/deploy.go
@@ -216,7 +216,7 @@ func (c *deployCommand) Run(ctx *cmd.Context) error {
 		ctx.Infof("deployment of bundle %q completed", f.Name())
 		return nil
 	} else if !os.IsNotExist(err) {
-		return block.ProcessBlockedError(err, block.BlockChange)
+		logger.Warningf("cannot open %q: %v; falling back to using charm repository", c.CharmOrBundle, err)
 	}
 
 	curl, repo, err := resolveCharmStoreEntityURL(c.CharmOrBundle, csClient.params, repoPath, conf)

--- a/cmd/juju/status/status.go
+++ b/cmd/juju/status/status.go
@@ -131,7 +131,7 @@ var newApiClientForStatus = func(c *statusCommand) (statusAPI, error) {
 func (c *statusCommand) Run(ctx *cmd.Context) error {
 	apiclient, err := newApiClientForStatus(c)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Errorf(connectionError, c.ConnectionName(), err)
 	}
 	defer apiclient.Close()
 


### PR DESCRIPTION
Under Windows, if call os.Open("local:foo"), it fails not with an os.IsNotExist
error but with another error ("The filename, directory name, or volume label syntax is incorrect").

We change the heuristic to ignore any error caused by opening the local file,
and always fall back to loading from a charm repository in this case.

Also fix a regression of the error printed by juju status.

(Review request: http://reviews.vapour.ws/r/2921/)