### PR TITLE
APISERVER: ControllerStatus

### DIFF
--- a/apiserver/params/systemmanager.go
+++ b/apiserver/params/systemmanager.go
@@ -32,3 +32,17 @@ type EnvironmentBlockInfoList struct {
 type RemoveBlocksArgs struct {
 	All bool `json:"all"`
 }
+
+// EnvironmentStatus holds information about the status of a juju environment.
+type EnvironmentStatus struct {
+	EnvironTag         string `json:"environ-tag"`
+	Life               Life   `json:"life"`
+	HostedMachineCount int    `json:"hosted-machine-count"`
+	ServiceCount       int    `json:"service-count"`
+	OwnerTag           string `json:"owner-tag"`
+}
+
+// EnvironmentStatusResult holds status information about a group of environments.
+type EnvironmentStatusResults struct {
+	Results []EnvironmentStatus `json:"environments"`
+}

--- a/apiserver/systemmanager/systemmanager_test.go
+++ b/apiserver/systemmanager/systemmanager_test.go
@@ -216,3 +216,50 @@ func (s *systemManagerSuite) TestWatchAllEnvs(c *gc.C) {
 		c.Fatal("timed out")
 	}
 }
+
+func (s *systemManagerSuite) TestEnvironmentStatus(c *gc.C) {
+	otherEnvOwner := s.Factory.MakeEnvUser(c, nil)
+	otherSt := s.Factory.MakeEnvironment(c, &factory.EnvParams{
+		Name:    "dummytoo",
+		Owner:   otherEnvOwner.UserTag(),
+		Prepare: true,
+		ConfigAttrs: testing.Attrs{
+			"state-server": false,
+		},
+	})
+	defer otherSt.Close()
+
+	s.Factory.MakeMachine(c, &factory.MachineParams{Jobs: []state.MachineJob{state.JobManageEnviron}})
+	s.Factory.MakeService(c, &factory.ServiceParams{
+		Charm: s.Factory.MakeCharm(c, nil),
+	})
+
+	otherFactory := factory.NewFactory(otherSt)
+	otherFactory.MakeMachine(c, nil)
+	otherFactory.MakeMachine(c, nil)
+	otherFactory.MakeService(c, &factory.ServiceParams{
+		Charm: otherFactory.MakeCharm(c, nil),
+	})
+
+	controllerEnvTag := s.State.EnvironTag().String()
+	hostedEnvTag := otherSt.EnvironTag().String()
+
+	req := params.Entities{
+		Entities: []params.Entity{{Tag: controllerEnvTag}, {Tag: hostedEnvTag}},
+	}
+	results, err := s.systemManager.EnvironmentStatus(req)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results.Results, gc.DeepEquals, []params.EnvironmentStatus{{
+		EnvironTag:         controllerEnvTag,
+		HostedMachineCount: 1,
+		ServiceCount:       1,
+		OwnerTag:           "user-dummy-admin@local",
+		Life:               params.Alive,
+	}, {
+		EnvironTag:         hostedEnvTag,
+		HostedMachineCount: 2,
+		ServiceCount:       1,
+		OwnerTag:           otherEnvOwner.UserTag().String(),
+		Life:               params.Alive,
+	}})
+}


### PR DESCRIPTION
Add a method on the System Manager facade which returns a summary of
the controller's state.

(Review request: http://reviews.vapour.ws/r/3151/)