### PR TITLE
add catacomb worker

### DIFF
--- a/worker/catacomb/catacomb.go
+++ b/worker/catacomb/catacomb.go
@@ -4,6 +4,7 @@
 package catacomb
 
 import (
+	"fmt"
 	"sync"
 
 	"github.com/juju/errors"
@@ -12,44 +13,44 @@ import (
 	"github.com/juju/juju/worker"
 )
 
-// ErrDying is used to signal acquiescence to a Catacomb's Dying notification.
-// As with tomb.ErrDying, it must not be used in *any* other circumstances, lest
-// it somehow leak into a worker that isn't really dying and cause a panic.
-var ErrDying = errors.New("catacomb is dying")
-
 // Catacomb is a variant of tomb.Tomb with its own internal goroutine, designed
 // for coordinating the lifetimes of a set of private workers needed by a single
 // parent. See the package documentation for detailed discussion and usage notes.
 type Catacomb struct {
-	tomb     tomb.Tomb
-	wg       sync.WaitGroup
-	requests chan addRequest
+	tomb tomb.Tomb
+	wg   sync.WaitGroup
+	adds chan addRequest
 }
 
-// addRequest holds a worker that should be added to a catacomb, and a channel
-// that will be closed to confirm successful addition.
+// addRequest holds a worker to be added and a channel to close when the
+// addition is confirmed.
 type addRequest struct {
 	worker worker.Worker
-	reply  chan<- struct{}
+	reply  chan struct{}
 }
 
 // New creates a new Catacomb. The caller is reponsible for calling Done exactly
 // once (twice will panic; never will leak a goroutine).
 func New() *Catacomb {
 	catacomb := &Catacomb{
-		requests: make(chan addRequest),
+		adds: make(chan addRequest),
 	}
-	go catacomb.loop()
+	catacomb.wg.Add(1)
+	go func() {
+		defer catacomb.wg.Done()
+		catacomb.loop()
+	}()
 	return catacomb
 }
 
-// loop registers added workers and waits for death.
+// loop registers added workers and waits for death. It must be called exactly
+// once, on its own goroutine.
 func (catacomb *Catacomb) loop() {
 	for {
 		select {
 		case <-catacomb.tomb.Dying():
 			return
-		case request := <-catacomb.requests:
+		case request := <-catacomb.adds:
 			catacomb.add(request)
 		}
 	}
@@ -57,7 +58,9 @@ func (catacomb *Catacomb) loop() {
 
 // Add causes the supplied worker's lifetime to be bound to that of the Catacomb,
 // relieving the client of responsibility for Kill()ing it and Wait()ing for an
-// error, *whether or not this method succeeds*.
+// error, *whether or not this method succeeds*. If the method returns an error,
+// it always indicates that the catacomb is shutting down; the value will either
+// be the error from the (now-stopped) worker, or catacomb.ErrDying().
 //
 // If the worker completes without error, the catacomb will continue unaffected;
 // otherwise the catacomb's tomb will be killed with the returned error. This
@@ -66,17 +69,17 @@ func (catacomb *Catacomb) loop() {
 // until the last moment, and so can be managed pretty casually once they've
 // been added.
 func (catacomb *Catacomb) Add(w worker.Worker) error {
+	adds := catacomb.adds
 	reply := make(chan struct{})
-	requests := catacomb.requests
 	for {
 		select {
 		case <-catacomb.tomb.Dying():
 			if err := worker.Stop(w); err != nil {
 				return errors.Trace(err)
 			}
-			return errors.New("catacomb not alive")
-		case requests <- addRequest{w, reply}:
-			requests = nil
+			return catacomb.ErrDying()
+		case adds <- addRequest{w, reply}:
+			adds = nil
 		case <-reply:
 			return nil
 		}
@@ -111,13 +114,25 @@ func (catacomb *Catacomb) add(request addRequest) {
 	}()
 }
 
-// Kill kills the Catacomb's internal tomb with the supplied error; *unless*
-// the error's Cause is ErrDying or tomb.ErrDying, in which case it passes on
-// tomb.ErrDying instead (which will panic if the tomb isn't already dying).
+// Kill kills the Catacomb's internal tomb with the supplied error, or one
+// derived from it.
+//  * if it's caused by this catacomb's ErrDying, it passes on tomb.ErrDying.
+//  * if it's tomb.ErrDying, or caused by another catacomb's ErrDying, it passes
+//    on a new error complaining about the misuse.
+//  * all other errors are passed on unmodified.
+// It's always safe to call Kill, but errors passed to Kill after the catacomb
+// is dead will be ignored.
 func (catacomb *Catacomb) Kill(err error) {
-	switch cause := errors.Cause(err); cause {
-	case ErrDying, tomb.ErrDying:
-		err = tomb.ErrDying
+	if err == tomb.ErrDying {
+		err = errors.New("bad catacomb Kill: tomb.ErrDying")
+	}
+	cause := errors.Cause(err)
+	if match, ok := cause.(dyingError); ok {
+		if catacomb != match.catacomb {
+			err = errors.Errorf("bad catacomb Kill: other catacomb's ErrDying")
+		} else {
+			err = tomb.ErrDying
+		}
 	}
 	catacomb.tomb.Kill(err)
 }
@@ -125,6 +140,19 @@ func (catacomb *Catacomb) Kill(err error) {
 // Dying returns a channel that will be closed when Kill is called.
 func (catacomb *Catacomb) Dying() <-chan struct{} {
 	return catacomb.tomb.Dying()
+}
+
+// ErrDying returns an error that can be used to Kill *this* catacomb without
+// overwriting nil errors. It should only be used when the catacomb is already
+// known to be dying; calling this method at any other time will return a
+// different error, indicating client misuse.
+func (catacomb *Catacomb) ErrDying() error {
+	select {
+	case <-catacomb.tomb.Dying():
+		return dyingError{catacomb}
+	default:
+		return errors.New("bad catacomb ErrDying: still alive")
+	}
 }
 
 // Done kills the Catacomb's internal tomb (with no error), waits for all added
@@ -138,7 +166,7 @@ func (catacomb *Catacomb) Done() {
 	catacomb.tomb.Done()
 }
 
-// Dead returns a channel that will be closed when Done is called (and thus
+// Dead returns a channel that will be closed when Done has completed (and thus
 // when subsequent calls to Wait() are known not to block).
 func (catacomb *Catacomb) Dead() <-chan struct{} {
 	return catacomb.tomb.Dead()
@@ -148,4 +176,14 @@ func (catacomb *Catacomb) Dead() <-chan struct{} {
 // non-tomb.ErrDying error passed to Kill before Done was called.
 func (catacomb *Catacomb) Wait() error {
 	return catacomb.tomb.Wait()
+}
+
+// dyingError holds a reference to the catacomb that created it.
+type dyingError struct {
+	catacomb *Catacomb
+}
+
+// Error is part of the error interface.
+func (err dyingError) Error() string {
+	return fmt.Sprintf("catacomb %p is dying", err.catacomb)
 }

--- a/worker/catacomb/catacomb.go
+++ b/worker/catacomb/catacomb.go
@@ -1,0 +1,133 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package catacomb
+
+import (
+	"sync"
+
+	"github.com/juju/errors"
+	"launchpad.net/tomb"
+
+	"github.com/juju/juju/worker"
+)
+
+// ErrDying is used to signal acquiescence to a Catacomb's Dying notification.
+// As with tomb.ErrDying, it must not be used in *any* other circumstances, lest
+// it somehow leak into a worker that isn't really dying and cause a panic.
+var ErrDying = errors.New("catacomb is dying")
+
+// Catacomb is a variant of tomb.Tomb with its own internal goroutine, designed
+// for coordinating the lifetimes of a set of private workers needed by a single
+// parent. See the package documentation for detailed discussion and usage notes.
+type Catacomb struct {
+	tomb     tomb.Tomb
+	wg       sync.WaitGroup
+	requests chan addRequest
+}
+
+// addRequest holds a worker that should be added to a catacomb, and a channel
+// that will be closed to confirm successful addition.
+type addRequest struct {
+	worker worker.Worker
+	reply  chan<- struct{}
+}
+
+// New creates a new Catacomb. The caller is reponsible for calling Done exactly
+// once (twice will panic; never will leak a goroutine).
+func New() *Catacomb {
+	catacomb := &Catacomb{
+		requests: make(chan addRequest),
+	}
+	go catacomb.loop()
+	return catacomb
+}
+
+// loop registers added workers and waits for death.
+func (catacomb *Catacomb) loop() {
+	for {
+		select {
+		case <-catacomb.tomb.Dying():
+			return
+		case request := <-catacomb.requests:
+			catacomb.add(request)
+		}
+	}
+}
+
+// Add causes the supplied worker's lifetime to be bound to that of the Catacomb,
+// relieving the client of responsibility for Kill()ing it and Wait()ing for an
+// error, *whether or not this method succeeds*.
+func (catacomb *Catacomb) Add(w worker.Worker) error {
+	reply := make(chan struct{})
+	requests := catacomb.requests
+	for {
+		select {
+		case <-catacomb.tomb.Dying():
+			if err := worker.Stop(w); err != nil {
+				return errors.Trace(err)
+			}
+			return errors.New("catacomb not alive")
+		case requests <- addRequest{w, reply}:
+			requests = nil
+		case <-reply:
+			return nil
+		}
+	}
+}
+
+// add starts two goroutines that (1) kill the catacomb's tomb with any
+// error encountered by the worker; and (2) kill the worker when the
+// catacomb starts dying. The reply channel is closed only once the worker
+// has been recorded in the catacomb's WaitGroup.
+func (catacomb *Catacomb) add(request addRequest) {
+	catacomb.wg.Add(1)
+	close(request.reply)
+	go func() {
+		defer catacomb.wg.Done()
+		catacomb.tomb.Kill(request.worker.Wait())
+	}()
+	go func() {
+		<-catacomb.tomb.Dying()
+		request.worker.Kill()
+	}()
+}
+
+// Kill kills the Catacomb's internal tomb with the supplied error; *unless*
+// the error's Cause is ErrDying or tomb.ErrDying, in which case it passes on
+// tomb.ErrDying instead (which will panic if the tomb isn't already dying).
+func (catacomb *Catacomb) Kill(err error) {
+	switch cause := errors.Cause(err); cause {
+	case ErrDying, tomb.ErrDying:
+		err = tomb.ErrDying
+	}
+	catacomb.tomb.Kill(err)
+}
+
+// Dying returns a channel that will be closed when Kill is called.
+func (catacomb *Catacomb) Dying() <-chan struct{} {
+	return catacomb.tomb.Dying()
+}
+
+// Done kills the Catacomb's internal tomb (with no error), waits for all added
+// workers to complete, and records their errors, before marking the tomb Dead
+// and impervious to further changes.
+// It is safe to call Done without having called Kill.
+// It is incorrect to call Done more than once.
+func (catacomb *Catacomb) Done() {
+	catacomb.tomb.Kill(nil)
+	catacomb.wg.Wait()
+	catacomb.tomb.Done()
+}
+
+// Dead returns a channel that will be closed when Done is called (and thus
+// when subsequent calls to Wait() are known not to block).
+func (catacomb *Catacomb) Dead() <-chan struct{} {
+	return catacomb.tomb.Dead()
+}
+
+// Wait blocks until someone calls Done, and returns the first non-nil and
+// non-tomb.ErrDying error passed to Kill before Done was called.
+func (catacomb *Catacomb) Wait() error {
+	return catacomb.tomb.Wait()
+}

--- a/worker/catacomb/catacomb_test.go
+++ b/worker/catacomb/catacomb_test.go
@@ -1,0 +1,323 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package catacomb_test
+
+import (
+	"time"
+
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"launchpad.net/tomb"
+
+	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/worker/catacomb"
+)
+
+type CatacombSuite struct {
+	testing.IsolationSuite
+	catacomb *catacomb.Catacomb
+}
+
+var _ = gc.Suite(&CatacombSuite{})
+
+func (s *CatacombSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+	s.catacomb = catacomb.New()
+}
+
+func (s *CatacombSuite) TearDownTest(c *gc.C) {
+	if s.catacomb != nil {
+		select {
+		case <-s.catacomb.Dead():
+		default:
+			s.catacomb.Done()
+		}
+	}
+	s.IsolationSuite.TearDownTest(c)
+}
+
+func (s *CatacombSuite) TestStartsAlive(c *gc.C) {
+	s.assertNotDying(c)
+	s.assertNotDead(c)
+}
+
+func (s *CatacombSuite) TestKillClosesDying(c *gc.C) {
+	s.catacomb.Kill(nil)
+	s.assertDying(c)
+}
+
+func (s *CatacombSuite) TestKillDoesNotCloseDead(c *gc.C) {
+	s.catacomb.Kill(nil)
+	s.assertNotDead(c)
+}
+
+func (s *CatacombSuite) TestDoneStopsCompletely(c *gc.C) {
+	s.assertDoneError(c, nil)
+	s.assertDying(c)
+}
+
+func (s *CatacombSuite) TestKillNonNilOverwritesNil(c *gc.C) {
+	s.catacomb.Kill(nil)
+	second := errors.New("blah")
+	s.catacomb.Kill(second)
+	s.assertDoneError(c, second)
+}
+
+func (s *CatacombSuite) TestKillNilDoesNotOverwriteNonNil(c *gc.C) {
+	first := errors.New("blib")
+	s.catacomb.Kill(first)
+	s.catacomb.Kill(nil)
+	s.assertDoneError(c, first)
+}
+
+func (s *CatacombSuite) TestKillNonNilDoesNotOverwriteNonNil(c *gc.C) {
+	first := errors.New("blib")
+	s.catacomb.Kill(first)
+	second := errors.New("blob")
+	s.catacomb.Kill(second)
+	s.assertDoneError(c, first)
+}
+
+func (s *CatacombSuite) TestKillErrDyingDoesNotOverwriteNil(c *gc.C) {
+	s.catacomb.Kill(nil)
+	for _, err := range errDyingVariants {
+		s.catacomb.Kill(err)
+	}
+	s.assertDoneError(c, nil)
+}
+
+func (s *CatacombSuite) TestKillErrDyingDoesNotOverwriteNonNil(c *gc.C) {
+	first := errors.New("FRIST!")
+	s.catacomb.Kill(first)
+	for _, err := range errDyingVariants {
+		s.catacomb.Kill(err)
+	}
+	s.assertDoneError(c, first)
+}
+
+func (s *CatacombSuite) TestKillErrDyingFatalWhenAlive(c *gc.C) {
+	for i, err := range errDyingVariants {
+		c.Logf("test %d", i)
+		f := func() {
+			s.catacomb.Kill(err)
+		}
+		c.Check(f, gc.PanicMatches, "tomb: Kill with ErrDying while still alive")
+	}
+
+	// the attempts panicked, but shouldn't have affected the catacomb itself.
+	s.assertNotDying(c)
+	s.assertNotDead(c)
+}
+
+func (s *CatacombSuite) TestKillStopsAddedWorker(c *gc.C) {
+	w := s.startErrorWorker(c, nil)
+	s.assertAddAlive(c, w)
+
+	s.catacomb.Kill(nil)
+	s.assertDoneError(c, nil)
+	w.assertDead(c)
+}
+
+func (s *CatacombSuite) TestStoppedWorkerErrorOverwritesNil(c *gc.C) {
+	expect := errors.New("splot")
+	w := s.startErrorWorker(c, expect)
+	s.assertAddAlive(c, w)
+
+	s.catacomb.Kill(nil)
+	s.assertDoneError(c, expect)
+	w.assertDead(c)
+}
+
+func (s *CatacombSuite) TestStoppedWorkerErrorDoesNotOverwriteNonNil(c *gc.C) {
+	w := s.startErrorWorker(c, errors.New("not interesting"))
+	s.assertAddAlive(c, w)
+
+	expect := errors.New("splot")
+	s.catacomb.Kill(expect)
+	s.assertDoneError(c, expect)
+	w.assertDead(c)
+}
+
+func (s *CatacombSuite) TestAddWhenDyingStopsWorker(c *gc.C) {
+	w := s.startErrorWorker(c, nil)
+
+	s.catacomb.Kill(nil)
+	err := s.catacomb.Add(w)
+	c.Assert(err, gc.ErrorMatches, "catacomb not alive")
+	w.assertDead(c)
+}
+
+func (s *CatacombSuite) TestAddWhenDyingReturnsWorkerError(c *gc.C) {
+	expect := errors.New("squelch")
+	w := s.startErrorWorker(c, expect)
+
+	s.catacomb.Kill(nil)
+	actual := s.catacomb.Add(w)
+	c.Assert(errors.Cause(actual), gc.Equals, expect)
+	w.assertDead(c)
+}
+
+func (s *CatacombSuite) TestFailedAddedWorkerKills(c *gc.C) {
+	expect := errors.New("blarft")
+	w := s.startErrorWorker(c, expect)
+	s.assertAddAlive(c, w)
+
+	w.Kill()
+	s.waitDying(c)
+	s.assertDoneError(c, expect)
+	w.assertDead(c)
+}
+
+func (s *CatacombSuite) TestAddFailedWorkerKills(c *gc.C) {
+	expect := errors.New("blarft")
+	w := s.startErrorWorker(c, expect)
+	w.Kill()
+	err := s.catacomb.Add(w)
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.waitDying(c)
+	s.assertDoneError(c, expect)
+	w.assertDead(c)
+}
+
+func (s *CatacombSuite) TestFinishAddedWorkerKills(c *gc.C) {
+	w := s.startErrorWorker(c, nil)
+	s.assertAddAlive(c, w)
+
+	w.Kill()
+	s.waitDying(c)
+	s.assertDoneError(c, nil)
+	w.assertDead(c)
+}
+
+func (s *CatacombSuite) TestAddFinishedWorkerKills(c *gc.C) {
+	w := s.startErrorWorker(c, nil)
+	w.Kill()
+	err := s.catacomb.Add(w)
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.waitDying(c)
+	s.assertDoneError(c, nil)
+}
+
+func (s *CatacombSuite) TestStress(c *gc.C) {
+	const workerCount = 100
+	for i := 0; i < workerCount; i++ {
+		w := s.startErrorWorker(c, errors.Errorf("error %d", i))
+		defer w.assertDead(c)
+		err := s.catacomb.Add(w)
+		c.Check(err, jc.ErrorIsNil)
+	}
+	s.catacomb.Done()
+	err := s.catacomb.Wait()
+	c.Check(err, gc.ErrorMatches, "error [0-9]+")
+}
+
+func (s *CatacombSuite) waitDying(c *gc.C) {
+	select {
+	case <-s.catacomb.Dying():
+	case <-time.After(coretesting.LongWait):
+		c.Fatalf("timed out; still alive")
+	}
+}
+
+func (s *CatacombSuite) assertDying(c *gc.C) {
+	select {
+	case <-s.catacomb.Dying():
+	default:
+		c.Fatalf("still alive")
+	}
+}
+
+func (s *CatacombSuite) assertNotDying(c *gc.C) {
+	select {
+	case <-s.catacomb.Dying():
+		c.Fatalf("already dying")
+	default:
+	}
+}
+
+func (s *CatacombSuite) assertDead(c *gc.C) {
+	select {
+	case <-s.catacomb.Dead():
+	default:
+		c.Fatalf("not dead")
+	}
+}
+
+func (s *CatacombSuite) assertNotDead(c *gc.C) {
+	select {
+	case <-s.catacomb.Dead():
+		c.Fatalf("already dead")
+	default:
+	}
+}
+
+func (s *CatacombSuite) assertDoneError(c *gc.C, expect error) {
+	s.catacomb.Done()
+	s.assertDead(c)
+	actual := s.catacomb.Wait()
+	if expect == nil {
+		c.Assert(actual, jc.ErrorIsNil)
+	} else {
+		c.Assert(actual, gc.Equals, expect)
+	}
+}
+
+func (s *CatacombSuite) assertAddAlive(c *gc.C, w *errorWorker) {
+	err := s.catacomb.Add(w)
+	c.Assert(err, jc.ErrorIsNil)
+	w.waitStillAlive(c)
+}
+
+func (s *CatacombSuite) startErrorWorker(c *gc.C, err error) *errorWorker {
+	ew := &errorWorker{}
+	go func() {
+		defer ew.tomb.Done()
+		defer ew.tomb.Kill(err)
+		<-ew.tomb.Dying()
+	}()
+	s.AddCleanup(func(c *gc.C) {
+		ew.Kill()
+		ew.Wait()
+	})
+	return ew
+}
+
+type errorWorker struct {
+	tomb tomb.Tomb
+}
+
+func (ew *errorWorker) Kill() {
+	ew.tomb.Kill(nil)
+}
+
+func (ew *errorWorker) Wait() error {
+	return ew.tomb.Wait()
+}
+
+func (ew *errorWorker) waitStillAlive(c *gc.C) {
+	select {
+	case <-ew.tomb.Dying():
+		c.Fatalf("already dying")
+	case <-time.After(coretesting.ShortWait):
+	}
+}
+
+func (ew *errorWorker) assertDead(c *gc.C) {
+	select {
+	case <-ew.tomb.Dead():
+	default:
+		c.Fatalf("not yet dead")
+	}
+}
+
+var errDyingVariants = []error{
+	tomb.ErrDying,
+	errors.Annotatef(tomb.ErrDying, "disguised"),
+	catacomb.ErrDying,
+	errors.Annotatef(catacomb.ErrDying, "disguised"),
+}

--- a/worker/catacomb/catacomb_test.go
+++ b/worker/catacomb/catacomb_test.go
@@ -183,23 +183,21 @@ func (s *CatacombSuite) TestAddFailedWorkerKills(c *gc.C) {
 	w.assertDead(c)
 }
 
-func (s *CatacombSuite) TestFinishAddedWorkerKills(c *gc.C) {
+func (s *CatacombSuite) TestFinishAddedWorkerDoesNotKill(c *gc.C) {
 	w := s.startErrorWorker(c, nil)
 	s.assertAddAlive(c, w)
-
 	w.Kill()
-	s.waitDying(c)
-	s.assertDoneError(c, nil)
+	s.assertAddAlive(c, s.startErrorWorker(c, nil))
 	w.assertDead(c)
+	s.assertDoneError(c, nil)
 }
 
-func (s *CatacombSuite) TestAddFinishedWorkerKills(c *gc.C) {
+func (s *CatacombSuite) TestAddFinishedWorkerDoesNotKill(c *gc.C) {
 	w := s.startErrorWorker(c, nil)
 	w.Kill()
 	err := s.catacomb.Add(w)
 	c.Assert(err, jc.ErrorIsNil)
-
-	s.waitDying(c)
+	s.assertAddAlive(c, s.startErrorWorker(c, nil))
 	s.assertDoneError(c, nil)
 }
 

--- a/worker/catacomb/doc.go
+++ b/worker/catacomb/doc.go
@@ -1,0 +1,83 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+/*
+Catacomb leverages tomb.Tomb to bind the lifetimes of, and track the errors
+of, a group of related workers. It's intended to be close to a drop-in
+replacement for a Tomb: if you're implementing a worker, the only differences
+should be (1) that a zero Catacomb is not valid, so you need to use New();
+and (2) you can call .Add(someWorker) to bind the worker's lifetime to the
+catacomb, and cause errors from that worker to be exposed via the catacomb.
+
+This approach costs an extra goroutine over tomb.v2, but is slightly more
+robust because Catacomb.Add() verfies worker registration, and is thus safer
+than Tomb.Go(); and, of course, because it's designed to integrate with the
+worker model already common in juju.
+
+Note that a Catacomb is *not* a worker itself, despite the internal goroutine;
+it's a tool to help you construct workers, just like tomb.Tomb.
+
+The canonical expected construction of a catacomb-based worker is almost
+identical to a tomb-based one, with s/tomb/catacomb/ and one extra line:
+
+    func NewWorker(config Config) (worker.Worker, error) {
+        if err := config.Validate(); err != nil {
+            return nil, errors.Trace(err)
+        }
+        w := &someWorker{
+            config:   config,
+            catacomb: catacomb.New(), // This line is new.
+        }
+        go func() {
+            defer w.catacomb.Done()
+            w.catacomb.Kill(w.loop())
+        }()
+        return w, nil
+    }
+
+...with the standard Kill and Wait implementations just as expected:
+
+    func (w *someWorker) Kill() {
+        w.catacomb.Kill(nil)
+    }
+
+    func (w *someWorker) Wait() error {
+        return w.catacomb.Wait()
+    }
+
+...and the ability for loop code to create workers and bind their lifetimes
+to the parent without risking the common misuse of a deferred watcher.Stop()
+that targets the parent's tomb -- which risks causing an initiating loop error
+to be overwritten by a later error from the Stop. Thus, while the Add in:
+
+    func (w *someWorker) loop() error {
+        watch, err := w.config.Facade.WatchSomething()
+        if err != nil {
+            return errors.Annotate(err, "cannot watch something")
+        }
+        if err := w.catacomb.Add(watch); err != nil {
+            // Note that Add takes responsibility for the supplied worker;
+            // if the catacomb can't accept the worker (because it's already
+            // dying) it will stop the worker and directly return any error
+            // thus encountered.
+            return errors.Trace(err)
+        }
+
+        for {
+            select {
+            case <-w.catacomb.Dying():
+                return catacomb.ErrDying
+            case change, ok := <-watch.Changes():
+                 if !ok {
+                     return watcher.EnsureErr(watch)
+                 }
+                 ...
+
+...is not *obviously* superior to `defer watcher.Stop(watch, &w.tomb)`, it
+does in fact behave better; and, furthermore, is more amenable to future
+extension (watcher.Stop is fine *if* the watcher is started in NewWorker,
+and deferred to run *after* the tomb is killed with the loop error; but that
+becomes unwieldy when more than one watcher/worker is needed, and profoundly
+tedious when the set is either large or dynamic).
+*/
+package catacomb

--- a/worker/catacomb/doc.go
+++ b/worker/catacomb/doc.go
@@ -5,9 +5,10 @@
 Catacomb leverages tomb.Tomb to bind the lifetimes of, and track the errors
 of, a group of related workers. It's intended to be close to a drop-in
 replacement for a Tomb: if you're implementing a worker, the only differences
-should be (1) that a zero Catacomb is not valid, so you need to use New();
-and (2) you can call .Add(someWorker) to bind the worker's lifetime to the
-catacomb, and cause errors from that worker to be exposed via the catacomb.
+should be (1) a slightly different creation dance; and (2) you can later call
+.Add(aWorker) to bind the worker's lifetime to the catacomb's, and cause errors
+from that worker to be exposed via the catacomb. Oh, and there's no global
+ErrDying to induce surprising panics when misused.
 
 This approach costs many extra goroutines over tomb.v2, but is slightly more
 robust because Catacomb.Add() verfies worker registration, and is thus safer
@@ -17,21 +18,39 @@ worker.Worker model already common in juju.
 Note that a Catacomb is *not* a worker itself, despite the internal goroutine;
 it's a tool to help you construct workers, just like tomb.Tomb.
 
-The canonical expected construction of a catacomb-based worker is almost
-identical to a tomb-based one, with s/tomb/catacomb/ and one extra line:
+The canonical expected construction of a catacomb-based worker is as follows:
+
+    type someWorker struct {
+        config   Config
+        catacomb catacomb.Catacomb
+        // more fields...
+    }
 
     func NewWorker(config Config) (worker.Worker, error) {
+
+        // This chunk is exactly as you'd expect for a tomb worker: just
+        // create the instance with an implicit zero catacomb.
         if err := config.Validate(); err != nil {
             return nil, errors.Trace(err)
         }
         w := &someWorker{
             config:   config,
-            catacomb: catacomb.New(), // This line is new.
+            // more fields...
         }
-        go func() {
-            defer w.catacomb.Done()
-            w.catacomb.Kill(w.loop())
-        }()
+
+        // Here, instead of starting one's own boilerplate goroutine, just
+        // hand responsibility over to the catacomb package. Evidently, it's
+        // pretty hard to get this code wrong, so some might think it'd be ok
+        // to write a panicky `MustInvoke(*Catacomb, func() error)`; please
+        // don't do this in juju. (Anything that can go wrong will. Let's not
+        // tempt fate.)
+        err := catacomb.Invoke(catacomb.Plan{
+            Site: &w.catacomb,
+            Work: w.loop,
+        })
+        if err != nil {
+            return nil, errors.Trace(err)
+        }
         return w, nil
     }
 
@@ -66,12 +85,25 @@ to be overwritten by a later error from the Stop. Thus, while the Add in:
         for {
             select {
             case <-w.catacomb.Dying():
-                return catacomb.ErrDying
+                // The other important difference is that there's no package-
+                // level ErrDying -- it's just too risky. Catacombs supply
+                // own ErrDying errors, and won't panic when they see them
+                // coming from other catacombs.
+                return w.catacomb.ErrDying()
             case change, ok := <-watch.Changes():
-                 if !ok {
-                     return watcher.EnsureErr(watch)
-                 }
-                 ...
+                if !ok {
+                    // Note: as discussed below, watcher.EnsureErr is an
+                    // antipattern. To actually write this code, we need to
+                    // (1) turn watchers into workers and (2) stop watchers
+                    // closing their channels on error.
+                    return errors.New("something watch failed")
+                }
+                if err := w.handle(change); err != nil {
+                    return nil, errors.Trace(err)
+                }
+            }
+        }
+    }
 
 ...is not *obviously* superior to `defer watcher.Stop(watch, &w.tomb)`, it
 does in fact behave better; and, furthermore, is more amenable to future
@@ -80,9 +112,28 @@ and deferred to run *after* the tomb is killed with the loop error; but that
 becomes unwieldy when more than one watcher/worker is needed, and profoundly
 tedious when the set is either large or dynamic).
 
+And that's not even getting into the issues with `watcher.EnsureErr`: this
+exists entirely because we picked a strange interface for watchers (Stop and
+Err, instead of Kill and Wait) that's not amenable to clean error-gathering;
+so we decided to signal worker errors with a closed change channel.
+
+This solved the immediate problem, but caused us to add EnsureErr to make sure
+we still failed with *some* error if the watcher closed the chan without error:
+either because it broke its contract, or if some *other* component stopped the
+watcher cleanly. That is not ideal: it would be far better *never* to close.
+Then we can expect clients to Add the watch to a catacomb to handle lifetime,
+and they can expect the Changes channel to deliver changes alone.
+
+Of course, client code still has to handle closed channels: once the scope of
+a chan gets beyond a single type, all users have to be properly paranoid, and
+e.g. expect channels to be closed even when the contract explicitly says they
+won't. But that's easy to track, and easy to handle -- just return an error
+complaining that the watcher broke its contract. Done.
+
 It's also important to note that you can easily manage dynamic workers: once
 you've Add()ed the worker you can freely Kill() it at any time; so long as it
 cleans itself up successfully, and returns no error from Wait(), it will be
-silently unregistered and leave the catacomb otherwise unaffected.
+silently unregistered and leave the catacomb otherwise unaffected. And that
+might happen in the loop goroutine; but it'll work just fine from anywhere.
 */
 package catacomb

--- a/worker/catacomb/doc.go
+++ b/worker/catacomb/doc.go
@@ -9,10 +9,10 @@ should be (1) that a zero Catacomb is not valid, so you need to use New();
 and (2) you can call .Add(someWorker) to bind the worker's lifetime to the
 catacomb, and cause errors from that worker to be exposed via the catacomb.
 
-This approach costs an extra goroutine over tomb.v2, but is slightly more
+This approach costs many extra goroutines over tomb.v2, but is slightly more
 robust because Catacomb.Add() verfies worker registration, and is thus safer
 than Tomb.Go(); and, of course, because it's designed to integrate with the
-worker model already common in juju.
+worker.Worker model already common in juju.
 
 Note that a Catacomb is *not* a worker itself, despite the internal goroutine;
 it's a tool to help you construct workers, just like tomb.Tomb.
@@ -79,5 +79,10 @@ extension (watcher.Stop is fine *if* the watcher is started in NewWorker,
 and deferred to run *after* the tomb is killed with the loop error; but that
 becomes unwieldy when more than one watcher/worker is needed, and profoundly
 tedious when the set is either large or dynamic).
+
+It's also important to note that you can easily manage dynamic workers: once
+you've Add()ed the worker you can freely Kill() it at any time; so long as it
+cleans itself up successfully, and returns no error from Wait(), it will be
+silently unregistered and leave the catacomb otherwise unaffected.
 */
 package catacomb

--- a/worker/catacomb/fixture_test.go
+++ b/worker/catacomb/fixture_test.go
@@ -1,0 +1,132 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package catacomb_test
+
+import (
+	"time"
+
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"launchpad.net/tomb"
+
+	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/worker/catacomb"
+)
+
+type cleaner interface {
+	AddCleanup(testing.CleanupFunc)
+}
+
+type fixture struct {
+	catacomb catacomb.Catacomb
+	cleaner  cleaner
+}
+
+func (fix *fixture) run(c *gc.C, task func()) error {
+	err := catacomb.Invoke(catacomb.Plan{
+		Site: &fix.catacomb,
+		Work: func() error { task(); return nil },
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	select {
+	case <-fix.catacomb.Dead():
+	case <-time.After(coretesting.LongWait):
+		c.Fatalf("timed out")
+	}
+	return fix.catacomb.Wait()
+}
+
+func (fix *fixture) waitDying(c *gc.C) {
+	select {
+	case <-fix.catacomb.Dying():
+	case <-time.After(coretesting.LongWait):
+		c.Fatalf("timed out; still alive")
+	}
+}
+
+func (fix *fixture) assertDying(c *gc.C) {
+	select {
+	case <-fix.catacomb.Dying():
+	default:
+		c.Fatalf("still alive")
+	}
+}
+
+func (fix *fixture) assertNotDying(c *gc.C) {
+	select {
+	case <-fix.catacomb.Dying():
+		c.Fatalf("already dying")
+	default:
+	}
+}
+
+func (fix *fixture) assertDead(c *gc.C) {
+	select {
+	case <-fix.catacomb.Dead():
+	default:
+		c.Fatalf("not dead")
+	}
+}
+
+func (fix *fixture) assertNotDead(c *gc.C) {
+	select {
+	case <-fix.catacomb.Dead():
+		c.Fatalf("already dead")
+	default:
+	}
+}
+
+func (fix *fixture) assertAddAlive(c *gc.C, w *errorWorker) {
+	err := fix.catacomb.Add(w)
+	c.Assert(err, jc.ErrorIsNil)
+	w.waitStillAlive(c)
+}
+
+func (fix *fixture) startErrorWorker(c *gc.C, err error) *errorWorker {
+	ew := &errorWorker{}
+	go func() {
+		defer ew.tomb.Done()
+		defer ew.tomb.Kill(err)
+		<-ew.tomb.Dying()
+	}()
+	fix.cleaner.AddCleanup(func(_ *gc.C) {
+		ew.stop()
+	})
+	return ew
+}
+
+type errorWorker struct {
+	tomb tomb.Tomb
+}
+
+func (ew *errorWorker) Kill() {
+	ew.tomb.Kill(nil)
+}
+
+func (ew *errorWorker) Wait() error {
+	return ew.tomb.Wait()
+}
+
+func (ew *errorWorker) stop() {
+	ew.Kill()
+	ew.Wait()
+}
+
+func (ew *errorWorker) waitStillAlive(c *gc.C) {
+	select {
+	case <-ew.tomb.Dying():
+		c.Fatalf("already dying")
+	case <-time.After(coretesting.ShortWait):
+	}
+}
+
+func (ew *errorWorker) assertDead(c *gc.C) {
+	select {
+	case <-ew.tomb.Dead():
+	default:
+		c.Fatalf("not yet dead")
+	}
+}

--- a/worker/catacomb/package_test.go
+++ b/worker/catacomb/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package catacomb_test
+
+import (
+	stdtesting "testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *stdtesting.T) {
+	gc.TestingT(t)
+}

--- a/worker/dependency/engine.go
+++ b/worker/dependency/engine.go
@@ -415,6 +415,10 @@ func (engine *engine) runWorker(name string, delay time.Duration, start StartFun
 		case engine.started <- startedTicket{name, worker, resourceGetter.accessLog}:
 			logger.Tracef("registered %q manifold worker", name)
 		}
+		if worker == engine {
+			<-engine.tomb.Dying()
+			return tomb.ErrDying
+		}
 		return worker.Wait()
 	}
 

--- a/worker/dependency/reporter_test.go
+++ b/worker/dependency/reporter_test.go
@@ -98,12 +98,12 @@ func (s *ReportSuite) TestReportInputs(c *gc.C) {
 	mh1 := newManifoldHarness()
 	err := s.engine.Install("task", mh1.Manifold())
 	c.Assert(err, jc.ErrorIsNil)
-	mh1.AssertStart(c)
+	mh1.AssertOneStart(c)
 
 	mh2 := newManifoldHarness("task")
 	err = s.engine.Install("another task", mh2.Manifold())
 	c.Assert(err, jc.ErrorIsNil)
-	mh2.AssertStart(c)
+	mh2.AssertOneStart(c)
 
 	report := s.engine.Report()
 	c.Check(report, jc.DeepEquals, map[string]interface{}{


### PR DESCRIPTION
Solves a subtle problem with watcher.Stop; and, in general, with tracking *non*-shared worker lifetimes. Not used yet; largely not actually *usable* yet because most of our watchers aren't actually workers; but that's a trivial fix.

Explained in more detail in doc.go.

(Review request: http://reviews.vapour.ws/r/3079/)