### PR TITLE
Run the upgrader worker inside the dependency engine

### DIFF
--- a/cmd/jujud/agent/machine/manifolds_test.go
+++ b/cmd/jujud/agent/machine/manifolds_test.go
@@ -41,10 +41,12 @@ func (s *ManifoldsSuite) TestManifoldNames(c *gc.C) {
 		"agent",
 		"termination",
 		"api-caller",
+		"api-info-gate",
 		"upgrade-steps-gate",
 		"upgrade-check-gate",
+		"upgrader",
 	}
-	c.Assert(expectedKeys, jc.SameContents, keys)
+	c.Assert(keys, jc.SameContents, expectedKeys)
 }
 
 func (s *ManifoldsSuite) TestUpgradeGates(c *gc.C) {


### PR DESCRIPTION
Run the upgrader worker inside the dependency engine

This includes use of the gates defined in an earlier revision for coordinating around upgrade related events.

The previous agent version is captured early and passed through as manifold config, avoiding the possibility of an updated version being seen.

---

worker/upgrader: replace the areUpgradeStepsRunning func with a gate

This is cleaner and less awkward.



(Review request: http://reviews.vapour.ws/r/3185/)