### PR TITLE
storage provisioner manifold and config

### DIFF
--- a/api/interface.go
+++ b/api/interface.go
@@ -28,7 +28,6 @@ import (
 	"github.com/juju/juju/api/reboot"
 	"github.com/juju/juju/api/resumer"
 	"github.com/juju/juju/api/rsyslog"
-	"github.com/juju/juju/api/storageprovisioner"
 	"github.com/juju/juju/api/uniter"
 	"github.com/juju/juju/api/upgrader"
 	"github.com/juju/juju/network"
@@ -167,7 +166,6 @@ type Connection interface {
 	Provisioner() *provisioner.State
 	Uniter() (*uniter.State, error)
 	DiskManager() (*diskmanager.State, error)
-	StorageProvisioner(scope names.Tag) *storageprovisioner.State
 	Firewaller() *firewaller.State
 	Agent() *agent.State
 	Upgrader() *upgrader.State

--- a/api/state.go
+++ b/api/state.go
@@ -30,7 +30,6 @@ import (
 	"github.com/juju/juju/api/reboot"
 	"github.com/juju/juju/api/resumer"
 	"github.com/juju/juju/api/rsyslog"
-	"github.com/juju/juju/api/storageprovisioner"
 	"github.com/juju/juju/api/uniter"
 	"github.com/juju/juju/api/upgrader"
 	"github.com/juju/juju/apiserver/params"
@@ -310,16 +309,6 @@ func (st *state) DiskManager() (*diskmanager.State, error) {
 		return nil, errors.Errorf("expected MachineTag, got %#v", st.authTag)
 	}
 	return diskmanager.NewState(st, machineTag), nil
-}
-
-// StorageProvisioner returns a version of the state that provides
-// functionality required by the storageprovisioner worker.
-// The scope tag defines the type of storage that is provisioned, either
-// either attached directly to a specified machine (machine scoped),
-// or provisioned on the underlying cloud for use by any machine in a
-// specified environment (environ scoped).
-func (st *state) StorageProvisioner(scope names.Tag) *storageprovisioner.State {
-	return storageprovisioner.NewState(st, scope)
 }
 
 // Firewaller returns a version of the state that provides functionality

--- a/api/storageprovisioner/provisioner.go
+++ b/api/storageprovisioner/provisioner.go
@@ -24,19 +24,19 @@ type State struct {
 }
 
 // NewState creates a new client-side StorageProvisioner facade.
-func NewState(caller base.APICaller, scope names.Tag) *State {
+func NewState(caller base.APICaller, scope names.Tag) (*State, error) {
 	switch scope.(type) {
 	case names.EnvironTag:
 	case names.MachineTag:
 	default:
-		panic(errors.Errorf("expected EnvironTag or MachineTag, got %T", scope))
+		return nil, errors.Errorf("expected EnvironTag or MachineTag, got %T", scope)
 	}
 	facadeCaller := base.NewFacadeCaller(caller, storageProvisionerFacade)
 	return &State{
 		facadeCaller,
 		scope,
 		common.NewEnvironWatcher(facadeCaller),
-	}
+	}, nil
 }
 
 // WatchBlockDevices watches for changes to the specified machine's block devices.

--- a/api/storageprovisioner/provisioner_test.go
+++ b/api/storageprovisioner/provisioner_test.go
@@ -23,18 +23,28 @@ type provisionerSuite struct {
 	coretesting.BaseSuite
 }
 
-func (s *provisionerSuite) TestNewState(c *gc.C) {
-	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+var nullAPICaller = testing.APICallerFunc(
+	func(objType string, version int, id, request string, arg, result interface{}) error {
 		return nil
-	})
+	},
+)
 
-	st := storageprovisioner.NewState(apiCaller, names.NewMachineTag("123"))
-	c.Assert(st, gc.NotNil)
-	st = storageprovisioner.NewState(apiCaller, names.NewEnvironTag("87927ace-9e41-4fd5-8103-1a6fb5ff7eb4"))
-	c.Assert(st, gc.NotNil)
-	c.Assert(func() {
-		storageprovisioner.NewState(apiCaller, names.NewUnitTag("mysql/0"))
-	}, gc.PanicMatches, "expected EnvironTag or MachineTag, got names.UnitTag")
+func (s *provisionerSuite) TestNewStateMachineScope(c *gc.C) {
+	st, err := storageprovisioner.NewState(nullAPICaller, names.NewMachineTag("123"))
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(st, gc.NotNil)
+}
+
+func (s *provisionerSuite) TestNewStateEnvironScope(c *gc.C) {
+	st, err := storageprovisioner.NewState(nullAPICaller, names.NewEnvironTag("87927ace-9e41-4fd5-8103-1a6fb5ff7eb4"))
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(st, gc.NotNil)
+}
+
+func (s *provisionerSuite) TestNewStateBadScope(c *gc.C) {
+	st, err := storageprovisioner.NewState(nullAPICaller, names.NewUnitTag("mysql/0"))
+	c.Check(st, gc.IsNil)
+	c.Check(err, gc.ErrorMatches, "expected EnvironTag or MachineTag, got names.UnitTag")
 }
 
 func (s *provisionerSuite) TestWatchVolumes(c *gc.C) {
@@ -54,8 +64,9 @@ func (s *provisionerSuite) TestWatchVolumes(c *gc.C) {
 		return nil
 	})
 
-	st := storageprovisioner.NewState(apiCaller, names.NewMachineTag("123"))
-	_, err := st.WatchVolumes()
+	st, err := storageprovisioner.NewState(apiCaller, names.NewMachineTag("123"))
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = st.WatchVolumes()
 	c.Check(err, gc.ErrorMatches, "FAIL")
 	c.Check(callCount, gc.Equals, 1)
 }
@@ -77,8 +88,9 @@ func (s *provisionerSuite) TestWatchFilesystems(c *gc.C) {
 		return nil
 	})
 
-	st := storageprovisioner.NewState(apiCaller, names.NewMachineTag("123"))
-	_, err := st.WatchFilesystems()
+	st, err := storageprovisioner.NewState(apiCaller, names.NewMachineTag("123"))
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = st.WatchFilesystems()
 	c.Check(err, gc.ErrorMatches, "FAIL")
 	c.Check(callCount, gc.Equals, 1)
 }
@@ -100,8 +112,9 @@ func (s *provisionerSuite) TestWatchVolumeAttachments(c *gc.C) {
 		return nil
 	})
 
-	st := storageprovisioner.NewState(apiCaller, names.NewMachineTag("123"))
-	_, err := st.WatchVolumeAttachments()
+	st, err := storageprovisioner.NewState(apiCaller, names.NewMachineTag("123"))
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = st.WatchVolumeAttachments()
 	c.Check(err, gc.ErrorMatches, "FAIL")
 	c.Check(callCount, gc.Equals, 1)
 }
@@ -123,8 +136,9 @@ func (s *provisionerSuite) TestWatchFilesystemAttachments(c *gc.C) {
 		return nil
 	})
 
-	st := storageprovisioner.NewState(apiCaller, names.NewMachineTag("123"))
-	_, err := st.WatchFilesystemAttachments()
+	st, err := storageprovisioner.NewState(apiCaller, names.NewMachineTag("123"))
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = st.WatchFilesystemAttachments()
 	c.Check(err, gc.ErrorMatches, "FAIL")
 	c.Check(callCount, gc.Equals, 1)
 }
@@ -147,8 +161,9 @@ func (s *provisionerSuite) TestWatchBlockDevices(c *gc.C) {
 		return nil
 	})
 
-	st := storageprovisioner.NewState(apiCaller, names.NewMachineTag("123"))
-	_, err := st.WatchBlockDevices(names.NewMachineTag("123"))
+	st, err := storageprovisioner.NewState(apiCaller, names.NewMachineTag("123"))
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = st.WatchBlockDevices(names.NewMachineTag("123"))
 	c.Check(err, gc.ErrorMatches, "FAIL")
 }
 
@@ -177,7 +192,8 @@ func (s *provisionerSuite) TestVolumes(c *gc.C) {
 		return nil
 	})
 
-	st := storageprovisioner.NewState(apiCaller, names.NewMachineTag("123"))
+	st, err := storageprovisioner.NewState(apiCaller, names.NewMachineTag("123"))
+	c.Assert(err, jc.ErrorIsNil)
 	volumes, err := st.Volumes([]names.VolumeTag{names.NewVolumeTag("100")})
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(callCount, gc.Equals, 1)
@@ -217,7 +233,8 @@ func (s *provisionerSuite) TestFilesystems(c *gc.C) {
 		return nil
 	})
 
-	st := storageprovisioner.NewState(apiCaller, names.NewMachineTag("123"))
+	st, err := storageprovisioner.NewState(apiCaller, names.NewMachineTag("123"))
+	c.Assert(err, jc.ErrorIsNil)
 	filesystems, err := st.Filesystems([]names.FilesystemTag{names.NewFilesystemTag("100")})
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(callCount, gc.Equals, 1)
@@ -262,7 +279,8 @@ func (s *provisionerSuite) TestVolumeAttachments(c *gc.C) {
 		return nil
 	})
 
-	st := storageprovisioner.NewState(apiCaller, names.NewMachineTag("123"))
+	st, err := storageprovisioner.NewState(apiCaller, names.NewMachineTag("123"))
+	c.Assert(err, jc.ErrorIsNil)
 	volumes, err := st.VolumeAttachments([]params.MachineStorageId{{
 		MachineTag: "machine-100", AttachmentTag: "volume-100",
 	}})
@@ -297,7 +315,8 @@ func (s *provisionerSuite) TestVolumeBlockDevices(c *gc.C) {
 		return nil
 	})
 
-	st := storageprovisioner.NewState(apiCaller, names.NewMachineTag("123"))
+	st, err := storageprovisioner.NewState(apiCaller, names.NewMachineTag("123"))
+	c.Assert(err, jc.ErrorIsNil)
 	volumes, err := st.VolumeBlockDevices([]params.MachineStorageId{{
 		MachineTag: "machine-100", AttachmentTag: "volume-100",
 	}})
@@ -335,7 +354,8 @@ func (s *provisionerSuite) TestFilesystemAttachments(c *gc.C) {
 		return nil
 	})
 
-	st := storageprovisioner.NewState(apiCaller, names.NewMachineTag("123"))
+	st, err := storageprovisioner.NewState(apiCaller, names.NewMachineTag("123"))
+	c.Assert(err, jc.ErrorIsNil)
 	filesystems, err := st.FilesystemAttachments([]params.MachineStorageId{{
 		MachineTag: "machine-100", AttachmentTag: "filesystem-100",
 	}})
@@ -366,7 +386,8 @@ func (s *provisionerSuite) TestVolumeParams(c *gc.C) {
 		return nil
 	})
 
-	st := storageprovisioner.NewState(apiCaller, names.NewMachineTag("123"))
+	st, err := storageprovisioner.NewState(apiCaller, names.NewMachineTag("123"))
+	c.Assert(err, jc.ErrorIsNil)
 	volumeParams, err := st.VolumeParams([]names.VolumeTag{names.NewVolumeTag("100")})
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(callCount, gc.Equals, 1)
@@ -399,7 +420,8 @@ func (s *provisionerSuite) TestFilesystemParams(c *gc.C) {
 		return nil
 	})
 
-	st := storageprovisioner.NewState(apiCaller, names.NewMachineTag("123"))
+	st, err := storageprovisioner.NewState(apiCaller, names.NewMachineTag("123"))
+	c.Assert(err, jc.ErrorIsNil)
 	filesystemParams, err := st.FilesystemParams([]names.FilesystemTag{names.NewFilesystemTag("100")})
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(callCount, gc.Equals, 1)
@@ -439,7 +461,8 @@ func (s *provisionerSuite) TestVolumeAttachmentParams(c *gc.C) {
 		return nil
 	})
 
-	st := storageprovisioner.NewState(apiCaller, names.NewMachineTag("123"))
+	st, err := storageprovisioner.NewState(apiCaller, names.NewMachineTag("123"))
+	c.Assert(err, jc.ErrorIsNil)
 	volumeParams, err := st.VolumeAttachmentParams([]params.MachineStorageId{{
 		MachineTag: "machine-100", AttachmentTag: "volume-100",
 	}})
@@ -478,7 +501,8 @@ func (s *provisionerSuite) TestFilesystemAttachmentParams(c *gc.C) {
 		return nil
 	})
 
-	st := storageprovisioner.NewState(apiCaller, names.NewMachineTag("123"))
+	st, err := storageprovisioner.NewState(apiCaller, names.NewMachineTag("123"))
+	c.Assert(err, jc.ErrorIsNil)
 	filesystemParams, err := st.FilesystemAttachmentParams([]params.MachineStorageId{{
 		MachineTag: "machine-100", AttachmentTag: "filesystem-100",
 	}})
@@ -513,7 +537,8 @@ func (s *provisionerSuite) TestSetVolumeInfo(c *gc.C) {
 		return nil
 	})
 
-	st := storageprovisioner.NewState(apiCaller, names.NewMachineTag("123"))
+	st, err := storageprovisioner.NewState(apiCaller, names.NewMachineTag("123"))
+	c.Assert(err, jc.ErrorIsNil)
 	volumes := []params.Volume{{
 		VolumeTag: "volume-100",
 		Info: params.VolumeInfo{
@@ -551,7 +576,8 @@ func (s *provisionerSuite) TestSetFilesystemInfo(c *gc.C) {
 		return nil
 	})
 
-	st := storageprovisioner.NewState(apiCaller, names.NewMachineTag("123"))
+	st, err := storageprovisioner.NewState(apiCaller, names.NewMachineTag("123"))
+	c.Assert(err, jc.ErrorIsNil)
 	filesystems := []params.Filesystem{{
 		FilesystemTag: "filesystem-100",
 		Info: params.FilesystemInfo{
@@ -590,7 +616,8 @@ func (s *provisionerSuite) TestSetVolumeAttachmentInfo(c *gc.C) {
 		return nil
 	})
 
-	st := storageprovisioner.NewState(apiCaller, names.NewMachineTag("123"))
+	st, err := storageprovisioner.NewState(apiCaller, names.NewMachineTag("123"))
+	c.Assert(err, jc.ErrorIsNil)
 	errorResults, err := st.SetVolumeAttachmentInfo(volumeAttachments)
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(callCount, gc.Equals, 1)
@@ -622,7 +649,8 @@ func (s *provisionerSuite) TestSetFilesystemAttachmentInfo(c *gc.C) {
 		return nil
 	})
 
-	st := storageprovisioner.NewState(apiCaller, names.NewMachineTag("123"))
+	st, err := storageprovisioner.NewState(apiCaller, names.NewMachineTag("123"))
+	c.Assert(err, jc.ErrorIsNil)
 	errorResults, err := st.SetFilesystemAttachmentInfo(filesystemAttachments)
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(callCount, gc.Equals, 1)
@@ -648,7 +676,8 @@ func (s *provisionerSuite) testOpWithTags(
 		return nil
 	})
 
-	st := storageprovisioner.NewState(apiCaller, names.NewMachineTag("123"))
+	st, err := storageprovisioner.NewState(apiCaller, names.NewMachineTag("123"))
+	c.Assert(err, jc.ErrorIsNil)
 	volumes := []names.Tag{names.NewVolumeTag("100")}
 	errorResults, err := apiCall(st, volumes)
 	c.Check(err, jc.ErrorIsNil)
@@ -684,7 +713,8 @@ func (s *provisionerSuite) TestLife(c *gc.C) {
 		return nil
 	})
 
-	st := storageprovisioner.NewState(apiCaller, names.NewMachineTag("123"))
+	st, err := storageprovisioner.NewState(apiCaller, names.NewMachineTag("123"))
+	c.Assert(err, jc.ErrorIsNil)
 	volumes := []names.Tag{names.NewVolumeTag("100")}
 	lifeResults, err := st.Life(volumes)
 	c.Check(err, jc.ErrorIsNil)
@@ -696,8 +726,9 @@ func (s *provisionerSuite) testClientError(c *gc.C, apiCall func(*storageprovisi
 	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		return errors.New("blargh")
 	})
-	st := storageprovisioner.NewState(apiCaller, names.NewMachineTag("123"))
-	err := apiCall(st)
+	st, err := storageprovisioner.NewState(apiCaller, names.NewMachineTag("123"))
+	c.Assert(err, jc.ErrorIsNil)
+	err = apiCall(st)
 	c.Check(err, gc.ErrorMatches, "blargh")
 }
 
@@ -773,8 +804,9 @@ func (s *provisionerSuite) TestWatchVolumesServerError(c *gc.C) {
 		}
 		return nil
 	})
-	st := storageprovisioner.NewState(apiCaller, names.NewMachineTag("123"))
-	_, err := st.WatchVolumes()
+	st, err := storageprovisioner.NewState(apiCaller, names.NewMachineTag("123"))
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = st.WatchVolumes()
 	c.Check(err, gc.ErrorMatches, "MSG")
 }
 
@@ -787,7 +819,8 @@ func (s *provisionerSuite) TestVolumesServerError(c *gc.C) {
 		}
 		return nil
 	})
-	st := storageprovisioner.NewState(apiCaller, names.NewMachineTag("123"))
+	st, err := storageprovisioner.NewState(apiCaller, names.NewMachineTag("123"))
+	c.Assert(err, jc.ErrorIsNil)
 	results, err := st.Volumes([]names.VolumeTag{names.NewVolumeTag("100")})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.HasLen, 1)
@@ -803,7 +836,8 @@ func (s *provisionerSuite) TestVolumeParamsServerError(c *gc.C) {
 		}
 		return nil
 	})
-	st := storageprovisioner.NewState(apiCaller, names.NewMachineTag("123"))
+	st, err := storageprovisioner.NewState(apiCaller, names.NewMachineTag("123"))
+	c.Assert(err, jc.ErrorIsNil)
 	results, err := st.VolumeParams([]names.VolumeTag{names.NewVolumeTag("100")})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.HasLen, 1)
@@ -819,7 +853,8 @@ func (s *provisionerSuite) TestSetVolumeInfoServerError(c *gc.C) {
 		}
 		return nil
 	})
-	st := storageprovisioner.NewState(apiCaller, names.NewMachineTag("123"))
+	st, err := storageprovisioner.NewState(apiCaller, names.NewMachineTag("123"))
+	c.Assert(err, jc.ErrorIsNil)
 	results, err := st.SetVolumeInfo([]params.Volume{{
 		VolumeTag: names.NewVolumeTag("100").String(),
 	}})
@@ -837,7 +872,8 @@ func (s *provisionerSuite) testServerError(c *gc.C, apiCall func(*storageprovisi
 		}
 		return nil
 	})
-	st := storageprovisioner.NewState(apiCaller, names.NewMachineTag("123"))
+	st, err := storageprovisioner.NewState(apiCaller, names.NewMachineTag("123"))
+	c.Assert(err, jc.ErrorIsNil)
 	tags := []names.Tag{
 		names.NewVolumeTag("100"),
 	}
@@ -868,7 +904,8 @@ func (s *provisionerSuite) TestLifeServerError(c *gc.C) {
 		}
 		return nil
 	})
-	st := storageprovisioner.NewState(apiCaller, names.NewMachineTag("123"))
+	st, err := storageprovisioner.NewState(apiCaller, names.NewMachineTag("123"))
+	c.Assert(err, jc.ErrorIsNil)
 	tags := []names.Tag{
 		names.NewVolumeTag("100"),
 	}
@@ -890,8 +927,9 @@ func (s *provisionerSuite) TestWatchForEnvironConfigChanges(c *gc.C) {
 		}
 		return errors.New("FAIL")
 	})
-	st := storageprovisioner.NewState(apiCaller, names.NewMachineTag("123"))
-	_, err := st.WatchForEnvironConfigChanges()
+	st, err := storageprovisioner.NewState(apiCaller, names.NewMachineTag("123"))
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = st.WatchForEnvironConfigChanges()
 	c.Assert(err, gc.ErrorMatches, "FAIL")
 }
 
@@ -908,7 +946,8 @@ func (s *provisionerSuite) TestEnvironConfig(c *gc.C) {
 		}
 		return nil
 	})
-	st := storageprovisioner.NewState(apiCaller, names.NewMachineTag("123"))
+	st, err := storageprovisioner.NewState(apiCaller, names.NewMachineTag("123"))
+	c.Assert(err, jc.ErrorIsNil)
 	outputCfg, err := st.EnvironConfig()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(outputCfg.AllAttrs(), jc.DeepEquals, inputCfg.AllAttrs())

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -39,6 +39,7 @@ import (
 	apilogsender "github.com/juju/juju/api/logsender"
 	"github.com/juju/juju/api/metricsmanager"
 	"github.com/juju/juju/api/statushistory"
+	apistorageprovisioner "github.com/juju/juju/api/storageprovisioner"
 	apiupgrader "github.com/juju/juju/api/upgrader"
 	"github.com/juju/juju/apiserver"
 	"github.com/juju/juju/apiserver/params"
@@ -810,12 +811,22 @@ func (a *MachineAgent) postUpgradeAPIWorker(
 	})
 	runner.StartWorker("storageprovisioner-machine", func() (worker.Worker, error) {
 		scope := agentConfig.Tag()
-		api := st.StorageProvisioner(scope)
+		api, err := apistorageprovisioner.NewState(st, scope)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
 		storageDir := filepath.Join(agentConfig.DataDir(), "storage")
-		return newStorageWorker(
-			scope, storageDir, api, api, api, api, api, api,
-			clock.WallClock,
-		), nil
+		return newStorageWorker(storageprovisioner.Config{
+			Scope:       scope,
+			StorageDir:  storageDir,
+			Volumes:     api,
+			Filesystems: api,
+			Life:        api,
+			Environ:     api,
+			Machines:    api,
+			Status:      api,
+			Clock:       clock.WallClock,
+		})
 	})
 
 	if isEnvironManager {
@@ -1205,11 +1216,20 @@ func (a *MachineAgent) startEnvWorkers(
 	})
 	singularRunner.StartWorker("environ-storageprovisioner", func() (worker.Worker, error) {
 		scope := st.EnvironTag()
-		api := apiSt.StorageProvisioner(scope)
-		return newStorageWorker(
-			scope, "", api, api, api, api, api, api,
-			clock.WallClock,
-		), nil
+		api, err := apistorageprovisioner.NewState(apiSt, scope)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		return newStorageWorker(storageprovisioner.Config{
+			Scope:       scope,
+			Volumes:     api,
+			Filesystems: api,
+			Life:        api,
+			Environ:     api,
+			Machines:    api,
+			Status:      api,
+			Clock:       clock.WallClock,
+		})
 	})
 	singularRunner.StartWorker("charm-revision-updater", func() (worker.Worker, error) {
 		return charmrevisionworker.NewRevisionUpdateWorker(apiSt.CharmRevisionUpdater()), nil

--- a/worker/storageprovisioner/blockdevices.go
+++ b/worker/storageprovisioner/blockdevices.go
@@ -63,7 +63,7 @@ func processPendingVolumeBlockDevices(ctx *context) error {
 // refreshVolumeBlockDevices refreshes the block devices for the specified
 // volumes.
 func refreshVolumeBlockDevices(ctx *context, volumeTags []names.VolumeTag) error {
-	machineTag, ok := ctx.scope.(names.MachineTag)
+	machineTag, ok := ctx.config.Scope.(names.MachineTag)
 	if !ok {
 		// This function should only be called by machine-scoped
 		// storage provisioners.
@@ -76,7 +76,7 @@ func refreshVolumeBlockDevices(ctx *context, volumeTags []names.VolumeTag) error
 			AttachmentTag: volumeTag.String(),
 		}
 	}
-	results, err := ctx.volumeAccessor.VolumeBlockDevices(ids)
+	results, err := ctx.config.Volumes.VolumeBlockDevices(ids)
 	if err != nil {
 		return errors.Annotate(err, "refreshing volume block devices")
 	}

--- a/worker/storageprovisioner/common.go
+++ b/worker/storageprovisioner/common.go
@@ -19,7 +19,7 @@ import (
 // storage entity (volume or filesystem), and then partitions the
 // tags by them.
 func storageEntityLife(ctx *context, tags []names.Tag) (alive, dying, dead []names.Tag, _ error) {
-	lifeResults, err := ctx.life.Life(tags)
+	lifeResults, err := ctx.config.Life.Life(tags)
 	if err != nil {
 		return nil, nil, nil, errors.Annotate(err, "getting storage entity life")
 	}
@@ -47,7 +47,7 @@ func storageEntityLife(ctx *context, tags []names.Tag) (alive, dying, dead []nam
 func attachmentLife(ctx *context, ids []params.MachineStorageId) (
 	alive, dying, dead []params.MachineStorageId, _ error,
 ) {
-	lifeResults, err := ctx.life.AttachmentLife(ids)
+	lifeResults, err := ctx.config.Life.AttachmentLife(ids)
 	if err != nil {
 		return nil, nil, nil, errors.Annotate(err, "getting machine attachment life")
 	}
@@ -76,7 +76,7 @@ func removeEntities(ctx *context, tags []names.Tag) error {
 		return nil
 	}
 	logger.Debugf("removing entities: %v", tags)
-	errorResults, err := ctx.life.Remove(tags)
+	errorResults, err := ctx.config.Life.Remove(tags)
 	if err != nil {
 		return errors.Annotate(err, "removing storage entities")
 	}
@@ -93,7 +93,7 @@ func removeAttachments(ctx *context, ids []params.MachineStorageId) error {
 	if len(ids) == 0 {
 		return nil
 	}
-	errorResults, err := ctx.life.RemoveAttachments(ids)
+	errorResults, err := ctx.config.Life.RemoveAttachments(ids)
 	if err != nil {
 		return errors.Annotate(err, "removing attachments")
 	}
@@ -112,7 +112,7 @@ func removeAttachments(ctx *context, ids []params.MachineStorageId) error {
 // the status fails the error is logged but otherwise ignored.
 func setStatus(ctx *context, statuses []params.EntityStatusArgs) {
 	if len(statuses) > 0 {
-		if err := ctx.statusSetter.SetStatus(statuses); err != nil {
+		if err := ctx.config.Status.SetStatus(statuses); err != nil {
 			logger.Errorf("failed to set status: %v", err)
 		}
 	}

--- a/worker/storageprovisioner/config.go
+++ b/worker/storageprovisioner/config.go
@@ -1,0 +1,63 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package storageprovisioner
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/names"
+	"github.com/juju/utils/clock"
+)
+
+// Config holds configuration and dependencies for a storageprovisioner worker.
+type Config struct {
+	Scope       names.Tag
+	StorageDir  string
+	Volumes     VolumeAccessor
+	Filesystems FilesystemAccessor
+	Life        LifecycleManager
+	Environ     EnvironAccessor
+	Machines    MachineAccessor
+	Status      StatusSetter
+	Clock       clock.Clock
+}
+
+// Validate returns an error if the config cannot be relied upon to start a worker.
+func (config Config) Validate() error {
+	switch config.Scope.(type) {
+	case nil:
+		return errors.NotValidf("nil Scope")
+	case names.EnvironTag:
+		if config.StorageDir != "" {
+			return errors.NotValidf("environ Scope with non-empty StorageDir")
+		}
+	case names.MachineTag:
+		if config.StorageDir == "" {
+			return errors.NotValidf("machine Scope with empty StorageDir")
+		}
+	default:
+		return errors.NotValidf("%T Scope", config.Scope)
+	}
+	if config.Volumes == nil {
+		return errors.NotValidf("nil Volumes")
+	}
+	if config.Filesystems == nil {
+		return errors.NotValidf("nil Filesystems")
+	}
+	if config.Life == nil {
+		return errors.NotValidf("nil Life")
+	}
+	if config.Environ == nil {
+		return errors.NotValidf("nil Environ")
+	}
+	if config.Machines == nil {
+		return errors.NotValidf("nil Machines")
+	}
+	if config.Status == nil {
+		return errors.NotValidf("nil Status")
+	}
+	if config.Clock == nil {
+		return errors.NotValidf("nil Clock")
+	}
+	return nil
+}

--- a/worker/storageprovisioner/config_test.go
+++ b/worker/storageprovisioner/config_test.go
@@ -1,0 +1,134 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package storageprovisioner_test
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/names"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/clock"
+	gc "gopkg.in/check.v1"
+
+	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/worker/storageprovisioner"
+)
+
+type ConfigSuite struct {
+	testing.IsolationSuite
+
+	// This is a bit unexpected: these tests should mutate the stored
+	// config, and then call the checkNotValid method.
+	config storageprovisioner.Config
+}
+
+var _ = gc.Suite(&ConfigSuite{})
+
+func (s *ConfigSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+	s.config = validEnvironConfig()
+}
+
+func (s *ConfigSuite) TestNilScope(c *gc.C) {
+	s.config.Scope = nil
+	s.checkNotValid(c, "nil Scope not valid")
+}
+
+func (s *ConfigSuite) TestInvalidScope(c *gc.C) {
+	s.config.Scope = names.NewServiceTag("boo")
+	s.checkNotValid(c, ".* Scope not valid")
+}
+
+func (s *ConfigSuite) TestEnvironScopeStorageDir(c *gc.C) {
+	s.config.StorageDir = "surprise!"
+	s.checkNotValid(c, "environ Scope with non-empty StorageDir not valid")
+}
+
+func (s *ConfigSuite) TestMachineScopeStorageDir(c *gc.C) {
+	s.config = validMachineConfig()
+	s.config.StorageDir = ""
+	s.checkNotValid(c, "machine Scope with empty StorageDir not valid")
+}
+
+func (s *ConfigSuite) TestNilVolumes(c *gc.C) {
+	s.config.Volumes = nil
+	s.checkNotValid(c, "nil Volumes not valid")
+}
+
+func (s *ConfigSuite) TestNilFilesystems(c *gc.C) {
+	s.config.Filesystems = nil
+	s.checkNotValid(c, "nil Filesystems not valid")
+}
+
+func (s *ConfigSuite) TestNilLife(c *gc.C) {
+	s.config.Life = nil
+	s.checkNotValid(c, "nil Life not valid")
+}
+
+func (s *ConfigSuite) TestNilEnviron(c *gc.C) {
+	s.config.Environ = nil
+	s.checkNotValid(c, "nil Environ not valid")
+}
+
+func (s *ConfigSuite) TestNilMachines(c *gc.C) {
+	s.config.Machines = nil
+	s.checkNotValid(c, "nil Machines not valid")
+}
+
+func (s *ConfigSuite) TestNilStatus(c *gc.C) {
+	s.config.Status = nil
+	s.checkNotValid(c, "nil Status not valid")
+}
+
+func (s *ConfigSuite) TestNilClock(c *gc.C) {
+	s.config.Clock = nil
+	s.checkNotValid(c, "nil Clock not valid")
+}
+
+func (s *ConfigSuite) checkNotValid(c *gc.C, match string) {
+	err := s.config.Validate()
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+	c.Check(err, gc.ErrorMatches, match)
+}
+
+func validEnvironConfig() storageprovisioner.Config {
+	config := almostValidConfig()
+	config.Scope = coretesting.EnvironmentTag
+	return config
+}
+
+func validMachineConfig() storageprovisioner.Config {
+	config := almostValidConfig()
+	config.Scope = names.NewMachineTag("123/lxc/7")
+	config.StorageDir = "storage-dir"
+	return config
+}
+
+func almostValidConfig() storageprovisioner.Config {
+	// gofmt doesn't seem to want to let me one-line any of these
+	// except the last one, so I'm standardising on multi-line.
+	return storageprovisioner.Config{
+		Volumes: struct {
+			storageprovisioner.VolumeAccessor
+		}{},
+		Filesystems: struct {
+			storageprovisioner.FilesystemAccessor
+		}{},
+		Life: struct {
+			storageprovisioner.LifecycleManager
+		}{},
+		Environ: struct {
+			storageprovisioner.EnvironAccessor
+		}{},
+		Machines: struct {
+			storageprovisioner.MachineAccessor
+		}{},
+		Status: struct {
+			storageprovisioner.StatusSetter
+		}{},
+		Clock: struct {
+			clock.Clock
+		}{},
+	}
+}

--- a/worker/storageprovisioner/filesystem_events.go
+++ b/worker/storageprovisioner/filesystem_events.go
@@ -40,7 +40,7 @@ func filesystemsChanged(ctx *context, changes []string) error {
 	for _, tag := range dead {
 		filesystemTags = append(filesystemTags, tag.(names.FilesystemTag))
 	}
-	filesystemResults, err := ctx.filesystemAccessor.Filesystems(filesystemTags)
+	filesystemResults, err := ctx.config.Filesystems.Filesystems(filesystemTags)
 	if err != nil {
 		return errors.Annotatef(err, "getting filesystem information")
 	}
@@ -84,7 +84,7 @@ func filesystemAttachmentsChanged(ctx *context, ids []params.MachineStorageId) e
 	// Get filesystem information for alive and dying filesystem attachments, so
 	// we can attach/detach.
 	ids = append(alive, dying...)
-	filesystemAttachmentResults, err := ctx.filesystemAccessor.FilesystemAttachments(ids)
+	filesystemAttachmentResults, err := ctx.config.Filesystems.FilesystemAttachments(ids)
 	if err != nil {
 		return errors.Annotatef(err, "getting filesystem attachment information")
 	}
@@ -380,7 +380,7 @@ func processAliveFilesystemAttachments(
 func filesystemAttachmentParams(
 	ctx *context, ids []params.MachineStorageId,
 ) ([]storage.FilesystemAttachmentParams, error) {
-	paramsResults, err := ctx.filesystemAccessor.FilesystemAttachmentParams(ids)
+	paramsResults, err := ctx.config.Filesystems.FilesystemAttachmentParams(ids)
 	if err != nil {
 		return nil, errors.Annotate(err, "getting filesystem attachment params")
 	}
@@ -400,7 +400,7 @@ func filesystemAttachmentParams(
 
 // filesystemParams obtains the specified filesystems' parameters.
 func filesystemParams(ctx *context, tags []names.FilesystemTag) ([]storage.FilesystemParams, error) {
-	paramsResults, err := ctx.filesystemAccessor.FilesystemParams(tags)
+	paramsResults, err := ctx.config.Filesystems.FilesystemParams(tags)
 	if err != nil {
 		return nil, errors.Annotate(err, "getting filesystem params")
 	}

--- a/worker/storageprovisioner/filesystem_ops.go
+++ b/worker/storageprovisioner/filesystem_ops.go
@@ -21,7 +21,7 @@ func createFilesystems(ctx *context, ops map[names.FilesystemTag]*createFilesyst
 		filesystemParams = append(filesystemParams, op.args)
 	}
 	paramsBySource, filesystemSources, err := filesystemParamsBySource(
-		ctx.environConfig, ctx.storageDir,
+		ctx.environConfig, ctx.config.StorageDir,
 		filesystemParams, ctx.managedFilesystemSource,
 	)
 	if err != nil {
@@ -93,7 +93,7 @@ func createFilesystems(ctx *context, ops map[names.FilesystemTag]*createFilesyst
 	// by environment, so that we can "harvest" them if they're
 	// unknown. This will take care of killing filesystems that we fail
 	// to record in state.
-	errorResults, err := ctx.filesystemAccessor.SetFilesystemInfo(filesystemsFromStorage(filesystems))
+	errorResults, err := ctx.config.Filesystems.SetFilesystemInfo(filesystemsFromStorage(filesystems))
 	if err != nil {
 		return errors.Annotate(err, "publishing filesystems to state")
 	}
@@ -118,12 +118,13 @@ func attachFilesystems(ctx *context, ops map[params.MachineStorageId]*attachFile
 	for _, op := range ops {
 		args := op.args
 		if args.Path == "" {
-			args.Path = filepath.Join(ctx.storageDir, args.Filesystem.Id())
+			args.Path = filepath.Join(ctx.config.StorageDir, args.Filesystem.Id())
 		}
 		filesystemAttachmentParams = append(filesystemAttachmentParams, args)
 	}
 	paramsBySource, filesystemSources, err := filesystemAttachmentParamsBySource(
-		ctx.environConfig, ctx.storageDir,
+		ctx.environConfig,
+		ctx.config.StorageDir,
 		filesystemAttachmentParams,
 		ctx.filesystems,
 		ctx.managedFilesystemSource,
@@ -192,7 +193,7 @@ func destroyFilesystems(ctx *context, ops map[names.FilesystemTag]*destroyFilesy
 		return errors.Trace(err)
 	}
 	paramsBySource, filesystemSources, err := filesystemParamsBySource(
-		ctx.environConfig, ctx.storageDir,
+		ctx.environConfig, ctx.config.StorageDir,
 		filesystemParams, ctx.managedFilesystemSource,
 	)
 	if err != nil {
@@ -265,7 +266,7 @@ func detachFilesystems(ctx *context, ops map[params.MachineStorageId]*detachFile
 		filesystemAttachmentParams = append(filesystemAttachmentParams, op.args)
 	}
 	paramsBySource, filesystemSources, err := filesystemAttachmentParamsBySource(
-		ctx.environConfig, ctx.storageDir,
+		ctx.environConfig, ctx.config.StorageDir,
 		filesystemAttachmentParams,
 		ctx.filesystems,
 		ctx.managedFilesystemSource,
@@ -430,7 +431,7 @@ func setFilesystemAttachmentInfo(ctx *context, filesystemAttachments []storage.F
 	// provider, by environment, so that we can "harvest" them if they're
 	// unknown. This will take care of killing filesystems that we fail to
 	// record in state.
-	errorResults, err := ctx.filesystemAccessor.SetFilesystemAttachmentInfo(
+	errorResults, err := ctx.config.Filesystems.SetFilesystemAttachmentInfo(
 		filesystemAttachmentsFromStorage(filesystemAttachments),
 	)
 	if err != nil {

--- a/worker/storageprovisioner/machines.go
+++ b/worker/storageprovisioner/machines.go
@@ -21,7 +21,7 @@ func watchMachine(ctx *context, tag names.MachineTag) {
 	if ok {
 		return
 	}
-	w := newMachineWatcher(ctx.machineAccessor, tag, ctx.machineChanges)
+	w := newMachineWatcher(ctx.config.Machines, tag, ctx.machineChanges)
 	ctx.machines[tag] = w
 }
 
@@ -40,7 +40,7 @@ func refreshMachine(ctx *context, tag names.MachineTag) error {
 		delete(ctx.machines, tag)
 		return nil
 	}
-	results, err := ctx.machineAccessor.InstanceIds([]names.MachineTag{tag})
+	results, err := ctx.config.Machines.InstanceIds([]names.MachineTag{tag})
 	if err != nil {
 		return errors.Annotate(err, "getting machine instance ID")
 	}

--- a/worker/storageprovisioner/manifold.go
+++ b/worker/storageprovisioner/manifold.go
@@ -1,0 +1,62 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package storageprovisioner
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/names"
+	"github.com/juju/utils/clock"
+
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/api/storageprovisioner"
+	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/dependency"
+)
+
+// ManifoldConfig defines a storage provisioner's configuration and dependencies.
+type ManifoldConfig struct {
+	APICallerName string
+	ClockName     string
+
+	Scope      names.Tag
+	StorageDir string
+}
+
+// Manifold returns a dependency.Manifold that runs a storage provisioner.
+func Manifold(config ManifoldConfig) dependency.Manifold {
+	return dependency.Manifold{
+		Inputs: []string{config.APICallerName, config.ClockName},
+		Start: func(getResource dependency.GetResourceFunc) (worker.Worker, error) {
+
+			var clock clock.Clock
+			if err := getResource(config.ClockName, &clock); err != nil {
+				return nil, errors.Trace(err)
+			}
+			var apiCaller base.APICaller
+			if err := getResource(config.APICallerName, &apiCaller); err != nil {
+				return nil, errors.Trace(err)
+			}
+
+			api, err := storageprovisioner.NewState(apiCaller, config.Scope)
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			w, err := NewStorageProvisioner(Config{
+				Scope:       config.Scope,
+				StorageDir:  config.StorageDir,
+				Volumes:     api,
+				Filesystems: api,
+				Life:        api,
+				Environ:     api,
+				Machines:    api,
+				Status:      api,
+				Clock:       clock,
+			})
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			return w, nil
+		},
+	}
+}

--- a/worker/storageprovisioner/manifold_test.go
+++ b/worker/storageprovisioner/manifold_test.go
@@ -1,0 +1,60 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package storageprovisioner_test
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/clock"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/worker/dependency"
+	dt "github.com/juju/juju/worker/dependency/testing"
+	"github.com/juju/juju/worker/storageprovisioner"
+)
+
+type ManifoldSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&ManifoldSuite{})
+
+func (s *ManifoldSuite) TestManifold(c *gc.C) {
+	manifold := storageprovisioner.Manifold(storageprovisioner.ManifoldConfig{
+		APICallerName: "grenouille",
+		ClockName:     "bustopher",
+	})
+	c.Check(manifold.Inputs, jc.DeepEquals, []string{"grenouille", "bustopher"})
+	c.Check(manifold.Output, gc.IsNil)
+	c.Check(manifold.Start, gc.NotNil)
+	// ...Start is *not* well-tested, in common with many manifold configs.
+	// Am starting to think that tasdomas nailed it with the metrics manifolds
+	// that take constructors as config... reviewers, thoughts please?
+}
+
+func (s *ManifoldSuite) TestMissingClock(c *gc.C) {
+	manifold := storageprovisioner.Manifold(storageprovisioner.ManifoldConfig{
+		APICallerName: "api-caller",
+		ClockName:     "clock",
+	})
+	_, err := manifold.Start(dt.StubGetResource(dt.StubResources{
+		"api-caller": dt.StubResource{Output: struct{ base.APICaller }{}},
+		"clock":      dt.StubResource{Error: dependency.ErrMissing},
+	}))
+	c.Check(errors.Cause(err), gc.Equals, dependency.ErrMissing)
+}
+
+func (s *ManifoldSuite) TestMissingAPICaller(c *gc.C) {
+	manifold := storageprovisioner.Manifold(storageprovisioner.ManifoldConfig{
+		APICallerName: "api-caller",
+		ClockName:     "clock",
+	})
+	_, err := manifold.Start(dt.StubGetResource(dt.StubResources{
+		"api-caller": dt.StubResource{Error: dependency.ErrMissing},
+		"clock":      dt.StubResource{Output: struct{ clock.Clock }{}},
+	}))
+	c.Check(errors.Cause(err), gc.Equals, dependency.ErrMissing)
+}

--- a/worker/storageprovisioner/schedule.go
+++ b/worker/storageprovisioner/schedule.go
@@ -25,7 +25,7 @@ func scheduleOperations(ctx *context, ops ...scheduleOp) {
 	if len(ops) == 0 {
 		return
 	}
-	now := ctx.time.Now()
+	now := ctx.config.Clock.Now()
 	for _, op := range ops {
 		k := op.key()
 		d := op.delay()

--- a/worker/storageprovisioner/volume_events.go
+++ b/worker/storageprovisioner/volume_events.go
@@ -40,7 +40,7 @@ func volumesChanged(ctx *context, changes []string) error {
 	for _, tag := range dead {
 		volumeTags = append(volumeTags, tag.(names.VolumeTag))
 	}
-	volumeResults, err := ctx.volumeAccessor.Volumes(volumeTags)
+	volumeResults, err := ctx.config.Volumes.Volumes(volumeTags)
 	if err != nil {
 		return errors.Annotatef(err, "getting volume information")
 	}
@@ -73,7 +73,7 @@ func volumeAttachmentsChanged(ctx *context, ids []params.MachineStorageId) error
 	// Get volume information for alive and dying volume attachments, so
 	// we can attach/detach.
 	ids = append(alive, dying...)
-	volumeAttachmentResults, err := ctx.volumeAccessor.VolumeAttachments(ids)
+	volumeAttachmentResults, err := ctx.config.Volumes.VolumeAttachments(ids)
 	if err != nil {
 		return errors.Annotatef(err, "getting volume attachment information")
 	}
@@ -342,7 +342,7 @@ func processAliveVolumeAttachments(
 func volumeAttachmentParams(
 	ctx *context, ids []params.MachineStorageId,
 ) ([]storage.VolumeAttachmentParams, error) {
-	paramsResults, err := ctx.volumeAccessor.VolumeAttachmentParams(ids)
+	paramsResults, err := ctx.config.Volumes.VolumeAttachmentParams(ids)
 	if err != nil {
 		return nil, errors.Annotate(err, "getting volume attachment params")
 	}
@@ -362,7 +362,7 @@ func volumeAttachmentParams(
 
 // volumeParams obtains the specified volumes' parameters.
 func volumeParams(ctx *context, tags []names.VolumeTag) ([]storage.VolumeParams, error) {
-	paramsResults, err := ctx.volumeAccessor.VolumeParams(tags)
+	paramsResults, err := ctx.config.Volumes.VolumeParams(tags)
 	if err != nil {
 		return nil, errors.Annotate(err, "getting volume params")
 	}

--- a/worker/storageprovisioner/volume_ops.go
+++ b/worker/storageprovisioner/volume_ops.go
@@ -19,7 +19,7 @@ func createVolumes(ctx *context, ops map[names.VolumeTag]*createVolumeOp) error 
 		volumeParams = append(volumeParams, op.args)
 	}
 	paramsBySource, volumeSources, err := volumeParamsBySource(
-		ctx.environConfig, ctx.storageDir, volumeParams,
+		ctx.environConfig, ctx.config.StorageDir, volumeParams,
 	)
 	if err != nil {
 		return errors.Trace(err)
@@ -93,7 +93,7 @@ func createVolumes(ctx *context, ops map[names.VolumeTag]*createVolumeOp) error 
 	// by environment, so that we can "harvest" them if they're
 	// unknown. This will take care of killing volumes that we fail
 	// to record in state.
-	errorResults, err := ctx.volumeAccessor.SetVolumeInfo(volumesFromStorage(volumes))
+	errorResults, err := ctx.config.Volumes.SetVolumeInfo(volumesFromStorage(volumes))
 	if err != nil {
 		return errors.Annotate(err, "publishing volumes to state")
 	}
@@ -128,7 +128,7 @@ func attachVolumes(ctx *context, ops map[params.MachineStorageId]*attachVolumeOp
 		volumeAttachmentParams = append(volumeAttachmentParams, op.args)
 	}
 	paramsBySource, volumeSources, err := volumeAttachmentParamsBySource(
-		ctx.environConfig, ctx.storageDir, volumeAttachmentParams,
+		ctx.environConfig, ctx.config.StorageDir, volumeAttachmentParams,
 	)
 	if err != nil {
 		return errors.Trace(err)
@@ -194,7 +194,7 @@ func destroyVolumes(ctx *context, ops map[names.VolumeTag]*destroyVolumeOp) erro
 		return errors.Trace(err)
 	}
 	paramsBySource, volumeSources, err := volumeParamsBySource(
-		ctx.environConfig, ctx.storageDir, volumeParams,
+		ctx.environConfig, ctx.config.StorageDir, volumeParams,
 	)
 	if err != nil {
 		return errors.Trace(err)
@@ -266,7 +266,7 @@ func detachVolumes(ctx *context, ops map[params.MachineStorageId]*detachVolumeOp
 		volumeAttachmentParams = append(volumeAttachmentParams, op.args)
 	}
 	paramsBySource, volumeSources, err := volumeAttachmentParamsBySource(
-		ctx.environConfig, ctx.storageDir, volumeAttachmentParams,
+		ctx.environConfig, ctx.config.StorageDir, volumeAttachmentParams,
 	)
 	if err != nil {
 		return errors.Trace(err)
@@ -415,7 +415,7 @@ func setVolumeAttachmentInfo(ctx *context, volumeAttachments []storage.VolumeAtt
 	// provider, by environment, so that we can "harvest" them if they're
 	// unknown. This will take care of killing volumes that we fail to
 	// record in state.
-	errorResults, err := ctx.volumeAccessor.SetVolumeAttachmentInfo(
+	errorResults, err := ctx.config.Volumes.SetVolumeAttachmentInfo(
 		volumeAttachmentsFromStorage(volumeAttachments),
 	)
 	if err != nil {


### PR DESCRIPTION
In `worker/storageprovisioner`, added `Config` type with `Validate` method, now passed to `NewStorageProvisioner`; which now checks config and can return an error, and otherwise passes the `Config` on directly to the `storageProvisioner` and `context` implementation types, allowing us to drop a lot of fields from both. Also added `Manifold` and `ManifoldConfig` for future use with a dependency engine.

Removed panic from `api/storageprovisioner.NewState`, which can now return an error; dropped the `StorageProvisioner` method from the `api.Conn` interface and implementation. (Does anyone know why we have all these specific-facade-access methods on the client? doesn't it have enough to worry about already?)

Various associated changes to existing tests in above packages, and in `cmd/jujud/agent`.



(Review request: http://reviews.vapour.ws/r/3034/)