### PR TITLE
Run the logger in the machine agent's dependency engine

### DIFF
--- a/api/interface.go
+++ b/api/interface.go
@@ -21,7 +21,6 @@ import (
 	"github.com/juju/juju/api/imagemetadata"
 	"github.com/juju/juju/api/instancepoller"
 	"github.com/juju/juju/api/keyupdater"
-	apilogger "github.com/juju/juju/api/logger"
 	"github.com/juju/juju/api/machiner"
 	"github.com/juju/juju/api/networker"
 	"github.com/juju/juju/api/provisioner"
@@ -173,7 +172,6 @@ type Connection interface {
 	Reboot() (*reboot.State, error)
 	Deployer() *deployer.State
 	Environment() *environment.Facade
-	Logger() *apilogger.State
 	KeyUpdater() *keyupdater.State
 	Addresser() *addresser.API
 	InstancePoller() *instancepoller.API

--- a/api/logger/logger_test.go
+++ b/api/logger/logger_test.go
@@ -35,7 +35,7 @@ func (s *loggerSuite) SetUpTest(c *gc.C) {
 	var stateAPI api.Connection
 	stateAPI, s.rawMachine = s.OpenAPIAsNewMachine(c)
 	// Create the logger facade.
-	s.logger = stateAPI.Logger()
+	s.logger = logger.NewState(stateAPI)
 	c.Assert(s.logger, gc.NotNil)
 }
 

--- a/api/state.go
+++ b/api/state.go
@@ -23,7 +23,6 @@ import (
 	"github.com/juju/juju/api/imagemetadata"
 	"github.com/juju/juju/api/instancepoller"
 	"github.com/juju/juju/api/keyupdater"
-	apilogger "github.com/juju/juju/api/logger"
 	"github.com/juju/juju/api/machiner"
 	"github.com/juju/juju/api/networker"
 	"github.com/juju/juju/api/provisioner"
@@ -359,11 +358,6 @@ func (st *state) Addresser() *addresser.API {
 // Environment returns access to the Environment API
 func (st *state) Environment() *environment.Facade {
 	return environment.NewFacade(st)
-}
-
-// Logger returns access to the Logger API
-func (st *state) Logger() *apilogger.State {
-	return apilogger.NewState(st)
 }
 
 // KeyUpdater returns access to the KeyUpdater API

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -89,7 +89,6 @@ import (
 	"github.com/juju/juju/worker/imagemetadataworker"
 	"github.com/juju/juju/worker/instancepoller"
 	"github.com/juju/juju/worker/localstorage"
-	workerlogger "github.com/juju/juju/worker/logger"
 	"github.com/juju/juju/worker/logsender"
 	"github.com/juju/juju/worker/machiner"
 	"github.com/juju/juju/worker/metricworker"
@@ -758,14 +757,6 @@ func (a *MachineAgent) startAPIWorkers(apiConn api.Connection) (_ worker.Worker,
 		w, err := apiaddressupdater.NewAPIAddressUpdater(apiConn.Machiner(), addressUpdater)
 		if err != nil {
 			return nil, errors.Annotate(err, "cannot start api address updater worker")
-		}
-		return w, nil
-	})
-
-	runner.StartWorker("logger", func() (worker.Worker, error) {
-		w, err := workerlogger.NewLogger(apiConn.Logger(), agentConfig)
-		if err != nil {
-			return nil, errors.Annotate(err, "cannot start logging config updater worker")
 		}
 		return w, nil
 	})

--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/juju/worker/apicaller"
 	"github.com/juju/juju/worker/dependency"
 	"github.com/juju/juju/worker/gate"
+	"github.com/juju/juju/worker/logger"
 	"github.com/juju/juju/worker/reboot"
 	"github.com/juju/juju/worker/terminationworker"
 	"github.com/juju/juju/worker/upgrader"
@@ -167,21 +168,32 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 			APICallerName:     apiCallerName,
 			UpgradeWaiterName: upgradeWaiterName,
 		}),
+
+		// The logging config updater is a leaf worker that indirectly
+		// controls the messages sent via the log sender or rsyslog,
+		// according to changes in environment config. We should only need
+		// one of these in a consolidated agent.
+		loggingConfigUpdaterName: logger.Manifold(logger.ManifoldConfig{
+			AgentName:         agentName,
+			APICallerName:     apiCallerName,
+			UpgradeWaiterName: upgradeWaiterName,
+		}),
 	}
 }
 
 const (
-	agentName             = "agent"
-	terminationName       = "termination"
-	apiCallerName         = "api-caller"
-	apiInfoGateName       = "api-info-gate"
-	upgradeStepsGateName  = "upgrade-steps-gate"
-	upgradeCheckGateName  = "upgrade-check-gate"
-	upgraderName          = "upgrader"
-	upgradeStepsName      = "upgradesteps"
-	upgradeWaiterName     = "upgradewaiter"
-	uninstallerName       = "uninstaller"
-	servingInfoSetterName = "serving-info-setter"
-	apiWorkersName        = "apiworkers"
-	rebootName            = "reboot"
+	agentName                = "agent"
+	terminationName          = "termination"
+	apiCallerName            = "api-caller"
+	apiInfoGateName          = "api-info-gate"
+	upgradeStepsGateName     = "upgrade-steps-gate"
+	upgradeCheckGateName     = "upgrade-check-gate"
+	upgraderName             = "upgrader"
+	upgradeStepsName         = "upgradesteps"
+	upgradeWaiterName        = "upgradewaiter"
+	uninstallerName          = "uninstaller"
+	servingInfoSetterName    = "serving-info-setter"
+	apiWorkersName           = "apiworkers"
+	rebootName               = "reboot"
+	loggingConfigUpdaterName = "logging-config-updater"
 )

--- a/cmd/jujud/agent/machine/manifolds_test.go
+++ b/cmd/jujud/agent/machine/manifolds_test.go
@@ -50,6 +50,7 @@ func (s *ManifoldsSuite) TestManifoldNames(c *gc.C) {
 		"serving-info-setter",
 		"apiworkers",
 		"reboot",
+		"logging-config-updater",
 	}
 	c.Assert(keys, jc.SameContents, expectedKeys)
 }

--- a/cmd/jujud/agent/unit/manifolds.go
+++ b/cmd/jujud/agent/unit/manifolds.go
@@ -25,6 +25,7 @@ import (
 	"github.com/juju/juju/worker/rsyslog"
 	"github.com/juju/juju/worker/uniter"
 	"github.com/juju/juju/worker/upgrader"
+	"github.com/juju/juju/worker/util"
 )
 
 // ManifoldsConfig allows specialisation of the result of Manifolds.
@@ -92,8 +93,9 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 		// according to changes in environment config. We should only need
 		// one of these in a consolidated agent.
 		LoggingConfigUpdaterName: logger.Manifold(logger.ManifoldConfig{
-			AgentName:     AgentName,
-			APICallerName: APICallerName,
+			AgentName:         AgentName,
+			APICallerName:     APICallerName,
+			UpgradeWaiterName: util.UpgradeWaitNotRequired,
 		}),
 
 		// The api address updater is a leaf worker that rewrites agent config

--- a/worker/logger/logger_test.go
+++ b/worker/logger/logger_test.go
@@ -12,7 +12,6 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/agent"
-	"github.com/juju/juju/api"
 	apilogger "github.com/juju/juju/api/logger"
 	"github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/state"
@@ -29,7 +28,6 @@ const worstCase = 5 * time.Second
 type LoggerSuite struct {
 	testing.JujuConnSuite
 
-	apiRoot   api.Connection
 	loggerApi *apilogger.State
 	machine   *state.Machine
 }
@@ -38,10 +36,11 @@ var _ = gc.Suite(&LoggerSuite{})
 
 func (s *LoggerSuite) SetUpTest(c *gc.C) {
 	s.JujuConnSuite.SetUpTest(c)
-	s.apiRoot, s.machine = s.OpenAPIAsNewMachine(c)
+	apiConn, machine := s.OpenAPIAsNewMachine(c)
 	// Create the machiner API facade.
-	s.loggerApi = s.apiRoot.Logger()
+	s.loggerApi = apilogger.NewState(apiConn)
 	c.Assert(s.loggerApi, gc.NotNil)
+	s.machine = machine
 }
 
 func (s *LoggerSuite) waitLoggingInfo(c *gc.C, expected string) {

--- a/worker/logger/manifold.go
+++ b/worker/logger/manifold.go
@@ -14,15 +14,15 @@ import (
 
 // ManifoldConfig defines the names of the manifolds on which a
 // Manifold will depend.
-type ManifoldConfig util.AgentApiManifoldConfig
+type ManifoldConfig util.PostUpgradeManifoldConfig
 
 // Manifold returns a dependency manifold that runs a logger
 // worker, using the resource names defined in the supplied config.
 func Manifold(config ManifoldConfig) dependency.Manifold {
-	return util.AgentApiManifold(util.AgentApiManifoldConfig(config), newWorker)
+	return util.PostUpgradeManifold(util.PostUpgradeManifoldConfig(config), newWorker)
 }
 
-// newWorker trivially wraps NewLogger to specialise an AgentApiManifold.
+// newWorker trivially wraps NewLogger to specialise a PostUpgradeManifold.
 var newWorker = func(a agent.Agent, apiCaller base.APICaller) (worker.Worker, error) {
 	currentConfig := a.CurrentConfig()
 	loggerFacade := logger.NewState(apiCaller)

--- a/worker/util/postupgrade_test.go
+++ b/worker/util/postupgrade_test.go
@@ -135,3 +135,27 @@ func (s *PostUpgradeManifoldSuite) TestStartSuccess(c *gc.C) {
 		Args:     []interface{}{expectAgent, expectApiCaller},
 	}})
 }
+
+func (s *PostUpgradeManifoldSuite) TestUpgradeWaitNotRequired(c *gc.C) {
+	manifold := util.PostUpgradeManifold(util.PostUpgradeManifoldConfig{
+		AgentName:         "agent-name",
+		APICallerName:     "api-caller-name",
+		UpgradeWaiterName: util.UpgradeWaitNotRequired,
+	}, s.newWorker)
+
+	c.Check(manifold.Inputs, jc.DeepEquals, []string{"agent-name", "api-caller-name"})
+
+	expectAgent := &dummyAgent{}
+	expectApiCaller := &dummyApiCaller{}
+	getResource := dt.StubGetResource(dt.StubResources{
+		"agent-name":      dt.StubResource{Output: expectAgent},
+		"api-caller-name": dt.StubResource{Output: expectApiCaller},
+	})
+	worker, err := manifold.Start(getResource)
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(worker, gc.Equals, s.worker)
+	s.CheckCalls(c, []testing.StubCall{{
+		FuncName: "newWorker",
+		Args:     []interface{}{expectAgent, expectApiCaller},
+	}})
+}


### PR DESCRIPTION
worker/util: Allow PostUpgradeManifold's upgrade wait to be optional

This is useful for workers that need to run in both the unit and machine agent. The upgrade wait doesn't make sense in the unit agent.

---

Base the logger worker on PostUpgradeManifoldConfig

... instead of AgentApiManifold. This way the manifold can be used both with the unit and machine agents. Under the unit agent the upgrade wait is skipped (util.UpgradeWaitNotRequired).

---

Run the logger work in the machine agent's dependency engine

---

api: Removed now-unused Logger method from api.Connection

We are trying to get rid of these constructor methods on Connection.


(Review request: http://reviews.vapour.ws/r/3434/)