### PR TITLE
Add offered services facade and offered service listener

### DIFF
--- a/api/crossmodel/offerredservices.go
+++ b/api/crossmodel/offerredservices.go
@@ -1,0 +1,96 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package crossmodel
+
+import (
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/api/watcher"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/model/crossmodel"
+)
+
+// offeredServicesAPI allows access to a services exported from the environment.
+type offeredServicesAPI struct {
+	base.ClientFacade
+	facade base.FacadeCaller
+}
+
+// OfferedServiceAPI provides access to service offerings from this environment.
+type OfferedServiceAPI interface {
+
+	// OfferedServices returns the offered services for the specified urls.
+	// The results are keyed by URL.
+	OfferedServices(urls ...string) (map[string]crossmodel.OfferedService, error)
+
+	// WatchOfferedServices starts a watcher for changes to the offered
+	// services from this environment.
+	WatchOfferedServices() (watcher.StringsWatcher, error)
+}
+
+// NewOfferedServices creates a new client for accessing an offered services API.
+func NewOfferedServices(st base.APICallCloser) OfferedServiceAPI {
+	frontend, backend := base.NewClientFacade(st, "OfferedServices")
+	return &offeredServicesAPI{ClientFacade: frontend, facade: backend}
+}
+
+// OfferedServices returns the offered services for the specified urls.
+func (s *offeredServicesAPI) OfferedServices(urls ...string) (map[string]crossmodel.OfferedService, error) {
+	if len(urls) == 0 {
+		return nil, nil
+	}
+	var queryParams params.OfferedServiceQueryParams
+	queryParams.URLS = make([]string, len(urls))
+	for i, url := range urls {
+		queryParams.URLS[i] = url
+	}
+	results := new(params.OfferedServiceResults)
+	if err := s.facade.FacadeCall("OfferedServices", queryParams, results); err != nil {
+		return nil, errors.Trace(err)
+	}
+	if len(results.Results) != len(urls) {
+		return nil, errors.Errorf("expected %d results, got %d", len(urls), len(results.Results))
+	}
+	offers := make(map[string]crossmodel.OfferedService)
+	for i, result := range results.Results {
+		if result.Error != nil {
+			if result.Error.ErrorCode() == params.CodeNotFound {
+				continue
+			}
+			return nil, errors.Annotatef(result.Error, "error retrieving offer at %q", urls[i])
+		}
+		offers[result.Result.ServiceURL] = MakeOfferedServiceFromParams(result.Result)
+	}
+	return offers, nil
+}
+
+// MakeOfferedServiceFromParams creates an OfferedService from api parameters.
+func MakeOfferedServiceFromParams(offer params.OfferedService) crossmodel.OfferedService {
+	eps := make(map[string]string, len(offer.Endpoints))
+	for k, v := range offer.Endpoints {
+		eps[k] = v
+	}
+	return crossmodel.OfferedService{
+		ServiceURL:  offer.ServiceURL,
+		ServiceName: offer.ServiceName,
+		Registered:  offer.Registered,
+		Endpoints:   eps,
+	}
+}
+
+// WatchOfferedServices starts a watcher for changes to the offered
+// services from this environment.
+func (s *offeredServicesAPI) WatchOfferedServices() (watcher.StringsWatcher, error) {
+	var result params.StringsWatchResult
+	err := s.facade.FacadeCall("WatchOfferedServices", nil, &result)
+	if err != nil {
+		return nil, err
+	}
+	if result.Error != nil {
+		return nil, result.Error
+	}
+	w := watcher.NewStringsWatcher(s.facade.RawAPICaller(), result)
+	return w, nil
+}

--- a/api/crossmodel/offerredservices.go
+++ b/api/crossmodel/offerredservices.go
@@ -23,7 +23,7 @@ type OfferedServiceAPI interface {
 
 	// OfferedServices returns the offered services for the specified urls.
 	// The results are keyed by URL.
-	OfferedServices(urls ...string) (map[string]crossmodel.OfferedService, error)
+	OfferedServices(serviceUrls ...string) (map[string]crossmodel.OfferedService, error)
 
 	// WatchOfferedServices starts a watcher for changes to the offered
 	// services from this environment.
@@ -37,21 +37,21 @@ func NewOfferedServices(st base.APICallCloser) OfferedServiceAPI {
 }
 
 // OfferedServices returns the offered services for the specified urls.
-func (s *offeredServicesAPI) OfferedServices(urls ...string) (map[string]crossmodel.OfferedService, error) {
-	if len(urls) == 0 {
+func (s *offeredServicesAPI) OfferedServices(serviceUrls ...string) (map[string]crossmodel.OfferedService, error) {
+	if len(serviceUrls) == 0 {
 		return nil, nil
 	}
 	var queryParams params.OfferedServiceQueryParams
-	queryParams.URLS = make([]string, len(urls))
-	for i, url := range urls {
-		queryParams.URLS[i] = url
+	queryParams.ServiceUrls = make([]string, len(serviceUrls))
+	for i, url := range serviceUrls {
+		queryParams.ServiceUrls[i] = url
 	}
 	results := new(params.OfferedServiceResults)
 	if err := s.facade.FacadeCall("OfferedServices", queryParams, results); err != nil {
 		return nil, errors.Trace(err)
 	}
-	if len(results.Results) != len(urls) {
-		return nil, errors.Errorf("expected %d results, got %d", len(urls), len(results.Results))
+	if len(results.Results) != len(serviceUrls) {
+		return nil, errors.Errorf("expected %d results, got %d", len(serviceUrls), len(results.Results))
 	}
 	offers := make(map[string]crossmodel.OfferedService)
 	for i, result := range results.Results {
@@ -59,7 +59,7 @@ func (s *offeredServicesAPI) OfferedServices(urls ...string) (map[string]crossmo
 			if result.Error.ErrorCode() == params.CodeNotFound {
 				continue
 			}
-			return nil, errors.Annotatef(result.Error, "error retrieving offer at %q", urls[i])
+			return nil, errors.Annotatef(result.Error, "error retrieving offer at %q", serviceUrls[i])
 		}
 		offers[result.Result.ServiceURL] = MakeOfferedServiceFromParams(result.Result)
 	}

--- a/api/crossmodel/offerredservices_test.go
+++ b/api/crossmodel/offerredservices_test.go
@@ -35,16 +35,16 @@ func offeredServicesCaller(c *gc.C, offers []params.OfferedService, err string) 
 			args, ok := a.(params.OfferedServiceQueryParams)
 			c.Assert(ok, jc.IsTrue)
 
-			url := args.URLS[0]
-			c.Check(url, gc.DeepEquals, "local:/u/user/name")
+			url := args.ServiceUrls[0]
+			c.Check(url, gc.DeepEquals, "local:/u/user/servicename")
 
 			offersByURL := make(map[string]params.OfferedService)
 			for _, offer := range offers {
 				offersByURL[offer.ServiceURL] = offer
 			}
 			if results, ok := result.(*params.OfferedServiceResults); ok {
-				results.Results = make([]params.OfferedServiceResult, len(args.URLS))
-				for i, url := range args.URLS {
+				results.Results = make([]params.OfferedServiceResult, len(args.ServiceUrls))
+				for i, url := range args.ServiceUrls {
 					if err != "" {
 						results.Results[i].Error = common.ServerError(errors.New(err))
 						continue
@@ -63,7 +63,7 @@ func offeredServicesCaller(c *gc.C, offers []params.OfferedService, err string) 
 func (s *offeredServicesSuite) TestOfferedServices(c *gc.C) {
 	offers := []params.OfferedService{
 		{
-			ServiceURL:  "local:/u/user/name",
+			ServiceURL:  "local:/u/user/servicename",
 			ServiceName: "service",
 			Endpoints:   map[string]string{"foo": "bar"},
 			Registered:  true,
@@ -71,17 +71,17 @@ func (s *offeredServicesSuite) TestOfferedServices(c *gc.C) {
 	}
 	apiCaller := offeredServicesCaller(c, offers, "")
 	client := crossmodel.NewOfferedServices(apiCaller)
-	result, err := client.OfferedServices("local:/u/user/name")
+	result, err := client.OfferedServices("local:/u/user/servicename")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.HasLen, 1)
 	expectedOffer := crossmodel.MakeOfferedServiceFromParams(offers[0])
-	c.Assert(result["local:/u/user/name"], jc.DeepEquals, expectedOffer)
+	c.Assert(result["local:/u/user/servicename"], jc.DeepEquals, expectedOffer)
 }
 
 func (s *offeredServicesSuite) TestOfferedServicesNotFound(c *gc.C) {
 	apiCaller := offeredServicesCaller(c, nil, "")
 	client := crossmodel.NewOfferedServices(apiCaller)
-	result, err := client.OfferedServices("local:/u/user/name")
+	result, err := client.OfferedServices("local:/u/user/servicename")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.HasLen, 0)
 }
@@ -89,8 +89,8 @@ func (s *offeredServicesSuite) TestOfferedServicesNotFound(c *gc.C) {
 func (s *offeredServicesSuite) TestOfferedServicesError(c *gc.C) {
 	apiCaller := offeredServicesCaller(c, nil, "error")
 	client := crossmodel.NewOfferedServices(apiCaller)
-	_, err := client.OfferedServices("local:/u/user/name")
-	c.Assert(err, gc.ErrorMatches, `error retrieving offer at "local:/u/user/name": error`)
+	_, err := client.OfferedServices("local:/u/user/servicename")
+	c.Assert(err, gc.ErrorMatches, `error retrieving offer at "local:/u/user/servicename": error`)
 }
 
 func watchOfferedServicesCaller(c *gc.C, err string) basetesting.APICallerFunc {

--- a/api/crossmodel/offerredservices_test.go
+++ b/api/crossmodel/offerredservices_test.go
@@ -1,0 +1,132 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package crossmodel_test
+
+import (
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	basetesting "github.com/juju/juju/api/base/testing"
+	"github.com/juju/juju/api/crossmodel"
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/testing"
+)
+
+type offeredServicesSuite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&offeredServicesSuite{})
+
+func offeredServicesCaller(c *gc.C, offers []params.OfferedService, err string) basetesting.APICallerFunc {
+	return basetesting.APICallerFunc(
+		func(objType string,
+			version int,
+			id, request string,
+			a, result interface{},
+		) error {
+			c.Check(objType, gc.Equals, "OfferedServices")
+			c.Check(id, gc.Equals, "")
+			c.Check(request, gc.Equals, "OfferedServices")
+
+			args, ok := a.(params.OfferedServiceQueryParams)
+			c.Assert(ok, jc.IsTrue)
+
+			url := args.URLS[0]
+			c.Check(url, gc.DeepEquals, "local:/u/user/name")
+
+			offersByURL := make(map[string]params.OfferedService)
+			for _, offer := range offers {
+				offersByURL[offer.ServiceURL] = offer
+			}
+			if results, ok := result.(*params.OfferedServiceResults); ok {
+				results.Results = make([]params.OfferedServiceResult, len(args.URLS))
+				for i, url := range args.URLS {
+					if err != "" {
+						results.Results[i].Error = common.ServerError(errors.New(err))
+						continue
+					}
+					if offer, ok := offersByURL[url]; ok {
+						results.Results[i] = params.OfferedServiceResult{Result: offer}
+					} else {
+						results.Results[i].Error = common.ServerError(errors.NotFoundf("offfer at url %q", url))
+					}
+				}
+			}
+			return nil
+		})
+}
+
+func (s *offeredServicesSuite) TestOfferedServices(c *gc.C) {
+	offers := []params.OfferedService{
+		{
+			ServiceURL:  "local:/u/user/name",
+			ServiceName: "service",
+			Endpoints:   map[string]string{"foo": "bar"},
+			Registered:  true,
+		},
+	}
+	apiCaller := offeredServicesCaller(c, offers, "")
+	client := crossmodel.NewOfferedServices(apiCaller)
+	result, err := client.OfferedServices("local:/u/user/name")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, gc.HasLen, 1)
+	expectedOffer := crossmodel.MakeOfferedServiceFromParams(offers[0])
+	c.Assert(result["local:/u/user/name"], jc.DeepEquals, expectedOffer)
+}
+
+func (s *offeredServicesSuite) TestOfferedServicesNotFound(c *gc.C) {
+	apiCaller := offeredServicesCaller(c, nil, "")
+	client := crossmodel.NewOfferedServices(apiCaller)
+	result, err := client.OfferedServices("local:/u/user/name")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, gc.HasLen, 0)
+}
+
+func (s *offeredServicesSuite) TestOfferedServicesError(c *gc.C) {
+	apiCaller := offeredServicesCaller(c, nil, "error")
+	client := crossmodel.NewOfferedServices(apiCaller)
+	_, err := client.OfferedServices("local:/u/user/name")
+	c.Assert(err, gc.ErrorMatches, `error retrieving offer at "local:/u/user/name": error`)
+}
+
+func watchOfferedServicesCaller(c *gc.C, err string) basetesting.APICallerFunc {
+	return basetesting.APICallerFunc(
+		func(objType string,
+			version int,
+			id, request string,
+			a, result interface{},
+		) error {
+			c.Check(objType, gc.Equals, "OfferedServices")
+			c.Check(id, gc.Equals, "")
+			c.Check(request, gc.Equals, "WatchOfferedServices")
+			c.Assert(a, gc.IsNil)
+
+			if result, ok := result.(*params.StringsWatchResult); ok {
+				result.Error = &params.Error{Message: "fail"}
+			}
+			return nil
+		})
+}
+
+func (s *offeredServicesSuite) TestWatchOfferedServices(c *gc.C) {
+	apiCaller := watchOfferedServicesCaller(c, "")
+	client := crossmodel.NewOfferedServices(apiCaller)
+	_, err := client.WatchOfferedServices()
+	c.Assert(err, gc.ErrorMatches, "fail")
+}
+
+func (s *offeredServicesSuite) TestWatchOfferedServicesFacadeCallError(c *gc.C) {
+	client := crossmodel.NewOfferedServices(apiCallerWithError(c, "OfferedServices", "WatchOfferedServices"))
+	_, err := client.WatchOfferedServices()
+	c.Assert(errors.Cause(err), gc.ErrorMatches, "facade failure")
+}
+
+func (s *offeredServicesSuite) TestOfferedServicesFacadeCallError(c *gc.C) {
+	client := crossmodel.NewOfferedServices(apiCallerWithError(c, "OfferedServices", "OfferedServices"))
+	_, err := client.OfferedServices("url")
+	c.Assert(errors.Cause(err), gc.ErrorMatches, "facade failure")
+}

--- a/api/crossmodel/servicedirectory_test.go
+++ b/api/crossmodel/servicedirectory_test.go
@@ -39,7 +39,7 @@ func serviceForURLCaller(c *gc.C, offers []params.ServiceOffer, err string) base
 			c.Assert(args.Filters, gc.HasLen, 1)
 
 			filter := args.Filters[0]
-			c.Check(filter.ServiceURL, gc.DeepEquals, "local:/u/user/name")
+			c.Check(filter.ServiceURL, gc.DeepEquals, "local:/u/user/servicename")
 			c.Check(filter.AllowedUserTags, jc.SameContents, []string{"user-foo"})
 			c.Check(filter.Endpoints, gc.HasLen, 0)
 			c.Check(filter.ServiceName, gc.Equals, "")
@@ -69,7 +69,7 @@ func (s *serviceDirectorySuite) TestServiceForURL(c *gc.C) {
 	}
 	offers := []params.ServiceOffer{
 		{
-			ServiceURL:       "local:/u/user/name",
+			ServiceURL:       "local:/u/user/servicename",
 			ServiceName:      "service",
 			SourceEnvironTag: "environment-" + fakeUUID,
 			Endpoints:        endpoints,
@@ -77,7 +77,7 @@ func (s *serviceDirectorySuite) TestServiceForURL(c *gc.C) {
 	}
 	apiCaller := serviceForURLCaller(c, offers, "")
 	client := crossmodel.NewServiceOffers(apiCaller)
-	result, err := jujucrossmodel.ServiceOfferForURL(client, "local:/u/user/name", "foo")
+	result, err := jujucrossmodel.ServiceOfferForURL(client, "local:/u/user/servicename", "foo")
 	c.Assert(err, jc.ErrorIsNil)
 	expectedOffer, err := crossmodel.MakeOfferFromParams(offers[0])
 	c.Assert(err, jc.ErrorIsNil)
@@ -87,14 +87,14 @@ func (s *serviceDirectorySuite) TestServiceForURL(c *gc.C) {
 func (s *serviceDirectorySuite) TestServiceForURLNoneOrNoAccess(c *gc.C) {
 	apiCaller := serviceForURLCaller(c, []params.ServiceOffer{}, "")
 	client := crossmodel.NewServiceOffers(apiCaller)
-	_, err := jujucrossmodel.ServiceOfferForURL(client, "local:/u/user/name", "foo")
+	_, err := jujucrossmodel.ServiceOfferForURL(client, "local:/u/user/servicename", "foo")
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
 
 func (s *serviceDirectorySuite) TestServiceForURLError(c *gc.C) {
 	apiCaller := serviceForURLCaller(c, nil, "error")
 	client := crossmodel.NewServiceOffers(apiCaller)
-	_, err := jujucrossmodel.ServiceOfferForURL(client, "local:/u/user/name", "foo")
+	_, err := jujucrossmodel.ServiceOfferForURL(client, "local:/u/user/servicename", "foo")
 	c.Assert(err, gc.ErrorMatches, "error")
 }
 
@@ -138,7 +138,7 @@ func (s *serviceDirectorySuite) TestListOffers(c *gc.C) {
 	}
 	offers := []params.ServiceOffer{
 		{
-			ServiceURL:       "local:/u/user/name",
+			ServiceURL:       "local:/u/user/servicename",
 			ServiceName:      "service",
 			SourceEnvironTag: "environment-" + fakeUUID,
 			Endpoints:        endpoints,
@@ -218,7 +218,7 @@ func (s *serviceDirectorySuite) TestAddOffers(c *gc.C) {
 	offers := []params.AddServiceOffer{
 		{
 			ServiceOffer: params.ServiceOffer{
-				ServiceURL:       "local:/u/user/name",
+				ServiceURL:       "local:/u/user/servicename",
 				ServiceName:      "service",
 				SourceEnvironTag: "environment-" + fakeUUID,
 				Endpoints:        endpoints,
@@ -245,7 +245,7 @@ func (s *serviceDirectorySuite) TestAddOffersError(c *gc.C) {
 	offers := []params.AddServiceOffer{
 		{
 			ServiceOffer: params.ServiceOffer{
-				ServiceURL:       "local:/u/user/name",
+				ServiceURL:       "local:/u/user/servicename",
 				ServiceName:      "service",
 				SourceEnvironTag: "environment-" + fakeUUID,
 				Endpoints:        endpoints,
@@ -285,7 +285,7 @@ func apiCallerWithError(c *gc.C, facadeName, apiName string) basetesting.APICall
 
 func (s *serviceDirectorySuite) TestServiceForURLFacadeCallError(c *gc.C) {
 	client := crossmodel.NewServiceOffers(apiCallerWithError(c, "ServiceOffers", "ListOffers"))
-	_, err := jujucrossmodel.ServiceOfferForURL(client, "local:/u/user/name", "user")
+	_, err := jujucrossmodel.ServiceOfferForURL(client, "local:/u/user/servicename", "user")
 	c.Assert(errors.Cause(err), gc.ErrorMatches, "facade failure")
 }
 

--- a/api/crossmodel/servicedirectory_test.go
+++ b/api/crossmodel/servicedirectory_test.go
@@ -268,14 +268,14 @@ func (s *serviceDirectorySuite) TestAddOffersInvalidUser(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `user name "foo/23" not valid`)
 }
 
-func apiCallerWithError(c *gc.C, apiName string) basetesting.APICallerFunc {
+func apiCallerWithError(c *gc.C, facadeName, apiName string) basetesting.APICallerFunc {
 	return basetesting.APICallerFunc(
 		func(objType string,
 			version int,
 			id, request string,
 			a, result interface{},
 		) error {
-			c.Check(objType, gc.Equals, "ServiceOffers")
+			c.Check(objType, gc.Equals, facadeName)
 			c.Check(id, gc.Equals, "")
 			c.Check(request, gc.Equals, apiName)
 
@@ -284,19 +284,19 @@ func apiCallerWithError(c *gc.C, apiName string) basetesting.APICallerFunc {
 }
 
 func (s *serviceDirectorySuite) TestServiceForURLFacadeCallError(c *gc.C) {
-	client := crossmodel.NewServiceOffers(apiCallerWithError(c, "ListOffers"))
+	client := crossmodel.NewServiceOffers(apiCallerWithError(c, "ServiceOffers", "ListOffers"))
 	_, err := jujucrossmodel.ServiceOfferForURL(client, "local:/u/user/name", "user")
 	c.Assert(errors.Cause(err), gc.ErrorMatches, "facade failure")
 }
 
 func (s *serviceDirectorySuite) TestListOffersFacadeCallError(c *gc.C) {
-	client := crossmodel.NewServiceOffers(apiCallerWithError(c, "ListOffers"))
+	client := crossmodel.NewServiceOffers(apiCallerWithError(c, "ServiceOffers", "ListOffers"))
 	_, err := client.ListOffers("local", jujucrossmodel.ServiceOfferFilter{})
 	c.Assert(errors.Cause(err), gc.ErrorMatches, "facade failure")
 }
 
 func (s *serviceDirectorySuite) TestAddOfferFacadeCallError(c *gc.C) {
-	client := crossmodel.NewServiceOffers(apiCallerWithError(c, "AddOffers"))
+	client := crossmodel.NewServiceOffers(apiCallerWithError(c, "ServiceOffers", "AddOffers"))
 	err := client.AddOffer(jujucrossmodel.ServiceOffer{}, nil)
 	c.Assert(errors.Cause(err), gc.ErrorMatches, "facade failure")
 }

--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -46,6 +46,7 @@ var facadeVersions = map[string]int{
 	"MetricsAdder":                 1,
 	"Networker":                    0,
 	"NotifyWatcher":                0,
+	"OfferedServices":              1,
 	"Pinger":                       0,
 	"Provisioner":                  1,
 	"Reboot":                       1,

--- a/apiserver/crossmodel/export_test.go
+++ b/apiserver/crossmodel/export_test.go
@@ -4,7 +4,8 @@
 package crossmodel
 
 var (
-	CreateAPI              = createAPI
-	CreateServiceOffersAPI = createServiceOffersAPI
-	NewServiceAPIFactory   = newServiceAPIFactory
+	CreateAPI               = createAPI
+	CreateServiceOffersAPI  = createServiceOffersAPI
+	CreateOfferedServiceAPI = createOfferedServiceAPI
+	NewServiceAPIFactory    = newServiceAPIFactory
 )

--- a/apiserver/crossmodel/mock_test.go
+++ b/apiserver/crossmodel/mock_test.go
@@ -7,6 +7,7 @@ import (
 	jtesting "github.com/juju/testing"
 
 	"github.com/juju/juju/model/crossmodel"
+	"github.com/juju/juju/state"
 )
 
 const (
@@ -41,4 +42,33 @@ func (m *mockServiceDirectory) UpdateOffer(offer crossmodel.ServiceOffer) error 
 func (m *mockServiceDirectory) Remove(url string) error {
 	m.AddCall(removeOfferCall)
 	panic("not implemented")
+}
+
+type mockState struct {
+	watchOfferedServices func() state.StringsWatcher
+}
+
+func (m *mockState) WatchOfferedServices() state.StringsWatcher {
+	return m.watchOfferedServices()
+}
+
+type mockStringsWatcher struct {
+	state.StringsWatcher
+	changes chan []string
+}
+
+func (m *mockStringsWatcher) Changes() <-chan []string {
+	return m.changes
+}
+
+func (m *mockStringsWatcher) Stop() error {
+	return nil
+}
+
+type mockOfferLister struct {
+	listOffers func(filters ...crossmodel.OfferedServiceFilter) ([]crossmodel.OfferedService, error)
+}
+
+func (m *mockOfferLister) ListOffers(filters ...crossmodel.OfferedServiceFilter) ([]crossmodel.OfferedService, error) {
+	return m.listOffers(filters...)
 }

--- a/apiserver/crossmodel/offeredservices.go
+++ b/apiserver/crossmodel/offeredservices.go
@@ -17,10 +17,13 @@ func init() {
 	common.RegisterStandardFacade("OfferedServices", 1, newOfferedServiceAPI)
 }
 
+// OfferedServiceLister instances allow offered services to be queried.
 type OfferedServiceLister interface {
+	// ListOffers returns the offered services matching the filter.
 	ListOffers(filter ...crossmodel.OfferedServiceFilter) ([]crossmodel.OfferedService, error)
 }
 
+// OfferedServiceAPI is a facade used to access offered services.
 type OfferedServiceAPI struct {
 	st              stateAccessor
 	offeredServices OfferedServiceLister
@@ -70,8 +73,8 @@ func (s *OfferedServiceAPI) WatchOfferedServices() (params.StringsWatchResult, e
 
 // OfferedServices returns the offered services matching the query parameters.
 func (s *OfferedServiceAPI) OfferedServices(filter params.OfferedServiceQueryParams) (params.OfferedServiceResults, error) {
-	offers := make([]params.OfferedServiceResult, len(filter.URLS))
-	for i, url := range filter.URLS {
+	offers := make([]params.OfferedServiceResult, len(filter.ServiceUrls))
+	for i, url := range filter.ServiceUrls {
 		offerResults, err := s.offeredServices.ListOffers(crossmodel.OfferedServiceFilter{
 			ServiceURL: url,
 		})

--- a/apiserver/crossmodel/offeredservices.go
+++ b/apiserver/crossmodel/offeredservices.go
@@ -1,0 +1,98 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package crossmodel
+
+import (
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/model/crossmodel"
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/state/watcher"
+)
+
+func init() {
+	common.RegisterStandardFacade("OfferedServices", 1, newOfferedServiceAPI)
+}
+
+type OfferedServiceLister interface {
+	ListOffers(filter ...crossmodel.OfferedServiceFilter) ([]crossmodel.OfferedService, error)
+}
+
+type OfferedServiceAPI struct {
+	st              stateAccessor
+	offeredServices OfferedServiceLister
+	resources       *common.Resources
+	authorizer      common.Authorizer
+}
+
+// createServiceDirectoryAPI returns a new cross model API facade.
+func createOfferedServiceAPI(
+	st stateAccessor,
+	offeredServiceLister OfferedServiceLister,
+	resources *common.Resources,
+	authorizer common.Authorizer,
+) (*OfferedServiceAPI, error) {
+	if !authorizer.AuthEnvironManager() {
+		return nil, common.ErrPerm
+	}
+
+	return &OfferedServiceAPI{
+		st:              st,
+		offeredServices: offeredServiceLister,
+		authorizer:      authorizer,
+		resources:       resources,
+	}, nil
+}
+
+func newOfferedServiceAPI(
+	st *state.State,
+	resources *common.Resources,
+	authorizer common.Authorizer,
+) (*OfferedServiceAPI, error) {
+	return createOfferedServiceAPI(getState(st), state.NewOfferedServices(st), resources, authorizer)
+}
+
+// WatchOfferedServices creates a watcher to listen to changes to the offered services.
+func (s *OfferedServiceAPI) WatchOfferedServices() (params.StringsWatchResult, error) {
+	nothing := params.StringsWatchResult{}
+	watch := s.st.WatchOfferedServices()
+	if changes, ok := <-watch.Changes(); ok {
+		return params.StringsWatchResult{
+			StringsWatcherId: s.resources.Register(watch),
+			Changes:          changes,
+		}, nil
+	}
+	return nothing, watcher.EnsureErr(watch)
+}
+
+// OfferedServices returns the offered services matching the query parameters.
+func (s *OfferedServiceAPI) OfferedServices(filter params.OfferedServiceQueryParams) (params.OfferedServiceResults, error) {
+	offers := make([]params.OfferedServiceResult, len(filter.URLS))
+	for i, url := range filter.URLS {
+		offerResults, err := s.offeredServices.ListOffers(crossmodel.OfferedServiceFilter{
+			ServiceURL: url,
+		})
+		if err != nil {
+			offers[i].Error = common.ServerError(err)
+			continue
+		}
+		if len(offerResults) == 0 {
+			offers[i].Error = common.ServerError(errors.NotFoundf("offered service at %q", url))
+			continue
+		}
+		if len(offerResults) != 1 {
+			offers[i].Error = common.ServerError(errors.Errorf("expected 1 result, got %d", len(offerResults)))
+			continue
+		}
+		offers[i].Result = params.OfferedService{
+			ServiceURL:  offerResults[0].ServiceURL,
+			ServiceName: offerResults[0].ServiceName,
+			Registered:  offerResults[0].Registered,
+			Endpoints:   offerResults[0].Endpoints,
+		}
+	}
+	return params.OfferedServiceResults{offers}, nil
+}

--- a/apiserver/crossmodel/offeredservices_test.go
+++ b/apiserver/crossmodel/offeredservices_test.go
@@ -103,8 +103,8 @@ func (s *offeredServicesSuite) constructOfferLister() *mockOfferLister {
 }
 
 func (s *offeredServicesSuite) TestListOffers(c *gc.C) {
-	s.offers["local:/u/user/name"] = jujucrossmodel.OfferedService{
-		ServiceURL:  "local:/u/user/name",
+	s.offers["local:/u/user/servicename"] = jujucrossmodel.OfferedService{
+		ServiceURL:  "local:/u/user/servicename",
 		ServiceName: "service",
 		Registered:  true,
 		Endpoints:   map[string]string{"foo": "bar"},
@@ -116,24 +116,24 @@ func (s *offeredServicesSuite) TestListOffers(c *gc.C) {
 		Endpoints:   map[string]string{"db": "db"},
 	}
 	results, err := s.api.OfferedServices(params.OfferedServiceQueryParams{
-		URLS: []string{"local:/u/user/name"},
+		ServiceUrls: []string{"local:/u/user/servicename"},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.HasLen, 1)
 	s.assertCalls(c, []string{"listoffers"})
 	offer := apicrossmodel.MakeOfferedServiceFromParams(results.Results[0].Result)
-	c.Assert(offer, jc.DeepEquals, s.offers["local:/u/user/name"])
+	c.Assert(offer, jc.DeepEquals, s.offers["local:/u/user/servicename"])
 }
 
 func (s *offeredServicesSuite) TestListOffersNoneFound(c *gc.C) {
-	s.offers["local:/u/user/name"] = jujucrossmodel.OfferedService{
-		ServiceURL:  "local:/u/user/name",
+	s.offers["local:/u/user/servicename"] = jujucrossmodel.OfferedService{
+		ServiceURL:  "local:/u/user/servicename",
 		ServiceName: "service",
 		Registered:  true,
 		Endpoints:   map[string]string{"foo": "bar"},
 	}
 	results, err := s.api.OfferedServices(params.OfferedServiceQueryParams{
-		URLS: []string{"local:/u/user/bogus"},
+		ServiceUrls: []string{"local:/u/user/bogus"},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.HasLen, 1)

--- a/apiserver/crossmodel/offeredservices_test.go
+++ b/apiserver/crossmodel/offeredservices_test.go
@@ -1,0 +1,142 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package crossmodel_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	apicrossmodel "github.com/juju/juju/api/crossmodel"
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/crossmodel"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/apiserver/testing"
+	jujucrossmodel "github.com/juju/juju/model/crossmodel"
+	"github.com/juju/juju/state"
+	coretesting "github.com/juju/juju/testing"
+)
+
+type offeredServicesSuite struct {
+	coretesting.BaseSuite
+
+	resources  *common.Resources
+	authoriser testing.FakeAuthorizer
+	api        *crossmodel.OfferedServiceAPI
+
+	calls       []string
+	offerLister *mockOfferLister
+	offers      map[string]jujucrossmodel.OfferedService
+}
+
+var _ = gc.Suite(&offeredServicesSuite{})
+
+func (s *offeredServicesSuite) SetUpTest(c *gc.C) {
+	s.authoriser = testing.FakeAuthorizer{
+		EnvironManager: true,
+	}
+	s.resources = common.NewResources()
+	s.AddCleanup(func(*gc.C) { s.resources.StopAll() })
+
+	s.calls = []string{}
+	s.offers = make(map[string]jujucrossmodel.OfferedService)
+	s.offerLister = s.constructOfferLister()
+
+	var err error
+	s.api, err = crossmodel.CreateOfferedServiceAPI(&mockState{}, s.offerLister, s.resources, s.authoriser)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *offeredServicesSuite) TestUnauthorised(c *gc.C) {
+	s.authoriser = testing.FakeAuthorizer{
+		EnvironManager: false,
+	}
+	_, err := crossmodel.CreateOfferedServiceAPI(&mockState{}, s.offerLister, s.resources, s.authoriser)
+	c.Assert(err, gc.Equals, common.ErrPerm)
+}
+
+func (s *offeredServicesSuite) TestWatchOfferedServices(c *gc.C) {
+	authoriser := testing.FakeAuthorizer{
+		EnvironManager: true,
+	}
+	resources := common.NewResources()
+	defer resources.StopAll()
+
+	watcher := &mockStringsWatcher{
+		changes: make(chan []string, 1),
+	}
+	watcher.changes <- []string{"local:/u/me/service", "local:/u/me/service"}
+	state := &mockState{
+		watchOfferedServices: func() state.StringsWatcher {
+			return watcher
+		},
+	}
+
+	api, err := crossmodel.CreateOfferedServiceAPI(state, s.constructOfferLister(), resources, authoriser)
+	c.Assert(err, jc.ErrorIsNil)
+	watches, err := api.WatchOfferedServices()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(watches, gc.DeepEquals, params.StringsWatchResult{
+		StringsWatcherId: "1",
+		Changes:          []string{"local:/u/me/service", "local:/u/me/service"},
+	})
+	c.Assert(resources.Get("1"), gc.Equals, watcher)
+}
+
+func (s *offeredServicesSuite) assertCalls(c *gc.C, expectedCalls []string) {
+	c.Assert(s.calls, jc.SameContents, expectedCalls)
+}
+
+func (s *offeredServicesSuite) constructOfferLister() *mockOfferLister {
+	return &mockOfferLister{
+		listOffers: func(filters ...jujucrossmodel.OfferedServiceFilter) ([]jujucrossmodel.OfferedService, error) {
+			s.calls = append(s.calls, "listoffers")
+			var result []jujucrossmodel.OfferedService
+			for _, filter := range filters {
+				if offer, ok := s.offers[filter.ServiceURL]; ok {
+					result = append(result, offer)
+				}
+			}
+			return result, nil
+		},
+	}
+}
+
+func (s *offeredServicesSuite) TestListOffers(c *gc.C) {
+	s.offers["local:/u/user/name"] = jujucrossmodel.OfferedService{
+		ServiceURL:  "local:/u/user/name",
+		ServiceName: "service",
+		Registered:  true,
+		Endpoints:   map[string]string{"foo": "bar"},
+	}
+	s.offers["local:/u/user/anothername"] = jujucrossmodel.OfferedService{
+		ServiceURL:  "local:/u/user/anothername",
+		ServiceName: "service2",
+		Registered:  true,
+		Endpoints:   map[string]string{"db": "db"},
+	}
+	results, err := s.api.OfferedServices(params.OfferedServiceQueryParams{
+		URLS: []string{"local:/u/user/name"},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results.Results, gc.HasLen, 1)
+	s.assertCalls(c, []string{"listoffers"})
+	offer := apicrossmodel.MakeOfferedServiceFromParams(results.Results[0].Result)
+	c.Assert(offer, jc.DeepEquals, s.offers["local:/u/user/name"])
+}
+
+func (s *offeredServicesSuite) TestListOffersNoneFound(c *gc.C) {
+	s.offers["local:/u/user/name"] = jujucrossmodel.OfferedService{
+		ServiceURL:  "local:/u/user/name",
+		ServiceName: "service",
+		Registered:  true,
+		Endpoints:   map[string]string{"foo": "bar"},
+	}
+	results, err := s.api.OfferedServices(params.OfferedServiceQueryParams{
+		URLS: []string{"local:/u/user/bogus"},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results.Results, gc.HasLen, 1)
+	s.assertCalls(c, []string{"listoffers"})
+	c.Assert(results.Results[0].Error.ErrorCode(), gc.Equals, params.CodeNotFound)
+}

--- a/apiserver/crossmodel/servicedirectory_test.go
+++ b/apiserver/crossmodel/servicedirectory_test.go
@@ -72,6 +72,14 @@ func (s *serviceDirectorySuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
+func (s *serviceDirectorySuite) TestUnauthorised(c *gc.C) {
+	s.authoriser = testing.FakeAuthorizer{
+		EnvironManager: false,
+	}
+	_, err := crossmodel.CreateServiceOffersAPI(nil, s.resources, s.authoriser)
+	c.Assert(err, gc.Equals, common.ErrPerm)
+}
+
 func (s *serviceDirectorySuite) assertCalls(c *gc.C, expectedCalls []string) {
 	c.Assert(s.calls, jc.SameContents, expectedCalls)
 }

--- a/apiserver/crossmodel/servicedirectory_test.go
+++ b/apiserver/crossmodel/servicedirectory_test.go
@@ -91,7 +91,7 @@ func (s *serviceDirectorySuite) TestAddOffer(c *gc.C) {
 		Offers: []params.AddServiceOffer{
 			{
 				ServiceOffer: params.ServiceOffer{
-					ServiceURL:       "local:/u/user/name",
+					ServiceURL:       "local:/u/user/servicename",
 					ServiceName:      "service",
 					SourceEnvironTag: names.NewEnvironTag(fakeUUID).String(),
 				},
@@ -112,7 +112,7 @@ func (s *serviceDirectorySuite) TestAddOffer(c *gc.C) {
 	s.assertCalls(c, []string{"addoffer", "addoffer"})
 	offer0, err := apicrossmodel.MakeOfferFromParams(offers.Offers[0].ServiceOffer)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(s.offers["local:/u/user/name"], jc.DeepEquals, offer0)
+	c.Assert(s.offers["local:/u/user/servicename"], jc.DeepEquals, offer0)
 	offer1, err := apicrossmodel.MakeOfferFromParams(offers.Offers[1].ServiceOffer)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.offers["local:/u/user/anothername"], jc.DeepEquals, offer1)
@@ -127,7 +127,7 @@ func (s *serviceDirectorySuite) TestAddOfferError(c *gc.C) {
 		Offers: []params.AddServiceOffer{
 			{
 				ServiceOffer: params.ServiceOffer{
-					ServiceURL:       "local:/u/user/name",
+					ServiceURL:       "local:/u/user/servicename",
 					ServiceName:      "service",
 					SourceEnvironTag: names.NewEnvironTag(fakeUUID).String(),
 				},
@@ -142,8 +142,8 @@ func (s *serviceDirectorySuite) TestAddOfferError(c *gc.C) {
 }
 
 func (s *serviceDirectorySuite) TestListOffers(c *gc.C) {
-	s.offers["local:/u/user/name"] = jujucrossmodel.ServiceOffer{
-		ServiceURL:    "local:/u/user/name",
+	s.offers["local:/u/user/servicename"] = jujucrossmodel.ServiceOffer{
+		ServiceURL:    "local:/u/user/servicename",
 		ServiceName:   "service",
 		SourceEnvUUID: fakeUUID,
 	}
@@ -156,7 +156,7 @@ func (s *serviceDirectorySuite) TestListOffers(c *gc.C) {
 		Directory: "local",
 		Filters: []params.OfferFilter{
 			{
-				ServiceURL: "local:/u/user/name",
+				ServiceURL: "local:/u/user/servicename",
 			},
 		},
 	})
@@ -166,8 +166,8 @@ func (s *serviceDirectorySuite) TestListOffers(c *gc.C) {
 	s.assertCalls(c, []string{"listoffers"})
 	offer, err := apicrossmodel.MakeOfferFromParams(results.Offers[0])
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(offer, jc.DeepEquals, s.offers["local:/u/user/name"])
-	c.Assert(results.Offers[0].ServiceURL, gc.Equals, "local:/u/user/name")
+	c.Assert(offer, jc.DeepEquals, s.offers["local:/u/user/servicename"])
+	c.Assert(results.Offers[0].ServiceURL, gc.Equals, "local:/u/user/servicename")
 	c.Assert(results.Offers[0].SourceEnvironTag, gc.Equals, names.NewEnvironTag(fakeUUID).String())
 }
 

--- a/apiserver/crossmodel/state.go
+++ b/apiserver/crossmodel/state.go
@@ -1,0 +1,20 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package crossmodel
+
+import (
+	"github.com/juju/juju/state"
+)
+
+type stateAccessor interface {
+	WatchOfferedServices() state.StringsWatcher
+}
+
+type storageStateShim struct {
+	*state.State
+}
+
+var getState = func(st *state.State) stateAccessor {
+	return storageStateShim{st}
+}

--- a/apiserver/params/crossmodel.go
+++ b/apiserver/params/crossmodel.go
@@ -112,3 +112,30 @@ type RemoteServiceResults struct {
 type ShowFilter struct {
 	URLs []string `json:"urls,omitempty"`
 }
+
+// OfferedService represents attributes for an offered service.
+// TODO(wallyworld) - consolidate this with the CLI when possible.
+type OfferedService struct {
+	ServiceURL  string            `json:"serviceurl"`
+	ServiceName string            `json:"servicename"`
+	Registered  bool              `json:"registered"`
+	Endpoints   map[string]string `json:"endpoints"`
+}
+
+// OfferedServiceResult holds the result of loading an
+// offerred service at a URL.
+type OfferedServiceResult struct {
+	Result OfferedService `json:"result,omitempty"`
+	Error  *Error         `json:"error,omitempty"`
+}
+
+// OfferedServiceResults represents the result of a ListOfferedServices call.
+type OfferedServiceResults struct {
+	Results []OfferedServiceResult
+}
+
+// OfferedServiceQueryParams is used to specify the URLs
+// for which we want to load offered service details.
+type OfferedServiceQueryParams struct {
+	URLS []string
+}

--- a/apiserver/params/crossmodel.go
+++ b/apiserver/params/crossmodel.go
@@ -137,5 +137,5 @@ type OfferedServiceResults struct {
 // OfferedServiceQueryParams is used to specify the URLs
 // for which we want to load offered service details.
 type OfferedServiceQueryParams struct {
-	URLS []string
+	ServiceUrls []string
 }

--- a/model/crossmodel/servicedirectory_test.go
+++ b/model/crossmodel/servicedirectory_test.go
@@ -29,18 +29,18 @@ func (m *mockServiceOfferLister) ListOffers(directory string, filter ...crossmod
 func (s *serviceDirectorySuite) TestServiceForURL(c *gc.C) {
 	offers := []crossmodel.ServiceOffer{
 		{
-			ServiceURL:  "local:/u/user/name",
+			ServiceURL:  "local:/u/user/servicename",
 			ServiceName: "service",
 		},
 	}
 	offerLister := &mockServiceOfferLister{offers}
-	result, err := crossmodel.ServiceOfferForURL(offerLister, "local:/u/user/name", "foo")
+	result, err := crossmodel.ServiceOfferForURL(offerLister, "local:/u/user/servicename", "foo")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, offers[0])
 }
 
 func (s *serviceDirectorySuite) TestServiceForURLNoneOrNoAccess(c *gc.C) {
 	offerLister := &mockServiceOfferLister{[]crossmodel.ServiceOffer{}}
-	_, err := crossmodel.ServiceOfferForURL(offerLister, "local:/u/user/name", "foo")
+	_, err := crossmodel.ServiceOfferForURL(offerLister, "local:/u/user/servicename", "foo")
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }

--- a/model/crossmodel/serviceurl_test.go
+++ b/model/crossmodel/serviceurl_test.go
@@ -23,19 +23,19 @@ var urlTests = []struct {
 	exact  string
 	url    *crossmodel.ServiceURL
 }{{
-	s:   "local:/u/user/name",
-	url: &crossmodel.ServiceURL{"local", "user", "name"},
+	s:   "local:/u/user/servicename",
+	url: &crossmodel.ServiceURL{"local", "user", "servicename"},
 }, {
-	s:   "nonlocal:/u/user/name",
+	s:   "nonlocal:/u/user/servicename",
 	err: "service URL has invalid directory: $URL",
 }, {
-	s:     "/u/user/name",
-	url:   &crossmodel.ServiceURL{"local", "user", "name"},
-	exact: "local:/u/user/name",
+	s:     "/u/user/servicename",
+	url:   &crossmodel.ServiceURL{"local", "user", "servicename"},
+	exact: "local:/u/user/servicename",
 }, {
-	s:     "u/user/name",
-	url:   &crossmodel.ServiceURL{"local", "user", "name"},
-	exact: "local:/u/user/name",
+	s:     "u/user/servicename",
+	url:   &crossmodel.ServiceURL{"local", "user", "servicename"},
+	exact: "local:/u/user/servicename",
 }, {
 	s:   "local:service",
 	err: `service URL has invalid form, missing "/u/<user>": $URL`,

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/instance"
+	"github.com/juju/juju/model/crossmodel"
 	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
@@ -571,6 +572,24 @@ func (s *MultiEnvStateSuite) TestWatchTwoEnvironments(c *gc.C) {
 				wordpress, err := st.Service("wordpress")
 				c.Assert(err, jc.ErrorIsNil)
 				err = wordpress.SetMinUnits(2)
+				c.Assert(err, jc.ErrorIsNil)
+			},
+		}, {
+			about: "offered services",
+			getWatcher: func(st *state.State) interface{} {
+				return st.WatchOfferedServices()
+			},
+			setUpState: func(st *state.State) bool {
+				offeredServices := state.NewOfferedServices(st)
+				offeredServices.AddOffer(crossmodel.OfferedService{
+					ServiceName: "mysql",
+					ServiceURL:  "local:/u/me/mysql",
+				})
+				return false
+			},
+			triggerEvent: func(st *state.State) {
+				offeredServices := state.NewOfferedServices(st)
+				err := offeredServices.SetOfferRegistered("local:/u/me/mysql", false)
 				c.Assert(err, jc.ErrorIsNil)
 			},
 		},
@@ -3534,6 +3553,66 @@ func (s *StateSuite) TestWatchMinUnits(c *gc.C) {
 func (s *StateSuite) TestWatchMinUnitsDiesOnStateClose(c *gc.C) {
 	testWatcherDiesWhenStateCloses(c, s.envTag, func(c *gc.C, st *state.State) waiter {
 		w := st.WatchMinUnits()
+		<-w.Changes()
+		return w
+	})
+}
+
+func (s *StateSuite) TestWatchOfferedServices(c *gc.C) {
+	// Check initial event.
+	w := s.State.WatchOfferedServices()
+	defer statetesting.AssertStop(c, w)
+	wc := statetesting.NewStringsWatcherC(c, s.State, w)
+	wc.AssertChange()
+	wc.AssertNoChange()
+
+	// Add a new offered service; a single change should occur.
+	offers := state.NewOfferedServices(s.State)
+	offer := crossmodel.OfferedService{
+		ServiceName: "service",
+		ServiceURL:  "local:/u/me/service",
+		Registered:  true,
+	}
+	err := offers.AddOffer(offer)
+	wc.AssertChange("local:/u/me/service")
+	wc.AssertNoChange()
+
+	// Set the registered value; expect one change.
+	err = offers.SetOfferRegistered("local:/u/me/service", false)
+	c.Assert(err, jc.ErrorIsNil)
+	offer.Registered = false
+	wc.AssertChange("local:/u/me/service")
+	wc.AssertNoChange()
+
+	// Insert a new offer2 and set registered value; expect 2 changes.
+	offer2 := crossmodel.OfferedService{
+		ServiceName: "service2",
+		ServiceURL:  "local:/u/me/service2",
+		Registered:  true,
+	}
+	err = offers.AddOffer(offer2)
+	c.Assert(err, jc.ErrorIsNil)
+	err = offers.SetOfferRegistered("local:/u/me/service", true)
+	offer.Registered = true
+	c.Assert(err, jc.ErrorIsNil)
+	wc.AssertChange("local:/u/me/service2", "local:/u/me/service")
+
+	// Update endpoints and registered value; expect 2 changes.
+	err = offers.UpdateOffer("local:/u/me/service2", map[string]string{"foo": "bar"})
+	c.Assert(err, jc.ErrorIsNil)
+	err = offers.SetOfferRegistered("local:/u/me/service", false)
+	offer.Registered = true
+	c.Assert(err, jc.ErrorIsNil)
+	wc.AssertChange("local:/u/me/service2", "local:/u/me/service")
+
+	// Stop watcher, check closed.
+	statetesting.AssertStop(c, w)
+	wc.AssertClosed()
+}
+
+func (s *StateSuite) TestWatchOfferedServicesDiesOnStateClose(c *gc.C) {
+	testWatcherDiesWhenStateCloses(c, s.envTag, func(c *gc.C, st *state.State) waiter {
+		w := st.WatchOfferedServices()
 		<-w.Changes()
 		return w
 	})

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -2673,3 +2673,106 @@ func (w *blockDevicesWatcher) loop() error {
 		}
 	}
 }
+
+// OfferedServiceWatcher notifies about values in the collection
+// of offered services. The first event returned by the watcher
+// is a slice of all current offer urls.
+// Subsequent events are generated when a service offer has it's
+// registered value changed.
+type offeredServicesWatcher struct {
+	commonWatcher
+	known map[string]int64
+	out   chan []string
+}
+
+func newOfferedServicesWatcher(st *State) StringsWatcher {
+	w := &offeredServicesWatcher{
+		commonWatcher: commonWatcher{st: st},
+		known:         make(map[string]int64),
+		out:           make(chan []string),
+	}
+	go func() {
+		defer w.tomb.Done()
+		defer close(w.out)
+		w.tomb.Kill(w.loop())
+	}()
+	return w
+}
+
+// WatchOfferedServices returns a OfferedServicesWatcher.
+func (st *State) WatchOfferedServices() StringsWatcher {
+	return newOfferedServicesWatcher(st)
+}
+
+func (w *offeredServicesWatcher) initial() (set.Strings, error) {
+	offered := set.NewStrings()
+	var revnoDoc struct {
+		ServiceURL string `bson:"serviceurl"`
+		TxnRevno   int64  `bson:"txn-revno"`
+	}
+	offeredCollection, closer := w.st.getCollection(serviceOffersC)
+	defer closer()
+
+	iter := offeredCollection.Find(nil).Iter()
+	for iter.Next(&revnoDoc) {
+		w.known[revnoDoc.ServiceURL] = revnoDoc.TxnRevno
+		offered.Add(revnoDoc.ServiceURL)
+	}
+	return offered, iter.Close()
+}
+
+func (w *offeredServicesWatcher) merge(serviceurls set.Strings, change watcher.Change) error {
+	serviceURL := w.st.localID(change.Id.(string))
+	if change.Revno == -1 {
+		delete(w.known, serviceURL)
+		serviceurls.Remove(serviceURL)
+		return nil
+	}
+	var revnoDoc struct {
+		TxnRevno int64 `bson:"txn-revno"`
+	}
+	offeredCollection, closer := w.st.getCollection(serviceOffersC)
+	defer closer()
+	if err := offeredCollection.FindId(change.Id).One(&revnoDoc); err != nil {
+		return err
+	}
+	revno, known := w.known[serviceURL]
+	w.known[serviceURL] = revnoDoc.TxnRevno
+	if !known || revnoDoc.TxnRevno > revno {
+		serviceurls.Add(serviceURL)
+	}
+	return nil
+}
+
+func (w *offeredServicesWatcher) loop() (err error) {
+	ch := make(chan watcher.Change)
+	w.st.watcher.WatchCollectionWithFilter(serviceOffersC, ch, w.st.isForStateEnv)
+	defer w.st.watcher.UnwatchCollection(serviceOffersC, ch)
+	offers, err := w.initial()
+	if err != nil {
+		return err
+	}
+	out := w.out
+	for {
+		select {
+		case <-w.tomb.Dying():
+			return tomb.ErrDying
+		case <-w.st.watcher.Dead():
+			return stateWatcherDeadError(w.st.watcher.Err())
+		case change := <-ch:
+			if err = w.merge(offers, change); err != nil {
+				return err
+			}
+			if len(offers) > 0 {
+				out = w.out
+			}
+		case out <- offers.Values():
+			out = nil
+			offers = set.NewStrings()
+		}
+	}
+}
+
+func (w *offeredServicesWatcher) Changes() <-chan []string {
+	return w.out
+}


### PR DESCRIPTION
We add a state watcher for offered services. Then, a new OfferedServices facade is added to expose this watcher plus provide a method to retrieve offered services which the listener informs about.

(Review request: http://reviews.vapour.ws/r/3177/)