### PR TITLE
Flatten user commands

### DIFF
--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -165,6 +165,13 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 
 	// Manage users and access
 	r.Register(user.NewSuperCommand())
+	r.RegisterSuperAlias("add-user", "user", "add", twoDotOhDeprecation("user add"))
+	r.RegisterSuperAlias("change-password", "user", "change-password", twoDotOhDeprecation("user change-password"))
+	r.RegisterSuperAlias("get-credentials", "user", "credentials", twoDotOhDeprecation("user credentials"))
+	r.RegisterSuperAlias("show-user", "user", "info", twoDotOhDeprecation("user info"))
+	r.RegisterSuperAlias("list-users", "user", "list", twoDotOhDeprecation("user list"))
+	r.RegisterSuperAlias("enable-user", "user", "enable", twoDotOhDeprecation("user enable"))
+	r.RegisterSuperAlias("disable-user", "user", "disable", twoDotOhDeprecation("user disable"))
 
 	// Manage cached images
 	r.Register(cachedimages.NewSuperCommand())

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -201,12 +201,14 @@ var commandNames = []string{
 	"add-unit",
 	"api-endpoints",
 	"api-info",
+	"add-user",        // alias for "user add"
 	"authorised-keys", // alias for authorized-keys
 	"authorized-keys",
 	"backups",
 	"block",
 	"bootstrap",
 	"cached-images",
+	"change-password", // alias for "user change-password"
 	"create-environment",
 	"create-model", // alias for create-environment
 	"debug-hooks",
@@ -219,6 +221,8 @@ var commandNames = []string{
 	"destroy-relation",
 	"destroy-service",
 	"destroy-unit",
+	"disable-user", // alias for "user disable"
+	"enable-user",  // alias for "user enable"
 	"ensure-availability",
 	"env", // alias for switch
 	"environment",
@@ -226,7 +230,8 @@ var commandNames = []string{
 	"generate-config", // alias for init
 	"get",
 	"get-constraints",
-	"get-env", // alias for get-environment
+	"get-credentials", // alias for "user credentials"
+	"get-env",         // alias for get-environment
 	"get-environment",
 	"help",
 	"help-tool",
@@ -236,6 +241,7 @@ var commandNames = []string{
 	"list-controllers",
 	"list-environments",
 	"list-models", // alias for list-environments
+	"list-users",  // alias for "user list"
 	"login",
 	"machine",
 	"publish",
@@ -253,6 +259,7 @@ var commandNames = []string{
 	"set-constraints",
 	"set-env", // alias for set-environment
 	"set-environment",
+	"show-user", // alias for "user info"
 	"space",
 	"ssh",
 	"stat", // alias for status


### PR DESCRIPTION
Add top level aliases for all the user commands.

(Review request: http://reviews.vapour.ws/r/3163/)