### PR TITLE
provider/lxd: implement RestrictedConfigAttributes

### DIFF
--- a/apiserver/environmentmanager/environmentmanager_test.go
+++ b/apiserver/environmentmanager/environmentmanager_test.go
@@ -21,6 +21,7 @@ import (
 	_ "github.com/juju/juju/provider/ec2"
 	_ "github.com/juju/juju/provider/joyent"
 	_ "github.com/juju/juju/provider/local"
+	_ "github.com/juju/juju/provider/lxd"
 	_ "github.com/juju/juju/provider/maas"
 	_ "github.com/juju/juju/provider/openstack"
 	"github.com/juju/juju/state"
@@ -157,6 +158,11 @@ func (s *envManagerSuite) TestRestrictedProviderFields(c *gc.C) {
 			expected: []string{
 				"type", "ca-cert", "state-port", "api-port", "syslog-port", "rsyslog-ca-cert", "rsyslog-ca-key",
 				"container", "network-bridge", "root-dir", "proxy-ssh"},
+		}, {
+			provider: "lxd",
+			expected: []string{
+				"type", "ca-cert", "state-port", "api-port", "syslog-port", "rsyslog-ca-cert", "rsyslog-ca-key",
+				"remote-url", "client-cert", "client-key"},
 		}, {
 			provider: "maas",
 			expected: []string{

--- a/apiserver/environmentmanager/environmentmanager_test.go
+++ b/apiserver/environmentmanager/environmentmanager_test.go
@@ -21,7 +21,6 @@ import (
 	_ "github.com/juju/juju/provider/ec2"
 	_ "github.com/juju/juju/provider/joyent"
 	_ "github.com/juju/juju/provider/local"
-	_ "github.com/juju/juju/provider/lxd"
 	_ "github.com/juju/juju/provider/maas"
 	_ "github.com/juju/juju/provider/openstack"
 	"github.com/juju/juju/state"
@@ -158,11 +157,6 @@ func (s *envManagerSuite) TestRestrictedProviderFields(c *gc.C) {
 			expected: []string{
 				"type", "ca-cert", "state-port", "api-port", "syslog-port", "rsyslog-ca-cert", "rsyslog-ca-key",
 				"container", "network-bridge", "root-dir", "proxy-ssh"},
-		}, {
-			provider: "lxd",
-			expected: []string{
-				"type", "ca-cert", "state-port", "api-port", "syslog-port", "rsyslog-ca-cert", "rsyslog-ca-key",
-				"remote-url", "client-cert", "client-key"},
 		}, {
 			provider: "maas",
 			expected: []string{

--- a/provider/lxd/provider.go
+++ b/provider/lxd/provider.go
@@ -56,8 +56,11 @@ func (environProvider) PrepareForCreateEnvironment(cfg *config.Config) (*config.
 
 // RestrictedConfigAttributes is specified in the EnvironProvider interface.
 func (environProvider) RestrictedConfigAttributes() []string {
-	// TODO(ericsnow) fix this...
-	return []string{}
+	return []string{
+		"remote-url",
+		"client-cert",
+		"client-key",
+	}
 }
 
 // Validate implements environs.EnvironProvider.


### PR DESCRIPTION
There are attributes in lxd config that need to be carried
across to new environments or they will fail immediately.

Fixes https://bugs.launchpad.net/juju-core/+bug/1531064

(Review request: http://reviews.vapour.ws/r/3453/)