### PR TITLE
Don't deprecate hyphenated commands in 2.0

### DIFF
--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -150,10 +150,8 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 
 	// Configuration commands.
 	r.Register(newInitCommand())
-	r.RegisterDeprecated(common.NewGetConstraintsCommand(),
-		twoDotOhDeprecation("environment get-constraints or service get-constraints"))
-	r.RegisterDeprecated(common.NewSetConstraintsCommand(),
-		twoDotOhDeprecation("environment set-constraints or service set-constraints"))
+	r.Register(common.NewGetConstraintsCommand())
+	r.Register(common.NewSetConstraintsCommand())
 	r.Register(newExposeCommand())
 	r.Register(newSyncToolsCommand())
 	r.Register(newUnexposeCommand())
@@ -180,20 +178,20 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 
 	// Manage machines
 	r.Register(machine.NewSuperCommand())
-	r.RegisterSuperAlias("add-machine", "machine", "add", twoDotOhDeprecation("machine add"))
-	r.RegisterSuperAlias("remove-machine", "machine", "remove", twoDotOhDeprecation("machine remove"))
-	r.RegisterSuperAlias("destroy-machine", "machine", "remove", twoDotOhDeprecation("machine remove"))
-	r.RegisterSuperAlias("terminate-machine", "machine", "remove", twoDotOhDeprecation("machine remove"))
+	r.RegisterSuperAlias("add-machine", "machine", "add", nil)
+	r.RegisterSuperAlias("remove-machine", "machine", "remove", nil)
+	r.RegisterSuperAlias("destroy-machine", "machine", "remove", nil)
+	r.RegisterSuperAlias("terminate-machine", "machine", "remove", nil)
 
 	// Mangage environment
 	r.Register(environment.NewSuperCommand())
-	r.RegisterSuperAlias("get-environment", "environment", "get", twoDotOhDeprecation("environment get"))
-	r.RegisterSuperAlias("get-env", "environment", "get", twoDotOhDeprecation("environment get"))
-	r.RegisterSuperAlias("set-environment", "environment", "set", twoDotOhDeprecation("environment set"))
-	r.RegisterSuperAlias("set-env", "environment", "set", twoDotOhDeprecation("environment set"))
-	r.RegisterSuperAlias("unset-environment", "environment", "unset", twoDotOhDeprecation("environment unset"))
-	r.RegisterSuperAlias("unset-env", "environment", "unset", twoDotOhDeprecation("environment unset"))
-	r.RegisterSuperAlias("retry-provisioning", "environment", "retry-provisioning", twoDotOhDeprecation("environment retry-provisioning"))
+	r.RegisterSuperAlias("get-environment", "environment", "get", nil)
+	r.RegisterSuperAlias("get-env", "environment", "get", nil)
+	r.RegisterSuperAlias("set-environment", "environment", "set", nil)
+	r.RegisterSuperAlias("set-env", "environment", "set", nil)
+	r.RegisterSuperAlias("unset-environment", "environment", "unset", nil)
+	r.RegisterSuperAlias("unset-env", "environment", "unset", nil)
+	r.RegisterSuperAlias("retry-provisioning", "environment", "retry-provisioning", nil)
 
 	// Manage and control actions
 	r.Register(action.NewSuperCommand())
@@ -203,10 +201,10 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 
 	// Manage and control services
 	r.Register(service.NewSuperCommand())
-	r.RegisterSuperAlias("add-unit", "service", "add-unit", twoDotOhDeprecation("service add-unit"))
-	r.RegisterSuperAlias("get", "service", "get", twoDotOhDeprecation("service get"))
-	r.RegisterSuperAlias("set", "service", "set", twoDotOhDeprecation("service set"))
-	r.RegisterSuperAlias("unset", "service", "unset", twoDotOhDeprecation("service unset"))
+	r.RegisterSuperAlias("add-unit", "service", "add-unit", nil)
+	r.RegisterSuperAlias("get", "service", "get", nil)
+	r.RegisterSuperAlias("set", "service", "set", nil)
+	r.RegisterSuperAlias("unset", "service", "unset", nil)
 
 	// Operation protection commands
 	r.Register(block.NewSuperBlockCommand())

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -503,37 +503,3 @@ func (s *MainSuite) TestTwoDotOhDeprecation(c *gc.C) {
 	c.Check(replacement, gc.Equals, "the replacement")
 	c.Check(check.Obsolete(), jc.IsTrue)
 }
-
-// obsoleteCommandNames is the list of commands that are deprecated in
-// 2.0, and obsolete in 3.0
-var obsoleteCommandNames = []string{
-	"add-machine",
-	"destroy-machine",
-	"get-constraints",
-	"get-env",
-	"get-environment",
-	"remove-machine",
-	"retry-provisioning",
-	"set-constraints",
-	"set-env",
-	"set-environment",
-	"terminate-machine",
-	"unset-env",
-	"unset-environment",
-}
-
-func (s *MainSuite) TestObsoleteRegistration(c *gc.C) {
-	var commands commands
-	s.PatchValue(&version.Current, version.MustParse("3.0-alpha1"))
-	registerCommands(&commands, testing.Context(c))
-
-	cmdSet := set.NewStrings(obsoleteCommandNames...)
-	registeredCmdSet := set.NewStrings()
-	for _, cmd := range commands {
-		registeredCmdSet.Add(cmd.Info().Name)
-	}
-
-	intersection := registeredCmdSet.Intersection(cmdSet)
-	c.Logf("Registered obsolete commands: %s", intersection.Values())
-	c.Assert(intersection.IsEmpty(), gc.Equals, true)
-}


### PR DESCRIPTION
The initial work for hierarchical commands introduced
aliases for the old commands that were to be deprecated
in 2.0, and obsolete in 3.0.  However, the new direction
is that we will have a flat command space.

The work to flatten the commands is ongoing, but in the
mean time, the aliases for the hyphenated commands should
not be deprecated in 2.0.

(Review request: http://reviews.vapour.ws/r/3377/)