### PR TITLE
Tests for discoverspaces apiserver

### DIFF
--- a/api/discoverspaces/discoverspaces.go
+++ b/api/discoverspaces/discoverspaces.go
@@ -8,7 +8,6 @@ import (
 	"github.com/juju/loggo"
 
 	"github.com/juju/juju/api/base"
-	"github.com/juju/juju/api/common"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/environs/config"
 )
@@ -19,10 +18,6 @@ const discoverspacesFacade = "DiscoverSpaces"
 
 // API provides access to the DiscoverSpaces API facade.
 type API struct {
-	// TODO(mfoord): we should drop EnvironWatcher and consider moving
-	// access to the provider methods needed (SupportsSpaceDiscovery and
-	// ListSubnets) onto the apiserver.
-	*common.EnvironWatcher
 	facade base.FacadeCaller
 }
 
@@ -33,8 +28,7 @@ func NewAPI(caller base.APICaller) *API {
 	}
 	facadeCaller := base.NewFacadeCaller(caller, discoverspacesFacade)
 	return &API{
-		EnvironWatcher: common.NewEnvironWatcher(facadeCaller),
-		facade:         facadeCaller,
+		facade: facadeCaller,
 	}
 }
 

--- a/api/discoverspaces/discoverspaces.go
+++ b/api/discoverspaces/discoverspaces.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/api/common"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/environs/config"
 )
 
 var logger = loggo.GetLogger("juju.api.discoverspaces")
@@ -69,4 +70,18 @@ func (api *API) ListSubnets(args params.SubnetsFilters) (params.ListSubnetsResul
 		return result, errors.Trace(err)
 	}
 	return result, nil
+}
+
+// EnvironConfig returns the current environment configuration.
+func (api *API) EnvironConfig() (*config.Config, error) {
+	var result params.EnvironConfigResult
+	err := api.facade.FacadeCall("EnvironConfig", nil, &result)
+	if err != nil {
+		return nil, err
+	}
+	conf, err := config.New(config.NoDefaults, result.Config)
+	if err != nil {
+		return nil, err
+	}
+	return conf, nil
 }

--- a/api/discoverspaces/discoverspaces_test.go
+++ b/api/discoverspaces/discoverspaces_test.go
@@ -13,6 +13,7 @@ import (
 	apitesting "github.com/juju/juju/api/base/testing"
 	"github.com/juju/juju/api/discoverspaces"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/environs/config"
 	coretesting "github.com/juju/juju/testing"
 )
 
@@ -108,5 +109,21 @@ func (s *DiscoverSpacesSuite) TestCreateSpaces(c *gc.C) {
 	result, err := api.CreateSpaces(expectedArgs)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, expectedResult)
+	c.Assert(called, gc.Equals, 1)
+}
+
+func (s *DiscoverSpacesSuite) TestEnvironConfig(c *gc.C) {
+	var called int
+	cfg, err := config.New(config.UseDefaults, coretesting.FakeConfig())
+	c.Assert(err, jc.ErrorIsNil)
+	expectedResult := params.EnvironConfigResult{
+		Config: cfg.AllAttrs(),
+	}
+	apiCaller := successAPICaller(c, "EnvironConfig", nil, expectedResult, &called)
+	api := discoverspaces.NewAPI(apiCaller)
+
+	result, err := api.EnvironConfig()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, jc.DeepEquals, cfg)
 	c.Assert(called, gc.Equals, 1)
 }

--- a/apiserver/discoverspaces/discoverspaces.go
+++ b/apiserver/discoverspaces/discoverspaces.go
@@ -17,25 +17,24 @@ func init() {
 
 // DiscoverSpacesAPI implements the API used by the discoverspaces worker.
 type DiscoverSpacesAPI struct {
-	*common.EnvironWatcher
-
-	st             networkingcommon.NetworkBacking
-	resources      *common.Resources
-	authorizer     common.Authorizer
-	StateAddresser *common.StateAddresser
+	st         networkingcommon.NetworkBacking
+	resources  *common.Resources
+	authorizer common.Authorizer
 }
 
 // NewDiscoverSpacesAPI creates a new instance of the DiscoverSpaces API.
 func NewDiscoverSpacesAPI(st *state.State, resources *common.Resources, authorizer common.Authorizer) (*DiscoverSpacesAPI, error) {
+	return NewDiscoverSpacesAPIWithBacking(networkingcommon.NewStateShim(st), resources, authorizer)
+}
+
+func NewDiscoverSpacesAPIWithBacking(st networkingcommon.NetworkBacking, resources *common.Resources, authorizer common.Authorizer) (*DiscoverSpacesAPI, error) {
 	if !authorizer.AuthEnvironManager() {
 		return nil, common.ErrPerm
 	}
 	return &DiscoverSpacesAPI{
-		EnvironWatcher: common.NewEnvironWatcher(st, resources, authorizer),
-		st:             networkingcommon.NewStateShim(st),
-		authorizer:     authorizer,
-		resources:      resources,
-		StateAddresser: common.NewStateAddresser(st),
+		st:         st,
+		authorizer: authorizer,
+		resources:  resources,
 	}, nil
 }
 

--- a/apiserver/discoverspaces/discoverspaces.go
+++ b/apiserver/discoverspaces/discoverspaces.go
@@ -38,6 +38,21 @@ func NewDiscoverSpacesAPIWithBacking(st networkingcommon.NetworkBacking, resourc
 	}, nil
 }
 
+// EnvironConfig returns the current environment's configuration.
+func (api *DiscoverSpacesAPI) EnvironConfig() (params.EnvironConfigResult, error) {
+	result := params.EnvironConfigResult{}
+
+	config, err := api.st.EnvironConfig()
+	if err != nil {
+		return result, err
+	}
+	allAttrs := config.AllAttrs()
+	// No need to obscure any secrets as caller needs to be an
+	// EnvironManager to call any api methods.
+	result.Config = allAttrs
+	return result, nil
+}
+
 // CreateSpaces creates a new Juju network space, associating the
 // specified subnets with it (optional; can be empty).
 func (api *DiscoverSpacesAPI) CreateSpaces(args params.CreateSpacesParams) (results params.ErrorResults, err error) {

--- a/apiserver/discoverspaces/discoverspaces_test.go
+++ b/apiserver/discoverspaces/discoverspaces_test.go
@@ -81,7 +81,7 @@ func (s *DiscoverSpacesSuite) TestEnvironConfigSuccess(c *gc.C) {
 	result, err := s.facade.EnvironConfig()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, params.EnvironConfigResult{
-		Config: nil,
+		Config: apiservertesting.BackingInstance.EnvConfig.AllAttrs(),
 	})
 
 	apiservertesting.BackingInstance.CheckCallNames(c, "EnvironConfig")

--- a/apiserver/discoverspaces/discoverspaces_test.go
+++ b/apiserver/discoverspaces/discoverspaces_test.go
@@ -91,33 +91,34 @@ func (s *DiscoverSpacesSuite) TestListSpaces(c *gc.C) {
 	result, err := s.facade.ListSpaces()
 	c.Assert(err, jc.ErrorIsNil)
 
-	expectedResult := []params.ProviderSpace{
-		{Name: "default",
-			Subnets: []params.Subnet{
-				{CIDR: "192.168.0.0/24",
-					ProviderId: "provider-192.168.0.0/24",
-					SpaceTag:   "space-default",
-					Zones:      []string{"foo"},
-					Status:     "in-use"},
-				{CIDR: "192.168.3.0/24",
-					ProviderId: "provider-192.168.3.0/24",
-					VLANTag:    23,
-					SpaceTag:   "space-default",
-					Zones:      []string{"bar", "bam"}}}},
-		{Name: "dmz",
-			Subnets: []params.Subnet{
-				{CIDR: "192.168.1.0/24",
-					ProviderId: "provider-192.168.1.0/24",
-					VLANTag:    23,
-					SpaceTag:   "space-dmz",
-					Zones:      []string{"bar", "bam"}}}},
-		{Name: "private",
-			Subnets: []params.Subnet{
-				{CIDR: "192.168.2.0/24",
-					ProviderId: "provider-192.168.2.0/24",
-					SpaceTag:   "space-private",
-					Zones:      []string{"foo"},
-					Status:     "in-use"}}}}
+	expectedResult := []params.ProviderSpace{{
+		Name: "default",
+		Subnets: []params.Subnet{
+			{CIDR: "192.168.0.0/24",
+				ProviderId: "provider-192.168.0.0/24",
+				SpaceTag:   "space-default",
+				Zones:      []string{"foo"},
+				Status:     "in-use"},
+			{CIDR: "192.168.3.0/24",
+				ProviderId: "provider-192.168.3.0/24",
+				VLANTag:    23,
+				SpaceTag:   "space-default",
+				Zones:      []string{"bar", "bam"}}}}, {
+		Name: "dmz",
+		Subnets: []params.Subnet{
+			{CIDR: "192.168.1.0/24",
+				ProviderId: "provider-192.168.1.0/24",
+				VLANTag:    23,
+				SpaceTag:   "space-dmz",
+				Zones:      []string{"bar", "bam"}}}}, {
+		Name: "private",
+		Subnets: []params.Subnet{
+			{CIDR: "192.168.2.0/24",
+				ProviderId: "provider-192.168.2.0/24",
+				SpaceTag:   "space-private",
+				Zones:      []string{"foo"},
+				Status:     "in-use"}},
+	}}
 	c.Assert(result.Results, jc.DeepEquals, expectedResult)
 	apiservertesting.BackingInstance.CheckCallNames(c, "AllSpaces")
 }

--- a/apiserver/discoverspaces/discoverspaces_test.go
+++ b/apiserver/discoverspaces/discoverspaces_test.go
@@ -1,0 +1,65 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package discoverspaces_test
+
+import (
+	"github.com/juju/names"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/discoverspaces"
+	apiservertesting "github.com/juju/juju/apiserver/testing"
+	coretesting "github.com/juju/juju/testing"
+)
+
+type DiscoverSpacesSuite struct {
+	coretesting.BaseSuite
+	apiservertesting.StubNetwork
+
+	resources  *common.Resources
+	authorizer apiservertesting.FakeAuthorizer
+	facade     *discoverspaces.DiscoverSpacesAPI
+}
+
+var _ = gc.Suite(&DiscoverSpacesSuite{})
+
+func (s *DiscoverSpacesSuite) SetUpSuite(c *gc.C) {
+	s.StubNetwork.SetUpSuite(c)
+	s.BaseSuite.SetUpSuite(c)
+}
+
+func (s *DiscoverSpacesSuite) TearDownSuite(c *gc.C) {
+	s.BaseSuite.TearDownSuite(c)
+}
+
+func (s *DiscoverSpacesSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+	apiservertesting.BackingInstance.SetUp(
+		c,
+		apiservertesting.StubZonedEnvironName,
+		apiservertesting.WithZones,
+		apiservertesting.WithSpaces,
+		apiservertesting.WithSubnets)
+
+	s.resources = common.NewResources()
+	s.authorizer = apiservertesting.FakeAuthorizer{
+		Tag:            names.NewUserTag("admin"),
+		EnvironManager: false,
+	}
+
+	var err error
+	s.facade, err = discoverspaces.NewDiscoverSpacesAPIWithBacking(
+		apiservertesting.BackingInstance, s.resources, s.authorizer,
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s.facade, gc.NotNil)
+}
+
+func (s *DiscoverSpacesSuite) TearDownTest(c *gc.C) {
+	if s.resources != nil {
+		s.resources.StopAll()
+	}
+	s.BaseSuite.TearDownTest(c)
+}

--- a/apiserver/discoverspaces/discoverspaces_test.go
+++ b/apiserver/discoverspaces/discoverspaces_test.go
@@ -119,4 +119,15 @@ func (s *DiscoverSpacesSuite) TestListSpaces(c *gc.C) {
 					Zones:      []string{"foo"},
 					Status:     "in-use"}}}}
 	c.Assert(result.Results, jc.DeepEquals, expectedResult)
+	apiservertesting.BackingInstance.CheckCallNames(c, "AllSpaces")
+}
+
+func (s *DiscoverSpacesSuite) TestListSpacesFailure(c *gc.C) {
+	apiservertesting.BackingInstance.SetErrors(errors.New("boom"))
+
+	result, err := s.facade.ListSpaces()
+	c.Assert(err, gc.ErrorMatches, "boom")
+	c.Assert(result, jc.DeepEquals, params.DiscoverSpacesResults{})
+
+	apiservertesting.BackingInstance.CheckCallNames(c, "AllSpaces")
 }

--- a/apiserver/discoverspaces/discoverspaces_test.go
+++ b/apiserver/discoverspaces/discoverspaces_test.go
@@ -86,3 +86,37 @@ func (s *DiscoverSpacesSuite) TestEnvironConfigSuccess(c *gc.C) {
 
 	apiservertesting.BackingInstance.CheckCallNames(c, "EnvironConfig")
 }
+
+func (s *DiscoverSpacesSuite) TestListSpaces(c *gc.C) {
+	result, err := s.facade.ListSpaces()
+	c.Assert(err, jc.ErrorIsNil)
+
+	expectedResult := []params.ProviderSpace{
+		{Name: "default",
+			Subnets: []params.Subnet{
+				{CIDR: "192.168.0.0/24",
+					ProviderId: "provider-192.168.0.0/24",
+					SpaceTag:   "space-default",
+					Zones:      []string{"foo"},
+					Status:     "in-use"},
+				{CIDR: "192.168.3.0/24",
+					ProviderId: "provider-192.168.3.0/24",
+					VLANTag:    23,
+					SpaceTag:   "space-default",
+					Zones:      []string{"bar", "bam"}}}},
+		{Name: "dmz",
+			Subnets: []params.Subnet{
+				{CIDR: "192.168.1.0/24",
+					ProviderId: "provider-192.168.1.0/24",
+					VLANTag:    23,
+					SpaceTag:   "space-dmz",
+					Zones:      []string{"bar", "bam"}}}},
+		{Name: "private",
+			Subnets: []params.Subnet{
+				{CIDR: "192.168.2.0/24",
+					ProviderId: "provider-192.168.2.0/24",
+					SpaceTag:   "space-private",
+					Zones:      []string{"foo"},
+					Status:     "in-use"}}}}
+	c.Assert(result.Results, jc.DeepEquals, expectedResult)
+}

--- a/worker/discoverspaces/discoverspaces.go
+++ b/worker/discoverspaces/discoverspaces.go
@@ -20,9 +20,8 @@ import (
 var logger = loggo.GetLogger("juju.discoverspaces")
 
 type discoverspacesWorker struct {
-	api      *discoverspaces.API
-	tomb     tomb.Tomb
-	observer *worker.EnvironObserver
+	api  *discoverspaces.API
+	tomb tomb.Tomb
 }
 
 // NewWorker returns a worker
@@ -46,17 +45,14 @@ func (dw *discoverspacesWorker) Wait() error {
 }
 
 func (dw *discoverspacesWorker) loop() (err error) {
-	dw.observer, err = worker.NewEnvironObserver(dw.api)
+	envCfg, err := dw.api.EnvironConfig()
 	if err != nil {
 		return err
 	}
-	defer func() {
-		obsErr := worker.Stop(dw.observer)
-		if err == nil {
-			err = obsErr
-		}
-	}()
-	environ := dw.observer.Environ()
+	environ, err := environs.New(envCfg)
+	if err != nil {
+		return err
+	}
 	networkingEnviron, ok := environs.SupportsNetworking(environ)
 
 	if ok {


### PR DESCRIPTION
Tests for discoverspaces apiserver. EnvironWatcher is no longer used in the worker, api client or apiserver. EnvironConfig is implemented directly instead.

(Review request: http://reviews.vapour.ws/r/3473/)