### PR TITLE
fix what we output for origin when no resource has been uploaded

### DIFF
--- a/resource/cmd/formatter.go
+++ b/resource/cmd/formatter.go
@@ -65,7 +65,7 @@ func FormatSvcResource(res resource.Resource) FormattedSvcResource {
 		Timestamp:        res.Timestamp,
 		Username:         res.Username,
 		combinedRevision: combinedRevision(res),
-		combinedOrigin:   combinedOrigin(res),
+		combinedOrigin:   combinedOrigin(used, res),
 		usedYesNo:        usedYesNo(used),
 	}
 }
@@ -82,13 +82,11 @@ func combinedRevision(r resource.Resource) string {
 	return "-"
 }
 
-func combinedOrigin(r resource.Resource) string {
-	switch r.Origin {
-	case charmresource.OriginUpload:
+func combinedOrigin(used bool, r resource.Resource) string {
+	if r.Origin == charmresource.OriginUpload && used && r.Username != "" {
 		return r.Username
-	default:
-		return r.Origin.String()
 	}
+	return r.Origin.String()
 }
 
 func usedYesNo(used bool) string {

--- a/resource/cmd/formatter_test.go
+++ b/resource/cmd/formatter_test.go
@@ -99,3 +99,26 @@ func (s *SvcFormatterSuite) TestUsed(c *gc.C) {
 	f := FormatSvcResource(r)
 	c.Assert(f.Used, jc.IsTrue)
 }
+
+func (s *SvcFormatterSuite) TestOriginUploadDeployed(c *gc.C) {
+	// represents what we get when we first deploy a service
+	r := resource.Resource{
+		Resource: charmresource.Resource{
+			Origin: charmresource.OriginUpload,
+		},
+		Username:  "bill",
+		Timestamp: time.Now(),
+	}
+	f := FormatSvcResource(r)
+	c.Assert(f.combinedOrigin, gc.Equals, "bill")
+}
+
+func (s *SvcFormatterSuite) TestInitialOriginUpload(c *gc.C) {
+	r := resource.Resource{
+		Resource: charmresource.Resource{
+			Origin: charmresource.OriginUpload,
+		},
+	}
+	f := FormatSvcResource(r)
+	c.Assert(f.combinedOrigin, gc.Equals, "upload")
+}

--- a/resource/cmd/output_tabular_test.go
+++ b/resource/cmd/output_tabular_test.go
@@ -126,7 +126,6 @@ func (s *SvcTabularSuite) TestFormatCharmTabularMulti(c *gc.C) {
 				},
 				Origin: charmresource.OriginUpload,
 			},
-			Username: "Sandra User",
 		},
 		{
 			Resource: charmresource.Resource{
@@ -162,11 +161,11 @@ func (s *SvcTabularSuite) TestFormatCharmTabularMulti(c *gc.C) {
 
 	// Notes: sorted by name, then by revision, newest first.
 	c.Check(string(data), gc.Equals, `
-RESOURCE ORIGIN      REV        USED COMMENT
-openjdk  store       7          no   the java runtime
-website  Sandra User -          no   your website data
-openjdk2 store       8          yes  another java runtime
-website2 Bill User   2012-12-12 yes  your website data
+RESOURCE ORIGIN    REV        USED COMMENT
+openjdk  store     7          no   the java runtime
+website  upload    -          no   your website data
+openjdk2 store     8          yes  another java runtime
+website2 Bill User 2012-12-12 yes  your website data
 `[1:])
 }
 

--- a/resource/cmd/show_service_test.go
+++ b/resource/cmd/show_service_test.go
@@ -89,7 +89,6 @@ func (s *ShowServiceSuite) TestRun(c *gc.C) {
 				},
 				Origin: charmresource.OriginUpload,
 			},
-			Username: "Sandra User",
 		},
 		{
 			Resource: charmresource.Resource{
@@ -127,11 +126,11 @@ func (s *ShowServiceSuite) TestRun(c *gc.C) {
 	c.Assert(stderr, gc.Equals, "")
 
 	c.Check(stdout, gc.Equals, `
-RESOURCE ORIGIN      REV        USED COMMENT
-openjdk  store       7          no   the java runtime
-website  Sandra User -          no   your website data
-rsc1234  store       15         yes  a big comment
-website2 Bill User   2012-12-12 yes  awesome data
+RESOURCE ORIGIN    REV        USED COMMENT
+openjdk  store     7          no   the java runtime
+website  upload    -          no   your website data
+rsc1234  store     15         yes  a big comment
+website2 Bill User 2012-12-12 yes  awesome data
 
 `[1:])
 


### PR DESCRIPTION
in the demo, we add stub metadata to the database when we deploy, giving resources with an origin of upload but no username.... this resulted in the "origin" field in show-service-resource trying to show the username, which was empty.  Now we only show the username if the resource is "used" and if the username is not empty.

(Review request: http://reviews.vapour.ws/r/3485/)