### PR TITLE
Undertaker: Call Destroy on provider after hosted environ is dead.

### DIFF
--- a/api/undertaker/undertaker.go
+++ b/api/undertaker/undertaker.go
@@ -8,6 +8,7 @@ import (
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/api/watcher"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/environs/config"
 )
 
 // Client provides access to the undertaker API
@@ -23,6 +24,7 @@ type UndertakerClient interface {
 	ProcessDyingEnviron() error
 	RemoveEnviron() error
 	WatchEnvironResources() (watcher.NotifyWatcher, error)
+	EnvironConfig() (*config.Config, error)
 }
 
 // NewClient creates a new client for accessing the undertaker API.
@@ -92,4 +94,23 @@ func (c *Client) WatchEnvironResources() (watcher.NotifyWatcher, error) {
 	}
 	w := watcher.NewNotifyWatcher(c.facade.RawAPICaller(), result)
 	return w, nil
+}
+
+// EnvironConfig returns configuration information on the environment needed
+// by the undertaker worker.
+func (c *Client) EnvironConfig() (*config.Config, error) {
+	p, err := c.params()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	var result params.EnvironConfigResult
+	err = c.facade.FacadeCall("EnvironConfig", p, &result)
+	if err != nil {
+		return nil, err
+	}
+	conf, err := config.New(config.NoDefaults, result.Config)
+	if err != nil {
+		return nil, err
+	}
+	return conf, nil
 }

--- a/api/undertaker/undertaker_test.go
+++ b/api/undertaker/undertaker_test.go
@@ -127,3 +127,19 @@ func (s *undertakerSuite) TestWatchEnvironResourcesError(c *gc.C) {
 	c.Assert(w, gc.IsNil)
 	c.Assert(called, jc.IsTrue)
 }
+
+func (s *undertakerSuite) TestEnvironConfig(c *gc.C) {
+	var called bool
+
+	// The undertaker feature tests ensure EnvironConfig is connected
+	// correctly end to end. This test just ensures that the API calls work.
+	client := s.mockClient(c, "EnvironConfig", func(response interface{}) {
+		called = true
+		c.Check(response, gc.DeepEquals, &params.EnvironConfigResult{Config: params.EnvironConfig(nil)})
+	})
+
+	cfg, err := client.EnvironConfig()
+	c.Assert(err, gc.ErrorMatches, ".*expected string, got nothing")
+	c.Assert(cfg, gc.IsNil)
+	c.Assert(called, jc.IsTrue)
+}

--- a/apiserver/undertaker/mock_test.go
+++ b/apiserver/undertaker/mock_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/names"
 
 	"github.com/juju/juju/apiserver/undertaker"
+	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/state"
 )
 
@@ -89,6 +90,10 @@ func (m *mockState) IsStateServer() bool {
 
 func (m *mockState) Environment() (undertaker.Environment, error) {
 	return m.env, nil
+}
+
+func (m *mockState) EnvironConfig() (*config.Config, error) {
+	return &config.Config{}, nil
 }
 
 // mockEnvironment implements Environment interface and allows inspection of called

--- a/apiserver/undertaker/state.go
+++ b/apiserver/undertaker/state.go
@@ -9,6 +9,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/names"
 
+	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/state"
 )
 
@@ -36,6 +37,9 @@ type State interface {
 
 	// AllServices returns all deployed services in the environment.
 	AllServices() ([]Service, error)
+
+	// EnvironConfig retrieves the environment configuration.
+	EnvironConfig() (*config.Config, error)
 }
 
 type stateShim struct {

--- a/apiserver/undertaker/undertaker.go
+++ b/apiserver/undertaker/undertaker.go
@@ -120,3 +120,16 @@ func (u *UndertakerAPI) WatchEnvironResources() params.NotifyWatchResults {
 		},
 	}
 }
+
+// EnvironConfig returns the environment's configuration.
+func (u *UndertakerAPI) EnvironConfig() (params.EnvironConfigResult, error) {
+	result := params.EnvironConfigResult{}
+
+	config, err := u.st.EnvironConfig()
+	if err != nil {
+		return result, err
+	}
+	allAttrs := config.AllAttrs()
+	result.Config = allAttrs
+	return result, nil
+}

--- a/apiserver/undertaker/undertaker_test.go
+++ b/apiserver/undertaker/undertaker_test.go
@@ -147,3 +147,11 @@ func (s *undertakerSuite) TestDeadRemoveEnviron(c *gc.C) {
 
 	c.Assert(otherSt.removed, jc.IsTrue)
 }
+
+func (s *undertakerSuite) TestEnvironConfig(c *gc.C) {
+	_, hostedAPI := s.setupStateAndAPI(c, false, "hostedenv")
+
+	cfg, err := hostedAPI.EnvironConfig()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cfg, gc.NotNil)
+}

--- a/featuretests/api_undertaker_test.go
+++ b/featuretests/api_undertaker_test.go
@@ -159,6 +159,17 @@ func (s *undertakerSuite) TestHostedRemoveEnviron(c *gc.C) {
 	c.Assert(otherSt.EnsureEnvironmentRemoved(), jc.ErrorIsNil)
 }
 
+func (s *undertakerSuite) TestHostedEnvironConfig(c *gc.C) {
+	undertakerClient, otherSt := s.hostedAPI(c)
+	defer otherSt.Close()
+
+	cfg, err := undertakerClient.EnvironConfig()
+	c.Assert(err, jc.ErrorIsNil)
+	uuid, ok := cfg.UUID()
+	c.Assert(ok, jc.IsTrue)
+	c.Assert(uuid, gc.Equals, otherSt.EnvironUUID())
+}
+
 func (s *undertakerSuite) hostedAPI(c *gc.C) (*undertaker.Client, *state.State) {
 	otherState := s.Factory.MakeEnvironment(c, &factory.EnvParams{Name: "hosted_env"})
 

--- a/worker/simpleworker.go
+++ b/worker/simpleworker.go
@@ -3,9 +3,7 @@
 
 package worker
 
-import (
-	"launchpad.net/tomb"
-)
+import "launchpad.net/tomb"
 
 // simpleWorker implements the worker returned by NewSimpleWorker.
 type simpleWorker struct {

--- a/worker/undertaker/mock_test.go
+++ b/worker/undertaker/mock_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/juju/juju/api/watcher"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/state"
 )
 
@@ -28,6 +29,7 @@ type mockClient struct {
 	lock        sync.RWMutex
 	mockEnviron clientEnviron
 	watcher     watcher.NotifyWatcher
+	cfg         *config.Config
 }
 
 func (m *mockClient) mockCall(call string) {
@@ -65,6 +67,10 @@ func (m *mockClient) EnvironInfo() (params.UndertakerEnvironInfoResult, error) {
 		TimeOfDeath: m.mockEnviron.TimeOfDeath,
 	}
 	return params.UndertakerEnvironInfoResult{Result: result}, nil
+}
+
+func (m *mockClient) EnvironConfig() (*config.Config, error) {
+	return m.cfg, nil
 }
 
 func (m *mockClient) WatchEnvironResources() (watcher.NotifyWatcher, error) {

--- a/worker/undertaker/undertaker.go
+++ b/worker/undertaker/undertaker.go
@@ -13,6 +13,7 @@ import (
 
 	apiundertaker "github.com/juju/juju/api/undertaker"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/environs"
 	"github.com/juju/juju/worker"
 )
 
@@ -52,6 +53,21 @@ func NewUndertaker(client apiundertaker.UndertakerClient, clock uc.Clock) worker
 			// Nothing to do. We don't remove environment docs for a state server
 			// environment.
 			return nil
+		}
+
+		cfg, err := client.EnvironConfig()
+		if err != nil {
+			return errors.Trace(err)
+		}
+
+		env, err := environs.New(cfg)
+		if err != nil {
+			return errors.Trace(err)
+		}
+
+		err = env.Destroy()
+		if err != nil {
+			return errors.Trace(err)
 		}
 
 		tod := clock.Now()

--- a/worker/undertaker/undertaker_test.go
+++ b/worker/undertaker/undertaker_test.go
@@ -12,6 +12,11 @@ import (
 	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cmd/envcmd"
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/environs/configstore"
+	"github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/undertaker"
@@ -48,13 +53,15 @@ func (c clock) advanceAfterNextNow(d time.Duration) {
 }
 
 func (s *undertakerSuite) TestAPICalls(c *gc.C) {
+	cfg, uuid := dummyCfgAndUUID(c)
 	client := &mockClient{
 		calls: make(chan string),
 		mockEnviron: clientEnviron{
 			Life: state.Dying,
-			UUID: utils.MustNewUUID().String(),
+			UUID: uuid,
 			HasMachinesAndServices: true,
 		},
+		cfg: cfg,
 		watcher: &mockEnvironResourceWatcher{
 			events: make(chan struct{}),
 		},
@@ -124,11 +131,13 @@ func (s *undertakerSuite) TestRemoveEnvironDocsNotCalledForStateServer(c *gc.C) 
 	mockWatcher := &mockEnvironResourceWatcher{
 		events: make(chan struct{}, 1),
 	}
+	uuid, err := utils.NewUUID()
+	c.Assert(err, jc.ErrorIsNil)
 	client := &mockClient{
 		calls: make(chan string, 1),
 		mockEnviron: clientEnviron{
 			Life:     state.Dying,
-			UUID:     utils.MustNewUUID().String(),
+			UUID:     uuid.String(),
 			IsSystem: true,
 		},
 		watcher: mockWatcher,
@@ -191,15 +200,17 @@ func (s *undertakerSuite) TestRemoveEnvironOnRebootCalled(c *gc.C) {
 	mClock := testing.NewClock(startTime)
 	halfDayEarlier := mClock.Now().Add(-12 * time.Hour)
 
+	cfg, uuid := dummyCfgAndUUID(c)
 	client := &mockClient{
 		calls: make(chan string, 1),
 		// Mimic the situation where the worker is started after the
 		// environment has been set to dead 12hrs ago.
 		mockEnviron: clientEnviron{
 			Life:        state.Dead,
-			UUID:        utils.MustNewUUID().String(),
+			UUID:        uuid,
 			TimeOfDeath: &halfDayEarlier,
 		},
+		cfg: cfg,
 	}
 
 	wg := sync.WaitGroup{}
@@ -248,4 +259,21 @@ func (s *undertakerSuite) TestRemoveEnvironOnRebootCalled(c *gc.C) {
 		c.Fatalf("unexpected API call: %q", call)
 	case <-time.After(testing.ShortWait):
 	}
+}
+
+func dummyCfgAndUUID(c *gc.C) (*config.Config, string) {
+	cfg := testingEnvConfig(c)
+	uuid, ok := cfg.UUID()
+	c.Assert(ok, jc.IsTrue)
+	return cfg, uuid
+}
+
+// testingEnvConfig prepares an environment configuration using
+// the dummy provider.
+func testingEnvConfig(c *gc.C) *config.Config {
+	cfg, err := config.New(config.NoDefaults, dummy.SampleConfig())
+	c.Assert(err, jc.ErrorIsNil)
+	env, err := environs.Prepare(cfg, envcmd.BootstrapContext(testing.Context(c)), configstore.NewMem())
+	c.Assert(err, jc.ErrorIsNil)
+	return env.Config()
 }


### PR DESCRIPTION
Make the undertaker worker call Destroy on the hosted environ provider
after it sets the hosted environ to dead.

The undertaker needs the environ config to do this. Add an API and API
server method for the undertaker to request the config of the hosted
environment.

(Review request: http://reviews.vapour.ws/r/3422/)