### PR TITLE
show-saas cli

### DIFF
--- a/api/crossmodel/client.go
+++ b/api/crossmodel/client.go
@@ -37,3 +37,13 @@ func (c *Client) Offer(service string, endpoints []string, url string, users []s
 	}
 	return out.Results, nil
 }
+
+// Show returns SAAS endpoints details for a given URL.
+func (c *Client) Show(url string) (params.SAASDetailsResult, error) {
+	found := params.SAASDetailsResult{}
+	filter := params.SAASSearchFilter{URL: url}
+	if err := c.facade.FacadeCall("Show", filter, &found); err != nil {
+		return params.SAASDetailsResult{}, errors.Trace(err)
+	}
+	return found, nil
+}

--- a/apiserver/crossmodel/crossmodel_test.go
+++ b/apiserver/crossmodel/crossmodel_test.go
@@ -19,6 +19,12 @@ type crossmodelSuite struct {
 
 var _ = gc.Suite(&crossmodelSuite{})
 
+func (s *crossmodelSuite) SetUpTest(c *gc.C) {
+	s.baseCrossmodelSuite.SetUpTest(c)
+
+	crossmodel.TempPlaceholder = make(map[names.ServiceTag]crossmodel.Offer)
+}
+
 func (s *crossmodelSuite) TestOffer(c *gc.C) {
 	serviceName := names.NewServiceTag("test")
 	one := params.CrossModelOffer{serviceName.String(), nil, "", nil}
@@ -33,4 +39,40 @@ func (s *crossmodelSuite) TestOffer(c *gc.C) {
 	offer, err := apicrossmodel.ParseOffer(one)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(crossmodel.TempPlaceholder[serviceName], gc.DeepEquals, offer)
+}
+
+func (s *crossmodelSuite) TestShow(c *gc.C) {
+	tag := names.NewServiceTag("test")
+	url := "local:/u/fred/prod/hosted-db2"
+	anOffer := crossmodel.NewOffer(tag, nil, url, nil)
+
+	crossmodel.TempPlaceholder[tag] = anOffer
+
+	found, err := s.api.Show(params.SAASSearchFilter{URL: url})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(found, gc.DeepEquals, params.SAASDetailsResult{Service: tag.String()})
+}
+
+func (s *crossmodelSuite) TestShowNotFound(c *gc.C) {
+	url := "local:/u/fred/prod/hosted-db2"
+
+	found, err := s.api.Show(params.SAASSearchFilter{URL: url})
+	c.Assert(err, gc.ErrorMatches, `endpoints with url "local:/u/fred/prod/hosted-db2" not found`)
+	c.Assert(found, gc.DeepEquals, params.SAASDetailsResult{})
+}
+
+func (s *crossmodelSuite) TestShowFoundMultiple(c *gc.C) {
+	url := "local:/u/fred/prod/hosted-db2"
+
+	tag := names.NewServiceTag("test")
+	anOffer := crossmodel.NewOffer(tag, nil, url, nil)
+	tag2 := names.NewServiceTag("testAgain")
+	anOffer2 := crossmodel.NewOffer(tag2, nil, url, nil)
+
+	crossmodel.TempPlaceholder[tag] = anOffer
+	crossmodel.TempPlaceholder[tag2] = anOffer2
+
+	found, err := s.api.Show(params.SAASSearchFilter{URL: url})
+	c.Assert(err, gc.ErrorMatches, `expected to find one result for url "local:/u/fred/prod/hosted-db2" but found 2`)
+	c.Assert(found, gc.DeepEquals, params.SAASDetailsResult{})
 }

--- a/apiserver/params/crossmodel.go
+++ b/apiserver/params/crossmodel.go
@@ -11,7 +11,7 @@ type CrossModelOffer struct {
 	// Endpoints list of service's endpoints that are being offered.
 	Endpoints []string `json:"endpoints"`
 
-	// URL is the location where these endpoitns will be accessible from.
+	// URL is the location where these endpoints will be accessible from.
 	URL string `json:"url"`
 
 	// Users is the list of user tags that are given permission to these endpoints.
@@ -21,4 +21,23 @@ type CrossModelOffer struct {
 // CrossModelOffers holds cross model relations offers..
 type CrossModelOffers struct {
 	Offers []CrossModelOffer `json:"offers"`
+}
+
+// SAASDetailsResult holds information about SAAS endpoints.
+type SAASDetailsResult struct {
+	// Service has service's tag.
+	Service string `json:"service"`
+
+	// Endpoints list of service's endpoints that are being offered.
+	Endpoints []string `json:"endpoints"`
+
+	// Desc is the user entered description.
+	Description string `json:"description,omitempty"`
+}
+
+// SAASSearchFilter holds filter used for show, find and list
+// operations for cross model relations.
+type SAASSearchFilter struct {
+	// URL has Juju location for offered service.
+	URL string `json:"url"`
 }

--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -120,6 +120,7 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 	r.Register(newDeployCommand())
 	r.Register(newAddRelationCommand())
 	r.Register(crossmodel.NewOfferCommand())
+	r.Register(crossmodel.NewShowSAASEndpointCommand())
 
 	// Destruction commands.
 	r.Register(newRemoveRelationCommand())

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -56,6 +56,10 @@ func offerHelpText() string {
 	return cmdtesting.HelpText(crossmodel.NewOfferCommand(), "juju offer")
 }
 
+func showSAASHelpText() string {
+	return cmdtesting.HelpText(crossmodel.NewShowSAASEndpointCommand(), "juju show-saas")
+}
+
 func (s *MainSuite) TestRunMain(c *gc.C) {
 	// The test array structure needs to be inline here as some of the
 	// expected values below use deployHelpText().  This constructs the deploy
@@ -177,6 +181,16 @@ func (s *MainSuite) TestRunMain(c *gc.C) {
 		args:    []string{"offer"},
 		code:    0,
 		out:     "error: an offer must at least specify service endpoint\n",
+	}, {
+		summary: "check show-saas command has help",
+		args:    []string{"show-saas", "-h"},
+		code:    0,
+		out:     showSAASHelpText(),
+	}, {
+		summary: "check show-saas command registered properly",
+		args:    []string{"show-saas"},
+		code:    0,
+		out:     "error: must specify endpoint URL\n",
 	},
 	} {
 		c.Logf("test %d: %s", i, t.summary)
@@ -258,6 +272,7 @@ var commandNames = []string{
 	"set-constraints",
 	"set-env", // alias for set-environment
 	"set-environment",
+	"show-saas",
 	"space",
 	"ssh",
 	"stat", // alias for status

--- a/cmd/juju/crossmodel/crossmodel.go
+++ b/cmd/juju/crossmodel/crossmodel.go
@@ -6,9 +6,12 @@
 package crossmodel
 
 import (
+	"github.com/juju/errors"
 	"github.com/juju/loggo"
+	"github.com/juju/names"
 
 	"github.com/juju/juju/api/crossmodel"
+	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/envcmd"
 )
 
@@ -27,4 +30,45 @@ func (c *CrossModelCommandBase) NewCrossModelAPI() (*crossmodel.Client, error) {
 		return nil, err
 	}
 	return crossmodel.NewClient(root), nil
+}
+
+// SAASEndpoint defines the serialization behaviour of SAAS endpoint details.
+type SAASEndpoint struct {
+	// Service has service name.
+	Service string `yaml:"service" json:"service"`
+
+	// Endpoints list of SAAS endpoints.
+	Endpoints []string `yaml:"endpoints" json:"endpoints"`
+
+	// Desc is the user entered description.
+	Desc string `yaml:"desc,omitempty" json:"desc,omitempty"`
+}
+
+// formatEndpoints takes any number of api-formatted SAAS endpoints and
+// creates a collection of ui-formatted endpoints.
+func formatEndpoints(apiEndpoints ...params.SAASDetailsResult) ([]SAASEndpoint, error) {
+	if len(apiEndpoints) == 0 {
+		return nil, nil
+	}
+	output := make([]SAASEndpoint, len(apiEndpoints))
+	for i, one := range apiEndpoints {
+		serviceName, err := getServiceNameFromTag(one.Service)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		output[i].Service = serviceName
+		output[i].Endpoints = one.Endpoints
+		if one.Description != "" {
+			output[i].Desc = one.Description
+		}
+	}
+	return output, nil
+}
+
+func getServiceNameFromTag(serviceTag string) (string, error) {
+	tag, err := names.ParseServiceTag(serviceTag)
+	if err != nil {
+		return "", errors.Annotatef(err, "could not parse service tag %q", serviceTag)
+	}
+	return tag.Name, nil
 }

--- a/cmd/juju/crossmodel/export_test.go
+++ b/cmd/juju/crossmodel/export_test.go
@@ -13,3 +13,8 @@ func NewOfferCommandForTest(api OfferAPI) cmd.Command {
 	cmd := &offerCommand{api: api}
 	return envcmd.Wrap(cmd)
 }
+
+func NewShowSAASEndpointCommandForTest(api ShowAPI) cmd.Command {
+	cmd := &showCommand{api: api}
+	return envcmd.Wrap(cmd)
+}

--- a/cmd/juju/crossmodel/formatters.go
+++ b/cmd/juju/crossmodel/formatters.go
@@ -1,0 +1,49 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package crossmodel
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/juju/errors"
+)
+
+// formatTabular returns a tabular summary of SAAS endpoints or
+// errors out if parameter is not of expected type.
+func formatTabular(value interface{}) ([]byte, error) {
+	endpoints, ok := value.([]SAASEndpoint)
+	if !ok {
+		return nil, errors.Errorf("expected value of type %T, got %T", endpoints, value)
+	}
+	return formatSAASEndpointsTabular(endpoints)
+}
+
+// formatSAASEndpointsTabular returns a tabular summary of SAAS endpoints.
+func formatSAASEndpointsTabular(all []SAASEndpoint) ([]byte, error) {
+	var out bytes.Buffer
+	const (
+		// To format things into columns.
+		minwidth = 0
+		tabwidth = 1
+		padding  = 2
+		padchar  = ' '
+		flags    = 0
+	)
+	tw := tabwriter.NewWriter(&out, minwidth, tabwidth, padding, padchar, flags)
+	print := func(values ...string) {
+		fmt.Fprintln(tw, strings.Join(values, "\t"))
+	}
+
+	print("SAAS", "INTERFACES", "DESCRIPTION")
+
+	for _, one := range all {
+		print(one.Service, strings.Join(one.Endpoints, ","), one.Desc)
+	}
+	tw.Flush()
+
+	return out.Bytes(), nil
+}

--- a/cmd/juju/crossmodel/show.go
+++ b/cmd/juju/crossmodel/show.go
@@ -1,0 +1,113 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package crossmodel
+
+import (
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+	"launchpad.net/gnuflag"
+
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/envcmd"
+	"github.com/juju/juju/crossmodel"
+)
+
+const showCommandDoc = `
+Show extended information about SAAS endpoint, an offered cross model relations endpoint.
+
+This command is aimed for a user who wants to see more detail about what’s offered behind a particular URL.
+The details are shown if the user has read permission to the directory containing the endpoint.
+
+options:
+-o, --output (= "")
+   specify an output file
+--format (= tabular)
+   specify output format (tabular|json|yaml)
+
+Examples:
+   $ juju show-saas local:/u/fred/prod/db2
+   $ juju show-saas vendor:/u/ibm/hosted-db2
+`
+
+type showCommand struct {
+	CrossModelCommandBase
+
+	url string
+	out cmd.Output
+	api ShowAPI
+}
+
+// NewShowSAASEndpointCommand constructs command that
+// allows to show details of SAAS endpoint.
+func NewShowSAASEndpointCommand() cmd.Command {
+	return envcmd.Wrap(&showCommand{})
+}
+
+// Init implements Command.Init.
+func (c *showCommand) Init(args []string) (err error) {
+	if len(args) != 1 {
+		return errors.New("must specify endpoint URL")
+	}
+
+	url := args[0]
+	if !crossmodel.IsValidURL(url) {
+		return errors.NotValidf("endpoint url %q", url)
+	}
+	c.url = url
+	return nil
+}
+
+// Info implements Command.Info.
+func (c *showCommand) Info() *cmd.Info {
+	return &cmd.Info{
+		Name:    "show-saas",
+		Purpose: "shows SAAS endpoints details",
+		Doc:     showCommandDoc,
+	}
+}
+
+// SetFlags implements Command.SetFlags.
+func (c *showCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.CrossModelCommandBase.SetFlags(f)
+	c.out.AddFlags(f, "tabular", map[string]cmd.Formatter{
+		"yaml":    cmd.FormatYaml,
+		"json":    cmd.FormatJson,
+		"tabular": formatTabular,
+	})
+}
+
+// Run implements Command.Run.
+func (c *showCommand) Run(ctx *cmd.Context) (err error) {
+	if c.api == nil {
+		api, err := getShowAPI(c)
+		if err != nil {
+			return err
+		}
+		defer api.Close()
+		c.api = api
+	}
+
+	found, err := c.api.Show(c.url)
+	if err != nil {
+		return err
+	}
+
+	output, err := formatEndpoints(found)
+	if err != nil {
+		return err
+	}
+	return c.out.Write(ctx, output)
+}
+
+// ShowAPI defines the API methods that cross model show command uses.
+type ShowAPI interface {
+	Close() error
+	Show(url string) (params.SAASDetailsResult, error)
+}
+
+var getShowAPI = (*showCommand).getShowAPI
+
+func (c *showCommand) getShowAPI() (ShowAPI, error) {
+	return c.NewCrossModelAPI()
+}

--- a/cmd/juju/crossmodel/show_test.go
+++ b/cmd/juju/crossmodel/show_test.go
@@ -1,0 +1,105 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package crossmodel_test
+
+import (
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/juju/crossmodel"
+	"github.com/juju/juju/testing"
+)
+
+type showSuite struct {
+	BaseCrossModelSuite
+	mockAPI *mockShowAPI
+}
+
+var _ = gc.Suite(&showSuite{})
+
+func (s *showSuite) SetUpTest(c *gc.C) {
+	s.BaseCrossModelSuite.SetUpTest(c)
+
+	s.mockAPI = &mockShowAPI{serviceTag: "service-hosted-db2"}
+}
+
+func (s *showSuite) runShow(c *gc.C, args ...string) (*cmd.Context, error) {
+	return testing.RunCommand(c, crossmodel.NewShowSAASEndpointCommandForTest(s.mockAPI), args...)
+}
+
+func (s *showSuite) TestShowNoUrl(c *gc.C) {
+	s.assertShowError(c, nil, ".*must specify endpoint URL.*")
+}
+
+func (s *showSuite) TestShowApiError(c *gc.C) {
+	s.mockAPI.msg = "fail"
+	s.assertShowError(c, []string{"local:/u/fred/prod/db2"}, ".*fail.*")
+}
+
+func (s *showSuite) TestShowConversionError(c *gc.C) {
+	s.mockAPI.serviceTag = "invalid_tag"
+	s.assertShowError(c, []string{"local:/u/fred/prod/db2"}, ".*could not parse service tag.*")
+}
+
+func (s *showSuite) TestShowYaml(c *gc.C) {
+	s.assertShow(
+		c,
+		[]string{"local:/u/fred/prod/db2", "--format", "yaml"},
+		`
+- service: hosted-db2
+  endpoints:
+  - db2
+  - log
+  desc: IBM DB2 Express Server Edition is an entry level database system
+`[1:],
+	)
+}
+
+func (s *showSuite) TestShowTabular(c *gc.C) {
+	s.assertShow(
+		c,
+		[]string{"local:/u/fred/prod/db2", "--format", "tabular"},
+		`
+SAAS        INTERFACES  DESCRIPTION
+hosted-db2  db2,log     IBM DB2 Express Server Edition is an entry level database system
+
+`[1:],
+	)
+}
+
+func (s *showSuite) assertShow(c *gc.C, args []string, expected string) {
+	context, err := s.runShow(c, args...)
+	c.Assert(err, jc.ErrorIsNil)
+
+	obtained := testing.Stdout(context)
+	c.Assert(obtained, gc.Matches, expected)
+}
+
+func (s *showSuite) assertShowError(c *gc.C, args []string, expected string) {
+	_, err := s.runShow(c, args...)
+	c.Assert(err, gc.ErrorMatches, expected)
+}
+
+type mockShowAPI struct {
+	msg, serviceTag string
+}
+
+func (s mockShowAPI) Close() error {
+	return nil
+}
+
+func (s mockShowAPI) Show(url string) (params.SAASDetailsResult, error) {
+	if s.msg != "" {
+		return params.SAASDetailsResult{}, errors.New(s.msg)
+	}
+
+	return params.SAASDetailsResult{
+		Service:     s.serviceTag,
+		Endpoints:   []string{"db2", "log"},
+		Description: "IBM DB2 Express Server Edition is an entry level database system",
+	}, nil
+}

--- a/crossmodel/interface.go
+++ b/crossmodel/interface.go
@@ -5,17 +5,30 @@ package crossmodel
 
 import "github.com/juju/names"
 
-// Offer holds information about service's offer.
-type Offer struct {
+// BaseDetails holds information about offered service and its endpoints.
+type BaseDetails interface {
 	// Service has service's tag.
-	Service names.ServiceTag
+	Service() names.ServiceTag
 
 	// Endpoints list of service's endpoints that are being offered.
-	Endpoints []string
+	Endpoints() []string
+}
 
-	// URL is the location where these endpoitns will be accessible from.
-	URL string
+// Offer holds information about service's offer.
+type Offer interface {
+	BaseDetails
+
+	// URL is the location where these endpoints will be accessible from.
+	URL() string
 
 	// Users is the list of user tags that are given permission to these endpoints.
-	Users []names.UserTag
+	Users() []names.UserTag
+}
+
+// ServiceDetails holds additional information about offered service and its endpoints.
+type ServiceDetails interface {
+	BaseDetails
+
+	// Description is description of this service.
+	Description() string
 }

--- a/crossmodel/offer.go
+++ b/crossmodel/offer.go
@@ -5,6 +5,8 @@ package crossmodel
 
 import (
 	"github.com/juju/names"
+
+	"github.com/juju/juju/apiserver/params"
 )
 
 // ExportOffer prepares service endpoints for consumption.
@@ -12,8 +14,72 @@ func ExportOffer(offer Offer) error {
 	// TODO(anastasiamac 2015-11-02) needs the actual implementation - this is a placeholder.
 	// actual implementation will coordinate the work:
 	// validate entities exist, access the service directory, write to state etc.
-	TempPlaceholder[offer.Service] = offer
+	TempPlaceholder[offer.Service()] = offer
 	return nil
+}
+
+// Search looks through offered services and returns the ones
+// that match speified filter.
+func Search(filter params.SAASSearchFilter) ([]ServiceDetails, error) {
+	// TODO(anastasiamac 2015-11-02) needs the actual implementation - this is a placeholder.
+
+	byURL := make(map[string][]ServiceDetails, len(TempPlaceholder))
+	for _, v := range TempPlaceholder {
+		//TODO(anastasiamac 2015-11-4) Pull description from the charm metadata
+		s := service{baseDetails{v.Service(), v.Endpoints()}, ""}
+		byURL[v.URL()] = append(byURL[v.URL()], &s)
+	}
+	return byURL[filter.URL], nil
+}
+
+type baseDetails struct {
+	service   names.ServiceTag
+	endpoints []string
+}
+
+// Service implements BaseDetails.Service.
+func (b *baseDetails) Service() names.ServiceTag {
+	return b.service
+}
+
+// Endpoints implements BaseDetails.Endpoints.
+func (b *baseDetails) Endpoints() []string {
+	return b.endpoints
+}
+
+type anOffer struct {
+	baseDetails
+	aURL  string
+	users []names.UserTag
+}
+
+func NewOffer(serviceTag names.ServiceTag, endpoints []string, URL string, users []names.UserTag) Offer {
+	offer := anOffer{
+		baseDetails{serviceTag, endpoints},
+		URL,
+		users,
+	}
+	return &offer
+}
+
+// URL implements Offer.URL.
+func (o *anOffer) URL() string {
+	return o.aURL
+}
+
+// Users implements Offer.Users.
+func (o *anOffer) Users() []names.UserTag {
+	return o.users
+}
+
+type service struct {
+	baseDetails
+	desc string
+}
+
+// Description implements ServiceDetails.Description.
+func (s *service) Description() string {
+	return s.desc
 }
 
 // START TEMP IN-MEMORY PLACEHOLDER ///////////////


### PR DESCRIPTION
For cross model relations, show-saas command fulfills this use case:

A user wants to see more detail about what’s offered behind a particular URL.

In this PR, also changed service layer to deal with interfaces.