### PR TITLE
Fix 1382556 mark2 fp

### DIFF
--- a/apiserver/client/export_test.go
+++ b/apiserver/client/export_test.go
@@ -24,7 +24,8 @@ var (
 
 type MachineAndContainers machineAndContainers
 
-// Status history exports
+var StartSerialWaitParallel = startSerialWaitParallel
+
 type StateInterface stateInterface
 
 type Patcher interface {

--- a/apiserver/client/run_test.go
+++ b/apiserver/client/run_test.go
@@ -5,6 +5,7 @@ package client_test
 
 import (
 	"fmt"
+	"sync"
 	"time"
 
 	gitjujutesting "github.com/juju/testing"
@@ -253,7 +254,10 @@ func (s *runSuite) TestRunOnAllMachines(c *gc.C) {
 			})
 	}
 
-	c.Assert(results, jc.DeepEquals, expectedResults)
+	c.Check(results, jc.DeepEquals, expectedResults)
+	c.Check(string(results[0].Stdout), gc.Equals, expectedCommand[0])
+	c.Check(string(results[1].Stdout), gc.Equals, expectedCommand[0])
+	c.Check(string(results[2].Stdout), gc.Equals, expectedCommand[0])
 }
 
 func (s *runSuite) TestBlockRunOnAllMachines(c *gc.C) {
@@ -345,4 +349,154 @@ func (s *runSuite) TestBlockRunMachineAndService(c *gc.C) {
 			Services: []string{"magic"},
 		})
 	s.AssertBlocked(c, err, "TestBlockRunMachineAndService")
+}
+
+func (s *runSuite) TestStartSerialWaitParallel(c *gc.C) {
+	st := starter{serialChecker{c: c, block: make(chan struct{})}}
+	w := waiter{concurrentChecker{c: c, block: make(chan struct{})}}
+	count := 4
+	w.started.Add(count)
+	st.finished.Add(count)
+	args := make([]*client.RemoteExec, count)
+	for i := range args {
+		args[i] = &client.RemoteExec{
+			ExecParams: ssh.ExecParams{Timeout: testing.LongWait},
+		}
+	}
+
+	results := &params.RunResults{}
+	results.Results = make([]params.RunResult, count)
+
+	// run this in a goroutine so we can futz with things asynchronously.
+	go client.StartSerialWaitParallel(args, results, st.start, w.wait)
+
+	// ok, so we give the function some time to run... if we are running start
+	// in goroutines, this would give them time to do their thing.
+	<-time.After(testing.ShortWait)
+
+	// if start is being run synchronously, then only one of the start functions
+	// should have been called by now.
+	c.Assert(st.count, gc.Equals, 1)
+
+	// good, now let's unblock start and let'em fly
+	st.unblock()
+
+	// wait for the start functions to complete
+	select {
+	case <-st.waitFinish():
+		// good, all start functions called.
+	case <-time.After(testing.ShortWait):
+		c.Fatalf("timed out waiting for start functions to be called.")
+	}
+
+	// wait for the wait functions to run their startups
+	select {
+	case <-w.waitStarted():
+		// good, all start functions called.
+	case <-time.After(testing.ShortWait):
+		c.Fatalf("Timed out waiting for start functions to be called. Start functions probably not called as goroutines.")
+	}
+	w.unblock()
+}
+
+type starter struct {
+	serialChecker
+}
+
+func (s *starter) start(_ ssh.ExecParams) (*ssh.RunningCmd, error) {
+	s.called()
+	return nil, nil
+}
+
+type waiter struct {
+	concurrentChecker
+}
+
+func (w *waiter) wait(wg *sync.WaitGroup, _ *ssh.RunningCmd, _ *params.RunResult, _ <-chan struct{}) {
+	defer wg.Done()
+	w.called()
+}
+
+// serialChecker is a type that lets us check that a function is called
+// serially, not concurrently.
+type serialChecker struct {
+	c        *gc.C
+	mu       sync.Mutex
+	block    chan struct{}
+	count    int
+	finished sync.WaitGroup
+}
+
+// unblock unblocks the called method.
+func (s *serialChecker) unblock() {
+	close(s.block)
+}
+
+// called registers tha this function has been called.  It will block until
+// unblock is called, or will timeout after a LongWait.
+func (s *serialChecker) called() {
+	defer s.finished.Done()
+	// make sure we serialize access to the struct
+	s.mu.Lock()
+	// log that we've been called
+	s.count++
+	s.mu.Unlock()
+	select {
+	case <-s.block:
+	case <-time.After(testing.LongWait):
+		s.c.Fatalf("time out waiting for unblock")
+	}
+}
+
+// waitFinish waits on the finished waitgroup, and closes the returned channel
+// when it is.
+func (s *serialChecker) waitFinish() <-chan struct{} {
+	done := make(chan struct{})
+	go func() {
+		s.finished.Wait()
+		close(done)
+	}()
+	return done
+}
+
+// concurrentChecker is a type to allow us to check that the a function is being
+// called concurrently, not serially.
+type concurrentChecker struct {
+	c       *gc.C
+	block   chan struct{}
+	started sync.WaitGroup
+}
+
+// unblock unblocks the functions currently blocked by this type.
+func (c *concurrentChecker) unblock() {
+	close(c.block)
+}
+
+// waitStarted waits on the started waitgroup, and closes the returned channel
+// when it is.
+func (c *concurrentChecker) waitStarted() <-chan struct{} {
+	done := make(chan struct{})
+	go func() {
+		c.started.Wait()
+		close(done)
+	}()
+	return done
+}
+
+// wait is the function we pass to startSerialWaitParallel. It gives each
+// goroutine an index, so we can keep track of which ones were run when, and
+// blocks until released by the unblock function.
+func (c *concurrentChecker) called() {
+	// signal that we've started
+	c.started.Done()
+
+	// now we block on the block channel, waiting to be unblocked.  This way, if
+	// we don't get the started waitgroup finished, we know these functions
+	// weren't run concurrently.
+	select {
+	case <-c.block:
+		// good, all functions were run and we got unblocked.
+	case <-time.After(testing.LongWait):
+		c.c.Fatalf("timed out waiting to unblock")
+	}
 }

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -33,7 +33,7 @@ github.com/juju/schema	git	afe1151cb49d1d7ed3c75592dfc6f38703f2e988	2015-08-07T0
 github.com/juju/syslog	git	6be94e8b718766e9ff7a37342157fe4795da7cfa	2015-02-05T15:59:36Z
 github.com/juju/testing	git	ad6f815f49f8209a27a3b7efb6d44876493e5939	2015-10-12T16:09:06Z
 github.com/juju/txn	git	99ec629d0066a4d73c54d8e021a7fc1dc07df614	2015-06-09T16:58:27Z
-github.com/juju/utils	git	c4785612a740e1577f489a519c047b00fd42fc37	2015-11-11T02:37:50Z
+github.com/juju/utils	git	cb3afdf142ea6b4279df2d552109195ff4c7af49	2015-11-19T20:11:44Z
 github.com/juju/xml	git	eb759a627588d35166bc505fceb51b88500e291e	2015-04-13T13:11:21Z
 github.com/julienschmidt/httprouter	git	109e267447e95ad1bb48b758e40dd7453eb7b039	2015-09-05T17:25:33Z
 github.com/lxc/lxd	git	42b4c228e84cba622f221e04a1fa7164a416a440	2015-10-27T22:33:42Z

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -33,7 +33,7 @@ github.com/juju/schema	git	afe1151cb49d1d7ed3c75592dfc6f38703f2e988	2015-08-07T0
 github.com/juju/syslog	git	6be94e8b718766e9ff7a37342157fe4795da7cfa	2015-02-05T15:59:36Z
 github.com/juju/testing	git	ad6f815f49f8209a27a3b7efb6d44876493e5939	2015-10-12T16:09:06Z
 github.com/juju/txn	git	99ec629d0066a4d73c54d8e021a7fc1dc07df614	2015-06-09T16:58:27Z
-github.com/juju/utils	git	cb3afdf142ea6b4279df2d552109195ff4c7af49	2015-11-19T20:11:44Z
+github.com/juju/utils	git	2c8f72a83e6830efc95c870fd7017a822d561c55	2015-11-19T20:50:34Z
 github.com/juju/xml	git	eb759a627588d35166bc505fceb51b88500e291e	2015-04-13T13:11:21Z
 github.com/julienschmidt/httprouter	git	109e267447e95ad1bb48b758e40dd7453eb7b039	2015-09-05T17:25:33Z
 github.com/lxc/lxd	git	42b4c228e84cba622f221e04a1fa7164a416a440	2015-10-27T22:33:42Z


### PR DESCRIPTION
Fix for http://pad.lv/1382556

We make the fork/exec of the ssh processes serially, but wait for the responses in parallel, so we'll never more than double our RAM burden on the system at any one time.

This code relies on https://github.com/juju/utils/pull/176 which copies over the ssh changes (but the ssh code got moved to the other repo).

(Review request: http://reviews.vapour.ws/r/3191/)