### PR TITLE
Skips subnets we already know about

### DIFF
--- a/api/discoverspaces/discoverspaces.go
+++ b/api/discoverspaces/discoverspaces.go
@@ -65,7 +65,7 @@ func (api *API) CreateSpaces(args params.CreateSpacesParams) (results params.Err
 
 func (api *API) ListSubnets(args params.SubnetsFilters) (params.ListSubnetsResults, error) {
 	var result params.ListSubnetsResults
-	if err := api.facade.FacadeCall("ListSpaces", args, &result); err != nil {
+	if err := api.facade.FacadeCall("ListSubnets", args, &result); err != nil {
 		return result, errors.Trace(err)
 	}
 	return result, nil

--- a/api/discoverspaces/discoverspaces.go
+++ b/api/discoverspaces/discoverspaces.go
@@ -62,3 +62,11 @@ func (api *API) CreateSpaces(args params.CreateSpacesParams) (results params.Err
 	}
 	return result, nil
 }
+
+func (api *API) ListSubnets(args params.SubnetsFilters) (params.ListSubnetsResults, error) {
+	var result params.ListSubnetsResults
+	if err := api.facade.FacadeCall("ListSpaces", args, &result); err != nil {
+		return result, errors.Trace(err)
+	}
+	return result, nil
+}

--- a/worker/discoverspaces/discoverspaces.go
+++ b/worker/discoverspaces/discoverspaces.go
@@ -60,6 +60,8 @@ func (dw *discoverspacesWorker) loop() (err error) {
 	networkingEnviron, ok := environs.SupportsNetworking(environ)
 
 	if ok {
+		// TODO: (mfoord) API should be switched off until this is
+		// completed.
 		err = dw.handleSubnets(networkingEnviron)
 		if err != nil {
 			return errors.Trace(err)

--- a/worker/discoverspaces/discoverspaces.go
+++ b/worker/discoverspaces/discoverspaces.go
@@ -144,7 +144,7 @@ func (dw *discoverspacesWorker) handleSubnets(env environs.NetworkingEnviron) er
 		// TODO(mfoord): currently no way of removing subnets, or
 		// changing the space they're in, so we can only add ones we
 		// don't already know about.
-		logger.Errorf("Created space %v with %v subnets", spaceName, len(space.Subnets))
+		logger.Debugf("Created space %v with %v subnets", spaceName, len(space.Subnets))
 		for _, subnet := range space.Subnets {
 			if stateSubnetIds.Contains(string(subnet.ProviderId)) {
 				continue


### PR DESCRIPTION
Fixes error when worker is restarted and attempts to re-create subnets that already exist.

(Review request: http://reviews.vapour.ws/r/3419/)