### PR TITLE
cmd/jujud/agent: basic dependency engine infrastructure for machine agent

### DIFF
--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -42,6 +42,7 @@ import (
 	"github.com/juju/juju/apiserver"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cert"
+	"github.com/juju/juju/cmd/jujud/agent/machine"
 	"github.com/juju/juju/cmd/jujud/reboot"
 	cmdutil "github.com/juju/juju/cmd/jujud/util"
 	"github.com/juju/juju/container"
@@ -74,6 +75,7 @@ import (
 	"github.com/juju/juju/worker/cleaner"
 	"github.com/juju/juju/worker/conv2state"
 	"github.com/juju/juju/worker/dblogpruner"
+	"github.com/juju/juju/worker/dependency"
 	"github.com/juju/juju/worker/deployer"
 	"github.com/juju/juju/worker/diskmanager"
 	"github.com/juju/juju/worker/envworkermanager"
@@ -447,6 +449,7 @@ func (a *MachineAgent) Run(*cmd.Context) error {
 	if err := a.createJujuRun(agentConfig.DataDir()); err != nil {
 		return fmt.Errorf("cannot create juju run symlink: %v", err)
 	}
+	a.runner.StartWorker("engine", a.createEngine)
 	a.runner.StartWorker("api", a.APIWorker)
 	a.runner.StartWorker("statestarter", a.newStateStarterWorker)
 	a.runner.StartWorker("termination", func() (worker.Worker, error) {
@@ -469,6 +472,29 @@ func (a *MachineAgent) Run(*cmd.Context) error {
 	err = cmdutil.AgentDone(logger, err)
 	a.tomb.Kill(err)
 	return err
+}
+
+func (a *MachineAgent) createEngine() (worker.Worker, error) {
+	config := dependency.EngineConfig{
+		IsFatal:     cmdutil.IsFatal,
+		WorstError:  cmdutil.MoreImportantError,
+		ErrorDelay:  3 * time.Second,
+		BounceDelay: 10 * time.Millisecond,
+	}
+	engine, err := dependency.NewEngine(config)
+	if err != nil {
+		return nil, err
+	}
+	manifolds := machine.Manifolds(machine.ManifoldsConfig{
+		Agent: agent.APIHostPortsSetter{a},
+	})
+	if err := dependency.Install(engine, manifolds); err != nil {
+		if err := worker.Stop(engine); err != nil {
+			logger.Errorf("while stopping engine with bad manifolds: %v", err)
+		}
+		return nil, err
+	}
+	return engine, nil
 }
 
 func (a *MachineAgent) executeRebootOrShutdown(action params.RebootAction) error {

--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -1,0 +1,34 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package machine
+
+import (
+	coreagent "github.com/juju/juju/agent"
+	"github.com/juju/juju/worker/agent"
+	"github.com/juju/juju/worker/dependency"
+)
+
+// ManifoldsConfig allows specialisation of the result of Manifolds.
+type ManifoldsConfig struct {
+
+	// Agent contains the agent that will be wrapped and made available to
+	// its dependencies via a dependency.Engine.
+	Agent coreagent.Agent
+}
+
+// Manifolds returns a set of co-configured manifolds covering the
+// various responsibilities of a machine agent.
+//
+// Thou Shalt Not Use String Literals In This Function. Or Else.
+func Manifolds(config ManifoldsConfig) dependency.Manifolds {
+	return dependency.Manifolds{
+		// The agent manifold references the enclosing agent, and is the
+		// foundation stone on which most other manifolds ultimately depend.
+		agentName: agent.Manifold(config.Agent),
+	}
+}
+
+const (
+	agentName = "agent"
+)

--- a/cmd/jujud/agent/machine/manifolds_test.go
+++ b/cmd/jujud/agent/machine/manifolds_test.go
@@ -1,0 +1,45 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package machine_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/agent"
+	"github.com/juju/juju/cmd/jujud/agent/machine"
+	"github.com/juju/juju/testing"
+)
+
+type ManifoldsSuite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&ManifoldsSuite{})
+
+func (s *ManifoldsSuite) TestStartFuncs(c *gc.C) {
+	manifolds := machine.Manifolds(machine.ManifoldsConfig{
+		Agent: fakeAgent{},
+	})
+	for name, manifold := range manifolds {
+		c.Logf("checking %q manifold", name)
+		c.Check(manifold.Start, gc.NotNil)
+	}
+}
+
+func (s *ManifoldsSuite) TestManifoldNames(c *gc.C) {
+	manifolds := machine.Manifolds(machine.ManifoldsConfig{})
+	keys := make([]string, 0, len(manifolds))
+	for k := range manifolds {
+		keys = append(keys, k)
+	}
+	expectedKeys := []string{
+		"agent",
+	}
+	c.Assert(expectedKeys, jc.SameContents, keys)
+}
+
+type fakeAgent struct {
+	agent.Agent
+}

--- a/cmd/jujud/agent/machine/package_test.go
+++ b/cmd/jujud/agent/machine/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package machine_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/worker/gate/manifold.go
+++ b/worker/gate/manifold.go
@@ -15,7 +15,7 @@ import (
 
 // Manifold returns a dependency.Manifold that wraps a single channel, shared
 // across all workers returned by the start func; it can be used to synchronize
-// operations acrosss manifolds that lack direct dependency relationships.
+// operations across manifolds that lack direct dependency relationships.
 //
 // The output func accepts an out pointer to either an Unlocker or a Waiter.
 func Manifold() dependency.Manifold {


### PR DESCRIPTION
The engine runs about only has the trivial "agent" manifold running in it at this stage.

Already reviewed here: http://reviews.vapour.ws/r/3028/ (originally proposed against master instead of the feature branch)


(Review request: http://reviews.vapour.ws/r/3035/)