### PR TITLE
fix api/metricsadder & apiserver/environment test compilation with ne…

### DIFF
--- a/api/metricsadder/client_test.go
+++ b/api/metricsadder/client_test.go
@@ -65,11 +65,9 @@ func (s *metricsAdderSuite) TestAddMetricBatches(c *gc.C) {
 
 func (s *metricsAdderSuite) TestAddMetricBatchesFails(c *gc.C) {
 	var called bool
-	var callParams params.MetricBatchParams
 	metricsadder.PatchFacadeCall(s, s.adder, func(request string, args, response interface{}) error {
-		p, ok := args.(params.MetricBatchParams)
+		_, ok := args.(params.MetricBatchParams)
 		c.Assert(ok, jc.IsTrue)
-		callParams = p
 		called = true
 		c.Assert(request, gc.Equals, "AddMetricBatches")
 		result := response.(*params.ErrorResults)

--- a/apiserver/environment/toolsversionupdate_test.go
+++ b/apiserver/environment/toolsversionupdate_test.go
@@ -38,15 +38,11 @@ func (s *updaterSuite) TestCheckTools(c *gc.C) {
 	}
 	s.PatchValue(&newEnvirons, fakeNewEnvirons)
 	var (
-		calledWithEnviron                environs.Environ
 		calledWithMajor, calledWithMinor int
-		calledWithFilter                 coretools.Filter
 	)
 	fakeToolFinder := func(e environs.Environ, maj int, min int, stream string, filter coretools.Filter) (coretools.List, error) {
-		calledWithEnviron = e
 		calledWithMajor = maj
 		calledWithMinor = min
-		calledWithFilter = filter
 		ver := version.Binary{Number: version.Number{Major: maj, Minor: min}}
 		t := coretools.Tools{Version: ver, URL: "http://example.com", Size: 1}
 		c.Assert(calledWithMajor, gc.Equals, 2)
@@ -74,16 +70,12 @@ func (s *updaterSuite) TestCheckToolsNonReleasedStream(c *gc.C) {
 	}
 	s.PatchValue(&newEnvirons, fakeNewEnvirons)
 	var (
-		calledWithEnviron                environs.Environ
 		calledWithMajor, calledWithMinor int
-		calledWithFilter                 coretools.Filter
 		calledWithStreams                []string
 	)
 	fakeToolFinder := func(e environs.Environ, maj int, min int, stream string, filter coretools.Filter) (coretools.List, error) {
-		calledWithEnviron = e
 		calledWithMajor = maj
 		calledWithMinor = min
-		calledWithFilter = filter
 		calledWithStreams = append(calledWithStreams, stream)
 		if stream == "released" {
 			return nil, coretools.ErrNoMatches


### PR DESCRIPTION
…w gccgo

gccgo (in xenial at least) is stricter than gc when it comes to a certain
class of declared but not used variable, see:

    https://github.com/golang/go/issues/6415
    https://github.com/golang/go/issues/3059