### PR TITLE
lp1526926:  Use kill-controller for local provider

### DIFF
--- a/provider/local/environ.go
+++ b/provider/local/environ.go
@@ -509,7 +509,7 @@ func (env *localEnviron) Destroy() error {
 		}
 		args := []string{
 			"env", osenv.JujuHomeEnvKey + "=" + osenv.JujuHome(),
-			juju, "destroy-environment", "-y", "--force", env.Config().Name(),
+			juju, "kill-controller", "-y", env.Config().Name(),
 		}
 		cmd := exec.Command("sudo", args...)
 		cmd.Stdout = os.Stdout

--- a/provider/local/environ_test.go
+++ b/provider/local/environ_test.go
@@ -267,9 +267,8 @@ func (s *localJujuTestSuite) TestDestroyCallSudo(c *gc.C) {
 		"env",
 		"JUJU_HOME=" + osenv.JujuHome(),
 		os.Args[0],
-		"destroy-environment",
+		"kill-controller",
 		"-y",
-		"--force",
 		env.Config().Name(),
 	}
 	c.Assert(string(data), gc.Equals, strings.Join(expected, " ")+"\n")


### PR DESCRIPTION
When going through the local provider to destroy a
controller, use the kill-controller command, rather
than destroy-environment --force.

(Review request: http://reviews.vapour.ws/r/3399/)