### PR TITLE
Better conn err

### DIFF
--- a/container/lxd/lxdclient/conn.go
+++ b/container/lxd/lxdclient/conn.go
@@ -67,11 +67,10 @@ func newRawClient(remote, configDir string) (*lxd.Client, error) {
 	logger.Debugf("using LXD remote %q", remote)
 	client, err := lxdNewClient(cfg, remote)
 	if err != nil {
-		if remote == "" {
+		if remote == remoteIDForLocal {
 			return nil, errors.Annotate(err, "can't connect to the local LXD server")
 		}
 		return nil, errors.Trace(err)
 	}
-
 	return client, nil
 }

--- a/container/lxd/lxdclient/conn.go
+++ b/container/lxd/lxdclient/conn.go
@@ -66,16 +66,11 @@ func newRawClient(remote, configDir string) (*lxd.Client, error) {
 	logger.Debugf("using LXD remote %q", remote)
 	client, err := lxdNewClient(cfg, remote)
 	if err != nil {
-		if IsLocal(remote) {
+		if remote == "" {
 			return nil, errors.Annotate(err, "can't connect to the local LXD server")
 		}
 		return nil, errors.Trace(err)
 	}
 
 	return client, nil
-}
-
-// IsLocal reports whether the given remote represents the local LCD server.
-func IsLocal(remote string) bool {
-	return remote == ""
 }

--- a/container/lxd/lxdclient/conn.go
+++ b/container/lxd/lxdclient/conn.go
@@ -50,6 +50,7 @@ func Connect(cfg Config) (*Client, error) {
 }
 
 var lxdNewClient = lxd.NewClient
+var lxdLoadConfig = lxd.LoadConfig
 
 func newRawClient(remote, configDir string) (*lxd.Client, error) {
 	logger.Debugf("loading LXD client config from %q", configDir)
@@ -58,7 +59,7 @@ func newRawClient(remote, configDir string) (*lxd.Client, error) {
 	origDirname := updateLXDVars(configDir)
 	defer updateLXDVars(origDirname)
 
-	cfg, err := lxd.LoadConfig()
+	cfg, err := lxdLoadConfig()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/container/lxd/lxdclient/conn.go
+++ b/container/lxd/lxdclient/conn.go
@@ -49,6 +49,8 @@ func Connect(cfg Config) (*Client, error) {
 	return conn, nil
 }
 
+var lxdNewClient = lxd.NewClient
+
 func newRawClient(remote, configDir string) (*lxd.Client, error) {
 	logger.Debugf("loading LXD client config from %q", configDir)
 
@@ -62,7 +64,7 @@ func newRawClient(remote, configDir string) (*lxd.Client, error) {
 	}
 
 	logger.Debugf("using LXD remote %q", remote)
-	client, err := lxd.NewClient(cfg, remote)
+	client, err := lxdNewClient(cfg, remote)
 	if err != nil {
 		if IsLocal(remote) {
 			return nil, errors.Annotate(err, "can't connect to the local LXD server")

--- a/container/lxd/lxdclient/conn.go
+++ b/container/lxd/lxdclient/conn.go
@@ -64,8 +64,16 @@ func newRawClient(remote, configDir string) (*lxd.Client, error) {
 	logger.Debugf("using LXD remote %q", remote)
 	client, err := lxd.NewClient(cfg, remote)
 	if err != nil {
+		if IsLocal(remote) {
+			return nil, errors.Annotate(err, "can't connect to the local LXD server")
+		}
 		return nil, errors.Trace(err)
 	}
 
 	return client, nil
+}
+
+// IsLocal reports whether the given remote represents the local LCD server.
+func IsLocal(remote string) bool {
+	return remote == ""
 }

--- a/container/lxd/lxdclient/conn_test.go
+++ b/container/lxd/lxdclient/conn_test.go
@@ -1,6 +1,8 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// +build go1.3
+
 package lxdclient
 
 import (

--- a/container/lxd/lxdclient/conn_test.go
+++ b/container/lxd/lxdclient/conn_test.go
@@ -16,9 +16,10 @@ type ConnectSuite struct {
 
 func (cs ConnectSuite) TestLocalConnectError(c *gc.C) {
 	cs.PatchValue(lxdNewClient, fakeNewClient)
+	cs.PatchValue(lxdLoadConfig, fakeLoadConfig)
 
 	// Empty remote means connect locally.
-	client, err := Connect(Config{Remote: ""})
+	client, err := Connect(Config{Remote: configIDForLocal})
 	c.Assert(client, gc.IsNil)
 
 	// Yes, the error message actually matters here... this is being displayed
@@ -28,16 +29,20 @@ func (cs ConnectSuite) TestLocalConnectError(c *gc.C) {
 
 func (cs ConnectSuite) TestRemoteConnectError(c *gc.C) {
 	cs.PatchValue(lxdNewClient, fakeNewClient)
+	cs.PatchValue(lxdLoadConfig, fakeLoadConfig)
 
-	// Empty remote means connect locally.
 	client, err := Connect(Config{Remote: "foo"})
 	c.Assert(client, gc.IsNil)
 
-	// Yes, the error message actually matters here... this is being displayed
-	// to the user.
-	c.Assert(err, gc.ErrorMatches, "boo!")
+	c.Assert(errors.Cause(err), gc.Equals, testerr)
 }
 
+var testerr = errors.Errorf("boo!")
+
 func fakeNewClient(config *lxd.Config, remote string) (*lxd.Client, error) {
-	return nil, errors.Errorf("boo!")
+	return nil, testerr
+}
+
+func fakeLoadConfig() (*lxd.Config, error) {
+	return nil, nil
 }

--- a/container/lxd/lxdclient/conn_test.go
+++ b/container/lxd/lxdclient/conn_test.go
@@ -1,0 +1,43 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package lxdclient
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+	"github.com/lxc/lxd"
+	gc "gopkg.in/check.v1"
+)
+
+type ConnectSuite struct {
+	testing.IsolationSuite
+}
+
+func (cs ConnectSuite) TestLocalConnectError(c *gc.C) {
+	cs.PatchValue(lxdNewClient, fakeNewClient)
+
+	// Empty remote means connect locally.
+	client, err := Connect(Config{Remote: ""})
+	c.Assert(client, gc.IsNil)
+
+	// Yes, the error message actually matters here... this is being displayed
+	// to the user.
+	c.Assert(err, gc.ErrorMatches, "can't connect to the local LXD server.*")
+}
+
+func (cs ConnectSuite) TestRemoteConnectError(c *gc.C) {
+	cs.PatchValue(lxdNewClient, fakeNewClient)
+
+	// Empty remote means connect locally.
+	client, err := Connect(Config{Remote: "foo"})
+	c.Assert(client, gc.IsNil)
+
+	// Yes, the error message actually matters here... this is being displayed
+	// to the user.
+	c.Assert(err, gc.ErrorMatches, "boo!")
+}
+
+func fakeNewClient(config *lxd.Config, remote string) (*lxd.Client, error) {
+	return nil, errors.Errorf("boo!")
+}

--- a/provider/lxd/environ_raw.go
+++ b/provider/lxd/environ_raw.go
@@ -64,6 +64,7 @@ func newClient(ecfg *environConfig) (*lxdclient.Client, error) {
 
 	client, err := lxdclient.Connect(clientCfg)
 	if err != nil {
+
 		return nil, errors.Trace(err)
 	}
 

--- a/provider/lxd/environ_raw.go
+++ b/provider/lxd/environ_raw.go
@@ -64,7 +64,6 @@ func newClient(ecfg *environConfig) (*lxdclient.Client, error) {
 
 	client, err := lxdclient.Connect(clientCfg)
 	if err != nil {
-
 		return nil, errors.Trace(err)
 	}
 


### PR DESCRIPTION
This gives us a better user-facing error message when we try to connect to a local LXD and it's not running.   The  error message coming back from a bad remote LXD is pretty much fine (I haven't tried a remote that you just can't connect to yet, since we don't actually support remotes right now, but we can double check when we do support remote lxds).

(Review request: http://reviews.vapour.ws/r/3021/)