### PR TITLE
fixed 2 spelling mistakes

### DIFF
--- a/apiserver/environment/toolsversionupdate.go
+++ b/apiserver/environment/toolsversionupdate.go
@@ -48,7 +48,7 @@ func checkToolsAvailability(cfg *config.Config, finder toolsFinder) (version.Num
 	// only return patches for the passed major.minor (from major.minor.patch).
 	vers, err := finder(env, currentVersion.Major, currentVersion.Minor, tools.ReleasedStream, coretools.Filter{})
 	if err != nil {
-		return version.Zero, errors.Annotatef(err, "canot find available tools")
+		return version.Zero, errors.Annotatef(err, "cannot find available tools")
 	}
 	// Newest also returns a list of the items in this list matching with the
 	// newest version.

--- a/cert/cert.go
+++ b/cert/cert.go
@@ -104,7 +104,7 @@ func NewCA(envName string, expiry time.Time) (certPEM, keyPEM string, err error)
 	}
 	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
 	if err != nil {
-		return "", "", fmt.Errorf("canot create certificate: %v", err)
+		return "", "", fmt.Errorf("cannot create certificate: %v", err)
 	}
 	certPEMData := pem.EncodeToMemory(&pem.Block{
 		Type:  "CERTIFICATE",


### PR DESCRIPTION
changed 'canot' to 'cannot' in cert.go(107) and toolsversionupdate.go(57)