### PR TITLE
Skip failing packages that time out under go 1.2 with the race detector

### DIFF
--- a/apiserver/client/api_test.go
+++ b/apiserver/client/api_test.go
@@ -5,7 +5,6 @@ package client_test
 
 import (
 	"fmt"
-	stdtesting "testing"
 	"time"
 
 	"github.com/juju/errors"
@@ -29,10 +28,6 @@ import (
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/testing/factory"
 )
-
-func TestAll(t *stdtesting.T) {
-	coretesting.MgoTestPackage(t)
-}
 
 type baseSuite struct {
 	testing.JujuConnSuite

--- a/apiserver/client/package_test.go
+++ b/apiserver/client/package_test.go
@@ -1,0 +1,19 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package client_test
+
+import (
+	stdtesting "testing"
+
+	"github.com/juju/testing"
+
+	coretesting "github.com/juju/juju/testing"
+)
+
+func TestPackage(t *stdtesting.T) {
+	if testing.RaceEnabled {
+		t.Skip("skipping package under -race, see LP 1518807")
+	}
+	coretesting.MgoTestPackage(t)
+}

--- a/apiserver/package_test.go
+++ b/apiserver/package_test.go
@@ -1,0 +1,19 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package apiserver_test
+
+import (
+	stdtesting "testing"
+
+	"github.com/juju/testing"
+
+	coretesting "github.com/juju/juju/testing"
+)
+
+func TestPackage(t *stdtesting.T) {
+	if testing.RaceEnabled {
+		t.Skip("skipping package under -race, see LP 1518806")
+	}
+	coretesting.MgoTestPackage(t)
+}

--- a/apiserver/server_test.go
+++ b/apiserver/server_test.go
@@ -10,7 +10,6 @@ import (
 	"io"
 	"net"
 	"net/http"
-	stdtesting "testing"
 	"time"
 
 	"github.com/juju/errors"
@@ -39,10 +38,6 @@ import (
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/testing/factory"
 )
-
-func TestAll(t *stdtesting.T) {
-	coretesting.MgoTestPackage(t)
-}
 
 var fastDialOpts = api.DialOpts{}
 

--- a/apiserver/uniter/package_test.go
+++ b/apiserver/uniter/package_test.go
@@ -6,9 +6,14 @@ package uniter_test
 import (
 	stdtesting "testing"
 
+	"github.com/juju/testing"
+
 	coretesting "github.com/juju/juju/testing"
 )
 
-func TestAll(t *stdtesting.T) {
+func TestPackage(t *stdtesting.T) {
+	if testing.RaceEnabled {
+		t.Skip("skipping package under -race, see LP 1518809")
+	}
 	coretesting.MgoTestPackage(t)
 }

--- a/cmd/juju/commands/package_test.go
+++ b/cmd/juju/commands/package_test.go
@@ -1,16 +1,14 @@
 // Copyright 2014 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-// TODO(dimitern): bug http://pad.lv/1425569
-// Disabled until we have time to fix these tests on i386 properly.
-//
-// +build !386
-
 package commands
 
 import (
 	"flag"
+	"runtime"
 	stdtesting "testing"
+
+	gittesting "github.com/juju/testing"
 
 	cmdtesting "github.com/juju/juju/cmd/testing"
 	_ "github.com/juju/juju/provider/dummy"
@@ -18,6 +16,12 @@ import (
 )
 
 func TestPackage(t *stdtesting.T) {
+	if runtime.GOARCH == "386" {
+		t.Skipf("skipping package for %v/%v, see http://pad.lv/1425569", runtime.GOOS, runtime.GOARCH)
+	}
+	if gittesting.RaceEnabled {
+		t.Skip("skipping test in -race mode, see LP 1518810")
+	}
 	testing.MgoTestPackage(t)
 }
 

--- a/environs/bootstrap/bootstrap_test.go
+++ b/environs/bootstrap/bootstrap_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"runtime"
 	"strings"
-	stdtesting "testing"
 
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
@@ -31,10 +30,6 @@ import (
 	"github.com/juju/juju/tools"
 	"github.com/juju/juju/version"
 )
-
-func TestPackage(t *stdtesting.T) {
-	gc.TestingT(t)
-}
 
 const (
 	useDefaultKeys = true

--- a/environs/bootstrap/package_test.go
+++ b/environs/bootstrap/package_test.go
@@ -1,0 +1,18 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package bootstrap_test
+
+import (
+	stdtesting "testing"
+
+	"github.com/juju/testing"
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *stdtesting.T) {
+	if testing.RaceEnabled {
+		t.Skip("skipping package under -race, see LP 1518820")
+	}
+	gc.TestingT(t)
+}


### PR DESCRIPTION
This commit skips running the tests of a specific package if does not complete on our go 1.2 ci race job.

The goal is to make the race job voting, and once that happens the skipped packages will be fixed and reactivated.

Note: this commit is not sufficient to make the race job voting, yet. There are 1/2 a dozen data races that prevent the job from becoming voting.

(Review request: http://reviews.vapour.ws/r/3204/)