### PR TITLE
storage: revise storage API

### DIFF
--- a/api/storage/client.go
+++ b/api/storage/client.go
@@ -28,40 +28,60 @@ func NewClient(st base.APICallCloser) *Client {
 	return &Client{ClientFacade: frontend, facade: backend}
 }
 
-// Show retrieves information about desired storage instances.
-func (c *Client) Show(tags []names.StorageTag) ([]params.StorageDetailsResult, error) {
+// StorageDetails retrieves details about desired storage instances.
+func (c *Client) StorageDetails(tags []names.StorageTag) ([]params.StorageDetailsResult, error) {
 	found := params.StorageDetailsResults{}
 	entities := make([]params.Entity, len(tags))
 	for i, tag := range tags {
 		entities[i] = params.Entity{Tag: tag.String()}
 	}
-	if err := c.facade.FacadeCall("Show", params.Entities{Entities: entities}, &found); err != nil {
+	if err := c.facade.FacadeCall("StorageDetails", params.Entities{Entities: entities}, &found); err != nil {
 		return nil, errors.Trace(err)
 	}
 	return found.Results, nil
 }
 
-// List lists all storage.
-func (c *Client) List() ([]params.StorageDetailsResult, error) {
-	found := params.StorageDetailsResults{}
-	if err := c.facade.FacadeCall("List", nil, &found); err != nil {
+// ListStorageDetails lists all storage.
+func (c *Client) ListStorageDetails() ([]params.StorageDetails, error) {
+	args := params.StorageFilters{
+		[]params.StorageFilter{{}}, // one empty filter
+	}
+	var results params.StorageDetailsListResults
+	if err := c.facade.FacadeCall("ListStorageDetails", args, &results); err != nil {
 		return nil, errors.Trace(err)
 	}
-	return found.Results, nil
+	if len(results.Results) != 1 {
+		return nil, errors.Errorf(
+			"expected 1 result, got %d",
+			len(results.Results),
+		)
+	}
+	if results.Results[0].Error != nil {
+		return nil, errors.Trace(results.Results[0].Error)
+	}
+	return results.Results[0].Result, nil
 }
 
 // ListPools returns a list of pools that matches given filter.
 // If no filter was provided, a list of all pools is returned.
 func (c *Client) ListPools(providers, names []string) ([]params.StoragePool, error) {
-	args := params.StoragePoolFilter{
-		Names:     names,
-		Providers: providers,
+	args := params.StoragePoolFilters{
+		Filters: []params.StoragePoolFilter{{
+			Names:     names,
+			Providers: providers,
+		}},
 	}
-	found := params.StoragePoolsResult{}
-	if err := c.facade.FacadeCall("ListPools", args, &found); err != nil {
+	var results params.StoragePoolsResults
+	if err := c.facade.FacadeCall("ListPools", args, &results); err != nil {
 		return nil, errors.Trace(err)
 	}
-	return found.Results, nil
+	if len(results.Results) != 1 {
+		return nil, errors.Errorf("expected 1 result, got %d", len(results.Results))
+	}
+	if err := results.Results[0].Error; err != nil {
+		return nil, err
+	}
+	return results.Results[0].Result, nil
 }
 
 // CreatePool creates pool with specified parameters.
@@ -76,32 +96,50 @@ func (c *Client) CreatePool(pname, provider string, attrs map[string]interface{}
 
 // ListVolumes lists volumes for desired machines.
 // If no machines provided, a list of all volumes is returned.
-func (c *Client) ListVolumes(machines []string) ([]params.VolumeDetailsResult, error) {
-	tags := make([]string, len(machines))
-	for i, one := range machines {
-		tags[i] = names.NewMachineTag(one).String()
+func (c *Client) ListVolumes(machines []string) ([]params.VolumeDetailsListResult, error) {
+	filters := make([]params.VolumeFilter, len(machines))
+	for i, machine := range machines {
+		filters[i].Machines = []string{names.NewMachineTag(machine).String()}
 	}
-	args := params.VolumeFilter{Machines: tags}
-	found := params.VolumeDetailsResults{}
-	if err := c.facade.FacadeCall("ListVolumes", args, &found); err != nil {
+	if len(filters) == 0 {
+		filters = []params.VolumeFilter{{}}
+	}
+	args := params.VolumeFilters{filters}
+	var results params.VolumeDetailsListResults
+	if err := c.facade.FacadeCall("ListVolumes", args, &results); err != nil {
 		return nil, errors.Trace(err)
 	}
-	return found.Results, nil
+	if len(results.Results) != len(filters) {
+		return nil, errors.Errorf(
+			"expected %d result(s), got %d",
+			len(filters), len(results.Results),
+		)
+	}
+	return results.Results, nil
 }
 
 // ListFilesystems lists filesystems for desired machines.
 // If no machines provided, a list of all filesystems is returned.
-func (c *Client) ListFilesystems(machines []string) ([]params.FilesystemDetailsResult, error) {
-	tags := make([]string, len(machines))
-	for i, one := range machines {
-		tags[i] = names.NewMachineTag(one).String()
+func (c *Client) ListFilesystems(machines []string) ([]params.FilesystemDetailsListResult, error) {
+	filters := make([]params.FilesystemFilter, len(machines))
+	for i, machine := range machines {
+		filters[i].Machines = []string{names.NewMachineTag(machine).String()}
 	}
-	args := params.FilesystemFilter{Machines: tags}
-	found := params.FilesystemDetailsResults{}
-	if err := c.facade.FacadeCall("ListFilesystems", args, &found); err != nil {
+	if len(filters) == 0 {
+		filters = []params.FilesystemFilter{{}}
+	}
+	args := params.FilesystemFilters{filters}
+	var results params.FilesystemDetailsListResults
+	if err := c.facade.FacadeCall("ListFilesystems", args, &results); err != nil {
 		return nil, errors.Trace(err)
 	}
-	return found.Results, nil
+	if len(results.Results) != len(filters) {
+		return nil, errors.Errorf(
+			"expected %d result(s), got %d",
+			len(filters), len(results.Results),
+		)
+	}
+	return results.Results, nil
 }
 
 // AddToUnit adds specified storage to desired units.

--- a/apiserver/params/storage.go
+++ b/apiserver/params/storage.go
@@ -414,44 +414,38 @@ type StorageDetails struct {
 	Attachments map[string]StorageAttachmentDetails `json:"attachments,omitempty"`
 }
 
-// LegacyStorageDetails holds information about storage.
-//
-// NOTE(axw): this is for backwards compatibility only. This struct
-// should not be changed!
-type LegacyStorageDetails struct {
-	// StorageTag holds tag for this storage.
-	StorageTag string `json:"storagetag"`
+// StorageFilter holds filter terms for listing storage details.
+type StorageFilter struct {
+	// We don't currently implement any filters. This exists to get the
+	// API structure right, and so we can add filters later as necessary.
+}
 
-	// OwnerTag holds tag for the owner of this storage, unit or service.
-	OwnerTag string `json:"ownertag"`
-
-	// Kind holds what kind of storage this instance is.
-	Kind StorageKind `json:"kind"`
-
-	// Status indicates storage status, e.g. pending, provisioned, attached.
-	Status string `json:"status,omitempty"`
-
-	// UnitTag holds tag for unit for attached instances.
-	UnitTag string `json:"unittag,omitempty"`
-
-	// Location holds location for provisioned attached instances.
-	Location string `json:"location,omitempty"`
-
-	// Persistent indicates whether the storage is persistent or not.
-	Persistent bool `json:"persistent"`
+// StorageFilters holds a set of storage filters.
+type StorageFilters struct {
+	Filters []StorageFilter `json:"filters,omitempty"`
 }
 
 // StorageDetailsResult holds information about a storage instance
 // or error related to its retrieval.
 type StorageDetailsResult struct {
-	Result *StorageDetails      `json:"details,omitempty"`
-	Legacy LegacyStorageDetails `json:"result"`
-	Error  *Error               `json:"error,omitempty"`
+	Result *StorageDetails `json:"result,omitempty"`
+	Error  *Error          `json:"error,omitempty"`
 }
 
 // StorageDetailsResults holds results for storage details or related storage error.
 type StorageDetailsResults struct {
 	Results []StorageDetailsResult `json:"results,omitempty"`
+}
+
+// StorageDetailsListResult holds a collection of storage details.
+type StorageDetailsListResult struct {
+	Result []StorageDetails `json:"result,omitempty"`
+	Error  *Error           `json:"error,omitempty"`
+}
+
+// StorageDetailsListResults holds a collection of collections of storage details.
+type StorageDetailsListResults struct {
+	Results []StorageDetailsListResult `json:"results,omitempty"`
 }
 
 // StorageAttachmentDetails holds detailed information about a storage attachment.
@@ -472,7 +466,6 @@ type StorageAttachmentDetails struct {
 
 // StoragePool holds data for a pool instance.
 type StoragePool struct {
-
 	// Name is the pool's name.
 	Name string `json:"name"`
 
@@ -483,9 +476,8 @@ type StoragePool struct {
 	Attrs map[string]interface{} `json:"attrs"`
 }
 
-// StoragePoolFilter holds a filter for pool API call.
+// StoragePoolFilter holds a filter for matching storage pools.
 type StoragePoolFilter struct {
-
 	// Names are pool's names to filter on.
 	Names []string `json:"names,omitempty"`
 
@@ -493,9 +485,20 @@ type StoragePoolFilter struct {
 	Providers []string `json:"providers,omitempty"`
 }
 
-// StoragePoolsResult holds a collection of pool instances.
+// StoragePoolFilters holds a collection of storage pool filters.
+type StoragePoolFilters struct {
+	Filters []StoragePoolFilter `json:"filters,omitempty"`
+}
+
+// StoragePoolsResult holds a collection of storage pools.
 type StoragePoolsResult struct {
-	Results []StoragePool `json:"results,omitempty"`
+	Result []StoragePool `json:"storagepools,omitempty"`
+	Error  *Error        `json:"error,omitempty"`
+}
+
+// StoragePoolsResults holds a collection of storage pools results.
+type StoragePoolsResults struct {
+	Results []StoragePoolsResult `json:"results,omitempty"`
 }
 
 // VolumeFilter holds a filter for volume list API call.
@@ -509,6 +512,11 @@ func (f *VolumeFilter) IsEmpty() bool {
 	return len(f.Machines) == 0
 }
 
+// VolumeFilters holds a collection of volume filters.
+type VolumeFilters struct {
+	Filters []VolumeFilter `json:"filters,omitempty"`
+}
+
 // FilesystemFilter holds a filter for filter list API call.
 type FilesystemFilter struct {
 	// Machines are machine tags to filter on.
@@ -520,6 +528,11 @@ func (f *FilesystemFilter) IsEmpty() bool {
 	return len(f.Machines) == 0
 }
 
+// FilesystemFilters holds a collection of filesystem filters.
+type FilesystemFilters struct {
+	Filters []FilesystemFilter `json:"filters,omitempty"`
+}
+
 // VolumeDetails describes a storage volume in the environment
 // for the purpose of volume CLI commands.
 //
@@ -528,7 +541,6 @@ func (f *FilesystemFilter) IsEmpty() bool {
 // to contain complete information about a volume and related
 // information (status, attachments, storage).
 type VolumeDetails struct {
-
 	// VolumeTag is the tag for the volume.
 	VolumeTag string `json:"volumetag"`
 
@@ -547,67 +559,11 @@ type VolumeDetails struct {
 	Storage *StorageDetails `json:"storage,omitempty"`
 }
 
-// LegacyVolumeDetails describes a storage volume in the environment
-// for the purpose of volume CLI commands.
-//
-// This is kept separate from Volume which contains only information
-// specific to the volume model, whereas LegacyVolumeDetails is intended
-// to contain complete information about a volume.
-//
-// NOTE(axw): this is for backwards compatibility only. This struct
-// should not be changed!
-type LegacyVolumeDetails struct {
-
-	// VolumeTag is tag for this volume instance.
-	VolumeTag string `json:"volumetag"`
-
-	// StorageInstance returns the tag of the storage instance that this
-	// volume is assigned to, if any.
-	StorageTag string `json:"storage,omitempty"`
-
-	// UnitTag is the tag of the unit attached to storage instance
-	// for this volume.
-	UnitTag string `json:"unit,omitempty"`
-
-	// VolumeId is a unique provider-supplied ID for the volume.
-	VolumeId string `json:"volumeid,omitempty"`
-
-	// HardwareId is the volume's hardware ID.
-	HardwareId string `json:"hardwareid,omitempty"`
-
-	// Size is the size of the volume in MiB.
-	Size uint64 `json:"size,omitempty"`
-
-	// Persistent reflects whether the volume is destroyed with the
-	// machine to which it is attached.
-	Persistent bool `json:"persistent"`
-
-	// Status contains the current status of the volume.
-	Status EntityStatus `json:"status"`
-}
-
 // VolumeDetailsResult contains details about a volume, its attachments or
 // an error preventing retrieving those details.
 type VolumeDetailsResult struct {
-
-	// Details describes the volume in detail.
-	Details *VolumeDetails `json:"details,omitempty"`
-
-	// LegacyVolume describes the volume in detail.
-	//
-	// NOTE(axw): VolumeDetails contains redundant and nonsensical
-	// information. Use Details if it is available, and only use
-	// this for backwards-compatibility.
-	LegacyVolume *LegacyVolumeDetails `json:"volume,omitempty"`
-
-	// LegacyAttachments describes the attachments of the volume to
-	// machines.
-	//
-	// NOTE(axw): this should have gone into VolumeDetails, but it's too
-	// late for that now. We'll continue to populate it, and use it
-	// if it's defined but Volume.Attachments is not. Please do not
-	// copy this structure.
-	LegacyAttachments []VolumeAttachment `json:"attachments,omitempty"`
+	// Result describes the volume in detail.
+	Result *VolumeDetails `json:"details,omitempty"`
 
 	// Error contains volume retrieval error.
 	Error *Error `json:"error,omitempty"`
@@ -618,6 +574,17 @@ type VolumeDetailsResults struct {
 	Results []VolumeDetailsResult `json:"results,omitempty"`
 }
 
+// VolumeDetailsListResult holds a collection of volume details.
+type VolumeDetailsListResult struct {
+	Result []VolumeDetails `json:"result,omitempty"`
+	Error  *Error          `json:"error,omitempty"`
+}
+
+// VolumeDetailsListResults holds a collection of collections of volume details.
+type VolumeDetailsListResults struct {
+	Results []VolumeDetailsListResult `json:"results,omitempty"`
+}
+
 // FilesystemDetails describes a storage filesystem in the environment
 // for the purpose of filesystem CLI commands.
 //
@@ -626,7 +593,6 @@ type VolumeDetailsResults struct {
 // to contain complete information about a filesystem and related
 // information (status, attachments, storage).
 type FilesystemDetails struct {
-
 	// FilesystemTag is the tag for the filesystem.
 	FilesystemTag string `json:"filesystemtag"`
 
@@ -659,6 +625,18 @@ type FilesystemDetailsResult struct {
 // FilesystemDetailsResults holds filesystem details.
 type FilesystemDetailsResults struct {
 	Results []FilesystemDetailsResult `json:"results,omitempty"`
+}
+
+// FilesystemDetailsListResult holds a collection of filesystem details.
+type FilesystemDetailsListResult struct {
+	Result []FilesystemDetails `json:"result,omitempty"`
+	Error  *Error              `json:"error,omitempty"`
+}
+
+// FilesystemDetailsListResults holds a collection of collections of
+// filesystem details.
+type FilesystemDetailsListResults struct {
+	Results []FilesystemDetailsListResult `json:"results,omitempty"`
 }
 
 // StorageConstraints contains constraints for storage instance.

--- a/apiserver/storage/export_test.go
+++ b/apiserver/storage/export_test.go
@@ -4,9 +4,9 @@
 package storage
 
 var (
-	IsValidPoolListFilter = (*API).isValidPoolListFilter
-	ValidateNames         = (*API).isValidNameCriteria
-	ValidateProviders     = (*API).isValidProviderCriteria
+	ValidatePoolListFilter   = (*API).validatePoolListFilter
+	ValidateNameCriteria     = (*API).validateNameCriteria
+	ValidateProviderCriteria = (*API).validateProviderCriteria
 
 	CreateAPI = createAPI
 )

--- a/apiserver/storage/filesystemlist_test.go
+++ b/apiserver/storage/filesystemlist_test.go
@@ -18,29 +18,27 @@ type filesystemSuite struct {
 
 var _ = gc.Suite(&filesystemSuite{})
 
-func (s *filesystemSuite) expectedFilesystemDetailsResult() params.FilesystemDetailsResult {
-	return params.FilesystemDetailsResult{
-		Result: &params.FilesystemDetails{
-			FilesystemTag: s.filesystemTag.String(),
+func (s *filesystemSuite) expectedFilesystemDetails() params.FilesystemDetails {
+	return params.FilesystemDetails{
+		FilesystemTag: s.filesystemTag.String(),
+		Status: params.EntityStatus{
+			Status: "attached",
+		},
+		MachineAttachments: map[string]params.FilesystemAttachmentInfo{
+			s.machineTag.String(): params.FilesystemAttachmentInfo{},
+		},
+		Storage: &params.StorageDetails{
+			StorageTag: "storage-data-0",
+			OwnerTag:   "unit-mysql-0",
+			Kind:       params.StorageKindFilesystem,
 			Status: params.EntityStatus{
 				Status: "attached",
 			},
-			MachineAttachments: map[string]params.FilesystemAttachmentInfo{
-				s.machineTag.String(): params.FilesystemAttachmentInfo{},
-			},
-			Storage: &params.StorageDetails{
-				StorageTag: "storage-data-0",
-				OwnerTag:   "unit-mysql-0",
-				Kind:       params.StorageKindFilesystem,
-				Status: params.EntityStatus{
-					Status: "attached",
-				},
-				Attachments: map[string]params.StorageAttachmentDetails{
-					"unit-mysql-0": params.StorageAttachmentDetails{
-						StorageTag: "storage-data-0",
-						UnitTag:    "unit-mysql-0",
-						MachineTag: "machine-66",
-					},
+			Attachments: map[string]params.StorageAttachmentDetails{
+				"unit-mysql-0": params.StorageAttachmentDetails{
+					StorageTag: "storage-data-0",
+					UnitTag:    "unit-mysql-0",
+					MachineTag: "machine-66",
 				},
 			},
 		},
@@ -48,10 +46,13 @@ func (s *filesystemSuite) expectedFilesystemDetailsResult() params.FilesystemDet
 }
 
 func (s *filesystemSuite) TestListFilesystemsEmptyFilter(c *gc.C) {
-	found, err := s.api.ListFilesystems(params.FilesystemFilter{})
+	found, err := s.api.ListFilesystems(params.FilesystemFilters{
+		[]params.FilesystemFilter{{}},
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(found.Results, gc.HasLen, 1)
-	c.Assert(found.Results[0], gc.DeepEquals, s.expectedFilesystemDetailsResult())
+	c.Assert(found.Results[0].Result, gc.HasLen, 1)
+	c.Assert(found.Results[0].Result[0], gc.DeepEquals, s.expectedFilesystemDetails())
 }
 
 func (s *filesystemSuite) TestListFilesystemsError(c *gc.C) {
@@ -59,48 +60,58 @@ func (s *filesystemSuite) TestListFilesystemsError(c *gc.C) {
 	s.state.allFilesystems = func() ([]state.Filesystem, error) {
 		return nil, errors.New(msg)
 	}
-	_, err := s.api.ListFilesystems(params.FilesystemFilter{})
-	c.Assert(err, gc.ErrorMatches, msg)
+	results, err := s.api.ListFilesystems(params.FilesystemFilters{
+		[]params.FilesystemFilter{{}},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results.Results, gc.HasLen, 1)
+	c.Assert(results.Results[0].Error, gc.ErrorMatches, msg)
 }
 
 func (s *filesystemSuite) TestListFilesystemsNoFilesystems(c *gc.C) {
 	s.state.allFilesystems = func() ([]state.Filesystem, error) {
 		return nil, nil
 	}
-	results, err := s.api.ListFilesystems(params.FilesystemFilter{})
+	results, err := s.api.ListFilesystems(params.FilesystemFilters{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.HasLen, 0)
 }
 
 func (s *filesystemSuite) TestListFilesystemsFilter(c *gc.C) {
-	filter := params.FilesystemFilter{
+	filters := []params.FilesystemFilter{{
 		Machines: []string{s.machineTag.String()},
-	}
-	found, err := s.api.ListFilesystems(filter)
+	}}
+	found, err := s.api.ListFilesystems(params.FilesystemFilters{filters})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(found.Results, gc.HasLen, 1)
-	c.Assert(found.Results[0], jc.DeepEquals, s.expectedFilesystemDetailsResult())
+	c.Assert(found.Results[0].Result, gc.HasLen, 1)
+	c.Assert(found.Results[0].Result[0], jc.DeepEquals, s.expectedFilesystemDetails())
 }
 
 func (s *filesystemSuite) TestListFilesystemsFilterNonMatching(c *gc.C) {
-	filter := params.FilesystemFilter{
+	filters := []params.FilesystemFilter{{
 		Machines: []string{"machine-42"},
-	}
-	found, err := s.api.ListFilesystems(filter)
+	}}
+	found, err := s.api.ListFilesystems(params.FilesystemFilters{filters})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(found.Results, gc.HasLen, 0)
+	c.Assert(found.Results, gc.HasLen, 1)
+	c.Assert(found.Results[0].Error, gc.IsNil)
+	c.Assert(found.Results[0].Result, gc.HasLen, 0)
 }
 
 func (s *filesystemSuite) TestListFilesystemsFilesystemInfo(c *gc.C) {
 	s.filesystem.info = &state.FilesystemInfo{
 		Size: 123,
 	}
-	expected := s.expectedFilesystemDetailsResult()
-	expected.Result.Info.Size = 123
-	found, err := s.api.ListFilesystems(params.FilesystemFilter{})
+	expected := s.expectedFilesystemDetails()
+	expected.Info.Size = 123
+	found, err := s.api.ListFilesystems(params.FilesystemFilters{
+		[]params.FilesystemFilter{{}},
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(found.Results, gc.HasLen, 1)
-	c.Assert(found.Results[0], jc.DeepEquals, expected)
+	c.Assert(found.Results[0].Result, gc.HasLen, 1)
+	c.Assert(found.Results[0].Result[0], jc.DeepEquals, expected)
 }
 
 func (s *filesystemSuite) TestListFilesystemsAttachmentInfo(c *gc.C) {
@@ -108,26 +119,32 @@ func (s *filesystemSuite) TestListFilesystemsAttachmentInfo(c *gc.C) {
 		MountPoint: "/tmp",
 		ReadOnly:   true,
 	}
-	expected := s.expectedFilesystemDetailsResult()
-	expected.Result.MachineAttachments[s.machineTag.String()] = params.FilesystemAttachmentInfo{
+	expected := s.expectedFilesystemDetails()
+	expected.MachineAttachments[s.machineTag.String()] = params.FilesystemAttachmentInfo{
 		MountPoint: "/tmp",
 		ReadOnly:   true,
 	}
-	expectedStorageAttachmentDetails := expected.Result.Storage.Attachments["unit-mysql-0"]
+	expectedStorageAttachmentDetails := expected.Storage.Attachments["unit-mysql-0"]
 	expectedStorageAttachmentDetails.Location = "/tmp"
-	expected.Result.Storage.Attachments["unit-mysql-0"] = expectedStorageAttachmentDetails
-	found, err := s.api.ListFilesystems(params.FilesystemFilter{})
+	expected.Storage.Attachments["unit-mysql-0"] = expectedStorageAttachmentDetails
+	found, err := s.api.ListFilesystems(params.FilesystemFilters{
+		[]params.FilesystemFilter{{}},
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(found.Results, gc.HasLen, 1)
-	c.Assert(found.Results[0], jc.DeepEquals, expected)
+	c.Assert(found.Results[0].Result, gc.HasLen, 1)
+	c.Assert(found.Results[0].Result[0], jc.DeepEquals, expected)
 }
 
 func (s *filesystemSuite) TestListFilesystemsVolumeBacked(c *gc.C) {
 	s.filesystem.volume = &s.volumeTag
-	expected := s.expectedFilesystemDetailsResult()
-	expected.Result.VolumeTag = s.volumeTag.String()
-	found, err := s.api.ListFilesystems(params.FilesystemFilter{})
+	expected := s.expectedFilesystemDetails()
+	expected.VolumeTag = s.volumeTag.String()
+	found, err := s.api.ListFilesystems(params.FilesystemFilters{
+		[]params.FilesystemFilter{{}},
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(found.Results, gc.HasLen, 1)
-	c.Assert(found.Results[0], jc.DeepEquals, expected)
+	c.Assert(found.Results[0].Result, gc.HasLen, 1)
+	c.Assert(found.Results[0].Result[0], jc.DeepEquals, expected)
 }

--- a/apiserver/storage/poollist_test.go
+++ b/apiserver/storage/poollist_test.go
@@ -6,7 +6,6 @@ package storage_test
 import (
 	"fmt"
 
-	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/set"
 	gc "gopkg.in/check.v1"
@@ -40,19 +39,21 @@ func (s *poolSuite) createPools(c *gc.C, num int) {
 
 func (s *poolSuite) TestList(c *gc.C) {
 	s.createPools(c, 1)
-	pools, err := s.api.ListPools(params.StoragePoolFilter{})
+	results, err := s.api.ListPools(params.StoragePoolFilters{[]params.StoragePoolFilter{{}}})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(pools.Results, gc.HasLen, 1)
-	one := pools.Results[0]
-	c.Assert(one.Name, gc.Equals, fmt.Sprintf("%v%v", tstName, 0))
-	c.Assert(one.Provider, gc.Equals, string(provider.LoopProviderType))
+	c.Assert(results.Results, gc.HasLen, 1)
+	one := results.Results[0]
+	c.Assert(one.Error, gc.IsNil)
+	c.Assert(one.Result, gc.HasLen, 1)
+	c.Assert(one.Result[0].Name, gc.Equals, fmt.Sprintf("%v%v", tstName, 0))
+	c.Assert(one.Result[0].Provider, gc.Equals, string(provider.LoopProviderType))
 }
 
 func (s *poolSuite) TestListManyResults(c *gc.C) {
 	s.createPools(c, 2)
-	pools, err := s.api.ListPools(params.StoragePoolFilter{})
+	results, err := s.api.ListPools(params.StoragePoolFilters{[]params.StoragePoolFilter{{}}})
 	c.Assert(err, jc.ErrorIsNil)
-	assertPoolNames(c, pools.Results,
+	assertPoolNames(c, results.Results[0].Result,
 		"testpool0", "testpool1",
 		"dummy", "loop",
 		"tmpfs", "rootfs")
@@ -62,11 +63,15 @@ func (s *poolSuite) TestListByName(c *gc.C) {
 	s.createPools(c, 2)
 	tstName := fmt.Sprintf("%v%v", tstName, 1)
 
-	pools, err := s.api.ListPools(params.StoragePoolFilter{
-		Names: []string{tstName}})
+	results, err := s.api.ListPools(params.StoragePoolFilters{
+		[]params.StoragePoolFilter{{
+			Names: []string{tstName},
+		}},
+	})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(pools.Results, gc.HasLen, 1)
-	c.Assert(pools.Results[0].Name, gc.DeepEquals, tstName)
+	c.Assert(results.Results, gc.HasLen, 1)
+	c.Assert(results.Results[0].Result, gc.HasLen, 1)
+	c.Assert(results.Results[0].Result[0].Name, gc.DeepEquals, tstName)
 }
 
 func (s *poolSuite) TestListByType(c *gc.C) {
@@ -79,10 +84,13 @@ func (s *poolSuite) TestListByType(c *gc.C) {
 		storage.NewConfig(poolName, provider.TmpfsProviderType, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
-	pools, err := s.api.ListPools(params.StoragePoolFilter{
-		Providers: []string{tstType}})
+	results, err := s.api.ListPools(params.StoragePoolFilters{
+		[]params.StoragePoolFilter{{
+			Providers: []string{tstType},
+		}},
+	})
 	c.Assert(err, jc.ErrorIsNil)
-	assertPoolNames(c, pools.Results, "rayofsunshine", "tmpfs")
+	assertPoolNames(c, results.Results[0].Result, "rayofsunshine", "tmpfs")
 }
 
 func (s *poolSuite) TestListByNameAndTypeAnd(c *gc.C) {
@@ -94,13 +102,17 @@ func (s *poolSuite) TestListByNameAndTypeAnd(c *gc.C) {
 	s.baseStorageSuite.pools[poolName], err =
 		storage.NewConfig(poolName, provider.TmpfsProviderType, nil)
 	c.Assert(err, jc.ErrorIsNil)
-	pools, err := s.api.ListPools(params.StoragePoolFilter{
-		Providers: []string{tstType},
-		Names:     []string{poolName}})
+	results, err := s.api.ListPools(params.StoragePoolFilters{
+		[]params.StoragePoolFilter{{
+			Providers: []string{tstType},
+			Names:     []string{poolName},
+		}},
+	})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(pools.Results, gc.HasLen, 1)
-	c.Assert(pools.Results[0].Provider, gc.DeepEquals, tstType)
-	c.Assert(pools.Results[0].Name, gc.DeepEquals, poolName)
+	c.Assert(results.Results, gc.HasLen, 1)
+	c.Assert(results.Results[0].Result, gc.HasLen, 1)
+	c.Assert(results.Results[0].Result[0].Provider, gc.DeepEquals, tstType)
+	c.Assert(results.Results[0].Result[0].Name, gc.DeepEquals, poolName)
 }
 
 func (s *poolSuite) TestListByNamesOr(c *gc.C) {
@@ -111,13 +123,16 @@ func (s *poolSuite) TestListByNamesOr(c *gc.C) {
 	s.baseStorageSuite.pools[poolName], err =
 		storage.NewConfig(poolName, provider.TmpfsProviderType, nil)
 	c.Assert(err, jc.ErrorIsNil)
-	pools, err := s.api.ListPools(params.StoragePoolFilter{
-		Names: []string{
-			fmt.Sprintf("%v%v", tstName, 1),
-			fmt.Sprintf("%v%v", tstName, 0),
-		}})
+	results, err := s.api.ListPools(params.StoragePoolFilters{
+		[]params.StoragePoolFilter{{
+			Names: []string{
+				fmt.Sprintf("%v%v", tstName, 1),
+				fmt.Sprintf("%v%v", tstName, 0),
+			},
+		}},
+	})
 	c.Assert(err, jc.ErrorIsNil)
-	assertPoolNames(c, pools.Results, "testpool0", "testpool1")
+	assertPoolNames(c, results.Results[0].Result, "testpool0", "testpool1")
 }
 
 func assertPoolNames(c *gc.C, results []params.StoragePool, expected ...string) {
@@ -137,21 +152,25 @@ func (s *poolSuite) TestListByTypesOr(c *gc.C) {
 	s.baseStorageSuite.pools[poolName], err =
 		storage.NewConfig(poolName, provider.TmpfsProviderType, nil)
 	c.Assert(err, jc.ErrorIsNil)
-	pools, err := s.api.ListPools(params.StoragePoolFilter{
-		Providers: []string{tstType, string(provider.LoopProviderType)}})
+	results, err := s.api.ListPools(params.StoragePoolFilters{
+		[]params.StoragePoolFilter{{
+			Providers: []string{tstType, string(provider.LoopProviderType)},
+		}},
+	})
 	c.Assert(err, jc.ErrorIsNil)
-	assertPoolNames(c, pools.Results, "testpool0", "testpool1", "rayofsunshine", "loop", "tmpfs")
+	assertPoolNames(c, results.Results[0].Result, "testpool0", "testpool1", "rayofsunshine", "loop", "tmpfs")
 }
 
 func (s *poolSuite) TestListNoPools(c *gc.C) {
-	pools, err := s.api.ListPools(params.StoragePoolFilter{})
+	results, err := s.api.ListPools(params.StoragePoolFilters{[]params.StoragePoolFilter{{}}})
 	c.Assert(err, jc.ErrorIsNil)
-	assertPoolNames(c, pools.Results, "dummy", "rootfs", "loop", "tmpfs")
+	c.Assert(results.Results, gc.HasLen, 1)
+	assertPoolNames(c, results.Results[0].Result, "dummy", "rootfs", "loop", "tmpfs")
 }
 
 func (s *poolSuite) TestListFilterEmpty(c *gc.C) {
-	valid, err := apiserverstorage.IsValidPoolListFilter(s.api, params.StoragePoolFilter{})
-	s.assertNoError(c, valid, err)
+	err := apiserverstorage.ValidatePoolListFilter(s.api, params.StoragePoolFilter{})
+	c.Assert(err, jc.ErrorIsNil)
 }
 
 const (
@@ -163,90 +182,80 @@ const (
 
 func (s *poolSuite) TestListFilterValidProviders(c *gc.C) {
 	s.registerProviders(c)
-	valid, err := apiserverstorage.ValidateProviders(
+	err := apiserverstorage.ValidateProviderCriteria(
 		s.api,
 		[]string{validProvider})
-	s.assertNoError(c, valid, err)
+	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *poolSuite) TestListFilterUnregisteredProvider(c *gc.C) {
 	s.state.envName = "noprovidersregistered"
-	valid, err := apiserverstorage.ValidateProviders(
+	err := apiserverstorage.ValidateProviderCriteria(
 		s.api,
 		[]string{validProvider})
-	s.assertError(c, valid, err, ".*not supported.*")
+	c.Assert(err, gc.ErrorMatches, ".*not supported.*")
 }
 
 func (s *poolSuite) TestListFilterUnknownProvider(c *gc.C) {
 	s.registerProviders(c)
-	valid, err := apiserverstorage.ValidateProviders(
+	err := apiserverstorage.ValidateProviderCriteria(
 		s.api,
 		[]string{invalidProvider})
-	s.assertError(c, valid, err, ".*not supported.*")
+	c.Assert(err, gc.ErrorMatches, ".*not supported.*")
 }
 
 func (s *poolSuite) TestListFilterValidNames(c *gc.C) {
-	valid, err := apiserverstorage.ValidateNames(
+	err := apiserverstorage.ValidateNameCriteria(
 		s.api,
 		[]string{validName})
-	s.assertNoError(c, valid, err)
+	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *poolSuite) TestListFilterInvalidNames(c *gc.C) {
-	valid, err := apiserverstorage.ValidateNames(
+	err := apiserverstorage.ValidateNameCriteria(
 		s.api,
 		[]string{invalidName})
-	s.assertError(c, valid, err, ".*not valid.*")
+	c.Assert(err, gc.ErrorMatches, ".*not valid.*")
 }
 
 func (s *poolSuite) TestListFilterValidProvidersAndNames(c *gc.C) {
 	s.registerProviders(c)
-	valid, err := apiserverstorage.IsValidPoolListFilter(
+	err := apiserverstorage.ValidatePoolListFilter(
 		s.api,
 		params.StoragePoolFilter{
 			Providers: []string{validProvider},
 			Names:     []string{validName}})
-	s.assertNoError(c, valid, err)
+	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *poolSuite) TestListFilterValidProvidersAndInvalidNames(c *gc.C) {
 	s.registerProviders(c)
-	valid, err := apiserverstorage.IsValidPoolListFilter(
+	err := apiserverstorage.ValidatePoolListFilter(
 		s.api,
 		params.StoragePoolFilter{
 			Providers: []string{validProvider},
 			Names:     []string{invalidName}})
-	s.assertError(c, valid, err, ".*not valid.*")
+	c.Assert(err, gc.ErrorMatches, ".*not valid.*")
 }
 
 func (s *poolSuite) TestListFilterInvalidProvidersAndValidNames(c *gc.C) {
-	valid, err := apiserverstorage.IsValidPoolListFilter(
+	err := apiserverstorage.ValidatePoolListFilter(
 		s.api,
 		params.StoragePoolFilter{
 			Providers: []string{invalidProvider},
 			Names:     []string{validName}})
-	s.assertError(c, valid, err, ".*not supported.*")
+	c.Assert(err, gc.ErrorMatches, ".*not supported.*")
 }
 
 func (s *poolSuite) TestListFilterInvalidProvidersAndNames(c *gc.C) {
-	valid, err := apiserverstorage.IsValidPoolListFilter(
+	err := apiserverstorage.ValidatePoolListFilter(
 		s.api,
 		params.StoragePoolFilter{
 			Providers: []string{invalidProvider},
 			Names:     []string{invalidName}})
-	s.assertError(c, valid, err, ".*not supported.*")
+	c.Assert(err, gc.ErrorMatches, ".*not supported.*")
 }
 
 func (s *poolSuite) registerProviders(c *gc.C) {
 	registry.RegisterEnvironStorageProviders(s.state.envName, "dummy")
-}
-
-func (s *poolSuite) assertNoError(c *gc.C, result bool, err error) {
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(result, jc.IsTrue)
-}
-
-func (s *poolSuite) assertError(c *gc.C, result bool, err error, msg string) {
-	c.Assert(errors.Cause(err), gc.ErrorMatches, msg)
-	c.Assert(result, jc.IsFalse)
 }

--- a/apiserver/storage/storage.go
+++ b/apiserver/storage/storage.go
@@ -359,6 +359,9 @@ func (a *API) CreatePool(p params.StoragePool) error {
 	return err
 }
 
+// ListVolumes lists volumes with the given filters. Each filter produces
+// an independent list of volumes, or an error if the filter is invalid
+// or the volumes could not be listed.
 func (a *API) ListVolumes(filters params.VolumeFilters) (params.VolumeDetailsListResults, error) {
 	results := params.VolumeDetailsListResults{
 		Results: make([]params.VolumeDetailsListResult, len(filters.Filters)),

--- a/apiserver/storage/storage.go
+++ b/apiserver/storage/storage.go
@@ -62,10 +62,10 @@ func poolManager(st *state.State) poolmanager.PoolManager {
 	return poolmanager.New(state.NewStateSettings(st))
 }
 
-// Show retrieves and returns detailed information about desired storage
-// identified by supplied tags. If specified storage cannot be retrieved,
-// individual error is returned instead of storage information.
-func (api *API) Show(entities params.Entities) (params.StorageDetailsResults, error) {
+// StorageDetails retrieves and returns detailed information about desired
+// storage identified by supplied tags. If specified storage cannot be
+// retrieved, individual error is returned instead of storage information.
+func (api *API) StorageDetails(entities params.Entities) (params.StorageDetailsResults, error) {
 	results := make([]params.StorageDetailsResult, len(entities.Entities))
 	for i, entity := range entities.Entities {
 		storageTag, err := names.ParseStorageTag(entity.Tag)
@@ -78,49 +78,55 @@ func (api *API) Show(entities params.Entities) (params.StorageDetailsResults, er
 			results[i].Error = common.ServerError(err)
 			continue
 		}
-		results[i] = api.createStorageDetailsResult(storageInstance)
+		details, err := createStorageDetails(api.storage, storageInstance)
+		if err != nil {
+			results[i].Error = common.ServerError(err)
+			continue
+		}
+		results[i].Result = details
 	}
 	return params.StorageDetailsResults{Results: results}, nil
 }
 
-// List returns all currently known storage. Unlike Show(),
-// if errors encountered while retrieving a particular
-// storage, this error is treated as part of the returned storage detail.
-func (api *API) List() (params.StorageDetailsResults, error) {
+// ListStorageDetails returns storage matching a filter.
+func (api *API) ListStorageDetails(filters params.StorageFilters) (params.StorageDetailsListResults, error) {
+	results := params.StorageDetailsListResults{
+		Results: make([]params.StorageDetailsListResult, len(filters.Filters)),
+	}
+	for i, filter := range filters.Filters {
+		list, err := api.listStorageDetails(filter)
+		if err != nil {
+			results.Results[i].Error = common.ServerError(err)
+			continue
+		}
+		results.Results[i].Result = list
+	}
+	return results, nil
+}
+
+func (api *API) listStorageDetails(filter params.StorageFilter) ([]params.StorageDetails, error) {
+	if filter != (params.StorageFilter{}) {
+		// StorageFilter has no fields at the time of writing, but
+		// check that no fields are set in case we forget to update
+		// this code.
+		return nil, errors.NotSupportedf("storage filters")
+	}
 	stateInstances, err := api.storage.AllStorageInstances()
 	if err != nil {
-		return params.StorageDetailsResults{}, common.ServerError(err)
+		return nil, common.ServerError(err)
 	}
-	results := make([]params.StorageDetailsResult, len(stateInstances))
+	results := make([]params.StorageDetails, len(stateInstances))
 	for i, stateInstance := range stateInstances {
-		results[i] = api.createStorageDetailsResult(stateInstance)
-	}
-	return params.StorageDetailsResults{Results: results}, nil
-}
-
-func (api *API) createStorageDetailsResult(si state.StorageInstance) params.StorageDetailsResult {
-	details, err := createStorageDetails(api.storage, si)
-	if err != nil {
-		return params.StorageDetailsResult{Error: common.ServerError(err)}
-	}
-
-	legacy := params.LegacyStorageDetails{
-		details.StorageTag,
-		details.OwnerTag,
-		details.Kind,
-		string(details.Status.Status),
-		"", // unit tag set below
-		"", // location set below
-		details.Persistent,
-	}
-	if len(details.Attachments) == 1 {
-		for unitTag, attachmentDetails := range details.Attachments {
-			legacy.UnitTag = unitTag
-			legacy.Location = attachmentDetails.Location
+		details, err := createStorageDetails(api.storage, stateInstance)
+		if err != nil {
+			return nil, errors.Annotatef(
+				err, "getting details for %s",
+				names.ReadableString(stateInstance.Tag()),
+			)
 		}
+		results[i] = *details
 	}
-
-	return params.StorageDetailsResult{Result: details, Legacy: legacy}
+	return results, nil
 }
 
 func createStorageDetails(st storageAccess, si state.StorageInstance) (*params.StorageDetails, error) {
@@ -209,27 +215,40 @@ func storageAttachmentInfo(st storageAccess, a state.StorageAttachment) (_ names
 // This method lists union of pools and environment provider types.
 // If no filter is provided, all pools are returned.
 func (a *API) ListPools(
-	filter params.StoragePoolFilter,
-) (params.StoragePoolsResult, error) {
-
-	if ok, err := a.isValidPoolListFilter(filter); !ok {
-		return params.StoragePoolsResult{}, err
+	filters params.StoragePoolFilters,
+) (params.StoragePoolsResults, error) {
+	results := params.StoragePoolsResults{
+		Results: make([]params.StoragePoolsResult, len(filters.Filters)),
 	}
+	for i, filter := range filters.Filters {
+		pools, err := a.listPools(filter)
+		if err != nil {
+			results.Results[i].Error = common.ServerError(err)
+			continue
+		}
+		results.Results[i].Result = pools
+	}
+	return results, nil
+}
 
+func (a *API) listPools(filter params.StoragePoolFilter) ([]params.StoragePool, error) {
+	if err := a.validatePoolListFilter(filter); err != nil {
+		return nil, err
+	}
 	pools, err := a.poolManager.List()
 	if err != nil {
-		return params.StoragePoolsResult{}, err
+		return nil, err
 	}
 	providers, err := a.allProviders()
 	if err != nil {
-		return params.StoragePoolsResult{}, err
+		return nil, err
 	}
 	matches := buildFilter(filter)
 	results := append(
 		filterPools(pools, matches),
 		filterProviders(providers, matches)...,
 	)
-	return params.StoragePoolsResult{results}, nil
+	return results, nil
 }
 
 func buildFilter(filter params.StoragePoolFilter) func(n, p string) bool {
@@ -299,42 +318,36 @@ func (a *API) allProviders() ([]storage.ProviderType, error) {
 	return nil, nil
 }
 
-func (a *API) isValidPoolListFilter(
-	filter params.StoragePoolFilter,
-) (bool, error) {
-	if len(filter.Providers) != 0 {
-		if valid, err := a.isValidProviderCriteria(filter.Providers); !valid {
-			return false, errors.Trace(err)
-		}
+func (a *API) validatePoolListFilter(filter params.StoragePoolFilter) error {
+	if err := a.validateProviderCriteria(filter.Providers); err != nil {
+		return errors.Trace(err)
 	}
-	if len(filter.Names) != 0 {
-		if valid, err := a.isValidNameCriteria(filter.Names); !valid {
-			return false, errors.Trace(err)
-		}
+	if err := a.validateNameCriteria(filter.Names); err != nil {
+		return errors.Trace(err)
 	}
-	return true, nil
+	return nil
 }
 
-func (a *API) isValidNameCriteria(names []string) (bool, error) {
+func (a *API) validateNameCriteria(names []string) error {
 	for _, n := range names {
 		if !storage.IsValidPoolName(n) {
-			return false, errors.NotValidf("pool name %q", n)
+			return errors.NotValidf("pool name %q", n)
 		}
 	}
-	return true, nil
+	return nil
 }
 
-func (a *API) isValidProviderCriteria(providers []string) (bool, error) {
+func (a *API) validateProviderCriteria(providers []string) error {
 	envName, err := a.storage.EnvName()
 	if err != nil {
-		return false, errors.Annotate(err, "getting env name")
+		return errors.Annotate(err, "getting environment name")
 	}
 	for _, p := range providers {
 		if !registry.IsProviderSupported(envName, storage.ProviderType(p)) {
-			return false, errors.NotSupportedf("%q for environment %q", p, envName)
+			return errors.NotSupportedf("%q", p)
 		}
 	}
-	return true, nil
+	return nil
 }
 
 // CreatePool creates a new pool with specified parameters.
@@ -346,13 +359,26 @@ func (a *API) CreatePool(p params.StoragePool) error {
 	return err
 }
 
-func (a *API) ListVolumes(filter params.VolumeFilter) (params.VolumeDetailsResults, error) {
-	volumes, volumeAttachments, err := filterVolumes(a.storage, filter)
-	if err != nil {
-		return params.VolumeDetailsResults{}, common.ServerError(err)
+func (a *API) ListVolumes(filters params.VolumeFilters) (params.VolumeDetailsListResults, error) {
+	results := params.VolumeDetailsListResults{
+		Results: make([]params.VolumeDetailsListResult, len(filters.Filters)),
 	}
-	results := createVolumeDetailsResults(a.storage, volumes, volumeAttachments)
-	return params.VolumeDetailsResults{Results: results}, nil
+	for i, filter := range filters.Filters {
+		volumes, volumeAttachments, err := filterVolumes(a.storage, filter)
+		if err != nil {
+			results.Results[i].Error = common.ServerError(err)
+			continue
+		}
+		details, err := createVolumeDetailsList(
+			a.storage, volumes, volumeAttachments,
+		)
+		if err != nil {
+			results.Results[i].Error = common.ServerError(err)
+			continue
+		}
+		results.Results[i].Result = details
+	}
+	return results, nil
 }
 
 func filterVolumes(
@@ -406,60 +432,27 @@ func filterVolumes(
 	return volumes, volumeAttachments, nil
 }
 
-func createVolumeDetailsResults(
+func createVolumeDetailsList(
 	st storageAccess,
 	volumes []state.Volume,
 	attachments map[names.VolumeTag][]state.VolumeAttachment,
-) []params.VolumeDetailsResult {
+) ([]params.VolumeDetails, error) {
 
 	if len(volumes) == 0 {
-		return nil
+		return nil, nil
 	}
-
-	results := make([]params.VolumeDetailsResult, len(volumes))
+	results := make([]params.VolumeDetails, len(volumes))
 	for i, v := range volumes {
 		details, err := createVolumeDetails(st, v, attachments[v.VolumeTag()])
 		if err != nil {
-			results[i].Error = common.ServerError(err)
-			continue
+			return nil, errors.Annotatef(
+				err, "getting details for %s",
+				names.ReadableString(v.VolumeTag()),
+			)
 		}
-		result := params.VolumeDetailsResult{
-			Details: details,
-		}
-
-		// We need to populate the legacy fields for old clients.
-		if len(details.MachineAttachments) > 0 {
-			result.LegacyAttachments = make([]params.VolumeAttachment, 0, len(details.MachineAttachments))
-			for machineTag, attachmentInfo := range details.MachineAttachments {
-				result.LegacyAttachments = append(result.LegacyAttachments, params.VolumeAttachment{
-					VolumeTag:  details.VolumeTag,
-					MachineTag: machineTag,
-					Info:       attachmentInfo,
-				})
-			}
-		}
-		result.LegacyVolume = &params.LegacyVolumeDetails{
-			VolumeTag:  details.VolumeTag,
-			VolumeId:   details.Info.VolumeId,
-			HardwareId: details.Info.HardwareId,
-			Size:       details.Info.Size,
-			Persistent: details.Info.Persistent,
-			Status:     details.Status,
-		}
-		if details.Storage != nil {
-			result.LegacyVolume.StorageTag = details.Storage.StorageTag
-			kind, err := names.TagKind(details.Storage.OwnerTag)
-			if err != nil {
-				results[i].Error = common.ServerError(err)
-				continue
-			}
-			if kind == names.UnitTagKind {
-				result.LegacyVolume.UnitTag = details.Storage.OwnerTag
-			}
-		}
-		results[i] = result
+		results[i] = *details
 	}
-	return results
+	return results, nil
 }
 
 func createVolumeDetails(
@@ -510,13 +503,26 @@ func createVolumeDetails(
 // ListFilesystems returns a list of filesystems in the environment matching
 // the provided filter. Each result describes a filesystem in detail, including
 // the filesystem's attachments.
-func (a *API) ListFilesystems(filter params.FilesystemFilter) (params.FilesystemDetailsResults, error) {
-	filesystems, filesystemAttachments, err := filterFilesystems(a.storage, filter)
-	if err != nil {
-		return params.FilesystemDetailsResults{}, common.ServerError(err)
+func (a *API) ListFilesystems(filters params.FilesystemFilters) (params.FilesystemDetailsListResults, error) {
+	results := params.FilesystemDetailsListResults{
+		Results: make([]params.FilesystemDetailsListResult, len(filters.Filters)),
 	}
-	results := createFilesystemDetailsResults(a.storage, filesystems, filesystemAttachments)
-	return params.FilesystemDetailsResults{Results: results}, nil
+	for i, filter := range filters.Filters {
+		filesystems, filesystemAttachments, err := filterFilesystems(a.storage, filter)
+		if err != nil {
+			results.Results[i].Error = common.ServerError(err)
+			continue
+		}
+		details, err := createFilesystemDetailsList(
+			a.storage, filesystems, filesystemAttachments,
+		)
+		if err != nil {
+			results.Results[i].Error = common.ServerError(err)
+			continue
+		}
+		results.Results[i].Result = details
+	}
+	return results, nil
 }
 
 func filterFilesystems(
@@ -570,26 +576,27 @@ func filterFilesystems(
 	return filesystems, filesystemAttachments, nil
 }
 
-func createFilesystemDetailsResults(
+func createFilesystemDetailsList(
 	st storageAccess,
 	filesystems []state.Filesystem,
 	attachments map[names.FilesystemTag][]state.FilesystemAttachment,
-) []params.FilesystemDetailsResult {
+) ([]params.FilesystemDetails, error) {
 
 	if len(filesystems) == 0 {
-		return nil
+		return nil, nil
 	}
-
-	results := make([]params.FilesystemDetailsResult, len(filesystems))
+	results := make([]params.FilesystemDetails, len(filesystems))
 	for i, f := range filesystems {
 		details, err := createFilesystemDetails(st, f, attachments[f.FilesystemTag()])
 		if err != nil {
-			results[i].Error = common.ServerError(err)
-			continue
+			return nil, errors.Annotatef(
+				err, "getting details for %s",
+				names.ReadableString(f.FilesystemTag()),
+			)
 		}
-		results[i].Result = details
+		results[i] = *details
 	}
-	return results
+	return results, nil
 }
 
 func createFilesystemDetails(

--- a/cmd/juju/storage/filesystem.go
+++ b/cmd/juju/storage/filesystem.go
@@ -71,7 +71,7 @@ type MachineFilesystemAttachment struct {
 }
 
 // convertToFilesystemInfo returns a map of filesystem IDs to filesystem info.
-func convertToFilesystemInfo(all []params.FilesystemDetailsResult) (map[string]FilesystemInfo, error) {
+func convertToFilesystemInfo(all []params.FilesystemDetails) (map[string]FilesystemInfo, error) {
 	result := make(map[string]FilesystemInfo)
 	for _, one := range all {
 		filesystemTag, info, err := createFilesystemInfo(one)
@@ -83,9 +83,7 @@ func convertToFilesystemInfo(all []params.FilesystemDetailsResult) (map[string]F
 	return result, nil
 }
 
-func createFilesystemInfo(result params.FilesystemDetailsResult) (names.FilesystemTag, FilesystemInfo, error) {
-	details := result.Result
-
+func createFilesystemInfo(details params.FilesystemDetails) (names.FilesystemTag, FilesystemInfo, error) {
 	filesystemTag, err := names.ParseFilesystemTag(details.FilesystemTag)
 	if err != nil {
 		return names.FilesystemTag{}, FilesystemInfo{}, errors.Trace(err)

--- a/cmd/juju/storage/filesystemlist.go
+++ b/cmd/juju/storage/filesystemlist.go
@@ -59,7 +59,7 @@ func (c *filesystemListCommand) Info() *cmd.Info {
 
 // SetFlags implements Command.SetFlags.
 func (c *filesystemListCommand) SetFlags(f *gnuflag.FlagSet) {
-	c.StorageCommandBase.SetFlags(f)
+	c.FilesystemCommandBase.SetFlags(f)
 
 	c.out.AddFlags(f, "tabular", map[string]cmd.Formatter{
 		"yaml":    cmd.FormatYaml,
@@ -76,19 +76,19 @@ func (c *filesystemListCommand) Run(ctx *cmd.Context) (err error) {
 	}
 	defer api.Close()
 
-	found, err := api.ListFilesystems(c.Ids)
+	results, err := api.ListFilesystems(c.Ids)
 	if err != nil {
 		return err
 	}
 	// filter out valid output, if any
-	var valid []params.FilesystemDetailsResult
-	for _, one := range found {
-		if one.Error == nil {
-			valid = append(valid, one)
+	var valid []params.FilesystemDetails
+	for _, result := range results {
+		if result.Error == nil {
+			valid = append(valid, result.Result...)
 			continue
 		}
 		// display individual error
-		fmt.Fprintf(ctx.Stderr, "%v\n", one.Error)
+		fmt.Fprintf(ctx.Stderr, "%v\n", result.Error)
 	}
 	if len(valid) == 0 {
 		return nil
@@ -111,5 +111,5 @@ func (c *filesystemListCommand) Run(ctx *cmd.Context) (err error) {
 // FilesystemListAPI defines the API methods that the filesystem list command use.
 type FilesystemListAPI interface {
 	Close() error
-	ListFilesystems(machines []string) ([]params.FilesystemDetailsResult, error)
+	ListFilesystems(machines []string) ([]params.FilesystemDetailsListResult, error)
 }

--- a/cmd/juju/storage/filesystemlist_test.go
+++ b/cmd/juju/storage/filesystemlist_test.go
@@ -31,7 +31,7 @@ func (s *filesystemListSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *filesystemListSuite) TestFilesystemListEmpty(c *gc.C) {
-	s.mockAPI.listFilesystems = func([]string) ([]params.FilesystemDetailsResult, error) {
+	s.mockAPI.listFilesystems = func([]string) ([]params.FilesystemDetailsListResult, error) {
 		return nil, nil
 	}
 	s.assertValidList(
@@ -42,7 +42,7 @@ func (s *filesystemListSuite) TestFilesystemListEmpty(c *gc.C) {
 }
 
 func (s *filesystemListSuite) TestFilesystemListError(c *gc.C) {
-	s.mockAPI.listFilesystems = func([]string) ([]params.FilesystemDetailsResult, error) {
+	s.mockAPI.listFilesystems = func([]string) ([]params.FilesystemDetailsListResult, error) {
 		return nil, errors.New("just my luck")
 	}
 	context, err := s.runFilesystemList(c, "--format", "yaml")
@@ -53,7 +53,7 @@ func (s *filesystemListSuite) TestFilesystemListError(c *gc.C) {
 func (s *filesystemListSuite) TestFilesystemListArgs(c *gc.C) {
 	var called bool
 	expectedArgs := []string{"a", "b", "c"}
-	s.mockAPI.listFilesystems = func(arg []string) ([]params.FilesystemDetailsResult, error) {
+	s.mockAPI.listFilesystems = func(arg []string) ([]params.FilesystemDetailsListResult, error) {
 		c.Assert(arg, jc.DeepEquals, expectedArgs)
 		called = true
 		return nil, nil
@@ -83,12 +83,12 @@ func (s *filesystemListSuite) TestFilesystemListJSON(c *gc.C) {
 }
 
 func (s *filesystemListSuite) TestFilesystemListWithErrorResults(c *gc.C) {
-	s.mockAPI.listFilesystems = func([]string) ([]params.FilesystemDetailsResult, error) {
+	s.mockAPI.listFilesystems = func([]string) ([]params.FilesystemDetailsListResult, error) {
 		results, _ := mockFilesystemListAPI{}.ListFilesystems(nil)
-		results = append(results, params.FilesystemDetailsResult{
+		results = append(results, params.FilesystemDetailsListResult{
 			Error: &params.Error{Message: "bad"},
 		})
-		results = append(results, params.FilesystemDetailsResult{
+		results = append(results, params.FilesystemDetailsListResult{
 			Error: &params.Error{Message: "ness"},
 		})
 		return results, nil
@@ -115,7 +115,7 @@ func (s *filesystemListSuite) TestFilesystemListTabular(c *gc.C) {
 
 	// Do it again, reversing the results returned by the API.
 	// We should get everything sorted in the appropriate order.
-	s.mockAPI.listFilesystems = func([]string) ([]params.FilesystemDetailsResult, error) {
+	s.mockAPI.listFilesystems = func([]string) ([]params.FilesystemDetailsListResult, error) {
 		results, _ := mockFilesystemListAPI{}.ListFilesystems(nil)
 		n := len(results)
 		for i := 0; i < n/2; i++ {
@@ -149,10 +149,10 @@ func (s *filesystemListSuite) expect(c *gc.C, machines []string) map[string]stor
 	all, err := s.mockAPI.ListFilesystems(machines)
 	c.Assert(err, jc.ErrorIsNil)
 
-	var valid []params.FilesystemDetailsResult
+	var valid []params.FilesystemDetails
 	for _, result := range all {
 		if result.Error == nil {
-			valid = append(valid, result)
+			valid = append(valid, result.Result...)
 		}
 	}
 	result, err := storage.ConvertToFilesystemInfo(valid)
@@ -181,22 +181,22 @@ func (s *filesystemListSuite) assertUserFacingOutput(c *gc.C, context *cmd.Conte
 }
 
 type mockFilesystemListAPI struct {
-	listFilesystems func([]string) ([]params.FilesystemDetailsResult, error)
+	listFilesystems func([]string) ([]params.FilesystemDetailsListResult, error)
 }
 
 func (s mockFilesystemListAPI) Close() error {
 	return nil
 }
 
-func (s mockFilesystemListAPI) ListFilesystems(machines []string) ([]params.FilesystemDetailsResult, error) {
+func (s mockFilesystemListAPI) ListFilesystems(machines []string) ([]params.FilesystemDetailsListResult, error) {
 	if s.listFilesystems != nil {
 		return s.listFilesystems(machines)
 	}
-	results := []params.FilesystemDetailsResult{{
+	results := []params.FilesystemDetailsListResult{{Result: []params.FilesystemDetails{
 		// filesystem 0/0 is attached to machine 0, assigned to
 		// storage db-dir/1001, which is attached to unit
 		// abc/0.
-		Result: &params.FilesystemDetails{
+		{
 			FilesystemTag: "filesystem-0-0",
 			VolumeTag:     "volume-0-1",
 			Info: params.FilesystemInfo{
@@ -224,10 +224,9 @@ func (s mockFilesystemListAPI) ListFilesystems(machines []string) ([]params.File
 				},
 			},
 		},
-	}, {
 		// filesystem 1 is attaching to machine 0, but is not assigned
 		// to any storage.
-		Result: &params.FilesystemDetails{
+		{
 			FilesystemTag: "filesystem-1",
 			Info: params.FilesystemInfo{
 				FilesystemId: "provider-supplied-filesystem-1",
@@ -238,10 +237,9 @@ func (s mockFilesystemListAPI) ListFilesystems(machines []string) ([]params.File
 				"machine-0": params.FilesystemAttachmentInfo{},
 			},
 		},
-	}, {
 		// filesystem 3 is due to be attached to machine 1, but is not
 		// assigned to any storage and has not yet been provisioned.
-		Result: &params.FilesystemDetails{
+		{
 			FilesystemTag: "filesystem-3",
 			Info: params.FilesystemInfo{
 				Size: 42,
@@ -251,10 +249,9 @@ func (s mockFilesystemListAPI) ListFilesystems(machines []string) ([]params.File
 				"machine-1": params.FilesystemAttachmentInfo{},
 			},
 		},
-	}, {
 		// filesystem 2 is due to be attached to machine 1, but is not
 		// assigned to any storage.
-		Result: &params.FilesystemDetails{
+		{
 			FilesystemTag: "filesystem-2",
 			Info: params.FilesystemInfo{
 				FilesystemId: "provider-supplied-filesystem-2",
@@ -267,10 +264,9 @@ func (s mockFilesystemListAPI) ListFilesystems(machines []string) ([]params.File
 				},
 			},
 		},
-	}, {
 		// filesystem 4 is attached to machines 0 and 1, and is assigned
 		// to shared storage.
-		Result: &params.FilesystemDetails{
+		{
 			FilesystemTag: "filesystem-4",
 			Info: params.FilesystemInfo{
 				FilesystemId: "provider-supplied-filesystem-4",
@@ -308,6 +304,6 @@ func (s mockFilesystemListAPI) ListFilesystems(machines []string) ([]params.File
 				},
 			},
 		},
-	}}
+	}}}
 	return results, nil
 }

--- a/cmd/juju/storage/list.go
+++ b/cmd/juju/storage/list.go
@@ -4,8 +4,6 @@
 package storage
 
 import (
-	"fmt"
-
 	"github.com/juju/cmd"
 	"launchpad.net/gnuflag"
 
@@ -72,28 +70,14 @@ func (c *listCommand) Run(ctx *cmd.Context) (err error) {
 	}
 	defer api.Close()
 
-	found, err := api.List()
+	results, err := api.ListStorageDetails()
 	if err != nil {
 		return err
 	}
-	// filter out valid output, if any
-	var valid []params.StorageDetails
-	for _, one := range found {
-		if one.Error != nil {
-			fmt.Fprintf(ctx.Stderr, "%v\n", one.Error)
-			continue
-		}
-		if one.Result != nil {
-			valid = append(valid, *one.Result)
-		} else {
-			details := storageDetailsFromLegacy(one.Legacy)
-			valid = append(valid, details)
-		}
-	}
-	if len(valid) == 0 {
+	if len(results) == 0 {
 		return nil
 	}
-	details, err := formatStorageDetails(valid)
+	details, err := formatStorageDetails(results)
 	if err != nil {
 		return err
 	}
@@ -110,5 +94,5 @@ func (c *listCommand) Run(ctx *cmd.Context) (err error) {
 // StorageAPI defines the API methods that the storage commands use.
 type StorageListAPI interface {
 	Close() error
-	List() ([]params.StorageDetailsResult, error)
+	ListStorageDetails() ([]params.StorageDetails, error)
 }

--- a/cmd/juju/storage/list_test.go
+++ b/cmd/juju/storage/list_test.go
@@ -4,6 +4,8 @@
 package storage_test
 
 import (
+	"errors"
+
 	"github.com/juju/cmd"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -40,13 +42,11 @@ func (s *ListSuite) TestList(c *gc.C) {
 \[Storage\]    
 UNIT         ID          LOCATION STATUS   MESSAGE 
 postgresql/0 db-dir/1100 hither   attached         
-transcode/0  db-dir/1000          pending          
+transcode/0  db-dir/1000 thither  pending          
 transcode/0  shared-fs/0 there    attached         
 transcode/1  shared-fs/0 here     attached         
 
-`[1:],
-		"",
-	)
+`[1:])
 }
 
 func (s *ListSuite) TestListYAML(c *gc.C) {
@@ -63,7 +63,8 @@ storage:
     persistent: false
     attachments:
       units:
-        transcode/0: {}
+        transcode/0:
+          location: thither
   db-dir/1100:
     kind: block
     status:
@@ -86,13 +87,10 @@ storage:
           location: there
         transcode/1:
           location: here
-`[1:],
-		"",
-	)
+`[1:])
 }
 
 func (s *ListSuite) TestListOwnerStorageIdSort(c *gc.C) {
-	s.mockAPI.includeErrors = true
 	s.assertValidList(
 		c,
 		nil,
@@ -101,91 +99,97 @@ func (s *ListSuite) TestListOwnerStorageIdSort(c *gc.C) {
 \[Storage\]    
 UNIT         ID          LOCATION STATUS   MESSAGE 
 postgresql/0 db-dir/1100 hither   attached         
-transcode/0  db-dir/1000          pending          
+transcode/0  db-dir/1000 thither  pending          
 transcode/0  shared-fs/0 there    attached         
 transcode/1  shared-fs/0 here     attached         
 
-`[1:],
-		"error for storage-db-dir-1010\n",
-	)
+`[1:])
 }
 
-func (s *ListSuite) assertValidList(c *gc.C, args []string, expectedValid, expectedErr string) {
+func (s *ListSuite) TestListError(c *gc.C) {
+	s.mockAPI.listErrors = true
+	context, err := s.runList(c, nil)
+	c.Assert(err, gc.ErrorMatches, "list fails")
+	stderr := testing.Stderr(context)
+	c.Assert(stderr, gc.Equals, "")
+	stdout := testing.Stdout(context)
+	c.Assert(stdout, gc.Equals, "")
+}
+
+func (s *ListSuite) assertValidList(c *gc.C, args []string, expectedValid string) {
 	context, err := s.runList(c, args)
 	c.Assert(err, jc.ErrorIsNil)
 
 	obtainedErr := testing.Stderr(context)
-	c.Assert(obtainedErr, gc.Matches, expectedErr)
+	c.Assert(obtainedErr, gc.Equals, "")
 
 	obtainedValid := testing.Stdout(context)
 	c.Assert(obtainedValid, gc.Matches, expectedValid)
 }
 
 type mockListAPI struct {
-	includeErrors bool
+	listErrors bool
 }
 
 func (s mockListAPI) Close() error {
 	return nil
 }
 
-func (s mockListAPI) List() ([]params.StorageDetailsResult, error) {
+func (s mockListAPI) ListStorageDetails() ([]params.StorageDetails, error) {
+	if s.listErrors {
+		return nil, errors.New("list fails")
+	}
+
 	// postgresql/0 has "db-dir/1100"
 	// transcode/1 has "db-dir/1000"
 	// transcode/0 and transcode/1 share "shared-fs/0"
 	//
 	// there is also a storage instance "db-dir/1010" which
 	// returns an error when listed.
-	results := []params.StorageDetailsResult{{
-		Legacy: params.LegacyStorageDetails{
-			StorageTag: "storage-db-dir-1000",
-			OwnerTag:   "unit-transcode-0",
-			UnitTag:    "unit-transcode-0",
-			Kind:       params.StorageKindBlock,
-			Status:     "pending",
+	results := []params.StorageDetails{{
+		StorageTag: "storage-db-dir-1000",
+		OwnerTag:   "unit-transcode-0",
+		Kind:       params.StorageKindBlock,
+		Status: params.EntityStatus{
+			Status: params.StatusPending,
+			Since:  &epoch,
 		},
-	}, {
-		Result: &params.StorageDetails{
-			StorageTag: "storage-db-dir-1100",
-			OwnerTag:   "unit-postgresql-0",
-			Kind:       params.StorageKindBlock,
-			Status: params.EntityStatus{
-				Status: params.StatusAttached,
-				Since:  &epoch,
-			},
-			Persistent: true,
-			Attachments: map[string]params.StorageAttachmentDetails{
-				"unit-postgresql-0": params.StorageAttachmentDetails{
-					Location: "hither",
-				},
+		Attachments: map[string]params.StorageAttachmentDetails{
+			"unit-transcode-0": params.StorageAttachmentDetails{
+				Location: "thither",
 			},
 		},
 	}, {
-		Result: &params.StorageDetails{
-			StorageTag: "storage-shared-fs-0",
-			OwnerTag:   "service-transcode",
-			Kind:       params.StorageKindFilesystem,
-			Status: params.EntityStatus{
-				Status: params.StatusAttached,
-				Since:  &epoch,
+		StorageTag: "storage-db-dir-1100",
+		OwnerTag:   "unit-postgresql-0",
+		Kind:       params.StorageKindBlock,
+		Status: params.EntityStatus{
+			Status: params.StatusAttached,
+			Since:  &epoch,
+		},
+		Persistent: true,
+		Attachments: map[string]params.StorageAttachmentDetails{
+			"unit-postgresql-0": params.StorageAttachmentDetails{
+				Location: "hither",
 			},
-			Persistent: true,
-			Attachments: map[string]params.StorageAttachmentDetails{
-				"unit-transcode-0": params.StorageAttachmentDetails{
-					Location: "there",
-				},
-				"unit-transcode-1": params.StorageAttachmentDetails{
-					Location: "here",
-				},
+		},
+	}, {
+		StorageTag: "storage-shared-fs-0",
+		OwnerTag:   "service-transcode",
+		Kind:       params.StorageKindFilesystem,
+		Status: params.EntityStatus{
+			Status: params.StatusAttached,
+			Since:  &epoch,
+		},
+		Persistent: true,
+		Attachments: map[string]params.StorageAttachmentDetails{
+			"unit-transcode-0": params.StorageAttachmentDetails{
+				Location: "there",
+			},
+			"unit-transcode-1": params.StorageAttachmentDetails{
+				Location: "here",
 			},
 		},
 	}}
-	if s.includeErrors {
-		results = append(results, params.StorageDetailsResult{
-			Error: &params.Error{
-				Message: "error for storage-db-dir-1010",
-			},
-		})
-	}
 	return results, nil
 }

--- a/cmd/juju/storage/show.go
+++ b/cmd/juju/storage/show.go
@@ -82,7 +82,7 @@ func (c *showCommand) Run(ctx *cmd.Context) (err error) {
 		return err
 	}
 
-	results, err := api.Show(tags)
+	results, err := api.StorageDetails(tags)
 	if err != nil {
 		return err
 	}
@@ -94,11 +94,7 @@ func (c *showCommand) Run(ctx *cmd.Context) (err error) {
 			errs.Results = append(errs.Results, params.ErrorResult{result.Error})
 			continue
 		}
-		if result.Result != nil {
-			valid = append(valid, *result.Result)
-		} else {
-			valid = append(valid, storageDetailsFromLegacy(result.Legacy))
-		}
+		valid = append(valid, *result.Result)
 	}
 	if len(errs.Results) > 0 {
 		return errs.Combine()
@@ -125,5 +121,5 @@ func (c *showCommand) getStorageTags() ([]names.StorageTag, error) {
 // StorageAPI defines the API methods that the storage commands use.
 type StorageShowAPI interface {
 	Close() error
-	Show(tags []names.StorageTag) ([]params.StorageDetailsResult, error)
+	StorageDetails(tags []names.StorageTag) ([]params.StorageDetailsResult, error)
 }

--- a/cmd/juju/storage/show_test.go
+++ b/cmd/juju/storage/show_test.go
@@ -138,7 +138,7 @@ func (s mockShowAPI) Close() error {
 	return nil
 }
 
-func (s mockShowAPI) Show(tags []names.StorageTag) ([]params.StorageDetailsResult, error) {
+func (s mockShowAPI) StorageDetails(tags []names.StorageTag) ([]params.StorageDetailsResult, error) {
 	if s.noMatch {
 		return nil, nil
 	}
@@ -166,14 +166,19 @@ func (s mockShowAPI) Show(tags []names.StorageTag) ([]params.StorageDetailsResul
 				},
 			}
 		} else {
-			all[i].Legacy = params.LegacyStorageDetails{
+			all[i].Result = &params.StorageDetails{
 				StorageTag: tag.String(),
-				UnitTag:    "unit-postgresql-0",
 				Kind:       params.StorageKindBlock,
-				Status:     "pending",
+				Status: params.EntityStatus{
+					Status: "pending",
+					Since:  &epoch,
+				},
+				Attachments: map[string]params.StorageAttachmentDetails{
+					"unit-postgresql-0": params.StorageAttachmentDetails{},
+				},
 			}
 			if i == 1 {
-				all[i].Legacy.Persistent = true
+				all[i].Result.Persistent = true
 			}
 		}
 	}

--- a/cmd/juju/storage/storage.go
+++ b/cmd/juju/storage/storage.go
@@ -7,8 +7,6 @@
 package storage
 
 import (
-	"time"
-
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
@@ -151,30 +149,4 @@ func createStorageInfo(details params.StorageDetails) (names.StorageTag, Storage
 	}
 
 	return storageTag, info, nil
-}
-
-func storageDetailsFromLegacy(legacy params.LegacyStorageDetails) params.StorageDetails {
-	nowUTC := time.Now().UTC()
-	details := params.StorageDetails{
-		legacy.StorageTag,
-		legacy.OwnerTag,
-		legacy.Kind,
-		params.EntityStatus{
-			Status: params.Status(legacy.Status),
-			Since:  &nowUTC,
-		},
-		legacy.Persistent,
-		nil,
-	}
-	if legacy.UnitTag != "" {
-		details.Attachments = map[string]params.StorageAttachmentDetails{
-			legacy.UnitTag: params.StorageAttachmentDetails{
-				legacy.StorageTag,
-				legacy.UnitTag,
-				"", // machine is unknown in legacy
-				legacy.Location,
-			},
-		}
-	}
-	return details
 }

--- a/cmd/juju/storage/volume.go
+++ b/cmd/juju/storage/volume.go
@@ -83,7 +83,7 @@ type MachineVolumeAttachment struct {
 }
 
 // convertToVolumeInfo returns a map of volume IDs to volume info.
-func convertToVolumeInfo(all []params.VolumeDetailsResult) (map[string]VolumeInfo, error) {
+func convertToVolumeInfo(all []params.VolumeDetails) (map[string]VolumeInfo, error) {
 	result := make(map[string]VolumeInfo)
 	for _, one := range all {
 		volumeTag, info, err := createVolumeInfo(one)
@@ -103,12 +103,7 @@ var idFromTag = func(s string) (string, error) {
 	return tag.Id(), nil
 }
 
-func createVolumeInfo(result params.VolumeDetailsResult) (names.VolumeTag, VolumeInfo, error) {
-	details := result.Details
-	if details == nil {
-		details = volumeDetailsFromLegacy(result)
-	}
-
+func createVolumeInfo(details params.VolumeDetails) (names.VolumeTag, VolumeInfo, error) {
 	volumeTag, err := names.ParseVolumeTag(details.VolumeTag)
 	if err != nil {
 		return names.VolumeTag{}, VolumeInfo{}, errors.Trace(err)
@@ -157,50 +152,4 @@ func createVolumeInfo(result params.VolumeDetailsResult) (names.VolumeTag, Volum
 	}
 
 	return volumeTag, info, nil
-}
-
-// volumeDetailsFromLegacy converts from legacy data structures
-// to params.VolumeDetails. This exists only for backwards-
-// compatibility. Please think long and hard before changing it.
-func volumeDetailsFromLegacy(result params.VolumeDetailsResult) *params.VolumeDetails {
-	details := &params.VolumeDetails{
-		VolumeTag: result.LegacyVolume.VolumeTag,
-		Status:    result.LegacyVolume.Status,
-	}
-	details.Info.VolumeId = result.LegacyVolume.VolumeId
-	details.Info.HardwareId = result.LegacyVolume.HardwareId
-	details.Info.Size = result.LegacyVolume.Size
-	details.Info.Persistent = result.LegacyVolume.Persistent
-	if len(result.LegacyAttachments) > 0 {
-		attachments := make(map[string]params.VolumeAttachmentInfo)
-		for _, attachment := range result.LegacyAttachments {
-			attachments[attachment.MachineTag] = attachment.Info
-		}
-		details.MachineAttachments = attachments
-	}
-	if result.LegacyVolume.StorageTag != "" {
-		details.Storage = &params.StorageDetails{
-			StorageTag: result.LegacyVolume.StorageTag,
-			Status:     details.Status,
-		}
-		if result.LegacyVolume.UnitTag != "" {
-			// Servers with legacy storage do not support shared
-			// storage, so there will only be one attachment, and
-			// the owner is always a unit.
-			details.Storage.OwnerTag = result.LegacyVolume.UnitTag
-			if len(result.LegacyAttachments) == 1 {
-				details.Storage.Attachments = map[string]params.StorageAttachmentDetails{
-					result.LegacyVolume.UnitTag: params.StorageAttachmentDetails{
-						StorageTag: result.LegacyVolume.StorageTag,
-						UnitTag:    result.LegacyVolume.UnitTag,
-						MachineTag: result.LegacyAttachments[0].MachineTag,
-						// Don't set Location, because we can't infer that
-						// from the legacy volume details.
-						Location: "",
-					},
-				}
-			}
-		}
-	}
-	return details
 }

--- a/cmd/juju/storage/volumelist_test.go
+++ b/cmd/juju/storage/volumelist_test.go
@@ -32,7 +32,7 @@ func (s *volumeListSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *volumeListSuite) TestVolumeListEmpty(c *gc.C) {
-	s.mockAPI.listVolumes = func([]string) ([]params.VolumeDetailsResult, error) {
+	s.mockAPI.listVolumes = func([]string) ([]params.VolumeDetailsListResult, error) {
 		return nil, nil
 	}
 	s.assertValidList(
@@ -43,7 +43,7 @@ func (s *volumeListSuite) TestVolumeListEmpty(c *gc.C) {
 }
 
 func (s *volumeListSuite) TestVolumeListError(c *gc.C) {
-	s.mockAPI.listVolumes = func([]string) ([]params.VolumeDetailsResult, error) {
+	s.mockAPI.listVolumes = func([]string) ([]params.VolumeDetailsListResult, error) {
 		return nil, errors.New("just my luck")
 	}
 	context, err := s.runVolumeList(c, "--format", "yaml")
@@ -54,7 +54,7 @@ func (s *volumeListSuite) TestVolumeListError(c *gc.C) {
 func (s *volumeListSuite) TestVolumeListArgs(c *gc.C) {
 	var called bool
 	expectedArgs := []string{"a", "b", "c"}
-	s.mockAPI.listVolumes = func(arg []string) ([]params.VolumeDetailsResult, error) {
+	s.mockAPI.listVolumes = func(arg []string) ([]params.VolumeDetailsListResult, error) {
 		c.Assert(arg, jc.DeepEquals, expectedArgs)
 		called = true
 		return nil, nil
@@ -84,12 +84,12 @@ func (s *volumeListSuite) TestVolumeListJSON(c *gc.C) {
 }
 
 func (s *volumeListSuite) TestVolumeListWithErrorResults(c *gc.C) {
-	s.mockAPI.listVolumes = func([]string) ([]params.VolumeDetailsResult, error) {
+	s.mockAPI.listVolumes = func([]string) ([]params.VolumeDetailsListResult, error) {
 		results, _ := mockVolumeListAPI{}.ListVolumes(nil)
-		results = append(results, params.VolumeDetailsResult{
+		results = append(results, params.VolumeDetailsListResult{
 			Error: &params.Error{Message: "bad"},
 		})
-		results = append(results, params.VolumeDetailsResult{
+		results = append(results, params.VolumeDetailsListResult{
 			Error: &params.Error{Message: "ness"},
 		})
 		return results, nil
@@ -101,14 +101,13 @@ func (s *volumeListSuite) TestVolumeListWithErrorResults(c *gc.C) {
 }
 
 var expectedVolumeListTabular = `
-MACHINE  UNIT         STORAGE      ID   PROVIDER-ID                   DEVICE  SIZE    STATE       MESSAGE
-0        abc/0        db-dir/1000  0    provider-supplied-volume-0    sda     1.0GiB  destroying  
-0        abc/0        db-dir/1001  0/0  provider-supplied-volume-0-0  loop0   512MiB  attached    
-0        transcode/0  shared-fs/0  4    provider-supplied-volume-4    xvdf2   1.0GiB  attached    
-0                                  1    provider-supplied-volume-1            2.0GiB  attaching   failed to attach, will retry
-1        transcode/1  shared-fs/0  4    provider-supplied-volume-4    xvdf3   1.0GiB  attached    
-1                                  2    provider-supplied-volume-2    xvdf1   3.0MiB  attached    
-1                                  3                                          42MiB   pending     
+MACHINE  UNIT         STORAGE      ID   PROVIDER-ID                   DEVICE  SIZE    STATE      MESSAGE
+0        abc/0        db-dir/1001  0/0  provider-supplied-volume-0-0  loop0   512MiB  attached   
+0        transcode/0  shared-fs/0  4    provider-supplied-volume-4    xvdf2   1.0GiB  attached   
+0                                  1    provider-supplied-volume-1            2.0GiB  attaching  failed to attach, will retry
+1        transcode/1  shared-fs/0  4    provider-supplied-volume-4    xvdf3   1.0GiB  attached   
+1                                  2    provider-supplied-volume-2    xvdf1   3.0MiB  attached   
+1                                  3                                          42MiB   pending    
 
 `[1:]
 
@@ -117,7 +116,7 @@ func (s *volumeListSuite) TestVolumeListTabular(c *gc.C) {
 
 	// Do it again, reversing the results returned by the API.
 	// We should get everything sorted in the appropriate order.
-	s.mockAPI.listVolumes = func([]string) ([]params.VolumeDetailsResult, error) {
+	s.mockAPI.listVolumes = func([]string) ([]params.VolumeDetailsListResult, error) {
 		results, _ := mockVolumeListAPI{}.ListVolumes(nil)
 		n := len(results)
 		for i := 0; i < n/2; i++ {
@@ -151,10 +150,10 @@ func (s *volumeListSuite) expect(c *gc.C, machines []string) map[string]storage.
 	all, err := s.mockAPI.ListVolumes(machines)
 	c.Assert(err, jc.ErrorIsNil)
 
-	var valid []params.VolumeDetailsResult
+	var valid []params.VolumeDetails
 	for _, result := range all {
 		if result.Error == nil {
-			valid = append(valid, result)
+			valid = append(valid, result.Result...)
 		}
 	}
 	result, err := storage.ConvertToVolumeInfo(valid)
@@ -183,22 +182,22 @@ func (s *volumeListSuite) assertUserFacingOutput(c *gc.C, context *cmd.Context, 
 }
 
 type mockVolumeListAPI struct {
-	listVolumes func([]string) ([]params.VolumeDetailsResult, error)
+	listVolumes func([]string) ([]params.VolumeDetailsListResult, error)
 }
 
 func (s mockVolumeListAPI) Close() error {
 	return nil
 }
 
-func (s mockVolumeListAPI) ListVolumes(machines []string) ([]params.VolumeDetailsResult, error) {
+func (s mockVolumeListAPI) ListVolumes(machines []string) ([]params.VolumeDetailsListResult, error) {
 	if s.listVolumes != nil {
 		return s.listVolumes(machines)
 	}
-	results := []params.VolumeDetailsResult{{
+	results := []params.VolumeDetailsListResult{{Result: []params.VolumeDetails{
 		// volume 0/0 is attached to machine 0, assigned to
 		// storage db-dir/1001, which is attached to unit
 		// abc/0.
-		Details: &params.VolumeDetails{
+		{
 			VolumeTag: "volume-0-0",
 			Info: params.VolumeInfo{
 				VolumeId: "provider-supplied-volume-0-0",
@@ -225,34 +224,9 @@ func (s mockVolumeListAPI) ListVolumes(machines []string) ([]params.VolumeDetail
 				},
 			},
 		},
-	}, {
-		// volume 0 is attached to machine 0, assigned to
-		// storage db-dir/1000, which is attached to unit
-		// abc/0.
-		//
-		// Use Legacy and LegacyAttachment here to test
-		// backwards compatibility.
-		LegacyVolume: &params.LegacyVolumeDetails{
-			VolumeTag:  "volume-0",
-			StorageTag: "storage-db-dir-1000",
-			UnitTag:    "unit-abc-0",
-			VolumeId:   "provider-supplied-volume-0",
-			Size:       1024,
-			Persistent: false,
-			Status:     createTestStatus(params.StatusDestroying, ""),
-		},
-		LegacyAttachments: []params.VolumeAttachment{{
-			VolumeTag:  "volume-0",
-			MachineTag: "machine-0",
-			Info: params.VolumeAttachmentInfo{
-				DeviceName: "sda",
-				ReadOnly:   true,
-			},
-		}},
-	}, {
 		// volume 1 is attaching to machine 0, but is not assigned
 		// to any storage.
-		Details: &params.VolumeDetails{
+		{
 			VolumeTag: "volume-1",
 			Info: params.VolumeInfo{
 				VolumeId:   "provider-supplied-volume-1",
@@ -265,10 +239,9 @@ func (s mockVolumeListAPI) ListVolumes(machines []string) ([]params.VolumeDetail
 				"machine-0": params.VolumeAttachmentInfo{},
 			},
 		},
-	}, {
 		// volume 3 is due to be attached to machine 1, but is not
 		// assigned to any storage and has not yet been provisioned.
-		Details: &params.VolumeDetails{
+		{
 			VolumeTag: "volume-3",
 			Info: params.VolumeInfo{
 				Size: 42,
@@ -278,10 +251,9 @@ func (s mockVolumeListAPI) ListVolumes(machines []string) ([]params.VolumeDetail
 				"machine-1": params.VolumeAttachmentInfo{},
 			},
 		},
-	}, {
 		// volume 2 is due to be attached to machine 1, but is not
 		// assigned to any storage and has not yet been provisioned.
-		Details: &params.VolumeDetails{
+		{
 			VolumeTag: "volume-2",
 			Info: params.VolumeInfo{
 				VolumeId: "provider-supplied-volume-2",
@@ -294,10 +266,9 @@ func (s mockVolumeListAPI) ListVolumes(machines []string) ([]params.VolumeDetail
 				},
 			},
 		},
-	}, {
 		// volume 4 is attached to machines 0 and 1, and is assigned
 		// to shared storage.
-		Details: &params.VolumeDetails{
+		{
 			VolumeTag: "volume-4",
 			Info: params.VolumeInfo{
 				VolumeId:   "provider-supplied-volume-4",
@@ -336,7 +307,7 @@ func (s mockVolumeListAPI) ListVolumes(machines []string) ([]params.VolumeDetail
 				},
 			},
 		},
-	}}
+	}}}
 	return results, nil
 }
 

--- a/featuretests/storage_test.go
+++ b/featuretests/storage_test.go
@@ -317,7 +317,7 @@ tmpfs:
 func (s *cmdStorageSuite) TestListPoolsProviderUnregistered(c *gc.C) {
 	_, stderr, err := runPoolList(c, "--provider", "oops")
 	c.Assert(err, gc.NotNil)
-	c.Assert(stderr, jc.Contains, `"oops" for environment "dummyenv" not supported`)
+	c.Assert(stderr, jc.Contains, `"oops" not supported`)
 }
 
 func (s *cmdStorageSuite) TestListPoolsNameAndProvider(c *gc.C) {
@@ -437,7 +437,7 @@ func runVolumeList(c *gc.C, args ...string) (string, string, error) {
 
 func (s *cmdStorageSuite) TestListVolumeInvalidMachine(c *gc.C) {
 	_, stderr, err := runVolumeList(c, "abc")
-	c.Assert(err, gc.ErrorMatches, "cmd: error out silently")
+	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(stderr, jc.Contains, `"machine-abc" is not a valid machine tag`)
 }
 


### PR DESCRIPTION
The storage API has been updated to remove
the legacy fields in preparation for the
upcoming 2.0 release, which affords us
an opportunity to tidy up without requiring
backwards compatibility.

In addition, various API methods have been
renamed and their arguments and results
restructured to be more consistent with
the rest of the API, and with the storage
model.

(Review request: http://reviews.vapour.ws/r/3470/)