### PR TITLE
Renaming ServerTag to be ControllerTag.

### DIFF
--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -52,10 +52,10 @@ type state struct {
 	// environTag holds the environment tag once we're connected
 	environTag string
 
-	// serverTag holds the server tag once we're connected.
+	// controllerTag holds the controller tag once we're connected.
 	// This is only set with newer apiservers where they are using
 	// the v1 login mechansim.
-	serverTag string
+	controllerTag string
 
 	// serverVersion holds the version of the API server that we are
 	// connected to.  It is possible that this version is 0 if the
@@ -399,8 +399,8 @@ func (st *state) addCookiesToHeader(h http.Header) {
 // endpoint path and query parameters. Note that the caller
 // is responsible for ensuring that the path *is* prefixed with a slash.
 func (st *state) apiEndpoint(path, query string) (*url.URL, error) {
-	if _, err := st.ServerTag(); err == nil {
-		// The server tag is set, so the agent version is >= 1.23,
+	if _, err := st.ControllerTag(); err == nil {
+		// The controller tag is set, so the agent version is >= 1.23,
 		// so we can use the environment endpoint.
 		envTag, err := st.EnvironTag()
 		if err != nil {
@@ -551,9 +551,9 @@ func (s *state) EnvironTag() (names.EnvironTag, error) {
 	return names.ParseEnvironTag(s.environTag)
 }
 
-// ServerTag returns the tag of the server we are connected to.
-func (s *state) ServerTag() (names.EnvironTag, error) {
-	return names.ParseEnvironTag(s.serverTag)
+// ControllerTag returns the tag of the server we are connected to.
+func (s *state) ControllerTag() (names.EnvironTag, error) {
+	return names.ParseEnvironTag(s.controllerTag)
 }
 
 // APIHostPorts returns addresses that may be used to connect

--- a/api/interface.go
+++ b/api/interface.go
@@ -132,11 +132,11 @@ type Connection interface {
 	// This should not be used outside the api/* packages or tests.
 	base.APICaller
 
-	// ServerTag returns the environment tag of the state server
+	// ControllerTag returns the environment tag of the controller
 	// (as opposed to the environment tag of the currently connected
-	// environment inside that state server).
+	// environment inside that controller).
 	// This could be defined on base.APICaller.
-	ServerTag() (names.EnvironTag, error)
+	ControllerTag() (names.EnvironTag, error)
 
 	// All the rest are strange and questionable and deserve extra attention
 	// and/or discussion.

--- a/api/state.go
+++ b/api/state.go
@@ -114,7 +114,7 @@ func (st *state) loginV2(tag names.Tag, password, nonce string) error {
 	}
 
 	servers := params.NetworkHostsPorts(result.Servers)
-	err = st.setLoginResult(tag, result.EnvironTag, result.ServerTag, servers, result.Facades)
+	err = st.setLoginResult(tag, result.EnvironTag, result.ControllerTag, servers, result.Facades)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -154,7 +154,7 @@ func (st *state) loginV1(tag names.Tag, password, nonce string) error {
 	// one should have an environ tag set.
 
 	var environTag string
-	var serverTag string
+	var controllerTag string
 	var servers [][]network.HostPort
 	var facades []params.FacadeVersions
 	// For quite old servers, it is possible that they don't send down
@@ -167,22 +167,22 @@ func (st *state) loginV1(tag names.Tag, password, nonce string) error {
 		facades = result.LoginResult.Facades
 	} else if result.LoginResultV1.EnvironTag != "" {
 		environTag = result.LoginResultV1.EnvironTag
-		serverTag = result.LoginResultV1.ServerTag
+		controllerTag = result.LoginResultV1.ControllerTag
 		servers = params.NetworkHostsPorts(result.LoginResultV1.Servers)
 		facades = result.LoginResultV1.Facades
 	}
 
-	err = st.setLoginResult(tag, environTag, serverTag, servers, facades)
+	err = st.setLoginResult(tag, environTag, controllerTag, servers, facades)
 	if err != nil {
 		return err
 	}
 	return nil
 }
 
-func (st *state) setLoginResult(tag names.Tag, environTag, serverTag string, servers [][]network.HostPort, facades []params.FacadeVersions) error {
+func (st *state) setLoginResult(tag names.Tag, environTag, controllerTag string, servers [][]network.HostPort, facades []params.FacadeVersions) error {
 	st.authTag = tag
 	st.environTag = environTag
-	st.serverTag = serverTag
+	st.controllerTag = controllerTag
 
 	hostPorts, err := addAddress(servers, st.addr)
 	if err != nil {

--- a/api/state_test.go
+++ b/api/state_test.go
@@ -88,11 +88,11 @@ func (s *stateSuite) TestLoginSetsEnvironTag(c *gc.C) {
 	envTag, err = apistate.EnvironTag()
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(envTag, gc.Equals, env.EnvironTag())
-	// The server tag is also set, and since the environment is the
-	// state server environment, the uuid is the same.
-	srvTag, err := apistate.ServerTag()
+	// The controller tag is also set, and since the environment is the
+	// controller environment, the uuid is the same.
+	controllerTag, err := apistate.ControllerTag()
 	c.Check(err, jc.ErrorIsNil)
-	c.Check(srvTag, gc.Equals, env.EnvironTag())
+	c.Check(controllerTag, gc.Equals, env.EnvironTag())
 }
 
 func (s *stateSuite) TestLoginTracksFacadeVersions(c *gc.C) {

--- a/apiserver/admin.go
+++ b/apiserver/admin.go
@@ -165,7 +165,7 @@ func (a *admin) doLogin(req params.LoginRequest, loginVersion int) (params.Login
 	loginResult := params.LoginResultV1{
 		Servers:       params.FromNetworkHostsPorts(hostPorts),
 		EnvironTag:    environ.Tag().String(),
-		ServerTag:     environ.ServerTag().String(),
+		ControllerTag: environ.ControllerTag().String(),
 		Facades:       DescribeFacades(),
 		UserInfo:      maybeUserInfo,
 		ServerVersion: version.Current.String(),

--- a/apiserver/admin_test.go
+++ b/apiserver/admin_test.go
@@ -531,7 +531,7 @@ func (s *loginV0Suite) TestLoginReportsEnvironTag(c *gc.C) {
 	c.Assert(result.EnvironTag, gc.Equals, s.State.EnvironTag().String())
 }
 
-func (s *loginV1Suite) TestLoginReportsEnvironAndServerTag(c *gc.C) {
+func (s *loginV1Suite) TestLoginReportsEnvironAndControllerTag(c *gc.C) {
 	otherState := s.Factory.MakeEnvironment(c, nil)
 	defer otherState.Close()
 	newEnvTag := otherState.EnvironTag()
@@ -546,7 +546,7 @@ func (s *loginV1Suite) TestLoginReportsEnvironAndServerTag(c *gc.C) {
 	err := st.APICall("Admin", 1, "", "Login", creds, &result)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.EnvironTag, gc.Equals, newEnvTag.String())
-	c.Assert(result.ServerTag, gc.Equals, s.State.EnvironTag().String())
+	c.Assert(result.ControllerTag, gc.Equals, s.State.EnvironTag().String())
 }
 
 func (s *loginV1Suite) TestLoginV1Valid(c *gc.C) {

--- a/apiserver/common/environdestroy.go
+++ b/apiserver/common/environdestroy.go
@@ -65,7 +65,7 @@ func DestroyEnvironment(st *state.State, environTag names.EnvironTag) error {
 
 	// If this is not the state server environment, remove all documents from
 	// state associated with the environment.
-	if env.EnvironTag() != env.ServerTag() {
+	if env.EnvironTag() != env.ControllerTag() {
 		return errors.Trace(st.RemoveAllEnvironDocs())
 	}
 

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -636,9 +636,9 @@ type LoginResultV1 struct {
 	// EnvironTag is the tag for the environment that is being connected to.
 	EnvironTag string `json:"environ-tag,omitempty"`
 
-	// ServerTag is the tag for the environment that holds the API servers.
+	// ControllerTag is the tag for the environment that holds the API servers.
 	// This is the initial environment created when bootstrapping juju.
-	ServerTag string `json:"server-tag,omitempty"`
+	ControllerTag string `json:"server-tag,omitempty"`
 
 	// UserInfo describes the authenticated user, if any.
 	UserInfo *AuthUserInfo `json:"user-info,omitempty"`

--- a/cmd/juju/system/login.go
+++ b/cmd/juju/system/login.go
@@ -209,7 +209,7 @@ func (c *loginCommand) cacheConnectionInfo(serverDetails envcmd.ServerFile, apiS
 	}
 	serverInfo := store.CreateInfo(c.Name)
 
-	serverTag, err := apiState.ServerTag()
+	controllerTag, err := apiState.ControllerTag()
 	if err != nil {
 		return nil, errors.Wrap(err, errors.New("juju system too old to support login"))
 	}
@@ -238,7 +238,7 @@ func (c *loginCommand) cacheConnectionInfo(serverDetails envcmd.ServerFile, apiS
 		Addresses:  addrs,
 		Hostnames:  hosts,
 		CACert:     serverDetails.CACert,
-		ServerUUID: serverTag.Id(),
+		ServerUUID: controllerTag.Id(),
 	})
 
 	if err = serverInfo.Write(); err != nil {

--- a/cmd/juju/system/login_test.go
+++ b/cmd/juju/system/login_test.go
@@ -41,8 +41,8 @@ func (s *LoginSuite) SetUpTest(c *gc.C) {
 	})
 	s.openError = nil
 	s.apiConnection = &mockAPIConnection{
-		serverTag: testing.EnvironmentTag,
-		addr:      "192.168.2.1:1234",
+		controllerTag: testing.EnvironmentTag,
+		addr:          "192.168.2.1:1234",
 	}
 	s.username = "valid-user"
 	s.password = "sekrit"
@@ -134,7 +134,7 @@ func (s *LoginSuite) TestAPIOpenError(c *gc.C) {
 }
 
 func (s *LoginSuite) TestOldServerNoServerUUID(c *gc.C) {
-	s.apiConnection.serverTag = names.EnvironTag{}
+	s.apiConnection.controllerTag = names.EnvironTag{}
 	_, err := s.runServerFile(c)
 	c.Assert(err, gc.ErrorMatches, `juju system too old to support login`)
 }
@@ -209,13 +209,13 @@ func (s *LoginSuite) TestWritesCurrentSystem(c *gc.C) {
 
 type mockAPIConnection struct {
 	api.Connection
-	info         *api.Info
-	opts         api.DialOpts
-	addr         string
-	apiHostPorts [][]network.HostPort
-	serverTag    names.EnvironTag
-	username     string
-	password     string
+	info          *api.Info
+	opts          api.DialOpts
+	addr          string
+	apiHostPorts  [][]network.HostPort
+	controllerTag names.EnvironTag
+	username      string
+	password      string
 }
 
 func (*mockAPIConnection) Close() error {
@@ -230,11 +230,11 @@ func (m *mockAPIConnection) APIHostPorts() [][]network.HostPort {
 	return m.apiHostPorts
 }
 
-func (m *mockAPIConnection) ServerTag() (names.EnvironTag, error) {
-	if m.serverTag.Id() == "" {
-		return m.serverTag, errors.New("no server tag")
+func (m *mockAPIConnection) ControllerTag() (names.EnvironTag, error) {
+	if m.controllerTag.Id() == "" {
+		return m.controllerTag, errors.New("no server tag")
 	}
-	return m.serverTag, nil
+	return m.controllerTag, nil
 }
 
 func (m *mockAPIConnection) SetPassword(username, password string) error {

--- a/juju/api.go
+++ b/juju/api.go
@@ -215,8 +215,8 @@ func newAPIFromStore(envName string, store configstore.Storage, apiOpen api.Open
 	if envTag, err := st.EnvironTag(); err == nil {
 		environUUID = envTag.Id()
 	}
-	if serverTag, err := st.ServerTag(); err == nil {
-		serverUUID = serverTag.Id()
+	if controllerTag, err := st.ControllerTag(); err == nil {
+		serverUUID = controllerTag.Id()
 	}
 	if localerr := cacheChangedAPIInfo(info, st.APIHostPorts(), addrConnectedTo, environUUID, serverUUID); localerr != nil {
 		logger.Warningf("cannot cache API addresses: %v", localerr)

--- a/juju/mock_test.go
+++ b/juju/mock_test.go
@@ -36,8 +36,8 @@ func (s *mockAPIState) EnvironTag() (names.EnvironTag, error) {
 	return names.ParseEnvironTag(s.environTag)
 }
 
-func (s *mockAPIState) ServerTag() (names.EnvironTag, error) {
-	return names.EnvironTag{}, errors.NotImplementedf("ServerTag")
+func (s *mockAPIState) ControllerTag() (names.EnvironTag, error) {
+	return names.EnvironTag{}, errors.NotImplementedf("ControllerTag")
 }
 
 func panicAPIOpen(apiInfo *api.Info, opts api.DialOpts) (api.Connection, error) {

--- a/state/environ.go
+++ b/state/environ.go
@@ -190,9 +190,9 @@ func (e *Environment) EnvironTag() names.EnvironTag {
 	return names.NewEnvironTag(e.doc.UUID)
 }
 
-// ServerTag is the environ tag for the server that the environment is running
-// within.
-func (e *Environment) ServerTag() names.EnvironTag {
+// ControllerTag is the environ tag for the controller that the environment is
+// running within.
+func (e *Environment) ControllerTag() names.EnvironTag {
 	return names.NewEnvironTag(e.doc.ServerUUID)
 }
 

--- a/state/environ_test.go
+++ b/state/environ_test.go
@@ -30,7 +30,7 @@ func (s *EnvironSuite) TestEnvironment(c *gc.C) {
 
 	expectedTag := names.NewEnvironTag(env.UUID())
 	c.Assert(env.Tag(), gc.Equals, expectedTag)
-	c.Assert(env.ServerTag(), gc.Equals, expectedTag)
+	c.Assert(env.ControllerTag(), gc.Equals, expectedTag)
 	c.Assert(env.Name(), gc.Equals, "testenv")
 	c.Assert(env.Owner(), gc.Equals, s.Owner)
 	c.Assert(env.Life(), gc.Equals, state.Alive)
@@ -94,7 +94,7 @@ func (s *EnvironSuite) TestNewEnvironment(c *gc.C) {
 	assertEnvMatches := func(env *state.Environment) {
 		c.Assert(env.UUID(), gc.Equals, envTag.Id())
 		c.Assert(env.Tag(), gc.Equals, envTag)
-		c.Assert(env.ServerTag(), gc.Equals, s.envTag)
+		c.Assert(env.ControllerTag(), gc.Equals, s.envTag)
 		c.Assert(env.Owner(), gc.Equals, owner)
 		c.Assert(env.Name(), gc.Equals, "testing")
 		c.Assert(env.Life(), gc.Equals, state.Alive)
@@ -129,7 +129,7 @@ func (s *EnvironSuite) TestStateServerEnvironment(c *gc.C) {
 
 	expectedTag := names.NewEnvironTag(env.UUID())
 	c.Assert(env.Tag(), gc.Equals, expectedTag)
-	c.Assert(env.ServerTag(), gc.Equals, expectedTag)
+	c.Assert(env.ControllerTag(), gc.Equals, expectedTag)
 	c.Assert(env.Name(), gc.Equals, "testenv")
 	c.Assert(env.Owner(), gc.Equals, s.Owner)
 	c.Assert(env.Life(), gc.Equals, state.Alive)

--- a/state/open.go
+++ b/state/open.go
@@ -229,7 +229,7 @@ func isUnauthorized(err error) bool {
 }
 
 // newState creates an incomplete *State, with a configured watcher but no
-// pwatcher, leadershipManager, or serverTag. You must start() the returned
+// pwatcher, leadershipManager, or controllerTag. You must start() the returned
 // *State before it will function correctly.
 func newState(environTag names.EnvironTag, session *mgo.Session, mongoInfo *mongo.MongoInfo, policy Policy) (_ *State, resultErr error) {
 	// Set up database.

--- a/state/state.go
+++ b/state/state.go
@@ -59,12 +59,12 @@ const (
 // State represents the state of an environment
 // managed by juju.
 type State struct {
-	environTag names.EnvironTag
-	serverTag  names.EnvironTag
-	mongoInfo  *mongo.MongoInfo
-	session    *mgo.Session
-	database   Database
-	policy     Policy
+	environTag    names.EnvironTag
+	controllerTag names.EnvironTag
+	mongoInfo     *mongo.MongoInfo
+	session       *mgo.Session
+	database      Database
+	policy        Policy
 
 	// TODO(fwereade): move these out of state and make them independent
 	// workers on which state depends.
@@ -99,7 +99,7 @@ type StateServingInfo struct {
 // IsStateServer returns true if this state instance has the bootstrap
 // environment UUID.
 func (st *State) IsStateServer() bool {
-	return st.environTag == st.serverTag
+	return st.environTag == st.controllerTag
 }
 
 // RemoveAllEnvironDocs removes all documents from multi-environment
@@ -162,16 +162,16 @@ func (st *State) ForEnviron(env names.EnvironTag) (*State, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	if err := newState.start(st.serverTag); err != nil {
+	if err := newState.start(st.controllerTag); err != nil {
 		return nil, errors.Trace(err)
 	}
 	return newState, nil
 }
 
 // start starts the presence watcher, leadership manager and images metadata storage,
-// and fills in the serverTag field with the supplied value.
-func (st *State) start(serverTag names.EnvironTag) error {
-	st.serverTag = serverTag
+// and fills in the controllerTag field with the supplied value.
+func (st *State) start(controllerTag names.EnvironTag) error {
+	st.controllerTag = controllerTag
 
 	var clientId string
 	if identity := st.mongoInfo.Tag; identity != nil {

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -1367,7 +1367,7 @@ func (s *upgradesSuite) TestSetOwnerAndServerUUIDForEnvironment(c *gc.C) {
 	// Make sure it is there now
 	env, err = s.state.Environment()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(env.ServerTag().Id(), gc.Equals, env.UUID())
+	c.Assert(env.ControllerTag().Id(), gc.Equals, env.UUID())
 	c.Assert(env.Owner().Id(), gc.Equals, "admin@local")
 }
 
@@ -1381,7 +1381,7 @@ func (s *upgradesSuite) TestSetOwnerAndServerUUIDForEnvironmentIdempotent(c *gc.
 	// Check as expected
 	env, err := s.state.Environment()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(env.ServerTag().Id(), gc.Equals, env.UUID())
+	c.Assert(env.ControllerTag().Id(), gc.Equals, env.UUID())
 	c.Assert(env.Owner().Id(), gc.Equals, "admin@local")
 }
 


### PR DESCRIPTION
This branch renames the ServerTag functions to be ControllerTag.

The main interesting bit is the params structure returned from LoginResposneV1. This still serializes the ControllerTag as 'server-tag' as this shouldn't change.  When we make the next version of the login response, we can change the serialization format.

A follow-up branch will handle the serverUUID values.

(Review request: http://reviews.vapour.ws/r/3011/)