### PR TITLE
dependencies.tsv: update to latest juju/utils

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -33,7 +33,7 @@ github.com/juju/schema	git	afe1151cb49d1d7ed3c75592dfc6f38703f2e988	2015-08-07T0
 github.com/juju/syslog	git	6be94e8b718766e9ff7a37342157fe4795da7cfa	2015-02-05T15:59:36Z
 github.com/juju/testing	git	3a4202497a8bff67966ecb327a0505fea8bb6ead	2015-11-23T15:50:06Z
 github.com/juju/txn	git	99ec629d0066a4d73c54d8e021a7fc1dc07df614	2015-06-09T16:58:27Z
-github.com/juju/utils	git	2c8f72a83e6830efc95c870fd7017a822d561c55	2015-11-19T20:50:34Z
+github.com/juju/utils	git	cd8c831097feb15b88597f2abe69e3b808df9131	2015-12-04T20:50:34Z
 github.com/juju/xml	git	eb759a627588d35166bc505fceb51b88500e291e	2015-04-13T13:11:21Z
 github.com/julienschmidt/httprouter	git	109e267447e95ad1bb48b758e40dd7453eb7b039	2015-09-05T17:25:33Z
 github.com/lxc/lxd	git	42b4c228e84cba622f221e04a1fa7164a416a440	2015-10-27T22:33:42Z


### PR DESCRIPTION
Fixes LP 1519097

Update github.com/juju/utils to pick up the fix for LP 1519097.

(Review request: http://reviews.vapour.ws/r/3301/)