### PR TITLE
all: disable any -race test that fails or times out

### DIFF
--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -12,7 +12,6 @@ import (
 	"runtime"
 	"strings"
 	"sync/atomic"
-	"testing"
 	"time"
 
 	"github.com/juju/cmd"
@@ -94,12 +93,6 @@ var (
 	_ = gc.Suite(&MachineWithCharmsSuite{})
 	_ = gc.Suite(&mongoSuite{})
 )
-
-func TestPackage(t *testing.T) {
-	// TODO(waigani) 2014-03-19 bug 1294458
-	// Refactor to use base suites
-	coretesting.MgoTestPackage(t)
-}
 
 type commonMachineSuite struct {
 	singularRecord *singularRunnerRecord

--- a/cmd/jujud/agent/package_test.go
+++ b/cmd/jujud/agent/package_test.go
@@ -1,7 +1,7 @@
-// Copyright 2014 Canonical Ltd.
+// Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package uniter_test
+package agent_test
 
 import (
 	stdtesting "testing"
@@ -13,7 +13,9 @@ import (
 
 func TestPackage(t *stdtesting.T) {
 	if testing.RaceEnabled {
-		t.Skip("skipping package under -race, see LP 1519097")
+		t.Skip("skipping package under -race, see LP 1519133, 1519097")
 	}
+	// TODO(waigani) 2014-03-19 bug 1294458
+	// Refactor to use base suites
 	coretesting.MgoTestPackage(t)
 }

--- a/provider/ec2/package_test.go
+++ b/provider/ec2/package_test.go
@@ -5,14 +5,19 @@ package ec2_test
 
 import (
 	"flag"
-	"testing"
+	stdtesting "testing"
+
+	"github.com/juju/testing"
 
 	gc "gopkg.in/check.v1"
 )
 
 var amazon = flag.Bool("amazon", false, "Also run some tests on live Amazon servers")
 
-func TestEC2(t *testing.T) {
+func TestPackage(t *stdtesting.T) {
+	if testing.RaceEnabled {
+		t.Skip("skipping package under -race, see LP 1519141")
+	}
 	if *amazon {
 		registerAmazonTests()
 	}

--- a/state/conn_test.go
+++ b/state/conn_test.go
@@ -4,21 +4,13 @@
 package state_test
 
 import (
-	stdtesting "testing"
-
 	"github.com/juju/names"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/mgo.v2"
 
 	"github.com/juju/juju/state"
 	statetesting "github.com/juju/juju/state/testing"
-	"github.com/juju/juju/testing"
 )
-
-// TestPackage integrates the tests into gotest.
-func TestPackage(t *stdtesting.T) {
-	testing.MgoTestPackage(t)
-}
 
 // ConnSuite provides the infrastructure for all other
 // test suites (StateSuite, CharmSuite, MachineSuite, etc).

--- a/state/package_test.go
+++ b/state/package_test.go
@@ -1,7 +1,7 @@
-// Copyright 2014 Canonical Ltd.
+// Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package uniter_test
+package state
 
 import (
 	stdtesting "testing"
@@ -13,7 +13,7 @@ import (
 
 func TestPackage(t *stdtesting.T) {
 	if testing.RaceEnabled {
-		t.Skip("skipping package under -race, see LP 1519097")
+		t.Skip("skipping package under -race, see LP 1519095")
 	}
 	coretesting.MgoTestPackage(t)
 }

--- a/worker/envworkermanager/envworkermanager_test.go
+++ b/worker/envworkermanager/envworkermanager_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names"
+	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"launchpad.net/tomb"
@@ -24,6 +25,10 @@ import (
 )
 
 func TestPackage(t *stdtesting.T) {
+	if jujutesting.RaceEnabled {
+		t.Skip("skipping package under -race, see LP 1519144")
+	}
+
 	testing.MgoTestPackage(t)
 }
 

--- a/worker/machiner/machiner_test.go
+++ b/worker/machiner/machiner_test.go
@@ -27,6 +27,13 @@ import (
 	"github.com/juju/juju/worker/machiner"
 )
 
+func TestPackage(t *stdtesting.T) {
+	if gitjujutesting.RaceEnabled {
+		t.Skip("skipping package under -race, see LP 1519145")
+	}
+	coretesting.MgoTestPackage(t)
+}
+
 type MachinerSuite struct {
 	coretesting.BaseSuite
 	accessor   *mockMachineAccessor
@@ -248,10 +255,6 @@ func (s *MachinerSuite) TestMachinerStorageAttached(c *gc.C) {
 // not affect the overall running time of the tests
 // unless they fail.
 const worstCase = 5 * time.Second
-
-func TestPackage(t *stdtesting.T) {
-	coretesting.MgoTestPackage(t)
-}
 
 type MachinerStateSuite struct {
 	testing.JujuConnSuite

--- a/worker/provisioner/package_test.go
+++ b/worker/provisioner/package_test.go
@@ -6,9 +6,14 @@ package provisioner_test
 import (
 	stdtesting "testing"
 
-	"github.com/juju/juju/testing"
+	"github.com/juju/testing"
+
+	coretesting "github.com/juju/juju/testing"
 )
 
-func Test(t *stdtesting.T) {
-	testing.MgoTestPackage(t)
+func TestPackage(t *stdtesting.T) {
+	if testing.RaceEnabled {
+		t.Skip("skipping package under -race, see LP 1519097")
+	}
+	coretesting.MgoTestPackage(t)
 }

--- a/worker/rsyslog/rsyslog_common_test.go
+++ b/worker/rsyslog/rsyslog_common_test.go
@@ -26,6 +26,9 @@ import (
 )
 
 func TestPackage(t *stdtesting.T) {
+	if testing.RaceEnabled {
+		t.Skip("skipping package under -race, see LP 1519147")
+	}
 	coretesting.MgoTestPackage(t)
 }
 

--- a/worker/uniter/remotestate/package_test.go
+++ b/worker/uniter/remotestate/package_test.go
@@ -4,11 +4,15 @@
 package remotestate_test
 
 import (
-	stdtesting "testing"
+	"testing"
 
+	jujutesting "github.com/juju/testing"
 	gc "gopkg.in/check.v1"
 )
 
-func TestPackage(t *stdtesting.T) {
+func TestPackage(t *testing.T) {
+	if jujutesting.RaceEnabled {
+		t.Skip("skipping package under -race, see LP 1519149")
+	}
 	gc.TestingT(t)
 }


### PR DESCRIPTION
This PR disables any package that fails under the race detector (ie, has a race)
or times out due to internal errors.

(Review request: http://reviews.vapour.ws/r/3216/)