### PR TITLE
Run the reboot worker under the dependency engine

### DIFF
--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -96,7 +96,6 @@ import (
 	"github.com/juju/juju/worker/peergrouper"
 	"github.com/juju/juju/worker/provisioner"
 	"github.com/juju/juju/worker/proxyupdater"
-	rebootworker "github.com/juju/juju/worker/reboot"
 	"github.com/juju/juju/worker/resumer"
 	"github.com/juju/juju/worker/rsyslog"
 	"github.com/juju/juju/worker/singular"
@@ -748,21 +747,6 @@ func (a *MachineAgent) startAPIWorkers(apiConn api.Connection) (_ worker.Worker,
 			return nil, errors.Annotate(err, "cannot start machiner worker")
 		}
 		return w, err
-	})
-	runner.StartWorker("reboot", func() (worker.Worker, error) {
-		reboot, err := apiConn.Reboot()
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		lock, err := cmdutil.HookExecutionLock(cmdutil.DataDir)
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		w, err := rebootworker.NewReboot(reboot, agentConfig, lock)
-		if err != nil {
-			return nil, errors.Annotate(err, "cannot start reboot worker")
-		}
-		return w, nil
 	})
 	runner.StartWorker("apiaddressupdater", func() (worker.Worker, error) {
 		addressUpdater := agent.APIHostPortsSetter{a}

--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/juju/worker/apicaller"
 	"github.com/juju/juju/worker/dependency"
 	"github.com/juju/juju/worker/gate"
+	"github.com/juju/juju/worker/reboot"
 	"github.com/juju/juju/worker/terminationworker"
 	"github.com/juju/juju/worker/upgrader"
 	"github.com/juju/juju/worker/upgradesteps"
@@ -151,6 +152,15 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 			UpgradeWaiterName: upgradeWaiterName,
 			StartAPIWorkers:   config.StartAPIWorkers,
 		}),
+
+		// The reboot manifold manages a worker which will reboot the
+		// machine when requested. It needs an API connection and
+		// waits for upgrades to be complete.
+		rebootName: reboot.Manifold(reboot.ManifoldConfig{
+			AgentName:         agentName,
+			APICallerName:     apiCallerName,
+			UpgradeWaiterName: upgradeWaiterName,
+		}),
 	}
 }
 
@@ -167,4 +177,5 @@ const (
 	uninstallerName       = "uninstaller"
 	servingInfoSetterName = "serving-info-setter"
 	apiWorkersName        = "apiworkers"
+	rebootName            = "reboot"
 )

--- a/cmd/jujud/agent/machine/manifolds_test.go
+++ b/cmd/jujud/agent/machine/manifolds_test.go
@@ -49,6 +49,7 @@ func (s *ManifoldsSuite) TestManifoldNames(c *gc.C) {
 		"uninstaller",
 		"serving-info-setter",
 		"apiworkers",
+		"reboot",
 	}
 	c.Assert(keys, jc.SameContents, expectedKeys)
 }

--- a/worker/reboot/manifold.go
+++ b/worker/reboot/manifold.go
@@ -1,0 +1,49 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package reboot
+
+import (
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/agent"
+	"github.com/juju/juju/api"
+	"github.com/juju/juju/api/base"
+	cmdutil "github.com/juju/juju/cmd/jujud/util"
+	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/dependency"
+	"github.com/juju/juju/worker/util"
+)
+
+// ManifoldConfig defines the names of the manifolds on which a Manifold will depend.
+type ManifoldConfig util.PostUpgradeManifoldConfig
+
+// Manifold returns a dependency manifold that runs a reboot worker,
+// using the resource names defined in the supplied config.
+func Manifold(config ManifoldConfig) dependency.Manifold {
+	return util.PostUpgradeManifold(util.PostUpgradeManifoldConfig(config), newWorker)
+}
+
+// newWorker trivially wraps NewReboot for use in a util.PostUpgradeManifold.
+//
+// TODO(mjs) - It's not tested at the moment, because the scaffolding
+// necessary is too unwieldy/distracting to introduce at this point.
+func newWorker(a agent.Agent, apiCaller base.APICaller) (worker.Worker, error) {
+	apiConn, ok := apiCaller.(api.Connection)
+	if !ok {
+		return nil, errors.New("unable to obtain api.Connection")
+	}
+	rebootState, err := apiConn.Reboot()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	lock, err := cmdutil.HookExecutionLock(cmdutil.DataDir)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	w, err := NewReboot(rebootState, a.CurrentConfig(), lock)
+	if err != nil {
+		return nil, errors.Annotate(err, "cannot start reboot worker")
+	}
+	return w, nil
+}

--- a/worker/util/postupgrade.go
+++ b/worker/util/postupgrade.go
@@ -1,0 +1,53 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package util
+
+import (
+	"github.com/juju/juju/agent"
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/dependency"
+)
+
+// Many machine agent manifolds depend on just the agent, an API
+// connection and upgrades being complete; this type configures them.
+type PostUpgradeManifoldConfig struct {
+	AgentName         string
+	APICallerName     string
+	UpgradeWaiterName string
+}
+
+// AgentApiUpgradesStartFunc encapsulates the behaviour that varies among PostUpgradeManifolds.
+type PostUpgradeStartFunc func(agent.Agent, base.APICaller) (worker.Worker, error)
+
+// PostUpgradeManifold returns a dependency.Manifold that calls the
+// supplied start func with API and agent resources once machine agent
+// upgrades have completed (and all required resources are present).
+func PostUpgradeManifold(config PostUpgradeManifoldConfig, start PostUpgradeStartFunc) dependency.Manifold {
+	return dependency.Manifold{
+		Inputs: []string{
+			config.AgentName,
+			config.APICallerName,
+			config.UpgradeWaiterName,
+		},
+		Start: func(getResource dependency.GetResourceFunc) (worker.Worker, error) {
+			var upgradesDone bool
+			if err := getResource(config.UpgradeWaiterName, &upgradesDone); err != nil {
+				return nil, err
+			}
+			if !upgradesDone {
+				return nil, dependency.ErrMissing
+			}
+			var agent agent.Agent
+			if err := getResource(config.AgentName, &agent); err != nil {
+				return nil, err
+			}
+			var apiCaller base.APICaller
+			if err := getResource(config.APICallerName, &apiCaller); err != nil {
+				return nil, err
+			}
+			return start(agent, apiCaller)
+		},
+	}
+}

--- a/worker/util/postupgrade_test.go
+++ b/worker/util/postupgrade_test.go
@@ -1,0 +1,137 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package util_test
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/agent"
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/dependency"
+	dt "github.com/juju/juju/worker/dependency/testing"
+	"github.com/juju/juju/worker/util"
+)
+
+type PostUpgradeManifoldSuite struct {
+	testing.IsolationSuite
+	testing.Stub
+	manifold dependency.Manifold
+	worker   worker.Worker
+}
+
+var _ = gc.Suite(&PostUpgradeManifoldSuite{})
+
+func (s *PostUpgradeManifoldSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+	s.Stub = testing.Stub{}
+	s.worker = &dummyWorker{}
+	s.manifold = util.PostUpgradeManifold(util.PostUpgradeManifoldConfig{
+		AgentName:         "agent-name",
+		APICallerName:     "api-caller-name",
+		UpgradeWaiterName: "upgradewaiter-name",
+	}, s.newWorker)
+}
+
+func (s *PostUpgradeManifoldSuite) newWorker(a agent.Agent, apiCaller base.APICaller) (worker.Worker, error) {
+	s.AddCall("newWorker", a, apiCaller)
+	if err := s.NextErr(); err != nil {
+		return nil, err
+	}
+	return s.worker, nil
+}
+
+func (s *PostUpgradeManifoldSuite) TestInputs(c *gc.C) {
+	c.Check(s.manifold.Inputs, jc.DeepEquals, []string{
+		"agent-name", "api-caller-name", "upgradewaiter-name"})
+}
+
+func (s *PostUpgradeManifoldSuite) TestOutput(c *gc.C) {
+	c.Check(s.manifold.Output, gc.IsNil)
+}
+
+func (s *PostUpgradeManifoldSuite) TestUpgradeWaiterMissing(c *gc.C) {
+	getResource := dt.StubGetResource(dt.StubResources{
+		"upgradewaiter-name": dt.StubResource{Error: dependency.ErrMissing},
+	})
+
+	worker, err := s.manifold.Start(getResource)
+	c.Check(worker, gc.IsNil)
+	c.Check(err, gc.Equals, dependency.ErrMissing)
+}
+
+func (s *PostUpgradeManifoldSuite) TestUpgradesNotComplete(c *gc.C) {
+	getResource := dt.StubGetResource(dt.StubResources{
+		"upgradewaiter-name": dt.StubResource{Output: false},
+		"agent-name":         dt.StubResource{Output: new(dummyAgent)},
+		"api-caller-name":    dt.StubResource{Output: new(dummyApiCaller)},
+	})
+
+	worker, err := s.manifold.Start(getResource)
+	c.Check(worker, gc.IsNil)
+	c.Check(err, gc.Equals, dependency.ErrMissing)
+}
+
+func (s *PostUpgradeManifoldSuite) TestStartAgentMissing(c *gc.C) {
+	getResource := dt.StubGetResource(dt.StubResources{
+		"upgradewaiter-name": dt.StubResource{Output: true},
+		"agent-name":         dt.StubResource{Error: dependency.ErrMissing},
+	})
+
+	worker, err := s.manifold.Start(getResource)
+	c.Check(worker, gc.IsNil)
+	c.Check(err, gc.Equals, dependency.ErrMissing)
+}
+
+func (s *PostUpgradeManifoldSuite) TestStartApiConnMissing(c *gc.C) {
+	getResource := dt.StubGetResource(dt.StubResources{
+		"upgradewaiter-name": dt.StubResource{Output: true},
+		"agent-name":         dt.StubResource{Output: &dummyAgent{}},
+		"api-caller-name":    dt.StubResource{Error: dependency.ErrMissing},
+	})
+
+	worker, err := s.manifold.Start(getResource)
+	c.Check(worker, gc.IsNil)
+	c.Check(err, gc.Equals, dependency.ErrMissing)
+}
+
+func (s *PostUpgradeManifoldSuite) TestStartFailure(c *gc.C) {
+	expectAgent := &dummyAgent{}
+	expectApiCaller := &dummyApiCaller{}
+	getResource := dt.StubGetResource(dt.StubResources{
+		"upgradewaiter-name": dt.StubResource{Output: true},
+		"agent-name":         dt.StubResource{Output: expectAgent},
+		"api-caller-name":    dt.StubResource{Output: expectApiCaller},
+	})
+	s.SetErrors(errors.New("some error"))
+
+	worker, err := s.manifold.Start(getResource)
+	c.Check(worker, gc.IsNil)
+	c.Check(err, gc.ErrorMatches, "some error")
+	s.CheckCalls(c, []testing.StubCall{{
+		FuncName: "newWorker",
+		Args:     []interface{}{expectAgent, expectApiCaller},
+	}})
+}
+
+func (s *PostUpgradeManifoldSuite) TestStartSuccess(c *gc.C) {
+	expectAgent := &dummyAgent{}
+	expectApiCaller := &dummyApiCaller{}
+	getResource := dt.StubGetResource(dt.StubResources{
+		"upgradewaiter-name": dt.StubResource{Output: true},
+		"agent-name":         dt.StubResource{Output: expectAgent},
+		"api-caller-name":    dt.StubResource{Output: expectApiCaller},
+	})
+
+	worker, err := s.manifold.Start(getResource)
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(worker, gc.Equals, s.worker)
+	s.CheckCalls(c, []testing.StubCall{{
+		FuncName: "newWorker",
+		Args:     []interface{}{expectAgent, expectApiCaller},
+	}})
+}


### PR DESCRIPTION
worker/util: Add PostUpgradeManifold

This helper manifold waits for machine agent upgrades to be complete and the API connection and agent to be available before calling the worker start function provided. It avoids repeating this functionality for all the machine agent workers which have these dependencies.

---

Run the reboot worker under the dependency engine


(Review request: http://reviews.vapour.ws/r/3428/)