### PR TITLE
1.25 fix 1.21 port upgrade

### DIFF
--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -318,6 +318,11 @@ func MigrateUnitPortsToOpenedPorts(st *State) error {
 	for _, uDoc := range unitSlice {
 		unit := &Unit{st: st, doc: uDoc}
 		upgradesLogger.Infof("migrating ports for unit %q", unit)
+		if len(uDoc.Ports) == 0 {
+			upgradesLogger.Infof("no ports to migrate for unit %q", unit)
+			continue
+		}
+
 		upgradesLogger.Debugf("raw ports for unit %q: %v", unit, uDoc.Ports)
 
 		skippedRanges, mergedRanges, validRanges := validateUnitPorts(st, unit)
@@ -358,18 +363,14 @@ func MigrateUnitPortsToOpenedPorts(st *State) error {
 			upgradesLogger.Warningf("migration failed for unit %q: %v", unit, err)
 		}
 
-		if len(uDoc.Ports) > 0 {
-			totalPorts := len(uDoc.Ports)
-			upgradesLogger.Infof(
-				"unit %q's ports (ranges) migrated: total %d(%d); ok %d(%d); skipped %d(%d)",
-				unit,
-				totalPorts, len(mergedRanges),
-				migratedPorts, migratedRanges,
-				totalPorts-migratedPorts, skippedRanges,
-			)
-		} else {
-			upgradesLogger.Infof("no ports to migrate for unit %q", unit)
-		}
+		totalPorts := len(uDoc.Ports)
+		upgradesLogger.Infof(
+			"unit %q's ports (ranges) migrated: total %d(%d); ok %d(%d); skipped %d(%d)",
+			unit,
+			totalPorts, len(mergedRanges),
+			migratedPorts, migratedRanges,
+			totalPorts-migratedPorts, skippedRanges,
+		)
 	}
 	upgradesLogger.Infof("legacy unit ports migrated to machine port ranges")
 

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -184,6 +184,14 @@ func beginUnitMigrationOps(st *State, unit *Unit, machineId string) (
 	if err != nil {
 		return nil, nil, errors.Trace(err)
 	}
+	if machinePorts.areNew {
+		doc := machinePorts.doc
+		ops = append(ops, txn.Op{
+			C:      openedPortsC,
+			Id:     doc.DocID,
+			Insert: &doc,
+		})
+	}
 	return ops, machinePorts, nil
 }
 
@@ -343,7 +351,7 @@ func MigrateUnitPortsToOpenedPorts(st *State) error {
 		skippedRanges += filteredRanges
 
 		migratedPorts, migratedRanges, ops := finishUnitMigrationOps(
-			unit, rangesToMigrate, machinePorts.GlobalKey(), ops,
+			unit, rangesToMigrate, machinePorts.doc.DocID, ops,
 		)
 
 		if err = st.runRawTransaction(ops); err != nil {


### PR DESCRIPTION
The openedPorts document was not being created when it didn't exist, and the updates didn't have any asserts making sure it existed.

The test passed because the asserts were not actually being executed because the allMachinePorts returned an empty list, and it wasn't asserting there was something there.

I reworked the migration slightly so it works with the new style collections, and this meant we could remove all the patch functions.

(Review request: http://reviews.vapour.ws/r/3313/)