### PR TITLE
lp1524914: Fix envManagerSuite to work with 2.0

### DIFF
--- a/apiserver/environmentmanager/environmentmanager_test.go
+++ b/apiserver/environmentmanager/environmentmanager_test.go
@@ -277,6 +277,7 @@ func (s *envManagerSuite) TestCreateEnvironmentSameAgentVersion(c *gc.C) {
 }
 
 func (s *envManagerSuite) TestCreateEnvironmentBadAgentVersion(c *gc.C) {
+	s.PatchValue(&version.Current, coretesting.FakeVersionNumber)
 	admin := s.AdminUserTag(c)
 	s.setAPIUser(c, admin)
 


### PR DESCRIPTION
Fixed test: envManagerSuite.TestCreateEnvironmentBadAgentVersion

(Review request: http://reviews.vapour.ws/r/3367/)