### PR TITLE
lp1517611 - Explicitly initialize all fields

### DIFF
--- a/state/filesystem_test.go
+++ b/state/filesystem_test.go
@@ -256,6 +256,8 @@ func (s *FilesystemStateSuite) TestFilesystemInfo(c *gc.C) {
 	s.assertFilesystemInfo(c, filesystemTag, filesystemInfo)
 	s.assertFilesystemAttachmentUnprovisioned(c, machineTag, filesystemTag)
 
+	// Explicitly set both MountPoint and ReadOnly to work around
+	// bug #1517611
 	filesystemAttachmentInfo := state.FilesystemAttachmentInfo{MountPoint: "/srv", ReadOnly: false}
 	err = s.State.SetFilesystemAttachmentInfo(machineTag, filesystemTag, filesystemAttachmentInfo)
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/filesystem_test.go
+++ b/state/filesystem_test.go
@@ -256,7 +256,7 @@ func (s *FilesystemStateSuite) TestFilesystemInfo(c *gc.C) {
 	s.assertFilesystemInfo(c, filesystemTag, filesystemInfo)
 	s.assertFilesystemAttachmentUnprovisioned(c, machineTag, filesystemTag)
 
-	filesystemAttachmentInfo := state.FilesystemAttachmentInfo{MountPoint: "/srv"}
+	filesystemAttachmentInfo := state.FilesystemAttachmentInfo{MountPoint: "/srv", ReadOnly: false}
 	err = s.State.SetFilesystemAttachmentInfo(machineTag, filesystemTag, filesystemAttachmentInfo)
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertFilesystemAttachmentInfo(c, machineTag, filesystemTag, filesystemAttachmentInfo)


### PR DESCRIPTION
There is a possible compiler issue with gccgo4.9
where the TestFilesystemInfo test fails on ppc
for very weird reasons.  A workaround seems
to be to specify all fields in the struct we're
initializing.

(Review request: http://reviews.vapour.ws/r/3198/)