### PR TITLE
cmd/jujud/agent: moved PrimeStateAgent

### DIFF
--- a/cmd/jujud/agent/agent_test.go
+++ b/cmd/jujud/agent/agent_test.go
@@ -4,31 +4,21 @@
 package agent
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/juju/cmd"
-	"github.com/juju/names"
-	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/series"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/agent"
-	agenttools "github.com/juju/juju/agent/tools"
 	apienvironment "github.com/juju/juju/api/environment"
-	"github.com/juju/juju/apiserver/params"
 	agenttesting "github.com/juju/juju/cmd/jujud/agent/testing"
 	cmdutil "github.com/juju/juju/cmd/jujud/util"
-	"github.com/juju/juju/environs/filestorage"
 	"github.com/juju/juju/environs/imagemetadata"
-	envtesting "github.com/juju/juju/environs/testing"
 	"github.com/juju/juju/juju/paths"
 	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/network"
 	coretesting "github.com/juju/juju/testing"
-	coretools "github.com/juju/juju/tools"
-	"github.com/juju/juju/version"
 	"github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/proxyupdater"
 )
@@ -103,67 +93,4 @@ func (s *AgentSuite) SetUpTest(c *gc.C) {
 
 	// Tests should not try to use internet. Ensure base url is empty.
 	imagemetadata.DefaultBaseURL = ""
-}
-
-func (s *AgentSuite) primeAPIHostPorts(c *gc.C) {
-	apiInfo := s.APIInfo(c)
-
-	c.Assert(apiInfo.Addrs, gc.HasLen, 1)
-	hostPorts, err := network.ParseHostPorts(apiInfo.Addrs[0])
-	c.Assert(err, jc.ErrorIsNil)
-
-	err = s.State.SetAPIHostPorts([][]network.HostPort{hostPorts})
-	c.Assert(err, jc.ErrorIsNil)
-
-	logger.Debugf("api host ports primed %#v", hostPorts)
-}
-
-// primeStateAgent writes the configuration file and tools with version vers
-// for an agent with the given entity name.  It returns the agent's configuration
-// and the current tools.
-func (s *AgentSuite) PrimeStateAgent(
-	c *gc.C, tag names.Tag, password string, vers version.Binary) (agent.ConfigSetterWriter, *coretools.Tools) {
-
-	stor, err := filestorage.NewFileStorageWriter(c.MkDir())
-	c.Assert(err, jc.ErrorIsNil)
-	agentTools := envtesting.PrimeTools(c, stor, s.DataDir(), "released", vers)
-	tools1, err := agenttools.ChangeAgentTools(s.DataDir(), tag.String(), vers)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(tools1, gc.DeepEquals, agentTools)
-
-	stateInfo := s.MongoInfo(c)
-	conf := writeStateAgentConfig(c, stateInfo, s.DataDir(), tag, password, vers, s.State.EnvironTag())
-	s.primeAPIHostPorts(c)
-	return conf, agentTools
-}
-
-// writeStateAgentConfig creates and writes a state agent config.
-func writeStateAgentConfig(
-	c *gc.C, stateInfo *mongo.MongoInfo, dataDir string, tag names.Tag,
-	password string, vers version.Binary, envTag names.EnvironTag) agent.ConfigSetterWriter {
-	port := gitjujutesting.FindTCPPort()
-	apiAddr := []string{fmt.Sprintf("localhost:%d", port)}
-	conf, err := agent.NewStateMachineConfig(
-		agent.AgentConfigParams{
-			Paths:             agent.NewPathsWithDefaults(agent.Paths{DataDir: dataDir}),
-			Tag:               tag,
-			UpgradedToVersion: vers.Number,
-			Password:          password,
-			Nonce:             agent.BootstrapNonce,
-			StateAddresses:    stateInfo.Addrs,
-			APIAddresses:      apiAddr,
-			CACert:            stateInfo.CACert,
-			Environment:       envTag,
-		},
-		params.StateServingInfo{
-			Cert:         coretesting.ServerCert,
-			PrivateKey:   coretesting.ServerKey,
-			CAPrivateKey: coretesting.CAKey,
-			StatePort:    gitjujutesting.MgoServer.Port(),
-			APIPort:      port,
-		})
-	c.Assert(err, jc.ErrorIsNil)
-	conf.SetPassword(password)
-	c.Assert(conf.Write(), gc.IsNil)
-	return conf
 }

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -216,7 +216,7 @@ func (s *commonMachineSuite) configureMachine(c *gc.C, machineId string, vers ve
 	if m.IsManager() {
 		err = m.SetMongoPassword(initialMachinePassword)
 		c.Assert(err, jc.ErrorIsNil)
-		agentConfig, tools = s.AgentSuite.PrimeStateAgent(c, tag, initialMachinePassword, vers)
+		agentConfig, tools = s.PrimeStateAgentVersion(c, tag, initialMachinePassword, vers)
 		info, ok := agentConfig.StateServingInfo()
 		c.Assert(ok, jc.IsTrue)
 		ssi := cmdutil.ParamsStateServingInfoToStateStateServingInfo(info)

--- a/cmd/jujud/agent/testing/agent.go
+++ b/cmd/jujud/agent/testing/agent.go
@@ -4,12 +4,14 @@
 package testing
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/names"
 	"github.com/juju/replicaset"
+	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/arch"
 	"github.com/juju/utils/series"
@@ -18,6 +20,7 @@ import (
 
 	"github.com/juju/juju/agent"
 	agenttools "github.com/juju/juju/agent/tools"
+	"github.com/juju/juju/apiserver/params"
 	cmdutil "github.com/juju/juju/cmd/jujud/util"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/filestorage"
@@ -107,7 +110,7 @@ type AgentSuite struct {
 	testing.JujuConnSuite
 }
 
-// PrimeAgentVersion writes the configuration file and tools for an agent
+// PrimeAgent writes the configuration file and tools for an agent
 // with the given entity name. It returns the agent's configuration and the
 // current tools.
 func (s *AgentSuite) PrimeAgent(c *gc.C, tag names.Tag, password string) (agent.ConfigSetterWriter, *coretools.Tools) {
@@ -153,6 +156,72 @@ func (s *AgentSuite) PrimeAgentVersion(c *gc.C, tag names.Tag, password string, 
 	c.Assert(conf.Write(), gc.IsNil)
 	s.primeAPIHostPorts(c)
 	return conf, agentTools
+}
+
+// PrimeStateAgent writes the configuration file and tools for
+// a state agent with the given entity name. It returns the agent's
+// configuration and the current tools.
+func (s *AgentSuite) PrimeStateAgent(c *gc.C, tag names.Tag, password string) (agent.ConfigSetterWriter, *coretools.Tools) {
+	vers := version.Binary{
+		Number: version.Current,
+		Arch:   arch.HostArch(),
+		Series: series.HostSeries(),
+	}
+	return s.PrimeStateAgentVersion(c, tag, password, vers)
+}
+
+// PrimeStateAgentVersion writes the configuration file and tools with
+// version vers for a state agent with the given entity name. It
+// returns the agent's configuration and the current tools.
+func (s *AgentSuite) PrimeStateAgentVersion(c *gc.C, tag names.Tag, password string, vers version.Binary) (
+	agent.ConfigSetterWriter, *coretools.Tools,
+) {
+	stor, err := filestorage.NewFileStorageWriter(c.MkDir())
+	c.Assert(err, jc.ErrorIsNil)
+	agentTools := envtesting.PrimeTools(c, stor, s.DataDir(), "released", vers)
+	tools1, err := agenttools.ChangeAgentTools(s.DataDir(), tag.String(), vers)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(tools1, gc.DeepEquals, agentTools)
+
+	conf := s.WriteStateAgentConfig(c, tag, password, vers, s.State.EnvironTag())
+	s.primeAPIHostPorts(c)
+	return conf, agentTools
+}
+
+// WriteStateAgentConfig creates and writes a state agent config.
+func (s *AgentSuite) WriteStateAgentConfig(
+	c *gc.C,
+	tag names.Tag,
+	password string,
+	vers version.Binary,
+	envTag names.EnvironTag,
+) agent.ConfigSetterWriter {
+	stateInfo := s.State.MongoConnectionInfo()
+	apiPort := gitjujutesting.FindTCPPort()
+	apiAddr := []string{fmt.Sprintf("localhost:%d", apiPort)}
+	conf, err := agent.NewStateMachineConfig(
+		agent.AgentConfigParams{
+			Paths:             agent.NewPathsWithDefaults(agent.Paths{DataDir: s.DataDir()}),
+			Tag:               tag,
+			UpgradedToVersion: vers.Number,
+			Password:          password,
+			Nonce:             agent.BootstrapNonce,
+			StateAddresses:    stateInfo.Addrs,
+			APIAddresses:      apiAddr,
+			CACert:            stateInfo.CACert,
+			Environment:       envTag,
+		},
+		params.StateServingInfo{
+			Cert:         coretesting.ServerCert,
+			PrivateKey:   coretesting.ServerKey,
+			CAPrivateKey: coretesting.CAKey,
+			StatePort:    gitjujutesting.MgoServer.Port(),
+			APIPort:      apiPort,
+		})
+	c.Assert(err, jc.ErrorIsNil)
+	conf.SetPassword(password)
+	c.Assert(conf.Write(), gc.IsNil)
+	return conf
 }
 
 func (s *AgentSuite) primeAPIHostPorts(c *gc.C) {


### PR DESCRIPTION
Moved the PrimeStateAgent test helper method from cmd/jujud/agent.AgentSuite to cmd/jujud/agent/testing.AgentSuite (the former embeds the latter). This puts it next to the companion PrimeAgent helper, eliminates some duplicate code and makes the method available to for use in feature tests.

(Review request: http://reviews.vapour.ws/r/3073/)