### PR TITLE
Ensure containers with static IP addresses have DNS info

### DIFF
--- a/worker/provisioner/lxc-broker.go
+++ b/worker/provisioner/lxc-broker.go
@@ -684,6 +684,17 @@ func prepareOrGetContainerInterfaceInfo(
 		return nil, errors.Trace(err)
 	}
 
+	dnsServers, searchDomain, dnsErr := localDNSServers()
+
+	if dnsErr != nil {
+		return nil, errors.Trace(dnsErr)
+	}
+
+	for i, _ := range preparedInfo {
+		preparedInfo[i].DNSServers = dnsServers
+		preparedInfo[i].DNSSearch = searchDomain
+	}
+
 	log.Tracef("PrepareContainerInterfaceInfo returned %#v", preparedInfo)
 	// Most likely there will be only one item in the list, but check
 	// all of them for forward compatibility.

--- a/worker/provisioner/lxc-broker_test.go
+++ b/worker/provisioner/lxc-broker_test.go
@@ -331,13 +331,12 @@ func (s *lxcBrokerSuite) TestStartInstanceWithBridgeEnviron(c *gc.C) {
 	AssertFileContains(c, lxc_conf, expect...)
 }
 
-func (s *lxcBrokerSuite) TestStartInstancePopulatesNetworkInfo(c *gc.C) {
-	s.SetFeatureFlags(feature.AddressAllocation)
+func (s *lxcBrokerSuite) startInstancePopulatesNetworkInfo(c *gc.C) (*environs.StartInstanceResult, error) {
 	s.PatchValue(provisioner.InterfaceAddrs, func(i *net.Interface) ([]net.Addr, error) {
 		return []net.Addr{&fakeAddr{"0.1.2.1/24"}}, nil
 	})
 	fakeResolvConf := filepath.Join(c.MkDir(), "resolv.conf")
-	err := ioutil.WriteFile(fakeResolvConf, []byte("nameserver ns1.dummy\n"), 0644)
+	err := ioutil.WriteFile(fakeResolvConf, []byte("nameserver ns1.dummy\nnameserver ns2.dummy\nsearch dummy\n"), 0644)
 	c.Assert(err, jc.ErrorIsNil)
 	s.PatchValue(provisioner.ResolvConf, fakeResolvConf)
 
@@ -346,11 +345,16 @@ func (s *lxcBrokerSuite) TestStartInstancePopulatesNetworkInfo(c *gc.C) {
 		Version: version.MustParseBinary("2.3.4-quantal-amd64"),
 		URL:     "http://tools.testing.invalid/2.3.4-quantal-amd64.tgz",
 	}}
-	result, err := s.broker.StartInstance(environs.StartInstanceParams{
+	return s.broker.StartInstance(environs.StartInstanceParams{
 		Constraints:    constraints.Value{},
 		Tools:          possibleTools,
 		InstanceConfig: instanceConfig,
 	})
+}
+
+func (s *lxcBrokerSuite) TestStartInstancePopulatesNetworkInfoWithAddressAllocation(c *gc.C) {
+	s.SetFeatureFlags(feature.AddressAllocation)
+	result, err := s.startInstancePopulatesNetworkInfo(c)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.NetworkInfo, gc.HasLen, 1)
 	iface := result.NetworkInfo[0]
@@ -361,11 +365,30 @@ func (s *lxcBrokerSuite) TestStartInstancePopulatesNetworkInfo(c *gc.C) {
 		ConfigType:     network.ConfigStatic,
 		InterfaceName:  "eth0", // generated from the device index.
 		MACAddress:     "aa:bb:cc:dd:ee:ff",
-		DNSServers:     network.NewAddresses("ns1.dummy"),
+		DNSServers:     network.NewAddresses("ns1.dummy", "ns2.dummy"),
+		DNSSearch:      "dummy",
 		Address:        network.NewAddress("0.1.2.3"),
 		GatewayAddress: network.NewAddress("0.1.2.1"),
 		NetworkName:    network.DefaultPrivate,
 		ProviderId:     network.DefaultProviderId,
+	})
+}
+
+func (s *lxcBrokerSuite) TestStartInstancePopulatesNetworkInfoWithoutAddressAllocation(c *gc.C) {
+	result, err := s.startInstancePopulatesNetworkInfo(c)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.NetworkInfo, gc.HasLen, 1)
+	iface := result.NetworkInfo[0]
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(iface, jc.DeepEquals, network.InterfaceInfo{
+		DeviceIndex:    0,
+		CIDR:           "0.1.2.0/24",
+		InterfaceName:  "dummy0", // generated from the device index.
+		MACAddress:     "aa:bb:cc:dd:ee:ff",
+		DNSServers:     network.NewAddresses("ns1.dummy", "ns2.dummy"),
+		DNSSearch:      "dummy",
+		Address:        network.NewAddress("0.1.2.3"),
+		GatewayAddress: network.NewAddress("0.1.2.1"),
 	})
 }
 

--- a/worker/provisioner/lxc-broker_test.go
+++ b/worker/provisioner/lxc-broker_test.go
@@ -375,6 +375,7 @@ func (s *lxcBrokerSuite) TestStartInstancePopulatesNetworkInfoWithAddressAllocat
 }
 
 func (s *lxcBrokerSuite) TestStartInstancePopulatesNetworkInfoWithoutAddressAllocation(c *gc.C) {
+	s.SetFeatureFlags()
 	result, err := s.startInstancePopulatesNetworkInfo(c)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.NetworkInfo, gc.HasLen, 1)


### PR DESCRIPTION
Since the switch to generate unique MAAS hostnames and with it a switch
to use static IP address allocation a container now has an empty
/etc/resolv.conf; its DNS info previously came from the DHCP lease.

This change augments the manually configured interface info by using the
existing code that parses /etc/resolv.conf (on the host) and adds that
to the containers' interface information.

Fixes [LP:#1528217](https://bugs.launchpad.net/juju-core/+bug/1528217)

(Review request: http://reviews.vapour.ws/r/3451/)