### PR TITLE
api: Ensure safe access to state.loggedIn

### DIFF
--- a/api/http.go
+++ b/api/http.go
@@ -18,7 +18,7 @@ import (
 
 // HTTPClient implements Connection.APICaller.HTTPClient.
 func (s *state) HTTPClient() (*httprequest.Client, error) {
-	if !s.loggedIn {
+	if !s.isLoggedIn() {
 		return nil, errors.New("no HTTP client available without logging in")
 	}
 	baseURL, err := s.apiEndpoint("/", "")

--- a/api/state.go
+++ b/api/state.go
@@ -198,7 +198,8 @@ func (st *state) setLoginResult(tag names.Tag, environTag, controllerTag string,
 	for _, facade := range facades {
 		st.facadeVersions[facade.Name] = facade.Versions
 	}
-	st.loggedIn = true
+
+	st.setLoggedIn()
 	return nil
 }
 


### PR DESCRIPTION
The loggedIn field on api.state was being accessed in a potentially un-goroutine-safe way.

(Review request: http://reviews.vapour.ws/r/3150/)