### PR TITLE
Fixed lp:1483879: Use MAAS 1.8+ devices for containers by default

### DIFF
--- a/api/provisioner/provisioner_test.go
+++ b/api/provisioner/provisioner_test.go
@@ -88,7 +88,7 @@ func (s *provisionerSuite) SetUpTest(c *gc.C) {
 func (s *provisionerSuite) TestPrepareContainerInterfaceInfoNoFeatureFlag(c *gc.C) {
 	s.SetFeatureFlags() // clear the flag
 	ifaceInfo, err := s.provisioner.PrepareContainerInterfaceInfo(names.NewMachineTag("42"))
-	// We'll still attempt to release the address, in case we're running on MAAS
+	// We'll still attempt to reserve an address, in case we're running on MAAS
 	// 1.8+ and have registered the container as a device.
 	c.Assert(err, gc.ErrorMatches, "machine 42 not found")
 	c.Assert(ifaceInfo, gc.HasLen, 0)
@@ -97,8 +97,8 @@ func (s *provisionerSuite) TestPrepareContainerInterfaceInfoNoFeatureFlag(c *gc.
 func (s *provisionerSuite) TestReleaseContainerAddressNoFeatureFlag(c *gc.C) {
 	s.SetFeatureFlags() // clear the flag
 	err := s.provisioner.ReleaseContainerAddresses(names.NewMachineTag("42"))
-	// We'll still attempt to release the address, in case we're running on MAAS
-	// 1.8+ and have registered the container as a device.
+	// We'll still attempt to release all addresses, in case we're running on
+	// MAAS 1.8+ and have registered the container as a device.
 	c.Assert(err, gc.ErrorMatches,
 		`cannot release static addresses for "42": machine 42 not found`,
 	)

--- a/api/provisioner/provisioner_test.go
+++ b/api/provisioner/provisioner_test.go
@@ -88,15 +88,19 @@ func (s *provisionerSuite) SetUpTest(c *gc.C) {
 func (s *provisionerSuite) TestPrepareContainerInterfaceInfoNoFeatureFlag(c *gc.C) {
 	s.SetFeatureFlags() // clear the flag
 	ifaceInfo, err := s.provisioner.PrepareContainerInterfaceInfo(names.NewMachineTag("42"))
-	c.Assert(err, gc.ErrorMatches, "address allocation not supported")
+	// We'll still attempt to release the address, in case we're running on MAAS
+	// 1.8+ and have registered the container as a device.
+	c.Assert(err, gc.ErrorMatches, "machine 42 not found")
 	c.Assert(ifaceInfo, gc.HasLen, 0)
 }
 
 func (s *provisionerSuite) TestReleaseContainerAddressNoFeatureFlag(c *gc.C) {
 	s.SetFeatureFlags() // clear the flag
 	err := s.provisioner.ReleaseContainerAddresses(names.NewMachineTag("42"))
+	// We'll still attempt to release the address, in case we're running on MAAS
+	// 1.8+ and have registered the container as a device.
 	c.Assert(err, gc.ErrorMatches,
-		`cannot release static addresses for "42": address allocation not supported`,
+		`cannot release static addresses for "42": machine 42 not found`,
 	)
 }
 
@@ -835,7 +839,6 @@ func (s *provisionerSuite) TestPrepareContainerInterfaceInfo(c *gc.C) {
 
 	expectInfo := []network.InterfaceInfo{{
 		DeviceIndex:      0,
-		MACAddress:       "aa:bb:cc:dd:ee:f0",
 		CIDR:             "0.10.0.0/24",
 		NetworkName:      "juju-private",
 		ProviderId:       "dummy-eth0",
@@ -845,18 +848,21 @@ func (s *provisionerSuite) TestPrepareContainerInterfaceInfo(c *gc.C) {
 		Disabled:         false,
 		NoAutoStart:      false,
 		ConfigType:       network.ConfigStatic,
-		// Overwrite the Address field below with the actual one, as
-		// it's chosen randomly.
-		Address:        network.Address{},
-		DNSServers:     network.NewAddresses("ns1.dummy", "ns2.dummy"),
-		GatewayAddress: network.NewAddress("0.10.0.2"),
-		ExtraConfig:    nil,
+		DNSServers:       network.NewAddresses("ns1.dummy", "ns2.dummy"),
+		GatewayAddress:   network.NewAddress("0.10.0.2"),
+		ExtraConfig:      nil,
+		// Overwrite Address and MACAddress fields below with the actual ones,
+		// as they are chosen randomly.
+		Address:    network.Address{},
+		MACAddress: "",
 	}}
 	ifaceInfo, err := s.provisioner.PrepareContainerInterfaceInfo(container.MachineTag())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ifaceInfo, gc.HasLen, 1)
 	c.Assert(ifaceInfo[0].Address, gc.Not(gc.DeepEquals), network.Address{})
+	c.Assert(ifaceInfo[0].MACAddress, gc.Not(gc.Equals), "")
 	expectInfo[0].Address = ifaceInfo[0].Address
+	expectInfo[0].MACAddress = ifaceInfo[0].MACAddress
 	c.Assert(ifaceInfo, jc.DeepEquals, expectInfo)
 }
 
@@ -883,7 +889,7 @@ func (s *provisionerSuite) TestReleaseContainerAddresses(c *gc.C) {
 		addr := network.NewAddress(fmt.Sprintf("0.10.0.%d", i))
 		ipaddr, err := s.State.AddIPAddress(addr, sub.ID())
 		c.Check(err, jc.ErrorIsNil)
-		err = ipaddr.AllocateTo(container.Id(), "")
+		err = ipaddr.AllocateTo(container.Id(), "nic42", "aa:bb:cc:dd:ee:f0")
 		c.Check(err, jc.ErrorIsNil)
 	}
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/provisioner/provisioner.go
+++ b/apiserver/provisioner/provisioner.go
@@ -841,6 +841,7 @@ func (p *ProvisionerAPI) ReleaseContainerAddresses(args params.Entities) (params
 		Results: make([]params.ErrorResult, len(args.Entities)),
 	}
 
+	logger.Tracef("checking if the environment supports releasing addresses")
 	netEnviron, err := p.maybeGetNetworkingEnviron()
 	if err != nil {
 		return result, errors.Trace(err)
@@ -875,6 +876,7 @@ func (p *ProvisionerAPI) ReleaseContainerAddresses(args params.Entities) (params
 		}
 
 		if !environs.AddressAllocationEnabled() {
+			logger.Tracef("trying to release all addresses for container %q", container.Id())
 			// Even if the address allocation feature flag is not enabled, we
 			// might be running on MAAS 1.8+ with devices support, which we
 			// detected earlier when the container has starter and registered a
@@ -889,6 +891,7 @@ func (p *ProvisionerAPI) ReleaseContainerAddresses(args params.Entities) (params
 				zeroMAC,
 				hostname,
 			)
+			logger.Tracef("ReleaseAddress for hostname %q returned: %v", hostname, err)
 			if err != nil && errors.IsNotSupported(err) {
 				// Not using MAAS 1.8+, just record the error.
 				result.Results[i].Error = common.ServerError(err)

--- a/apiserver/provisioner/provisioner.go
+++ b/apiserver/provisioner/provisioner.go
@@ -879,7 +879,7 @@ func (p *ProvisionerAPI) ReleaseContainerAddresses(args params.Entities) (params
 			logger.Tracef("trying to release all addresses for container %q", container.Id())
 			// Even if the address allocation feature flag is not enabled, we
 			// might be running on MAAS 1.8+ with devices support, which we
-			// detected earlier when the container has starter and registered a
+			// detected earlier when the container has started and registered a
 			// device for it. Now we can just call ReleaseAddress with the
 			// hostname set and the rest left empty.
 			zeroIP, zeroMAC := network.Address{}, ""
@@ -951,6 +951,9 @@ const MACAddressTemplate = "00:16:3e:%02x:%02x:%02x"
 
 // generateMACAddress creates a random MAC address within the space defined by
 // MACAddressTemplate above.
+//
+// TODO(dimitern): We should make a best effort to ensure the MAC address we
+// generate is unique at least within the current environment.
 func generateMACAddress() string {
 	digits := make([]interface{}, 3)
 	for i := range digits {

--- a/container/kvm/container.go
+++ b/container/kvm/container.go
@@ -9,6 +9,7 @@ import (
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/container"
+	"github.com/juju/juju/network"
 )
 
 type kvmContainer struct {
@@ -33,9 +34,11 @@ func (c *kvmContainer) Start(params StartParams) error {
 		return err
 	}
 	var bridge string
+	var interfaces []network.InterfaceInfo
 	if params.Network != nil {
 		if params.Network.NetworkType == container.BridgeNetwork {
 			bridge = params.Network.Device
+			interfaces = params.Network.Interfaces
 		} else {
 			err := errors.New("Non-bridge network devices not yet supported")
 			logger.Infof(err.Error())
@@ -52,6 +55,7 @@ func (c *kvmContainer) Start(params StartParams) error {
 		Memory:        params.Memory,
 		CpuCores:      params.CpuCores,
 		RootDisk:      params.RootDisk,
+		Interfaces:    interfaces,
 	}); err != nil {
 		return err
 	}

--- a/container/kvm/export_test.go
+++ b/container/kvm/export_test.go
@@ -3,10 +3,12 @@ package kvm
 // This file exports internal package implementations so that tests
 // can utilize them to mock behavior.
 
-var KVMPath = &kvmPath
+var (
+	KVMPath = &kvmPath
 
-// Used to export the parameters used to call Start on the KVM Container
-var TestStartParams = &startParams
+	// Used to export the parameters used to call Start on the KVM Container
+	TestStartParams = &startParams
+)
 
 func NewEmptyKvmContainer() *kvmContainer {
 	return &kvmContainer{}

--- a/container/kvm/kvm_test.go
+++ b/container/kvm/kvm_test.go
@@ -21,6 +21,7 @@ import (
 	containertesting "github.com/juju/juju/container/testing"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/instance"
+	"github.com/juju/juju/network"
 	"github.com/juju/juju/provider/dummy"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/version"
@@ -99,6 +100,60 @@ func (s *KVMSuite) TestCreateContainer(c *gc.C) {
 	name := string(instance.Id())
 	cloudInitFilename := filepath.Join(s.ContainerDir, name, "cloud-init")
 	containertesting.AssertCloudInit(c, cloudInitFilename)
+}
+
+func (s *KVMSuite) TestWriteTemplate(c *gc.C) {
+	params := kvm.CreateMachineParams{
+		Hostname:      "foo-bar",
+		NetworkBridge: "br0",
+		Interfaces: []network.InterfaceInfo{
+			{MACAddress: "00:16:3e:20:b0:11"},
+		},
+	}
+	tempDir := c.MkDir()
+
+	templatePath := filepath.Join(tempDir, "kvm.xml")
+	err := kvm.WriteTemplate(templatePath, params)
+	c.Assert(err, jc.ErrorIsNil)
+	templateBytes, err := ioutil.ReadFile(templatePath)
+	c.Assert(err, jc.ErrorIsNil)
+
+	template := string(templateBytes)
+
+	c.Assert(template, jc.Contains, "<name>foo-bar</name>")
+	c.Assert(template, jc.Contains, "<mac address='00:16:3e:20:b0:11'/>")
+	c.Assert(template, jc.Contains, "<source bridge='br0'/>")
+	c.Assert(strings.Count(string(template), "<interface type='bridge'>"), gc.Equals, 1)
+}
+
+func (s *KVMSuite) TestCreateMachineUsesTemplate(c *gc.C) {
+	const uvtKvmBinName = "uvt-kvm"
+	testing.PatchExecutableAsEchoArgs(c, s, uvtKvmBinName)
+
+	tempDir := c.MkDir()
+	params := kvm.CreateMachineParams{
+		Hostname:      "foo-bar",
+		NetworkBridge: "br0",
+		Interfaces: []network.InterfaceInfo{
+			{MACAddress: "00:16:3e:20:b0:11"},
+		},
+		UserDataFile: filepath.Join(tempDir, "something"),
+	}
+
+	err := kvm.CreateMachine(params)
+	c.Assert(err, jc.ErrorIsNil)
+
+	expectedArgs := []string{
+		"create",
+		"--log-console-output",
+		"--user-data",
+		filepath.Join(tempDir, "something"),
+		"--template",
+		filepath.Join(tempDir, "kvm-template.xml"),
+		"foo-bar",
+	}
+
+	testing.AssertEchoArgs(c, uvtKvmBinName, expectedArgs...)
 }
 
 func (s *KVMSuite) TestDestroyContainer(c *gc.C) {

--- a/container/kvm/libvirt.go
+++ b/container/kvm/libvirt.go
@@ -16,9 +16,12 @@ package kvm
 
 import (
 	"fmt"
+	"path/filepath"
 	"regexp"
 	"strings"
 
+	"github.com/juju/errors"
+	"github.com/juju/juju/network"
 	"github.com/juju/utils"
 )
 
@@ -65,6 +68,7 @@ type CreateMachineParams struct {
 	Memory        uint64
 	CpuCores      uint64
 	RootDisk      uint64
+	Interfaces    []network.InterfaceInfo
 }
 
 // CreateMachine creates a virtual machine and starts it.
@@ -79,9 +83,6 @@ func CreateMachine(params CreateMachineParams) error {
 	if params.UserDataFile != "" {
 		args = append(args, "--user-data", params.UserDataFile)
 	}
-	if params.NetworkBridge != "" {
-		args = append(args, "--bridge", params.NetworkBridge)
-	}
 	if params.Memory != 0 {
 		args = append(args, "--memory", fmt.Sprint(params.Memory))
 	}
@@ -91,6 +92,22 @@ func CreateMachine(params CreateMachineParams) error {
 	if params.RootDisk != 0 {
 		args = append(args, "--disk", fmt.Sprint(params.RootDisk))
 	}
+	if params.NetworkBridge != "" {
+		if len(params.Interfaces) != 0 {
+			templateDir := filepath.Dir(params.UserDataFile)
+
+			templatePath := filepath.Join(templateDir, "kvm-template.xml")
+			err := WriteTemplate(templatePath, params)
+			if err != nil {
+				return errors.Trace(err)
+			}
+
+			args = append(args, "--template", templatePath)
+		} else {
+			args = append(args, "--bridge", params.NetworkBridge)
+		}
+	}
+
 	// TODO add memory, cpu and disk prior to hostname
 	args = append(args, params.Hostname)
 	if params.Series != "" {

--- a/container/kvm/template.go
+++ b/container/kvm/template.go
@@ -1,0 +1,77 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package kvm
+
+import (
+	"bytes"
+	"os"
+	"text/template"
+
+	"github.com/juju/errors"
+)
+
+var kvmTemplate = `
+<domain type='kvm'>
+  <name>{{.Hostname}}</name>
+  <vcpu placement='static'>1</vcpu>
+  <os>
+    <type>hvm</type>
+  </os>
+  <features>
+    <acpi/>
+    <apic/>
+    <pae/>
+  </features>
+  <devices>
+    <controller type='usb' index='0'>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x01' function='0x2'/>
+    </controller>
+    <controller type='pci' index='0' model='pci-root'/>
+    <serial type='stdio'>
+      <target port='0'/>
+    </serial>
+    <console type='stdio'>
+      <target type='serial' port='0'/>
+    </console>
+    <input type='mouse' bus='ps2'/>
+    <input type='keyboard' bus='ps2'/>
+    <graphics type='vnc' port='-1' autoport='yes' listen='127.0.0.1'>
+      <listen type='address' address='127.0.0.1'/>
+    </graphics>
+    <video>
+      <model type='cirrus' vram='9216' heads='1'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x02' function='0x0'/>
+    </video>
+    {{$bridge := .NetworkBridge}}{{range $nic := .Interfaces}}
+    <interface type='bridge'>
+      <mac address='{{$nic.MACAddress}}'/>
+      <model type='virtio'/>
+      <source bridge='{{$bridge}}'/>
+    </interface>
+    {{end}}
+  </devices>
+</domain>
+`
+
+func WriteTemplate(path string, params CreateMachineParams) (err error) {
+	defer errors.DeferredAnnotatef(&err, "cannot write kvm container config")
+
+	tmpl, err := template.New("kvm").Parse(kvmTemplate)
+	if err != nil {
+		return err
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, params); err != nil {
+		return err
+	}
+
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	_, err = f.WriteString(buf.String())
+	return err
+}

--- a/container/lxc/lxc.go
+++ b/container/lxc/lxc.go
@@ -851,7 +851,8 @@ const singleNICTemplate = `
 lxc.network.type = {{.Type}}
 lxc.network.link = {{.Link}}
 lxc.network.flags = up{{if .MTU}}
-lxc.network.mtu = {{.MTU}}{{end}}
+lxc.network.mtu = {{.MTU}}{{end}}{{if .MACAddress}}
+lxc.network.hwaddr = {{.MACAddress}}{{end}}
 
 `
 
@@ -861,8 +862,8 @@ const multipleNICsTemplate = `
 lxc.network.type = {{$nic.Type}}{{if $nic.VLANTag}}
 lxc.network.vlan.id = {{$nic.VLANTag}}{{end}}
 lxc.network.link = {{$nic.Link}}{{if not $nic.NoAutoStart}}
-lxc.network.flags = up{{end}}
-lxc.network.name = {{$nic.Name}}{{if $nic.MACAddress}}
+lxc.network.flags = up{{end}}{{if $nic.Name}}
+lxc.network.name = {{$nic.Name}}{{end}}{{if $nic.MACAddress}}
 lxc.network.hwaddr = {{$nic.MACAddress}}{{end}}{{if $nic.IPv4Address}}
 lxc.network.ipv4 = {{$nic.IPv4Address}}{{end}}{{if $nic.IPv4Gateway}}
 lxc.network.ipv4.gateway = {{$nic.IPv4Gateway}}{{end}}{{if $mtu}}
@@ -885,8 +886,10 @@ func networkConfigTemplate(config container.NetworkConfig) string {
 	type configData struct {
 		Type       string
 		Link       string
-		MTU        int
 		Interfaces []nicData
+		// The following are used only with a single NIC config.
+		MTU        int
+		MACAddress string
 	}
 	data := configData{
 		Link: config.Device,

--- a/environs/networking.go
+++ b/environs/networking.go
@@ -16,11 +16,11 @@ import (
 type Networking interface {
 	// AllocateAddress requests a specific address to be allocated for the
 	// given instance on the given subnet.
-	AllocateAddress(instId instance.Id, subnetId network.Id, addr network.Address) error
+	AllocateAddress(instId instance.Id, subnetId network.Id, addr network.Address, macAddress, hostname string) error
 
 	// ReleaseAddress releases a specific address previously allocated with
 	// AllocateAddress.
-	ReleaseAddress(instId instance.Id, subnetId network.Id, addr network.Address) error
+	ReleaseAddress(instId instance.Id, subnetId network.Id, addr network.Address, macAddress, hostname string) error
 
 	// Subnets returns basic information about subnets known
 	// by the provider for the environment.

--- a/provider/cloudsigma/environinstance.go
+++ b/provider/cloudsigma/environinstance.go
@@ -198,10 +198,10 @@ func (env *environ) StopInstances(instances ...instance.Id) error {
 
 // AllocateAddress requests a new address to be allocated for the
 // given instance on the given network.
-func (env *environ) AllocateAddress(instID instance.Id, netID network.Id, addr network.Address) error {
+func (env *environ) AllocateAddress(instID instance.Id, netID network.Id, addr network.Address, macAddress, hostname string) error {
 	return errors.NotSupportedf("AllocateAddress")
 }
-func (env *environ) ReleaseAddress(instId instance.Id, netId network.Id, addr network.Address) error {
+func (env *environ) ReleaseAddress(instId instance.Id, netId network.Id, addr network.Address, macAddress, hostname string) error {
 	return errors.NotSupportedf("ReleaseAddress")
 }
 func (env *environ) Subnets(inst instance.Id) ([]network.SubnetInfo, error) {

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -164,6 +164,8 @@ type OpAllocateAddress struct {
 	InstanceId instance.Id
 	SubnetId   network.Id
 	Address    network.Address
+	MACAddress string
+	Hostname   string
 }
 
 type OpReleaseAddress struct {
@@ -171,6 +173,8 @@ type OpReleaseAddress struct {
 	InstanceId instance.Id
 	SubnetId   network.Id
 	Address    network.Address
+	MACAddress string
+	Hostname   string
 }
 
 type OpNetworkInterfaces struct {
@@ -1061,7 +1065,7 @@ func (env *environ) SupportsAddressAllocation(subnetId network.Id) (bool, error)
 
 // AllocateAddress requests an address to be allocated for the
 // given instance on the given subnet.
-func (env *environ) AllocateAddress(instId instance.Id, subnetId network.Id, addr network.Address) error {
+func (env *environ) AllocateAddress(instId instance.Id, subnetId network.Id, addr network.Address, macAddress, hostname string) error {
 	if !environs.AddressAllocationEnabled() {
 		return errors.NotSupportedf("address allocation")
 	}
@@ -1082,13 +1086,15 @@ func (env *environ) AllocateAddress(instId instance.Id, subnetId network.Id, add
 		InstanceId: instId,
 		SubnetId:   subnetId,
 		Address:    addr,
+		MACAddress: macAddress,
+		Hostname:   hostname,
 	}
 	return nil
 }
 
 // ReleaseAddress releases a specific address previously allocated with
 // AllocateAddress.
-func (env *environ) ReleaseAddress(instId instance.Id, subnetId network.Id, addr network.Address) error {
+func (env *environ) ReleaseAddress(instId instance.Id, subnetId network.Id, addr network.Address, macAddress, hostname string) error {
 	if !environs.AddressAllocationEnabled() {
 		return errors.NotSupportedf("address allocation")
 	}
@@ -1108,6 +1114,8 @@ func (env *environ) ReleaseAddress(instId instance.Id, subnetId network.Id, addr
 		InstanceId: instId,
 		SubnetId:   subnetId,
 		Address:    addr,
+		MACAddress: macAddress,
+		Hostname:   hostname,
 	}
 	return nil
 }

--- a/provider/ec2/config_test.go
+++ b/provider/ec2/config_test.go
@@ -294,9 +294,15 @@ func (s *ConfigSuite) TestConfig(c *gc.C) {
 func (s *ConfigSuite) TestMissingAuth(c *gc.C) {
 	os.Setenv("AWS_ACCESS_KEY_ID", "")
 	os.Setenv("AWS_SECRET_ACCESS_KEY", "")
+
+	// Since PR #52 amz.v3 uses these AWS_ vars as fallbacks, if set.
+	os.Setenv("AWS_ACCESS_KEY", "")
+	os.Setenv("AWS_SECRET_KEY", "")
+
 	// Since r37 goamz uses these as fallbacks, so unset them too.
 	os.Setenv("EC2_ACCESS_KEY", "")
 	os.Setenv("EC2_SECRET_KEY", "")
+
 	test := configTests[0]
 	test.err = ".*environment has no access-key or secret-key"
 	test.check(c)

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -791,7 +791,7 @@ func (e *environ) fetchNetworkInterfaceId(ec2Inst *ec2.EC2, instId instance.Id) 
 
 // AllocateAddress requests an address to be allocated for the given
 // instance on the given subnet. Implements NetworkingEnviron.AllocateAddress.
-func (e *environ) AllocateAddress(instId instance.Id, _ network.Id, addr network.Address) (err error) {
+func (e *environ) AllocateAddress(instId instance.Id, _ network.Id, addr network.Address, macAddress, hostname string) (err error) {
 	if !environs.AddressAllocationEnabled() {
 		return errors.NotSupportedf("address allocation")
 	}
@@ -829,7 +829,7 @@ func (e *environ) AllocateAddress(instId instance.Id, _ network.Id, addr network
 
 // ReleaseAddress releases a specific address previously allocated with
 // AllocateAddress. Implements NetworkingEnviron.ReleaseAddress.
-func (e *environ) ReleaseAddress(instId instance.Id, _ network.Id, addr network.Address) (err error) {
+func (e *environ) ReleaseAddress(instId instance.Id, _ network.Id, addr network.Address, macAddress, hostname string) (err error) {
 	if !environs.AddressAllocationEnabled() {
 		return errors.NotSupportedf("address allocation")
 	}

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -734,11 +734,11 @@ func (t *localServerSuite) TestAllocateAddressFailureToFindNetworkInterface(c *g
 	addr := network.Address{Value: "8.0.0.4"}
 
 	// Invalid instance found
-	err = env.AllocateAddress(instId+"foo", "", addr)
+	err = env.AllocateAddress(instId+"foo", "", addr, "mac", "host")
 	c.Assert(err, gc.ErrorMatches, ".*InvalidInstanceID.NotFound.*")
 
 	// No network interface
-	err = env.AllocateAddress(instId, "", addr)
+	err = env.AllocateAddress(instId, "", addr, "mac", "host")
 	c.Assert(errors.Cause(err), gc.ErrorMatches, "unexpected AWS response: network interface not found")
 }
 
@@ -767,7 +767,7 @@ func (t *localServerSuite) TestAllocateAddress(c *gc.C) {
 	}
 	t.PatchValue(&ec2.AssignPrivateIPAddress, mockAssign)
 
-	err := env.AllocateAddress(instId, "", addr)
+	err := env.AllocateAddress(instId, "", addr, "mac", "host")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(actualAddr, gc.Equals, addr)
 }
@@ -781,10 +781,10 @@ func (t *localServerSuite) TestAllocateAddressIPAddressInUseOrEmpty(c *gc.C) {
 	}
 	t.PatchValue(&ec2.AssignPrivateIPAddress, mockAssign)
 
-	err := env.AllocateAddress(instId, "", addr)
+	err := env.AllocateAddress(instId, "", addr, "mac", "host")
 	c.Assert(errors.Cause(err), gc.Equals, environs.ErrIPAddressUnavailable)
 
-	err = env.AllocateAddress(instId, "", network.Address{})
+	err = env.AllocateAddress(instId, "", network.Address{}, "", "")
 	c.Assert(errors.Cause(err), gc.Equals, environs.ErrIPAddressUnavailable)
 }
 
@@ -797,7 +797,7 @@ func (t *localServerSuite) TestAllocateAddressNetworkInterfaceFull(c *gc.C) {
 	}
 	t.PatchValue(&ec2.AssignPrivateIPAddress, mockAssign)
 
-	err := env.AllocateAddress(instId, "", addr)
+	err := env.AllocateAddress(instId, "", addr, "", "")
 	c.Assert(errors.Cause(err), gc.Equals, environs.ErrIPAddressesExhausted)
 }
 
@@ -805,15 +805,15 @@ func (t *localServerSuite) TestReleaseAddress(c *gc.C) {
 	env, instId := t.setUpInstanceWithDefaultVpc(c)
 	addr := network.Address{Value: "8.0.0.4"}
 	// Allocate the address first so we can release it
-	err := env.AllocateAddress(instId, "", addr)
+	err := env.AllocateAddress(instId, "", addr, "", "")
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = env.ReleaseAddress(instId, "", addr)
+	err = env.ReleaseAddress(instId, "", addr, "", "")
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Releasing a second time tests that the first call actually released
 	// it plus tests the error handling of ReleaseAddress
-	err = env.ReleaseAddress(instId, "", addr)
+	err = env.ReleaseAddress(instId, "", addr, "", "")
 	msg := fmt.Sprintf(`failed to release address "8\.0\.0\.4" from instance %q.*`, instId)
 	c.Assert(err, gc.ErrorMatches, msg)
 }
@@ -824,7 +824,7 @@ func (t *localServerSuite) TestReleaseAddressUnknownInstance(c *gc.C) {
 	// We should be able to release an address with an unknown instance id
 	// without it being allocated.
 	addr := network.Address{Value: "8.0.0.4"}
-	err := env.ReleaseAddress(instance.UnknownId, "", addr)
+	err := env.ReleaseAddress(instance.UnknownId, "", addr, "", "")
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -901,7 +901,7 @@ func (t *localServerSuite) TestSupportsAddressAllocationWithNoFeatureFlag(c *gc.
 func (t *localServerSuite) TestAllocateAddressWithNoFeatureFlag(c *gc.C) {
 	t.SetFeatureFlags() // clear the flags.
 	env := t.prepareEnviron(c)
-	err := env.AllocateAddress("i-foo", "net1", network.NewAddresses("1.2.3.4")[0])
+	err := env.AllocateAddress("i-foo", "net1", network.NewAddresses("1.2.3.4")[0], "mac", "host")
 	c.Assert(err, gc.ErrorMatches, "address allocation not supported")
 	c.Assert(err, jc.Satisfies, errors.IsNotSupported)
 }
@@ -909,7 +909,7 @@ func (t *localServerSuite) TestAllocateAddressWithNoFeatureFlag(c *gc.C) {
 func (t *localServerSuite) TestReleaseAddressWithNoFeatureFlag(c *gc.C) {
 	t.SetFeatureFlags() // clear the flags.
 	env := t.prepareEnviron(c)
-	err := env.ReleaseAddress("i-foo", "net1", network.NewAddresses("1.2.3.4")[0])
+	err := env.ReleaseAddress("i-foo", "net1", network.NewAddresses("1.2.3.4")[0], "mac", "host")
 	c.Assert(err, gc.ErrorMatches, "address allocation not supported")
 	c.Assert(err, jc.Satisfies, errors.IsNotSupported)
 }

--- a/provider/gce/environ_network.go
+++ b/provider/gce/environ_network.go
@@ -12,12 +12,12 @@ import (
 )
 
 // AllocateAddress implements environs.Environ, but is not implmemented.
-func (env *environ) AllocateAddress(instID instance.Id, netID network.Id, addr network.Address) error {
+func (env *environ) AllocateAddress(instID instance.Id, netID network.Id, addr network.Address, macAddress, hostname string) error {
 	return errors.Trace(errNotImplemented)
 }
 
 // ReleaseAddress implements environs.Environ, but is not implmemented.
-func (env *environ) ReleaseAddress(instID instance.Id, netID network.Id, addr network.Address) error {
+func (env *environ) ReleaseAddress(instID instance.Id, netID network.Id, addr network.Address, macAddress, hostname string) error {
 	return errors.Trace(errNotImplemented)
 }
 

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -102,6 +102,10 @@ type maasEnviron struct {
 
 	availabilityZonesMutex sync.Mutex
 	availabilityZones      []common.AvailabilityZone
+
+	// Those are initialized from the MAAS API capabilities, if supported.
+	devicesAPISupported bool
+	staticIPsSupported  bool
 }
 
 var _ environs.Environ = (*maasEnviron)(nil)
@@ -114,11 +118,32 @@ func NewEnviron(cfg *config.Config) (*maasEnviron, error) {
 	}
 	env.name = cfg.Name()
 	env.storageUnlocked = NewStorage(env)
+
+	// Since we need to switch behavior based on the available API capabilities,
+	// get them as soon as possible and cache them.
+	capabilities, err := env.getCapabilities()
+	if err != nil {
+		logger.Warningf("cannot get MAAS API capabilities: %v", err)
+	}
+	logger.Debugf("MAAS API capabilities: %v", capabilities.SortedValues())
+	env.devicesAPISupported = capabilities.Contains(capDevices)
+	env.staticIPsSupported = capabilities.Contains(capStaticIPAddresses)
 	return env, nil
 }
 
+const noDevicesWarning = `
+Using MAAS version older than 1.8.2: devices API support not detected!
+
+Juju cannot guarantee resources allocated to containers, like DHCP
+leases or static IP addresses will be properly cleaned up when the
+container, its host, or the environment is destroyed.
+
+Juju recommends upgrading MAAS to version 1.8.2 or later.
+`
+
 // Bootstrap is specified in the Environ interface.
 func (env *maasEnviron) Bootstrap(ctx environs.BootstrapContext, args environs.BootstrapParams) (arch, series string, _ environs.BootstrapFinalizer, _ error) {
+
 	if !environs.AddressAllocationEnabled() {
 		// When address allocation is not enabled, we should use the
 		// default bridge for both LXC and KVM containers. The bridge
@@ -129,6 +154,11 @@ func (env *maasEnviron) Bootstrap(ctx environs.BootstrapContext, args environs.B
 			instancecfg.DefaultBridgeName,
 		)
 		args.ContainerBridgeName = instancecfg.DefaultBridgeName
+
+		if !env.devicesAPISupported {
+			// Inform the user container resources might leak.
+			ctx.Infof("WARNING: %s", noDevicesWarning)
+		}
 	} else {
 		logger.Debugf(
 			"address allocation feature enabled; using static IPs for containers: %q",
@@ -235,14 +265,15 @@ func (env *maasEnviron) SupportedArchitectures() ([]string, error) {
 // SupportsAddressAllocation is specified on environs.Networking.
 func (env *maasEnviron) SupportsAddressAllocation(_ network.Id) (bool, error) {
 	if !environs.AddressAllocationEnabled() {
-		return false, errors.NotSupportedf("address allocation")
+		if !env.devicesAPISupported {
+			return false, errors.NotSupportedf("address allocation")
+		} else {
+			// We can use devices for DHCP-allocated container IPs.
+			return true, nil
+		}
 	}
 
-	caps, err := env.getCapabilities()
-	if err != nil {
-		return false, errors.Annotatef(err, "getCapabilities failed")
-	}
-	return caps.Contains(capStaticIPAddresses), nil
+	return env.staticIPsSupported, nil
 }
 
 // allBootImages queries MAAS for all of the boot-images across
@@ -521,6 +552,7 @@ func (env *maasEnviron) PrecheckInstance(series string, cons constraints.Value, 
 const (
 	capNetworksManagement = "networks-management"
 	capStaticIPAddresses  = "static-ipaddresses"
+	capDevices            = "devices-management"
 )
 
 // getCapabilities asks the MAAS server for its capabilities, if
@@ -1388,11 +1420,119 @@ func (environ *maasEnviron) Instances(ids []instance.Id) ([]instance.Instance, e
 	return result, nil
 }
 
+// newDevice creates a new MAAS device for a MAC address, returning the Id of
+// the new device.
+func (environ *maasEnviron) newDevice(macAddress string, instId instance.Id, hostname string) (string, error) {
+	client := environ.getMAASClient()
+	devices := client.GetSubObject("devices")
+	params := url.Values{}
+	params.Add("mac_addresses", macAddress)
+	params.Add("hostname", hostname)
+	params.Add("parent", extractSystemId(instId))
+	logger.Tracef("creating a new MAAS device for MAC %q, hostname %q, parent %q", macAddress, hostname, string(instId))
+	result, err := devices.CallPost("new", params)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	resultMap, err := result.GetMap()
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	device, err := resultMap["system_id"].GetString()
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	return device, nil
+}
+
+// fetchFullDevice fetches an existing device Id associated with a MAC address
+// and/or hostname, or returns an error if there is no device.
+func (environ *maasEnviron) fetchFullDevice(macAddress, hostname string) (map[string]gomaasapi.JSONObject, error) {
+	client := environ.getMAASClient()
+	devices := client.GetSubObject("devices")
+	params := url.Values{}
+	if macAddress != "" {
+		params.Add("mac_address", macAddress)
+	}
+	if hostname != "" {
+		params.Add("hostname", macAddress)
+	}
+	result, err := devices.CallGet("list", params)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	resultArray, err := result.GetArray()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if len(resultArray) == 0 {
+		return nil, errors.NotFoundf("no device for MAC %q and/or hostname %q", macAddress, hostname)
+	}
+	if len(resultArray) != 1 {
+		return nil, errors.Errorf("unexpected response, expected 1 device got %d", len(resultArray))
+	}
+	resultMap, err := resultArray[0].GetMap()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return resultMap, nil
+}
+
+func (environ *maasEnviron) fetchDevice(macAddress, hostname string) (string, error) {
+	deviceMap, err := environ.fetchFullDevice(macAddress, hostname)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+
+	deviceId, err := deviceMap["system_id"].GetString()
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	return deviceId, nil
+}
+
+// createOrFetchDevice returns a device Id associated with a MAC address. If
+// there is not already one it will create one.
+func (environ *maasEnviron) createOrFetchDevice(macAddress string, instId instance.Id, hostname string) (string, error) {
+	device, err := environ.fetchDevice(macAddress, hostname)
+	if err == nil {
+		return device, nil
+	}
+	if !errors.IsNotFound(err) {
+		return "", errors.Trace(err)
+	}
+	device, err = environ.newDevice(macAddress, instId, hostname)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	return device, nil
+}
+
 // AllocateAddress requests an address to be allocated for the
 // given instance on the given network.
-func (environ *maasEnviron) AllocateAddress(instId instance.Id, subnetId network.Id, addr network.Address) (err error) {
+func (environ *maasEnviron) AllocateAddress(instId instance.Id, subnetId network.Id, addr network.Address, macAddress, hostname string) (err error) {
+
 	if !environs.AddressAllocationEnabled() {
-		return errors.NotSupportedf("address allocation")
+		if !environ.devicesAPISupported {
+			logger.Warningf(
+				"resources used by container %q with MAC address %q can leak: devices API not supported",
+				hostname, macAddress,
+			)
+			return errors.NotSupportedf("address allocation")
+		}
+		deviceID, err := environ.createOrFetchDevice(macAddress, instId, hostname)
+		if err != nil {
+			return errors.Annotatef(
+				err,
+				"creating MAAS device for container %q with MAC address %q",
+				hostname, macAddress,
+			)
+		}
+		logger.Infof(
+			"created device %q for container %q with MAC address %q on parent node %q",
+			deviceID, hostname, macAddress, instId,
+		)
+		return nil
 	}
 
 	defer errors.DeferredAnnotatef(&err, "failed to allocate address %q for instance %q", addr, instId)
@@ -1441,9 +1581,34 @@ func (environ *maasEnviron) AllocateAddress(instId instance.Id, subnetId network
 
 // ReleaseAddress releases a specific address previously allocated with
 // AllocateAddress.
-func (environ *maasEnviron) ReleaseAddress(instId instance.Id, _ network.Id, addr network.Address) (err error) {
+func (environ *maasEnviron) ReleaseAddress(instId instance.Id, _ network.Id, addr network.Address, macAddress, hostname string) (err error) {
+
 	if !environs.AddressAllocationEnabled() {
-		return errors.NotSupportedf("address allocation")
+		if !environ.devicesAPISupported {
+			logger.Warningf(
+				"resources used by container %q with MAC address %q can leak: devices API not supported",
+				instId, macAddress,
+			)
+			return errors.NotSupportedf("address allocation")
+		}
+		deviceID, err := environ.fetchDevice(macAddress, hostname)
+		if err != nil {
+			return errors.Annotatef(
+				err,
+				"getting MAAS device for container %q with MAC address %q",
+				hostname, macAddress,
+			)
+		}
+		apiDevice := environ.getMAASClient().GetSubObject("devices").GetSubObject(deviceID)
+		if err := apiDevice.Delete(); err != nil {
+			return errors.Annotatef(
+				err,
+				"deleting MAAS device %q for container %q with MAC address %q",
+				deviceID, instId, macAddress,
+			)
+		}
+		logger.Debugf("deleted device %q for container %q with MAC address %q", deviceID, instId, macAddress)
+		return nil
 	}
 
 	defer errors.DeferredAnnotatef(&err, "failed to release IP address %q from instance %q", addr, instId)
@@ -1656,6 +1821,11 @@ func (env *maasEnviron) Storage() storage.Storage {
 }
 
 func (environ *maasEnviron) Destroy() error {
+	if !environ.devicesAPISupported {
+		// Warn the user that container resources can leak.
+		logger.Warningf(noDevicesWarning)
+	}
+
 	if err := common.Destroy(environ); err != nil {
 		return errors.Trace(err)
 	}

--- a/provider/vsphere/environ_network.go
+++ b/provider/vsphere/environ_network.go
@@ -13,12 +13,12 @@ import (
 )
 
 // AllocateAddress implements environs.Environ.
-func (env *environ) AllocateAddress(instID instance.Id, netID network.Id, addr network.Address) error {
+func (env *environ) AllocateAddress(instID instance.Id, netID network.Id, addr network.Address, macAddress, hostname string) error {
 	return env.changeAddress(instID, netID, addr, true)
 }
 
 // ReleaseAddress implements environs.Environ:w.
-func (env *environ) ReleaseAddress(instID instance.Id, netID network.Id, addr network.Address) error {
+func (env *environ) ReleaseAddress(instID instance.Id, netID network.Id, addr network.Address, macAddress, hostname string) error {
 	return env.changeAddress(instID, netID, addr, false)
 }
 

--- a/state/ipaddresses.go
+++ b/state/ipaddresses.go
@@ -55,6 +55,7 @@ type ipaddressDoc struct {
 	Life        Life         `bson:"life"`
 	SubnetId    string       `bson:"subnetid,omitempty"`
 	MachineId   string       `bson:"machineid,omitempty"`
+	MACAddress  string       `bson:"macaddress,omitempty"`
 	InstanceId  string       `bson:"instanceid,omitempty"`
 	InterfaceId string       `bson:"interfaceid,omitempty"`
 	Value       string       `bson:"value"`
@@ -91,6 +92,12 @@ func (i *IPAddress) MachineId() string {
 // instance.UnknownId).
 func (i *IPAddress) InstanceId() instance.Id {
 	return instance.Id(i.doc.InstanceId)
+}
+
+// MACAddress returns the MAC address of the container NIC the IP address is
+// associated with.
+func (i *IPAddress) MACAddress() string {
+	return i.doc.MACAddress
 }
 
 // InterfaceId returns the ID of the network interface the IP address is
@@ -242,10 +249,10 @@ func (i *IPAddress) SetState(newState AddressState) (err error) {
 	return nil
 }
 
-// AllocateTo sets the machine ID and interface ID of the IP address.
-// It will fail if the state is not AddressStateUnknown. On success,
-// the address state will also change to AddressStateAllocated.
-func (i *IPAddress) AllocateTo(machineId, interfaceId string) (err error) {
+// AllocateTo sets the machine ID, interface ID, and the underlying MAC address
+// of the IP address. It will fail if the state is not AddressStateUnknown. On
+// success, the address state will also change to AddressStateAllocated.
+func (i *IPAddress) AllocateTo(machineId, interfaceId, macAddress string) (err error) {
 	defer errors.DeferredAnnotatef(&err, "cannot allocate IP address %q to machine %q, interface %q", i, machineId, interfaceId)
 
 	var instId instance.Id
@@ -290,6 +297,7 @@ func (i *IPAddress) AllocateTo(machineId, interfaceId string) (err error) {
 					{"machineid", machineId},
 					{"interfaceid", interfaceId},
 					{"instanceid", instId},
+					{"macaddress", macAddress},
 					{"state", string(AddressStateAllocated)},
 				},
 				}},
@@ -302,6 +310,7 @@ func (i *IPAddress) AllocateTo(machineId, interfaceId string) (err error) {
 		return err
 	}
 	i.doc.MachineId = machineId
+	i.doc.MACAddress = macAddress
 	i.doc.InterfaceId = interfaceId
 	i.doc.State = AddressStateAllocated
 	i.doc.InstanceId = string(instId)

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -472,22 +472,22 @@ func (s *MachineSuite) TestRemoveMarksAddressesAsDead(c *gc.C) {
 
 	addr1, err := s.State.AddIPAddress(network.NewAddress("10.0.0.1"), "foo")
 	c.Assert(err, jc.ErrorIsNil)
-	err = addr1.AllocateTo(s.machine.Id(), "bar")
+	err = addr1.AllocateTo(s.machine.Id(), "bar", "mac")
 	c.Assert(err, jc.ErrorIsNil)
 
 	addr2, err := s.State.AddIPAddress(network.NewAddress("10.0.0.2"), "foo")
 	c.Assert(err, jc.ErrorIsNil)
-	err = addr2.AllocateTo(s.machine.Id(), "bar")
+	err = addr2.AllocateTo(s.machine.Id(), "bar", "mac")
 	c.Assert(err, jc.ErrorIsNil)
 
 	addr3, err := s.State.AddIPAddress(network.NewAddress("10.0.0.3"), "bar")
 	c.Assert(err, jc.ErrorIsNil)
-	err = addr3.AllocateTo(s.machine0.Id(), "bar")
+	err = addr3.AllocateTo(s.machine0.Id(), "bar", "mac")
 	c.Assert(err, jc.ErrorIsNil)
 
 	addr4, err := s.State.AddIPAddress(network.NewAddress("10.0.0.4"), "foo")
 	c.Assert(err, jc.ErrorIsNil)
-	err = addr4.AllocateTo(s.machine.Id(), "bar")
+	err = addr4.AllocateTo(s.machine.Id(), "bar", "mac")
 	c.Assert(err, jc.ErrorIsNil)
 	err = addr4.EnsureDead()
 	c.Assert(err, jc.ErrorIsNil)

--- a/worker/addresser/worker.go
+++ b/worker/addresser/worker.go
@@ -22,7 +22,7 @@ var logger = loggo.GetLogger("juju.worker.addresser")
 type releaser interface {
 	// ReleaseAddress has the same signature as the same method in the
 	// environs.Networking interface.
-	ReleaseAddress(instance.Id, network.Id, network.Address) error
+	ReleaseAddress(instance.Id, network.Id, network.Address, string, string) error
 }
 
 // stateAddresser defines the State methods used by the addresserHandler
@@ -105,7 +105,8 @@ func (a *addresserHandler) releaseIPAddress(addr *state.IPAddress) (err error) {
 
 	subnetId := network.Id(addr.SubnetId())
 	for attempt := common.ShortAttempt.Start(); attempt.Next(); {
-		err = a.releaser.ReleaseAddress(addr.InstanceId(), subnetId, addr.Address())
+		// Since we're passing the MAC address below, hostname can be empty.
+		err = a.releaser.ReleaseAddress(addr.InstanceId(), subnetId, addr.Address(), addr.MACAddress(), "")
 		if err == nil {
 			return nil
 		}

--- a/worker/addresser/worker_test.go
+++ b/worker/addresser/worker_test.go
@@ -62,9 +62,9 @@ func (s *workerSuite) createAddresses(c *gc.C) {
 		ipAddr, err := s.State.AddIPAddress(addr, "foobar")
 		c.Assert(err, jc.ErrorIsNil)
 		if i%2 == 1 {
-			err = ipAddr.AllocateTo(s.machine2.Id(), "wobble")
+			err = ipAddr.AllocateTo(s.machine2.Id(), "wobble", "mac")
 		} else {
-			err = ipAddr.AllocateTo(s.machine.Id(), "wobble")
+			err = ipAddr.AllocateTo(s.machine.Id(), "wobble", "mac")
 			c.Assert(err, jc.ErrorIsNil)
 		}
 
@@ -103,6 +103,7 @@ func makeReleaseOp(digit int) dummy.OpReleaseAddress {
 		InstanceId: "foo",
 		SubnetId:   "foobar",
 		Address:    network.NewAddress(fmt.Sprintf("0.1.2.%d", digit)),
+		MACAddress: "mac",
 	}
 }
 
@@ -157,7 +158,7 @@ func (s *workerSuite) TestWorkerIgnoresAliveAddresses(c *gc.C) {
 	addr := network.NewAddress("0.1.2.9")
 	ipAddr, err := s.State.AddIPAddress(addr, "foobar")
 	c.Assert(err, jc.ErrorIsNil)
-	err = ipAddr.AllocateTo(s.machine.Id(), "wobble")
+	err = ipAddr.AllocateTo(s.machine.Id(), "wobble", "mac")
 	c.Assert(err, jc.ErrorIsNil)
 
 	// The worker must not kill this address.
@@ -211,9 +212,10 @@ func (s *workerSuite) TestMachineRemovalTriggersWorker(c *gc.C) {
 
 	addr, err := s.State.AddIPAddress(network.NewAddress("0.1.2.9"), "foobar")
 	c.Assert(err, jc.ErrorIsNil)
-	err = addr.AllocateTo(machine.Id(), "foo")
+	err = addr.AllocateTo(machine.Id(), "foo", "mac")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(addr.InstanceId(), gc.Equals, instance.Id("foo"))
+	c.Assert(addr.MACAddress(), gc.Equals, "mac")
 	s.State.StartSync()
 
 	err = machine.EnsureDead()

--- a/worker/provisioner/kvm-broker.go
+++ b/worker/provisioner/kvm-broker.go
@@ -126,8 +126,11 @@ func (broker *kvmBroker) StartInstance(args environs.StartInstanceParams) (*envi
 	}, nil
 }
 
-// MaintainInstance checks that the container's host has the required iptables and routing
-// rules to make the container visible to both the host and other machines on the same subnet.
+// MaintainInstance ensures the container's host has the required iptables and
+// routing rules to make the container visible to both the host and other
+// machines on the same subnet. This is important mostly when address allocation
+// feature flag is enabled, as otherwise we don't create additional iptables
+// rules or routes.
 func (broker *kvmBroker) MaintainInstance(args environs.StartInstanceParams) error {
 	machineID := args.InstanceConfig.MachineId
 

--- a/worker/provisioner/kvm-broker.go
+++ b/worker/provisioner/kvm-broker.go
@@ -25,12 +25,15 @@ func NewKvmBroker(
 	managerConfig container.ManagerConfig,
 	enableNAT bool,
 ) (environs.InstanceBroker, error) {
+	namespace := maybeGetManagerConfigNamespaces(managerConfig)
+
 	manager, err := kvm.NewContainerManager(managerConfig)
 	if err != nil {
 		return nil, err
 	}
 	return &kvmBroker{
 		manager:     manager,
+		namespace:   namespace,
 		api:         api,
 		agentConfig: agentConfig,
 		enableNAT:   enableNAT,
@@ -39,6 +42,7 @@ func NewKvmBroker(
 
 type kvmBroker struct {
 	manager     container.Manager
+	namespace   string
 	api         APICalls
 	agentConfig agent.Config
 	enableNAT   bool
@@ -60,29 +64,22 @@ func (broker *kvmBroker) StartInstance(args environs.StartInstanceParams) (*envi
 	if bridgeDevice == "" {
 		bridgeDevice = kvm.DefaultKvmBridge
 	}
-	if !environs.AddressAllocationEnabled() {
-		logger.Debugf(
-			"address allocation feature flag not enabled; using DHCP for container %q",
-			machineId,
-		)
-	} else {
-		logger.Debugf("trying to allocate static IP for container %q", machineId)
 
-		allocatedInfo, err := configureContainerNetwork(
-			machineId,
-			bridgeDevice,
-			broker.api,
-			args.NetworkInfo,
-			true, // allocate a new address.
-			broker.enableNAT,
-		)
-		if err != nil {
-			// It's fine, just ignore it. The effect will be that the
-			// container won't have a static address configured.
-			logger.Infof("not allocating static IP for container %q: %v", machineId, err)
-		} else {
-			args.NetworkInfo = allocatedInfo
-		}
+	preparedInfo, err := prepareOrGetContainerInterfaceInfo(
+		broker.api,
+		machineId,
+		bridgeDevice,
+		true, // allocate if possible, do not maintain existing.
+		broker.enableNAT,
+		args.NetworkInfo,
+		kvmLogger,
+	)
+	if err != nil {
+		// It's not fatal (yet) if we couldn't pre-allocate addresses for the
+		// container.
+		logger.Warningf("failed to prepare container %q network config: %v", machineId, err)
+	} else {
+		args.NetworkInfo = preparedInfo
 	}
 
 	// Unlike with LXC, we don't override the default MTU to use.
@@ -129,6 +126,30 @@ func (broker *kvmBroker) StartInstance(args environs.StartInstanceParams) (*envi
 	}, nil
 }
 
+// MaintainInstance checks that the container's host has the required iptables and routing
+// rules to make the container visible to both the host and other machines on the same subnet.
+func (broker *kvmBroker) MaintainInstance(args environs.StartInstanceParams) error {
+	machineID := args.InstanceConfig.MachineId
+
+	// Default to using the host network until we can configure.
+	bridgeDevice := broker.agentConfig.Value(agent.LxcBridge)
+	if bridgeDevice == "" {
+		bridgeDevice = kvm.DefaultKvmBridge
+	}
+
+	// There's no InterfaceInfo we expect to get below.
+	_, err := prepareOrGetContainerInterfaceInfo(
+		broker.api,
+		machineID,
+		bridgeDevice,
+		false, // maintain, do not allocate.
+		broker.enableNAT,
+		args.NetworkInfo,
+		kvmLogger,
+	)
+	return err
+}
+
 // StopInstances shuts down the given instances.
 func (broker *kvmBroker) StopInstances(ids ...instance.Id) error {
 	// TODO: potentially parallelise.
@@ -138,6 +159,7 @@ func (broker *kvmBroker) StopInstances(ids ...instance.Id) error {
 			kvmLogger.Errorf("container did not stop: %v", err)
 			return err
 		}
+		maybeReleaseContainerAddresses(broker.api, id, broker.namespace, kvmLogger)
 	}
 	return nil
 }
@@ -145,32 +167,4 @@ func (broker *kvmBroker) StopInstances(ids ...instance.Id) error {
 // AllInstances only returns running containers.
 func (broker *kvmBroker) AllInstances() (result []instance.Instance, err error) {
 	return broker.manager.ListContainers()
-}
-
-// MaintainInstance checks that the container's host has the required iptables and routing
-// rules to make the container visible to both the host and other machines on the same subnet.
-func (broker *kvmBroker) MaintainInstance(args environs.StartInstanceParams) error {
-	machineId := args.InstanceConfig.MachineId
-	if !environs.AddressAllocationEnabled() {
-		kvmLogger.Debugf("address allocation disabled: Not running maintenance for kvm with machineId: %s",
-			machineId)
-		return nil
-	}
-
-	kvmLogger.Debugf("running maintenance for kvm with machineId: %s", machineId)
-
-	// Default to using the host network until we can configure.
-	bridgeDevice := broker.agentConfig.Value(agent.LxcBridge)
-	if bridgeDevice == "" {
-		bridgeDevice = kvm.DefaultKvmBridge
-	}
-	_, err := configureContainerNetwork(
-		machineId,
-		bridgeDevice,
-		broker.api,
-		args.NetworkInfo,
-		false, // don't allocate a new address.
-		broker.enableNAT,
-	)
-	return err
 }

--- a/worker/provisioner/kvm-broker_test.go
+++ b/worker/provisioner/kvm-broker_test.go
@@ -151,6 +151,9 @@ func (s *kvmBrokerSuite) TestStartInstanceAddressAllocationDisabled(c *gc.C) {
 	machineId := "1/kvm/0"
 	kvm := s.startInstance(c, machineId)
 	s.api.CheckCalls(c, []gitjujutesting.StubCall{{
+		FuncName: "PrepareContainerInterfaceInfo",
+		Args:     []interface{}{names.NewMachineTag("1-kvm-0")},
+	}, {
 		FuncName: "ContainerConfig",
 	}})
 	c.Assert(kvm.Id(), gc.Equals, instance.Id("juju-machine-1-kvm-0"))

--- a/worker/provisioner/lxc-broker.go
+++ b/worker/provisioner/lxc-broker.go
@@ -532,11 +532,6 @@ func discoverPrimaryNIC() (string, network.Address, error) {
 	return "", network.Address{}, errors.Errorf("cannot detect the primary network interface")
 }
 
-// MACAddressTemplate is used to generate a unique MAC address for a
-// container. Every 'x' is replaced by a random hexadecimal digit,
-// while the rest is kept as-is.
-const MACAddressTemplate = "00:16:3e:xx:xx:xx"
-
 // configureContainerNetworking tries to allocate a static IP address
 // for the given containerId using the provisioner API, when
 // allocateAddress is true. Otherwise it configures the container with
@@ -598,7 +593,6 @@ func configureContainerNetwork(
 		// interface name.
 		finalIfaceInfo[i].DeviceIndex = i
 		finalIfaceInfo[i].InterfaceName = fmt.Sprintf("eth%d", i)
-		finalIfaceInfo[i].MACAddress = MACAddressTemplate
 		finalIfaceInfo[i].ConfigType = network.ConfigStatic
 		finalIfaceInfo[i].DNSServers = dnsServers
 		finalIfaceInfo[i].DNSSearch = searchDomain

--- a/worker/provisioner/lxc-broker.go
+++ b/worker/provisioner/lxc-broker.go
@@ -170,8 +170,11 @@ func (broker *lxcBroker) StartInstance(args environs.StartInstanceParams) (*envi
 	}, nil
 }
 
-// MaintainInstance checks that the container's host has the required iptables and routing
-// rules to make the container visible to both the host and other machines on the same subnet.
+// MaintainInstance ensures the container's host has the required iptables and
+// routing rules to make the container visible to both the host and other
+// machines on the same subnet. This is important mostly when address allocation
+// feature flag is enabled, as otherwise we don't create additional iptables
+// rules or routes.
 func (broker *lxcBroker) MaintainInstance(args environs.StartInstanceParams) error {
 	machineID := args.InstanceConfig.MachineId
 

--- a/worker/provisioner/lxc-broker.go
+++ b/worker/provisioner/lxc-broker.go
@@ -16,6 +16,7 @@ import (
 	"github.com/juju/loggo"
 	"github.com/juju/names"
 	"github.com/juju/utils/exec"
+	"github.com/juju/utils/set"
 
 	"github.com/juju/juju/agent"
 	apiprovisioner "github.com/juju/juju/api/provisioner"
@@ -38,6 +39,7 @@ type APICalls interface {
 	ContainerConfig() (params.ContainerConfig, error)
 	PrepareContainerInterfaceInfo(names.MachineTag) ([]network.InterfaceInfo, error)
 	GetContainerInterfaceInfo(names.MachineTag) ([]network.InterfaceInfo, error)
+	ReleaseContainerAddresses(names.MachineTag) error
 }
 
 var _ APICalls = (*apiprovisioner.State)(nil)
@@ -53,12 +55,15 @@ func newLxcBroker(
 	enableNAT bool,
 	defaultMTU int,
 ) (environs.InstanceBroker, error) {
+	namespace := maybeGetManagerConfigNamespaces(managerConfig)
+
 	manager, err := lxc.NewContainerManager(managerConfig, imageURLGetter)
 	if err != nil {
 		return nil, err
 	}
 	return &lxcBroker{
 		manager:     manager,
+		namespace:   namespace,
 		api:         api,
 		agentConfig: agentConfig,
 		enableNAT:   enableNAT,
@@ -68,6 +73,7 @@ func newLxcBroker(
 
 type lxcBroker struct {
 	manager     container.Manager
+	namespace   string
 	api         APICalls
 	agentConfig agent.Config
 	enableNAT   bool
@@ -89,29 +95,23 @@ func (broker *lxcBroker) StartInstance(args environs.StartInstanceParams) (*envi
 		bridgeDevice = lxc.DefaultLxcBridge
 	}
 
-	if !environs.AddressAllocationEnabled() {
-		logger.Debugf(
-			"address allocation feature flag not enabled; using DHCP for container %q",
-			machineId,
-		)
+	preparedInfo, err := prepareOrGetContainerInterfaceInfo(
+		broker.api,
+		machineId,
+		bridgeDevice,
+		true, // allocate if possible, do not maintain existing.
+		broker.enableNAT,
+		args.NetworkInfo,
+		lxcLogger,
+	)
+	if err != nil {
+		// It's not fatal (yet) if we couldn't pre-allocate addresses for the
+		// container.
+		logger.Warningf("failed to prepare container %q network config: %v", machineId, err)
 	} else {
-		logger.Debugf("trying to allocate static IP for container %q", machineId)
-		allocatedInfo, err := configureContainerNetwork(
-			machineId,
-			bridgeDevice,
-			broker.api,
-			args.NetworkInfo,
-			true, // allocate a new address.
-			broker.enableNAT,
-		)
-		if err != nil {
-			// It's fine, just ignore it. The effect will be that the
-			// container won't have a static address configured.
-			logger.Infof("not allocating static IP for container %q: %v", machineId, err)
-		} else {
-			args.NetworkInfo = allocatedInfo
-		}
+		args.NetworkInfo = preparedInfo
 	}
+
 	network := container.BridgeNetworkConfig(bridgeDevice, broker.defaultMTU, args.NetworkInfo)
 
 	// The provisioner worker will provide all tools it knows about
@@ -170,6 +170,30 @@ func (broker *lxcBroker) StartInstance(args environs.StartInstanceParams) (*envi
 	}, nil
 }
 
+// MaintainInstance checks that the container's host has the required iptables and routing
+// rules to make the container visible to both the host and other machines on the same subnet.
+func (broker *lxcBroker) MaintainInstance(args environs.StartInstanceParams) error {
+	machineID := args.InstanceConfig.MachineId
+
+	// Default to using the host network until we can configure.
+	bridgeDevice := broker.agentConfig.Value(agent.LxcBridge)
+	if bridgeDevice == "" {
+		bridgeDevice = lxc.DefaultLxcBridge
+	}
+
+	// There's no InterfaceInfo we expect to get below.
+	_, err := prepareOrGetContainerInterfaceInfo(
+		broker.api,
+		machineID,
+		bridgeDevice,
+		false, // maintain, do not allocate.
+		broker.enableNAT,
+		args.NetworkInfo,
+		lxcLogger,
+	)
+	return err
+}
+
 // StopInstances shuts down the given instances.
 func (broker *lxcBroker) StopInstances(ids ...instance.Id) error {
 	// TODO: potentially parallelise.
@@ -179,6 +203,7 @@ func (broker *lxcBroker) StopInstances(ids ...instance.Id) error {
 			lxcLogger.Errorf("container did not stop: %v", err)
 			return err
 		}
+		maybeReleaseContainerAddresses(broker.api, id, broker.namespace, lxcLogger)
 	}
 	return nil
 }
@@ -589,30 +614,111 @@ func configureContainerNetwork(
 	return finalIfaceInfo, nil
 }
 
-// MaintainInstance checks that the container's host has the required iptables and routing
-// rules to make the container visible to both the host and other machines on the same subnet.
-func (broker *lxcBroker) MaintainInstance(args environs.StartInstanceParams) error {
-	machineId := args.InstanceConfig.MachineId
-	if !environs.AddressAllocationEnabled() {
-		lxcLogger.Debugf("address allocation disabled: Not running maintenance for lxc container with machineId: %s",
-			machineId)
-		return nil
+func maybeGetManagerConfigNamespaces(managerConfig container.ManagerConfig) string {
+	if len(managerConfig) == 0 {
+		return ""
+	}
+	if namespace, ok := managerConfig[container.ConfigName]; ok {
+		return namespace
+	}
+	return ""
+}
+
+func prepareOrGetContainerInterfaceInfo(
+	api APICalls,
+	machineID string,
+	bridgeDevice string,
+	allocateOrMaintain bool,
+	enableNAT bool,
+	startingNetworkInfo []network.InterfaceInfo,
+	log loggo.Logger,
+) ([]network.InterfaceInfo, error) {
+
+	maintain := !allocateOrMaintain
+
+	if environs.AddressAllocationEnabled() {
+		if maintain {
+			log.Debugf("running maintenance for container %q", machineID)
+		} else {
+			log.Debugf("trying to allocate static IP for container %q", machineID)
+		}
+
+		allocatedInfo, err := configureContainerNetwork(
+			machineID,
+			bridgeDevice,
+			api,
+			startingNetworkInfo,
+			allocateOrMaintain,
+			enableNAT,
+		)
+		if err != nil && !maintain {
+			log.Infof("not allocating static IP for container %q: %v", machineID, err)
+		}
+		return allocatedInfo, err
 	}
 
-	lxcLogger.Debugf("running maintenance for lxc container with machineId: %s", machineId)
-
-	// Default to using the host network until we can configure.
-	bridgeDevice := broker.agentConfig.Value(agent.LxcBridge)
-	if bridgeDevice == "" {
-		bridgeDevice = lxc.DefaultLxcBridge
+	if maintain {
+		log.Debugf("address allocation disabled: Not running maintenance for machine %q", machineID)
+		return nil, nil
 	}
-	_, err := configureContainerNetwork(
-		machineId,
-		bridgeDevice,
-		broker.api,
-		args.NetworkInfo,
-		false, // don't allocate a new address.
-		broker.enableNAT,
+
+	log.Debugf("address allocation feature flag not enabled; using DHCP for container %q", machineID)
+
+	// In case we're running on MAAS 1.8+ with devices support, we'll still
+	// call PrepareContainerInterfaceInfo(), but we'll ignore a NotSupported
+	// error if we get it (which means we're not using MAAS 1.8+).
+	containerTag := names.NewMachineTag(machineID)
+	preparedInfo, err := api.PrepareContainerInterfaceInfo(containerTag)
+	if err != nil && errors.IsNotSupported(err) {
+		log.Debugf("new container %q not registered as device: not running on MAAS 1.8+", machineID)
+		return nil, nil
+	}
+
+	log.Tracef("PrepareContainerInterfaceInfo returned %#v", preparedInfo)
+	// Most likely there will be only one item in the list, but check
+	// all of them for forward compatibility.
+	macAddresses := set.NewStrings()
+	for _, prepInfo := range preparedInfo {
+		macAddresses.Add(prepInfo.MACAddress)
+	}
+	log.Infof(
+		"new container %q registered as a MAAS device with MAC address(es) %v",
+		machineID, macAddresses.SortedValues(),
 	)
-	return err
+	return preparedInfo, nil
+}
+
+func maybeReleaseContainerAddresses(
+	api APICalls,
+	instanceID instance.Id,
+	namespace string,
+	log loggo.Logger,
+) {
+	if environs.AddressAllocationEnabled() {
+		// The addresser worker will take care of the addresses.
+		return
+	}
+	// If we're not using addressable containers, we might still have used MAAS
+	// 1.8+ device to register the container when provisioning. In that case we
+	// need to attempt releasing the device, but ignore a NotSupported error
+	// (when we're not using MAAS 1.8+).
+	namespacePrefix := fmt.Sprintf("%s-", namespace)
+	tagString := strings.TrimPrefix(string(instanceID), namespacePrefix)
+	containerTag, err := names.ParseMachineTag(tagString)
+	if err != nil {
+		// Not a reason to cause StopInstances to fail though..
+		log.Warningf("unexpected container tag %q: %v", instanceID, err)
+		return
+	}
+	err = api.ReleaseContainerAddresses(containerTag)
+	switch {
+	case err == nil:
+		log.Infof("released all addresses for container %q", containerTag.Id())
+	case errors.IsNotSupported(err):
+	default:
+		log.Warningf(
+			"unexpected error trying to release container %q addreses: %v",
+			containerTag.Id(), err,
+		)
+	}
 }

--- a/worker/provisioner/lxc-broker_test.go
+++ b/worker/provisioner/lxc-broker_test.go
@@ -190,6 +190,9 @@ func (s *lxcBrokerSuite) TestStartInstanceAddressAllocationDisabled(c *gc.C) {
 	machineId := "1/lxc/0"
 	lxc := s.startInstance(c, machineId, nil)
 	s.api.CheckCalls(c, []gitjujutesting.StubCall{{
+		FuncName: "PrepareContainerInterfaceInfo",
+		Args:     []interface{}{names.NewMachineTag("1-lxc-0")},
+	}, {
 		FuncName: "ContainerConfig",
 	}})
 	c.Assert(lxc.Id(), gc.Equals, instance.Id("juju-machine-1-lxc-0"))
@@ -312,6 +315,9 @@ func (s *lxcBrokerSuite) TestStartInstanceWithBridgeEnviron(c *gc.C) {
 	machineId := "1/lxc/0"
 	lxc := s.startInstance(c, machineId, nil)
 	s.api.CheckCalls(c, []gitjujutesting.StubCall{{
+		FuncName: "PrepareContainerInterfaceInfo",
+		Args:     []interface{}{names.NewMachineTag("1-lxc-0")},
+	}, {
 		FuncName: "ContainerConfig",
 	}})
 	c.Assert(lxc.Id(), gc.Equals, instance.Id("juju-machine-1-lxc-0"))
@@ -1096,4 +1102,12 @@ func (f *fakeAPI) GetContainerInterfaceInfo(tag names.MachineTag) ([]network.Int
 		return nil, err
 	}
 	return []network.InterfaceInfo{f.fakeInterfaceInfo}, nil
+}
+
+func (f *fakeAPI) ReleaseContainerAddresses(tag names.MachineTag) error {
+	f.MethodCall(f, "ReleaseContainerAddresses", tag)
+	if err := f.NextErr(); err != nil {
+		return err
+	}
+	return nil
 }

--- a/worker/provisioner/lxc-broker_test.go
+++ b/worker/provisioner/lxc-broker_test.go
@@ -869,7 +869,7 @@ func (s *lxcBrokerSuite) TestConfigureContainerNetwork(c *gc.C) {
 		CIDR:           "0.1.2.0/24",
 		ConfigType:     network.ConfigStatic,
 		InterfaceName:  "eth0", // generated from the device index.
-		MACAddress:     provisioner.MACAddressTemplate,
+		MACAddress:     "aa:bb:cc:dd:ee:ff",
 		DNSServers:     network.NewAddresses("ns1.dummy"),
 		Address:        network.NewAddress("0.1.2.3"),
 		GatewayAddress: network.NewAddress("0.1.2.1"),


### PR DESCRIPTION
This PR changes the default behavior around starting and stopping both
LXC containers and KVM instances, regardless whether the feature flag
"address-allocation" is enabled or not. It aims to resolve a few corner
cases where container resources (IP addresses or DHCP leases) can leak
over time, especially if the same underlying MAAS substrate is being
reused over and over again (i.e. CI/CD automated tests, OIL, etc.).

The cases are:
$ juju destroy-environment --force
$ juju destroy-machine # --force
$ juju destroy-machine #

See the related LP bug http://pad.lv/1483879

With this patch, some of the addressable containers changes from 1.25+
are cherry-picked and applied to the container brokers and provisioner
(worker and API). Before any container is started, Juju will now make a
best effort to register the container as a MAAS 1.8+ device with a pre-
generated MAC address, and then explicitly claim a sticky IP address
for it. In case older MAAS version is used or a non-MAAS provider in
general, the process goes on as expected. Also, if using the experimental,
feature-flagged addressable containers, the existing behavior is preserved
(allocating a static IP, tracking its lifecycle, releasing it by the addresser worker).

Manually tested on MAAS 1.9.0beta2 in the following combinations:
1. precise/trusty/vivid/wily MAAS node hosting one or more LXC/KVM
  containers with matching series (without the feature flag enabled).
2. same as 1., but with the address-allocation feature flag on.
3. same as 1., but with MAAS 1.7 (no devices support).
4. same as 3., but with the feature flag on.

In all cases tested so far, it was verified all containers get addresses
as expected, and without the feature flag, there are matching devices
created on MAAS, and the latter are removed as the containers are stopped.

While testing, I've discovered an issue with MAAS 1.9 around devices with
sticky IP addresses, and filed a bug for it: http://pad.lv/1514486.

(Review request: http://reviews.vapour.ws/r/3088/)