### PR TITLE
Various backend changes for x-env relations

### DIFF
--- a/apiserver/params/internal.go
+++ b/apiserver/params/internal.go
@@ -510,15 +510,32 @@ type ServiceRelationsWatchResults struct {
 	Results []ServiceRelationsWatchResult `json:"results"`
 }
 
+// ServiceChange describes changes to a service.
+type ServiceChange struct {
+	ServiceTag string                 `json:"servicetag"`
+	Life       Life                   `json:"life"`
+	Relations  ServiceRelationsChange `json:"relations"`
+}
+
+// ServiceChanges describes a set of changes to services.
+type ServiceChanges struct {
+	Changes []ServiceChange `json:"changes,omitempty"`
+}
+
 // ServiceRelationsChange describes changes to the relations that a service
 // is involved in.
 type ServiceRelationsChange struct {
 	// ChangedRelations maps relation IDs to relation changes.
-	ChangedRelations []RelationChange
+	ChangedRelations []RelationChange `json:"changed,omitempty"`
 
 	// RemovedRelations contains the IDs of relations removed
 	// since the last change.
-	RemovedRelations []int
+	RemovedRelations []int `json:"removed,omitempty"`
+}
+
+// ServiceRelationsChanges holds a set of ServiceRelationsChange structures.
+type ServiceRelationsChanges struct {
+	Changes []ServiceRelationsChange `json:"changes,omitempty"`
 }
 
 // RelationChange describes changes to a relation.

--- a/apiserver/remoterelations/mock_test.go
+++ b/apiserver/remoterelations/mock_test.go
@@ -48,7 +48,7 @@ func (st *mockState) Relation(id int) (remoterelations.Relation, error) {
 		return nil, err
 	}
 	for _, r := range st.relations {
-		if r.Id() == id {
+		if r.id == id {
 			return r, nil
 		}
 	}
@@ -165,10 +165,12 @@ func newMockRemoteService(name, url string) *mockRemoteService {
 }
 
 func (r *mockRemoteService) Name() string {
+	r.MethodCall(r, "Name")
 	return r.name
 }
 
 func (r *mockRemoteService) URL() string {
+	r.MethodCall(r, "URL")
 	return r.url
 }
 

--- a/featuretests/remoterelations_test.go
+++ b/featuretests/remoterelations_test.go
@@ -35,7 +35,7 @@ func (s *remoteRelationsSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *remoteRelationsSuite) TestWatchRemoteServices(c *gc.C) {
-	_, err := s.State.AddRemoteService("mysql", nil)
+	_, err := s.State.AddRemoteService("mysql", "local:/u/me/mysql", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	w, err := s.client.WatchRemoteServices()
@@ -47,7 +47,7 @@ func (s *remoteRelationsSuite) TestWatchRemoteServices(c *gc.C) {
 	wc.AssertChangeInSingleEvent("mysql")
 	wc.AssertNoChange()
 
-	_, err = s.State.AddRemoteService("db2", nil)
+	_, err = s.State.AddRemoteService("db2", "local:/u/ibm/db2", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertChangeInSingleEvent("db2")
 	wc.AssertNoChange()
@@ -56,7 +56,7 @@ func (s *remoteRelationsSuite) TestWatchRemoteServices(c *gc.C) {
 func (s *remoteRelationsSuite) TestWatchRemoteService(c *gc.C) {
 	// Add a remote service, and watch it. It should initially have no
 	// relations.
-	_, err := s.State.AddRemoteService("mysql", []charm.Relation{{
+	_, err := s.State.AddRemoteService("mysql", "local:/u/me/mysql", []charm.Relation{{
 		Interface: "mysql",
 		Name:      "db",
 		Role:      charm.RoleProvider,

--- a/state/allwatcher.go
+++ b/state/allwatcher.go
@@ -497,10 +497,11 @@ func (svc *backingRemoteService) updated(st *State, store *multiwatcherStore, id
 		endpoints[i] = multiwatcher.Endpoint{ep.ServiceName, ep.Relation}
 	}
 	info := &multiwatcher.RemoteServiceInfo{
-		EnvUUID:   st.EnvironUUID(),
-		Name:      svc.Name,
-		Endpoints: endpoints,
-		Life:      multiwatcher.Life(svc.Life.String()),
+		EnvUUID:    st.EnvironUUID(),
+		Name:       svc.Name,
+		ServiceURL: svc.URL,
+		Endpoints:  endpoints,
+		Life:       multiwatcher.Life(svc.Life.String()),
 	}
 	if store.Get(info.EntityId()) == nil {
 		logger.Debugf("new remote service %q added to backing state", svc.Name)

--- a/state/multiwatcher/multiwatcher.go
+++ b/state/multiwatcher/multiwatcher.go
@@ -195,10 +195,11 @@ func (i *ServiceInfo) EntityId() EntityId {
 // RemoteServiceInfo holds the information about a remote service that is
 // tracked by multiwatcherStore.
 type RemoteServiceInfo struct {
-	EnvUUID   string
-	Name      string
-	Life      Life
-	Endpoints []Endpoint
+	EnvUUID    string
+	Name       string
+	ServiceURL string
+	Life       Life
+	Endpoints  []Endpoint
 	// TODO(axw) Description, Icon. These would normally be part of a
 	// charm, but remote services do not have this information currently.
 	// TODO(axw) Status? Needs status in the remote service model too.

--- a/state/relationunit.go
+++ b/state/relationunit.go
@@ -15,18 +15,18 @@ import (
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
-
-	"github.com/juju/juju/network"
 )
 
 // RelationUnit holds information about a single unit in a relation, and
 // allows clients to conveniently access unit-specific functionality.
 type RelationUnit struct {
-	st       *State
-	relation *Relation
-	unit     *Unit
-	endpoint Endpoint
-	scope    string
+	st            *State
+	relation      *Relation
+	unitName      string
+	isPrincipal   bool
+	checkUnitLife bool
+	endpoint      Endpoint
+	scope         string
 }
 
 // Relation returns the relation associated with the unit.
@@ -38,11 +38,6 @@ func (ru *RelationUnit) Relation() *Relation {
 // participation in the relation.
 func (ru *RelationUnit) Endpoint() Endpoint {
 	return ru.endpoint
-}
-
-// PrivateAddress returns the private address of the unit.
-func (ru *RelationUnit) PrivateAddress() (network.Address, error) {
-	return ru.unit.PrivateAddress()
 }
 
 // ErrCannotEnterScope indicates that a relation unit failed to enter its scope
@@ -78,7 +73,7 @@ func (ru *RelationUnit) EnterScope(settings map[string]interface{}) error {
 
 	// Verify that the unit is not already in scope, and abort without error
 	// if it is.
-	ruKey, err := ru.key(ru.unit.Name())
+	ruKey, err := ru.key(ru.unitName)
 	if err != nil {
 		return err
 	}
@@ -93,17 +88,21 @@ func (ru *RelationUnit) EnterScope(settings map[string]interface{}) error {
 	// * TODO(fwereade): check unit status == params.StatusActive (this
 	//   breaks a bunch of tests in a boring but noisy-to-fix way, and is
 	//   being saved for a followup).
-	unitDocID, relationDocID := ru.unit.doc.DocID, ru.relation.doc.DocID
-	ops := []txn.Op{{
-		C:      unitsC,
-		Id:     unitDocID,
-		Assert: isAliveDoc,
-	}, {
+	relationDocID := ru.relation.doc.DocID
+	var ops []txn.Op
+	if ru.checkUnitLife {
+		ops = append(ops, txn.Op{
+			C:      unitsC,
+			Id:     ru.unitName,
+			Assert: isAliveDoc,
+		})
+	}
+	ops = append(ops, txn.Op{
 		C:      relationsC,
 		Id:     relationDocID,
 		Assert: isAliveDoc,
 		Update: bson.D{{"$inc", bson.D{{"unitcount", 1}}}},
-	}}
+	})
 
 	// * Create the unit settings in this relation, if they do not already
 	//   exist; or completely overwrite them if they do. This must happen
@@ -158,34 +157,35 @@ func (ru *RelationUnit) EnterScope(settings map[string]interface{}) error {
 		return nil
 	}
 
-	units, closer := db.GetCollection(unitsC)
-	defer closer()
-	relations, closer := db.GetCollection(relationsC)
-	defer closer()
-
 	// The relation or unit might no longer be Alive. (Note that there is no
 	// need for additional checks if we're trying to create a subordinate
 	// unit: this could fail due to the subordinate service's not being Alive,
 	// but this case will always be caught by the check for the relation's
 	// life (because a relation cannot be Alive if its services are not).)
-	if alive, err := isAliveWithSession(units, unitDocID); err != nil {
-		return err
-	} else if !alive {
-		return ErrCannotEnterScope
-	}
+	relations, closer := db.GetCollection(relationsC)
+	defer closer()
 	if alive, err := isAliveWithSession(relations, relationDocID); err != nil {
 		return err
 	} else if !alive {
 		return ErrCannotEnterScope
 	}
-
-	// Maybe a subordinate used to exist, but is no longer alive. If that is
-	// case, we will be unable to enter scope until that unit is gone.
-	if existingSubName != "" {
-		if alive, err := isAliveWithSession(units, existingSubName); err != nil {
+	if ru.checkUnitLife {
+		units, closer := db.GetCollection(unitsC)
+		defer closer()
+		if alive, err := isAliveWithSession(units, ru.unitName); err != nil {
 			return err
 		} else if !alive {
-			return ErrCannotEnterScopeYet
+			return ErrCannotEnterScope
+		}
+
+		// Maybe a subordinate used to exist, but is no longer alive. If that is
+		// case, we will be unable to enter scope until that unit is gone.
+		if existingSubName != "" {
+			if alive, err := isAliveWithSession(units, existingSubName); err != nil {
+				return err
+			} else if !alive {
+				return ErrCannotEnterScopeYet
+			}
 		}
 	}
 
@@ -193,7 +193,7 @@ func (ru *RelationUnit) EnterScope(settings map[string]interface{}) error {
 	// has changed under our feet, preventing us from clearing it properly; if
 	// that is the case, something is seriously wrong (nobody else should be
 	// touching that doc under our feet) and we should bail out.
-	prefix := fmt.Sprintf("cannot enter scope for unit %q in relation %q: ", ru.unit, ru.relation)
+	prefix := fmt.Sprintf("cannot enter scope for unit %q in relation %q: ", ru.unitName, ru.relation)
 	if changed, err := settingsChanged(); err != nil {
 		return err
 	} else if changed {
@@ -213,7 +213,7 @@ func (ru *RelationUnit) subordinateOps() ([]txn.Op, string, error) {
 	units, closer := ru.st.getCollection(unitsC)
 	defer closer()
 
-	if !ru.unit.IsPrincipal() || ru.endpoint.Scope != charm.ScopeContainer {
+	if !ru.isPrincipal || ru.endpoint.Scope != charm.ScopeContainer {
 		return nil, "", nil
 	}
 	related, err := ru.relation.RelatedEndpoints(ru.endpoint.ServiceName)
@@ -223,7 +223,7 @@ func (ru *RelationUnit) subordinateOps() ([]txn.Op, string, error) {
 	if len(related) != 1 {
 		return nil, "", fmt.Errorf("expected single related endpoint, got %v", related)
 	}
-	serviceName, unitName := related[0].ServiceName, ru.unit.doc.Name
+	serviceName, unitName := related[0].ServiceName, ru.unitName
 	selSubordinate := bson.D{{"service", serviceName}, {"principal", unitName}}
 	var lDoc lifeDoc
 	if err := units.Find(selSubordinate).One(&lDoc); err == mgo.ErrNotFound {
@@ -252,7 +252,7 @@ func (ru *RelationUnit) PrepareLeaveScope() error {
 	relationScopes, closer := ru.st.getCollection(relationScopesC)
 	defer closer()
 
-	key, err := ru.key(ru.unit.Name())
+	key, err := ru.key(ru.unitName)
 	if err != nil {
 		return err
 	}
@@ -278,7 +278,7 @@ func (ru *RelationUnit) LeaveScope() error {
 	relationScopes, closer := ru.st.getCollection(relationScopesC)
 	defer closer()
 
-	key, err := ru.key(ru.unit.Name())
+	key, err := ru.key(ru.unitName)
 	if err != nil {
 		return err
 	}
@@ -304,7 +304,7 @@ func (ru *RelationUnit) LeaveScope() error {
 	// to have a Dying relation with a smaller-than-real unit count, because
 	// Destroy changes the Life attribute in memory (units could join before
 	// the database is actually changed).
-	desc := fmt.Sprintf("unit %q in relation %q", ru.unit, ru.relation)
+	desc := fmt.Sprintf("unit %q in relation %q", ru.unitName, ru.relation)
 	buildTxn := func(attempt int) ([]txn.Op, error) {
 		if attempt > 0 {
 			if err := ru.relation.Refresh(); errors.IsNotFound(err) {
@@ -340,7 +340,7 @@ func (ru *RelationUnit) LeaveScope() error {
 				Update: bson.D{{"$inc", bson.D{{"unitcount", -1}}}},
 			})
 		} else {
-			relOps, err := ru.relation.removeOps("", ru.unit)
+			relOps, err := ru.relation.removeOps("", ru.unitName)
 			if err != nil {
 				return nil, err
 			}
@@ -371,7 +371,7 @@ func (ru *RelationUnit) inScope(sel bson.D) (bool, error) {
 	relationScopes, closer := ru.st.getCollection(relationScopesC)
 	defer closer()
 
-	key, err := ru.key(ru.unit.Name())
+	key, err := ru.key(ru.unitName)
 	if err != nil {
 		return false, err
 	}
@@ -387,7 +387,7 @@ func (ru *RelationUnit) inScope(sel bson.D) (bool, error) {
 // entering and leaving the unit's scope.
 func (ru *RelationUnit) WatchScope() *RelationScopeWatcher {
 	role := counterpartRole(ru.endpoint.Role)
-	return watchRelationScope(ru.st, ru.scope, role, ru.unit.Name())
+	return watchRelationScope(ru.st, ru.scope, role, ru.unitName)
 }
 
 func watchRelationScope(
@@ -400,7 +400,7 @@ func watchRelationScope(
 // Settings returns a Settings which allows access to the unit's settings
 // within the relation.
 func (ru *RelationUnit) Settings() (*Settings, error) {
-	key, err := ru.key(ru.unit.Name())
+	key, err := ru.key(ru.unitName)
 	if err != nil {
 		return nil, err
 	}

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -370,7 +370,7 @@ func (s *MultiEnvStateSuite) TestWatchTwoEnvironments(c *gc.C) {
 				return st.WatchRemoteServices()
 			},
 			triggerEvent: func(st *state.State) {
-				st.AddRemoteService("db2", nil)
+				st.AddRemoteService("db2", "local:/u/ibm/db2", nil)
 			},
 		}, {
 			about: "relations",
@@ -1930,7 +1930,7 @@ func (s *StateSuite) TestAddServiceEnvironmentDying(c *gc.C) {
 
 func (s *StateSuite) TestAddServiceSameRemoteExists(c *gc.C) {
 	charm := s.AddTestingCharm(c, "dummy")
-	_, err := s.State.AddRemoteService("s1", nil)
+	_, err := s.State.AddRemoteService("s1", "local:/u/me/dummy", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = s.State.AddService(state.AddServiceArgs{Name: "s1", Owner: s.Owner.String(), Charm: charm})
 	c.Assert(err, gc.ErrorMatches, `cannot add service "s1": remote service with same name already exists`)
@@ -1942,7 +1942,7 @@ func (s *StateSuite) TestAddServiceRemotedAddedAfterInitial(c *gc.C) {
 	// there is no conflict initially but a remote service is added
 	// before the transaction is run.
 	defer state.SetBeforeHooks(c, s.State, func() {
-		_, err := s.State.AddRemoteService("s1", nil)
+		_, err := s.State.AddRemoteService("s1", "local:/u/me/s1", nil)
 		c.Assert(err, jc.ErrorIsNil)
 	}).Check()
 	_, err := s.State.AddService(state.AddServiceArgs{Name: "s1", Owner: s.Owner.String(), Charm: charm})


### PR DESCRIPTION
state:
  - Add RemoteService.URL()
  - Add RemoteServiceInfo.ServiceURL
  - Add Relation.RemoteUnit()
  - Remove RelationUnit.PrivateAddress

apiserver/remoterelations:
  - expand API to support publishing/consuming changes

(Review request: http://reviews.vapour.ws/r/3231/)