### PR TITLE
cmd/juju/status: added environment-status section (1.25)

### DIFF
--- a/cmd/juju/status/formatted.go
+++ b/cmd/juju/status/formatted.go
@@ -12,15 +12,19 @@ import (
 )
 
 type formattedStatus struct {
-	Environment      string                   `json:"environment"`
-	AvailableVersion string                   `json:"available-version,omitempty" yaml:"available-version,omitempty"`
-	Machines         map[string]machineStatus `json:"machines"`
-	Services         map[string]serviceStatus `json:"services"`
-	Networks         map[string]networkStatus `json:"networks,omitempty" yaml:",omitempty"`
+	Environment       string                   `json:"environment"`
+	EnvironmentStatus *environmentStatus       `json:"environment-status,omitempty" yaml:"environment-status,omitempty"`
+	Machines          map[string]machineStatus `json:"machines"`
+	Services          map[string]serviceStatus `json:"services"`
+	Networks          map[string]networkStatus `json:"networks,omitempty" yaml:",omitempty"`
 }
 
 type errorStatus struct {
 	StatusError string `json:"status-error" yaml:"status-error"`
+}
+
+type environmentStatus struct {
+	AvailableVersion string `json:"upgrade-available,omitempty" yaml:"upgrade-available,omitempty"`
 }
 
 type machineStatus struct {

--- a/cmd/juju/status/formatter.go
+++ b/cmd/juju/status/formatter.go
@@ -36,11 +36,16 @@ func (sf *statusFormatter) format() formattedStatus {
 		return formattedStatus{}
 	}
 	out := formattedStatus{
-		Environment:      sf.status.EnvironmentName,
-		AvailableVersion: sf.status.AvailableVersion,
-		Machines:         make(map[string]machineStatus),
-		Services:         make(map[string]serviceStatus),
+		Environment: sf.status.EnvironmentName,
+		Machines:    make(map[string]machineStatus),
+		Services:    make(map[string]serviceStatus),
 	}
+	if sf.status.AvailableVersion != "" {
+		out.EnvironmentStatus = &environmentStatus{
+			AvailableVersion: sf.status.AvailableVersion,
+		}
+	}
+
 	for k, m := range sf.status.Machines {
 		out.Machines[k] = sf.formatMachine(m)
 	}

--- a/cmd/juju/status/output_oneline.go
+++ b/cmd/juju/status/output_oneline.go
@@ -69,9 +69,6 @@ func formatOneline(value interface{}, printf onelinePrintf) ([]byte, error) {
 			recurseUnits(unit, 1, pprint)
 		}
 	}
-	if fs.AvailableVersion != "" {
-		fmt.Fprintf(&out, "\n- new available version: %q", fs.AvailableVersion)
-	}
 
 	return out.Bytes(), nil
 }

--- a/cmd/juju/status/output_tabular.go
+++ b/cmd/juju/status/output_tabular.go
@@ -35,6 +35,16 @@ func FormatTabular(value interface{}) ([]byte, error) {
 		fmt.Fprintln(tw)
 	}
 
+	if envStatus := fs.EnvironmentStatus; envStatus != nil {
+		p("[Environment]")
+		if envStatus.AvailableVersion != "" {
+			p("UPGRADE-AVAILABLE")
+			p(envStatus.AvailableVersion)
+		}
+		p()
+		tw.Flush()
+	}
+
 	units := make(map[string]unitStatus)
 	p("[Services]")
 	p("NAME\tSTATUS\tEXPOSED\tCHARM")
@@ -95,13 +105,6 @@ func FormatTabular(value interface{}) ([]byte, error) {
 	for _, name := range common.SortStringsNaturally(stringKeysFromMap(fs.Machines)) {
 		m := fs.Machines[name]
 		p(m.Id, m.AgentState, m.AgentVersion, m.DNSName, m.InstanceId, m.Series, m.Hardware)
-	}
-	tw.Flush()
-
-	if fs.AvailableVersion != "" {
-		p("\n[Juju]")
-		p("UPGRADE-AVAILABLE")
-		p(fs.AvailableVersion)
 	}
 	tw.Flush()
 

--- a/cmd/juju/status/status_test.go
+++ b/cmd/juju/status/status_test.go
@@ -34,10 +34,10 @@ import (
 	"github.com/juju/juju/version"
 )
 
-func defineNextVersion() string {
+func defineNextVersion() version.Number {
 	ver := version.Current.Number
 	ver.Patch++
-	return ver.String()
+	return ver
 }
 
 var nextVersion = defineNextVersion()
@@ -128,15 +128,6 @@ func (ctx *context) setAgentPresence(c *gc.C, p presence.Presencer) *presence.Pi
 
 func (s *StatusSuite) newContext(c *gc.C) *context {
 	st := s.Environ.(testing.GetStater).GetStateInAPIServer()
-
-	// We need to have a new version available to test it outputs
-	// correctly.
-	env, err := st.Environment()
-	c.Check(err, jc.ErrorIsNil)
-	ver := version.Current.Number
-	ver.Patch++
-	err = env.UpdateLatestToolsVersion(ver)
-	c.Check(err, jc.ErrorIsNil)
 
 	// We make changes in the API server's state so that
 	// our changes to presence are immediately noticed
@@ -274,8 +265,7 @@ var statusTests = []testCase{
 		expect{
 			"simulate juju bootstrap by adding machine/0 to the state",
 			M{
-				"environment":       "dummyenv",
-				"available-version": nextVersion,
+				"environment": "dummyenv",
 				"machines": M{
 					"0": M{
 						"agent-state":                "pending",
@@ -296,8 +286,7 @@ var statusTests = []testCase{
 		expect{
 			"simulate the PA starting an instance in response to the state change",
 			M{
-				"environment":       "dummyenv",
-				"available-version": nextVersion,
+				"environment": "dummyenv",
 				"machines": M{
 					"0": M{
 						"agent-state":                "pending",
@@ -316,8 +305,7 @@ var statusTests = []testCase{
 		expect{
 			"simulate the MA started and set the machine status",
 			M{
-				"environment":       "dummyenv",
-				"available-version": nextVersion,
+				"environment": "dummyenv",
 				"machines": M{
 					"0": machine0,
 				},
@@ -329,8 +317,7 @@ var statusTests = []testCase{
 		expect{
 			"simulate the MA setting the version",
 			M{
-				"environment":       "dummyenv",
-				"available-version": nextVersion,
+				"environment": "dummyenv",
 				"machines": M{
 					"0": M{
 						"dns-name":                   "dummyenv-0.dns",
@@ -358,8 +345,7 @@ var statusTests = []testCase{
 		expect{
 			"machine 0 has specific hardware characteristics",
 			M{
-				"environment":       "dummyenv",
-				"available-version": nextVersion,
+				"environment": "dummyenv",
 				"machines": M{
 					"0": M{
 						"agent-state":                "started",
@@ -382,8 +368,7 @@ var statusTests = []testCase{
 		expect{
 			"machine 0 has no dns-name",
 			M{
-				"environment":       "dummyenv",
-				"available-version": nextVersion,
+				"environment": "dummyenv",
 				"machines": M{
 					"0": M{
 						"agent-state":                "started",
@@ -403,8 +388,7 @@ var statusTests = []testCase{
 		expect{
 			"machine 0 reports pending",
 			M{
-				"environment":       "dummyenv",
-				"available-version": nextVersion,
+				"environment": "dummyenv",
 				"machines": M{
 					"0": M{
 						"agent-state":                "pending",
@@ -421,8 +405,7 @@ var statusTests = []testCase{
 		expect{
 			"machine 0 reports missing",
 			M{
-				"environment":       "dummyenv",
-				"available-version": nextVersion,
+				"environment": "dummyenv",
 				"machines": M{
 					"0": M{
 						"instance-state":             "missing",
@@ -450,8 +433,7 @@ var statusTests = []testCase{
 		expect{
 			"no services exposed yet",
 			M{
-				"environment":       "dummyenv",
-				"available-version": nextVersion,
+				"environment": "dummyenv",
 				"machines": M{
 					"0": machine0,
 				},
@@ -467,8 +449,7 @@ var statusTests = []testCase{
 		expect{
 			"one exposed service",
 			M{
-				"environment":       "dummyenv",
-				"available-version": nextVersion,
+				"environment": "dummyenv",
 				"machines": M{
 					"0": machine0,
 				},
@@ -491,8 +472,7 @@ var statusTests = []testCase{
 		expect{
 			"two more machines added",
 			M{
-				"environment":       "dummyenv",
-				"available-version": nextVersion,
+				"environment": "dummyenv",
 				"machines": M{
 					"0": machine0,
 					"1": machine1,
@@ -527,8 +507,7 @@ var statusTests = []testCase{
 		expect{
 			"add two units, one alive (in error state), one started",
 			M{
-				"environment":       "dummyenv",
-				"available-version": nextVersion,
+				"environment": "dummyenv",
 				"machines": M{
 					"0": machine0,
 					"1": machine1,
@@ -607,8 +586,7 @@ var statusTests = []testCase{
 		expect{
 			"add three more machine, one with a dead agent, one in error state and one dead itself; also one dying unit",
 			M{
-				"environment":       "dummyenv",
-				"available-version": nextVersion,
+				"environment": "dummyenv",
 				"machines": M{
 					"0": machine0,
 					"1": machine1,
@@ -699,8 +677,7 @@ var statusTests = []testCase{
 			"scope status on dummy-service/0 unit",
 			[]string{"dummy-service/0"},
 			M{
-				"environment":       "dummyenv",
-				"available-version": nextVersion,
+				"environment": "dummyenv",
 				"machines": M{
 					"1": machine1,
 				},
@@ -736,8 +713,7 @@ var statusTests = []testCase{
 			"scope status on exposed-service service",
 			[]string{"exposed-service"},
 			M{
-				"environment":       "dummyenv",
-				"available-version": nextVersion,
+				"environment": "dummyenv",
 				"machines": M{
 					"2": machine2,
 				},
@@ -778,8 +754,7 @@ var statusTests = []testCase{
 			"scope status on service pattern",
 			[]string{"d*-service"},
 			M{
-				"environment":       "dummyenv",
-				"available-version": nextVersion,
+				"environment": "dummyenv",
 				"machines": M{
 					"1": machine1,
 				},
@@ -815,8 +790,7 @@ var statusTests = []testCase{
 			"scope status on unit pattern",
 			[]string{"e*posed-service/*"},
 			M{
-				"environment":       "dummyenv",
-				"available-version": nextVersion,
+				"environment": "dummyenv",
 				"machines": M{
 					"2": machine2,
 				},
@@ -857,8 +831,7 @@ var statusTests = []testCase{
 			"scope status on combination of service and unit patterns",
 			[]string{"exposed-service", "dummy-service", "e*posed-service/*", "dummy-service/*"},
 			M{
-				"environment":       "dummyenv",
-				"available-version": nextVersion,
+				"environment": "dummyenv",
 				"machines": M{
 					"1": machine1,
 					"2": machine2,
@@ -950,8 +923,7 @@ var statusTests = []testCase{
 		expect{
 			"a unit with a hook relation error",
 			M{
-				"environment":       "dummyenv",
-				"available-version": nextVersion,
+				"environment": "dummyenv",
 				"machines": M{
 					"0": machine0,
 					"1": machine1,
@@ -1047,8 +1019,7 @@ var statusTests = []testCase{
 		expect{
 			"a unit with a hook relation error when the agent is down",
 			M{
-				"environment":       "dummyenv",
-				"available-version": nextVersion,
+				"environment": "dummyenv",
 				"machines": M{
 					"0": machine0,
 					"1": machine1,
@@ -1125,8 +1096,7 @@ var statusTests = []testCase{
 		expect{
 			"service shows life==dying",
 			M{
-				"environment":       "dummyenv",
-				"available-version": nextVersion,
+				"environment": "dummyenv",
 				"machines": M{
 					"0": M{
 						"agent-state": "pending",
@@ -1177,8 +1147,7 @@ var statusTests = []testCase{
 		expect{
 			"unit shows that agent is lost",
 			M{
-				"environment":       "dummyenv",
-				"available-version": nextVersion,
+				"environment": "dummyenv",
 				"machines": M{
 					"0": M{
 						"agent-state": "started",
@@ -1271,8 +1240,7 @@ var statusTests = []testCase{
 		expect{
 			"multiples services with relations between some of them",
 			M{
-				"environment":       "dummyenv",
-				"available-version": nextVersion,
+				"environment": "dummyenv",
 				"machines": M{
 					"0": machine0,
 					"1": machine1,
@@ -1430,8 +1398,7 @@ var statusTests = []testCase{
 		expect{
 			"multiples related peer units",
 			M{
-				"environment":       "dummyenv",
-				"available-version": nextVersion,
+				"environment": "dummyenv",
 				"machines": M{
 					"0": machine0,
 					"1": machine1,
@@ -1545,8 +1512,7 @@ var statusTests = []testCase{
 		expect{
 			"multiples related peer units",
 			M{
-				"environment":       "dummyenv",
-				"available-version": nextVersion,
+				"environment": "dummyenv",
 				"machines": M{
 					"0": machine0,
 					"1": machine1,
@@ -1656,8 +1622,7 @@ var statusTests = []testCase{
 			"subordinates scoped on logging",
 			[]string{"logging"},
 			M{
-				"environment":       "dummyenv",
-				"available-version": nextVersion,
+				"environment": "dummyenv",
 				"machines": M{
 					"1": machine1,
 					"2": machine2,
@@ -1766,8 +1731,7 @@ var statusTests = []testCase{
 			"subordinates scoped on logging",
 			[]string{"wordpress/0"},
 			M{
-				"environment":       "dummyenv",
-				"available-version": nextVersion,
+				"environment": "dummyenv",
 				"machines": M{
 					"1": machine1,
 				},
@@ -1866,8 +1830,7 @@ var statusTests = []testCase{
 		expect{
 			"machines with nested containers",
 			M{
-				"environment":       "dummyenv",
-				"available-version": nextVersion,
+				"environment": "dummyenv",
 				"machines": M{
 					"0": machine0,
 					"1": machine1WithContainers,
@@ -1918,8 +1881,7 @@ var statusTests = []testCase{
 			"machines with nested containers",
 			[]string{"mysql/1"},
 			M{
-				"environment":       "dummyenv",
-				"available-version": nextVersion,
+				"environment": "dummyenv",
 				"machines": M{
 					"1": M{
 						"agent-state": "started",
@@ -1984,8 +1946,7 @@ var statusTests = []testCase{
 		expect{
 			"services and units with correct charm status",
 			M{
-				"environment":       "dummyenv",
-				"available-version": nextVersion,
+				"environment": "dummyenv",
 				"machines": M{
 					"0": machine0,
 					"1": machine1,
@@ -2042,8 +2003,7 @@ var statusTests = []testCase{
 		expect{
 			"services and units with correct charm status",
 			M{
-				"environment":       "dummyenv",
-				"available-version": nextVersion,
+				"environment": "dummyenv",
 				"machines": M{
 					"0": machine0,
 					"1": machine1,
@@ -2099,8 +2059,7 @@ var statusTests = []testCase{
 		expect{
 			"services and units with correct charm status",
 			M{
-				"environment":       "dummyenv",
-				"available-version": nextVersion,
+				"environment": "dummyenv",
 				"machines": M{
 					"0": machine0,
 					"1": machine1,
@@ -2157,8 +2116,7 @@ var statusTests = []testCase{
 		expect{
 			"services and units with correct charm status",
 			M{
-				"environment":       "dummyenv",
-				"available-version": nextVersion,
+				"environment": "dummyenv",
 				"machines": M{
 					"0": machine0,
 					"1": machine1,
@@ -2247,8 +2205,7 @@ var statusTests = []testCase{
 		expect{
 			"simulate just the two services and a bootstrap node",
 			M{
-				"environment":       "dummyenv",
-				"available-version": nextVersion,
+				"environment": "dummyenv",
 				"machines": M{
 					"0": machine0,
 					"1": machine1,
@@ -2339,6 +2296,21 @@ var statusTests = []testCase{
 						},
 					},
 				},
+			},
+		},
+	),
+	test( // 18
+		"upgrade available",
+		setToolsUpgradeAvailable{},
+		expect{
+			"upgrade availability should be shown in environment-status",
+			M{
+				"environment": "dummyenv",
+				"environment-status": M{
+					"upgrade-available": nextVersion.String(),
+				},
+				"machines": M{},
+				"services": M{},
 			},
 		},
 	),
@@ -2844,6 +2816,15 @@ func (e expect) step(c *gc.C, ctx *context) {
 	scopedExpect{e.what, nil, e.output}.step(c, ctx)
 }
 
+type setToolsUpgradeAvailable struct{}
+
+func (ua setToolsUpgradeAvailable) step(c *gc.C, ctx *context) {
+	env, err := ctx.st.Environment()
+	c.Assert(err, jc.ErrorIsNil)
+	err = env.UpdateLatestToolsVersion(nextVersion)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
 func (s *StatusSuite) TestStatusAllFormats(c *gc.C) {
 	for i, t := range statusTests {
 		c.Logf("test %d: %s", i, t.summary)
@@ -3127,19 +3108,17 @@ func (s *StatusSuite) TestStatusWithFormatOneline(c *gc.C) {
   - logging/1: dummyenv-2.dns (error)
 - wordpress/0: dummyenv-1.dns (started)
   - logging/0: dummyenv-1.dns (started)
-- new available version: %q
 `
-	assertOneLineStatus(c, fmt.Sprintf(expectedV1, nextVersion))
+	assertOneLineStatus(c, expectedV1)
 
 	const expectedV2 = `
 - mysql/0: dummyenv-2.dns (agent:idle, workload:active)
   - logging/1: dummyenv-2.dns (agent:idle, workload:error)
 - wordpress/0: dummyenv-1.dns (agent:idle, workload:active)
   - logging/0: dummyenv-1.dns (agent:idle, workload:active)
-- new available version: %q
 `
 	s.PatchEnvironment(osenv.JujuCLIVersion, "2")
-	assertOneLineStatus(c, fmt.Sprintf(expectedV2, nextVersion))
+	assertOneLineStatus(c, expectedV2)
 }
 
 func assertOneLineStatus(c *gc.C, expected string) {
@@ -3164,6 +3143,7 @@ func assertOneLineStatus(c *gc.C, expected string) {
 func (s *StatusSuite) prepareTabularData(c *gc.C) *context {
 	ctx := s.newContext(c)
 	steps := []stepper{
+		setToolsUpgradeAvailable{},
 		addMachine{machineId: "0", job: state.JobManageEnviron},
 		setAddresses{"0", network.NewAddresses("dummyenv-0.dns")},
 		startAliveMachine{"0"},
@@ -3223,6 +3203,10 @@ func (s *StatusSuite) testStatusWithFormatTabular(c *gc.C, useFeatureFlag bool) 
 	c.Check(code, gc.Equals, 0)
 	c.Check(string(stderr), gc.Equals, "")
 	const expected = `
+[Environment]     
+UPGRADE-AVAILABLE 
+%s        
+
 [Services] 
 NAME       STATUS      EXPOSED CHARM                  
 logging                true    cs:quantal/logging-1   
@@ -3241,10 +3225,6 @@ ID         STATE   VERSION DNS            INS-ID     SERIES  HARDWARE
 0          started         dummyenv-0.dns dummyenv-0 quantal arch=amd64 cpu-cores=1 mem=1024M root-disk=8192M 
 1          started         dummyenv-1.dns dummyenv-1 quantal arch=amd64 cpu-cores=1 mem=1024M root-disk=8192M 
 2          started         dummyenv-2.dns dummyenv-2 quantal arch=amd64 cpu-cores=1 mem=1024M root-disk=8192M 
-
-[Juju]            
-UPGRADE-AVAILABLE 
-%s        
 
 `
 	c.Assert(string(stdout), gc.Equals, fmt.Sprintf(expected[1:], nextVersion))
@@ -3426,10 +3406,8 @@ func (s *StatusSuite) TestFilterToStarted(c *gc.C) {
 
 - wordpress/0: dummyenv-1.dns (started)
   - logging/0: dummyenv-1.dns (started)
-- new available version: %q
 `
-
-	c.Assert(string(stdout), gc.Equals, fmt.Sprintf(expected[1:], nextVersion))
+	c.Assert(string(stdout), gc.Equals, expected[1:])
 }
 
 // Scenario: One unit is in an errored state and user filters to errored
@@ -3447,10 +3425,8 @@ func (s *StatusSuite) TestFilterToErrored(c *gc.C) {
 
 - mysql/0: dummyenv-2.dns (started)
   - logging/1: dummyenv-2.dns (error)
-- new available version: %q
 `
-
-	c.Assert(string(stdout), gc.Equals, fmt.Sprintf(expected[1:], nextVersion))
+	c.Assert(string(stdout), gc.Equals, expected[1:])
 }
 
 // Scenario: User filters to mysql service
@@ -3466,10 +3442,9 @@ func (s *StatusSuite) TestFilterToService(c *gc.C) {
 
 - mysql/0: dummyenv-2.dns (started)
   - logging/1: dummyenv-2.dns (started)
-- new available version: %q
 `
 
-	c.Assert(string(stdout), gc.Equals, fmt.Sprintf(expected[1:], nextVersion))
+	c.Assert(string(stdout), gc.Equals, expected[1:])
 }
 
 // Scenario: User filters to exposed services
@@ -3491,10 +3466,8 @@ func (s *StatusSuite) TestFilterToExposedService(c *gc.C) {
 
 - mysql/0: dummyenv-2.dns (started)
   - logging/1: dummyenv-2.dns (started)
-- new available version: %q
 `
-
-	c.Assert(string(stdout), gc.Equals, fmt.Sprintf(expected[1:], nextVersion))
+	c.Assert(string(stdout), gc.Equals, expected[1:])
 }
 
 // Scenario: User filters to non-exposed services
@@ -3511,10 +3484,8 @@ func (s *StatusSuite) TestFilterToNotExposedService(c *gc.C) {
 
 - wordpress/0: dummyenv-1.dns (started)
   - logging/0: dummyenv-1.dns (started)
-- new available version: %q
 `
-
-	c.Assert(string(stdout), gc.Equals, fmt.Sprintf(expected[1:], nextVersion))
+	c.Assert(string(stdout), gc.Equals, expected[1:])
 }
 
 // Scenario: Filtering on Subnets
@@ -3534,10 +3505,8 @@ func (s *StatusSuite) TestFilterOnSubnet(c *gc.C) {
 
 - wordpress/0: localhost (started)
   - logging/0: localhost (started)
-- new available version: %q
 `
-
-	c.Assert(string(stdout), gc.Equals, fmt.Sprintf(expected[1:], nextVersion))
+	c.Assert(string(stdout), gc.Equals, expected[1:])
 }
 
 // Scenario: Filtering on Ports
@@ -3558,10 +3527,8 @@ func (s *StatusSuite) TestFilterOnPorts(c *gc.C) {
 
 - wordpress/0: localhost (started) 80/tcp
   - logging/0: localhost (started)
-- new available version: %q
 `
-
-	c.Assert(string(stdout), gc.Equals, fmt.Sprintf(expected[1:], nextVersion))
+	c.Assert(string(stdout), gc.Equals, expected[1:])
 }
 
 // Scenario: User filters out a parent, but not its subordinate
@@ -3579,10 +3546,8 @@ func (s *StatusSuite) TestFilterParentButNotSubordinate(c *gc.C) {
   - logging/1: dummyenv-2.dns (started)
 - wordpress/0: dummyenv-1.dns (started)
   - logging/0: dummyenv-1.dns (started)
-- new available version: %q
 `
-
-	c.Assert(string(stdout), gc.Equals, fmt.Sprintf(expected[1:], nextVersion))
+	c.Assert(string(stdout), gc.Equals, expected[1:])
 }
 
 // Scenario: User filters out a subordinate, but not its parent
@@ -3600,10 +3565,8 @@ func (s *StatusSuite) TestFilterSubordinateButNotParent(c *gc.C) {
 
 - mysql/0: dummyenv-2.dns (started)
   - logging/1: dummyenv-2.dns (started)
-- new available version: %q
 `
-
-	c.Assert(string(stdout), gc.Equals, fmt.Sprintf(expected[1:], nextVersion))
+	c.Assert(string(stdout), gc.Equals, expected[1:])
 }
 
 func (s *StatusSuite) TestFilterMultipleHomogenousPatterns(c *gc.C) {
@@ -3619,10 +3582,8 @@ func (s *StatusSuite) TestFilterMultipleHomogenousPatterns(c *gc.C) {
   - logging/1: dummyenv-2.dns (started)
 - wordpress/0: dummyenv-1.dns (started)
   - logging/0: dummyenv-1.dns (started)
-- new available version: %q
 `
-
-	c.Assert(string(stdout), gc.Equals, fmt.Sprintf(expected[1:], nextVersion))
+	c.Assert(string(stdout), gc.Equals, expected[1:])
 }
 
 func (s *StatusSuite) TestFilterMultipleHeterogenousPatterns(c *gc.C) {
@@ -3638,10 +3599,8 @@ func (s *StatusSuite) TestFilterMultipleHeterogenousPatterns(c *gc.C) {
   - logging/1: dummyenv-2.dns (started)
 - wordpress/0: dummyenv-1.dns (started)
   - logging/0: dummyenv-1.dns (started)
-- new available version: %q
 `
-
-	c.Assert(string(stdout), gc.Equals, fmt.Sprintf(expected[1:], nextVersion))
+	c.Assert(string(stdout), gc.Equals, expected[1:])
 }
 
 // TestSummaryStatusWithUnresolvableDns is result of bug# 1410320.
@@ -3710,8 +3669,7 @@ var statusTimeTest = test(
 	expect{
 		"add two units, one alive (in error state), one started",
 		M{
-			"environment":       "dummyenv",
-			"available-version": nextVersion,
+			"environment": "dummyenv",
 			"machines": M{
 				"0": machine0,
 				"1": machine1,


### PR DESCRIPTION
1. The recently added top-level available-version section is now underneath a new environment-status section. This section will later be used to also show information about environment migration and other
high-level concerns. The environment-status section is only displayed when there's something to be shown in it.

2. The display of an available upgrade was removed from the oneline formatter. The upgrade notification was being shown as if it was a unit which is confusing and could break automated parsing. Given the tight focus of the oneline output (showing the units and subordinates) I think it's best not to even attempt to include the upgrade notification there.

3. The tests have been cleaned up. Instead of making it appear an upgrade is available during all status tests - requiring that all expected output include the upgrade notification, even when a test case has nothing to do with the upgrade notification - there are now specific tests for the upgrade notification.

(Review request: http://reviews.vapour.ws/r/2933/)