### PR TITLE
Fix #1517748: Do not run functional tests if LXD not running locally.

### DIFF
--- a/provider/lxd/config_test.go
+++ b/provider/lxd/config_test.go
@@ -309,6 +309,11 @@ var newConfigTests = []configTestSpec{{
 }}
 
 func (s *configSuite) TestNewEnvironConfig(c *gc.C) {
+	// TODO(ericsnow) Move to a functional suite.
+	if !s.IsRunningLocally(c) {
+		c.Skip("LXD not running locally")
+	}
+
 	for i, test := range newConfigTests {
 		c.Logf("test %d: %s", i, test.info)
 
@@ -411,6 +416,11 @@ func (s *configSuite) TestValidateChange(c *gc.C) {
 }
 
 func (s *configSuite) TestSetConfig(c *gc.C) {
+	// TODO(ericsnow) Move to a functional suite.
+	if !s.IsRunningLocally(c) {
+		c.Skip("LXD not running locally")
+	}
+
 	for i, test := range changeConfigTests {
 		c.Logf("test %d: %s", i, test.info)
 

--- a/provider/lxd/lxdclient/utils.go
+++ b/provider/lxd/lxdclient/utils.go
@@ -7,6 +7,12 @@ package lxdclient
 
 import (
 	"bytes"
+
+	"github.com/juju/errors"
+	"github.com/juju/utils/series"
+
+	"github.com/juju/juju/service"
+	"github.com/juju/juju/service/common"
 )
 
 type closingBuffer struct {
@@ -16,4 +22,41 @@ type closingBuffer struct {
 // Close implements io.Closer.
 func (closingBuffer) Close() error {
 	return nil
+}
+
+// IsInstalledLocally returns true if LXD is installed locally.
+func IsInstalledLocally() (bool, error) {
+	names, err := service.ListServices()
+	if err != nil {
+		return false, errors.Trace(err)
+	}
+	for _, name := range names {
+		if name == "lxd" {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// IsRunningLocally returns true if LXD is running locally.
+func IsRunningLocally() (bool, error) {
+	installed, err := IsInstalledLocally()
+	if err != nil {
+		return installed, errors.Trace(err)
+	}
+	if !installed {
+		return false, nil
+	}
+
+	svc, err := service.NewService("lxd", common.Conf{}, series.HostSeries())
+	if err != nil {
+		return false, errors.Trace(err)
+	}
+
+	running, err := svc.Running()
+	if err != nil {
+		return running, errors.Trace(err)
+	}
+
+	return running, nil
 }

--- a/provider/lxd/provider_test.go
+++ b/provider/lxd/provider_test.go
@@ -114,6 +114,10 @@ type ProviderFunctionalSuite struct {
 }
 
 func (s *ProviderFunctionalSuite) SetUpTest(c *gc.C) {
+	if !s.IsRunningLocally(c) {
+		c.Skip("LXD not running locally")
+	}
+
 	s.BaseSuite.SetUpTest(c)
 
 	provider, err := environs.Provider("lxd")

--- a/provider/lxd/provider_test.go
+++ b/provider/lxd/provider_test.go
@@ -31,28 +31,27 @@ func (s *providerSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 
 	provider, err := environs.Provider("lxd")
-	c.Check(err, jc.ErrorIsNil)
+	c.Assert(err, jc.ErrorIsNil)
 	s.provider = provider
 }
 
 func (s *providerSuite) TestRegistered(c *gc.C) {
-	c.Assert(s.provider, gc.Equals, lxd.Provider)
+	c.Check(s.provider, gc.Equals, lxd.Provider)
 }
 
 func (s *providerSuite) TestValidate(c *gc.C) {
 	validCfg, err := s.provider.Validate(s.Config, nil)
-	c.Check(err, jc.ErrorIsNil)
-
+	c.Assert(err, jc.ErrorIsNil)
 	validAttrs := validCfg.AllAttrs()
-	c.Assert(s.Config.AllAttrs(), gc.DeepEquals, validAttrs)
+
+	c.Check(s.Config.AllAttrs(), gc.DeepEquals, validAttrs)
 }
 
 func (s *providerSuite) TestSecretAttrs(c *gc.C) {
 	obtainedAttrs, err := s.provider.SecretAttrs(s.Config)
-	c.Check(err, jc.ErrorIsNil)
+	c.Assert(err, jc.ErrorIsNil)
 
-	c.Assert(obtainedAttrs, gc.HasLen, 0)
-
+	c.Check(obtainedAttrs, gc.HasLen, 0)
 }
 
 func (s *providerSuite) TestBoilerplateConfig(c *gc.C) {
@@ -121,21 +120,22 @@ func (s *ProviderFunctionalSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 
 	provider, err := environs.Provider("lxd")
-	c.Check(err, jc.ErrorIsNil)
+	c.Assert(err, jc.ErrorIsNil)
 
 	s.provider = provider
 }
 
 func (s *ProviderFunctionalSuite) TestOpen(c *gc.C) {
 	env, err := s.provider.Open(s.Config)
-	c.Check(err, jc.ErrorIsNil)
-
+	c.Assert(err, jc.ErrorIsNil)
 	envConfig := env.Config()
-	c.Assert(envConfig.Name(), gc.Equals, "testenv")
+
+	c.Check(envConfig.Name(), gc.Equals, "testenv")
 }
 
 func (s *ProviderFunctionalSuite) TestPrepareForBootstrap(c *gc.C) {
 	env, err := s.provider.PrepareForBootstrap(envtesting.BootstrapContext(c), s.Config)
-	c.Check(err, jc.ErrorIsNil)
+	c.Assert(err, jc.ErrorIsNil)
+
 	c.Check(env, gc.NotNil)
 }

--- a/provider/lxd/provider_test.go
+++ b/provider/lxd/provider_test.go
@@ -16,13 +16,16 @@ import (
 	"github.com/juju/juju/provider/lxd"
 )
 
+var (
+	_ = gc.Suite(&providerSuite{})
+	_ = gc.Suite(&ProviderFunctionalSuite{})
+)
+
 type providerSuite struct {
 	lxd.BaseSuite
 
 	provider environs.EnvironProvider
 }
-
-var _ = gc.Suite(&providerSuite{})
 
 func (s *providerSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
@@ -34,20 +37,6 @@ func (s *providerSuite) SetUpTest(c *gc.C) {
 
 func (s *providerSuite) TestRegistered(c *gc.C) {
 	c.Assert(s.provider, gc.Equals, lxd.Provider)
-}
-
-func (s *providerSuite) TestOpen(c *gc.C) {
-	env, err := s.provider.Open(s.Config)
-	c.Check(err, jc.ErrorIsNil)
-
-	envConfig := env.Config()
-	c.Assert(envConfig.Name(), gc.Equals, "testenv")
-}
-
-func (s *providerSuite) TestPrepareForBootstrap(c *gc.C) {
-	env, err := s.provider.PrepareForBootstrap(envtesting.BootstrapContext(c), s.Config)
-	c.Check(err, jc.ErrorIsNil)
-	c.Check(env, gc.NotNil)
 }
 
 func (s *providerSuite) TestValidate(c *gc.C) {
@@ -116,4 +105,33 @@ lxd:
 
 	c.Check(boilerplateConfig, gc.Equals, expected)
 	c.Check(strings.Split(boilerplateConfig, "\n"), jc.DeepEquals, strings.Split(expected, "\n"))
+}
+
+type ProviderFunctionalSuite struct {
+	lxd.BaseSuite
+
+	provider environs.EnvironProvider
+}
+
+func (s *ProviderFunctionalSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+
+	provider, err := environs.Provider("lxd")
+	c.Check(err, jc.ErrorIsNil)
+
+	s.provider = provider
+}
+
+func (s *ProviderFunctionalSuite) TestOpen(c *gc.C) {
+	env, err := s.provider.Open(s.Config)
+	c.Check(err, jc.ErrorIsNil)
+
+	envConfig := env.Config()
+	c.Assert(envConfig.Name(), gc.Equals, "testenv")
+}
+
+func (s *ProviderFunctionalSuite) TestPrepareForBootstrap(c *gc.C) {
+	env, err := s.provider.PrepareForBootstrap(envtesting.BootstrapContext(c), s.Config)
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(env, gc.NotNil)
 }

--- a/provider/lxd/testing_test.go
+++ b/provider/lxd/testing_test.go
@@ -112,7 +112,10 @@ type BaseSuiteUnpatched struct {
 func (s *BaseSuiteUnpatched) SetUpSuite(c *gc.C) {
 	s.osPathOrig = os.Getenv("PATH")
 	if s.osPathOrig == "" {
-		// TODO(ericsnow) This shouldn't happen...
+		// TODO(ericsnow) This shouldn't happen. However, an undiagnosed
+		// bug in testing.IsolationSuite is causing $PATH to remain unset
+		// sometimes.  Once that is cleared up this special-case can go
+		// away.
 		s.osPathOrig =
 			"/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin"
 	}
@@ -258,7 +261,7 @@ func (s *BaseSuiteUnpatched) IsRunningLocally(c *gc.C) bool {
 	defer restore()
 
 	running, err := lxdclient.IsRunningLocally()
-	c.Assert(err, jc.ErrorIsNil) // TODO(ericsnow) Ignore err instead?
+	c.Assert(err, jc.ErrorIsNil)
 	return running
 }
 

--- a/provider/lxd/testing_test.go
+++ b/provider/lxd/testing_test.go
@@ -8,6 +8,7 @@ package lxd
 import (
 	"crypto/tls"
 	"encoding/pem"
+	"os"
 
 	"github.com/juju/errors"
 	gitjujutesting "github.com/juju/testing"
@@ -88,6 +89,8 @@ var (
 type BaseSuiteUnpatched struct {
 	gitjujutesting.IsolationSuite
 
+	osPathOrig string
+
 	Config    *config.Config
 	EnvConfig *environConfig
 	Env       *environ
@@ -104,6 +107,16 @@ type BaseSuiteUnpatched struct {
 	//InstanceType  instances.InstanceType
 
 	Ports []network.PortRange
+}
+
+func (s *BaseSuiteUnpatched) SetUpSuite(c *gc.C) {
+	s.osPathOrig = os.Getenv("PATH")
+	if s.osPathOrig == "" {
+		// TODO(ericsnow) This shouldn't happen...
+		s.osPathOrig =
+			"/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin"
+	}
+	s.IsolationSuite.SetUpTest(c)
 }
 
 func (s *BaseSuiteUnpatched) SetUpTest(c *gc.C) {
@@ -238,6 +251,15 @@ func (s *BaseSuiteUnpatched) NewRawInstance(c *gc.C, name string) *lxdclient.Ins
 func (s *BaseSuiteUnpatched) NewInstance(c *gc.C, name string) *environInstance {
 	raw := s.NewRawInstance(c, name)
 	return newInstance(raw, s.Env)
+}
+
+func (s *BaseSuiteUnpatched) IsRunningLocally(c *gc.C) bool {
+	restore := gitjujutesting.PatchEnvPathPrepend(s.osPathOrig)
+	defer restore()
+
+	running, err := lxdclient.IsRunningLocally()
+	c.Assert(err, jc.ErrorIsNil) // TODO(ericsnow) Ignore err instead?
+	return running
 }
 
 type BaseSuite struct {


### PR DESCRIPTION
See: https://bugs.launchpad.net/juju-core/+bug/1517748

Some of the LXD provider tests rely on a locally running LXD.  This patch skips those tests if LXD is not running locally.

(Review request: http://reviews.vapour.ws/r/3211/)