### PR TITLE
Fix 1506680, no current environ after bootstrap

### DIFF
--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -317,6 +317,12 @@ func (c *BootstrapCommand) Run(ctx *cmd.Context) (resultErr error) {
 	if err != nil {
 		return errors.Annotate(err, "saving bootstrap endpoint address")
 	}
+
+	err = envcmd.SetCurrentEnvironment(ctx, envName)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
 	// To avoid race conditions when running scripted bootstraps, wait
 	// for the state server's machine agent to be ready to accept commands
 	// before exiting this bootstrap command.

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -420,6 +420,24 @@ func (s *BootstrapSuite) TestBootstrapTwice(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "environment is already bootstrapped")
 }
 
+func (s *BootstrapSuite) TestBootstrapSetsCurrentEnvironment(c *gc.C) {
+	env := resetJujuHome(c, "devenv")
+	defaultSeriesVersion := version.Current
+	defaultSeriesVersion.Series = config.PreferredSeries(env.Config())
+	// Force a dev version by having a non zero build number.
+	// This is because we have not uploaded any tools and auto
+	// upload is only enabled for dev versions.
+	defaultSeriesVersion.Build = 1234
+	s.PatchValue(&version.Current, defaultSeriesVersion)
+
+	coretesting.WriteEnvironments(c, coretesting.MultipleEnvConfig)
+	ctx, err := coretesting.RunCommand(c, envcmd.Wrap(&BootstrapCommand{}), "-e", "devenv")
+	c.Assert(coretesting.Stderr(ctx), jc.Contains, "-> devenv")
+	currentEnv, err := envcmd.ReadCurrentEnvironment()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(currentEnv, gc.Equals, "devenv")
+}
+
 type mockBootstrapInstance struct {
 	instance.Instance
 }
@@ -431,13 +449,13 @@ func (*mockBootstrapInstance) Addresses() ([]network.Address, error) {
 func (s *BootstrapSuite) TestSeriesDeprecation(c *gc.C) {
 	ctx := s.checkSeriesArg(c, "--series")
 	c.Check(coretesting.Stderr(ctx), gc.Equals,
-		"Use of --series is obsolete. --upload-tools now expands to all supported series of the same operating system.\nBootstrap complete\n")
+		"Use of --series is obsolete. --upload-tools now expands to all supported series of the same operating system.\n-> peckham\nBootstrap complete\n")
 }
 
 func (s *BootstrapSuite) TestUploadSeriesDeprecation(c *gc.C) {
 	ctx := s.checkSeriesArg(c, "--upload-series")
 	c.Check(coretesting.Stderr(ctx), gc.Equals,
-		"Use of --upload-series is obsolete. --upload-tools now expands to all supported series of the same operating system.\nBootstrap complete\n")
+		"Use of --upload-series is obsolete. --upload-tools now expands to all supported series of the same operating system.\n-> peckham\nBootstrap complete\n")
 }
 
 func (s *BootstrapSuite) checkSeriesArg(c *gc.C, argVariant string) *cmd.Context {


### PR DESCRIPTION
Set the current environment at the end of bootstrap.

(Review request: http://reviews.vapour.ws/r/3256/)