### PR TITLE
state: remove unit assignment docs after assigning

### DIFF
--- a/state/unit.go
+++ b/state/unit.go
@@ -1396,7 +1396,9 @@ func (u *Unit) assignToNewMachine(template MachineTemplate, parentId string, con
 		Id:     u.doc.DocID,
 		Assert: asserts,
 		Update: bson.D{{"$set", bson.D{{"machineid", mdoc.Id}}}},
-	})
+	},
+		removeStagedAssignmentOp(u.doc.DocID),
+	)
 
 	err = u.st.runTransaction(ops)
 	if err == nil {

--- a/state/unit_assignment.go
+++ b/state/unit_assignment.go
@@ -18,6 +18,18 @@ type assignUnitDoc struct {
 	Directive string `bson:"scope`
 }
 
+// UnitAssignment represents a staged unit assignment.
+type UnitAssignment struct {
+	// Unit is the ID of the unit to be assigned.
+	Unit string
+
+	// Scope is the placement scope to apply to the unit.
+	Scope string
+
+	// Directive is the placement directive to apply to the unit.
+	Directive string
+}
+
 // UnitAssignmentResult is the result of running a staged unit assignment.
 type UnitAssignmentResult struct {
 	Unit  string

--- a/state/unit_assignment_test.go
+++ b/state/unit_assignment_test.go
@@ -1,0 +1,73 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state_test
+
+import (
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/instance"
+	"github.com/juju/juju/state"
+)
+
+type UnitAssignmentSuite struct {
+	ConnSuite
+}
+
+var _ = gc.Suite(&UnitAssignmentSuite{})
+
+func (s *UnitAssignmentSuite) testAddServiceUnitAssignment(c *gc.C) (*state.Service, []state.UnitAssignment) {
+	charm := s.AddTestingCharm(c, "dummy")
+	svc, err := s.State.AddService(state.AddServiceArgs{
+		Name: "dummy", Owner: s.Owner.String(),
+		Charm: charm, NumUnits: 2,
+		Placement: []*instance.Placement{{s.State.EnvironUUID(), "abc"}},
+	})
+	units, err := svc.AllUnits()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(units, gc.HasLen, 2)
+	for _, u := range units {
+		_, err := u.AssignedMachineId()
+		c.Assert(err, jc.Satisfies, errors.IsNotAssigned)
+	}
+
+	assignments, err := s.State.AllUnitAssignments()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(assignments, jc.SameContents, []state.UnitAssignment{
+		{Unit: "dummy/0", Scope: s.State.EnvironUUID(), Directive: "abc"},
+		{Unit: "dummy/1"},
+	})
+	return svc, assignments
+}
+
+func (s *UnitAssignmentSuite) TestAddServiceUnitAssignment(c *gc.C) {
+	s.testAddServiceUnitAssignment(c)
+}
+
+func (s *UnitAssignmentSuite) TestAssignStagedUnits(c *gc.C) {
+	svc, _ := s.testAddServiceUnitAssignment(c)
+
+	results, err := s.State.AssignStagedUnits([]string{
+		"dummy/0", "dummy/1",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, jc.SameContents, []state.UnitAssignmentResult{
+		{Unit: "dummy/0"},
+		{Unit: "dummy/1"},
+	})
+
+	units, err := svc.AllUnits()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(units, gc.HasLen, 2)
+	for _, u := range units {
+		_, err := u.AssignedMachineId()
+		c.Assert(err, jc.ErrorIsNil)
+	}
+
+	// There should be no staged assignments now.
+	assignments, err := s.State.AllUnitAssignments()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(assignments, gc.HasLen, 0)
+}


### PR DESCRIPTION
We were removing the docs in one case, but not the
other. Crucially, we weren't removing them in the
typical case where the unit is assigned to a new
machine.

The tests are still woefully inadequate, but at least
they're non-zero and cover the linked bug.

Fixes https://bugs.launchpad.net/juju-core/+bug/1516144

(Review request: http://reviews.vapour.ws/r/3176/)