### PR TITLE
WIP: worker/gate2 

### DIFF
--- a/worker/gate2/interface.go
+++ b/worker/gate2/interface.go
@@ -1,0 +1,33 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// package gate2 provides a mechanism by which independent workers can wait for
+// one another to finish a task, without introducing explicit dependencies
+// between those workers.
+package gate2
+
+// Checker is an output from the gate2 Manifold.
+type Checker interface {
+	// IsUnlocked returns true when the gate is unlocked.
+	IsUnlocked() bool
+}
+
+// Unlocker is used to unlock a gate.
+type Unlocker interface {
+	// Unlock will unlock a gate. It is goroutine-safe and may be
+	// called multiple times. Only the first call will have any effect
+	// however.
+	Unlock()
+
+	// Unlocked returns a channel that will be closed when the gate is
+	// unlocked.
+	//
+	// TODO(mjs) - This becomes unnecessary once the machine agent
+	// dependency engine conversion is done. The returned channel is
+	// necessary while we have unconverted workers that need a channel
+	// to block their startup waiting for the upgrader and
+	// upgrade-steps workers. Eventually, the Unlocker interface can
+	// go away completely and be replaced with a simple unlock
+	// functioning returned by Manifold.
+	Unlocked() <-chan struct{}
+}

--- a/worker/gate2/manifold.go
+++ b/worker/gate2/manifold.go
@@ -1,0 +1,125 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package gate2
+
+import (
+	"sync"
+
+	"github.com/juju/errors"
+	"launchpad.net/tomb"
+
+	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/dependency"
+)
+
+// Manifold returns a dependency.Manifold which implements a gate that
+// can be used to synchronize the start of manifolds. The manifold's
+// worker will restart when the gate is unlocked so that waiting
+// dependents will be started by the dependency engine at that time.
+//
+// An Unlocker is also returned. This can be used anywhere to unlock
+// the gate. It may be directly passed to a manifold via it's
+// config. This isn't available as a convential output because the
+// unlocking manifold would effectively kill itself when unlocking the
+// gate!
+//
+// The output func accepts an out pointer to a Checker. Dependents
+// should call the IsUnlocked method on the Checker to see if the gate
+// is unlocked.
+func Manifold() (dependency.Manifold, Unlocker) {
+
+	ch := make(chan struct{})
+
+	m := dependency.Manifold{
+		Start: func(_ dependency.GetResourceFunc) (worker.Worker, error) {
+			w := &gate{ch: ch}
+			go func() {
+				defer w.tomb.Done()
+				w.tomb.Kill(w.wait())
+			}()
+			return w, nil
+		},
+		Output: func(in worker.Worker, out interface{}) error {
+			inWorker, _ := in.(*gate)
+			if inWorker == nil {
+				return errors.Errorf("in should be a *gate; is %#v", in)
+			}
+			switch outPointer := out.(type) {
+			case *Checker:
+				*outPointer = inWorker
+			default:
+				return errors.Errorf("out should be a pointer to a Checker; is %#v", out)
+			}
+			return nil
+		},
+	}
+	u := &unlocker{
+		ch: ch,
+	}
+	return m, u
+}
+
+// unlocker is an implementation of Unlocker.
+type unlocker struct {
+	mu sync.Mutex
+	ch chan struct{}
+}
+
+// Unlock implements Unlocker.
+func (u *unlocker) Unlock() {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	select {
+	case <-u.ch:
+	default:
+		close(u.ch)
+	}
+}
+
+// Unlocked implements Unlocker.
+func (u *unlocker) Unlocked() <-chan struct{} {
+	return u.ch
+}
+
+// gate implements Checker and worker.Worker.
+type gate struct {
+	tomb tomb.Tomb
+	ch   chan struct{}
+}
+
+func (w *gate) wait() error {
+	// If the gate is unblocked (channel has been closed), don't
+	// select on it.
+	ch := w.ch
+	if w.IsUnlocked() {
+		ch = nil
+	}
+
+	select {
+	case err := <-w.tomb.Dying():
+		return tomb.ErrDying
+	case <-ch:
+		return errors.New("gate closed")
+	}
+}
+
+// Kill is part of the worker.Worker interface.
+func (w *gate) Kill() {
+	w.tomb.Kill(nil)
+}
+
+// Wait is part of the worker.Worker interface.
+func (w *gate) Wait() error {
+	return w.tomb.Wait()
+}
+
+// IsUnlocked is part of the Checker interface.
+func (w *gate) IsUnlocked() bool {
+	select {
+	case <-w.ch:
+		return true
+	default:
+		return false
+	}
+}


### PR DESCRIPTION
This is a WIP for Will to take a look at. Other reviewers may ignore this.

gate2 is an alternative gate manifold which can be used for synchronising manifold startup based on some arbitrary event. The name is a placeholder - this implementation could end up replacing the current gate. There's a mock example of how it could be used in the second commit.

Differences from the existing gate: 
* It can be used as a direct dependency for manifolds, allowing the dep engine to manage the start of a manifolds that depend on some event.
* The gate can be safely unlocked from any arbitrary place, including code outside of the dependency engine (useful during the conversion process).
* The gate's channel is externally available (for reading only). This is necessary during the conversion process while we have workers that still need a channel to watch before starting. As indicated by the big TODO, this can eventually go away.

I have confirm this all works with an ugly ugly prototype. 

Will: If you're happy with the approach I'll write tests and use it for the upgrader "first upgrade check is done" and upgrade-steps "upgrade is complete" events.


(Review request: http://reviews.vapour.ws/r/3121/)