### PR TITLE
Leadership test races

### DIFF
--- a/state/leadership/fixture_test.go
+++ b/state/leadership/fixture_test.go
@@ -69,6 +69,7 @@ type Fixture struct {
 // RunTest sets up a Manager and a Clock and passes them into the supplied
 // test function. The manager will be cleaned up afterwards.
 func (fix *Fixture) RunTest(c *gc.C, test func(leadership.ManagerWorker, *testing.Clock)) {
+	waitForAlarm := len(fix.leases) > 0
 	clock := testing.NewClock(defaultClockStart)
 	client := NewClient(fix.leases, fix.expectCalls)
 	manager, err := leadership.NewManager(leadership.ManagerConfig{
@@ -86,5 +87,20 @@ func (fix *Fixture) RunTest(c *gc.C, test func(leadership.ManagerWorker, *testin
 		}
 	}()
 	defer client.Wait(c)
+
+	if waitForAlarm {
+		waitAlarms(c, clock, 1)
+	}
 	test(manager, clock)
+}
+
+func waitAlarms(c *gc.C, clock *testing.Clock, count int) {
+	timeout := time.After(testing.LongWait)
+	for i := 0; i < count; i++ {
+		select {
+		case <-clock.Alarms():
+		case <-timeout:
+			c.Fatalf("timed out waiting for %dth alarm set", i)
+		}
+	}
 }

--- a/state/leadership/manager_expire_test.go
+++ b/state/leadership/manager_expire_test.go
@@ -263,6 +263,10 @@ func (s *ExpireLeadershipSuite) TestExpire_Multiple(c *gc.C) {
 				Holder: "vvvvvv/2",
 				Expiry: offset(time.Second), // would expire, but errors first.
 			},
+			"worgen": lease.Info{
+				Holder: "worgen/2",
+				Expiry: offset(time.Minute), // verifies absence of loop-var bug.
+			},
 		},
 		expectCalls: []call{{
 			method: "ExpireLease",

--- a/state/leadership/manager_expire_test.go
+++ b/state/leadership/manager_expire_test.go
@@ -35,10 +35,7 @@ func (s *ExpireLeadershipSuite) TestStartup_ExpiryInPast(c *gc.C) {
 			},
 		}},
 	}
-	fix.RunTest(c, func(_ leadership.ManagerWorker, _ *coretesting.Clock) {
-		//XXX WTF
-		time.Sleep(coretesting.ShortWait)
-	})
+	fix.RunTest(c, func(_ leadership.ManagerWorker, _ *coretesting.Clock) {})
 }
 
 func (s *ExpireLeadershipSuite) TestStartup_ExpiryInFuture(c *gc.C) {

--- a/testing/clock.go
+++ b/testing/clock.go
@@ -190,9 +190,7 @@ func (a byTime) Len() int           { return len(a) }
 func (a byTime) Less(i, j int) bool { return a[i].time.Before(a[j].time) }
 func (a byTime) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
 
-// removeFromSlice removes item at the specified index from the slice
-// It exists to make the append train clearer
-// This doesn't check that index is valid, so the caller needs to check that.
+// removeFromSlice removes item at the specified index from the slice.
 func removeFromSlice(sl []alarm, index int) []alarm {
 	return append(sl[:index], sl[index+1:]...)
 }


### PR DESCRIPTION
Run under go 1.5, TestExpire_Multiple was reliably hanging and failing badly. Now, if it were to fail, it would time out nicely; but it shouldn't fail any more, because clock Advances can now be; and now are: synchronised with the SUT.

Also fixed a hideously embarrassing pointer-to-loop-var bug. Hanging head in shame.

(Review request: http://reviews.vapour.ws/r/3290/)