### PR TITLE
Add proper defaults for saving image metadata

### DIFF
--- a/apiserver/imagemetadata/export_test.go
+++ b/apiserver/imagemetadata/export_test.go
@@ -5,6 +5,7 @@ package imagemetadata
 
 import (
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/environs"
 	"github.com/juju/juju/state/cloudimagemetadata"
 )
 
@@ -13,6 +14,6 @@ var (
 	ProcessErrors = processErrors
 )
 
-func ParseMetadataFromParams(api *API, p params.CloudImageMetadata) (cloudimagemetadata.Metadata, error) {
-	return api.parseMetadataFromParams(p)
+func ParseMetadataFromParams(api *API, p params.CloudImageMetadata, env environs.Environ) (cloudimagemetadata.Metadata, error) {
+	return api.parseMetadataFromParams(p, env)
 }

--- a/apiserver/imagemetadata/export_test.go
+++ b/apiserver/imagemetadata/export_test.go
@@ -3,8 +3,16 @@
 
 package imagemetadata
 
-var (
-	CreateAPI               = createAPI
-	ParseMetadataFromParams = parseMetadataFromParams
-	ProcessErrors           = processErrors
+import (
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/state/cloudimagemetadata"
 )
+
+var (
+	CreateAPI     = createAPI
+	ProcessErrors = processErrors
+)
+
+func ParseMetadataFromParams(api *API, p params.CloudImageMetadata) (cloudimagemetadata.Metadata, error) {
+	return api.parseMetadataFromParams(p)
+}

--- a/apiserver/imagemetadata/metadata_test.go
+++ b/apiserver/imagemetadata/metadata_test.go
@@ -104,7 +104,7 @@ func (s *metadataSuite) TestSaveEmpty(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(errs.Results, gc.HasLen, 0)
 	// not expected to call state :D
-	s.assertCalls(c, []string{})
+	s.assertCalls(c, []string{environConfig})
 }
 
 func (s *metadataSuite) TestSave(c *gc.C) {
@@ -129,5 +129,5 @@ func (s *metadataSuite) TestSave(c *gc.C) {
 	c.Assert(errs.Results, gc.HasLen, 2)
 	c.Assert(errs.Results[0].Error, gc.IsNil)
 	c.Assert(errs.Results[1].Error, gc.ErrorMatches, msg)
-	s.assertCalls(c, []string{environConfig, saveMetadata, environConfig, saveMetadata})
+	s.assertCalls(c, []string{environConfig, saveMetadata, saveMetadata})
 }

--- a/apiserver/imagemetadata/metadata_test.go
+++ b/apiserver/imagemetadata/metadata_test.go
@@ -113,9 +113,11 @@ func (s *metadataSuite) TestSave(c *gc.C) {
 	}
 	msg := "save error"
 
+	saveCalls := 0
 	s.state.saveMetadata = func(m cloudimagemetadata.Metadata) error {
 		s.calls = append(s.calls, saveMetadata)
-		if len(s.calls) == 1 {
+		saveCalls += 1
+		if saveCalls == 1 {
 			// don't err on first call
 			return nil
 		}
@@ -127,5 +129,5 @@ func (s *metadataSuite) TestSave(c *gc.C) {
 	c.Assert(errs.Results, gc.HasLen, 2)
 	c.Assert(errs.Results[0].Error, gc.IsNil)
 	c.Assert(errs.Results[1].Error, gc.ErrorMatches, msg)
-	s.assertCalls(c, []string{saveMetadata, saveMetadata})
+	s.assertCalls(c, []string{environConfig, saveMetadata, environConfig, saveMetadata})
 }

--- a/apiserver/imagemetadata/package_test.go
+++ b/apiserver/imagemetadata/package_test.go
@@ -45,7 +45,7 @@ type baseImageMetadataSuite struct {
 
 func (s *baseImageMetadataSuite) SetUpSuite(c *gc.C) {
 	s.BaseSuite.SetUpSuite(c)
-	imagetesting.PatchOfficialDataSources(&s.CleanupSuite, "")
+	imagetesting.PatchOfficialDataSources(&s.CleanupSuite, "test:")
 }
 
 func (s *baseImageMetadataSuite) SetUpTest(c *gc.C) {

--- a/apiserver/imagemetadata/package_test.go
+++ b/apiserver/imagemetadata/package_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/configstore"
+	imagetesting "github.com/juju/juju/environs/imagemetadata/testing"
 	envtesting "github.com/juju/juju/environs/testing"
 	"github.com/juju/juju/state/cloudimagemetadata"
 	coretesting "github.com/juju/juju/testing"
@@ -23,6 +24,11 @@ import (
 
 func TestAll(t *stdtesting.T) {
 	gc.TestingT(t)
+}
+
+func init() {
+	provider := mockEnvironProvider{}
+	environs.RegisterProvider("mock", provider)
 }
 
 type baseImageMetadataSuite struct {
@@ -35,6 +41,11 @@ type baseImageMetadataSuite struct {
 	state *mockState
 
 	calls []string
+}
+
+func (s *baseImageMetadataSuite) SetUpSuite(c *gc.C) {
+	s.BaseSuite.SetUpSuite(c)
+	imagetesting.PatchOfficialDataSources(&s.CleanupSuite, "")
 }
 
 func (s *baseImageMetadataSuite) SetUpTest(c *gc.C) {
@@ -97,7 +108,7 @@ func (st *mockState) EnvironConfig() (*config.Config, error) {
 
 func testConfig(c *gc.C) *config.Config {
 	attrs := coretesting.FakeConfig().Merge(coretesting.Attrs{
-		"type":         "dummy",
+		"type":         "mock",
 		"state-server": true,
 		"state-id":     "1",
 	})

--- a/apiserver/imagemetadata/updatefrompublished_test.go
+++ b/apiserver/imagemetadata/updatefrompublished_test.go
@@ -232,8 +232,7 @@ var _ = gc.Suite(&regionMetadataSuite{})
 type regionMetadataSuite struct {
 	baseImageMetadataSuite
 
-	provider mockEnvironProvider
-	env      *mockEnviron
+	env *mockEnviron
 
 	saved    []cloudimagemetadata.Metadata
 	expected []cloudimagemetadata.Metadata
@@ -242,9 +241,7 @@ type regionMetadataSuite struct {
 func (s *regionMetadataSuite) SetUpSuite(c *gc.C) {
 	s.baseImageMetadataSuite.SetUpSuite(c)
 
-	s.provider = mockEnvironProvider{}
 	s.env = &mockEnviron{}
-	environs.RegisterProvider("mock", s.provider)
 
 	s.PatchValue(&imagemetadata.SimplestreamsImagesPublicKey, sstesting.SignedMetadataPublicKey)
 	// Prepare mock http transport for overriding metadata and images output in tests.

--- a/apiserver/imagemetadata/updatefrompublished_test.go
+++ b/apiserver/imagemetadata/updatefrompublished_test.go
@@ -425,7 +425,11 @@ func (s *regionMetadataSuite) TestUpdateFromPublishedImagesMultipleDS(c *gc.C) {
 
 	s.expected = append(s.expected, m1)
 
-	s.checkStoredPublished(c)
+	err = s.api.UpdateFromPublishedImages()
+	c.Assert(err, jc.ErrorIsNil)
+	calls := []string{environConfig, environConfig, saveMetadata, environConfig, saveMetadata, saveMetadata}
+	s.assertCalls(c, calls)
+	c.Assert(s.saved, jc.SameContents, s.expected)
 }
 
 func (s *regionMetadataSuite) TestUpdateFromPublishedImagesMultipleDSError(c *gc.C) {

--- a/apiserver/imagemetadata/updatefrompublished_test.go
+++ b/apiserver/imagemetadata/updatefrompublished_test.go
@@ -307,7 +307,7 @@ func (s *regionMetadataSuite) checkStoredPublished(c *gc.C) {
 	err := s.api.UpdateFromPublishedImages()
 	c.Assert(err, jc.ErrorIsNil)
 
-	tempCalls := []string{environConfig}
+	tempCalls := []string{environConfig, environConfig}
 	for _ = range s.expected {
 		tempCalls = append(tempCalls, saveMetadata)
 	}

--- a/apiserver/provisioner/provisioner.go
+++ b/apiserver/provisioner/provisioner.go
@@ -1545,6 +1545,7 @@ func (p *ProvisionerAPI) availableImageMetadata(m *state.Machine) ([]params.Clou
 	}
 
 	sort.Sort(metadataList(data))
+	logger.Debugf("available image metadata for provisioning: %v", data)
 	return data, nil
 }
 
@@ -1604,7 +1605,7 @@ func (p *ProvisionerAPI) findImageMetadata(imageConstraint *imagemetadata.ImageC
 			return nil, errors.Trace(err)
 		}
 	}
-	logger.Warningf("got from data sources %d metadata", len(dsMetadata))
+	logger.Debugf("got from data sources %d metadata", len(dsMetadata))
 
 	return dsMetadata, nil
 }

--- a/cmd/plugins/juju-metadata/addimage.go
+++ b/cmd/plugins/juju-metadata/addimage.go
@@ -35,8 +35,8 @@ options:
 -e, --environment (= "")
    juju environment to operate in
 --region
-   cloud region
---series (= "trusty")
+   cloud region (= region of current model)
+--series (= current model preferred series)
    image series
 --arch (= "amd64")
    image architectures
@@ -91,9 +91,7 @@ func (c *addImageMetadataCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.cloudImageMetadataCommandBase.SetFlags(f)
 
 	f.StringVar(&c.Region, "region", "", "image cloud region")
-	// TODO (anastasiamac 2015-09-30) Ideally default should be latest LTS.
-	// Hard-coding "trusty" for now.
-	f.StringVar(&c.Series, "series", "trusty", "image series")
+	f.StringVar(&c.Series, "series", "", "image series")
 	f.StringVar(&c.Arch, "arch", "amd64", "image architecture")
 	f.StringVar(&c.VirtType, "virt-type", "", "image metadata virtualisation type")
 	f.StringVar(&c.RootStorageType, "storage-type", "", "image metadata root storage type")
@@ -140,8 +138,10 @@ func (c *addImageMetadataCommand) getImageMetadataAddAPI() (MetadataAddAPI, erro
 
 // Init implements Command.Init.
 func (c *addImageMetadataCommand) validate() error {
-	if _, err := series.SeriesVersion(c.Series); err != nil {
-		return errors.Trace(err)
+	if c.Series != "" {
+		if _, err := series.SeriesVersion(c.Series); err != nil {
+			return errors.Trace(err)
+		}
 	}
 	return nil
 }

--- a/cmd/plugins/juju-metadata/addimage_test.go
+++ b/cmd/plugins/juju-metadata/addimage_test.go
@@ -136,9 +136,6 @@ func (s *addImageSuite) assertValidAddImageMetadata(c *gc.C, m params.CloudImage
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Need to make sure that defaults are populated
-	if m.Series == "" {
-		m.Series = "trusty"
-	}
 	if m.Arch == "" {
 		m.Arch = "amd64"
 	}

--- a/cmd/plugins/juju-metadata/imagemetadata_test.go
+++ b/cmd/plugins/juju-metadata/imagemetadata_test.go
@@ -71,6 +71,7 @@ var seriesVersions map[string]string = map[string]string{
 	"precise": "12.04",
 	"raring":  "13.04",
 	"trusty":  "14.04",
+	"xenial":  "16.04",
 }
 
 type expectedMetadata struct {

--- a/provider/ec2/image.go
+++ b/provider/ec2/image.go
@@ -51,6 +51,7 @@ func findInstanceSpec(
 		ic.Constraints.CpuPower = instances.CpuPower(defaultCpuPower)
 	}
 	suitableImages := filterImages(allImageMetadata, ic)
+	logger.Debugf("suitable images %v", suitableImages)
 	images := instances.ImageMetadataToImages(suitableImages)
 
 	// Make a copy of the known EC2 instance types, filling in the cost for the specified region.

--- a/state/cloudimagemetadata/image.go
+++ b/state/cloudimagemetadata/image.go
@@ -36,6 +36,7 @@ var emptyMetadata = Metadata{}
 
 // SaveMetadata implements Storage.SaveMetadata and behaves as save-or-update.
 func (s *storage) SaveMetadata(metadata Metadata) error {
+	logger.Debugf("saving image metadata to state: %#v", metadata)
 	newDoc := s.mongoDoc(metadata)
 	if err := validateMetadata(&newDoc); err != nil {
 		return err


### PR DESCRIPTION
On the apiserver side, when image metadata is saved, we set the correct default values for region and series. These come from the environment.

Also add extra debugging to allow CI test failures to be diagnosed beter.

(Review request: http://reviews.vapour.ws/r/3455/)