### PR TITLE
Run the upgradesteps worker under the dependency engine

### DIFF
--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -438,7 +438,6 @@ func (a *MachineAgent) Run(*cmd.Context) error {
 	} else {
 		a.upgradeComplete = upgradeComplete
 	}
-	a.configChangedVal.Set(struct{}{})
 
 	agentConfig := a.CurrentConfig()
 

--- a/cmd/jujud/agent/machine/manifolds_test.go
+++ b/cmd/jujud/agent/machine/manifolds_test.go
@@ -44,6 +44,7 @@ func (s *ManifoldsSuite) TestManifoldNames(c *gc.C) {
 		"upgrade-steps-gate",
 		"upgrade-check-gate",
 		"upgrader",
+		"upgradesteps",
 	}
 	c.Assert(keys, jc.SameContents, expectedKeys)
 }

--- a/upgrades/contexts.go
+++ b/upgrades/contexts.go
@@ -12,6 +12,11 @@ import (
 // Context provides the dependencies used when executing upgrade steps.
 type Context interface {
 	// APIState returns an API connection to state.
+	//
+	// TODO(mjs) - for 2.0, this should return a base.APICaller
+	// instead of api.Connection once the 1.x upgrade steps have been
+	// removed. Upgrade steps should not be able close the API
+	// connection.
 	APIState() api.Connection
 
 	// State returns a connection to state. This will be non-nil

--- a/worker/apicaller/manifold_test.go
+++ b/worker/apicaller/manifold_test.go
@@ -218,13 +218,18 @@ func (s *ManifoldSuite) TestOutputSuccess(c *gc.C) {
 	err := s.manifold.Output(worker, &apicaller)
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(apicaller, gc.Equals, s.conn)
+
+	var conn api.Connection
+	err = s.manifold.Output(worker, &conn)
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(conn, gc.Equals, s.conn)
 }
 
 func (s *ManifoldSuite) TestOutputBadWorker(c *gc.C) {
 	var apicaller base.APICaller
 	err := s.manifold.Output(dummyWorker{}, &apicaller)
 	c.Check(apicaller, gc.IsNil)
-	c.Check(err.Error(), gc.Equals, "expected *apicaller.apiConnWorker->*base.APICaller; got apicaller_test.dummyWorker->*base.APICaller")
+	c.Check(err.Error(), gc.Equals, "in should be a *apicaller.apiConnWorker; got apicaller_test.dummyWorker")
 }
 
 func (s *ManifoldSuite) TestOutputBadTarget(c *gc.C) {
@@ -233,5 +238,5 @@ func (s *ManifoldSuite) TestOutputBadTarget(c *gc.C) {
 	var apicaller interface{}
 	err := s.manifold.Output(worker, &apicaller)
 	c.Check(apicaller, gc.IsNil)
-	c.Check(err.Error(), gc.Equals, "expected *apicaller.apiConnWorker->*base.APICaller; got *apicaller.apiConnWorker->*interface {}")
+	c.Check(err.Error(), gc.Equals, "out should be *base.APICaller or *api.Connection; got *interface {}")
 }

--- a/worker/gate/manifold.go
+++ b/worker/gate/manifold.go
@@ -49,8 +49,10 @@ func ManifoldEx(lock Lock) dependency.Manifold {
 				*outPointer = inWorker.lock
 			case *Waiter:
 				*outPointer = inWorker.lock
+			case *Lock:
+				*outPointer = inWorker.lock
 			default:
-				return errors.Errorf("out should be a pointer to an Unlocker or a Waiter; is %#v", out)
+				return errors.Errorf("out should be a *Unlocker, *Waiter, *Lock; is %#v", out)
 			}
 			return nil
 		},

--- a/worker/gate/manifold_test.go
+++ b/worker/gate/manifold_test.go
@@ -70,6 +70,17 @@ func (s *ManifoldSuite) TestSameManifoldWorkersConnected(c *gc.C) {
 	assertUnlocked(c, w)
 }
 
+func (s *ManifoldSuite) TestLockOutput(c *gc.C) {
+	var lock gate.Lock
+	err := s.manifold.Output(s.worker, &lock)
+	c.Assert(err, jc.ErrorIsNil)
+
+	w := waiter(c, s.manifold, s.worker)
+	assertLocked(c, w)
+	lock.Unlock()
+	assertUnlocked(c, w)
+}
+
 func (s *ManifoldSuite) TestDifferentManifoldWorkersUnconnected(c *gc.C) {
 	manifold2 := gate.Manifold()
 	worker2, err := manifold2.Start(nil)

--- a/worker/upgradesteps/manifold.go
+++ b/worker/upgradesteps/manifold.go
@@ -1,0 +1,84 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgradesteps
+
+import (
+	"errors"
+
+	"github.com/juju/juju/agent"
+	"github.com/juju/juju/api"
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/dependency"
+	"github.com/juju/juju/worker/gate"
+	"github.com/juju/names"
+)
+
+// ManifoldConfig defines the names of the manifolds on which a
+// Manifold will depend.
+type ManifoldConfig struct {
+	AgentName            string
+	APICallerName        string
+	UpgradeStepsGateName string
+	OpenStateForUpgrade  func() (*state.State, func(), error)
+}
+
+// Manifold returns a dependency manifold that runs an upgrader
+// worker, using the resource names defined in the supplied config.
+func Manifold(config ManifoldConfig) dependency.Manifold {
+	return dependency.Manifold{
+		Inputs: []string{
+			config.AgentName,
+			config.APICallerName,
+			config.UpgradeStepsGateName,
+		},
+		Start: func(getResource dependency.GetResourceFunc) (worker.Worker, error) {
+			// Get machine agent.
+			var agent agent.Agent
+			if err := getResource(config.AgentName, &agent); err != nil {
+				return nil, err
+			}
+
+			// Grab the tag and ensure that it's for a machine.
+			tag, ok := agent.CurrentConfig().Tag().(names.MachineTag)
+			if !ok {
+				return nil, errors.New("agent's tag is not a machine tag")
+			}
+
+			// Get API connection.
+			var apiConn api.Connection
+			if err := getResource(config.APICallerName, &apiConn); err != nil {
+				return nil, err
+			}
+
+			// Get the machine agent's jobs.
+			entity, err := apiConn.Agent().Entity(tag)
+			if err != nil {
+				return nil, err
+			}
+			jobs := entity.Jobs()
+
+			// Get machine instance for setting status on.
+			machine, err := apiConn.Machiner().Machine(tag)
+			if err != nil {
+				return nil, err
+			}
+
+			// Get upgradesteps completed lock.
+			var upgradeStepsLock gate.Lock
+			if err := getResource(config.UpgradeStepsGateName, &upgradeStepsLock); err != nil {
+				return nil, err
+			}
+
+			return NewWorker(
+				upgradeStepsLock,
+				agent,
+				apiConn,
+				jobs,
+				config.OpenStateForUpgrade,
+				machine,
+			)
+		},
+	}
+}


### PR DESCRIPTION
cmd/jujud/machine: Remove unnecessary configChanged trigger

The removed call to configChangedVal.Set was there in case upgradesteps.NewLock updated the agent's configuration. This is unnecessary because NewLock uses the agent's ChangeConfig method which already calls configChangedVal.Set.

---

upgrades: Add a TODO about API connection type

---

worker/apicaller: Expose api.Connection

This is needed for legacy upgrade steps. Use elsewhere is discouraged.

---

worker/gate: expose the lock as a Lock

This interface is needed by the upgradesteps worker.

---

Run the upgradesteps worker under the dependency engine

The new upgradesteps manifold does the setup work that used to be done in the machine agent.


(Review request: http://reviews.vapour.ws/r/3336/)