### PR TITLE
add catacomb.Plan.Init; better test coverage

### DIFF
--- a/worker/catacomb/catacomb_test.go
+++ b/worker/catacomb/catacomb_test.go
@@ -428,16 +428,17 @@ func (s *CatacombSuite) TestPlanBadSite(c *gc.C) {
 		Init: []worker.Worker{w},
 	}
 	checkInvalid(c, plan, "nil Site not valid")
-	w.waitStillAlive(c)
+	w.assertDead(c)
 }
 
 func (s *CatacombSuite) TestPlanBadWork(c *gc.C) {
 	w := s.fix.startErrorWorker(c, nil)
 	plan := catacomb.Plan{
 		Site: &catacomb.Catacomb{},
+		Init: []worker.Worker{w},
 	}
 	checkInvalid(c, plan, "nil Work not valid")
-	w.waitStillAlive(c)
+	w.assertDead(c)
 }
 
 func (s *CatacombSuite) TestPlanBadInit(c *gc.C) {
@@ -448,7 +449,7 @@ func (s *CatacombSuite) TestPlanBadInit(c *gc.C) {
 		Init: []worker.Worker{w, nil},
 	}
 	checkInvalid(c, plan, "nil Init item 1 not valid")
-	w.waitStillAlive(c)
+	w.assertDead(c)
 }
 
 func checkInvalid(c *gc.C, plan catacomb.Plan, match string) {

--- a/worker/catacomb/catacomb_test.go
+++ b/worker/catacomb/catacomb_test.go
@@ -414,11 +414,14 @@ func (s *CatacombSuite) TestReusedCatacomb(c *gc.C) {
 	err = site.Wait()
 	c.Check(err, jc.ErrorIsNil)
 
+	w := s.fix.startErrorWorker(c, nil)
 	err = catacomb.Invoke(catacomb.Plan{
 		Site: &site,
 		Work: func() error { return nil },
+		Init: []worker.Worker{w},
 	})
 	c.Check(err, gc.ErrorMatches, "catacomb 0x[0-9a-f]+ has already been used")
+	w.assertDead(c)
 }
 
 func (s *CatacombSuite) TestPlanBadSite(c *gc.C) {

--- a/worker/catacomb/catacomb_test.go
+++ b/worker/catacomb/catacomb_test.go
@@ -12,7 +12,8 @@ import (
 	gc "gopkg.in/check.v1"
 	"launchpad.net/tomb"
 
-	_ "github.com/juju/juju/worker/catacomb"
+	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/catacomb"
 )
 
 type CatacombSuite struct {
@@ -184,6 +185,16 @@ func (s *CatacombSuite) TestStopsAddedWorker(c *gc.C) {
 	w.assertDead(c)
 }
 
+func (s *CatacombSuite) TestStopsInitWorker(c *gc.C) {
+	w := s.fix.startErrorWorker(c, nil)
+
+	err := s.fix.run(c, func() {
+		w.waitStillAlive(c)
+	}, w)
+	c.Check(err, jc.ErrorIsNil)
+	w.assertDead(c)
+}
+
 func (s *CatacombSuite) TestStoppedWorkerErrorOverwritesNil(c *gc.C) {
 	expect := errors.New("splot")
 	w := s.fix.startErrorWorker(c, expect)
@@ -279,6 +290,17 @@ func (s *CatacombSuite) TestAddFailedWorkerKills(c *gc.C) {
 	c.Check(err, gc.Equals, expect)
 }
 
+func (s *CatacombSuite) TestInitFailedWorkerKills(c *gc.C) {
+	expect := errors.New("blarft")
+	w := s.fix.startErrorWorker(c, expect)
+	w.stop()
+
+	err := s.fix.run(c, func() {
+		s.fix.waitDying(c)
+	}, w)
+	c.Check(err, gc.Equals, expect)
+}
+
 func (s *CatacombSuite) TestFinishAddedWorkerDoesNotKill(c *gc.C) {
 	w := s.fix.startErrorWorker(c, nil)
 
@@ -304,6 +326,17 @@ func (s *CatacombSuite) TestAddFinishedWorkerDoesNotKill(c *gc.C) {
 		w2 := s.fix.startErrorWorker(c, nil)
 		s.fix.assertAddAlive(c, w2)
 	})
+	c.Check(err, jc.ErrorIsNil)
+}
+
+func (s *CatacombSuite) TestInitFinishedWorkerDoesNotKill(c *gc.C) {
+	w := s.fix.startErrorWorker(c, nil)
+	w.stop()
+
+	err := s.fix.run(c, func() {
+		w2 := s.fix.startErrorWorker(c, nil)
+		s.fix.assertAddAlive(c, w2)
+	}, w)
 	c.Check(err, jc.ErrorIsNil)
 }
 
@@ -369,4 +402,60 @@ func (s *CatacombSuite) TestStressAddKillRaces(c *gc.C) {
 	})
 	cause := errors.Cause(err)
 	c.Check(cause, gc.Equals, errFailed)
+}
+
+func (s *CatacombSuite) TestReusedCatacomb(c *gc.C) {
+	var site catacomb.Catacomb
+	err := catacomb.Invoke(catacomb.Plan{
+		Site: &site,
+		Work: func() error { return nil },
+	})
+	c.Check(err, jc.ErrorIsNil)
+	err = site.Wait()
+	c.Check(err, jc.ErrorIsNil)
+
+	err = catacomb.Invoke(catacomb.Plan{
+		Site: &site,
+		Work: func() error { return nil },
+	})
+	c.Check(err, gc.ErrorMatches, "catacomb 0x[0-9a-f]+ has already been used")
+}
+
+func (s *CatacombSuite) TestPlanBadSite(c *gc.C) {
+	w := s.fix.startErrorWorker(c, nil)
+	plan := catacomb.Plan{
+		Work: func() error { panic("no") },
+		Init: []worker.Worker{w},
+	}
+	checkInvalid(c, plan, "nil Site not valid")
+	w.waitStillAlive(c)
+}
+
+func (s *CatacombSuite) TestPlanBadWork(c *gc.C) {
+	w := s.fix.startErrorWorker(c, nil)
+	plan := catacomb.Plan{
+		Site: &catacomb.Catacomb{},
+	}
+	checkInvalid(c, plan, "nil Work not valid")
+	w.waitStillAlive(c)
+}
+
+func (s *CatacombSuite) TestPlanBadInit(c *gc.C) {
+	w := s.fix.startErrorWorker(c, nil)
+	plan := catacomb.Plan{
+		Site: &catacomb.Catacomb{},
+		Work: func() error { panic("no") },
+		Init: []worker.Worker{w, nil},
+	}
+	checkInvalid(c, plan, "nil Init item 1 not valid")
+	w.waitStillAlive(c)
+}
+
+func checkInvalid(c *gc.C, plan catacomb.Plan, match string) {
+	check := func(err error) {
+		c.Check(err, gc.ErrorMatches, match)
+		c.Check(err, jc.Satisfies, errors.IsNotValid)
+	}
+	check(plan.Validate())
+	check(catacomb.Invoke(plan))
 }

--- a/worker/catacomb/fixture_test.go
+++ b/worker/catacomb/fixture_test.go
@@ -12,6 +12,7 @@ import (
 	"launchpad.net/tomb"
 
 	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/catacomb"
 )
 
@@ -24,10 +25,11 @@ type fixture struct {
 	cleaner  cleaner
 }
 
-func (fix *fixture) run(c *gc.C, task func()) error {
+func (fix *fixture) run(c *gc.C, task func(), init ...worker.Worker) error {
 	err := catacomb.Invoke(catacomb.Plan{
 		Site: &fix.catacomb,
 		Work: func() error { task(); return nil },
+		Init: init,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 


### PR DESCRIPTION
Init lets you pass a list of workers to Invoke to have them added to the catacomb automatically.

(Review request: http://reviews.vapour.ws/r/3143/)