### PR TITLE
worker/statusholder manifold

### DIFF
--- a/cmd/jujud/agent/unit/manifolds.go
+++ b/cmd/jujud/agent/unit/manifolds.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/juju/worker/apicaller"
 	"github.com/juju/juju/worker/dependency"
 	"github.com/juju/juju/worker/fortress"
+	"github.com/juju/juju/worker/keyvalue"
 	"github.com/juju/juju/worker/leadership"
 	"github.com/juju/juju/worker/logger"
 	"github.com/juju/juju/worker/logsender"
@@ -146,6 +147,7 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 			LeadershipTrackerName: LeadershipTrackerName,
 			MachineLockName:       MachineLockName,
 			CharmDirName:          CharmDirName,
+			KeyValueStoreName:     UniterKeyValueStoreName,
 		}),
 
 		// TODO (mattyw) should be added to machine agent.
@@ -161,10 +163,10 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 		// The metric collect worker executes the collect-metrics hook in a
 		// restricted context that can safely run concurrently with other hooks.
 		MetricCollectName: collect.Manifold(collect.ManifoldConfig{
-			AgentName:       AgentName,
-			APICallerName:   APICallerName,
-			MetricSpoolName: MetricSpoolName,
-			CharmDirName:    CharmDirName,
+			AgentName:               AgentName,
+			UniterKeyValueStoreName: UniterKeyValueStoreName,
+			MetricSpoolName:         MetricSpoolName,
+			CharmDirName:            CharmDirName,
 		}),
 
 		// The meter status worker executes the meter-status-changed hook when it detects
@@ -183,6 +185,14 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 		MetricSenderName: sender.Manifold(sender.ManifoldConfig{
 			APICallerName:   APICallerName,
 			MetricSpoolName: MetricSpoolName,
+		}),
+
+		// The uniter key-value store manifold hold value that
+		// the uniter sets for use by other manifolds - those manifolds
+		// do not depend directly on the uniter manifold and are therefore
+		// not affected by uniter bounces.
+		UniterKeyValueStoreName: keyvalue.Manifold(keyvalue.ManifoldConfig{
+			AgentName: AgentName,
 		}),
 	}
 }
@@ -204,4 +214,5 @@ const (
 	MeterStatusName          = "meter-status"
 	MetricCollectName        = "metric-collect"
 	MetricSenderName         = "metric-sender"
+	UniterKeyValueStoreName  = "uniter-keyvalue-store"
 )

--- a/cmd/jujud/agent/unit/manifolds_test.go
+++ b/cmd/jujud/agent/unit/manifolds_test.go
@@ -54,6 +54,7 @@ func (s *ManifoldsSuite) TestManifoldNames(c *gc.C) {
 		unit.MeterStatusName,
 		unit.MetricSenderName,
 		unit.CharmDirName,
+		unit.UniterKeyValueStoreName,
 	}
 	keys := make([]string, 0, len(manifolds))
 	for k := range manifolds {

--- a/worker/keyvalue/export_test.go
+++ b/worker/keyvalue/export_test.go
@@ -1,0 +1,12 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package keyvalue
+
+var (
+	NewKeyValueStore = newKeyValueStore
+)
+
+func (f *KeyValueStore) ResetData() {
+	f.data = make(map[string]interface{})
+}

--- a/worker/keyvalue/keyvalue.go
+++ b/worker/keyvalue/keyvalue.go
@@ -1,0 +1,82 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package keyvalue
+
+import (
+	"fmt"
+	"os"
+	"sync"
+
+	"github.com/juju/errors"
+	"github.com/juju/utils"
+)
+
+// notSetError denotes that the value for the specified key was not set.
+type notSetError struct {
+	key string
+}
+
+// Error implements the error interface.
+func (e *notSetError) Error() string {
+	return fmt.Sprintf("value for key %q not set", e.key)
+}
+
+func newNotSetError(key string) *notSetError {
+	return &notSetError{key: key}
+}
+
+// IsNotSetError returns true if the error is a notSetError.
+func IsNotSetError(e error) bool {
+	_, ok := errors.Cause(e).(*notSetError)
+	return ok
+}
+
+// newKeyValueStore creates a store for persistent storage of
+// the key-value pairs.
+var newKeyValueStore = func(path string) *KeyValueStore {
+	return &KeyValueStore{path: path, data: make(map[string]interface{})}
+}
+
+// KeyValueStore stores the key-value pairs and persists them
+// in a file on disk.
+type KeyValueStore struct {
+	mu   sync.RWMutex
+	data map[string]interface{}
+	path string
+}
+
+// Get retrieves the value for the specified key.
+func (f *KeyValueStore) Get(key string) (interface{}, error) {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	value, ok := f.data[key]
+	if ok {
+		return value, nil
+	}
+
+	if err := utils.ReadYaml(f.path, &f.data); err != nil {
+		if os.IsNotExist(err) {
+			return nil, newNotSetError(key)
+		}
+		return nil, errors.Trace(err)
+	}
+
+	value, ok = f.data[key]
+	if ok {
+		return value, nil
+	}
+	return nil, newNotSetError(key)
+}
+
+// Set stores the value for the specified key.
+func (f *KeyValueStore) Set(key string, in interface{}) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.data[key] = in
+	err := utils.WriteYaml(f.path, f.data)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return nil
+}

--- a/worker/keyvalue/keyvalue_test.go
+++ b/worker/keyvalue/keyvalue_test.go
@@ -1,0 +1,58 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package keyvalue_test
+
+import (
+	"path"
+	stdtesting "testing"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/worker/keyvalue"
+)
+
+func TestPackage(t *stdtesting.T) {
+	gc.TestingT(t)
+}
+
+type keyvalueSuite struct {
+	path  string
+	store *keyvalue.KeyValueStore
+}
+
+var _ = gc.Suite(&keyvalueSuite{})
+
+func (t *keyvalueSuite) SetUpTest(c *gc.C) {
+	t.path = path.Join(c.MkDir(), "data.yaml")
+	t.store = keyvalue.NewKeyValueStore(t.path)
+}
+
+func (t *keyvalueSuite) TestReadNonExist(c *gc.C) {
+	value, err := t.store.Get("charm-url")
+	c.Assert(err, gc.NotNil)
+	c.Assert(keyvalue.IsNotSetError(err), gc.Equals, true)
+	c.Assert(err, gc.ErrorMatches, "value for key \"charm-url\" not set")
+	c.Assert(value, gc.Equals, nil)
+}
+
+func (t *keyvalueSuite) TestWriteRead(c *gc.C) {
+	err := t.store.Set("charm-url", "cs:wordpress-42")
+	c.Assert(err, jc.ErrorIsNil)
+
+	value, err := t.store.Get("charm-url")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(value, gc.Equals, "cs:wordpress-42")
+}
+
+func (t *keyvalueSuite) TestWriteResetRead(c *gc.C) {
+	err := t.store.Set("charm-url", "cs:wordpress-42")
+	c.Assert(err, jc.ErrorIsNil)
+
+	t.store.ResetData()
+
+	value, err := t.store.Get("charm-url")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(value, gc.Equals, "cs:wordpress-42")
+}

--- a/worker/keyvalue/manifold.go
+++ b/worker/keyvalue/manifold.go
@@ -1,0 +1,107 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+/*
+Package keyvalue provides a worker that provides a concurrency-safe
+way for other workers to share information without depending on
+each other (worker sharing information is not affected by restarts
+of worker it is sharing information with).
+
+The original motivating use case was the need of the collect metric
+manifold to have access to the charm URL of the unit ran by the uniter.
+Originally the collect metric manifold did direct queries to the controller
+via the API, which meant that metrics collection would stop, should the
+unit lose connection to the controller. The uniter knows the charm url of
+the charm it is running and can share that information out with other
+workers running on the same unit.
+*/
+package keyvalue
+
+import (
+	"path"
+
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	"launchpad.net/tomb"
+
+	"github.com/juju/juju/agent"
+	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/dependency"
+)
+
+var (
+	logger = loggo.GetLogger("juju.worker.keyvalue")
+)
+
+// ManifoldConfig identifies resource names upon which the keyvalue
+// store manifold depends.
+type ManifoldConfig struct {
+	AgentName string
+}
+
+// Manifold returns a keyvalue store manifold.
+func Manifold(config ManifoldConfig) dependency.Manifold {
+	return dependency.Manifold{
+		Inputs: []string{
+			config.AgentName,
+		},
+		Start: func(getResource dependency.GetResourceFunc) (worker.Worker, error) {
+			return newKeyValueWorker(config, getResource)
+		},
+		Output: outputFunc,
+	}
+}
+
+func newKeyValueWorker(config ManifoldConfig, getResource dependency.GetResourceFunc) (worker.Worker, error) {
+	var agent agent.Agent
+	if err := getResource(config.AgentName, &agent); err != nil {
+		return nil, err
+	}
+
+	w := &keyValueWorker{store: newKeyValueStore(path.Join(agent.CurrentConfig().DataDir(), "uniter_keyvalue.yaml"))}
+	go func() {
+		defer w.tomb.Done()
+		<-w.tomb.Dying()
+	}()
+	return w, nil
+}
+
+// Setter sets the value for the specified key.
+type Setter interface {
+	Set(key string, value interface{}) error
+}
+
+// Getter retrieves the value for the specified key.
+type Getter interface {
+	Get(key string) (interface{}, error)
+}
+
+type keyValueWorker struct {
+	tomb  tomb.Tomb
+	store *KeyValueStore
+}
+
+// Kill implements the worker.Worker interface.
+func (w *keyValueWorker) Kill() {
+	w.tomb.Kill(nil)
+}
+
+// Wait implements the worker.Worker interface.
+func (w *keyValueWorker) Wait() error {
+	return w.tomb.Wait()
+}
+
+func outputFunc(in worker.Worker, out interface{}) error {
+	inWorker, _ := in.(*keyValueWorker)
+	outSetter, _ := out.(*Setter)
+	outGetter, _ := out.(*Getter)
+	if inWorker == nil || (outSetter == nil && outGetter == nil) {
+		return errors.Errorf("expected %T-> %T or %T, got %T->%T", inWorker, outSetter, outGetter, in, out)
+	}
+	if outSetter != nil {
+		*outSetter = inWorker.store
+		return nil
+	}
+	*outGetter = inWorker.store
+	return nil
+}

--- a/worker/keyvalue/manifold_test.go
+++ b/worker/keyvalue/manifold_test.go
@@ -1,0 +1,135 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package keyvalue_test
+
+import (
+	"path"
+
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/agent"
+	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/dependency"
+	dt "github.com/juju/juju/worker/dependency/testing"
+	"github.com/juju/juju/worker/keyvalue"
+)
+
+type ManifoldSuite struct {
+	testing.IsolationSuite
+	manifold    dependency.Manifold
+	getResource dependency.GetResourceFunc
+	path        string
+}
+
+var _ = gc.Suite(&ManifoldSuite{})
+
+func (s *ManifoldSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+	s.manifold = keyvalue.Manifold(keyvalue.ManifoldConfig{
+		AgentName: "agent-name",
+	})
+	s.path = c.MkDir()
+	s.getResource = dt.StubGetResource(dt.StubResources{
+		"agent-name": dt.StubResource{Output: &dummyAgent{dataDir: s.path}},
+	})
+}
+
+func (s *ManifoldSuite) TestInputs(c *gc.C) {
+	c.Check(s.manifold.Inputs, jc.DeepEquals, []string{"agent-name"})
+}
+
+func (s *ManifoldSuite) TestStartMissingAgent(c *gc.C) {
+	getResource := dt.StubGetResource(dt.StubResources{
+		"agent-name": dt.StubResource{Error: dependency.ErrMissing},
+	})
+	worker, err := s.manifold.Start(getResource)
+	c.Check(worker, gc.IsNil)
+	c.Check(err, gc.Equals, dependency.ErrMissing)
+}
+
+func (s *ManifoldSuite) TestStartSuccess(c *gc.C) {
+	s.setupWorkerTest(c)
+}
+
+func (s *ManifoldSuite) TestOutputSuccess(c *gc.C) {
+	worker := s.setupWorkerTest(c)
+	var getter keyvalue.Getter
+	var setter keyvalue.Setter
+	err := s.manifold.Output(worker, &setter)
+	c.Check(err, jc.ErrorIsNil)
+	err = s.manifold.Output(worker, &getter)
+	c.Check(err, jc.ErrorIsNil)
+
+	err = setter.Set("charm-url", "cs:wordpress-42")
+	c.Assert(err, jc.ErrorIsNil)
+
+	var yamlState map[string]interface{}
+	err = utils.ReadYaml(path.Join(s.path, "uniter_keyvalue.yaml"), &yamlState)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(yamlState["charm-url"], gc.Equals, "cs:wordpress-42")
+
+	charmURL, err := getter.Get("charm-url")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(charmURL, gc.Equals, "cs:wordpress-42")
+
+	err = setter.Set("charm-url", "cs:wordpress-43")
+	c.Assert(err, jc.ErrorIsNil)
+
+	charmURL, err = getter.Get("charm-url")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(charmURL, gc.Equals, "cs:wordpress-43")
+}
+
+func (s *ManifoldSuite) TestOutputIfStateNotSet(c *gc.C) {
+	worker := s.setupWorkerTest(c)
+	var getter keyvalue.Getter
+	err := s.manifold.Output(worker, &getter)
+	c.Check(err, jc.ErrorIsNil)
+
+	charmURL, err := getter.Get("charm-url")
+	c.Assert(err, gc.NotNil)
+	c.Assert(keyvalue.IsNotSetError(err), gc.Equals, true)
+	c.Assert(charmURL, gc.Equals, nil)
+}
+
+func (s *ManifoldSuite) setupWorkerTest(c *gc.C) worker.Worker {
+	worker, err := s.manifold.Start(s.getResource)
+	c.Check(err, jc.ErrorIsNil)
+	s.AddCleanup(func(c *gc.C) {
+		worker.Kill()
+		err := worker.Wait()
+		c.Assert(err, jc.ErrorIsNil)
+	})
+	return worker
+}
+
+func (s *ManifoldSuite) TestOutputBadTarget(c *gc.C) {
+	worker := s.setupWorkerTest(c)
+	c.Assert(worker, gc.NotNil)
+	var keyvaluePlaceholder interface{}
+	err := s.manifold.Output(worker, &keyvaluePlaceholder)
+	c.Assert(err.Error(), gc.Equals, "expected *keyvalue.keyValueWorker-> *keyvalue.Setter or *keyvalue.Getter, got *keyvalue.keyValueWorker->*interface {}")
+	c.Assert(keyvaluePlaceholder, gc.IsNil)
+}
+
+type dummyAgent struct {
+	agent.Agent
+	dataDir string
+}
+
+func (a dummyAgent) CurrentConfig() agent.Config {
+	return &dummyAgentConfig{dataDir: a.dataDir}
+}
+
+type dummyAgentConfig struct {
+	agent.Config
+	dataDir string
+}
+
+func (ac dummyAgentConfig) DataDir() string {
+	return ac.dataDir
+}

--- a/worker/uniter/uniter_test.go
+++ b/worker/uniter/uniter_test.go
@@ -2093,3 +2093,29 @@ func (s *UniterSuite) TestOperationErrorReported(c *gc.C) {
 		),
 	})
 }
+
+func (s *UniterSuite) TestCharmURLSet(c *gc.C) {
+	s.runUniterTests(c, []uniterTest{
+		// Upgrade scenarios from steady state.
+		ut(
+			"steady state upgrade",
+			quickStart{},
+			waitCharmURL{"cs:quantal/wordpress-0"},
+			createCharm{revision: 1},
+			upgradeCharm{revision: 1},
+			waitUnitAgent{
+				status: params.StatusIdle,
+				charm:  1,
+			},
+			waitUnitAgent{
+				statusGetter: unitStatusGetter,
+				status:       params.StatusUnknown,
+				charm:        1,
+			},
+			waitHooks{"upgrade-charm", "config-changed"},
+			verifyCharm{revision: 1},
+			verifyRunning{},
+			waitCharmURL{"cs:quantal/wordpress-1"},
+		),
+	})
+}


### PR DESCRIPTION
- a manifold that holds data the uniter needs to share with other manifolds.
- other manifolds do not have to depend on the uniter and are therefore
  not affected by its bounces.

(Review request: http://reviews.vapour.ws/r/3412/)