### PR TITLE
cmd/jujud/agent/unit: removed APIInfo gate

### DIFF
--- a/cmd/jujud/agent/unit/manifolds.go
+++ b/cmd/jujud/agent/unit/manifolds.go
@@ -13,7 +13,6 @@ import (
 	"github.com/juju/juju/worker/apicaller"
 	"github.com/juju/juju/worker/dependency"
 	"github.com/juju/juju/worker/fortress"
-	"github.com/juju/juju/worker/gate"
 	"github.com/juju/juju/worker/leadership"
 	"github.com/juju/juju/worker/logger"
 	"github.com/juju/juju/worker/logsender"
@@ -69,16 +68,8 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 		// how this works when we consolidate the agents; might be best to
 		// handle the auth changes server-side..?
 		APICallerName: apicaller.Manifold(apicaller.ManifoldConfig{
-			AgentName:       AgentName,
-			APIInfoGateName: APIInfoGateName,
+			AgentName: AgentName,
 		}),
-
-		// This manifold is used to coordinate between the api caller and the
-		// log sender, which share the API credentials that the API caller may
-		// update. To avoid surprising races, the log sender waits for the api
-		// caller to unblock this, indicating that any password dance has been
-		// completed and the log-sender can now connect without confusion.
-		APIInfoGateName: gate.Manifold(),
 
 		// The log sender is a leaf worker that sends log messages to some
 		// API server, when configured so to do. We should only need one of
@@ -200,7 +191,6 @@ const (
 	AgentName                = "agent"
 	APIAdddressUpdaterName   = "api-address-updater"
 	APICallerName            = "api-caller"
-	APIInfoGateName          = "api-info-gate"
 	LeadershipTrackerName    = "leadership-tracker"
 	LoggingConfigUpdaterName = "logging-config-updater"
 	LogSenderName            = "log-sender"

--- a/cmd/jujud/agent/unit/manifolds_test.go
+++ b/cmd/jujud/agent/unit/manifolds_test.go
@@ -41,7 +41,6 @@ func (s *ManifoldsSuite) TestManifoldNames(c *gc.C) {
 		unit.AgentName,
 		unit.APIAdddressUpdaterName,
 		unit.APICallerName,
-		unit.APIInfoGateName,
 		unit.LeadershipTrackerName,
 		unit.LoggingConfigUpdaterName,
 		unit.LogSenderName,

--- a/worker/apicaller/manifold_test.go
+++ b/worker/apicaller/manifold_test.go
@@ -25,7 +25,6 @@ type ManifoldSuite struct {
 	testing.Stub
 	manifold    dependency.Manifold
 	agent       *mockAgent
-	gate        *mockGate
 	conn        *mockConn
 	getResource dependency.GetResourceFunc
 }
@@ -36,20 +35,15 @@ func (s *ManifoldSuite) SetUpTest(c *gc.C) {
 	s.IsolationSuite.SetUpTest(c)
 	s.Stub = testing.Stub{}
 	s.manifold = apicaller.Manifold(apicaller.ManifoldConfig{
-		AgentName:       "agent-name",
-		APIInfoGateName: "api-info-gate-name",
+		AgentName: "agent-name",
 	})
 
 	s.agent = &mockAgent{
 		stub: &s.Stub,
 		env:  coretesting.EnvironmentTag,
 	}
-	s.gate = &mockGate{
-		stub: &s.Stub,
-	}
 	s.getResource = dt.StubGetResource(dt.StubResources{
-		"agent-name":         dt.StubResource{Output: s.agent},
-		"api-info-gate-name": dt.StubResource{Output: s.gate},
+		"agent-name": dt.StubResource{Output: s.agent},
 	})
 
 	// Watch out for this: it uses its own Stub because Close calls are made from
@@ -70,25 +64,12 @@ func (s *ManifoldSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *ManifoldSuite) TestInputs(c *gc.C) {
-	c.Check(s.manifold.Inputs, jc.DeepEquals, []string{"agent-name", "api-info-gate-name"})
+	c.Check(s.manifold.Inputs, jc.DeepEquals, []string{"agent-name"})
 }
 
 func (s *ManifoldSuite) TestStartMissingAgent(c *gc.C) {
 	getResource := dt.StubGetResource(dt.StubResources{
-		"agent-name":         dt.StubResource{Error: dependency.ErrMissing},
-		"api-info-gate-name": dt.StubResource{Output: s.gate},
-	})
-
-	worker, err := s.manifold.Start(getResource)
-	c.Check(worker, gc.IsNil)
-	c.Check(err, gc.Equals, dependency.ErrMissing)
-	s.CheckCalls(c, nil)
-}
-
-func (s *ManifoldSuite) TestStartMissingGate(c *gc.C) {
-	getResource := dt.StubGetResource(dt.StubResources{
-		"agent-name":         dt.StubResource{Output: s.agent},
-		"api-info-gate-name": dt.StubResource{Error: dependency.ErrMissing},
+		"agent-name": dt.StubResource{Error: dependency.ErrMissing},
 	})
 
 	worker, err := s.manifold.Start(getResource)
@@ -116,8 +97,6 @@ func (s *ManifoldSuite) TestStartSuccessWithEnvironnmentIdSet(c *gc.C) {
 	s.CheckCalls(c, []testing.StubCall{{
 		FuncName: "openConnection",
 		Args:     []interface{}{s.agent},
-	}, {
-		FuncName: "Unlock",
 	}})
 }
 
@@ -133,7 +112,7 @@ func (s *ManifoldSuite) setupMutatorTest(c *gc.C) agent.ConfigMutator {
 	c.Assert(err, jc.ErrorIsNil)
 	s.AddCleanup(func(c *gc.C) { assertStop(c, worker) })
 
-	s.CheckCallNames(c, "openConnection", "ChangeConfig", "Unlock")
+	s.CheckCallNames(c, "openConnection", "ChangeConfig")
 	changeArgs := s.Calls()[1].Args
 	c.Assert(changeArgs, gc.HasLen, 1)
 	s.ResetCalls()


### PR DESCRIPTION
This gate is no longer in use. The problem it was dealing with is now handled in another way.

(Review request: http://reviews.vapour.ws/r/3148/)