### PR TITLE
state: pre-validate "juju deploy ... --to <N>"

### DIFF
--- a/state/assign_test.go
+++ b/state/assign_test.go
@@ -283,6 +283,16 @@ func (s *AssignSuite) TestAssignMachineWhenDying(c *gc.C) {
 	testWhenDying(c, machine, expect, expect, assignTest)
 }
 
+func (s *AssignSuite) TestAssignMachineDifferentSeries(c *gc.C) {
+	machine, err := s.State.AddMachine("trusty", state.JobHostUnits)
+	c.Assert(err, jc.ErrorIsNil)
+	unit, err := s.wordpress.AddUnit()
+	c.Assert(err, jc.ErrorIsNil)
+	err = unit.AssignToMachine(machine)
+	c.Assert(err, gc.ErrorMatches,
+		`cannot assign unit "wordpress/0" to machine 0: series does not match`)
+}
+
 func (s *AssignSuite) TestPrincipals(c *gc.C) {
 	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -1940,6 +1940,20 @@ func (s *StateSuite) TestAddServiceNonExistentUser(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `cannot add service "wordpress": environment user "notAuser@local" not found`)
 }
 
+func (s *StateSuite) TestAddServiceMachinePlacementInvalidSeries(c *gc.C) {
+	m, err := s.State.AddMachine("trusty", state.JobHostUnits)
+	c.Assert(err, jc.ErrorIsNil)
+
+	charm := s.AddTestingCharm(c, "dummy")
+	_, err = s.State.AddService(state.AddServiceArgs{
+		Name: "wordpress", Owner: s.Owner.String(), Charm: charm,
+		Placement: []*instance.Placement{
+			{instance.MachineScope, m.Id()},
+		},
+	})
+	c.Assert(err, gc.ErrorMatches, "cannot add service \"wordpress\": cannot deploy to machine .*: series does not match")
+}
+
 func (s *StateSuite) TestAllServices(c *gc.C) {
 	charm := s.AddTestingCharm(c, "dummy")
 	services, err := s.State.AllServices()

--- a/state/unit.go
+++ b/state/unit.go
@@ -1163,44 +1163,26 @@ func (u *Unit) assignToMachineOps(m *Machine, unused bool) ([]txn.Op, error) {
 	if u.Life() != Alive {
 		return nil, unitNotAliveErr
 	}
-	if m.Life() != Alive {
-		return nil, machineNotAliveErr
-	}
-	if u.doc.Series != m.doc.Series {
-		return nil, fmt.Errorf("series does not match")
-	}
 	if u.doc.MachineId != "" {
 		if u.doc.MachineId != m.Id() {
 			return nil, alreadyAssignedErr
 		}
 		return nil, jujutxn.ErrNoOperations
 	}
-	if u.doc.Principal != "" {
-		return nil, fmt.Errorf("unit is a subordinate")
-	}
 	if unused && !m.doc.Clean {
 		return nil, inUseErr
-	}
-	canHost := false
-	for _, j := range m.doc.Jobs {
-		if j == JobHostUnits {
-			canHost = true
-			break
-		}
-	}
-	if !canHost {
-		return nil, fmt.Errorf("machine %q cannot host units", m)
-	}
-	// assignToMachine implies assignment to an existing machine,
-	// which is only permitted if unit placement is supported.
-	if err := u.st.supportsUnitPlacement(); err != nil {
-		return nil, err
 	}
 	storageParams, err := u.machineStorageParams()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	if err := validateDynamicMachineStorageParams(m, storageParams); err != nil {
+	storagePools, err := machineStoragePools(m.st, storageParams)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if err := validateUnitMachineAssignment(
+		m, u.doc.Series, u.doc.Principal != "", storagePools,
+	); err != nil {
 		return nil, errors.Trace(err)
 	}
 	storageOps, volumesAttached, filesystemsAttached, err := u.st.machineStorageOps(
@@ -1247,10 +1229,105 @@ func (u *Unit) assignToMachineOps(m *Machine, unused bool) ([]txn.Op, error) {
 	return ops, nil
 }
 
+func validateUnitMachineAssignment(
+	m *Machine,
+	series string,
+	isSubordinate bool,
+	storagePools set.Strings,
+) (err error) {
+	if m.Life() != Alive {
+		return machineNotAliveErr
+	}
+	if isSubordinate {
+		return fmt.Errorf("unit is a subordinate")
+	}
+	if series != m.doc.Series {
+		return fmt.Errorf("series does not match")
+	}
+	canHost := false
+	for _, j := range m.doc.Jobs {
+		if j == JobHostUnits {
+			canHost = true
+			break
+		}
+	}
+	if !canHost {
+		return fmt.Errorf("machine %q cannot host units", m)
+	}
+	if err := m.st.supportsUnitPlacement(); err != nil {
+		return errors.Trace(err)
+	}
+	if err := validateDynamicMachineStoragePools(m, storagePools); err != nil {
+		return errors.Trace(err)
+	}
+	return nil
+}
+
 // validateDynamicMachineStorageParams validates that the provided machine
 // storage parameters are compatible with the specified machine.
 func validateDynamicMachineStorageParams(m *Machine, params *machineStorageParams) error {
-	if len(params.volumes)+len(params.filesystems)+len(params.volumeAttachments)+len(params.filesystemAttachments) == 0 {
+	pools, err := machineStoragePools(m.st, params)
+	if err != nil {
+		return err
+	}
+	return validateDynamicMachineStoragePools(m, pools)
+}
+
+func machineStoragePools(st *State, params *machineStorageParams) (set.Strings, error) {
+	pools := make(set.Strings)
+	for _, v := range params.volumes {
+		v, err := st.volumeParamsWithDefaults(v.Volume)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		pools.Add(v.Pool)
+	}
+	for _, f := range params.filesystems {
+		f, err := st.filesystemParamsWithDefaults(f.Filesystem)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		pools.Add(f.Pool)
+	}
+	for volumeTag := range params.volumeAttachments {
+		volume, err := st.Volume(volumeTag)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		if params, ok := volume.Params(); ok {
+			pools.Add(params.Pool)
+		} else {
+			info, err := volume.Info()
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			pools.Add(info.Pool)
+		}
+	}
+	for filesystemTag := range params.filesystemAttachments {
+		filesystem, err := st.Filesystem(filesystemTag)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		if params, ok := filesystem.Params(); ok {
+			pools.Add(params.Pool)
+		} else {
+			info, err := filesystem.Info()
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			pools.Add(info.Pool)
+		}
+	}
+	return pools, nil
+}
+
+// validateDynamicMachineStoragePools validates that all storage providers
+// required for provisioning the storage in params support dynamic storage.
+// If any provider doesn't support dynamic storage, then an IsNotSupported
+// error is returned.
+func validateDynamicMachineStoragePools(m *Machine, pools set.Strings) error {
+	if pools.IsEmpty() {
 		return nil
 	}
 	if m.ContainerType() != "" {
@@ -1264,85 +1341,41 @@ func validateDynamicMachineStorageParams(m *Machine, params *machineStorageParam
 		// to be restarted to pick up new configuration.
 		return errors.NotSupportedf("adding storage to %s container", m.ContainerType())
 	}
-	if err := validateDynamicStorageParams(m.st, params); err != nil {
-		return errors.Trace(err)
-	}
-	return nil
+	return validateDynamicStoragePools(m.st, pools)
 }
 
-// validateDynamicStorageParams validates that all storage providers required for
-// provisioning the storage in params support dynamic storage.
-// If any provider doesn't support dynamic storage, then an IsNotSupported error
-// is returned.
-func validateDynamicStorageParams(st *State, params *machineStorageParams) error {
-	pools := make(set.Strings)
-	for _, v := range params.volumes {
-		v, err := st.volumeParamsWithDefaults(v.Volume)
-		if err != nil {
-			return errors.Trace(err)
-		}
-		pools.Add(v.Pool)
-	}
-	for _, f := range params.filesystems {
-		f, err := st.filesystemParamsWithDefaults(f.Filesystem)
-		if err != nil {
-			return errors.Trace(err)
-		}
-		pools.Add(f.Pool)
-	}
-	for volumeTag := range params.volumeAttachments {
-		volume, err := st.Volume(volumeTag)
-		if err != nil {
-			return errors.Trace(err)
-		}
-		if params, ok := volume.Params(); ok {
-			pools.Add(params.Pool)
-		} else {
-			info, err := volume.Info()
-			if err != nil {
-				return errors.Trace(err)
-			}
-			pools.Add(info.Pool)
-		}
-	}
-	for filesystemTag := range params.filesystemAttachments {
-		filesystem, err := st.Filesystem(filesystemTag)
-		if err != nil {
-			return errors.Trace(err)
-		}
-		if params, ok := filesystem.Params(); ok {
-			pools.Add(params.Pool)
-		} else {
-			info, err := filesystem.Info()
-			if err != nil {
-				return errors.Trace(err)
-			}
-			pools.Add(info.Pool)
-		}
-	}
+// validateDynamicStoragePools validates that all storage providers required
+// for provisioning the storage in params support dynamic storage. If any
+// provider doesn't support dynamic storage, then an IsNotSupported error is
+// returned.
+func validateDynamicStoragePools(st *State, pools set.Strings) error {
 	for pool := range pools {
 		providerType, provider, err := poolStorageProvider(st, pool)
 		if err != nil {
 			return errors.Trace(err)
 		}
 		if !provider.Dynamic() {
-			return errors.NewNotSupported(
-				err,
-				fmt.Sprintf("%q storage provider does not support dynamic storage", providerType))
+			return errors.NewNotSupported(err, fmt.Sprintf(
+				"%q storage provider does not support dynamic storage",
+				providerType,
+			))
 		}
 	}
 	return nil
 }
 
-func assignContextf(err *error, unit *Unit, target string) {
+func assignContextf(err *error, unitName string, target string) {
 	if *err != nil {
-		*err = fmt.Errorf("cannot assign unit %q to %s: %v", unit, target, *err)
+		*err = errors.Annotatef(*err,
+			"cannot assign unit %q to %s",
+			unitName, target,
+		)
 	}
 }
 
 // AssignToMachine assigns this unit to a given machine.
 func (u *Unit) AssignToMachine(m *Machine) (err error) {
-	defer assignContextf(&err, u, fmt.Sprintf("machine %s", m))
+	defer assignContextf(&err, u.Name(), fmt.Sprintf("machine %s", m))
 	return u.assignToMachine(m, false)
 }
 
@@ -1465,7 +1498,7 @@ func (u *Unit) Constraints() (*constraints.Value, error) {
 // on which to create the container. An existing clean, empty instance
 // is first searched for, and if not found, a new one is created.
 func (u *Unit) AssignToNewMachineOrContainer() (err error) {
-	defer assignContextf(&err, u, "new machine or container")
+	defer assignContextf(&err, u.Name(), "new machine or container")
 	if u.doc.Principal != "" {
 		return fmt.Errorf("unit is a subordinate")
 	}
@@ -1523,7 +1556,7 @@ func (u *Unit) AssignToNewMachineOrContainer() (err error) {
 // determined according to the service and environment constraints at the
 // time of unit creation.
 func (u *Unit) AssignToNewMachine() (err error) {
-	defer assignContextf(&err, u, "new machine")
+	defer assignContextf(&err, u.Name(), "new machine")
 	if u.doc.Principal != "" {
 		return fmt.Errorf("unit is a subordinate")
 	}
@@ -1849,7 +1882,7 @@ func (u *Unit) assignToCleanMaybeEmptyMachine(requireEmpty bool) (m *Machine, er
 
 	if u.doc.Principal != "" {
 		err = fmt.Errorf("unit is a subordinate")
-		assignContextf(&err, u, context)
+		assignContextf(&err, u.Name(), context)
 		return nil, err
 	}
 
@@ -1857,26 +1890,31 @@ func (u *Unit) assignToCleanMaybeEmptyMachine(requireEmpty bool) (m *Machine, er
 	// to a new machine is required.
 	storageParams, err := u.machineStorageParams()
 	if err != nil {
-		assignContextf(&err, u, context)
+		assignContextf(&err, u.Name(), context)
 		return nil, err
 	}
-	if err := validateDynamicStorageParams(u.st, storageParams); err != nil {
+	storagePools, err := machineStoragePools(u.st, storageParams)
+	if err != nil {
+		assignContextf(&err, u.Name(), context)
+		return nil, err
+	}
+	if err := validateDynamicStoragePools(u.st, storagePools); err != nil {
 		if errors.IsNotSupported(err) {
 			return nil, noCleanMachines
 		}
-		assignContextf(&err, u, context)
+		assignContextf(&err, u.Name(), context)
 		return nil, err
 	}
 
 	// Get the unit constraints to see what deployment requirements we have to adhere to.
 	cons, err := u.Constraints()
 	if err != nil {
-		assignContextf(&err, u, context)
+		assignContextf(&err, u.Name(), context)
 		return nil, err
 	}
 	query, err := u.findCleanMachineQuery(requireEmpty, cons)
 	if err != nil {
-		assignContextf(&err, u, context)
+		assignContextf(&err, u.Name(), context)
 		return nil, err
 	}
 
@@ -1888,7 +1926,7 @@ func (u *Unit) assignToCleanMaybeEmptyMachine(requireEmpty bool) (m *Machine, er
 	defer closer()
 	var mdocs []*machineDoc
 	if err := machinesCollection.Find(query).All(&mdocs); err != nil {
-		assignContextf(&err, u, context)
+		assignContextf(&err, u.Name(), context)
 		return nil, err
 	}
 	var unprovisioned []*Machine
@@ -1900,7 +1938,7 @@ func (u *Unit) assignToCleanMaybeEmptyMachine(requireEmpty bool) (m *Machine, er
 		if errors.IsNotProvisioned(err) {
 			unprovisioned = append(unprovisioned, m)
 		} else if err != nil {
-			assignContextf(&err, u, context)
+			assignContextf(&err, u.Name(), context)
 			return nil, err
 		} else {
 			instances = append(instances, instance)
@@ -1916,7 +1954,7 @@ func (u *Unit) assignToCleanMaybeEmptyMachine(requireEmpty bool) (m *Machine, er
 	// The partition of provisioned/unprovisioned machines
 	// must be maintained.
 	if instances, err = distributeUnit(u, instances); err != nil {
-		assignContextf(&err, u, context)
+		assignContextf(&err, u.Name(), context)
 		return nil, err
 	}
 	machines := make([]*Machine, len(instances), len(instances)+len(unprovisioned))
@@ -1924,7 +1962,7 @@ func (u *Unit) assignToCleanMaybeEmptyMachine(requireEmpty bool) (m *Machine, er
 		m, ok := instanceMachines[instance]
 		if !ok {
 			err := fmt.Errorf("invalid instance returned: %v", instance)
-			assignContextf(&err, u, context)
+			assignContextf(&err, u.Name(), context)
 			return nil, err
 		}
 		machines[i] = m
@@ -1945,15 +1983,17 @@ func (u *Unit) assignToCleanMaybeEmptyMachine(requireEmpty bool) (m *Machine, er
 			if errors.IsNotSupported(err) {
 				continue
 			}
-			assignContextf(&err, u, context)
+			assignContextf(&err, u.Name(), context)
 			return nil, err
 		}
 		err := u.assignToMachine(m, true)
 		if err == nil {
 			return m, nil
 		}
-		if err != inUseErr && err != machineNotAliveErr {
-			assignContextf(&err, u, context)
+		switch errors.Cause(err) {
+		case inUseErr, machineNotAliveErr:
+		default:
+			assignContextf(&err, u.Name(), context)
 			return nil, err
 		}
 	}

--- a/state/unit.go
+++ b/state/unit.go
@@ -1229,6 +1229,8 @@ func (u *Unit) assignToMachineOps(m *Machine, unused bool) ([]txn.Op, error) {
 	return ops, nil
 }
 
+// validateUnitMachineAssignment validates the parameters for assigning a unit
+// to a specified machine.
 func validateUnitMachineAssignment(
 	m *Machine,
 	series string,
@@ -1273,6 +1275,8 @@ func validateDynamicMachineStorageParams(m *Machine, params *machineStorageParam
 	return validateDynamicMachineStoragePools(m, pools)
 }
 
+// machineStoragePools returns the names of storage pools in each of the
+// volume, filesystem and attachments in the machine storage parameters.
 func machineStoragePools(st *State, params *machineStorageParams) (set.Strings, error) {
 	pools := make(set.Strings)
 	for _, v := range params.volumes {
@@ -1322,10 +1326,9 @@ func machineStoragePools(st *State, params *machineStorageParams) (set.Strings, 
 	return pools, nil
 }
 
-// validateDynamicMachineStoragePools validates that all storage providers
-// required for provisioning the storage in params support dynamic storage.
-// If any provider doesn't support dynamic storage, then an IsNotSupported
-// error is returned.
+// validateDynamicMachineStoragePools validates that all of the specified
+// storage pools support dynamic storage provisioning. If any provider doesn't
+// support dynamic storage, then an IsNotSupported error is returned.
 func validateDynamicMachineStoragePools(m *Machine, pools set.Strings) error {
 	if pools.IsEmpty() {
 		return nil
@@ -1344,10 +1347,9 @@ func validateDynamicMachineStoragePools(m *Machine, pools set.Strings) error {
 	return validateDynamicStoragePools(m.st, pools)
 }
 
-// validateDynamicStoragePools validates that all storage providers required
-// for provisioning the storage in params support dynamic storage. If any
-// provider doesn't support dynamic storage, then an IsNotSupported error is
-// returned.
+// validateDynamicStoragePools validates that all of the specified storage
+// providers support dynamic storage provisioning. If any provider doesn't
+// support dynamic storage, then an IsNotSupported error is returned.
 func validateDynamicStoragePools(st *State, pools set.Strings) error {
 	for pool := range pools {
 		providerType, provider, err := poolStorageProvider(st, pool)


### PR DESCRIPTION
With the recent changes to assign units to
machines asynchronously, we now also validate
the parameters asynchronously, making for a
poor user experience. If we can determine
that an assignment cannot succeed, we should
reject the assignment immediately.

We change the state package to validate the
assignment parameters against existing machines
specified with "--to".

Fixes https://bugs.launchpad.net/juju-core/+bug/1524527

(Review request: http://reviews.vapour.ws/r/3394/)