### PR TITLE
Fix 1382556: juju-run --all: start commands serially, wait concurrently

### DIFF
--- a/apiserver/client/run.go
+++ b/apiserver/client/run.go
@@ -182,6 +182,12 @@ func ParallelExecute(dataDir string, args []*RemoteExec) params.RunResults {
 // command we run will require a separate fork. This can be a problem
 // for controllers with low resources or in environments with many
 // machines.
+//
+// Note that when the start operation completes, the memory of the
+// forked process will have already been replaced with that of the
+// exec'ed command. This is a relatively quick operation relative to
+// the wait operation. That is why start-serially-and-wait-in-parallel
+// is a viable approach.
 func startSerialWaitParallel(args []*RemoteExec, results *params.RunResults) {
 	var wg sync.WaitGroup
 	for i, arg := range args {

--- a/apiserver/client/run.go
+++ b/apiserver/client/run.go
@@ -81,9 +81,6 @@ func (c *Client) getDataDir() string {
 	return dataResource.String()
 }
 
-// pulled out of my butt
-const jujuRunParallelism = 5
-
 // Run the commands specified on the machines identified through the
 // list of machines, units and services.
 func (c *Client) Run(run params.RunParams) (results params.RunResults, err error) {
@@ -122,7 +119,7 @@ func (c *Client) Run(run params.RunParams) (results params.RunResults, err error
 		execParam := remoteParamsForMachine(machine, command, run.Timeout)
 		params = append(params, execParam)
 	}
-	return ParallelExecute(c.getDataDir(), params, jujuRunParallelism), nil
+	return ParallelExecute(c.getDataDir(), params), nil
 }
 
 // RunOnAllMachines attempts to run the specified command on all the machines.
@@ -140,7 +137,7 @@ func (c *Client) RunOnAllMachines(run params.RunParams) (params.RunResults, erro
 	for _, machine := range machines {
 		params = append(params, remoteParamsForMachine(machine, command, run.Timeout))
 	}
-	return ParallelExecute(c.getDataDir(), params, jujuRunParallelism), nil
+	return ParallelExecute(c.getDataDir(), params), nil
 }
 
 // RemoteExec extends the standard ssh.ExecParams by providing the machine and
@@ -154,74 +151,57 @@ type RemoteExec struct {
 
 // ParallelExecute executes all of the requests defined in the params,
 // using the system identity stored in the dataDir.
-func ParallelExecute(dataDir string, runParams []*RemoteExec, numWorkers int) params.RunResults {
-	logger.Debugf("exec %#v", runParams)
-
-	var wg sync.WaitGroup
-	queue := make(chan *RemoteExec)
-	results := make(chan params.RunResult)
-
-	// Let's not spawn extra goroutines, eh?
-	if numWorkers > len(runParams) {
-		numWorkers = len(runParams)
-	}
-
-	// Limit the parallelization. Since this uses fork, which starts
-	// off by using a copy of juju's memory, and thus can easily cause OOM
-	// issues.
-	for x := 0; x < numWorkers; x++ {
-		wg.Add(1)
-		go execWorker(&wg, queue, results)
-	}
-
-	output := make(chan []params.RunResult)
-	go resultCollator(len(runParams), results, output)
+func ParallelExecute(dataDir string, args []*RemoteExec) params.RunResults {
+	var results params.RunResults
+	results.Results = make([]params.RunResult, len(args), len(args))
 
 	identity := filepath.Join(dataDir, agent.SystemIdentity)
-	for _, param := range runParams {
-		param.IdentityFile = identity
-		logger.Debugf("exec on %s: %#v", param.MachineId, *param)
-		queue <- param
-	}
 
-	close(queue)
-	wg.Wait()
-	close(results)
-	result := <-output
+	var wg sync.WaitGroup
+	for i, arg := range args {
+		// TODO(ericsnow) Move the log entry to after setting the identity.
+		logger.Debugf("exec on %s: %#v", arg.MachineId, *arg)
+		arg.ExecParams.IdentityFile = identity
+		timeout := arg.Timeout
 
-	sort.Sort(MachineOrder(result))
-	return params.RunResults{result}
-}
-
-// execWorker is a worker that runs in a goroutine to execute commands from, the
-// queue and pass on the results.
-func execWorker(wg *sync.WaitGroup, queue <-chan *RemoteExec, results chan<- params.RunResult) {
-	for param := range queue {
-		// this function call has its own internal timeout, so we don't need one.
-		response, err := ssh.ExecuteCommandOnMachine(param.ExecParams)
-		logger.Debugf("reponse from %s: %v (err:%v)", param.MachineId, response, err)
-		execResponse := params.RunResult{
-			ExecResponse: response,
-			MachineId:    param.MachineId,
-			UnitId:       param.UnitId,
+		results.Results[i] = params.RunResult{
+			MachineId: arg.MachineId,
+			UnitId:    arg.UnitId,
 		}
+		result := &results.Results[i]
+
+		// Start the commands serially...
+		cmd, err := ssh.StartCommandOnMachine(arg.ExecParams)
 		if err != nil {
-			execResponse.Error = fmt.Sprint(err)
+			result.Error = fmt.Sprint(err)
+			continue
 		}
 
-		results <- execResponse
-	}
-	wg.Done()
-}
+		// ...but wait for them in parallel.
+		//
+		// We do this because ssh.StartCommandOnMachine() relies on
+		// os/exec.Cmd, which in turn relies on fork+exec. That means
+		// every copy of the command we run will require a separate
+		// fork. This can be a problem for controllers with low
+		// resources or in environments with many machines.
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
 
-// resultCollator collects the results into a slice and passes them on to output
-// when done.
-func resultCollator(count int, results <-chan params.RunResult, output chan<- []params.RunResult) {
-	result := make([]params.RunResult, 0, count)
-	for res := range results {
-		result = append(result, res)
+			response, err := cmd.WaitWithTimeout(timeout)
+			logger.Debugf("response from %s: %#v (err:%v)", result.MachineId, response, err)
+			result.ExecResponse = response
+			if err != nil {
+				result.Error = fmt.Sprint(err)
+			}
+		}()
 	}
-	output <- result
+	wg.Wait()
+
+	// TODO(ericsnow) Why do we sort these? Shouldn't we keep them
+	// in the same order that they were requested?
+	sort.Sort(MachineOrder(results.Results))
+	return results
 }
 
 // MachineOrder is used to provide the api to sort the results by the machine

--- a/apiserver/client/run.go
+++ b/apiserver/client/run.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/utils"
+	"github.com/juju/utils/clock"
 	"github.com/juju/utils/set"
 
 	"github.com/juju/juju/agent"
@@ -186,7 +187,8 @@ func ParallelExecute(dataDir string, args []*RemoteExec) params.RunResults {
 		wait := func(result *params.RunResult, timeout time.Duration) {
 			defer wg.Done()
 
-			response, err := cmd.WaitWithTimeout(timeout)
+			timeoutChan := clock.WallClock.After(timeout)
+			response, err := cmd.WaitWithTimeout(timeoutChan)
 			logger.Debugf("response from %s: %#v (err:%v)", result.MachineId, response, err)
 			result.ExecResponse = response
 			if err != nil {

--- a/apiserver/client/run.go
+++ b/apiserver/client/run.go
@@ -168,7 +168,8 @@ func ParallelExecute(dataDir string, args []*RemoteExec) params.RunResults {
 
 	startSerialWaitParallel(args, &results)
 
-	// TODO(ericsnow) Why do we sort these? Shouldn't we keep them
+	// TODO(ericsnow) lp:1517076
+	// Why do we sort these? Shouldn't we keep them
 	// in the same order that they were requested?
 	sort.Sort(MachineOrder(results.Results))
 	return results

--- a/apiserver/client/run_test.go
+++ b/apiserver/client/run_test.go
@@ -253,7 +253,10 @@ func (s *runSuite) TestRunOnAllMachines(c *gc.C) {
 			})
 	}
 
-	c.Assert(results, jc.DeepEquals, expectedResults)
+	c.Check(results, jc.DeepEquals, expectedResults)
+	c.Check(string(results[0].Stdout), gc.Equals, expectedCommand[0])
+	c.Check(string(results[1].Stdout), gc.Equals, expectedCommand[0])
+	c.Check(string(results[2].Stdout), gc.Equals, expectedCommand[0])
 }
 
 func (s *runSuite) TestBlockRunOnAllMachines(c *gc.C) {

--- a/utils/ssh/run.go
+++ b/utils/ssh/run.go
@@ -83,6 +83,13 @@ func (cmd *RunningCmd) Wait() (result utilexec.ExecResponse, _ error) {
 	return result, nil
 }
 
+// TODO(ericsnow) Add RunningCmd.WaitAbortable(abortChan <-chan error) ...
+// based on WaitWithTimeout and update WaitWithTimeout to use it. We
+// could make it WaitAbortable(abortChans ...<-chan error), which would
+// require using reflect.Select(). Then that could simply replace Wait().
+// It may make more sense, however, to have a helper function:
+//   Wait(cmd T, abortChans ...<-chan error) ...
+
 // TimedOut is an error indicating that a command timed out.
 var TimedOut = errors.New("command timed out")
 

--- a/utils/ssh/run.go
+++ b/utils/ssh/run.go
@@ -126,8 +126,11 @@ func getExitCode(err error) (int, error) {
 	}
 	err = errors.Cause(err)
 	if ee, ok := err.(*exec.ExitError); ok {
-		status := ee.ProcessState.Sys().(syscall.WaitStatus)
-		if status.Exited() {
+		raw := ee.ProcessState.Sys()
+		status, ok := raw.(syscall.WaitStatus)
+		if !ok {
+			logger.Errorf("unexpected type %T from ProcessState.Sys()", raw)
+		} else if status.Exited() {
 			// A non-zero return code isn't considered an error here.
 			return status.ExitStatus(), nil
 		}


### PR DESCRIPTION
See: https://bugs.launchpad.net/juju-core/+bug/1382556

juju-run --all executes the commands (over SSH) in parallel.  The SSH code runs the command through the local ssh client via bash.  This is accomplished by using os/exec.Cmd, which takes a fork+exec approach.  The problem for juju-run is that forking a bunch all at once can cause virtual memory allocation to skyrocket (at least temporarily).  On resource-constrained controllers and in environments with many machines, this has a good chance of causing juju-run to fail, particularly if jujud has been running for a while.

This patch addresses the issue by taking advantage of the fundamental parallelization support in os/exec.Cmd.  First we start the pending commands one at a time, effectively limiting the number of simultaneous forks to 1.  Then we wait for the commands to finish in parallel, which is where the bulk of the execution time will be spent.

(Review request: http://reviews.vapour.ws/r/3173/)