### PR TITLE
worker/deployer: add missing error check

### DIFF
--- a/worker/deployer/simple.go
+++ b/worker/deployer/simple.go
@@ -115,13 +115,16 @@ func (ctx *SimpleContext) DeployUnit(unitName, initialPassword string) (err erro
 		Arch:   arch.HostArch(),
 		Series: series.HostSeries(),
 	}
-	_, err = tools.ChangeAgentTools(dataDir, tag.String(), current)
 	toolsDir := tools.ToolsDir(dataDir, tag.String())
 	defer removeOnErr(&err, toolsDir)
+	_, err = tools.ChangeAgentTools(dataDir, tag.String(), current)
+	if err != nil {
+		return errors.Trace(err)
+	}
 
 	result, err := ctx.api.ConnectionInfo()
 	if err != nil {
-		return err
+		return errors.Trace(err)
 	}
 	logger.Debugf("state addresses: %q", result.StateAddresses)
 	logger.Debugf("API addresses: %q", result.APIAddresses)
@@ -149,7 +152,7 @@ func (ctx *SimpleContext) DeployUnit(unitName, initialPassword string) (err erro
 			},
 		})
 	if err != nil {
-		return err
+		return errors.Trace(err)
 	}
 	if err := conf.Write(); err != nil {
 		return err


### PR DESCRIPTION
Spent some time debugging a deployment because juju didn't log here. I'm not sure if it's intentional or not, it goes back sometime. I'd argue we should at least log it, but returning it feels better. Opinions welcome.

(Review request: http://reviews.vapour.ws/r/3450/)