### PR TITLE
maas: Make spaces constraints work on MAAS 1.9+

### DIFF
--- a/provider/maas/constraints.go
+++ b/provider/maas/constraints.go
@@ -154,11 +154,6 @@ func addInterfaces(
 				"duplicated interface binding %q",
 				binding.Name,
 			))
-		case spacesSet.Contains(binding.SpaceProviderId):
-			return errors.NewNotValid(nil, fmt.Sprintf(
-				"duplicated space %q in interface binding %q",
-				binding.SpaceProviderId, binding.Name,
-			))
 		}
 		namesSet.Add(binding.Name)
 		spacesSet.Add(binding.SpaceProviderId)

--- a/provider/maas/constraints.go
+++ b/provider/maas/constraints.go
@@ -166,7 +166,7 @@ func addInterfaces(params url.Values, bindings []interfaceBinding) error {
 		}
 		namesSet.Add(binding.Name)
 		if binding.IsExcluded {
-			negatives = append(negatives, fmt.Sprintf("space=%s", binding.SpaceProviderId))
+			negatives = append(negatives, fmt.Sprintf("space:%s", binding.SpaceProviderId))
 		} else {
 			positives = append(positives, fmt.Sprintf("%s:space=%s", binding.Name, binding.SpaceProviderId))
 		}

--- a/provider/maas/constraints.go
+++ b/provider/maas/constraints.go
@@ -72,33 +72,13 @@ func convertTagsToParams(params url.Values, tags *[]string) {
 	}
 }
 
-// convertSpacesFromConstraints converts a list of positive/negative spaces from
-// constraints into a list of interface bindings for the positive spaces, and a
-// list all negative spaces (if any). The bindings use zero-based numeric labels
-// using "space=<positive-name>". Negative spaces are returned with a "space:"
-// prefix. The results are then used to prepare the "intefaces" and
-// "not_networks" arguments passed to MAAS acquire node API.
-func convertSpacesFromConstraints(spaces *[]string) ([]interfaceBinding, []string) {
+// convertSpacesFromConstraints extracts spaces from constraints and converts
+// them to two lists of positive and negative spaces.
+func convertSpacesFromConstraints(spaces *[]string) ([]string, []string) {
 	if spaces == nil || len(*spaces) == 0 {
 		return nil, nil
 	}
-	var (
-		index    uint
-		bindings []interfaceBinding
-		excluded []string
-	)
-	positives, negatives := parseDelimitedValues(*spaces)
-	for _, space := range positives {
-		bindings = append(bindings, interfaceBinding{
-			Name:            fmt.Sprintf("%v", index),
-			SpaceProviderId: space,
-		})
-		index++
-	}
-	for _, space := range negatives {
-		excluded = append(excluded, fmt.Sprintf("space:%s", space))
-	}
-	return bindings, excluded
+	return parseDelimitedValues(*spaces)
 }
 
 // parseDelimitedValues parses a slice of raw values coming from constraints
@@ -136,34 +116,97 @@ type interfaceBinding struct {
 	// add more as needed.
 }
 
-// addInterfaces converts a slice of interface bindings to the format MAAS
-// expects for the "interfaces" and "not_networks" arguments to acquire node.
-// Returns an error satisfying errors.IsNotValid() if bindings contains
-// duplicates or empty Name/SpaceName.
-func addInterfaces(params url.Values, bindings []interfaceBinding) error {
-	if len(bindings) == 0 {
-		return nil
-	}
-	var positives []string
+// numericLabelLimit is a sentinel value used in addInterfaces to limit the
+// number of disabmiguation inner loop iterations in case named labels clash
+// with numeric labels for spaces coming from constraints. It's defined here to
+// facilitate testing this behavior.
+var numericLabelLimit uint = 0xffff
+
+// addInterfaces converts a slice of interface bindings, postiveSpaces and
+// negativeSpaces coming from constraints to the format MAAS expects for the
+// "interfaces" and "not_networks" arguments to acquire node. Returns an error
+// satisfying errors.IsNotValid() if the bindings contains duplicates, empty
+// Name/SpaceProviderId, or if negative spaces clash with specified bindings.
+// Duplicates between specified bindings and positiveSpaces are silently
+// skipped.
+func addInterfaces(
+	params url.Values,
+	bindings []interfaceBinding,
+	positiveSpaces, negativeSpaces []string,
+) error {
+	var (
+		index            uint
+		combinedBindings []string
+	)
 	namesSet := set.NewStrings()
+	spacesSet := set.NewStrings()
 	for _, binding := range bindings {
 		switch {
 		case binding.Name == "":
 			return errors.NewNotValid(nil, "interface bindings cannot have empty names")
 		case binding.SpaceProviderId == "":
 			return errors.NewNotValid(nil, fmt.Sprintf(
-				"invalid interface binding %q: space provider ID is required", binding.Name),
-			)
+				"invalid interface binding %q: space provider ID is required",
+				binding.Name,
+			))
 		case namesSet.Contains(binding.Name):
 			return errors.NewNotValid(nil, fmt.Sprintf(
-				"duplicated interface binding %q", binding.Name),
-			)
+				"duplicated interface binding %q",
+				binding.Name,
+			))
+		case spacesSet.Contains(binding.SpaceProviderId):
+			return errors.NewNotValid(nil, fmt.Sprintf(
+				"duplicated space %q in interface binding %q",
+				binding.SpaceProviderId, binding.Name,
+			))
 		}
 		namesSet.Add(binding.Name)
-		positives = append(positives, fmt.Sprintf("%s:space=%s", binding.Name, binding.SpaceProviderId))
+		spacesSet.Add(binding.SpaceProviderId)
+
+		item := fmt.Sprintf("%s:space=%s", binding.Name, binding.SpaceProviderId)
+		combinedBindings = append(combinedBindings, item)
 	}
-	if len(positives) > 0 {
-		params.Add("interfaces", strings.Join(positives, ";"))
+
+	for _, space := range positiveSpaces {
+		if spacesSet.Contains(space) {
+			// Skip duplicates in positiveSpaces.
+			continue
+		}
+		spacesSet.Add(space)
+		// Make sure we pick a label that doesn't clash with possible bindings.
+		var label string
+		for {
+			label = fmt.Sprintf("%v", index)
+			if !namesSet.Contains(label) {
+				break
+			}
+			if index > numericLabelLimit { // ...just to make sure we won't loop forever.
+				return errors.Errorf("too many conflicting numeric labels, giving up.")
+			}
+			index++
+		}
+		namesSet.Add(label)
+		item := fmt.Sprintf("%s:space=%s", label, space)
+		combinedBindings = append(combinedBindings, item)
+		index++
+	}
+
+	var negatives []string
+	for _, space := range negativeSpaces {
+		if spacesSet.Contains(space) {
+			return errors.NewNotValid(nil, fmt.Sprintf(
+				"negative space %q from constraints clashes with interface bindings",
+				space,
+			))
+		}
+		negatives = append(negatives, fmt.Sprintf("space:%s", space))
+	}
+
+	if len(combinedBindings) > 0 {
+		params.Add("interfaces", strings.Join(combinedBindings, ";"))
+	}
+	if len(negatives) > 0 {
+		params.Add("not_networks", strings.Join(negatives, ","))
 	}
 	return nil
 }

--- a/provider/maas/constraints_test.go
+++ b/provider/maas/constraints_test.go
@@ -416,7 +416,7 @@ func (suite *environSuite) TestAcquireNodePassesPositiveAndNegativeSpaces(c *gc.
 	nodeValues, found := requestValues["node0"]
 	c.Assert(found, jc.IsTrue)
 	c.Assert(nodeValues[0].Get("interfaces"), gc.Equals, "0:space=space1;1:space=space3")
-	c.Assert(nodeValues[0].Get("not_networks"), gc.Equals, "space=space2,space=space4")
+	c.Assert(nodeValues[0].Get("not_networks"), gc.Equals, "space:space2,space:space4")
 }
 
 func (suite *environSuite) TestAcquireNodeStorage(c *gc.C) {
@@ -470,7 +470,7 @@ func (suite *environSuite) TestAcquireNodeInterfaces(c *gc.C) {
 	}{{ // without specified bindings, spaces constraints are used instead.
 		interfaces:        nil,
 		expectedPositives: "0:space=foo",
-		expectedNegatives: "space=bar",
+		expectedNegatives: "space:bar",
 		expectedError:     "",
 	}, {
 		interfaces:        []interfaceBinding{{"name-1", "space-1", false}},
@@ -491,7 +491,7 @@ func (suite *environSuite) TestAcquireNodeInterfaces(c *gc.C) {
 			{"name-3", "space-3", true},
 		},
 		expectedPositives: "name-1:space=space-1",
-		expectedNegatives: "space=space-2,space=space-3",
+		expectedNegatives: "space:space-2,space:space-3",
 	}, {
 		interfaces:    []interfaceBinding{{"", "anything", false}},
 		expectedError: "interface bindings cannot have empty names",

--- a/provider/maas/constraints_test.go
+++ b/provider/maas/constraints_test.go
@@ -423,7 +423,8 @@ func (suite *environSuite) TestAcquireNodeInterfaces(c *gc.C) {
 			{"shared-db", "dup-space"},
 			{"db", "dup-space"},
 		},
-		expectedError: `duplicated space "dup-space" in interface binding "db"`,
+		expectedPositives: "shared-db:space=dup-space;db:space=dup-space;0:space=foo",
+		expectedNegatives: "space:bar",
 	}, {
 		interfaces:    []interfaceBinding{{"", ""}},
 		expectedError: "interface bindings cannot have empty names",

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -677,6 +677,12 @@ func (environ *maasEnviron) acquireNode(
 ) (gomaasapi.MAASObject, error) {
 
 	acquireParams := convertConstraints(cons)
+	// Specified bindings always override spaces constraints, and since both of
+	// them end up as part of the "interfaces=" argument to acquire, we only
+	// process spaces constraints if there are no bindings.
+	if len(interfaces) == 0 {
+		interfaces = convertSpacesToBindings(cons.Spaces)
+	}
 	if err := addInterfaces(acquireParams, interfaces); err != nil {
 		return gomaasapi.MAASObject{}, err
 	}
@@ -709,6 +715,7 @@ func (environ *maasEnviron) acquireNode(
 	var err error
 	for a := shortAttempt.Start(); a.Next(); {
 		client := environ.getMAASClient().GetSubObject("nodes/")
+		logger.Tracef("calling acquire with params: %+v", acquireParams)
 		result, err = client.CallPost("acquire", acquireParams)
 		if err == nil {
 			break
@@ -1707,6 +1714,11 @@ func (environ *maasEnviron) allocatableRangeForSubnet(cidr string, subnetId stri
 	if err != nil {
 		return nil, nil, errors.Trace(err)
 	}
+	// Skip IPv6 subnets until we can handle them correctly.
+	if ip.To4() == nil && ip.To16() != nil {
+		logger.Debugf("ignoring static IP range for IPv6 subnet %q", cidr)
+		return nil, nil, nil
+	}
 
 	// TODO(mfoord): needs updating to work with IPv6 as well.
 	lowBound, err := network.IPv4ToDecimal(ip)
@@ -1791,19 +1803,26 @@ func (environ *maasEnviron) allocatableRangeForSubnet(cidr string, subnetId stri
 // subnetsWithSpaces uses the MAAS 1.9+ API to fetch subnet information
 // including space name.
 func (environ *maasEnviron) subnetsWithSpaces(instId instance.Id, subnetIds []network.Id) ([]network.SubnetInfo, error) {
-	inst, err := environ.getInstance(instId)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	nodeId, err := environ.nodeIdFromInstance(inst)
-	if err != nil {
-		return nil, errors.Trace(err)
+	var nodeId string
+	if instId != instance.UnknownId {
+		inst, err := environ.getInstance(instId)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		nodeId, err = environ.nodeIdFromInstance(inst)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
 	}
 	subnets, err := environ.filteredSubnets(nodeId, subnetIds)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	logger.Debugf("instance %q has subnets %v", instId, subnets)
+	if instId != instance.UnknownId {
+		logger.Debugf("instance %q has subnets %v", instId, subnets)
+	} else {
+		logger.Debugf("found subnets %v", instId, subnets)
+	}
 
 	return subnets, nil
 }
@@ -1856,13 +1875,23 @@ func (environ *maasEnviron) subnetFromJson(subnet gomaasapi.JSONObject) (network
 	return subnetInfo, nil
 }
 
-// filteredSubnets fetches subnets, filtering by nodeId and optionally a slice
-// of subnetIds. If subnetIds is empty then all subnets for that node are
-// fetched.
+// filteredSubnets fetches subnets, filtering optionally by nodeId and/or a
+// slice of subnetIds. If subnetIds is empty then all subnets for that node are
+// fetched. If nodeId is empty, all subnets are returned (filtering by subnetIds
+// first, if set).
 func (environ *maasEnviron) filteredSubnets(nodeId string, subnetIds []network.Id) ([]network.SubnetInfo, error) {
-	jsonNets, err := environ.subnetsFromNode(nodeId)
-	if err != nil {
-		return nil, errors.Trace(err)
+	var jsonNets []gomaasapi.JSONObject
+	var err error
+	if nodeId != "" {
+		jsonNets, err = environ.subnetsFromNode(nodeId)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+	} else {
+		jsonNets, err = environ.fetchAllSubnets()
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
 	}
 	subnetIdSet := make(map[string]bool)
 	for _, netId := range subnetIds {
@@ -1916,10 +1945,10 @@ func (environ *maasEnviron) getInstance(instId instance.Id) (instance.Instance, 
 	return inst, nil
 }
 
-// Spaces returns all the spaces, that have subnets, known to the provider.
-// Space name is not filled in as the provider doesn't know the juju name for
-// the space.
-func (environ *maasEnviron) Spaces() ([]network.SpaceInfo, error) {
+// fetchAllSubnets calls the MAAS subnets API to get all subnets and returns the
+// JSON response or an error. If capNetworkDeploymentUbuntu is not available, an
+// error satisfying errors.IsNotSupported will be returned.
+func (environ *maasEnviron) fetchAllSubnets() ([]gomaasapi.JSONObject, error) {
 	ok, err := environ.SupportsSpaces()
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -1933,7 +1962,14 @@ func (environ *maasEnviron) Spaces() ([]network.SpaceInfo, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	jsonNets, err := json.GetArray()
+	return json.GetArray()
+}
+
+// Spaces returns all the spaces, that have subnets, known to the provider.
+// Space name is not filled in as the provider doesn't know the juju name for
+// the space.
+func (environ *maasEnviron) Spaces() ([]network.SpaceInfo, error) {
+	jsonNets, err := environ.fetchAllSubnets()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -1972,14 +2008,17 @@ func (environ *maasEnviron) Subnets(instId instance.Id, subnetIds []network.Id) 
 	if ok {
 		return environ.subnetsWithSpaces(instId, subnetIds)
 	}
-	// At some point in the future an empty subnetIds may mean "fetch all subnets"
-	// but until that functionality is needed it's an error.
-	if len(subnetIds) == 0 {
-		return nil, errors.Errorf("subnetIds must not be empty")
+	// When not using MAAS API with spaces support, we require both instance ID
+	// and list of subnet IDs, that's due to the limitations of the old API.
+	if instId == instance.UnknownId {
+		return nil, errors.Errorf("instance ID is required")
 	}
 	inst, err := environ.getInstance(instId)
 	if err != nil {
 		return nil, errors.Trace(err)
+	}
+	if len(subnetIds) == 0 {
+		return nil, errors.Errorf("subnet IDs must not be empty")
 	}
 	// The MAAS API get networks call returns named subnets, not physical networks,
 	// so we save the data from this call into a variable called subnets.

--- a/provider/maas/environ_whitebox_test.go
+++ b/provider/maas/environ_whitebox_test.go
@@ -983,86 +983,258 @@ func (suite *environSuite) TestNetworkInterfaces(c *gc.C) {
 	c.Assert(netInfo, jc.DeepEquals, expectedInfo)
 }
 
-func (suite *environSuite) TestSubnets(c *gc.C) {
+func (suite *environSuite) TestSubnetsWithInstanceIdAndSubnetIdsWhenSpacesNotSupported(c *gc.C) {
+	suite.testMAASObject.TestServer.SetVersionJSON(`{"capabilities": []}`)
 	testInstance := suite.createSubnets(c, false)
 
-	netInfo, err := suite.makeEnviron().Subnets(testInstance.Id(), []network.Id{"LAN", "Virt", "WLAN"})
+	subnetsInfo, err := suite.makeEnviron().Subnets(testInstance.Id(), []network.Id{"LAN", "Virt", "WLAN"})
 	c.Assert(err, jc.ErrorIsNil)
 
-	expectedInfo := []network.SubnetInfo{
-		{CIDR: "192.168.2.1/24", ProviderId: "LAN", VLANTag: 42, AllocatableIPLow: net.ParseIP("192.168.2.0"), AllocatableIPHigh: net.ParseIP("192.168.2.127")},
-		{CIDR: "192.168.3.1/24", ProviderId: "Virt", VLANTag: 0},
-		{CIDR: "192.168.1.1/24", ProviderId: "WLAN", VLANTag: 0, AllocatableIPLow: net.ParseIP("192.168.1.129"), AllocatableIPHigh: net.ParseIP("192.168.1.255")}}
-	c.Assert(netInfo, jc.DeepEquals, expectedInfo)
+	expectedInfo := []network.SubnetInfo{{
+		CIDR:              "192.168.2.1/24",
+		ProviderId:        "LAN",
+		VLANTag:           42,
+		AllocatableIPLow:  net.ParseIP("192.168.2.0"),
+		AllocatableIPHigh: net.ParseIP("192.168.2.127"),
+	}, {
+		CIDR:              "192.168.3.1/24",
+		ProviderId:        "Virt",
+		AllocatableIPLow:  nil,
+		AllocatableIPHigh: nil,
+		VLANTag:           0,
+	}, {
+		CIDR:              "192.168.1.1/24",
+		ProviderId:        "WLAN",
+		VLANTag:           0,
+		AllocatableIPLow:  net.ParseIP("192.168.1.129"),
+		AllocatableIPHigh: net.ParseIP("192.168.1.255"),
+	}}
+	c.Assert(subnetsInfo, jc.DeepEquals, expectedInfo)
 }
 
-func (suite *environSuite) TestSubnetsNoNetIds(c *gc.C) {
+func (suite *environSuite) TestSubnetsWithInstanceIdNoSubnetIdsWhenSpacesNotSupported(c *gc.C) {
+	suite.testMAASObject.TestServer.SetVersionJSON(`{"capabilities": []}`)
 	testInstance := suite.createSubnets(c, false)
-	_, err := suite.makeEnviron().Subnets(testInstance.Id(), []network.Id{})
-	c.Assert(err, gc.ErrorMatches, "subnetIds must not be empty")
+	env := suite.makeEnviron()
+	_, err := env.Subnets(testInstance.Id(), []network.Id{})
+	c.Assert(err, gc.ErrorMatches, "subnet IDs must not be empty")
+
+	_, err = env.Subnets(testInstance.Id(), nil)
+	c.Assert(err, gc.ErrorMatches, "subnet IDs must not be empty")
 }
 
-func (suite *environSuite) TestSubnetsMissingNetwork(c *gc.C) {
+func (suite *environSuite) TestSubnetsNoInstanceIdWithSubnetIdsWhenSpacesNotSupported(c *gc.C) {
+	suite.testMAASObject.TestServer.SetVersionJSON(`{"capabilities": []}`)
+	suite.createSubnets(c, false)
+	_, err := suite.makeEnviron().Subnets(instance.UnknownId, []network.Id{"LAN", "Virt", "WLAN"})
+	c.Assert(err, gc.ErrorMatches, "instance ID is required")
+}
+
+func (suite *environSuite) TestSubnetsNoInstaceIdNoSubnetIdsWhenSpacesNotSupported(c *gc.C) {
+	suite.testMAASObject.TestServer.SetVersionJSON(`{"capabilities": []}`)
+	suite.createSubnets(c, false)
+	env := suite.makeEnviron()
+	_, err := env.Subnets(instance.UnknownId, nil)
+	c.Assert(err, gc.ErrorMatches, "instance ID is required")
+}
+
+func (suite *environSuite) TestSubnetsInvalidInstaceIdAnySubnetIdsWhenSpacesNotSupported(c *gc.C) {
+	suite.testMAASObject.TestServer.SetVersionJSON(`{"capabilities": []}`)
+	suite.createSubnets(c, false)
+	env := suite.makeEnviron()
+	_, err := env.Subnets("invalid", []network.Id{"anything"})
+	c.Assert(err, gc.ErrorMatches, `instance "invalid" not found`)
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+
+	_, err = env.Subnets("invalid", nil)
+	c.Assert(err, gc.ErrorMatches, `instance "invalid" not found`)
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+}
+
+func (suite *environSuite) TestSubnetsWithInstanceIdAndSubnetIdsWhenSpacesAreSupported(c *gc.C) {
+	suite.testMAASObject.TestServer.SetVersionJSON(`{"capabilities": ["network-deployment-ubuntu"]}`)
+	var subnetIDs []network.Id
+	var uintIDs []uint
+	for _, i := range []uint{1, 2, 3} {
+		id := suite.addSubnet(c, i, i, "node1")
+		subnetIDs = append(subnetIDs, network.Id(fmt.Sprintf("%v", id)))
+		uintIDs = append(uintIDs, id)
+		suite.addSubnet(c, i+5, i, "node2")
+		suite.addSubnet(c, i+10, i, "") // not linked to a node
+	}
+	testInstance := suite.getInstance("node1")
+	env := suite.makeEnviron()
+
+	subnetsInfo, err := env.Subnets(testInstance.Id(), subnetIDs)
+	c.Assert(err, jc.ErrorIsNil)
+	expectedInfo := []network.SubnetInfo{
+		createSubnetInfo(uintIDs[0], 1, 1),
+		createSubnetInfo(uintIDs[1], 2, 2),
+		createSubnetInfo(uintIDs[2], 3, 3),
+	}
+	c.Assert(subnetsInfo, jc.DeepEquals, expectedInfo)
+
+	subnetsInfo, err = env.Subnets(testInstance.Id(), subnetIDs[1:])
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(subnetsInfo, jc.DeepEquals, expectedInfo[1:])
+}
+
+func (suite *environSuite) TestSubnetsWithInstaceIdNoSubnetIdsWhenSpacesAreSupported(c *gc.C) {
+	suite.testMAASObject.TestServer.SetVersionJSON(`{"capabilities": ["network-deployment-ubuntu"]}`)
+	id1 := suite.addSubnet(c, 1, 1, "node1")
+	id2 := suite.addSubnet(c, 2, 2, "node1")
+	suite.addSubnet(c, 3, 2, "")      // not linked to a node
+	suite.addSubnet(c, 4, 2, "node2") // linked to another node
+	testInstance := suite.getInstance("node1")
+	env := suite.makeEnviron()
+
+	subnetsInfo, err := env.Subnets(testInstance.Id(), []network.Id{})
+	c.Assert(err, jc.ErrorIsNil)
+	expectedInfo := []network.SubnetInfo{
+		createSubnetInfo(id1, 1, 1),
+		createSubnetInfo(id2, 2, 2),
+	}
+	c.Assert(subnetsInfo, jc.DeepEquals, expectedInfo)
+
+	subnetsInfo, err = env.Subnets(testInstance.Id(), nil)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(subnetsInfo, jc.DeepEquals, expectedInfo)
+}
+
+func (suite *environSuite) TestSubnetsInvalidInstaceIdAnySubnetIdsWhenSpacesAreSupported(c *gc.C) {
+	suite.testMAASObject.TestServer.SetVersionJSON(`{"capabilities": ["network-deployment-ubuntu"]}`)
+	suite.addSubnet(c, 1, 1, "node1")
+	suite.addSubnet(c, 2, 2, "node2")
+
+	_, err := suite.makeEnviron().Subnets("invalid", []network.Id{"anything"})
+	c.Assert(err, gc.ErrorMatches, `instance "invalid" not found`)
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+}
+func (suite *environSuite) TestSubnetsNoInstanceIdWithSubnetIdsWhenSpacesAreSupported(c *gc.C) {
+	suite.testMAASObject.TestServer.SetVersionJSON(`{"capabilities": ["network-deployment-ubuntu"]}`)
+	id1 := suite.addSubnet(c, 1, 1, "node1")
+	id2 := suite.addSubnet(c, 2, 2, "node2")
+	subnetIDs := []network.Id{
+		network.Id(fmt.Sprintf("%v", id1)),
+		network.Id(fmt.Sprintf("%v", id2)),
+	}
+
+	subnetsInfo, err := suite.makeEnviron().Subnets(instance.UnknownId, subnetIDs)
+	c.Assert(err, jc.ErrorIsNil)
+	expectedInfo := []network.SubnetInfo{
+		createSubnetInfo(id1, 1, 1),
+		createSubnetInfo(id2, 2, 2),
+	}
+	c.Assert(subnetsInfo, jc.DeepEquals, expectedInfo)
+}
+
+func (suite *environSuite) TestSubnetsNoInstanceIdNoSubnetIdsWhenSpacesAreSupported(c *gc.C) {
+	suite.testMAASObject.TestServer.SetVersionJSON(`{"capabilities": ["network-deployment-ubuntu"]}`)
+	id1 := suite.addSubnet(c, 1, 1, "node1")
+	id2 := suite.addSubnet(c, 2, 2, "node2")
+	env := suite.makeEnviron()
+
+	subnetsInfo, err := suite.makeEnviron().Subnets(instance.UnknownId, []network.Id{})
+	c.Assert(err, jc.ErrorIsNil)
+	expectedInfo := []network.SubnetInfo{
+		createSubnetInfo(id1, 1, 1),
+		createSubnetInfo(id2, 2, 2),
+	}
+	c.Assert(subnetsInfo, jc.DeepEquals, expectedInfo)
+
+	subnetsInfo, err = env.Subnets(instance.UnknownId, nil)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(subnetsInfo, jc.DeepEquals, expectedInfo)
+}
+
+func (suite *environSuite) TestSubnetsMissingSubnetWhenSpacesNotSupported(c *gc.C) {
+	suite.testMAASObject.TestServer.SetVersionJSON(`{"capabilities": []}`)
 	testInstance := suite.createSubnets(c, false)
 	_, err := suite.makeEnviron().Subnets(testInstance.Id(), []network.Id{"WLAN", "Missing"})
 	c.Assert(err, gc.ErrorMatches, "failed to find the following subnets: Missing")
 }
 
+func (suite *environSuite) TestSubnetsMissingSubnetWhenSpacesAreSupported(c *gc.C) {
+	suite.testMAASObject.TestServer.SetVersionJSON(`{"capabilities": ["network-deployment-ubuntu"]}`)
+	testInstance := suite.getInstance("node1")
+	suite.addSubnet(c, 1, 1, "node1")
+	_, err := suite.makeEnviron().Subnets(testInstance.Id(), []network.Id{"1", "2"})
+	c.Assert(err, gc.ErrorMatches, "failed to find the following subnets: 2")
+}
+
 func (suite *environSuite) TestSubnetsNoDuplicates(c *gc.C) {
 	testInstance := suite.createSubnets(c, true)
 
-	netInfo, err := suite.makeEnviron().Subnets(testInstance.Id(), []network.Id{"LAN", "Virt", "WLAN"})
+	subnetsInfo, err := suite.makeEnviron().Subnets(testInstance.Id(), []network.Id{"LAN", "Virt", "WLAN"})
 	c.Assert(err, jc.ErrorIsNil)
 
-	expectedInfo := []network.SubnetInfo{
-		{CIDR: "192.168.2.1/24", ProviderId: "LAN", VLANTag: 42, AllocatableIPLow: net.ParseIP("192.168.2.0"), AllocatableIPHigh: net.ParseIP("192.168.2.127")},
-		{CIDR: "192.168.3.1/24", ProviderId: "Virt", VLANTag: 0},
-		{CIDR: "192.168.1.1/24", ProviderId: "WLAN", VLANTag: 0, AllocatableIPLow: net.ParseIP("192.168.1.129"), AllocatableIPHigh: net.ParseIP("192.168.1.255")}}
-	c.Assert(netInfo, jc.DeepEquals, expectedInfo)
+	expectedInfo := []network.SubnetInfo{{
+		CIDR:              "192.168.2.1/24",
+		ProviderId:        "LAN",
+		VLANTag:           42,
+		AllocatableIPLow:  net.ParseIP("192.168.2.0"),
+		AllocatableIPHigh: net.ParseIP("192.168.2.127"),
+	}, {
+		CIDR:              "192.168.3.1/24",
+		ProviderId:        "Virt",
+		AllocatableIPLow:  nil,
+		AllocatableIPHigh: nil,
+		VLANTag:           0,
+	}, {
+		CIDR:              "192.168.1.1/24",
+		ProviderId:        "WLAN",
+		VLANTag:           0,
+		AllocatableIPLow:  net.ParseIP("192.168.1.129"),
+		AllocatableIPHigh: net.ParseIP("192.168.1.255"),
+	}}
+	c.Assert(subnetsInfo, jc.DeepEquals, expectedInfo)
 }
 
-func createSubnet(id uint, interfaceAndSpace uint) gomaasapi.CreateSubnet {
+func createSubnet(ipRange, spaceAndNICID uint) gomaasapi.CreateSubnet {
 	var s gomaasapi.CreateSubnet
 	s.DNSServers = []string{"192.168.1.2"}
-	s.Name = fmt.Sprintf("maas-eth%d", interfaceAndSpace)
-	s.Space = fmt.Sprintf("Space %d", interfaceAndSpace)
-	s.GatewayIP = fmt.Sprintf("192.168.%v.1", id)
-	s.CIDR = fmt.Sprintf("192.168.%v.0/24", id)
-	s.ID = id
+	s.Name = fmt.Sprintf("maas-eth%d", spaceAndNICID)
+	s.Space = fmt.Sprintf("Space %d", spaceAndNICID)
+	s.GatewayIP = fmt.Sprintf("192.168.%v.1", ipRange)
+	s.CIDR = fmt.Sprintf("192.168.%v.0/24", ipRange)
 	return s
 }
 
-func createSubnetInfo(id, space, ipRange int) network.SubnetInfo {
+func createSubnetInfo(subnetID, spaceID, ipRange uint) network.SubnetInfo {
 	return network.SubnetInfo{
 		CIDR:              fmt.Sprintf("192.168.%d.0/24", ipRange),
-		ProviderId:        network.Id(strconv.Itoa(id)),
+		ProviderId:        network.Id(strconv.Itoa(int(subnetID))),
 		AllocatableIPLow:  net.ParseIP(fmt.Sprintf("192.168.%d.139", ipRange)).To4(),
 		AllocatableIPHigh: net.ParseIP(fmt.Sprintf("192.168.%d.255", ipRange)).To4(),
-		SpaceProviderId:   network.Id(fmt.Sprintf("Space %d", space)),
+		SpaceProviderId:   network.Id(fmt.Sprintf("Space %d", spaceID)),
 	}
 }
 
-func (suite *environSuite) addSubnet(c *gc.C, i, j uint, systemID string) {
+func (suite *environSuite) addSubnet(c *gc.C, ipRange, spaceAndNICID uint, systemID string) uint {
 	out := bytes.Buffer{}
-	err := json.NewEncoder(&out).Encode(createSubnet(i, j))
+	err := json.NewEncoder(&out).Encode(createSubnet(ipRange, spaceAndNICID))
 	c.Assert(err, jc.ErrorIsNil)
 	subnet := suite.testMAASObject.TestServer.NewSubnet(&out)
+	c.Assert(err, jc.ErrorIsNil)
 
 	other := gomaasapi.AddressRange{}
-	other.Start = fmt.Sprintf("192.168.%d.139", i)
-	other.End = fmt.Sprintf("192.168.%d.149", i)
+	other.Start = fmt.Sprintf("192.168.%d.139", ipRange)
+	other.End = fmt.Sprintf("192.168.%d.149", ipRange)
 	other.Purpose = []string{"not-the-dynamic-range"}
 	suite.testMAASObject.TestServer.AddFixedAddressRange(subnet.ID, other)
 
 	ar := gomaasapi.AddressRange{}
-	ar.Start = fmt.Sprintf("192.168.%d.10", i)
-	ar.End = fmt.Sprintf("192.168.%d.138", i)
+	ar.Start = fmt.Sprintf("192.168.%d.10", ipRange)
+	ar.End = fmt.Sprintf("192.168.%d.138", ipRange)
 	ar.Purpose = []string{"something", "dynamic-range"}
 	suite.testMAASObject.TestServer.AddFixedAddressRange(subnet.ID, ar)
-	var nni gomaasapi.NodeNetworkInterface
-	nni.Name = subnet.Name
-	nni.Links = append(nni.Links, gomaasapi.NetworkLink{uint(1), "auto", subnet})
-	suite.testMAASObject.TestServer.SetNodeNetworkLink(systemID, nni)
+	if systemID != "" {
+		var nni gomaasapi.NodeNetworkInterface
+		nni.Name = subnet.Name
+		nni.Links = append(nni.Links, gomaasapi.NetworkLink{uint(1), "auto", subnet})
+		suite.testMAASObject.TestServer.SetNodeNetworkLink(systemID, nni)
+	}
+	return subnet.ID
 }
 
 func (suite *environSuite) TestSpaces(c *gc.C) {


### PR DESCRIPTION
This PR introduces 2 main changes:
 * Subnets() can now be called without instance ID and/or empty subnet
   IDs when we detect the new MAAS 1.9 API is available
 * acquireNode API properly transforms spaces constraints and interface
   bindings into "interfaces=" argument. Bindings override spaces
   constraints when both exist, however there's no way yet to pass
   explicit interface bindings.

Added more tests around the various ways Subnets() is being called and
implemented - with older and newer MAAS APIs.

Live tested on MAAS 1.9RC3 to ensure the following steps work:

```
$ juju bootstrap --upload-tools
$ juju space create space-0     # matching existing one in MAAS
$ juju subnet add 10.20.19.0/24 default # zone is required (e.g. "default")
$ juju deploy mysql --constraints spaces=space-0
```

Also, for a more real-life-like demo, I managed to deploy a modified
mediawiki bundle (http://paste.ubuntu.com/13837091/) once the subnets,
VLANs, and spaces were preconfigured like this: http://paste.ubuntu.com/13837104/
and I've run:

```
$ juju space create admin
$ juju space create public
$ juju subnet add 10.50.19.0/24 admin default
$ juju subnet add 10.100.19.0/24 public default
```

Discovered an issue with the bridge script - it's not handling VLANs
correctly, so I needed to use `disable-network-management: true` as a
workaround (otherwise bootstrap failed).

(Review request: http://reviews.vapour.ws/r/3342/)