### PR TITLE
Increment juju to 1.26-alpha4

### DIFF
--- a/scripts/win-installer/setup.iss
+++ b/scripts/win-installer/setup.iss
@@ -2,7 +2,7 @@
 ; SEE THE DOCUMENTATION FOR DETAILS ON CREATING INNO SETUP SCRIPT FILES!
 
 #define MyAppName "Juju"
-#define MyAppVersion "1.26-alpha3"
+#define MyAppVersion "1.26-alpha4"
 #define MyAppPublisher "Canonical, Ltd"
 #define MyAppURL "http://juju.ubuntu.com/"
 #define MyAppExeName "juju.exe"

--- a/version/version.go
+++ b/version/version.go
@@ -23,7 +23,7 @@ import (
 // The presence and format of this constant is very important.
 // The debian/rules build recipe uses this value for the version
 // number of the release package.
-const version = "1.26-alpha3"
+const version = "1.26-alpha4"
 
 // The version that we switched over from old style numbering to new style.
 var switchOverVersion = MustParse("1.19.9")


### PR DESCRIPTION
We have decided to temporarily call the next devel version alpha4. We expect to officially rename it to 2.0-aloha1 when 2.0 CI and Juju comparability are verified.

(Review request: http://reviews.vapour.ws/r/3421/)