### PR TITLE
utils: fork ReadYaml and WriteYaml from juju/utils

### DIFF
--- a/provider/maas/util.go
+++ b/provider/maas/util.go
@@ -9,13 +9,13 @@ import (
 	"strings"
 
 	"github.com/juju/errors"
-	"github.com/juju/utils"
-	goyaml "gopkg.in/yaml.v2"
+	goyaml "gopkg.in/yaml.v2" // TODO(dfc) this is horridly wrong, utils.ReadYaml requires yaml.v1
 
 	"github.com/juju/juju/cloudconfig/cloudinit"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/juju/paths"
+	"github.com/juju/juju/utils"
 )
 
 // extractSystemId extracts the 'system_id' part from an InstanceId.

--- a/storage/provider/tmpfs.go
+++ b/storage/provider/tmpfs.go
@@ -10,10 +10,10 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/names"
-	"github.com/juju/utils"
 
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/storage"
+	"github.com/juju/juju/utils"
 )
 
 const (

--- a/utils/yaml.go
+++ b/utils/yaml.go
@@ -1,0 +1,65 @@
+// Copyright 2012, 2013 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package utils
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/juju/errors"
+	"github.com/juju/utils"
+
+	// juju dependends on the handing of empty elements
+	// provided by yaml.v1. Changing the version of yaml
+	// that this package uses will break juju.
+	"gopkg.in/yaml.v1"
+)
+
+// WriteYaml marshals obj as yaml to a temporary file in the same directory
+// as path, than atomically replaces path with the temporary file.
+func WriteYaml(path string, obj interface{}) error {
+	data, err := yaml.Marshal(obj)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	dir := filepath.Dir(path)
+	f, err := ioutil.TempFile(dir, "juju")
+	if err != nil {
+		return errors.Trace(err)
+	}
+	tmp := f.Name()
+	if _, err := f.Write(data); err != nil {
+		f.Close()      // don't leak file handle
+		os.Remove(tmp) // don't leak half written files on disk
+		return errors.Trace(err)
+	}
+	// Explicitly close the file before moving it. This is needed on Windows
+	// where the OS will not allow us to move a file that still has an open
+	// file handle. Must check the error on close because filesystems can delay
+	// reporting errors until the file is closed.
+	if err := f.Close(); err != nil {
+		os.Remove(tmp) // don't leak half written files on disk
+		return errors.Trace(err)
+	}
+
+	// ioutils.TempFile creates files 0600, but this function has a contract
+	// that files will be world readable, 0644 after replacement.
+	if err := os.Chmod(tmp, 0644); err != nil {
+		os.Remove(tmp) // remove file with incorrect permissions.
+		return errors.Trace(err)
+	}
+
+	return utils.ReplaceFile(tmp, path)
+}
+
+// ReadYaml unmarshals the yaml contained in the file at path into obj. See
+// goyaml.Unmarshal.
+func ReadYaml(path string, obj interface{}) error {
+	data, err := ioutil.ReadFile(path)
+	if err != nil {
+		return err // cannot wrap here because callers check for NotFound.
+	}
+	return yaml.Unmarshal(data, obj)
+}

--- a/worker/meterstatus/state.go
+++ b/worker/meterstatus/state.go
@@ -8,7 +8,8 @@ import (
 	"time"
 
 	"github.com/juju/errors"
-	"github.com/juju/utils"
+
+	"github.com/juju/juju/utils"
 )
 
 // StateFile holds the meter status on disk.

--- a/worker/uniter/charm/charm.go
+++ b/worker/uniter/charm/charm.go
@@ -8,9 +8,10 @@ import (
 	"net/url"
 
 	"github.com/juju/loggo"
-	"github.com/juju/utils"
 	"github.com/juju/utils/set"
 	"gopkg.in/juju/charm.v6-unstable"
+
+	"github.com/juju/juju/utils"
 )
 
 var logger = loggo.GetLogger("juju.worker.uniter.charm")

--- a/worker/uniter/charm/manifest_deployer.go
+++ b/worker/uniter/charm/manifest_deployer.go
@@ -8,9 +8,11 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/juju/utils"
+	jujuutils "github.com/juju/utils"
 	"github.com/juju/utils/set"
 	"gopkg.in/juju/charm.v6-unstable"
+
+	"github.com/juju/juju/utils"
 )
 
 const (
@@ -147,7 +149,7 @@ func (d *manifestDeployer) finishDeploy() error {
 	logger.Debugf("finishing deploy of charm %q", d.staged.url)
 	oldPath := d.CharmPath(deployingURLPath)
 	newPath := d.CharmPath(charmURLPath)
-	return utils.ReplaceFile(oldPath, newPath)
+	return jujuutils.ReplaceFile(oldPath, newPath)
 }
 
 // ensureBaseFiles checks for an interrupted deploy operation and, if it finds

--- a/worker/uniter/operation/state.go
+++ b/worker/uniter/operation/state.go
@@ -7,9 +7,9 @@ import (
 	"os"
 
 	"github.com/juju/errors"
-	"github.com/juju/utils"
 	"gopkg.in/juju/charm.v6-unstable"
 
+	"github.com/juju/juju/utils"
 	"github.com/juju/juju/worker/uniter/hook"
 )
 

--- a/worker/uniter/relation/state.go
+++ b/worker/uniter/relation/state.go
@@ -14,9 +14,9 @@ import (
 	"strings"
 
 	"github.com/juju/errors"
-	"github.com/juju/utils"
 	"gopkg.in/juju/charm.v6-unstable/hooks"
 
+	"github.com/juju/juju/utils"
 	"github.com/juju/juju/worker/uniter/hook"
 )
 

--- a/worker/uniter/storage/state.go
+++ b/worker/uniter/storage/state.go
@@ -11,9 +11,9 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/names"
-	"github.com/juju/utils"
 	"gopkg.in/juju/charm.v6-unstable/hooks"
 
+	"github.com/juju/juju/utils"
 	"github.com/juju/juju/worker/uniter/hook"
 )
 

--- a/worker/uniter/upgrade123.go
+++ b/worker/uniter/upgrade123.go
@@ -7,9 +7,9 @@ import (
 	"os"
 
 	"github.com/juju/names"
-	"github.com/juju/utils"
 	"gopkg.in/juju/charm.v6-unstable/hooks"
 
+	"github.com/juju/juju/utils"
 	"github.com/juju/juju/worker/uniter/operation"
 )
 


### PR DESCRIPTION
Juju depends on the behaviour of the yaml.v1. However this contact
is poorly expressed as the functions which perform Yaml reading and
writing are in a different repository, juju/utils, who's version of
the yaml floats.

To resolve this, fork two functions juju/utils and bring them into juju's
own utils package.

A comment explaining why this was done and the requirement on yaml.v1 has
been added to this fork.

Additionally WriteYaml has been cleaned up to avoid leaking temporary files
on disk, or overwriting a temporary file as it is being prepared.

(Review request: http://reviews.vapour.ws/r/3074/)