### PR TITLE
Upgrade automatically chooses latest compatible released version

### DIFF
--- a/cmd/juju/commands/upgradejuju.go
+++ b/cmd/juju/commands/upgradejuju.go
@@ -42,10 +42,14 @@ The upgrade-juju command upgrades a running environment by setting a version
 number for all juju agents to run. By default, it chooses the most recent
 supported version compatible with the command-line tools version.
 
-A development version is defined to be any version with an odd minor
-version or a nonzero build component (for example version 2.1.1, 3.3.0
-and 2.0.0.1 are development versions; 2.0.3 and 3.4.1 are not). A
-development version may be chosen in two cases:
+A development version is defined to be any version with a tag like
+alpha or beta, or a nonzero build component. For exmple:
+Development versions:
+ - 1.24-alpha1
+ - 1.24-alpha1.2
+ - 1.24.0.1
+
+A development version may be chosen in two cases:
 
  - when the current agent version is a development one and there is
    a more recent version available with the same major.minor numbers;
@@ -59,13 +63,10 @@ Currently the tools will be uploaded as if they had the version of the current
 juju tool, unless specified otherwise by the --version flag.
 
 When run without arguments. upgrade-juju will try to upgrade to the
-following versions, in order of preference, depending on the current
-value of the environment's agent-version setting:
+highest available minor.patch.build version of the major version
+matching the Juju client used to perform the upgrade.
 
- - The highest patch.build version of the *next* stable major.minor version.
- - The highest patch.build version of the *current* major.minor version.
-
-Both of these depend on tools availability, which some situations (no
+This depends on tools availability, which some situations (no
 outgoing internet access) and provider types (such as maas) require that
 you manage yourself; see the documentation for "sync-tools".
 
@@ -214,9 +215,9 @@ func (c *UpgradeJujuCommand) Run(ctx *cmd.Context) (err error) {
 		return err
 	}
 	// TODO(fwereade): this list may be incomplete, pending envtools.Upload change.
-	ctx.Infof("available tools:\n%s", formatTools(context.tools))
-	ctx.Infof("best version:\n    %s", context.chosen)
+	logger.Debugf("available tools:\n%s", formatTools(context.tools))
 	if c.DryRun {
+		ctx.Infof("best available tools version:\n    %s", context.chosen)
 		ctx.Infof("upgrade to this version by running\n    juju upgrade-juju --version=\"%s\"\n", context.chosen)
 	} else {
 		if c.ResetPrevious {
@@ -242,7 +243,7 @@ func (c *UpgradeJujuCommand) Run(ctx *cmd.Context) (err error) {
 				return block.ProcessBlockedError(err, block.BlockChange)
 			}
 		}
-		logger.Infof("started upgrade to %s", context.chosen)
+		ctx.Infof("started upgrade of Juju environment to version %s", context.chosen)
 	}
 	return nil
 }
@@ -373,48 +374,22 @@ func (context *upgradeContext) uploadTools() (err error) {
 // If validate returns no error, the environment agent-version can be set to
 // the value of the chosen field.
 func (context *upgradeContext) validate() (err error) {
-	if context.chosen == version.Zero {
-		// No explicitly specified version, so find the version to which we
-		// need to upgrade. If the CLI and agent major versions match, we find
-		// next available stable release to upgrade to by incrementing the
-		// minor version, starting from the current agent version and doing
-		// major.minor+1.patch=0. If the CLI has a greater major version,
-		// we just use the CLI version as is.
-		nextVersion := context.agent
-		if nextVersion.Major == context.client.Major {
-			nextVersion.Minor += 1
-			nextVersion.Patch = 0
-			// Explicitly skip 1.21 and 1.23.
-			if nextVersion.Major == 1 && (nextVersion.Minor == 21 || nextVersion.Minor == 23) {
-				nextVersion.Minor += 1
-			}
-		} else {
-			nextVersion = context.client
-		}
+	// Filter the available tools to get those with compatible
+	// series and arch.
+	filter := coretools.Filter{Number: context.chosen}
+	if context.tools, err = context.tools.Match(filter); err != nil {
+		return err
+	}
 
-		newestNextStable, found := context.tools.NewestCompatible(nextVersion)
-		if found {
-			logger.Debugf("found a more recent stable version %s", newestNextStable)
-			context.chosen = newestNextStable
-		} else {
-			newestCurrent, found := context.tools.NewestCompatible(context.agent)
-			if found {
-				logger.Debugf("found more recent current version %s", newestCurrent)
-				context.chosen = newestCurrent
-			} else {
-				if context.agent.Major != context.client.Major {
-					return fmt.Errorf("no compatible tools available")
-				} else {
-					return fmt.Errorf("no more recent supported versions available")
-				}
-			}
+	// If no explicit version specified, get the newest released tools.
+	if context.chosen == version.Zero {
+		newest, found := context.tools.NewestReleased(context.agent)
+		if !found {
+			return fmt.Errorf("no more recent supported versions available")
 		}
+		context.chosen = newest
 	} else {
-		// If not completely specified already, pick a single tools version.
-		filter := coretools.Filter{Number: context.chosen}
-		if context.tools, err = context.tools.Match(filter); err != nil {
-			return err
-		}
+		// Otherwise get the newest tools matching the user specified version.
 		context.chosen, context.tools = context.tools.Newest()
 	}
 	if context.chosen == context.agent {
@@ -431,6 +406,8 @@ func (context *upgradeContext) validate() (err error) {
 			"    juju upgrade-juju --version=1.20.14")
 	}
 
+	// We should select tools past these versions, but just in case
+	// a deployment only has access to old tools we'll still check.
 	// Skip 1.21 and 1.23 if the agents are not already on them.
 	if context.agent.Major == 1 && context.chosen.Major == 1 &&
 		context.agent.Minor != context.chosen.Minor &&

--- a/cmd/juju/commands/upgradejuju.go
+++ b/cmd/juju/commands/upgradejuju.go
@@ -374,13 +374,6 @@ func (context *upgradeContext) uploadTools() (err error) {
 // If validate returns no error, the environment agent-version can be set to
 // the value of the chosen field.
 func (context *upgradeContext) validate() (err error) {
-	// Filter the available tools to get those with compatible
-	// series and arch.
-	filter := coretools.Filter{Number: context.chosen}
-	if context.tools, err = context.tools.Match(filter); err != nil {
-		return err
-	}
-
 	// If no explicit version specified, get the newest released tools.
 	if context.chosen == version.Zero {
 		newest, found := context.tools.NewestReleased(context.agent)
@@ -390,6 +383,10 @@ func (context *upgradeContext) validate() (err error) {
 		context.chosen = newest
 	} else {
 		// Otherwise get the newest tools matching the user specified version.
+		filter := coretools.Filter{Number: context.chosen}
+		if context.tools, err = context.tools.Match(filter); err != nil {
+			return err
+		}
 		context.chosen, context.tools = context.tools.Newest()
 	}
 	if context.chosen == context.agent {

--- a/cmd/juju/commands/upgradejuju_test.go
+++ b/cmd/juju/commands/upgradejuju_test.go
@@ -135,13 +135,13 @@ var upgradeJujuTests = []struct {
 	tools:          []string{"2.0.5-quantal-amd64", "2.0.1-quantal-i386", "2.3.3-quantal-amd64"},
 	currentVersion: "2.0.0-quantal-amd64",
 	agentVersion:   "2.0.0",
-	expectVersion:  "2.0.5",
+	expectVersion:  "2.3.3",
 }, {
-	about:          "latest current release matching CLI, major version",
+	about:          "disallow unsupported major version upgrades",
 	tools:          []string{"3.2.0-quantal-amd64"},
 	currentVersion: "3.2.0-quantal-amd64",
 	agentVersion:   "2.8.2",
-	expectVersion:  "3.2.0",
+	expectErr:      "no more recent supported versions available",
 }, {
 	about:          "latest current release matching CLI, major version, no matching major tools",
 	tools:          []string{"2.8.2-quantal-amd64"},
@@ -153,12 +153,6 @@ var upgradeJujuTests = []struct {
 	tools:          []string{"3.3.0-quantal-amd64"},
 	currentVersion: "3.2.0-quantal-amd64",
 	agentVersion:   "2.8.2",
-	expectErr:      "no compatible tools available",
-}, {
-	about:          "no next supported available",
-	tools:          []string{"2.2.0-quantal-amd64", "2.2.5-quantal-i386", "2.3.3-quantal-amd64", "2.1-dev1-quantal-amd64"},
-	currentVersion: "2.0.0-quantal-amd64",
-	agentVersion:   "2.0.0",
 	expectErr:      "no more recent supported versions available",
 }, {
 	about:          "latest supported stable, when client is dev",
@@ -251,9 +245,9 @@ var upgradeJujuTests = []struct {
 	about:          "minor version downgrade to incompatible version",
 	tools:          []string{"3.2.0-quantal-amd64"},
 	currentVersion: "3.2.0-quantal-amd64",
-	agentVersion:   "3.3-dev0",
+	agentVersion:   "3.3.0",
 	args:           []string{"--version", "3.2.0"},
-	expectErr:      "cannot change version from 3.3-dev0 to 3.2.0",
+	expectErr:      "cannot change version from 3.3.0 to 3.2.0",
 }, {
 	about:          "nothing available",
 	currentVersion: "2.0.0-quantal-amd64",
@@ -523,16 +517,10 @@ func (s *UpgradeJujuSuite) TestUpgradeDryRun(c *gc.C) {
 			tools:          []string{"2.1.0-quantal-amd64", "2.1.2-quantal-i386", "2.1.3-quantal-amd64", "2.1-dev1-quantal-amd64", "2.2.3-quantal-amd64"},
 			currentVersion: "2.0.0-quantal-amd64",
 			agentVersion:   "2.0.0",
-			expectedCmdOutput: `available tools:
-    2.1-dev1-quantal-amd64
-    2.1.0-quantal-amd64
-    2.1.2-quantal-i386
-    2.1.3-quantal-amd64
-    2.2.3-quantal-amd64
-best version:
-    2.1.3
+			expectedCmdOutput: `best available tools version:
+    2.2.3
 upgrade to this version by running
-    juju upgrade-juju --version="2.1.3"
+    juju upgrade-juju --version="2.2.3"
 `,
 		},
 		{
@@ -541,16 +529,10 @@ upgrade to this version by running
 			tools:          []string{"2.1.0-quantal-amd64", "2.1.2-quantal-i386", "2.1.3-quantal-amd64", "2.1-dev1-quantal-amd64", "2.2.3-quantal-amd64"},
 			currentVersion: "2.0.0-quantal-amd64",
 			agentVersion:   "2.0.0",
-			expectedCmdOutput: `available tools:
-    2.1-dev1-quantal-amd64
-    2.1.0-quantal-amd64
-    2.1.2-quantal-i386
-    2.1.3-quantal-amd64
-    2.2.3-quantal-amd64
-best version:
-    2.1.3
+			expectedCmdOutput: `best available tools version:
+    2.2.3
 upgrade to this version by running
-    juju upgrade-juju --version="2.1.3"
+    juju upgrade-juju --version="2.2.3"
 `,
 		},
 		{
@@ -559,11 +541,7 @@ upgrade to this version by running
 			tools:          []string{"2.1.0-quantal-amd64", "2.1.2-quantal-i386", "2.1.3-quantal-amd64", "1.2.3-myawesomeseries-amd64"},
 			currentVersion: "2.0.0-quantal-amd64",
 			agentVersion:   "2.0.0",
-			expectedCmdOutput: `available tools:
-    2.1.0-quantal-amd64
-    2.1.2-quantal-i386
-    2.1.3-quantal-amd64
-best version:
+			expectedCmdOutput: `best available tools version:
     2.1.3
 upgrade to this version by running
     juju upgrade-juju --version="2.1.3"
@@ -767,10 +745,10 @@ func (s *UpgradeJujuSuite) TestMajorVersionRestriction(c *gc.C) {
 
 		ctx := coretesting.Context(c)
 		err = com.Run(ctx)
-		c.Assert(err, gc.ErrorMatches, "cannot upgrade to version incompatible with CLI")
+		c.Check(err, gc.ErrorMatches, "cannot upgrade to version incompatible with CLI")
 
 		output := coretesting.Stderr(ctx)
-		c.Assert(output, gc.Equals, "Upgrades to "+vers+" must first go through juju 2.0.\n")
+		c.Check(output, gc.Equals, "Upgrades to "+vers+" must first go through juju 2.0.\n")
 	}
 }
 

--- a/tools/list.go
+++ b/tools/list.go
@@ -86,19 +86,16 @@ func (src List) Newest() (version.Number, List) {
 	return best, result
 }
 
-// NewestCompatible returns the most recent version compatible with
-// base, i.e. with the same major and minor numbers and greater or
-// equal patch and build numbers.
-func (src List) NewestCompatible(base version.Number) (newest version.Number, found bool) {
+// NewestReleased returns the most recent released tools version (base or higher)
+// i.e. with the same major and greater or equal patch and build numbers.
+func (src List) NewestReleased(base version.Number) (newest version.Number, found bool) {
 	newest = base
 	found = false
 	for _, tool := range src {
 		toolVersion := tool.Version.Number
 		if newest == toolVersion {
 			found = true
-		} else if newest.Compare(toolVersion) < 0 &&
-			toolVersion.Major == newest.Major &&
-			toolVersion.Minor == newest.Minor {
+		} else if newest.Compare(toolVersion) < 0 && toolVersion.Major == newest.Major && toolVersion.Tag == "" {
 			newest = toolVersion
 			found = true
 		}

--- a/tools/list_test.go
+++ b/tools/list_test.go
@@ -38,10 +38,11 @@ var (
 	t100all       = tools.List{
 		t100precise, t100precise32, t100quantal, t100quantal32,
 	}
-	t190precise   = mustParseTools("1.9.0-precise-amd64")
-	t190precise32 = mustParseTools("1.9.0-precise-i386")
-	t190quantal   = mustParseTools("1.9.0-quantal-amd64")
-	t190all       = tools.List{
+	t110preciseDev = mustParseTools("1.1-alpha1-precise-amd64")
+	t190precise    = mustParseTools("1.9.0-precise-amd64")
+	t190precise32  = mustParseTools("1.9.0-precise-i386")
+	t190quantal    = mustParseTools("1.9.0-quantal-amd64")
+	t190all        = tools.List{
 		t190precise, t190precise32, t190quantal,
 	}
 	t200precise   = mustParseTools("2.0.0-precise-amd64")
@@ -149,7 +150,7 @@ func (s *ListSuite) TestNewest(c *gc.C) {
 	}
 }
 
-var newestCompatibleTests = []struct {
+var newestReleasedTests = []struct {
 	src    tools.List
 	base   version.Number
 	expect version.Number
@@ -184,12 +185,17 @@ var newestCompatibleTests = []struct {
 	base:   version.MustParse("2.1.1"),
 	expect: version.MustParse("2.1.5.2"),
 	found:  true,
+}, {
+	src:    append(t100all, t110preciseDev),
+	base:   version.MustParse("1.0.0"),
+	expect: version.MustParse("1.0.0"),
+	found:  true,
 }}
 
-func (s *ListSuite) TestNewestCompatible(c *gc.C) {
-	for i, test := range newestCompatibleTests {
+func (s *ListSuite) TestNewestReleased(c *gc.C) {
+	for i, test := range newestReleasedTests {
 		c.Logf("test %d", i)
-		actual, found := test.src.NewestCompatible(test.base)
+		actual, found := test.src.NewestReleased(test.base)
 		c.Check(actual, gc.DeepEquals, test.expect)
 		c.Check(found, gc.Equals, test.found)
 	}


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/juju-core/+bug/1403655

Plus, upgrade-juju will now, by default, choose the latest stable version with the same major number.
So if we are running 1.20, doing:

juju upgrade-juju 

will upgrade to 1.25.2

This auto version selection will not choose dev versions, just released.

(Review request: http://reviews.vapour.ws/r/3372/)