### PR TITLE
worker/uniter: record reboot before killing hook

### DIFF
--- a/worker/meterstatus/context.go
+++ b/worker/meterstatus/context.go
@@ -6,7 +6,6 @@ package meterstatus
 import (
 	"fmt"
 	"math/rand"
-	"os"
 	"time"
 
 	"github.com/juju/juju/worker/uniter/runner/context"
@@ -60,7 +59,7 @@ func (ctx *limitedContext) UnitName() string {
 }
 
 // SetProcess implements runner.Context.
-func (ctx *limitedContext) SetProcess(process *os.Process) {}
+func (ctx *limitedContext) SetProcess(process context.HookProcess) {}
 
 // ActionData implements runner.Context.
 func (ctx *limitedContext) ActionData() (*context.ActionData, error) {

--- a/worker/metrics/collect/context.go
+++ b/worker/metrics/collect/context.go
@@ -6,7 +6,6 @@ package collect
 import (
 	"fmt"
 	"math/rand"
-	"os"
 	"time"
 
 	"github.com/juju/errors"
@@ -68,7 +67,7 @@ func (ctx *hookContext) addJujuUnitsMetric() error {
 }
 
 // SetProcess implements runner.Context.
-func (ctx *hookContext) SetProcess(process *os.Process) {}
+func (ctx *hookContext) SetProcess(process context.HookProcess) {}
 
 // ActionData implements runner.Context.
 func (ctx *hookContext) ActionData() (*context.ActionData, error) {

--- a/worker/uniter/manifold.go
+++ b/worker/uniter/manifold.go
@@ -6,6 +6,7 @@ package uniter
 import (
 	"github.com/juju/errors"
 	"github.com/juju/names"
+	"github.com/juju/utils/clock"
 	"github.com/juju/utils/fslock"
 
 	"github.com/juju/juju/agent"
@@ -83,6 +84,7 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 				CharmDirLocker:       charmDirLocker,
 				UpdateStatusSignal:   NewUpdateStatusTimer(),
 				NewOperationExecutor: operation.NewExecutor,
+				Clock:                clock.WallClock,
 			}), nil
 		},
 	}

--- a/worker/uniter/runner/context/context.go
+++ b/worker/uniter/runner/context/context.go
@@ -167,6 +167,11 @@ type HookContext struct {
 }
 
 func (ctx *HookContext) RequestReboot(priority jujuc.RebootPriority) error {
+	// Must set reboot priority first, because killing the hook
+	// process will trigger the completion of the hook. If killing
+	// the hook fails, then we can reset the priority.
+	ctx.SetRebootPriority(priority)
+
 	var err error
 	if priority == jujuc.RebootNow {
 		// At this point, the hook should be running
@@ -176,7 +181,8 @@ func (ctx *HookContext) RequestReboot(priority jujuc.RebootPriority) error {
 	switch err {
 	case nil, ErrNoProcess:
 		// ErrNoProcess almost certainly means we are running in debug hooks
-		ctx.SetRebootPriority(priority)
+	default:
+		ctx.SetRebootPriority(jujuc.RebootSkip)
 	}
 	return err
 }

--- a/worker/uniter/runner/context/context.go
+++ b/worker/uniter/runner/context/context.go
@@ -7,7 +7,6 @@ package context
 
 import (
 	"fmt"
-	"os"
 	"strings"
 	"sync"
 	"time"
@@ -15,6 +14,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names"
+	"github.com/juju/utils/clock"
 	"github.com/juju/utils/proxy"
 	"gopkg.in/juju/charm.v6-unstable"
 
@@ -53,6 +53,12 @@ var ErrIsNotLeader = errors.Errorf("this unit is not the leader")
 type meterStatus struct {
 	code string
 	info string
+}
+
+// HookProcess is an interface representing a process running a hook.
+type HookProcess interface {
+	Pid() int
+	Kill() error
 }
 
 // HookContext is the implementation of jujuc.Context.
@@ -140,7 +146,7 @@ type HookContext struct {
 
 	// process is the process of the command that is being run in the local context,
 	// like a juju-run command or a hook
-	process *os.Process
+	process HookProcess
 
 	// rebootPriority tells us when the hook wants to reboot. If rebootPriority is jujuc.RebootNow
 	// the hook will be killed and requeued
@@ -164,6 +170,9 @@ type HookContext struct {
 	// This collection will be added to the unit on successful
 	// hook run, so the actual add will happen in a flush.
 	storageAddConstraints map[string][]params.StorageConstraints
+
+	// clock is used for any time operations.
+	clock clock.Clock
 }
 
 func (ctx *HookContext) RequestReboot(priority jujuc.RebootPriority) error {
@@ -199,13 +208,13 @@ func (ctx *HookContext) SetRebootPriority(priority jujuc.RebootPriority) {
 	ctx.rebootPriority = priority
 }
 
-func (ctx *HookContext) GetProcess() *os.Process {
+func (ctx *HookContext) GetProcess() HookProcess {
 	mutex.Lock()
 	defer mutex.Unlock()
 	return ctx.process
 }
 
-func (ctx *HookContext) SetProcess(process *os.Process) {
+func (ctx *HookContext) SetProcess(process HookProcess) {
 	mutex.Lock()
 	defer mutex.Unlock()
 	ctx.process = process
@@ -698,10 +707,10 @@ func (ctx *HookContext) killCharmHook() error {
 		// nothing to kill
 		return ErrNoProcess
 	}
-	logger.Infof("trying to kill context process %d", proc.Pid)
+	logger.Infof("trying to kill context process %v", proc.Pid())
 
-	tick := time.After(0)
-	timeout := time.After(30 * time.Second)
+	tick := ctx.clock.After(0)
+	timeout := ctx.clock.After(30 * time.Second)
 	for {
 		// We repeatedly try to kill the process until we fail; this is
 		// because we don't control the *Process, and our clients expect
@@ -717,9 +726,9 @@ func (ctx *HookContext) killCharmHook() error {
 				return nil
 			}
 		case <-timeout:
-			return errors.Errorf("failed to kill context process %d", proc.Pid)
+			return errors.Errorf("failed to kill context process %v", proc.Pid())
 		}
-		logger.Infof("waiting for context process %d to die", proc.Pid)
-		tick = time.After(100 * time.Millisecond)
+		logger.Infof("waiting for context process %v to die", proc.Pid())
+		tick = ctx.clock.After(100 * time.Millisecond)
 	}
 }

--- a/worker/uniter/runner/context/contextfactory.go
+++ b/worker/uniter/runner/context/contextfactory.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/names"
+	"github.com/juju/utils/clock"
 	"gopkg.in/juju/charm.v6-unstable/hooks"
 
 	"github.com/juju/juju/api/uniter"
@@ -71,6 +72,7 @@ type contextFactory struct {
 	envName    string
 	machineTag names.MachineTag
 	storage    StorageContextAccessor
+	clock      clock.Clock
 
 	// Callback to get relation state snapshot.
 	getRelationInfos RelationsFunc
@@ -89,6 +91,7 @@ func NewContextFactory(
 	getRelationInfos RelationsFunc,
 	storage StorageContextAccessor,
 	paths Paths,
+	clock clock.Clock,
 ) (
 	ContextFactory, error,
 ) {
@@ -116,6 +119,7 @@ func NewContextFactory(
 		relationCaches:   map[int]*RelationCache{},
 		storage:          storage,
 		rand:             rand.New(rand.NewSource(time.Now().Unix())),
+		clock:            clock,
 	}
 	return f, nil
 }
@@ -144,6 +148,7 @@ func (f *contextFactory) coreContext() (*HookContext, error) {
 		relationId:         -1,
 		pendingPorts:       make(map[PortRange]PortRangeInfo),
 		storage:            f.storage,
+		clock:              f.clock,
 	}
 	if err := f.updateContext(ctx); err != nil {
 		return nil, err

--- a/worker/uniter/runner/context/contextfactory_test.go
+++ b/worker/uniter/runner/context/contextfactory_test.go
@@ -5,6 +5,7 @@ package context_test
 
 import (
 	"os"
+	"time"
 
 	"github.com/juju/errors"
 	"github.com/juju/names"
@@ -19,6 +20,7 @@ import (
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/storage"
 	"github.com/juju/juju/testcharms"
+	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/leadership"
 	"github.com/juju/juju/worker/uniter/hook"
 	"github.com/juju/juju/worker/uniter/runner/context"
@@ -46,6 +48,7 @@ func (s *ContextFactorySuite) SetUpTest(c *gc.C) {
 		s.getRelationInfos,
 		s.storage,
 		s.paths,
+		coretesting.NewClock(time.Time{}),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	s.factory = contextFactory
@@ -207,6 +210,7 @@ func (s *ContextFactorySuite) TestNewHookContextWithStorage(c *gc.C) {
 		s.getRelationInfos,
 		s.storage,
 		s.paths,
+		coretesting.NewClock(time.Time{}),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	ctx, err := contextFactory.HookContext(hook.Info{

--- a/worker/uniter/runner/context/export_test.go
+++ b/worker/uniter/runner/context/export_test.go
@@ -6,6 +6,7 @@ package context
 import (
 	"github.com/juju/errors"
 	"github.com/juju/names"
+	"github.com/juju/utils/clock"
 	"github.com/juju/utils/proxy"
 	"gopkg.in/juju/charm.v6-unstable"
 
@@ -37,6 +38,7 @@ func NewHookContext(
 	actionData *ActionData,
 	assignedMachineTag names.MachineTag,
 	paths Paths,
+	clock clock.Clock,
 ) (*HookContext, error) {
 	ctx := &HookContext{
 		unit:               unit,
@@ -53,6 +55,7 @@ func NewHookContext(
 		actionData:         actionData,
 		pendingPorts:       make(map[PortRange]PortRangeInfo),
 		assignedMachineTag: assignedMachineTag,
+		clock:              clock,
 	}
 	// Get and cache the addresses.
 	var err error

--- a/worker/uniter/runner/context/util_test.go
+++ b/worker/uniter/runner/context/util_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/multiwatcher"
 	"github.com/juju/juju/storage"
+	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/uniter/runner/context"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
 	runnertesting "github.com/juju/juju/worker/uniter/runner/testing"
@@ -43,6 +44,7 @@ type HookContextSuite struct {
 	relch    *state.Charm
 	relunits map[int]*state.RelationUnit
 	storage  *runnertesting.StorageContextAccessor
+	clock    *coretesting.Clock
 
 	st             api.Connection
 	uniter         *uniter.State
@@ -111,6 +113,8 @@ func (s *HookContextSuite) SetUpTest(c *gc.C) {
 			},
 		},
 	}
+
+	s.clock = coretesting.NewClock(time.Time{})
 }
 
 func (s *HookContextSuite) GetContext(
@@ -195,7 +199,7 @@ func (s *HookContextSuite) getHookContext(c *gc.C, uuid string, relid int,
 	context, err := context.NewHookContext(s.apiUnit, facade, "TestCtx", uuid,
 		env.Name(), relid, remote, relctxs, apiAddrs,
 		proxies, false, nil, nil, s.machine.Tag().(names.MachineTag),
-		runnertesting.NewRealPaths(c))
+		runnertesting.NewRealPaths(c), s.clock)
 	c.Assert(err, jc.ErrorIsNil)
 	return context
 }
@@ -218,7 +222,7 @@ func (s *HookContextSuite) getMeteredHookContext(c *gc.C, uuid string, relid int
 	context, err := context.NewHookContext(s.meteredApiUnit, facade, "TestCtx", uuid,
 		"test-env-name", relid, remote, relctxs, apiAddrs,
 		proxies, canAddMetrics, metrics, nil, s.machine.Tag().(names.MachineTag),
-		paths)
+		paths, s.clock)
 	c.Assert(err, jc.ErrorIsNil)
 	return context
 }

--- a/worker/uniter/runner/factory_test.go
+++ b/worker/uniter/runner/factory_test.go
@@ -6,6 +6,7 @@ package runner_test
 import (
 	"os"
 	"strings"
+	"time"
 
 	"github.com/juju/errors"
 	"github.com/juju/names"
@@ -15,6 +16,7 @@ import (
 	"gopkg.in/juju/charm.v6-unstable/hooks"
 
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/uniter/hook"
 	"github.com/juju/juju/worker/uniter/runner"
 	"github.com/juju/juju/worker/uniter/runner/context"
@@ -165,6 +167,7 @@ func (s *FactorySuite) TestNewHookRunnerWithStorage(c *gc.C) {
 		s.getRelationInfos,
 		s.storage,
 		s.paths,
+		testing.NewClock(time.Time{}),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	factory, err := runner.NewFactory(

--- a/worker/uniter/runner/runner.go
+++ b/worker/uniter/runner/runner.go
@@ -44,7 +44,7 @@ type Context interface {
 	Id() string
 	HookVars(paths context.Paths) ([]string, error)
 	ActionData() (*context.ActionData, error)
-	SetProcess(process *os.Process)
+	SetProcess(process context.HookProcess)
 	HasExecutionSetUnitStatus() bool
 	ResetExecutionSetUnitStatus()
 
@@ -89,7 +89,7 @@ func (runner *runner) RunCommands(commands string) (*utilexec.ExecResponse, erro
 	if err != nil {
 		return nil, err
 	}
-	runner.context.SetProcess(command.Process())
+	runner.context.SetProcess(hookProcess{command.Process()})
 
 	// Block and wait for process to finish
 	result, err := command.Wait()
@@ -163,7 +163,7 @@ func (runner *runner) runCharmHook(hookName string, env []string, charmLocation 
 	outWriter.Close()
 	if err == nil {
 		// Record the *os.Process of the hook
-		runner.context.SetProcess(ps.Process)
+		runner.context.SetProcess(hookProcess{ps.Process})
 		// Block until execution finishes
 		err = ps.Wait()
 	}
@@ -189,4 +189,12 @@ func (runner *runner) startJujucServer() (*jujuc.Server, error) {
 
 func (runner *runner) getLogger(hookName string) loggo.Logger {
 	return loggo.GetLogger(fmt.Sprintf("unit.%s.%s", runner.context.UnitName(), hookName))
+}
+
+type hookProcess struct {
+	*os.Process
+}
+
+func (p hookProcess) Pid() int {
+	return p.Process.Pid
 }

--- a/worker/uniter/runner/runner_test.go
+++ b/worker/uniter/runner/runner_test.go
@@ -6,7 +6,6 @@ package runner_test
 import (
 	"fmt"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -169,8 +168,8 @@ func (ctx *MockContext) ActionData() (*context.ActionData, error) {
 	return ctx.actionData, nil
 }
 
-func (ctx *MockContext) SetProcess(process *os.Process) {
-	ctx.expectPid = process.Pid
+func (ctx *MockContext) SetProcess(process context.HookProcess) {
+	ctx.expectPid = process.Pid()
 }
 
 func (ctx *MockContext) Prepare() error {

--- a/worker/uniter/runner/util_test.go
+++ b/worker/uniter/runner/util_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"time"
 
 	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
@@ -24,6 +25,7 @@ import (
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/storage"
 	"github.com/juju/juju/testcharms"
+	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/uniter/runner"
 	"github.com/juju/juju/worker/uniter/runner/context"
 	runnertesting "github.com/juju/juju/worker/uniter/runner/testing"
@@ -103,6 +105,7 @@ func (s *ContextSuite) SetUpTest(c *gc.C) {
 		s.getRelationInfos,
 		s.storage,
 		s.paths,
+		coretesting.NewClock(time.Time{}),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/worker/uniter/uniter.go
+++ b/worker/uniter/uniter.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names"
+	"github.com/juju/utils/clock"
 	"github.com/juju/utils/exec"
 	"github.com/juju/utils/fslock"
 	corecharm "gopkg.in/juju/charm.v6-unstable"
@@ -61,6 +62,7 @@ type Uniter struct {
 	relations relation.Relations
 	cleanups  []cleanup
 	storage   *storage.Attachments
+	clock     clock.Clock
 
 	// Cache the last reported status information
 	// so we don't make unnecessary api calls.
@@ -100,6 +102,7 @@ type UniterParams struct {
 	CharmDirLocker       charmdir.Locker
 	UpdateStatusSignal   func() <-chan time.Time
 	NewOperationExecutor NewExecutorFunc
+	Clock                clock.Clock
 	// TODO (mattyw, wallyworld, fwereade) Having the observer here make this approach a bit more legitimate, but it isn't.
 	// the observer is only a stop gap to be used in tests. A better approach would be to have the uniter tests start hooks
 	// that write to files, and have the tests watch the output to know that hooks have finished.
@@ -121,6 +124,7 @@ func NewUniter(uniterParams *UniterParams) *Uniter {
 		updateStatusAt:       uniterParams.UpdateStatusSignal,
 		newOperationExecutor: uniterParams.NewOperationExecutor,
 		observer:             uniterParams.Observer,
+		clock:                uniterParams.Clock,
 	}
 	go func() {
 		defer u.tomb.Done()
@@ -408,7 +412,7 @@ func (u *Uniter) init(unitTag names.UnitTag) (err error) {
 	}
 	u.deployer = &deployerProxy{deployer}
 	contextFactory, err := context.NewContextFactory(
-		u.st, unitTag, u.leadershipTracker, u.relations.GetInfo, u.storage, u.paths,
+		u.st, unitTag, u.leadershipTracker, u.relations.GetInfo, u.storage, u.paths, u.clock,
 	)
 	if err != nil {
 		return err

--- a/worker/uniter/util_test.go
+++ b/worker/uniter/util_test.go
@@ -485,8 +485,9 @@ func (s startUniter) step(c *gc.C, ctx *context) {
 		UpdateStatusSignal:   ctx.updateStatusHookTicker.ReturnTimer,
 		NewOperationExecutor: operationExecutor,
 		Observer:             ctx,
-		// TODO(axw) update tests that rely on timing to advance
-		// clock appropriately.
+		// TODO(axw) 2015-11-02 #1512191
+		// update tests that rely on timing to advance clock
+		// appropriately.
 		Clock: clock.WallClock,
 	}
 	ctx.uniter = uniter.NewUniter(&uniterParams)

--- a/worker/uniter/util_test.go
+++ b/worker/uniter/util_test.go
@@ -23,6 +23,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	ft "github.com/juju/testing/filetesting"
 	"github.com/juju/utils"
+	"github.com/juju/utils/clock"
 	utilexec "github.com/juju/utils/exec"
 	"github.com/juju/utils/fslock"
 	"github.com/juju/utils/proxy"
@@ -484,6 +485,9 @@ func (s startUniter) step(c *gc.C, ctx *context) {
 		UpdateStatusSignal:   ctx.updateStatusHookTicker.ReturnTimer,
 		NewOperationExecutor: operationExecutor,
 		Observer:             ctx,
+		// TODO(axw) update tests that rely on timing to advance
+		// clock appropriately.
+		Clock: clock.WallClock,
 	}
 	ctx.uniter = uniter.NewUniter(&uniterParams)
 }


### PR DESCRIPTION
When running the "juju-reboot" hook tool with --now, we
kill the hook process and then record the reboot priority.
This is racey: completion of the hook process is the
trigger for the completion of the run-hook operation.

Instead, set the reboot priority first, kill the hook
process, and the revert the reboot priority if killing
the hook process failed.

(Review request: http://reviews.vapour.ws/r/3002/)