### PR TITLE
Implemented juju-dumplogs

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -471,11 +471,19 @@ func NewStateMachineConfig(configParams AgentConfigParams, serverInfo params.Sta
 	return config, nil
 }
 
+// BaseDir returns the directory containing the data directories for
+// all the agents.
+func BaseDir(dataDir string) string {
+	// Note: must use path, not filepath, as this function is
+	// (indirectly) used by the client on Windows.
+	return path.Join(dataDir, "agents")
+}
+
 // Dir returns the agent-specific data directory.
 func Dir(dataDir string, tag names.Tag) string {
 	// Note: must use path, not filepath, as this
 	// function is used by the client on Windows.
-	return path.Join(dataDir, "agents", tag.String())
+	return path.Join(BaseDir(dataDir), tag.String())
 }
 
 // ConfigPath returns the full path to the agent config file.

--- a/cmd/jujud/dumplogs/dumplogs.go
+++ b/cmd/jujud/dumplogs/dumplogs.go
@@ -1,0 +1,189 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// A simple command for dumping out the logs stored in
+// MongoDB. Intended to be use in emergency situations to recover logs
+// when Juju is broken somehow.
+
+package dumplogs
+
+import (
+	"bufio"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	"github.com/juju/names"
+	"launchpad.net/gnuflag"
+
+	"github.com/juju/juju/agent"
+	jujudagent "github.com/juju/juju/cmd/jujud/agent"
+	"github.com/juju/juju/environs"
+	corenames "github.com/juju/juju/juju/names"
+	"github.com/juju/juju/mongo"
+	"github.com/juju/juju/state"
+)
+
+// NewCommand returns a new Command instance which implements the
+// "juju-dumplogs" command.
+func NewCommand() cmd.Command {
+	return &dumpLogsCommand{
+		agentConfig: jujudagent.NewAgentConf(""),
+	}
+}
+
+type dumpLogsCommand struct {
+	cmd.CommandBase
+	agentConfig jujudagent.AgentConf
+	machineId   string
+	outDir      string
+}
+
+// Info implements cmd.Command.
+func (c *dumpLogsCommand) Info() *cmd.Info {
+	doc := `
+This tool can be used to access Juju's logs when the Juju controller
+isn't functioning for some reason. It must be run on a Juju controller
+server, connecting to the Juju database instance and generating a log
+file for each environment that exists in the controller.
+
+Log files are written out to the current working directory by
+default. Use -d / --output-directory option to specify an alternate
+target directory.
+
+In order to connect to the database, the local machine agent's
+configuration is needed. In most circumstances the configuration will
+be found automatically. The --data-dir and/or --machine-id options may
+be required if the agent configuration can't be found automatically.
+`[1:]
+	return &cmd.Info{
+		Name:    corenames.JujuDumpLogs,
+		Purpose: "output the logs that are stored in the local Juju database",
+		Doc:     doc,
+	}
+}
+
+// SetFlags implements cmd.Command.
+func (c *dumpLogsCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.agentConfig.AddFlags(f)
+	f.StringVar(&c.outDir, "d", ".", "directory to write logs files to")
+	f.StringVar(&c.outDir, "output-directory", ".", "")
+	f.StringVar(&c.machineId, "machine-id", "", "id of the machine on this host (optional)")
+}
+
+// Init implements cmd.Command.
+func (c *dumpLogsCommand) Init(args []string) error {
+	err := c.agentConfig.CheckArgs(args)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	if c.machineId == "" {
+		machineId, err := c.findMachineId(c.agentConfig.DataDir())
+		if err != nil {
+			return errors.Trace(err)
+		}
+		c.machineId = machineId
+	} else if !names.IsValidMachine(c.machineId) {
+		return errors.New("--machine-id option expects a non-negative integer")
+	}
+
+	err = c.agentConfig.ReadConfig(names.NewMachineTag(c.machineId).String())
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	return nil
+}
+
+// Run implements cmd.Command.
+func (c *dumpLogsCommand) Run(ctx *cmd.Context) error {
+	config := c.agentConfig.CurrentConfig()
+	info, ok := config.MongoInfo()
+	if !ok {
+		return errors.New("no database connection info available (is this a controller host?)")
+	}
+
+	st0, err := state.Open(config.Environment(), info, mongo.DefaultDialOpts(), environs.NewStatePolicy())
+	if err != nil {
+		return errors.Annotate(err, "failed to connect to database")
+	}
+	defer st0.Close()
+
+	envs, err := st0.AllEnvironments()
+	if err != nil {
+		return errors.Annotate(err, "failed to look up environments")
+	}
+	for _, env := range envs {
+		err := c.dumpLogsForEnv(ctx, st0, env.EnvironTag())
+		if err != nil {
+			return errors.Annotatef(err, "failed to dump logs for environment %s", env.UUID())
+		}
+	}
+
+	return nil
+}
+
+func (c *dumpLogsCommand) findMachineId(dataDir string) (string, error) {
+	entries, err := ioutil.ReadDir(agent.BaseDir(dataDir))
+	if err != nil {
+		return "", errors.Annotate(err, "failed to read agent configuration base directory")
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			tag, err := names.ParseMachineTag(entry.Name())
+			if err == nil {
+				return tag.Id(), nil
+			}
+		}
+	}
+	return "", errors.New("no machine agent configuration found")
+}
+
+func (c *dumpLogsCommand) dumpLogsForEnv(ctx *cmd.Context, st0 *state.State, tag names.EnvironTag) error {
+	st, err := st0.ForEnviron(tag)
+	if err != nil {
+		return errors.Annotate(err, "failed open environment")
+	}
+	defer st.Close()
+
+	logName := ctx.AbsPath(filepath.Join(c.outDir, fmt.Sprintf("%s.log", tag.Id())))
+	ctx.Infof("writing to %s", logName)
+
+	file, err := os.Create(logName)
+	if err != nil {
+		return errors.Annotate(err, "failed to open output file")
+	}
+	defer file.Close()
+
+	writer := bufio.NewWriter(file)
+	defer writer.Flush()
+
+	tailer := state.NewLogTailer(st, &state.LogTailerParams{NoTail: true})
+	logs := tailer.Logs()
+	for {
+		rec, ok := <-logs
+		if !ok {
+			break
+		}
+		writer.WriteString(c.format(
+			rec.Time,
+			rec.Level,
+			rec.Entity,
+			rec.Module,
+			rec.Message,
+		) + "\n")
+	}
+
+	return nil
+}
+
+func (c *dumpLogsCommand) format(timestamp time.Time, level loggo.Level, entity, module, message string) string {
+	ts := timestamp.In(time.UTC).Format("2006-01-02 15:04:05")
+	return fmt.Sprintf("%s: %s %s %s %s", entity, ts, level, module, message)
+}

--- a/cmd/jujud/main.go
+++ b/cmd/jujud/main.go
@@ -20,6 +20,7 @@ import (
 
 	jujucmd "github.com/juju/juju/cmd"
 	agentcmd "github.com/juju/juju/cmd/jujud/agent"
+	"github.com/juju/juju/cmd/jujud/dumplogs"
 	components "github.com/juju/juju/component/all"
 	"github.com/juju/juju/juju/names"
 	"github.com/juju/juju/juju/sockets"
@@ -190,6 +191,8 @@ func Main(args []string) int {
 		err = fmt.Errorf("jujuc should not be called directly")
 	} else if commandName == names.JujuRun {
 		code = cmd.Main(&RunCommand{}, ctx, args[1:])
+	} else if commandName == names.JujuDumpLogs {
+		code = cmd.Main(dumplogs.NewCommand(), ctx, args[1:])
 	} else {
 		code, err = jujuCMain(commandName, ctx, args)
 	}

--- a/featuretests/cmd_juju_dumplogs_test.go
+++ b/featuretests/cmd_juju_dumplogs_test.go
@@ -1,0 +1,80 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package featuretests
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/juju/loggo"
+	"github.com/juju/names"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/agent"
+	agenttesting "github.com/juju/juju/cmd/jujud/agent/testing"
+	"github.com/juju/juju/cmd/jujud/dumplogs"
+	"github.com/juju/juju/feature"
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/testing"
+	"github.com/juju/juju/testing/factory"
+)
+
+type dumpLogsCommandSuite struct {
+	agenttesting.AgentSuite
+}
+
+func (s *dumpLogsCommandSuite) SetUpTest(c *gc.C) {
+	s.AgentSuite.SetUpTest(c)
+	s.SetFeatureFlags(feature.JES)
+}
+
+func (s *dumpLogsCommandSuite) TestRun(c *gc.C) {
+	// Create a controller machine and an agent for it.
+	m, password := s.Factory.MakeMachineReturningPassword(c, &factory.MachineParams{
+		Jobs:  []state.MachineJob{state.JobManageEnviron},
+		Nonce: agent.BootstrapNonce,
+	})
+	err := m.SetMongoPassword(password)
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.PrimeStateAgent(c, m.Tag(), password)
+
+	//  Create multiple environments and add some logs for each.
+	st1 := s.Factory.MakeEnvironment(c, nil)
+	defer st1.Close()
+	st2 := s.Factory.MakeEnvironment(c, nil)
+	defer st2.Close()
+	states := []*state.State{s.State, st1, st2}
+
+	t := time.Date(2015, 11, 4, 3, 2, 1, 0, time.UTC)
+	for _, st := range states {
+		w := state.NewDbLogger(st, names.NewMachineTag("42"))
+		defer w.Close()
+		for i := 0; i < 3; i++ {
+			err := w.Log(t, "module", "location", loggo.INFO, fmt.Sprintf("%d", i))
+			c.Assert(err, jc.ErrorIsNil)
+		}
+	}
+
+	// Run the juju-dumplogs command
+	command := dumplogs.NewCommand()
+	context, err := testing.RunCommand(c, command, "--data-dir", s.DataDir())
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Check the log file for each environment
+	expectedLog := "machine-42: 2015-11-04 03:02:01 INFO module %d"
+	for _, st := range states {
+		logName := context.AbsPath(fmt.Sprintf("%s.log", st.EnvironUUID()))
+		logFile, err := os.Open(logName)
+		c.Assert(err, jc.ErrorIsNil)
+		scanner := bufio.NewScanner(logFile)
+		for i := 0; scanner.Scan(); i++ {
+			c.Assert(scanner.Text(), gc.Equals, fmt.Sprintf(expectedLog, i))
+		}
+		c.Assert(scanner.Err(), jc.ErrorIsNil)
+	}
+}

--- a/featuretests/package_test.go
+++ b/featuretests/package_test.go
@@ -34,6 +34,7 @@ func init() {
 	gc.Suite(&cloudImageMetadataSuite{})
 	gc.Suite(&cmdSpaceSuite{})
 	gc.Suite(&cmdSubnetSuite{})
+	gc.Suite(&dumpLogsCommandSuite{})
 }
 
 func Test(t *testing.T) {

--- a/juju/names/names.go
+++ b/juju/names/names.go
@@ -6,8 +6,9 @@
 package names
 
 const (
-	Juju    = "juju"
-	Jujud   = "jujud"
-	Jujuc   = "jujuc"
-	JujuRun = "juju-run"
+	Juju         = "juju"
+	Jujud        = "jujud"
+	Jujuc        = "jujuc"
+	JujuRun      = "juju-run"
+	JujuDumpLogs = "juju-dumplogs"
 )

--- a/juju/paths/paths.go
+++ b/juju/paths/paths.go
@@ -21,6 +21,7 @@ const (
 	certDir
 	metricsSpoolDir
 	uniterStateDir
+	jujuDumpLogs
 )
 
 var nixVals = map[osVarType]string{
@@ -30,6 +31,7 @@ var nixVals = map[osVarType]string{
 	storageDir:      "/var/lib/juju/storage",
 	confDir:         "/etc/juju",
 	jujuRun:         "/usr/bin/juju-run",
+	jujuDumpLogs:    "/usr/bin/juju-dumplogs",
 	certDir:         "/etc/juju/certs.d",
 	metricsSpoolDir: "/var/lib/juju/metricspool",
 	uniterStateDir:  "/var/lib/juju/uniter/state",
@@ -42,6 +44,7 @@ var winVals = map[osVarType]string{
 	storageDir:      "C:/Juju/lib/juju/storage",
 	confDir:         "C:/Juju/etc",
 	jujuRun:         "C:/Juju/bin/juju-run.exe",
+	jujuDumpLogs:    "C:/Juju/bin/juju-dumplogs.exe",
 	certDir:         "C:/Juju/certs",
 	metricsSpoolDir: "C:/Juju/lib/juju/metricspool",
 	uniterStateDir:  "C:/Juju/lib/juju/uniter/state",
@@ -108,9 +111,15 @@ func ConfDir(series string) (string, error) {
 }
 
 // JujuRun returns the absolute path to the juju-run binary for
-// a particular series
+// a particular series.
 func JujuRun(series string) (string, error) {
 	return osVal(series, jujuRun)
+}
+
+// JujuDumpLogs returns the absolute path to the juju-dumplogs binary
+// for a particular series.
+func JujuDumpLogs(series string) (string, error) {
+	return osVal(series, jujuDumpLogs)
 }
 
 func MustSucceed(s string, e error) string {
@@ -123,12 +132,11 @@ func MustSucceed(s string, e error) string {
 var osStat = os.Stat
 var execLookPath = exec.LookPath
 
-// mongorestorePath will look for mongorestore binary on the system
-// and return it if mongorestore actually exists.
-// it will look first for the juju provided one and if not found make a
-// try at a system one.
+// MongorestorePath will look for a mongorestore binary and return it
+// if it exists. It will look first for the juju provided one and if
+// not found make a try at a system installed one.
 func MongorestorePath() (string, error) {
-	// TODO (perrito666) this seems to be a package decission we should not
+	// TODO (perrito666) this seems to be a packaging decision we should not
 	// rely on it and we should be aware of /usr/lib/juju if its something
 	// of ours.
 	const mongoRestoreFullPath string = "/usr/lib/juju/bin/mongorestore"


### PR DESCRIPTION
juju-dumplogs is a jujud alias which can be run on a state server to retrieve Juju's logs out of Juju's DB. It uses the state server's agent configuration to retrieve DB connection details.

(Review request: http://reviews.vapour.ws/r/3075/)