### PR TITLE
1509292: ignore machine addresses 1.24

### DIFF
--- a/apiserver/client/status.go
+++ b/apiserver/client/status.go
@@ -650,7 +650,7 @@ func (context *statusContext) processUnit(unit *state.Unit, serviceCharm string)
 		// Usually this indicates that no addresses have been set on the
 		// machine yet.
 		addr = network.Address{}
-		logger.Warningf("error fetching public address: \"%v\"", err)
+		logger.Warningf("error fetching public address: %q", err)
 	}
 	result.PublicAddress = addr.Value
 	unitPorts, _ := unit.OpenedPorts()

--- a/apiserver/client/status.go
+++ b/apiserver/client/status.go
@@ -650,7 +650,7 @@ func (context *statusContext) processUnit(unit *state.Unit, serviceCharm string)
 		// Usually this indicates that no addresses have been set on the
 		// machine yet.
 		addr = network.Address{}
-		logger.Warningf("error fetching public address: %q", err)
+		logger.Warningf("error fetching public address: \"%v\"", err)
 	}
 	result.PublicAddress = addr.Value
 	unitPorts, _ := unit.OpenedPorts()

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -721,7 +721,10 @@ func (a *MachineAgent) postUpgradeAPIWorker(
 	if err != nil {
 		return nil, fmt.Errorf("cannot read environment config: %v", err)
 	}
-	ignoreMachineAddresses, _ := envConfig.IgnoreMachineAddresses()
+	ignoreMachineAddresses := false
+	if !names.IsContainerMachine(agentConfig.Tag().Id()) {
+		ignoreMachineAddresses, _ = envConfig.IgnoreMachineAddresses()
+	}
 	if ignoreMachineAddresses {
 		logger.Infof("machine addresses not used, only addresses from provider")
 	}

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -721,9 +721,11 @@ func (a *MachineAgent) postUpgradeAPIWorker(
 	if err != nil {
 		return nil, fmt.Errorf("cannot read environment config: %v", err)
 	}
-	ignoreMachineAddresses := false
-	if !names.IsContainerMachine(agentConfig.Tag().Id()) {
-		ignoreMachineAddresses, _ = envConfig.IgnoreMachineAddresses()
+
+	ignoreMachineAddresses, _ := envConfig.IgnoreMachineAddresses()
+	// Containers only have machine addresses, so we can't ignore them.
+	if names.IsContainerMachine(agentConfig.Tag().Id()) {
+		ignoreMachineAddresses = false
 	}
 	if ignoreMachineAddresses {
 		logger.Infof("machine addresses not used, only addresses from provider")

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -163,7 +163,10 @@ func (s *commonMachineSuite) primeAgent(
 
 	m, err := s.State.AddMachine("quantal", jobs...)
 	c.Assert(err, jc.ErrorIsNil)
+	return s.primeAgentWithMachine(c, m, vers)
+}
 
+func (s *commonMachineSuite) primeAgentWithMachine(c *gc.C, m *state.Machine, vers version.Binary) (*state.Machine, agent.ConfigSetterWriter, *tools.Tools) {
 	pinger, err := m.SetAgentPresence()
 	c.Assert(err, jc.ErrorIsNil)
 	s.AddCleanup(func(c *gc.C) {
@@ -1643,14 +1646,7 @@ func (s *MachineSuite) TestMachineAgentIgnoreAddressesContainer(c *gc.C) {
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
-	pinger, err := m.SetAgentPresence()
-	c.Assert(err, jc.ErrorIsNil)
-	s.AddCleanup(func(c *gc.C) {
-		err := pinger.Stop()
-		c.Check(err, jc.ErrorIsNil)
-	})
-
-	m, _, _ = s.configureMachine(c, m.Id(), version.Current)
+	s.primeAgentWithMachine(c, m, version.Current)
 	a := s.newAgent(c, m)
 	defer a.Stop()
 	doneCh := make(chan error)

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -1656,7 +1656,7 @@ func (s *MachineSuite) TestMachineAgentIgnoreAddressesContainer(c *gc.C) {
 
 	select {
 	case ignoreMachineAddresses := <-ignoreAddressCh:
-		if ignoreMachineAddresses != false {
+		if ignoreMachineAddresses {
 			c.Fatalf("expected ignore-machine-addresses = false, got = true")
 		}
 	case <-time.After(coretesting.LongWait):


### PR DESCRIPTION
Ignore machine addresses should be ignored for containers, which only have machine addresses.

(Review request: http://reviews.vapour.ws/r/2992/)