### PR TITLE
Extract the upgradesteps worker to its own package

### DIFF
--- a/cmd/jujud/agent/unit/manifolds.go
+++ b/cmd/jujud/agent/unit/manifolds.go
@@ -119,7 +119,7 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 		// and the agent to be restarted running the new tools. We should only
 		// need one of these in a consolidated agent, but we'll need to be
 		// careful about behavioural differences, and interactions with the
-		// upgrade-steps worker.
+		// upgradesteps worker.
 		UpgraderName: upgrader.Manifold(upgrader.ManifoldConfig{
 			AgentName:     AgentName,
 			APICallerName: APICallerName,

--- a/featuretests/upgrade_test.go
+++ b/featuretests/upgrade_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/juju/juju/upgrades"
 	"github.com/juju/juju/version"
 	"github.com/juju/juju/worker/upgrader"
+	"github.com/juju/juju/worker/upgradesteps"
 )
 
 type exposedAPI bool
@@ -59,8 +60,8 @@ func (s *upgradeSuite) SetUpTest(c *gc.C) {
 	s.oldVersion.Minor = 16
 
 	// Don't wait so long in tests.
-	s.PatchValue(&agentcmd.UpgradeStartTimeoutMaster, time.Duration(time.Millisecond*50))
-	s.PatchValue(&agentcmd.UpgradeStartTimeoutSecondary, time.Duration(time.Millisecond*60))
+	s.PatchValue(&upgradesteps.UpgradeStartTimeoutMaster, time.Duration(time.Millisecond*50))
+	s.PatchValue(&upgradesteps.UpgradeStartTimeoutSecondary, time.Duration(time.Millisecond*60))
 
 	// TODO(mjs) - the following should maybe be part of AgentSuite.SetUpTest()
 	s.PatchValue(&cmdutil.EnsureMongoServer, func(mongo.EnsureServerParams) error {
@@ -102,7 +103,7 @@ func (s *upgradeSuite) TestLoginsDuringUpgrade(c *gc.C) {
 		}
 		return nil
 	}
-	s.PatchValue(&agentcmd.PerformUpgrade, fakePerformUpgrade)
+	s.PatchValue(&upgradesteps.PerformUpgrade, fakePerformUpgrade)
 
 	a := s.newAgent(c, machine)
 	go func() { c.Check(a.Run(nil), jc.ErrorIsNil) }()
@@ -157,7 +158,7 @@ func (s *upgradeSuite) TestDowngradeOnMasterWhenOtherStateServerDoesntStartUpgra
 	fakeIsMachineMaster := func(*state.State, string) (bool, error) {
 		return true, nil
 	}
-	s.PatchValue(&agentcmd.IsMachineMaster, fakeIsMachineMaster)
+	s.PatchValue(&upgradesteps.IsMachineMaster, fakeIsMachineMaster)
 
 	// Start the agent
 	agent := s.newAgent(c, machineA)

--- a/worker/upgradesteps/package_test.go
+++ b/worker/upgradesteps/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgradesteps
+
+import (
+	stdtesting "testing"
+
+	"github.com/juju/juju/testing"
+)
+
+func TestAll(t *stdtesting.T) {
+	testing.MgoTestPackage(t)
+}


### PR DESCRIPTION
This change moves the upgradesteps worker from cmd/jujud/agent to worker/upgradesteps and makes the required changes to allow this to work. This move is required for the upcoming change to get this worker running under the dependency engine.

A number of cleanups were made along the way including:
- a state opening function is now passed in to the worker instead of the worker having knowledge of how to do this.
- the function to set machine status is now passed via an interface instead of pulling this off the agent

The upgradesteps worker code is now cleaner but there are a number of other improvements to make. These are documented in a new set of TODOs at the top of worker/upgradesteps/worker.go and will be addressed in the next PR.

(Review request: http://reviews.vapour.ws/r/3269/)