### PR TITLE
worker: make worker.RestartDelay a constant

### DIFF
--- a/cmd/jujud/agent/agent_test.go
+++ b/cmd/jujud/agent/agent_test.go
@@ -4,8 +4,6 @@
 package agent
 
 import (
-	"time"
-
 	"github.com/juju/cmd"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/series"
@@ -58,25 +56,14 @@ func ParseAgentCommand(ac cmd.Command, args []string) error {
 // AgentSuite is a fixture to be used by agent test suites.
 type AgentSuite struct {
 	agenttesting.AgentSuite
-	oldRestartDelay time.Duration
 }
 
 func (s *AgentSuite) SetUpSuite(c *gc.C) {
 	s.JujuConnSuite.SetUpSuite(c)
 
-	s.oldRestartDelay = worker.RestartDelay
-	// We could use testing.ShortWait, but this thrashes quite
-	// a bit when some tests are restarting every 50ms for 10 seconds,
-	// so use a slightly more friendly delay.
-	worker.RestartDelay = 250 * time.Millisecond
 	s.PatchValue(&cmdutil.EnsureMongoServer, func(mongo.EnsureServerParams) error {
 		return nil
 	})
-}
-
-func (s *AgentSuite) TearDownSuite(c *gc.C) {
-	s.JujuConnSuite.TearDownSuite(c)
-	worker.RestartDelay = s.oldRestartDelay
 }
 
 func (s *AgentSuite) SetUpTest(c *gc.C) {

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -280,7 +280,7 @@ func MachineAgentFactoryFn(
 			agentConfWriter,
 			bufferedLogs,
 			NewUpgradeWorkerContext(),
-			worker.NewRunner(cmdutil.IsFatal, cmdutil.MoreImportant),
+			worker.NewRunner(cmdutil.IsFatal, cmdutil.MoreImportant, worker.RestartDelay),
 			loopDeviceManager,
 			rootDir,
 		)
@@ -1087,7 +1087,7 @@ func (a *MachineAgent) StateWorker() (worker.Worker, error) {
 		case state.JobManageEnviron:
 			useMultipleCPUs()
 			a.startWorkerAfterUpgrade(runner, "env worker manager", func() (worker.Worker, error) {
-				return envworkermanager.NewEnvWorkerManager(st, a.startEnvWorkers), nil
+				return envworkermanager.NewEnvWorkerManager(st, a.startEnvWorkers, worker.RestartDelay), nil
 			})
 			a.startWorkerAfterUpgrade(runner, "peergrouper", func() (worker.Worker, error) {
 				return peergrouperNew(st)
@@ -1846,7 +1846,7 @@ func (a *MachineAgent) uninstallAgent(agentConfig agent.Config) error {
 }
 
 func newConnRunner(conns ...cmdutil.Pinger) worker.Runner {
-	return worker.NewRunner(cmdutil.ConnectionIsFatal(logger, conns...), cmdutil.MoreImportant)
+	return worker.NewRunner(cmdutil.ConnectionIsFatal(logger, conns...), cmdutil.MoreImportant, worker.RestartDelay)
 }
 
 type MongoSessioner interface {

--- a/cmd/jujud/agent/unit.go
+++ b/cmd/jujud/agent/unit.go
@@ -85,7 +85,7 @@ func (a *UnitAgent) Init(args []string) error {
 	if err := a.AgentConf.CheckArgs(args); err != nil {
 		return err
 	}
-	a.runner = worker.NewRunner(cmdutil.IsFatal, cmdutil.MoreImportant)
+	a.runner = worker.NewRunner(cmdutil.IsFatal, cmdutil.MoreImportant, worker.RestartDelay)
 
 	if !a.logToStdErr {
 		if err := a.ReadConfig(a.Tag().String()); err != nil {

--- a/cmd/jujud/agent/upgrade_test.go
+++ b/cmd/jujud/agent/upgrade_test.go
@@ -502,7 +502,7 @@ func (s *UpgradeSuite) TestLoginsDuringUpgrade(c *gc.C) {
 	s.PatchValue(&upgradesPerformUpgrade, fakePerformUpgrade)
 
 	// Start the API server and upgrade-steps works just as the agent would.
-	runner := worker.NewRunner(cmdutil.IsFatal, cmdutil.MoreImportant)
+	runner := worker.NewRunner(cmdutil.IsFatal, cmdutil.MoreImportant, 250*time.Millisecond)
 	defer func() {
 		close(abort)
 		runner.Kill()

--- a/worker/envworkermanager/envworkermanager.go
+++ b/worker/envworkermanager/envworkermanager.go
@@ -4,6 +4,8 @@
 package envworkermanager
 
 import (
+	"time"
+
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names"
@@ -21,15 +23,12 @@ var logger = loggo.GetLogger("juju.worker.envworkermanager")
 // needs to run on a per environment basis. It takes a function which will
 // be called to start a worker for a new environment. This worker
 // will be killed when an environment goes away.
-func NewEnvWorkerManager(
-	st InitialState,
-	startEnvWorker func(InitialState, *state.State) (worker.Worker, error),
-) worker.Worker {
+func NewEnvWorkerManager(st InitialState, fn func(InitialState, *state.State) (worker.Worker, error), delay time.Duration) worker.Worker {
 	m := &envWorkerManager{
 		st:             st,
-		startEnvWorker: startEnvWorker,
+		startEnvWorker: fn,
 	}
-	m.runner = worker.NewRunner(cmdutil.IsFatal, cmdutil.MoreImportant)
+	m.runner = worker.NewRunner(cmdutil.IsFatal, cmdutil.MoreImportant, delay)
 	go func() {
 		defer m.tomb.Done()
 		m.tomb.Kill(m.loop())

--- a/worker/envworkermanager/envworkermanager_test.go
+++ b/worker/envworkermanager/envworkermanager_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names"
-	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"launchpad.net/tomb"
@@ -25,10 +24,6 @@ import (
 )
 
 func TestPackage(t *stdtesting.T) {
-	if jujutesting.RaceEnabled {
-		t.Skip("skipping package under -race, see LP 1519144")
-	}
-
 	testing.MgoTestPackage(t)
 }
 
@@ -48,6 +43,11 @@ func (s *suite) SetUpTest(c *gc.C) {
 	s.startErr = nil
 }
 
+func (s *suite) TearDownTest(c *gc.C) {
+	close(s.runnerC)
+	s.StateSuite.TearDownTest(c)
+}
+
 func (s *suite) makeEnvironment(c *gc.C) *state.State {
 	st := s.factory.MakeEnvironment(c, nil)
 	s.AddCleanup(func(*gc.C) { st.Close() })
@@ -58,7 +58,7 @@ func (s *suite) TestStartsWorkersForPreExistingEnvs(c *gc.C) {
 	moreState := s.makeEnvironment(c)
 
 	var seenEnvs []string
-	m := envworkermanager.NewEnvWorkerManager(s.State, s.startEnvWorker)
+	m := envworkermanager.NewEnvWorkerManager(s.State, s.startEnvWorker, time.Millisecond)
 	defer m.Kill()
 	for _, r := range s.seeRunnersStart(c, 2) {
 		seenEnvs = append(seenEnvs, r.envUUID)
@@ -69,7 +69,7 @@ func (s *suite) TestStartsWorkersForPreExistingEnvs(c *gc.C) {
 }
 
 func (s *suite) TestStartsWorkersForNewEnv(c *gc.C) {
-	m := envworkermanager.NewEnvWorkerManager(s.State, s.startEnvWorker)
+	m := envworkermanager.NewEnvWorkerManager(s.State, s.startEnvWorker, time.Millisecond)
 	defer m.Kill()
 	s.seeRunnersStart(c, 1) // Runner for state server env
 
@@ -80,7 +80,7 @@ func (s *suite) TestStartsWorkersForNewEnv(c *gc.C) {
 }
 
 func (s *suite) TestStopsWorkersWhenEnvGoesAway(c *gc.C) {
-	m := envworkermanager.NewEnvWorkerManager(s.State, s.startEnvWorker)
+	m := envworkermanager.NewEnvWorkerManager(s.State, s.startEnvWorker, time.Millisecond)
 	defer m.Kill()
 	runner0 := s.seeRunnersStart(c, 1)[0]
 
@@ -119,7 +119,7 @@ func (s *suite) TestStopsWorkersWhenEnvGoesAway(c *gc.C) {
 func (s *suite) TestKillPropagates(c *gc.C) {
 	s.makeEnvironment(c)
 
-	m := envworkermanager.NewEnvWorkerManager(s.State, s.startEnvWorker)
+	m := envworkermanager.NewEnvWorkerManager(s.State, s.startEnvWorker, time.Millisecond)
 	runners := s.seeRunnersStart(c, 2)
 	c.Assert(runners[0].killed, jc.IsFalse)
 	c.Assert(runners[1].killed, jc.IsFalse)
@@ -158,7 +158,7 @@ func (s *suite) TestLoopExitKillsRunner(c *gc.C) {
 	// m.st.GetEnvironment(tag) fail with any error other than NotFound
 	st := newStateWithFailingGetEnvironment(s.State)
 	uuid := st.EnvironUUID()
-	m := envworkermanager.NewEnvWorkerManager(st, s.startEnvWorker)
+	m := envworkermanager.NewEnvWorkerManager(st, s.startEnvWorker, time.Millisecond)
 	defer m.Kill()
 
 	// First time: runners started
@@ -187,7 +187,7 @@ func (s *suite) TestWorkerErrorIsPropagatedWhenKilled(c *gc.C) {
 		return &errorWhenKilledWorker{
 			err: &cmdutil.FatalError{"an error"},
 		}, nil
-	})
+	}, time.Millisecond)
 	st.sendEnvChange(st.EnvironUUID())
 	s.State.StartSync()
 	<-started
@@ -221,7 +221,7 @@ func (s *suite) TestNothingHappensWhenEnvIsSeenAgain(c *gc.C) {
 	st := newStateWithFakeWatcher(s.State)
 	uuid := st.EnvironUUID()
 
-	m := envworkermanager.NewEnvWorkerManager(st, s.startEnvWorker)
+	m := envworkermanager.NewEnvWorkerManager(st, s.startEnvWorker, time.Millisecond)
 	defer m.Kill()
 
 	// First time: runners started
@@ -238,7 +238,7 @@ func (s *suite) TestNothingHappensWhenUnknownEnvReported(c *gc.C) {
 	// the EnvWorkerManager is coming up (unlikely but possible).
 	st := newStateWithFakeWatcher(s.State)
 
-	m := envworkermanager.NewEnvWorkerManager(st, s.startEnvWorker)
+	m := envworkermanager.NewEnvWorkerManager(st, s.startEnvWorker, time.Millisecond)
 	defer m.Kill()
 
 	st.sendEnvChange("unknown-env-uuid")
@@ -250,7 +250,7 @@ func (s *suite) TestNothingHappensWhenUnknownEnvReported(c *gc.C) {
 }
 
 func (s *suite) TestFatalErrorKillsEnvWorkerManager(c *gc.C) {
-	m := envworkermanager.NewEnvWorkerManager(s.State, s.startEnvWorker)
+	m := envworkermanager.NewEnvWorkerManager(s.State, s.startEnvWorker, time.Millisecond)
 	runner := s.seeRunnersStart(c, 1)[0]
 
 	runner.tomb.Kill(worker.ErrTerminateAgent)
@@ -261,9 +261,7 @@ func (s *suite) TestFatalErrorKillsEnvWorkerManager(c *gc.C) {
 }
 
 func (s *suite) TestNonFatalErrorCausesRunnerRestart(c *gc.C) {
-	s.PatchValue(&worker.RestartDelay, time.Millisecond)
-
-	m := envworkermanager.NewEnvWorkerManager(s.State, s.startEnvWorker)
+	m := envworkermanager.NewEnvWorkerManager(s.State, s.startEnvWorker, time.Millisecond)
 	defer m.Kill()
 	runner0 := s.seeRunnersStart(c, 1)[0]
 
@@ -278,13 +276,13 @@ func (s *suite) TestStateIsClosedIfStartEnvWorkersFails(c *gc.C) {
 	// dirty socket detection will pick up the leaked socket and
 	// panic.
 	s.startErr = worker.ErrTerminateAgent // This will make envWorkerManager exit.
-	m := envworkermanager.NewEnvWorkerManager(s.State, s.startEnvWorker)
+	m := envworkermanager.NewEnvWorkerManager(s.State, s.startEnvWorker, time.Millisecond)
 	waitOrFatal(c, m.Wait)
 }
 
 func (s *suite) seeRunnersStart(c *gc.C, expectedCount int) []*fakeRunner {
 	if expectedCount < 1 {
-		panic("expectedCount must be >= 1")
+		c.Fatal("expectedCount must be >= 1")
 	}
 	s.State.StartSync()
 	runners := make([]*fakeRunner, 0, expectedCount)

--- a/worker/metricworker/metricmanager.go
+++ b/worker/metricworker/metricmanager.go
@@ -21,7 +21,7 @@ func NewMetricsManager(client metricsmanager.MetricsManagerClient) (worker.Runne
 	moreImportant := func(error, error) bool {
 		return false
 	}
-	runner := worker.NewRunner(isFatal, moreImportant)
+	runner := worker.NewRunner(isFatal, moreImportant, worker.RestartDelay)
 	err := runner.StartWorker("sender", func() (worker.Worker, error) {
 		return NewSender(client), nil
 	})

--- a/worker/provisioner/container_initialisation_test.go
+++ b/worker/provisioner/container_initialisation_test.go
@@ -99,7 +99,7 @@ func (s *ContainerSetupSuite) TearDownTest(c *gc.C) {
 
 func (s *ContainerSetupSuite) setupContainerWorker(c *gc.C, tag names.MachineTag) (worker.StringsWatchHandler, worker.Runner) {
 	testing.PatchExecutable(c, s, "ubuntu-cloudimg-query", containertesting.FakeLxcURLScript)
-	runner := worker.NewRunner(allFatal, noImportance)
+	runner := worker.NewRunner(allFatal, noImportance, worker.RestartDelay)
 	pr := s.st.Provisioner()
 	machine, err := pr.Machine(tag)
 	c.Assert(err, jc.ErrorIsNil)

--- a/worker/runner.go
+++ b/worker/runner.go
@@ -12,7 +12,7 @@ import (
 
 // RestartDelay holds the length of time that a worker
 // will wait between exiting and restarting.
-var RestartDelay = 3 * time.Second
+const RestartDelay = 3 * time.Second
 
 // Worker is implemented by a running worker.
 type Worker interface {
@@ -41,9 +41,11 @@ type runner struct {
 	startedc      chan startInfo
 	isFatal       func(error) bool
 	moreImportant func(err0, err1 error) bool
-}
 
-var _ Runner = (*runner)(nil)
+	// restartDelay holds the length of time that a worker
+	// will wait between exiting and restarting.
+	restartDelay time.Duration
+}
 
 type startReq struct {
 	id    string
@@ -70,7 +72,7 @@ type doneInfo struct {
 // The function isFatal(err) returns whether err is a fatal error.  The
 // function moreImportant(err0, err1) returns whether err0 is considered
 // more important than err1.
-func NewRunner(isFatal func(error) bool, moreImportant func(err0, err1 error) bool) Runner {
+func NewRunner(isFatal func(error) bool, moreImportant func(err0, err1 error) bool, restartDelay time.Duration) Runner {
 	runner := &runner{
 		startc:        make(chan startReq),
 		stopc:         make(chan string),
@@ -78,6 +80,7 @@ func NewRunner(isFatal func(error) bool, moreImportant func(err0, err1 error) bo
 		startedc:      make(chan startInfo),
 		isFatal:       isFatal,
 		moreImportant: moreImportant,
+		restartDelay:  restartDelay,
 	}
 	go func() {
 		defer runner.tomb.Done()
@@ -172,7 +175,7 @@ func (runner *runner) run() error {
 			if info == nil {
 				workers[req.id] = &workerInfo{
 					start:        req.start,
-					restartDelay: RestartDelay,
+					restartDelay: runner.restartDelay,
 				}
 				go runner.runWorker(0, req.id, req.start)
 				break
@@ -232,7 +235,7 @@ func (runner *runner) run() error {
 				break
 			}
 			go runner.runWorker(workerInfo.restartDelay, info.id, workerInfo.start)
-			workerInfo.restartDelay = RestartDelay
+			workerInfo.restartDelay = runner.restartDelay
 		}
 	}
 }

--- a/worker/runner_test.go
+++ b/worker/runner_test.go
@@ -41,14 +41,8 @@ func noImportance(err0, err1 error) bool {
 	return false
 }
 
-func (s *runnerSuite) SetUpTest(c *gc.C) {
-	s.BaseSuite.SetUpTest(c)
-	// Avoid patching RestartDealy to zero, as it changes worker behaviour.
-	s.PatchValue(&worker.RestartDelay, time.Duration(time.Millisecond))
-}
-
 func (*runnerSuite) TestOneWorkerStart(c *gc.C) {
-	runner := worker.NewRunner(noneFatal, noImportance)
+	runner := worker.NewRunner(noneFatal, noImportance, time.Millisecond)
 	starter := newTestWorkerStarter()
 	err := runner.StartWorker("id", testWorkerStart(starter))
 	c.Assert(err, jc.ErrorIsNil)
@@ -59,7 +53,7 @@ func (*runnerSuite) TestOneWorkerStart(c *gc.C) {
 }
 
 func (*runnerSuite) TestOneWorkerFinish(c *gc.C) {
-	runner := worker.NewRunner(noneFatal, noImportance)
+	runner := worker.NewRunner(noneFatal, noImportance, time.Millisecond)
 	starter := newTestWorkerStarter()
 	err := runner.StartWorker("id", testWorkerStart(starter))
 	c.Assert(err, jc.ErrorIsNil)
@@ -73,7 +67,7 @@ func (*runnerSuite) TestOneWorkerFinish(c *gc.C) {
 }
 
 func (*runnerSuite) TestOneWorkerRestart(c *gc.C) {
-	runner := worker.NewRunner(noneFatal, noImportance)
+	runner := worker.NewRunner(noneFatal, noImportance, time.Millisecond)
 	starter := newTestWorkerStarter()
 	err := runner.StartWorker("id", testWorkerStart(starter))
 	c.Assert(err, jc.ErrorIsNil)
@@ -91,7 +85,7 @@ func (*runnerSuite) TestOneWorkerRestart(c *gc.C) {
 }
 
 func (*runnerSuite) TestOneWorkerStartFatalError(c *gc.C) {
-	runner := worker.NewRunner(allFatal, noImportance)
+	runner := worker.NewRunner(allFatal, noImportance, time.Millisecond)
 	starter := newTestWorkerStarter()
 	starter.startErr = errors.New("cannot start test task")
 	err := runner.StartWorker("id", testWorkerStart(starter))
@@ -101,7 +95,7 @@ func (*runnerSuite) TestOneWorkerStartFatalError(c *gc.C) {
 }
 
 func (*runnerSuite) TestOneWorkerDieFatalError(c *gc.C) {
-	runner := worker.NewRunner(allFatal, noImportance)
+	runner := worker.NewRunner(allFatal, noImportance, time.Millisecond)
 	starter := newTestWorkerStarter()
 	err := runner.StartWorker("id", testWorkerStart(starter))
 	c.Assert(err, jc.ErrorIsNil)
@@ -114,7 +108,7 @@ func (*runnerSuite) TestOneWorkerDieFatalError(c *gc.C) {
 }
 
 func (*runnerSuite) TestOneWorkerStartStop(c *gc.C) {
-	runner := worker.NewRunner(allFatal, noImportance)
+	runner := worker.NewRunner(allFatal, noImportance, time.Millisecond)
 	starter := newTestWorkerStarter()
 	err := runner.StartWorker("id", testWorkerStart(starter))
 	c.Assert(err, jc.ErrorIsNil)
@@ -126,7 +120,7 @@ func (*runnerSuite) TestOneWorkerStartStop(c *gc.C) {
 }
 
 func (*runnerSuite) TestOneWorkerStopFatalError(c *gc.C) {
-	runner := worker.NewRunner(allFatal, noImportance)
+	runner := worker.NewRunner(allFatal, noImportance, time.Millisecond)
 	starter := newTestWorkerStarter()
 	starter.stopErr = errors.New("stop error")
 	err := runner.StartWorker("id", testWorkerStart(starter))
@@ -139,8 +133,7 @@ func (*runnerSuite) TestOneWorkerStopFatalError(c *gc.C) {
 }
 
 func (*runnerSuite) TestOneWorkerStartWhenStopping(c *gc.C) {
-	worker.RestartDelay = 3 * time.Second
-	runner := worker.NewRunner(allFatal, noImportance)
+	runner := worker.NewRunner(allFatal, noImportance, 3*time.Second)
 	starter := newTestWorkerStarter()
 	starter.stopWait = make(chan struct{})
 
@@ -166,8 +159,8 @@ func (*runnerSuite) TestOneWorkerStartWhenStopping(c *gc.C) {
 }
 
 func (*runnerSuite) TestOneWorkerRestartDelay(c *gc.C) {
-	worker.RestartDelay = 100 * time.Millisecond
-	runner := worker.NewRunner(noneFatal, noImportance)
+	const delay = 100 * time.Millisecond
+	runner := worker.NewRunner(noneFatal, noImportance, delay)
 	starter := newTestWorkerStarter()
 	err := runner.StartWorker("id", testWorkerStart(starter))
 	c.Assert(err, jc.ErrorIsNil)
@@ -177,8 +170,8 @@ func (*runnerSuite) TestOneWorkerRestartDelay(c *gc.C) {
 	t0 := time.Now()
 	starter.assertStarted(c, true)
 	restartDuration := time.Since(t0)
-	if restartDuration < worker.RestartDelay {
-		c.Fatalf("restart delay was not respected; got %v want %v", restartDuration, worker.RestartDelay)
+	if restartDuration < delay {
+		c.Fatalf("restart delay was not respected; got %v want %v", restartDuration, delay)
 	}
 	c.Assert(worker.Stop(runner), gc.IsNil)
 }
@@ -194,7 +187,7 @@ func (*runnerSuite) TestErrorImportance(c *gc.C) {
 		return err0.(errorLevel) > err1.(errorLevel)
 	}
 	id := func(i int) string { return fmt.Sprint(i) }
-	runner := worker.NewRunner(allFatal, moreImportant)
+	runner := worker.NewRunner(allFatal, moreImportant, time.Millisecond)
 	for i := 0; i < 10; i++ {
 		starter := newTestWorkerStarter()
 		starter.stopErr = errorLevel(i)
@@ -208,19 +201,19 @@ func (*runnerSuite) TestErrorImportance(c *gc.C) {
 }
 
 func (*runnerSuite) TestStartWorkerWhenDead(c *gc.C) {
-	runner := worker.NewRunner(allFatal, noImportance)
+	runner := worker.NewRunner(allFatal, noImportance, time.Millisecond)
 	c.Assert(worker.Stop(runner), gc.IsNil)
 	c.Assert(runner.StartWorker("foo", nil), gc.Equals, worker.ErrDead)
 }
 
 func (*runnerSuite) TestStopWorkerWhenDead(c *gc.C) {
-	runner := worker.NewRunner(allFatal, noImportance)
+	runner := worker.NewRunner(allFatal, noImportance, time.Millisecond)
 	c.Assert(worker.Stop(runner), gc.IsNil)
 	c.Assert(runner.StopWorker("foo"), gc.Equals, worker.ErrDead)
 }
 
 func (*runnerSuite) TestAllWorkersStoppedWhenOneDiesWithFatalError(c *gc.C) {
-	runner := worker.NewRunner(allFatal, noImportance)
+	runner := worker.NewRunner(allFatal, noImportance, time.Millisecond)
 	var starters []*testWorkerStarter
 	for i := 0; i < 10; i++ {
 		starter := newTestWorkerStarter()
@@ -244,7 +237,7 @@ func (*runnerSuite) TestFatalErrorWhileStarting(c *gc.C) {
 	// Original deadlock problem that this tests for:
 	// A worker dies with fatal error while another worker
 	// is inside start(). runWorker can't send startInfo on startedc.
-	runner := worker.NewRunner(allFatal, noImportance)
+	runner := worker.NewRunner(allFatal, noImportance, time.Millisecond)
 
 	slowStarter := newTestWorkerStarter()
 	// make the startNotify channel synchronous so
@@ -282,7 +275,7 @@ func (*runnerSuite) TestFatalErrorWhileSelfStartWorker(c *gc.C) {
 	// A worker tries to call StartWorker in its start function
 	// at the same time another worker dies with a fatal error.
 	// It might not be able to send on startc.
-	runner := worker.NewRunner(allFatal, noImportance)
+	runner := worker.NewRunner(allFatal, noImportance, time.Millisecond)
 
 	selfStarter := newTestWorkerStarter()
 	// make the startNotify channel synchronous so

--- a/worker/singular/mongo_test.go
+++ b/worker/singular/mongo_test.go
@@ -174,10 +174,9 @@ func (a *agent) mongoWorker() (worker.Worker, error) {
 		localHostPort: a.hostPort,
 		session:       session,
 	}
-	runner := worker.NewRunner(
-		connectionIsFatal(mc),
-		func(err0, err1 error) bool { return true },
-	)
+
+	fn := func(err0, err1 error) bool { return true }
+	runner := worker.NewRunner(connectionIsFatal(mc), fn, worker.RestartDelay)
 	singularRunner, err := singular.New(runner, mc)
 	if err != nil {
 		return nil, fmt.Errorf("cannot start singular runner: %v", err)

--- a/worker/singular/singular_test.go
+++ b/worker/singular/singular_test.go
@@ -172,6 +172,7 @@ func newRunner() worker.Runner {
 			return err == errFatal
 		},
 		func(err0, err1 error) bool { return true },
+		worker.RestartDelay,
 	)
 }
 


### PR DESCRIPTION
Fixes LP 1519144

Many tests try to patch, or just straight overwrite the value of
worker.RestartDelay. This is unsafe because of the way the worker's
Run method operates.

This PR forces worker.RestartDelay to be a constant and allows callers
creating worker.Workers to provide the restart delay they wish.

(Review request: http://reviews.vapour.ws/r/3232/)