### PR TITLE
"juju upload": Preserve CLI order of resources.

### DIFF
--- a/resource/cmd/file.go
+++ b/resource/cmd/file.go
@@ -1,0 +1,55 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/juju/errors"
+)
+
+// resourceFile associates a resource name to a filename.
+type resourceFile struct {
+	service  string
+	name     string
+	filename string
+}
+
+// parseResourceFile converts the provided string into a resourceFile.
+// The string must be in the "<name>=<filename>" format.
+func parseResourceFile(service, raw string) (resourceFile, error) {
+	rf := resourceFile{
+		service: service,
+	}
+
+	vals := strings.SplitN(raw, "=", 2)
+	if len(vals) < 2 {
+		msg := fmt.Sprintf("resource given: %q, but expected name=path format", raw)
+		return rf, errors.NewNotValid(nil, msg)
+	}
+
+	rf.name, rf.filename = vals[0], vals[1]
+	if err := rf.validate(); err != nil {
+		return rf, errors.Annotatef(err, "invalid arg %q", raw)
+	}
+	return rf, nil
+}
+
+// validate ensures that the resourceFile is correct.
+func (rf resourceFile) validate() error {
+	if rf.service == "" {
+		return errors.NewNotValid(nil, "missing service name")
+	}
+
+	if rf.name == "" {
+		return errors.NewNotValid(nil, "missing resource name")
+	}
+
+	if rf.filename == "" {
+		return errors.NewNotValid(nil, "missing filename")
+	}
+
+	return nil
+}

--- a/resource/cmd/file.go
+++ b/resource/cmd/file.go
@@ -17,39 +17,21 @@ type resourceFile struct {
 	filename string
 }
 
-// parseResourceFile converts the provided string into a resourceFile.
-// The string must be in the "<name>=<filename>" format.
-func parseResourceFile(service, raw string) (resourceFile, error) {
-	rf := resourceFile{
-		service: service,
-	}
-
+// parseResourceFileArg converts the provided string into a name and
+// filename. The string must be in the "<name>=<filename>" format.
+func parseResourceFileArg(raw string) (name string, filename string, _ error) {
 	vals := strings.SplitN(raw, "=", 2)
 	if len(vals) < 2 {
-		msg := fmt.Sprintf("resource given: %q, but expected name=path format", raw)
-		return rf, errors.NewNotValid(nil, msg)
+		msg := fmt.Sprintf("expected name=path format")
+		return "", "", errors.NewNotValid(nil, msg)
 	}
 
-	rf.name, rf.filename = vals[0], vals[1]
-	if err := rf.validate(); err != nil {
-		return rf, errors.Annotatef(err, "invalid arg %q", raw)
+	name, filename = vals[0], vals[1]
+	if name == "" {
+		return "", "", errors.NewNotValid(nil, "missing resource name")
 	}
-	return rf, nil
-}
-
-// validate ensures that the resourceFile is correct.
-func (rf resourceFile) validate() error {
-	if rf.service == "" {
-		return errors.NewNotValid(nil, "missing service name")
+	if filename == "" {
+		return "", "", errors.NewNotValid(nil, "missing filename")
 	}
-
-	if rf.name == "" {
-		return errors.NewNotValid(nil, "missing resource name")
-	}
-
-	if rf.filename == "" {
-		return errors.NewNotValid(nil, "missing filename")
-	}
-
-	return nil
+	return name, filename, nil
 }

--- a/resource/cmd/stub_test.go
+++ b/resource/cmd/stub_test.go
@@ -27,12 +27,6 @@ func (s *stubCharmStore) ListResources(charmURLs []charm.URL) ([][]charmresource
 	return s.ReturnListResources, nil
 }
 
-func (s *stubCharmStore) Upload(service, name string, resource io.Reader) error {
-	s.stub.AddCall("Upload", service, name, resource)
-	err := s.stub.NextErr()
-	return errors.Trace(err)
-}
-
 func (s *stubCharmStore) Close() error {
 	s.stub.AddCall("Close")
 	if err := s.stub.NextErr(); err != nil {
@@ -40,4 +34,37 @@ func (s *stubCharmStore) Close() error {
 	}
 
 	return nil
+}
+
+type stubAPIClient struct {
+	stub *testing.Stub
+}
+
+func (s *stubAPIClient) Upload(service, name string, resource io.Reader) error {
+	s.stub.AddCall("Upload", service, name, resource)
+	if err := s.stub.NextErr(); err != nil {
+		return errors.Trace(err)
+	}
+
+	return nil
+}
+
+func (s *stubAPIClient) Close() error {
+	s.stub.AddCall("Close")
+	if err := s.stub.NextErr(); err != nil {
+		return errors.Trace(err)
+	}
+
+	return nil
+}
+
+type stubFile struct {
+	// No one actually tries to read from this during tests.
+	io.Reader
+	stub *testing.Stub
+}
+
+func (s *stubFile) Close() error {
+	s.stub.AddCall("FileClose")
+	return errors.Trace(s.stub.NextErr())
 }

--- a/resource/cmd/upload.go
+++ b/resource/cmd/upload.go
@@ -110,7 +110,7 @@ func (c *UploadCommand) Run(*cmd.Context) error {
 	for _, rf := range c.resourceFiles {
 		// don't want to do a bulk upload since we're doing potentially large
 		// file uploads.
-		if err := c.upload(rf.service, rf.name, rf.filename, apiclient); err != nil {
+		if err := c.upload(rf, apiclient); err != nil {
 			name := rf.service + "/" + rf.name
 			errs = append(errs, errors.Annotatef(err, "failed to upload resource %q", name))
 		}
@@ -131,12 +131,12 @@ func (c *UploadCommand) Run(*cmd.Context) error {
 
 // upload opens the given file and calls the apiclient to upload it to the given
 // service with the given name.
-func (c *UploadCommand) upload(service, name, file string, client UploadClient) error {
-	f, err := c.deps.OpenResource(file)
+func (c *UploadCommand) upload(rf resourceFile, client UploadClient) error {
+	f, err := c.deps.OpenResource(rf.filename)
 	if err != nil {
 		return errors.Trace(err)
 	}
 	defer f.Close()
-	err = client.Upload(service, name, f)
+	err = client.Upload(rf.service, rf.name, f)
 	return errors.Trace(err)
 }

--- a/resource/cmd/upload.go
+++ b/resource/cmd/upload.go
@@ -97,7 +97,6 @@ func (c *UploadCommand) addResourceFile(arg string) error {
 		filename: filename,
 	}
 
-	// TODO(ericsnow) Allow last one to win (a standard CLI approach)?
 	if c.resources[rf.name] {
 		msg := fmt.Sprintf("duplicate resource %q", rf.name)
 		return errors.NewAlreadyExists(nil, msg)

--- a/resource/cmd/upload.go
+++ b/resource/cmd/upload.go
@@ -120,8 +120,7 @@ func (c *UploadCommand) Run(*cmd.Context) error {
 		// don't want to do a bulk upload since we're doing potentially large
 		// file uploads.
 		if err := c.upload(rf, apiclient); err != nil {
-			name := rf.service + "/" + rf.name
-			errs = append(errs, errors.Annotatef(err, "failed to upload resource %q", name))
+			errs = append(errs, errors.Annotatef(err, "failed to upload resource %q", rf.name))
 		}
 	}
 	switch len(errs) {

--- a/resource/cmd/upload.go
+++ b/resource/cmd/upload.go
@@ -4,6 +4,7 @@
 package cmd
 
 import (
+	"fmt"
 	"io"
 	"strings"
 
@@ -88,8 +89,8 @@ func (c *UploadCommand) addResourceFile(arg string) error {
 
 	// TODO(ericsnow) Allow last one to win (a standard CLI approach)?
 	if c.resources[rf.name] {
-		// TODO(ericsnow) Use a better error message.
-		return errors.AlreadyExistsf("resource %q", rf.name)
+		msg := fmt.Sprintf("duplicate resource %q", rf.name)
+		return errors.NewAlreadyExists(nil, msg)
 	}
 	c.resourceFiles = append(c.resourceFiles, rf)
 	c.resources[rf.name] = true

--- a/resource/cmd/upload.go
+++ b/resource/cmd/upload.go
@@ -35,7 +35,7 @@ type UploadCommand struct {
 	envcmd.EnvCommandBase
 	service       string
 	resourceFiles []resourceFile
-	resources     map[string]bool
+	resources     map[string]struct{}
 }
 
 // NewUploadCommand returns a new command that lists resources defined
@@ -73,7 +73,7 @@ func (c *UploadCommand) Init(args []string) error {
 	}
 	c.service = service
 
-	c.resources = make(map[string]bool)
+	c.resources = make(map[string]struct{})
 
 	for _, arg := range args[1:] {
 		if err := c.addResourceFile(arg); err != nil {
@@ -97,12 +97,12 @@ func (c *UploadCommand) addResourceFile(arg string) error {
 		filename: filename,
 	}
 
-	if c.resources[rf.name] {
+	if _, ok := c.resources[rf.name]; ok {
 		msg := fmt.Sprintf("duplicate resource %q", rf.name)
 		return errors.NewAlreadyExists(nil, msg)
 	}
 	c.resourceFiles = append(c.resourceFiles, rf)
-	c.resources[rf.name] = true
+	c.resources[rf.name] = struct{}{}
 	return nil
 }
 

--- a/resource/cmd/upload_test.go
+++ b/resource/cmd/upload_test.go
@@ -19,17 +19,18 @@ var _ = gc.Suite(&UploadSuite{})
 type UploadSuite struct {
 	testing.IsolationSuite
 
+	stub     *testing.Stub
 	stubDeps *stubUploadDeps
 }
 
 func (s *UploadSuite) SetUpTest(c *gc.C) {
 	s.IsolationSuite.SetUpTest(c)
 
-	stub := &testing.Stub{}
+	s.stub = &testing.Stub{}
 	s.stubDeps = &stubUploadDeps{
-		stub:   stub,
-		file:   &stubFile{stub: stub},
-		client: &stubCharmStore{stub: stub},
+		stub:   s.stub,
+		file:   &stubFile{stub: s.stub},
+		client: &stubCharmStore{stub: s.stub},
 	}
 }
 
@@ -140,11 +141,11 @@ func (s *UploadSuite) TestRun(c *gc.C) {
 	err := u.Run(nil)
 	c.Assert(err, jc.ErrorIsNil)
 
-	checkCall(c, s.stubDeps.stub, "OpenResource", [][]interface{}{
+	checkCall(c, s.stub, "OpenResource", [][]interface{}{
 		{"bar"},
 		{"bat"},
 	})
-	checkCall(c, s.stubDeps.stub, "Upload", [][]interface{}{
+	checkCall(c, s.stub, "Upload", [][]interface{}{
 		{"svc", "foo", s.stubDeps.file},
 		{"svc", "baz", s.stubDeps.file},
 	})

--- a/resource/cmd/upload_test.go
+++ b/resource/cmd/upload_test.go
@@ -34,64 +34,73 @@ func (s *UploadSuite) SetUpTest(c *gc.C) {
 }
 
 func (*UploadSuite) TestInitEmpty(c *gc.C) {
-	u := UploadCommand{resourceFiles: map[string]string{}}
+	var u UploadCommand
 
 	err := u.Init([]string{})
 	c.Assert(err, jc.Satisfies, errors.IsBadRequest)
 }
 
 func (*UploadSuite) TestInitOneArg(c *gc.C) {
-	u := UploadCommand{resourceFiles: map[string]string{}}
+	var u UploadCommand
 	err := u.Init([]string{"foo"})
 	c.Assert(err, jc.Satisfies, errors.IsBadRequest)
 }
 
 func (*UploadSuite) TestInitJustName(c *gc.C) {
-	u := UploadCommand{resourceFiles: map[string]string{}}
+	var u UploadCommand
 
 	err := u.Init([]string{"foo", "bar"})
 	c.Assert(err, jc.Satisfies, errors.IsNotValid)
 }
 
 func (*UploadSuite) TestInitDuplicate(c *gc.C) {
-	u := UploadCommand{resourceFiles: map[string]string{}}
+	var u UploadCommand
 
 	err := u.Init([]string{"foo", "foo=bar", "foo=baz"})
 	c.Assert(errors.Cause(err), jc.Satisfies, errors.IsAlreadyExists)
 }
 
 func (*UploadSuite) TestInitNoName(c *gc.C) {
-	u := UploadCommand{resourceFiles: map[string]string{}}
+	var u UploadCommand
 
 	err := u.Init([]string{"foo", "=foobar"})
 	c.Assert(errors.Cause(err), jc.Satisfies, errors.IsNotValid)
 }
 
 func (*UploadSuite) TestInitNoPath(c *gc.C) {
-	u := UploadCommand{resourceFiles: map[string]string{}}
+	var u UploadCommand
 
 	err := u.Init([]string{"foo", "foobar="})
 	c.Assert(errors.Cause(err), jc.Satisfies, errors.IsNotValid)
 }
 
 func (*UploadSuite) TestInitGood(c *gc.C) {
-	u := UploadCommand{resourceFiles: map[string]string{}}
+	var u UploadCommand
 
 	err := u.Init([]string{"foo", "bar=baz"})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(u.resourceFiles, gc.DeepEquals, map[string]string{"bar": "baz"})
+	c.Assert(u.resourceFiles, gc.DeepEquals, []resourceFile{{
+		service:  "foo",
+		name:     "bar",
+		filename: "baz",
+	}})
 	c.Assert(u.service, gc.Equals, "foo")
 }
 
 func (*UploadSuite) TestInitTwoResources(c *gc.C) {
-	u := UploadCommand{resourceFiles: map[string]string{}}
+	var u UploadCommand
 
 	err := u.Init([]string{"foo", "bar=baz", "fizz=buzz"})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(u.resourceFiles, gc.DeepEquals, map[string]string{
-		"bar":  "baz",
-		"fizz": "buzz",
-	})
+	c.Assert(u.resourceFiles, gc.DeepEquals, []resourceFile{{
+		service:  "foo",
+		name:     "bar",
+		filename: "baz",
+	}, {
+		service:  "foo",
+		name:     "fizz",
+		filename: "buzz",
+	}})
 	c.Assert(u.service, gc.Equals, "foo")
 }
 
@@ -116,8 +125,16 @@ func (s *UploadSuite) TestRun(c *gc.C) {
 			NewClient:    s.stubDeps.NewClient,
 			OpenResource: s.stubDeps.OpenResource,
 		},
-		resourceFiles: map[string]string{"foo": "bar", "baz": "bat"},
-		service:       "svc",
+		resourceFiles: []resourceFile{{
+			service:  "svc",
+			name:     "foo",
+			filename: "bar",
+		}, {
+			service:  "svc",
+			name:     "baz",
+			filename: "bat",
+		}},
+		service: "svc",
 	}
 
 	err := u.Run(nil)

--- a/resource/cmd/upload_test.go
+++ b/resource/cmd/upload_test.go
@@ -30,7 +30,7 @@ func (s *UploadSuite) SetUpTest(c *gc.C) {
 	s.stubDeps = &stubUploadDeps{
 		stub:   s.stub,
 		file:   &stubFile{stub: s.stub},
-		client: &stubCharmStore{stub: s.stub},
+		client: &stubAPIClient{stub: s.stub},
 	}
 }
 
@@ -184,8 +184,8 @@ func checkSameContent(c *gc.C, actual, expected [][]interface{}) {
 
 type stubUploadDeps struct {
 	stub   *testing.Stub
-	file   *stubFile
-	client *stubCharmStore
+	file   io.ReadCloser
+	client UploadClient
 }
 
 func (s *stubUploadDeps) NewClient(c *UploadCommand) (UploadClient, error) {
@@ -204,15 +204,4 @@ func (s *stubUploadDeps) OpenResource(path string) (io.ReadCloser, error) {
 	}
 
 	return s.file, nil
-}
-
-type stubFile struct {
-	// No one actually tries to read from this during tests.
-	io.Reader
-	stub *testing.Stub
-}
-
-func (s *stubFile) Close() error {
-	s.stub.AddCall("FileClose")
-	return errors.Trace(s.stub.NextErr())
 }

--- a/resource/cmd/upload_test.go
+++ b/resource/cmd/upload_test.go
@@ -34,61 +34,61 @@ func (s *UploadSuite) SetUpTest(c *gc.C) {
 }
 
 func (*UploadSuite) TestInitEmpty(c *gc.C) {
-	u := UploadCommand{resources: map[string]string{}}
+	u := UploadCommand{resourceFiles: map[string]string{}}
 
 	err := u.Init([]string{})
 	c.Assert(err, jc.Satisfies, errors.IsBadRequest)
 }
 
 func (*UploadSuite) TestInitOneArg(c *gc.C) {
-	u := UploadCommand{resources: map[string]string{}}
+	u := UploadCommand{resourceFiles: map[string]string{}}
 	err := u.Init([]string{"foo"})
 	c.Assert(err, jc.Satisfies, errors.IsBadRequest)
 }
 
 func (*UploadSuite) TestInitJustName(c *gc.C) {
-	u := UploadCommand{resources: map[string]string{}}
+	u := UploadCommand{resourceFiles: map[string]string{}}
 
 	err := u.Init([]string{"foo", "bar"})
 	c.Assert(err, jc.Satisfies, errors.IsNotValid)
 }
 
 func (*UploadSuite) TestInitDuplicate(c *gc.C) {
-	u := UploadCommand{resources: map[string]string{}}
+	u := UploadCommand{resourceFiles: map[string]string{}}
 
 	err := u.Init([]string{"foo", "foo=bar", "foo=baz"})
 	c.Assert(errors.Cause(err), jc.Satisfies, errors.IsAlreadyExists)
 }
 
 func (*UploadSuite) TestInitNoName(c *gc.C) {
-	u := UploadCommand{resources: map[string]string{}}
+	u := UploadCommand{resourceFiles: map[string]string{}}
 
 	err := u.Init([]string{"foo", "=foobar"})
 	c.Assert(errors.Cause(err), jc.Satisfies, errors.IsNotValid)
 }
 
 func (*UploadSuite) TestInitNoPath(c *gc.C) {
-	u := UploadCommand{resources: map[string]string{}}
+	u := UploadCommand{resourceFiles: map[string]string{}}
 
 	err := u.Init([]string{"foo", "foobar="})
 	c.Assert(errors.Cause(err), jc.Satisfies, errors.IsNotValid)
 }
 
 func (*UploadSuite) TestInitGood(c *gc.C) {
-	u := UploadCommand{resources: map[string]string{}}
+	u := UploadCommand{resourceFiles: map[string]string{}}
 
 	err := u.Init([]string{"foo", "bar=baz"})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(u.resources, gc.DeepEquals, map[string]string{"bar": "baz"})
+	c.Assert(u.resourceFiles, gc.DeepEquals, map[string]string{"bar": "baz"})
 	c.Assert(u.service, gc.Equals, "foo")
 }
 
 func (*UploadSuite) TestInitTwoResources(c *gc.C) {
-	u := UploadCommand{resources: map[string]string{}}
+	u := UploadCommand{resourceFiles: map[string]string{}}
 
 	err := u.Init([]string{"foo", "bar=baz", "fizz=buzz"})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(u.resources, gc.DeepEquals, map[string]string{
+	c.Assert(u.resourceFiles, gc.DeepEquals, map[string]string{
 		"bar":  "baz",
 		"fizz": "buzz",
 	})
@@ -116,8 +116,8 @@ func (s *UploadSuite) TestRun(c *gc.C) {
 			NewClient:    s.stubDeps.NewClient,
 			OpenResource: s.stubDeps.OpenResource,
 		},
-		resources: map[string]string{"foo": "bar", "baz": "bat"},
-		service:   "svc",
+		resourceFiles: map[string]string{"foo": "bar", "baz": "bat"},
+		service:       "svc",
 	}
 
 	err := u.Run(nil)


### PR DESCRIPTION
This started out as a patch to address a map ordering issue in a test.  However, that was only a symptom of the fact that were not preserving the order of the resources passed to the CLI.  This patch adjusts "juju upload" to preserve that order.  Consequently I was able to simplify the tests.  I also included a couple of small drive-by cleanups.

(Review request: http://reviews.vapour.ws/r/3458/)