### PR TITLE
provider/...: use StartInstanceParams.ImageMetadata

### DIFF
--- a/provider/cloudsigma/environinstance.go
+++ b/provider/cloudsigma/environinstance.go
@@ -11,7 +11,6 @@ import (
 	"github.com/juju/juju/cloudconfig/providerinit"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/imagemetadata"
-	"github.com/juju/juju/environs/simplestreams"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/tools"
 )
@@ -20,21 +19,12 @@ import (
 // Imlementation of InstanceBroker: methods for starting and stopping instances.
 //
 
-var findInstanceImage = func(env *environ, ic *imagemetadata.ImageConstraint) (*imagemetadata.ImageMetadata, error) {
-
-	sources, err := environs.ImageMetadataSources(env)
-	if err != nil {
-		return nil, err
-	}
-
-	matchingImages, _, err := imagemetadata.Fetch(sources, ic)
-	if err != nil {
-		return nil, err
-	}
+var findInstanceImage = func(
+	matchingImages []*imagemetadata.ImageMetadata,
+) (*imagemetadata.ImageMetadata, error) {
 	if len(matchingImages) == 0 {
 		return nil, errors.New("no matching image meta data")
 	}
-
 	return matchingImages[0], nil
 }
 
@@ -63,13 +53,7 @@ func (env *environ) StartInstance(args environs.StartInstanceParams) (*environs.
 		return nil, errors.New("tools not found")
 	}
 
-	region, _ := env.Region()
-	img, err := findInstanceImage(env, imagemetadata.NewImageConstraint(simplestreams.LookupParams{
-		CloudSpec: region,
-		Series:    args.Tools.AllSeries(),
-		Arches:    args.Tools.Arches(),
-		Stream:    env.Config().ImageStream(),
-	}))
+	img, err := findInstanceImage(args.ImageMetadata)
 	if err != nil {
 		return nil, err
 	}

--- a/provider/cloudsigma/environinstance_test.go
+++ b/provider/cloudsigma/environinstance_test.go
@@ -63,7 +63,7 @@ func (s *environInstanceSuite) TearDownTest(c *gc.C) {
 }
 
 func (s *environInstanceSuite) createEnviron(c *gc.C, cfg *config.Config) environs.Environ {
-	s.PatchValue(&findInstanceImage, func(env *environ, ic *imagemetadata.ImageConstraint) (*imagemetadata.ImageMetadata, error) {
+	s.PatchValue(&findInstanceImage, func([]*imagemetadata.ImageMetadata) (*imagemetadata.ImageMetadata, error) {
 		img := &imagemetadata.ImageMetadata{
 			Id: validImageId,
 		}

--- a/provider/gce/environ_broker.go
+++ b/provider/gce/environ_broker.go
@@ -17,7 +17,6 @@ import (
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/imagemetadata"
 	"github.com/juju/juju/environs/instances"
-	"github.com/juju/juju/environs/simplestreams"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/provider/common"
@@ -117,47 +116,37 @@ func (env *environ) finishInstanceConfig(args environs.StartInstanceParams, spec
 func (env *environ) buildInstanceSpec(args environs.StartInstanceParams) (*instances.InstanceSpec, error) {
 	arches := args.Tools.Arches()
 	series := args.Tools.OneSeries()
-	spec, err := findInstanceSpec(env, env.Config().ImageStream(), &instances.InstanceConstraint{
-		Region:      env.ecfg.region(),
-		Series:      series,
-		Arches:      arches,
-		Constraints: args.Constraints,
-	})
+	spec, err := findInstanceSpec(
+		env, &instances.InstanceConstraint{
+			Region:      env.ecfg.region(),
+			Series:      series,
+			Arches:      arches,
+			Constraints: args.Constraints,
+		},
+		args.ImageMetadata,
+	)
 	return spec, errors.Trace(err)
 }
 
-var findInstanceSpec = func(env *environ, stream string, ic *instances.InstanceConstraint) (*instances.InstanceSpec, error) {
-	return env.findInstanceSpec(stream, ic)
+var findInstanceSpec = func(
+	env *environ,
+	ic *instances.InstanceConstraint,
+	imageMetadata []*imagemetadata.ImageMetadata,
+) (*instances.InstanceSpec, error) {
+	return env.findInstanceSpec(ic, imageMetadata)
 }
 
-// findInstanceSpec initializes a new instance spec for the given stream
-// (and constraints) and returns it. This only covers populating the
-// initial data for the spec. However, it does include fetching the
-// correct simplestreams image data.
-func (env *environ) findInstanceSpec(stream string, ic *instances.InstanceConstraint) (*instances.InstanceSpec, error) {
-	sources, err := environs.ImageMetadataSources(env)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	imageConstraint := imagemetadata.NewImageConstraint(simplestreams.LookupParams{
-		CloudSpec: env.cloudSpec(ic.Region),
-		Series:    []string{ic.Series},
-		Arches:    ic.Arches,
-		Stream:    stream,
-	})
-
-	matchingImages, _, err := imageMetadataFetch(sources, imageConstraint)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	images := instances.ImageMetadataToImages(matchingImages)
+// findInstanceSpec initializes a new instance spec for the given
+// constraints and returns it. This only covers populating the
+// initial data for the spec.
+func (env *environ) findInstanceSpec(
+	ic *instances.InstanceConstraint,
+	imageMetadata []*imagemetadata.ImageMetadata,
+) (*instances.InstanceSpec, error) {
+	images := instances.ImageMetadataToImages(imageMetadata)
 	spec, err := instances.FindInstanceSpec(images, ic, allInstanceTypes)
 	return spec, errors.Trace(err)
 }
-
-var imageMetadataFetch = imagemetadata.Fetch
 
 // newRawInstance is where the new physical instance is actually
 // provisioned, relative to the provided args and spec. Info for that

--- a/provider/gce/environ_broker_test.go
+++ b/provider/gce/environ_broker_test.go
@@ -148,10 +148,7 @@ func (s *environBrokerSuite) TestBuildInstanceSpec(c *gc.C) {
 }
 
 func (s *environBrokerSuite) TestFindInstanceSpec(c *gc.C) {
-	s.FakeImages.Metadata = s.imageMetadata
-	s.FakeImages.ResolveInfo = s.resolveInfo
-
-	spec, err := gce.FindInstanceSpec(s.Env, s.Env.Config().ImageStream(), s.ic)
+	spec, err := gce.FindInstanceSpec(s.Env, s.ic, s.imageMetadata)
 
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(spec, gc.DeepEquals, s.spec)

--- a/provider/gce/export_test.go
+++ b/provider/gce/export_test.go
@@ -5,6 +5,7 @@ package gce
 
 import (
 	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/imagemetadata"
 	"github.com/juju/juju/environs/instances"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/provider/gce/google"
@@ -58,8 +59,12 @@ func FinishInstanceConfig(env *environ, args environs.StartInstanceParams, spec 
 	return env.finishInstanceConfig(args, spec)
 }
 
-func FindInstanceSpec(env *environ, stream string, ic *instances.InstanceConstraint) (*instances.InstanceSpec, error) {
-	return env.findInstanceSpec(stream, ic)
+func FindInstanceSpec(
+	env *environ,
+	ic *instances.InstanceConstraint,
+	imageMetadata []*imagemetadata.ImageMetadata,
+) (*instances.InstanceSpec, error) {
+	return env.findInstanceSpec(ic, imageMetadata)
 }
 
 func BuildInstanceSpec(env *environ, args environs.StartInstanceParams) (*instances.InstanceSpec, error) {

--- a/provider/joyent/environ_instance.go
+++ b/provider/joyent/environ_instance.go
@@ -22,7 +22,6 @@ import (
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/imagemetadata"
 	"github.com/juju/juju/environs/instances"
-	"github.com/juju/juju/environs/simplestreams"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/provider/common"
 	"github.com/juju/juju/state/multiwatcher"
@@ -101,7 +100,7 @@ func (env *joyentEnviron) StartInstance(args environs.StartInstanceParams) (*env
 		Series:      series,
 		Arches:      arches,
 		Constraints: args.Constraints,
-	})
+	}, args.ImageMetadata)
 	if err != nil {
 		return nil, err
 	}
@@ -345,7 +344,10 @@ func (env *joyentEnviron) listInstanceTypes() ([]instances.InstanceType, error) 
 }
 
 // FindInstanceSpec returns an InstanceSpec satisfying the supplied instanceConstraint.
-func (env *joyentEnviron) FindInstanceSpec(ic *instances.InstanceConstraint) (*instances.InstanceSpec, error) {
+func (env *joyentEnviron) FindInstanceSpec(
+	ic *instances.InstanceConstraint,
+	imageMetadata []*imagemetadata.ImageMetadata,
+) (*instances.InstanceSpec, error) {
 	// Require at least one VCPU so we get KVM rather than smart package.
 	if ic.Constraints.CpuCores == nil {
 		ic.Constraints.CpuCores = &defaultCpuCores
@@ -354,21 +356,7 @@ func (env *joyentEnviron) FindInstanceSpec(ic *instances.InstanceConstraint) (*i
 	if err != nil {
 		return nil, err
 	}
-	imageConstraint := imagemetadata.NewImageConstraint(simplestreams.LookupParams{
-		CloudSpec: simplestreams.CloudSpec{ic.Region, env.Ecfg().SdcUrl()},
-		Series:    []string{ic.Series},
-		Arches:    ic.Arches,
-	})
-	sources, err := environs.ImageMetadataSources(env)
-	if err != nil {
-		return nil, err
-	}
-
-	matchingImages, _, err := imagemetadata.Fetch(sources, imageConstraint)
-	if err != nil {
-		return nil, err
-	}
-	images := instances.ImageMetadataToImages(matchingImages)
+	images := instances.ImageMetadataToImages(imageMetadata)
 	spec, err := instances.FindInstanceSpec(images, ic, allInstanceTypes)
 	if err != nil {
 		return nil, err

--- a/provider/joyent/export_test.go
+++ b/provider/joyent/export_test.go
@@ -170,14 +170,17 @@ func UnregisterMachinesEndpoint() {
 	sstesting.SetRoundTripperFiles(nil, nil)
 }
 
-func FindInstanceSpec(e environs.Environ, series, arch, cons string) (spec *instances.InstanceSpec, err error) {
+func FindInstanceSpec(
+	e environs.Environ, series, arch, cons string,
+	imageMetadata []*imagemetadata.ImageMetadata,
+) (spec *instances.InstanceSpec, err error) {
 	env := e.(*joyentEnviron)
 	spec, err = env.FindInstanceSpec(&instances.InstanceConstraint{
 		Series:      series,
 		Arches:      []string{arch},
 		Region:      env.Ecfg().Region(),
 		Constraints: constraints.MustParse(cons),
-	})
+	}, imageMetadata)
 	return
 }
 

--- a/provider/joyent/local_test.go
+++ b/provider/joyent/local_test.go
@@ -345,7 +345,12 @@ func (s *localServerSuite) TestGetToolsMetadataSources(c *gc.C) {
 
 func (s *localServerSuite) TestFindInstanceSpec(c *gc.C) {
 	env := s.Prepare(c)
-	spec, err := joyent.FindInstanceSpec(env, "trusty", "amd64", "mem=4G")
+	imageMetadata := []*imagemetadata.ImageMetadata{{
+		Id:       "image-id",
+		Arch:     "amd64",
+		VirtType: "kvm",
+	}}
+	spec, err := joyent.FindInstanceSpec(env, "trusty", "amd64", "mem=4G", imageMetadata)
 	c.Assert(err, gc.IsNil)
 	c.Assert(spec.InstanceType.VirtType, gc.NotNil)
 	c.Check(spec.Image.Arch, gc.Equals, "amd64")
@@ -357,7 +362,7 @@ func (s *localServerSuite) TestFindInstanceSpec(c *gc.C) {
 func (s *localServerSuite) TestFindImageBadDefaultImage(c *gc.C) {
 	env := s.Prepare(c)
 	// An error occurs if no suitable image is found.
-	_, err := joyent.FindInstanceSpec(env, "saucy", "amd64", "mem=4G")
+	_, err := joyent.FindInstanceSpec(env, "saucy", "amd64", "mem=4G", nil)
 	c.Assert(err, gc.ErrorMatches, `no "saucy" images in some-region with arches \[amd64\]`)
 }
 

--- a/provider/maas/environ_whitebox_test.go
+++ b/provider/maas/environ_whitebox_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/bootstrap"
 	"github.com/juju/juju/environs/config"
-	"github.com/juju/juju/environs/simplestreams"
 	envstorage "github.com/juju/juju/environs/storage"
 	envtesting "github.com/juju/juju/environs/testing"
 	envtools "github.com/juju/juju/environs/tools"
@@ -753,15 +752,6 @@ func (suite *environSuite) TestBootstrapFailsIfNoNodes(c *gc.C) {
 	// Since there are no nodes, the attempt to allocate one returns a
 	// 409: Conflict.
 	c.Check(err, gc.ErrorMatches, ".*409.*")
-}
-
-func assertSourceContents(c *gc.C, source simplestreams.DataSource, filename string, content []byte) {
-	rc, _, err := source.Fetch(filename)
-	c.Assert(err, jc.ErrorIsNil)
-	defer rc.Close()
-	retrieved, err := ioutil.ReadAll(rc)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(retrieved, gc.DeepEquals, content)
 }
 
 func (suite *environSuite) TestGetToolsMetadataSources(c *gc.C) {

--- a/provider/openstack/export_test.go
+++ b/provider/openstack/export_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/environs/imagemetadata"
 	"github.com/juju/juju/environs/instances"
 	"github.com/juju/juju/environs/simplestreams"
 	envstorage "github.com/juju/juju/environs/storage"
@@ -287,15 +288,18 @@ func DiscardSecurityGroup(e environs.Environ, name string) error {
 	return nil
 }
 
-func FindInstanceSpec(e environs.Environ, series, arch, cons string) (spec *instances.InstanceSpec, err error) {
+func FindInstanceSpec(
+	e environs.Environ,
+	series, arch, cons string,
+	imageMetadata []*imagemetadata.ImageMetadata,
+) (spec *instances.InstanceSpec, err error) {
 	env := e.(*environ)
-	spec, err = findInstanceSpec(env, &instances.InstanceConstraint{
+	return findInstanceSpec(env, &instances.InstanceConstraint{
 		Series:      series,
 		Arches:      []string{arch},
 		Region:      env.ecfg().region(),
 		Constraints: constraints.MustParse(cons),
-	})
-	return
+	}, imageMetadata)
 }
 
 func ControlBucketName(e environs.Environ) string {

--- a/provider/openstack/image.go
+++ b/provider/openstack/image.go
@@ -4,15 +4,17 @@
 package openstack
 
 import (
-	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/imagemetadata"
 	"github.com/juju/juju/environs/instances"
-	"github.com/juju/juju/environs/simplestreams"
 )
 
 // findInstanceSpec returns an image and instance type satisfying the constraint.
 // The instance type comes from querying the flavors supported by the deployment.
-func findInstanceSpec(e *environ, ic *instances.InstanceConstraint) (*instances.InstanceSpec, error) {
+func findInstanceSpec(
+	e *environ,
+	ic *instances.InstanceConstraint,
+	imageMetadata []*imagemetadata.ImageMetadata,
+) (*instances.InstanceSpec, error) {
 	// first construct all available instance types from the supported flavors.
 	nova := e.nova()
 	flavors, err := nova.ListFlavorsDetail()
@@ -33,21 +35,7 @@ func findInstanceSpec(e *environ, ic *instances.InstanceConstraint) (*instances.
 		allInstanceTypes = append(allInstanceTypes, instanceType)
 	}
 
-	imageConstraint := imagemetadata.NewImageConstraint(simplestreams.LookupParams{
-		CloudSpec: simplestreams.CloudSpec{ic.Region, e.ecfg().authURL()},
-		Series:    []string{ic.Series},
-		Arches:    ic.Arches,
-		Stream:    e.Config().ImageStream(),
-	})
-	sources, err := environs.ImageMetadataSources(e)
-	if err != nil {
-		return nil, err
-	}
-	matchingImages, _, err := imagemetadata.Fetch(sources, imageConstraint)
-	if err != nil {
-		return nil, err
-	}
-	images := instances.ImageMetadataToImages(matchingImages)
+	images := instances.ImageMetadataToImages(imageMetadata)
 	spec, err := instances.FindInstanceSpec(images, ic, allInstanceTypes)
 	if err != nil {
 		return nil, err

--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -909,7 +909,7 @@ func (s *localServerSuite) TestFindImageBadDefaultImage(c *gc.C) {
 	env := s.Open(c)
 
 	// An error occurs if no suitable image is found.
-	_, err := openstack.FindInstanceSpec(env, "saucy", "amd64", "mem=1G")
+	_, err := openstack.FindInstanceSpec(env, "saucy", "amd64", "mem=1G", nil)
 	c.Assert(err, gc.ErrorMatches, `no "saucy" images in some-region with arches \[amd64\]`)
 }
 
@@ -947,21 +947,30 @@ func (s *localServerSuite) TestConstraintsMerge(c *gc.C) {
 }
 
 func (s *localServerSuite) TestFindImageInstanceConstraint(c *gc.C) {
-	// Prevent falling over to the public datasource.
-	s.BaseSuite.PatchValue(&imagemetadata.DefaultBaseURL, "")
-
 	env := s.Open(c)
-	spec, err := openstack.FindInstanceSpec(env, coretesting.FakeDefaultSeries, "amd64", "instance-type=m1.tiny")
+	imageMetadata := []*imagemetadata.ImageMetadata{{
+		Id:   "image-id",
+		Arch: "amd64",
+	}}
+
+	spec, err := openstack.FindInstanceSpec(
+		env, coretesting.FakeDefaultSeries, "amd64", "instance-type=m1.tiny",
+		imageMetadata,
+	)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(spec.InstanceType.Name, gc.Equals, "m1.tiny")
 }
 
 func (s *localServerSuite) TestFindImageInvalidInstanceConstraint(c *gc.C) {
-	// Prevent falling over to the public datasource.
-	s.BaseSuite.PatchValue(&imagemetadata.DefaultBaseURL, "")
-
 	env := s.Open(c)
-	_, err := openstack.FindInstanceSpec(env, coretesting.FakeDefaultSeries, "amd64", "instance-type=m1.large")
+	imageMetadata := []*imagemetadata.ImageMetadata{{
+		Id:   "image-id",
+		Arch: "amd64",
+	}}
+	_, err := openstack.FindInstanceSpec(
+		env, coretesting.FakeDefaultSeries, "amd64", "instance-type=m1.large",
+		imageMetadata,
+	)
 	c.Assert(err, gc.ErrorMatches, `no instance types in some-region matching constraints "instance-type=m1.large"`)
 }
 

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -1015,7 +1015,7 @@ func (e *environ) StartInstance(args environs.StartInstanceParams) (*environs.St
 		Series:      series,
 		Arches:      arches,
 		Constraints: args.Constraints,
-	})
+	}, args.ImageMetadata)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Update remaining providers to use StartInstanceParams.ImageMetadata, where it makes sense to do so. We have not updated the legacy azure, or vsphere providers. Legacy Azure requires more intrusive changes, and should be removed soon anyway; vphere has non-standard image metadata lookup.

(Review request: http://reviews.vapour.ws/r/3431/)