### PR TITLE
Add the ListResources endpoint to the resources facade.

### DIFF
--- a/component/all/resource.go
+++ b/component/all/resource.go
@@ -124,12 +124,8 @@ func (r resources) registerPublicCommands() {
 	}
 
 	newShowAPIClient := func(command *cmd.ShowCommand) (cmd.CharmResourceLister, error) {
-		//return newCharmstore()
-		store, err := newCharmstore()
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		return &charmstore{store}, nil
+		client := newCharmstoreClient()
+		return &charmstoreClient{client}, nil
 	}
 	commands.RegisterEnvCommand(func() envcmd.EnvironCommand {
 		return cmd.NewShowCommand(newShowAPIClient)
@@ -148,25 +144,25 @@ func (r resources) registerPublicCommands() {
 	})
 }
 
-func newCharmstore() (charmrepo.Interface, error) {
+func newCharmstoreClient() charmrepo.Interface {
 	// Also see apiserver/service/charmstore.go.
 	var args charmrepo.NewCharmStoreParams
-	store := charmrepo.NewCharmStore(args)
-	return store, nil
+	client := charmrepo.NewCharmStore(args)
+	return client
 }
 
-// TODO(ericsnow) Get rid of charmstore one charmrepo.Interface grows the methods.
+// TODO(ericsnow) Get rid of charmstoreClient one charmrepo.Interface grows the methods.
 
-type charmstore struct {
+type charmstoreClient struct {
 	charmrepo.Interface
 }
 
-func (charmstore) ListResources(charmURLs []charm.URL) ([][]charmresource.Resource, error) {
+func (charmstoreClient) ListResources(charmURLs []charm.URL) ([][]charmresource.Resource, error) {
 	// TODO(ericsnow) finish!
 	return nil, errors.Errorf("not implemented")
 }
 
-func (charmstore) Close() error {
+func (charmstoreClient) Close() error {
 	return nil
 }
 

--- a/component/all/resource.go
+++ b/component/all/resource.go
@@ -8,6 +8,9 @@ import (
 	"os"
 
 	"github.com/juju/errors"
+	"gopkg.in/juju/charm.v6-unstable"
+	charmresource "gopkg.in/juju/charm.v6-unstable/resource"
+	"gopkg.in/juju/charmrepo.v2-unstable"
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/base"
@@ -121,13 +124,12 @@ func (r resources) registerPublicCommands() {
 	}
 
 	newShowAPIClient := func(command *cmd.ShowCommand) (cmd.CharmResourceLister, error) {
-		//apiCaller, err := command.NewAPIRoot()
-		//if err != nil {
-		//	return nil, errors.Trace(err)
-		//}
-		//return r.newAPIClient(apiCaller)
-		// TODO(ericsnow) finish!
-		return nil, errors.Errorf("not implemented")
+		//return newCharmstore()
+		store, err := newCharmstore()
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		return &charmstore{store}, nil
 	}
 	commands.RegisterEnvCommand(func() envcmd.EnvironCommand {
 		return cmd.NewShowCommand(newShowAPIClient)
@@ -144,6 +146,28 @@ func (r resources) registerPublicCommands() {
 		})
 
 	})
+}
+
+func newCharmstore() (charmrepo.Interface, error) {
+	// Also see apiserver/service/charmstore.go.
+	var args charmrepo.NewCharmStoreParams
+	store := charmrepo.NewCharmStore(args)
+	return store, nil
+}
+
+// TODO(ericsnow) Get rid of charmstore one charmrepo.Interface grows the methods.
+
+type charmstore struct {
+	charmrepo.Interface
+}
+
+func (charmstore) ListResources(charmURLs []charm.URL) ([][]charmresource.Resource, error) {
+	// TODO(ericsnow) finish!
+	return nil, errors.Errorf("not implemented")
+}
+
+func (charmstore) Close() error {
+	return nil
 }
 
 type apicommand interface {

--- a/resource/api/client/base_test.go
+++ b/resource/api/client/base_test.go
@@ -1,0 +1,137 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package client_test
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/juju/errors"
+	"github.com/juju/names"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	charmresource "gopkg.in/juju/charm.v6-unstable/resource"
+
+	basetesting "github.com/juju/juju/api/base/testing"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/resource"
+	"github.com/juju/juju/resource/api"
+)
+
+type BaseSuite struct {
+	testing.IsolationSuite
+
+	stub   *testing.Stub
+	facade *stubFacade
+}
+
+func (s *BaseSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+
+	s.stub = &testing.Stub{}
+	s.facade = newStubFacade(c, s.stub)
+}
+
+func newResourceResult(c *gc.C, serviceID string, names ...string) ([]resource.Resource, api.ResourcesResult) {
+	var resources []resource.Resource
+	var apiResult api.ResourcesResult
+	for _, name := range names {
+		data := name + "...spamspamspam"
+		res, apiRes := newResource(c, name, "a-user", data)
+		resources = append(resources, res)
+		apiResult.Resources = append(apiResult.Resources, apiRes)
+	}
+	return resources, apiResult
+}
+
+func newResource(c *gc.C, name, username, data string) (resource.Resource, api.Resource) {
+	fp, err := charmresource.GenerateFingerprint([]byte(data))
+	c.Assert(err, jc.ErrorIsNil)
+	var now time.Time
+	if username != "" {
+		now = time.Now()
+	}
+	res := resource.Resource{
+		Resource: charmresource.Resource{
+			Meta: charmresource.Meta{
+				Name: name,
+				Type: charmresource.TypeFile,
+				Path: name + ".tgz",
+			},
+			Origin:      charmresource.OriginUpload,
+			Revision:    1,
+			Fingerprint: fp,
+		},
+		Username:  username,
+		Timestamp: now,
+	}
+	err = res.Validate()
+	c.Assert(err, jc.ErrorIsNil)
+
+	apiRes := api.Resource{
+		CharmResource: api.CharmResource{
+			Name:        name,
+			Type:        "file",
+			Path:        name + ".tgz",
+			Origin:      "upload",
+			Revision:    1,
+			Fingerprint: fp.Bytes(),
+		},
+		Username:  username,
+		Timestamp: now,
+	}
+
+	return res, apiRes
+}
+
+type stubFacade struct {
+	basetesting.StubFacadeCaller
+
+	apiResults map[string]api.ResourcesResult
+}
+
+func newStubFacade(c *gc.C, stub *testing.Stub) *stubFacade {
+	s := &stubFacade{
+		StubFacadeCaller: basetesting.StubFacadeCaller{
+			Stub: stub,
+		},
+		apiResults: make(map[string]api.ResourcesResult),
+	}
+
+	s.FacadeCallFn = func(_ string, args, response interface{}) error {
+		typedResponse, ok := response.(*api.ResourcesResults)
+		c.Assert(ok, jc.IsTrue)
+
+		typedArgs, ok := args.(*api.ListResourcesArgs)
+		c.Assert(ok, jc.IsTrue)
+
+		for _, e := range typedArgs.Entities {
+			tag, err := names.ParseTag(e.Tag)
+			c.Assert(err, jc.ErrorIsNil)
+			service := tag.Id()
+
+			apiResult, ok := s.apiResults[service]
+			if !ok {
+				apiResult.Error = &params.Error{
+					Message: fmt.Sprintf("service %q not found", service),
+					Code:    params.CodeNotFound,
+				}
+			}
+			typedResponse.Results = append(typedResponse.Results, apiResult)
+		}
+		return nil
+	}
+
+	return s
+}
+
+func (s *stubFacade) Close() error {
+	s.Stub.AddCall("Close")
+	if err := s.Stub.NextErr(); err != nil {
+		return errors.Trace(err)
+	}
+
+	return nil
+}

--- a/resource/api/client/client.go
+++ b/resource/api/client/client.go
@@ -39,7 +39,7 @@ func NewClient(caller FacadeCaller, closer io.Closer) *Client {
 // ListResources calls the ListResources API server method with
 // the given service names.
 func (c Client) ListResources(services []string) ([][]resource.Resource, error) {
-	args, err := api.NewListResourcesArgs(services...)
+	args, err := api.NewListResourcesArgs(services)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/resource/api/client/client_listresources_test.go
+++ b/resource/api/client/client_listresources_test.go
@@ -1,0 +1,219 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package client_test
+
+import (
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/resource"
+	"github.com/juju/juju/resource/api"
+	"github.com/juju/juju/resource/api/client"
+)
+
+var _ = gc.Suite(&ListResourcesSuite{})
+
+type ListResourcesSuite struct {
+	BaseSuite
+}
+
+func (s *ListResourcesSuite) TestOkay(c *gc.C) {
+	expected, apiResult := newResourceResult(c, "a-service", "spam")
+	s.facade.apiResults["a-service"] = apiResult
+
+	cl := client.NewClient(s.facade, s.facade)
+
+	services := []string{"a-service"}
+	results, err := cl.ListResources(services)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(results, jc.DeepEquals, [][]resource.Resource{
+		expected,
+	})
+	c.Check(s.stub.Calls(), gc.HasLen, 1)
+	s.stub.CheckCall(c, 0, "FacadeCall",
+		"ListResources",
+		&api.ListResourcesArgs{
+			Entities: []params.Entity{{
+				Tag: "service-a-service",
+			}},
+		},
+		&api.ResourcesResults{
+			Results: []api.ResourcesResult{
+				apiResult,
+			},
+		},
+	)
+}
+
+func (s *ListResourcesSuite) TestBulk(c *gc.C) {
+	expected1, apiResult1 := newResourceResult(c, "a-service", "spam")
+	s.facade.apiResults["a-service"] = apiResult1
+	expected2, apiResult2 := newResourceResult(c, "other-service", "eggs", "ham")
+	s.facade.apiResults["other-service"] = apiResult2
+
+	cl := client.NewClient(s.facade, s.facade)
+
+	services := []string{"a-service", "other-service"}
+	results, err := cl.ListResources(services)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(results, jc.DeepEquals, [][]resource.Resource{
+		expected1,
+		expected2,
+	})
+	c.Check(s.stub.Calls(), gc.HasLen, 1)
+	s.stub.CheckCall(c, 0, "FacadeCall",
+		"ListResources",
+		&api.ListResourcesArgs{
+			Entities: []params.Entity{{
+				Tag: "service-a-service",
+			}, {
+				Tag: "service-other-service",
+			}},
+		},
+		&api.ResourcesResults{
+			Results: []api.ResourcesResult{
+				apiResult1,
+				apiResult2,
+			},
+		},
+	)
+}
+
+func (s *ListResourcesSuite) TestNoServices(c *gc.C) {
+	cl := client.NewClient(s.facade, s.facade)
+
+	var services []string
+	results, err := cl.ListResources(services)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(results, gc.HasLen, 0)
+	s.stub.CheckCallNames(c, "FacadeCall")
+}
+
+func (s *ListResourcesSuite) TestBadServices(c *gc.C) {
+	cl := client.NewClient(s.facade, s.facade)
+
+	services := []string{"???"}
+	_, err := cl.ListResources(services)
+
+	c.Check(err, gc.ErrorMatches, `.*invalid service.*`)
+	s.stub.CheckNoCalls(c)
+}
+
+func (s *ListResourcesSuite) TestServiceNotFound(c *gc.C) {
+	cl := client.NewClient(s.facade, s.facade)
+
+	services := []string{"a-service"}
+	_, err := cl.ListResources(services)
+
+	c.Check(err, jc.Satisfies, errors.IsNotFound)
+	s.stub.CheckCallNames(c, "FacadeCall")
+}
+
+func (s *ListResourcesSuite) TestServiceEmpty(c *gc.C) {
+	s.facade.apiResults["a-service"] = api.ResourcesResult{}
+
+	cl := client.NewClient(s.facade, s.facade)
+
+	services := []string{"a-service"}
+	results, err := cl.ListResources(services)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(results, jc.DeepEquals, [][]resource.Resource{
+		{},
+	})
+	s.stub.CheckCallNames(c, "FacadeCall")
+}
+
+func (s *ListResourcesSuite) TestServerError(c *gc.C) {
+	failure := errors.New("<failure>")
+	s.facade.FacadeCallFn = func(_ string, _, _ interface{}) error {
+		return failure
+	}
+
+	cl := client.NewClient(s.facade, s.facade)
+
+	services := []string{"a-service"}
+	_, err := cl.ListResources(services)
+
+	c.Check(err, gc.ErrorMatches, `<failure>`)
+	s.stub.CheckCallNames(c, "FacadeCall")
+}
+
+func (s *ListResourcesSuite) TestTooFew(c *gc.C) {
+	s.facade.FacadeCallFn = func(_ string, _, response interface{}) error {
+		typedResponse, ok := response.(*api.ResourcesResults)
+		c.Assert(ok, jc.IsTrue)
+
+		typedResponse.Results = []api.ResourcesResult{{
+			Resources: nil,
+		}}
+
+		return nil
+	}
+
+	cl := client.NewClient(s.facade, s.facade)
+
+	services := []string{"a-service", "other-service"}
+	results, err := cl.ListResources(services)
+
+	c.Check(results, gc.HasLen, 0)
+	c.Check(err, gc.ErrorMatches, `.*got invalid data from server \(expected 2 results, got 1\).*`)
+	s.stub.CheckCallNames(c, "FacadeCall")
+}
+
+func (s *ListResourcesSuite) TestTooMany(c *gc.C) {
+	s.facade.FacadeCallFn = func(_ string, _, response interface{}) error {
+		typedResponse, ok := response.(*api.ResourcesResults)
+		c.Assert(ok, jc.IsTrue)
+
+		typedResponse.Results = []api.ResourcesResult{{
+			Resources: nil,
+		}, {
+			Resources: nil,
+		}, {
+			Resources: nil,
+		}}
+
+		return nil
+	}
+
+	cl := client.NewClient(s.facade, s.facade)
+
+	services := []string{"a-service", "other-service"}
+	results, err := cl.ListResources(services)
+
+	c.Check(results, gc.HasLen, 0)
+	c.Check(err, gc.ErrorMatches, `.*got invalid data from server \(expected 2 results, got 3\).*`)
+	s.stub.CheckCallNames(c, "FacadeCall")
+}
+
+func (s *ListResourcesSuite) TestConversionFailed(c *gc.C) {
+	s.facade.FacadeCallFn = func(_ string, _, response interface{}) error {
+		typedResponse, ok := response.(*api.ResourcesResults)
+		c.Assert(ok, jc.IsTrue)
+
+		var res api.Resource
+		res.Name = "spam"
+		typedResponse.Results = []api.ResourcesResult{{
+			Resources: []api.Resource{
+				res,
+			},
+		}}
+
+		return nil
+	}
+
+	cl := client.NewClient(s.facade, s.facade)
+
+	services := []string{"a-service"}
+	_, err := cl.ListResources(services)
+
+	c.Check(err, gc.ErrorMatches, `.*got bad data.*`)
+	s.stub.CheckCallNames(c, "FacadeCall")
+}

--- a/resource/api/data.go
+++ b/resource/api/data.go
@@ -52,9 +52,7 @@ type ResourcesResult struct {
 // NewResourcesResult produces a ResourcesResult for the given service
 // tag. The corresponding service ID is also returned. If any error
 // results, it is stored in the Error field of the result.
-func NewResourcesResult(tagStr string) (ResourcesResult, string) {
-	var result ResourcesResult
-
+func NewResourcesResult(tagStr string) (result ResourcesResult, serviceID string) {
 	serviceID, err := ServiceTag2ID(tagStr)
 	if err != nil {
 		result.Error = &params.Error{

--- a/resource/api/data.go
+++ b/resource/api/data.go
@@ -3,13 +3,81 @@
 
 package api
 
+// TODO(ericsnow) Eliminate the dependence on apiserver if possible.
+
 import (
 	"time"
+
+	"github.com/juju/errors"
+	"github.com/juju/names"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/params"
 )
+
+// ListResourcesArgs are the arguments for the ListResources endpoint.
+type ListResourcesArgs params.Entities
+
+// NewListResourcesArgs returns the arguments for the ListResources endpoint.
+func NewListResourcesArgs(services ...string) (ListResourcesArgs, error) {
+	var args ListResourcesArgs
+	for _, service := range services {
+		if !names.IsValidService(service) {
+			return args, errors.Errorf("invalid service %q", service)
+		}
+
+		args.Entities = append(args.Entities, params.Entity{
+			Tag: names.NewServiceTag(service).String(),
+		})
+	}
+	return args, nil
+}
+
+// ResourcesResults holds the resources that result
+// from a bulk API call.
+type ResourcesResults struct {
+	// Results is the list of resource results.
+	Results []ResourcesResult
+}
+
+// ResourcesResult holds the resources that result from an API call
+// for a single service.
+type ResourcesResult struct {
+	params.ErrorResult
+
+	// Resources is the list of resources for the service.
+	Resources []Resource
+}
+
+// NewResourcesResult produces a ResourcesResult for the given service
+// tag. The corresponding service ID is also returned. If any error
+// results, it is stored in the Error field of the result.
+func NewResourcesResult(tagStr string) (ResourcesResult, string) {
+	var result ResourcesResult
+
+	serviceID, err := ServiceTag2ID(tagStr)
+	if err != nil {
+		result.Error = &params.Error{
+			Message: err.Error(),
+			Code:    params.CodeBadRequest,
+		}
+		return result, ""
+	}
+
+	return result, serviceID
+}
+
+// SetResultError sets the error on the result.
+func SetResultError(result *ResourcesResult, err error) {
+	result.Error = common.ServerError(err)
+}
 
 // Resource contains info about a Resource.
 type Resource struct {
 	CharmResource
+
+	// Charm identifies the resource's charm.
+	Charm names.CharmTag
 
 	// Username is the ID of the user that added the revision
 	// to the model (whether implicitly or explicitly).

--- a/resource/api/data.go
+++ b/resource/api/data.go
@@ -74,9 +74,6 @@ func SetResultError(result *ResourcesResult, err error) {
 type Resource struct {
 	CharmResource
 
-	// Charm identifies the resource's charm.
-	Charm names.CharmTag
-
 	// Username is the ID of the user that added the revision
 	// to the model (whether implicitly or explicitly).
 	Username string `json:"username"`

--- a/resource/api/data.go
+++ b/resource/api/data.go
@@ -19,7 +19,7 @@ import (
 type ListResourcesArgs params.Entities
 
 // NewListResourcesArgs returns the arguments for the ListResources endpoint.
-func NewListResourcesArgs(services ...string) (ListResourcesArgs, error) {
+func NewListResourcesArgs(services []string) (ListResourcesArgs, error) {
 	var args ListResourcesArgs
 	for _, service := range services {
 		if !names.IsValidService(service) {

--- a/resource/api/helpers_test.go
+++ b/resource/api/helpers_test.go
@@ -6,11 +6,13 @@ package api_test
 import (
 	"time"
 
+	"github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	charmresource "gopkg.in/juju/charm.v6-unstable/resource"
 
+	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/resource"
 	"github.com/juju/juju/resource/api"
 )
@@ -65,6 +67,108 @@ func (helpersSuite) TestResource2API(c *gc.C) {
 		Username:  "a-user",
 		Timestamp: now,
 	})
+}
+
+func (helpersSuite) TestAPIResult2ResourcesOkay(c *gc.C) {
+	fp, err := charmresource.NewFingerprint([]byte(fingerprint))
+	c.Assert(err, jc.ErrorIsNil)
+	now := time.Now()
+	expected := resource.Resource{
+		Resource: charmresource.Resource{
+			Meta: charmresource.Meta{
+				Name:    "spam",
+				Type:    charmresource.TypeFile,
+				Path:    "spam.tgz",
+				Comment: "you need it",
+			},
+			Origin:      charmresource.OriginUpload,
+			Revision:    1,
+			Fingerprint: fp,
+		},
+		Username:  "a-user",
+		Timestamp: now,
+	}
+	err = expected.Validate()
+	c.Assert(err, jc.ErrorIsNil)
+	apiRes := api.Resource{
+		CharmResource: api.CharmResource{
+			Name:        "spam",
+			Type:        "file",
+			Path:        "spam.tgz",
+			Comment:     "you need it",
+			Origin:      "upload",
+			Revision:    1,
+			Fingerprint: []byte(fingerprint),
+		},
+		Username:  "a-user",
+		Timestamp: now,
+	}
+
+	resources, err := api.APIResult2Resources(api.ResourcesResult{
+		Resources: []api.Resource{
+			apiRes,
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(resources, jc.DeepEquals, []resource.Resource{
+		expected,
+	})
+}
+
+func (helpersSuite) TestAPIResult2ResourcesFailure(c *gc.C) {
+	apiRes := api.Resource{
+		CharmResource: api.CharmResource{
+			Name:        "spam",
+			Type:        "file",
+			Path:        "spam.tgz",
+			Origin:      "upload",
+			Revision:    1,
+			Fingerprint: []byte(fingerprint),
+		},
+	}
+	failure := errors.New("<failure>")
+
+	_, err := api.APIResult2Resources(api.ResourcesResult{
+		ErrorResult: params.ErrorResult{
+			Error: &params.Error{
+				Message: failure.Error(),
+			},
+		},
+		Resources: []api.Resource{
+			apiRes,
+		},
+	})
+
+	c.Check(err, gc.ErrorMatches, "<failure>")
+	c.Check(errors.Cause(err), gc.Not(gc.Equals), failure)
+}
+
+func (helpersSuite) TestAPIResult2ResourcesNotFound(c *gc.C) {
+	apiRes := api.Resource{
+		CharmResource: api.CharmResource{
+			Name:        "spam",
+			Type:        "file",
+			Path:        "spam.tgz",
+			Origin:      "upload",
+			Revision:    1,
+			Fingerprint: []byte(fingerprint),
+		},
+	}
+
+	_, err := api.APIResult2Resources(api.ResourcesResult{
+		ErrorResult: params.ErrorResult{
+			Error: &params.Error{
+				Message: `service "a-service" not found`,
+				Code:    params.CodeNotFound,
+			},
+		},
+		Resources: []api.Resource{
+			apiRes,
+		},
+	})
+
+	c.Check(err, jc.Satisfies, errors.IsNotFound)
 }
 
 func (helpersSuite) TestAPI2Resource(c *gc.C) {

--- a/resource/api/server/base_test.go
+++ b/resource/api/server/base_test.go
@@ -1,0 +1,86 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package server_test
+
+import (
+	"time"
+
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	charmresource "gopkg.in/juju/charm.v6-unstable/resource"
+
+	"github.com/juju/juju/resource"
+	"github.com/juju/juju/resource/api"
+)
+
+type BaseSuite struct {
+	testing.IsolationSuite
+
+	stub *testing.Stub
+	data *stubDataStore
+}
+
+func (s *BaseSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+
+	s.stub = &testing.Stub{}
+	s.data = &stubDataStore{stub: s.stub}
+}
+
+func newResource(c *gc.C, name, username, data string) (resource.Resource, api.Resource) {
+	fp, err := charmresource.GenerateFingerprint([]byte(data))
+	c.Assert(err, jc.ErrorIsNil)
+	var now time.Time
+	if username != "" {
+		now = time.Now()
+	}
+	res := resource.Resource{
+		Resource: charmresource.Resource{
+			Meta: charmresource.Meta{
+				Name: name,
+				Type: charmresource.TypeFile,
+				Path: name + ".tgz",
+			},
+			Origin:      charmresource.OriginUpload,
+			Revision:    1,
+			Fingerprint: fp,
+		},
+		Username:  username,
+		Timestamp: now,
+	}
+	err = res.Validate()
+	c.Assert(err, jc.ErrorIsNil)
+
+	apiRes := api.Resource{
+		CharmResource: api.CharmResource{
+			Name:        name,
+			Type:        "file",
+			Path:        name + ".tgz",
+			Origin:      "upload",
+			Revision:    1,
+			Fingerprint: fp.Bytes(),
+		},
+		Username:  username,
+		Timestamp: now,
+	}
+
+	return res, apiRes
+}
+
+type stubDataStore struct {
+	stub *testing.Stub
+
+	ReturnListResources []resource.Resource
+}
+
+func (s *stubDataStore) ListResources(service string) ([]resource.Resource, error) {
+	s.stub.AddCall("ListResources", service)
+	if err := s.stub.NextErr(); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	return s.ReturnListResources, nil
+}

--- a/resource/api/server/server.go
+++ b/resource/api/server/server.go
@@ -5,6 +5,9 @@ package server
 
 import (
 	"github.com/juju/loggo"
+
+	"github.com/juju/juju/resource"
+	"github.com/juju/juju/resource/api"
 )
 
 var logger = loggo.GetLogger("juju.resource.api.server")
@@ -14,17 +17,53 @@ const Version = 1
 
 // DataStore is the functionality of Juju's state needed for the resources API.
 type DataStore interface {
-	// Add the sub-dependencies here.
+	resourceLister
 }
 
 // Facade is the public API facade for resources.
 type Facade struct {
-	// Add sub-facades here.
+	// lister is the data source for the ListResources endpoint.
+	lister resourceLister
 }
 
 // NewFacade returns a new resoures facade for the given Juju state.
 func NewFacade(data DataStore) *Facade {
 	return &Facade{
-	// Add sub-facades here.
+		lister: data,
 	}
+}
+
+// resourceLister is the portion of Juju's "state" needed
+// for the ListResources endpoint.
+type resourceLister interface {
+	// ListResources returns the resources for the given service.
+	ListResources(service string) ([]resource.Resource, error)
+}
+
+// ListResources returns the list of resources for the given service.
+func (f Facade) ListResources(args api.ListResourcesArgs) (api.ResourcesResults, error) {
+	var r api.ResourcesResults
+	r.Results = make([]api.ResourcesResult, len(args.Entities))
+
+	for i, e := range args.Entities {
+		result, service := api.NewResourcesResult(e.Tag)
+		r.Results[i] = result
+		if result.Error != nil {
+			continue
+		}
+
+		resources, err := f.lister.ListResources(service)
+		if err != nil {
+			api.SetResultError(&r.Results[i], err)
+			continue
+		}
+
+		var apiResources []api.Resource
+		for _, res := range resources {
+			apiRes := api.Resource2API(res)
+			apiResources = append(apiResources, apiRes)
+		}
+		r.Results[i].Resources = apiResources
+	}
+	return r, nil
 }

--- a/resource/api/server/server_listresources_test.go
+++ b/resource/api/server/server_listresources_test.go
@@ -1,0 +1,89 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package server_test
+
+import (
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/resource"
+	"github.com/juju/juju/resource/api"
+	"github.com/juju/juju/resource/api/server"
+)
+
+var _ = gc.Suite(&ListResourcesSuite{})
+
+type ListResourcesSuite struct {
+	BaseSuite
+}
+
+func (s *ListResourcesSuite) TestOkay(c *gc.C) {
+	res1, apiRes1 := newResource(c, "spam", "a-user", "spamspamspam")
+	res2, apiRes2 := newResource(c, "eggs", "a-user", "...")
+	s.data.ReturnListResources = []resource.Resource{
+		res1,
+		res2,
+	}
+	facade := server.NewFacade(s.data)
+
+	results, err := facade.ListResources(api.ListResourcesArgs{
+		Entities: []params.Entity{{
+			Tag: "service-a-service",
+		}},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(results, jc.DeepEquals, api.ResourcesResults{
+		Results: []api.ResourcesResult{{
+			Resources: []api.Resource{
+				apiRes1,
+				apiRes2,
+			},
+		}},
+	})
+	s.stub.CheckCallNames(c, "ListResources")
+	s.stub.CheckCall(c, 0, "ListResources", "a-service")
+}
+
+func (s *ListResourcesSuite) TestEmpty(c *gc.C) {
+	facade := server.NewFacade(s.data)
+
+	results, err := facade.ListResources(api.ListResourcesArgs{
+		Entities: []params.Entity{{
+			Tag: "service-a-service",
+		}},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(results, jc.DeepEquals, api.ResourcesResults{
+		Results: []api.ResourcesResult{{
+			Resources: nil,
+		}},
+	})
+	s.stub.CheckCallNames(c, "ListResources")
+}
+
+func (s *ListResourcesSuite) TestError(c *gc.C) {
+	failure := errors.New("<failure>")
+	s.stub.SetErrors(failure)
+	facade := server.NewFacade(s.data)
+
+	results, err := facade.ListResources(api.ListResourcesArgs{
+		Entities: []params.Entity{{
+			Tag: "service-a-service",
+		}},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(results, jc.DeepEquals, api.ResourcesResults{
+		Results: []api.ResourcesResult{{
+			ErrorResult: params.ErrorResult{Error: &params.Error{
+				Message: "<failure>",
+			}},
+		}},
+	})
+	s.stub.CheckCallNames(c, "ListResources")
+}

--- a/resource/resource.go
+++ b/resource/resource.go
@@ -30,12 +30,12 @@ func (res Resource) Validate() error {
 		return errors.Annotate(err, "bad info")
 	}
 
-	if len(res.Username) == 0 {
-		return errors.NewNotValid(nil, "missing username")
-	}
+	// TODO(ericsnow) Require that Username be set if timestamp is?
 
 	if res.Timestamp.IsZero() {
-		return errors.NewNotValid(nil, "missing timestamp")
+		if res.Username != "" {
+			return errors.NewNotValid(nil, "missing timestamp")
+		}
 	}
 
 	return nil

--- a/resource/resource.go
+++ b/resource/resource.go
@@ -32,10 +32,8 @@ func (res Resource) Validate() error {
 
 	// TODO(ericsnow) Require that Username be set if timestamp is?
 
-	if res.Timestamp.IsZero() {
-		if res.Username != "" {
-			return errors.NewNotValid(nil, "missing timestamp")
-		}
+	if res.Timestamp.IsZero() && res.Username != "" {
+		return errors.NewNotValid(nil, "missing timestamp")
 	}
 
 	return nil

--- a/resource/resource_test.go
+++ b/resource/resource_test.go
@@ -21,11 +21,21 @@ type ResourceSuite struct {
 
 var _ = gc.Suite(&ResourceSuite{})
 
-func (ResourceSuite) TestValidateUploadFull(c *gc.C) {
+func (ResourceSuite) TestValidateUploadUsed(c *gc.C) {
 	res := resource.Resource{
 		Resource:  newFullCharmResource(c, "spam"),
 		Username:  "a-user",
 		Timestamp: time.Now(),
+	}
+
+	err := res.Validate()
+
+	c.Check(err, jc.ErrorIsNil)
+}
+
+func (ResourceSuite) TestValidateUploadNotUsed(c *gc.C) {
+	res := resource.Resource{
+		Resource: newFullCharmResource(c, "spam"),
 	}
 
 	err := res.Validate()
@@ -39,6 +49,7 @@ func (ResourceSuite) TestValidateZeroValue(c *gc.C) {
 	err := res.Validate()
 
 	c.Check(errors.Cause(err), jc.Satisfies, errors.IsNotValid)
+	c.Check(err, gc.ErrorMatches, `.*bad info.*`)
 }
 
 func (ResourceSuite) TestValidateBadInfo(c *gc.C) {
@@ -46,9 +57,7 @@ func (ResourceSuite) TestValidateBadInfo(c *gc.C) {
 	c.Assert(charmRes.Validate(), gc.NotNil)
 
 	res := resource.Resource{
-		Resource:  charmRes,
-		Username:  "a-user",
-		Timestamp: time.Now(),
+		Resource: charmRes,
 	}
 
 	err := res.Validate()
@@ -57,7 +66,7 @@ func (ResourceSuite) TestValidateBadInfo(c *gc.C) {
 	c.Check(err, gc.ErrorMatches, `.*bad info.*`)
 }
 
-func (ResourceSuite) TestValidateBadUsername(c *gc.C) {
+func (ResourceSuite) TestValidateMissingUsername(c *gc.C) {
 	res := resource.Resource{
 		Resource:  newFullCharmResource(c, "spam"),
 		Username:  "",
@@ -66,11 +75,10 @@ func (ResourceSuite) TestValidateBadUsername(c *gc.C) {
 
 	err := res.Validate()
 
-	c.Check(errors.Cause(err), jc.Satisfies, errors.IsNotValid)
-	c.Check(err, gc.ErrorMatches, `.*missing username.*`)
+	c.Check(err, jc.ErrorIsNil)
 }
 
-func (ResourceSuite) TestValidateBadTimestamp(c *gc.C) {
+func (ResourceSuite) TestValidateMissingTimestamp(c *gc.C) {
 	res := resource.Resource{
 		Resource:  newFullCharmResource(c, "spam"),
 		Username:  "a-user",


### PR DESCRIPTION
For the most part this patch simply resurrects the old ListSpecs endpoint.

(Review request: http://reviews.vapour.ws/r/3444/)