### PR TITLE
lp1518128: Use net.JoinHostPort to join addr:host

### DIFF
--- a/provider/local/config.go
+++ b/provider/local/config.go
@@ -5,8 +5,10 @@ package local
 
 import (
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
+	"strconv"
 
 	"github.com/juju/schema"
 	"gopkg.in/juju/environschema.v1"
@@ -168,7 +170,7 @@ func (c *environConfig) storagePort() int {
 }
 
 func (c *environConfig) storageAddr() string {
-	return fmt.Sprintf("%s:%d", c.bootstrapIPAddress(), c.storagePort())
+	return net.JoinHostPort(c.bootstrapIPAddress(), strconv.Itoa(c.storagePort()))
 }
 
 func (c *environConfig) configFile(filename string) string {

--- a/provider/manual/config.go
+++ b/provider/manual/config.go
@@ -5,6 +5,8 @@ package manual
 
 import (
 	"fmt"
+	"net"
+	"strconv"
 
 	"github.com/juju/schema"
 
@@ -77,11 +79,11 @@ func (c *environConfig) storageAuthKey() string {
 // storageAddr returns an address for connecting to the
 // bootstrap machine's localstorage.
 func (c *environConfig) storageAddr() string {
-	return fmt.Sprintf("%s:%d", c.bootstrapHost(), c.storagePort())
+	return net.JoinHostPort(c.bootstrapHost(), strconv.Itoa(c.storagePort()))
 }
 
 // storageListenAddr returns an address for the bootstrap
 // machine to listen on for its localstorage.
 func (c *environConfig) storageListenAddr() string {
-	return fmt.Sprintf("%s:%d", c.storageListenIPAddress(), c.storagePort())
+	return net.JoinHostPort(c.storageListenIPAddress(), strconv.Itoa(c.storagePort()))
 }

--- a/state/address.go
+++ b/state/address.go
@@ -4,8 +4,9 @@
 package state
 
 import (
-	"fmt"
+	"net"
 	"reflect"
+	"strconv"
 
 	"github.com/juju/errors"
 	"gopkg.in/mgo.v2/bson"
@@ -64,7 +65,7 @@ func (st *State) stateServerAddresses() ([]string, error) {
 func appendPort(addrs []string, port int) []string {
 	newAddrs := make([]string, len(addrs))
 	for i, addr := range addrs {
-		newAddrs[i] = fmt.Sprintf("%s:%d", addr, port)
+		newAddrs[i] = net.JoinHostPort(addr, strconv.Itoa(port))
 	}
 	return newAddrs
 }

--- a/state/backups/backups_linux.go
+++ b/state/backups/backups_linux.go
@@ -6,7 +6,7 @@
 package backups
 
 import (
-	"fmt"
+	"net"
 	"strconv"
 
 	"github.com/juju/errors"
@@ -154,7 +154,7 @@ func (b *backups) Restore(backupId string, args RestoreArgs) (names.Tag, error) 
 	}
 
 	logger.Infof("restarting replicaset")
-	memberHostPort := fmt.Sprintf("%s:%d", args.PrivateAddress, ssi.StatePort)
+	memberHostPort := net.JoinHostPort(args.PrivateAddress, strconv.Itoa(ssi.StatePort))
 	err = resetReplicaSet(dialInfo, memberHostPort)
 	if err != nil {
 		return nil, errors.Annotate(err, "cannot reset replicaSet")

--- a/state/backups/restore.go
+++ b/state/backups/restore.go
@@ -7,8 +7,9 @@ package backups
 
 import (
 	"bytes"
-	"fmt"
+	"net"
 	"os"
+	"strconv"
 	"sync"
 	"text/template"
 	"time"
@@ -61,7 +62,7 @@ func newDialInfo(privateAddr string, conf agent.Config) (*mgo.DialInfo, error) {
 		return nil, errors.Errorf("cannot get state serving info to dial")
 	}
 	info := mongo.Info{
-		Addrs:  []string{fmt.Sprintf("%s:%d", privateAddr, ssi.StatePort)},
+		Addrs:  []string{net.JoinHostPort(privateAddr, strconv.Itoa(ssi.StatePort))},
 		CACert: conf.CACert(),
 	}
 	dialInfo, err := mongo.DialInfo(info, dialOpts)

--- a/state/backups/restore_test.go
+++ b/state/backups/restore_test.go
@@ -237,7 +237,7 @@ func (r *RestoreSuite) TestNewDialInfo(c *gc.C) {
 			c.Assert(dialInfo.Username, gc.Equals, testCase.expectedUser)
 			c.Assert(dialInfo.Password, gc.Equals, testCase.expectedPassword)
 			c.Assert(dialInfo.Direct, gc.Equals, true)
-			c.Assert(dialInfo.Addrs, gc.DeepEquals, []string{fmt.Sprintf("%s:%d", privateAddress, statePort)})
+			c.Assert(dialInfo.Addrs, gc.DeepEquals, []string{net.JoinHostPort(privateAddress, strconv.Itoa(statePort))})
 		}
 	}
 }

--- a/utils/ssh/ssh_gocrypto.go
+++ b/utils/ssh/ssh_gocrypto.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"os/user"
+	"strconv"
 	"strings"
 
 	"github.com/juju/utils"
@@ -58,7 +59,7 @@ func (c *GoCryptoClient) Command(host string, command []string, options *Options
 	return &Cmd{impl: &goCryptoCommand{
 		signers:      signers,
 		user:         user,
-		addr:         fmt.Sprintf("%s:%d", host, port),
+		addr:         net.JoinHostPort(host, strconv.Itoa(port)),
 		command:      shellCommand,
 		proxyCommand: proxyCommand,
 	}}


### PR DESCRIPTION
To properly handle IPv6, net.JoinHostPort should be
used, rather than fmt.Sprintf("%s:%d"...)

(Review request: http://reviews.vapour.ws/r/3200/)