### PR TITLE
Add state model for service offers

### DIFF
--- a/model/crossmodel/interface.go
+++ b/model/crossmodel/interface.go
@@ -79,3 +79,39 @@ type ServiceDirectory interface {
 	// Remove removes the service offer at the specified URL.
 	Remove(url string) error
 }
+
+// OfferedService holds the details of services offered
+// by this environment.
+type OfferedService struct {
+	// ServiceName is the service name.
+	ServiceName string
+
+	// ServiceURL is the URl where the service can be located.
+	ServiceURL string
+
+	// Endpoints are the endpoints to be offered.
+	Endpoints []string
+}
+
+// OfferedServiceFilter is used to query services offered
+// by this environment.
+type OfferedServiceFilter OfferedService
+
+// An OfferedService instance holds service offers from this environment.
+type OfferedServices interface {
+
+	// AddOffer adds a new service offer to the directory.
+	AddOffer(offer OfferedService) error
+
+	// ListOffers returns the offers satisfying the specified filter.
+	ListOffers(filter ...OfferedServiceFilter) ([]OfferedService, error)
+
+	// RegisterOffer marks a previously saved offer as registered.
+	RegisterOffer(name, url string) error
+
+	// UnregisteredOffers offers returns the offers not yet registered with a service directory.
+	UnregisteredOffers() ([]OfferedService, error)
+
+	// Remove removes the service offer at the specified URL.
+	RemoveOffer(name, url string) error
+}

--- a/model/crossmodel/interface.go
+++ b/model/crossmodel/interface.go
@@ -86,7 +86,7 @@ type OfferedService struct {
 	// ServiceName is the service name.
 	ServiceName string
 
-	// ServiceURL is the URl where the service can be located.
+	// ServiceURL is the URL where the service can be located.
 	ServiceURL string
 
 	// Endpoints is the collection of endpoint names offered (internal->published).
@@ -107,9 +107,16 @@ type OfferedServiceFilter struct {
 	// ServiceURL is the URl where the service can be located.
 	ServiceURL string
 
-	// Registered is true if this offer is to be registered with
-	// the relevant service directory.
+	// Registered, if non-nil, returns only the offered services
+	// that are registered or not.
 	Registered *bool
+}
+
+// RegisteredFilter is a helper function for creating an offered service filter.
+func RegisteredFilter(registered bool) OfferedServiceFilter {
+	var filter OfferedServiceFilter
+	filter.Registered = &registered
+	return filter
 }
 
 // An OfferedService instance holds service offers from this environment.
@@ -126,9 +133,6 @@ type OfferedServices interface {
 
 	// SetOfferRegistered marks a previously saved offer as registered or not.
 	SetOfferRegistered(url string, registered bool) error
-
-	// ListOffersByRegisteredState returns the service offers matching the supplied registered state.
-	ListOffersByRegisteredState(isRegistered bool) ([]OfferedService, error)
 
 	// Remove removes the service offer at the specified URL.
 	RemoveOffer(url string) error

--- a/model/crossmodel/interface.go
+++ b/model/crossmodel/interface.go
@@ -91,11 +91,25 @@ type OfferedService struct {
 
 	// Endpoints are the endpoints to be offered.
 	Endpoints []string
+
+	// Registered is true if this offer is to be registered with
+	// the relevant service directory.
+	Registered bool
 }
 
 // OfferedServiceFilter is used to query services offered
 // by this environment.
-type OfferedServiceFilter OfferedService
+type OfferedServiceFilter struct {
+	// ServiceName is the service name.
+	ServiceName string
+
+	// ServiceURL is the URl where the service can be located.
+	ServiceURL string
+
+	// Registered is true if this offer is to be registered with
+	// the relevant service directory.
+	Registered *bool
+}
 
 // An OfferedService instance holds service offers from this environment.
 type OfferedServices interface {
@@ -106,11 +120,11 @@ type OfferedServices interface {
 	// ListOffers returns the offers satisfying the specified filter.
 	ListOffers(filter ...OfferedServiceFilter) ([]OfferedService, error)
 
-	// RegisterOffer marks a previously saved offer as registered.
-	RegisterOffer(name, url string) error
+	// SetOfferRegistered marks a previously saved offer as registered or not.
+	SetOfferRegistered(name, url string, registered bool) error
 
-	// UnregisteredOffers offers returns the offers not yet registered with a service directory.
-	UnregisteredOffers() ([]OfferedService, error)
+	// ListOffersByRegisteredState returns the service offers matching the supplied registered state.
+	ListOffersByRegisteredState(isRegistered bool) ([]OfferedService, error)
 
 	// Remove removes the service offer at the specified URL.
 	RemoveOffer(name, url string) error

--- a/model/crossmodel/interface.go
+++ b/model/crossmodel/interface.go
@@ -89,8 +89,9 @@ type OfferedService struct {
 	// ServiceURL is the URl where the service can be located.
 	ServiceURL string
 
-	// Endpoints are the endpoints to be offered.
-	Endpoints []string
+	// Endpoints is the collection of endpoint names offered (internal->published).
+	// The map allows for advertised endpoint names to be aliased.
+	Endpoints map[string]string
 
 	// Registered is true if this offer is to be registered with
 	// the relevant service directory.
@@ -114,18 +115,21 @@ type OfferedServiceFilter struct {
 // An OfferedService instance holds service offers from this environment.
 type OfferedServices interface {
 
-	// AddOffer adds a new service offer to the directory.
+	// AddOffer adds a new service offer.
 	AddOffer(offer OfferedService) error
+
+	// UpdateOffer updates an existing service offer.
+	UpdateOffer(url string, endpoints map[string]string) error
 
 	// ListOffers returns the offers satisfying the specified filter.
 	ListOffers(filter ...OfferedServiceFilter) ([]OfferedService, error)
 
 	// SetOfferRegistered marks a previously saved offer as registered or not.
-	SetOfferRegistered(name, url string, registered bool) error
+	SetOfferRegistered(url string, registered bool) error
 
 	// ListOffersByRegisteredState returns the service offers matching the supplied registered state.
 	ListOffersByRegisteredState(isRegistered bool) ([]OfferedService, error)
 
 	// Remove removes the service offer at the specified URL.
-	RemoveOffer(name, url string) error
+	RemoveOffer(url string) error
 }

--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -133,7 +133,7 @@ func allCollections() collectionSchema {
 		// This collection holds information about services that have been
 		// offered (exported) for use in other models managed by the same
 		// host controller.
-		localServiceOffersC: {
+		localServiceDirectoryC: {
 			global: true,
 			indexes: []mgo.Index{{
 				Key: []string{"url"},
@@ -383,7 +383,7 @@ const (
 	restoreInfoC           = "restoreInfo"
 	sequenceC              = "sequence"
 	servicesC              = "services"
-	localServiceOffersC    = "localserviceoffers"
+	localServiceDirectoryC = "localservicedirectory"
 	settingsC              = "settings"
 	settingsrefsC          = "settingsrefs"
 	stateServersC          = "stateServers"

--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -131,8 +131,9 @@ func allCollections() collectionSchema {
 		actionresultsC: {global: true},
 
 		// This collection holds information about services that have been
-		// offered (exported) for use in other models.
-		serviceOffersC: {
+		// offered (exported) for use in other models managed by the same
+		// host controller.
+		localServiceOffersC: {
 			global: true,
 			indexes: []mgo.Index{{
 				Key: []string{"url"},
@@ -185,6 +186,9 @@ func allCollections() collectionSchema {
 		charmsC:         {},
 		remoteServicesC: {},
 		servicesC:       {},
+		serviceOffersC: {
+			indexes: []mgo.Index{{Key: []string{"env-uuid", "url"}}},
+		},
 		unitsC: {
 			indexes: []mgo.Index{{
 				Key: []string{"env-uuid", "service"},
@@ -370,6 +374,7 @@ const (
 	networkInterfacesC     = "networkinterfaces"
 	networksC              = "networks"
 	openedPortsC           = "openedPorts"
+	serviceOffersC         = "serviceoffers"
 	rebootC                = "reboot"
 	relationScopesC        = "relationscopes"
 	relationsC             = "relations"
@@ -378,7 +383,7 @@ const (
 	restoreInfoC           = "restoreInfo"
 	sequenceC              = "sequence"
 	servicesC              = "services"
-	serviceOffersC         = "serviceoffers"
+	localServiceOffersC    = "localserviceoffers"
 	settingsC              = "settings"
 	settingsrefsC          = "settingsrefs"
 	stateServersC          = "stateServers"

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -95,13 +95,6 @@ func MakeServiceOfferDoc(sd crossmodel.ServiceDirectory, url string, offer cross
 	return sd.(*serviceDirectory).makeServiceOfferDoc(offer)
 }
 
-func OfferedServicesCount(st *State, name, url string) (int, error) {
-	settingsRefsCollection, closer := st.getCollection(serviceOffersC)
-	defer closer()
-
-	return settingsRefsCollection.FindId(fmt.Sprintf("%s-%s", name, url)).Count()
-}
-
 // SetPolicy updates the State's policy field to the
 // given Policy, and returns the old value.
 func SetPolicy(st *State, p Policy) Policy {

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -102,25 +102,6 @@ func OfferedServicesCount(st *State, name, url string) (int, error) {
 	return settingsRefsCollection.FindId(fmt.Sprintf("%s-%s", name, url)).Count()
 }
 
-func AddRegisteredOffer(c *gc.C, st *State, name string) {
-	doc := offeredServiceDoc{
-		DocID:        fmt.Sprintf("%s-local:/u/me/%s", name, name),
-		URL:          "local:/u/me/" + name,
-		ServiceName:  name,
-		IsRegistered: true,
-	}
-	ops := []txn.Op{
-		{
-			C:      serviceOffersC,
-			Id:     doc.DocID,
-			Assert: txn.DocMissing,
-			Insert: doc,
-		},
-	}
-	err := st.runTransaction(ops)
-	c.Assert(err, jc.ErrorIsNil)
-}
-
 // SetPolicy updates the State's policy field to the
 // given Policy, and returns the old value.
 func SetPolicy(st *State, p Policy) Policy {

--- a/state/offeredservices.go
+++ b/state/offeredservices.go
@@ -1,0 +1,258 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+
+	"github.com/juju/errors"
+	"github.com/juju/names"
+	"gopkg.in/mgo.v2/bson"
+	"gopkg.in/mgo.v2/txn"
+
+	"github.com/juju/juju/model/crossmodel"
+)
+
+// serviceOfferDoc represents the internal state of a service offer in MongoDB.
+type offeredServiceDoc struct {
+	DocID string `bson:"_id"`
+
+	// URL is the URL used to locate the offer in a directory.
+	URL string `bson:"url"`
+
+	// ServiceName is the name of the service.
+	ServiceName string `bson:"servicename"`
+
+	// Endpoints is the name of the endpoints offered.
+	Endpoints []string `bson:"endpoints"`
+
+	// IsRegistered is set to true when the service in this offer has
+	// been recorded in the service directory indicated by the URL.
+	IsRegistered bool `bson:"isregistered"`
+}
+
+var _ crossmodel.OfferedServices = (*offeredServices)(nil)
+
+type offeredServices struct {
+	st *State
+}
+
+// NewOfferedServices creates a offered services manager backed by a state instance.
+func NewOfferedServices(st *State) crossmodel.OfferedServices {
+	return &offeredServices{st: st}
+}
+
+func (s *offeredServices) docId(name, url string) string {
+	return fmt.Sprintf("%s-%s", name, url)
+}
+
+// Remove deletes the service offer at url immediately.
+func (s *offeredServices) RemoveOffer(name, url string) (err error) {
+	defer errors.DeferredAnnotatef(&err, "cannot delete service offer record %q", url)
+	err = s.st.runTransaction(s.removeOps(name, url))
+	if err == txn.ErrAborted {
+		// Already deleted.
+		return nil
+	}
+	return err
+}
+
+// removeOps returns the operations required to remove the record at url.
+func (s *offeredServices) removeOps(name, url string) []txn.Op {
+	return []txn.Op{
+		{
+			C:      serviceOffersC,
+			Id:     s.docId(name, url),
+			Assert: txn.DocExists,
+			Remove: true,
+		},
+	}
+}
+
+func (s *offeredServices) validateOffer(offer crossmodel.OfferedService) (err error) {
+	// Sanity checks.
+	if !names.IsValidService(offer.ServiceName) {
+		return errors.NotValidf("service name %q", offer.ServiceName)
+	}
+	if _, err := crossmodel.ParseServiceURL(offer.ServiceURL); err != nil {
+		return errors.NotValidf("service URL %q", offer.ServiceURL)
+	}
+	return nil
+}
+
+// AddOffer adds a new service offering to state.
+func (s *offeredServices) AddOffer(offer crossmodel.OfferedService) (err error) {
+	defer errors.DeferredAnnotatef(&err, "cannot add service offer %q at %q", offer.ServiceName, offer.ServiceURL)
+
+	if err := s.validateOffer(offer); err != nil {
+		return err
+	}
+	env, err := s.st.Environment()
+	if err != nil {
+		return errors.Trace(err)
+	} else if env.Life() != Alive {
+		return errors.Errorf("environment is no longer alive")
+	}
+
+	doc := s.makeOfferedServiceDoc(offer)
+	buildTxn := func(attempt int) ([]txn.Op, error) {
+		// If we've tried once already and failed, check that
+		// environment may have been destroyed.
+		if attempt > 0 {
+			if err := checkEnvLife(s.st); err != nil {
+				return nil, errors.Trace(err)
+			}
+			return nil, errDuplicateServiceOffer
+		}
+		ops := []txn.Op{
+			env.assertAliveOp(),
+			{
+				C:      serviceOffersC,
+				Id:     doc.DocID,
+				Assert: txn.DocMissing,
+				Insert: doc,
+			},
+		}
+		return ops, nil
+	}
+	err = s.st.run(buildTxn)
+	return errors.Trace(err)
+}
+
+func (s *offeredServices) makeOfferedServiceDoc(offer crossmodel.OfferedService) offeredServiceDoc {
+	doc := offeredServiceDoc{
+		DocID:       s.docId(offer.ServiceName, offer.ServiceURL),
+		URL:         offer.ServiceURL,
+		ServiceName: offer.ServiceName,
+	}
+	eps := make([]string, len(offer.Endpoints))
+	for i, ep := range offer.Endpoints {
+		eps[i] = ep
+	}
+	doc.Endpoints = eps
+	return doc
+}
+
+func (s *offeredServices) makeFilterTerm(filterTerm crossmodel.OfferedServiceFilter) bson.D {
+	var filter bson.D
+	if filterTerm.ServiceName != "" {
+		filter = append(filter, bson.DocElem{"servicename", filterTerm.ServiceName})
+	}
+	// We match on partial URLs eg /u/user
+	if filterTerm.ServiceURL != "" {
+		url := regexp.QuoteMeta(filterTerm.ServiceURL)
+		filter = append(filter, bson.DocElem{"url", bson.D{{"$regex", fmt.Sprintf(".*%s.*", url)}}})
+	}
+	return filter
+}
+
+// ListOffers returns the service offers matching any one of the filter terms.
+func (s *offeredServices) ListOffers(filter ...crossmodel.OfferedServiceFilter) ([]crossmodel.OfferedService, error) {
+	serviceOffersCollection, closer := s.st.getCollection(serviceOffersC)
+	defer closer()
+
+	var mgoTerms []bson.D
+	for _, term := range filter {
+		elems := s.makeFilterTerm(term)
+		if len(elems) == 0 {
+			continue
+		}
+		mgoTerms = append(mgoTerms, bson.D{{"$and", []bson.D{elems}}})
+	}
+	var docs []offeredServiceDoc
+	var mgoQuery bson.D
+	if len(mgoTerms) > 0 {
+		mgoQuery = bson.D{{"$or", mgoTerms}}
+	}
+	err := serviceOffersCollection.Find(mgoQuery).All(&docs)
+	if err != nil {
+		return nil, errors.Annotate(err, "cannot find service offers")
+	}
+	sort.Sort(soSlice(docs))
+	offers := make([]crossmodel.OfferedService, len(docs))
+	for i, doc := range docs {
+		offers[i] = s.makeServiceOffer(doc)
+	}
+	return offers, nil
+}
+
+func (s *offeredServices) makeServiceOffer(doc offeredServiceDoc) crossmodel.OfferedService {
+	offer := crossmodel.OfferedService{
+		ServiceURL:  doc.URL,
+		ServiceName: doc.ServiceName,
+	}
+	offer.Endpoints = make([]string, len(doc.Endpoints))
+	for i, ep := range doc.Endpoints {
+		offer.Endpoints[i] = ep
+	}
+	return offer
+}
+
+// RegisterOffer marks a previously saved offer as registered.
+func (s *offeredServices) RegisterOffer(name, url string) (err error) {
+	defer errors.DeferredAnnotatef(&err, "cannot register service offer")
+
+	env, err := s.st.Environment()
+	if err != nil {
+		return errors.Trace(err)
+	} else if env.Life() != Alive {
+		return errors.Errorf("environment is no longer alive")
+	}
+
+	buildTxn := func(attempt int) ([]txn.Op, error) {
+		// If we've tried once already and failed, check that
+		// environment may have been destroyed.
+		if attempt > 0 {
+			if err := checkEnvLife(s.st); err != nil {
+				return nil, errors.Trace(err)
+			}
+			return nil, errors.NotFoundf("service offer %q at url %q", name, url)
+		}
+		ops := []txn.Op{
+			env.assertAliveOp(),
+			{
+				C:      serviceOffersC,
+				Id:     s.docId(name, url),
+				Assert: txn.DocExists,
+				Update: bson.M{"$set": bson.M{"isregistered": true}},
+			},
+		}
+		return ops, nil
+	}
+	err = s.st.run(buildTxn)
+	return errors.Trace(err)
+}
+
+// UnregisteredOffers returns the service offers not yet registered with a service directory.
+func (s *offeredServices) UnregisteredOffers() ([]crossmodel.OfferedService, error) {
+	serviceOffersCollection, closer := s.st.getCollection(serviceOffersC)
+	defer closer()
+
+	var docs []offeredServiceDoc
+	err := serviceOffersCollection.Find(bson.D{{"isregistered", false}}).All(&docs)
+	if err != nil {
+		return nil, errors.Annotate(err, "cannot find unregistered service offers")
+	}
+	sort.Sort(soSlice(docs))
+	offers := make([]crossmodel.OfferedService, len(docs))
+	for i, doc := range docs {
+		offers[i] = s.makeServiceOffer(doc)
+	}
+	return offers, nil
+}
+
+type soSlice []offeredServiceDoc
+
+func (so soSlice) Len() int      { return len(so) }
+func (so soSlice) Swap(i, j int) { so[i], so[j] = so[j], so[i] }
+func (so soSlice) Less(i, j int) bool {
+	so1 := so[i]
+	so2 := so[j]
+	if so1.URL != so2.URL {
+		return so1.ServiceName < so2.ServiceName
+	}
+	return so1.URL < so2.URL
+}

--- a/state/offeredservices_test.go
+++ b/state/offeredservices_test.go
@@ -1,0 +1,206 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/model/crossmodel"
+	"github.com/juju/juju/state"
+)
+
+type offeredServicesSuite struct {
+	ConnSuite
+}
+
+var _ = gc.Suite(&offeredServicesSuite{})
+
+func (s *offeredServicesSuite) createDefaultOffer(c *gc.C) crossmodel.OfferedService {
+	eps := []string{"db", "db-admin"}
+	offered := state.NewOfferedServices(s.State)
+	offer := crossmodel.OfferedService{
+		ServiceURL:  "local:/u/me/service",
+		ServiceName: "mysql",
+		Endpoints:   eps,
+	}
+	err := offered.AddOffer(offer)
+	c.Assert(err, jc.ErrorIsNil)
+	return offer
+}
+
+func (s *offeredServicesSuite) TestRemove(c *gc.C) {
+	offer := s.createDefaultOffer(c)
+	offered := state.NewOfferedServices(s.State)
+	err := offered.RemoveOffer(offer.ServiceName, offer.ServiceURL)
+	c.Assert(err, jc.ErrorIsNil)
+	n, err := state.OfferedServicesCount(s.State, offer.ServiceName, offer.ServiceURL)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(n, gc.Equals, 0)
+}
+
+func (s *offeredServicesSuite) TestAddServiceOffer(c *gc.C) {
+	eps := []string{"mysql", "mysql-root"}
+	offered := state.NewOfferedServices(s.State)
+	offer := crossmodel.OfferedService{
+		ServiceURL:  "local:/u/me/service",
+		ServiceName: "mysql",
+		Endpoints:   eps,
+	}
+	err := offered.AddOffer(offer)
+	c.Assert(err, jc.ErrorIsNil)
+	n, err := state.OfferedServicesCount(s.State, offer.ServiceName, offer.ServiceURL)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(n, gc.Equals, 1)
+	offers, err := offered.ListOffers()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(offers, gc.HasLen, 1)
+	c.Assert(offers[0], jc.DeepEquals, offer)
+}
+
+func (s *offeredServicesSuite) TestListOffersNone(c *gc.C) {
+	sd := state.NewOfferedServices(s.State)
+	offers, err := sd.ListOffers()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(len(offers), gc.Equals, 0)
+}
+
+func (s *offeredServicesSuite) createOffedService(c *gc.C, name string) crossmodel.OfferedService {
+	eps := []string{name + "-interface", name + "-interface2"}
+	offers := state.NewOfferedServices(s.State)
+	offer := crossmodel.OfferedService{
+		ServiceURL:  "local:/u/me/" + name,
+		ServiceName: name,
+		Endpoints:   eps,
+	}
+	err := offers.AddOffer(offer)
+	c.Assert(err, jc.ErrorIsNil)
+	return offer
+}
+
+func (s *offeredServicesSuite) TestListOffersAll(c *gc.C) {
+	offeredServices := state.NewOfferedServices(s.State)
+	offer := s.createDefaultOffer(c)
+	offers, err := offeredServices.ListOffers()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(len(offers), gc.Equals, 1)
+	c.Assert(offers[0], jc.DeepEquals, offer)
+}
+
+func (s *offeredServicesSuite) TestListOffersOneFilter(c *gc.C) {
+	offeredServices := state.NewOfferedServices(s.State)
+	offer := s.createOffedService(c, "offer1")
+	s.createOffedService(c, "offer2")
+	s.createOffedService(c, "offer3")
+	offers, err := offeredServices.ListOffers(crossmodel.OfferedServiceFilter{
+		ServiceURL:  "local:/u/me/offer1",
+		ServiceName: "offer1",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(len(offers), gc.Equals, 1)
+	c.Assert(offers[0], jc.DeepEquals, offer)
+}
+
+func (s *offeredServicesSuite) TestListOffersManyFilters(c *gc.C) {
+	offeredServices := state.NewOfferedServices(s.State)
+	offer := s.createOffedService(c, "offer1")
+	offer2 := s.createOffedService(c, "offer2")
+	s.createOffedService(c, "offer3")
+	offers, err := offeredServices.ListOffers(
+		crossmodel.OfferedServiceFilter{
+			ServiceURL:  "local:/u/me/offer1",
+			ServiceName: "offer1",
+		},
+		crossmodel.OfferedServiceFilter{
+			ServiceURL: "local:/u/me/offer2",
+		},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(len(offers), gc.Equals, 2)
+	c.Assert(offers, jc.DeepEquals, []crossmodel.OfferedService{offer, offer2})
+}
+
+func (s *offeredServicesSuite) TestListOffersFilterServiceURLRegexp(c *gc.C) {
+	offeredServices := state.NewOfferedServices(s.State)
+	s.createOffedService(c, "offer1")
+	offer := s.createOffedService(c, "offer2")
+	s.createOffedService(c, "offer3")
+	offers, err := offeredServices.ListOffers(crossmodel.OfferedServiceFilter{
+		ServiceURL: "me/offer2",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(len(offers), gc.Equals, 1)
+	c.Assert(offers[0], jc.DeepEquals, offer)
+}
+
+func (s *offeredServicesSuite) TestRegisterOffer(c *gc.C) {
+	offeredServices := state.NewOfferedServices(s.State)
+	offer := s.createOffedService(c, "offer1")
+	offer2 := s.createOffedService(c, "offer2")
+	s.createOffedService(c, "offer3")
+	err := offeredServices.RegisterOffer("offer3", "local:/u/me/offer3")
+	c.Assert(err, jc.ErrorIsNil)
+	offers, err := offeredServices.UnregisteredOffers()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(len(offers), gc.Equals, 2)
+	c.Assert(offers, jc.DeepEquals, []crossmodel.OfferedService{offer, offer2})
+}
+
+func (s *offeredServicesSuite) TestUnregisteredOffers(c *gc.C) {
+	offeredServices := state.NewOfferedServices(s.State)
+	offer := s.createOffedService(c, "offer1")
+	offer2 := s.createOffedService(c, "offer2")
+	state.AddRegisteredOffer(c, s.State, "offer3")
+	offers, err := offeredServices.ListOffers()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(len(offers), gc.Equals, 3)
+	offers, err = offeredServices.UnregisteredOffers()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(len(offers), gc.Equals, 2)
+	c.Assert(offers, jc.DeepEquals, []crossmodel.OfferedService{offer, offer2})
+}
+
+func (s *offeredServicesSuite) TestAddServiceOfferDuplicate(c *gc.C) {
+	offered := state.NewOfferedServices(s.State)
+	err := offered.AddOffer(crossmodel.OfferedService{
+		ServiceURL:  "local:/u/me/service",
+		ServiceName: "mysql",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	err = offered.AddOffer(crossmodel.OfferedService{
+		ServiceURL:  "local:/u/me/service",
+		ServiceName: "mysql",
+	})
+	c.Assert(err, gc.ErrorMatches, `cannot add service offer "mysql" at "local:/u/me/service": service offer already exists`)
+}
+
+func (s *offeredServicesSuite) TestAddServiceOfferDuplicateAddedAfterInitial(c *gc.C) {
+	// Check that a record with a URL conflict cannot be added if
+	// there is no conflict initially but a record is added
+	// before the transaction is run.
+	offers := state.NewOfferedServices(s.State)
+	defer state.SetBeforeHooks(c, s.State, func() {
+		err := offers.AddOffer(crossmodel.OfferedService{
+			ServiceURL:  "local:/u/me/service",
+			ServiceName: "mysql",
+		})
+		c.Assert(err, jc.ErrorIsNil)
+	}).Check()
+	err := offers.AddOffer(crossmodel.OfferedService{
+		ServiceURL:  "local:/u/me/service",
+		ServiceName: "mysql",
+	})
+	c.Assert(err, gc.ErrorMatches, `cannot add service offer "mysql" at "local:/u/me/service": service offer already exists`)
+}
+
+func (s *offeredServicesSuite) TestRegisterOfferDeleteAfterInitial(c *gc.C) {
+	offeredServices := state.NewOfferedServices(s.State)
+	offer := s.createOffedService(c, "offer1")
+	defer state.SetBeforeHooks(c, s.State, func() {
+		err := offeredServices.RemoveOffer(offer.ServiceName, offer.ServiceURL)
+		c.Assert(err, jc.ErrorIsNil)
+	}).Check()
+	err := offeredServices.RegisterOffer(offer.ServiceName, offer.ServiceURL)
+	c.Assert(err, gc.ErrorMatches, `.* service offer "offer1" at url "local:/u/me/offer1" not found`)
+}

--- a/state/offeredservices_test.go
+++ b/state/offeredservices_test.go
@@ -196,7 +196,7 @@ func (s *offeredServicesSuite) TestSetOfferRegistered(c *gc.C) {
 	s.createOffedService(c, "offer3")
 	err := offeredServices.SetOfferRegistered("local:/u/me/offer3", false)
 	c.Assert(err, jc.ErrorIsNil)
-	offers, err := offeredServices.ListOffersByRegisteredState(true)
+	offers, err := offeredServices.ListOffers(crossmodel.RegisteredFilter(true))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(len(offers), gc.Equals, 2)
 	c.Assert(offers, jc.DeepEquals, []crossmodel.OfferedService{offer, offer2})

--- a/state/servicedirectory.go
+++ b/state/servicedirectory.go
@@ -68,7 +68,7 @@ func ServiceOfferEndpoint(offer crossmodel.ServiceOffer, relationName string) (E
 }
 
 func (s *serviceDirectory) offerAtURL(url string) (*serviceOfferDoc, error) {
-	serviceOffersCollection, closer := s.st.getCollection(localServiceOffersC)
+	serviceOffersCollection, closer := s.st.getCollection(localServiceDirectoryC)
 	defer closer()
 
 	var doc serviceOfferDoc
@@ -97,7 +97,7 @@ func (s *serviceDirectory) Remove(url string) (err error) {
 func (s *serviceDirectory) removeOps(url string) []txn.Op {
 	return []txn.Op{
 		{
-			C:      localServiceOffersC,
+			C:      localServiceDirectoryC,
 			Id:     url,
 			Assert: txn.DocExists,
 			Remove: true,
@@ -149,7 +149,7 @@ func (s *serviceDirectory) AddOffer(offer crossmodel.ServiceOffer) (err error) {
 		ops := []txn.Op{
 			env.assertAliveOp(),
 			{
-				C:      localServiceOffersC,
+				C:      localServiceDirectoryC,
 				Id:     doc.DocID,
 				Assert: txn.DocMissing,
 				Insert: doc,
@@ -193,7 +193,7 @@ func (s *serviceDirectory) UpdateOffer(offer crossmodel.ServiceOffer) (err error
 		ops := []txn.Op{
 			env.assertAliveOp(),
 			{
-				C:      localServiceOffersC,
+				C:      localServiceDirectoryC,
 				Id:     doc.DocID,
 				Assert: txn.DocExists,
 				Update: doc,
@@ -254,7 +254,7 @@ func (s *serviceDirectory) makeFilterTerm(filterTerm crossmodel.ServiceOfferFilt
 
 // ListOffers returns the service offers matching any one of the filter terms.
 func (s *serviceDirectory) ListOffers(filter ...crossmodel.ServiceOfferFilter) ([]crossmodel.ServiceOffer, error) {
-	serviceOffersCollection, closer := s.st.getCollection(localServiceOffersC)
+	serviceOffersCollection, closer := s.st.getCollection(localServiceDirectoryC)
 	defer closer()
 
 	var mgoTerms []bson.D

--- a/state/servicedirectory.go
+++ b/state/servicedirectory.go
@@ -68,7 +68,7 @@ func ServiceOfferEndpoint(offer crossmodel.ServiceOffer, relationName string) (E
 }
 
 func (s *serviceDirectory) offerAtURL(url string) (*serviceOfferDoc, error) {
-	serviceOffersCollection, closer := s.st.getCollection(serviceOffersC)
+	serviceOffersCollection, closer := s.st.getCollection(localServiceOffersC)
 	defer closer()
 
 	var doc serviceOfferDoc
@@ -97,7 +97,7 @@ func (s *serviceDirectory) Remove(url string) (err error) {
 func (s *serviceDirectory) removeOps(url string) []txn.Op {
 	return []txn.Op{
 		{
-			C:      serviceOffersC,
+			C:      localServiceOffersC,
 			Id:     url,
 			Assert: txn.DocExists,
 			Remove: true,
@@ -149,7 +149,7 @@ func (s *serviceDirectory) AddOffer(offer crossmodel.ServiceOffer) (err error) {
 		ops := []txn.Op{
 			env.assertAliveOp(),
 			{
-				C:      serviceOffersC,
+				C:      localServiceOffersC,
 				Id:     doc.DocID,
 				Assert: txn.DocMissing,
 				Insert: doc,
@@ -193,7 +193,7 @@ func (s *serviceDirectory) UpdateOffer(offer crossmodel.ServiceOffer) (err error
 		ops := []txn.Op{
 			env.assertAliveOp(),
 			{
-				C:      serviceOffersC,
+				C:      localServiceOffersC,
 				Id:     doc.DocID,
 				Assert: txn.DocExists,
 				Update: doc,
@@ -254,7 +254,7 @@ func (s *serviceDirectory) makeFilterTerm(filterTerm crossmodel.ServiceOfferFilt
 
 // ListOffers returns the service offers matching any one of the filter terms.
 func (s *serviceDirectory) ListOffers(filter ...crossmodel.ServiceOfferFilter) ([]crossmodel.ServiceOffer, error) {
-	serviceOffersCollection, closer := s.st.getCollection(serviceOffersC)
+	serviceOffersCollection, closer := s.st.getCollection(localServiceOffersC)
 	defer closer()
 
 	var mgoTerms []bson.D


### PR DESCRIPTION
Add a collection, doc structs and APIs for persisting service offer intentions to state. A subsequent worker will process these and update the relevant service directory.

We rename a previous collection also.

(Review request: http://reviews.vapour.ws/r/3157/)