### PR TITLE
Reject invalid tools metadata, remove invalid metadata on upgrade

### DIFF
--- a/apiserver/tools.go
+++ b/apiserver/tools.go
@@ -245,7 +245,10 @@ func (h *toolsUploadHandler) processPost(r *http.Request, st *state.State) (*too
 	}
 
 	// We'll clone the tools for each additional series specified.
-	cloneSeries := strings.Split(query.Get("series"), ",")
+	var cloneSeries []string
+	if seriesParam := query.Get("series"); seriesParam != "" {
+		cloneSeries = strings.Split(seriesParam, ",")
+	}
 	logger.Debugf("request to upload tools: %s", toolsVersion)
 	logger.Debugf("additional series: %s", cloneSeries)
 

--- a/apiserver/tools_test.go
+++ b/apiserver/tools_test.go
@@ -140,10 +140,12 @@ func (s *toolsSuite) TestUpload(c *gc.C) {
 	s.assertUploadResponse(c, resp, expectedTools[0])
 
 	// Check the contents.
-	_, uploadedData := s.getToolsFromStorage(c, s.State, vers)
+	metadata, uploadedData := s.getToolsFromStorage(c, s.State, vers)
 	expectedData, err := ioutil.ReadFile(toolPath)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(uploadedData, gc.DeepEquals, expectedData)
+	allMetadata := s.getToolsMetadataFromStorage(c, s.State)
+	c.Assert(allMetadata, jc.DeepEquals, []toolstorage.Metadata{metadata})
 }
 
 func (s *toolsSuite) TestBlockUpload(c *gc.C) {
@@ -349,6 +351,15 @@ func (s *toolsSuite) getToolsFromStorage(c *gc.C, st *state.State, vers version.
 	r.Close()
 	c.Assert(err, jc.ErrorIsNil)
 	return metadata, data
+}
+
+func (s *toolsSuite) getToolsMetadataFromStorage(c *gc.C, st *state.State) []toolstorage.Metadata {
+	storage, err := st.ToolsStorage()
+	c.Assert(err, jc.ErrorIsNil)
+	defer storage.Close()
+	metadata, err := storage.AllMetadata()
+	c.Assert(err, jc.ErrorIsNil)
+	return metadata
 }
 
 func (s *toolsSuite) assertToolsNotStored(c *gc.C, vers version.Binary) {

--- a/state/tools_test.go
+++ b/state/tools_test.go
@@ -83,7 +83,9 @@ func (s *ToolsSuite) TestStorage(c *gc.C) {
 		c.Assert(err, jc.ErrorIsNil)
 	}()
 
-	err = storage.AddTools(strings.NewReader(""), toolstorage.Metadata{})
+	err = storage.AddTools(strings.NewReader(""), toolstorage.Metadata{
+		Version: version.MustParseBinary("1.2.3-trusty-amd64"),
+	})
 	c.Assert(err, jc.ErrorIsNil)
 
 	collectionNames, err = session.DB("juju").CollectionNames()

--- a/state/toolstorage/interface.go
+++ b/state/toolstorage/interface.go
@@ -35,6 +35,16 @@ type Storage interface {
 	// Metadata returns the Metadata for the specified version
 	// if it exists, else an error satisfying errors.IsNotFound.
 	Metadata(v version.Binary) (Metadata, error)
+
+	// RemoveInvalid will remove all tools with invalid metadata. This
+	// exists because we had a bug that would allow tools with invalid
+	// metadata to be entered, which would render "AllMetadata" unusable.
+	//
+	// NOTE(axw) this should not be carried over to 2.0. The upgrade step
+	// will be run when upgrading to the first version of the 1.25 series
+	// that is allowed to upgrade to 2.0; after that the issue should not
+	// occur.
+	RemoveInvalid() error
 }
 
 // StorageCloser extends the Storage interface with a Close method.

--- a/state/toolstorage/tools_test.go
+++ b/state/toolstorage/tools_test.go
@@ -355,9 +355,7 @@ func (s *ToolsSuite) TestRemoveInvalid(c *gc.C) {
 	err := s.managedStorage.PutForEnvironment("my-uuid", "path1", strings.NewReader("blah"), 4)
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.addMetadataDoc(c, versionWithoutArch, 4, "hash(abc)", "path2")
-	err = s.managedStorage.PutForEnvironment("my-uuid", "path2", strings.NewReader("blah"), 4)
-	c.Assert(err, jc.ErrorIsNil)
+	s.addMetadataDoc(c, versionWithoutArch, 4, "hash(abc)", "non-existent-path")
 
 	s.addMetadataDoc(c, goodVersion, 4, "hash(abc)", "path3")
 	err = s.managedStorage.PutForEnvironment("my-uuid", "path3", strings.NewReader("blah"), 4)
@@ -372,6 +370,12 @@ func (s *ToolsSuite) TestRemoveInvalid(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(metadata, gc.HasLen, 1)
 	c.Assert(metadata[0].Version, gc.Equals, goodVersion)
+
+	// Only path3 should remain in managed storage.
+	err = s.managedStorage.RemoveForEnvironment("my-uuid", "path1")
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+	err = s.managedStorage.RemoveForEnvironment("my-uuid", "path3")
+	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *ToolsSuite) addMetadataDoc(c *gc.C, v version.Binary, size int64, hash, path string) {

--- a/state/toolstorage/tools_test.go
+++ b/state/toolstorage/tools_test.go
@@ -325,6 +325,24 @@ func (s *ToolsSuite) TestAddToolsExcessiveContention(c *gc.C) {
 	s.assertTools(c, metadata[3], "3")
 }
 
+func (s *ToolsSuite) TestAddToolsInvalidVersion(c *gc.C) {
+	number := version.MustParse("1.2.3")
+	versionWithoutSeries := version.Binary{Number: number, Arch: "amd64"}
+	versionWithoutArch := version.Binary{Number: number, Series: "trusty"}
+
+	err := s.storage.AddTools(strings.NewReader("xyzzzz"), toolstorage.Metadata{
+		Version: versionWithoutArch,
+	})
+	c.Assert(err, gc.ErrorMatches,
+		`invalid tools version: invalid binary version "1.2.3-trusty-"`)
+
+	err = s.storage.AddTools(strings.NewReader("xyzzzz"), toolstorage.Metadata{
+		Version: versionWithoutSeries,
+	})
+	c.Assert(err, gc.ErrorMatches,
+		`invalid tools version: invalid binary version "1.2.3--amd64"`)
+}
+
 func (s *ToolsSuite) addMetadataDoc(c *gc.C, v version.Binary, size int64, hash, path string) {
 	doc := struct {
 		Id      string         `bson:"_id"`

--- a/upgrades/export_test.go
+++ b/upgrades/export_test.go
@@ -52,9 +52,10 @@ var (
 	CopyFile         = copyFile
 
 	// 125 upgrade functions
-	AddInstanceTags = addInstanceTags
-	RemoveJujudpass = removeJujudpass
-	AddJujuRegKey   = addJujuRegKey
+	AddInstanceTags   = addInstanceTags
+	RemoveJujudpass   = removeJujudpass
+	AddJujuRegKey     = addJujuRegKey
+	CleanToolsStorage = cleanToolsStorage
 )
 
 type EnvironConfigUpdater environConfigUpdater

--- a/upgrades/operations.go
+++ b/upgrades/operations.go
@@ -43,6 +43,10 @@ var stateUpgradeOperations = func() []Operation {
 			version.MustParse("1.25.0"),
 			stateStepsFor125(),
 		},
+		upgradeToVersion{
+			version.MustParse("1.25.2"),
+			stateStepsFor1252(),
+		},
 	}
 	return steps
 }

--- a/upgrades/steps125.go
+++ b/upgrades/steps125.go
@@ -115,6 +115,18 @@ func stateStepsFor125() []Step {
 	}
 }
 
+// stateStepsFor1252 returns upgrade steps for Juju 1.25.2 that manipulate state directly.
+func stateStepsFor1252() []Step {
+	return []Step{
+		&upgradeStep{
+			description: "remove invalid tools metadata from state",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return cleanToolsStorage(context.State())
+			}},
+	}
+}
+
 // stepsFor125 returns upgrade steps for Juju 1.25 that only need the API.
 func stepsFor125() []Step {
 	return []Step{

--- a/upgrades/steps125_test.go
+++ b/upgrades/steps125_test.go
@@ -42,6 +42,13 @@ func (s *steps125Suite) TestStateStepsFor125(c *gc.C) {
 	assertStateSteps(c, version.MustParse("1.25.0"), expected)
 }
 
+func (s *steps125Suite) TestStateStepsFor1252(c *gc.C) {
+	expected := []string{
+		"remove invalid tools metadata from state",
+	}
+	assertStateSteps(c, version.MustParse("1.25.2"), expected)
+}
+
 func (s *steps125Suite) TestStepsFor125(c *gc.C) {
 	expected := []string{
 		"remove Jujud.pass file on windows",

--- a/upgrades/toolstorage.go
+++ b/upgrades/toolstorage.go
@@ -130,6 +130,17 @@ func isErrInvalidMetadata(err error) bool {
 	return ok
 }
 
+// cleanToolsStorage removes invalid tools from environment storage.
+func cleanToolsStorage(st *state.State) error {
+	logger.Debugf("removing invalid tools from environment storage")
+	tstor, err := stateToolsStorage(st)
+	if err != nil {
+		return errors.Annotate(err, "cannot get tools storage")
+	}
+	defer tstor.Close()
+	return tstor.RemoveInvalid()
+}
+
 func fetchToolsArchive(stor storage.StorageReader, toolsDir string, agentTools *tools.Tools) ([]byte, error) {
 	r, err := stor.Get(envtools.StorageName(agentTools.Version, toolsDir))
 	if err != nil {

--- a/upgrades/upgrade_test.go
+++ b/upgrades/upgrade_test.go
@@ -672,7 +672,7 @@ func (s *upgradeSuite) TestUpgradeOperationsOrdered(c *gc.C) {
 func (s *upgradeSuite) TestStateUpgradeOperationsVersions(c *gc.C) {
 	versions := extractUpgradeVersions(c, (*upgrades.StateUpgradeOperations)())
 	c.Assert(versions, gc.DeepEquals, []string{
-		"1.18.0", "1.21.0", "1.22.0", "1.23.0", "1.24.0", "1.24.4", "1.25.0",
+		"1.18.0", "1.21.0", "1.22.0", "1.23.0", "1.24.0", "1.24.4", "1.25.0", "1.25.2",
 	})
 }
 


### PR DESCRIPTION
There were some holes that allowed invalid tools metadata to be entered into the tools storage in Mongo. We now reject any attempt to add tools to Mongo with missing series or arch, and we add an upgrade step to remove any existing invalid metadata from Mongo on upgrade to Juju 1.25.2.

(Review request: http://reviews.vapour.ws/r/3356/)