### PR TITLE
Support using local LXD as remote.

### DIFF
--- a/container/lxd/lxdclient/addserver.go
+++ b/container/lxd/lxdclient/addserver.go
@@ -1,6 +1,8 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// +build go1.3
+
 package lxdclient
 
 import (

--- a/container/lxd/lxdclient/addserver.go
+++ b/container/lxd/lxdclient/addserver.go
@@ -13,12 +13,16 @@ import (
 	"github.com/lxc/lxd/shared"
 )
 
+// TODO(ericsnow) This file should be removed as soon as possible.
+// It is copied from https://github.com/lxc/lxd/blob/master/lxc/remote.go
+// and the code there should instead be exported so we could use it here.
+
 // TODO(ericsnow) Address licensing.
 
 // addServer adds the given remote info to the provided config.
-// The implementation is copied from:
+// The implementation is derived from:
 //  https://github.com/lxc/lxd/blob/master/lxc/remote.go
-// TODO(ericsnow) Remove this once the lxd code exports it.
+// Note that some validation code was removed (we don't need it).
 func addServer(config *lxd.Config, server string, addr string) error {
 	addr, err := fixAddr(addr)
 	if err != nil {
@@ -35,6 +39,8 @@ func addServer(config *lxd.Config, server string, addr string) error {
 	return nil
 }
 
+// fixAddr is the portion of the original addServer function that fixes
+// up the provided addr to be a fully qualified URL.
 func fixAddr(addr string) (string, error) {
 	var r_scheme string
 	var r_host string

--- a/container/lxd/lxdclient/addserver.go
+++ b/container/lxd/lxdclient/addserver.go
@@ -14,15 +14,16 @@ import (
 )
 
 // TODO(ericsnow) This file should be removed as soon as possible.
-// It is copied from https://github.com/lxc/lxd/blob/master/lxc/remote.go
-// and the code there should instead be exported so we could use it here.
+// It is based on https://github.com/lxc/lxd/blob/master/lxc/remote.go
+// and the code there should instead be cleaned up and exported so we
+// could use it here.
 
 // TODO(ericsnow) Address licensing.
 
 // addServer adds the given remote info to the provided config.
 // The implementation is derived from:
 //  https://github.com/lxc/lxd/blob/master/lxc/remote.go
-// Note that some validation code was removed (we don't need it).
+// Note that we've removed some validation code (we don't need it).
 func addServer(config *lxd.Config, server string, addr string) error {
 	addr, err := fixAddr(addr)
 	if err != nil {

--- a/container/lxd/lxdclient/addserver.go
+++ b/container/lxd/lxdclient/addserver.go
@@ -7,23 +7,17 @@ import (
 	"fmt"
 	"net"
 	"net/url"
+	"strconv"
 	"strings"
 
+	"github.com/juju/errors"
 	"github.com/lxc/lxd"
 	"github.com/lxc/lxd/shared"
 )
 
-// TODO(ericsnow) This file should be removed as soon as possible.
-// It is based on https://github.com/lxc/lxd/blob/master/lxc/remote.go
-// and the code there should instead be cleaned up and exported so we
-// could use it here.
-
-// TODO(ericsnow) Address licensing.
-
 // addServer adds the given remote info to the provided config.
-// The implementation is derived from:
+// The implementation is based loosely on:
 //  https://github.com/lxc/lxd/blob/master/lxc/remote.go
-// Note that we've removed some validation code (we don't need it).
 func addServer(config *lxd.Config, server string, addr string) error {
 	addr, err := fixAddr(addr, shared.PathExists)
 	if err != nil {
@@ -41,80 +35,180 @@ func addServer(config *lxd.Config, server string, addr string) error {
 	return nil
 }
 
-// fixAddr is the portion of the original addServer function that fixes
-// up the provided addr to be a fully qualified URL.
 func fixAddr(addr string, pathExists func(string) bool) (string, error) {
-	if addr == "" {
+	if addr == "" || addr == "unix://" {
 		// TODO(ericsnow) Return lxd.LocalRemote.Addr?
 		return addr, nil
 	}
 
+	if strings.HasPrefix(addr, ":") {
+		parts := strings.SplitN(addr, "/", 2)
+		if net.ParseIP(parts[0]) != nil {
+			addr = fmt.Sprintf("[%s]", parts[0])
+			if len(parts) == 2 {
+				addr = "/" + parts[1]
+			}
+		}
+	}
+
+	if strings.HasPrefix(addr, "//") {
+		addr = addr[2:]
+	} else if strings.HasPrefix(addr, "unix://") {
+		addr = addr[len("unix://"):]
+	}
+
 	parsedURL, err := url.Parse(addr)
 	if err != nil {
-		return "", err
+		return "", errors.Trace(err)
 	}
+	if parsedURL.RawQuery != "" {
+		return "", errors.NewNotValid(nil, fmt.Sprintf("URL queries not supported (got %q)", addr))
+	}
+	if parsedURL.Fragment != "" {
+		return "", errors.NewNotValid(nil, fmt.Sprintf("URL fragments not supported (got %q)", addr))
+	}
+	if parsedURL.Opaque != "" {
+		if strings.Contains(parsedURL.Scheme, ".") {
+			addr, err := fixAddr("https://"+addr, pathExists)
+			if err != nil {
+				return "", errors.Trace(err)
+			}
+			return addr, nil
+		}
+		return "", errors.NewNotValid(nil, fmt.Sprintf("opaque URLs not supported (got %q)", addr))
+	}
+
 	remoteURL := url.URL{
 		Scheme: parsedURL.Scheme,
 		Host:   parsedURL.Host,
-		//Path:   parsedURL.Path,
+		Path:   strings.TrimRight(parsedURL.Path, "/"),
 	}
 
 	// Fix the scheme.
-	switch remoteURL.Scheme {
-	case "https":
-	case "unix":
-	case "":
-		// TODO(ericsnow) Decided based on whether or not Host is set?
-		remoteURL.Scheme = "https"
-		// TODO(ericsnow) Use remoteURL.Path/.Opaque here instead of addr.
-		if addr[0] == '/' || pathExists(addr) {
-			remoteURL.Scheme = "unix"
-		}
-	default:
-		// TODO(ericsnow) Fail by default?
-		remoteURL.Scheme = "https"
+	remoteURL.Scheme = fixScheme(remoteURL, pathExists)
+	if err := validateScheme(remoteURL); err != nil {
+		return "", errors.Trace(err)
 	}
 
 	// Fix the host.
-	if remoteURL.Host == "" {
-		// TODO(ericsnow) Instead, make use of Path and Opaque below.
-		remoteURL.Host = addr
-	}
-	host, port, err := net.SplitHostPort(remoteURL.Host)
-	if err != nil {
-		port = shared.DefaultPort
-	} else {
-		remoteURL.Host = host
-	}
-
-	// Special-case "unix".
 	if remoteURL.Scheme == "unix" {
-		// TODO(ericsnow) All this could be done earlier.
-		// TODO(ericsnow) Use Path and Opaque instead of addr.
-		if addr[0:5] == "unix:" {
-			if len(addr) > 6 && addr[0:7] == "unix://" {
-				if len(addr) > 8 {
-					remoteURL.Host = addr[8:]
-				} else {
-					remoteURL.Host = ""
-				}
-			} else {
-				remoteURL.Host = addr[6:]
-			}
+		if remoteURL.Host != "" {
+			return "", errors.NewNotValid(nil, fmt.Sprintf("invalid unix socket URL (got %q)", addr))
 		}
-		port = ""
+		remoteURL.Host = remoteURL.Path
+		remoteURL.Path = ""
+	} else {
+		if remoteURL.Host == "" {
+			addr = fmt.Sprintf("%s://%s%s", remoteURL.Scheme, remoteURL.Host, remoteURL.Path)
+			addr, err := fixAddr(addr, pathExists)
+			if err != nil {
+				return "", errors.Trace(err)
+			}
+			return addr, nil
+		}
+		remoteURL.Host = fixHost(remoteURL.Host, shared.DefaultPort)
+		if err := validateHost(remoteURL); err != nil {
+			return "", errors.Trace(err)
+		}
 	}
 
-	// Handle IPv6 hosts.
-	if strings.Contains(remoteURL.Host, ":") && !strings.HasPrefix(remoteURL.Host, "[") {
-		remoteURL.Host = fmt.Sprintf("[%s]", remoteURL.Host)
-	}
-
-	// Add the port, if applicable.
-	if port != "" {
-		remoteURL.Host += ":" + port
+	// Do some final validation.
+	if remoteURL.Scheme == "unix" {
+		if !strings.HasPrefix(remoteURL.Host, "/") {
+			return "", errors.NewNotValid(nil, fmt.Sprintf("relative unix socket paths not supported (got %q)", addr))
+		}
+		if !pathExists(remoteURL.Host) {
+			return "", errors.NewNotValid(nil, fmt.Sprintf("unix socket file %q not found", remoteURL.Host))
+		}
 	}
 
 	// TODO(ericsnow) Use remoteUrl.String()
-	return fmt.Sprintf("%s://%s", remoteURL.Scheme, remoteURL.Host), nil
+	return fmt.Sprintf("%s://%s%s", remoteURL.Scheme, remoteURL.Host, remoteURL.Path), nil
+}
+
+func fixScheme(url url.URL, pathExists func(string) bool) string {
+	switch url.Scheme {
+	case "unix":
+		return url.Scheme
+	case "https":
+		return url.Scheme
+	case "http":
+		return "https"
+	case "":
+		if url.Host != "" {
+			return "https"
+		}
+		if strings.HasPrefix(url.Path, "/") {
+			return "unix"
+		}
+		if pathExists(url.Path) {
+			return "unix"
+		}
+		return "https"
+	default:
+		return url.Scheme
+	}
+}
+
+func validateScheme(url url.URL) error {
+	switch url.Scheme {
+	case "unix":
+	case "https":
+	case "http":
+	default:
+		return errors.NewNotValid(nil, fmt.Sprintf("unsupported URL scheme %q", url.Scheme))
+	}
+	return nil
+}
+
+func fixHost(host, defaultPort string) string {
+	// Handle IPv6 hosts.
+	if strings.Count(host, ":") > 1 {
+		if !strings.HasPrefix(host, "[") {
+			return fmt.Sprintf("[%s]:%s", host, defaultPort)
+		} else if !strings.Contains(host, "]:") {
+			return host + ":" + defaultPort
+		}
+		return host
+	}
+
+	// Handle ports.
+	if !strings.Contains(host, ":") {
+		return host + ":" + defaultPort
+	}
+
+	return host
+}
+
+func validateHost(url url.URL) error {
+	if url.Host == "" {
+		return errors.NewNotValid(nil, "URL missing host")
+	}
+
+	host, port, err := net.SplitHostPort(url.Host)
+	if err != nil {
+		return errors.NewNotValid(err, "")
+	}
+
+	// Check the host.
+	if net.ParseIP(host) == nil {
+		if err := validateDomainName(host); err != nil {
+			return errors.Trace(err)
+		}
+	}
+
+	// Check the port.
+	if p, err := strconv.Atoi(port); err != nil {
+		return errors.NewNotValid(err, fmt.Sprintf("invalid port in host %q", url.Host))
+	} else if p <= 0 || p > 0xFFFF {
+		return errors.NewNotValid(err, fmt.Sprintf("invalid port in host %q", url.Host))
+	}
+
+	return nil
+}
+
+func validateDomainName(fqdn string) error {
+	// TODO(ericsnow) Do checks for a valid domain name.
+
+	return nil
 }

--- a/container/lxd/lxdclient/addserver.go
+++ b/container/lxd/lxdclient/addserver.go
@@ -34,6 +34,7 @@ func addServer(config *lxd.Config, server string, addr string) error {
 	}
 
 	/* Actually add the remote */
+	// TODO(ericsnow) Fail on collision?
 	config.Remotes[server] = lxd.RemoteConfig{Addr: addr}
 
 	return nil

--- a/container/lxd/lxdclient/addserver_test.go
+++ b/container/lxd/lxdclient/addserver_test.go
@@ -1,6 +1,8 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// +build go1.3
+
 package lxdclient
 
 import (

--- a/container/lxd/lxdclient/addserver_test.go
+++ b/container/lxd/lxdclient/addserver_test.go
@@ -1,0 +1,135 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package lxdclient
+
+import (
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	//"github.com/lxc/lxd"
+	gc "gopkg.in/check.v1"
+)
+
+var _ = gc.Suite(&fixAddrSuite{})
+
+type fixAddrSuite struct {
+	testing.IsolationSuite
+}
+
+type addrTest struct {
+	addr     string
+	exists   bool
+	expected string
+	err      string
+}
+
+func (t addrTest) pathExists(path string) bool {
+	return t.exists
+}
+
+var addrTests = []addrTest{{
+	addr:     "",
+	expected: "",
+}, {
+	// the typical remote case
+	addr:     "https://x.y.z",
+	expected: "https://x.y.z:8443",
+}, {
+	addr:     "https://x.y.z/",
+	expected: "https://x.y.z:8443",
+}, {
+	addr:     "https://x.y.z:1234",
+	expected: "https://x.y.z:1234",
+}, {
+	addr:     "https://x.y.z/:1234",
+	expected: "https://x.y.z:8443",
+}, {
+	addr:     "https://x.y.z/a/b/c",
+	expected: "https://x.y.z:8443",
+}, {
+	addr:     "https://x.y.z/a/b/c",
+	expected: "https://x.y.z:8443",
+}, {
+	addr:     "http://x.y.z",
+	expected: "https://x.y.z:8443",
+}, {
+	addr:     "http://x.y.z/a/b/c",
+	expected: "https://x.y.z:8443",
+}, {
+	addr:     "http://x.y.z/a/b/c:1234",
+	expected: "https://x.y.z:8443",
+}, {
+	addr:     "spam://x.y.z/a/b/c",
+	expected: "https://x.y.z:8443",
+}, {
+	addr:     "2001:db8::ff00:42:8329/a/b/c",
+	expected: "https://[2001:db8::ff00:42:8329/a/b/c]:8443",
+}, {
+	addr:     "https://2001:db8::ff00:42:8329/a/b/c",
+	expected: "https://[2001:db8::ff00:42:8329]:8443",
+}, {
+	addr:     "https://[2001:db8::ff00:42:8329]/a/b/c",
+	expected: "https://[2001:db8::ff00:42:8329]:8443",
+}, {
+	addr:     "//x.y.z/a/b/c",
+	expected: "unix://x.y.z",
+}, {
+	addr:     "/xyz/a/b/c",
+	expected: "unix:///xyz/a/b/c",
+}, {
+	addr:     "x.y.z/a/b/c",
+	exists:   true,
+	expected: "unix://x.y.z/a/b/c",
+}, {
+	addr:     "xyz/a/b/c",
+	exists:   true,
+	expected: "unix://xyz/a/b/c",
+}, {
+	addr:     "x.y.z/a/b/c",
+	exists:   false,
+	expected: "https://x.y.z/a/b/c:8443",
+}, {
+	addr:     "xyz/a/b/c",
+	exists:   false,
+	expected: "https://xyz/a/b/c:8443",
+}, {
+	// the default local case
+	addr:     "unix://",
+	expected: "unix://",
+}, {
+	addr:     "unix:/",
+	expected: "unix://",
+}, {
+	addr:     "unix://x/y/z",
+	expected: "unix:///y/z",
+}, {
+	addr:     "unix:///x/y/z",
+	expected: "unix://x/y/z",
+}, {
+	addr:     "unix:/x/y/z",
+	expected: "unix://x/y/z",
+}, {
+	addr:     "unix:/x/y/z:8443",
+	expected: "unix://[x/y/z:8443]",
+}, {
+	// a malformed URL
+	addr: ":x.y.z",
+	err:  `.*`,
+}}
+
+func (s *fixAddrSuite) TestFixAddr(c *gc.C) {
+	for i, test := range addrTests {
+		c.Logf("test %d: checking %q (exists: %v)", i, test.addr, test.exists)
+
+		fixed, err := fixAddr(test.addr, test.pathExists)
+
+		if test.err == "" {
+			if !c.Check(err, jc.ErrorIsNil) {
+				continue
+			}
+			c.Check(fixed, gc.Equals, test.expected)
+		} else {
+			c.Check(err, gc.ErrorMatches, test.err)
+		}
+	}
+}

--- a/container/lxd/lxdclient/addserver_test.go
+++ b/container/lxd/lxdclient/addserver_test.go
@@ -30,26 +30,59 @@ var typicalAddrTests = []addrTest{{
 	addr:     "",
 	expected: "",
 }, {
-	addr:     "https://x.y.z",
-	expected: "https://x.y.z:8443",
+	addr:     "unix://",
+	expected: "unix://",
 }, {
-	addr:     "https://x.y.z/",
-	expected: "https://x.y.z:8443",
+	addr:     "a.b.c",
+	exists:   false,
+	expected: "https://a.b.c:8443",
 }, {
-	addr:     "https://x.y.z:1234",
-	expected: "https://x.y.z:1234",
+	addr:     "https://a.b.c",
+	expected: "https://a.b.c:8443",
 }, {
-	addr:     "http://x.y.z",
-	expected: "https://x.y.z:8443",
+	addr:     "https://a.b.c/",
+	expected: "https://a.b.c:8443",
+}, {
+	addr:     "a.b.c:1234",
+	exists:   false,
+	expected: "https://a.b.c:1234",
+}, {
+	addr:     "https://a.b.c:1234",
+	expected: "https://a.b.c:1234",
+}, {
+	addr:     "https://a.b.c:1234/",
+	expected: "https://a.b.c:1234",
+}, {
+	addr:     "a.b.c/x/y/z",
+	exists:   false,
+	expected: "https://a.b.c:8443/x/y/z",
+}, {
+	addr:     "https://a.b.c/x/y/z",
+	expected: "https://a.b.c:8443/x/y/z",
+}, {
+	addr:     "https://a.b.c:1234/x/y/z",
+	expected: "https://a.b.c:1234/x/y/z",
+}, {
+	addr:     "http://a.b.c",
+	expected: "https://a.b.c:8443",
 }, {
 	addr:     "1.2.3.4",
 	expected: "https://1.2.3.4:8443",
 }, {
+	addr:     "1.2.3.4:1234",
+	expected: "https://1.2.3.4:1234",
+}, {
 	addr:     "https://1.2.3.4",
 	expected: "https://1.2.3.4:8443",
 }, {
+	addr:     "127.0.0.1",
+	expected: "https://127.0.0.1:8443",
+}, {
 	addr:     "2001:db8::ff00:42:8329",
 	expected: "https://[2001:db8::ff00:42:8329]:8443",
+}, {
+	addr:     "[2001:db8::ff00:42:8329]:1234",
+	expected: "https://[2001:db8::ff00:42:8329]:1234",
 }, {
 	addr:     "https://2001:db8::ff00:42:8329",
 	expected: "https://[2001:db8::ff00:42:8329]:8443",
@@ -57,27 +90,24 @@ var typicalAddrTests = []addrTest{{
 	addr:     "https://[2001:db8::ff00:42:8329]:1234",
 	expected: "https://[2001:db8::ff00:42:8329]:1234",
 }, {
-	addr:     "unix://",
-	expected: "unix://",
+	addr:     "::1",
+	expected: "https://[::1]:8443",
 }, {
-	// TODO(ericsnow) Expect 3 slashes?
 	addr:     "unix:///x/y/z",
-	expected: "unix://x/y/z",
-}, {
-	// TODO(ericsnow) Expect 3 slashes?
-	addr:     "unix:/x/y/z",
-	expected: "unix://x/y/z",
-}, {
-	addr:     "/x/y/z",
+	exists:   true,
 	expected: "unix:///x/y/z",
 }, {
-	addr:     "x/y/z",
+	addr:     "unix:/x/y/z",
 	exists:   true,
-	expected: "unix://x/y/z",
+	expected: "unix:///x/y/z",
 }, {
-	addr:     "x.y.z",
+	addr:     "/x/y/z",
+	exists:   true,
+	expected: "unix:///x/y/z",
+}, {
+	addr:     "a.b.c",
 	exists:   false,
-	expected: "https://x.y.z:8443",
+	expected: "https://a.b.c:8443",
 }}
 
 func (s *fixAddrSuite) TestFixAddrTypical(c *gc.C) {
@@ -94,10 +124,47 @@ func (s *fixAddrSuite) TestFixAddrTypical(c *gc.C) {
 	}
 }
 
+// TODO(ericsnow) Add failure tests for bad domain names
+// and IP addresses (v4/v6).
+
 var failureAddrTests = []addrTest{{
 	// a malformed URL
-	addr: ":x.y.z",
+	addr: ":a.b.c",
 	err:  `.*`,
+}, {
+	addr: "https://a.b.c:xyz",
+	err:  `.*invalid port.*`,
+}, {
+	addr: "https://a.b.c:0",
+	err:  `.*invalid port.*`,
+}, {
+	addr: "https://a.b.c:99999",
+	err:  `.*invalid port.*`,
+}, {
+	addr: "spam://a.b.c",
+	err:  `.*unsupported URL scheme.*`,
+}, {
+	addr: "https://a.b.c?d=e",
+	err:  `.*URL queries not supported.*`,
+}, {
+	addr: "https://a.b.c#d",
+	err:  `.*URL fragments not supported.*`,
+}, {
+	addr:   "/x/y/z",
+	exists: false,
+	err:    `.*unix socket file .* not found.*`,
+}, {
+	addr:   "x/y/z",
+	exists: true,
+	err:    `.*relative unix socket paths not supported \(got "x/y/z"\).*`,
+}, {
+	addr:   "//x/y/z",
+	exists: true,
+	err:    `.*relative unix socket paths not supported \(got "x/y/z"\).*`,
+}, {
+	addr:   "unix://x/y/z",
+	exists: true,
+	err:    `.*relative unix socket paths not supported \(got "x/y/z"\).*`,
 }}
 
 func (s *fixAddrSuite) TestFixAddrFailures(c *gc.C) {
@@ -108,72 +175,5 @@ func (s *fixAddrSuite) TestFixAddrFailures(c *gc.C) {
 		_, err := fixAddr(test.addr, test.pathExists)
 
 		c.Check(err, gc.ErrorMatches, test.err)
-	}
-}
-
-var weirdAddrTests = []addrTest{{
-	addr:     "https://x.y.z/:1234",
-	expected: "https://x.y.z:8443",
-}, {
-	addr:     "https://x.y.z/a/b/c",
-	expected: "https://x.y.z:8443",
-}, {
-	addr:     "https://x.y.z/a/b/c",
-	expected: "https://x.y.z:8443",
-}, {
-	addr:     "http://x.y.z/a/b/c",
-	expected: "https://x.y.z:8443",
-}, {
-	addr:     "http://x.y.z/a/b/c:1234",
-	expected: "https://x.y.z:8443",
-}, {
-	addr:     "spam://x.y.z/a/b/c",
-	expected: "https://x.y.z:8443",
-}, {
-	addr:     "2001:db8::ff00:42:8329/a/b/c",
-	expected: "https://[2001:db8::ff00:42:8329/a/b/c]:8443",
-}, {
-	addr:     "https://2001:db8::ff00:42:8329/a/b/c",
-	expected: "https://[2001:db8::ff00:42:8329]:8443",
-}, {
-	addr:     "https://[2001:db8::ff00:42:8329]/a/b/c",
-	expected: "https://[2001:db8::ff00:42:8329]:8443",
-}, {
-	addr:     "//a.b.c/x/y/z",
-	expected: "unix://a.b.c",
-}, {
-	addr:     "a.b.c/x/y/z",
-	exists:   true,
-	expected: "unix://a.b.c/x/y/z",
-}, {
-	addr:     "x.y.z/a/b/c",
-	exists:   false,
-	expected: "https://x.y.z/a/b/c:8443",
-}, {
-	addr:     "xyz/a/b/c",
-	exists:   false,
-	expected: "https://xyz/a/b/c:8443",
-}, {
-	addr:     "unix:/",
-	expected: "unix://",
-}, {
-	addr:     "unix://x/y/z",
-	expected: "unix:///y/z",
-}, {
-	addr:     "unix:/x/y/z:8443",
-	expected: "unix://[x/y/z:8443]",
-}}
-
-func (s *fixAddrSuite) TestFixAddrWeird(c *gc.C) {
-	for i, test := range weirdAddrTests {
-		c.Logf("test %d: checking %q (exists: %v)", i, test.addr, test.exists)
-		c.Assert(test.err, gc.Equals, "")
-
-		fixed, err := fixAddr(test.addr, test.pathExists)
-
-		if !c.Check(err, jc.ErrorIsNil) {
-			continue
-		}
-		c.Check(fixed, gc.Equals, test.expected)
 	}
 }

--- a/container/lxd/lxdclient/cert.go
+++ b/container/lxd/lxdclient/cert.go
@@ -1,6 +1,8 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// +build go1.3
+
 package lxdclient
 
 import (

--- a/container/lxd/lxdclient/cert.go
+++ b/container/lxd/lxdclient/cert.go
@@ -53,6 +53,8 @@ func NewCert(certPEM, keyPEM []byte) Cert {
 // SetDefaults updates a copy of the remote with default values
 // where needed.
 func (cert Cert) SetDefaults() (*Cert, error) {
+	// Note that cert is a value receiver, so it is an implicit copy.
+
 	if cert.Name == "" {
 		// TODO(ericsnow) Use x509.Certificate.Subject for the default?
 		cert.Name = certDefaultName

--- a/container/lxd/lxdclient/cert.go
+++ b/container/lxd/lxdclient/cert.go
@@ -75,7 +75,7 @@ func (cert Cert) WriteKeyPEM(out io.Writer) error {
 }
 
 // Fingerprint returns the cert's LXD fingerprint.
-func (cert Certificate) Fingerprint() (string, error) {
+func (cert Cert) Fingerprint() (string, error) {
 	// See: https://github.com/lxc/lxd/blob/master/lxd/certificates.go
 	x509Cert, err := cert.X509()
 	if err != nil {

--- a/container/lxd/lxdclient/cert.go
+++ b/container/lxd/lxdclient/cert.go
@@ -42,9 +42,9 @@ type Cert struct {
 	KeyPEM []byte
 }
 
-// NewCert creates a new Cert for the given cert and key.
-func NewCert(certPEM, keyPEM []byte) *Cert {
-	return &Cert{
+// NewCertificate creates a new Certificate for the given cert and key.
+func NewCert(certPEM, keyPEM []byte) Cert {
+	return Cert{
 		CertPEM: certPEM,
 		KeyPEM:  keyPEM,
 	}

--- a/container/lxd/lxdclient/cert.go
+++ b/container/lxd/lxdclient/cert.go
@@ -6,6 +6,8 @@
 package lxdclient
 
 import (
+	"crypto/x509"
+	"encoding/pem"
 	"io"
 	"io/ioutil"
 	"os"
@@ -68,6 +70,21 @@ func (cert Cert) WriteKeyPEM(out io.Writer) error {
 		return errors.Trace(err)
 	}
 	return nil
+}
+
+// X509 returns the x.509 certificate.
+func (cert Cert) X509() (*x509.Certificate, error) {
+	block, _ := pem.Decode(cert.CertPEM)
+	if block == nil {
+		return nil, errors.Errorf("invalid cert PEM (%d bytes)", len(cert.CertPEM))
+	}
+
+	x509Cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	return x509Cert, nil
 }
 
 func genCertAndKey() ([]byte, []byte, error) {

--- a/container/lxd/lxdclient/cert.go
+++ b/container/lxd/lxdclient/cert.go
@@ -16,11 +16,6 @@ import (
 const (
 	tempPrefix = "juju-lxd-"
 
-	// See readMyCert() in:
-	//  https://github.com/lxc/lxd/blob/master/client.go
-	authCertFile = "client.crt"
-	authKeyFile  = "client.key"
-
 	pemBlockTypeCert = "CERTIFICATE"
 	pemBlockTypeKey  = "RSA PRIVATE KEY"
 )
@@ -63,8 +58,8 @@ func genCertAndKey() ([]byte, []byte, error) {
 		return nil, nil, errors.Trace(err)
 	}
 	defer os.RemoveAll(tempdir)
-	certFile := filepath.Join(tempdir, authCertFile)
-	keyFile := filepath.Join(tempdir, authKeyFile)
+	certFile := filepath.Join(tempdir, configCertFile)
+	keyFile := filepath.Join(tempdir, configKeyFile)
 	if err := shared.GenCert(certFile, keyFile); err != nil {
 		return nil, nil, errors.Trace(err)
 	}

--- a/container/lxd/lxdclient/cert.go
+++ b/container/lxd/lxdclient/cert.go
@@ -50,9 +50,9 @@ func NewCert(certPEM, keyPEM []byte) Cert {
 	}
 }
 
-// SetDefaults updates a copy of the remote with default values
+// WithDefaults updates a copy of the remote with default values
 // where needed.
-func (cert Cert) SetDefaults() (Cert, error) {
+func (cert Cert) WithDefaults() (Cert, error) {
 	// Note that cert is a value receiver, so it is an implicit copy.
 
 	if cert.Name == "" {

--- a/container/lxd/lxdclient/cert.go
+++ b/container/lxd/lxdclient/cert.go
@@ -52,7 +52,7 @@ func NewCert(certPEM, keyPEM []byte) Cert {
 
 // SetDefaults updates a copy of the remote with default values
 // where needed.
-func (cert Cert) SetDefaults() (*Cert, error) {
+func (cert Cert) SetDefaults() (Cert, error) {
 	// Note that cert is a value receiver, so it is an implicit copy.
 
 	if cert.Name == "" {
@@ -62,7 +62,7 @@ func (cert Cert) SetDefaults() (*Cert, error) {
 
 	// TODO(ericsnow) populate cert/key (use genCertAndKey)?
 
-	return &cert, nil
+	return cert, nil
 }
 
 // Validate ensures that the cert is valid.

--- a/container/lxd/lxdclient/cert.go
+++ b/container/lxd/lxdclient/cert.go
@@ -24,6 +24,9 @@ const (
 
 	pemBlockTypeCert = "CERTIFICATE"
 	pemBlockTypeKey  = "RSA PRIVATE KEY"
+
+	// TODO(ericsnow) Is this the right default?
+	certDefaultName = configCertFile
 )
 
 // Cert holds the information for a single certificate a client
@@ -45,6 +48,18 @@ func NewCert(certPEM, keyPEM []byte) *Cert {
 		CertPEM: certPEM,
 		KeyPEM:  keyPEM,
 	}
+}
+
+// SetDefaults updates a copy of the remote with default values
+// where needed.
+func (cert Cert) SetDefaults() (*Cert, error) {
+	if cert.Name == "" {
+		cert.Name = certDefaultName
+	}
+
+	// TODO(ericsnow) populate cert/key (use genCertAndKey)?
+
+	return &cert, nil
 }
 
 // Validate ensures that the cert is valid.

--- a/container/lxd/lxdclient/cert.go
+++ b/container/lxd/lxdclient/cert.go
@@ -38,45 +38,6 @@ func NewCert(certPEM, keyPEM []byte) *Cert {
 	}
 }
 
-// GenerateCert creates a new LXD client certificate. It uses
-// the provided function to generate the raw data.
-func GenerateCert(genCertAndKey func() ([]byte, []byte, error)) (*Cert, error) {
-	certPEM, keyPEM, err := genCertAndKey()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	return NewCert(certPEM, keyPEM), nil
-}
-
-func genCertAndKey() ([]byte, []byte, error) {
-	// See GenCert() in:
-	//  https://github.com/lxc/lxd/blob/master/shared/cert.go
-	// TODO(ericsnow) Split up GenCert so it is more re-usable.
-	tempdir, err := ioutil.TempDir("", tempPrefix)
-	if err != nil {
-		return nil, nil, errors.Trace(err)
-	}
-	defer os.RemoveAll(tempdir)
-	certFile := filepath.Join(tempdir, configCertFile)
-	keyFile := filepath.Join(tempdir, configKeyFile)
-	if err := shared.GenCert(certFile, keyFile); err != nil {
-		return nil, nil, errors.Trace(err)
-	}
-
-	certPEM, err := ioutil.ReadFile(certFile)
-	if err != nil {
-		return nil, nil, errors.Trace(err)
-	}
-
-	keyPEM, err := ioutil.ReadFile(keyFile)
-	if err != nil {
-		return nil, nil, errors.Trace(err)
-	}
-
-	return certPEM, keyPEM, nil
-}
-
 // Validate ensures that the cert is valid.
 func (cert Cert) Validate() error {
 	if len(cert.CertPEM) == 0 {
@@ -105,4 +66,32 @@ func (cert Cert) WriteKeyPEM(out io.Writer) error {
 		return errors.Trace(err)
 	}
 	return nil
+}
+
+func genCertAndKey() ([]byte, []byte, error) {
+	// See GenCert() in:
+	//  https://github.com/lxc/lxd/blob/master/shared/cert.go
+	// TODO(ericsnow) Split up GenCert so it is more re-usable.
+	tempdir, err := ioutil.TempDir("", tempPrefix)
+	if err != nil {
+		return nil, nil, errors.Trace(err)
+	}
+	defer os.RemoveAll(tempdir)
+	certFile := filepath.Join(tempdir, configCertFile)
+	keyFile := filepath.Join(tempdir, configKeyFile)
+	if err := shared.GenCert(certFile, keyFile); err != nil {
+		return nil, nil, errors.Trace(err)
+	}
+
+	certPEM, err := ioutil.ReadFile(certFile)
+	if err != nil {
+		return nil, nil, errors.Trace(err)
+	}
+
+	keyPEM, err := ioutil.ReadFile(keyFile)
+	if err != nil {
+		return nil, nil, errors.Trace(err)
+	}
+
+	return certPEM, keyPEM, nil
 }

--- a/container/lxd/lxdclient/cert.go
+++ b/container/lxd/lxdclient/cert.go
@@ -54,6 +54,7 @@ func NewCert(certPEM, keyPEM []byte) *Cert {
 // where needed.
 func (cert Cert) SetDefaults() (*Cert, error) {
 	if cert.Name == "" {
+		// TODO(ericsnow) Use x509.Certificate.Subject for the default?
 		cert.Name = certDefaultName
 	}
 

--- a/container/lxd/lxdclient/cert.go
+++ b/container/lxd/lxdclient/cert.go
@@ -29,6 +29,9 @@ const (
 // Cert holds the information for a single certificate a client
 // may use to connect to a remote server.
 type Cert struct {
+	// Name is the name that LXD will use for the cert.
+	Name string
+
 	// CertPEM is the PEM-encoded x.509 cert.
 	CertPEM []byte
 

--- a/container/lxd/lxdclient/cert.go
+++ b/container/lxd/lxdclient/cert.go
@@ -20,9 +20,9 @@ const (
 	pemBlockTypeKey  = "RSA PRIVATE KEY"
 )
 
-// Certificate holds the information for a single certificate a client
+// Cert holds the information for a single certificate a client
 // may use to connect to a remote server.
-type Certificate struct {
+type Cert struct {
 	// CertPEM is the PEM-encoded x.509 cert.
 	CertPEM []byte
 
@@ -30,23 +30,23 @@ type Certificate struct {
 	KeyPEM []byte
 }
 
-// NewCertificate creates a new Certificate for the given cert and key.
-func NewCertificate(certPEM, keyPEM []byte) *Certificate {
-	return &Certificate{
+// NewCert creates a new Cert for the given cert and key.
+func NewCert(certPEM, keyPEM []byte) *Cert {
+	return &Cert{
 		CertPEM: certPEM,
 		KeyPEM:  keyPEM,
 	}
 }
 
-// GenerateCertificate creates a new LXD client certificate. It uses
+// GenerateCert creates a new LXD client certificate. It uses
 // the provided function to generate the raw data.
-func GenerateCertificate(genCertAndKey func() ([]byte, []byte, error)) (*Certificate, error) {
+func GenerateCert(genCertAndKey func() ([]byte, []byte, error)) (*Cert, error) {
 	certPEM, keyPEM, err := genCertAndKey()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 
-	return NewCertificate(certPEM, keyPEM), nil
+	return NewCert(certPEM, keyPEM), nil
 }
 
 func genCertAndKey() ([]byte, []byte, error) {
@@ -78,7 +78,7 @@ func genCertAndKey() ([]byte, []byte, error) {
 }
 
 // Validate ensures that the cert is valid.
-func (cert Certificate) Validate() error {
+func (cert Cert) Validate() error {
 	if len(cert.CertPEM) == 0 {
 		return errors.NotValidf("missing cert PEM")
 	}
@@ -92,7 +92,7 @@ func (cert Certificate) Validate() error {
 }
 
 // WriteCertPEM writes the cert's x.509 PEM data to the given writer.
-func (cert Certificate) WriteCertPEM(out io.Writer) error {
+func (cert Cert) WriteCertPEM(out io.Writer) error {
 	if _, err := out.Write(cert.CertPEM); err != nil {
 		return errors.Trace(err)
 	}
@@ -100,7 +100,7 @@ func (cert Certificate) WriteCertPEM(out io.Writer) error {
 }
 
 // WriteKeytPEM writes the key's x.509 PEM data to the given writer.
-func (cert Certificate) WriteKeyPEM(out io.Writer) error {
+func (cert Cert) WriteKeyPEM(out io.Writer) error {
 	if _, err := out.Write(cert.KeyPEM); err != nil {
 		return errors.Trace(err)
 	}

--- a/container/lxd/lxdclient/cert.go
+++ b/container/lxd/lxdclient/cert.go
@@ -6,8 +6,10 @@
 package lxdclient
 
 import (
+	"crypto/sha256"
 	"crypto/x509"
 	"encoding/pem"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
@@ -70,6 +72,17 @@ func (cert Cert) WriteKeyPEM(out io.Writer) error {
 		return errors.Trace(err)
 	}
 	return nil
+}
+
+// Fingerprint returns the cert's LXD fingerprint.
+func (cert Certificate) Fingerprint() (string, error) {
+	// See: https://github.com/lxc/lxd/blob/master/lxd/certificates.go
+	x509Cert, err := cert.X509()
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	data := sha256.Sum256(x509Cert.Raw)
+	return fmt.Sprintf("%x", data), nil
 }
 
 // X509 returns the x.509 certificate.

--- a/container/lxd/lxdclient/cert_test.go
+++ b/container/lxd/lxdclient/cert_test.go
@@ -93,6 +93,15 @@ func (s *certSuite) TestWritePEMs(c *gc.C) {
 	c.Check(pemfile.String(), gc.Equals, expected)
 }
 
+func (s *certSuite) TestFingerprint(c *gc.C) {
+	certPEM := []byte(testCertPEM)
+	cert := lxdclient.NewCertificate(certPEM, nil)
+	fingerprint, err := cert.Fingerprint()
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(fingerprint, gc.Equals, testCertFingerprint)
+}
+
 func (s *certSuite) TestX509Okay(c *gc.C) {
 	certPEM := []byte(testCertPEM)
 	cert := lxdclient.NewCert(certPEM, nil)
@@ -154,7 +163,8 @@ func checkValidCert(c *gc.C, cert *lxdclient.Cert) {
 }
 
 const (
-	testCertPEM = `
+	testCertFingerprint = "1c5156027fe71cfd0f7db807123e6873879f0f9754e08eab151f224783b2bff0"
+	testCertPEM         = `
 -----BEGIN CERTIFICATE-----
 MIIF0jCCA7qgAwIBAgIQEFjWOkN8qXNbWKtveG5ddTANBgkqhkiG9w0BAQsFADA2
 MRwwGgYDVQQKExNsaW51eGNvbnRhaW5lcnMub3JnMRYwFAYDVQQDDA1lc25vd0Bm

--- a/container/lxd/lxdclient/cert_test.go
+++ b/container/lxd/lxdclient/cert_test.go
@@ -128,14 +128,7 @@ func (s *certFunctionalSuite) TestGenerateCert(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	cert := lxdclient.NewCert(certPEM, keyPEM)
 
-	_, err = tls.X509KeyPair(cert.CertPEM, cert.KeyPEM)
-	c.Check(err, jc.ErrorIsNil)
-	block, remainder := pem.Decode(cert.CertPEM)
-	c.Check(block.Type, gc.Equals, "CERTIFICATE")
-	c.Check(remainder, gc.HasLen, 0)
-	block, remainder = pem.Decode(cert.KeyPEM)
-	c.Check(block.Type, gc.Equals, "RSA PRIVATE KEY")
-	c.Check(remainder, gc.HasLen, 0)
+	checkValidCert(c, cert)
 }
 
 func checkCert(c *gc.C, cert *lxdclient.Cert, certPEM, keyPEM []byte) {
@@ -145,6 +138,19 @@ func checkCert(c *gc.C, cert *lxdclient.Cert, certPEM, keyPEM []byte) {
 	})
 	c.Check(string(cert.CertPEM), gc.Equals, string(certPEM))
 	c.Check(string(cert.KeyPEM), gc.Equals, string(keyPEM))
+}
+
+func checkValidCert(c *gc.C, cert *lxdclient.Cert) {
+	_, err := tls.X509KeyPair(cert.CertPEM, cert.KeyPEM)
+	c.Check(err, jc.ErrorIsNil)
+
+	block, remainder := pem.Decode(cert.CertPEM)
+	c.Check(block.Type, gc.Equals, "CERTIFICATE")
+	c.Check(remainder, gc.HasLen, 0)
+
+	block, remainder = pem.Decode(cert.KeyPEM)
+	c.Check(block.Type, gc.Equals, "RSA PRIVATE KEY")
+	c.Check(remainder, gc.HasLen, 0)
 }
 
 const (

--- a/container/lxd/lxdclient/cert_test.go
+++ b/container/lxd/lxdclient/cert_test.go
@@ -93,6 +93,31 @@ func (s *certSuite) TestWritePEMs(c *gc.C) {
 	c.Check(pemfile.String(), gc.Equals, expected)
 }
 
+func (s *certSuite) TestX509Okay(c *gc.C) {
+	certPEM := []byte(testCertPEM)
+	cert := lxdclient.NewCert(certPEM, nil)
+	x509Cert, err := cert.X509()
+	c.Assert(err, jc.ErrorIsNil)
+
+	block, _ := pem.Decode(certPEM)
+	c.Assert(block, gc.NotNil)
+	c.Check(string(x509Cert.Raw), gc.Equals, string(block.Bytes))
+}
+
+func (s *certSuite) TestX509ZeroValue(c *gc.C) {
+	var cert lxdclient.Cert
+	_, err := cert.X509()
+
+	c.Check(err, gc.ErrorMatches, `invalid cert PEM \(0 bytes\)`)
+}
+
+func (s *certSuite) TestX509BadPEM(c *gc.C) {
+	cert := lxdclient.NewCert(s.certPEM, s.keyPEM)
+	_, err := cert.X509()
+
+	c.Check(err, gc.ErrorMatches, `invalid cert PEM \(\d+ bytes\)`)
+}
+
 type certFunctionalSuite struct {
 	lxdclient.BaseSuite
 }
@@ -121,3 +146,42 @@ func checkCert(c *gc.C, cert *lxdclient.Cert, certPEM, keyPEM []byte) {
 	c.Check(string(cert.CertPEM), gc.Equals, string(certPEM))
 	c.Check(string(cert.KeyPEM), gc.Equals, string(keyPEM))
 }
+
+const (
+	testCertPEM = `
+-----BEGIN CERTIFICATE-----
+MIIF0jCCA7qgAwIBAgIQEFjWOkN8qXNbWKtveG5ddTANBgkqhkiG9w0BAQsFADA2
+MRwwGgYDVQQKExNsaW51eGNvbnRhaW5lcnMub3JnMRYwFAYDVQQDDA1lc25vd0Bm
+dXJpb3VzMB4XDTE1MTAwMTIxMjAyMloXDTI1MDkyODIxMjAyMlowNjEcMBoGA1UE
+ChMTbGludXhjb250YWluZXJzLm9yZzEWMBQGA1UEAwwNZXNub3dAZnVyaW91czCC
+AiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBAMQgSXXaZMWImOP6IFBy/3E6
+JFHwrgy5YMqRikoernt5cMr838nNdNLW9woBIVRZfZIFbAjf38PGBQYAs/4G/WIt
+oydFp37JASsjPCEa/9I9WdIvm1+HpL7p7KjY/0bzcCZY8PbnUY98XGmWAdR38wY6
+S79Q8kDE6iOWls/zwndwlPPGoQlrOaITyzcl9aurH9ZZc4aoRz9DeKiPEXwYD9rl
+TMYPOVYu+YvN/UHOnzpFxYXJw1o5upvvF2QOHEm6kuYq/8azv0Iu+cOR1+Ok08Y+
+IGpXAkqqINf4qKWqd3/xq/ltkGpt/RfuUaMtbTbpU1UpLFsw7jkI5tGJarsXQZQP
+mw0auh63Ty9y7MdKluy44HcFsuttGeeihXp6oHz2IqEOYzbFh1wlJfIUFFkmJ3lY
+p81tA8A5Y7o/Il4aL+DudIzF8MmTHhElSZYF74KUVt/eiyQikUn/CjlGXzNfi/NC
+J8yIbR1HCDLAsWg1a1CvGdKBBi4VH2w9yI9HsNm4hvcF/nQojPNxqlbHDZ7lVESN
+tZZYDWACPUow9y8IQiVcI0hgAK1o/sxRWqt2URnz09iv3zNsOu/Y0oNyOJSrVeOq
+bObbt9dcifOkDx09uG7A4i7pOk9lD/zIXx8o9Zkw0D/1HLYyE+jNz1V6zEnUDem8
+cRTMPAvAE6JQtR8zyckVAgMBAAGjgdswgdgwDgYDVR0PAQH/BAQDAgWgMBMGA1Ud
+JQQMMAoGCCsGAQUFBwMBMAwGA1UdEwEB/wQCMAAwgaIGA1UdEQSBmjCBl4IHZnVy
+aW91c4IRMTkyLjE2OC4yNy4xMTMvMjSCHGZlODA6OjVlNTE6NGZmZjpmZWRjOmM1
+ZmQvNjSCCzEwLjAuMy4xLzI0ghtmZTgwOjpkNDZhOmFmZjpmZWY2OjUzOTgvNjSC
+EDE5Mi4xNjguMTIyLjEvMjSCDzE5Mi4xNjguNjQuMS8yNIIOMTcyLjE3LjQyLjEv
+MTYwDQYJKoZIhvcNAQELBQADggIBADg+1q7OT/euwJIIGjvgo/UfIr7Xj//Sarfx
+UcF6Qq125G2ZWb8epkB/sqoAerVpI0tRQX4G1sZvSe67sQvQDj17VHit9IrE14dY
+A0xA77wWZThRKX/yyTSUhFBU8QYEVPi72D31NgcDY3Ppy6wBvcIjv4vWedeTdgrb
+w09x/auAcvOl87bQXOduRl6xVoXu+mXwhjoK1rMrcqlPW6xcVn6yTWLODPNbAyx8
+xvaeHwKf67sIF/IBeRNoeVvuw6fANEGINB/JIaW5l6TwHakGaXBLOCe1dC6f7t5O
+Zj9Kb5IS6YMbxUVKnzFLtEty4vPN/pDeLPrJt00wvvbA0SrMpM+M8gspKrQsJ3Oz
+GiuXnLorumhOUXT7UQqw2gZ4FE/WA3W0LlIlpPuAbgZKRecJjilmnRPHa9+9hSXX
+BmxTLbEvz87PrrsoVR9K5R261ciAFdFiE7Jbh15qUm4qXYHT9QgJeXnDtV/bxO+Y
+Rrh9WfSP8x0SKrAoO7uhjI9Y276c8+etF0EY8u/+joqS8cZbOLXMuafgtF5E1trd
+QNRHwiIhEUVqctdguzMHbhFfKthq6vP8qhWNOF6FowZgSg+Q5Tvm1jaU++BNPqWi
+Zxy0qbMLRW8i/ABuTmzqtS3AHTtIFgdHx+BeT4W9LwU2dsO3Ijni2Rutmuz04rT+
+zxBNMbP3
+-----END CERTIFICATE-----
+`
+)

--- a/container/lxd/lxdclient/cert_test.go
+++ b/container/lxd/lxdclient/cert_test.go
@@ -137,11 +137,11 @@ func (s *certFunctionalSuite) TestGenerateCert(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	cert := lxdclient.NewCert(certPEM, keyPEM)
 
-	checkValidCert(c, cert)
+	checkValidCert(c, &cert)
 }
 
-func checkCert(c *gc.C, cert *lxdclient.Cert, certPEM, keyPEM []byte) {
-	c.Check(cert, jc.DeepEquals, &lxdclient.Cert{
+func checkCert(c *gc.C, cert lxdclient.Cert, certPEM, keyPEM []byte) {
+	c.Check(cert, jc.DeepEquals, lxdclient.Cert{
 		CertPEM: certPEM,
 		KeyPEM:  keyPEM,
 	})
@@ -150,6 +150,8 @@ func checkCert(c *gc.C, cert *lxdclient.Cert, certPEM, keyPEM []byte) {
 }
 
 func checkValidCert(c *gc.C, cert *lxdclient.Cert) {
+	c.Assert(cert, gc.NotNil)
+
 	_, err := tls.X509KeyPair(cert.CertPEM, cert.KeyPEM)
 	c.Check(err, jc.ErrorIsNil)
 

--- a/container/lxd/lxdclient/cert_test.go
+++ b/container/lxd/lxdclient/cert_test.go
@@ -34,27 +34,10 @@ func (s *certSuite) SetUpTest(c *gc.C) {
 	s.keyPEM = []byte("<a valid PEM-encoded x.509 key>")
 }
 
-func (s *certSuite) genCertAndKey() ([]byte, []byte, error) {
-	s.Stub.AddCall("genCertAndKey")
-	if err := s.Stub.NextErr(); err != nil {
-		return nil, nil, errors.Trace(err)
-	}
-
-	return s.certPEM, s.keyPEM, nil
-}
-
 func (s *certSuite) TestNewCert(c *gc.C) {
 	cert := lxdclient.NewCert(s.certPEM, s.keyPEM)
 
 	checkCert(c, cert, s.certPEM, s.keyPEM)
-}
-
-func (s *certSuite) TestGenerateCert(c *gc.C) {
-	cert, err := lxdclient.GenerateCert(s.genCertAndKey)
-	c.Assert(err, jc.ErrorIsNil)
-
-	checkCert(c, cert, s.certPEM, s.keyPEM)
-	s.Stub.CheckCallNames(c, "genCertAndKey")
 }
 
 func (s *certSuite) TestValidateOkay(c *gc.C) {
@@ -114,8 +97,9 @@ type certFunctionalSuite struct {
 
 func (s *certFunctionalSuite) TestGenerateCert(c *gc.C) {
 	// This test involves the filesystem.
-	cert, err := lxdclient.GenerateCert(lxdclient.GenCertAndKey)
+	certPEM, keyPEM, err := lxdclient.GenCertAndKey()
 	c.Assert(err, jc.ErrorIsNil)
+	cert := lxdclient.NewCert(certPEM, keyPEM)
 
 	_, err = tls.X509KeyPair(cert.CertPEM, cert.KeyPEM)
 	c.Check(err, jc.ErrorIsNil)

--- a/container/lxd/lxdclient/cert_test.go
+++ b/container/lxd/lxdclient/cert_test.go
@@ -43,14 +43,14 @@ func (s *certSuite) genCertAndKey() ([]byte, []byte, error) {
 	return s.certPEM, s.keyPEM, nil
 }
 
-func (s *certSuite) TestNewCertificate(c *gc.C) {
-	cert := lxdclient.NewCertificate(s.certPEM, s.keyPEM)
+func (s *certSuite) TestNewCert(c *gc.C) {
+	cert := lxdclient.NewCert(s.certPEM, s.keyPEM)
 
 	checkCert(c, cert, s.certPEM, s.keyPEM)
 }
 
-func (s *certSuite) TestGenerateCertificate(c *gc.C) {
-	cert, err := lxdclient.GenerateCertificate(s.genCertAndKey)
+func (s *certSuite) TestGenerateCert(c *gc.C) {
+	cert, err := lxdclient.GenerateCert(s.genCertAndKey)
 	c.Assert(err, jc.ErrorIsNil)
 
 	checkCert(c, cert, s.certPEM, s.keyPEM)
@@ -58,28 +58,28 @@ func (s *certSuite) TestGenerateCertificate(c *gc.C) {
 }
 
 func (s *certSuite) TestValidateOkay(c *gc.C) {
-	cert := lxdclient.NewCertificate(s.certPEM, s.keyPEM)
+	cert := lxdclient.NewCert(s.certPEM, s.keyPEM)
 	err := cert.Validate()
 
 	c.Check(err, jc.ErrorIsNil)
 }
 
 func (s *certSuite) TestValidateMissingCertPEM(c *gc.C) {
-	cert := lxdclient.NewCertificate(nil, s.keyPEM)
+	cert := lxdclient.NewCert(nil, s.keyPEM)
 	err := cert.Validate()
 
 	c.Check(err, jc.Satisfies, errors.IsNotValid)
 }
 
 func (s *certSuite) TestValidateMissingKeyPEM(c *gc.C) {
-	cert := lxdclient.NewCertificate(s.certPEM, nil)
+	cert := lxdclient.NewCert(s.certPEM, nil)
 	err := cert.Validate()
 
 	c.Check(err, jc.Satisfies, errors.IsNotValid)
 }
 
 func (s *certSuite) TestWriteCertPEM(c *gc.C) {
-	cert := lxdclient.NewCertificate(s.certPEM, s.keyPEM)
+	cert := lxdclient.NewCert(s.certPEM, s.keyPEM)
 	var pemfile bytes.Buffer
 	err := cert.WriteCertPEM(&pemfile)
 	c.Assert(err, jc.ErrorIsNil)
@@ -88,7 +88,7 @@ func (s *certSuite) TestWriteCertPEM(c *gc.C) {
 }
 
 func (s *certSuite) TestWriteKeyPEM(c *gc.C) {
-	cert := lxdclient.NewCertificate(s.certPEM, s.keyPEM)
+	cert := lxdclient.NewCert(s.certPEM, s.keyPEM)
 	var pemfile bytes.Buffer
 	err := cert.WriteKeyPEM(&pemfile)
 	c.Assert(err, jc.ErrorIsNil)
@@ -97,7 +97,7 @@ func (s *certSuite) TestWriteKeyPEM(c *gc.C) {
 }
 
 func (s *certSuite) TestWritePEMs(c *gc.C) {
-	cert := lxdclient.NewCertificate(s.certPEM, s.keyPEM)
+	cert := lxdclient.NewCert(s.certPEM, s.keyPEM)
 	var pemfile bytes.Buffer
 	err := cert.WriteCertPEM(&pemfile)
 	c.Assert(err, jc.ErrorIsNil)
@@ -112,9 +112,9 @@ type certFunctionalSuite struct {
 	lxdclient.BaseSuite
 }
 
-func (s *certFunctionalSuite) TestGenerateCertificate(c *gc.C) {
+func (s *certFunctionalSuite) TestGenerateCert(c *gc.C) {
 	// This test involves the filesystem.
-	cert, err := lxdclient.GenerateCertificate(lxdclient.GenCertAndKey)
+	cert, err := lxdclient.GenerateCert(lxdclient.GenCertAndKey)
 	c.Assert(err, jc.ErrorIsNil)
 
 	_, err = tls.X509KeyPair(cert.CertPEM, cert.KeyPEM)
@@ -127,8 +127,8 @@ func (s *certFunctionalSuite) TestGenerateCertificate(c *gc.C) {
 	c.Check(remainder, gc.HasLen, 0)
 }
 
-func checkCert(c *gc.C, cert *lxdclient.Certificate, certPEM, keyPEM []byte) {
-	c.Check(cert, jc.DeepEquals, &lxdclient.Certificate{
+func checkCert(c *gc.C, cert *lxdclient.Cert, certPEM, keyPEM []byte) {
+	c.Check(cert, jc.DeepEquals, &lxdclient.Cert{
 		CertPEM: certPEM,
 		KeyPEM:  keyPEM,
 	})

--- a/container/lxd/lxdclient/cert_test.go
+++ b/container/lxd/lxdclient/cert_test.go
@@ -95,7 +95,7 @@ func (s *certSuite) TestWritePEMs(c *gc.C) {
 
 func (s *certSuite) TestFingerprint(c *gc.C) {
 	certPEM := []byte(testCertPEM)
-	cert := lxdclient.NewCertificate(certPEM, nil)
+	cert := lxdclient.NewCert(certPEM, nil)
 	fingerprint, err := cert.Fingerprint()
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/container/lxd/lxdclient/cert_test.go
+++ b/container/lxd/lxdclient/cert_test.go
@@ -1,6 +1,8 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// +build go1.3
+
 package lxdclient_test
 
 import (

--- a/container/lxd/lxdclient/config.go
+++ b/container/lxd/lxdclient/config.go
@@ -197,7 +197,6 @@ func (cfg Config) writeConfigFile() error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	dirty := false
 
 	if cfg.Remote.ID() != Local.ID() {
 		// Ensure the remote is set correctly.
@@ -207,14 +206,11 @@ func (cfg Config) writeConfigFile() error {
 		if err := addServer(config, remote, addr); err != nil {
 			return errors.Trace(err)
 		}
-		dirty = true
 	}
 
-	if dirty {
-		// Write out the updated config.
-		if err := lxd.SaveConfig(config); err != nil {
-			return errors.Trace(err)
-		}
+	// Write out the updated config.
+	if err := lxd.SaveConfig(config); err != nil {
+		return errors.Trace(err)
 	}
 
 	return nil

--- a/container/lxd/lxdclient/config.go
+++ b/container/lxd/lxdclient/config.go
@@ -45,9 +45,9 @@ type Config struct {
 	Remote Remote
 }
 
-// SetDefaults updates a copy of the config with default values
+// WithDefaults updates a copy of the config with default values
 // where needed.
-func (cfg Config) SetDefaults() (Config, error) {
+func (cfg Config) WithDefaults() (Config, error) {
 	// We leave a blank namespace alone.
 
 	if cfg.Filename == "" {
@@ -61,7 +61,7 @@ func (cfg Config) SetDefaults() (Config, error) {
 	}
 
 	var err error
-	cfg.Remote, err = cfg.Remote.SetDefaults()
+	cfg.Remote, err = cfg.Remote.WithDefaults()
 	if err != nil {
 		return cfg, errors.Trace(err)
 	}

--- a/container/lxd/lxdclient/config.go
+++ b/container/lxd/lxdclient/config.go
@@ -216,7 +216,7 @@ func (cfg Config) writeConfigFile() error {
 	return nil
 }
 
-func (cfg Config) writeCertPEM(cert Certificate) error {
+func (cfg Config) writeCertPEM(cert Cert) error {
 	filename := cfg.resolve(configCertFile)
 	logger.Debugf("writing cert PEM file %q", filename)
 
@@ -232,7 +232,7 @@ func (cfg Config) writeCertPEM(cert Certificate) error {
 	return nil
 }
 
-func (cfg Config) writeKeyPEM(cert Certificate) error {
+func (cfg Config) writeKeyPEM(cert Cert) error {
 	filename := cfg.resolve(configKeyFile)
 	logger.Debugf("writing key PEM file %q", filename)
 

--- a/container/lxd/lxdclient/config.go
+++ b/container/lxd/lxdclient/config.go
@@ -20,8 +20,8 @@ const (
 	// see https://github.com/lxc/lxd/blob/master/config.go
 	configDefaultFile = "config.yml"
 	// see https://github.com/lxc/lxd/blob/master/client.go (readMyCert)
-	configCertfile = "client.crt"
-	configKeyfile  = "client.key"
+	configCertFile = "client.crt"
+	configKeyFile  = "client.key"
 )
 
 // Config contains the config values used for a connection to the LXD API.
@@ -221,7 +221,7 @@ func (cfg Config) writeConfigFile() error {
 }
 
 func (cfg Config) writeCertPEM(cert Certificate) error {
-	filename := cfg.resolve(configCertfile)
+	filename := cfg.resolve(configCertFile)
 	logger.Debugf("writing cert PEM file %q", filename)
 
 	file, err := os.Create(filename)
@@ -237,7 +237,7 @@ func (cfg Config) writeCertPEM(cert Certificate) error {
 }
 
 func (cfg Config) writeKeyPEM(cert Certificate) error {
-	filename := cfg.resolve(configKeyfile)
+	filename := cfg.resolve(configKeyFile)
 	logger.Debugf("writing key PEM file %q", filename)
 
 	file, err := os.OpenFile(filename, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)

--- a/container/lxd/lxdclient/config.go
+++ b/container/lxd/lxdclient/config.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/lxc/lxd"
-	"github.com/lxc/lxd/shared"
 )
 
 // The LXD repo does not expose any consts for these values.
@@ -113,18 +112,8 @@ func (cfg Config) AsNonLocal() (Config, error) {
 		return cfg, errors.Trace(err)
 	}
 
-	cert, err := remote.Cert.X509()
-	if err != nil {
-		return cfg, errors.Trace(err)
-	}
-	name, _ := shared.SplitExt(cfg.Filename)
-
 	// Update the server config and authorized certs.
-	client, err := Connect(cfg)
-	if err != nil {
-		return cfg, errors.Trace(err)
-	}
-	if err := client.setUpRemote(cert, "juju-"+name); err != nil {
+	if err := prepareRemote(cfg, *remote.Cert); err != nil {
 		return cfg, errors.Trace(err)
 	}
 

--- a/container/lxd/lxdclient/config.go
+++ b/container/lxd/lxdclient/config.go
@@ -49,7 +49,7 @@ type Config struct {
 // where needed.
 func (cfg Config) WithDefaults() (Config, error) {
 	// We leave a blank namespace alone.
-	// Also, note that cert is a value receiver, so it is an implicit copy.
+	// Also, note that cfg is a value receiver, so it is an implicit copy.
 
 	if cfg.Filename == "" {
 		cfg.Filename = configDefaultFile
@@ -101,14 +101,21 @@ func (cfg Config) Write() error {
 	return nil
 }
 
-// AsNonLocal converts the config into a non-local version. For
-// non-local remotes
-func (cfg Config) AsNonLocal() (Config, error) {
+// UsingTCPRemote converts the config into a "non-local" version. An
+// already non-local remote is left alone.
+//
+// For a "local" remote (see Local), the remote is changed to a one
+// with the host set to the IP address of the local lxcbr0 bridge
+// interface. The LXD server is also set up for remote access, exposing
+// the TCP port and adding a certificate for remote access.
+func (cfg Config) UsingTCPRemote() (Config, error) {
+	// Note that cfg is a value receiver, so it is an implicit copy.
+
 	if !cfg.Remote.isLocal() {
 		return cfg, nil
 	}
 
-	remote, err := cfg.Remote.AsNonLocal()
+	remote, err := cfg.Remote.UsingTCP()
 	if err != nil {
 		return cfg, errors.Trace(err)
 	}

--- a/container/lxd/lxdclient/config.go
+++ b/container/lxd/lxdclient/config.go
@@ -171,7 +171,7 @@ func (cfg Config) writeConfigFile() error {
 	logger.Debugf("writing config file %q", filename)
 
 	// TODO(ericsnow) Cache the low-level config in Config?
-	config, err := lxd.LoadConfig()
+	rawCfg, err := lxd.LoadConfig()
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -179,15 +179,16 @@ func (cfg Config) writeConfigFile() error {
 	if !cfg.Remote.isLocal() {
 		// Ensure the remote is set correctly.
 		remote := cfg.Remote.Name
-		delete(config.Remotes, remote)
+		delete(rawCfg.Remotes, remote)
 		addr := cfg.Remote.Host
-		if err := addServer(config, remote, addr); err != nil {
+		if err := addServer(rawCfg, remote, addr); err != nil {
 			return errors.Trace(err)
 		}
 	}
 
-	// Write out the updated config.
-	if err := lxd.SaveConfig(config); err != nil {
+	// Write out the updated config, if changed.
+	// TODO(ericsnow) Check if changed.
+	if err := lxd.SaveConfig(rawCfg); err != nil {
 		return errors.Trace(err)
 	}
 

--- a/container/lxd/lxdclient/config.go
+++ b/container/lxd/lxdclient/config.go
@@ -49,6 +49,7 @@ type Config struct {
 // where needed.
 func (cfg Config) WithDefaults() (Config, error) {
 	// We leave a blank namespace alone.
+	// Also, note that cert is a value receiver, so it is an implicit copy.
 
 	if cfg.Filename == "" {
 		cfg.Filename = configDefaultFile

--- a/container/lxd/lxdclient/config.go
+++ b/container/lxd/lxdclient/config.go
@@ -129,6 +129,23 @@ func (cfg Config) UsingTCPRemote() (Config, error) {
 	return cfg, nil
 }
 
+func prepareRemote(cfg Config, newCert Cert) error {
+	client, err := Connect(cfg)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	if err := client.SetConfig("core.https_address", "[::]"); err != nil {
+		return errors.Trace(err)
+	}
+
+	if err := client.AddCert(newCert); err != nil {
+		return errors.Trace(err)
+	}
+
+	return nil
+}
+
 func updateLXDVars(dirname string) string {
 	// Change the hard-coded config dir that the raw client uses.
 	// TODO(ericsnow) This is exactly what happens in the lxc CLI for

--- a/container/lxd/lxdclient/config.go
+++ b/container/lxd/lxdclient/config.go
@@ -146,6 +146,10 @@ func initializeConfigDir(cfg Config) error {
 		return errors.Trace(err)
 	}
 
+	// Force the default config to get written. LoadConfig() returns the
+	// default config from memory if there isn't a config file on disk.
+	// So we load that and then explicitly save it to disk with a call
+	// to SaveConfig().
 	config, err := lxd.LoadConfig()
 	if err != nil {
 		return errors.Trace(err)

--- a/container/lxd/lxdclient/config.go
+++ b/container/lxd/lxdclient/config.go
@@ -61,7 +61,7 @@ func (cfg Config) SetDefaults() (Config, error) {
 	}
 
 	var err error
-	cfg.Remote, err = cfg.Remote.setDefaults()
+	cfg.Remote, err = cfg.Remote.SetDefaults()
 	if err != nil {
 		return cfg, errors.Trace(err)
 	}
@@ -148,8 +148,10 @@ func (cfg Config) write() error {
 	}
 
 	// Write the cert file and key file, if applicable.
-	// TODO(ericsnow) cert should be a pointer?
-	cert := cfg.Remote.Cert()
+	var cert Cert
+	if cfg.Remote.Cert != nil {
+		cert = *cfg.Remote.Cert
+	}
 	if err := cert.Validate(); err != nil {
 		logger.Debugf("not writing invalid/empty certificate")
 	} else {

--- a/container/lxd/lxdclient/config.go
+++ b/container/lxd/lxdclient/config.go
@@ -115,16 +115,6 @@ func (cfg Config) Write() error {
 	return nil
 }
 
-//type LXDOps interface {
-//    UpdateVars(dirname string) string
-//    InitializeConfDir() error
-//    CreateCertFile(filename string) (io.ReadCloser, error)
-//    CreateFile(filename string) (io.ReadCloser, error)
-//}
-//
-//type lxdOps struct {
-//}
-
 func updateLXDVars(dirname string) string {
 	// Change the hard-coded config dir that the raw client uses.
 	// TODO(ericsnow) This is exactly what happens in the lxc CLI for
@@ -160,9 +150,6 @@ func initializeConfigDir(cfg Config) error {
 
 	return nil
 }
-
-//type ConfigOps struct {
-//}
 
 func (cfg Config) write() error {
 	// Ensure the initial config is set up.

--- a/container/lxd/lxdclient/config.go
+++ b/container/lxd/lxdclient/config.go
@@ -84,21 +84,6 @@ func (cfg Config) Validate() error {
 	return nil
 }
 
-// Apply updates the current process such that the LXD client
-// will operate with this config satisfied.
-// A cfg.SetDefaults() call may be needed first.
-func (cfg Config) Apply() error {
-	if err := cfg.Validate(); err != nil {
-		return errors.Trace(err)
-	}
-
-	updateLXDVars(cfg.Dirname)
-
-	// TODO(ericsnow) Call cfg.write() here if not already done?
-
-	return nil
-}
-
 // Write writes all the various files for this config.
 func (cfg Config) Write() error {
 	if err := cfg.Validate(); err != nil {

--- a/container/lxd/lxdclient/config.go
+++ b/container/lxd/lxdclient/config.go
@@ -176,7 +176,7 @@ func (cfg Config) writeConfigFile() error {
 		return errors.Trace(err)
 	}
 
-	if cfg.Remote.ID() != Local.ID() {
+	if !cfg.Remote.isLocal() {
 		// Ensure the remote is set correctly.
 		remote := cfg.Remote.Name
 		delete(config.Remotes, remote)

--- a/container/lxd/lxdclient/config.go
+++ b/container/lxd/lxdclient/config.go
@@ -125,7 +125,7 @@ func (cfg Config) UsingTCPRemote() (Config, error) {
 		return cfg, errors.Trace(err)
 	}
 
-	cfg.Remote = *remote
+	cfg.Remote = remote
 	return cfg, nil
 }
 

--- a/container/lxd/lxdclient/config_test.go
+++ b/container/lxd/lxdclient/config_test.go
@@ -151,18 +151,6 @@ func (s *configSuite) TestValidateZeroValue(c *gc.C) {
 	c.Check(err, jc.Satisfies, errors.IsNotValid)
 }
 
-func (s *configSuite) TestApplyOkay(c *gc.C) {
-	c.Skip("not implemented yet")
-	// TODO(ericsnow) Finish!
-}
-
-func (s *configSuite) TestApplyInvalid(c *gc.C) {
-	var cfg lxdclient.Config
-	err := cfg.Apply()
-
-	c.Check(err, jc.Satisfies, errors.IsNotValid)
-}
-
 func (s *configSuite) TestWriteOkay(c *gc.C) {
 	c.Skip("not implemented yet")
 	// TODO(ericsnow) Finish!
@@ -191,19 +179,6 @@ func (s *configFunctionalSuite) SetUpTest(c *gc.C) {
 	s.AddCleanup(func(c *gc.C) {
 		lxd.ConfigDir = origConfigDir
 	})
-}
-
-func (s *configFunctionalSuite) TestApply(c *gc.C) {
-	cfg := lxdclient.Config{
-		Namespace: "my-ns",
-		Dirname:   "some-dir",
-		Filename:  "config.yml",
-		Remote:    s.remote,
-	}
-	err := cfg.Apply()
-	c.Assert(err, jc.ErrorIsNil)
-
-	c.Check(lxd.ConfigDir, gc.Equals, cfg.Dirname)
 }
 
 func (s *configFunctionalSuite) TestWrite(c *gc.C) {

--- a/container/lxd/lxdclient/config_test.go
+++ b/container/lxd/lxdclient/config_test.go
@@ -41,27 +41,27 @@ type configSuite struct {
 	configBaseSuite
 }
 
-func (s *configSuite) TestSetDefaultsOkay(c *gc.C) {
+func (s *configSuite) TestWithDefaultsOkay(c *gc.C) {
 	cfg := lxdclient.Config{
 		Namespace: "my-ns",
 		Dirname:   "some-dir",
 		Filename:  "config.yaml",
 		Remote:    s.remote,
 	}
-	updated, err := cfg.SetDefaults()
+	updated, err := cfg.WithDefaults()
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(updated, jc.DeepEquals, cfg)
 }
 
-func (s *configSuite) TestSetDefaultsMissingDirname(c *gc.C) {
+func (s *configSuite) TestWithDefaultsMissingDirname(c *gc.C) {
 	cfg := lxdclient.Config{
 		Namespace: "my-ns",
 		Dirname:   "",
 		Filename:  "config.yaml",
 		Remote:    s.remote,
 	}
-	updated, err := cfg.SetDefaults()
+	updated, err := cfg.WithDefaults()
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(updated, jc.DeepEquals, lxdclient.Config{
@@ -74,14 +74,14 @@ func (s *configSuite) TestSetDefaultsMissingDirname(c *gc.C) {
 	})
 }
 
-func (s *configSuite) TestSetDefaultsFilename(c *gc.C) {
+func (s *configSuite) TestWithDefaultsFilename(c *gc.C) {
 	cfg := lxdclient.Config{
 		Namespace: "my-ns",
 		Dirname:   "some-dir",
 		Filename:  "",
 		Remote:    s.remote,
 	}
-	updated, err := cfg.SetDefaults()
+	updated, err := cfg.WithDefaults()
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(updated, jc.DeepEquals, lxdclient.Config{
@@ -92,13 +92,13 @@ func (s *configSuite) TestSetDefaultsFilename(c *gc.C) {
 	})
 }
 
-func (s *configSuite) TestSetDefaultsMissingRemote(c *gc.C) {
+func (s *configSuite) TestWithDefaultsMissingRemote(c *gc.C) {
 	cfg := lxdclient.Config{
 		Namespace: "my-ns",
 		Dirname:   "some-dir",
 		Filename:  "config.yaml",
 	}
-	updated, err := cfg.SetDefaults()
+	updated, err := cfg.WithDefaults()
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(updated, jc.DeepEquals, lxdclient.Config{

--- a/container/lxd/lxdclient/config_test.go
+++ b/container/lxd/lxdclient/config_test.go
@@ -152,6 +152,7 @@ func (s *configSuite) TestValidateZeroValue(c *gc.C) {
 }
 
 func (s *configSuite) TestApplyOkay(c *gc.C) {
+	c.Skip("not implemented yet")
 	// TODO(ericsnow) Finish!
 }
 
@@ -163,10 +164,12 @@ func (s *configSuite) TestApplyInvalid(c *gc.C) {
 }
 
 func (s *configSuite) TestWriteOkay(c *gc.C) {
+	c.Skip("not implemented yet")
 	// TODO(ericsnow) Finish!
 }
 
 func (s *configSuite) TestWriteRemoteAlreadySet(c *gc.C) {
+	c.Skip("not implemented yet")
 	// TODO(ericsnow) Finish!
 }
 

--- a/container/lxd/lxdclient/config_test.go
+++ b/container/lxd/lxdclient/config_test.go
@@ -30,11 +30,11 @@ type configBaseSuite struct {
 func (s *configBaseSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 
-	s.remote = lxdclient.NewRemote(lxdclient.RemoteInfo{
+	s.remote = lxdclient.Remote{
 		Name: "my-remote",
 		Host: "some-host",
 		Cert: s.Cert,
-	})
+	}
 }
 
 type configSuite struct {
@@ -196,7 +196,10 @@ func (s *configFunctionalSuite) TestWrite(c *gc.C) {
 }
 
 func checkFiles(c *gc.C, cfg lxdclient.Config) {
-	certificate := cfg.Remote.Cert()
+	var certificate lxdclient.Cert
+	if cfg.Remote.Cert != nil {
+		certificate = *cfg.Remote.Cert
+	}
 
 	filename := filepath.Join(cfg.Dirname, "client.crt")
 	c.Logf("reading cert PEM from %q", filename)

--- a/container/lxd/lxdclient/config_test.go
+++ b/container/lxd/lxdclient/config_test.go
@@ -245,6 +245,7 @@ func checkFiles(c *gc.C, cfg lxdclient.Config) {
 	c.Check(config, jc.DeepEquals, lxd.Config{
 		DefaultRemote: "local",
 		Remotes: map[string]lxd.RemoteConfig{
+			// TODO(ericsnow) Use the following once we switch to a newer LXD.
 			//"local": lxd.LocalRemote,
 			"local": config.Remotes["local"],
 			cfg.Remote.Name: lxd.RemoteConfig{
@@ -252,6 +253,7 @@ func checkFiles(c *gc.C, cfg lxdclient.Config) {
 				Public: false,
 			},
 		},
+		// TODO(ericsnow) Use the following once we switch to a newer LXD.
 		//Aliases: nil,
 	})
 }

--- a/container/lxd/lxdclient/config_test.go
+++ b/container/lxd/lxdclient/config_test.go
@@ -1,6 +1,8 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// +build go1.3
+
 package lxdclient_test
 
 import (

--- a/container/lxd/lxdclient/config_test.go
+++ b/container/lxd/lxdclient/config_test.go
@@ -171,18 +171,18 @@ func (s *configSuite) TestWriteInvalid(c *gc.C) {
 	c.Check(err, jc.Satisfies, errors.IsNotValid)
 }
 
-func (s *configSuite) TestAsNonLocalOkay(c *gc.C) {
+func (s *configSuite) TestUsingTCPRemoteOkay(c *gc.C) {
 	// TODO(ericsnow) Finish!
 }
 
-func (s *configSuite) TestAsNonLocalNoop(c *gc.C) {
+func (s *configSuite) TestUsingTCPRemoteNoop(c *gc.C) {
 	cfg := lxdclient.Config{
 		Namespace: "my-ns",
 		Dirname:   "some-dir",
 		Filename:  "config.yml",
 		Remote:    s.remote,
 	}
-	nonlocal, err := cfg.AsNonLocal()
+	nonlocal, err := cfg.UsingTCPRemote()
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(nonlocal, jc.DeepEquals, cfg)
@@ -237,7 +237,7 @@ func (s *configFunctionalSuite) TestWrite(c *gc.C) {
 	checkFiles(c, cfg)
 }
 
-func (s *configFunctionalSuite) TestAsNonLocal(c *gc.C) {
+func (s *configFunctionalSuite) TestUsingTCPRemote(c *gc.C) {
 	if s.client == nil {
 		c.Skip("LXD not running locally")
 	}
@@ -248,7 +248,7 @@ func (s *configFunctionalSuite) TestAsNonLocal(c *gc.C) {
 		Filename:  "config.yml",
 		Remote:    lxdclient.Local,
 	}
-	nonlocal, err := cfg.AsNonLocal()
+	nonlocal, err := cfg.UsingTCPRemote()
 	c.Assert(err, jc.ErrorIsNil)
 
 	checkValidRemote(c, &nonlocal.Remote)

--- a/container/lxd/lxdclient/config_test.go
+++ b/container/lxd/lxdclient/config_test.go
@@ -170,6 +170,23 @@ func (s *configSuite) TestWriteInvalid(c *gc.C) {
 	c.Check(err, jc.Satisfies, errors.IsNotValid)
 }
 
+func (s *configSuite) TestAsNonLocalOkay(c *gc.C) {
+	// TODO(ericsnow) Finish!
+}
+
+func (s *configSuite) TestAsNonLocalNoop(c *gc.C) {
+	cfg := lxdclient.Config{
+		Namespace: "my-ns",
+		Dirname:   "some-dir",
+		Filename:  "config.yml",
+		Remote:    s.remote,
+	}
+	nonlocal, err := cfg.AsNonLocal()
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(nonlocal, jc.DeepEquals, cfg)
+}
+
 type configFunctionalSuite struct {
 	configBaseSuite
 }
@@ -181,6 +198,7 @@ func (s *configFunctionalSuite) SetUpTest(c *gc.C) {
 	s.AddCleanup(func(c *gc.C) {
 		lxd.ConfigDir = origConfigDir
 	})
+	// TODO(ericsnow) Add a cleanup func to remove any added certs.
 }
 
 func (s *configFunctionalSuite) TestWrite(c *gc.C) {
@@ -195,6 +213,49 @@ func (s *configFunctionalSuite) TestWrite(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	checkFiles(c, cfg)
+}
+
+func (s *configFunctionalSuite) TestAsNonLocal(c *gc.C) {
+	if !lxdRunningLocally() {
+		c.Skip("LXD not running locally")
+	}
+
+	cfg := lxdclient.Config{
+		Namespace: "my-ns",
+		Dirname:   "some-dir",
+		Filename:  "config.yml",
+		Remote:    lxdclient.Local,
+	}
+	nonlocal, err := cfg.AsNonLocal()
+	c.Assert(err, jc.ErrorIsNil)
+
+	checkValidRemote(c, &nonlocal.Remote)
+	c.Check(nonlocal, jc.DeepEquals, lxdclient.Config{
+		Namespace: "my-ns",
+		Dirname:   "some-dir",
+		Filename:  "config.yml",
+		Remote: lxdclient.Remote{
+			Name: lxdclient.Local.Name,
+			Host: nonlocal.Remote.Host,
+			Cert: nonlocal.Remote.Cert,
+		},
+	})
+	// TODO(ericsnow) Check that the server has the certs.
+}
+
+func lxdRunningLocally() bool {
+	origConfigDir := lxd.ConfigDir
+	defer func() {
+		lxd.ConfigDir = origConfigDir
+	}()
+
+	_, err := lxdclient.Connect(lxdclient.Config{
+		Namespace: "my-ns",
+		Dirname:   "some-dir",
+		Filename:  "config.yml",
+		Remote:    lxdclient.Local,
+	})
+	return err == nil
 }
 
 func checkFiles(c *gc.C, cfg lxdclient.Config) {

--- a/container/lxd/lxdclient/conn.go
+++ b/container/lxd/lxdclient/conn.go
@@ -13,7 +13,8 @@ import (
 
 // Client is a high-level wrapper around the LXD API client.
 type Client struct {
-	*clientServerMethods
+	*serverConfigClient
+	*certClient
 
 	raw       rawClientWrapper
 	namespace string
@@ -36,7 +37,8 @@ func Connect(cfg Config) (*Client, error) {
 	}
 
 	conn := &Client{
-		clientServerMethods: &clientServerMethods{raw},
+		serverConfigClient: &serverConfigClient{raw},
+		certClient:         &certClient{raw},
 
 		raw:       raw,
 		namespace: cfg.Namespace,

--- a/container/lxd/lxdclient/conn.go
+++ b/container/lxd/lxdclient/conn.go
@@ -8,6 +8,7 @@ package lxdclient
 import (
 	"github.com/juju/errors"
 	"github.com/lxc/lxd"
+	"github.com/lxc/lxd/shared"
 )
 
 // Client is a high-level wrapper around the LXD API client.
@@ -63,4 +64,23 @@ func newRawClient(remote, configDir string) (*lxd.Client, error) {
 	}
 
 	return client, nil
+}
+
+func prepareRemote(cfg Config, newCert Cert) error {
+	client, err := Connect(cfg)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	if err := client.SetConfig("core.https_address", "[::]"); err != nil {
+		return errors.Trace(err)
+	}
+
+	name, _ := shared.SplitExt(cfg.Filename) // TODO(ericsnow) Is this right?
+	name = "juju-" + name
+	if err := client.AddCert(newCert, name); err != nil {
+		return errors.Trace(err)
+	}
+
+	return nil
 }

--- a/container/lxd/lxdclient/conn.go
+++ b/container/lxd/lxdclient/conn.go
@@ -66,20 +66,3 @@ func newRawClient(remote, configDir string) (*lxd.Client, error) {
 
 	return client, nil
 }
-
-func prepareRemote(cfg Config, newCert Cert) error {
-	client, err := Connect(cfg)
-	if err != nil {
-		return errors.Trace(err)
-	}
-
-	if err := client.SetConfig("core.https_address", "[::]"); err != nil {
-		return errors.Trace(err)
-	}
-
-	if err := client.AddCert(newCert); err != nil {
-		return errors.Trace(err)
-	}
-
-	return nil
-}

--- a/container/lxd/lxdclient/conn.go
+++ b/container/lxd/lxdclient/conn.go
@@ -12,6 +12,8 @@ import (
 
 // Client is a high-level wrapper around the LXD API client.
 type Client struct {
+	*clientServerMethods
+
 	raw       rawClientWrapper
 	namespace string
 	remote    string
@@ -33,6 +35,8 @@ func Connect(cfg Config) (*Client, error) {
 	}
 
 	conn := &Client{
+		clientServerMethods: &clientServerMethods{raw},
+
 		raw:       raw,
 		namespace: cfg.Namespace,
 		remote:    remote,

--- a/container/lxd/lxdclient/conn.go
+++ b/container/lxd/lxdclient/conn.go
@@ -20,12 +20,13 @@ type Client struct {
 // Connect opens an API connection to LXD and returns a high-level
 // Client wrapper around that connection.
 func Connect(cfg Config) (*Client, error) {
-	if err := cfg.Apply(); err != nil {
+	if err := cfg.Validate(); err != nil {
 		return nil, errors.Trace(err)
 	}
+	// TODO(ericsnow) Call cfg.Write here if necessary?
 	remote := cfg.Remote.ID()
 
-	raw, err := newRawClient(remote)
+	raw, err := newRawClient(remote, cfg.Dirname)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -38,8 +39,11 @@ func Connect(cfg Config) (*Client, error) {
 	return conn, nil
 }
 
-func newRawClient(remote string) (*lxd.Client, error) {
-	logger.Debugf("loading LXD client config from %q", lxd.ConfigDir)
+func newRawClient(remote, configDir string) (*lxd.Client, error) {
+	logger.Debugf("loading LXD client config from %q", configDir)
+
+	// This will go away once LoadConfig takes a dirname argument.
+	updateLXDVars(configDir)
 
 	cfg, err := lxd.LoadConfig()
 	if err != nil {

--- a/container/lxd/lxdclient/conn.go
+++ b/container/lxd/lxdclient/conn.go
@@ -8,7 +8,6 @@ package lxdclient
 import (
 	"github.com/juju/errors"
 	"github.com/lxc/lxd"
-	"github.com/lxc/lxd/shared"
 )
 
 // Client is a high-level wrapper around the LXD API client.
@@ -78,9 +77,7 @@ func prepareRemote(cfg Config, newCert Cert) error {
 		return errors.Trace(err)
 	}
 
-	name, _ := shared.SplitExt(cfg.Filename) // TODO(ericsnow) Is this right?
-	name = "juju-" + name
-	if err := client.AddCert(newCert, name); err != nil {
+	if err := client.AddCert(newCert); err != nil {
 		return errors.Trace(err)
 	}
 

--- a/container/lxd/lxdclient/conn.go
+++ b/container/lxd/lxdclient/conn.go
@@ -15,6 +15,7 @@ type Client struct {
 	raw       rawClientWrapper
 	namespace string
 	remote    string
+	isLocal   bool
 }
 
 // Connect opens an API connection to LXD and returns a high-level
@@ -35,6 +36,7 @@ func Connect(cfg Config) (*Client, error) {
 		raw:       raw,
 		namespace: cfg.Namespace,
 		remote:    remote,
+		isLocal:   cfg.Remote.isLocal(),
 	}
 	return conn, nil
 }

--- a/container/lxd/lxdclient/conn_cert.go
+++ b/container/lxd/lxdclient/conn_cert.go
@@ -1,6 +1,8 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// +build go1.3
+
 package lxdclient
 
 import (

--- a/container/lxd/lxdclient/conn_cert.go
+++ b/container/lxd/lxdclient/conn_cert.go
@@ -21,13 +21,13 @@ type certClient struct {
 }
 
 // AddCert adds the given certificate to the server.
-func (c certClient) AddCert(cert Cert, name string) error {
+func (c certClient) AddCert(cert Cert) error {
 	x509Cert, err := cert.X509()
 	if err != nil {
 		return errors.Trace(err)
 	}
 
-	if err := c.raw.CertificateAdd(x509Cert, name); err != nil {
+	if err := c.raw.CertificateAdd(x509Cert, cert.Name); err != nil {
 		return errors.Trace(err)
 	}
 

--- a/container/lxd/lxdclient/conn_cert.go
+++ b/container/lxd/lxdclient/conn_cert.go
@@ -7,46 +7,21 @@ import (
 	"crypto/x509"
 
 	"github.com/juju/errors"
-	"github.com/lxc/lxd"
 	"github.com/lxc/lxd/shared"
 )
 
-type rawClientServerMethods interface {
-	WaitForSuccess(waitURL string) error
-
-	SetServerConfig(key string, value string) (*lxd.Response, error)
-
+type rawCertClient interface {
 	CertificateList() ([]shared.CertInfo, error)
 	CertificateAdd(cert *x509.Certificate, name string) error
 	CertificateRemove(fingerprint string) error
 }
 
-// clientServerMethods implements the Client methods related
-// to server operations.
-type clientServerMethods struct {
-	raw rawServerMethods
-}
-
-// SetConfig sets the given value in the server's config.
-func (c clientServerMethods) SetConfig(key, value string) error {
-	resp, err := c.raw.SetServerConfig(key, value)
-	if err != nil {
-		return errors.Trace(err)
-	}
-
-	if resp.Operation != "" {
-		if err := c.raw.WaitForSuccess(resp.Operation); err != nil {
-			// TODO(ericsnow) Handle different failures (from the async
-			// operation) differently?
-			return errors.Trace(err)
-		}
-	}
-
-	return nil
+type certClient struct {
+	raw rawCertClient
 }
 
 // AddCert adds the given certificate to the server.
-func (c clientServerMethods) AddCert(cert Cert, name string) error {
+func (c certClient) AddCert(cert Cert, name string) error {
 	x509Cert, err := cert.X509()
 	if err != nil {
 		return errors.Trace(err)
@@ -60,7 +35,7 @@ func (c clientServerMethods) AddCert(cert Cert, name string) error {
 }
 
 // ListCerts returns the list of cert fingerprints from the server.
-func (c clientServerMethods) ListCerts() ([]string, error) {
+func (c certClient) ListCerts() ([]string, error) {
 	certs, err := c.raw.CertificateList()
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -74,7 +49,7 @@ func (c clientServerMethods) ListCerts() ([]string, error) {
 }
 
 // RemoveCert removes the cert from the server.
-func (c clientServerMethods) RemoveCert(cert *Cert) error {
+func (c certClient) RemoveCert(cert *Cert) error {
 	fingerprint, err := cert.Fingerprint()
 	if err != nil {
 		return errors.Trace(err)
@@ -87,7 +62,7 @@ func (c clientServerMethods) RemoveCert(cert *Cert) error {
 }
 
 // RemoveCertByFingerprint removes the cert from the server.
-func (c clientServerMethods) RemoveCertByFingerprint(fingerprint string) error {
+func (c certClient) RemoveCertByFingerprint(fingerprint string) error {
 	if err := c.raw.CertificateRemove(fingerprint); err != nil {
 		return errors.Trace(err)
 	}

--- a/container/lxd/lxdclient/conn_instance.go
+++ b/container/lxd/lxdclient/conn_instance.go
@@ -19,10 +19,8 @@ import (
 // get handled in container/lxc/clonetemplate.go.
 
 func (client *Client) addInstance(spec InstanceSpec) error {
-	// TODO(ericsnow) Default to spec.ImageRemote.
+	// TODO(ericsnow) Default to spec.ImageRemote (once it gets added).
 	imageRemote := ""
-	//remote := client.remote
-	//remote := spec.ImageRemote
 	if imageRemote == "" {
 		imageRemote = client.remote
 	}

--- a/container/lxd/lxdclient/conn_instance.go
+++ b/container/lxd/lxdclient/conn_instance.go
@@ -15,6 +15,9 @@ import (
 	"github.com/lxc/lxd/shared"
 )
 
+// TODO(ericsnow) Put these methods in their own struct
+// (a la clientServerMethods).
+
 // TODO(ericsnow) We probably need to address some of the things that
 // get handled in container/lxc/clonetemplate.go.
 

--- a/container/lxd/lxdclient/conn_instance.go
+++ b/container/lxd/lxdclient/conn_instance.go
@@ -57,16 +57,6 @@ func (client *Client) addInstance(spec InstanceSpec) error {
 		return errors.Trace(err)
 	}
 
-	if client.isLocal {
-		// TODO(ericsnow) Only do this if it's a state server...
-		if err := client.exposeHostAPI(spec); err != nil {
-			if err := client.removeInstance(spec.Name); err != nil {
-				logger.Errorf("could not remove container %q after exposing the API sock failed", spec.Name)
-			}
-			return errors.Trace(err)
-		}
-	}
-
 	return nil
 }
 
@@ -78,31 +68,6 @@ func (client *Client) initInstanceConfig(spec InstanceSpec) error {
 			return errors.Trace(err)
 		}
 	}
-	return nil
-}
-
-func (client *Client) exposeHostAPI(spec InstanceSpec) error {
-	// lxc config device add juju-container lxdsock disk \
-	// source=/var/lib/lxd/unix.socket path=var/lib/lxd/unix.socket
-	const apiDevName = "lxdsock"
-	const devType = "disk"
-	const filename = "/var/lib/lxd/unix.socket"
-	props := []string{
-		// TODO(ericsnow) hard-coded, unix-centric...
-		"source=/var/lib/lxd/unix.socket",
-		"path=var/lib/lxd/unix.socket",
-	}
-	resp, err := client.raw.ContainerDeviceAdd(spec.Name, apiDevName, devType, props)
-	if err != nil {
-		return errors.Trace(err)
-	}
-
-	if err := client.raw.WaitForSuccess(resp.Operation); err != nil {
-		// TODO(ericsnow) Handle different failures (from the async
-		// operation) differently?
-		return errors.Trace(err)
-	}
-
 	return nil
 }
 
@@ -196,47 +161,6 @@ func (client *Client) startInstance(spec InstanceSpec) error {
 	return nil
 }
 
-func (client *Client) fixSockfile(spec InstanceSpec) error {
-	const filename = "/var/lib/lxd/unix.socket"
-
-	//info, err := os.Stat(filename)
-	//if err != nil {
-	//	return nil, errors.Trace(err)
-	//}
-	//gid := info.Sys().(*syscall.Stat_t).Gid
-
-	//cmd := []string{
-	//	"/usr/sbin/groupadd",
-	//	fmt.Sprintf("--gid=%d", gid),
-	//	"lxd",
-	//}
-	//if err := client.exec(spec, cmd); err != nil {
-	//	return errors.Trace(err)
-	//}
-
-	//cmd = []string{
-	//	"/usr/sbin/usermod",
-	//	"-a",
-	//	"-G", "lxd",
-	//	"root",
-	//}
-	//if err := client.exec(spec, cmd); err != nil {
-	//	return errors.Trace(err)
-	//}
-
-	// TODO(ericsnow) Instead of modifying the socket file, add the
-	// "lxd" group, ensure the GID matches the one on the host, and add
-	// the root user to that group.
-
-	// TODO(ericsnow) For now, ensure that your local unix.socket is 0666...
-	//if err := client.chmod(spec, filename, 0666); err != nil {
-	//	fmt.Println("---- ", err)
-	//	//return errors.Trace(err)
-	//}
-
-	return nil
-}
-
 // AddInstance creates a new instance based on the spec's data and
 // returns it. The instance will be created using the client.
 func (client *Client) AddInstance(spec InstanceSpec) (*Instance, error) {
@@ -248,11 +172,6 @@ func (client *Client) AddInstance(spec InstanceSpec) (*Instance, error) {
 		if err := client.removeInstance(spec.Name); err != nil {
 			logger.Errorf("could not remove container %q after starting it failed", spec.Name)
 		}
-		return nil, errors.Trace(err)
-	}
-
-	// TODO(ericsnow) This is a hack tied to exposeHostAPI().
-	if err := client.fixSockfile(spec); err != nil {
 		return nil, errors.Trace(err)
 	}
 

--- a/container/lxd/lxdclient/conn_instance.go
+++ b/container/lxd/lxdclient/conn_instance.go
@@ -54,7 +54,7 @@ func (client *Client) addInstance(spec InstanceSpec) error {
 		return errors.Trace(err)
 	}
 
-	if client.remote.isLocal() {
+	if client.isLocal {
 		// TODO(ericsnow) Only do this if it's a state server...
 		if err := client.exposeHostAPI(spec); err != nil {
 			if err := client.removeInstance(spec.Name); err != nil {

--- a/container/lxd/lxdclient/conn_instance.go
+++ b/container/lxd/lxdclient/conn_instance.go
@@ -54,7 +54,7 @@ func (client *Client) addInstance(spec InstanceSpec) error {
 		return errors.Trace(err)
 	}
 
-	if client.remote == Local.ID() {
+	if client.remote.isLocal() {
 		// TODO(ericsnow) Only do this if it's a state server...
 		if err := client.exposeHostAPI(spec); err != nil {
 			if err := client.removeInstance(spec.Name); err != nil {

--- a/container/lxd/lxdclient/conn_raw.go
+++ b/container/lxd/lxdclient/conn_raw.go
@@ -64,11 +64,14 @@ type rawServerMethods interface {
 
 	// auth
 	UserAuthServerCert(name string, acceptCert bool) error
-	CertificateList() ([]shared.CertInfo, error)
+	AmTrusted() bool
+}
+
+type rawCertMethods interface {
 	AddMyCertToServer(pwd string) error
+	CertificateList() ([]shared.CertInfo, error)
 	CertificateAdd(cert *x509.Certificate, name string) error
 	CertificateRemove(fingerprint string) error
-	AmTrusted() bool
 }
 
 type rawImageMethods interface {

--- a/container/lxd/lxdclient/conn_raw.go
+++ b/container/lxd/lxdclient/conn_raw.go
@@ -35,7 +35,6 @@ type rawClientWrapper interface {
 	ContainerStatus(name string) (*shared.ContainerState, error)
 	Init(name string, imgremote string, image string, profiles *[]string, ephem bool) (*lxd.Response, error)
 	SetContainerConfig(container, key, value string) error
-	ContainerDeviceAdd(container, devname, devtype string, props []string) (*lxd.Response, error)
 	Action(name string, action shared.ContainerAction, timeout int, force bool) (*lxd.Response, error)
 	Exec(name string, cmd []string, env map[string]string, stdin *os.File, stdout *os.File, stderr *os.File) (int, error)
 	Delete(name string) (*lxd.Response, error)

--- a/container/lxd/lxdclient/conn_server.go
+++ b/container/lxd/lxdclient/conn_server.go
@@ -1,0 +1,39 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package lxdclient
+
+import (
+	"crypto/x509"
+
+	"github.com/juju/errors"
+	"github.com/lxc/lxd"
+)
+
+type rawClientServerMethods interface {
+	WaitForSuccess(waitURL string) error
+	SetServerConfig(key string, value string) (*lxd.Response, error)
+	CertificateAdd(cert *x509.Certificate, name string) error
+}
+
+type clientServerMethods struct {
+	raw rawServerMethods
+}
+
+func (c clientServerMethods) setUpRemote(cert *x509.Certificate, name string) error {
+	resp, err := c.raw.SetServerConfig("core.https_address", "[::]")
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if err := c.raw.WaitForSuccess(resp.Operation); err != nil {
+		// TODO(ericsnow) Handle different failures (from the async
+		// operation) differently?
+		return errors.Trace(err)
+	}
+
+	if err := c.raw.CertificateAdd(cert, name); err != nil {
+		return errors.Trace(err)
+	}
+
+	return nil
+}

--- a/container/lxd/lxdclient/conn_server.go
+++ b/container/lxd/lxdclient/conn_server.go
@@ -14,6 +14,7 @@ type rawClientServerMethods interface {
 	WaitForSuccess(waitURL string) error
 	SetServerConfig(key string, value string) (*lxd.Response, error)
 	CertificateAdd(cert *x509.Certificate, name string) error
+	CertificateRemove(fingerprint string) error
 }
 
 type clientServerMethods struct {
@@ -37,5 +38,18 @@ func (c clientServerMethods) setUpRemote(cert *x509.Certificate, name string) er
 		return errors.Trace(err)
 	}
 
+	return nil
+}
+
+// RemoveCert removes the cert from the server.
+func (c clientServerMethods) RemoveCert(cert *Certificate) error {
+	fingerprint, err := cert.Fingerprint()
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	if err := c.raw.CertificateRemove(fingerprint); err != nil {
+		return errors.Trace(err)
+	}
 	return nil
 }

--- a/container/lxd/lxdclient/conn_server.go
+++ b/container/lxd/lxdclient/conn_server.go
@@ -60,7 +60,7 @@ func (c clientServerMethods) ListCerts() ([]string, error) {
 }
 
 // RemoveCert removes the cert from the server.
-func (c clientServerMethods) RemoveCert(cert *Certificate) error {
+func (c clientServerMethods) RemoveCert(cert *Cert) error {
 	fingerprint, err := cert.Fingerprint()
 	if err != nil {
 		return errors.Trace(err)

--- a/container/lxd/lxdclient/conn_server.go
+++ b/container/lxd/lxdclient/conn_server.go
@@ -71,3 +71,11 @@ func (c clientServerMethods) RemoveCert(cert *Certificate) error {
 	}
 	return nil
 }
+
+// RemoveCertByFingerprint removes the cert from the server.
+func (c clientServerMethods) RemoveCertByFingerprint(fingerprint string) error {
+	if err := c.raw.CertificateRemove(fingerprint); err != nil {
+		return errors.Trace(err)
+	}
+	return nil
+}

--- a/container/lxd/lxdclient/conn_server.go
+++ b/container/lxd/lxdclient/conn_server.go
@@ -21,6 +21,8 @@ type rawClientServerMethods interface {
 	CertificateRemove(fingerprint string) error
 }
 
+// clientServerMethods implements the Client methods related
+// to server operations.
 type clientServerMethods struct {
 	raw rawServerMethods
 }

--- a/container/lxd/lxdclient/conn_server.go
+++ b/container/lxd/lxdclient/conn_server.go
@@ -27,11 +27,12 @@ type clientServerMethods struct {
 	raw rawServerMethods
 }
 
-func (c clientServerMethods) setUpRemote(cert *x509.Certificate, name string) error {
-	resp, err := c.raw.SetServerConfig("core.https_address", "[::]")
+func (c clientServerMethods) SetConfig(key, value string) error {
+	resp, err := c.raw.SetServerConfig(key, value)
 	if err != nil {
 		return errors.Trace(err)
 	}
+
 	if resp.Operation != "" {
 		if err := c.raw.WaitForSuccess(resp.Operation); err != nil {
 			// TODO(ericsnow) Handle different failures (from the async
@@ -40,7 +41,17 @@ func (c clientServerMethods) setUpRemote(cert *x509.Certificate, name string) er
 		}
 	}
 
-	if err := c.raw.CertificateAdd(cert, name); err != nil {
+	return nil
+}
+
+// AddCert adds the given certificate to the server.
+func (c clientServerMethods) AddCert(cert Cert, name string) error {
+	x509Cert, err := cert.X509()
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	if err := c.raw.CertificateAdd(x509Cert, name); err != nil {
 		return errors.Trace(err)
 	}
 

--- a/container/lxd/lxdclient/conn_server.go
+++ b/container/lxd/lxdclient/conn_server.go
@@ -25,10 +25,12 @@ func (c clientServerMethods) setUpRemote(cert *x509.Certificate, name string) er
 	if err != nil {
 		return errors.Trace(err)
 	}
-	if err := c.raw.WaitForSuccess(resp.Operation); err != nil {
-		// TODO(ericsnow) Handle different failures (from the async
-		// operation) differently?
-		return errors.Trace(err)
+	if resp.Operation != "" {
+		if err := c.raw.WaitForSuccess(resp.Operation); err != nil {
+			// TODO(ericsnow) Handle different failures (from the async
+			// operation) differently?
+			return errors.Trace(err)
+		}
 	}
 
 	if err := c.raw.CertificateAdd(cert, name); err != nil {

--- a/container/lxd/lxdclient/conn_server.go
+++ b/container/lxd/lxdclient/conn_server.go
@@ -27,6 +27,7 @@ type clientServerMethods struct {
 	raw rawServerMethods
 }
 
+// SetConfig sets the given value in the server's config.
 func (c clientServerMethods) SetConfig(key, value string) error {
 	resp, err := c.raw.SetServerConfig(key, value)
 	if err != nil {

--- a/container/lxd/lxdclient/conn_server.go
+++ b/container/lxd/lxdclient/conn_server.go
@@ -8,11 +8,15 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/lxc/lxd"
+	"github.com/lxc/lxd/shared"
 )
 
 type rawClientServerMethods interface {
 	WaitForSuccess(waitURL string) error
+
 	SetServerConfig(key string, value string) (*lxd.Response, error)
+
+	CertificateList() ([]shared.CertInfo, error)
 	CertificateAdd(cert *x509.Certificate, name string) error
 	CertificateRemove(fingerprint string) error
 }
@@ -39,6 +43,20 @@ func (c clientServerMethods) setUpRemote(cert *x509.Certificate, name string) er
 	}
 
 	return nil
+}
+
+// ListCerts returns the list of cert fingerprints from the server.
+func (c clientServerMethods) ListCerts() ([]string, error) {
+	certs, err := c.raw.CertificateList()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	var fingerprints []string
+	for _, cert := range certs {
+		fingerprints = append(fingerprints, cert.Fingerprint)
+	}
+	return fingerprints, nil
 }
 
 // RemoveCert removes the cert from the server.

--- a/container/lxd/lxdclient/conn_serverconfig.go
+++ b/container/lxd/lxdclient/conn_serverconfig.go
@@ -1,6 +1,8 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// +build go1.3
+
 package lxdclient
 
 import (

--- a/container/lxd/lxdclient/conn_serverconfig.go
+++ b/container/lxd/lxdclient/conn_serverconfig.go
@@ -1,0 +1,37 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package lxdclient
+
+import (
+	"github.com/juju/errors"
+	"github.com/lxc/lxd"
+)
+
+type rawServerConfigClient interface {
+	SetServerConfig(key string, value string) (*lxd.Response, error)
+
+	WaitForSuccess(waitURL string) error
+}
+
+type serverConfigClient struct {
+	raw rawServerConfigClient
+}
+
+// SetConfig sets the given value in the server's config.
+func (c serverConfigClient) SetConfig(key, value string) error {
+	resp, err := c.raw.SetServerConfig(key, value)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	if resp.Operation != "" {
+		if err := c.raw.WaitForSuccess(resp.Operation); err != nil {
+			// TODO(ericsnow) Handle different failures (from the async
+			// operation) differently?
+			return errors.Trace(err)
+		}
+	}
+
+	return nil
+}

--- a/container/lxd/lxdclient/export_test.go
+++ b/container/lxd/lxdclient/export_test.go
@@ -1,6 +1,8 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// +build go1.3
+
 package lxdclient
 
 var (

--- a/container/lxd/lxdclient/remote.go
+++ b/container/lxd/lxdclient/remote.go
@@ -1,6 +1,8 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// +build go1.3
+
 package lxdclient
 
 import (

--- a/container/lxd/lxdclient/remote.go
+++ b/container/lxd/lxdclient/remote.go
@@ -7,6 +7,9 @@ package lxdclient
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/utils"
+
+	"github.com/juju/juju/container/lxc"
 )
 
 const (
@@ -119,6 +122,28 @@ func (r Remote) validateLocal() error {
 	}
 
 	return nil
+}
+
+// AsNonLocal converts the remote into a non-local version. For
+// non-local remotes this is a no-op.
+func (r Remote) AsNonLocal() (*Remote, error) {
+	if !r.isLocal() {
+		return &r, nil
+	}
+
+	netIF := lxc.DefaultLxcBridge
+	addr, err := utils.GetAddressForInterface(netIF)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	r.Host = addr
+
+	r, err = r.SetDefaults()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	return &r, nil
 }
 
 // TODO(ericsnow) Add a "Connect(Config)" method that connects

--- a/container/lxd/lxdclient/remote.go
+++ b/container/lxd/lxdclient/remote.go
@@ -140,28 +140,28 @@ func (r Remote) validateLocal() error {
 // with the host set to the IP address of the local lxcbr0 bridge
 // interface. The remote is also set up for remote access, setting
 // the cert if not already set.
-func (r Remote) UsingTCP() (*Remote, error) {
+func (r Remote) UsingTCP() (Remote, error) {
 	// Note that r is a value receiver, so it is an implicit copy.
 
 	if !r.isLocal() {
-		return &r, nil
+		return r, nil
 	}
 
 	netIF := lxc.DefaultLxcBridge
 	addr, err := utils.GetAddressForInterface(netIF)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return r, errors.Trace(err)
 	}
 	r.Host = addr
 
 	r, err = r.SetDefaults()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return r, errors.Trace(err)
 	}
 
 	// TODO(ericsnow) Change r.Name if "local"? Prepend "juju-"?
 
-	return &r, nil
+	return r, nil
 }
 
 // TODO(ericsnow) Add a "Connect(Config)" method that connects

--- a/container/lxd/lxdclient/remote.go
+++ b/container/lxd/lxdclient/remote.go
@@ -76,7 +76,8 @@ func (r Remote) WithDefaults() (Remote, error) {
 		if err != nil {
 			return r, errors.Trace(err)
 		}
-		r.Cert = NewCert(certPEM, keyPEM)
+		cert := NewCert(certPEM, keyPEM)
+		r.Cert = &cert
 	}
 
 	cert, err := r.Cert.SetDefaults()

--- a/container/lxd/lxdclient/remote.go
+++ b/container/lxd/lxdclient/remote.go
@@ -49,11 +49,11 @@ func (ri RemoteInfo) SetDefaults() (RemoteInfo, error) {
 	}
 
 	if ri.Cert == nil {
-		cert, err := GenerateCert(genCertAndKey)
+		certPEM, keyPEM, err := genCertAndKey()
 		if err != nil {
 			return ri, errors.Trace(err)
 		}
-		ri.Cert = cert
+		ri.Cert = NewCert(certPEM, keyPEM)
 	}
 
 	return ri, nil

--- a/container/lxd/lxdclient/remote.go
+++ b/container/lxd/lxdclient/remote.go
@@ -67,6 +67,8 @@ func (r Remote) ID() string {
 // WithDefaults updates a copy of the remote with default values
 // where needed.
 func (r Remote) WithDefaults() (Remote, error) {
+	// Note that cert is a value receiver, so it is an implicit copy.
+
 	if r.isLocal() {
 		return r.withLocalDefaults(), nil
 	}

--- a/container/lxd/lxdclient/remote.go
+++ b/container/lxd/lxdclient/remote.go
@@ -86,7 +86,7 @@ func (r Remote) WithDefaults() (Remote, error) {
 	if err != nil {
 		return r, errors.Trace(err)
 	}
-	r.Cert = cert
+	r.Cert = &cert
 
 	return r, nil
 }

--- a/container/lxd/lxdclient/remote.go
+++ b/container/lxd/lxdclient/remote.go
@@ -20,6 +20,7 @@ const (
 var Local = Remote{
 	RemoteInfo: RemoteInfo{
 		Name: remoteLocalName,
+		Host: "", // The LXD API turns this into the local unix socket.
 	},
 }
 
@@ -44,7 +45,7 @@ type RemoteInfo struct {
 // SetDefaults updates a copy of the remote with default values
 // where needed.
 func (ri RemoteInfo) SetDefaults() (RemoteInfo, error) {
-	if ri.Host == "" {
+	if ri.Host == Local.Host {
 		return ri.setLocalDefaults(), nil
 	}
 
@@ -75,7 +76,7 @@ func (ri RemoteInfo) Validate() error {
 		return errors.NotValidf("remote missing name,")
 	}
 
-	if ri.Host == "" {
+	if ri.Host == Local.Host {
 		if err := ri.validateLocal(); err != nil {
 			return errors.Trace(err)
 		}
@@ -127,7 +128,7 @@ func (r Remote) setDefaults() (Remote, error) {
 
 // ID identifies the remote to the raw LXD client code.
 func (r Remote) ID() string {
-	if r.RemoteInfo.Host == "" {
+	if r.RemoteInfo.Host == Local.Host {
 		return remoteIDForLocal
 	}
 	return r.RemoteInfo.Name

--- a/container/lxd/lxdclient/remote.go
+++ b/container/lxd/lxdclient/remote.go
@@ -38,7 +38,7 @@ type RemoteInfo struct {
 	Host string
 
 	// Cert holds the TLS certificate data for the client to use.
-	Cert *Certificate
+	Cert *Cert
 }
 
 // SetDefaults updates a copy of the remote with default values
@@ -49,7 +49,7 @@ func (ri RemoteInfo) SetDefaults() (RemoteInfo, error) {
 	}
 
 	if ri.Cert == nil {
-		cert, err := GenerateCertificate(genCertAndKey)
+		cert, err := GenerateCert(genCertAndKey)
 		if err != nil {
 			return ri, errors.Trace(err)
 		}
@@ -134,9 +134,9 @@ func (r Remote) ID() string {
 }
 
 // Cert returns the certificate the client should use.
-func (r Remote) Cert() Certificate {
+func (r Remote) Cert() Cert {
 	if r.RemoteInfo.Cert == nil {
-		return Certificate{}
+		return Cert{}
 	}
 	return *r.RemoteInfo.Cert
 }

--- a/container/lxd/lxdclient/remote.go
+++ b/container/lxd/lxdclient/remote.go
@@ -143,6 +143,8 @@ func (r Remote) AsNonLocal() (*Remote, error) {
 		return nil, errors.Trace(err)
 	}
 
+	// TODO(ericsnow) Change r.Name if "local"? Prepend "juju-"?
+
 	return &r, nil
 }
 

--- a/container/lxd/lxdclient/remote.go
+++ b/container/lxd/lxdclient/remote.go
@@ -39,9 +39,18 @@ type Remote struct {
 	Cert *Cert
 }
 
+// isLocal determines if the remote is the implicit "local" remote,
+// an unencrypted, unauthenticated unix socket to a locally running LXD.
+func (r Remote) isLocal() bool {
+	if Local.Host != "" {
+		logger.Errorf("%#v", Local)
+	}
+	return r.Host == Local.Host
+}
+
 // ID identifies the remote to the raw LXD client code.
 func (r Remote) ID() string {
-	if r.Host == Local.Host {
+	if r.isLocal() {
 		return remoteIDForLocal
 	}
 	return r.Name
@@ -50,7 +59,7 @@ func (r Remote) ID() string {
 // SetDefaults updates a copy of the remote with default values
 // where needed.
 func (r Remote) SetDefaults() (Remote, error) {
-	if r.ID() == Local.ID() {
+	if r.isLocal() {
 		return r.setLocalDefaults(), nil
 	}
 
@@ -81,7 +90,7 @@ func (r Remote) Validate() error {
 		return errors.NotValidf("remote missing name,")
 	}
 
-	if r.ID() == Local.ID() {
+	if r.isLocal() {
 		if err := r.validateLocal(); err != nil {
 			return errors.Trace(err)
 		}

--- a/container/lxd/lxdclient/remote.go
+++ b/container/lxd/lxdclient/remote.go
@@ -50,7 +50,7 @@ func (r Remote) ID() string {
 // SetDefaults updates a copy of the remote with default values
 // where needed.
 func (r Remote) SetDefaults() (Remote, error) {
-	if r.Host == Local.Host {
+	if r.ID() == Local.ID() {
 		return r.setLocalDefaults(), nil
 	}
 
@@ -81,7 +81,7 @@ func (r Remote) Validate() error {
 		return errors.NotValidf("remote missing name,")
 	}
 
-	if r.Host == Local.Host {
+	if r.ID() == Local.ID() {
 		if err := r.validateLocal(); err != nil {
 			return errors.Trace(err)
 		}

--- a/container/lxd/lxdclient/remote.go
+++ b/container/lxd/lxdclient/remote.go
@@ -48,7 +48,9 @@ func (r Remote) isLocal() bool {
 	return r.Host == Local.Host
 }
 
-// ID identifies the remote to the raw LXD client code.
+// ID identifies the remote to the raw LXD client code. For the
+// non-local case this is Remote.Name. For the local case it is the
+// remote name that LXD special-cases for the local unix socket.
 func (r Remote) ID() string {
 	if r.isLocal() {
 		return remoteIDForLocal

--- a/container/lxd/lxdclient/remote.go
+++ b/container/lxd/lxdclient/remote.go
@@ -79,6 +79,12 @@ func (r Remote) WithDefaults() (Remote, error) {
 		r.Cert = NewCert(certPEM, keyPEM)
 	}
 
+	cert, err := r.Cert.SetDefaults()
+	if err != nil {
+		return r, errors.Trace(err)
+	}
+	r.Cert = cert
+
 	return r, nil
 }
 

--- a/container/lxd/lxdclient/remote.go
+++ b/container/lxd/lxdclient/remote.go
@@ -67,7 +67,7 @@ func (r Remote) ID() string {
 // WithDefaults updates a copy of the remote with default values
 // where needed.
 func (r Remote) WithDefaults() (Remote, error) {
-	// Note that cert is a value receiver, so it is an implicit copy.
+	// Note that ri is a value receiver, so it is an implicit copy.
 
 	if r.isLocal() {
 		return r.withLocalDefaults(), nil
@@ -133,9 +133,16 @@ func (r Remote) validateLocal() error {
 	return nil
 }
 
-// AsNonLocal converts the remote into a non-local version. For
+// UsingTCP converts the remote into a non-local version. For
 // non-local remotes this is a no-op.
-func (r Remote) AsNonLocal() (*Remote, error) {
+//
+// For a "local" remote (see Local), the remote is changed to a one
+// with the host set to the IP address of the local lxcbr0 bridge
+// interface. The remote is also set up for remote access, setting
+// the cert if not already set.
+func (r Remote) UsingTCP() (*Remote, error) {
+	// Note that r is a value receiver, so it is an implicit copy.
+
 	if !r.isLocal() {
 		return &r, nil
 	}

--- a/container/lxd/lxdclient/remote.go
+++ b/container/lxd/lxdclient/remote.go
@@ -82,7 +82,7 @@ func (r Remote) WithDefaults() (Remote, error) {
 		r.Cert = &cert
 	}
 
-	cert, err := r.Cert.SetDefaults()
+	cert, err := r.Cert.WithDefaults()
 	if err != nil {
 		return r, errors.Trace(err)
 	}
@@ -154,7 +154,7 @@ func (r Remote) UsingTCP() (Remote, error) {
 	}
 	r.Host = addr
 
-	r, err = r.SetDefaults()
+	r, err = r.WithDefaults()
 	if err != nil {
 		return r, errors.Trace(err)
 	}

--- a/container/lxd/lxdclient/remote.go
+++ b/container/lxd/lxdclient/remote.go
@@ -59,11 +59,11 @@ func (r Remote) ID() string {
 	return r.Name
 }
 
-// SetDefaults updates a copy of the remote with default values
+// WithDefaults updates a copy of the remote with default values
 // where needed.
-func (r Remote) SetDefaults() (Remote, error) {
+func (r Remote) WithDefaults() (Remote, error) {
 	if r.isLocal() {
-		return r.setLocalDefaults(), nil
+		return r.withLocalDefaults(), nil
 	}
 
 	if r.Cert == nil {
@@ -77,7 +77,7 @@ func (r Remote) SetDefaults() (Remote, error) {
 	return r, nil
 }
 
-func (r Remote) setLocalDefaults() Remote {
+func (r Remote) withLocalDefaults() Remote {
 	if r.Name == "" {
 		r.Name = remoteLocalName
 	}

--- a/container/lxd/lxdclient/remote.go
+++ b/container/lxd/lxdclient/remote.go
@@ -8,8 +8,9 @@ import (
 )
 
 const (
-	remoteLocalName   = "local"
-	remoteDefaultName = remoteLocalName
+	// remoteLocalName is a specific remote name in the default LXD config.
+	// See https://github.com/lxc/lxd/blob/master/config.go:defaultRemote.
+	remoteLocalName = "local"
 
 	// TODO(ericsnow) This may be changing to "local"
 	remoteIDForLocal = ""

--- a/container/lxd/lxdclient/remote_test.go
+++ b/container/lxd/lxdclient/remote_test.go
@@ -19,13 +19,13 @@ type remoteSuite struct {
 	lxdclient.BaseSuite
 }
 
-func (s *remoteSuite) TestSetDefaultsNoop(c *gc.C) {
+func (s *remoteSuite) TestWithDefaultsNoop(c *gc.C) {
 	remote := lxdclient.Remote{
 		Name: "my-remote",
 		Host: "some-host",
 		Cert: s.Cert,
 	}
-	updated, err := remote.SetDefaults()
+	updated, err := remote.WithDefaults()
 	c.Assert(err, jc.ErrorIsNil)
 	err = updated.Validate()
 
@@ -33,20 +33,20 @@ func (s *remoteSuite) TestSetDefaultsNoop(c *gc.C) {
 	c.Check(updated, jc.DeepEquals, remote)
 }
 
-func (s *remoteSuite) TestSetDefaultsMissingName(c *gc.C) {
+func (s *remoteSuite) TestWithDefaultsMissingName(c *gc.C) {
 	remote := lxdclient.Remote{
 		Name: "",
 		Host: "some-host",
 		Cert: s.Cert,
 	}
-	updated, err := remote.SetDefaults()
+	updated, err := remote.WithDefaults()
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(updated, jc.DeepEquals, remote) // Name is not updated.
 }
 
 // TODO(ericsnow) Move this test to a functional suite.
-func (s *remoteSuite) TestSetDefaultsMissingCert(c *gc.C) {
+func (s *remoteSuite) TestWithDefaultsMissingCert(c *gc.C) {
 	remote := lxdclient.Remote{
 		Name: "my-remote",
 		Host: "some-host",
@@ -55,7 +55,7 @@ func (s *remoteSuite) TestSetDefaultsMissingCert(c *gc.C) {
 	err := remote.Validate()
 	c.Assert(err, gc.NotNil) // Make sure the original is invalid.
 
-	updated, err := remote.SetDefaults()
+	updated, err := remote.WithDefaults()
 	c.Assert(err, jc.ErrorIsNil)
 	err = updated.Validate()
 
@@ -68,9 +68,9 @@ func (s *remoteSuite) TestSetDefaultsMissingCert(c *gc.C) {
 	})
 }
 
-func (s *remoteSuite) TestSetDefaultsZeroValue(c *gc.C) {
+func (s *remoteSuite) TestWithDefaultsZeroValue(c *gc.C) {
 	var remote lxdclient.Remote
-	updated, err := remote.SetDefaults()
+	updated, err := remote.WithDefaults()
 	c.Assert(err, jc.ErrorIsNil)
 	err = updated.Validate()
 
@@ -82,13 +82,13 @@ func (s *remoteSuite) TestSetDefaultsZeroValue(c *gc.C) {
 	})
 }
 
-func (s *remoteSuite) TestSetDefaultsLocalNoop(c *gc.C) {
+func (s *remoteSuite) TestWithDefaultsLocalNoop(c *gc.C) {
 	remote := lxdclient.Remote{
 		Name: "my-local",
 		Host: "",
 		Cert: nil,
 	}
-	updated, err := remote.SetDefaults()
+	updated, err := remote.WithDefaults()
 	c.Assert(err, jc.ErrorIsNil)
 	err = updated.Validate()
 
@@ -100,13 +100,13 @@ func (s *remoteSuite) TestSetDefaultsLocalNoop(c *gc.C) {
 	})
 }
 
-func (s *remoteSuite) TestSetDefaultsLocalMissingName(c *gc.C) {
+func (s *remoteSuite) TestWithDefaultsLocalMissingName(c *gc.C) {
 	remote := lxdclient.Remote{
 		Name: "",
 		Host: "",
 		Cert: nil,
 	}
-	updated, err := remote.SetDefaults()
+	updated, err := remote.WithDefaults()
 	c.Assert(err, jc.ErrorIsNil)
 	err = updated.Validate()
 

--- a/container/lxd/lxdclient/remote_test.go
+++ b/container/lxd/lxdclient/remote_test.go
@@ -156,7 +156,7 @@ func (s *remoteInfoSuite) TestValidateBadCert(c *gc.C) {
 	info := lxdclient.RemoteInfo{
 		Name: "my-remote",
 		Host: "some-host",
-		Cert: &lxdclient.Certificate{},
+		Cert: &lxdclient.Cert{},
 	}
 	err := info.Validate()
 
@@ -189,7 +189,7 @@ func (s *remoteInfoSuite) TestValidateLocalWithCert(c *gc.C) {
 	info := lxdclient.RemoteInfo{
 		Name: "my-local",
 		Host: "",
-		Cert: &lxdclient.Certificate{},
+		Cert: &lxdclient.Cert{},
 	}
 	err := info.Validate()
 
@@ -279,5 +279,5 @@ func (s *remoteSuite) TestCertMissing(c *gc.C) {
 	})
 	cert := remote.Cert()
 
-	c.Check(cert, jc.DeepEquals, lxdclient.Certificate{})
+	c.Check(cert, jc.DeepEquals, lxdclient.Cert{})
 }

--- a/container/lxd/lxdclient/remote_test.go
+++ b/container/lxd/lxdclient/remote_test.go
@@ -253,7 +253,7 @@ func (s *remoteSuite) TestUsingTCPNoop(c *gc.C) {
 	nonlocal, err := remote.UsingTCP()
 	c.Assert(err, jc.ErrorIsNil)
 
-	c.Check(*nonlocal, jc.DeepEquals, remote)
+	c.Check(nonlocal, jc.DeepEquals, remote)
 }
 
 type remoteFunctionalSuite struct {
@@ -273,8 +273,8 @@ func (s *remoteFunctionalSuite) TestUsingTCP(c *gc.C) {
 	nonlocal, err := remote.UsingTCP()
 	c.Assert(err, jc.ErrorIsNil)
 
-	checkValidRemote(c, nonlocal)
-	c.Check(*nonlocal, jc.DeepEquals, lxdclient.Remote{
+	checkValidRemote(c, &nonlocal)
+	c.Check(nonlocal, jc.DeepEquals, lxdclient.Remote{
 		Name: "my-remote",
 		Host: nonlocal.Host,
 		Cert: nonlocal.Cert,

--- a/container/lxd/lxdclient/remote_test.go
+++ b/container/lxd/lxdclient/remote_test.go
@@ -273,13 +273,23 @@ func (s *remoteFunctionalSuite) TestAsNonLocal(c *gc.C) {
 	nonlocal, err := remote.AsNonLocal()
 	c.Assert(err, jc.ErrorIsNil)
 
-	c.Check(nonlocal.Host, jc.Satisfies, func(v interface{}) bool {
-		return net.ParseIP(v.(string)) != nil
-	})
-	checkValidCert(c, nonlocal.Cert)
+	checkValidRemote(c, nonlocal)
 	c.Check(*nonlocal, jc.DeepEquals, lxdclient.Remote{
 		Name: "my-remote",
 		Host: nonlocal.Host,
 		Cert: nonlocal.Cert,
 	})
+}
+
+func checkValidRemote(c *gc.C, remote *lxdclient.Remote) {
+	c.Check(remote.Host, jc.Satisfies, isValidAddr)
+	checkValidCert(c, remote.Cert)
+}
+
+func isValidAddr(value interface{}) bool {
+	addr, ok := value.(string)
+	if !ok {
+		return false
+	}
+	return net.ParseIP(addr) != nil
 }

--- a/container/lxd/lxdclient/remote_test.go
+++ b/container/lxd/lxdclient/remote_test.go
@@ -6,15 +6,19 @@
 package lxdclient_test
 
 import (
+	"net"
+
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/container/lxc"
 	"github.com/juju/juju/container/lxd/lxdclient"
 )
 
 var (
 	_ = gc.Suite(&remoteSuite{})
+	_ = gc.Suite(&remoteFunctionalSuite{})
 )
 
 type remoteSuite struct {
@@ -233,4 +237,49 @@ func (s *remoteSuite) TestIDLocal(c *gc.C) {
 	id := remote.ID()
 
 	c.Check(id, gc.Equals, "")
+}
+
+func (s *remoteSuite) TestAsNonLocalOkay(c *gc.C) {
+	c.Skip("not implemented yet")
+	// TODO(ericsnow) Finish this!
+}
+
+func (s *remoteSuite) TestAsNonLocalNoop(c *gc.C) {
+	remote := lxdclient.Remote{
+		Name: "my-remote",
+		Host: "some-host",
+		Cert: s.Cert,
+	}
+	nonlocal, err := remote.AsNonLocal()
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(*nonlocal, jc.DeepEquals, remote)
+}
+
+type remoteFunctionalSuite struct {
+	lxdclient.BaseSuite
+}
+
+func (s *remoteFunctionalSuite) TestAsNonLocal(c *gc.C) {
+	if _, err := net.InterfaceByName(lxc.DefaultLxcBridge); err != nil {
+		c.Skip("network bridge interface not found")
+	}
+
+	remote := lxdclient.Remote{
+		Name: "my-remote",
+		Host: "",
+		Cert: nil,
+	}
+	nonlocal, err := remote.AsNonLocal()
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(nonlocal.Host, jc.Satisfies, func(v interface{}) bool {
+		return net.ParseIP(v.(string)) != nil
+	})
+	checkValidCert(c, nonlocal.Cert)
+	c.Check(*nonlocal, jc.DeepEquals, lxdclient.Remote{
+		Name: "my-remote",
+		Host: nonlocal.Host,
+		Cert: nonlocal.Cert,
+	})
 }

--- a/container/lxd/lxdclient/remote_test.go
+++ b/container/lxd/lxdclient/remote_test.go
@@ -239,18 +239,18 @@ func (s *remoteSuite) TestIDLocal(c *gc.C) {
 	c.Check(id, gc.Equals, "")
 }
 
-func (s *remoteSuite) TestAsNonLocalOkay(c *gc.C) {
+func (s *remoteSuite) TestUsingTCPOkay(c *gc.C) {
 	c.Skip("not implemented yet")
 	// TODO(ericsnow) Finish this!
 }
 
-func (s *remoteSuite) TestAsNonLocalNoop(c *gc.C) {
+func (s *remoteSuite) TestUsingTCPNoop(c *gc.C) {
 	remote := lxdclient.Remote{
 		Name: "my-remote",
 		Host: "some-host",
 		Cert: s.Cert,
 	}
-	nonlocal, err := remote.AsNonLocal()
+	nonlocal, err := remote.UsingTCP()
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(*nonlocal, jc.DeepEquals, remote)
@@ -260,7 +260,7 @@ type remoteFunctionalSuite struct {
 	lxdclient.BaseSuite
 }
 
-func (s *remoteFunctionalSuite) TestAsNonLocal(c *gc.C) {
+func (s *remoteFunctionalSuite) TestUsingTCP(c *gc.C) {
 	if _, err := net.InterfaceByName(lxc.DefaultLxcBridge); err != nil {
 		c.Skip("network bridge interface not found")
 	}
@@ -270,7 +270,7 @@ func (s *remoteFunctionalSuite) TestAsNonLocal(c *gc.C) {
 		Host: "",
 		Cert: nil,
 	}
-	nonlocal, err := remote.AsNonLocal()
+	nonlocal, err := remote.UsingTCP()
 	c.Assert(err, jc.ErrorIsNil)
 
 	checkValidRemote(c, nonlocal)

--- a/container/lxd/lxdclient/remote_test.go
+++ b/container/lxd/lxdclient/remote_test.go
@@ -1,6 +1,8 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// +build go1.3
+
 package lxdclient_test
 
 import (

--- a/container/lxd/lxdclient/remote_test.go
+++ b/container/lxd/lxdclient/remote_test.go
@@ -12,209 +12,118 @@ import (
 )
 
 var (
-	_ = gc.Suite(&remoteInfoSuite{})
 	_ = gc.Suite(&remoteSuite{})
 )
-
-type remoteInfoSuite struct {
-	lxdclient.BaseSuite
-}
-
-func (s *remoteInfoSuite) TestSetDefaultsNoop(c *gc.C) {
-	info := lxdclient.RemoteInfo{
-		Name: "my-remote",
-		Host: "some-host",
-		Cert: s.Cert,
-	}
-	updated, err := info.SetDefaults()
-	c.Assert(err, jc.ErrorIsNil)
-	err = updated.Validate()
-
-	c.Check(err, jc.ErrorIsNil)
-	c.Check(updated, jc.DeepEquals, info)
-}
-
-func (s *remoteInfoSuite) TestSetDefaultsMissingName(c *gc.C) {
-	info := lxdclient.RemoteInfo{
-		Name: "",
-		Host: "some-host",
-		Cert: s.Cert,
-	}
-	updated, err := info.SetDefaults()
-	c.Assert(err, jc.ErrorIsNil)
-
-	c.Check(updated, jc.DeepEquals, info) // Name is not updated.
-}
-
-// TODO(ericsnow) Move this test to a functional suite.
-func (s *remoteInfoSuite) TestSetDefaultsMissingCert(c *gc.C) {
-	info := lxdclient.RemoteInfo{
-		Name: "my-remote",
-		Host: "some-host",
-		Cert: nil,
-	}
-	err := info.Validate()
-	c.Assert(err, gc.NotNil) // Make sure the original is invalid.
-
-	updated, err := info.SetDefaults()
-	c.Assert(err, jc.ErrorIsNil)
-	err = updated.Validate()
-
-	c.Check(err, jc.ErrorIsNil)
-	updated.Cert = nil // Validate ensured that the cert was okay.
-	c.Check(updated, jc.DeepEquals, lxdclient.RemoteInfo{
-		Name: "my-remote",
-		Host: "some-host",
-		Cert: nil,
-	})
-}
-
-func (s *remoteInfoSuite) TestSetDefaultsZeroValue(c *gc.C) {
-	var info lxdclient.RemoteInfo
-	updated, err := info.SetDefaults()
-	c.Assert(err, jc.ErrorIsNil)
-	err = updated.Validate()
-
-	c.Check(err, jc.ErrorIsNil)
-	c.Check(updated, jc.DeepEquals, lxdclient.RemoteInfo{
-		Name: "local",
-		Host: "",
-		Cert: nil,
-	})
-}
-
-func (s *remoteInfoSuite) TestSetDefaultsLocalNoop(c *gc.C) {
-	info := lxdclient.RemoteInfo{
-		Name: "my-local",
-		Host: "",
-		Cert: nil,
-	}
-	updated, err := info.SetDefaults()
-	c.Assert(err, jc.ErrorIsNil)
-	err = updated.Validate()
-
-	c.Check(err, jc.ErrorIsNil)
-	c.Check(updated, jc.DeepEquals, lxdclient.RemoteInfo{
-		Name: "my-local",
-		Host: "",
-		Cert: nil,
-	})
-}
-
-func (s *remoteInfoSuite) TestSetDefaultsLocalMissingName(c *gc.C) {
-	info := lxdclient.RemoteInfo{
-		Name: "",
-		Host: "",
-		Cert: nil,
-	}
-	updated, err := info.SetDefaults()
-	c.Assert(err, jc.ErrorIsNil)
-	err = updated.Validate()
-
-	c.Check(err, jc.ErrorIsNil)
-	c.Check(updated, jc.DeepEquals, lxdclient.RemoteInfo{
-		Name: "local",
-		Host: "",
-		Cert: nil,
-	})
-}
-
-func (s *remoteInfoSuite) TestValidateOkay(c *gc.C) {
-	info := lxdclient.RemoteInfo{
-		Name: "my-remote",
-		Host: "some-host",
-		Cert: s.Cert,
-	}
-	err := info.Validate()
-
-	c.Check(err, jc.ErrorIsNil)
-}
-
-func (s *remoteInfoSuite) TestValidateMissingName(c *gc.C) {
-	info := lxdclient.RemoteInfo{
-		Name: "",
-		Host: "some-host",
-		Cert: s.Cert,
-	}
-	err := info.Validate()
-
-	c.Check(err, jc.Satisfies, errors.IsNotValid)
-}
-
-func (s *remoteInfoSuite) TestValidateMissingCert(c *gc.C) {
-	info := lxdclient.RemoteInfo{
-		Name: "my-remote",
-		Host: "some-host",
-		Cert: nil,
-	}
-	err := info.Validate()
-
-	c.Check(err, jc.Satisfies, errors.IsNotValid)
-}
-
-func (s *remoteInfoSuite) TestValidateBadCert(c *gc.C) {
-	info := lxdclient.RemoteInfo{
-		Name: "my-remote",
-		Host: "some-host",
-		Cert: &lxdclient.Cert{},
-	}
-	err := info.Validate()
-
-	c.Check(err, jc.Satisfies, errors.IsNotValid)
-}
-
-func (s *remoteInfoSuite) TestValidateLocalOkay(c *gc.C) {
-	info := lxdclient.RemoteInfo{
-		Name: "my-local",
-		Host: "",
-		Cert: nil,
-	}
-	err := info.Validate()
-
-	c.Check(err, jc.ErrorIsNil)
-}
-
-func (s *remoteInfoSuite) TestValidateLocalMissingName(c *gc.C) {
-	info := lxdclient.RemoteInfo{
-		Name: "",
-		Host: "",
-		Cert: nil,
-	}
-	err := info.Validate()
-
-	c.Check(err, jc.Satisfies, errors.IsNotValid)
-}
-
-func (s *remoteInfoSuite) TestValidateLocalWithCert(c *gc.C) {
-	info := lxdclient.RemoteInfo{
-		Name: "my-local",
-		Host: "",
-		Cert: &lxdclient.Cert{},
-	}
-	err := info.Validate()
-
-	c.Check(err, jc.Satisfies, errors.IsNotValid)
-}
 
 type remoteSuite struct {
 	lxdclient.BaseSuite
 }
 
-func (s *remoteSuite) TestLocal(c *gc.C) {
-	expected := lxdclient.NewRemote(lxdclient.RemoteInfo{
+func (s *remoteSuite) TestSetDefaultsNoop(c *gc.C) {
+	remote := lxdclient.Remote{
+		Name: "my-remote",
+		Host: "some-host",
+		Cert: s.Cert,
+	}
+	updated, err := remote.SetDefaults()
+	c.Assert(err, jc.ErrorIsNil)
+	err = updated.Validate()
+
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(updated, jc.DeepEquals, remote)
+}
+
+func (s *remoteSuite) TestSetDefaultsMissingName(c *gc.C) {
+	remote := lxdclient.Remote{
+		Name: "",
+		Host: "some-host",
+		Cert: s.Cert,
+	}
+	updated, err := remote.SetDefaults()
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(updated, jc.DeepEquals, remote) // Name is not updated.
+}
+
+// TODO(ericsnow) Move this test to a functional suite.
+func (s *remoteSuite) TestSetDefaultsMissingCert(c *gc.C) {
+	remote := lxdclient.Remote{
+		Name: "my-remote",
+		Host: "some-host",
+		Cert: nil,
+	}
+	err := remote.Validate()
+	c.Assert(err, gc.NotNil) // Make sure the original is invalid.
+
+	updated, err := remote.SetDefaults()
+	c.Assert(err, jc.ErrorIsNil)
+	err = updated.Validate()
+
+	c.Check(err, jc.ErrorIsNil)
+	updated.Cert = nil // Validate ensured that the cert was okay.
+	c.Check(updated, jc.DeepEquals, lxdclient.Remote{
+		Name: "my-remote",
+		Host: "some-host",
+		Cert: nil,
+	})
+}
+
+func (s *remoteSuite) TestSetDefaultsZeroValue(c *gc.C) {
+	var remote lxdclient.Remote
+	updated, err := remote.SetDefaults()
+	c.Assert(err, jc.ErrorIsNil)
+	err = updated.Validate()
+
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(updated, jc.DeepEquals, lxdclient.Remote{
 		Name: "local",
 		Host: "",
 		Cert: nil,
 	})
-	c.Check(lxdclient.Local, jc.DeepEquals, expected)
+}
+
+func (s *remoteSuite) TestSetDefaultsLocalNoop(c *gc.C) {
+	remote := lxdclient.Remote{
+		Name: "my-local",
+		Host: "",
+		Cert: nil,
+	}
+	updated, err := remote.SetDefaults()
+	c.Assert(err, jc.ErrorIsNil)
+	err = updated.Validate()
+
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(updated, jc.DeepEquals, lxdclient.Remote{
+		Name: "my-local",
+		Host: "",
+		Cert: nil,
+	})
+}
+
+func (s *remoteSuite) TestSetDefaultsLocalMissingName(c *gc.C) {
+	remote := lxdclient.Remote{
+		Name: "",
+		Host: "",
+		Cert: nil,
+	}
+	updated, err := remote.SetDefaults()
+	c.Assert(err, jc.ErrorIsNil)
+	err = updated.Validate()
+
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(updated, jc.DeepEquals, lxdclient.Remote{
+		Name: "local",
+		Host: "",
+		Cert: nil,
+	})
 }
 
 func (s *remoteSuite) TestValidateOkay(c *gc.C) {
-	remote := lxdclient.NewRemote(lxdclient.RemoteInfo{
+	remote := lxdclient.Remote{
 		Name: "my-remote",
 		Host: "some-host",
 		Cert: s.Cert,
-	})
+	}
 	err := remote.Validate()
 
 	c.Check(err, jc.ErrorIsNil)
@@ -227,57 +136,99 @@ func (s *remoteSuite) TestValidateZeroValue(c *gc.C) {
 	c.Check(err, jc.Satisfies, errors.IsNotValid)
 }
 
-func (s *remoteSuite) TestValidateInvalid(c *gc.C) {
-	remote := lxdclient.NewRemote(lxdclient.RemoteInfo{
+func (s *remoteSuite) TestValidateMissingName(c *gc.C) {
+	remote := lxdclient.Remote{
 		Name: "",
 		Host: "some-host",
 		Cert: s.Cert,
-	})
+	}
 	err := remote.Validate()
 
 	c.Check(err, jc.Satisfies, errors.IsNotValid)
 }
 
+func (s *remoteSuite) TestValidateMissingCert(c *gc.C) {
+	remote := lxdclient.Remote{
+		Name: "my-remote",
+		Host: "some-host",
+		Cert: nil,
+	}
+	err := remote.Validate()
+
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+}
+
+func (s *remoteSuite) TestValidateBadCert(c *gc.C) {
+	remote := lxdclient.Remote{
+		Name: "my-remote",
+		Host: "some-host",
+		Cert: &lxdclient.Cert{},
+	}
+	err := remote.Validate()
+
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+}
+
+func (s *remoteSuite) TestValidateLocalOkay(c *gc.C) {
+	remote := lxdclient.Remote{
+		Name: "my-local",
+		Host: "",
+		Cert: nil,
+	}
+	err := remote.Validate()
+
+	c.Check(err, jc.ErrorIsNil)
+}
+
+func (s *remoteSuite) TestValidateLocalMissingName(c *gc.C) {
+	remote := lxdclient.Remote{
+		Name: "",
+		Host: "",
+		Cert: nil,
+	}
+	err := remote.Validate()
+
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+}
+
+func (s *remoteSuite) TestValidateLocalWithCert(c *gc.C) {
+	remote := lxdclient.Remote{
+		Name: "my-local",
+		Host: "",
+		Cert: &lxdclient.Cert{},
+	}
+	err := remote.Validate()
+
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+}
+
+func (s *remoteSuite) TestLocal(c *gc.C) {
+	expected := lxdclient.Remote{
+		Name: "local",
+		Host: "",
+		Cert: nil,
+	}
+	c.Check(lxdclient.Local, jc.DeepEquals, expected)
+}
+
 func (s *remoteSuite) TestIDOkay(c *gc.C) {
-	remote := lxdclient.NewRemote(lxdclient.RemoteInfo{
+	remote := lxdclient.Remote{
 		Name: "my-remote",
 		Host: "some-host",
 		Cert: s.Cert,
-	})
+	}
 	id := remote.ID()
 
 	c.Check(id, gc.Equals, "my-remote")
 }
 
 func (s *remoteSuite) TestIDLocal(c *gc.C) {
-	remote := lxdclient.NewRemote(lxdclient.RemoteInfo{
+	remote := lxdclient.Remote{
 		Name: "my-remote",
 		Host: "",
 		Cert: s.Cert,
-	})
+	}
 	id := remote.ID()
 
 	c.Check(id, gc.Equals, "")
-}
-
-func (s *remoteSuite) TestCertOkay(c *gc.C) {
-	remote := lxdclient.NewRemote(lxdclient.RemoteInfo{
-		Name: "my-remote",
-		Host: "some-host",
-		Cert: s.Cert,
-	})
-	cert := remote.Cert()
-
-	c.Check(cert, jc.DeepEquals, *s.Cert)
-}
-
-func (s *remoteSuite) TestCertMissing(c *gc.C) {
-	remote := lxdclient.NewRemote(lxdclient.RemoteInfo{
-		Name: "my-remote",
-		Host: "some-host",
-		Cert: nil,
-	})
-	cert := remote.Cert()
-
-	c.Check(cert, jc.DeepEquals, lxdclient.Cert{})
 }

--- a/container/lxd/lxdclient/testing_test.go
+++ b/container/lxd/lxdclient/testing_test.go
@@ -133,12 +133,3 @@ func (s *stubClient) SetContainerConfig(name, key, value string) error {
 
 	return nil
 }
-
-func (s *stubClient) ContainerDeviceAdd(name, devname, devtype string, props []string) (*lxd.Response, error) {
-	s.stub.AddCall("ContainerDeviceAdd", name, devname, devtype, props)
-	if err := s.stub.NextErr(); err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	return s.Response, nil
-}

--- a/container/lxd/lxdclient/testing_test.go
+++ b/container/lxd/lxdclient/testing_test.go
@@ -30,6 +30,7 @@ func (s *BaseSuite) SetUpTest(c *gc.C) {
 	s.Stub = &testing.Stub{}
 	s.Client = &stubClient{stub: s.Stub}
 	s.Cert = &Cert{
+		Name:    "a-cert",
 		CertPEM: []byte("<a valid PEM-encoded x.509 cert>"),
 		KeyPEM:  []byte("<a valid PEM-encoded x.509 key>"),
 	}

--- a/container/lxd/lxdclient/testing_test.go
+++ b/container/lxd/lxdclient/testing_test.go
@@ -6,6 +6,7 @@
 package lxdclient
 
 import (
+	"crypto/x509"
 	"os"
 
 	"github.com/juju/errors"
@@ -45,6 +46,24 @@ type stubClient struct {
 
 func (s *stubClient) WaitForSuccess(waitURL string) error {
 	s.stub.AddCall("WaitForSuccess", waitURL)
+	if err := s.stub.NextErr(); err != nil {
+		return errors.Trace(err)
+	}
+
+	return nil
+}
+
+func (s *stubClient) SetServerConfig(key string, value string) (*lxd.Response, error) {
+	s.stub.AddCall("SetServerConfig", key, value)
+	if err := s.stub.NextErr(); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	return s.Response, nil
+}
+
+func (s *stubClient) CertificateAdd(cert *x509.Certificate, name string) error {
+	s.stub.AddCall("CertificateAdd", cert, name)
 	if err := s.stub.NextErr(); err != nil {
 		return errors.Trace(err)
 	}

--- a/container/lxd/lxdclient/testing_test.go
+++ b/container/lxd/lxdclient/testing_test.go
@@ -30,7 +30,7 @@ func (s *BaseSuite) SetUpTest(c *gc.C) {
 	s.Stub = &testing.Stub{}
 	s.Client = &stubClient{stub: s.Stub}
 	s.Cert = &Cert{
-		Name:    "a-cert",
+		Name:    "some cert",
 		CertPEM: []byte("<a valid PEM-encoded x.509 cert>"),
 		KeyPEM:  []byte("<a valid PEM-encoded x.509 key>"),
 	}

--- a/container/lxd/lxdclient/testing_test.go
+++ b/container/lxd/lxdclient/testing_test.go
@@ -20,7 +20,7 @@ type BaseSuite struct {
 
 	Stub   *testing.Stub
 	Client *stubClient
-	Cert   *Certificate
+	Cert   *Cert
 }
 
 func (s *BaseSuite) SetUpTest(c *gc.C) {
@@ -28,7 +28,7 @@ func (s *BaseSuite) SetUpTest(c *gc.C) {
 
 	s.Stub = &testing.Stub{}
 	s.Client = &stubClient{stub: s.Stub}
-	s.Cert = &Certificate{
+	s.Cert = &Cert{
 		CertPEM: []byte("<a valid PEM-encoded x.509 cert>"),
 		KeyPEM:  []byte("<a valid PEM-encoded x.509 key>"),
 	}

--- a/provider/lxd/config.go
+++ b/provider/lxd/config.go
@@ -278,14 +278,8 @@ func (c *environConfig) clientConfig() (lxdclient.Config, error) {
 	return cfg, nil
 }
 
-func asNonLocal(cfg lxdclient.Config) (lxdclient.Config, error) {
-	// TODO(ericsnow) If local then set up cert and reset clientCfg.
-	nonlocal, err := cfg.AsNonLocal()
-	if err != nil {
-		return nonlocal, errors.Trace(err)
-	}
-	return nonlocal, nil
-}
+// TODO(ericsnow) Switch to a DI testing approach and eliminiate this var.
+var asNonLocal = lxdclient.Config.AsNonLocal
 
 func (c *environConfig) updateForClientConfig(clientCfg lxdclient.Config) (*environConfig, error) {
 	nonlocal, err := asNonLocal(clientCfg)

--- a/provider/lxd/config.go
+++ b/provider/lxd/config.go
@@ -256,20 +256,20 @@ func (c *environConfig) clientKey() string {
 
 // clientConfig builds a LXD Config based on the env config and returns it.
 func (c *environConfig) clientConfig() (lxdclient.Config, error) {
-	remoteInfo := lxdclient.RemoteInfo{
+	remote := lxdclient.Remote{
 		Name: "juju-remote",
 		Host: c.remoteURL(),
 	}
 	if c.clientCert() != "" {
 		certPEM := []byte(c.clientCert())
 		keyPEM := []byte(c.clientKey())
-		remoteInfo.Cert = lxdclient.NewCert(certPEM, keyPEM)
+		remote.Cert = lxdclient.NewCert(certPEM, keyPEM)
 	}
 
 	cfg := lxdclient.Config{
 		Namespace: c.namespace(),
 		Dirname:   c.dirname(),
-		Remote:    lxdclient.NewRemote(remoteInfo),
+		Remote:    remote,
 	}
 	cfg, err := cfg.SetDefaults()
 	if err != nil {
@@ -295,7 +295,10 @@ func (c *environConfig) updateForClientConfig(clientCfg lxdclient.Config) (*envi
 
 	c.attrs[cfgRemoteURL] = clientCfg.Remote.Host
 
-	cert := clientCfg.Remote.Cert()
+	var cert lxdclient.Cert
+	if clientCfg.Remote.Cert != nil {
+		cert = *clientCfg.Remote.Cert
+	}
 	c.attrs[cfgClientCert] = string(cert.CertPEM)
 	c.attrs[cfgClientKey] = string(cert.KeyPEM)
 

--- a/provider/lxd/config.go
+++ b/provider/lxd/config.go
@@ -278,11 +278,18 @@ func (c *environConfig) clientConfig() (lxdclient.Config, error) {
 	return cfg, nil
 }
 
+func asNonLocal(cfg lxdclient.Config) (lxdclient.Config, error) {
+	// TODO(ericsnow) If local then set up cert and reset clientCfg.
+	//return errors.Errorf("not finished!")
+	return cfg, nil
+}
+
 func (c *environConfig) updateForClientConfig(clientCfg lxdclient.Config) (*environConfig, error) {
-	if clientCfg.Remote.ID() == "" {
-		// TODO(ericsnow) Set up cert and reset clientCfg.
-		//return errors.Errorf("not finished!")
+	nonlocal, err := asNonLocal(clientCfg)
+	if err != nil {
+		return nil, errors.Trace(err)
 	}
+	clientCfg = nonlocal
 
 	c.attrs[cfgNamespace] = clientCfg.Namespace
 

--- a/provider/lxd/config.go
+++ b/provider/lxd/config.go
@@ -382,17 +382,3 @@ func (c *environConfig) update(cfg *config.Config) error {
 	c.attrs = cfg.UnknownAttrs()
 	return nil
 }
-
-// setRemoteFromHost sets the "remote" option to the address of the
-// host machine, as reachable by an LXD container. It also ensures that
-// the host's LXD is configured properly.
-func (c *environConfig) setRemoteFromHost() (*environConfig, error) {
-	updated, err := newValidConfig(c.Config, nil)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	// TODO(ericsnow) Do the work.
-
-	return updated, nil
-}

--- a/provider/lxd/config.go
+++ b/provider/lxd/config.go
@@ -280,8 +280,11 @@ func (c *environConfig) clientConfig() (lxdclient.Config, error) {
 
 func asNonLocal(cfg lxdclient.Config) (lxdclient.Config, error) {
 	// TODO(ericsnow) If local then set up cert and reset clientCfg.
-	//return errors.Errorf("not finished!")
-	return cfg, nil
+	nonlocal, err := cfg.AsNonLocal()
+	if err != nil {
+		return nonlocal, errors.Trace(err)
+	}
+	return nonlocal, nil
 }
 
 func (c *environConfig) updateForClientConfig(clientCfg lxdclient.Config) (*environConfig, error) {

--- a/provider/lxd/config.go
+++ b/provider/lxd/config.go
@@ -6,6 +6,8 @@
 package lxd
 
 import (
+	"fmt"
+
 	"github.com/juju/errors"
 	"github.com/juju/schema"
 	"gopkg.in/juju/environschema.v1"
@@ -264,6 +266,7 @@ func (c *environConfig) clientConfig() (lxdclient.Config, error) {
 		certPEM := []byte(c.clientCert())
 		keyPEM := []byte(c.clientKey())
 		remote.Cert = lxdclient.NewCert(certPEM, keyPEM)
+		remote.Cert.Name = fmt.Sprintf("juju cert for env %q", c.Name())
 	}
 
 	cfg := lxdclient.Config{

--- a/provider/lxd/config.go
+++ b/provider/lxd/config.go
@@ -271,7 +271,7 @@ func (c *environConfig) clientConfig() (lxdclient.Config, error) {
 		Dirname:   c.dirname(),
 		Remote:    remote,
 	}
-	cfg, err := cfg.SetDefaults()
+	cfg, err := cfg.WithDefaults()
 	if err != nil {
 		return cfg, errors.Trace(err)
 	}

--- a/provider/lxd/config.go
+++ b/provider/lxd/config.go
@@ -265,8 +265,9 @@ func (c *environConfig) clientConfig() (lxdclient.Config, error) {
 	if c.clientCert() != "" {
 		certPEM := []byte(c.clientCert())
 		keyPEM := []byte(c.clientKey())
-		remote.Cert = lxdclient.NewCert(certPEM, keyPEM)
-		remote.Cert.Name = fmt.Sprintf("juju cert for env %q", c.Name())
+		cert := lxdclient.NewCert(certPEM, keyPEM)
+		cert.Name = fmt.Sprintf("juju cert for env %q", c.Name())
+		remote.Cert = &cert
 	}
 
 	cfg := lxdclient.Config{
@@ -282,7 +283,7 @@ func (c *environConfig) clientConfig() (lxdclient.Config, error) {
 }
 
 // TODO(ericsnow) Switch to a DI testing approach and eliminiate this var.
-var asNonLocal = lxdclient.Config.AsNonLocal
+var asNonLocal = lxdclient.Config.UsingTCPRemote
 
 func (c *environConfig) updateForClientConfig(clientCfg lxdclient.Config) (*environConfig, error) {
 	nonlocal, err := asNonLocal(clientCfg)

--- a/provider/lxd/config.go
+++ b/provider/lxd/config.go
@@ -263,7 +263,7 @@ func (c *environConfig) clientConfig() (lxdclient.Config, error) {
 	if c.clientCert() != "" {
 		certPEM := []byte(c.clientCert())
 		keyPEM := []byte(c.clientKey())
-		remoteInfo.Cert = lxdclient.NewCertificate(certPEM, keyPEM)
+		remoteInfo.Cert = lxdclient.NewCert(certPEM, keyPEM)
 	}
 
 	cfg := lxdclient.Config{

--- a/provider/lxd/config_test.go
+++ b/provider/lxd/config_test.go
@@ -59,11 +59,11 @@ func (s *configSuite) TestClientConfigLocal(c *gc.C) {
 		Namespace: cfg.Name(),
 		Dirname:   os.ExpandEnv(lxdlib.ConfigDir),
 		Filename:  "config.yml",
-		Remote: lxdclient.NewRemote(lxdclient.RemoteInfo{
+		Remote: lxdclient.Remote{
 			Name: "juju-remote",
 			Host: "",
 			Cert: nil,
-		}),
+		},
 	})
 }
 
@@ -83,14 +83,14 @@ func (s *configSuite) TestClientConfigNonLocal(c *gc.C) {
 		Namespace: cfg.Name(),
 		Dirname:   os.ExpandEnv(lxdlib.ConfigDir),
 		Filename:  "config.yml",
-		Remote: lxdclient.NewRemote(lxdclient.RemoteInfo{
+		Remote: lxdclient.Remote{
 			Name: "juju-remote",
 			Host: "10.0.0.1",
 			Cert: &lxdclient.Cert{
 				CertPEM: []byte("<a valid x.509 cert>"),
 				KeyPEM:  []byte("<a valid x.509 key>"),
 			},
-		}),
+		},
 	})
 }
 

--- a/provider/lxd/config_test.go
+++ b/provider/lxd/config_test.go
@@ -6,6 +6,7 @@
 package lxd_test
 
 import (
+	"fmt"
 	"os"
 
 	jc "github.com/juju/testing/checkers"
@@ -91,6 +92,7 @@ func (s *configSuite) TestClientConfigNonLocal(c *gc.C) {
 			Name: "juju-remote",
 			Host: "10.0.0.1",
 			Cert: &lxdclient.Cert{
+				Name:    fmt.Sprintf("juju cert for env %q", s.config.Name()),
 				CertPEM: []byte("<a valid x.509 cert>"),
 				KeyPEM:  []byte("<a valid x.509 key>"),
 			},

--- a/provider/lxd/config_test.go
+++ b/provider/lxd/config_test.go
@@ -86,7 +86,7 @@ func (s *configSuite) TestClientConfigNonLocal(c *gc.C) {
 		Remote: lxdclient.NewRemote(lxdclient.RemoteInfo{
 			Name: "juju-remote",
 			Host: "10.0.0.1",
-			Cert: &lxdclient.Certificate{
+			Cert: &lxdclient.Cert{
 				CertPEM: []byte("<a valid x.509 cert>"),
 				KeyPEM:  []byte("<a valid x.509 key>"),
 			},

--- a/provider/lxd/config_test.go
+++ b/provider/lxd/config_test.go
@@ -20,12 +20,16 @@ import (
 )
 
 type configSuite struct {
+	lxd.BaseSuite
+
 	config *config.Config
 }
 
 var _ = gc.Suite(&configSuite{})
 
 func (s *configSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+
 	cfg, err := testing.EnvironConfig(c).Apply(lxd.ConfigAttrs)
 	c.Assert(err, jc.ErrorIsNil)
 	s.config = cfg

--- a/provider/lxd/environ_broker.go
+++ b/provider/lxd/environ_broker.go
@@ -88,17 +88,8 @@ func (env *environ) finishInstanceConfig(args environs.StartInstanceParams) (*co
 
 	args.InstanceConfig.AgentEnvironment[agent.Namespace] = env.ecfg.namespace()
 
-	// Set the "remote" option in the config to localhost and enable it
-	// on the server config. This is necessary because exposing the API
-	// unix socket doesn't work securely (ownership issues).
+	// TODO(ericsnow) Drop the Config return so we don't need this.
 	var envConfig *config.Config
-	if env.ecfg.remoteURL() == "" { // TODO(ericsnow) wrong place!
-		ecfg, err := env.ecfg.setRemoteFromHost()
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		envConfig = ecfg.Config
-	}
 
 	return envConfig, nil
 }

--- a/provider/lxd/environ_test.go
+++ b/provider/lxd/environ_test.go
@@ -47,7 +47,7 @@ func (s *environSuite) TestSetConfigNoAPI(c *gc.C) {
 	err := s.Env.SetConfig(s.Config)
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.CheckNoAPI(c)
+	s.Stub.CheckCallNames(c, "asNonLocal")
 }
 
 func (s *environSuite) TestSetConfigMissing(c *gc.C) {

--- a/provider/lxd/testing_test.go
+++ b/provider/lxd/testing_test.go
@@ -204,7 +204,6 @@ func (s *BaseSuiteUnpatched) setConfig(c *gc.C, cfg *config.Config) {
 }
 
 func (s *BaseSuiteUnpatched) NewConfig(c *gc.C, updates testing.Attrs) *config.Config {
-	//return NewCustomBaseConfig(c, updates)
 	if updates == nil {
 		updates = make(testing.Attrs)
 	}

--- a/provider/lxd/testing_test.go
+++ b/provider/lxd/testing_test.go
@@ -258,6 +258,9 @@ type BaseSuite struct {
 }
 
 func (s *BaseSuite) SetUpTest(c *gc.C) {
+	// Do this *before* s.initEnv() gets called.
+	s.PatchValue(&asNonLocal, s.asNonLocal)
+
 	s.BaseSuiteUnpatched.SetUpTest(c)
 
 	s.Stub = &gitjujutesting.Stub{}
@@ -273,6 +276,7 @@ func (s *BaseSuite) SetUpTest(c *gc.C) {
 		policyProvider: s.Policy,
 	}
 	s.Env.base = s.Common
+
 	//s.PatchValue(&newConnection, func(*environConfig) (gceConnection, error) {
 	//	return s.StubConn, nil
 	//})
@@ -290,6 +294,18 @@ func (s *BaseSuite) SetUpTest(c *gc.C) {
 
 func (s *BaseSuite) CheckNoAPI(c *gc.C) {
 	s.Stub.CheckCalls(c, nil)
+}
+
+func (s *BaseSuite) asNonLocal(clientCfg lxdclient.Config) (lxdclient.Config, error) {
+	if s.Stub == nil {
+		return clientCfg, nil
+	}
+	s.Stub.AddCall("asNonLocal", clientCfg)
+	if err := s.Stub.NextErr(); err != nil {
+		return clientCfg, errors.Trace(err)
+	}
+
+	return clientCfg, nil
 }
 
 func NewBaseConfig(c *gc.C) *config.Config {


### PR DESCRIPTION
Previously this required using the "local" unix socket on the controller.  This patch switches the LXD provider to using the unix socket only to add a new cert to the local LXD.  This then allows bootstrap to always connect to the "remote" via TCP, even in the case of a local LXD server (the provider's default).

(Review request: http://reviews.vapour.ws/r/3013/)