### PR TITLE
Fetch region relevant metadata only.

### DIFF
--- a/apiserver/imagemetadata/metadata.go
+++ b/apiserver/imagemetadata/metadata.go
@@ -174,7 +174,6 @@ func (api *API) retrievePublished() (*simplestreams.ResolveInfo, []*envmetadata.
 	// We want all metadata.
 	cons := envmetadata.NewImageConstraint(simplestreams.LookupParams{})
 	if inst, ok := env.(simplestreams.HasRegion); !ok {
-		// All environments that are cloud agnostic, do not rely on simplestreams anyway.
 		return nil, nil, errors.Errorf("environment cloud specification cannot be determined")
 	} else {
 		// If we can determine current region,

--- a/apiserver/imagemetadata/metadata.go
+++ b/apiserver/imagemetadata/metadata.go
@@ -173,12 +173,15 @@ func (api *API) retrievePublished() (*simplestreams.ResolveInfo, []*envmetadata.
 
 	// We want all metadata.
 	cons := envmetadata.NewImageConstraint(simplestreams.LookupParams{})
-	if inst, ok := env.(simplestreams.HasRegion); ok {
+	if inst, ok := env.(simplestreams.HasRegion); !ok {
+		// All environments that are cloud agnostic, do not rely on simplestreams anyway.
+		return nil, nil, errors.Errorf("environment cloud specification cannot be determined")
+	} else {
 		// If we can determine current region,
 		// we want only metadata specific to this region.
 		cloud, err := inst.Region()
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		cons.CloudSpec = cloud
 	}

--- a/apiserver/imagemetadata/metadata.go
+++ b/apiserver/imagemetadata/metadata.go
@@ -173,6 +173,16 @@ func (api *API) retrievePublished() (*simplestreams.ResolveInfo, []*envmetadata.
 
 	// We want all metadata.
 	cons := envmetadata.NewImageConstraint(simplestreams.LookupParams{})
+	if inst, ok := env.(simplestreams.HasRegion); ok {
+		// If we can determine current region,
+		// we want only metadata specific to this region.
+		cloud, err := inst.Region()
+		if err != nil {
+			return nil, err
+		}
+		cons.CloudSpec = cloud
+	}
+
 	metadata, info, err := envmetadata.Fetch(sources, cons, false)
 	if err != nil {
 		return nil, nil, err

--- a/apiserver/imagemetadata/updatefrompublished_test.go
+++ b/apiserver/imagemetadata/updatefrompublished_test.go
@@ -48,8 +48,8 @@ var testImagesData = map[string]string{
 		   "updated": "Wed, 01 May 2013 13:31:26 +0000",
 		   "clouds": [
 			{
-			 "region": "us-east-1",
-			 "endpoint": "https://ec2.us-east-1.amazonaws.com"
+			 "region": "dummy_region",
+			 "endpoint": ""
 			}
 		   ],
 		   "cloudname": "aws",
@@ -70,7 +70,7 @@ var testImagesData = map[string]string{
 {
  "updated": "Wed, 01 May 2013 13:31:26 +0000",
  "content_id": "com.ubuntu.cloud:released:aws",
- "region": "nz-east-1",
+ "region": "dummy_region",
  "endpoint": "https://anywhere",
  "products": {
   "com.ubuntu.cloud:server:14.04:amd64": {
@@ -99,7 +99,7 @@ var testImagesData = map[string]string{
    "endpoint": "https://somewhere",
    "versions": {
     "20121218": {
-     "region": "au-east-2",
+     "region": "dummy_region",
      "endpoint": "https://somewhere-else",
      "items": {
       "usww1pe": {
@@ -156,8 +156,8 @@ func (s *imageMetadataUpdateSuite) TestUpdateFromPublishedImages(c *gc.C) {
 				VirtType:        "pv",
 				Arch:            "amd64",
 				Series:          "trusty",
-				Region:          "nz-east-1",
-				Source:          "default cloud images",
+				Region:          "dummy_region",
+				Source:          "public",
 				Stream:          "released"},
 			"ami-36745463",
 		},
@@ -167,8 +167,8 @@ func (s *imageMetadataUpdateSuite) TestUpdateFromPublishedImages(c *gc.C) {
 				VirtType:        "pv",
 				Arch:            "amd64",
 				Series:          "precise",
-				Region:          "au-east-2",
-				Source:          "default cloud images",
+				Region:          "dummy_region",
+				Source:          "public",
 				Stream:          "released"},
 			"ami-26745463",
 		},

--- a/apiserver/imagemetadata/updatefrompublished_test.go
+++ b/apiserver/imagemetadata/updatefrompublished_test.go
@@ -167,52 +167,6 @@ func (s *imageMetadataUpdateSuite) SetUpTest(c *gc.C) {
 func (s *imageMetadataUpdateSuite) TestUpdateFromPublishedImagesForProviderWithNoRegions(c *gc.C) {
 	// This will save all available image metadata.
 	saved := []cloudimagemetadata.Metadata{}
-	expected := []cloudimagemetadata.Metadata{
-		cloudimagemetadata.Metadata{
-			cloudimagemetadata.MetadataAttributes{
-				RootStorageType: "ebs",
-				VirtType:        "pv",
-				Arch:            "amd64",
-				Series:          "trusty",
-				Region:          "dummy_region",
-				Source:          "public",
-				Stream:          "released"},
-			"ami-36745463",
-		},
-		cloudimagemetadata.Metadata{
-			cloudimagemetadata.MetadataAttributes{
-				RootStorageType: "ebs",
-				VirtType:        "pv",
-				Arch:            "amd64",
-				Series:          "precise",
-				Region:          "dummy_region",
-				Source:          "public",
-				Stream:          "released"},
-			"ami-26745463",
-		},
-		cloudimagemetadata.Metadata{
-			cloudimagemetadata.MetadataAttributes{
-				RootStorageType: "ebs",
-				VirtType:        "pv",
-				Arch:            "amd64",
-				Series:          "trusty",
-				Region:          "another_dummy_region",
-				Source:          "public",
-				Stream:          "released"},
-			"ami-1136745463",
-		},
-		cloudimagemetadata.Metadata{
-			cloudimagemetadata.MetadataAttributes{
-				RootStorageType: "ebs",
-				VirtType:        "pv",
-				Arch:            "amd64",
-				Series:          "precise",
-				Region:          "another_dummy_region",
-				Source:          "public",
-				Stream:          "released"},
-			"ami-1126745463",
-		},
-	}
 
 	// testingEnvConfig prepares an environment configuration using
 	// the dummy provider since it doesn't implement simplestreams.HasRegion.
@@ -232,10 +186,10 @@ func (s *imageMetadataUpdateSuite) TestUpdateFromPublishedImagesForProviderWithN
 	}
 
 	err := s.api.UpdateFromPublishedImages()
-	c.Assert(err, jc.ErrorIsNil)
-	s.assertCalls(c, []string{environConfig, saveMetadata, saveMetadata, saveMetadata, saveMetadata})
+	c.Assert(err, gc.ErrorMatches, ".*environment cloud specification cannot be determined.*")
+	s.assertCalls(c, []string{environConfig})
 
-	c.Assert(saved, jc.SameContents, expected)
+	c.Assert(saved, jc.SameContents, []cloudimagemetadata.Metadata{})
 }
 
 // mockConfig returns a configuration for the usage of the
@@ -317,7 +271,7 @@ func (s *regionMetadataSuite) TestUpdateFromPublishedImagesForProviderWithRegion
 				Arch:            "amd64",
 				Series:          "trusty",
 				Region:          "dummy_region",
-				Source:          "public",
+				Source:          "default cloud images",
 				Stream:          "released"},
 			"ami-36745463",
 		},
@@ -328,7 +282,7 @@ func (s *regionMetadataSuite) TestUpdateFromPublishedImagesForProviderWithRegion
 				Arch:            "amd64",
 				Series:          "precise",
 				Region:          "dummy_region",
-				Source:          "public",
+				Source:          "default cloud images",
 				Stream:          "released"},
 			"ami-26745463",
 		},


### PR DESCRIPTION
We are only interested in metadata that is relevant to environment (provider) cloud specification.

(Review request: http://reviews.vapour.ws/r/2987/)