### PR TITLE
cmd/envcmd: only make apiContext when we need one

### DIFF
--- a/cmd/envcmd/environmentcommand_test.go
+++ b/cmd/envcmd/environmentcommand_test.go
@@ -82,6 +82,11 @@ func (s *EnvironmentCommandSuite) TestEnvironCommandInitExplicit(c *gc.C) {
 	testEnsureEnvName(c, "explicit", "-e", "explicit")
 }
 
+func (s *EnvironmentCommandSuite) TestEnvironCommandInitExplicitLongForm(c *gc.C) {
+	// Take environment name from command line arg.
+	testEnsureEnvName(c, "explicit", "--environment", "explicit")
+}
+
 func (s *EnvironmentCommandSuite) TestEnvironCommandInitMultipleConfigs(c *gc.C) {
 	// Take environment name from the default.
 	testing.WriteEnvironments(c, testing.MultipleEnvConfig)

--- a/cmd/envcmd/export_test.go
+++ b/cmd/envcmd/export_test.go
@@ -14,12 +14,7 @@ var (
 // and error as specified for testing purposes.
 // If getterErr != nil then the NewEnvironmentGetter returns the specified error.
 func NewEnvCommandBase(name string, client EnvironmentGetter, getterErr error) *EnvCommandBase {
-	ctx, err := newAPIContext()
-	if err != nil {
-		panic(err.Error())
-	}
 	return &EnvCommandBase{
-		apiContext:      ctx,
 		envName:         name,
 		envGetterClient: client,
 		envGetterErr:    getterErr,


### PR DESCRIPTION
This means that commands that don't make an API context will not
load and save the cookie jar, which was a problem in particular
for the juju plugins because any cookies a plugin was creating
were being overwritten by the juju wrapper.


(Review request: http://reviews.vapour.ws/r/2948/)