### PR TITLE
cmd/jujud: simplify cmd.Log factory

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -10,7 +10,7 @@ github.com/joyent/gomanta	git	cabd97b029d931836571f00b7e48c331809a30b7	2014-05-2
 github.com/joyent/gosdc	git	2f11feadd2d9891e92296a1077c3e2e56939547d	2014-05-24T00:08:15Z
 github.com/joyent/gosign	git	0da0d5f1342065321c97812b1f4ac0c2b0bab56c	2014-05-24T00:07:34Z
 github.com/juju/blobstore	git	337aa7d5d712728d181dbda2547a6556d4189626	2015-05-08T07:43:36Z
-github.com/juju/cmd	git	635549110c21af54dc354494854b36b998245a73	2015-10-07T12:06:54Z
+github.com/juju/cmd	git	081dd27e371031b13c297d4016d7ef7b0d4fefa4	2015-10-07T12:06:54Z
 github.com/juju/errors	git	4567a5e69fd3130ca0d89f69478e7ac025b67452	2015-03-27T19:24:31Z
 github.com/juju/gojsonpointer	git	afe8b77aa08f272b49e01b82de78510c11f61500	2015-02-04T19:46:29Z
 github.com/juju/gojsonreference	git	f0d24ac5ee330baa21721cdff56d45e4ee42628e	2015-02-04T19:46:33Z


### PR DESCRIPTION
Update to juju/cmd c3d54bf5.

Simplify logic for installing a cmd logger factory.

(Review request: http://reviews.vapour.ws/r/2944/)