### PR TITLE
Data source require signed.

### DIFF
--- a/apiserver/imagemetadata/metadata.go
+++ b/apiserver/imagemetadata/metadata.go
@@ -176,7 +176,7 @@ func (api *API) retrievePublished() error {
 	// We want all relevant metadata from all data sources.
 	for _, source := range sources {
 		logger.Debugf("looking in data source %v", source.Description())
-		metadata, info, err := envmetadata.Fetch([]simplestreams.DataSource{source}, cons, false)
+		metadata, info, err := envmetadata.Fetch([]simplestreams.DataSource{source}, cons)
 		if err != nil {
 			// Do not stop looking in other data sources if there is an issue here.
 			logger.Errorf("encountered %v while getting published images metadata from %v", err, source.Description())

--- a/apiserver/images_test.go
+++ b/apiserver/images_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/juju/juju/apiserver/params"
 	containertesting "github.com/juju/juju/container/testing"
+	sstesting "github.com/juju/juju/environs/simplestreams/testing"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/imagestorage"
 	coretesting "github.com/juju/juju/testing"
@@ -39,7 +40,6 @@ var _ = gc.Suite(&imageSuite{})
 
 func (s *imageSuite) SetUpSuite(c *gc.C) {
 	s.authHttpSuite.SetUpSuite(c)
-	testRoundTripper.RegisterForScheme("test")
 }
 
 func (s *imageSuite) TestDownloadMissingEnvUUIDPath(c *gc.C) {
@@ -81,10 +81,6 @@ func (s *imageSuite) TestDownloadRejectsWrongEnvUUIDPath(c *gc.C) {
 	s.assertErrorResponse(c, response, http.StatusNotFound, `unknown environment: "dead-beef-123456"`)
 }
 
-// This provides the content for code accessing test:///... URLs. This allows
-// us to set the responses for things like image queries.
-var testRoundTripper = &coretesting.ProxyRoundTripper{}
-
 type CountingRoundTripper struct {
 	count int
 	*coretesting.CannedRoundTripper
@@ -97,11 +93,11 @@ func (v *CountingRoundTripper) RoundTrip(req *http.Request) (*http.Response, err
 
 func useTestImageData(files map[string]string) {
 	if files != nil {
-		testRoundTripper.Sub = &CountingRoundTripper{
+		sstesting.TestRoundTripper.Sub = &CountingRoundTripper{
 			CannedRoundTripper: coretesting.NewCannedRoundTripper(files, nil),
 		}
 	} else {
-		testRoundTripper.Sub = nil
+		sstesting.TestRoundTripper.Sub = nil
 	}
 }
 
@@ -167,7 +163,7 @@ func (s *imageSuite) TestDownloadFetchesAndCachesConcurrent(c *gc.C) {
 	}
 
 	// Downloading an image is 2 requests - one for image, one for SA256.
-	c.Assert(testRoundTripper.Sub.(*CountingRoundTripper).count, gc.Equals, 2)
+	c.Assert(sstesting.TestRoundTripper.Sub.(*CountingRoundTripper).count, gc.Equals, 2)
 
 	// Check that the image is correctly cached.
 	metadata, cachedData := s.getImageFromStorage(c, s.State, "lxc", "trusty", "amd64")

--- a/apiserver/provisioner/provisioner.go
+++ b/apiserver/provisioner/provisioner.go
@@ -1693,10 +1693,7 @@ func (p *ProvisionerAPI) imageMetadataFromDataSources(env environs.Environ, cons
 
 	for _, source := range sources {
 		logger.Debugf("looking in data source %v", source.Description())
-		// TODO (anastasiamac 2015-12-02) signedOnly for now defaulted to false... how do i get provider specific one?
-		// do i need to add another property to metadata, like signed?
-		// Fix this when fixing DS in the follow-up PR to contain signed/unsigned bool.
-		found, info, err := imagemetadata.Fetch([]simplestreams.DataSource{source}, constraint, false)
+		found, info, err := imagemetadata.Fetch([]simplestreams.DataSource{source}, constraint)
 		if err != nil {
 			// Do not stop looking in other data sources if there is an issue here.
 			logger.Errorf("encountered %v while getting published images metadata from %v", err, source.Description())

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -1061,7 +1061,7 @@ func (a *MachineAgent) StateWorker() (worker.Worker, error) {
 	reportOpenedState(st)
 
 	stor := statestorage.NewStorage(st.EnvironUUID(), st.MongoSession())
-	registerSimplestreamsDataSource(stor)
+	registerSimplestreamsDataSource(stor, false)
 
 	runner := newConnRunner(st)
 	singularRunner, err := newSingularStateRunner(runner, st, m)

--- a/cmd/jujud/agent/simplestreams.go
+++ b/cmd/jujud/agent/simplestreams.go
@@ -24,14 +24,15 @@ const (
 // environmentStorageDataSource is a simplestreams.DataSource that
 // retrieves simplestreams metadata from environment storage.
 type environmentStorageDataSource struct {
-	stor     storage.Storage
-	priority int
+	stor          storage.Storage
+	priority      int
+	requireSigned bool
 }
 
 // NewEnvironmentStorageDataSource returns a new datasource that retrieves
 // metadata from environment storage.
-func NewEnvironmentStorageDataSource(stor storage.Storage, priority int) simplestreams.DataSource {
-	return environmentStorageDataSource{stor, priority}
+func NewEnvironmentStorageDataSource(stor storage.Storage, priority int, requireSigned bool) simplestreams.DataSource {
+	return environmentStorageDataSource{stor, priority, requireSigned}
 }
 
 // Description is defined in simplestreams.DataSource.
@@ -71,9 +72,14 @@ func (d environmentStorageDataSource) Priority() int {
 	return d.priority
 }
 
+// RequireSigned is defined in simplestreams.DataSource.
+func (d environmentStorageDataSource) RequireSigned() bool {
+	return d.requireSigned
+}
+
 // registerSimplestreamsDataSource registers a environmentStorageDataSource.
-func registerSimplestreamsDataSource(stor storage.Storage) {
-	ds := NewEnvironmentStorageDataSource(stor, simplestreams.DEFAULT_CLOUD_DATA)
+func registerSimplestreamsDataSource(stor storage.Storage, requireSigned bool) {
+	ds := NewEnvironmentStorageDataSource(stor, simplestreams.DEFAULT_CLOUD_DATA, requireSigned)
 	environs.RegisterUserImageDataSourceFunc(storageDataSourceId, func(environs.Environ) (simplestreams.DataSource, error) {
 		return ds, nil
 	})

--- a/cmd/jujud/agent/upgrade.go
+++ b/cmd/jujud/agent/upgrade.go
@@ -182,7 +182,7 @@ func (c *upgradeWorkerContext) run(stop <-chan struct{}) error {
 		// We may not need this anymore.
 		// At the very least, there could be an upgrade step to read the data
 		// and add it to structured data.
-		registerSimplestreamsDataSource(stor, true)
+		registerSimplestreamsDataSource(stor, false)
 
 		// This state-dependent data source will be useless
 		// once state is closed in previous defer - un-register it.

--- a/cmd/jujud/agent/upgrade.go
+++ b/cmd/jujud/agent/upgrade.go
@@ -182,7 +182,7 @@ func (c *upgradeWorkerContext) run(stop <-chan struct{}) error {
 		// We may not need this anymore.
 		// At the very least, there could be an upgrade step to read the data
 		// and add it to structured data.
-		registerSimplestreamsDataSource(stor)
+		registerSimplestreamsDataSource(stor, true)
 
 		// This state-dependent data source will be useless
 		// once state is closed in previous defer - un-register it.

--- a/cmd/jujud/bootstrap.go
+++ b/cmd/jujud/bootstrap.go
@@ -440,7 +440,7 @@ var seriesFromVersion = series.VersionSeries
 func (c *BootstrapCommand) saveCustomImageMetadata(st *state.State, env environs.Environ) error {
 	logger.Debugf("saving custom image metadata from %q", c.ImageMetadataDir)
 	baseURL := fmt.Sprintf("file://%s", filepath.ToSlash(c.ImageMetadataDir))
-	datasource := simplestreams.NewURLDataSource("custom", baseURL, utils.NoVerifySSLHostnames, simplestreams.CUSTOM_CLOUD_DATA)
+	datasource := simplestreams.NewURLDataSource("custom", baseURL, utils.NoVerifySSLHostnames, simplestreams.CUSTOM_CLOUD_DATA, false)
 	return storeImageMetadataFromFiles(st, env, datasource)
 }
 
@@ -458,7 +458,7 @@ func storeImageMetadataFromFiles(st *state.State, env environs.Environ, source s
 		imageConstraint.CloudSpec = cloud
 	}
 
-	existingMetadata, info, err := imagemetadata.Fetch([]simplestreams.DataSource{source}, imageConstraint, false)
+	existingMetadata, info, err := imagemetadata.Fetch([]simplestreams.DataSource{source}, imageConstraint)
 	if err != nil && !errors.IsNotFound(err) {
 		return errors.Annotate(err, "cannot read image metadata")
 	}

--- a/cmd/jujud/bootstrap_test.go
+++ b/cmd/jujud/bootstrap_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/juju/juju/environs/configstore"
 	"github.com/juju/juju/environs/filestorage"
 	"github.com/juju/juju/environs/simplestreams"
+	sstesting "github.com/juju/juju/environs/simplestreams/testing"
 	"github.com/juju/juju/environs/storage"
 	envtesting "github.com/juju/juju/environs/testing"
 	envtools "github.com/juju/juju/environs/tools"
@@ -834,6 +835,7 @@ func (s *BootstrapSuite) makeTestEnv(c *gc.C) {
 	env, err := provider.PrepareForBootstrap(nullContext(), cfg)
 	c.Assert(err, jc.ErrorIsNil)
 
+	s.PatchValue(&envtools.SimplestreamsToolsPublicKey, sstesting.SignedMetadataPublicKey)
 	envtesting.MustUploadFakeTools(s.toolsStorage, cfg.AgentStream(), cfg.AgentStream())
 	inst, _, _, err := jujutesting.StartInstance(env, "0")
 	c.Assert(err, jc.ErrorIsNil)

--- a/cmd/plugins/juju-metadata/toolsmetadata.go
+++ b/cmd/plugins/juju-metadata/toolsmetadata.go
@@ -124,7 +124,7 @@ func (c *toolsMetadataCommand) Run(context *cmd.Context) error {
 		if err != nil {
 			return err
 		}
-		sourceDataSource := simplestreams.NewURLDataSource("local source", source, utils.VerifySSLHostnames, simplestreams.CUSTOM_CLOUD_DATA)
+		sourceDataSource := simplestreams.NewURLDataSource("local source", source, utils.VerifySSLHostnames, simplestreams.CUSTOM_CLOUD_DATA, false)
 		toolsList, err = envtools.FindToolsForCloud(
 			[]simplestreams.DataSource{sourceDataSource}, simplestreams.CloudSpec{}, c.stream,
 			version.Current.Major, minorVersion, coretools.Filter{})

--- a/cmd/plugins/juju-metadata/validateimagemetadata.go
+++ b/cmd/plugins/juju-metadata/validateimagemetadata.go
@@ -189,7 +189,7 @@ func (c *validateImageMetadataCommand) Run(context *cmd.Context) error {
 		}
 		params.Sources = []simplestreams.DataSource{
 			simplestreams.NewURLDataSource(
-				"local metadata directory", "file://"+dir, utils.VerifySSLHostnames, simplestreams.CUSTOM_CLOUD_DATA),
+				"local metadata directory", "file://"+dir, utils.VerifySSLHostnames, simplestreams.CUSTOM_CLOUD_DATA, false),
 		}
 	}
 	params.Stream = c.stream

--- a/cmd/plugins/juju-metadata/validatetoolsmetadata.go
+++ b/cmd/plugins/juju-metadata/validatetoolsmetadata.go
@@ -210,7 +210,7 @@ func (c *validateToolsMetadataCommand) Run(context *cmd.Context) error {
 			return err
 		}
 		params.Sources = []simplestreams.DataSource{simplestreams.NewURLDataSource(
-			"local metadata directory", toolsURL, utils.VerifySSLHostnames, simplestreams.CUSTOM_CLOUD_DATA),
+			"local metadata directory", toolsURL, utils.VerifySSLHostnames, simplestreams.CUSTOM_CLOUD_DATA, false),
 		}
 	}
 	params.Stream = c.stream

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -258,12 +258,11 @@ func setPrivateMetadataSources(env environs.Environ, metadataDir string) ([]*ima
 	}
 
 	baseURL := fmt.Sprintf("file://%s", filepath.ToSlash(imageMetadataDir))
-	datasource := simplestreams.NewURLDataSource("bootstrap metadata", baseURL, utils.NoVerifySSLHostnames, simplestreams.CUSTOM_CLOUD_DATA)
+	datasource := simplestreams.NewURLDataSource("bootstrap metadata", baseURL, utils.NoVerifySSLHostnames, simplestreams.CUSTOM_CLOUD_DATA, false)
 
 	// Read the image metadata, as we'll want to upload it to the environment.
 	imageConstraint := imagemetadata.NewImageConstraint(simplestreams.LookupParams{})
-	existingMetadata, _, err := imagemetadata.Fetch(
-		[]simplestreams.DataSource{datasource}, imageConstraint, false)
+	existingMetadata, _, err := imagemetadata.Fetch([]simplestreams.DataSource{datasource}, imageConstraint)
 	if err != nil && !errors.IsNotFound(err) {
 		return nil, errors.Annotate(err, "cannot read image metadata")
 	}

--- a/environs/bootstrap/bootstrap_test.go
+++ b/environs/bootstrap/bootstrap_test.go
@@ -290,7 +290,7 @@ func (s *bootstrapSuite) setupBootstrapSpecificVersion(c *gc.C, clientMajor, cli
 	env := newEnviron("foo", useDefaultKeys, nil)
 	s.setDummyStorage(c, env)
 	envtools.RegisterToolsDataSourceFunc("local storage", func(environs.Environ) (simplestreams.DataSource, error) {
-		return storage.NewStorageSimpleStreamsDataSource("test datasource", env.storage, "tools", simplestreams.CUSTOM_CLOUD_DATA), nil
+		return storage.NewStorageSimpleStreamsDataSource("test datasource", env.storage, "tools", simplestreams.CUSTOM_CLOUD_DATA, false), nil
 	})
 	defer envtools.UnregisterToolsDataSourceFunc("local storage")
 

--- a/environs/imagemetadata.go
+++ b/environs/imagemetadata.go
@@ -90,7 +90,7 @@ func ImageMetadataSources(env Environ) ([]simplestreams.DataSource, error) {
 		if !config.SSLHostnameVerification() {
 			verify = utils.NoVerifySSLHostnames
 		}
-		sources = append(sources, simplestreams.NewURLDataSource("image-metadata-url", userURL, verify, simplestreams.SPECIFIC_CLOUD_DATA))
+		sources = append(sources, simplestreams.NewURLDataSource("image-metadata-url", userURL, verify, simplestreams.SPECIFIC_CLOUD_DATA, false))
 	}
 
 	envDataSources, err := environmentDataSources(env)
@@ -106,7 +106,7 @@ func ImageMetadataSources(env Environ) ([]simplestreams.DataSource, error) {
 	}
 	if defaultURL != "" {
 		sources = append(sources,
-			simplestreams.NewURLDataSource("default cloud images", defaultURL, utils.VerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA))
+			simplestreams.NewURLDataSource("default cloud images", defaultURL, utils.VerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA, true))
 	}
 	for _, ds := range sources {
 		logger.Debugf("using image datasource %q", ds.Description())

--- a/environs/imagemetadata/export_test.go
+++ b/environs/imagemetadata/export_test.go
@@ -7,7 +7,7 @@ const CurrentStreamsVersion = currentStreamsVersion
 
 // SetSigningPublicKey sets a new public key for testing and returns the original key.
 func SetSigningPublicKey(key string) string {
-	oldKey := simplestreamsImagesPublicKey
-	simplestreamsImagesPublicKey = key
+	oldKey := SimplestreamsImagesPublicKey
+	SimplestreamsImagesPublicKey = key
 	return oldKey
 }

--- a/environs/imagemetadata/generate.go
+++ b/environs/imagemetadata/generate.go
@@ -46,9 +46,9 @@ func MergeAndWriteMetadata(ser string, metadata []*ImageMetadata, cloudSpec *sim
 // readMetadata reads the image metadata from metadataStore.
 func readMetadata(metadataStore storage.Storage) ([]*ImageMetadata, error) {
 	// Read any existing metadata so we can merge the new tools metadata with what's there.
-	dataSource := storage.NewStorageSimpleStreamsDataSource("existing metadata", metadataStore, storage.BaseImagesPath, simplestreams.EXISTING_CLOUD_DATA)
+	dataSource := storage.NewStorageSimpleStreamsDataSource("existing metadata", metadataStore, storage.BaseImagesPath, simplestreams.EXISTING_CLOUD_DATA, false)
 	imageConstraint := NewImageConstraint(simplestreams.LookupParams{})
-	existingMetadata, _, err := Fetch([]simplestreams.DataSource{dataSource}, imageConstraint, false)
+	existingMetadata, _, err := Fetch([]simplestreams.DataSource{dataSource}, imageConstraint)
 	if err != nil && !errors.IsNotFound(err) {
 		return nil, err
 	}

--- a/environs/imagemetadata/generate_test.go
+++ b/environs/imagemetadata/generate_test.go
@@ -27,8 +27,8 @@ func assertFetch(c *gc.C, stor storage.Storage, series, arch, region, endpoint, 
 		Series:    []string{series},
 		Arches:    []string{arch},
 	})
-	dataSource := storage.NewStorageSimpleStreamsDataSource("test datasource", stor, "images", simplestreams.DEFAULT_CLOUD_DATA)
-	metadata, _, err := imagemetadata.Fetch([]simplestreams.DataSource{dataSource}, cons, false)
+	dataSource := storage.NewStorageSimpleStreamsDataSource("test datasource", stor, "images", simplestreams.DEFAULT_CLOUD_DATA, false)
+	metadata, _, err := imagemetadata.Fetch([]simplestreams.DataSource{dataSource}, cons)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(metadata, gc.HasLen, 1)
 	c.Assert(metadata[0].Id, gc.Equals, id)

--- a/environs/imagemetadata/simplestreams.go
+++ b/environs/imagemetadata/simplestreams.go
@@ -37,7 +37,7 @@ const (
 // authenticate the simple streams data on http://cloud-images.ubuntu.com.
 // Declared as a var so it can be overidden for testing.
 // See http://bazaar.launchpad.net/~smoser/simplestreams/trunk/view/head:/examples/keys/cloud-images.pub
-var simplestreamsImagesPublicKey = `-----BEGIN PGP PUBLIC KEY BLOCK-----
+var SimplestreamsImagesPublicKey = `-----BEGIN PGP PUBLIC KEY BLOCK-----
 Version: GnuPG v1.4.12 (GNU/Linux)
 
 mQINBFCMc9EBEADDKn9mOi9VZhW+0cxmu3aFZWMg0p7NEKuIokkEdd6P+BRITccO
@@ -189,17 +189,16 @@ func (im *ImageMetadata) productId() string {
 // then unsigned data is used.
 func Fetch(
 	sources []simplestreams.DataSource, cons *ImageConstraint,
-	onlySigned bool) ([]*ImageMetadata, *simplestreams.ResolveInfo, error) {
+) ([]*ImageMetadata, *simplestreams.ResolveInfo, error) {
 
 	params := simplestreams.GetMetadataParams{
 		StreamsVersion:   currentStreamsVersion,
-		OnlySigned:       onlySigned,
 		LookupConstraint: cons,
 		ValueParams: simplestreams.ValueParams{
 			DataType:      ImageIds,
 			FilterFunc:    appendMatchingImages,
 			ValueTemplate: ImageMetadata{},
-			PublicKey:     simplestreamsImagesPublicKey,
+			PublicKey:     SimplestreamsImagesPublicKey,
 		},
 	}
 	items, resolveInfo, err := simplestreams.GetMetadata(sources, params)

--- a/environs/imagemetadata/simplestreams_test.go
+++ b/environs/imagemetadata/simplestreams_test.go
@@ -69,7 +69,7 @@ func registerSimpleStreamsTests() {
 	gc.Suite(&simplestreamsSuite{
 		LocalLiveSimplestreamsSuite: sstesting.LocalLiveSimplestreamsSuite{
 			Source: simplestreams.NewURLDataSource(
-				"test roundtripper", "test:", utils.VerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA),
+				"test roundtripper", "test:", utils.VerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA, false),
 			RequireSigned:  false,
 			DataType:       imagemetadata.ImageIds,
 			StreamsVersion: imagemetadata.CurrentStreamsVersion,
@@ -88,7 +88,7 @@ func registerSimpleStreamsTests() {
 
 func registerLiveSimpleStreamsTests(baseURL string, validImageConstraint simplestreams.LookupConstraint, requireSigned bool) {
 	gc.Suite(&sstesting.LocalLiveSimplestreamsSuite{
-		Source:          simplestreams.NewURLDataSource("test", baseURL, utils.VerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA),
+		Source:          simplestreams.NewURLDataSource("test", baseURL, utils.VerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA, requireSigned),
 		RequireSigned:   requireSigned,
 		DataType:        imagemetadata.ImageIds,
 		ValidConstraint: validImageConstraint,
@@ -270,9 +270,9 @@ func (s *simplestreamsSuite) TestFetch(c *gc.C) {
 			Arches:    t.arches,
 		})
 		// Add invalid datasource and check later that resolveInfo is correct.
-		invalidSource := simplestreams.NewURLDataSource("invalid", "file://invalid", utils.VerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA)
+		invalidSource := simplestreams.NewURLDataSource("invalid", "file://invalid", utils.VerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA, s.RequireSigned)
 		images, resolveInfo, err := imagemetadata.Fetch(
-			[]simplestreams.DataSource{invalidSource, s.Source}, imageConstraint, s.RequireSigned)
+			[]simplestreams.DataSource{invalidSource, s.Source}, imageConstraint)
 		if !c.Check(err, jc.ErrorIsNil) {
 			continue
 		}
@@ -377,13 +377,13 @@ func (s *signedSuite) TearDownSuite(c *gc.C) {
 }
 
 func (s *signedSuite) TestSignedImageMetadata(c *gc.C) {
-	signedSource := simplestreams.NewURLDataSource("test", "signedtest://host/signed", utils.VerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA)
+	signedSource := simplestreams.NewURLDataSource("test", "signedtest://host/signed", utils.VerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA, true)
 	imageConstraint := imagemetadata.NewImageConstraint(simplestreams.LookupParams{
 		CloudSpec: simplestreams.CloudSpec{"us-east-1", "https://ec2.us-east-1.amazonaws.com"},
 		Series:    []string{"precise"},
 		Arches:    []string{"amd64"},
 	})
-	images, resolveInfo, err := imagemetadata.Fetch([]simplestreams.DataSource{signedSource}, imageConstraint, true)
+	images, resolveInfo, err := imagemetadata.Fetch([]simplestreams.DataSource{signedSource}, imageConstraint)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(len(images), gc.Equals, 1)
 	c.Assert(images[0].Id, gc.Equals, "ami-123456")
@@ -396,14 +396,14 @@ func (s *signedSuite) TestSignedImageMetadata(c *gc.C) {
 }
 
 func (s *signedSuite) TestSignedImageMetadataInvalidSignature(c *gc.C) {
-	signedSource := simplestreams.NewURLDataSource("test", "signedtest://host/signed", utils.VerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA)
+	signedSource := simplestreams.NewURLDataSource("test", "signedtest://host/signed", utils.VerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA, true)
 	imageConstraint := imagemetadata.NewImageConstraint(simplestreams.LookupParams{
 		CloudSpec: simplestreams.CloudSpec{"us-east-1", "https://ec2.us-east-1.amazonaws.com"},
 		Series:    []string{"precise"},
 		Arches:    []string{"amd64"},
 	})
 	imagemetadata.SetSigningPublicKey(s.origKey)
-	_, _, err := imagemetadata.Fetch([]simplestreams.DataSource{signedSource}, imageConstraint, true)
+	_, _, err := imagemetadata.Fetch([]simplestreams.DataSource{signedSource}, imageConstraint)
 	c.Assert(err, gc.ErrorMatches, "cannot read index data.*")
 }
 

--- a/environs/imagemetadata/testing/testing.go
+++ b/environs/imagemetadata/testing/testing.go
@@ -28,7 +28,7 @@ func ParseMetadataFromDir(c *gc.C, metadataDir string) []*imagemetadata.ImageMet
 
 // ParseMetadataFromStorage loads ImageMetadata from the specified storage reader.
 func ParseMetadataFromStorage(c *gc.C, stor storage.StorageReader) []*imagemetadata.ImageMetadata {
-	source := storage.NewStorageSimpleStreamsDataSource("test storage reader", stor, "images", simplestreams.DEFAULT_CLOUD_DATA)
+	source := storage.NewStorageSimpleStreamsDataSource("test storage reader", stor, "images", simplestreams.DEFAULT_CLOUD_DATA, false)
 
 	// Find the simplestreams index file.
 	params := simplestreams.ValueParams{

--- a/environs/imagemetadata/validation.go
+++ b/environs/imagemetadata/validation.go
@@ -36,7 +36,7 @@ func ValidateImageMetadata(params *simplestreams.MetadataLookupParams) ([]string
 		Arches: params.Architectures,
 		Stream: params.Stream,
 	})
-	matchingImages, resolveInfo, err := Fetch(params.Sources, imageConstraint, false)
+	matchingImages, resolveInfo, err := Fetch(params.Sources, imageConstraint)
 	if err != nil {
 		return nil, resolveInfo, err
 	}

--- a/environs/imagemetadata/validation_test.go
+++ b/environs/imagemetadata/validation_test.go
@@ -60,7 +60,7 @@ func (s *ValidateSuite) assertMatch(c *gc.C, stream string) {
 		Endpoint:      "some-auth-url",
 		Stream:        stream,
 		Sources: []simplestreams.DataSource{
-			simplestreams.NewURLDataSource("test", utils.MakeFileURL(metadataPath), utils.VerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA)},
+			simplestreams.NewURLDataSource("test", utils.MakeFileURL(metadataPath), utils.VerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA, false)},
 	}
 	imageIds, resolveInfo, err := imagemetadata.ValidateImageMetadata(params)
 	c.Assert(err, jc.ErrorIsNil)
@@ -88,7 +88,7 @@ func (s *ValidateSuite) assertNoMatch(c *gc.C, stream string) {
 		Endpoint:      "some-auth-url",
 		Stream:        stream,
 		Sources: []simplestreams.DataSource{
-			simplestreams.NewURLDataSource("test", "file://"+s.metadataDir, utils.VerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA)},
+			simplestreams.NewURLDataSource("test", "file://"+s.metadataDir, utils.VerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA, false)},
 	}
 	_, _, err := imagemetadata.ValidateImageMetadata(params)
 	c.Assert(err, gc.Not(gc.IsNil))

--- a/environs/imagemetadata_test.go
+++ b/environs/imagemetadata_test.go
@@ -70,17 +70,17 @@ func (s *ImageMetadataSuite) TestImageMetadataURLs(c *gc.C) {
 
 func (s *ImageMetadataSuite) TestImageMetadataURLsRegisteredFuncs(c *gc.C) {
 	environs.RegisterImageDataSourceFunc("id0", func(environs.Environ) (simplestreams.DataSource, error) {
-		return simplestreams.NewURLDataSource("id0", "betwixt/releases", utils.NoVerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA), nil
+		return simplestreams.NewURLDataSource("id0", "betwixt/releases", utils.NoVerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA, false), nil
 	})
 	environs.RegisterImageDataSourceFunc("id1", func(environs.Environ) (simplestreams.DataSource, error) {
-		return simplestreams.NewURLDataSource("id1", "yoink", utils.NoVerifySSLHostnames, simplestreams.SPECIFIC_CLOUD_DATA), nil
+		return simplestreams.NewURLDataSource("id1", "yoink", utils.NoVerifySSLHostnames, simplestreams.SPECIFIC_CLOUD_DATA, false), nil
 	})
 	// overwrite the one previously registered against id1
 	environs.RegisterImageDataSourceFunc("id1", func(environs.Environ) (simplestreams.DataSource, error) {
 		return nil, errors.NewNotSupported(nil, "oyvey")
 	})
 	environs.RegisterUserImageDataSourceFunc("id2", func(environs.Environ) (simplestreams.DataSource, error) {
-		return simplestreams.NewURLDataSource("id2", "foobar", utils.NoVerifySSLHostnames, simplestreams.CUSTOM_CLOUD_DATA), nil
+		return simplestreams.NewURLDataSource("id2", "foobar", utils.NoVerifySSLHostnames, simplestreams.CUSTOM_CLOUD_DATA, false), nil
 	})
 	defer environs.UnregisterImageDataSourceFunc("id0")
 	defer environs.UnregisterImageDataSourceFunc("id1")

--- a/environs/instances/image_test.go
+++ b/environs/instances/image_test.go
@@ -357,7 +357,7 @@ func (s *imageSuite) TestFindInstanceSpec(c *gc.C) {
 		})
 		imageMeta, err := imagemetadata.GetLatestImageIdMetadata(
 			[]byte(jsonImagesContent),
-			simplestreams.NewURLDataSource("test", "some-url", utils.VerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA), cons)
+			simplestreams.NewURLDataSource("test", "some-url", utils.VerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA, false), cons)
 		c.Assert(err, jc.ErrorIsNil)
 		var images []Image
 		for _, imageMetadata := range imageMeta {

--- a/environs/jujutest/livetests.go
+++ b/environs/jujutest/livetests.go
@@ -24,6 +24,7 @@ import (
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/configstore"
 	"github.com/juju/juju/environs/filestorage"
+	sstesting "github.com/juju/juju/environs/simplestreams/testing"
 	"github.com/juju/juju/environs/storage"
 	"github.com/juju/juju/environs/sync"
 	envtesting "github.com/juju/juju/environs/testing"
@@ -49,6 +50,7 @@ type LiveTests struct {
 	gitjujutesting.CleanupSuite
 
 	envtesting.ToolsFixture
+	sstesting.TestDataSuite
 
 	// TestConfig contains the configuration attributes for opening an environment.
 	TestConfig coretesting.Attrs
@@ -81,6 +83,7 @@ type LiveTests struct {
 
 func (t *LiveTests) SetUpSuite(c *gc.C) {
 	t.CleanupSuite.SetUpSuite(c)
+	t.TestDataSuite.SetUpSuite(c)
 	t.ConfigStore = configstore.NewMem()
 }
 
@@ -112,6 +115,7 @@ func publicAttrs(e environs.Environ) map[string]interface{} {
 
 func (t *LiveTests) TearDownSuite(c *gc.C) {
 	t.Destroy(c)
+	t.TestDataSuite.TearDownSuite(c)
 	t.CleanupSuite.TearDownSuite(c)
 }
 

--- a/environs/jujutest/tests.go
+++ b/environs/jujutest/tests.go
@@ -18,6 +18,7 @@ import (
 	"github.com/juju/juju/environs/bootstrap"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/configstore"
+	sstesting "github.com/juju/juju/environs/simplestreams/testing"
 	"github.com/juju/juju/environs/storage"
 	envtesting "github.com/juju/juju/environs/testing"
 	"github.com/juju/juju/instance"
@@ -34,7 +35,7 @@ import (
 type Tests struct {
 	TestConfig coretesting.Attrs
 	envtesting.ToolsFixture
-
+	sstesting.TestDataSuite
 	// ConfigStore holds the configuration storage
 	// used when preparing the environment.
 	// This is initialized by SetUpTest.

--- a/environs/open_test.go
+++ b/environs/open_test.go
@@ -30,11 +30,13 @@ var _ = gc.Suite(&OpenSuite{})
 
 func (s *OpenSuite) SetUpTest(c *gc.C) {
 	s.FakeJujuHomeSuite.SetUpTest(c)
+	s.ToolsFixture.SetUpTest(c)
 	testing.WriteEnvironments(c, testing.MultipleEnvConfigNoDefault)
 }
 
 func (s *OpenSuite) TearDownTest(c *gc.C) {
 	dummy.Reset()
+	s.ToolsFixture.TearDownTest(c)
 	s.FakeJujuHomeSuite.TearDownTest(c)
 }
 

--- a/environs/simplestreams/datasource.go
+++ b/environs/simplestreams/datasource.go
@@ -31,6 +31,8 @@ type DataSource interface {
 	// Priority is an importance factor for Data Source. Higher number means higher priority.
 	// This is will allow to sort data sources in order of importance.
 	Priority() int
+	// RequireSigned indicates whether this data source requires signed data.
+	RequireSigned() bool
 }
 
 const (
@@ -61,15 +63,17 @@ type urlDataSource struct {
 	baseURL              string
 	hostnameVerification utils.SSLHostnameVerification
 	priority             int
+	requireSigned        bool
 }
 
 // NewURLDataSource returns a new datasource reading from the specified baseURL.
-func NewURLDataSource(description, baseURL string, hostnameVerification utils.SSLHostnameVerification, priority int) DataSource {
+func NewURLDataSource(description, baseURL string, hostnameVerification utils.SSLHostnameVerification, priority int, requireSigned bool) DataSource {
 	return &urlDataSource{
 		description:          description,
 		baseURL:              baseURL,
 		hostnameVerification: hostnameVerification,
 		priority:             priority,
+		requireSigned:        requireSigned,
 	}
 }
 
@@ -131,4 +135,9 @@ func (h *urlDataSource) SetAllowRetry(allow bool) {
 // Priority is defined in simplestreams.DataSource.
 func (h *urlDataSource) Priority() int {
 	return h.priority
+}
+
+// RequireSigned is defined in simplestreams.DataSource.
+func (h *urlDataSource) RequireSigned() bool {
+	return h.requireSigned
 }

--- a/environs/simplestreams/datasource_test.go
+++ b/environs/simplestreams/datasource_test.go
@@ -25,7 +25,7 @@ type datasourceSuite struct {
 }
 
 func (s *datasourceSuite) TestFetch(c *gc.C) {
-	ds := simplestreams.NewURLDataSource("test", "test:", utils.VerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA)
+	ds := simplestreams.NewURLDataSource("test", "test:", utils.VerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA, false)
 	rc, url, err := ds.Fetch("streams/v1/tools_metadata.json")
 	c.Assert(err, jc.ErrorIsNil)
 	defer rc.Close()
@@ -37,7 +37,7 @@ func (s *datasourceSuite) TestFetch(c *gc.C) {
 }
 
 func (s *datasourceSuite) TestURL(c *gc.C) {
-	ds := simplestreams.NewURLDataSource("test", "foo", utils.VerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA)
+	ds := simplestreams.NewURLDataSource("test", "foo", utils.VerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA, false)
 	url, err := ds.URL("bar")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(url, gc.Equals, "foo/bar")
@@ -65,7 +65,7 @@ func (s *datasourceHTTPSSuite) TearDownTest(c *gc.C) {
 }
 
 func (s *datasourceHTTPSSuite) TestNormalClientFails(c *gc.C) {
-	ds := simplestreams.NewURLDataSource("test", s.Server.URL, utils.VerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA)
+	ds := simplestreams.NewURLDataSource("test", s.Server.URL, utils.VerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA, false)
 	url, err := ds.URL("bar")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(url, gc.Equals, s.Server.URL+"/bar")
@@ -77,7 +77,7 @@ func (s *datasourceHTTPSSuite) TestNormalClientFails(c *gc.C) {
 }
 
 func (s *datasourceHTTPSSuite) TestNonVerifyingClientSucceeds(c *gc.C) {
-	ds := simplestreams.NewURLDataSource("test", s.Server.URL, utils.NoVerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA)
+	ds := simplestreams.NewURLDataSource("test", s.Server.URL, utils.NoVerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA, false)
 	url, err := ds.URL("bar")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(url, gc.Equals, s.Server.URL+"/bar")

--- a/environs/simplestreams/simplestreams.go
+++ b/environs/simplestreams/simplestreams.go
@@ -361,7 +361,6 @@ func UnsignedMirror(streamsVersion string) string {
 type GetMetadataParams struct {
 	StreamsVersion   string
 	LookupConstraint LookupConstraint
-	OnlySigned       bool
 	ValueParams      ValueParams
 }
 
@@ -374,7 +373,7 @@ func GetMetadata(sources []DataSource, params GetMetadataParams) (items []interf
 		logger.Tracef("searching for metadata in datasource %q", source.Description())
 		items, resolveInfo, err = getMaybeSignedMetadata(source, params, true)
 		// If no items are found using signed metadata, check unsigned.
-		if err != nil && len(items) == 0 && !params.OnlySigned {
+		if err != nil && len(items) == 0 && !source.RequireSigned() {
 			items, resolveInfo, err = getMaybeSignedMetadata(source, params, false)
 		}
 		if err == nil {
@@ -518,7 +517,7 @@ func GetIndexWithFormat(source DataSource, indexPath, indexFormat, mirrorsPath s
 			source, mirrors, params.DataType, params.MirrorContentId, cloudSpec, requireSigned, params.PublicKey)
 		if err == nil {
 			logger.Debugf("using mirrored products path: %s", path.Join(mirrorInfo.MirrorURL, mirrorInfo.Path))
-			indexRef.Source = NewURLDataSource("mirror", mirrorInfo.MirrorURL, utils.VerifySSLHostnames, source.Priority())
+			indexRef.Source = NewURLDataSource("mirror", mirrorInfo.MirrorURL, utils.VerifySSLHostnames, source.Priority(), source.RequireSigned())
 			indexRef.MirroredProductsPath = mirrorInfo.Path
 		} else {
 			logger.Tracef("no mirror information available for %s: %v", cloudSpec, err)

--- a/environs/simplestreams/simplestreams_test.go
+++ b/environs/simplestreams/simplestreams_test.go
@@ -26,7 +26,7 @@ func Test(t *testing.T) {
 func registerSimpleStreamsTests() {
 	gc.Suite(&simplestreamsSuite{
 		LocalLiveSimplestreamsSuite: sstesting.LocalLiveSimplestreamsSuite{
-			Source:         simplestreams.NewURLDataSource("test", "test:", utils.VerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA),
+			Source:         simplestreams.NewURLDataSource("test", "test:", utils.VerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA, false),
 			RequireSigned:  false,
 			DataType:       "image-ids",
 			StreamsVersion: "v1",
@@ -330,7 +330,11 @@ func (s *countingSource) URL(path string) (string, error) {
 func (s *simplestreamsSuite) TestGetMetadataNoMatching(c *gc.C) {
 	source := &countingSource{
 		DataSource: simplestreams.NewURLDataSource(
-			"test", "test:/daily", utils.VerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA,
+			"test",
+			"test:/daily",
+			utils.VerifySSLHostnames,
+			simplestreams.DEFAULT_CLOUD_DATA,
+			false,
 		),
 	}
 	sources := []simplestreams.DataSource{source, source, source}

--- a/environs/simplestreams/testing/testing.go
+++ b/environs/simplestreams/testing/testing.go
@@ -533,10 +533,9 @@ var imageData = map[string]string{
 `,
 }
 
-var testRoundTripper *testing.ProxyRoundTripper
+var testRoundTripper = &testing.ProxyRoundTripper{}
 
 func init() {
-	testRoundTripper = &testing.ProxyRoundTripper{}
 	testRoundTripper.RegisterForScheme("test")
 }
 

--- a/environs/storage/storage.go
+++ b/environs/storage/storage.go
@@ -73,11 +73,12 @@ var BaseImagesPath = "images"
 
 // A storageSimpleStreamsDataSource retrieves data from a StorageReader.
 type storageSimpleStreamsDataSource struct {
-	description string
-	basePath    string
-	storage     StorageReader
-	allowRetry  bool
-	priority    int
+	description   string
+	basePath      string
+	storage       StorageReader
+	allowRetry    bool
+	priority      int
+	requireSigned bool
 }
 
 // TestingGetAllowRetry is used in tests which need to see if allowRetry has been
@@ -90,8 +91,8 @@ func TestingGetAllowRetry(s simplestreams.DataSource) (bool, ok bool) {
 }
 
 // NewStorageSimpleStreamsDataSource returns a new datasource reading from the specified storage.
-func NewStorageSimpleStreamsDataSource(description string, storage StorageReader, basePath string, priority int) simplestreams.DataSource {
-	return &storageSimpleStreamsDataSource{description, basePath, storage, false, priority}
+func NewStorageSimpleStreamsDataSource(description string, storage StorageReader, basePath string, priority int, requireSigned bool) simplestreams.DataSource {
+	return &storageSimpleStreamsDataSource{description, basePath, storage, false, priority, requireSigned}
 }
 
 func (s *storageSimpleStreamsDataSource) relpath(storagePath string) string {
@@ -139,4 +140,9 @@ func (s *storageSimpleStreamsDataSource) SetAllowRetry(allow bool) {
 // Priority is defined in simplestreams.DataSource.
 func (s *storageSimpleStreamsDataSource) Priority() int {
 	return s.priority
+}
+
+// RequireSigned is defined in simplestreams.DataSource.
+func (s *storageSimpleStreamsDataSource) RequireSigned() bool {
+	return s.requireSigned
 }

--- a/environs/storage/storage_test.go
+++ b/environs/storage/storage_test.go
@@ -46,7 +46,7 @@ func (s *datasourceSuite) SetUpTest(c *gc.C) {
 func (s *datasourceSuite) TestFetch(c *gc.C) {
 	sampleData := "hello world"
 	s.stor.Put("foo/bar/data.txt", bytes.NewReader([]byte(sampleData)), int64(len(sampleData)))
-	ds := storage.NewStorageSimpleStreamsDataSource("test datasource", s.stor, "", simplestreams.DEFAULT_CLOUD_DATA)
+	ds := storage.NewStorageSimpleStreamsDataSource("test datasource", s.stor, "", simplestreams.DEFAULT_CLOUD_DATA, false)
 	rc, url, err := ds.Fetch("foo/bar/data.txt")
 	c.Assert(err, jc.ErrorIsNil)
 	defer rc.Close()
@@ -58,7 +58,7 @@ func (s *datasourceSuite) TestFetch(c *gc.C) {
 func (s *datasourceSuite) TestFetchWithBasePath(c *gc.C) {
 	sampleData := "hello world"
 	s.stor.Put("base/foo/bar/data.txt", bytes.NewReader([]byte(sampleData)), int64(len(sampleData)))
-	ds := storage.NewStorageSimpleStreamsDataSource("test datasource", s.stor, "base", simplestreams.DEFAULT_CLOUD_DATA)
+	ds := storage.NewStorageSimpleStreamsDataSource("test datasource", s.stor, "base", simplestreams.DEFAULT_CLOUD_DATA, false)
 	rc, url, err := ds.Fetch("foo/bar/data.txt")
 	c.Assert(err, jc.ErrorIsNil)
 	defer rc.Close()
@@ -69,7 +69,7 @@ func (s *datasourceSuite) TestFetchWithBasePath(c *gc.C) {
 
 func (s *datasourceSuite) TestFetchWithRetry(c *gc.C) {
 	stor := &fakeStorage{shouldRetry: true}
-	ds := storage.NewStorageSimpleStreamsDataSource("test datasource", stor, "base", simplestreams.DEFAULT_CLOUD_DATA)
+	ds := storage.NewStorageSimpleStreamsDataSource("test datasource", stor, "base", simplestreams.DEFAULT_CLOUD_DATA, false)
 	ds.SetAllowRetry(true)
 	_, _, err := ds.Fetch("foo/bar/data.txt")
 	c.Assert(err, gc.ErrorMatches, "an error")
@@ -81,7 +81,7 @@ func (s *datasourceSuite) TestFetchWithNoRetry(c *gc.C) {
 	// NB shouldRetry below is true indicating the fake storage is capable of
 	// retrying, not that it will retry.
 	stor := &fakeStorage{shouldRetry: true}
-	ds := storage.NewStorageSimpleStreamsDataSource("test datasource", stor, "base", simplestreams.DEFAULT_CLOUD_DATA)
+	ds := storage.NewStorageSimpleStreamsDataSource("test datasource", stor, "base", simplestreams.DEFAULT_CLOUD_DATA, false)
 	_, _, err := ds.Fetch("foo/bar/data.txt")
 	c.Assert(err, gc.ErrorMatches, "an error")
 	c.Assert(stor.getName, gc.Equals, "base/foo/bar/data.txt")
@@ -91,7 +91,7 @@ func (s *datasourceSuite) TestFetchWithNoRetry(c *gc.C) {
 func (s *datasourceSuite) TestURL(c *gc.C) {
 	sampleData := "hello world"
 	s.stor.Put("bar/data.txt", bytes.NewReader([]byte(sampleData)), int64(len(sampleData)))
-	ds := storage.NewStorageSimpleStreamsDataSource("test datasource", s.stor, "", simplestreams.DEFAULT_CLOUD_DATA)
+	ds := storage.NewStorageSimpleStreamsDataSource("test datasource", s.stor, "", simplestreams.DEFAULT_CLOUD_DATA, false)
 	url, err := ds.URL("bar")
 	c.Assert(err, jc.ErrorIsNil)
 	expectedURL, _ := s.stor.URL("bar")
@@ -101,7 +101,7 @@ func (s *datasourceSuite) TestURL(c *gc.C) {
 func (s *datasourceSuite) TestURLWithBasePath(c *gc.C) {
 	sampleData := "hello world"
 	s.stor.Put("base/bar/data.txt", bytes.NewReader([]byte(sampleData)), int64(len(sampleData)))
-	ds := storage.NewStorageSimpleStreamsDataSource("test datasource", s.stor, "base", simplestreams.DEFAULT_CLOUD_DATA)
+	ds := storage.NewStorageSimpleStreamsDataSource("test datasource", s.stor, "base", simplestreams.DEFAULT_CLOUD_DATA, false)
 	url, err := ds.URL("bar")
 	c.Assert(err, jc.ErrorIsNil)
 	expectedURL, _ := s.stor.URL("base/bar")

--- a/environs/sync/sync.go
+++ b/environs/sync/sync.go
@@ -159,7 +159,7 @@ func selectSourceDatasource(syncContext *SyncContext) (simplestreams.DataSource,
 		return nil, err
 	}
 	logger.Infof("using sync tools source: %v", sourceURL)
-	return simplestreams.NewURLDataSource("sync tools source", sourceURL, utils.VerifySSLHostnames, simplestreams.CUSTOM_CLOUD_DATA), nil
+	return simplestreams.NewURLDataSource("sync tools source", sourceURL, utils.VerifySSLHostnames, simplestreams.CUSTOM_CLOUD_DATA, false), nil
 }
 
 // copyTools copies a set of tools from the source to the target.

--- a/environs/testing/tools.go
+++ b/environs/testing/tools.go
@@ -45,7 +45,6 @@ type ToolsFixture struct {
 	// to just arch.HostArch()
 	UploadArches []string
 
-	// origPublicKey is an Original Public Key :D
 	origPublicKey string
 }
 

--- a/environs/tools/export_test.go
+++ b/environs/tools/export_test.go
@@ -15,7 +15,7 @@ var (
 
 // SetSigningPublicKey sets a new public key for testing and returns the original key.
 func SetSigningPublicKey(key string) string {
-	oldKey := simplestreamsToolsPublicKey
-	simplestreamsToolsPublicKey = key
+	oldKey := SimplestreamsToolsPublicKey
+	SimplestreamsToolsPublicKey = key
 	return oldKey
 }

--- a/environs/tools/simplestreams.go
+++ b/environs/tools/simplestreams.go
@@ -47,10 +47,9 @@ const (
 
 var currentStreamsVersion = StreamsVersionV1
 
-// simplestreamsToolsPublicKey is the public key required to
+// SimplestreamsToolsPublicKey is the public key required to
 // authenticate the simple streams data on http://streams.canonical.com.
-// Declared as a var so it can be overidden for testing.
-var simplestreamsToolsPublicKey = `-----BEGIN PGP PUBLIC KEY BLOCK-----
+var SimplestreamsToolsPublicKey = `-----BEGIN PGP PUBLIC KEY BLOCK-----
 Version: GnuPG v1.4.11 (GNU/Linux)
 
 mQINBFJN1n8BEAC1vt2w08Y4ztJrv3maOycMezBb7iUs6DLH8hOZoqRO9EW9558W
@@ -221,18 +220,17 @@ func (t *ToolsMetadata) productId() (string, error) {
 // then unsigned data is used.
 func Fetch(
 	sources []simplestreams.DataSource, cons *ToolsConstraint,
-	onlySigned bool) ([]*ToolsMetadata, *simplestreams.ResolveInfo, error) {
+) ([]*ToolsMetadata, *simplestreams.ResolveInfo, error) {
 
 	params := simplestreams.GetMetadataParams{
 		StreamsVersion:   currentStreamsVersion,
-		OnlySigned:       onlySigned,
 		LookupConstraint: cons,
 		ValueParams: simplestreams.ValueParams{
 			DataType:        ContentDownload,
 			FilterFunc:      appendMatchingTools,
 			MirrorContentId: ToolsContentId(cons.Stream),
 			ValueTemplate:   ToolsMetadata{},
-			PublicKey:       simplestreamsToolsPublicKey,
+			PublicKey:       SimplestreamsToolsPublicKey,
 		},
 	}
 	items, resolveInfo, err := simplestreams.GetMetadata(sources, params)
@@ -409,13 +407,12 @@ func MergeMetadata(tmlist1, tmlist2 []*ToolsMetadata) ([]*ToolsMetadata, error) 
 
 // ReadMetadata returns the tools metadata from the given storage for the specified stream.
 func ReadMetadata(store storage.StorageReader, stream string) ([]*ToolsMetadata, error) {
-	dataSource := storage.NewStorageSimpleStreamsDataSource("existing metadata", store, storage.BaseToolsPath, simplestreams.EXISTING_CLOUD_DATA)
+	dataSource := storage.NewStorageSimpleStreamsDataSource("existing metadata", store, storage.BaseToolsPath, simplestreams.EXISTING_CLOUD_DATA, false)
 	toolsConstraint, err := makeToolsConstraint(simplestreams.CloudSpec{}, stream, -1, -1, coretools.Filter{})
 	if err != nil {
 		return nil, err
 	}
-	metadata, _, err := Fetch(
-		[]simplestreams.DataSource{dataSource}, toolsConstraint, false)
+	metadata, _, err := Fetch([]simplestreams.DataSource{dataSource}, toolsConstraint)
 	if err != nil && !errors.IsNotFound(err) {
 		return nil, err
 	}

--- a/environs/tools/testing/testing.go
+++ b/environs/tools/testing/testing.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/juju/juju/environs/filestorage"
 	"github.com/juju/juju/environs/simplestreams"
+	sstesting "github.com/juju/juju/environs/simplestreams/testing"
 	"github.com/juju/juju/environs/storage"
 	"github.com/juju/juju/environs/sync"
 	envtesting "github.com/juju/juju/environs/testing"
@@ -240,7 +241,7 @@ func generateMetadata(c *gc.C, stream string, versions ...version.Binary) []meta
 		// add unsigned
 		objects = append(objects, metadataFile{fileName, content})
 
-		signedFilename, signedContent, err := envtesting.SignMetadata(fileName, content)
+		signedFilename, signedContent, err := sstesting.SignMetadata(fileName, content)
 		c.Assert(err, jc.ErrorIsNil)
 
 		// add signed
@@ -252,7 +253,7 @@ func generateMetadata(c *gc.C, stream string, versions ...version.Binary) []meta
 		addTools(simplestreams.UnsignedIndex("v1", 1), legacyIndex)
 	}
 	for stream, metadata := range products {
-		objects = append(objects, metadataFile{tools.ProductMetadataPath(stream), metadata})
+		addTools(tools.ProductMetadataPath(stream), metadata)
 	}
 	return objects
 }

--- a/environs/tools/tools.go
+++ b/environs/tools/tools.go
@@ -120,7 +120,7 @@ func FindToolsForCloud(sources []simplestreams.DataSource, cloudSpec simplestrea
 	if err != nil {
 		return nil, err
 	}
-	toolsMetadata, _, err := Fetch(sources, toolsConstraint, false)
+	toolsMetadata, _, err := Fetch(sources, toolsConstraint)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			err = ErrNoTools

--- a/environs/tools/tools_test.go
+++ b/environs/tools/tools_test.go
@@ -202,7 +202,7 @@ func (s *SimpleStreamsToolsSuite) TestFindToolsFiltering(c *gc.C) {
 	}
 	sources, err := envtools.GetMetadataSources(s.env)
 	c.Assert(err, jc.ErrorIsNil)
-	for i := 0; i < 2*len(sources); i++ {
+	for i := 0; i < len(sources); i++ {
 		messages = append(messages,
 			jc.SimpleMessage{loggo.TRACE, `fetchData failed for .*`},
 			jc.SimpleMessage{loggo.TRACE, `cannot load index .*`})

--- a/environs/tools/urls.go
+++ b/environs/tools/urls.go
@@ -76,7 +76,7 @@ func GetMetadataSources(env environs.Environ) ([]simplestreams.DataSource, error
 		if !config.SSLHostnameVerification() {
 			verify = utils.NoVerifySSLHostnames
 		}
-		sources = append(sources, simplestreams.NewURLDataSource(conf.AgentMetadataURLKey, userURL, verify, simplestreams.SPECIFIC_CLOUD_DATA))
+		sources = append(sources, simplestreams.NewURLDataSource(conf.AgentMetadataURLKey, userURL, verify, simplestreams.SPECIFIC_CLOUD_DATA, false))
 	}
 
 	envDataSources, err := environmentDataSources(env)
@@ -92,7 +92,7 @@ func GetMetadataSources(env environs.Environ) ([]simplestreams.DataSource, error
 	}
 	if defaultURL != "" {
 		sources = append(sources,
-			simplestreams.NewURLDataSource("default simplestreams", defaultURL, utils.VerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA))
+			simplestreams.NewURLDataSource("default simplestreams", defaultURL, utils.VerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA, true))
 	}
 	return sources, nil
 }

--- a/environs/tools/urls_test.go
+++ b/environs/tools/urls_test.go
@@ -67,10 +67,10 @@ func (s *URLsSuite) TestToolsSources(c *gc.C) {
 
 func (s *URLsSuite) TestToolsMetadataURLsRegisteredFuncs(c *gc.C) {
 	tools.RegisterToolsDataSourceFunc("id0", func(environs.Environ) (simplestreams.DataSource, error) {
-		return simplestreams.NewURLDataSource("id0", "betwixt/releases", utils.NoVerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA), nil
+		return simplestreams.NewURLDataSource("id0", "betwixt/releases", utils.NoVerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA, false), nil
 	})
 	tools.RegisterToolsDataSourceFunc("id1", func(environs.Environ) (simplestreams.DataSource, error) {
-		return simplestreams.NewURLDataSource("id1", "yoink", utils.NoVerifySSLHostnames, simplestreams.SPECIFIC_CLOUD_DATA), nil
+		return simplestreams.NewURLDataSource("id1", "yoink", utils.NoVerifySSLHostnames, simplestreams.SPECIFIC_CLOUD_DATA, false), nil
 	})
 	// overwrite the one previously registered against id1
 	tools.RegisterToolsDataSourceFunc("id1", func(environs.Environ) (simplestreams.DataSource, error) {

--- a/environs/tools/validation.go
+++ b/environs/tools/validation.go
@@ -56,7 +56,7 @@ func ValidateToolsMetadata(params *ToolsMetadataLookupParams) ([]string, *simple
 			Arches: params.Architectures,
 		})
 	}
-	matchingTools, resolveInfo, err := Fetch(params.Sources, toolsConstraint, false)
+	matchingTools, resolveInfo, err := Fetch(params.Sources, toolsConstraint)
 	if err != nil {
 		return nil, resolveInfo, err
 	}

--- a/environs/tools/validation_test.go
+++ b/environs/tools/validation_test.go
@@ -63,7 +63,7 @@ func (s *ValidateSuite) TestExactVersionMatch(c *gc.C) {
 			Endpoint:      "some-auth-url",
 			Stream:        "released",
 			Sources: []simplestreams.DataSource{
-				simplestreams.NewURLDataSource("test", s.toolsURL(), utils.VerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA)},
+				simplestreams.NewURLDataSource("test", s.toolsURL(), utils.VerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA, false)},
 		},
 	}
 	versions, resolveInfo, err := ValidateToolsMetadata(params)
@@ -89,7 +89,7 @@ func (s *ValidateSuite) TestMajorVersionMatch(c *gc.C) {
 			Endpoint:      "some-auth-url",
 			Stream:        "released",
 			Sources: []simplestreams.DataSource{
-				simplestreams.NewURLDataSource("test", s.toolsURL(), utils.VerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA)},
+				simplestreams.NewURLDataSource("test", s.toolsURL(), utils.VerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA, false)},
 		},
 	}
 	versions, resolveInfo, err := ValidateToolsMetadata(params)
@@ -115,7 +115,7 @@ func (s *ValidateSuite) TestMajorMinorVersionMatch(c *gc.C) {
 			Endpoint:      "some-auth-url",
 			Stream:        "released",
 			Sources: []simplestreams.DataSource{
-				simplestreams.NewURLDataSource("test", s.toolsURL(), utils.VerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA)},
+				simplestreams.NewURLDataSource("test", s.toolsURL(), utils.VerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA, false)},
 		},
 	}
 	versions, resolveInfo, err := ValidateToolsMetadata(params)
@@ -140,7 +140,7 @@ func (s *ValidateSuite) TestNoMatch(c *gc.C) {
 			Endpoint:      "some-auth-url",
 			Stream:        "released",
 			Sources: []simplestreams.DataSource{
-				simplestreams.NewURLDataSource("test", s.toolsURL(), utils.VerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA)},
+				simplestreams.NewURLDataSource("test", s.toolsURL(), utils.VerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA, false)},
 		},
 	}
 	_, _, err := ValidateToolsMetadata(params)
@@ -158,7 +158,7 @@ func (s *ValidateSuite) TestStreamsNoMatch(c *gc.C) {
 			Endpoint:      "some-auth-url",
 			Stream:        "testing",
 			Sources: []simplestreams.DataSource{
-				simplestreams.NewURLDataSource("test", s.toolsURL(), utils.VerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA)},
+				simplestreams.NewURLDataSource("test", s.toolsURL(), utils.VerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA, false)},
 		},
 	}
 	_, _, err := ValidateToolsMetadata(params)

--- a/provider/azure/internal/legacy/azure/azure_test.go
+++ b/provider/azure/internal/legacy/azure/azure_test.go
@@ -16,7 +16,9 @@ import (
 
 	"github.com/juju/juju/environs/imagemetadata"
 	"github.com/juju/juju/environs/simplestreams"
+	sstesting "github.com/juju/juju/environs/simplestreams/testing"
 	envtesting "github.com/juju/juju/environs/testing"
+	envtools "github.com/juju/juju/environs/tools"
 	testing "github.com/juju/juju/testing"
 )
 
@@ -32,15 +34,12 @@ type providerSuite struct {
 
 var _ = gc.Suite(&providerSuite{})
 
-var testRoundTripper = &testing.ProxyRoundTripper{}
-
-func init() {
-	// Prepare mock http transport for overriding metadata and images output in tests.
-	testRoundTripper.RegisterForScheme("test")
-}
-
 func (s *providerSuite) SetUpSuite(c *gc.C) {
 	s.BaseSuite.SetUpSuite(c)
+
+	s.PatchValue(&imagemetadata.SimplestreamsImagesPublicKey, sstesting.SignedMetadataPublicKey)
+	s.PatchValue(&envtools.SimplestreamsToolsPublicKey, sstesting.SignedMetadataPublicKey)
+
 	s.restoreTimeouts = envtesting.PatchAttemptStrategies()
 	s.UploadArches = []string{arch.AMD64}
 }
@@ -95,5 +94,5 @@ func (s *providerSuite) makeTestMetadata(c *gc.C, ser, location string, im []*im
 		"/streams/v1/index.json":                string(index),
 		"/" + imagemetadata.ProductMetadataPath: string(products),
 	}
-	s.PatchValue(&testRoundTripper.Sub, testing.NewCannedRoundTripper(files, nil))
+	sstesting.SetRoundTripperFiles(sstesting.AddSignedFiles(c, files), nil)
 }

--- a/provider/azure/internal/legacy/azure/instancetype.go
+++ b/provider/azure/internal/legacy/azure/instancetype.go
@@ -86,7 +86,7 @@ func findMatchingImages(e *azureEnviron, location, series string, arches []strin
 	if err != nil {
 		return nil, err
 	}
-	images, _, err := imagemetadata.Fetch(sources, constraint, signedImageDataOnly)
+	images, _, err := imagemetadata.Fetch(sources, constraint)
 	if len(images) == 0 || errors.IsNotFound(err) {
 		return nil, fmt.Errorf("no OS images found for location %q, series %q, architectures %q (and endpoint: %q)", location, series, arches, endpoint)
 	} else if err != nil {

--- a/provider/cloudsigma/environinstance.go
+++ b/provider/cloudsigma/environinstance.go
@@ -27,7 +27,7 @@ var findInstanceImage = func(env *environ, ic *imagemetadata.ImageConstraint) (*
 		return nil, err
 	}
 
-	matchingImages, _, err := imagemetadata.Fetch(sources, ic, false)
+	matchingImages, _, err := imagemetadata.Fetch(sources, ic)
 	if err != nil {
 		return nil, err
 	}

--- a/provider/cloudsigma/provider.go
+++ b/provider/cloudsigma/provider.go
@@ -29,7 +29,7 @@ func getImageSource(env environs.Environ) (simplestreams.DataSource, error) {
 	if !ok {
 		return nil, errors.NotSupportedf("non-cloudsigma environment")
 	}
-	return simplestreams.NewURLDataSource("cloud images", fmt.Sprintf(CloudsigmaCloudImagesURLTemplate, e.ecfg.region()), utils.VerifySSLHostnames, simplestreams.SPECIFIC_CLOUD_DATA), nil
+	return simplestreams.NewURLDataSource("cloud images", fmt.Sprintf(CloudsigmaCloudImagesURLTemplate, e.ecfg.region()), utils.VerifySSLHostnames, simplestreams.SPECIFIC_CLOUD_DATA, false), nil
 }
 
 type environProvider struct{}

--- a/provider/common/mock_test.go
+++ b/provider/common/mock_test.go
@@ -84,7 +84,7 @@ func (env *mockEnviron) GetToolsSources() ([]simplestreams.DataSource, error) {
 	if env.getToolsSources != nil {
 		return env.getToolsSources()
 	}
-	datasource := storage.NewStorageSimpleStreamsDataSource("test cloud storage", env.Storage(), storage.BaseToolsPath, simplestreams.SPECIFIC_CLOUD_DATA)
+	datasource := storage.NewStorageSimpleStreamsDataSource("test cloud storage", env.Storage(), storage.BaseToolsPath, simplestreams.SPECIFIC_CLOUD_DATA, false)
 	return []simplestreams.DataSource{datasource}, nil
 }
 

--- a/provider/common/supportedarchitectures.go
+++ b/provider/common/supportedarchitectures.go
@@ -16,7 +16,7 @@ func SupportedArchitectures(env environs.Environ, imageConstraint *imagemetadata
 	if err != nil {
 		return nil, err
 	}
-	matchingImages, _, err := imagemetadata.Fetch(sources, imageConstraint, false)
+	matchingImages, _, err := imagemetadata.Fetch(sources, imageConstraint)
 	if err != nil {
 		return nil, err
 	}

--- a/provider/common/supportedarchitectures_test.go
+++ b/provider/common/supportedarchitectures_test.go
@@ -56,7 +56,7 @@ func (s *archSuite) setupMetadata(c *gc.C, arches []string) (environs.Environ, s
 
 	id := "SupportedArchitectures"
 	environs.RegisterImageDataSourceFunc(id, func(environs.Environ) (simplestreams.DataSource, error) {
-		return simplestreams.NewURLDataSource(id, "file://"+metadataDir+"/images", false, simplestreams.DEFAULT_CLOUD_DATA), nil
+		return simplestreams.NewURLDataSource(id, "file://"+metadataDir+"/images", false, simplestreams.DEFAULT_CLOUD_DATA, false), nil
 	})
 	s.AddCleanup(func(*gc.C) {
 		environs.UnregisterImageDataSourceFunc(id)

--- a/provider/ec2/ebs_test.go
+++ b/provider/ec2/ebs_test.go
@@ -59,7 +59,6 @@ var _ = gc.Suite(&ebsVolumeSuite{})
 type ebsVolumeSuite struct {
 	testing.BaseSuite
 	jujutest.Tests
-	//	sstesting.TestDataSuite
 	srv                localServer
 	restoreEC2Patching func()
 
@@ -73,13 +72,11 @@ func (s *ebsVolumeSuite) SetUpSuite(c *gc.C) {
 	s.TestConfig = localConfigAttrs
 	s.restoreEC2Patching = patchEC2ForTesting()
 	s.BaseSuite.SetUpSuite(c)
-	//	s.TestDataSuite.SetUpSuite(c)
-	//	s.PatchValue(&imagemetadata.SimplestreamsImagesPublicKey, sstesting.SignedMetadataPublicKey)
-	//	s.PatchValue(&envtools.SimplestreamsToolsPublicKey, sstesting.SignedMetadataPublicKey)
+	s.Tests.SetUpSuite(c)
 }
 
 func (s *ebsVolumeSuite) TearDownSuite(c *gc.C) {
-	//	s.TestDataSuite.TearDownSuite(c)
+	s.Tests.TearDownSuite(c)
 	s.BaseSuite.TearDownSuite(c)
 	s.restoreEC2Patching()
 }

--- a/provider/ec2/ebs_test.go
+++ b/provider/ec2/ebs_test.go
@@ -20,8 +20,11 @@ import (
 
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs/config"
+	//	"github.com/juju/juju/environs/imagemetadata"
 	"github.com/juju/juju/environs/jujutest"
+	//	sstesting "github.com/juju/juju/environs/simplestreams/testing"
 	"github.com/juju/juju/environs/tags"
+	//	envtools "github.com/juju/juju/environs/tools"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/provider/ec2"
 	"github.com/juju/juju/storage"
@@ -56,6 +59,7 @@ var _ = gc.Suite(&ebsVolumeSuite{})
 type ebsVolumeSuite struct {
 	testing.BaseSuite
 	jujutest.Tests
+	//	sstesting.TestDataSuite
 	srv                localServer
 	restoreEC2Patching func()
 
@@ -69,9 +73,13 @@ func (s *ebsVolumeSuite) SetUpSuite(c *gc.C) {
 	s.TestConfig = localConfigAttrs
 	s.restoreEC2Patching = patchEC2ForTesting()
 	s.BaseSuite.SetUpSuite(c)
+	//	s.TestDataSuite.SetUpSuite(c)
+	//	s.PatchValue(&imagemetadata.SimplestreamsImagesPublicKey, sstesting.SignedMetadataPublicKey)
+	//	s.PatchValue(&envtools.SimplestreamsToolsPublicKey, sstesting.SignedMetadataPublicKey)
 }
 
 func (s *ebsVolumeSuite) TearDownSuite(c *gc.C) {
+	//	s.TestDataSuite.TearDownSuite(c)
 	s.BaseSuite.TearDownSuite(c)
 	s.restoreEC2Patching()
 }

--- a/provider/ec2/ebs_test.go
+++ b/provider/ec2/ebs_test.go
@@ -20,11 +20,8 @@ import (
 
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs/config"
-	//	"github.com/juju/juju/environs/imagemetadata"
 	"github.com/juju/juju/environs/jujutest"
-	//	sstesting "github.com/juju/juju/environs/simplestreams/testing"
 	"github.com/juju/juju/environs/tags"
-	//	envtools "github.com/juju/juju/environs/tools"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/provider/ec2"
 	"github.com/juju/juju/storage"

--- a/provider/ec2/ebs_test.go
+++ b/provider/ec2/ebs_test.go
@@ -66,13 +66,13 @@ type ebsVolumeSuite struct {
 }
 
 func (s *ebsVolumeSuite) SetUpSuite(c *gc.C) {
+	s.BaseSuite.SetUpSuite(c)
+	s.Tests.SetUpSuite(c)
 	// Upload arches that ec2 supports; add to this
 	// as ec2 coverage expands.
 	s.UploadArches = []string{arch.AMD64, arch.I386}
 	s.TestConfig = localConfigAttrs
-	s.restoreEC2Patching = patchEC2ForTesting()
-	s.BaseSuite.SetUpSuite(c)
-	s.Tests.SetUpSuite(c)
+	s.restoreEC2Patching = patchEC2ForTesting(c)
 }
 
 func (s *ebsVolumeSuite) TearDownSuite(c *gc.C) {

--- a/provider/ec2/image.go
+++ b/provider/ec2/image.go
@@ -11,10 +11,6 @@ import (
 	"github.com/juju/juju/environs/simplestreams"
 )
 
-// signedImageDataOnly is defined here to allow tests to override the content.
-// If true, only inline PGP signed image metadata will be used.
-var signedImageDataOnly = true
-
 // defaultCpuPower is larger the smallest instance's cpuPower, and no larger than
 // any other instance type's cpuPower. It is used when no explicit CpuPower
 // constraint exists, preventing the smallest instance from being chosen unless
@@ -60,7 +56,7 @@ func findInstanceSpec(
 		Arches:    ic.Arches,
 		Stream:    stream,
 	})
-	matchingImages, _, err := imagemetadata.Fetch(sources, imageConstraint, signedImageDataOnly)
+	matchingImages, _, err := imagemetadata.Fetch(sources, imageConstraint)
 	if err != nil {
 		return nil, err
 	}

--- a/provider/ec2/image_test.go
+++ b/provider/ec2/image_test.go
@@ -31,14 +31,14 @@ func (s *specSuite) SetUpSuite(c *gc.C) {
 	s.PatchValue(&imagemetadata.SimplestreamsImagesPublicKey, sstesting.SignedMetadataPublicKey)
 	s.PatchValue(&envtools.SimplestreamsToolsPublicKey, sstesting.SignedMetadataPublicKey)
 
-	UseTestImageData(TestImagesData)
+	UseTestImageData(c, TestImagesData)
 	UseTestInstanceTypeData(TestInstanceTypeCosts)
 	UseTestRegionData(TestRegions)
 }
 
 func (s *specSuite) TearDownSuite(c *gc.C) {
 	UseTestInstanceTypeData(nil)
-	UseTestImageData(nil)
+	UseTestImageData(c, nil)
 	UseTestRegionData(nil)
 	s.TestDataSuite.TearDownSuite(c)
 	s.BaseSuite.TearDownSuite(c)

--- a/provider/ec2/image_test.go
+++ b/provider/ec2/image_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/juju/juju/environs/imagemetadata"
 	"github.com/juju/juju/environs/instances"
 	"github.com/juju/juju/environs/simplestreams"
+	sstesting "github.com/juju/juju/environs/simplestreams/testing"
+	envtools "github.com/juju/juju/environs/tools"
 	"github.com/juju/juju/testing"
 )
 
@@ -19,10 +21,16 @@ var _ = gc.Suite(&specSuite{})
 
 type specSuite struct {
 	testing.BaseSuite
+	sstesting.TestDataSuite
 }
 
 func (s *specSuite) SetUpSuite(c *gc.C) {
 	s.BaseSuite.SetUpSuite(c)
+	s.TestDataSuite.SetUpSuite(c)
+
+	s.PatchValue(&imagemetadata.SimplestreamsImagesPublicKey, sstesting.SignedMetadataPublicKey)
+	s.PatchValue(&envtools.SimplestreamsToolsPublicKey, sstesting.SignedMetadataPublicKey)
+
 	UseTestImageData(TestImagesData)
 	UseTestInstanceTypeData(TestInstanceTypeCosts)
 	UseTestRegionData(TestRegions)
@@ -32,6 +40,7 @@ func (s *specSuite) TearDownSuite(c *gc.C) {
 	UseTestInstanceTypeData(nil)
 	UseTestImageData(nil)
 	UseTestRegionData(nil)
+	s.TestDataSuite.TearDownSuite(c)
 	s.BaseSuite.TearDownSuite(c)
 }
 
@@ -164,7 +173,7 @@ func (s *specSuite) TestFindInstanceSpec(c *gc.C) {
 		}
 		spec, err := findInstanceSpec(
 			[]simplestreams.DataSource{
-				simplestreams.NewURLDataSource("test", "test:", utils.VerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA)},
+				simplestreams.NewURLDataSource("test", "test:", utils.VerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA, false)},
 			"released",
 			&instances.InstanceConstraint{
 				Region:      "test",
@@ -182,7 +191,7 @@ func (s *specSuite) TestFindInstanceSpec(c *gc.C) {
 func (s *specSuite) TestFindInstanceSpecNotSetCpuPowerWhenInstanceTypeSet(c *gc.C) {
 
 	source := []simplestreams.DataSource{
-		simplestreams.NewURLDataSource("test", "test:", utils.VerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA),
+		simplestreams.NewURLDataSource("test", "test:", utils.VerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA, false),
 	}
 	instanceConstraint := &instances.InstanceConstraint{
 		Region:      "test",
@@ -228,7 +237,7 @@ func (s *specSuite) TestFindInstanceSpecErrors(c *gc.C) {
 		c.Logf("test %d", i)
 		_, err := findInstanceSpec(
 			[]simplestreams.DataSource{
-				simplestreams.NewURLDataSource("test", "test:", utils.VerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA)},
+				simplestreams.NewURLDataSource("test", "test:", utils.VerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA, false)},
 			"released",
 			&instances.InstanceConstraint{
 				Region:      "test",

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -83,14 +83,14 @@ type localLiveSuite struct {
 }
 
 func (t *localLiveSuite) SetUpSuite(c *gc.C) {
+	t.LiveTests.SetUpSuite(c)
 	// Upload arches that ec2 supports; add to this
 	// as ec2 coverage expands.
 	t.UploadArches = []string{arch.AMD64, arch.I386}
 	t.TestConfig = localConfigAttrs
-	t.restoreEC2Patching = patchEC2ForTesting()
+	t.restoreEC2Patching = patchEC2ForTesting(c)
 	t.srv.createRootDisks = true
 	t.srv.startServer(c)
-	t.LiveTests.SetUpSuite(c)
 }
 
 func (t *localLiveSuite) TearDownSuite(c *gc.C) {
@@ -175,19 +175,18 @@ func (srv *localServer) stopServer(c *gc.C) {
 type localServerSuite struct {
 	coretesting.BaseSuite
 	jujutest.Tests
-
 	srv                localServer
 	restoreEC2Patching func()
 }
 
 func (t *localServerSuite) SetUpSuite(c *gc.C) {
+	t.BaseSuite.SetUpSuite(c)
+	t.Tests.SetUpSuite(c)
 	// Upload arches that ec2 supports; add to this
 	// as ec2 coverage expands.
 	t.UploadArches = []string{arch.AMD64, arch.I386}
 	t.TestConfig = localConfigAttrs
-	t.restoreEC2Patching = patchEC2ForTesting()
-	t.BaseSuite.SetUpSuite(c)
-	t.Tests.SetUpSuite(c)
+	t.restoreEC2Patching = patchEC2ForTesting(c)
 	t.srv.createRootDisks = true
 }
 
@@ -1220,7 +1219,7 @@ func (t *localNonUSEastSuite) SetUpSuite(c *gc.C) {
 	t.PatchValue(&imagemetadata.SimplestreamsImagesPublicKey, sstesting.SignedMetadataPublicKey)
 	t.PatchValue(&tools.SimplestreamsToolsPublicKey, sstesting.SignedMetadataPublicKey)
 
-	t.restoreEC2Patching = patchEC2ForTesting()
+	t.restoreEC2Patching = patchEC2ForTesting(c)
 }
 
 func (t *localNonUSEastSuite) TearDownSuite(c *gc.C) {
@@ -1248,8 +1247,8 @@ func (t *localNonUSEastSuite) TearDownTest(c *gc.C) {
 	t.BaseSuite.TearDownTest(c)
 }
 
-func patchEC2ForTesting() func() {
-	ec2.UseTestImageData(ec2.TestImagesData)
+func patchEC2ForTesting(c *gc.C) func() {
+	ec2.UseTestImageData(c, ec2.TestImagesData)
 	ec2.UseTestInstanceTypeData(ec2.TestInstanceTypeCosts)
 	ec2.UseTestRegionData(ec2.TestRegions)
 	restoreTimeouts := envtesting.PatchAttemptStrategies(ec2.ShortAttempt, ec2.StorageAttempt)
@@ -1257,7 +1256,7 @@ func patchEC2ForTesting() func() {
 	return func() {
 		restoreFinishBootstrap()
 		restoreTimeouts()
-		ec2.UseTestImageData(nil)
+		ec2.UseTestImageData(c, nil)
 		ec2.UseTestInstanceTypeData(nil)
 		ec2.UseTestRegionData(nil)
 	}

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -187,11 +187,12 @@ func (t *localServerSuite) SetUpSuite(c *gc.C) {
 	t.TestConfig = localConfigAttrs
 	t.restoreEC2Patching = patchEC2ForTesting()
 	t.BaseSuite.SetUpSuite(c)
-
+	t.Tests.SetUpSuite(c)
 	t.srv.createRootDisks = true
 }
 
 func (t *localServerSuite) TearDownSuite(c *gc.C) {
+	t.Tests.TearDownSuite(c)
 	t.BaseSuite.TearDownSuite(c)
 	t.restoreEC2Patching()
 }

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/juju/juju/environs/imagemetadata"
 	"github.com/juju/juju/environs/jujutest"
 	"github.com/juju/juju/environs/simplestreams"
+	sstesting "github.com/juju/juju/environs/simplestreams/testing"
 	envtesting "github.com/juju/juju/environs/testing"
 	"github.com/juju/juju/environs/tools"
 	"github.com/juju/juju/feature"
@@ -174,6 +175,7 @@ func (srv *localServer) stopServer(c *gc.C) {
 type localServerSuite struct {
 	coretesting.BaseSuite
 	jujutest.Tests
+
 	srv                localServer
 	restoreEC2Patching func()
 }
@@ -185,6 +187,7 @@ func (t *localServerSuite) SetUpSuite(c *gc.C) {
 	t.TestConfig = localConfigAttrs
 	t.restoreEC2Patching = patchEC2ForTesting()
 	t.BaseSuite.SetUpSuite(c)
+
 	t.srv.createRootDisks = true
 }
 
@@ -1202,6 +1205,8 @@ func (t *localServerSuite) TestRootDiskTags(c *gc.C) {
 // behaves as if it is not in the us-east region.
 type localNonUSEastSuite struct {
 	coretesting.BaseSuite
+	sstesting.TestDataSuite
+
 	restoreEC2Patching func()
 	srv                localServer
 	env                environs.Environ
@@ -1209,11 +1214,17 @@ type localNonUSEastSuite struct {
 
 func (t *localNonUSEastSuite) SetUpSuite(c *gc.C) {
 	t.BaseSuite.SetUpSuite(c)
+	t.TestDataSuite.SetUpSuite(c)
+
+	t.PatchValue(&imagemetadata.SimplestreamsImagesPublicKey, sstesting.SignedMetadataPublicKey)
+	t.PatchValue(&tools.SimplestreamsToolsPublicKey, sstesting.SignedMetadataPublicKey)
+
 	t.restoreEC2Patching = patchEC2ForTesting()
 }
 
 func (t *localNonUSEastSuite) TearDownSuite(c *gc.C) {
 	t.restoreEC2Patching()
+	t.TestDataSuite.TearDownSuite(c)
 	t.BaseSuite.TearDownSuite(c)
 }
 

--- a/provider/gce/environ_broker.go
+++ b/provider/gce/environ_broker.go
@@ -147,8 +147,7 @@ func (env *environ) findInstanceSpec(stream string, ic *instances.InstanceConstr
 		Stream:    stream,
 	})
 
-	signedImageDataOnly := false
-	matchingImages, _, err := imageMetadataFetch(sources, imageConstraint, signedImageDataOnly)
+	matchingImages, _, err := imageMetadataFetch(sources, imageConstraint)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/provider/gce/testing_test.go
+++ b/provider/gce/testing_test.go
@@ -422,7 +422,7 @@ type fakeImages struct {
 	ResolveInfo *simplestreams.ResolveInfo
 }
 
-func (fi *fakeImages) ImageMetadataFetch(sources []simplestreams.DataSource, cons *imagemetadata.ImageConstraint, onlySigned bool) ([]*imagemetadata.ImageMetadata, *simplestreams.ResolveInfo, error) {
+func (fi *fakeImages) ImageMetadataFetch(sources []simplestreams.DataSource, cons *imagemetadata.ImageConstraint) ([]*imagemetadata.ImageMetadata, *simplestreams.ResolveInfo, error) {
 	return fi.Metadata, fi.ResolveInfo, fi.err()
 }
 

--- a/provider/joyent/environ_instance.go
+++ b/provider/joyent/environ_instance.go
@@ -32,7 +32,6 @@ import (
 var (
 	vTypeSmartmachine   = "smartmachine"
 	vTypeVirtualmachine = "kvm"
-	signedImageDataOnly = false
 	defaultCpuCores     = uint64(1)
 )
 
@@ -365,7 +364,7 @@ func (env *joyentEnviron) FindInstanceSpec(ic *instances.InstanceConstraint) (*i
 		return nil, err
 	}
 
-	matchingImages, _, err := imagemetadata.Fetch(sources, imageConstraint, signedImageDataOnly)
+	matchingImages, _, err := imagemetadata.Fetch(sources, imageConstraint)
 	if err != nil {
 		return nil, err
 	}

--- a/provider/joyent/local_test.go
+++ b/provider/joyent/local_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/juju/juju/environs/imagemetadata"
 	"github.com/juju/juju/environs/jujutest"
 	"github.com/juju/juju/environs/simplestreams"
+	sstesting "github.com/juju/juju/environs/simplestreams/testing"
 	"github.com/juju/juju/environs/storage"
 	envtesting "github.com/juju/juju/environs/testing"
 	"github.com/juju/juju/environs/tools"
@@ -123,7 +124,7 @@ func (s *localLiveSuite) SetUpTest(c *gc.C) {
 	s.PatchValue(&version.Current, coretesting.FakeVersionNumber)
 	s.providerSuite.SetUpTest(c)
 	creds := joyent.MakeCredentials(c, s.TestConfig)
-	joyent.UseExternalTestImageMetadata(creds)
+	joyent.UseExternalTestImageMetadata(c, creds)
 	restoreFinishBootstrap := envtesting.DisableFinishBootstrap()
 	s.AddCleanup(func(*gc.C) { restoreFinishBootstrap() })
 	s.LiveTests.SetUpTest(c)
@@ -146,6 +147,9 @@ type localServerSuite struct {
 }
 
 func (s *localServerSuite) SetUpSuite(c *gc.C) {
+	s.PatchValue(&imagemetadata.SimplestreamsImagesPublicKey, sstesting.SignedMetadataPublicKey)
+	s.PatchValue(&tools.SimplestreamsToolsPublicKey, sstesting.SignedMetadataPublicKey)
+
 	s.providerSuite.SetUpSuite(c)
 	restoreFinishBootstrap := envtesting.DisableFinishBootstrap()
 	s.AddSuiteCleanup(func(*gc.C) { restoreFinishBootstrap() })
@@ -165,7 +169,7 @@ func (s *localServerSuite) SetUpTest(c *gc.C) {
 	s.TestConfig = GetFakeConfig(s.cSrv.Server.URL, s.mSrv.Server.URL)
 	// Put some fake image metadata in place.
 	creds := joyent.MakeCredentials(c, s.TestConfig)
-	joyent.UseExternalTestImageMetadata(creds)
+	joyent.UseExternalTestImageMetadata(c, creds)
 }
 
 func (s *localServerSuite) TearDownTest(c *gc.C) {

--- a/provider/openstack/export_test.go
+++ b/provider/openstack/export_test.go
@@ -20,20 +20,12 @@ import (
 	"github.com/juju/juju/environs/instances"
 	"github.com/juju/juju/environs/simplestreams"
 	envstorage "github.com/juju/juju/environs/storage"
+	envtesting "github.com/juju/juju/environs/testing"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/storage"
 	"github.com/juju/juju/testing"
 )
-
-// This provides the content for code accessing test:///... URLs. This allows
-// us to set the responses for things like the Metadata server, by pointing
-// metadata requests at test:///... rather than http://169.254.169.254
-var testRoundTripper = &testing.ProxyRoundTripper{}
-
-func init() {
-	testRoundTripper.RegisterForScheme("test")
-}
 
 var (
 	ShortAttempt   = &shortAttempt
@@ -268,11 +260,12 @@ func UseTestImageData(stor envstorage.Storage, cred *identity.Credentials) {
 	stor.Put(simplestreams.UnsignedIndex("v1", 1), bytes.NewReader(data), int64(len(data)))
 	stor.Put(
 		productMetadatafile, strings.NewReader(imagesData), int64(len(imagesData)))
+
+	envtesting.SignTestTools(stor)
 }
 
 func RemoveTestImageData(stor envstorage.Storage) {
-	stor.Remove(simplestreams.UnsignedIndex("v1", 1))
-	stor.Remove(productMetadatafile)
+	stor.RemoveAll()
 }
 
 // DiscardSecurityGroup cleans up a security group, it is not an error to

--- a/provider/openstack/image.go
+++ b/provider/openstack/image.go
@@ -43,8 +43,7 @@ func findInstanceSpec(e *environ, ic *instances.InstanceConstraint) (*instances.
 	if err != nil {
 		return nil, err
 	}
-	// TODO (wallyworld): use an env parameter (default true) to mandate use of only signed image metadata.
-	matchingImages, _, err := imagemetadata.Fetch(sources, imageConstraint, false)
+	matchingImages, _, err := imagemetadata.Fetch(sources, imageConstraint)
 	if err != nil {
 		return nil, err
 	}

--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -40,9 +40,11 @@ import (
 	"github.com/juju/juju/environs/imagemetadata"
 	"github.com/juju/juju/environs/jujutest"
 	"github.com/juju/juju/environs/simplestreams"
+	sstesting "github.com/juju/juju/environs/simplestreams/testing"
 	"github.com/juju/juju/environs/storage"
 	envtesting "github.com/juju/juju/environs/testing"
 	"github.com/juju/juju/environs/tools"
+	envtools "github.com/juju/juju/environs/tools"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/network"
@@ -1749,6 +1751,9 @@ func (s *noSwiftSuite) SetUpSuite(c *gc.C) {
 	s.BaseSuite.SetUpSuite(c)
 	restoreFinishBootstrap := envtesting.DisableFinishBootstrap()
 	s.AddSuiteCleanup(func(*gc.C) { restoreFinishBootstrap() })
+
+	s.PatchValue(&imagemetadata.SimplestreamsImagesPublicKey, sstesting.SignedMetadataPublicKey)
+	s.PatchValue(&envtools.SimplestreamsToolsPublicKey, sstesting.SignedMetadataPublicKey)
 }
 
 func (s *noSwiftSuite) SetUpTest(c *gc.C) {

--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -1022,7 +1022,7 @@ func (s *localServerSuite) TestValidateImageMetadata(c *gc.C) {
 
 func (s *localServerSuite) TestImageMetadataSourceOrder(c *gc.C) {
 	src := func(env environs.Environ) (simplestreams.DataSource, error) {
-		return simplestreams.NewURLDataSource("my datasource", "bar", false, simplestreams.CUSTOM_CLOUD_DATA), nil
+		return simplestreams.NewURLDataSource("my datasource", "bar", false, simplestreams.CUSTOM_CLOUD_DATA, false), nil
 	}
 	environs.RegisterUserImageDataSourceFunc("my func", src)
 	env := s.Open(c)

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -862,7 +862,7 @@ func (e *environ) getKeystoneDataSource(mu *sync.Mutex, datasource *simplestream
 	if !e.Config().SSLHostnameVerification() {
 		verify = utils.NoVerifySSLHostnames
 	}
-	*datasource = simplestreams.NewURLDataSource("keystone catalog", url, verify, simplestreams.SPECIFIC_CLOUD_DATA)
+	*datasource = simplestreams.NewURLDataSource("keystone catalog", url, verify, simplestreams.SPECIFIC_CLOUD_DATA, false)
 	return *datasource, nil
 }
 

--- a/provider/vsphere/image_metadata.go
+++ b/provider/vsphere/image_metadata.go
@@ -61,7 +61,6 @@ func findImageMetadata(env *environ, args environs.StartInstanceParams) (*OvaFil
 func imageMetadataFetch(sources []simplestreams.DataSource, cons *imagemetadata.ImageConstraint) ([]*OvaFileMetadata, error) {
 	params := simplestreams.GetMetadataParams{
 		StreamsVersion:   imagemetadata.StreamsVersionV1,
-		OnlySigned:       false,
 		LookupConstraint: cons,
 		ValueParams: simplestreams.ValueParams{
 			DataType:      "image-downloads",

--- a/upgrades/toolstorage.go
+++ b/upgrades/toolstorage.go
@@ -58,7 +58,7 @@ func migrateToolsStorage(st *state.State, agentConfig agent.Config) error {
 	}
 
 	// Search provider storage for tools.
-	datasource := storage.NewStorageSimpleStreamsDataSource("provider storage", stor, storage.BaseToolsPath, simplestreams.SPECIFIC_CLOUD_DATA)
+	datasource := storage.NewStorageSimpleStreamsDataSource("provider storage", stor, storage.BaseToolsPath, simplestreams.SPECIFIC_CLOUD_DATA, false)
 	toolsList, err := envtools.FindToolsForCloud(
 		[]simplestreams.DataSource{datasource},
 		simplestreams.CloudSpec{},


### PR DESCRIPTION
This proposal ensures that data sources contain information whether they require signed data.

All public metadata is now signed; tests modified accordingly.
Searches are modified to not specify require signed but to rely on data source property.

All tests that use round tripper are changed to use common refactored functionality. 

(Review request: http://reviews.vapour.ws/r/3426/)