### PR TITLE
Add remote service info to status

### DIFF
--- a/api/allwatcher.go
+++ b/api/allwatcher.go
@@ -72,9 +72,27 @@ func (o orderedDeltas) Len() int {
 	return len(o)
 }
 
+func (o orderedDeltas) kindPriority(kind string) int {
+	switch kind {
+	case "machine":
+		return 1
+	case "service":
+		return 2
+	case "relation":
+		return 3
+	}
+	return 0
+}
+
 func (o orderedDeltas) Less(i, j int) bool {
 	// All we care about is having relation deltas last.
-	return o[j].Entity.EntityId().Kind == "relation"
+	// We'll add extra checks though to make the order more
+	// deterministic for tests.
+	pi, pj := o.kindPriority(o[i].Entity.EntityId().Kind), o.kindPriority(o[j].Entity.EntityId().Kind)
+	if pi == pj {
+		return o[i].Entity.EntityId().Id < o[j].Entity.EntityId().Id
+	}
+	return pi < pj
 }
 
 func (o orderedDeltas) Swap(i, j int) {

--- a/apiserver/client/api_test.go
+++ b/apiserver/client/api_test.go
@@ -201,6 +201,7 @@ var scenarioStatus = &params.FullStatus{
 			WantsVote:      false,
 		},
 	},
+	RemoteServices: map[string]params.RemoteServiceStatus{},
 	Services: map[string]params.ServiceStatus{
 		"logging": {
 			Charm: "local:quantal/logging-1",

--- a/apiserver/client/state.go
+++ b/apiserver/client/state.go
@@ -36,6 +36,7 @@ type stateInterface interface {
 	Machine(string) (*state.Machine, error)
 	AllMachines() ([]*state.Machine, error)
 	AllServices() ([]*state.Service, error)
+	AllRemoteServices() ([]*state.RemoteService, error)
 	AllRelations() ([]*state.Relation, error)
 	AllNetworks() ([]*state.Network, error)
 	AddOneMachine(state.MachineTemplate) (*state.Machine, error)

--- a/apiserver/client/status.go
+++ b/apiserver/client/status.go
@@ -97,7 +97,7 @@ func (c *Client) FullStatus(args params.StatusParams) (params.FullStatus, error)
 		return noStatus, errors.Annotate(err, "could not fetch services and units")
 	} else if context.remoteServices, err =
 		fetchRemoteServices(c.api.stateAccessor); err != nil {
-		return noStatus, errors.Annotate(err, "could not fetch services and units")
+		return noStatus, errors.Annotate(err, "could not fetch remote services")
 	} else if context.machines, err = fetchMachines(c.api.stateAccessor, nil); err != nil {
 		return noStatus, errors.Annotate(err, "could not fetch machines")
 	} else if context.relations, err = fetchRelations(c.api.stateAccessor); err != nil {

--- a/apiserver/client/status_test.go
+++ b/apiserver/client/status_test.go
@@ -38,6 +38,7 @@ func (s *statusSuite) TestFullStatus(c *gc.C) {
 	c.Check(status.Services, gc.HasLen, 0)
 	c.Check(status.Machines, gc.HasLen, 1)
 	c.Check(status.Networks, gc.HasLen, 0)
+	c.Check(status.RemoteServices, gc.HasLen, 0)
 	resultMachine, ok := status.Machines[machine.Id()]
 	if !ok {
 		c.Fatalf("Missing machine with id %q", machine.Id())

--- a/apiserver/params/status.go
+++ b/apiserver/params/status.go
@@ -28,6 +28,7 @@ type FullStatus struct {
 	AvailableVersion string
 	Machines         map[string]MachineStatus
 	Services         map[string]ServiceStatus
+	RemoteServices   map[string]RemoteServiceStatus
 	Networks         map[string]NetworkStatus
 	Relations        []RelationStatus
 }
@@ -71,6 +72,17 @@ type ServiceStatus struct {
 	Units         map[string]UnitStatus
 	MeterStatuses map[string]MeterStatus
 	Status        AgentStatus
+}
+
+// RemoteServiceStatus holds status info about a remote service.
+type RemoteServiceStatus struct {
+	Err         error
+	ServiceURL  string
+	ServiceName string
+	Endpoints   []RemoteEndpoint
+	Life        string
+	Relations   map[string][]string
+	Status      AgentStatus
 }
 
 // MeterStatus represents the meter status of a unit.

--- a/cmd/juju/status/formatter.go
+++ b/cmd/juju/status/formatter.go
@@ -36,9 +36,10 @@ func (sf *statusFormatter) format() formattedStatus {
 		return formattedStatus{}
 	}
 	out := formattedStatus{
-		Environment: sf.status.EnvironmentName,
-		Machines:    make(map[string]machineStatus),
-		Services:    make(map[string]serviceStatus),
+		Environment:    sf.status.EnvironmentName,
+		Machines:       make(map[string]machineStatus),
+		Services:       make(map[string]serviceStatus),
+		RemoteServices: make(map[string]remoteServiceStatus),
 	}
 	if sf.status.AvailableVersion != "" {
 		out.EnvironmentStatus = &environmentStatus{
@@ -51,6 +52,9 @@ func (sf *statusFormatter) format() formattedStatus {
 	}
 	for sn, s := range sf.status.Services {
 		out.Services[sn] = sf.formatService(sn, s)
+	}
+	for sn, s := range sf.status.RemoteServices {
+		out.RemoteServices[sn] = sf.formatRemoteService(sn, s)
 	}
 	for k, n := range sf.status.Networks {
 		if out.Networks == nil {
@@ -113,6 +117,24 @@ func (sf *statusFormatter) formatMachine(machine params.MachineStatus) machineSt
 	return out
 }
 
+func (sf *statusFormatter) formatRemoteService(name string, service params.RemoteServiceStatus) remoteServiceStatus {
+	out := remoteServiceStatus{
+		Err:        service.Err,
+		ServiceURL: service.ServiceURL,
+		Life:       service.Life,
+		Relations:  service.Relations,
+		StatusInfo: sf.getServiceStatusInfo(service.Status),
+	}
+	out.Endpoints = make(map[string]remoteEndpoint)
+	for _, ep := range service.Endpoints {
+		out.Endpoints[ep.Name] = remoteEndpoint{
+			Interface: ep.Interface,
+			Role:      string(ep.Role),
+		}
+	}
+	return out
+}
+
 func (sf *statusFormatter) formatService(name string, service params.ServiceStatus) serviceStatus {
 	out := serviceStatus{
 		Err:           service.Err,
@@ -124,7 +146,7 @@ func (sf *statusFormatter) formatService(name string, service params.ServiceStat
 		CanUpgradeTo:  service.CanUpgradeTo,
 		SubordinateTo: service.SubordinateTo,
 		Units:         make(map[string]unitStatus),
-		StatusInfo:    sf.getServiceStatusInfo(service),
+		StatusInfo:    sf.getServiceStatusInfo(service.Status),
 	}
 	if len(service.Networks.Enabled) > 0 {
 		out.Networks["enabled"] = service.Networks.Enabled
@@ -143,15 +165,15 @@ func (sf *statusFormatter) formatService(name string, service params.ServiceStat
 	return out
 }
 
-func (sf *statusFormatter) getServiceStatusInfo(service params.ServiceStatus) statusInfoContents {
+func (sf *statusFormatter) getServiceStatusInfo(status params.AgentStatus) statusInfoContents {
 	info := statusInfoContents{
-		Err:     service.Status.Err,
-		Current: service.Status.Status,
-		Message: service.Status.Info,
-		Version: service.Status.Version,
+		Err:     status.Err,
+		Current: status.Status,
+		Message: status.Info,
+		Version: status.Version,
 	}
-	if service.Status.Since != nil {
-		info.Since = common.FormatTime(service.Status.Since, sf.isoTime)
+	if status.Since != nil {
+		info.Since = common.FormatTime(status.Since, sf.isoTime)
 	}
 	return info
 }

--- a/cmd/juju/status/formatter.go
+++ b/cmd/juju/status/formatter.go
@@ -123,7 +123,7 @@ func (sf *statusFormatter) formatRemoteService(name string, service params.Remot
 		ServiceURL: service.ServiceURL,
 		Life:       service.Life,
 		Relations:  service.Relations,
-		StatusInfo: sf.getServiceStatusInfo(service.Status),
+		StatusInfo: sf.getAgentStatusInfo(service.Status),
 	}
 	out.Endpoints = make(map[string]remoteEndpoint)
 	for _, ep := range service.Endpoints {
@@ -146,7 +146,7 @@ func (sf *statusFormatter) formatService(name string, service params.ServiceStat
 		CanUpgradeTo:  service.CanUpgradeTo,
 		SubordinateTo: service.SubordinateTo,
 		Units:         make(map[string]unitStatus),
-		StatusInfo:    sf.getServiceStatusInfo(service.Status),
+		StatusInfo:    sf.getAgentStatusInfo(service.Status),
 	}
 	if len(service.Networks.Enabled) > 0 {
 		out.Networks["enabled"] = service.Networks.Enabled
@@ -165,7 +165,7 @@ func (sf *statusFormatter) formatService(name string, service params.ServiceStat
 	return out
 }
 
-func (sf *statusFormatter) getServiceStatusInfo(status params.AgentStatus) statusInfoContents {
+func (sf *statusFormatter) getAgentStatusInfo(status params.AgentStatus) statusInfoContents {
 	info := statusInfoContents{
 		Err:     status.Err,
 		Current: status.Status,
@@ -190,8 +190,8 @@ func (sf *statusFormatter) formatUnit(info unitFormatInfo) unitStatus {
 	sf.updateUnitStatusInfo(&info.unit, info.serviceName)
 
 	out := unitStatus{
-		WorkloadStatusInfo: sf.getWorkloadStatusInfo(info.unit),
-		AgentStatusInfo:    sf.getAgentStatusInfo(info.unit),
+		WorkloadStatusInfo: sf.getAgentStatusInfo(info.unit.Workload),
+		AgentStatusInfo:    sf.getAgentStatusInfo(info.unit.UnitAgent),
 		Machine:            info.unit.Machine,
 		OpenedPorts:        info.unit.OpenedPorts,
 		PublicAddress:      info.unit.PublicAddress,
@@ -224,32 +224,6 @@ func (sf *statusFormatter) formatUnit(info unitFormatInfo) unitStatus {
 		})
 	}
 	return out
-}
-
-func (sf *statusFormatter) getWorkloadStatusInfo(unit params.UnitStatus) statusInfoContents {
-	info := statusInfoContents{
-		Err:     unit.Workload.Err,
-		Current: unit.Workload.Status,
-		Message: unit.Workload.Info,
-		Version: unit.Workload.Version,
-	}
-	if unit.Workload.Since != nil {
-		info.Since = common.FormatTime(unit.Workload.Since, sf.isoTime)
-	}
-	return info
-}
-
-func (sf *statusFormatter) getAgentStatusInfo(unit params.UnitStatus) statusInfoContents {
-	info := statusInfoContents{
-		Err:     unit.UnitAgent.Err,
-		Current: unit.UnitAgent.Status,
-		Message: unit.UnitAgent.Info,
-		Version: unit.UnitAgent.Version,
-	}
-	if unit.UnitAgent.Since != nil {
-		info.Since = common.FormatTime(unit.UnitAgent.Since, sf.isoTime)
-	}
-	return info
 }
 
 func (sf *statusFormatter) updateUnitStatusInfo(unit *params.UnitStatus, serviceName string) {

--- a/cmd/juju/status/output_summary.go
+++ b/cmd/juju/status/output_summary.go
@@ -27,6 +27,7 @@ import (
 //   - Units: Displays total #, and then # in each state.
 //   - Services: Displays total #, their names, and how many of each
 //     are exposed.
+//   - RemoteServices: Displays total #, their names.
 func FormatSummary(value interface{}) ([]byte, error) {
 	fs, valueConverted := value.(formattedStatus)
 	if !valueConverted {
@@ -57,6 +58,13 @@ func FormatSummary(value interface{}) ([]byte, error) {
 	for _, svcName := range common.SortStringsNaturally(stringKeysFromMap(svcExposure)) {
 		s := svcExposure[svcName]
 		p(svcName, fmt.Sprintf("%d/%d\texposed", s[true], s[true]+s[false]))
+	}
+	p(" ")
+
+	p("# REMOTE:", fmt.Sprintf(" (%d)", len(fs.RemoteServices)))
+	for _, svcName := range common.SortStringsNaturally(stringKeysFromMap(fs.RemoteServices)) {
+		s := fs.RemoteServices[svcName]
+		p(svcName, "", s.ServiceURL)
 	}
 	f.tw.Flush()
 

--- a/cmd/juju/status/output_summary.go
+++ b/cmd/juju/status/output_summary.go
@@ -27,7 +27,7 @@ import (
 //   - Units: Displays total #, and then # in each state.
 //   - Services: Displays total #, their names, and how many of each
 //     are exposed.
-//   - RemoteServices: Displays total #, their names.
+//   - RemoteServices: Displays total #, their names and URLs.
 func FormatSummary(value interface{}) ([]byte, error) {
 	fs, valueConverted := value.(formattedStatus)
 	if !valueConverted {

--- a/cmd/juju/status/output_tabular.go
+++ b/cmd/juju/status/output_tabular.go
@@ -59,6 +59,7 @@ func FormatTabular(value interface{}) ([]byte, error) {
 				urlPath = url.Path()
 			} else {
 				// This is not expected.
+				logger.Errorf("invalid service URL %q: %v", svc.ServiceURL, err)
 				store = "unknown"
 				urlPath = svc.ServiceURL
 			}

--- a/cmd/juju/status/output_tabular.go
+++ b/cmd/juju/status/output_tabular.go
@@ -16,6 +16,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/juju/common"
 	"github.com/juju/juju/instance"
+	"github.com/juju/juju/model/crossmodel"
 )
 
 // FormatTabular returns a tabular summary of machines, services, and
@@ -41,6 +42,32 @@ func FormatTabular(value interface{}) ([]byte, error) {
 		if envStatus.AvailableVersion != "" {
 			p("UPGRADE-AVAILABLE")
 			p(envStatus.AvailableVersion)
+		}
+		p()
+		tw.Flush()
+	}
+
+	if len(fs.RemoteServices) > 0 {
+		p("[Service Endpoints]")
+		p("NAME\tSTATUS\tSTORE\tURL\tINTERFACES")
+		for _, svcName := range common.SortStringsNaturally(stringKeysFromMap(fs.RemoteServices)) {
+			svc := fs.RemoteServices[svcName]
+			var store, urlPath string
+			url, err := crossmodel.ParseServiceURL(svc.ServiceURL)
+			if err == nil {
+				store = url.Directory
+				urlPath = url.Path()
+			} else {
+				// This is not expected.
+				store = "unknown"
+				urlPath = svc.ServiceURL
+			}
+			interfaces := make([]string, len(svc.Endpoints))
+			for i, name := range common.SortStringsNaturally(stringKeysFromMap(svc.Endpoints)) {
+				ep := svc.Endpoints[name]
+				interfaces[i] = fmt.Sprintf("%s:%s", ep.Interface, name)
+			}
+			p(svcName, svc.StatusInfo.Current, store, urlPath, strings.Join(interfaces, ", "))
 		}
 		p()
 		tw.Flush()

--- a/cmd/juju/status/status_test.go
+++ b/cmd/juju/status/status_test.go
@@ -2327,8 +2327,9 @@ var statusTests = []testCase{
 		addService{name: "wordpress", charm: "wordpress"},
 		addAliveUnit{"wordpress", "1"},
 
-		addCharm{"riak"},
-		addRemoteService{name: "hosted-riak", url: "local:/u/me/riak", charm: "riak", endpoints: []string{"endpoint"}},
+		addCharm{"mysql"},
+		addRemoteService{name: "hosted-mysql", url: "local:/u/me/mysql", charm: "mysql", endpoints: []string{"server"}},
+		relateServices{"wordpress", "hosted-mysql"},
 
 		expect{
 			"a remote service",
@@ -2339,11 +2340,11 @@ var statusTests = []testCase{
 					"1": machine1,
 				},
 				"service-endpoints": M{
-					"hosted-riak": M{
-						"url": "local:/u/me/riak",
+					"hosted-mysql": M{
+						"url": "local:/u/me/mysql",
 						"endpoints": M{
-							"endpoint": M{
-								"interface": "http",
+							"server": M{
+								"interface": "mysql",
 								"role":      "provider",
 							},
 						},
@@ -2351,6 +2352,9 @@ var statusTests = []testCase{
 							"current": "unknown",
 							"message": "waiting for remote connection",
 							"since":   "01 Apr 15 01:23+10:00",
+						},
+						"relations": M{
+							"server": L{"wordpress"},
 						},
 					},
 				},
@@ -2362,6 +2366,9 @@ var statusTests = []testCase{
 							"current": "unknown",
 							"message": "Waiting for agent initialization to finish",
 							"since":   "01 Apr 15 01:23+10:00",
+						},
+						"relations": M{
+							"db": L{"hosted-mysql"},
 						},
 						"units": M{
 							"wordpress/0": M{

--- a/model/crossmodel/serviceurl.go
+++ b/model/crossmodel/serviceurl.go
@@ -29,7 +29,8 @@ type ServiceURL struct {
 	ServiceName string
 }
 
-func (u *ServiceURL) path() string {
+// Path returns the path component of the URL.
+func (u *ServiceURL) Path() string {
 	var parts []string
 	if u.User != "" {
 		parts = append(parts, "u", u.User)
@@ -42,7 +43,7 @@ func (u *ServiceURL) path() string {
 }
 
 func (u *ServiceURL) String() string {
-	return fmt.Sprintf("%s:/%s", u.Directory, u.path())
+	return fmt.Sprintf("%s:/%s", u.Directory, u.Path())
 }
 
 var supportedURLDirectories = []string{


### PR DESCRIPTION
Modify juju status so that it displays remote service information.
yaml, tabular, summary formats are updated

(Review request: http://reviews.vapour.ws/r/3447/)