### PR TITLE
bootstrap: args for bootstrap-specific constraints, series, image-ID

### DIFF
--- a/agent/bootstrap.go
+++ b/agent/bootstrap.go
@@ -31,9 +31,11 @@ type BootstrapMachineConfig struct {
 	// Addresses holds the bootstrap machine's addresses.
 	Addresses []network.Address
 
-	// Constraints holds the bootstrap machine's constraints.
-	// This value is also used for the environment-level constraints.
-	Constraints constraints.Value
+	// BootstrapConstraints holds the bootstrap machine's constraints.
+	BootstrapConstraints constraints.Value
+
+	// EnvironConstraints holds the environment-level constraints.
+	EnvironConstraints constraints.Value
 
 	// Jobs holds the jobs that the machine agent will run.
 	Jobs []multiwatcher.MachineJob
@@ -140,7 +142,7 @@ func paramsStateServingInfoToStateStateServingInfo(i params.StateServingInfo) st
 }
 
 func initConstraintsAndBootstrapMachine(c ConfigSetter, st *state.State, cfg BootstrapMachineConfig) (*state.Machine, error) {
-	if err := st.SetEnvironConstraints(cfg.Constraints); err != nil {
+	if err := st.SetEnvironConstraints(cfg.EnvironConstraints); err != nil {
 		return nil, errors.Errorf("cannot set initial environ constraints: %v", err)
 	}
 	m, err := initBootstrapMachine(c, st, cfg)
@@ -177,7 +179,7 @@ func initBootstrapMachine(c ConfigSetter, st *state.State, cfg BootstrapMachineC
 		Addresses:               cfg.Addresses,
 		Series:                  series.HostSeries(),
 		Nonce:                   BootstrapNonce,
-		Constraints:             cfg.Constraints,
+		Constraints:             cfg.BootstrapConstraints,
 		InstanceId:              cfg.InstanceId,
 		HardwareCharacteristics: cfg.Characteristics,
 		Jobs: jobs,

--- a/cloudconfig/cloudinit/renderscript_test.go
+++ b/cloudconfig/cloudinit/renderscript_test.go
@@ -57,7 +57,10 @@ func (s *configureSuite) getCloudConfig(c *gc.C, stateServer bool, vers version.
 	var icfg *instancecfg.InstanceConfig
 	var err error
 	if stateServer {
-		icfg, err = instancecfg.NewBootstrapInstanceConfig(constraints.Value{}, vers.Series, "")
+		icfg, err = instancecfg.NewBootstrapInstanceConfig(
+			constraints.Value{}, constraints.Value{},
+			vers.Series, "",
+		)
 		c.Assert(err, jc.ErrorIsNil)
 		icfg.InstanceId = "instance-id"
 		icfg.Jobs = []multiwatcher.MachineJob{multiwatcher.JobManageEnviron, multiwatcher.JobHostUnits}

--- a/cloudconfig/instancecfg/instancecfg.go
+++ b/cloudconfig/instancecfg/instancecfg.go
@@ -138,8 +138,11 @@ type InstanceConfig struct {
 	// Config holds the initial environment configuration.
 	Config *config.Config
 
-	// Constraints holds the initial environment constraints.
+	// Constraints holds the machine constraints.
 	Constraints constraints.Value
+
+	// EnvironConstraints holds the initial environment constraints.
+	EnvironConstraints constraints.Value
 
 	// DisableSSLHostnameVerification can be set to true to tell cloud-init
 	// that it shouldn't verify SSL certificates
@@ -457,7 +460,7 @@ func NewInstanceConfig(
 // NewBootstrapInstanceConfig sets up a basic machine configuration for a
 // bootstrap node.  You'll still need to supply more information, but this
 // takes care of the fixed entries and the ones that are always needed.
-func NewBootstrapInstanceConfig(cons constraints.Value, series, publicImageSigningKey string) (*InstanceConfig, error) {
+func NewBootstrapInstanceConfig(cons, environCons constraints.Value, series, publicImageSigningKey string) (*InstanceConfig, error) {
 	// For a bootstrap instance, FinishInstanceConfig will provide the
 	// state.Info and the api.Info. The machine id must *always* be "0".
 	icfg, err := NewInstanceConfig("0", agent.BootstrapNonce, "", series, publicImageSigningKey, true, nil, nil, nil)
@@ -470,6 +473,7 @@ func NewBootstrapInstanceConfig(cons constraints.Value, series, publicImageSigni
 		multiwatcher.JobHostUnits,
 	}
 	icfg.Constraints = cons
+	icfg.EnvironConstraints = environCons
 	return icfg, nil
 }
 

--- a/cloudconfig/userdatacfg_test.go
+++ b/cloudconfig/userdatacfg_test.go
@@ -44,7 +44,8 @@ type cloudinitSuite struct {
 var _ = gc.Suite(&cloudinitSuite{})
 
 var (
-	envConstraints = constraints.MustParse("mem=2G")
+	envConstraints       = constraints.MustParse("mem=2G")
+	bootstrapConstraints = constraints.MustParse("mem=4G")
 
 	allMachineJobs = []multiwatcher.MachineJob{
 		multiwatcher.JobManageEnviron,
@@ -189,7 +190,8 @@ func (cfg *testInstanceConfig) setSeries(series string) *testInstanceConfig {
 // a state server instance.
 func (cfg *testInstanceConfig) setStateServer() *testInstanceConfig {
 	cfg.setMachineID("0")
-	cfg.Constraints = envConstraints
+	cfg.Constraints = bootstrapConstraints
+	cfg.EnvironConstraints = envConstraints
 	cfg.Bootstrap = true
 	cfg.StateServingInfo = stateServingInfo
 	cfg.Jobs = allMachineJobs
@@ -306,7 +308,7 @@ mkdir -p '/var/lib/juju/agents/machine-0'
 cat > '/var/lib/juju/agents/machine-0/agent\.conf' << 'EOF'\\n.*\\nEOF
 chmod 0600 '/var/lib/juju/agents/machine-0/agent\.conf'
 echo 'Bootstrapping Juju machine agent'.*
-/var/lib/juju/tools/1\.2\.3-precise-amd64/jujud bootstrap-state --data-dir '/var/lib/juju' --env-config '[^']*' --instance-id 'i-bootstrap' --constraints 'mem=2048M' --debug
+/var/lib/juju/tools/1\.2\.3-precise-amd64/jujud bootstrap-state --data-dir '/var/lib/juju' --env-config '[^']*' --instance-id 'i-bootstrap' --bootstrap-constraints 'mem=4096M' --environ-constraints 'mem=2048M' --debug
 ln -s 1\.2\.3-precise-amd64 '/var/lib/juju/tools/machine-0'
 echo 'Starting Juju machine agent \(jujud-machine-0\)'.*
 cat > /etc/init/jujud-machine-0\.conf << 'EOF'\\ndescription "juju agent for machine-0"\\nauthor "Juju Team <juju@lists\.ubuntu\.com>"\\nstart on runlevel \[2345\]\\nstop on runlevel \[!2345\]\\nrespawn\\nnormal exit 0\\n\\nlimit nofile 20000 20000\\n\\nscript\\n\\n\\n  # Ensure log files are properly protected\\n  touch /var/log/juju/machine-0\.log\\n  chown syslog:syslog /var/log/juju/machine-0\.log\\n  chmod 0600 /var/log/juju/machine-0\.log\\n\\n  exec '/var/lib/juju/tools/machine-0/jujud' machine --data-dir '/var/lib/juju' --machine-id 0 --debug >> /var/log/juju/machine-0\.log 2>&1\\nend script\\nEOF\\n
@@ -326,7 +328,7 @@ curl .* '.*' --retry 10 -o \$bin/tools\.tar\.gz 'http://foo\.com/tools/released/
 sha256sum \$bin/tools\.tar\.gz > \$bin/juju1\.2\.3-raring-amd64\.sha256
 grep '1234' \$bin/juju1\.2\.3-raring-amd64.sha256 \|\| \(echo "Tools checksum mismatch"; exit 1\)
 printf %s '{"version":"1\.2\.3-raring-amd64","url":"http://foo\.com/tools/released/juju1\.2\.3-raring-amd64\.tgz","sha256":"1234","size":10}' > \$bin/downloaded-tools\.txt
-/var/lib/juju/tools/1\.2\.3-raring-amd64/jujud bootstrap-state --data-dir '/var/lib/juju' --env-config '[^']*' --instance-id 'i-bootstrap' --constraints 'mem=2048M' --debug
+/var/lib/juju/tools/1\.2\.3-raring-amd64/jujud bootstrap-state --data-dir '/var/lib/juju' --env-config '[^']*' --instance-id 'i-bootstrap' --bootstrap-constraints 'mem=4096M' --environ-constraints 'mem=2048M' --debug
 ln -s 1\.2\.3-raring-amd64 '/var/lib/juju/tools/machine-0'
 rm \$bin/tools\.tar\.gz && rm \$bin/juju1\.2\.3-raring-amd64\.sha256
 `,
@@ -427,7 +429,19 @@ curl .* --noproxy "\*" --insecure -o \$bin/tools\.tar\.gz 'https://state-addr\.t
 		setEnvConfig: true,
 		inexactMatch: true,
 		expectScripts: `
-/var/lib/juju/tools/1\.2\.3-precise-amd64/jujud bootstrap-state --data-dir '/var/lib/juju' --env-config '[^']*' --instance-id 'i-bootstrap' --debug
+/var/lib/juju/tools/1\.2\.3-precise-amd64/jujud bootstrap-state --data-dir '/var/lib/juju' --env-config '[^']*' --instance-id 'i-bootstrap' --environ-constraints 'mem=2048M' --debug
+`,
+	},
+
+	// empty environ contraints.
+	{
+		cfg: makeBootstrapConfig("precise").mutate(func(cfg *testInstanceConfig) {
+			cfg.EnvironConstraints = constraints.Value{}
+		}),
+		setEnvConfig: true,
+		inexactMatch: true,
+		expectScripts: `
+/var/lib/juju/tools/1\.2\.3-precise-amd64/jujud bootstrap-state --data-dir '/var/lib/juju' --env-config '[^']*' --instance-id 'i-bootstrap' --bootstrap-constraints 'mem=4096M' --debug
 `,
 	},
 
@@ -616,7 +630,8 @@ func (*cloudinitSuite) TestCloudInitConfigureBootstrapLogging(c *gc.C) {
 		}
 	}
 	expected := "jujud bootstrap-state --data-dir '.*' --env-config '.*'" +
-		" --instance-id '.*' --constraints 'mem=2048M' --show-log"
+		" --instance-id '.*' --bootstrap-constraints 'mem=4096M'" +
+		" --environ-constraints 'mem=2048M' --show-log"
 	assertScriptMatch(c, scripts, expected, false)
 }
 

--- a/cloudconfig/userdatacfg_unix.go
+++ b/cloudconfig/userdatacfg_unix.go
@@ -323,9 +323,13 @@ func (w *unixConfigure) ConfigureJuju() error {
 			metadataDir = "  --image-metadata " + shquote(metadataDir)
 		}
 
-		cons := w.icfg.Constraints.String()
-		if cons != "" {
-			cons = " --constraints " + shquote(cons)
+		bootstrapCons := w.icfg.Constraints.String()
+		if bootstrapCons != "" {
+			bootstrapCons = " --bootstrap-constraints " + shquote(bootstrapCons)
+		}
+		environCons := w.icfg.EnvironConstraints.String()
+		if environCons != "" {
+			environCons = " --environ-constraints " + shquote(environCons)
 		}
 		var hardware string
 		if w.icfg.HardwareCharacteristics != nil {
@@ -347,7 +351,8 @@ func (w *unixConfigure) ConfigureJuju() error {
 				" --env-config " + shquote(base64yaml(w.icfg.Config)) +
 				" --instance-id " + shquote(string(w.icfg.InstanceId)) +
 				hardware +
-				cons +
+				bootstrapCons +
+				environCons +
 				metadataDir +
 				loggingOption,
 		)

--- a/cmd/juju/backups/restore.go
+++ b/cmd/juju/backups/restore.go
@@ -172,7 +172,7 @@ func (c *restoreCommand) rebootstrap(ctx *cmd.Context) error {
 	}
 
 	cons := c.constraints
-	args := bootstrap.BootstrapParams{Constraints: cons, UploadTools: c.uploadTools}
+	args := bootstrap.BootstrapParams{EnvironConstraints: cons, UploadTools: c.uploadTools}
 	if err := bootstrap.Bootstrap(envcmd.BootstrapContext(ctx), env, args); err != nil {
 		return errors.Annotatef(err, "cannot bootstrap new instance")
 	}

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -13,7 +13,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/utils"
 	"github.com/juju/utils/featureflag"
-	"gopkg.in/juju/charm.v5"
+	"gopkg.in/juju/charm.v6-unstable"
 	"launchpad.net/gnuflag"
 
 	apiblock "github.com/juju/juju/api/block"

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -294,6 +294,7 @@ func (c *bootstrapCommand) Run(ctx *cmd.Context) (resultErr error) {
 	if err != nil {
 		return errors.Trace(err)
 	}
+	logger.Infof("combined bootstrap constraints: %v", bootstrapConstraints)
 
 	err = bootstrapFuncs.Bootstrap(envcmd.BootstrapContext(ctx), environ, bootstrap.BootstrapParams{
 		EnvironConstraints:   c.Constraints,

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -289,22 +289,6 @@ var bootstrapTests = []bootstrapTest{{
 	args: []string{"--constraints", "instance-type=foo mem=4G"},
 	err:  `failed to bootstrap environment: ambiguous constraints: "instance-type" overlaps with "mem"`,
 }, {
-	info: "bad --series",
-	args: []string{"--series", "1bad1"},
-	err:  `invalid value "1bad1" for flag --series: invalid series name "1bad1"`,
-}, {
-	info: "lonely --series",
-	args: []string{"--series", "fine"},
-	err:  `--series requires --upload-tools`,
-}, {
-	info: "lonely --upload-series",
-	args: []string{"--upload-series", "fine"},
-	err:  `--upload-series requires --upload-tools`,
-}, {
-	info: "--upload-series with --series",
-	args: []string{"--upload-tools", "--upload-series", "foo", "--series", "bar"},
-	err:  `--upload-series and --series can't be used together`,
-}, {
 	info:    "bad environment",
 	version: "1.2.3-%LTS%-amd64",
 	args:    []string{"-e", "brokenenv"},
@@ -447,34 +431,6 @@ type mockBootstrapInstance struct {
 
 func (*mockBootstrapInstance) Addresses() ([]network.Address, error) {
 	return []network.Address{{Value: "localhost"}}, nil
-}
-
-func (s *BootstrapSuite) TestSeriesDeprecation(c *gc.C) {
-	ctx := s.checkSeriesArg(c, "--series")
-	c.Check(coretesting.Stderr(ctx), gc.Equals,
-		"Use of --series is obsolete. --upload-tools now expands to all supported series of the same operating system.\n-> peckham\nBootstrap complete\n")
-}
-
-func (s *BootstrapSuite) TestUploadSeriesDeprecation(c *gc.C) {
-	ctx := s.checkSeriesArg(c, "--upload-series")
-	c.Check(coretesting.Stderr(ctx), gc.Equals,
-		"Use of --upload-series is obsolete. --upload-tools now expands to all supported series of the same operating system.\n-> peckham\nBootstrap complete\n")
-}
-
-func (s *BootstrapSuite) checkSeriesArg(c *gc.C, argVariant string) *cmd.Context {
-	_bootstrap := &fakeBootstrapFuncs{}
-	s.PatchValue(&getBootstrapFuncs, func() BootstrapInterface {
-		return _bootstrap
-	})
-	resetJujuHome(c, "devenv")
-	s.PatchValue(&allInstances, func(environ environs.Environ) ([]instance.Instance, error) {
-		return []instance.Instance{&mockBootstrapInstance{}}, nil
-	})
-
-	ctx, err := coretesting.RunCommand(c, newBootstrapCommand(), "--upload-tools", argVariant, "foo,bar")
-
-	c.Assert(err, jc.ErrorIsNil)
-	return ctx
 }
 
 // In the case where we cannot examine an environment, we want the

--- a/cmd/juju/commands/upgradejuju.go
+++ b/cmd/juju/commands/upgradejuju.go
@@ -39,7 +39,6 @@ type upgradeJujuCommand struct {
 	DryRun        bool
 	ResetPrevious bool
 	AssumeYes     bool
-	Series        []string
 }
 
 var upgradeJujuDoc = `
@@ -96,7 +95,6 @@ func (c *upgradeJujuCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.BoolVar(&c.ResetPrevious, "reset-previous-upgrade", false, "clear the previous (incomplete) upgrade status (use with care)")
 	f.BoolVar(&c.AssumeYes, "y", false, "answer 'yes' to confirmation prompts")
 	f.BoolVar(&c.AssumeYes, "yes", false, "")
-	f.Var(newSeriesValue(nil, &c.Series), "series", "upload tools for supplied comma-separated series list (OBSOLETE)")
 }
 
 func (c *upgradeJujuCommand) Init(args []string) error {
@@ -118,9 +116,6 @@ func (c *upgradeJujuCommand) Init(args []string) error {
 			return fmt.Errorf("cannot specify build number when uploading tools")
 		}
 		c.Version = vers
-	}
-	if len(c.Series) > 0 && !c.UploadTools {
-		return fmt.Errorf("--series requires --upload-tools")
 	}
 	return cmd.CheckEmpty(args)
 }
@@ -150,10 +145,6 @@ var getUpgradeJujuAPI = func(c *upgradeJujuCommand) (upgradeJujuAPI, error) {
 
 // Run changes the version proposed for the juju envtools.
 func (c *upgradeJujuCommand) Run(ctx *cmd.Context) (err error) {
-	if len(c.Series) > 0 {
-		fmt.Fprintln(ctx.Stderr, "Use of --series is obsolete. --upload-tools now expands to all supported series of the same operating system.")
-	}
-
 	client, err := getUpgradeJujuAPI(c)
 	if err != nil {
 		return err

--- a/cmd/juju/commands/upgradejuju_test.go
+++ b/cmd/juju/commands/upgradejuju_test.go
@@ -101,16 +101,6 @@ var upgradeJujuTests = []struct {
 	args:           []string{"--version", "3.2.0"},
 	expectInitErr:  "cannot upgrade to version incompatible with CLI",
 }, {
-	about:          "invalid --series",
-	currentVersion: "4.2.0-quantal-amd64",
-	args:           []string{"--series", "precise&quantal"},
-	expectInitErr:  `invalid value "precise&quantal" for flag --series: .*`,
-}, {
-	about:          "--series without --upload-tools",
-	currentVersion: "4.2.0-quantal-amd64",
-	args:           []string{"--series", "precise,quantal"},
-	expectInitErr:  "--series requires --upload-tools",
-}, {
 	about:          "--upload-tools with inappropriate version 1",
 	currentVersion: "4.2.0-quantal-amd64",
 	args:           []string{"--upload-tools", "--version", "3.1.0"},
@@ -261,13 +251,6 @@ var upgradeJujuTests = []struct {
 	args:           []string{"--upload-tools", "--version", "2.7.3"},
 	expectVersion:  "2.7.3.1",
 	expectUploaded: []string{"2.7.3.1-quantal-amd64", "2.7.3.1-%LTS%-amd64", "2.7.3.1-raring-amd64"},
-}, {
-	about:          "upload with explicit series",
-	currentVersion: "2.2.0-quantal-amd64",
-	agentVersion:   "2.0.0",
-	args:           []string{"--upload-tools", "--series", "raring"},
-	expectVersion:  "2.2.0.1",
-	expectUploaded: []string{"2.2.0.1-quantal-amd64", "2.2.0.1-raring-amd64"},
 }, {
 	about:          "upload dev version, currently on release version",
 	currentVersion: "2.1.0-quantal-amd64",

--- a/cmd/jujud/bootstrap.go
+++ b/cmd/jujud/bootstrap.go
@@ -61,12 +61,13 @@ var (
 type BootstrapCommand struct {
 	cmd.CommandBase
 	agentcmd.AgentConf
-	EnvConfig        map[string]interface{}
-	Constraints      constraints.Value
-	Hardware         instance.HardwareCharacteristics
-	InstanceId       string
-	AdminUsername    string
-	ImageMetadataDir string
+	EnvConfig            map[string]interface{}
+	BootstrapConstraints constraints.Value
+	EnvironConstraints   constraints.Value
+	Hardware             instance.HardwareCharacteristics
+	InstanceId           string
+	AdminUsername        string
+	ImageMetadataDir     string
 }
 
 // NewBootstrapCommand returns a new BootstrapCommand that has been initialized.
@@ -87,7 +88,8 @@ func (c *BootstrapCommand) Info() *cmd.Info {
 func (c *BootstrapCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.AgentConf.AddFlags(f)
 	yamlBase64Var(f, &c.EnvConfig, "env-config", "", "initial environment configuration (yaml, base64 encoded)")
-	f.Var(constraints.ConstraintsValue{Target: &c.Constraints}, "constraints", "initial environment constraints (space-separated strings)")
+	f.Var(constraints.ConstraintsValue{Target: &c.BootstrapConstraints}, "bootstrap-constraints", "bootstrap machine constraints (space-separated strings)")
+	f.Var(constraints.ConstraintsValue{Target: &c.EnvironConstraints}, "environ-constraints", "initial environment constraints (space-separated strings)")
 	f.Var(&c.Hardware, "hardware", "hardware characteristics (space-separated strings)")
 	f.StringVar(&c.InstanceId, "instance-id", "", "unique instance-id for bootstrap machine")
 	f.StringVar(&c.AdminUsername, "admin-user", "admin", "set the name for the juju admin user")
@@ -247,12 +249,13 @@ func (c *BootstrapCommand) Run(_ *cmd.Context) error {
 			agentConfig,
 			envCfg,
 			agent.BootstrapMachineConfig{
-				Addresses:       addrs,
-				Constraints:     c.Constraints,
-				Jobs:            jobs,
-				InstanceId:      instanceId,
-				Characteristics: c.Hardware,
-				SharedSecret:    sharedSecret,
+				Addresses:            addrs,
+				BootstrapConstraints: c.BootstrapConstraints,
+				EnvironConstraints:   c.EnvironConstraints,
+				Jobs:                 jobs,
+				InstanceId:           instanceId,
+				Characteristics:      c.Hardware,
+				SharedSecret:         sharedSecret,
 			},
 			dialOpts,
 			environs.NewStatePolicy(),

--- a/cmd/jujud/bootstrap_test.go
+++ b/cmd/jujud/bootstrap_test.go
@@ -303,11 +303,13 @@ func (s *BootstrapSuite) TestInitializeEnvironmentToolsNotFound(c *gc.C) {
 }
 
 func (s *BootstrapSuite) TestSetConstraints(c *gc.C) {
-	tcons := constraints.Value{Mem: uint64p(2048), CpuCores: uint64p(2)}
+	bootstrapCons := constraints.Value{Mem: uint64p(4096), CpuCores: uint64p(4)}
+	environCons := constraints.Value{Mem: uint64p(2048), CpuCores: uint64p(2)}
 	_, cmd, err := s.initBootstrapCommand(c, nil,
 		"--env-config", s.b64yamlEnvcfg,
 		"--instance-id", string(s.instanceId),
-		"--constraints", tcons.String(),
+		"--bootstrap-constraints", bootstrapCons.String(),
+		"--environ-constraints", environCons.String(),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	err = cmd.Run(nil)
@@ -322,16 +324,17 @@ func (s *BootstrapSuite) TestSetConstraints(c *gc.C) {
 	}, mongo.DefaultDialOpts(), environs.NewStatePolicy())
 	c.Assert(err, jc.ErrorIsNil)
 	defer st.Close()
+
 	cons, err := st.EnvironConstraints()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cons, gc.DeepEquals, tcons)
+	c.Assert(cons, gc.DeepEquals, environCons)
 
 	machines, err := st.AllMachines()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(machines, gc.HasLen, 1)
 	cons, err = machines[0].Constraints()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cons, gc.DeepEquals, tcons)
+	c.Assert(cons, gc.DeepEquals, bootstrapCons)
 }
 
 func uint64p(v uint64) *uint64 {

--- a/constraints/constraints.go
+++ b/constraints/constraints.go
@@ -120,6 +120,11 @@ func IsEmpty(v *Value) bool {
 	return v.String() == ""
 }
 
+// HasArch returns true if the constraints.Value specifies an architecture.
+func (v *Value) HasArch() bool {
+	return v.Arch != nil && *v.Arch != ""
+}
+
 // HasInstanceType returns true if the constraints.Value specifies an instance type.
 func (v *Value) HasInstanceType() bool {
 	return v.InstanceType != nil && *v.InstanceType != ""

--- a/environs/bootstrap.go
+++ b/environs/bootstrap.go
@@ -15,9 +15,15 @@ import (
 
 // BootstrapParams holds the parameters for bootstrapping an environment.
 type BootstrapParams struct {
-	// Constraints are used to choose the initial instance specification,
-	// and will be stored in the new environment's state.
-	Constraints constraints.Value
+	// EnvironConstraints are merged with the bootstrap constraints
+	// to choose the initial instance, and will be stored in the new
+	// environment's state.
+	EnvironConstraints constraints.Value
+
+	// BootstrapConstraints, in conjunction with EnvironConstraints,
+	// are used to choose the initial instance. BootstrapConstraints
+	// will not be stored in state for the environment.
+	BootstrapConstraints constraints.Value
 
 	// Placement, if non-empty, holds an environment-specific placement
 	// directive used to choose the initial instance.

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -253,6 +253,14 @@ func userPublicSigningKey() (string, error) {
 	return signingKey, nil
 }
 
+// bootstrapImageMetadata returns the image metadata to use for bootstrapping
+// the given environment. If the environment provider does not make use of
+// simplestreams, no metadata will be returned.
+//
+// If a bootstrap image ID is specified, image metadat will be synthesised
+// using that image ID, and the architecture and series specified by the
+// initiator. In addition, the custom image metadat that is saved into the
+// state database will have the synthesised image metadata added to it.
 func bootstrapImageMetadata(
 	environ environs.Environ,
 	availableTools coretools.List,

--- a/environs/bootstrap/bootstrap_test.go
+++ b/environs/bootstrap/bootstrap_test.go
@@ -104,11 +104,16 @@ func (s *bootstrapSuite) TestBootstrapEmptyConstraints(c *gc.C) {
 func (s *bootstrapSuite) TestBootstrapSpecifiedConstraints(c *gc.C) {
 	env := newEnviron("foo", useDefaultKeys, nil)
 	s.setDummyStorage(c, env)
-	cons := constraints.MustParse("cpu-cores=2 mem=4G")
-	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{Constraints: cons})
+	bootstrapCons := constraints.MustParse("cpu-cores=3 mem=7G")
+	environCons := constraints.MustParse("cpu-cores=2 mem=4G")
+	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{
+		BootstrapConstraints: bootstrapCons,
+		EnvironConstraints:   environCons,
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(env.bootstrapCount, gc.Equals, 1)
-	c.Assert(env.args.Constraints, gc.DeepEquals, cons)
+	c.Assert(env.args.BootstrapConstraints, gc.DeepEquals, bootstrapCons)
+	c.Assert(env.args.EnvironConstraints, gc.DeepEquals, environCons)
 }
 
 func (s *bootstrapSuite) TestBootstrapSpecifiedPlacement(c *gc.C) {

--- a/environs/bootstrap/tools.go
+++ b/environs/bootstrap/tools.go
@@ -24,13 +24,23 @@ var (
 
 // validateUploadAllowed returns an error if an attempt to upload tools should
 // not be allowed.
-func validateUploadAllowed(env environs.Environ, toolsArch *string) error {
-	// Now check that the architecture for which we are setting up an
+func validateUploadAllowed(env environs.Environ, toolsArch, toolsSeries *string) error {
+	// Now check that the architecture and series for which we are setting up an
 	// environment matches that from which we are bootstrapping.
 	hostArch := arch.HostArch()
 	// We can't build tools for a different architecture if one is specified.
 	if toolsArch != nil && *toolsArch != hostArch {
 		return fmt.Errorf("cannot build tools for %q using a machine running on %q", *toolsArch, hostArch)
+	}
+	hostOS := jujuos.HostOS()
+	if toolsSeries != nil {
+		toolsSeriesOS, err := series.GetOSFromSeries(*toolsSeries)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		if toolsSeriesOS != hostOS {
+			return errors.Errorf("cannot build tools for %q using a machine running %q", *toolsSeries, hostOS)
+		}
 	}
 	// If no architecture is specified, ensure the target provider supports instances matching our architecture.
 	supportedArchitectures, err := env.SupportedArchitectures()
@@ -56,13 +66,13 @@ func validateUploadAllowed(env environs.Environ, toolsArch *string) error {
 // including tools that may be locally built and then
 // uploaded. Tools that need to be built will have an
 // empty URL.
-func findAvailableTools(env environs.Environ, vers *version.Number, arch *string, upload bool) (coretools.List, error) {
+func findAvailableTools(env environs.Environ, vers *version.Number, arch, series *string, upload bool) (coretools.List, error) {
 	if upload {
 		// We're forcing an upload: ensure we can do so.
-		if err := validateUploadAllowed(env, arch); err != nil {
+		if err := validateUploadAllowed(env, arch, series); err != nil {
 			return nil, err
 		}
-		return locallyBuildableTools(), nil
+		return locallyBuildableTools(series), nil
 	}
 
 	// We're not forcing an upload, so look for tools
@@ -77,7 +87,7 @@ func findAvailableTools(env environs.Environ, vers *version.Number, arch *string
 		}
 	}
 	logger.Infof("looking for bootstrap tools: version=%v", vers)
-	toolsList, findToolsErr := findBootstrapTools(env, vers, arch)
+	toolsList, findToolsErr := findBootstrapTools(env, vers, arch, series)
 	if findToolsErr != nil && !errors.IsNotFound(findToolsErr) {
 		return nil, findToolsErr
 	}
@@ -103,12 +113,12 @@ func findAvailableTools(env environs.Environ, vers *version.Number, arch *string
 		archSeries.Add(tools.Version.Arch + tools.Version.Series)
 	}
 	var localToolsList coretools.List
-	for _, tools := range locallyBuildableTools() {
+	for _, tools := range locallyBuildableTools(series) {
 		if !archSeries.Contains(tools.Version.Arch + tools.Version.Series) {
 			localToolsList = append(localToolsList, tools)
 		}
 	}
-	if len(localToolsList) == 0 || validateUploadAllowed(env, arch) != nil {
+	if len(localToolsList) == 0 || validateUploadAllowed(env, arch, series) != nil {
 		return toolsList, findToolsErr
 	}
 	return append(toolsList, localToolsList...), nil
@@ -116,9 +126,12 @@ func findAvailableTools(env environs.Environ, vers *version.Number, arch *string
 
 // locallyBuildableTools returns the list of tools that
 // can be built locally, for series of the same OS.
-func locallyBuildableTools() (buildable coretools.List) {
+func locallyBuildableTools(toolsSeries *string) (buildable coretools.List) {
 	for _, ser := range series.SupportedSeries() {
 		if os, err := series.GetOSFromSeries(ser); err != nil || os != jujuos.HostOS() {
+			continue
+		}
+		if toolsSeries != nil && ser != *toolsSeries {
 			continue
 		}
 		binary := version.Binary{
@@ -137,12 +150,15 @@ func locallyBuildableTools() (buildable coretools.List) {
 // which it would be reasonable to launch an environment's first machine,
 // given the supplied constraints. If a specific agent version is not requested,
 // all tools matching the current major.minor version are chosen.
-func findBootstrapTools(env environs.Environ, vers *version.Number, arch *string) (list coretools.List, err error) {
+func findBootstrapTools(env environs.Environ, vers *version.Number, arch, series *string) (list coretools.List, err error) {
 	// Construct a tools filter.
 	cliVersion := version.Current
 	var filter coretools.Filter
 	if arch != nil {
 		filter.Arch = *arch
+	}
+	if series != nil {
+		filter.Series = *series
 	}
 	if vers != nil {
 		filter.Number = *vers

--- a/environs/instances/image_test.go
+++ b/environs/instances/image_test.go
@@ -396,30 +396,35 @@ func (s *imageSuite) TestFindInstanceSpec(c *gc.C) {
 var imageMatchtests = []struct {
 	image Image
 	itype InstanceType
-	match bool
+	match imageMatch
 }{
 	{
 		image: Image{Arch: "amd64"},
 		itype: InstanceType{Arches: []string{"amd64"}},
-		match: true,
+		match: exactMatch,
 	}, {
 		image: Image{Arch: "amd64"},
 		itype: InstanceType{Arches: []string{"amd64", "armhf"}},
-		match: true,
+		match: exactMatch,
 	}, {
 		image: Image{Arch: "amd64", VirtType: hvm},
 		itype: InstanceType{Arches: []string{"amd64"}, VirtType: &hvm},
-		match: true,
+		match: exactMatch,
 	}, {
 		image: Image{Arch: "armhf"},
 		itype: InstanceType{Arches: []string{"amd64"}},
 	}, {
 		image: Image{Arch: "amd64", VirtType: hvm},
 		itype: InstanceType{Arches: []string{"amd64"}},
-		match: true,
+		match: exactMatch,
+	}, {
+		image: Image{Arch: "amd64"}, // no known virt type
+		itype: InstanceType{Arches: []string{"amd64"}, VirtType: &hvm},
+		match: partialMatch,
 	}, {
 		image: Image{Arch: "amd64", VirtType: "pv"},
 		itype: InstanceType{Arches: []string{"amd64"}, VirtType: &hvm},
+		match: nonMatch,
 	},
 }
 

--- a/environs/jujutest/livetests.go
+++ b/environs/jujutest/livetests.go
@@ -155,7 +155,10 @@ func (t *LiveTests) BootstrapOnce(c *gc.C) {
 	}
 	err := bootstrap.EnsureNotBootstrapped(t.Env)
 	c.Assert(err, jc.ErrorIsNil)
-	err = bootstrap.Bootstrap(envtesting.BootstrapContext(c), t.Env, bootstrap.BootstrapParams{Constraints: cons})
+	err = bootstrap.Bootstrap(envtesting.BootstrapContext(c), t.Env, bootstrap.BootstrapParams{
+		BootstrapConstraints: cons,
+		EnvironConstraints:   cons,
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	t.bootstrapped = true
 }

--- a/provider/common/bootstrap.go
+++ b/provider/common/bootstrap.go
@@ -102,7 +102,9 @@ func BootstrapInstance(ctx environs.BootstrapContext, env environs.Environ, args
 	if err != nil {
 		return nil, "", nil, err
 	}
-	instanceConfig, err := instancecfg.NewBootstrapInstanceConfig(args.Constraints, selectedSeries, publicKey)
+	instanceConfig, err := instancecfg.NewBootstrapInstanceConfig(
+		args.BootstrapConstraints, args.EnvironConstraints, selectedSeries, publicKey,
+	)
 	if err != nil {
 		return nil, "", nil, err
 	}
@@ -125,7 +127,7 @@ func BootstrapInstance(ctx environs.BootstrapContext, env environs.Environ, args
 
 	fmt.Fprintln(ctx.GetStderr(), "Launching instance")
 	result, err := env.StartInstance(environs.StartInstanceParams{
-		Constraints:    args.Constraints,
+		Constraints:    args.BootstrapConstraints,
 		Tools:          availableTools,
 		InstanceConfig: instanceConfig,
 		Placement:      args.Placement,

--- a/provider/common/bootstrap_test.go
+++ b/provider/common/bootstrap_test.go
@@ -101,7 +101,7 @@ func (s *BootstrapSuite) TestCannotStartInstance(c *gc.C) {
 
 		// The machine config should set its upgrade behavior based on
 		// the environment config.
-		expectedMcfg, err := instancecfg.NewBootstrapInstanceConfig(cons, icfg.Series, "")
+		expectedMcfg, err := instancecfg.NewBootstrapInstanceConfig(cons, cons, icfg.Series, "")
 		c.Assert(err, jc.ErrorIsNil)
 		expectedMcfg.EnableOSRefreshUpdate = env.Config().EnableOSRefreshUpdate()
 		expectedMcfg.EnableOSUpgrade = env.Config().EnableOSUpgrade()
@@ -118,8 +118,9 @@ func (s *BootstrapSuite) TestCannotStartInstance(c *gc.C) {
 
 	ctx := envtesting.BootstrapContext(c)
 	_, err := common.Bootstrap(ctx, env, environs.BootstrapParams{
-		Constraints: checkCons,
-		Placement:   checkPlacement,
+		BootstrapConstraints: checkCons,
+		EnvironConstraints:   checkCons,
+		Placement:            checkPlacement,
 		AvailableTools: tools.List{
 			&tools.Tools{
 				Version: version.Binary{

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -728,7 +728,7 @@ func (e *environ) Bootstrap(ctx environs.BootstrapContext, args environs.Bootstr
 		if err != nil {
 			panic(err)
 		}
-		if err := st.SetEnvironConstraints(args.Constraints); err != nil {
+		if err := st.SetEnvironConstraints(args.EnvironConstraints); err != nil {
 			panic(err)
 		}
 		if err := st.SetAdminMongoPassword(password); err != nil {

--- a/provider/ec2/image.go
+++ b/provider/ec2/image.go
@@ -35,7 +35,9 @@ func filterImages(images []*imagemetadata.ImageMetadata, ic *instances.InstanceC
 			return imagesByStorage[storageType]
 		}
 	}
-	return nil
+	// If the user specifies an image ID during bootstrap, then it will not
+	// have a storage type.
+	return imagesByStorage[""]
 }
 
 // findInstanceSpec returns an InstanceSpec satisfying the supplied instanceConstraint.

--- a/provider/gce/testing_test.go
+++ b/provider/gce/testing_test.go
@@ -125,7 +125,7 @@ func (s *BaseSuiteUnpatched) initInst(c *gc.C) {
 
 	cons := constraints.Value{InstanceType: &allInstanceTypes[0].Name}
 
-	instanceConfig, err := instancecfg.NewBootstrapInstanceConfig(cons, "trusty", "")
+	instanceConfig, err := instancecfg.NewBootstrapInstanceConfig(cons, cons, "trusty", "")
 	c.Assert(err, jc.ErrorIsNil)
 
 	instanceConfig.Tools = tools[0]

--- a/provider/local/environ_test.go
+++ b/provider/local/environ_test.go
@@ -191,7 +191,9 @@ func (s *localJujuTestSuite) testBootstrap(c *gc.C, cfg *config.Config) environs
 		AvailableTools: availableTools,
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	icfg, err := instancecfg.NewBootstrapInstanceConfig(constraints.Value{}, "quantal", "")
+	icfg, err := instancecfg.NewBootstrapInstanceConfig(
+		constraints.Value{}, constraints.Value{}, "quantal", "",
+	)
 	c.Assert(err, jc.ErrorIsNil)
 	icfg.Tools = availableTools[0]
 	err = result.Finalize(ctx, icfg)

--- a/provider/lxd/testing_test.go
+++ b/provider/lxd/testing_test.go
@@ -150,7 +150,7 @@ func (s *BaseSuiteUnpatched) initInst(c *gc.C) {
 	// nothing
 	}
 
-	instanceConfig, err := instancecfg.NewBootstrapInstanceConfig(cons, "trusty", "")
+	instanceConfig, err := instancecfg.NewBootstrapInstanceConfig(cons, cons, "trusty", "")
 	c.Assert(err, jc.ErrorIsNil)
 
 	instanceConfig.Tools = tools[0]

--- a/provider/vsphere/environ_broker_test.go
+++ b/provider/vsphere/environ_broker_test.go
@@ -56,7 +56,7 @@ func (s *environBrokerSuite) CreateStartInstanceArgs(c *gc.C) environs.StartInst
 
 	cons := constraints.Value{}
 
-	instanceConfig, err := instancecfg.NewBootstrapInstanceConfig(cons, "trusty", "")
+	instanceConfig, err := instancecfg.NewBootstrapInstanceConfig(cons, cons, "trusty", "")
 	c.Assert(err, jc.ErrorIsNil)
 
 	instanceConfig.Tools = tools[0]


### PR DESCRIPTION
This PR makes it possible to specify constraints and series specifically for the bootstrap machine. In addition, we introduce the ability to specify the image ID for the bootstrap machine only. This simplifies bootstrapping in network-restricted environments, eliminating the need to prepare custom image metadata.

(Review request: http://reviews.vapour.ws/r/3461/)