### PR TITLE
cmd/jujud/agent/machine: start using api-caller

### DIFF
--- a/cmd/jujud/agent/machine/manifolds_test.go
+++ b/cmd/jujud/agent/machine/manifolds_test.go
@@ -37,6 +37,8 @@ func (s *ManifoldsSuite) TestManifoldNames(c *gc.C) {
 	expectedKeys := []string{
 		"agent",
 		"termination",
+		"api-caller",
+		"api-info-gate",
 	}
 	c.Assert(expectedKeys, jc.SameContents, keys)
 }


### PR DESCRIPTION
The api-caller manifold is used with the dependency engine to maintain an API connection. Many other manifolds will depend on it.

This change means that the machine agent is making an extra API connection which it wasn't before. The agent will return to maintaining just 1 API connection once the dependency engine conversion is completed and the old "api" worker is removed.

(Review request: http://reviews.vapour.ws/r/3037/)