### PR TITLE
lp 1485784: Retry lxc container creation / clone

### DIFF
--- a/container/lxc/lxc.go
+++ b/container/lxc/lxc.go
@@ -268,10 +268,10 @@ func (manager *containerManager) CreateContainer(
 
 		lxcContainer, err = templateContainer.Clone(name, extraCloneArgs, templateParams)
 		if err != nil {
-			return nil, nil, errors.Annotate(err, "lxc container cloning failed")
+			return nil, nil, errors.Wrap(err, instance.NewRetryableCreationError("lxc container cloning failed"))
 		}
 	} else {
-		// Note here that the lxcObjectFacotry only returns a valid container
+		// Note here that the lxcObjectFactory only returns a valid container
 		// object, and doesn't actually construct the underlying lxc container on
 		// disk.
 		lxcContainer = LxcObjectFactory.New(name)
@@ -422,7 +422,7 @@ func createContainer(
 	logger.Debugf("creating lxc container %q", lxcContainer.Name())
 	logger.Debugf("lxc-create template params: %v", templateParams)
 	if err := lxcContainer.Create(configPath, defaultTemplate, extraCreateArgs, templateParams, execEnv); err != nil {
-		return errors.Annotatef(err, "lxc container creation failed")
+		return errors.Wrap(err, instance.NewRetryableCreationError("lxc container creation failed: "+lxcContainer.Name()))
 	}
 	return nil
 }

--- a/container/lxc/mock/mock-lxc.go
+++ b/container/lxc/mock/mock-lxc.go
@@ -33,21 +33,21 @@ var (
 )
 
 // PatchStartTransientErrorInjectionChannel sets the startTransientInjectionError
-// channel which can be used to inject errors into Start function for
+// channel which can be used to inject errors into the Start function for
 // testing purposes.
 func PatchStartTransientErrorInjectionChannel(c chan error) func() {
 	return testing.PatchValue(&startTransientErrorInjection, c)
 }
 
 // PatchCreateTransientErrorInjectionChannel sets the createTransientInjectionError
-// channel which can be used to inject errors into Create function for
+// channel which can be used to inject errors into the Create function for
 // testing purposes.
 func PatchCreateTransientErrorInjectionChannel(c chan error) func() {
 	return testing.PatchValue(&createTransientErrorInjection, c)
 }
 
 // PatchCloneTransientErrorInjectionChannel sets the cloneTransientInjectionError
-// channel which can be used to inject errors into Clone function for
+// channel which can be used to inject errors into the Clone function for
 // testing purposes.
 func PatchCloneTransientErrorInjectionChannel(c chan error) func() {
 	return testing.PatchValue(&cloneTransientErrorInjection, c)

--- a/container/lxc/mock/mock-lxc.go
+++ b/container/lxc/mock/mock-lxc.go
@@ -26,13 +26,31 @@ var logger = loggo.GetLogger("juju.container.lxc.mock")
 
 type Action int
 
-var transientErrorInjection chan error
+var (
+	startTransientErrorInjection  chan error
+	createTransientErrorInjection chan error
+	cloneTransientErrorInjection  chan error
+)
 
-// PatchTransientErrorInjectionChannel sets the transientInjectionError
+// PatchStartTransientErrorInjectionChannel sets the startTransientInjectionError
 // channel which can be used to inject errors into Start function for
-// testing purposes
-func PatchTransientErrorInjectionChannel(c chan error) func() {
-	return testing.PatchValue(&transientErrorInjection, c)
+// testing purposes.
+func PatchStartTransientErrorInjectionChannel(c chan error) func() {
+	return testing.PatchValue(&startTransientErrorInjection, c)
+}
+
+// PatchCreateTransientErrorInjectionChannel sets the createTransientInjectionError
+// channel which can be used to inject errors into Create function for
+// testing purposes.
+func PatchCreateTransientErrorInjectionChannel(c chan error) func() {
+	return testing.PatchValue(&createTransientErrorInjection, c)
+}
+
+// PatchCloneTransientErrorInjectionChannel sets the cloneTransientInjectionError
+// channel which can be used to inject errors into Clone function for
+// testing purposes.
+func PatchCloneTransientErrorInjectionChannel(c chan error) func() {
+	return testing.PatchValue(&cloneTransientErrorInjection, c)
 }
 
 const (
@@ -125,6 +143,12 @@ func (mock *mockContainer) configFilename() string {
 
 // Create creates a new container based on the given template.
 func (mock *mockContainer) Create(configFile, template string, extraArgs []string, templateArgs []string, envArgs []string) error {
+	select {
+	case injectedError := <-createTransientErrorInjection:
+		return injectedError
+	default:
+	}
+
 	if mock.getState() != golxc.StateUnknown {
 		return fmt.Errorf("container is already created")
 	}
@@ -145,7 +169,7 @@ func (mock *mockContainer) Create(configFile, template string, extraArgs []strin
 // Start runs the container as a daemon.
 func (mock *mockContainer) Start(configFile, consoleFile string) error {
 	select {
-	case injectedError := <-transientErrorInjection:
+	case injectedError := <-startTransientErrorInjection:
 		return injectedError
 	default:
 	}
@@ -179,6 +203,12 @@ func (mock *mockContainer) Stop() error {
 
 // Clone creates a copy of the container, giving the copy the specified name.
 func (mock *mockContainer) Clone(name string, extraArgs []string, templateArgs []string) (golxc.Container, error) {
+	select {
+	case injectedError := <-cloneTransientErrorInjection:
+		return nil, injectedError
+	default:
+	}
+
 	state := mock.getState()
 	if state == golxc.StateUnknown {
 		return nil, fmt.Errorf("container has not been created")
@@ -220,7 +250,7 @@ func (mock *mockContainer) Unfreeze() error {
 // Destroy stops and removes the container.
 func (mock *mockContainer) Destroy() error {
 	select {
-	case injectedError := <-transientErrorInjection:
+	case injectedError := <-startTransientErrorInjection:
 		return injectedError
 	default:
 	}

--- a/worker/provisioner/export_test.go
+++ b/worker/provisioner/export_test.go
@@ -44,6 +44,8 @@ var (
 	MaybeOverrideDefaultLXCNet = maybeOverrideDefaultLXCNet
 	EtcDefaultLXCNetPath       = &etcDefaultLXCNetPath
 	EtcDefaultLXCNet           = etcDefaultLXCNet
+	RetryStrategyDelay         = &retryStrategyDelay
+	RetryStrategyCount         = &retryStrategyCount
 )
 
 const (

--- a/worker/provisioner/provisioner_task.go
+++ b/worker/provisioner/provisioner_task.go
@@ -71,41 +71,49 @@ func NewProvisionerTask(
 	auth authentication.AuthenticationProvider,
 	imageStream string,
 	secureServerConnection bool,
+	retryStartInstanceStrategy RetryStrategy,
 ) ProvisionerTask {
 	task := &provisionerTask{
-		machineTag:             machineTag,
-		machineGetter:          machineGetter,
-		toolsFinder:            toolsFinder,
-		machineWatcher:         machineWatcher,
-		retryWatcher:           retryWatcher,
-		broker:                 broker,
-		auth:                   auth,
-		harvestMode:            harvestMode,
-		harvestModeChan:        make(chan config.HarvestMode, 1),
-		machines:               make(map[string]*apiprovisioner.Machine),
-		imageStream:            imageStream,
-		secureServerConnection: secureServerConnection,
+		machineTag:                 machineTag,
+		machineGetter:              machineGetter,
+		toolsFinder:                toolsFinder,
+		machineWatcher:             machineWatcher,
+		retryWatcher:               retryWatcher,
+		broker:                     broker,
+		auth:                       auth,
+		harvestMode:                harvestMode,
+		harvestModeChan:            make(chan config.HarvestMode, 1),
+		machines:                   make(map[string]*apiprovisioner.Machine),
+		imageStream:                imageStream,
+		secureServerConnection:     secureServerConnection,
+		retryStartInstanceStrategy: retryStartInstanceStrategy,
 	}
 	go func() {
 		defer task.tomb.Done()
-		task.tomb.Kill(task.loop())
+		err := task.loop()
+		switch cause := errors.Cause(err); cause {
+		case tomb.ErrDying:
+			err = cause
+		}
+		task.tomb.Kill(err)
 	}()
 	return task
 }
 
 type provisionerTask struct {
-	machineTag             names.MachineTag
-	machineGetter          MachineGetter
-	toolsFinder            ToolsFinder
-	machineWatcher         apiwatcher.StringsWatcher
-	retryWatcher           apiwatcher.NotifyWatcher
-	broker                 environs.InstanceBroker
-	tomb                   tomb.Tomb
-	auth                   authentication.AuthenticationProvider
-	imageStream            string
-	secureServerConnection bool
-	harvestMode            config.HarvestMode
-	harvestModeChan        chan config.HarvestMode
+	machineTag                 names.MachineTag
+	machineGetter              MachineGetter
+	toolsFinder                ToolsFinder
+	machineWatcher             apiwatcher.StringsWatcher
+	retryWatcher               apiwatcher.NotifyWatcher
+	broker                     environs.InstanceBroker
+	tomb                       tomb.Tomb
+	auth                       authentication.AuthenticationProvider
+	imageStream                string
+	secureServerConnection     bool
+	harvestMode                config.HarvestMode
+	harvestModeChan            chan config.HarvestMode
+	retryStartInstanceStrategy RetryStrategy
 	// instance id -> instance
 	instances map[instance.Id]instance.Instance
 	// machine id -> machine
@@ -689,18 +697,31 @@ func (task *provisionerTask) startMachine(
 
 	result, err := task.broker.StartInstance(startInstanceParams)
 	if err != nil {
-		// If this is a retryable error, we retry once
-		if instance.IsRetryableCreationError(errors.Cause(err)) {
-			logger.Infof("retryable error received on start instance - retrying instance creation")
-			result, err = task.broker.StartInstance(startInstanceParams)
-			if err != nil {
-				return task.setErrorStatus("cannot start instance for machine after a retry %q: %v", machine, err)
-			}
-		} else {
+		if !instance.IsRetryableCreationError(errors.Cause(err)) {
 			// Set the state to error, so the machine will be skipped next
 			// time until the error is resolved, but don't return an
 			// error; just keep going with the other machines.
 			return task.setErrorStatus("cannot start instance for machine %q: %v", machine, err)
+		}
+		logger.Infof("retryable error received on start instance: %v", err)
+		for count := task.retryStartInstanceStrategy.retryCount; count > 0; count-- {
+			if task.retryStartInstanceStrategy.retryDelay > 0 {
+				select {
+				case <-task.tomb.Dying():
+					return tomb.ErrDying
+				case <-time.After(task.retryStartInstanceStrategy.retryDelay):
+				}
+
+			}
+			result, err = task.broker.StartInstance(startInstanceParams)
+			if err == nil {
+				break
+			}
+			// If this was the last attempt and an error was received, set the error
+			// status on the machine.
+			if count == 1 {
+				return task.setErrorStatus("cannot start instance for machine %q: %v", machine, err)
+			}
 		}
 	}
 

--- a/worker/provisioner/provisioner_test.go
+++ b/worker/provisioner/provisioner_test.go
@@ -612,7 +612,7 @@ func (s *ProvisionerSuite) TestProvisionerSetsErrorStatusWhenStartInstanceFailed
 }
 
 func (s *ProvisionerSuite) TestProvisionerFailedStartInstanceWithInjectedCreationError(c *gc.C) {
-	// Set the retry delay to 0, and retry count to 1 to keep tests short
+	// Set the retry delay to 0, and retry count to 2 to keep tests short
 	s.PatchValue(provisioner.RetryStrategyDelay, 0*time.Second)
 	s.PatchValue(provisioner.RetryStrategyCount, 2)
 

--- a/worker/provisioner/provisioner_test.go
+++ b/worker/provisioner/provisioner_test.go
@@ -612,8 +612,12 @@ func (s *ProvisionerSuite) TestProvisionerSetsErrorStatusWhenStartInstanceFailed
 }
 
 func (s *ProvisionerSuite) TestProvisionerFailedStartInstanceWithInjectedCreationError(c *gc.C) {
+	// Set the retry delay to 0, and retry count to 1 to keep tests short
+	s.PatchValue(provisioner.RetryStrategyDelay, 0*time.Second)
+	s.PatchValue(provisioner.RetryStrategyCount, 2)
+
 	// create the error injection channel
-	errorInjectionChannel := make(chan error, 2)
+	errorInjectionChannel := make(chan error, 3)
 
 	p := s.newEnvironProvisioner(c)
 	defer stop(c, p)
@@ -624,7 +628,8 @@ func (s *ProvisionerSuite) TestProvisionerFailedStartInstanceWithInjectedCreatio
 
 	retryableError := instance.NewRetryableCreationError("container failed to start and was destroyed")
 	destroyError := errors.New("container failed to start and failed to destroy: manual cleanup of containers needed")
-	// send the error message TWICE, because the provisioner will retry only ONCE
+	// send the error message three times, because the provisioner will retry twice as patched above.
+	errorInjectionChannel <- retryableError
 	errorInjectionChannel <- retryableError
 	errorInjectionChannel <- destroyError
 
@@ -644,12 +649,16 @@ func (s *ProvisionerSuite) TestProvisionerFailedStartInstanceWithInjectedCreatio
 		c.Assert(statusInfo.Status, gc.Equals, state.StatusError)
 		// check that the status matches the error message
 		c.Assert(statusInfo.Message, gc.Equals, destroyError.Error())
-		break
+		return
 	}
-
+	c.Fatal("Test took too long to complete")
 }
 
 func (s *ProvisionerSuite) TestProvisionerSucceedStartInstanceWithInjectedRetryableCreationError(c *gc.C) {
+	// Set the retry delay to 0, and retry count to 2 to keep tests short
+	s.PatchValue(provisioner.RetryStrategyDelay, 0*time.Second)
+	s.PatchValue(provisioner.RetryStrategyCount, 2)
+
 	// create the error injection channel
 	errorInjectionChannel := make(chan error, 1)
 	c.Assert(errorInjectionChannel, gc.NotNil)
@@ -672,6 +681,10 @@ func (s *ProvisionerSuite) TestProvisionerSucceedStartInstanceWithInjectedRetrya
 }
 
 func (s *ProvisionerSuite) TestProvisionerSucceedStartInstanceWithInjectedWrappedRetryableCreationError(c *gc.C) {
+	// Set the retry delay to 0, and retry count to 1 to keep tests short
+	s.PatchValue(provisioner.RetryStrategyDelay, 0*time.Second)
+	s.PatchValue(provisioner.RetryStrategyCount, 1)
+
 	// create the error injection channel
 	errorInjectionChannel := make(chan error, 1)
 	c.Assert(errorInjectionChannel, gc.NotNil)
@@ -706,7 +719,6 @@ func (s *ProvisionerSuite) TestProvisionerFailStartInstanceWithInjectedNonRetrya
 	defer cleanup()
 
 	// send the error message once
-	// - instance creation should succeed
 	nonRetryableError := errors.New("some nonretryable error")
 	errorInjectionChannel <- nonRetryableError
 
@@ -726,8 +738,36 @@ func (s *ProvisionerSuite) TestProvisionerFailStartInstanceWithInjectedNonRetrya
 		c.Assert(statusInfo.Status, gc.Equals, state.StatusError)
 		// check that the status matches the error message
 		c.Assert(statusInfo.Message, gc.Equals, nonRetryableError.Error())
-		break
+		return
 	}
+	c.Fatal("Test took too long to complete")
+}
+
+func (s *ProvisionerSuite) TestProvisionerStopRetryingIfDying(c *gc.C) {
+	// Create the error injection channel and inject
+	// a retryable error
+	errorInjectionChannel := make(chan error, 1)
+
+	p := s.newEnvironProvisioner(c)
+	// Don't refer the stop.  We will manually stop and verify the result.
+
+	// patch the dummy provider error injection channel
+	cleanup := dummy.PatchTransientErrorInjectionChannel(errorInjectionChannel)
+	defer cleanup()
+
+	retryableError := instance.NewRetryableCreationError("container failed to start and was destroyed")
+	errorInjectionChannel <- retryableError
+
+	m, err := s.addMachine()
+	c.Assert(err, jc.ErrorIsNil)
+
+	time.Sleep(coretesting.ShortWait)
+
+	stop(c, p)
+	statusInfo, err := m.Status()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(statusInfo.Status, gc.Equals, state.StatusPending)
+	s.checkNoOperations(c)
 }
 
 func (s *ProvisionerSuite) TestProvisioningDoesNotOccurForLXC(c *gc.C) {
@@ -1296,6 +1336,8 @@ func (s *ProvisionerSuite) newProvisionerTask(
 	auth, err := authentication.NewAPIAuthenticator(s.provisioner)
 	c.Assert(err, jc.ErrorIsNil)
 
+	retryStrategy := provisioner.NewRetryStrategy(0*time.Second, 0)
+
 	return provisioner.NewProvisionerTask(
 		names.NewMachineTag("0"),
 		harvestingMethod,
@@ -1307,6 +1349,7 @@ func (s *ProvisionerSuite) newProvisionerTask(
 		auth,
 		imagemetadata.ReleasedStream,
 		true,
+		retryStrategy,
 	)
 }
 


### PR DESCRIPTION
If an error is returned from lxc-create or lxc-clone,
treat it as a transient error and retry with a slight
delay.

(Review request: http://reviews.vapour.ws/r/2998/)