### PR TITLE
Use gates for upgrade related machine agent synchronisation

### DIFF
--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -328,7 +328,7 @@ type MachineAgent struct {
 	// Used to signal that the upgrade worker will not
 	// reboot the agent on startup because there are no
 	// longer any immediately pending agent upgrades.
-	initialUpgradeCheckComplete gate.WaiterUnlocker
+	initialUpgradeCheckComplete gate.Lock
 
 	mongoInitMutex   sync.Mutex
 	mongoInitialized bool
@@ -471,7 +471,7 @@ func (a *MachineAgent) Run(*cmd.Context) error {
 	return err
 }
 
-func (a *MachineAgent) makeEngineCreator(upgradeStepsLock, upgradeCheckLock gate.WaiterUnlocker) func() (worker.Worker, error) {
+func (a *MachineAgent) makeEngineCreator(upgradeStepsLock, upgradeCheckLock gate.Lock) func() (worker.Worker, error) {
 	return func() (worker.Worker, error) {
 		config := dependency.EngineConfig{
 			IsFatal:     cmdutil.IsFatal,

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -483,7 +483,7 @@ func (a *MachineAgent) createEngine() (worker.Worker, error) {
 	if err != nil {
 		return nil, err
 	}
-	manifolds, _, _ := machine.Manifolds(machine.ManifoldsConfig{
+	manifolds := machine.Manifolds(machine.ManifoldsConfig{
 		Agent: agent.APIHostPortsSetter{a},
 	})
 	if err := dependency.Install(engine, manifolds); err != nil {

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -483,7 +483,7 @@ func (a *MachineAgent) createEngine() (worker.Worker, error) {
 	if err != nil {
 		return nil, err
 	}
-	manifolds := machine.Manifolds(machine.ManifoldsConfig{
+	manifolds, _, _ := machine.Manifolds(machine.ManifoldsConfig{
 		Agent: agent.APIHostPortsSetter{a},
 	})
 	if err := dependency.Install(engine, manifolds); err != nil {

--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -22,12 +22,12 @@ type ManifoldsConfig struct {
 	// UpgradeStepsLock is passed to the upgrade steps gate to
 	// coordinate workers that shouldn't do anything until the
 	// upgrade-steps worker is done.
-	UpgradeStepsLock gate.WaiterUnlocker
+	UpgradeStepsLock gate.Lock
 
 	// UpgradeCheckLock is passed to the upgrade check gate to
 	// coordinate workers that shouldn't do anything until the
 	// upgrader worker completes it's first check.
-	UpgradeCheckLock gate.WaiterUnlocker
+	UpgradeCheckLock gate.Lock
 }
 
 // Manifolds returns a set of co-configured manifolds covering the

--- a/cmd/jujud/agent/machine/manifolds_test.go
+++ b/cmd/jujud/agent/machine/manifolds_test.go
@@ -22,7 +22,7 @@ type ManifoldsSuite struct {
 var _ = gc.Suite(&ManifoldsSuite{})
 
 func (s *ManifoldsSuite) TestStartFuncs(c *gc.C) {
-	manifolds, _, _ := machine.Manifolds(machine.ManifoldsConfig{
+	manifolds := machine.Manifolds(machine.ManifoldsConfig{
 		Agent: fakeAgent{},
 	})
 	for name, manifold := range manifolds {
@@ -32,7 +32,7 @@ func (s *ManifoldsSuite) TestStartFuncs(c *gc.C) {
 }
 
 func (s *ManifoldsSuite) TestManifoldNames(c *gc.C) {
-	manifolds, _, _ := machine.Manifolds(machine.ManifoldsConfig{})
+	manifolds := machine.Manifolds(machine.ManifoldsConfig{})
 	keys := make([]string, 0, len(manifolds))
 	for k := range manifolds {
 		keys = append(keys, k)
@@ -48,9 +48,14 @@ func (s *ManifoldsSuite) TestManifoldNames(c *gc.C) {
 }
 
 func (s *ManifoldsSuite) TestUpgradeGates(c *gc.C) {
-	manifolds, upgradeStepsGate, upgradeCheckGate := machine.Manifolds(machine.ManifoldsConfig{})
-	assertGate(c, manifolds["upgrade-steps-gate"], upgradeStepsGate)
-	assertGate(c, manifolds["upgrade-check-gate"], upgradeCheckGate)
+	upgradeStepsLock := gate.NewLock()
+	upgradeCheckLock := gate.NewLock()
+	manifolds := machine.Manifolds(machine.ManifoldsConfig{
+		UpgradeStepsLock: upgradeStepsLock,
+		UpgradeCheckLock: upgradeCheckLock,
+	})
+	assertGate(c, manifolds["upgrade-steps-gate"], upgradeStepsLock)
+	assertGate(c, manifolds["upgrade-check-gate"], upgradeCheckLock)
 }
 
 func assertGate(c *gc.C, manifold dependency.Manifold, unlocker gate.Unlocker) {

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -948,7 +948,7 @@ func (s *MachineSuite) TestNoUpgradeRequired(c *gc.C) {
 	done := make(chan error)
 	go func() { done <- a.Run(nil) }()
 	select {
-	case <-a.initialAgentUpgradeCheckComplete:
+	case <-a.initialUpgradeCheckComplete.Unlocked():
 	case <-time.After(coretesting.LongWait):
 		c.Fatalf("timeout waiting for upgrade check")
 	}

--- a/cmd/jujud/agent/unit.go
+++ b/cmd/jujud/agent/unit.go
@@ -47,7 +47,7 @@ type UnitAgent struct {
 	// reboot the agent on startup because there are no
 	// longer any immediately pending agent upgrades.
 	// Channel used as a selectable bool (closed means true).
-	initialAgentUpgradeCheckComplete chan struct{}
+	initialUpgradeCheckComplete chan struct{}
 }
 
 // NewUnitAgent creates a new UnitAgent value properly initialized.
@@ -55,8 +55,8 @@ func NewUnitAgent(ctx *cmd.Context, bufferedLogs logsender.LogRecordCh) *UnitAge
 	return &UnitAgent{
 		AgentConf: NewAgentConf(""),
 		ctx:       ctx,
-		initialAgentUpgradeCheckComplete: make(chan struct{}),
-		bufferedLogs:                     bufferedLogs,
+		initialUpgradeCheckComplete: make(chan struct{}),
+		bufferedLogs:                bufferedLogs,
 	}
 }
 

--- a/cmd/jujud/agent/upgrade.go
+++ b/cmd/jujud/agent/upgrade.go
@@ -60,7 +60,7 @@ func NewUpgradeWorkerContext() *upgradeWorkerContext {
 }
 
 type upgradeWorkerContext struct {
-	UpgradeComplete gate.WaiterUnlocker
+	UpgradeComplete gate.Lock
 	fromVersion     version.Number
 	toVersion       version.Number
 	agent           upgradingMachineAgent

--- a/cmd/jujud/agent/upgrade_test.go
+++ b/cmd/jujud/agent/upgrade_test.go
@@ -535,7 +535,7 @@ func (s *UpgradeSuite) TestLoginsDuringUpgrade(c *gc.C) {
 	// Wait for agent upgrade worker to determine that no
 	// agent upgrades are required.
 	select {
-	case <-a.initialAgentUpgradeCheckComplete:
+	case <-a.initialUpgradeCheckComplete.Unlocked():
 	case <-time.After(coretesting.LongWait):
 		c.Fatalf("timeout waiting for upgrade check")
 	}

--- a/cmd/jujud/agent/upgrade_test.go
+++ b/cmd/jujud/agent/upgrade_test.go
@@ -159,12 +159,8 @@ func (s *UpgradeSuite) TestContextInitializeWhenNoUpgradeRequired(c *gc.C) {
 	context := NewUpgradeWorkerContext()
 	context.InitializeUsingAgent(agent)
 
-	select {
-	case <-context.UpgradeComplete:
-		// Success
-	default:
-		c.Fatal("UpgradeComplete channel should be closed because no upgrade is required")
-	}
+	c.Assert(context.UpgradeComplete.IsUnlocked(), jc.IsTrue)
+
 	// The agent's version should have been updated.
 	c.Assert(config.Version, gc.Equals, version.Current)
 
@@ -179,12 +175,8 @@ func (s *UpgradeSuite) TestContextInitializeWhenUpgradeRequired(c *gc.C) {
 	context := NewUpgradeWorkerContext()
 	context.InitializeUsingAgent(agent)
 
-	select {
-	case <-context.UpgradeComplete:
-		c.Fatal("UpgradeComplete channel shouldn't be closed because upgrade is required")
-	default:
-		// Success
-	}
+	c.Assert(context.UpgradeComplete.IsUnlocked(), jc.IsFalse)
+
 	// The agent's version should NOT have been updated.
 	c.Assert(config.Version, gc.Equals, initialVersion)
 }
@@ -199,7 +191,7 @@ func (s *UpgradeSuite) TestIsUpgradeRunning(c *gc.C) {
 	context := NewUpgradeWorkerContext()
 	c.Assert(context.IsUpgradeRunning(), jc.IsTrue)
 
-	close(context.UpgradeComplete)
+	context.UpgradeComplete.Unlock()
 	c.Assert(context.IsUpgradeRunning(), jc.IsFalse)
 }
 
@@ -955,19 +947,11 @@ var upgradeTestDialOpts = api.DialOpts{
 }
 
 func assertUpgradeComplete(c *gc.C, context *upgradeWorkerContext) {
-	select {
-	case <-context.UpgradeComplete:
-	default:
-		c.Error("UpgradeComplete channel is open but shouldn't be")
-	}
+	c.Assert(context.UpgradeComplete.IsUnlocked(), jc.IsTrue)
 }
 
 func assertUpgradeNotComplete(c *gc.C, context *upgradeWorkerContext) {
-	select {
-	case <-context.UpgradeComplete:
-		c.Error("UpgradeComplete channel is closed but shouldn't be")
-	default:
-	}
+	c.Assert(context.UpgradeComplete.IsUnlocked(), jc.IsFalse)
 }
 
 // NewFakeConfigSetter returns a fakeConfigSetter which implements

--- a/worker/gate/interface.go
+++ b/worker/gate/interface.go
@@ -14,6 +14,7 @@ type Unlocker interface {
 // Waiter is used to wait for a shared gate to be unlocked.
 type Waiter interface {
 	Unlocked() <-chan struct{}
+	IsUnlocked() bool
 }
 
 // WaiterUnlocker combines the Waiter and Unlocker interfaces.
@@ -30,4 +31,9 @@ func (AlreadyUnlocked) Unlocked() <-chan struct{} {
 	ch := make(chan struct{})
 	close(ch)
 	return ch
+}
+
+// IsUnlocked is part of the Waiter interface.
+func (AlreadyUnlocked) IsUnlocked() bool {
+	return true
 }

--- a/worker/gate/interface.go
+++ b/worker/gate/interface.go
@@ -17,8 +17,8 @@ type Waiter interface {
 	IsUnlocked() bool
 }
 
-// WaiterUnlocker combines the Waiter and Unlocker interfaces.
-type WaiterUnlocker interface {
+// Lock combines the Waiter and Unlocker interfaces.
+type Lock interface {
 	Waiter
 	Unlocker
 }

--- a/worker/gate/manifold.go
+++ b/worker/gate/manifold.go
@@ -94,6 +94,16 @@ func (l *lock) Unlocked() <-chan struct{} {
 	return l.ch
 }
 
+// IsUnlocked implements Waiter.
+func (l *lock) IsUnlocked() bool {
+	select {
+	case <-l.ch:
+		return true
+	default:
+		return false
+	}
+}
+
 // gate implements a degenerate worker that holds a lock.
 type gate struct {
 	tomb tomb.Tomb

--- a/worker/gate/manifold.go
+++ b/worker/gate/manifold.go
@@ -23,13 +23,13 @@ func Manifold() dependency.Manifold {
 }
 
 // ManifoldEx does the same thing as Manifold but takes the
-// WaiterUnlocker which used to wait on or unlock the gate. This
+// Lock which used to wait on or unlock the gate. This
 // allows code running outside of a dependency engine managed worker
 // to monitor or unlock the gate.
 //
 // TODO(mjs) - this can likely go away once all machine agent workers
-// are running under the dependency engine.
-func ManifoldEx(lock WaiterUnlocker) dependency.Manifold {
+// are running inside the dependency engine.
+func ManifoldEx(lock Lock) dependency.Manifold {
 	return dependency.Manifold{
 		Start: func(_ dependency.GetResourceFunc) (worker.Worker, error) {
 			w := &gate{lock: lock}
@@ -57,10 +57,10 @@ func ManifoldEx(lock WaiterUnlocker) dependency.Manifold {
 	}
 }
 
-// NewLock returns a new WaiterUnlocker for the gate manifold,
-// suitable for passing to ManifoldEx. It can be safely unlocked and
-// monitored by code runner under or outside of the dependency engine.
-func NewLock() WaiterUnlocker {
+// NewLock returns a new Lock for the gate manifold, suitable for
+// passing to ManifoldEx. It can be safely unlocked and monitored by
+// code running inside or outside of the dependency engine.
+func NewLock() Lock {
 	return &lock{
 		// mu and ch are shared across all workers started by the returned manifold.
 		// In normal operation, there will only be one such worker at a time; but if
@@ -103,10 +103,10 @@ func (l *lock) IsUnlocked() bool {
 	}
 }
 
-// gate implements a degenerate worker that holds a WaiterUnlocker.
+// gate implements a degenerate worker that holds a Lock.
 type gate struct {
 	tomb tomb.Tomb
-	lock WaiterUnlocker
+	lock Lock
 }
 
 // Kill is part of the worker.Worker interface.

--- a/worker/gate/manifold_test.go
+++ b/worker/gate/manifold_test.go
@@ -89,21 +89,23 @@ func (s *ManifoldSuite) TestAlreadyUnlockedIsUnlocked(c *gc.C) {
 }
 
 func (s *ManifoldSuite) TestManifoldEx(c *gc.C) {
-	manifold, wu := gate.ManifoldEx()
-	var w1 gate.Waiter = wu
-	var u gate.Unlocker = wu
+	lock := gate.NewLock()
+
+	manifold := gate.ManifoldEx(lock)
+	var waiter1 gate.Waiter = lock
+	var unlocker1 gate.Unlocker = lock
 
 	worker, err := manifold.Start(nil)
 	c.Assert(err, jc.ErrorIsNil)
 	defer checkStop(c, worker)
-	w2 := waiter(c, manifold, worker)
+	waiter2 := waiter(c, manifold, worker)
 
-	assertLocked(c, w1)
-	assertLocked(c, w2)
+	assertLocked(c, waiter1)
+	assertLocked(c, waiter2)
 
-	u.Unlock()
-	assertUnlocked(c, w1)
-	assertUnlocked(c, w2)
+	unlocker1.Unlock()
+	assertUnlocked(c, waiter1)
+	assertUnlocked(c, waiter2)
 }
 
 func unlocker(c *gc.C, m dependency.Manifold, w worker.Worker) gate.Unlocker {

--- a/worker/gate/manifold_test.go
+++ b/worker/gate/manifold_test.go
@@ -123,6 +123,7 @@ func waiter(c *gc.C, m dependency.Manifold, w worker.Worker) gate.Waiter {
 }
 
 func assertLocked(c *gc.C, waiter gate.Waiter) {
+	c.Assert(waiter.IsUnlocked(), jc.IsFalse)
 	select {
 	case <-waiter.Unlocked():
 		c.Fatalf("expected gate to be locked")
@@ -131,6 +132,7 @@ func assertLocked(c *gc.C, waiter gate.Waiter) {
 }
 
 func assertUnlocked(c *gc.C, waiter gate.Waiter) {
+	c.Assert(waiter.IsUnlocked(), jc.IsTrue)
 	select {
 	case <-waiter.Unlocked():
 	default:

--- a/worker/upgrader/manifold.go
+++ b/worker/upgrader/manifold.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/juju/api/upgrader"
 	"github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/dependency"
+	"github.com/juju/juju/worker/gate"
 	"github.com/juju/juju/worker/util"
 )
 
@@ -38,7 +39,7 @@ var newWorker = func(a agent.Agent, apiCaller base.APICaller) (worker.Worker, er
 		// TODO(fwereade): these are unit-agent-specific, and very much
 		// unsuitable for use in a machine agent.
 		func() bool { return false },
-		make(chan struct{}),
+		gate.NewLock(),
 	)
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/worker/upgrader/upgrader.go
+++ b/worker/upgrader/upgrader.go
@@ -96,10 +96,10 @@ func (u *Upgrader) Stop() error {
 func allowedTargetVersion(
 	origAgentVersion version.Number,
 	curVersion version.Number,
-	upgradeRunning bool,
+	upgradeStepsRunning bool,
 	targetVersion version.Number,
 ) bool {
-	if upgradeRunning && targetVersion == origAgentVersion {
+	if upgradeStepsRunning && targetVersion == origAgentVersion {
 		return true
 	}
 	if targetVersion.Major < curVersion.Major {

--- a/worker/upgrader/upgrader.go
+++ b/worker/upgrader/upgrader.go
@@ -21,6 +21,7 @@ import (
 	coretools "github.com/juju/juju/tools"
 	"github.com/juju/juju/version"
 	"github.com/juju/juju/worker/catacomb"
+	"github.com/juju/juju/worker/gate"
 )
 
 // retryAfter returns a channel that receives a value
@@ -34,13 +35,13 @@ var logger = loggo.GetLogger("juju.worker.upgrader")
 // Upgrader represents a worker that watches the state for upgrade
 // requests.
 type Upgrader struct {
-	catacomb               catacomb.Catacomb
-	st                     *upgrader.State
-	dataDir                string
-	tag                    names.Tag
-	origAgentVersion       version.Number
-	areUpgradeStepsRunning func() bool
-	agentUpgradeComplete   chan struct{}
+	catacomb                    catacomb.Catacomb
+	st                          *upgrader.State
+	dataDir                     string
+	tag                         names.Tag
+	origAgentVersion            version.Number
+	areUpgradeStepsRunning      func() bool
+	initialUpgradeCheckComplete gate.Unlocker
 }
 
 // NewAgentUpgrader returns a new upgrader worker. It watches changes to the
@@ -54,15 +55,15 @@ func NewAgentUpgrader(
 	agentConfig agent.Config,
 	origAgentVersion version.Number,
 	areUpgradeStepsRunning func() bool,
-	agentUpgradeComplete chan struct{},
+	initialUpgradeCheckComplete gate.Unlocker,
 ) (*Upgrader, error) {
 	u := &Upgrader{
-		st:                     st,
-		dataDir:                agentConfig.DataDir(),
-		tag:                    agentConfig.Tag(),
-		origAgentVersion:       origAgentVersion,
-		areUpgradeStepsRunning: areUpgradeStepsRunning,
-		agentUpgradeComplete:   agentUpgradeComplete,
+		st:                          st,
+		dataDir:                     agentConfig.DataDir(),
+		tag:                         agentConfig.Tag(),
+		origAgentVersion:            origAgentVersion,
+		areUpgradeStepsRunning:      areUpgradeStepsRunning,
+		initialUpgradeCheckComplete: initialUpgradeCheckComplete,
 	}
 	err := catacomb.Invoke(catacomb.Plan{
 		Site: &u.catacomb,
@@ -109,17 +110,6 @@ func allowedTargetVersion(
 		return false
 	}
 	return true
-}
-
-// closeChannel can be called multiple times to
-// close the channel without panicing.
-func closeChannel(ch chan struct{}) {
-	select {
-	case <-ch:
-		return
-	default:
-		close(ch)
-	}
 }
 
 func (u *Upgrader) loop() error {
@@ -185,7 +175,7 @@ func (u *Upgrader) loop() error {
 		logger.Infof("desired tool version: %v", wantVersion)
 
 		if wantVersion == version.Current {
-			closeChannel(u.agentUpgradeComplete)
+			u.initialUpgradeCheckComplete.Unlock()
 			continue
 		} else if !allowedTargetVersion(u.origAgentVersion, version.Current,
 			u.areUpgradeStepsRunning(), wantVersion) {
@@ -196,7 +186,7 @@ func (u *Upgrader) loop() error {
 			// finished upgrading.
 			logger.Infof("desired tool version: %s is older than current %s, refusing to downgrade",
 				wantVersion, version.Current)
-			closeChannel(u.agentUpgradeComplete)
+			u.initialUpgradeCheckComplete.Unlock()
 			continue
 		}
 		logger.Infof("upgrade requested from %v to %v", version.Current, wantVersion)


### PR DESCRIPTION
This series of changes replaces the channels that were previously used to synchronise worker startup around the "upgrade steps done" and "first upgrade check done" events with gate "locks". These drive gate manifolds in the machine agent's dependency engine, allowing clean synchronisation of workers both inside and outside the dependency engine (a requirement during the conversion to the dependency engine).

There are also some changes around gate.ManifoldEx's semantics as it became obvious during actual use that the initial structure was not optimal. Also gate.WaiterUnlocker is now called the much more snappy gate.Lock.

(Review request: http://reviews.vapour.ws/r/3178/)
