### PR TITLE
utils: move LoggedErrorStack helper to worker/provisioner

### DIFF
--- a/worker/provisioner/logging.go
+++ b/worker/provisioner/logging.go
@@ -1,23 +1,20 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package utils
+package provisioner
 
 import (
 	"github.com/juju/errors"
-	"github.com/juju/loggo"
 	"github.com/juju/utils/featureflag"
 
 	"github.com/juju/juju/feature"
 )
 
-var logger = loggo.GetLogger("juju.utils")
-
-// LoggedErrorStack is a developer helper function that will cause the error
+// loggedErrorStack is a developer helper function that will cause the error
 // stack of the error to be printed out at error severity if and only if the
 // "log-error-stack" feature flag has been specified.  The passed in error
 // is also the return value of this function.
-func LoggedErrorStack(err error) error {
+func loggedErrorStack(err error) error {
 	if featureflag.Enabled(feature.LogErrorStack) {
 		logger.Errorf("error stack:\n%s", errors.ErrorStack(err))
 	}

--- a/worker/provisioner/logging_test.go
+++ b/worker/provisioner/logging_test.go
@@ -1,7 +1,7 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package utils_test
+package provisioner
 
 import (
 	"errors"
@@ -11,7 +11,6 @@ import (
 
 	"github.com/juju/juju/feature"
 	"github.com/juju/juju/testing"
-	"github.com/juju/juju/utils"
 )
 
 type logSuite struct {
@@ -22,7 +21,7 @@ var _ = gc.Suite(&logSuite{})
 
 func (*logSuite) TestFlagNotSet(c *gc.C) {
 	err := errors.New("test error")
-	err2 := utils.LoggedErrorStack(err)
+	err2 := loggedErrorStack(err)
 	c.Assert(err, gc.Equals, err2)
 	c.Assert(c.GetTestLog(), gc.Equals, "")
 }
@@ -30,8 +29,8 @@ func (*logSuite) TestFlagNotSet(c *gc.C) {
 func (s *logSuite) TestFlagSet(c *gc.C) {
 	s.SetFeatureFlags(feature.LogErrorStack)
 	err := errors.New("test error")
-	err2 := utils.LoggedErrorStack(err)
+	err2 := loggedErrorStack(err)
 	c.Assert(err, gc.Equals, err2)
-	expected := "ERROR juju.utils error stack:\ntest error"
+	expected := "ERROR juju.provisioner error stack:\ntest error"
 	c.Assert(c.GetTestLog(), jc.Contains, expected)
 }

--- a/worker/provisioner/provisioner.go
+++ b/worker/provisioner/provisioner.go
@@ -20,7 +20,6 @@ import (
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/state/watcher"
-	"github.com/juju/juju/utils"
 	"github.com/juju/juju/worker"
 )
 
@@ -202,21 +201,21 @@ func (p *environProvisioner) loop() error {
 	var environConfigChanges <-chan struct{}
 	environWatcher, err := p.st.WatchForEnvironConfigChanges()
 	if err != nil {
-		return utils.LoggedErrorStack(errors.Trace(err))
+		return loggedErrorStack(errors.Trace(err))
 	}
 	environConfigChanges = environWatcher.Changes()
 	defer watcher.Stop(environWatcher, &p.tomb)
 
 	p.environ, err = worker.WaitForEnviron(environWatcher, p.st, p.tomb.Dying())
 	if err != nil {
-		return utils.LoggedErrorStack(errors.Trace(err))
+		return loggedErrorStack(errors.Trace(err))
 	}
 	p.broker = p.environ
 
 	harvestMode := p.environ.Config().ProvisionerHarvestMode()
 	task, err := p.getStartTask(harvestMode)
 	if err != nil {
-		return utils.LoggedErrorStack(errors.Trace(err))
+		return loggedErrorStack(errors.Trace(err))
 	}
 	defer watcher.Stop(task, &p.tomb)
 


### PR DESCRIPTION
The only usage of utils.LoggedErrorStack was the provisioner worker.
Move this type and its tests to worker/provisioner/logger.go

(Review request: http://reviews.vapour.ws/r/3096/)