### PR TITLE
Add support for listing resources in state.

### DIFF
--- a/component/all/payload.go
+++ b/component/all/payload.go
@@ -54,6 +54,10 @@ func (payloads) newPublicFacade(st *state.State, resources *common.Resources, au
 }
 
 func (c payloads) registerPublicFacade() {
+	if !markRegistered(payload.ComponentName, "public-facade") {
+		return
+	}
+
 	common.RegisterStandardFacade(
 		payload.ComponentName,
 		0,
@@ -188,6 +192,10 @@ func (payloads) registerHookContextCommands() {
 }
 
 func (payloads) registerState() {
+	if !markRegistered(payload.ComponentName, "state") {
+		return
+	}
+
 	// TODO(ericsnow) Use a more general registration mechanism.
 	//state.RegisterMultiEnvCollections(persistence.Collections...)
 

--- a/component/all/resource.go
+++ b/component/all/resource.go
@@ -8,7 +8,6 @@ import (
 	"os"
 
 	"github.com/juju/errors"
-	"gopkg.in/juju/charm.v6-unstable"
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/base"
@@ -19,9 +18,9 @@ import (
 	"github.com/juju/juju/resource/api/client"
 	"github.com/juju/juju/resource/api/server"
 	"github.com/juju/juju/resource/cmd"
+	"github.com/juju/juju/resource/persistence"
 	"github.com/juju/juju/resource/state"
 	corestate "github.com/juju/juju/state"
-	"github.com/juju/juju/state/utils"
 )
 
 // resources exposes the registration methods needed
@@ -31,6 +30,7 @@ type resources struct{}
 // RegisterForServer is the top-level registration method
 // for the component in a jujud context.
 func (r resources) registerForServer() error {
+	r.registerState()
 	r.registerPublicFacade()
 	return nil
 }
@@ -45,6 +45,10 @@ func (r resources) registerForClient() error {
 // registerPublicFacade adds the resources public API facade
 // to the API server.
 func (r resources) registerPublicFacade() {
+	if !markRegistered(resource.ComponentName, "public-facade") {
+		return
+	}
+
 	common.RegisterStandardFacade(
 		resource.ComponentName,
 		server.Version,
@@ -59,23 +63,13 @@ func (resources) newPublicFacade(st *corestate.State, _ *common.Resources, autho
 		return nil, common.ErrPerm
 	}
 
-	rst := state.NewState(&resourceState{raw: st})
-	return server.NewFacade(rst), nil
-}
-
-// resourceState is a wrapper around state.State that supports the needs
-// of resources.
-type resourceState struct {
-	raw *corestate.State
-}
-
-// CharmMetadata implements resource/state.RawState.
-func (st resourceState) CharmMetadata(serviceID string) (*charm.Meta, error) {
-	meta, err := utils.CharmMetadata(st.raw, serviceID)
+	rst, err := st.Resources()
+	//rst, err := state.NewState(&resourceState{raw: st})
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return meta, nil
+
+	return server.NewFacade(rst), nil
 }
 
 // resourcesApiClient adds a Close() method to the resources public API client.
@@ -87,6 +81,34 @@ type resourcesAPIClient struct {
 // Close implements io.Closer.
 func (client resourcesAPIClient) Close() error {
 	return client.closeConnFunc()
+}
+
+// registerState registers the state functionality for resources.
+func (resources) registerState() {
+	if !markRegistered(resource.ComponentName, "state") {
+		return
+	}
+
+	newResources := func(persist corestate.Persistence) (corestate.Resources, error) {
+		st, err := state.NewState(&resourceState{persist: persist})
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		return st, nil
+	}
+
+	corestate.SetResourcesComponent(newResources)
+}
+
+// resourceState is a wrapper around state.State that supports the needs
+// of resources.
+type resourceState struct {
+	persist corestate.Persistence
+}
+
+// Persistence implements resource/state.RawState.
+func (st resourceState) Persistence() (state.Persistence, error) {
+	return persistence.NewPersistence(st.persist), nil
 }
 
 // registerPublicCommands adds the resources-related commands

--- a/component/all/resource.go
+++ b/component/all/resource.go
@@ -89,12 +89,9 @@ func (resources) registerState() {
 		return
 	}
 
-	newResources := func(persist corestate.Persistence) (corestate.Resources, error) {
-		st, err := state.NewState(&resourceState{persist: persist})
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		return st, nil
+	newResources := func(persist corestate.Persistence) corestate.Resources {
+		st := state.NewState(&resourceState{persist: persist})
+		return st
 	}
 
 	corestate.SetResourcesComponent(newResources)
@@ -107,8 +104,8 @@ type resourceState struct {
 }
 
 // Persistence implements resource/state.RawState.
-func (st resourceState) Persistence() (state.Persistence, error) {
-	return persistence.NewPersistence(st.persist), nil
+func (st resourceState) Persistence() state.Persistence {
+	return persistence.NewPersistence(st.persist)
 }
 
 // registerPublicCommands adds the resources-related commands

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -49,7 +49,7 @@ gopkg.in/check.v1	git	b3d3430320d4260e5fea99841af984b3badcea63	2015-06-26T10:50:
 gopkg.in/errgo.v1	git	66cb46252b94c1f3d65646f54ee8043ab38d766c	2015-10-07T15:31:57Z
 gopkg.in/goose.v1	git	e4a91e8b8323b8eef6fe41a66fd3ac6120520bb0	2015-11-13T22:25:24Z
 gopkg.in/inconshreveable/log15.v2	git	b105bd37f74e5d9dc7b6ad7806715c7a2b83fd3f	2015-09-21T21:38:54Z
-gopkg.in/juju/charm.v6-unstable	git	24bd2be93973af4baee76f719f6e3f370663ac2c	2015-12-15T23:08:55Z
+gopkg.in/juju/charm.v6-unstable	git	0229ee1077c43e8397bb0bde071752098145c5fe	2015-12-22T19:42:03Z
 gopkg.in/juju/charmrepo.v2-unstable	git	e738044bd65b121158cd7f37910e0debb3cfa0a5	2015-11-23T04:36:59Z
 gopkg.in/juju/charmstore.v5-unstable	git	a3afbf1cc0b2438ef7f7fc028cc54b19bd4f91e3	2015-11-19T15:07:26Z
 gopkg.in/juju/environschema.v1	git	7bea6a9a531586600a7741e9bdd5e3c978ffda15	2015-10-20T16:12:31Z

--- a/payload/persistence/package_test.go
+++ b/payload/persistence/package_test.go
@@ -1,7 +1,7 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package persistence_test
+package persistence
 
 import (
 	"testing"

--- a/resource/persistence/mongo.go
+++ b/resource/persistence/mongo.go
@@ -1,0 +1,132 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package persistence
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/juju/errors"
+	charmresource "gopkg.in/juju/charm.v6-unstable/resource"
+	"gopkg.in/mgo.v2/bson"
+
+	"github.com/juju/juju/resource"
+)
+
+const (
+	resourcesC = "resources"
+)
+
+// Collections is the list of names of the mongo collections where state
+// is stored for resources.
+// TODO(ericsnow) Not needed anymore...modify for a new registration scheme?
+var Collections = []string{
+	resourcesC,
+}
+
+// TODO(ericsnow) Move the methods under their own type (resourcecollection?).
+
+// all updates the provided "docs" with all the resource docs in mongo.
+func (p Persistence) all(query bson.D, docs interface{}) error {
+	if err := p.base.All(resourcesC, query, docs); err != nil {
+		return errors.Trace(err)
+	}
+	return nil
+}
+
+// resourceID converts an external resource ID into an internal one.
+func (p Persistence) resourceID(id, serviceID string) string {
+	return fmt.Sprintf("resource#%s#%s", serviceID, id)
+}
+
+// newResourceDoc generates a doc that represents the given resource.
+func (p Persistence) newResourcDoc(id, serviceID string, res resource.Resource) *resourceDoc {
+	id = p.resourceID(id, serviceID)
+
+	return &resourceDoc{
+		DocID:     id,
+		ServiceID: serviceID,
+
+		Name:    res.Name,
+		Type:    res.Type.String(),
+		Path:    res.Path,
+		Comment: res.Comment,
+
+		Origin:      res.Origin.String(),
+		Revision:    res.Revision,
+		Fingerprint: res.Fingerprint.Bytes(),
+
+		Username:  res.Username,
+		Timestamp: res.Timestamp,
+	}
+}
+
+// resources returns the resource docs for the given service.
+func (p Persistence) resources(serviceID string) ([]resourceDoc, error) {
+	var docs []resourceDoc
+	query := bson.D{{"service-id", serviceID}}
+	if err := p.all(query, &docs); err != nil {
+		return nil, errors.Trace(err)
+	}
+	return docs, nil
+}
+
+// resourceDoc is the top-level document for resources.
+type resourceDoc struct {
+	DocID     string `bson:"_id"`
+	EnvUUID   string `bson:"env-uuid"`
+	ServiceID string `bson:"service-id"`
+
+	Name    string `bson:"name"`
+	Type    string `bson:"type"`
+	Path    string `bson:"path"`
+	Comment string `bson:"comment"`
+
+	Origin      string `bson:"origin"`
+	Revision    int    `bson:"revision"`
+	Fingerprint []byte `bson:"fingerprint"`
+
+	Username  string    `bson:"username"`
+	Timestamp time.Time `bson:"timestamp-when-added"`
+}
+
+// resource returns the resource.Resource represented by the doc.
+func (doc resourceDoc) resource() (resource.Resource, error) {
+	var res resource.Resource
+
+	resType, err := charmresource.ParseType(doc.Type)
+	if err != nil {
+		return res, errors.Annotate(err, "got invalid data from DB")
+	}
+
+	origin, err := charmresource.ParseOrigin(doc.Origin)
+	if err != nil {
+		return res, errors.Annotate(err, "got invalid data from DB")
+	}
+
+	fp, err := charmresource.NewFingerprint(doc.Fingerprint)
+	if err != nil {
+		return res, errors.Annotate(err, "got invalid data from DB")
+	}
+
+	res = resource.Resource{
+		Resource: charmresource.Resource{
+			Meta: charmresource.Meta{
+				Name:    doc.Name,
+				Type:    resType,
+				Path:    doc.Path,
+				Comment: doc.Comment,
+			},
+			Origin:      origin,
+			Revision:    doc.Revision,
+			Fingerprint: fp,
+		},
+		Username:  doc.Username,
+		Timestamp: doc.Timestamp,
+	}
+	if err := res.Validate(); err != nil {
+		return res, errors.Annotate(err, "got invalid data from DB")
+	}
+	return res, nil
+}

--- a/resource/persistence/mongo.go
+++ b/resource/persistence/mongo.go
@@ -18,13 +18,6 @@ const (
 	resourcesC = "resources"
 )
 
-// Collections is the list of names of the mongo collections where state
-// is stored for resources.
-// TODO(ericsnow) Not needed anymore...modify for a new registration scheme?
-var Collections = []string{
-	resourcesC,
-}
-
 // TODO(ericsnow) Move the methods under their own type (resourcecollection?).
 
 // all updates the provided "docs" with all the resource docs in mongo.

--- a/resource/persistence/mongo.go
+++ b/resource/persistence/mongo.go
@@ -20,14 +20,6 @@ const (
 
 // TODO(ericsnow) Move the methods under their own type (resourcecollection?).
 
-// all updates the provided "docs" with all the resource docs in mongo.
-func (p Persistence) all(query bson.D, docs interface{}) error {
-	if err := p.base.All(resourcesC, query, docs); err != nil {
-		return errors.Trace(err)
-	}
-	return nil
-}
-
 // resourceID converts an external resource ID into an internal one.
 func (p Persistence) resourceID(id, serviceID string) string {
 	return fmt.Sprintf("resource#%s#%s", serviceID, id)
@@ -59,7 +51,7 @@ func (p Persistence) newResourcDoc(id, serviceID string, res resource.Resource) 
 func (p Persistence) resources(serviceID string) ([]resourceDoc, error) {
 	var docs []resourceDoc
 	query := bson.D{{"service-id", serviceID}}
-	if err := p.all(query, &docs); err != nil {
+	if err := p.base.All(resourcesC, query, &docs); err != nil {
 		return nil, errors.Trace(err)
 	}
 	return docs, nil

--- a/resource/persistence/mongo.go
+++ b/resource/persistence/mongo.go
@@ -18,8 +18,6 @@ const (
 	resourcesC = "resources"
 )
 
-// TODO(ericsnow) Move the methods under their own type (resourcecollection?).
-
 // resourceID converts an external resource ID into an internal one.
 func (p Persistence) resourceID(id, serviceID string) string {
 	return fmt.Sprintf("resource#%s#%s", serviceID, id)

--- a/resource/persistence/mongo.go
+++ b/resource/persistence/mongo.go
@@ -74,8 +74,8 @@ type resourceDoc struct {
 	Timestamp time.Time `bson:"timestamp-when-added"`
 }
 
-// resource returns the resource.Resource represented by the doc.
-func (doc resourceDoc) resource() (resource.Resource, error) {
+// doc2resource returns the resource.Resource represented by the doc.
+func doc2resource(doc resourceDoc) (resource.Resource, error) {
 	var res resource.Resource
 
 	resType, err := charmresource.ParseType(doc.Type)

--- a/resource/persistence/package_test.go
+++ b/resource/persistence/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package persistence
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/resource/persistence/persistence.go
+++ b/resource/persistence/persistence.go
@@ -46,7 +46,7 @@ func (p Persistence) ListResources(serviceID string) ([]resource.Resource, error
 
 	var results []resource.Resource
 	for _, doc := range docs {
-		res, err := doc.resource()
+		res, err := doc2resource(doc)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}

--- a/resource/persistence/persistence.go
+++ b/resource/persistence/persistence.go
@@ -1,0 +1,56 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package persistence
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+
+	"github.com/juju/juju/resource"
+)
+
+var logger = loggo.GetLogger("juju.resource.persistence")
+
+// PersistenceBase exposes the core persistence functionality needed
+// for resources.
+type PersistenceBase interface {
+	// All populates docs with the list of the documents corresponding
+	// to the provided query.
+	All(collName string, query, docs interface{}) error
+}
+
+// Persistence provides the persistence functionality for the
+// Juju environment as a whole.
+type Persistence struct {
+	base PersistenceBase
+}
+
+// NewPersistence wraps the base in a new Persistence.
+func NewPersistence(base PersistenceBase) *Persistence {
+	return &Persistence{
+		base: base,
+	}
+}
+
+// ListResources returns the resource data for the given service ID.
+func (p Persistence) ListResources(serviceID string) ([]resource.Resource, error) {
+	logger.Tracef("listing all resources for service %q", serviceID)
+
+	// TODO(ericsnow) Ensure that the service is still there?
+
+	docs, err := p.resources(serviceID)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	var results []resource.Resource
+	for _, doc := range docs {
+		res, err := doc.resource()
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		results = append(results, res)
+	}
+	return results, nil
+}

--- a/resource/persistence/persistence_test.go
+++ b/resource/persistence/persistence_test.go
@@ -1,0 +1,162 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package persistence
+
+import (
+	"time"
+
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	charmresource "gopkg.in/juju/charm.v6-unstable/resource"
+	"gopkg.in/mgo.v2/bson"
+
+	"github.com/juju/juju/resource"
+)
+
+var _ = gc.Suite(&PersistenceSuite{})
+
+type PersistenceSuite struct {
+	testing.IsolationSuite
+
+	stub *testing.Stub
+	base *stubStatePersistence
+}
+
+func (s *PersistenceSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+
+	s.stub = &testing.Stub{}
+	s.base = &stubStatePersistence{
+		stub: s.stub,
+	}
+}
+
+func (s *PersistenceSuite) TestListResourcesOkay(c *gc.C) {
+	expected, docs := newResources(c, "a-service", "spam", "eggs")
+	s.base.docs = docs
+
+	p := NewPersistence(s.base)
+	resources, err := p.ListResources("a-service")
+	c.Assert(err, jc.ErrorIsNil)
+
+	checkResources(c, resources, expected)
+	s.stub.CheckCallNames(c, "All")
+	s.stub.CheckCall(c, 0, "All",
+		"resources",
+		bson.D{{"service-id", "a-service"}},
+		&docs,
+	)
+}
+
+func (s *PersistenceSuite) TestListResourcesNoResources(c *gc.C) {
+	p := NewPersistence(s.base)
+	resources, err := p.ListResources("a-service")
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(resources, gc.HasLen, 0)
+	s.stub.CheckCallNames(c, "All")
+	s.stub.CheckCall(c, 0, "All",
+		"resources",
+		bson.D{{"service-id", "a-service"}},
+		&[]resourceDoc{},
+	)
+}
+
+func (s *PersistenceSuite) TestListResourcesBaseError(c *gc.C) {
+	failure := errors.New("<failure>")
+	s.stub.SetErrors(failure)
+
+	p := NewPersistence(s.base)
+	_, err := p.ListResources("a-service")
+
+	c.Check(errors.Cause(err), gc.Equals, failure)
+	s.stub.CheckCallNames(c, "All")
+	s.stub.CheckCall(c, 0, "All",
+		"resources",
+		bson.D{{"service-id", "a-service"}},
+		&[]resourceDoc{},
+	)
+}
+
+func (s *PersistenceSuite) TestListResourcesBadDoc(c *gc.C) {
+	_, docs := newResources(c, "a-service", "spam", "eggs")
+	docs[0].Timestamp = time.Time{}
+	s.base.docs = docs
+
+	p := NewPersistence(s.base)
+	_, err := p.ListResources("a-service")
+
+	c.Check(err, gc.ErrorMatches, `got invalid data from DB.*`)
+	s.stub.CheckCallNames(c, "All")
+	s.stub.CheckCall(c, 0, "All",
+		"resources",
+		bson.D{{"service-id", "a-service"}},
+		&docs,
+	)
+}
+
+func newResources(c *gc.C, serviceID string, names ...string) ([]resource.Resource, []resourceDoc) {
+	var resources []resource.Resource
+	var docs []resourceDoc
+	for _, name := range names {
+		res, doc := newResource(c, serviceID, name)
+		resources = append(resources, res)
+		docs = append(docs, doc)
+	}
+	return resources, docs
+}
+
+func newResource(c *gc.C, serviceID, name string) (resource.Resource, resourceDoc) {
+	fp, err := charmresource.GenerateFingerprint([]byte(name))
+	c.Assert(err, jc.ErrorIsNil)
+
+	res := resource.Resource{
+		Resource: charmresource.Resource{
+			Meta: charmresource.Meta{
+				Name:    name,
+				Type:    charmresource.TypeFile,
+				Path:    name + ".tgz",
+				Comment: "you need it",
+			},
+			Origin:      charmresource.OriginUpload,
+			Revision:    1,
+			Fingerprint: fp,
+		},
+		Username:  "a-user",
+		Timestamp: time.Now(),
+	}
+
+	doc := resourceDoc{
+		DocID:     "resource#" + serviceID + "#" + name,
+		ServiceID: serviceID,
+
+		Name:    res.Name,
+		Type:    res.Type.String(),
+		Path:    res.Path,
+		Comment: res.Comment,
+
+		Origin:      res.Origin.String(),
+		Revision:    res.Revision,
+		Fingerprint: res.Fingerprint.Bytes(),
+
+		Username:  res.Username,
+		Timestamp: res.Timestamp,
+	}
+
+	return res, doc
+}
+
+func checkResources(c *gc.C, resources, expected []resource.Resource) {
+	resMap := make(map[string]resource.Resource)
+	for _, res := range resources {
+		resMap[res.Name] = res
+	}
+	expMap := make(map[string]resource.Resource)
+	for _, res := range expected {
+		expMap[res.Name] = res
+	}
+	c.Check(resMap, jc.DeepEquals, expMap)
+}

--- a/resource/persistence/stubs_test.go
+++ b/resource/persistence/stubs_test.go
@@ -1,0 +1,26 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package persistence
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+)
+
+type stubStatePersistence struct {
+	stub *testing.Stub
+
+	docs []resourceDoc
+}
+
+func (s stubStatePersistence) All(collName string, query, docs interface{}) error {
+	s.stub.AddCall("All", collName, query, docs)
+	if err := s.stub.NextErr(); err != nil {
+		return errors.Trace(err)
+	}
+
+	actual := docs.(*[]resourceDoc)
+	*actual = s.docs
+	return nil
+}

--- a/resource/state/resource.go
+++ b/resource/state/resource.go
@@ -1,0 +1,29 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/resource"
+)
+
+type resourcePersistence interface {
+	// ListResources returns the resource data for the given service ID.
+	ListResources(serviceID string) ([]resource.Resource, error)
+}
+
+type resourceState struct {
+	persist resourcePersistence
+}
+
+// ListResources returns the resource data for the given service ID.
+func (st resourceState) ListResources(serviceID string) ([]resource.Resource, error) {
+	resources, err := st.persist.ListResources(serviceID)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	return resources, nil
+}

--- a/resource/state/resource_test.go
+++ b/resource/state/resource_test.go
@@ -1,0 +1,106 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state_test
+
+import (
+	"time"
+
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	charmresource "gopkg.in/juju/charm.v6-unstable/resource"
+
+	"github.com/juju/juju/resource"
+	"github.com/juju/juju/resource/state"
+)
+
+var _ = gc.Suite(&ResourceSuite{})
+
+type ResourceSuite struct {
+	testing.IsolationSuite
+
+	stub    *testing.Stub
+	raw     *stubRawState
+	persist *stubPersistence
+}
+
+func (s *ResourceSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+
+	s.stub = &testing.Stub{}
+	s.raw = &stubRawState{stub: s.stub}
+	s.persist = &stubPersistence{stub: s.stub}
+	s.raw.ReturnPersistence = s.persist
+}
+
+func (s *ResourceSuite) TestListResourcesOkay(c *gc.C) {
+	expected := newUploadResources(c, "spam", "eggs")
+	s.persist.ReturnListResources = expected
+	st, err := state.NewState(s.raw)
+	c.Assert(err, jc.ErrorIsNil)
+	s.stub.ResetCalls()
+
+	resources, err := st.ListResources("a-service")
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(resources, jc.DeepEquals, expected)
+	s.stub.CheckCallNames(c, "ListResources")
+	s.stub.CheckCall(c, 0, "ListResources", "a-service")
+}
+
+func (s *ResourceSuite) TestListResourcesEmpty(c *gc.C) {
+	st, err := state.NewState(s.raw)
+	c.Assert(err, jc.ErrorIsNil)
+	s.stub.ResetCalls()
+
+	resources, err := st.ListResources("a-service")
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(resources, gc.HasLen, 0)
+	s.stub.CheckCallNames(c, "ListResources")
+}
+
+func (s *ResourceSuite) TestListResourcesError(c *gc.C) {
+	expected := newUploadResources(c, "spam", "eggs")
+	s.persist.ReturnListResources = expected
+	st, err := state.NewState(s.raw)
+	c.Assert(err, jc.ErrorIsNil)
+	s.stub.ResetCalls()
+	failure := errors.New("<failure>")
+	s.stub.SetErrors(failure)
+
+	_, err = st.ListResources("a-service")
+
+	c.Check(errors.Cause(err), gc.Equals, failure)
+	s.stub.CheckCallNames(c, "ListResources")
+}
+
+func newUploadResources(c *gc.C, names ...string) []resource.Resource {
+	var resources []resource.Resource
+	for _, name := range names {
+		fp, err := charmresource.GenerateFingerprint([]byte(name))
+		c.Assert(err, jc.ErrorIsNil)
+
+		res := resource.Resource{
+			Resource: charmresource.Resource{
+				Meta: charmresource.Meta{
+					Name: name,
+					Type: charmresource.TypeFile,
+					Path: name + ".tgz",
+				},
+				Origin:      charmresource.OriginUpload,
+				Revision:    0,
+				Fingerprint: fp,
+			},
+			Username:  "a-user",
+			Timestamp: time.Now(),
+		}
+		err = res.Validate()
+		c.Assert(err, jc.ErrorIsNil)
+
+		resources = append(resources, res)
+	}
+	return resources
+}

--- a/resource/state/resource_test.go
+++ b/resource/state/resource_test.go
@@ -38,8 +38,7 @@ func (s *ResourceSuite) SetUpTest(c *gc.C) {
 func (s *ResourceSuite) TestListResourcesOkay(c *gc.C) {
 	expected := newUploadResources(c, "spam", "eggs")
 	s.persist.ReturnListResources = expected
-	st, err := state.NewState(s.raw)
-	c.Assert(err, jc.ErrorIsNil)
+	st := state.NewState(s.raw)
 	s.stub.ResetCalls()
 
 	resources, err := st.ListResources("a-service")
@@ -51,8 +50,7 @@ func (s *ResourceSuite) TestListResourcesOkay(c *gc.C) {
 }
 
 func (s *ResourceSuite) TestListResourcesEmpty(c *gc.C) {
-	st, err := state.NewState(s.raw)
-	c.Assert(err, jc.ErrorIsNil)
+	st := state.NewState(s.raw)
 	s.stub.ResetCalls()
 
 	resources, err := st.ListResources("a-service")
@@ -65,13 +63,12 @@ func (s *ResourceSuite) TestListResourcesEmpty(c *gc.C) {
 func (s *ResourceSuite) TestListResourcesError(c *gc.C) {
 	expected := newUploadResources(c, "spam", "eggs")
 	s.persist.ReturnListResources = expected
-	st, err := state.NewState(s.raw)
-	c.Assert(err, jc.ErrorIsNil)
+	st := state.NewState(s.raw)
 	s.stub.ResetCalls()
 	failure := errors.New("<failure>")
 	s.stub.SetErrors(failure)
 
-	_, err = st.ListResources("a-service")
+	_, err := st.ListResources("a-service")
 
 	c.Check(errors.Cause(err), gc.Equals, failure)
 	s.stub.CheckCallNames(c, "ListResources")

--- a/resource/state/state.go
+++ b/resource/state/state.go
@@ -4,25 +4,39 @@
 package state
 
 import (
+	"github.com/juju/errors"
 	"github.com/juju/loggo"
 )
 
 var logger = loggo.GetLogger("juju.resource.state")
 
+// Persistence is the state persistence functionality needed for resources.
+type Persistence interface {
+	resourcePersistence
+}
+
 // RawState defines the functionality needed from state.State for resources.
 type RawState interface {
-	// TODO(ericsnow) Add sub-interfaces here.
+	// Persistence exposes the state data persistence needed for resources.
+	Persistence() (Persistence, error)
 }
 
 // State exposes the state functionality needed for resources.
 type State struct {
-	// TODO(ericsnow) Embed sub-structs here.
+	*resourceState
 }
 
 // NewState returns a new State for the given raw Juju state.
-func NewState(raw RawState) *State {
+func NewState(raw RawState) (*State, error) {
 	logger.Tracef("wrapping state for resources")
-	return &State{
-	// TODO(ericsnow) Add sub-structs here.
+
+	persist, err := raw.Persistence()
+	if err != nil {
+		return nil, errors.Trace(err)
 	}
+
+	st := &State{
+		resourceState: &resourceState{persist},
+	}
+	return st, nil
 }

--- a/resource/state/state.go
+++ b/resource/state/state.go
@@ -4,7 +4,6 @@
 package state
 
 import (
-	"github.com/juju/errors"
 	"github.com/juju/loggo"
 )
 
@@ -18,7 +17,7 @@ type Persistence interface {
 // RawState defines the functionality needed from state.State for resources.
 type RawState interface {
 	// Persistence exposes the state data persistence needed for resources.
-	Persistence() (Persistence, error)
+	Persistence() Persistence
 }
 
 // State exposes the state functionality needed for resources.
@@ -27,16 +26,12 @@ type State struct {
 }
 
 // NewState returns a new State for the given raw Juju state.
-func NewState(raw RawState) (*State, error) {
+func NewState(raw RawState) *State {
 	logger.Tracef("wrapping state for resources")
 
-	persist, err := raw.Persistence()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
+	persist := raw.Persistence()
 	st := &State{
 		resourceState: &resourceState{persist},
 	}
-	return st, nil
+	return st
 }

--- a/resource/state/stub_test.go
+++ b/resource/state/stub_test.go
@@ -1,0 +1,42 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state_test
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+
+	"github.com/juju/juju/resource"
+	"github.com/juju/juju/resource/state"
+)
+
+type stubRawState struct {
+	stub *testing.Stub
+
+	ReturnPersistence state.Persistence
+}
+
+func (s *stubRawState) Persistence() (state.Persistence, error) {
+	s.stub.AddCall("Persistence")
+	if err := s.stub.NextErr(); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	return s.ReturnPersistence, nil
+}
+
+type stubPersistence struct {
+	stub *testing.Stub
+
+	ReturnListResources []resource.Resource
+}
+
+func (s *stubPersistence) ListResources(serviceID string) ([]resource.Resource, error) {
+	s.stub.AddCall("ListResources", serviceID)
+	if err := s.stub.NextErr(); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	return s.ReturnListResources, nil
+}

--- a/resource/state/stub_test.go
+++ b/resource/state/stub_test.go
@@ -17,13 +17,11 @@ type stubRawState struct {
 	ReturnPersistence state.Persistence
 }
 
-func (s *stubRawState) Persistence() (state.Persistence, error) {
+func (s *stubRawState) Persistence() state.Persistence {
 	s.stub.AddCall("Persistence")
-	if err := s.stub.NextErr(); err != nil {
-		return nil, errors.Trace(err)
-	}
+	s.stub.NextErr()
 
-	return s.ReturnPersistence, nil
+	return s.ReturnPersistence
 }
 
 type stubPersistence struct {

--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -302,6 +302,10 @@ func allCollections() collectionSchema {
 		// See payload/persistence/mongo.go.
 		"payloads": {},
 
+		// This collection holds information associated with charm resources.
+		// See resource/persistence/mongo.go.
+		"resources": {},
+
 		// -----
 
 		// The remaining non-global collections share the property of being
@@ -403,4 +407,5 @@ const (
 	volumeAttachmentsC     = "volumeattachments"
 	volumesC               = "volumes"
 	// "payloads" (see payload/persistence/mongo.go)
+	// "resources" (see resource/persistence/mongo.go)
 )

--- a/state/package_test.go
+++ b/state/package_test.go
@@ -1,7 +1,7 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package state
+package state_test
 
 import (
 	stdtesting "testing"

--- a/state/resources.go
+++ b/state/resources.go
@@ -1,0 +1,40 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/resource"
+)
+
+// Resources describes the state functionality for resources.
+type Resources interface {
+	// ListResources returns the list of resources for the given service.
+	ListResources(serviceID string) ([]resource.Resource, error)
+}
+
+type newResourcesFunc func(Persistence) (Resources, error)
+
+var newResources newResourcesFunc
+
+// SetResourcesComponent registers the function that provide the state
+// functionality related to resources.
+func SetResourcesComponent(fn newResourcesFunc) {
+	newResources = fn
+}
+
+// Resources returns the resources functionality for the current state.
+func (st *State) Resources() (Resources, error) {
+	if newResources == nil {
+		return nil, errors.Errorf("resources not supported")
+	}
+
+	persist := st.newPersistence()
+	resources, err := newResources(persist)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return resources, nil
+}

--- a/state/resources.go
+++ b/state/resources.go
@@ -15,13 +15,11 @@ type Resources interface {
 	ListResources(serviceID string) ([]resource.Resource, error)
 }
 
-type newResourcesFunc func(Persistence) (Resources, error)
-
-var newResources newResourcesFunc
+var newResources func(Persistence) (Resources, error)
 
 // SetResourcesComponent registers the function that provide the state
 // functionality related to resources.
-func SetResourcesComponent(fn newResourcesFunc) {
+func SetResourcesComponent(fn func(Persistence) (Resources, error)) {
 	newResources = fn
 }
 

--- a/state/resources.go
+++ b/state/resources.go
@@ -15,11 +15,11 @@ type Resources interface {
 	ListResources(serviceID string) ([]resource.Resource, error)
 }
 
-var newResources func(Persistence) (Resources, error)
+var newResources func(Persistence) Resources
 
 // SetResourcesComponent registers the function that provide the state
 // functionality related to resources.
-func SetResourcesComponent(fn func(Persistence) (Resources, error)) {
+func SetResourcesComponent(fn func(Persistence) Resources) {
 	newResources = fn
 }
 
@@ -30,9 +30,6 @@ func (st *State) Resources() (Resources, error) {
 	}
 
 	persist := st.newPersistence()
-	resources, err := newResources(persist)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
+	resources := newResources(persist)
 	return resources, nil
 }

--- a/state/resources_test.go
+++ b/state/resources_test.go
@@ -1,0 +1,35 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/component/all"
+)
+
+func init() {
+	if err := all.RegisterForServer(); err != nil {
+		panic(err)
+	}
+}
+
+var _ = gc.Suite(&ResourcesSuite{})
+
+type ResourcesSuite struct {
+	ConnSuite
+}
+
+func (s *ResourcesSuite) TestFunctional(c *gc.C) {
+	st, err := s.State.Resources()
+	c.Assert(err, jc.ErrorIsNil)
+
+	resources, err := st.ListResources("a-service")
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(resources, gc.HasLen, 0)
+
+	// TODO(ericsnow) Add more as state.Resources grows more functionality.
+}


### PR DESCRIPTION
This is the initial state-related patch for resources.  As such it introduces the state and persistence framework for resources, as well as the document struct.  Later patches will add support for adding, removing, and updating resources in state.

(Review request: http://reviews.vapour.ws/r/3403/)