### PR TITLE
lp1522861 - panic in CleanupOldMetrics

### DIFF
--- a/state/metrics.go
+++ b/state/metrics.go
@@ -186,7 +186,9 @@ func (st *State) CleanupOldMetrics() error {
 		"sent":    true,
 		"created": bson.M{"$lte": age},
 	})
-	metricsLogger.Tracef("cleanup removed %d metrics", info.Removed)
+	if err == nil {
+		metricsLogger.Tracef("cleanup removed %d metrics", info.Removed)
+	}
 	return errors.Trace(err)
 }
 


### PR DESCRIPTION
Check the err before referencing returned
struct.

(Review request: http://reviews.vapour.ws/r/3321/)