### PR TITLE
lp1509032 - Fix juju to allow 1.25.0

### DIFF
--- a/cmd/juju/status/status_test.go
+++ b/cmd/juju/status/status_test.go
@@ -34,13 +34,11 @@ import (
 	"github.com/juju/juju/version"
 )
 
-func defineNextVersion() version.Number {
+func nextVersion() version.Number {
 	ver := version.Current.Number
 	ver.Patch++
 	return ver
 }
-
-var nextVersion = defineNextVersion()
 
 func runStatus(c *gc.C, args ...string) (code int, stdout, stderr []byte) {
 	ctx := coretesting.Context(c)
@@ -2307,7 +2305,7 @@ var statusTests = []testCase{
 			M{
 				"environment": "dummyenv",
 				"environment-status": M{
-					"upgrade-available": nextVersion.String(),
+					"upgrade-available": nextVersion().String(),
 				},
 				"machines": M{},
 				"services": M{},
@@ -2821,7 +2819,7 @@ type setToolsUpgradeAvailable struct{}
 func (ua setToolsUpgradeAvailable) step(c *gc.C, ctx *context) {
 	env, err := ctx.st.Environment()
 	c.Assert(err, jc.ErrorIsNil)
-	err = env.UpdateLatestToolsVersion(nextVersion)
+	err = env.UpdateLatestToolsVersion(nextVersion())
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -3205,7 +3203,7 @@ func (s *StatusSuite) testStatusWithFormatTabular(c *gc.C, useFeatureFlag bool) 
 	const expected = `
 [Environment]     
 UPGRADE-AVAILABLE 
-%s        
+%s            
 
 [Services] 
 NAME       STATUS      EXPOSED CHARM                  
@@ -3227,15 +3225,17 @@ ID         STATE   VERSION DNS            INS-ID     SERIES  HARDWARE
 2          started         dummyenv-2.dns dummyenv-2 quantal arch=amd64 cpu-cores=1 mem=1024M root-disk=8192M 
 
 `
-	c.Assert(string(stdout), gc.Equals, fmt.Sprintf(expected[1:], nextVersion))
+	c.Assert(string(stdout), gc.Equals, fmt.Sprintf(expected[1:], nextVersion()))
 }
 
 func (s *StatusSuite) TestStatusV2(c *gc.C) {
+	s.PatchValue(&version.Current, version.MustParseBinary("1.25.0-trusty-amd64"))
 	s.PatchEnvironment(osenv.JujuCLIVersion, "2")
 	s.testStatusWithFormatTabular(c, true)
 }
 
 func (s *StatusSuite) TestStatusWithFormatTabular(c *gc.C) {
+	s.PatchValue(&version.Current, version.MustParseBinary("1.25.0-trusty-amd64"))
 	s.testStatusWithFormatTabular(c, false)
 }
 

--- a/scripts/win-installer/setup.iss
+++ b/scripts/win-installer/setup.iss
@@ -2,7 +2,7 @@
 ; SEE THE DOCUMENTATION FOR DETAILS ON CREATING INNO SETUP SCRIPT FILES!
 
 #define MyAppName "Juju"
-#define MyAppVersion "1.25-beta2"
+#define MyAppVersion "1.25.0"
 #define MyAppPublisher "Canonical, Ltd"
 #define MyAppURL "http://juju.ubuntu.com/"
 #define MyAppExeName "juju.exe"

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -3696,15 +3696,14 @@ func (s *StateSuite) TestSetEnvironAgentVersionSucceedsWithSameVersion(c *gc.C) 
 }
 
 func (s *StateSuite) TestSetEnvironAgentVersionOnOtherEnviron(c *gc.C) {
+	s.PatchValue(&version.Current, version.MustParseBinary("1.24.7-trusty-amd64"))
 	otherSt := s.Factory.MakeEnvironment(c, nil)
 	defer otherSt.Close()
 
-	higher := version.Current
-	higher.Patch++
-	lower := version.Current
-	lower.Patch--
+	higher := version.MustParseBinary("1.25.0-trusty-amd64")
+	lower := version.MustParseBinary("1.24.6-trusty-amd64")
 
-	// Set other environ version to < server envrion version
+	// Set other environ version to < server environ version
 	err := otherSt.SetEnvironAgentVersion(lower.Number)
 	c.Assert(err, jc.ErrorIsNil)
 	assertAgentVersion(c, otherSt, lower.Number.String())

--- a/version/version.go
+++ b/version/version.go
@@ -24,7 +24,7 @@ import (
 // The presence and format of this constant is very important.
 // The debian/rules build recipe uses this value for the version
 // number of the release package.
-const version = "1.25-beta2"
+const version = "1.25.0"
 
 // The version that we switched over from old style numbering to new style.
 var switchOverVersion = MustParse("1.19.9")


### PR DESCRIPTION
This patch:
- Increments juju to 1.25.0
- Fixes the failing test in state:
  TestSetEnvironAgentVersionOnOtherEnviron
- Fixes failing status tests and changes nextVersion
  to be evaluated during test runs to allow patching
  of version.Current.  This prevents the tests from
  failing if the length of the current version changes
  again.

(Review request: http://reviews.vapour.ws/r/2977/)