### PR TITLE
Error out on destruction if there is no maas-agent-name.

### DIFF
--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -1908,6 +1908,13 @@ func (env *maasEnviron) Storage() storage.Storage {
 }
 
 func (environ *maasEnviron) Destroy() error {
+	if environ.ecfg().maasAgentName() == "" {
+		logger.Warningf("No MAAS agent name specified.\n\n" +
+			"The environment is either not running or from a very early Juju version.\n" +
+			"It is not safe to release all MAAS instances without an agent name.\n" +
+			"If the environment is still running, please manually decomission the MAAS machines.")
+		return errors.New("unsafe destruction")
+	}
 	if !environ.supportsDevices {
 		// Warn the user that container resources can leak.
 		logger.Warningf(noDevicesWarning)

--- a/provider/maas/environ_test.go
+++ b/provider/maas/environ_test.go
@@ -147,6 +147,16 @@ func (*environSuite) TestSetConfigAllowsEmptyFromNilAgentName(c *gc.C) {
 	c.Check(err, gc.ErrorMatches, ".*cannot change maas-agent-name.*")
 }
 
+func (*environSuite) TestDestroyWithEmptyAgentName(c *gc.C) {
+	// Related bug #1256179, comment as above.
+	baseCfg := getSimpleTestConfig(c, coretesting.Attrs{"maas-agent-name": ""})
+	env, err := maas.NewEnviron(baseCfg)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = env.Destroy()
+	c.Assert(err, gc.ErrorMatches, "unsafe destruction")
+}
+
 func (*environSuite) TestSetConfigAllowsChangingNilAgentNameToEmptyString(c *gc.C) {
 	oldCfg := getSimpleTestConfig(c, nil)
 	newCfgTwo := getSimpleTestConfig(c, coretesting.Attrs{"maas-agent-name": ""})


### PR DESCRIPTION
Fixes http://pad.lv/1490865.

The maas-agent-name was not set for Juju versions < 1.18, so almost all MAAS environments in existence (if not all) will have this set.

(Review request: http://reviews.vapour.ws/r/3240/)