### PR TITLE
Decrease the log level for uniter.operation executor steps.

### DIFF
--- a/worker/uniter/operation/executor.go
+++ b/worker/uniter/operation/executor.go
@@ -65,7 +65,7 @@ func (x *executor) State() State {
 
 // Run is part of the Executor interface.
 func (x *executor) Run(op Operation) (runErr error) {
-	logger.Infof("running operation %v", op)
+	logger.Debugf("running operation %v", op)
 
 	if op.NeedsGlobalMachineLock() {
 		unlock, err := x.acquireMachineLock(fmt.Sprintf("executing operation: %s", op.String()))
@@ -99,13 +99,13 @@ func (x *executor) Run(op Operation) (runErr error) {
 
 // Skip is part of the Executor interface.
 func (x *executor) Skip(op Operation) error {
-	logger.Infof("skipping operation %v", op)
+	logger.Debugf("skipping operation %v", op)
 	return x.do(op, stepCommit)
 }
 
 func (x *executor) do(op Operation, step executorStep) (err error) {
 	message := step.message(op)
-	logger.Infof(message)
+	logger.Debugf(message)
 	newState, firstErr := step.run(op, *x.state)
 	if newState != nil {
 		writeErr := x.writeState(*newState)


### PR DESCRIPTION
This addresses bug #1524089. We were logging all of the uniter steps at INFO level, but that gets overly chatty when you have lots of units. Generally these are only interesting when debugging something, which makes DEBUG a good level to use.


(Review request: http://reviews.vapour.ws/r/3343/)