### PR TITLE
maas: add bridge script using AddBootTextFile()

### DIFF
--- a/cloudconfig/instancecfg/instancecfg.go
+++ b/cloudconfig/instancecfg/instancecfg.go
@@ -395,7 +395,7 @@ var logDir = paths.MustSucceed(paths.LogDir(series.HostSeries()))
 
 // DefaultBridgePrefix is the prefix for all network bridge device
 // name used for LXC and KVM containers.
-const DefaultBridgePrefix = "juju-br-"
+const DefaultBridgePrefix = "br-"
 
 // DefaultBridgeName is the network bridge device name used for LXC and KVM
 // containers

--- a/provider/maas/Makefile
+++ b/provider/maas/Makefile
@@ -5,9 +5,12 @@ bridgescript.go: add-juju-bridge.py Makefile
 	echo -n '// This file is auto generated. Edits will be lost.\n\n' >> $@
 	echo -n 'package maas\n\n' >> $@
 	echo -n '//go:generate make -q\n\n' >> $@
-	echo -n "const bridgeScriptPythonBashDef = \`python_script=\$$(cat <<'PYTHON_SCRIPT'\n" >> $@
+	echo -n 'import "path"\n\n' >> $@
+	echo -n 'const bridgeScriptName = "add-juju-bridge.py"\n\n' >> $@
+	echo -n 'var bridgeScriptPath = path.Join("/tmp", bridgeScriptName)\n\n' >> $@
+	echo -n "const bridgeScriptPython = \`" >> $@
 	cat add-juju-bridge.py >> $@
-	echo -n 'PYTHON_SCRIPT\n)`\n' >> $@
+	echo -n '`\n' >> $@
 
 format:
 	pyfmt -i add-juju-bridge.py

--- a/provider/maas/Makefile
+++ b/provider/maas/Makefile
@@ -1,5 +1,9 @@
 all: bridgescript.go
 
+# TODO add bridgescript_doc.go that explains (in a package comment)
+# what this script (add-juju-bridge.py) does, and why, and how to
+# change it.
+
 bridgescript.go: add-juju-bridge.py Makefile
 	$(RM) $@
 	echo -n '// This file is auto generated. Edits will be lost.\n\n' >> $@

--- a/provider/maas/bridgescript.go
+++ b/provider/maas/bridgescript.go
@@ -4,8 +4,13 @@ package maas
 
 //go:generate make -q
 
-const bridgeScriptPythonBashDef = `python_script=$(cat <<'PYTHON_SCRIPT'
-#!/usr/bin/env python
+import "path"
+
+const bridgeScriptName = "add-juju-bridge.py"
+
+var bridgeScriptPath = path.Join("/tmp", bridgeScriptName)
+
+const bridgeScriptPython = `#!/usr/bin/env python
 
 # Copyright 2015 Canonical Ltd.
 # Licensed under the AGPLv3, see LICENCE file for details.
@@ -330,5 +335,4 @@ def main(args):
 
 if __name__ == '__main__':
     main(arg_parser().parse_args())
-PYTHON_SCRIPT
-)`
+`

--- a/provider/maas/bridgescript_test.go
+++ b/provider/maas/bridgescript_test.go
@@ -20,9 +20,9 @@ import (
 type bridgeConfigSuite struct {
 	coretesting.BaseSuite
 
-	testConfig     string
-	testConfigPath string
-	testBridgeName string
+	testConfig       string
+	testConfigPath   string
+	testPythonScript string
 }
 
 var _ = gc.Suite(&bridgeConfigSuite{})
@@ -36,9 +36,11 @@ func (s *bridgeConfigSuite) SetUpSuite(c *gc.C) {
 
 func (s *bridgeConfigSuite) SetUpTest(c *gc.C) {
 	s.testConfigPath = filepath.Join(c.MkDir(), "network-config")
+	s.testPythonScript = filepath.Join(c.MkDir(), bridgeScriptName)
 	s.testConfig = "# test network config\n"
-	s.testBridgeName = "test-bridge"
 	err := ioutil.WriteFile(s.testConfigPath, []byte(s.testConfig), 0644)
+	c.Assert(err, jc.ErrorIsNil)
+	err = ioutil.WriteFile(s.testPythonScript, []byte(bridgeScriptPython), 0755)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -100,9 +102,8 @@ func (s *bridgeConfigSuite) TestBridgeScriptWithVLANs(c *gc.C) {
 }
 
 func (s *bridgeConfigSuite) runScript(c *gc.C, configFile string, bridgePrefix string) (output string, exitCode int) {
-	script := fmt.Sprintf("%s\npython -c %q --bridge-prefix=%q %q\n",
-		bridgeScriptPythonBashDef,
-		"$python_script",
+	script := fmt.Sprintf("%q --bridge-prefix=%q %q\n",
+		s.testPythonScript,
 		bridgePrefix,
 		configFile)
 

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -1079,9 +1079,7 @@ func (environ *maasEnviron) selectNode(args selectNodeArgs) (*gomaasapi.MAASObje
 // setupJujuNetworking returns a string representing the script to run
 // in order to prepare the Juju-specific networking config on a node.
 func setupJujuNetworking() string {
-	return fmt.Sprintf("trap 'rm -f %q' EXIT; if [ -f %q ]; then %q --bridge-prefix=%q --one-time-backup --activate %q; fi\n",
-		bridgeScriptPath,
-		bridgeScriptPath,
+	return fmt.Sprintf("trap 'rm -f %[1]q' EXIT; if [ -f %[1]q ]; then %[1]q --bridge-prefix=%q --one-time-backup --activate %q; fi\n",
 		bridgeScriptPath,
 		instancecfg.DefaultBridgePrefix,
 		"/etc/network/interfaces")

--- a/provider/maas/environ_test.go
+++ b/provider/maas/environ_test.go
@@ -226,8 +226,7 @@ func (s *environSuite) TestNewCloudinitConfigNoFeatureFlag(c *gc.C) {
 
 	// Now test with the flag off.
 	s.SetFeatureFlags() // clear the flags.
-	modifyNetworkScript, err := maas.RenderEtcNetworkInterfacesScript()
-	c.Assert(err, jc.ErrorIsNil)
+	modifyNetworkScript := maas.RenderEtcNetworkInterfacesScript()
 	script := expectedCloudinitConfig
 	script = append(script, modifyNetworkScript)
 	testCase(script)


### PR DESCRIPTION
Add the python-based bridge script to the node using AddBootTextFile().

This is written as /tmp/add-juju-bridge.py. The run commands that use
this script are bracketed by calls that check for its existence. Ala:

  trap 'rm -f /tmp/add-juju-bridge.py' EXIT

  if [ -f /tmp/add-juju-bridge.py ]; then
     /tmp/add-juju-bridge.py ...
  fi

And the script itself is deleted once it has run once as it is not
idempotent; the script is expected to run once against the
machine-generated /etc/network/interfaces from curtin and MAAS.

This change no longer requires that the python script be encapsulated as
a bash 'here doc' which removes issues with quoting and various other
characters such as embedded "\n". And because it is no longer a 'here
doc' the script is no longer echoed to the console when cloud-init runs
during node deployment.

(Review request: http://reviews.vapour.ws/r/3414/)