### PR TITLE
Reverted PRs #3730, #3966, #3866

### DIFF
--- a/apiserver/addresser/addresser.go
+++ b/apiserver/addresser/addresser.go
@@ -132,8 +132,8 @@ func (api *AddresserAPI) CleanupIPAddresses() params.ErrorResult {
 
 // netEnvReleaseAddress is used for testability.
 var netEnvReleaseAddress = func(env environs.NetworkingEnviron,
-	instId instance.Id, subnetId network.Id, addr network.Address, macAddress, hostname string) error {
-	return env.ReleaseAddress(instId, subnetId, addr, macAddress, hostname)
+	instId instance.Id, subnetId network.Id, addr network.Address, macAddress string) error {
+	return env.ReleaseAddress(instId, subnetId, addr, macAddress)
 }
 
 // releaseIPAddress releases one IP address.
@@ -146,7 +146,7 @@ func (api *AddresserAPI) releaseIPAddress(netEnv environs.NetworkingEnviron, ipA
 	}
 	// Now release the IP address.
 	subnetId := network.Id(ipAddress.SubnetId())
-	err = netEnvReleaseAddress(netEnv, ipAddress.InstanceId(), subnetId, ipAddress.Address(), ipAddress.MACAddress(), "")
+	err = netEnvReleaseAddress(netEnv, ipAddress.InstanceId(), subnetId, ipAddress.Address(), ipAddress.MACAddress())
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/apiserver/addresser/addresser_test.go
+++ b/apiserver/addresser/addresser_test.go
@@ -152,19 +152,13 @@ func (s *AddresserSuite) TestReleaseAddress(c *gc.C) {
 
 	// Prepare tests.
 	called := 0
-	s.PatchValue(addresser.NetEnvReleaseAddress, func(
-		env environs.NetworkingEnviron,
-		instId instance.Id,
-		subnetId network.Id,
-		addr network.Address,
-		macAddress, hostname string,
-	) error {
+	s.PatchValue(addresser.NetEnvReleaseAddress, func(env environs.NetworkingEnviron,
+		instId instance.Id, subnetId network.Id, addr network.Address, macAddress string) error {
 		called++
 		c.Assert(instId, gc.Equals, instance.Id("a3"))
 		c.Assert(subnetId, gc.Equals, network.Id("a"))
 		c.Assert(addr, gc.Equals, network.NewAddress("0.1.2.3"))
 		c.Assert(macAddress, gc.Equals, "fff3")
-		c.Assert(hostname, gc.Equals, "")
 		return nil
 	})
 

--- a/apiserver/provisioner/container_test.go
+++ b/apiserver/provisioner/container_test.go
@@ -4,6 +4,7 @@
 package provisioner_test
 
 import (
+	"encoding/hex"
 	"fmt"
 	"strings"
 
@@ -28,8 +29,6 @@ type containerSuite struct {
 
 	provAPI *provisioner.ProvisionerAPI
 }
-
-const regexpMACAddress = "([a-f0-9]{2}:){5}[a-f0-9]{2}"
 
 func (s *containerSuite) SetUpTest(c *gc.C) {
 	s.setUpTest(c, false)
@@ -153,11 +152,13 @@ func (s *prepareSuite) assertCall(c *gc.C, args params.Entities, expectResults *
 					c.Assert(cfg[j].Address, gc.Matches, rex)
 					expectResults.Results[i].Config[j].Address = cfg[j].Address
 				}
-				if strings.HasPrefix(expCfg.MACAddress, "regex:") {
-					rex := strings.TrimPrefix(expCfg.MACAddress, "regex:")
-					c.Assert(cfg[j].MACAddress, gc.Matches, rex)
-					expectResults.Results[i].Config[j].MACAddress = cfg[j].MACAddress
-				}
+				macAddress := cfg[j].MACAddress
+				c.Assert(macAddress[:8], gc.Equals, provisioner.MACAddressTemplate[:8])
+				remainder := strings.Replace(macAddress[8:], ":", "", 3)
+				c.Assert(remainder, gc.HasLen, 6)
+				_, err = hex.DecodeString(remainder)
+				c.Assert(err, jc.ErrorIsNil)
+				expectResults.Results[i].Config[j].MACAddress = macAddress
 			}
 		}
 
@@ -180,62 +181,9 @@ func (s *prepareSuite) TestErrorWithNoFeatureFlag(c *gc.C) {
 	s.SetFeatureFlags() // clear the flags.
 	container := s.newAPI(c, true, true)
 	args := s.makeArgs(container)
-	expectedError := &params.Error{
-		Message: `failed to allocate an address for "0/lxc/0": address allocation not supported`,
-		Code:    params.CodeNotSupported,
-	}
-	s.assertCall(c, args, &params.MachineNetworkConfigResults{
-		Results: []params.MachineNetworkConfigResult{
-			{Error: expectedError},
-		},
-	}, "")
-}
-
-func (s *prepareSuite) TestErrorWithNoFeatureFlagAndBrokenAllocate(c *gc.C) {
-	s.breakEnvironMethods(c, "AllocateAddress")
-	s.SetFeatureFlags()
-	// Use the special "i-alloc-" prefix to force the dummy provider to allow
-	// AllocateAddress to run without the feature flag.
-	container := s.newCustomAPI(c, "i-alloc-me", true, false)
-	args := s.makeArgs(container)
-	expectedError := &params.Error{
-		Message: `failed to allocate an address for "0/lxc/0": dummy.AllocateAddress is broken`,
-	}
-	s.assertCall(c, args, &params.MachineNetworkConfigResults{
-		Results: []params.MachineNetworkConfigResult{
-			{Error: expectedError},
-		},
-	}, "")
-}
-
-func (s *prepareSuite) TestErrorWithNoFeatureFlagAllocateSuccess(c *gc.C) {
-	s.SetFeatureFlags()
-	s.breakEnvironMethods(c)
-	// Use the special "i-alloc-" prefix to force the dummy provider to allow
-	// AllocateAddress to run without the feature flag, which simulates a MAAS
-	// 1.8+ environment where without the flag we still try calling
-	// AllocateAddress for the device we created for the container.
-	container := s.newCustomAPI(c, "i-alloc-me", true, false)
-	args := s.makeArgs(container)
-	_, testLog := s.assertCall(c, args, s.makeResults([]params.NetworkConfig{{
-		DeviceIndex:    0,
-		NetworkName:    "juju-private",
-		ProviderId:     "dummy-eth0",
-		InterfaceName:  "eth0",
-		DNSServers:     []string{"ns1.dummy", "ns2.dummy"},
-		GatewayAddress: "0.10.0.1",
-		ConfigType:     "static",
-		MACAddress:     "regex:" + regexpMACAddress,
-		Address:        "regex:0.10.0.[0-9]{1,3}", // we don't care about the actual value.
-	}}), "")
-
-	c.Assert(testLog, jc.LogMatches, jc.SimpleMessages{{
-		loggo.INFO,
-		`allocated address ".+" on instance "i-alloc-me" for container "juju-machine-0-lxc-0"`,
-	}, {
-		loggo.INFO,
-		`assigned address ".+" to container "0/lxc/0"`,
-	}})
+	s.assertCall(c, args, &params.MachineNetworkConfigResults{},
+		`address allocation not supported`,
+	)
 }
 
 func (s *prepareSuite) TestErrorWithNonProvisionedHost(c *gc.C) {
@@ -471,9 +419,8 @@ func (s *prepareSuite) TestReleaseAndCleanupWhenAllocateAndOrSetFail(c *gc.C) {
 	// are called along with the addresses to verify the logs later.
 	var allocAttemptedAddrs, allocAddrsOK, setAddrs, releasedAddrs []string
 	s.PatchValue(provisioner.AllocateAddrTo, func(ip *state.IPAddress, m *state.Machine, mac string) error {
-		c.Logf("allocateAddrTo called for address %q, machine %q, mac %q", ip.String(), m, mac)
+		c.Logf("allocateAddrTo called for address %q, machine %q", ip.String(), m)
 		c.Assert(m.Id(), gc.Equals, container.Id())
-		c.Assert(mac, gc.Matches, regexpMACAddress)
 		allocAttemptedAddrs = append(allocAttemptedAddrs, ip.Value())
 
 		// Succeed on every other call to give a chance to call
@@ -576,7 +523,6 @@ func (s *prepareSuite) TestReleaseAndRetryWhenSetOnlyFails(c *gc.C) {
 		DeviceIndex:      0,
 		InterfaceName:    "eth0",
 		VLANTag:          0,
-		MACAddress:       "regex:" + regexpMACAddress,
 		Disabled:         false,
 		NoAutoStart:      false,
 		ConfigType:       "static",
@@ -658,7 +604,6 @@ func (s *prepareSuite) TestSuccessWithSingleContainer(c *gc.C) {
 		DeviceIndex:      0,
 		InterfaceName:    "eth0",
 		VLANTag:          0,
-		MACAddress:       "regex:" + regexpMACAddress,
 		Disabled:         false,
 		NoAutoStart:      false,
 		ConfigType:       "static",
@@ -695,7 +640,6 @@ func (s *prepareSuite) TestSuccessWhenFirstSubnetNotAllocatable(c *gc.C) {
 		DeviceIndex:      1,
 		InterfaceName:    "eth1",
 		VLANTag:          1,
-		MACAddress:       "regex:" + regexpMACAddress,
 		Disabled:         false,
 		NoAutoStart:      true,
 		ConfigType:       "static",
@@ -769,12 +713,9 @@ func (s *releaseSuite) TestErrorWithNoFeatureFlag(c *gc.C) {
 	s.SetFeatureFlags() // clear the flags.
 	s.newAPI(c, true, false)
 	args := s.makeArgs(s.machines[0])
-	expectedError := `cannot mark addresses for removal for "machine-0": not a container`
-	s.assertCall(c, args, &params.ErrorResults{
-		Results: []params.ErrorResult{{
-			Error: apiservertesting.ServerError(expectedError),
-		}},
-	}, "")
+	s.assertCall(c, args, &params.ErrorResults{},
+		"address allocation not supported",
+	)
 }
 
 func (s *releaseSuite) TestErrorWithHostInsteadOfContainer(c *gc.C) {

--- a/container/lxc/lxc.go
+++ b/container/lxc/lxc.go
@@ -852,8 +852,7 @@ const singleNICTemplate = `
 lxc.network.type = {{.Type}}
 lxc.network.link = {{.Link}}
 lxc.network.flags = up{{if .MTU}}
-lxc.network.mtu = {{.MTU}}{{end}}{{if .MACAddress}}
-lxc.network.hwaddr = {{.MACAddress}}{{end}}
+lxc.network.mtu = {{.MTU}}{{end}}
 
 `
 
@@ -863,8 +862,8 @@ const multipleNICsTemplate = `
 lxc.network.type = {{$nic.Type}}{{if $nic.VLANTag}}
 lxc.network.vlan.id = {{$nic.VLANTag}}{{end}}
 lxc.network.link = {{$nic.Link}}{{if not $nic.NoAutoStart}}
-lxc.network.flags = up{{end}}{{if $nic.Name}}
-lxc.network.name = {{$nic.Name}}{{end}}{{if $nic.MACAddress}}
+lxc.network.flags = up{{end}}
+lxc.network.name = {{$nic.Name}}{{if $nic.MACAddress}}
 lxc.network.hwaddr = {{$nic.MACAddress}}{{end}}{{if $nic.IPv4Address}}
 lxc.network.ipv4 = {{$nic.IPv4Address}}{{end}}{{if $nic.IPv4Gateway}}
 lxc.network.ipv4.gateway = {{$nic.IPv4Gateway}}{{end}}{{if $mtu}}
@@ -887,10 +886,8 @@ func networkConfigTemplate(config container.NetworkConfig) string {
 	type configData struct {
 		Type       string
 		Link       string
-		Interfaces []nicData
-		// The following are used only with a single NIC config.
 		MTU        int
-		MACAddress string
+		Interfaces []nicData
 	}
 	data := configData{
 		Link: config.Device,

--- a/environs/networking.go
+++ b/environs/networking.go
@@ -14,16 +14,13 @@ import (
 // Networking interface defines methods that environments
 // with networking capabilities must implement.
 type Networking interface {
-	// AllocateAddress requests a specific address to be allocated for the given
-	// instance on the given subnet, using the specified macAddress and
-	// hostnameSuffix. If addr is empty, this is interpreted as an output
-	// argument, which will contain the allocated address. Otherwise, addr must
-	// be non-empty and will be allocated as specified, if possible.
-	AllocateAddress(instId instance.Id, subnetId network.Id, addr *network.Address, macAddress, hostnameSuffix string) error
+	// AllocateAddress requests a specific address to be allocated for the
+	// given instance on the given subnet.
+	AllocateAddress(instId instance.Id, subnetId network.Id, addr network.Address, macAddress, hostname string) error
 
 	// ReleaseAddress releases a specific address previously allocated with
 	// AllocateAddress.
-	ReleaseAddress(instId instance.Id, subnetId network.Id, addr network.Address, macAddress, hostname string) error
+	ReleaseAddress(instId instance.Id, subnetId network.Id, addr network.Address, macAddress string) error
 
 	// Subnets returns basic information about subnets known
 	// by the provider for the environment.

--- a/juju/deploy_test.go
+++ b/juju/deploy_test.go
@@ -226,12 +226,11 @@ func (s *DeployLocalSuite) TestDeployWithPlacement(c *gc.C) {
 			ServiceName: "bob",
 			Charm:       s.charm,
 			Constraints: serviceCons,
-			NumUnits:    4,
+			NumUnits:    3,
 			Placement: []*instance.Placement{
 				{Scope: s.State.EnvironUUID(), Directive: "valid"},
 				{Scope: "#", Directive: "0"},
 				{Scope: "lxc", Directive: "1"},
-				{Scope: "lxc", Directive: ""},
 			},
 			ToMachineSpec: "will be ignored",
 		})
@@ -239,13 +238,12 @@ func (s *DeployLocalSuite) TestDeployWithPlacement(c *gc.C) {
 	s.assertConstraints(c, service, serviceCons)
 	units, err := service.AllUnits()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(units, gc.HasLen, 4)
+	c.Assert(units, gc.HasLen, 3)
 
 	// Check each of the newly added units.
 	s.assertAssignedUnit(c, units[0], "1", constraints.MustParse("mem=2G cpu-cores=2"))
 	s.assertAssignedUnit(c, units[1], "0", constraints.Value{})
 	s.assertAssignedUnit(c, units[2], "1/lxc/0", constraints.MustParse("mem=2G cpu-cores=2"))
-	s.assertAssignedUnit(c, units[3], "2/lxc/0", constraints.MustParse("mem=2G cpu-cores=2"))
 }
 
 func (s *DeployLocalSuite) TestDeployWithFewerPlacement(c *gc.C) {

--- a/provider/dummy/environs_test.go
+++ b/provider/dummy/environs_test.go
@@ -225,25 +225,25 @@ func (s *suite) TestAllocateAddress(c *gc.C) {
 
 	// Test allocating a couple of addresses.
 	newAddress := network.NewScopedAddress("0.1.2.1", network.ScopeCloudLocal)
-	err := e.AllocateAddress(inst.Id(), subnetId, &newAddress, "foo", "bar")
+	err := e.AllocateAddress(inst.Id(), subnetId, newAddress, "foo", "bar")
 	c.Assert(err, jc.ErrorIsNil)
 	assertAllocateAddress(c, e, opc, inst.Id(), subnetId, newAddress, "foo", "bar")
 
 	newAddress = network.NewScopedAddress("0.1.2.2", network.ScopeCloudLocal)
-	err = e.AllocateAddress(inst.Id(), subnetId, &newAddress, "foo", "bar")
+	err = e.AllocateAddress(inst.Id(), subnetId, newAddress, "foo", "bar")
 	c.Assert(err, jc.ErrorIsNil)
 	assertAllocateAddress(c, e, opc, inst.Id(), subnetId, newAddress, "foo", "bar")
 
 	// Test we can induce errors.
 	s.breakMethods(c, e, "AllocateAddress")
 	newAddress = network.NewScopedAddress("0.1.2.3", network.ScopeCloudLocal)
-	err = e.AllocateAddress(inst.Id(), subnetId, &newAddress, "foo", "bar")
+	err = e.AllocateAddress(inst.Id(), subnetId, newAddress, "foo", "bar")
 	c.Assert(err, gc.ErrorMatches, `dummy\.AllocateAddress is broken`)
 
 	// Finally, test the method respects the feature flag when
 	// disabled.
 	s.SetFeatureFlags() // clear the flags.
-	err = e.AllocateAddress(inst.Id(), subnetId, &newAddress, "foo", "bar")
+	err = e.AllocateAddress(inst.Id(), subnetId, newAddress, "foo", "bar")
 	c.Assert(err, gc.ErrorMatches, "address allocation not supported")
 	c.Assert(err, jc.Satisfies, errors.IsNotSupported)
 }
@@ -265,26 +265,25 @@ func (s *suite) TestReleaseAddress(c *gc.C) {
 	// Release a couple of addresses.
 	address := network.NewScopedAddress("0.1.2.1", network.ScopeCloudLocal)
 	macAddress := "foobar"
-	hostname := "myhostname"
-	err := e.ReleaseAddress(inst.Id(), subnetId, address, macAddress, hostname)
+	err := e.ReleaseAddress(inst.Id(), subnetId, address, macAddress)
 	c.Assert(err, jc.ErrorIsNil)
-	assertReleaseAddress(c, e, opc, inst.Id(), subnetId, address, macAddress, hostname)
+	assertReleaseAddress(c, e, opc, inst.Id(), subnetId, address, macAddress)
 
 	address = network.NewScopedAddress("0.1.2.2", network.ScopeCloudLocal)
-	err = e.ReleaseAddress(inst.Id(), subnetId, address, macAddress, hostname)
+	err = e.ReleaseAddress(inst.Id(), subnetId, address, macAddress)
 	c.Assert(err, jc.ErrorIsNil)
-	assertReleaseAddress(c, e, opc, inst.Id(), subnetId, address, macAddress, hostname)
+	assertReleaseAddress(c, e, opc, inst.Id(), subnetId, address, macAddress)
 
 	// Test we can induce errors.
 	s.breakMethods(c, e, "ReleaseAddress")
 	address = network.NewScopedAddress("0.1.2.3", network.ScopeCloudLocal)
-	err = e.ReleaseAddress(inst.Id(), subnetId, address, macAddress, hostname)
+	err = e.ReleaseAddress(inst.Id(), subnetId, address, macAddress)
 	c.Assert(err, gc.ErrorMatches, `dummy\.ReleaseAddress is broken`)
 
 	// Finally, test the method respects the feature flag when
 	// disabled.
 	s.SetFeatureFlags() // clear the flags.
-	err = e.ReleaseAddress(inst.Id(), subnetId, address, macAddress, hostname)
+	err = e.ReleaseAddress(inst.Id(), subnetId, address, macAddress)
 	c.Assert(err, gc.ErrorMatches, "address allocation not supported")
 	c.Assert(err, jc.Satisfies, errors.IsNotSupported)
 }
@@ -550,16 +549,7 @@ func (s *suite) TestPreferIPv6Off(c *gc.C) {
 	c.Assert(addrs, jc.DeepEquals, network.NewAddresses("only-0.dns", "127.0.0.1"))
 }
 
-func assertAllocateAddress(
-	c *gc.C,
-	e environs.Environ,
-	opc chan dummy.Operation,
-	expectInstId instance.Id,
-	expectSubnetId network.Id,
-	expectAddress network.Address,
-	expectMAC string,
-	expectHost string,
-) {
+func assertAllocateAddress(c *gc.C, e environs.Environ, opc chan dummy.Operation, expectInstId instance.Id, expectSubnetId network.Id, expectAddress network.Address, expectMAC, expectHostName string) {
 	select {
 	case op := <-opc:
 		addrOp, ok := op.(dummy.OpAllocateAddress)
@@ -570,23 +560,14 @@ func assertAllocateAddress(
 		c.Check(addrOp.InstanceId, gc.Equals, expectInstId)
 		c.Check(addrOp.Address, gc.Equals, expectAddress)
 		c.Check(addrOp.MACAddress, gc.Equals, expectMAC)
-		c.Check(addrOp.HostName, gc.Equals, expectHost)
+		c.Check(addrOp.HostName, gc.Equals, expectHostName)
 		return
 	case <-time.After(testing.ShortWait):
 		c.Fatalf("time out wating for operation")
 	}
 }
 
-func assertReleaseAddress(
-	c *gc.C,
-	e environs.Environ,
-	opc chan dummy.Operation,
-	expectInstId instance.Id,
-	expectSubnetId network.Id,
-	expectAddress network.Address,
-	expectMAC string,
-	expectHost string,
-) {
+func assertReleaseAddress(c *gc.C, e environs.Environ, opc chan dummy.Operation, expectInstId instance.Id, expectSubnetId network.Id, expectAddress network.Address, macAddress string) {
 	select {
 	case op := <-opc:
 		addrOp, ok := op.(dummy.OpReleaseAddress)
@@ -596,8 +577,7 @@ func assertReleaseAddress(
 		c.Check(addrOp.SubnetId, gc.Equals, expectSubnetId)
 		c.Check(addrOp.InstanceId, gc.Equals, expectInstId)
 		c.Check(addrOp.Address, gc.Equals, expectAddress)
-		c.Check(addrOp.MACAddress, gc.Equals, expectMAC)
-		c.Check(addrOp.HostName, gc.Equals, expectHost)
+		c.Check(addrOp.MACAddress, gc.Equals, macAddress)
 		return
 	case <-time.After(testing.ShortWait):
 		c.Fatalf("time out wating for operation")

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -903,12 +903,9 @@ func (e *environ) fetchNetworkInterfaceId(ec2Inst *ec2.EC2, instId instance.Id) 
 
 // AllocateAddress requests an address to be allocated for the given
 // instance on the given subnet. Implements NetworkingEnviron.AllocateAddress.
-func (e *environ) AllocateAddress(instId instance.Id, _ network.Id, addr *network.Address, _, _ string) (err error) {
+func (e *environ) AllocateAddress(instId instance.Id, _ network.Id, addr network.Address, _, _ string) (err error) {
 	if !environs.AddressAllocationEnabled() {
 		return errors.NotSupportedf("address allocation")
-	}
-	if addr == nil || addr.Value == "" {
-		return errors.NewNotValid(nil, "invalid address: nil or empty")
 	}
 
 	defer errors.DeferredAnnotatef(&err, "failed to allocate address %q for instance %q", addr, instId)
@@ -920,17 +917,17 @@ func (e *environ) AllocateAddress(instId instance.Id, _ network.Id, addr *networ
 		return errors.Trace(err)
 	}
 	for a := shortAttempt.Start(); a.Next(); {
-		err = AssignPrivateIPAddress(ec2Inst, nicId, *addr)
-		logger.Tracef("AssignPrivateIPAddresses(%v, %v) returned: %v", nicId, *addr, err)
+		err = AssignPrivateIPAddress(ec2Inst, nicId, addr)
+		logger.Tracef("AssignPrivateIPAddresses(%v, %v) returned: %v", nicId, addr, err)
 		if err == nil {
-			logger.Tracef("allocated address %v for instance %v, NIC %v", *addr, instId, nicId)
+			logger.Tracef("allocated address %v for instance %v, NIC %v", addr, instId, nicId)
 			break
 		}
 		if ec2Err, ok := err.(*ec2.Error); ok {
 			if ec2Err.Code == invalidParameterValue {
 				// Note: this Code is also used if we specify
 				// an IP address outside the subnet. Take care!
-				logger.Tracef("address %q not available for allocation", *addr)
+				logger.Tracef("address %q not available for allocation", addr)
 				return environs.ErrIPAddressUnavailable
 			} else if ec2Err.Code == privateAddressLimitExceeded {
 				logger.Tracef("no more addresses available on the subnet")
@@ -944,7 +941,7 @@ func (e *environ) AllocateAddress(instId instance.Id, _ network.Id, addr *networ
 
 // ReleaseAddress releases a specific address previously allocated with
 // AllocateAddress. Implements NetworkingEnviron.ReleaseAddress.
-func (e *environ) ReleaseAddress(instId instance.Id, _ network.Id, addr network.Address, _, _ string) (err error) {
+func (e *environ) ReleaseAddress(instId instance.Id, _ network.Id, addr network.Address, _ string) (err error) {
 	if !environs.AddressAllocationEnabled() {
 		return errors.NotSupportedf("address allocation")
 	}

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -858,19 +858,12 @@ func (t *localServerSuite) TestAllocateAddressFailureToFindNetworkInterface(c *g
 	addr := network.Address{Value: "8.0.0.4"}
 
 	// Invalid instance found
-	err = env.AllocateAddress(instId+"foo", "", &addr, "foo", "bar")
+	err = env.AllocateAddress(instId+"foo", "", addr, "foo", "bar")
 	c.Assert(err, gc.ErrorMatches, ".*InvalidInstanceID.NotFound.*")
 
 	// No network interface
-	err = env.AllocateAddress(instId, "", &addr, "foo", "bar")
+	err = env.AllocateAddress(instId, "", addr, "foo", "bar")
 	c.Assert(errors.Cause(err), gc.ErrorMatches, "unexpected AWS response: network interface not found")
-
-	// Nil or empty address given.
-	err = env.AllocateAddress(instId, "", nil, "foo", "bar")
-	c.Assert(errors.Cause(err), gc.ErrorMatches, "invalid address: nil or empty")
-
-	err = env.AllocateAddress(instId, "", &network.Address{Value: ""}, "foo", "bar")
-	c.Assert(errors.Cause(err), gc.ErrorMatches, "invalid address: nil or empty")
 }
 
 func (t *localServerSuite) setUpInstanceWithDefaultVpc(c *gc.C) (environs.NetworkingEnviron, instance.Id) {
@@ -897,7 +890,7 @@ func (t *localServerSuite) TestAllocateAddress(c *gc.C) {
 	}
 	t.PatchValue(&ec2.AssignPrivateIPAddress, mockAssign)
 
-	err := env.AllocateAddress(instId, "", &addr, "foo", "bar")
+	err := env.AllocateAddress(instId, "", addr, "foo", "bar")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(actualAddr, gc.Equals, addr)
 }
@@ -911,7 +904,10 @@ func (t *localServerSuite) TestAllocateAddressIPAddressInUseOrEmpty(c *gc.C) {
 	}
 	t.PatchValue(&ec2.AssignPrivateIPAddress, mockAssign)
 
-	err := env.AllocateAddress(instId, "", &addr, "foo", "bar")
+	err := env.AllocateAddress(instId, "", addr, "foo", "bar")
+	c.Assert(errors.Cause(err), gc.Equals, environs.ErrIPAddressUnavailable)
+
+	err = env.AllocateAddress(instId, "", network.Address{}, "foo", "bar")
 	c.Assert(errors.Cause(err), gc.Equals, environs.ErrIPAddressUnavailable)
 }
 
@@ -924,7 +920,7 @@ func (t *localServerSuite) TestAllocateAddressNetworkInterfaceFull(c *gc.C) {
 	}
 	t.PatchValue(&ec2.AssignPrivateIPAddress, mockAssign)
 
-	err := env.AllocateAddress(instId, "", &addr, "foo", "bar")
+	err := env.AllocateAddress(instId, "", addr, "foo", "bar")
 	c.Assert(errors.Cause(err), gc.Equals, environs.ErrIPAddressesExhausted)
 }
 
@@ -932,15 +928,15 @@ func (t *localServerSuite) TestReleaseAddress(c *gc.C) {
 	env, instId := t.setUpInstanceWithDefaultVpc(c)
 	addr := network.Address{Value: "8.0.0.4"}
 	// Allocate the address first so we can release it
-	err := env.AllocateAddress(instId, "", &addr, "foo", "bar")
+	err := env.AllocateAddress(instId, "", addr, "foo", "bar")
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = env.ReleaseAddress(instId, "", addr, "", "")
+	err = env.ReleaseAddress(instId, "", addr, "")
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Releasing a second time tests that the first call actually released
 	// it plus tests the error handling of ReleaseAddress
-	err = env.ReleaseAddress(instId, "", addr, "", "")
+	err = env.ReleaseAddress(instId, "", addr, "")
 	msg := fmt.Sprintf(`failed to release address "8\.0\.0\.4" from instance %q.*`, instId)
 	c.Assert(err, gc.ErrorMatches, msg)
 }
@@ -951,7 +947,7 @@ func (t *localServerSuite) TestReleaseAddressUnknownInstance(c *gc.C) {
 	// We should be able to release an address with an unknown instance id
 	// without it being allocated.
 	addr := network.Address{Value: "8.0.0.4"}
-	err := env.ReleaseAddress(instance.UnknownId, "", addr, "", "")
+	err := env.ReleaseAddress(instance.UnknownId, "", addr, "")
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -1111,8 +1107,7 @@ func (t *localServerSuite) TestSupportsAddressAllocationWithNoFeatureFlag(c *gc.
 func (t *localServerSuite) TestAllocateAddressWithNoFeatureFlag(c *gc.C) {
 	t.SetFeatureFlags() // clear the flags.
 	env := t.prepareEnviron(c)
-	addr := network.NewAddresses("1.2.3.4")[0]
-	err := env.AllocateAddress("i-foo", "net1", &addr, "foo", "bar")
+	err := env.AllocateAddress("i-foo", "net1", network.NewAddresses("1.2.3.4")[0], "foo", "bar")
 	c.Assert(err, gc.ErrorMatches, "address allocation not supported")
 	c.Assert(err, jc.Satisfies, errors.IsNotSupported)
 }
@@ -1120,7 +1115,7 @@ func (t *localServerSuite) TestAllocateAddressWithNoFeatureFlag(c *gc.C) {
 func (t *localServerSuite) TestReleaseAddressWithNoFeatureFlag(c *gc.C) {
 	t.SetFeatureFlags() // clear the flags.
 	env := t.prepareEnviron(c)
-	err := env.ReleaseAddress("i-foo", "net1", network.NewAddress("1.2.3.4"), "", "")
+	err := env.ReleaseAddress("i-foo", "net1", network.NewAddress("1.2.3.4"), "")
 	c.Assert(err, gc.ErrorMatches, "address allocation not supported")
 	c.Assert(err, jc.Satisfies, errors.IsNotSupported)
 }

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -56,8 +56,6 @@ var (
 	ReleaseNodes             = releaseNodes
 	ReserveIPAddress         = reserveIPAddress
 	ReserveIPAddressOnDevice = reserveIPAddressOnDevice
-	NewDeviceParams          = newDeviceParams
-	UpdateDeviceHostname     = updateDeviceHostname
 	ReleaseIPAddress         = releaseIPAddress
 	DeploymentStatusCall     = deploymentStatusCall
 )
@@ -75,58 +73,12 @@ func reserveIPAddress(ipaddresses gomaasapi.MAASObject, cidr string, addr networ
 	return err
 }
 
-func reserveIPAddressOnDevice(devices gomaasapi.MAASObject, deviceID, macAddress string, addr network.Address) (network.Address, error) {
-	device := devices.GetSubObject(deviceID)
+func reserveIPAddressOnDevice(devices gomaasapi.MAASObject, deviceId string, addr network.Address) error {
+	device := devices.GetSubObject(deviceId)
 	params := url.Values{}
-	if addr.Value != "" {
-		params.Add("requested_address", addr.Value)
-	}
-	if macAddress != "" {
-		params.Add("mac_address", macAddress)
-	}
-	resp, err := device.CallPost("claim_sticky_ip_address", params)
-	if err != nil {
-		return network.Address{}, errors.Annotatef(
-			err, "failed to reserve sticky IP address for device %q",
-			deviceID,
-		)
-	}
-	respMap, err := resp.GetMap()
-	if err != nil {
-		return network.Address{}, errors.Annotate(err, "failed to parse response")
-	}
-	addresses, err := respMap["ip_addresses"].GetArray()
-	if err != nil {
-		return network.Address{}, errors.Annotatef(err, "failed to parse IP addresses")
-	}
-	if len(addresses) == 0 {
-		return network.Address{}, errors.Errorf(
-			"expected to find a sticky IP address for device %q: MAAS API response contains no IP addresses",
-			deviceID,
-		)
-	}
-	var firstAddress network.Address
-	for _, address := range addresses {
-		value, err := address.GetString()
-		if err != nil {
-			return network.Address{}, errors.Annotatef(err,
-				"failed to parse reserved IP address for device %q",
-				deviceID,
-			)
-		}
-		if ip := net.ParseIP(value); ip == nil {
-			return network.Address{}, errors.Annotatef(err,
-				"failed to parse reserved IP address %q for device %q",
-				value, deviceID,
-			)
-		}
-		if firstAddress.Value == "" {
-			// We only need the first address, but we're logging all we got.
-			firstAddress = network.NewAddress(value)
-		}
-		logger.Debugf("reserved address %q for device %q and MAC %q", value, deviceID, macAddress)
-	}
-	return firstAddress, nil
+	params.Add("requested_address", addr.Value)
+	_, err := device.CallPost("claim_sticky_ip_address", params)
+	return err
 }
 
 func releaseIPAddress(ipaddresses gomaasapi.MAASObject, addr network.Address) error {
@@ -156,10 +108,6 @@ type maasEnviron struct {
 
 	availabilityZonesMutex sync.Mutex
 	availabilityZones      []common.AvailabilityZone
-
-	// The following are initialized from the discovered MAAS API capabilities.
-	supportsDevices   bool
-	supportsStaticIPs bool
 }
 
 var _ environs.Environ = (*maasEnviron)(nil)
@@ -172,28 +120,8 @@ func NewEnviron(cfg *config.Config) (*maasEnviron, error) {
 	}
 	env.name = cfg.Name()
 	env.storageUnlocked = NewStorage(env)
-
-	// Since we need to switch behavior based on the available API capabilities,
-	// get them as soon as possible and cache them.
-	capabilities, err := env.getCapabilities()
-	if err != nil {
-		logger.Warningf("cannot get MAAS API capabilities: %v", err)
-	}
-	logger.Tracef("MAAS API capabilities: %v", capabilities.SortedValues())
-	env.supportsDevices = capabilities.Contains(capDevices)
-	env.supportsStaticIPs = capabilities.Contains(capStaticIPAddresses)
 	return env, nil
 }
-
-var noDevicesWarning = `
-Using MAAS version older than 1.8.2: devices API support not detected!
-
-Juju cannot guarantee resources allocated to containers, like DHCP
-leases or static IP addresses will be properly cleaned up when the
-container, its host, or the environment is destroyed.
-
-Juju recommends upgrading MAAS to version 1.8.2 or later.
-`[1:]
 
 // Bootstrap is specified in the Environ interface.
 func (env *maasEnviron) Bootstrap(ctx environs.BootstrapContext, args environs.BootstrapParams) (arch, series string, _ environs.BootstrapFinalizer, _ error) {
@@ -207,11 +135,6 @@ func (env *maasEnviron) Bootstrap(ctx environs.BootstrapContext, args environs.B
 			instancecfg.DefaultBridgeName,
 		)
 		args.ContainerBridgeName = instancecfg.DefaultBridgeName
-
-		if !env.supportsDevices {
-			// Inform the user container resources might leak.
-			ctx.Infof("WARNING: %s", noDevicesWarning)
-		}
 	} else {
 		logger.Debugf(
 			"address allocation feature enabled; using static IPs for containers: %q",
@@ -323,14 +246,14 @@ func (env *maasEnviron) SupportsSpaces() (bool, error) {
 // SupportsAddressAllocation is specified on environs.Networking.
 func (env *maasEnviron) SupportsAddressAllocation(_ network.Id) (bool, error) {
 	if !environs.AddressAllocationEnabled() {
-		if !env.supportsDevices {
-			return false, errors.NotSupportedf("address allocation")
-		}
-		// We can use devices for DHCP-allocated container IPs.
-		return true, nil
+		return false, errors.NotSupportedf("address allocation")
 	}
 
-	return env.supportsStaticIPs, nil
+	caps, err := env.getCapabilities()
+	if err != nil {
+		return false, errors.Annotatef(err, "getCapabilities failed")
+	}
+	return caps.Contains(capStaticIPAddresses), nil
 }
 
 // allBootImages queries MAAS for all of the boot-images across
@@ -612,6 +535,14 @@ const (
 	capDevices            = "devices-management"
 )
 
+func (env *maasEnviron) supportsDevices() (bool, error) {
+	caps, err := env.getCapabilities()
+	if err != nil {
+		return false, errors.Trace(err)
+	}
+	return caps.Contains(capDevices), nil
+}
+
 // getCapabilities asks the MAAS server for its capabilities, if
 // supported by the server.
 func (env *maasEnviron) getCapabilities() (set.Strings, error) {
@@ -877,23 +808,17 @@ func (environ *maasEnviron) setupNetworks(inst instance.Instance, networksToDisa
 		}
 		logger.Debugf("network %q has MACs: %v", netw.Name, macs)
 
-		var defaultGateway network.Address
-		if netw.DefaultGateway != "" {
-			defaultGateway = network.NewAddress(netw.DefaultGateway)
-		}
-
 		for _, mac := range macs {
 			if ifinfo, ok := interfaces[mac]; ok {
 				tempInterfaceInfo = append(tempInterfaceInfo, network.InterfaceInfo{
-					MACAddress:     mac,
-					InterfaceName:  ifinfo.InterfaceName,
-					DeviceIndex:    ifinfo.DeviceIndex,
-					CIDR:           netCIDR.String(),
-					VLANTag:        netw.VLANTag,
-					ProviderId:     network.Id(netw.Name),
-					NetworkName:    netw.Name,
-					Disabled:       disabled || ifinfo.Disabled,
-					GatewayAddress: defaultGateway,
+					MACAddress:    mac,
+					InterfaceName: ifinfo.InterfaceName,
+					DeviceIndex:   ifinfo.DeviceIndex,
+					CIDR:          netCIDR.String(),
+					VLANTag:       netw.VLANTag,
+					ProviderId:    network.Id(netw.Name),
+					NetworkName:   netw.Name,
+					Disabled:      disabled || ifinfo.Disabled,
 				})
 			}
 		}
@@ -1397,62 +1322,16 @@ func (environ *maasEnviron) Instances(ids []instance.Id) ([]instance.Instance, e
 	return result, nil
 }
 
-// transformDeviceHostname transforms deviceHostname to include hostnameSuffix
-// after the first "." in deviceHostname. Returns errors if deviceHostname does
-// not contain any "." or hostnameSuffix is empty.
-func transformDeviceHostname(deviceID, deviceHostname, hostnameSuffix string) (string, error) {
-	if hostnameSuffix == "" {
-		return "", errors.New("hostname suffix cannot be empty")
-	}
-	parts := strings.SplitN(deviceHostname, ".", 2)
-	if len(parts) != 2 {
-		return "", errors.Errorf("unexpected device %q hostname %q", deviceID, deviceHostname)
-	}
-	return fmt.Sprintf("%s-%s.%s", parts[0], hostnameSuffix, parts[1]), nil
-}
-
-// updateDeviceHostname updates the hostname of a MAAS device to be unique and
-// to contain the given hostnameSuffix.
-func updateDeviceHostname(client *gomaasapi.MAASObject, deviceID, deviceHostname, hostnameSuffix string) (string, error) {
-
-	newHostname, err := transformDeviceHostname(deviceID, deviceHostname, hostnameSuffix)
-	if err != nil {
-		return "", errors.Trace(err)
-	}
-
-	deviceObj := client.GetSubObject("devices").GetSubObject(deviceID)
-	params := make(url.Values)
-	params.Add("hostname", newHostname)
-	if _, err := deviceObj.Update(params); err != nil {
-		return "", errors.Annotatef(err, "updating device %q hostname to %q", deviceID, newHostname)
-	}
-	return newHostname, nil
-}
-
-// newDeviceParams prepares the params to call "devices new" API. Declared
-// separately so it can be mocked out in the test to work around the gomaasapi's
-// testservice limitation.
-func newDeviceParams(macAddress string, instId instance.Id, _ string) url.Values {
-	params := make(url.Values)
-	params.Add("mac_addresses", macAddress)
-	// We create the device without a hostname, to allow MAAS to create a unique
-	// hostname first.
-	params.Add("parent", extractSystemId(instId))
-
-	return params
-}
-
-// newDevice creates a new MAAS device with parent instance instId, using the
-// given macAddress and hostnameSuffix, returning the ID of the new device.
-func (environ *maasEnviron) newDevice(macAddress string, instId instance.Id, hostnameSuffix string) (string, error) {
+// newDevice creates a new MAAS device for a MAC address, returning the Id of
+// the new device.
+func (environ *maasEnviron) newDevice(macAddress string, instId instance.Id, hostname string) (string, error) {
 	client := environ.getMAASClient()
 	devices := client.GetSubObject("devices")
-	// Work around the limitation of gomaasapi's testservice expecting all 3
-	// arguments (parent, mac_addresses, and hostname) to be filled in.
-	params := NewDeviceParams(macAddress, instId, hostnameSuffix)
-	logger.Tracef(
-		"creating a new MAAS device for MAC %q, parent %q", macAddress, instId,
-	)
+	params := url.Values{}
+	params.Add("mac_addresses", macAddress)
+	params.Add("hostname", hostname)
+	params.Add("parent", extractSystemId(instId))
+	logger.Tracef("creating a new MAAS device for MAC %q, hostname %q, parent %q", macAddress, hostname, string(instId))
 	result, err := devices.CallPost("new", params)
 	if err != nil {
 		return "", errors.Trace(err)
@@ -1463,62 +1342,38 @@ func (environ *maasEnviron) newDevice(macAddress string, instId instance.Id, hos
 		return "", errors.Trace(err)
 	}
 
-	deviceID, err := resultMap["system_id"].GetString()
+	device, err := resultMap["system_id"].GetString()
 	if err != nil {
 		return "", errors.Trace(err)
 	}
-	deviceHostname, err := resultMap["hostname"].GetString()
-	if err != nil {
-		return deviceID, errors.Trace(err)
-	}
-
-	logger.Tracef("created device %q with MAC %q and hostname %q", deviceID, macAddress, deviceHostname)
-
-	newHostname, err := UpdateDeviceHostname(client, deviceID, deviceHostname, hostnameSuffix)
-	if err != nil {
-		return deviceID, errors.Trace(err)
-	}
-	logger.Tracef("updated device %q hostname to %q", deviceID, newHostname)
-
-	return deviceID, nil
+	return device, nil
 }
 
-// fetchFullDevice fetches an existing device ID associated with the given
-// macAddress, or returns an error if there is no device.
+// fetchFullDevice fetches an existing device Id associated with a MAC address, or
+// returns an error if there is no device.
 func (environ *maasEnviron) fetchFullDevice(macAddress string) (map[string]gomaasapi.JSONObject, error) {
-	if macAddress == "" {
-		return nil, errors.Errorf("given MAC address is empty")
-	}
-
 	client := environ.getMAASClient()
 	devices := client.GetSubObject("devices")
 	params := url.Values{}
 	params.Add("mac_address", macAddress)
-
 	result, err := devices.CallGet("list", params)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-
 	resultArray, err := result.GetArray()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-
 	if len(resultArray) == 0 {
-		return nil, errors.NotFoundf("no device for MAC address %q", macAddress)
+		return nil, errors.NotFoundf("no device for MAC %q", macAddress)
 	}
-
 	if len(resultArray) != 1 {
 		return nil, errors.Errorf("unexpected response, expected 1 device got %d", len(resultArray))
 	}
-
 	resultMap, err := resultArray[0].GetMap()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-
-	logger.Tracef("device found as %+v", resultMap)
 	return resultMap, nil
 }
 
@@ -1528,11 +1383,11 @@ func (environ *maasEnviron) fetchDevice(macAddress string) (string, error) {
 		return "", errors.Trace(err)
 	}
 
-	deviceID, err := deviceMap["system_id"].GetString()
+	deviceId, err := deviceMap["system_id"].GetString()
 	if err != nil {
 		return "", errors.Trace(err)
 	}
-	return deviceID, nil
+	return deviceId, nil
 }
 
 // createOrFetchDevice returns a device Id associated with a MAC address. If
@@ -1545,70 +1400,37 @@ func (environ *maasEnviron) createOrFetchDevice(macAddress string, instId instan
 	if !errors.IsNotFound(err) {
 		return "", errors.Trace(err)
 	}
-	return environ.newDevice(macAddress, instId, hostname)
+	device, err = environ.newDevice(macAddress, instId, hostname)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	return device, nil
 }
 
 // AllocateAddress requests an address to be allocated for the
 // given instance on the given network.
-func (environ *maasEnviron) AllocateAddress(instId instance.Id, subnetId network.Id, addr *network.Address, macAddress, hostname string) (err error) {
-	logger.Tracef(
-		"AllocateAddress for instId %q, subnet %q, addr %q, MAC %q, hostname %q",
-		instId, subnetId, addr, macAddress, hostname,
-	)
-	if addr == nil {
-		return errors.NewNotValid(nil, "invalid address: cannot be nil")
-	}
-
+func (environ *maasEnviron) AllocateAddress(instId instance.Id, subnetId network.Id, addr network.Address, macAddress, hostname string) (err error) {
 	if !environs.AddressAllocationEnabled() {
-		if !environ.supportsDevices {
-			logger.Warningf(
-				"resources used by container %q with MAC address %q can leak: devices API not supported",
-				hostname, macAddress,
-			)
-			return errors.NotSupportedf("address allocation")
-		}
-		logger.Tracef("creating device for container %q with MAC %q", hostname, macAddress)
-		deviceID, err := environ.createOrFetchDevice(macAddress, instId, hostname)
-		if err != nil {
-			return errors.Annotatef(
-				err,
-				"failed creating MAAS device for container %q with MAC address %q",
-				hostname, macAddress,
-			)
-		}
-		logger.Infof(
-			"created device %q for container %q with MAC address %q on parent node %q",
-			deviceID, hostname, macAddress, instId,
-		)
-		devices := environ.getMAASClient().GetSubObject("devices")
-		newAddr, err := ReserveIPAddressOnDevice(devices, deviceID, macAddress, network.Address{})
-		if err != nil {
-			return errors.Trace(err)
-		}
-		logger.Infof(
-			"reserved sticky IP address %q for device %q with MAC address %q representing container %q",
-			newAddr, deviceID, macAddress, hostname,
-		)
-		*addr = newAddr
-		return nil
+		return errors.NotSupportedf("address allocation")
 	}
 	defer errors.DeferredAnnotatef(&err, "failed to allocate address %q for instance %q", addr, instId)
 
 	client := environ.getMAASClient()
 	var maasErr gomaasapi.ServerError
-	if environ.supportsDevices {
-		deviceID, err := environ.createOrFetchDevice(macAddress, instId, hostname)
+	supportsDevices, err := environ.supportsDevices()
+	if err != nil {
+		return err
+	}
+	if supportsDevices {
+		device, err := environ.createOrFetchDevice(macAddress, instId, hostname)
 		if err != nil {
 			return err
 		}
 
 		devices := client.GetSubObject("devices")
-		newAddr, err := ReserveIPAddressOnDevice(devices, deviceID, macAddress, *addr)
+		err = ReserveIPAddressOnDevice(devices, device, addr)
 		if err == nil {
-			logger.Infof(
-				"allocated address %q for instance %q on device %q (asked for address %q)",
-				addr, instId, deviceID, newAddr,
-			)
+			logger.Infof("allocated address %q for instance %q on device %q", addr, instId, device)
 			return nil
 		}
 
@@ -1622,7 +1444,7 @@ func (environ *maasEnviron) AllocateAddress(instId instance.Id, subnetId network
 		var subnets []network.SubnetInfo
 
 		subnets, err = environ.Subnets(instId, []network.Id{subnetId})
-		logger.Tracef("Subnets(%q, %q, %q) returned: %v (%v)", instId, subnetId, *addr, subnets, err)
+		logger.Tracef("Subnets(%q, %q, %q) returned: %v (%v)", instId, subnetId, addr, subnets, err)
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -1634,9 +1456,9 @@ func (environ *maasEnviron) AllocateAddress(instId instance.Id, subnetId network
 
 		cidr := foundSub.CIDR
 		ipaddresses := client.GetSubObject("ipaddresses")
-		err = ReserveIPAddress(ipaddresses, cidr, *addr)
+		err = ReserveIPAddress(ipaddresses, cidr, addr)
 		if err == nil {
-			logger.Infof("allocated address %q for instance %q on subnet %q", *addr, instId, cidr)
+			logger.Infof("allocated address %q for instance %q on subnet %q", addr, instId, cidr)
 			return nil
 		}
 
@@ -1666,46 +1488,22 @@ func (environ *maasEnviron) AllocateAddress(instId instance.Id, subnetId network
 
 // ReleaseAddress releases a specific address previously allocated with
 // AllocateAddress.
-func (environ *maasEnviron) ReleaseAddress(instId instance.Id, _ network.Id, addr network.Address, macAddress, hostname string) (err error) {
+func (environ *maasEnviron) ReleaseAddress(instId instance.Id, _ network.Id, addr network.Address, macAddress string) (err error) {
 	if !environs.AddressAllocationEnabled() {
-		if !environ.supportsDevices {
-			logger.Warningf(
-				"resources used by container %q with MAC address %q can leak: devices API not supported",
-				hostname, macAddress,
-			)
-			return errors.NotSupportedf("address allocation")
-		}
-		logger.Tracef("getting device ID for container %q with MAC %q", macAddress, hostname)
-		deviceID, err := environ.fetchDevice(macAddress)
-		if err != nil {
-			return errors.Annotatef(
-				err,
-				"getting MAAS device for container %q with MAC address %q",
-				hostname, macAddress,
-			)
-		}
-		logger.Tracef("deleting device %q for container %q", deviceID, hostname)
-		apiDevice := environ.getMAASClient().GetSubObject("devices").GetSubObject(deviceID)
-		if err := apiDevice.Delete(); err != nil {
-			return errors.Annotatef(
-				err,
-				"deleting MAAS device %q for container %q with MAC address %q",
-				deviceID, instId, macAddress,
-			)
-		}
-		logger.Debugf("deleted device %q for container %q with MAC address %q", deviceID, instId, macAddress)
-		return nil
+		return errors.NotSupportedf("address allocation")
 	}
 
 	defer errors.DeferredAnnotatef(&err, "failed to release IP address %q from instance %q", addr, instId)
 
-	logger.Infof(
-		"releasing address: %q, MAC address: %q, hostname: %q, supports devices: %v",
-		addr, macAddress, hostname, environ.supportsDevices,
-	)
+	supportsDevices, err := environ.supportsDevices()
+	if err != nil {
+		return err
+	}
+
+	logger.Infof("releasing address: %q, MAC address: %q, supports devices: %v", addr, macAddress, supportsDevices)
 	// Addresses originally allocated without a device will have macAddress
 	// set to "". We shouldn't look for a device for these addresses.
-	if environ.supportsDevices && macAddress != "" {
+	if supportsDevices && macAddress != "" {
 		device, err := environ.fetchFullDevice(macAddress)
 		if err == nil {
 			addresses, err := device["ip_addresses"].GetArray()
@@ -1773,18 +1571,14 @@ func (environ *maasEnviron) NetworkInterfaces(instId instance.Id) ([]network.Int
 		return nil, errors.Annotatef(err, "failed to get instance %q subnets", instId)
 	}
 
-	macToNetworksMap := make(map[string][]networkDetails)
+	macToNetworkMap := make(map[string]networkDetails)
 	for _, network := range networks {
 		macs, err := environ.listConnectedMacs(network)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
 		for _, mac := range macs {
-			if networks, found := macToNetworksMap[mac]; found {
-				macToNetworksMap[mac] = append(networks, network)
-			} else {
-				macToNetworksMap[mac] = append([]networkDetails(nil), network)
-			}
+			macToNetworkMap[mac] = network
 		}
 	}
 
@@ -1802,26 +1596,18 @@ func (environ *maasEnviron) NetworkInterfaces(instId instance.Id) ([]network.Int
 			MACAddress:    serial,
 			ConfigType:    network.ConfigDHCP,
 		}
-		allDetails, ok := macToNetworksMap[serial]
-		if !ok {
-			logger.Debugf("no subnet information for MAC address %q, instance %q", serial, instId)
-			continue
-		}
-		for _, details := range allDetails {
+		details, ok := macToNetworkMap[serial]
+		if ok {
 			ifaceInfo.VLANTag = details.VLANTag
 			ifaceInfo.ProviderSubnetId = network.Id(details.Name)
 			mask := net.IPMask(net.ParseIP(details.Mask))
-			cidr := net.IPNet{
-				IP:   net.ParseIP(details.IP),
-				Mask: mask,
-			}
+			cidr := net.IPNet{net.ParseIP(details.IP), mask}
 			ifaceInfo.CIDR = cidr.String()
 			ifaceInfo.Address = network.NewAddress(cidr.IP.String())
-			if details.DefaultGateway != "" {
-				ifaceInfo.GatewayAddress = network.NewAddress(details.DefaultGateway)
-			}
-			result = append(result, ifaceInfo)
+		} else {
+			logger.Debugf("no subnet information for MAC address %q, instance %q", serial, instId)
 		}
+		result = append(result, ifaceInfo)
 	}
 	return result, nil
 }
@@ -1973,11 +1759,6 @@ func (environ *maasEnviron) Destroy() error {
 			"If the environment is still running, please manually decomission the MAAS machines.")
 		return errors.New("unsafe destruction")
 	}
-	if !environ.supportsDevices {
-		// Warn the user that container resources can leak.
-		logger.Warningf(noDevicesWarning)
-	}
-
 	if err := common.Destroy(environ); err != nil {
 		return errors.Trace(err)
 	}
@@ -2006,12 +1787,11 @@ func (*maasEnviron) Provider() environs.EnvironProvider {
 
 // networkDetails holds information about a MAAS network.
 type networkDetails struct {
-	Name           string
-	IP             string
-	Mask           string
-	VLANTag        int
-	Description    string
-	DefaultGateway string
+	Name        string
+	IP          string
+	Mask        string
+	VLANTag     int
+	Description string
 }
 
 // getInstanceNetworks returns a list of all MAAS networks for a given node.
@@ -2037,57 +1817,41 @@ func (environ *maasEnviron) getInstanceNetworks(inst instance.Instance) ([]netwo
 	for i, jsonNet := range jsonNets {
 		fields, err := jsonNet.GetMap()
 		if err != nil {
-			return nil, errors.Annotate(err, "parsing network details")
+			return nil, err
 		}
-
 		name, err := fields["name"].GetString()
 		if err != nil {
-			return nil, errors.Annotate(err, "cannot get name")
+			return nil, fmt.Errorf("cannot get name: %v", err)
 		}
-
 		ip, err := fields["ip"].GetString()
 		if err != nil {
-			return nil, errors.Annotate(err, "cannot get ip")
+			return nil, fmt.Errorf("cannot get ip: %v", err)
 		}
-
-		defaultGateway := ""
-		defaultGatewayField, ok := fields["default_gateway"]
-		if ok && !defaultGatewayField.IsNil() {
-			// default_gateway is optional, so ignore it when unset or null.
-			defaultGateway, err = defaultGatewayField.GetString()
-			if err != nil {
-				return nil, errors.Annotate(err, "cannot get default_gateway")
-			}
-		}
-
 		netmask, err := fields["netmask"].GetString()
 		if err != nil {
-			return nil, errors.Annotate(err, "cannot get netmask")
+			return nil, fmt.Errorf("cannot get netmask: %v", err)
 		}
-
 		vlanTag := 0
 		vlanTagField, ok := fields["vlan_tag"]
 		if ok && !vlanTagField.IsNil() {
 			// vlan_tag is optional, so assume it's 0 when missing or nil.
 			vlanTagFloat, err := vlanTagField.GetFloat64()
 			if err != nil {
-				return nil, errors.Annotate(err, "cannot get vlan_tag")
+				return nil, fmt.Errorf("cannot get vlan_tag: %v", err)
 			}
 			vlanTag = int(vlanTagFloat)
 		}
-
 		description, err := fields["description"].GetString()
 		if err != nil {
-			return nil, errors.Annotate(err, "cannot get description")
+			return nil, fmt.Errorf("cannot get description: %v", err)
 		}
 
 		networks[i] = networkDetails{
-			Name:           name,
-			IP:             ip,
-			Mask:           netmask,
-			DefaultGateway: defaultGateway,
-			VLANTag:        vlanTag,
-			Description:    description,
+			Name:        name,
+			IP:          ip,
+			Mask:        netmask,
+			VLANTag:     vlanTag,
+			Description: description,
 		}
 	}
 	return networks, nil
@@ -2201,14 +1965,15 @@ func extractInterfaces(inst instance.Instance, lshwXML []byte) (map[string]iface
 					primaryIface = node.LogicalName
 					logger.Debugf("node %q primary network interface is %q", inst.Id(), primaryIface)
 				}
-				if node.Disabled {
-					logger.Debugf("node %q skipping disabled network interface %q", inst.Id(), node.LogicalName)
-				}
 				interfaces[node.Serial] = ifaceInfo{
 					DeviceIndex:   index,
 					InterfaceName: node.LogicalName,
 					Disabled:      node.Disabled,
 				}
+				if node.Disabled {
+					logger.Debugf("node %q skipping disabled network interface %q", inst.Id(), node.LogicalName)
+				}
+
 			}
 			if err := processNodes(node.Children); err != nil {
 				return err

--- a/provider/maas/maas_test.go
+++ b/provider/maas/maas_test.go
@@ -9,6 +9,7 @@ import (
 	gc "gopkg.in/check.v1"
 	"launchpad.net/gomaasapi"
 
+	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	envtesting "github.com/juju/juju/environs/testing"
 	"github.com/juju/juju/feature"
@@ -16,6 +17,9 @@ import (
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/version"
 )
+
+// Ensure maasEnviron supports environs.NetworkingEnviron.
+var _ environs.NetworkingEnviron = (*maasEnviron)(nil)
 
 type providerSuite struct {
 	coretesting.FakeJujuHomeSuite

--- a/provider/vsphere/environ_network.go
+++ b/provider/vsphere/environ_network.go
@@ -13,12 +13,12 @@ import (
 )
 
 // AllocateAddress implements environs.Environ.
-func (env *environ) AllocateAddress(instID instance.Id, subnetID network.Id, addr *network.Address, _, _ string) error {
-	return env.changeAddress(instID, subnetID, *addr, true)
+func (env *environ) AllocateAddress(instID instance.Id, subnetID network.Id, addr network.Address, _, _ string) error {
+	return env.changeAddress(instID, subnetID, addr, true)
 }
 
 // ReleaseAddress implements environs.Environ.
-func (env *environ) ReleaseAddress(instID instance.Id, netID network.Id, addr network.Address, _, _ string) error {
+func (env *environ) ReleaseAddress(instID instance.Id, netID network.Id, addr network.Address, _ string) error {
 	return env.changeAddress(instID, netID, addr, false)
 }
 

--- a/worker/provisioner/kvm-broker.go
+++ b/worker/provisioner/kvm-broker.go
@@ -25,14 +25,12 @@ func NewKvmBroker(
 	managerConfig container.ManagerConfig,
 	enableNAT bool,
 ) (environs.InstanceBroker, error) {
-	namespace := maybeGetManagerConfigNamespaces(managerConfig)
 	manager, err := kvm.NewContainerManager(managerConfig)
 	if err != nil {
 		return nil, err
 	}
 	return &kvmBroker{
 		manager:     manager,
-		namespace:   namespace,
 		api:         api,
 		agentConfig: agentConfig,
 		enableNAT:   enableNAT,
@@ -41,7 +39,6 @@ func NewKvmBroker(
 
 type kvmBroker struct {
 	manager     container.Manager
-	namespace   string
 	api         APICalls
 	agentConfig agent.Config
 	enableNAT   bool
@@ -63,22 +60,29 @@ func (broker *kvmBroker) StartInstance(args environs.StartInstanceParams) (*envi
 	if bridgeDevice == "" {
 		bridgeDevice = kvm.DefaultKvmBridge
 	}
-
-	preparedInfo, err := prepareOrGetContainerInterfaceInfo(
-		broker.api,
-		machineId,
-		bridgeDevice,
-		true, // allocate if possible, do not maintain existing.
-		broker.enableNAT,
-		args.NetworkInfo,
-		kvmLogger,
-	)
-	if err != nil {
-		// It's not fatal (yet) if we couldn't pre-allocate addresses for the
-		// container.
-		logger.Warningf("failed to prepare container %q network config: %v", machineId, err)
+	if !environs.AddressAllocationEnabled() {
+		logger.Debugf(
+			"address allocation feature flag not enabled; using DHCP for container %q",
+			machineId,
+		)
 	} else {
-		args.NetworkInfo = preparedInfo
+		logger.Debugf("trying to allocate static IP for container %q", machineId)
+
+		allocatedInfo, err := configureContainerNetwork(
+			machineId,
+			bridgeDevice,
+			broker.api,
+			args.NetworkInfo,
+			true, // allocate a new address.
+			broker.enableNAT,
+		)
+		if err != nil {
+			// It's fine, just ignore it. The effect will be that the
+			// container won't have a static address configured.
+			logger.Infof("not allocating static IP for container %q: %v", machineId, err)
+		} else {
+			args.NetworkInfo = allocatedInfo
+		}
 	}
 
 	// Unlike with LXC, we don't override the default MTU to use.
@@ -126,33 +130,6 @@ func (broker *kvmBroker) StartInstance(args environs.StartInstanceParams) (*envi
 	}, nil
 }
 
-// MaintainInstance ensures the container's host has the required iptables and
-// routing rules to make the container visible to both the host and other
-// machines on the same subnet. This is important mostly when address allocation
-// feature flag is enabled, as otherwise we don't create additional iptables
-// rules or routes.
-func (broker *kvmBroker) MaintainInstance(args environs.StartInstanceParams) error {
-	machineID := args.InstanceConfig.MachineId
-
-	// Default to using the host network until we can configure.
-	bridgeDevice := broker.agentConfig.Value(agent.LxcBridge)
-	if bridgeDevice == "" {
-		bridgeDevice = kvm.DefaultKvmBridge
-	}
-
-	// There's no InterfaceInfo we expect to get below.
-	_, err := prepareOrGetContainerInterfaceInfo(
-		broker.api,
-		machineID,
-		bridgeDevice,
-		false, // maintain, do not allocate.
-		broker.enableNAT,
-		args.NetworkInfo,
-		kvmLogger,
-	)
-	return err
-}
-
 // StopInstances shuts down the given instances.
 func (broker *kvmBroker) StopInstances(ids ...instance.Id) error {
 	// TODO: potentially parallelise.
@@ -162,7 +139,6 @@ func (broker *kvmBroker) StopInstances(ids ...instance.Id) error {
 			kvmLogger.Errorf("container did not stop: %v", err)
 			return err
 		}
-		maybeReleaseContainerAddresses(broker.api, id, broker.namespace, kvmLogger)
 	}
 	return nil
 }
@@ -170,4 +146,32 @@ func (broker *kvmBroker) StopInstances(ids ...instance.Id) error {
 // AllInstances only returns running containers.
 func (broker *kvmBroker) AllInstances() (result []instance.Instance, err error) {
 	return broker.manager.ListContainers()
+}
+
+// MaintainInstance checks that the container's host has the required iptables and routing
+// rules to make the container visible to both the host and other machines on the same subnet.
+func (broker *kvmBroker) MaintainInstance(args environs.StartInstanceParams) error {
+	machineId := args.InstanceConfig.MachineId
+	if !environs.AddressAllocationEnabled() {
+		kvmLogger.Debugf("address allocation disabled: Not running maintenance for kvm with machineId: %s",
+			machineId)
+		return nil
+	}
+
+	kvmLogger.Debugf("running maintenance for kvm with machineId: %s", machineId)
+
+	// Default to using the host network until we can configure.
+	bridgeDevice := broker.agentConfig.Value(agent.LxcBridge)
+	if bridgeDevice == "" {
+		bridgeDevice = kvm.DefaultKvmBridge
+	}
+	_, err := configureContainerNetwork(
+		machineId,
+		bridgeDevice,
+		broker.api,
+		args.NetworkInfo,
+		false, // don't allocate a new address.
+		broker.enableNAT,
+	)
+	return err
 }

--- a/worker/provisioner/kvm-broker_test.go
+++ b/worker/provisioner/kvm-broker_test.go
@@ -162,9 +162,6 @@ func (s *kvmBrokerSuite) TestStartInstanceAddressAllocationDisabled(c *gc.C) {
 	machineId := "1/kvm/0"
 	kvm := s.startInstance(c, machineId)
 	s.api.CheckCalls(c, []gitjujutesting.StubCall{{
-		FuncName: "PrepareContainerInterfaceInfo",
-		Args:     []interface{}{names.NewMachineTag("1-kvm-0")},
-	}, {
 		FuncName: "ContainerConfig",
 	}})
 	c.Assert(kvm.Id(), gc.Equals, instance.Id("juju-machine-1-kvm-0"))

--- a/worker/provisioner/lxc-broker.go
+++ b/worker/provisioner/lxc-broker.go
@@ -16,7 +16,6 @@ import (
 	"github.com/juju/loggo"
 	"github.com/juju/names"
 	"github.com/juju/utils/exec"
-	"github.com/juju/utils/set"
 
 	"github.com/juju/juju/agent"
 	apiprovisioner "github.com/juju/juju/api/provisioner"
@@ -41,7 +40,6 @@ type APICalls interface {
 	ContainerConfig() (params.ContainerConfig, error)
 	PrepareContainerInterfaceInfo(names.MachineTag) ([]network.InterfaceInfo, error)
 	GetContainerInterfaceInfo(names.MachineTag) ([]network.InterfaceInfo, error)
-	ReleaseContainerAddresses(names.MachineTag) error
 }
 
 var _ APICalls = (*apiprovisioner.State)(nil)
@@ -57,7 +55,6 @@ func newLxcBroker(
 	enableNAT bool,
 	defaultMTU int,
 ) (environs.InstanceBroker, error) {
-	namespace := maybeGetManagerConfigNamespaces(managerConfig)
 	manager, err := lxc.NewContainerManager(
 		managerConfig, imageURLGetter, looputil.NewLoopDeviceManager(),
 	)
@@ -66,7 +63,6 @@ func newLxcBroker(
 	}
 	return &lxcBroker{
 		manager:     manager,
-		namespace:   namespace,
 		api:         api,
 		agentConfig: agentConfig,
 		enableNAT:   enableNAT,
@@ -76,7 +72,6 @@ func newLxcBroker(
 
 type lxcBroker struct {
 	manager     container.Manager
-	namespace   string
 	api         APICalls
 	agentConfig agent.Config
 	enableNAT   bool
@@ -98,22 +93,28 @@ func (broker *lxcBroker) StartInstance(args environs.StartInstanceParams) (*envi
 		bridgeDevice = lxc.DefaultLxcBridge
 	}
 
-	preparedInfo, err := prepareOrGetContainerInterfaceInfo(
-		broker.api,
-		machineId,
-		bridgeDevice,
-		true, // allocate if possible, do not maintain existing.
-		broker.enableNAT,
-		args.NetworkInfo,
-		lxcLogger,
-	)
-	if err != nil {
-		// It's not fatal (yet) if we couldn't pre-allocate addresses for the
-		// container.
-		logger.Warningf("failed to prepare container %q network config: %v", machineId, err)
+	if !environs.AddressAllocationEnabled() {
+		logger.Debugf(
+			"address allocation feature flag not enabled; using DHCP for container %q",
+			machineId,
+		)
 	} else {
-		args.NetworkInfo = preparedInfo
-
+		logger.Debugf("trying to allocate static IP for container %q", machineId)
+		allocatedInfo, err := configureContainerNetwork(
+			machineId,
+			bridgeDevice,
+			broker.api,
+			args.NetworkInfo,
+			true, // allocate a new address.
+			broker.enableNAT,
+		)
+		if err != nil {
+			// It's fine, just ignore it. The effect will be that the
+			// container won't have a static address configured.
+			logger.Infof("not allocating static IP for container %q: %v", machineId, err)
+		} else {
+			args.NetworkInfo = allocatedInfo
+		}
 	}
 	network := container.BridgeNetworkConfig(bridgeDevice, broker.defaultMTU, args.NetworkInfo)
 
@@ -175,33 +176,6 @@ func (broker *lxcBroker) StartInstance(args environs.StartInstanceParams) (*envi
 	}, nil
 }
 
-// MaintainInstance ensures the container's host has the required iptables and
-// routing rules to make the container visible to both the host and other
-// machines on the same subnet. This is important mostly when address allocation
-// feature flag is enabled, as otherwise we don't create additional iptables
-// rules or routes.
-func (broker *lxcBroker) MaintainInstance(args environs.StartInstanceParams) error {
-	machineID := args.InstanceConfig.MachineId
-
-	// Default to using the host network until we can configure.
-	bridgeDevice := broker.agentConfig.Value(agent.LxcBridge)
-	if bridgeDevice == "" {
-		bridgeDevice = lxc.DefaultLxcBridge
-	}
-
-	// There's no InterfaceInfo we expect to get below.
-	_, err := prepareOrGetContainerInterfaceInfo(
-		broker.api,
-		machineID,
-		bridgeDevice,
-		false, // maintain, do not allocate.
-		broker.enableNAT,
-		args.NetworkInfo,
-		lxcLogger,
-	)
-	return err
-}
-
 // StopInstances shuts down the given instances.
 func (broker *lxcBroker) StopInstances(ids ...instance.Id) error {
 	// TODO: potentially parallelise.
@@ -211,7 +185,6 @@ func (broker *lxcBroker) StopInstances(ids ...instance.Id) error {
 			lxcLogger.Errorf("container did not stop: %v", err)
 			return err
 		}
-		maybeReleaseContainerAddresses(broker.api, id, broker.namespace, lxcLogger)
 	}
 	return nil
 }
@@ -623,113 +596,30 @@ func configureContainerNetwork(
 	return finalIfaceInfo, nil
 }
 
-func maybeGetManagerConfigNamespaces(managerConfig container.ManagerConfig) string {
-	if len(managerConfig) == 0 {
-		return ""
-	}
-	if namespace, ok := managerConfig[container.ConfigName]; ok {
-		return namespace
-	}
-	return ""
-}
-
-func prepareOrGetContainerInterfaceInfo(
-	api APICalls,
-	machineID string,
-	bridgeDevice string,
-	allocateOrMaintain bool,
-	enableNAT bool,
-	startingNetworkInfo []network.InterfaceInfo,
-	log loggo.Logger,
-) ([]network.InterfaceInfo, error) {
-	maintain := !allocateOrMaintain
-
-	if environs.AddressAllocationEnabled() {
-		if maintain {
-			log.Debugf("running maintenance for container %q", machineID)
-		} else {
-			log.Debugf("trying to allocate static IP for container %q", machineID)
-		}
-
-		allocatedInfo, err := configureContainerNetwork(
-			machineID,
-			bridgeDevice,
-			api,
-			startingNetworkInfo,
-			allocateOrMaintain,
-			enableNAT,
-		)
-		if err != nil && !maintain {
-			log.Infof("not allocating static IP for container %q: %v", machineID, err)
-		}
-		return allocatedInfo, err
+// MaintainInstance checks that the container's host has the required iptables and routing
+// rules to make the container visible to both the host and other machines on the same subnet.
+func (broker *lxcBroker) MaintainInstance(args environs.StartInstanceParams) error {
+	machineId := args.InstanceConfig.MachineId
+	if !environs.AddressAllocationEnabled() {
+		lxcLogger.Debugf("address allocation disabled: Not running maintenance for lxc container with machineId: %s",
+			machineId)
+		return nil
 	}
 
-	if maintain {
-		log.Debugf("address allocation disabled: Not running maintenance for machine %q", machineID)
-		return nil, nil
-	}
+	lxcLogger.Debugf("running maintenance for lxc container with machineId: %s", machineId)
 
-	log.Debugf("address allocation feature flag not enabled; using DHCP for container %q", machineID)
-
-	// In case we're running on MAAS 1.8+ with devices support, we'll still
-	// call PrepareContainerInterfaceInfo(), but we'll ignore a NotSupported
-	// error if we get it (which means we're not using MAAS 1.8+).
-	containerTag := names.NewMachineTag(machineID)
-	preparedInfo, err := api.PrepareContainerInterfaceInfo(containerTag)
-	if err != nil && errors.IsNotSupported(err) {
-		log.Warningf("new container %q not registered as device: not running on MAAS 1.8+", machineID)
-		return nil, nil
-	} else if err != nil {
-		return nil, errors.Trace(err)
+	// Default to using the host network until we can configure.
+	bridgeDevice := broker.agentConfig.Value(agent.LxcBridge)
+	if bridgeDevice == "" {
+		bridgeDevice = lxc.DefaultLxcBridge
 	}
-
-	log.Tracef("PrepareContainerInterfaceInfo returned %#v", preparedInfo)
-	// Most likely there will be only one item in the list, but check
-	// all of them for forward compatibility.
-	macAddresses := set.NewStrings()
-	for _, prepInfo := range preparedInfo {
-		macAddresses.Add(prepInfo.MACAddress)
-	}
-	log.Infof(
-		"new container %q registered as a MAAS device with MAC address(es) %v",
-		machineID, macAddresses.SortedValues(),
+	_, err := configureContainerNetwork(
+		machineId,
+		bridgeDevice,
+		broker.api,
+		args.NetworkInfo,
+		false, // don't allocate a new address.
+		broker.enableNAT,
 	)
-	return preparedInfo, nil
-}
-
-func maybeReleaseContainerAddresses(
-	api APICalls,
-	instanceID instance.Id,
-	namespace string,
-	log loggo.Logger,
-) {
-	if environs.AddressAllocationEnabled() {
-		// The addresser worker will take care of the addresses.
-		return
-	}
-	// If we're not using addressable containers, we might still have used MAAS
-	// 1.8+ device to register the container when provisioning. In that case we
-	// need to attempt releasing the device, but ignore a NotSupported error
-	// (when we're not using MAAS 1.8+).
-	namespacePrefix := fmt.Sprintf("%s-", namespace)
-	tagString := strings.TrimPrefix(string(instanceID), namespacePrefix)
-	containerTag, err := names.ParseMachineTag(tagString)
-	if err != nil {
-		// Not a reason to cause StopInstances to fail though..
-		log.Warningf("unexpected container tag %q: %v", instanceID, err)
-		return
-	}
-	err = api.ReleaseContainerAddresses(containerTag)
-	switch {
-	case err == nil:
-		log.Infof("released all addresses for container %q", containerTag.Id())
-	case errors.IsNotSupported(err):
-		log.Warningf("not releasing all addresses for container %q: %v", containerTag.Id(), err)
-	default:
-		log.Warningf(
-			"unexpected error trying to release container %q addreses: %v",
-			containerTag.Id(), err,
-		)
-	}
+	return err
 }

--- a/worker/provisioner/lxc-broker_test.go
+++ b/worker/provisioner/lxc-broker_test.go
@@ -190,9 +190,6 @@ func (s *lxcBrokerSuite) TestStartInstanceAddressAllocationDisabled(c *gc.C) {
 	machineId := "1/lxc/0"
 	lxc := s.startInstance(c, machineId, nil)
 	s.api.CheckCalls(c, []gitjujutesting.StubCall{{
-		FuncName: "PrepareContainerInterfaceInfo",
-		Args:     []interface{}{names.NewMachineTag("1-lxc-0")},
-	}, {
 		FuncName: "ContainerConfig",
 	}})
 	c.Assert(lxc.Id(), gc.Equals, instance.Id("juju-machine-1-lxc-0"))
@@ -314,9 +311,6 @@ func (s *lxcBrokerSuite) TestStartInstanceWithBridgeEnviron(c *gc.C) {
 	machineId := "1/lxc/0"
 	lxc := s.startInstance(c, machineId, nil)
 	s.api.CheckCalls(c, []gitjujutesting.StubCall{{
-		FuncName: "PrepareContainerInterfaceInfo",
-		Args:     []interface{}{names.NewMachineTag("1-lxc-0")},
-	}, {
 		FuncName: "ContainerConfig",
 	}})
 	c.Assert(lxc.Id(), gc.Equals, instance.Id("juju-machine-1-lxc-0"))
@@ -1166,12 +1160,4 @@ func (f *fakeAPI) GetContainerInterfaceInfo(tag names.MachineTag) ([]network.Int
 		return nil, err
 	}
 	return []network.InterfaceInfo{f.fakeInterfaceInfo}, nil
-}
-
-func (f *fakeAPI) ReleaseContainerAddresses(tag names.MachineTag) error {
-	f.MethodCall(f, "ReleaseContainerAddresses", tag)
-	if err := f.NextErr(); err != nil {
-		return err
-	}
-	return nil
 }

--- a/worker/provisioner/provisioner_task.go
+++ b/worker/provisioner/provisioner_task.go
@@ -667,21 +667,6 @@ func (task *provisionerTask) prepareNetworkAndInterfaces(networkInfo []network.I
 	}
 	visitedNetworks := set.NewStrings()
 	for _, info := range networkInfo {
-		// TODO(dimitern): The following few fields are required, but no longer
-		// matter and will be dropped or changed soon as part of making spaces
-		// and subnets usable across the board.
-		if info.NetworkName == "" {
-			info.NetworkName = network.DefaultPrivate
-		}
-		if info.ProviderId == "" {
-			info.ProviderId = network.DefaultPrivate
-		}
-		if info.CIDR == "" {
-			// TODO(dimitern): This is only when NOT using addressable
-			// containers, as we don't fetch the subnet details, but since
-			// networks in state are going away real soon, it's not important.
-			info.CIDR = "0.0.0.0/32"
-		}
 		if !names.IsValidNetwork(info.NetworkName) {
 			return nil, nil, errors.Errorf("invalid network name %q", info.NetworkName)
 		}


### PR DESCRIPTION
Using devices by default for containers as a behavior is being backed
out as it turns out MAAS 1.8 (latest stable in trusty) doesn't do a full
cleanup of the devices IPs, so in fact using devices makes things worse.
It was decided to back out the original #3730 and the follow-ups to it
like #3966 and #3866 (they fix issues introduced by the first PR, e.g.
http://pad.lv/1520199 and http://pad.lv/1525280).

Tested on 1.7, 1.8, and 1.9 to confirm devices are not created unless
the address-allocation feature flag is on (and then on 1.8+ only, as
1.7 doesn't support devices).

(Review request: http://reviews.vapour.ws/r/3472/)