### PR TITLE
mongo: prefer machine address for replica set peername

### DIFF
--- a/cmd/jujud/bootstrap_test.go
+++ b/cmd/jujud/bootstrap_test.go
@@ -215,8 +215,7 @@ func (s *BootstrapSuite) TestInitializeEnvironment(c *gc.C) {
 	gotDialAddrs := s.fakeEnsureMongo.InitiateParams.DialInfo.Addrs
 	c.Assert(gotDialAddrs, gc.DeepEquals, expectDialAddrs)
 
-	memberHost := fmt.Sprintf("%s:%d", s.bootstrapName, expectInfo.StatePort)
-	c.Assert(s.fakeEnsureMongo.InitiateParams.MemberHostPort, gc.Equals, memberHost)
+	c.Assert(s.fakeEnsureMongo.InitiateParams.MemberHostPort, gc.Equals, expectDialAddrs[0])
 	c.Assert(s.fakeEnsureMongo.InitiateParams.User, gc.Equals, "")
 	c.Assert(s.fakeEnsureMongo.InitiateParams.Password, gc.Equals, "")
 

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -79,14 +79,14 @@ func IsMaster(session *mgo.Session, obj WithAddresses) (bool, error) {
 // mongo replica set peer address by selecting it from the given addresses. If
 // no addresses are available an empty string is returned.
 func SelectPeerAddress(addrs []network.Address) string {
-	addr, _ := network.SelectInternalAddress(addrs, false)
+	addr, _ := network.SelectInternalAddress(addrs, true)
 	return addr.Value
 }
 
 // SelectPeerHostPort returns the HostPort to use as the
 // mongo replica set peer by selecting it from the given hostPorts.
 func SelectPeerHostPort(hostPorts []network.HostPort) string {
-	return network.SelectInternalHostPort(hostPorts, false)
+	return network.SelectInternalHostPort(hostPorts, true)
 }
 
 // GenerateSharedSecret generates a pseudo-random shared secret (keyfile)

--- a/network/address.go
+++ b/network/address.go
@@ -487,3 +487,24 @@ func IPv4ToDecimal(ipv4Addr net.IP) (uint32, error) {
 	}
 	return binary.BigEndian.Uint32([]byte(ip)), nil
 }
+
+// ResolvableHostnames returns the set of all DNS resolvable names
+// from addrs. Note that 'localhost' is always considered resolvable
+// because it can be used both as an IPv4 or IPv6 endpoint (e.g., in
+// IPv6-only networks).
+func ResolvableHostnames(addrs []Address) []Address {
+	resolveableAddrs := make([]Address, 0, len(addrs))
+	for _, addr := range addrs {
+		if addr.Value == "localhost" || net.ParseIP(addr.Value) != nil {
+			resolveableAddrs = append(resolveableAddrs, addr)
+			continue
+		}
+		_, err := netLookupIP(addr.Value)
+		if err != nil {
+			logger.Infof("removing unresolvable address %q: %v", addr.Value, err)
+			continue
+		}
+		resolveableAddrs = append(resolveableAddrs, addr)
+	}
+	return resolveableAddrs
+}

--- a/network/address_test.go
+++ b/network/address_test.go
@@ -4,6 +4,8 @@
 package network_test
 
 import (
+	"errors"
+	"fmt"
 	"net"
 
 	jc "github.com/juju/testing/checkers"
@@ -867,4 +869,73 @@ func (*AddressSuite) TestExactScopeMatchHonoursPreferIPv6(c *gc.C) {
 	c.Assert(match, jc.IsTrue)
 	match = network.ExactScopeMatch(addr, network.ScopePublic)
 	c.Assert(match, jc.IsFalse)
+}
+
+func (s *AddressSuite) TestResolvableHostnames(c *gc.C) {
+	seq := 0
+
+	s.PatchValue(network.NetLookupIP, func(host string) ([]net.IP, error) {
+		if host == "not-resolvable.com" {
+			return nil, errors.New("no such host")
+		}
+		seq++
+		return []net.IP{net.ParseIP(fmt.Sprintf("1.1.1.%d", seq))}, nil
+	})
+
+	// Test empty input yields empty output.
+	empty := []network.Address{}
+	c.Assert(empty, jc.DeepEquals, network.ResolvableHostnames(empty))
+
+	// Test unresolvable inputs yields empty output.
+	unresolvable := []network.Address{{Value: "not-resolvable.com", Type: network.HostName}}
+	c.Assert(empty, jc.DeepEquals, network.ResolvableHostnames(unresolvable))
+
+	// Test resolvable inputs yields identical outputs.
+	resolvable := []network.Address{{Value: "localhost", Type: network.HostName}}
+	c.Assert(resolvable, jc.DeepEquals, network.ResolvableHostnames(resolvable))
+
+	unscopedAddrs := []network.Address{
+		network.NewAddress("localhost"),
+		network.NewAddress("127.0.0.1"),
+		network.NewAddress("fe80::d806:dbff:fe23:1199"),
+		network.NewAddress("not-resolvable.com"),
+		network.NewAddress("not-resolvable.com"),
+		network.NewAddress("fe80::1"),
+		network.NewAddress("resolvable.com"),
+		network.NewAddress("localhost"),
+		network.NewAddress("resolvable.com"),
+		network.NewAddress("ubuntu.com"),
+	}
+
+	unscopedAddrsExpected := []network.Address{
+		unscopedAddrs[0], unscopedAddrs[1],
+		unscopedAddrs[2], unscopedAddrs[5],
+		unscopedAddrs[6], unscopedAddrs[7],
+		unscopedAddrs[8], unscopedAddrs[9],
+	}
+
+	c.Assert(unscopedAddrsExpected, jc.DeepEquals, network.ResolvableHostnames(unscopedAddrs))
+
+	// Test multiple inputs have their order preserved, that
+	// duplicates are preserved but unresolvable hostnames (except
+	// 'localhost') are removed.
+	scopedAddrs := []network.Address{
+		network.NewScopedAddress("172.16.1.1", network.ScopeCloudLocal),
+		network.NewScopedAddress("not-resolvable.com", network.ScopePublic),
+		network.NewScopedAddress("8.8.8.8", network.ScopePublic),
+		network.NewScopedAddress("resolvable.com", network.ScopePublic),
+		network.NewScopedAddress("fc00:1", network.ScopeCloudLocal),
+		network.NewScopedAddress("localhost", network.ScopePublic),
+		network.NewScopedAddress("192.168.1.1", network.ScopeCloudLocal),
+		network.NewScopedAddress("localhost", network.ScopeCloudLocal),
+		network.NewScopedAddress("not-resolvable.com", network.ScopePublic),
+		network.NewScopedAddress("resolvable.com", network.ScopePublic),
+	}
+
+	scopedAddrsExpected := []network.Address{
+		scopedAddrs[0], scopedAddrs[2], scopedAddrs[3], scopedAddrs[4],
+		scopedAddrs[5], scopedAddrs[6], scopedAddrs[7], scopedAddrs[9],
+	}
+
+	c.Assert(scopedAddrsExpected, jc.DeepEquals, network.ResolvableHostnames(scopedAddrs))
 }

--- a/provider/maas/instance.go
+++ b/provider/maas/instance.go
@@ -90,7 +90,10 @@ func (mi *maasInstance) Addresses() ([]network.Address, error) {
 	}
 	addrs = append(addrs, network.NewAddresses(ips...)...)
 
-	return addrs, nil
+	// Although we would prefer a DNS name there's no point
+	// returning unresolvable names because activities like 'juju
+	// ssh 0' will instantly fail.
+	return network.ResolvableHostnames(addrs), nil
 }
 
 func (mi *maasInstance) ipAddresses() ([]string, error) {

--- a/provider/maas/instance_test.go
+++ b/provider/maas/instance_test.go
@@ -72,8 +72,6 @@ func (s *instanceTest) TestAddresses(c *gc.C) {
 	inst := maasInstance{maasObject: &obj, environ: s.makeEnviron()}
 
 	expected := []network.Address{
-		network.NewScopedAddress("testing.invalid", network.ScopePublic),
-		network.NewScopedAddress("testing.invalid", network.ScopeCloudLocal),
 		network.NewAddress("1.2.3.4"),
 		network.NewAddress("fe80::d806:dbff:fe23:1199"),
 	}
@@ -96,10 +94,7 @@ func (s *instanceTest) TestAddressesMissing(c *gc.C) {
 
 	addr, err := inst.Addresses()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Check(addr, gc.DeepEquals, []network.Address{
-		{Value: "testing.invalid", Type: network.HostName, Scope: network.ScopePublic},
-		{Value: "testing.invalid", Type: network.HostName, Scope: network.ScopeCloudLocal},
-	})
+	c.Check(addr, gc.DeepEquals, []network.Address{})
 }
 
 func (s *instanceTest) TestAddressesInvalid(c *gc.C) {


### PR DESCRIPTION
The network addresses used for mongo replica set initiation will
occasionally fail to resolve on MAAS resulting in a failed bootstrap.
This happens because the DNS zone tables on the MAAS controller are not
always updated with the new machine address causing subsequent lookups
of that name to fail.

If you bootstrap with --debug you see the following warning (folded for
readability):

 Initiate: fetching replication status failed:
   cannot get replica set status:
   can't get local.system.replset config from self or any seed (EMPTYCONFIG)

We workaround this MAAS issue by always preferring machine
addresses (i.e., IP addresses) for replica set initiation.

And for the MAAS provider only we drop all unresolvable hostnames from
Addresses(). If we left Addresses() with unresolvable names we end up
with:

  $ juju status
  machines:
    "0":
      agent-state: started
      agent-version: 1.26-alpha1.1
      dns-name: "maas-node3.maas"

but addressing that machine will subsequently fail:

  $ juju ssh 0
  Warning: Permanently added '10.17.17.105' (ECDSA) to the list of known hosts.
  nc: getaddrinfo: Name or service not known
  ssh_exchange_identification: Connection closed by remote host

Fixes [LP:#1412621](https://bugs.launchpad.net/juju-core/+bug/1412621)

(Review request: http://reviews.vapour.ws/r/3122/)