### PR TITLE
watcher/legacy package

### DIFF
--- a/watcher/entities.go
+++ b/watcher/entities.go
@@ -1,0 +1,16 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package watcher
+
+// EntitiesWatcher conveniently ties an StringsChan to the worker.Worker that
+// represents its validity.
+//
+// It purports to deliver strings that can be parsed as tags, but since it
+// doesn't actually produce tags today we may as well make it compatible with
+// StringsWatcher so we can use it with a StringsHandler. In an ideal world
+// we'd have something like `type EntitiesChan <-chan []names.Tag` instead.
+type EntitiesWatcher interface {
+	CoreWatcher
+	Changes() StringsChan
+}

--- a/watcher/interface.go
+++ b/watcher/interface.go
@@ -1,0 +1,35 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package watcher
+
+import (
+	"github.com/juju/juju/worker"
+)
+
+// CoreWatcher encodes some features of a watcher. The most obvious one:
+//
+//     Changes() <-chan <T>
+//
+// ...can't be expressed cleanly; and this is annoying because every such chan
+// needs to share common behaviours for the abstraction to be generally helpful.
+// The critical features of a Changes chan are as follows:
+//
+//    * The channel should never be closed.
+//    * The channel should send a single baseline value, representing the change
+//      from a nil state; and subsequently send values representing deltas from
+//      whatever had previously been sent.
+//    * The channel should really never be closed. Many existing watchers *do*
+//      close their channels when the watcher stops; this is harmful because it
+//      mixes lifetime-handling into change-handling at the cost of clarity (and
+//      in some cases correctness). So long as a watcher implements Worker, it
+//      can be safely managed with the worker/catacomb package; client code ofc
+//      still needs to check for closed channels (never trust a contract...) but
+//      can treat that scenario as a simple error.
+//
+// To convert a state/watcher.Watcher to a CoreWatcher, replace Stop() and Err()
+// with the boilerplate Kill() and Wait() implementations; and ensure that the
+// watcher no longer closes its Changes channel.
+type CoreWatcher interface {
+	worker.Worker
+}

--- a/watcher/legacy/doc.go
+++ b/watcher/legacy/doc.go
@@ -1,0 +1,11 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+/*
+Package legacy contains state-watcher-tuned worker harnesses; the canonical
+implementations are in the watcher package, but aren't type-compatible with
+original-style watchers -- such as those returned from state methods -- which
+we still have a couple of uses for (and the certupdater use might even be
+legitimate).
+*/
+package legacy

--- a/watcher/legacy/export_test.go
+++ b/watcher/legacy/export_test.go
@@ -1,0 +1,20 @@
+// Copyright 2012-2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package legacy
+
+import (
+	"github.com/juju/juju/state/watcher"
+)
+
+func SetEnsureErr(f func(watcher.Errer) error) {
+	if f == nil {
+		ensureErr = watcher.EnsureErr
+	} else {
+		ensureErr = f
+	}
+}
+
+func EnsureErr() func(watcher.Errer) error {
+	return ensureErr
+}

--- a/watcher/legacy/notifyworker.go
+++ b/watcher/legacy/notifyworker.go
@@ -1,0 +1,109 @@
+// Copyright 2012, 2013 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package legacy
+
+import (
+	"launchpad.net/tomb"
+
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/state/watcher"
+	"github.com/juju/juju/worker"
+)
+
+// ensureErr is defined as a variable to allow the test suite
+// to override it.
+var ensureErr = watcher.EnsureErr
+
+// notifyWorker is the internal implementation of the Worker
+// interface, using a NotifyWatcher for handling changes.
+type notifyWorker struct {
+	tomb tomb.Tomb
+
+	// handler is what will handle when events are triggered
+	handler NotifyWatchHandler
+}
+
+// NotifyWatchHandler implements the business logic that is triggered
+// as part of watching a NotifyWatcher.
+type NotifyWatchHandler interface {
+	// SetUp starts the handler, this should create the watcher we
+	// will be waiting on for more events. SetUp can return a Watcher
+	// even if there is an error, and the notify Worker will make sure
+	// to stop the watcher.
+	SetUp() (state.NotifyWatcher, error)
+
+	// TearDown should cleanup any resources that are left around
+	TearDown() error
+
+	// Handle is called when the Watcher has indicated there are changes, do
+	// whatever work is necessary to process it. The done channel is closed if
+	// the worker is being interrupted to finish. Any worker should avoid any
+	// bare channel reads or writes, but instead use a select with the done
+	// channel.
+	Handle(done <-chan struct{}) error
+}
+
+// NewNotifyWorker starts a new worker running the business logic from
+// the handler. The worker loop is started in another goroutine as a
+// side effect of calling this.
+func NewNotifyWorker(handler NotifyWatchHandler) worker.Worker {
+	nw := &notifyWorker{
+		handler: handler,
+	}
+
+	go func() {
+		defer nw.tomb.Done()
+		nw.tomb.Kill(nw.loop())
+	}()
+	return nw
+}
+
+// Kill the loop with no-error
+func (nw *notifyWorker) Kill() {
+	nw.tomb.Kill(nil)
+}
+
+// Wait for the looping to finish
+func (nw *notifyWorker) Wait() error {
+	return nw.tomb.Wait()
+}
+
+type tearDowner interface {
+	TearDown() error
+}
+
+// propagateTearDown tears down the handler, but ensures any error is
+// propagated through the tomb's Kill method.
+func propagateTearDown(handler tearDowner, t *tomb.Tomb) {
+	if err := handler.TearDown(); err != nil {
+		t.Kill(err)
+	}
+}
+
+func (nw *notifyWorker) loop() error {
+	w, err := nw.handler.SetUp()
+	if err != nil {
+		if w != nil {
+			// We don't bother to propagate an error, because we
+			// already have an error
+			w.Stop()
+		}
+		return err
+	}
+	defer propagateTearDown(nw.handler, &nw.tomb)
+	defer watcher.Stop(w, &nw.tomb)
+	for {
+		select {
+		case <-nw.tomb.Dying():
+			return tomb.ErrDying
+		case _, ok := <-w.Changes():
+			if !ok {
+				return ensureErr(w)
+			}
+			if err := nw.handler.Handle(nw.tomb.Dying()); err != nil {
+				return err
+			}
+		}
+	}
+}

--- a/watcher/legacy/notifyworker_test.go
+++ b/watcher/legacy/notifyworker_test.go
@@ -1,0 +1,353 @@
+// Copyright 2012, 2013 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package legacy_test
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"launchpad.net/tomb"
+
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/state/watcher"
+	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/watcher/legacy"
+	"github.com/juju/juju/worker"
+)
+
+type notifyWorkerSuite struct {
+	coretesting.BaseSuite
+	worker worker.Worker
+	actor  *notifyHandler
+}
+
+var _ = gc.Suite(&notifyWorkerSuite{})
+
+func newNotifyHandlerWorker(c *gc.C, setupError, handlerError, teardownError error) (*notifyHandler, worker.Worker) {
+	nh := &notifyHandler{
+		actions:       nil,
+		handled:       make(chan struct{}, 1),
+		setupError:    setupError,
+		teardownError: teardownError,
+		handlerError:  handlerError,
+		watcher: &testNotifyWatcher{
+			changes: make(chan struct{}),
+		},
+		setupDone: make(chan struct{}),
+	}
+	w := legacy.NewNotifyWorker(nh)
+	select {
+	case <-nh.setupDone:
+	case <-time.After(coretesting.ShortWait):
+		c.Error("Failed waiting for notifyHandler.Setup to be called during SetUpTest")
+	}
+	return nh, w
+}
+
+func (s *notifyWorkerSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+	s.actor, s.worker = newNotifyHandlerWorker(c, nil, nil, nil)
+}
+
+func (s *notifyWorkerSuite) TearDownTest(c *gc.C) {
+	legacy.SetEnsureErr(nil)
+	s.stopWorker(c)
+	s.BaseSuite.TearDownTest(c)
+}
+
+type notifyHandler struct {
+	actions []string
+	mu      sync.Mutex
+	// Signal handled when we get a handle() call
+	handled       chan struct{}
+	setupError    error
+	teardownError error
+	handlerError  error
+	watcher       *testNotifyWatcher
+	setupDone     chan struct{}
+}
+
+func (nh *notifyHandler) SetUp() (state.NotifyWatcher, error) {
+	defer func() { nh.setupDone <- struct{}{} }()
+	nh.mu.Lock()
+	defer nh.mu.Unlock()
+	nh.actions = append(nh.actions, "setup")
+	if nh.watcher == nil {
+		return nil, nh.setupError
+	}
+	return nh.watcher, nh.setupError
+}
+
+func (nh *notifyHandler) TearDown() error {
+	nh.mu.Lock()
+	defer nh.mu.Unlock()
+	nh.actions = append(nh.actions, "teardown")
+	if nh.handled != nil {
+		close(nh.handled)
+	}
+	return nh.teardownError
+}
+
+func (nh *notifyHandler) Handle(_ <-chan struct{}) error {
+	nh.mu.Lock()
+	defer nh.mu.Unlock()
+	nh.actions = append(nh.actions, "handler")
+	if nh.handled != nil {
+		// Unlock while we are waiting for the send
+		nh.mu.Unlock()
+		nh.handled <- struct{}{}
+		nh.mu.Lock()
+	}
+	return nh.handlerError
+}
+
+func (nh *notifyHandler) CheckActions(c *gc.C, actions ...string) {
+	nh.mu.Lock()
+	defer nh.mu.Unlock()
+	c.Check(nh.actions, gc.DeepEquals, actions)
+}
+
+// During teardown we try to stop the worker, but don't hang the test suite if
+// Stop never returns
+func (s *notifyWorkerSuite) stopWorker(c *gc.C) {
+	if s.worker == nil {
+		return
+	}
+	done := make(chan error)
+	go func() {
+		done <- worker.Stop(s.worker)
+	}()
+	err := waitForTimeout(c, done, coretesting.LongWait)
+	c.Check(err, jc.ErrorIsNil)
+	s.actor = nil
+	s.worker = nil
+}
+
+type testNotifyWatcher struct {
+	state.NotifyWatcher
+	mu        sync.Mutex
+	changes   chan struct{}
+	stopped   bool
+	stopError error
+}
+
+func (tnw *testNotifyWatcher) Changes() <-chan struct{} {
+	return tnw.changes
+}
+
+func (tnw *testNotifyWatcher) Err() error {
+	return tnw.stopError
+}
+
+func (tnw *testNotifyWatcher) Stop() error {
+	tnw.mu.Lock()
+	defer tnw.mu.Unlock()
+	if !tnw.stopped {
+		close(tnw.changes)
+	}
+	tnw.stopped = true
+	return tnw.stopError
+}
+
+func (tnw *testNotifyWatcher) SetStopError(err error) {
+	tnw.mu.Lock()
+	tnw.stopError = err
+	tnw.mu.Unlock()
+}
+
+func (tnw *testNotifyWatcher) TriggerChange(c *gc.C) {
+	select {
+	case tnw.changes <- struct{}{}:
+	case <-time.After(coretesting.LongWait):
+		c.Errorf("timed out trying to trigger a change")
+	}
+}
+
+func waitForTimeout(c *gc.C, ch <-chan error, timeout time.Duration) error {
+	select {
+	case err := <-ch:
+		return err
+	case <-time.After(timeout):
+		c.Errorf("timed out waiting to receive a change after %s", timeout)
+	}
+	return nil
+}
+
+func waitShort(c *gc.C, w worker.Worker) error {
+	done := make(chan error)
+	go func() {
+		done <- w.Wait()
+	}()
+	return waitForTimeout(c, done, coretesting.ShortWait)
+}
+
+func waitForHandledNotify(c *gc.C, handled chan struct{}) {
+	select {
+	case <-handled:
+	case <-time.After(coretesting.LongWait):
+		c.Errorf("handled failed to signal after %s", coretesting.LongWait)
+	}
+}
+
+func (s *notifyWorkerSuite) TestKill(c *gc.C) {
+	s.worker.Kill()
+	err := waitShort(c, s.worker)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *notifyWorkerSuite) TestStop(c *gc.C) {
+	err := worker.Stop(s.worker)
+	c.Assert(err, jc.ErrorIsNil)
+	// After stop, Wait should return right away
+	err = waitShort(c, s.worker)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *notifyWorkerSuite) TestWait(c *gc.C) {
+	done := make(chan error)
+	go func() {
+		done <- s.worker.Wait()
+	}()
+	// Wait should not return until we've killed the worker
+	select {
+	case err := <-done:
+		c.Errorf("Wait() didn't wait until we stopped it: %v", err)
+	case <-time.After(coretesting.ShortWait):
+	}
+	s.worker.Kill()
+	err := waitForTimeout(c, done, coretesting.LongWait)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *notifyWorkerSuite) TestCallSetUpAndTearDown(c *gc.C) {
+	// After calling NewNotifyWorker, we should have called setup
+	s.actor.CheckActions(c, "setup")
+	// If we kill the worker, it should notice, and call teardown
+	s.worker.Kill()
+	err := waitShort(c, s.worker)
+	c.Check(err, jc.ErrorIsNil)
+	s.actor.CheckActions(c, "setup", "teardown")
+	c.Check(s.actor.watcher.stopped, jc.IsTrue)
+}
+
+func (s *notifyWorkerSuite) TestChangesTriggerHandler(c *gc.C) {
+	s.actor.CheckActions(c, "setup")
+	s.actor.watcher.TriggerChange(c)
+	waitForHandledNotify(c, s.actor.handled)
+	s.actor.CheckActions(c, "setup", "handler")
+	s.actor.watcher.TriggerChange(c)
+	waitForHandledNotify(c, s.actor.handled)
+	s.actor.watcher.TriggerChange(c)
+	waitForHandledNotify(c, s.actor.handled)
+	s.actor.CheckActions(c, "setup", "handler", "handler", "handler")
+	c.Assert(worker.Stop(s.worker), gc.IsNil)
+	s.actor.CheckActions(c, "setup", "handler", "handler", "handler", "teardown")
+}
+
+func (s *notifyWorkerSuite) TestSetUpFailureStopsWithTearDown(c *gc.C) {
+	// Stop the worker and SetUp again, this time with an error
+	s.stopWorker(c)
+	actor, w := newNotifyHandlerWorker(c, fmt.Errorf("my special error"), nil, nil)
+	err := waitShort(c, w)
+	c.Check(err, gc.ErrorMatches, "my special error")
+	// TearDown is not called on SetUp error.
+	actor.CheckActions(c, "setup")
+	c.Check(actor.watcher.stopped, jc.IsTrue)
+}
+
+func (s *notifyWorkerSuite) TestWatcherStopFailurePropagates(c *gc.C) {
+	s.actor.watcher.SetStopError(fmt.Errorf("error while stopping watcher"))
+	s.worker.Kill()
+	c.Assert(s.worker.Wait(), gc.ErrorMatches, "error while stopping watcher")
+	// We've already stopped the worker, don't let teardown notice the
+	// worker is in an error state
+	s.worker = nil
+}
+
+func (s *notifyWorkerSuite) TestCleanRunNoticesTearDownError(c *gc.C) {
+	s.actor.teardownError = fmt.Errorf("failed to tear down watcher")
+	s.worker.Kill()
+	c.Assert(s.worker.Wait(), gc.ErrorMatches, "failed to tear down watcher")
+	s.worker = nil
+}
+
+func (s *notifyWorkerSuite) TestHandleErrorStopsWorkerAndWatcher(c *gc.C) {
+	s.stopWorker(c)
+	actor, w := newNotifyHandlerWorker(c, nil, fmt.Errorf("my handling error"), nil)
+	actor.watcher.TriggerChange(c)
+	waitForHandledNotify(c, actor.handled)
+	err := waitShort(c, w)
+	c.Check(err, gc.ErrorMatches, "my handling error")
+	actor.CheckActions(c, "setup", "handler", "teardown")
+	c.Check(actor.watcher.stopped, jc.IsTrue)
+}
+
+func (s *notifyWorkerSuite) TestNoticesStoppedWatcher(c *gc.C) {
+	// The default closedHandler doesn't panic if you have a genuine error
+	// (because it assumes you want to propagate a real error and then
+	// restart
+	s.actor.watcher.SetStopError(fmt.Errorf("Stopped Watcher"))
+	s.actor.watcher.Stop()
+	err := waitShort(c, s.worker)
+	c.Check(err, gc.ErrorMatches, "Stopped Watcher")
+	s.actor.CheckActions(c, "setup", "teardown")
+	// Worker is stopped, don't fail TearDownTest
+	s.worker = nil
+}
+
+func noopHandler(watcher.Errer) error {
+	return nil
+}
+
+type CannedErrer struct {
+	err error
+}
+
+func (c CannedErrer) Err() error {
+	return c.err
+}
+
+func (s *notifyWorkerSuite) TestDefaultClosedHandler(c *gc.C) {
+	// Roundabout check for function equality.
+	// Is this test really worth it?
+	c.Assert(fmt.Sprintf("%p", legacy.EnsureErr()), gc.Equals, fmt.Sprintf("%p", watcher.EnsureErr))
+}
+
+func (s *notifyWorkerSuite) TestErrorsOnStillAliveButClosedChannel(c *gc.C) {
+	foundErr := fmt.Errorf("did not get an error")
+	triggeredHandler := func(errer watcher.Errer) error {
+		foundErr = errer.Err()
+		return foundErr
+	}
+	legacy.SetEnsureErr(triggeredHandler)
+	s.actor.watcher.SetStopError(tomb.ErrStillAlive)
+	s.actor.watcher.Stop()
+	err := waitShort(c, s.worker)
+	c.Check(foundErr, gc.Equals, tomb.ErrStillAlive)
+	// ErrStillAlive is trapped by the Stop logic and gets turned into a
+	// 'nil' when stopping. However TestDefaultClosedHandler can assert
+	// that it would have triggered a panic.
+	c.Check(err, jc.ErrorIsNil)
+	s.actor.CheckActions(c, "setup", "teardown")
+	// Worker is stopped, don't fail TearDownTest
+	s.worker = nil
+}
+
+func (s *notifyWorkerSuite) TestErrorsOnClosedChannel(c *gc.C) {
+	foundErr := fmt.Errorf("did not get an error")
+	triggeredHandler := func(errer watcher.Errer) error {
+		foundErr = errer.Err()
+		return foundErr
+	}
+	legacy.SetEnsureErr(triggeredHandler)
+	s.actor.watcher.Stop()
+	err := waitShort(c, s.worker)
+	// If the foundErr is nil, we would have panic-ed (see TestDefaultClosedHandler)
+	c.Check(foundErr, gc.IsNil)
+	c.Check(err, jc.ErrorIsNil)
+	s.actor.CheckActions(c, "setup", "teardown")
+}

--- a/watcher/legacy/package_test.go
+++ b/watcher/legacy/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package legacy_test
+
+import (
+	stdtesting "testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *stdtesting.T) {
+	gc.TestingT(t)
+}

--- a/watcher/legacy/stringsworker.go
+++ b/watcher/legacy/stringsworker.go
@@ -1,0 +1,89 @@
+// Copyright 2013 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package legacy
+
+import (
+	"launchpad.net/tomb"
+
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/state/watcher"
+	"github.com/juju/juju/worker"
+)
+
+// stringsWorker is the internal implementation of the Worker
+// interface, using a StringsWatcher for handling changes.
+type stringsWorker struct {
+	tomb tomb.Tomb
+
+	// handler is what will be called when events are triggered.
+	handler StringsWatchHandler
+}
+
+// StringsWatchHandler implements the business logic triggered as part
+// of watching a StringsWatcher.
+type StringsWatchHandler interface {
+	// SetUp starts the handler, this should create the watcher we
+	// will be waiting on for more events. SetUp can return a Watcher
+	// even if there is an error, and strings Worker will make sure to
+	// stop the watcher.
+	SetUp() (state.StringsWatcher, error)
+
+	// TearDown should cleanup any resources that are left around
+	TearDown() error
+
+	// Handle is called when the Watcher has indicated there are
+	// changes, do whatever work is necessary to process it
+	Handle(changes []string) error
+}
+
+// NewStringsWorker starts a new worker running the business logic
+// from the handler. The worker loop is started in another goroutine
+// as a side effect of calling this.
+func NewStringsWorker(handler StringsWatchHandler) worker.Worker {
+	sw := &stringsWorker{
+		handler: handler,
+	}
+	go func() {
+		defer sw.tomb.Done()
+		sw.tomb.Kill(sw.loop())
+	}()
+	return sw
+}
+
+// Kill the loop with no-error
+func (sw *stringsWorker) Kill() {
+	sw.tomb.Kill(nil)
+}
+
+// Wait for the looping to finish
+func (sw *stringsWorker) Wait() error {
+	return sw.tomb.Wait()
+}
+
+func (sw *stringsWorker) loop() error {
+	w, err := sw.handler.SetUp()
+	if err != nil {
+		if w != nil {
+			// We don't bother to propagate an error, because we
+			// already have an error
+			w.Stop()
+		}
+		return err
+	}
+	defer propagateTearDown(sw.handler, &sw.tomb)
+	defer watcher.Stop(w, &sw.tomb)
+	for {
+		select {
+		case <-sw.tomb.Dying():
+			return tomb.ErrDying
+		case changes, ok := <-w.Changes():
+			if !ok {
+				return ensureErr(w)
+			}
+			if err := sw.handler.Handle(changes); err != nil {
+				return err
+			}
+		}
+	}
+}

--- a/watcher/legacy/stringsworker_test.go
+++ b/watcher/legacy/stringsworker_test.go
@@ -1,0 +1,317 @@
+// Copyright 2013 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package legacy_test
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"launchpad.net/tomb"
+
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/state/watcher"
+	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/watcher/legacy"
+	"github.com/juju/juju/worker"
+)
+
+type stringsWorkerSuite struct {
+	coretesting.BaseSuite
+	worker worker.Worker
+	actor  *stringsHandler
+}
+
+var _ = gc.Suite(&stringsWorkerSuite{})
+
+func newStringsHandlerWorker(c *gc.C, setupError, handlerError, teardownError error) (*stringsHandler, worker.Worker) {
+	sh := &stringsHandler{
+		actions:       nil,
+		handled:       make(chan []string, 1),
+		setupError:    setupError,
+		teardownError: teardownError,
+		handlerError:  handlerError,
+		watcher: &testStringsWatcher{
+			changes: make(chan []string),
+		},
+		setupDone: make(chan struct{}),
+	}
+	w := legacy.NewStringsWorker(sh)
+	select {
+	case <-sh.setupDone:
+	case <-time.After(coretesting.ShortWait):
+		c.Error("Failed waiting for stringsHandler.Setup to be called during SetUpTest")
+	}
+	return sh, w
+}
+
+func (s *stringsWorkerSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+	s.actor, s.worker = newStringsHandlerWorker(c, nil, nil, nil)
+}
+
+func (s *stringsWorkerSuite) TearDownTest(c *gc.C) {
+	s.stopWorker(c)
+	s.BaseSuite.TearDownTest(c)
+}
+
+type stringsHandler struct {
+	actions []string
+	mu      sync.Mutex
+	// Signal handled when we get a handle() call
+	handled       chan []string
+	setupError    error
+	teardownError error
+	handlerError  error
+	watcher       *testStringsWatcher
+	setupDone     chan struct{}
+}
+
+func (sh *stringsHandler) SetUp() (state.StringsWatcher, error) {
+	defer func() { sh.setupDone <- struct{}{} }()
+	sh.mu.Lock()
+	defer sh.mu.Unlock()
+	sh.actions = append(sh.actions, "setup")
+	if sh.watcher == nil {
+		return nil, sh.setupError
+	}
+	return sh.watcher, sh.setupError
+}
+
+func (sh *stringsHandler) TearDown() error {
+	sh.mu.Lock()
+	defer sh.mu.Unlock()
+	sh.actions = append(sh.actions, "teardown")
+	if sh.handled != nil {
+		close(sh.handled)
+	}
+	return sh.teardownError
+}
+
+func (sh *stringsHandler) Handle(changes []string) error {
+	sh.mu.Lock()
+	defer sh.mu.Unlock()
+	sh.actions = append(sh.actions, "handler")
+	if sh.handled != nil {
+		// Unlock while we are waiting for the send
+		sh.mu.Unlock()
+		sh.handled <- changes
+		sh.mu.Lock()
+	}
+	return sh.handlerError
+}
+
+func (sh *stringsHandler) CheckActions(c *gc.C, actions ...string) {
+	sh.mu.Lock()
+	defer sh.mu.Unlock()
+	c.Check(sh.actions, gc.DeepEquals, actions)
+}
+
+// During teardown we try to stop the worker, but don't hang the test suite if
+// Stop never returns
+func (s *stringsWorkerSuite) stopWorker(c *gc.C) {
+	if s.worker == nil {
+		return
+	}
+	done := make(chan error)
+	go func() {
+		done <- worker.Stop(s.worker)
+	}()
+	err := waitForTimeout(c, done, coretesting.LongWait)
+	c.Check(err, jc.ErrorIsNil)
+	s.actor = nil
+	s.worker = nil
+}
+
+type testStringsWatcher struct {
+	state.StringsWatcher
+	mu        sync.Mutex
+	changes   chan []string
+	stopped   bool
+	stopError error
+}
+
+func (tsw *testStringsWatcher) Changes() <-chan []string {
+	return tsw.changes
+}
+
+func (tsw *testStringsWatcher) Err() error {
+	return tsw.stopError
+}
+
+func (tsw *testStringsWatcher) Stop() error {
+	tsw.mu.Lock()
+	defer tsw.mu.Unlock()
+	if !tsw.stopped {
+		close(tsw.changes)
+	}
+	tsw.stopped = true
+	return tsw.stopError
+}
+
+func (tsw *testStringsWatcher) SetStopError(err error) {
+	tsw.mu.Lock()
+	tsw.stopError = err
+	tsw.mu.Unlock()
+}
+
+func (tsw *testStringsWatcher) TriggerChange(c *gc.C, changes []string) {
+	select {
+	case tsw.changes <- changes:
+	case <-time.After(coretesting.LongWait):
+		c.Errorf("timed out trying to trigger a change")
+	}
+}
+
+func waitForHandledStrings(c *gc.C, handled chan []string, expect []string) {
+	select {
+	case changes := <-handled:
+		c.Assert(changes, gc.DeepEquals, expect)
+	case <-time.After(coretesting.LongWait):
+		c.Errorf("handled failed to signal after %s", coretesting.LongWait)
+	}
+}
+
+func (s *stringsWorkerSuite) TestKill(c *gc.C) {
+	s.worker.Kill()
+	err := waitShort(c, s.worker)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *stringsWorkerSuite) TestStop(c *gc.C) {
+	err := worker.Stop(s.worker)
+	c.Assert(err, jc.ErrorIsNil)
+	// After stop, Wait should return right away
+	err = waitShort(c, s.worker)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *stringsWorkerSuite) TestWait(c *gc.C) {
+	done := make(chan error)
+	go func() {
+		done <- s.worker.Wait()
+	}()
+	// Wait should not return until we've killed the worker
+	select {
+	case err := <-done:
+		c.Errorf("Wait() didn't wait until we stopped it: %v", err)
+	case <-time.After(coretesting.ShortWait):
+	}
+	s.worker.Kill()
+	err := waitForTimeout(c, done, coretesting.LongWait)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *stringsWorkerSuite) TestCallSetUpAndTearDown(c *gc.C) {
+	// After calling NewStringsWorker, we should have called setup
+	s.actor.CheckActions(c, "setup")
+	// If we kill the worker, it should notice, and call teardown
+	s.worker.Kill()
+	err := waitShort(c, s.worker)
+	c.Check(err, jc.ErrorIsNil)
+	s.actor.CheckActions(c, "setup", "teardown")
+	c.Check(s.actor.watcher.stopped, jc.IsTrue)
+}
+
+func (s *stringsWorkerSuite) TestChangesTriggerHandler(c *gc.C) {
+	s.actor.CheckActions(c, "setup")
+	s.actor.watcher.TriggerChange(c, []string{"aa", "bb"})
+	waitForHandledStrings(c, s.actor.handled, []string{"aa", "bb"})
+	s.actor.CheckActions(c, "setup", "handler")
+	s.actor.watcher.TriggerChange(c, []string{"cc", "dd"})
+	waitForHandledStrings(c, s.actor.handled, []string{"cc", "dd"})
+	s.actor.watcher.TriggerChange(c, []string{"ee", "ff"})
+	waitForHandledStrings(c, s.actor.handled, []string{"ee", "ff"})
+	s.actor.CheckActions(c, "setup", "handler", "handler", "handler")
+	c.Assert(worker.Stop(s.worker), gc.IsNil)
+	s.actor.CheckActions(c, "setup", "handler", "handler", "handler", "teardown")
+}
+
+func (s *stringsWorkerSuite) TestSetUpFailureStopsWithTearDown(c *gc.C) {
+	// Stop the worker and SetUp again, this time with an error
+	s.stopWorker(c)
+	actor, w := newStringsHandlerWorker(c, fmt.Errorf("my special error"), nil, nil)
+	err := waitShort(c, w)
+	c.Check(err, gc.ErrorMatches, "my special error")
+	// TearDown is not called on SetUp error.
+	actor.CheckActions(c, "setup")
+	c.Check(actor.watcher.stopped, jc.IsTrue)
+}
+
+func (s *stringsWorkerSuite) TestWatcherStopFailurePropagates(c *gc.C) {
+	s.actor.watcher.SetStopError(fmt.Errorf("error while stopping watcher"))
+	s.worker.Kill()
+	c.Assert(s.worker.Wait(), gc.ErrorMatches, "error while stopping watcher")
+	// We've already stopped the worker, don't let teardown notice the
+	// worker is in an error state
+	s.worker = nil
+}
+
+func (s *stringsWorkerSuite) TestCleanRunNoticesTearDownError(c *gc.C) {
+	s.actor.teardownError = fmt.Errorf("failed to tear down watcher")
+	s.worker.Kill()
+	c.Assert(s.worker.Wait(), gc.ErrorMatches, "failed to tear down watcher")
+	s.worker = nil
+}
+
+func (s *stringsWorkerSuite) TestHandleErrorStopsWorkerAndWatcher(c *gc.C) {
+	s.stopWorker(c)
+	actor, w := newStringsHandlerWorker(c, nil, fmt.Errorf("my handling error"), nil)
+	actor.watcher.TriggerChange(c, []string{"aa", "bb"})
+	waitForHandledStrings(c, actor.handled, []string{"aa", "bb"})
+	err := waitShort(c, w)
+	c.Check(err, gc.ErrorMatches, "my handling error")
+	actor.CheckActions(c, "setup", "handler", "teardown")
+	c.Check(actor.watcher.stopped, jc.IsTrue)
+}
+
+func (s *stringsWorkerSuite) TestNoticesStoppedWatcher(c *gc.C) {
+	// The default closedHandler doesn't panic if you have a genuine error
+	// (because it assumes you want to propagate a real error and then
+	// restart
+	s.actor.watcher.SetStopError(fmt.Errorf("Stopped Watcher"))
+	s.actor.watcher.Stop()
+	err := waitShort(c, s.worker)
+	c.Check(err, gc.ErrorMatches, "Stopped Watcher")
+	s.actor.CheckActions(c, "setup", "teardown")
+	// Worker is stopped, don't fail TearDownTest
+	s.worker = nil
+}
+
+func (s *stringsWorkerSuite) TestErrorsOnStillAliveButClosedChannel(c *gc.C) {
+	foundErr := fmt.Errorf("did not get an error")
+	triggeredHandler := func(errer watcher.Errer) error {
+		foundErr = errer.Err()
+		return foundErr
+	}
+	legacy.SetEnsureErr(triggeredHandler)
+	s.actor.watcher.SetStopError(tomb.ErrStillAlive)
+	s.actor.watcher.Stop()
+	err := waitShort(c, s.worker)
+	c.Check(foundErr, gc.Equals, tomb.ErrStillAlive)
+	// ErrStillAlive is trapped by the Stop logic and gets turned into a
+	// 'nil' when stopping. However TestDefaultClosedHandler can assert
+	// that it would have triggered an error.
+	c.Check(err, jc.ErrorIsNil)
+	s.actor.CheckActions(c, "setup", "teardown")
+	// Worker is stopped, don't fail TearDownTest
+	s.worker = nil
+}
+
+func (s *stringsWorkerSuite) TestErrorsOnClosedChannel(c *gc.C) {
+	foundErr := fmt.Errorf("did not get an error")
+	triggeredHandler := func(errer watcher.Errer) error {
+		foundErr = errer.Err()
+		return foundErr
+	}
+	legacy.SetEnsureErr(triggeredHandler)
+	s.actor.watcher.Stop()
+	err := waitShort(c, s.worker)
+	// If the foundErr is nil, we would have panic-ed (see TestDefaultClosedHandler)
+	c.Check(foundErr, gc.IsNil)
+	c.Check(err, jc.ErrorIsNil)
+	s.actor.CheckActions(c, "setup", "teardown")
+}

--- a/watcher/machinestorageids.go
+++ b/watcher/machinestorageids.go
@@ -1,0 +1,27 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package watcher
+
+// MachineStorageId associates a machine entity with a storage entity. They're
+// expressed as tags because they arrived here as a move, not a change; ideally
+// a MachineStorageIdsWatcher would return them in a more model-appropriate
+// format (i.e. not as strings-that-probably-parse-to-tags).
+type MachineStorageId struct {
+	MachineTag    string
+	AttachmentTag string
+}
+
+// MachineStorageIdsChan is a change channel as described in the CoreWatcher
+// docs.
+//
+// Other than that, I don't know its exact semantics. axw, description? standard
+// add/remove? changes to referenced entities?
+type MachineStorageIdsChan <-chan []MachineStorageId
+
+// MachineStorageIdsWatcher conveniently ties a MachineStorageIdsChan to the
+// worker.Worker that represents its validity.
+type MachineStorageIdsWatcher interface {
+	CoreWatcher
+	Changes() MachineStorageIdsChan
+}

--- a/watcher/notify.go
+++ b/watcher/notify.go
@@ -1,0 +1,139 @@
+// Copyright 2012-2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package watcher
+
+import (
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/worker/catacomb"
+)
+
+// NotifyChan is a change channel as described in the CoreWatcher docs.
+//
+// It sends a single value to indicate that the watch is active, and subsequent
+// values whenever the value(s) under observation change(s).
+type NotifyChan <-chan struct{}
+
+// NotifyWatcher conveniently ties a NotifyChan to the worker.Worker that
+// represents its validity.
+type NotifyWatcher interface {
+	CoreWatcher
+	Changes() NotifyChan
+}
+
+// NotifyHandler defines the operation of a NotifyWorker.
+type NotifyHandler interface {
+
+	// SetUp is called once when creating a NotifyWorker. It must return a
+	// NotifyWatcher or an error. The NotifyHandler takes responsibility for
+	// stopping any returned watcher and handling any errors.
+	SetUp() (NotifyWatcher, error)
+
+	// Handle is called whenever a value is received from the NotifyWatcher
+	// returned by SetUp. If it returns an error, the NotifyWorker will be
+	// stopped.
+	//
+	// If Handle runs any blocking operations it must pass through, or select
+	// on, the supplied abort channel; this channnel will be closed when the
+	// NotifyWorker is killed. An aborted Handle should not return an error.
+	Handle(abort <-chan struct{}) error
+
+	// TearDown is called once when stopping a NotifyWorker, whether or not
+	// SetUp succeeded. It need not concern itself with the NotifyWatcher, but
+	// must clean up any other resources created in SetUp or Handle.
+	TearDown() error
+}
+
+// NotifyConfig holds the direct dependencies of a NotifyWorker.
+type NotifyConfig struct {
+	Handler NotifyHandler
+}
+
+// Validate returns an error if the config cannot start a NotifyWorker.
+func (config NotifyConfig) Validate() error {
+	if config.Handler == nil {
+		return errors.NotValidf("nil Handler")
+	}
+	return nil
+}
+
+// NewNotifyWorker starts a new worker that runs a NotifyHandler.
+func NewNotifyWorker(config NotifyConfig) (*NotifyWorker, error) {
+	if err := config.Validate(); err != nil {
+		return nil, errors.Trace(err)
+	}
+	nw := &NotifyWorker{
+		config: config,
+	}
+	err := catacomb.Invoke(catacomb.Plan{
+		Site: &nw.catacomb,
+		Work: nw.loop,
+	})
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return nw, nil
+}
+
+// NotifyWorker is a worker that wraps a NotifyWatcher.
+type NotifyWorker struct {
+	config   NotifyConfig
+	catacomb catacomb.Catacomb
+}
+
+func (nw *NotifyWorker) loop() (err error) {
+	changes := nw.setUp()
+	defer nw.tearDown(err)
+	for {
+		select {
+		case <-nw.catacomb.Dying():
+			return nw.catacomb.ErrDying()
+		case _, ok := <-changes:
+			if !ok {
+				return errors.New("change channel closed")
+			}
+			abort := nw.catacomb.Dying()
+			err = nw.config.Handler.Handle(abort)
+			if err != nil {
+				return err
+			}
+		}
+	}
+}
+
+// setUp calls the handler's SetUp method; registers any returned watcher with
+// the worker's catacomb; and returns the watcher's changes channel. Any errors
+// encountered kill the worker and cause a nil channel to be returned.
+func (nw *NotifyWorker) setUp() NotifyChan {
+	watcher, err := nw.config.Handler.SetUp()
+	if err != nil {
+		nw.catacomb.Kill(err)
+	}
+	if watcher == nil {
+		nw.catacomb.Kill(errors.New("handler returned nil watcher"))
+	} else if err := nw.catacomb.Add(watcher); err != nil {
+		nw.catacomb.Kill(err)
+	} else {
+		return watcher.Changes()
+	}
+	return nil
+}
+
+// tearDown kills the worker with the supplied error; and then kills it with
+// any error returned by the handler's TearDown method.
+func (nw *NotifyWorker) tearDown(err error) {
+	nw.catacomb.Kill(err)
+	err = nw.config.Handler.TearDown()
+	nw.catacomb.Kill(err)
+}
+
+// Kill is part of the worker.Worker interface.
+func (nw *NotifyWorker) Kill() {
+	nw.catacomb.Kill(nil)
+}
+
+// Wait is part of the worker.Worker interface.
+func (nw *NotifyWorker) Wait() error {
+	return nw.catacomb.Wait()
+}

--- a/watcher/notify_test.go
+++ b/watcher/notify_test.go
@@ -1,0 +1,314 @@
+// Copyright 2012, 2013 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package watcher_test
+
+import (
+	"sync"
+	"time"
+
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"launchpad.net/tomb"
+
+	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/watcher"
+	"github.com/juju/juju/worker"
+)
+
+type notifyWorkerSuite struct {
+	coretesting.BaseSuite
+	worker worker.Worker
+	actor  *notifyHandler
+}
+
+var _ = gc.Suite(&notifyWorkerSuite{})
+
+func newNotifyHandlerWorker(c *gc.C, setupError, handlerError, teardownError error) (*notifyHandler, worker.Worker) {
+	nh := &notifyHandler{
+		actions:       nil,
+		handled:       make(chan struct{}, 1),
+		setupError:    setupError,
+		teardownError: teardownError,
+		handlerError:  handlerError,
+		watcher:       newTestNotifyWatcher(),
+		setupDone:     make(chan struct{}),
+	}
+	w, err := watcher.NewNotifyWorker(watcher.NotifyConfig{Handler: nh})
+	c.Assert(err, jc.ErrorIsNil)
+	select {
+	case <-nh.setupDone:
+	case <-time.After(coretesting.ShortWait):
+		c.Error("Failed waiting for notifyHandler.Setup to be called during SetUpTest")
+	}
+	return nh, w
+}
+
+func (s *notifyWorkerSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+	s.actor, s.worker = newNotifyHandlerWorker(c, nil, nil, nil)
+}
+
+func (s *notifyWorkerSuite) TearDownTest(c *gc.C) {
+	s.stopWorker(c)
+	s.BaseSuite.TearDownTest(c)
+}
+
+type notifyHandler struct {
+	actions []string
+	mu      sync.Mutex
+	// Signal handled when we get a handle() call
+	handled       chan struct{}
+	setupError    error
+	teardownError error
+	handlerError  error
+	watcher       *testNotifyWatcher
+	setupDone     chan struct{}
+}
+
+func (nh *notifyHandler) SetUp() (watcher.NotifyWatcher, error) {
+	defer func() { nh.setupDone <- struct{}{} }()
+	nh.mu.Lock()
+	defer nh.mu.Unlock()
+	nh.actions = append(nh.actions, "setup")
+	if nh.watcher == nil {
+		return nil, nh.setupError
+	}
+	return nh.watcher, nh.setupError
+}
+
+func (nh *notifyHandler) TearDown() error {
+	nh.mu.Lock()
+	defer nh.mu.Unlock()
+	nh.actions = append(nh.actions, "teardown")
+	if nh.handled != nil {
+		close(nh.handled)
+	}
+	return nh.teardownError
+}
+
+func (nh *notifyHandler) Handle(_ <-chan struct{}) error {
+	nh.mu.Lock()
+	defer nh.mu.Unlock()
+	nh.actions = append(nh.actions, "handler")
+	if nh.handled != nil {
+		// Unlock while we are waiting for the send
+		nh.mu.Unlock()
+		nh.handled <- struct{}{}
+		nh.mu.Lock()
+	}
+	return nh.handlerError
+}
+
+func (nh *notifyHandler) CheckActions(c *gc.C, actions ...string) {
+	nh.mu.Lock()
+	defer nh.mu.Unlock()
+	c.Check(nh.actions, gc.DeepEquals, actions)
+}
+
+// During teardown we try to stop the worker, but don't hang the test suite if
+// Stop never returns
+func (s *notifyWorkerSuite) stopWorker(c *gc.C) {
+	if s.worker == nil {
+		return
+	}
+	done := make(chan error)
+	go func() {
+		done <- worker.Stop(s.worker)
+	}()
+	err := waitForTimeout(c, done, coretesting.LongWait)
+	c.Check(err, jc.ErrorIsNil)
+	s.actor = nil
+	s.worker = nil
+}
+
+func newTestNotifyWatcher() *testNotifyWatcher {
+	w := &testNotifyWatcher{
+		changes: make(chan struct{}),
+	}
+	go func() {
+		defer w.tomb.Done()
+		<-w.tomb.Dying()
+	}()
+	return w
+}
+
+type testNotifyWatcher struct {
+	tomb      tomb.Tomb
+	changes   chan struct{}
+	mu        sync.Mutex
+	stopError error
+}
+
+func (tnw *testNotifyWatcher) Changes() watcher.NotifyChan {
+	return tnw.changes
+}
+
+func (tnw *testNotifyWatcher) Kill() {
+	tnw.mu.Lock()
+	tnw.tomb.Kill(tnw.stopError)
+	tnw.mu.Unlock()
+}
+
+func (tnw *testNotifyWatcher) Wait() error {
+	return tnw.tomb.Wait()
+}
+
+func (tnw *testNotifyWatcher) Stopped() bool {
+	select {
+	case <-tnw.tomb.Dead():
+		return true
+	default:
+		return false
+	}
+}
+
+func (tnw *testNotifyWatcher) SetStopError(err error) {
+	tnw.mu.Lock()
+	tnw.stopError = err
+	tnw.mu.Unlock()
+}
+
+func (tnw *testNotifyWatcher) TriggerChange(c *gc.C) {
+	select {
+	case tnw.changes <- struct{}{}:
+	case <-time.After(coretesting.LongWait):
+		c.Errorf("timed out trying to trigger a change")
+	}
+}
+
+func waitForTimeout(c *gc.C, ch <-chan error, timeout time.Duration) error {
+	select {
+	case err := <-ch:
+		return err
+	case <-time.After(timeout):
+		c.Errorf("timed out waiting to receive a change after %s", timeout)
+	}
+	return nil
+}
+
+func waitShort(c *gc.C, w worker.Worker) error {
+	done := make(chan error)
+	go func() {
+		done <- w.Wait()
+	}()
+	return waitForTimeout(c, done, coretesting.ShortWait)
+}
+
+func waitForHandledNotify(c *gc.C, handled chan struct{}) {
+	select {
+	case <-handled:
+	case <-time.After(coretesting.LongWait):
+		c.Errorf("handled failed to signal after %s", coretesting.LongWait)
+	}
+}
+
+func (s *notifyWorkerSuite) TestKill(c *gc.C) {
+	s.worker.Kill()
+	err := waitShort(c, s.worker)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *notifyWorkerSuite) TestStop(c *gc.C) {
+	err := worker.Stop(s.worker)
+	c.Assert(err, jc.ErrorIsNil)
+	// After stop, Wait should return right away
+	err = waitShort(c, s.worker)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *notifyWorkerSuite) TestWait(c *gc.C) {
+	done := make(chan error)
+	go func() {
+		done <- s.worker.Wait()
+	}()
+	// Wait should not return until we've killed the worker
+	select {
+	case err := <-done:
+		c.Errorf("Wait() didn't wait until we stopped it: %v", err)
+	case <-time.After(coretesting.ShortWait):
+	}
+	s.worker.Kill()
+	err := waitForTimeout(c, done, coretesting.LongWait)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *notifyWorkerSuite) TestCallSetUpAndTearDown(c *gc.C) {
+	// After calling NewNotifyWorker, we should have called setup
+	s.actor.CheckActions(c, "setup")
+	// If we kill the worker, it should notice, and call teardown
+	s.worker.Kill()
+	err := waitShort(c, s.worker)
+	c.Check(err, jc.ErrorIsNil)
+	s.actor.CheckActions(c, "setup", "teardown")
+	c.Check(s.actor.watcher.Stopped(), jc.IsTrue)
+}
+
+func (s *notifyWorkerSuite) TestChangesTriggerHandler(c *gc.C) {
+	s.actor.CheckActions(c, "setup")
+	s.actor.watcher.TriggerChange(c)
+	waitForHandledNotify(c, s.actor.handled)
+	s.actor.CheckActions(c, "setup", "handler")
+	s.actor.watcher.TriggerChange(c)
+	waitForHandledNotify(c, s.actor.handled)
+	s.actor.watcher.TriggerChange(c)
+	waitForHandledNotify(c, s.actor.handled)
+	s.actor.CheckActions(c, "setup", "handler", "handler", "handler")
+	c.Assert(worker.Stop(s.worker), gc.IsNil)
+	s.actor.CheckActions(c, "setup", "handler", "handler", "handler", "teardown")
+}
+
+func (s *notifyWorkerSuite) TestSetUpFailureStopsWithTearDown(c *gc.C) {
+	// Stop the worker and SetUp again, this time with an error
+	s.stopWorker(c)
+	actor, w := newNotifyHandlerWorker(c, errors.New("my special error"), nil, errors.New("teardown"))
+	err := waitShort(c, w)
+	c.Check(err, gc.ErrorMatches, "my special error")
+	actor.CheckActions(c, "setup", "teardown")
+	c.Check(actor.watcher.Stopped(), jc.IsTrue)
+}
+
+func (s *notifyWorkerSuite) TestWatcherStopFailurePropagates(c *gc.C) {
+	s.actor.watcher.SetStopError(errors.New("error while stopping watcher"))
+	s.worker.Kill()
+	c.Assert(s.worker.Wait(), gc.ErrorMatches, "error while stopping watcher")
+	// We've already stopped the worker, don't let teardown notice the
+	// worker is in an error state
+	s.worker = nil
+}
+
+func (s *notifyWorkerSuite) TestCleanRunNoticesTearDownError(c *gc.C) {
+	s.actor.teardownError = errors.New("failed to tear down watcher")
+	s.worker.Kill()
+	c.Assert(s.worker.Wait(), gc.ErrorMatches, "failed to tear down watcher")
+	s.worker = nil
+}
+
+func (s *notifyWorkerSuite) TestHandleErrorStopsWorkerAndWatcher(c *gc.C) {
+	s.stopWorker(c)
+	actor, w := newNotifyHandlerWorker(c, nil, errors.New("my handling error"), nil)
+	actor.watcher.TriggerChange(c)
+	waitForHandledNotify(c, actor.handled)
+	err := waitShort(c, w)
+	c.Check(err, gc.ErrorMatches, "my handling error")
+	actor.CheckActions(c, "setup", "handler", "teardown")
+	c.Check(actor.watcher.Stopped(), jc.IsTrue)
+}
+
+func (s *notifyWorkerSuite) TestNoticesStoppedWatcher(c *gc.C) {
+	s.actor.watcher.SetStopError(errors.New("Stopped Watcher"))
+	s.actor.watcher.Kill()
+	err := waitShort(c, s.worker)
+	c.Check(err, gc.ErrorMatches, "Stopped Watcher")
+	s.actor.CheckActions(c, "setup", "teardown")
+	s.worker = nil
+}
+
+func (s *notifyWorkerSuite) TestErrorsOnClosedChannel(c *gc.C) {
+	close(s.actor.watcher.changes)
+	err := waitShort(c, s.worker)
+	c.Check(err, gc.ErrorMatches, "change channel closed")
+	s.actor.CheckActions(c, "setup", "teardown")
+	s.worker = nil
+}

--- a/watcher/package_test.go
+++ b/watcher/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package watcher_test
+
+import (
+	stdtesting "testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *stdtesting.T) {
+	gc.TestingT(t)
+}

--- a/watcher/relationunits.go
+++ b/watcher/relationunits.go
@@ -1,0 +1,40 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package watcher
+
+// UnitSettings specifies the version of some unit's settings in some relation.
+type UnitSettings struct {
+	Version int64
+}
+
+// RelationUnitsChange describes the membership and settings of; or changes to;
+// some relation scope.
+type RelationUnitsChange struct {
+
+	// Changed holds a set of units that are known to be in scope, and the
+	// latest known settings version for each.
+	Changed map[string]UnitSettings
+
+	// Departed holds a set of units that have previously been reported to
+	// be in scope, but which no longer are.
+	Departed []string
+}
+
+// RelationUnitsChan is a change channel as described in the CoreWatcher docs.
+//
+// It sends a single value representing the current membership of a relation
+// scope; and the versions of the settings documents for each; and subsequent
+// values representing entry, settings-change, and departure for units in that
+// scope.
+//
+// It feeds the joined-changed-departed logic in worker/uniter, but these events
+// do not map 1:1 with hooks.
+type RelationUnitsChan <-chan RelationUnitsChange
+
+// RelationUnitsWatcher conveniently ties a RelationUnitsChan to the
+// worker.Worker that represents its validity.
+type RelationUnitsWatcher interface {
+	CoreWatcher
+	Changes() RelationUnitsChan
+}

--- a/watcher/strings.go
+++ b/watcher/strings.go
@@ -1,0 +1,142 @@
+// Copyright 2013-2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package watcher
+
+import (
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/worker/catacomb"
+)
+
+// StringsChan is a change channel as described in the CoreWatcher docs.
+//
+// It sends a single value indicating a baseline set of values, and subsequent
+// values representing additions, changes, and/or removals of those values. The
+// precise semantics may depend upon the individual watcher.
+type StringsChan <-chan []string
+
+// StringsWatcher conveniently ties a StringsChan to the worker.Worker that
+// represents its validity.
+type StringsWatcher interface {
+	CoreWatcher
+	Changes() StringsChan
+}
+
+// StringsHandler defines the operation of a StringsWorker.
+type StringsHandler interface {
+
+	// SetUp is called once when creating a StringsWorker. It must return a
+	// StringsWatcher or an error. The StringsHandler takes responsibility for
+	// stopping any returned watcher and handling any errors.
+	SetUp() (StringsWatcher, error)
+
+	// Handle is called with every value received from the StringsWatcher
+	// returned by SetUp. If it returns an error, the StringsWorker will be
+	// stopped.
+	//
+	// If Handle runs any blocking operations it must pass through, or select
+	// on, the supplied abort channel; this channel will be closed when the
+	// StringsWorker is killed. An aborted Handle should not return an error.
+	Handle(abort <-chan struct{}, changes []string) error
+
+	// TearDown is called once when stopping a StringsWorker, whether or not
+	// SetUp succeeded. It need not concern itself with the StringsWatcher, but
+	// must clean up any other resources created in SetUp or Handle.
+	TearDown() error
+}
+
+// StringsConfig holds the direct dependencies of a StringsWorker.
+type StringsConfig struct {
+	Handler StringsHandler
+}
+
+// Validate returns ann error if the config cannot start a StringsWorker.
+func (config StringsConfig) Validate() error {
+	if config.Handler == nil {
+		return errors.NotValidf("nil Handler")
+	}
+	return nil
+}
+
+// NewStringsWorker starts a new worker that runs a StringsHandler.
+func NewStringsWorker(config StringsConfig) (*StringsWorker, error) {
+	if err := config.Validate(); err != nil {
+		return nil, errors.Trace(err)
+	}
+	sw := &StringsWorker{
+		config: config,
+	}
+	err := catacomb.Invoke(catacomb.Plan{
+		Site: &sw.catacomb,
+		Work: sw.loop,
+	})
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return sw, nil
+}
+
+// StringsWorker is a worker that wraps a StringsWatcher.
+type StringsWorker struct {
+	config   StringsConfig
+	catacomb catacomb.Catacomb
+}
+
+func (sw *StringsWorker) loop() (err error) {
+	changes := sw.setUp()
+	defer sw.tearDown(err)
+	for {
+		select {
+		case <-sw.catacomb.Dying():
+			return sw.catacomb.ErrDying()
+		case strings, ok := <-changes:
+			if !ok {
+				return errors.New("change channel closed")
+			}
+			abort := sw.catacomb.Dying()
+			err = sw.config.Handler.Handle(abort, strings)
+			if err != nil {
+				return err
+			}
+		}
+	}
+}
+
+// setUp calls the handler's SetUp method; registers any returned watcher with
+// the worker's catacomb; and returns the watcher's changes channel. Any errors
+// encountered kill the worker and cause a nil channel to be returned.
+func (sw *StringsWorker) setUp() StringsChan {
+	watcher, err := sw.config.Handler.SetUp()
+	if err != nil {
+		sw.catacomb.Kill(err)
+	}
+	if watcher == nil {
+		sw.catacomb.Kill(errors.New("handler returned nil watcher"))
+	} else {
+		if err := sw.catacomb.Add(watcher); err != nil {
+			sw.catacomb.Kill(err)
+		} else {
+			return watcher.Changes()
+		}
+	}
+	return nil
+}
+
+// tearDown kills the worker with the supplied error; and then kills it with
+// any error returned by the handler's TearDown method.
+func (sw *StringsWorker) tearDown(err error) {
+	sw.catacomb.Kill(err)
+	err = sw.config.Handler.TearDown()
+	sw.catacomb.Kill(err)
+}
+
+// Kill is part of the worker.Worker interface.
+func (sw *StringsWorker) Kill() {
+	sw.catacomb.Kill(nil)
+}
+
+// Wait is part of the worker.Worker interface.
+func (sw *StringsWorker) Wait() error {
+	return sw.catacomb.Wait()
+}

--- a/watcher/strings_test.go
+++ b/watcher/strings_test.go
@@ -1,0 +1,301 @@
+// Copyright 2013 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package watcher_test
+
+import (
+	"sync"
+	"time"
+
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"launchpad.net/tomb"
+
+	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/watcher"
+	"github.com/juju/juju/worker"
+)
+
+type stringsWorkerSuite struct {
+	coretesting.BaseSuite
+	worker worker.Worker
+	actor  *stringsHandler
+}
+
+var _ = gc.Suite(&stringsWorkerSuite{})
+
+func newStringsHandlerWorker(c *gc.C, setupError, handlerError, teardownError error) (*stringsHandler, worker.Worker) {
+	sh := &stringsHandler{
+		actions:       nil,
+		handled:       make(chan []string, 1),
+		setupError:    setupError,
+		teardownError: teardownError,
+		handlerError:  handlerError,
+		watcher:       newTestStringsWatcher(),
+		setupDone:     make(chan struct{}),
+	}
+	w, err := watcher.NewStringsWorker(watcher.StringsConfig{Handler: sh})
+	c.Assert(err, jc.ErrorIsNil)
+	select {
+	case <-sh.setupDone:
+	case <-time.After(coretesting.ShortWait):
+		c.Error("Failed waiting for stringsHandler.Setup to be called during SetUpTest")
+	}
+	return sh, w
+}
+
+func (s *stringsWorkerSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+	s.actor, s.worker = newStringsHandlerWorker(c, nil, nil, nil)
+}
+
+func (s *stringsWorkerSuite) TearDownTest(c *gc.C) {
+	s.stopWorker(c)
+	s.BaseSuite.TearDownTest(c)
+}
+
+type stringsHandler struct {
+	actions []string
+	mu      sync.Mutex
+	// Signal handled when we get a handle() call
+	handled       chan []string
+	setupError    error
+	teardownError error
+	handlerError  error
+	watcher       *testStringsWatcher
+	setupDone     chan struct{}
+}
+
+func (sh *stringsHandler) SetUp() (watcher.StringsWatcher, error) {
+	defer func() { sh.setupDone <- struct{}{} }()
+	sh.mu.Lock()
+	defer sh.mu.Unlock()
+	sh.actions = append(sh.actions, "setup")
+	if sh.watcher == nil {
+		return nil, sh.setupError
+	}
+	return sh.watcher, sh.setupError
+}
+
+func (sh *stringsHandler) TearDown() error {
+	sh.mu.Lock()
+	defer sh.mu.Unlock()
+	sh.actions = append(sh.actions, "teardown")
+	if sh.handled != nil {
+		close(sh.handled)
+	}
+	return sh.teardownError
+}
+
+func (sh *stringsHandler) Handle(_ <-chan struct{}, changes []string) error {
+	sh.mu.Lock()
+	defer sh.mu.Unlock()
+	sh.actions = append(sh.actions, "handler")
+	if sh.handled != nil {
+		// Unlock while we are waiting for the send
+		sh.mu.Unlock()
+		sh.handled <- changes
+		sh.mu.Lock()
+	}
+	return sh.handlerError
+}
+
+func (sh *stringsHandler) CheckActions(c *gc.C, actions ...string) {
+	sh.mu.Lock()
+	defer sh.mu.Unlock()
+	c.Check(sh.actions, gc.DeepEquals, actions)
+}
+
+// During teardown we try to stop the worker, but don't hang the test suite if
+// Stop never returns
+func (s *stringsWorkerSuite) stopWorker(c *gc.C) {
+	if s.worker == nil {
+		return
+	}
+	done := make(chan error)
+	go func() {
+		done <- worker.Stop(s.worker)
+	}()
+	err := waitForTimeout(c, done, coretesting.LongWait)
+	c.Check(err, jc.ErrorIsNil)
+	s.actor = nil
+	s.worker = nil
+}
+
+func newTestStringsWatcher() *testStringsWatcher {
+	w := &testStringsWatcher{
+		changes: make(chan []string),
+	}
+	go func() {
+		defer w.tomb.Done()
+		<-w.tomb.Dying()
+	}()
+	return w
+}
+
+type testStringsWatcher struct {
+	tomb      tomb.Tomb
+	changes   chan []string
+	mu        sync.Mutex
+	stopError error
+}
+
+func (tsw *testStringsWatcher) Changes() watcher.StringsChan {
+	return tsw.changes
+}
+
+func (tsw *testStringsWatcher) Kill() {
+	tsw.mu.Lock()
+	tsw.tomb.Kill(tsw.stopError)
+	tsw.mu.Unlock()
+}
+
+func (tsw *testStringsWatcher) Wait() error {
+	return tsw.tomb.Wait()
+}
+
+func (tsw *testStringsWatcher) Stopped() bool {
+	select {
+	case <-tsw.tomb.Dead():
+		return true
+	default:
+		return false
+	}
+}
+
+func (tsw *testStringsWatcher) SetStopError(err error) {
+	tsw.mu.Lock()
+	tsw.stopError = err
+	tsw.mu.Unlock()
+}
+
+func (tsw *testStringsWatcher) TriggerChange(c *gc.C, changes []string) {
+	select {
+	case tsw.changes <- changes:
+	case <-time.After(coretesting.LongWait):
+		c.Errorf("timed out trying to trigger a change")
+	}
+}
+
+func waitForHandledStrings(c *gc.C, handled chan []string, expect []string) {
+	select {
+	case changes := <-handled:
+		c.Assert(changes, gc.DeepEquals, expect)
+	case <-time.After(coretesting.LongWait):
+		c.Errorf("handled failed to signal after %s", coretesting.LongWait)
+	}
+}
+
+func (s *stringsWorkerSuite) TestKill(c *gc.C) {
+	s.worker.Kill()
+	err := waitShort(c, s.worker)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *stringsWorkerSuite) TestStop(c *gc.C) {
+	err := worker.Stop(s.worker)
+	c.Assert(err, jc.ErrorIsNil)
+	// After stop, Wait should return right away
+	err = waitShort(c, s.worker)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *stringsWorkerSuite) TestWait(c *gc.C) {
+	done := make(chan error)
+	go func() {
+		done <- s.worker.Wait()
+	}()
+	// Wait should not return until we've killed the worker
+	select {
+	case err := <-done:
+		c.Errorf("Wait() didn't wait until we stopped it: %v", err)
+	case <-time.After(coretesting.ShortWait):
+	}
+	s.worker.Kill()
+	err := waitForTimeout(c, done, coretesting.LongWait)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *stringsWorkerSuite) TestCallSetUpAndTearDown(c *gc.C) {
+	// After calling NewStringsWorker, we should have called setup
+	s.actor.CheckActions(c, "setup")
+	// If we kill the worker, it should notice, and call teardown
+	s.worker.Kill()
+	err := waitShort(c, s.worker)
+	c.Check(err, jc.ErrorIsNil)
+	s.actor.CheckActions(c, "setup", "teardown")
+	c.Check(s.actor.watcher.Stopped(), jc.IsTrue)
+}
+
+func (s *stringsWorkerSuite) TestChangesTriggerHandler(c *gc.C) {
+	s.actor.CheckActions(c, "setup")
+	s.actor.watcher.TriggerChange(c, []string{"aa", "bb"})
+	waitForHandledStrings(c, s.actor.handled, []string{"aa", "bb"})
+	s.actor.CheckActions(c, "setup", "handler")
+	s.actor.watcher.TriggerChange(c, []string{"cc", "dd"})
+	waitForHandledStrings(c, s.actor.handled, []string{"cc", "dd"})
+	s.actor.watcher.TriggerChange(c, []string{"ee", "ff"})
+	waitForHandledStrings(c, s.actor.handled, []string{"ee", "ff"})
+	s.actor.CheckActions(c, "setup", "handler", "handler", "handler")
+	c.Assert(worker.Stop(s.worker), gc.IsNil)
+	s.actor.CheckActions(c, "setup", "handler", "handler", "handler", "teardown")
+}
+
+func (s *stringsWorkerSuite) TestSetUpFailureStopsWithTearDown(c *gc.C) {
+	// Stop the worker and SetUp again, this time with an error
+	s.stopWorker(c)
+	actor, w := newStringsHandlerWorker(c, errors.New("my special error"), nil, nil)
+	err := waitShort(c, w)
+	c.Check(err, gc.ErrorMatches, "my special error")
+	actor.CheckActions(c, "setup", "teardown")
+	c.Check(actor.watcher.Stopped(), jc.IsTrue)
+}
+
+func (s *stringsWorkerSuite) TestWatcherStopFailurePropagates(c *gc.C) {
+	s.actor.watcher.SetStopError(errors.New("error while stopping watcher"))
+	s.worker.Kill()
+	c.Assert(s.worker.Wait(), gc.ErrorMatches, "error while stopping watcher")
+	// We've already stopped the worker, don't let teardown notice the
+	// worker is in an error state
+	s.worker = nil
+}
+
+func (s *stringsWorkerSuite) TestCleanRunNoticesTearDownError(c *gc.C) {
+	s.actor.teardownError = errors.New("failed to tear down watcher")
+	s.worker.Kill()
+	c.Assert(s.worker.Wait(), gc.ErrorMatches, "failed to tear down watcher")
+	s.worker = nil
+}
+
+func (s *stringsWorkerSuite) TestHandleErrorStopsWorkerAndWatcher(c *gc.C) {
+	s.stopWorker(c)
+	actor, w := newStringsHandlerWorker(c, nil, errors.New("my handling error"), nil)
+	actor.watcher.TriggerChange(c, []string{"aa", "bb"})
+	waitForHandledStrings(c, actor.handled, []string{"aa", "bb"})
+	err := waitShort(c, w)
+	c.Check(err, gc.ErrorMatches, "my handling error")
+	actor.CheckActions(c, "setup", "handler", "teardown")
+	c.Check(actor.watcher.Stopped(), jc.IsTrue)
+}
+
+func (s *stringsWorkerSuite) TestNoticesStoppedWatcher(c *gc.C) {
+	// The default closedHandler doesn't panic if you have a genuine error
+	// (because it assumes you want to propagate a real error and then
+	// restart
+	s.actor.watcher.SetStopError(errors.New("Stopped Watcher"))
+	s.actor.watcher.Kill()
+	err := waitShort(c, s.worker)
+	c.Check(err, gc.ErrorMatches, "Stopped Watcher")
+	s.actor.CheckActions(c, "setup", "teardown")
+	// Worker is stopped, don't fail TearDownTest
+	s.worker = nil
+}
+
+func (s *stringsWorkerSuite) TestErrorsOnClosedChannel(c *gc.C) {
+	close(s.actor.watcher.changes)
+	err := waitShort(c, s.worker)
+	c.Check(err, gc.ErrorMatches, "change channel closed")
+	s.actor.CheckActions(c, "setup", "teardown")
+	s.worker = nil
+}

--- a/watcher/watchertest/notify.go
+++ b/watcher/watchertest/notify.go
@@ -1,0 +1,81 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package watchertest
+
+import (
+	"time"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/testing"
+	"github.com/juju/juju/watcher"
+)
+
+func NewNotifyWatcherC(c *gc.C, watcher watcher.NotifyWatcher, preAssert func()) NotifyWatcherC {
+	if preAssert == nil {
+		preAssert = func() {}
+	}
+	return NotifyWatcherC{
+		C:         c,
+		Watcher:   watcher,
+		PreAssert: preAssert,
+	}
+}
+
+type NotifyWatcherC struct {
+	*gc.C
+	Watcher   watcher.NotifyWatcher
+	PreAssert func()
+}
+
+// AssertOneChange fails if no change is sent before a long time has passed; or
+// if, subsequent to that, any further change is sent before a short time has
+// passed.
+func (c NotifyWatcherC) AssertOneChange() {
+	c.PreAssert()
+	select {
+	case _, ok := <-c.Watcher.Changes():
+		c.Assert(ok, jc.IsTrue)
+	case <-time.After(testing.LongWait):
+		c.Fatalf("watcher did not send change")
+	}
+	c.AssertNoChange()
+}
+
+// AssertNoChange fails if it manages to read a value from Changes before a
+// short time has passed.
+func (c NotifyWatcherC) AssertNoChange() {
+	c.PreAssert()
+	select {
+	case _, ok := <-c.Watcher.Changes():
+		c.Fatalf("watcher sent unexpected change: (_, %v)", ok)
+	case <-time.After(testing.ShortWait):
+	}
+}
+
+// AssertStops Kills the watcher and asserts (1) that Wait completes without
+// error before a long time has passed; and (2) that Changes remains open but
+// no values are being sent.
+func (c NotifyWatcherC) AssertStops() {
+	c.Watcher.Kill()
+	wait := make(chan error)
+	go func() {
+		c.PreAssert()
+		wait <- c.Watcher.Wait()
+	}()
+	select {
+	case <-time.After(testing.LongWait):
+		c.Fatalf("watcher never stopped")
+	case err := <-wait:
+		c.Assert(err, jc.ErrorIsNil)
+	}
+
+	c.PreAssert()
+	select {
+	case _, ok := <-c.Watcher.Changes():
+		c.Fatalf("watcher sent unexpected change: (_, %v)", ok)
+	default:
+	}
+}

--- a/watcher/watchertest/relationunits.go
+++ b/watcher/watchertest/relationunits.go
@@ -1,0 +1,106 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package watchertest
+
+import (
+	"time"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/testing"
+	"github.com/juju/juju/watcher"
+)
+
+// NewRelationUnitsWatcherC returns a RelationUnitsWatcherC that
+// checks for aggressive event coalescence.
+func NewRelationUnitsWatcherC(c *gc.C, w watcher.RelationUnitsWatcher, preAssert func()) RelationUnitsWatcherC {
+	if preAssert == nil {
+		preAssert = func() {}
+	}
+	return RelationUnitsWatcherC{
+		C:                c,
+		PreAssert:        preAssert,
+		Watcher:          w,
+		settingsVersions: make(map[string]int64),
+	}
+}
+
+type RelationUnitsWatcherC struct {
+	*gc.C
+	Watcher          watcher.RelationUnitsWatcher
+	PreAssert        func()
+	settingsVersions map[string]int64
+}
+
+func (c RelationUnitsWatcherC) AssertNoChange() {
+	c.PreAssert()
+	select {
+	case actual, ok := <-c.Watcher.Changes():
+		c.Fatalf("watcher sent unexpected change: (%#v, %v)", actual, ok)
+	case <-time.After(testing.ShortWait):
+	}
+}
+
+// AssertChange asserts the given changes was reported by the watcher,
+// but does not assume there are no following changes.
+func (c RelationUnitsWatcherC) AssertChange(changed []string, departed []string) {
+	// Get all items in changed in a map for easy lookup.
+	changedNames := make(map[string]bool)
+	for _, name := range changed {
+		changedNames[name] = true
+	}
+	c.PreAssert()
+	timeout := time.After(testing.LongWait)
+	select {
+	case actual, ok := <-c.Watcher.Changes():
+		c.Assert(ok, jc.IsTrue)
+		c.Assert(actual.Changed, gc.HasLen, len(changed))
+		// Because the versions can change, we only need to make sure
+		// the keys match, not the contents (UnitSettings == txnRevno).
+		for k, settings := range actual.Changed {
+			_, ok := changedNames[k]
+			c.Assert(ok, jc.IsTrue)
+			oldVer, ok := c.settingsVersions[k]
+			if !ok {
+				// This is the first time we see this unit, so
+				// save the settings version for later.
+				c.settingsVersions[k] = settings.Version
+			} else {
+				// Already seen; make sure the version increased.
+				if settings.Version <= oldVer {
+					c.Fatalf("expected unit settings version > %d (got %d)", oldVer, settings.Version)
+				}
+			}
+		}
+		c.Assert(actual.Departed, jc.SameContents, departed)
+	case <-timeout:
+		c.Fatalf("watcher did not send change")
+	}
+}
+
+// AssertStops Kills the watcher and asserts (1) that Wait completes without
+// error before a long time has passed; and (2) that Changes remains open but
+// no values are being sent.
+func (c RelationUnitsWatcherC) AssertStops() {
+	c.Watcher.Kill()
+	wait := make(chan error)
+	go func() {
+		c.PreAssert()
+		wait <- c.Watcher.Wait()
+	}()
+	select {
+	case <-time.After(testing.LongWait):
+		c.Fatalf("watcher never stopped")
+	case err := <-wait:
+		c.Assert(err, jc.ErrorIsNil)
+	}
+
+	c.PreAssert()
+	select {
+	case change, ok := <-c.Watcher.Changes():
+		c.Fatalf("watcher sent unexpected change: (%#v, %v)", change, ok)
+	default:
+	}
+}

--- a/watcher/watchertest/strings.go
+++ b/watcher/watchertest/strings.go
@@ -1,0 +1,144 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package watchertest
+
+import (
+	"time"
+
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/set"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/testing"
+	"github.com/juju/juju/watcher"
+)
+
+func NewStringsWatcherC(c *gc.C, watcher watcher.StringsWatcher, preAssert func()) StringsWatcherC {
+	if preAssert == nil {
+		preAssert = func() {}
+	}
+	return StringsWatcherC{
+		C:         c,
+		Watcher:   watcher,
+		PreAssert: preAssert,
+	}
+}
+
+type StringsWatcherC struct {
+	*gc.C
+	Watcher   watcher.StringsWatcher
+	PreAssert func()
+}
+
+// AssertChanges fails if it cannot read a value from Changes despite waiting a
+// long time. It logs, but does not check, the received changes; but will fail
+// if the Changes chan is closed.
+func (c StringsWatcherC) AssertChanges() {
+	c.PreAssert()
+	select {
+	case change, ok := <-c.Watcher.Changes():
+		c.Logf("received change: %#v", change)
+		c.Assert(ok, jc.IsTrue)
+	case <-time.After(testing.LongWait):
+		c.Fatalf("watcher did not send change")
+	}
+	c.AssertNoChange()
+}
+
+// AssertNoChange fails if it manages to read a value from Changes before a
+// short time has passed.
+func (c StringsWatcherC) AssertNoChange() {
+	c.PreAssert()
+	select {
+	case change, ok := <-c.Watcher.Changes():
+		c.Fatalf("watcher sent unexpected change: (%#v, %v)", change, ok)
+	case <-time.After(testing.ShortWait):
+	}
+}
+
+// AssertStops Kills the watcher and asserts (1) that Wait completes without
+// error before a long time has passed; and (2) that Changes remains open but
+// no values are being sent.
+func (c StringsWatcherC) AssertStops() {
+	c.Watcher.Kill()
+	wait := make(chan error)
+	go func() {
+		c.PreAssert()
+		wait <- c.Watcher.Wait()
+	}()
+	select {
+	case <-time.After(testing.LongWait):
+		c.Fatalf("watcher never stopped")
+	case err := <-wait:
+		c.Assert(err, jc.ErrorIsNil)
+	}
+
+	c.PreAssert()
+	select {
+	case change, ok := <-c.Watcher.Changes():
+		c.Fatalf("watcher sent unexpected change: (%#v, %v)", change, ok)
+	default:
+	}
+}
+
+func (c StringsWatcherC) AssertChange(expect ...string) {
+	c.assertChange(false, expect...)
+}
+
+func (c StringsWatcherC) AssertChangeInSingleEvent(expect ...string) {
+	c.assertChange(true, expect...)
+}
+
+// AssertChangeMaybeIncluding verifies that there is a change that may
+// contain zero to all of the passed in strings, and no other changes.
+func (c StringsWatcherC) AssertChangeMaybeIncluding(expect ...string) {
+	maxCount := len(expect)
+	actual := c.collectChanges(true, maxCount)
+
+	if maxCount == 0 {
+		c.Assert(actual, gc.HasLen, 0)
+	} else {
+		actualCount := len(actual)
+		c.Assert(actualCount <= maxCount, jc.IsTrue, gc.Commentf("expected at most %d, got %d", maxCount, actualCount))
+		unexpected := set.NewStrings(actual...).Difference(set.NewStrings(expect...))
+		c.Assert(unexpected.Values(), gc.HasLen, 0)
+	}
+}
+
+// assertChange asserts the given list of changes was reported by
+// the watcher, but does not assume there are no following changes.
+func (c StringsWatcherC) assertChange(single bool, expect ...string) {
+	actual := c.collectChanges(single, len(expect))
+	if len(expect) == 0 {
+		c.Assert(actual, gc.HasLen, 0)
+	} else {
+		c.Assert(actual, jc.SameContents, expect)
+	}
+}
+
+// collectChanges gets up to the max number of changes within the
+// testing.LongWait period.
+func (c StringsWatcherC) collectChanges(single bool, max int) []string {
+	timeout := time.After(testing.LongWait)
+	var actual []string
+	gotOneChange := false
+loop:
+	for {
+		c.PreAssert()
+		select {
+		case changes, ok := <-c.Watcher.Changes():
+			c.Assert(ok, jc.IsTrue)
+			gotOneChange = true
+			actual = append(actual, changes...)
+			if single || len(actual) >= max {
+				break loop
+			}
+		case <-timeout:
+			if !gotOneChange {
+				c.Fatalf("watcher did not send change")
+			}
+		}
+	}
+	return actual
+}

--- a/worker/catacomb/catacomb_test.go
+++ b/worker/catacomb/catacomb_test.go
@@ -428,16 +428,17 @@ func (s *CatacombSuite) TestPlanBadSite(c *gc.C) {
 		Init: []worker.Worker{w},
 	}
 	checkInvalid(c, plan, "nil Site not valid")
-	w.waitStillAlive(c)
+	w.assertDead(c)
 }
 
 func (s *CatacombSuite) TestPlanBadWork(c *gc.C) {
 	w := s.fix.startErrorWorker(c, nil)
 	plan := catacomb.Plan{
 		Site: &catacomb.Catacomb{},
+		Init: []worker.Worker{w},
 	}
 	checkInvalid(c, plan, "nil Work not valid")
-	w.waitStillAlive(c)
+	w.assertDead(c)
 }
 
 func (s *CatacombSuite) TestPlanBadInit(c *gc.C) {
@@ -448,7 +449,7 @@ func (s *CatacombSuite) TestPlanBadInit(c *gc.C) {
 		Init: []worker.Worker{w, nil},
 	}
 	checkInvalid(c, plan, "nil Init item 1 not valid")
-	w.waitStillAlive(c)
+	w.assertDead(c)
 }
 
 func checkInvalid(c *gc.C, plan catacomb.Plan, match string) {

--- a/worker/catacomb/catacomb_test.go
+++ b/worker/catacomb/catacomb_test.go
@@ -414,11 +414,14 @@ func (s *CatacombSuite) TestReusedCatacomb(c *gc.C) {
 	err = site.Wait()
 	c.Check(err, jc.ErrorIsNil)
 
+	w := s.fix.startErrorWorker(c, nil)
 	err = catacomb.Invoke(catacomb.Plan{
 		Site: &site,
 		Work: func() error { return nil },
+		Init: []worker.Worker{w},
 	})
 	c.Check(err, gc.ErrorMatches, "catacomb 0x[0-9a-f]+ has already been used")
+	w.assertDead(c)
 }
 
 func (s *CatacombSuite) TestPlanBadSite(c *gc.C) {

--- a/worker/catacomb/catacomb_test.go
+++ b/worker/catacomb/catacomb_test.go
@@ -12,7 +12,8 @@ import (
 	gc "gopkg.in/check.v1"
 	"launchpad.net/tomb"
 
-	_ "github.com/juju/juju/worker/catacomb"
+	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/catacomb"
 )
 
 type CatacombSuite struct {
@@ -184,6 +185,16 @@ func (s *CatacombSuite) TestStopsAddedWorker(c *gc.C) {
 	w.assertDead(c)
 }
 
+func (s *CatacombSuite) TestStopsInitWorker(c *gc.C) {
+	w := s.fix.startErrorWorker(c, nil)
+
+	err := s.fix.run(c, func() {
+		w.waitStillAlive(c)
+	}, w)
+	c.Check(err, jc.ErrorIsNil)
+	w.assertDead(c)
+}
+
 func (s *CatacombSuite) TestStoppedWorkerErrorOverwritesNil(c *gc.C) {
 	expect := errors.New("splot")
 	w := s.fix.startErrorWorker(c, expect)
@@ -279,6 +290,17 @@ func (s *CatacombSuite) TestAddFailedWorkerKills(c *gc.C) {
 	c.Check(err, gc.Equals, expect)
 }
 
+func (s *CatacombSuite) TestInitFailedWorkerKills(c *gc.C) {
+	expect := errors.New("blarft")
+	w := s.fix.startErrorWorker(c, expect)
+	w.stop()
+
+	err := s.fix.run(c, func() {
+		s.fix.waitDying(c)
+	}, w)
+	c.Check(err, gc.Equals, expect)
+}
+
 func (s *CatacombSuite) TestFinishAddedWorkerDoesNotKill(c *gc.C) {
 	w := s.fix.startErrorWorker(c, nil)
 
@@ -304,6 +326,17 @@ func (s *CatacombSuite) TestAddFinishedWorkerDoesNotKill(c *gc.C) {
 		w2 := s.fix.startErrorWorker(c, nil)
 		s.fix.assertAddAlive(c, w2)
 	})
+	c.Check(err, jc.ErrorIsNil)
+}
+
+func (s *CatacombSuite) TestInitFinishedWorkerDoesNotKill(c *gc.C) {
+	w := s.fix.startErrorWorker(c, nil)
+	w.stop()
+
+	err := s.fix.run(c, func() {
+		w2 := s.fix.startErrorWorker(c, nil)
+		s.fix.assertAddAlive(c, w2)
+	}, w)
 	c.Check(err, jc.ErrorIsNil)
 }
 
@@ -369,4 +402,60 @@ func (s *CatacombSuite) TestStressAddKillRaces(c *gc.C) {
 	})
 	cause := errors.Cause(err)
 	c.Check(cause, gc.Equals, errFailed)
+}
+
+func (s *CatacombSuite) TestReusedCatacomb(c *gc.C) {
+	var site catacomb.Catacomb
+	err := catacomb.Invoke(catacomb.Plan{
+		Site: &site,
+		Work: func() error { return nil },
+	})
+	c.Check(err, jc.ErrorIsNil)
+	err = site.Wait()
+	c.Check(err, jc.ErrorIsNil)
+
+	err = catacomb.Invoke(catacomb.Plan{
+		Site: &site,
+		Work: func() error { return nil },
+	})
+	c.Check(err, gc.ErrorMatches, "catacomb 0x[0-9a-f]+ has already been used")
+}
+
+func (s *CatacombSuite) TestPlanBadSite(c *gc.C) {
+	w := s.fix.startErrorWorker(c, nil)
+	plan := catacomb.Plan{
+		Work: func() error { panic("no") },
+		Init: []worker.Worker{w},
+	}
+	checkInvalid(c, plan, "nil Site not valid")
+	w.waitStillAlive(c)
+}
+
+func (s *CatacombSuite) TestPlanBadWork(c *gc.C) {
+	w := s.fix.startErrorWorker(c, nil)
+	plan := catacomb.Plan{
+		Site: &catacomb.Catacomb{},
+	}
+	checkInvalid(c, plan, "nil Work not valid")
+	w.waitStillAlive(c)
+}
+
+func (s *CatacombSuite) TestPlanBadInit(c *gc.C) {
+	w := s.fix.startErrorWorker(c, nil)
+	plan := catacomb.Plan{
+		Site: &catacomb.Catacomb{},
+		Work: func() error { panic("no") },
+		Init: []worker.Worker{w, nil},
+	}
+	checkInvalid(c, plan, "nil Init item 1 not valid")
+	w.waitStillAlive(c)
+}
+
+func checkInvalid(c *gc.C, plan catacomb.Plan, match string) {
+	check := func(err error) {
+		c.Check(err, gc.ErrorMatches, match)
+		c.Check(err, jc.Satisfies, errors.IsNotValid)
+	}
+	check(plan.Validate())
+	check(catacomb.Invoke(plan))
 }

--- a/worker/catacomb/fixture_test.go
+++ b/worker/catacomb/fixture_test.go
@@ -12,6 +12,7 @@ import (
 	"launchpad.net/tomb"
 
 	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/catacomb"
 )
 
@@ -24,10 +25,11 @@ type fixture struct {
 	cleaner  cleaner
 }
 
-func (fix *fixture) run(c *gc.C, task func()) error {
+func (fix *fixture) run(c *gc.C, task func(), init ...worker.Worker) error {
 	err := catacomb.Invoke(catacomb.Plan{
 		Site: &fix.catacomb,
 		Work: func() error { task(); return nil },
+		Init: init,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/worker/certupdater/certupdater.go
+++ b/worker/certupdater/certupdater.go
@@ -10,12 +10,12 @@ import (
 	"github.com/juju/loggo"
 	"github.com/juju/utils/set"
 
-	"github.com/juju/juju/api/watcher"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cert"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/watcher/legacy"
 	"github.com/juju/juju/worker"
 )
 
@@ -70,7 +70,7 @@ type APIHostPortsGetter interface {
 func NewCertificateUpdater(addressWatcher AddressWatcher, getter StateServingInfoGetter,
 	configGetter EnvironConfigGetter, hostPortsGetter APIHostPortsGetter, setter StateServingInfoSetter,
 ) worker.Worker {
-	return worker.NewNotifyWorker(&CertificateUpdater{
+	return legacy.NewNotifyWorker(&CertificateUpdater{
 		addressWatcher:  addressWatcher,
 		configGetter:    configGetter,
 		hostPortsGetter: hostPortsGetter,
@@ -80,7 +80,7 @@ func NewCertificateUpdater(addressWatcher AddressWatcher, getter StateServingInf
 }
 
 // SetUp is defined on the NotifyWatchHandler interface.
-func (c *CertificateUpdater) SetUp() (watcher.NotifyWatcher, error) {
+func (c *CertificateUpdater) SetUp() (state.NotifyWatcher, error) {
 	// Populate certificate SAN with any addresses we know about now.
 	apiHostPorts, err := c.hostPortsGetter.APIHostPorts()
 	if err != nil {

--- a/worker/minunitsworker/minunitsworker.go
+++ b/worker/minunitsworker/minunitsworker.go
@@ -6,9 +6,10 @@ package minunitsworker
 import (
 	"github.com/juju/loggo"
 
-	"github.com/juju/juju/api/watcher"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/worker"
+
+	"github.com/juju/juju/watcher/legacy"
 )
 
 var logger = loggo.GetLogger("juju.worker.minunitsworker")
@@ -23,10 +24,10 @@ type MinUnitsWorker struct {
 // minimum required number of units for a service is increased.
 func NewMinUnitsWorker(st *state.State) worker.Worker {
 	mu := &MinUnitsWorker{st: st}
-	return worker.NewStringsWorker(mu)
+	return legacy.NewStringsWorker(mu)
 }
 
-func (mu *MinUnitsWorker) SetUp() (watcher.StringsWatcher, error) {
+func (mu *MinUnitsWorker) SetUp() (state.StringsWatcher, error) {
 	return mu.st.WatchMinUnits(), nil
 }
 

--- a/worker/minunitsworker/minunitsworker_test.go
+++ b/worker/minunitsworker/minunitsworker_test.go
@@ -4,7 +4,6 @@
 package minunitsworker_test
 
 import (
-	stdtesting "testing"
 	"time"
 
 	"github.com/juju/loggo"
@@ -19,17 +18,11 @@ import (
 
 var logger = loggo.GetLogger("juju.worker.minunitsworker_test")
 
-func TestPackage(t *stdtesting.T) {
-	coretesting.MgoTestPackage(t)
-}
-
 type minUnitsWorkerSuite struct {
 	testing.JujuConnSuite
 }
 
 var _ = gc.Suite(&minUnitsWorkerSuite{})
-
-var _ worker.StringsWatchHandler = (*minunitsworker.MinUnitsWorker)(nil)
 
 func (s *minUnitsWorkerSuite) TestMinUnitsWorker(c *gc.C) {
 	mu := minunitsworker.NewMinUnitsWorker(s.State)

--- a/worker/minunitsworker/package_test.go
+++ b/worker/minunitsworker/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2013 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package minunitsworker_test
+
+import (
+	stdtesting "testing"
+
+	coretesting "github.com/juju/juju/testing"
+)
+
+func TestPackage(t *stdtesting.T) {
+	coretesting.MgoTestPackage(t)
+}


### PR DESCRIPTION
This contains copies of the `./worker.StringsWorker` and `./worker/NotifyWorker`, some subset of which is still needed by `./worker/certupdater` and `./worker/minunitsworker`. They should probably go, but they's not my primary focus at the moment; fixing the api watchers takes priority, and this addition can be cleanly extracted from the forthcoming watcher-monster PR.

(Review request: http://reviews.vapour.ws/r/3146/)