### PR TITLE
Enable $(JUJU_HOME)/aliases

### DIFF
--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -76,9 +76,10 @@ func Main(args []string) {
 
 func NewJujuCommand(ctx *cmd.Context) cmd.Command {
 	jcmd := jujucmd.NewSuperCommand(cmd.SuperCommandParams{
-		Name:            "juju",
-		Doc:             jujuDoc,
-		MissingCallback: RunPlugin,
+		Name:                "juju",
+		Doc:                 jujuDoc,
+		MissingCallback:     RunPlugin,
+		UserAliasesFilename: osenv.JujuHomePath("aliases"),
 	})
 	jcmd.AddHelpTopic("basics", "Basic commands", helptopics.Basics)
 	jcmd.AddHelpTopic("local-provider", "How to configure a local (LXC) provider",

--- a/cmd/supercommand.go
+++ b/cmd/supercommand.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/juju/cmd"
@@ -11,10 +12,12 @@ import (
 )
 
 func init() {
-	// Ignore any parse errors that the configuration may have.
-	// This is a developer feature, and if it isn't working, then it
-	// is probably due to the configuration being wrong.
-	loggo.ConfigureLoggers(os.Getenv(osenv.JujuStartupLoggingConfigEnvKey))
+	// If the environment key is empty, ConfigureLoggers returns nil and does
+	// nothing.
+	err := loggo.ConfigureLoggers(os.Getenv(osenv.JujuStartupLoggingConfigEnvKey))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR parsing %s: %s\n\n", osenv.JujuStartupLoggingConfigEnvKey, err)
+	}
 }
 
 var logger = loggo.GetLogger("juju.cmd")

--- a/cmd/supercommand.go
+++ b/cmd/supercommand.go
@@ -10,6 +10,13 @@ import (
 	"github.com/juju/juju/version"
 )
 
+func init() {
+	// Ignore any parse errors that the configuration may have.
+	// This is a developer feature, and if it isn't working, then it
+	// is probably due to the configuration being wrong.
+	loggo.ConfigureLoggers(os.Getenv(osenv.JujuStartupLoggingConfigEnvKey))
+}
+
 var logger = loggo.GetLogger("juju.cmd")
 
 // NewSuperCommand is like cmd.NewSuperCommand but

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -10,7 +10,7 @@ github.com/joyent/gomanta	git	cabd97b029d931836571f00b7e48c331809a30b7	2014-05-2
 github.com/joyent/gosdc	git	2f11feadd2d9891e92296a1077c3e2e56939547d	2014-05-24T00:08:15Z
 github.com/joyent/gosign	git	0da0d5f1342065321c97812b1f4ac0c2b0bab56c	2014-05-24T00:07:34Z
 github.com/juju/blobstore	git	337aa7d5d712728d181dbda2547a6556d4189626	2015-05-08T07:43:36Z
-github.com/juju/cmd	git	6374a642ca4eb05707d69104b9aef9662155a29a	2015-10-21T01:51:04Z
+github.com/juju/cmd	git	b1413672b3bcc049754fe66e9d21633c5071c86a	2015-10-22T20:49:08Z
 github.com/juju/errors	git	4567a5e69fd3130ca0d89f69478e7ac025b67452	2015-03-27T19:24:31Z
 github.com/juju/gojsonpointer	git	afe8b77aa08f272b49e01b82de78510c11f61500	2015-02-04T19:46:29Z
 github.com/juju/gojsonreference	git	f0d24ac5ee330baa21721cdff56d45e4ee42628e	2015-02-04T19:46:33Z

--- a/juju/osenv/vars.go
+++ b/juju/osenv/vars.go
@@ -17,6 +17,11 @@ const (
 	JujuLoggingConfigEnvKey = "JUJU_LOGGING_CONFIG"
 	JujuFeatureFlagEnvKey   = "JUJU_DEV_FEATURE_FLAGS"
 
+	// JujuStartupLoggingConfigEnvKey if set is used to configure the initial
+	// logging before the command objects are even created to allow debugging
+	// of the command creation and initialisation process.
+	JujuStartupLoggingConfigEnvKey = "JUJU_STARTUP_LOGGING_CONFIG"
+
 	// Registry key containing juju related information
 	JujuRegistryKey = `HKLM:\SOFTWARE\juju-core`
 


### PR DESCRIPTION
This branch also adds a development feature to configure the logging config at an earlier state to aid developers in the debugging of command initialisation.

(Review request: http://reviews.vapour.ws/r/2971/)