### PR TITLE
state: added NoTail to LogTailerParams

### DIFF
--- a/state/logs.go
+++ b/state/logs.go
@@ -140,6 +140,7 @@ type LogTailerParams struct {
 	StartTime     time.Time
 	MinLevel      loggo.Level
 	InitialLines  int
+	NoTail        bool
 	IncludeEntity []string
 	ExcludeEntity []string
 	IncludeModule []string
@@ -222,6 +223,10 @@ func (t *logTailer) loop() error {
 	err := t.processCollection()
 	if err != nil {
 		return errors.Trace(err)
+	}
+
+	if t.params.NoTail {
+		return nil
 	}
 
 	err = t.tailOplog()


### PR DESCRIPTION
Setting NoTail makes the tailer stop as soon as the logs collection has been read, without consulting the oplog. This is required for adding a "no tail" feature to the /logs API and for an in-development utility for dumping logs directly out of the database.

(Review request: http://reviews.vapour.ws/r/3054/)