### PR TITLE
worker/instancepoller: Allow aggregator shutdown when request is being handled

### DIFF
--- a/worker/instancepoller/aggregate.go
+++ b/worker/instancepoller/aggregate.go
@@ -93,7 +93,11 @@ func (a *aggregator) loop() error {
 				} else {
 					reply.info, reply.err = a.instInfo(req.instId, insts[i])
 				}
-				req.reply <- reply
+				select {
+				case <-a.tomb.Dying():
+					return tomb.ErrDying
+				case req.reply <- reply:
+				}
 			}
 			reqs = nil
 		}


### PR DESCRIPTION
A recent change introduced the ability of requests to the aggregator to be aborted when the tomb is killed. This means that sometimes when a request is sent, the reply channel is never read.

The code handling the other end of the channel wasn't changed in the same way. There was still a naked channel write to the reply channel meaning that the aggregator could sometimes fail to shut down. This revision adds removed the naked write, ensuring that the tomb's Dying channel is also checked there.

(Review request: http://reviews.vapour.ws/r/3393/)