### PR TITLE
provider/maas: make network bridge script work for MAAS 1.9

### DIFF
--- a/provider/maas/bridgescript.go
+++ b/provider/maas/bridgescript.go
@@ -94,11 +94,11 @@ modify_network_config() {
 # with a space, if they could be discovered. The output is undefined
 # otherwise.
 get_gateway() {
-    $IP_CMD "$1" route list exact default | cut -d' ' -f3
+    $IP_CMD "$1" route list exact default | head -n1 | cut -d' ' -f3
 }
 
 get_primary_nic() {
-    $IP_CMD "$1" route list exact default | cut -d' ' -f5
+    $IP_CMD "$1" route list exact default | head -n1 | cut -d' ' -f5
 }
 
 # Display route table contents (IPv4 and IPv6), network devices, all

--- a/provider/maas/bridgescript.go
+++ b/provider/maas/bridgescript.go
@@ -1,0 +1,243 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package maas
+
+const bridgeScriptBase = `
+# Print message with function and line number info from perspective of
+# the caller and exit with status code 1.
+fatal()
+{
+    local message=$1
+    echo "${BASH_SOURCE[1]}: line ${BASH_LINENO[0]}: ${FUNCNAME[1]}: fatal error: ${message:-'died'}." >&2
+    exit 1
+}
+
+# Modifies $configfile to enslave $primary_nic using $bridge.
+#
+# This function does not ifdown/up any interfaces, it merely rewrites
+# $configfile so that this can be done as and when necessary.
+#
+# Returns 1 on any error, otherwise 0 for success.
+#
+modify_network_config() {
+    [ $# -lt 4 ] && return 1
+
+    if [ -z "$1" ] || [ -z "$2" ] || [ -z "$3" ] || [ -z "$4" ]; then
+	return 1
+    fi
+
+    local address_family=$1
+    local primary_nic=$2
+    local configfile=$3
+    local bridge=$4
+
+    [ -f "$configfile" ] || return 1
+
+    if [ "$address_family" != "inet" ] && [ "$address_family" != "inet6" ]; then
+	return 1
+    fi
+
+    grep -q -E "iface $primary_nic\s+$address_family\s+" "$configfile" || return 1
+    grep -q -E "auto $primary_nic[^:]*$" "$configfile" || return 1
+
+    # Change:
+    #     iface eth0 inet dhcp|manual|static
+    # to:
+    #     iface juju-br0 inet dhcp|manual|static
+    sed -ri "s/^\s*iface\s+${primary_nic}\s+${address_family}\s+(.*)$/iface $bridge $address_family \1/" "$configfile" || fatal 'sed failed'
+
+    # Change:
+    #     auto eth0
+    # to:
+    #     auto juju-br0
+    sed -ri "s/^\s*auto\s+${primary_nic}\s*$/auto $bridge/" "$configfile" || fatal 'sed failed'
+
+    # Append line after:
+    #     iface juju-br0 inet
+    # to:
+    #     iface juju-br0 inet
+    #         bridge_ports eth0
+    #
+    sed -i "/^iface $bridge $address_family /a\    bridge_ports $primary_nic" "$configfile" || fatal 'sed failed'
+
+    # Ensure the existing primary nic becomes manual.
+    # Change:
+    #     auto juju-br0
+    # to:
+    #     iface eth0 inet manual
+    #     auto juju-br0
+    #
+    sed -i "/^auto $bridge/iiface $primary_nic $address_family manual\n" "$configfile" || fatal 'sed failed'
+
+    # Also enslave any aliases (e.g. like eth0:0, eth0:1).
+
+    # Change:
+    #     auto eth0:1
+    #     iface eth0:1 inet static
+    # to:
+    #     auto juju-br0:1
+    #     iface juju-br0:1 inet static
+    sed -ri "s/^\s*auto\s+${primary_nic}(:.+)\s*$/auto $bridge\1/" "$configfile" || fatal 'sed failed'
+    sed -ri "s/^\s*iface\s+${primary_nic}(:.+)\s+${address_family}\s+(.*)$/iface $bridge\1 $address_family \2/" "$configfile" || fatal 'sed failed'
+
+    return 0
+}
+
+# Discover the needed IPv4/IPv6 configuration for $BRIDGE (if any).
+#
+# Arguments:
+#
+#   $1: the first argument to $IP_CMD (e.g. "-6" or "-4")
+#
+# Outputs the discovered default gateway and primary NIC, separated
+# with a space, if they could be discovered. The output is undefined
+# otherwise.
+get_gateway() {
+    $IP_CMD "$1" route list exact default | cut -d' ' -f3
+}
+
+get_primary_nic() {
+    $IP_CMD "$1" route list exact default | cut -d' ' -f5
+}
+
+# Display route table contents (IPv4 and IPv6), network devices, all
+# configured IPv4 and IPv6 addresses, and the contents of $CONFIGFILE
+# for diagnosing connectivity issues.
+dump_network_config() {
+    # Note: Use the simplest command and options to be compatible with
+    # precise.
+
+    echo "======================================================="
+    echo "${1} Network Configuration"
+    echo "======================================================="
+    echo
+
+    echo "-------------------------------------------------------"
+    echo "Route table contents:"
+    echo "-------------------------------------------------------"
+    $IP_CMD route show
+    echo
+
+    echo "-------------------------------------------------------"
+    echo "Network devices:"
+    echo "-------------------------------------------------------"
+    $IFCONFIG_CMD -a
+    echo
+
+    echo "-------------------------------------------------------"
+    echo "Contents of $CONFIGFILE"
+    echo "-------------------------------------------------------"
+    cat "$CONFIGFILE"
+}
+`
+
+const bridgeScriptMain = `
+: ${CONFIGFILE:={{.Config}}}
+: ${PING_CMD:="ping"}
+: ${IP_CMD:="ip"}
+: ${IFUP_CMD:="ifup"}
+: ${IFDOWN_CMD:="ifdown"}
+: ${IFCONFIG_CMD:="ifconfig"}
+: ${BRIDGE:={{.Bridge}}}
+
+set -u
+
+main() {
+    local orig_config_file="$CONFIGFILE"
+    local new_config_file="${CONFIGFILE}-juju"
+
+    # In case we already created the bridge, don't do it again.
+    grep -q "iface $BRIDGE inet" "$orig_config_file" && exit 0
+
+    # We're going to do all our mods against a new file.
+    cp -a "$CONFIGFILE" "$new_config_file" || fatal "cp failed"
+
+    # Take a one-time reference of the original file
+    if [ ! -f "${CONFIGFILE}-orig" ]; then
+	cp -a "$CONFIGFILE" "${CONFIGFILE}-orig" || fatal "cp failed"
+    fi
+
+    # determine whether to configure $bridge for ipv4, ipv6, or both.
+    local ipv4_gateway=$(get_gateway -4)
+    local ipv4_primary_nic=$(get_primary_nic -4)
+    local ipv6_gateway=$(get_gateway -6)
+    local ipv6_primary_nic=$(get_primary_nic -6)
+
+    echo "ipv4 gateway = $ipv4_gateway"
+    echo "ipv4 primary nic = $ipv4_primary_nic"
+    echo
+    echo "ipv6 gateway = $ipv6_gateway"
+    echo "ipv6 primary nic = $ipv6_primary_nic"
+
+    if [ -z "$ipv4_gateway" ] && [ -z "$ipv6_gateway" ]; then
+	fatal "cannot discover ipv4 and ipv6 gateway"
+    fi
+
+    local modify_network_config_failed=0
+
+    if [ -n "$ipv4_gateway" ]; then
+	modify_network_config "inet" "$ipv4_primary_nic" "$new_config_file" "$BRIDGE"
+	if [ $? -ne 0 ]; then
+	    modify_network_config_failed=1
+	fi
+    fi
+
+    if [ -n "$ipv6_gateway" ]; then
+	# TODO This should be similar to the IPv4 block above.
+	# TODO Further work and testing required for IPv6 setups.
+	echo "Cannot enslave $ipv6_primary_nic; IPv6 not supported in this script"
+    fi
+
+    if [ $modify_network_config_failed -eq 1 ]; then
+	fatal "failed to add $BRIDGE to $orig_config_file"
+    fi
+
+    if ! ip link list "$BRIDGE"; then
+	$IP_CMD link add dev "$ipv4_primary_nic" name "$BRIDGE" type bridge
+	if [ $? -ne 0 ]; then
+	    fatal "cannot add $BRIDGE bridge"
+	fi
+    fi
+
+    local nics=""
+
+    if [ -n "$ipv4_gateway" ]; then
+	nics="${nics} $ipv4_primary_nic"
+    fi
+
+    if [ -n "$ipv6_gateway" ]; then
+	# TODO Further work and testing required for IPv6 setups.
+	:
+    fi
+
+    echo "--------------------------------------------------
+    echo "Activating $BRIDGE configuration"
+    echo "--------------------------------------------------
+    cat "$new_config_file"
+
+    for nic in $nics; do
+	$IFDOWN_CMD -v -i "$orig_config_file" "$nic"
+	if [ $? -ne 0 ]; then
+	    fatal "failed to bring down $nic"
+	fi
+    done
+
+    $IFUP_CMD -v -i "$new_config_file" "$BRIDGE"
+    if [ $? -ne 0 ]; then
+	fatal "failed to bring up $BRIDGE"
+    fi
+
+    # Bring up all aliases or bonds on the bridge.
+    $IFUP_CMD -a -v -i "$new_config_file"
+    if [ $? -ne 0 ]; then
+	fatal "failed to bring up all interfaces"
+    fi
+
+    mv -f "$new_config_file" "$orig_config_file" || fatal "mv failed"
+}
+
+trap 'dump_network_config "Active"' EXIT
+dump_network_config "Current"
+main
+`

--- a/provider/maas/bridgescript_test.go
+++ b/provider/maas/bridgescript_test.go
@@ -1,0 +1,327 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package maas
+
+import (
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/exec"
+	gc "gopkg.in/check.v1"
+
+	coretesting "github.com/juju/juju/testing"
+)
+
+type bridgeConfigSuite struct {
+	coretesting.BaseSuite
+
+	testConfig     string
+	testConfigPath string
+	testBridgeName string
+}
+
+var _ = gc.Suite(&bridgeConfigSuite{})
+
+func (s *bridgeConfigSuite) SetUpSuite(c *gc.C) {
+	if runtime.GOOS == "windows" {
+		c.Skip("Skipping bridge config tests on windows")
+	}
+	s.BaseSuite.SetUpSuite(c)
+}
+
+func (s *bridgeConfigSuite) SetUpTest(c *gc.C) {
+	s.testConfigPath = filepath.Join(c.MkDir(), "network-config")
+	s.testConfig = "# test network config\n"
+	s.testBridgeName = "test-bridge"
+	err := ioutil.WriteFile(s.testConfigPath, []byte(s.testConfig), 0644)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *bridgeConfigSuite) assertScript(c *gc.C, initialConfig, expectedConfig, addrFamily, nic, bridge string) {
+	err := ioutil.WriteFile(s.testConfigPath, []byte(initialConfig), 0644)
+	c.Check(err, jc.ErrorIsNil)
+	// Run the script and verify the modified config.
+	output, code := s.runScript(c, addrFamily, nic, s.testConfigPath, bridge)
+	c.Check(code, gc.Equals, 0)
+	c.Check(output, gc.Equals, "")
+	data, err := ioutil.ReadFile(s.testConfigPath)
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(string(data), gc.Equals, expectedConfig)
+}
+
+func (s *bridgeConfigSuite) XXXTestBridgeScriptWithInvalidParams(c *gc.C) {
+	var tests = []struct {
+		about  string
+		params []string
+	}{{
+		about:  "argument 1 is zero length",
+		params: []string{"", "2", "3", "4"},
+	}, {
+		about:  "argument 2 is zero length",
+		params: []string{"1", "", "3", "4"},
+	}, {
+		about:  "argument 3 is zero length",
+		params: []string{"1", "2", "", "4"},
+	}, {
+		about:  "argument 4 is zero length",
+		params: []string{"1", "2", "3", ""},
+	}, {
+		about:  "both addr_family and primary_nic arguments empty",
+		params: []string{"", "", s.testBridgeName, s.testConfigPath},
+	}, {
+		about:  "invalid address family, empty primary NIC",
+		params: []string{"foo", "", s.testBridgeName, s.testConfigPath},
+	}, {
+		about:  "empty address family, invalid primary NIC",
+		params: []string{"", "bar", s.testBridgeName, s.testConfigPath},
+	}, {
+		about:  "valid address family, empty primary NIC",
+		params: []string{"inet", "", s.testBridgeName, s.testConfigPath},
+	}, {
+		about:  "valid address family, invalid primary NIC",
+		params: []string{"inet", "foo", s.testBridgeName, s.testConfigPath},
+	}, {
+		about:  "valid, but mismatched address family, valid primary NIC",
+		params: []string{"inet6", "eth0", s.testBridgeName, s.testConfigPath},
+	}}
+
+	for i, test := range tests {
+		c.Logf("test #%d: %s", i, test.about)
+
+		// Simple initial config.
+		err := ioutil.WriteFile(s.testConfigPath, []byte(networkDHCPInitial), 0644)
+		c.Check(err, jc.ErrorIsNil)
+
+		// Run and check it fails.
+		output, code := s.runScript(c, test.params[0], test.params[1], test.params[2], test.params[3])
+		c.Check(code, gc.Equals, 1)
+		c.Check(output, gc.Equals, "")
+
+		// Verify the config was not modified.
+		data, err := ioutil.ReadFile(s.testConfigPath)
+		c.Check(err, jc.ErrorIsNil)
+		c.Check(string(data), gc.Equals, networkDHCPInitial)
+	}
+}
+
+func (s *bridgeConfigSuite) TestBridgeScriptWithZeroArgs(c *gc.C) {
+	_, code := s.runScript(c, "", "", "", "")
+	c.Check(code, gc.Equals, 1)
+}
+
+func (s *bridgeConfigSuite) TestBridgeScriptDHCP(c *gc.C) {
+	s.assertScript(c, networkDHCPInitial, networkDHCPExpected, "inet", "eth0", "juju-br0")
+}
+
+func (s *bridgeConfigSuite) TestBridgeScriptStatic(c *gc.C) {
+	s.assertScript(c, networkStaticInitial, networkStaticExpected, "inet", "eth0", "juju-br0")
+}
+
+func (s *bridgeConfigSuite) TestBridgeScriptMultiple(c *gc.C) {
+	s.assertScript(c, networkMultipleInitial, networkMultipleExpected, "inet", "eth0", "juju-br0")
+}
+
+func (s *bridgeConfigSuite) TestBridgeScriptWithAlias(c *gc.C) {
+	s.assertScript(c, networkWithAliasInitial, networkWithAliasExpected, "inet", "eth0", "juju-br0")
+}
+
+func (s *bridgeConfigSuite) TestBridgeScriptDHCPWithAlias(c *gc.C) {
+	s.assertScript(c, networkDHCPWithAliasInitial, networkDHCPWithAliasExpected, "inet", "eth0", "juju-br0")
+}
+
+func (s *bridgeConfigSuite) TestBridgeScriptMultipleStaticWithAliases(c *gc.C) {
+	s.assertScript(c, networkMultipleStaticWithAliasesInitial, networkMultipleStaticWithAliasesExpected, "inet", "eth0", "juju-br0")
+}
+
+func (s *bridgeConfigSuite) runScript(c *gc.C, addressFamily, nic, configFile, bridgeName string) (output string, exitCode int) {
+	script := fmt.Sprintf("%s\n%s %q %q %q %q\n",
+		bridgeScriptBase,
+		"modify_network_config",
+		addressFamily,
+		nic,
+		configFile,
+		bridgeName)
+
+	result, err := exec.RunCommands(exec.RunParams{Commands: script})
+	c.Assert(err, jc.ErrorIsNil, gc.Commentf("script failed unexpectedly"))
+	// To simplify most cases, trim any trailing new lines, but still separate
+	// the stdout and stderr (in that order) with a new line, if both are
+	// non-empty.
+	stdout := strings.TrimSuffix(string(result.Stdout), "\n")
+	stderr := strings.TrimSuffix(string(result.Stderr), "\n")
+	if stderr != "" {
+		return stdout + "\n" + stderr, result.Code
+	}
+	return stdout, result.Code
+}
+
+// The rest of the file contains various forms of network config for
+// both before and after it has been run through the
+// modify_network_config bash function. They are used in individual
+// test functions.
+
+const networkStaticInitial = `auto lo
+iface lo inet loopback
+
+auto eth0
+iface eth0 inet static
+    address 1.2.3.4
+    netmask 255.255.255.0
+    gateway 4.3.2.1`
+
+const networkStaticExpected = `auto lo
+iface lo inet loopback
+
+iface eth0 inet manual
+
+auto juju-br0
+iface juju-br0 inet static
+    bridge_ports eth0
+    address 1.2.3.4
+    netmask 255.255.255.0
+    gateway 4.3.2.1`
+
+const networkDHCPInitial = `auto lo
+iface lo inet loopback
+
+auto eth0
+iface eth0 inet dhcp`
+
+const networkDHCPExpected = `auto lo
+iface lo inet loopback
+
+iface eth0 inet manual
+
+auto juju-br0
+iface juju-br0 inet dhcp
+    bridge_ports eth0
+`
+
+const networkMultipleInitial = networkStaticInitial + `
+auto eth1
+iface eth1 inet static
+    address 1.2.3.5
+    netmask 255.255.255.0
+    gateway 4.3.2.1`
+
+const networkMultipleExpected = `auto lo
+iface lo inet loopback
+
+iface eth0 inet manual
+
+auto juju-br0
+iface juju-br0 inet static
+    bridge_ports eth0
+    address 1.2.3.4
+    netmask 255.255.255.0
+    gateway 4.3.2.1
+auto eth1
+iface eth1 inet static
+    address 1.2.3.5
+    netmask 255.255.255.0
+    gateway 4.3.2.1`
+
+const networkWithAliasInitial = networkStaticInitial + `
+auto eth0:1
+iface eth0:1 inet static
+    address 1.2.3.5`
+
+const networkWithAliasExpected = `auto lo
+iface lo inet loopback
+
+iface eth0 inet manual
+
+auto juju-br0
+iface juju-br0 inet static
+    bridge_ports eth0
+    address 1.2.3.4
+    netmask 255.255.255.0
+    gateway 4.3.2.1
+auto juju-br0:1
+iface juju-br0:1 inet static
+    address 1.2.3.5`
+
+const networkDHCPWithAliasInitial = `auto lo
+iface lo inet loopback
+
+auto eth0
+iface eth0 inet static
+    gateway 10.14.0.1
+    address 10.14.0.102/24
+
+auto eth0:1
+iface eth0:1 inet static
+    address 10.14.0.103/24
+
+auto eth0:2
+iface eth0:2 inet static
+    address 10.14.0.100/24
+
+dns-nameserver 192.168.1.142`
+
+const networkDHCPWithAliasExpected = `auto lo
+iface lo inet loopback
+
+iface eth0 inet manual
+
+auto juju-br0
+iface juju-br0 inet static
+    bridge_ports eth0
+    gateway 10.14.0.1
+    address 10.14.0.102/24
+
+auto juju-br0:1
+iface juju-br0:1 inet static
+    address 10.14.0.103/24
+
+auto juju-br0:2
+iface juju-br0:2 inet static
+    address 10.14.0.100/24
+
+dns-nameserver 192.168.1.142`
+
+const networkMultipleStaticWithAliasesInitial = `
+auto eth0
+iface eth0 inet static
+    gateway 10.17.20.1
+    address 10.17.20.201/24
+    mtu 1500
+
+auto eth0:1
+iface eth0:1 inet static
+    address 10.17.20.202/24
+    mtu 1500
+
+auto eth1
+iface eth1 inet manual
+    mtu 1500
+
+dns-nameservers 10.17.20.200
+dns-search maas`
+
+const networkMultipleStaticWithAliasesExpected = `
+iface eth0 inet manual
+
+auto juju-br0
+iface juju-br0 inet static
+    bridge_ports eth0
+    gateway 10.17.20.1
+    address 10.17.20.201/24
+    mtu 1500
+
+auto juju-br0:1
+iface juju-br0:1 inet static
+    address 10.17.20.202/24
+    mtu 1500
+
+auto eth1
+iface eth1 inet manual
+    mtu 1500
+
+dns-nameservers 10.17.20.200
+dns-search maas`

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -1264,38 +1264,22 @@ ifup -v {{.Bridge}}
 // setupJujuNetworking returns a string representing the script to run
 // in order to prepare the Juju-specific networking config on a node.
 func setupJujuNetworking() (string, error) {
-	modifyConfigScript, err := renderEtcNetworkInterfacesScript("/etc/network/interfaces", instancecfg.DefaultBridgeName)
-	if err != nil {
-		return "", err
-	}
 	parsedTemplate := template.Must(
-		template.New("BridgeConfig").Parse(bridgeConfigTemplate),
+		template.New("BridgeConfig").Parse(bridgeScriptMain),
 	)
 	var buf bytes.Buffer
-	err = parsedTemplate.Execute(&buf, map[string]interface{}{
+	err := parsedTemplate.Execute(&buf, map[string]interface{}{
 		"Config": "/etc/network/interfaces",
 		"Bridge": instancecfg.DefaultBridgeName,
-		"Script": modifyConfigScript,
 	})
 	if err != nil {
 		return "", errors.Annotate(err, "bridge config template error")
 	}
-	return buf.String(), nil
+	return bridgeScriptBase + buf.String(), nil
 }
 
-func renderEtcNetworkInterfacesScript(config, bridge string) (string, error) {
-	parsedTemplate := template.Must(
-		template.New("ModifyConfigScript").Parse(modifyEtcNetworkInterfaces),
-	)
-	var buf bytes.Buffer
-	err := parsedTemplate.Execute(&buf, map[string]interface{}{
-		"Config": config,
-		"Bridge": bridge,
-	})
-	if err != nil {
-		return "", errors.Annotate(err, "modify /etc/network/interfaces script template error")
-	}
-	return buf.String(), nil
+func renderEtcNetworkInterfacesScript() (string, error) {
+	return setupJujuNetworking()
 }
 
 // newCloudinitConfig creates a cloudinit.Config structure

--- a/provider/maas/environ_test.go
+++ b/provider/maas/environ_test.go
@@ -4,10 +4,6 @@
 package maas_test
 
 import (
-	"io/ioutil"
-	"os/exec"
-	"path/filepath"
-	"runtime"
 	stdtesting "testing"
 
 	jc "github.com/juju/testing/checkers"
@@ -205,156 +201,6 @@ var expectedCloudinitConfig = []string{
 	"mkdir -p '/var/lib/juju'\ncat > '/var/lib/juju/MAASmachine.txt' << 'EOF'\n'hostname: testing.invalid\n'\nEOF\nchmod 0755 '/var/lib/juju/MAASmachine.txt'",
 }
 
-var expectedCloudinitConfigWithBridge = []string{
-	"set -xe",
-	"mkdir -p '/var/lib/juju'\ncat > '/var/lib/juju/MAASmachine.txt' << 'EOF'\n'hostname: testing.invalid\n'\nEOF\nchmod 0755 '/var/lib/juju/MAASmachine.txt'",
-}
-
-var expectedCloudinitConfigWithBridgeScriptPreamble = "\n# In case we already created the bridge, don't do it again.\ngrep -q \"iface juju-br0 inet dhcp\" /etc/network/interfaces && exit 0\n\n# Discover primary interface at run-time using the default route (if set)\nPRIMARY_IFACE=$(ip route list exact 0/0 | head -n1 | egrep -o 'dev [^ ]+' | cut -b5-)\n\n# If $PRIMARY_IFACE is empty, there's nothing to do.\n[ -z \"$PRIMARY_IFACE\" ] && exit 0\n\n# Bring down the primary interface while /e/n/i still matches the live config.\n# Will bring it back up within a bridge after updating /e/n/i.\nifdown -v ${PRIMARY_IFACE}\n\n# Log the contents of /etc/network/interfaces prior to modifying\necho \"Contents of /etc/network/interfaces before changes\"\ncat /etc/network/interfaces\n"
-
-var expectedCloudinitConfigWithBridgeScriptPostamble = "\n# Log the contents of /etc/network/interfaces after modifying\necho \"Contents of /etc/network/interfaces after changes\"\ncat /etc/network/interfaces\n\nifup -v juju-br0\n"
-
-var networkStaticInitial = `auto lo
-iface lo inet loopback
-
-auto eth0
-iface eth0 inet static
-    address 1.2.3.4
-    netmask 255.255.255.0
-    gateway 4.3.2.1`
-
-var networkStaticFinal = `auto lo
-iface lo inet loopback
-
-auto juju-br0
-iface juju-br0 inet static
-    bridge_ports eth0
-    address 1.2.3.4
-    netmask 255.255.255.0
-    gateway 4.3.2.1
-# Primary interface (defining the default route)
-iface eth0 inet manual
-`
-
-var networkDHCPInitial = `auto lo
-iface lo inet loopback
-
-auto eth0
-iface eth0 inet dhcp`
-
-var networkDHCPFinal = `auto lo
-iface lo inet loopback
-
-
-
-# Primary interface (defining the default route)
-iface eth0 inet manual
-
-# Bridge to use for LXC/KVM containers
-auto juju-br0
-iface juju-br0 inet dhcp
-    bridge_ports eth0
-`
-
-var networkMultipleInitial = networkStaticInitial + `
-auto eth1
-iface eth1 inet static
-    address 1.2.3.5
-    netmask 255.255.255.0
-    gateway 4.3.2.1`
-
-var networkMultipleFinal = `auto lo
-iface lo inet loopback
-
-auto juju-br0
-iface juju-br0 inet static
-    bridge_ports eth0
-    address 1.2.3.4
-    netmask 255.255.255.0
-    gateway 4.3.2.1
-auto eth1
-iface eth1 inet static
-    address 1.2.3.5
-    netmask 255.255.255.0
-    gateway 4.3.2.1
-# Primary interface (defining the default route)
-iface eth0 inet manual
-`
-
-var networkWithAliasInitial = networkStaticInitial + `
-auto eth0:1
-iface eth0:1 inet static
-    address 1.2.3.5`
-
-var networkWithAliasFinal = `auto lo
-iface lo inet loopback
-
-auto juju-br0
-iface juju-br0 inet static
-    bridge_ports eth0
-    address 1.2.3.4
-    netmask 255.255.255.0
-    gateway 4.3.2.1
-auto eth0:1
-iface eth0:1 inet static
-    address 1.2.3.5
-# Primary interface (defining the default route)
-iface eth0 inet manual
-`
-var networkDHCPWithAliasInitial = `auto lo
-iface lo inet loopback
-
-auto eth0
-iface eth0 inet static
-    gateway 10.14.0.1
-    address 10.14.0.102/24
-
-auto eth0:1
-iface eth0:1 inet static
-    address 10.14.0.103/24
-
-auto eth0:2
-iface eth0:2 inet static
-    address 10.14.0.100/24
-
-dns-nameserver 192.168.1.142`
-
-var networkDHCPWithAliasFinal = `auto lo
-iface lo inet loopback
-
-auto juju-br0
-iface juju-br0 inet static
-    bridge_ports eth0
-    gateway 10.14.0.1
-    address 10.14.0.102/24
-
-auto eth0:1
-iface eth0:1 inet static
-    address 10.14.0.103/24
-
-auto eth0:2
-iface eth0:2 inet static
-    address 10.14.0.100/24
-
-dns-nameserver 192.168.1.142
-# Primary interface (defining the default route)
-iface eth0 inet manual
-`
-
-func writeNetworkScripts(c *gc.C, initialScript string) (string, string) {
-	tempDir := c.MkDir()
-	initialScriptPath := filepath.Join(tempDir, "foobar")
-	testScriptPath := filepath.Join(tempDir, "script")
-	err := ioutil.WriteFile(initialScriptPath, []byte(initialScript), 0666)
-	c.Assert(err, jc.ErrorIsNil)
-	script, err := maas.RenderEtcNetworkInterfacesScript(initialScriptPath, "juju-br0")
-	c.Assert(err, jc.ErrorIsNil)
-	fullScript := "PRIMARY_IFACE=\"eth0\"\n" + script
-	err = ioutil.WriteFile(testScriptPath, []byte(fullScript), 0755)
-	c.Assert(err, jc.ErrorIsNil)
-	return testScriptPath, initialScriptPath
-}
-
 func (*environSuite) TestNewCloudinitConfigWithFeatureFlag(c *gc.C) {
 	cfg := getSimpleTestConfig(c, nil)
 	env, err := maas.NewEnviron(cfg)
@@ -380,44 +226,11 @@ func (s *environSuite) TestNewCloudinitConfigNoFeatureFlag(c *gc.C) {
 
 	// Now test with the flag off.
 	s.SetFeatureFlags() // clear the flags.
-	modifyNetworkScript, err := maas.RenderEtcNetworkInterfacesScript("/etc/network/interfaces", "juju-br0")
+	modifyNetworkScript, err := maas.RenderEtcNetworkInterfacesScript()
 	c.Assert(err, jc.ErrorIsNil)
-	expectedCloudinitConfigWithBridgeScript := expectedCloudinitConfigWithBridgeScriptPreamble + modifyNetworkScript + expectedCloudinitConfigWithBridgeScriptPostamble
-	expectedCloudinitConfigWithBridge = append(expectedCloudinitConfigWithBridge, expectedCloudinitConfigWithBridgeScript)
-	testCase(expectedCloudinitConfigWithBridge)
-}
-
-func (s *environSuite) assertNetworkScript(c *gc.C, initial, final string) {
-	if runtime.GOOS == "windows" {
-		c.Skip("Tests relevant only on *nix systems")
-	}
-	scriptPath, resultPath := writeNetworkScripts(c, initial)
-	cmd := exec.Command("/bin/sh", scriptPath)
-	err := cmd.Run()
-	c.Assert(err, jc.ErrorIsNil)
-	data, err := ioutil.ReadFile(resultPath)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(string(data), jc.DeepEquals, final)
-}
-
-func (s *environSuite) TestRenderNetworkInterfacesScriptDHCP(c *gc.C) {
-	s.assertNetworkScript(c, networkDHCPInitial, networkDHCPFinal)
-}
-
-func (s *environSuite) TestRenderNetworkInterfacesScriptStatic(c *gc.C) {
-	s.assertNetworkScript(c, networkStaticInitial, networkStaticFinal)
-}
-
-func (s *environSuite) TestRenderNetworkInterfacesScriptMultiple(c *gc.C) {
-	s.assertNetworkScript(c, networkMultipleInitial, networkMultipleFinal)
-}
-
-func (s *environSuite) TestRenderNetworkInterfacesScriptWithAlias(c *gc.C) {
-	s.assertNetworkScript(c, networkWithAliasInitial, networkWithAliasFinal)
-}
-
-func (s *environSuite) TestRenderNetworkInterfacesScriptDHCPWithAlias(c *gc.C) {
-	s.assertNetworkScript(c, networkDHCPWithAliasInitial, networkDHCPWithAliasFinal)
+	script := expectedCloudinitConfig
+	script = append(script, modifyNetworkScript)
+	testCase(script)
 }
 
 func (*environSuite) TestNewCloudinitConfigWithDisabledNetworkManagement(c *gc.C) {


### PR DESCRIPTION
This is a forward port of PR #3780 from 1.25.

The previous rendering of /etc/network/interfaces would result in a
broken bootstrap on MAAS 1.9 when the interface was set to DHCP. This
change reworks the script to replace interface names and bridge names
in-situ and no longer reorders the existing content; the ifup/down
scripts failed to parse the (previously) modified file.

Fixes [LP:#1512371](https://bugs.launchpad.net/juju-core/+bug/1512371)

(cherry picked from commit c2511d450e9f8ba07606b622f6dd126b651f2706)
(cherry picked from commit e7fc23963fee92fef6b57cc3b4ea3521766d627e)

(Review request: http://reviews.vapour.ws/r/3311/)