### PR TITLE
Fix type of error used to detect no tools

### DIFF
--- a/apiserver/environment/toolsversionupdate.go
+++ b/apiserver/environment/toolsversionupdate.go
@@ -82,7 +82,7 @@ func updateToolsAvailability(st EnvironGetter, finder toolsFinder, update envVer
 	}
 	ver, err := checkToolsAvailability(cfg, finder)
 	if err != nil {
-		if errors.Cause(err) == coretools.ErrNoMatches {
+		if errors.IsNotFound(err) {
 			// No newer tools, so exit silently.
 			return nil
 		}

--- a/apiserver/environment/toolsversionupdate_test.go
+++ b/apiserver/environment/toolsversionupdate_test.go
@@ -4,6 +4,7 @@
 package environment
 
 import (
+	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -160,7 +161,7 @@ func (s *updaterSuite) TestUpdateToolsAvailabilityNoMatches(c *gc.C) {
 
 	// No new tools available.
 	fakeToolFinder := func(_ environs.Environ, _ int, _ int, _ string, _ coretools.Filter) (coretools.List, error) {
-		return nil, coretools.ErrNoMatches
+		return nil, errors.NotFoundf("tools")
 	}
 
 	// Update should never be called.


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/juju-core/+bug/1502202

The first attempt used the wrong error type for no tools found.

(Review request: http://reviews.vapour.ws/r/2994/)