### PR TITLE
state: reject deploying charm with invalid OS

### DIFF
--- a/state/state_test.go
+++ b/state/state_test.go
@@ -1954,6 +1954,39 @@ func (s *StateSuite) TestAddServiceMachinePlacementInvalidSeries(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "cannot add service \"wordpress\": cannot deploy to machine .*: series does not match")
 }
 
+func (s *StateSuite) TestAddServiceIncompatibleOSWithSeriesInURL(c *gc.C) {
+	charm := s.AddTestingCharm(c, "dummy")
+	// A charm with a series in its URL is implicitly supported by that
+	// series only.
+	_, err := s.State.AddService(state.AddServiceArgs{
+		Name: "wordpress", Owner: s.Owner.String(), Charm: charm,
+		Series: "centos7",
+	})
+	c.Assert(err, gc.ErrorMatches, "cannot add service \"wordpress\": series \"centos7\" \\(OS \"CentOS\"\\) not supported by charm")
+}
+
+func (s *StateSuite) TestAddServiceCompatibleOSWithSeriesInURL(c *gc.C) {
+	charm := s.AddTestingCharm(c, "dummy")
+	// A charm with a series in its URL is implicitly supported by that
+	// series only.
+	_, err := s.State.AddService(state.AddServiceArgs{
+		Name: "wordpress", Owner: s.Owner.String(), Charm: charm,
+		Series: charm.URL().Series,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *StateSuite) TestAddServiceOSIncompatibleWithSupportedSeries(c *gc.C) {
+	charm := state.AddTestingCharmMultiSeries(c, s.State, "multi-series")
+	// A charm with supported series can only be force-deployed to series
+	// of the same operating systems as the suppoted series.
+	_, err := s.State.AddService(state.AddServiceArgs{
+		Name: "wordpress", Owner: s.Owner.String(), Charm: charm,
+		Series: "centos7",
+	})
+	c.Assert(err, gc.ErrorMatches, "cannot add service \"wordpress\": series \"centos7\" \\(OS \"CentOS\"\\) not supported by charm")
+}
+
 func (s *StateSuite) TestAllServices(c *gc.C) {
 	charm := s.AddTestingCharm(c, "dummy")
 	services, err := s.State.AllServices()


### PR DESCRIPTION
If a charm specifies supported series, do not allow
deployment of the charm with series of operating
systems other than those of the supported series.

Fixes https://bugs.launchpad.net/juju-core/+bug/1526296

(Review request: http://reviews.vapour.ws/r/3396/)