### PR TITLE
cmd/jujud/agent: rework uninstall-gating logic

### DIFF
--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -763,7 +763,7 @@ func (a *MachineAgent) postUpgradeAPIWorker(
 			NotifyMachineDead: func() error {
 				return writeUninstallAgentFile(agentConfig.DataDir())
 			},
-		}), nil
+		})
 	})
 	runner.StartWorker("reboot", func() (worker.Worker, error) {
 		reboot, err := st.Reboot()

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -478,14 +478,10 @@ func (a *MachineAgent) executeRebootOrShutdown(action params.RebootAction) error
 	// We need to reopen the API to clear the reboot flag after
 	// scheduling the reboot. It may be cleaner to do this in the reboot
 	// worker, before returning the ErrRebootMachine.
-	st, entity, err := apicaller.OpenAPIState(a)
+	st, _, err := apicaller.OpenAPIState(a)
 	if err != nil {
 		logger.Infof("Reboot: Error connecting to state")
 		return errors.Trace(err)
-	}
-	if entity.Life() == params.Dead {
-		logger.Errorf("agent terminating - entity %q is dead", entity.Tag())
-		return worker.ErrTerminateAgent
 	}
 
 	// block until all units/containers are ready, and reboot/shutdown
@@ -756,12 +752,14 @@ func (a *MachineAgent) postUpgradeAPIWorker(
 	}
 	runner.StartWorker("machiner", func() (worker.Worker, error) {
 		accessor := machiner.APIMachineAccessor{st.Machiner()}
-		return newMachiner(
-			accessor, agentConfig, ignoreMachineAddresses,
-			func() error {
+		return newMachiner(machiner.Config{
+			MachineAccessor: accessor,
+			Tag:             agentConfig.Tag().(names.MachineTag),
+			ClearMachineAddressesOnStart: ignoreMachineAddresses,
+			NotifyMachineDead: func() error {
 				return writeUninstallAgentFile(agentConfig.DataDir())
 			},
-		), nil
+		}), nil
 	})
 	runner.StartWorker("reboot", func() (worker.Worker, error) {
 		reboot, err := st.Reboot()

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -6,6 +6,7 @@ package agent
 import (
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -450,11 +451,7 @@ func (a *MachineAgent) Run(*cmd.Context) error {
 	a.runner.StartWorker("api", a.APIWorker)
 	a.runner.StartWorker("statestarter", a.newStateStarterWorker)
 	a.runner.StartWorker("termination", func() (worker.Worker, error) {
-		return startTerminationWorker(
-			agentConfig.DataDir(),
-			terminationworker.NewWorker,
-			os.Stat,
-		), nil
+		return terminationworker.NewWorker(), nil
 	})
 
 	// At this point, all workers will have been configured to start
@@ -475,44 +472,22 @@ func (a *MachineAgent) Run(*cmd.Context) error {
 	return err
 }
 
-// startTerminationWorker starts a new termination worker that will cause
-// the machine agent to uninstall if the uninstall-agent file is present.
-func startTerminationWorker(
-	dataDir string,
-	newTerminationWorker func(func() error) worker.Worker,
-	statFile func(string) (os.FileInfo, error),
-) worker.Worker {
-	uninstallFile := filepath.Join(dataDir, agent.UninstallAgentFile)
-	terminationError := func() error {
-		// If the uninstall file exists, then the termination
-		// signal should cause the agent to uninstall; otherwise
-		// it should just restart the workers.
-		if _, err := statFile(uninstallFile); err == nil {
-			return worker.ErrTerminateAgent
-		}
-		logger.Debugf(
-			"uninstall file %q does not exist",
-			uninstallFile,
-		)
-		return &cmdutil.FatalError{fmt.Sprintf(
-			"%q signal received",
-			terminationworker.TerminationSignal,
-		)}
-	}
-	return newTerminationWorker(terminationError)
-}
-
 func (a *MachineAgent) executeRebootOrShutdown(action params.RebootAction) error {
 	agentCfg := a.CurrentConfig()
 	// At this stage, all API connections would have been closed
 	// We need to reopen the API to clear the reboot flag after
 	// scheduling the reboot. It may be cleaner to do this in the reboot
 	// worker, before returning the ErrRebootMachine.
-	st, _, err := apicaller.OpenAPIState(a)
+	st, entity, err := apicaller.OpenAPIState(a)
 	if err != nil {
 		logger.Infof("Reboot: Error connecting to state")
 		return errors.Trace(err)
 	}
+	if entity.Life() == params.Dead {
+		logger.Errorf("agent terminating - entity %q is dead", entity.Tag())
+		return worker.ErrTerminateAgent
+	}
+
 	// block until all units/containers are ready, and reboot/shutdown
 	finalize, err := reboot.NewRebootWaiter(st, agentCfg)
 	if err != nil {
@@ -690,6 +665,14 @@ func (a *MachineAgent) APIWorker() (_ worker.Worker, err error) {
 	}()
 
 	agentConfig := a.CurrentConfig()
+	if entity.Life() == params.Dead {
+		logger.Errorf("agent terminating - entity %q is dead", entity.Tag())
+		if err := writeUninstallAgentFile(agentConfig.DataDir()); err != nil {
+			return nil, errors.Annotate(err, "writing uninstall agent file")
+		}
+		return nil, worker.ErrTerminateAgent
+	}
+
 	for _, job := range entity.Jobs() {
 		if job.NeedsState() {
 			info, err := st.Agent().StateServingInfo()
@@ -773,7 +756,12 @@ func (a *MachineAgent) postUpgradeAPIWorker(
 	}
 	runner.StartWorker("machiner", func() (worker.Worker, error) {
 		accessor := machiner.APIMachineAccessor{st.Machiner()}
-		return newMachiner(accessor, agentConfig, ignoreMachineAddresses), nil
+		return newMachiner(
+			accessor, agentConfig, ignoreMachineAddresses,
+			func() error {
+				return writeUninstallAgentFile(agentConfig.DataDir())
+			},
+		), nil
 	})
 	runner.StartWorker("reboot", func() (worker.Worker, error) {
 		reboot, err := st.Reboot()
@@ -1741,8 +1729,23 @@ func (a *MachineAgent) createJujuRun(dataDir string) error {
 	return symlink.New(jujud, JujuRun)
 }
 
+// writeUninstallAgentFile creates the uninstall-agent file on disk,
+// which will cause the agent to uninstall itself when it encounters
+// the ErrTerminateAgent error.
+func writeUninstallAgentFile(dataDir string) error {
+	uninstallFile := filepath.Join(dataDir, agent.UninstallAgentFile)
+	return ioutil.WriteFile(uninstallFile, nil, 0644)
+}
+
 func (a *MachineAgent) uninstallAgent(agentConfig agent.Config) error {
-	logger.Infof("machine agent uninstalling itself")
+	// We should only uninstall if the uninstall file is present.
+	uninstallFile := filepath.Join(agentConfig.DataDir(), agent.UninstallAgentFile)
+	if _, err := os.Stat(uninstallFile); err != nil {
+		logger.Debugf("uninstall file %q does not exist", uninstallFile)
+		return nil
+	}
+	logger.Infof("%q found, uninstalling agent", uninstallFile)
+
 	var errors []error
 	agentServiceName := agentConfig.Value(agent.AgentServiceName)
 	if agentServiceName == "" {

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -1856,7 +1856,7 @@ func (s *MachineSuite) TestMachineAgentNetworkerMode(c *gc.C) {
 func (s *MachineSuite) TestMachineAgentIgnoreAddresses(c *gc.C) {
 	for _, expectedIgnoreValue := range []bool{true, false} {
 		ignoreAddressCh := make(chan bool, 1)
-		s.AgentSuite.PatchValue(&newMachiner, func(cfg machiner.Config) worker.Worker {
+		s.AgentSuite.PatchValue(&newMachiner, func(cfg machiner.Config) (worker.Worker, error) {
 			select {
 			case ignoreAddressCh <- cfg.ClearMachineAddressesOnStart:
 			default:

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -1857,19 +1857,12 @@ func (s *MachineSuite) TestMachineAgentNetworkerMode(c *gc.C) {
 func (s *MachineSuite) TestMachineAgentIgnoreAddresses(c *gc.C) {
 	for _, expectedIgnoreValue := range []bool{true, false} {
 		ignoreAddressCh := make(chan bool, 1)
-		s.AgentSuite.PatchValue(&newMachiner, func(
-			accessor machiner.MachineAccessor,
-			conf agent.Config,
-			ignoreMachineAddresses bool,
-			machineDead func() error,
-		) worker.Worker {
+		s.AgentSuite.PatchValue(&newMachiner, func(cfg machiner.Config) worker.Worker {
 			select {
-			case ignoreAddressCh <- ignoreMachineAddresses:
+			case ignoreAddressCh <- cfg.ClearMachineAddressesOnStart:
 			default:
 			}
-			return machiner.NewMachiner(
-				accessor, conf, ignoreMachineAddresses, func() error { return nil },
-			)
+			return machiner.NewMachiner(cfg)
 		})
 
 		attrs := coretesting.Attrs{"ignore-machine-addresses": expectedIgnoreValue}

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -1286,11 +1286,10 @@ func (s *MachineSuite) runOpenAPISTateTest(c *gc.C, machine *state.Machine, conf
 		agent := NewAgentConf(conf.DataDir())
 		err := agent.ReadConfig(tagString)
 		c.Assert(err, jc.ErrorIsNil)
-		st, gotEntity, err := apicaller.OpenAPIState(agent)
+		st, err := apicaller.OpenAPIState(agent)
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(st, gc.NotNil)
 		st.Close()
-		c.Assert(gotEntity.Tag(), gc.Equals, tagString)
 	}
 	assertOpen()
 

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -392,13 +392,29 @@ func (s *MachineSuite) TestWithDeadMachine(c *gc.C) {
 }
 
 func (s *MachineSuite) TestWithRemovedMachine(c *gc.C) {
-	m, _, _ := s.primeAgent(c, state.JobHostUnits)
+	m, ac, _ := s.primeAgent(c, state.JobHostUnits)
 	err := m.EnsureDead()
 	c.Assert(err, jc.ErrorIsNil)
 	err = m.Remove()
 	c.Assert(err, jc.ErrorIsNil)
 	a := s.newAgent(c, m)
 	err = runWithTimeout(a)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Since the machine is removed from state, when
+	// the agent attempts to open the API connection
+	// it will receive an error stating that either
+	// the entity does not exist, or the agent is
+	// not authorised. Since we don't know which, we
+	// do not uninstall unless the uninstall-agent
+	// file is found (which we haven't written in
+	// this test).
+	//
+	// Since the machine agent is responsible for
+	// setting itself to Dead, this could only happen
+	// if it failed to write the uninstall-agent file,
+	// and then bounced.
+	_, err = os.Stat(ac.DataDir())
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -1845,12 +1861,15 @@ func (s *MachineSuite) TestMachineAgentIgnoreAddresses(c *gc.C) {
 			accessor machiner.MachineAccessor,
 			conf agent.Config,
 			ignoreMachineAddresses bool,
+			machineDead func() error,
 		) worker.Worker {
 			select {
 			case ignoreAddressCh <- ignoreMachineAddresses:
 			default:
 			}
-			return machiner.NewMachiner(accessor, conf, ignoreMachineAddresses)
+			return machiner.NewMachiner(
+				accessor, conf, ignoreMachineAddresses, func() error { return nil },
+			)
 		})
 
 		attrs := coretesting.Attrs{"ignore-machine-addresses": expectedIgnoreValue}
@@ -2267,37 +2286,6 @@ func (s *shouldWriteProxyFilesSuite) TestAll(c *gc.C) {
 		}
 		c.Check(shouldWriteProxyFiles(mockConf), gc.Equals, test.expect)
 	}
-}
-
-type machineAgentTerminationSuite struct {
-	coretesting.BaseSuite
-}
-
-var _ = gc.Suite(&machineAgentTerminationSuite{})
-
-func (*machineAgentTerminationSuite) TestStartTerminationWorker(c *gc.C) {
-	var stub gitjujutesting.Stub
-	statFile := func(path string) (os.FileInfo, error) {
-		stub.AddCall("Stat", path)
-		return nil, stub.NextErr()
-	}
-	var errorFunction func() error
-	newTerminationWorker := func(f func() error) worker.Worker {
-		errorFunction = f
-		return nil
-	}
-	startTerminationWorker("data-dir", newTerminationWorker, statFile)
-	c.Assert(errorFunction, gc.NotNil)
-
-	stub.SetErrors(os.ErrNotExist, nil)
-	errorResult := errorFunction()
-	c.Assert(errorResult, gc.FitsTypeOf, (*cmdutil.FatalError)(nil))
-	c.Assert(errorResult, gc.ErrorMatches, `"[aA]borted" signal received`)
-	stub.CheckCall(c, 0, "Stat", filepath.Join("data-dir", "uninstall-agent"))
-
-	// No error returned from Stat == uninstall-agent exists.
-	c.Assert(errorFunction(), gc.Equals, worker.ErrTerminateAgent)
-	stub.CheckCall(c, 1, "Stat", filepath.Join("data-dir", "uninstall-agent"))
 }
 
 type mockAgentConfig struct {

--- a/cmd/jujud/agent/unit_test.go
+++ b/cmd/jujud/agent/unit_test.go
@@ -313,15 +313,6 @@ func (s *UnitSuite) TestOpenAPIStateWithBadCredsTerminates(c *gc.C) {
 	c.Assert(err, gc.Equals, worker.ErrTerminateAgent)
 }
 
-func (s *UnitSuite) TestOpenAPIStateWithDeadEntityTerminates(c *gc.C) {
-	_, unit, conf, _ := s.primeAgent(c)
-	err := unit.EnsureDead()
-	c.Assert(err, jc.ErrorIsNil)
-
-	_, _, err = apicaller.OpenAPIState(fakeConfAgent{conf: conf})
-	c.Assert(err, gc.Equals, worker.ErrTerminateAgent)
-}
-
 type fakeConfAgent struct {
 	agent.Agent
 	conf agent.Config

--- a/cmd/jujud/agent/unit_test.go
+++ b/cmd/jujud/agent/unit_test.go
@@ -277,11 +277,10 @@ func (s *UnitSuite) TestOpenAPIState(c *gc.C) {
 		agent := NewAgentConf(conf.DataDir())
 		err := agent.ReadConfig(conf.Tag().String())
 		c.Assert(err, jc.ErrorIsNil)
-		st, gotEntity, err := apicaller.OpenAPIState(agent)
+		st, err := apicaller.OpenAPIState(agent)
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(st, gc.NotNil)
 		st.Close()
-		c.Assert(gotEntity.Tag(), gc.Equals, unit.Tag().String())
 	}
 	assertOpen()
 
@@ -309,7 +308,7 @@ func (s *UnitSuite) TestOpenAPIState(c *gc.C) {
 
 func (s *UnitSuite) TestOpenAPIStateWithBadCredsTerminates(c *gc.C) {
 	conf, _ := s.PrimeAgent(c, names.NewUnitTag("missing/0"), "no-password")
-	_, _, err := apicaller.OpenAPIState(fakeConfAgent{conf: conf})
+	_, err := apicaller.OpenAPIState(fakeConfAgent{conf: conf})
 	c.Assert(err, gc.Equals, worker.ErrTerminateAgent)
 }
 

--- a/worker/apicaller/open.go
+++ b/worker/apicaller/open.go
@@ -45,7 +45,7 @@ func OpenAPIState(a agent.Agent) (_ api.Connection, err error) {
 	agentConfig := a.CurrentConfig()
 	info, ok := agentConfig.APIInfo()
 	if !ok {
-		return nil, nil, errors.New("API info not available")
+		return nil, errors.New("API info not available")
 	}
 	st, usedOldPassword, err := openAPIStateUsingInfo(info, agentConfig.OldPassword())
 	if err != nil {

--- a/worker/apicaller/open.go
+++ b/worker/apicaller/open.go
@@ -41,7 +41,7 @@ func openAPIForAgent(info *api.Info, opts api.DialOpts) (api.Connection, error) 
 // OpenAPIState opens the API using the given information. The agent's
 // password is changed if the fallback password was used to connect to
 // the API.
-func OpenAPIState(a agent.Agent) (_ api.Connection, _ *apiagent.Entity, err error) {
+func OpenAPIState(a agent.Agent) (_ api.Connection, err error) {
 	agentConfig := a.CurrentConfig()
 	info, ok := agentConfig.APIInfo()
 	if !ok {
@@ -49,7 +49,7 @@ func OpenAPIState(a agent.Agent) (_ api.Connection, _ *apiagent.Entity, err erro
 	}
 	st, usedOldPassword, err := openAPIStateUsingInfo(info, agentConfig.OldPassword())
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 	defer func() {
 		// NOTE(fwereade): we may close and overwrite st below,
@@ -63,22 +63,23 @@ func OpenAPIState(a agent.Agent) (_ api.Connection, _ *apiagent.Entity, err erro
 
 	tag := agentConfig.Tag()
 	entity, err := st.Agent().Entity(tag)
-	if err == nil && entity.Life() == params.Dead {
-		return st, entity, nil
-	}
 	if params.IsCodeUnauthorized(err) {
 		logger.Errorf("agent terminating due to error returned during entity lookup: %v", err)
-		return nil, nil, worker.ErrTerminateAgent
+		return nil, worker.ErrTerminateAgent
+	} else if err != nil {
+		return nil, err
 	}
-	if err != nil {
-		return nil, nil, err
+
+	if entity.Life() == params.Dead {
+		// The entity is Dead, so the password cannot (and should not) be updated.
+		return st, nil
 	}
 
 	if !usedOldPassword {
 		// Call set password with the current password.  If we've recently
 		// become a state server, this will fix up our credentials in mongo.
 		if err := entity.SetPassword(info.Password); err != nil {
-			return nil, nil, errors.Annotate(err, "can't reset agent password")
+			return nil, errors.Annotate(err, "can't reset agent password")
 		}
 	} else {
 		// We succeeded in connecting with the fallback
@@ -87,11 +88,11 @@ func OpenAPIState(a agent.Agent) (_ api.Connection, _ *apiagent.Entity, err erro
 		logger.Debugf("replacing insecure password")
 		newPassword, err := utils.RandomPassword()
 		if err != nil {
-			return nil, nil, err
+			return nil, err
 		}
 		err = setAgentPassword(newPassword, info.Password, a, entity)
 		if err != nil {
-			return nil, nil, err
+			return nil, err
 		}
 
 		// Reconnect to the API with the new password.
@@ -105,11 +106,11 @@ func OpenAPIState(a agent.Agent) (_ api.Connection, _ *apiagent.Entity, err erro
 		// untested way.
 		st, err = apiOpen(info, api.DialOpts{})
 		if err != nil {
-			return nil, nil, err
+			return nil, err
 		}
 	}
 
-	return st, entity, nil
+	return st, nil
 }
 
 func setAgentPassword(newPw, oldPw string, a agent.Agent, entity *apiagent.Entity) error {

--- a/worker/apicaller/open.go
+++ b/worker/apicaller/open.go
@@ -64,8 +64,7 @@ func OpenAPIState(a agent.Agent) (_ api.Connection, _ *apiagent.Entity, err erro
 	tag := agentConfig.Tag()
 	entity, err := st.Agent().Entity(tag)
 	if err == nil && entity.Life() == params.Dead {
-		logger.Errorf("agent terminating - entity %q is dead", tag)
-		return nil, nil, worker.ErrTerminateAgent
+		return st, entity, nil
 	}
 	if params.IsCodeUnauthorized(err) {
 		logger.Errorf("agent terminating due to error returned during entity lookup: %v", err)

--- a/worker/apicaller/open_test.go
+++ b/worker/apicaller/open_test.go
@@ -49,7 +49,7 @@ func (s *OpenAPIStateSuite) TestOpenAPIStateReplaceErrors(c *gc.C) {
 	for i, test := range errReplacePairs {
 		c.Logf("test %d", i)
 		apiError = test.openErr
-		_, _, err := OpenAPIState(fakeAgent{})
+		_, err := OpenAPIState(fakeAgent{})
 		if test.replaceErr == nil {
 			c.Check(err, gc.Equals, test.openErr)
 		} else {
@@ -68,7 +68,7 @@ func (s *OpenAPIStateSuite) TestOpenAPIStateWaitsProvisioned(c *gc.C) {
 		}
 		return nil, &params.Error{Code: params.CodeNotProvisioned}
 	})
-	_, _, err := OpenAPIState(fakeAgent{})
+	_, err := OpenAPIState(fakeAgent{})
 	c.Assert(err, gc.Equals, worker.ErrTerminateAgent)
 	c.Assert(called, gc.Equals, checkProvisionedStrategy.Min-1)
 }
@@ -80,7 +80,7 @@ func (s *OpenAPIStateSuite) TestOpenAPIStateWaitsProvisionedGivesUp(c *gc.C) {
 		called++
 		return nil, &params.Error{Code: params.CodeNotProvisioned}
 	})
-	_, _, err := OpenAPIState(fakeAgent{})
+	_, err := OpenAPIState(fakeAgent{})
 	c.Assert(err, gc.Equals, worker.ErrTerminateAgent)
 	// +1 because we always attempt at least once outside the attempt strategy
 	// (twice if the API server initially returns CodeUnauthorized.)

--- a/worker/apicaller/worker.go
+++ b/worker/apicaller/worker.go
@@ -18,7 +18,7 @@ var logger = loggo.GetLogger("juju.worker.apicaller")
 // openConnection exists to be patched out in export_test.go (and let us test
 // this component without using a real API connection).
 var openConnection = func(a agent.Agent) (api.Connection, error) {
-	st, _, err := OpenAPIState(a)
+	st, err := OpenAPIState(a)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/worker/machiner/machiner.go
+++ b/worker/machiner/machiner.go
@@ -35,13 +35,21 @@ type Config struct {
 	NotifyMachineDead func() error
 }
 
+// Validate reports whether or not the configuration is valid.
+func (cfg *Config) Validate() error {
+	if cfg.MachineAccessor == nil {
+		return errors.NotValidf("unspecified MachineAccessor")
+	}
+	if cfg.Tag == (names.MachineTag{}) {
+		return errors.NotValidf("unspecified Tag")
+	}
+	return nil
+}
+
 // Machiner is responsible for a machine agent's lifecycle.
 type Machiner struct {
-	st                     MachineAccessor
-	tag                    names.MachineTag
-	machine                Machine
-	ignoreAddressesOnStart bool
-	machineDead            func() error
+	config  Config
+	machine Machine
 }
 
 // NewMachiner returns a Worker that will wait for the identified machine
@@ -50,19 +58,17 @@ type Machiner struct {
 //
 // The machineDead function will be called immediately after the machine's
 // lifecycle is updated to Dead.
-func NewMachiner(cfg Config) worker.Worker {
-	mr := &Machiner{
-		st:  cfg.MachineAccessor,
-		tag: cfg.Tag,
-		ignoreAddressesOnStart: cfg.ClearMachineAddressesOnStart,
-		machineDead:            cfg.NotifyMachineDead,
+func NewMachiner(cfg Config) (worker.Worker, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, errors.Annotate(err, "validating config")
 	}
-	return worker.NewNotifyWorker(mr)
+	mr := &Machiner{config: cfg}
+	return worker.NewNotifyWorker(mr), nil
 }
 
 func (mr *Machiner) SetUp() (watcher.NotifyWatcher, error) {
 	// Find which machine we're responsible for.
-	m, err := mr.st.Machine(mr.tag)
+	m, err := mr.config.MachineAccessor.Machine(mr.config.Tag)
 	if params.IsCodeNotFoundOrCodeUnauthorized(err) {
 		return nil, worker.ErrTerminateAgent
 	} else if err != nil {
@@ -70,23 +76,23 @@ func (mr *Machiner) SetUp() (watcher.NotifyWatcher, error) {
 	}
 	mr.machine = m
 
-	if mr.ignoreAddressesOnStart {
+	if mr.config.ClearMachineAddressesOnStart {
 		logger.Debugf("machine addresses ignored on start - resetting machine addresses")
 		if err := m.SetMachineAddresses(nil); err != nil {
 			return nil, errors.Annotate(err, "reseting machine addresses")
 		}
 	} else {
 		// Set the addresses in state to the host's addresses.
-		if err := setMachineAddresses(mr.tag, m); err != nil {
+		if err := setMachineAddresses(mr.config.Tag, m); err != nil {
 			return nil, errors.Annotate(err, "setting machine addresses")
 		}
 	}
 
 	// Mark the machine as started and log it.
 	if err := m.SetStatus(params.StatusStarted, "", nil); err != nil {
-		return nil, errors.Annotatef(err, "%s failed to set status started", mr.tag)
+		return nil, errors.Annotatef(err, "%s failed to set status started", mr.config.Tag)
 	}
-	logger.Infof("%q started", mr.tag)
+	logger.Infof("%q started", mr.config.Tag)
 
 	return m.Watch()
 }
@@ -129,6 +135,11 @@ func setMachineAddresses(tag names.MachineTag, m Machine) error {
 
 func (mr *Machiner) Handle(_ <-chan struct{}) error {
 	if err := mr.machine.Refresh(); params.IsCodeNotFoundOrCodeUnauthorized(err) {
+		// NOTE(axw) we can distinguish between NotFound and CodeUnauthorized,
+		// so we could call NotifyMachineDead here in case the agent failed to
+		// call NotifyMachineDead directly after setting the machine Dead in
+		// the first place. We're not doing that to be cautious: the machine
+		// could be missing from state due to invalid global state.
 		return worker.ErrTerminateAgent
 	} else if err != nil {
 		return err
@@ -137,9 +148,9 @@ func (mr *Machiner) Handle(_ <-chan struct{}) error {
 	if life == params.Alive {
 		return nil
 	}
-	logger.Debugf("%q is now %s", mr.tag, life)
+	logger.Debugf("%q is now %s", mr.config.Tag, life)
 	if err := mr.machine.SetStatus(params.StatusStopped, "", nil); err != nil {
-		return errors.Annotatef(err, "%s failed to set status stopped", mr.tag)
+		return errors.Annotatef(err, "%s failed to set status stopped", mr.config.Tag)
 	}
 
 	// Attempt to mark the machine Dead. If the machine still has units
@@ -155,14 +166,16 @@ func (mr *Machiner) Handle(_ <-chan struct{}) error {
 			logger.Tracef("machine still has storage attached")
 			return nil
 		}
-		return errors.Annotatef(err, "%s failed to set machine to dead", mr.tag)
+		return errors.Annotatef(err, "%s failed to set machine to dead", mr.config.Tag)
 	}
 	// Report on the machine's death. It is important that we do this after
 	// the machine is Dead, because this is the mechanism we use to clean up
 	// the machine (uninstall). If we were to report before marking the machine
 	// as Dead, then we would risk uninstalling prematurely.
-	if err := mr.machineDead(); err != nil {
-		return errors.Annotate(err, "reporting machine death")
+	if mr.config.NotifyMachineDead != nil {
+		if err := mr.config.NotifyMachineDead(); err != nil {
+			return errors.Annotate(err, "reporting machine death")
+		}
 	}
 	return worker.ErrTerminateAgent
 }

--- a/worker/terminationworker/worker_test.go
+++ b/worker/terminationworker/worker_test.go
@@ -4,7 +4,6 @@
 package terminationworker_test
 
 import (
-	"errors"
 	"os"
 	"os/signal"
 	"runtime"
@@ -14,6 +13,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/testing"
+	"github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/terminationworker"
 )
 
@@ -43,9 +43,7 @@ func (s *TerminationWorkerSuite) TearDownTest(c *gc.C) {
 }
 
 func (s *TerminationWorkerSuite) TestStartStop(c *gc.C) {
-	w := terminationworker.NewWorker(func() error {
-		return errors.New("anything")
-	})
+	w := terminationworker.NewWorker()
 	w.Kill()
 	err := w.Wait()
 	c.Assert(err, jc.ErrorIsNil)
@@ -56,14 +54,12 @@ func (s *TerminationWorkerSuite) TestSignal(c *gc.C) {
 	if runtime.GOOS == "windows" {
 		c.Skip("bug 1403084: sending this signal is not supported on windows")
 	}
-	w := terminationworker.NewWorker(func() error {
-		return errors.New("anything")
-	})
+	w := terminationworker.NewWorker()
 	proc, err := os.FindProcess(os.Getpid())
 	c.Assert(err, jc.ErrorIsNil)
 	defer proc.Release()
 	err = proc.Signal(terminationworker.TerminationSignal)
 	c.Assert(err, jc.ErrorIsNil)
 	err = w.Wait()
-	c.Assert(err, gc.ErrorMatches, "anything")
+	c.Assert(err, gc.Equals, worker.ErrTerminateAgent)
 }


### PR DESCRIPTION
The fix for https://bugs.launchpad.net/juju-core/+bug/1464304
was too narrowly focused on the SIGABRT trigger, and so this
commit changes how we gate uninstall.

The termination worker was doing the uninstall-agent file
check, but it really belongs at the top level of the machine
agent, because we attempt to uninstall whenever the agent gets
an ErrTerminateAgent. This can happen in various ways, such
as SIGABRT, or just because the agent made an bad authorization
attempt when opening the API connection. So we move the check
to the top level, and undo the checking in the termination worker.

For this to work and still uninstall when the machine is destroyed,
we must make deeper changes:
 - the machiner worker must inform the agent code when it has
   set the machine to Dead. Immediately after the machine is set
   to Dead, we write out the uninstall-agent file so the ensuing
   ErrTerminateAgent will cause an uninstall
 - if the machine is Dead in state when the agent connects, we
   also want to write out the uninstall-agent file. This means
   changing worker/apicaller to not error on Dead entities, but
   leave that up to the caller

There is a test removed from the unit agent which was really in
the wrong place (it was calling worker/apicaller code directly,
and asserting on its results). More importantly, this behaviour
has changed; we now rely on the worker/uniter code to return
ErrTerminateAgent when it encounters the Dead unit entity.

Fixes https://bugs.launchpad.net/juju-core/+bug/1444912

(Review request: http://reviews.vapour.ws/r/2958/)