### PR TITLE
Fixed lp:1522484

### DIFF
--- a/state/package_test.go
+++ b/state/package_test.go
@@ -1,7 +1,7 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package state
+package state_test
 
 import (
 	stdtesting "testing"


### PR DESCRIPTION
Fixes the regression caused by #3806 which effectively skipped all
tests in the state package itself (not its subpackages)

Luckily, all tests pass.

(Review request: http://reviews.vapour.ws/r/3309/)