### PR TITLE
cmd/jujud/agent: fix test snafu

### DIFF
--- a/cmd/jujud/agent/package_test.go
+++ b/cmd/jujud/agent/package_test.go
@@ -1,7 +1,7 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package agent_test
+package agent // not agent_test for no good reason
 
 import (
 	stdtesting "testing"


### PR DESCRIPTION
62097950 accidentally excluded Upgrade test because this package
uses both internal and external tests.

(Review request: http://reviews.vapour.ws/r/3245/)