### PR TITLE
Added UUID to GCE disks

### DIFF
--- a/provider/gce/disks.go
+++ b/provider/gce/disks.go
@@ -199,6 +199,7 @@ func (v *volumeSource) createOneVolume(p storage.VolumeParams, instances instanc
 		SizeHintGB:         mibToGib(p.Size),
 		Name:               volumeName,
 		PersistentDiskType: persistentType,
+		Description:        v.envUUID,
 	}
 
 	gceDisks, err := v.gce.CreateDisks(zone, []google.DiskSpec{disk})
@@ -282,6 +283,7 @@ func (v *volumeSource) ListVolumes() ([]string, error) {
 	}
 	var volumes []string
 	for _, zone := range azs {
+		// FIXME(perrito666) Check Description for UUID
 		disks, err := v.gce.Disks(zone.Name())
 		if err != nil {
 			// maybe use available and status also.
@@ -289,6 +291,9 @@ func (v *volumeSource) ListVolumes() ([]string, error) {
 			continue
 		}
 		for _, disk := range disks {
+			if disk.Description != v.envUUID && disk.Description != "" {
+				continue
+			}
 			volumes = append(volumes, disk.Name)
 		}
 	}

--- a/provider/gce/environ_broker_test.go
+++ b/provider/gce/environ_broker_test.go
@@ -174,7 +174,7 @@ func (s *environBrokerSuite) TestGetMetadata(c *gc.C) {
 }
 
 func (s *environBrokerSuite) TestGetDisks(c *gc.C) {
-	diskSpecs := gce.GetDisks(s.spec, s.StartInstArgs.Constraints, "trusty")
+	diskSpecs := gce.GetDisks(s.spec, s.StartInstArgs.Constraints, "trusty", "87d18dd4-49e0-43b1-b681-b3d81e66a62e")
 
 	c.Assert(diskSpecs, gc.HasLen, 1)
 

--- a/provider/gce/google/disk.go
+++ b/provider/gce/google/disk.go
@@ -89,6 +89,9 @@ type DiskSpec struct {
 	// characters must be a dash, lowercase letter, or digit, except the
 	// last character, which cannot be a dash.
 	Name string
+	// Description holds a description of the disk, it currently holds
+	// envUUID.
+	Description string
 }
 
 // TooSmall checks the spec's size hint and indicates whether or not
@@ -122,7 +125,7 @@ func (ds *DiskSpec) newAttached() *compute.AttachedDisk {
 	if ds.Readonly {
 		mode = ModeRO
 	}
-
+	// FIXME: Add description uuid here too.
 	disk := compute.AttachedDisk{
 		Type:       diskType,
 		Boot:       ds.Boot,
@@ -155,6 +158,7 @@ func (ds *DiskSpec) newDetached() (*compute.Disk, error) {
 		SizeGb:      int64(ds.SizeGB()),
 		SourceImage: ds.ImageURL,
 		Type:        string(ds.PersistentDiskType),
+		Description: ds.Description,
 	}, nil
 }
 
@@ -177,6 +181,8 @@ type Disk struct {
 	Id uint64
 	// Name is a unique identifier string for each disk.
 	Name string
+	// Description holds the description field for a disk, we store env UUID here.
+	Description string
 	// Size is the size in mbit.
 	Size uint64
 	// Type is one of the available disk types supported by
@@ -190,12 +196,13 @@ type Disk struct {
 
 func NewDisk(cd *compute.Disk) *Disk {
 	d := &Disk{
-		Id:     cd.Id,
-		Name:   cd.Name,
-		Size:   gibToMib(cd.SizeGb),
-		Type:   DiskType(cd.Type),
-		Zone:   cd.Zone,
-		Status: DiskStatus(cd.Status),
+		Id:          cd.Id,
+		Name:        cd.Name,
+		Description: cd.Description,
+		Size:        gibToMib(cd.SizeGb),
+		Type:        DiskType(cd.Type),
+		Zone:        cd.Zone,
+		Status:      DiskStatus(cd.Status),
 	}
 	return d
 }


### PR DESCRIPTION
GCE sports no decent way to write extra metadata to the disks so we write the UUID to description field which is unused.

(Review request: http://reviews.vapour.ws/r/3360/)