### PR TITLE
Fixed lp:1525280: Disambiguate container hostnames for devices on MAAS

### DIFF
--- a/apiserver/provisioner/container_test.go
+++ b/apiserver/provisioner/container_test.go
@@ -218,10 +218,15 @@ func (s *prepareSuite) TestErrorWithNoFeatureFlagAllocateSuccess(c *gc.C) {
 	container := s.newCustomAPI(c, "i-alloc-me", true, false)
 	args := s.makeArgs(container)
 	_, testLog := s.assertCall(c, args, s.makeResults([]params.NetworkConfig{{
-		DeviceIndex: 0,
-		ConfigType:  "static",
-		MACAddress:  "regex:" + regexpMACAddress,
-		Address:     "regex:0.10.0.[0-9]{1,3}", // we don't care about the actual value.
+		DeviceIndex:    0,
+		NetworkName:    "juju-private",
+		ProviderId:     "dummy-eth0",
+		InterfaceName:  "eth0",
+		DNSServers:     []string{"ns1.dummy", "ns2.dummy"},
+		GatewayAddress: "0.10.0.1",
+		ConfigType:     "static",
+		MACAddress:     "regex:" + regexpMACAddress,
+		Address:        "regex:0.10.0.[0-9]{1,3}", // we don't care about the actual value.
 	}}), "")
 
 	c.Assert(testLog, jc.LogMatches, jc.SimpleMessages{{

--- a/apiserver/provisioner/container_test.go
+++ b/apiserver/provisioner/container_test.go
@@ -218,17 +218,18 @@ func (s *prepareSuite) TestErrorWithNoFeatureFlagAllocateSuccess(c *gc.C) {
 	container := s.newCustomAPI(c, "i-alloc-me", true, false)
 	args := s.makeArgs(container)
 	_, testLog := s.assertCall(c, args, s.makeResults([]params.NetworkConfig{{
-		DeviceIndex:   0,
-		InterfaceName: "eth0",
-		ConfigType:    "dhcp",
-		MACAddress:    "regex:" + regexpMACAddress,
-		ProviderId:    "juju-private",
-		NetworkName:   "juju-private",
+		DeviceIndex: 0,
+		ConfigType:  "static",
+		MACAddress:  "regex:" + regexpMACAddress,
+		Address:     "regex:0.10.0.[0-9]{1,3}", // we don't care about the actual value.
 	}}), "")
 
 	c.Assert(testLog, jc.LogMatches, jc.SimpleMessages{{
 		loggo.INFO,
-		`reserved address for container "0/lxc/0" with MAC address ".+" \(using DHCP\)`,
+		`allocated address ".+" on instance "i-alloc-me" for container "juju-machine-0-lxc-0"`,
+	}, {
+		loggo.INFO,
+		`assigned address ".+" to container "0/lxc/0"`,
 	}})
 }
 

--- a/apiserver/provisioner/provisioner.go
+++ b/apiserver/provisioner/provisioner.go
@@ -1201,8 +1201,9 @@ func (p *ProvisionerAPI) prepareAllocationNetwork(
 			subnetInfo = sub
 			interfaceInfo = subnetIdToInterface[sub.ProviderId]
 
-			// Since with addressable containers the host acts like a gateway, we
-			// use the host's primary NIC's address as gateway.
+			// Since with addressable containers the host acts like a gateway
+			// for the containers, instead of using the same gateway for the
+			// containers as their host's
 			interfaceInfo.GatewayAddress.Value = interfaceInfo.Address.Value
 
 			success = true

--- a/environs/networking.go
+++ b/environs/networking.go
@@ -14,9 +14,12 @@ import (
 // Networking interface defines methods that environments
 // with networking capabilities must implement.
 type Networking interface {
-	// AllocateAddress requests a specific address to be allocated for the
-	// given instance on the given subnet.
-	AllocateAddress(instId instance.Id, subnetId network.Id, addr network.Address, macAddress, hostname string) error
+	// AllocateAddress requests a specific address to be allocated for the given
+	// instance on the given subnet, using the specified macAddress and
+	// hostnameSuffix. If addr is empty, this is interpreted as an output
+	// argument, which will contain the allocated address. Otherwise, addr must
+	// be non-empty and will be allocated as specified, if possible.
+	AllocateAddress(instId instance.Id, subnetId network.Id, addr *network.Address, macAddress, hostnameSuffix string) error
 
 	// ReleaseAddress releases a specific address previously allocated with
 	// AllocateAddress.

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -1102,13 +1102,18 @@ func (env *environ) SupportsAddressAllocation(subnetId network.Id) (bool, error)
 
 // AllocateAddress requests an address to be allocated for the
 // given instance on the given subnet.
-func (env *environ) AllocateAddress(instId instance.Id, subnetId network.Id, addr network.Address, macAddress, hostname string) error {
+func (env *environ) AllocateAddress(instId instance.Id, subnetId network.Id, addr *network.Address, macAddress, hostname string) error {
 	if !environs.AddressAllocationEnabled() {
 		// Any instId starting with "i-alloc-" when the feature flag is off will
 		// still work, in order to be able to test MAAS 1.8+ environment where
 		// we can use devices for containers.
 		if !strings.HasPrefix(string(instId), "i-alloc-") {
 			return errors.NotSupportedf("address allocation")
+		}
+		// Also, in this case we expect addr to be non-nil, but empty, so it can
+		// be used as an output argument (same as in provider/maas).
+		if addr == nil || addr.Value != "" {
+			return errors.NewNotValid(nil, "invalid address: nil or non-empty")
 		}
 	}
 
@@ -1123,11 +1128,16 @@ func (env *environ) AllocateAddress(instId instance.Id, subnetId network.Id, add
 	estate.mu.Lock()
 	defer estate.mu.Unlock()
 	estate.maxAddr++
+
+	if addr.Value == "" {
+		*addr = network.NewAddress(fmt.Sprintf("0.10.0.%v", estate.maxAddr))
+	}
+
 	estate.ops <- OpAllocateAddress{
 		Env:        env.name,
 		InstanceId: instId,
 		SubnetId:   subnetId,
-		Address:    addr,
+		Address:    *addr,
 		MACAddress: macAddress,
 		HostName:   hostname,
 	}

--- a/provider/dummy/environs_test.go
+++ b/provider/dummy/environs_test.go
@@ -225,25 +225,25 @@ func (s *suite) TestAllocateAddress(c *gc.C) {
 
 	// Test allocating a couple of addresses.
 	newAddress := network.NewScopedAddress("0.1.2.1", network.ScopeCloudLocal)
-	err := e.AllocateAddress(inst.Id(), subnetId, newAddress, "foo", "bar")
+	err := e.AllocateAddress(inst.Id(), subnetId, &newAddress, "foo", "bar")
 	c.Assert(err, jc.ErrorIsNil)
 	assertAllocateAddress(c, e, opc, inst.Id(), subnetId, newAddress, "foo", "bar")
 
 	newAddress = network.NewScopedAddress("0.1.2.2", network.ScopeCloudLocal)
-	err = e.AllocateAddress(inst.Id(), subnetId, newAddress, "foo", "bar")
+	err = e.AllocateAddress(inst.Id(), subnetId, &newAddress, "foo", "bar")
 	c.Assert(err, jc.ErrorIsNil)
 	assertAllocateAddress(c, e, opc, inst.Id(), subnetId, newAddress, "foo", "bar")
 
 	// Test we can induce errors.
 	s.breakMethods(c, e, "AllocateAddress")
 	newAddress = network.NewScopedAddress("0.1.2.3", network.ScopeCloudLocal)
-	err = e.AllocateAddress(inst.Id(), subnetId, newAddress, "foo", "bar")
+	err = e.AllocateAddress(inst.Id(), subnetId, &newAddress, "foo", "bar")
 	c.Assert(err, gc.ErrorMatches, `dummy\.AllocateAddress is broken`)
 
 	// Finally, test the method respects the feature flag when
 	// disabled.
 	s.SetFeatureFlags() // clear the flags.
-	err = e.AllocateAddress(inst.Id(), subnetId, newAddress, "foo", "bar")
+	err = e.AllocateAddress(inst.Id(), subnetId, &newAddress, "foo", "bar")
 	c.Assert(err, gc.ErrorMatches, "address allocation not supported")
 	c.Assert(err, jc.Satisfies, errors.IsNotSupported)
 }

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -903,9 +903,12 @@ func (e *environ) fetchNetworkInterfaceId(ec2Inst *ec2.EC2, instId instance.Id) 
 
 // AllocateAddress requests an address to be allocated for the given
 // instance on the given subnet. Implements NetworkingEnviron.AllocateAddress.
-func (e *environ) AllocateAddress(instId instance.Id, _ network.Id, addr network.Address, _, _ string) (err error) {
+func (e *environ) AllocateAddress(instId instance.Id, _ network.Id, addr *network.Address, _, _ string) (err error) {
 	if !environs.AddressAllocationEnabled() {
 		return errors.NotSupportedf("address allocation")
+	}
+	if addr == nil || addr.Value == "" {
+		return errors.NewNotValid(nil, "invalid address: nil or empty")
 	}
 
 	defer errors.DeferredAnnotatef(&err, "failed to allocate address %q for instance %q", addr, instId)
@@ -917,17 +920,17 @@ func (e *environ) AllocateAddress(instId instance.Id, _ network.Id, addr network
 		return errors.Trace(err)
 	}
 	for a := shortAttempt.Start(); a.Next(); {
-		err = AssignPrivateIPAddress(ec2Inst, nicId, addr)
-		logger.Tracef("AssignPrivateIPAddresses(%v, %v) returned: %v", nicId, addr, err)
+		err = AssignPrivateIPAddress(ec2Inst, nicId, *addr)
+		logger.Tracef("AssignPrivateIPAddresses(%v, %v) returned: %v", nicId, *addr, err)
 		if err == nil {
-			logger.Tracef("allocated address %v for instance %v, NIC %v", addr, instId, nicId)
+			logger.Tracef("allocated address %v for instance %v, NIC %v", *addr, instId, nicId)
 			break
 		}
 		if ec2Err, ok := err.(*ec2.Error); ok {
 			if ec2Err.Code == invalidParameterValue {
 				// Note: this Code is also used if we specify
 				// an IP address outside the subnet. Take care!
-				logger.Tracef("address %q not available for allocation", addr)
+				logger.Tracef("address %q not available for allocation", *addr)
 				return environs.ErrIPAddressUnavailable
 			} else if ec2Err.Code == privateAddressLimitExceeded {
 				logger.Tracef("no more addresses available on the subnet")

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -1412,7 +1412,7 @@ func transformDeviceHostname(deviceID, deviceHostname, hostnameSuffix string) (s
 }
 
 // updateDeviceHostname updates the hostname of a MAAS device to be unique and
-// to contain the given hostnameSuff.
+// to contain the given hostnameSuffix.
 func updateDeviceHostname(client *gomaasapi.MAASObject, deviceID, deviceHostname, hostnameSuffix string) (string, error) {
 
 	newHostname, err := transformDeviceHostname(deviceID, deviceHostname, hostnameSuffix)
@@ -1432,7 +1432,7 @@ func updateDeviceHostname(client *gomaasapi.MAASObject, deviceID, deviceHostname
 // newDeviceParams prepares the params to call "devices new" API. Declared
 // separately so it can be mocked out in the test to work around the gomaasapi's
 // testservice limitation.
-func newDeviceParams(macAddress string, instId instance.Id, hostnameSuffx string) url.Values {
+func newDeviceParams(macAddress string, instId instance.Id, _ string) url.Values {
 	params := make(url.Values)
 	params.Add("mac_addresses", macAddress)
 	// We create the device without a hostname, to allow MAAS to create a unique

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -56,6 +56,8 @@ var (
 	ReleaseNodes             = releaseNodes
 	ReserveIPAddress         = reserveIPAddress
 	ReserveIPAddressOnDevice = reserveIPAddressOnDevice
+	NewDeviceParams          = newDeviceParams
+	UpdateDeviceHostname     = updateDeviceHostname
 	ReleaseIPAddress         = releaseIPAddress
 	DeploymentStatusCall     = deploymentStatusCall
 )
@@ -73,15 +75,21 @@ func reserveIPAddress(ipaddresses gomaasapi.MAASObject, cidr string, addr networ
 	return err
 }
 
-func reserveIPAddressOnDevice(devices gomaasapi.MAASObject, deviceId string, addr network.Address) (network.Address, error) {
-	device := devices.GetSubObject(deviceId)
+func reserveIPAddressOnDevice(devices gomaasapi.MAASObject, deviceID, macAddress string, addr network.Address) (network.Address, error) {
+	device := devices.GetSubObject(deviceID)
 	params := url.Values{}
 	if addr.Value != "" {
 		params.Add("requested_address", addr.Value)
 	}
+	if macAddress != "" {
+		params.Add("mac_address", macAddress)
+	}
 	resp, err := device.CallPost("claim_sticky_ip_address", params)
 	if err != nil {
-		return network.Address{}, errors.Annotatef(err, "failed to reserve sticky IP address for device %q", deviceId)
+		return network.Address{}, errors.Annotatef(
+			err, "failed to reserve sticky IP address for device %q",
+			deviceID,
+		)
 	}
 	respMap, err := resp.GetMap()
 	if err != nil {
@@ -94,7 +102,7 @@ func reserveIPAddressOnDevice(devices gomaasapi.MAASObject, deviceId string, add
 	if len(addresses) == 0 {
 		return network.Address{}, errors.Errorf(
 			"expected to find a sticky IP address for device %q: MAAS API response contains no IP addresses",
-			deviceId,
+			deviceID,
 		)
 	}
 	var firstAddress network.Address
@@ -103,20 +111,20 @@ func reserveIPAddressOnDevice(devices gomaasapi.MAASObject, deviceId string, add
 		if err != nil {
 			return network.Address{}, errors.Annotatef(err,
 				"failed to parse reserved IP address for device %q",
-				deviceId,
+				deviceID,
 			)
 		}
 		if ip := net.ParseIP(value); ip == nil {
 			return network.Address{}, errors.Annotatef(err,
 				"failed to parse reserved IP address %q for device %q",
-				value, deviceId,
+				value, deviceID,
 			)
 		}
 		if firstAddress.Value == "" {
 			// We only need the first address, but we're logging all we got.
 			firstAddress = network.NewAddress(value)
 		}
-		logger.Debugf("reserved address %q for device %q", value, deviceId)
+		logger.Debugf("reserved address %q for device %q and MAC %q", value, deviceID, macAddress)
 	}
 	return firstAddress, nil
 }
@@ -1382,16 +1390,48 @@ func (environ *maasEnviron) Instances(ids []instance.Id) ([]instance.Instance, e
 	return result, nil
 }
 
-// newDevice creates a new MAAS device for a MAC address, returning the Id of
-// the new device.
-func (environ *maasEnviron) newDevice(macAddress string, instId instance.Id, hostname string) (string, error) {
+// updateDeviceHostname uses the given client to update the hostname of the
+// device with the given deviceID to have the specified hostnameSuffx.
+func updateDeviceHostname(client *gomaasapi.MAASObject, deviceID, deviceHostname, hostnameSuffix string) (string, error) {
+
+	hostnameParts := strings.SplitN(deviceHostname, ".", 2)
+	if len(hostnameParts) != 2 {
+		return "", errors.Errorf("unexpected device %q hostname %q", deviceID, deviceHostname)
+	}
+	newHostname := fmt.Sprintf("%s-%s.%s", hostnameParts[0], hostnameSuffix, hostnameParts[1])
+	deviceObj := client.GetSubObject("devices").GetSubObject(deviceID)
+	params := make(url.Values)
+	params.Add("hostname", newHostname)
+	if _, err := deviceObj.Update(params); err != nil {
+		return "", errors.Annotatef(err, "updating device %q hostname to %q", deviceID, newHostname)
+	}
+	return newHostname, nil
+}
+
+// newDeviceParams prepares the params to call "devices new" API. Declared
+// separately so it can be mocked out in the test to work around the gomaasapi's
+// testservice limitation.
+func newDeviceParams(macAddress string, instId instance.Id, hostnameSuffx string) url.Values {
+	params := make(url.Values)
+	params.Add("mac_addresses", macAddress)
+	// We create the device without a hostname, to allow MAAS to create a unique
+	// hostname first.
+	params.Add("parent", extractSystemId(instId))
+
+	return params
+}
+
+// newDevice creates a new MAAS device with parent instance instId, using the
+// given macAddress and hostnameSuffix, returning the ID of the new device.
+func (environ *maasEnviron) newDevice(macAddress string, instId instance.Id, hostnameSuffix string) (string, error) {
 	client := environ.getMAASClient()
 	devices := client.GetSubObject("devices")
-	params := url.Values{}
-	params.Add("mac_addresses", macAddress)
-	params.Add("hostname", hostname)
-	params.Add("parent", extractSystemId(instId))
-	logger.Tracef("creating a new MAAS device for MAC %q, hostname %q, parent %q", macAddress, hostname, string(instId))
+	// Work around the limitation of gomaasapi's testservice expecting all 3
+	// arguments (parent, mac_addresses, and hostname) to be filled in.
+	params := NewDeviceParams(macAddress, instId, hostnameSuffix)
+	logger.Tracef(
+		"creating a new MAAS device for MAC %q, parent %q", macAddress, instId,
+	)
 	result, err := devices.CallPost("new", params)
 	if err != nil {
 		return "", errors.Trace(err)
@@ -1402,12 +1442,24 @@ func (environ *maasEnviron) newDevice(macAddress string, instId instance.Id, hos
 		return "", errors.Trace(err)
 	}
 
-	device, err := resultMap["system_id"].GetString()
+	deviceID, err := resultMap["system_id"].GetString()
 	if err != nil {
 		return "", errors.Trace(err)
 	}
-	logger.Tracef("created device %q", device)
-	return device, nil
+	deviceHostname, err := resultMap["hostname"].GetString()
+	if err != nil {
+		return deviceID, errors.Trace(err)
+	}
+
+	logger.Tracef("created device %q with MAC %q and hostname %q", deviceID, macAddress, deviceHostname)
+
+	newHostname, err := UpdateDeviceHostname(client, deviceID, deviceHostname, hostnameSuffix)
+	if err != nil {
+		return deviceID, errors.Trace(err)
+	}
+	logger.Tracef("updated device %q hostname to %q", deviceID, newHostname)
+
+	return deviceID, nil
 }
 
 // fetchFullDevice fetches an existing device Id associated with a MAC address
@@ -1467,20 +1519,19 @@ func (environ *maasEnviron) createOrFetchDevice(macAddress string, instId instan
 	if !errors.IsNotFound(err) {
 		return "", errors.Trace(err)
 	}
-	device, err = environ.newDevice(macAddress, instId, hostname)
-	if err != nil {
-		return "", errors.Trace(err)
-	}
-	return device, nil
+	return environ.newDevice(macAddress, instId, hostname)
 }
 
 // AllocateAddress requests an address to be allocated for the
 // given instance on the given network.
-func (environ *maasEnviron) AllocateAddress(instId instance.Id, subnetId network.Id, addr network.Address, macAddress, hostname string) (err error) {
+func (environ *maasEnviron) AllocateAddress(instId instance.Id, subnetId network.Id, addr *network.Address, macAddress, hostname string) (err error) {
 	logger.Tracef(
 		"AllocateAddress for instId %q, subnet %q, addr %q, MAC %q, hostname %q",
 		instId, subnetId, addr, macAddress, hostname,
 	)
+	if addr == nil {
+		return errors.NewNotValid(nil, "invalid address: cannot be nil")
+	}
 
 	if !environs.AddressAllocationEnabled() {
 		if !environ.supportsDevices {
@@ -1504,14 +1555,15 @@ func (environ *maasEnviron) AllocateAddress(instId instance.Id, subnetId network
 			deviceID, hostname, macAddress, instId,
 		)
 		devices := environ.getMAASClient().GetSubObject("devices")
-		addr, err := ReserveIPAddressOnDevice(devices, deviceID, network.Address{})
+		newAddr, err := ReserveIPAddressOnDevice(devices, deviceID, macAddress, network.Address{})
 		if err != nil {
 			return errors.Trace(err)
 		}
 		logger.Infof(
-			"reserved sticky IP address %q for device %q representing container %q",
-			addr, deviceID, hostname,
+			"reserved sticky IP address %q for device %q with MAC address %q representing container %q",
+			newAddr, deviceID, macAddress, hostname,
 		)
+		*addr = newAddr
 		return nil
 	}
 	defer errors.DeferredAnnotatef(&err, "failed to allocate address %q for instance %q", addr, instId)
@@ -1519,14 +1571,18 @@ func (environ *maasEnviron) AllocateAddress(instId instance.Id, subnetId network
 	client := environ.getMAASClient()
 	var maasErr gomaasapi.ServerError
 	if environ.supportsDevices {
-		device, err := environ.createOrFetchDevice(macAddress, instId, hostname)
+		deviceID, err := environ.createOrFetchDevice(macAddress, instId, hostname)
 		if err != nil {
 			return err
 		}
 
 		devices := client.GetSubObject("devices")
-		if gotAddr, err := ReserveIPAddressOnDevice(devices, device, addr); err == nil {
-			logger.Infof("allocated address %q for instance %q on device %q (asked for address %q)", addr, instId, device, gotAddr)
+		newAddr, err := ReserveIPAddressOnDevice(devices, deviceID, macAddress, *addr)
+		if err == nil {
+			logger.Infof(
+				"allocated address %q for instance %q on device %q (asked for address %q)",
+				addr, instId, deviceID, newAddr,
+			)
 			return nil
 		}
 
@@ -1540,7 +1596,7 @@ func (environ *maasEnviron) AllocateAddress(instId instance.Id, subnetId network
 		var subnets []network.SubnetInfo
 
 		subnets, err = environ.Subnets(instId, []network.Id{subnetId})
-		logger.Tracef("Subnets(%q, %q, %q) returned: %v (%v)", instId, subnetId, addr, subnets, err)
+		logger.Tracef("Subnets(%q, %q, %q) returned: %v (%v)", instId, subnetId, *addr, subnets, err)
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -1552,9 +1608,9 @@ func (environ *maasEnviron) AllocateAddress(instId instance.Id, subnetId network
 
 		cidr := foundSub.CIDR
 		ipaddresses := client.GetSubObject("ipaddresses")
-		err = ReserveIPAddress(ipaddresses, cidr, addr)
+		err = ReserveIPAddress(ipaddresses, cidr, *addr)
 		if err == nil {
-			logger.Infof("allocated address %q for instance %q on subnet %q", addr, instId, cidr)
+			logger.Infof("allocated address %q for instance %q on subnet %q", *addr, instId, cidr)
 			return nil
 		}
 
@@ -1594,7 +1650,9 @@ func (environ *maasEnviron) ReleaseAddress(instId instance.Id, _ network.Id, add
 			return errors.NotSupportedf("address allocation")
 		}
 		logger.Tracef("getting device ID for container %q with MAC %q", macAddress, hostname)
-		deviceID, err := environ.fetchDevice(macAddress, hostname)
+		// The MAC address should uniquely identity the device, no need to pass
+		// hostname.
+		deviceID, err := environ.fetchDevice(macAddress, "")
 		if err != nil {
 			return errors.Annotatef(
 				err,

--- a/provider/maas/environ_whitebox_test.go
+++ b/provider/maas/environ_whitebox_test.go
@@ -567,13 +567,16 @@ func (suite *environSuite) newNetwork(name string, id int, vlanTag int, defaultG
 		defaultGateway = fmt.Sprintf("%q", defaultGateway)
 	}
 
-	input := fmt.Sprintf(
-		`{ "name": %q,
-"ip":"192.168.%d.2",
-"netmask": "255.255.255.0",
-"vlan_tag": %s,
-"description": "%s_%d_%d",
-"default_gateway": %s }`,
+	// TODO(dimitern): Use JSON tags on structs, JSON encoder, or at least
+	// text/template below and in similar cases.
+	input := fmt.Sprintf(`{
+		"name": %q,
+		"ip":"192.168.%d.2",
+		"netmask": "255.255.255.0",
+		"vlan_tag": %s,
+		"description": "%s_%d_%d",
+		"default_gateway": %s
+	}`,
 		name,
 		id,
 		vlan,

--- a/provider/maas/maas_test.go
+++ b/provider/maas/maas_test.go
@@ -9,7 +9,6 @@ import (
 	gc "gopkg.in/check.v1"
 	"launchpad.net/gomaasapi"
 
-	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	envtesting "github.com/juju/juju/environs/testing"
 	"github.com/juju/juju/feature"
@@ -17,9 +16,6 @@ import (
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/version"
 )
-
-// Ensure maasEnviron supports environs.NetworkingEnviron.
-var _ environs.NetworkingEnviron = (*maasEnviron)(nil)
 
 type providerSuite struct {
 	coretesting.FakeJujuHomeSuite

--- a/provider/vsphere/environ_network.go
+++ b/provider/vsphere/environ_network.go
@@ -13,8 +13,8 @@ import (
 )
 
 // AllocateAddress implements environs.Environ.
-func (env *environ) AllocateAddress(instID instance.Id, subnetID network.Id, addr network.Address, _, _ string) error {
-	return env.changeAddress(instID, subnetID, addr, true)
+func (env *environ) AllocateAddress(instID instance.Id, subnetID network.Id, addr *network.Address, _, _ string) error {
+	return env.changeAddress(instID, subnetID, *addr, true)
 }
 
 // ReleaseAddress implements environs.Environ.

--- a/worker/provisioner/provisioner_task.go
+++ b/worker/provisioner/provisioner_task.go
@@ -667,6 +667,21 @@ func (task *provisionerTask) prepareNetworkAndInterfaces(networkInfo []network.I
 	}
 	visitedNetworks := set.NewStrings()
 	for _, info := range networkInfo {
+		// TODO(dimitern): The following few fields are required, but no longer
+		// matter and will be dropped or changed soon as part of making spaces
+		// and subnets usable across the board.
+		if info.NetworkName == "" {
+			info.NetworkName = network.DefaultPrivate
+		}
+		if info.ProviderId == "" {
+			info.ProviderId = network.DefaultPrivate
+		}
+		if info.CIDR == "" {
+			// TODO(dimitern): This is only when NOT using addressable
+			// containers, as we don't fetch the subnet details, but since
+			// networks in state are going away real soon, it's not important.
+			info.CIDR = "0.0.0.0/32"
+		}
 		if !names.IsValidNetwork(info.NetworkName) {
 			return nil, nil, errors.Errorf("invalid network name %q", info.NetworkName)
 		}


### PR DESCRIPTION
Container hostnames now are prefixed with a unique MAAS-generated prefix
so different environments on the same MAAS don't clash when creating
containers (and devices for them).

See http://pad.lv/1525280 for more info.

Unit tested and live tested on MAAS 1.9RC4 and 1.8.
Also tested on 1.9 with the address-allocation feature flag enabled (and fixed an issue there).

(Review request: http://reviews.vapour.ws/r/3388/)