### PR TITLE
new package: utils/filelock

### DIFF
--- a/container/lxc/clonetemplate.go
+++ b/container/lxc/clonetemplate.go
@@ -20,6 +20,7 @@ import (
 	"github.com/juju/juju/cloudconfig/containerinit"
 	"github.com/juju/juju/container"
 	"github.com/juju/juju/instance"
+	"github.com/juju/juju/utils/filelock"
 )
 
 var (
@@ -28,9 +29,9 @@ var (
 	TemplateStopTimeout = 5 * time.Minute
 )
 
-func AcquireTemplateLock(name, message string) (*container.Lock, error) {
+func AcquireTemplateLock(name, message string) (*filelock.Lock, error) {
 	logger.Infof("wait for flock on %v", name)
-	lock, err := container.NewLock(TemplateLockDir, name)
+	lock, err := filelock.NewLock(TemplateLockDir, name)
 	if err != nil {
 		logger.Tracef("failed to create flock for template: %v", err)
 		return nil, err

--- a/utils/filelock/export_test.go
+++ b/utils/filelock/export_test.go
@@ -1,7 +1,7 @@
 // Copyright 2014 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package container
+package filelock
 
 // IsLocked is used just to see if the local lock instance is locked, and
 // is only required for use in tests.

--- a/utils/filelock/flock.go
+++ b/utils/filelock/flock.go
@@ -3,7 +3,7 @@
 
 // +build !windows
 
-package container
+package filelock
 
 import (
 	"syscall"

--- a/utils/filelock/flock_windows.go
+++ b/utils/filelock/flock_windows.go
@@ -3,7 +3,7 @@
 
 // +build windows
 
-package container
+package filelock
 
 import "fmt"
 

--- a/utils/filelock/package_test.go
+++ b/utils/filelock/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package filelock_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}


### PR DESCRIPTION
Juju contains two types that manage on disk locks, the main one is in
juju/utils/fslock, and a second, and less featureful version in container/

This PR moves the second version to its own package (as it has nothing to do
with the container package). This move is temporary, and after refactoring
utils/filelock will be merged into juju/utils/fslock (or fslock merged into this
package).

(Review request: http://reviews.vapour.ws/r/3278/)