### PR TITLE
azure, firewaller: fix firewalling on Azure

### DIFF
--- a/provider/azure/networking.go
+++ b/provider/azure/networking.go
@@ -394,7 +394,7 @@ func internalSubnetId(resourceGroup, controllerResourceGroup, subscriptionId str
 	return path.Join(
 		"/subscriptions", subscriptionId,
 		"resourceGroups", controllerResourceGroup,
-		"providers/Microsoft.Network/virtualnetworks",
+		"providers/Microsoft.Network/virtualNetworks",
 		internalNetworkName, "subnets", resourceGroup,
 	)
 }

--- a/worker/firewaller/firewaller.go
+++ b/worker/firewaller/firewaller.go
@@ -130,7 +130,9 @@ func (fw *Firewaller) loop() error {
 				return watcher.EnsureErr(fw.machinesWatcher)
 			}
 			for _, machineId := range change {
-				fw.machineLifeChanged(names.NewMachineTag(machineId))
+				if err := fw.machineLifeChanged(names.NewMachineTag(machineId)); err != nil {
+					return err
+				}
 			}
 			if !reconciled {
 				reconciled = true


### PR DESCRIPTION
In Azure's OpenPorts, we now make the subnet ID comparison
case insensitive. It has changed once already, who knows
whether it'll change again.

Also, modify OpenPorts to not attempt to recreate rules if
they already exist. The firewaller does not always call Ports
first to check which ones need to be opened.

Also, worker.firewaller was ignoring OpenPorts errors when
it started watching new machines. Fixed to exit the worker,
which will cause it to restart and reattempt in the new
session.

Fixes https://bugs.launchpad.net/juju-core/+bug/1527681

(Review request: http://reviews.vapour.ws/r/3460/)