### PR TITLE
Use the latest util & testing repos.

### DIFF
--- a/apiserver/images.go
+++ b/apiserver/images.go
@@ -85,7 +85,7 @@ func (h *imagesDownloadHandler) loadImage(st *state.State, envuuid, kind, series
 	// this only happens once.
 	imageIdent := fmt.Sprintf("image-%s-%s-%s-%s", envuuid, kind, series, arch)
 	lockDir := filepath.Join(h.dataDir, "locks")
-	lock, err := fslock.NewLock(lockDir, imageIdent)
+	lock, err := fslock.NewLock(lockDir, imageIdent, fslock.Defaults())
 	if err != nil {
 		return nil, nil, errors.Trace(err)
 	}

--- a/cmd/envcmd/files.go
+++ b/cmd/envcmd/files.go
@@ -142,7 +142,7 @@ func acquireEnvironmentLock(operation string) (*fslock.Lock, error) {
 	// NOTE: any reading or writing from the directory should be done with a
 	// fslock to make sure we have a consistent read or write.  Also worth
 	// noting, we should use a very short timeout.
-	lock, err := fslock.NewLock(osenv.JujuHome(), lockName)
+	lock, err := fslock.NewLock(osenv.JujuHome(), lockName, fslock.Defaults())
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/cmd/jujud/util/util.go
+++ b/cmd/jujud/util/util.go
@@ -233,7 +233,7 @@ func (c *CloseWorker) Wait() error {
 // they require isolation from hook execution.
 func HookExecutionLock(dataDir string) (*fslock.Lock, error) {
 	lockDir := filepath.Join(dataDir, "locks")
-	return fslock.NewLock(lockDir, "uniter-hook-execution")
+	return fslock.NewLock(lockDir, "uniter-hook-execution", fslock.Defaults())
 }
 
 // NewRsyslogConfigWorker creates and returns a new

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -31,9 +31,9 @@ github.com/juju/replicaset	git	fb7294cf57a1e2f08a57691f1246d129a87ab7e8	2015-05-
 github.com/juju/retry	git	62c62032529169c7ec02fa48f93349604c345e1f	2015-10-29T02:48:21Z
 github.com/juju/schema	git	afe1151cb49d1d7ed3c75592dfc6f38703f2e988	2015-08-07T07:58:08Z
 github.com/juju/syslog	git	6be94e8b718766e9ff7a37342157fe4795da7cfa	2015-02-05T15:59:36Z
-github.com/juju/testing	git	ad6f815f49f8209a27a3b7efb6d44876493e5939	2015-10-12T16:09:06Z
+github.com/juju/testing	git	ac910f00ee74b5e1ad51b6fd04893b07b1d330f2	2015-11-19T15:50:06Z
 github.com/juju/txn	git	99ec629d0066a4d73c54d8e021a7fc1dc07df614	2015-06-09T16:58:27Z
-github.com/juju/utils	git	c4785612a740e1577f489a519c047b00fd42fc37	2015-11-11T05:38:00Z
+github.com/juju/utils	git	abea1e37851fc9fd0f85b552e19399680e56a3d0	2015-11-13T13:27:55Z
 github.com/juju/xml	git	eb759a627588d35166bc505fceb51b88500e291e	2015-04-13T13:11:21Z
 github.com/julienschmidt/httprouter	git	109e267447e95ad1bb48b758e40dd7453eb7b039	2015-09-05T17:25:33Z
 github.com/lxc/lxd	git	42b4c228e84cba622f221e04a1fa7164a416a440	2015-10-27T22:33:42Z

--- a/environs/configstore/disk.go
+++ b/environs/configstore/disk.go
@@ -486,7 +486,7 @@ func (info *environInfo) writeJENVFile() error {
 }
 
 func acquireEnvironmentLock(dir, operation string) (*fslock.Lock, error) {
-	lock, err := fslock.NewLock(dir, lockName)
+	lock, err := fslock.NewLock(dir, lockName, fslock.Defaults())
 	if err != nil {
 		return nil, errors.Trace(err)
 	}


### PR DESCRIPTION
This requires adjusting usage of fslock.NewLock() since its signature has changed in a backward-incompatible way.

(Review request: http://reviews.vapour.ws/r/3189/)