### PR TITLE
provider/maas: DNS entries do not demarcate stanzas

### DIFF
--- a/provider/maas/add-juju-bridge.py
+++ b/provider/maas/add-juju-bridge.py
@@ -173,7 +173,7 @@ class NetworkInterfaceParser(object):
 
     @classmethod
     def is_stanza(cls, s):
-        return re.match(r'^(iface|mapping|auto|allow-|source|dns-)', s)
+        return re.match(r'^(iface|mapping|auto|allow-|source)', s)
 
     def __init__(self, filename):
         self._stanzas = []

--- a/provider/maas/bridgescript.go
+++ b/provider/maas/bridgescript.go
@@ -185,7 +185,7 @@ class NetworkInterfaceParser(object):
 
     @classmethod
     def is_stanza(cls, s):
-        return re.match(r'^(iface|mapping|auto|allow-|source|dns-)', s)
+        return re.match(r'^(iface|mapping|auto|allow-|source)', s)
 
     def __init__(self, filename):
         self._stanzas = []

--- a/provider/maas/bridgescript_test.go
+++ b/provider/maas/bridgescript_test.go
@@ -258,8 +258,7 @@ iface eth0:1 inet static
 auto eth0:2
 iface eth0:2 inet static
     address 10.14.0.100/24
-
-dns-nameserver 192.168.1.142`
+    dns-nameserver 192.168.1.142`
 
 const networkMultipleStaticWithAliasesInitial = `
 auto eth0
@@ -297,9 +296,8 @@ iface eth0:1 inet static
 auto eth1
 iface eth1 inet manual
     mtu 1500
-
-dns-nameservers 10.17.20.200
-dns-search maas`
+    dns-nameservers 10.17.20.200
+    dns-search maas`
 
 const networkDHCPWithBondInitial = `auto eth0
 iface eth0 inet manual
@@ -359,15 +357,16 @@ iface bond0 inet manual
     bond-mode active-backup
     hwaddress 52:54:00:1c:f1:5b
     bond-slaves none
+    dns-nameservers 10.17.20.200
+    dns-search maas19
 
 auto test-br-bond0
 iface test-br-bond0 inet dhcp
     mtu 1500
     hwaddress 52:54:00:1c:f1:5b
-    bridge_ports bond0
-
-dns-nameservers 10.17.20.200
-dns-search maas19`
+    dns-nameservers 10.17.20.200
+    dns-search maas19
+    bridge_ports bond0`
 
 const networkMultipleAliasesInitial = `auto eth0
 iface eth0 inet dhcp
@@ -424,9 +423,8 @@ auto eth10:2
 iface eth10:2 inet static
     address 10.17.20.203/24
     mtu 1500
-
-dns-nameservers 10.17.20.200
-dns-search maas19`
+    dns-nameservers 10.17.20.200
+    dns-search maas19`
 
 const networkSmorgasboardInitial = `auto eth0
 iface eth0 inet manual
@@ -631,15 +629,16 @@ iface bond1 inet manual
     bond-mode active-backup
     hwaddress 52:54:00:8e:6e:b0
     bond-slaves none
+    dns-nameservers 10.17.20.200
+    dns-search maas19
 
 auto juju-br-bond1
 iface juju-br-bond1 inet dhcp
     mtu 1500
     hwaddress 52:54:00:8e:6e:b0
-    bridge_ports bond1
-
-dns-nameservers 10.17.20.200
-dns-search maas19`
+    dns-nameservers 10.17.20.200
+    dns-search maas19
+    bridge_ports bond1`
 
 const networkVLANInitial = `auto eth0
 iface eth0 inet static
@@ -699,6 +698,5 @@ iface eth1.3 inet static
     vlan-raw-device eth1
     mtu 1500
     vlan_id 3
-
-dns-nameservers 10.17.20.200
-dns-search maas19`
+    dns-nameservers 10.17.20.200
+    dns-search maas19`

--- a/provider/maas/bridgescript_test.go
+++ b/provider/maas/bridgescript_test.go
@@ -101,6 +101,10 @@ func (s *bridgeConfigSuite) TestBridgeScriptWithVLANs(c *gc.C) {
 	s.assertScript(c, networkVLANInitial, networkVLANExpected, "vlan-br-")
 }
 
+func (s *bridgeConfigSuite) TestBridgeScriptWithMultipleNameservers(c *gc.C) {
+	s.assertScript(c, networkVLANWithMultipleNameserversInitial, networkVLANWithMultipleNameserversExpected, "br-")
+}
+
 func (s *bridgeConfigSuite) runScript(c *gc.C, configFile string, bridgePrefix string) (output string, exitCode int) {
 	script := fmt.Sprintf("%q --bridge-prefix=%q %q\n",
 		s.testPythonScript,
@@ -700,3 +704,113 @@ iface eth1.3 inet static
     vlan_id 3
     dns-nameservers 10.17.20.200
     dns-search maas19`
+
+const networkVLANWithMultipleNameserversInitial = `auto eth0
+iface eth0 inet static
+    dns-nameservers 10.245.168.2
+    gateway 10.245.168.1
+    address 10.245.168.11/21
+    mtu 1500
+
+auto eth1
+iface eth1 inet manual
+    mtu 1500
+
+auto eth2
+iface eth2 inet manual
+    mtu 1500
+
+auto eth3
+iface eth3 inet manual
+    mtu 1500
+
+auto eth1.2667
+iface eth1.2667 inet static
+    dns-nameservers 10.245.168.2
+    address 10.245.184.2/24
+    vlan-raw-device eth1
+    mtu 1500
+    vlan_id 2667
+
+auto eth1.2668
+iface eth1.2668 inet static
+    dns-nameservers 10.245.168.2
+    address 10.245.185.1/24
+    vlan-raw-device eth1
+    mtu 1500
+    vlan_id 2668
+
+auto eth1.2669
+iface eth1.2669 inet static
+    dns-nameservers 10.245.168.2
+    address 10.245.186.1/24
+    vlan-raw-device eth1
+    mtu 1500
+    vlan_id 2669
+
+auto eth1.2670
+iface eth1.2670 inet static
+    dns-nameservers 10.245.168.2
+    address 10.245.187.2/24
+    vlan-raw-device eth1
+    mtu 1500
+    vlan_id 2670
+
+dns-nameservers 10.245.168.2
+dns-search dellstack`
+
+const networkVLANWithMultipleNameserversExpected = `iface eth0 inet manual
+
+auto br-eth0
+iface br-eth0 inet static
+    dns-nameservers 10.245.168.2
+    gateway 10.245.168.1
+    address 10.245.168.11/21
+    mtu 1500
+    bridge_ports eth0
+
+auto eth1
+iface eth1 inet manual
+    mtu 1500
+
+auto eth2
+iface eth2 inet manual
+    mtu 1500
+
+auto eth3
+iface eth3 inet manual
+    mtu 1500
+
+auto eth1.2667
+iface eth1.2667 inet static
+    dns-nameservers 10.245.168.2
+    address 10.245.184.2/24
+    vlan-raw-device eth1
+    mtu 1500
+    vlan_id 2667
+
+auto eth1.2668
+iface eth1.2668 inet static
+    dns-nameservers 10.245.168.2
+    address 10.245.185.1/24
+    vlan-raw-device eth1
+    mtu 1500
+    vlan_id 2668
+
+auto eth1.2669
+iface eth1.2669 inet static
+    dns-nameservers 10.245.168.2
+    address 10.245.186.1/24
+    vlan-raw-device eth1
+    mtu 1500
+    vlan_id 2669
+
+auto eth1.2670
+iface eth1.2670 inet static
+    dns-nameservers 10.245.168.2
+    address 10.245.187.2/24
+    vlan-raw-device eth1
+    mtu 1500
+    vlan_id 2670
+    dns-nameservers 10.245.168.2
+    dns-search dellstack`


### PR DESCRIPTION
When parsing an interfaces file, entries beginning with 'dns-' do not
demarcate stanzas. DNS entries are now considered part of the iface
stanza that is being parsed.

For example, the following interfaces file:

   auto eth0
   iface eth0 inet dhcp

   dns-nameservers 10.10.19.2
   dns-search maas-19

we would previously bridge and render as:

   iface eth0 inet manual

   auto br-eth0
   iface br-eth0 inet dhcp
       bridge_ports eth0

   dns-nameservers 10.10.19.2
   dns-search maas-19

but is now parsed and rendered as:

   iface eth0 inet manual

   auto br-eth0
   iface br-eth0 inet dhcp
       dns-nameservers 10.10.19.2
       dns-search maas-19
       bridge_ports eth0

Fixes [LP:#1532176](https://bugs.launchpad.net/juju-core/+bug/1532176)

(Review request: http://reviews.vapour.ws/r/3481/)