### PR TITLE
More upgradesteps cleanups

### DIFF
--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -374,12 +374,6 @@ func (a *MachineAgent) Stop() error {
 	return a.tomb.Wait()
 }
 
-// Dying returns the channel that can be used to see if the machine
-// agent is terminating.
-func (a *MachineAgent) Dying() <-chan struct{} {
-	return a.tomb.Dying()
-}
-
 // upgradeCertificateDNSNames ensure that the state server certificate
 // recorded in the agent config and also mongo server.pem contains the
 // DNSNames entires required by Juju/

--- a/worker/upgradesteps/worker.go
+++ b/worker/upgradesteps/worker.go
@@ -34,21 +34,14 @@ import (
 // single run of the worker. Create a separate struct for the worker
 // leaving only a few things in the context.
 //
-// 2. upgradeMachineAgent should be replaced with agent.Agent.
-//
-// 3. The work done by InitializeUsingAgent should probably be done in
+// 2. The work done by InitializeUsingAgent should probably be done in
 // NewUpgradeWorkerContext (so that InitializeUsingAgent can be
 // removed).
 //
-// 4. The tests are internal tests and are too tightly coupled to the
+// 3. The tests are internal tests and are too tightly coupled to the
 // implementation.
 
 var logger = loggo.GetLogger("juju.worker.upgradesteps")
-
-type upgradingMachineAgent interface {
-	CurrentConfig() agent.Config
-	ChangeConfig(agent.ConfigMutator) error
-}
 
 // StatusSetter defines the single method required to set an agent's
 // status.
@@ -91,7 +84,7 @@ type UpgradeWorkerContext struct {
 	UpgradeComplete     chan struct{}
 	fromVersion         version.Number
 	toVersion           version.Number
-	agent               upgradingMachineAgent
+	agent               agent.Agent
 	apiConn             api.Connection
 	openStateForUpgrade func() (*state.State, func(), error)
 	machine             StatusSetter
@@ -106,7 +99,7 @@ type UpgradeWorkerContext struct {
 
 // InitialiseUsingAgent sets up a UpgradeWorkerContext from a machine agent instance.
 // It may update the agent's configuration.
-func (c *UpgradeWorkerContext) InitializeUsingAgent(a upgradingMachineAgent) error {
+func (c *UpgradeWorkerContext) InitializeUsingAgent(a agent.Agent) error {
 	if wrench.IsActive("machine-agent", "always-try-upgrade") {
 		// Always enter upgrade mode. This allows test of upgrades
 		// even when there's actually no upgrade steps to run.
@@ -126,7 +119,7 @@ func (c *UpgradeWorkerContext) InitializeUsingAgent(a upgradingMachineAgent) err
 	})
 }
 func (c *UpgradeWorkerContext) Worker(
-	agent upgradingMachineAgent,
+	agent agent.Agent,
 	apiConn api.Connection,
 	jobs []multiwatcher.MachineJob,
 	openStateForUpgrade func() (*state.State, func(), error),


### PR DESCRIPTION
Fix upgradesteps worker so it no longer uses the machine agent's tomb

... and no longer ignores it's own tomb! It looks like using the
machine agent's tomb was due to misunderstanding of how the machine
agent works. This is no longer done (it was unnecessary) and the
worker now has a manually managed tomb intead of using SimpleWorker
(in preparation for further changes).

---

worker/upgradesteps: use agent.Agent instead of upgradeMachineAgent interface



(Review request: http://reviews.vapour.ws/r/3270/)