### PR TITLE
Handle bug #1524135 by changing the Sort() for debug-log

### DIFF
--- a/apiserver/logsink.go
+++ b/apiserver/logsink.go
@@ -34,8 +34,8 @@ func newLogSinkHandler(h httpContext, logDir string) http.Handler {
 		ctxt: h,
 		fileLogger: &lumberjack.Logger{
 			Filename:   logPath,
-			MaxSize:    500, // MB
-			MaxBackups: 1,
+			MaxSize:    300, // MB
+			MaxBackups: 2,
 		},
 	}
 }

--- a/state/logs.go
+++ b/state/logs.go
@@ -249,7 +249,7 @@ func (t *logTailer) processCollection() error {
 		}
 	}
 
-	iter := query.Sort("e", "t").Iter()
+	iter := query.Sort("t").Iter()
 	doc := new(logDoc)
 	for iter.Next(doc) {
 		select {

--- a/state/logs.go
+++ b/state/logs.go
@@ -249,7 +249,7 @@ func (t *logTailer) processCollection() error {
 		}
 	}
 
-	iter := query.Sort("t", "_id").Iter()
+	iter := query.Sort("e", "t").Iter()
 	doc := new(logDoc)
 	for iter.Next(doc) {
 		select {


### PR DESCRIPTION
I'm working on a test for this, but for now this fixes bug #1524135.

Specifically, Mongo requires you to match indexes exactly, its query planner isn't very smart. (If you sort on (a,b) it won't use the index on (a).) It will be smart about if you have an index on (a,b) and do a find(a=1).sort(b) then it will use the index.

This also updates our log rotation for 'logsink.log' to match the log rotation we use for other logs (instead of 500MB with 1 backup, do 300MB with 2 backups.)

(Review request: http://reviews.vapour.ws/r/3348/)