### PR TITLE
Update dependency to use new juju/cmd revision

### DIFF
--- a/cmd/jujud/main.go
+++ b/cmd/jujud/main.go
@@ -135,7 +135,11 @@ func jujuDMain(args []string, ctx *cmd.Context) (code int, err error) {
 		Name: "jujud",
 		Doc:  jujudDoc,
 	})
-	jujud.Log.Factory = &writerFactory{}
+
+	jujud.Log.NewWriter = func(target io.Writer) loggo.Writer {
+		return &jujudWriter{target: target}
+	}
+
 	jujud.Register(NewBootstrapCommand())
 
 	// TODO(katco-): AgentConf type is doing too much. The
@@ -195,19 +199,11 @@ func Main(args []string) int {
 	return code
 }
 
-type writerFactory struct{}
-
-func (*writerFactory) NewWriter(target io.Writer) loggo.Writer {
-	return &jujudWriter{target: target}
-}
-
 type jujudWriter struct {
 	target           io.Writer
 	unitFormatter    simpleFormatter
 	defaultFormatter loggo.DefaultFormatter
 }
-
-var _ loggo.Writer = (*jujudWriter)(nil)
 
 func (w *jujudWriter) Write(level loggo.Level, module, filename string, line int, timestamp time.Time, message string) {
 	if strings.HasPrefix(module, "unit.") {

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -10,7 +10,7 @@ github.com/joyent/gomanta	git	cabd97b029d931836571f00b7e48c331809a30b7	2014-05-2
 github.com/joyent/gosdc	git	2f11feadd2d9891e92296a1077c3e2e56939547d	2014-05-24T00:08:15Z
 github.com/joyent/gosign	git	0da0d5f1342065321c97812b1f4ac0c2b0bab56c	2014-05-24T00:07:34Z
 github.com/juju/blobstore	git	337aa7d5d712728d181dbda2547a6556d4189626	2015-05-08T07:43:36Z
-github.com/juju/cmd	git	4a5e8abce36462f89d92d28bd69b54c7845db818	2015-08-20T13:46:44Z
+github.com/juju/cmd	git	081dd27e371031b13c297d4016d7ef7b0d4fefa4	2015-10-20T04:25:17Z
 github.com/juju/deputy	git	63a2b10f43a34dca15080bfc7e21b712989562a9	2015-06-26T10:38:40Z
 github.com/juju/errors	git	4567a5e69fd3130ca0d89f69478e7ac025b67452	2015-03-27T19:24:31Z
 github.com/juju/gojsonpointer	git	afe8b77aa08f272b49e01b82de78510c11f61500	2015-02-04T19:46:29Z


### PR DESCRIPTION
We need to use an updated juju/cmd revision to pick up a fix for:

https://bugs.launchpad.net/juju-core/+bug/1302118

We also need to tweak the logging setup in jujud/main to account for changes to juju/cmd.

(Review request: http://reviews.vapour.ws/r/2967/)