### PR TITLE
fix a bunch of go vet errors

### DIFF
--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -83,10 +83,10 @@ type changeCertListener struct {
 	certChanged <-chan params.StateServingInfo
 
 	// The config to update with any new certificate.
-	config tls.Config
+	config *tls.Config
 }
 
-func newChangeCertListener(lis net.Listener, certChanged <-chan params.StateServingInfo, config tls.Config) *changeCertListener {
+func newChangeCertListener(lis net.Listener, certChanged <-chan params.StateServingInfo, config *tls.Config) *changeCertListener {
 	cl := &changeCertListener{
 		Listener:    lis,
 		certChanged: certChanged,
@@ -108,7 +108,7 @@ func (cl *changeCertListener) Accept() (net.Conn, error) {
 	cl.m.Lock()
 	defer cl.m.Unlock()
 	config := cl.config
-	return tls.Server(conn, &config), nil
+	return tls.Server(conn, config), nil
 }
 
 // Close closes the listener.
@@ -201,7 +201,7 @@ func newServer(s *state.State, lis *net.TCPListener, cfg ServerConfig) (_ *Serve
 	}
 	// TODO(rog) check that *srvRoot is a valid type for using
 	// as an RPC server.
-	tlsConfig := tls.Config{
+	tlsConfig := &tls.Config{
 		Certificates: []tls.Certificate{tlsCert},
 	}
 	changeCertListener := newChangeCertListener(lis, cfg.CertChanged, tlsConfig)

--- a/apiserver/debuglog_db.go
+++ b/apiserver/debuglog_db.go
@@ -52,8 +52,6 @@ func handleDebugLogDBRequest(
 			}
 		}
 	}
-
-	return nil
 }
 
 func makeLogTailerParams(reqParams *debugLogParams) *state.LogTailerParams {

--- a/apiserver/params/network.go
+++ b/apiserver/params/network.go
@@ -19,7 +19,7 @@ type Subnet struct {
 	CIDR string `json:"CIDR"`
 
 	// ProviderId is the provider-specific subnet ID (if applicable).
-	ProviderId string `json:"ProviderId,omitempty`
+	ProviderId string `json:"ProviderId,omitempty"`
 
 	// VLANTag needs to be between 1 and 4094 for VLANs and 0 for
 	// normal networks. It's defined by IEEE 802.1Q standard.

--- a/provider/cloudsigma/environ.go
+++ b/provider/cloudsigma/environ.go
@@ -36,12 +36,12 @@ type environ struct {
 }
 
 // Name returns the Environ's name.
-func (env environ) Name() string {
+func (env *environ) Name() string {
 	return env.name
 }
 
 // Provider returns the EnvironProvider that created this Environ.
-func (environ) Provider() environs.EnvironProvider {
+func (*environ) Provider() environs.EnvironProvider {
 	return providerInstance
 }
 

--- a/provider/gce/environ.go
+++ b/provider/gce/environ.go
@@ -140,8 +140,9 @@ var newConnection = func(ecfg *environConfig) (gceConnection, error) {
 // getSnapshot returns a copy of the environment. This is useful for
 // ensuring the env you are using does not get changed by other code
 // while you are using it.
-func (env environ) getSnapshot() *environ {
-	return &env
+func (env *environ) getSnapshot() *environ {
+	e := *env
+	return &e
 }
 
 // Config returns the configuration data with which the env was created.

--- a/provider/lxd/environ.go
+++ b/provider/lxd/environ.go
@@ -128,8 +128,9 @@ func (env *environ) SetConfig(cfg *config.Config) error {
 // getSnapshot returns a copy of the environment. This is useful for
 // ensuring the env you are using does not get changed by other code
 // while you are using it.
-func (env environ) getSnapshot() *environ {
-	return &env
+func (env *environ) getSnapshot() *environ {
+	e := *env
+	return &e
 }
 
 // Config returns the configuration data with which the env was created.

--- a/provider/lxd/testing_test.go
+++ b/provider/lxd/testing_test.go
@@ -150,7 +150,7 @@ func (s *BaseSuiteUnpatched) initInst(c *gc.C) {
 	// nothing
 	}
 
-	instanceConfig, err := instancecfg.NewBootstrapInstanceConfig(cons, "trusty")
+	instanceConfig, err := instancecfg.NewBootstrapInstanceConfig(cons, "trusty", "")
 	c.Assert(err, jc.ErrorIsNil)
 
 	instanceConfig.Tools = tools[0]

--- a/provider/vsphere/environ.go
+++ b/provider/vsphere/environ.go
@@ -80,8 +80,9 @@ func (env *environ) SetConfig(cfg *config.Config) error {
 // getSnapshot returns a copy of the environment. This is useful for
 // ensuring the env you are using does not get changed by other code
 // while you are using it.
-func (env environ) getSnapshot() *environ {
-	return &env
+func (env *environ) getSnapshot() *environ {
+	e := *env
+	return &e
 }
 
 // Config returns the configuration data with which the env was created.

--- a/state/subnets.go
+++ b/state/subnets.go
@@ -59,9 +59,9 @@ type subnetDoc struct {
 	AllocatableIPLow  string `bson:"allocatableiplow,omitempty"`
 	VLANTag           int    `bson:"vlantag,omitempty"`
 	AvailabilityZone  string `bson:"availabilityzone,omitempty"`
-	IsPublic          bool   `bson:"is-public",omitempty`
+	IsPublic          bool   `bson:"is-public,omitempty"`
 	// TODO(dooferlad 2015-08-03): add an upgrade step to insert IsPublic=false
-	SpaceName string `bson:"space-name",omitempty`
+	SpaceName string `bson:"space-name,omitempty"`
 }
 
 // Life returns whether the subnet is Alive, Dying or Dead.

--- a/worker/meterstatus/isolated.go
+++ b/worker/meterstatus/isolated.go
@@ -133,7 +133,6 @@ func (w *isolatedStatusWorker) loop() error {
 			return errors.Annotate(err, "failed to record meter status worker state")
 		}
 	}
-	return nil
 }
 
 func (w *isolatedStatusWorker) applyStatus(code, info string) {

--- a/worker/uniter/operation/executor_test.go
+++ b/worker/uniter/operation/executor_test.go
@@ -503,8 +503,7 @@ type mockLockFunc struct {
 func (mock *mockLockFunc) newFailingLock() func(string) (func() error, error) {
 	return func(string) (func() error, error) {
 		mock.noStepsCalledOnLock = mock.op.prepare.called == false &&
-			mock.op.commit.called == false &&
-			mock.op.prepare.called == false
+			mock.op.commit.called == false
 		return nil, errors.New("wat")
 	}
 
@@ -515,8 +514,7 @@ func (mock *mockLockFunc) newSucceedingLock(unlockFails bool) func(string) (func
 		mock.calledLock = true
 		// Ensure that when we lock no operation has been called
 		mock.noStepsCalledOnLock = mock.op.prepare.called == false &&
-			mock.op.commit.called == false &&
-			mock.op.prepare.called == false
+			mock.op.commit.called == false
 		return func() error {
 			// Record steps called when unlocking
 			mock.stepsCalledOnUnlock = []bool{mock.op.prepare.called,

--- a/worker/uniter/remotestate/relationunits.go
+++ b/worker/uniter/remotestate/relationunits.go
@@ -63,5 +63,4 @@ func (w *relationUnitsWatcher) loop() error {
 			}
 		}
 	}
-	return nil
 }


### PR DESCRIPTION
This fixes the go vet errors indicated by doing the following:

```bash
go get -u golang.org/x/tools/cmd/vet
cd $GOPATH/src/github.com/juju/juju
go tool vet -composites=false .
```

Note that this go vet is evidently newer than the one that is running in the landing 

(Review request: http://reviews.vapour.ws/r/3378/)