### PR TITLE
Add cloud credentials structs and yaml marshalling

### DIFF
--- a/cloud/clouds.go
+++ b/cloud/clouds.go
@@ -30,8 +30,11 @@ const (
 	// UserPassAuthType is an authentication type using a username and password.
 	UserPassAuthType = AuthType("userpass")
 
-	// OAuthAuthType is an authentication type using oauth2.
-	OAuthAuthType = AuthType("oauth2")
+	// OAuthAuth1Type is an authentication type using oauth1.
+	OAuthAuth1Type = AuthType("oauth1")
+
+	// OAuthAuth2Type is an authentication type using oauth2.
+	OAuthAuth2Type = AuthType("oauth2")
 )
 
 // Clouds is a struct containing cloud definitions.

--- a/cloud/credentials.go
+++ b/cloud/credentials.go
@@ -1,0 +1,179 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cloud
+
+// Credentials is a struct containing cloud credential information.
+type Credentials struct {
+	// Credentials is a map of cloud credentials, keyed on cloud name.
+	Credentials map[string]CloudCredential `yaml:"credentials"`
+}
+
+// CloudCredential contains attributes used to define credentials for a cloud.
+type CloudCredential struct {
+	// DefaultCredential is the named credential to use by default.
+	DefaultCredential string `yaml:"default-credential,omitempty"`
+
+	// DefaultRegion is the cloud region to use by default.
+	DefaultRegion string `yaml:"default-region,omitempty"`
+
+	// AuthCredentials is the credentials for a cloud, keyed on name.
+	AuthCredentials map[string]Credential `yaml:",omitempty,inline"`
+}
+
+// Credential instances represent cloud credentials.
+type Credential interface {
+	// AuthType is the type of authorisation.
+	AuthType() AuthType
+
+	// Attributes are the credential values.
+	Attributes() map[string]string
+}
+
+type cloudCredentialYAML struct {
+	CloudCredential `yaml:",inline"`
+	AuthCredentials map[string]Credential `yaml:",omitempty,inline"`
+}
+
+var _ Credential = (*AccessKeyCredentials)(nil)
+
+// AccessKeyCredentials represent key/secret credentials.
+type AccessKeyCredentials struct {
+	Key    string `yaml:"key,omitempty"`
+	Secret string `yaml:"secret,omitempty"`
+}
+
+// AuthType is defined on Credentials interface.
+func (c *AccessKeyCredentials) AuthType() AuthType {
+	return AccessKeyAuthType
+}
+
+// Attributes is defined on Credentials interface.
+func (c *AccessKeyCredentials) Attributes() map[string]string {
+	return map[string]string{
+		"key":    c.Key,
+		"secret": c.Secret,
+	}
+}
+
+var _ Credential = (*OpenstackAccessKeyCredentials)(nil)
+
+// OpenstackAccessKeyCredentials are key/secret credentials for Openstack clouds.
+type OpenstackAccessKeyCredentials struct {
+	AccessKeyCredentials `yaml:",inline"`
+	Tenant               string `yaml:"tenant-name,omitempty"`
+}
+
+// AuthType is defined on Credentials interface.
+func (c *OpenstackAccessKeyCredentials) AuthType() AuthType {
+	return AccessKeyAuthType
+}
+
+// Attributes is defined on Credentials interface.
+func (c *OpenstackAccessKeyCredentials) Attributes() map[string]string {
+	return map[string]string{
+		"key":         c.Key,
+		"secret":      c.Secret,
+		"tenant-name": c.Tenant,
+	}
+}
+
+// UserPassCredentials are username/password credentials.
+type UserPassCredentials struct {
+	User     string `yaml:"username,omitempty"`
+	Password string `yaml:"password,omitempty"`
+}
+
+var _ Credential = (*OpenstackUserPassCredentials)(nil)
+
+// OpenstackUserPassCredentials are user/password credentials for Openstack clouds.
+type OpenstackUserPassCredentials struct {
+	UserPassCredentials `yaml:",inline"`
+	Tenant              string `yaml:"tenant-name,omitempty"`
+}
+
+// AuthType is defined on Credentials interface.
+func (c *OpenstackUserPassCredentials) AuthType() AuthType {
+	return UserPassAuthType
+}
+
+// Attributes is defined on Credentials interface.
+func (c *OpenstackUserPassCredentials) Attributes() map[string]string {
+	return map[string]string{
+		"username":    c.User,
+		"password":    c.Password,
+		"tenant-name": c.Tenant,
+	}
+}
+
+var _ Credential = (*AzureUserPassCredentials)(nil)
+
+// AzureUserPassCredentials are user/password credentials for Azure clouds.
+type AzureUserPassCredentials struct {
+	UserPassCredentials `yaml:",inline"`
+	ApplicationId       string `yaml:"application-id,omitempty"`
+	ApplicationPassword string `yaml:"application-password,omitempty"`
+}
+
+// AuthType is defined on Credentials interface.
+func (c *AzureUserPassCredentials) AuthType() AuthType {
+	return UserPassAuthType
+}
+
+// Attributes is defined on Credentials interface.
+func (c *AzureUserPassCredentials) Attributes() map[string]string {
+	return map[string]string{
+		"username":             c.User,
+		"password":             c.Password,
+		"application-id":       c.ApplicationId,
+		"application-password": c.ApplicationPassword,
+	}
+}
+
+var _ Credential = (*OAuth1Credentials)(nil)
+
+// OAuth1Credentials are oauth1 credentials.
+type OAuth1Credentials struct {
+	ConsumerKey    string `yaml:"consumer-key,omitempty"`
+	ConsumerSecret string `yaml:"consumer-secret,omitempty"`
+	AccessToken    string `yaml:"access-token,omitempty"`
+	TokenSecret    string `yaml:"token-secret,omitempty"`
+}
+
+// AuthType is defined on Credentials interface.
+func (c *OAuth1Credentials) AuthType() AuthType {
+	return OAuthAuth1Type
+}
+
+// Attributes is defined on Credentials interface.
+func (c *OAuth1Credentials) Attributes() map[string]string {
+	return map[string]string{
+		"consumer-key":    c.ConsumerKey,
+		"consumer-secret": c.ConsumerSecret,
+		"access-token":    c.AccessToken,
+		"token-secret":    c.TokenSecret,
+	}
+}
+
+var _ Credential = (*OAuth2Credentials)(nil)
+
+// OAuth2Credentials are oauth1 credentials.
+type OAuth2Credentials struct {
+	ClientId    string `yaml:"client-id,omitempty"`
+	ClientEmail string `yaml:"client-email,omitempty"`
+	PrivateKey  string `yaml:"private-key,omitempty"`
+}
+
+// AuthType is defined on Credentials interface.
+func (c *OAuth2Credentials) AuthType() AuthType {
+	return OAuthAuth2Type
+}
+
+// Attributes is defined on Credentials interface.
+func (c *OAuth2Credentials) Attributes() map[string]string {
+	return map[string]string{
+		"client-id":    c.ClientId,
+		"client-email": c.ClientEmail,
+		"private-key":  c.PrivateKey,
+	}
+}

--- a/cloud/credentials.go
+++ b/cloud/credentials.go
@@ -39,7 +39,10 @@ var _ Credential = (*AccessKeyCredentials)(nil)
 
 // AccessKeyCredentials represent key/secret credentials.
 type AccessKeyCredentials struct {
-	Key    string `yaml:"key,omitempty"`
+	// Key is the credential access key.
+	Key string `yaml:"key,omitempty"`
+
+	// Secret is the credential access secret.
 	Secret string `yaml:"secret,omitempty"`
 }
 
@@ -61,7 +64,9 @@ var _ Credential = (*OpenstackAccessKeyCredentials)(nil)
 // OpenstackAccessKeyCredentials are key/secret credentials for Openstack clouds.
 type OpenstackAccessKeyCredentials struct {
 	AccessKeyCredentials `yaml:",inline"`
-	Tenant               string `yaml:"tenant-name,omitempty"`
+
+	// Tenant is the openstack account tenant.
+	Tenant string `yaml:"tenant-name,omitempty"`
 }
 
 // AuthType is defined on Credentials interface.
@@ -80,7 +85,10 @@ func (c *OpenstackAccessKeyCredentials) Attributes() map[string]string {
 
 // UserPassCredentials are username/password credentials.
 type UserPassCredentials struct {
-	User     string `yaml:"username,omitempty"`
+	// User is the credential user name.
+	User string `yaml:"username,omitempty"`
+
+	// Password is the credential password.
 	Password string `yaml:"password,omitempty"`
 }
 
@@ -89,7 +97,9 @@ var _ Credential = (*OpenstackUserPassCredentials)(nil)
 // OpenstackUserPassCredentials are user/password credentials for Openstack clouds.
 type OpenstackUserPassCredentials struct {
 	UserPassCredentials `yaml:",inline"`
-	Tenant              string `yaml:"tenant-name,omitempty"`
+
+	// Tenant is the openstack account tenant.
+	Tenant string `yaml:"tenant-name,omitempty"`
 }
 
 // AuthType is defined on Credentials interface.
@@ -110,8 +120,16 @@ var _ Credential = (*AzureUserPassCredentials)(nil)
 
 // AzureUserPassCredentials are user/password credentials for Azure clouds.
 type AzureUserPassCredentials struct {
-	UserPassCredentials `yaml:",inline"`
-	ApplicationId       string `yaml:"application-id,omitempty"`
+	// Subscription Id is the Azure account subscription id.
+	SubscriptionId string `yaml:"subscription-id,omitempty"`
+
+	// TenantId is the Azure Active Directory tenant id.
+	TenantId string `yaml:"tenant-id,omitempty"`
+
+	// Application Id is the Azure account application id.
+	ApplicationId string `yaml:"application-id,omitempty"`
+
+	// Tenant is the Azure account account password.
 	ApplicationPassword string `yaml:"application-password,omitempty"`
 }
 
@@ -123,10 +141,10 @@ func (c *AzureUserPassCredentials) AuthType() AuthType {
 // Attributes is defined on Credentials interface.
 func (c *AzureUserPassCredentials) Attributes() map[string]string {
 	return map[string]string{
-		"username":             c.User,
-		"password":             c.Password,
 		"application-id":       c.ApplicationId,
 		"application-password": c.ApplicationPassword,
+		"subscription-id":      c.SubscriptionId,
+		"tenant-id":            c.TenantId,
 	}
 }
 
@@ -134,10 +152,17 @@ var _ Credential = (*OAuth1Credentials)(nil)
 
 // OAuth1Credentials are oauth1 credentials.
 type OAuth1Credentials struct {
-	ConsumerKey    string `yaml:"consumer-key,omitempty"`
+	// ConsumerKey is the credential consumer key.
+	ConsumerKey string `yaml:"consumer-key,omitempty"`
+
+	// ConsumerSecret is the credential consumer secret.
 	ConsumerSecret string `yaml:"consumer-secret,omitempty"`
-	AccessToken    string `yaml:"access-token,omitempty"`
-	TokenSecret    string `yaml:"token-secret,omitempty"`
+
+	// AccessToken is the credential access token.
+	AccessToken string `yaml:"access-token,omitempty"`
+
+	// TokenSecret is the credential token secret.
+	TokenSecret string `yaml:"token-secret,omitempty"`
 }
 
 // AuthType is defined on Credentials interface.
@@ -159,9 +184,14 @@ var _ Credential = (*OAuth2Credentials)(nil)
 
 // OAuth2Credentials are oauth1 credentials.
 type OAuth2Credentials struct {
-	ClientId    string `yaml:"client-id,omitempty"`
+	// Client Id is the credential client id.
+	ClientId string `yaml:"client-id,omitempty"`
+
+	// ClientEmail is the credential client email.
 	ClientEmail string `yaml:"client-email,omitempty"`
-	PrivateKey  string `yaml:"private-key,omitempty"`
+
+	// PrivateKey is the credential private key.
+	PrivateKey string `yaml:"private-key,omitempty"`
 }
 
 // AuthType is defined on Credentials interface.

--- a/cloud/credentials_test.go
+++ b/cloud/credentials_test.go
@@ -112,7 +112,7 @@ credentials:
 `[1:])
 }
 
-func (s *credentialsSuite) TestMarshallAzureUserPass(c *gc.C) {
+func (s *credentialsSuite) TestMarshallAzureCredntials(c *gc.C) {
 	creds := cloud.Credentials{
 		Credentials: map[string]cloud.CloudCredential{
 			"azure": {
@@ -120,12 +120,10 @@ func (s *credentialsSuite) TestMarshallAzureUserPass(c *gc.C) {
 				DefaultRegion:     "Central US",
 				AuthCredentials: map[string]cloud.Credential{
 					"peter": &cloud.AzureUserPassCredentials{
-						UserPassCredentials: cloud.UserPassCredentials{
-							User:     "user",
-							Password: "secret",
-						},
 						ApplicationId:       "app-id",
 						ApplicationPassword: "app-secret",
+						SubscriptionId:      "subscription-id",
+						TenantId:            "tenant-id",
 					},
 				},
 			},
@@ -139,8 +137,8 @@ credentials:
     default-credential: default-cred
     default-region: Central US
     peter:
-      username: user
-      password: secret
+      subscription-id: subscription-id
+      tenant-id: tenant-id
       application-id: app-id
       application-password: app-secret
 `[1:])

--- a/cloud/credentials_test.go
+++ b/cloud/credentials_test.go
@@ -1,0 +1,209 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cloud_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/yaml.v2"
+
+	"github.com/juju/juju/cloud"
+)
+
+type credentialsSuite struct{}
+
+var _ = gc.Suite(&credentialsSuite{})
+
+func (s *credentialsSuite) TestMarshallAccessKey(c *gc.C) {
+	creds := cloud.Credentials{
+		Credentials: map[string]cloud.CloudCredential{
+			"aws": {
+				DefaultCredential: "default-cred",
+				DefaultRegion:     "us-west-2",
+				AuthCredentials: map[string]cloud.Credential{
+					"peter": &cloud.AccessKeyCredentials{
+						Key:    "key",
+						Secret: "secret",
+					},
+					// TODO(wallyworld) - add anther credential once goyaml.v2 supports inline MapSlice.
+					//"paul": &cloud.AccessKeyCredentials{
+					//	Key: "paulkey",
+					//	Secret: "paulsecret",
+					//},
+				},
+			},
+		},
+	}
+	out, err := yaml.Marshal(creds)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(string(out), gc.Equals, `
+credentials:
+  aws:
+    default-credential: default-cred
+    default-region: us-west-2
+    peter:
+      key: key
+      secret: secret
+`[1:])
+}
+
+func (s *credentialsSuite) TestMarshallOpenstackAccessKey(c *gc.C) {
+	creds := cloud.Credentials{
+		Credentials: map[string]cloud.CloudCredential{
+			"openstack": {
+				DefaultCredential: "default-cred",
+				DefaultRegion:     "region-a",
+				AuthCredentials: map[string]cloud.Credential{
+					"peter": &cloud.OpenstackAccessKeyCredentials{
+						AccessKeyCredentials: cloud.AccessKeyCredentials{
+							Key:    "key",
+							Secret: "secret",
+						},
+						Tenant: "tenant",
+					},
+				},
+			},
+		},
+	}
+	out, err := yaml.Marshal(creds)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(string(out), gc.Equals, `
+credentials:
+  openstack:
+    default-credential: default-cred
+    default-region: region-a
+    peter:
+      key: key
+      secret: secret
+      tenant-name: tenant
+`[1:])
+}
+
+func (s *credentialsSuite) TestMarshallOpenstackUserPass(c *gc.C) {
+	creds := cloud.Credentials{
+		Credentials: map[string]cloud.CloudCredential{
+			"openstack": {
+				DefaultCredential: "default-cred",
+				DefaultRegion:     "region-a",
+				AuthCredentials: map[string]cloud.Credential{
+					"peter": &cloud.OpenstackUserPassCredentials{
+						UserPassCredentials: cloud.UserPassCredentials{
+							User:     "user",
+							Password: "secret",
+						},
+						Tenant: "tenant",
+					},
+				},
+			},
+		},
+	}
+	out, err := yaml.Marshal(creds)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(string(out), gc.Equals, `
+credentials:
+  openstack:
+    default-credential: default-cred
+    default-region: region-a
+    peter:
+      username: user
+      password: secret
+      tenant-name: tenant
+`[1:])
+}
+
+func (s *credentialsSuite) TestMarshallAzureUserPass(c *gc.C) {
+	creds := cloud.Credentials{
+		Credentials: map[string]cloud.CloudCredential{
+			"azure": {
+				DefaultCredential: "default-cred",
+				DefaultRegion:     "Central US",
+				AuthCredentials: map[string]cloud.Credential{
+					"peter": &cloud.AzureUserPassCredentials{
+						UserPassCredentials: cloud.UserPassCredentials{
+							User:     "user",
+							Password: "secret",
+						},
+						ApplicationId:       "app-id",
+						ApplicationPassword: "app-secret",
+					},
+				},
+			},
+		},
+	}
+	out, err := yaml.Marshal(creds)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(string(out), gc.Equals, `
+credentials:
+  azure:
+    default-credential: default-cred
+    default-region: Central US
+    peter:
+      username: user
+      password: secret
+      application-id: app-id
+      application-password: app-secret
+`[1:])
+}
+
+func (s *credentialsSuite) TestMarshallOAuth1(c *gc.C) {
+	creds := cloud.Credentials{
+		Credentials: map[string]cloud.CloudCredential{
+			"maas": {
+				DefaultCredential: "default-cred",
+				DefaultRegion:     "region-default",
+				AuthCredentials: map[string]cloud.Credential{
+					"peter": &cloud.OAuth1Credentials{
+						ConsumerKey:    "consumer-key",
+						ConsumerSecret: "consumer-secret",
+						AccessToken:    "access-token",
+						TokenSecret:    "token-secret",
+					},
+				},
+			},
+		},
+	}
+	out, err := yaml.Marshal(creds)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(string(out), gc.Equals, `
+credentials:
+  maas:
+    default-credential: default-cred
+    default-region: region-default
+    peter:
+      consumer-key: consumer-key
+      consumer-secret: consumer-secret
+      access-token: access-token
+      token-secret: token-secret
+`[1:])
+}
+
+func (s *credentialsSuite) TestMarshallOAuth2(c *gc.C) {
+	creds := cloud.Credentials{
+		Credentials: map[string]cloud.CloudCredential{
+			"google": {
+				DefaultCredential: "default-cred",
+				DefaultRegion:     "West US",
+				AuthCredentials: map[string]cloud.Credential{
+					"peter": &cloud.OAuth2Credentials{
+						ClientId:    "client-id",
+						ClientEmail: "client-email",
+						PrivateKey:  "secret",
+					},
+				},
+			},
+		},
+	}
+	out, err := yaml.Marshal(creds)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(string(out), gc.Equals, `
+credentials:
+  google:
+    default-credential: default-cred
+    default-region: West US
+    peter:
+      client-id: client-id
+      client-email: client-email
+      private-key: secret
+`[1:])
+}


### PR DESCRIPTION
We add the data structs used for holding cloud credential info and the code to support yaml marshalling.

(Review request: http://reviews.vapour.ws/r/3449/)