### PR TITLE
provider/azure: enable CentOS support

### DIFF
--- a/cloudconfig/cloudinit/cloudinittest/fake.go
+++ b/cloudconfig/cloudinit/cloudinittest/fake.go
@@ -1,0 +1,28 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cloudinittest
+
+import (
+	"github.com/juju/testing"
+
+	"github.com/juju/juju/cloudconfig/cloudinit"
+)
+
+type CloudConfig struct {
+	cloudinit.CloudConfig
+	testing.Stub
+
+	YAML   []byte
+	Script string
+}
+
+func (c *CloudConfig) RenderYAML() ([]byte, error) {
+	c.MethodCall(c, "RenderYAML")
+	return c.YAML, c.NextErr()
+}
+
+func (c *CloudConfig) RenderScript() (string, error) {
+	c.MethodCall(c, "RenderScript")
+	return c.Script, c.NextErr()
+}

--- a/cloudconfig/providerinit/providerinit.go
+++ b/cloudconfig/providerinit/providerinit.go
@@ -65,11 +65,7 @@ func ComposeUserData(icfg *instancecfg.InstanceConfig, cloudcfg cloudinit.CloudC
 	}
 	// This might get replaced by a renderer.RenderUserdata which will either
 	// render it as YAML or Bash since some CentOS images might ship without cloudnit
-	udata, err := cloudcfg.RenderYAML()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	udata, err = renderer.EncodeUserdata(udata, operatingSystem)
+	udata, err := renderer.Render(cloudcfg, operatingSystem)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/cloudconfig/providerinit/providerinit.go
+++ b/cloudconfig/providerinit/providerinit.go
@@ -63,8 +63,6 @@ func ComposeUserData(icfg *instancecfg.InstanceConfig, cloudcfg cloudinit.CloudC
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	// This might get replaced by a renderer.RenderUserdata which will either
-	// render it as YAML or Bash since some CentOS images might ship without cloudnit
 	udata, err := renderer.Render(cloudcfg, operatingSystem)
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/cloudconfig/providerinit/renderers/common.go
+++ b/cloudconfig/providerinit/renderers/common.go
@@ -11,7 +11,6 @@ import (
 	"github.com/juju/juju/cloudconfig"
 	"github.com/juju/juju/cloudconfig/cloudinit"
 	"github.com/juju/utils"
-	"github.com/juju/utils/os"
 )
 
 // ToBase64 just transforms whatever userdata it gets to base64 format
@@ -40,7 +39,7 @@ type Decorator func([]byte) []byte
 
 // RenderYAML renders the given cloud-config as YAML, and then passes the
 // YAML through the given decorators.
-func RenderYAML(cfg cloudinit.RenderConfig, os os.OSType, ds ...Decorator) ([]byte, error) {
+func RenderYAML(cfg cloudinit.RenderConfig, ds ...Decorator) ([]byte, error) {
 	out, err := cfg.RenderYAML()
 	if err != nil {
 		return nil, err
@@ -50,7 +49,7 @@ func RenderYAML(cfg cloudinit.RenderConfig, os os.OSType, ds ...Decorator) ([]by
 
 // RenderScript renders the given cloud-config as a script, and then passes the
 // script through the given decorators.
-func RenderScript(cfg cloudinit.RenderConfig, os os.OSType, ds ...Decorator) ([]byte, error) {
+func RenderScript(cfg cloudinit.RenderConfig, ds ...Decorator) ([]byte, error) {
 	out, err := cfg.RenderScript()
 	if err != nil {
 		return nil, err

--- a/cloudconfig/providerinit/renderers/common.go
+++ b/cloudconfig/providerinit/renderers/common.go
@@ -9,7 +9,9 @@ import (
 	"fmt"
 
 	"github.com/juju/juju/cloudconfig"
+	"github.com/juju/juju/cloudconfig/cloudinit"
 	"github.com/juju/utils"
+	"github.com/juju/utils/os"
 )
 
 // ToBase64 just transforms whatever userdata it gets to base64 format
@@ -31,4 +33,34 @@ func AddPowershellTags(udata []byte) []byte {
 	return []byte(`<powershell>` +
 		string(udata) +
 		`</powershell>`)
+}
+
+// Decorator is a function that can be used as part of a rendering pipeline.
+type Decorator func([]byte) []byte
+
+// RenderYAML renders the given cloud-config as YAML, and then passes the
+// YAML through the given decorators.
+func RenderYAML(cfg cloudinit.RenderConfig, os os.OSType, ds ...Decorator) ([]byte, error) {
+	out, err := cfg.RenderYAML()
+	if err != nil {
+		return nil, err
+	}
+	return applyDecorators(out, ds), nil
+}
+
+// RenderScript renders the given cloud-config as a script, and then passes the
+// script through the given decorators.
+func RenderScript(cfg cloudinit.RenderConfig, os os.OSType, ds ...Decorator) ([]byte, error) {
+	out, err := cfg.RenderScript()
+	if err != nil {
+		return nil, err
+	}
+	return applyDecorators([]byte(out), ds), nil
+}
+
+func applyDecorators(out []byte, ds []Decorator) []byte {
+	for _, d := range ds {
+		out = d(out)
+	}
+	return out
 }

--- a/cloudconfig/providerinit/renderers/common_test.go
+++ b/cloudconfig/providerinit/renderers/common_test.go
@@ -10,7 +10,6 @@ import (
 
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
-	"github.com/juju/utils/os"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cloudconfig"
@@ -54,7 +53,7 @@ func (s *RenderersSuite) TestRenderYAML(c *gc.C) {
 	d2 := func(in []byte) []byte {
 		return []byte("2." + string(in))
 	}
-	out, err := renderers.RenderYAML(cloudcfg, os.Windows, d2, d1)
+	out, err := renderers.RenderYAML(cloudcfg, d2, d1)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(out), jc.DeepEquals, "1.2.yaml")
 	cloudcfg.CheckCallNames(c, "RenderYAML")
@@ -68,7 +67,7 @@ func (s *RenderersSuite) TestRenderScript(c *gc.C) {
 	d2 := func(in []byte) []byte {
 		return []byte("2." + string(in))
 	}
-	out, err := renderers.RenderScript(cloudcfg, os.Windows, d2, d1)
+	out, err := renderers.RenderScript(cloudcfg, d2, d1)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(out), jc.DeepEquals, "1.2.script")
 	cloudcfg.CheckCallNames(c, "RenderScript")

--- a/cloudconfig/providerinit/renderers/common_test.go
+++ b/cloudconfig/providerinit/renderers/common_test.go
@@ -10,9 +10,11 @@ import (
 
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
+	"github.com/juju/utils/os"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cloudconfig"
+	"github.com/juju/juju/cloudconfig/cloudinit/cloudinittest"
 	"github.com/juju/juju/cloudconfig/providerinit/renderers"
 	"github.com/juju/juju/testing"
 )
@@ -42,4 +44,32 @@ func (s *RenderersSuite) TestAddPowershellTags(c *gc.C) {
 	expected := []byte(`<powershell>` + string(in) + `</powershell>`)
 	out := renderers.AddPowershellTags(in)
 	c.Assert(out, jc.DeepEquals, expected)
+}
+
+func (s *RenderersSuite) TestRenderYAML(c *gc.C) {
+	cloudcfg := &cloudinittest.CloudConfig{YAML: []byte("yaml")}
+	d1 := func(in []byte) []byte {
+		return []byte("1." + string(in))
+	}
+	d2 := func(in []byte) []byte {
+		return []byte("2." + string(in))
+	}
+	out, err := renderers.RenderYAML(cloudcfg, os.Windows, d2, d1)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(string(out), jc.DeepEquals, "1.2.yaml")
+	cloudcfg.CheckCallNames(c, "RenderYAML")
+}
+
+func (s *RenderersSuite) TestRenderScript(c *gc.C) {
+	cloudcfg := &cloudinittest.CloudConfig{Script: "script"}
+	d1 := func(in []byte) []byte {
+		return []byte("1." + string(in))
+	}
+	d2 := func(in []byte) []byte {
+		return []byte("2." + string(in))
+	}
+	out, err := renderers.RenderScript(cloudcfg, os.Windows, d2, d1)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(string(out), jc.DeepEquals, "1.2.script")
+	cloudcfg.CheckCallNames(c, "RenderScript")
 }

--- a/cloudconfig/providerinit/renderers/interface.go
+++ b/cloudconfig/providerinit/renderers/interface.go
@@ -10,6 +10,8 @@ package renderers
 
 import (
 	"github.com/juju/utils/os"
+
+	"github.com/juju/juju/cloudconfig/cloudinit"
 )
 
 // ProviderRenderer defines a method to encode userdata depending on
@@ -18,8 +20,5 @@ import (
 // the userdata differently(bash vs yaml) since some providers might
 // not ship cloudinit on every OS
 type ProviderRenderer interface {
-
-	// EncodeUserdata takes a []byte and encodes it in the right format.
-	// The implementations are based on the different providers and OSTypes.
-	EncodeUserdata([]byte, os.OSType) ([]byte, error)
+	Render(cloudinit.CloudConfig, os.OSType) ([]byte, error)
 }

--- a/provider/azure/internal/imageutils/images.go
+++ b/provider/azure/internal/imageutils/images.go
@@ -24,6 +24,9 @@ import (
 var logger = loggo.GetLogger("juju.provider.azure")
 
 const (
+	centOSPublisher = "OpenLogic"
+	centOSOffering  = "CentOS"
+
 	ubuntuPublisher = "Canonical"
 	ubuntuOffering  = "UbuntuServer"
 
@@ -57,6 +60,7 @@ func SeriesImage(
 		if err != nil {
 			return nil, errors.Annotatef(err, "selecting SKU for %s", series)
 		}
+
 	case os.Windows:
 		publisher = windowsPublisher
 		offering = windowsOffering
@@ -65,7 +69,20 @@ func SeriesImage(
 			sku = "2012-Datacenter"
 		case "win2012r2":
 			sku = "2012-R2-Datacenter"
+		default:
+			return nil, errors.NotSupportedf("deploying %s", series)
 		}
+
+	case os.CentOS:
+		publisher = centOSPublisher
+		offering = centOSOffering
+		switch series {
+		case "centos7":
+			sku = "7.1"
+		default:
+			return nil, errors.NotSupportedf("deploying %s", series)
+		}
+
 	default:
 		// TODO(axw) CentOS
 		return nil, errors.NotSupportedf("deploying %s", seriesOS)

--- a/provider/azure/internal/imageutils/images_test.go
+++ b/provider/azure/internal/imageutils/images_test.go
@@ -64,8 +64,12 @@ func (s *imageutilsSuite) TestSeriesImageWindows(c *gc.C) {
 }
 
 func (s *imageutilsSuite) TestSeriesImageCentOS(c *gc.C) {
-	_, err := imageutils.SeriesImage("centos7", "released", "westus", s.client)
-	c.Assert(err, gc.ErrorMatches, "deploying CentOS not supported")
+	s.assertImageId(c, "centos7", "released", "OpenLogic:CentOS:7.1:latest")
+}
+
+func (s *imageutilsSuite) TestSeriesImageArch(c *gc.C) {
+	_, err := imageutils.SeriesImage("arch", "released", "westus", s.client)
+	c.Assert(err, gc.ErrorMatches, "deploying Arch not supported")
 }
 
 func (s *imageutilsSuite) TestSeriesImageStream(c *gc.C) {

--- a/provider/azure/internal/legacy/azure/userdata.go
+++ b/provider/azure/internal/legacy/azure/userdata.go
@@ -9,6 +9,7 @@ import (
 	"github.com/juju/utils"
 	"github.com/juju/utils/os"
 
+	"github.com/juju/juju/cloudconfig/cloudinit"
 	"github.com/juju/juju/cloudconfig/providerinit/renderers"
 )
 
@@ -25,7 +26,11 @@ rm C:\AzureData\CustomData.ps1
 
 type AzureRenderer struct{}
 
-func (AzureRenderer) EncodeUserdata(udata []byte, vers os.OSType) ([]byte, error) {
+func (AzureRenderer) Render(cfg cloudinit.CloudConfig, vers os.OSType) ([]byte, error) {
+	udata, err := cfg.RenderYAML()
+	if err != nil {
+		return nil, err
+	}
 	switch vers {
 	case os.Ubuntu, os.CentOS:
 		return renderers.ToBase64(utils.Gzip(udata)), nil

--- a/provider/azure/internal/legacy/azure/userdata_test.go
+++ b/provider/azure/internal/legacy/azure/userdata_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/utils/os"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cloudconfig/cloudinit/cloudinittest"
 	"github.com/juju/juju/cloudconfig/providerinit/renderers"
 	"github.com/juju/juju/provider/azure/internal/legacy/azure"
 	"github.com/juju/juju/testing"
@@ -25,30 +26,32 @@ var _ = gc.Suite(&UserdataSuite{})
 
 func (s *UserdataSuite) TestAzureUnix(c *gc.C) {
 	renderer := azure.AzureRenderer{}
-	data := []byte("test")
-	result, err := renderer.EncodeUserdata(data, os.Ubuntu)
+	cloudcfg := &cloudinittest.CloudConfig{YAML: []byte("yaml")}
+
+	result, err := renderer.Render(cloudcfg, os.Ubuntu)
 	c.Assert(err, jc.ErrorIsNil)
-	expected := base64.StdEncoding.EncodeToString(utils.Gzip(data))
+	expected := base64.StdEncoding.EncodeToString(utils.Gzip(cloudcfg.YAML))
 	c.Assert(string(result), jc.DeepEquals, expected)
 
-	data = []byte("test")
-	result, err = renderer.EncodeUserdata(data, os.CentOS)
+	result, err = renderer.Render(cloudcfg, os.CentOS)
 	c.Assert(err, jc.ErrorIsNil)
-	expected = base64.StdEncoding.EncodeToString(utils.Gzip(data))
 	c.Assert(string(result), jc.DeepEquals, expected)
 }
 
 func (s *UserdataSuite) TestAzureWindows(c *gc.C) {
 	renderer := azure.AzureRenderer{}
-	data := []byte("test")
-	result, err := renderer.EncodeUserdata(data, os.Windows)
+	cloudcfg := &cloudinittest.CloudConfig{YAML: []byte("yaml")}
+
+	result, err := renderer.Render(cloudcfg, os.Windows)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(result, jc.DeepEquals, renderers.ToBase64(renderers.WinEmbedInScript(data)))
+	expected := base64.StdEncoding.EncodeToString(renderers.WinEmbedInScript(cloudcfg.YAML))
+	c.Assert(string(result), jc.DeepEquals, expected)
 }
 
 func (s *UserdataSuite) TestAzureUnknownOS(c *gc.C) {
 	renderer := azure.AzureRenderer{}
-	result, err := renderer.EncodeUserdata(nil, os.Arch)
-	c.Assert(result, gc.IsNil)
+	cloudcfg := &cloudinittest.CloudConfig{YAML: []byte("yaml")}
+
+	_, err := renderer.Render(cloudcfg, os.Arch)
 	c.Assert(err, gc.ErrorMatches, "Cannot encode userdata for OS: Arch")
 }

--- a/provider/azure/userdata.go
+++ b/provider/azure/userdata.go
@@ -18,13 +18,11 @@ type AzureRenderer struct{}
 func (AzureRenderer) Render(cfg cloudinit.CloudConfig, os jujuos.OSType) ([]byte, error) {
 	switch os {
 	case jujuos.Ubuntu:
-		return renderers.RenderYAML(cfg, os, utils.Gzip, renderers.ToBase64)
-
+		return renderers.RenderYAML(cfg, utils.Gzip, renderers.ToBase64)
 	case jujuos.CentOS:
-		return renderers.RenderScript(cfg, os, renderers.ToBase64)
-
+		return renderers.RenderScript(cfg, renderers.ToBase64)
 	case jujuos.Windows:
-		return renderers.RenderYAML(cfg, os, renderers.WinEmbedInScript, renderers.ToBase64)
+		return renderers.RenderYAML(cfg, renderers.WinEmbedInScript, renderers.ToBase64)
 	default:
 		return nil, errors.Errorf("Cannot encode userdata for OS: %s", os)
 	}

--- a/provider/azure/vmextension.go
+++ b/provider/azure/vmextension.go
@@ -1,0 +1,75 @@
+package azure
+
+import (
+	"github.com/Azure/azure-sdk-for-go/Godeps/_workspace/src/github.com/Azure/go-autorest/autorest/to"
+	"github.com/Azure/azure-sdk-for-go/arm/compute"
+	"github.com/juju/errors"
+	jujuos "github.com/juju/utils/os"
+)
+
+const extensionName = "JujuCustomScriptExtension"
+
+const (
+	windowsExecuteCustomScriptCommand = `` +
+		`move C:\AzureData\CustomData.bin C:\AzureData\CustomData.ps1 && ` +
+		`powershell.exe -ExecutionPolicy Unrestricted -File C:\AzureData\CustomData.ps1 && ` +
+		`del /q C:\AzureData\CustomData.ps1`
+	windowsCustomScriptPublisher = "Microsoft.Compute"
+	windowsCustomScriptType      = "CustomScriptExtension"
+	windowsCustomScriptVersion   = "1.4"
+)
+
+const (
+	// The string will be split and executed by Python's
+	// subprocess.call, not interpreted as a shell command.
+	linuxExecuteCustomScriptCommand = `bash -c 'base64 -d /var/lib/waagent/CustomData | bash'`
+	linuxCustomScriptPublisher      = "Microsoft.OSTCExtensions"
+	linuxCustomScriptType           = "CustomScriptForLinux"
+	linuxCustomScriptVersion        = "1.4"
+)
+
+// createVMExtension creates a CustomScript VM extension for the given VM
+// which will execute the CustomData on the machine as a script.
+func createVMExtension(
+	vmExtensionClient compute.VirtualMachineExtensionsClient,
+	os jujuos.OSType, resourceGroup, vmName, location string, vmTags map[string]string,
+) error {
+	var commandToExecute, extensionPublisher, extensionType, extensionVersion string
+
+	switch os {
+	case jujuos.Windows:
+		commandToExecute = windowsExecuteCustomScriptCommand
+		extensionPublisher = windowsCustomScriptPublisher
+		extensionType = windowsCustomScriptType
+		extensionVersion = windowsCustomScriptVersion
+	case jujuos.CentOS:
+		commandToExecute = linuxExecuteCustomScriptCommand
+		extensionPublisher = linuxCustomScriptPublisher
+		extensionType = linuxCustomScriptType
+		extensionVersion = linuxCustomScriptVersion
+	default:
+		// Ubuntu renders CustomData as cloud-config, and interprets
+		// it with cloud-init. Windows and CentOS do not use cloud-init
+		// on Azure.
+		return errors.NotSupportedf("CustomScript extension for OS %q", os)
+	}
+
+	extensionSettings := map[string]*string{
+		"commandToExecute": to.StringPtr(commandToExecute),
+	}
+	extension := compute.VirtualMachineExtension{
+		Location: to.StringPtr(location),
+		Tags:     toTagsPtr(vmTags),
+		Properties: &compute.VirtualMachineExtensionProperties{
+			Publisher:               to.StringPtr(extensionPublisher),
+			Type:                    to.StringPtr(extensionType),
+			TypeHandlerVersion:      to.StringPtr(extensionVersion),
+			AutoUpgradeMinorVersion: to.BoolPtr(true),
+			Settings:                &extensionSettings,
+		},
+	}
+	_, err := vmExtensionClient.CreateOrUpdate(
+		resourceGroup, vmName, extensionName, extension,
+	)
+	return err
+}

--- a/provider/cloudsigma/userdata.go
+++ b/provider/cloudsigma/userdata.go
@@ -8,15 +8,16 @@ import (
 	"github.com/juju/errors"
 	jujuos "github.com/juju/utils/os"
 
+	"github.com/juju/juju/cloudconfig/cloudinit"
 	"github.com/juju/juju/cloudconfig/providerinit/renderers"
 )
 
 type CloudSigmaRenderer struct{}
 
-func (CloudSigmaRenderer) EncodeUserdata(udata []byte, os jujuos.OSType) ([]byte, error) {
+func (CloudSigmaRenderer) Render(cfg cloudinit.CloudConfig, os jujuos.OSType) ([]byte, error) {
 	switch os {
 	case jujuos.Ubuntu, jujuos.CentOS:
-		return renderers.ToBase64(udata), nil
+		return renderers.RenderYAML(cfg, os, renderers.ToBase64)
 	default:
 		return nil, errors.Errorf("Cannot encode userdata for OS: %s", os.String())
 	}

--- a/provider/cloudsigma/userdata.go
+++ b/provider/cloudsigma/userdata.go
@@ -17,7 +17,7 @@ type CloudSigmaRenderer struct{}
 func (CloudSigmaRenderer) Render(cfg cloudinit.CloudConfig, os jujuos.OSType) ([]byte, error) {
 	switch os {
 	case jujuos.Ubuntu, jujuos.CentOS:
-		return renderers.RenderYAML(cfg, os, renderers.ToBase64)
+		return renderers.RenderYAML(cfg, renderers.ToBase64)
 	default:
 		return nil, errors.Errorf("Cannot encode userdata for OS: %s", os.String())
 	}

--- a/provider/cloudsigma/userdata_test.go
+++ b/provider/cloudsigma/userdata_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/utils/os"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cloudconfig/cloudinit/cloudinittest"
 	"github.com/juju/juju/provider/cloudsigma"
 	"github.com/juju/juju/testing"
 )
@@ -21,22 +22,23 @@ var _ = gc.Suite(&UserdataSuite{})
 
 func (s *UserdataSuite) TestCloudSigmaUnix(c *gc.C) {
 	renderer := cloudsigma.CloudSigmaRenderer{}
-	data := []byte("test")
-	result, err := renderer.EncodeUserdata(data, os.Ubuntu)
+	cloudcfg := &cloudinittest.CloudConfig{YAML: []byte("test")}
+
+	result, err := renderer.Render(cloudcfg, os.Ubuntu)
 	c.Assert(err, jc.ErrorIsNil)
-	expected := base64.StdEncoding.EncodeToString(data)
+	expected := base64.StdEncoding.EncodeToString(cloudcfg.YAML)
 	c.Assert(string(result), jc.DeepEquals, expected)
 
-	data = []byte("test")
-	result, err = renderer.EncodeUserdata(data, os.CentOS)
+	result, err = renderer.Render(cloudcfg, os.CentOS)
 	c.Assert(err, jc.ErrorIsNil)
-	expected = base64.StdEncoding.EncodeToString(data)
+	expected = base64.StdEncoding.EncodeToString(cloudcfg.YAML)
 	c.Assert(string(result), jc.DeepEquals, expected)
 }
 
 func (s *UserdataSuite) TestCloudSigmaUnknownOS(c *gc.C) {
 	renderer := cloudsigma.CloudSigmaRenderer{}
-	result, err := renderer.EncodeUserdata(nil, os.Windows)
+	cloudcfg := &cloudinittest.CloudConfig{YAML: []byte("test")}
+	result, err := renderer.Render(cloudcfg, os.Windows)
 	c.Assert(result, gc.IsNil)
 	c.Assert(err, gc.ErrorMatches, "Cannot encode userdata for OS: Windows")
 }

--- a/provider/ec2/userdata.go
+++ b/provider/ec2/userdata.go
@@ -9,17 +9,18 @@ import (
 	"github.com/juju/utils"
 	jujuos "github.com/juju/utils/os"
 
+	"github.com/juju/juju/cloudconfig/cloudinit"
 	"github.com/juju/juju/cloudconfig/providerinit/renderers"
 )
 
 type AmazonRenderer struct{}
 
-func (AmazonRenderer) EncodeUserdata(udata []byte, os jujuos.OSType) ([]byte, error) {
+func (AmazonRenderer) Render(cfg cloudinit.CloudConfig, os jujuos.OSType) ([]byte, error) {
 	switch os {
 	case jujuos.Ubuntu, jujuos.CentOS:
-		return utils.Gzip(udata), nil
+		return renderers.RenderYAML(cfg, os, utils.Gzip)
 	case jujuos.Windows:
-		return renderers.AddPowershellTags(renderers.WinEmbedInScript(udata)), nil
+		return renderers.RenderYAML(cfg, os, renderers.WinEmbedInScript, renderers.AddPowershellTags)
 	default:
 		return nil, errors.Errorf("Cannot encode userdata for OS: %s", os.String())
 	}

--- a/provider/ec2/userdata.go
+++ b/provider/ec2/userdata.go
@@ -18,9 +18,9 @@ type AmazonRenderer struct{}
 func (AmazonRenderer) Render(cfg cloudinit.CloudConfig, os jujuos.OSType) ([]byte, error) {
 	switch os {
 	case jujuos.Ubuntu, jujuos.CentOS:
-		return renderers.RenderYAML(cfg, os, utils.Gzip)
+		return renderers.RenderYAML(cfg, utils.Gzip)
 	case jujuos.Windows:
-		return renderers.RenderYAML(cfg, os, renderers.WinEmbedInScript, renderers.AddPowershellTags)
+		return renderers.RenderYAML(cfg, renderers.WinEmbedInScript, renderers.AddPowershellTags)
 	default:
 		return nil, errors.Errorf("Cannot encode userdata for OS: %s", os.String())
 	}

--- a/provider/ec2/userdata_test.go
+++ b/provider/ec2/userdata_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/utils/os"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cloudconfig/cloudinit/cloudinittest"
 	"github.com/juju/juju/cloudconfig/providerinit/renderers"
 	"github.com/juju/juju/provider/ec2"
 	"github.com/juju/juju/testing"
@@ -23,31 +24,33 @@ var _ = gc.Suite(&UserdataSuite{})
 
 func (s *UserdataSuite) TestAmazonUnix(c *gc.C) {
 	renderer := ec2.AmazonRenderer{}
-	data := []byte("test")
-	result, err := renderer.EncodeUserdata(data, os.Ubuntu)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(result, jc.DeepEquals, utils.Gzip(data))
+	cloudcfg := &cloudinittest.CloudConfig{YAML: []byte("yaml")}
 
-	data = []byte("test")
-	result, err = renderer.EncodeUserdata(data, os.CentOS)
+	result, err := renderer.Render(cloudcfg, os.Ubuntu)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(result, jc.DeepEquals, utils.Gzip(data))
+	c.Assert(result, jc.DeepEquals, utils.Gzip(cloudcfg.YAML))
+
+	result, err = renderer.Render(cloudcfg, os.CentOS)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, jc.DeepEquals, utils.Gzip(cloudcfg.YAML))
 }
 
 func (s *UserdataSuite) TestAmazonWindows(c *gc.C) {
 	renderer := ec2.AmazonRenderer{}
-	data := []byte("test")
-	result, err := renderer.EncodeUserdata(data, os.Windows)
+	cloudcfg := &cloudinittest.CloudConfig{YAML: []byte("yaml")}
+
+	result, err := renderer.Render(cloudcfg, os.Windows)
 	c.Assert(err, jc.ErrorIsNil)
 	expected := []byte(`<powershell>` +
-		string(renderers.WinEmbedInScript(data)) +
+		string(renderers.WinEmbedInScript(cloudcfg.YAML)) +
 		`</powershell>`)
 	c.Assert(result, jc.DeepEquals, expected)
 }
 
 func (s *UserdataSuite) TestAmazonUnknownOS(c *gc.C) {
 	renderer := ec2.AmazonRenderer{}
-	result, err := renderer.EncodeUserdata(nil, os.Arch)
+	cloudcfg := &cloudinittest.CloudConfig{}
+	result, err := renderer.Render(cloudcfg, os.Arch)
 	c.Assert(result, gc.IsNil)
 	c.Assert(err, gc.ErrorMatches, "Cannot encode userdata for OS: Arch")
 }

--- a/provider/gce/userdata.go
+++ b/provider/gce/userdata.go
@@ -18,9 +18,9 @@ type GCERenderer struct{}
 func (GCERenderer) Render(cfg cloudinit.CloudConfig, os jujuos.OSType) ([]byte, error) {
 	switch os {
 	case jujuos.Ubuntu, jujuos.CentOS:
-		return renderers.RenderYAML(cfg, os, utils.Gzip, renderers.ToBase64)
+		return renderers.RenderYAML(cfg, utils.Gzip, renderers.ToBase64)
 	case jujuos.Windows:
-		return renderers.RenderYAML(cfg, os, renderers.WinEmbedInScript)
+		return renderers.RenderYAML(cfg, renderers.WinEmbedInScript)
 	default:
 		return nil, errors.Errorf("Cannot encode userdata for OS: %s", os.String())
 	}

--- a/provider/gce/userdata.go
+++ b/provider/gce/userdata.go
@@ -9,17 +9,18 @@ import (
 	"github.com/juju/utils"
 	jujuos "github.com/juju/utils/os"
 
+	"github.com/juju/juju/cloudconfig/cloudinit"
 	"github.com/juju/juju/cloudconfig/providerinit/renderers"
 )
 
 type GCERenderer struct{}
 
-func (GCERenderer) EncodeUserdata(udata []byte, os jujuos.OSType) ([]byte, error) {
+func (GCERenderer) Render(cfg cloudinit.CloudConfig, os jujuos.OSType) ([]byte, error) {
 	switch os {
 	case jujuos.Ubuntu, jujuos.CentOS:
-		return renderers.ToBase64(utils.Gzip(udata)), nil
+		return renderers.RenderYAML(cfg, os, utils.Gzip, renderers.ToBase64)
 	case jujuos.Windows:
-		return renderers.WinEmbedInScript(udata), nil
+		return renderers.RenderYAML(cfg, os, renderers.WinEmbedInScript)
 	default:
 		return nil, errors.Errorf("Cannot encode userdata for OS: %s", os.String())
 	}

--- a/provider/gce/userdata_test.go
+++ b/provider/gce/userdata_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/utils/os"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cloudconfig/cloudinit/cloudinittest"
 	"github.com/juju/juju/cloudconfig/providerinit/renderers"
 	"github.com/juju/juju/provider/gce"
 	"github.com/juju/juju/testing"
@@ -25,30 +26,33 @@ var _ = gc.Suite(&UserdataSuite{})
 
 func (s *UserdataSuite) TestGCEUnix(c *gc.C) {
 	renderer := gce.GCERenderer{}
-	data := []byte("test")
-	result, err := renderer.EncodeUserdata(data, os.Ubuntu)
+	cloudcfg := &cloudinittest.CloudConfig{YAML: []byte("yaml")}
+
+	result, err := renderer.Render(cloudcfg, os.Ubuntu)
 	c.Assert(err, jc.ErrorIsNil)
-	expected := base64.StdEncoding.EncodeToString(utils.Gzip(data))
+	expected := base64.StdEncoding.EncodeToString(utils.Gzip(cloudcfg.YAML))
 	c.Assert(string(result), jc.DeepEquals, expected)
 
-	data = []byte("test")
-	result, err = renderer.EncodeUserdata(data, os.CentOS)
+	result, err = renderer.Render(cloudcfg, os.CentOS)
 	c.Assert(err, jc.ErrorIsNil)
-	expected = base64.StdEncoding.EncodeToString(utils.Gzip(data))
+	expected = base64.StdEncoding.EncodeToString(utils.Gzip(cloudcfg.YAML))
 	c.Assert(string(result), jc.DeepEquals, expected)
 }
 
 func (s *UserdataSuite) TestAzureWindows(c *gc.C) {
 	renderer := gce.GCERenderer{}
-	data := []byte("test")
-	result, err := renderer.EncodeUserdata(data, os.Windows)
+	cloudcfg := &cloudinittest.CloudConfig{YAML: []byte("yaml")}
+
+	result, err := renderer.Render(cloudcfg, os.Windows)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(result, jc.DeepEquals, renderers.WinEmbedInScript(data))
+	c.Assert(result, jc.DeepEquals, renderers.WinEmbedInScript(cloudcfg.YAML))
 }
 
 func (s *UserdataSuite) TestGCEUnknownOS(c *gc.C) {
 	renderer := gce.GCERenderer{}
-	result, err := renderer.EncodeUserdata(nil, os.Arch)
+	cloudcfg := &cloudinittest.CloudConfig{}
+
+	result, err := renderer.Render(cloudcfg, os.Arch)
 	c.Assert(result, gc.IsNil)
 	c.Assert(err, gc.ErrorMatches, "Cannot encode userdata for OS: Arch")
 }

--- a/provider/joyent/userdata.go
+++ b/provider/joyent/userdata.go
@@ -6,16 +6,18 @@ package joyent
 
 import (
 	"github.com/juju/errors"
-
 	jujuos "github.com/juju/utils/os"
+
+	"github.com/juju/juju/cloudconfig/cloudinit"
+	"github.com/juju/juju/cloudconfig/providerinit/renderers"
 )
 
 type JoyentRenderer struct{}
 
-func (JoyentRenderer) EncodeUserdata(udata []byte, os jujuos.OSType) ([]byte, error) {
+func (JoyentRenderer) Render(cfg cloudinit.CloudConfig, os jujuos.OSType) ([]byte, error) {
 	switch os {
 	case jujuos.Ubuntu, jujuos.CentOS:
-		return udata, nil
+		return renderers.RenderYAML(cfg, os)
 	default:
 		return nil, errors.Errorf("Cannot encode userdata for OS: %s", os.String())
 	}

--- a/provider/joyent/userdata.go
+++ b/provider/joyent/userdata.go
@@ -17,7 +17,7 @@ type JoyentRenderer struct{}
 func (JoyentRenderer) Render(cfg cloudinit.CloudConfig, os jujuos.OSType) ([]byte, error) {
 	switch os {
 	case jujuos.Ubuntu, jujuos.CentOS:
-		return renderers.RenderYAML(cfg, os)
+		return renderers.RenderYAML(cfg)
 	default:
 		return nil, errors.Errorf("Cannot encode userdata for OS: %s", os.String())
 	}

--- a/provider/joyent/userdata_test.go
+++ b/provider/joyent/userdata_test.go
@@ -8,6 +8,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cloudconfig/cloudinit/cloudinittest"
 	"github.com/juju/juju/provider/joyent"
 	"github.com/juju/juju/testing"
 	"github.com/juju/utils/os"
@@ -21,20 +22,21 @@ var _ = gc.Suite(&UserdataSuite{})
 
 func (s *UserdataSuite) TestJoyentUnix(c *gc.C) {
 	renderer := joyent.JoyentRenderer{}
-	data := []byte("test")
-	result, err := renderer.EncodeUserdata(data, os.Ubuntu)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(result, jc.DeepEquals, data)
+	cloudcfg := &cloudinittest.CloudConfig{YAML: []byte("yaml")}
 
-	data = []byte("test")
-	result, err = renderer.EncodeUserdata(data, os.CentOS)
+	result, err := renderer.Render(cloudcfg, os.Ubuntu)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(result, jc.DeepEquals, data)
+	c.Assert(result, jc.DeepEquals, cloudcfg.YAML)
+
+	result, err = renderer.Render(cloudcfg, os.CentOS)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, jc.DeepEquals, cloudcfg.YAML)
 }
 
 func (s *UserdataSuite) TestJoyentUnknownOS(c *gc.C) {
 	renderer := joyent.JoyentRenderer{}
-	result, err := renderer.EncodeUserdata(nil, os.Windows)
+	cloudcfg := &cloudinittest.CloudConfig{}
+	result, err := renderer.Render(cloudcfg, os.Windows)
 	c.Assert(result, gc.IsNil)
 	c.Assert(err, gc.ErrorMatches, "Cannot encode userdata for OS: Windows")
 }

--- a/provider/lxd/userdata.go
+++ b/provider/lxd/userdata.go
@@ -8,15 +8,18 @@ package lxd
 import (
 	"github.com/juju/errors"
 	jujuos "github.com/juju/utils/os"
+
+	"github.com/juju/juju/cloudconfig/cloudinit"
+	"github.com/juju/juju/cloudconfig/providerinit/renderers"
 )
 
 type lxdRenderer struct{}
 
 // EncodeUserdata implements renderers.ProviderRenderer.
-func (lxdRenderer) EncodeUserdata(udata []byte, os jujuos.OSType) ([]byte, error) {
+func (lxdRenderer) Render(cfg cloudinit.CloudConfig, os jujuos.OSType) ([]byte, error) {
 	switch os {
 	case jujuos.Ubuntu, jujuos.CentOS:
-		return udata, nil
+		return renderers.RenderYAML(cfg, os)
 	default:
 		return nil, errors.Errorf("cannot encode userdata for OS %q", os)
 	}

--- a/provider/lxd/userdata.go
+++ b/provider/lxd/userdata.go
@@ -19,7 +19,7 @@ type lxdRenderer struct{}
 func (lxdRenderer) Render(cfg cloudinit.CloudConfig, os jujuos.OSType) ([]byte, error) {
 	switch os {
 	case jujuos.Ubuntu, jujuos.CentOS:
-		return renderers.RenderYAML(cfg, os)
+		return renderers.RenderYAML(cfg)
 	default:
 		return nil, errors.Errorf("cannot encode userdata for OS %q", os)
 	}

--- a/provider/maas/userdata.go
+++ b/provider/maas/userdata.go
@@ -18,9 +18,9 @@ type MAASRenderer struct{}
 func (MAASRenderer) Render(cfg cloudinit.CloudConfig, os jujuos.OSType) ([]byte, error) {
 	switch os {
 	case jujuos.Ubuntu, jujuos.CentOS:
-		return renderers.RenderYAML(cfg, os, utils.Gzip, renderers.ToBase64)
+		return renderers.RenderYAML(cfg, utils.Gzip, renderers.ToBase64)
 	case jujuos.Windows:
-		return renderers.RenderYAML(cfg, os, renderers.WinEmbedInScript, renderers.ToBase64)
+		return renderers.RenderYAML(cfg, renderers.WinEmbedInScript, renderers.ToBase64)
 	default:
 		return nil, errors.Errorf("Cannot encode userdata for OS: %s", os.String())
 	}

--- a/provider/maas/userdata.go
+++ b/provider/maas/userdata.go
@@ -9,17 +9,18 @@ import (
 	"github.com/juju/utils"
 	jujuos "github.com/juju/utils/os"
 
+	"github.com/juju/juju/cloudconfig/cloudinit"
 	"github.com/juju/juju/cloudconfig/providerinit/renderers"
 )
 
 type MAASRenderer struct{}
 
-func (MAASRenderer) EncodeUserdata(udata []byte, os jujuos.OSType) ([]byte, error) {
+func (MAASRenderer) Render(cfg cloudinit.CloudConfig, os jujuos.OSType) ([]byte, error) {
 	switch os {
 	case jujuos.Ubuntu, jujuos.CentOS:
-		return renderers.ToBase64(utils.Gzip(udata)), nil
+		return renderers.RenderYAML(cfg, os, utils.Gzip, renderers.ToBase64)
 	case jujuos.Windows:
-		return renderers.ToBase64(renderers.WinEmbedInScript(udata)), nil
+		return renderers.RenderYAML(cfg, os, renderers.WinEmbedInScript, renderers.ToBase64)
 	default:
 		return nil, errors.Errorf("Cannot encode userdata for OS: %s", os.String())
 	}

--- a/provider/maas/userdata_test.go
+++ b/provider/maas/userdata_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/utils/os"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cloudconfig/cloudinit/cloudinittest"
 	"github.com/juju/juju/cloudconfig/providerinit/renderers"
 	"github.com/juju/juju/provider/maas"
 	"github.com/juju/juju/testing"
@@ -25,31 +26,33 @@ var _ = gc.Suite(&RenderersSuite{})
 
 func (s *RenderersSuite) TestMAASUnix(c *gc.C) {
 	renderer := maas.MAASRenderer{}
-	data := []byte("test")
-	result, err := renderer.EncodeUserdata(data, os.Ubuntu)
+	cloudcfg := &cloudinittest.CloudConfig{YAML: []byte("yaml")}
+
+	result, err := renderer.Render(cloudcfg, os.Ubuntu)
 	c.Assert(err, jc.ErrorIsNil)
-	expected := base64.StdEncoding.EncodeToString(utils.Gzip(data))
+	expected := base64.StdEncoding.EncodeToString(utils.Gzip(cloudcfg.YAML))
 	c.Assert(string(result), jc.DeepEquals, expected)
 
-	data = []byte("test")
-	result, err = renderer.EncodeUserdata(data, os.CentOS)
+	result, err = renderer.Render(cloudcfg, os.CentOS)
 	c.Assert(err, jc.ErrorIsNil)
-	expected = base64.StdEncoding.EncodeToString(utils.Gzip(data))
+	expected = base64.StdEncoding.EncodeToString(utils.Gzip(cloudcfg.YAML))
 	c.Assert(string(result), jc.DeepEquals, expected)
 }
 
 func (s *RenderersSuite) TestMAASWindows(c *gc.C) {
 	renderer := maas.MAASRenderer{}
-	data := []byte("test")
-	result, err := renderer.EncodeUserdata(data, os.Windows)
+	cloudcfg := &cloudinittest.CloudConfig{YAML: []byte("yaml")}
+
+	result, err := renderer.Render(cloudcfg, os.Windows)
 	c.Assert(err, jc.ErrorIsNil)
-	expected := base64.StdEncoding.EncodeToString(renderers.WinEmbedInScript(data))
+	expected := base64.StdEncoding.EncodeToString(renderers.WinEmbedInScript(cloudcfg.YAML))
 	c.Assert(string(result), jc.DeepEquals, expected)
 }
 
 func (s *RenderersSuite) TestMAASUnknownOS(c *gc.C) {
 	renderer := maas.MAASRenderer{}
-	result, err := renderer.EncodeUserdata(nil, os.Arch)
+	cloudcfg := &cloudinittest.CloudConfig{}
+	result, err := renderer.Render(cloudcfg, os.Arch)
 	c.Assert(result, gc.IsNil)
 	c.Assert(err, gc.ErrorMatches, "Cannot encode userdata for OS: Arch")
 }

--- a/provider/openstack/userdata.go
+++ b/provider/openstack/userdata.go
@@ -18,9 +18,9 @@ type OpenstackRenderer struct{}
 func (OpenstackRenderer) Render(cfg cloudinit.CloudConfig, os jujuos.OSType) ([]byte, error) {
 	switch os {
 	case jujuos.Ubuntu, jujuos.CentOS:
-		return renderers.RenderYAML(cfg, os, utils.Gzip)
+		return renderers.RenderYAML(cfg, utils.Gzip)
 	case jujuos.Windows:
-		return renderers.RenderYAML(cfg, os, renderers.WinEmbedInScript)
+		return renderers.RenderYAML(cfg, renderers.WinEmbedInScript)
 	default:
 		return nil, errors.Errorf("Cannot encode userdata for OS: %s", os.String())
 	}

--- a/provider/openstack/userdata.go
+++ b/provider/openstack/userdata.go
@@ -7,19 +7,20 @@ package openstack
 import (
 	"github.com/juju/errors"
 	"github.com/juju/utils"
-
-	"github.com/juju/juju/cloudconfig/providerinit/renderers"
 	jujuos "github.com/juju/utils/os"
+
+	"github.com/juju/juju/cloudconfig/cloudinit"
+	"github.com/juju/juju/cloudconfig/providerinit/renderers"
 )
 
 type OpenstackRenderer struct{}
 
-func (OpenstackRenderer) EncodeUserdata(udata []byte, os jujuos.OSType) ([]byte, error) {
+func (OpenstackRenderer) Render(cfg cloudinit.CloudConfig, os jujuos.OSType) ([]byte, error) {
 	switch os {
 	case jujuos.Ubuntu, jujuos.CentOS:
-		return utils.Gzip(udata), nil
+		return renderers.RenderYAML(cfg, os, utils.Gzip)
 	case jujuos.Windows:
-		return renderers.WinEmbedInScript(udata), nil
+		return renderers.RenderYAML(cfg, os, renderers.WinEmbedInScript)
 	default:
 		return nil, errors.Errorf("Cannot encode userdata for OS: %s", os.String())
 	}

--- a/provider/openstack/userdata_test.go
+++ b/provider/openstack/userdata_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/utils/os"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cloudconfig/cloudinit/cloudinittest"
 	"github.com/juju/juju/cloudconfig/providerinit/renderers"
 	"github.com/juju/juju/provider/openstack"
 	"github.com/juju/juju/testing"
@@ -23,28 +24,30 @@ var _ = gc.Suite(&UserdataSuite{})
 
 func (s *UserdataSuite) TestOpenstackUnix(c *gc.C) {
 	renderer := openstack.OpenstackRenderer{}
-	data := []byte("test")
-	result, err := renderer.EncodeUserdata(data, os.Ubuntu)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(result, jc.DeepEquals, utils.Gzip(data))
+	cloudcfg := &cloudinittest.CloudConfig{YAML: []byte("yaml")}
 
-	data = []byte("test")
-	result, err = renderer.EncodeUserdata(data, os.CentOS)
+	result, err := renderer.Render(cloudcfg, os.Ubuntu)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(result, jc.DeepEquals, utils.Gzip(data))
+	c.Assert(result, jc.DeepEquals, utils.Gzip(cloudcfg.YAML))
+
+	result, err = renderer.Render(cloudcfg, os.CentOS)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, jc.DeepEquals, utils.Gzip(cloudcfg.YAML))
 }
 
 func (s *UserdataSuite) TestOpenstackWindows(c *gc.C) {
 	renderer := openstack.OpenstackRenderer{}
-	data := []byte("test")
-	result, err := renderer.EncodeUserdata(data, os.Windows)
+	cloudcfg := &cloudinittest.CloudConfig{YAML: []byte("yaml")}
+
+	result, err := renderer.Render(cloudcfg, os.Windows)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(result, jc.DeepEquals, renderers.WinEmbedInScript(data))
+	c.Assert(result, jc.DeepEquals, renderers.WinEmbedInScript(cloudcfg.YAML))
 }
 
 func (s *UserdataSuite) TestOpenstackUnknownOS(c *gc.C) {
 	renderer := openstack.OpenstackRenderer{}
-	result, err := renderer.EncodeUserdata(nil, os.Arch)
+	cloudcfg := &cloudinittest.CloudConfig{}
+	result, err := renderer.Render(cloudcfg, os.Arch)
 	c.Assert(result, gc.IsNil)
 	c.Assert(err, gc.ErrorMatches, "Cannot encode userdata for OS: Arch")
 }

--- a/provider/vsphere/userdata.go
+++ b/provider/vsphere/userdata.go
@@ -7,16 +7,17 @@ package vsphere
 import (
 	"github.com/juju/errors"
 
+	"github.com/juju/juju/cloudconfig/cloudinit"
 	"github.com/juju/juju/cloudconfig/providerinit/renderers"
 	jujuos "github.com/juju/utils/os"
 )
 
 type VsphereRenderer struct{}
 
-func (VsphereRenderer) EncodeUserdata(udata []byte, os jujuos.OSType) ([]byte, error) {
+func (VsphereRenderer) Render(cfg cloudinit.CloudConfig, os jujuos.OSType) ([]byte, error) {
 	switch os {
 	case jujuos.Ubuntu, jujuos.CentOS:
-		return renderers.ToBase64(udata), nil
+		return renderers.RenderYAML(cfg, os, renderers.ToBase64)
 	default:
 		return nil, errors.Errorf("Cannot encode userdata for OS: %s", os.String())
 	}

--- a/provider/vsphere/userdata.go
+++ b/provider/vsphere/userdata.go
@@ -17,7 +17,7 @@ type VsphereRenderer struct{}
 func (VsphereRenderer) Render(cfg cloudinit.CloudConfig, os jujuos.OSType) ([]byte, error) {
 	switch os {
 	case jujuos.Ubuntu, jujuos.CentOS:
-		return renderers.RenderYAML(cfg, os, renderers.ToBase64)
+		return renderers.RenderYAML(cfg, renderers.ToBase64)
 	default:
 		return nil, errors.Errorf("Cannot encode userdata for OS: %s", os.String())
 	}

--- a/provider/vsphere/userdata_test.go
+++ b/provider/vsphere/userdata_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/utils/os"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cloudconfig/cloudinit/cloudinittest"
 	"github.com/juju/juju/provider/vsphere"
 	"github.com/juju/juju/testing"
 )
@@ -23,22 +24,23 @@ var _ = gc.Suite(&UserdataSuite{})
 
 func (s *UserdataSuite) TestVsphereUnix(c *gc.C) {
 	renderer := vsphere.VsphereRenderer{}
-	data := []byte("test")
-	result, err := renderer.EncodeUserdata(data, os.Ubuntu)
+	cloudcfg := &cloudinittest.CloudConfig{YAML: []byte("yaml")}
+
+	result, err := renderer.Render(cloudcfg, os.Ubuntu)
 	c.Assert(err, jc.ErrorIsNil)
-	expected := base64.StdEncoding.EncodeToString(data)
+	expected := base64.StdEncoding.EncodeToString(cloudcfg.YAML)
 	c.Assert(string(result), jc.DeepEquals, expected)
 
-	data = []byte("test")
-	result, err = renderer.EncodeUserdata(data, os.CentOS)
+	result, err = renderer.Render(cloudcfg, os.CentOS)
 	c.Assert(err, jc.ErrorIsNil)
-	expected = base64.StdEncoding.EncodeToString(data)
+	expected = base64.StdEncoding.EncodeToString(cloudcfg.YAML)
 	c.Assert(string(result), jc.DeepEquals, expected)
 }
 
 func (s *UserdataSuite) TestVsphereUnknownOS(c *gc.C) {
 	renderer := vsphere.VsphereRenderer{}
-	result, err := renderer.EncodeUserdata(nil, os.Windows)
+	cloudcfg := &cloudinittest.CloudConfig{}
+	result, err := renderer.Render(cloudcfg, os.Windows)
 	c.Assert(result, gc.IsNil)
 	c.Assert(err, gc.ErrorMatches, "Cannot encode userdata for OS: Windows")
 }


### PR DESCRIPTION
Most of the changes here are refactoring
the user-data rendering interfaces and
implementations to support rendering to a
script instead of to YAML.

With the rendering changes in place, the
azure provider changes are relatively
trivial: start the OpenLogic CentOS 7.1
image with cloud-config rendered as a
script in CustomData, and then execute it
using the CustomScript extension as we do
on Windows.

(Review request: http://reviews.vapour.ws/r/3405/)