### PR TITLE
Add find-endpoints command

### DIFF
--- a/api/crossmodel/client.go
+++ b/api/crossmodel/client.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/model/crossmodel"
+	"github.com/juju/names"
 )
 
 // Client allows access to the cross model management API end points.
@@ -61,6 +62,63 @@ func (c *Client) ServiceOffer(url string) (params.ServiceOffer, error) {
 		return params.ServiceOffer{}, errors.Trace(theOne.Error)
 	}
 	return theOne.Result, nil
+}
+
+// FindServiceOffers returns all service offers matching the supplied filter.
+func (c *Client) FindServiceOffers(filters ...crossmodel.ServiceOfferFilter) ([]params.ServiceOffer, error) {
+	// We need at least one filter. The default filter will list all local services.
+	if len(filters) == 0 {
+		filters = []crossmodel.ServiceOfferFilter{{ServiceOffer: crossmodel.ServiceOffer{ServiceURL: "local:"}}}
+	}
+	var paramsFilter params.OfferFilterParams
+	for _, f := range filters {
+		urlParts, err := crossmodel.ParseServiceURLParts(f.ServiceURL)
+		if err != nil {
+			return nil, err
+		}
+		if urlParts.Directory == "" {
+			return nil, errors.Errorf("service offer filter needs a directory: %#v", f)
+		}
+		// TODO(wallyworld) - include allowed users
+		filterTerm := params.OfferFilter{
+			ServiceURL:         f.ServiceURL,
+			ServiceName:        f.ServiceName,
+			ServiceDescription: f.ServiceDescription,
+			SourceLabel:        f.SourceLabel,
+		}
+		if f.SourceEnvUUID != "" {
+			filterTerm.SourceEnvUUIDTag = names.NewEnvironTag(f.SourceEnvUUID).String()
+		}
+		filterTerm.Endpoints = make([]params.EndpointFilterAttributes, len(f.Endpoints))
+		for i, ep := range f.Endpoints {
+			filterTerm.Endpoints[i].Name = ep.Name
+			filterTerm.Endpoints[i].Interface = ep.Interface
+			filterTerm.Endpoints[i].Role = ep.Role
+		}
+		paramsFilter.Filters = append(paramsFilter.Filters, params.OfferFilters{
+			Directory: urlParts.Directory,
+			Filters:   []params.OfferFilter{filterTerm},
+		})
+	}
+
+	out := params.FindServiceOffersResults{}
+	err := c.facade.FacadeCall("FindServiceOffers", paramsFilter, &out)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	result := out.Results
+	// Since only one filters set was sent, expecting only one back
+	if len(result) != 1 {
+		return nil, errors.Errorf("expected to find one result but found %d", len(result))
+
+	}
+
+	theOne := result[0]
+	if theOne.Error != nil {
+		return nil, errors.Trace(theOne.Error)
+	}
+	return theOne.Offers, nil
 }
 
 // ListOffers gets all remote services that have been offered from this Juju model.

--- a/api/crossmodel/client.go
+++ b/api/crossmodel/client.go
@@ -68,7 +68,7 @@ func (c *Client) ServiceOffer(url string) (params.ServiceOffer, error) {
 func (c *Client) FindServiceOffers(filters ...crossmodel.ServiceOfferFilter) ([]params.ServiceOffer, error) {
 	// We need at least one filter. The default filter will list all local services.
 	if len(filters) == 0 {
-		filters = []crossmodel.ServiceOfferFilter{{ServiceOffer: crossmodel.ServiceOffer{ServiceURL: "local:"}}}
+		return nil, errors.New("at least one filter must be specified")
 	}
 	var paramsFilter params.OfferFilterParams
 	for _, f := range filters {

--- a/api/crossmodel/client.go
+++ b/api/crossmodel/client.go
@@ -5,12 +5,12 @@ package crossmodel
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/names"
 	"gopkg.in/juju/charm.v6-unstable"
 
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/model/crossmodel"
-	"github.com/juju/names"
 )
 
 // Client allows access to the cross model management API end points.

--- a/api/crossmodel/client_test.go
+++ b/api/crossmodel/client_test.go
@@ -395,3 +395,176 @@ func (s *crossmodelMockSuite) TestListFacadeCallError(c *gc.C) {
 	c.Assert(errors.Cause(err), gc.ErrorMatches, msg)
 	c.Assert(results, gc.IsNil)
 }
+
+func (s *crossmodelMockSuite) TestFind(c *gc.C) {
+	directoryName := "local"
+	charmName := "db2"
+	serviceName := fmt.Sprintf("hosted-%s", charmName)
+	url := fmt.Sprintf("%s:/u/fred/%s", directoryName, serviceName)
+	endpoints := []params.RemoteEndpoint{{Name: "endPointA"}}
+	relations := []charm.Relation{{Name: "endPointA", Interface: "http"}}
+
+	filter := model.ServiceOfferFilter{
+		ServiceOffer: model.ServiceOffer{
+			ServiceURL:  fmt.Sprintf("%s:/u/fred/%s", directoryName, serviceName),
+			ServiceName: fmt.Sprintf("hosted-%s", charmName),
+			Endpoints:   relations,
+		},
+	}
+
+	called := false
+	apiCaller := basetesting.APICallerFunc(
+		func(objType string,
+			version int,
+			id, request string,
+			a, result interface{},
+		) error {
+			c.Check(objType, gc.Equals, "CrossModelRelations")
+			c.Check(id, gc.Equals, "")
+			c.Check(request, gc.Equals, "FindServiceOffers")
+
+			called = true
+			args, ok := a.(params.OfferFilterParams)
+			c.Assert(ok, jc.IsTrue)
+			c.Assert(args.Filters, gc.HasLen, 1)
+			c.Assert(args.Filters[0].Directory, gc.Equals, "local")
+			c.Assert(args.Filters[0].Filters, jc.DeepEquals, []params.OfferFilter{{
+				ServiceURL:  filter.ServiceURL,
+				ServiceName: filter.ServiceName,
+				Endpoints: []params.EndpointFilterAttributes{{
+					Name:      "endPointA",
+					Interface: "http",
+				}},
+			}})
+
+			if results, ok := result.(*params.FindServiceOffersResults); ok {
+				offer := params.ServiceOffer{
+					ServiceURL:  url,
+					ServiceName: serviceName,
+					Endpoints:   endpoints,
+				}
+				results.Results = []params.ServiceOfferResults{{
+					Offers: []params.ServiceOffer{offer},
+				}}
+			}
+
+			return nil
+		})
+
+	client := crossmodel.NewClient(apiCaller)
+	results, err := client.FindServiceOffers(filter)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(called, jc.IsTrue)
+	c.Assert(results, jc.DeepEquals, []params.ServiceOffer{{
+		ServiceName: serviceName,
+		ServiceURL:  url,
+		Endpoints:   endpoints,
+	}})
+}
+
+func (s *crossmodelMockSuite) TestFindDefaultFilter(c *gc.C) {
+	called := false
+	apiCaller := basetesting.APICallerFunc(
+		func(objType string,
+			version int,
+			id, request string,
+			a, result interface{},
+		) error {
+			c.Check(objType, gc.Equals, "CrossModelRelations")
+			c.Check(id, gc.Equals, "")
+			c.Check(request, gc.Equals, "FindServiceOffers")
+
+			called = true
+			args, ok := a.(params.OfferFilterParams)
+			c.Assert(ok, jc.IsTrue)
+			c.Assert(args.Filters, gc.HasLen, 1)
+			c.Assert(args.Filters[0].Directory, gc.Equals, "local")
+			c.Assert(args.Filters[0].Filters, jc.DeepEquals, []params.OfferFilter{{ServiceURL: "local:"}})
+			if results, ok := result.(*params.FindServiceOffersResults); ok {
+				results.Results = []params.ServiceOfferResults{{
+					Offers: []params.ServiceOffer{},
+				}}
+			}
+			return nil
+		})
+
+	client := crossmodel.NewClient(apiCaller)
+	_, err := client.FindServiceOffers()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(called, jc.IsTrue)
+}
+
+func (s *crossmodelMockSuite) TestFindMultipleResults(c *gc.C) {
+	called := false
+	apiCaller := basetesting.APICallerFunc(
+		func(objType string,
+			version int,
+			id, request string,
+			a, result interface{},
+		) error {
+			c.Check(objType, gc.Equals, "CrossModelRelations")
+			c.Check(id, gc.Equals, "")
+			c.Check(request, gc.Equals, "FindServiceOffers")
+
+			called = true
+			if results, ok := result.(*params.FindServiceOffersResults); ok {
+				results.Results = []params.ServiceOfferResults{{}, {}}
+			}
+
+			return nil
+		})
+
+	client := crossmodel.NewClient(apiCaller)
+	_, err := client.FindServiceOffers()
+	c.Assert(errors.Cause(err), gc.ErrorMatches, ".*expected to find one result but found 2.*")
+	c.Assert(called, jc.IsTrue)
+}
+
+func (s *crossmodelMockSuite) TestFindError(c *gc.C) {
+	msg := "find failure"
+	called := false
+	apiCaller := basetesting.APICallerFunc(
+		func(objType string,
+			version int,
+			id, request string,
+			a, result interface{},
+		) error {
+			c.Check(objType, gc.Equals, "CrossModelRelations")
+			c.Check(id, gc.Equals, "")
+			c.Check(request, gc.Equals, "FindServiceOffers")
+
+			called = true
+			if results, ok := result.(*params.FindServiceOffersResults); ok {
+				results.Results = []params.ServiceOfferResults{{
+					Error: common.ServerError(errors.New(msg)),
+				}}
+			}
+
+			return nil
+		})
+
+	client := crossmodel.NewClient(apiCaller)
+	_, err := client.FindServiceOffers()
+	c.Assert(errors.Cause(err), gc.ErrorMatches, msg)
+	c.Assert(called, jc.IsTrue)
+}
+
+func (s *crossmodelMockSuite) TestFindFacadeCallError(c *gc.C) {
+	msg := "facade failure"
+	apiCaller := basetesting.APICallerFunc(
+		func(objType string,
+			version int,
+			id, request string,
+			a, result interface{},
+		) error {
+			c.Check(objType, gc.Equals, "CrossModelRelations")
+			c.Check(id, gc.Equals, "")
+			c.Check(request, gc.Equals, "FindServiceOffers")
+
+			return errors.New(msg)
+		})
+	client := crossmodel.NewClient(apiCaller)
+	results, err := client.FindServiceOffers()
+	c.Assert(errors.Cause(err), gc.ErrorMatches, msg)
+	c.Assert(results, gc.IsNil)
+}

--- a/api/crossmodel/servicedirectory.go
+++ b/api/crossmodel/servicedirectory.go
@@ -105,6 +105,7 @@ func (s *serviceOffersAPI) ListOffers(directory string, filters ...crossmodel.Se
 		eps := make([]params.EndpointFilterAttributes, len(filter.Endpoints))
 		for j, ep := range filter.Endpoints {
 			eps[j] = params.EndpointFilterAttributes{
+				Name:      ep.Name,
 				Interface: ep.Interface,
 				Role:      ep.Role,
 			}

--- a/apiserver/crossmodel/crossmodel.go
+++ b/apiserver/crossmodel/crossmodel.go
@@ -215,6 +215,25 @@ func (api *API) ServiceOffers(filter params.ServiceURLs) (params.ServiceOffersRe
 	return params.ServiceOffersResults{results}, nil
 }
 
+// FindServiceOffers gets details about remote services that match given filter.
+func (api *API) FindServiceOffers(filters params.OfferFilterParams) (params.FindServiceOffersResults, error) {
+	var result params.FindServiceOffersResults
+	result.Results = make([]params.ServiceOfferResults, len(filters.Filters))
+
+	for i, filter := range filters.Filters {
+		offers, err := api.backend.ListDirectoryOffers(filter)
+		if err == nil && offers.Error != nil {
+			err = offers.Error
+		}
+		if err != nil {
+			result.Results[i].Error = common.ServerError(err)
+			continue
+		}
+		result.Results[i] = offers
+	}
+	return result, nil
+}
+
 // ListOffers gets all remote services that have been offered from this Juju model.
 // Each returned service satisfies at least one of the the specified filters.
 func (api *API) ListOffers(args params.OfferedServiceFilters) (params.ListOffersResults, error) {

--- a/apiserver/crossmodel/servicedirectory.go
+++ b/apiserver/crossmodel/servicedirectory.go
@@ -137,6 +137,7 @@ func makeOfferFilterFromParams(filters []params.OfferFilter) ([]crossmodel.Servi
 			}
 			offerFilters[i].SourceEnvUUID = envTag.Id()
 		}
+		// TODO(wallyworld) - add support for Endpoint filter attribute
 	}
 	return offerFilters, nil
 }

--- a/apiserver/params/crossmodel.go
+++ b/apiserver/params/crossmodel.go
@@ -7,11 +7,18 @@ import (
 	"gopkg.in/juju/charm.v6-unstable"
 )
 
+// OfferFilterParams contains filters used to query service offers
+// from one or more directories.
+type OfferFilterParams struct {
+	Filters []OfferFilters `json:"filters"`
+}
+
 // EndpointFilterAttributes is used to filter offers matching the
 // specified endpoint criteria.
 type EndpointFilterAttributes struct {
 	Role      charm.RelationRole `json:"role"`
 	Interface string             `json:"interface"`
+	Name      string             `json:"name"`
 }
 
 // OfferFilters is used to query offers in a service directory.
@@ -93,6 +100,12 @@ type ServiceOfferParams struct {
 // ServiceOffersParams contains a collection of offers to allow adding offers in bulk.
 type ServiceOffersParams struct {
 	Offers []ServiceOfferParams `json:"offers"`
+}
+
+// FindServiceOffersResults is a result of finding remote service offers.
+type FindServiceOffersResults struct {
+	// Results contains service offers matching each filter.
+	Results []ServiceOfferResults `json:"results"`
 }
 
 // ServiceOfferResult is a result of listing a remote service offer.

--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -130,6 +130,7 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 	r.Register(crossmodel.NewOfferCommand())
 	r.Register(crossmodel.NewShowOfferedEndpointCommand())
 	r.Register(crossmodel.NewListEndpointsCommand())
+	r.Register(crossmodel.NewFindEndpointsCommand())
 
 	// Destruction commands.
 	r.Register(newRemoveRelationCommand())

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -62,6 +62,10 @@ func showEndpointsHelpText() string {
 	return cmdtesting.HelpText(crossmodel.NewShowOfferedEndpointCommand(), "juju show-endpoints")
 }
 
+func findEndpointsHelpText() string {
+	return cmdtesting.HelpText(crossmodel.NewFindEndpointCommand(), "juju find-endpoints")
+}
+
 func (s *MainSuite) TestRunMain(c *gc.C) {
 	// The test array structure needs to be inline here as some of the
 	// expected values below use deployHelpText().  This constructs the deploy
@@ -194,6 +198,16 @@ func (s *MainSuite) TestRunMain(c *gc.C) {
 		code:    0,
 		out:     "error: must specify endpoint URL\n",
 	}, {
+		summary: "check find-endpoints command has help",
+		args:    []string{"find-endpoints", "-h"},
+		code:    0,
+		out:     showEndpointsHelpText(),
+	}, {
+		summary: "check find-endpoints command registered properly",
+		args:    []string{"find-endpoints"},
+		code:    0,
+		out:     "error: must specify at the minimum a URL fragment\n",
+	}, {
 		summary: "check list-offers command registered properly",
 		args:    []string{"list-offers"},
 		code:    0,
@@ -255,6 +269,7 @@ var commandNames = []string{
 	"env", // alias for switch
 	"environment",
 	"expose",
+	"find-endpoints",
 	"generate-config", // alias for init
 	"get",
 	"get-constraints",

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -63,7 +63,7 @@ func showEndpointsHelpText() string {
 }
 
 func findEndpointsHelpText() string {
-	return cmdtesting.HelpText(crossmodel.NewFindEndpointCommand(), "juju find-endpoints")
+	return cmdtesting.HelpText(crossmodel.NewFindEndpointsCommand(), "juju find-endpoints")
 }
 
 func (s *MainSuite) TestRunMain(c *gc.C) {
@@ -201,12 +201,12 @@ func (s *MainSuite) TestRunMain(c *gc.C) {
 		summary: "check find-endpoints command has help",
 		args:    []string{"find-endpoints", "-h"},
 		code:    0,
-		out:     showEndpointsHelpText(),
+		out:     findEndpointsHelpText(),
 	}, {
 		summary: "check find-endpoints command registered properly",
 		args:    []string{"find-endpoints"},
 		code:    0,
-		out:     "error: must specify at the minimum a URL fragment\n",
+		out:     "ERROR environment is not prepared\n",
 	}, {
 		summary: "check list-offers command registered properly",
 		args:    []string{"list-offers"},

--- a/cmd/juju/crossmodel/export_test.go
+++ b/cmd/juju/crossmodel/export_test.go
@@ -37,3 +37,10 @@ func NewListEndpointsCommandForTest(api ListAPI) cmd.Command {
 	}}
 	return envcmd.Wrap(aCmd)
 }
+
+func NewFindEndpointsCommandForTest(api FindAPI) cmd.Command {
+	aCmd := &findCommand{newAPIFunc: func() (FindAPI, error) {
+		return api, nil
+	}}
+	return envcmd.Wrap(aCmd)
+}

--- a/cmd/juju/crossmodel/find.go
+++ b/cmd/juju/crossmodel/find.go
@@ -4,12 +4,13 @@
 package crossmodel
 
 import (
+	"fmt"
+
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"gopkg.in/juju/charm.v6-unstable"
 	"launchpad.net/gnuflag"
 
-	"fmt"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/envcmd"
 	"github.com/juju/juju/model/crossmodel"

--- a/cmd/juju/crossmodel/find.go
+++ b/cmd/juju/crossmodel/find.go
@@ -1,0 +1,170 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package crossmodel
+
+import (
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+	"gopkg.in/juju/charm.v6-unstable"
+	"launchpad.net/gnuflag"
+
+	"fmt"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/envcmd"
+	"github.com/juju/juju/model/crossmodel"
+)
+
+const findCommandDoc = `
+Find which offered service endpoints are available to the current user.
+
+This command is aimed for a user who wants to discover what endpoints are available to them.
+
+options:
+-o, --output (= "")
+   specify an output file
+--format (= tabular)
+   specify output format (tabular|json|yaml)
+
+Examples:
+   $ juju find-endpoints local:
+   $ juju find-endpoints local:/u/fred
+   $ juju find-endpoints --interface mysql --url local:
+   $ juju find-endpoints --charm db2 --url vendor:/u/ibm
+   $ juju find-endpoints --charm db2 --author ibm
+`
+
+type findCommand struct {
+	CrossModelCommandBase
+
+	url           string
+	interfaceName string
+	endpoint      string
+	user          string
+	charm         string
+	author        string
+
+	out        cmd.Output
+	newAPIFunc func() (FindAPI, error)
+}
+
+// NewFindEndpointsCommand constructs command that
+// allows to find offered service endpoints.
+func NewFindEndpointsCommand() cmd.Command {
+	findCmd := &findCommand{}
+	findCmd.newAPIFunc = func() (FindAPI, error) {
+		return findCmd.NewCrossModelAPI()
+	}
+	return envcmd.Wrap(findCmd)
+}
+
+// Init implements Command.Init.
+func (c *findCommand) Init(args []string) (err error) {
+	if len(args) > 1 {
+		return errors.Errorf("unrecognized args: %q", args[1:])
+	}
+
+	if len(args) == 1 {
+		if c.url != "" {
+			return errors.New("URL term cannot be specified twice")
+		}
+		c.url = args[0]
+	}
+	if c.url != "" {
+		if _, err := crossmodel.ParseServiceURLParts(c.url); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Info implements Command.Info.
+func (c *findCommand) Info() *cmd.Info {
+	return &cmd.Info{
+		Name:    "find-endpoints",
+		Purpose: "find offered service endpoints",
+		Doc:     findCommandDoc,
+	}
+}
+
+// SetFlags implements Command.SetFlags.
+func (c *findCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.CrossModelCommandBase.SetFlags(f)
+	f.StringVar(&c.url, "url", "", "service URL")
+	f.StringVar(&c.interfaceName, "interface", "", "service URL")
+	f.StringVar(&c.endpoint, "endpoint", "", "service URL")
+	f.StringVar(&c.user, "user", "", "service URL")
+	f.StringVar(&c.charm, "charm", "", "service URL")
+	f.StringVar(&c.author, "author", "", "service URL")
+	c.out.AddFlags(f, "tabular", map[string]cmd.Formatter{
+		"yaml":    cmd.FormatYaml,
+		"json":    cmd.FormatJson,
+		"tabular": formatFindTabular,
+	})
+}
+
+// Run implements Command.Run.
+func (c *findCommand) Run(ctx *cmd.Context) (err error) {
+	api, err := c.newAPIFunc()
+	if err != nil {
+		return err
+	}
+	defer api.Close()
+
+	filter := crossmodel.ServiceOfferFilter{
+		ServiceOffer: crossmodel.ServiceOffer{
+			ServiceURL: c.url,
+		},
+		// TODO(wallyworld): allowed users
+		// TODO(wallyworld): charm
+		// TODO(wallyworld): user
+		// TODO(wallyworld): author
+	}
+	if c.interfaceName != "" || c.endpoint != "" {
+		filter.Endpoints = []charm.Relation{{
+			Interface: c.interfaceName,
+			Name:      c.endpoint,
+		}}
+	}
+	found, err := api.FindServiceOffers(filter)
+	if err != nil {
+		return err
+	}
+
+	output, err := convertFoundServices(found...)
+	if err != nil {
+		return err
+	}
+	if len(output) == 0 {
+		fmt.Fprintln(ctx.Stdout, "no matching service offers found")
+		return nil
+	}
+	return c.out.Write(ctx, output)
+}
+
+// FindAPI defines the API methods that cross model find command uses.
+type FindAPI interface {
+	Close() error
+	FindServiceOffers(filters ...crossmodel.ServiceOfferFilter) ([]params.ServiceOffer, error)
+}
+
+// RemoteServiceResult defines the serialization behaviour of remote service.
+// This is used in map-style yaml output where remote service URL is the key.
+type RemoteServiceResult struct {
+	// Endpoints is the list of offered service endpoints.
+	Endpoints map[string]RemoteEndpoint `yaml:"endpoints" json:"endpoints"`
+}
+
+// convertFoundServices takes any number of api-formatted remote services and
+// creates a collection of ui-formatted services.
+func convertFoundServices(services ...params.ServiceOffer) (map[string]RemoteServiceResult, error) {
+	if len(services) == 0 {
+		return nil, nil
+	}
+	output := make(map[string]RemoteServiceResult, len(services))
+	for _, one := range services {
+		service := RemoteServiceResult{Endpoints: convertRemoteEndpoints(one.Endpoints...)}
+		output[one.ServiceURL] = service
+	}
+	return output, nil
+}

--- a/cmd/juju/crossmodel/find.go
+++ b/cmd/juju/crossmodel/find.go
@@ -61,7 +61,7 @@ func NewFindEndpointsCommand() cmd.Command {
 func (c *findCommand) Init(args []string) (err error) {
 	url, err := cmd.ZeroOrOneArgs(args)
 	if err != nil {
-		return errors.Errorf("unrecognized args: %q", args[1:])
+		return err
 	}
 
 	if url != "" {

--- a/cmd/juju/crossmodel/find_test.go
+++ b/cmd/juju/crossmodel/find_test.go
@@ -1,0 +1,178 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package crossmodel_test
+
+import (
+	"fmt"
+
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/charm.v6-unstable"
+
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/juju/crossmodel"
+	jujucrossmodel "github.com/juju/juju/model/crossmodel"
+	"github.com/juju/juju/testing"
+)
+
+type findSuite struct {
+	BaseCrossModelSuite
+	mockAPI *mockFindAPI
+}
+
+var _ = gc.Suite(&findSuite{})
+
+func (s *findSuite) SetUpTest(c *gc.C) {
+	s.BaseCrossModelSuite.SetUpTest(c)
+
+	s.mockAPI = &mockFindAPI{
+		serviceName: "hosted-db2",
+	}
+}
+
+func (s *findSuite) runFind(c *gc.C, args ...string) (*cmd.Context, error) {
+	return testing.RunCommand(c, crossmodel.NewFindEndpointsCommandForTest(s.mockAPI), args...)
+}
+
+func (s *findSuite) TestFindDuplicateUrl(c *gc.C) {
+	s.assertFindError(c, []string{"url", "--url", "urlparam"}, ".*URL term cannot be specified twice.*")
+}
+
+func (s *findSuite) TestNoResults(c *gc.C) {
+	s.mockAPI.c = c
+	s.mockAPI.expectedFilter = &jujucrossmodel.ServiceOfferFilter{
+		ServiceOffer: jujucrossmodel.ServiceOffer{
+			ServiceURL: "local:/u/none",
+		},
+	}
+	s.mockAPI.results = []params.ServiceOffer{}
+	s.assertFind(
+		c,
+		[]string{"--url", "local:/u/none"},
+		`no matching service offers found
+`,
+	)
+}
+
+func (s *findSuite) TestSimpleFilter(c *gc.C) {
+	s.mockAPI.c = c
+	s.mockAPI.expectedFilter = &jujucrossmodel.ServiceOfferFilter{
+		ServiceOffer: jujucrossmodel.ServiceOffer{
+			ServiceURL: "local:/u/fred",
+		},
+	}
+	s.assertFind(
+		c,
+		[]string{"--format", "tabular", "--url", "local:/u/fred"},
+		`
+URL                       INTERFACES
+local:/u/fred/hosted-db2  http:db2, http:log
+
+`[1:],
+	)
+}
+
+func (s *findSuite) TestEndpointFilter(c *gc.C) {
+	s.mockAPI.c = c
+	s.mockAPI.expectedFilter = &jujucrossmodel.ServiceOfferFilter{
+		ServiceOffer: jujucrossmodel.ServiceOffer{
+			ServiceURL: "local:/u/fred",
+			Endpoints: []charm.Relation{{
+				Interface: "mysql",
+				Name:      "db",
+			}},
+		},
+	}
+	s.assertFind(
+		c,
+		[]string{"--format", "tabular", "--url", "local:/u/fred", "--endpoint", "db", "--interface", "mysql"},
+		`
+URL                       INTERFACES
+local:/u/fred/hosted-db2  http:db2, http:log
+
+`[1:],
+	)
+}
+
+func (s *findSuite) TestFindApiError(c *gc.C) {
+	s.mockAPI.msg = "fail"
+	s.assertFindError(c, []string{"local:/u/fred/db2"}, ".*fail.*")
+}
+
+func (s *findSuite) TestFindYaml(c *gc.C) {
+	s.assertFind(
+		c,
+		[]string{"local:/u/fred/db2", "--format", "yaml"},
+		`
+local:/u/fred/hosted-db2:
+  endpoints:
+    db2:
+      interface: http
+      role: requirer
+    log:
+      interface: http
+      role: provider
+`[1:],
+	)
+}
+
+func (s *findSuite) TestFindTabular(c *gc.C) {
+	s.assertFind(
+		c,
+		[]string{"local:/u/fred/db2", "--format", "tabular"},
+		`
+URL                       INTERFACES
+local:/u/fred/hosted-db2  http:db2, http:log
+
+`[1:],
+	)
+}
+
+func (s *findSuite) assertFind(c *gc.C, args []string, expected string) {
+	context, err := s.runFind(c, args...)
+	c.Assert(err, jc.ErrorIsNil)
+
+	obtained := testing.Stdout(context)
+	c.Assert(obtained, gc.Matches, expected)
+}
+
+func (s *findSuite) assertFindError(c *gc.C, args []string, expected string) {
+	_, err := s.runFind(c, args...)
+	c.Assert(err, gc.ErrorMatches, expected)
+}
+
+type mockFindAPI struct {
+	c                *gc.C
+	msg, serviceName string
+	expectedFilter   *jujucrossmodel.ServiceOfferFilter
+	results          []params.ServiceOffer
+}
+
+func (s mockFindAPI) Close() error {
+	return nil
+}
+
+func (s mockFindAPI) FindServiceOffers(filters ...jujucrossmodel.ServiceOfferFilter) ([]params.ServiceOffer, error) {
+	if s.msg != "" {
+		return nil, errors.New(s.msg)
+	}
+	if s.expectedFilter != nil {
+		s.c.Assert(filters, gc.HasLen, 1)
+		s.c.Assert(filters[0], jc.DeepEquals, *s.expectedFilter)
+	}
+
+	if s.results != nil {
+		return s.results, nil
+	}
+	return []params.ServiceOffer{{
+		ServiceURL:  fmt.Sprintf("local:/u/fred/%s", s.serviceName),
+		ServiceName: s.serviceName,
+		Endpoints: []params.RemoteEndpoint{
+			params.RemoteEndpoint{Name: "log", Interface: "http", Role: charm.RoleProvider},
+			params.RemoteEndpoint{Name: "db2", Interface: "http", Role: charm.RoleRequirer},
+		},
+	}}, nil
+}

--- a/cmd/juju/crossmodel/find_test.go
+++ b/cmd/juju/crossmodel/find_test.go
@@ -37,6 +37,24 @@ func (s *findSuite) runFind(c *gc.C, args ...string) (*cmd.Context, error) {
 	return testing.RunCommand(c, crossmodel.NewFindEndpointsCommandForTest(s.mockAPI), args...)
 }
 
+func (s *findSuite) TestFindNoArgs(c *gc.C) {
+	s.mockAPI.c = c
+	s.mockAPI.expectedFilter = &jujucrossmodel.ServiceOfferFilter{
+		ServiceOffer: jujucrossmodel.ServiceOffer{
+			ServiceURL: "local:",
+		},
+	}
+	s.assertFind(
+		c,
+		[]string{},
+		`
+URL                       INTERFACES
+local:/u/fred/hosted-db2  http:db2, http:log
+
+`[1:],
+	)
+}
+
 func (s *findSuite) TestFindDuplicateUrl(c *gc.C) {
 	s.assertFindError(c, []string{"url", "--url", "urlparam"}, ".*URL term cannot be specified twice.*")
 }
@@ -49,11 +67,10 @@ func (s *findSuite) TestNoResults(c *gc.C) {
 		},
 	}
 	s.mockAPI.results = []params.ServiceOffer{}
-	s.assertFind(
+	s.assertFindError(
 		c,
 		[]string{"--url", "local:/u/none"},
-		`no matching service offers found
-`,
+		`no matching service offers found`,
 	)
 }
 

--- a/cmd/juju/crossmodel/findformatter.go
+++ b/cmd/juju/crossmodel/findformatter.go
@@ -1,0 +1,49 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package crossmodel
+
+import (
+	"bytes"
+	"fmt"
+	"sort"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/juju/errors"
+)
+
+// formatFindTabular returns a tabular summary of remote services or
+// errors out if parameter is not of expected type.
+func formatFindTabular(value interface{}) ([]byte, error) {
+	endpoints, ok := value.(map[string]RemoteServiceResult)
+	if !ok {
+		return nil, errors.Errorf("expected value of type %T, got %T", endpoints, value)
+	}
+	return formatFoundEndpointsTabular(endpoints)
+}
+
+// formatFoundEndpointsTabular returns a tabular summary of offered services' endpoints.
+func formatFoundEndpointsTabular(all map[string]RemoteServiceResult) ([]byte, error) {
+	var out bytes.Buffer
+	tw := tabwriter.NewWriter(&out, minwidth, tabwidth, padding, padchar, flags)
+	print := func(values ...string) {
+		fmt.Fprintln(tw, strings.Join(values, "\t"))
+	}
+
+	print("URL", "INTERFACES")
+
+	for url, one := range all {
+		serviceURL := url
+
+		interfaces := []string{}
+		for name, ep := range one.Endpoints {
+			interfaces = append(interfaces, fmt.Sprintf("%s:%s", ep.Interface, name))
+		}
+		sort.Strings(interfaces)
+		print(serviceURL, strings.Join(interfaces, ", "))
+	}
+	tw.Flush()
+
+	return out.Bytes(), nil
+}

--- a/cmd/juju/crossmodel/show.go
+++ b/cmd/juju/crossmodel/show.go
@@ -14,7 +14,7 @@ import (
 )
 
 const showCommandDoc = `
-Show extended information about service's endpoints previously exported through "juju offer".
+Show extended information about an exported service.
 
 This command is aimed for a user who wants to see more detail about what’s offered behind a particular URL.
 

--- a/cmd/juju/crossmodel/show_test.go
+++ b/cmd/juju/crossmodel/show_test.go
@@ -57,7 +57,7 @@ func (s *showSuite) TestShowYaml(c *gc.C) {
 hosted-db2:
   endpoints:
     db2:
-      interface: hhtp
+      interface: http
       role: requirer
     log:
       interface: http
@@ -72,42 +72,43 @@ func (s *showSuite) TestShowTabular(c *gc.C) {
 		c,
 		[]string{"local:/u/fred/db2", "--format", "tabular"},
 		`
-SERVICE     DESCRIPTION                     ENDPOINT  INTERFACE  ROLE
-hosted-db2  IBM DB2 Express Server Edition  db2       hhtp       requirer
-            an entry level database system  log       http       provider
-                                                                 
+SERVICE     DESCRIPTION                                 ENDPOINT  INTERFACE  ROLE
+hosted-db2  IBM DB2 Express Server Edition is an entry  db2       http       requirer
+            level database system                       log       http       provider
 
 `[1:],
 	)
 }
 
-func (s *showSuite) TestShowTabularExactly100Desc(c *gc.C) {
-	s.mockAPI.desc = s.mockAPI.desc + s.mockAPI.desc[:36]
+func (s *showSuite) TestShowTabularExactly180Desc(c *gc.C) {
+	s.mockAPI.desc = s.mockAPI.desc + s.mockAPI.desc + s.mockAPI.desc[:52]
 	s.assertShow(
 		c,
 		[]string{"local:/u/fred/db2", "--format", "tabular"},
 		`
-SERVICE     DESCRIPTION                     ENDPOINT  INTERFACE  ROLE
-hosted-db2  IBM DB2 Express Server Edition  db2       hhtp       requirer
-            an entry level database         log       http       provider
-            DB2 Express Server Edition is                        
-                                                                 
+SERVICE     DESCRIPTION                                   ENDPOINT  INTERFACE  ROLE
+hosted-db2  IBM DB2 Express Server Edition is an entry    db2       http       requirer
+            level database systemIBM DB2 Express Server   log       http       provider
+            Edition is an entry level database systemIBM                       
+            DB2 Express Server Edition is an entry level                       
+            dat                                                                
 
 `[1:],
 	)
 }
 
-func (s *showSuite) TestShowTabularMoreThan100Desc(c *gc.C) {
-	s.mockAPI.desc = s.mockAPI.desc + s.mockAPI.desc
+func (s *showSuite) TestShowTabularMoreThan180Desc(c *gc.C) {
+	s.mockAPI.desc = s.mockAPI.desc + s.mockAPI.desc + s.mockAPI.desc
 	s.assertShow(
 		c,
 		[]string{"local:/u/fred/db2", "--format", "tabular"},
 		`
-SERVICE     DESCRIPTION                     ENDPOINT  INTERFACE  ROLE
-hosted-db2  IBM DB2 Express Server Edition  db2       hhtp       requirer
-            an entry level database         log       http       provider
-            DB2 Express Server Edition                           
-                                                                 
+SERVICE     DESCRIPTION                                   ENDPOINT  INTERFACE  ROLE
+hosted-db2  IBM DB2 Express Server Edition is an entry    db2       http       requirer
+            level database systemIBM DB2 Express Server   log       http       provider
+            Edition is an entry level database systemIBM                       
+            DB2 Express Server Edition is an entry level                       
+            ...                                                                
 
 `[1:],
 	)
@@ -144,7 +145,7 @@ func (s mockShowAPI) ServiceOffer(url string) (params.ServiceOffer, error) {
 		ServiceDescription: s.desc,
 		Endpoints: []params.RemoteEndpoint{
 			params.RemoteEndpoint{Name: "log", Interface: "http", Role: charm.RoleProvider},
-			params.RemoteEndpoint{Name: "db2", Interface: "hhtp", Role: charm.RoleRequirer},
+			params.RemoteEndpoint{Name: "db2", Interface: "http", Role: charm.RoleRequirer},
 		},
 	}, nil
 }

--- a/cmd/juju/crossmodel/showformatter.go
+++ b/cmd/juju/crossmodel/showformatter.go
@@ -15,10 +15,10 @@ import (
 
 const (
 	// To wrap long lines within a column.
-	maxColumnLength = 100
+	maxColumnLength = 180
 	truncatedSuffix = "..."
 	maxFieldLength  = maxColumnLength - len(truncatedSuffix)
-	columnWidth     = 30
+	columnWidth     = 45
 
 	// To format things into columns.
 	minwidth = 0
@@ -41,7 +41,6 @@ func formatShowTabular(value interface{}) ([]byte, error) {
 // formatOfferedEndpointsTabular returns a tabular summary of offered services' endpoints.
 func formatOfferedEndpointsTabular(all map[string]ShowRemoteService) ([]byte, error) {
 	var out bytes.Buffer
-	const ()
 	tw := tabwriter.NewWriter(&out, minwidth, tabwidth, padding, padchar, flags)
 	print := func(values ...string) {
 		fmt.Fprintln(tw, strings.Join(values, "\t"))
@@ -117,6 +116,7 @@ func breakLines(text string) []string {
 		tp := fmt.Sprintf("%v %v", lines[index], aWord)
 		if len(tp) > columnWidth {
 			index++
+			lines[index] = aWord
 			continue
 		}
 		lines[index] = tp

--- a/cmd/juju/crossmodel/showformatter_test.go
+++ b/cmd/juju/crossmodel/showformatter_test.go
@@ -63,8 +63,8 @@ func (s *funcSuite) TestBreakLinesManyWordsManyLines(c *gc.C) {
 	aWord := "aWord aWord aWord aWord aWord aWord aWord aWord aWord aWord"
 	c.Assert(crossmodel.BreakLines(aWord), gc.DeepEquals,
 		[]string{
-			"aWord aWord aWord aWord aWord",
-			"aWord aWord aWord aWord",
+			"aWord aWord aWord aWord aWord aWord aWord",
+			"aWord aWord aWord",
 		})
 }
 
@@ -74,7 +74,7 @@ func (s *funcSuite) TestBreakOneWord(c *gc.C) {
 }
 
 func (s *funcSuite) TestBreakOneLongWord(c *gc.C) {
-	aWord := "aVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryaWord"
+	aWord := "aVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryaWordaWordaWordaWordaWordaWord"
 	c.Assert(crossmodel.BreakOneWord(aWord), gc.DeepEquals,
 		[]string{
 			aWord[0:crossmodel.ColumnWidth],

--- a/model/crossmodel/interface.go
+++ b/model/crossmodel/interface.go
@@ -56,7 +56,7 @@ type ServiceDirectory interface {
 	// UpdateOffer replaces an existing offer at the same URL.
 	UpdateOffer(offer ServiceOffer) error
 
-	// List offers returns the offers satisfying the specified filter.
+	// ListOffers returns the offers satisfying the specified filter.
 	ListOffers(filter ...ServiceOfferFilter) ([]ServiceOffer, error)
 
 	// Remove removes the service offer at the specified URL.
@@ -119,7 +119,7 @@ func RegisteredFilter(registered bool) OfferedServiceFilter {
 	return filter
 }
 
-// An OfferedService instance holds service offers from this environment.
+// OfferedServices instances hold service offers from this environment.
 type OfferedServices interface {
 
 	// AddOffer adds a new service offer.
@@ -134,11 +134,11 @@ type OfferedServices interface {
 	// SetOfferRegistered marks a previously saved offer as registered or not.
 	SetOfferRegistered(url string, registered bool) error
 
-	// Remove removes the service offer at the specified URL.
+	// RemoveOffer removes the service offer at the specified URL.
 	RemoveOffer(url string) error
 }
 
-// RemoteEndpoint represents a remote endpoint filter.
+// EndpointFilterTerm represents a remote endpoint filter.
 type EndpointFilterTerm struct {
 	// Name is an endpoint name.
 	Name string

--- a/model/crossmodel/servicedirectory.go
+++ b/model/crossmodel/servicedirectory.go
@@ -8,7 +8,7 @@ import (
 )
 
 type ServiceOfferLister interface {
-	// List offers returns the offers from the specified directory satisfying the specified filter.
+	// ListOffers returns the offers from the specified directory satisfying the specified filter.
 	ListOffers(directory string, filter ...ServiceOfferFilter) ([]ServiceOffer, error)
 }
 

--- a/model/crossmodel/serviceurl.go
+++ b/model/crossmodel/serviceurl.go
@@ -124,6 +124,7 @@ func ServiceDirectoryForURL(urlStr string) (string, error) {
 type ServiceURLParts ServiceURL
 
 // ParseServiceURLParts parses a partial URL, filling out what parts are supplied.
+// TODO(wallyworld) update ParseServiceURL to use this method and perform additional validation on top.
 func ParseServiceURLParts(urlStr string) (*ServiceURLParts, error) {
 	url, err := gourl.Parse(urlStr)
 	if err != nil {

--- a/model/crossmodel/serviceurl.go
+++ b/model/crossmodel/serviceurl.go
@@ -120,8 +120,11 @@ func ServiceDirectoryForURL(urlStr string) (string, error) {
 	return url.Directory, nil
 }
 
+// ServiceURLParts contains various attributes of a URL.
+type ServiceURLParts ServiceURL
+
 // ParseServiceURLParts parses a partial URL, filling out what parts are supplied.
-func ParseServiceURLParts(urlStr string) (*ServiceURL, error) {
+func ParseServiceURLParts(urlStr string) (*ServiceURLParts, error) {
 	url, err := gourl.Parse(urlStr)
 	if err != nil {
 		return nil, errors.Errorf("cannot parse service URL: %q", urlStr)
@@ -130,7 +133,7 @@ func ParseServiceURLParts(urlStr string) (*ServiceURL, error) {
 		return nil, errors.Errorf("service URL %q has unrecognized parts", urlStr)
 	}
 
-	var result ServiceURL
+	var result ServiceURLParts
 	if url.Scheme != "" {
 		result.Directory = url.Scheme
 	}

--- a/model/crossmodel/serviceurl_test.go
+++ b/model/crossmodel/serviceurl_test.go
@@ -100,31 +100,31 @@ func (s *ServiceURLSuite) TestServiceDirectoryForURLError(c *gc.C) {
 
 var urlPartsTests = []struct {
 	s, err string
-	url    *crossmodel.ServiceURL
+	url    *crossmodel.ServiceURLParts
 }{{
 	s:   "local:/u/user/servicename",
-	url: &crossmodel.ServiceURL{"local", "user", "", "servicename"},
+	url: &crossmodel.ServiceURLParts{"local", "user", "", "servicename"},
 }, {
 	s:   "u/user/servicename",
-	url: &crossmodel.ServiceURL{"", "user", "", "servicename"},
+	url: &crossmodel.ServiceURLParts{"", "user", "", "servicename"},
 }, {
 	s:   "u/user/prod/servicename",
-	url: &crossmodel.ServiceURL{"", "user", "prod", "servicename"},
+	url: &crossmodel.ServiceURLParts{"", "user", "prod", "servicename"},
 }, {
 	s:   "u/user",
-	url: &crossmodel.ServiceURL{"", "user", "", ""},
+	url: &crossmodel.ServiceURLParts{"", "user", "", ""},
 }, {
 	s:   "service",
-	url: &crossmodel.ServiceURL{"", "", "", "service"},
+	url: &crossmodel.ServiceURLParts{"", "", "", "service"},
 }, {
 	s:   "prod/service",
-	url: &crossmodel.ServiceURL{"", "", "prod", "service"},
+	url: &crossmodel.ServiceURLParts{"", "", "prod", "service"},
 }, {
 	s:   "local:/service",
-	url: &crossmodel.ServiceURL{"local", "", "", "service"},
+	url: &crossmodel.ServiceURLParts{"local", "", "", "service"},
 }, {
 	s:   "",
-	url: &crossmodel.ServiceURL{},
+	url: &crossmodel.ServiceURLParts{},
 }, {
 	s:   "a/b/c",
 	err: `service URL has too many parts: "a/b/c"`,

--- a/state/servicedirectory.go
+++ b/state/servicedirectory.go
@@ -257,6 +257,7 @@ func (s *serviceDirectory) ListOffers(filter ...crossmodel.ServiceOfferFilter) (
 	serviceOffersCollection, closer := s.st.getCollection(localServiceDirectoryC)
 	defer closer()
 
+	// TODO(wallyworld) - add support for filtering on endpoints
 	var mgoTerms []bson.D
 	for _, term := range filter {
 		elems := s.makeFilterTerm(term)


### PR DESCRIPTION
Two major changes:

1. juju find-endpoints which allows the user to see what services have been offered
Includes:
- CLI command
- api and apiserver components
- feature tests

TODO - we still don't filter on endpoint name or interface

2. fix issues with juju show-endpoint command
- description column too narrow
- words in description were omitted

(Review request: http://reviews.vapour.ws/r/3446/)