### PR TITLE
Add endpoint binding support to charm bundle deployment.

### DIFF
--- a/cmd/juju/commands/bundle.go
+++ b/cmd/juju/commands/bundle.go
@@ -242,11 +242,12 @@ func (h *bundleHandler) addService(id string, p bundlechanges.AddServiceParams) 
 	}
 	// Deploy the service.
 	if err := h.serviceDeployer.serviceDeploy(serviceDeployParams{
-		charmURL:    ch,
-		serviceName: p.Service,
-		configYAML:  configYAML,
-		constraints: cons,
-		storage:     storageConstraints,
+		charmURL:      ch,
+		serviceName:   p.Service,
+		configYAML:    configYAML,
+		constraints:   cons,
+		storage:       storageConstraints,
+		spaceBindings: p.EndpointBindings,
 	}); err == nil {
 		h.log.Infof("service %s deployed (charm: %s)", p.Service, ch)
 		return nil

--- a/cmd/juju/commands/bundle_test.go
+++ b/cmd/juju/commands/bundle_test.go
@@ -106,6 +106,68 @@ deployment of bundle "cs:bundle/wordpress-with-mysql-storage-1" completed`
 	})
 }
 
+func (s *DeployCharmStoreSuite) TestDeployBundleEndpointBindingsSpaceMissing(c *gc.C) {
+	testcharms.UploadCharm(c, s.client, "trusty/mysql-42", "mysql")
+	testcharms.UploadCharm(c, s.client, "trusty/wordpress-47", "wordpress")
+	testcharms.UploadBundle(c, s.client, "bundle/wordpress-with-endpoint-bindings-1", "wordpress-with-endpoint-bindings")
+	output, err := runDeployCommand(c, "bundle/wordpress-with-endpoint-bindings")
+	c.Assert(err, gc.ErrorMatches,
+		"cannot deploy bundle: cannot deploy service \"mysql\": "+
+			"cannot add service \"mysql\": unknown space \"db\" not valid")
+	c.Assert(output, gc.Equals, "added charm cs:trusty/mysql-42")
+	s.assertCharmsUplodaded(c, "cs:trusty/mysql-42")
+	s.assertServicesDeployed(c, map[string]serviceInfo{})
+	s.assertUnitsCreated(c, map[string]string{})
+}
+
+func (s *DeployCharmStoreSuite) TestDeployBundleEndpointBindingsSuccess(c *gc.C) {
+	_, err := s.State.AddSpace("db", "", nil, false)
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = s.State.AddSpace("public", "", nil, false)
+	c.Assert(err, jc.ErrorIsNil)
+
+	testcharms.UploadCharm(c, s.client, "trusty/mysql-42", "mysql")
+	testcharms.UploadCharm(c, s.client, "trusty/wordpress-47", "wordpress")
+	testcharms.UploadBundle(c, s.client, "bundle/wordpress-with-endpoint-bindings-1", "wordpress-with-endpoint-bindings")
+	output, err := runDeployCommand(c, "bundle/wordpress-with-endpoint-bindings")
+	c.Assert(err, jc.ErrorIsNil)
+	expectedOutput := `
+added charm cs:trusty/mysql-42
+service mysql deployed (charm: cs:trusty/mysql-42)
+added charm cs:trusty/wordpress-47
+service wordpress deployed (charm: cs:trusty/wordpress-47)
+related wordpress:db and mysql:server
+added mysql/0 unit to new machine
+added wordpress/0 unit to new machine
+deployment of bundle "cs:bundle/wordpress-with-endpoint-bindings-1" completed`
+	c.Assert(output, gc.Equals, strings.TrimSpace(expectedOutput))
+	s.assertCharmsUplodaded(c, "cs:trusty/mysql-42", "cs:trusty/wordpress-47")
+
+	s.assertServicesDeployed(c, map[string]serviceInfo{
+		"mysql":     {charm: "cs:trusty/mysql-42"},
+		"wordpress": {charm: "cs:trusty/wordpress-47"},
+	})
+	s.assertDeployedServiceBindings(c, map[string]serviceInfo{
+		"mysql": {
+			endpointBindings: map[string]string{"server": "db"},
+		},
+		"wordpress": {
+			endpointBindings: map[string]string{
+				"cache":           "default",
+				"url":             "public",
+				"logging-dir":     "default",
+				"monitoring-port": "default",
+				"db":              "db",
+			},
+		},
+	})
+	s.assertRelationsEstablished(c, "wordpress:db mysql:server")
+	s.assertUnitsCreated(c, map[string]string{
+		"mysql/0":     "0",
+		"wordpress/0": "1",
+	})
+}
+
 func (s *DeployCharmStoreSuite) TestDeployBundleTwice(c *gc.C) {
 	testcharms.UploadCharm(c, s.client, "trusty/mysql-42", "mysql")
 	testcharms.UploadCharm(c, s.client, "trusty/wordpress-47", "wordpress")

--- a/cmd/juju/commands/deploy_test.go
+++ b/cmd/juju/commands/deploy_test.go
@@ -792,11 +792,25 @@ func (s *charmStoreSuite) assertCharmsUplodaded(c *gc.C, ids ...string) {
 
 // serviceInfo holds information about a deployed service.
 type serviceInfo struct {
-	charm       string
-	config      charm.Settings
-	constraints constraints.Value
-	exposed     bool
-	storage     map[string]state.StorageConstraints
+	charm            string
+	config           charm.Settings
+	constraints      constraints.Value
+	exposed          bool
+	storage          map[string]state.StorageConstraints
+	endpointBindings map[string]string
+}
+
+// assertDeployedServiceBindings checks that services were deployed into the expected spaces.
+// It is separate to assertServicesDeployed because it is only relevant to one test.
+func (s *charmStoreSuite) assertDeployedServiceBindings(c *gc.C, info map[string]serviceInfo) {
+	services, err := s.State.AllServices()
+	c.Assert(err, jc.ErrorIsNil)
+
+	for _, service := range services {
+		endpointBindings, err := service.EndpointBindings()
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(endpointBindings, jc.DeepEquals, info[service.Name()].endpointBindings)
+	}
 }
 
 // assertServicesDeployed checks that the given services have been deployed.

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -14,7 +14,7 @@ github.com/joyent/gomanta	git	cabd97b029d931836571f00b7e48c331809a30b7	2014-05-2
 github.com/joyent/gosdc	git	2f11feadd2d9891e92296a1077c3e2e56939547d	2014-05-24T00:08:15Z
 github.com/joyent/gosign	git	0da0d5f1342065321c97812b1f4ac0c2b0bab56c	2014-05-24T00:07:34Z
 github.com/juju/blobstore	git	3e9b30af648f96e85d8f41f946ae4a1ce0ce588b	2015-06-11T10:42:44Z
-github.com/juju/bundlechanges	git	ad10a12382f17c55d3f30049671bddfe514cdcdd	2015-11-19T12:03:14Z
+github.com/juju/bundlechanges	git	ad533f529b3b4a8bb2b76bf6213f1ef6b68df392	2016-01-06T16:13:59Z
 github.com/juju/cmd	git	33554d631f79b840d76673665b292215882ba90a	2015-10-28T03:05:29Z
 github.com/juju/errors	git	1b5e39b83d1835fa480e0c2ddefb040ee82d58b3	2015-09-16T12:56:42Z
 github.com/juju/gojsonpointer	git	afe8b77aa08f272b49e01b82de78510c11f61500	2015-02-04T19:46:29Z
@@ -49,7 +49,7 @@ gopkg.in/check.v1	git	b3d3430320d4260e5fea99841af984b3badcea63	2015-06-26T10:50:
 gopkg.in/errgo.v1	git	66cb46252b94c1f3d65646f54ee8043ab38d766c	2015-10-07T15:31:57Z
 gopkg.in/goose.v1	git	e4a91e8b8323b8eef6fe41a66fd3ac6120520bb0	2015-11-13T22:25:24Z
 gopkg.in/inconshreveable/log15.v2	git	b105bd37f74e5d9dc7b6ad7806715c7a2b83fd3f	2015-09-21T21:38:54Z
-gopkg.in/juju/charm.v6-unstable	git	ba541b945799430ccfcbab02453d898bfa714f27	2015-11-24T15:06:54Z
+gopkg.in/juju/charm.v6-unstable	git	0d22d549d60dbc5011064710a2913073ed951975	2016-01-06T15:03:58Z
 gopkg.in/juju/charmrepo.v2-unstable	git	0dccc5f663f5842ead1ee6855bf7f7c87e7ca2fa	2015-11-26T03:49:04Z
 gopkg.in/juju/charmstore.v5-unstable	git	a3afbf1cc0b2438ef7f7fc028cc54b19bd4f91e3	2015-11-19T15:07:26Z
 gopkg.in/juju/environschema.v1	git	7bea6a9a531586600a7741e9bdd5e3c978ffda15	2015-10-20T16:12:31Z

--- a/testcharms/charm-repo/bundle/wordpress-with-endpoint-bindings/README.md
+++ b/testcharms/charm-repo/bundle/wordpress-with-endpoint-bindings/README.md
@@ -1,0 +1,1 @@
+A dummy bundle

--- a/testcharms/charm-repo/bundle/wordpress-with-endpoint-bindings/bundle.yaml
+++ b/testcharms/charm-repo/bundle/wordpress-with-endpoint-bindings/bundle.yaml
@@ -1,0 +1,14 @@
+services:
+    wordpress:
+        charm: wordpress
+        num_units: 1
+        bindings:
+            db: db
+            url: public
+    mysql:
+        charm: mysql
+        num_units: 1
+        bindings:
+            server: db
+relations:
+    - ["wordpress:db", "mysql:server"]


### PR DESCRIPTION
Adds support for reading endpoint bindings from a charm bundle, for example:
```yaml
services:
    wordpress:
        charm: wordpress
        num_units: 1
        bindings:
            db: db
            url: public
    mysql:
        charm: mysql
        num_units: 1
        bindings:
            server: db
relations:
    - ["wordpress:db", "mysql:server"]
```
There is no support for overriding endpoint bindings on the command line like there is for storage, but it could, in theory, be added after the syntax has been agreed.

(Review request: http://reviews.vapour.ws/r/3475/)