### PR TITLE
System Kill Async

### DIFF
--- a/api/systemmanager/systemmanager.go
+++ b/api/systemmanager/systemmanager.go
@@ -66,10 +66,9 @@ func (c *Client) EnvironmentConfig() (map[string]interface{}, error) {
 // and removes all non-manager machine instances. Underlying DestroyEnvironment
 // calls will fail if there are any manually-provisioned non-manager machines
 // in state.
-func (c *Client) DestroySystem(destroyEnvs bool, ignoreBlocks bool) error {
+func (c *Client) DestroySystem(destroyEnvs bool) error {
 	args := params.DestroySystemArgs{
 		DestroyEnvironments: destroyEnvs,
-		IgnoreBlocks:        ignoreBlocks,
 	}
 	return c.facade.FacadeCall("DestroySystem", args, nil)
 }

--- a/api/systemmanager/systemmanager_test.go
+++ b/api/systemmanager/systemmanager_test.go
@@ -78,7 +78,7 @@ func (s *systemManagerSuite) TestDestroySystem(c *gc.C) {
 	s.Factory.MakeEnvironment(c, &factory.EnvParams{Name: "foo"}).Close()
 
 	sysManager := s.OpenAPI(c)
-	err := sysManager.DestroySystem(false, false)
+	err := sysManager.DestroySystem(false)
 	c.Assert(err, gc.ErrorMatches, "state server environment cannot be destroyed before all other environments are destroyed")
 }
 

--- a/apiserver/client/client_test.go
+++ b/apiserver/client/client_test.go
@@ -3501,7 +3501,7 @@ func (s *clientSuite) assertForceDestroyMachines(c *gc.C) {
 	m0, m1, m2, u := s.setupDestroyMachinesTest(c)
 
 	err := s.APIState.Client().ForceDestroyMachines("0", "1", "2")
-	c.Assert(err, gc.ErrorMatches, `some machines were not destroyed: machine 0 is required by the environment`)
+	c.Assert(err, gc.ErrorMatches, `some machines were not destroyed: machine is required by the environment`)
 	assertLife(c, m0, state.Alive)
 	assertLife(c, m1, state.Alive)
 	assertLife(c, m2, state.Alive)

--- a/apiserver/common/environdestroy.go
+++ b/apiserver/common/environdestroy.go
@@ -16,10 +16,25 @@ var sendMetrics = func(st *state.State) error {
 	return errors.Trace(err)
 }
 
-// DestroyEnvironment destroys all services and non-manager machine
-// instances in the specified environment. This function assumes that all
-// necessary authentication checks have been done.
+// DestroyEnvironment sets the environment to dying. Cleanup jobs then destroy
+// all services and non-manager, non-manual machine instances in the specified
+// environment. This function assumes that all necessary authentication checks
+// have been done. If the environment is a controller hosting other
+// environments, they will also be destroyed.
+func DestroyEnvironmentIncludingHosted(st *state.State, environTag names.EnvironTag) error {
+	return destroyEnvironment(st, environTag, true)
+}
+
+// DestroyEnvironment sets the environment to dying. Cleanup jobs then destroy
+// all services and non-manager, non-manual machine instances in the specified
+// environment. This function assumes that all necessary authentication checks
+// have been done. An error will be returned if this environment is a
+// controller hosting other environments.
 func DestroyEnvironment(st *state.State, environTag names.EnvironTag) error {
+	return destroyEnvironment(st, environTag, false)
+}
+
+func destroyEnvironment(st *state.State, environTag names.EnvironTag, destroyHostedEnvirons bool) error {
 	var err error
 	if environTag != st.EnvironTag() {
 		if st, err = st.ForEnviron(environTag); err != nil {
@@ -28,9 +43,27 @@ func DestroyEnvironment(st *state.State, environTag names.EnvironTag) error {
 		defer st.Close()
 	}
 
-	check := NewBlockChecker(st)
-	if err = check.DestroyAllowed(); err != nil {
-		return errors.Trace(err)
+	if destroyHostedEnvirons {
+		envs, err := st.AllEnvironments()
+		if err != nil {
+			return errors.Trace(err)
+		}
+		for _, env := range envs {
+			envSt, err := st.ForEnviron(env.EnvironTag())
+			defer envSt.Close()
+			if err != nil {
+				return errors.Trace(err)
+			}
+			check := NewBlockChecker(envSt)
+			if err = check.DestroyAllowed(); err != nil {
+				return errors.Trace(err)
+			}
+		}
+	} else {
+		check := NewBlockChecker(st)
+		if err = check.DestroyAllowed(); err != nil {
+			return errors.Trace(err)
+		}
 	}
 
 	env, err := st.Environment()
@@ -38,33 +71,19 @@ func DestroyEnvironment(st *state.State, environTag names.EnvironTag) error {
 		return errors.Trace(err)
 	}
 
-	if err = env.Destroy(); err != nil {
-		return errors.Trace(err)
-	}
-
-	machines, err := st.AllMachines()
-	if err != nil {
-		return errors.Trace(err)
+	if destroyHostedEnvirons {
+		if err := env.DestroyIncludingHosted(); err != nil {
+			return err
+		}
+	} else {
+		if err = env.Destroy(); err != nil {
+			return errors.Trace(err)
+		}
 	}
 
 	err = sendMetrics(st)
 	if err != nil {
 		logger.Warningf("failed to send leftover metrics: %v", err)
-	}
-
-	// We must destroy instances server-side to support JES (Juju Environment
-	// Server), as there's no CLI to fall back on. In that case, we only ever
-	// destroy non-state machines; we leave destroying state servers in non-
-	// hosted environments to the CLI, as otherwise the API server may get cut
-	// off.
-	if err := destroyNonManagerMachines(st, machines); err != nil {
-		return errors.Trace(err)
-	}
-
-	// If this is not the state server environment, remove all documents from
-	// state associated with the environment.
-	if env.EnvironTag() != env.ControllerTag() {
-		return errors.Trace(st.RemoveAllEnvironDocs())
 	}
 
 	// Return to the caller. If it's the CLI, it will finish up by calling the
@@ -73,47 +92,4 @@ func DestroyEnvironment(st *state.State, environTag names.EnvironTag) error {
 	// resources are torn down, the Undertaker worker handles the removal of
 	// the environment.
 	return nil
-}
-
-// destroyNonManagerMachines directly destroys all non-manager, non-manual
-// machine instances.
-func destroyNonManagerMachines(st *state.State, machines []*state.Machine) error {
-	var ids []string
-	for _, m := range machines {
-		if m.IsManager() {
-			continue
-		}
-		if _, isContainer := m.ParentId(); isContainer {
-			continue
-		}
-		manual, err := m.IsManual()
-		if err != nil {
-			return err
-		} else if manual {
-			continue
-		}
-		ids = append(ids, m.Id())
-	}
-	if len(ids) == 0 {
-		return nil
-	}
-
-	return DestroyMachines(st, true, ids...)
-}
-
-func destroyAllServices(st *state.State) error {
-	var errs []string
-	services, err := st.AllServices()
-	if err != nil {
-		return errors.Trace(err)
-	}
-	var ids []string
-	for _, service := range services {
-		ids = append(ids, service.Name())
-		if err := service.Destroy(); err != nil {
-			errs = append(errs, err.Error())
-		}
-	}
-
-	return DestroyErr("service", ids, errs)
 }

--- a/apiserver/common/environdestroy_test.go
+++ b/apiserver/common/environdestroy_test.go
@@ -12,13 +12,13 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/api"
 	"github.com/juju/juju/apiserver/client"
 	"github.com/juju/juju/apiserver/common"
 	commontesting "github.com/juju/juju/apiserver/common/testing"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/juju/testing"
-	"github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/state"
 	jujutesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/testing/factory"
@@ -27,7 +27,6 @@ import (
 type destroyEnvironmentSuite struct {
 	testing.JujuConnSuite
 	commontesting.BlockHelper
-	metricSender *testMetricSender
 }
 
 var _ = gc.Suite(&destroyEnvironmentSuite{})
@@ -36,9 +35,6 @@ func (s *destroyEnvironmentSuite) SetUpTest(c *gc.C) {
 	s.JujuConnSuite.SetUpTest(c)
 	s.BlockHelper = commontesting.NewBlockHelper(s.APIState)
 	s.AddCleanup(func(*gc.C) { s.BlockHelper.Close() })
-
-	s.metricSender = &testMetricSender{}
-	s.PatchValue(common.SendMetrics, s.metricSender.SendMetrics)
 }
 
 // setUpManual adds "manually provisioned" machines to state:
@@ -82,6 +78,25 @@ func (s *destroyEnvironmentSuite) setUpInstances(c *gc.C) (m0, m1, m2 *state.Mac
 	return m0, m1, m2
 }
 
+type testMetricSender struct {
+	jtesting.Stub
+}
+
+func (t *testMetricSender) SendMetrics(st *state.State) error {
+	t.AddCall("SendMetrics")
+	return nil
+}
+
+func (s *destroyEnvironmentSuite) TestMetrics(c *gc.C) {
+	metricSender := &testMetricSender{}
+	s.PatchValue(common.SendMetrics, metricSender.SendMetrics)
+
+	err := common.DestroyEnvironment(s.State, s.State.EnvironTag())
+	c.Assert(err, jc.ErrorIsNil)
+
+	metricSender.CheckCalls(c, []jtesting.StubCall{{FuncName: "SendMetrics"}})
+}
+
 func (s *destroyEnvironmentSuite) TestDestroyEnvironmentManual(c *gc.C) {
 	_, nonManager := s.setUpManual(c)
 
@@ -105,7 +120,6 @@ func (s *destroyEnvironmentSuite) TestDestroyEnvironmentManual(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(env.Life(), gc.Equals, state.Dying)
 
-	s.metricSender.CheckCalls(c, []jtesting.StubCall{{FuncName: "SendMetrics"}})
 }
 
 func (s *destroyEnvironmentSuite) TestDestroyEnvironment(c *gc.C) {
@@ -125,16 +139,10 @@ func (s *destroyEnvironmentSuite) TestDestroyEnvironment(c *gc.C) {
 	err = common.DestroyEnvironment(s.State, s.State.EnvironTag())
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.metricSender.CheckCalls(c, []jtesting.StubCall{{FuncName: "SendMetrics"}})
+	runAllCleanups(c, s.State)
 
-	needsCleanup, err := s.State.NeedsCleanup()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(needsCleanup, jc.IsTrue)
-	err = s.State.Cleanup()
-	c.Assert(err, jc.ErrorIsNil)
-
-	// After DestroyEnvironment returns, we should have:
-	//   - all non-manager machines dead
+	// After DestroyEnvironment returns and all cleanup jobs have run, we should have:
+	//   - all non-manager machines dying
 	assertLife(c, manager, state.Alive)
 	// Note: we leave the machine in a dead state and rely on the provisioner
 	// to stop the backing instances, remove the dead machines and finally
@@ -163,34 +171,27 @@ func assertLife(c *gc.C, entity state.Living, life state.Life) {
 	c.Assert(entity.Life(), gc.Equals, life)
 }
 
-func (s *destroyEnvironmentSuite) TestDestroyEnvironmentWithContainers(c *gc.C) {
-	// TODO(waigani) fix this test before landing into master.
-	c.Skip("DestroyEnvironment now queues hosted machines for removal.")
-	ops := make(chan dummy.Operation, 500)
-	dummy.Listen(ops)
-
-	_, nonManager, _ := s.setUpInstances(c)
-	nonManagerId, _ := nonManager.InstanceId()
-
-	err := common.DestroyEnvironment(s.State, s.State.EnvironTag())
-	c.Assert(err, jc.ErrorIsNil)
-	for op := range ops {
-		if op, ok := op.(dummy.OpStopInstances); ok {
-			c.Assert(op.Ids, jc.SameContents, []instance.Id{nonManagerId})
-			break
-		}
-	}
-
-	s.metricSender.CheckCalls(c, []jtesting.StubCall{{FuncName: "SendMetrics"}})
-}
-
 func (s *destroyEnvironmentSuite) TestBlockDestroyDestroyEnvironment(c *gc.C) {
 	// Setup environment
 	s.setUpInstances(c)
 	s.BlockDestroyEnvironment(c, "TestBlockDestroyDestroyEnvironment")
 	err := common.DestroyEnvironment(s.State, s.State.EnvironTag())
 	s.AssertBlocked(c, err, "TestBlockDestroyDestroyEnvironment")
-	s.metricSender.CheckCalls(c, []jtesting.StubCall{})
+}
+
+func (s *destroyEnvironmentSuite) TestBlockDestroyDestroyHostedEnvironment(c *gc.C) {
+	otherSt := s.Factory.MakeEnvironment(c, nil)
+	defer otherSt.Close()
+	info := s.APIInfo(c)
+	info.EnvironTag = otherSt.EnvironTag()
+	apiState, err := api.Open(info, api.DefaultDialOpts())
+
+	block := commontesting.NewBlockHelper(apiState)
+	defer block.Close()
+
+	block.BlockDestroyEnvironment(c, "TestBlockDestroyDestroyEnvironment")
+	err = common.DestroyEnvironmentIncludingHosted(s.State, s.State.EnvironTag())
+	s.AssertBlocked(c, err, "TestBlockDestroyDestroyEnvironment")
 }
 
 func (s *destroyEnvironmentSuite) TestBlockRemoveDestroyEnvironment(c *gc.C) {
@@ -199,7 +200,6 @@ func (s *destroyEnvironmentSuite) TestBlockRemoveDestroyEnvironment(c *gc.C) {
 	s.BlockRemoveObject(c, "TestBlockRemoveDestroyEnvironment")
 	err := common.DestroyEnvironment(s.State, s.State.EnvironTag())
 	s.AssertBlocked(c, err, "TestBlockRemoveDestroyEnvironment")
-	s.metricSender.CheckCalls(c, []jtesting.StubCall{})
 }
 
 func (s *destroyEnvironmentSuite) TestBlockChangesDestroyEnvironment(c *gc.C) {
@@ -209,7 +209,6 @@ func (s *destroyEnvironmentSuite) TestBlockChangesDestroyEnvironment(c *gc.C) {
 	s.BlockAllChanges(c, "TestBlockChangesDestroyEnvironment")
 	err := common.DestroyEnvironment(s.State, s.State.EnvironTag())
 	s.AssertBlocked(c, err, "TestBlockChangesDestroyEnvironment")
-	s.metricSender.CheckCalls(c, []jtesting.StubCall{})
 }
 
 type destroyTwoEnvironmentsSuite struct {
@@ -217,7 +216,6 @@ type destroyTwoEnvironmentsSuite struct {
 	otherState     *state.State
 	otherEnvOwner  names.UserTag
 	otherEnvClient *client.Client
-	metricSender   *testMetricSender
 }
 
 var _ = gc.Suite(&destroyTwoEnvironmentsSuite{})
@@ -244,33 +242,56 @@ func (s *destroyTwoEnvironmentsSuite) SetUpTest(c *gc.C) {
 	s.otherEnvClient, err = client.NewClient(s.otherState, common.NewResources(), auth)
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.metricSender = &testMetricSender{}
-	s.PatchValue(common.SendMetrics, s.metricSender.SendMetrics)
 }
 
-func (s *destroyTwoEnvironmentsSuite) TestCleanupEnvironDocs(c *gc.C) {
-	// TODO(waigani) fix this test before landing into master.
-	c.Skip("DestroyEnvironment now queues machines to be destroyed. Environ docs are not removed until all machines and services have been torn down.")
+func (s *destroyTwoEnvironmentsSuite) TestCleanupEnvironResources(c *gc.C) {
 	otherFactory := factory.NewFactory(s.otherState)
-	otherFactory.MakeMachine(c, nil)
 	m := otherFactory.MakeMachine(c, nil)
 	otherFactory.MakeMachineNested(c, m.Id(), nil)
 
 	err := common.DestroyEnvironment(s.otherState, s.otherState.EnvironTag())
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = s.otherState.Environment()
-	c.Assert(errors.IsNotFound(err), jc.IsTrue)
+	// Assert that the machines are not removed until the cleanup runs.
+	c.Assert(m.Refresh(), jc.ErrorIsNil)
+	assertMachineCount(c, s.otherState, 2)
+	runAllCleanups(c, s.otherState)
+	assertAllMachinesDeadAndRemove(c, s.otherState)
 
-	_, err = s.State.Environment()
+	otherEnv, err := s.otherState.Environment()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(s.otherState.EnsureEnvironmentRemoved(), jc.ErrorIsNil)
-	s.metricSender.CheckCalls(c, []jtesting.StubCall{{FuncName: "SendMetrics"}})
+	c.Assert(otherEnv.Life(), gc.Equals, state.Dying)
+
+	c.Assert(s.otherState.ProcessDyingEnviron(), jc.ErrorIsNil)
+	c.Assert(otherEnv.Refresh(), jc.ErrorIsNil)
+	c.Assert(otherEnv.Life(), gc.Equals, state.Dead)
+
+}
+
+// The provisioner will remove dead machines once their backing instances are
+// stopped. For the tests, we remove them directly.
+func assertAllMachinesDeadAndRemove(c *gc.C, st *state.State) {
+	machines, err := st.AllMachines()
+	c.Assert(err, jc.ErrorIsNil)
+	for _, m := range machines {
+		if m.IsManager() {
+			continue
+		}
+		if _, isContainer := m.ParentId(); isContainer {
+			continue
+		}
+		manual, err := m.IsManual()
+		c.Assert(err, jc.ErrorIsNil)
+		if manual {
+			continue
+		}
+
+		c.Assert(m.Life(), gc.Equals, state.Dead)
+		c.Assert(m.Remove(), jc.ErrorIsNil)
+	}
 }
 
 func (s *destroyTwoEnvironmentsSuite) TestDifferentStateEnv(c *gc.C) {
-	// TODO(waigani) fix this test before landing into master.
-	c.Skip("DestroyEnvironment now queues machines to be destroyed. Environ docs are not removed until all machines and services have been torn down.")
 	otherFactory := factory.NewFactory(s.otherState)
 	otherFactory.MakeMachine(c, nil)
 	m := otherFactory.MakeMachine(c, nil)
@@ -281,30 +302,76 @@ func (s *destroyTwoEnvironmentsSuite) TestDifferentStateEnv(c *gc.C) {
 	err := common.DestroyEnvironment(s.State, s.otherState.EnvironTag())
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = s.otherState.Environment()
-	c.Assert(errors.IsNotFound(err), jc.IsTrue)
+	runAllCleanups(c, s.otherState)
+	assertAllMachinesDeadAndRemove(c, s.otherState)
 
-	_, err = s.State.Environment()
+	otherEnv, err := s.otherState.Environment()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(s.otherState.EnsureEnvironmentRemoved(), jc.ErrorIsNil)
-	s.metricSender.CheckCalls(c, []jtesting.StubCall{{FuncName: "SendMetrics"}})
+	c.Assert(s.otherState.ProcessDyingEnviron(), jc.ErrorIsNil)
+	c.Assert(otherEnv.Refresh(), jc.ErrorIsNil)
+	c.Assert(otherEnv.Life(), gc.Equals, state.Dead)
+
+	env, err := s.State.Environment()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(env.Life(), gc.Equals, state.Alive)
 }
 
 func (s *destroyTwoEnvironmentsSuite) TestDestroyStateServerAfterNonStateServerIsDestroyed(c *gc.C) {
-	// TODO(waigani) fix this test before landing into master.
-	c.Skip("DestroyEnvironment is now async. A followup branch will get these passing again before landing into master.")
+	otherFactory := factory.NewFactory(s.otherState)
+	otherFactory.MakeMachine(c, nil)
+	m := otherFactory.MakeMachine(c, nil)
+	otherFactory.MakeMachineNested(c, m.Id(), nil)
+
 	err := common.DestroyEnvironment(s.State, s.State.EnvironTag())
 	c.Assert(err, gc.ErrorMatches, "failed to destroy environment: hosting 1 other environments")
+
+	needsCleanup, err := s.State.NeedsCleanup()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(needsCleanup, jc.IsFalse)
+
 	err = common.DestroyEnvironment(s.State, s.otherState.EnvironTag())
 	c.Assert(err, jc.ErrorIsNil)
+
 	err = common.DestroyEnvironment(s.State, s.State.EnvironTag())
 	c.Assert(err, jc.ErrorIsNil)
-	s.metricSender.CheckCalls(c, []jtesting.StubCall{{FuncName: "SendMetrics"}, {FuncName: "SendMetrics"}})
+
+	// Make sure we can continue to take the hosted environ down while the
+	// controller environ is dying.
+	runAllCleanups(c, s.otherState)
+	assertAllMachinesDeadAndRemove(c, s.otherState)
+	c.Assert(s.otherState.ProcessDyingEnviron(), jc.ErrorIsNil)
+
+	otherEnv, err := s.otherState.Environment()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(otherEnv.Life(), gc.Equals, state.Dead)
+
+	env, err := s.State.Environment()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(env.Life(), gc.Equals, state.Dying)
+	c.Assert(s.State.ProcessDyingEnviron(), jc.ErrorIsNil)
+	c.Assert(env.Refresh(), jc.ErrorIsNil)
+	c.Assert(env.Life(), gc.Equals, state.Dead)
+}
+
+func (s *destroyTwoEnvironmentsSuite) TestDestroyStateServerAndNonStateServer(c *gc.C) {
+	otherFactory := factory.NewFactory(s.otherState)
+	otherFactory.MakeMachine(c, nil)
+	m := otherFactory.MakeMachine(c, nil)
+	otherFactory.MakeMachineNested(c, m.Id(), nil)
+
+	err := common.DestroyEnvironmentIncludingHosted(s.State, s.State.EnvironTag())
+	c.Assert(err, jc.ErrorIsNil)
+
+	runAllCleanups(c, s.State)
+	runAllCleanups(c, s.otherState)
+	assertAllMachinesDeadAndRemove(c, s.otherState)
+
+	// Make sure we can continue to take the hosted environ down while the
+	// controller environ is dying.
+	c.Assert(s.otherState.ProcessDyingEnviron(), jc.ErrorIsNil)
 }
 
 func (s *destroyTwoEnvironmentsSuite) TestCanDestroyNonBlockedEnv(c *gc.C) {
-	// TODO(waigani) fix this test before landing into master.
-	c.Skip("DestroyEnvironment is now async. A followup branch will get these passing again before landing into master.")
 	bh := commontesting.NewBlockHelper(s.APIState)
 	defer bh.Close()
 
@@ -315,15 +382,22 @@ func (s *destroyTwoEnvironmentsSuite) TestCanDestroyNonBlockedEnv(c *gc.C) {
 
 	err = common.DestroyEnvironment(s.State, s.State.EnvironTag())
 	bh.AssertBlocked(c, err, "TestBlockDestroyDestroyEnvironment")
-
-	s.metricSender.CheckCalls(c, []jtesting.StubCall{{FuncName: "SendMetrics"}})
 }
 
-type testMetricSender struct {
-	jtesting.Stub
+func runAllCleanups(c *gc.C, st *state.State) {
+	needCleanup, err := st.NeedsCleanup()
+	c.Assert(err, jc.ErrorIsNil)
+
+	for needCleanup {
+		err := st.Cleanup()
+		c.Assert(err, jc.ErrorIsNil)
+		needCleanup, err = st.NeedsCleanup()
+		c.Assert(err, jc.ErrorIsNil)
+	}
 }
 
-func (t *testMetricSender) SendMetrics(st *state.State) error {
-	t.AddCall("SendMetrics")
-	return nil
+func assertMachineCount(c *gc.C, st *state.State, count int) {
+	otherMachines, err := st.AllMachines()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(otherMachines, gc.HasLen, count)
 }

--- a/apiserver/params/systemmanager.go
+++ b/apiserver/params/systemmanager.go
@@ -9,10 +9,6 @@ type DestroySystemArgs struct {
 	// should be destroyed as well. If this is not specified, and there are
 	// other hosted environments, the destruction of the system will fail.
 	DestroyEnvironments bool `json:"destroy-environments"`
-
-	// IgnoreBlocks specifies whether or not to ignore blocks
-	// on hosted environments.
-	IgnoreBlocks bool `json:"ignore-blocks"`
 }
 
 // EnvironmentBlockInfo holds information about an environment and its

--- a/apiserver/systemmanager/destroy.go
+++ b/apiserver/systemmanager/destroy.go
@@ -1,0 +1,54 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package systemmanager
+
+import (
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/state"
+)
+
+// DestroySystem will attempt to destroy the system. If the args specify the
+// removal of blocks or the destruction of the environments, this method will
+// attempt to do so.
+func (s *SystemManagerAPI) DestroySystem(args params.DestroySystemArgs) error {
+	systemEnv, err := s.state.StateServerEnvironment()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	systemTag := systemEnv.EnvironTag()
+
+	if err = s.ensureNotBlocked(args); err != nil {
+		return errors.Trace(err)
+	}
+
+	// If we are destroying environments, we need to tolerate living
+	// environments but set the system to dying to prevent new environments
+	// sneaking in. If we are not destroying hosted environments, this will
+	// fail if any hosted environments are found.
+	if args.DestroyEnvironments {
+		return errors.Trace(common.DestroyEnvironmentIncludingHosted(s.state, systemTag))
+	}
+	if err = common.DestroyEnvironment(s.state, systemTag); state.IsHasHostedEnvironsError(err) {
+		err = errors.New("state server environment cannot be destroyed before all other environments are destroyed")
+	}
+	return errors.Trace(err)
+}
+
+func (s *SystemManagerAPI) ensureNotBlocked(args params.DestroySystemArgs) error {
+	// If there are blocks, and we aren't being told to ignore them, let the
+	// user know.
+	blocks, err := s.state.AllBlocksForSystem()
+	if err != nil {
+		logger.Debugf("Unable to get blocks for system: %s", err)
+		return errors.Trace(err)
+	}
+
+	if len(blocks) > 0 {
+		return common.OperationBlockedError("found blocks in system environments")
+	}
+	return nil
+}

--- a/apiserver/systemmanager/destroy_test.go
+++ b/apiserver/systemmanager/destroy_test.go
@@ -4,7 +4,6 @@
 package systemmanager_test
 
 import (
-	"github.com/juju/errors"
 	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -68,9 +67,7 @@ func (s *destroySystemSuite) SetUpTest(c *gc.C) {
 	s.otherEnvUUID = s.otherState.EnvironUUID()
 }
 
-func (s *destroySystemSuite) TestDestroySystemKillsHostedEnvsWithBlocks(c *gc.C) {
-	// TODO(waigani) fix this test before landing into master.
-	c.Skip("environment is now removed asynchronously. DestroySystem will need to wait.")
+func (s *destroySystemSuite) TestDestroySystemKillErrsOnHostedEnvsWithBlocks(c *gc.C) {
 	s.BlockDestroyEnvironment(c, "TestBlockDestroyEnvironment")
 	s.BlockRemoveObject(c, "TestBlockRemoveObject")
 	s.otherState.SwitchBlockOn(state.DestroyBlock, "TestBlockDestroyEnvironment")
@@ -78,16 +75,12 @@ func (s *destroySystemSuite) TestDestroySystemKillsHostedEnvsWithBlocks(c *gc.C)
 
 	err := s.systemManager.DestroySystem(params.DestroySystemArgs{
 		DestroyEnvironments: true,
-		IgnoreBlocks:        true,
 	})
-	c.Assert(err, jc.ErrorIsNil)
-
-	_, err = s.otherState.Environment()
-	c.Assert(errors.IsNotFound(err), jc.IsTrue)
+	c.Assert(err, gc.ErrorMatches, "found blocks in system environments")
 
 	env, err := s.State.Environment()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(env.Life(), gc.Equals, state.Dying)
+	c.Assert(env.Life(), gc.Equals, state.Alive)
 }
 
 func (s *destroySystemSuite) TestDestroySystemReturnsBlockedEnvironmentsErr(c *gc.C) {
@@ -110,15 +103,10 @@ func (s *destroySystemSuite) TestDestroySystemReturnsBlockedEnvironmentsErr(c *g
 }
 
 func (s *destroySystemSuite) TestDestroySystemKillsHostedEnvs(c *gc.C) {
-	// TODO(waigani) fix this test before landing into master.
-	c.Skip("environment is now removed asynchronously. DestroySystem will need to wait.")
 	err := s.systemManager.DestroySystem(params.DestroySystemArgs{
 		DestroyEnvironments: true,
 	})
 	c.Assert(err, jc.ErrorIsNil)
-
-	_, err = s.otherState.Environment()
-	c.Assert(errors.IsNotFound(err), jc.IsTrue)
 
 	env, err := s.State.Environment()
 	c.Assert(err, jc.ErrorIsNil)
@@ -131,10 +119,8 @@ func (s *destroySystemSuite) TestDestroySystemLeavesBlocksIfNotKillAll(c *gc.C) 
 	s.otherState.SwitchBlockOn(state.DestroyBlock, "TestBlockDestroyEnvironment")
 	s.otherState.SwitchBlockOn(state.ChangeBlock, "TestChangeBlock")
 
-	err := s.systemManager.DestroySystem(params.DestroySystemArgs{
-		IgnoreBlocks: true,
-	})
-	c.Assert(err, gc.ErrorMatches, "state server environment cannot be destroyed before all other environments are destroyed")
+	err := s.systemManager.DestroySystem(params.DestroySystemArgs{})
+	c.Assert(err, gc.ErrorMatches, "found blocks in system environments")
 
 	numBlocks, err := s.State.AllBlocksForSystem()
 	c.Assert(err, jc.ErrorIsNil)
@@ -142,8 +128,6 @@ func (s *destroySystemSuite) TestDestroySystemLeavesBlocksIfNotKillAll(c *gc.C) 
 }
 
 func (s *destroySystemSuite) TestDestroySystemNoHostedEnvs(c *gc.C) {
-	// TODO(waigani) fix this test before landing into master.
-	c.Skip("environment is now removed asynchronously. DestroySystem will need to wait.")
 	err := common.DestroyEnvironment(s.State, s.otherState.EnvironTag())
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -155,28 +139,21 @@ func (s *destroySystemSuite) TestDestroySystemNoHostedEnvs(c *gc.C) {
 	c.Assert(env.Life(), gc.Equals, state.Dying)
 }
 
-func (s *destroySystemSuite) TestDestroySystemNoHostedEnvsWithBlock(c *gc.C) {
-	// TODO(waigani) fix this test before landing into master.
-	c.Skip("environment is now removed asynchronously. DestroySystem will need to wait.")
+func (s *destroySystemSuite) TestDestroySystemErrsOnNoHostedEnvsWithBlock(c *gc.C) {
 	err := common.DestroyEnvironment(s.State, s.otherState.EnvironTag())
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.BlockDestroyEnvironment(c, "TestBlockDestroyEnvironment")
 	s.BlockRemoveObject(c, "TestBlockRemoveObject")
 
-	err = s.systemManager.DestroySystem(params.DestroySystemArgs{
-		IgnoreBlocks: true,
-	})
-	c.Assert(err, jc.ErrorIsNil)
-
+	err = s.systemManager.DestroySystem(params.DestroySystemArgs{})
+	c.Assert(err, gc.ErrorMatches, "found blocks in system environments")
 	env, err := s.State.Environment()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(env.Life(), gc.Equals, state.Dying)
+	c.Assert(env.Life(), gc.Equals, state.Alive)
 }
 
 func (s *destroySystemSuite) TestDestroySystemNoHostedEnvsWithBlockFail(c *gc.C) {
-	// TODO(waigani) fix this test before landing into master.
-	c.Skip("environment is now removed asynchronously. DestroySystem will need to wait.")
 	err := common.DestroyEnvironment(s.State, s.otherState.EnvironTag())
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/apiserver/systemmanager/systemmanager.go
+++ b/apiserver/systemmanager/systemmanager.go
@@ -176,62 +176,6 @@ func (s *SystemManagerAPI) ListBlockedEnvironments() (params.EnvironmentBlockInf
 	return results, nil
 }
 
-// DestroySystem will attempt to destroy the system. If the args specify the
-// removal of blocks or the destruction of the environments, this method will
-// attempt to do so.
-func (s *SystemManagerAPI) DestroySystem(args params.DestroySystemArgs) error {
-	// Get list of all environments in the system.
-	allEnvs, err := s.state.AllEnvironments()
-	if err != nil {
-		return errors.Trace(err)
-	}
-
-	// If there are hosted environments and DestroyEnvironments was not
-	// specified, don't bother trying to destroy the system, as it will fail.
-	if len(allEnvs) > 1 && !args.DestroyEnvironments {
-		return errors.Errorf("state server environment cannot be destroyed before all other environments are destroyed")
-	}
-
-	// If there are blocks, and we aren't being told to ignore them, let the
-	// user know.
-	blocks, err := s.state.AllBlocksForSystem()
-	if err != nil {
-		logger.Debugf("Unable to get blocks for system: %s", err)
-		if !args.IgnoreBlocks {
-			return errors.Trace(err)
-		}
-	}
-	if len(blocks) > 0 {
-		if !args.IgnoreBlocks {
-			return common.OperationBlockedError("found blocks in system environments")
-		}
-
-		err := s.state.RemoveAllBlocksForSystem()
-		if err != nil {
-			return errors.Trace(err)
-		}
-	}
-
-	systemEnv, err := s.state.StateServerEnvironment()
-	if err != nil {
-		return errors.Trace(err)
-	}
-	systemTag := systemEnv.EnvironTag()
-
-	if args.DestroyEnvironments {
-		for _, env := range allEnvs {
-			environTag := env.EnvironTag()
-			if environTag != systemTag {
-				if err := common.DestroyEnvironment(s.state, environTag); err != nil {
-					logger.Errorf("unable to destroy environment %q: %s", env.UUID(), err)
-				}
-			}
-		}
-	}
-
-	return errors.Trace(common.DestroyEnvironment(s.state, systemTag))
-}
-
 // EnvironmentConfig returns the environment config for the system
 // environment.  For information on the current environment, use
 // client.EnvironmentGet

--- a/cmd/juju/system/destroy.go
+++ b/cmd/juju/system/destroy.go
@@ -46,7 +46,7 @@ Continue [y/N]? `[1:]
 type destroySystemAPI interface {
 	Close() error
 	EnvironmentConfig() (map[string]interface{}, error)
-	DestroySystem(destroyEnvs bool, ignoreBlocks bool) error
+	DestroySystem(destroyEnvs bool) error
 	ListBlockedEnvironments() ([]params.EnvironmentBlockInfo, error)
 }
 
@@ -125,7 +125,7 @@ func (c *destroyCommand) Run(ctx *cmd.Context) error {
 	}
 
 	// Attempt to destroy the system.
-	err = api.DestroySystem(c.destroyEnvs, false)
+	err = api.DestroySystem(c.destroyEnvs)
 	if params.IsCodeNotImplemented(err) {
 		// Fall back to using the client endpoint to destroy the system,
 		// sending the info we were already able to collect.

--- a/cmd/juju/system/destroy_test.go
+++ b/cmd/juju/system/destroy_test.go
@@ -33,12 +33,11 @@ var _ = gc.Suite(&DestroySuite{})
 
 // fakeDestroyAPI mocks out the systemmanager API
 type fakeDestroyAPI struct {
-	err          error
-	env          map[string]interface{}
-	destroyAll   bool
-	ignoreBlocks bool
-	blocks       []params.EnvironmentBlockInfo
-	blocksErr    error
+	err        error
+	env        map[string]interface{}
+	destroyAll bool
+	blocks     []params.EnvironmentBlockInfo
+	blocksErr  error
 }
 
 func (f *fakeDestroyAPI) Close() error { return nil }
@@ -50,9 +49,8 @@ func (f *fakeDestroyAPI) EnvironmentConfig() (map[string]interface{}, error) {
 	return f.env, nil
 }
 
-func (f *fakeDestroyAPI) DestroySystem(destroyAll bool, ignoreBlocks bool) error {
+func (f *fakeDestroyAPI) DestroySystem(destroyAll bool) error {
 	f.destroyAll = destroyAll
-	f.ignoreBlocks = ignoreBlocks
 	return f.err
 }
 
@@ -204,7 +202,6 @@ func (s *DestroySuite) TestDestroyCannotConnectToAPI(c *gc.C) {
 func (s *DestroySuite) TestDestroy(c *gc.C) {
 	_, err := s.runDestroyCommand(c, "test1", "-y")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(s.api.ignoreBlocks, jc.IsFalse)
 	c.Assert(s.api.destroyAll, jc.IsFalse)
 	c.Assert(s.clientapi.destroycalled, jc.IsFalse)
 	checkSystemRemovedFromStore(c, "test1", s.store)
@@ -213,7 +210,6 @@ func (s *DestroySuite) TestDestroy(c *gc.C) {
 func (s *DestroySuite) TestDestroyWithDestroyAllEnvsFlag(c *gc.C) {
 	_, err := s.runDestroyCommand(c, "test1", "-y", "--destroy-all-environments")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(s.api.ignoreBlocks, jc.IsFalse)
 	c.Assert(s.api.destroyAll, jc.IsTrue)
 	checkSystemRemovedFromStore(c, "test1", s.store)
 }
@@ -247,7 +243,6 @@ func (s *DestroySuite) TestFailedDestroyEnvironment(c *gc.C) {
 	s.api.err = errors.New("permission denied")
 	_, err := s.runDestroyCommand(c, "test1", "-y")
 	c.Assert(err, gc.ErrorMatches, "cannot destroy system: permission denied")
-	c.Assert(s.api.ignoreBlocks, jc.IsFalse)
 	c.Assert(s.api.destroyAll, jc.IsFalse)
 	checkSystemExistsInStore(c, "test1", s.store)
 }

--- a/cmd/juju/system/kill.go
+++ b/cmd/juju/system/kill.go
@@ -154,8 +154,8 @@ func (c *killCommand) Run(ctx *cmd.Context) error {
 		return environs.Destroy(systemEnviron, store)
 	}
 
-	// Attempt to destroy the system with destroyEnvs and ignoreBlocks = true
-	err = api.DestroySystem(true, true)
+	// Attempt to destroy the system with destroyEnvs.
+	err = api.DestroySystem(true)
 	if params.IsCodeNotImplemented(err) {
 		// Fall back to using the client endpoint to destroy the system,
 		// sending the info we were already able to collect.
@@ -164,9 +164,16 @@ func (c *killCommand) Run(ctx *cmd.Context) error {
 
 	if err != nil {
 		ctx.Infof("Unable to destroy system through the API: %s.  Destroying through provider.", err)
+		return environs.Destroy(systemEnviron, store)
 	}
 
-	return environs.Destroy(systemEnviron, store)
+	// TODO(waigani) FIX BEFORE LANDING IN MASTER. A follow up branch will
+	// poll state and wait for the controller to be down before destroying
+	// it's provider.
+
+	// return environs.Destroy(systemEnviron, store)
+
+	return nil
 }
 
 // killSystemViaClient attempts to kill the system using the client

--- a/state/cleanup.go
+++ b/state/cleanup.go
@@ -18,16 +18,18 @@ type cleanupKind string
 
 const (
 	// SCHEMACHANGE: the names are expressive, the values not so much.
-	cleanupRelationSettings              cleanupKind = "settings"
-	cleanupUnitsForDyingService          cleanupKind = "units"
-	cleanupDyingUnit                     cleanupKind = "dyingUnit"
-	cleanupRemovedUnit                   cleanupKind = "removedUnit"
-	cleanupServicesForDyingEnvironment   cleanupKind = "services"
-	cleanupDyingMachine                  cleanupKind = "dyingMachine"
-	cleanupForceDestroyedMachine         cleanupKind = "machine"
-	cleanupAttachmentsForDyingStorage    cleanupKind = "storageAttachments"
-	cleanupAttachmentsForDyingVolume     cleanupKind = "volumeAttachments"
-	cleanupAttachmentsForDyingFilesystem cleanupKind = "filesystemAttachments"
+	cleanupRelationSettings               cleanupKind = "settings"
+	cleanupUnitsForDyingService           cleanupKind = "units"
+	cleanupDyingUnit                      cleanupKind = "dyingUnit"
+	cleanupRemovedUnit                    cleanupKind = "removedUnit"
+	cleanupServicesForDyingEnvironment    cleanupKind = "services"
+	cleanupDyingMachine                   cleanupKind = "dyingMachine"
+	cleanupForceDestroyedMachine          cleanupKind = "machine"
+	cleanupAttachmentsForDyingStorage     cleanupKind = "storageAttachments"
+	cleanupAttachmentsForDyingVolume      cleanupKind = "volumeAttachments"
+	cleanupAttachmentsForDyingFilesystem  cleanupKind = "filesystemAttachments"
+	cleanupEnvironmentsForDyingController cleanupKind = "environments"
+	cleanupMachinesForDyingEnvironment    cleanupKind = "environmentMachines"
 )
 
 // cleanupDoc represents a potentially large set of documents that should be
@@ -99,6 +101,10 @@ func (st *State) Cleanup() (err error) {
 			err = st.cleanupAttachmentsForDyingVolume(doc.Prefix)
 		case cleanupAttachmentsForDyingFilesystem:
 			err = st.cleanupAttachmentsForDyingFilesystem(doc.Prefix)
+		case cleanupEnvironmentsForDyingController:
+			err = st.cleanupEnvironmentsForDyingController()
+		case cleanupMachinesForDyingEnvironment:
+			err = st.cleanupMachinesForDyingEnvironment()
 		default:
 			err = fmt.Errorf("unknown cleanup kind %q", doc.Kind)
 		}
@@ -132,6 +138,57 @@ func (st *State) cleanupRelationSettings(prefix string) error {
 	} else if count != 0 {
 		if _, err := settingsW.RemoveAll(sel); err != nil {
 			return fmt.Errorf("cannot remove documents marked for cleanup: %v", err)
+		}
+	}
+	return nil
+}
+
+// cleanupEnvironmentsForDyingController sets all environments to dying, if
+// they are not already Dying or Dead. It's expected to be used when a
+// controller is destroyed.
+func (st *State) cleanupEnvironmentsForDyingController() (err error) {
+	environs, err := st.AllEnvironments()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	for _, env := range environs {
+
+		if env.Life() == Alive {
+			if err := env.Destroy(); err != nil {
+				return errors.Trace(err)
+			}
+		}
+	}
+	return nil
+}
+
+// cleanupMachinesForDyingEnvironment sets all non-manager, non-manual
+// machines to Dying, if they are not already Dying or Dead. It's expected to
+// be used when an environment is destroyed.
+func (st *State) cleanupMachinesForDyingEnvironment() (err error) {
+	// This won't miss machines, because a Dying environment cannot have
+	// machines added to it. But we do have to remove the machines themselves
+	// via individual transactions, because they could be in any state at all.
+	machines, err := st.AllMachines()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	for _, m := range machines {
+		if m.IsManager() {
+			continue
+		}
+		if _, isContainer := m.ParentId(); isContainer {
+			continue
+		}
+		manual, err := m.IsManual()
+		if err != nil {
+			return err
+		} else if manual {
+			continue
+		}
+		err = m.ForceDestroy()
+		if err != nil {
+			return errors.Trace(err)
 		}
 	}
 	return nil

--- a/state/cleanup_test.go
+++ b/state/cleanup_test.go
@@ -71,6 +71,70 @@ func (s *CleanupSuite) TestCleanupDyingServiceUnits(c *gc.C) {
 	s.assertCleanupCount(c, 1)
 }
 
+func (s *CleanupSuite) TestCleanupControllerEnvironments(c *gc.C) {
+	s.assertDoesNotNeedCleanup(c)
+
+	// Create an environment.
+	otherSt := s.Factory.MakeEnvironment(c, nil)
+	defer otherSt.Close()
+	otherEnv, err := otherSt.Environment()
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.assertDoesNotNeedCleanup(c)
+
+	// Destroy the controller and check the environment is unaffected, but a
+	// cleanup for the environment and services has been scheduled.
+	controllerEnv, err := s.State.Environment()
+	c.Assert(err, jc.ErrorIsNil)
+	err = controllerEnv.DestroyIncludingHosted()
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Two cleanups should be scheduled. One to destroy the hosted
+	// environments, the other to destroy the controller environment's
+	// services.
+	s.assertCleanupCount(c, 1)
+	err = otherEnv.Refresh()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(otherEnv.Life(), gc.Equals, state.Dying)
+
+	s.assertDoesNotNeedCleanup(c)
+}
+
+func (s *CleanupSuite) TestCleanupEnvironmentMachines(c *gc.C) {
+	// Create a state and hosted machine.
+	stateMachine, err := s.State.AddMachine("quantal", state.JobManageEnviron)
+	c.Assert(err, jc.ErrorIsNil)
+	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Create a relation with a unit in scope and assigned to the hosted machine.
+	pr := NewPeerRelation(c, s.State, s.Owner)
+	err = pr.u0.AssignToMachine(machine)
+	c.Assert(err, jc.ErrorIsNil)
+	err = pr.ru0.EnterScope(nil)
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertDoesNotNeedCleanup(c)
+
+	// Destroy environment, check cleanup queued.
+	env, err := s.State.Environment()
+	c.Assert(err, jc.ErrorIsNil)
+	err = env.Destroy()
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertNeedsCleanup(c)
+
+	// Clean up, and check that the unit has been removed...
+	s.assertCleanupCount(c, 3)
+	assertRemoved(c, pr.u0)
+
+	// ...and the unit has departed relation scope...
+	assertNotJoined(c, pr.ru0)
+
+	// ...but that the machine remains, and is Dead, ready for removal by the
+	// provisioner.
+	assertLife(c, machine, state.Dead)
+	assertLife(c, stateMachine, state.Alive)
+}
+
 func (s *CleanupSuite) TestCleanupEnvironmentServices(c *gc.C) {
 	s.assertDoesNotNeedCleanup(c)
 
@@ -152,7 +216,7 @@ func (s *CleanupSuite) TestForceDestroyMachineErrors(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertDoesNotNeedCleanup(c)
 	err = manager.ForceDestroy()
-	expect := fmt.Sprintf("machine %s is required by the environment", manager.Id())
+	expect := fmt.Sprintf("machine is required by the environment")
 	c.Assert(err, gc.ErrorMatches, expect)
 	s.assertDoesNotNeedCleanup(c)
 	assertLife(c, manager, state.Alive)

--- a/state/environ.go
+++ b/state/environ.go
@@ -4,6 +4,7 @@
 package state
 
 import (
+	"fmt"
 	"strings"
 	"time"
 
@@ -24,6 +25,10 @@ const environGlobalKey = "e"
 
 // Environment represents the state of an environment.
 type Environment struct {
+	// st is not neccessarly the state of this environment. Though it is
+	// usually safe to assume that it is. The only times it isn't is when we
+	// get environments other than the current one - which is mostly in
+	// controller api endpoints.
 	st  *State
 	doc environmentDoc
 }
@@ -339,6 +344,17 @@ func (e *Environment) Users() ([]*EnvironmentUser, error) {
 // Destroy sets the environment's lifecycle to Dying, preventing
 // addition of services or machines to state.
 func (e *Environment) Destroy() (err error) {
+	return e.destroy(false)
+}
+
+// Destroy sets the environment's lifecycle to Dying, preventing addition of
+// services or machines to state. If this environment is a controller hosting
+// other environments, they will also be destroyed.
+func (e *Environment) DestroyIncludingHosted() error {
+	return e.destroy(true)
+}
+
+func (e *Environment) destroy(destroyHostedEnvirons bool) (err error) {
 	defer errors.DeferredAnnotatef(&err, "failed to destroy environment")
 
 	buildTxn := func(attempt int) ([]txn.Op, error) {
@@ -349,12 +365,12 @@ func (e *Environment) Destroy() (err error) {
 			// ...but on subsequent attempts, we read fresh environ
 			// state from the DB. Note that we do *not* refresh `e`
 			// itself, as detailed in doc/hacking-state.txt
-			if e, err = e.st.Environment(); err != nil {
+			if e, err = e.st.GetEnvironment(e.EnvironTag()); err != nil {
 				return nil, errors.Trace(err)
 			}
 		}
 
-		ops, err := e.destroyOps()
+		ops, err := e.destroyOps(destroyHostedEnvirons)
 		if err == errEnvironNotAlive {
 			return nil, jujutxn.ErrNoOperations
 		} else if err != nil {
@@ -363,21 +379,52 @@ func (e *Environment) Destroy() (err error) {
 
 		return ops, nil
 	}
-	return e.st.run(buildTxn)
+
+	st := e.st
+	if e.UUID() != e.st.EnvironUUID() {
+		st, err = e.st.ForEnviron(e.EnvironTag())
+		defer st.Close()
+		if err != nil {
+			return errors.Trace(err)
+		}
+	}
+	return st.run(buildTxn)
 }
 
 // errEnvironNotAlive is a signal emitted from destroyOps to indicate
 // that environment destruction is already underway.
 var errEnvironNotAlive = errors.New("environment is no longer alive")
 
+type hasHostedEnvironsError int
+
+func (e hasHostedEnvironsError) Error() string {
+	return fmt.Sprintf("hosting %d other environments", e)
+}
+
+func IsHasHostedEnvironsError(err error) bool {
+	_, ok := errors.Cause(err).(hasHostedEnvironsError)
+	return ok
+}
+
 // destroyOps returns the txn operations necessary to begin environ
 // destruction, or an error indicating why it can't.
-func (e *Environment) destroyOps() ([]txn.Op, error) {
+func (e *Environment) destroyOps(destroyHostedEnvirons bool) ([]txn.Op, error) {
+	// Ensure we're using the environment's state.
+	st := e.st
+	var err error
+	if e.UUID() != e.st.EnvironUUID() {
+		st, err = e.st.ForEnviron(e.EnvironTag())
+		defer st.Close()
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+	}
+
 	if e.Life() != Alive {
 		return nil, errEnvironNotAlive
 	}
 
-	err := e.ensureDestroyable()
+	err = e.ensureDestroyable()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -392,26 +439,32 @@ func (e *Environment) destroyOps() ([]txn.Op, error) {
 			{"time-of-dying", nowToTheSecond()},
 		}}},
 	}}
-	if uuid == e.doc.ServerUUID {
-		if count, err := hostedEnvironCount(e.st); err != nil {
+	if uuid == e.doc.ServerUUID && !destroyHostedEnvirons {
+		if count, err := hostedEnvironCount(st); err != nil {
 			return nil, errors.Trace(err)
 		} else if count != 0 {
-			return nil, errors.Errorf("hosting %d other environments", count)
+			return nil, errors.Trace(hasHostedEnvironsError(count))
 		}
 		ops = append(ops, assertNoHostedEnvironsOp())
 	} else {
-		// When we're destroying a hosted environment, no further
-		// checks are necessary -- we just need to make sure we
-		// update the refcount.
+		// If this environment isn't hosting any environments, no further
+		// checks are necessary -- we just need to make sure we update the
+		// refcount.
 		ops = append(ops, decHostedEnvironCountOp())
 	}
 
 	// Because txn operations execute in order, and may encounter
 	// arbitrarily long delays, we need to make sure every op
 	// causes a state change that's still consistent; so we make
-	// sure the cleanup op is the last thing that will execute.
-	cleanupOp := e.st.newCleanupOp(cleanupServicesForDyingEnvironment, uuid)
-	ops = append(ops, cleanupOp)
+	// sure the cleanup ops are the last thing that will execute.
+	if uuid == e.doc.ServerUUID {
+		cleanupOp := st.newCleanupOp(cleanupEnvironmentsForDyingController, uuid)
+		ops = append(ops, cleanupOp)
+	}
+	cleanupMachinesOp := st.newCleanupOp(cleanupMachinesForDyingEnvironment, uuid)
+	ops = append(ops, cleanupMachinesOp)
+	cleanupServicesOp := st.newCleanupOp(cleanupServicesForDyingEnvironment, uuid)
+	ops = append(ops, cleanupServicesOp)
 	return ops, nil
 }
 

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
@@ -442,4 +443,12 @@ func WriteLogWithOplog(
 
 func SpaceDoc(s *Space) spaceDoc {
 	return s.doc
+}
+
+func ForceDestroyMachineOps(m *Machine) ([]txn.Op, error) {
+	return m.forceDestroyOps()
+}
+
+func IsManagerMachineError(err error) bool {
+	return errors.Cause(err) == managerMachineError
 }

--- a/state/machine.go
+++ b/state/machine.go
@@ -436,17 +436,28 @@ func (m *Machine) Destroy() error {
 // ForceDestroy queues the machine for complete removal, including the
 // destruction of all units and containers on the machine.
 func (m *Machine) ForceDestroy() error {
-	if !m.IsManager() {
-		ops := []txn.Op{{
-			C:      machinesC,
-			Id:     m.doc.DocID,
-			Assert: bson.D{{"jobs", bson.D{{"$nin", []MachineJob{JobManageEnviron}}}}},
-		}, m.st.newCleanupOp(cleanupForceDestroyedMachine, m.doc.Id)}
-		if err := m.st.runTransaction(ops); err != txn.ErrAborted {
-			return err
-		}
+	ops, err := m.forceDestroyOps()
+	if err != nil {
+		return errors.Trace(err)
 	}
-	return fmt.Errorf("machine %s is required by the environment", m.doc.Id)
+	if err := m.st.runTransaction(ops); err != txn.ErrAborted {
+		return errors.Trace(err)
+	}
+	return nil
+}
+
+var managerMachineError = errors.New("machine is required by the environment")
+
+func (m *Machine) forceDestroyOps() ([]txn.Op, error) {
+	if m.IsManager() {
+		return nil, errors.Trace(managerMachineError)
+	}
+
+	return []txn.Op{{
+		C:      machinesC,
+		Id:     m.doc.DocID,
+		Assert: bson.D{{"jobs", bson.D{{"$nin", []MachineJob{JobManageEnviron}}}}},
+	}, m.st.newCleanupOp(cleanupForceDestroyedMachine, m.doc.Id)}, nil
 }
 
 // EnsureDead sets the machine lifecycle to Dead if it is Alive or Dying.

--- a/state/undertaker.go
+++ b/state/undertaker.go
@@ -21,6 +21,18 @@ func (st *State) ProcessDyingEnviron() (err error) {
 			return nil, errors.New("environment is not dying")
 		}
 
+		if st.IsStateServer() {
+			envs, err := st.AllEnvironments()
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			for _, env := range envs {
+				if env.UUID() != st.EnvironUUID() && env.Life() != Dead {
+					return nil, errors.Errorf("one or more hosted environments are not yet dead")
+				}
+			}
+		}
+
 		machines, err := st.AllMachines()
 		if err != nil {
 			return nil, errors.Trace(err)


### PR DESCRIPTION
This branch targets a feature branch that has not updated to the
controller name yet and still refers to system.

- On system kill, add cleanup jobs to destroy all environments and
schedule further cleanups to remove all machines and services for each
environment.

- Update state.ProcessDyingEnviron to error if the environ is a
controller with non-dead hosted environments. This ensures the
controller environ stays functional in a dying state until all hosted
environs are dead.

- Fix a bug with the undertaker worker watcher (on apiserver side) and
refactor code to make it clearer.

- Remove TestDestroyEnvironmentWithContainers as it no longer makes
sense. It's testing that we call stopInstance, which we no longer do.

- TestKillWithAPIConnection didn't actually test that the system was
killed with the api connection. The method was falling back to
destroying it via environs.Destroy, which we no longer do. So I
removed checkSystemRemovedFromStore(c, "test1", s.store).

Other notes:

I have removed destroying all services from the original
DestroyEnvironment method - as this is exactly what
cleanupServicesForDyingEnvironment does. Effectively, all
DestroyEnvironment now does is set the environment to dying and add
cleanup jobs.

assertCleanupCount has been copied to two tests, this could be moved
to a testing utils pkg (I'll see what the reviewer thinks).

Testing:

Unit tests: api, apiserver, state

Manually tested: two hosted environments and controller environment,
each with with the ubuntu service and a machine added. All machines
and services brought down successfully. Each environment can still be
switched to and status can be read, but nothing added as they are all
dead.

Follow up:

A follow up branch will poll state and display the status of the
controller take down. At the end of that, the client will call destroy
on the provider to remove the final state machines.

(Review request: http://reviews.vapour.ws/r/3119/)