### PR TITLE
cmd/jujud/agent: update distro-info before upgrade

### DIFF
--- a/cmd/jujud/agent/upgrade.go
+++ b/cmd/jujud/agent/upgrade.go
@@ -7,6 +7,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/names"
 	"github.com/juju/utils"
+	"github.com/juju/utils/packaging/manager"
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/api"
@@ -251,6 +252,13 @@ func (c *upgradeWorkerContext) prepareForUpgrade() (*state.UpgradeInfo, error) {
 		return nil, errors.Trace(err)
 	}
 
+	// Update distro info in case the new version of Juju is aware of new
+	// supported series.
+	logger.Infof("updating distro-info")
+	if err := c.updateDistroInfo(); err != nil {
+		return nil, errors.Trace(err)
+	}
+
 	// State servers need to wait for other state servers to be ready
 	// to run the upgrade steps.
 	logger.Infof("waiting for other state servers to be ready for upgrade")
@@ -384,6 +392,17 @@ func (c *upgradeWorkerContext) finaliseUpgrade(info *state.UpgradeInfo) error {
 	}
 
 	return nil
+}
+
+func (c *upgradeWorkerContext) updateDistroInfo() error {
+	pm := manager.NewAptPackageManager()
+	if err := pm.Update(); err != nil {
+		return errors.Annotate(err, "updating package list")
+	}
+	if err := pm.Install("distro-info"); err != nil {
+		return errors.Annotate(err, "updating distro-info package")
+	}
+	return version.UpdateSeriesVersions()
 }
 
 func getUpgradeStartTimeout(isMaster bool) time.Duration {

--- a/cmd/jujud/agent/upgrade.go
+++ b/cmd/jujud/agent/upgrade.go
@@ -253,10 +253,11 @@ func (c *upgradeWorkerContext) prepareForUpgrade() (*state.UpgradeInfo, error) {
 	}
 
 	// Update distro info in case the new version of Juju is aware of new
-	// supported series.
+	// supported series. We'll keep going if this fails, and the user can
+	// manually update it if they need to.
 	logger.Infof("updating distro-info")
 	if err := c.updateDistroInfo(); err != nil {
-		return nil, errors.Trace(err)
+		logger.Warningf("failed to update distro-info")
 	}
 
 	// State servers need to wait for other state servers to be ready

--- a/version/osversion.go
+++ b/version/osversion.go
@@ -80,7 +80,7 @@ func readSeries() (string, error) {
 	if err != nil {
 		return "unknown", err
 	}
-	updateSeriesVersions()
+	updateSeriesVersionsOnce()
 	switch values["ID"] {
 	case strings.ToLower(Ubuntu.String()):
 		return getValue(ubuntuSeries, values["VERSION_ID"])

--- a/version/supportedseries.go
+++ b/version/supportedseries.go
@@ -192,7 +192,7 @@ func SeriesVersion(series string) (string, error) {
 	if vers, ok := seriesVersions[series]; ok {
 		return vers, nil
 	}
-	updateSeriesVersions()
+	updateSeriesVersionsOnce()
 	if vers, ok := seriesVersions[series]; ok {
 		return vers, nil
 	}
@@ -204,7 +204,7 @@ func SeriesVersion(series string) (string, error) {
 func SupportedSeries() []string {
 	seriesVersionsMutex.Lock()
 	defer seriesVersionsMutex.Unlock()
-	updateSeriesVersions()
+	updateSeriesVersionsOnce()
 	var series []string
 	for s := range seriesVersions {
 		series = append(series, s)
@@ -226,7 +226,15 @@ func OSSupportedSeries(os OSType) []string {
 	return osSeries
 }
 
-func updateSeriesVersions() {
+// UpdateSeriesVersions forces an update of the series versions by querying
+// distro-info if possible.
+func UpdateSeriesVersions() error {
+	seriesVersionsMutex.Lock()
+	defer seriesVersionsMutex.Unlock()
+	return updateDistroInfo()
+}
+
+func updateSeriesVersionsOnce() {
 	if !updatedseriesVersions {
 		err := updateDistroInfo()
 		if err != nil {


### PR DESCRIPTION
When upgrading a controller, run "apt-get update"
and then upgrade distro-info. This ensures that
the controller is aware of any new series that
may be supported by the upgraded version of Juju.

(Review request: http://reviews.vapour.ws/r/3358/)