### PR TITLE
Tweak tools validation to fix test on windows

### DIFF
--- a/state/toolstorage/tools.go
+++ b/state/toolstorage/tools.go
@@ -260,7 +260,7 @@ func validateVersion(v version.Binary) error {
 	if err := bson.Unmarshal(data, &doc); err != nil {
 		return errors.Trace(err)
 	}
-	if v != doc.Version {
+	if v.String() != doc.Version.String() {
 		return errors.Errorf("version %q != %q", v, doc.Version)
 	}
 	return nil


### PR DESCRIPTION
toolstorage validateVersion() needed a tweak to make the tests reliable.

(Review request: http://reviews.vapour.ws/r/3386/)