### PR TITLE
maas: Fix a go vet warning

### DIFF
--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -118,7 +118,7 @@ func reserveIPAddressOnDevice(devices gomaasapi.MAASObject, deviceId string, add
 			// We only need the first address, but we're logging all we got.
 			firstAddress = network.NewAddress(value)
 		}
-		logger.Debugf("reserved address %q for device %q", value)
+		logger.Debugf("reserved address %q for device %q", value, deviceId)
 	}
 	return firstAddress, nil
 }


### PR DESCRIPTION
Fixes an issue discovered in #3866 by running ./scripts.verify.bash:
```
$ ./scripts/verify.bash 
go version go1.2.1
checking: go fmt ...
checking: go vet ...
provider/maas/environ.go:121: missing argument for Debugf verb %q: need 2, have 1
checking: go build ...
checking: tests are wired up ...
```

(Review request: http://reviews.vapour.ws/r/3296/)