### PR TITLE
Do not panic if api address info is missing from agent conf

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -125,7 +125,7 @@ type Config interface {
 	StateServingInfo() (params.StateServingInfo, bool)
 
 	// APIInfo returns details for connecting to the API server.
-	APIInfo() *api.Info
+	APIInfo() (*api.Info, bool)
 
 	// MongoInfo returns details for connecting to the state server's mongo
 	// database and reports whether those details are available
@@ -671,7 +671,10 @@ func (c *configInternal) WriteCommands(renderer shell.Renderer) ([]string, error
 	return commands, nil
 }
 
-func (c *configInternal) APIInfo() *api.Info {
+func (c *configInternal) APIInfo() (*api.Info, bool) {
+	if c.apiDetails == nil || c.apiDetails.addresses == nil {
+		return nil, false
+	}
 	servingInfo, isStateServer := c.StateServingInfo()
 	addrs := c.apiDetails.addresses
 	if isStateServer {
@@ -698,7 +701,7 @@ func (c *configInternal) APIInfo() *api.Info {
 		Tag:        c.tag,
 		Nonce:      c.nonce,
 		EnvironTag: c.environment,
-	}
+	}, true
 }
 
 func (c *configInternal) MongoInfo() (info *mongo.MongoInfo, ok bool) {

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -124,7 +124,8 @@ type Config interface {
 	// are available
 	StateServingInfo() (params.StateServingInfo, bool)
 
-	// APIInfo returns details for connecting to the API server.
+	// APIInfo returns details for connecting to the API server and
+	// reports whether the details are available.
 	APIInfo() (*api.Info, bool)
 
 	// MongoInfo returns details for connecting to the state server's mongo
@@ -659,6 +660,7 @@ func (c *configInternal) fileContents() ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
+// WriteCommands is defined on Config interface.
 func (c *configInternal) WriteCommands(renderer shell.Renderer) ([]string, error) {
 	data, err := c.fileContents()
 	if err != nil {
@@ -671,6 +673,7 @@ func (c *configInternal) WriteCommands(renderer shell.Renderer) ([]string, error
 	return commands, nil
 }
 
+// APIInfo is defined on Config interface.
 func (c *configInternal) APIInfo() (*api.Info, bool) {
 	if c.apiDetails == nil || c.apiDetails.addresses == nil {
 		return nil, false
@@ -704,6 +707,7 @@ func (c *configInternal) APIInfo() (*api.Info, bool) {
 	}, true
 }
 
+// MongoInfo is defined on Config interface.
 func (c *configInternal) MongoInfo() (info *mongo.MongoInfo, ok bool) {
 	ssi, ok := c.StateServingInfo()
 	if !ok {

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -542,12 +542,19 @@ func (*suite) TestWriteAndRead(c *gc.C) {
 	c.Assert(reread, jc.DeepEquals, conf)
 }
 
+func (*suite) TestAPIInfoMissingAddress(c *gc.C) {
+	conf := agent.EmptyConfig()
+	_, ok := conf.APIInfo()
+	c.Assert(ok, jc.IsFalse)
+}
+
 func (*suite) TestAPIInfoAddsLocalhostWhenServingInfoPresent(c *gc.C) {
 	attrParams := attributeParams
 	servingInfo := stateServingInfo()
 	conf, err := agent.NewStateMachineConfig(attrParams, servingInfo)
 	c.Assert(err, jc.ErrorIsNil)
-	apiinfo := conf.APIInfo()
+	apiinfo, ok := conf.APIInfo()
+	c.Assert(ok, jc.IsTrue)
 	c.Check(apiinfo.Addrs, gc.HasLen, len(attrParams.APIAddresses)+1)
 	localhostAddressFound := false
 	for _, eachApiAddress := range apiinfo.Addrs {
@@ -565,7 +572,8 @@ func (*suite) TestAPIInfoAddsLocalhostWhenServingInfoPresentAndPreferIPv6On(c *g
 	servingInfo := stateServingInfo()
 	conf, err := agent.NewStateMachineConfig(attrParams, servingInfo)
 	c.Assert(err, jc.ErrorIsNil)
-	apiinfo := conf.APIInfo()
+	apiinfo, ok := conf.APIInfo()
+	c.Assert(ok, jc.IsTrue)
 	c.Check(apiinfo.Addrs, gc.HasLen, len(attrParams.APIAddresses)+1)
 	localhostAddressFound := false
 	for _, eachApiAddress := range apiinfo.Addrs {
@@ -601,7 +609,8 @@ func (*suite) TestAPIInfoDoesntAddLocalhostWhenNoServingInfoPreferIPv6Off(c *gc.
 	attrParams.PreferIPv6 = false
 	conf, err := agent.NewAgentConfig(attrParams)
 	c.Assert(err, jc.ErrorIsNil)
-	apiinfo := conf.APIInfo()
+	apiinfo, ok := conf.APIInfo()
+	c.Assert(ok, jc.IsTrue)
 	c.Assert(apiinfo.Addrs, gc.DeepEquals, attrParams.APIAddresses)
 }
 
@@ -610,7 +619,8 @@ func (*suite) TestAPIInfoDoesntAddLocalhostWhenNoServingInfoPreferIPv6On(c *gc.C
 	attrParams.PreferIPv6 = true
 	conf, err := agent.NewAgentConfig(attrParams)
 	c.Assert(err, jc.ErrorIsNil)
-	apiinfo := conf.APIInfo()
+	apiinfo, ok := conf.APIInfo()
+	c.Assert(ok, jc.IsTrue)
 	c.Assert(apiinfo.Addrs, gc.DeepEquals, attrParams.APIAddresses)
 }
 
@@ -629,7 +639,9 @@ func (*suite) TestSetPassword(c *gc.C) {
 		Nonce:      attrParams.Nonce,
 		EnvironTag: attrParams.Environment,
 	}
-	c.Assert(conf.APIInfo(), jc.DeepEquals, expectAPIInfo)
+	apiInfo, ok := conf.APIInfo()
+	c.Assert(ok, jc.IsTrue)
+	c.Assert(apiInfo, jc.DeepEquals, expectAPIInfo)
 	addr := fmt.Sprintf("127.0.0.1:%d", servingInfo.StatePort)
 	expectStateInfo := &mongo.MongoInfo{
 		Info: mongo.Info{
@@ -648,7 +660,9 @@ func (*suite) TestSetPassword(c *gc.C) {
 	expectAPIInfo.Password = "newpassword"
 	expectStateInfo.Password = "newpassword"
 
-	c.Assert(conf.APIInfo(), jc.DeepEquals, expectAPIInfo)
+	apiInfo, ok = conf.APIInfo()
+	c.Assert(ok, jc.IsTrue)
+	c.Assert(apiInfo, jc.DeepEquals, expectAPIInfo)
 	info, ok = conf.MongoInfo()
 	c.Assert(ok, jc.IsTrue)
 	c.Assert(info, jc.DeepEquals, expectStateInfo)

--- a/agent/export_test.go
+++ b/agent/export_test.go
@@ -55,3 +55,7 @@ var (
 	MachineJobFromParams = machineJobFromParams
 	IsLocalEnv           = &isLocalEnv
 )
+
+func EmptyConfig() Config {
+	return &configInternal{}
+}

--- a/agent/format-1.18_whitebox_test.go
+++ b/agent/format-1.18_whitebox_test.go
@@ -52,7 +52,9 @@ func (s *format_1_18Suite) TestMissingAttributes(c *gc.C) {
 	c.Assert(configDataDir, gc.Equals, realDataDir)
 	c.Assert(readConfig.PreferIPv6(), jc.IsFalse)
 	// The api info doesn't have the environment tag set.
-	c.Assert(readConfig.APIInfo().EnvironTag.Id(), gc.Equals, "")
+	apiInfo, ok := readConfig.APIInfo()
+	c.Assert(ok, jc.IsTrue)
+	c.Assert(apiInfo.EnvironTag.Id(), gc.Equals, "")
 }
 
 func (s *format_1_18Suite) TestStatePortNotParsedWithoutSecret(c *gc.C) {

--- a/cmd/jujud/agent/agent.go
+++ b/cmd/jujud/agent/agent.go
@@ -187,7 +187,10 @@ type configChanger func(c *agent.Config)
 // password is changed if the fallback password was used to connect to
 // the API.
 func OpenAPIState(agentConfig agent.Config, a Agent) (_ *api.State, _ *apiagent.Entity, outErr error) {
-	info := agentConfig.APIInfo()
+	info, ok := agentConfig.APIInfo()
+	if !ok {
+		return nil, nil, errors.New("API info not available")
+	}
 	st, usedOldPassword, err := openAPIStateUsingInfo(info, a, agentConfig.OldPassword())
 	if err != nil {
 		return nil, nil, err

--- a/cmd/jujud/agent/agent_test.go
+++ b/cmd/jujud/agent/agent_test.go
@@ -268,6 +268,6 @@ func writeStateAgentConfig(
 
 type fakeAPIOpenConfig struct{ agent.Config }
 
-func (fakeAPIOpenConfig) APIInfo() *api.Info              { return &api.Info{} }
+func (fakeAPIOpenConfig) APIInfo() (*api.Info, bool)      { return &api.Info{}, true }
 func (fakeAPIOpenConfig) OldPassword() string             { return "old" }
 func (fakeAPIOpenConfig) Jobs() []multiwatcher.MachineJob { return []multiwatcher.MachineJob{} }

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -1085,7 +1085,10 @@ func (a *MachineAgent) startEnvWorkers(
 
 	// Establish API connection for this environment.
 	agentConfig := a.CurrentConfig()
-	apiInfo := agentConfig.APIInfo()
+	apiInfo, ok := agentConfig.APIInfo()
+	if !ok {
+		return nil, errors.New("API info not available")
+	}
 	apiInfo.EnvironTag = st.EnvironTag()
 	apiSt, err := OpenAPIStateUsingInfo(apiInfo, a, agentConfig.OldPassword())
 	if err != nil {

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -922,7 +922,9 @@ func (s *MachineSuite) assertAgentOpensState(
 
 func (s *MachineSuite) TestManageEnvironServesAPI(c *gc.C) {
 	s.assertJobWithState(c, state.JobManageEnviron, func(conf agent.Config, agentState *state.State) {
-		st, err := api.Open(conf.APIInfo(), fastDialOpts)
+		apiInfo, ok := conf.APIInfo()
+		c.Assert(ok, jc.IsTrue)
+		st, err := api.Open(apiInfo, fastDialOpts)
 		c.Assert(err, jc.ErrorIsNil)
 		defer st.Close()
 		m, err := st.Machiner().Machine(conf.Tag().(names.MachineTag))

--- a/cmd/jujud/agent/upgrade_test.go
+++ b/cmd/jujud/agent/upgrade_test.go
@@ -901,7 +901,8 @@ func (s *UpgradeSuite) checkLoginToAPIAsUser(c *gc.C, conf agent.Config, expectF
 }
 
 func (s *UpgradeSuite) attemptRestrictedAPIAsUser(c *gc.C, conf agent.Config) error {
-	info := conf.APIInfo()
+	info, ok := conf.APIInfo()
+	c.Assert(ok, jc.IsTrue)
 	info.Tag = s.AdminUserTag(c)
 	info.Password = "dummy-secret"
 	info.Nonce = ""
@@ -920,9 +921,12 @@ func (s *UpgradeSuite) attemptRestrictedAPIAsUser(c *gc.C, conf agent.Config) er
 }
 
 func canLoginToAPIAsMachine(c *gc.C, fromConf, toConf agent.Config) bool {
-	info := fromConf.APIInfo()
-	info.Addrs = toConf.APIInfo().Addrs
-	apiState, err := api.Open(info, upgradeTestDialOpts)
+	fromInfo, ok := fromConf.APIInfo()
+	c.Assert(ok, jc.IsTrue)
+	toInfo, ok := toConf.APIInfo()
+	c.Assert(ok, jc.IsTrue)
+	fromInfo.Addrs = toInfo.Addrs
+	apiState, err := api.Open(fromInfo, upgradeTestDialOpts)
 	if apiState != nil {
 		apiState.Close()
 	}


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/juju-core/+bug/1392814

If the is api address info missing from agent conf, we used to panic. Now just an error is returned.

(Review request: http://reviews.vapour.ws/r/2957/)