### PR TITLE
Fix TestStartTerminationWorker on gccgo for 1.25

### DIFF
--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -2206,9 +2206,9 @@ func (*machineAgentTerminationSuite) TestStartTerminationWorker(c *gc.C) {
 	c.Assert(errorFunction, gc.NotNil)
 
 	stub.SetErrors(os.ErrNotExist, nil)
-	c.Assert(errorFunction(), jc.DeepEquals, &cmdutil.FatalError{
-		`"aborted" signal received`,
-	})
+	errorResult := errorFunction()
+	c.Assert(errorResult, gc.FitsTypeOf, (*cmdutil.FatalError)(nil))
+	c.Assert(errorResult, gc.ErrorMatches, `"[aA]borted" signal received`)
 	stub.CheckCall(c, 0, "Stat", filepath.Join("data-dir", "uninstall-agent"))
 
 	// No error returned from Stat == uninstall-agent exists.


### PR DESCRIPTION
Seems SIGABRT name is title-case on gccgo, adapt the error check
to accept that so the ppc64el tests pass.

(Review request: http://reviews.vapour.ws/r/2939/)