### PR TITLE
cmd/jujud/agent: rework uninstall-gating logic (1.25)

### DIFF
--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -759,7 +759,7 @@ func (a *MachineAgent) postUpgradeAPIWorker(
 			NotifyMachineDead: func() error {
 				return writeUninstallAgentFile(agentConfig.DataDir())
 			},
-		}), nil
+		})
 	})
 	runner.StartWorker("reboot", func() (worker.Worker, error) {
 		reboot, err := st.Reboot()

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -34,7 +34,6 @@ import (
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/api"
-	apiagent "github.com/juju/juju/api/agent"
 	apideployer "github.com/juju/juju/api/deployer"
 	"github.com/juju/juju/api/metricsmanager"
 	apiupgrader "github.com/juju/juju/api/upgrader"
@@ -474,7 +473,7 @@ func (a *MachineAgent) executeRebootOrShutdown(action params.RebootAction) error
 	// We need to reopen the API to clear the reboot flag after
 	// scheduling the reboot. It may be cleaner to do this in the reboot
 	// worker, before returning the ErrRebootMachine.
-	st, _, err := apicaller.OpenAPIState(a)
+	st, err := apicaller.OpenAPIState(a)
 	if err != nil {
 		logger.Infof("Reboot: Error connecting to state")
 		return errors.Trace(err)
@@ -636,7 +635,7 @@ func (a *MachineAgent) stateStarter(stopch <-chan struct{}) error {
 // APIWorker returns a Worker that connects to the API and starts any
 // workers that need an API connection.
 func (a *MachineAgent) APIWorker() (_ worker.Worker, err error) {
-	st, entity, err := apicaller.OpenAPIState(a)
+	st, err := apicaller.OpenAPIState(a)
 	if err != nil {
 		return nil, err
 	}
@@ -656,16 +655,21 @@ func (a *MachineAgent) APIWorker() (_ worker.Worker, err error) {
 		}
 	}()
 
+	machine, err := st.Agent().Entity(a.Tag())
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
 	agentConfig := a.CurrentConfig()
-	if entity.Life() == params.Dead {
-		logger.Errorf("agent terminating - entity %q is dead", entity.Tag())
+	if machine.Life() == params.Dead {
+		logger.Errorf("agent terminating - %s is dead", names.ReadableString(a.Tag()))
 		if err := writeUninstallAgentFile(agentConfig.DataDir()); err != nil {
 			return nil, errors.Annotate(err, "writing uninstall agent file")
 		}
 		return nil, worker.ErrTerminateAgent
 	}
 
-	for _, job := range entity.Jobs() {
+	for _, job := range machine.Jobs() {
 		if job.NeedsState() {
 			info, err := st.Agent().StateServingInfo()
 			if err != nil {
@@ -688,11 +692,11 @@ func (a *MachineAgent) APIWorker() (_ worker.Worker, err error) {
 	// Run the agent upgrader and the upgrade-steps worker without waiting for
 	// the upgrade steps to complete.
 	runner.StartWorker("upgrader", a.agentUpgraderWorkerStarter(st.Upgrader(), agentConfig))
-	runner.StartWorker("upgrade-steps", a.upgradeStepsWorkerStarter(st, entity.Jobs()))
+	runner.StartWorker("upgrade-steps", a.upgradeStepsWorkerStarter(st, machine.Jobs()))
 
 	// All other workers must wait for the upgrade steps to complete before starting.
 	a.startWorkerAfterUpgrade(runner, "api-post-upgrade", func() (worker.Worker, error) {
-		return a.postUpgradeAPIWorker(st, agentConfig, entity)
+		return a.postUpgradeAPIWorker(st, agentConfig, machine.Jobs())
 	})
 
 	return cmdutil.NewCloseWorker(logger, runner, st), nil // Note: a worker.Runner is itself a worker.Worker.
@@ -701,11 +705,11 @@ func (a *MachineAgent) APIWorker() (_ worker.Worker, err error) {
 func (a *MachineAgent) postUpgradeAPIWorker(
 	st api.Connection,
 	agentConfig agent.Config,
-	entity *apiagent.Entity,
+	machineJobs []multiwatcher.MachineJob,
 ) (worker.Worker, error) {
 
 	var isEnvironManager bool
-	for _, job := range entity.Jobs() {
+	for _, job := range machineJobs {
 		if job == multiwatcher.JobManageEnviron {
 			isEnvironManager = true
 			break
@@ -818,7 +822,7 @@ func (a *MachineAgent) postUpgradeAPIWorker(
 
 	// Start networker depending on configuration and job.
 	intrusiveMode := false
-	for _, job := range entity.Jobs() {
+	for _, job := range machineJobs {
 		if job == multiwatcher.JobManageNetworking {
 			intrusiveMode = true
 			break
@@ -839,14 +843,14 @@ func (a *MachineAgent) postUpgradeAPIWorker(
 	}
 
 	// Perform the operations needed to set up hosting for containers.
-	if err := a.setupContainerSupport(runner, st, entity, agentConfig); err != nil {
+	if err := a.setupContainerSupport(runner, st, agentConfig); err != nil {
 		cause := errors.Cause(err)
 		if params.IsCodeDead(cause) || cause == worker.ErrTerminateAgent {
 			return nil, worker.ErrTerminateAgent
 		}
 		return nil, fmt.Errorf("setting up container support: %v", err)
 	}
-	for _, job := range entity.Jobs() {
+	for _, job := range machineJobs {
 		switch job {
 		case multiwatcher.JobHostUnits:
 			runner.StartWorker("deployer", func() (worker.Worker, error) {
@@ -922,7 +926,7 @@ var shouldWriteProxyFiles = func(conf agent.Config) bool {
 
 // setupContainerSupport determines what containers can be run on this machine and
 // initialises suitable infrastructure to support such containers.
-func (a *MachineAgent) setupContainerSupport(runner worker.Runner, st api.Connection, entity *apiagent.Entity, agentConfig agent.Config) error {
+func (a *MachineAgent) setupContainerSupport(runner worker.Runner, st api.Connection, agentConfig agent.Config) error {
 	var supportedContainers []instance.ContainerType
 	// LXC containers are only supported on bare metal and fully virtualized linux systems
 	// Nested LXC containers and Windows machines cannot run LXC containers
@@ -941,7 +945,7 @@ func (a *MachineAgent) setupContainerSupport(runner worker.Runner, st api.Connec
 	if err == nil && supportsKvm {
 		supportedContainers = append(supportedContainers, instance.KVM)
 	}
-	return a.updateSupportedContainers(runner, st, entity.Tag(), supportedContainers, agentConfig)
+	return a.updateSupportedContainers(runner, st, supportedContainers, agentConfig)
 }
 
 // updateSupportedContainers records in state that a machine can run the specified containers.
@@ -951,15 +955,11 @@ func (a *MachineAgent) setupContainerSupport(runner worker.Runner, st api.Connec
 func (a *MachineAgent) updateSupportedContainers(
 	runner worker.Runner,
 	st api.Connection,
-	machineTag string,
 	containers []instance.ContainerType,
 	agentConfig agent.Config,
 ) error {
 	pr := st.Provisioner()
-	tag, err := names.ParseMachineTag(machineTag)
-	if err != nil {
-		return err
-	}
+	tag := agentConfig.Tag().(names.MachineTag)
 	machine, err := pr.Machine(tag)
 	if errors.IsNotFound(err) || err == nil && machine.Life() == params.Dead {
 		return worker.ErrTerminateAgent

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -1264,11 +1264,10 @@ func (s *MachineSuite) runOpenAPISTateTest(c *gc.C, machine *state.Machine, conf
 		agent := NewAgentConf(conf.DataDir())
 		err := agent.ReadConfig(tagString)
 		c.Assert(err, jc.ErrorIsNil)
-		st, gotEntity, err := apicaller.OpenAPIState(agent)
+		st, err := apicaller.OpenAPIState(agent)
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(st, gc.NotNil)
 		st.Close()
-		c.Assert(gotEntity.Tag(), gc.Equals, tagString)
 	}
 	assertOpen()
 

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -1776,7 +1776,7 @@ func (s *MachineSuite) TestMachineAgentNetworkerMode(c *gc.C) {
 func (s *MachineSuite) TestMachineAgentIgnoreAddresses(c *gc.C) {
 	for _, expectedIgnoreValue := range []bool{true, false} {
 		ignoreAddressCh := make(chan bool, 1)
-		s.AgentSuite.PatchValue(&newMachiner, func(cfg machiner.Config) worker.Worker {
+		s.AgentSuite.PatchValue(&newMachiner, func(cfg machiner.Config) (worker.Worker, error) {
 			select {
 			case ignoreAddressCh <- cfg.ClearMachineAddressesOnStart:
 			default:

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -1777,19 +1777,12 @@ func (s *MachineSuite) TestMachineAgentNetworkerMode(c *gc.C) {
 func (s *MachineSuite) TestMachineAgentIgnoreAddresses(c *gc.C) {
 	for _, expectedIgnoreValue := range []bool{true, false} {
 		ignoreAddressCh := make(chan bool, 1)
-		s.AgentSuite.PatchValue(&newMachiner, func(
-			accessor machiner.MachineAccessor,
-			conf agent.Config,
-			ignoreMachineAddresses bool,
-			machineDead func() error,
-		) worker.Worker {
+		s.AgentSuite.PatchValue(&newMachiner, func(cfg machiner.Config) worker.Worker {
 			select {
-			case ignoreAddressCh <- ignoreMachineAddresses:
+			case ignoreAddressCh <- cfg.ClearMachineAddressesOnStart:
 			default:
 			}
-			return machiner.NewMachiner(
-				accessor, conf, ignoreMachineAddresses, func() error { return nil },
-			)
+			return machiner.NewMachiner(cfg)
 		})
 
 		attrs := coretesting.Attrs{"ignore-machine-addresses": expectedIgnoreValue}

--- a/cmd/jujud/agent/unit_test.go
+++ b/cmd/jujud/agent/unit_test.go
@@ -304,15 +304,6 @@ func (s *UnitSuite) TestOpenAPIStateWithBadCredsTerminates(c *gc.C) {
 	c.Assert(err, gc.Equals, worker.ErrTerminateAgent)
 }
 
-func (s *UnitSuite) TestOpenAPIStateWithDeadEntityTerminates(c *gc.C) {
-	_, unit, conf, _ := s.primeAgent(c)
-	err := unit.EnsureDead()
-	c.Assert(err, jc.ErrorIsNil)
-
-	_, _, err = apicaller.OpenAPIState(fakeConfAgent{conf: conf})
-	c.Assert(err, gc.Equals, worker.ErrTerminateAgent)
-}
-
 type fakeConfAgent struct {
 	agent.Agent
 	conf agent.Config

--- a/cmd/jujud/agent/unit_test.go
+++ b/cmd/jujud/agent/unit_test.go
@@ -267,11 +267,10 @@ func (s *UnitSuite) TestOpenAPIState(c *gc.C) {
 		agent := NewAgentConf(conf.DataDir())
 		err := agent.ReadConfig(conf.Tag().String())
 		c.Assert(err, jc.ErrorIsNil)
-		st, gotEntity, err := apicaller.OpenAPIState(agent)
+		st, err := apicaller.OpenAPIState(agent)
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(st, gc.NotNil)
 		st.Close()
-		c.Assert(gotEntity.Tag(), gc.Equals, unit.Tag().String())
 	}
 	assertOpen()
 
@@ -300,7 +299,7 @@ func (s *UnitSuite) TestOpenAPIState(c *gc.C) {
 func (s *UnitSuite) TestOpenAPIStateWithBadCredsTerminates(c *gc.C) {
 	conf, _ := s.PrimeAgent(c, names.NewUnitTag("missing/0"), "no-password", version.Current)
 
-	_, _, err := apicaller.OpenAPIState(fakeConfAgent{conf: conf})
+	_, err := apicaller.OpenAPIState(fakeConfAgent{conf: conf})
 	c.Assert(err, gc.Equals, worker.ErrTerminateAgent)
 }
 

--- a/worker/apicaller/open.go
+++ b/worker/apicaller/open.go
@@ -45,7 +45,7 @@ func OpenAPIState(a agent.Agent) (_ api.Connection, err error) {
 	agentConfig := a.CurrentConfig()
 	info, ok := agentConfig.APIInfo()
 	if !ok {
-		return nil, nil, errors.New("API info not available")
+		return nil, errors.New("API info not available")
 	}
 	st, usedOldPassword, err := openAPIStateUsingInfo(info, agentConfig.OldPassword())
 	if err != nil {

--- a/worker/apicaller/open.go
+++ b/worker/apicaller/open.go
@@ -41,7 +41,7 @@ func openAPIForAgent(info *api.Info, opts api.DialOpts) (api.Connection, error) 
 // OpenAPIState opens the API using the given information. The agent's
 // password is changed if the fallback password was used to connect to
 // the API.
-func OpenAPIState(a agent.Agent) (_ api.Connection, _ *apiagent.Entity, err error) {
+func OpenAPIState(a agent.Agent) (_ api.Connection, err error) {
 	agentConfig := a.CurrentConfig()
 	info, ok := agentConfig.APIInfo()
 	if !ok {
@@ -49,7 +49,7 @@ func OpenAPIState(a agent.Agent) (_ api.Connection, _ *apiagent.Entity, err erro
 	}
 	st, usedOldPassword, err := openAPIStateUsingInfo(info, agentConfig.OldPassword())
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 	defer func() {
 		// NOTE(fwereade): we may close and overwrite st below,
@@ -63,22 +63,23 @@ func OpenAPIState(a agent.Agent) (_ api.Connection, _ *apiagent.Entity, err erro
 
 	tag := agentConfig.Tag()
 	entity, err := st.Agent().Entity(tag)
-	if err == nil && entity.Life() == params.Dead {
-		return st, entity, nil
-	}
 	if params.IsCodeUnauthorized(err) {
 		logger.Errorf("agent terminating due to error returned during entity lookup: %v", err)
-		return nil, nil, worker.ErrTerminateAgent
+		return nil, worker.ErrTerminateAgent
+	} else if err != nil {
+		return nil, err
 	}
-	if err != nil {
-		return nil, nil, err
+
+	if entity.Life() == params.Dead {
+		// The entity is Dead, so the password cannot (and should not) be updated.
+		return st, nil
 	}
 
 	if !usedOldPassword {
 		// Call set password with the current password.  If we've recently
 		// become a state server, this will fix up our credentials in mongo.
 		if err := entity.SetPassword(info.Password); err != nil {
-			return nil, nil, errors.Annotate(err, "can't reset agent password")
+			return nil, errors.Annotate(err, "can't reset agent password")
 		}
 	} else {
 		// We succeeded in connecting with the fallback
@@ -87,11 +88,11 @@ func OpenAPIState(a agent.Agent) (_ api.Connection, _ *apiagent.Entity, err erro
 		logger.Debugf("replacing insecure password")
 		newPassword, err := utils.RandomPassword()
 		if err != nil {
-			return nil, nil, err
+			return nil, err
 		}
 		err = setAgentPassword(newPassword, info.Password, a, entity)
 		if err != nil {
-			return nil, nil, err
+			return nil, err
 		}
 
 		// Reconnect to the API with the new password.
@@ -105,11 +106,11 @@ func OpenAPIState(a agent.Agent) (_ api.Connection, _ *apiagent.Entity, err erro
 		// untested way.
 		st, err = apiOpen(info, api.DialOpts{})
 		if err != nil {
-			return nil, nil, err
+			return nil, err
 		}
 	}
 
-	return st, entity, nil
+	return st, nil
 }
 
 func setAgentPassword(newPw, oldPw string, a agent.Agent, entity *apiagent.Entity) error {

--- a/worker/apicaller/open.go
+++ b/worker/apicaller/open.go
@@ -64,8 +64,7 @@ func OpenAPIState(a agent.Agent) (_ api.Connection, _ *apiagent.Entity, err erro
 	tag := agentConfig.Tag()
 	entity, err := st.Agent().Entity(tag)
 	if err == nil && entity.Life() == params.Dead {
-		logger.Errorf("agent terminating - entity %q is dead", tag)
-		return nil, nil, worker.ErrTerminateAgent
+		return st, entity, nil
 	}
 	if params.IsCodeUnauthorized(err) {
 		logger.Errorf("agent terminating due to error returned during entity lookup: %v", err)

--- a/worker/apicaller/open_test.go
+++ b/worker/apicaller/open_test.go
@@ -49,7 +49,7 @@ func (s *OpenAPIStateSuite) TestOpenAPIStateReplaceErrors(c *gc.C) {
 	for i, test := range errReplacePairs {
 		c.Logf("test %d", i)
 		apiError = test.openErr
-		_, _, err := OpenAPIState(fakeAgent{})
+		_, err := OpenAPIState(fakeAgent{})
 		if test.replaceErr == nil {
 			c.Check(err, gc.Equals, test.openErr)
 		} else {
@@ -68,7 +68,7 @@ func (s *OpenAPIStateSuite) TestOpenAPIStateWaitsProvisioned(c *gc.C) {
 		}
 		return nil, &params.Error{Code: params.CodeNotProvisioned}
 	})
-	_, _, err := OpenAPIState(fakeAgent{})
+	_, err := OpenAPIState(fakeAgent{})
 	c.Assert(err, gc.Equals, worker.ErrTerminateAgent)
 	c.Assert(called, gc.Equals, checkProvisionedStrategy.Min-1)
 }
@@ -80,7 +80,7 @@ func (s *OpenAPIStateSuite) TestOpenAPIStateWaitsProvisionedGivesUp(c *gc.C) {
 		called++
 		return nil, &params.Error{Code: params.CodeNotProvisioned}
 	})
-	_, _, err := OpenAPIState(fakeAgent{})
+	_, err := OpenAPIState(fakeAgent{})
 	c.Assert(err, gc.Equals, worker.ErrTerminateAgent)
 	// +1 because we always attempt at least once outside the attempt strategy
 	// (twice if the API server initially returns CodeUnauthorized.)

--- a/worker/apicaller/worker.go
+++ b/worker/apicaller/worker.go
@@ -18,7 +18,7 @@ var logger = loggo.GetLogger("juju.worker.apicaller")
 // openConnection exists to be patched out in export_test.go (and let us test
 // this component without using a real API connection).
 var openConnection = func(a agent.Agent) (api.Connection, error) {
-	st, _, err := OpenAPIState(a)
+	st, err := OpenAPIState(a)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/worker/machiner/machiner.go
+++ b/worker/machiner/machiner.go
@@ -35,13 +35,21 @@ type Config struct {
 	NotifyMachineDead func() error
 }
 
+// Validate reports whether or not the configuration is valid.
+func (cfg *Config) Validate() error {
+	if cfg.MachineAccessor == nil {
+		return errors.NotValidf("unspecified MachineAccessor")
+	}
+	if cfg.Tag == (names.MachineTag{}) {
+		return errors.NotValidf("unspecified Tag")
+	}
+	return nil
+}
+
 // Machiner is responsible for a machine agent's lifecycle.
 type Machiner struct {
-	st                     MachineAccessor
-	tag                    names.MachineTag
-	machine                Machine
-	ignoreAddressesOnStart bool
-	machineDead            func() error
+	config  Config
+	machine Machine
 }
 
 // NewMachiner returns a Worker that will wait for the identified machine
@@ -50,19 +58,17 @@ type Machiner struct {
 //
 // The machineDead function will be called immediately after the machine's
 // lifecycle is updated to Dead.
-func NewMachiner(cfg Config) worker.Worker {
-	mr := &Machiner{
-		st:  cfg.MachineAccessor,
-		tag: cfg.Tag,
-		ignoreAddressesOnStart: cfg.ClearMachineAddressesOnStart,
-		machineDead:            cfg.NotifyMachineDead,
+func NewMachiner(cfg Config) (worker.Worker, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, errors.Annotate(err, "validating config")
 	}
-	return worker.NewNotifyWorker(mr)
+	mr := &Machiner{config: cfg}
+	return worker.NewNotifyWorker(mr), nil
 }
 
 func (mr *Machiner) SetUp() (watcher.NotifyWatcher, error) {
 	// Find which machine we're responsible for.
-	m, err := mr.st.Machine(mr.tag)
+	m, err := mr.config.MachineAccessor.Machine(mr.config.Tag)
 	if params.IsCodeNotFoundOrCodeUnauthorized(err) {
 		return nil, worker.ErrTerminateAgent
 	} else if err != nil {
@@ -70,23 +76,23 @@ func (mr *Machiner) SetUp() (watcher.NotifyWatcher, error) {
 	}
 	mr.machine = m
 
-	if mr.ignoreAddressesOnStart {
+	if mr.config.ClearMachineAddressesOnStart {
 		logger.Debugf("machine addresses ignored on start - resetting machine addresses")
 		if err := m.SetMachineAddresses(nil); err != nil {
 			return nil, errors.Annotate(err, "reseting machine addresses")
 		}
 	} else {
 		// Set the addresses in state to the host's addresses.
-		if err := setMachineAddresses(mr.tag, m); err != nil {
+		if err := setMachineAddresses(mr.config.Tag, m); err != nil {
 			return nil, errors.Annotate(err, "setting machine addresses")
 		}
 	}
 
 	// Mark the machine as started and log it.
 	if err := m.SetStatus(params.StatusStarted, "", nil); err != nil {
-		return nil, errors.Annotatef(err, "%s failed to set status started", mr.tag)
+		return nil, errors.Annotatef(err, "%s failed to set status started", mr.config.Tag)
 	}
-	logger.Infof("%q started", mr.tag)
+	logger.Infof("%q started", mr.config.Tag)
 
 	return m.Watch()
 }
@@ -129,6 +135,11 @@ func setMachineAddresses(tag names.MachineTag, m Machine) error {
 
 func (mr *Machiner) Handle(_ <-chan struct{}) error {
 	if err := mr.machine.Refresh(); params.IsCodeNotFoundOrCodeUnauthorized(err) {
+		// NOTE(axw) we can distinguish between NotFound and CodeUnauthorized,
+		// so we could call NotifyMachineDead here in case the agent failed to
+		// call NotifyMachineDead directly after setting the machine Dead in
+		// the first place. We're not doing that to be cautious: the machine
+		// could be missing from state due to invalid global state.
 		return worker.ErrTerminateAgent
 	} else if err != nil {
 		return err
@@ -137,9 +148,9 @@ func (mr *Machiner) Handle(_ <-chan struct{}) error {
 	if life == params.Alive {
 		return nil
 	}
-	logger.Debugf("%q is now %s", mr.tag, life)
+	logger.Debugf("%q is now %s", mr.config.Tag, life)
 	if err := mr.machine.SetStatus(params.StatusStopped, "", nil); err != nil {
-		return errors.Annotatef(err, "%s failed to set status stopped", mr.tag)
+		return errors.Annotatef(err, "%s failed to set status stopped", mr.config.Tag)
 	}
 
 	// Attempt to mark the machine Dead. If the machine still has units
@@ -155,14 +166,16 @@ func (mr *Machiner) Handle(_ <-chan struct{}) error {
 			logger.Tracef("machine still has storage attached")
 			return nil
 		}
-		return errors.Annotatef(err, "%s failed to set machine to dead", mr.tag)
+		return errors.Annotatef(err, "%s failed to set machine to dead", mr.config.Tag)
 	}
 	// Report on the machine's death. It is important that we do this after
 	// the machine is Dead, because this is the mechanism we use to clean up
 	// the machine (uninstall). If we were to report before marking the machine
 	// as Dead, then we would risk uninstalling prematurely.
-	if err := mr.machineDead(); err != nil {
-		return errors.Annotate(err, "reporting machine death")
+	if mr.config.NotifyMachineDead != nil {
+		if err := mr.config.NotifyMachineDead(); err != nil {
+			return errors.Annotate(err, "reporting machine death")
+		}
 	}
 	return worker.ErrTerminateAgent
 }

--- a/worker/terminationworker/worker_test.go
+++ b/worker/terminationworker/worker_test.go
@@ -4,7 +4,6 @@
 package terminationworker_test
 
 import (
-	"errors"
 	"os"
 	"os/signal"
 	"runtime"
@@ -14,6 +13,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/testing"
+	"github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/terminationworker"
 )
 
@@ -43,9 +43,7 @@ func (s *TerminationWorkerSuite) TearDownTest(c *gc.C) {
 }
 
 func (s *TerminationWorkerSuite) TestStartStop(c *gc.C) {
-	w := terminationworker.NewWorker(func() error {
-		return errors.New("anything")
-	})
+	w := terminationworker.NewWorker()
 	w.Kill()
 	err := w.Wait()
 	c.Assert(err, jc.ErrorIsNil)
@@ -56,14 +54,12 @@ func (s *TerminationWorkerSuite) TestSignal(c *gc.C) {
 	if runtime.GOOS == "windows" {
 		c.Skip("bug 1403084: sending this signal is not supported on windows")
 	}
-	w := terminationworker.NewWorker(func() error {
-		return errors.New("anything")
-	})
+	w := terminationworker.NewWorker()
 	proc, err := os.FindProcess(os.Getpid())
 	c.Assert(err, jc.ErrorIsNil)
 	defer proc.Release()
 	err = proc.Signal(terminationworker.TerminationSignal)
 	c.Assert(err, jc.ErrorIsNil)
 	err = w.Wait()
-	c.Assert(err, gc.ErrorMatches, "anything")
+	c.Assert(err, gc.Equals, worker.ErrTerminateAgent)
 }


### PR DESCRIPTION
(Back port)

The fix for https://bugs.launchpad.net/juju-core/+bug/1464304 was too
narrowly focused on the SIGABRT trigger, and so this commit changes how we
gate uninstall.

The termination worker was doing the uninstall-agent file check, but it
really belongs at the top level of the machine agent, because we attempt to
uninstall whenever the agent gets an ErrTerminateAgent. This can happen in
various ways, such as SIGABRT, or just because the agent made an bad
authorization attempt when opening the API connection. So we move the check
to the top level, and undo the checking in the termination worker.

For this to work and still uninstall when the machine is destroyed, we must
make deeper changes:
 - the machiner worker must inform the agent code when it has
   set the machine to Dead. Immediately after the machine is set
   to Dead, we write out the uninstall-agent file so the ensuing
   ErrTerminateAgent will cause an uninstall
 - if the machine is Dead in state when the agent connects, we
   also want to write out the uninstall-agent file. This means
   changing worker/apicaller to not error on Dead entities, but
   leave that up to the caller

There is a test removed from the unit agent which was really in the wrong
place (it was calling worker/apicaller code directly, and asserting on its
results). More importantly, this behaviour has changed; we now rely on the
worker/uniter code to return ErrTerminateAgent when it encounters the Dead
unit entity.

Fixes https://bugs.launchpad.net/juju-core/+bug/1444912

(Review request: http://reviews.vapour.ws/r/3003/)