### PR TITLE
Do not log error if no matching tools found

### DIFF
--- a/apiserver/environment/toolsversionupdate.go
+++ b/apiserver/environment/toolsversionupdate.go
@@ -46,9 +46,15 @@ func checkToolsAvailability(cfg *config.Config, finder toolsFinder) (version.Num
 
 	// finder receives major and minor as parameters as it uses them to filter versions and
 	// only return patches for the passed major.minor (from major.minor.patch).
+	// We'll try the released stream first, then fall back to the current configured stream
+	// if no released tools are found.
 	vers, err := finder(env, currentVersion.Major, currentVersion.Minor, tools.ReleasedStream, coretools.Filter{})
+	stream := cfg.AgentStream()
+	if stream != tools.ReleasedStream && errors.Cause(err) == coretools.ErrNoMatches {
+		vers, err = finder(env, currentVersion.Major, currentVersion.Minor, stream, coretools.Filter{})
+	}
 	if err != nil {
-		return version.Zero, errors.Annotatef(err, "canot find available tools")
+		return version.Zero, errors.Annotatef(err, "cannot find available tools")
 	}
 	// Newest also returns a list of the items in this list matching with the
 	// newest version.
@@ -76,6 +82,10 @@ func updateToolsAvailability(st EnvironGetter, finder toolsFinder, update envVer
 	}
 	ver, err := checkToolsAvailability(cfg, finder)
 	if err != nil {
+		if errors.Cause(err) == coretools.ErrNoMatches {
+			// No newer tools, so exit silently.
+			return nil
+		}
 		return errors.Annotate(err, "cannot get latest version")
 	}
 	if ver == version.Zero {

--- a/apiserver/environment/toolsversionupdate_test.go
+++ b/apiserver/environment/toolsversionupdate_test.go
@@ -41,7 +41,7 @@ func (s *updaterSuite) TestCheckTools(c *gc.C) {
 		calledWithMajor, calledWithMinor int
 		calledWithFilter                 coretools.Filter
 	)
-	fakeToolFinder := func(e environs.Environ, maj int, min int, _ string, filter coretools.Filter) (coretools.List, error) {
+	fakeToolFinder := func(e environs.Environ, maj int, min int, stream string, filter coretools.Filter) (coretools.List, error) {
 		calledWithEnviron = e
 		calledWithMajor = maj
 		calledWithMinor = min
@@ -50,11 +50,52 @@ func (s *updaterSuite) TestCheckTools(c *gc.C) {
 		t := coretools.Tools{Version: ver, URL: "http://example.com", Size: 1}
 		c.Assert(calledWithMajor, gc.Equals, 2)
 		c.Assert(calledWithMinor, gc.Equals, 5)
+		c.Assert(stream, gc.Equals, "released")
 		return coretools.List{&t}, nil
 	}
 
 	ver, err := checkToolsAvailability(cfg, fakeToolFinder)
 	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ver, gc.Not(gc.Equals), version.Zero)
+	c.Assert(ver, gc.Equals, version.Number{Major: 2, Minor: 5, Patch: 0})
+}
+
+func (s *updaterSuite) TestCheckToolsNonReleasedStream(c *gc.C) {
+	sConfig := coretesting.FakeConfig()
+	sConfig = sConfig.Merge(coretesting.Attrs{
+		"agent-version": "2.5-alpha1",
+		"agent-stream":  "proposed",
+	})
+	cfg, err := config.New(config.NoDefaults, sConfig)
+	c.Assert(err, jc.ErrorIsNil)
+	fakeNewEnvirons := func(*config.Config) (environs.Environ, error) {
+		return dummyEnviron{}, nil
+	}
+	s.PatchValue(&newEnvirons, fakeNewEnvirons)
+	var (
+		calledWithEnviron                environs.Environ
+		calledWithMajor, calledWithMinor int
+		calledWithFilter                 coretools.Filter
+		calledWithStreams                []string
+	)
+	fakeToolFinder := func(e environs.Environ, maj int, min int, stream string, filter coretools.Filter) (coretools.List, error) {
+		calledWithEnviron = e
+		calledWithMajor = maj
+		calledWithMinor = min
+		calledWithFilter = filter
+		calledWithStreams = append(calledWithStreams, stream)
+		if stream == "released" {
+			return nil, coretools.ErrNoMatches
+		}
+		ver := version.Binary{Number: version.Number{Major: maj, Minor: min}}
+		t := coretools.Tools{Version: ver, URL: "http://example.com", Size: 1}
+		c.Assert(calledWithMajor, gc.Equals, 2)
+		c.Assert(calledWithMinor, gc.Equals, 5)
+		return coretools.List{&t}, nil
+	}
+	ver, err := checkToolsAvailability(cfg, fakeToolFinder)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(calledWithStreams, gc.DeepEquals, []string{"released", "proposed"})
 	c.Assert(ver, gc.Not(gc.Equals), version.Zero)
 	c.Assert(ver, gc.Equals, version.Number{Major: 2, Minor: 5, Patch: 0})
 }
@@ -100,4 +141,34 @@ func (s *updaterSuite) TestUpdateToolsAvailability(c *gc.C) {
 
 	c.Assert(ver, gc.Not(gc.Equals), version.Zero)
 	c.Assert(ver, gc.Equals, version.Number{Major: 2, Minor: 5, Patch: 2})
+}
+
+func (s *updaterSuite) TestUpdateToolsAvailabilityNoMatches(c *gc.C) {
+	fakeNewEnvirons := func(*config.Config) (environs.Environ, error) {
+		return dummyEnviron{}, nil
+	}
+	s.PatchValue(&newEnvirons, fakeNewEnvirons)
+
+	fakeEnvConfig := func(_ *state.Environment) (*config.Config, error) {
+		sConfig := coretesting.FakeConfig()
+		sConfig = sConfig.Merge(coretesting.Attrs{
+			"agent-version": "2.5.0",
+		})
+		return config.New(config.NoDefaults, sConfig)
+	}
+	s.PatchValue(&envConfig, fakeEnvConfig)
+
+	// No new tools available.
+	fakeToolFinder := func(_ environs.Environ, _ int, _ int, _ string, _ coretools.Filter) (coretools.List, error) {
+		return nil, coretools.ErrNoMatches
+	}
+
+	// Update should never be called.
+	fakeUpdate := func(_ *state.Environment, v version.Number) error {
+		c.Fail()
+		return nil
+	}
+
+	err := updateToolsAvailability(&envGetter{}, fakeToolFinder, fakeUpdate)
+	c.Assert(err, jc.ErrorIsNil)
 }


### PR DESCRIPTION
When looking for newer tools, and no matches are found, no need to log an error, that's just noise.

Also, if the user has configured a different agent-stream to released, we check for tools in that stream if no released tools are found.

(Review request: http://reviews.vapour.ws/r/2942/)