### PR TITLE
Add upgradewaiter 

### DIFF
--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/juju/worker/terminationworker"
 	"github.com/juju/juju/worker/upgrader"
 	"github.com/juju/juju/worker/upgradesteps"
+	"github.com/juju/juju/worker/upgradewaiter"
 )
 
 // ManifoldsConfig allows specialisation of the result of Manifolds.
@@ -123,6 +124,16 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 			AgentName:     agentName,
 			APICallerName: apiCallerName,
 		}),
+
+		// The upgradewaiter manifold aggregates the
+		// upgrade-steps-gate and upgrade-check-gate manifolds into
+		// one boolean output. It makes it easy to create manifolds
+		// which must only run after these upgrade events have
+		// occured.
+		upgradeWaiterName: upgradewaiter.Manifold(upgradewaiter.ManifoldConfig{
+			UpgradeStepsWaiterName: upgradeStepsGateName,
+			UpgradeCheckWaiterName: upgradeCheckGateName,
+		}),
 	}
 }
 
@@ -135,6 +146,7 @@ const (
 	upgradeCheckGateName  = "upgrade-check-gate"
 	upgraderName          = "upgrader"
 	upgradeStepsName      = "upgradesteps"
+	upgradeWaiterName     = "upgradewaiter"
 	uninstallerName       = "uninstaller"
 	servingInfoSetterName = "serving-info-setter"
 )

--- a/cmd/jujud/agent/machine/manifolds_test.go
+++ b/cmd/jujud/agent/machine/manifolds_test.go
@@ -45,6 +45,7 @@ func (s *ManifoldsSuite) TestManifoldNames(c *gc.C) {
 		"upgrade-check-gate",
 		"upgrader",
 		"upgradesteps",
+		"upgradewaiter",
 		"uninstaller",
 		"serving-info-setter",
 	}

--- a/worker/dependency/engine.go
+++ b/worker/dependency/engine.go
@@ -497,6 +497,10 @@ func (engine *engine) gotStopped(name string, err error, resourceLog []resourceA
 			// The task can't even start with the current state. Nothing more
 			// can be done (until the inputs change, in which case we retry
 			// anyway).
+		case ErrBounce:
+			// The task exited but wanted to restart immediately.
+			logger.Debugf("%q manifold worker requested immediate restart")
+			engine.requestStart(name, engine.config.BounceDelay)
 		case ErrUninstall:
 			// The task should never run again, and can be removed completely.
 			engine.uninstall(name)

--- a/worker/dependency/interface.go
+++ b/worker/dependency/interface.go
@@ -117,6 +117,12 @@ type GetResourceFunc func(name string, out interface{}) error
 // because that's a lot of implementation hassle for little practical gain.
 var ErrMissing = errors.New("dependency not available")
 
+// ErrBounce can be returned by a StartFunc or a worker to indicate to
+// the engine that it should be restarted immediately, instead of
+// waiting for ErrorDelay. This is useful for workers which restart
+// themselves to alert dependents that an output has changed.
+var ErrBounce = errors.New("restart immediately")
+
 // ErrUninstall can be returned by a StartFunc or a worker to indicate to the
 // engine that it can/should never run again, and that the originating manifold
 // should be completely removed.

--- a/worker/upgradewaiter/manifold.go
+++ b/worker/upgradewaiter/manifold.go
@@ -1,0 +1,133 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgradewaiter
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	"launchpad.net/tomb"
+
+	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/dependency"
+	"github.com/juju/juju/worker/gate"
+)
+
+var logger = loggo.GetLogger("juju.worker.upgradewaiter")
+
+type ManifoldConfig struct {
+	// UpgradeStepsWaiterName is the name of a gate.Waiter which
+	// reports when upgrade steps have been run.
+	UpgradeStepsWaiterName string
+
+	// UpgradeCheckWaiter name is the name of a gate.Waiter which
+	// reports when the initial check for the need to upgrade has been
+	// done.
+	UpgradeCheckWaiterName string
+}
+
+// Manifold returns a dependency.Manifold which aggregates the
+// upgradesteps lock and the upgrader's "initial check" lock into a
+// single boolean output. The output is false until both locks are
+// unlocked. To make it easy to depend on this manifold, the
+// manifold's worker restarts when the output value changes, causing
+// dependent workers to be restarted.
+func Manifold(config ManifoldConfig) dependency.Manifold {
+
+	// This lock is unlocked when both the upgradesteps and upgrader
+	// locks are unlocked. It exists outside of the start func and
+	// worker code so that the state can be maintained beyond restart
+	// of the manifold's worker.
+	done := gate.NewLock()
+
+	return dependency.Manifold{
+		Inputs: []string{
+			config.UpgradeStepsWaiterName,
+			config.UpgradeCheckWaiterName,
+		},
+		Start: func(getResource dependency.GetResourceFunc) (worker.Worker, error) {
+			var stepsWaiter gate.Waiter
+			if err := getResource(config.UpgradeStepsWaiterName, &stepsWaiter); err != nil {
+				return nil, err
+			}
+			var checkWaiter gate.Waiter
+			if err := getResource(config.UpgradeCheckWaiterName, &checkWaiter); err != nil {
+				return nil, err
+			}
+
+			w := &upgradeWaiter{
+				done:        done,
+				stepsWaiter: stepsWaiter,
+				checkWaiter: checkWaiter,
+			}
+			go func() {
+				defer w.tomb.Done()
+				w.tomb.Kill(w.wait())
+			}()
+			return w, nil
+		},
+		Output: func(in worker.Worker, out interface{}) error {
+			inWorker, _ := in.(*upgradeWaiter)
+			if inWorker == nil {
+				return errors.Errorf("in should be a *upgradeWaiter; is %T", in)
+			}
+			switch outPointer := out.(type) {
+			case *bool:
+				*outPointer = done.IsUnlocked()
+			default:
+				return errors.Errorf("out should be a *bool; is %T", out)
+			}
+			return nil
+		},
+	}
+}
+
+type upgradeWaiter struct {
+	tomb        tomb.Tomb
+	stepsWaiter gate.Waiter
+	checkWaiter gate.Waiter
+	done        gate.Lock
+}
+
+func (w *upgradeWaiter) wait() error {
+	stepsCh := getWaiterChannel(w.stepsWaiter)
+	checkCh := getWaiterChannel(w.checkWaiter)
+
+	for {
+		// If both waiters have unlocked and the aggregate gate to
+		// signal upgrade completion hasn't been unlocked yet, unlock
+		// it and trigger an upgradeWaiter restart so that dependent
+		// manifolds notice.
+		if stepsCh == nil && checkCh == nil && !w.done.IsUnlocked() {
+			logger.Infof("startup upgrade operations complete")
+			w.done.Unlock()
+			return dependency.ErrBounce
+		}
+		select {
+		case <-w.tomb.Dying():
+			return tomb.ErrDying
+		case <-stepsCh:
+			stepsCh = nil
+		case <-checkCh:
+			checkCh = nil
+		}
+	}
+}
+
+func getWaiterChannel(waiter gate.Waiter) <-chan struct{} {
+	// If a gate is unlocked, don't select on it.
+	if waiter.IsUnlocked() {
+		return nil
+	}
+	return waiter.Unlocked()
+}
+
+// Kill is part of the worker.Worker interface.
+func (w *upgradeWaiter) Kill() {
+	w.tomb.Kill(nil)
+}
+
+// Wait is part of the worker.Worker interface.
+func (w *upgradeWaiter) Wait() error {
+	return w.tomb.Wait()
+}

--- a/worker/upgradewaiter/manifold_test.go
+++ b/worker/upgradewaiter/manifold_test.go
@@ -1,0 +1,158 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgradewaiter_test
+
+import (
+	"time"
+
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/dependency"
+	dt "github.com/juju/juju/worker/dependency/testing"
+	"github.com/juju/juju/worker/gate"
+	"github.com/juju/juju/worker/upgradewaiter"
+)
+
+type ManifoldSuite struct {
+	testing.IsolationSuite
+	manifold dependency.Manifold
+	worker   worker.Worker
+}
+
+var _ = gc.Suite(&ManifoldSuite{})
+
+func (s *ManifoldSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+	s.manifold = upgradewaiter.Manifold(upgradewaiter.ManifoldConfig{
+		UpgradeStepsWaiterName: "steps-waiter",
+		UpgradeCheckWaiterName: "check-waiter",
+	})
+}
+
+func (s *ManifoldSuite) TestInputs(c *gc.C) {
+	c.Assert(s.manifold.Inputs, jc.SameContents, []string{"steps-waiter", "check-waiter"})
+}
+
+func (s *ManifoldSuite) TestStartNoStepsWaiter(c *gc.C) {
+	getResource := dt.StubGetResource(dt.StubResources{
+		"steps-waiter": dt.StubResource{Error: dependency.ErrMissing},
+		"check-waiter": dt.StubResource{Output: gate.NewLock()},
+	})
+	w, err := s.manifold.Start(getResource)
+	c.Assert(w, gc.IsNil)
+	c.Assert(err, gc.Equals, dependency.ErrMissing)
+}
+
+func (s *ManifoldSuite) TestStartNoCheckWaiter(c *gc.C) {
+	getResource := dt.StubGetResource(dt.StubResources{
+		"steps-waiter": dt.StubResource{Output: gate.NewLock()},
+		"check-waiter": dt.StubResource{Error: dependency.ErrMissing},
+	})
+	w, err := s.manifold.Start(getResource)
+	c.Assert(w, gc.IsNil)
+	c.Assert(err, gc.Equals, dependency.ErrMissing)
+}
+
+func (s *ManifoldSuite) TestStartSuccess(c *gc.C) {
+	getResource := dt.StubGetResource(dt.StubResources{
+		"steps-waiter": dt.StubResource{Output: gate.NewLock()},
+		"check-waiter": dt.StubResource{Output: gate.NewLock()},
+	})
+	w, err := s.manifold.Start(getResource)
+	c.Assert(err, jc.ErrorIsNil)
+	checkStop(c, w)
+}
+
+func (s *ManifoldSuite) TestOutput(c *gc.C) {
+	stepsLock := gate.NewLock()
+	checkLock := gate.NewLock()
+	getResource := dt.StubGetResource(dt.StubResources{
+		"steps-waiter": dt.StubResource{Output: stepsLock},
+		"check-waiter": dt.StubResource{Output: checkLock},
+	})
+	w, err := s.manifold.Start(getResource)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Upgrades not completed yet so output is false.
+	s.assertOutputFalse(c, w)
+
+	// Unlock one of the upgrade gates, output should still be false.
+	stepsLock.Unlock()
+	s.assertOutputFalse(c, w)
+
+	// Unlock the other gate, output should now be true.
+	checkLock.Unlock()
+	s.assertOutputTrue(c, w)
+
+	// .. and the worker should exit with ErrBounce.
+	checkStopWithError(c, w, dependency.ErrBounce)
+
+	// Restarting the worker should result in the output immediately
+	// being true.
+	w2, err := s.manifold.Start(getResource)
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertOutputTrue(c, w)
+	checkStop(c, w2)
+}
+
+func (s *ManifoldSuite) TestOutputWithWrongWorker(c *gc.C) {
+	getResource := dt.StubGetResource(dt.StubResources{
+		"steps-waiter": dt.StubResource{Output: gate.NewLock()},
+		"check-waiter": dt.StubResource{Output: gate.NewLock()},
+	})
+	_, err := s.manifold.Start(getResource)
+	c.Assert(err, jc.ErrorIsNil)
+
+	type dummyWorker struct {
+		worker.Worker
+	}
+	var foo bool
+	err = s.manifold.Output(new(dummyWorker), &foo)
+	c.Assert(err, gc.ErrorMatches, `in should be a \*upgradeWaiter;.+`)
+}
+
+func (s *ManifoldSuite) TestOutputWithWrongType(c *gc.C) {
+	getResource := dt.StubGetResource(dt.StubResources{
+		"steps-waiter": dt.StubResource{Output: gate.NewLock()},
+		"check-waiter": dt.StubResource{Output: gate.NewLock()},
+	})
+	w, err := s.manifold.Start(getResource)
+	c.Assert(err, jc.ErrorIsNil)
+
+	var foo int
+	err = s.manifold.Output(w, &foo)
+	c.Assert(err, gc.ErrorMatches, `out should be a \*bool;.+`)
+}
+
+func (s *ManifoldSuite) assertOutputFalse(c *gc.C, w worker.Worker) {
+	time.Sleep(coretesting.ShortWait)
+	var done bool
+	s.manifold.Output(w, &done)
+	c.Assert(done, jc.IsFalse)
+}
+
+func (s *ManifoldSuite) assertOutputTrue(c *gc.C, w worker.Worker) {
+	for attempt := coretesting.LongAttempt.Start(); attempt.Next(); {
+		var done bool
+		s.manifold.Output(w, &done)
+		if done == true {
+			return
+		}
+	}
+	c.Fatalf("timed out waiting for output to become true")
+}
+
+func checkStop(c *gc.C, w worker.Worker) {
+	err := worker.Stop(w)
+	c.Check(err, jc.ErrorIsNil)
+}
+
+func checkStopWithError(c *gc.C, w worker.Worker, expectedErr error) {
+	err := worker.Stop(w)
+	c.Check(err, gc.Equals, expectedErr)
+}

--- a/worker/upgradewaiter/package_test.go
+++ b/worker/upgradewaiter/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgradewaiter_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}


### PR DESCRIPTION
worker/dependency: Add ErrBounce

The special ErrBounce error can be returned by a start func or worker to indicate that the worker should be restarted immediately (well close enough, after BounceDelay). This is useful for some workers which would like to restart to notify dependents of a change in one of their outputs.

---

worker/upgradewaiter: Add the upgradewaiter manifold

This manifold provides a boolean output which is set once upgrade steps have run and the upgrader's initial check has complete. It makes it easy to create manifolds which must only start after these upgrade events have occurred.

---

cmd/jujud/agent/machine: Run the upgradewaiter in the machine agent



(Review request: http://reviews.vapour.ws/r/3410/)