### PR TITLE
worker/instancepoller: correct package name in log

### DIFF
--- a/worker/instancepoller/updater.go
+++ b/worker/instancepoller/updater.go
@@ -16,7 +16,7 @@ import (
 	"github.com/juju/juju/state/watcher"
 )
 
-var logger = loggo.GetLogger("juju.worker.instanceupdater")
+var logger = loggo.GetLogger("juju.worker.instancepoller")
 
 // ShortPoll and LongPoll hold the polling intervals for the instance
 // updater. When a machine has no address or is not started, it will be


### PR DESCRIPTION
Set logging name to "juju.worker.instancepoller".

Fixes https://bugs.launchpad.net/juju-core/+bug/1439375

(Review request: http://reviews.vapour.ws/r/2947/)