### PR TITLE
service/windows: fix error logic

### DIFF
--- a/service/windows/service_windows.go
+++ b/service/windows/service_windows.go
@@ -400,8 +400,9 @@ func (s *SvcManager) ensureRestartOnFailure(name string) (err error) {
 	}
 	defer func() {
 		// The CloseHandle error is less important than another error
+		closeErr := s.mgr.CloseHandle(handle)
 		if err == nil {
-			err = s.mgr.CloseHandle(handle)
+			err = errors.Annotatef(closeErr, "could not close %s's handle", name)
 		}
 	}()
 	action := serviceAction{

--- a/service/windows/service_windows.go
+++ b/service/windows/service_windows.go
@@ -401,8 +401,12 @@ func (s *SvcManager) ensureRestartOnFailure(name string) (err error) {
 	defer func() {
 		// The CloseHandle error is less important than another error
 		closeErr := s.mgr.CloseHandle(handle)
-		if err == nil {
-			err = errors.Annotatef(closeErr, "could not close %s's handle", name)
+		if closeErr != nil {
+			if err == nil {
+				err = errors.Annotatef(closeErr, "close %q handle failed", name)
+			} else {
+				err = errors.Annotatef(err, "(also close %q handle failed: %s)", name, closeErr)
+			}
 		}
 	}()
 	action := serviceAction{

--- a/service/windows/service_windows_test.go
+++ b/service/windows/service_windows_test.go
@@ -7,6 +7,7 @@
 package windows_test
 
 import (
+	"fmt"
 	"syscall"
 
 	win "github.com/gabriel-samfira/sys/windows"
@@ -216,14 +217,14 @@ func (s *serviceManagerSuite) TestEnsureRestartOnFailureCloseHandleDoesNotOverwr
 	}
 	s.stub.SetErrors(nil, nil, errors.New("CloseHandle: floosh"))
 	err := s.mgr.Create(s.name, s.conf)
-	c.Assert(err, gc.ErrorMatches, "ChangeServiceConfig2: zoinks")
+	c.Assert(err, gc.ErrorMatches, fmt.Sprintf("\\(also close %q handle failed: CloseHandle: floosh\\): ChangeServiceConfig2: zoinks", s.name))
 	s.stub.CheckCallNames(c, "CreateService", "GetHandle", "CloseHandle", "Close")
 }
 
 func (s *serviceManagerSuite) TestEnsureRestartOnFailureCloseHandleReturnsErrorSuccessfully(c *gc.C) {
 	s.stub.SetErrors(nil, nil, errors.New("CloseHandle: floosh"))
 	err := s.mgr.Create(s.name, s.conf)
-	c.Assert(err, gc.ErrorMatches, "could not close "+s.name+"'s handle: CloseHandle: floosh")
+	c.Assert(err, gc.ErrorMatches, fmt.Sprintf("close %q handle failed: CloseHandle: floosh", s.name))
 	s.stub.CheckCallNames(c, "CreateService", "GetHandle", "CloseHandle", "Close")
 }
 


### PR DESCRIPTION
Fixes a bug I found by accident while reading some code.

Basically a close function would only get called in a specific situation, potentially leaving a handle open.

Also got rid of PatchValue as a drive-by fix and added tests to make sure the logic is fine.

(Review request: http://reviews.vapour.ws/r/3382/)