### PR TITLE
Add checks to see if upgrade should occur

### DIFF
--- a/apiserver/client/export_test.go
+++ b/apiserver/client/export_test.go
@@ -24,7 +24,10 @@ var (
 
 type MachineAndContainers machineAndContainers
 
-var StartSerialWaitParallel = startSerialWaitParallel
+var (
+	StartSerialWaitParallel = startSerialWaitParallel
+	GetEnvironment          = &getEnvironment
+)
 
 type StateInterface stateInterface
 

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -66,6 +66,7 @@ import (
 	"github.com/juju/juju/state/multiwatcher"
 	statestorage "github.com/juju/juju/state/storage"
 	"github.com/juju/juju/storage/looputil"
+	"github.com/juju/juju/upgrades"
 	"github.com/juju/juju/version"
 	"github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/addresser"
@@ -932,6 +933,7 @@ func (a *MachineAgent) upgradeStepsWorkerStarter(
 			apiConn,
 			jobs,
 			a.openStateForUpgrade,
+			upgrades.PreUpgradeSteps,
 			machine,
 		)
 	}

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -33,7 +33,7 @@ github.com/juju/schema	git	afe1151cb49d1d7ed3c75592dfc6f38703f2e988	2015-08-07T0
 github.com/juju/syslog	git	6be94e8b718766e9ff7a37342157fe4795da7cfa	2015-02-05T15:59:36Z
 github.com/juju/testing	git	3a4202497a8bff67966ecb327a0505fea8bb6ead	2015-11-23T15:50:06Z
 github.com/juju/txn	git	99ec629d0066a4d73c54d8e021a7fc1dc07df614	2015-06-09T16:58:27Z
-github.com/juju/utils	git	cd8c831097feb15b88597f2abe69e3b808df9131	2015-12-04T20:50:34Z
+github.com/juju/utils	git	3d0905454f10e9da0eb5d2b4e4c2242c05de30d6	2015-12-08T02:44:23Z
 github.com/juju/xml	git	eb759a627588d35166bc505fceb51b88500e291e	2015-04-13T13:11:21Z
 github.com/julienschmidt/httprouter	git	109e267447e95ad1bb48b758e40dd7453eb7b039	2015-09-05T17:25:33Z
 github.com/lxc/lxd	git	42b4c228e84cba622f221e04a1fa7164a416a440	2015-10-27T22:33:42Z

--- a/environs/utils.go
+++ b/environs/utils.go
@@ -113,3 +113,16 @@ func APIInfo(env Environ) (*api.Info, error) {
 	apiInfo := &api.Info{Addrs: apiAddrs, CACert: cert, EnvironTag: envTag}
 	return apiInfo, nil
 }
+
+// CheckProviderAPI returns an error if a simple API call
+// to check a basic response from the specified environ fails.
+func CheckProviderAPI(env Environ) error {
+	// We will make a simple API call to the provider
+	// to ensure the underlying substrate is ok.
+	_, err := env.AllInstances()
+	switch err {
+	case nil, ErrPartialInstances, ErrNoInstances:
+		return nil
+	}
+	return errors.Annotate(err, "cannot make API call to provider")
+}

--- a/featuretests/upgrade_test.go
+++ b/featuretests/upgrade_test.go
@@ -64,6 +64,9 @@ func (s *upgradeSuite) SetUpTest(c *gc.C) {
 	s.PatchValue(&upgradesteps.UpgradeStartTimeoutMaster, time.Duration(time.Millisecond*50))
 	s.PatchValue(&upgradesteps.UpgradeStartTimeoutSecondary, time.Duration(time.Millisecond*60))
 
+	// Ensure we don't fail disk space check.
+	s.PatchValue(&upgrades.MinDiskSpaceGib, 0)
+
 	// TODO(mjs) - the following should maybe be part of AgentSuite.SetUpTest()
 	s.PatchValue(&cmdutil.EnsureMongoServer, func(mongo.EnsureServerParams) error {
 		return nil

--- a/upgrades/export_test.go
+++ b/upgrades/export_test.go
@@ -17,7 +17,6 @@ var (
 	NewStateStorage           = &newStateStorage
 	StateToolsStorage         = &stateToolsStorage
 	AddAZToInstData           = &addAZToInstData
-	MinDiskSpaceGib           = &minDiskSpaceGib
 
 	ChownPath       = &chownPath
 	IsLocalEnviron  = &isLocalEnviron

--- a/upgrades/export_test.go
+++ b/upgrades/export_test.go
@@ -17,6 +17,8 @@ var (
 	NewStateStorage           = &newStateStorage
 	StateToolsStorage         = &stateToolsStorage
 	AddAZToInstData           = &addAZToInstData
+	MinDiskSpaceGib           = &minDiskSpaceGib
+	GetEnvironment            = &getEnvironment
 
 	ChownPath       = &chownPath
 	IsLocalEnviron  = &isLocalEnviron

--- a/upgrades/export_test.go
+++ b/upgrades/export_test.go
@@ -18,7 +18,6 @@ var (
 	StateToolsStorage         = &stateToolsStorage
 	AddAZToInstData           = &addAZToInstData
 	MinDiskSpaceGib           = &minDiskSpaceGib
-	GetEnvironment            = &getEnvironment
 
 	ChownPath       = &chownPath
 	IsLocalEnviron  = &isLocalEnviron

--- a/upgrades/preupgradesteps.go
+++ b/upgrades/preupgradesteps.go
@@ -22,14 +22,14 @@ func PreUpgradeSteps(st *state.State, agentConf agent.Config, isMaster bool) err
 }
 
 // We'll be conservative and require at least 2GiB of disk space for an upgrade.
-var minDiskSpaceGib = 2
+var MinDiskSpaceGib = 2
 
 func checkDiskSpace(dir string) error {
 	usage := du.NewDiskUsage(dir)
 	free := usage.Free()
-	if free < uint64(minDiskSpaceGib*humanize.GiByte) {
+	if free < uint64(MinDiskSpaceGib*humanize.GiByte) {
 		return errors.Errorf("not enough free disk space for upgrade: %s available, require %dGiB",
-			humanize.IBytes(free), minDiskSpaceGib)
+			humanize.IBytes(free), MinDiskSpaceGib)
 	}
 	return nil
 }

--- a/upgrades/preupgradesteps.go
+++ b/upgrades/preupgradesteps.go
@@ -1,0 +1,67 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades
+
+import (
+	"github.com/dustin/go-humanize"
+	"github.com/juju/errors"
+	"github.com/juju/utils/du"
+
+	"github.com/juju/juju/agent"
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/state"
+)
+
+// PreUpgradeSteps runs various checks and prepares for performing an upgrade.
+// If any check fails, an error is returned which aborts the upgrade.
+func PreUpgradeSteps(st *state.State, agentConf agent.Config, isMaster bool) error {
+	if err := checkDiskSpace(agentConf.DataDir()); err != nil {
+		return err
+	}
+	if isMaster {
+		if err := checkProviderAPI(st); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// We'll be conservative and require at least 2GiB of disk space for an upgrade.
+var minDiskSpaceGib = 2
+
+func checkDiskSpace(dir string) error {
+	usage := du.NewDiskUsage(dir)
+	free := usage.Free()
+	if free < uint64(minDiskSpaceGib*humanize.GiByte) {
+		return errors.Errorf("not enough free disk space for upgrade %dGiB available, require %dGiB",
+			free/humanize.GiByte, minDiskSpaceGib)
+	}
+	return nil
+}
+
+func checkProviderAPI(st *state.State) error {
+	// We will make a simple API call to the provider
+	// to ensure the underlying substrate is ok.
+	env, err := getEnvironment(st)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	_, err = env.AllInstances()
+	if err != nil {
+		return errors.Annotate(err, "cannot make API call to provider")
+	}
+	return nil
+}
+
+var getEnvironment = func(st *state.State) (environs.Environ, error) {
+	cfg, err := st.EnvironConfig()
+	if err != nil {
+		return nil, err
+	}
+	env, err := environs.New(cfg)
+	if err != nil {
+		return nil, err
+	}
+	return env, nil
+}

--- a/upgrades/preupgradesteps_test.go
+++ b/upgrades/preupgradesteps_test.go
@@ -1,0 +1,70 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades_test
+
+import (
+	"github.com/dustin/go-humanize"
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/instance"
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/testing"
+	"github.com/juju/juju/upgrades"
+)
+
+type preupgradechecksSuite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&preupgradechecksSuite{})
+
+func (s *preupgradechecksSuite) TestCheckFreeDiskSpace(c *gc.C) {
+	// Expect an impossibly large amount of free disk.
+	s.PatchValue(upgrades.MinDiskSpaceGib, 1000*humanize.EiByte/humanize.GiByte)
+	err := upgrades.PreUpgradeSteps(nil, &mockAgentConfig{dataDir: "/"}, false)
+	c.Assert(err, gc.ErrorMatches, "not enough free disk space for upgrade .*")
+}
+
+type mockEnviron struct {
+	environs.Environ
+	allInstancesCalled bool
+}
+
+func (m *mockEnviron) AllInstances() ([]instance.Instance, error) {
+	m.allInstancesCalled = true
+	return nil, errors.New("instances error")
+}
+
+func (s *preupgradechecksSuite) TestCheckProviderAPI(c *gc.C) {
+	// We don't want to fail on disk space in this test.
+	s.PatchValue(upgrades.MinDiskSpaceGib, 0)
+
+	env := &mockEnviron{}
+	var callSt *state.State
+	s.PatchValue(upgrades.GetEnvironment, func(st *state.State) (environs.Environ, error) {
+		c.Assert(st, gc.Equals, callSt)
+		return env, nil
+	})
+	err := upgrades.PreUpgradeSteps(callSt, &mockAgentConfig{dataDir: "/"}, true)
+	c.Assert(err, gc.ErrorMatches, "cannot make API call to provider: instances error")
+	c.Assert(env.allInstancesCalled, jc.IsTrue)
+}
+
+func (s *preupgradechecksSuite) TestCheckProviderAPINotMaster(c *gc.C) {
+	// We don't want to fail on disk space in this test.
+	s.PatchValue(upgrades.MinDiskSpaceGib, 0)
+
+	env := &mockEnviron{}
+	var callSt *state.State
+	s.PatchValue(upgrades.GetEnvironment, func(st *state.State) (environs.Environ, error) {
+		c.Assert(st, gc.Equals, callSt)
+		return env, nil
+	})
+	err := upgrades.PreUpgradeSteps(callSt, &mockAgentConfig{dataDir: "/"}, false)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(env.allInstancesCalled, jc.IsFalse)
+}

--- a/upgrades/preupgradesteps_test.go
+++ b/upgrades/preupgradesteps_test.go
@@ -5,13 +5,8 @@ package upgrades_test
 
 import (
 	"github.com/dustin/go-humanize"
-	"github.com/juju/errors"
-	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/environs"
-	"github.com/juju/juju/instance"
-	"github.com/juju/juju/state"
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/upgrades"
 )
@@ -27,44 +22,4 @@ func (s *preupgradechecksSuite) TestCheckFreeDiskSpace(c *gc.C) {
 	s.PatchValue(upgrades.MinDiskSpaceGib, 1000*humanize.EiByte/humanize.GiByte)
 	err := upgrades.PreUpgradeSteps(nil, &mockAgentConfig{dataDir: "/"}, false)
 	c.Assert(err, gc.ErrorMatches, "not enough free disk space for upgrade .*")
-}
-
-type mockEnviron struct {
-	environs.Environ
-	allInstancesCalled bool
-}
-
-func (m *mockEnviron) AllInstances() ([]instance.Instance, error) {
-	m.allInstancesCalled = true
-	return nil, errors.New("instances error")
-}
-
-func (s *preupgradechecksSuite) TestCheckProviderAPI(c *gc.C) {
-	// We don't want to fail on disk space in this test.
-	s.PatchValue(upgrades.MinDiskSpaceGib, 0)
-
-	env := &mockEnviron{}
-	var callSt *state.State
-	s.PatchValue(upgrades.GetEnvironment, func(st *state.State) (environs.Environ, error) {
-		c.Assert(st, gc.Equals, callSt)
-		return env, nil
-	})
-	err := upgrades.PreUpgradeSteps(callSt, &mockAgentConfig{dataDir: "/"}, true)
-	c.Assert(err, gc.ErrorMatches, "cannot make API call to provider: instances error")
-	c.Assert(env.allInstancesCalled, jc.IsTrue)
-}
-
-func (s *preupgradechecksSuite) TestCheckProviderAPINotMaster(c *gc.C) {
-	// We don't want to fail on disk space in this test.
-	s.PatchValue(upgrades.MinDiskSpaceGib, 0)
-
-	env := &mockEnviron{}
-	var callSt *state.State
-	s.PatchValue(upgrades.GetEnvironment, func(st *state.State) (environs.Environ, error) {
-		c.Assert(st, gc.Equals, callSt)
-		return env, nil
-	})
-	err := upgrades.PreUpgradeSteps(callSt, &mockAgentConfig{dataDir: "/"}, false)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(env.allInstancesCalled, jc.IsFalse)
 }

--- a/upgrades/preupgradesteps_test.go
+++ b/upgrades/preupgradesteps_test.go
@@ -19,7 +19,7 @@ var _ = gc.Suite(&preupgradechecksSuite{})
 
 func (s *preupgradechecksSuite) TestCheckFreeDiskSpace(c *gc.C) {
 	// Expect an impossibly large amount of free disk.
-	s.PatchValue(upgrades.MinDiskSpaceGib, 1000*humanize.EiByte/humanize.GiByte)
+	s.PatchValue(&upgrades.MinDiskSpaceGib, 1000*humanize.EiByte/humanize.GiByte)
 	err := upgrades.PreUpgradeSteps(nil, &mockAgentConfig{dataDir: "/"}, false)
-	c.Assert(err, gc.ErrorMatches, "not enough free disk space for upgrade .*")
+	c.Assert(err, gc.ErrorMatches, "not enough free disk space for upgrade: .*")
 }

--- a/worker/upgradesteps/worker.go
+++ b/worker/upgradesteps/worker.go
@@ -255,7 +255,7 @@ func (w *upgradesteps) runUpgrades() error {
 func (w *upgradesteps) prepareForUpgrade() (*state.UpgradeInfo, error) {
 	logger.Infof("checking that upgrade can proceed")
 	if err := w.preUpgradeSteps(w.st, w.agent.CurrentConfig(), w.isMaster); err != nil {
-		return nil, errors.Annotatef(err, "machine %q cannot be upgraded", w.tag)
+		return nil, errors.Annotatef(err, "%s cannot be upgraded", names.ReadableString(w.tag))
 	}
 
 	if !w.isStateServer {

--- a/worker/upgradesteps/worker_test.go
+++ b/worker/upgradesteps/worker_test.go
@@ -42,6 +42,7 @@ type UpgradeSuite struct {
 	logWriter       loggo.TestWriter
 	connectionDead  bool
 	machineIsMaster bool
+	preUpgradeError bool
 }
 
 var _ = gc.Suite(&UpgradeSuite{})
@@ -52,6 +53,7 @@ const succeeds = false
 func (s *UpgradeSuite) SetUpTest(c *gc.C) {
 	s.StateSuite.SetUpTest(c)
 
+	s.preUpgradeError = false
 	// Most of these tests normally finish sub-second on a fast machine.
 	// If any given test hits a minute, we have almost certainly become
 	// wedged, so dump the logs.
@@ -371,6 +373,33 @@ func (s *UpgradeSuite) TestJobsToTargets(c *gc.C) {
 		upgrades.StateServer, upgrades.DatabaseMaster, upgrades.HostMachine)
 }
 
+func (s *UpgradeSuite) TestPreUpgradeFail(c *gc.C) {
+	s.preUpgradeError = true
+	defer s.captureLogs(c)
+
+	workerErr, config, statusCalls, doneCh := s.runUpgradeWorker(c, multiwatcher.JobHostUnits)
+
+	c.Check(workerErr, jc.ErrorIsNil)
+	c.Check(config.Version, gc.Equals, s.oldVersion.Number) // Upgrade didn't finish
+	assertUpgradeNotComplete(c, doneCh)
+	assertUpgradeNotComplete(c, doneCh)
+
+	causeMessage := `machine "machine-0" cannot be upgraded: preupgrade error`
+	failMessage := fmt.Sprintf(
+		`upgrade from %s to %s for "machine-0" failed \(giving up\): %s`,
+		s.oldVersion.Number, version.Current, causeMessage)
+	c.Assert(s.logWriter.Log(), jc.LogMatches, []jc.SimpleMessage{
+		{loggo.INFO, "checking that upgrade can proceed"},
+		{loggo.ERROR, failMessage},
+	})
+
+	statusMessage := fmt.Sprintf(
+		`upgrade to %s failed \(giving up\): %s`, version.Current, causeMessage)
+	c.Assert(statusCalls, jc.DeepEquals, []StatusCall{{
+		params.StatusError, statusMessage,
+	}})
+}
+
 // Run just the upgradesteps worker with a fake machine agent and
 // fake agent config.
 func (s *UpgradeSuite) runUpgradeWorker(c *gc.C, jobs ...multiwatcher.MachineJob) (
@@ -382,7 +411,7 @@ func (s *UpgradeSuite) runUpgradeWorker(c *gc.C, jobs ...multiwatcher.MachineJob
 	doneCh, err := NewChannel(agent)
 	c.Assert(err, jc.ErrorIsNil)
 	machineStatus := &testStatusSetter{}
-	worker, err := NewWorker(doneCh, agent, nil, jobs, s.openStateForUpgrade, machineStatus)
+	worker, err := NewWorker(doneCh, agent, nil, jobs, s.openStateForUpgrade, s.preUpgradeSteps, machineStatus)
 	c.Assert(err, jc.ErrorIsNil)
 	return worker.Wait(), config, machineStatus.Calls, doneCh
 }
@@ -394,6 +423,13 @@ func (s *UpgradeSuite) openStateForUpgrade() (*state.State, func(), error) {
 		return nil, nil, err
 	}
 	return st, func() { st.Close() }, nil
+}
+
+func (s *UpgradeSuite) preUpgradeSteps(st *state.State, agentConf agent.Config, isStateServer bool) error {
+	if s.preUpgradeError {
+		return errors.New("preupgrade error")
+	}
+	return nil
 }
 
 func (s *UpgradeSuite) makeFakeConfig() *fakeConfigSetter {

--- a/worker/upgradesteps/worker_test.go
+++ b/worker/upgradesteps/worker_test.go
@@ -375,16 +375,15 @@ func (s *UpgradeSuite) TestJobsToTargets(c *gc.C) {
 
 func (s *UpgradeSuite) TestPreUpgradeFail(c *gc.C) {
 	s.preUpgradeError = true
-	defer s.captureLogs(c)
+	s.captureLogs(c)
 
 	workerErr, config, statusCalls, doneCh := s.runUpgradeWorker(c, multiwatcher.JobHostUnits)
 
 	c.Check(workerErr, jc.ErrorIsNil)
 	c.Check(config.Version, gc.Equals, s.oldVersion.Number) // Upgrade didn't finish
 	assertUpgradeNotComplete(c, doneCh)
-	assertUpgradeNotComplete(c, doneCh)
 
-	causeMessage := `machine "machine-0" cannot be upgraded: preupgrade error`
+	causeMessage := `machine 0 cannot be upgraded: preupgrade error`
 	failMessage := fmt.Sprintf(
 		`upgrade from %s to %s for "machine-0" failed \(giving up\): %s`,
 		s.oldVersion.Number, version.Current, causeMessage)
@@ -394,7 +393,7 @@ func (s *UpgradeSuite) TestPreUpgradeFail(c *gc.C) {
 	})
 
 	statusMessage := fmt.Sprintf(
-		`upgrade to %s failed \(giving up\): %s`, version.Current, causeMessage)
+		`upgrade to %s failed (giving up): %s`, version.Current, causeMessage)
 	c.Assert(statusCalls, jc.DeepEquals, []StatusCall{{
 		params.StatusError, statusMessage,
 	}})


### PR DESCRIPTION
When preparing for an upgrade, checks are run to see if the upgrade should succeed. Currently the checks are:

- free disk space (all machines)
- simple provider api call (master state server)


(Review request: http://reviews.vapour.ws/r/3340/)