### PR TITLE
singular-controller apiserver implementation

### DIFF
--- a/apiserver/params/internal.go
+++ b/apiserver/params/internal.go
@@ -650,3 +650,16 @@ type MeterStatusResult struct {
 type MeterStatusResults struct {
 	Results []MeterStatusResult
 }
+
+// SingularClaim represents a request for exclusive model administration access
+// on the part of some controller.
+type SingularClaim struct {
+	ModelTag      string        `json:"ModelTag"`
+	ControllerTag string        `json:"ControllerTag"`
+	Duration      time.Duration `json:"Duration"`
+}
+
+// SingularClaims holds any number of SingularClaim~s.
+type SingularClaims struct {
+	Claims []SingularClaim `json:"Claims"`
+}

--- a/apiserver/singular/fixture_test.go
+++ b/apiserver/singular/fixture_test.go
@@ -1,0 +1,58 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package singular_test
+
+import (
+	"time"
+
+	"github.com/juju/names"
+	"github.com/juju/testing"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/core/lease"
+	coretesting "github.com/juju/juju/testing"
+)
+
+// mockAuth represents a machine which may or may not be an environ manager.
+type mockAuth struct {
+	common.Authorizer
+	nonManager bool
+}
+
+// AuthEnvironManager is part of the common.Authorizer interface.
+func (mock mockAuth) AuthEnvironManager() bool {
+	return !mock.nonManager
+}
+
+// GetAuthTag is part of the common.Authorizer interface.
+func (mockAuth) GetAuthTag() names.Tag {
+	return names.NewMachineTag("123")
+}
+
+// mockBackend implements singular.Backend and lease.Claimer.
+type mockBackend struct {
+	stub testing.Stub
+}
+
+// EnvironTag is part of the singular.Backend interface.
+func (mock *mockBackend) EnvironTag() names.EnvironTag {
+	return coretesting.EnvironmentTag
+}
+
+// SingularClaimer is part of the singular.Backend interface.
+func (mock *mockBackend) SingularClaimer() lease.Claimer {
+	return mock
+}
+
+// Claim is part of the lease.Claimer interface.
+func (mock *mockBackend) Claim(lease, holder string, duration time.Duration) error {
+	mock.stub.AddCall("Claim", lease, holder, duration)
+	return mock.stub.NextErr()
+}
+
+// WaitUntilExpired is part of the lease.Claimer interface.
+func (mock *mockBackend) WaitUntilExpired(lease string) error {
+	mock.stub.AddCall("WaitUntilExpired", lease)
+	return mock.stub.NextErr()
+}

--- a/apiserver/singular/package_test.go
+++ b/apiserver/singular/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package singular_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/apiserver/singular/singular.go
+++ b/apiserver/singular/singular.go
@@ -1,0 +1,105 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package singular
+
+import (
+	"time"
+
+	"github.com/juju/names"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/lease"
+	"github.com/juju/juju/state"
+)
+
+func init() {
+	common.RegisterStandardFacade(
+		"Singular", 1,
+		func(st *state.State, _ *common.Resources, auth common.Authorizer) (*Facade, error) {
+			return NewFacade(st, auth)
+		},
+	)
+}
+
+// Backend supplies capabilities required by a Facade.
+type Backend interface {
+
+	// EnvironTag tells the Facade what models it should consider requests for.
+	EnvironTag() names.EnvironTag
+
+	// SingularClaimer allows the Facade to make claims.
+	SingularClaimer() lease.Claimer
+}
+
+// NewFacade returns a singular-controller API facade, backed by the supplied
+// state, so long as the authorizer represents a controller machine.
+func NewFacade(backend Backend, auth common.Authorizer) (*Facade, error) {
+	if !auth.AuthEnvironManager() {
+		return nil, common.ErrPerm
+	}
+	return &Facade{
+		auth:    auth,
+		model:   backend.EnvironTag(),
+		claimer: backend.SingularClaimer(),
+	}, nil
+}
+
+// Facade allows controller machines to request exclusive rights to administer
+// some specific model for a limited time.
+type Facade struct {
+	auth    common.Authorizer
+	model   names.EnvironTag
+	claimer lease.Claimer
+}
+
+// Wait waits for the singular-controller lease to expire for all supplied
+// entities. (In practice, any requests that do not refer to the connection's
+// model will be rejected.)
+func (facade *Facade) Wait(args params.Entities) (result params.ErrorResults) {
+	result.Results = make([]params.ErrorResult, len(args.Entities))
+	for i, entity := range args.Entities {
+		var err error
+		switch {
+		case entity.Tag != facade.model.String():
+			err = common.ErrPerm
+		default:
+			err = facade.claimer.WaitUntilExpired(facade.model.Id())
+		}
+		result.Results[i].Error = common.ServerError(err)
+	}
+	return result
+}
+
+// Claim makes the supplied singular-controller lease requests. (In practice,
+// any requests not for the connection's model, or not on behalf of the
+// connected EnvironManager machine, will be rejected.)
+func (facade *Facade) Claim(args params.SingularClaims) (result params.ErrorResults) {
+	result.Results = make([]params.ErrorResult, len(args.Claims))
+	for i, claim := range args.Claims {
+		var err error
+		switch {
+		case claim.ModelTag != facade.model.String():
+			err = common.ErrPerm
+		case claim.ControllerTag != facade.auth.GetAuthTag().String():
+			err = common.ErrPerm
+		case !allowedDuration(claim.Duration):
+			err = common.ErrPerm
+		default:
+			err = facade.claimer.Claim(facade.model.Id(), claim.ControllerTag, claim.Duration)
+		}
+		result.Results[i].Error = common.ServerError(err)
+	}
+	return result
+}
+
+// allowedDuration returns true if the supplied duration is at least one second,
+// and no more than one minute. (We expect to refine the lease-length times, but
+// these seem like reasonable bounds.)
+func allowedDuration(duration time.Duration) bool {
+	if duration < time.Second {
+		return false
+	}
+	return duration <= time.Minute
+}

--- a/apiserver/singular/singular_test.go
+++ b/apiserver/singular/singular_test.go
@@ -1,0 +1,170 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package singular_test
+
+import (
+	"time"
+
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/apiserver/singular"
+	coretesting "github.com/juju/juju/testing"
+)
+
+type SingularSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&SingularSuite{})
+
+func (s *SingularSuite) TestRequiresEnvironManager(c *gc.C) {
+	auth := mockAuth{nonManager: true}
+	facade, err := singular.NewFacade(nil, auth)
+	c.Check(facade, gc.IsNil)
+	c.Check(err, gc.Equals, common.ErrPerm)
+}
+
+func (s *SingularSuite) TestAcceptsEnvironManager(c *gc.C) {
+	backend := &mockBackend{}
+	facade, err := singular.NewFacade(backend, mockAuth{})
+	c.Check(facade, gc.NotNil)
+	c.Check(err, jc.ErrorIsNil)
+
+	backend.stub.CheckCallNames(c)
+}
+
+func (s *SingularSuite) TestInvalidClaims(c *gc.C) {
+	breakers := []func(claim *params.SingularClaim){
+		func(claim *params.SingularClaim) { claim.ModelTag = "" },
+		func(claim *params.SingularClaim) { claim.ModelTag = "machine-123" },
+		func(claim *params.SingularClaim) { claim.ModelTag = "environ-blargle" },
+		func(claim *params.SingularClaim) { claim.ControllerTag = "" },
+		func(claim *params.SingularClaim) { claim.ControllerTag = "machine-456" },
+		func(claim *params.SingularClaim) { claim.ControllerTag = coretesting.EnvironmentTag.String() },
+		func(claim *params.SingularClaim) { claim.Duration = time.Second - time.Millisecond },
+		func(claim *params.SingularClaim) { claim.Duration = time.Minute + time.Millisecond },
+	}
+	count := len(breakers)
+
+	var claims params.SingularClaims
+	claims.Claims = make([]params.SingularClaim, count)
+	for i, breaker := range breakers {
+		claim := params.SingularClaim{
+			ModelTag:      coretesting.EnvironmentTag.String(),
+			ControllerTag: "machine-123",
+			Duration:      time.Minute,
+		}
+		breaker(&claim)
+		claims.Claims[i] = claim
+	}
+
+	backend := &mockBackend{}
+	facade, err := singular.NewFacade(backend, mockAuth{})
+	c.Assert(err, jc.ErrorIsNil)
+	result := facade.Claim(claims)
+	c.Assert(result.Results, gc.HasLen, count)
+
+	for i, result := range result.Results {
+		c.Logf("checking claim %d", i)
+		checkDenied(c, result)
+	}
+	backend.stub.CheckCallNames(c)
+}
+
+func (s *SingularSuite) TestValidClaims(c *gc.C) {
+	durations := []time.Duration{
+		time.Second,
+		30 * time.Second,
+		time.Minute,
+	}
+	errors := []error{
+		nil,
+		errors.New("pow!"),
+		nil,
+	}
+	count := len(durations)
+	if len(errors) != count {
+		c.Fatalf("please fix your test data")
+	}
+
+	var claims params.SingularClaims
+	claims.Claims = make([]params.SingularClaim, count)
+	expectCalls := []testing.StubCall{}
+	for i, duration := range durations {
+		claims.Claims[i] = params.SingularClaim{
+			ModelTag:      coretesting.EnvironmentTag.String(),
+			ControllerTag: "machine-123",
+			Duration:      duration,
+		}
+		expectCalls = append(expectCalls, testing.StubCall{
+			FuncName: "Claim",
+			Args: []interface{}{
+				coretesting.EnvironmentTag.Id(),
+				"machine-123",
+				durations[i],
+			},
+		})
+	}
+
+	backend := &mockBackend{}
+	backend.stub.SetErrors(errors...)
+	facade, err := singular.NewFacade(backend, mockAuth{})
+	c.Assert(err, jc.ErrorIsNil)
+	result := facade.Claim(claims)
+	c.Assert(result.Results, gc.HasLen, count)
+
+	for i, err := range result.Results {
+		if errors[i] == nil {
+			c.Check(err.Error, gc.IsNil)
+		} else {
+			c.Check(err.Error.Error(), gc.Equals, errors[i].Error())
+		}
+	}
+	backend.stub.CheckCalls(c, expectCalls)
+}
+
+func (s *SingularSuite) TestWait(c *gc.C) {
+	waits := params.Entities{
+		Entities: []params.Entity{{
+			"machine-123", // rejected
+		}, {
+			"grarble floop", // rejected
+		}, {
+			coretesting.EnvironmentTag.String(), // stub-error
+		}, {
+			coretesting.EnvironmentTag.String(), // success
+		}},
+	}
+	count := len(waits.Entities)
+
+	backend := &mockBackend{}
+	backend.stub.SetErrors(errors.New("zap!"), nil)
+	facade, err := singular.NewFacade(backend, mockAuth{})
+	c.Assert(err, jc.ErrorIsNil)
+	result := facade.Wait(waits)
+	c.Assert(result.Results, gc.HasLen, count)
+
+	checkDenied(c, result.Results[0])
+	checkDenied(c, result.Results[1])
+	c.Check(result.Results[2].Error, gc.ErrorMatches, "zap!")
+	c.Check(result.Results[3].Error, gc.IsNil)
+
+	backend.stub.CheckCalls(c, []testing.StubCall{{
+		FuncName: "WaitUntilExpired",
+		Args:     []interface{}{coretesting.EnvironmentTag.Id()},
+	}, {
+		FuncName: "WaitUntilExpired",
+		Args:     []interface{}{coretesting.EnvironmentTag.Id()},
+	}})
+}
+
+func checkDenied(c *gc.C, result params.ErrorResult) {
+	c.Check(result.Error, gc.ErrorMatches, "permission denied")
+	c.Check(result.Error, jc.Satisfies, params.IsCodeUnauthorized)
+}


### PR DESCRIPTION
takes bulk args, but only accepts requests for the connection's environment on behalf of a connected controller machine.

ignore changes outside apiserver package, they're from http://reviews.vapour.ws/r/3274/ -- will upload clean diff imminently.

(Review request: http://reviews.vapour.ws/r/3284/)