### PR TITLE
Check "uninstall-agent" file before uninstalling (1.25)

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -32,6 +32,13 @@ import (
 
 var logger = loggo.GetLogger("juju.agent")
 
+const (
+	// UninstallAgentFile is the name of the file inside the data
+	// dir that, if it exists, will cause a machine agent to uninstall
+	// when it receives the termination signal.
+	UninstallAgentFile = "uninstall-agent"
+)
+
 // These are base values used for the corresponding defaults.
 var (
 	logDir  = paths.MustSucceed(paths.LogDir(version.Current.Series))

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -446,7 +446,26 @@ func (a *MachineAgent) Run(*cmd.Context) error {
 	a.runner.StartWorker("api", a.APIWorker)
 	a.runner.StartWorker("statestarter", a.newStateStarterWorker)
 	a.runner.StartWorker("termination", func() (worker.Worker, error) {
-		return terminationworker.NewWorker(), nil
+		uninstallFile := filepath.Join(
+			agentConfig.DataDir(), agent.UninstallAgentFile,
+		)
+		terminationError := func() error {
+			// If the uninstall file exists, then the termination
+			// signal should cause the agent to uninstall; otherwise
+			// it should just restart the workers.
+			if _, err := os.Stat(uninstallFile); err == nil {
+				return worker.ErrTerminateAgent
+			}
+			logger.Debugf(
+				"uninstall file %q does not exist",
+				uninstallFile,
+			)
+			return &cmdutil.FatalError{fmt.Sprintf(
+				"%s signal received",
+				terminationworker.TerminationSignal,
+			)}
+		}
+		return terminationworker.NewWorker(terminationError), nil
 	})
 
 	// At this point, all workers will have been configured to start

--- a/provider/local/environ.go
+++ b/provider/local/environ.go
@@ -5,6 +5,7 @@ package local
 
 import (
 	"fmt"
+	"io/ioutil"
 	"net"
 	"os"
 	"os/exec"
@@ -510,6 +511,10 @@ func (env *localEnviron) Destroy() error {
 		if err := env.containerManager.DestroyContainer(inst.Id()); err != nil {
 			return err
 		}
+	}
+	uninstallFile := filepath.Join(env.config.rootDir(), agent.UninstallAgentFile)
+	if err := ioutil.WriteFile(uninstallFile, nil, 0644); err != nil {
+		logger.Debugf("could not write uninstall file: %s", err)
 	}
 	cmd := exec.Command(
 		"pkill",

--- a/provider/manual/environ.go
+++ b/provider/manual/environ.go
@@ -282,6 +282,7 @@ var runSSHCommand = func(host string, command []string, stdin string) (stdout st
 func (e *manualEnviron) Destroy() error {
 	script := `
 set -x
+touch %s
 pkill -%d jujud && exit
 stop %s
 rm -f /etc/init/juju*
@@ -291,6 +292,10 @@ exit 0
 `
 	script = fmt.Sprintf(
 		script,
+		utils.ShQuote(path.Join(
+			agent.DefaultDataDir,
+			agent.UninstallAgentFile,
+		)),
 		terminationworker.TerminationSignal,
 		mongo.ServiceName(""),
 		utils.ShQuote(agent.DefaultDataDir),

--- a/provider/manual/environ_test.go
+++ b/provider/manual/environ_test.go
@@ -88,8 +88,9 @@ func (s *environSuite) TestDestroy(c *gc.C) {
 	runSSHCommandTesting := func(host string, command []string, stdin string) (string, error) {
 		c.Assert(host, gc.Equals, "ubuntu@hostname")
 		c.Assert(command, gc.DeepEquals, []string{"sudo", "/bin/bash"})
-		c.Assert(stdin, gc.DeepEquals, `
+		c.Assert(stdin, jc.DeepEquals, `
 set -x
+touch '/var/lib/juju/uninstall-agent'
 pkill -6 jujud && exit
 stop juju-db
 rm -f /etc/init/juju*

--- a/worker/terminationworker/worker.go
+++ b/worker/terminationworker/worker.go
@@ -9,6 +9,8 @@ import (
 	"syscall"
 
 	"launchpad.net/tomb"
+
+	"github.com/juju/juju/worker"
 )
 
 // TerminationSignal is the signal that
@@ -29,7 +31,7 @@ type terminationWorker struct {
 // TerminationSignal signal, and then exits
 // with the result of calling the provided
 // function.
-func NewWorker(f func() error) *terminationWorker {
+func NewWorker(f func() error) worker.Worker {
 	u := &terminationWorker{onSignal: f}
 	go func() {
 		defer u.tomb.Done()

--- a/worker/terminationworker/worker.go
+++ b/worker/terminationworker/worker.go
@@ -9,8 +9,6 @@ import (
 	"syscall"
 
 	"launchpad.net/tomb"
-
-	"github.com/juju/juju/worker"
 )
 
 // TerminationSignal is the signal that
@@ -22,16 +20,17 @@ import (
 // shutdown.
 const TerminationSignal = syscall.SIGABRT
 
-// NewWorker returns a worker that wais for a
-
 type terminationWorker struct {
-	tomb tomb.Tomb
+	tomb     tomb.Tomb
+	onSignal func() error
 }
 
-// TerminationSignal signal and exits with
-// ErrTerminateAgent.
-func NewWorker() worker.Worker {
-	u := &terminationWorker{}
+// NewWorker returns a worker that waits for a
+// TerminationSignal signal, and then exits
+// with the result of calling the provided
+// function.
+func NewWorker(f func() error) *terminationWorker {
+	u := &terminationWorker{onSignal: f}
 	go func() {
 		defer u.tomb.Done()
 		u.tomb.Kill(u.loop())
@@ -53,8 +52,8 @@ func (u *terminationWorker) loop() (err error) {
 	defer signal.Stop(c)
 	select {
 	case <-c:
-		return worker.ErrTerminateAgent
+		return u.onSignal()
 	case <-u.tomb.Dying():
-		return nil
+		return tomb.ErrDying
 	}
 }

--- a/worker/terminationworker/worker_test.go
+++ b/worker/terminationworker/worker_test.go
@@ -4,6 +4,7 @@
 package terminationworker_test
 
 import (
+	"errors"
 	"os"
 	"os/signal"
 	"runtime"
@@ -13,7 +14,6 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/testing"
-	"github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/terminationworker"
 )
 
@@ -43,7 +43,9 @@ func (s *TerminationWorkerSuite) TearDownTest(c *gc.C) {
 }
 
 func (s *TerminationWorkerSuite) TestStartStop(c *gc.C) {
-	w := terminationworker.NewWorker()
+	w := terminationworker.NewWorker(func() error {
+		return errors.New("anything")
+	})
 	w.Kill()
 	err := w.Wait()
 	c.Assert(err, jc.ErrorIsNil)
@@ -54,12 +56,14 @@ func (s *TerminationWorkerSuite) TestSignal(c *gc.C) {
 	if runtime.GOOS == "windows" {
 		c.Skip("bug 1403084: sending this signal is not supported on windows")
 	}
-	w := terminationworker.NewWorker()
+	w := terminationworker.NewWorker(func() error {
+		return errors.New("anything")
+	})
 	proc, err := os.FindProcess(os.Getpid())
 	c.Assert(err, jc.ErrorIsNil)
 	defer proc.Release()
 	err = proc.Signal(terminationworker.TerminationSignal)
 	c.Assert(err, jc.ErrorIsNil)
 	err = w.Wait()
-	c.Assert(err, gc.Equals, worker.ErrTerminateAgent)
+	c.Assert(err, gc.ErrorMatches, "anything")
 }


### PR DESCRIPTION
Back-port.

If SIGABRT is received, then jujud would previously uninstall itself. We
now add a further condition: there must exist a file called
"uninstall-agent" in the agent's data directory. If it does not exist, the
agent is simply bounced; otherwise it uninstalls.

Fixes https://bugs.launchpad.net/juju-core/+bug/1464304

(Review request: http://reviews.vapour.ws/r/2936/)