### PR TITLE
worker/rsyslog: use net.JoinHostPort

### DIFF
--- a/worker/rsyslog/worker.go
+++ b/worker/rsyslog/worker.go
@@ -216,7 +216,7 @@ func (h *RsyslogConfigHandler) replaceRemoteLogger(caCert string) error {
 			// No port was found
 			host = j
 		}
-		target := fmt.Sprintf("%s:%d", host, h.syslogConfig.Port)
+		target := net.JoinHostPort(host, strconv.Itoa(h.syslogConfig.Port))
 		namespace := h.syslogConfig.Namespace
 		if namespace != "" {
 			namespace = "-" + namespace


### PR DESCRIPTION
fmt.Sprintf("%s:%d", ...) doesn't do the right thing for IPv6 addresses.

(Review request: http://reviews.vapour.ws/r/3183/)