### PR TITLE
Implemented the "apiworkers" manifold

### DIFF
--- a/cmd/jujud/agent/deploy_test.go
+++ b/cmd/jujud/agent/deploy_test.go
@@ -29,7 +29,7 @@ type fakeContext struct {
 	deployed    set.Strings
 	st          *state.State
 	agentConfig agent.Config
-	inited      chan struct{}
+	inited      *signal
 }
 
 func (ctx *fakeContext) DeployUnit(unitName, _ string) error {
@@ -61,7 +61,7 @@ func (ctx *fakeContext) waitDeployed(c *gc.C, want ...string) {
 	select {
 	case <-timeout:
 		c.Fatalf("manager never initialized")
-	case <-ctx.inited:
+	case <-ctx.inited.triggered():
 		for {
 			ctx.st.StartSync()
 			select {

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -705,6 +705,13 @@ func (a *MachineAgent) startAPIWorkers(apiConn api.Connection) (worker.Worker, e
 	}
 
 	runner := newConnRunner(apiConn)
+	defer func() {
+		// If startAPIWorkers exits early with an error, stop the
+		// runner so that any already started runners aren't leaked.
+		if outErr != nil {
+			worker.Stop(runner)
+		}
+	}()
 
 	// TODO(fwereade): this is *still* a hideous layering violation, but at least
 	// it's confined to jujud rather than extending into the worker itself.

--- a/cmd/jujud/agent/machine/apiworkers.go
+++ b/cmd/jujud/agent/machine/apiworkers.go
@@ -1,0 +1,60 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package machine
+
+import (
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/api"
+	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/dependency"
+)
+
+// APIWorkersConfig provides the dependencies for the
+// apiworkers manifold.
+type APIWorkersConfig struct {
+	APICallerName     string
+	UpgradeWaiterName string
+	StartAPIWorkers   func(api.Connection) (worker.Worker, error)
+}
+
+// APIWorkersManifold starts workers that rely on an API connection
+// using a function provided to it. It waits until the machine agent's
+// initial upgrade operations have completed (using the upgradewaiter
+// manifold).
+//
+// This manifold exists to start API workers which have not yet been
+// ported to work directly with the dependency engine. Once all API
+// workers started by StartAPIWorkers have been migrated to the
+// dependency engine, this manifold can be removed.
+func APIWorkersManifold(config APIWorkersConfig) dependency.Manifold {
+	return dependency.Manifold{
+		Inputs: []string{
+			config.APICallerName,
+			config.UpgradeWaiterName,
+		},
+		Start: func(getResource dependency.GetResourceFunc) (worker.Worker, error) {
+			if config.StartAPIWorkers == nil {
+				return nil, errors.New("StartAPIWorkers not specified")
+			}
+
+			// Check if upgrades have completed.
+			var upgradesDone bool
+			if err := getResource(config.UpgradeWaiterName, &upgradesDone); err != nil {
+				return nil, err
+			}
+			if !upgradesDone {
+				return nil, dependency.ErrMissing
+			}
+
+			// Get API connection.
+			var apiConn api.Connection
+			if err := getResource(config.APICallerName, &apiConn); err != nil {
+				return nil, err
+			}
+
+			return config.StartAPIWorkers(apiConn)
+		},
+	}
+}

--- a/cmd/jujud/agent/machine/apiworkers_test.go
+++ b/cmd/jujud/agent/machine/apiworkers_test.go
@@ -1,0 +1,104 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package machine_test
+
+import (
+	"github.com/juju/juju/api"
+	"github.com/juju/juju/cmd/jujud/agent/machine"
+	"github.com/juju/juju/testing"
+	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/dependency"
+	dt "github.com/juju/juju/worker/dependency/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+)
+
+type APIWorkersSuite struct {
+	testing.BaseSuite
+	manifold    dependency.Manifold
+	startCalled bool
+}
+
+var _ = gc.Suite(&APIWorkersSuite{})
+
+func (s *APIWorkersSuite) SetUpTest(c *gc.C) {
+	s.startCalled = false
+	s.manifold = machine.APIWorkersManifold(machine.APIWorkersConfig{
+		APICallerName:     "api-caller",
+		UpgradeWaiterName: "upgrade-waiter",
+		StartAPIWorkers:   s.startAPIWorkers,
+	})
+}
+
+func (s *APIWorkersSuite) startAPIWorkers(api.Connection) (worker.Worker, error) {
+	s.startCalled = true
+	return new(mockWorker), nil
+}
+
+func (s *APIWorkersSuite) TestInputs(c *gc.C) {
+	c.Assert(s.manifold.Inputs, jc.SameContents, []string{
+		"api-caller",
+		"upgrade-waiter",
+	})
+}
+
+func (s *APIWorkersSuite) TestStartNoStartAPIWorkers(c *gc.C) {
+	manifold := machine.APIWorkersManifold(machine.APIWorkersConfig{})
+	worker, err := manifold.Start(dt.StubGetResource(nil))
+	c.Check(worker, gc.IsNil)
+	c.Check(err, gc.ErrorMatches, "StartAPIWorkers not specified")
+	c.Check(s.startCalled, jc.IsFalse)
+}
+
+func (s *APIWorkersSuite) TestStartAPIMissing(c *gc.C) {
+	getResource := dt.StubGetResource(dt.StubResources{
+		"api-caller":     dt.StubResource{Error: dependency.ErrMissing},
+		"upgrade-waiter": dt.StubResource{Output: true},
+	})
+	worker, err := s.manifold.Start(getResource)
+	c.Check(worker, gc.IsNil)
+	c.Check(err, gc.Equals, dependency.ErrMissing)
+	c.Check(s.startCalled, jc.IsFalse)
+}
+
+func (s *APIWorkersSuite) TestStartUpgradeWaiterMissing(c *gc.C) {
+	getResource := dt.StubGetResource(dt.StubResources{
+		"api-caller":     dt.StubResource{Output: new(mockAPIConn)},
+		"upgrade-waiter": dt.StubResource{Error: dependency.ErrMissing},
+	})
+	worker, err := s.manifold.Start(getResource)
+	c.Check(worker, gc.IsNil)
+	c.Check(err, gc.Equals, dependency.ErrMissing)
+	c.Check(s.startCalled, jc.IsFalse)
+}
+
+func (s *APIWorkersSuite) TestStartUpgradesNotComplete(c *gc.C) {
+	getResource := dt.StubGetResource(dt.StubResources{
+		"api-caller":     dt.StubResource{Output: new(mockAPIConn)},
+		"upgrade-waiter": dt.StubResource{Output: false},
+	})
+	worker, err := s.manifold.Start(getResource)
+	c.Check(worker, gc.IsNil)
+	c.Check(err, gc.Equals, dependency.ErrMissing)
+	c.Check(s.startCalled, jc.IsFalse)
+}
+
+func (s *APIWorkersSuite) TestStartSuccess(c *gc.C) {
+	getResource := dt.StubGetResource(dt.StubResources{
+		"api-caller":     dt.StubResource{Output: new(mockAPIConn)},
+		"upgrade-waiter": dt.StubResource{Output: true},
+	})
+	worker, err := s.manifold.Start(getResource)
+	c.Check(worker, gc.Not(gc.IsNil))
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(s.startCalled, jc.IsTrue)
+}
+
+type mockAPIConn struct {
+	api.Connection
+}
+
+type mockWorker struct {
+	worker.Worker
+}

--- a/cmd/jujud/agent/machine/manifolds_test.go
+++ b/cmd/jujud/agent/machine/manifolds_test.go
@@ -48,6 +48,7 @@ func (s *ManifoldsSuite) TestManifoldNames(c *gc.C) {
 		"upgradewaiter",
 		"uninstaller",
 		"serving-info-setter",
+		"apiworkers",
 	}
 	c.Assert(keys, jc.SameContents, expectedKeys)
 }

--- a/worker/dependency/engine.go
+++ b/worker/dependency/engine.go
@@ -499,7 +499,6 @@ func (engine *engine) gotStopped(name string, err error, resourceLog []resourceA
 			// anyway).
 		case ErrBounce:
 			// The task exited but wanted to restart immediately.
-			logger.Debugf("%q manifold worker requested immediate restart")
 			engine.requestStart(name, engine.config.BounceDelay)
 		case ErrUninstall:
 			// The task should never run again, and can be removed completely.


### PR DESCRIPTION
cmd/jujud/agent/machine: Add apiworkers manifold

APIWorkersManifold starts workers that rely on an API connection using a function provided to it. It waits until the machine agent's initial upgrade operations have completed (using the upgradewaiter manifold).

This manifold exists to start API workers which have not yet been ported to work directly with the dependency engine. Once all API workers started by StartAPIWorkers have been migrated to the dependency engine, this manifold can be removed.

---

cmd/jujud/agent/machine: Test all job types with serving-info-setter

By doing a little more testing here, some tests can be removed from the machine agent suite.

---

worker/dependency: Remove ErrBounce log message

The log message is unnecessary as it doubles up with another more general one emitted when any worker exits.

---

cmd/jujud/agent: Kill the API workers runner on exit with error

...otherwise already started goroutines may be leaked. I lost most of a day tracking this down.

---

cmd/jujud/agent: Integrate apiworkers manifold

The machine agent's workers that rely on the primary API connection are now started using the via the apiworkers manifold instead of being started via the machine agent's runner/worker heirarchy. This means that the machine agent now only opens up one API connection in this feature branch instead of having one opened by the "api-caller" manifold and one by the (now removed) "api" worker.

This change has required significant changes in some of the machine agent's tests due to changed semantics and the loss of the "reportOpenedAPI" helper. Some tests were also removed because they were testing functionality that is now part of the dependency engine (and is well tested there).

---

cmd/jujud/agent: Safer channel closing in tests

Under the dependency engine workers may be restarted more often. This causes some of the patched in functions in the machine agent's tests to be called more than once, causing signaling-by-channel-closing to fail after the first call (channel already closed).

This change introduces a simple "signal" struct which provides a safer abstraction to support the test requirement of needing to know if something was called which.


(Review request: http://reviews.vapour.ws/r/3425/)