### PR TITLE
lp1521777 - Allow upgrades to 2.0

### DIFF
--- a/cmd/juju/commands/upgradejuju.go
+++ b/cmd/juju/commands/upgradejuju.go
@@ -174,8 +174,7 @@ func (c *UpgradeJujuCommand) Run(ctx *cmd.Context) (err error) {
 		return fmt.Errorf("incomplete environment configuration")
 	}
 
-	// Don't try to upgrade if the agent is on a different
-	// major release.
+	// Do not allow an upgrade if the agent is on a greater major version than the CLI.
 	if agentVersion.Major > version.Current.Major {
 		return fmt.Errorf("cannot upgrade a %s environment with a %s client", agentVersion, version.Current.Number)
 	}
@@ -188,11 +187,11 @@ func (c *UpgradeJujuCommand) Run(ctx *cmd.Context) (err error) {
 		}
 		retErr := false
 		if c.Version.Major > 2 || c.Version.Minor > 0 {
-			ctx.Infof("upgrades to %s must first go through juju 2.0", c.Version)
+			ctx.Infof("Upgrades to %s must first go through juju 2.0.", c.Version)
 			retErr = true
 		}
 		if agentVersion.Minor < 25 || (agentVersion.Minor == 25 && agentVersion.Patch < 2) {
-			ctx.Infof("upgrades to juju 2.0 must first go through juju 1.25.2 or higher")
+			ctx.Infof("Upgrades to juju 2.0 must first go through juju 1.25.2 or higher.")
 			retErr = true
 		}
 		if retErr {

--- a/cmd/juju/commands/upgradejuju.go
+++ b/cmd/juju/commands/upgradejuju.go
@@ -100,9 +100,6 @@ func (c *UpgradeJujuCommand) Init(args []string) error {
 		if err != nil {
 			return err
 		}
-		if vers.Major != version.Current.Major {
-			return fmt.Errorf("cannot upgrade to version incompatible with CLI")
-		}
 		if c.UploadTools && vers.Build != 0 {
 			// TODO(fwereade): when we start taking versions from actual built
 			// code, we should disable --version when used with --upload-tools.
@@ -170,7 +167,42 @@ func (c *UpgradeJujuCommand) Run(ctx *cmd.Context) (err error) {
 	if err != nil {
 		return err
 	}
-	context, err := c.initVersions(client, cfg)
+
+	agentVersion, ok := cfg.AgentVersion()
+	if !ok {
+		// Can't happen. In theory.
+		return fmt.Errorf("incomplete environment configuration")
+	}
+
+	// Don't try to upgrade if the agent is on a different
+	// major release.
+	if agentVersion.Major > version.Current.Major {
+		return fmt.Errorf("cannot upgrade a %s environment with a %s client", agentVersion, version.Current.Number)
+	}
+
+	if c.Version.Major > agentVersion.Major {
+		// We can only upgrade a major version if we're currently on 1.25.2 or later
+		// and we're going to 2.0.x, and the version was explicitly requested.
+		if agentVersion.Major != 1 {
+			return fmt.Errorf("cannot upgrade to version incompatible with CLI")
+		}
+		retErr := false
+		if c.Version.Major > 2 || c.Version.Minor > 0 {
+			ctx.Infof("upgrades to %s must first go through juju 2.0", c.Version)
+			retErr = true
+		}
+		if agentVersion.Minor < 25 || (agentVersion.Minor == 25 && agentVersion.Patch < 2) {
+			ctx.Infof("upgrades to juju 2.0 must first go through juju 1.25.2 or higher")
+			retErr = true
+		}
+		if retErr {
+			return fmt.Errorf("cannot upgrade to version incompatible with CLI")
+		}
+	} else if c.Version != version.Zero && c.Version.Major < agentVersion.Major {
+		return fmt.Errorf("cannot upgrade to version incompatible with CLI")
+	}
+
+	context, err := c.initVersions(client, cfg, agentVersion)
 	if err != nil {
 		return err
 	}
@@ -242,17 +274,16 @@ func (c *UpgradeJujuCommand) confirmResetPreviousUpgrade(ctx *cmd.Context) (bool
 // agent and client versions, and the list of currently available tools, will
 // always be accurate; the chosen version, and the flag indicating development
 // mode, may remain blank until uploadTools or validate is called.
-func (c *UpgradeJujuCommand) initVersions(client upgradeJujuAPI, cfg *config.Config) (*upgradeContext, error) {
-	agent, ok := cfg.AgentVersion()
-	if !ok {
-		// Can't happen. In theory.
-		return nil, fmt.Errorf("incomplete environment configuration")
-	}
-	if c.Version == agent {
+func (c *UpgradeJujuCommand) initVersions(client upgradeJujuAPI, cfg *config.Config, agentVersion version.Number) (*upgradeContext, error) {
+	if c.Version == agentVersion {
 		return nil, errUpToDate
 	}
-	clientVersion := version.Current.Number
-	findResult, err := client.FindTools(clientVersion.Major, -1, "", "")
+
+	filterVersion := version.Current.Number
+	if c.Version != version.Zero {
+		filterVersion = c.Version
+	}
+	findResult, err := client.FindTools(filterVersion.Major, -1, "", "")
 	if err != nil {
 		return nil, err
 	}
@@ -264,15 +295,15 @@ func (c *UpgradeJujuCommand) initVersions(client upgradeJujuAPI, cfg *config.Con
 		if !c.UploadTools {
 			// No tools found and we shouldn't upload any, so if we are not asking for a
 			// major upgrade, pretend there is no more recent version available.
-			if c.Version == version.Zero && agent.Major == clientVersion.Major {
+			if c.Version == version.Zero && agentVersion.Major == filterVersion.Major {
 				return nil, errUpToDate
 			}
 			return nil, err
 		}
 	}
 	return &upgradeContext{
-		agent:     agent,
-		client:    clientVersion,
+		agent:     agentVersion,
+		client:    version.Current.Number,
 		chosen:    c.Version,
 		tools:     findResult.List,
 		apiClient: client,

--- a/cmd/juju/commands/upgradejuju_test.go
+++ b/cmd/juju/commands/upgradejuju_test.go
@@ -748,7 +748,7 @@ func (s *UpgradeJujuSuite) TestMinimumVersionForMajorUpgrade(c *gc.C) {
 		c.Assert(err, gc.ErrorMatches, "cannot upgrade to version incompatible with CLI")
 
 		output := coretesting.Stderr(ctx)
-		c.Assert(output, gc.Equals, "upgrades to juju 2.0 must first go through juju 1.25.2 or higher\n")
+		c.Assert(output, gc.Equals, "Upgrades to juju 2.0 must first go through juju 1.25.2 or higher.\n")
 	}
 }
 
@@ -770,7 +770,7 @@ func (s *UpgradeJujuSuite) TestMajorVersionRestriction(c *gc.C) {
 		c.Assert(err, gc.ErrorMatches, "cannot upgrade to version incompatible with CLI")
 
 		output := coretesting.Stderr(ctx)
-		c.Assert(output, gc.Equals, "upgrades to "+vers+" must first go through juju 2.0\n")
+		c.Assert(output, gc.Equals, "Upgrades to "+vers+" must first go through juju 2.0.\n")
 	}
 }
 
@@ -790,8 +790,8 @@ func (s *UpgradeJujuSuite) TestMinFromAndMaxToMajorVersion(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "cannot upgrade to version incompatible with CLI")
 
 	output := coretesting.Stderr(ctx)
-	c.Assert(output, gc.Equals, "upgrades to 2.1.4 must first go through juju 2.0\n"+
-		"upgrades to juju 2.0 must first go through juju 1.25.2 or higher\n")
+	c.Assert(output, gc.Equals, "Upgrades to 2.1.4 must first go through juju 2.0.\n"+
+		"Upgrades to juju 2.0 must first go through juju 1.25.2 or higher.\n")
 }
 
 func NewFakeUpgradeJujuAPI(c *gc.C, st *state.State) *fakeUpgradeJujuAPI {

--- a/cmd/juju/commands/upgradejuju_test.go
+++ b/cmd/juju/commands/upgradejuju_test.go
@@ -91,31 +91,37 @@ var upgradeJujuTests = []struct {
 }, {
 	about:          "major version upgrade to incompatible version",
 	currentVersion: "2.0.0-quantal-amd64",
+	agentVersion:   "2.0.0",
 	args:           []string{"--version", "5.2.0"},
-	expectInitErr:  "cannot upgrade to version incompatible with CLI",
+	expectErr:      "cannot upgrade to version incompatible with CLI",
 }, {
 	about:          "major version downgrade to incompatible version",
 	currentVersion: "4.2.0-quantal-amd64",
+	agentVersion:   "4.2.0",
 	args:           []string{"--version", "3.2.0"},
-	expectInitErr:  "cannot upgrade to version incompatible with CLI",
+	expectErr:      "cannot upgrade to version incompatible with CLI",
 }, {
 	about:          "invalid --series",
 	currentVersion: "4.2.0-quantal-amd64",
+	agentVersion:   "4.2.0",
 	args:           []string{"--series", "precise&quantal"},
 	expectInitErr:  `invalid value "precise&quantal" for flag --series: .*`,
 }, {
 	about:          "--series without --upload-tools",
 	currentVersion: "4.2.0-quantal-amd64",
+	agentVersion:   "4.2.0",
 	args:           []string{"--series", "precise,quantal"},
 	expectInitErr:  "--series requires --upload-tools",
 }, {
 	about:          "--upload-tools with inappropriate version 1",
 	currentVersion: "4.2.0-quantal-amd64",
+	agentVersion:   "4.2.0",
 	args:           []string{"--upload-tools", "--version", "3.1.0"},
-	expectInitErr:  "cannot upgrade to version incompatible with CLI",
+	expectErr:      "cannot upgrade to version incompatible with CLI",
 }, {
 	about:          "--upload-tools with inappropriate version 2",
 	currentVersion: "3.2.7-quantal-amd64",
+	agentVersion:   "3.2.7",
 	args:           []string{"--upload-tools", "--version", "3.2.8.4"},
 	expectInitErr:  "cannot specify build number when uploading tools",
 }, {
@@ -174,12 +180,26 @@ var upgradeJujuTests = []struct {
 	args:           []string{"--version", "2.3-dev0"},
 	expectVersion:  "2.3-dev0",
 }, {
-	about:          "specified major version",
-	tools:          []string{"3.2.0-quantal-amd64"},
-	currentVersion: "3.2.0-quantal-amd64",
-	agentVersion:   "2.8.2",
-	args:           []string{"--version", "3.2.0"},
-	expectVersion:  "3.2.0",
+	about:          "specified major version from 1.25.2",
+	tools:          []string{"2.0.1-quantal-amd64"},
+	currentVersion: "1.25.2-quantal-amd64",
+	agentVersion:   "1.25.2",
+	args:           []string{"--version", "2.0.1"},
+	expectVersion:  "2.0.1",
+}, {
+	about:          "specified major version from 1.26-alpha2",
+	tools:          []string{"2.0.0-quantal-amd64"},
+	currentVersion: "1.25.2-quantal-amd64",
+	agentVersion:   "1.26-alpha2",
+	args:           []string{"--version", "2.0.0"},
+	expectVersion:  "2.0.0",
+}, {
+	about:          "specified valid major upgrade with no tools available",
+	tools:          []string{"1.25.2-quantal-amd64"},
+	currentVersion: "1.25.2-quantal-amd64",
+	agentVersion:   "1.25.2",
+	args:           []string{"--version", "2.0.0"},
+	expectErr:      "no matching tools available",
 }, {
 	about:          "specified version missing, but already set",
 	currentVersion: "3.0.0-quantal-amd64",
@@ -226,7 +246,7 @@ var upgradeJujuTests = []struct {
 	currentVersion: "3.2.0-quantal-amd64",
 	agentVersion:   "4.2.0",
 	args:           []string{"--version", "3.2.0"},
-	expectErr:      "cannot change version from 4.2.0 to 3.2.0",
+	expectErr:      "cannot upgrade a 4.2.0 environment with a 3.2.0 client",
 }, {
 	about:          "minor version downgrade to incompatible version",
 	tools:          []string{"3.2.0-quantal-amd64"},
@@ -703,6 +723,75 @@ func (s *UpgradeJujuSuite) TestResetPreviousUpgrade(c *gc.C) {
 	for _, answer := range []string{"n", "N", "no", "foo"} {
 		run(answer, expectNoUpgrade)
 	}
+}
+
+func (s *UpgradeJujuSuite) TestMinimumVersionForMajorUpgrade(c *gc.C) {
+	versions := []version.Binary{
+		version.MustParseBinary("1.25.1-trusty-amd64"),
+		version.MustParseBinary("1.24.7-trusty-amd64"),
+	}
+	for _, vers := range versions {
+		c.Logf("testing TestMinimumVersionForMajorUpgrade with version: %s", vers.Number)
+		s.PatchValue(&version.Current, vers)
+		updateAttrs := map[string]interface{}{
+			"agent-version": vers.Number.String(),
+		}
+		err := s.State.UpdateEnvironConfig(updateAttrs, nil, nil)
+		c.Assert(err, jc.ErrorIsNil)
+
+		com := &UpgradeJujuCommand{}
+		err = coretesting.InitCommand(envcmd.Wrap(com), []string{"--version", "2.0.4"})
+		c.Assert(err, jc.ErrorIsNil)
+
+		ctx := coretesting.Context(c)
+		err = com.Run(ctx)
+		c.Assert(err, gc.ErrorMatches, "cannot upgrade to version incompatible with CLI")
+
+		output := coretesting.Stderr(ctx)
+		c.Assert(output, gc.Equals, "upgrades to juju 2.0 must first go through juju 1.25.2 or higher\n")
+	}
+}
+
+func (s *UpgradeJujuSuite) TestMajorVersionRestriction(c *gc.C) {
+	for _, vers := range []string{"2.1.4", "3.0.0"} {
+		c.Logf("testing TestMajorVersionRestriction with version: %s", vers)
+		s.PatchValue(&version.Current, version.MustParseBinary("1.25.2-trusty-amd64"))
+		updateAttrs := map[string]interface{}{
+			"agent-version": "1.25.2",
+		}
+		err := s.State.UpdateEnvironConfig(updateAttrs, nil, nil)
+		c.Assert(err, jc.ErrorIsNil)
+		com := &UpgradeJujuCommand{}
+		err = coretesting.InitCommand(envcmd.Wrap(com), []string{"--version", vers})
+		c.Assert(err, jc.ErrorIsNil)
+
+		ctx := coretesting.Context(c)
+		err = com.Run(ctx)
+		c.Assert(err, gc.ErrorMatches, "cannot upgrade to version incompatible with CLI")
+
+		output := coretesting.Stderr(ctx)
+		c.Assert(output, gc.Equals, "upgrades to "+vers+" must first go through juju 2.0\n")
+	}
+}
+
+func (s *UpgradeJujuSuite) TestMinFromAndMaxToMajorVersion(c *gc.C) {
+	s.PatchValue(&version.Current, version.MustParseBinary("1.25.1-trusty-amd64"))
+	updateAttrs := map[string]interface{}{
+		"agent-version": "1.25.1",
+	}
+	err := s.State.UpdateEnvironConfig(updateAttrs, nil, nil)
+	c.Assert(err, jc.ErrorIsNil)
+	com := &UpgradeJujuCommand{}
+	err = coretesting.InitCommand(envcmd.Wrap(com), []string{"--version", "2.1.4"})
+	c.Assert(err, jc.ErrorIsNil)
+
+	ctx := coretesting.Context(c)
+	err = com.Run(ctx)
+	c.Assert(err, gc.ErrorMatches, "cannot upgrade to version incompatible with CLI")
+
+	output := coretesting.Stderr(ctx)
+	c.Assert(output, gc.Equals, "upgrades to 2.1.4 must first go through juju 2.0\n"+
+		"upgrades to juju 2.0 must first go through juju 1.25.2 or higher\n")
 }
 
 func NewFakeUpgradeJujuAPI(c *gc.C, st *state.State) *fakeUpgradeJujuAPI {


### PR DESCRIPTION
In preparation for a 2.0 release, changes are needed to
the 1.25 client to allow for an upgrade to a major release.

This patch:
- Prevents a 1.25 client from attempting to upgrade an
environment running a higher major release
- Allows an upgrade to juju 2.0 if the environment is
running 1.25.2 or higher
- Prevents upgrades to 2.1 or higher, as upgrades will
need to go through 2.0 before continuing

(Review request: http://reviews.vapour.ws/r/3312/)