### PR TITLE
state: add watchers for remote services

### DIFF
--- a/state/relation.go
+++ b/state/relation.go
@@ -7,7 +7,6 @@ import (
 	stderrors "errors"
 	"fmt"
 	"sort"
-	"strconv"
 	"strings"
 
 	"github.com/juju/errors"
@@ -333,19 +332,25 @@ func (r *Relation) Unit(u *Unit) (*RelationUnit, error) {
 	if err != nil {
 		return nil, err
 	}
-	scope := []string{"r", strconv.Itoa(r.doc.Id)}
+	scope := r.globalScope()
 	if ep.Scope == charm.ScopeContainer {
 		container := u.doc.Principal
 		if container == "" {
 			container = u.doc.Name
 		}
-		scope = append(scope, container)
+		scope = fmt.Sprintf("%s#%s", scope, container)
 	}
 	return &RelationUnit{
 		st:       r.st,
 		relation: r,
 		unit:     u,
 		endpoint: ep,
-		scope:    strings.Join(scope, "#"),
+		scope:    scope,
 	}, nil
+}
+
+// globalScope returns the scope prefix for relation scope document keys
+// in the global scope.
+func (r *Relation) globalScope() string {
+	return fmt.Sprintf("r#%d", r.doc.Id)
 }

--- a/state/relationunit.go
+++ b/state/relationunit.go
@@ -387,8 +387,14 @@ func (ru *RelationUnit) inScope(sel bson.D) (bool, error) {
 // entering and leaving the unit's scope.
 func (ru *RelationUnit) WatchScope() *RelationScopeWatcher {
 	role := counterpartRole(ru.endpoint.Role)
-	scope := ru.scope + "#" + string(role)
-	return newRelationScopeWatcher(ru.st, scope, ru.unit.Name())
+	return watchRelationScope(ru.st, ru.scope, role, ru.unit.Name())
+}
+
+func watchRelationScope(
+	st *State, scope string, role charm.RelationRole, ignore string,
+) *RelationScopeWatcher {
+	scope = scope + "#" + string(role)
+	return newRelationScopeWatcher(st, scope, ignore)
 }
 
 // Settings returns a Settings which allows access to the unit's settings

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -364,6 +364,14 @@ func (s *MultiEnvStateSuite) TestWatchTwoEnvironments(c *gc.C) {
 				f.MakeService(c, nil)
 			},
 		}, {
+			about: "remote services",
+			getWatcher: func(st *state.State) interface{} {
+				return st.WatchRemoteServices()
+			},
+			triggerEvent: func(st *state.State) {
+				st.AddRemoteService("db2", nil)
+			},
+		}, {
 			about: "relations",
 			getWatcher: func(st *state.State) interface{} {
 				f := factory.NewFactory(st)


### PR DESCRIPTION
Added two new methods for watching remote
services and relation unit endpoints:
 - State.WatchRemoteServices
 - Relation.WatchCounterpartEndpointUnits

The first one is necessary just so we can
watch remote services. Nothing special there.

WatchCounterpartEndpointUnits will be used
to watch the local units of a relation
involving a remote service. Because we won't
be tracking units of a remote service, we
cannot use the usual Unit -> RelationUnit ->
RelationUnit.Watch procedure. Instead, we
pass in the name of the remote service to
watch the counterpart units -- the units of
the local service involved in the relation.

(Review request: http://reviews.vapour.ws/r/3175/)