### PR TITLE
worker/uniter: retry hook timer

### DIFF
--- a/worker/uniter/remotestate/snapshot.go
+++ b/worker/uniter/remotestate/snapshot.go
@@ -36,6 +36,11 @@ type Snapshot struct {
 	// hook execution errors.
 	ResolvedMode params.ResolvedMode
 
+	// RetryHookVersion increments each time a failed
+	// hook is meant to be retried if ResolvedMode is
+	// set to ResolvedNone.
+	RetryHookVersion int
+
 	// ConfigVersion is the last published version of
 	// the unit's config settings.
 	ConfigVersion int

--- a/worker/uniter/remotestate/watcher.go
+++ b/worker/uniter/remotestate/watcher.go
@@ -442,6 +442,8 @@ func (w *RemoteStateWatcher) updateStatusChanged() error {
 func (w *RemoteStateWatcher) commandsChanged(id string) error {
 	w.mu.Lock()
 	w.current.Commands = append(w.current.Commands, id)
+	w.mu.Unlock()
+	return nil
 }
 
 // retryHookTimerTriggered is called when the retry hook timer expires.

--- a/worker/uniter/resolver.go
+++ b/worker/uniter/resolver.go
@@ -33,6 +33,7 @@ type uniterResolver struct {
 	retryHookTimerStarted bool
 }
 
+// NewUniterResolver returns a new resolver.Resolver for the uniter.
 func NewUniterResolver(cfg ResolverConfig) resolver.Resolver {
 	return &uniterResolver{cfg}
 }

--- a/worker/uniter/resolver/interface.go
+++ b/worker/uniter/resolver/interface.go
@@ -70,6 +70,10 @@ type LocalState struct {
 	// for which an update-status hook has been committed.
 	UpdateStatusVersion int
 
+	// RetryHookVersion is the version of hook-retries from
+	// remotestate.Snapshot for which a hook has been retried.
+	RetryHookVersion int
+
 	// ConfigVersion is the version of config from remotestate.Snapshot
 	// for which a config-changed hook has been committed.
 	ConfigVersion int

--- a/worker/uniter/resolver_test.go
+++ b/worker/uniter/resolver_test.go
@@ -6,10 +6,13 @@ package uniter_test
 import (
 	"github.com/juju/errors"
 	"github.com/juju/names"
+	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v6-unstable"
+	"gopkg.in/juju/charm.v6-unstable/hooks"
 
+	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/worker/uniter"
 	uniteractions "github.com/juju/juju/worker/uniter/actions"
 	"github.com/juju/juju/worker/uniter/hook"
@@ -22,15 +25,20 @@ import (
 )
 
 type resolverSuite struct {
+	stub        testing.Stub
 	charmURL    *charm.URL
 	remoteState remotestate.Snapshot
 	opFactory   operation.Factory
 	resolver    resolver.Resolver
+
+	clearResolved   func() error
+	reportHookError func(hook.Info) error
 }
 
 var _ = gc.Suite(&resolverSuite{})
 
 func (s *resolverSuite) SetUpTest(c *gc.C) {
+	s.stub = testing.Stub{}
 	s.charmURL = charm.MustParseURL("cs:precise/mysql-2")
 	s.remoteState = remotestate.Snapshot{
 		CharmURL: s.charmURL,
@@ -44,8 +52,8 @@ func (s *resolverSuite) SetUpTest(c *gc.C) {
 		ClearResolved:       func() error { return errors.New("unexpected resolved") },
 		ReportHookError:     func(_ hook.Info) error { return errors.New("unexpected report hook error") },
 		FixDeployer:         func() error { return nil },
-		StartRetryHookTimer: func() {},
-		StopRetryHookTimer:  func() {},
+		StartRetryHookTimer: func() { s.stub.AddCall("startRetryHookTimer") },
+		StopRetryHookTimer:  func() { s.stub.AddCall("stopRetryHookTimer") },
 		Leadership:          leadership.NewResolver(),
 		Actions:             uniteractions.NewResolver(),
 		Relations:           relation.NewRelationsResolver(&dummyRelations{}),
@@ -84,4 +92,122 @@ func (s *resolverSuite) TestNotStartedNotInstalled(c *gc.C) {
 	op, err := s.resolver.NextOp(localState, s.remoteState, s.opFactory)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(op.String(), gc.Equals, "run install hook")
+}
+
+func (s *resolverSuite) TestHookErrorStartRetryTimer(c *gc.C) {
+	s.reportHookError = func(hook.Info) error { return nil }
+	localState := resolver.LocalState{
+		CharmURL: s.charmURL,
+		State: operation.State{
+			Kind:      operation.RunHook,
+			Step:      operation.Pending,
+			Installed: true,
+			Started:   true,
+			Hook: &hook.Info{
+				Kind: hooks.ConfigChanged,
+			},
+		},
+	}
+	// Run the resolver twice; we should start the hook retry
+	// timer on the first time through, no change on the second.
+	_, err := s.resolver.NextOp(localState, s.remoteState, s.opFactory)
+	c.Assert(err, gc.Equals, resolver.ErrNoOperation)
+	s.stub.CheckCallNames(c, "startRetryHookTimer")
+
+	_, err = s.resolver.NextOp(localState, s.remoteState, s.opFactory)
+	c.Assert(err, gc.Equals, resolver.ErrNoOperation)
+	s.stub.CheckCallNames(c, "startRetryHookTimer") // no change
+}
+
+func (s *resolverSuite) TestHookErrorStartRetryTimerAgain(c *gc.C) {
+	s.reportHookError = func(hook.Info) error { return nil }
+	localState := resolver.LocalState{
+		CharmURL: s.charmURL,
+		State: operation.State{
+			Kind:      operation.RunHook,
+			Step:      operation.Pending,
+			Installed: true,
+			Started:   true,
+			Hook: &hook.Info{
+				Kind: hooks.ConfigChanged,
+			},
+		},
+	}
+
+	_, err := s.resolver.NextOp(localState, s.remoteState, s.opFactory)
+	c.Assert(err, gc.Equals, resolver.ErrNoOperation)
+	s.stub.CheckCallNames(c, "startRetryHookTimer")
+
+	s.remoteState.RetryHookVersion = 1
+	op, err := s.resolver.NextOp(localState, s.remoteState, s.opFactory)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(op.String(), gc.Equals, "run config-changed hook")
+	s.stub.CheckCallNames(c, "startRetryHookTimer") // no change
+	localState.RetryHookVersion = 1
+
+	_, err = s.resolver.NextOp(localState, s.remoteState, s.opFactory)
+	c.Assert(err, gc.Equals, resolver.ErrNoOperation)
+	s.stub.CheckCallNames(c, "startRetryHookTimer", "startRetryHookTimer")
+}
+
+func (s *resolverSuite) TestResolvedRetryHooksStopRetryTimer(c *gc.C) {
+	// Resolving a failed hook should stop the retry timer.
+	s.testResolveHookErrorStopRetryTimer(c, params.ResolvedRetryHooks)
+}
+
+func (s *resolverSuite) TestResolvedNoHooksStopRetryTimer(c *gc.C) {
+	// Resolving a failed hook should stop the retry timer.
+	s.testResolveHookErrorStopRetryTimer(c, params.ResolvedNoHooks)
+}
+
+func (s *resolverSuite) testResolveHookErrorStopRetryTimer(c *gc.C, mode params.ResolvedMode) {
+	s.stub.ResetCalls()
+	s.clearResolved = func() error { return nil }
+	s.reportHookError = func(hook.Info) error { return nil }
+	localState := resolver.LocalState{
+		CharmURL: s.charmURL,
+		State: operation.State{
+			Kind:      operation.RunHook,
+			Step:      operation.Pending,
+			Installed: true,
+			Started:   true,
+			Hook: &hook.Info{
+				Kind: hooks.ConfigChanged,
+			},
+		},
+	}
+
+	_, err := s.resolver.NextOp(localState, s.remoteState, s.opFactory)
+	c.Assert(err, gc.Equals, resolver.ErrNoOperation)
+	s.stub.CheckCallNames(c, "startRetryHookTimer")
+
+	s.remoteState.ResolvedMode = mode
+	_, err = s.resolver.NextOp(localState, s.remoteState, s.opFactory)
+	c.Assert(err, jc.ErrorIsNil)
+	s.stub.CheckCallNames(c, "startRetryHookTimer", "stopRetryHookTimer")
+}
+
+func (s *resolverSuite) TestRunHookStopRetryTimer(c *gc.C) {
+	s.reportHookError = func(hook.Info) error { return nil }
+	localState := resolver.LocalState{
+		CharmURL: s.charmURL,
+		State: operation.State{
+			Kind:      operation.RunHook,
+			Step:      operation.Pending,
+			Installed: true,
+			Started:   true,
+			Hook: &hook.Info{
+				Kind: hooks.ConfigChanged,
+			},
+		},
+	}
+
+	_, err := s.resolver.NextOp(localState, s.remoteState, s.opFactory)
+	c.Assert(err, gc.Equals, resolver.ErrNoOperation)
+	s.stub.CheckCallNames(c, "startRetryHookTimer")
+
+	localState.Kind = operation.Continue
+	_, err = s.resolver.NextOp(localState, s.remoteState, s.opFactory)
+	c.Assert(err, gc.Equals, resolver.ErrNoOperation)
+	s.stub.CheckCallNames(c, "startRetryHookTimer", "stopRetryHookTimer")
 }

--- a/worker/uniter/resolver_test.go
+++ b/worker/uniter/resolver_test.go
@@ -41,14 +41,16 @@ func (s *resolverSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.resolver = uniter.NewUniterResolver(uniter.ResolverConfig{
-		ClearResolved:   func() error { return errors.New("unexpected resolved") },
-		ReportHookError: func(_ hook.Info) error { return errors.New("unexpected report hook error") },
-		FixDeployer:     func() error { return nil },
-		Leadership:      leadership.NewResolver(),
-		Actions:         uniteractions.NewResolver(),
-		Relations:       relation.NewRelationsResolver(&dummyRelations{}),
-		Storage:         storage.NewResolver(attachments),
-		Commands:        nopResolver{},
+		ClearResolved:       func() error { return errors.New("unexpected resolved") },
+		ReportHookError:     func(_ hook.Info) error { return errors.New("unexpected report hook error") },
+		FixDeployer:         func() error { return nil },
+		StartRetryHookTimer: func() {},
+		StopRetryHookTimer:  func() {},
+		Leadership:          leadership.NewResolver(),
+		Actions:             uniteractions.NewResolver(),
+		Relations:           relation.NewRelationsResolver(&dummyRelations{}),
+		Storage:             storage.NewResolver(attachments),
+		Commands:            nopResolver{},
 	})
 }
 

--- a/worker/uniter/resolver_test.go
+++ b/worker/uniter/resolver_test.go
@@ -60,8 +60,8 @@ func (s *resolverSuite) SetUpTest(c *gc.C) {
 		ClearResolved:       func() error { return s.clearResolved() },
 		ReportHookError:     func(info hook.Info) error { return s.reportHookError(info) },
 		FixDeployer:         func() error { return nil },
-		StartRetryHookTimer: func() { s.stub.AddCall("startRetryHookTimer") },
-		StopRetryHookTimer:  func() { s.stub.AddCall("stopRetryHookTimer") },
+		StartRetryHookTimer: func() { s.stub.AddCall("StartRetryHookTimer") },
+		StopRetryHookTimer:  func() { s.stub.AddCall("StopRetryHookTimer") },
 		Leadership:          leadership.NewResolver(),
 		Actions:             uniteractions.NewResolver(),
 		Relations:           relation.NewRelationsResolver(&dummyRelations{}),
@@ -120,11 +120,11 @@ func (s *resolverSuite) TestHookErrorStartRetryTimer(c *gc.C) {
 	// timer on the first time through, no change on the second.
 	_, err := s.resolver.NextOp(localState, s.remoteState, s.opFactory)
 	c.Assert(err, gc.Equals, resolver.ErrNoOperation)
-	s.stub.CheckCallNames(c, "startRetryHookTimer")
+	s.stub.CheckCallNames(c, "StartRetryHookTimer")
 
 	_, err = s.resolver.NextOp(localState, s.remoteState, s.opFactory)
 	c.Assert(err, gc.Equals, resolver.ErrNoOperation)
-	s.stub.CheckCallNames(c, "startRetryHookTimer") // no change
+	s.stub.CheckCallNames(c, "StartRetryHookTimer") // no change
 }
 
 func (s *resolverSuite) TestHookErrorStartRetryTimerAgain(c *gc.C) {
@@ -144,18 +144,18 @@ func (s *resolverSuite) TestHookErrorStartRetryTimerAgain(c *gc.C) {
 
 	_, err := s.resolver.NextOp(localState, s.remoteState, s.opFactory)
 	c.Assert(err, gc.Equals, resolver.ErrNoOperation)
-	s.stub.CheckCallNames(c, "startRetryHookTimer")
+	s.stub.CheckCallNames(c, "StartRetryHookTimer")
 
 	s.remoteState.RetryHookVersion = 1
 	op, err := s.resolver.NextOp(localState, s.remoteState, s.opFactory)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(op.String(), gc.Equals, "run config-changed hook")
-	s.stub.CheckCallNames(c, "startRetryHookTimer") // no change
+	s.stub.CheckCallNames(c, "StartRetryHookTimer") // no change
 	localState.RetryHookVersion = 1
 
 	_, err = s.resolver.NextOp(localState, s.remoteState, s.opFactory)
 	c.Assert(err, gc.Equals, resolver.ErrNoOperation)
-	s.stub.CheckCallNames(c, "startRetryHookTimer", "startRetryHookTimer")
+	s.stub.CheckCallNames(c, "StartRetryHookTimer", "StartRetryHookTimer")
 }
 
 func (s *resolverSuite) TestResolvedRetryHooksStopRetryTimer(c *gc.C) {
@@ -187,12 +187,12 @@ func (s *resolverSuite) testResolveHookErrorStopRetryTimer(c *gc.C, mode params.
 
 	_, err := s.resolver.NextOp(localState, s.remoteState, s.opFactory)
 	c.Assert(err, gc.Equals, resolver.ErrNoOperation)
-	s.stub.CheckCallNames(c, "startRetryHookTimer")
+	s.stub.CheckCallNames(c, "StartRetryHookTimer")
 
 	s.remoteState.ResolvedMode = mode
 	_, err = s.resolver.NextOp(localState, s.remoteState, s.opFactory)
 	c.Assert(err, jc.ErrorIsNil)
-	s.stub.CheckCallNames(c, "startRetryHookTimer", "stopRetryHookTimer")
+	s.stub.CheckCallNames(c, "StartRetryHookTimer", "StopRetryHookTimer")
 }
 
 func (s *resolverSuite) TestRunHookStopRetryTimer(c *gc.C) {
@@ -212,10 +212,10 @@ func (s *resolverSuite) TestRunHookStopRetryTimer(c *gc.C) {
 
 	_, err := s.resolver.NextOp(localState, s.remoteState, s.opFactory)
 	c.Assert(err, gc.Equals, resolver.ErrNoOperation)
-	s.stub.CheckCallNames(c, "startRetryHookTimer")
+	s.stub.CheckCallNames(c, "StartRetryHookTimer")
 
 	localState.Kind = operation.Continue
 	_, err = s.resolver.NextOp(localState, s.remoteState, s.opFactory)
 	c.Assert(err, gc.Equals, resolver.ErrNoOperation)
-	s.stub.CheckCallNames(c, "startRetryHookTimer", "stopRetryHookTimer")
+	s.stub.CheckCallNames(c, "StartRetryHookTimer", "StopRetryHookTimer")
 }

--- a/worker/uniter/resolver_test.go
+++ b/worker/uniter/resolver_test.go
@@ -48,9 +48,17 @@ func (s *resolverSuite) SetUpTest(c *gc.C) {
 	attachments, err := storage.NewAttachments(&dummyStorageAccessor{}, names.NewUnitTag("u/0"), c.MkDir(), nil)
 	c.Assert(err, jc.ErrorIsNil)
 
+	s.clearResolved = func() error {
+		return errors.New("unexpected resolved")
+	}
+
+	s.reportHookError = func(hook.Info) error {
+		return errors.New("unexpected report hook error")
+	}
+
 	s.resolver = uniter.NewUniterResolver(uniter.ResolverConfig{
-		ClearResolved:       func() error { return errors.New("unexpected resolved") },
-		ReportHookError:     func(_ hook.Info) error { return errors.New("unexpected report hook error") },
+		ClearResolved:       func() error { return s.clearResolved() },
+		ReportHookError:     func(info hook.Info) error { return s.reportHookError(info) },
 		FixDeployer:         func() error { return nil },
 		StartRetryHookTimer: func() { s.stub.AddCall("startRetryHookTimer") },
 		StopRetryHookTimer:  func() { s.stub.AddCall("stopRetryHookTimer") },

--- a/worker/uniter/timer.go
+++ b/worker/uniter/timer.go
@@ -4,6 +4,7 @@
 package uniter
 
 import (
+	"math/rand"
 	"time"
 )
 
@@ -11,6 +12,84 @@ const (
 	// interval at which the unit's status should be polled
 	statusPollInterval = 5 * time.Minute
 )
+
+// BackoffTimer implements a timer that will signal after a
+// internally stored duration. The steps as well as min and max
+// durations are declared upon initialization
+type BackoffTimer interface {
+	// Channel returns the channel that can be listened for events
+	Channel() <-chan struct{}
+
+	// Reset will reset the timer to it's minimum value
+	Reset()
+
+	// Signal will return after a internally stored duration
+	// and increase the duration for the next call
+	Signal()
+}
+
+// NewBackoffTimer creates and initializer a new BackoffTimer
+func NewBackoffTimer(min, max time.Duration, jitter bool, factor int64) BackoffTimer {
+	return &backoffTimer{
+		min:             min,
+		max:             max,
+		jitter:          jitter,
+		factor:          factor,
+		channel:         make(chan struct{}, 1),
+		currentDuration: min,
+	}
+}
+
+type backoffTimer struct {
+	timer *time.Timer
+
+	min    time.Duration
+	max    time.Duration
+	jitter bool
+	factor int64
+
+	channel chan struct{}
+
+	currentDuration time.Duration
+}
+
+func (t *backoffTimer) Channel() <-chan struct{} {
+	return t.channel
+}
+
+func (t *backoffTimer) Signal() {
+	if t.timer != nil {
+		t.timer.Stop()
+	}
+	t.timer = time.AfterFunc(t.currentDuration, func() {
+		t.channel <- struct{}{}
+	})
+	// Since it's a backoff timer we will increase
+	// the duration after each signal.
+	t.increaseDuration()
+}
+
+func (t *backoffTimer) increaseDuration() {
+	current := int64(t.currentDuration)
+	nextDuration := time.Duration(current * t.factor)
+	if t.jitter {
+		// Get a factor in [-1; 1]
+		randFactor := (rand.Float64() * 2) - 1
+		jitter := float64(nextDuration) * randFactor * 0.03
+		nextDuration = nextDuration + time.Duration(jitter)
+	}
+	if nextDuration > t.max {
+		nextDuration = t.max
+	}
+	t.currentDuration = nextDuration
+}
+
+func (t *backoffTimer) Reset() {
+	if t.currentDuration > t.min {
+		t.timer.Stop()
+		t.currentDuration = t.min
+	}
+}
 
 // updateStatusSignal returns a time channel that fires after a given interval.
 func updateStatusSignal() <-chan time.Time {

--- a/worker/uniter/timer.go
+++ b/worker/uniter/timer.go
@@ -4,7 +4,6 @@
 package uniter
 
 import (
-	"math/rand"
 	"time"
 )
 
@@ -12,84 +11,6 @@ const (
 	// interval at which the unit's status should be polled
 	statusPollInterval = 5 * time.Minute
 )
-
-// BackoffTimer implements a timer that will signal after a
-// internally stored duration. The steps as well as min and max
-// durations are declared upon initialization
-type BackoffTimer interface {
-	// Channel returns the channel that can be listened for events
-	Channel() <-chan struct{}
-
-	// Reset will reset the timer to it's minimum value
-	Reset()
-
-	// Signal will return after a internally stored duration
-	// and increase the duration for the next call
-	Signal()
-}
-
-// NewBackoffTimer creates and initializer a new BackoffTimer
-func NewBackoffTimer(min, max time.Duration, jitter bool, factor int64) BackoffTimer {
-	return &backoffTimer{
-		min:             min,
-		max:             max,
-		jitter:          jitter,
-		factor:          factor,
-		channel:         make(chan struct{}, 1),
-		currentDuration: min,
-	}
-}
-
-type backoffTimer struct {
-	timer *time.Timer
-
-	min    time.Duration
-	max    time.Duration
-	jitter bool
-	factor int64
-
-	channel chan struct{}
-
-	currentDuration time.Duration
-}
-
-func (t *backoffTimer) Channel() <-chan struct{} {
-	return t.channel
-}
-
-func (t *backoffTimer) Signal() {
-	if t.timer != nil {
-		t.timer.Stop()
-	}
-	t.timer = time.AfterFunc(t.currentDuration, func() {
-		t.channel <- struct{}{}
-	})
-	// Since it's a backoff timer we will increase
-	// the duration after each signal.
-	t.increaseDuration()
-}
-
-func (t *backoffTimer) increaseDuration() {
-	current := int64(t.currentDuration)
-	nextDuration := time.Duration(current * t.factor)
-	if t.jitter {
-		// Get a factor in [-1; 1]
-		randFactor := (rand.Float64() * 2) - 1
-		jitter := float64(nextDuration) * randFactor * 0.03
-		nextDuration = nextDuration + time.Duration(jitter)
-	}
-	if nextDuration > t.max {
-		nextDuration = t.max
-	}
-	t.currentDuration = nextDuration
-}
-
-func (t *backoffTimer) Reset() {
-	if t.currentDuration > t.min {
-		t.timer.Stop()
-		t.currentDuration = t.min
-	}
-}
 
 // updateStatusSignal returns a time channel that fires after a given interval.
 func updateStatusSignal() <-chan time.Time {

--- a/worker/uniter/uniter.go
+++ b/worker/uniter/uniter.go
@@ -212,7 +212,7 @@ func (u *Uniter) loop(unitTag names.UnitTag) (err error) {
 			default:
 			}
 		},
-		Clock: clock.WallClock,
+		Clock: u.clock,
 	})
 	u.addCleanup(func() error {
 		// Stop any send that might be pending

--- a/worker/uniter/uniter.go
+++ b/worker/uniter/uniter.go
@@ -204,7 +204,13 @@ func (u *Uniter) loop(unitTag names.UnitTag) (err error) {
 		Jitter: retryTimeJitter,
 		Factor: retryTimeFactor,
 		Func: func() {
-			retryHookChan <- struct{}{}
+			// Don't try to send on the channel if it's already full
+			// This can happen if the timer fires off before the event is consumed
+			// by the resolver loop
+			select {
+			case retryHookChan <- struct{}{}:
+			default:
+			}
 		},
 		Clock: clock.WallClock,
 	})

--- a/worker/uniter/uniter.go
+++ b/worker/uniter/uniter.go
@@ -44,6 +44,13 @@ import (
 
 var logger = loggo.GetLogger("juju.worker.uniter")
 
+const (
+	retryTimeMin    = 5 * time.Second
+	retryTimeMax    = 5 * time.Minute
+	retryTimeJitter = true
+	retryTimeFactor = 2
+)
+
 // A UniterExecutionObserver gets the appropriate methods called when a hook
 // is executed and either succeeds or fails.  Missing hooks don't get reported
 // in this way.
@@ -191,13 +198,12 @@ func (u *Uniter) loop(unitTag names.UnitTag) (err error) {
 
 	retryHookChan := make(chan struct{}, 1)
 	defer close(retryHookChan)
-	// TODO extract constants
-	// TODO decide on exact duration
+
 	retryHookTimer := utils.NewBackoffTimer(utils.BackoffTimerConfig{
-		Min:    10 * time.Second,
-		Max:    20 * time.Minute,
-		Jitter: true,
-		Factor: 2,
+		Min:    retryTimeMin,
+		Max:    retryTimeMax,
+		Jitter: retryTimeJitter,
+		Factor: retryTimeFactor,
 		Func: func() {
 			retryHookChan <- struct{}{}
 		},


### PR DESCRIPTION
This PR implements work to make the uniter retry a failed hook.

Basically what's happening is that each time we stumble upon a pending hook, if we don't see a resolved flag, we will start a timer that will eventually make the hook retry itself with an exponential backoff.

What's still left open is the exact durations that we want to use.

(Review request: http://reviews.vapour.ws/r/3014/)