### PR TITLE
Added UUID to GCE disks

### DIFF
--- a/provider/gce/disks.go
+++ b/provider/gce/disks.go
@@ -298,7 +298,7 @@ func (v *volumeSource) ListVolumes() ([]string, error) {
 			if disk.Description != v.envUUID && disk.Description != "" {
 				continue
 			}
-			// We don't want tolay hads on disks we did not create.
+			// We don't want to lay hands on disks we did not create.
 			if isValidVolume(disk.Name) {
 				volumes = append(volumes, disk.Name)
 			}

--- a/provider/gce/disks.go
+++ b/provider/gce/disks.go
@@ -295,6 +295,8 @@ func (v *volumeSource) ListVolumes() ([]string, error) {
 			continue
 		}
 		for _, disk := range disks {
+			// Blank disk description means an older disk or a disk
+			// not created by storage, we should not touch it.
 			if disk.Description != v.envUUID && disk.Description != "" {
 				continue
 			}

--- a/provider/gce/disks.go
+++ b/provider/gce/disks.go
@@ -199,6 +199,7 @@ func (v *volumeSource) createOneVolume(p storage.VolumeParams, instances instanc
 		SizeHintGB:         mibToGib(p.Size),
 		Name:               volumeName,
 		PersistentDiskType: persistentType,
+		Description:        v.envUUID,
 	}
 
 	gceDisks, err := v.gce.CreateDisks(zone, []google.DiskSpec{disk})
@@ -263,6 +264,12 @@ func parseVolumeId(volName string) (string, string, error) {
 	return zone, volumeUUID, nil
 
 }
+
+func isValidVolume(volumeName string) bool {
+	_, _, err := parseVolumeId(volumeName)
+	return err == nil
+}
+
 func (v *volumeSource) destroyOneVolume(volName string) error {
 	zone, _, err := parseVolumeId(volName)
 	if err != nil {
@@ -272,7 +279,6 @@ func (v *volumeSource) destroyOneVolume(volName string) error {
 		return errors.Annotatef(err, "cannot destroy volume %q", volName)
 	}
 	return nil
-
 }
 
 func (v *volumeSource) ListVolumes() ([]string, error) {
@@ -289,7 +295,13 @@ func (v *volumeSource) ListVolumes() ([]string, error) {
 			continue
 		}
 		for _, disk := range disks {
-			volumes = append(volumes, disk.Name)
+			if disk.Description != v.envUUID && disk.Description != "" {
+				continue
+			}
+			// We don't want tolay hads on disks we did not create.
+			if isValidVolume(disk.Name) {
+				volumes = append(volumes, disk.Name)
+			}
 		}
 	}
 	return volumes, nil

--- a/provider/gce/disks_test.go
+++ b/provider/gce/disks_test.go
@@ -197,6 +197,54 @@ func (s *volumeSourceSuite) TestListVolumes(c *gc.C) {
 	c.Assert(call[0].ZoneName, gc.Equals, "home-zone")
 }
 
+func (s *volumeSourceSuite) TestListVolumesOnlyListsCurrentEnvUUID(c *gc.C) {
+	otherDisk := &google.Disk{
+		Id:          1234568,
+		Name:        "home-zone--566fe7b2-c026-4a86-a2cc-84cb7f9a4868",
+		Zone:        "home-zone",
+		Status:      google.StatusReady,
+		Size:        1024,
+		Description: "a-different-env-uuid",
+	}
+	s.FakeConn.GoogleDisks = []*google.Disk{s.BaseDisk, otherDisk}
+	s.FakeConn.Zones = []google.AvailabilityZone{google.NewZone("home-zone", "Ready", "", "")}
+	vols, err := s.source.ListVolumes()
+	c.Check(err, jc.ErrorIsNil)
+	c.Assert(vols, gc.HasLen, 1)
+}
+
+func (s *volumeSourceSuite) TestListVolumesListsEmptyUUIDVolumes(c *gc.C) {
+	otherDisk := &google.Disk{
+		Id:          1234568,
+		Name:        "home-zone--566fe7b2-c026-4a86-a2cc-84cb7f9a4868",
+		Zone:        "home-zone",
+		Status:      google.StatusReady,
+		Size:        1024,
+		Description: "",
+	}
+	s.FakeConn.GoogleDisks = []*google.Disk{s.BaseDisk, otherDisk}
+	s.FakeConn.Zones = []google.AvailabilityZone{google.NewZone("home-zone", "Ready", "", "")}
+	vols, err := s.source.ListVolumes()
+	c.Check(err, jc.ErrorIsNil)
+	c.Assert(vols, gc.HasLen, 2)
+}
+
+func (s *volumeSourceSuite) TestListVolumesIgnoresNamesFormatteDifferently(c *gc.C) {
+	otherDisk := &google.Disk{
+		Id:          1234568,
+		Name:        "juju-566fe7b2-c026-4a86-a2cc-84cb7f9a4868",
+		Zone:        "home-zone",
+		Status:      google.StatusReady,
+		Size:        1024,
+		Description: "",
+	}
+	s.FakeConn.GoogleDisks = []*google.Disk{s.BaseDisk, otherDisk}
+	s.FakeConn.Zones = []google.AvailabilityZone{google.NewZone("home-zone", "Ready", "", "")}
+	vols, err := s.source.ListVolumes()
+	c.Check(err, jc.ErrorIsNil)
+	c.Assert(vols, gc.HasLen, 1)
+}
+
 func (s *volumeSourceSuite) TestDescribeVolumes(c *gc.C) {
 	s.FakeConn.GoogleDisk = s.BaseDisk
 	volName := "home-zone--c930380d-8337-4bf5-b07a-9dbb5ae771e4"

--- a/provider/gce/environ_broker.go
+++ b/provider/gce/environ_broker.go
@@ -183,7 +183,7 @@ func (env *environ) newRawInstance(args environs.StartInstanceParams, spec *inst
 	cfg := env.Config()
 	eUUID, ok := cfg.UUID()
 	if !ok {
-		return nil, errors.NotFoundf("cannot find UUID necessary to create the instance disk")
+		return nil, errors.NotFoundf("UUID necessary to create the instance disk")
 	}
 
 	disks, err := getDisks(spec, args.Constraints, args.InstanceConfig.Series, eUUID)

--- a/provider/gce/environ_broker_test.go
+++ b/provider/gce/environ_broker_test.go
@@ -205,7 +205,7 @@ var getDisksTests = []struct {
 
 func (s *environBrokerSuite) TestGetDisks(c *gc.C) {
 	for _, test := range getDisksTests {
-		diskSpecs, err := gce.GetDisks(s.spec, s.StartInstArgs.Constraints, test.Series)
+		diskSpecs, err := gce.GetDisks(s.spec, s.StartInstArgs.Constraints, test.Series, "32f7d570-5bac-4b72-b169-250c24a94b2b")
 		if test.error != nil {
 			c.Assert(err, gc.Equals, err)
 		} else {

--- a/provider/gce/google/disk.go
+++ b/provider/gce/google/disk.go
@@ -108,6 +108,11 @@ type DiskSpec struct {
 	Name string
 	// Description holds a description of the disk, it currently holds
 	// envUUID.
+	// This field is used instead of a tag or metadata because, at the moment of writing
+	// this feature, compute (v1) API does not support any way to add extra data
+	// to disks.
+	// Description was picked because it is not mutable (actually no field is) for disks.
+	// There is a metadata API but it is not supported for disks for the moment.
 	Description string
 }
 

--- a/provider/gce/google/disk.go
+++ b/provider/gce/google/disk.go
@@ -106,6 +106,9 @@ type DiskSpec struct {
 	// characters must be a dash, lowercase letter, or digit, except the
 	// last character, which cannot be a dash.
 	Name string
+	// Description holds a description of the disk, it currently holds
+	// envUUID.
+	Description string
 }
 
 // TooSmall checks the spec's size hint and indicates whether or not
@@ -172,6 +175,7 @@ func (ds *DiskSpec) newDetached() (*compute.Disk, error) {
 		SizeGb:      int64(ds.SizeGB()),
 		SourceImage: ds.ImageURL,
 		Type:        string(ds.PersistentDiskType),
+		Description: ds.Description,
 	}, nil
 }
 
@@ -194,6 +198,8 @@ type Disk struct {
 	Id uint64
 	// Name is a unique identifier string for each disk.
 	Name string
+	// Description holds the description field for a disk, we store env UUID here.
+	Description string
 	// Size is the size in mbit.
 	Size uint64
 	// Type is one of the available disk types supported by
@@ -207,12 +213,13 @@ type Disk struct {
 
 func NewDisk(cd *compute.Disk) *Disk {
 	d := &Disk{
-		Id:     cd.Id,
-		Name:   cd.Name,
-		Size:   gibToMib(cd.SizeGb),
-		Type:   DiskType(cd.Type),
-		Zone:   cd.Zone,
-		Status: DiskStatus(cd.Status),
+		Id:          cd.Id,
+		Name:        cd.Name,
+		Description: cd.Description,
+		Size:        gibToMib(cd.SizeGb),
+		Type:        DiskType(cd.Type),
+		Zone:        cd.Zone,
+		Status:      DiskStatus(cd.Status),
 	}
 	return d
 }

--- a/provider/gce/testing_test.go
+++ b/provider/gce/testing_test.go
@@ -165,13 +165,17 @@ func (s *BaseSuiteUnpatched) initInst(c *gc.C) {
 	}
 
 	s.InstanceType = allInstanceTypes[0]
+
 	// Storage
+	eUUID, ok := s.Env.Config().UUID()
+	c.Check(ok, jc.IsTrue)
 	s.BaseDisk = &google.Disk{
-		Id:     1234567,
-		Name:   "home-zone--c930380d-8337-4bf5-b07a-9dbb5ae771e4",
-		Zone:   "home-zone",
-		Status: google.StatusReady,
-		Size:   1024,
+		Id:          1234567,
+		Name:        "home-zone--c930380d-8337-4bf5-b07a-9dbb5ae771e4",
+		Zone:        "home-zone",
+		Status:      google.StatusReady,
+		Size:        1024,
+		Description: eUUID,
 	}
 }
 


### PR DESCRIPTION
GCE Disks don't have a way to be tagged or support any other API
exported metadata.
To support UUID tagging we are using the Description field, since the
API does not support modification of said field we don't risk user
breaking it.
This could change if the metadata API grows a library or if disks start
supporting tags or other metadata form.

(Review request: http://reviews.vapour.ws/r/3392/)