### PR TITLE
Lxd provider build flags

### DIFF
--- a/container/factory/factory_go12.go
+++ b/container/factory/factory_go12.go
@@ -1,6 +1,8 @@
 // Copyright 2013 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// +build !go1.3
+
 // This package exists solely to avoid circular imports.
 
 package factory
@@ -11,7 +13,6 @@ import (
 	"github.com/juju/juju/container"
 	"github.com/juju/juju/container/kvm"
 	"github.com/juju/juju/container/lxc"
-	"github.com/juju/juju/container/lxd"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/storage/looputil"
 )
@@ -23,8 +24,6 @@ func NewContainerManager(forType instance.ContainerType, conf container.ManagerC
 	switch forType {
 	case instance.LXC:
 		return lxc.NewContainerManager(conf, imageURLGetter, looputil.NewLoopDeviceManager())
-	case instance.LXD:
-		return lxd.NewContainerManager(conf)
 	case instance.KVM:
 		return kvm.NewContainerManager(conf)
 	}

--- a/container/factory/factory_go13.go
+++ b/container/factory/factory_go13.go
@@ -1,0 +1,34 @@
+// Copyright 2013 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// +build go1.3
+
+// This package exists solely to avoid circular imports.
+
+package factory
+
+import (
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/container"
+	"github.com/juju/juju/container/kvm"
+	"github.com/juju/juju/container/lxc"
+	"github.com/juju/juju/container/lxd"
+	"github.com/juju/juju/instance"
+	"github.com/juju/juju/storage/looputil"
+)
+
+// NewContainerManager creates the appropriate container.Manager for the
+// specified container type.
+func NewContainerManager(forType instance.ContainerType, conf container.ManagerConfig, imageURLGetter container.ImageURLGetter,
+) (container.Manager, error) {
+	switch forType {
+	case instance.LXC:
+		return lxc.NewContainerManager(conf, imageURLGetter, looputil.NewLoopDeviceManager())
+	case instance.LXD:
+		return lxd.NewContainerManager(conf)
+	case instance.KVM:
+		return kvm.NewContainerManager(conf)
+	}
+	return nil, errors.Errorf("unknown container type: %q", forType)
+}

--- a/container/factory/factory_go13_test.go
+++ b/container/factory/factory_go13_test.go
@@ -1,0 +1,19 @@
+// Copyright 2013 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package factory_test
+
+// +build go1.3
+
+import (
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/instance"
+)
+
+func (*factorySuite) TestNewContainerManagerLXD(c *gc.C) {
+	testContainerManager(c, containerTest{
+		containerType: instance.LXD,
+		valid:         true,
+	})
+}

--- a/container/factory/factory_test.go
+++ b/container/factory/factory_test.go
@@ -19,15 +19,14 @@ type factorySuite struct {
 
 var _ = gc.Suite(&factorySuite{})
 
+type containerTest struct {
+	containerType instance.ContainerType
+	valid         bool
+}
+
 func (*factorySuite) TestNewContainerManager(c *gc.C) {
-	for _, test := range []struct {
-		containerType instance.ContainerType
-		valid         bool
-	}{{
+	for _, test := range []containerTest{{
 		containerType: instance.LXC,
-		valid:         true,
-	}, {
-		containerType: instance.LXD,
 		valid:         true,
 	}, {
 		containerType: instance.KVM,
@@ -39,14 +38,18 @@ func (*factorySuite) TestNewContainerManager(c *gc.C) {
 		containerType: instance.ContainerType("other"),
 		valid:         false,
 	}} {
-		conf := container.ManagerConfig{container.ConfigName: "test"}
-		manager, err := factory.NewContainerManager(test.containerType, conf, nil)
-		if test.valid {
-			c.Assert(err, jc.ErrorIsNil)
-			c.Assert(manager, gc.NotNil)
-		} else {
-			c.Assert(err, gc.ErrorMatches, `unknown container type: ".*"`)
-			c.Assert(manager, gc.IsNil)
-		}
+		testContainerManager(c, test)
+	}
+}
+
+func testContainerManager(c *gc.C, test containerTest) {
+	conf := container.ManagerConfig{container.ConfigName: "test"}
+	manager, err := factory.NewContainerManager(test.containerType, conf, nil)
+	if test.valid {
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(manager, gc.NotNil)
+	} else {
+		c.Assert(err, gc.ErrorMatches, `unknown container type: ".*"`)
+		c.Assert(manager, gc.IsNil)
 	}
 }

--- a/container/lxd/instance.go
+++ b/container/lxd/instance.go
@@ -1,6 +1,8 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// +build go1.3
+
 package lxd
 
 import (

--- a/container/lxd/lxd.go
+++ b/container/lxd/lxd.go
@@ -1,6 +1,8 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// +build go1.3
+
 package lxd
 
 import (

--- a/container/lxd/lxdclient/conn.go
+++ b/container/lxd/lxdclient/conn.go
@@ -1,6 +1,8 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// +build go1.3
+
 package lxdclient
 
 import (

--- a/container/lxd/lxdclient/conn_instance.go
+++ b/container/lxd/lxdclient/conn_instance.go
@@ -1,6 +1,8 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// +build go1.3
+
 package lxdclient
 
 import (

--- a/container/lxd/lxdclient/conn_raw.go
+++ b/container/lxd/lxdclient/conn_raw.go
@@ -1,6 +1,8 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// +build go1.3
+
 package lxdclient
 
 import (

--- a/container/lxd/lxdclient/instance.go
+++ b/container/lxd/lxdclient/instance.go
@@ -1,6 +1,8 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// +build go1.3
+
 package lxdclient
 
 import (

--- a/container/lxd/lxdclient/lxd_client.go
+++ b/container/lxd/lxdclient/lxd_client.go
@@ -1,6 +1,8 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// +build go1.3
+
 package lxdclient
 
 import (

--- a/container/lxd/lxdclient/testing_test.go
+++ b/container/lxd/lxdclient/testing_test.go
@@ -1,6 +1,8 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// +build go1.3
+
 package lxdclient
 
 import (

--- a/environs/bootstrap/bootstrap_test.go
+++ b/environs/bootstrap/bootstrap_test.go
@@ -419,7 +419,7 @@ func (s *bootstrapSuite) setDummyStorage(c *gc.C, env *bootstrapEnviron) {
 	s.AddCleanup(func(c *gc.C) { closer.Close() })
 }
 
-func (e *bootstrapEnviron) Bootstrap(ctx environs.BootstrapContext, args environs.BootstrapParams) (string, string, environs.BootstrapFinalizer, error) {
+func (e *bootstrapEnviron) Bootstrap(ctx environs.BootstrapContext, args environs.BootstrapParams) (*environs.BootstrapResult, error) {
 	e.bootstrapCount++
 	e.args = args
 	finalizer := func(_ environs.BootstrapContext, icfg *instancecfg.InstanceConfig) error {
@@ -427,7 +427,7 @@ func (e *bootstrapEnviron) Bootstrap(ctx environs.BootstrapContext, args environ
 		e.instanceConfig = icfg
 		return nil
 	}
-	return arch.HostArch(), series.HostSeries(), finalizer, nil
+	return &environs.BootstrapResult{Arch: arch.HostArch(), Series: series.HostSeries(), Finalize: finalizer}, nil
 }
 
 func (e *bootstrapEnviron) Config() *config.Config {

--- a/instance/container_go13_test.go
+++ b/instance/container_go13_test.go
@@ -1,0 +1,25 @@
+// Copyright 2013 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// +build go1.3
+
+package instance_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/instance"
+)
+
+func (s *InstanceSuite) TestParseContainerTypeLXD(c *gc.C) {
+	ctype, err = instance.ParseContainerType("lxd")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ctype, gc.Equals, instance.LXD)
+}
+
+func (s *InstanceSuite) TestParseContainerTypeLXDOrNone(c *gc.C) {
+	ctype, err = instance.ParseContainerTypeOrNone("lxd")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ctype, gc.Equals, instance.LXD)
+}

--- a/instance/container_go13_test.go
+++ b/instance/container_go13_test.go
@@ -13,13 +13,13 @@ import (
 )
 
 func (s *InstanceSuite) TestParseContainerTypeLXD(c *gc.C) {
-	ctype, err = instance.ParseContainerType("lxd")
+	ctype, err := instance.ParseContainerType("lxd")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ctype, gc.Equals, instance.LXD)
 }
 
 func (s *InstanceSuite) TestParseContainerTypeLXDOrNone(c *gc.C) {
-	ctype, err = instance.ParseContainerTypeOrNone("lxd")
+	ctype, err := instance.ParseContainerTypeOrNone("lxd")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ctype, gc.Equals, instance.LXD)
 }

--- a/instance/container_test.go
+++ b/instance/container_test.go
@@ -25,10 +25,6 @@ func (s *InstanceSuite) TestParseContainerType(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ctype, gc.Equals, instance.LXC)
 
-	ctype, err = instance.ParseContainerType("lxd")
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(ctype, gc.Equals, instance.LXD)
-
 	ctype, err = instance.ParseContainerType("kvm")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ctype, gc.Equals, instance.KVM)
@@ -44,10 +40,6 @@ func (s *InstanceSuite) TestParseContainerTypeOrNone(c *gc.C) {
 	ctype, err := instance.ParseContainerTypeOrNone("lxc")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ctype, gc.Equals, instance.LXC)
-
-	ctype, err := instance.ParseContainerTypeOrNone("lxd")
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(ctype, gc.Equals, instance.LXD)
 
 	ctype, err = instance.ParseContainerTypeOrNone("kvm")
 	c.Assert(err, jc.ErrorIsNil)

--- a/provider/all/all.go
+++ b/provider/all/all.go
@@ -11,7 +11,6 @@ import (
 	_ "github.com/juju/juju/provider/gce"
 	_ "github.com/juju/juju/provider/joyent"
 	_ "github.com/juju/juju/provider/local"
-	_ "github.com/juju/juju/provider/lxd"
 	_ "github.com/juju/juju/provider/maas"
 	_ "github.com/juju/juju/provider/manual"
 	_ "github.com/juju/juju/provider/openstack"

--- a/provider/all/all_go13.go
+++ b/provider/all/all_go13.go
@@ -3,14 +3,9 @@
 
 // +build go1.3
 
-package lxd_test
+package all
 
+// Register all the available providers.
 import (
-	"testing"
-
-	gc "gopkg.in/check.v1"
+	_ "github.com/juju/juju/provider/lxd"
 )
-
-func TestPackage(t *testing.T) {
-	gc.TestingT(t)
-}

--- a/provider/lxd/config_test.go
+++ b/provider/lxd/config_test.go
@@ -1,6 +1,8 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// +build go1.3
+
 package lxd_test
 
 import (

--- a/provider/lxd/environ.go
+++ b/provider/lxd/environ.go
@@ -1,6 +1,8 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// +build go1.3
+
 package lxd
 
 import (

--- a/provider/lxd/environ_broker.go
+++ b/provider/lxd/environ_broker.go
@@ -1,6 +1,8 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// +build go1.3
+
 package lxd
 
 import (

--- a/provider/lxd/environ_broker_test.go
+++ b/provider/lxd/environ_broker_test.go
@@ -1,6 +1,8 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// +build go1.3
+
 package lxd_test
 
 import (

--- a/provider/lxd/environ_instance.go
+++ b/provider/lxd/environ_instance.go
@@ -1,6 +1,8 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// +build go1.3
+
 package lxd
 
 import (

--- a/provider/lxd/environ_instance_test.go
+++ b/provider/lxd/environ_instance_test.go
@@ -1,6 +1,8 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// +build go1.3
+
 package lxd_test
 
 import (

--- a/provider/lxd/environ_network.go
+++ b/provider/lxd/environ_network.go
@@ -1,6 +1,8 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// +build go1.3
+
 package lxd
 
 import (

--- a/provider/lxd/environ_network_test.go
+++ b/provider/lxd/environ_network_test.go
@@ -1,6 +1,8 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// +build go1.3
+
 package lxd_test
 
 import (

--- a/provider/lxd/environ_policy.go
+++ b/provider/lxd/environ_policy.go
@@ -1,6 +1,8 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// +build go1.3
+
 package lxd
 
 import (

--- a/provider/lxd/environ_policy_test.go
+++ b/provider/lxd/environ_policy_test.go
@@ -1,6 +1,8 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// +build go1.3
+
 package lxd_test
 
 import (

--- a/provider/lxd/environ_raw.go
+++ b/provider/lxd/environ_raw.go
@@ -1,6 +1,8 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// +build go1.3
+
 package lxd
 
 import (

--- a/provider/lxd/environ_test.go
+++ b/provider/lxd/environ_test.go
@@ -1,6 +1,8 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// +build go1.3
+
 package lxd_test
 
 import (

--- a/provider/lxd/export_test.go
+++ b/provider/lxd/export_test.go
@@ -1,6 +1,8 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// +build go1.3
+
 package lxd
 
 import (

--- a/provider/lxd/init.go
+++ b/provider/lxd/init.go
@@ -1,6 +1,8 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// +build go1.3
+
 package lxd
 
 import (

--- a/provider/lxd/instance.go
+++ b/provider/lxd/instance.go
@@ -1,6 +1,8 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// +build go1.3
+
 package lxd
 
 import (

--- a/provider/lxd/instance_test.go
+++ b/provider/lxd/instance_test.go
@@ -1,6 +1,8 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// +build go1.3
+
 package lxd_test
 
 import (

--- a/provider/lxd/lxd.go
+++ b/provider/lxd/lxd.go
@@ -1,6 +1,8 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// +build go1.3
+
 package lxd
 
 import (

--- a/provider/lxd/provider.go
+++ b/provider/lxd/provider.go
@@ -1,6 +1,8 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// +build go1.3
+
 package lxd
 
 import (

--- a/provider/lxd/provider_test.go
+++ b/provider/lxd/provider_test.go
@@ -1,6 +1,8 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// +build go1.3
+
 package lxd_test
 
 import (

--- a/provider/lxd/testing_test.go
+++ b/provider/lxd/testing_test.go
@@ -1,6 +1,8 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+// +build go1.3
+
 package lxd
 
 import (


### PR DESCRIPTION
github.com/lxc/lxd requires go 1.3, but we still need to support go 1.2 for a little while longer, so put in a bunch of build tags to exclude the lxd stuff under go 1.2.

(Review request: http://reviews.vapour.ws/r/3070/)