### PR TITLE
cmd/jujud/agent: Add uninstaller manifold

### DIFF
--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -39,6 +39,10 @@ type ManifoldsConfig struct {
 	// OpenStateForUpgrade is a function the upgradesteps worker can
 	// use to establish a connection to state.
 	OpenStateForUpgrade func() (*state.State, func(), error)
+
+	// WriteUninstallFile is a function the uninstaller manifold uses
+	// to write the agent uninstall file.
+	WriteUninstallFile func() error
 }
 
 // Manifolds returns a set of co-configured manifolds covering the
@@ -102,6 +106,15 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 			UpgradeStepsGateName: upgradeStepsGateName,
 			OpenStateForUpgrade:  config.OpenStateForUpgrade,
 		}),
+
+		// The uninstaller manifold checks if the machine is dead. If
+		// it is it writes the agent uninstall file and returns
+		// ErrTerminateAgent which causes the agent to remove itself.
+		uninstallerName: uninstallerManifold(uninstallerManifoldConfig{
+			AgentName:          agentName,
+			APICallerName:      apiCallerName,
+			WriteUninstallFile: config.WriteUninstallFile,
+		}),
 	}
 }
 
@@ -114,4 +127,5 @@ const (
 	upgradeCheckGateName = "upgrade-check-gate"
 	upgraderName         = "upgrader"
 	upgradeStepsName     = "upgradesteps"
+	uninstallerName      = "uninstaller"
 )

--- a/cmd/jujud/agent/machine/manifolds_test.go
+++ b/cmd/jujud/agent/machine/manifolds_test.go
@@ -45,6 +45,7 @@ func (s *ManifoldsSuite) TestManifoldNames(c *gc.C) {
 		"upgrade-check-gate",
 		"upgrader",
 		"upgradesteps",
+		"uninstaller",
 	}
 	c.Assert(keys, jc.SameContents, expectedKeys)
 }

--- a/cmd/jujud/agent/machine/uninstaller.go
+++ b/cmd/jujud/agent/machine/uninstaller.go
@@ -1,0 +1,83 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package machine
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/names"
+
+	"github.com/juju/juju/agent"
+	"github.com/juju/juju/api"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/dependency"
+)
+
+// uninstallerManifoldConfig provides the dependencies for the
+// uninstaller manifold.
+type uninstallerManifoldConfig struct {
+	AgentName          string
+	APICallerName      string
+	WriteUninstallFile func() error
+}
+
+// uninstallerManifold defines a simple start function which retrieves
+// some dependencies, checks if the machine is dead and causes the
+// agent to uninstall itself if it is. This doubles up on part of the
+// machiner's functionality but the machiner doesn't run until
+// upgrades are complete, and the upgrade related workers may not be
+// able to make API requests if the machine is dead.
+func uninstallerManifold(config uninstallerManifoldConfig) dependency.Manifold {
+	return dependency.Manifold{
+		Inputs: []string{
+			config.AgentName,
+			config.APICallerName,
+		},
+		Start: func(getResource dependency.GetResourceFunc) (worker.Worker, error) {
+			if config.WriteUninstallFile == nil {
+				return nil, errors.New("WriteUninstallFile not specified")
+			}
+
+			// Get the agent.
+			var agent agent.Agent
+			if err := getResource(config.AgentName, &agent); err != nil {
+				return nil, err
+			}
+
+			// Grab the tag and ensure that it's for a machine.
+			tag, ok := agent.CurrentConfig().Tag().(names.MachineTag)
+			if !ok {
+				return nil, errors.New("agent's tag is not a machine tag")
+			}
+
+			// Get API connection.
+			//
+			// TODO(mjs) - this should really be a base.APICaller to
+			// remove the possibility of the API connection being closed
+			// here.
+			var apiConn api.Connection
+			if err := getResource(config.APICallerName, &apiConn); err != nil {
+				return nil, err
+			}
+
+			// Check if the machine is dead and set the agent to
+			// uninstall if it is.
+			//
+			// TODO(mjs) - ideally this would be using its own agent.
+			machine, err := apiConn.Agent().Entity(tag)
+			if err != nil {
+				return nil, err
+			}
+			if machine.Life() == params.Dead {
+				if err := config.WriteUninstallFile(); err != nil {
+					return nil, errors.Annotate(err, "writing uninstall agent file")
+				}
+				return nil, worker.ErrTerminateAgent
+			}
+
+			// All is well - we're done (no actual worker is actually returned).
+			return nil, dependency.ErrUninstall
+		},
+	}
+}


### PR DESCRIPTION
The uninstaller manifold replaces some functionality which used to be at the top of the legacy API worker which ensures that a machine agent is uninstalled if the machine is dead at agent startup. This change is preparation for moving the API worker to run under the dependency engine.

(Review request: http://reviews.vapour.ws/r/3347/)