### PR TITLE
Add status to remote services and update allwatcher model

### DIFF
--- a/apiserver/service/service.go
+++ b/apiserver/service/service.go
@@ -31,7 +31,15 @@ func init() {
 
 // Service defines the methods on the service API end point.
 type Service interface {
+	// SetMetricCredentials sets credentials on the service.
 	SetMetricCredentials(args params.ServiceMetricCredentials) (params.ErrorResults, error)
+
+	// ServicesDeploy fetches the charms from the charm store and deploys them.
+	ServicesDeploy(args params.ServicesDeploy) (params.ErrorResults, error)
+
+	// ServicesDeployWithPlacement fetches the charms from the charm store and deploys them
+	// using the specified placement directives.
+	ServicesDeployWithPlacement(args params.ServicesDeploy) (params.ErrorResults, error)
 }
 
 // API implements the service interface and is the concrete
@@ -47,7 +55,7 @@ func NewAPI(
 	st *state.State,
 	resources *common.Resources,
 	authorizer common.Authorizer,
-) (*API, error) {
+) (Service, error) {
 	if !authorizer.AuthClient() {
 		return nil, common.ErrPerm
 	}

--- a/apiserver/service/service_test.go
+++ b/apiserver/service/service_test.go
@@ -39,7 +39,7 @@ type serviceSuite struct {
 	apiservertesting.CharmStoreSuite
 	commontesting.BlockHelper
 
-	serviceApi *service.API
+	serviceApi service.Service
 	service    *state.Service
 	authorizer apiservertesting.FakeAuthorizer
 }

--- a/apiserver/service/service_test.go
+++ b/apiserver/service/service_test.go
@@ -46,8 +46,6 @@ type serviceSuite struct {
 
 var _ = gc.Suite(&serviceSuite{})
 
-var _ service.Service = (*service.API)(nil)
-
 func (s *serviceSuite) SetUpSuite(c *gc.C) {
 	s.CharmStoreSuite.SetUpSuite(c)
 	s.JujuConnSuite.SetUpSuite(c)

--- a/state/allwatcher.go
+++ b/state/allwatcher.go
@@ -505,10 +505,7 @@ func (svc *backingRemoteService) updated(st *State, store *multiwatcherStore, id
 	}
 	serviceStatus, err := service.Status()
 	if err != nil {
-		logger.Warningf("reading remote service status for key %s: %v", key, err)
-	}
-	if err != nil {
-		return errors.Annotatef(err, "reading service status for key %s", key)
+		return errors.Annotatef(err, "reading remote service status for key %s", key)
 	}
 	info.Status = multiwatcher.StatusInfo{
 		Current: multiwatcher.Status(serviceStatus.Status),

--- a/state/allwatcher_internal_test.go
+++ b/state/allwatcher_internal_test.go
@@ -3018,13 +3018,7 @@ func testChangeRemoteServices(c *gc.C, owner names.UserTag, runChangeTests func(
 			mysql, remoteServiceInfo := addTestingRemoteService(
 				c, st, "remote-mysql", "local:/u/me/mysql", mysqlRelations,
 			)
-			err := setStatus(st, setStatusParams{
-				badge:     "remote service",
-				globalKey: mysql.globalKey(),
-				status:    "active",
-				message:   "running",
-				rawData:   map[string]interface{}{"foo": "bar"},
-			})
+			err := mysql.SetStatus(StatusActive, "running", map[string]interface{}{"foo": "bar"})
 			c.Assert(err, jc.ErrorIsNil)
 			initialRemoteServiceInfo := remoteServiceInfo
 			remoteServiceInfo.Status = multiwatcher.StatusInfo{

--- a/state/multiwatcher/multiwatcher.go
+++ b/state/multiwatcher/multiwatcher.go
@@ -199,10 +199,7 @@ type RemoteServiceInfo struct {
 	Name       string
 	ServiceURL string
 	Life       Life
-	Endpoints  []Endpoint
-	// TODO(axw) Description, Icon. These would normally be part of a
-	// charm, but remote services do not have this information currently.
-	// TODO(axw) Status? Needs status in the remote service model too.
+	Status     StatusInfo
 }
 
 // EntityId returns a unique identifier for a remote service across

--- a/state/remoteservice.go
+++ b/state/remoteservice.go
@@ -55,7 +55,7 @@ func newRemoteService(st *State, doc *remoteServiceDoc) *RemoteService {
 // remoteServiceGlobalKey returns the global database key for the
 // remote service with the given name.
 func remoteServiceGlobalKey(svcName string) string {
-	return "rs#" + svcName
+	return "c#" + svcName
 }
 
 // globalKey returns the global database key for the remote service.

--- a/state/remoteservice.go
+++ b/state/remoteservice.go
@@ -358,6 +358,7 @@ func (st *State) AddRemoteService(name, url string, endpoints []charm.Relation) 
 		}
 		ops := []txn.Op{
 			env.assertAliveOp(),
+			createStatusOp(st, svc.globalKey(), statusDoc),
 			{
 				C:      remoteServicesC,
 				Id:     serviceID,
@@ -368,7 +369,6 @@ func (st *State) AddRemoteService(name, url string, endpoints []charm.Relation) 
 				Id:     serviceID,
 				Assert: txn.DocMissing,
 			},
-			createStatusOp(st, svc.globalKey(), statusDoc),
 		}
 		return ops, nil
 	}

--- a/state/remoteservice.go
+++ b/state/remoteservice.go
@@ -6,6 +6,7 @@ package state
 import (
 	"fmt"
 	"sort"
+	"time"
 
 	"github.com/juju/errors"
 	"github.com/juju/juju/model/crossmodel"
@@ -49,6 +50,17 @@ func newRemoteService(st *State, doc *remoteServiceDoc) *RemoteService {
 		doc: *doc,
 	}
 	return svc
+}
+
+// remoteServiceGlobalKey returns the global database key for the
+// remote service with the given name.
+func remoteServiceGlobalKey(svcName string) string {
+	return "rs#" + svcName
+}
+
+// globalKey returns the global database key for the remote service.
+func (s *RemoteService) globalKey() string {
+	return remoteServiceGlobalKey(s.doc.Name)
 }
 
 // IsRemote returns true for a remote service.
@@ -185,8 +197,28 @@ func (s *RemoteService) removeOps(asserts bson.D) []txn.Op {
 			Assert: asserts,
 			Remove: true,
 		},
+		removeStatusOp(s.st, s.globalKey()),
 	}
 	return ops
+}
+
+// Status returns the status of the remote service.
+func (s *RemoteService) Status() (StatusInfo, error) {
+	return getStatus(s.st, s.globalKey(), "remote service")
+}
+
+// SetStatus sets the status for the service.
+func (s *RemoteService) SetStatus(status Status, info string, data map[string]interface{}) error {
+	if !ValidWorkloadStatus(status) {
+		return errors.Errorf("cannot set invalid status %q", status)
+	}
+	return setStatus(s.st, setStatusParams{
+		badge:     "remote service",
+		globalKey: s.globalKey(),
+		status:    status,
+		message:   info,
+		rawData:   data,
+	})
 }
 
 // Endpoints returns the service's currently available relation endpoints.
@@ -297,6 +329,13 @@ func (st *State) AddRemoteService(name, url string, endpoints []charm.Relation) 
 	svcDoc.Endpoints = eps
 	svc := newRemoteService(st, svcDoc)
 
+	statusDoc := statusDoc{
+		EnvUUID:    st.EnvironUUID(),
+		Status:     StatusUnknown,
+		StatusInfo: "waiting for remote connection",
+		Updated:    time.Now().UnixNano(),
+	}
+
 	buildTxn := func(attempt int) ([]txn.Op, error) {
 		// If we've tried once already and failed, check that
 		// environment may have been destroyed.
@@ -329,6 +368,7 @@ func (st *State) AddRemoteService(name, url string, endpoints []charm.Relation) 
 				Id:     serviceID,
 				Assert: txn.DocMissing,
 			},
+			createStatusOp(st, svc.globalKey(), statusDoc),
 		}
 		return ops, nil
 	}

--- a/state/remoteservice_test.go
+++ b/state/remoteservice_test.go
@@ -110,7 +110,7 @@ func (s *remoteServiceSuite) TestSetStatusSince(c *gc.C) {
 	c.Assert(timeBeforeOrEqual(*firstTime, *status.Since), jc.IsTrue)
 }
 
-func (s *remoteServiceSuite) TestGetSetStatusGone(c *gc.C) {
+func (s *remoteServiceSuite) TestGetSetStatusNotFound(c *gc.C) {
 	err := s.service.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/state/remoteservice_test.go
+++ b/state/remoteservice_test.go
@@ -5,6 +5,7 @@ package state_test
 
 import (
 	"sort"
+	"time"
 
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
@@ -62,6 +63,63 @@ func (s *remoteServiceSuite) assertServiceRelations(c *gc.C, svc *state.Service,
 	sort.Strings(relKeys)
 	c.Assert(relKeys, gc.DeepEquals, expectedKeys)
 	return rels
+}
+
+func (s *remoteServiceSuite) TestInitialStatus(c *gc.C) {
+	status, err := s.service.Status()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(status.Since, gc.NotNil)
+	status.Since = nil
+	c.Assert(status, gc.DeepEquals, state.StatusInfo{
+		Status:  state.StatusUnknown,
+		Message: "waiting for remote connection",
+		Data:    map[string]interface{}{},
+	})
+}
+
+func (s *remoteServiceSuite) TestStatus(c *gc.C) {
+	err := s.service.SetStatus(state.StatusMaintenance, "busy", map[string]interface{}{"foo": "bar"})
+	c.Assert(err, jc.ErrorIsNil)
+	svc, err := s.State.RemoteService("mysql")
+	c.Assert(err, jc.ErrorIsNil)
+	status, err := svc.Status()
+	c.Assert(status.Since, gc.NotNil)
+	status.Since = nil
+	c.Assert(status, gc.DeepEquals, state.StatusInfo{
+		Status:  state.StatusMaintenance,
+		Message: "busy",
+		Data:    map[string]interface{}{"foo": "bar"},
+	})
+}
+
+func (s *remoteServiceSuite) TestSetStatusSince(c *gc.C) {
+	now := time.Now()
+	err := s.service.SetStatus(state.StatusMaintenance, "", nil)
+	c.Assert(err, jc.ErrorIsNil)
+	status, err := s.service.Status()
+	c.Assert(err, jc.ErrorIsNil)
+	firstTime := status.Since
+	c.Assert(firstTime, gc.NotNil)
+	c.Assert(timeBeforeOrEqual(now, *firstTime), jc.IsTrue)
+
+	// Setting the same status a second time also updates the timestamp.
+	err = s.service.SetStatus(state.StatusMaintenance, "", nil)
+	c.Assert(err, jc.ErrorIsNil)
+	status, err = s.service.Status()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(timeBeforeOrEqual(*firstTime, *status.Since), jc.IsTrue)
+}
+
+func (s *remoteServiceSuite) TestGetSetStatusGone(c *gc.C) {
+	err := s.service.Destroy()
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = s.service.SetStatus(state.StatusActive, "not really", nil)
+	c.Check(err, gc.ErrorMatches, `cannot set status: remote service not found`)
+
+	statusInfo, err := s.service.Status()
+	c.Check(err, gc.ErrorMatches, `cannot get status: remote service not found`)
+	c.Check(statusInfo, gc.DeepEquals, state.StatusInfo{})
 }
 
 func (s *remoteServiceSuite) TestTag(c *gc.C) {

--- a/state/status_filesystem_test.go
+++ b/state/status_filesystem_test.go
@@ -131,7 +131,7 @@ func (s *FilesystemStatusSuite) TestGetSetStatusDead(c *gc.C) {
 	s.checkGetSetStatus(c)
 }
 
-func (s *FilesystemStatusSuite) TestGetSetStatusGone(c *gc.C) {
+func (s *FilesystemStatusSuite) TestGetSetStatusNotFound(c *gc.C) {
 	s.obliterateFilesystem(c, s.filesystem.FilesystemTag())
 
 	err := s.filesystem.SetStatus(state.StatusAttaching, "not really", nil)

--- a/state/status_machine_test.go
+++ b/state/status_machine_test.go
@@ -109,7 +109,7 @@ func (s *MachineStatusSuite) TestGetSetStatusDead(c *gc.C) {
 	s.checkGetSetStatus(c)
 }
 
-func (s *MachineStatusSuite) TestGetSetStatusGone(c *gc.C) {
+func (s *MachineStatusSuite) TestGetSetStatusNotFound(c *gc.C) {
 	err := s.machine.EnsureDead()
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.machine.Remove()

--- a/state/status_service_test.go
+++ b/state/status_service_test.go
@@ -86,7 +86,7 @@ func (s *ServiceStatusSuite) TestGetSetStatusDying(c *gc.C) {
 	s.checkGetSetStatus(c)
 }
 
-func (s *ServiceStatusSuite) TestGetSetStatusGone(c *gc.C) {
+func (s *ServiceStatusSuite) TestGetSetStatusNotFound(c *gc.C) {
 	err := s.service.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/state/status_unit_test.go
+++ b/state/status_unit_test.go
@@ -98,7 +98,7 @@ func (s *UnitStatusSuite) TestGetSetStatusDead(c *gc.C) {
 	s.checkGetSetStatus(c)
 }
 
-func (s *UnitStatusSuite) TestGetSetStatusGone(c *gc.C) {
+func (s *UnitStatusSuite) TestGetSetStatusNotFound(c *gc.C) {
 	err := s.unit.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/state/status_unitagent_test.go
+++ b/state/status_unitagent_test.go
@@ -112,7 +112,7 @@ func (s *StatusUnitAgentSuite) TestGetSetStatusDead(c *gc.C) {
 	s.checkGetSetStatus(c)
 }
 
-func (s *StatusUnitAgentSuite) TestGetSetStatusGone(c *gc.C) {
+func (s *StatusUnitAgentSuite) TestGetSetStatusNotFound(c *gc.C) {
 	err := s.unit.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/state/status_volume_test.go
+++ b/state/status_volume_test.go
@@ -137,7 +137,7 @@ func (s *VolumeStatusSuite) TestGetSetStatusDead(c *gc.C) {
 	s.checkGetSetStatus(c, state.StatusAttaching)
 }
 
-func (s *VolumeStatusSuite) TestGetSetStatusGone(c *gc.C) {
+func (s *VolumeStatusSuite) TestGetSetStatusNotFound(c *gc.C) {
 	s.obliterateVolume(c, s.volume.VolumeTag())
 
 	err := s.volume.SetStatus(state.StatusAttaching, "not really", nil)


### PR DESCRIPTION
Remote services now are able to record their status.
No status history in this branch.

The status is reflected in the allwatcher model. Endpoints in this model are removed. Such information is available via the CrossModelRelations.Show() API.

Also, a drive by fix for apiserver service.go to update the interface.

(Review request: http://reviews.vapour.ws/r/3291/)