### PR TITLE
apiserver correctly checks the result of calling SupportsSpaces

### DIFF
--- a/apiserver/spaces/spaces.go
+++ b/apiserver/spaces/spaces.go
@@ -186,7 +186,6 @@ func (api *spacesAPI) supportsSpaces() error {
 	}
 	ok, err = netEnv.SupportsSpaces()
 	if !ok {
-		logger.Warningf("environment does not support spaces: %v", err)
 		return errors.NotSupportedf("spaces")
 	}
 	return err

--- a/apiserver/spaces/spaces.go
+++ b/apiserver/spaces/spaces.go
@@ -185,8 +185,9 @@ func (api *spacesAPI) supportsSpaces() error {
 		return errors.NotSupportedf("networking")
 	}
 	ok, err = netEnv.SupportsSpaces()
-	if err != nil {
+	if !ok {
 		logger.Warningf("environment does not support spaces: %v", err)
+		return errors.NotSupportedf("spaces")
 	}
 	return err
 }


### PR DESCRIPTION
Correct a bug in the apiserver to correctly check the result of calling SupportsSpaces.

(Review request: http://reviews.vapour.ws/r/3125/)