### PR TITLE
Fix #1519027: Support separate images, per series.

### DIFF
--- a/provider/lxd/config.go
+++ b/provider/lxd/config.go
@@ -65,18 +65,22 @@ lxd:
     # You will also need to prepare the "ubuntu" images that Juju uses:
     #
     #   lxc remote add images images.linuxcontainers.org
-    #   lxd-images import ubuntu --alias ubuntu-trusty
+    #   lxd-images import ubuntu --alias ubuntu-wily wily
     #
     # (Also consider the --stream and --sync options.)
     #
     # You will need to prepare an image for each Ubuntu series for which
     # you want to create instances.  The alias must match the series:
     #
-    #   lxd-images import ubuntu --alias ubuntu-trusty
-    #   lxd-images import ubuntu --alias ubuntu-wily
-    #   lxd-images import ubuntu --alias ubuntu-xenial
+    #   lxd-images import ubuntu --alias ubuntu-trusty trusty
+    #   lxd-images import ubuntu --alias ubuntu-wily wily
+    #   lxd-images import ubuntu --alias ubuntu-xenial xenial
     #
     # See: https://linuxcontainers.org/lxd/getting-started-cli/
+    #
+    # Note: the LXD provider does not support using any series older
+    # than wily for a controller instance.  However, non-controller
+    # instances may be provisioned on earler series (e.g. trusty).
     #
     # remote-url:
 

--- a/provider/lxd/config.go
+++ b/provider/lxd/config.go
@@ -62,10 +62,19 @@ lxd:
     #
     #   newgrp lxd
     #
-    # You will also need to prepare the "ubuntu" image that Juju uses:
+    # You will also need to prepare the "ubuntu" images that Juju uses:
     #
     #   lxc remote add images images.linuxcontainers.org
-    #   lxd-images import ubuntu --alias ubuntu
+    #   lxd-images import ubuntu --alias ubuntu-trusty
+    #
+    # (Also consider the --stream and --sync options.)
+    #
+    # You will need to prepare an image for each Ubuntu series for which
+    # you want to create instances.  The alias must match the series:
+    #
+    #   lxd-images import ubuntu --alias ubuntu-trusty
+    #   lxd-images import ubuntu --alias ubuntu-wily
+    #   lxd-images import ubuntu --alias ubuntu-xenial
     #
     # See: https://linuxcontainers.org/lxd/getting-started-cli/
     #

--- a/provider/lxd/environ_broker.go
+++ b/provider/lxd/environ_broker.go
@@ -94,6 +94,9 @@ func (env *environ) finishInstanceConfig(args environs.StartInstanceParams) erro
 func (env *environ) newRawInstance(args environs.StartInstanceParams) (*lxdclient.Instance, error) {
 	machineID := common.MachineFullName(env, args.InstanceConfig.MachineId)
 
+	series := args.Tools.OneSeries()
+	image := "ubuntu-" + series
+
 	metadata, err := getMetadata(args)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -107,7 +110,8 @@ func (env *environ) newRawInstance(args environs.StartInstanceParams) (*lxdclien
 	// TODO(ericsnow) Support multiple networks?
 	// TODO(ericsnow) Use a different net interface name? Configurable?
 	instSpec := lxdclient.InstanceSpec{
-		Name: machineID,
+		Name:  machineID,
+		Image: image,
 		//Type:              spec.InstanceType.Name,
 		//Disks:             getDisks(spec, args.Constraints),
 		//NetworkInterfaces: []string{"ExternalNAT"},

--- a/provider/lxd/environ_broker.go
+++ b/provider/lxd/environ_broker.go
@@ -128,6 +128,7 @@ func (env *environ) newRawInstance(args environs.StartInstanceParams) (*lxdclien
 		// Network is omitted (left empty).
 	}
 
+	logger.Infof("starting instance %q (image %q)...", instSpec.Name, instSpec.Image)
 	inst, err := env.raw.AddInstance(instSpec)
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/provider/lxd/lxdclient/client_instance.go
+++ b/provider/lxd/lxdclient/client_instance.go
@@ -37,8 +37,7 @@ type instanceClient struct {
 }
 
 func (client *instanceClient) addInstance(spec InstanceSpec) error {
-	// TODO(ericsnow) Default to spec.ImageRemote (once it gets added).
-	imageRemote := ""
+	imageRemote := spec.ImageRemote
 	if imageRemote == "" {
 		imageRemote = client.remote
 	}

--- a/provider/lxd/lxdclient/client_instance.go
+++ b/provider/lxd/lxdclient/client_instance.go
@@ -42,8 +42,13 @@ func (client *instanceClient) addInstance(spec InstanceSpec) error {
 	if imageRemote == "" {
 		imageRemote = client.remote
 	}
-	imageAlias := "ubuntu" // TODO(ericsnow) Do not hard-code.
-	//imageAlias := spec.Image
+
+	imageAlias := spec.Image
+	if imageAlias == "" {
+		// TODO(ericsnow) Do not have a default?
+		imageAlias = "ubuntu"
+	}
+
 	var profiles *[]string
 	if len(spec.Profiles) > 0 {
 		profiles = &spec.Profiles

--- a/provider/lxd/lxdclient/instance.go
+++ b/provider/lxd/lxdclient/instance.go
@@ -58,6 +58,10 @@ type InstanceSpec struct {
 	// Image is the name of the image to use.
 	Image string
 
+	// ImageRemote identifies the remote to use for images. By default
+	// the client's remote is used.
+	ImageRemote string
+
 	// Profiles are the names of the container profiles to apply to the
 	// new container, in order.
 	Profiles []string

--- a/provider/lxd/lxdclient/instance.go
+++ b/provider/lxd/lxdclient/instance.go
@@ -55,6 +55,9 @@ type InstanceSpec struct {
 	// Name is the "name" of the instance.
 	Name string
 
+	// Image is the name of the image to use.
+	Image string
+
 	// Profiles are the names of the container profiles to apply to the
 	// new container, in order.
 	Profiles []string

--- a/provider/lxd/provider_test.go
+++ b/provider/lxd/provider_test.go
@@ -77,6 +77,9 @@ lxd:
     # created by the provider.  It is prepended to the container names.
     # By default the environment's name is used as the namespace.
     #
+    # Setting the namespace is useful when more than one environment
+    # is using the same remote (e.g. the local LXD socket).
+    #
     # namespace: lxd
 
     # remote-url is the URL to the LXD API server to use for managing
@@ -96,12 +99,25 @@ lxd:
     #
     #   newgrp lxd
     #
-    # You will also need to prepare the "ubuntu" image that Juju uses:
+    # You will also need to prepare the "ubuntu" images that Juju uses:
     #
     #   lxc remote add images images.linuxcontainers.org
-    #   lxd-images import ubuntu --alias ubuntu
+    #   lxd-images import ubuntu --alias ubuntu-wily wily
+    #
+    # (Also consider the --stream and --sync options.)
+    #
+    # You will need to prepare an image for each Ubuntu series for which
+    # you want to create instances.  The alias must match the series:
+    #
+    #   lxd-images import ubuntu --alias ubuntu-trusty trusty
+    #   lxd-images import ubuntu --alias ubuntu-wily wily
+    #   lxd-images import ubuntu --alias ubuntu-xenial xenial
     #
     # See: https://linuxcontainers.org/lxd/getting-started-cli/
+    #
+    # Note: the LXD provider does not support using any series older
+    # than wily for a controller instance.  However, non-controller
+    # instances may be provisioned on earler series (e.g. trusty).
     #
     # remote-url:
 


### PR DESCRIPTION
See: https://bugs.launchpad.net/juju-core/+bug/1519027

The LXD provider was using a single LXD image, "ubuntu", for all series.  If that image was trusty and someone asked for wily then the provider would happily give them trusty without any warning.  This patch addresses that problem by requiring one image per desired series.  The boilerplate config is also updated with accordingly corrected info and instructions.

(Review request: http://reviews.vapour.ws/r/3222/)