### PR TITLE
Fix issue with filtering image metadata

### DIFF
--- a/apiserver/imagemetadata/metadata.go
+++ b/apiserver/imagemetadata/metadata.go
@@ -150,7 +150,7 @@ func (api *API) parseMetadataFromParams(p params.CloudImageMetadata, env environ
 
 	// Fill in any required default values.
 	if p.Stream == "" {
-		result.Stream = "released"
+		result.Stream = env.Config().ImageStream()
 	}
 	if p.Source == "" {
 		result.Source = "custom"

--- a/apiserver/provisioner/imagemetadata_test.go
+++ b/apiserver/provisioner/imagemetadata_test.go
@@ -36,7 +36,7 @@ func (s *ImageMetadataSuite) SetUpSuite(c *gc.C) {
 
 	// Make sure that there is nothing in data sources.
 	// Each individual tests will decide if it needs metadata there.
-	imagetesting.PatchOfficialDataSources(&s.CleanupSuite, "test:")
+	imagetesting.PatchOfficialDataSources(&s.CleanupSuite, "test:/daily")
 	s.PatchValue(&imagemetadata.SimplestreamsImagesPublicKey, sstesting.SignedMetadataPublicKey)
 	useTestImageData(c, nil)
 }
@@ -68,7 +68,7 @@ func (s *ImageMetadataSuite) TestMetadataNotInStateButInDataSources(c *gc.C) {
 	// ensure metadata in data sources and not in state
 	useTestImageData(c, testImagesData)
 
-	criteria := cloudimagemetadata.MetadataFilter{Stream: "released"}
+	criteria := cloudimagemetadata.MetadataFilter{Stream: "daily"}
 	found, err := s.State.CloudImageMetadataStorage.FindMetadata(criteria)
 	c.Assert(errors.IsNotFound(err), jc.IsTrue)
 	c.Assert(found, gc.HasLen, 0)
@@ -152,7 +152,7 @@ func (s *ImageMetadataSuite) expectedDataSoureImageMetadata() [][]params.CloudIm
 				VirtType:        "pv",
 				RootStorageType: "ebs",
 				Source:          "default cloud images",
-				Stream:          "released",
+				Stream:          "daily",
 				Priority:        10,
 			},
 			{ImageId: "ami-26745463",
@@ -162,7 +162,7 @@ func (s *ImageMetadataSuite) expectedDataSoureImageMetadata() [][]params.CloudIm
 				Arch:            "amd64",
 				VirtType:        "pv",
 				RootStorageType: "ebs",
-				Stream:          "released",
+				Stream:          "daily",
 				Source:          "default cloud images",
 				Priority:        10},
 		}
@@ -181,10 +181,10 @@ func (s *ImageMetadataSuite) assertImageMetadataResults(c *gc.C, obtained params
 // TODO (anastasiamac 2015-09-04) This metadata is so verbose.
 // Need to generate the text by creating a struct and marshalling it.
 var testImagesData = map[string]string{
-	"/streams/v1/index.json": `
+	"/daily/streams/v1/index.json": `
 		{
 		 "index": {
-		  "com.ubuntu.cloud:released:aws": {
+		  "com.ubuntu.cloud:daily:aws": {
 		   "updated": "Wed, 01 May 2013 13:31:26 +0000",
 		   "clouds": [
 			{
@@ -200,8 +200,8 @@ var testImagesData = map[string]string{
 		   "datatype": "image-ids",
 		   "format": "products:1.0",
 		   "products": [
-			"com.ubuntu.cloud:server:12.10:amd64",
-			"com.ubuntu.cloud:server:14.04:amd64"
+			"com.ubuntu.cloud.daily:server:12.10:amd64",
+			"com.ubuntu.cloud.daily:server:14.04:amd64"
 		   ],
 		   "path": "streams/v1/image_metadata.json"
 		   }
@@ -210,12 +210,12 @@ var testImagesData = map[string]string{
 		 "format": "index:1.0"
 		}
 `,
-	"/streams/v1/image_metadata.json": `
+	"/daily/streams/v1/image_metadata.json": `
 {
  "updated": "Wed, 27 May 2015 13:31:26 +0000",
- "content_id": "com.ubuntu.cloud:released:aws",
+ "content_id": "com.ubuntu.cloud:daily:aws",
  "products": {
-  "com.ubuntu.cloud:server:14.04:amd64": {
+  "com.ubuntu.cloud.daily:server:14.04:amd64": {
    "release": "trusty",
    "version": "14.04",
    "arch": "amd64",
@@ -240,7 +240,7 @@ var testImagesData = map[string]string{
     }
    }
   },
-  "com.ubuntu.cloud:server:12.10:amd64": {
+  "com.ubuntu.cloud.daily:server:12.10:amd64": {
    "release": "quantal",
    "version": "12.10",
    "arch": "amd64",

--- a/apiserver/provisioner/provisioner.go
+++ b/apiserver/provisioner/provisioner.go
@@ -1560,7 +1560,7 @@ func (p *ProvisionerAPI) constructImageConstraint(m *state.Machine) (*imagemetad
 
 	lookup := simplestreams.LookupParams{
 		Series: []string{m.Series()},
-		Stream: cfg.AgentStream(),
+		Stream: cfg.ImageStream(),
 	}
 
 	mcons, err := m.Constraints()
@@ -1683,7 +1683,10 @@ func (p *ProvisionerAPI) imageMetadataFromDataSources(env environs.Environ, cons
 
 	getStream := func(current string) string {
 		if current == "" {
-			return imagemetadata.ReleasedStream
+			if constraint.Stream != "" {
+				return constraint.Stream
+			}
+			return env.Config().ImageStream()
 		}
 		return current
 	}

--- a/apiserver/provisioner/provisioner_test.go
+++ b/apiserver/provisioner/provisioner_test.go
@@ -60,6 +60,9 @@ func (s *provisionerSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *provisionerSuite) setUpTest(c *gc.C, withStateServer bool) {
+	s.JujuConnSuite.ConfigAttrs = map[string]interface{}{
+		"image-stream": "daily",
+	}
 	s.JujuConnSuite.SetUpTest(c)
 	// We're testing with address allocation on by default. There are
 	// separate tests to check the behavior when the flag is not

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -1107,9 +1107,6 @@ func (a *MachineAgent) StateWorker() (worker.Worker, error) {
 	}
 	reportOpenedState(st)
 
-	stor := statestorage.NewStorage(st.EnvironUUID(), st.MongoSession())
-	registerSimplestreamsDataSource(stor, false)
-
 	runner := newConnRunner(st)
 	singularRunner, err := newSingularStateRunner(runner, st, m)
 	if err != nil {

--- a/cmd/jujud/agent/simplestreams.go
+++ b/cmd/jujud/agent/simplestreams.go
@@ -12,13 +12,13 @@ import (
 
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/simplestreams"
-	envstorage "github.com/juju/juju/environs/storage"
 	"github.com/juju/juju/state/storage"
 )
 
 const (
 	storageDataSourceId          = "environment storage"
 	storageDataSourceDescription = storageDataSourceId
+	metadataBasePath             = "imagemetadata"
 )
 
 // environmentStorageDataSource is a simplestreams.DataSource that
@@ -44,7 +44,7 @@ func (d environmentStorageDataSource) Description() string {
 func (d environmentStorageDataSource) Fetch(file string) (io.ReadCloser, string, error) {
 	logger.Debugf("fetching %q", file)
 
-	r, _, err := d.stor.Get(path.Join(envstorage.BaseImagesPath, file))
+	r, _, err := d.stor.Get(path.Join(metadataBasePath, file))
 	if err != nil {
 		return nil, "", err
 	}
@@ -59,7 +59,7 @@ func (d environmentStorageDataSource) Fetch(file string) (io.ReadCloser, string,
 
 // URL is defined in simplestreams.DataSource.
 func (d environmentStorageDataSource) URL(file string) (string, error) {
-	path := path.Join(envstorage.BaseImagesPath, file)
+	path := path.Join(metadataBasePath, file)
 	return fmt.Sprintf("environment-storage://%s", path), nil
 }
 

--- a/provider/ec2/image.go
+++ b/provider/ec2/image.go
@@ -51,7 +51,6 @@ func findInstanceSpec(
 		ic.Constraints.CpuPower = instances.CpuPower(defaultCpuPower)
 	}
 	suitableImages := filterImages(allImageMetadata, ic)
-	logger.Debugf("suitable images %v", suitableImages)
 	images := instances.ImageMetadataToImages(suitableImages)
 
 	// Make a copy of the known EC2 instance types, filling in the cost for the specified region.

--- a/state/cloudimagemetadata/image.go
+++ b/state/cloudimagemetadata/image.go
@@ -36,7 +36,6 @@ var emptyMetadata = Metadata{}
 
 // SaveMetadata implements Storage.SaveMetadata and behaves as save-or-update.
 func (s *storage) SaveMetadata(metadata Metadata) error {
-	logger.Debugf("saving image metadata to state: %#v", metadata)
 	newDoc := s.mongoDoc(metadata)
 	if err := validateMetadata(&newDoc); err != nil {
 		return err
@@ -218,6 +217,7 @@ func (s *storage) FindMetadata(criteria MetadataFilter) (map[string][]Metadata, 
 	coll, closer := s.store.GetCollection(s.collection)
 	defer closer()
 
+	logger.Debugf("searching for image metadata %#v", criteria)
 	searchCriteria := buildSearchClauses(criteria)
 	var docs []imagesMetadataDoc
 	if err := coll.Find(searchCriteria).Sort("date_created").All(&docs); err != nil {


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/juju-core/+bug/1528932

Fix an issue where we were using the wrong value for Stream when looking for image metadata.
Added tests.

Also fix the path in blobstore used to store metadata. And remove an unnecessary datasource registration.

Tested live on AWS.

(Review request: http://reviews.vapour.ws/r/3459/)