### PR TITLE
worker/provisioner: skip package tests under xenial

### DIFF
--- a/worker/provisioner/package_test.go
+++ b/worker/provisioner/package_test.go
@@ -12,6 +12,9 @@ import (
 )
 
 func TestPackage(t *stdtesting.T) {
+	if testing.GOVERSION == 1.5 {
+		t.Skip("skipping package under Go version 1.5, see LP 1520380")
+	}
 	if testing.RaceEnabled {
 		t.Skip("skipping package under -race, see LP 1519097")
 	}


### PR DESCRIPTION
See LP 1520380

(Review request: http://reviews.vapour.ws/r/3259/)