### PR TITLE
Make tests pass on i386

### DIFF
--- a/featuretests/upgrade_test.go
+++ b/featuretests/upgrade_test.go
@@ -65,7 +65,7 @@ func (s *upgradeSuite) SetUpTest(c *gc.C) {
 	s.PatchValue(&upgradesteps.UpgradeStartTimeoutSecondary, time.Duration(time.Millisecond*60))
 
 	// Ensure we don't fail disk space check.
-	s.PatchValue(&upgrades.MinDiskSpaceGib, 0)
+	s.PatchValue(&upgrades.MinDiskSpaceGib, uint64(0))
 
 	// TODO(mjs) - the following should maybe be part of AgentSuite.SetUpTest()
 	s.PatchValue(&cmdutil.EnsureMongoServer, func(mongo.EnsureServerParams) error {

--- a/upgrades/preupgradesteps.go
+++ b/upgrades/preupgradesteps.go
@@ -22,7 +22,7 @@ func PreUpgradeSteps(st *state.State, agentConf agent.Config, isMaster bool) err
 }
 
 // We'll be conservative and require at least 2GiB of disk space for an upgrade.
-var MinDiskSpaceGib = 2
+var MinDiskSpaceGib = uint64(2)
 
 func checkDiskSpace(dir string) error {
 	usage := du.NewDiskUsage(dir)

--- a/upgrades/preupgradesteps_test.go
+++ b/upgrades/preupgradesteps_test.go
@@ -19,7 +19,7 @@ var _ = gc.Suite(&preupgradechecksSuite{})
 
 func (s *preupgradechecksSuite) TestCheckFreeDiskSpace(c *gc.C) {
 	// Expect an impossibly large amount of free disk.
-	s.PatchValue(&upgrades.MinDiskSpaceGib, 1000*humanize.EiByte/humanize.GiByte)
+	s.PatchValue(&upgrades.MinDiskSpaceGib, uint64(humanize.EiByte/humanize.GiByte))
 	err := upgrades.PreUpgradeSteps(nil, &mockAgentConfig{dataDir: "/"}, false)
 	c.Assert(err, gc.ErrorMatches, "not enough free disk space for upgrade: .*")
 }


### PR DESCRIPTION
Use uint64 to make i386 happy.

(Review request: http://reviews.vapour.ws/r/3351/)