### PR TITLE
Add a public API facade and client to the new resources component.

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -49,7 +49,7 @@ gopkg.in/check.v1	git	b3d3430320d4260e5fea99841af984b3badcea63	2015-06-26T10:50:
 gopkg.in/errgo.v1	git	66cb46252b94c1f3d65646f54ee8043ab38d766c	2015-10-07T15:31:57Z
 gopkg.in/goose.v1	git	e4a91e8b8323b8eef6fe41a66fd3ac6120520bb0	2015-11-13T22:25:24Z
 gopkg.in/inconshreveable/log15.v2	git	b105bd37f74e5d9dc7b6ad7806715c7a2b83fd3f	2015-09-21T21:38:54Z
-gopkg.in/juju/charm.v6-unstable	git	ec819671565a1e9099ad585b536889b1cda97442	2015-11-24T23:14:05Z
+gopkg.in/juju/charm.v6-unstable	git	010adbf0b5c40796b3b4086d3cc84f5f514a5f45	2015-12-01T18:46:23Z
 gopkg.in/juju/charmrepo.v2-unstable	git	e738044bd65b121158cd7f37910e0debb3cfa0a5	2015-11-23T04:36:59Z
 gopkg.in/juju/charmstore.v5-unstable	git	a3afbf1cc0b2438ef7f7fc028cc54b19bd4f91e3	2015-11-19T15:07:26Z
 gopkg.in/juju/environschema.v1	git	7bea6a9a531586600a7741e9bdd5e3c978ffda15	2015-10-20T16:12:31Z

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -49,7 +49,7 @@ gopkg.in/check.v1	git	b3d3430320d4260e5fea99841af984b3badcea63	2015-06-26T10:50:
 gopkg.in/errgo.v1	git	66cb46252b94c1f3d65646f54ee8043ab38d766c	2015-10-07T15:31:57Z
 gopkg.in/goose.v1	git	e4a91e8b8323b8eef6fe41a66fd3ac6120520bb0	2015-11-13T22:25:24Z
 gopkg.in/inconshreveable/log15.v2	git	b105bd37f74e5d9dc7b6ad7806715c7a2b83fd3f	2015-09-21T21:38:54Z
-gopkg.in/juju/charm.v6-unstable	git	a3d228ef5292531219d17d47679b260580fba1a8	2015-11-19T07:39:58Z
+gopkg.in/juju/charm.v6-unstable	git	ec819671565a1e9099ad585b536889b1cda97442	2015-11-24T23:14:05Z
 gopkg.in/juju/charmrepo.v2-unstable	git	e738044bd65b121158cd7f37910e0debb3cfa0a5	2015-11-23T04:36:59Z
 gopkg.in/juju/charmstore.v5-unstable	git	a3afbf1cc0b2438ef7f7fc028cc54b19bd4f91e3	2015-11-19T15:07:26Z
 gopkg.in/juju/environschema.v1	git	7bea6a9a531586600a7741e9bdd5e3c978ffda15	2015-10-20T16:12:31Z

--- a/resource/api/apitesting/spec.go
+++ b/resource/api/apitesting/spec.go
@@ -6,16 +6,16 @@ package apitesting
 import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-	"gopkg.in/juju/charm.v6-unstable"
+	charmresource "gopkg.in/juju/charm.v6-unstable/resource"
 
 	"github.com/juju/juju/resource"
 	"github.com/juju/juju/resource/api"
 )
 
 func NewSpec(c *gc.C, name string) (resource.Spec, api.ResourceSpec) {
-	info := charm.ResourceInfo{
+	info := charmresource.Info{
 		Name: name,
-		Type: charm.ResourceTypeFile,
+		Type: charmresource.TypeFile,
 		Path: name + ".tgz",
 	}
 	spec, err := resource.NewSpec(info, resource.OriginUpload, "")

--- a/resource/api/apitesting/spec.go
+++ b/resource/api/apitesting/spec.go
@@ -1,0 +1,32 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package apitesting
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/charm.v6-unstable"
+
+	"github.com/juju/juju/resource"
+	"github.com/juju/juju/resource/api"
+)
+
+func NewSpec(c *gc.C, name string) (resource.Spec, api.ResourceSpec) {
+	info := charm.ResourceInfo{
+		Name: name,
+		Type: charm.ResourceTypeFile,
+		Path: name + ".tgz",
+	}
+	spec, err := resource.NewSpec(info, resource.OriginUpload, "")
+	c.Assert(err, jc.ErrorIsNil)
+
+	apiSpec := api.ResourceSpec{
+		Name:   name,
+		Type:   "file",
+		Path:   name + ".tgz",
+		Origin: "upload",
+	}
+
+	return spec, apiSpec
+}

--- a/resource/api/client/client.go
+++ b/resource/api/client/client.go
@@ -5,6 +5,28 @@ package client
 
 import (
 	"github.com/juju/loggo"
+	"io"
 )
 
 var logger = loggo.GetLogger("juju.resource.api.client")
+
+type facadeCaller interface {
+	FacadeCall(request string, params, response interface{}) error
+}
+
+type rawAPI interface {
+	facadeCaller
+	io.Closer
+}
+
+// Client is the public client for the resources API facade.
+type Client struct {
+	*specClient
+}
+
+// NewClient returns a new Client for the given raw API caller.
+func NewClient(raw rawAPI) *Client {
+	return &Client{
+		specClient: &specClient{raw},
+	}
+}

--- a/resource/api/client/client.go
+++ b/resource/api/client/client.go
@@ -1,0 +1,10 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package client
+
+import (
+	"github.com/juju/loggo"
+)
+
+var logger = loggo.GetLogger("juju.resource.api.client")

--- a/resource/api/client/client.go
+++ b/resource/api/client/client.go
@@ -5,18 +5,15 @@ package client
 
 import (
 	"github.com/juju/loggo"
-	"io"
 )
 
 var logger = loggo.GetLogger("juju.resource.api.client")
 
-type facadeCaller interface {
-	FacadeCall(request string, params, response interface{}) error
-}
+// TODO(ericsnow) Move FacadeCaller to a component-central package.
 
-type rawAPI interface {
-	facadeCaller
-	io.Closer
+// FacadeCaller has the api/base.FacadeCaller methods needed for the component.
+type FacadeCaller interface {
+	FacadeCall(request string, params, response interface{}) error
 }
 
 // Client is the public client for the resources API facade.
@@ -25,7 +22,7 @@ type Client struct {
 }
 
 // NewClient returns a new Client for the given raw API caller.
-func NewClient(raw rawAPI) *Client {
+func NewClient(raw FacadeCaller) *Client {
 	return &Client{
 		specClient: &specClient{raw},
 	}

--- a/resource/api/client/package_test.go
+++ b/resource/api/client/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package client_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/resource/api/client/spec.go
+++ b/resource/api/client/spec.go
@@ -14,7 +14,7 @@ import (
 // specClient provides methods for interacting with resource specs
 // in Juju's public RPC API.
 type specClient struct {
-	rawAPI
+	FacadeCaller
 }
 
 // ListSpecs calls the ListSpecs API server method with

--- a/resource/api/client/spec.go
+++ b/resource/api/client/spec.go
@@ -1,0 +1,45 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package client
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/names"
+
+	"github.com/juju/juju/resource"
+	"github.com/juju/juju/resource/api"
+)
+
+// specClient provides methods for interacting with resource specs
+// in Juju's public RPC API.
+type specClient struct {
+	rawAPI
+}
+
+// ListSpecs calls the ListSpecs API server method with
+// the given service name.
+func (c specClient) ListSpecs(service string) ([]resource.Spec, error) {
+	if service == "" {
+		return nil, errors.New("missing service")
+	}
+
+	var result api.ListSpecsResults
+	args := api.ListSpecsArgs{
+		Service: names.NewServiceTag(service).String(),
+	}
+	if err := c.FacadeCall("ListSpecs", &args, &result); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	specs := make([]resource.Spec, len(result.Results))
+	for i, apiSpec := range result.Results {
+		spec, err := api.API2ResourceSpec(apiSpec)
+		if err != nil {
+			// We should never see this happen; we control the input safely.
+			return nil, errors.Trace(err)
+		}
+		specs[i] = spec
+	}
+	return specs, nil
+}

--- a/resource/api/client/spec.go
+++ b/resource/api/client/spec.go
@@ -26,7 +26,7 @@ func (c specClient) ListSpecs(service string) ([]resource.Spec, error) {
 
 	var result api.ListSpecsResults
 	args := api.ListSpecsArgs{
-		Service: names.NewServiceTag(service).String(),
+		Service: names.NewServiceTag(service),
 	}
 	if err := c.FacadeCall("ListSpecs", &args, &result); err != nil {
 		return nil, errors.Trace(err)

--- a/resource/api/client/spec_test.go
+++ b/resource/api/client/spec_test.go
@@ -1,0 +1,97 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package client_test
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/resource"
+	"github.com/juju/juju/resource/api"
+	"github.com/juju/juju/resource/api/client"
+)
+
+var _ = gc.Suite(&specSuite{})
+
+type specSuite struct {
+	testing.IsolationSuite
+
+	stub    *testing.Stub
+	facade  *stubFacade
+	apiSpec api.ResourceSpec
+}
+
+func (s *specSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+
+	s.stub = &testing.Stub{}
+	s.facade = &stubFacade{stub: s.stub}
+	s.apiSpec = api.ResourceSpec{
+		Name:     "spam",
+		Type:     "file",
+		Path:     "spam.tgz",
+		Comment:  "you need it",
+		Origin:   "upload",
+		Revision: "",
+	}
+}
+
+func (s *specSuite) TestListSpecOkay(c *gc.C) {
+	s.facade.FacadeCallFn = func(_ string, _, response interface{}) error {
+		typedResponse, ok := response.(*api.ListSpecsResults)
+		c.Assert(ok, gc.Equals, true)
+		typedResponse.Results = append(typedResponse.Results, s.apiSpec)
+		return nil
+	}
+
+	cl := client.NewClient(s.facade)
+
+	specs, err := cl.ListSpecs("a-service")
+	c.Assert(err, jc.ErrorIsNil)
+
+	expected, _ := api.API2ResourceSpec(s.apiSpec)
+	c.Check(specs, jc.DeepEquals, []resource.Spec{
+		expected,
+	})
+	c.Check(s.stub.Calls(), gc.HasLen, 1)
+	s.stub.CheckCall(c, 0, "FacadeCall",
+		"ListSpecs",
+		&api.ListSpecsArgs{
+			Service: "service-a-service",
+		},
+		&api.ListSpecsResults{
+			Results: []api.ResourceSpec{s.apiSpec},
+		},
+	)
+}
+
+// TODO(ericsnow) Move this to a common testing package.
+
+type stubFacade struct {
+	stub         *testing.Stub
+	FacadeCallFn func(name string, params, response interface{}) error
+}
+
+func (s *stubFacade) FacadeCall(request string, params, response interface{}) error {
+	s.stub.AddCall("FacadeCall", request, params, response)
+	if err := s.stub.NextErr(); err != nil {
+		return errors.Trace(err)
+	}
+
+	if s.FacadeCallFn != nil {
+		return s.FacadeCallFn(request, params, response)
+	}
+	return nil
+}
+
+func (s *stubFacade) Close() error {
+	s.stub.AddCall("Close")
+	if err := s.stub.NextErr(); err != nil {
+		return errors.Trace(err)
+	}
+
+	return nil
+}

--- a/resource/api/client/spec_test.go
+++ b/resource/api/client/spec_test.go
@@ -5,6 +5,7 @@ package client_test
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/names"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -60,12 +61,18 @@ func (s *specSuite) TestListSpecOkay(c *gc.C) {
 	s.stub.CheckCall(c, 0, "FacadeCall",
 		"ListSpecs",
 		&api.ListSpecsArgs{
-			Service: "service-a-service",
+			Service: newServiceTag(c, "service-a-service"),
 		},
 		&api.ListSpecsResults{
 			Results: []api.ResourceSpec{s.apiSpec},
 		},
 	)
+}
+
+func newServiceTag(c *gc.C, service string) names.ServiceTag {
+	tag, err := names.ParseTag(service)
+	c.Assert(err, jc.ErrorIsNil)
+	return tag.(names.ServiceTag)
 }
 
 // TODO(ericsnow) Move this to a common testing package.

--- a/resource/api/data.go
+++ b/resource/api/data.go
@@ -1,0 +1,37 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package api
+
+// ListSpecsArgs are the arguments for the ListSpecs endpoint.
+type ListSpecsArgs struct {
+	// Service identifies the tag for the service to list.
+	Service string
+}
+
+// ListSpecsResults holds the results of the ListSpecs endpoint.
+type ListSpecsResults struct {
+	// Results is the list of resource results.
+	Results []ResourceSpec
+}
+
+// ResourceSpec contains the definition for a resource.
+type ResourceSpec struct {
+	// Name identifies the resource.
+	Name string
+
+	// Type is the name of the resource type.
+	Type string
+
+	// Path is where the resource will be stored.
+	Path string
+
+	// Comment contains user-facing info about the resource.
+	Comment string
+
+	// Origin is where the resource will come from.
+	Origin string
+
+	// Revision is the desired revision, if applicable.
+	Revision string
+}

--- a/resource/api/data.go
+++ b/resource/api/data.go
@@ -3,10 +3,14 @@
 
 package api
 
+import (
+	"github.com/juju/names"
+)
+
 // ListSpecsArgs are the arguments for the ListSpecs endpoint.
 type ListSpecsArgs struct {
 	// Service identifies the tag for the service to list.
-	Service string
+	Service names.ServiceTag
 }
 
 // ListSpecsResults holds the results of the ListSpecs endpoint.

--- a/resource/api/helpers.go
+++ b/resource/api/helpers.go
@@ -1,0 +1,41 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package api
+
+import (
+	"github.com/juju/errors"
+	"gopkg.in/juju/charm.v6-unstable"
+
+	"github.com/juju/juju/resource"
+)
+
+// ResourceSpec2API converts a resource.ResourceSpec into
+// a ResourceSpec struct.
+func ResourceSpec2API(r resource.ResourceSpec) ResourceSpec {
+	info := r.Definition()
+	return ResourceSpec{
+		Name:     info.Name,
+		Type:     info.Type,
+		Path:     info.Path,
+		Comment:  info.Comment,
+		Origin:   r.Origin(),
+		Revision: r.Revision(),
+	}
+}
+
+// API2ResourceSpec converts an API ResourceSpec info struct into
+// a resource.ResourceSpec.
+func API2ResourceSpec(apiSpec ResourceSpec) (resource.ResourceSpec, error) {
+	info := charm.ResourceInfo{
+		Name:    apiSpec.Name,
+		Type:    apiSpec.Type,
+		Path:    apiSpec.Path,
+		Comment: apiSpec.Comment,
+	}
+	res, err := resource.NewResourceSpec(info, apiSpec.Origin, apiSpec.Revision)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return res, nil
+}

--- a/resource/api/helpers.go
+++ b/resource/api/helpers.go
@@ -10,9 +10,9 @@ import (
 	"github.com/juju/juju/resource"
 )
 
-// ResourceSpec2API converts a resource.ResourceSpec into
+// ResourceSpec2API converts a resource.Spec into
 // a ResourceSpec struct.
-func ResourceSpec2API(r resource.ResourceSpec) ResourceSpec {
+func ResourceSpec2API(r resource.Spec) ResourceSpec {
 	info := r.Definition()
 	return ResourceSpec{
 		Name:     info.Name,
@@ -25,15 +25,15 @@ func ResourceSpec2API(r resource.ResourceSpec) ResourceSpec {
 }
 
 // API2ResourceSpec converts an API ResourceSpec info struct into
-// a resource.ResourceSpec.
-func API2ResourceSpec(apiSpec ResourceSpec) (resource.ResourceSpec, error) {
+// a resource.Spec.
+func API2ResourceSpec(apiSpec ResourceSpec) (resource.Spec, error) {
 	info := charm.ResourceInfo{
 		Name:    apiSpec.Name,
 		Type:    apiSpec.Type,
 		Path:    apiSpec.Path,
 		Comment: apiSpec.Comment,
 	}
-	res, err := resource.NewResourceSpec(info, apiSpec.Origin, apiSpec.Revision)
+	res, err := resource.NewSpec(info, apiSpec.Origin, apiSpec.Revision)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/resource/api/helpers.go
+++ b/resource/api/helpers.go
@@ -5,7 +5,7 @@ package api
 
 import (
 	"github.com/juju/errors"
-	"gopkg.in/juju/charm.v6-unstable"
+	charmresource "gopkg.in/juju/charm.v6-unstable/resource"
 
 	"github.com/juju/juju/resource"
 )
@@ -16,7 +16,7 @@ func ResourceSpec2API(r resource.Spec) ResourceSpec {
 	info := r.Definition()
 	return ResourceSpec{
 		Name:     info.Name,
-		Type:     info.Type,
+		Type:     info.Type.String(),
 		Path:     info.Path,
 		Comment:  info.Comment,
 		Origin:   r.Origin(),
@@ -27,12 +27,15 @@ func ResourceSpec2API(r resource.Spec) ResourceSpec {
 // API2ResourceSpec converts an API ResourceSpec info struct into
 // a resource.Spec.
 func API2ResourceSpec(apiSpec ResourceSpec) (resource.Spec, error) {
-	info := charm.ResourceInfo{
+	rtype, _ := charmresource.ParseType(apiSpec.Type)
+	info := charmresource.Info{
 		Name:    apiSpec.Name,
-		Type:    apiSpec.Type,
+		Type:    rtype,
 		Path:    apiSpec.Path,
 		Comment: apiSpec.Comment,
 	}
+	// TODO(ericsnow) Call info.Validate()?
+
 	res, err := resource.NewSpec(info, apiSpec.Origin, apiSpec.Revision)
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/resource/api/helpers_test.go
+++ b/resource/api/helpers_test.go
@@ -1,0 +1,69 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package api_test
+
+import (
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/charm.v6-unstable"
+
+	"github.com/juju/juju/resource"
+	"github.com/juju/juju/resource/api"
+)
+
+var _ = gc.Suite(&helpersSuite{})
+
+type helpersSuite struct {
+	testing.IsolationSuite
+}
+
+func (helpersSuite) TestResourceSpec2API(c *gc.C) {
+	spec, err := resource.NewResourceSpec(
+		charm.ResourceInfo{
+			Name:    "spam",
+			Type:    "file",
+			Path:    "spam.tgz",
+			Comment: "you need it",
+		},
+		resource.OriginUpload,
+		resource.NoRevision,
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	apiSpec := api.ResourceSpec2API(spec)
+
+	c.Check(apiSpec, jc.DeepEquals, api.ResourceSpec{
+		Name:     "spam",
+		Type:     "file",
+		Path:     "spam.tgz",
+		Comment:  "you need it",
+		Origin:   "upload",
+		Revision: "",
+	})
+}
+
+func (helpersSuite) TestAPI2ResourceSpec(c *gc.C) {
+	spec, err := api.API2ResourceSpec(api.ResourceSpec{
+		Name:     "spam",
+		Type:     "file",
+		Path:     "spam.tgz",
+		Comment:  "you need it",
+		Origin:   "upload",
+		Revision: "",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	expected, err := resource.NewResourceSpec(
+		charm.ResourceInfo{
+			Name:    "spam",
+			Type:    "file",
+			Path:    "spam.tgz",
+			Comment: "you need it",
+		},
+		resource.OriginUpload,
+		resource.NoRevision,
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(spec, jc.DeepEquals, expected)
+}

--- a/resource/api/helpers_test.go
+++ b/resource/api/helpers_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-	"gopkg.in/juju/charm.v6-unstable"
+	charmresource "gopkg.in/juju/charm.v6-unstable/resource"
 
 	"github.com/juju/juju/resource"
 	"github.com/juju/juju/resource/api"
@@ -21,7 +21,7 @@ type helpersSuite struct {
 
 func (helpersSuite) TestResourceSpec2API(c *gc.C) {
 	spec, err := resource.NewSpec(
-		charm.ResourceInfo{
+		charmresource.Info{
 			Name:    "spam",
 			Type:    "file",
 			Path:    "spam.tgz",
@@ -55,7 +55,7 @@ func (helpersSuite) TestAPI2ResourceSpec(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	expected, err := resource.NewSpec(
-		charm.ResourceInfo{
+		charmresource.Info{
 			Name:    "spam",
 			Type:    "file",
 			Path:    "spam.tgz",

--- a/resource/api/helpers_test.go
+++ b/resource/api/helpers_test.go
@@ -20,7 +20,7 @@ type helpersSuite struct {
 }
 
 func (helpersSuite) TestResourceSpec2API(c *gc.C) {
-	spec, err := resource.NewResourceSpec(
+	spec, err := resource.NewSpec(
 		charm.ResourceInfo{
 			Name:    "spam",
 			Type:    "file",
@@ -54,7 +54,7 @@ func (helpersSuite) TestAPI2ResourceSpec(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	expected, err := resource.NewResourceSpec(
+	expected, err := resource.NewSpec(
 		charm.ResourceInfo{
 			Name:    "spam",
 			Type:    "file",

--- a/resource/api/package_test.go
+++ b/resource/api/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package api
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/resource/api/package_test.go
+++ b/resource/api/package_test.go
@@ -1,7 +1,7 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package api
+package api_test
 
 import (
 	"testing"

--- a/resource/api/server/package_test.go
+++ b/resource/api/server/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package server_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/resource/api/server/server.go
+++ b/resource/api/server/server.go
@@ -8,3 +8,20 @@ import (
 )
 
 var logger = loggo.GetLogger("juju.resource.api.server")
+
+// State is the functionality of Juju's state needed for the resources API.
+type State interface {
+	specState
+}
+
+// Facade is the public API facade for resources.
+type Facade struct {
+	*specFacade
+}
+
+// NewFacade returns a new resoures facade for the given Juju state.
+func NewFacade(st State) *Facade {
+	return &Facade{
+		specFacade: &specFacade{st},
+	}
+}

--- a/resource/api/server/server.go
+++ b/resource/api/server/server.go
@@ -9,6 +9,9 @@ import (
 
 var logger = loggo.GetLogger("juju.resource.api.server")
 
+// Version is the version number of the current Facade.
+const Version = 0
+
 // State is the functionality of Juju's state needed for the resources API.
 type State interface {
 	specState

--- a/resource/api/server/server.go
+++ b/resource/api/server/server.go
@@ -1,0 +1,10 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package server
+
+import (
+	"github.com/juju/loggo"
+)
+
+var logger = loggo.GetLogger("juju.resource.api.server")

--- a/resource/api/server/spec.go
+++ b/resource/api/server/spec.go
@@ -1,0 +1,43 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package server
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/names"
+
+	"github.com/juju/juju/resource"
+	"github.com/juju/juju/resource/api"
+)
+
+type specState interface {
+	// ListResourceSpecs returns the resource specs for the given service.
+	ListResourceSpecs(service string) ([]resource.Spec, error)
+}
+
+type specFacade struct {
+	state specState
+}
+
+// ListSpecs returns the list of resource specs for the given service.
+func (f specFacade) ListSpecs(args api.ListSpecsArgs) (api.ListSpecsResults, error) {
+	var r api.ListSpecsResults
+
+	tag, err := names.ParseTag(args.Service)
+	if err != nil {
+		return r, errors.Trace(err)
+	}
+	service := tag.Id()
+
+	specs, err := f.state.ListResourceSpecs(service)
+	if err != nil {
+		return r, errors.Trace(err)
+	}
+
+	for _, spec := range specs {
+		apiSpec := api.ResourceSpec2API(spec)
+		r.Results = append(r.Results, apiSpec)
+	}
+	return r, nil
+}

--- a/resource/api/server/spec.go
+++ b/resource/api/server/spec.go
@@ -5,7 +5,6 @@ package server
 
 import (
 	"github.com/juju/errors"
-	"github.com/juju/names"
 
 	"github.com/juju/juju/resource"
 	"github.com/juju/juju/resource/api"
@@ -24,11 +23,7 @@ type specFacade struct {
 func (f specFacade) ListSpecs(args api.ListSpecsArgs) (api.ListSpecsResults, error) {
 	var r api.ListSpecsResults
 
-	tag, err := names.ParseTag(args.Service)
-	if err != nil {
-		return r, errors.Trace(err)
-	}
-	service := tag.Id()
+	service := args.Service.Id()
 
 	specs, err := f.state.ListResourceSpecs(service)
 	if err != nil {

--- a/resource/api/server/spec_test.go
+++ b/resource/api/server/spec_test.go
@@ -1,0 +1,107 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package server_test
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/resource"
+	"github.com/juju/juju/resource/api"
+	"github.com/juju/juju/resource/api/apitesting"
+	"github.com/juju/juju/resource/api/server"
+)
+
+var _ = gc.Suite(&specSuite{})
+
+type specSuite struct {
+	testing.IsolationSuite
+
+	stub  *testing.Stub
+	state *stubSpecState
+}
+
+func (s *specSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+
+	s.stub = &testing.Stub{}
+	s.state = &stubSpecState{stub: s.stub}
+}
+
+func (s *specSuite) TestListSpecsOkay(c *gc.C) {
+	spec1, apiSpec1 := apitesting.NewSpec(c, "spam")
+	spec2, apiSpec2 := apitesting.NewSpec(c, "eggs")
+	s.state.ReturnSpecs = []resource.Spec{
+		spec1,
+		spec2,
+	}
+	facade := server.NewFacade(s.state)
+
+	apiSpecs, err := facade.ListSpecs(api.ListSpecsArgs{
+		Service: "service-a-service",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(apiSpecs, jc.DeepEquals, api.ListSpecsResults{
+		Results: []api.ResourceSpec{
+			apiSpec1,
+			apiSpec2,
+		},
+	})
+	c.Check(s.stub.Calls(), gc.HasLen, 1)
+	s.stub.CheckCall(c, 0, "ListResourceSpecs", "a-service")
+}
+
+func (s *specSuite) TestListSpecsEmpty(c *gc.C) {
+	facade := server.NewFacade(s.state)
+
+	apiSpecs, err := facade.ListSpecs(api.ListSpecsArgs{
+		Service: "service-a-service",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(apiSpecs, jc.DeepEquals, api.ListSpecsResults{})
+	s.stub.CheckCallNames(c, "ListResourceSpecs")
+}
+
+func (s *specSuite) TestListSpecsBadTag(c *gc.C) {
+	facade := server.NewFacade(s.state)
+
+	_, err := facade.ListSpecs(api.ListSpecsArgs{
+		Service: "a-service",
+	})
+
+	c.Check(err, gc.NotNil)
+	s.stub.CheckNoCalls(c)
+}
+
+func (s *specSuite) TestListSpecsError(c *gc.C) {
+	failure := errors.New("<failure>")
+	s.stub.SetErrors(failure)
+	facade := server.NewFacade(s.state)
+
+	_, err := facade.ListSpecs(api.ListSpecsArgs{
+		Service: "service-a-service",
+	})
+
+	c.Check(errors.Cause(err), gc.Equals, failure)
+	s.stub.CheckCallNames(c, "ListResourceSpecs")
+}
+
+type stubSpecState struct {
+	stub *testing.Stub
+
+	ReturnSpecs []resource.Spec
+}
+
+func (s *stubSpecState) ListResourceSpecs(service string) ([]resource.Spec, error) {
+	s.stub.AddCall("ListResourceSpecs", service)
+	if err := s.stub.NextErr(); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	return s.ReturnSpecs, nil
+}

--- a/resource/api/server/spec_test.go
+++ b/resource/api/server/spec_test.go
@@ -5,6 +5,7 @@ package server_test
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/names"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -41,7 +42,7 @@ func (s *specSuite) TestListSpecsOkay(c *gc.C) {
 	facade := server.NewFacade(s.state)
 
 	apiSpecs, err := facade.ListSpecs(api.ListSpecsArgs{
-		Service: "service-a-service",
+		Service: newServiceTag(c, "service-a-service"),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -59,23 +60,12 @@ func (s *specSuite) TestListSpecsEmpty(c *gc.C) {
 	facade := server.NewFacade(s.state)
 
 	apiSpecs, err := facade.ListSpecs(api.ListSpecsArgs{
-		Service: "service-a-service",
+		Service: newServiceTag(c, "service-a-service"),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(apiSpecs, jc.DeepEquals, api.ListSpecsResults{})
 	s.stub.CheckCallNames(c, "ListResourceSpecs")
-}
-
-func (s *specSuite) TestListSpecsBadTag(c *gc.C) {
-	facade := server.NewFacade(s.state)
-
-	_, err := facade.ListSpecs(api.ListSpecsArgs{
-		Service: "a-service",
-	})
-
-	c.Check(err, gc.NotNil)
-	s.stub.CheckNoCalls(c)
 }
 
 func (s *specSuite) TestListSpecsError(c *gc.C) {
@@ -84,11 +74,17 @@ func (s *specSuite) TestListSpecsError(c *gc.C) {
 	facade := server.NewFacade(s.state)
 
 	_, err := facade.ListSpecs(api.ListSpecsArgs{
-		Service: "service-a-service",
+		Service: newServiceTag(c, "service-a-service"),
 	})
 
 	c.Check(errors.Cause(err), gc.Equals, failure)
 	s.stub.CheckCallNames(c, "ListResourceSpecs")
+}
+
+func newServiceTag(c *gc.C, service string) names.ServiceTag {
+	tag, err := names.ParseTag(service)
+	c.Assert(err, jc.ErrorIsNil)
+	return tag.(names.ServiceTag)
 }
 
 type stubSpecState struct {

--- a/resource/component.go
+++ b/resource/component.go
@@ -1,0 +1,10 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// The resource package provides the functionality of the "resources"
+// feature in Juju. The various pieces are connected to the Juju
+// machinery in component/all/resource.go.
+package resource
+
+// ComponentName is the name of the Juju component for resource management.
+const ComponentName = "resources"

--- a/resource/package_test.go
+++ b/resource/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package resource_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/resource/spec.go
+++ b/resource/spec.go
@@ -7,7 +7,7 @@ package resource
 
 import (
 	"github.com/juju/errors"
-	"gopkg.in/juju/charm.v6-unstable"
+	"gopkg.in/juju/charm.v6-unstable/resource"
 )
 
 // TODO(ericsnow) Move the this file or something similar to the charm repo?
@@ -23,7 +23,7 @@ const NoRevision = ""
 // Spec describes one resource that a service uses.
 type Spec interface {
 	// Definition is the basic info about the resource.
-	Definition() charm.ResourceInfo
+	Definition() resource.Info
 
 	// Origin identifies where the resource should come from.
 	Origin() string
@@ -34,7 +34,7 @@ type Spec interface {
 }
 
 // NewSpec returns a new Spec for the given info.
-func NewSpec(info charm.ResourceInfo, origin, revision string) (Spec, error) {
+func NewSpec(info resource.Info, origin, revision string) (Spec, error) {
 	switch origin {
 	case OriginUpload:
 		// TODO(ericsnow) Fail if revision not NoRevision?
@@ -46,12 +46,12 @@ func NewSpec(info charm.ResourceInfo, origin, revision string) (Spec, error) {
 
 // UploadSpec defines an *uploaded* resource that a service expects.
 type UploadSpec struct {
-	charm.ResourceInfo
+	resource.Info
 }
 
 // Definition implements Spec.
-func (res UploadSpec) Definition() charm.ResourceInfo {
-	return res.ResourceInfo
+func (res UploadSpec) Definition() resource.Info {
+	return res.Info
 }
 
 // Origin implements Spec.

--- a/resource/spec.go
+++ b/resource/spec.go
@@ -20,8 +20,8 @@ const (
 // NoRevision indicates that the spec does not have a revision specified.
 const NoRevision = ""
 
-// ResourceSpec describes one resource that a service uses.
-type ResourceSpec interface {
+// Spec describes one resource that a service uses.
+type Spec interface {
 	// Definition is the basic info about the resource.
 	Definition() charm.ResourceInfo
 
@@ -33,33 +33,33 @@ type ResourceSpec interface {
 	Revision() string
 }
 
-// NewResourceSpec returns a new ResourceSpec for the given info.
-func NewResourceSpec(info charm.ResourceInfo, origin, revision string) (ResourceSpec, error) {
+// NewSpec returns a new Spec for the given info.
+func NewSpec(info charm.ResourceInfo, origin, revision string) (Spec, error) {
 	switch origin {
 	case OriginUpload:
 		// TODO(ericsnow) Fail if revision not NoRevision?
-		return &UploadResourceSpec{info}, nil
+		return &UploadSpec{info}, nil
 	default:
 		return nil, errors.NotSupportedf("resource origin %q", origin)
 	}
 }
 
-// UploadResourceSpec defines an *uploaded* resource that a service expects.
-type UploadResourceSpec struct {
+// UploadSpec defines an *uploaded* resource that a service expects.
+type UploadSpec struct {
 	charm.ResourceInfo
 }
 
-// Definition implements ResourceSpec.
-func (res UploadResourceSpec) Definition() charm.ResourceInfo {
+// Definition implements Spec.
+func (res UploadSpec) Definition() charm.ResourceInfo {
 	return res.ResourceInfo
 }
 
-// Origin implements ResourceSpec.
-func (res UploadResourceSpec) Origin() string {
+// Origin implements Spec.
+func (res UploadSpec) Origin() string {
 	return OriginUpload
 }
 
-// Revision implements ResourceSpec.
-func (res UploadResourceSpec) Revision() string {
+// Revision implements Spec.
+func (res UploadSpec) Revision() string {
 	return NoRevision
 }

--- a/resource/spec.go
+++ b/resource/spec.go
@@ -1,0 +1,65 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// The resource package provides the functionality of the "resources"
+// feature in Juju.
+package resource
+
+import (
+	"github.com/juju/errors"
+	"gopkg.in/juju/charm.v6-unstable"
+)
+
+// TODO(ericsnow) Move the this file or something similar to the charm repo?
+
+// These are the valid resource origins.
+const (
+	OriginUpload = "upload"
+)
+
+// NoRevision indicates that the spec does not have a revision specified.
+const NoRevision = ""
+
+// ResourceSpec describes one resource that a service uses.
+type ResourceSpec interface {
+	// Definition is the basic info about the resource.
+	Definition() charm.ResourceInfo
+
+	// Origin identifies where the resource should come from.
+	Origin() string
+
+	// Revision is the desired revision of the resource. It returns ""
+	// for origins that do not support revisions.
+	Revision() string
+}
+
+// NewResourceSpec returns a new ResourceSpec for the given info.
+func NewResourceSpec(info charm.ResourceInfo, origin, revision string) (ResourceSpec, error) {
+	switch origin {
+	case OriginUpload:
+		// TODO(ericsnow) Fail if revision not NoRevision?
+		return &UploadResourceSpec{info}, nil
+	default:
+		return nil, errors.NotSupportedf("resource origin %q", origin)
+	}
+}
+
+// UploadResourceSpec defines an *uploaded* resource that a service expects.
+type UploadResourceSpec struct {
+	charm.ResourceInfo
+}
+
+// Definition implements ResourceSpec.
+func (res UploadResourceSpec) Definition() charm.ResourceInfo {
+	return res.ResourceInfo
+}
+
+// Origin implements ResourceSpec.
+func (res UploadResourceSpec) Origin() string {
+	return OriginUpload
+}
+
+// Revision implements ResourceSpec.
+func (res UploadResourceSpec) Revision() string {
+	return NoRevision
+}

--- a/resource/spec_test.go
+++ b/resource/spec_test.go
@@ -1,0 +1,81 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package resource_test
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/charm.v6-unstable"
+
+	"github.com/juju/juju/resource"
+)
+
+var _ = gc.Suite(&specSuite{})
+
+type specSuite struct {
+	testing.IsolationSuite
+}
+
+func (specSuite) TestNewResourceSpecUpload(c *gc.C) {
+	info := charm.ResourceInfo{
+		Name:    "spam",
+		Type:    "file",
+		Path:    "spam.tgz",
+		Comment: "you need it",
+	}
+	origin := resource.OriginUpload
+	revision := resource.NoRevision
+
+	spec, err := resource.NewResourceSpec(info, origin, revision)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(spec.Definition(), jc.DeepEquals, info)
+	c.Check(spec.Origin(), gc.Equals, origin)
+	c.Check(spec.Revision(), gc.Equals, revision)
+}
+
+func (specSuite) TestNewResourceSpecEmptyInfo(c *gc.C) {
+	var info charm.ResourceInfo
+	origin := resource.OriginUpload
+	revision := resource.NoRevision
+
+	spec, err := resource.NewResourceSpec(info, origin, revision)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(spec.Definition(), jc.DeepEquals, info)
+	c.Check(spec.Origin(), gc.Equals, origin)
+	c.Check(spec.Revision(), gc.Equals, revision)
+}
+
+func (specSuite) TestNewResourceSpecEmptyOrigin(c *gc.C) {
+	info := charm.ResourceInfo{
+		Name:    "spam",
+		Type:    "file",
+		Path:    "spam.tgz",
+		Comment: "you need it",
+	}
+	revision := resource.NoRevision
+
+	_, err := resource.NewResourceSpec(info, "", revision)
+
+	c.Check(err, jc.Satisfies, errors.IsNotSupported)
+	c.Check(err, gc.ErrorMatches, `.*origin.*`)
+}
+
+func (specSuite) TestNewResourceSpecUnknownOrigin(c *gc.C) {
+	info := charm.ResourceInfo{
+		Name:    "spam",
+		Type:    "file",
+		Path:    "spam.tgz",
+		Comment: "you need it",
+	}
+	revision := resource.NoRevision
+
+	_, err := resource.NewResourceSpec(info, "<bogus>", revision)
+
+	c.Check(err, jc.Satisfies, errors.IsNotSupported)
+	c.Check(err, gc.ErrorMatches, `.*origin.*`)
+}

--- a/resource/spec_test.go
+++ b/resource/spec_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-	"gopkg.in/juju/charm.v6-unstable"
+	charmresource "gopkg.in/juju/charm.v6-unstable/resource"
 
 	"github.com/juju/juju/resource"
 )
@@ -20,7 +20,7 @@ type specSuite struct {
 }
 
 func (specSuite) TestNewSpecUpload(c *gc.C) {
-	info := charm.ResourceInfo{
+	info := charmresource.Info{
 		Name:    "spam",
 		Type:    "file",
 		Path:    "spam.tgz",
@@ -38,7 +38,7 @@ func (specSuite) TestNewSpecUpload(c *gc.C) {
 }
 
 func (specSuite) TestNewSpecEmptyInfo(c *gc.C) {
-	var info charm.ResourceInfo
+	var info charmresource.Info
 	origin := resource.OriginUpload
 	revision := resource.NoRevision
 
@@ -51,7 +51,7 @@ func (specSuite) TestNewSpecEmptyInfo(c *gc.C) {
 }
 
 func (specSuite) TestNewSpecEmptyOrigin(c *gc.C) {
-	info := charm.ResourceInfo{
+	info := charmresource.Info{
 		Name:    "spam",
 		Type:    "file",
 		Path:    "spam.tgz",
@@ -66,7 +66,7 @@ func (specSuite) TestNewSpecEmptyOrigin(c *gc.C) {
 }
 
 func (specSuite) TestNewSpecUnknownOrigin(c *gc.C) {
-	info := charm.ResourceInfo{
+	info := charmresource.Info{
 		Name:    "spam",
 		Type:    "file",
 		Path:    "spam.tgz",

--- a/resource/spec_test.go
+++ b/resource/spec_test.go
@@ -19,7 +19,7 @@ type specSuite struct {
 	testing.IsolationSuite
 }
 
-func (specSuite) TestNewResourceSpecUpload(c *gc.C) {
+func (specSuite) TestNewSpecUpload(c *gc.C) {
 	info := charm.ResourceInfo{
 		Name:    "spam",
 		Type:    "file",
@@ -29,7 +29,7 @@ func (specSuite) TestNewResourceSpecUpload(c *gc.C) {
 	origin := resource.OriginUpload
 	revision := resource.NoRevision
 
-	spec, err := resource.NewResourceSpec(info, origin, revision)
+	spec, err := resource.NewSpec(info, origin, revision)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(spec.Definition(), jc.DeepEquals, info)
@@ -37,12 +37,12 @@ func (specSuite) TestNewResourceSpecUpload(c *gc.C) {
 	c.Check(spec.Revision(), gc.Equals, revision)
 }
 
-func (specSuite) TestNewResourceSpecEmptyInfo(c *gc.C) {
+func (specSuite) TestNewSpecEmptyInfo(c *gc.C) {
 	var info charm.ResourceInfo
 	origin := resource.OriginUpload
 	revision := resource.NoRevision
 
-	spec, err := resource.NewResourceSpec(info, origin, revision)
+	spec, err := resource.NewSpec(info, origin, revision)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(spec.Definition(), jc.DeepEquals, info)
@@ -50,7 +50,7 @@ func (specSuite) TestNewResourceSpecEmptyInfo(c *gc.C) {
 	c.Check(spec.Revision(), gc.Equals, revision)
 }
 
-func (specSuite) TestNewResourceSpecEmptyOrigin(c *gc.C) {
+func (specSuite) TestNewSpecEmptyOrigin(c *gc.C) {
 	info := charm.ResourceInfo{
 		Name:    "spam",
 		Type:    "file",
@@ -59,13 +59,13 @@ func (specSuite) TestNewResourceSpecEmptyOrigin(c *gc.C) {
 	}
 	revision := resource.NoRevision
 
-	_, err := resource.NewResourceSpec(info, "", revision)
+	_, err := resource.NewSpec(info, "", revision)
 
 	c.Check(err, jc.Satisfies, errors.IsNotSupported)
 	c.Check(err, gc.ErrorMatches, `.*origin.*`)
 }
 
-func (specSuite) TestNewResourceSpecUnknownOrigin(c *gc.C) {
+func (specSuite) TestNewSpecUnknownOrigin(c *gc.C) {
 	info := charm.ResourceInfo{
 		Name:    "spam",
 		Type:    "file",
@@ -74,7 +74,7 @@ func (specSuite) TestNewResourceSpecUnknownOrigin(c *gc.C) {
 	}
 	revision := resource.NoRevision
 
-	_, err := resource.NewResourceSpec(info, "<bogus>", revision)
+	_, err := resource.NewSpec(info, "<bogus>", revision)
 
 	c.Check(err, jc.Satisfies, errors.IsNotSupported)
 	c.Check(err, gc.ErrorMatches, `.*origin.*`)


### PR DESCRIPTION
This is the initial core addition for the new resources feature.  The patch adds a public facade with (for now) a single method, `ListSpecs`, which lists resources defined in charms.  For now there is only one supported resource origin, "upload".  Several other patches will be building on this one.

(reviews: http://reviews.vapour.ws/r/3242/)