### PR TITLE
Add resource.Resource.

### DIFF
--- a/resource/api/client/spec_test.go
+++ b/resource/api/client/spec_test.go
@@ -249,6 +249,7 @@ func (s *SpecSuite) TestListSpecsConversionFailed(c *gc.C) {
 			Definition: charmresource.Info{
 				Name: "spam",
 			},
+			Revision: resource.NoRevision,
 		}},
 		Error: results[0].Error,
 	}})

--- a/resource/cmd/util_test.go
+++ b/resource/cmd/util_test.go
@@ -23,6 +23,7 @@ func NewSpec(c *gc.C, name, suffix, comment string) resource.Spec {
 	spec := resource.Spec{
 		Definition: info,
 		Origin:     resource.OriginKindUpload,
+		Revision:   resource.NoRevision,
 	}
 	err := spec.Validate()
 	c.Assert(err, jc.ErrorIsNil)

--- a/resource/origin.go
+++ b/resource/origin.go
@@ -12,7 +12,7 @@ import (
 // These are the valid kinds of resource origin.
 const (
 	OriginKindUnknown OriginKind = ""
-	OriginKindUpload             = "upload"
+	OriginKindUpload  OriginKind = "upload"
 )
 
 var knownOriginKinds = map[OriginKind]bool{
@@ -39,5 +39,36 @@ func (o OriginKind) Validate() error {
 	if !knownOriginKinds[o] {
 		return errors.NewNotValid(nil, "unknown origin")
 	}
+	return nil
+}
+
+// Origin identifies where a resource came from.
+type Origin struct {
+	// Kind is the origin's kind.
+	Kind OriginKind
+
+	// Value is the specific origin.
+	Value string
+}
+
+// String returns the printable representation of the origin.
+func (o Origin) String() string {
+	return o.Value
+}
+
+// Validate ensures that the origin is correct.
+func (o Origin) Validate() error {
+	if err := o.Kind.Validate(); err != nil {
+		return errors.Annotate(err, "bad origin kind")
+	}
+
+	switch o.Kind {
+	case OriginKindUpload:
+		// Ensure it's a valid username.
+		if o.Value == "" {
+			return errors.NewNotValid(nil, "missing upload username")
+		}
+	}
+
 	return nil
 }

--- a/resource/origin_test.go
+++ b/resource/origin_test.go
@@ -1,0 +1,89 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package resource_test
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/resource"
+)
+
+var (
+	_ = gc.Suite(&OriginKindSuite{})
+	_ = gc.Suite(&OriginSuite{})
+)
+
+type OriginKindSuite struct {
+	testing.IsolationSuite
+}
+
+func (OriginKindSuite) TestValidateKnown(c *gc.C) {
+	recognized := []resource.OriginKind{
+		resource.OriginKindUpload,
+	}
+	for _, kind := range recognized {
+		err := kind.Validate()
+
+		c.Check(err, jc.ErrorIsNil)
+	}
+}
+
+func (OriginKindSuite) TestValidateUnknown(c *gc.C) {
+	kind := resource.OriginKind("<invalid>")
+	err := kind.Validate()
+
+	c.Check(errors.Cause(err), jc.Satisfies, errors.IsNotValid)
+	c.Check(err, gc.ErrorMatches, `.*unknown origin.*`)
+}
+
+type OriginSuite struct {
+	testing.IsolationSuite
+}
+
+func (OriginSuite) TestValidateOkay(c *gc.C) {
+	recognized := map[resource.OriginKind]string{
+		resource.OriginKindUpload: "a-user",
+	}
+	for kind, value := range recognized {
+		o := resource.Origin{
+			Kind:  kind,
+			Value: value,
+		}
+		err := o.Validate()
+
+		c.Check(err, jc.ErrorIsNil)
+	}
+}
+
+func (OriginSuite) TestValidateZeroValue(c *gc.C) {
+	var o resource.Origin
+	err := o.Validate()
+
+	c.Check(errors.Cause(err), jc.Satisfies, errors.IsNotValid)
+}
+
+func (OriginSuite) TestValidateBadKind(c *gc.C) {
+	o := resource.Origin{
+		Kind:  resource.OriginKind("<invalid>"),
+		Value: "spam",
+	}
+	err := o.Validate()
+
+	c.Check(errors.Cause(err), jc.Satisfies, errors.IsNotValid)
+	c.Check(err, gc.ErrorMatches, `.*bad origin kind.*`)
+}
+
+func (OriginSuite) TestValidateUploadBadUsername(c *gc.C) {
+	o := resource.Origin{
+		Kind:  resource.OriginKindUpload,
+		Value: "",
+	}
+	err := o.Validate()
+
+	c.Check(errors.Cause(err), jc.Satisfies, errors.IsNotValid)
+	c.Check(err, gc.ErrorMatches, `.*missing upload username.*`)
+}

--- a/resource/resource.go
+++ b/resource/resource.go
@@ -17,6 +17,7 @@ var originRevisionTypes = map[OriginKind]RevisionType{
 
 // Resource defines a single resource within Juju state.
 type Resource struct {
+	// Spec is the backing resource spec.
 	Spec Spec
 
 	// Origin identifies the where the resource came from.

--- a/resource/resource.go
+++ b/resource/resource.go
@@ -1,0 +1,51 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// The resource package provides the functionality of the "resources"
+// feature in Juju.
+package resource
+
+import (
+	"fmt"
+
+	"github.com/juju/errors"
+)
+
+var originRevisionTypes = map[OriginKind]RevisionType{
+	OriginKindUpload: RevisionTypeDate,
+}
+
+type Resource struct {
+	Spec Spec
+
+	// Origin identifies the where the resource came from.
+	Origin Origin
+
+	// Revision is the actual revision of the resource.
+	Revision Revision
+}
+
+// Validate ensures that the spec is valid.
+func (res Resource) Validate() error {
+	if err := res.Spec.Validate(); err != nil {
+		return errors.Annotate(err, "bad spec")
+	}
+
+	if err := res.Origin.Validate(); err != nil {
+		return errors.Annotate(err, "bad origin")
+	}
+	if res.Origin.Kind != res.Spec.Origin {
+		return errors.NotValidf("origin kind does not match spec (expected %q)", res.Spec.Origin)
+	}
+
+	if err := res.Revision.Validate(); err != nil {
+		return errors.Annotate(err, "bad revision")
+	}
+
+	revType := res.Revision.Type
+	if originRevisionTypes[res.Origin.Kind] != revType {
+		return errors.NewNotValid(nil, fmt.Sprintf("resource origin %q does not support revision type %q", res.Origin, revType))
+	}
+
+	return nil
+}

--- a/resource/resource.go
+++ b/resource/resource.go
@@ -15,6 +15,7 @@ var originRevisionTypes = map[OriginKind]RevisionType{
 	OriginKindUpload: RevisionTypeDate,
 }
 
+// Resource defines a single resource within Juju state.
 type Resource struct {
 	Spec Spec
 
@@ -23,6 +24,9 @@ type Resource struct {
 
 	// Revision is the actual revision of the resource.
 	Revision Revision
+
+	// Fingerprint is the MD5 checksum for the resource blob.
+	Fingerprint string
 }
 
 // Validate ensures that the spec is valid.
@@ -45,6 +49,10 @@ func (res Resource) Validate() error {
 	revType := res.Revision.Type
 	if originRevisionTypes[res.Origin.Kind] != revType {
 		return errors.NewNotValid(nil, fmt.Sprintf("resource origin %q does not support revision type %q", res.Origin, revType))
+	}
+
+	if res.Fingerprint == "" {
+		return errors.NewNotValid(nil, "missing fingerprint")
 	}
 
 	return nil

--- a/resource/resource_test.go
+++ b/resource/resource_test.go
@@ -1,0 +1,149 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package resource_test
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	charmresource "gopkg.in/juju/charm.v6-unstable/resource"
+
+	"github.com/juju/juju/resource"
+)
+
+var _ = gc.Suite(&ResourceSuite{})
+
+type ResourceSuite struct {
+	testing.IsolationSuite
+}
+
+func (ResourceSuite) TestValidateUploadOkay(c *gc.C) {
+	res := resource.Resource{
+		Spec: resource.Spec{
+			Definition: charmresource.Info{
+				Name:    "spam",
+				Type:    charmresource.TypeFile,
+				Path:    "spam.tgz",
+				Comment: "you need it",
+			},
+			Origin:   resource.OriginKindUpload,
+			Revision: resource.NoRevision,
+		},
+		Origin: resource.Origin{
+			Kind:  resource.OriginKindUpload,
+			Value: "a-user",
+		},
+		Revision: resource.Revision{
+			Type:  resource.RevisionTypeDate,
+			Value: "2015-02-12",
+		},
+	}
+
+	err := res.Validate()
+
+	c.Check(err, jc.ErrorIsNil)
+}
+
+func (ResourceSuite) TestValidateZeroValue(c *gc.C) {
+	var res resource.Resource
+
+	err := res.Validate()
+
+	c.Check(errors.Cause(err), jc.Satisfies, errors.IsNotValid)
+}
+
+func (ResourceSuite) TestValidateBadSpec(c *gc.C) {
+	res := resource.Resource{
+		Origin: resource.Origin{
+			Kind:  resource.OriginKindUpload,
+			Value: "a-user",
+		},
+		Revision: resource.Revision{
+			Type:  resource.RevisionTypeDate,
+			Value: "2015-02-12",
+		},
+	}
+
+	err := res.Validate()
+
+	c.Check(errors.Cause(err), jc.Satisfies, errors.IsNotValid)
+	c.Check(err, gc.ErrorMatches, `.*bad spec.*`)
+}
+
+func (ResourceSuite) TestValidateBadOrigin(c *gc.C) {
+	c.Assert(resource.Origin{}.Validate(), gc.NotNil)
+
+	res := resource.Resource{
+		Spec: resource.Spec{
+			Definition: charmresource.Info{
+				Name: "spam",
+				Type: charmresource.TypeFile,
+				Path: "spam.tgz",
+			},
+			Origin:   resource.OriginKindUpload,
+			Revision: resource.NoRevision,
+		},
+		Origin: resource.Origin{},
+		Revision: resource.Revision{
+			Type:  resource.RevisionTypeDate,
+			Value: "2015-02-12",
+		},
+	}
+
+	err := res.Validate()
+
+	c.Check(errors.Cause(err), jc.Satisfies, errors.IsNotValid)
+	c.Check(err, gc.ErrorMatches, `.*bad origin.*`)
+}
+
+func (ResourceSuite) TestValidateBadRevision(c *gc.C) {
+	c.Assert(resource.Revision{}.Validate(), gc.NotNil)
+
+	res := resource.Resource{
+		Spec: resource.Spec{
+			Definition: charmresource.Info{
+				Name: "spam",
+				Type: charmresource.TypeFile,
+				Path: "spam.tgz",
+			},
+			Origin:   resource.OriginKindUpload,
+			Revision: resource.NoRevision,
+		},
+		Origin: resource.Origin{
+			Kind:  resource.OriginKindUpload,
+			Value: "a-user",
+		},
+		Revision: resource.Revision{},
+	}
+
+	err := res.Validate()
+
+	c.Check(errors.Cause(err), jc.Satisfies, errors.IsNotValid)
+	c.Check(err, gc.ErrorMatches, `.*bad revision.*`)
+}
+
+func (ResourceSuite) TestValidateUploadNoRevision(c *gc.C) {
+	res := resource.Resource{
+		Spec: resource.Spec{
+			Definition: charmresource.Info{
+				Name: "spam",
+				Type: charmresource.TypeFile,
+				Path: "spam.tgz",
+			},
+			Origin:   resource.OriginKindUpload,
+			Revision: resource.NoRevision,
+		},
+		Origin: resource.Origin{
+			Kind:  resource.OriginKindUpload,
+			Value: "a-user",
+		},
+		Revision: resource.NoRevision,
+	}
+
+	err := res.Validate()
+
+	c.Check(errors.Cause(err), jc.Satisfies, errors.IsNotValid)
+	c.Check(err, gc.ErrorMatches, `.*origin.*does not support revision type.*`)
+}

--- a/resource/resource_test.go
+++ b/resource/resource_test.go
@@ -39,6 +39,7 @@ func (ResourceSuite) TestValidateUploadOkay(c *gc.C) {
 			Type:  resource.RevisionTypeDate,
 			Value: "2015-02-12",
 		},
+		Fingerprint: "deadbeef",
 	}
 
 	err := res.Validate()
@@ -64,6 +65,7 @@ func (ResourceSuite) TestValidateBadSpec(c *gc.C) {
 			Type:  resource.RevisionTypeDate,
 			Value: "2015-02-12",
 		},
+		Fingerprint: "deadbeef",
 	}
 
 	err := res.Validate()
@@ -90,6 +92,7 @@ func (ResourceSuite) TestValidateBadOrigin(c *gc.C) {
 			Type:  resource.RevisionTypeDate,
 			Value: "2015-02-12",
 		},
+		Fingerprint: "deadbeef",
 	}
 
 	err := res.Validate()
@@ -115,7 +118,8 @@ func (ResourceSuite) TestValidateBadRevision(c *gc.C) {
 			Kind:  resource.OriginKindUpload,
 			Value: "a-user",
 		},
-		Revision: resource.Revision{},
+		Revision:    resource.Revision{},
+		Fingerprint: "deadbeef",
 	}
 
 	err := res.Validate()
@@ -139,11 +143,42 @@ func (ResourceSuite) TestValidateUploadNoRevision(c *gc.C) {
 			Kind:  resource.OriginKindUpload,
 			Value: "a-user",
 		},
-		Revision: resource.NoRevision,
+		Revision:    resource.NoRevision,
+		Fingerprint: "deadbeef",
 	}
 
 	err := res.Validate()
 
 	c.Check(errors.Cause(err), jc.Satisfies, errors.IsNotValid)
 	c.Check(err, gc.ErrorMatches, `.*origin.*does not support revision type.*`)
+}
+
+func (ResourceSuite) TestValidateBadFingerprint(c *gc.C) {
+	c.Assert(resource.Revision{}.Validate(), gc.NotNil)
+
+	res := resource.Resource{
+		Spec: resource.Spec{
+			Definition: charmresource.Info{
+				Name: "spam",
+				Type: charmresource.TypeFile,
+				Path: "spam.tgz",
+			},
+			Origin:   resource.OriginKindUpload,
+			Revision: resource.NoRevision,
+		},
+		Origin: resource.Origin{
+			Kind:  resource.OriginKindUpload,
+			Value: "a-user",
+		},
+		Revision: resource.Revision{
+			Type:  resource.RevisionTypeDate,
+			Value: "2015-02-12",
+		},
+		Fingerprint: "",
+	}
+
+	err := res.Validate()
+
+	c.Check(errors.Cause(err), jc.Satisfies, errors.IsNotValid)
+	c.Check(err, gc.ErrorMatches, `.*missing fingerprint.*`)
 }

--- a/resource/revision.go
+++ b/resource/revision.go
@@ -61,8 +61,10 @@ var NoRevision Revision = Revision{
 
 // Revision identifies a resouce revision.
 type Revision struct {
+	// TYpe is the kind of revision.
 	Type RevisionType
 
+	// Value is the revision value.
 	Value string
 }
 

--- a/resource/revision_test.go
+++ b/resource/revision_test.go
@@ -1,0 +1,172 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package resource_test
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/resource"
+)
+
+var (
+	_ = gc.Suite(&RevisionTypeSuite{})
+	_ = gc.Suite(&RevisionSuite{})
+)
+
+type RevisionTypeSuite struct {
+	testing.IsolationSuite
+}
+
+func (RevisionTypeSuite) TestValidateKnown(c *gc.C) {
+	recognized := []resource.RevisionType{
+		resource.RevisionTypeNone,
+		resource.RevisionTypeNumber,
+		resource.RevisionTypeDate,
+	}
+	for _, rt := range recognized {
+		err := rt.Validate()
+
+		c.Check(err, jc.ErrorIsNil)
+	}
+}
+
+func (RevisionTypeSuite) TestValidateUnknown(c *gc.C) {
+	rt := resource.RevisionType("<invalid>")
+	err := rt.Validate()
+
+	c.Check(errors.Cause(err), jc.Satisfies, errors.IsNotValid)
+	c.Check(err, gc.ErrorMatches, `.*unknown revision type.*`)
+}
+
+type RevisionSuite struct {
+	testing.IsolationSuite
+}
+
+func (RevisionSuite) TestParseRevisionOkay(c *gc.C) {
+	recognized := map[resource.RevisionType]string{
+		resource.RevisionTypeNone:   "",
+		resource.RevisionTypeNumber: "1",
+		resource.RevisionTypeDate:   "2015-02-12",
+	}
+	for rt, value := range recognized {
+		c.Logf("checking %q:%q", rt, value)
+		rev, ok := resource.ParseRevision(value)
+
+		c.Check(ok, jc.IsTrue)
+		c.Check(rev, jc.DeepEquals, resource.Revision{
+			Type:  rt,
+			Value: value,
+		})
+	}
+}
+
+func (RevisionSuite) TestParseRevisionUnrecognized(c *gc.C) {
+	rev, ok := resource.ParseRevision("spam")
+
+	c.Check(ok, jc.IsFalse)
+	c.Check(rev, jc.DeepEquals, resource.Revision{
+		Type:  resource.RevisionTypeUnknown,
+		Value: "spam",
+	})
+
+}
+
+func (RevisionSuite) TestValidateOkay(c *gc.C) {
+	recognized := map[resource.RevisionType]string{
+		resource.RevisionTypeNone:   "",
+		resource.RevisionTypeNumber: "1",
+		resource.RevisionTypeDate:   "2015-02-12",
+	}
+	for rt, value := range recognized {
+		rev := resource.Revision{rt, value}
+		err := rev.Validate()
+
+		c.Check(err, jc.ErrorIsNil)
+	}
+}
+
+func (RevisionSuite) TestValidateZeroValue(c *gc.C) {
+	var rev resource.Revision
+	err := rev.Validate()
+
+	c.Check(errors.Cause(err), jc.Satisfies, errors.IsNotValid)
+}
+
+func (RevisionSuite) TestValidateBadRevisionType(c *gc.C) {
+	rev := resource.Revision{Value: "<ignored>"}
+	err := rev.Validate()
+
+	c.Check(errors.Cause(err), jc.Satisfies, errors.IsNotValid)
+	c.Check(err, gc.ErrorMatches, `.*bad revision type.*`)
+}
+
+func (RevisionSuite) TestValidateBadValue(c *gc.C) {
+	rev := resource.Revision{
+		Type:  resource.RevisionTypeDate,
+		Value: "<not-a-date>",
+	}
+	err := rev.Validate()
+
+	c.Check(errors.Cause(err), jc.Satisfies, errors.IsNotValid)
+	c.Check(err, gc.ErrorMatches, `.*invalid value.*`)
+}
+
+func (RevisionSuite) checkRevision(c *gc.C, rt resource.RevisionType, value string, valid bool) {
+	rev := resource.Revision{
+		Type:  rt,
+		Value: value,
+	}
+	err := rev.Validate()
+
+	if valid {
+		c.Check(err, jc.ErrorIsNil)
+	} else {
+		c.Check(errors.Cause(err), jc.Satisfies, errors.IsNotValid)
+		c.Check(err, gc.ErrorMatches, `invalid value.*for revision type.*`)
+	}
+}
+
+func (s RevisionSuite) TestValidateNumber(c *gc.C) {
+	values := map[string]bool{
+		"0":         true,
+		"1":         true,
+		"2":         true,
+		"1234":      true,
+		"987654321": true,
+		"spam":      false,
+		"-1":        false,
+	}
+	for value, ok := range values {
+		c.Logf("checking %q (%v)", value, ok)
+		rt := resource.RevisionTypeNumber
+		s.checkRevision(c, rt, value, ok)
+	}
+}
+
+func (s RevisionSuite) TestValidateDate(c *gc.C) {
+	values := map[string]bool{
+		"2012-01-01":    true,
+		"2020-12-31":    true,
+		"2016-02-29":    true,
+		"spam":          false,
+		"15-01-01":      false,
+		"2012-01":       false,
+		"2012":          false,
+		"2012-01-01-01": false,
+		"20012-01-01":   false,
+		"2012-13-01":    false,
+		"2012-01-32":    false,
+		"2012-01-01xxx": false,
+		"2012-01-01.1":  false,
+		"2012-01-01-1":  false,
+	}
+	for value, ok := range values {
+		c.Logf("checking %q (%v)", value, ok)
+		rt := resource.RevisionTypeDate
+		s.checkRevision(c, rt, value, ok)
+	}
+}

--- a/resource/revision_test.go
+++ b/resource/revision_test.go
@@ -54,9 +54,9 @@ func (RevisionSuite) TestParseRevisionOkay(c *gc.C) {
 	}
 	for rt, value := range recognized {
 		c.Logf("checking %q:%q", rt, value)
-		rev, ok := resource.ParseRevision(value)
+		rev, err := resource.ParseRevision(value)
 
-		c.Check(ok, jc.IsTrue)
+		c.Check(err, jc.ErrorIsNil)
 		c.Check(rev, jc.DeepEquals, resource.Revision{
 			Type:  rt,
 			Value: value,
@@ -65,9 +65,9 @@ func (RevisionSuite) TestParseRevisionOkay(c *gc.C) {
 }
 
 func (RevisionSuite) TestParseRevisionUnrecognized(c *gc.C) {
-	rev, ok := resource.ParseRevision("spam")
+	rev, err := resource.ParseRevision("spam")
 
-	c.Check(ok, jc.IsFalse)
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
 	c.Check(rev, jc.DeepEquals, resource.Revision{
 		Type:  resource.RevisionTypeUnknown,
 		Value: "spam",

--- a/resource/spec.go
+++ b/resource/spec.go
@@ -14,7 +14,7 @@ import (
 
 // TODO(ericsnow) Move the this file or something similar to the charm repo?
 
-var revisionTypes = map[OriginKind]RevisionType{
+var specRevisionTypes = map[OriginKind]RevisionType{
 	OriginKindUpload: RevisionTypeNone,
 }
 
@@ -51,13 +51,13 @@ func (s Spec) Validate() error {
 		return errors.NewNotValid(nil, fmt.Sprintf("resource origin %q not supported", s.Origin))
 	}
 
-	revType := s.Revision.Type()
-	if revisionTypes[s.Origin] != revType {
+	revType := s.Revision.Type
+	if specRevisionTypes[s.Origin] != revType {
 		return errors.NewNotValid(nil, fmt.Sprintf("resource origin %q does not support revision type %q", s.Origin, revType))
 	}
 
 	if err := s.Revision.Validate(); err != nil {
-		return errors.Trace(err)
+		return errors.Annotate(err, "bad revision")
 	}
 
 	return nil

--- a/resource/spec.go
+++ b/resource/spec.go
@@ -1,8 +1,6 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-// The resource package provides the functionality of the "resources"
-// feature in Juju.
 package resource
 
 import (

--- a/resource/spec_test.go
+++ b/resource/spec_test.go
@@ -13,13 +13,13 @@ import (
 	"github.com/juju/juju/resource"
 )
 
-var _ = gc.Suite(&specSuite{})
+var _ = gc.Suite(&SpecSuite{})
 
-type specSuite struct {
+type SpecSuite struct {
 	testing.IsolationSuite
 }
 
-func (specSuite) TestValidateUploadOkay(c *gc.C) {
+func (SpecSuite) TestValidateUploadOkay(c *gc.C) {
 	spec := resource.Spec{
 		Definition: charmresource.Info{
 			Name:    "spam",
@@ -36,15 +36,18 @@ func (specSuite) TestValidateUploadOkay(c *gc.C) {
 	c.Check(err, jc.ErrorIsNil)
 }
 
-func (specSuite) TestValidateUploadHasRevision(c *gc.C) {
+func (SpecSuite) TestValidateUploadHasRevision(c *gc.C) {
 	spec := resource.Spec{
 		Definition: charmresource.Info{
 			Name: "spam",
 			Type: charmresource.TypeFile,
 			Path: "spam.tgz",
 		},
-		Origin:   resource.OriginKindUpload,
-		Revision: "???",
+		Origin: resource.OriginKindUpload,
+		Revision: resource.Revision{
+			Type:  resource.RevisionType("<date>"),
+			Value: "2012-01-01",
+		},
 	}
 
 	err := spec.Validate()
@@ -53,7 +56,7 @@ func (specSuite) TestValidateUploadHasRevision(c *gc.C) {
 	c.Check(err, gc.ErrorMatches, `.*don't have revisions.*`)
 }
 
-func (specSuite) TestValidateUnknownOrigin(c *gc.C) {
+func (SpecSuite) TestValidateUnknownOrigin(c *gc.C) {
 	spec := resource.Spec{
 		Definition: charmresource.Info{
 			Name: "spam",
@@ -70,7 +73,7 @@ func (specSuite) TestValidateUnknownOrigin(c *gc.C) {
 	c.Check(err, gc.ErrorMatches, `.*origin.*`)
 }
 
-func (specSuite) TestValidateEmptyInfo(c *gc.C) {
+func (SpecSuite) TestValidateEmptyInfo(c *gc.C) {
 	spec := resource.Spec{
 		Origin:   resource.OriginKindUpload,
 		Revision: resource.NoRevision,

--- a/resource/spec_test.go
+++ b/resource/spec_test.go
@@ -45,7 +45,7 @@ func (SpecSuite) TestValidateUploadHasRevision(c *gc.C) {
 		},
 		Origin: resource.OriginKindUpload,
 		Revision: resource.Revision{
-			Type:  resource.RevisionType("<date>"),
+			Type:  resource.RevisionTypeDate,
 			Value: "2012-01-01",
 		},
 	}

--- a/resource/state/spec.go
+++ b/resource/state/spec.go
@@ -44,6 +44,7 @@ func newSpec(res charmresource.Resource, serviceID string) (resource.Spec, error
 	spec := resource.Spec{
 		Definition: res.Info,
 		Origin:     resource.OriginKindUpload,
+		Revision:   resource.NoRevision,
 	}
 	if err := spec.Validate(); err != nil {
 		return spec, errors.Annotatef(err, "invalid charm metadata for service %q", serviceID)

--- a/resource/state/spec_test.go
+++ b/resource/state/spec_test.go
@@ -95,6 +95,7 @@ func newSpecs(c *gc.C, names ...string) ([]resource.Spec, *charm.Meta) {
 		spec := resource.Spec{
 			Definition: info,
 			Origin:     resource.OriginKindUpload,
+			Revision:   resource.NoRevision,
 		}
 		specs = append(specs, spec)
 


### PR DESCRIPTION
This patch adds a top-level resource.Resource type.  It also fixes up revisions and origins correspondingly.

(Review request: http://reviews.vapour.ws/r/3325/)