### PR TITLE
lp1508585: Add wily as ubuntuSeries

### DIFF
--- a/version/supportedseries.go
+++ b/version/supportedseries.go
@@ -111,6 +111,7 @@ var ubuntuSeries = map[string]string{
 	"trusty":  "14.04",
 	"utopic":  "14.10",
 	"vivid":   "15.04",
+	"wily":    "15.10",
 }
 
 // Windows versions come in various flavors:

--- a/version/supportedseries_windows_test.go
+++ b/version/supportedseries_windows_test.go
@@ -42,6 +42,7 @@ func (s *supportedSeriesWindowsSuite) TestSupportedSeries(c *gc.C) {
 		"trusty",
 		"utopic",
 		"vivid",
+		"wily",
 		"win10",
 		"win2012",
 		"win2012hv",


### PR DESCRIPTION
This also fixes the failing test:
supportedSeriesWindowsSuite.TestSupportedSeries

(Review request: http://reviews.vapour.ws/r/2965/)