### PR TITLE
provider/azure: rename application-key

### DIFF
--- a/apiserver/environmentmanager/environmentmanager_test.go
+++ b/apiserver/environmentmanager/environmentmanager_test.go
@@ -142,7 +142,7 @@ func (s *envManagerSuite) TestRestrictedProviderFields(c *gc.C) {
 			provider: "azure",
 			expected: []string{
 				"type", "ca-cert", "state-port", "api-port", "syslog-port", "rsyslog-ca-cert", "rsyslog-ca-key",
-				"subscription-id", "tenant-id", "application-id", "application-key", "location",
+				"subscription-id", "tenant-id", "application-id", "application-password", "location",
 				"controller-resource-group", "storage-account-type"},
 		}, {
 			provider: "dummy",

--- a/provider/azure/config.go
+++ b/provider/azure/config.go
@@ -18,7 +18,7 @@ const (
 	configAttrAppId              = "application-id"
 	configAttrSubscriptionId     = "subscription-id"
 	configAttrTenantId           = "tenant-id"
-	configAttrAppKey             = "application-key"
+	configAttrAppPassword        = "application-password"
 	configAttrLocation           = "location"
 	configAttrStorageAccountType = "storage-account-type"
 
@@ -47,7 +47,7 @@ var configFields = schema.Fields{
 	configAttrAppId:                   schema.String(),
 	configAttrSubscriptionId:          schema.String(),
 	configAttrTenantId:                schema.String(),
-	configAttrAppKey:                  schema.String(),
+	configAttrAppPassword:             schema.String(),
 	configAttrStorageAccount:          schema.String(),
 	configAttrStorageAccountKey:       schema.String(),
 	configAttrStorageAccountType:      schema.String(),
@@ -63,7 +63,7 @@ var configDefaults = schema.Defaults{
 
 var requiredConfigAttributes = []string{
 	configAttrAppId,
-	configAttrAppKey,
+	configAttrAppPassword,
 	configAttrSubscriptionId,
 	configAttrTenantId,
 	configAttrLocation,
@@ -164,7 +164,7 @@ func validateConfig(newCfg, oldCfg *config.Config) (*azureEnvironConfig, error) 
 	appId := validated[configAttrAppId].(string)
 	subscriptionId := validated[configAttrSubscriptionId].(string)
 	tenantId := validated[configAttrTenantId].(string)
-	appKey := validated[configAttrAppKey].(string)
+	appPassword := validated[configAttrAppPassword].(string)
 	storageAccount, _ := validated[configAttrStorageAccount].(string)
 	storageAccountKey, _ := validated[configAttrStorageAccountKey].(string)
 	storageAccountType := validated[configAttrStorageAccountType].(string)
@@ -183,7 +183,7 @@ func validateConfig(newCfg, oldCfg *config.Config) (*azureEnvironConfig, error) 
 	}
 
 	token, err := azure.NewServicePrincipalToken(
-		appId, appKey, tenantId,
+		appId, appPassword, tenantId,
 		azure.AzureResourceManagerScope,
 	)
 	if err != nil {
@@ -239,8 +239,8 @@ azure:
     #   https://azure.microsoft.com/en-us/documentation/articles/resource-group-authenticate-service-principal
     application-id: 00000000-0000-0000-0000-000000000000
 
-    # application-key is the password specified when creating the application
-    # in Azure Active Directory.
+    # application-password is the password specified when creating the
+    # application in Azure Active Directory.
     application-password: XXX
 
     # subscription-id defines the Azure account subscription ID to

--- a/provider/azure/config_test.go
+++ b/provider/azure/config_test.go
@@ -64,7 +64,7 @@ func (s *configSuite) TestValidateLocation(c *gc.C) {
 
 func (s *configSuite) TestValidateInvalidCredentials(c *gc.C) {
 	s.assertConfigInvalid(c, testing.Attrs{"application-id": ""}, `"application-id" config not specified`)
-	s.assertConfigInvalid(c, testing.Attrs{"application-key": ""}, `"application-key" config not specified`)
+	s.assertConfigInvalid(c, testing.Attrs{"application-password": ""}, `"application-password" config not specified`)
 	s.assertConfigInvalid(c, testing.Attrs{"tenant-id": ""}, `"tenant-id" config not specified`)
 	s.assertConfigInvalid(c, testing.Attrs{"subscription-id": ""}, `"subscription-id" config not specified`)
 	s.assertConfigInvalid(c, testing.Attrs{"controller-resource-group": ""}, `"controller-resource-group" config not specified`)
@@ -101,7 +101,7 @@ func makeTestEnvironConfig(c *gc.C, extra ...testing.Attrs) *config.Config {
 		"type":                      "azure",
 		"application-id":            fakeApplicationId,
 		"tenant-id":                 fakeTenantId,
-		"application-key":           "opensezme",
+		"application-password":      "opensezme",
 		"subscription-id":           fakeSubscriptionId,
 		"location":                  "westus",
 		"controller-resource-group": "arbitrary",

--- a/provider/azure/environprovider.go
+++ b/provider/azure/environprovider.go
@@ -78,7 +78,7 @@ func (prov *azureEnvironProvider) RestrictedConfigAttributes() []string {
 		configAttrSubscriptionId,
 		configAttrTenantId,
 		configAttrAppId,
-		configAttrAppKey,
+		configAttrAppPassword,
 		configAttrLocation,
 		configAttrControllerResourceGroup,
 		configAttrStorageAccountType,
@@ -141,7 +141,7 @@ func (prov *azureEnvironProvider) BoilerplateConfig() string {
 func (prov *azureEnvironProvider) SecretAttrs(cfg *config.Config) (map[string]string, error) {
 	unknownAttrs := cfg.UnknownAttrs()
 	secretAttrs := map[string]string{
-		configAttrAppKey: unknownAttrs[configAttrAppKey].(string),
+		configAttrAppPassword: unknownAttrs[configAttrAppPassword].(string),
 	}
 	if storageAccountKey, ok := unknownAttrs[configAttrStorageAccountKey].(string); ok {
 		secretAttrs[configAttrStorageAccountKey] = storageAccountKey


### PR DESCRIPTION
Rename application-key to application-password
to be more obvious, and also correct w.r.t. the
config boilerplate.

Fixes #3975

(Review request: http://reviews.vapour.ws/r/3406/)