### PR TITLE
Fixed lp:1520199: Better handling of MAAS errors around address allocation

### DIFF
--- a/apiserver/provisioner/container_test.go
+++ b/apiserver/provisioner/container_test.go
@@ -193,9 +193,9 @@ func (s *prepareSuite) TestErrorWithNoFeatureFlag(c *gc.C) {
 
 func (s *prepareSuite) TestErrorWithNoFeatureFlagAndBrokenAllocate(c *gc.C) {
 	s.breakEnvironMethods(c, "AllocateAddress")
-	s.SetFeatureFlags() // clear the flags.
+	s.SetFeatureFlags()
 	// Use the special "i-alloc-" prefix to force the dummy provider to allow
-	// AllocateAddress run without the feature flag.
+	// AllocateAddress to run without the feature flag.
 	container := s.newCustomAPI(c, "i-alloc-me", true, false)
 	args := s.makeArgs(container)
 	expectedError := &params.Error{
@@ -212,9 +212,9 @@ func (s *prepareSuite) TestErrorWithNoFeatureFlagAllocateSuccess(c *gc.C) {
 	s.SetFeatureFlags()
 	s.breakEnvironMethods(c)
 	// Use the special "i-alloc-" prefix to force the dummy provider to allow
-	// AllocateAddress run without the feature flag, which simulates a MAAS 1.8+
-	// environment where without the flag we still try calling AllocateAddress
-	// for the device we created for the container.
+	// AllocateAddress to run without the feature flag, which simulates a MAAS
+	// 1.8+ environment where without the flag we still try calling
+	// AllocateAddress for the device we created for the container.
 	container := s.newCustomAPI(c, "i-alloc-me", true, false)
 	args := s.makeArgs(container)
 	_, testLog := s.assertCall(c, args, s.makeResults([]params.NetworkConfig{{

--- a/apiserver/provisioner/provisioner.go
+++ b/apiserver/provisioner/provisioner.go
@@ -892,8 +892,8 @@ func (p *ProvisionerAPI) ReleaseContainerAddresses(args params.Entities) (params
 				hostname,
 			)
 			logger.Tracef("ReleaseAddress for hostname %q returned: %v", hostname, err)
-			if err != nil && errors.IsNotSupported(err) {
-				// Not using MAAS 1.8+, just record the error.
+			if err != nil {
+				// Likely not using MAAS 1.8+, just record the error.
 				result.Results[i].Error = common.ServerError(err)
 			}
 			continue
@@ -1042,22 +1042,36 @@ func (p *ProvisionerAPI) prepareOrGetContainerInterfaceInfo(
 				result.Results[i].Error = common.ServerError(err)
 				continue
 			}
-			if address == nil && !environs.AddressAllocationEnabled() {
-				// Container will use DHCP to get its IP, and it needs to use
-				// the generated MAC address.
-				result.Results[i] = params.MachineNetworkConfigResult{
-					Config: []params.NetworkConfig{{
-						DeviceIndex:   0,
-						InterfaceName: "eth0",
-						ConfigType:    string(network.ConfigDHCP),
-						MACAddress:    macAddress,
-						// The following should not be needed anymore, but the
-						// worker still validates them on SetProvisioned.
-						NetworkName: network.DefaultPrivate,
-						ProviderId:  network.DefaultPrivate,
-					}},
+			if address == nil {
+				// This is only an issue when the address allocation is enabled,
+				// as it should've been reported as an error after retrying a
+				// few times.
+				if !environs.AddressAllocationEnabled() {
+					// Without the feature flag, we might be running on MAAS
+					// 1.8+ in which case the container will use DHCP to get its
+					// IP, and it needs to use the generated MAC address.
+					result.Results[i] = params.MachineNetworkConfigResult{
+						Config: []params.NetworkConfig{{
+							DeviceIndex:   0,
+							InterfaceName: "eth0",
+							ConfigType:    string(network.ConfigDHCP),
+							MACAddress:    macAddress,
+							// The following should not be needed anymore, but the
+							// worker still validates them on SetProvisioned.
+							NetworkName: network.DefaultPrivate,
+							ProviderId:  network.DefaultPrivate,
+						}},
+					}
+					logger.Infof(
+						"reserved address for container %q with MAC address %q (using DHCP)",
+						container, macAddress,
+					)
+					continue
+				} else {
+					err = errors.New("expected allocated address, got nil and no error")
+					result.Results[i].Error = common.ServerError(err)
+					continue
 				}
-				continue
 			}
 		} else {
 			id := container.Id()
@@ -1280,11 +1294,12 @@ func (p *ProvisionerAPI) allocateAddress(
 		// and a MAC address (no subnet or IP address).
 		zeroIP := network.Address{}
 		err := environ.AllocateAddress(instId, network.AnySubnet, zeroIP, macAddress, hostname)
-		if err != nil && errors.IsNotSupported(err) {
-			// Not using MAAS 1.8+.
+		if err != nil {
+			// Not using MAAS 1.8+ or some other error.
 			return nil, errors.Trace(err)
 		}
-		// No address to return since the container will be using DHCP.
+		// No address to return since the container will be using DHCP (but the
+		// reserved address will be logged).
 		return nil, nil
 	}
 

--- a/apiserver/provisioner/provisioner.go
+++ b/apiserver/provisioner/provisioner.go
@@ -1238,6 +1238,14 @@ func (p *ProvisionerAPI) prepareAllocationNetwork(
 			// this subnet has no allocatable IPs
 			continue
 		}
+		if sub.AllocatableIPLow != nil && sub.AllocatableIPLow.To4() == nil {
+			logger.Tracef("ignoring IPv6 subnet %q - allocating IPv6 addresses not yet supported", sub.ProviderId)
+			// Until we change the way we pick addresses, IPv6 subnets with
+			// their *huge* ranges (/64 being the default), there is no point in
+			// allowing such subnets (it won't even work as PickNewAddress()
+			// assumes IPv4 allocatable range anyway).
+			continue
+		}
 		ok, err := environ.SupportsAddressAllocation(sub.ProviderId)
 		if err == nil && ok {
 			subnetInfo = sub

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -1104,7 +1104,12 @@ func (env *environ) SupportsAddressAllocation(subnetId network.Id) (bool, error)
 // given instance on the given subnet.
 func (env *environ) AllocateAddress(instId instance.Id, subnetId network.Id, addr network.Address, macAddress, hostname string) error {
 	if !environs.AddressAllocationEnabled() {
-		return errors.NotSupportedf("address allocation")
+		// Any instId starting with "i-alloc-" when the feature flag is off will
+		// still work, in order to be able to test MAAS 1.8+ environment where
+		// we can use devices for containers.
+		if !strings.HasPrefix(string(instId), "i-alloc-") {
+			return errors.NotSupportedf("address allocation")
+		}
 	}
 
 	if err := env.checkBroken("AllocateAddress"); err != nil {

--- a/provider/maas/bridgescript.go
+++ b/provider/maas/bridgescript.go
@@ -94,11 +94,11 @@ modify_network_config() {
 # with a space, if they could be discovered. The output is undefined
 # otherwise.
 get_gateway() {
-    $IP_CMD "$1" route list exact default | cut -d' ' -f3
+    $IP_CMD "$1" route list exact default | head -n1 | cut -d' ' -f3
 }
 
 get_primary_nic() {
-    $IP_CMD "$1" route list exact default | cut -d' ' -f5
+    $IP_CMD "$1" route list exact default | head -n1 | cut -d' ' -f5
 }
 
 # Display route table contents (IPv4 and IPv6), network devices, all

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -159,15 +159,15 @@ func NewEnviron(cfg *config.Config) (*maasEnviron, error) {
 	return env, nil
 }
 
-const noDevicesWarning = `
-WARNING: Using MAAS version older than 1.8.2: devices API support not detected!
+var noDevicesWarning = `
+Using MAAS version older than 1.8.2: devices API support not detected!
 
 Juju cannot guarantee resources allocated to containers, like DHCP
 leases or static IP addresses will be properly cleaned up when the
 container, its host, or the environment is destroyed.
 
 Juju recommends upgrading MAAS to version 1.8.2 or later.
-`
+`[1:]
 
 // Bootstrap is specified in the Environ interface.
 func (env *maasEnviron) Bootstrap(ctx environs.BootstrapContext, args environs.BootstrapParams) (arch, series string, _ environs.BootstrapFinalizer, _ error) {

--- a/provider/maas/environ_whitebox_test.go
+++ b/provider/maas/environ_whitebox_test.go
@@ -1348,7 +1348,7 @@ func (suite *environSuite) TestAllocateAddressDevicesFailures(c *gc.C) {
 		"GetMap of the response failed",
 		"no ip_addresses in response",
 		"unexpected ip_addresses in response",
-		"single IP in ip_addresses not a string",
+		"IP in ip_addresses not a string",
 	}
 	reserveIP := func(devices gomaasapi.MAASObject, deviceId string, addr network.Address) (network.Address, error) {
 		c.Check(deviceId, gc.Matches, "node-[a-f0-9]+")

--- a/provider/maas/environ_whitebox_test.go
+++ b/provider/maas/environ_whitebox_test.go
@@ -1337,6 +1337,34 @@ func (suite *environSuite) TestAllocateAddressDevices(c *gc.C) {
 	c.Assert(mac, gc.Equals, "foo")
 }
 
+func (suite *environSuite) TestAllocateAddressDevicesFailures(c *gc.C) {
+	suite.SetFeatureFlags()
+	suite.testMAASObject.TestServer.SetVersionJSON(`{"capabilities": ["devices-management"]}`)
+	testInstance := suite.createSubnets(c, false)
+	env := suite.makeEnviron()
+
+	responses := []string{
+		"claim_sticky_ip_address failed",
+		"GetMap of the response failed",
+		"no ip_addresses in response",
+		"unexpected ip_addresses in response",
+		"single IP in ip_addresses not a string",
+	}
+	reserveIP := func(devices gomaasapi.MAASObject, deviceId string, addr network.Address) (network.Address, error) {
+		c.Check(deviceId, gc.Matches, "node-[a-f0-9]+")
+		c.Check(addr, jc.DeepEquals, network.Address{})
+		nextError := responses[0]
+		return network.Address{}, errors.New(nextError)
+	}
+	suite.PatchValue(&ReserveIPAddressOnDevice, reserveIP)
+
+	for len(responses) > 0 {
+		err := env.AllocateAddress(testInstance.Id(), network.AnySubnet, network.Address{}, "mac-address", "hostname")
+		c.Check(err, gc.ErrorMatches, responses[0])
+		responses = responses[1:]
+	}
+}
+
 func (suite *environSuite) getDeviceArray(c *gc.C) []gomaasapi.JSONObject {
 	devicesURL := "/api/1.0/devices/?op=list"
 	resp, err := http.Get(suite.testMAASObject.TestServer.Server.URL + devicesURL)

--- a/worker/provisioner/lxc-broker.go
+++ b/worker/provisioner/lxc-broker.go
@@ -678,8 +678,10 @@ func prepareOrGetContainerInterfaceInfo(
 	containerTag := names.NewMachineTag(machineID)
 	preparedInfo, err := api.PrepareContainerInterfaceInfo(containerTag)
 	if err != nil && errors.IsNotSupported(err) {
-		log.Debugf("new container %q not registered as device: not running on MAAS 1.8+", machineID)
+		log.Warningf("new container %q not registered as device: not running on MAAS 1.8+", machineID)
 		return nil, nil
+	} else if err != nil {
+		return nil, errors.Trace(err)
 	}
 
 	log.Tracef("PrepareContainerInterfaceInfo returned %#v", preparedInfo)
@@ -723,6 +725,7 @@ func maybeReleaseContainerAddresses(
 	case err == nil:
 		log.Infof("released all addresses for container %q", containerTag.Id())
 	case errors.IsNotSupported(err):
+		log.Warningf("not releasing all addresses for container %q: %v", containerTag.Id(), err)
 	default:
 		log.Warningf(
 			"unexpected error trying to release container %q addreses: %v",


### PR DESCRIPTION
A few issues fixed in provider/maas:
 * Errors and unexpected responses from MAAS devices API are now logged
   and returned when relevant, rather than ignored in a few cases.
 * Better support for MAAS nodes with NICs having both IPv4 and IPv6
   addresses (for the same MAC address) from subnets with allocatable
   static ranges.
 * Correct handling of multiple IPv6 gateways in the MAAS bridge script.
 * Related to bug http://pad.lv/1519527 - claim_sticky_ip_address
   response is verified to contain an IP address for the container. If
   it doesn't have it, report and error (rather than cause all
   containers to get the same IP as described in the bug above).

See bug http://pad.lv/1520199 for more details.

Live tested on MAAS 1.7, 1.8, and 1.9rc2 with and without the
addressable containers feature flag, using LXC containers, both on
trusty and precise.

(Review request: http://reviews.vapour.ws/r/3285/)