### PR TITLE
Merge pull request #3572 from wallyworld/logged-apiaddresses

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -591,6 +591,7 @@ func (c *configInternal) SetAPIHostPorts(servers [][]network.HostPort) {
 		addrs = append(addrs, network.SelectInternalHostPorts(serverHostPorts, false)...)
 	}
 	c.apiDetails.addresses = addrs
+	logger.Infof("API server address details %q written to agent config as %q", servers, addrs)
 }
 
 func (c *configInternal) SetValue(key, value string) {

--- a/worker/apiaddressupdater/apiaddressupdater.go
+++ b/worker/apiaddressupdater/apiaddressupdater.go
@@ -75,7 +75,6 @@ func (c *APIAddressUpdater) Handle(_ <-chan struct{}) error {
 	if err := c.setter.SetAPIHostPorts(hpsToSet); err != nil {
 		return fmt.Errorf("error setting addresses: %v", err)
 	}
-	logger.Infof("API addresses updated to %q", hpsToSet)
 	return nil
 }
 


### PR DESCRIPTION
Log what api addresses were actually updated to agent config

Fixes: https://bugs.launchpad.net/juju-core/+bug/1497098

Log the ingoing and resulting addresses which are written to agent conf.

(Review request: http://reviews.vapour.ws/r/2972/)

(Review request: http://reviews.vapour.ws/r/2973/)