### PR TITLE
provider/maas: isolate tests from DNS setup

### DIFF
--- a/provider/maas/instance.go
+++ b/provider/maas/instance.go
@@ -24,6 +24,11 @@ type maasInstance struct {
 
 var _ instance.Instance = (*maasInstance)(nil)
 
+// Override for testing.
+var resolveHostnames = func(addrs []network.Address) []network.Address {
+	return network.ResolvableHostnames(addrs)
+}
+
 func (mi *maasInstance) String() string {
 	hostname, err := mi.hostname()
 	if err != nil {
@@ -93,7 +98,7 @@ func (mi *maasInstance) Addresses() ([]network.Address, error) {
 	// Although we would prefer a DNS name there's no point
 	// returning unresolvable names because activities like 'juju
 	// ssh 0' will instantly fail.
-	return network.ResolvableHostnames(addrs), nil
+	return resolveHostnames(addrs), nil
 }
 
 func (mi *maasInstance) ipAddresses() ([]string, error) {

--- a/provider/maas/instance_test.go
+++ b/provider/maas/instance_test.go
@@ -72,6 +72,8 @@ func (s *instanceTest) TestAddresses(c *gc.C) {
 	inst := maasInstance{maasObject: &obj, environ: s.makeEnviron()}
 
 	expected := []network.Address{
+		network.NewScopedAddress("testing.invalid", network.ScopePublic),
+		network.NewScopedAddress("testing.invalid", network.ScopeCloudLocal),
 		network.NewAddress("1.2.3.4"),
 		network.NewAddress("fe80::d806:dbff:fe23:1199"),
 	}
@@ -94,7 +96,10 @@ func (s *instanceTest) TestAddressesMissing(c *gc.C) {
 
 	addr, err := inst.Addresses()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Check(addr, gc.DeepEquals, []network.Address{})
+	c.Check(addr, gc.DeepEquals, []network.Address{
+		{Value: "testing.invalid", Type: network.HostName, Scope: network.ScopePublic},
+		{Value: "testing.invalid", Type: network.HostName, Scope: network.ScopeCloudLocal},
+	})
 }
 
 func (s *instanceTest) TestAddressesInvalid(c *gc.C) {

--- a/provider/maas/maas_test.go
+++ b/provider/maas/maas_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/juju/environs/config"
 	envtesting "github.com/juju/juju/environs/testing"
 	"github.com/juju/juju/feature"
+	"github.com/juju/juju/network"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/version"
 )
@@ -40,6 +41,9 @@ func (s *providerSuite) SetUpSuite(c *gc.C) {
 	})
 	s.PatchValue(&nodeDeploymentTimeout, func(*maasEnviron) time.Duration {
 		return coretesting.ShortWait
+	})
+	s.PatchValue(&resolveHostnames, func(addrs []network.Address) []network.Address {
+		return addrs
 	})
 }
 


### PR DESCRIPTION
Isolate the runner's setup so that the tests don't depend on a real
resolver when attempting to resolve host names as part of instance
creation. This change brings back some of the expected host names that
were removed as part of 1e7a0c1dad3aae4db6161662fd3e7d2c8b0ee320.

Fixes [LP:#1516036](https://bugs.launchpad.net/juju-core/+bug/1516036)

(Review request: http://reviews.vapour.ws/r/3327/)