### PR TITLE
state: limit WatchMachine{Volume,Vilesystem}Att... (1.25)

### DIFF
--- a/apiserver/storageprovisioner/storageprovisioner_test.go
+++ b/apiserver/storageprovisioner/storageprovisioner_test.go
@@ -740,15 +740,6 @@ func (s *provisionerSuite) TestWatchVolumeAttachments(c *gc.C) {
 				Changes: []params.MachineStorageId{{
 					MachineTag:    "machine-0",
 					AttachmentTag: "volume-0-0",
-				}, {
-					MachineTag:    "machine-0",
-					AttachmentTag: "volume-1",
-				}, {
-					MachineTag:    "machine-0",
-					AttachmentTag: "volume-2",
-				}, {
-					MachineTag:    "machine-0",
-					AttachmentTag: "volume-3",
 				}},
 			},
 			{
@@ -855,12 +846,6 @@ func (s *provisionerSuite) TestWatchFilesystemAttachments(c *gc.C) {
 				Changes: []params.MachineStorageId{{
 					MachineTag:    "machine-0",
 					AttachmentTag: "filesystem-0-0",
-				}, {
-					MachineTag:    "machine-0",
-					AttachmentTag: "filesystem-1",
-				}, {
-					MachineTag:    "machine-0",
-					AttachmentTag: "filesystem-2",
 				}},
 			},
 			{

--- a/state/filesystem_test.go
+++ b/state/filesystem_test.go
@@ -348,28 +348,54 @@ func (s *FilesystemStateSuite) TestWatchMachineFilesystems(c *gc.C) {
 
 func (s *FilesystemStateSuite) TestWatchMachineFilesystemAttachments(c *gc.C) {
 	service := s.setupMixedScopeStorageService(c, "filesystem")
-	addUnit := func() {
-		u, err := service.AddUnit()
+	addUnit := func(to *state.Machine) (u *state.Unit, m *state.Machine) {
+		var err error
+		u, err = service.AddUnit()
 		c.Assert(err, jc.ErrorIsNil)
+		if to != nil {
+			err = u.AssignToMachine(to)
+			c.Assert(err, jc.ErrorIsNil)
+			return u, to
+		}
 		err = s.State.AssignUnit(u, state.AssignCleanEmpty)
 		c.Assert(err, jc.ErrorIsNil)
+		mid, err := u.AssignedMachineId()
+		c.Assert(err, jc.ErrorIsNil)
+		m, err = s.State.Machine(mid)
+		c.Assert(err, jc.ErrorIsNil)
+		return u, m
 	}
-	addUnit()
+	_, m0 := addUnit(nil)
 
 	w := s.State.WatchMachineFilesystemAttachments(names.NewMachineTag("0"))
 	defer testing.AssertStop(c, w)
 	wc := testing.NewStringsWatcherC(c, s.State, w)
-	wc.AssertChangeInSingleEvent("0:0", "0:0/1", "0:0/2") // initial
+	wc.AssertChangeInSingleEvent("0:0/1", "0:0/2") // initial
 	wc.AssertNoChange()
 
-	addUnit()
+	addUnit(nil)
 	// no change, since we're only interested in the one machine.
 	wc.AssertNoChange()
 
-	// TODO(axw) respond to changes to the same machine when we support
-	// dynamic storage and/or placement.
-	// TODO(axw) respond to Dying/Dead when we have
-	// the means to progress Filesystem lifecycle.
+	err := s.State.DetachFilesystem(names.NewMachineTag("0"), names.NewFilesystemTag("0"))
+	c.Assert(err, jc.ErrorIsNil)
+	// no change, since we're only interested in attachments of
+	// machine-scoped volumes.
+	wc.AssertNoChange()
+
+	err = s.State.DetachFilesystem(names.NewMachineTag("0"), names.NewFilesystemTag("0/1"))
+	c.Assert(err, jc.ErrorIsNil)
+	wc.AssertChangeInSingleEvent("0:0/1") // dying
+	wc.AssertNoChange()
+
+	err = s.State.RemoveFilesystemAttachment(names.NewMachineTag("0"), names.NewFilesystemTag("0/1"))
+	c.Assert(err, jc.ErrorIsNil)
+	wc.AssertChangeInSingleEvent("0:0/1") // removed
+	wc.AssertNoChange()
+
+	addUnit(m0)
+	wc.AssertChangeInSingleEvent("0:0/7", "0:0/8")
+	wc.AssertNoChange()
 }
 
 func (s *FilesystemStateSuite) TestParseFilesystemAttachmentId(c *gc.C) {

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -260,22 +260,22 @@ func (st *State) watchEnvironMachineStorageAttachments(collection string) String
 
 // WatchMachineVolumeAttachments returns a StringsWatcher that notifies of
 // changes to the lifecycles of all volume attachments related to the specified
-// machine.
+// machine, for volumes scoped to the machine.
 func (st *State) WatchMachineVolumeAttachments(m names.MachineTag) StringsWatcher {
 	return st.watchMachineStorageAttachments(m, volumeAttachmentsC)
 }
 
 // WatchMachineFilesystemAttachments returns a StringsWatcher that notifies of
 // changes to the lifecycles of all filesystem attachments related to the specified
-// machine.
+// machine, for filesystems scoped to the machine.
 func (st *State) WatchMachineFilesystemAttachments(m names.MachineTag) StringsWatcher {
 	return st.watchMachineStorageAttachments(m, filesystemAttachmentsC)
 }
 
 func (st *State) watchMachineStorageAttachments(m names.MachineTag, collection string) StringsWatcher {
-	pattern := fmt.Sprintf("^%s:.*", st.docID(m.Id()))
+	pattern := fmt.Sprintf("^%s:%s/.*", st.docID(m.Id()), m.Id())
 	members := bson.D{{"_id", bson.D{{"$regex", pattern}}}}
-	prefix := m.Id() + ":"
+	prefix := m.Id() + fmt.Sprintf(":%s/", m.Id())
 	filter := func(id interface{}) bool {
 		k, err := st.strictLocalID(id.(string))
 		if err != nil {


### PR DESCRIPTION
Limits WatchMachineFilesystemAttachments and WatchMachineVolumeAttachments
to machine-scoped volumes/filesystems. When we have storage providers that
do things in both scopes, we'll probably introduce a new scope that allows
both scope workers to obtain relevant details.

Fixes https://bugs.launchpad.net/juju-core/+bug/1483492

(Review request: http://reviews.vapour.ws/r/3129/)