### PR TITLE
ec2: use StartInstanceParams.ImageMetadata

### DIFF
--- a/environs/bootstrap.go
+++ b/environs/bootstrap.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/juju/juju/cloudconfig/instancecfg"
 	"github.com/juju/juju/constraints"
+	"github.com/juju/juju/environs/imagemetadata"
 	"github.com/juju/juju/tools"
 )
 
@@ -30,6 +31,11 @@ type BootstrapParams struct {
 	// network bridge device to use for LXC and KVM containers. See
 	// also instancecfg.DefaultBridgeName.
 	ContainerBridgeName string
+
+	// ImageMetadata contains simplestreams image metadata for providers
+	// that rely on it for selecting images. This will be empty for
+	// providers that do not implements simplestreams.HasRegion.
+	ImageMetadata []*imagemetadata.ImageMetadata
 }
 
 // BootstrapFinalizer is a function returned from Environ.Bootstrap.

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -133,10 +133,7 @@ func Bootstrap(ctx environs.BootstrapContext, environ environs.Environ, args Boo
 			Arches:    availableTools.Arches(),
 			Stream:    environ.Config().ImageStream(),
 		})
-		const onlySigned = false // TODO(axw)
-		publicImageMetadata, _, err = imagemetadata.Fetch(
-			sources, imageConstraint, onlySigned,
-		)
+		publicImageMetadata, _, err = imagemetadata.Fetch(sources, imageConstraint)
 		if err != nil {
 			return errors.Annotate(err, "searching image metadata")
 		}

--- a/environs/instances/image.go
+++ b/environs/instances/image.go
@@ -24,13 +24,14 @@ type InstanceConstraint struct {
 	Arches      []string
 	Constraints constraints.Value
 
-	// Optional filtering criteria not supported by all providers. These attributes are not specified
-	// by the user as a constraint but rather passed in by the provider implementation to restrict the
-	// choice of available images.
+	// Optional filtering criteria not supported by all providers. These
+	// attributes are not specified by the user as a constraint but rather
+	// passed in by the provider implementation to restrict the choice of
+	// available images.
 
 	// Storage specifies a list of storage types, in order of preference.
-	// eg ["ssd", "ebs"] means find images with ssd storage, but if none exist,
-	// find those with ebs instead.
+	// eg ["ssd", "ebs"] means find images with ssd storage, but if none
+	// exist, find those with ebs instead.
 	Storage []string
 }
 

--- a/environs/jujutest/livetests.go
+++ b/environs/jujutest/livetests.go
@@ -741,11 +741,21 @@ func (t *LiveTests) TestStartInstanceWithEmptyNonceFails(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	t.PrepareOnce(c)
-	possibleTools := envtesting.AssertUploadFakeToolsVersions(c, t.toolsStorage, "released", "released", version.MustParseBinary("5.4.5-trusty-amd64"))
-	result, err := t.Env.StartInstance(environs.StartInstanceParams{
+	possibleTools := coretools.List(envtesting.AssertUploadFakeToolsVersions(
+		c, t.toolsStorage, "released", "released", version.MustParseBinary("5.4.5-trusty-amd64"),
+	))
+	params := environs.StartInstanceParams{
 		Tools:          possibleTools,
 		InstanceConfig: instanceConfig,
-	})
+	}
+	err = jujutesting.SetImageMetadata(
+		t.Env,
+		possibleTools.AllSeries(),
+		possibleTools.Arches(),
+		&params.ImageMetadata,
+	)
+	c.Check(err, jc.ErrorIsNil)
+	result, err := t.Env.StartInstance(params)
 	if result != nil && result.Instance != nil {
 		err := t.Env.StopInstances(result.Instance.Id())
 		c.Check(err, jc.ErrorIsNil)

--- a/juju/testing/instance.go
+++ b/juju/testing/instance.go
@@ -227,8 +227,7 @@ func SetImageMetadata(env environs.Environ, series, arches []string, out *[]*ima
 		Arches:    arches,
 		Stream:    env.Config().ImageStream(),
 	})
-	const onlySigned = false // TODO(axw)
-	imageMetadata, _, err := imagemetadata.Fetch(sources, imageConstraint, onlySigned)
+	imageMetadata, _, err := imagemetadata.Fetch(sources, imageConstraint)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/provider/azure/internal/legacy/azure/environ.go
+++ b/provider/azure/internal/legacy/azure/environ.go
@@ -1410,7 +1410,7 @@ func (env *azureEnviron) Region() (simplestreams.CloudSpec, error) {
 	ecfg := env.getSnapshot().ecfg
 	return simplestreams.CloudSpec{
 		Region:   ecfg.location(),
-		Endpoint: string(gwacl.GetEndpoint(ecfg.location())),
+		Endpoint: getEndpoint(ecfg.location()),
 	}, nil
 }
 

--- a/provider/common/bootstrap.go
+++ b/provider/common/bootstrap.go
@@ -107,6 +107,7 @@ func BootstrapInstance(ctx environs.BootstrapContext, env environs.Environ, args
 		Tools:          availableTools,
 		InstanceConfig: instanceConfig,
 		Placement:      args.Placement,
+		ImageMetadata:  args.ImageMetadata,
 	})
 	if err != nil {
 		return nil, "", nil, errors.Annotate(err, "cannot start bootstrap instance")

--- a/provider/common/bootstrap.go
+++ b/provider/common/bootstrap.go
@@ -16,6 +16,7 @@ import (
 	"github.com/juju/loggo"
 	"github.com/juju/utils"
 	"github.com/juju/utils/parallel"
+	"github.com/juju/utils/series"
 	"github.com/juju/utils/shell"
 	"github.com/juju/utils/ssh"
 
@@ -26,6 +27,7 @@ import (
 	"github.com/juju/juju/cloudconfig/sshinit"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/environs/imagemetadata"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/network"
 	coretools "github.com/juju/juju/tools"
@@ -59,16 +61,31 @@ func Bootstrap(ctx environs.BootstrapContext, env environs.Environ, args environ
 // This method is called by Bootstrap above, which implements environs.Bootstrap, but
 // is also exported so that providers can manipulate the started instance.
 func BootstrapInstance(ctx environs.BootstrapContext, env environs.Environ, args environs.BootstrapParams,
-) (_ *environs.StartInstanceResult, series string, _ environs.BootstrapFinalizer, err error) {
+) (_ *environs.StartInstanceResult, selectedSeries string, _ environs.BootstrapFinalizer, err error) {
 	// TODO make safe in the case of racing Bootstraps
 	// If two Bootstraps are called concurrently, there's
 	// no way to make sure that only one succeeds.
 
 	// First thing, ensure we have tools otherwise there's no point.
-	series = config.PreferredSeries(env.Config())
-	availableTools, err := args.AvailableTools.Match(coretools.Filter{Series: series})
+	selectedSeries = config.PreferredSeries(env.Config())
+	availableTools, err := args.AvailableTools.Match(coretools.Filter{
+		Series: selectedSeries,
+	})
 	if err != nil {
 		return nil, "", nil, err
+	}
+
+	// Filter image metadata to the selected series.
+	var imageMetadata []*imagemetadata.ImageMetadata
+	seriesVersion, err := series.SeriesVersion(selectedSeries)
+	if err != nil {
+		return nil, "", nil, errors.Trace(err)
+	}
+	for _, m := range args.ImageMetadata {
+		if m.Version != seriesVersion {
+			continue
+		}
+		imageMetadata = append(imageMetadata, m)
 	}
 
 	// Get the bootstrap SSH client. Do this early, so we know
@@ -80,7 +97,9 @@ func BootstrapInstance(ctx environs.BootstrapContext, env environs.Environ, args
 		return nil, "", nil, fmt.Errorf("no SSH client available")
 	}
 
-	instanceConfig, err := instancecfg.NewBootstrapInstanceConfig(args.Constraints, series)
+	instanceConfig, err := instancecfg.NewBootstrapInstanceConfig(
+		args.Constraints, selectedSeries,
+	)
 	if err != nil {
 		return nil, "", nil, err
 	}
@@ -107,7 +126,7 @@ func BootstrapInstance(ctx environs.BootstrapContext, env environs.Environ, args
 		Tools:          availableTools,
 		InstanceConfig: instanceConfig,
 		Placement:      args.Placement,
-		ImageMetadata:  args.ImageMetadata,
+		ImageMetadata:  imageMetadata,
 	})
 	if err != nil {
 		return nil, "", nil, errors.Annotate(err, "cannot start bootstrap instance")
@@ -131,7 +150,7 @@ func BootstrapInstance(ctx environs.BootstrapContext, env environs.Environ, args
 		maybeSetBridge(icfg)
 		return FinishBootstrap(ctx, client, env, result.Instance, icfg)
 	}
-	return result, series, finalize, nil
+	return result, selectedSeries, finalize, nil
 }
 
 // FinishBootstrap completes the bootstrap process by connecting

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -495,12 +495,8 @@ func (e *environ) StartInstance(args environs.StartInstanceParams) (_ *environs.
 		return nil, errors.New("starting instances with networks is not supported yet")
 	}
 	arches := args.Tools.Arches()
-	sources, err := environs.ImageMetadataSources(e)
-	if err != nil {
-		return nil, err
-	}
 
-	spec, err := findInstanceSpec(sources, e.Config().ImageStream(), &instances.InstanceConstraint{
+	spec, err := findInstanceSpec(args.ImageMetadata, &instances.InstanceConstraint{
 		Region:      e.ecfg().region(),
 		Series:      args.InstanceConfig.Series,
 		Arches:      arches,

--- a/provider/ec2/export_test.go
+++ b/provider/ec2/export_test.go
@@ -141,6 +141,38 @@ func (s *ec2storage) ResetMadeBucket() {
 	s.madeBucket = false
 }
 
+func makeImage(id, storage, virtType, arch, version, region string) *imagemetadata.ImageMetadata {
+	return &imagemetadata.ImageMetadata{
+		Id:         id,
+		Storage:    storage,
+		VirtType:   virtType,
+		Arch:       arch,
+		Version:    version,
+		RegionName: region,
+		Endpoint:   "https://ec2.endpoint.com",
+		Stream:     "released",
+	}
+}
+
+var TestImageMetadata = []*imagemetadata.ImageMetadata{
+	// 14.04:amd64
+	makeImage("ami-00000033", "ssd", "pv", "amd64", "14.04", "test"),
+	makeImage("ami-00000039", "ebs", "pv", "amd64", "14.04", "test"),
+	makeImage("ami-00000035", "ssd", "hvm", "amd64", "14.04", "test"),
+
+	// 14.04:i386
+	makeImage("ami-00000034", "ssd", "pv", "i386", "14.04", "test"),
+
+	// 12.10:amd64
+	makeImage("ami-01000035", "ssd", "hvm", "amd64", "12.10", "test"),
+
+	// 12.10:i386
+	makeImage("ami-01000034", "ssd", "pv", "i386", "12.10", "test"),
+
+	// 13.04:i386
+	makeImage("ami-02000034", "ssd", "pv", "i386", "13.04", "test"),
+}
+
 var TestImagesData = map[string]string{
 	"/streams/v1/index.json": `
         {


### PR DESCRIPTION
Use the provisioner-provided ImageMetadata in the
ec2 provider, rather than fetching image metadata
in the provider itself.

Some additional changes were required in bootstrap
(fetch image metadata at bootstrap time, propagate
through BootstrapParams), and to testing code.

(Review request: http://reviews.vapour.ws/r/3427/)