### PR TITLE
maas: add a bridge to all active interfaces

### DIFF
--- a/cloudconfig/instancecfg/instancecfg.go
+++ b/cloudconfig/instancecfg/instancecfg.go
@@ -393,9 +393,13 @@ func (cfg *InstanceConfig) VerifyConfig() (err error) {
 // may create a folder containing logs
 var logDir = paths.MustSucceed(paths.LogDir(series.HostSeries()))
 
+// DefaultBridgePrefix is the prefix for all network bridge device
+// name used for LXC and KVM containers.
+const DefaultBridgePrefix = "juju-br-"
+
 // DefaultBridgeName is the network bridge device name used for LXC and KVM
 // containers
-const DefaultBridgeName = "juju-br0"
+const DefaultBridgeName = DefaultBridgePrefix + "eth0"
 
 // NewInstanceConfig sets up a basic machine configuration, for a
 // non-bootstrap node. You'll still need to supply more information,

--- a/provider/maas/Makefile
+++ b/provider/maas/Makefile
@@ -9,5 +9,8 @@ bridgescript.go: add-juju-bridge.py Makefile
 	cat add-juju-bridge.py >> $@
 	echo -n 'PYTHON_SCRIPT\n)`\n' >> $@
 
+format:
+	pyfmt -i add-juju-bridge.py
+
 clean:
 	$(RM) bridgescript.go

--- a/provider/maas/add-juju-bridge.py
+++ b/provider/maas/add-juju-bridge.py
@@ -3,6 +3,10 @@
 # Copyright 2015 Canonical Ltd.
 # Licensed under the AGPLv3, see LICENCE file for details.
 
+#
+# This file has been and should be formatted using pyfmt(1).
+#
+
 from __future__ import print_function
 import argparse
 import os
@@ -11,9 +15,6 @@ import shutil
 import subprocess
 import sys
 
-
-# This script re-renders an interfaces(5) file to enslave the primary
-# NIC with a bridge. It is aware of bond interfaces and aliases.
 
 class SeekableIterator(object):
     """An iterator that supports relative seeking."""
@@ -45,44 +46,136 @@ class SeekableIterator(object):
             raise IndexError
 
 
-class Stanza(object):
-    """Represents one stanza together with all its options."""
+class PhysicalInterface(object):
+    """Represents a physical ('auto') interface."""
+
+    def __init__(self, definition):
+        self.name = definition.split()[1]
+
+    def __str__(self):
+        return self.name
+
+
+class LogicalInterface(object):
+    """Represents a logical ('iface') interface."""
 
     def __init__(self, definition, options=None):
         if not options:
             options = []
-        self._definition = definition
-        self._options = options
+        _, self.name, self.family, self.method = definition.split()
+        self.options = options
+        self.is_bonded = [x for x in self.options if "bond-" in x]
+        self.is_alias = ":" in self.name
+        self.is_vlan = [x for x in self.options if x.startswith("vlan-raw-device")]
+        self.is_active = self.method == "dhcp" or self.method == "static"
 
-    def is_physical_interface(self):
-        return self._definition.startswith('auto ')
+    def __str__(self):
+        return self.name
 
-    def is_logical_interface(self):
-        return self._definition.startswith('iface ')
+    # Returns an ordered set of stanzas to bridge this interface.
+    def bridge(self, prefix, add_auto_stanza, active_interfaces):
+        # Note: the testing order here is significant.
+        if not self.is_active:
+            return self._bridge_inactive(add_auto_stanza)
+        elif self.is_alias:
+            return self._bridge_alias(add_auto_stanza)
+        elif self.is_vlan:
+            return self._bridge_vlan(prefix, add_auto_stanza, active_interfaces)
+        elif self.is_bonded:
+            return self._bridge_bond(prefix, add_auto_stanza)
+        else:
+            return self._bridge_device(prefix)
 
-    def options(self):
-        return self._options
+    def _bridge_device(self, prefix):
+        bridge_name = prefix + self.name
+        s1 = IfaceStanza(self.name, self.family, "manual", [])
+        s2 = AutoStanza(bridge_name)
+        options = list(self.options)
+        options.append("bridge_ports {}".format(self.name))
+        s3 = IfaceStanza(bridge_name, self.family, self.method, options)
+        return [s1, s2, s3]
 
-    def definition(self):
-        return self._definition
+    def _bridge_vlan(self, prefix, add_auto_stanza, active_interfaces):
+        stanzas = []
+        device = None
+        for o in self.options:
+            if o.startswith('vlan-raw-device'):
+                device = o.split()[1]
+                break
+        # Should vlans of inactive raw devices be bridged? If so
+        # remove the next two lines.
+        if device not in active_interfaces:
+            return self._bridge_inactive(add_auto_stanza)
+        s1 = IfaceStanza(self.name, self.family, "manual", self.options)
+        stanzas.append(s1)
+        bridge_name = prefix + self.name
+        if add_auto_stanza:
+            stanzas.append(AutoStanza(bridge_name))
+        options = [x for x in self.options if not x.startswith("vlan")]
+        options.append("bridge_ports {}".format(self.name))
+        s3 = IfaceStanza(bridge_name, self.family, self.method, options)
+        stanzas.append(s3)
+        return stanzas
 
-    def interface_name(self):
-        if self.is_physical_interface():
-            return self._definition.split()[1]
-        if self.is_logical_interface():
-            return self._definition.split()[1]
-        return None
+    def _bridge_alias(self, add_auto_stanza):
+        stanzas = []
+        if add_auto_stanza:
+            stanzas.append(AutoStanza(self.name))
+        s1 = IfaceStanza(self.name, self.family, self.method, list(self.options))
+        stanzas.append(s1)
+        return stanzas
+
+    def _bridge_bond(self, prefix, add_auto_stanza):
+        stanzas = []
+        bridge_name = prefix + self.name
+        if add_auto_stanza:
+            stanzas.append(AutoStanza(self.name))
+        s1 = IfaceStanza(self.name, self.family, "manual", list(self.options))
+        s2 = AutoStanza(bridge_name)
+        options = [x for x in self.options if not x.startswith("bond")]
+        options.append("bridge_ports {}".format(self.name))
+        s3 = IfaceStanza(bridge_name, self.family, self.method, options)
+        stanzas.extend([s1, s2, s3])
+        return stanzas
+
+    def _bridge_inactive(self, add_auto_stanza):
+        stanzas = []
+        if add_auto_stanza:
+            stanzas.append(AutoStanza(self.name))
+        s1 = IfaceStanza(self.name, self.family, self.method, list(self.options))
+        stanzas.append(s1)
+        return stanzas
+
+
+class Stanza(object):
+    """Represents one stanza together with all of its options."""
+
+    def __init__(self, definition, options=None):
+        if not options:
+            options = []
+        self.definition = definition
+        self.options = options
+        self.is_logical_interface = definition.startswith('iface ')
+        self.is_physical_interface = definition.startswith('auto ')
+        self.iface = None
+        self.phy = None
+        if self.is_logical_interface:
+            self.iface = LogicalInterface(definition, self.options)
+        if self.is_physical_interface:
+            self.phy = PhysicalInterface(definition)
+
+    def __str__(self):
+        return self.definition
 
 
 class NetworkInterfaceParser(object):
-    """Parse a network interface file into its set of stanzas."""
+    """Parse a network interface file into a set of stanzas."""
 
     @classmethod
     def is_stanza(cls, s):
         return re.match(r'^(iface|mapping|auto|allow-|source|dns-)', s)
 
     def __init__(self, filename):
-        self._filename = filename
         self._stanzas = []
         with open(filename) as f:
             lines = f.readlines()
@@ -107,95 +200,42 @@ class NetworkInterfaceParser(object):
     def stanzas(self):
         return [x for x in self._stanzas]
 
+    def physical_interfaces(self):
+        return {x.phy.name: x.phy for x in [y for y in self._stanzas if y.is_physical_interface]}
+
+    def logical_interfaces(self):
+        return {x.iface.name: x.iface for x in [y for y in self._stanzas if y.is_logical_interface]}
+
+    def active_interfaces(self):
+        return [x.name for x in self.logical_interfaces().values() if x.is_active]
+
+    def __iter__(self):  # class iter
+        for s in self._stanzas:
+            yield s
+
+
+def IfaceStanza(name, family, method, options):
+    # Convenience function to create a new "iface" stanza.
+    return Stanza("iface {} {} {}".format(name, family, method), options)
+
+
+def AutoStanza(name):
+    # Convenience function to create a new "auto" stanza.
+    return Stanza("auto {}".format(name))
+
 
 def print_stanza(s, stream=sys.stdout):
-    print(s.definition(), file=stream)
-    for o in s.options():
+    print(s.definition, file=stream)
+    for o in s.options:
         print("   ", o, file=stream)
 
 
 def print_stanzas(stanzas, stream=sys.stdout):
     n = len(stanzas)
-    for i, s in enumerate(stanzas):
-        print_stanza(s, stream)
-        if s.is_logical_interface() and i + 1 < n:
+    for i, stanza in enumerate(stanzas):
+        print_stanza(stanza, stream)
+        if stanza.is_logical_interface and i + 1 < n:
             print(file=stream)
-
-
-# Parses filename and returns a set of stanzas that have the existing
-# primary NIC bridged.
-def add_bridge(filename, bridge_name, primary_nic, bonded):
-    stanzas = []
-
-    for s in NetworkInterfaceParser(filename).stanzas():
-        if not s.is_logical_interface() and not s.is_physical_interface():
-            stanzas.append(s)
-            continue
-
-        if primary_nic != s.interface_name() and \
-                        primary_nic not in s.interface_name():
-            stanzas.append(s)
-            continue
-
-        if bonded:
-            if s.is_physical_interface():
-                stanzas.append(s)
-            else:
-                iface, orig_name, addr_family, method = s.definition().split()
-                stanzas.append(Stanza("iface {} {} manual".format(orig_name, addr_family), s.options()))
-
-                # new auto <bridge_name>
-                stanzas.append(Stanza("auto {}".format(bridge_name)))
-
-                # new iface <bridge_name> ...
-                options = [x for x in s.options() if not x.startswith("bond")]
-                options.insert(0, "bridge_ports {}".format(primary_nic))
-                options.append("pre-up ip link add dev {} name {} type bridge || true".format(orig_name, bridge_name))
-                stanzas.append(Stanza("iface {} {} {}".format(bridge_name, addr_family, method), options))
-            continue
-
-        if primary_nic == s.interface_name():
-            if s.is_physical_interface():
-                # The net change:
-                #   auto eth0
-                # to:
-                #   auto <bridge_name>
-                words = s.definition().split()
-                words[1] = bridge_name
-                stanzas.append(Stanza(" ".join(words)))
-            else:
-                # The net change is:
-                #   auto eth0
-                #   iface eth0 inet <config>
-                # to:
-                #   iface eth0 inet manual
-                #
-                #   auto <bridge_name>
-                #   iface <bridge_name> inet <config>
-                words = s.definition().split()
-                words[3] = "manual"
-                if len(stanzas) > 0:
-                    last_stanza = stanzas.pop()
-                else:
-                    last_stanza = None
-                stanzas.append(Stanza(" ".join(words)))
-                if last_stanza:
-                    stanzas.append(last_stanza)
-                # Replace existing 'iface' line with new <bridge_name>
-                words = s.definition().split()
-                words[1] = bridge_name
-                options = s.options()
-                options.insert(0, "bridge_ports {}".format(primary_nic))
-                stanzas.append(Stanza(" ".join(words), options))
-            continue
-
-        # Aliases, hence the 'eth0' in 'auto eth0:1'.
-
-        if primary_nic in s.definition():
-            definition = s.definition().replace(primary_nic, bridge_name)
-            stanzas.append(Stanza(definition, s.options()))
-
-    return stanzas
 
 
 def shell_cmd(s):
@@ -204,141 +244,82 @@ def shell_cmd(s):
     return [out, err, p.returncode]
 
 
-def print_shell_cmd(s, verbose=True, exitOnError=False):
-    if verbose: print(s)
+def print_shell_cmd(s, verbose=True, exit_on_error=False):
+    if verbose:
+        print(s)
     out, err, retcode = shell_cmd(s)
     if out and len(out) > 0:
-        print(out.rstrip(chr(10)))
+        print(out.rstrip('\n'))
     if err and len(err) > 0:
-        print(err.rstrip(chr(10)))
-    if exitOnError and retcode != 0:
-        sys.exit(1)
+        print(err.rstrip('\n'))
+    if exit_on_error and retcode != 0:
+        exit(1)
 
 
 def check_shell_cmd(s, verbose=False):
-    if verbose: print(s)
+    if verbose:
+        print(s)
     output = subprocess.check_output(s, shell=True, stderr=subprocess.STDOUT).strip().decode("utf-8")
-    if verbose: print(output.rstrip('\n'))
+    if verbose:
+        print(output.rstrip('\n'))
     return output
 
 
-def get_gateway(ver='-4'):
-    return check_shell_cmd("ip {} route list exact default | head -n1 | cut -d' ' -f3".format(ver))
+def arg_parser():
+    parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument('--bridge-prefix', help="bridge prefix", type=str, required=False, default='br-')
+    parser.add_argument('--one-time-backup', help='A one time backup of filename', action='store_true', default=True, required=False)
+    parser.add_argument('--activate', help='activate new configuration', action='store_true', default=False, required=False)
+    parser.add_argument('filename', help="interfaces(5) based filename")
+    return parser
 
 
-def get_primary_nic(ver='-4'):
-    return check_shell_cmd("ip {} route list exact default | head -n1 | cut -d' ' -f5".format(ver))
+def main(args):
+    stanzas = []
+    config_parser = NetworkInterfaceParser(args.filename)
+    physical_interfaces = config_parser.physical_interfaces()
+    active_interfaces = config_parser.active_interfaces()
 
+    for s in config_parser.stanzas():
+        if s.is_logical_interface:
+            add_auto_stanza = s.iface.name in physical_interfaces
+            bridged_stanzas = s.iface.bridge(args.bridge_prefix, add_auto_stanza, active_interfaces)
+            stanzas.extend(bridged_stanzas)
+        elif not s.is_physical_interface:
+            stanzas.append(s)
 
-def is_nic_bonded(name):
-    out, err, retcode = shell_cmd("cat {}".format("/sys/class/net/bonding_masters"))
-    return name in out
+    if not args.activate:
+        print_stanzas(stanzas)
+        exit(0)
 
+    if args.one_time_backup:
+        backup_file = "{}-before-add-juju-bridge".format(args.filename)
+        if not os.path.isfile(backup_file):
+            shutil.copy2(args.filename, backup_file)
 
-def is_bridged(name, filename):
-    for s in NetworkInterfaceParser(filename).stanzas():
-        if name in s.definition():
-            return True
-    return False
+    ifquery = "$(ifquery -i {} --exclude=lo -l)".format(args.filename)
 
+    print("**** Original configuration")
+    print_shell_cmd("cat {}".format(args.filename))
+    print_shell_cmd("ifconfig -a")
+    print_shell_cmd("ifdown --exclude=lo -i {} {}".format(args.filename, ifquery))
 
-def link_is_up(name):
-    out, err, retcode = shell_cmd('ip link show {} up'.format(name))
-    return re.search(r'\s+{}:\s+.*\s+state\s+UP\s+'.format(name), out)
+    print("**** Activating new configuration")
 
+    with open(args.filename, 'w') as f:
+        print_stanzas(stanzas, f)
+        f.close()
 
-def ifup(name, retries=5):
-    if retries < 1:
-        retries = 1
-    i = 1
-    while i <= retries:
-        print("link {} not up, attempt ({}/{})".format(name, i, retries))
-        print_shell_cmd("ifdown -v -a")
-        print_shell_cmd("ifup -v -a")
-        if link_is_up(name):
-            return True
-        print_shell_cmd("ip link")
-        i += 1
-    return False
+    print_shell_cmd("cat {}".format(args.filename))
+    print_shell_cmd("ifup --exclude=lo -i {} {}".format(args.filename, ifquery))
+    print_shell_cmd("ip link show up")
+    print_shell_cmd("ifconfig -a")
+    print_shell_cmd("ip route show")
+    print_shell_cmd("brctl show")
 
+# This script re-renders an interfaces(5) file to add a bridge to all
+# active interfaces; active interfaces are those that are declared as
+# either 'static' or 'dhcp'.
 
-parser = argparse.ArgumentParser()
-
-parser.add_argument('--filename',
-                    help='filename to re-render',
-                    type=str,
-                    required=False,
-                    default="/etc/network/interfaces")
-
-parser.add_argument('--bridge-name',
-                    help="bridge name",
-                    type=str,
-                    required=False,
-                    default='juju-br0')
-
-parser.add_argument('--primary-nic',
-                    help="primary NIC name",
-                    type=str,
-                    required=False)
-
-parser.add_argument('--primary-nic-is-bonded',
-                    help="primary NIC is bonded",
-                    action='store_true',
-                    required=False)
-
-parser.add_argument('--render-only',
-                    help='render to stdout, no network restart',
-                    action='store_true',
-                    required=False)
-
-parser.add_argument('--backup-filename',
-                    help='backup filename',
-                    type=str,
-                    required=False)
-
-args = parser.parse_args()
-
-if is_bridged(args.bridge_name, args.filename):
-    print("already bridged; nothing to do")
-    sys.exit(0)
-
-if not args.primary_nic:
-    args.primary_nic = get_primary_nic()
-
-if not args.primary_nic_is_bonded:
-    args.primary_nic_is_bonded = is_nic_bonded(args.primary_nic)
-
-bridged_stanzas = add_bridge(args.filename,
-                             args.bridge_name,
-                             args.primary_nic,
-                             args.primary_nic_is_bonded)
-
-if args.render_only:
-    print_stanzas(bridged_stanzas)
-    sys.exit(0)
-
-if not get_gateway():
-    print("no default gw; continue continue")
-    sys.exit(1)
-
-if args.backup_filename and not os.path.isfile(args.backup_filename):
-    shutil.copy2(args.filename, args.backup_filename)
-
-print("**** Original configuration")
-print_shell_cmd("cat {}".format(args.filename))
-print_shell_cmd("ifconfig -a")
-print_shell_cmd("ip route show")
-print_shell_cmd("ifdown -v -a")
-
-print("**** Activating new configuration")
-
-with open(args.filename, 'w') as f:
-    print_stanzas(bridged_stanzas, f)
-    f.close()
-
-if not ifup(args.bridge_name):
-    sys.exit(1)
-
-print_shell_cmd("ifconfig -a")
-print_shell_cmd("ip route show")
-print_shell_cmd("brctl show")
+if __name__ == '__main__':
+    main(arg_parser().parse_args())

--- a/provider/maas/bridgescript.go
+++ b/provider/maas/bridgescript.go
@@ -10,6 +10,10 @@ const bridgeScriptPythonBashDef = `python_script=$(cat <<'PYTHON_SCRIPT'
 # Copyright 2015 Canonical Ltd.
 # Licensed under the AGPLv3, see LICENCE file for details.
 
+#
+# This file has been and should be formatted using pyfmt(1).
+#
+
 from __future__ import print_function
 import argparse
 import os
@@ -18,9 +22,6 @@ import shutil
 import subprocess
 import sys
 
-
-# This script re-renders an interfaces(5) file to enslave the primary
-# NIC with a bridge. It is aware of bond interfaces and aliases.
 
 class SeekableIterator(object):
     """An iterator that supports relative seeking."""
@@ -52,44 +53,136 @@ class SeekableIterator(object):
             raise IndexError
 
 
-class Stanza(object):
-    """Represents one stanza together with all its options."""
+class PhysicalInterface(object):
+    """Represents a physical ('auto') interface."""
+
+    def __init__(self, definition):
+        self.name = definition.split()[1]
+
+    def __str__(self):
+        return self.name
+
+
+class LogicalInterface(object):
+    """Represents a logical ('iface') interface."""
 
     def __init__(self, definition, options=None):
         if not options:
             options = []
-        self._definition = definition
-        self._options = options
+        _, self.name, self.family, self.method = definition.split()
+        self.options = options
+        self.is_bonded = [x for x in self.options if "bond-" in x]
+        self.is_alias = ":" in self.name
+        self.is_vlan = [x for x in self.options if x.startswith("vlan-raw-device")]
+        self.is_active = self.method == "dhcp" or self.method == "static"
 
-    def is_physical_interface(self):
-        return self._definition.startswith('auto ')
+    def __str__(self):
+        return self.name
 
-    def is_logical_interface(self):
-        return self._definition.startswith('iface ')
+    # Returns an ordered set of stanzas to bridge this interface.
+    def bridge(self, prefix, add_auto_stanza, active_interfaces):
+        # Note: the testing order here is significant.
+        if not self.is_active:
+            return self._bridge_inactive(add_auto_stanza)
+        elif self.is_alias:
+            return self._bridge_alias(add_auto_stanza)
+        elif self.is_vlan:
+            return self._bridge_vlan(prefix, add_auto_stanza, active_interfaces)
+        elif self.is_bonded:
+            return self._bridge_bond(prefix, add_auto_stanza)
+        else:
+            return self._bridge_device(prefix)
 
-    def options(self):
-        return self._options
+    def _bridge_device(self, prefix):
+        bridge_name = prefix + self.name
+        s1 = IfaceStanza(self.name, self.family, "manual", [])
+        s2 = AutoStanza(bridge_name)
+        options = list(self.options)
+        options.append("bridge_ports {}".format(self.name))
+        s3 = IfaceStanza(bridge_name, self.family, self.method, options)
+        return [s1, s2, s3]
 
-    def definition(self):
-        return self._definition
+    def _bridge_vlan(self, prefix, add_auto_stanza, active_interfaces):
+        stanzas = []
+        device = None
+        for o in self.options:
+            if o.startswith('vlan-raw-device'):
+                device = o.split()[1]
+                break
+        # Should vlans of inactive raw devices be bridged? If so
+        # remove the next two lines.
+        if device not in active_interfaces:
+            return self._bridge_inactive(add_auto_stanza)
+        s1 = IfaceStanza(self.name, self.family, "manual", self.options)
+        stanzas.append(s1)
+        bridge_name = prefix + self.name
+        if add_auto_stanza:
+            stanzas.append(AutoStanza(bridge_name))
+        options = [x for x in self.options if not x.startswith("vlan")]
+        options.append("bridge_ports {}".format(self.name))
+        s3 = IfaceStanza(bridge_name, self.family, self.method, options)
+        stanzas.append(s3)
+        return stanzas
 
-    def interface_name(self):
-        if self.is_physical_interface():
-            return self._definition.split()[1]
-        if self.is_logical_interface():
-            return self._definition.split()[1]
-        return None
+    def _bridge_alias(self, add_auto_stanza):
+        stanzas = []
+        if add_auto_stanza:
+            stanzas.append(AutoStanza(self.name))
+        s1 = IfaceStanza(self.name, self.family, self.method, list(self.options))
+        stanzas.append(s1)
+        return stanzas
+
+    def _bridge_bond(self, prefix, add_auto_stanza):
+        stanzas = []
+        bridge_name = prefix + self.name
+        if add_auto_stanza:
+            stanzas.append(AutoStanza(self.name))
+        s1 = IfaceStanza(self.name, self.family, "manual", list(self.options))
+        s2 = AutoStanza(bridge_name)
+        options = [x for x in self.options if not x.startswith("bond")]
+        options.append("bridge_ports {}".format(self.name))
+        s3 = IfaceStanza(bridge_name, self.family, self.method, options)
+        stanzas.extend([s1, s2, s3])
+        return stanzas
+
+    def _bridge_inactive(self, add_auto_stanza):
+        stanzas = []
+        if add_auto_stanza:
+            stanzas.append(AutoStanza(self.name))
+        s1 = IfaceStanza(self.name, self.family, self.method, list(self.options))
+        stanzas.append(s1)
+        return stanzas
+
+
+class Stanza(object):
+    """Represents one stanza together with all of its options."""
+
+    def __init__(self, definition, options=None):
+        if not options:
+            options = []
+        self.definition = definition
+        self.options = options
+        self.is_logical_interface = definition.startswith('iface ')
+        self.is_physical_interface = definition.startswith('auto ')
+        self.iface = None
+        self.phy = None
+        if self.is_logical_interface:
+            self.iface = LogicalInterface(definition, self.options)
+        if self.is_physical_interface:
+            self.phy = PhysicalInterface(definition)
+
+    def __str__(self):
+        return self.definition
 
 
 class NetworkInterfaceParser(object):
-    """Parse a network interface file into its set of stanzas."""
+    """Parse a network interface file into a set of stanzas."""
 
     @classmethod
     def is_stanza(cls, s):
         return re.match(r'^(iface|mapping|auto|allow-|source|dns-)', s)
 
     def __init__(self, filename):
-        self._filename = filename
         self._stanzas = []
         with open(filename) as f:
             lines = f.readlines()
@@ -114,95 +207,42 @@ class NetworkInterfaceParser(object):
     def stanzas(self):
         return [x for x in self._stanzas]
 
+    def physical_interfaces(self):
+        return {x.phy.name: x.phy for x in [y for y in self._stanzas if y.is_physical_interface]}
+
+    def logical_interfaces(self):
+        return {x.iface.name: x.iface for x in [y for y in self._stanzas if y.is_logical_interface]}
+
+    def active_interfaces(self):
+        return [x.name for x in self.logical_interfaces().values() if x.is_active]
+
+    def __iter__(self):  # class iter
+        for s in self._stanzas:
+            yield s
+
+
+def IfaceStanza(name, family, method, options):
+    # Convenience function to create a new "iface" stanza.
+    return Stanza("iface {} {} {}".format(name, family, method), options)
+
+
+def AutoStanza(name):
+    # Convenience function to create a new "auto" stanza.
+    return Stanza("auto {}".format(name))
+
 
 def print_stanza(s, stream=sys.stdout):
-    print(s.definition(), file=stream)
-    for o in s.options():
+    print(s.definition, file=stream)
+    for o in s.options:
         print("   ", o, file=stream)
 
 
 def print_stanzas(stanzas, stream=sys.stdout):
     n = len(stanzas)
-    for i, s in enumerate(stanzas):
-        print_stanza(s, stream)
-        if s.is_logical_interface() and i + 1 < n:
+    for i, stanza in enumerate(stanzas):
+        print_stanza(stanza, stream)
+        if stanza.is_logical_interface and i + 1 < n:
             print(file=stream)
-
-
-# Parses filename and returns a set of stanzas that have the existing
-# primary NIC bridged.
-def add_bridge(filename, bridge_name, primary_nic, bonded):
-    stanzas = []
-
-    for s in NetworkInterfaceParser(filename).stanzas():
-        if not s.is_logical_interface() and not s.is_physical_interface():
-            stanzas.append(s)
-            continue
-
-        if primary_nic != s.interface_name() and \
-                        primary_nic not in s.interface_name():
-            stanzas.append(s)
-            continue
-
-        if bonded:
-            if s.is_physical_interface():
-                stanzas.append(s)
-            else:
-                iface, orig_name, addr_family, method = s.definition().split()
-                stanzas.append(Stanza("iface {} {} manual".format(orig_name, addr_family), s.options()))
-
-                # new auto <bridge_name>
-                stanzas.append(Stanza("auto {}".format(bridge_name)))
-
-                # new iface <bridge_name> ...
-                options = [x for x in s.options() if not x.startswith("bond")]
-                options.insert(0, "bridge_ports {}".format(primary_nic))
-                options.append("pre-up ip link add dev {} name {} type bridge || true".format(orig_name, bridge_name))
-                stanzas.append(Stanza("iface {} {} {}".format(bridge_name, addr_family, method), options))
-            continue
-
-        if primary_nic == s.interface_name():
-            if s.is_physical_interface():
-                # The net change:
-                #   auto eth0
-                # to:
-                #   auto <bridge_name>
-                words = s.definition().split()
-                words[1] = bridge_name
-                stanzas.append(Stanza(" ".join(words)))
-            else:
-                # The net change is:
-                #   auto eth0
-                #   iface eth0 inet <config>
-                # to:
-                #   iface eth0 inet manual
-                #
-                #   auto <bridge_name>
-                #   iface <bridge_name> inet <config>
-                words = s.definition().split()
-                words[3] = "manual"
-                if len(stanzas) > 0:
-                    last_stanza = stanzas.pop()
-                else:
-                    last_stanza = None
-                stanzas.append(Stanza(" ".join(words)))
-                if last_stanza:
-                    stanzas.append(last_stanza)
-                # Replace existing 'iface' line with new <bridge_name>
-                words = s.definition().split()
-                words[1] = bridge_name
-                options = s.options()
-                options.insert(0, "bridge_ports {}".format(primary_nic))
-                stanzas.append(Stanza(" ".join(words), options))
-            continue
-
-        # Aliases, hence the 'eth0' in 'auto eth0:1'.
-
-        if primary_nic in s.definition():
-            definition = s.definition().replace(primary_nic, bridge_name)
-            stanzas.append(Stanza(definition, s.options()))
-
-    return stanzas
 
 
 def shell_cmd(s):
@@ -211,143 +251,84 @@ def shell_cmd(s):
     return [out, err, p.returncode]
 
 
-def print_shell_cmd(s, verbose=True, exitOnError=False):
-    if verbose: print(s)
+def print_shell_cmd(s, verbose=True, exit_on_error=False):
+    if verbose:
+        print(s)
     out, err, retcode = shell_cmd(s)
     if out and len(out) > 0:
-        print(out.rstrip(chr(10)))
+        print(out.rstrip('\n'))
     if err and len(err) > 0:
-        print(err.rstrip(chr(10)))
-    if exitOnError and retcode != 0:
-        sys.exit(1)
+        print(err.rstrip('\n'))
+    if exit_on_error and retcode != 0:
+        exit(1)
 
 
 def check_shell_cmd(s, verbose=False):
-    if verbose: print(s)
+    if verbose:
+        print(s)
     output = subprocess.check_output(s, shell=True, stderr=subprocess.STDOUT).strip().decode("utf-8")
-    if verbose: print(output.rstrip('\n'))
+    if verbose:
+        print(output.rstrip('\n'))
     return output
 
 
-def get_gateway(ver='-4'):
-    return check_shell_cmd("ip {} route list exact default | head -n1 | cut -d' ' -f3".format(ver))
+def arg_parser():
+    parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument('--bridge-prefix', help="bridge prefix", type=str, required=False, default='br-')
+    parser.add_argument('--one-time-backup', help='A one time backup of filename', action='store_true', default=True, required=False)
+    parser.add_argument('--activate', help='activate new configuration', action='store_true', default=False, required=False)
+    parser.add_argument('filename', help="interfaces(5) based filename")
+    return parser
 
 
-def get_primary_nic(ver='-4'):
-    return check_shell_cmd("ip {} route list exact default | head -n1 | cut -d' ' -f5".format(ver))
+def main(args):
+    stanzas = []
+    config_parser = NetworkInterfaceParser(args.filename)
+    physical_interfaces = config_parser.physical_interfaces()
+    active_interfaces = config_parser.active_interfaces()
 
+    for s in config_parser.stanzas():
+        if s.is_logical_interface:
+            add_auto_stanza = s.iface.name in physical_interfaces
+            bridged_stanzas = s.iface.bridge(args.bridge_prefix, add_auto_stanza, active_interfaces)
+            stanzas.extend(bridged_stanzas)
+        elif not s.is_physical_interface:
+            stanzas.append(s)
 
-def is_nic_bonded(name):
-    out, err, retcode = shell_cmd("cat {}".format("/sys/class/net/bonding_masters"))
-    return name in out
+    if not args.activate:
+        print_stanzas(stanzas)
+        exit(0)
 
+    if args.one_time_backup:
+        backup_file = "{}-before-add-juju-bridge".format(args.filename)
+        if not os.path.isfile(backup_file):
+            shutil.copy2(args.filename, backup_file)
 
-def is_bridged(name, filename):
-    for s in NetworkInterfaceParser(filename).stanzas():
-        if name in s.definition():
-            return True
-    return False
+    ifquery = "$(ifquery -i {} --exclude=lo -l)".format(args.filename)
 
+    print("**** Original configuration")
+    print_shell_cmd("cat {}".format(args.filename))
+    print_shell_cmd("ifconfig -a")
+    print_shell_cmd("ifdown --exclude=lo -i {} {}".format(args.filename, ifquery))
 
-def link_is_up(name):
-    out, err, retcode = shell_cmd('ip link show {} up'.format(name))
-    return re.search(r'\s+{}:\s+.*\s+state\s+UP\s+'.format(name), out)
+    print("**** Activating new configuration")
 
+    with open(args.filename, 'w') as f:
+        print_stanzas(stanzas, f)
+        f.close()
 
-def ifup(name, retries=5):
-    if retries < 1:
-        retries = 1
-    i = 1
-    while i <= retries:
-        print("link {} not up, attempt ({}/{})".format(name, i, retries))
-        print_shell_cmd("ifdown -v -a")
-        print_shell_cmd("ifup -v -a")
-        if link_is_up(name):
-            return True
-        print_shell_cmd("ip link")
-        i += 1
-    return False
+    print_shell_cmd("cat {}".format(args.filename))
+    print_shell_cmd("ifup --exclude=lo -i {} {}".format(args.filename, ifquery))
+    print_shell_cmd("ip link show up")
+    print_shell_cmd("ifconfig -a")
+    print_shell_cmd("ip route show")
+    print_shell_cmd("brctl show")
 
+# This script re-renders an interfaces(5) file to add a bridge to all
+# active interfaces; active interfaces are those that are declared as
+# either 'static' or 'dhcp'.
 
-parser = argparse.ArgumentParser()
-
-parser.add_argument('--filename',
-                    help='filename to re-render',
-                    type=str,
-                    required=False,
-                    default="/etc/network/interfaces")
-
-parser.add_argument('--bridge-name',
-                    help="bridge name",
-                    type=str,
-                    required=False,
-                    default='juju-br0')
-
-parser.add_argument('--primary-nic',
-                    help="primary NIC name",
-                    type=str,
-                    required=False)
-
-parser.add_argument('--primary-nic-is-bonded',
-                    help="primary NIC is bonded",
-                    action='store_true',
-                    required=False)
-
-parser.add_argument('--render-only',
-                    help='render to stdout, no network restart',
-                    action='store_true',
-                    required=False)
-
-parser.add_argument('--backup-filename',
-                    help='backup filename',
-                    type=str,
-                    required=False)
-
-args = parser.parse_args()
-
-if is_bridged(args.bridge_name, args.filename):
-    print("already bridged; nothing to do")
-    sys.exit(0)
-
-if not args.primary_nic:
-    args.primary_nic = get_primary_nic()
-
-if not args.primary_nic_is_bonded:
-    args.primary_nic_is_bonded = is_nic_bonded(args.primary_nic)
-
-bridged_stanzas = add_bridge(args.filename,
-                             args.bridge_name,
-                             args.primary_nic,
-                             args.primary_nic_is_bonded)
-
-if args.render_only:
-    print_stanzas(bridged_stanzas)
-    sys.exit(0)
-
-if not get_gateway():
-    print("no default gw; continue continue")
-    sys.exit(1)
-
-if args.backup_filename and not os.path.isfile(args.backup_filename):
-    shutil.copy2(args.filename, args.backup_filename)
-
-print("**** Original configuration")
-print_shell_cmd("cat {}".format(args.filename))
-print_shell_cmd("ifconfig -a")
-print_shell_cmd("ip route show")
-print_shell_cmd("ifdown -v -a")
-
-print("**** Activating new configuration")
-
-with open(args.filename, 'w') as f:
-    print_stanzas(bridged_stanzas, f)
-    f.close()
-
-if not ifup(args.bridge_name):
-    sys.exit(1)
-
-print_shell_cmd("ifconfig -a")
-print_shell_cmd("ip route show")
-print_shell_cmd("brctl show")
+if __name__ == '__main__':
+    main(arg_parser().parse_args())
 PYTHON_SCRIPT
 )`

--- a/provider/maas/bridgescript_test.go
+++ b/provider/maas/bridgescript_test.go
@@ -42,73 +42,69 @@ func (s *bridgeConfigSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-func (s *bridgeConfigSuite) assertScript(c *gc.C, initialConfig, expectedConfig, nic, bridge string, isBond bool) {
+func (s *bridgeConfigSuite) assertScript(c *gc.C, initialConfig, expectedConfig, bridgePrefix string) {
 	// To simplify most cases, trim trailing new lines.
 	initialConfig = strings.TrimSuffix(initialConfig, "\n")
 	expectedConfig = strings.TrimSuffix(expectedConfig, "\n")
 	err := ioutil.WriteFile(s.testConfigPath, []byte(initialConfig), 0644)
 	c.Check(err, jc.ErrorIsNil)
 	// Run the script and verify the modified config.
-	output, retcode := s.runScript(c, s.testConfigPath, nic, bridge, isBond)
+	output, retcode := s.runScript(c, s.testConfigPath, bridgePrefix)
 	c.Check(retcode, gc.Equals, 0)
 	c.Check(strings.Trim(output, "\n"), gc.Equals, expectedConfig)
 }
 
 func (s *bridgeConfigSuite) TestBridgeScriptWithUndefinedArgs(c *gc.C) {
-	_, code := s.runScript(c, "", "", "", false)
+	_, code := s.runScript(c, "", "")
 	c.Check(code, gc.Equals, 1)
 }
 
 func (s *bridgeConfigSuite) TestBridgeScriptDHCP(c *gc.C) {
-	s.assertScript(c, networkDHCPInitial, networkDHCPExpected, "eth0", "juju-br0", false)
+	s.assertScript(c, networkDHCPInitial, networkDHCPExpected, "test-br-")
 }
 
 func (s *bridgeConfigSuite) TestBridgeScriptStatic(c *gc.C) {
-	s.assertScript(c, networkStaticInitial, networkStaticExpected, "eth0", "juju-br0", false)
+	s.assertScript(c, networkStaticInitial, networkStaticExpected, "test-br-")
 }
 
-func (s *bridgeConfigSuite) TestBridgeScriptMultiple(c *gc.C) {
-	s.assertScript(c, networkMultipleInitial, networkMultipleExpected, "eth0", "juju-br0", false)
+func (s *bridgeConfigSuite) TestBridgeScriptDualNIC(c *gc.C) {
+	s.assertScript(c, networkDualNICInitial, networkDualNICExpected, "test-br-")
 }
 
 func (s *bridgeConfigSuite) TestBridgeScriptWithAlias(c *gc.C) {
-	s.assertScript(c, networkWithAliasInitial, networkWithAliasExpected, "eth0", "juju-br0", false)
+	s.assertScript(c, networkWithAliasInitial, networkWithAliasExpected, "test-br-")
 }
 
 func (s *bridgeConfigSuite) TestBridgeScriptDHCPWithAlias(c *gc.C) {
-	s.assertScript(c, networkDHCPWithAliasInitial, networkDHCPWithAliasExpected, "eth0", "juju-br0", false)
+	s.assertScript(c, networkDHCPWithAliasInitial, networkDHCPWithAliasExpected, "test-br-")
 }
 
 func (s *bridgeConfigSuite) TestBridgeScriptMultipleStaticWithAliases(c *gc.C) {
-	s.assertScript(c, networkMultipleStaticWithAliasesInitial, networkMultipleStaticWithAliasesExpected, "eth0", "juju-br0", false)
+	s.assertScript(c, networkMultipleStaticWithAliasesInitial, networkMultipleStaticWithAliasesExpected, "test-br-")
 }
 
 func (s *bridgeConfigSuite) TestBridgeScriptDHCPWithBond(c *gc.C) {
-	s.assertScript(c, networkDHCPWithBondInitial, networkDHCPWithBondExpected, "bond0", "juju-br0", true)
+	s.assertScript(c, networkDHCPWithBondInitial, networkDHCPWithBondExpected, "test-br-")
 }
 
 func (s *bridgeConfigSuite) TestBridgeScriptMultipleAliases(c *gc.C) {
-	s.assertScript(c, networkMultipleAliasesInitial, networkMultipleAliasesExpected, "eth10", "juju-br10", false)
+	s.assertScript(c, networkMultipleAliasesInitial, networkMultipleAliasesExpected, "test-br-")
 }
 
-func (s *bridgeConfigSuite) TestBridgeScriptPopEmptyStanza(c *gc.C) {
-	s.assertScript(c, networkMinimalInitial, networkMinimalExpected, "eth0", "juju-br0", false)
+func (s *bridgeConfigSuite) TestBridgeScriptSmorgasboard(c *gc.C) {
+	s.assertScript(c, networkSmorgasboardInitial, networkSmorgasboardExpected, "juju-br-")
 }
 
-func (s *bridgeConfigSuite) runScript(c *gc.C, configFile string, nic string, bridge string, isBond bool) (output string, exitCode int) {
-	var primaryNicIsBonded = ""
+func (s *bridgeConfigSuite) TestBridgeScriptWithVLANs(c *gc.C) {
+	s.assertScript(c, networkVLANInitial, networkVLANExpected, "vlan-br-")
+}
 
-	if isBond {
-		primaryNicIsBonded = "--primary-nic-is-bonded"
-	}
-
-	script := fmt.Sprintf("%s\npython -c %q --render-only --filename=%q --primary-nic=%q --bridge-name=%q %s\n",
+func (s *bridgeConfigSuite) runScript(c *gc.C, configFile string, bridgePrefix string) (output string, exitCode int) {
+	script := fmt.Sprintf("%s\npython -c %q --bridge-prefix=%q %q\n",
 		bridgeScriptPythonBashDef,
 		"$python_script",
-		configFile,
-		nic,
-		bridge,
-		primaryNicIsBonded)
+		bridgePrefix,
+		configFile)
 
 	result, err := exec.RunCommands(exec.RunParams{Commands: script})
 	c.Assert(err, jc.ErrorIsNil, gc.Commentf("script failed unexpectedly"))
@@ -121,9 +117,8 @@ func (s *bridgeConfigSuite) runScript(c *gc.C, configFile string, nic string, br
 }
 
 // The rest of the file contains various forms of network config for
-// both before and after it has been run through the
-// modify_network_config bash function. They are used in individual
-// test functions.
+// both before and after it has been run through the python script.
+// They are used in individual test functions.
 
 const networkStaticInitial = `auto lo
 iface lo inet loopback
@@ -139,12 +134,12 @@ iface lo inet loopback
 
 iface eth0 inet manual
 
-auto juju-br0
-iface juju-br0 inet static
-    bridge_ports eth0
+auto test-br-eth0
+iface test-br-eth0 inet static
     address 1.2.3.4
     netmask 255.255.255.0
-    gateway 4.3.2.1`
+    gateway 4.3.2.1
+    bridge_ports eth0`
 
 const networkDHCPInitial = `auto lo
 iface lo inet loopback
@@ -157,25 +152,15 @@ iface lo inet loopback
 
 iface eth0 inet manual
 
-auto juju-br0
-iface juju-br0 inet dhcp
+auto test-br-eth0
+iface test-br-eth0 inet dhcp
     bridge_ports eth0`
 
-const networkMultipleInitial = networkStaticInitial + `
-auto eth1
-iface eth1 inet static
-    address 1.2.3.5
-    netmask 255.255.255.0
-    gateway 4.3.2.1`
-
-const networkMultipleExpected = `auto lo
+const networkDualNICInitial = `auto lo
 iface lo inet loopback
 
-iface eth0 inet manual
-
-auto juju-br0
-iface juju-br0 inet static
-    bridge_ports eth0
+auto eth0
+iface eth0 inet static
     address 1.2.3.4
     netmask 255.255.255.0
     gateway 4.3.2.1
@@ -186,7 +171,36 @@ iface eth1 inet static
     netmask 255.255.255.0
     gateway 4.3.2.1`
 
-const networkWithAliasInitial = networkStaticInitial + `
+const networkDualNICExpected = `auto lo
+iface lo inet loopback
+
+iface eth0 inet manual
+
+auto test-br-eth0
+iface test-br-eth0 inet static
+    address 1.2.3.4
+    netmask 255.255.255.0
+    gateway 4.3.2.1
+    bridge_ports eth0
+
+iface eth1 inet manual
+
+auto test-br-eth1
+iface test-br-eth1 inet static
+    address 1.2.3.5
+    netmask 255.255.255.0
+    gateway 4.3.2.1
+    bridge_ports eth1`
+
+const networkWithAliasInitial = `auto lo
+iface lo inet loopback
+
+auto eth0
+iface eth0 inet static
+    address 1.2.3.4
+    netmask 255.255.255.0
+    gateway 4.3.2.1
+
 auto eth0:1
 iface eth0:1 inet static
     address 1.2.3.5`
@@ -196,15 +210,15 @@ iface lo inet loopback
 
 iface eth0 inet manual
 
-auto juju-br0
-iface juju-br0 inet static
-    bridge_ports eth0
+auto test-br-eth0
+iface test-br-eth0 inet static
     address 1.2.3.4
     netmask 255.255.255.0
     gateway 4.3.2.1
+    bridge_ports eth0
 
-auto juju-br0:1
-iface juju-br0:1 inet static
+auto eth0:1
+iface eth0:1 inet static
     address 1.2.3.5`
 
 const networkDHCPWithAliasInitial = `auto lo
@@ -230,18 +244,18 @@ iface lo inet loopback
 
 iface eth0 inet manual
 
-auto juju-br0
-iface juju-br0 inet static
-    bridge_ports eth0
+auto test-br-eth0
+iface test-br-eth0 inet static
     gateway 10.14.0.1
     address 10.14.0.102/24
+    bridge_ports eth0
 
-auto juju-br0:1
-iface juju-br0:1 inet static
+auto eth0:1
+iface eth0:1 inet static
     address 10.14.0.103/24
 
-auto juju-br0:2
-iface juju-br0:2 inet static
+auto eth0:2
+iface eth0:2 inet static
     address 10.14.0.100/24
 
 dns-nameserver 192.168.1.142`
@@ -267,15 +281,15 @@ dns-search maas`
 
 const networkMultipleStaticWithAliasesExpected = `iface eth0 inet manual
 
-auto juju-br0
-iface juju-br0 inet static
-    bridge_ports eth0
+auto test-br-eth0
+iface test-br-eth0 inet static
     gateway 10.17.20.1
     address 10.17.20.201/24
     mtu 1500
+    bridge_ports eth0
 
-auto juju-br0:1
-iface juju-br0:1 inet static
+auto eth0:1
+iface eth0:1 inet static
     address 10.17.20.202/24
     mtu 1500
 
@@ -345,12 +359,11 @@ iface bond0 inet manual
     hwaddress 52:54:00:1c:f1:5b
     bond-slaves none
 
-auto juju-br0
-iface juju-br0 inet dhcp
-    bridge_ports bond0
+auto test-br-bond0
+iface test-br-bond0 inet dhcp
     mtu 1500
     hwaddress 52:54:00:1c:f1:5b
-    pre-up ip link add dev bond0 name juju-br0 type bridge || true
+    bridge_ports bond0
 
 dns-nameservers 10.17.20.200
 dns-search maas19`
@@ -360,33 +373,6 @@ iface eth0 inet dhcp
 
 auto eth1
 iface eth1 inet dhcp
-
-auto eth2
-iface eth2 inet dhcp
-
-auto eth3
-iface eth3 inet dhcp
-
-auto eth4
-iface eth4 inet dhcp
-
-auto eth5
-iface eth5 inet dhcp
-
-auto eth5
-iface eth5 inet dhcp
-
-auto eth6
-iface eth6 inet dhcp
-
-auto eth7
-iface eth7 inet dhcp
-
-auto eth8
-iface eth8 inet dhcp
-
-auto eth9
-iface eth9 inet dhcp
 
 auto eth10
 iface eth10 inet static
@@ -404,169 +390,314 @@ iface eth10:2 inet static
     address 10.17.20.203/24
     mtu 1500
 
-auto eth10:3
-iface eth10:3 inet static
-    address 10.17.20.204/24
-    mtu 1500
-
-auto eth10:4
-iface eth10:4 inet static
-    address 10.17.20.205/24
-    mtu 1500
-
-auto eth10:5
-iface eth10:5 inet static
-    address 10.17.20.206/24
-    mtu 1500
-
-auto eth10:6
-iface eth10:6 inet static
-    address 10.17.20.207/24
-    mtu 1500
-
-auto eth10:7
-iface eth10:7 inet static
-    address 10.17.20.208/24
-    mtu 1500
-
-auto eth10:8
-iface eth10:8 inet static
-    address 10.17.20.209/24
-    mtu 1500
-
-auto eth10:9
-iface eth10:9 inet static
-    address 10.17.20.210/24
-    mtu 1500
-
-auto eth10:10
-iface eth10:10 inet static
-    address 10.17.20.211/24
-    mtu 1500
-
-auto eth10:11
-iface eth10:11 inet static
-    address 10.17.20.212/24
-    mtu 1500
-
-auto eth10:12
-iface eth10:12 inet static
-    address 10.17.20.213/24
-    mtu 1500
-
 dns-nameservers 10.17.20.200
 dns-search maas19`
 
-const networkMultipleAliasesExpected = `auto eth0
-iface eth0 inet dhcp
+const networkMultipleAliasesExpected = `iface eth0 inet manual
 
-auto eth1
-iface eth1 inet dhcp
+auto test-br-eth0
+iface test-br-eth0 inet dhcp
+    bridge_ports eth0
 
-auto eth2
-iface eth2 inet dhcp
+iface eth1 inet manual
 
-auto eth3
-iface eth3 inet dhcp
-
-auto eth4
-iface eth4 inet dhcp
-
-auto eth5
-iface eth5 inet dhcp
-
-auto eth5
-iface eth5 inet dhcp
-
-auto eth6
-iface eth6 inet dhcp
-
-auto eth7
-iface eth7 inet dhcp
-
-auto eth8
-iface eth8 inet dhcp
-
-auto eth9
-iface eth9 inet dhcp
+auto test-br-eth1
+iface test-br-eth1 inet dhcp
+    bridge_ports eth1
 
 iface eth10 inet manual
 
-auto juju-br10
-iface juju-br10 inet static
-    bridge_ports eth10
+auto test-br-eth10
+iface test-br-eth10 inet static
     gateway 10.17.20.1
     address 10.17.20.201/24
     mtu 1500
+    bridge_ports eth10
 
-auto juju-br10:1
-iface juju-br10:1 inet static
+auto eth10:1
+iface eth10:1 inet static
     address 10.17.20.202/24
     mtu 1500
 
-auto juju-br10:2
-iface juju-br10:2 inet static
+auto eth10:2
+iface eth10:2 inet static
     address 10.17.20.203/24
-    mtu 1500
-
-auto juju-br10:3
-iface juju-br10:3 inet static
-    address 10.17.20.204/24
-    mtu 1500
-
-auto juju-br10:4
-iface juju-br10:4 inet static
-    address 10.17.20.205/24
-    mtu 1500
-
-auto juju-br10:5
-iface juju-br10:5 inet static
-    address 10.17.20.206/24
-    mtu 1500
-
-auto juju-br10:6
-iface juju-br10:6 inet static
-    address 10.17.20.207/24
-    mtu 1500
-
-auto juju-br10:7
-iface juju-br10:7 inet static
-    address 10.17.20.208/24
-    mtu 1500
-
-auto juju-br10:8
-iface juju-br10:8 inet static
-    address 10.17.20.209/24
-    mtu 1500
-
-auto juju-br10:9
-iface juju-br10:9 inet static
-    address 10.17.20.210/24
-    mtu 1500
-
-auto juju-br10:10
-iface juju-br10:10 inet static
-    address 10.17.20.211/24
-    mtu 1500
-
-auto juju-br10:11
-iface juju-br10:11 inet static
-    address 10.17.20.212/24
-    mtu 1500
-
-auto juju-br10:12
-iface juju-br10:12 inet static
-    address 10.17.20.213/24
     mtu 1500
 
 dns-nameservers 10.17.20.200
 dns-search maas19`
 
-const networkMinimalInitial = `auto eth0
-iface eth0 inet dhcp`
+const networkSmorgasboardInitial = `auto eth0
+iface eth0 inet manual
+    bond-lacp_rate slow
+    bond-xmit_hash_policy layer2
+    bond-miimon 100
+    bond-master bond0
+    mtu 1500
+    bond-mode active-backup
 
-const networkMinimalExpected = `iface eth0 inet manual
+auto eth1
+iface eth1 inet manual
+    bond-lacp_rate slow
+    bond-xmit_hash_policy layer2
+    bond-miimon 100
+    bond-master bond0
+    mtu 1500
+    bond-mode active-backup
 
-auto juju-br0
-iface juju-br0 inet dhcp
-    bridge_ports eth0`
+auto eth2
+iface eth2 inet manual
+    bond-lacp_rate slow
+    bond-xmit_hash_policy layer2
+    bond-miimon 100
+    bond-master bond1
+    mtu 1500
+    bond-mode active-backup
+
+auto eth3
+iface eth3 inet manual
+    bond-lacp_rate slow
+    bond-xmit_hash_policy layer2
+    bond-miimon 100
+    bond-master bond1
+    mtu 1500
+    bond-mode active-backup
+
+auto eth4
+iface eth4 inet static
+    address 10.17.20.202/24
+    mtu 1500
+
+auto eth5
+iface eth5 inet dhcp
+    mtu 1500
+
+auto eth6
+iface eth6 inet static
+    address 10.17.20.203/24
+    mtu 1500
+
+auto eth6:1
+iface eth6:1 inet static
+    address 10.17.20.205/24
+    mtu 1500
+
+auto eth6:2
+iface eth6:2 inet static
+    address 10.17.20.204/24
+    mtu 1500
+
+auto eth6:3
+iface eth6:3 inet static
+    address 10.17.20.206/24
+    mtu 1500
+
+auto eth6:4
+iface eth6:4 inet static
+    address 10.17.20.207/24
+    mtu 1500
+
+auto bond0
+iface bond0 inet static
+    gateway 10.17.20.1
+    address 10.17.20.201/24
+    bond-lacp_rate slow
+    bond-xmit_hash_policy layer2
+    bond-miimon 100
+    mtu 1500
+    bond-mode active-backup
+    hwaddress 52:54:00:6a:4f:fd
+    bond-slaves none
+
+auto bond1
+iface bond1 inet dhcp
+    bond-lacp_rate slow
+    bond-xmit_hash_policy layer2
+    bond-miimon 100
+    mtu 1500
+    bond-mode active-backup
+    hwaddress 52:54:00:8e:6e:b0
+    bond-slaves none
+
+dns-nameservers 10.17.20.200
+dns-search maas19`
+
+const networkSmorgasboardExpected = `auto eth0
+iface eth0 inet manual
+    bond-lacp_rate slow
+    bond-xmit_hash_policy layer2
+    bond-miimon 100
+    bond-master bond0
+    mtu 1500
+    bond-mode active-backup
+
+auto eth1
+iface eth1 inet manual
+    bond-lacp_rate slow
+    bond-xmit_hash_policy layer2
+    bond-miimon 100
+    bond-master bond0
+    mtu 1500
+    bond-mode active-backup
+
+auto eth2
+iface eth2 inet manual
+    bond-lacp_rate slow
+    bond-xmit_hash_policy layer2
+    bond-miimon 100
+    bond-master bond1
+    mtu 1500
+    bond-mode active-backup
+
+auto eth3
+iface eth3 inet manual
+    bond-lacp_rate slow
+    bond-xmit_hash_policy layer2
+    bond-miimon 100
+    bond-master bond1
+    mtu 1500
+    bond-mode active-backup
+
+iface eth4 inet manual
+
+auto juju-br-eth4
+iface juju-br-eth4 inet static
+    address 10.17.20.202/24
+    mtu 1500
+    bridge_ports eth4
+
+iface eth5 inet manual
+
+auto juju-br-eth5
+iface juju-br-eth5 inet dhcp
+    mtu 1500
+    bridge_ports eth5
+
+iface eth6 inet manual
+
+auto juju-br-eth6
+iface juju-br-eth6 inet static
+    address 10.17.20.203/24
+    mtu 1500
+    bridge_ports eth6
+
+auto eth6:1
+iface eth6:1 inet static
+    address 10.17.20.205/24
+    mtu 1500
+
+auto eth6:2
+iface eth6:2 inet static
+    address 10.17.20.204/24
+    mtu 1500
+
+auto eth6:3
+iface eth6:3 inet static
+    address 10.17.20.206/24
+    mtu 1500
+
+auto eth6:4
+iface eth6:4 inet static
+    address 10.17.20.207/24
+    mtu 1500
+
+auto bond0
+iface bond0 inet manual
+    gateway 10.17.20.1
+    address 10.17.20.201/24
+    bond-lacp_rate slow
+    bond-xmit_hash_policy layer2
+    bond-miimon 100
+    mtu 1500
+    bond-mode active-backup
+    hwaddress 52:54:00:6a:4f:fd
+    bond-slaves none
+
+auto juju-br-bond0
+iface juju-br-bond0 inet static
+    gateway 10.17.20.1
+    address 10.17.20.201/24
+    mtu 1500
+    hwaddress 52:54:00:6a:4f:fd
+    bridge_ports bond0
+
+auto bond1
+iface bond1 inet manual
+    bond-lacp_rate slow
+    bond-xmit_hash_policy layer2
+    bond-miimon 100
+    mtu 1500
+    bond-mode active-backup
+    hwaddress 52:54:00:8e:6e:b0
+    bond-slaves none
+
+auto juju-br-bond1
+iface juju-br-bond1 inet dhcp
+    mtu 1500
+    hwaddress 52:54:00:8e:6e:b0
+    bridge_ports bond1
+
+dns-nameservers 10.17.20.200
+dns-search maas19`
+
+const networkVLANInitial = `auto eth0
+iface eth0 inet static
+    gateway 10.17.20.1
+    address 10.17.20.212/24
+    mtu 1500
+
+auto eth1
+iface eth1 inet manual
+    mtu 1500
+
+auto eth0.2
+iface eth0.2 inet static
+    address 192.168.2.3/24
+    vlan-raw-device eth0
+    mtu 1500
+    vlan_id 2
+
+auto eth1.3
+iface eth1.3 inet static
+    address 192.168.3.3/24
+    vlan-raw-device eth1
+    mtu 1500
+    vlan_id 3
+
+dns-nameservers 10.17.20.200
+dns-search maas19`
+
+const networkVLANExpected = `iface eth0 inet manual
+
+auto vlan-br-eth0
+iface vlan-br-eth0 inet static
+    gateway 10.17.20.1
+    address 10.17.20.212/24
+    mtu 1500
+    bridge_ports eth0
+
+auto eth1
+iface eth1 inet manual
+    mtu 1500
+
+iface eth0.2 inet manual
+    address 192.168.2.3/24
+    vlan-raw-device eth0
+    mtu 1500
+    vlan_id 2
+
+auto vlan-br-eth0.2
+iface vlan-br-eth0.2 inet static
+    address 192.168.2.3/24
+    mtu 1500
+    bridge_ports eth0.2
+
+auto eth1.3
+iface eth1.3 inet static
+    address 192.168.3.3/24
+    vlan-raw-device eth1
+    mtu 1500
+    vlan_id 3
+
+dns-nameservers 10.17.20.200
+dns-search maas19`

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -1079,14 +1079,11 @@ func (environ *maasEnviron) selectNode(args selectNodeArgs) (*gomaasapi.MAASObje
 // setupJujuNetworking returns a string representing the script to run
 // in order to prepare the Juju-specific networking config on a node.
 func setupJujuNetworking() (string, error) {
-	eni := "/etc/network/interfaces"
-	script := fmt.Sprintf("%s\npython -c %q --backup-filename=%q --filename=%q --bridge-name=%q\n",
+	return fmt.Sprintf("%s\npython -c %q --bridge-prefix=%q --one-time-backup --activate %q\n",
 		bridgeScriptPythonBashDef,
 		"$python_script",
-		eni+"-orig",
-		eni,
-		instancecfg.DefaultBridgeName)
-	return script, nil
+		instancecfg.DefaultBridgePrefix,
+		"/etc/network/interfaces"), nil
 }
 
 func renderEtcNetworkInterfacesScript() (string, error) {


### PR DESCRIPTION
Reworked the bridge script so that all active interfaces get bridged. An
'active' interface is one that has both an 'auto' stanza and whose
'iface' method is either 'dhcp' or 'static'.

To avoid any clashes a prefix ('juju-br-') is added to device names that
become bridges; this allows for 'juju-br-eth0' and 'juju-br-bond0'.
Sticking to the old format we would end up with 'juju-br0' for both
'eth0' and 'bond0'.

I'm landing this change so that the script itself can have some exposure
on the maas-spaces branch. A subsequent PR will follow that ensures LXC
configurations are updated to include network entries for each active
interface.

The script is aware of bonds, VLANs and aliases.

(Review request: http://reviews.vapour.ws/r/3398/)