### PR TITLE
Update undertaker worker to watch dying environ resources.

### DIFF
--- a/apiserver/client/state.go
+++ b/apiserver/client/state.go
@@ -28,7 +28,7 @@ type Unit interface {
 }
 
 // stateInterface contains the state.State methods used in this package,
-// allowing stubs to ve created for testing.
+// allowing stubs to be created for testing.
 type stateInterface interface {
 	FindEntity(names.Tag) (state.Entity, error)
 	Unit(string) (Unit, error)

--- a/worker/undertaker/export_test.go
+++ b/worker/undertaker/export_test.go
@@ -4,6 +4,5 @@
 package undertaker
 
 const (
-	RIPTime          = ripTime
-	UndertakerPeriod = undertakerPeriod
+	RIPTime = ripTime
 )


### PR DESCRIPTION
This PR updates the API client, server and undertaker worker to enable
the worker to watch for any changes to machines and services of a
dying environment - rather than polling it.

(Review request: http://reviews.vapour.ws/r/3061/)