### PR TITLE
cmd/jujud/agent: run termination worker under the dependency engine

### DIFF
--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -99,7 +99,6 @@ import (
 	"github.com/juju/juju/worker/singular"
 	"github.com/juju/juju/worker/statushistorypruner"
 	"github.com/juju/juju/worker/storageprovisioner"
-	"github.com/juju/juju/worker/terminationworker"
 	"github.com/juju/juju/worker/toolsversionchecker"
 	"github.com/juju/juju/worker/txnpruner"
 	"github.com/juju/juju/worker/upgrader"
@@ -452,9 +451,6 @@ func (a *MachineAgent) Run(*cmd.Context) error {
 	a.runner.StartWorker("engine", a.createEngine)
 	a.runner.StartWorker("api", a.APIWorker)
 	a.runner.StartWorker("statestarter", a.newStateStarterWorker)
-	a.runner.StartWorker("termination", func() (worker.Worker, error) {
-		return terminationworker.NewWorker(), nil
-	})
 
 	// At this point, all workers will have been configured to start
 	close(a.workersStarted)

--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -7,6 +7,7 @@ import (
 	coreagent "github.com/juju/juju/agent"
 	"github.com/juju/juju/worker/agent"
 	"github.com/juju/juju/worker/dependency"
+	"github.com/juju/juju/worker/terminationworker"
 )
 
 // ManifoldsConfig allows specialisation of the result of Manifolds.
@@ -26,9 +27,16 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 		// The agent manifold references the enclosing agent, and is the
 		// foundation stone on which most other manifolds ultimately depend.
 		agentName: agent.Manifold(config.Agent),
+
+		// The termination worker returns ErrTerminateAgent if a
+		// termination signal is received by the process it's running
+		// in. It has no inputs and its only output is the error it
+		// returns.
+		terminationName: terminationworker.Manifold(),
 	}
 }
 
 const (
-	agentName = "agent"
+	agentName       = "agent"
+	terminationName = "termination"
 )

--- a/cmd/jujud/agent/machine/manifolds_test.go
+++ b/cmd/jujud/agent/machine/manifolds_test.go
@@ -36,6 +36,7 @@ func (s *ManifoldsSuite) TestManifoldNames(c *gc.C) {
 	}
 	expectedKeys := []string{
 		"agent",
+		"termination",
 	}
 	c.Assert(expectedKeys, jc.SameContents, keys)
 }

--- a/worker/terminationworker/manifold.go
+++ b/worker/terminationworker/manifold.go
@@ -1,0 +1,19 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package terminationworker
+
+import (
+	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/dependency"
+)
+
+// Manifold returns a manifold whose worker returns ErrTerminateAgent
+// if a termination signal is received by the process it's running in.
+func Manifold() dependency.Manifold {
+	return dependency.Manifold{
+		Start: func(dependency.GetResourceFunc) (worker.Worker, error) {
+			return NewWorker(), nil
+		},
+	}
+}

--- a/worker/terminationworker/worker_test.go
+++ b/worker/terminationworker/worker_test.go
@@ -37,8 +37,8 @@ func (s *TerminationWorkerSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *TerminationWorkerSuite) TearDownTest(c *gc.C) {
-	close(s.c)
 	signal.Stop(s.c)
+	close(s.c)
 	s.BaseSuite.TearDownTest(c)
 }
 


### PR DESCRIPTION
... and a trivial test fix.

(Review request: http://reviews.vapour.ws/r/3036/)