### PR TITLE
implement gate.ManifoldEx

### DIFF
--- a/worker/gate/interface.go
+++ b/worker/gate/interface.go
@@ -16,6 +16,12 @@ type Waiter interface {
 	Unlocked() <-chan struct{}
 }
 
+// WaiterUnlocker combines the Waiter and Unlocker interfaces.
+type WaiterUnlocker interface {
+	Waiter
+	Unlocker
+}
+
 // AlreadyUnlocked is a Waiter that always reports its gate to be unlocked.
 type AlreadyUnlocked struct{}
 

--- a/worker/gate/manifold.go
+++ b/worker/gate/manifold.go
@@ -19,20 +19,23 @@ import (
 //
 // The output func accepts an out pointer to either an Unlocker or a Waiter.
 func Manifold() dependency.Manifold {
+	m, _ := ManifoldEx()
+	return m
+}
 
-	// mu and ch are shared across all workers started by the returned manifold.
-	// In normal operation, there will only be one such worker at a time; but if
-	// multiple workers somehow run in parallel, mu should prevent panic and/or
-	// confusion.
-	mu := new(sync.Mutex)
-	ch := make(chan struct{})
+// ManifoldEx does the same thing as Manifold but provides access to
+// the WaiterUnlocker which can be used to wait on or unlock the
+// gate. This allows code running outside of a dependency engine
+// managed worker monitor or unlock the gate.
+//
+// TODO(mjs) - this can likely go away once all machine agent workers
+// are running under the dependency engine.
+func ManifoldEx() (dependency.Manifold, WaiterUnlocker) {
+	lock := newLock()
 
-	return dependency.Manifold{
+	manifold := dependency.Manifold{
 		Start: func(_ dependency.GetResourceFunc) (worker.Worker, error) {
-			w := &gate{
-				mu: mu,
-				ch: ch,
-			}
+			w := &gate{lock: lock}
 			go func() {
 				defer w.tomb.Done()
 				<-w.tomb.Dying()
@@ -46,22 +49,55 @@ func Manifold() dependency.Manifold {
 			}
 			switch outPointer := out.(type) {
 			case *Unlocker:
-				*outPointer = inWorker
+				*outPointer = inWorker.lock
 			case *Waiter:
-				*outPointer = inWorker
+				*outPointer = inWorker.lock
 			default:
 				return errors.Errorf("out should be a pointer to an Unlocker or a Waiter; is %#v", out)
 			}
 			return nil
 		},
 	}
+	return manifold, lock
 }
 
-// gate implements Waiter, Unlocker, and worker.Worker.
+func newLock() *lock {
+	return &lock{
+		// mu and ch are shared across all workers started by the returned manifold.
+		// In normal operation, there will only be one such worker at a time; but if
+		// multiple workers somehow run in parallel, mu should prevent panic and/or
+		// confusion.
+		mu: new(sync.Mutex),
+		ch: make(chan struct{}),
+	}
+}
+
+// lock implements of Unlocker and Waiter
+type lock struct {
+	mu *sync.Mutex
+	ch chan struct{}
+}
+
+// Unlock implements Unlocker.
+func (l *lock) Unlock() {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	select {
+	case <-l.ch:
+	default:
+		close(l.ch)
+	}
+}
+
+// Unlocked implements Waiter.
+func (l *lock) Unlocked() <-chan struct{} {
+	return l.ch
+}
+
+// gate implements a degenerate worker that holds a lock.
 type gate struct {
 	tomb tomb.Tomb
-	mu   *sync.Mutex
-	ch   chan struct{}
+	lock *lock
 }
 
 // Kill is part of the worker.Worker interface.
@@ -72,20 +108,4 @@ func (w *gate) Kill() {
 // Wait is part of the worker.Worker interface.
 func (w *gate) Wait() error {
 	return w.tomb.Wait()
-}
-
-// Unlocked is part of the Waiter interface.
-func (w *gate) Unlocked() <-chan struct{} {
-	return w.ch
-}
-
-// Unlock is part of the Unlocker interface.
-func (w *gate) Unlock() {
-	w.mu.Lock()
-	defer w.mu.Unlock()
-	select {
-	case <-w.ch:
-	default:
-		close(w.ch)
-	}
 }

--- a/worker/gate/manifold_test.go
+++ b/worker/gate/manifold_test.go
@@ -88,6 +88,24 @@ func (s *ManifoldSuite) TestAlreadyUnlockedIsUnlocked(c *gc.C) {
 	assertUnlocked(c, w)
 }
 
+func (s *ManifoldSuite) TestManifoldEx(c *gc.C) {
+	manifold, wu := gate.ManifoldEx()
+	var w1 gate.Waiter = wu
+	var u gate.Unlocker = wu
+
+	worker, err := manifold.Start(nil)
+	c.Assert(err, jc.ErrorIsNil)
+	defer checkStop(c, worker)
+	w2 := waiter(c, manifold, worker)
+
+	assertLocked(c, w1)
+	assertLocked(c, w2)
+
+	u.Unlock()
+	assertUnlocked(c, w1)
+	assertUnlocked(c, w2)
+}
+
 func unlocker(c *gc.C, m dependency.Manifold, w worker.Worker) gate.Unlocker {
 	var unlocker gate.Unlocker
 	err := m.Output(w, &unlocker)


### PR DESCRIPTION
This allows code running outside the dependency engine to wait for and/or unlock the gate in a goroutine-safe way. It's required during the conversion of the machine agent to use the dependency engine and can likely go away once the conversion is complete.