### PR TITLE
Fix creation of machine agent symlinks

### DIFF
--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -1741,7 +1741,7 @@ func (a *MachineAgent) createJujudSymlinks(dataDir string) error {
 }
 
 func (a *MachineAgent) createSymlink(target, link string) error {
-	fullLink := filepath.Join(a.rootDir, link)
+	fullLink := utils.EnsureBaseDir(a.rootDir, link)
 
 	currentTarget, err := symlink.Read(fullLink)
 	if err != nil && !os.IsNotExist(err) {
@@ -1766,7 +1766,7 @@ func (a *MachineAgent) createSymlink(target, link string) error {
 
 func (a *MachineAgent) removeJujudSymlinks() (errs []error) {
 	for _, link := range []string{jujuRun, jujuDumpLogs} {
-		err := os.Remove(filepath.Join(a.rootDir, link))
+		err := os.Remove(utils.EnsureBaseDir(a.rootDir, link))
 		if err != nil && !os.IsNotExist(err) {
 			errs = append(errs, errors.Annotatef(err, "failed to remove %s symlink", link))
 		}

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -180,7 +180,7 @@ type AgentConfigWriter interface {
 // MachineAgent.
 func NewMachineAgentCmd(
 	ctx *cmd.Context,
-	machineAgentFactory func(string, string) *MachineAgent,
+	machineAgentFactory func(string) *MachineAgent,
 	agentInitializer AgentInitializer,
 	configFetcher AgentConfigWriter,
 ) cmd.Command {
@@ -198,7 +198,7 @@ type machineAgentCmd struct {
 	// This group of arguments is required.
 	agentInitializer    AgentInitializer
 	currentConfig       AgentConfigWriter
-	machineAgentFactory func(string, string) *MachineAgent
+	machineAgentFactory func(string) *MachineAgent
 	ctx                 *cmd.Context
 
 	// This group is for debugging purposes.
@@ -247,7 +247,7 @@ func (a *machineAgentCmd) Init(args []string) error {
 
 // Run instantiates a MachineAgent and runs it.
 func (a *machineAgentCmd) Run(c *cmd.Context) error {
-	machineAgent := a.machineAgentFactory(a.machineId, c.Dir)
+	machineAgent := a.machineAgentFactory(a.machineId)
 	return machineAgent.Run(c)
 }
 
@@ -271,8 +271,9 @@ func MachineAgentFactoryFn(
 	agentConfWriter AgentConfigWriter,
 	bufferedLogs logsender.LogRecordCh,
 	loopDeviceManager looputil.LoopDeviceManager,
-) func(string, string) *MachineAgent {
-	return func(machineId, rootDir string) *MachineAgent {
+	rootDir string,
+) func(string) *MachineAgent {
+	return func(machineId string) *MachineAgent {
 		return NewMachineAgent(
 			machineId,
 			agentConfWriter,

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -231,9 +231,9 @@ func (s *commonMachineSuite) newAgent(c *gc.C, m *state.Machine) *MachineAgent {
 	logsCh, err := logsender.InstallBufferedLogWriter(1024)
 	c.Assert(err, jc.ErrorIsNil)
 	machineAgentFactory := MachineAgentFactoryFn(
-		&agentConf, logsCh, &mockLoopDeviceManager{},
+		&agentConf, logsCh, &mockLoopDeviceManager{}, c.MkDir(),
 	)
-	return machineAgentFactory(m.Id(), c.MkDir())
+	return machineAgentFactory(m.Id())
 }
 
 func (s *MachineSuite) TestParseSuccess(c *gc.C) {
@@ -241,7 +241,7 @@ func (s *MachineSuite) TestParseSuccess(c *gc.C) {
 		agentConf := agentConf{dataDir: s.DataDir()}
 		a := NewMachineAgentCmd(
 			nil,
-			MachineAgentFactoryFn(&agentConf, nil, &mockLoopDeviceManager{}),
+			MachineAgentFactoryFn(&agentConf, nil, &mockLoopDeviceManager{}, c.MkDir()),
 			&agentConf,
 			&agentConf,
 		)
@@ -314,7 +314,7 @@ func (s *MachineSuite) TestUseLumberjack(c *gc.C) {
 
 	a := NewMachineAgentCmd(
 		ctx,
-		MachineAgentFactoryFn(agentConf, nil, &mockLoopDeviceManager{}),
+		MachineAgentFactoryFn(agentConf, nil, &mockLoopDeviceManager{}, c.MkDir()),
 		agentConf,
 		agentConf,
 	)
@@ -338,7 +338,7 @@ func (s *MachineSuite) TestDontUseLumberjack(c *gc.C) {
 
 	a := NewMachineAgentCmd(
 		ctx,
-		MachineAgentFactoryFn(agentConf, nil, &mockLoopDeviceManager{}),
+		MachineAgentFactoryFn(agentConf, nil, &mockLoopDeviceManager{}, c.MkDir()),
 		agentConf,
 		agentConf,
 	)

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/juju/names"
 	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils"
 	"github.com/juju/utils/arch"
 	"github.com/juju/utils/clock"
 	"github.com/juju/utils/proxy"
@@ -1313,7 +1314,7 @@ func (s *MachineSuite) TestMachineAgentSymlinks(c *gc.C) {
 
 	// Symlinks should have been created
 	for _, link := range []string{jujuRun, jujuDumpLogs} {
-		_, err := os.Stat(filepath.Join(a.rootDir, link))
+		_, err := os.Stat(utils.EnsureBaseDir(a.rootDir, link))
 		c.Assert(err, jc.ErrorIsNil, gc.Commentf(link))
 	}
 
@@ -1335,7 +1336,7 @@ func (s *MachineSuite) TestMachineAgentSymlinkJujuRunExists(c *gc.C) {
 	links := []string{jujuRun, jujuDumpLogs}
 	a.rootDir = c.MkDir()
 	for _, link := range links {
-		fullLink := filepath.Join(a.rootDir, link)
+		fullLink := utils.EnsureBaseDir(a.rootDir, link)
 		c.Assert(os.MkdirAll(filepath.Dir(fullLink), os.FileMode(0755)), jc.ErrorIsNil)
 		c.Assert(symlink.New("/nowhere/special", fullLink), jc.ErrorIsNil, gc.Commentf(link))
 	}
@@ -1345,7 +1346,7 @@ func (s *MachineSuite) TestMachineAgentSymlinkJujuRunExists(c *gc.C) {
 
 	// juju-run symlink should have been recreated.
 	for _, link := range links {
-		fullLink := filepath.Join(a.rootDir, link)
+		fullLink := utils.EnsureBaseDir(a.rootDir, link)
 		linkTarget, err := symlink.Read(fullLink)
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(linkTarget, gc.Not(gc.Equals), "/nowhere/special", gc.Commentf(link))
@@ -1420,7 +1421,7 @@ func (s *MachineSuite) TestMachineAgentUninstall(c *gc.C) {
 	// juju-run and juju-dumplogs symlinks should have been removed on
 	// termination.
 	for _, link := range []string{jujuRun, jujuDumpLogs} {
-		_, err = os.Stat(filepath.Join(a.rootDir, link))
+		_, err = os.Stat(utils.EnsureBaseDir(a.rootDir, link))
 		c.Assert(err, jc.Satisfies, os.IsNotExist)
 	}
 

--- a/cmd/jujud/main.go
+++ b/cmd/jujud/main.go
@@ -148,7 +148,7 @@ func jujuDMain(args []string, ctx *cmd.Context) (code int, err error) {
 	// AgentConf should be split up to follow suit.
 	agentConf := agentcmd.NewAgentConf("")
 	machineAgentFactory := agentcmd.MachineAgentFactoryFn(
-		agentConf, logCh, looputil.NewLoopDeviceManager(),
+		agentConf, logCh, looputil.NewLoopDeviceManager(), "",
 	)
 	jujud.Register(agentcmd.NewMachineAgentCmd(ctx, machineAgentFactory, agentConf, agentConf))
 

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -30,7 +30,7 @@ github.com/juju/schema	git	afe1151cb49d1d7ed3c75592dfc6f38703f2e988	2015-08-07T0
 github.com/juju/syslog	git	6be94e8b718766e9ff7a37342157fe4795da7cfa	2015-02-05T15:59:36Z
 github.com/juju/testing	git	ad6f815f49f8209a27a3b7efb6d44876493e5939	2015-10-12T16:09:06Z
 github.com/juju/txn	git	99ec629d0066a4d73c54d8e021a7fc1dc07df614	2015-06-09T16:58:27Z
-github.com/juju/utils	git	f2db28cef935aba0a7207254fa5dba273e649d0e	2015-11-09T11:51:43Z
+github.com/juju/utils	git	c4785612a740e1577f489a519c047b00fd42fc37	2015-11-11T05:38:00Z
 github.com/juju/xml	git	eb759a627588d35166bc505fceb51b88500e291e	2015-04-13T13:11:21Z
 github.com/julienschmidt/httprouter	git	109e267447e95ad1bb48b758e40dd7453eb7b039	2015-09-05T17:25:33Z
 golang.org/x/crypto	git	c57d4a71915a248dbad846d60825145062b4c18e	2015-03-27T05:11:19Z

--- a/featuretests/dblog_test.go
+++ b/featuretests/dblog_test.go
@@ -86,8 +86,8 @@ func (s *dblogSuite) runMachineAgentTest(c *gc.C) bool {
 	agentConf.ReadConfig(m.Tag().String())
 	logsCh, err := logsender.InstallBufferedLogWriter(1000)
 	c.Assert(err, jc.ErrorIsNil)
-	machineAgentFactory := agentcmd.MachineAgentFactoryFn(agentConf, logsCh, nil)
-	a := machineAgentFactory(m.Id(), c.MkDir())
+	machineAgentFactory := agentcmd.MachineAgentFactoryFn(agentConf, logsCh, nil, c.MkDir())
+	a := machineAgentFactory(m.Id())
 
 	// Ensure there's no logs to begin with.
 	c.Assert(s.getLogCount(c, m.Tag()), gc.Equals, 0)


### PR DESCRIPTION
cmd/jujud/agent: remove the use of Context.Dir as the root directory

The command context's Dir field is typically the current working directory which happens to be "/" for agents on Unix but is something quite different under Windows. Don't use the context Dir and set is explictly instead.

---

cmd/jujud/agent: construct symlinks in a Windows-safe way

Using utils.EnsureBaseDir means that the full symlinks are still valid even when both the root directory and the symlink contain Windows drive letters.

This fixes LP #1515066.


(Review request: http://reviews.vapour.ws/r/3114/)