### PR TITLE
utils: move Network operation helpers into apiserver

### DIFF
--- a/apiserver/network_test.go
+++ b/apiserver/network_test.go
@@ -1,7 +1,7 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package utils_test
+package apiserver
 
 import (
 	"time"
@@ -11,7 +11,6 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/testing"
-	"github.com/juju/juju/utils"
 )
 
 type networkSuite struct {
@@ -26,52 +25,52 @@ func (s *networkSuite) TestOpSuccess(c *gc.C) {
 		isCalled = true
 		return nil
 	}
-	err := utils.NetworkOperationWitDefaultRetries(f, "do it")()
+	err := networkOperationWitDefaultRetries(f, "do it")()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(isCalled, jc.IsTrue)
 }
 
 func (s *networkSuite) TestOpFailureNoRetry(c *gc.C) {
-	s.PatchValue(&utils.DefaultNetworkOperationRetryDelay, 1*time.Millisecond)
+	s.PatchValue(&defaultNetworkOperationRetryDelay, 1*time.Millisecond)
 	netErr := &netError{false}
 	callCount := 0
 	f := func() error {
 		callCount++
 		return netErr
 	}
-	err := utils.NetworkOperationWitDefaultRetries(f, "do it")()
+	err := networkOperationWitDefaultRetries(f, "do it")()
 	c.Assert(errors.Cause(err), gc.Equals, netErr)
 	c.Assert(callCount, gc.Equals, 1)
 }
 
 func (s *networkSuite) TestOpFailureRetries(c *gc.C) {
-	s.PatchValue(&utils.DefaultNetworkOperationRetryDelay, 1*time.Millisecond)
+	s.PatchValue(&defaultNetworkOperationRetryDelay, 1*time.Millisecond)
 	netErr := &netError{true}
 	callCount := 0
 	f := func() error {
 		callCount++
 		return netErr
 	}
-	err := utils.NetworkOperationWitDefaultRetries(f, "do it")()
+	err := networkOperationWitDefaultRetries(f, "do it")()
 	c.Assert(errors.Cause(err), gc.Equals, netErr)
 	c.Assert(callCount, gc.Equals, 10)
 }
 
 func (s *networkSuite) TestOpNestedFailureRetries(c *gc.C) {
-	s.PatchValue(&utils.DefaultNetworkOperationRetryDelay, 1*time.Millisecond)
+	s.PatchValue(&defaultNetworkOperationRetryDelay, 1*time.Millisecond)
 	netErr := &netError{true}
 	callCount := 0
 	f := func() error {
 		callCount++
 		return errors.Annotate(errors.Trace(netErr), "create a wrapped error")
 	}
-	err := utils.NetworkOperationWitDefaultRetries(f, "do it")()
+	err := networkOperationWitDefaultRetries(f, "do it")()
 	c.Assert(errors.Cause(err), gc.Equals, netErr)
 	c.Assert(callCount, gc.Equals, 10)
 }
 
 func (s *networkSuite) TestOpSucceedsAfterRetries(c *gc.C) {
-	s.PatchValue(&utils.DefaultNetworkOperationRetryDelay, 1*time.Millisecond)
+	s.PatchValue(&defaultNetworkOperationRetryDelay, 1*time.Millisecond)
 	netErr := &netError{true}
 	callCount := 0
 	f := func() error {
@@ -81,7 +80,7 @@ func (s *networkSuite) TestOpSucceedsAfterRetries(c *gc.C) {
 		}
 		return netErr
 	}
-	err := utils.NetworkOperationWitDefaultRetries(f, "do it")()
+	err := networkOperationWitDefaultRetries(f, "do it")()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(callCount, gc.Equals, 5)
 }


### PR DESCRIPTION
These two functions were only used in the apiserver. Move them
and their tests to the apiserver package.

(Review request: http://reviews.vapour.ws/r/3112/)