### PR TITLE
Fixed lp:1483879: Use MAAS 1.8+ devices for containers by default

### DIFF
--- a/apiserver/addresser/addresser.go
+++ b/apiserver/addresser/addresser.go
@@ -132,8 +132,8 @@ func (api *AddresserAPI) CleanupIPAddresses() params.ErrorResult {
 
 // netEnvReleaseAddress is used for testability.
 var netEnvReleaseAddress = func(env environs.NetworkingEnviron,
-	instId instance.Id, subnetId network.Id, addr network.Address, macAddress string) error {
-	return env.ReleaseAddress(instId, subnetId, addr, macAddress)
+	instId instance.Id, subnetId network.Id, addr network.Address, macAddress, hostname string) error {
+	return env.ReleaseAddress(instId, subnetId, addr, macAddress, hostname)
 }
 
 // releaseIPAddress releases one IP address.
@@ -146,7 +146,7 @@ func (api *AddresserAPI) releaseIPAddress(netEnv environs.NetworkingEnviron, ipA
 	}
 	// Now release the IP address.
 	subnetId := network.Id(ipAddress.SubnetId())
-	err = netEnvReleaseAddress(netEnv, ipAddress.InstanceId(), subnetId, ipAddress.Address(), ipAddress.MACAddress())
+	err = netEnvReleaseAddress(netEnv, ipAddress.InstanceId(), subnetId, ipAddress.Address(), ipAddress.MACAddress(), "")
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/apiserver/addresser/addresser_test.go
+++ b/apiserver/addresser/addresser_test.go
@@ -152,13 +152,19 @@ func (s *AddresserSuite) TestReleaseAddress(c *gc.C) {
 
 	// Prepare tests.
 	called := 0
-	s.PatchValue(addresser.NetEnvReleaseAddress, func(env environs.NetworkingEnviron,
-		instId instance.Id, subnetId network.Id, addr network.Address, macAddress string) error {
+	s.PatchValue(addresser.NetEnvReleaseAddress, func(
+		env environs.NetworkingEnviron,
+		instId instance.Id,
+		subnetId network.Id,
+		addr network.Address,
+		macAddress, hostname string,
+	) error {
 		called++
 		c.Assert(instId, gc.Equals, instance.Id("a3"))
 		c.Assert(subnetId, gc.Equals, network.Id("a"))
 		c.Assert(addr, gc.Equals, network.NewAddress("0.1.2.3"))
 		c.Assert(macAddress, gc.Equals, "fff3")
+		c.Assert(hostname, gc.Equals, "")
 		return nil
 	})
 

--- a/apiserver/provisioner/container_test.go
+++ b/apiserver/provisioner/container_test.go
@@ -4,7 +4,6 @@
 package provisioner_test
 
 import (
-	"encoding/hex"
 	"fmt"
 	"strings"
 
@@ -152,13 +151,11 @@ func (s *prepareSuite) assertCall(c *gc.C, args params.Entities, expectResults *
 					c.Assert(cfg[j].Address, gc.Matches, rex)
 					expectResults.Results[i].Config[j].Address = cfg[j].Address
 				}
-				macAddress := cfg[j].MACAddress
-				c.Assert(macAddress[:8], gc.Equals, provisioner.MACAddressTemplate[:8])
-				remainder := strings.Replace(macAddress[8:], ":", "", 3)
-				c.Assert(remainder, gc.HasLen, 6)
-				_, err = hex.DecodeString(remainder)
-				c.Assert(err, jc.ErrorIsNil)
-				expectResults.Results[i].Config[j].MACAddress = macAddress
+				if strings.HasPrefix(expCfg.MACAddress, "regex:") {
+					rex := strings.TrimPrefix(expCfg.MACAddress, "regex:")
+					c.Assert(cfg[j].MACAddress, gc.Matches, rex)
+					expectResults.Results[i].Config[j].MACAddress = cfg[j].MACAddress
+				}
 			}
 		}
 
@@ -177,13 +174,19 @@ func (s *prepareSuite) assertCall(c *gc.C, args params.Entities, expectResults *
 	return err, tw.Log()
 }
 
-func (s *prepareSuite) TestErrorWitnNoFeatureFlag(c *gc.C) {
+func (s *prepareSuite) TestErrorWithNoFeatureFlag(c *gc.C) {
 	s.SetFeatureFlags() // clear the flags.
 	container := s.newAPI(c, true, true)
 	args := s.makeArgs(container)
-	s.assertCall(c, args, &params.MachineNetworkConfigResults{},
-		`address allocation not supported`,
-	)
+	expectedError := &params.Error{
+		Message: `failed to allocate an address for "0/lxc/0": address allocation not supported`,
+		Code:    params.CodeNotSupported,
+	}
+	s.assertCall(c, args, &params.MachineNetworkConfigResults{
+		Results: []params.MachineNetworkConfigResult{
+			{Error: expectedError},
+		},
+	}, "")
 }
 
 func (s *prepareSuite) TestErrorWithNonProvisionedHost(c *gc.C) {
@@ -419,8 +422,9 @@ func (s *prepareSuite) TestReleaseAndCleanupWhenAllocateAndOrSetFail(c *gc.C) {
 	// are called along with the addresses to verify the logs later.
 	var allocAttemptedAddrs, allocAddrsOK, setAddrs, releasedAddrs []string
 	s.PatchValue(provisioner.AllocateAddrTo, func(ip *state.IPAddress, m *state.Machine, mac string) error {
-		c.Logf("allocateAddrTo called for address %q, machine %q", ip.String(), m)
+		c.Logf("allocateAddrTo called for address %q, machine %q, mac %q", ip.String(), m, mac)
 		c.Assert(m.Id(), gc.Equals, container.Id())
+		c.Assert(mac, gc.Matches, "([a-f0-9]{2}:){5}[a-f0-9]{2}")
 		allocAttemptedAddrs = append(allocAttemptedAddrs, ip.Value())
 
 		// Succeed on every other call to give a chance to call
@@ -523,6 +527,7 @@ func (s *prepareSuite) TestReleaseAndRetryWhenSetOnlyFails(c *gc.C) {
 		DeviceIndex:      0,
 		InterfaceName:    "eth0",
 		VLANTag:          0,
+		MACAddress:       "regex:([a-f0-9]{2}:){5}[a-f0-9]{2}",
 		Disabled:         false,
 		NoAutoStart:      false,
 		ConfigType:       "static",
@@ -604,6 +609,7 @@ func (s *prepareSuite) TestSuccessWithSingleContainer(c *gc.C) {
 		DeviceIndex:      0,
 		InterfaceName:    "eth0",
 		VLANTag:          0,
+		MACAddress:       "regex:([a-f0-9]{2}:){5}[a-f0-9]{2}",
 		Disabled:         false,
 		NoAutoStart:      false,
 		ConfigType:       "static",
@@ -640,6 +646,7 @@ func (s *prepareSuite) TestSuccessWhenFirstSubnetNotAllocatable(c *gc.C) {
 		DeviceIndex:      1,
 		InterfaceName:    "eth1",
 		VLANTag:          1,
+		MACAddress:       "regex:([a-f0-9]{2}:){5}[a-f0-9]{2}",
 		Disabled:         false,
 		NoAutoStart:      true,
 		ConfigType:       "static",
@@ -713,9 +720,12 @@ func (s *releaseSuite) TestErrorWithNoFeatureFlag(c *gc.C) {
 	s.SetFeatureFlags() // clear the flags.
 	s.newAPI(c, true, false)
 	args := s.makeArgs(s.machines[0])
-	s.assertCall(c, args, &params.ErrorResults{},
-		"address allocation not supported",
-	)
+	expectedError := `cannot mark addresses for removal for "machine-0": not a container`
+	s.assertCall(c, args, &params.ErrorResults{
+		Results: []params.ErrorResult{{
+			Error: apiservertesting.ServerError(expectedError),
+		}},
+	}, "")
 }
 
 func (s *releaseSuite) TestErrorWithHostInsteadOfContainer(c *gc.C) {

--- a/apiserver/provisioner/container_test.go
+++ b/apiserver/provisioner/container_test.go
@@ -29,6 +29,8 @@ type containerSuite struct {
 	provAPI *provisioner.ProvisionerAPI
 }
 
+const regexpMACAddress = "([a-f0-9]{2}:){5}[a-f0-9]{2}"
+
 func (s *containerSuite) SetUpTest(c *gc.C) {
 	s.setUpTest(c, false)
 	// Reset any "broken" dummy provider methods.
@@ -424,7 +426,7 @@ func (s *prepareSuite) TestReleaseAndCleanupWhenAllocateAndOrSetFail(c *gc.C) {
 	s.PatchValue(provisioner.AllocateAddrTo, func(ip *state.IPAddress, m *state.Machine, mac string) error {
 		c.Logf("allocateAddrTo called for address %q, machine %q, mac %q", ip.String(), m, mac)
 		c.Assert(m.Id(), gc.Equals, container.Id())
-		c.Assert(mac, gc.Matches, "([a-f0-9]{2}:){5}[a-f0-9]{2}")
+		c.Assert(mac, gc.Matches, regexpMACAddress)
 		allocAttemptedAddrs = append(allocAttemptedAddrs, ip.Value())
 
 		// Succeed on every other call to give a chance to call
@@ -527,7 +529,7 @@ func (s *prepareSuite) TestReleaseAndRetryWhenSetOnlyFails(c *gc.C) {
 		DeviceIndex:      0,
 		InterfaceName:    "eth0",
 		VLANTag:          0,
-		MACAddress:       "regex:([a-f0-9]{2}:){5}[a-f0-9]{2}",
+		MACAddress:       "regex:" + regexpMACAddress,
 		Disabled:         false,
 		NoAutoStart:      false,
 		ConfigType:       "static",
@@ -609,7 +611,7 @@ func (s *prepareSuite) TestSuccessWithSingleContainer(c *gc.C) {
 		DeviceIndex:      0,
 		InterfaceName:    "eth0",
 		VLANTag:          0,
-		MACAddress:       "regex:([a-f0-9]{2}:){5}[a-f0-9]{2}",
+		MACAddress:       "regex:" + regexpMACAddress,
 		Disabled:         false,
 		NoAutoStart:      false,
 		ConfigType:       "static",
@@ -646,7 +648,7 @@ func (s *prepareSuite) TestSuccessWhenFirstSubnetNotAllocatable(c *gc.C) {
 		DeviceIndex:      1,
 		InterfaceName:    "eth1",
 		VLANTag:          1,
-		MACAddress:       "regex:([a-f0-9]{2}:){5}[a-f0-9]{2}",
+		MACAddress:       "regex:" + regexpMACAddress,
 		Disabled:         false,
 		NoAutoStart:      true,
 		ConfigType:       "static",

--- a/apiserver/provisioner/provisioner.go
+++ b/apiserver/provisioner/provisioner.go
@@ -1051,6 +1051,10 @@ func (p *ProvisionerAPI) prepareOrGetContainerInterfaceInfo(
 						InterfaceName: "eth0",
 						ConfigType:    string(network.ConfigDHCP),
 						MACAddress:    macAddress,
+						// The following should not be needed anymore, but the
+						// worker still validates them on SetProvisioned.
+						NetworkName: network.DefaultPrivate,
+						ProviderId:  network.DefaultPrivate,
 					}},
 				}
 				continue

--- a/apiserver/provisioner/provisioner.go
+++ b/apiserver/provisioner/provisioner.go
@@ -828,6 +828,10 @@ func (p *ProvisionerAPI) WatchMachineErrorRetry() (params.NotifyWatchResult, err
 	return result, nil
 }
 
+func containerHostname(containerTag names.Tag) string {
+	return fmt.Sprintf("%s-%s", container.DefaultNamespace, containerTag.String())
+}
+
 // ReleaseContainerAddresses finds addresses allocated to a container
 // and marks them as Dead, to be released and removed. It accepts
 // container tags as arguments. If address allocation feature flag is
@@ -837,8 +841,10 @@ func (p *ProvisionerAPI) ReleaseContainerAddresses(args params.Entities) (params
 		Results: make([]params.ErrorResult, len(args.Entities)),
 	}
 
-	if !environs.AddressAllocationEnabled() {
-		return result, errors.NotSupportedf("address allocation")
+	logger.Tracef("checking if the environment supports releasing addresses")
+	netEnviron, err := p.maybeGetNetworkingEnviron()
+	if err != nil {
+		return result, errors.Trace(err)
 	}
 
 	canAccess, err := p.getAuthFunc()
@@ -868,6 +874,32 @@ func (p *ProvisionerAPI) ReleaseContainerAddresses(args params.Entities) (params
 			result.Results[i].Error = common.ServerError(err)
 			continue
 		}
+
+		if !environs.AddressAllocationEnabled() {
+			logger.Tracef("trying to release all addresses for container %q", container.Id())
+			// Even if the address allocation feature flag is not enabled, we
+			// might be running on MAAS 1.8+ with devices support, which we
+			// detected earlier when the container has started and registered a
+			// device for it. Now we can just call ReleaseAddress with the
+			// hostname set and the rest left empty.
+			zeroIP, zeroMAC := network.Address{}, ""
+			hostname := containerHostname(container.Tag())
+			err := netEnviron.ReleaseAddress(
+				instance.UnknownId,
+				network.AnySubnet,
+				zeroIP,
+				zeroMAC,
+				hostname,
+			)
+			logger.Tracef("ReleaseAddress for hostname %q returned: %v", hostname, err)
+			if err != nil && errors.IsNotSupported(err) {
+				// Not using MAAS 1.8+, just record the error.
+				result.Results[i].Error = common.ServerError(err)
+			}
+			continue
+		}
+		// With addressable containers feature flag enabled, the addresser will
+		// release the IPs once they are set to dead.
 
 		id := container.Id()
 		addresses, err := p.st.AllocatedIPAddresses(id)
@@ -919,6 +951,9 @@ const MACAddressTemplate = "00:16:3e:%02x:%02x:%02x"
 
 // generateMACAddress creates a random MAC address within the space defined by
 // MACAddressTemplate above.
+//
+// TODO(dimitern): We should make a best effort to ensure the MAC address we
+// generate is unique at least within the current environment.
 func generateMACAddress() string {
 	digits := make([]interface{}, 3)
 	for i := range digits {
@@ -930,14 +965,14 @@ func generateMACAddress() string {
 // prepareOrGetContainerInterfaceInfo optionally allocates an address and returns information
 // for configuring networking on a container. It accepts container tags as arguments.
 func (p *ProvisionerAPI) prepareOrGetContainerInterfaceInfo(
-	args params.Entities, provisionContainer bool) (
-	params.MachineNetworkConfigResults, error) {
+	args params.Entities,
+	provisionContainer bool,
+) (
+	params.MachineNetworkConfigResults,
+	error,
+) {
 	result := params.MachineNetworkConfigResults{
 		Results: make([]params.MachineNetworkConfigResult, len(args.Entities)),
-	}
-
-	if !environs.AddressAllocationEnabled() {
-		return result, errors.NotSupportedf("address allocation")
 	}
 
 	// Some preparations first.
@@ -953,9 +988,15 @@ func (p *ProvisionerAPI) prepareOrGetContainerInterfaceInfo(
 		err = errors.NotProvisionedf("cannot allocate addresses: host machine %q", host)
 		return result, err
 	}
-	subnet, subnetInfo, interfaceInfo, err := p.prepareAllocationNetwork(environ, host, instId)
-	if err != nil {
-		return result, errors.Annotate(err, "cannot allocate addresses")
+	var subnet *state.Subnet
+	var subnetInfo network.SubnetInfo
+	var interfaceInfo network.InterfaceInfo
+	if environs.AddressAllocationEnabled() {
+		// We don't need a subnet unless we need to allocate a static IP.
+		subnet, subnetInfo, interfaceInfo, err = p.prepareAllocationNetwork(environ, host, instId)
+		if err != nil {
+			return result, errors.Annotate(err, "cannot allocate addresses")
+		}
 	}
 
 	// Loop over the passed container tags.
@@ -993,12 +1034,25 @@ func (p *ProvisionerAPI) prepareOrGetContainerInterfaceInfo(
 		var macAddress string
 		var address *state.IPAddress
 		if provisionContainer {
-			// Allocate and set address.
+			// Allocate and set an address.
 			macAddress = generateMACAddress()
 			address, err = p.allocateAddress(environ, subnet, host, container, instId, macAddress)
 			if err != nil {
 				err = errors.Annotatef(err, "failed to allocate an address for %q", container)
 				result.Results[i].Error = common.ServerError(err)
+				continue
+			}
+			if address == nil && !environs.AddressAllocationEnabled() {
+				// Container will use DHCP to get its IP, and it needs to use
+				// the generated MAC address.
+				result.Results[i] = params.MachineNetworkConfigResult{
+					Config: []params.NetworkConfig{{
+						DeviceIndex:   0,
+						InterfaceName: "eth0",
+						ConfigType:    string(network.ConfigDHCP),
+						MACAddress:    macAddress,
+					}},
+				}
 				continue
 			}
 		} else {
@@ -1057,21 +1111,29 @@ func (p *ProvisionerAPI) prepareOrGetContainerInterfaceInfo(
 	return result, nil
 }
 
-// prepareContainerAccessEnvironment retrieves the environment, host machine, and access
-// for working with containers.
-func (p *ProvisionerAPI) prepareContainerAccessEnvironment() (environs.NetworkingEnviron, *state.Machine, common.AuthFunc, error) {
+func (p *ProvisionerAPI) maybeGetNetworkingEnviron() (environs.NetworkingEnviron, error) {
 	cfg, err := p.st.EnvironConfig()
 	if err != nil {
-		return nil, nil, nil, errors.Annotate(err, "failed to get environment config")
+		return nil, errors.Annotate(err, "failed to get environment config")
 	}
 	environ, err := environs.New(cfg)
 	if err != nil {
-		return nil, nil, nil, errors.Annotate(err, "failed to construct an environment from config")
+		return nil, errors.Annotate(err, "failed to construct an environment from config")
 	}
 	netEnviron, supported := environs.SupportsNetworking(environ)
 	if !supported {
 		// " not supported" will be appended to the message below.
-		return nil, nil, nil, errors.NotSupportedf("environment %q networking", cfg.Name())
+		return nil, errors.NotSupportedf("environment %q networking", cfg.Name())
+	}
+	return netEnviron, nil
+}
+
+// prepareContainerAccessEnvironment retrieves the environment, host machine, and access
+// for working with containers.
+func (p *ProvisionerAPI) prepareContainerAccessEnvironment() (environs.NetworkingEnviron, *state.Machine, common.AuthFunc, error) {
+	netEnviron, err := p.maybeGetNetworkingEnviron()
+	if err != nil {
+		return nil, nil, nil, errors.Trace(err)
 	}
 
 	canAccess, err := p.getAuthFunc()
@@ -1204,9 +1266,25 @@ func (p *ProvisionerAPI) allocateAddress(
 	instId instance.Id,
 	macAddress string,
 ) (*state.IPAddress, error) {
+	hostname := containerHostname(container.Tag())
+
+	if !environs.AddressAllocationEnabled() {
+		// Even if the address allocation feature flag is not enabled, we might
+		// be running on MAAS 1.8+ with devices support, which we can use to
+		// register containers getting IPs via DHCP. However, most of the usual
+		// allocation code can be bypassed, we just need the parent instance ID
+		// and a MAC address (no subnet or IP address).
+		zeroIP := network.Address{}
+		err := environ.AllocateAddress(instId, network.AnySubnet, zeroIP, macAddress, hostname)
+		if err != nil && errors.IsNotSupported(err) {
+			// Not using MAAS 1.8+.
+			return nil, errors.Trace(err)
+		}
+		// No address to return since the container will be using DHCP.
+		return nil, nil
+	}
 
 	subnetId := network.Id(subnet.ProviderId())
-	name := names.NewMachineTag(container.Id()).String()
 	for {
 		addr, err := subnet.PickNewAddress()
 		if err != nil {
@@ -1214,7 +1292,7 @@ func (p *ProvisionerAPI) allocateAddress(
 		}
 		logger.Tracef("picked new address %q on subnet %q", addr.String(), subnetId)
 		// Attempt to allocate with environ.
-		err = environ.AllocateAddress(instId, subnetId, addr.Address(), macAddress, name)
+		err = environ.AllocateAddress(instId, subnetId, addr.Address(), macAddress, hostname)
 		if err != nil {
 			logger.Warningf(
 				"allocating address %q on instance %q and subnet %q failed: %v (retrying)",
@@ -1278,7 +1356,7 @@ func (p *ProvisionerAPI) setAllocatedOrRelease(
 				addr.String(), state.AddressStateUnavailable, err,
 			)
 		}
-		err = environ.ReleaseAddress(instId, subnetId, addr.Address(), addr.MACAddress())
+		err = environ.ReleaseAddress(instId, subnetId, addr.Address(), addr.MACAddress(), "")
 		if err == nil {
 			logger.Infof("address %q released; trying to allocate new", addr.String())
 			return

--- a/container/lxc/lxc.go
+++ b/container/lxc/lxc.go
@@ -852,7 +852,8 @@ const singleNICTemplate = `
 lxc.network.type = {{.Type}}
 lxc.network.link = {{.Link}}
 lxc.network.flags = up{{if .MTU}}
-lxc.network.mtu = {{.MTU}}{{end}}
+lxc.network.mtu = {{.MTU}}{{end}}{{if .MACAddress}}
+lxc.network.hwaddr = {{.MACAddress}}{{end}}
 
 `
 
@@ -862,8 +863,8 @@ const multipleNICsTemplate = `
 lxc.network.type = {{$nic.Type}}{{if $nic.VLANTag}}
 lxc.network.vlan.id = {{$nic.VLANTag}}{{end}}
 lxc.network.link = {{$nic.Link}}{{if not $nic.NoAutoStart}}
-lxc.network.flags = up{{end}}
-lxc.network.name = {{$nic.Name}}{{if $nic.MACAddress}}
+lxc.network.flags = up{{end}}{{if $nic.Name}}
+lxc.network.name = {{$nic.Name}}{{end}}{{if $nic.MACAddress}}
 lxc.network.hwaddr = {{$nic.MACAddress}}{{end}}{{if $nic.IPv4Address}}
 lxc.network.ipv4 = {{$nic.IPv4Address}}{{end}}{{if $nic.IPv4Gateway}}
 lxc.network.ipv4.gateway = {{$nic.IPv4Gateway}}{{end}}{{if $mtu}}
@@ -886,8 +887,10 @@ func networkConfigTemplate(config container.NetworkConfig) string {
 	type configData struct {
 		Type       string
 		Link       string
-		MTU        int
 		Interfaces []nicData
+		// The following are used only with a single NIC config.
+		MTU        int
+		MACAddress string
 	}
 	data := configData{
 		Link: config.Device,

--- a/environs/networking.go
+++ b/environs/networking.go
@@ -20,7 +20,7 @@ type Networking interface {
 
 	// ReleaseAddress releases a specific address previously allocated with
 	// AllocateAddress.
-	ReleaseAddress(instId instance.Id, subnetId network.Id, addr network.Address, macAddress string) error
+	ReleaseAddress(instId instance.Id, subnetId network.Id, addr network.Address, macAddress, hostname string) error
 
 	// Subnets returns basic information about subnets known
 	// by the provider for the environment.

--- a/juju/deploy.go
+++ b/juju/deploy.go
@@ -114,16 +114,18 @@ func addMachineForUnit(st *state.State, unit *state.Unit, placement *instance.Pl
 		return nil, err
 	}
 	var containerType instance.ContainerType
-	var mid, placementDirective string
+	var hostMachineID, placementDirective string
 	// Extract container type and parent from container placement directives.
 	if containerType, err = instance.ParseContainerType(placement.Scope); err == nil {
-		mid = placement.Directive
+		// Use a new container on an existing host machine.
+		hostMachineID = placement.Directive
 	} else {
+		// Use a new or existing machine (not a container).
 		switch placement.Scope {
 		case st.EnvironUUID():
 			placementDirective = placement.Directive
 		case instance.MachineScope:
-			mid = placement.Directive
+			hostMachineID = placement.Directive
 		default:
 			return nil, errors.Errorf("invalid environment UUID %q", placement.Scope)
 		}
@@ -131,33 +133,40 @@ func addMachineForUnit(st *state.State, unit *state.Unit, placement *instance.Pl
 
 	// Create any new machine marked as dirty so that
 	// nothing else will grab it before we assign the unit to it.
+	hostTemplate := state.MachineTemplate{
+		Series:            unit.Series(),
+		Jobs:              []state.MachineJob{state.JobHostUnits},
+		Dirty:             true,
+		Constraints:       *unitCons,
+		RequestedNetworks: networks,
+		Placement:         placementDirective,
+	}
 
 	// If a container is to be used, create it.
 	if containerType != "" {
-		template := state.MachineTemplate{
+		containerTemplate := state.MachineTemplate{
 			Series:            unit.Series(),
 			Jobs:              []state.MachineJob{state.JobHostUnits},
 			Dirty:             true,
 			Constraints:       *unitCons,
 			RequestedNetworks: networks,
 		}
-		return st.AddMachineInsideMachine(template, mid, containerType)
+		if hostMachineID != "" {
+			// Create a new container on an existing parent machine.
+			return st.AddMachineInsideMachine(containerTemplate, hostMachineID, containerType)
+		}
+		// Create a new parent machine, and a new container inside it.
+		return st.AddMachineInsideNewMachine(containerTemplate, hostTemplate, containerType)
 	}
+
 	// If a placement directive is to be used, do that here.
 	if placementDirective != "" {
-		template := state.MachineTemplate{
-			Series:            unit.Series(),
-			Jobs:              []state.MachineJob{state.JobHostUnits},
-			Dirty:             true,
-			Constraints:       *unitCons,
-			RequestedNetworks: networks,
-			Placement:         placementDirective,
-		}
-		return st.AddOneMachine(template)
+		// Create a new host machine.
+		return st.AddOneMachine(hostTemplate)
 	}
 
 	// Otherwise use an existing machine.
-	return st.Machine(mid)
+	return st.Machine(hostMachineID)
 }
 
 // AddUnits starts n units of the given service and allocates machines

--- a/juju/deploy_test.go
+++ b/juju/deploy_test.go
@@ -226,11 +226,12 @@ func (s *DeployLocalSuite) TestDeployWithPlacement(c *gc.C) {
 			ServiceName: "bob",
 			Charm:       s.charm,
 			Constraints: serviceCons,
-			NumUnits:    3,
+			NumUnits:    4,
 			Placement: []*instance.Placement{
 				{Scope: s.State.EnvironUUID(), Directive: "valid"},
 				{Scope: "#", Directive: "0"},
 				{Scope: "lxc", Directive: "1"},
+				{Scope: "lxc", Directive: ""},
 			},
 			ToMachineSpec: "will be ignored",
 		})
@@ -238,12 +239,13 @@ func (s *DeployLocalSuite) TestDeployWithPlacement(c *gc.C) {
 	s.assertConstraints(c, service, serviceCons)
 	units, err := service.AllUnits()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(units, gc.HasLen, 3)
+	c.Assert(units, gc.HasLen, 4)
 
 	// Check each of the newly added units.
 	s.assertAssignedUnit(c, units[0], "1", constraints.MustParse("mem=2G cpu-cores=2"))
 	s.assertAssignedUnit(c, units[1], "0", constraints.Value{})
 	s.assertAssignedUnit(c, units[2], "1/lxc/0", constraints.MustParse("mem=2G cpu-cores=2"))
+	s.assertAssignedUnit(c, units[3], "2/lxc/0", constraints.MustParse("mem=2G cpu-cores=2"))
 }
 
 func (s *DeployLocalSuite) TestDeployWithFewerPlacement(c *gc.C) {

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -165,8 +165,8 @@ type OpAllocateAddress struct {
 	InstanceId instance.Id
 	SubnetId   network.Id
 	Address    network.Address
-	HostName   string
 	MACAddress string
+	HostName   string
 }
 
 type OpReleaseAddress struct {
@@ -175,6 +175,7 @@ type OpReleaseAddress struct {
 	SubnetId   network.Id
 	Address    network.Address
 	MACAddress string
+	HostName   string
 }
 
 type OpNetworkInterfaces struct {
@@ -1130,7 +1131,7 @@ func (env *environ) AllocateAddress(instId instance.Id, subnetId network.Id, add
 
 // ReleaseAddress releases a specific address previously allocated with
 // AllocateAddress.
-func (env *environ) ReleaseAddress(instId instance.Id, subnetId network.Id, addr network.Address, macAddress string) error {
+func (env *environ) ReleaseAddress(instId instance.Id, subnetId network.Id, addr network.Address, macAddress, hostname string) error {
 	if !environs.AddressAllocationEnabled() {
 		return errors.NotSupportedf("address allocation")
 	}
@@ -1151,6 +1152,7 @@ func (env *environ) ReleaseAddress(instId instance.Id, subnetId network.Id, addr
 		SubnetId:   subnetId,
 		Address:    addr,
 		MACAddress: macAddress,
+		HostName:   hostname,
 	}
 	return nil
 }

--- a/provider/dummy/environs_test.go
+++ b/provider/dummy/environs_test.go
@@ -265,25 +265,26 @@ func (s *suite) TestReleaseAddress(c *gc.C) {
 	// Release a couple of addresses.
 	address := network.NewScopedAddress("0.1.2.1", network.ScopeCloudLocal)
 	macAddress := "foobar"
-	err := e.ReleaseAddress(inst.Id(), subnetId, address, macAddress)
+	hostname := "myhostname"
+	err := e.ReleaseAddress(inst.Id(), subnetId, address, macAddress, hostname)
 	c.Assert(err, jc.ErrorIsNil)
-	assertReleaseAddress(c, e, opc, inst.Id(), subnetId, address, macAddress)
+	assertReleaseAddress(c, e, opc, inst.Id(), subnetId, address, macAddress, hostname)
 
 	address = network.NewScopedAddress("0.1.2.2", network.ScopeCloudLocal)
-	err = e.ReleaseAddress(inst.Id(), subnetId, address, macAddress)
+	err = e.ReleaseAddress(inst.Id(), subnetId, address, macAddress, hostname)
 	c.Assert(err, jc.ErrorIsNil)
-	assertReleaseAddress(c, e, opc, inst.Id(), subnetId, address, macAddress)
+	assertReleaseAddress(c, e, opc, inst.Id(), subnetId, address, macAddress, hostname)
 
 	// Test we can induce errors.
 	s.breakMethods(c, e, "ReleaseAddress")
 	address = network.NewScopedAddress("0.1.2.3", network.ScopeCloudLocal)
-	err = e.ReleaseAddress(inst.Id(), subnetId, address, macAddress)
+	err = e.ReleaseAddress(inst.Id(), subnetId, address, macAddress, hostname)
 	c.Assert(err, gc.ErrorMatches, `dummy\.ReleaseAddress is broken`)
 
 	// Finally, test the method respects the feature flag when
 	// disabled.
 	s.SetFeatureFlags() // clear the flags.
-	err = e.ReleaseAddress(inst.Id(), subnetId, address, macAddress)
+	err = e.ReleaseAddress(inst.Id(), subnetId, address, macAddress, hostname)
 	c.Assert(err, gc.ErrorMatches, "address allocation not supported")
 	c.Assert(err, jc.Satisfies, errors.IsNotSupported)
 }
@@ -549,7 +550,16 @@ func (s *suite) TestPreferIPv6Off(c *gc.C) {
 	c.Assert(addrs, jc.DeepEquals, network.NewAddresses("only-0.dns", "127.0.0.1"))
 }
 
-func assertAllocateAddress(c *gc.C, e environs.Environ, opc chan dummy.Operation, expectInstId instance.Id, expectSubnetId network.Id, expectAddress network.Address, expectMAC, expectHostName string) {
+func assertAllocateAddress(
+	c *gc.C,
+	e environs.Environ,
+	opc chan dummy.Operation,
+	expectInstId instance.Id,
+	expectSubnetId network.Id,
+	expectAddress network.Address,
+	expectMAC string,
+	expectHost string,
+) {
 	select {
 	case op := <-opc:
 		addrOp, ok := op.(dummy.OpAllocateAddress)
@@ -560,14 +570,23 @@ func assertAllocateAddress(c *gc.C, e environs.Environ, opc chan dummy.Operation
 		c.Check(addrOp.InstanceId, gc.Equals, expectInstId)
 		c.Check(addrOp.Address, gc.Equals, expectAddress)
 		c.Check(addrOp.MACAddress, gc.Equals, expectMAC)
-		c.Check(addrOp.HostName, gc.Equals, expectHostName)
+		c.Check(addrOp.HostName, gc.Equals, expectHost)
 		return
 	case <-time.After(testing.ShortWait):
 		c.Fatalf("time out wating for operation")
 	}
 }
 
-func assertReleaseAddress(c *gc.C, e environs.Environ, opc chan dummy.Operation, expectInstId instance.Id, expectSubnetId network.Id, expectAddress network.Address, macAddress string) {
+func assertReleaseAddress(
+	c *gc.C,
+	e environs.Environ,
+	opc chan dummy.Operation,
+	expectInstId instance.Id,
+	expectSubnetId network.Id,
+	expectAddress network.Address,
+	expectMAC string,
+	expectHost string,
+) {
 	select {
 	case op := <-opc:
 		addrOp, ok := op.(dummy.OpReleaseAddress)
@@ -577,7 +596,8 @@ func assertReleaseAddress(c *gc.C, e environs.Environ, opc chan dummy.Operation,
 		c.Check(addrOp.SubnetId, gc.Equals, expectSubnetId)
 		c.Check(addrOp.InstanceId, gc.Equals, expectInstId)
 		c.Check(addrOp.Address, gc.Equals, expectAddress)
-		c.Check(addrOp.MACAddress, gc.Equals, macAddress)
+		c.Check(addrOp.MACAddress, gc.Equals, expectMAC)
+		c.Check(addrOp.HostName, gc.Equals, expectHost)
 		return
 	case <-time.After(testing.ShortWait):
 		c.Fatalf("time out wating for operation")

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -941,7 +941,7 @@ func (e *environ) AllocateAddress(instId instance.Id, _ network.Id, addr network
 
 // ReleaseAddress releases a specific address previously allocated with
 // AllocateAddress. Implements NetworkingEnviron.ReleaseAddress.
-func (e *environ) ReleaseAddress(instId instance.Id, _ network.Id, addr network.Address, _ string) (err error) {
+func (e *environ) ReleaseAddress(instId instance.Id, _ network.Id, addr network.Address, _, _ string) (err error) {
 	if !environs.AddressAllocationEnabled() {
 		return errors.NotSupportedf("address allocation")
 	}

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -929,12 +929,12 @@ func (t *localServerSuite) TestReleaseAddress(c *gc.C) {
 	err := env.AllocateAddress(instId, "", addr, "foo", "bar")
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = env.ReleaseAddress(instId, "", addr, "")
+	err = env.ReleaseAddress(instId, "", addr, "", "")
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Releasing a second time tests that the first call actually released
 	// it plus tests the error handling of ReleaseAddress
-	err = env.ReleaseAddress(instId, "", addr, "")
+	err = env.ReleaseAddress(instId, "", addr, "", "")
 	msg := fmt.Sprintf(`failed to release address "8\.0\.0\.4" from instance %q.*`, instId)
 	c.Assert(err, gc.ErrorMatches, msg)
 }
@@ -945,7 +945,7 @@ func (t *localServerSuite) TestReleaseAddressUnknownInstance(c *gc.C) {
 	// We should be able to release an address with an unknown instance id
 	// without it being allocated.
 	addr := network.Address{Value: "8.0.0.4"}
-	err := env.ReleaseAddress(instance.UnknownId, "", addr, "")
+	err := env.ReleaseAddress(instance.UnknownId, "", addr, "", "")
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -1113,7 +1113,7 @@ func (t *localServerSuite) TestAllocateAddressWithNoFeatureFlag(c *gc.C) {
 func (t *localServerSuite) TestReleaseAddressWithNoFeatureFlag(c *gc.C) {
 	t.SetFeatureFlags() // clear the flags.
 	env := t.prepareEnviron(c)
-	err := env.ReleaseAddress("i-foo", "net1", network.NewAddress("1.2.3.4"), "")
+	err := env.ReleaseAddress("i-foo", "net1", network.NewAddress("1.2.3.4"), "", "")
 	c.Assert(err, gc.ErrorMatches, "address allocation not supported")
 	c.Assert(err, jc.Satisfies, errors.IsNotSupported)
 }

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -78,7 +78,9 @@ func reserveIPAddress(ipaddresses gomaasapi.MAASObject, cidr string, addr networ
 func reserveIPAddressOnDevice(devices gomaasapi.MAASObject, deviceId string, addr network.Address) error {
 	device := devices.GetSubObject(deviceId)
 	params := url.Values{}
-	params.Add("requested_address", addr.Value)
+	if addr.Value != "" {
+		params.Add("requested_address", addr.Value)
+	}
 	_, err := device.CallPost("claim_sticky_ip_address", params)
 	return err
 
@@ -111,6 +113,10 @@ type maasEnviron struct {
 
 	availabilityZonesMutex sync.Mutex
 	availabilityZones      []common.AvailabilityZone
+
+	// The following are initialized from the discovered MAAS API capabilities.
+	supportsDevices   bool
+	supportsStaticIPs bool
 }
 
 var _ environs.Environ = (*maasEnviron)(nil)
@@ -123,8 +129,28 @@ func NewEnviron(cfg *config.Config) (*maasEnviron, error) {
 	}
 	env.name = cfg.Name()
 	env.storageUnlocked = NewStorage(env)
+
+	// Since we need to switch behavior based on the available API capabilities,
+	// get them as soon as possible and cache them.
+	capabilities, err := env.getCapabilities()
+	if err != nil {
+		logger.Warningf("cannot get MAAS API capabilities: %v", err)
+	}
+	logger.Debugf("MAAS API capabilities: %v", capabilities.SortedValues())
+	env.supportsDevices = capabilities.Contains(capDevices)
+	env.supportsStaticIPs = capabilities.Contains(capStaticIPAddresses)
 	return env, nil
 }
+
+const noDevicesWarning = `
+WARNING: Using MAAS version older than 1.8.2: devices API support not detected!
+
+Juju cannot guarantee resources allocated to containers, like DHCP
+leases or static IP addresses will be properly cleaned up when the
+container, its host, or the environment is destroyed.
+
+Juju recommends upgrading MAAS to version 1.8.2 or later.
+`
 
 // Bootstrap is specified in the Environ interface.
 func (env *maasEnviron) Bootstrap(ctx environs.BootstrapContext, args environs.BootstrapParams) (arch, series string, _ environs.BootstrapFinalizer, _ error) {
@@ -138,6 +164,11 @@ func (env *maasEnviron) Bootstrap(ctx environs.BootstrapContext, args environs.B
 			instancecfg.DefaultBridgeName,
 		)
 		args.ContainerBridgeName = instancecfg.DefaultBridgeName
+
+		if !env.supportsDevices {
+			// Inform the user container resources might leak.
+			ctx.Infof("WARNING: %s", noDevicesWarning)
+		}
 	} else {
 		logger.Debugf(
 			"address allocation feature enabled; using static IPs for containers: %q",
@@ -249,14 +280,14 @@ func (env *maasEnviron) SupportsSpaces() (bool, error) {
 // SupportsAddressAllocation is specified on environs.Networking.
 func (env *maasEnviron) SupportsAddressAllocation(_ network.Id) (bool, error) {
 	if !environs.AddressAllocationEnabled() {
-		return false, errors.NotSupportedf("address allocation")
+		if !env.supportsDevices {
+			return false, errors.NotSupportedf("address allocation")
+		}
+		// We can use devices for DHCP-allocated container IPs.
+		return true, nil
 	}
 
-	caps, err := env.getCapabilities()
-	if err != nil {
-		return false, errors.Annotatef(err, "getCapabilities failed")
-	}
-	return caps.Contains(capStaticIPAddresses), nil
+	return env.supportsStaticIPs, nil
 }
 
 // allBootImages queries MAAS for all of the boot-images across
@@ -537,14 +568,6 @@ const (
 	capStaticIPAddresses  = "static-ipaddresses"
 	capDevices            = "devices-management"
 )
-
-func (env *maasEnviron) supportsDevices() (bool, error) {
-	caps, err := env.getCapabilities()
-	if err != nil {
-		return false, errors.Trace(err)
-	}
-	return caps.Contains(capDevices), nil
-}
 
 // getCapabilities asks the MAAS server for its capabilities, if
 // supported by the server.
@@ -1437,16 +1460,22 @@ func (environ *maasEnviron) newDevice(macAddress string, instId instance.Id, hos
 	if err != nil {
 		return "", errors.Trace(err)
 	}
+	logger.Tracef("created device %q", device)
 	return device, nil
 }
 
-// fetchFullDevice fetches an existing device Id associated with a MAC address, or
-// returns an error if there is no device.
-func (environ *maasEnviron) fetchFullDevice(macAddress string) (map[string]gomaasapi.JSONObject, error) {
+// fetchFullDevice fetches an existing device Id associated with a MAC address
+// and/or hostname, or returns an error if there is no device.
+func (environ *maasEnviron) fetchFullDevice(macAddress, hostname string) (map[string]gomaasapi.JSONObject, error) {
 	client := environ.getMAASClient()
 	devices := client.GetSubObject("devices")
 	params := url.Values{}
-	params.Add("mac_address", macAddress)
+	if macAddress != "" {
+		params.Add("mac_address", macAddress)
+	}
+	if hostname != "" {
+		params.Add("hostname", hostname)
+	}
 	result, err := devices.CallGet("list", params)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -1456,7 +1485,7 @@ func (environ *maasEnviron) fetchFullDevice(macAddress string) (map[string]gomaa
 		return nil, errors.Trace(err)
 	}
 	if len(resultArray) == 0 {
-		return nil, errors.NotFoundf("no device for MAC %q", macAddress)
+		return nil, errors.NotFoundf("no device for MAC %q and/or hostname %q", macAddress, hostname)
 	}
 	if len(resultArray) != 1 {
 		return nil, errors.Errorf("unexpected response, expected 1 device got %d", len(resultArray))
@@ -1465,11 +1494,12 @@ func (environ *maasEnviron) fetchFullDevice(macAddress string) (map[string]gomaa
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+	logger.Tracef("device found as %+v", resultMap)
 	return resultMap, nil
 }
 
-func (environ *maasEnviron) fetchDevice(macAddress string) (string, error) {
-	deviceMap, err := environ.fetchFullDevice(macAddress)
+func (environ *maasEnviron) fetchDevice(macAddress, hostname string) (string, error) {
+	deviceMap, err := environ.fetchFullDevice(macAddress, hostname)
 	if err != nil {
 		return "", errors.Trace(err)
 	}
@@ -1484,7 +1514,7 @@ func (environ *maasEnviron) fetchDevice(macAddress string) (string, error) {
 // createOrFetchDevice returns a device Id associated with a MAC address. If
 // there is not already one it will create one.
 func (environ *maasEnviron) createOrFetchDevice(macAddress string, instId instance.Id, hostname string) (string, error) {
-	device, err := environ.fetchDevice(macAddress)
+	device, err := environ.fetchDevice(macAddress, hostname)
 	if err == nil {
 		return device, nil
 	}
@@ -1501,18 +1531,45 @@ func (environ *maasEnviron) createOrFetchDevice(macAddress string, instId instan
 // AllocateAddress requests an address to be allocated for the
 // given instance on the given network.
 func (environ *maasEnviron) AllocateAddress(instId instance.Id, subnetId network.Id, addr network.Address, macAddress, hostname string) (err error) {
+	logger.Tracef(
+		"AllocateAddress for instId %q, subnet %q, addr %q, MAC %q, hostname %q",
+		instId, subnetId, addr, macAddress, hostname,
+	)
+
 	if !environs.AddressAllocationEnabled() {
-		return errors.NotSupportedf("address allocation")
+		if !environ.supportsDevices {
+			logger.Warningf(
+				"resources used by container %q with MAC address %q can leak: devices API not supported",
+				hostname, macAddress,
+			)
+			return errors.NotSupportedf("address allocation")
+		}
+		logger.Tracef("creating device for container %q with MAC %q", hostname, macAddress)
+		deviceID, err := environ.createOrFetchDevice(macAddress, instId, hostname)
+		if err != nil {
+			return errors.Annotatef(
+				err,
+				"creating MAAS device for container %q with MAC address %q",
+				hostname, macAddress,
+			)
+		}
+		logger.Infof(
+			"created device %q for container %q with MAC address %q on parent node %q",
+			deviceID, hostname, macAddress, instId,
+		)
+		devices := environ.getMAASClient().GetSubObject("devices")
+		if err := reserveIPAddressOnDevice(devices, deviceID, network.Address{}); err != nil {
+			return errors.Annotatef(err, "reserving a sticky IP address for device %q", deviceID)
+		}
+		logger.Infof("reserved sticky IP address for device %q representing container %q", deviceID, hostname)
+
+		return nil
 	}
 	defer errors.DeferredAnnotatef(&err, "failed to allocate address %q for instance %q", addr, instId)
 
 	client := environ.getMAASClient()
 	var maasErr gomaasapi.ServerError
-	supportsDevices, err := environ.supportsDevices()
-	if err != nil {
-		return err
-	}
-	if supportsDevices {
+	if environ.supportsDevices {
 		device, err := environ.createOrFetchDevice(macAddress, instId, hostname)
 		if err != nil {
 			return err
@@ -1579,23 +1636,47 @@ func (environ *maasEnviron) AllocateAddress(instId instance.Id, subnetId network
 
 // ReleaseAddress releases a specific address previously allocated with
 // AllocateAddress.
-func (environ *maasEnviron) ReleaseAddress(instId instance.Id, _ network.Id, addr network.Address, macAddress string) (err error) {
+func (environ *maasEnviron) ReleaseAddress(instId instance.Id, _ network.Id, addr network.Address, macAddress, hostname string) (err error) {
 	if !environs.AddressAllocationEnabled() {
-		return errors.NotSupportedf("address allocation")
+		if !environ.supportsDevices {
+			logger.Warningf(
+				"resources used by container %q with MAC address %q can leak: devices API not supported",
+				hostname, macAddress,
+			)
+			return errors.NotSupportedf("address allocation")
+		}
+		logger.Tracef("getting device ID for container %q with MAC %q", macAddress, hostname)
+		deviceID, err := environ.fetchDevice(macAddress, hostname)
+		if err != nil {
+			return errors.Annotatef(
+				err,
+				"getting MAAS device for container %q with MAC address %q",
+				hostname, macAddress,
+			)
+		}
+		logger.Tracef("deleting device %q for container %q", deviceID, hostname)
+		apiDevice := environ.getMAASClient().GetSubObject("devices").GetSubObject(deviceID)
+		if err := apiDevice.Delete(); err != nil {
+			return errors.Annotatef(
+				err,
+				"deleting MAAS device %q for container %q with MAC address %q",
+				deviceID, instId, macAddress,
+			)
+		}
+		logger.Debugf("deleted device %q for container %q with MAC address %q", deviceID, instId, macAddress)
+		return nil
 	}
 
 	defer errors.DeferredAnnotatef(&err, "failed to release IP address %q from instance %q", addr, instId)
 
-	supportsDevices, err := environ.supportsDevices()
-	if err != nil {
-		return err
-	}
-
-	logger.Infof("releasing address: %q, MAC address: %q, supports devices: %v", addr, macAddress, supportsDevices)
+	logger.Infof(
+		"releasing address: %q, MAC address: %q, hostname: %q, supports devices: %v",
+		addr, macAddress, hostname, environ.supportsDevices,
+	)
 	// Addresses originally allocated without a device will have macAddress
 	// set to "". We shouldn't look for a device for these addresses.
-	if supportsDevices && macAddress != "" {
-		device, err := environ.fetchFullDevice(macAddress)
+	if environ.supportsDevices && macAddress != "" {
+		device, err := environ.fetchFullDevice(macAddress, hostname)
 		if err == nil {
 			addresses, err := device["ip_addresses"].GetArray()
 			if err != nil {
@@ -1843,6 +1924,11 @@ func (env *maasEnviron) Storage() storage.Storage {
 }
 
 func (environ *maasEnviron) Destroy() error {
+	if !environ.supportsDevices {
+		// Warn the user that container resources can leak.
+		logger.Warningf(noDevicesWarning)
+	}
+
 	if err := common.Destroy(environ); err != nil {
 		return errors.Trace(err)
 	}

--- a/provider/maas/environ_whitebox_test.go
+++ b/provider/maas/environ_whitebox_test.go
@@ -1365,7 +1365,7 @@ func (suite *environSuite) TestReleaseAddressDeletesDevice(c *gc.C) {
 	devicesArray := suite.getDeviceArray(c)
 	c.Assert(devicesArray, gc.HasLen, 1)
 
-	err = env.ReleaseAddress(testInstance.Id(), "LAN", addr, "foo")
+	err = env.ReleaseAddress(testInstance.Id(), "LAN", addr, "foo", "bar")
 	c.Assert(err, jc.ErrorIsNil)
 
 	devicesArray = suite.getDeviceArray(c)
@@ -1421,12 +1421,13 @@ func (suite *environSuite) TestReleaseAddress(c *gc.C) {
 
 	ipAddress := network.Address{Value: "192.168.2.1"}
 	macAddress := "foobar"
-	err = env.ReleaseAddress(testInstance.Id(), "bar", ipAddress, macAddress)
+	hostname := "myhostname"
+	err = env.ReleaseAddress(testInstance.Id(), "bar", ipAddress, macAddress, hostname)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// by releasing again we can test that the first release worked, *and*
 	// the error handling of ReleaseError
-	err = env.ReleaseAddress(testInstance.Id(), "bar", ipAddress, macAddress)
+	err = env.ReleaseAddress(testInstance.Id(), "bar", ipAddress, macAddress, hostname)
 	expected := fmt.Sprintf("(?s).*failed to release IP address %q from instance %q.*", ipAddress, testInstance.Id())
 	c.Assert(err, gc.ErrorMatches, expected)
 }
@@ -1456,7 +1457,8 @@ func (suite *environSuite) TestReleaseAddressRetry(c *gc.C) {
 	// ReleaseAddress must fail with 5 retries.
 	ipAddress := network.Address{Value: "192.168.2.1"}
 	macAddress := "foobar"
-	err = env.ReleaseAddress(testInstance.Id(), "bar", ipAddress, macAddress)
+	hostname := "myhostname"
+	err = env.ReleaseAddress(testInstance.Id(), "bar", ipAddress, macAddress, hostname)
 	expected := fmt.Sprintf("(?s).*failed to release IP address %q from instance %q: ouch", ipAddress, testInstance.Id())
 	c.Assert(err, gc.ErrorMatches, expected)
 	c.Assert(retries, gc.Equals, 5)
@@ -1464,7 +1466,7 @@ func (suite *environSuite) TestReleaseAddressRetry(c *gc.C) {
 	// Now let it succeed after 3 retries.
 	retries = 0
 	enoughRetries = 3
-	err = env.ReleaseAddress(testInstance.Id(), "bar", ipAddress, macAddress)
+	err = env.ReleaseAddress(testInstance.Id(), "bar", ipAddress, macAddress, hostname)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(retries, gc.Equals, 3)
 }

--- a/provider/vsphere/environ_network.go
+++ b/provider/vsphere/environ_network.go
@@ -18,7 +18,7 @@ func (env *environ) AllocateAddress(instID instance.Id, subnetID network.Id, add
 }
 
 // ReleaseAddress implements environs.Environ.
-func (env *environ) ReleaseAddress(instID instance.Id, netID network.Id, addr network.Address, _ string) error {
+func (env *environ) ReleaseAddress(instID instance.Id, netID network.Id, addr network.Address, _, _ string) error {
 	return env.changeAddress(instID, netID, addr, false)
 }
 

--- a/worker/provisioner/kvm-broker_test.go
+++ b/worker/provisioner/kvm-broker_test.go
@@ -162,6 +162,9 @@ func (s *kvmBrokerSuite) TestStartInstanceAddressAllocationDisabled(c *gc.C) {
 	machineId := "1/kvm/0"
 	kvm := s.startInstance(c, machineId)
 	s.api.CheckCalls(c, []gitjujutesting.StubCall{{
+		FuncName: "PrepareContainerInterfaceInfo",
+		Args:     []interface{}{names.NewMachineTag("1-kvm-0")},
+	}, {
 		FuncName: "ContainerConfig",
 	}})
 	c.Assert(kvm.Id(), gc.Equals, instance.Id("juju-machine-1-kvm-0"))

--- a/worker/provisioner/lxc-broker.go
+++ b/worker/provisioner/lxc-broker.go
@@ -16,6 +16,7 @@ import (
 	"github.com/juju/loggo"
 	"github.com/juju/names"
 	"github.com/juju/utils/exec"
+	"github.com/juju/utils/set"
 
 	"github.com/juju/juju/agent"
 	apiprovisioner "github.com/juju/juju/api/provisioner"
@@ -40,6 +41,7 @@ type APICalls interface {
 	ContainerConfig() (params.ContainerConfig, error)
 	PrepareContainerInterfaceInfo(names.MachineTag) ([]network.InterfaceInfo, error)
 	GetContainerInterfaceInfo(names.MachineTag) ([]network.InterfaceInfo, error)
+	ReleaseContainerAddresses(names.MachineTag) error
 }
 
 var _ APICalls = (*apiprovisioner.State)(nil)
@@ -55,6 +57,7 @@ func newLxcBroker(
 	enableNAT bool,
 	defaultMTU int,
 ) (environs.InstanceBroker, error) {
+	namespace := maybeGetManagerConfigNamespaces(managerConfig)
 	manager, err := lxc.NewContainerManager(
 		managerConfig, imageURLGetter, looputil.NewLoopDeviceManager(),
 	)
@@ -63,6 +66,7 @@ func newLxcBroker(
 	}
 	return &lxcBroker{
 		manager:     manager,
+		namespace:   namespace,
 		api:         api,
 		agentConfig: agentConfig,
 		enableNAT:   enableNAT,
@@ -72,6 +76,7 @@ func newLxcBroker(
 
 type lxcBroker struct {
 	manager     container.Manager
+	namespace   string
 	api         APICalls
 	agentConfig agent.Config
 	enableNAT   bool
@@ -93,28 +98,22 @@ func (broker *lxcBroker) StartInstance(args environs.StartInstanceParams) (*envi
 		bridgeDevice = lxc.DefaultLxcBridge
 	}
 
-	if !environs.AddressAllocationEnabled() {
-		logger.Debugf(
-			"address allocation feature flag not enabled; using DHCP for container %q",
-			machineId,
-		)
+	preparedInfo, err := prepareOrGetContainerInterfaceInfo(
+		broker.api,
+		machineId,
+		bridgeDevice,
+		true, // allocate if possible, do not maintain existing.
+		broker.enableNAT,
+		args.NetworkInfo,
+		lxcLogger,
+	)
+	if err != nil {
+		// It's not fatal (yet) if we couldn't pre-allocate addresses for the
+		// container.
+		logger.Warningf("failed to prepare container %q network config: %v", machineId, err)
 	} else {
-		logger.Debugf("trying to allocate static IP for container %q", machineId)
-		allocatedInfo, err := configureContainerNetwork(
-			machineId,
-			bridgeDevice,
-			broker.api,
-			args.NetworkInfo,
-			true, // allocate a new address.
-			broker.enableNAT,
-		)
-		if err != nil {
-			// It's fine, just ignore it. The effect will be that the
-			// container won't have a static address configured.
-			logger.Infof("not allocating static IP for container %q: %v", machineId, err)
-		} else {
-			args.NetworkInfo = allocatedInfo
-		}
+		args.NetworkInfo = preparedInfo
+
 	}
 	network := container.BridgeNetworkConfig(bridgeDevice, broker.defaultMTU, args.NetworkInfo)
 
@@ -176,6 +175,33 @@ func (broker *lxcBroker) StartInstance(args environs.StartInstanceParams) (*envi
 	}, nil
 }
 
+// MaintainInstance ensures the container's host has the required iptables and
+// routing rules to make the container visible to both the host and other
+// machines on the same subnet. This is important mostly when address allocation
+// feature flag is enabled, as otherwise we don't create additional iptables
+// rules or routes.
+func (broker *lxcBroker) MaintainInstance(args environs.StartInstanceParams) error {
+	machineID := args.InstanceConfig.MachineId
+
+	// Default to using the host network until we can configure.
+	bridgeDevice := broker.agentConfig.Value(agent.LxcBridge)
+	if bridgeDevice == "" {
+		bridgeDevice = lxc.DefaultLxcBridge
+	}
+
+	// There's no InterfaceInfo we expect to get below.
+	_, err := prepareOrGetContainerInterfaceInfo(
+		broker.api,
+		machineID,
+		bridgeDevice,
+		false, // maintain, do not allocate.
+		broker.enableNAT,
+		args.NetworkInfo,
+		lxcLogger,
+	)
+	return err
+}
+
 // StopInstances shuts down the given instances.
 func (broker *lxcBroker) StopInstances(ids ...instance.Id) error {
 	// TODO: potentially parallelise.
@@ -185,6 +211,7 @@ func (broker *lxcBroker) StopInstances(ids ...instance.Id) error {
 			lxcLogger.Errorf("container did not stop: %v", err)
 			return err
 		}
+		maybeReleaseContainerAddresses(broker.api, id, broker.namespace, lxcLogger)
 	}
 	return nil
 }
@@ -596,30 +623,110 @@ func configureContainerNetwork(
 	return finalIfaceInfo, nil
 }
 
-// MaintainInstance checks that the container's host has the required iptables and routing
-// rules to make the container visible to both the host and other machines on the same subnet.
-func (broker *lxcBroker) MaintainInstance(args environs.StartInstanceParams) error {
-	machineId := args.InstanceConfig.MachineId
-	if !environs.AddressAllocationEnabled() {
-		lxcLogger.Debugf("address allocation disabled: Not running maintenance for lxc container with machineId: %s",
-			machineId)
-		return nil
+func maybeGetManagerConfigNamespaces(managerConfig container.ManagerConfig) string {
+	if len(managerConfig) == 0 {
+		return ""
+	}
+	if namespace, ok := managerConfig[container.ConfigName]; ok {
+		return namespace
+	}
+	return ""
+}
+
+func prepareOrGetContainerInterfaceInfo(
+	api APICalls,
+	machineID string,
+	bridgeDevice string,
+	allocateOrMaintain bool,
+	enableNAT bool,
+	startingNetworkInfo []network.InterfaceInfo,
+	log loggo.Logger,
+) ([]network.InterfaceInfo, error) {
+	maintain := !allocateOrMaintain
+
+	if environs.AddressAllocationEnabled() {
+		if maintain {
+			log.Debugf("running maintenance for container %q", machineID)
+		} else {
+			log.Debugf("trying to allocate static IP for container %q", machineID)
+		}
+
+		allocatedInfo, err := configureContainerNetwork(
+			machineID,
+			bridgeDevice,
+			api,
+			startingNetworkInfo,
+			allocateOrMaintain,
+			enableNAT,
+		)
+		if err != nil && !maintain {
+			log.Infof("not allocating static IP for container %q: %v", machineID, err)
+		}
+		return allocatedInfo, err
 	}
 
-	lxcLogger.Debugf("running maintenance for lxc container with machineId: %s", machineId)
-
-	// Default to using the host network until we can configure.
-	bridgeDevice := broker.agentConfig.Value(agent.LxcBridge)
-	if bridgeDevice == "" {
-		bridgeDevice = lxc.DefaultLxcBridge
+	if maintain {
+		log.Debugf("address allocation disabled: Not running maintenance for machine %q", machineID)
+		return nil, nil
 	}
-	_, err := configureContainerNetwork(
-		machineId,
-		bridgeDevice,
-		broker.api,
-		args.NetworkInfo,
-		false, // don't allocate a new address.
-		broker.enableNAT,
+
+	log.Debugf("address allocation feature flag not enabled; using DHCP for container %q", machineID)
+
+	// In case we're running on MAAS 1.8+ with devices support, we'll still
+	// call PrepareContainerInterfaceInfo(), but we'll ignore a NotSupported
+	// error if we get it (which means we're not using MAAS 1.8+).
+	containerTag := names.NewMachineTag(machineID)
+	preparedInfo, err := api.PrepareContainerInterfaceInfo(containerTag)
+	if err != nil && errors.IsNotSupported(err) {
+		log.Debugf("new container %q not registered as device: not running on MAAS 1.8+", machineID)
+		return nil, nil
+	}
+
+	log.Tracef("PrepareContainerInterfaceInfo returned %#v", preparedInfo)
+	// Most likely there will be only one item in the list, but check
+	// all of them for forward compatibility.
+	macAddresses := set.NewStrings()
+	for _, prepInfo := range preparedInfo {
+		macAddresses.Add(prepInfo.MACAddress)
+	}
+	log.Infof(
+		"new container %q registered as a MAAS device with MAC address(es) %v",
+		machineID, macAddresses.SortedValues(),
 	)
-	return err
+	return preparedInfo, nil
+}
+
+func maybeReleaseContainerAddresses(
+	api APICalls,
+	instanceID instance.Id,
+	namespace string,
+	log loggo.Logger,
+) {
+	if environs.AddressAllocationEnabled() {
+		// The addresser worker will take care of the addresses.
+		return
+	}
+	// If we're not using addressable containers, we might still have used MAAS
+	// 1.8+ device to register the container when provisioning. In that case we
+	// need to attempt releasing the device, but ignore a NotSupported error
+	// (when we're not using MAAS 1.8+).
+	namespacePrefix := fmt.Sprintf("%s-", namespace)
+	tagString := strings.TrimPrefix(string(instanceID), namespacePrefix)
+	containerTag, err := names.ParseMachineTag(tagString)
+	if err != nil {
+		// Not a reason to cause StopInstances to fail though..
+		log.Warningf("unexpected container tag %q: %v", instanceID, err)
+		return
+	}
+	err = api.ReleaseContainerAddresses(containerTag)
+	switch {
+	case err == nil:
+		log.Infof("released all addresses for container %q", containerTag.Id())
+	case errors.IsNotSupported(err):
+	default:
+		log.Warningf(
+			"unexpected error trying to release container %q addreses: %v",
+			containerTag.Id(), err,
+		)
+	}
 }

--- a/worker/provisioner/lxc-broker_test.go
+++ b/worker/provisioner/lxc-broker_test.go
@@ -190,6 +190,9 @@ func (s *lxcBrokerSuite) TestStartInstanceAddressAllocationDisabled(c *gc.C) {
 	machineId := "1/lxc/0"
 	lxc := s.startInstance(c, machineId, nil)
 	s.api.CheckCalls(c, []gitjujutesting.StubCall{{
+		FuncName: "PrepareContainerInterfaceInfo",
+		Args:     []interface{}{names.NewMachineTag("1-lxc-0")},
+	}, {
 		FuncName: "ContainerConfig",
 	}})
 	c.Assert(lxc.Id(), gc.Equals, instance.Id("juju-machine-1-lxc-0"))
@@ -311,6 +314,9 @@ func (s *lxcBrokerSuite) TestStartInstanceWithBridgeEnviron(c *gc.C) {
 	machineId := "1/lxc/0"
 	lxc := s.startInstance(c, machineId, nil)
 	s.api.CheckCalls(c, []gitjujutesting.StubCall{{
+		FuncName: "PrepareContainerInterfaceInfo",
+		Args:     []interface{}{names.NewMachineTag("1-lxc-0")},
+	}, {
 		FuncName: "ContainerConfig",
 	}})
 	c.Assert(lxc.Id(), gc.Equals, instance.Id("juju-machine-1-lxc-0"))
@@ -1160,4 +1166,12 @@ func (f *fakeAPI) GetContainerInterfaceInfo(tag names.MachineTag) ([]network.Int
 		return nil, err
 	}
 	return []network.InterfaceInfo{f.fakeInterfaceInfo}, nil
+}
+
+func (f *fakeAPI) ReleaseContainerAddresses(tag names.MachineTag) error {
+	f.MethodCall(f, "ReleaseContainerAddresses", tag)
+	if err := f.NextErr(); err != nil {
+		return err
+	}
+	return nil
 }


### PR DESCRIPTION
This PR changes the default behavior around starting and stopping both
LXC containers and KVM instances, regardless whether the feature flag
"address-allocation" is enabled or not. It aims to resolve a few corner
cases where container resources (IP addresses or DHCP leases) can leak
over time, especially if the same underlying MAAS substrate is being
reused over and over again (i.e. CI/CD automated tests, OIL, etc.).

The cases are:
$ juju destroy-environment --force
$ juju destroy-machine # --force
$ juju destroy-machine #

See the related LP bug http://pad.lv/1483879

With this patch, before any container is started, Juju will now make a
best effort to register the container as a MAAS 1.8+ device with a pre-
generated MAC address, and then explicitly claim a sticky IP address
for it. In case older MAAS version is used or a non-MAAS provider in
general, the process goes on as expected. Also, if using the experimental,
feature-flagged addressable containers, the existing behavior is preserved
(allocating a static IP, tracking its lifecycle, releasing it by the
addresser worker).

Manually tested on MAAS 1.9.0rc1 in the following combinations:
1. precise/trusty/vivid/wily MAAS node hosting one or more LXC/KVM
containers with matching series (without the feature flag enabled).
2. same as 1., but with the address-allocation feature flag on.
3. same as 1., but with MAAS 1.8.3 (stable).
4. same as 3., but with the feature flag on.

In all cases tested so far, it was verified all containers get addresses
as expected, and without the feature flag, there are matching devices
created on MAAS, and the latter are removed as the containers are stopped.

(Review request: http://reviews.vapour.ws/r/3136/)