### PR TITLE
Fix panic when provisioning instances on Rackspace

### DIFF
--- a/provider/rackspace/environ.go
+++ b/provider/rackspace/environ.go
@@ -40,7 +40,8 @@ func (e environ) StartInstance(args environs.StartInstanceParams) (*environs.Sta
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	if os == jujuos.Windows && args.InstanceConfig.Config.FirewallMode() != config.FwNone {
+	fwmode := e.Config().FirewallMode()
+	if os == jujuos.Windows && fwmode != config.FwNone {
 		return nil, errors.Errorf("rackspace provider doesn't support firewalls for windows instances")
 
 	}
@@ -49,7 +50,7 @@ func (e environ) StartInstance(args environs.StartInstanceParams) (*environs.Sta
 		return nil, errors.Trace(err)
 	}
 	r.Instance = environInstance{Instance: r.Instance}
-	if args.InstanceConfig.Config.FirewallMode() != config.FwNone {
+	if fwmode != config.FwNone {
 		err = e.connectToSsh(args, r.Instance)
 	}
 	return r, errors.Trace(err)

--- a/provider/rackspace/environ_test.go
+++ b/provider/rackspace/environ_test.go
@@ -51,7 +51,9 @@ func (s *environSuite) TestStartInstance(c *gc.C) {
 		"type":            "some-type",
 		"authorized-keys": "key",
 	})
-	c.Check(err, gc.IsNil)
+	c.Assert(err, gc.IsNil)
+	err = s.environ.SetConfig(config)
+	c.Assert(err, gc.IsNil)
 	_, err = s.environ.StartInstance(environs.StartInstanceParams{
 		InstanceConfig: &instancecfg.InstanceConfig{
 			Config: config,
@@ -73,6 +75,7 @@ type methodCall struct {
 }
 
 type fakeEnviron struct {
+	config      *config.Config
 	methodCalls []methodCall
 }
 
@@ -119,8 +122,7 @@ func (e *fakeEnviron) MaintainInstance(args environs.StartInstanceParams) error 
 }
 
 func (e *fakeEnviron) Config() *config.Config {
-	e.Push("Config")
-	return nil
+	return e.config
 }
 
 func (e *fakeEnviron) SupportedArchitectures() ([]string, error) {
@@ -139,7 +141,7 @@ func (e *fakeEnviron) ConstraintsValidator() (constraints.Validator, error) {
 }
 
 func (e *fakeEnviron) SetConfig(cfg *config.Config) error {
-	e.Push("SetConfig", cfg)
+	e.config = cfg
 	return nil
 }
 


### PR DESCRIPTION
The rackspace provider StartInstance implementation attempts
to query InstanceConfig to validate 'firewall-mode'. This is
fine for bootstrap, but nothing ensures that setting is
propogated from Config for the state server provisioner.

This branch just switches the code the check Config directly,
and alters the testing fake so that works as expected.

An alternative would be to change instancecfg.FinishInstanceConfig
to copy the setting over, however this doesn't work neatly
as the setting is checked before delegating to the openstack
provider StartInstance which calls that function.

(Review request: http://reviews.vapour.ws/r/3139/)