### PR TITLE
Assign unit worker

### DIFF
--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -60,6 +60,7 @@ var facadeVersions = map[string]int{
 	"StringsWatcher":               0,
 	"SystemManager":                1,
 	"Upgrader":                     0,
+	"UnitAssigner":                 1,
 	"Uniter":                       2,
 	"UserManager":                  0,
 	"VolumeAttachmentsWatcher":     1,

--- a/api/facadeversions_test.go
+++ b/api/facadeversions_test.go
@@ -6,6 +6,7 @@ package api_test
 import (
 	"strings"
 
+	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/set"
 	gc "gopkg.in/check.v1"
 
@@ -43,7 +44,7 @@ func (s *facadeVersionSuite) TestFacadeVersionsMatchServerVersions(c *gc.C) {
 	c.Check(serverFacadeNames.Difference(clientFacadeNames).SortedValues(), gc.HasLen, 0)
 	c.Check(clientFacadeNames.Difference(serverFacadeNames).SortedValues(), gc.HasLen, 0)
 	// Next check that the best versions match
-	c.Check(*api.FacadeVersions, gc.DeepEquals, serverFacadeBestVersions)
+	c.Check(*api.FacadeVersions, jc.DeepEquals, serverFacadeBestVersions)
 }
 
 func checkBestVersion(c *gc.C, desiredVersion int, versions []int, expectedVersion int) {

--- a/api/interface.go
+++ b/api/interface.go
@@ -29,6 +29,7 @@ import (
 	"github.com/juju/juju/api/resumer"
 	"github.com/juju/juju/api/rsyslog"
 	"github.com/juju/juju/api/storageprovisioner"
+	"github.com/juju/juju/api/unitassigner"
 	"github.com/juju/juju/api/uniter"
 	"github.com/juju/juju/api/upgrader"
 	"github.com/juju/juju/network"
@@ -182,4 +183,5 @@ type Connection interface {
 	Cleaner() *cleaner.API
 	Rsyslog() *rsyslog.State
 	MetadataUpdater() *imagemetadata.Client
+	UnitAssigner() unitassigner.API
 }

--- a/api/state.go
+++ b/api/state.go
@@ -31,6 +31,7 @@ import (
 	"github.com/juju/juju/api/resumer"
 	"github.com/juju/juju/api/rsyslog"
 	"github.com/juju/juju/api/storageprovisioner"
+	"github.com/juju/juju/api/unitassigner"
 	"github.com/juju/juju/api/uniter"
 	"github.com/juju/juju/api/upgrader"
 	"github.com/juju/juju/apiserver/params"
@@ -272,6 +273,12 @@ func (st *state) Client() *Client {
 // required by the machiner worker.
 func (st *state) Machiner() *machiner.State {
 	return machiner.NewState(st)
+}
+
+// UnitAssigner returns a version of the state that provides functionality
+// required by the unitassigner worker.
+func (st *state) UnitAssigner() unitassigner.API {
+	return unitassigner.New(st)
 }
 
 // Resumer returns a version of the state that provides functionality

--- a/api/unitassigner/package_test.go
+++ b/api/unitassigner/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package unitassigner
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/api/unitassigner/unitassigner.go
+++ b/api/unitassigner/unitassigner.go
@@ -1,0 +1,82 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package unitassigner
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/api/watcher"
+	"github.com/juju/juju/apiserver/params"
+
+	"github.com/juju/names"
+)
+
+const uaFacade = "UnitAssigner"
+
+// API provides access to the UnitAssigner API facade.
+type API struct {
+	facade base.FacadeCaller
+}
+
+// New creates a new client-side UnitAssigner facade.
+func New(caller base.APICaller) API {
+	fc := base.NewFacadeCaller(caller, uaFacade)
+	return API{facade: fc}
+}
+
+// AssignUnits tells the state server to run whatever unit assignments it has.
+// Unit assignments for units that no longer exist will return an error that
+// satisfies errors.IsNotFound.
+func (a API) AssignUnits(tags []names.UnitTag) ([]error, error) {
+	entities := make([]params.Entity, len(tags))
+	for i, tag := range tags {
+		entities[i] = params.Entity{Tag: tag.String()}
+	}
+	args := params.Entities{Entities: entities}
+	var result params.ErrorResults
+	if err := a.facade.FacadeCall("AssignUnits", args, &result); err != nil {
+		return nil, err
+	}
+
+	errs := make([]error, len(result.Results))
+	for i, e := range result.Results {
+		if e.Error != nil {
+			errs[i] = convertNotFound(e.Error)
+		}
+	}
+	return errs, nil
+}
+
+// convertNotFound converts param notfound errors into errors.notfound values.
+func convertNotFound(err error) error {
+	if params.IsCodeNotFound(err) {
+		return errors.NewNotFound(err, "")
+	}
+	return err
+}
+
+// WatchUnitAssignments watches the server for new unit assignments to be
+// created.
+func (a API) WatchUnitAssignments() (watcher.StringsWatcher, error) {
+	var result params.StringsWatchResult
+	err := a.facade.FacadeCall("WatchUnitAssignments", nil, &result)
+	if err != nil {
+		return nil, err
+	}
+	if result.Error != nil {
+		return nil, result.Error
+	}
+	w := watcher.NewStringsWatcher(a.facade.RawAPICaller(), result)
+	return w, nil
+}
+
+// SetAgentStatus sets the status of the unit agents.
+func (a API) SetAgentStatus(args params.SetStatus) error {
+	var result params.ErrorResults
+	err := a.facade.FacadeCall("SetAgentStatus", args, &result)
+	if err != nil {
+		return err
+	}
+	return result.Combine()
+}

--- a/api/unitassigner/unitassigner_test.go
+++ b/api/unitassigner/unitassigner_test.go
@@ -1,0 +1,120 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package unitassigner
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/names"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/apiserver/params"
+)
+
+var _ = gc.Suite(testsuite{})
+
+type testsuite struct{}
+
+func (testsuite) TestAssignUnits(c *gc.C) {
+	f := &fakeAssignCaller{c: c, response: params.ErrorResults{
+		Results: []params.ErrorResult{
+			{},
+			{},
+		}}}
+	api := New(f)
+	ids := []names.UnitTag{names.NewUnitTag("mysql/0"), names.NewUnitTag("mysql/1")}
+	errs, err := api.AssignUnits(ids)
+	c.Assert(f.request, gc.Equals, "AssignUnits")
+	c.Assert(f.params, gc.DeepEquals,
+		params.Entities{[]params.Entity{
+			{Tag: "unit-mysql-0"},
+			{Tag: "unit-mysql-1"},
+		}},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(errs, gc.DeepEquals, []error{nil, nil})
+}
+
+func (testsuite) TestAssignUnitsNotFound(c *gc.C) {
+	f := &fakeAssignCaller{c: c, response: params.ErrorResults{
+		Results: []params.ErrorResult{
+			{Error: &params.Error{Code: params.CodeNotFound}},
+		}}}
+	api := New(f)
+	ids := []names.UnitTag{names.NewUnitTag("mysql/0")}
+	errs, err := api.AssignUnits(ids)
+	c.Assert(f.request, gc.Equals, "AssignUnits")
+	c.Assert(f.params, gc.DeepEquals,
+		params.Entities{[]params.Entity{
+			{Tag: "unit-mysql-0"},
+		}},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(errs, gc.HasLen, 1)
+	c.Assert(errs[0], jc.Satisfies, errors.IsNotFound)
+}
+
+func (testsuite) TestWatchUnitAssignment(c *gc.C) {
+	f := &fakeWatchCaller{
+		c:        c,
+		response: params.StringsWatchResult{},
+	}
+	api := New(f)
+	w, err := api.WatchUnitAssignments()
+	c.Assert(f.request, gc.Equals, "WatchUnitAssignments")
+	c.Assert(f.params, gc.IsNil)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(w, gc.NotNil)
+}
+
+type fakeAssignCaller struct {
+	base.APICaller
+	request  string
+	params   interface{}
+	response params.ErrorResults
+	err      error
+	c        *gc.C
+}
+
+func (f *fakeAssignCaller) APICall(objType string, version int, id, request string, param, response interface{}) error {
+	f.request = request
+	f.params = param
+	res, ok := response.(*params.ErrorResults)
+	if !ok {
+		f.c.Errorf("Expected *params.ErrorResults as response, but was %#v", response)
+	}
+	*res = f.response
+	return f.err
+
+}
+
+func (fakeAssignCaller) BestFacadeVersion(facade string) int {
+	return 1
+}
+
+type fakeWatchCaller struct {
+	base.APICaller
+	request  string
+	params   interface{}
+	response params.StringsWatchResult
+	err      error
+	c        *gc.C
+}
+
+func (f *fakeWatchCaller) APICall(objType string, version int, id, request string, param, response interface{}) error {
+	f.request = request
+	f.params = param
+	res, ok := response.(*params.StringsWatchResult)
+	if !ok {
+		f.c.Errorf("Expected *params.StringsWatchResult as response, but was %#v", response)
+	}
+	*res = f.response
+	return f.err
+
+}
+
+func (fakeWatchCaller) BestFacadeVersion(facade string) int {
+	return 1
+}

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -45,6 +45,7 @@ import (
 	_ "github.com/juju/juju/apiserver/storageprovisioner"
 	_ "github.com/juju/juju/apiserver/subnets"
 	_ "github.com/juju/juju/apiserver/systemmanager"
+	_ "github.com/juju/juju/apiserver/unitassigner"
 	_ "github.com/juju/juju/apiserver/uniter"
 	_ "github.com/juju/juju/apiserver/upgrader"
 	_ "github.com/juju/juju/apiserver/usermanager"

--- a/apiserver/charmrevisionupdater/testing/suite.go
+++ b/apiserver/charmrevisionupdater/testing/suite.go
@@ -109,7 +109,7 @@ func (s *CharmSuite) AddService(c *gc.C, charmName, serviceName string, networks
 	ch, ok := s.charms[charmName]
 	c.Assert(ok, jc.IsTrue)
 	owner := s.jcSuite.AdminUserTag(c)
-	_, err := s.jcSuite.State.AddService(serviceName, owner.String(), ch, networks, nil)
+	_, err := s.jcSuite.State.AddService(state.AddServiceArgs{Name: serviceName, Owner: owner.String(), Charm: ch, Networks: networks})
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/apiserver/client/run_test.go
+++ b/apiserver/client/run_test.go
@@ -76,22 +76,22 @@ func (s *runSuite) addUnit(c *gc.C, service *state.Service) *state.Unit {
 func (s *runSuite) TestGetAllUnitNames(c *gc.C) {
 	charm := s.AddTestingCharm(c, "dummy")
 	owner := s.AdminUserTag(c)
-	magic, err := s.State.AddService("magic", owner.String(), charm, nil, nil)
+	magic, err := s.State.AddService(state.AddServiceArgs{Name: "magic", Owner: owner.String(), Charm: charm})
 	s.addUnit(c, magic)
 	s.addUnit(c, magic)
 
-	notAssigned, err := s.State.AddService("not-assigned", owner.String(), charm, nil, nil)
+	notAssigned, err := s.State.AddService(state.AddServiceArgs{Name: "not-assigned", Owner: owner.String(), Charm: charm})
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = notAssigned.AddUnit()
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = s.State.AddService("no-units", owner.String(), charm, nil, nil)
+	_, err = s.State.AddService(state.AddServiceArgs{Name: "no-units", Owner: owner.String(), Charm: charm})
 	c.Assert(err, jc.ErrorIsNil)
 
-	wordpress, err := s.State.AddService("wordpress", owner.String(), s.AddTestingCharm(c, "wordpress"), nil, nil)
+	wordpress, err := s.State.AddService(state.AddServiceArgs{Name: "wordpress", Owner: owner.String(), Charm: s.AddTestingCharm(c, "wordpress")})
 	c.Assert(err, jc.ErrorIsNil)
 	wordpress0 := s.addUnit(c, wordpress)
-	_, err = s.State.AddService("logging", owner.String(), s.AddTestingCharm(c, "logging"), nil, nil)
+	_, err = s.State.AddService(state.AddServiceArgs{Name: "logging", Owner: owner.String(), Charm: s.AddTestingCharm(c, "logging")})
 	c.Assert(err, jc.ErrorIsNil)
 
 	eps, err := s.State.InferEndpoints("logging", "wordpress")
@@ -276,7 +276,7 @@ func (s *runSuite) TestRunMachineAndService(c *gc.C) {
 
 	charm := s.AddTestingCharm(c, "dummy")
 	owner := s.Factory.MakeUser(c, nil).Tag()
-	magic, err := s.State.AddService("magic", owner.String(), charm, nil, nil)
+	magic, err := s.State.AddService(state.AddServiceArgs{Name: "magic", Owner: owner.String(), Charm: charm})
 	c.Assert(err, jc.ErrorIsNil)
 	s.addUnit(c, magic)
 	s.addUnit(c, magic)
@@ -323,7 +323,7 @@ func (s *runSuite) TestBlockRunMachineAndService(c *gc.C) {
 
 	charm := s.AddTestingCharm(c, "dummy")
 	owner := s.Factory.MakeUser(c, nil).Tag()
-	magic, err := s.State.AddService("magic", owner.String(), charm, nil, nil)
+	magic, err := s.State.AddService(state.AddServiceArgs{Name: "magic", Owner: owner.String(), Charm: charm})
 	c.Assert(err, jc.ErrorIsNil)
 	s.addUnit(c, magic)
 	s.addUnit(c, magic)

--- a/apiserver/common/registry.go
+++ b/apiserver/common/registry.go
@@ -220,6 +220,7 @@ func (f *FacadeRegistry) Register(name string, version int, factory FacadeFactor
 	} else {
 		f.facades[name] = versions{version: record}
 	}
+	logger.Tracef("Registered facade %q v%d", name, version)
 	return nil
 }
 

--- a/apiserver/common/setstatus.go
+++ b/apiserver/common/setstatus.go
@@ -227,3 +227,27 @@ func (s *StatusSetter) UpdateStatus(args params.SetStatus) (params.ErrorResults,
 	}
 	return result, nil
 }
+
+// UnitAgentFinder is a state.EntityFinder that finds unit agents.
+type UnitAgentFinder struct {
+	state.EntityFinder
+}
+
+// FindEntity implements state.EntityFinder and returns unit agents.
+func (ua *UnitAgentFinder) FindEntity(tag names.Tag) (state.Entity, error) {
+	_, ok := tag.(names.UnitTag)
+	if !ok {
+		return nil, errors.Errorf("unsupported tag %T", tag)
+	}
+	entity, err := ua.EntityFinder.FindEntity(tag)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	// this returns a state.Unit, but for testing we just cast to the minimal
+	// interface we need.
+	return entity.(hasAgent).Agent(), nil
+}
+
+type hasAgent interface {
+	Agent() *state.UnitAgent
+}

--- a/apiserver/service/service_test.go
+++ b/apiserver/service/service_test.go
@@ -369,6 +369,7 @@ func (s *serviceSuite) TestClientServiceDeployWithInvalidPlacement(c *gc.C) {
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.HasLen, 1)
+	c.Assert(results.Results[0].Error, gc.NotNil)
 	c.Assert(results.Results[0].Error.Error(), gc.Matches, ".* invalid placement is invalid")
 }
 

--- a/apiserver/testing/service.go
+++ b/apiserver/testing/service.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/state"
+	coretesting "github.com/juju/juju/testing"
 )
 
 func AssertPrincipalServiceDeployed(c *gc.C, st *state.State, serviceName string, curl *charm.URL, forced bool, bundle charm.Charm, cons constraints.Value) *state.Service {
@@ -35,16 +36,24 @@ func AssertPrincipalServiceDeployed(c *gc.C, st *state.State, serviceName string
 	serviceCons, err := service.Constraints()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(serviceCons, gc.DeepEquals, cons)
-	units, err := service.AllUnits()
-	c.Assert(err, jc.ErrorIsNil)
-	for _, unit := range units {
-		mid, err := unit.AssignedMachineId()
+
+	for a := coretesting.LongAttempt.Start(); a.Next(); {
+		units, err := service.AllUnits()
 		c.Assert(err, jc.ErrorIsNil)
-		machine, err := st.Machine(mid)
-		c.Assert(err, jc.ErrorIsNil)
-		machineCons, err := machine.Constraints()
-		c.Assert(err, jc.ErrorIsNil)
-		c.Assert(machineCons, gc.DeepEquals, cons)
+		for _, unit := range units {
+			mid, err := unit.AssignedMachineId()
+			if !a.HasNext() {
+				c.Assert(err, jc.ErrorIsNil)
+			} else if err != nil {
+				continue
+			}
+			machine, err := st.Machine(mid)
+			c.Assert(err, jc.ErrorIsNil)
+			machineCons, err := machine.Constraints()
+			c.Assert(err, jc.ErrorIsNil)
+			c.Assert(machineCons, gc.DeepEquals, cons)
+		}
+		break
 	}
 	return service
 }

--- a/apiserver/unitassigner/package_test.go
+++ b/apiserver/unitassigner/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package unitassigner
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/apiserver/unitassigner/unitassigner.go
+++ b/apiserver/unitassigner/unitassigner.go
@@ -1,0 +1,105 @@
+package unitassigner
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/names"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/state/watcher"
+)
+
+func init() {
+	common.RegisterStandardFacade("UnitAssigner", 1, New)
+}
+
+// assignerState defines the state methods this facade needs, so they can be mocked
+// for testing.
+type assignerState interface {
+	WatchForUnitAssignment() state.StringsWatcher
+	AssignStagedUnits(ids []string) ([]state.UnitAssignmentResult, error)
+}
+
+type statusSetter interface {
+	SetStatus(args params.SetStatus) (params.ErrorResults, error)
+}
+
+// API implements the functionality for assigning units to machines.
+type API struct {
+	st           assignerState
+	res          *common.Resources
+	statusSetter statusSetter
+}
+
+// New returns a new unitAssigner api instance.
+func New(st *state.State, res *common.Resources, _ common.Authorizer) (*API, error) {
+	setter := common.NewStatusSetter(&common.UnitAgentFinder{st}, common.AuthAlways())
+	return &API{
+		st:           st,
+		res:          res,
+		statusSetter: setter,
+	}, nil
+}
+
+//  AssignUnits assigns the units with the given ids to the correct machine. The
+//  error results are returned in the same order as the given entities.
+func (a *API) AssignUnits(args params.Entities) (params.ErrorResults, error) {
+	result := params.ErrorResults{}
+
+	// state uses ids, but the API uses Tags, so we have to convert back and
+	// forth (whee!).  The list of ids is (crucially) in the same order as the
+	// list of tags.  This is the same order as the list of errors we return.
+	ids := make([]string, len(args.Entities))
+	for i, e := range args.Entities {
+		tag, err := names.ParseUnitTag(e.Tag)
+		if err != nil {
+			return result, err
+		}
+		ids[i] = tag.Id()
+	}
+
+	res, err := a.st.AssignStagedUnits(ids)
+	if err != nil {
+		return result, common.ServerError(err)
+	}
+
+	// The results come back from state in an undetermined order and do not
+	// include results for units that were not found, so we have to make up for
+	// that here.
+	resultMap := make(map[string]error, len(ids))
+	for _, r := range res {
+		resultMap[r.Unit] = r.Error
+	}
+
+	result.Results = make([]params.ErrorResult, len(args.Entities))
+	for i, id := range ids {
+		if err, ok := resultMap[id]; ok {
+			result.Results[i].Error = common.ServerError(err)
+		} else {
+			result.Results[i].Error =
+				common.ServerError(errors.NotFoundf("unit %q", args.Entities[i].Tag))
+		}
+	}
+
+	return result, nil
+}
+
+// WatchUnitAssignments returns a strings watcher that is notified when new unit
+// assignments are added to the db.
+func (a *API) WatchUnitAssignments() (params.StringsWatchResult, error) {
+	watch := a.st.WatchForUnitAssignment()
+	if changes, ok := <-watch.Changes(); ok {
+		return params.StringsWatchResult{
+			StringsWatcherId: a.res.Register(watch),
+			Changes:          changes,
+		}, nil
+	}
+	return params.StringsWatchResult{}, watcher.EnsureErr(watch)
+}
+
+// SetAgentStatus will set status for agents of Units passed in args, if one
+// of the args is not an Unit it will fail.
+func (a *API) SetAgentStatus(args params.SetStatus) (params.ErrorResults, error) {
+	return a.statusSetter.SetStatus(args)
+}

--- a/apiserver/unitassigner/unitassigner_test.go
+++ b/apiserver/unitassigner/unitassigner_test.go
@@ -1,0 +1,101 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package unitassigner
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/state"
+)
+
+var _ = gc.Suite(testsuite{})
+
+type testsuite struct{}
+
+func (testsuite) TestAssignUnits(c *gc.C) {
+	f := &fakeState{}
+	f.results = []state.UnitAssignmentResult{{Unit: "foo/0"}}
+	api := API{st: f, res: common.NewResources()}
+	args := params.Entities{Entities: []params.Entity{{Tag: "unit-foo-0"}, {Tag: "unit-bar-1"}}}
+	res, err := api.AssignUnits(args)
+	c.Assert(f.ids, gc.DeepEquals, []string{"foo/0", "bar/1"})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(res.Results, gc.HasLen, 2)
+	c.Assert(res.Results, gc.HasLen, 2)
+	c.Assert(res.Results[0].Error, gc.IsNil)
+	c.Assert(res.Results[1].Error, gc.ErrorMatches, `unit "unit-bar-1" not found`)
+}
+
+func (testsuite) TestWatchUnitAssignment(c *gc.C) {
+	f := &fakeState{}
+	api := API{st: f, res: common.NewResources()}
+	f.ids = []string{"boo", "far"}
+	res, err := api.WatchUnitAssignments()
+	c.Assert(f.watchCalled, jc.IsTrue)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(res.Changes, gc.DeepEquals, f.ids)
+}
+
+func (testsuite) TestSetStatus(c *gc.C) {
+	f := &fakeStatusSetter{
+		res: params.ErrorResults{
+			Results: []params.ErrorResult{
+				{Error: &params.Error{Message: "boo"}}}}}
+	api := API{statusSetter: f}
+	args := params.SetStatus{
+		Entities: []params.EntityStatusArgs{{Tag: "foo/0"}},
+	}
+	res, err := api.SetAgentStatus(args)
+	c.Assert(args, jc.DeepEquals, f.args)
+	c.Assert(res, jc.DeepEquals, f.res)
+	c.Assert(err, gc.Equals, f.err)
+}
+
+type fakeState struct {
+	watchCalled bool
+	ids         []string
+	results     []state.UnitAssignmentResult
+	err         error
+}
+
+func (f *fakeState) WatchForUnitAssignment() state.StringsWatcher {
+	f.watchCalled = true
+	return fakeWatcher{f.ids}
+}
+
+func (f *fakeState) AssignStagedUnits(ids []string) ([]state.UnitAssignmentResult, error) {
+	f.ids = ids
+	return f.results, f.err
+}
+
+type fakeWatcher struct {
+	changes []string
+}
+
+func (f fakeWatcher) Changes() <-chan []string {
+	changes := make(chan []string, 1)
+	changes <- f.changes
+	return changes
+}
+func (fakeWatcher) Kill() {}
+
+func (fakeWatcher) Wait() error { return nil }
+
+func (fakeWatcher) Stop() error { return nil }
+
+func (fakeWatcher) Err() error { return nil }
+
+type fakeStatusSetter struct {
+	args params.SetStatus
+	res  params.ErrorResults
+	err  error
+}
+
+func (f *fakeStatusSetter) SetStatus(args params.SetStatus) (params.ErrorResults, error) {
+	f.args = args
+	return f.res, f.err
+}

--- a/apiserver/uniter/status.go
+++ b/apiserver/uniter/status.go
@@ -4,9 +4,6 @@
 package uniter
 
 import (
-	"github.com/juju/errors"
-	"github.com/juju/names"
-
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
@@ -24,22 +21,6 @@ type StatusAPI struct {
 	getCanModify  common.GetAuthFunc
 }
 
-type unitAgentFinder struct {
-	state.EntityFinder
-}
-
-func (ua *unitAgentFinder) FindEntity(tag names.Tag) (state.Entity, error) {
-	_, ok := tag.(names.UnitTag)
-	if !ok {
-		return nil, errors.Errorf("unsupported tag %T", tag)
-	}
-	entity, err := ua.EntityFinder.FindEntity(tag)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	return entity.(*state.Unit).Agent(), nil
-}
-
 // NewStatusAPI creates a new server-side Status setter API facade.
 func NewStatusAPI(st *state.State, getCanModify common.GetAuthFunc) *StatusAPI {
 	// TODO(fwereade): so *all* of these have exactly the same auth
@@ -48,7 +29,7 @@ func NewStatusAPI(st *state.State, getCanModify common.GetAuthFunc) *StatusAPI {
 	unitGetter := common.NewStatusGetter(st, getCanModify)
 	serviceSetter := common.NewServiceStatusSetter(st, getCanModify)
 	serviceGetter := common.NewServiceStatusGetter(st, getCanModify)
-	agentSetter := common.NewStatusSetter(&unitAgentFinder{st}, getCanModify)
+	agentSetter := common.NewStatusSetter(&common.UnitAgentFinder{st}, getCanModify)
 	return &StatusAPI{
 		agentSetter:   agentSetter,
 		unitSetter:    unitSetter,

--- a/cmd/juju/commands/bundle_test.go
+++ b/cmd/juju/commands/bundle_test.go
@@ -291,7 +291,7 @@ func (s *deployRepoCharmStoreSuite) TestDeployBundleInvalidSeries(c *gc.C) {
             1:
                 series: trusty
     `)
-	c.Assert(err, gc.ErrorMatches, `cannot deploy bundle: cannot add unit for service "django": cannot assign unit "django/0" to machine 0: series does not match`)
+	c.Assert(err, gc.ErrorMatches, `cannot deploy bundle: cannot add unit for service "django": adding new machine to host unit "django/0": cannot assign unit "django/0" to machine 0: series does not match`)
 }
 
 func (s *deployRepoCharmStoreSuite) TestDeployBundleWatcherTimeout(c *gc.C) {

--- a/cmd/juju/status/status_test.go
+++ b/cmd/juju/status/status_test.go
@@ -2486,7 +2486,7 @@ type addService struct {
 func (as addService) step(c *gc.C, ctx *context) {
 	ch, ok := ctx.charms[as.charm]
 	c.Assert(ok, jc.IsTrue)
-	svc, err := ctx.st.AddService(as.name, ctx.adminUserTag, ch, as.networks, nil)
+	svc, err := ctx.st.AddService(state.AddServiceArgs{Name: as.name, Owner: ctx.adminUserTag, Charm: ch, Networks: as.networks})
 	c.Assert(err, jc.ErrorIsNil)
 	if svc.IsPrincipal() {
 		err = svc.SetConstraints(as.cons)

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -1238,6 +1238,12 @@ func (a *MachineAgent) startEnvWorkers(
 		return newAddresser(apiSt.Addresser())
 	})
 
+	if machine.IsManager() {
+		singularRunner.StartWorker("unitassigner", func() (worker.Worker, error) {
+			return unitassigner.New(apiSt.UnitAssigner()), nil
+		})
+	}
+
 	// TODO(axw) 2013-09-24 bug #1229506
 	// Make another job to enable the firewaller. Not all
 	// environments are capable of managing ports

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -101,6 +101,7 @@ import (
 	"github.com/juju/juju/worker/terminationworker"
 	"github.com/juju/juju/worker/toolsversionchecker"
 	"github.com/juju/juju/worker/txnpruner"
+	"github.com/juju/juju/worker/unitassigner"
 	"github.com/juju/juju/worker/upgrader"
 )
 
@@ -791,6 +792,11 @@ func (a *MachineAgent) postUpgradeAPIWorker(
 		addressUpdater := agent.APIHostPortsSetter{a}
 		return apiaddressupdater.NewAPIAddressUpdater(st.Machiner(), addressUpdater), nil
 	})
+
+	runner.StartWorker("unitassigner", func() (worker.Worker, error) {
+		return unitassigner.New(st.UnitAssigner()), nil
+	})
+
 	runner.StartWorker("logger", func() (worker.Worker, error) {
 		return workerlogger.NewLogger(st.Logger(), agentConfig), nil
 	})

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -793,10 +793,6 @@ func (a *MachineAgent) postUpgradeAPIWorker(
 		return apiaddressupdater.NewAPIAddressUpdater(st.Machiner(), addressUpdater), nil
 	})
 
-	runner.StartWorker("unitassigner", func() (worker.Worker, error) {
-		return unitassigner.New(st.UnitAssigner()), nil
-	})
-
 	runner.StartWorker("logger", func() (worker.Worker, error) {
 		return workerlogger.NewLogger(st.Logger(), agentConfig), nil
 	})

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -266,6 +266,7 @@ var perEnvSingularWorkers = []string{
 	"charm-revision-updater",
 	"instancepoller",
 	"firewaller",
+	"unitassigner",
 }
 
 const initialMachinePassword = "machine-password-1234567890"

--- a/environs/jujutest/livetests.go
+++ b/environs/jujutest/livetests.go
@@ -468,7 +468,7 @@ func (t *LiveTests) TestBootstrapAndDeploy(c *gc.C) {
 	url := testcharms.Repo.ClonedURL(repoDir, mtools0.Version.Series, "dummy")
 	sch, err := jujutesting.PutCharm(st, url, &charmrepo.LocalRepository{Path: repoDir}, false)
 	c.Assert(err, jc.ErrorIsNil)
-	svc, err := st.AddService("dummy", owner.String(), sch, nil, nil)
+	svc, err := st.AddService(state.AddServiceArgs{Name: "dummy", Owner: owner.String(), Charm: sch})
 	c.Assert(err, jc.ErrorIsNil)
 	units, err := juju.AddUnits(st, svc, 1, "")
 	c.Assert(err, jc.ErrorIsNil)

--- a/juju/deploy.go
+++ b/juju/deploy.go
@@ -40,8 +40,13 @@ type DeployServiceParams struct {
 	Storage  map[string]storage.Constraints
 }
 
+type ServiceDeployer interface {
+	Environment() (*state.Environment, error)
+	AddService(state.AddServiceArgs) (*state.Service, error)
+}
+
 // DeployService takes a charm and various parameters and deploys it.
-func DeployService(st *state.State, args DeployServiceParams) (*state.Service, error) {
+func DeployService(st ServiceDeployer, args DeployServiceParams) (*state.Service, error) {
 	if args.NumUnits > 1 && len(args.Placement) == 0 && args.ToMachineSpec != "" {
 		return nil, fmt.Errorf("cannot use --num-units with --to")
 	}
@@ -71,97 +76,31 @@ func DeployService(st *state.State, args DeployServiceParams) (*state.Service, e
 		return nil, fmt.Errorf("use of --networks is deprecated. Please use spaces")
 	}
 
+	if len(args.Placement) == 0 {
+		args.Placement, err = makePlacement(args.ToMachineSpec)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+	}
+
+	asa := state.AddServiceArgs{
+		Name:      args.ServiceName,
+		Owner:     args.ServiceOwner,
+		Charm:     args.Charm,
+		Networks:  args.Networks,
+		Storage:   stateStorageConstraints(args.Storage),
+		Settings:  settings,
+		NumUnits:  args.NumUnits,
+		Placement: args.Placement,
+	}
+
+	if !args.Charm.Meta().Subordinate {
+		asa.Constraints = args.Constraints
+	}
+
 	// TODO(dimitern): In a follow-up drop Networks and use spaces
 	// constraints for this when possible.
-	service, err := st.AddService(
-		args.ServiceName,
-		args.ServiceOwner,
-		args.Charm,
-		args.Networks,
-		stateStorageConstraints(args.Storage),
-	)
-	if err != nil {
-		return nil, err
-	}
-	if len(settings) > 0 {
-		if err := service.UpdateConfigSettings(settings); err != nil {
-			return nil, err
-		}
-	}
-	if args.Charm.Meta().Subordinate {
-		return service, nil
-	}
-	if !constraints.IsEmpty(&args.Constraints) {
-		if err := service.SetConstraints(args.Constraints); err != nil {
-			return nil, err
-		}
-	}
-	if args.NumUnits > 0 {
-		var err error
-		// We either have a machine spec or a placement directive.
-		// Placement directives take precedence.
-		if len(args.Placement) > 0 || args.ToMachineSpec == "" {
-			_, err = AddUnitsWithPlacement(st, service, args.NumUnits, args.Placement)
-		} else {
-			_, err = AddUnits(st, service, args.NumUnits, args.ToMachineSpec)
-		}
-		if err != nil {
-			return nil, err
-		}
-	}
-	return service, nil
-}
-
-func addMachineForUnit(st *state.State, unit *state.Unit, placement *instance.Placement, networks []string) (*state.Machine, error) {
-	unitCons, err := unit.Constraints()
-	if err != nil {
-		return nil, err
-	}
-	var containerType instance.ContainerType
-	var mid, placementDirective string
-	// Extract container type and parent from container placement directives.
-	if containerType, err = instance.ParseContainerType(placement.Scope); err == nil {
-		mid = placement.Directive
-	} else {
-		switch placement.Scope {
-		case st.EnvironUUID():
-			placementDirective = placement.Directive
-		case instance.MachineScope:
-			mid = placement.Directive
-		default:
-			return nil, errors.Errorf("invalid environment UUID %q", placement.Scope)
-		}
-	}
-
-	// Create any new machine marked as dirty so that
-	// nothing else will grab it before we assign the unit to it.
-
-	// If a container is to be used, create it.
-	if containerType != "" {
-		template := state.MachineTemplate{
-			Series:            unit.Series(),
-			Jobs:              []state.MachineJob{state.JobHostUnits},
-			Dirty:             true,
-			Constraints:       *unitCons,
-			RequestedNetworks: networks,
-		}
-		return st.AddMachineInsideMachine(template, mid, containerType)
-	}
-	// If a placement directive is to be used, do that here.
-	if placementDirective != "" {
-		template := state.MachineTemplate{
-			Series:            unit.Series(),
-			Jobs:              []state.MachineJob{state.JobHostUnits},
-			Dirty:             true,
-			Constraints:       *unitCons,
-			RequestedNetworks: networks,
-			Placement:         placementDirective,
-		}
-		return st.AddOneMachine(template)
-	}
-
-	// Otherwise use an existing machine.
-	return st.Machine(mid)
+	return st.AddService(asa)
 }
 
 // AddUnits starts n units of the given service and allocates machines
@@ -170,31 +109,39 @@ func AddUnits(st *state.State, svc *state.Service, n int, machineIdSpec string) 
 	if machineIdSpec != "" && n != 1 {
 		return nil, errors.Errorf("cannot add multiple units of service %q to a single machine", svc.Name())
 	}
-	var placement []*instance.Placement
-	if machineIdSpec != "" {
-		mid := machineIdSpec
-		scope := instance.MachineScope
-		var containerType instance.ContainerType
-		specParts := strings.SplitN(machineIdSpec, ":", 2)
-		if len(specParts) > 1 {
-			firstPart := specParts[0]
-			var err error
-			if containerType, err = instance.ParseContainerType(firstPart); err == nil {
-				mid = specParts[1]
-				scope = string(containerType)
-			}
-		}
-		if !names.IsValidMachine(mid) {
-			return nil, fmt.Errorf("invalid force machine id %q", mid)
-		}
-		placement = []*instance.Placement{
-			{
-				Scope:     scope,
-				Directive: mid,
-			},
-		}
+	placement, err := makePlacement(machineIdSpec)
+	if err != nil {
+		return nil, errors.Trace(err)
 	}
 	return AddUnitsWithPlacement(st, svc, n, placement)
+}
+
+// makePlacement makes a placement directive for the given machineIdSpec.
+func makePlacement(machineIdSpec string) ([]*instance.Placement, error) {
+	if machineIdSpec == "" {
+		return nil, nil
+	}
+	mid := machineIdSpec
+	scope := instance.MachineScope
+	var containerType instance.ContainerType
+	specParts := strings.SplitN(machineIdSpec, ":", 2)
+	if len(specParts) > 1 {
+		firstPart := specParts[0]
+		var err error
+		if containerType, err = instance.ParseContainerType(firstPart); err == nil {
+			mid = specParts[1]
+			scope = string(containerType)
+		}
+	}
+	if !names.IsValidMachine(mid) {
+		return nil, errors.Errorf("invalid force machine id %q", mid)
+	}
+	return []*instance.Placement{
+		{
+			Scope:     scope,
+			Directive: mid,
+		},
+	}, nil
 }
 
 // AddUnitsWithPlacement starts n units of the given service using the specified placement
@@ -222,12 +169,8 @@ func AddUnitsWithPlacement(st *state.State, svc *state.Service, n int, placement
 			units[i] = unit
 			continue
 		}
-		m, err := addMachineForUnit(st, unit, placement[i], networks)
-		if err != nil {
+		if err := st.AssignUnitWithPlacement(unit, placement[i], networks); err != nil {
 			return nil, errors.Annotatef(err, "adding new machine to host unit %q", unit.Name())
-		}
-		if err = unit.AssignToMachine(m); err != nil {
-			return nil, errors.Trace(err)
 		}
 		units[i] = unit
 	}

--- a/juju/deploy_test.go
+++ b/juju/deploy_test.go
@@ -69,8 +69,8 @@ func (s *DeployLocalSuite) TestDeployMinimal(c *gc.C) {
 	s.assertCharm(c, service, s.charm.URL())
 	s.assertSettings(c, service, charm.Settings{})
 	s.assertConstraints(c, service, constraints.Value{})
-	s.assertMachines(c, service, constraints.Value{})
 	c.Assert(service.GetOwnerTag(), gc.Equals, s.AdminUserTag(c).String())
+	s.assertMachines(c, service, constraints.Value{})
 }
 
 func (s *DeployLocalSuite) TestDeployOwnerTag(c *gc.C) {
@@ -131,10 +131,10 @@ func (s *DeployLocalSuite) TestDeployConstraints(c *gc.C) {
 }
 
 func (s *DeployLocalSuite) TestDeployNumUnits(c *gc.C) {
-	err := s.State.SetEnvironConstraints(constraints.MustParse("mem=2G"))
-	c.Assert(err, jc.ErrorIsNil)
+	f := &fakeDeployer{State: s.State}
+
 	serviceCons := constraints.MustParse("cpu-cores=2")
-	service, err := juju.DeployService(s.State,
+	_, err := juju.DeployService(f,
 		juju.DeployServiceParams{
 			ServiceName: "bob",
 			Charm:       s.charm,
@@ -142,8 +142,11 @@ func (s *DeployLocalSuite) TestDeployNumUnits(c *gc.C) {
 			NumUnits:    2,
 		})
 	c.Assert(err, jc.ErrorIsNil)
-	s.assertConstraints(c, service, serviceCons)
-	s.assertMachines(c, service, constraints.MustParse("mem=2G cpu-cores=2"), "0", "1")
+
+	c.Assert(f.args.Name, gc.Equals, "bob")
+	c.Assert(f.args.Charm, gc.DeepEquals, s.charm)
+	c.Assert(f.args.Constraints, gc.DeepEquals, serviceCons)
+	c.Assert(f.args.NumUnits, gc.Equals, 2)
 }
 
 func (s *DeployLocalSuite) TestDeployWithForceMachineRejectsTooManyUnits(c *gc.C) {
@@ -161,13 +164,10 @@ func (s *DeployLocalSuite) TestDeployWithForceMachineRejectsTooManyUnits(c *gc.C
 }
 
 func (s *DeployLocalSuite) TestDeployForceMachineId(c *gc.C) {
-	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(machine.Id(), gc.Equals, "0")
-	err = s.State.SetEnvironConstraints(constraints.MustParse("mem=2G"))
-	c.Assert(err, jc.ErrorIsNil)
+	f := &fakeDeployer{State: s.State}
+
 	serviceCons := constraints.MustParse("cpu-cores=2")
-	service, err := juju.DeployService(s.State,
+	_, err := juju.DeployService(f,
 		juju.DeployServiceParams{
 			ServiceName:   "bob",
 			Charm:         s.charm,
@@ -176,19 +176,20 @@ func (s *DeployLocalSuite) TestDeployForceMachineId(c *gc.C) {
 			ToMachineSpec: "0",
 		})
 	c.Assert(err, jc.ErrorIsNil)
-	s.assertConstraints(c, service, serviceCons)
-	s.assertMachines(c, service, constraints.Value{}, "0")
+
+	c.Assert(f.args.Name, gc.Equals, "bob")
+	c.Assert(f.args.Charm, gc.DeepEquals, s.charm)
+	c.Assert(f.args.Constraints, gc.DeepEquals, serviceCons)
+	c.Assert(f.args.NumUnits, gc.Equals, 1)
+	c.Assert(f.args.Placement, gc.HasLen, 1)
+	c.Assert(*f.args.Placement[0], gc.Equals, instance.Placement{Scope: instance.MachineScope, Directive: "0"})
 }
 
 func (s *DeployLocalSuite) TestDeployForceMachineIdWithContainer(c *gc.C) {
-	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(machine.Id(), gc.Equals, "0")
-	envCons := constraints.MustParse("mem=2G")
-	err = s.State.SetEnvironConstraints(envCons)
-	c.Assert(err, jc.ErrorIsNil)
+	f := &fakeDeployer{State: s.State}
+
 	serviceCons := constraints.MustParse("cpu-cores=2")
-	service, err := juju.DeployService(s.State,
+	_, err := juju.DeployService(f,
 		juju.DeployServiceParams{
 			ServiceName:   "bob",
 			Charm:         s.charm,
@@ -197,79 +198,59 @@ func (s *DeployLocalSuite) TestDeployForceMachineIdWithContainer(c *gc.C) {
 			ToMachineSpec: fmt.Sprintf("%s:0", instance.LXC),
 		})
 	c.Assert(err, jc.ErrorIsNil)
-	s.assertConstraints(c, service, serviceCons)
-	units, err := service.AllUnits()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(units, gc.HasLen, 1)
-
-	// The newly created container will use the constraints.
-	id, err := units[0].AssignedMachineId()
-	c.Assert(err, jc.ErrorIsNil)
-	machine, err = s.State.Machine(id)
-	c.Assert(err, jc.ErrorIsNil)
-	machineCons, err := machine.Constraints()
-	c.Assert(err, jc.ErrorIsNil)
-	unitCons, err := units[0].Constraints()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(machineCons, gc.DeepEquals, *unitCons)
+	c.Assert(f.args.Name, gc.Equals, "bob")
+	c.Assert(f.args.Charm, gc.DeepEquals, s.charm)
+	c.Assert(f.args.Constraints, gc.DeepEquals, serviceCons)
+	c.Assert(f.args.NumUnits, gc.Equals, 1)
+	c.Assert(f.args.Placement, gc.HasLen, 1)
+	c.Assert(*f.args.Placement[0], gc.Equals, instance.Placement{Scope: string(instance.LXC), Directive: "0"})
 }
 
 func (s *DeployLocalSuite) TestDeployWithPlacement(c *gc.C) {
-	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(machine.Id(), gc.Equals, "0")
-	err = s.State.SetEnvironConstraints(constraints.MustParse("mem=2G"))
-	c.Assert(err, jc.ErrorIsNil)
+	f := &fakeDeployer{State: s.State}
+
 	serviceCons := constraints.MustParse("cpu-cores=2")
-	service, err := juju.DeployService(s.State,
+	placement := []*instance.Placement{
+		{Scope: s.State.EnvironUUID(), Directive: "valid"},
+		{Scope: "#", Directive: "0"},
+		{Scope: "lxc", Directive: "1"},
+	}
+	_, err := juju.DeployService(f,
 		juju.DeployServiceParams{
-			ServiceName: "bob",
-			Charm:       s.charm,
-			Constraints: serviceCons,
-			NumUnits:    3,
-			Placement: []*instance.Placement{
-				{Scope: s.State.EnvironUUID(), Directive: "valid"},
-				{Scope: "#", Directive: "0"},
-				{Scope: "lxc", Directive: "1"},
-			},
+			ServiceName:   "bob",
+			Charm:         s.charm,
+			Constraints:   serviceCons,
+			NumUnits:      3,
+			Placement:     placement,
 			ToMachineSpec: "will be ignored",
 		})
 	c.Assert(err, jc.ErrorIsNil)
-	s.assertConstraints(c, service, serviceCons)
-	units, err := service.AllUnits()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(units, gc.HasLen, 3)
 
-	// Check each of the newly added units.
-	s.assertAssignedUnit(c, units[0], "1", constraints.MustParse("mem=2G cpu-cores=2"))
-	s.assertAssignedUnit(c, units[1], "0", constraints.Value{})
-	s.assertAssignedUnit(c, units[2], "1/lxc/0", constraints.MustParse("mem=2G cpu-cores=2"))
+	c.Assert(f.args.Name, gc.Equals, "bob")
+	c.Assert(f.args.Charm, gc.DeepEquals, s.charm)
+	c.Assert(f.args.Constraints, gc.DeepEquals, serviceCons)
+	c.Assert(f.args.NumUnits, gc.Equals, 3)
+	c.Assert(f.args.Placement, gc.DeepEquals, placement)
 }
 
 func (s *DeployLocalSuite) TestDeployWithFewerPlacement(c *gc.C) {
-	err := s.State.SetEnvironConstraints(constraints.MustParse("mem=2G"))
-	c.Assert(err, jc.ErrorIsNil)
+	f := &fakeDeployer{State: s.State}
 	serviceCons := constraints.MustParse("cpu-cores=2")
-	service, err := juju.DeployService(s.State,
+	placement := []*instance.Placement{{Scope: s.State.EnvironUUID(), Directive: "valid"}}
+	_, err := juju.DeployService(f,
 		juju.DeployServiceParams{
 			ServiceName: "bob",
 			Charm:       s.charm,
 			Constraints: serviceCons,
 			NumUnits:    3,
-			Placement: []*instance.Placement{
-				{Scope: s.State.EnvironUUID(), Directive: "valid"},
-			},
+			Placement:   placement,
 		})
 	c.Assert(err, jc.ErrorIsNil)
-	s.assertConstraints(c, service, serviceCons)
-	units, err := service.AllUnits()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(units, gc.HasLen, 3)
-
-	// Check each of the newly added units.
-	s.assertAssignedUnit(c, units[0], "0", constraints.MustParse("mem=2G cpu-cores=2"))
-	s.assertAssignedUnit(c, units[1], "1", constraints.MustParse("mem=2G cpu-cores=2"))
-	s.assertAssignedUnit(c, units[2], "2", constraints.MustParse("mem=2G cpu-cores=2"))
+	c.Assert(f.args.Name, gc.Equals, "bob")
+	c.Assert(f.args.Charm, gc.DeepEquals, s.charm)
+	c.Assert(f.args.Constraints, gc.DeepEquals, serviceCons)
+	c.Assert(f.args.NumUnits, gc.Equals, 3)
+	c.Assert(f.args.Placement, gc.DeepEquals, placement)
 }
 
 func (s *DeployLocalSuite) assertAssignedUnit(c *gc.C, u *state.Unit, mId string, cons constraints.Value) {
@@ -304,6 +285,19 @@ func (s *DeployLocalSuite) assertMachines(c *gc.C, service *state.Service, expec
 	units, err := service.AllUnits()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(units, gc.HasLen, len(expectIds))
+	// first manually tell state to assign all the units
+	for _, unit := range units {
+		id := unit.Tag().Id()
+		res, err := s.State.AssignStagedUnits([]string{id})
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(res[0].Error, jc.ErrorIsNil)
+		c.Assert(res[0].Unit, gc.Equals, id)
+	}
+
+	// refresh the list of units from state
+	units, err = service.AllUnits()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(units, gc.HasLen, len(expectIds))
 	unseenIds := set.NewStrings(expectIds...)
 	for _, unit := range units {
 		id, err := unit.AssignedMachineId()
@@ -316,4 +310,14 @@ func (s *DeployLocalSuite) assertMachines(c *gc.C, service *state.Service, expec
 		c.Assert(cons, gc.DeepEquals, expectCons)
 	}
 	c.Assert(unseenIds, gc.DeepEquals, set.NewStrings())
+}
+
+type fakeDeployer struct {
+	*state.State
+	args state.AddServiceArgs
+}
+
+func (f *fakeDeployer) AddService(args state.AddServiceArgs) (*state.Service, error) {
+	f.args = args
+	return nil, nil
 }

--- a/juju/testing/repo.go
+++ b/juju/testing/repo.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/storage"
+	coretesting "github.com/juju/juju/testing"
 )
 
 // BaseRepoSuite sets up $JUJU_REPOSITORY to point to a local charm repository.
@@ -86,6 +87,7 @@ func (s *RepoSuite) AssertService(c *gc.C, name string, expectCurl *charm.URL, u
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ch.URL(), gc.DeepEquals, expectCurl)
 	s.AssertCharmUploaded(c, expectCurl)
+
 	units, err := svc.AllUnits()
 	c.Logf("Service units: %+v", units)
 	c.Assert(err, jc.ErrorIsNil)
@@ -118,16 +120,30 @@ func (s *RepoSuite) AssertUnitMachines(c *gc.C, units []*state.Unit) {
 	}
 	sort.Strings(expectUnitNames)
 
-	machines, err := s.State.AllMachines()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(machines, gc.HasLen, len(units))
-	unitNames := []string{}
-	for _, m := range machines {
-		mUnits, err := m.Units()
+	for a := coretesting.LongAttempt.Start(); a.Next(); {
+		machines, err := s.State.AllMachines()
 		c.Assert(err, jc.ErrorIsNil)
-		c.Assert(mUnits, gc.HasLen, 1)
-		unitNames = append(unitNames, mUnits[0].Name())
+		if !a.HasNext() {
+			c.Assert(machines, gc.HasLen, len(units))
+		} else if len(machines) != len(units) {
+			continue
+		}
+
+		unitNames := []string{}
+		for _, m := range machines {
+			mUnits, err := m.Units()
+			c.Assert(err, jc.ErrorIsNil)
+			if !a.HasNext() {
+				c.Assert(mUnits, gc.HasLen, 1)
+			} else if len(mUnits) != 1 {
+				// not all units have been assigned to machines yet.
+				// wait a bit longer
+				continue
+			}
+			unitNames = append(unitNames, mUnits[0].Name())
+		}
+		sort.Strings(unitNames)
+		c.Assert(unitNames, gc.DeepEquals, expectUnitNames)
+		break
 	}
-	sort.Strings(unitNames)
-	c.Assert(unitNames, gc.DeepEquals, expectUnitNames)
 }

--- a/state/action_test.go
+++ b/state/action_test.go
@@ -615,7 +615,7 @@ func (s *ActionSuite) TestMergeIds(c *gc.C) {
 		expected := sliceify(test.expected)
 
 		c.Log(fmt.Sprintf("test number %d %#v", ix, test))
-		err := state.WatcherMergeIds(s.State, &changes, updates)
+		err := state.WatcherMergeIds(s.State, &changes, updates, state.ActionNotificationIdToActionId)
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(changes, jc.SameContents, expected)
 	}
@@ -639,7 +639,7 @@ func (s *ActionSuite) TestMergeIdsErrors(c *gc.C) {
 		changes, updates := []string{}, map[interface{}]bool{}
 
 		updates[test.key] = true
-		err := state.WatcherMergeIds(s.State, &changes, updates)
+		err := state.WatcherMergeIds(s.State, &changes, updates, state.ActionNotificationIdToActionId)
 
 		if test.ok {
 			c.Assert(err, jc.ErrorIsNil)

--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -186,6 +186,11 @@ func allCollections() collectionSchema {
 		},
 		minUnitsC: {},
 
+		// This collection holds documents that indicate units which are queued
+		// to be assigned to machines. It is used exclusively by the
+		// AssignUnitWorker.
+		assignUnitC: {},
+
 		// meterStatusC is the collection used to store meter status information.
 		meterStatusC:  {},
 		settingsrefsC: {},
@@ -345,6 +350,7 @@ const (
 	actionresultsC         = "actionresults"
 	actionsC               = "actions"
 	annotationsC           = "annotations"
+	assignUnitC            = "assignUnits"
 	blockDevicesC          = "blockdevices"
 	blocksC                = "blocks"
 	charmsC                = "charms"

--- a/state/compat_test.go
+++ b/state/compat_test.go
@@ -52,7 +52,7 @@ func (s *compatSuite) TestEnvironAssertAlive(c *gc.C) {
 func (s *compatSuite) TestGetServiceWithoutNetworksIsOK(c *gc.C) {
 	charm := addCharm(c, s.state, "quantal", testcharms.Repo.CharmDir("mysql"))
 	owner := s.env.Owner()
-	service, err := s.state.AddService("mysql", owner.String(), charm, nil, nil)
+	service, err := s.state.AddService(AddServiceArgs{Name: "mysql", Owner: owner.String(), Charm: charm})
 	c.Assert(err, jc.ErrorIsNil)
 	// In 1.17.7+ all services have associated document in the
 	// requested networks collection. We remove it here to test

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -128,7 +128,7 @@ func AddTestingServiceWithStorage(c *gc.C, st *State, name string, ch *Charm, ow
 
 func addTestingService(c *gc.C, st *State, name string, ch *Charm, owner names.UserTag, networks []string, storage map[string]StorageConstraints) *Service {
 	c.Assert(ch, gc.NotNil)
-	service, err := st.AddService(name, owner.String(), ch, networks, storage)
+	service, err := st.AddService(AddServiceArgs{Name: name, Owner: owner.String(), Charm: ch, Networks: networks, Storage: storage})
 	c.Assert(err, jc.ErrorIsNil)
 	return service
 }
@@ -246,8 +246,8 @@ func CheckUserExists(st *State, name string) (bool, error) {
 	return st.checkUserExists(name)
 }
 
-func WatcherMergeIds(st *State, changeset *[]string, updates map[interface{}]bool) error {
-	return mergeIds(st, changeset, updates)
+func WatcherMergeIds(st *State, changeset *[]string, updates map[interface{}]bool, idconv func(string) string) error {
+	return mergeIds(st, changeset, updates, idconv)
 }
 
 func WatcherEnsureSuffixFn(marker string) func(string) string {
@@ -427,3 +427,5 @@ func MakeLogDoc(
 func SpaceDoc(s *Space) spaceDoc {
 	return s.doc
 }
+
+var ActionNotificationIdToActionId = actionNotificationIdToActionId

--- a/state/filesystem_test.go
+++ b/state/filesystem_test.go
@@ -25,7 +25,7 @@ func (s *FilesystemStateSuite) TestAddServiceInvalidPool(c *gc.C) {
 	storage := map[string]state.StorageConstraints{
 		"data": makeStorageCons("invalid-pool", 1024, 1),
 	}
-	_, err := s.State.AddService("storage-filesystem", s.Owner.String(), ch, nil, storage)
+	_, err := s.State.AddService(state.AddServiceArgs{Name: "storage-filesystem", Owner: s.Owner.String(), Charm: ch, Storage: storage})
 	c.Assert(err, gc.ErrorMatches, `.* pool "invalid-pool" not found`)
 }
 
@@ -49,7 +49,7 @@ func (s *FilesystemStateSuite) testAddServiceDefaultPool(c *gc.C, expectedPool s
 	storage := map[string]state.StorageConstraints{
 		"data": makeStorageCons("", 1024, 1),
 	}
-	svc, err := s.State.AddService("storage-filesystem", s.Owner.String(), ch, nil, storage)
+	svc, err := s.State.AddService(state.AddServiceArgs{Name: "storage-filesystem", Owner: s.Owner.String(), Charm: ch, Storage: storage})
 	c.Assert(err, jc.ErrorIsNil)
 	cons, err := svc.StorageConstraints()
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/service.go
+++ b/state/service.go
@@ -644,14 +644,6 @@ func (s *Service) Refresh() error {
 
 // newUnitName returns the next unit name.
 func (s *Service) newUnitName() (string, error) {
-	services, closer := s.st.getCollection(servicesC)
-	defer closer()
-
-	result := &serviceDoc{}
-	if err := services.FindId(s.doc.DocID).One(&result); err == mgo.ErrNotFound {
-		return "", errors.NotFoundf("service %q", s)
-	}
-
 	unitSeq, err := s.st.sequence(s.Tag().String())
 	if err != nil {
 		return "", errors.Trace(err)
@@ -666,8 +658,45 @@ const MessageWaitForAgentInit = "Waiting for agent initialization to finish"
 // necessary to create that unit. The principalName param must be non-empty if
 // and only if s is a subordinate service. Only one subordinate of a given
 // service will be assigned to a given principal. The asserts param can be used
-// to include additional assertions for the service document.
+// to include additional assertions for the service document.  This method
+// assumes that the service already exists in the db.
 func (s *Service) addUnitOps(principalName string, asserts bson.D) (string, []txn.Op, error) {
+	var cons constraints.Value
+	if !s.doc.Subordinate {
+		scons, err := s.Constraints()
+		if errors.IsNotFound(err) {
+			return "", nil, errors.NotFoundf("service %q", s.Name())
+		}
+		if err != nil {
+			return "", nil, err
+		}
+		cons, err = s.st.resolveConstraints(scons)
+		if err != nil {
+			return "", nil, err
+		}
+	}
+	names, ops, err := s.addUnitOpsWithCons(principalName, cons)
+	if err != nil {
+		return names, ops, err
+	}
+	// we verify the service is alive
+	asserts = append(isAliveDoc, asserts...)
+	ops = append(ops, s.incUnitCountOp(asserts))
+	return names, ops, err
+}
+
+// addServiceUnitOps is just like addUnitOps but explicitly takes a
+// constraints value (this is used at service creation time).
+func (s *Service) addServiceUnitOps(principalName string, asserts bson.D, cons constraints.Value) (string, []txn.Op, error) {
+	names, ops, err := s.addUnitOpsWithCons(principalName, cons)
+	if err == nil {
+		ops = append(ops, s.incUnitCountOp(asserts))
+	}
+	return names, ops, err
+}
+
+// addUnitOpsWithCons is a helper method for returning addUnitOps.
+func (s *Service) addUnitOpsWithCons(principalName string, cons constraints.Value) (string, []txn.Op, error) {
 	if s.doc.Subordinate && principalName == "" {
 		return "", nil, fmt.Errorf("service is a subordinate")
 	} else if !s.doc.Subordinate && principalName != "" {
@@ -711,6 +740,7 @@ func (s *Service) addUnitOps(principalName string, asserts bson.D) (string, []tx
 		Updated:    now.UnixNano(),
 		EnvUUID:    s.st.EnvironUUID(),
 	}
+
 	ops := []txn.Op{
 		createStatusOp(s.st, globalKey, unitStatusDoc),
 		createStatusOp(s.st, agentGlobalKey, agentStatusDoc),
@@ -720,12 +750,6 @@ func (s *Service) addUnitOps(principalName string, asserts bson.D) (string, []tx
 			Id:     docID,
 			Assert: txn.DocMissing,
 			Insert: udoc,
-		},
-		{
-			C:      servicesC,
-			Id:     s.doc.DocID,
-			Assert: append(isAliveDoc, asserts...),
-			Update: bson.D{{"$inc", bson.D{{"unitcount", 1}}}},
 		},
 	}
 	ops = append(ops, storageOps...)
@@ -740,14 +764,6 @@ func (s *Service) addUnitOps(principalName string, asserts bson.D) (string, []tx
 			Update: bson.D{{"$addToSet", bson.D{{"subordinates", name}}}},
 		})
 	} else {
-		scons, err := s.Constraints()
-		if err != nil {
-			return "", nil, err
-		}
-		cons, err := s.st.resolveConstraints(scons)
-		if err != nil {
-			return "", nil, err
-		}
 		ops = append(ops, createConstraintsOp(s.st, agentGlobalKey, cons))
 	}
 
@@ -758,6 +774,19 @@ func (s *Service) addUnitOps(principalName string, asserts bson.D) (string, []tx
 	probablyUpdateStatusHistory(s.st, globalKey, unitStatusDoc)
 	probablyUpdateStatusHistory(s.st, agentGlobalKey, agentStatusDoc)
 	return name, ops, nil
+}
+
+// incUnitCountOp returns the operation to increment the service's unit count.
+func (s *Service) incUnitCountOp(asserts bson.D) txn.Op {
+	op := txn.Op{
+		C:      servicesC,
+		Id:     s.doc.DocID,
+		Update: bson.D{{"$inc", bson.D{{"unitcount", 1}}}},
+	}
+	if len(asserts) > 0 {
+		op.Assert = asserts
+	}
+	return op
 }
 
 // unitStorageOps returns operations for creating storage

--- a/state/state.go
+++ b/state/state.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/instance"
 	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state/cloudimagemetadata"
@@ -1091,25 +1092,35 @@ func (st *State) addPeerRelationsOps(serviceName string, peers map[string]charm.
 	return ops, nil
 }
 
+type AddServiceArgs struct {
+	Name        string
+	Owner       string
+	Charm       *Charm
+	Networks    []string
+	Storage     map[string]StorageConstraints
+	Settings    charm.Settings
+	NumUnits    int
+	Placement   []*instance.Placement
+	Constraints constraints.Value
+}
+
 // AddService creates a new service, running the supplied charm, with the
 // supplied name (which must be unique). If the charm defines peer relations,
 // they will be created automatically.
-func (st *State) AddService(
-	name, owner string, ch *Charm, networks []string, storage map[string]StorageConstraints,
-) (service *Service, err error) {
-	defer errors.DeferredAnnotatef(&err, "cannot add service %q", name)
-	ownerTag, err := names.ParseUserTag(owner)
+func (st *State) AddService(args AddServiceArgs) (service *Service, err error) {
+	defer errors.DeferredAnnotatef(&err, "cannot add service %q", args.Name)
+	ownerTag, err := names.ParseUserTag(args.Owner)
 	if err != nil {
-		return nil, errors.Annotatef(err, "Invalid ownertag %s", owner)
+		return nil, errors.Annotatef(err, "Invalid ownertag %s", args.Owner)
 	}
 	// Sanity checks.
-	if !names.IsValidService(name) {
+	if !names.IsValidService(args.Name) {
 		return nil, errors.Errorf("invalid name")
 	}
-	if ch == nil {
+	if args.Charm == nil {
 		return nil, errors.Errorf("charm is nil")
 	}
-	if exists, err := isNotDead(st, servicesC, name); err != nil {
+	if exists, err := isNotDead(st, servicesC, args.Name); err != nil {
 		return nil, errors.Trace(err)
 	} else if exists {
 		return nil, errors.Errorf("service already exists")
@@ -1123,29 +1134,46 @@ func (st *State) AddService(
 	if _, err := st.EnvironmentUser(ownerTag); err != nil {
 		return nil, errors.Trace(err)
 	}
-	if storage == nil {
-		storage = make(map[string]StorageConstraints)
+	if args.Storage == nil {
+		args.Storage = make(map[string]StorageConstraints)
 	}
-	if err := addDefaultStorageConstraints(st, storage, ch.Meta()); err != nil {
+
+	if err := addDefaultStorageConstraints(st, args.Storage, args.Charm.Meta()); err != nil {
 		return nil, errors.Trace(err)
 	}
-	if err := validateStorageConstraints(st, storage, ch.Meta()); err != nil {
+	if err := validateStorageConstraints(st, args.Storage, args.Charm.Meta()); err != nil {
 		return nil, errors.Trace(err)
 	}
-	serviceID := st.docID(name)
+
+	series := args.Charm.URL().Series
+
+	for _, placement := range args.Placement {
+		data, err := st.parsePlacement(placement)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		if data.placementType() == directivePlacement {
+			if err := st.precheckInstance(series, args.Constraints, data.directive); err != nil {
+				return nil, errors.Trace(err)
+			}
+		}
+	}
+
+	serviceID := st.docID(args.Name)
 	// Create the service addition operations.
-	peers := ch.Meta().Peers
+	peers := args.Charm.Meta().Peers
 	svcDoc := &serviceDoc{
 		DocID:         serviceID,
-		Name:          name,
+		Name:          args.Name,
 		EnvUUID:       env.UUID(),
-		Series:        ch.URL().Series,
-		Subordinate:   ch.Meta().Subordinate,
-		CharmURL:      ch.URL(),
+		Series:        series,
+		Subordinate:   args.Charm.Meta().Subordinate,
+		CharmURL:      args.Charm.URL(),
 		RelationCount: len(peers),
 		Life:          Alive,
-		OwnerTag:      owner,
+		OwnerTag:      args.Owner,
 	}
+
 	svc := newService(st, svcDoc)
 
 	statusDoc := statusDoc{
@@ -1164,14 +1192,14 @@ func (st *State) AddService(
 
 	ops := []txn.Op{
 		env.assertAliveOp(),
-		createConstraintsOp(st, svc.globalKey(), constraints.Value{}),
+		createConstraintsOp(st, svc.globalKey(), args.Constraints),
 		// TODO(dimitern) 2014-04-04 bug #1302498
 		// Once we can add networks independently of machine
 		// provisioning, we should check the given networks are valid
 		// and known before setting them.
-		createRequestedNetworksOp(st, svc.globalKey(), networks),
-		createStorageConstraintsOp(svc.globalKey(), storage),
-		createSettingsOp(svc.settingsKey(), nil),
+		createRequestedNetworksOp(st, svc.globalKey(), args.Networks),
+		createStorageConstraintsOp(svc.globalKey(), args.Storage),
+		createSettingsOp(svc.settingsKey(), map[string]interface{}(args.Settings)),
 		addLeadershipSettingsOp(svc.Tag().Id()),
 		createStatusOp(st, svc.globalKey(), statusDoc),
 		{
@@ -1188,13 +1216,26 @@ func (st *State) AddService(
 			Insert: svcDoc,
 		},
 	}
+
 	// Collect peer relation addition operations.
-	peerOps, err := st.addPeerRelationsOps(name, peers)
+	peerOps, err := st.addPeerRelationsOps(args.Name, peers)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 	ops = append(ops, peerOps...)
 
+	for x := 0; x < args.NumUnits; x++ {
+		unit, unitOps, err := svc.addServiceUnitOps("", nil, args.Constraints)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		ops = append(ops, unitOps...)
+		placement := instance.Placement{}
+		if x < len(args.Placement) {
+			placement = *args.Placement[x]
+		}
+		ops = append(ops, assignUnitOps(st, unit, placement)...)
+	}
 	// At the last moment before inserting the service, prime status history.
 	probablyUpdateStatusHistory(st, svc.globalKey(), statusDoc)
 
@@ -1211,6 +1252,184 @@ func (st *State) AddService(
 		return nil, errors.Trace(err)
 	}
 	return svc, nil
+}
+
+// assignUnitOps returns the db ops to save unit assignment for use by the
+// UnitAssigner worker.
+func assignUnitOps(st *State, unit string, placement instance.Placement) []txn.Op {
+	udoc := assignUnitDoc{
+		DocId:     unit,
+		Scope:     placement.Scope,
+		Directive: placement.Directive,
+	}
+	return []txn.Op{
+		{
+			C:      assignUnitC,
+			Id:     udoc.DocId,
+			Assert: txn.DocMissing,
+			Insert: udoc,
+		},
+	}
+}
+
+// AssignStagedUnits gets called by the UnitAssigner worker, and runs the given
+// assignments.
+func (st *State) AssignStagedUnits(ids []string) ([]UnitAssignmentResult, error) {
+	col, close := st.getCollection(assignUnitC)
+	defer close()
+	docs := []assignUnitDoc{}
+
+	for i, id := range ids {
+		ids[i] = st.docID(id)
+	}
+
+	sel := bson.D{{"_id", bson.D{{"$in", ids}}}}
+	if err := col.Find(sel).All(&docs); err != nil {
+		return nil, errors.Annotatef(err, "cannot get assign unit docs")
+	}
+	results := make([]UnitAssignmentResult, len(docs))
+	for i, doc := range docs {
+		err := st.assignStagedUnit(doc)
+		results[i].Unit = doc.DocId
+		results[i].Error = err
+	}
+	return results, nil
+}
+
+func removeStagedAssignmentOp(id string) txn.Op {
+	return txn.Op{
+		C:      assignUnitC,
+		Id:     id,
+		Remove: true,
+	}
+}
+
+func (st *State) assignStagedUnit(doc assignUnitDoc) error {
+	u, err := st.Unit(st.localID(doc.DocId))
+	if err != nil {
+		return errors.Trace(err)
+	}
+	svc, err := u.Service()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	networks, err := svc.Networks()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if doc.Scope == "" && doc.Directive == "" {
+		return errors.Trace(st.AssignUnit(u, AssignCleanEmpty))
+	}
+
+	placement := &instance.Placement{Scope: doc.Scope, Directive: doc.Directive}
+
+	// units always have the same networks as their service.
+	return errors.Trace(st.AssignUnitWithPlacement(u, placement, networks))
+}
+
+// AssignUnitWithPlacement chooses a machine using the given placement directive
+// and then assigns the unit to it.
+func (st *State) AssignUnitWithPlacement(unit *Unit, placement *instance.Placement, networks []string) error {
+	// TODO(natefinch) this should be done as a single transaction, not two.
+	// Mark https://launchpad.net/bugs/1506994 fixed when done.
+
+	m, err := st.addMachineWithPlacement(unit, placement, networks)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return unit.AssignToMachine(m)
+}
+
+// placementData is a helper type that encodes some of the logic behind how an
+// instance.Placement gets translated into a placement directive the providers
+// understand.
+type placementData struct {
+	machineId     string
+	directive     string
+	containerType instance.ContainerType
+}
+
+type placementType int
+
+const (
+	containerPlacement placementType = iota
+	directivePlacement
+	machinePlacement
+)
+
+// placementType returns the type of placement that this data represents.
+func (p placementData) placementType() placementType {
+	if p.containerType != "" {
+		return containerPlacement
+	}
+	if p.directive != "" {
+		return directivePlacement
+	}
+	return machinePlacement
+}
+
+func (st *State) parsePlacement(placement *instance.Placement) (*placementData, error) {
+	// Extract container type and parent from container placement directives.
+	if container, err := instance.ParseContainerType(placement.Scope); err == nil {
+		return &placementData{
+			containerType: container,
+			machineId:     placement.Directive,
+		}, nil
+	}
+	switch placement.Scope {
+	case st.EnvironUUID():
+		return &placementData{directive: placement.Directive}, nil
+	case instance.MachineScope:
+		return &placementData{machineId: placement.Directive}, nil
+	default:
+		return nil, errors.Errorf("invalid environment UUID %q", placement.Scope)
+	}
+}
+
+// addMachineWithPlacement finds a machine that matches the given placment directive for the given unit.
+func (st *State) addMachineWithPlacement(unit *Unit, placement *instance.Placement, networks []string) (*Machine, error) {
+	unitCons, err := unit.Constraints()
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := st.parsePlacement(placement)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	// Create any new machine marked as dirty so that
+	// nothing else will grab it before we assign the unit to it.
+	// TODO(natefinch) fix this when we put assignment in the same
+	// transaction as adding a machine.  See bug
+	// https://launchpad.net/bugs/1506994
+
+	switch data.placementType() {
+	case containerPlacement:
+		// If a container is to be used, create it.
+		template := MachineTemplate{
+			Series:            unit.Series(),
+			Jobs:              []MachineJob{JobHostUnits},
+			Dirty:             true,
+			Constraints:       *unitCons,
+			RequestedNetworks: networks,
+		}
+		return st.AddMachineInsideMachine(template, data.machineId, data.containerType)
+	case directivePlacement:
+		// If a placement directive is to be used, do that here.
+		template := MachineTemplate{
+			Series:            unit.Series(),
+			Jobs:              []MachineJob{JobHostUnits},
+			Dirty:             true,
+			Constraints:       *unitCons,
+			RequestedNetworks: networks,
+			Placement:         data.directive,
+		}
+		return st.AddOneMachine(template)
+	default:
+		// Otherwise use an existing machine.
+		return st.Machine(data.machineId)
+	}
 }
 
 // AddIPAddress creates and returns a new IP address. It can return an

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -1851,20 +1851,26 @@ func (s *StateSuite) TestAllNetworks(c *gc.C) {
 }
 
 func (s *StateSuite) TestAddService(c *gc.C) {
-	charm := s.AddTestingCharm(c, "dummy")
-	_, err := s.State.AddService("haha/borken", s.Owner.String(), charm, nil, nil)
+	ch := s.AddTestingCharm(c, "dummy")
+	_, err := s.State.AddService(state.AddServiceArgs{Name: "haha/borken", Owner: s.Owner.String(), Charm: ch})
 	c.Assert(err, gc.ErrorMatches, `cannot add service "haha/borken": invalid name`)
 	_, err = s.State.Service("haha/borken")
 	c.Assert(err, gc.ErrorMatches, `"haha/borken" is not a valid service name`)
 
 	// set that a nil charm is handled correctly
-	_, err = s.State.AddService("umadbro", s.Owner.String(), nil, nil, nil)
+	_, err = s.State.AddService(state.AddServiceArgs{Name: "umadbro", Owner: s.Owner.String()})
 	c.Assert(err, gc.ErrorMatches, `cannot add service "umadbro": charm is nil`)
 
-	wordpress, err := s.State.AddService("wordpress", s.Owner.String(), charm, nil, nil)
+	insettings := charm.Settings{"tuning": "optimized"}
+
+	wordpress, err := s.State.AddService(state.AddServiceArgs{Name: "wordpress", Owner: s.Owner.String(), Charm: ch, Settings: insettings})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(wordpress.Name(), gc.Equals, "wordpress")
-	mysql, err := s.State.AddService("mysql", s.Owner.String(), charm, nil, nil)
+	outsettings, err := wordpress.ConfigSettings()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(outsettings, gc.DeepEquals, insettings)
+
+	mysql, err := s.State.AddService(state.AddServiceArgs{Name: "mysql", Owner: s.Owner.String(), Charm: ch})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(mysql.Name(), gc.Equals, "mysql")
 
@@ -1872,15 +1878,15 @@ func (s *StateSuite) TestAddService(c *gc.C) {
 	wordpress, err = s.State.Service("wordpress")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(wordpress.Name(), gc.Equals, "wordpress")
-	ch, _, err := wordpress.Charm()
+	ch, _, err = wordpress.Charm()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(ch.URL(), gc.DeepEquals, charm.URL())
+	c.Assert(ch.URL(), gc.DeepEquals, ch.URL())
 	mysql, err = s.State.Service("mysql")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(mysql.Name(), gc.Equals, "mysql")
 	ch, _, err = mysql.Charm()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(ch.URL(), gc.DeepEquals, charm.URL())
+	c.Assert(ch.URL(), gc.DeepEquals, ch.URL())
 }
 
 func (s *StateSuite) TestAddServiceEnvironmentDying(c *gc.C) {
@@ -1891,7 +1897,7 @@ func (s *StateSuite) TestAddServiceEnvironmentDying(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = env.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = s.State.AddService("s1", s.Owner.String(), charm, nil, nil)
+	_, err = s.State.AddService(state.AddServiceArgs{Name: "s1", Owner: s.Owner.String(), Charm: charm})
 	c.Assert(err, gc.ErrorMatches, `cannot add service "s1": environment is no longer alive`)
 }
 
@@ -1906,7 +1912,7 @@ func (s *StateSuite) TestAddServiceEnvironmentDyingAfterInitial(c *gc.C) {
 		c.Assert(env.Life(), gc.Equals, state.Alive)
 		c.Assert(env.Destroy(), gc.IsNil)
 	}).Check()
-	_, err = s.State.AddService("s1", s.Owner.String(), charm, nil, nil)
+	_, err = s.State.AddService(state.AddServiceArgs{Name: "s1", Owner: s.Owner.String(), Charm: charm})
 	c.Assert(err, gc.ErrorMatches, `cannot add service "s1": environment is no longer alive`)
 }
 
@@ -1918,19 +1924,19 @@ func (s *StateSuite) TestServiceNotFound(c *gc.C) {
 
 func (s *StateSuite) TestAddServiceNoTag(c *gc.C) {
 	charm := s.AddTestingCharm(c, "dummy")
-	_, err := s.State.AddService("wordpress", "admin", charm, nil, nil)
+	_, err := s.State.AddService(state.AddServiceArgs{Name: "wordpress", Owner: "admin", Charm: charm})
 	c.Assert(err, gc.ErrorMatches, "cannot add service \"wordpress\": Invalid ownertag admin: \"admin\" is not a valid tag")
 }
 
 func (s *StateSuite) TestAddServiceNotUserTag(c *gc.C) {
 	charm := s.AddTestingCharm(c, "dummy")
-	_, err := s.State.AddService("wordpress", "machine-3", charm, nil, nil)
+	_, err := s.State.AddService(state.AddServiceArgs{Name: "wordpress", Owner: "machine-3", Charm: charm})
 	c.Assert(err, gc.ErrorMatches, "cannot add service \"wordpress\": Invalid ownertag machine-3: \"machine-3\" is not a valid user tag")
 }
 
 func (s *StateSuite) TestAddServiceNonExistentUser(c *gc.C) {
 	charm := s.AddTestingCharm(c, "dummy")
-	_, err := s.State.AddService("wordpress", "user-notAuser", charm, nil, nil)
+	_, err := s.State.AddService(state.AddServiceArgs{Name: "wordpress", Owner: "user-notAuser", Charm: charm})
 	c.Assert(err, gc.ErrorMatches, `cannot add service "wordpress": environment user "notAuser@local" not found`)
 }
 
@@ -1941,13 +1947,13 @@ func (s *StateSuite) TestAllServices(c *gc.C) {
 	c.Assert(len(services), gc.Equals, 0)
 
 	// Check that after adding services the result is ok.
-	_, err = s.State.AddService("wordpress", s.Owner.String(), charm, nil, nil)
+	_, err = s.State.AddService(state.AddServiceArgs{Name: "wordpress", Owner: s.Owner.String(), Charm: charm})
 	c.Assert(err, jc.ErrorIsNil)
 	services, err = s.State.AllServices()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(len(services), gc.Equals, 1)
 
-	_, err = s.State.AddService("mysql", s.Owner.String(), charm, nil, nil)
+	_, err = s.State.AddService(state.AddServiceArgs{Name: "mysql", Owner: s.Owner.String(), Charm: charm})
 	c.Assert(err, jc.ErrorIsNil)
 	services, err = s.State.AllServices()
 	c.Assert(err, jc.ErrorIsNil)
@@ -3564,7 +3570,7 @@ func (s *StateSuite) TestSetEnvironAgentVersionErrors(c *gc.C) {
 	// Add a service and 4 units: one with a different version, one
 	// with an empty version, one with the current version, and one
 	// with the new version.
-	service, err := s.State.AddService("wordpress", s.Owner.String(), s.AddTestingCharm(c, "wordpress"), nil, nil)
+	service, err := s.State.AddService(state.AddServiceArgs{Name: "wordpress", Owner: s.Owner.String(), Charm: s.AddTestingCharm(c, "wordpress")})
 	c.Assert(err, jc.ErrorIsNil)
 	unit0, err := service.AddUnit()
 	c.Assert(err, jc.ErrorIsNil)
@@ -3614,7 +3620,7 @@ func (s *StateSuite) prepareAgentVersionTests(c *gc.C, st *state.State) (*config
 	// Add a machine and a unit with the current version.
 	machine, err := st.AddMachine("series", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
-	service, err := st.AddService("wordpress", s.Owner.String(), s.AddTestingCharm(c, "wordpress"), nil, nil)
+	service, err := st.AddService(state.AddServiceArgs{Name: "wordpress", Owner: s.Owner.String(), Charm: s.AddTestingCharm(c, "wordpress")})
 	c.Assert(err, jc.ErrorIsNil)
 	unit, err := service.AddUnit()
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/storage_dynamicadd_test.go
+++ b/state/storage_dynamicadd_test.go
@@ -30,7 +30,7 @@ func (s *storageAddSuite) setupMultipleStoragesForAdd(c *gc.C) *state.Unit {
 		"multi1to10": makeStorageCons("loop", 0, 3),
 	}
 	charm := s.AddTestingCharm(c, "storage-block2")
-	service, err := s.State.AddService("storage-block2", "user-test-admin@local", charm, nil, storageCons)
+	service, err := s.State.AddService(state.AddServiceArgs{Name: "storage-block2", Owner: "user-test-admin@local", Charm: charm, Storage: storageCons})
 	c.Assert(err, jc.ErrorIsNil)
 	u, err := service.AddUnit()
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/storage_test.go
+++ b/state/storage_test.go
@@ -369,7 +369,7 @@ func makeStorageCons(pool string, size, count uint64) state.StorageConstraints {
 
 func (s *StorageStateSuite) TestAddServiceStorageConstraintsDefault(c *gc.C) {
 	ch := s.AddTestingCharm(c, "storage-block")
-	storageBlock, err := s.State.AddService("storage-block", "user-test-admin@local", ch, nil, nil)
+	storageBlock, err := s.State.AddService(state.AddServiceArgs{Name: "storage-block", Owner: "user-test-admin@local", Charm: ch})
 	c.Assert(err, jc.ErrorIsNil)
 	constraints, err := storageBlock.StorageConstraints()
 	c.Assert(err, jc.ErrorIsNil)
@@ -387,7 +387,7 @@ func (s *StorageStateSuite) TestAddServiceStorageConstraintsDefault(c *gc.C) {
 	})
 
 	ch = s.AddTestingCharm(c, "storage-filesystem")
-	storageFilesystem, err := s.State.AddService("storage-filesystem", "user-test-admin@local", ch, nil, nil)
+	storageFilesystem, err := s.State.AddService(state.AddServiceArgs{Name: "storage-filesystem", Owner: "user-test-admin@local", Charm: ch})
 	c.Assert(err, jc.ErrorIsNil)
 	constraints, err = storageFilesystem.StorageConstraints()
 	c.Assert(err, jc.ErrorIsNil)
@@ -403,7 +403,7 @@ func (s *StorageStateSuite) TestAddServiceStorageConstraintsDefault(c *gc.C) {
 func (s *StorageStateSuite) TestAddServiceStorageConstraintsValidation(c *gc.C) {
 	ch := s.AddTestingCharm(c, "storage-block2")
 	addService := func(storage map[string]state.StorageConstraints) (*state.Service, error) {
-		return s.State.AddService("storage-block2", "user-test-admin@local", ch, nil, storage)
+		return s.State.AddService(state.AddServiceArgs{Name: "storage-block2", Owner: "user-test-admin@local", Charm: ch, Storage: storage})
 	}
 	assertErr := func(storage map[string]state.StorageConstraints, expect string) {
 		_, err := addService(storage)
@@ -435,7 +435,7 @@ func (s *StorageStateSuite) assertAddServiceStorageConstraintsDefaults(c *gc.C, 
 		c.Assert(err, jc.ErrorIsNil)
 	}
 	ch := s.AddTestingCharm(c, "storage-block")
-	service, err := s.State.AddService("storage-block2", "user-test-admin@local", ch, nil, cons)
+	service, err := s.State.AddService(state.AddServiceArgs{Name: "storage-block2", Owner: "user-test-admin@local", Charm: ch, Storage: cons})
 	c.Assert(err, jc.ErrorIsNil)
 	savedCons, err := service.StorageConstraints()
 	c.Assert(err, jc.ErrorIsNil)
@@ -507,7 +507,7 @@ func (s *StorageStateSuite) TestAddServiceStorageConstraintsDefaultSizeFromCharm
 		"multi2up":   makeStorageCons("loop", 2048, 2),
 	}
 	ch := s.AddTestingCharm(c, "storage-block2")
-	service, err := s.State.AddService("storage-block2", "user-test-admin@local", ch, nil, storageCons)
+	service, err := s.State.AddService(state.AddServiceArgs{Name: "storage-block2", Owner: "user-test-admin@local", Charm: ch, Storage: storageCons})
 	c.Assert(err, jc.ErrorIsNil)
 	savedCons, err := service.StorageConstraints()
 	c.Assert(err, jc.ErrorIsNil)
@@ -517,7 +517,7 @@ func (s *StorageStateSuite) TestAddServiceStorageConstraintsDefaultSizeFromCharm
 func (s *StorageStateSuite) TestProviderFallbackToType(c *gc.C) {
 	ch := s.AddTestingCharm(c, "storage-block")
 	addService := func(storage map[string]state.StorageConstraints) (*state.Service, error) {
-		return s.State.AddService("storage-block", "user-test-admin@local", ch, nil, storage)
+		return s.State.AddService(state.AddServiceArgs{Name: "storage-block", Owner: "user-test-admin@local", Charm: ch, Storage: storage})
 	}
 	storageCons := map[string]state.StorageConstraints{
 		"data": makeStorageCons("loop", 1024, 1),

--- a/state/unit.go
+++ b/state/unit.go
@@ -1240,7 +1240,9 @@ func (u *Unit) assignToMachineOps(m *Machine, unused bool) ([]txn.Op, error) {
 		Id:     m.doc.DocID,
 		Assert: massert,
 		Update: bson.D{{"$addToSet", bson.D{{"principals", u.doc.Name}}}, {"$set", bson.D{{"clean", false}}}},
-	}}
+	},
+		removeStagedAssignmentOp(u.doc.DocID),
+	}
 	ops = append(ops, storageOps...)
 	return ops, nil
 }

--- a/state/unit_assignment.go
+++ b/state/unit_assignment.go
@@ -1,0 +1,25 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+// assignUnitDoc is a document that temporarily stores unit assignment
+// information created during srevice creation until the unitassigner worker can
+// come along and use it.
+type assignUnitDoc struct {
+	// DocId is the unique id of the document, which is also the unit id of the
+	// unit to be assigned.
+	DocId string `bson:"_id"`
+
+	// Scope is the placement scope to apply to the unit.
+	Scope string `bson:"scope`
+
+	// Directive is the placement directive to apply to the unit.
+	Directive string `bson:"scope`
+}
+
+// UnitAssignmentResult is the result of running a staged unit assignment.
+type UnitAssignmentResult struct {
+	Unit  string
+	Error error
+}

--- a/state/volume_test.go
+++ b/state/volume_test.go
@@ -83,7 +83,7 @@ func (s *VolumeStateSuite) TestAddServiceInvalidPool(c *gc.C) {
 	storage := map[string]state.StorageConstraints{
 		"data": makeStorageCons("invalid-pool", 1024, 1),
 	}
-	_, err := s.State.AddService("storage-block", s.Owner.String(), ch, nil, storage)
+	_, err := s.State.AddService(state.AddServiceArgs{Name: "storage-block", Owner: s.Owner.String(), Charm: ch, Storage: storage})
 	c.Assert(err, gc.ErrorMatches, `.* pool "invalid-pool" not found`)
 }
 
@@ -92,7 +92,7 @@ func (s *VolumeStateSuite) TestAddServiceNoUserDefaultPool(c *gc.C) {
 	storage := map[string]state.StorageConstraints{
 		"data": makeStorageCons("", 1024, 1),
 	}
-	service, err := s.State.AddService("storage-block", s.Owner.String(), ch, nil, storage)
+	service, err := s.State.AddService(state.AddServiceArgs{Name: "storage-block", Owner: s.Owner.String(), Charm: ch, Storage: storage})
 	c.Assert(err, jc.ErrorIsNil)
 	cons, err := service.StorageConstraints()
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -1431,6 +1431,12 @@ func (st *State) WatchForEnvironConfigChanges() NotifyWatcher {
 	return newEntityWatcher(st, settingsC, st.docID(environGlobalKey))
 }
 
+// WatchForUnitAssignment watches for new services that request units to be
+// assigned to machines.
+func (st *State) WatchForUnitAssignment() StringsWatcher {
+	return newcollectionWatcher(st, colWCfg{col: assignUnitC})
+}
+
 // WatchAPIHostPorts returns a NotifyWatcher that notifies
 // when the set of API addresses changes.
 func (st *State) WatchAPIHostPorts() NotifyWatcher {
@@ -2053,29 +2059,34 @@ func statusInCollectionOp(statusSet ...ActionStatus) bson.D {
 	return inCollectionOp("status", ids...)
 }
 
-// idPrefixWatcher is a StringsWatcher that watches for changes on the
-// specified collection that match common prefixes
-type idPrefixWatcher struct {
+// collectionWatcher is a StringsWatcher that watches for changes on the
+// specified collection that match a filter on the id.
+type collectionWatcher struct {
 	commonWatcher
-	source   chan watcher.Change
-	sink     chan []string
-	filterFn func(interface{}) bool
-	targetC  string
+	colWCfg
+	source chan watcher.Change
+	sink   chan []string
 }
 
-// ensure idPrefixWatcher is a StringsWatcher
+// ensure collectionWatcher is a StringsWatcher
 // TODO(dfc) this needs to move to a test
-var _ StringsWatcher = (*idPrefixWatcher)(nil)
+var _ StringsWatcher = (*collectionWatcher)(nil)
 
-// newIdPrefixWatcher starts and returns a new StringsWatcher configured
+// colWCfg contains the parameters for watching a collection.
+type colWCfg struct {
+	col    string
+	filter func(interface{}) bool
+	idconv func(string) string
+}
+
+// newcollectionWatcher starts and returns a new StringsWatcher configured
 // with the given collection and filter function
-func newIdPrefixWatcher(st *State, collectionName string, filter func(interface{}) bool) StringsWatcher {
-	w := &idPrefixWatcher{
+func newcollectionWatcher(st *State, cfg colWCfg) StringsWatcher {
+	w := &collectionWatcher{
+		colWCfg:       cfg,
 		commonWatcher: commonWatcher{st: st},
 		source:        make(chan watcher.Change),
 		sink:          make(chan []string),
-		filterFn:      filter,
-		targetC:       collectionName,
 	}
 
 	go func() {
@@ -2089,21 +2100,21 @@ func newIdPrefixWatcher(st *State, collectionName string, filter func(interface{
 }
 
 // Changes returns the event channel for this watcher
-func (w *idPrefixWatcher) Changes() <-chan []string {
+func (w *collectionWatcher) Changes() <-chan []string {
 	return w.sink
 }
 
 // loop performs the main event loop cycle, polling for changes and
 // responding to Changes requests
-func (w *idPrefixWatcher) loop() error {
+func (w *collectionWatcher) loop() error {
 	var (
 		changes []string
 		in      = (<-chan watcher.Change)(w.source)
 		out     = (chan<- []string)(w.sink)
 	)
 
-	w.st.watcher.WatchCollectionWithFilter(w.targetC, w.source, w.filterFn)
-	defer w.st.watcher.UnwatchCollection(w.targetC, w.source)
+	w.st.watcher.WatchCollectionWithFilter(w.col, w.source, w.filter)
+	defer w.st.watcher.UnwatchCollection(w.col, w.source)
 
 	changes, err := w.initial()
 	if err != nil {
@@ -2121,7 +2132,7 @@ func (w *idPrefixWatcher) loop() error {
 			if !ok {
 				return tomb.ErrDying
 			}
-			if err := mergeIds(w.st, &changes, updates); err != nil {
+			if err := w.mergeIds(w.st, &changes, updates); err != nil {
 				return err
 			}
 			if len(changes) > 0 {
@@ -2164,18 +2175,21 @@ func makeIdFilter(st *State, marker string, receivers ...ActionReceiver) func(in
 
 // initial pre-loads the id's that have already been added to the
 // collection that would otherwise not normally trigger the watcher
-func (w *idPrefixWatcher) initial() ([]string, error) {
+func (w *collectionWatcher) initial() ([]string, error) {
 	var ids []string
 	var doc struct {
 		DocId string `bson:"_id"`
 	}
-	coll, closer := w.st.getCollection(w.targetC)
+	coll, closer := w.st.getCollection(w.col)
 	defer closer()
 	iter := coll.Find(nil).Iter()
 	for iter.Next(&doc) {
-		if w.filterFn == nil || w.filterFn(doc.DocId) {
-			actionId := actionNotificationIdToActionId(w.st.localID(doc.DocId))
-			ids = append(ids, actionId)
+		if w.filter == nil || w.filter(doc.DocId) {
+			id := w.st.localID(doc.DocId)
+			if w.idconv != nil {
+				id = w.idconv(id)
+			}
+			ids = append(ids, id)
 		}
 	}
 	return ids, iter.Close()
@@ -2189,25 +2203,31 @@ func (w *idPrefixWatcher) initial() ([]string, error) {
 // watcher.
 // Additionally, mergeIds strips the environment UUID prefix from the id
 // before emitting it through the watcher.
-func mergeIds(st *State, changes *[]string, updates map[interface{}]bool) error {
-	for id, idExists := range updates {
-		switch id := id.(type) {
-		case string:
-			localId := st.localID(id)
-			actionId := actionNotificationIdToActionId(localId)
-			chIx, idAlreadyInChangeset := indexOf(actionId, *changes)
-			if idExists {
-				if !idAlreadyInChangeset {
-					*changes = append(*changes, actionId)
-				}
-			} else {
-				if idAlreadyInChangeset {
-					// remove id from changes
-					*changes = append([]string(*changes)[:chIx], []string(*changes)[chIx+1:]...)
-				}
+func (w *collectionWatcher) mergeIds(st *State, changes *[]string, updates map[interface{}]bool) error {
+	return mergeIds(st, changes, updates, w.idconv)
+}
+
+func mergeIds(st *State, changes *[]string, updates map[interface{}]bool, idconv func(string) string) error {
+	for val, idExists := range updates {
+		id, ok := val.(string)
+		if !ok {
+			return errors.Errorf("id is not of type string, got %T", val)
+		}
+		id = st.localID(id)
+		if idconv != nil {
+			id = idconv(id)
+		}
+
+		chIx, idAlreadyInChangeset := indexOf(id, *changes)
+		if idExists {
+			if !idAlreadyInChangeset {
+				*changes = append(*changes, id)
 			}
-		default:
-			return errors.Errorf("id is not of type string, got %T", id)
+		} else {
+			if idAlreadyInChangeset {
+				// remove id from changes
+				*changes = append([]string(*changes)[:chIx], []string(*changes)[chIx+1:]...)
+			}
 		}
 	}
 	return nil
@@ -2244,14 +2264,22 @@ func ensureSuffixFn(marker string) func(string) string {
 // watchEnqueuedActions starts and returns a StringsWatcher that
 // notifies on new Actions being enqueued.
 func (st *State) watchEnqueuedActions() StringsWatcher {
-	return newIdPrefixWatcher(st, actionNotificationsC, makeIdFilter(st, actionMarker))
+	return newcollectionWatcher(st, colWCfg{
+		col:    actionNotificationsC,
+		filter: makeIdFilter(st, actionMarker),
+		idconv: actionNotificationIdToActionId,
+	})
 }
 
 // watchEnqueuedActionsFilteredBy starts and returns a StringsWatcher
 // that notifies on new Actions being enqueued on the ActionRecevers
 // being watched.
 func (st *State) watchEnqueuedActionsFilteredBy(receivers ...ActionReceiver) StringsWatcher {
-	return newIdPrefixWatcher(st, actionNotificationsC, makeIdFilter(st, actionMarker, receivers...))
+	return newcollectionWatcher(st, colWCfg{
+		col:    actionNotificationsC,
+		filter: makeIdFilter(st, actionMarker, receivers...),
+		idconv: actionNotificationIdToActionId,
+	})
 }
 
 // WatchActionResults starts and returns a StringsWatcher that

--- a/testing/factory/factory.go
+++ b/testing/factory/factory.go
@@ -335,7 +335,7 @@ func (factory *Factory) MakeService(c *gc.C, params *ServiceParams) *state.Servi
 		params.Creator = creator.Tag()
 	}
 	_ = params.Creator.(names.UserTag)
-	service, err := factory.st.AddService(params.Name, params.Creator.String(), params.Charm, nil, nil)
+	service, err := factory.st.AddService(state.AddServiceArgs{Name: params.Name, Owner: params.Creator.String(), Charm: params.Charm})
 	c.Assert(err, jc.ErrorIsNil)
 
 	if params.Status != nil {

--- a/worker/unitassigner/package_test.go
+++ b/worker/unitassigner/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package unitassigner
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/worker/unitassigner/unitassigner.go
+++ b/worker/unitassigner/unitassigner.go
@@ -1,0 +1,90 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package unitassigner
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/juju/api/watcher"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/worker"
+	"github.com/juju/loggo"
+	"github.com/juju/names"
+)
+
+var logger = loggo.GetLogger("juju.worker.unitassigner")
+
+type UnitAssigner interface {
+	AssignUnits(tags []names.UnitTag) ([]error, error)
+	WatchUnitAssignments() (watcher.StringsWatcher, error)
+	SetAgentStatus(args params.SetStatus) error
+}
+
+func New(ua UnitAssigner) worker.Worker {
+	return worker.NewStringsWorker(unitAssigner{api: ua})
+}
+
+type unitAssigner struct {
+	api UnitAssigner
+}
+
+func (u unitAssigner) SetUp() (watcher.StringsWatcher, error) {
+	return u.api.WatchUnitAssignments()
+}
+
+func (u unitAssigner) Handle(ids []string) error {
+	logger.Tracef("Handling unit assignments: %q", ids)
+	if len(ids) == 0 {
+		return nil
+	}
+
+	units := make([]names.UnitTag, len(ids))
+	for i, id := range ids {
+		if !names.IsValidUnit(id) {
+			return errors.Errorf("%q is not a valid unit id", id)
+		}
+		units[i] = names.NewUnitTag(id)
+	}
+
+	results, err := u.api.AssignUnits(units)
+	if err != nil {
+		return err
+	}
+
+	failures := map[string]error{}
+
+	logger.Tracef("Unit assignment results: %q", results)
+	// errors are returned in the same order as the ids given. Any errors from
+	// the assign units call must be reported as error statuses on the
+	// respective units (though the assignments will be retried).  Not found
+	// errors indicate that the unit was removed before the assignment was
+	// requested, which can be safely ignored.
+	for i, err := range results {
+		if err != nil && !errors.IsNotFound(err) {
+			failures[units[i].String()] = err
+		}
+	}
+
+	if len(failures) > 0 {
+		args := params.SetStatus{
+			Entities: make([]params.EntityStatusArgs, len(failures)),
+		}
+
+		x := 0
+		for unit, err := range failures {
+			args.Entities[x] = params.EntityStatusArgs{
+				Tag:    unit,
+				Status: params.StatusError,
+				Info:   err.Error(),
+			}
+			x++
+		}
+
+		return u.api.SetAgentStatus(args)
+	}
+	return nil
+}
+
+func (unitAssigner) TearDown() error {
+	return nil
+}

--- a/worker/unitassigner/unitassigner_test.go
+++ b/worker/unitassigner/unitassigner_test.go
@@ -1,0 +1,91 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package unitassigner
+
+import (
+	"errors"
+
+	"github.com/juju/names"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/api/watcher"
+	"github.com/juju/juju/apiserver/params"
+)
+
+var _ = gc.Suite(testsuite{})
+
+type testsuite struct{}
+
+func (testsuite) TestSetup(c *gc.C) {
+	f := &fakeAPI{}
+	ua := unitAssigner{api: f}
+	_, err := ua.SetUp()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(f.calledWatch, jc.IsTrue)
+
+	f.err = errors.New("boo")
+	_, err = ua.SetUp()
+	c.Assert(err, gc.Equals, f.err)
+}
+
+func (testsuite) TestHandle(c *gc.C) {
+	f := &fakeAPI{}
+	ua := unitAssigner{api: f}
+	ids := []string{"foo/0", "bar/0"}
+	err := ua.Handle(ids)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(f.assignTags, gc.DeepEquals, []names.UnitTag{
+		names.NewUnitTag("foo/0"),
+		names.NewUnitTag("bar/0"),
+	})
+
+	f.err = errors.New("boo")
+	err = ua.Handle(ids)
+	c.Assert(err, gc.Equals, f.err)
+}
+
+func (testsuite) TestHandleError(c *gc.C) {
+	e := errors.New("some error")
+	f := &fakeAPI{assignErrs: []error{e}}
+	ua := unitAssigner{api: f}
+	ids := []string{"foo/0", "bar/0"}
+	err := ua.Handle(ids)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(f.assignTags, gc.DeepEquals, []names.UnitTag{
+		names.NewUnitTag("foo/0"),
+		names.NewUnitTag("bar/0"),
+	})
+	c.Assert(f.status.Entities, gc.NotNil)
+	entities := f.status.Entities
+	c.Assert(entities, gc.HasLen, 1)
+	c.Assert(entities[0], gc.DeepEquals, params.EntityStatusArgs{
+		Tag:    "unit-foo-0",
+		Status: params.StatusError,
+		Info:   e.Error(),
+	})
+}
+
+type fakeAPI struct {
+	calledWatch bool
+	assignTags  []names.UnitTag
+	err         error
+	status      params.SetStatus
+	assignErrs  []error
+}
+
+func (f *fakeAPI) AssignUnits(tags []names.UnitTag) ([]error, error) {
+	f.assignTags = tags
+	return f.assignErrs, f.err
+}
+
+func (f *fakeAPI) WatchUnitAssignments() (watcher.StringsWatcher, error) {
+	f.calledWatch = true
+	return nil, f.err
+}
+
+func (f *fakeAPI) SetAgentStatus(args params.SetStatus) error {
+	f.status = args
+	return f.err
+}


### PR DESCRIPTION
This re-applies the original PR (since it had been reverted) and fixes the two bugs that were found with it - unable to deploy units (actually, the problem was that the units were getting assigned multiple times) and machines were getting created with non-sequential numbers.  both were caused by the fact that the unitassigner was being run on all machines, and so every machine would issue a request to assign a unit whenever one was ready to be assigned.  Now we use a singular runner to ensure that only one unitassigner is running.

(Review request: http://reviews.vapour.ws/r/3103/)