### PR TITLE
provider/maas: handle bonded interfaces when adding bridge

### DIFF
--- a/provider/maas/Makefile
+++ b/provider/maas/Makefile
@@ -1,0 +1,13 @@
+all: bridgescript.go
+
+bridgescript.go: add-juju-bridge.py Makefile
+	$(RM) $@
+	echo -n '// This file is auto generated. Edits will be lost.\n\n' >> $@
+	echo -n 'package maas\n\n' >> $@
+	echo -n '//go:generate make -q\n\n' >> $@
+	echo -n "const bridgeScriptPythonBashDef = \`python_script=\$$(cat <<'PYTHON_SCRIPT'\n" >> $@
+	cat add-juju-bridge.py >> $@
+	echo -n 'PYTHON_SCRIPT\n)`\n' >> $@
+
+clean:
+	$(RM) bridgescript.go

--- a/provider/maas/add-juju-bridge.py
+++ b/provider/maas/add-juju-bridge.py
@@ -1,10 +1,3 @@
-// This file is auto generated. Edits will be lost.
-
-package maas
-
-//go:generate make -q
-
-const bridgeScriptPythonBashDef = `python_script=$(cat <<'PYTHON_SCRIPT'
 #!/usr/bin/env python
 
 # Copyright 2015 Canonical Ltd.
@@ -349,5 +342,3 @@ if not ifup(args.bridge_name):
 print_shell_cmd("ifconfig -a")
 print_shell_cmd("ip route show")
 print_shell_cmd("brctl show")
-PYTHON_SCRIPT
-)`

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -4,7 +4,6 @@
 package maas
 
 import (
-	"bytes"
 	"encoding/xml"
 	"fmt"
 	"net"
@@ -13,7 +12,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"text/template"
 	"time"
 
 	"github.com/juju/errors"
@@ -118,7 +116,7 @@ func reserveIPAddressOnDevice(devices gomaasapi.MAASObject, deviceId string, add
 			// We only need the first address, but we're logging all we got.
 			firstAddress = network.NewAddress(value)
 		}
-		logger.Debugf("reserved address %q for device %q", value)
+		logger.Debugf("reserved address %q for device %q", value, deviceId)
 	}
 	return firstAddress, nil
 }
@@ -1185,90 +1183,17 @@ func (environ *maasEnviron) selectNode(args selectNodeArgs) (*gomaasapi.MAASObje
 	return &node, nil
 }
 
-const modifyEtcNetworkInterfaces = `isDHCP() {
-    grep -q "iface ${PRIMARY_IFACE} inet dhcp" {{.Config}}
-    return $?
-}
-
-isStatic() {
-    grep -q "iface ${PRIMARY_IFACE} inet static" {{.Config}}
-    return $?
-}
-
-unAuto() {
-    # Remove the line auto starting the primary interface. \s*$ matches
-    # whitespace and the end of the line to avoid mangling aliases.
-    grep -q "auto ${PRIMARY_IFACE}\s*$" {{.Config}} && \
-    sed -i "s/auto ${PRIMARY_IFACE}\s*$//" {{.Config}}
-}
-
-# Change the config to make $PRIMARY_IFACE manual instead of DHCP,
-# then create the bridge and enslave $PRIMARY_IFACE into it.
-if isDHCP; then
-    sed -i "s/iface ${PRIMARY_IFACE} inet dhcp//" {{.Config}}
-    cat >> {{.Config}} << EOF
-
-# Primary interface (defining the default route)
-iface ${PRIMARY_IFACE} inet manual
-
-# Bridge to use for LXC/KVM containers
-auto {{.Bridge}}
-iface {{.Bridge}} inet dhcp
-    bridge_ports ${PRIMARY_IFACE}
-EOF
-    # Make the primary interface not auto-starting.
-    unAuto
-elif isStatic
-then
-    sed -i "s/iface ${PRIMARY_IFACE} inet static/iface {{.Bridge}} inet static\n    bridge_ports ${PRIMARY_IFACE}/" {{.Config}}
-    sed -i "s/auto ${PRIMARY_IFACE}\s*$/auto {{.Bridge}}/" {{.Config}}
-    cat >> {{.Config}} << EOF
-
-# Primary interface (defining the default route)
-iface ${PRIMARY_IFACE} inet manual
-EOF
-fi`
-
-const bridgeConfigTemplate = `
-# In case we already created the bridge, don't do it again.
-grep -q "iface {{.Bridge}} inet dhcp" {{.Config}} && exit 0
-
-# Discover primary interface at run-time using the default route (if set)
-PRIMARY_IFACE=$(ip route list exact 0/0 | egrep -o 'dev [^ ]+' | cut -b5-)
-
-# If $PRIMARY_IFACE is empty, there's nothing to do.
-[ -z "$PRIMARY_IFACE" ] && exit 0
-
-# Bring down the primary interface while /e/n/i still matches the live config.
-# Will bring it back up within a bridge after updating /e/n/i.
-ifdown -v ${PRIMARY_IFACE}
-
-# Log the contents of /etc/network/interfaces prior to modifying
-echo "Contents of /etc/network/interfaces before changes"
-cat /etc/network/interfaces
-{{.Script}}
-# Log the contents of /etc/network/interfaces after modifying
-echo "Contents of /etc/network/interfaces after changes"
-cat /etc/network/interfaces
-
-ifup -v {{.Bridge}}
-`
-
 // setupJujuNetworking returns a string representing the script to run
 // in order to prepare the Juju-specific networking config on a node.
 func setupJujuNetworking() (string, error) {
-	parsedTemplate := template.Must(
-		template.New("BridgeConfig").Parse(bridgeScriptMain),
-	)
-	var buf bytes.Buffer
-	err := parsedTemplate.Execute(&buf, map[string]interface{}{
-		"Config": "/etc/network/interfaces",
-		"Bridge": instancecfg.DefaultBridgeName,
-	})
-	if err != nil {
-		return "", errors.Annotate(err, "bridge config template error")
-	}
-	return bridgeScriptBase + buf.String(), nil
+	eni := "/etc/network/interfaces"
+	script := fmt.Sprintf("%s\npython -c %q --backup-filename=%q --filename=%q --bridge-name=%q\n",
+		bridgeScriptPythonBashDef,
+		"$python_script",
+		eni+"-orig",
+		eni,
+		instancecfg.DefaultBridgeName)
+	return script, nil
 }
 
 func renderEtcNetworkInterfacesScript() (string, error) {


### PR DESCRIPTION
When adding the juju bridge (juju-br0) there is less work to do when the
primary NIC is a bond. The existing bond0 stanza needs to become
'manual' and we just add an additional stanza for the bridge and bring
the bridge interface up.

(Review request: http://reviews.vapour.ws/r/3275/)