### PR TITLE
cmd/jujud/agent: Added serving-info-setter manifold

### DIFF
--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -690,30 +690,12 @@ func (a *MachineAgent) APIWorker() (_ worker.Worker, err error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	for _, job := range machine.Jobs() {
-		if job.NeedsState() {
-			info, err := st.Agent().StateServingInfo()
-			if err != nil {
-				return nil, fmt.Errorf("cannot get state serving info: %v", err)
-			}
-			err = a.ChangeConfig(func(config agent.ConfigSetter) error {
-				config.SetStateServingInfo(info)
-				return nil
-			})
-			if err != nil {
-				return nil, err
-			}
-			break
-		}
-	}
-
-	runner := newConnRunner(st)
 
 	// All other workers must wait for the upgrade steps to complete before starting.
+	runner := newConnRunner(st)
 	a.startWorkerAfterUpgrade(runner, "api-post-upgrade", func() (worker.Worker, error) {
 		return a.postUpgradeAPIWorker(st, a.CurrentConfig(), machine.Jobs())
 	})
-
 	return cmdutil.NewCloseWorker(logger, runner, st), nil // Note: a worker.Runner is itself a worker.Worker.
 }
 

--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -115,17 +115,26 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 			APICallerName:      apiCallerName,
 			WriteUninstallFile: config.WriteUninstallFile,
 		}),
+
+		// The serving-info-setter manifold sets grabs the state
+		// serving info from the API connection and writes it to the
+		// agent config.
+		servingInfoSetterName: servingInfoSetterManifold(servingInfoSetterConfig{
+			AgentName:     agentName,
+			APICallerName: apiCallerName,
+		}),
 	}
 }
 
 const (
-	agentName            = "agent"
-	terminationName      = "termination"
-	apiCallerName        = "api-caller"
-	apiInfoGateName      = "api-info-gate"
-	upgradeStepsGateName = "upgrade-steps-gate"
-	upgradeCheckGateName = "upgrade-check-gate"
-	upgraderName         = "upgrader"
-	upgradeStepsName     = "upgradesteps"
-	uninstallerName      = "uninstaller"
+	agentName             = "agent"
+	terminationName       = "termination"
+	apiCallerName         = "api-caller"
+	apiInfoGateName       = "api-info-gate"
+	upgradeStepsGateName  = "upgrade-steps-gate"
+	upgradeCheckGateName  = "upgrade-check-gate"
+	upgraderName          = "upgrader"
+	upgradeStepsName      = "upgradesteps"
+	uninstallerName       = "uninstaller"
+	servingInfoSetterName = "serving-info-setter"
 )

--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -119,7 +119,7 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 		// The serving-info-setter manifold sets grabs the state
 		// serving info from the API connection and writes it to the
 		// agent config.
-		servingInfoSetterName: servingInfoSetterManifold(servingInfoSetterConfig{
+		servingInfoSetterName: ServingInfoSetterManifold(ServingInfoSetterConfig{
 			AgentName:     agentName,
 			APICallerName: apiCallerName,
 		}),

--- a/cmd/jujud/agent/machine/manifolds_test.go
+++ b/cmd/jujud/agent/machine/manifolds_test.go
@@ -46,6 +46,7 @@ func (s *ManifoldsSuite) TestManifoldNames(c *gc.C) {
 		"upgrader",
 		"upgradesteps",
 		"uninstaller",
+		"serving-info-setter",
 	}
 	c.Assert(keys, jc.SameContents, expectedKeys)
 }

--- a/cmd/jujud/agent/machine/servinginfo_setter_test.go
+++ b/cmd/jujud/agent/machine/servinginfo_setter_test.go
@@ -1,0 +1,198 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package machine_test
+
+import (
+	"github.com/juju/names"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	coreagent "github.com/juju/juju/agent"
+	basetesting "github.com/juju/juju/api/base/testing"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/jujud/agent/machine"
+	"github.com/juju/juju/state/multiwatcher"
+	"github.com/juju/juju/testing"
+	"github.com/juju/juju/worker/dependency"
+	dt "github.com/juju/juju/worker/dependency/testing"
+)
+
+type ServingInfoSetterSuite struct {
+	testing.BaseSuite
+	manifold dependency.Manifold
+}
+
+var _ = gc.Suite(&ServingInfoSetterSuite{})
+
+func (s *ServingInfoSetterSuite) SetUpTest(c *gc.C) {
+	s.manifold = machine.ServingInfoSetterManifold(machine.ServingInfoSetterConfig{
+		AgentName:     "agent",
+		APICallerName: "api-caller",
+	})
+}
+
+func (s *ServingInfoSetterSuite) TestInputs(c *gc.C) {
+	c.Assert(s.manifold.Inputs, jc.SameContents, []string{
+		"agent",
+		"api-caller",
+	})
+}
+
+func (s *ServingInfoSetterSuite) TestStartAgentMissing(c *gc.C) {
+	getResource := dt.StubGetResource(dt.StubResources{
+		"agent": dt.StubResource{Error: dependency.ErrMissing},
+	})
+	worker, err := s.manifold.Start(getResource)
+	c.Check(worker, gc.IsNil)
+	c.Check(err, gc.Equals, dependency.ErrMissing)
+}
+
+func (s *ServingInfoSetterSuite) TestStartApiCallerMissing(c *gc.C) {
+	getResource := dt.StubGetResource(dt.StubResources{
+		"agent":      dt.StubResource{Output: &mockAgent{}},
+		"api-caller": dt.StubResource{Error: dependency.ErrMissing},
+	})
+	worker, err := s.manifold.Start(getResource)
+	c.Check(worker, gc.IsNil)
+	c.Check(err, gc.Equals, dependency.ErrMissing)
+}
+
+func (s *ServingInfoSetterSuite) TestNotMachine(c *gc.C) {
+	a := &mockAgent{
+		conf: mockConfig{tag: names.NewUnitTag("foo/0")},
+	}
+	getResource := dt.StubGetResource(dt.StubResources{
+		"agent": dt.StubResource{Output: a},
+	})
+	worker, err := s.manifold.Start(getResource)
+	c.Check(worker, gc.IsNil)
+	c.Check(err, gc.ErrorMatches, "agent's tag is not a machine tag")
+}
+
+func (s *ServingInfoSetterSuite) TestEntityLookupFailure(c *gc.C) {
+	// Set up a fake Agent and APICaller
+	a := &mockAgent{}
+	apiCaller := basetesting.APICallerFunc(
+		func(objType string, version int, id, request string, args, response interface{}) error {
+			c.Assert(objType, gc.Equals, "Agent")
+			switch request {
+			case "GetEntities":
+				c.Assert(args.(params.Entities).Entities, gc.HasLen, 1)
+				result := response.(*params.AgentGetEntitiesResults)
+				result.Entities = []params.AgentGetEntitiesResult{{
+					Error: &params.Error{Message: "boom"},
+				}}
+			default:
+				c.Fatalf("not sure how to handle: %q", request)
+			}
+			return nil
+		},
+	)
+	// Call the manifold's start func with a fake resource getter that
+	// returns the fake Agent and APICaller
+	w, err := s.manifold.Start(dt.StubGetResource(dt.StubResources{
+		"agent":      dt.StubResource{Output: a},
+		"api-caller": dt.StubResource{Output: apiCaller},
+	}))
+	c.Assert(w, gc.IsNil)
+	c.Assert(err, gc.ErrorMatches, "boom")
+}
+
+func (s *ServingInfoSetterSuite) TestSetsStateServingInfo(c *gc.C) {
+	const mockAPIPort = 1234
+
+	a := &mockAgent{}
+	apiCaller := basetesting.APICallerFunc(
+		func(objType string, version int, id, request string, args, response interface{}) error {
+			c.Assert(objType, gc.Equals, "Agent")
+			switch request {
+			case "GetEntities":
+				c.Assert(args.(params.Entities).Entities, gc.HasLen, 1)
+				result := response.(*params.AgentGetEntitiesResults)
+				result.Entities = []params.AgentGetEntitiesResult{{
+					Jobs: []multiwatcher.MachineJob{multiwatcher.JobManageEnviron},
+				}}
+			case "StateServingInfo":
+				result := response.(*params.StateServingInfo)
+				*result = params.StateServingInfo{
+					APIPort: mockAPIPort,
+				}
+			default:
+				c.Fatalf("not sure how to handle: %q", request)
+			}
+			return nil
+		},
+	)
+	w, err := s.manifold.Start(dt.StubGetResource(dt.StubResources{
+		"agent":      dt.StubResource{Output: a},
+		"api-caller": dt.StubResource{Output: apiCaller},
+	}))
+	c.Assert(w, gc.IsNil)
+	c.Assert(err, gc.Equals, dependency.ErrUninstall)
+
+	// Verify that the state serving info was actually set.
+	c.Assert(a.conf.ssiSet, jc.IsTrue)
+	c.Assert(a.conf.ssi.APIPort, gc.Equals, mockAPIPort)
+}
+
+func (s *ServingInfoSetterSuite) TestNotStateServer(c *gc.C) {
+	a := &mockAgent{}
+	apiCaller := basetesting.APICallerFunc(
+		func(objType string, version int, id, request string, args, response interface{}) error {
+			c.Assert(objType, gc.Equals, "Agent")
+			switch request {
+			case "GetEntities":
+				c.Assert(args.(params.Entities).Entities, gc.HasLen, 1)
+				result := response.(*params.AgentGetEntitiesResults)
+				result.Entities = []params.AgentGetEntitiesResult{{
+					Jobs: []multiwatcher.MachineJob{multiwatcher.JobHostUnits},
+				}}
+			default:
+				c.Fatalf("not sure how to handle: %q", request)
+			}
+			return nil
+		},
+	)
+	w, err := s.manifold.Start(dt.StubGetResource(dt.StubResources{
+		"agent":      dt.StubResource{Output: a},
+		"api-caller": dt.StubResource{Output: apiCaller},
+	}))
+	c.Assert(w, gc.IsNil)
+	c.Assert(err, gc.Equals, dependency.ErrUninstall)
+
+	// State serving info shouldn't have been set for JobHostUnits
+	c.Assert(a.conf.ssiSet, jc.IsFalse)
+}
+
+type mockAgent struct {
+	coreagent.Agent
+	conf mockConfig
+}
+
+func (ma *mockAgent) CurrentConfig() coreagent.Config {
+	return &ma.conf
+}
+
+func (ma *mockAgent) ChangeConfig(f coreagent.ConfigMutator) error {
+	return f(&ma.conf)
+}
+
+type mockConfig struct {
+	coreagent.ConfigSetter
+	tag    names.Tag
+	ssiSet bool
+	ssi    params.StateServingInfo
+}
+
+func (mc *mockConfig) Tag() names.Tag {
+	if mc.tag == nil {
+		return names.NewMachineTag("99")
+	}
+	return mc.tag
+}
+
+func (mc *mockConfig) SetStateServingInfo(info params.StateServingInfo) {
+	mc.ssiSet = true
+	mc.ssi = info
+}


### PR DESCRIPTION
The serving-info-setter manifold sets grabs the state serving info from the API connection and writes it to the agent config.

(Review request: http://reviews.vapour.ws/r/3368/)