### PR TITLE
Make Openstack MultiSameNameEnvs compatible.

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -48,7 +48,7 @@ google.golang.org/cloud	git	f20d6dcccb44ed49de45ae3703312cb46e627db1	2015-03-19T
 gopkg.in/amz.v3	git	bff3a097c4108da57bb8cbe3aad2990d74d23676	2015-08-20T12:28:33Z
 gopkg.in/check.v1	git	b3d3430320d4260e5fea99841af984b3badcea63	2015-06-26T10:50:28Z
 gopkg.in/errgo.v1	git	66cb46252b94c1f3d65646f54ee8043ab38d766c	2015-10-07T15:31:57Z
-gopkg.in/goose.v1	git	e4a91e8b8323b8eef6fe41a66fd3ac6120520bb0	2015-11-13T22:25:24Z
+gopkg.in/goose.v1	git	33121bddecedb2c9f9053c5c84ee729c379ab5ac	2015-11-13T22:25:24Z
 gopkg.in/inconshreveable/log15.v2	git	b105bd37f74e5d9dc7b6ad7806715c7a2b83fd3f	2015-09-21T21:38:54Z
 gopkg.in/juju/charm.v6-unstable	git	ba541b945799430ccfcbab02453d898bfa714f27	2015-11-24T15:06:54Z
 gopkg.in/juju/charmrepo.v2-unstable	git	0dccc5f663f5842ead1ee6855bf7f7c87e7ca2fa	2015-11-26T03:49:04Z

--- a/juju/testing/instance.go
+++ b/juju/testing/instance.go
@@ -15,6 +15,7 @@ import (
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/imagemetadata"
+	"github.com/juju/juju/environs/tags"
 	"github.com/juju/juju/environs/tools"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/mongo"
@@ -191,6 +192,8 @@ func StartInstanceWithParams(
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+	eUUID, _ := env.Config().UUID()
+	instanceConfig.Tags[tags.JujuEnv] = eUUID
 	params.Tools = possibleTools
 	params.InstanceConfig = instanceConfig
 	return env.StartInstance(params)

--- a/provider/interfaces.go
+++ b/provider/interfaces.go
@@ -1,0 +1,12 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package provider
+
+import "github.com/juju/juju/version"
+
+// Upgradable represents a provider that supports upgrade steps
+// if present, these steps will get called upon upgrading.
+type Upgradable interface {
+	RunUpgradeStepsFor(version.Number) error
+}

--- a/provider/interfaces.go
+++ b/provider/interfaces.go
@@ -5,8 +5,8 @@ package provider
 
 import "github.com/juju/juju/version"
 
-// Upgradable represents a provider that supports upgrade steps
+// Upgradeable represents a provider that supports upgrade steps
 // if present, these steps will get called upon upgrading.
-type Upgradable interface {
+type Upgradeable interface {
 	RunUpgradeStepsFor(version.Number) error
 }

--- a/provider/openstack/firewaller.go
+++ b/provider/openstack/firewaller.go
@@ -430,5 +430,7 @@ func (c *defaultFirewaller) machineGroupName(machineId string) string {
 }
 
 func (c *defaultFirewaller) jujuGroupName() string {
-	return fmt.Sprintf("juju-%s", c.environ.name)
+	cfg := c.environ.Config()
+	eUUID, _ := cfg.UUID()
+	return fmt.Sprintf("juju-%s", eUUID)
 }

--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -484,12 +484,12 @@ func (s *localServerSuite) TestStopInstance(c *gc.C) {
 	// Openstack now has three security groups for the server, the default
 	// group, one group for the entire environment, and another for the
 	// new instance.
-	name := env.Config().Name()
-	assertSecurityGroups(c, env, []string{"default", fmt.Sprintf("juju-%v", name), fmt.Sprintf("juju-%v-%v", name, instanceName)})
+	eUUID, _ := env.Config().UUID()
+	assertSecurityGroups(c, env, []string{"default", fmt.Sprintf("juju-%v", eUUID), fmt.Sprintf("juju-%v-%v", eUUID, instanceName)})
 	err = env.StopInstances(inst.Id())
 	c.Assert(err, jc.ErrorIsNil)
 	// The security group for this instance is now removed.
-	assertSecurityGroups(c, env, []string{"default", fmt.Sprintf("juju-%v", name)})
+	assertSecurityGroups(c, env, []string{"default", fmt.Sprintf("juju-%v", eUUID)})
 }
 
 // Due to bug #1300755 it can happen that the security group intended for
@@ -514,8 +514,8 @@ func (s *localServerSuite) TestStopInstanceSecurityGroupNotDeleted(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	instanceName := "100"
 	inst, _ := testing.AssertStartInstance(c, env, instanceName)
-	name := env.Config().Name()
-	allSecurityGroups := []string{"default", fmt.Sprintf("juju-%v", name), fmt.Sprintf("juju-%v-%v", name, instanceName)}
+	eUUID, _ := env.Config().UUID()
+	allSecurityGroups := []string{"default", fmt.Sprintf("juju-%v", eUUID), fmt.Sprintf("juju-%v-%v", eUUID, instanceName)}
 	assertSecurityGroups(c, env, allSecurityGroups)
 	err = env.StopInstances(inst.Id())
 	c.Assert(err, jc.ErrorIsNil)
@@ -530,8 +530,8 @@ func (s *localServerSuite) TestDestroyEnvironmentDeletesSecurityGroupsFWModeInst
 	c.Assert(err, jc.ErrorIsNil)
 	instanceName := "100"
 	testing.AssertStartInstance(c, env, instanceName)
-	name := env.Config().Name()
-	allSecurityGroups := []string{"default", fmt.Sprintf("juju-%v", name), fmt.Sprintf("juju-%v-%v", name, instanceName)}
+	eUUID, _ := env.Config().UUID()
+	allSecurityGroups := []string{"default", fmt.Sprintf("juju-%v", eUUID), fmt.Sprintf("juju-%v-%v", eUUID, instanceName)}
 	assertSecurityGroups(c, env, allSecurityGroups)
 	err = env.Destroy()
 	c.Check(err, jc.ErrorIsNil)
@@ -546,8 +546,8 @@ func (s *localServerSuite) TestDestroyEnvironmentDeletesSecurityGroupsFWModeGlob
 	c.Assert(err, jc.ErrorIsNil)
 	instanceName := "100"
 	testing.AssertStartInstance(c, env, instanceName)
-	name := env.Config().Name()
-	allSecurityGroups := []string{"default", fmt.Sprintf("juju-%v", name), fmt.Sprintf("juju-%v-global", name)}
+	eUUID, _ := env.Config().UUID()
+	allSecurityGroups := []string{"default", fmt.Sprintf("juju-%v", eUUID), fmt.Sprintf("juju-%v-global", eUUID)}
 	assertSecurityGroups(c, env, allSecurityGroups)
 	err = env.Destroy()
 	c.Check(err, jc.ErrorIsNil)

--- a/provider/openstack/upgrade.go
+++ b/provider/openstack/upgrade.go
@@ -1,0 +1,108 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package openstack
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/juju/errors"
+	"github.com/juju/juju/version"
+	"gopkg.in/goose.v1/nova"
+)
+
+// RunUpgradeStepsFor implements provider.Upgradable
+func (e *Environ) RunUpgradeStepsFor(ver version.Number) error {
+	switch ver {
+	case version.Number{Major: 1, Minor: 26}:
+		if err := addUUIDToSecurityGroupNames(e); err != nil {
+			return errors.Annotate(err, "upgrading security group names in upgrade step for version 1.26")
+		}
+		if err := addUUIDToMachineNames(e); err != nil {
+			return errors.Annotate(err, "upgrading security machine names in upgrade step for version 1.26")
+		}
+	}
+	return nil
+}
+
+func replaceNameWithID(oldName, envName, eUUID string) (string, error, bool) {
+	nameStart := strings.LastIndex(oldName, envName)
+	if nameStart <= -1 {
+		uuidPresent := strings.LastIndex(oldName, eUUID)
+		if uuidPresent < 0 {
+			return "", nil, false
+		}
+		return oldName, nil, false
+	}
+	partial := oldName[nameStart:]
+	return fmt.Sprintf("%s%s", oldName[:nameStart], strings.Replace(partial, envName, eUUID, -1)), nil, true
+}
+
+func addUUIDToSecurityGroupNames(e *Environ) error {
+	nova := e.nova()
+	groups, err := nova.ListSecurityGroups()
+	if err != nil {
+		return errors.Annotate(err, "upgrading instance names")
+	}
+	cfg := e.Config()
+	eName := cfg.Name()
+	eUUID, ok := cfg.UUID()
+	if !ok {
+		return errors.NotFoundf("environment uuid for environment %q", eName)
+	}
+	for _, group := range groups {
+		newName, err, ok := replaceNameWithID(group.Name, eName, eUUID)
+		if err != nil {
+			return errors.Annotate(err, "generating the new security group name")
+		}
+		if !ok {
+			continue
+		}
+		// Name should have uuid instead of name
+		_, err = nova.UpdateSecurityGroup(group.Id, newName, group.Description)
+		if err != nil {
+			return errors.Annotatef(err, "upgrading security group name from %q to %q", group.Name, newName)
+		}
+
+	}
+	return nil
+}
+
+// oldMachinesFilter returns a nova.Filter matching all machines in the environment
+// that use the old name schema (juju-EnvironmentName-number).
+func oldMachinesFilter(e *Environ) *nova.Filter {
+	filter := nova.NewFilter()
+	filter.Set(nova.FilterServer, fmt.Sprintf("juju-%s-machine-\\d*", e.Config().Name()))
+	return filter
+}
+
+func addUUIDToMachineNames(e *Environ) error {
+	nova := e.nova()
+	servers, err := nova.ListServers(oldMachinesFilter(e))
+	if err != nil {
+		return errors.Annotate(err, "upgrading server names")
+	}
+	cfg := e.Config()
+	eName := cfg.Name()
+	eUUID, ok := cfg.UUID()
+	if !ok {
+		return errors.NotFoundf("environment uuid for environment %q", eName)
+	}
+	for _, server := range servers {
+		newName, err, ok := replaceNameWithID(server.Name, eName, eUUID)
+		if err != nil {
+			return errors.Annotate(err, "generating the new server name")
+		}
+		if !ok {
+			continue
+		}
+		// Name should have uuid instead of name
+		_, err = nova.UpdateServerName(server.Id, newName)
+		if err != nil {
+			return errors.Annotatef(err, "upgrading machine name from %q to %q", server.Name, newName)
+		}
+
+	}
+	return nil
+}

--- a/provider/openstack/upgrade.go
+++ b/provider/openstack/upgrade.go
@@ -31,10 +31,9 @@ func replaceNameWithID(oldName, envName, eUUID string) (string, bool, error) {
 	if !strings.HasPrefix(oldName, prefix) {
 		return "", false, nil
 	}
-	if len(prefix) < len(oldName) {
-		if oldName[len(prefix)] != '-' {
-			return "", false, nil
-		}
+	// This might be an env with a name that shares prefix with our current one.
+	if len(prefix) < len(oldName) && !strings.HasPrefix(oldName, prefix+"-") {
+		return "", false, nil
 	}
 	newPrefix := "juju-" + eUUID
 	return strings.Replace(oldName, prefix, newPrefix, -1), true, nil

--- a/upgrades/providerchanges.go
+++ b/upgrades/providerchanges.go
@@ -1,0 +1,29 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/provider"
+	"github.com/juju/juju/version"
+)
+
+func upgradeProviderChanges(env environs.Environ, reader environConfigReader, ver version.Number) error {
+	cfg, err := reader.EnvironConfig()
+	if err != nil {
+		return errors.Annotate(err, "reading environment config")
+	}
+
+	upgrader, ok := env.(provider.Upgradable)
+	if !ok {
+		logger.Debugf("provider %q has no upgrades", cfg.Type())
+		return nil
+	}
+
+	if err := upgrader.RunUpgradeStepsFor(ver); err != nil {
+		return errors.Annotate(err, "running upgrade steps")
+	}
+	return nil
+}

--- a/upgrades/providerchanges.go
+++ b/upgrades/providerchanges.go
@@ -16,7 +16,7 @@ func upgradeProviderChanges(env environs.Environ, reader environConfigReader, ve
 		return errors.Annotate(err, "reading environment config")
 	}
 
-	upgrader, ok := env.(provider.Upgradable)
+	upgrader, ok := env.(provider.Upgradeable)
 	if !ok {
 		logger.Debugf("provider %q has no upgrades", cfg.Type())
 		return nil

--- a/upgrades/steps126.go
+++ b/upgrades/steps126.go
@@ -4,8 +4,11 @@
 package upgrades
 
 import (
+	"github.com/juju/errors"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/state/utils"
+	"github.com/juju/juju/version"
 )
 
 // stepsFor126 returns upgrade steps for Juju 1.26.
@@ -39,6 +42,18 @@ func stateStepsFor126() []Step {
 				// package from provider-specific upgrades.
 				st := context.State()
 				return upgradeEnvironConfig(st, st, environs.GlobalProviderRegistry())
+			},
+		},
+		&upgradeStep{
+			description: "provider side upgrades",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				st := context.State()
+				env, err := utils.GetEnvironment(st)
+				if err != nil {
+					return errors.Annotate(err, "getting provider for upgrade")
+				}
+				return upgradeProviderChanges(env, st, version.Number{Major: 1, Minor: 26})
 			},
 		},
 		&upgradeStep{

--- a/upgrades/steps126.go
+++ b/upgrades/steps126.go
@@ -5,6 +5,7 @@ package upgrades
 
 import (
 	"github.com/juju/errors"
+
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/utils"
@@ -44,6 +45,8 @@ func stateStepsFor126() []Step {
 				return upgradeEnvironConfig(st, st, environs.GlobalProviderRegistry())
 			},
 		},
+		//TODO(perrito666) make this an unconditional upgrade step.
+		// it would be ideal not to have to modify this package whenever we add provider upgrade steps.
 		&upgradeStep{
 			description: "provider side upgrades",
 			targets:     []Target{DatabaseMaster},

--- a/upgrades/steps126_test.go
+++ b/upgrades/steps126_test.go
@@ -26,6 +26,7 @@ func (s *steps126Suite) TestStateStepsFor126(c *gc.C) {
 		"add the version field to all settings docs",
 		"add status to filesystem",
 		"upgrade environment config",
+		"provider side upgrades",
 		"update machine preferred addresses",
 	}
 	assertStateSteps(c, version.MustParse("1.26.0"), expected)


### PR DESCRIPTION
Openstack was using the environment name for certain operations which
made impossible to deploy multimple environments with the same name
with the same credentials.
Now the remaining items:
 * Instances
 * Security Groups

Have been fixed to use environment UUID instead.

(Review request: http://reviews.vapour.ws/r/3408/)