### PR TITLE
Revert PRs #3730 #3866 #3877 #3966 (which switched to using devices for containers)

### DIFF
--- a/apiserver/addresser/addresser.go
+++ b/apiserver/addresser/addresser.go
@@ -132,8 +132,8 @@ func (api *AddresserAPI) CleanupIPAddresses() params.ErrorResult {
 
 // netEnvReleaseAddress is used for testability.
 var netEnvReleaseAddress = func(env environs.NetworkingEnviron,
-	instId instance.Id, subnetId network.Id, addr network.Address, macAddress, hostname string) error {
-	return env.ReleaseAddress(instId, subnetId, addr, macAddress, hostname)
+	instId instance.Id, subnetId network.Id, addr network.Address, macAddress string) error {
+	return env.ReleaseAddress(instId, subnetId, addr, macAddress)
 }
 
 // releaseIPAddress releases one IP address.
@@ -146,7 +146,7 @@ func (api *AddresserAPI) releaseIPAddress(netEnv environs.NetworkingEnviron, ipA
 	}
 	// Now release the IP address.
 	subnetId := network.Id(ipAddress.SubnetId())
-	err = netEnvReleaseAddress(netEnv, ipAddress.InstanceId(), subnetId, ipAddress.Address(), ipAddress.MACAddress(), "")
+	err = netEnvReleaseAddress(netEnv, ipAddress.InstanceId(), subnetId, ipAddress.Address(), ipAddress.MACAddress())
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/apiserver/addresser/addresser_test.go
+++ b/apiserver/addresser/addresser_test.go
@@ -152,19 +152,13 @@ func (s *AddresserSuite) TestReleaseAddress(c *gc.C) {
 
 	// Prepare tests.
 	called := 0
-	s.PatchValue(addresser.NetEnvReleaseAddress, func(
-		env environs.NetworkingEnviron,
-		instId instance.Id,
-		subnetId network.Id,
-		addr network.Address,
-		macAddress, hostname string,
-	) error {
+	s.PatchValue(addresser.NetEnvReleaseAddress, func(env environs.NetworkingEnviron,
+		instId instance.Id, subnetId network.Id, addr network.Address, macAddress string) error {
 		called++
 		c.Assert(instId, gc.Equals, instance.Id("a3"))
 		c.Assert(subnetId, gc.Equals, network.Id("a"))
 		c.Assert(addr, gc.Equals, network.NewAddress("0.1.2.3"))
 		c.Assert(macAddress, gc.Equals, "fff3")
-		c.Assert(hostname, gc.Equals, "")
 		return nil
 	})
 

--- a/apiserver/provisioner/container_test.go
+++ b/apiserver/provisioner/container_test.go
@@ -218,23 +218,17 @@ func (s *prepareSuite) TestErrorWithNoFeatureFlagAllocateSuccess(c *gc.C) {
 	container := s.newCustomAPI(c, "i-alloc-me", true, false)
 	args := s.makeArgs(container)
 	_, testLog := s.assertCall(c, args, s.makeResults([]params.NetworkConfig{{
-		DeviceIndex:    0,
-		NetworkName:    "juju-private",
-		ProviderId:     "dummy-eth0",
-		InterfaceName:  "eth0",
-		DNSServers:     []string{"ns1.dummy", "ns2.dummy"},
-		GatewayAddress: "0.10.0.1",
-		ConfigType:     "static",
-		MACAddress:     "regex:" + regexpMACAddress,
-		Address:        "regex:0.10.0.[0-9]{1,3}", // we don't care about the actual value.
+		DeviceIndex:   0,
+		InterfaceName: "eth0",
+		ConfigType:    "dhcp",
+		MACAddress:    "regex:" + regexpMACAddress,
+		ProviderId:    "juju-private",
+		NetworkName:   "juju-private",
 	}}), "")
 
 	c.Assert(testLog, jc.LogMatches, jc.SimpleMessages{{
 		loggo.INFO,
-		`allocated address ".+" on instance "i-alloc-me" for container "juju-machine-0-lxc-0"`,
-	}, {
-		loggo.INFO,
-		`assigned address ".+" to container "0/lxc/0"`,
+		`reserved address for container "0/lxc/0" with MAC address ".+" \(using DHCP\)`,
 	}})
 }
 

--- a/apiserver/provisioner/container_test.go
+++ b/apiserver/provisioner/container_test.go
@@ -191,47 +191,6 @@ func (s *prepareSuite) TestErrorWithNoFeatureFlag(c *gc.C) {
 	}, "")
 }
 
-func (s *prepareSuite) TestErrorWithNoFeatureFlagAndBrokenAllocate(c *gc.C) {
-	s.breakEnvironMethods(c, "AllocateAddress")
-	s.SetFeatureFlags()
-	// Use the special "i-alloc-" prefix to force the dummy provider to allow
-	// AllocateAddress to run without the feature flag.
-	container := s.newCustomAPI(c, "i-alloc-me", true, false)
-	args := s.makeArgs(container)
-	expectedError := &params.Error{
-		Message: `failed to allocate an address for "0/lxc/0": dummy.AllocateAddress is broken`,
-	}
-	s.assertCall(c, args, &params.MachineNetworkConfigResults{
-		Results: []params.MachineNetworkConfigResult{
-			{Error: expectedError},
-		},
-	}, "")
-}
-
-func (s *prepareSuite) TestErrorWithNoFeatureFlagAllocateSuccess(c *gc.C) {
-	s.SetFeatureFlags()
-	s.breakEnvironMethods(c)
-	// Use the special "i-alloc-" prefix to force the dummy provider to allow
-	// AllocateAddress to run without the feature flag, which simulates a MAAS
-	// 1.8+ environment where without the flag we still try calling
-	// AllocateAddress for the device we created for the container.
-	container := s.newCustomAPI(c, "i-alloc-me", true, false)
-	args := s.makeArgs(container)
-	_, testLog := s.assertCall(c, args, s.makeResults([]params.NetworkConfig{{
-		DeviceIndex:   0,
-		InterfaceName: "eth0",
-		ConfigType:    "dhcp",
-		MACAddress:    "regex:" + regexpMACAddress,
-		ProviderId:    "juju-private",
-		NetworkName:   "juju-private",
-	}}), "")
-
-	c.Assert(testLog, jc.LogMatches, jc.SimpleMessages{{
-		loggo.INFO,
-		`reserved address for container "0/lxc/0" with MAC address ".+" \(using DHCP\)`,
-	}})
-}
-
 func (s *prepareSuite) TestErrorWithNonProvisionedHost(c *gc.C) {
 	container := s.newAPI(c, false, true)
 	args := s.makeArgs(container)

--- a/apiserver/provisioner/container_test.go
+++ b/apiserver/provisioner/container_test.go
@@ -4,6 +4,7 @@
 package provisioner_test
 
 import (
+	"encoding/hex"
 	"fmt"
 	"strings"
 
@@ -28,8 +29,6 @@ type containerSuite struct {
 
 	provAPI *provisioner.ProvisionerAPI
 }
-
-const regexpMACAddress = "([a-f0-9]{2}:){5}[a-f0-9]{2}"
 
 func (s *containerSuite) SetUpTest(c *gc.C) {
 	s.setUpTest(c, false)
@@ -153,11 +152,13 @@ func (s *prepareSuite) assertCall(c *gc.C, args params.Entities, expectResults *
 					c.Assert(cfg[j].Address, gc.Matches, rex)
 					expectResults.Results[i].Config[j].Address = cfg[j].Address
 				}
-				if strings.HasPrefix(expCfg.MACAddress, "regex:") {
-					rex := strings.TrimPrefix(expCfg.MACAddress, "regex:")
-					c.Assert(cfg[j].MACAddress, gc.Matches, rex)
-					expectResults.Results[i].Config[j].MACAddress = cfg[j].MACAddress
-				}
+				macAddress := cfg[j].MACAddress
+				c.Assert(macAddress[:8], gc.Equals, provisioner.MACAddressTemplate[:8])
+				remainder := strings.Replace(macAddress[8:], ":", "", 3)
+				c.Assert(remainder, gc.HasLen, 6)
+				_, err = hex.DecodeString(remainder)
+				c.Assert(err, jc.ErrorIsNil)
+				expectResults.Results[i].Config[j].MACAddress = macAddress
 			}
 		}
 
@@ -176,19 +177,13 @@ func (s *prepareSuite) assertCall(c *gc.C, args params.Entities, expectResults *
 	return err, tw.Log()
 }
 
-func (s *prepareSuite) TestErrorWithNoFeatureFlag(c *gc.C) {
+func (s *prepareSuite) TestErrorWitnNoFeatureFlag(c *gc.C) {
 	s.SetFeatureFlags() // clear the flags.
 	container := s.newAPI(c, true, true)
 	args := s.makeArgs(container)
-	expectedError := &params.Error{
-		Message: `failed to allocate an address for "0/lxc/0": address allocation not supported`,
-		Code:    params.CodeNotSupported,
-	}
-	s.assertCall(c, args, &params.MachineNetworkConfigResults{
-		Results: []params.MachineNetworkConfigResult{
-			{Error: expectedError},
-		},
-	}, "")
+	s.assertCall(c, args, &params.MachineNetworkConfigResults{},
+		`address allocation not supported`,
+	)
 }
 
 func (s *prepareSuite) TestErrorWithNonProvisionedHost(c *gc.C) {
@@ -424,9 +419,8 @@ func (s *prepareSuite) TestReleaseAndCleanupWhenAllocateAndOrSetFail(c *gc.C) {
 	// are called along with the addresses to verify the logs later.
 	var allocAttemptedAddrs, allocAddrsOK, setAddrs, releasedAddrs []string
 	s.PatchValue(provisioner.AllocateAddrTo, func(ip *state.IPAddress, m *state.Machine, mac string) error {
-		c.Logf("allocateAddrTo called for address %q, machine %q, mac %q", ip.String(), m, mac)
+		c.Logf("allocateAddrTo called for address %q, machine %q", ip.String(), m)
 		c.Assert(m.Id(), gc.Equals, container.Id())
-		c.Assert(mac, gc.Matches, regexpMACAddress)
 		allocAttemptedAddrs = append(allocAttemptedAddrs, ip.Value())
 
 		// Succeed on every other call to give a chance to call
@@ -529,7 +523,6 @@ func (s *prepareSuite) TestReleaseAndRetryWhenSetOnlyFails(c *gc.C) {
 		DeviceIndex:      0,
 		InterfaceName:    "eth0",
 		VLANTag:          0,
-		MACAddress:       "regex:" + regexpMACAddress,
 		Disabled:         false,
 		NoAutoStart:      false,
 		ConfigType:       "static",
@@ -611,7 +604,6 @@ func (s *prepareSuite) TestSuccessWithSingleContainer(c *gc.C) {
 		DeviceIndex:      0,
 		InterfaceName:    "eth0",
 		VLANTag:          0,
-		MACAddress:       "regex:" + regexpMACAddress,
 		Disabled:         false,
 		NoAutoStart:      false,
 		ConfigType:       "static",
@@ -648,7 +640,6 @@ func (s *prepareSuite) TestSuccessWhenFirstSubnetNotAllocatable(c *gc.C) {
 		DeviceIndex:      1,
 		InterfaceName:    "eth1",
 		VLANTag:          1,
-		MACAddress:       "regex:" + regexpMACAddress,
 		Disabled:         false,
 		NoAutoStart:      true,
 		ConfigType:       "static",
@@ -722,12 +713,9 @@ func (s *releaseSuite) TestErrorWithNoFeatureFlag(c *gc.C) {
 	s.SetFeatureFlags() // clear the flags.
 	s.newAPI(c, true, false)
 	args := s.makeArgs(s.machines[0])
-	expectedError := `cannot mark addresses for removal for "machine-0": not a container`
-	s.assertCall(c, args, &params.ErrorResults{
-		Results: []params.ErrorResult{{
-			Error: apiservertesting.ServerError(expectedError),
-		}},
-	}, "")
+	s.assertCall(c, args, &params.ErrorResults{},
+		"address allocation not supported",
+	)
 }
 
 func (s *releaseSuite) TestErrorWithHostInsteadOfContainer(c *gc.C) {

--- a/apiserver/provisioner/provisioner.go
+++ b/apiserver/provisioner/provisioner.go
@@ -828,10 +828,6 @@ func (p *ProvisionerAPI) WatchMachineErrorRetry() (params.NotifyWatchResult, err
 	return result, nil
 }
 
-func containerHostname(containerTag names.Tag) string {
-	return fmt.Sprintf("%s-%s", container.DefaultNamespace, containerTag.String())
-}
-
 // ReleaseContainerAddresses finds addresses allocated to a container
 // and marks them as Dead, to be released and removed. It accepts
 // container tags as arguments. If address allocation feature flag is
@@ -841,10 +837,8 @@ func (p *ProvisionerAPI) ReleaseContainerAddresses(args params.Entities) (params
 		Results: make([]params.ErrorResult, len(args.Entities)),
 	}
 
-	logger.Tracef("checking if the environment supports releasing addresses")
-	netEnviron, err := p.maybeGetNetworkingEnviron()
-	if err != nil {
-		return result, errors.Trace(err)
+	if !environs.AddressAllocationEnabled() {
+		return result, errors.NotSupportedf("address allocation")
 	}
 
 	canAccess, err := p.getAuthFunc()
@@ -874,32 +868,6 @@ func (p *ProvisionerAPI) ReleaseContainerAddresses(args params.Entities) (params
 			result.Results[i].Error = common.ServerError(err)
 			continue
 		}
-
-		if !environs.AddressAllocationEnabled() {
-			logger.Tracef("trying to release all addresses for container %q", container.Id())
-			// Even if the address allocation feature flag is not enabled, we
-			// might be running on MAAS 1.8+ with devices support, which we
-			// detected earlier when the container has started and registered a
-			// device for it. Now we can just call ReleaseAddress with the
-			// hostname set and the rest left empty.
-			zeroIP, zeroMAC := network.Address{}, ""
-			hostname := containerHostname(container.Tag())
-			err := netEnviron.ReleaseAddress(
-				instance.UnknownId,
-				network.AnySubnet,
-				zeroIP,
-				zeroMAC,
-				hostname,
-			)
-			logger.Tracef("ReleaseAddress for hostname %q returned: %v", hostname, err)
-			if err != nil && errors.IsNotSupported(err) {
-				// Not using MAAS 1.8+, just record the error.
-				result.Results[i].Error = common.ServerError(err)
-			}
-			continue
-		}
-		// With addressable containers feature flag enabled, the addresser will
-		// release the IPs once they are set to dead.
 
 		id := container.Id()
 		addresses, err := p.st.AllocatedIPAddresses(id)
@@ -951,9 +919,6 @@ const MACAddressTemplate = "00:16:3e:%02x:%02x:%02x"
 
 // generateMACAddress creates a random MAC address within the space defined by
 // MACAddressTemplate above.
-//
-// TODO(dimitern): We should make a best effort to ensure the MAC address we
-// generate is unique at least within the current environment.
 func generateMACAddress() string {
 	digits := make([]interface{}, 3)
 	for i := range digits {
@@ -965,14 +930,14 @@ func generateMACAddress() string {
 // prepareOrGetContainerInterfaceInfo optionally allocates an address and returns information
 // for configuring networking on a container. It accepts container tags as arguments.
 func (p *ProvisionerAPI) prepareOrGetContainerInterfaceInfo(
-	args params.Entities,
-	provisionContainer bool,
-) (
-	params.MachineNetworkConfigResults,
-	error,
-) {
+	args params.Entities, provisionContainer bool) (
+	params.MachineNetworkConfigResults, error) {
 	result := params.MachineNetworkConfigResults{
 		Results: make([]params.MachineNetworkConfigResult, len(args.Entities)),
+	}
+
+	if !environs.AddressAllocationEnabled() {
+		return result, errors.NotSupportedf("address allocation")
 	}
 
 	// Some preparations first.
@@ -988,15 +953,9 @@ func (p *ProvisionerAPI) prepareOrGetContainerInterfaceInfo(
 		err = errors.NotProvisionedf("cannot allocate addresses: host machine %q", host)
 		return result, err
 	}
-	var subnet *state.Subnet
-	var subnetInfo network.SubnetInfo
-	var interfaceInfo network.InterfaceInfo
-	if environs.AddressAllocationEnabled() {
-		// We don't need a subnet unless we need to allocate a static IP.
-		subnet, subnetInfo, interfaceInfo, err = p.prepareAllocationNetwork(environ, host, instId)
-		if err != nil {
-			return result, errors.Annotate(err, "cannot allocate addresses")
-		}
+	subnet, subnetInfo, interfaceInfo, err := p.prepareAllocationNetwork(environ, host, instId)
+	if err != nil {
+		return result, errors.Annotate(err, "cannot allocate addresses")
 	}
 
 	// Loop over the passed container tags.
@@ -1034,29 +993,12 @@ func (p *ProvisionerAPI) prepareOrGetContainerInterfaceInfo(
 		var macAddress string
 		var address *state.IPAddress
 		if provisionContainer {
-			// Allocate and set an address.
+			// Allocate and set address.
 			macAddress = generateMACAddress()
 			address, err = p.allocateAddress(environ, subnet, host, container, instId, macAddress)
 			if err != nil {
 				err = errors.Annotatef(err, "failed to allocate an address for %q", container)
 				result.Results[i].Error = common.ServerError(err)
-				continue
-			}
-			if address == nil && !environs.AddressAllocationEnabled() {
-				// Container will use DHCP to get its IP, and it needs to use
-				// the generated MAC address.
-				result.Results[i] = params.MachineNetworkConfigResult{
-					Config: []params.NetworkConfig{{
-						DeviceIndex:   0,
-						InterfaceName: "eth0",
-						ConfigType:    string(network.ConfigDHCP),
-						MACAddress:    macAddress,
-						// The following should not be needed anymore, but the
-						// worker still validates them on SetProvisioned.
-						NetworkName: network.DefaultPrivate,
-						ProviderId:  network.DefaultPrivate,
-					}},
-				}
 				continue
 			}
 		} else {
@@ -1115,29 +1057,21 @@ func (p *ProvisionerAPI) prepareOrGetContainerInterfaceInfo(
 	return result, nil
 }
 
-func (p *ProvisionerAPI) maybeGetNetworkingEnviron() (environs.NetworkingEnviron, error) {
+// prepareContainerAccessEnvironment retrieves the environment, host machine, and access
+// for working with containers.
+func (p *ProvisionerAPI) prepareContainerAccessEnvironment() (environs.NetworkingEnviron, *state.Machine, common.AuthFunc, error) {
 	cfg, err := p.st.EnvironConfig()
 	if err != nil {
-		return nil, errors.Annotate(err, "failed to get environment config")
+		return nil, nil, nil, errors.Annotate(err, "failed to get environment config")
 	}
 	environ, err := environs.New(cfg)
 	if err != nil {
-		return nil, errors.Annotate(err, "failed to construct an environment from config")
+		return nil, nil, nil, errors.Annotate(err, "failed to construct an environment from config")
 	}
 	netEnviron, supported := environs.SupportsNetworking(environ)
 	if !supported {
 		// " not supported" will be appended to the message below.
-		return nil, errors.NotSupportedf("environment %q networking", cfg.Name())
-	}
-	return netEnviron, nil
-}
-
-// prepareContainerAccessEnvironment retrieves the environment, host machine, and access
-// for working with containers.
-func (p *ProvisionerAPI) prepareContainerAccessEnvironment() (environs.NetworkingEnviron, *state.Machine, common.AuthFunc, error) {
-	netEnviron, err := p.maybeGetNetworkingEnviron()
-	if err != nil {
-		return nil, nil, nil, errors.Trace(err)
+		return nil, nil, nil, errors.NotSupportedf("environment %q networking", cfg.Name())
 	}
 
 	canAccess, err := p.getAuthFunc()
@@ -1270,25 +1204,9 @@ func (p *ProvisionerAPI) allocateAddress(
 	instId instance.Id,
 	macAddress string,
 ) (*state.IPAddress, error) {
-	hostname := containerHostname(container.Tag())
-
-	if !environs.AddressAllocationEnabled() {
-		// Even if the address allocation feature flag is not enabled, we might
-		// be running on MAAS 1.8+ with devices support, which we can use to
-		// register containers getting IPs via DHCP. However, most of the usual
-		// allocation code can be bypassed, we just need the parent instance ID
-		// and a MAC address (no subnet or IP address).
-		zeroIP := network.Address{}
-		err := environ.AllocateAddress(instId, network.AnySubnet, zeroIP, macAddress, hostname)
-		if err != nil && errors.IsNotSupported(err) {
-			// Not using MAAS 1.8+.
-			return nil, errors.Trace(err)
-		}
-		// No address to return since the container will be using DHCP.
-		return nil, nil
-	}
 
 	subnetId := network.Id(subnet.ProviderId())
+	name := names.NewMachineTag(container.Id()).String()
 	for {
 		addr, err := subnet.PickNewAddress()
 		if err != nil {
@@ -1296,7 +1214,7 @@ func (p *ProvisionerAPI) allocateAddress(
 		}
 		logger.Tracef("picked new address %q on subnet %q", addr.String(), subnetId)
 		// Attempt to allocate with environ.
-		err = environ.AllocateAddress(instId, subnetId, addr.Address(), macAddress, hostname)
+		err = environ.AllocateAddress(instId, subnetId, addr.Address(), macAddress, name)
 		if err != nil {
 			logger.Warningf(
 				"allocating address %q on instance %q and subnet %q failed: %v (retrying)",
@@ -1360,7 +1278,7 @@ func (p *ProvisionerAPI) setAllocatedOrRelease(
 				addr.String(), state.AddressStateUnavailable, err,
 			)
 		}
-		err = environ.ReleaseAddress(instId, subnetId, addr.Address(), addr.MACAddress(), "")
+		err = environ.ReleaseAddress(instId, subnetId, addr.Address(), addr.MACAddress())
 		if err == nil {
 			logger.Infof("address %q released; trying to allocate new", addr.String())
 			return

--- a/apiserver/provisioner/provisioner.go
+++ b/apiserver/provisioner/provisioner.go
@@ -892,8 +892,8 @@ func (p *ProvisionerAPI) ReleaseContainerAddresses(args params.Entities) (params
 				hostname,
 			)
 			logger.Tracef("ReleaseAddress for hostname %q returned: %v", hostname, err)
-			if err != nil {
-				// Likely not using MAAS 1.8+, just record the error.
+			if err != nil && errors.IsNotSupported(err) {
+				// Not using MAAS 1.8+, just record the error.
 				result.Results[i].Error = common.ServerError(err)
 			}
 			continue
@@ -1042,36 +1042,22 @@ func (p *ProvisionerAPI) prepareOrGetContainerInterfaceInfo(
 				result.Results[i].Error = common.ServerError(err)
 				continue
 			}
-			if address == nil {
-				// This is only an issue when the address allocation is enabled,
-				// as it should've been reported as an error after retrying a
-				// few times.
-				if !environs.AddressAllocationEnabled() {
-					// Without the feature flag, we might be running on MAAS
-					// 1.8+ in which case the container will use DHCP to get its
-					// IP, and it needs to use the generated MAC address.
-					result.Results[i] = params.MachineNetworkConfigResult{
-						Config: []params.NetworkConfig{{
-							DeviceIndex:   0,
-							InterfaceName: "eth0",
-							ConfigType:    string(network.ConfigDHCP),
-							MACAddress:    macAddress,
-							// The following should not be needed anymore, but the
-							// worker still validates them on SetProvisioned.
-							NetworkName: network.DefaultPrivate,
-							ProviderId:  network.DefaultPrivate,
-						}},
-					}
-					logger.Infof(
-						"reserved address for container %q with MAC address %q (using DHCP)",
-						container, macAddress,
-					)
-					continue
-				} else {
-					err = errors.New("expected allocated address, got nil and no error")
-					result.Results[i].Error = common.ServerError(err)
-					continue
+			if address == nil && !environs.AddressAllocationEnabled() {
+				// Container will use DHCP to get its IP, and it needs to use
+				// the generated MAC address.
+				result.Results[i] = params.MachineNetworkConfigResult{
+					Config: []params.NetworkConfig{{
+						DeviceIndex:   0,
+						InterfaceName: "eth0",
+						ConfigType:    string(network.ConfigDHCP),
+						MACAddress:    macAddress,
+						// The following should not be needed anymore, but the
+						// worker still validates them on SetProvisioned.
+						NetworkName: network.DefaultPrivate,
+						ProviderId:  network.DefaultPrivate,
+					}},
 				}
+				continue
 			}
 		} else {
 			id := container.Id()
@@ -1238,14 +1224,6 @@ func (p *ProvisionerAPI) prepareAllocationNetwork(
 			// this subnet has no allocatable IPs
 			continue
 		}
-		if sub.AllocatableIPLow != nil && sub.AllocatableIPLow.To4() == nil {
-			logger.Tracef("ignoring IPv6 subnet %q - allocating IPv6 addresses not yet supported", sub.ProviderId)
-			// Until we change the way we pick addresses, IPv6 subnets with
-			// their *huge* ranges (/64 being the default), there is no point in
-			// allowing such subnets (it won't even work as PickNewAddress()
-			// assumes IPv4 allocatable range anyway).
-			continue
-		}
 		ok, err := environ.SupportsAddressAllocation(sub.ProviderId)
 		if err == nil && ok {
 			subnetInfo = sub
@@ -1302,12 +1280,11 @@ func (p *ProvisionerAPI) allocateAddress(
 		// and a MAC address (no subnet or IP address).
 		zeroIP := network.Address{}
 		err := environ.AllocateAddress(instId, network.AnySubnet, zeroIP, macAddress, hostname)
-		if err != nil {
-			// Not using MAAS 1.8+ or some other error.
+		if err != nil && errors.IsNotSupported(err) {
+			// Not using MAAS 1.8+.
 			return nil, errors.Trace(err)
 		}
-		// No address to return since the container will be using DHCP (but the
-		// reserved address will be logged).
+		// No address to return since the container will be using DHCP.
 		return nil, nil
 	}
 

--- a/container/lxc/lxc.go
+++ b/container/lxc/lxc.go
@@ -852,8 +852,7 @@ const singleNICTemplate = `
 lxc.network.type = {{.Type}}
 lxc.network.link = {{.Link}}
 lxc.network.flags = up{{if .MTU}}
-lxc.network.mtu = {{.MTU}}{{end}}{{if .MACAddress}}
-lxc.network.hwaddr = {{.MACAddress}}{{end}}
+lxc.network.mtu = {{.MTU}}{{end}}
 
 `
 
@@ -863,8 +862,8 @@ const multipleNICsTemplate = `
 lxc.network.type = {{$nic.Type}}{{if $nic.VLANTag}}
 lxc.network.vlan.id = {{$nic.VLANTag}}{{end}}
 lxc.network.link = {{$nic.Link}}{{if not $nic.NoAutoStart}}
-lxc.network.flags = up{{end}}{{if $nic.Name}}
-lxc.network.name = {{$nic.Name}}{{end}}{{if $nic.MACAddress}}
+lxc.network.flags = up{{end}}
+lxc.network.name = {{$nic.Name}}{{if $nic.MACAddress}}
 lxc.network.hwaddr = {{$nic.MACAddress}}{{end}}{{if $nic.IPv4Address}}
 lxc.network.ipv4 = {{$nic.IPv4Address}}{{end}}{{if $nic.IPv4Gateway}}
 lxc.network.ipv4.gateway = {{$nic.IPv4Gateway}}{{end}}{{if $mtu}}
@@ -887,10 +886,8 @@ func networkConfigTemplate(config container.NetworkConfig) string {
 	type configData struct {
 		Type       string
 		Link       string
-		Interfaces []nicData
-		// The following are used only with a single NIC config.
 		MTU        int
-		MACAddress string
+		Interfaces []nicData
 	}
 	data := configData{
 		Link: config.Device,

--- a/environs/networking.go
+++ b/environs/networking.go
@@ -14,12 +14,9 @@ import (
 // Networking interface defines methods that environments
 // with networking capabilities must implement.
 type Networking interface {
-	// AllocateAddress requests a specific address to be allocated for the given
-	// instance on the given subnet, using the specified macAddress and
-	// hostnameSuffix. If addr is empty, this is interpreted as an output
-	// argument, which will contain the allocated address. Otherwise, addr must
-	// be non-empty and will be allocated as specified, if possible.
-	AllocateAddress(instId instance.Id, subnetId network.Id, addr *network.Address, macAddress, hostnameSuffix string) error
+	// AllocateAddress requests a specific address to be allocated for the
+	// given instance on the given subnet.
+	AllocateAddress(instId instance.Id, subnetId network.Id, addr network.Address, macAddress, hostname string) error
 
 	// ReleaseAddress releases a specific address previously allocated with
 	// AllocateAddress.

--- a/environs/networking.go
+++ b/environs/networking.go
@@ -20,7 +20,7 @@ type Networking interface {
 
 	// ReleaseAddress releases a specific address previously allocated with
 	// AllocateAddress.
-	ReleaseAddress(instId instance.Id, subnetId network.Id, addr network.Address, macAddress, hostname string) error
+	ReleaseAddress(instId instance.Id, subnetId network.Id, addr network.Address, macAddress string) error
 
 	// Subnets returns basic information about subnets known
 	// by the provider for the environment.

--- a/juju/deploy_test.go
+++ b/juju/deploy_test.go
@@ -226,12 +226,11 @@ func (s *DeployLocalSuite) TestDeployWithPlacement(c *gc.C) {
 			ServiceName: "bob",
 			Charm:       s.charm,
 			Constraints: serviceCons,
-			NumUnits:    4,
+			NumUnits:    3,
 			Placement: []*instance.Placement{
 				{Scope: s.State.EnvironUUID(), Directive: "valid"},
 				{Scope: "#", Directive: "0"},
 				{Scope: "lxc", Directive: "1"},
-				{Scope: "lxc", Directive: ""},
 			},
 			ToMachineSpec: "will be ignored",
 		})
@@ -239,13 +238,12 @@ func (s *DeployLocalSuite) TestDeployWithPlacement(c *gc.C) {
 	s.assertConstraints(c, service, serviceCons)
 	units, err := service.AllUnits()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(units, gc.HasLen, 4)
+	c.Assert(units, gc.HasLen, 3)
 
 	// Check each of the newly added units.
 	s.assertAssignedUnit(c, units[0], "1", constraints.MustParse("mem=2G cpu-cores=2"))
 	s.assertAssignedUnit(c, units[1], "0", constraints.Value{})
 	s.assertAssignedUnit(c, units[2], "1/lxc/0", constraints.MustParse("mem=2G cpu-cores=2"))
-	s.assertAssignedUnit(c, units[3], "2/lxc/0", constraints.MustParse("mem=2G cpu-cores=2"))
 }
 
 func (s *DeployLocalSuite) TestDeployWithFewerPlacement(c *gc.C) {

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -165,8 +165,8 @@ type OpAllocateAddress struct {
 	InstanceId instance.Id
 	SubnetId   network.Id
 	Address    network.Address
-	MACAddress string
 	HostName   string
+	MACAddress string
 }
 
 type OpReleaseAddress struct {
@@ -175,7 +175,6 @@ type OpReleaseAddress struct {
 	SubnetId   network.Id
 	Address    network.Address
 	MACAddress string
-	HostName   string
 }
 
 type OpNetworkInterfaces struct {
@@ -1131,7 +1130,7 @@ func (env *environ) AllocateAddress(instId instance.Id, subnetId network.Id, add
 
 // ReleaseAddress releases a specific address previously allocated with
 // AllocateAddress.
-func (env *environ) ReleaseAddress(instId instance.Id, subnetId network.Id, addr network.Address, macAddress, hostname string) error {
+func (env *environ) ReleaseAddress(instId instance.Id, subnetId network.Id, addr network.Address, macAddress string) error {
 	if !environs.AddressAllocationEnabled() {
 		return errors.NotSupportedf("address allocation")
 	}
@@ -1152,7 +1151,6 @@ func (env *environ) ReleaseAddress(instId instance.Id, subnetId network.Id, addr
 		SubnetId:   subnetId,
 		Address:    addr,
 		MACAddress: macAddress,
-		HostName:   hostname,
 	}
 	return nil
 }

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -1102,18 +1102,13 @@ func (env *environ) SupportsAddressAllocation(subnetId network.Id) (bool, error)
 
 // AllocateAddress requests an address to be allocated for the
 // given instance on the given subnet.
-func (env *environ) AllocateAddress(instId instance.Id, subnetId network.Id, addr *network.Address, macAddress, hostname string) error {
+func (env *environ) AllocateAddress(instId instance.Id, subnetId network.Id, addr network.Address, macAddress, hostname string) error {
 	if !environs.AddressAllocationEnabled() {
 		// Any instId starting with "i-alloc-" when the feature flag is off will
 		// still work, in order to be able to test MAAS 1.8+ environment where
 		// we can use devices for containers.
 		if !strings.HasPrefix(string(instId), "i-alloc-") {
 			return errors.NotSupportedf("address allocation")
-		}
-		// Also, in this case we expect addr to be non-nil, but empty, so it can
-		// be used as an output argument (same as in provider/maas).
-		if addr == nil || addr.Value != "" {
-			return errors.NewNotValid(nil, "invalid address: nil or non-empty")
 		}
 	}
 
@@ -1128,16 +1123,11 @@ func (env *environ) AllocateAddress(instId instance.Id, subnetId network.Id, add
 	estate.mu.Lock()
 	defer estate.mu.Unlock()
 	estate.maxAddr++
-
-	if addr.Value == "" {
-		*addr = network.NewAddress(fmt.Sprintf("0.10.0.%v", estate.maxAddr))
-	}
-
 	estate.ops <- OpAllocateAddress{
 		Env:        env.name,
 		InstanceId: instId,
 		SubnetId:   subnetId,
-		Address:    *addr,
+		Address:    addr,
 		MACAddress: macAddress,
 		HostName:   hostname,
 	}

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -1104,12 +1104,7 @@ func (env *environ) SupportsAddressAllocation(subnetId network.Id) (bool, error)
 // given instance on the given subnet.
 func (env *environ) AllocateAddress(instId instance.Id, subnetId network.Id, addr network.Address, macAddress, hostname string) error {
 	if !environs.AddressAllocationEnabled() {
-		// Any instId starting with "i-alloc-" when the feature flag is off will
-		// still work, in order to be able to test MAAS 1.8+ environment where
-		// we can use devices for containers.
-		if !strings.HasPrefix(string(instId), "i-alloc-") {
-			return errors.NotSupportedf("address allocation")
-		}
+		return errors.NotSupportedf("address allocation")
 	}
 
 	if err := env.checkBroken("AllocateAddress"); err != nil {

--- a/provider/dummy/environs_test.go
+++ b/provider/dummy/environs_test.go
@@ -265,26 +265,25 @@ func (s *suite) TestReleaseAddress(c *gc.C) {
 	// Release a couple of addresses.
 	address := network.NewScopedAddress("0.1.2.1", network.ScopeCloudLocal)
 	macAddress := "foobar"
-	hostname := "myhostname"
-	err := e.ReleaseAddress(inst.Id(), subnetId, address, macAddress, hostname)
+	err := e.ReleaseAddress(inst.Id(), subnetId, address, macAddress)
 	c.Assert(err, jc.ErrorIsNil)
-	assertReleaseAddress(c, e, opc, inst.Id(), subnetId, address, macAddress, hostname)
+	assertReleaseAddress(c, e, opc, inst.Id(), subnetId, address, macAddress)
 
 	address = network.NewScopedAddress("0.1.2.2", network.ScopeCloudLocal)
-	err = e.ReleaseAddress(inst.Id(), subnetId, address, macAddress, hostname)
+	err = e.ReleaseAddress(inst.Id(), subnetId, address, macAddress)
 	c.Assert(err, jc.ErrorIsNil)
-	assertReleaseAddress(c, e, opc, inst.Id(), subnetId, address, macAddress, hostname)
+	assertReleaseAddress(c, e, opc, inst.Id(), subnetId, address, macAddress)
 
 	// Test we can induce errors.
 	s.breakMethods(c, e, "ReleaseAddress")
 	address = network.NewScopedAddress("0.1.2.3", network.ScopeCloudLocal)
-	err = e.ReleaseAddress(inst.Id(), subnetId, address, macAddress, hostname)
+	err = e.ReleaseAddress(inst.Id(), subnetId, address, macAddress)
 	c.Assert(err, gc.ErrorMatches, `dummy\.ReleaseAddress is broken`)
 
 	// Finally, test the method respects the feature flag when
 	// disabled.
 	s.SetFeatureFlags() // clear the flags.
-	err = e.ReleaseAddress(inst.Id(), subnetId, address, macAddress, hostname)
+	err = e.ReleaseAddress(inst.Id(), subnetId, address, macAddress)
 	c.Assert(err, gc.ErrorMatches, "address allocation not supported")
 	c.Assert(err, jc.Satisfies, errors.IsNotSupported)
 }
@@ -550,16 +549,7 @@ func (s *suite) TestPreferIPv6Off(c *gc.C) {
 	c.Assert(addrs, jc.DeepEquals, network.NewAddresses("only-0.dns", "127.0.0.1"))
 }
 
-func assertAllocateAddress(
-	c *gc.C,
-	e environs.Environ,
-	opc chan dummy.Operation,
-	expectInstId instance.Id,
-	expectSubnetId network.Id,
-	expectAddress network.Address,
-	expectMAC string,
-	expectHost string,
-) {
+func assertAllocateAddress(c *gc.C, e environs.Environ, opc chan dummy.Operation, expectInstId instance.Id, expectSubnetId network.Id, expectAddress network.Address, expectMAC, expectHostName string) {
 	select {
 	case op := <-opc:
 		addrOp, ok := op.(dummy.OpAllocateAddress)
@@ -570,23 +560,14 @@ func assertAllocateAddress(
 		c.Check(addrOp.InstanceId, gc.Equals, expectInstId)
 		c.Check(addrOp.Address, gc.Equals, expectAddress)
 		c.Check(addrOp.MACAddress, gc.Equals, expectMAC)
-		c.Check(addrOp.HostName, gc.Equals, expectHost)
+		c.Check(addrOp.HostName, gc.Equals, expectHostName)
 		return
 	case <-time.After(testing.ShortWait):
 		c.Fatalf("time out wating for operation")
 	}
 }
 
-func assertReleaseAddress(
-	c *gc.C,
-	e environs.Environ,
-	opc chan dummy.Operation,
-	expectInstId instance.Id,
-	expectSubnetId network.Id,
-	expectAddress network.Address,
-	expectMAC string,
-	expectHost string,
-) {
+func assertReleaseAddress(c *gc.C, e environs.Environ, opc chan dummy.Operation, expectInstId instance.Id, expectSubnetId network.Id, expectAddress network.Address, macAddress string) {
 	select {
 	case op := <-opc:
 		addrOp, ok := op.(dummy.OpReleaseAddress)
@@ -596,8 +577,7 @@ func assertReleaseAddress(
 		c.Check(addrOp.SubnetId, gc.Equals, expectSubnetId)
 		c.Check(addrOp.InstanceId, gc.Equals, expectInstId)
 		c.Check(addrOp.Address, gc.Equals, expectAddress)
-		c.Check(addrOp.MACAddress, gc.Equals, expectMAC)
-		c.Check(addrOp.HostName, gc.Equals, expectHost)
+		c.Check(addrOp.MACAddress, gc.Equals, macAddress)
 		return
 	case <-time.After(testing.ShortWait):
 		c.Fatalf("time out wating for operation")

--- a/provider/dummy/environs_test.go
+++ b/provider/dummy/environs_test.go
@@ -225,25 +225,25 @@ func (s *suite) TestAllocateAddress(c *gc.C) {
 
 	// Test allocating a couple of addresses.
 	newAddress := network.NewScopedAddress("0.1.2.1", network.ScopeCloudLocal)
-	err := e.AllocateAddress(inst.Id(), subnetId, &newAddress, "foo", "bar")
+	err := e.AllocateAddress(inst.Id(), subnetId, newAddress, "foo", "bar")
 	c.Assert(err, jc.ErrorIsNil)
 	assertAllocateAddress(c, e, opc, inst.Id(), subnetId, newAddress, "foo", "bar")
 
 	newAddress = network.NewScopedAddress("0.1.2.2", network.ScopeCloudLocal)
-	err = e.AllocateAddress(inst.Id(), subnetId, &newAddress, "foo", "bar")
+	err = e.AllocateAddress(inst.Id(), subnetId, newAddress, "foo", "bar")
 	c.Assert(err, jc.ErrorIsNil)
 	assertAllocateAddress(c, e, opc, inst.Id(), subnetId, newAddress, "foo", "bar")
 
 	// Test we can induce errors.
 	s.breakMethods(c, e, "AllocateAddress")
 	newAddress = network.NewScopedAddress("0.1.2.3", network.ScopeCloudLocal)
-	err = e.AllocateAddress(inst.Id(), subnetId, &newAddress, "foo", "bar")
+	err = e.AllocateAddress(inst.Id(), subnetId, newAddress, "foo", "bar")
 	c.Assert(err, gc.ErrorMatches, `dummy\.AllocateAddress is broken`)
 
 	// Finally, test the method respects the feature flag when
 	// disabled.
 	s.SetFeatureFlags() // clear the flags.
-	err = e.AllocateAddress(inst.Id(), subnetId, &newAddress, "foo", "bar")
+	err = e.AllocateAddress(inst.Id(), subnetId, newAddress, "foo", "bar")
 	c.Assert(err, gc.ErrorMatches, "address allocation not supported")
 	c.Assert(err, jc.Satisfies, errors.IsNotSupported)
 }

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -903,12 +903,9 @@ func (e *environ) fetchNetworkInterfaceId(ec2Inst *ec2.EC2, instId instance.Id) 
 
 // AllocateAddress requests an address to be allocated for the given
 // instance on the given subnet. Implements NetworkingEnviron.AllocateAddress.
-func (e *environ) AllocateAddress(instId instance.Id, _ network.Id, addr *network.Address, _, _ string) (err error) {
+func (e *environ) AllocateAddress(instId instance.Id, _ network.Id, addr network.Address, _, _ string) (err error) {
 	if !environs.AddressAllocationEnabled() {
 		return errors.NotSupportedf("address allocation")
-	}
-	if addr == nil || addr.Value == "" {
-		return errors.NewNotValid(nil, "invalid address: nil or empty")
 	}
 
 	defer errors.DeferredAnnotatef(&err, "failed to allocate address %q for instance %q", addr, instId)
@@ -920,17 +917,17 @@ func (e *environ) AllocateAddress(instId instance.Id, _ network.Id, addr *networ
 		return errors.Trace(err)
 	}
 	for a := shortAttempt.Start(); a.Next(); {
-		err = AssignPrivateIPAddress(ec2Inst, nicId, *addr)
-		logger.Tracef("AssignPrivateIPAddresses(%v, %v) returned: %v", nicId, *addr, err)
+		err = AssignPrivateIPAddress(ec2Inst, nicId, addr)
+		logger.Tracef("AssignPrivateIPAddresses(%v, %v) returned: %v", nicId, addr, err)
 		if err == nil {
-			logger.Tracef("allocated address %v for instance %v, NIC %v", *addr, instId, nicId)
+			logger.Tracef("allocated address %v for instance %v, NIC %v", addr, instId, nicId)
 			break
 		}
 		if ec2Err, ok := err.(*ec2.Error); ok {
 			if ec2Err.Code == invalidParameterValue {
 				// Note: this Code is also used if we specify
 				// an IP address outside the subnet. Take care!
-				logger.Tracef("address %q not available for allocation", *addr)
+				logger.Tracef("address %q not available for allocation", addr)
 				return environs.ErrIPAddressUnavailable
 			} else if ec2Err.Code == privateAddressLimitExceeded {
 				logger.Tracef("no more addresses available on the subnet")

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -941,7 +941,7 @@ func (e *environ) AllocateAddress(instId instance.Id, _ network.Id, addr network
 
 // ReleaseAddress releases a specific address previously allocated with
 // AllocateAddress. Implements NetworkingEnviron.ReleaseAddress.
-func (e *environ) ReleaseAddress(instId instance.Id, _ network.Id, addr network.Address, _, _ string) (err error) {
+func (e *environ) ReleaseAddress(instId instance.Id, _ network.Id, addr network.Address, _ string) (err error) {
 	if !environs.AddressAllocationEnabled() {
 		return errors.NotSupportedf("address allocation")
 	}

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -858,19 +858,12 @@ func (t *localServerSuite) TestAllocateAddressFailureToFindNetworkInterface(c *g
 	addr := network.Address{Value: "8.0.0.4"}
 
 	// Invalid instance found
-	err = env.AllocateAddress(instId+"foo", "", &addr, "foo", "bar")
+	err = env.AllocateAddress(instId+"foo", "", addr, "foo", "bar")
 	c.Assert(err, gc.ErrorMatches, ".*InvalidInstanceID.NotFound.*")
 
 	// No network interface
-	err = env.AllocateAddress(instId, "", &addr, "foo", "bar")
+	err = env.AllocateAddress(instId, "", addr, "foo", "bar")
 	c.Assert(errors.Cause(err), gc.ErrorMatches, "unexpected AWS response: network interface not found")
-
-	// Nil or empty address given.
-	err = env.AllocateAddress(instId, "", nil, "foo", "bar")
-	c.Assert(errors.Cause(err), gc.ErrorMatches, "invalid address: nil or empty")
-
-	err = env.AllocateAddress(instId, "", &network.Address{Value: ""}, "foo", "bar")
-	c.Assert(errors.Cause(err), gc.ErrorMatches, "invalid address: nil or empty")
 }
 
 func (t *localServerSuite) setUpInstanceWithDefaultVpc(c *gc.C) (environs.NetworkingEnviron, instance.Id) {
@@ -897,7 +890,7 @@ func (t *localServerSuite) TestAllocateAddress(c *gc.C) {
 	}
 	t.PatchValue(&ec2.AssignPrivateIPAddress, mockAssign)
 
-	err := env.AllocateAddress(instId, "", &addr, "foo", "bar")
+	err := env.AllocateAddress(instId, "", addr, "foo", "bar")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(actualAddr, gc.Equals, addr)
 }
@@ -911,7 +904,10 @@ func (t *localServerSuite) TestAllocateAddressIPAddressInUseOrEmpty(c *gc.C) {
 	}
 	t.PatchValue(&ec2.AssignPrivateIPAddress, mockAssign)
 
-	err := env.AllocateAddress(instId, "", &addr, "foo", "bar")
+	err := env.AllocateAddress(instId, "", addr, "foo", "bar")
+	c.Assert(errors.Cause(err), gc.Equals, environs.ErrIPAddressUnavailable)
+
+	err = env.AllocateAddress(instId, "", network.Address{}, "foo", "bar")
 	c.Assert(errors.Cause(err), gc.Equals, environs.ErrIPAddressUnavailable)
 }
 
@@ -924,7 +920,7 @@ func (t *localServerSuite) TestAllocateAddressNetworkInterfaceFull(c *gc.C) {
 	}
 	t.PatchValue(&ec2.AssignPrivateIPAddress, mockAssign)
 
-	err := env.AllocateAddress(instId, "", &addr, "foo", "bar")
+	err := env.AllocateAddress(instId, "", addr, "foo", "bar")
 	c.Assert(errors.Cause(err), gc.Equals, environs.ErrIPAddressesExhausted)
 }
 
@@ -932,7 +928,7 @@ func (t *localServerSuite) TestReleaseAddress(c *gc.C) {
 	env, instId := t.setUpInstanceWithDefaultVpc(c)
 	addr := network.Address{Value: "8.0.0.4"}
 	// Allocate the address first so we can release it
-	err := env.AllocateAddress(instId, "", &addr, "foo", "bar")
+	err := env.AllocateAddress(instId, "", addr, "foo", "bar")
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = env.ReleaseAddress(instId, "", addr, "", "")
@@ -1111,8 +1107,7 @@ func (t *localServerSuite) TestSupportsAddressAllocationWithNoFeatureFlag(c *gc.
 func (t *localServerSuite) TestAllocateAddressWithNoFeatureFlag(c *gc.C) {
 	t.SetFeatureFlags() // clear the flags.
 	env := t.prepareEnviron(c)
-	addr := network.NewAddresses("1.2.3.4")[0]
-	err := env.AllocateAddress("i-foo", "net1", &addr, "foo", "bar")
+	err := env.AllocateAddress("i-foo", "net1", network.NewAddresses("1.2.3.4")[0], "foo", "bar")
 	c.Assert(err, gc.ErrorMatches, "address allocation not supported")
 	c.Assert(err, jc.Satisfies, errors.IsNotSupported)
 }

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -931,12 +931,12 @@ func (t *localServerSuite) TestReleaseAddress(c *gc.C) {
 	err := env.AllocateAddress(instId, "", addr, "foo", "bar")
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = env.ReleaseAddress(instId, "", addr, "", "")
+	err = env.ReleaseAddress(instId, "", addr, "")
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Releasing a second time tests that the first call actually released
 	// it plus tests the error handling of ReleaseAddress
-	err = env.ReleaseAddress(instId, "", addr, "", "")
+	err = env.ReleaseAddress(instId, "", addr, "")
 	msg := fmt.Sprintf(`failed to release address "8\.0\.0\.4" from instance %q.*`, instId)
 	c.Assert(err, gc.ErrorMatches, msg)
 }
@@ -947,7 +947,7 @@ func (t *localServerSuite) TestReleaseAddressUnknownInstance(c *gc.C) {
 	// We should be able to release an address with an unknown instance id
 	// without it being allocated.
 	addr := network.Address{Value: "8.0.0.4"}
-	err := env.ReleaseAddress(instance.UnknownId, "", addr, "", "")
+	err := env.ReleaseAddress(instance.UnknownId, "", addr, "")
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -1115,7 +1115,7 @@ func (t *localServerSuite) TestAllocateAddressWithNoFeatureFlag(c *gc.C) {
 func (t *localServerSuite) TestReleaseAddressWithNoFeatureFlag(c *gc.C) {
 	t.SetFeatureFlags() // clear the flags.
 	env := t.prepareEnviron(c)
-	err := env.ReleaseAddress("i-foo", "net1", network.NewAddress("1.2.3.4"), "", "")
+	err := env.ReleaseAddress("i-foo", "net1", network.NewAddress("1.2.3.4"), "")
 	c.Assert(err, gc.ErrorMatches, "address allocation not supported")
 	c.Assert(err, jc.Satisfies, errors.IsNotSupported)
 }

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -116,7 +116,7 @@ func reserveIPAddressOnDevice(devices gomaasapi.MAASObject, deviceId string, add
 			// We only need the first address, but we're logging all we got.
 			firstAddress = network.NewAddress(value)
 		}
-		logger.Debugf("reserved address %q for device %q", value, deviceId)
+		logger.Debugf("reserved address %q for device %q", value)
 	}
 	return firstAddress, nil
 }

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -76,9 +76,7 @@ func reserveIPAddress(ipaddresses gomaasapi.MAASObject, cidr string, addr networ
 func reserveIPAddressOnDevice(devices gomaasapi.MAASObject, deviceId string, addr network.Address) error {
 	device := devices.GetSubObject(deviceId)
 	params := url.Values{}
-	if addr.Value != "" {
-		params.Add("requested_address", addr.Value)
-	}
+	params.Add("requested_address", addr.Value)
 	_, err := device.CallPost("claim_sticky_ip_address", params)
 	return err
 
@@ -111,10 +109,6 @@ type maasEnviron struct {
 
 	availabilityZonesMutex sync.Mutex
 	availabilityZones      []common.AvailabilityZone
-
-	// The following are initialized from the discovered MAAS API capabilities.
-	supportsDevices   bool
-	supportsStaticIPs bool
 }
 
 var _ environs.Environ = (*maasEnviron)(nil)
@@ -127,28 +121,8 @@ func NewEnviron(cfg *config.Config) (*maasEnviron, error) {
 	}
 	env.name = cfg.Name()
 	env.storageUnlocked = NewStorage(env)
-
-	// Since we need to switch behavior based on the available API capabilities,
-	// get them as soon as possible and cache them.
-	capabilities, err := env.getCapabilities()
-	if err != nil {
-		logger.Warningf("cannot get MAAS API capabilities: %v", err)
-	}
-	logger.Debugf("MAAS API capabilities: %v", capabilities.SortedValues())
-	env.supportsDevices = capabilities.Contains(capDevices)
-	env.supportsStaticIPs = capabilities.Contains(capStaticIPAddresses)
 	return env, nil
 }
-
-const noDevicesWarning = `
-WARNING: Using MAAS version older than 1.8.2: devices API support not detected!
-
-Juju cannot guarantee resources allocated to containers, like DHCP
-leases or static IP addresses will be properly cleaned up when the
-container, its host, or the environment is destroyed.
-
-Juju recommends upgrading MAAS to version 1.8.2 or later.
-`
 
 // Bootstrap is specified in the Environ interface.
 func (env *maasEnviron) Bootstrap(ctx environs.BootstrapContext, args environs.BootstrapParams) (arch, series string, _ environs.BootstrapFinalizer, _ error) {
@@ -162,11 +136,6 @@ func (env *maasEnviron) Bootstrap(ctx environs.BootstrapContext, args environs.B
 			instancecfg.DefaultBridgeName,
 		)
 		args.ContainerBridgeName = instancecfg.DefaultBridgeName
-
-		if !env.supportsDevices {
-			// Inform the user container resources might leak.
-			ctx.Infof("WARNING: %s", noDevicesWarning)
-		}
 	} else {
 		logger.Debugf(
 			"address allocation feature enabled; using static IPs for containers: %q",
@@ -278,14 +247,14 @@ func (env *maasEnviron) SupportsSpaces() (bool, error) {
 // SupportsAddressAllocation is specified on environs.Networking.
 func (env *maasEnviron) SupportsAddressAllocation(_ network.Id) (bool, error) {
 	if !environs.AddressAllocationEnabled() {
-		if !env.supportsDevices {
-			return false, errors.NotSupportedf("address allocation")
-		}
-		// We can use devices for DHCP-allocated container IPs.
-		return true, nil
+		return false, errors.NotSupportedf("address allocation")
 	}
 
-	return env.supportsStaticIPs, nil
+	caps, err := env.getCapabilities()
+	if err != nil {
+		return false, errors.Annotatef(err, "getCapabilities failed")
+	}
+	return caps.Contains(capStaticIPAddresses), nil
 }
 
 // allBootImages queries MAAS for all of the boot-images across
@@ -566,6 +535,14 @@ const (
 	capStaticIPAddresses  = "static-ipaddresses"
 	capDevices            = "devices-management"
 )
+
+func (env *maasEnviron) supportsDevices() (bool, error) {
+	caps, err := env.getCapabilities()
+	if err != nil {
+		return false, errors.Trace(err)
+	}
+	return caps.Contains(capDevices), nil
+}
 
 // getCapabilities asks the MAAS server for its capabilities, if
 // supported by the server.
@@ -1369,22 +1346,16 @@ func (environ *maasEnviron) newDevice(macAddress string, instId instance.Id, hos
 	if err != nil {
 		return "", errors.Trace(err)
 	}
-	logger.Tracef("created device %q", device)
 	return device, nil
 }
 
-// fetchFullDevice fetches an existing device Id associated with a MAC address
-// and/or hostname, or returns an error if there is no device.
-func (environ *maasEnviron) fetchFullDevice(macAddress, hostname string) (map[string]gomaasapi.JSONObject, error) {
+// fetchFullDevice fetches an existing device Id associated with a MAC address, or
+// returns an error if there is no device.
+func (environ *maasEnviron) fetchFullDevice(macAddress string) (map[string]gomaasapi.JSONObject, error) {
 	client := environ.getMAASClient()
 	devices := client.GetSubObject("devices")
 	params := url.Values{}
-	if macAddress != "" {
-		params.Add("mac_address", macAddress)
-	}
-	if hostname != "" {
-		params.Add("hostname", hostname)
-	}
+	params.Add("mac_address", macAddress)
 	result, err := devices.CallGet("list", params)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -1394,7 +1365,7 @@ func (environ *maasEnviron) fetchFullDevice(macAddress, hostname string) (map[st
 		return nil, errors.Trace(err)
 	}
 	if len(resultArray) == 0 {
-		return nil, errors.NotFoundf("no device for MAC %q and/or hostname %q", macAddress, hostname)
+		return nil, errors.NotFoundf("no device for MAC %q", macAddress)
 	}
 	if len(resultArray) != 1 {
 		return nil, errors.Errorf("unexpected response, expected 1 device got %d", len(resultArray))
@@ -1403,12 +1374,11 @@ func (environ *maasEnviron) fetchFullDevice(macAddress, hostname string) (map[st
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	logger.Tracef("device found as %+v", resultMap)
 	return resultMap, nil
 }
 
-func (environ *maasEnviron) fetchDevice(macAddress, hostname string) (string, error) {
-	deviceMap, err := environ.fetchFullDevice(macAddress, hostname)
+func (environ *maasEnviron) fetchDevice(macAddress string) (string, error) {
+	deviceMap, err := environ.fetchFullDevice(macAddress)
 	if err != nil {
 		return "", errors.Trace(err)
 	}
@@ -1423,7 +1393,7 @@ func (environ *maasEnviron) fetchDevice(macAddress, hostname string) (string, er
 // createOrFetchDevice returns a device Id associated with a MAC address. If
 // there is not already one it will create one.
 func (environ *maasEnviron) createOrFetchDevice(macAddress string, instId instance.Id, hostname string) (string, error) {
-	device, err := environ.fetchDevice(macAddress, hostname)
+	device, err := environ.fetchDevice(macAddress)
 	if err == nil {
 		return device, nil
 	}
@@ -1440,45 +1410,18 @@ func (environ *maasEnviron) createOrFetchDevice(macAddress string, instId instan
 // AllocateAddress requests an address to be allocated for the
 // given instance on the given network.
 func (environ *maasEnviron) AllocateAddress(instId instance.Id, subnetId network.Id, addr network.Address, macAddress, hostname string) (err error) {
-	logger.Tracef(
-		"AllocateAddress for instId %q, subnet %q, addr %q, MAC %q, hostname %q",
-		instId, subnetId, addr, macAddress, hostname,
-	)
-
 	if !environs.AddressAllocationEnabled() {
-		if !environ.supportsDevices {
-			logger.Warningf(
-				"resources used by container %q with MAC address %q can leak: devices API not supported",
-				hostname, macAddress,
-			)
-			return errors.NotSupportedf("address allocation")
-		}
-		logger.Tracef("creating device for container %q with MAC %q", hostname, macAddress)
-		deviceID, err := environ.createOrFetchDevice(macAddress, instId, hostname)
-		if err != nil {
-			return errors.Annotatef(
-				err,
-				"creating MAAS device for container %q with MAC address %q",
-				hostname, macAddress,
-			)
-		}
-		logger.Infof(
-			"created device %q for container %q with MAC address %q on parent node %q",
-			deviceID, hostname, macAddress, instId,
-		)
-		devices := environ.getMAASClient().GetSubObject("devices")
-		if err := reserveIPAddressOnDevice(devices, deviceID, network.Address{}); err != nil {
-			return errors.Annotatef(err, "reserving a sticky IP address for device %q", deviceID)
-		}
-		logger.Infof("reserved sticky IP address for device %q representing container %q", deviceID, hostname)
-
-		return nil
+		return errors.NotSupportedf("address allocation")
 	}
 	defer errors.DeferredAnnotatef(&err, "failed to allocate address %q for instance %q", addr, instId)
 
 	client := environ.getMAASClient()
 	var maasErr gomaasapi.ServerError
-	if environ.supportsDevices {
+	supportsDevices, err := environ.supportsDevices()
+	if err != nil {
+		return err
+	}
+	if supportsDevices {
 		device, err := environ.createOrFetchDevice(macAddress, instId, hostname)
 		if err != nil {
 			return err
@@ -1545,47 +1488,23 @@ func (environ *maasEnviron) AllocateAddress(instId instance.Id, subnetId network
 
 // ReleaseAddress releases a specific address previously allocated with
 // AllocateAddress.
-func (environ *maasEnviron) ReleaseAddress(instId instance.Id, _ network.Id, addr network.Address, macAddress, hostname string) (err error) {
+func (environ *maasEnviron) ReleaseAddress(instId instance.Id, _ network.Id, addr network.Address, macAddress string) (err error) {
 	if !environs.AddressAllocationEnabled() {
-		if !environ.supportsDevices {
-			logger.Warningf(
-				"resources used by container %q with MAC address %q can leak: devices API not supported",
-				hostname, macAddress,
-			)
-			return errors.NotSupportedf("address allocation")
-		}
-		logger.Tracef("getting device ID for container %q with MAC %q", macAddress, hostname)
-		deviceID, err := environ.fetchDevice(macAddress, hostname)
-		if err != nil {
-			return errors.Annotatef(
-				err,
-				"getting MAAS device for container %q with MAC address %q",
-				hostname, macAddress,
-			)
-		}
-		logger.Tracef("deleting device %q for container %q", deviceID, hostname)
-		apiDevice := environ.getMAASClient().GetSubObject("devices").GetSubObject(deviceID)
-		if err := apiDevice.Delete(); err != nil {
-			return errors.Annotatef(
-				err,
-				"deleting MAAS device %q for container %q with MAC address %q",
-				deviceID, instId, macAddress,
-			)
-		}
-		logger.Debugf("deleted device %q for container %q with MAC address %q", deviceID, instId, macAddress)
-		return nil
+		return errors.NotSupportedf("address allocation")
 	}
 
 	defer errors.DeferredAnnotatef(&err, "failed to release IP address %q from instance %q", addr, instId)
 
-	logger.Infof(
-		"releasing address: %q, MAC address: %q, hostname: %q, supports devices: %v",
-		addr, macAddress, hostname, environ.supportsDevices,
-	)
+	supportsDevices, err := environ.supportsDevices()
+	if err != nil {
+		return err
+	}
+
+	logger.Infof("releasing address: %q, MAC address: %q, supports devices: %v", addr, macAddress, supportsDevices)
 	// Addresses originally allocated without a device will have macAddress
 	// set to "". We shouldn't look for a device for these addresses.
-	if environ.supportsDevices && macAddress != "" {
-		device, err := environ.fetchFullDevice(macAddress, hostname)
+	if supportsDevices && macAddress != "" {
+		device, err := environ.fetchFullDevice(macAddress)
 		if err == nil {
 			addresses, err := device["ip_addresses"].GetArray()
 			if err != nil {
@@ -1840,11 +1759,6 @@ func (environ *maasEnviron) Destroy() error {
 			"If the environment is still running, please manually decomission the MAAS machines.")
 		return errors.New("unsafe destruction")
 	}
-	if !environ.supportsDevices {
-		// Warn the user that container resources can leak.
-		logger.Warningf(noDevicesWarning)
-	}
-
 	if err := common.Destroy(environ); err != nil {
 		return errors.Trace(err)
 	}

--- a/provider/maas/environ_whitebox_test.go
+++ b/provider/maas/environ_whitebox_test.go
@@ -554,35 +554,16 @@ func (suite *environSuite) getInstance(systemId string) *maasInstance {
 	return &maasInstance{maasObject: &node, environ: suite.makeEnviron()}
 }
 
-func (suite *environSuite) newNetwork(name string, id int, vlanTag int, defaultGateway string) *gomaasapi.MAASObject {
+func (suite *environSuite) getNetwork(name string, id int, vlanTag int) *gomaasapi.MAASObject {
 	var vlan string
 	if vlanTag == 0 {
 		vlan = "null"
 	} else {
 		vlan = fmt.Sprintf("%d", vlanTag)
 	}
-
-	if defaultGateway != "null" {
-		/// since we use %s below only "null" (if passed) should remain unquoted.
-		defaultGateway = fmt.Sprintf("%q", defaultGateway)
-	}
-
-	// TODO(dimitern): Use JSON tags on structs, JSON encoder, or at least
-	// text/template below and in similar cases.
-	input := fmt.Sprintf(`{
-		"name": %q,
-		"ip":"192.168.%d.2",
-		"netmask": "255.255.255.0",
-		"vlan_tag": %s,
-		"description": "%s_%d_%d",
-		"default_gateway": %s
-	}`,
-		name,
-		id,
-		vlan,
-		name, id, vlanTag,
-		defaultGateway,
-	)
+	var input string
+	input = fmt.Sprintf(`{"name": %q, "ip":"192.168.%d.1", "netmask": "255.255.255.0",`+
+		`"vlan_tag": %s, "description": "%s_%d_%d" }`, name, id, vlan, name, id, vlanTag)
 	network := suite.testMAASObject.TestServer.NewNetwork(input)
 	return &network
 }
@@ -870,19 +851,15 @@ func (suite *environSuite) TestGetNetworkMACs(c *gc.C) {
 }
 
 func (suite *environSuite) TestGetInstanceNetworks(c *gc.C) {
-	suite.newNetwork("test_network", 123, 321, "null")
+	suite.getNetwork("test_network", 123, 321)
 	testInstance := suite.getInstance("instance_for_network")
 	suite.testMAASObject.TestServer.ConnectNodeToNetwork("instance_for_network", "test_network")
 	networks, err := suite.makeEnviron().getInstanceNetworks(testInstance)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Check(networks, jc.DeepEquals, []networkDetails{{
-		Name:           "test_network",
-		IP:             "192.168.123.2",
-		Mask:           "255.255.255.0",
-		VLANTag:        321,
-		Description:    "test_network_123_321",
-		DefaultGateway: "", // "null" and "" are treated as N/A.
-	}})
+	c.Check(networks, gc.DeepEquals, []networkDetails{
+		{Name: "test_network", IP: "192.168.123.1", Mask: "255.255.255.0", VLANTag: 321,
+			Description: "test_network_123_321"},
+	})
 }
 
 // A typical lshw XML dump with lots of things left out.
@@ -1000,11 +977,11 @@ func (suite *environSuite) TestSetupNetworks(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	suite.testMAASObject.TestServer.AddNodeDetails("node1", lshwXML)
-	suite.newNetwork("LAN", 2, 42, "null")
+	suite.getNetwork("LAN", 2, 42)
 	suite.testMAASObject.TestServer.ConnectNodeToNetworkWithMACAddress("node1", "LAN", "aa:bb:cc:dd:ee:f1")
-	suite.newNetwork("Virt", 3, 0, "0.1.2.3") // primary + gateway
+	suite.getNetwork("Virt", 3, 0)
 	suite.testMAASObject.TestServer.ConnectNodeToNetworkWithMACAddress("node1", "Virt", "aa:bb:cc:dd:ee:f2")
-	suite.newNetwork("WLAN", 1, 0, "") // "" same as "null" for gateway
+	suite.getNetwork("WLAN", 1, 0)
 	suite.testMAASObject.TestServer.ConnectNodeToNetworkWithMACAddress("node1", "WLAN", "aa:bb:cc:dd:ee:ff")
 	networkInfo, primaryIface, err := suite.makeEnviron().setupNetworks(
 		testInstance,
@@ -1022,7 +999,7 @@ func (suite *environSuite) TestSetupNetworks(c *gc.C) {
 		case 0:
 			c.Check(info, jc.DeepEquals, network.InterfaceInfo{
 				MACAddress:    "aa:bb:cc:dd:ee:ff",
-				CIDR:          "192.168.1.2/24",
+				CIDR:          "192.168.1.1/24",
 				NetworkName:   "WLAN",
 				ProviderId:    "WLAN",
 				VLANTag:       0,
@@ -1034,7 +1011,7 @@ func (suite *environSuite) TestSetupNetworks(c *gc.C) {
 			c.Check(info, jc.DeepEquals, network.InterfaceInfo{
 				DeviceIndex:   1,
 				MACAddress:    "aa:bb:cc:dd:ee:f1",
-				CIDR:          "192.168.2.2/24",
+				CIDR:          "192.168.2.1/24",
 				NetworkName:   "LAN",
 				ProviderId:    "LAN",
 				VLANTag:       42,
@@ -1043,15 +1020,14 @@ func (suite *environSuite) TestSetupNetworks(c *gc.C) {
 			})
 		case 2:
 			c.Check(info, jc.DeepEquals, network.InterfaceInfo{
-				MACAddress:     "aa:bb:cc:dd:ee:f2",
-				CIDR:           "192.168.3.2/24",
-				NetworkName:    "Virt",
-				ProviderId:     "Virt",
-				VLANTag:        0,
-				DeviceIndex:    2,
-				InterfaceName:  "vnet1",
-				Disabled:       false,
-				GatewayAddress: network.NewAddress("0.1.2.3"), // from newNetwork("Virt", 3, 0, "0.1.2.3")
+				MACAddress:    "aa:bb:cc:dd:ee:f2",
+				CIDR:          "192.168.3.1/24",
+				NetworkName:   "Virt",
+				ProviderId:    "Virt",
+				VLANTag:       0,
+				DeviceIndex:   2,
+				InterfaceName: "vnet1",
+				Disabled:      false,
 			})
 		}
 	}
@@ -1069,9 +1045,9 @@ func (suite *environSuite) TestSetupNetworksPartialMatch(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	suite.testMAASObject.TestServer.AddNodeDetails("node1", lshwXML)
-	suite.newNetwork("LAN", 2, 42, "192.168.2.1")
+	suite.getNetwork("LAN", 2, 42)
 	suite.testMAASObject.TestServer.ConnectNodeToNetworkWithMACAddress("node1", "LAN", "aa:bb:cc:dd:ee:f1")
-	suite.newNetwork("Virt", 3, 0, "")
+	suite.getNetwork("Virt", 3, 0)
 	suite.testMAASObject.TestServer.ConnectNodeToNetworkWithMACAddress("node1", "Virt", "aa:bb:cc:dd:ee:f3")
 	networkInfo, primaryIface, err := suite.makeEnviron().setupNetworks(
 		testInstance,
@@ -1082,15 +1058,14 @@ func (suite *environSuite) TestSetupNetworksPartialMatch(c *gc.C) {
 	// Note: order of networks is based on lshwXML
 	c.Check(primaryIface, gc.Equals, "eth0")
 	c.Check(networkInfo, jc.DeepEquals, []network.InterfaceInfo{{
-		MACAddress:     "aa:bb:cc:dd:ee:f1",
-		CIDR:           "192.168.2.2/24",
-		NetworkName:    "LAN",
-		ProviderId:     "LAN",
-		VLANTag:        42,
-		DeviceIndex:    1,
-		InterfaceName:  "eth0",
-		Disabled:       false,
-		GatewayAddress: network.NewAddress("192.168.2.1"),
+		MACAddress:    "aa:bb:cc:dd:ee:f1",
+		CIDR:          "192.168.2.1/24",
+		NetworkName:   "LAN",
+		ProviderId:    "LAN",
+		VLANTag:       42,
+		DeviceIndex:   1,
+		InterfaceName: "eth0",
+		Disabled:      false,
 	}})
 }
 
@@ -1106,7 +1081,7 @@ func (suite *environSuite) TestSetupNetworksNoMatch(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	suite.testMAASObject.TestServer.AddNodeDetails("node1", lshwXML)
-	suite.newNetwork("Virt", 3, 0, "")
+	suite.getNetwork("Virt", 3, 0)
 	suite.testMAASObject.TestServer.ConnectNodeToNetworkWithMACAddress("node1", "Virt", "aa:bb:cc:dd:ee:f3")
 	networkInfo, primaryIface, err := suite.makeEnviron().setupNetworks(
 		testInstance,
@@ -1134,7 +1109,6 @@ func (suite *environSuite) TestSupportsAddressAllocation(c *gc.C) {
 
 func (suite *environSuite) createSubnets(c *gc.C, duplicates bool) instance.Instance {
 	testInstance := suite.getInstance("node1")
-	testServer := suite.testMAASObject.TestServer
 	templateInterfaces := map[string]ifaceInfo{
 		"aa:bb:cc:dd:ee:ff": {0, "wlan0", true},
 		"aa:bb:cc:dd:ee:f1": {1, "eth0", false},
@@ -1147,24 +1121,24 @@ func (suite *environSuite) createSubnets(c *gc.C, duplicates bool) instance.Inst
 	lshwXML, err := suite.generateHWTemplate(templateInterfaces)
 	c.Assert(err, jc.ErrorIsNil)
 
-	testServer.AddNodeDetails("node1", lshwXML)
-	// resulting CIDR 192.168.2.2/24
-	suite.newNetwork("LAN", 2, 42, "192.168.2.1") // primary + gateway
-	testServer.ConnectNodeToNetworkWithMACAddress("node1", "LAN", "aa:bb:cc:dd:ee:f1")
-	// resulting CIDR 192.168.3.2/24
-	suite.newNetwork("Virt", 3, 0, "")
-	testServer.ConnectNodeToNetworkWithMACAddress("node1", "Virt", "aa:bb:cc:dd:ee:f2")
-	// resulting CIDR 192.168.1.2/24
-	suite.newNetwork("WLAN", 1, 0, "")
-	testServer.ConnectNodeToNetworkWithMACAddress("node1", "WLAN", "aa:bb:cc:dd:ee:ff")
+	suite.testMAASObject.TestServer.AddNodeDetails("node1", lshwXML)
+	// resulting CIDR 192.168.2.1/24
+	suite.getNetwork("LAN", 2, 42)
+	suite.testMAASObject.TestServer.ConnectNodeToNetworkWithMACAddress("node1", "LAN", "aa:bb:cc:dd:ee:f1")
+	// resulting CIDR 192.168.3.1/24
+	suite.getNetwork("Virt", 3, 0)
+	suite.testMAASObject.TestServer.ConnectNodeToNetworkWithMACAddress("node1", "Virt", "aa:bb:cc:dd:ee:f2")
+	// resulting CIDR 192.168.1.1/24
+	suite.getNetwork("WLAN", 1, 0)
+	suite.testMAASObject.TestServer.ConnectNodeToNetworkWithMACAddress("node1", "WLAN", "aa:bb:cc:dd:ee:ff")
 	if duplicates {
-		testServer.ConnectNodeToNetworkWithMACAddress("node1", "LAN", "aa:bb:cc:dd:ee:f3")
-		testServer.ConnectNodeToNetworkWithMACAddress("node1", "Virt", "aa:bb:cc:dd:ee:f4")
+		suite.testMAASObject.TestServer.ConnectNodeToNetworkWithMACAddress("node1", "LAN", "aa:bb:cc:dd:ee:f3")
+		suite.testMAASObject.TestServer.ConnectNodeToNetworkWithMACAddress("node1", "Virt", "aa:bb:cc:dd:ee:f4")
 	}
 
 	// needed for getNodeGroups to work
-	testServer.AddBootImage("uuid-0", `{"architecture": "amd64", "release": "precise"}`)
-	testServer.AddBootImage("uuid-1", `{"architecture": "amd64", "release": "precise"}`)
+	suite.testMAASObject.TestServer.AddBootImage("uuid-0", `{"architecture": "amd64", "release": "precise"}`)
+	suite.testMAASObject.TestServer.AddBootImage("uuid-1", `{"architecture": "amd64", "release": "precise"}`)
 
 	jsonText1 := `{
 		"ip_range_high":        "192.168.2.255",
@@ -1214,10 +1188,10 @@ func (suite *environSuite) createSubnets(c *gc.C, duplicates bool) instance.Inst
 		"static_ip_range_high": "172.16.8.255",
 		"interface":            "eth3"
 	}`
-	testServer.NewNodegroupInterface("uuid-0", jsonText1)
-	testServer.NewNodegroupInterface("uuid-0", jsonText2)
-	testServer.NewNodegroupInterface("uuid-1", jsonText3)
-	testServer.NewNodegroupInterface("uuid-1", jsonText4)
+	suite.testMAASObject.TestServer.NewNodegroupInterface("uuid-0", jsonText1)
+	suite.testMAASObject.TestServer.NewNodegroupInterface("uuid-0", jsonText2)
+	suite.testMAASObject.TestServer.NewNodegroupInterface("uuid-1", jsonText3)
+	suite.testMAASObject.TestServer.NewNodegroupInterface("uuid-1", jsonText4)
 	return testInstance
 }
 
@@ -1230,7 +1204,7 @@ func (suite *environSuite) TestNetworkInterfaces(c *gc.C) {
 	expectedInfo := []network.InterfaceInfo{{
 		DeviceIndex:      0,
 		MACAddress:       "aa:bb:cc:dd:ee:ff",
-		CIDR:             "192.168.1.2/24",
+		CIDR:             "192.168.1.1/24",
 		ProviderSubnetId: "WLAN",
 		VLANTag:          0,
 		InterfaceName:    "wlan0",
@@ -1239,11 +1213,11 @@ func (suite *environSuite) TestNetworkInterfaces(c *gc.C) {
 		ConfigType:       network.ConfigDHCP,
 		ExtraConfig:      nil,
 		GatewayAddress:   network.Address{},
-		Address:          network.NewScopedAddress("192.168.1.2", network.ScopeCloudLocal),
+		Address:          network.NewScopedAddress("192.168.1.1", network.ScopeCloudLocal),
 	}, {
 		DeviceIndex:      1,
 		MACAddress:       "aa:bb:cc:dd:ee:f1",
-		CIDR:             "192.168.2.2/24",
+		CIDR:             "192.168.2.1/24",
 		ProviderSubnetId: "LAN",
 		VLANTag:          42,
 		InterfaceName:    "eth0",
@@ -1251,12 +1225,12 @@ func (suite *environSuite) TestNetworkInterfaces(c *gc.C) {
 		NoAutoStart:      false,
 		ConfigType:       network.ConfigDHCP,
 		ExtraConfig:      nil,
-		GatewayAddress:   network.NewScopedAddress("192.168.2.1", network.ScopeCloudLocal),
-		Address:          network.NewScopedAddress("192.168.2.2", network.ScopeCloudLocal),
+		GatewayAddress:   network.Address{},
+		Address:          network.NewScopedAddress("192.168.2.1", network.ScopeCloudLocal),
 	}, {
 		DeviceIndex:      2,
 		MACAddress:       "aa:bb:cc:dd:ee:f2",
-		CIDR:             "192.168.3.2/24",
+		CIDR:             "192.168.3.1/24",
 		ProviderSubnetId: "Virt",
 		VLANTag:          0,
 		InterfaceName:    "vnet1",
@@ -1265,7 +1239,7 @@ func (suite *environSuite) TestNetworkInterfaces(c *gc.C) {
 		ConfigType:       network.ConfigDHCP,
 		ExtraConfig:      nil,
 		GatewayAddress:   network.Address{},
-		Address:          network.NewScopedAddress("192.168.3.2", network.ScopeCloudLocal),
+		Address:          network.NewScopedAddress("192.168.3.1", network.ScopeCloudLocal),
 	}}
 	network.SortInterfaceInfo(netInfo)
 	c.Assert(netInfo, jc.DeepEquals, expectedInfo)
@@ -1277,25 +1251,10 @@ func (suite *environSuite) TestSubnets(c *gc.C) {
 	netInfo, err := suite.makeEnviron().Subnets(testInstance.Id(), []network.Id{"LAN", "Virt", "WLAN"})
 	c.Assert(err, jc.ErrorIsNil)
 
-	expectedInfo := []network.SubnetInfo{{
-		CIDR:              "192.168.2.2/24",
-		ProviderId:        "LAN",
-		VLANTag:           42,
-		AllocatableIPLow:  net.ParseIP("192.168.2.0"),
-		AllocatableIPHigh: net.ParseIP("192.168.2.127"),
-	}, {
-		CIDR:              "192.168.3.2/24",
-		ProviderId:        "Virt",
-		VLANTag:           0,
-		AllocatableIPLow:  nil,
-		AllocatableIPHigh: nil,
-	}, {
-		CIDR:              "192.168.1.2/24",
-		ProviderId:        "WLAN",
-		VLANTag:           0,
-		AllocatableIPLow:  net.ParseIP("192.168.1.129"),
-		AllocatableIPHigh: net.ParseIP("192.168.1.255"),
-	}}
+	expectedInfo := []network.SubnetInfo{
+		{CIDR: "192.168.2.1/24", ProviderId: "LAN", VLANTag: 42, AllocatableIPLow: net.ParseIP("192.168.2.0"), AllocatableIPHigh: net.ParseIP("192.168.2.127")},
+		{CIDR: "192.168.3.1/24", ProviderId: "Virt", VLANTag: 0},
+		{CIDR: "192.168.1.1/24", ProviderId: "WLAN", VLANTag: 0, AllocatableIPLow: net.ParseIP("192.168.1.129"), AllocatableIPHigh: net.ParseIP("192.168.1.255")}}
 	c.Assert(netInfo, jc.DeepEquals, expectedInfo)
 }
 
@@ -1317,25 +1276,10 @@ func (suite *environSuite) TestSubnetsNoDuplicates(c *gc.C) {
 	netInfo, err := suite.makeEnviron().Subnets(testInstance.Id(), []network.Id{"LAN", "Virt", "WLAN"})
 	c.Assert(err, jc.ErrorIsNil)
 
-	expectedInfo := []network.SubnetInfo{{
-		CIDR:              "192.168.2.2/24",
-		ProviderId:        "LAN",
-		VLANTag:           42,
-		AllocatableIPLow:  net.ParseIP("192.168.2.0"),
-		AllocatableIPHigh: net.ParseIP("192.168.2.127"),
-	}, {
-		CIDR:              "192.168.3.2/24",
-		ProviderId:        "Virt",
-		VLANTag:           0,
-		AllocatableIPLow:  nil,
-		AllocatableIPHigh: nil,
-	}, {
-		CIDR:              "192.168.1.2/24",
-		ProviderId:        "WLAN",
-		VLANTag:           0,
-		AllocatableIPLow:  net.ParseIP("192.168.1.129"),
-		AllocatableIPHigh: net.ParseIP("192.168.1.255"),
-	}}
+	expectedInfo := []network.SubnetInfo{
+		{CIDR: "192.168.2.1/24", ProviderId: "LAN", VLANTag: 42, AllocatableIPLow: net.ParseIP("192.168.2.0"), AllocatableIPHigh: net.ParseIP("192.168.2.127")},
+		{CIDR: "192.168.3.1/24", ProviderId: "Virt", VLANTag: 0},
+		{CIDR: "192.168.1.1/24", ProviderId: "WLAN", VLANTag: 0, AllocatableIPLow: net.ParseIP("192.168.1.129"), AllocatableIPHigh: net.ParseIP("192.168.1.255")}}
 	c.Assert(netInfo, jc.DeepEquals, expectedInfo)
 }
 
@@ -1345,7 +1289,7 @@ func (suite *environSuite) TestAllocateAddress(c *gc.C) {
 
 	// note that the default test server always succeeds if we provide a
 	// valid instance id and net id
-	err := env.AllocateAddress(testInstance.Id(), "LAN", &network.Address{Value: "192.168.2.1"}, "foo", "bar")
+	err := env.AllocateAddress(testInstance.Id(), "LAN", network.Address{Value: "192.168.2.1"}, "foo", "bar")
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -1354,37 +1298,9 @@ func (suite *environSuite) TestAllocateAddressDevices(c *gc.C) {
 	testInstance := suite.createSubnets(c, false)
 	env := suite.makeEnviron()
 
-	// Work around the lack of support for devices PUT and POST without hostname
-	// set in gomaasapi's testservices
-	newParams := func(macAddress string, instId instance.Id, hostnameSuffix string) url.Values {
-		c.Check(macAddress, gc.Equals, "aa:bb:cc:dd:ee:f0") // passed to AllocateAddress() below
-		c.Check(instId, gc.Equals, testInstance.Id())
-		c.Check(hostnameSuffix, gc.Equals, "juju-machine-0-kvm-5") // passed to AllocateAddress() below
-		params := make(url.Values)
-		params.Add("mac_addresses", macAddress)
-		params.Add("hostname", "auto-generated.maas")
-		params.Add("parent", extractSystemId(instId))
-		return params
-	}
-	suite.PatchValue(&NewDeviceParams, newParams)
-	updateHostname := func(client *gomaasapi.MAASObject, deviceID, deviceHostname, hostnameSuffix string) (string, error) {
-		c.Check(client, gc.NotNil)
-		c.Check(deviceID, gc.Matches, `node-[0-9a-f-]+`)
-		c.Check(deviceHostname, gc.Equals, "auto-generated.maas")  // "generated" above in NewDeviceParams()
-		c.Check(hostnameSuffix, gc.Equals, "juju-machine-0-kvm-5") // passed to AllocateAddress() below
-		return "auto-generated-juju-lxc.maas", nil
-	}
-	suite.PatchValue(&UpdateDeviceHostname, updateHostname)
-
 	// note that the default test server always succeeds if we provide a
 	// valid instance id and net id
-	err := env.AllocateAddress(
-		testInstance.Id(),
-		"LAN",
-		&network.Address{Value: "192.168.2.1"},
-		"aa:bb:cc:dd:ee:f0",
-		"juju-machine-0-kvm-5",
-	)
+	err := env.AllocateAddress(testInstance.Id(), "LAN", network.Address{Value: "192.168.2.1"}, "foo", "bar")
 	c.Assert(err, jc.ErrorIsNil)
 
 	devicesArray := suite.getDeviceArray(c)
@@ -1395,7 +1311,7 @@ func (suite *environSuite) TestAllocateAddressDevices(c *gc.C) {
 
 	hostname, err := device["hostname"].GetString()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(hostname, gc.Equals, "auto-generated.maas")
+	c.Assert(hostname, gc.Equals, "bar")
 
 	parent, err := device["parent"].GetString()
 	c.Assert(err, jc.ErrorIsNil)
@@ -1418,72 +1334,7 @@ func (suite *environSuite) TestAllocateAddressDevices(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	mac, err := macMap["mac_address"].GetString()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(mac, gc.Equals, "aa:bb:cc:dd:ee:f0")
-}
-
-func (suite *environSuite) TestTransformDeviceHostname(c *gc.C) {
-	for i, test := range []struct {
-		deviceHostname string
-		hostnameSuffix string
-
-		expectedOutput string
-		expectedError  string
-	}{{
-		deviceHostname: "shiny-town.maas",
-		hostnameSuffix: "juju-machine-1-lxc-2",
-		expectedOutput: "shiny-town-juju-machine-1-lxc-2.maas",
-	}, {
-		deviceHostname: "foo.subdomain.example.com",
-		hostnameSuffix: "suffix",
-		expectedOutput: "foo-suffix.subdomain.example.com",
-	}, {
-		deviceHostname: "bad-food.example.com",
-		hostnameSuffix: "suffix.example.org",
-		expectedOutput: "bad-food-suffix.example.org.example.com",
-	}, {
-		deviceHostname: "strangers-and.freaks",
-		hostnameSuffix: "just-this",
-		expectedOutput: "strangers-and-just-this.freaks",
-	}, {
-		deviceHostname: "no-dot-hostname",
-		hostnameSuffix: "anything",
-		expectedError:  `unexpected device "dev-id" hostname "no-dot-hostname"`,
-	}, {
-		deviceHostname: "anything",
-		hostnameSuffix: "",
-		expectedError:  "hostname suffix cannot be empty",
-	}} {
-		c.Logf(
-			"test #%d: %q + %q -> %q (err: %s)",
-			i, test.deviceHostname, test.hostnameSuffix,
-			test.expectedOutput, test.expectedError,
-		)
-		output, err := transformDeviceHostname("dev-id", test.deviceHostname, test.hostnameSuffix)
-		if test.expectedError != "" {
-			c.Check(err, gc.ErrorMatches, test.expectedError)
-			c.Check(output, gc.Equals, "")
-			continue
-		}
-		c.Check(err, jc.ErrorIsNil)
-		c.Check(output, gc.Equals, test.expectedOutput)
-	}
-}
-
-func (suite *environSuite) patchDeviceCreation() {
-	// Work around the lack of support for devices PUT and POST without hostname
-	// set in gomaasapi's testservices
-	newParams := func(macAddress string, instId instance.Id, _ string) url.Values {
-		params := make(url.Values)
-		params.Add("mac_addresses", macAddress)
-		params.Add("hostname", "auto-generated.maas")
-		params.Add("parent", extractSystemId(instId))
-		return params
-	}
-	suite.PatchValue(&NewDeviceParams, newParams)
-	updateHostname := func(_ *gomaasapi.MAASObject, _, _, _ string) (string, error) {
-		return "auto-generated-juju-lxc.maas", nil
-	}
-	suite.PatchValue(&UpdateDeviceHostname, updateHostname)
+	c.Assert(mac, gc.Equals, "foo")
 }
 
 func (suite *environSuite) TestAllocateAddressDevicesFailures(c *gc.C) {
@@ -1491,7 +1342,6 @@ func (suite *environSuite) TestAllocateAddressDevicesFailures(c *gc.C) {
 	suite.testMAASObject.TestServer.SetVersionJSON(`{"capabilities": ["devices-management"]}`)
 	testInstance := suite.createSubnets(c, false)
 	env := suite.makeEnviron()
-	suite.patchDeviceCreation()
 
 	responses := []string{
 		"claim_sticky_ip_address failed",
@@ -1500,9 +1350,8 @@ func (suite *environSuite) TestAllocateAddressDevicesFailures(c *gc.C) {
 		"unexpected ip_addresses in response",
 		"IP in ip_addresses not a string",
 	}
-	reserveIP := func(_ gomaasapi.MAASObject, deviceID, macAddress string, addr network.Address) (network.Address, error) {
-		c.Check(deviceID, gc.Matches, "node-[a-f0-9]+")
-		c.Check(macAddress, gc.Matches, "aa:bb:cc:dd:ee:f0")
+	reserveIP := func(devices gomaasapi.MAASObject, deviceId string, addr network.Address) (network.Address, error) {
+		c.Check(deviceId, gc.Matches, "node-[a-f0-9]+")
 		c.Check(addr, jc.DeepEquals, network.Address{})
 		nextError := responses[0]
 		return network.Address{}, errors.New(nextError)
@@ -1510,11 +1359,7 @@ func (suite *environSuite) TestAllocateAddressDevicesFailures(c *gc.C) {
 	suite.PatchValue(&ReserveIPAddressOnDevice, reserveIP)
 
 	for len(responses) > 0 {
-		addr := &network.Address{}
-		err := env.AllocateAddress(
-			testInstance.Id(), network.AnySubnet, addr,
-			"aa:bb:cc:dd:ee:f0", "juju-lxc",
-		)
+		err := env.AllocateAddress(testInstance.Id(), network.AnySubnet, network.Address{}, "mac-address", "hostname")
 		c.Check(err, gc.ErrorMatches, responses[0])
 		responses = responses[1:]
 	}
@@ -1541,20 +1386,14 @@ func (suite *environSuite) TestReleaseAddressDeletesDevice(c *gc.C) {
 	suite.testMAASObject.TestServer.SetVersionJSON(`{"capabilities": ["networks-management","static-ipaddresses", "devices-management"]}`)
 	testInstance := suite.createSubnets(c, false)
 	env := suite.makeEnviron()
-	suite.patchDeviceCreation()
-
 	addr := network.NewAddress("192.168.2.1")
-	err := env.AllocateAddress(testInstance.Id(), "LAN", &addr, "foo", "juju-lxc")
+	err := env.AllocateAddress(testInstance.Id(), "LAN", addr, "foo", "bar")
 	c.Assert(err, jc.ErrorIsNil)
 
 	devicesArray := suite.getDeviceArray(c)
 	c.Assert(devicesArray, gc.HasLen, 1)
 
-	// Since we're mocking out updateDeviceHostname, no need to check if the
-	// hostname was updated (only manually tested for now until we change
-	// gomaasapi).
-
-	err = env.ReleaseAddress(testInstance.Id(), "LAN", addr, "foo", "juju-lxc")
+	err = env.ReleaseAddress(testInstance.Id(), "LAN", addr, "foo", "bar")
 	c.Assert(err, jc.ErrorIsNil)
 
 	devicesArray = suite.getDeviceArray(c)
@@ -1565,7 +1404,7 @@ func (suite *environSuite) TestAllocateAddressInvalidInstance(c *gc.C) {
 	env := suite.makeEnviron()
 	addr := network.Address{Value: "192.168.2.1"}
 	instId := instance.Id("foo")
-	err := env.AllocateAddress(instId, "bar", &addr, "foo", "juju-lxc")
+	err := env.AllocateAddress(instId, "bar", addr, "foo", "bar")
 	expected := fmt.Sprintf("failed to allocate address %q for instance %q.*", addr, instId)
 	c.Assert(err, gc.ErrorMatches, expected)
 }
@@ -1573,7 +1412,7 @@ func (suite *environSuite) TestAllocateAddressInvalidInstance(c *gc.C) {
 func (suite *environSuite) TestAllocateAddressMissingSubnet(c *gc.C) {
 	testInstance := suite.createSubnets(c, false)
 	env := suite.makeEnviron()
-	err := env.AllocateAddress(testInstance.Id(), "bar", &network.Address{Value: "192.168.2.1"}, "foo", "bar")
+	err := env.AllocateAddress(testInstance.Id(), "bar", network.Address{Value: "192.168.2.1"}, "foo", "bar")
 	c.Assert(errors.Cause(err), gc.ErrorMatches, "failed to find the following subnets: \\[bar\\]")
 }
 
@@ -1587,7 +1426,7 @@ func (suite *environSuite) TestAllocateAddressIPAddressUnavailable(c *gc.C) {
 	suite.PatchValue(&ReserveIPAddress, reserveIPAddress)
 
 	ipAddress := network.Address{Value: "192.168.2.1"}
-	err := env.AllocateAddress(testInstance.Id(), "LAN", &ipAddress, "foo", "bar")
+	err := env.AllocateAddress(testInstance.Id(), "LAN", ipAddress, "foo", "bar")
 	c.Assert(errors.Cause(err), gc.Equals, environs.ErrIPAddressUnavailable)
 	expected := fmt.Sprintf("failed to allocate address %q for instance %q.*", ipAddress, testInstance.Id())
 	c.Assert(err, gc.ErrorMatches, expected)
@@ -1605,7 +1444,7 @@ func (suite *environSuite) TestReleaseAddress(c *gc.C) {
 	testInstance := suite.createSubnets(c, false)
 	env := suite.makeEnviron()
 
-	err := env.AllocateAddress(testInstance.Id(), "LAN", &network.Address{Value: "192.168.2.1"}, "foo", "bar")
+	err := env.AllocateAddress(testInstance.Id(), "LAN", network.Address{Value: "192.168.2.1"}, "foo", "bar")
 	c.Assert(err, jc.ErrorIsNil)
 
 	ipAddress := network.Address{Value: "192.168.2.1"}
@@ -1640,7 +1479,7 @@ func (suite *environSuite) TestReleaseAddressRetry(c *gc.C) {
 	testInstance := suite.createSubnets(c, false)
 	env := suite.makeEnviron()
 
-	err := env.AllocateAddress(testInstance.Id(), "LAN", &network.Address{Value: "192.168.2.1"}, "foo", "bar")
+	err := env.AllocateAddress(testInstance.Id(), "LAN", network.Address{Value: "192.168.2.1"}, "foo", "bar")
 	c.Assert(err, jc.ErrorIsNil)
 
 	// ReleaseAddress must fail with 5 retries.

--- a/provider/maas/environ_whitebox_test.go
+++ b/provider/maas/environ_whitebox_test.go
@@ -1337,34 +1337,6 @@ func (suite *environSuite) TestAllocateAddressDevices(c *gc.C) {
 	c.Assert(mac, gc.Equals, "foo")
 }
 
-func (suite *environSuite) TestAllocateAddressDevicesFailures(c *gc.C) {
-	suite.SetFeatureFlags()
-	suite.testMAASObject.TestServer.SetVersionJSON(`{"capabilities": ["devices-management"]}`)
-	testInstance := suite.createSubnets(c, false)
-	env := suite.makeEnviron()
-
-	responses := []string{
-		"claim_sticky_ip_address failed",
-		"GetMap of the response failed",
-		"no ip_addresses in response",
-		"unexpected ip_addresses in response",
-		"IP in ip_addresses not a string",
-	}
-	reserveIP := func(devices gomaasapi.MAASObject, deviceId string, addr network.Address) (network.Address, error) {
-		c.Check(deviceId, gc.Matches, "node-[a-f0-9]+")
-		c.Check(addr, jc.DeepEquals, network.Address{})
-		nextError := responses[0]
-		return network.Address{}, errors.New(nextError)
-	}
-	suite.PatchValue(&ReserveIPAddressOnDevice, reserveIP)
-
-	for len(responses) > 0 {
-		err := env.AllocateAddress(testInstance.Id(), network.AnySubnet, network.Address{}, "mac-address", "hostname")
-		c.Check(err, gc.ErrorMatches, responses[0])
-		responses = responses[1:]
-	}
-}
-
 func (suite *environSuite) getDeviceArray(c *gc.C) []gomaasapi.JSONObject {
 	devicesURL := "/api/1.0/devices/?op=list"
 	resp, err := http.Get(suite.testMAASObject.TestServer.Server.URL + devicesURL)

--- a/provider/maas/environ_whitebox_test.go
+++ b/provider/maas/environ_whitebox_test.go
@@ -1365,7 +1365,7 @@ func (suite *environSuite) TestReleaseAddressDeletesDevice(c *gc.C) {
 	devicesArray := suite.getDeviceArray(c)
 	c.Assert(devicesArray, gc.HasLen, 1)
 
-	err = env.ReleaseAddress(testInstance.Id(), "LAN", addr, "foo", "bar")
+	err = env.ReleaseAddress(testInstance.Id(), "LAN", addr, "foo")
 	c.Assert(err, jc.ErrorIsNil)
 
 	devicesArray = suite.getDeviceArray(c)
@@ -1421,13 +1421,12 @@ func (suite *environSuite) TestReleaseAddress(c *gc.C) {
 
 	ipAddress := network.Address{Value: "192.168.2.1"}
 	macAddress := "foobar"
-	hostname := "myhostname"
-	err = env.ReleaseAddress(testInstance.Id(), "bar", ipAddress, macAddress, hostname)
+	err = env.ReleaseAddress(testInstance.Id(), "bar", ipAddress, macAddress)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// by releasing again we can test that the first release worked, *and*
 	// the error handling of ReleaseError
-	err = env.ReleaseAddress(testInstance.Id(), "bar", ipAddress, macAddress, hostname)
+	err = env.ReleaseAddress(testInstance.Id(), "bar", ipAddress, macAddress)
 	expected := fmt.Sprintf("(?s).*failed to release IP address %q from instance %q.*", ipAddress, testInstance.Id())
 	c.Assert(err, gc.ErrorMatches, expected)
 }
@@ -1457,8 +1456,7 @@ func (suite *environSuite) TestReleaseAddressRetry(c *gc.C) {
 	// ReleaseAddress must fail with 5 retries.
 	ipAddress := network.Address{Value: "192.168.2.1"}
 	macAddress := "foobar"
-	hostname := "myhostname"
-	err = env.ReleaseAddress(testInstance.Id(), "bar", ipAddress, macAddress, hostname)
+	err = env.ReleaseAddress(testInstance.Id(), "bar", ipAddress, macAddress)
 	expected := fmt.Sprintf("(?s).*failed to release IP address %q from instance %q: ouch", ipAddress, testInstance.Id())
 	c.Assert(err, gc.ErrorMatches, expected)
 	c.Assert(retries, gc.Equals, 5)
@@ -1466,7 +1464,7 @@ func (suite *environSuite) TestReleaseAddressRetry(c *gc.C) {
 	// Now let it succeed after 3 retries.
 	retries = 0
 	enoughRetries = 3
-	err = env.ReleaseAddress(testInstance.Id(), "bar", ipAddress, macAddress, hostname)
+	err = env.ReleaseAddress(testInstance.Id(), "bar", ipAddress, macAddress)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(retries, gc.Equals, 3)
 }

--- a/provider/maas/maas_test.go
+++ b/provider/maas/maas_test.go
@@ -9,6 +9,7 @@ import (
 	gc "gopkg.in/check.v1"
 	"launchpad.net/gomaasapi"
 
+	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	envtesting "github.com/juju/juju/environs/testing"
 	"github.com/juju/juju/feature"
@@ -16,6 +17,9 @@ import (
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/version"
 )
+
+// Ensure maasEnviron supports environs.NetworkingEnviron.
+var _ environs.NetworkingEnviron = (*maasEnviron)(nil)
 
 type providerSuite struct {
 	coretesting.FakeJujuHomeSuite

--- a/provider/vsphere/environ_network.go
+++ b/provider/vsphere/environ_network.go
@@ -18,7 +18,7 @@ func (env *environ) AllocateAddress(instID instance.Id, subnetID network.Id, add
 }
 
 // ReleaseAddress implements environs.Environ.
-func (env *environ) ReleaseAddress(instID instance.Id, netID network.Id, addr network.Address, _, _ string) error {
+func (env *environ) ReleaseAddress(instID instance.Id, netID network.Id, addr network.Address, _ string) error {
 	return env.changeAddress(instID, netID, addr, false)
 }
 

--- a/provider/vsphere/environ_network.go
+++ b/provider/vsphere/environ_network.go
@@ -13,8 +13,8 @@ import (
 )
 
 // AllocateAddress implements environs.Environ.
-func (env *environ) AllocateAddress(instID instance.Id, subnetID network.Id, addr *network.Address, _, _ string) error {
-	return env.changeAddress(instID, subnetID, *addr, true)
+func (env *environ) AllocateAddress(instID instance.Id, subnetID network.Id, addr network.Address, _, _ string) error {
+	return env.changeAddress(instID, subnetID, addr, true)
 }
 
 // ReleaseAddress implements environs.Environ.

--- a/worker/provisioner/kvm-broker.go
+++ b/worker/provisioner/kvm-broker.go
@@ -25,14 +25,12 @@ func NewKvmBroker(
 	managerConfig container.ManagerConfig,
 	enableNAT bool,
 ) (environs.InstanceBroker, error) {
-	namespace := maybeGetManagerConfigNamespaces(managerConfig)
 	manager, err := kvm.NewContainerManager(managerConfig)
 	if err != nil {
 		return nil, err
 	}
 	return &kvmBroker{
 		manager:     manager,
-		namespace:   namespace,
 		api:         api,
 		agentConfig: agentConfig,
 		enableNAT:   enableNAT,
@@ -41,7 +39,6 @@ func NewKvmBroker(
 
 type kvmBroker struct {
 	manager     container.Manager
-	namespace   string
 	api         APICalls
 	agentConfig agent.Config
 	enableNAT   bool
@@ -63,22 +60,29 @@ func (broker *kvmBroker) StartInstance(args environs.StartInstanceParams) (*envi
 	if bridgeDevice == "" {
 		bridgeDevice = kvm.DefaultKvmBridge
 	}
-
-	preparedInfo, err := prepareOrGetContainerInterfaceInfo(
-		broker.api,
-		machineId,
-		bridgeDevice,
-		true, // allocate if possible, do not maintain existing.
-		broker.enableNAT,
-		args.NetworkInfo,
-		kvmLogger,
-	)
-	if err != nil {
-		// It's not fatal (yet) if we couldn't pre-allocate addresses for the
-		// container.
-		logger.Warningf("failed to prepare container %q network config: %v", machineId, err)
+	if !environs.AddressAllocationEnabled() {
+		logger.Debugf(
+			"address allocation feature flag not enabled; using DHCP for container %q",
+			machineId,
+		)
 	} else {
-		args.NetworkInfo = preparedInfo
+		logger.Debugf("trying to allocate static IP for container %q", machineId)
+
+		allocatedInfo, err := configureContainerNetwork(
+			machineId,
+			bridgeDevice,
+			broker.api,
+			args.NetworkInfo,
+			true, // allocate a new address.
+			broker.enableNAT,
+		)
+		if err != nil {
+			// It's fine, just ignore it. The effect will be that the
+			// container won't have a static address configured.
+			logger.Infof("not allocating static IP for container %q: %v", machineId, err)
+		} else {
+			args.NetworkInfo = allocatedInfo
+		}
 	}
 
 	// Unlike with LXC, we don't override the default MTU to use.
@@ -126,33 +130,6 @@ func (broker *kvmBroker) StartInstance(args environs.StartInstanceParams) (*envi
 	}, nil
 }
 
-// MaintainInstance ensures the container's host has the required iptables and
-// routing rules to make the container visible to both the host and other
-// machines on the same subnet. This is important mostly when address allocation
-// feature flag is enabled, as otherwise we don't create additional iptables
-// rules or routes.
-func (broker *kvmBroker) MaintainInstance(args environs.StartInstanceParams) error {
-	machineID := args.InstanceConfig.MachineId
-
-	// Default to using the host network until we can configure.
-	bridgeDevice := broker.agentConfig.Value(agent.LxcBridge)
-	if bridgeDevice == "" {
-		bridgeDevice = kvm.DefaultKvmBridge
-	}
-
-	// There's no InterfaceInfo we expect to get below.
-	_, err := prepareOrGetContainerInterfaceInfo(
-		broker.api,
-		machineID,
-		bridgeDevice,
-		false, // maintain, do not allocate.
-		broker.enableNAT,
-		args.NetworkInfo,
-		kvmLogger,
-	)
-	return err
-}
-
 // StopInstances shuts down the given instances.
 func (broker *kvmBroker) StopInstances(ids ...instance.Id) error {
 	// TODO: potentially parallelise.
@@ -162,7 +139,6 @@ func (broker *kvmBroker) StopInstances(ids ...instance.Id) error {
 			kvmLogger.Errorf("container did not stop: %v", err)
 			return err
 		}
-		maybeReleaseContainerAddresses(broker.api, id, broker.namespace, kvmLogger)
 	}
 	return nil
 }
@@ -170,4 +146,32 @@ func (broker *kvmBroker) StopInstances(ids ...instance.Id) error {
 // AllInstances only returns running containers.
 func (broker *kvmBroker) AllInstances() (result []instance.Instance, err error) {
 	return broker.manager.ListContainers()
+}
+
+// MaintainInstance checks that the container's host has the required iptables and routing
+// rules to make the container visible to both the host and other machines on the same subnet.
+func (broker *kvmBroker) MaintainInstance(args environs.StartInstanceParams) error {
+	machineId := args.InstanceConfig.MachineId
+	if !environs.AddressAllocationEnabled() {
+		kvmLogger.Debugf("address allocation disabled: Not running maintenance for kvm with machineId: %s",
+			machineId)
+		return nil
+	}
+
+	kvmLogger.Debugf("running maintenance for kvm with machineId: %s", machineId)
+
+	// Default to using the host network until we can configure.
+	bridgeDevice := broker.agentConfig.Value(agent.LxcBridge)
+	if bridgeDevice == "" {
+		bridgeDevice = kvm.DefaultKvmBridge
+	}
+	_, err := configureContainerNetwork(
+		machineId,
+		bridgeDevice,
+		broker.api,
+		args.NetworkInfo,
+		false, // don't allocate a new address.
+		broker.enableNAT,
+	)
+	return err
 }

--- a/worker/provisioner/kvm-broker_test.go
+++ b/worker/provisioner/kvm-broker_test.go
@@ -162,9 +162,6 @@ func (s *kvmBrokerSuite) TestStartInstanceAddressAllocationDisabled(c *gc.C) {
 	machineId := "1/kvm/0"
 	kvm := s.startInstance(c, machineId)
 	s.api.CheckCalls(c, []gitjujutesting.StubCall{{
-		FuncName: "PrepareContainerInterfaceInfo",
-		Args:     []interface{}{names.NewMachineTag("1-kvm-0")},
-	}, {
 		FuncName: "ContainerConfig",
 	}})
 	c.Assert(kvm.Id(), gc.Equals, instance.Id("juju-machine-1-kvm-0"))

--- a/worker/provisioner/lxc-broker.go
+++ b/worker/provisioner/lxc-broker.go
@@ -678,10 +678,8 @@ func prepareOrGetContainerInterfaceInfo(
 	containerTag := names.NewMachineTag(machineID)
 	preparedInfo, err := api.PrepareContainerInterfaceInfo(containerTag)
 	if err != nil && errors.IsNotSupported(err) {
-		log.Warningf("new container %q not registered as device: not running on MAAS 1.8+", machineID)
+		log.Debugf("new container %q not registered as device: not running on MAAS 1.8+", machineID)
 		return nil, nil
-	} else if err != nil {
-		return nil, errors.Trace(err)
 	}
 
 	log.Tracef("PrepareContainerInterfaceInfo returned %#v", preparedInfo)
@@ -725,7 +723,6 @@ func maybeReleaseContainerAddresses(
 	case err == nil:
 		log.Infof("released all addresses for container %q", containerTag.Id())
 	case errors.IsNotSupported(err):
-		log.Warningf("not releasing all addresses for container %q: %v", containerTag.Id(), err)
 	default:
 		log.Warningf(
 			"unexpected error trying to release container %q addreses: %v",

--- a/worker/provisioner/lxc-broker.go
+++ b/worker/provisioner/lxc-broker.go
@@ -16,7 +16,6 @@ import (
 	"github.com/juju/loggo"
 	"github.com/juju/names"
 	"github.com/juju/utils/exec"
-	"github.com/juju/utils/set"
 
 	"github.com/juju/juju/agent"
 	apiprovisioner "github.com/juju/juju/api/provisioner"
@@ -41,7 +40,6 @@ type APICalls interface {
 	ContainerConfig() (params.ContainerConfig, error)
 	PrepareContainerInterfaceInfo(names.MachineTag) ([]network.InterfaceInfo, error)
 	GetContainerInterfaceInfo(names.MachineTag) ([]network.InterfaceInfo, error)
-	ReleaseContainerAddresses(names.MachineTag) error
 }
 
 var _ APICalls = (*apiprovisioner.State)(nil)
@@ -57,7 +55,6 @@ func newLxcBroker(
 	enableNAT bool,
 	defaultMTU int,
 ) (environs.InstanceBroker, error) {
-	namespace := maybeGetManagerConfigNamespaces(managerConfig)
 	manager, err := lxc.NewContainerManager(
 		managerConfig, imageURLGetter, looputil.NewLoopDeviceManager(),
 	)
@@ -66,7 +63,6 @@ func newLxcBroker(
 	}
 	return &lxcBroker{
 		manager:     manager,
-		namespace:   namespace,
 		api:         api,
 		agentConfig: agentConfig,
 		enableNAT:   enableNAT,
@@ -76,7 +72,6 @@ func newLxcBroker(
 
 type lxcBroker struct {
 	manager     container.Manager
-	namespace   string
 	api         APICalls
 	agentConfig agent.Config
 	enableNAT   bool
@@ -98,22 +93,28 @@ func (broker *lxcBroker) StartInstance(args environs.StartInstanceParams) (*envi
 		bridgeDevice = lxc.DefaultLxcBridge
 	}
 
-	preparedInfo, err := prepareOrGetContainerInterfaceInfo(
-		broker.api,
-		machineId,
-		bridgeDevice,
-		true, // allocate if possible, do not maintain existing.
-		broker.enableNAT,
-		args.NetworkInfo,
-		lxcLogger,
-	)
-	if err != nil {
-		// It's not fatal (yet) if we couldn't pre-allocate addresses for the
-		// container.
-		logger.Warningf("failed to prepare container %q network config: %v", machineId, err)
+	if !environs.AddressAllocationEnabled() {
+		logger.Debugf(
+			"address allocation feature flag not enabled; using DHCP for container %q",
+			machineId,
+		)
 	} else {
-		args.NetworkInfo = preparedInfo
-
+		logger.Debugf("trying to allocate static IP for container %q", machineId)
+		allocatedInfo, err := configureContainerNetwork(
+			machineId,
+			bridgeDevice,
+			broker.api,
+			args.NetworkInfo,
+			true, // allocate a new address.
+			broker.enableNAT,
+		)
+		if err != nil {
+			// It's fine, just ignore it. The effect will be that the
+			// container won't have a static address configured.
+			logger.Infof("not allocating static IP for container %q: %v", machineId, err)
+		} else {
+			args.NetworkInfo = allocatedInfo
+		}
 	}
 	network := container.BridgeNetworkConfig(bridgeDevice, broker.defaultMTU, args.NetworkInfo)
 
@@ -175,33 +176,6 @@ func (broker *lxcBroker) StartInstance(args environs.StartInstanceParams) (*envi
 	}, nil
 }
 
-// MaintainInstance ensures the container's host has the required iptables and
-// routing rules to make the container visible to both the host and other
-// machines on the same subnet. This is important mostly when address allocation
-// feature flag is enabled, as otherwise we don't create additional iptables
-// rules or routes.
-func (broker *lxcBroker) MaintainInstance(args environs.StartInstanceParams) error {
-	machineID := args.InstanceConfig.MachineId
-
-	// Default to using the host network until we can configure.
-	bridgeDevice := broker.agentConfig.Value(agent.LxcBridge)
-	if bridgeDevice == "" {
-		bridgeDevice = lxc.DefaultLxcBridge
-	}
-
-	// There's no InterfaceInfo we expect to get below.
-	_, err := prepareOrGetContainerInterfaceInfo(
-		broker.api,
-		machineID,
-		bridgeDevice,
-		false, // maintain, do not allocate.
-		broker.enableNAT,
-		args.NetworkInfo,
-		lxcLogger,
-	)
-	return err
-}
-
 // StopInstances shuts down the given instances.
 func (broker *lxcBroker) StopInstances(ids ...instance.Id) error {
 	// TODO: potentially parallelise.
@@ -211,7 +185,6 @@ func (broker *lxcBroker) StopInstances(ids ...instance.Id) error {
 			lxcLogger.Errorf("container did not stop: %v", err)
 			return err
 		}
-		maybeReleaseContainerAddresses(broker.api, id, broker.namespace, lxcLogger)
 	}
 	return nil
 }
@@ -623,110 +596,30 @@ func configureContainerNetwork(
 	return finalIfaceInfo, nil
 }
 
-func maybeGetManagerConfigNamespaces(managerConfig container.ManagerConfig) string {
-	if len(managerConfig) == 0 {
-		return ""
-	}
-	if namespace, ok := managerConfig[container.ConfigName]; ok {
-		return namespace
-	}
-	return ""
-}
-
-func prepareOrGetContainerInterfaceInfo(
-	api APICalls,
-	machineID string,
-	bridgeDevice string,
-	allocateOrMaintain bool,
-	enableNAT bool,
-	startingNetworkInfo []network.InterfaceInfo,
-	log loggo.Logger,
-) ([]network.InterfaceInfo, error) {
-	maintain := !allocateOrMaintain
-
-	if environs.AddressAllocationEnabled() {
-		if maintain {
-			log.Debugf("running maintenance for container %q", machineID)
-		} else {
-			log.Debugf("trying to allocate static IP for container %q", machineID)
-		}
-
-		allocatedInfo, err := configureContainerNetwork(
-			machineID,
-			bridgeDevice,
-			api,
-			startingNetworkInfo,
-			allocateOrMaintain,
-			enableNAT,
-		)
-		if err != nil && !maintain {
-			log.Infof("not allocating static IP for container %q: %v", machineID, err)
-		}
-		return allocatedInfo, err
+// MaintainInstance checks that the container's host has the required iptables and routing
+// rules to make the container visible to both the host and other machines on the same subnet.
+func (broker *lxcBroker) MaintainInstance(args environs.StartInstanceParams) error {
+	machineId := args.InstanceConfig.MachineId
+	if !environs.AddressAllocationEnabled() {
+		lxcLogger.Debugf("address allocation disabled: Not running maintenance for lxc container with machineId: %s",
+			machineId)
+		return nil
 	}
 
-	if maintain {
-		log.Debugf("address allocation disabled: Not running maintenance for machine %q", machineID)
-		return nil, nil
-	}
+	lxcLogger.Debugf("running maintenance for lxc container with machineId: %s", machineId)
 
-	log.Debugf("address allocation feature flag not enabled; using DHCP for container %q", machineID)
-
-	// In case we're running on MAAS 1.8+ with devices support, we'll still
-	// call PrepareContainerInterfaceInfo(), but we'll ignore a NotSupported
-	// error if we get it (which means we're not using MAAS 1.8+).
-	containerTag := names.NewMachineTag(machineID)
-	preparedInfo, err := api.PrepareContainerInterfaceInfo(containerTag)
-	if err != nil && errors.IsNotSupported(err) {
-		log.Debugf("new container %q not registered as device: not running on MAAS 1.8+", machineID)
-		return nil, nil
+	// Default to using the host network until we can configure.
+	bridgeDevice := broker.agentConfig.Value(agent.LxcBridge)
+	if bridgeDevice == "" {
+		bridgeDevice = lxc.DefaultLxcBridge
 	}
-
-	log.Tracef("PrepareContainerInterfaceInfo returned %#v", preparedInfo)
-	// Most likely there will be only one item in the list, but check
-	// all of them for forward compatibility.
-	macAddresses := set.NewStrings()
-	for _, prepInfo := range preparedInfo {
-		macAddresses.Add(prepInfo.MACAddress)
-	}
-	log.Infof(
-		"new container %q registered as a MAAS device with MAC address(es) %v",
-		machineID, macAddresses.SortedValues(),
+	_, err := configureContainerNetwork(
+		machineId,
+		bridgeDevice,
+		broker.api,
+		args.NetworkInfo,
+		false, // don't allocate a new address.
+		broker.enableNAT,
 	)
-	return preparedInfo, nil
-}
-
-func maybeReleaseContainerAddresses(
-	api APICalls,
-	instanceID instance.Id,
-	namespace string,
-	log loggo.Logger,
-) {
-	if environs.AddressAllocationEnabled() {
-		// The addresser worker will take care of the addresses.
-		return
-	}
-	// If we're not using addressable containers, we might still have used MAAS
-	// 1.8+ device to register the container when provisioning. In that case we
-	// need to attempt releasing the device, but ignore a NotSupported error
-	// (when we're not using MAAS 1.8+).
-	namespacePrefix := fmt.Sprintf("%s-", namespace)
-	tagString := strings.TrimPrefix(string(instanceID), namespacePrefix)
-	containerTag, err := names.ParseMachineTag(tagString)
-	if err != nil {
-		// Not a reason to cause StopInstances to fail though..
-		log.Warningf("unexpected container tag %q: %v", instanceID, err)
-		return
-	}
-	err = api.ReleaseContainerAddresses(containerTag)
-	switch {
-	case err == nil:
-		log.Infof("released all addresses for container %q", containerTag.Id())
-	case errors.IsNotSupported(err):
-	default:
-		log.Warningf(
-			"unexpected error trying to release container %q addreses: %v",
-			containerTag.Id(), err,
-		)
-	}
+	return err
 }

--- a/worker/provisioner/lxc-broker_test.go
+++ b/worker/provisioner/lxc-broker_test.go
@@ -190,9 +190,6 @@ func (s *lxcBrokerSuite) TestStartInstanceAddressAllocationDisabled(c *gc.C) {
 	machineId := "1/lxc/0"
 	lxc := s.startInstance(c, machineId, nil)
 	s.api.CheckCalls(c, []gitjujutesting.StubCall{{
-		FuncName: "PrepareContainerInterfaceInfo",
-		Args:     []interface{}{names.NewMachineTag("1-lxc-0")},
-	}, {
 		FuncName: "ContainerConfig",
 	}})
 	c.Assert(lxc.Id(), gc.Equals, instance.Id("juju-machine-1-lxc-0"))
@@ -314,9 +311,6 @@ func (s *lxcBrokerSuite) TestStartInstanceWithBridgeEnviron(c *gc.C) {
 	machineId := "1/lxc/0"
 	lxc := s.startInstance(c, machineId, nil)
 	s.api.CheckCalls(c, []gitjujutesting.StubCall{{
-		FuncName: "PrepareContainerInterfaceInfo",
-		Args:     []interface{}{names.NewMachineTag("1-lxc-0")},
-	}, {
 		FuncName: "ContainerConfig",
 	}})
 	c.Assert(lxc.Id(), gc.Equals, instance.Id("juju-machine-1-lxc-0"))
@@ -1166,12 +1160,4 @@ func (f *fakeAPI) GetContainerInterfaceInfo(tag names.MachineTag) ([]network.Int
 		return nil, err
 	}
 	return []network.InterfaceInfo{f.fakeInterfaceInfo}, nil
-}
-
-func (f *fakeAPI) ReleaseContainerAddresses(tag names.MachineTag) error {
-	f.MethodCall(f, "ReleaseContainerAddresses", tag)
-	if err := f.NextErr(); err != nil {
-		return err
-	}
-	return nil
 }

--- a/worker/provisioner/provisioner_task.go
+++ b/worker/provisioner/provisioner_task.go
@@ -667,21 +667,6 @@ func (task *provisionerTask) prepareNetworkAndInterfaces(networkInfo []network.I
 	}
 	visitedNetworks := set.NewStrings()
 	for _, info := range networkInfo {
-		// TODO(dimitern): The following few fields are required, but no longer
-		// matter and will be dropped or changed soon as part of making spaces
-		// and subnets usable across the board.
-		if info.NetworkName == "" {
-			info.NetworkName = network.DefaultPrivate
-		}
-		if info.ProviderId == "" {
-			info.ProviderId = network.DefaultPrivate
-		}
-		if info.CIDR == "" {
-			// TODO(dimitern): This is only when NOT using addressable
-			// containers, as we don't fetch the subnet details, but since
-			// networks in state are going away real soon, it's not important.
-			info.CIDR = "0.0.0.0/32"
-		}
 		if !names.IsValidNetwork(info.NetworkName) {
 			return nil, nil, errors.Errorf("invalid network name %q", info.NetworkName)
 		}


### PR DESCRIPTION
Using devices by default for containers as a behavior is being backed
out as it turns out MAAS 1.8 (latest stable in trusty) doesn't do a full
cleanup of the devices IPs, so in fact using devices makes things worse.
It was decided to back out the original #3730 and the follow-ups to it
like #3966 and #3866 (they fix issues introduced by the first PR, e.g.
http://pad.lv/1520199 and http://pad.lv/1525280).

Tested on 1.7, 1.8, and 1.9 to confirm devices are not created unless
the address-allocation feature flag is on (and then on 1.8+ only, as
1.7 doesn't support devices).

(Review request: http://reviews.vapour.ws/r/3474/)