### PR TITLE
service/windows: comply syscall structure with go1.5

### DIFF
--- a/service/windows/service_windows.go
+++ b/service/windows/service_windows.go
@@ -49,7 +49,7 @@ type serviceFailureActions struct {
 
 // https://msdn.microsoft.com/en-us/library/windows/desktop/ms685937(v=vs.85).aspx
 type serviceFailureActionsFlag struct {
-	failureActionsOnNonCrashFailures bool
+	failureActionsOnNonCrashFailures int32
 }
 
 // This is done so we can mock this function out
@@ -420,7 +420,7 @@ func (s *SvcManager) ensureRestartOnFailure(name string) (err error) {
 		return errors.Trace(err)
 	}
 	flag := serviceFailureActionsFlag{
-		failureActionsOnNonCrashFailures: true,
+		failureActionsOnNonCrashFailures: 1,
 	}
 	err = WinChangeServiceConfig2(handle, SERVICE_CONFIG_FAILURE_ACTIONS_FLAG, (*byte)(unsafe.Pointer(&flag)))
 	if err != nil {


### PR DESCRIPTION
As seen [here](https://github.com/kardianos/service/issues/49#issuecomment-162339599), it seems like using booleans in go1.5 causes a problem that can be easily solved by using int32.

(Review request: http://reviews.vapour.ws/r/3383/)