### PR TITLE
network: remove racy InitaliseFromConfig

### DIFF
--- a/apiserver/client/client_test.go
+++ b/apiserver/client/client_test.go
@@ -2598,7 +2598,7 @@ func (s *clientSuite) TestClientPublicAddressErrors(c *gc.C) {
 
 func (s *clientSuite) TestClientPublicAddressMachine(c *gc.C) {
 	s.setUpScenario(c)
-	network.ResetGlobalPreferIPv6()
+	network.SetPreferIPv6(false)
 
 	// Internally, network.SelectPublicAddress is used; the "most public"
 	// address is returned.
@@ -2641,7 +2641,7 @@ func (s *clientSuite) TestClientPrivateAddressErrors(c *gc.C) {
 
 func (s *clientSuite) TestClientPrivateAddress(c *gc.C) {
 	s.setUpScenario(c)
-	network.ResetGlobalPreferIPv6()
+	network.SetPreferIPv6(false)
 
 	// Internally, network.SelectInternalAddress is used; the public
 	// address if no cloud-local one is available.

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -450,7 +450,7 @@ func (a *MachineAgent) Run(*cmd.Context) error {
 	a.configChangedVal.Set(struct{}{})
 	a.previousAgentVersion = agentConfig.UpgradedToVersion()
 
-	network.InitializeFromConfig(agentConfig)
+	network.SetPreferIPv6(agentConfig.PreferIPv6())
 	charmrepo.CacheDir = filepath.Join(agentConfig.DataDir(), "charmcache")
 	if err := a.createJujudSymlinks(agentConfig.DataDir()); err != nil {
 		return err

--- a/cmd/jujud/agent/unit.go
+++ b/cmd/jujud/agent/unit.go
@@ -123,7 +123,7 @@ func (a *UnitAgent) Run(ctx *cmd.Context) error {
 	if flags := featureflag.String(); flags != "" {
 		logger.Warningf("developer feature flags enabled: %s", flags)
 	}
-	network.InitializeFromConfig(agentConfig)
+	network.SetPreferIPv6(agentConfig.PreferIPv6())
 
 	// Sometimes there are upgrade steps that are needed for each unit.
 	// There are plans afoot to unify the unit and machine agents. When

--- a/cmd/jujud/bootstrap.go
+++ b/cmd/jujud/bootstrap.go
@@ -119,7 +119,7 @@ func (c *BootstrapCommand) Run(_ *cmd.Context) error {
 		return err
 	}
 	agentConfig := c.CurrentConfig()
-	network.InitializeFromConfig(agentConfig)
+	network.SetPreferIPv6(agentConfig.PreferIPv6())
 
 	// agent.Jobs is an optional field in the agent config, and was
 	// introduced after 1.17.2. We default to allowing units on

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -62,7 +62,7 @@ type BootstrapParams struct {
 // environment.
 func Bootstrap(ctx environs.BootstrapContext, environ environs.Environ, args BootstrapParams) error {
 	cfg := environ.Config()
-	network.InitializeFromConfig(cfg)
+	network.SetPreferIPv6(cfg.PreferIPv6())
 	if secret := cfg.AdminSecret(); secret == "" {
 		return errors.Errorf("environment configuration has no admin-secret")
 	}

--- a/network/address.go
+++ b/network/address.go
@@ -22,20 +22,6 @@ var (
 	ipv6UniqueLocal = mustParseCIDR("fc00::/7")
 )
 
-// globalPreferIPv6 determines whether IPv6 addresses will be
-// preferred when selecting a public or internal addresses, using the
-// Select*() methods below. InitializeFromConfig() needs to be called
-// to set this flag globally at the earliest time possible (e.g. at
-// bootstrap, agent startup, before any CLI command).
-var globalPreferIPv6 bool = false
-
-// ResetGlobalPreferIPv6 resets the global variable back to the default,
-// and is called only from the isolation test suite to make sure we have
-// a clean environment.
-func ResetGlobalPreferIPv6() {
-	globalPreferIPv6 = false
-}
-
 func mustParseCIDR(s string) *net.IPNet {
 	_, net, err := net.ParseCIDR(s)
 	if err != nil {
@@ -207,7 +193,7 @@ func deriveScope(addr Address) Scope {
 // scopes. An address will not match if globalPreferIPv6 is set and it isn't an
 // IPv6 address.
 func ExactScopeMatch(addr Address, addrScopes ...Scope) bool {
-	if globalPreferIPv6 && addr.Type != IPv6Address {
+	if PreferIPv6() && addr.Type != IPv6Address {
 		return false
 	}
 	for _, scope := range addrScopes {
@@ -223,7 +209,7 @@ func ExactScopeMatch(addr Address, addrScopes ...Scope) bool {
 // are no suitable addresses, then ok is false (and an empty address is
 // returned). If a suitable address is then ok is true.
 func SelectPublicAddress(addresses []Address) (Address, bool) {
-	index := bestAddressIndex(len(addresses), globalPreferIPv6, func(i int) Address {
+	index := bestAddressIndex(len(addresses), PreferIPv6(), func(i int) Address {
 		return addresses[i]
 	}, publicMatch)
 	if index < 0 {
@@ -236,7 +222,7 @@ func SelectPublicAddress(addresses []Address) (Address, bool) {
 // appropriate to display as a publicly accessible endpoint. If there
 // are no suitable candidates, the empty string is returned.
 func SelectPublicHostPort(hps []HostPort) string {
-	index := bestAddressIndex(len(hps), globalPreferIPv6, func(i int) Address {
+	index := bestAddressIndex(len(hps), PreferIPv6(), func(i int) Address {
 		return hps[i].Address
 	}, publicMatch)
 	if index < 0 {
@@ -250,7 +236,7 @@ func SelectPublicHostPort(hps []HostPort) string {
 // are no suitable addresses, then ok is false (and an empty address is
 // returned). If a suitable address was found then ok is true.
 func SelectInternalAddress(addresses []Address, machineLocal bool) (Address, bool) {
-	index := bestAddressIndex(len(addresses), globalPreferIPv6, func(i int) Address {
+	index := bestAddressIndex(len(addresses), PreferIPv6(), func(i int) Address {
 		return addresses[i]
 	}, internalAddressMatcher(machineLocal))
 	if index < 0 {
@@ -264,7 +250,7 @@ func SelectInternalAddress(addresses []Address, machineLocal bool) (Address, boo
 // in its NetAddr form. If there are no suitable addresses, the empty
 // string is returned.
 func SelectInternalHostPort(hps []HostPort, machineLocal bool) string {
-	index := bestAddressIndex(len(hps), globalPreferIPv6, func(i int) Address {
+	index := bestAddressIndex(len(hps), PreferIPv6(), func(i int) Address {
 		return hps[i].Address
 	}, internalAddressMatcher(machineLocal))
 	if index < 0 {
@@ -278,7 +264,7 @@ func SelectInternalHostPort(hps []HostPort, machineLocal bool) string {
 // communication and returns them in NetAddr form. If there are no
 // suitable addresses, an empty slice is returned.
 func SelectInternalHostPorts(hps []HostPort, machineLocal bool) []string {
-	indexes := bestAddressIndexes(len(hps), globalPreferIPv6, func(i int) Address {
+	indexes := bestAddressIndexes(len(hps), PreferIPv6(), func(i int) Address {
 		return hps[i].Address
 	}, internalAddressMatcher(machineLocal))
 

--- a/network/address_test.go
+++ b/network/address_test.go
@@ -342,7 +342,7 @@ var selectPublicTests = []selectTest{{
 }}
 
 func (s *AddressSuite) TestSelectPublicAddress(c *gc.C) {
-	oldValue := network.GetPreferIPv6()
+	oldValue := network.PreferIPv6()
 	defer func() {
 		network.SetPreferIPv6(oldValue)
 	}()
@@ -441,7 +441,7 @@ var selectInternalTests = []selectTest{{
 }}
 
 func (s *AddressSuite) TestSelectInternalAddress(c *gc.C) {
-	oldValue := network.GetPreferIPv6()
+	oldValue := network.PreferIPv6()
 	defer func() {
 		network.SetPreferIPv6(oldValue)
 	}()
@@ -593,7 +593,7 @@ var selectInternalMachineTests = []selectTest{{
 }}
 
 func (s *AddressSuite) TestSelectInternalMachineAddress(c *gc.C) {
-	oldValue := network.GetPreferIPv6()
+	oldValue := network.PreferIPv6()
 	defer func() {
 		network.SetPreferIPv6(oldValue)
 	}()
@@ -674,7 +674,7 @@ var selectInternalHostPortsTests = []selectInternalHostPortsTest{{
 }}
 
 func (s *AddressSuite) TestSelectInternalHostPorts(c *gc.C) {
-	oldValue := network.GetPreferIPv6()
+	oldValue := network.PreferIPv6()
 	defer func() {
 		network.SetPreferIPv6(oldValue)
 	}()

--- a/network/export_test.go
+++ b/network/export_test.go
@@ -4,11 +4,3 @@
 package network
 
 var NetLookupIP = &netLookupIP
-
-func SetPreferIPv6(value bool) {
-	globalPreferIPv6 = value
-}
-
-func GetPreferIPv6() bool {
-	return globalPreferIPv6
-}

--- a/network/hostport_test.go
+++ b/network/hostport_test.go
@@ -54,7 +54,7 @@ func (t hostPortTest) expected() string {
 }
 
 func (*HostPortSuite) TestSelectPublicHostPort(c *gc.C) {
-	oldValue := network.GetPreferIPv6()
+	oldValue := network.PreferIPv6()
 	defer func() {
 		network.SetPreferIPv6(oldValue)
 	}()
@@ -67,7 +67,7 @@ func (*HostPortSuite) TestSelectPublicHostPort(c *gc.C) {
 }
 
 func (*HostPortSuite) TestSelectInternalHostPort(c *gc.C) {
-	oldValue := network.GetPreferIPv6()
+	oldValue := network.PreferIPv6()
 	defer func() {
 		network.SetPreferIPv6(oldValue)
 	}()
@@ -80,7 +80,7 @@ func (*HostPortSuite) TestSelectInternalHostPort(c *gc.C) {
 }
 
 func (*HostPortSuite) TestSelectInternalMachineHostPort(c *gc.C) {
-	oldValue := network.GetPreferIPv6()
+	oldValue := network.PreferIPv6()
 	defer func() {
 		network.SetPreferIPv6(oldValue)
 	}()

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -92,19 +92,19 @@ type NetworkSuite struct {
 var _ = gc.Suite(&NetworkSuite{})
 
 func (*NetworkSuite) TestInitializeFromConfig(c *gc.C) {
-	c.Check(network.GetPreferIPv6(), jc.IsFalse)
+	c.Check(network.PreferIPv6(), jc.IsFalse)
 
 	envConfig := testing.CustomEnvironConfig(c, testing.Attrs{
 		"prefer-ipv6": true,
 	})
-	network.InitializeFromConfig(envConfig)
-	c.Check(network.GetPreferIPv6(), jc.IsTrue)
+	network.SetPreferIPv6(envConfig.PreferIPv6())
+	c.Check(network.PreferIPv6(), jc.IsTrue)
 
 	envConfig = testing.CustomEnvironConfig(c, testing.Attrs{
 		"prefer-ipv6": false,
 	})
-	network.InitializeFromConfig(envConfig)
-	c.Check(network.GetPreferIPv6(), jc.IsFalse)
+	network.SetPreferIPv6(envConfig.PreferIPv6())
+	c.Check(network.PreferIPv6(), jc.IsFalse)
 }
 
 func (s *NetworkSuite) TestFilterLXCAddresses(c *gc.C) {

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -709,7 +709,7 @@ func (e *environ) Bootstrap(ctx environs.BootstrapContext, args environs.Bootstr
 	if err := e.checkBroken("Bootstrap"); err != nil {
 		return nil, err
 	}
-	network.InitializeFromConfig(e.Config())
+	network.SetPreferIPv6(e.Config().PreferIPv6())
 	password := e.Config().AdminSecret()
 	if password == "" {
 		return nil, fmt.Errorf("admin-secret is required for bootstrap")

--- a/rpc/jsoncodec/codec_test.go
+++ b/rpc/jsoncodec/codec_test.go
@@ -9,16 +9,16 @@ import (
 	stdtesting "testing"
 
 	"github.com/juju/loggo"
+	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/rpc"
 	"github.com/juju/juju/rpc/jsoncodec"
-	"github.com/juju/juju/testing"
 )
 
 type suite struct {
-	testing.BaseSuite
+	testing.LoggingSuite
 }
 
 var _ = gc.Suite(&suite{})

--- a/testing/base.go
+++ b/testing/base.go
@@ -151,7 +151,7 @@ func (s *BaseSuite) SetUpTest(c *gc.C) {
 	// We can't always just use IsolationSuite because we still need
 	// PATH and possibly a couple other envars.
 	s.PatchEnvironment("BASH_ENV", "")
-	network.ResetGlobalPreferIPv6()
+	network.SetPreferIPv6(false)
 }
 
 func (s *BaseSuite) TearDownTest(c *gc.C) {

--- a/worker/provisioner/logging_test.go
+++ b/worker/provisioner/logging_test.go
@@ -6,15 +6,22 @@ package provisioner
 import (
 	"errors"
 
+	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/feature"
-	"github.com/juju/juju/testing"
+	jujutesting "github.com/juju/juju/testing"
 )
 
 type logSuite struct {
-	testing.BaseSuite
+	testing.LoggingSuite
+	jujutesting.JujuOSEnvSuite
+}
+
+func (l *logSuite) SetUpTest(c *gc.C) {
+	l.LoggingSuite.SetUpTest(c)
+	l.JujuOSEnvSuite.SetUpTest(c)
 }
 
 var _ = gc.Suite(&logSuite{})


### PR DESCRIPTION
Fixes LP 1517744

The package singleton network.globalPreferIPV6 is very racy.

Replace this with a simple atomic variable and a getter and setter.
Also remove the unnecessary PreferIPV6Getter interfaces.

(Review request: http://reviews.vapour.ws/r/3194/)