### PR TITLE
Wire up bindings.

### DIFF
--- a/apiserver/service/service.go
+++ b/apiserver/service/service.go
@@ -106,7 +106,6 @@ func (api *API) ServicesDeployWithPlacement(args params.ServicesDeploy) (params.
 // ServicesDeployWithBindings fetches the charms from the charm store and deploys them
 // using the specified placement directives and saving the specified space bindings.
 func (api *API) ServicesDeployWithBindings(args params.ServicesDeploy) (params.ErrorResults, error) {
-	// TODO(dooferlad): save those space bindings
 	return api.ServicesDeployWithPlacement(args)
 }
 
@@ -168,15 +167,16 @@ func DeployService(st *state.State, owner string, args params.ServiceDeploy) err
 			ServiceName: args.ServiceName,
 			Series:      args.Series,
 			// TODO(dfc) ServiceOwner should be a tag
-			ServiceOwner:   owner,
-			Charm:          ch,
-			NumUnits:       args.NumUnits,
-			ConfigSettings: settings,
-			Constraints:    args.Constraints,
-			ToMachineSpec:  args.ToMachineSpec,
-			Placement:      args.Placement,
-			Networks:       requestedNetworks,
-			Storage:        args.Storage,
+			ServiceOwner:     owner,
+			Charm:            ch,
+			NumUnits:         args.NumUnits,
+			ConfigSettings:   settings,
+			Constraints:      args.Constraints,
+			ToMachineSpec:    args.ToMachineSpec,
+			Placement:        args.Placement,
+			Networks:         requestedNetworks,
+			Storage:          args.Storage,
+			EndpointBindings: args.EndpointBindings,
 		})
 	return err
 }

--- a/apiserver/service/service.go
+++ b/apiserver/service/service.go
@@ -104,7 +104,8 @@ func (api *API) ServicesDeployWithPlacement(args params.ServicesDeploy) (params.
 }
 
 // ServicesDeployWithBindings fetches the charms from the charm store and deploys them
-// using the specified placement directives and saving the specified space bindings.
+// using the specified placement directives and saving the specified endpoint bindings.
+// It is identical to ServicesDeployWithPlacement, but only exists when the API supports bindings.
 func (api *API) ServicesDeployWithBindings(args params.ServicesDeploy) (params.ErrorResults, error) {
 	return api.ServicesDeployWithPlacement(args)
 }

--- a/juju/deploy.go
+++ b/juju/deploy.go
@@ -37,8 +37,9 @@ type DeployServiceParams struct {
 	Placement []*instance.Placement
 	// Networks holds a list of networks to required to start on boot.
 	// TODO(dimitern): Drop this in a follow-up in favor of constraints.
-	Networks []string
-	Storage  map[string]storage.Constraints
+	Networks         []string
+	Storage          map[string]storage.Constraints
+	EndpointBindings map[string]string
 }
 
 type ServiceDeployer interface {
@@ -85,15 +86,16 @@ func DeployService(st ServiceDeployer, args DeployServiceParams) (*state.Service
 	}
 
 	asa := state.AddServiceArgs{
-		Name:      args.ServiceName,
-		Series:    args.Series,
-		Owner:     args.ServiceOwner,
-		Charm:     args.Charm,
-		Networks:  args.Networks,
-		Storage:   stateStorageConstraints(args.Storage),
-		Settings:  settings,
-		NumUnits:  args.NumUnits,
-		Placement: args.Placement,
+		Name:             args.ServiceName,
+		Series:           args.Series,
+		Owner:            args.ServiceOwner,
+		Charm:            args.Charm,
+		Networks:         args.Networks,
+		Storage:          stateStorageConstraints(args.Storage),
+		Settings:         settings,
+		NumUnits:         args.NumUnits,
+		Placement:        args.Placement,
+		EndpointBindings: args.EndpointBindings,
 	}
 
 	if !args.Charm.Meta().Subordinate {


### PR DESCRIPTION
This is the second half of deploy with bindings, adding in code to send the specified bindings to where they will be used and adding tests for these changes.

(Review request: http://reviews.vapour.ws/r/3380/)