### PR TITLE
Fix 1382556 mark2

### DIFF
--- a/apiserver/client/export_test.go
+++ b/apiserver/client/export_test.go
@@ -21,3 +21,5 @@ var (
 )
 
 type MachineAndContainers machineAndContainers
+
+var StartSerialWaitParallel = startSerialWaitParallel

--- a/apiserver/client/run.go
+++ b/apiserver/client/run.go
@@ -182,6 +182,12 @@ func ParallelExecute(dataDir string, args []*RemoteExec) params.RunResults {
 // command we run will require a separate fork. This can be a problem
 // for controllers with low resources or in environments with many
 // machines.
+//
+// Note that when the start operation completes, the memory of the
+// forked process will have already been replaced with that of the
+// exec'ed command. This is a relatively quick operation relative to
+// the wait operation. That is why start-serially-and-wait-in-parallel
+// is a viable approach.
 func startSerialWaitParallel(args []*RemoteExec, results *params.RunResults) {
 	var wg sync.WaitGroup
 	for i, arg := range args {

--- a/apiserver/client/run.go
+++ b/apiserver/client/run.go
@@ -175,9 +175,6 @@ func ParallelExecute(dataDir string, args []*RemoteExec) params.RunResults {
 	return results
 }
 
-type startSSH func(params ssh.ExecParams) (*ssh.RunningCmd, error)
-type waitSSH func(wg *sync.WaitGroup, cmd *ssh.RunningCmd, result *params.RunResult, cancel <-chan struct{})
-
 // startSerialWaitParallel start a command for each RemoteExec, one at
 // a time and then waits for all the results asynchronously.
 //
@@ -192,7 +189,12 @@ type waitSSH func(wg *sync.WaitGroup, cmd *ssh.RunningCmd, result *params.RunRes
 // exec'ed command. This is a relatively quick operation relative to
 // the wait operation. That is why start-serially-and-wait-in-parallel
 // is a viable approach.
-func startSerialWaitParallel(args []*RemoteExec, results *params.RunResults, start startSSH, wait waitSSH) {
+func startSerialWaitParallel(
+	args []*RemoteExec,
+	results *params.RunResults,
+	start func(params ssh.ExecParams) (*ssh.RunningCmd, error),
+	wait func(wg *sync.WaitGroup, cmd *ssh.RunningCmd, result *params.RunResult, cancel <-chan struct{}),
+) {
 	var wg sync.WaitGroup
 	for i, arg := range args {
 		logger.Debugf("exec on %s: %#v", arg.MachineId, *arg)

--- a/apiserver/client/run.go
+++ b/apiserver/client/run.go
@@ -81,9 +81,6 @@ func (c *Client) getDataDir() string {
 	return dataResource.String()
 }
 
-// pulled out of my butt
-const jujuRunParallelism = 5
-
 // Run the commands specified on the machines identified through the
 // list of machines, units and services.
 func (c *Client) Run(run params.RunParams) (results params.RunResults, err error) {
@@ -122,7 +119,7 @@ func (c *Client) Run(run params.RunParams) (results params.RunResults, err error
 		execParam := remoteParamsForMachine(machine, command, run.Timeout)
 		params = append(params, execParam)
 	}
-	return ParallelExecute(c.getDataDir(), params, jujuRunParallelism), nil
+	return ParallelExecute(c.getDataDir(), params), nil
 }
 
 // RunOnAllMachines attempts to run the specified command on all the machines.
@@ -140,7 +137,7 @@ func (c *Client) RunOnAllMachines(run params.RunParams) (params.RunResults, erro
 	for _, machine := range machines {
 		params = append(params, remoteParamsForMachine(machine, command, run.Timeout))
 	}
-	return ParallelExecute(c.getDataDir(), params, jujuRunParallelism), nil
+	return ParallelExecute(c.getDataDir(), params), nil
 }
 
 // RemoteExec extends the standard ssh.ExecParams by providing the machine and
@@ -154,74 +151,57 @@ type RemoteExec struct {
 
 // ParallelExecute executes all of the requests defined in the params,
 // using the system identity stored in the dataDir.
-func ParallelExecute(dataDir string, runParams []*RemoteExec, numWorkers int) params.RunResults {
-	logger.Debugf("exec %#v", runParams)
-
-	var wg sync.WaitGroup
-	queue := make(chan *RemoteExec)
-	results := make(chan params.RunResult)
-
-	// Let's not spawn extra goroutines, eh?
-	if numWorkers > len(runParams) {
-		numWorkers = len(runParams)
-	}
-
-	// Limit the parallelization. Since this uses fork, which starts
-	// off by using a copy of juju's memory, and thus can easily cause OOM
-	// issues.
-	for x := 0; x < numWorkers; x++ {
-		wg.Add(1)
-		go execWorker(&wg, queue, results)
-	}
-
-	output := make(chan []params.RunResult)
-	go resultCollator(len(runParams), results, output)
+func ParallelExecute(dataDir string, args []*RemoteExec) params.RunResults {
+	var results params.RunResults
+	results.Results = make([]params.RunResult, len(args), len(args))
 
 	identity := filepath.Join(dataDir, agent.SystemIdentity)
-	for _, param := range runParams {
-		param.IdentityFile = identity
-		logger.Debugf("exec on %s: %#v", param.MachineId, *param)
-		queue <- param
-	}
 
-	close(queue)
-	wg.Wait()
-	close(results)
-	result := <-output
+	var wg sync.WaitGroup
+	for i, arg := range args {
+		// TODO(ericsnow) Move the log entry to after setting the identity.
+		logger.Debugf("exec on %s: %#v", arg.MachineId, *arg)
+		arg.ExecParams.IdentityFile = identity
+		timeout := arg.Timeout
 
-	sort.Sort(MachineOrder(result))
-	return params.RunResults{result}
-}
-
-// execWorker is a worker that runs in a goroutine to execute commands from, the
-// queue and pass on the results.
-func execWorker(wg *sync.WaitGroup, queue <-chan *RemoteExec, results chan<- params.RunResult) {
-	for param := range queue {
-		// this function call has its own internal timeout, so we don't need one.
-		response, err := ssh.ExecuteCommandOnMachine(param.ExecParams)
-		logger.Debugf("reponse from %s: %v (err:%v)", param.MachineId, response, err)
-		execResponse := params.RunResult{
-			ExecResponse: response,
-			MachineId:    param.MachineId,
-			UnitId:       param.UnitId,
+		results.Results[i] = params.RunResult{
+			MachineId: arg.MachineId,
+			UnitId:    arg.UnitId,
 		}
+		result := &results.Results[i]
+
+		// Start the commands serially...
+		cmd, err := ssh.StartCommandOnMachine(arg.ExecParams)
 		if err != nil {
-			execResponse.Error = fmt.Sprint(err)
+			result.Error = fmt.Sprint(err)
+			continue
 		}
 
-		results <- execResponse
-	}
-	wg.Done()
-}
+		// ...but wait for them in parallel.
+		//
+		// We do this because ssh.StartCommandOnMachine() relies on
+		// os/exec.Cmd, which in turn relies on fork+exec. That means
+		// every copy of the command we run will require a separate
+		// fork. This can be a problem for controllers with low
+		// resources or in environments with many machines.
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
 
-// resultCollator collects the results into a slice and passes them on to output
-// when done.
-func resultCollator(count int, results <-chan params.RunResult, output chan<- []params.RunResult) {
-	result := make([]params.RunResult, 0, count)
-	for res := range results {
-		result = append(result, res)
+			response, err := cmd.WaitWithTimeout(timeout)
+			logger.Debugf("response from %s: %#v (err:%v)", result.MachineId, response, err)
+			result.ExecResponse = response
+			if err != nil {
+				result.Error = fmt.Sprint(err)
+			}
+		}()
 	}
-	output <- result
+	wg.Wait()
+
+	// TODO(ericsnow) Why do we sort these? Shouldn't we keep them
+	// in the same order that they were requested?
+	sort.Sort(MachineOrder(results.Results))
+	return results
 }
 
 // MachineOrder is used to provide the api to sort the results by the machine

--- a/apiserver/client/run.go
+++ b/apiserver/client/run.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/utils"
+	"github.com/juju/utils/clock"
 	"github.com/juju/utils/set"
 
 	"github.com/juju/juju/agent"
@@ -186,7 +187,8 @@ func ParallelExecute(dataDir string, args []*RemoteExec) params.RunResults {
 		wait := func(result *params.RunResult, timeout time.Duration) {
 			defer wg.Done()
 
-			response, err := cmd.WaitWithTimeout(timeout)
+			timeoutChan := clock.WallClock.After(timeout)
+			response, err := cmd.WaitWithTimeout(timeoutChan)
 			logger.Debugf("response from %s: %#v (err:%v)", result.MachineId, response, err)
 			result.ExecResponse = response
 			if err != nil {

--- a/apiserver/client/run.go
+++ b/apiserver/client/run.go
@@ -168,7 +168,8 @@ func ParallelExecute(dataDir string, args []*RemoteExec) params.RunResults {
 
 	startSerialWaitParallel(args, &results)
 
-	// TODO(ericsnow) Why do we sort these? Shouldn't we keep them
+	// TODO(ericsnow) lp:1517076
+	// Why do we sort these? Shouldn't we keep them
 	// in the same order that they were requested?
 	sort.Sort(MachineOrder(results.Results))
 	return results

--- a/apiserver/client/run_test.go
+++ b/apiserver/client/run_test.go
@@ -5,6 +5,7 @@ package client_test
 
 import (
 	"fmt"
+	"sync"
 	"time"
 
 	gitjujutesting "github.com/juju/testing"
@@ -348,4 +349,154 @@ func (s *runSuite) TestBlockRunMachineAndService(c *gc.C) {
 			Services: []string{"magic"},
 		})
 	s.AssertBlocked(c, err, "TestBlockRunMachineAndService")
+}
+
+func (s *runSuite) TestStartSerialWaitParallel(c *gc.C) {
+	st := starter{serialChecker{c: c, block: make(chan struct{})}}
+	w := waiter{concurrentChecker{c: c}}
+	count := 4
+	w.started.Add(count)
+	st.finished.Add(count)
+	args := make([]*client.RemoteExec, count)
+	for i := range args {
+		args[i] = &client.RemoteExec{
+			ExecParams: ssh.ExecParams{Timeout: testing.LongWait},
+		}
+	}
+
+	results := &params.RunResults{}
+	results.Results = make([]params.RunResult, count)
+
+	// run this in a goroutine so we can futz with things asynchronously.
+	go client.StartSerialWaitParallel(args, results, st.start, w.wait)
+
+	// ok, so we give the function some time to run... if we are running start
+	// in goroutines, this would give them time to do their thing.
+	<-time.After(testing.ShortWait)
+
+	// if start is being run synchronously, then only one of the start functions
+	// should have been called by now.
+	c.Assert(st.count, gc.Equals, 1)
+
+	// good, now let's unblock start and let'em fly
+	st.unblock()
+
+	// wait for the start functions to complete
+	select {
+	case <-st.waitFinish():
+		// good, all start functions called.
+	case <-time.After(testing.ShortWait):
+		c.Fatalf("timed out waiting for start functions to be called.")
+	}
+
+	// wait for the wait functions to run their startups
+	select {
+	case <-w.waitStarted():
+		// good, all start functions called.
+	case <-time.After(testing.ShortWait):
+		c.Fatalf("Timed out waiting for start functions to be called. Start functions probably not called as goroutines.")
+	}
+	w.unblock()
+}
+
+type starter struct {
+	serialChecker
+}
+
+func (s *starter) start(_ ssh.ExecParams) (*ssh.RunningCmd, error) {
+	s.called()
+	return nil, nil
+}
+
+type waiter struct {
+	concurrentChecker
+}
+
+func (w *waiter) wait(wg *sync.WaitGroup, _ *ssh.RunningCmd, _ *params.RunResult, _ <-chan struct{}) {
+	defer wg.Done()
+	w.called()
+}
+
+// serialChecker is a type that lets us check that a function is called
+// serially, not concurrently.
+type serialChecker struct {
+	c        *gc.C
+	mu       sync.Mutex
+	block    chan struct{}
+	count    int
+	finished sync.WaitGroup
+}
+
+// unblock unblocks the called method.
+func (s *serialChecker) unblock() {
+	close(s.block)
+}
+
+// called registers tha this function has been called.  It will block until
+// unblock is called, or will timeout after a LongWait.
+func (s *serialChecker) called() {
+	defer s.finished.Done()
+	// make sure we serialize access to the struct
+	s.mu.Lock()
+	// log that we've been called
+	s.count++
+	s.mu.Unlock()
+	select {
+	case <-s.block:
+	case <-time.After(testing.LongWait):
+		s.c.Fatalf("time out waiting for unblock")
+	}
+}
+
+// waitFinish waits on the finished waitgroup, and closes the returned channel
+// when it is.
+func (s *serialChecker) waitFinish() <-chan struct{} {
+	done := make(chan struct{})
+	go func() {
+		s.finished.Wait()
+		close(done)
+	}()
+	return done
+}
+
+// concurrentChecker is a type to allow us to check that the a function is being
+// called concurrently, not serially.
+type concurrentChecker struct {
+	c       *gc.C
+	block   chan struct{}
+	started sync.WaitGroup
+}
+
+// unblock unblocks the functions currently blocked by this type.
+func (c *concurrentChecker) unblock() {
+	close(c.block)
+}
+
+// waitStarted waits on the started waitgroup, and closes the returned channel
+// when it is.
+func (c *concurrentChecker) waitStarted() <-chan struct{} {
+	done := make(chan struct{})
+	go func() {
+		c.started.Wait()
+		close(done)
+	}()
+	return done
+}
+
+// wait is the function we pass to startSerialWaitParallel. It gives each
+// goroutine an index, so we can keep track of which ones were run when, and
+// blocks until released by the unblock function.
+func (c *concurrentChecker) called() {
+	// signal that we've started
+	c.started.Done()
+
+	// now we block on the block channel, waiting to be unblocked.  This way, if
+	// we don't get the started waitgroup finished, we know these functions
+	// weren't run concurrently.
+	select {
+	case <-c.block:
+		// good, all functions were run and we got unblocked.
+	case <-time.After(testing.LongWait):
+		c.c.Fatalf("timed out waiting to unblock")
+	}
 }

--- a/apiserver/client/run_test.go
+++ b/apiserver/client/run_test.go
@@ -353,7 +353,7 @@ func (s *runSuite) TestBlockRunMachineAndService(c *gc.C) {
 
 func (s *runSuite) TestStartSerialWaitParallel(c *gc.C) {
 	st := starter{serialChecker{c: c, block: make(chan struct{})}}
-	w := waiter{concurrentChecker{c: c}}
+	w := waiter{concurrentChecker{c: c, block: make(chan struct{})}}
 	count := 4
 	w.started.Add(count)
 	st.finished.Add(count)

--- a/apiserver/client/run_test.go
+++ b/apiserver/client/run_test.go
@@ -253,7 +253,10 @@ func (s *runSuite) TestRunOnAllMachines(c *gc.C) {
 			})
 	}
 
-	c.Assert(results, jc.DeepEquals, expectedResults)
+	c.Check(results, jc.DeepEquals, expectedResults)
+	c.Check(string(results[0].Stdout), gc.Equals, expectedCommand[0])
+	c.Check(string(results[1].Stdout), gc.Equals, expectedCommand[0])
+	c.Check(string(results[2].Stdout), gc.Equals, expectedCommand[0])
 }
 
 func (s *runSuite) TestBlockRunOnAllMachines(c *gc.C) {

--- a/utils/ssh/run.go
+++ b/utils/ssh/run.go
@@ -83,6 +83,13 @@ func (cmd *RunningCmd) Wait() (result utilexec.ExecResponse, _ error) {
 	return result, nil
 }
 
+// TODO(ericsnow) Add RunningCmd.WaitAbortable(abortChan <-chan error) ...
+// based on WaitWithTimeout and update WaitWithTimeout to use it. We
+// could make it WaitAbortable(abortChans ...<-chan error), which would
+// require using reflect.Select(). Then that could simply replace Wait().
+// It may make more sense, however, to have a helper function:
+//   Wait(cmd T, abortChans ...<-chan error) ...
+
 // TimedOut is an error indicating that a command timed out.
 var TimedOut = errors.New("command timed out")
 

--- a/utils/ssh/run.go
+++ b/utils/ssh/run.go
@@ -126,8 +126,11 @@ func getExitCode(err error) (int, error) {
 	}
 	err = errors.Cause(err)
 	if ee, ok := err.(*exec.ExitError); ok {
-		status := ee.ProcessState.Sys().(syscall.WaitStatus)
-		if status.Exited() {
+		raw := ee.ProcessState.Sys()
+		status, ok := raw.(syscall.WaitStatus)
+		if !ok {
+			logger.Errorf("unexpected type %T from ProcessState.Sys()", raw)
+		} else if status.Exited() {
 			// A non-zero return code isn't considered an error here.
 			return status.ExitStatus(), nil
 		}


### PR DESCRIPTION
This is a copy of http://reviews.vapour.ws/r/3173/ with an added test to ensure that start is being called serially and wait is being called concurrently.

In addition, make the cancel channel for StartCommandOnMachine into a more generic chan struct{}.

(Review request: http://reviews.vapour.ws/r/3186/)