### PR TITLE
Increase the dependency engine logging level in 2 places

### DIFF
--- a/worker/dependency/engine.go
+++ b/worker/dependency/engine.go
@@ -437,7 +437,7 @@ func (engine *engine) gotStarted(name string, worker worker.Worker, resourceLog 
 		worker.Kill()
 	default:
 		// It's fine to use this worker; update info and copy back.
-		logger.Tracef("%q manifold worker started", name)
+		logger.Debugf("%q manifold worker started", name)
 		engine.current[name] = workerInfo{
 			worker:      worker,
 			resourceLog: resourceLog,
@@ -451,7 +451,7 @@ func (engine *engine) gotStarted(name string, worker worker.Worker, resourceLog 
 // gotStopped updates the engine to reflect the demise of (or failure to create)
 // a worker. It must only be called from the loop goroutine.
 func (engine *engine) gotStopped(name string, err error, resourceLog []resourceAccess) {
-	logger.Tracef("%q manifold worker stopped: %v", name, err)
+	logger.Debugf("%q manifold worker stopped: %v", name, err)
 
 	// Copy current info and check for reasons to stop the engine.
 	info := engine.current[name]


### PR DESCRIPTION
This change increases the dependency engine's log level when manifolds have started and when they have stopped (or failed to start). Tweaking these 2 sites provides valuable information about manifold execution, especially as agents are starting, without contributing excessive log spam.