### PR TITLE
worker/undertaker: fix alignment for atomic ops

### DIFF
--- a/worker/undertaker/undertaker_test.go
+++ b/worker/undertaker/undertaker_test.go
@@ -24,11 +24,11 @@ type undertakerSuite struct {
 var _ = gc.Suite(&undertakerSuite{})
 
 type clock struct {
-	*testing.Clock
-
 	// advanceDurationAfterNow is the duration to advance the clock after the
 	// next call to Now().
 	advanceDurationAfterNow int64
+
+	*testing.Clock
 }
 
 func (c *clock) Now() time.Time {


### PR DESCRIPTION
Fix tests on 32-bit architectures by aligning variable
used in atomic operations to 64-bit boundary.

Fixes https://bugs.launchpad.net/juju-core/+bug/1528259