### PR TITLE
worker/peergrouper: eliminate JujuConnSuite usage

### DIFF
--- a/featuretests/initiate_replset_test.go
+++ b/featuretests/initiate_replset_test.go
@@ -1,7 +1,7 @@
 // Copyright 2014 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package peergrouper_test
+package featuretests_test
 
 import (
 	gitjujutesting "github.com/juju/testing"

--- a/worker/peergrouper/publish_test.go
+++ b/worker/peergrouper/publish_test.go
@@ -74,3 +74,14 @@ func (s *publishSuite) TestPublisherSortsHostPorts(c *gc.C) {
 	check(true, ipV4First, ipV6First)
 	check(true, ipV6First, ipV6First)
 }
+
+func (s *publishSuite) TestPublisherRejectsNoServers(c *gc.C) {
+	check := func(preferIPv6 bool) {
+		var mock mockAPIHostPortsSetter
+		statePublish := newPublisher(&mock, preferIPv6)
+		err := statePublish.PublishAPIServers(nil, nil)
+		c.Assert(err, gc.ErrorMatches, "no api servers specified")
+	}
+	check(false)
+	check(true)
+}

--- a/worker/peergrouper/suite_test.go
+++ b/worker/peergrouper/suite_test.go
@@ -4,11 +4,11 @@
 package peergrouper_test
 
 import (
-	stdtesting "testing"
+	"testing"
 
-	"github.com/juju/juju/testing"
+	gc "gopkg.in/check.v1"
 )
 
-func TestPackage(t *stdtesting.T) {
-	testing.MgoTestPackage(t)
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
 }


### PR DESCRIPTION
There was only one test in worker/peergrouper that
was using a real Mongo connection in a meaningful
way: TestInitiateReplicaSet. This has been moved
to the featuretests package. The other tests that
were using Mongo (via State) were doing so in
meaningless ways.

TestStartStop was taking a real State, but was not
expected to use it. There is a race though, if the
state-server machines change (not sure how?), then
the worker would be notified and would attempt to
query the mongo replicaset; in this test, mongo is
not started with --replSet, and so the test fails
in that scenario. Passing a fake State ensures we
have complete control over the state-server machines
reported to the worker.

TestPublisherSetsAPIHostPorts was using State as
a means of recording and then checking for API
host ports; it was even doing so through a mocked
publisher. Instead of passing through to State,
we report the values to the test via a channel.

TestPublisherRejectsNoServers doesn't need a State
at all, and was in the wrong place. It has been
moved and simplified.

(Review request: http://reviews.vapour.ws/r/2946/)