### PR TITLE
Use cinder endpoint as given to openstack provider

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -41,7 +41,7 @@ google.golang.org/cloud	git	f20d6dcccb44ed49de45ae3703312cb46e627db1	2015-03-19T
 gopkg.in/amz.v3	git	bff3a097c4108da57bb8cbe3aad2990d74d23676	2015-08-20T12:28:33Z
 gopkg.in/check.v1	git	b3d3430320d4260e5fea99841af984b3badcea63	2015-06-26T10:50:28Z
 gopkg.in/errgo.v1	git	66cb46252b94c1f3d65646f54ee8043ab38d766c	2015-10-07T15:31:57Z
-gopkg.in/goose.v1	git	be6030ce33a6d77f5e9c63b7698030e6431d5343	2015-08-24T15:19:40Z
+gopkg.in/goose.v1	git	e4a91e8b8323b8eef6fe41a66fd3ac6120520bb0	2015-11-13T22:25:24Z
 gopkg.in/juju/charm.v6-unstable	git	fcea74e783acf89c3d095dfec7b52a5d00d536ae	2015-11-06T09:56:06Z
 gopkg.in/juju/charmrepo.v1	git	12348f5cefcac2fdc8c81a2a9ec80c5f6ce57d77	2015-11-05T17:57:21Z
 gopkg.in/juju/charmstore.v5-unstable	git	475920bf612769da77969237ed511a921fb785be	2015-09-16T09:44:01Z

--- a/provider/openstack/cinder.go
+++ b/provider/openstack/cinder.go
@@ -406,17 +406,13 @@ func getVolumeEndpointURL(client endpointResolver, region string) (*url.URL, err
 	// The cinder openstack charm appends 'v2' to the type for the v2 api.
 	endpoint, ok := endpointMap["volumev2"]
 	if !ok {
-		logger.Debugf("volumev2 endpoint not found for %q region, trying volume instead", region)
+		logger.Debugf(`endpoint "volumev2" not found for %q region, trying "volume"`, region)
 		endpoint, ok = endpointMap["volume"]
 		if !ok {
-			return nil, errors.Errorf("volume endpoint not found for %q region", region)
+			return nil, errors.Errorf(`endpoint "volume" not found for %q region`, region)
 		}
 	}
-	endpointUrl, err := url.Parse(endpoint)
-	if err != nil {
-		return nil, errors.Annotate(err, "error parsing endpoint")
-	}
-	return endpointUrl, nil
+	return url.Parse(endpoint)
 }
 
 func newOpenstackStorageAdapter(environConfig *config.Config) (openstackStorage, error) {
@@ -431,7 +427,7 @@ func newOpenstackStorageAdapter(environConfig *config.Config) (openstackStorage,
 
 	endpointUrl, err := getVolumeEndpointURL(client, ecfg.region())
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Annotate(err, "getting volume endpoint")
 	}
 
 	return &openstackStorageAdapter{

--- a/provider/openstack/cinder.go
+++ b/provider/openstack/cinder.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/utils"
 	"gopkg.in/goose.v1/cinder"
+	"gopkg.in/goose.v1/identity"
 	"gopkg.in/goose.v1/nova"
 
 	"github.com/juju/juju/environs/config"
@@ -396,28 +397,46 @@ type openstackStorage interface {
 	ListVolumeAttachments(serverId string) ([]nova.VolumeAttachment, error)
 }
 
-func newOpenstackStorageAdapter(environConfig *config.Config) (openstackStorage, error) {
-	ecfg, err := providerInstance.newConfig(environConfig)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	authClient := authClient(ecfg)
-	if err := authClient.Authenticate(); err != nil {
-		return nil, errors.Trace(err)
-	}
+type endpointResolver interface {
+	EndpointsForRegion(region string) identity.ServiceURLs
+}
 
-	endpoint, ok := authClient.EndpointsForRegion(ecfg.region())["volume"]
+func getVolumeEndpointURL(client endpointResolver, region string) (*url.URL, error) {
+	endpointMap := client.EndpointsForRegion(region)
+	// The cinder openstack charm appends 'v2' to the type for the v2 api.
+	endpoint, ok := endpointMap["volumev2"]
 	if !ok {
-		return nil, errors.Errorf("volume endpoint not found for %q endpoint", ecfg.region())
+		logger.Debugf("volumev2 endpoint not found for %q region, trying volume instead", region)
+		endpoint, ok = endpointMap["volume"]
+		if !ok {
+			return nil, errors.Errorf("volume endpoint not found for %q region", region)
+		}
 	}
 	endpointUrl, err := url.Parse(endpoint)
 	if err != nil {
 		return nil, errors.Annotate(err, "error parsing endpoint")
 	}
+	return endpointUrl, nil
+}
+
+func newOpenstackStorageAdapter(environConfig *config.Config) (openstackStorage, error) {
+	ecfg, err := providerInstance.newConfig(environConfig)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	client := authClient(ecfg)
+	if err := client.Authenticate(); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	endpointUrl, err := getVolumeEndpointURL(client, ecfg.region())
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 
 	return &openstackStorageAdapter{
-		cinderClient{cinder.Basic(endpointUrl, authClient.TenantId(), authClient.Token)},
-		novaClient{nova.New(authClient)},
+		cinderClient{cinder.Basic(endpointUrl, client.TenantId(), client.Token)},
+		novaClient{nova.New(client)},
 	}, nil
 }
 

--- a/provider/openstack/cinder_test.go
+++ b/provider/openstack/cinder_test.go
@@ -530,11 +530,11 @@ var volumeEndpointTests = []struct {
 	url: "http://cinder.testing/v2",
 }, {
 	summary:    "error on missing region",
-	errormatch: `volume endpoint not found for "west" region`,
+	errormatch: `endpoint "volume" not found for "west" region`,
 }, {
 	summary:    "error on bad url",
 	endpoints:  map[string]string{"volume": "%2 wha!"},
-	errormatch: `error parsing endpoint: .*`,
+	errormatch: `parse %2 wha!: .*`,
 }}
 
 func (s *cinderVolumeSourceSuite) TestGetVolumeEndpoint(c *gc.C) {

--- a/provider/openstack/export_test.go
+++ b/provider/openstack/export_test.go
@@ -371,3 +371,5 @@ var RuleMatchesPortRange = ruleMatchesPortRange
 
 var MakeServiceURL = &makeServiceURL
 var ProviderInstance = providerInstance
+
+var GetVolumeEndpointURL = getVolumeEndpointURL


### PR DESCRIPTION
Fixes lp:1512399 "environment destruction failed: ... record overflow".

Picks up fix from goose to how cinder api requests were constructed,
which was causing https requests to be sent to a http cinder endpoint.

Because the previous code also hardcoded '/v2/' in the urls being used,
logic is added in the openstack provider to prefer a v2 endpoint
where available.

As keystone does not provide a standard mechanism to specify the
version of an endpoint, this is somewhat fragile. Our Openstack
charms use a different type in the catalog for v2 api cinder, but
not all deployments will follow this scheme.

(Review request: http://reviews.vapour.ws/r/3170/)