### PR TITLE
apiserver/tools: fix tools upload

### DIFF
--- a/apiserver/tools.go
+++ b/apiserver/tools.go
@@ -204,7 +204,10 @@ func (h *toolsUploadHandler) processPost(r *http.Request, st *state.State) (*too
 	}
 
 	// We'll clone the tools for each additional series specified.
-	cloneSeries := strings.Split(query.Get("series"), ",")
+	var cloneSeries []string
+	if seriesParam := query.Get("series"); seriesParam != "" {
+		cloneSeries = strings.Split(seriesParam, ",")
+	}
 	logger.Debugf("request to upload tools: %s", toolsVersion)
 	logger.Debugf("additional series: %s", cloneSeries)
 

--- a/apiserver/tools_test.go
+++ b/apiserver/tools_test.go
@@ -186,10 +186,12 @@ func (s *toolsSuite) TestUpload(c *gc.C) {
 	s.assertUploadResponse(c, resp, expectedTools[0])
 
 	// Check the contents.
-	_, uploadedData := s.getToolsFromStorage(c, s.State, vers)
+	metadata, uploadedData := s.getToolsFromStorage(c, s.State, vers)
 	expectedData, err := ioutil.ReadFile(toolPath)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(uploadedData, gc.DeepEquals, expectedData)
+	allMetadata := s.getToolsMetadataFromStorage(c, s.State)
+	c.Assert(allMetadata, jc.DeepEquals, []toolstorage.Metadata{metadata})
 }
 
 func (s *toolsSuite) TestBlockUpload(c *gc.C) {
@@ -409,6 +411,15 @@ func (s *toolsSuite) getToolsFromStorage(c *gc.C, st *state.State, vers version.
 	r.Close()
 	c.Assert(err, jc.ErrorIsNil)
 	return metadata, data
+}
+
+func (s *toolsSuite) getToolsMetadataFromStorage(c *gc.C, st *state.State) []toolstorage.Metadata {
+	storage, err := st.ToolsStorage()
+	c.Assert(err, jc.ErrorIsNil)
+	defer storage.Close()
+	metadata, err := storage.AllMetadata()
+	c.Assert(err, jc.ErrorIsNil)
+	return metadata
 }
 
 func (s *toolsSuite) assertToolsNotStored(c *gc.C, vers version.Binary) {


### PR DESCRIPTION
When extra series are not specified, the API server
would incorrectly register a tools archive in storage
with a series of "". This causes errors when the
toolstorage code attempts to unmarshal metadata.

(Review request: http://reviews.vapour.ws/r/3084/)