### PR TITLE
Fixed lp:1499426 - spaces with no subnets not allowed for deployments

### DIFF
--- a/apiserver/provisioner/provisioner.go
+++ b/apiserver/provisioner/provisioner.go
@@ -1385,6 +1385,9 @@ func (p *ProvisionerAPI) machineSubnetsAndZones(m *state.Machine) (map[string][]
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+	if len(subnets) == 0 {
+		return nil, errors.Errorf("cannot use space %q as deployment target: no subnets", spaceName)
+	}
 	subnetsToZones := make(map[string][]string, len(subnets))
 	for _, subnet := range subnets {
 		warningPrefix := fmt.Sprintf(


### PR DESCRIPTION
Straight forward port of #3749 from 1.25 to master, no other changes.

Provisioner no longer accepts spaces with no subnets as a deployment
target. See bug http://pad.lv/1499426 for details.

Added a unit test and also live tested on EC2 trying to deploy a service
or add units to one, when spaces constraints are present and include a
known space without subnets.

(Review request: http://reviews.vapour.ws/r/3158/)