### PR TITLE
Refactoring of how the machine agent creates symlinks

### DIFF
--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -1733,13 +1733,20 @@ func (a *MachineAgent) Tag() names.Tag {
 }
 
 func (a *MachineAgent) createJujuRun(dataDir string) error {
+	jujud := filepath.Join(dataDir, "tools", a.Tag().String(), jujunames.Jujud)
+	jujuRunLink := filepath.Join(a.rootDir, JujuRun)
+
 	// TODO do not remove the symlink if it already points
 	// to the right place.
-	if err := os.Remove(JujuRun); err != nil && !os.IsNotExist(err) {
+	if err := os.Remove(jujuRunLink); err != nil && !os.IsNotExist(err) {
 		return err
 	}
-	jujud := filepath.Join(dataDir, "tools", a.Tag().String(), jujunames.Jujud)
-	return symlink.New(jujud, JujuRun)
+
+	err := os.MkdirAll(filepath.Dir(jujuRunLink), os.FileMode(0755))
+	if err != nil {
+		return err
+	}
+	return symlink.New(jujud, jujuRunLink)
 }
 
 // writeUninstallAgentFile creates the uninstall-agent file on disk,
@@ -1775,7 +1782,7 @@ func (a *MachineAgent) uninstallAgent(agentConfig agent.Config) error {
 	}
 
 	// Remove the juju-run symlink.
-	if err := os.Remove(JujuRun); err != nil && !os.IsNotExist(err) {
+	if err := os.Remove(filepath.Join(a.rootDir, JujuRun)); err != nil && !os.IsNotExist(err) {
 		errors = append(errors, err)
 	}
 

--- a/cmd/jujud/main_test.go
+++ b/cmd/jujud/main_test.go
@@ -22,7 +22,6 @@ import (
 	gc "gopkg.in/check.v1"
 	"launchpad.net/gnuflag"
 
-	agentcmd "github.com/juju/juju/cmd/jujud/agent"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/juju/names"
 	coretesting "github.com/juju/juju/testing"
@@ -55,11 +54,6 @@ func mktemp(prefix string, content string) string {
 func TestPackage(t *stdtesting.T) {
 	// TODO(waigani) 2014-03-19 bug 1294458
 	// Refactor to use base suites
-
-	// Change the path to "juju-run", so that the
-	// tests don't try to write to /usr/local/bin.
-	agentcmd.JujuRun = mktemp("juju-run", "")
-	defer os.Remove(agentcmd.JujuRun)
 
 	// Create a CA certificate available for all tests.
 	caCertFile = mktemp("juju-test-cert", coretesting.CACert)

--- a/featuretests/dblog_test.go
+++ b/featuretests/dblog_test.go
@@ -94,7 +94,7 @@ func (s *dblogSuite) runMachineAgentTest(c *gc.C) bool {
 	logsCh, err := logsender.InstallBufferedLogWriter(1000)
 	c.Assert(err, jc.ErrorIsNil)
 	machineAgentFactory := agentcmd.MachineAgentFactoryFn(agentConf, logsCh, nil)
-	a := machineAgentFactory(m.Id())
+	a := machineAgentFactory(m.Id(), c.MkDir())
 
 	// Ensure there's no logs to begin with.
 	c.Assert(s.getLogCount(c, m.Tag()), gc.Equals, 0)

--- a/featuretests/dblog_test.go
+++ b/featuretests/dblog_test.go
@@ -5,7 +5,6 @@ package featuretests
 
 import (
 	"bufio"
-	"io/ioutil"
 	"time"
 
 	"github.com/juju/loggo"
@@ -38,12 +37,6 @@ type dblogSuite struct {
 func (s *dblogSuite) SetUpTest(c *gc.C) {
 	s.SetInitialFeatureFlags("db-log")
 	s.AgentSuite.SetUpTest(c)
-
-	// Change the path to "juju-run", so that the
-	// tests don't try to write to /usr/local/bin.
-	file, _ := ioutil.TempFile("", "juju-run")
-	defer file.Close()
-	s.PatchValue(&agentcmd.JujuRun, file.Name())
 }
 
 func (s *dblogSuite) TestMachineAgentLogsGoToDB(c *gc.C) {


### PR DESCRIPTION
These changes add the concept of a root directory to the machine agent and then use the root directory as a prefix for the /usr/bin/juju-run symlink. The root directory comes from the command Context's directory. This avoids the need to remember to patch out the JujuRun variable in tests that run the machine agent.

Also: the /usr/bin/juju-run symlink is now left alone if it's already correct (previously it would be removed and put back; and a hardcoded path to the agent's tools is avoided.

These changes will make an upcoming change, which requires another symlink in /usr/bin, more straightforward.



(Review request: http://reviews.vapour.ws/r/3082/)