### PR TITLE
Add juju-dumplogs to windows executable name constants.

### DIFF
--- a/juju/names/names_windows.go
+++ b/juju/names/names_windows.go
@@ -5,8 +5,9 @@
 package names
 
 const (
-	Juju    = "juju.exe"
-	Jujud   = "jujud.exe"
-	Jujuc   = "jujuc.exe"
-	JujuRun = "juju-run.exe"
+	Juju         = "juju.exe"
+	Jujud        = "jujud.exe"
+	Jujuc        = "jujuc.exe"
+	JujuRun      = "juju-run.exe"
+	JujuDumpLogs = "juju-dumplogs.exe"
 )


### PR DESCRIPTION
Fix https://bugs.launchpad.net/juju-core/+bug/1514444

(Review request: http://reviews.vapour.ws/r/3100/)