### PR TITLE
state: Add Environment Mode

### DIFF
--- a/state/charm.go
+++ b/state/charm.go
@@ -95,7 +95,9 @@ func insertAnyCharmOps(cdoc *charmDoc) ([]txn.Op, error) {
 		Id:     cdoc.DocID,
 		Assert: txn.DocMissing,
 		Insert: cdoc,
-	}}, nil
+	},
+		assertEnvAliveAndNormalOp(cdoc.EnvUUID),
+	}, nil
 }
 
 // updateCharmOps returns the txn operations necessary to update the charm
@@ -115,12 +117,14 @@ func updateCharmOps(
 		{"pendingupload", false},
 		{"placeholder", false},
 	}}}
-	return []txn.Op{{
-		C:      charmsC,
-		Id:     curl.String(),
-		Assert: assert,
-		Update: updateFields,
-	}}, nil
+	return []txn.Op{
+		assertEnvAliveAndNormalOp(st.EnvironUUID()),
+		{
+			C:      charmsC,
+			Id:     curl.String(),
+			Assert: assert,
+			Update: updateFields,
+		}}, nil
 }
 
 // convertPlaceholderCharmOps returns the txn operations necessary to convert

--- a/state/environ.go
+++ b/state/environ.go
@@ -28,6 +28,30 @@ type Environment struct {
 	doc environmentDoc
 }
 
+// EnvironMode represents the different modes an environment can be in. The
+// default is "normal".
+type EnvironMode int8
+
+const (
+	// EnvNormal is the default mode of an environment.
+	EnvNormal EnvironMode = iota
+
+	// EnvFrozen prevents adding and provisioning resources. In the case of the
+	// system environment, it also prevents the addition of new environments.
+	EnvFrozen
+)
+
+// String returns a string representation of the EnvironMode.
+func (e EnvironMode) String() string {
+	switch e {
+	case EnvNormal:
+		return "normal"
+	case EnvFrozen:
+		return "frozen"
+	}
+	return "invalid"
+}
+
 // environmentDoc represents the internal state of the environment in MongoDB.
 type environmentDoc struct {
 	UUID        string `bson:"_id"`
@@ -41,6 +65,8 @@ type environmentDoc struct {
 	// LatestAvailableTools is a string representing the newest version
 	// found while checking streams for new versions.
 	LatestAvailableTools string `bson:"available-tools,omitempty"`
+
+	Mode EnvironMode `bson:"mode"`
 }
 
 // StateServerEnvironment returns the environment that was bootstrapped.
@@ -181,6 +207,24 @@ func (st *State) NewEnvironment(cfg *config.Config, owner names.UserTag) (_ *Env
 	return newEnv, newState, nil
 }
 
+// SetMode sets the mode of the environment.
+func (e *Environment) SetMode(mode EnvironMode) error {
+	ops := []txn.Op{{
+		C:  environmentsC,
+		Id: e.UUID(),
+		Update: bson.D{{"$set", bson.D{
+			{"mode", mode},
+		}}},
+	}}
+
+	err := e.st.runTransaction(ops)
+	if err != nil {
+		return errors.Annotatef(err, "failed to set environment mode to %q", mode)
+	}
+	e.doc.Mode = mode
+	return nil
+}
+
 // Tag returns a name identifying the environment.
 // The returned name will be different from other Tag values returned
 // by any other entities from the same state.
@@ -213,6 +257,11 @@ func (e *Environment) ServerUUID() string {
 // Name returns the human friendly name of the environment.
 func (e *Environment) Name() string {
 	return e.doc.Name
+}
+
+// Mode returns the mode of the environment.
+func (e *Environment) Mode() EnvironMode {
+	return e.doc.Mode
 }
 
 // Life returns whether the environment is Alive, Dying or Dead.
@@ -386,7 +435,7 @@ func (e *Environment) destroyOps() ([]txn.Op, error) {
 	ops := []txn.Op{{
 		C:      environmentsC,
 		Id:     uuid,
-		Assert: isEnvAliveDoc,
+		Assert: bson.D{isEnvAliveDocElem},
 		Update: bson.D{{"$set", bson.D{
 			{"life", Dying},
 			{"time-of-dying", nowToTheSecond()},
@@ -471,6 +520,7 @@ func createEnvironmentOp(st *State, owner names.UserTag, name, uuid, server stri
 		Life:       Alive,
 		Owner:      owner.Username(),
 		ServerUUID: server,
+		Mode:       EnvNormal,
 	}
 	return txn.Op{
 		C:      environmentsC,
@@ -548,11 +598,27 @@ func assertEnvAliveOp(envUUID string) txn.Op {
 	return txn.Op{
 		C:      environmentsC,
 		Id:     envUUID,
-		Assert: isEnvAliveDoc,
+		Assert: bson.D{isEnvAliveDocElem},
 	}
 }
 
-// isEnvAlive is an Environment-specific version of isAliveDoc.
+// assertAliveAndNormalOp returns a txn.Op that asserts the environment is alive and in
+// an EnvNormal mode.
+func (e *Environment) assertAliveAndNormalOp() txn.Op {
+	return assertEnvAliveAndNormalOp(e.UUID())
+}
+
+// assertEnvAliveOp returns a txn.Op that asserts the given
+// environment UUID refers to an Alive environment in an EnvNormal mode.
+func assertEnvAliveAndNormalOp(envUUID string) txn.Op {
+	return txn.Op{
+		C:      environmentsC,
+		Id:     envUUID,
+		Assert: bson.D{isEnvAliveDocElem, isEnvNormalDocElem},
+	}
+}
+
+// isEnvAliveDocElem is an Environment-specific version of isAliveDoc.
 //
 // Environment documents from versions of Juju prior to 1.17
 // do not have the life field; if it does not exist, it should
@@ -560,16 +626,20 @@ func assertEnvAliveOp(envUUID string) txn.Op {
 //
 // TODO(mjs) - this should be removed with existing uses replaced with
 // isAliveDoc. A DB migration should convert nil to Alive.
-var isEnvAliveDoc = bson.D{
-	{"life", bson.D{{"$in", []interface{}{Alive, nil}}}},
-}
+var isEnvAliveDocElem = bson.DocElem{"life", bson.D{{"$in", []interface{}{Alive, nil}}}}
+var isEnvNormalDocElem = bson.DocElem{"mode", EnvNormal}
 
-func checkEnvLife(st *State) error {
+func checkEnvLifeAndMode(st *State) error {
 	env, err := st.Environment()
 	if (err == nil && env.Life() != Alive) || errors.IsNotFound(err) {
 		return errors.New("environment is no longer alive")
 	} else if err != nil {
 		return errors.Annotate(err, "unable to read environment")
 	}
+
+	if mode := env.Mode(); mode != EnvNormal {
+		return errors.Errorf("environment is in %q mode", mode.String())
+	}
+
 	return nil
 }

--- a/state/environ_test.go
+++ b/state/environ_test.go
@@ -331,6 +331,22 @@ func (s *EnvironSuite) assertDyingEnvironTransitionDyingToDead(c *gc.C, st *stat
 	c.Assert(env.Destroy(), jc.ErrorIsNil)
 }
 
+func (s *EnvironSuite) TestEnvironMode(c *gc.C) {
+	env, err := s.State.Environment()
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(env.Mode(), gc.Equals, state.EnvNormal)
+	c.Assert(env.SetMode(state.EnvFrozen), jc.ErrorIsNil)
+	c.Assert(env.Mode(), gc.Equals, state.EnvFrozen)
+	c.Assert(env.Refresh(), jc.ErrorIsNil)
+	c.Assert(env.Mode(), gc.Equals, state.EnvFrozen)
+
+	c.Assert(env.SetMode(40), jc.ErrorIsNil)
+	c.Assert(env.Mode().String(), gc.Equals, "invalid")
+	c.Assert(env.Refresh(), jc.ErrorIsNil)
+	c.Assert(env.Mode().String(), gc.Equals, "invalid")
+}
+
 func (s *EnvironSuite) TestProcessDyingEnvironWithMachinesAndServicesNoOp(c *gc.C) {
 	st := s.Factory.MakeEnvironment(c, nil)
 	defer st.Close()

--- a/state/ipaddresses.go
+++ b/state/ipaddresses.go
@@ -61,7 +61,7 @@ func addIPAddress(st *State, addr network.Address, subnetid string) (ipaddress *
 	err = st.runTransaction(ops)
 	switch err {
 	case txn.ErrAborted:
-		if err := checkEnvLife(st); err != nil {
+		if err := checkEnvLifeAndMode(st); err != nil {
 			return nil, errors.Trace(err)
 		}
 		if _, err = st.IPAddress(addr.Value); err == nil {
@@ -397,7 +397,7 @@ func (i *IPAddress) AllocateTo(machineId, interfaceId, macAddress string) (err e
 
 	buildTxn := func(attempt int) ([]txn.Op, error) {
 		if attempt > 0 {
-			if err := checkEnvLife(i.st); err != nil {
+			if err := checkEnvLifeAndMode(i.st); err != nil {
 				return nil, errors.Trace(err)
 			}
 			if err := i.Refresh(); errors.IsNotFound(err) {
@@ -412,7 +412,7 @@ func (i *IPAddress) AllocateTo(machineId, interfaceId, macAddress string) (err e
 
 		}
 		return []txn.Op{
-			assertEnvAliveOp(i.st.EnvironUUID()),
+			assertEnvAliveAndNormalOp(i.st.EnvironUUID()),
 			{
 				C:      ipaddressesC,
 				Id:     i.doc.DocID,

--- a/state/machine.go
+++ b/state/machine.go
@@ -1498,7 +1498,7 @@ func (m *Machine) AddNetworkInterface(args NetworkInterfaceInfo) (iface *Network
 	}
 	doc := newNetworkInterfaceDoc(m.doc.Id, m.st.EnvironUUID(), args)
 	ops := []txn.Op{
-		assertEnvAliveOp(m.st.EnvironUUID()),
+		assertEnvAliveAndNormalOp(m.st.EnvironUUID()),
 		{
 			C:      networksC,
 			Id:     m.st.docID(args.NetworkName),

--- a/state/networkinterfaces.go
+++ b/state/networkinterfaces.go
@@ -206,10 +206,10 @@ func (ni *NetworkInterface) setDisabled(shouldDisable bool) error {
 	if err != nil {
 		return err
 	}
-	ops = append(ops, assertEnvAliveOp(ni.st.EnvironUUID()))
+	ops = append(ops, assertEnvAliveAndNormalOp(ni.st.EnvironUUID()))
 	err = ni.st.runTransaction(ops)
 	if err != nil {
-		if err := checkEnvLife(ni.st); err != nil {
+		if err := checkEnvLifeAndMode(ni.st); err != nil {
 			return errors.Trace(err)
 		}
 		return onAbort(err, errors.NotFoundf("network interface"))

--- a/state/ports.go
+++ b/state/ports.go
@@ -200,7 +200,7 @@ func (p *Ports) OpenPorts(portRange PortRange) (err error) {
 
 	buildTxn := func(attempt int) ([]txn.Op, error) {
 		if attempt > 0 {
-			if err := checkEnvLife(p.st); err != nil {
+			if err := checkEnvLifeAndMode(p.st); err != nil {
 				return nil, errors.Trace(err)
 			}
 			if err = ports.Refresh(); errors.IsNotFound(err) {
@@ -230,7 +230,7 @@ func (p *Ports) OpenPorts(portRange PortRange) (err error) {
 		}
 
 		ops := []txn.Op{
-			assertEnvAliveOp(p.st.EnvironUUID()),
+			assertEnvAliveAndNormalOp(p.st.EnvironUUID()),
 		}
 		if ports.areNew {
 			// Create a new document.

--- a/state/reboot.go
+++ b/state/reboot.go
@@ -42,7 +42,7 @@ func (m *Machine) setFlag() error {
 		return mgo.ErrNotFound
 	}
 	ops := []txn.Op{
-		assertEnvAliveOp(m.st.EnvironUUID()),
+		assertEnvAliveAndNormalOp(m.st.EnvironUUID()),
 		{
 			C:      machinesC,
 			Id:     m.doc.DocID,
@@ -55,7 +55,7 @@ func (m *Machine) setFlag() error {
 	}
 	err := m.st.runTransaction(ops)
 	if err == txn.ErrAborted {
-		if err := checkEnvLife(m.st); err != nil {
+		if err := checkEnvLifeAndMode(m.st); err != nil {
 			return errors.Trace(err)
 		}
 		return mgo.ErrNotFound

--- a/state/service.go
+++ b/state/service.go
@@ -712,6 +712,7 @@ func (s *Service) addUnitOps(principalName string, asserts bson.D) (string, []tx
 		EnvUUID:    s.st.EnvironUUID(),
 	}
 	ops := []txn.Op{
+		assertEnvAliveAndNormalOp(s.st.EnvironUUID()),
 		createStatusOp(s.st, globalKey, unitStatusDoc),
 		createStatusOp(s.st, agentGlobalKey, agentStatusDoc),
 		createMeterStatusOp(s.st, meterStatusGlobalKey, &meterStatusDoc{Code: MeterNotSet.String()}),

--- a/state/state.go
+++ b/state/state.go
@@ -1163,7 +1163,7 @@ func (st *State) AddService(
 	}
 
 	ops := []txn.Op{
-		env.assertAliveOp(),
+		env.assertAliveAndNormalOp(),
 		createConstraintsOp(st, svc.globalKey(), constraints.Value{}),
 		// TODO(dimitern) 2014-04-04 bug #1302498
 		// Once we can add networks independently of machine
@@ -1199,7 +1199,7 @@ func (st *State) AddService(
 	probablyUpdateStatusHistory(st, svc.globalKey(), statusDoc)
 
 	if err := st.runTransaction(ops); err == txn.ErrAborted {
-		if err := checkEnvLife(st); err != nil {
+		if err := checkEnvLifeAndMode(st); err != nil {
 			return nil, errors.Trace(err)
 		}
 		return nil, errors.Errorf("service already exists")
@@ -1264,7 +1264,7 @@ func (st *State) AddSubnet(args SubnetInfo) (subnet *Subnet, err error) {
 		return nil, err
 	}
 	ops := []txn.Op{
-		assertEnvAliveOp(st.EnvironUUID()),
+		assertEnvAliveAndNormalOp(st.EnvironUUID()),
 		{
 			C:      subnetsC,
 			Id:     subnetID,
@@ -1276,7 +1276,7 @@ func (st *State) AddSubnet(args SubnetInfo) (subnet *Subnet, err error) {
 	err = st.runTransaction(ops)
 	switch err {
 	case txn.ErrAborted:
-		if err := checkEnvLife(st); err != nil {
+		if err := checkEnvLifeAndMode(st); err != nil {
 			return nil, errors.Trace(err)
 		}
 		if _, err = st.Subnet(args.CIDR); err == nil {
@@ -1352,7 +1352,7 @@ func (st *State) AddNetwork(args NetworkInfo) (n *Network, err error) {
 	}
 	doc := st.newNetworkDoc(args)
 	ops := []txn.Op{
-		assertEnvAliveOp(st.EnvironUUID()),
+		assertEnvAliveAndNormalOp(st.EnvironUUID()),
 		{
 			C:      networksC,
 			Id:     doc.DocID,
@@ -1363,7 +1363,7 @@ func (st *State) AddNetwork(args NetworkInfo) (n *Network, err error) {
 	err = st.runTransaction(ops)
 	switch err {
 	case txn.ErrAborted:
-		if err := checkEnvLife(st); err != nil {
+		if err := checkEnvLifeAndMode(st); err != nil {
 			return nil, errors.Trace(err)
 		}
 		if _, err = st.Network(args.Name); err == nil {

--- a/state/storage.go
+++ b/state/storage.go
@@ -381,6 +381,7 @@ func createStorageOps(
 	}
 
 	ops = make([]txn.Op, 0, len(templates)*2)
+	ops = append(ops, assertEnvAliveAndNormalOp(st.EnvironUUID()))
 	for _, t := range templates {
 		owner := entity.String()
 		var kind StorageKind

--- a/upgrades/steps126.go
+++ b/upgrades/steps126.go
@@ -41,5 +41,12 @@ func stateStepsFor126() []Step {
 				return upgradeEnvironConfig(st, st, environs.GlobalProviderRegistry())
 			},
 		},
+		&upgradeStep{
+			description: "add the mode field to all environment docs",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return state.AddEnvironMode(context.State())
+			},
+		},
 	}
 }

--- a/upgrades/steps126_test.go
+++ b/upgrades/steps126_test.go
@@ -26,6 +26,7 @@ func (s *steps126Suite) TestStateStepsFor126(c *gc.C) {
 		"add the version field to all settings docs",
 		"add status to filesystem",
 		"upgrade environment config",
+		"add the mode field to all environment docs",
 	}
 	assertStateSteps(c, version.MustParse("1.26.0"), expected)
 }

--- a/worker/statushistorypruner/tenet.toml
+++ b/worker/statushistorypruner/tenet.toml
@@ -1,0 +1,8 @@
+include = ""
+cascade = false
+
+[[tenet]]
+  name = "lingoreviews/juju_worker_nostate"
+  driver = "binary"
+  tag = ""
+  registry = ""


### PR DESCRIPTION
Add a new "mode" field to the environment doc. Add SetMode and Mode
methods. Add two modes "normal" (default) and "frozen". Add a 1.26
upgrade step to add the mode field to all environment docs and set the
value to "normal". Change checkEnvLife to checkEnvLifeAndMode. This
ensures that the environment is normal as well as alive.

(Review request: http://reviews.vapour.ws/r/2931/)