### PR TITLE
Fix assign worker tests

### DIFF
--- a/apiserver/client/client_test.go
+++ b/apiserver/client/client_test.go
@@ -1791,20 +1791,17 @@ func (s *clientRepoSuite) TestClientServiceDeployToMachine(c *gc.C) {
 	c.Assert(charm.Meta(), gc.DeepEquals, ch.Meta())
 	c.Assert(charm.Config(), gc.DeepEquals, ch.Config())
 
-	for a := coretesting.LongAttempt.Start(); a.Next(); {
-		units, err := service.AllUnits()
-		c.Assert(err, jc.ErrorIsNil)
-		c.Assert(units, gc.HasLen, 1)
+	errs, err := s.APIState.UnitAssigner().AssignUnits([]names.UnitTag{names.NewUnitTag("service-name/0")})
+	c.Assert(errs, gc.DeepEquals, []error{nil})
+	c.Assert(err, jc.ErrorIsNil)
 
-		mid, err := units[0].AssignedMachineId()
-		if !a.HasNext() {
-			c.Assert(err, jc.ErrorIsNil)
-		} else if err != nil {
-			continue // we'll retry
-		}
-		c.Assert(mid, gc.Equals, machine.Id())
-		break
-	}
+	units, err := service.AllUnits()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(units, gc.HasLen, 1)
+
+	mid, err := units[0].AssignedMachineId()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(mid, gc.Equals, machine.Id())
 }
 
 func (s *clientSuite) TestClientServiceDeployToMachineNotFound(c *gc.C) {

--- a/cmd/juju/commands/deploy_test.go
+++ b/cmd/juju/commands/deploy_test.go
@@ -287,17 +287,16 @@ func (s *DeploySuite) TestNumUnitsSubordinate(c *gc.C) {
 func (s *DeploySuite) assertForceMachine(c *gc.C, machineId string) {
 	svc, err := s.State.Service("portlandia")
 	c.Assert(err, jc.ErrorIsNil)
+
+	// manually run staged assignments
+	errs, err := s.APIState.UnitAssigner().AssignUnits([]names.UnitTag{names.NewUnitTag("portlandia/0")})
+	c.Assert(errs, gc.DeepEquals, []error{nil})
+	c.Assert(err, jc.ErrorIsNil)
+
 	units, err := svc.AllUnits()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(units, gc.HasLen, 1)
 
-	// manually run staged assignments
-	errs, err := s.APIState.UnitAssigner().AssignUnits([]names.UnitTag{units[0].UnitTag()})
-	c.Assert(errs, gc.DeepEquals, []error{nil})
-	c.Assert(err, jc.ErrorIsNil)
-
-	// refresh units so we get the assigned machines with them.
-	units, err = svc.AllUnits()
 	mid, err := units[0].AssignedMachineId()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(mid, gc.Equals, machineId)

--- a/cmd/juju/commands/deploy_test.go
+++ b/cmd/juju/commands/deploy_test.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/juju/errors"
+	"github.com/juju/names"
 	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
@@ -248,19 +249,17 @@ func (s *DeploySuite) TestPlacement(c *gc.C) {
 	svc, err := s.State.Service("dummy")
 	c.Assert(err, jc.ErrorIsNil)
 
-	for a := coretesting.LongAttempt.Start(); a.Next(); {
-		units, err := svc.AllUnits()
-		c.Assert(err, jc.ErrorIsNil)
-		c.Assert(units, gc.HasLen, 1)
-		mid, err := units[0].AssignedMachineId()
-		if !a.HasNext() {
-			c.Assert(err, jc.ErrorIsNil)
-		} else if err != nil {
-			continue
-		}
-		c.Assert(mid, gc.Not(gc.Equals), machine.Id())
-		break
-	}
+	// manually run staged assignments
+	errs, err := s.APIState.UnitAssigner().AssignUnits([]names.UnitTag{names.NewUnitTag("dummy/0")})
+	c.Assert(errs, gc.DeepEquals, []error{nil})
+	c.Assert(err, jc.ErrorIsNil)
+
+	units, err := svc.AllUnits()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(units, gc.HasLen, 1)
+	mid, err := units[0].AssignedMachineId()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(mid, gc.Not(gc.Equals), machine.Id())
 }
 
 func (s *DeploySuite) TestSubordinateConstraints(c *gc.C) {
@@ -288,20 +287,20 @@ func (s *DeploySuite) TestNumUnitsSubordinate(c *gc.C) {
 func (s *DeploySuite) assertForceMachine(c *gc.C, machineId string) {
 	svc, err := s.State.Service("portlandia")
 	c.Assert(err, jc.ErrorIsNil)
+	units, err := svc.AllUnits()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(units, gc.HasLen, 1)
 
-	for a := coretesting.LongAttempt.Start(); a.Next(); {
-		units, err := svc.AllUnits()
-		c.Assert(err, jc.ErrorIsNil)
-		c.Assert(units, gc.HasLen, 1)
-		mid, err := units[0].AssignedMachineId()
-		if !a.HasNext() {
-			c.Assert(err, jc.ErrorIsNil)
-		} else if err != nil {
-			continue
-		}
-		c.Assert(mid, gc.Equals, machineId)
-		break
-	}
+	// manually run staged assignments
+	errs, err := s.APIState.UnitAssigner().AssignUnits([]names.UnitTag{units[0].UnitTag()})
+	c.Assert(errs, gc.DeepEquals, []error{nil})
+	c.Assert(err, jc.ErrorIsNil)
+
+	// refresh units so we get the assigned machines with them.
+	units, err = svc.AllUnits()
+	mid, err := units[0].AssignedMachineId()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(mid, gc.Equals, machineId)
 }
 
 func (s *DeploySuite) TestForceMachine(c *gc.C) {


### PR DESCRIPTION
This removes the ugly code in JujuconnSuite that was running the unit assigner, and instead just manually assigns machines as needed during testing via the unitassigner's API .

(Review request: http://reviews.vapour.ws/r/3068/)