### PR TITLE
Add extra version checks for upgrade-juju.

### DIFF
--- a/cmd/juju/commands/upgradejuju.go
+++ b/cmd/juju/commands/upgradejuju.go
@@ -406,7 +406,7 @@ func (context *upgradeContext) validate() (err error) {
 		context.agent.Minor != context.chosen.Minor &&
 		(context.chosen.Minor == 21 || context.chosen.Minor == 23) {
 		return errors.Errorf("unsupported upgrade\n\n"+
-			"Upgrading to %s is not supported. 1.21 and 1.23 are to be avoided.",
+			"Upgrading to %s is not supported. Please upgrade to the latest 1.25 release.",
 			context.chosen.String())
 	}
 

--- a/cmd/juju/commands/upgradejuju.go
+++ b/cmd/juju/commands/upgradejuju.go
@@ -354,6 +354,10 @@ func (context *upgradeContext) validate() (err error) {
 		if nextVersion.Major == context.client.Major {
 			nextVersion.Minor += 1
 			nextVersion.Patch = 0
+			// Explicitly skip 1.21 and 1.23.
+			if nextVersion.Major == 1 && (nextVersion.Minor == 21 || nextVersion.Minor == 23) {
+				nextVersion.Minor += 1
+			}
 		} else {
 			nextVersion = context.client
 		}
@@ -385,6 +389,25 @@ func (context *upgradeContext) validate() (err error) {
 	}
 	if context.chosen == context.agent {
 		return errUpToDate
+	}
+
+	// If the client is on a version before 1.20, they must upgrade
+	// through 1.20.14.
+	if context.agent.Major == 1 && context.agent.Minor < 20 &&
+		(context.chosen.Major > 1 ||
+			(context.chosen.Major == 1 && context.chosen.Minor > 20)) {
+		return errors.New("unsupported upgrade\n\n" +
+			"Environment must first be upgraded to 1.20.14.\n" +
+			"    juju upgrade-juju --version=1.20.14")
+	}
+
+	// Skip 1.21 and 1.23 if the agents are not already on them.
+	if context.agent.Major == 1 && context.chosen.Major == 1 &&
+		context.agent.Minor != context.chosen.Minor &&
+		(context.chosen.Minor == 21 || context.chosen.Minor == 23) {
+		return errors.Errorf("unsupported upgrade\n\n"+
+			"Upgrading to %s is not supported. 1.21 and 1.23 are to be avoided.",
+			context.chosen.String())
 	}
 
 	// Disallow major.minor version downgrades.

--- a/cmd/juju/commands/upgradejuju_test.go
+++ b/cmd/juju/commands/upgradejuju_test.go
@@ -316,7 +316,7 @@ var upgradeJujuTests = []struct {
 	currentVersion: "1.22.1-quantal-amd64",
 	agentVersion:   "1.20.14",
 	args:           []string{"--version=1.21.3"},
-	expectErr:      "unsupported upgrade\n\nUpgrading to 1.21.3 is not supported. 1.21 and 1.23 are to be avoided.",
+	expectErr:      "unsupported upgrade\n\nUpgrading to 1.21.3 is not supported. Please upgrade to the latest 1.25 release.",
 }, {
 	about:          "latest supported stable release, skips 1.23",
 	tools:          []string{"1.23.3-quantal-amd64", "1.24.1-quantal-amd64"},
@@ -329,7 +329,7 @@ var upgradeJujuTests = []struct {
 	currentVersion: "1.24.1-quantal-amd64",
 	agentVersion:   "1.22.3",
 	args:           []string{"--version=1.23.3"},
-	expectErr:      "unsupported upgrade\n\nUpgrading to 1.23.3 is not supported. 1.21 and 1.23 are to be avoided.",
+	expectErr:      "unsupported upgrade\n\nUpgrading to 1.23.3 is not supported. Please upgrade to the latest 1.25 release.",
 }}
 
 func (s *UpgradeJujuSuite) TestUpgradeJuju(c *gc.C) {

--- a/cmd/juju/commands/upgradejuju_test.go
+++ b/cmd/juju/commands/upgradejuju_test.go
@@ -298,11 +298,38 @@ var upgradeJujuTests = []struct {
 	expectVersion:  "2.7.3.2",
 	expectUploaded: []string{"2.7.3.2-quantal-amd64", "2.7.3.2-%LTS%-amd64", "2.7.3.2-raring-amd64"},
 }, {
-	about:          "latest supported stable release",
+	about:          "upgrading from 1.18 needs 1.20.14.",
+	tools:          []string{"1.20.14-quantal-amd64", "1.22.1-quantal-amd64"},
+	currentVersion: "1.22.1-quantal-amd64",
+	agentVersion:   "1.18.0",
+	args:           []string{"--version=1.22.1"},
+	expectErr:      "unsupported upgrade\n\nEnvironment must first be upgraded to 1.20.14.\n    juju upgrade-juju --version=1.20.14",
+}, {
+	about:          "latest supported stable release, skips 1.21",
 	tools:          []string{"1.21.3-quantal-amd64", "1.22.1-quantal-amd64"},
 	currentVersion: "1.22.1-quantal-amd64",
 	agentVersion:   "1.20.14",
-	expectVersion:  "1.21.3",
+	expectVersion:  "1.22.1",
+}, {
+	about:          "1.21 is unsupported",
+	tools:          []string{"1.21.3-quantal-amd64", "1.22.1-quantal-amd64"},
+	currentVersion: "1.22.1-quantal-amd64",
+	agentVersion:   "1.20.14",
+	args:           []string{"--version=1.21.3"},
+	expectErr:      "unsupported upgrade\n\nUpgrading to 1.21.3 is not supported. 1.21 and 1.23 are to be avoided.",
+}, {
+	about:          "latest supported stable release, skips 1.23",
+	tools:          []string{"1.23.3-quantal-amd64", "1.24.1-quantal-amd64"},
+	currentVersion: "1.24.1-quantal-amd64",
+	agentVersion:   "1.22.3",
+	expectVersion:  "1.24.1",
+}, {
+	about:          "1.23 is unsupported",
+	tools:          []string{"1.23.3-quantal-amd64", "1.24.1-quantal-amd64"},
+	currentVersion: "1.24.1-quantal-amd64",
+	agentVersion:   "1.22.3",
+	args:           []string{"--version=1.23.3"},
+	expectErr:      "unsupported upgrade\n\nUpgrading to 1.23.3 is not supported. 1.21 and 1.23 are to be avoided.",
 }}
 
 func (s *UpgradeJujuSuite) TestUpgradeJuju(c *gc.C) {
@@ -441,6 +468,7 @@ func (s *UpgradeJujuSuite) Reset(c *gc.C) {
 
 func (s *UpgradeJujuSuite) TestUpgradeJujuWithRealUpload(c *gc.C) {
 	s.Reset(c)
+	s.PatchValue(&version.Current, version.MustParseBinary("1.4.6-quantal-amd64"))
 	cmd := envcmd.Wrap(&UpgradeJujuCommand{})
 	_, err := coretesting.RunCommand(c, cmd, "--upload-tools")
 	c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
Skip known bad versions, and ensure upgrading through 1.20.14 from older systems.

(Review request: http://reviews.vapour.ws/r/3281/)