### PR TITLE
Merge pull request #3560 from wallyworld/missing-address-panic-1.25

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -220,8 +220,9 @@ type Config interface {
 	// are available
 	StateServingInfo() (params.StateServingInfo, bool)
 
-	// APIInfo returns details for connecting to the API server.
-	APIInfo() *api.Info
+	// APIInfo returns details for connecting to the API server and
+	// reports whether the details are available.
+	APIInfo() (*api.Info, bool)
 
 	// MongoInfo returns details for connecting to the state server's mongo
 	// database and reports whether those details are available
@@ -750,6 +751,7 @@ func (c *configInternal) fileContents() ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
+// WriteCommands is defined on Config interface.
 func (c *configInternal) WriteCommands(renderer shell.Renderer) ([]string, error) {
 	data, err := c.fileContents()
 	if err != nil {
@@ -762,7 +764,11 @@ func (c *configInternal) WriteCommands(renderer shell.Renderer) ([]string, error
 	return commands, nil
 }
 
-func (c *configInternal) APIInfo() *api.Info {
+// APIInfo is defined on Config interface.
+func (c *configInternal) APIInfo() (*api.Info, bool) {
+	if c.apiDetails == nil || c.apiDetails.addresses == nil {
+		return nil, false
+	}
 	servingInfo, isStateServer := c.StateServingInfo()
 	addrs := c.apiDetails.addresses
 	if isStateServer {
@@ -789,9 +795,10 @@ func (c *configInternal) APIInfo() *api.Info {
 		Tag:        c.tag,
 		Nonce:      c.nonce,
 		EnvironTag: c.environment,
-	}
+	}, true
 }
 
+// MongoInfo is defined on Config interface.
 func (c *configInternal) MongoInfo() (info *mongo.MongoInfo, ok bool) {
 	ssi, ok := c.StateServingInfo()
 	if !ok {

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -584,12 +584,19 @@ func (*suite) TestWriteAndRead(c *gc.C) {
 	c.Assert(reread, jc.DeepEquals, conf)
 }
 
+func (*suite) TestAPIInfoMissingAddress(c *gc.C) {
+	conf := agent.EmptyConfig()
+	_, ok := conf.APIInfo()
+	c.Assert(ok, jc.IsFalse)
+}
+
 func (*suite) TestAPIInfoAddsLocalhostWhenServingInfoPresent(c *gc.C) {
 	attrParams := attributeParams
 	servingInfo := stateServingInfo()
 	conf, err := agent.NewStateMachineConfig(attrParams, servingInfo)
 	c.Assert(err, jc.ErrorIsNil)
-	apiinfo := conf.APIInfo()
+	apiinfo, ok := conf.APIInfo()
+	c.Assert(ok, jc.IsTrue)
 	c.Check(apiinfo.Addrs, gc.HasLen, len(attrParams.APIAddresses)+1)
 	localhostAddressFound := false
 	for _, eachApiAddress := range apiinfo.Addrs {
@@ -607,7 +614,8 @@ func (*suite) TestAPIInfoAddsLocalhostWhenServingInfoPresentAndPreferIPv6On(c *g
 	servingInfo := stateServingInfo()
 	conf, err := agent.NewStateMachineConfig(attrParams, servingInfo)
 	c.Assert(err, jc.ErrorIsNil)
-	apiinfo := conf.APIInfo()
+	apiinfo, ok := conf.APIInfo()
+	c.Assert(ok, jc.IsTrue)
 	c.Check(apiinfo.Addrs, gc.HasLen, len(attrParams.APIAddresses)+1)
 	localhostAddressFound := false
 	for _, eachApiAddress := range apiinfo.Addrs {
@@ -643,7 +651,8 @@ func (*suite) TestAPIInfoDoesntAddLocalhostWhenNoServingInfoPreferIPv6Off(c *gc.
 	attrParams.PreferIPv6 = false
 	conf, err := agent.NewAgentConfig(attrParams)
 	c.Assert(err, jc.ErrorIsNil)
-	apiinfo := conf.APIInfo()
+	apiinfo, ok := conf.APIInfo()
+	c.Assert(ok, jc.IsTrue)
 	c.Assert(apiinfo.Addrs, gc.DeepEquals, attrParams.APIAddresses)
 }
 
@@ -652,7 +661,8 @@ func (*suite) TestAPIInfoDoesntAddLocalhostWhenNoServingInfoPreferIPv6On(c *gc.C
 	attrParams.PreferIPv6 = true
 	conf, err := agent.NewAgentConfig(attrParams)
 	c.Assert(err, jc.ErrorIsNil)
-	apiinfo := conf.APIInfo()
+	apiinfo, ok := conf.APIInfo()
+	c.Assert(ok, jc.IsTrue)
 	c.Assert(apiinfo.Addrs, gc.DeepEquals, attrParams.APIAddresses)
 }
 
@@ -671,7 +681,9 @@ func (*suite) TestSetPassword(c *gc.C) {
 		Nonce:      attrParams.Nonce,
 		EnvironTag: attrParams.Environment,
 	}
-	c.Assert(conf.APIInfo(), jc.DeepEquals, expectAPIInfo)
+	apiInfo, ok := conf.APIInfo()
+	c.Assert(ok, jc.IsTrue)
+	c.Assert(apiInfo, jc.DeepEquals, expectAPIInfo)
 	addr := fmt.Sprintf("127.0.0.1:%d", servingInfo.StatePort)
 	expectStateInfo := &mongo.MongoInfo{
 		Info: mongo.Info{
@@ -690,7 +702,9 @@ func (*suite) TestSetPassword(c *gc.C) {
 	expectAPIInfo.Password = "newpassword"
 	expectStateInfo.Password = "newpassword"
 
-	c.Assert(conf.APIInfo(), jc.DeepEquals, expectAPIInfo)
+	apiInfo, ok = conf.APIInfo()
+	c.Assert(ok, jc.IsTrue)
+	c.Assert(apiInfo, jc.DeepEquals, expectAPIInfo)
 	info, ok = conf.MongoInfo()
 	c.Assert(ok, jc.IsTrue)
 	c.Assert(info, jc.DeepEquals, expectStateInfo)

--- a/agent/export_test.go
+++ b/agent/export_test.go
@@ -59,3 +59,7 @@ var (
 	MachineJobFromParams = machineJobFromParams
 	IsLocalEnv           = &isLocalEnv
 )
+
+func EmptyConfig() Config {
+	return &configInternal{}
+}

--- a/agent/format-1.18_whitebox_test.go
+++ b/agent/format-1.18_whitebox_test.go
@@ -53,7 +53,9 @@ func (s *format_1_18Suite) TestMissingAttributes(c *gc.C) {
 	c.Assert(configDataDir, gc.Equals, realDataDir)
 	c.Assert(readConfig.PreferIPv6(), jc.IsFalse)
 	// The api info doesn't have the environment tag set.
-	c.Assert(readConfig.APIInfo().EnvironTag.Id(), gc.Equals, "")
+	apiInfo, ok := readConfig.APIInfo()
+	c.Assert(ok, jc.IsTrue)
+	c.Assert(apiInfo.EnvironTag.Id(), gc.Equals, "")
 }
 
 func (s *format_1_18Suite) TestStatePortNotParsedWithoutSecret(c *gc.C) {

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -1161,7 +1161,10 @@ func (a *MachineAgent) startEnvWorkers(
 
 	// Establish API connection for this environment.
 	agentConfig := a.CurrentConfig()
-	apiInfo := agentConfig.APIInfo()
+	apiInfo, ok := agentConfig.APIInfo()
+	if !ok {
+		return nil, errors.New("API info not available")
+	}
 	apiInfo.EnvironTag = st.EnvironTag()
 	apiSt, err := apicaller.OpenAPIStateUsingInfo(apiInfo, agentConfig.OldPassword())
 	if err != nil {

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -1031,7 +1031,9 @@ func (s *MachineSuite) assertAgentOpensState(
 
 func (s *MachineSuite) TestManageEnvironServesAPI(c *gc.C) {
 	s.assertJobWithState(c, state.JobManageEnviron, func(conf agent.Config, agentState *state.State) {
-		st, err := api.Open(conf.APIInfo(), fastDialOpts)
+		apiInfo, ok := conf.APIInfo()
+		c.Assert(ok, jc.IsTrue)
+		st, err := api.Open(apiInfo, fastDialOpts)
 		c.Assert(err, jc.ErrorIsNil)
 		defer st.Close()
 		m, err := st.Machiner().Machine(conf.Tag().(names.MachineTag))
@@ -1280,7 +1282,9 @@ func (s *MachineSuite) runOpenAPISTateTest(c *gc.C, machine *state.Machine, conf
 	// Read the configuration and check that we can connect with it.
 	confR, err := agent.ReadConfig(configPath)
 	c.Assert(err, gc.IsNil)
-	newPassword := confR.APIInfo().Password
+	apiInfo, ok := confR.APIInfo()
+	c.Assert(ok, jc.IsTrue)
+	newPassword := apiInfo.Password
 	assertPassword(newPassword, true)
 
 	// Double-check that we can open a fresh connection with the stored

--- a/cmd/jujud/agent/unit_test.go
+++ b/cmd/jujud/agent/unit_test.go
@@ -286,7 +286,9 @@ func (s *UnitSuite) TestOpenAPIState(c *gc.C) {
 	// Read the stored password and check it's valid.
 	confR, err := agent.ReadConfig(configPath)
 	c.Assert(err, gc.IsNil)
-	newPassword := confR.APIInfo().Password
+	apiInfo, ok := confR.APIInfo()
+	c.Assert(ok, jc.IsTrue)
+	newPassword := apiInfo.Password
 	assertPassword(newPassword, true)
 
 	// Double-check that we can open a fresh connection with the stored

--- a/cmd/jujud/agent/upgrade_test.go
+++ b/cmd/jujud/agent/upgrade_test.go
@@ -906,7 +906,8 @@ func (s *UpgradeSuite) checkLoginToAPIAsUser(c *gc.C, conf agent.Config, expectF
 }
 
 func (s *UpgradeSuite) attemptRestrictedAPIAsUser(c *gc.C, conf agent.Config) error {
-	info := conf.APIInfo()
+	info, ok := conf.APIInfo()
+	c.Assert(ok, jc.IsTrue)
 	info.Tag = s.AdminUserTag(c)
 	info.Password = "dummy-secret"
 	info.Nonce = ""
@@ -925,9 +926,12 @@ func (s *UpgradeSuite) attemptRestrictedAPIAsUser(c *gc.C, conf agent.Config) er
 }
 
 func canLoginToAPIAsMachine(c *gc.C, fromConf, toConf agent.Config) bool {
-	info := fromConf.APIInfo()
-	info.Addrs = toConf.APIInfo().Addrs
-	apiState, err := api.Open(info, upgradeTestDialOpts)
+	fromInfo, ok := fromConf.APIInfo()
+	c.Assert(ok, jc.IsTrue)
+	toInfo, ok := toConf.APIInfo()
+	c.Assert(ok, jc.IsTrue)
+	fromInfo.Addrs = toInfo.Addrs
+	apiState, err := api.Open(fromInfo, upgradeTestDialOpts)
 	if apiState != nil {
 		apiState.Close()
 	}

--- a/worker/apicaller/open.go
+++ b/worker/apicaller/open.go
@@ -43,7 +43,10 @@ func openAPIForAgent(info *api.Info, opts api.DialOpts) (api.Connection, error) 
 // the API.
 func OpenAPIState(a agent.Agent) (_ api.Connection, _ *apiagent.Entity, err error) {
 	agentConfig := a.CurrentConfig()
-	info := agentConfig.APIInfo()
+	info, ok := agentConfig.APIInfo()
+	if !ok {
+		return nil, nil, errors.New("API info not available")
+	}
 	st, usedOldPassword, err := openAPIStateUsingInfo(info, agentConfig.OldPassword())
 	if err != nil {
 		return nil, nil, err

--- a/worker/apicaller/open_test.go
+++ b/worker/apicaller/open_test.go
@@ -99,6 +99,6 @@ type fakeAPIOpenConfig struct {
 	agent.Config
 }
 
-func (fakeAPIOpenConfig) APIInfo() *api.Info              { return &api.Info{} }
+func (fakeAPIOpenConfig) APIInfo() (*api.Info, bool)      { return &api.Info{}, true }
 func (fakeAPIOpenConfig) OldPassword() string             { return "old" }
 func (fakeAPIOpenConfig) Jobs() []multiwatcher.MachineJob { return []multiwatcher.MachineJob{} }

--- a/worker/logsender/worker.go
+++ b/worker/logsender/worker.go
@@ -37,7 +37,10 @@ func New(logs LogRecordCh, apiInfoGate gate.Waiter, agent agent.Agent) worker.Wo
 		}
 
 		logger.Debugf("dialing log-sender connection")
-		apiInfo := agent.CurrentConfig().APIInfo()
+		apiInfo, ok := agent.CurrentConfig().APIInfo()
+		if !ok {
+			return errors.New("API info not available")
+		}
 		conn, err := dialLogsinkAPI(apiInfo)
 		if err != nil {
 			return errors.Annotate(err, "logsender dial failed")

--- a/worker/logsender/worker_test.go
+++ b/worker/logsender/worker_test.go
@@ -200,8 +200,8 @@ func (a *mockAgent) CurrentConfig() agent.Config {
 	return a
 }
 
-func (a *mockAgent) APIInfo() *api.Info {
-	return a.apiInfo
+func (a *mockAgent) APIInfo() (*api.Info, bool) {
+	return a.apiInfo, true
 }
 
 type lockedGate struct{}


### PR DESCRIPTION
Merge pull request #3557 from wallyworld/missing-address-panic

Do not panic if api address info is missing from agent conf

Fixes: https://bugs.launchpad.net/juju-core/+bug/1392814

If the is api address info missing from agent conf, we used to panic. Now just an error is returned.

(Review request: http://reviews.vapour.ws/r/2957/)

(Review request: http://reviews.vapour.ws/r/2960/)

(Review request: http://reviews.vapour.ws/r/2968/)