### PR TITLE
Metadata order

### DIFF
--- a/apiserver/imagemetadata/functions_test.go
+++ b/apiserver/imagemetadata/functions_test.go
@@ -29,6 +29,7 @@ func (s *funcSuite) SetUpTest(c *gc.C) {
 			Stream: "released",
 			Source: "custom",
 		},
+		0,
 		"",
 	}
 }

--- a/apiserver/imagemetadata/metadata.go
+++ b/apiserver/imagemetadata/metadata.go
@@ -7,10 +7,10 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/utils/series"
 
-	"github.com/juju/errors"
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/environs"

--- a/apiserver/imagemetadata/metadata.go
+++ b/apiserver/imagemetadata/metadata.go
@@ -60,7 +60,7 @@ func NewAPI(
 
 // List returns all found cloud image metadata that satisfy
 // given filter.
-// Returned list contains metadata order by priority.
+// Returned list contains metadata ordered by priority.
 func (api *API) List(filter params.ImageMetadataFilter) (params.ListCloudImageMetadataResult, error) {
 	found, err := api.metadata.FindMetadata(cloudimagemetadata.MetadataFilter{
 		Region:          filter.Region,
@@ -84,7 +84,6 @@ func (api *API) List(filter params.ImageMetadataFilter) (params.ListCloudImageMe
 	for _, ms := range found {
 		addAll(ms)
 	}
-	// Sort source keys in alphabetic order.
 	sort.Sort(metadataList(all))
 
 	return params.ListCloudImageMetadataResult{Result: all}, nil
@@ -241,7 +240,7 @@ func processErrors(errs []params.ErrorResult) error {
 }
 
 // metadataList is a convenience type enabling to sort
-// a collection of Metadata
+// a collection of Metadata in order of priority.
 type metadataList []params.CloudImageMetadata
 
 // Implements sort.Interface

--- a/apiserver/imagemetadata/metadata_test.go
+++ b/apiserver/imagemetadata/metadata_test.go
@@ -75,12 +75,12 @@ func (s *metadataSuite) TestFindOrder(c *gc.C) {
 		s.calls = append(s.calls, findMetadata)
 		return map[string][]cloudimagemetadata.Metadata{
 				"public": []cloudimagemetadata.Metadata{
-					cloudimagemetadata.Metadata{ImageId: publicImageId},
+					cloudimagemetadata.Metadata{ImageId: publicImageId, Priority: 15},
 				},
 				"custom": []cloudimagemetadata.Metadata{
-					cloudimagemetadata.Metadata{ImageId: customImageId},
-					cloudimagemetadata.Metadata{ImageId: customImageId2},
-					cloudimagemetadata.Metadata{ImageId: customImageId3},
+					cloudimagemetadata.Metadata{ImageId: customImageId, Priority: 87},
+					cloudimagemetadata.Metadata{ImageId: customImageId2, Priority: 20},
+					cloudimagemetadata.Metadata{ImageId: customImageId3, Priority: 56},
 				},
 			},
 			nil
@@ -89,11 +89,12 @@ func (s *metadataSuite) TestFindOrder(c *gc.C) {
 	found, err := s.api.List(params.ImageMetadataFilter{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(found.Result, gc.HasLen, 4)
+
 	c.Assert(found.Result, jc.SameContents, []params.CloudImageMetadata{
-		params.CloudImageMetadata{ImageId: customImageId},
-		params.CloudImageMetadata{ImageId: customImageId2},
-		params.CloudImageMetadata{ImageId: customImageId3},
-		params.CloudImageMetadata{ImageId: publicImageId},
+		params.CloudImageMetadata{ImageId: customImageId, Priority: 87},
+		params.CloudImageMetadata{ImageId: customImageId3, Priority: 56},
+		params.CloudImageMetadata{ImageId: customImageId2, Priority: 20},
+		params.CloudImageMetadata{ImageId: publicImageId, Priority: 15},
 	})
 	s.assertCalls(c, []string{findMetadata})
 }

--- a/apiserver/imagemetadata/updatefrompublished_test.go
+++ b/apiserver/imagemetadata/updatefrompublished_test.go
@@ -4,6 +4,11 @@
 package imagemetadata_test
 
 import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -241,12 +246,17 @@ type regionMetadataSuite struct {
 	baseImageMetadataSuite
 
 	provider mockEnvironProvider
+	env      *mockEnviron
+
+	saved    []cloudimagemetadata.Metadata
+	expected []cloudimagemetadata.Metadata
 }
 
 func (s *regionMetadataSuite) SetUpSuite(c *gc.C) {
 	s.BaseSuite.SetUpSuite(c)
 
 	s.provider = mockEnvironProvider{}
+	s.env = &mockEnviron{}
 	environs.RegisterProvider("mock", s.provider)
 	useTestImageData(testImagesData)
 }
@@ -258,12 +268,14 @@ func (s *regionMetadataSuite) TearDownSuite(c *gc.C) {
 
 func (s *regionMetadataSuite) SetUpTest(c *gc.C) {
 	s.baseImageMetadataSuite.SetUpTest(c)
+
+	s.saved = nil
+	s.expected = nil
 }
 
-func (s *regionMetadataSuite) TestUpdateFromPublishedImagesForProviderWithRegions(c *gc.C) {
+func (s *regionMetadataSuite) setExpectations(c *gc.C) {
 	// This will only save image metadata specific to provider cloud spec.
-	saved := []cloudimagemetadata.Metadata{}
-	expected := []cloudimagemetadata.Metadata{
+	s.expected = []cloudimagemetadata.Metadata{
 		cloudimagemetadata.Metadata{
 			cloudimagemetadata.MetadataAttributes{
 				RootStorageType: "ebs",
@@ -292,19 +304,145 @@ func (s *regionMetadataSuite) TestUpdateFromPublishedImagesForProviderWithRegion
 	// mock provider which impelements simplestreams.HasRegion interface.
 	s.state.environConfig = func() (*config.Config, error) {
 		s.calls = append(s.calls, environConfig)
-		env := &mockEnviron{}
-		return env.Config(), nil
+		return s.env.Config(), nil
 	}
 
 	s.state.saveMetadata = func(m cloudimagemetadata.Metadata) error {
 		s.calls = append(s.calls, saveMetadata)
-		saved = append(saved, m)
+		s.saved = append(s.saved, m)
 		return nil
 	}
+}
 
+func (s *regionMetadataSuite) checkStoredPublished(c *gc.C) {
 	err := s.api.UpdateFromPublishedImages()
 	c.Assert(err, jc.ErrorIsNil)
-	s.assertCalls(c, []string{environConfig, saveMetadata, saveMetadata})
 
-	c.Assert(saved, jc.SameContents, expected)
+	tempCalls := []string{environConfig}
+	for _ = range s.expected {
+		tempCalls = append(tempCalls, saveMetadata)
+	}
+	s.assertCalls(c, tempCalls)
+
+	c.Assert(s.saved, jc.SameContents, s.expected)
+}
+
+func (s *regionMetadataSuite) TestUpdateFromPublishedImagesForProviderWithRegions(c *gc.C) {
+	// This will only save image metadata specific to provider cloud spec.
+	s.setExpectations(c)
+	s.checkStoredPublished(c)
+}
+
+const (
+	indexContent = `{
+    "index": {
+        "com.ubuntu.cloud:%v": {
+            "updated": "Fri, 17 Jul 2015 13:42:48 +1000",
+            "format": "products:1.0",
+            "datatype": "image-ids",
+            "cloudname": "custom",
+            "clouds": [
+                {
+                    "region": "%v",
+                    "endpoint": "%v"
+                }
+            ],
+            "path": "streams/v1/products.json",
+            "products": [
+                "com.ubuntu.cloud:server:14.04:%v"
+            ]
+        }
+    },
+    "updated": "Fri, 17 Jul 2015 13:42:48 +1000",
+    "format": "index:1.0"
+}`
+
+	productContent = `{
+    "products": {
+        "com.ubuntu.cloud:server:14.04:%v": {
+            "version": "14.04",
+            "arch": "%v",
+            "versions": {
+                "20151707": {
+                    "items": {
+                        "%v": {
+                            "id": "%v",
+                            "root_store": "%v", 
+                            "virt": "%v", 
+                            "region": "%v",
+                            "endpoint": "%v"
+                        }
+                    }
+                }
+            }
+        }
+     },
+    "updated": "Fri, 17 Jul 2015 13:42:48 +1000",
+    "format": "products:1.0",
+    "content_id": "com.ubuntu.cloud:custom"
+}`
+)
+
+func writeTempFiles(c *gc.C, metadataDir string, expected []struct{ path, content string }) {
+	for _, pair := range expected {
+		path := filepath.Join(metadataDir, pair.path)
+		err := os.MkdirAll(filepath.Dir(path), 0755)
+		c.Assert(err, jc.ErrorIsNil)
+		err = ioutil.WriteFile(path, []byte(pair.content), 0644)
+		c.Assert(err, jc.ErrorIsNil)
+	}
+}
+
+func (s *regionMetadataSuite) createTestDataSource(c *gc.C, dsID string, files []struct{ path, content string }) {
+	metadataDir := c.MkDir()
+	writeTempFiles(c, metadataDir, files)
+	environs.RegisterImageDataSourceFunc(dsID, func(environs.Environ) (simplestreams.DataSource, error) {
+		return simplestreams.NewURLDataSource(dsID, "file://"+metadataDir, false), nil
+	})
+	s.AddCleanup(func(*gc.C) {
+		environs.UnregisterImageDataSourceFunc(dsID)
+	})
+}
+
+func (s *regionMetadataSuite) setupMetadata(c *gc.C, dsID string, cloudSpec simplestreams.CloudSpec, metadata cloudimagemetadata.Metadata) {
+	files := []struct{ path, content string }{{
+		path:    "streams/v1/index.json",
+		content: fmt.Sprintf(indexContent, metadata.Source, metadata.Region, cloudSpec.Endpoint, metadata.Arch),
+	}, {
+		path:    "streams/v1/products.json",
+		content: fmt.Sprintf(productContent, metadata.Arch, metadata.Arch, metadata.ImageId, metadata.ImageId, metadata.RootStorageType, metadata.VirtType, metadata.Region, cloudSpec.Endpoint),
+	}, {
+		path:    "wayward/file.txt",
+		content: "ghi",
+	}}
+	s.createTestDataSource(c, dsID, files)
+}
+
+func (s *regionMetadataSuite) TestUpdateFromPublishedImagesMultipleDS(c *gc.C) {
+	s.setExpectations(c)
+
+	// register another data source
+	cloudSpec, err := s.env.Region()
+	c.Assert(err, jc.ErrorIsNil)
+	anotherDS := "second ds"
+
+	m1 := s.expected[0]
+	s.setupMetadata(c, anotherDS, cloudSpec, m1)
+	m1.Source = anotherDS
+	s.expected = append(s.expected, m1)
+
+	s.checkStoredPublished(c)
+}
+
+func (s *regionMetadataSuite) TestUpdateFromPublishedImagesMultipleDSError(c *gc.C) {
+	s.setExpectations(c)
+
+	// register another data source that would error
+	files := []struct{ path, content string }{{
+		path:    "wayward/file.txt",
+		content: "ghi",
+	}}
+	s.createTestDataSource(c, "error in ds", files)
+
+	s.checkStoredPublished(c)
 }

--- a/apiserver/params/image_metadata.go
+++ b/apiserver/params/image_metadata.go
@@ -57,6 +57,11 @@ type CloudImageMetadata struct {
 
 	// Source describes where this image is coming from: is it public? custom?
 	Source string `json:"source"`
+
+	// Priority is an importance factor for image metadata.
+	// Higher number means higher priority.
+	// This will allow to sort metadata by importance.
+	Priority int `json:"priority"`
 }
 
 // ListCloudImageMetadataResult holds the results of querying cloud image metadata.

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -1061,7 +1061,7 @@ func (a *MachineAgent) StateWorker() (worker.Worker, error) {
 	reportOpenedState(st)
 
 	stor := statestorage.NewStorage(st.EnvironUUID(), st.MongoSession())
-	registerSimplestreamsDataSource(stor, 10)
+	registerSimplestreamsDataSource(stor)
 
 	runner := newConnRunner(st)
 	singularRunner, err := newSingularStateRunner(runner, st, m)

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -1061,7 +1061,7 @@ func (a *MachineAgent) StateWorker() (worker.Worker, error) {
 	reportOpenedState(st)
 
 	stor := statestorage.NewStorage(st.EnvironUUID(), st.MongoSession())
-	registerSimplestreamsDataSource(stor)
+	registerSimplestreamsDataSource(stor, 10)
 
 	runner := newConnRunner(st)
 	singularRunner, err := newSingularStateRunner(runner, st, m)

--- a/cmd/jujud/agent/simplestreams.go
+++ b/cmd/jujud/agent/simplestreams.go
@@ -72,8 +72,8 @@ func (d environmentStorageDataSource) Priority() int {
 }
 
 // registerSimplestreamsDataSource registers a environmentStorageDataSource.
-func registerSimplestreamsDataSource(stor storage.Storage, priority int) {
-	ds := NewEnvironmentStorageDataSource(stor, priority)
+func registerSimplestreamsDataSource(stor storage.Storage) {
+	ds := NewEnvironmentStorageDataSource(stor, simplestreams.DEFAULT_CLOUD_DATA)
 	environs.RegisterUserImageDataSourceFunc(storageDataSourceId, func(environs.Environ) (simplestreams.DataSource, error) {
 		return ds, nil
 	})

--- a/cmd/jujud/agent/simplestreams.go
+++ b/cmd/jujud/agent/simplestreams.go
@@ -24,13 +24,14 @@ const (
 // environmentStorageDataSource is a simplestreams.DataSource that
 // retrieves simplestreams metadata from environment storage.
 type environmentStorageDataSource struct {
-	stor storage.Storage
+	stor     storage.Storage
+	priority int
 }
 
 // NewEnvironmentStorageDataSource returns a new datasource that retrieves
 // metadata from environment storage.
-func NewEnvironmentStorageDataSource(stor storage.Storage) simplestreams.DataSource {
-	return environmentStorageDataSource{stor}
+func NewEnvironmentStorageDataSource(stor storage.Storage, priority int) simplestreams.DataSource {
+	return environmentStorageDataSource{stor, priority}
 }
 
 // Description is defined in simplestreams.DataSource.
@@ -65,9 +66,14 @@ func (d environmentStorageDataSource) URL(file string) (string, error) {
 func (d environmentStorageDataSource) SetAllowRetry(allow bool) {
 }
 
+// Priority is defined in simplestreams.DataSource.
+func (d environmentStorageDataSource) Priority() int {
+	return d.priority
+}
+
 // registerSimplestreamsDataSource registers a environmentStorageDataSource.
-func registerSimplestreamsDataSource(stor storage.Storage) {
-	ds := NewEnvironmentStorageDataSource(stor)
+func registerSimplestreamsDataSource(stor storage.Storage, priority int) {
+	ds := NewEnvironmentStorageDataSource(stor, priority)
 	environs.RegisterUserImageDataSourceFunc(storageDataSourceId, func(environs.Environ) (simplestreams.DataSource, error) {
 		return ds, nil
 	})

--- a/cmd/jujud/agent/upgrade.go
+++ b/cmd/jujud/agent/upgrade.go
@@ -178,7 +178,7 @@ func (c *upgradeWorkerContext) run(stop <-chan struct{}) error {
 		}
 
 		stor := storage.NewStorage(c.st.EnvironUUID(), c.st.MongoSession())
-		registerSimplestreamsDataSource(stor)
+		registerSimplestreamsDataSource(stor, 10)
 
 		// This state-dependent data source will be useless
 		// once state is closed in previous defer - un-register it.

--- a/cmd/jujud/agent/upgrade.go
+++ b/cmd/jujud/agent/upgrade.go
@@ -182,7 +182,7 @@ func (c *upgradeWorkerContext) run(stop <-chan struct{}) error {
 		// We may not need this anymore.
 		// At the very least, there could be an upgrade step to read the data
 		// and add it to structured data.
-		registerSimplestreamsDataSource(stor, 10)
+		registerSimplestreamsDataSource(stor)
 
 		// This state-dependent data source will be useless
 		// once state is closed in previous defer - un-register it.

--- a/cmd/jujud/agent/upgrade.go
+++ b/cmd/jujud/agent/upgrade.go
@@ -178,6 +178,10 @@ func (c *upgradeWorkerContext) run(stop <-chan struct{}) error {
 		}
 
 		stor := storage.NewStorage(c.st.EnvironUUID(), c.st.MongoSession())
+		// TODO(anastasiamac 2015-10-30)
+		// We may not need this anymore.
+		// At the very least, there could be an upgrade step to read the data
+		// and add it to structured data.
 		registerSimplestreamsDataSource(stor, 10)
 
 		// This state-dependent data source will be useless

--- a/cmd/jujud/bootstrap.go
+++ b/cmd/jujud/bootstrap.go
@@ -405,7 +405,7 @@ func (c *BootstrapCommand) saveCustomImageMetadata(st *state.State) error {
 	logger.Debugf("saving custom image metadata from %q", c.ImageMetadataDir)
 
 	baseURL := fmt.Sprintf("file://%s", filepath.ToSlash(c.ImageMetadataDir))
-	datasource := simplestreams.NewURLDataSource("bootstrap metadata", baseURL, utils.NoVerifySSLHostnames, 50)
+	datasource := simplestreams.NewURLDataSource("bootstrap metadata", baseURL, utils.NoVerifySSLHostnames, simplestreams.CUSTOM_CLOUD_DATA)
 
 	// Read user supplied image metadata, as we'll want to upload it to the environment.
 	imageConstraint := imagemetadata.NewImageConstraint(simplestreams.LookupParams{})

--- a/cmd/jujud/bootstrap.go
+++ b/cmd/jujud/bootstrap.go
@@ -407,7 +407,7 @@ func (c *BootstrapCommand) saveCustomImageMetadata(st *state.State) error {
 	baseURL := fmt.Sprintf("file://%s", filepath.ToSlash(c.ImageMetadataDir))
 	datasource := simplestreams.NewURLDataSource("bootstrap metadata", baseURL, utils.NoVerifySSLHostnames, 50)
 
-	// Read the image metadata, as we'll want to upload it to the environment.
+	// Read user supplied image metadata, as we'll want to upload it to the environment.
 	imageConstraint := imagemetadata.NewImageConstraint(simplestreams.LookupParams{})
 	existingMetadata, _, err := imagemetadata.Fetch(
 		[]simplestreams.DataSource{datasource}, imageConstraint, false)

--- a/cmd/jujud/bootstrap.go
+++ b/cmd/jujud/bootstrap.go
@@ -405,7 +405,7 @@ func (c *BootstrapCommand) saveCustomImageMetadata(st *state.State) error {
 	logger.Debugf("saving custom image metadata from %q", c.ImageMetadataDir)
 
 	baseURL := fmt.Sprintf("file://%s", filepath.ToSlash(c.ImageMetadataDir))
-	datasource := simplestreams.NewURLDataSource("bootstrap metadata", baseURL, utils.NoVerifySSLHostnames)
+	datasource := simplestreams.NewURLDataSource("bootstrap metadata", baseURL, utils.NoVerifySSLHostnames, 50)
 
 	// Read the image metadata, as we'll want to upload it to the environment.
 	imageConstraint := imagemetadata.NewImageConstraint(simplestreams.LookupParams{})
@@ -429,6 +429,7 @@ func (c *BootstrapCommand) saveCustomImageMetadata(st *state.State) error {
 				RootStorageType: one.Storage,
 				Source:          "custom",
 			},
+			datasource.Priority(),
 			one.Id,
 		}
 		s, err := seriesFromVersion(one.Version)

--- a/cmd/jujud/bootstrap_test.go
+++ b/cmd/jujud/bootstrap_test.go
@@ -675,7 +675,8 @@ func createImageMetadata(c *gc.C) (string, cloudimagemetadata.Metadata) {
 			VirtType:        "virtType",
 			RootStorageType: "rootStore",
 			Source:          "custom"},
-		ImageId: "imageId"}
+		Priority: 50,
+		ImageId:  "imageId"}
 
 	// setup files containing test's data
 	metadataDir := c.MkDir()

--- a/cmd/jujud/bootstrap_test.go
+++ b/cmd/jujud/bootstrap_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/configstore"
 	"github.com/juju/juju/environs/filestorage"
+	"github.com/juju/juju/environs/simplestreams"
 	"github.com/juju/juju/environs/storage"
 	envtesting "github.com/juju/juju/environs/testing"
 	envtools "github.com/juju/juju/environs/tools"
@@ -675,7 +676,7 @@ func createImageMetadata(c *gc.C) (string, cloudimagemetadata.Metadata) {
 			VirtType:        "virtType",
 			RootStorageType: "rootStore",
 			Source:          "custom"},
-		Priority: 50,
+		Priority: simplestreams.CUSTOM_CLOUD_DATA,
 		ImageId:  "imageId"}
 
 	// setup files containing test's data

--- a/cmd/plugins/juju-metadata/toolsmetadata.go
+++ b/cmd/plugins/juju-metadata/toolsmetadata.go
@@ -120,7 +120,7 @@ func (c *ToolsMetadataCommand) Run(context *cmd.Context) error {
 		if err != nil {
 			return err
 		}
-		sourceDataSource := simplestreams.NewURLDataSource("local source", source, utils.VerifySSLHostnames)
+		sourceDataSource := simplestreams.NewURLDataSource("local source", source, utils.VerifySSLHostnames, 60)
 		toolsList, err = envtools.FindToolsForCloud(
 			[]simplestreams.DataSource{sourceDataSource}, simplestreams.CloudSpec{}, c.stream,
 			version.Current.Major, minorVersion, coretools.Filter{})

--- a/cmd/plugins/juju-metadata/toolsmetadata.go
+++ b/cmd/plugins/juju-metadata/toolsmetadata.go
@@ -120,7 +120,7 @@ func (c *ToolsMetadataCommand) Run(context *cmd.Context) error {
 		if err != nil {
 			return err
 		}
-		sourceDataSource := simplestreams.NewURLDataSource("local source", source, utils.VerifySSLHostnames, 60)
+		sourceDataSource := simplestreams.NewURLDataSource("local source", source, utils.VerifySSLHostnames, simplestreams.CUSTOM_CLOUD_DATA)
 		toolsList, err = envtools.FindToolsForCloud(
 			[]simplestreams.DataSource{sourceDataSource}, simplestreams.CloudSpec{}, c.stream,
 			version.Current.Major, minorVersion, coretools.Filter{})

--- a/cmd/plugins/juju-metadata/validateimagemetadata.go
+++ b/cmd/plugins/juju-metadata/validateimagemetadata.go
@@ -184,7 +184,7 @@ func (c *ValidateImageMetadataCommand) Run(context *cmd.Context) error {
 		}
 		params.Sources = []simplestreams.DataSource{
 			simplestreams.NewURLDataSource(
-				"local metadata directory", "file://"+dir, utils.VerifySSLHostnames, 60),
+				"local metadata directory", "file://"+dir, utils.VerifySSLHostnames, simplestreams.CUSTOM_CLOUD_DATA),
 		}
 	}
 	params.Stream = c.stream

--- a/cmd/plugins/juju-metadata/validateimagemetadata.go
+++ b/cmd/plugins/juju-metadata/validateimagemetadata.go
@@ -184,7 +184,7 @@ func (c *ValidateImageMetadataCommand) Run(context *cmd.Context) error {
 		}
 		params.Sources = []simplestreams.DataSource{
 			simplestreams.NewURLDataSource(
-				"local metadata directory", "file://"+dir, utils.VerifySSLHostnames),
+				"local metadata directory", "file://"+dir, utils.VerifySSLHostnames, 60),
 		}
 	}
 	params.Stream = c.stream

--- a/cmd/plugins/juju-metadata/validatetoolsmetadata.go
+++ b/cmd/plugins/juju-metadata/validatetoolsmetadata.go
@@ -205,7 +205,7 @@ func (c *ValidateToolsMetadataCommand) Run(context *cmd.Context) error {
 			return err
 		}
 		params.Sources = []simplestreams.DataSource{simplestreams.NewURLDataSource(
-			"local metadata directory", toolsURL, utils.VerifySSLHostnames, 60),
+			"local metadata directory", toolsURL, utils.VerifySSLHostnames, simplestreams.CUSTOM_CLOUD_DATA),
 		}
 	}
 	params.Stream = c.stream

--- a/cmd/plugins/juju-metadata/validatetoolsmetadata.go
+++ b/cmd/plugins/juju-metadata/validatetoolsmetadata.go
@@ -205,7 +205,7 @@ func (c *ValidateToolsMetadataCommand) Run(context *cmd.Context) error {
 			return err
 		}
 		params.Sources = []simplestreams.DataSource{simplestreams.NewURLDataSource(
-			"local metadata directory", toolsURL, utils.VerifySSLHostnames),
+			"local metadata directory", toolsURL, utils.VerifySSLHostnames, 60),
 		}
 	}
 	params.Stream = c.stream

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -258,7 +258,7 @@ func setPrivateMetadataSources(env environs.Environ, metadataDir string) ([]*ima
 	}
 
 	baseURL := fmt.Sprintf("file://%s", filepath.ToSlash(imageMetadataDir))
-	datasource := simplestreams.NewURLDataSource("bootstrap metadata", baseURL, utils.NoVerifySSLHostnames)
+	datasource := simplestreams.NewURLDataSource("bootstrap metadata", baseURL, utils.NoVerifySSLHostnames, 50)
 
 	// Read the image metadata, as we'll want to upload it to the environment.
 	imageConstraint := imagemetadata.NewImageConstraint(simplestreams.LookupParams{})

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -258,7 +258,7 @@ func setPrivateMetadataSources(env environs.Environ, metadataDir string) ([]*ima
 	}
 
 	baseURL := fmt.Sprintf("file://%s", filepath.ToSlash(imageMetadataDir))
-	datasource := simplestreams.NewURLDataSource("bootstrap metadata", baseURL, utils.NoVerifySSLHostnames, 50)
+	datasource := simplestreams.NewURLDataSource("bootstrap metadata", baseURL, utils.NoVerifySSLHostnames, simplestreams.CUSTOM_CLOUD_DATA)
 
 	// Read the image metadata, as we'll want to upload it to the environment.
 	imageConstraint := imagemetadata.NewImageConstraint(simplestreams.LookupParams{})

--- a/environs/bootstrap/bootstrap_test.go
+++ b/environs/bootstrap/bootstrap_test.go
@@ -299,7 +299,7 @@ func (s *bootstrapSuite) setupBootstrapSpecificVersion(
 	env := newEnviron("foo", useDefaultKeys, nil)
 	s.setDummyStorage(c, env)
 	envtools.RegisterToolsDataSourceFunc("local storage", func(environs.Environ) (simplestreams.DataSource, error) {
-		return storage.NewStorageSimpleStreamsDataSource("test datasource", env.storage, "tools"), nil
+		return storage.NewStorageSimpleStreamsDataSource("test datasource", env.storage, "tools", 20), nil
 	})
 	defer envtools.UnregisterToolsDataSourceFunc("local storage")
 

--- a/environs/bootstrap/bootstrap_test.go
+++ b/environs/bootstrap/bootstrap_test.go
@@ -299,7 +299,7 @@ func (s *bootstrapSuite) setupBootstrapSpecificVersion(
 	env := newEnviron("foo", useDefaultKeys, nil)
 	s.setDummyStorage(c, env)
 	envtools.RegisterToolsDataSourceFunc("local storage", func(environs.Environ) (simplestreams.DataSource, error) {
-		return storage.NewStorageSimpleStreamsDataSource("test datasource", env.storage, "tools", 20), nil
+		return storage.NewStorageSimpleStreamsDataSource("test datasource", env.storage, "tools", simplestreams.CUSTOM_CLOUD_DATA), nil
 	})
 	defer envtools.UnregisterToolsDataSourceFunc("local storage")
 

--- a/environs/imagemetadata.go
+++ b/environs/imagemetadata.go
@@ -90,7 +90,7 @@ func ImageMetadataSources(env Environ) ([]simplestreams.DataSource, error) {
 		if !config.SSLHostnameVerification() {
 			verify = utils.NoVerifySSLHostnames
 		}
-		sources = append(sources, simplestreams.NewURLDataSource("image-metadata-url", userURL, verify))
+		sources = append(sources, simplestreams.NewURLDataSource("image-metadata-url", userURL, verify, 20))
 	}
 
 	envDataSources, err := environmentDataSources(env)
@@ -106,7 +106,7 @@ func ImageMetadataSources(env Environ) ([]simplestreams.DataSource, error) {
 	}
 	if defaultURL != "" {
 		sources = append(sources,
-			simplestreams.NewURLDataSource("default cloud images", defaultURL, utils.VerifySSLHostnames))
+			simplestreams.NewURLDataSource("default cloud images", defaultURL, utils.VerifySSLHostnames, 10))
 	}
 	for _, ds := range sources {
 		logger.Debugf("using image datasource %q", ds.Description())

--- a/environs/imagemetadata.go
+++ b/environs/imagemetadata.go
@@ -90,7 +90,7 @@ func ImageMetadataSources(env Environ) ([]simplestreams.DataSource, error) {
 		if !config.SSLHostnameVerification() {
 			verify = utils.NoVerifySSLHostnames
 		}
-		sources = append(sources, simplestreams.NewURLDataSource("image-metadata-url", userURL, verify, 20))
+		sources = append(sources, simplestreams.NewURLDataSource("image-metadata-url", userURL, verify, simplestreams.SPECIFIC_CLOUD_DATA))
 	}
 
 	envDataSources, err := environmentDataSources(env)
@@ -106,7 +106,7 @@ func ImageMetadataSources(env Environ) ([]simplestreams.DataSource, error) {
 	}
 	if defaultURL != "" {
 		sources = append(sources,
-			simplestreams.NewURLDataSource("default cloud images", defaultURL, utils.VerifySSLHostnames, 10))
+			simplestreams.NewURLDataSource("default cloud images", defaultURL, utils.VerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA))
 	}
 	for _, ds := range sources {
 		logger.Debugf("using image datasource %q", ds.Description())

--- a/environs/imagemetadata/generate.go
+++ b/environs/imagemetadata/generate.go
@@ -46,7 +46,7 @@ func MergeAndWriteMetadata(ser string, metadata []*ImageMetadata, cloudSpec *sim
 // readMetadata reads the image metadata from metadataStore.
 func readMetadata(metadataStore storage.Storage) ([]*ImageMetadata, error) {
 	// Read any existing metadata so we can merge the new tools metadata with what's there.
-	dataSource := storage.NewStorageSimpleStreamsDataSource("existing metadata", metadataStore, storage.BaseImagesPath)
+	dataSource := storage.NewStorageSimpleStreamsDataSource("existing metadata", metadataStore, storage.BaseImagesPath, 0)
 	imageConstraint := NewImageConstraint(simplestreams.LookupParams{})
 	existingMetadata, _, err := Fetch([]simplestreams.DataSource{dataSource}, imageConstraint, false)
 	if err != nil && !errors.IsNotFound(err) {

--- a/environs/imagemetadata/generate.go
+++ b/environs/imagemetadata/generate.go
@@ -46,7 +46,7 @@ func MergeAndWriteMetadata(ser string, metadata []*ImageMetadata, cloudSpec *sim
 // readMetadata reads the image metadata from metadataStore.
 func readMetadata(metadataStore storage.Storage) ([]*ImageMetadata, error) {
 	// Read any existing metadata so we can merge the new tools metadata with what's there.
-	dataSource := storage.NewStorageSimpleStreamsDataSource("existing metadata", metadataStore, storage.BaseImagesPath, 0)
+	dataSource := storage.NewStorageSimpleStreamsDataSource("existing metadata", metadataStore, storage.BaseImagesPath, simplestreams.EXISTING_CLOUD_DATA)
 	imageConstraint := NewImageConstraint(simplestreams.LookupParams{})
 	existingMetadata, _, err := Fetch([]simplestreams.DataSource{dataSource}, imageConstraint, false)
 	if err != nil && !errors.IsNotFound(err) {

--- a/environs/imagemetadata/generate_test.go
+++ b/environs/imagemetadata/generate_test.go
@@ -27,7 +27,7 @@ func assertFetch(c *gc.C, stor storage.Storage, series, arch, region, endpoint, 
 		Series:    []string{series},
 		Arches:    []string{arch},
 	})
-	dataSource := storage.NewStorageSimpleStreamsDataSource("test datasource", stor, "images")
+	dataSource := storage.NewStorageSimpleStreamsDataSource("test datasource", stor, "images", 10)
 	metadata, _, err := imagemetadata.Fetch([]simplestreams.DataSource{dataSource}, cons, false)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(metadata, gc.HasLen, 1)

--- a/environs/imagemetadata/generate_test.go
+++ b/environs/imagemetadata/generate_test.go
@@ -27,7 +27,7 @@ func assertFetch(c *gc.C, stor storage.Storage, series, arch, region, endpoint, 
 		Series:    []string{series},
 		Arches:    []string{arch},
 	})
-	dataSource := storage.NewStorageSimpleStreamsDataSource("test datasource", stor, "images", 10)
+	dataSource := storage.NewStorageSimpleStreamsDataSource("test datasource", stor, "images", simplestreams.DEFAULT_CLOUD_DATA)
 	metadata, _, err := imagemetadata.Fetch([]simplestreams.DataSource{dataSource}, cons, false)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(metadata, gc.HasLen, 1)

--- a/environs/imagemetadata/simplestreams_test.go
+++ b/environs/imagemetadata/simplestreams_test.go
@@ -69,7 +69,7 @@ func registerSimpleStreamsTests() {
 	gc.Suite(&simplestreamsSuite{
 		LocalLiveSimplestreamsSuite: sstesting.LocalLiveSimplestreamsSuite{
 			Source: simplestreams.NewURLDataSource(
-				"test roundtripper", "test:", utils.VerifySSLHostnames, 10),
+				"test roundtripper", "test:", utils.VerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA),
 			RequireSigned:  false,
 			DataType:       imagemetadata.ImageIds,
 			StreamsVersion: imagemetadata.CurrentStreamsVersion,
@@ -88,7 +88,7 @@ func registerSimpleStreamsTests() {
 
 func registerLiveSimpleStreamsTests(baseURL string, validImageConstraint simplestreams.LookupConstraint, requireSigned bool) {
 	gc.Suite(&sstesting.LocalLiveSimplestreamsSuite{
-		Source:          simplestreams.NewURLDataSource("test", baseURL, utils.VerifySSLHostnames, 10),
+		Source:          simplestreams.NewURLDataSource("test", baseURL, utils.VerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA),
 		RequireSigned:   requireSigned,
 		DataType:        imagemetadata.ImageIds,
 		ValidConstraint: validImageConstraint,
@@ -270,7 +270,7 @@ func (s *simplestreamsSuite) TestFetch(c *gc.C) {
 			Arches:    t.arches,
 		})
 		// Add invalid datasource and check later that resolveInfo is correct.
-		invalidSource := simplestreams.NewURLDataSource("invalid", "file://invalid", utils.VerifySSLHostnames, 10)
+		invalidSource := simplestreams.NewURLDataSource("invalid", "file://invalid", utils.VerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA)
 		images, resolveInfo, err := imagemetadata.Fetch(
 			[]simplestreams.DataSource{invalidSource, s.Source}, imageConstraint, s.RequireSigned)
 		if !c.Check(err, jc.ErrorIsNil) {
@@ -377,7 +377,7 @@ func (s *signedSuite) TearDownSuite(c *gc.C) {
 }
 
 func (s *signedSuite) TestSignedImageMetadata(c *gc.C) {
-	signedSource := simplestreams.NewURLDataSource("test", "signedtest://host/signed", utils.VerifySSLHostnames, 10)
+	signedSource := simplestreams.NewURLDataSource("test", "signedtest://host/signed", utils.VerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA)
 	imageConstraint := imagemetadata.NewImageConstraint(simplestreams.LookupParams{
 		CloudSpec: simplestreams.CloudSpec{"us-east-1", "https://ec2.us-east-1.amazonaws.com"},
 		Series:    []string{"precise"},
@@ -396,7 +396,7 @@ func (s *signedSuite) TestSignedImageMetadata(c *gc.C) {
 }
 
 func (s *signedSuite) TestSignedImageMetadataInvalidSignature(c *gc.C) {
-	signedSource := simplestreams.NewURLDataSource("test", "signedtest://host/signed", utils.VerifySSLHostnames, 10)
+	signedSource := simplestreams.NewURLDataSource("test", "signedtest://host/signed", utils.VerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA)
 	imageConstraint := imagemetadata.NewImageConstraint(simplestreams.LookupParams{
 		CloudSpec: simplestreams.CloudSpec{"us-east-1", "https://ec2.us-east-1.amazonaws.com"},
 		Series:    []string{"precise"},

--- a/environs/imagemetadata/simplestreams_test.go
+++ b/environs/imagemetadata/simplestreams_test.go
@@ -69,7 +69,7 @@ func registerSimpleStreamsTests() {
 	gc.Suite(&simplestreamsSuite{
 		LocalLiveSimplestreamsSuite: sstesting.LocalLiveSimplestreamsSuite{
 			Source: simplestreams.NewURLDataSource(
-				"test roundtripper", "test:", utils.VerifySSLHostnames),
+				"test roundtripper", "test:", utils.VerifySSLHostnames, 10),
 			RequireSigned:  false,
 			DataType:       imagemetadata.ImageIds,
 			StreamsVersion: imagemetadata.CurrentStreamsVersion,
@@ -88,7 +88,7 @@ func registerSimpleStreamsTests() {
 
 func registerLiveSimpleStreamsTests(baseURL string, validImageConstraint simplestreams.LookupConstraint, requireSigned bool) {
 	gc.Suite(&sstesting.LocalLiveSimplestreamsSuite{
-		Source:          simplestreams.NewURLDataSource("test", baseURL, utils.VerifySSLHostnames),
+		Source:          simplestreams.NewURLDataSource("test", baseURL, utils.VerifySSLHostnames, 10),
 		RequireSigned:   requireSigned,
 		DataType:        imagemetadata.ImageIds,
 		ValidConstraint: validImageConstraint,
@@ -270,7 +270,7 @@ func (s *simplestreamsSuite) TestFetch(c *gc.C) {
 			Arches:    t.arches,
 		})
 		// Add invalid datasource and check later that resolveInfo is correct.
-		invalidSource := simplestreams.NewURLDataSource("invalid", "file://invalid", utils.VerifySSLHostnames)
+		invalidSource := simplestreams.NewURLDataSource("invalid", "file://invalid", utils.VerifySSLHostnames, 10)
 		images, resolveInfo, err := imagemetadata.Fetch(
 			[]simplestreams.DataSource{invalidSource, s.Source}, imageConstraint, s.RequireSigned)
 		if !c.Check(err, jc.ErrorIsNil) {
@@ -377,7 +377,7 @@ func (s *signedSuite) TearDownSuite(c *gc.C) {
 }
 
 func (s *signedSuite) TestSignedImageMetadata(c *gc.C) {
-	signedSource := simplestreams.NewURLDataSource("test", "signedtest://host/signed", utils.VerifySSLHostnames)
+	signedSource := simplestreams.NewURLDataSource("test", "signedtest://host/signed", utils.VerifySSLHostnames, 10)
 	imageConstraint := imagemetadata.NewImageConstraint(simplestreams.LookupParams{
 		CloudSpec: simplestreams.CloudSpec{"us-east-1", "https://ec2.us-east-1.amazonaws.com"},
 		Series:    []string{"precise"},
@@ -396,7 +396,7 @@ func (s *signedSuite) TestSignedImageMetadata(c *gc.C) {
 }
 
 func (s *signedSuite) TestSignedImageMetadataInvalidSignature(c *gc.C) {
-	signedSource := simplestreams.NewURLDataSource("test", "signedtest://host/signed", utils.VerifySSLHostnames)
+	signedSource := simplestreams.NewURLDataSource("test", "signedtest://host/signed", utils.VerifySSLHostnames, 10)
 	imageConstraint := imagemetadata.NewImageConstraint(simplestreams.LookupParams{
 		CloudSpec: simplestreams.CloudSpec{"us-east-1", "https://ec2.us-east-1.amazonaws.com"},
 		Series:    []string{"precise"},

--- a/environs/imagemetadata/testing/testing.go
+++ b/environs/imagemetadata/testing/testing.go
@@ -28,7 +28,7 @@ func ParseMetadataFromDir(c *gc.C, metadataDir string) []*imagemetadata.ImageMet
 
 // ParseMetadataFromStorage loads ImageMetadata from the specified storage reader.
 func ParseMetadataFromStorage(c *gc.C, stor storage.StorageReader) []*imagemetadata.ImageMetadata {
-	source := storage.NewStorageSimpleStreamsDataSource("test storage reader", stor, "images", 10)
+	source := storage.NewStorageSimpleStreamsDataSource("test storage reader", stor, "images", simplestreams.DEFAULT_CLOUD_DATA)
 
 	// Find the simplestreams index file.
 	params := simplestreams.ValueParams{

--- a/environs/imagemetadata/testing/testing.go
+++ b/environs/imagemetadata/testing/testing.go
@@ -28,7 +28,7 @@ func ParseMetadataFromDir(c *gc.C, metadataDir string) []*imagemetadata.ImageMet
 
 // ParseMetadataFromStorage loads ImageMetadata from the specified storage reader.
 func ParseMetadataFromStorage(c *gc.C, stor storage.StorageReader) []*imagemetadata.ImageMetadata {
-	source := storage.NewStorageSimpleStreamsDataSource("test storage reader", stor, "images")
+	source := storage.NewStorageSimpleStreamsDataSource("test storage reader", stor, "images", 10)
 
 	// Find the simplestreams index file.
 	params := simplestreams.ValueParams{

--- a/environs/imagemetadata/validation_test.go
+++ b/environs/imagemetadata/validation_test.go
@@ -60,7 +60,7 @@ func (s *ValidateSuite) assertMatch(c *gc.C, stream string) {
 		Endpoint:      "some-auth-url",
 		Stream:        stream,
 		Sources: []simplestreams.DataSource{
-			simplestreams.NewURLDataSource("test", utils.MakeFileURL(metadataPath), utils.VerifySSLHostnames)},
+			simplestreams.NewURLDataSource("test", utils.MakeFileURL(metadataPath), utils.VerifySSLHostnames, 10)},
 	}
 	imageIds, resolveInfo, err := imagemetadata.ValidateImageMetadata(params)
 	c.Assert(err, jc.ErrorIsNil)
@@ -88,7 +88,7 @@ func (s *ValidateSuite) assertNoMatch(c *gc.C, stream string) {
 		Endpoint:      "some-auth-url",
 		Stream:        stream,
 		Sources: []simplestreams.DataSource{
-			simplestreams.NewURLDataSource("test", "file://"+s.metadataDir, utils.VerifySSLHostnames)},
+			simplestreams.NewURLDataSource("test", "file://"+s.metadataDir, utils.VerifySSLHostnames, 10)},
 	}
 	_, _, err := imagemetadata.ValidateImageMetadata(params)
 	c.Assert(err, gc.Not(gc.IsNil))

--- a/environs/imagemetadata/validation_test.go
+++ b/environs/imagemetadata/validation_test.go
@@ -60,7 +60,7 @@ func (s *ValidateSuite) assertMatch(c *gc.C, stream string) {
 		Endpoint:      "some-auth-url",
 		Stream:        stream,
 		Sources: []simplestreams.DataSource{
-			simplestreams.NewURLDataSource("test", utils.MakeFileURL(metadataPath), utils.VerifySSLHostnames, 10)},
+			simplestreams.NewURLDataSource("test", utils.MakeFileURL(metadataPath), utils.VerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA)},
 	}
 	imageIds, resolveInfo, err := imagemetadata.ValidateImageMetadata(params)
 	c.Assert(err, jc.ErrorIsNil)
@@ -88,7 +88,7 @@ func (s *ValidateSuite) assertNoMatch(c *gc.C, stream string) {
 		Endpoint:      "some-auth-url",
 		Stream:        stream,
 		Sources: []simplestreams.DataSource{
-			simplestreams.NewURLDataSource("test", "file://"+s.metadataDir, utils.VerifySSLHostnames, 10)},
+			simplestreams.NewURLDataSource("test", "file://"+s.metadataDir, utils.VerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA)},
 	}
 	_, _, err := imagemetadata.ValidateImageMetadata(params)
 	c.Assert(err, gc.Not(gc.IsNil))

--- a/environs/imagemetadata_test.go
+++ b/environs/imagemetadata_test.go
@@ -70,17 +70,17 @@ func (s *ImageMetadataSuite) TestImageMetadataURLs(c *gc.C) {
 
 func (s *ImageMetadataSuite) TestImageMetadataURLsRegisteredFuncs(c *gc.C) {
 	environs.RegisterImageDataSourceFunc("id0", func(environs.Environ) (simplestreams.DataSource, error) {
-		return simplestreams.NewURLDataSource("id0", "betwixt/releases", utils.NoVerifySSLHostnames), nil
+		return simplestreams.NewURLDataSource("id0", "betwixt/releases", utils.NoVerifySSLHostnames, 10), nil
 	})
 	environs.RegisterImageDataSourceFunc("id1", func(environs.Environ) (simplestreams.DataSource, error) {
-		return simplestreams.NewURLDataSource("id1", "yoink", utils.NoVerifySSLHostnames), nil
+		return simplestreams.NewURLDataSource("id1", "yoink", utils.NoVerifySSLHostnames, 20), nil
 	})
 	// overwrite the one previously registered against id1
 	environs.RegisterImageDataSourceFunc("id1", func(environs.Environ) (simplestreams.DataSource, error) {
 		return nil, errors.NewNotSupported(nil, "oyvey")
 	})
 	environs.RegisterUserImageDataSourceFunc("id2", func(environs.Environ) (simplestreams.DataSource, error) {
-		return simplestreams.NewURLDataSource("id2", "foobar", utils.NoVerifySSLHostnames), nil
+		return simplestreams.NewURLDataSource("id2", "foobar", utils.NoVerifySSLHostnames, 30), nil
 	})
 	defer environs.UnregisterImageDataSourceFunc("id0")
 	defer environs.UnregisterImageDataSourceFunc("id1")

--- a/environs/imagemetadata_test.go
+++ b/environs/imagemetadata_test.go
@@ -70,17 +70,17 @@ func (s *ImageMetadataSuite) TestImageMetadataURLs(c *gc.C) {
 
 func (s *ImageMetadataSuite) TestImageMetadataURLsRegisteredFuncs(c *gc.C) {
 	environs.RegisterImageDataSourceFunc("id0", func(environs.Environ) (simplestreams.DataSource, error) {
-		return simplestreams.NewURLDataSource("id0", "betwixt/releases", utils.NoVerifySSLHostnames, 10), nil
+		return simplestreams.NewURLDataSource("id0", "betwixt/releases", utils.NoVerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA), nil
 	})
 	environs.RegisterImageDataSourceFunc("id1", func(environs.Environ) (simplestreams.DataSource, error) {
-		return simplestreams.NewURLDataSource("id1", "yoink", utils.NoVerifySSLHostnames, 20), nil
+		return simplestreams.NewURLDataSource("id1", "yoink", utils.NoVerifySSLHostnames, simplestreams.SPECIFIC_CLOUD_DATA), nil
 	})
 	// overwrite the one previously registered against id1
 	environs.RegisterImageDataSourceFunc("id1", func(environs.Environ) (simplestreams.DataSource, error) {
 		return nil, errors.NewNotSupported(nil, "oyvey")
 	})
 	environs.RegisterUserImageDataSourceFunc("id2", func(environs.Environ) (simplestreams.DataSource, error) {
-		return simplestreams.NewURLDataSource("id2", "foobar", utils.NoVerifySSLHostnames, 30), nil
+		return simplestreams.NewURLDataSource("id2", "foobar", utils.NoVerifySSLHostnames, simplestreams.CUSTOM_CLOUD_DATA), nil
 	})
 	defer environs.UnregisterImageDataSourceFunc("id0")
 	defer environs.UnregisterImageDataSourceFunc("id1")

--- a/environs/instances/image_test.go
+++ b/environs/instances/image_test.go
@@ -357,7 +357,7 @@ func (s *imageSuite) TestFindInstanceSpec(c *gc.C) {
 		})
 		imageMeta, err := imagemetadata.GetLatestImageIdMetadata(
 			[]byte(jsonImagesContent),
-			simplestreams.NewURLDataSource("test", "some-url", utils.VerifySSLHostnames, 10), cons)
+			simplestreams.NewURLDataSource("test", "some-url", utils.VerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA), cons)
 		c.Assert(err, jc.ErrorIsNil)
 		var images []Image
 		for _, imageMetadata := range imageMeta {

--- a/environs/instances/image_test.go
+++ b/environs/instances/image_test.go
@@ -357,7 +357,7 @@ func (s *imageSuite) TestFindInstanceSpec(c *gc.C) {
 		})
 		imageMeta, err := imagemetadata.GetLatestImageIdMetadata(
 			[]byte(jsonImagesContent),
-			simplestreams.NewURLDataSource("test", "some-url", utils.VerifySSLHostnames), cons)
+			simplestreams.NewURLDataSource("test", "some-url", utils.VerifySSLHostnames, 10), cons)
 		c.Assert(err, jc.ErrorIsNil)
 		var images []Image
 		for _, imageMetadata := range imageMeta {

--- a/environs/simplestreams/datasource.go
+++ b/environs/simplestreams/datasource.go
@@ -33,6 +33,28 @@ type DataSource interface {
 	Priority() int
 }
 
+const (
+	// These values used as priority factors for sorting data source data.
+
+	// EXISTING_CLOUD_DATA is the lowest in priority.
+	// It is mostly used in merge functions
+	// where existing data does not need to be ranked.
+	EXISTING_CLOUD_DATA = 0
+
+	// DEFAULT_CLOUD_DATA is used for common cloud data that
+	// is shared an is publically available.
+	DEFAULT_CLOUD_DATA = 10
+
+	// SPECIFIC_CLOUD_DATA is used to rank cloud specific data
+	// above commonly available.
+	// For e.g., openstack's "keystone catalogue".
+	SPECIFIC_CLOUD_DATA = 20
+
+	// CUSTOM_CLOUD_DATA is the highest available ranking and
+	// is given to custom data.
+	CUSTOM_CLOUD_DATA = 50
+)
+
 // A urlDataSource retrieves data from an HTTP URL.
 type urlDataSource struct {
 	description          string

--- a/environs/simplestreams/datasource.go
+++ b/environs/simplestreams/datasource.go
@@ -28,6 +28,9 @@ type DataSource interface {
 	// SetAllowRetry sets the flag which determines if the datasource will retry fetching the metadata
 	// if it is not immediately available.
 	SetAllowRetry(allow bool)
+	// Priority is an importance factor for Data Source. Higher number means higher priority.
+	// This is will allow to sort data sources in order of importance.
+	Priority() int
 }
 
 // A urlDataSource retrieves data from an HTTP URL.
@@ -35,14 +38,16 @@ type urlDataSource struct {
 	description          string
 	baseURL              string
 	hostnameVerification utils.SSLHostnameVerification
+	priority             int
 }
 
 // NewURLDataSource returns a new datasource reading from the specified baseURL.
-func NewURLDataSource(description, baseURL string, hostnameVerification utils.SSLHostnameVerification) DataSource {
+func NewURLDataSource(description, baseURL string, hostnameVerification utils.SSLHostnameVerification, priority int) DataSource {
 	return &urlDataSource{
 		description:          description,
 		baseURL:              baseURL,
 		hostnameVerification: hostnameVerification,
+		priority:             priority,
 	}
 }
 
@@ -99,4 +104,9 @@ func (h *urlDataSource) URL(path string) (string, error) {
 // SetAllowRetry is defined in simplestreams.DataSource.
 func (h *urlDataSource) SetAllowRetry(allow bool) {
 	// This is a NOOP for url datasources.
+}
+
+// Priority is defined in simplestreams.DataSource.
+func (h *urlDataSource) Priority() int {
+	return h.priority
 }

--- a/environs/simplestreams/datasource_test.go
+++ b/environs/simplestreams/datasource_test.go
@@ -25,7 +25,7 @@ type datasourceSuite struct {
 }
 
 func (s *datasourceSuite) TestFetch(c *gc.C) {
-	ds := simplestreams.NewURLDataSource("test", "test:", utils.VerifySSLHostnames, 10)
+	ds := simplestreams.NewURLDataSource("test", "test:", utils.VerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA)
 	rc, url, err := ds.Fetch("streams/v1/tools_metadata.json")
 	c.Assert(err, jc.ErrorIsNil)
 	defer rc.Close()
@@ -37,7 +37,7 @@ func (s *datasourceSuite) TestFetch(c *gc.C) {
 }
 
 func (s *datasourceSuite) TestURL(c *gc.C) {
-	ds := simplestreams.NewURLDataSource("test", "foo", utils.VerifySSLHostnames, 10)
+	ds := simplestreams.NewURLDataSource("test", "foo", utils.VerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA)
 	url, err := ds.URL("bar")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(url, gc.Equals, "foo/bar")
@@ -65,7 +65,7 @@ func (s *datasourceHTTPSSuite) TearDownTest(c *gc.C) {
 }
 
 func (s *datasourceHTTPSSuite) TestNormalClientFails(c *gc.C) {
-	ds := simplestreams.NewURLDataSource("test", s.Server.URL, utils.VerifySSLHostnames, 10)
+	ds := simplestreams.NewURLDataSource("test", s.Server.URL, utils.VerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA)
 	url, err := ds.URL("bar")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(url, gc.Equals, s.Server.URL+"/bar")
@@ -77,7 +77,7 @@ func (s *datasourceHTTPSSuite) TestNormalClientFails(c *gc.C) {
 }
 
 func (s *datasourceHTTPSSuite) TestNonVerifyingClientSucceeds(c *gc.C) {
-	ds := simplestreams.NewURLDataSource("test", s.Server.URL, utils.NoVerifySSLHostnames, 10)
+	ds := simplestreams.NewURLDataSource("test", s.Server.URL, utils.NoVerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA)
 	url, err := ds.URL("bar")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(url, gc.Equals, s.Server.URL+"/bar")

--- a/environs/simplestreams/datasource_test.go
+++ b/environs/simplestreams/datasource_test.go
@@ -25,7 +25,7 @@ type datasourceSuite struct {
 }
 
 func (s *datasourceSuite) TestFetch(c *gc.C) {
-	ds := simplestreams.NewURLDataSource("test", "test:", utils.VerifySSLHostnames)
+	ds := simplestreams.NewURLDataSource("test", "test:", utils.VerifySSLHostnames, 10)
 	rc, url, err := ds.Fetch("streams/v1/tools_metadata.json")
 	c.Assert(err, jc.ErrorIsNil)
 	defer rc.Close()
@@ -37,7 +37,7 @@ func (s *datasourceSuite) TestFetch(c *gc.C) {
 }
 
 func (s *datasourceSuite) TestURL(c *gc.C) {
-	ds := simplestreams.NewURLDataSource("test", "foo", utils.VerifySSLHostnames)
+	ds := simplestreams.NewURLDataSource("test", "foo", utils.VerifySSLHostnames, 10)
 	url, err := ds.URL("bar")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(url, gc.Equals, "foo/bar")
@@ -65,7 +65,7 @@ func (s *datasourceHTTPSSuite) TearDownTest(c *gc.C) {
 }
 
 func (s *datasourceHTTPSSuite) TestNormalClientFails(c *gc.C) {
-	ds := simplestreams.NewURLDataSource("test", s.Server.URL, utils.VerifySSLHostnames)
+	ds := simplestreams.NewURLDataSource("test", s.Server.URL, utils.VerifySSLHostnames, 10)
 	url, err := ds.URL("bar")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(url, gc.Equals, s.Server.URL+"/bar")
@@ -77,7 +77,7 @@ func (s *datasourceHTTPSSuite) TestNormalClientFails(c *gc.C) {
 }
 
 func (s *datasourceHTTPSSuite) TestNonVerifyingClientSucceeds(c *gc.C) {
-	ds := simplestreams.NewURLDataSource("test", s.Server.URL, utils.NoVerifySSLHostnames)
+	ds := simplestreams.NewURLDataSource("test", s.Server.URL, utils.NoVerifySSLHostnames, 10)
 	url, err := ds.URL("bar")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(url, gc.Equals, s.Server.URL+"/bar")

--- a/environs/simplestreams/simplestreams.go
+++ b/environs/simplestreams/simplestreams.go
@@ -518,7 +518,7 @@ func GetIndexWithFormat(source DataSource, indexPath, indexFormat, mirrorsPath s
 			source, mirrors, params.DataType, params.MirrorContentId, cloudSpec, requireSigned, params.PublicKey)
 		if err == nil {
 			logger.Debugf("using mirrored products path: %s", path.Join(mirrorInfo.MirrorURL, mirrorInfo.Path))
-			indexRef.Source = NewURLDataSource("mirror", mirrorInfo.MirrorURL, utils.VerifySSLHostnames)
+			indexRef.Source = NewURLDataSource("mirror", mirrorInfo.MirrorURL, utils.VerifySSLHostnames, source.Priority())
 			indexRef.MirroredProductsPath = mirrorInfo.Path
 		} else {
 			logger.Tracef("no mirror information available for %s: %v", cloudSpec, err)

--- a/environs/simplestreams/simplestreams_test.go
+++ b/environs/simplestreams/simplestreams_test.go
@@ -26,7 +26,7 @@ func Test(t *testing.T) {
 func registerSimpleStreamsTests() {
 	gc.Suite(&simplestreamsSuite{
 		LocalLiveSimplestreamsSuite: sstesting.LocalLiveSimplestreamsSuite{
-			Source:         simplestreams.NewURLDataSource("test", "test:", utils.VerifySSLHostnames, 10),
+			Source:         simplestreams.NewURLDataSource("test", "test:", utils.VerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA),
 			RequireSigned:  false,
 			DataType:       "image-ids",
 			StreamsVersion: "v1",
@@ -330,7 +330,7 @@ func (s *countingSource) URL(path string) (string, error) {
 func (s *simplestreamsSuite) TestGetMetadataNoMatching(c *gc.C) {
 	source := &countingSource{
 		DataSource: simplestreams.NewURLDataSource(
-			"test", "test:/daily", utils.VerifySSLHostnames, 10,
+			"test", "test:/daily", utils.VerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA,
 		),
 	}
 	sources := []simplestreams.DataSource{source, source, source}

--- a/environs/simplestreams/simplestreams_test.go
+++ b/environs/simplestreams/simplestreams_test.go
@@ -26,7 +26,7 @@ func Test(t *testing.T) {
 func registerSimpleStreamsTests() {
 	gc.Suite(&simplestreamsSuite{
 		LocalLiveSimplestreamsSuite: sstesting.LocalLiveSimplestreamsSuite{
-			Source:         simplestreams.NewURLDataSource("test", "test:", utils.VerifySSLHostnames),
+			Source:         simplestreams.NewURLDataSource("test", "test:", utils.VerifySSLHostnames, 10),
 			RequireSigned:  false,
 			DataType:       "image-ids",
 			StreamsVersion: "v1",
@@ -330,7 +330,7 @@ func (s *countingSource) URL(path string) (string, error) {
 func (s *simplestreamsSuite) TestGetMetadataNoMatching(c *gc.C) {
 	source := &countingSource{
 		DataSource: simplestreams.NewURLDataSource(
-			"test", "test:/daily", utils.VerifySSLHostnames,
+			"test", "test:/daily", utils.VerifySSLHostnames, 10,
 		),
 	}
 	sources := []simplestreams.DataSource{source, source, source}

--- a/environs/storage/storage.go
+++ b/environs/storage/storage.go
@@ -77,6 +77,7 @@ type storageSimpleStreamsDataSource struct {
 	basePath    string
 	storage     StorageReader
 	allowRetry  bool
+	priority    int
 }
 
 // TestingGetAllowRetry is used in tests which need to see if allowRetry has been
@@ -89,8 +90,8 @@ func TestingGetAllowRetry(s simplestreams.DataSource) (bool, ok bool) {
 }
 
 // NewStorageSimpleStreamsDataSource returns a new datasource reading from the specified storage.
-func NewStorageSimpleStreamsDataSource(description string, storage StorageReader, basePath string) simplestreams.DataSource {
-	return &storageSimpleStreamsDataSource{description, basePath, storage, false}
+func NewStorageSimpleStreamsDataSource(description string, storage StorageReader, basePath string, priority int) simplestreams.DataSource {
+	return &storageSimpleStreamsDataSource{description, basePath, storage, false, priority}
 }
 
 func (s *storageSimpleStreamsDataSource) relpath(storagePath string) string {
@@ -133,4 +134,9 @@ func (s *storageSimpleStreamsDataSource) URL(path string) (string, error) {
 // SetAllowRetry is defined in simplestreams.DataSource.
 func (s *storageSimpleStreamsDataSource) SetAllowRetry(allow bool) {
 	s.allowRetry = allow
+}
+
+// Priority is defined in simplestreams.DataSource.
+func (s *storageSimpleStreamsDataSource) Priority() int {
+	return s.priority
 }

--- a/environs/storage/storage_test.go
+++ b/environs/storage/storage_test.go
@@ -15,6 +15,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/environs/filestorage"
+	"github.com/juju/juju/environs/simplestreams"
 	"github.com/juju/juju/environs/storage"
 	"github.com/juju/juju/testing"
 )
@@ -45,7 +46,7 @@ func (s *datasourceSuite) SetUpTest(c *gc.C) {
 func (s *datasourceSuite) TestFetch(c *gc.C) {
 	sampleData := "hello world"
 	s.stor.Put("foo/bar/data.txt", bytes.NewReader([]byte(sampleData)), int64(len(sampleData)))
-	ds := storage.NewStorageSimpleStreamsDataSource("test datasource", s.stor, "", 10)
+	ds := storage.NewStorageSimpleStreamsDataSource("test datasource", s.stor, "", simplestreams.DEFAULT_CLOUD_DATA)
 	rc, url, err := ds.Fetch("foo/bar/data.txt")
 	c.Assert(err, jc.ErrorIsNil)
 	defer rc.Close()
@@ -57,7 +58,7 @@ func (s *datasourceSuite) TestFetch(c *gc.C) {
 func (s *datasourceSuite) TestFetchWithBasePath(c *gc.C) {
 	sampleData := "hello world"
 	s.stor.Put("base/foo/bar/data.txt", bytes.NewReader([]byte(sampleData)), int64(len(sampleData)))
-	ds := storage.NewStorageSimpleStreamsDataSource("test datasource", s.stor, "base", 10)
+	ds := storage.NewStorageSimpleStreamsDataSource("test datasource", s.stor, "base", simplestreams.DEFAULT_CLOUD_DATA)
 	rc, url, err := ds.Fetch("foo/bar/data.txt")
 	c.Assert(err, jc.ErrorIsNil)
 	defer rc.Close()
@@ -68,7 +69,7 @@ func (s *datasourceSuite) TestFetchWithBasePath(c *gc.C) {
 
 func (s *datasourceSuite) TestFetchWithRetry(c *gc.C) {
 	stor := &fakeStorage{shouldRetry: true}
-	ds := storage.NewStorageSimpleStreamsDataSource("test datasource", stor, "base", 10)
+	ds := storage.NewStorageSimpleStreamsDataSource("test datasource", stor, "base", simplestreams.DEFAULT_CLOUD_DATA)
 	ds.SetAllowRetry(true)
 	_, _, err := ds.Fetch("foo/bar/data.txt")
 	c.Assert(err, gc.ErrorMatches, "an error")
@@ -80,7 +81,7 @@ func (s *datasourceSuite) TestFetchWithNoRetry(c *gc.C) {
 	// NB shouldRetry below is true indicating the fake storage is capable of
 	// retrying, not that it will retry.
 	stor := &fakeStorage{shouldRetry: true}
-	ds := storage.NewStorageSimpleStreamsDataSource("test datasource", stor, "base", 10)
+	ds := storage.NewStorageSimpleStreamsDataSource("test datasource", stor, "base", simplestreams.DEFAULT_CLOUD_DATA)
 	_, _, err := ds.Fetch("foo/bar/data.txt")
 	c.Assert(err, gc.ErrorMatches, "an error")
 	c.Assert(stor.getName, gc.Equals, "base/foo/bar/data.txt")
@@ -90,7 +91,7 @@ func (s *datasourceSuite) TestFetchWithNoRetry(c *gc.C) {
 func (s *datasourceSuite) TestURL(c *gc.C) {
 	sampleData := "hello world"
 	s.stor.Put("bar/data.txt", bytes.NewReader([]byte(sampleData)), int64(len(sampleData)))
-	ds := storage.NewStorageSimpleStreamsDataSource("test datasource", s.stor, "", 10)
+	ds := storage.NewStorageSimpleStreamsDataSource("test datasource", s.stor, "", simplestreams.DEFAULT_CLOUD_DATA)
 	url, err := ds.URL("bar")
 	c.Assert(err, jc.ErrorIsNil)
 	expectedURL, _ := s.stor.URL("bar")
@@ -100,7 +101,7 @@ func (s *datasourceSuite) TestURL(c *gc.C) {
 func (s *datasourceSuite) TestURLWithBasePath(c *gc.C) {
 	sampleData := "hello world"
 	s.stor.Put("base/bar/data.txt", bytes.NewReader([]byte(sampleData)), int64(len(sampleData)))
-	ds := storage.NewStorageSimpleStreamsDataSource("test datasource", s.stor, "base", 10)
+	ds := storage.NewStorageSimpleStreamsDataSource("test datasource", s.stor, "base", simplestreams.DEFAULT_CLOUD_DATA)
 	url, err := ds.URL("bar")
 	c.Assert(err, jc.ErrorIsNil)
 	expectedURL, _ := s.stor.URL("base/bar")

--- a/environs/storage/storage_test.go
+++ b/environs/storage/storage_test.go
@@ -45,7 +45,7 @@ func (s *datasourceSuite) SetUpTest(c *gc.C) {
 func (s *datasourceSuite) TestFetch(c *gc.C) {
 	sampleData := "hello world"
 	s.stor.Put("foo/bar/data.txt", bytes.NewReader([]byte(sampleData)), int64(len(sampleData)))
-	ds := storage.NewStorageSimpleStreamsDataSource("test datasource", s.stor, "")
+	ds := storage.NewStorageSimpleStreamsDataSource("test datasource", s.stor, "", 10)
 	rc, url, err := ds.Fetch("foo/bar/data.txt")
 	c.Assert(err, jc.ErrorIsNil)
 	defer rc.Close()
@@ -57,7 +57,7 @@ func (s *datasourceSuite) TestFetch(c *gc.C) {
 func (s *datasourceSuite) TestFetchWithBasePath(c *gc.C) {
 	sampleData := "hello world"
 	s.stor.Put("base/foo/bar/data.txt", bytes.NewReader([]byte(sampleData)), int64(len(sampleData)))
-	ds := storage.NewStorageSimpleStreamsDataSource("test datasource", s.stor, "base")
+	ds := storage.NewStorageSimpleStreamsDataSource("test datasource", s.stor, "base", 10)
 	rc, url, err := ds.Fetch("foo/bar/data.txt")
 	c.Assert(err, jc.ErrorIsNil)
 	defer rc.Close()
@@ -68,7 +68,7 @@ func (s *datasourceSuite) TestFetchWithBasePath(c *gc.C) {
 
 func (s *datasourceSuite) TestFetchWithRetry(c *gc.C) {
 	stor := &fakeStorage{shouldRetry: true}
-	ds := storage.NewStorageSimpleStreamsDataSource("test datasource", stor, "base")
+	ds := storage.NewStorageSimpleStreamsDataSource("test datasource", stor, "base", 10)
 	ds.SetAllowRetry(true)
 	_, _, err := ds.Fetch("foo/bar/data.txt")
 	c.Assert(err, gc.ErrorMatches, "an error")
@@ -80,7 +80,7 @@ func (s *datasourceSuite) TestFetchWithNoRetry(c *gc.C) {
 	// NB shouldRetry below is true indicating the fake storage is capable of
 	// retrying, not that it will retry.
 	stor := &fakeStorage{shouldRetry: true}
-	ds := storage.NewStorageSimpleStreamsDataSource("test datasource", stor, "base")
+	ds := storage.NewStorageSimpleStreamsDataSource("test datasource", stor, "base", 10)
 	_, _, err := ds.Fetch("foo/bar/data.txt")
 	c.Assert(err, gc.ErrorMatches, "an error")
 	c.Assert(stor.getName, gc.Equals, "base/foo/bar/data.txt")
@@ -90,7 +90,7 @@ func (s *datasourceSuite) TestFetchWithNoRetry(c *gc.C) {
 func (s *datasourceSuite) TestURL(c *gc.C) {
 	sampleData := "hello world"
 	s.stor.Put("bar/data.txt", bytes.NewReader([]byte(sampleData)), int64(len(sampleData)))
-	ds := storage.NewStorageSimpleStreamsDataSource("test datasource", s.stor, "")
+	ds := storage.NewStorageSimpleStreamsDataSource("test datasource", s.stor, "", 10)
 	url, err := ds.URL("bar")
 	c.Assert(err, jc.ErrorIsNil)
 	expectedURL, _ := s.stor.URL("bar")
@@ -100,7 +100,7 @@ func (s *datasourceSuite) TestURL(c *gc.C) {
 func (s *datasourceSuite) TestURLWithBasePath(c *gc.C) {
 	sampleData := "hello world"
 	s.stor.Put("base/bar/data.txt", bytes.NewReader([]byte(sampleData)), int64(len(sampleData)))
-	ds := storage.NewStorageSimpleStreamsDataSource("test datasource", s.stor, "base")
+	ds := storage.NewStorageSimpleStreamsDataSource("test datasource", s.stor, "base", 10)
 	url, err := ds.URL("bar")
 	c.Assert(err, jc.ErrorIsNil)
 	expectedURL, _ := s.stor.URL("base/bar")

--- a/environs/sync/sync.go
+++ b/environs/sync/sync.go
@@ -159,7 +159,7 @@ func selectSourceDatasource(syncContext *SyncContext) (simplestreams.DataSource,
 		return nil, err
 	}
 	logger.Infof("using sync tools source: %v", sourceURL)
-	return simplestreams.NewURLDataSource("sync tools source", sourceURL, utils.VerifySSLHostnames, 30), nil
+	return simplestreams.NewURLDataSource("sync tools source", sourceURL, utils.VerifySSLHostnames, simplestreams.CUSTOM_CLOUD_DATA), nil
 }
 
 // copyTools copies a set of tools from the source to the target.

--- a/environs/sync/sync.go
+++ b/environs/sync/sync.go
@@ -159,7 +159,7 @@ func selectSourceDatasource(syncContext *SyncContext) (simplestreams.DataSource,
 		return nil, err
 	}
 	logger.Infof("using sync tools source: %v", sourceURL)
-	return simplestreams.NewURLDataSource("sync tools source", sourceURL, utils.VerifySSLHostnames), nil
+	return simplestreams.NewURLDataSource("sync tools source", sourceURL, utils.VerifySSLHostnames, 30), nil
 }
 
 // copyTools copies a set of tools from the source to the target.

--- a/environs/tools/simplestreams.go
+++ b/environs/tools/simplestreams.go
@@ -409,7 +409,7 @@ func MergeMetadata(tmlist1, tmlist2 []*ToolsMetadata) ([]*ToolsMetadata, error) 
 
 // ReadMetadata returns the tools metadata from the given storage for the specified stream.
 func ReadMetadata(store storage.StorageReader, stream string) ([]*ToolsMetadata, error) {
-	dataSource := storage.NewStorageSimpleStreamsDataSource("existing metadata", store, storage.BaseToolsPath, 30)
+	dataSource := storage.NewStorageSimpleStreamsDataSource("existing metadata", store, storage.BaseToolsPath, simplestreams.EXISTING_CLOUD_DATA)
 	toolsConstraint, err := makeToolsConstraint(simplestreams.CloudSpec{}, stream, -1, -1, coretools.Filter{})
 	if err != nil {
 		return nil, err

--- a/environs/tools/simplestreams.go
+++ b/environs/tools/simplestreams.go
@@ -409,7 +409,7 @@ func MergeMetadata(tmlist1, tmlist2 []*ToolsMetadata) ([]*ToolsMetadata, error) 
 
 // ReadMetadata returns the tools metadata from the given storage for the specified stream.
 func ReadMetadata(store storage.StorageReader, stream string) ([]*ToolsMetadata, error) {
-	dataSource := storage.NewStorageSimpleStreamsDataSource("existing metadata", store, storage.BaseToolsPath)
+	dataSource := storage.NewStorageSimpleStreamsDataSource("existing metadata", store, storage.BaseToolsPath, 30)
 	toolsConstraint, err := makeToolsConstraint(simplestreams.CloudSpec{}, stream, -1, -1, coretools.Filter{})
 	if err != nil {
 		return nil, err

--- a/environs/tools/simplestreams_test.go
+++ b/environs/tools/simplestreams_test.go
@@ -83,7 +83,7 @@ func setupSimpleStreamsTests(t *testing.T) {
 func registerSimpleStreamsTests() {
 	gc.Suite(&simplestreamsSuite{
 		LocalLiveSimplestreamsSuite: sstesting.LocalLiveSimplestreamsSuite{
-			Source:         simplestreams.NewURLDataSource("test", "test:", utils.VerifySSLHostnames),
+			Source:         simplestreams.NewURLDataSource("test", "test:", utils.VerifySSLHostnames, 10),
 			RequireSigned:  false,
 			DataType:       tools.ContentDownload,
 			StreamsVersion: tools.CurrentStreamsVersion,
@@ -103,7 +103,7 @@ func registerSimpleStreamsTests() {
 
 func registerLiveSimpleStreamsTests(baseURL string, validToolsConstraint simplestreams.LookupConstraint, requireSigned bool) {
 	gc.Suite(&sstesting.LocalLiveSimplestreamsSuite{
-		Source:          simplestreams.NewURLDataSource("test", baseURL, utils.VerifySSLHostnames),
+		Source:          simplestreams.NewURLDataSource("test", baseURL, utils.VerifySSLHostnames, 10),
 		RequireSigned:   requireSigned,
 		DataType:        tools.ContentDownload,
 		StreamsVersion:  tools.CurrentStreamsVersion,
@@ -262,7 +262,7 @@ func (s *simplestreamsSuite) TestFetch(c *gc.C) {
 				})
 		}
 		// Add invalid datasource and check later that resolveInfo is correct.
-		invalidSource := simplestreams.NewURLDataSource("invalid", "file://invalid", utils.VerifySSLHostnames)
+		invalidSource := simplestreams.NewURLDataSource("invalid", "file://invalid", utils.VerifySSLHostnames, 10)
 		tools, resolveInfo, err := tools.Fetch(
 			[]simplestreams.DataSource{invalidSource, s.Source}, toolsConstraint, s.RequireSigned)
 		if !c.Check(err, jc.ErrorIsNil) {
@@ -1065,7 +1065,7 @@ func (s *signedSuite) TearDownSuite(c *gc.C) {
 }
 
 func (s *signedSuite) TestSignedToolsMetadata(c *gc.C) {
-	signedSource := simplestreams.NewURLDataSource("test", "signedtest://host/signed", utils.VerifySSLHostnames)
+	signedSource := simplestreams.NewURLDataSource("test", "signedtest://host/signed", utils.VerifySSLHostnames, 10)
 	toolsConstraint := tools.NewVersionedToolsConstraint(version.MustParse("1.13.0"), simplestreams.LookupParams{
 		CloudSpec: simplestreams.CloudSpec{"us-east-1", "https://ec2.us-east-1.amazonaws.com"},
 		Series:    []string{"precise"},

--- a/environs/tools/simplestreams_test.go
+++ b/environs/tools/simplestreams_test.go
@@ -83,7 +83,7 @@ func setupSimpleStreamsTests(t *testing.T) {
 func registerSimpleStreamsTests() {
 	gc.Suite(&simplestreamsSuite{
 		LocalLiveSimplestreamsSuite: sstesting.LocalLiveSimplestreamsSuite{
-			Source:         simplestreams.NewURLDataSource("test", "test:", utils.VerifySSLHostnames, 10),
+			Source:         simplestreams.NewURLDataSource("test", "test:", utils.VerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA),
 			RequireSigned:  false,
 			DataType:       tools.ContentDownload,
 			StreamsVersion: tools.CurrentStreamsVersion,
@@ -103,7 +103,7 @@ func registerSimpleStreamsTests() {
 
 func registerLiveSimpleStreamsTests(baseURL string, validToolsConstraint simplestreams.LookupConstraint, requireSigned bool) {
 	gc.Suite(&sstesting.LocalLiveSimplestreamsSuite{
-		Source:          simplestreams.NewURLDataSource("test", baseURL, utils.VerifySSLHostnames, 10),
+		Source:          simplestreams.NewURLDataSource("test", baseURL, utils.VerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA),
 		RequireSigned:   requireSigned,
 		DataType:        tools.ContentDownload,
 		StreamsVersion:  tools.CurrentStreamsVersion,
@@ -262,7 +262,7 @@ func (s *simplestreamsSuite) TestFetch(c *gc.C) {
 				})
 		}
 		// Add invalid datasource and check later that resolveInfo is correct.
-		invalidSource := simplestreams.NewURLDataSource("invalid", "file://invalid", utils.VerifySSLHostnames, 10)
+		invalidSource := simplestreams.NewURLDataSource("invalid", "file://invalid", utils.VerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA)
 		tools, resolveInfo, err := tools.Fetch(
 			[]simplestreams.DataSource{invalidSource, s.Source}, toolsConstraint, s.RequireSigned)
 		if !c.Check(err, jc.ErrorIsNil) {
@@ -1065,7 +1065,7 @@ func (s *signedSuite) TearDownSuite(c *gc.C) {
 }
 
 func (s *signedSuite) TestSignedToolsMetadata(c *gc.C) {
-	signedSource := simplestreams.NewURLDataSource("test", "signedtest://host/signed", utils.VerifySSLHostnames, 10)
+	signedSource := simplestreams.NewURLDataSource("test", "signedtest://host/signed", utils.VerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA)
 	toolsConstraint := tools.NewVersionedToolsConstraint(version.MustParse("1.13.0"), simplestreams.LookupParams{
 		CloudSpec: simplestreams.CloudSpec{"us-east-1", "https://ec2.us-east-1.amazonaws.com"},
 		Series:    []string{"precise"},

--- a/environs/tools/testing/testing.go
+++ b/environs/tools/testing/testing.go
@@ -130,7 +130,7 @@ func ParseMetadataFromDir(c *gc.C, metadataDir, stream string, expectMirrors boo
 
 // ParseMetadataFromStorage loads ToolsMetadata from the specified storage reader.
 func ParseMetadataFromStorage(c *gc.C, stor storage.StorageReader, stream string, expectMirrors bool) []*tools.ToolsMetadata {
-	source := storage.NewStorageSimpleStreamsDataSource("test storage reader", stor, "tools", 100)
+	source := storage.NewStorageSimpleStreamsDataSource("test storage reader", stor, "tools", simplestreams.CUSTOM_CLOUD_DATA)
 	params := simplestreams.ValueParams{
 		DataType:      tools.ContentDownload,
 		ValueTemplate: tools.ToolsMetadata{},

--- a/environs/tools/testing/testing.go
+++ b/environs/tools/testing/testing.go
@@ -130,7 +130,7 @@ func ParseMetadataFromDir(c *gc.C, metadataDir, stream string, expectMirrors boo
 
 // ParseMetadataFromStorage loads ToolsMetadata from the specified storage reader.
 func ParseMetadataFromStorage(c *gc.C, stor storage.StorageReader, stream string, expectMirrors bool) []*tools.ToolsMetadata {
-	source := storage.NewStorageSimpleStreamsDataSource("test storage reader", stor, "tools")
+	source := storage.NewStorageSimpleStreamsDataSource("test storage reader", stor, "tools", 100)
 	params := simplestreams.ValueParams{
 		DataType:      tools.ContentDownload,
 		ValueTemplate: tools.ToolsMetadata{},

--- a/environs/tools/urls.go
+++ b/environs/tools/urls.go
@@ -76,7 +76,7 @@ func GetMetadataSources(env environs.Environ) ([]simplestreams.DataSource, error
 		if !config.SSLHostnameVerification() {
 			verify = utils.NoVerifySSLHostnames
 		}
-		sources = append(sources, simplestreams.NewURLDataSource(conf.AgentMetadataURLKey, userURL, verify, 20))
+		sources = append(sources, simplestreams.NewURLDataSource(conf.AgentMetadataURLKey, userURL, verify, simplestreams.SPECIFIC_CLOUD_DATA))
 	}
 
 	envDataSources, err := environmentDataSources(env)
@@ -92,7 +92,7 @@ func GetMetadataSources(env environs.Environ) ([]simplestreams.DataSource, error
 	}
 	if defaultURL != "" {
 		sources = append(sources,
-			simplestreams.NewURLDataSource("default simplestreams", defaultURL, utils.VerifySSLHostnames, 10))
+			simplestreams.NewURLDataSource("default simplestreams", defaultURL, utils.VerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA))
 	}
 	return sources, nil
 }

--- a/environs/tools/urls.go
+++ b/environs/tools/urls.go
@@ -76,7 +76,7 @@ func GetMetadataSources(env environs.Environ) ([]simplestreams.DataSource, error
 		if !config.SSLHostnameVerification() {
 			verify = utils.NoVerifySSLHostnames
 		}
-		sources = append(sources, simplestreams.NewURLDataSource(conf.AgentMetadataURLKey, userURL, verify))
+		sources = append(sources, simplestreams.NewURLDataSource(conf.AgentMetadataURLKey, userURL, verify, 20))
 	}
 
 	envDataSources, err := environmentDataSources(env)
@@ -92,7 +92,7 @@ func GetMetadataSources(env environs.Environ) ([]simplestreams.DataSource, error
 	}
 	if defaultURL != "" {
 		sources = append(sources,
-			simplestreams.NewURLDataSource("default simplestreams", defaultURL, utils.VerifySSLHostnames))
+			simplestreams.NewURLDataSource("default simplestreams", defaultURL, utils.VerifySSLHostnames, 10))
 	}
 	return sources, nil
 }

--- a/environs/tools/urls_test.go
+++ b/environs/tools/urls_test.go
@@ -67,10 +67,10 @@ func (s *URLsSuite) TestToolsSources(c *gc.C) {
 
 func (s *URLsSuite) TestToolsMetadataURLsRegisteredFuncs(c *gc.C) {
 	tools.RegisterToolsDataSourceFunc("id0", func(environs.Environ) (simplestreams.DataSource, error) {
-		return simplestreams.NewURLDataSource("id0", "betwixt/releases", utils.NoVerifySSLHostnames), nil
+		return simplestreams.NewURLDataSource("id0", "betwixt/releases", utils.NoVerifySSLHostnames, 10), nil
 	})
 	tools.RegisterToolsDataSourceFunc("id1", func(environs.Environ) (simplestreams.DataSource, error) {
-		return simplestreams.NewURLDataSource("id1", "yoink", utils.NoVerifySSLHostnames), nil
+		return simplestreams.NewURLDataSource("id1", "yoink", utils.NoVerifySSLHostnames, 20), nil
 	})
 	// overwrite the one previously registered against id1
 	tools.RegisterToolsDataSourceFunc("id1", func(environs.Environ) (simplestreams.DataSource, error) {

--- a/environs/tools/urls_test.go
+++ b/environs/tools/urls_test.go
@@ -67,10 +67,10 @@ func (s *URLsSuite) TestToolsSources(c *gc.C) {
 
 func (s *URLsSuite) TestToolsMetadataURLsRegisteredFuncs(c *gc.C) {
 	tools.RegisterToolsDataSourceFunc("id0", func(environs.Environ) (simplestreams.DataSource, error) {
-		return simplestreams.NewURLDataSource("id0", "betwixt/releases", utils.NoVerifySSLHostnames, 10), nil
+		return simplestreams.NewURLDataSource("id0", "betwixt/releases", utils.NoVerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA), nil
 	})
 	tools.RegisterToolsDataSourceFunc("id1", func(environs.Environ) (simplestreams.DataSource, error) {
-		return simplestreams.NewURLDataSource("id1", "yoink", utils.NoVerifySSLHostnames, 20), nil
+		return simplestreams.NewURLDataSource("id1", "yoink", utils.NoVerifySSLHostnames, simplestreams.SPECIFIC_CLOUD_DATA), nil
 	})
 	// overwrite the one previously registered against id1
 	tools.RegisterToolsDataSourceFunc("id1", func(environs.Environ) (simplestreams.DataSource, error) {

--- a/environs/tools/validation_test.go
+++ b/environs/tools/validation_test.go
@@ -63,7 +63,7 @@ func (s *ValidateSuite) TestExactVersionMatch(c *gc.C) {
 			Endpoint:      "some-auth-url",
 			Stream:        "released",
 			Sources: []simplestreams.DataSource{
-				simplestreams.NewURLDataSource("test", s.toolsURL(), utils.VerifySSLHostnames, 10)},
+				simplestreams.NewURLDataSource("test", s.toolsURL(), utils.VerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA)},
 		},
 	}
 	versions, resolveInfo, err := ValidateToolsMetadata(params)
@@ -89,7 +89,7 @@ func (s *ValidateSuite) TestMajorVersionMatch(c *gc.C) {
 			Endpoint:      "some-auth-url",
 			Stream:        "released",
 			Sources: []simplestreams.DataSource{
-				simplestreams.NewURLDataSource("test", s.toolsURL(), utils.VerifySSLHostnames, 10)},
+				simplestreams.NewURLDataSource("test", s.toolsURL(), utils.VerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA)},
 		},
 	}
 	versions, resolveInfo, err := ValidateToolsMetadata(params)
@@ -115,7 +115,7 @@ func (s *ValidateSuite) TestMajorMinorVersionMatch(c *gc.C) {
 			Endpoint:      "some-auth-url",
 			Stream:        "released",
 			Sources: []simplestreams.DataSource{
-				simplestreams.NewURLDataSource("test", s.toolsURL(), utils.VerifySSLHostnames, 10)},
+				simplestreams.NewURLDataSource("test", s.toolsURL(), utils.VerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA)},
 		},
 	}
 	versions, resolveInfo, err := ValidateToolsMetadata(params)
@@ -140,7 +140,7 @@ func (s *ValidateSuite) TestNoMatch(c *gc.C) {
 			Endpoint:      "some-auth-url",
 			Stream:        "released",
 			Sources: []simplestreams.DataSource{
-				simplestreams.NewURLDataSource("test", s.toolsURL(), utils.VerifySSLHostnames, 10)},
+				simplestreams.NewURLDataSource("test", s.toolsURL(), utils.VerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA)},
 		},
 	}
 	_, _, err := ValidateToolsMetadata(params)
@@ -158,7 +158,7 @@ func (s *ValidateSuite) TestStreamsNoMatch(c *gc.C) {
 			Endpoint:      "some-auth-url",
 			Stream:        "testing",
 			Sources: []simplestreams.DataSource{
-				simplestreams.NewURLDataSource("test", s.toolsURL(), utils.VerifySSLHostnames, 10)},
+				simplestreams.NewURLDataSource("test", s.toolsURL(), utils.VerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA)},
 		},
 	}
 	_, _, err := ValidateToolsMetadata(params)

--- a/environs/tools/validation_test.go
+++ b/environs/tools/validation_test.go
@@ -63,7 +63,7 @@ func (s *ValidateSuite) TestExactVersionMatch(c *gc.C) {
 			Endpoint:      "some-auth-url",
 			Stream:        "released",
 			Sources: []simplestreams.DataSource{
-				simplestreams.NewURLDataSource("test", s.toolsURL(), utils.VerifySSLHostnames)},
+				simplestreams.NewURLDataSource("test", s.toolsURL(), utils.VerifySSLHostnames, 10)},
 		},
 	}
 	versions, resolveInfo, err := ValidateToolsMetadata(params)
@@ -89,7 +89,7 @@ func (s *ValidateSuite) TestMajorVersionMatch(c *gc.C) {
 			Endpoint:      "some-auth-url",
 			Stream:        "released",
 			Sources: []simplestreams.DataSource{
-				simplestreams.NewURLDataSource("test", s.toolsURL(), utils.VerifySSLHostnames)},
+				simplestreams.NewURLDataSource("test", s.toolsURL(), utils.VerifySSLHostnames, 10)},
 		},
 	}
 	versions, resolveInfo, err := ValidateToolsMetadata(params)
@@ -115,7 +115,7 @@ func (s *ValidateSuite) TestMajorMinorVersionMatch(c *gc.C) {
 			Endpoint:      "some-auth-url",
 			Stream:        "released",
 			Sources: []simplestreams.DataSource{
-				simplestreams.NewURLDataSource("test", s.toolsURL(), utils.VerifySSLHostnames)},
+				simplestreams.NewURLDataSource("test", s.toolsURL(), utils.VerifySSLHostnames, 10)},
 		},
 	}
 	versions, resolveInfo, err := ValidateToolsMetadata(params)
@@ -140,7 +140,7 @@ func (s *ValidateSuite) TestNoMatch(c *gc.C) {
 			Endpoint:      "some-auth-url",
 			Stream:        "released",
 			Sources: []simplestreams.DataSource{
-				simplestreams.NewURLDataSource("test", s.toolsURL(), utils.VerifySSLHostnames)},
+				simplestreams.NewURLDataSource("test", s.toolsURL(), utils.VerifySSLHostnames, 10)},
 		},
 	}
 	_, _, err := ValidateToolsMetadata(params)
@@ -158,7 +158,7 @@ func (s *ValidateSuite) TestStreamsNoMatch(c *gc.C) {
 			Endpoint:      "some-auth-url",
 			Stream:        "testing",
 			Sources: []simplestreams.DataSource{
-				simplestreams.NewURLDataSource("test", s.toolsURL(), utils.VerifySSLHostnames)},
+				simplestreams.NewURLDataSource("test", s.toolsURL(), utils.VerifySSLHostnames, 10)},
 		},
 	}
 	_, _, err := ValidateToolsMetadata(params)

--- a/provider/cloudsigma/provider.go
+++ b/provider/cloudsigma/provider.go
@@ -29,7 +29,7 @@ func getImageSource(env environs.Environ) (simplestreams.DataSource, error) {
 	if !ok {
 		return nil, errors.NotSupportedf("non-cloudsigma environment")
 	}
-	return simplestreams.NewURLDataSource("cloud images", fmt.Sprintf(CloudsigmaCloudImagesURLTemplate, e.ecfg.region()), utils.VerifySSLHostnames, 30), nil
+	return simplestreams.NewURLDataSource("cloud images", fmt.Sprintf(CloudsigmaCloudImagesURLTemplate, e.ecfg.region()), utils.VerifySSLHostnames, simplestreams.SPECIFIC_CLOUD_DATA), nil
 }
 
 type environProvider struct{}

--- a/provider/cloudsigma/provider.go
+++ b/provider/cloudsigma/provider.go
@@ -29,7 +29,7 @@ func getImageSource(env environs.Environ) (simplestreams.DataSource, error) {
 	if !ok {
 		return nil, errors.NotSupportedf("non-cloudsigma environment")
 	}
-	return simplestreams.NewURLDataSource("cloud images", fmt.Sprintf(CloudsigmaCloudImagesURLTemplate, e.ecfg.region()), utils.VerifySSLHostnames), nil
+	return simplestreams.NewURLDataSource("cloud images", fmt.Sprintf(CloudsigmaCloudImagesURLTemplate, e.ecfg.region()), utils.VerifySSLHostnames, 30), nil
 }
 
 type environProvider struct{}

--- a/provider/common/mock_test.go
+++ b/provider/common/mock_test.go
@@ -84,7 +84,7 @@ func (env *mockEnviron) GetToolsSources() ([]simplestreams.DataSource, error) {
 	if env.getToolsSources != nil {
 		return env.getToolsSources()
 	}
-	datasource := storage.NewStorageSimpleStreamsDataSource("test cloud storage", env.Storage(), storage.BaseToolsPath)
+	datasource := storage.NewStorageSimpleStreamsDataSource("test cloud storage", env.Storage(), storage.BaseToolsPath, 20)
 	return []simplestreams.DataSource{datasource}, nil
 }
 

--- a/provider/common/mock_test.go
+++ b/provider/common/mock_test.go
@@ -84,7 +84,7 @@ func (env *mockEnviron) GetToolsSources() ([]simplestreams.DataSource, error) {
 	if env.getToolsSources != nil {
 		return env.getToolsSources()
 	}
-	datasource := storage.NewStorageSimpleStreamsDataSource("test cloud storage", env.Storage(), storage.BaseToolsPath, 20)
+	datasource := storage.NewStorageSimpleStreamsDataSource("test cloud storage", env.Storage(), storage.BaseToolsPath, simplestreams.SPECIFIC_CLOUD_DATA)
 	return []simplestreams.DataSource{datasource}, nil
 }
 

--- a/provider/common/supportedarchitectures_test.go
+++ b/provider/common/supportedarchitectures_test.go
@@ -56,7 +56,7 @@ func (s *archSuite) setupMetadata(c *gc.C, arches []string) (environs.Environ, s
 
 	id := "SupportedArchitectures"
 	environs.RegisterImageDataSourceFunc(id, func(environs.Environ) (simplestreams.DataSource, error) {
-		return simplestreams.NewURLDataSource(id, "file://"+metadataDir+"/images", false), nil
+		return simplestreams.NewURLDataSource(id, "file://"+metadataDir+"/images", false, 40), nil
 	})
 	s.AddCleanup(func(*gc.C) {
 		environs.UnregisterImageDataSourceFunc(id)

--- a/provider/common/supportedarchitectures_test.go
+++ b/provider/common/supportedarchitectures_test.go
@@ -56,7 +56,7 @@ func (s *archSuite) setupMetadata(c *gc.C, arches []string) (environs.Environ, s
 
 	id := "SupportedArchitectures"
 	environs.RegisterImageDataSourceFunc(id, func(environs.Environ) (simplestreams.DataSource, error) {
-		return simplestreams.NewURLDataSource(id, "file://"+metadataDir+"/images", false, 40), nil
+		return simplestreams.NewURLDataSource(id, "file://"+metadataDir+"/images", false, simplestreams.DEFAULT_CLOUD_DATA), nil
 	})
 	s.AddCleanup(func(*gc.C) {
 		environs.UnregisterImageDataSourceFunc(id)

--- a/provider/ec2/image_test.go
+++ b/provider/ec2/image_test.go
@@ -164,7 +164,7 @@ func (s *specSuite) TestFindInstanceSpec(c *gc.C) {
 		}
 		spec, err := findInstanceSpec(
 			[]simplestreams.DataSource{
-				simplestreams.NewURLDataSource("test", "test:", utils.VerifySSLHostnames, 10)},
+				simplestreams.NewURLDataSource("test", "test:", utils.VerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA)},
 			"released",
 			&instances.InstanceConstraint{
 				Region:      "test",
@@ -182,7 +182,7 @@ func (s *specSuite) TestFindInstanceSpec(c *gc.C) {
 func (s *specSuite) TestFindInstanceSpecNotSetCpuPowerWhenInstanceTypeSet(c *gc.C) {
 
 	source := []simplestreams.DataSource{
-		simplestreams.NewURLDataSource("test", "test:", utils.VerifySSLHostnames, 10),
+		simplestreams.NewURLDataSource("test", "test:", utils.VerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA),
 	}
 	instanceConstraint := &instances.InstanceConstraint{
 		Region:      "test",
@@ -228,7 +228,7 @@ func (s *specSuite) TestFindInstanceSpecErrors(c *gc.C) {
 		c.Logf("test %d", i)
 		_, err := findInstanceSpec(
 			[]simplestreams.DataSource{
-				simplestreams.NewURLDataSource("test", "test:", utils.VerifySSLHostnames, 10)},
+				simplestreams.NewURLDataSource("test", "test:", utils.VerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA)},
 			"released",
 			&instances.InstanceConstraint{
 				Region:      "test",

--- a/provider/ec2/image_test.go
+++ b/provider/ec2/image_test.go
@@ -164,7 +164,7 @@ func (s *specSuite) TestFindInstanceSpec(c *gc.C) {
 		}
 		spec, err := findInstanceSpec(
 			[]simplestreams.DataSource{
-				simplestreams.NewURLDataSource("test", "test:", utils.VerifySSLHostnames)},
+				simplestreams.NewURLDataSource("test", "test:", utils.VerifySSLHostnames, 10)},
 			"released",
 			&instances.InstanceConstraint{
 				Region:      "test",
@@ -182,7 +182,7 @@ func (s *specSuite) TestFindInstanceSpec(c *gc.C) {
 func (s *specSuite) TestFindInstanceSpecNotSetCpuPowerWhenInstanceTypeSet(c *gc.C) {
 
 	source := []simplestreams.DataSource{
-		simplestreams.NewURLDataSource("test", "test:", utils.VerifySSLHostnames),
+		simplestreams.NewURLDataSource("test", "test:", utils.VerifySSLHostnames, 10),
 	}
 	instanceConstraint := &instances.InstanceConstraint{
 		Region:      "test",
@@ -228,7 +228,7 @@ func (s *specSuite) TestFindInstanceSpecErrors(c *gc.C) {
 		c.Logf("test %d", i)
 		_, err := findInstanceSpec(
 			[]simplestreams.DataSource{
-				simplestreams.NewURLDataSource("test", "test:", utils.VerifySSLHostnames)},
+				simplestreams.NewURLDataSource("test", "test:", utils.VerifySSLHostnames, 10)},
 			"released",
 			&instances.InstanceConstraint{
 				Region:      "test",

--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -1020,7 +1020,7 @@ func (s *localServerSuite) TestValidateImageMetadata(c *gc.C) {
 
 func (s *localServerSuite) TestImageMetadataSourceOrder(c *gc.C) {
 	src := func(env environs.Environ) (simplestreams.DataSource, error) {
-		return simplestreams.NewURLDataSource("my datasource", "bar", false), nil
+		return simplestreams.NewURLDataSource("my datasource", "bar", false, 30), nil
 	}
 	environs.RegisterUserImageDataSourceFunc("my func", src)
 	env := s.Open(c)

--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -1020,7 +1020,7 @@ func (s *localServerSuite) TestValidateImageMetadata(c *gc.C) {
 
 func (s *localServerSuite) TestImageMetadataSourceOrder(c *gc.C) {
 	src := func(env environs.Environ) (simplestreams.DataSource, error) {
-		return simplestreams.NewURLDataSource("my datasource", "bar", false, 30), nil
+		return simplestreams.NewURLDataSource("my datasource", "bar", false, simplestreams.CUSTOM_CLOUD_DATA), nil
 	}
 	environs.RegisterUserImageDataSourceFunc("my func", src)
 	env := s.Open(c)

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -860,7 +860,7 @@ func (e *environ) getKeystoneDataSource(mu *sync.Mutex, datasource *simplestream
 	if !e.Config().SSLHostnameVerification() {
 		verify = utils.NoVerifySSLHostnames
 	}
-	*datasource = simplestreams.NewURLDataSource("keystone catalog", url, verify)
+	*datasource = simplestreams.NewURLDataSource("keystone catalog", url, verify, 30)
 	return *datasource, nil
 }
 

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -860,7 +860,7 @@ func (e *environ) getKeystoneDataSource(mu *sync.Mutex, datasource *simplestream
 	if !e.Config().SSLHostnameVerification() {
 		verify = utils.NoVerifySSLHostnames
 	}
-	*datasource = simplestreams.NewURLDataSource("keystone catalog", url, verify, 30)
+	*datasource = simplestreams.NewURLDataSource("keystone catalog", url, verify, simplestreams.SPECIFIC_CLOUD_DATA)
 	return *datasource, nil
 }
 

--- a/state/cloudimagemetadata/image.go
+++ b/state/cloudimagemetadata/image.go
@@ -128,6 +128,11 @@ type imagesMetadataDoc struct {
 
 	// Source describes where this image is coming from: is it public? custom?
 	Source string `bson:"source"`
+
+	// Priority is an importance factor for image metadata.
+	// Higher number means higher priority.
+	// This will allow to sort metadata by importance.
+	Priority int `bson:"priority"`
 }
 
 func (m imagesMetadataDoc) metadata() Metadata {
@@ -141,6 +146,7 @@ func (m imagesMetadataDoc) metadata() Metadata {
 			RootStorageType: m.RootStorageType,
 			VirtType:        m.VirtType,
 		},
+		m.Priority,
 		m.ImageId,
 	}
 	if m.RootStorageSize != 0 {
@@ -162,6 +168,7 @@ func (s *storage) mongoDoc(m Metadata) imagesMetadataDoc {
 		ImageId:         m.ImageId,
 		DateCreated:     time.Now().UnixNano(),
 		Source:          m.Source,
+		Priority:        m.Priority,
 	}
 	if m.RootStorageSize != nil {
 		r.RootStorageSize = *m.RootStorageSize

--- a/state/cloudimagemetadata/image_test.go
+++ b/state/cloudimagemetadata/image_test.go
@@ -48,7 +48,7 @@ func (s *cloudImageMetadataSuite) TestSaveMetadata(c *gc.C) {
 		VirtType:        "virtType-test",
 		RootStorageType: "rootStorageType-test"}
 
-	added := cloudimagemetadata.Metadata{attrs, "1"}
+	added := cloudimagemetadata.Metadata{attrs, 0, "1"}
 	s.assertRecordMetadata(c, added)
 	s.assertMetadataRecorded(c, attrs, added)
 
@@ -70,7 +70,7 @@ func (s *cloudImageMetadataSuite) TestFindMetadataNotFound(c *gc.C) {
 		Arch:            "arch",
 		VirtType:        "virtType",
 		RootStorageType: "rootStorageType"}
-	m := cloudimagemetadata.Metadata{attrs, "1"}
+	m := cloudimagemetadata.Metadata{attrs, 0, "1"}
 	s.assertRecordMetadata(c, m)
 
 	// ...but look for something else.
@@ -107,7 +107,7 @@ func (s *cloudImageMetadataSuite) TestFindMetadata(c *gc.C) {
 		VirtType:        "virtType",
 		RootStorageType: "rootStorageType"}
 
-	m := cloudimagemetadata.Metadata{attrs, "1"}
+	m := cloudimagemetadata.Metadata{attrs, 0, "1"}
 
 	_, err := s.storage.FindMetadata(buildAttributesFilter(attrs))
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
@@ -117,7 +117,7 @@ func (s *cloudImageMetadataSuite) TestFindMetadata(c *gc.C) {
 	s.assertMetadataRecorded(c, attrs, expected...)
 
 	attrs.Stream = "another_stream"
-	m = cloudimagemetadata.Metadata{attrs, "2"}
+	m = cloudimagemetadata.Metadata{attrs, 0, "2"}
 	s.assertRecordMetadata(c, m)
 
 	expected = append(expected, m)
@@ -131,8 +131,8 @@ func (s *cloudImageMetadataSuite) TestSaveMetadataUpdateSameAttrsAndImages(c *gc
 		Series: "series",
 		Arch:   "arch",
 	}
-	metadata0 := cloudimagemetadata.Metadata{attrs, "1"}
-	metadata1 := cloudimagemetadata.Metadata{attrs, "1"}
+	metadata0 := cloudimagemetadata.Metadata{attrs, 0, "1"}
+	metadata1 := cloudimagemetadata.Metadata{attrs, 0, "1"}
 
 	s.assertRecordMetadata(c, metadata0)
 	s.assertRecordMetadata(c, metadata1)
@@ -145,8 +145,8 @@ func (s *cloudImageMetadataSuite) TestSaveMetadataUpdateSameAttrsDiffImages(c *g
 		Series: "series",
 		Arch:   "arch",
 	}
-	metadata0 := cloudimagemetadata.Metadata{attrs, "1"}
-	metadata1 := cloudimagemetadata.Metadata{attrs, "12"}
+	metadata0 := cloudimagemetadata.Metadata{attrs, 0, "1"}
+	metadata1 := cloudimagemetadata.Metadata{attrs, 0, "12"}
 
 	s.assertRecordMetadata(c, metadata0)
 	s.assertMetadataRecorded(c, attrs, metadata0)
@@ -161,8 +161,8 @@ func (s *cloudImageMetadataSuite) TestSaveDiffMetadataConcurrentlyAndOrderByDate
 		Series: "series",
 		Arch:   "arch",
 	}
-	metadata0 := cloudimagemetadata.Metadata{attrs, "0"}
-	metadata1 := cloudimagemetadata.Metadata{attrs, "1"}
+	metadata0 := cloudimagemetadata.Metadata{attrs, 0, "0"}
+	metadata1 := cloudimagemetadata.Metadata{attrs, 0, "1"}
 	metadata1.Stream = "scream"
 
 	s.assertConcurrentSave(c,
@@ -180,8 +180,8 @@ func (s *cloudImageMetadataSuite) TestSaveSameMetadataDiffImageConcurrently(c *g
 		Series: "series",
 		Arch:   "arch",
 	}
-	metadata0 := cloudimagemetadata.Metadata{attrs, "0"}
-	metadata1 := cloudimagemetadata.Metadata{attrs, "1"}
+	metadata0 := cloudimagemetadata.Metadata{attrs, 0, "0"}
+	metadata1 := cloudimagemetadata.Metadata{attrs, 0, "1"}
 
 	s.assertConcurrentSave(c,
 		metadata0, // add this one
@@ -196,7 +196,7 @@ func (s *cloudImageMetadataSuite) TestSaveSameMetadataSameImageConcurrently(c *g
 		Series: "series",
 		Arch:   "arch",
 	}
-	metadata0 := cloudimagemetadata.Metadata{attrs, "0"}
+	metadata0 := cloudimagemetadata.Metadata{attrs, 0, "0"}
 
 	s.assertConcurrentSave(c,
 		metadata0, // add this one
@@ -212,10 +212,10 @@ func (s *cloudImageMetadataSuite) TestSaveSameMetadataSameImageDiffSourceConcurr
 		Arch:   "arch",
 		Source: "public",
 	}
-	metadata0 := cloudimagemetadata.Metadata{attrs, "0"}
+	metadata0 := cloudimagemetadata.Metadata{attrs, 0, "0"}
 
 	attrs.Source = "custom"
-	metadata1 := cloudimagemetadata.Metadata{attrs, "0"}
+	metadata1 := cloudimagemetadata.Metadata{attrs, 0, "0"}
 
 	s.assertConcurrentSave(c,
 		metadata0,

--- a/state/cloudimagemetadata/interface.go
+++ b/state/cloudimagemetadata/interface.go
@@ -41,6 +41,11 @@ type MetadataAttributes struct {
 type Metadata struct {
 	MetadataAttributes
 
+	// Priority is an importance factor for image metadata.
+	// Higher number means higher priority.
+	// This will allow to sort metadata by importance.
+	Priority int
+
 	// ImageId contains image identifier.
 	ImageId string
 }

--- a/upgrades/toolstorage.go
+++ b/upgrades/toolstorage.go
@@ -58,7 +58,7 @@ func migrateToolsStorage(st *state.State, agentConfig agent.Config) error {
 	}
 
 	// Search provider storage for tools.
-	datasource := storage.NewStorageSimpleStreamsDataSource("provider storage", stor, storage.BaseToolsPath)
+	datasource := storage.NewStorageSimpleStreamsDataSource("provider storage", stor, storage.BaseToolsPath, 30)
 	toolsList, err := envtools.FindToolsForCloud(
 		[]simplestreams.DataSource{datasource},
 		simplestreams.CloudSpec{},

--- a/upgrades/toolstorage.go
+++ b/upgrades/toolstorage.go
@@ -58,7 +58,7 @@ func migrateToolsStorage(st *state.State, agentConfig agent.Config) error {
 	}
 
 	// Search provider storage for tools.
-	datasource := storage.NewStorageSimpleStreamsDataSource("provider storage", stor, storage.BaseToolsPath, 30)
+	datasource := storage.NewStorageSimpleStreamsDataSource("provider storage", stor, storage.BaseToolsPath, simplestreams.SPECIFIC_CLOUD_DATA)
 	toolsList, err := envtools.FindToolsForCloud(
 		[]simplestreams.DataSource{datasource},
 		simplestreams.CloudSpec{},


### PR DESCRIPTION
This PR enables data sources to define their priority. Image metadata can now be sorted in order of priority.

In addition, when storing published image metadata, we want to get matching metadata from all registered data sources.

(Review request: http://reviews.vapour.ws/r/3024/)