### PR TITLE
lp1521777 - Allow 2.0 client to upgrade 1.x to 2.0

### DIFF
--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -155,7 +155,7 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 	r.Register(newExposeCommand())
 	r.Register(newSyncToolsCommand())
 	r.Register(newUnexposeCommand())
-	r.Register(newUpgradeJujuCommand())
+	r.Register(newUpgradeJujuCommand(nil))
 	r.Register(newUpgradeCharmCommand())
 
 	// Charm publishing commands.

--- a/cmd/juju/commands/upgradejuju.go
+++ b/cmd/juju/commands/upgradejuju.go
@@ -46,7 +46,7 @@ type upgradeJujuCommand struct {
 	// minMajorUpgradeVersion maps known major numbers to
 	// the minimum version that can be upgraded to that
 	// major version.  For example, users must be running
-	// 1.25.2 or later in order to upgrade to 2.0.
+	// 1.25.3 or later in order to upgrade to 2.0.
 	minMajorUpgradeVersion map[int]version.Number
 }
 
@@ -130,7 +130,7 @@ var (
 	errUpToDate            = stderrors.New("no upgrades available")
 	downgradeErrMsg        = "cannot change version from %s to %s"
 	minMajorUpgradeVersion = map[int]version.Number{
-		2: version.MustParse("1.25.2"),
+		2: version.MustParse("1.25.3"),
 	}
 )
 
@@ -150,7 +150,7 @@ var (
 // it can be used to upgrade the environment to N.0.*.  For
 // example, the 2.0.1 upgrade-juju command must be able to upgrade
 // environments running 1.* since it must be able to upgrade
-// environments from 1.25.2 -> 2.0.*.
+// environments from 1.25.3 -> 2.0.*.
 func canUpgradeRunningVersion(runningAgentVer version.Number) bool {
 	if runningAgentVer.Major == version.Current.Major {
 		return true

--- a/cmd/juju/commands/upgradejuju.go
+++ b/cmd/juju/commands/upgradejuju.go
@@ -26,19 +26,23 @@ import (
 	"github.com/juju/juju/version"
 )
 
-func newUpgradeJujuCommand() cmd.Command {
-	return envcmd.Wrap(&upgradeJujuCommand{})
+func newUpgradeJujuCommand(minUpgradeVers map[int]version.Number) cmd.Command {
+	if minUpgradeVers == nil {
+		minUpgradeVers = minMajorUpgradeVersion
+	}
+	return envcmd.Wrap(&upgradeJujuCommand{minMajorUpgradeVersion: minUpgradeVers})
 }
 
 // upgradeJujuCommand upgrades the agents in a juju installation.
 type upgradeJujuCommand struct {
 	envcmd.EnvCommandBase
-	vers          string
-	Version       version.Number
-	UploadTools   bool
-	DryRun        bool
-	ResetPrevious bool
-	AssumeYes     bool
+	vers                   string
+	Version                version.Number
+	UploadTools            bool
+	DryRun                 bool
+	ResetPrevious          bool
+	AssumeYes              bool
+	minMajorUpgradeVersion map[int]version.Number
 }
 
 var upgradeJujuDoc = `
@@ -103,9 +107,6 @@ func (c *upgradeJujuCommand) Init(args []string) error {
 		if err != nil {
 			return err
 		}
-		if vers.Major != version.Current.Major {
-			return fmt.Errorf("cannot upgrade to version incompatible with CLI")
-		}
 		if c.UploadTools && vers.Build != 0 {
 			// TODO(fwereade): when we start taking versions from actual built
 			// code, we should disable --version when used with --upload-tools.
@@ -120,7 +121,27 @@ func (c *upgradeJujuCommand) Init(args []string) error {
 	return cmd.CheckEmpty(args)
 }
 
-var errUpToDate = stderrors.New("no upgrades available")
+var (
+	errUpToDate            = stderrors.New("no upgrades available")
+	downgradeErrMsg        = "cannot change version from %s to %s"
+	minMajorUpgradeVersion = map[int]version.Number{
+		2: version.MustParse("1.25.2"),
+	}
+)
+
+// canUpgradeVersion determines if the version of the running
+// environment can be upgraded using this client.  Only clients
+// with a minor version of 0 are expected to be able to upgrade
+// environments running the previous major version.
+func canUpgradeVersion(ver version.Number) bool {
+	if ver.Major == version.Current.Major {
+		return true
+	}
+	if version.Current.Minor == 0 && ver.Major == (version.Current.Major-1) {
+		return true
+	}
+	return false
+}
 
 func formatTools(tools coretools.List) string {
 	formatted := make([]string, len(tools))
@@ -166,7 +187,63 @@ func (c *upgradeJujuCommand) Run(ctx *cmd.Context) (err error) {
 	if err != nil {
 		return err
 	}
-	context, err := c.initVersions(client, cfg)
+
+	agentVersion, ok := cfg.AgentVersion()
+	if !ok {
+		// Can't happen. In theory.
+		return fmt.Errorf("incomplete environment configuration")
+	}
+
+	if c.UploadTools && c.Version == version.Zero {
+		// Currently, uploading tools assumes the version to be
+		// the same as version.Current if not specified with
+		// --version.
+		c.Version = version.Current
+	}
+	warnCompat := false
+	switch {
+	case !canUpgradeVersion(agentVersion):
+		// This client cannot upgrade the running environment.
+		return fmt.Errorf("cannot upgrade a %s environment with a %s client", agentVersion, version.Current)
+	case c.Version != version.Zero && c.Version.Major < agentVersion.Major:
+		// Cannot take the environment backwards.
+		return fmt.Errorf(downgradeErrMsg, agentVersion, c.Version)
+	case agentVersion.Major != version.Current.Major:
+		// Upgrading the previous major version.
+		if c.Version == version.Zero || c.Version.Major == agentVersion.Major {
+			// Not requesting an upgrade across major release boundary.
+			// Warn of incompatible CLI.
+			// TODO(cherylj) Add in a suggestion to upgrade to 2.0 if
+			// no matching tools are found (bug 1532670)
+			warnCompat = true
+			break
+		}
+		fallthrough
+	case c.Version.Major > agentVersion.Major:
+		// User is requesting an upgrade to a new major number
+		// Only upgrade to a different major number if:
+		// 1 - Explicitly requested with --version or using --upload-tools, and
+		// 2 - The environment is running a valid version to upgrade from, and
+		// 3 - The upgrade is to a minor version of 0.
+		minVer, ok := c.minMajorUpgradeVersion[c.Version.Major]
+		if !ok {
+			return errors.Errorf("unknown version %q", c.Version)
+		}
+		retErr := false
+		if c.Version.Minor != 0 {
+			ctx.Infof("upgrades to %s must first go through juju %d.0", c.Version, c.Version.Major)
+			retErr = true
+		}
+		if comp := agentVersion.Compare(minVer); comp < 0 {
+			ctx.Infof("upgrades to a new major version must first go through %s", minVer)
+			retErr = true
+		}
+		if retErr {
+			return fmt.Errorf("unable to upgrade to requested version")
+		}
+	}
+
+	context, err := c.initVersions(client, cfg, agentVersion, warnCompat)
 	if err != nil {
 		return err
 	}
@@ -181,6 +258,9 @@ func (c *upgradeJujuCommand) Run(ctx *cmd.Context) (err error) {
 	// TODO(fwereade): this list may be incomplete, pending envtools.Upload change.
 	ctx.Infof("available tools:\n%s", formatTools(context.tools))
 	ctx.Infof("best version:\n    %s", context.chosen)
+	if warnCompat {
+		logger.Warningf("version %s incompatible with this client (%s)", context.chosen, version.Current)
+	}
 	if c.DryRun {
 		ctx.Infof("upgrade to this version by running\n    juju upgrade-juju --version=\"%s\"\n", context.chosen)
 	} else {
@@ -238,17 +318,21 @@ func (c *upgradeJujuCommand) confirmResetPreviousUpgrade(ctx *cmd.Context) (bool
 // agent and client versions, and the list of currently available tools, will
 // always be accurate; the chosen version, and the flag indicating development
 // mode, may remain blank until uploadTools or validate is called.
-func (c *upgradeJujuCommand) initVersions(client upgradeJujuAPI, cfg *config.Config) (*upgradeContext, error) {
-	agent, ok := cfg.AgentVersion()
-	if !ok {
-		// Can't happen. In theory.
-		return nil, fmt.Errorf("incomplete environment configuration")
-	}
-	if c.Version == agent {
+func (c *upgradeJujuCommand) initVersions(client upgradeJujuAPI, cfg *config.Config, agentVersion version.Number, filterOnPrior bool) (*upgradeContext, error) {
+	if c.Version == agentVersion {
 		return nil, errUpToDate
 	}
-	clientVersion := version.Current
-	findResult, err := client.FindTools(clientVersion.Major, -1, "", "")
+	filterVersion := version.Current
+	if c.Version != version.Zero {
+		filterVersion = c.Version
+	} else if filterOnPrior {
+		// Trying to find the latest of the prior major version.
+		// TODO (cherylj) if no tools found, suggest upgrade to
+		// the current client version.
+		filterVersion.Major--
+	}
+	logger.Debugf("searching for tools with major: %d", filterVersion.Major)
+	findResult, err := client.FindTools(filterVersion.Major, -1, "", "")
 	if err != nil {
 		return nil, err
 	}
@@ -260,15 +344,15 @@ func (c *upgradeJujuCommand) initVersions(client upgradeJujuAPI, cfg *config.Con
 		if !c.UploadTools {
 			// No tools found and we shouldn't upload any, so if we are not asking for a
 			// major upgrade, pretend there is no more recent version available.
-			if c.Version == version.Zero && agent.Major == clientVersion.Major {
+			if c.Version == version.Zero && agentVersion.Major == filterVersion.Major {
 				return nil, errUpToDate
 			}
 			return nil, err
 		}
 	}
 	return &upgradeContext{
-		agent:     agent,
-		client:    clientVersion,
+		agent:     agentVersion,
+		client:    version.Current,
 		chosen:    c.Version,
 		tools:     findResult.List,
 		apiClient: client,
@@ -306,6 +390,10 @@ func (context *upgradeContext) uploadTools() (err error) {
 	// ...but there's no way we have time for that now. In the meantime,
 	// considering the use cases, this should work well enough; but it
 	// won't detect an incompatible major-version change, which is a shame.
+	//
+	// TODO(cherylj) If the determiniation of version changes, we will
+	// need to also change the upgrade version checks in Run() that check
+	// if a major upgrade is allowed.
 	if context.chosen == version.Zero {
 		context.chosen = context.client
 	}
@@ -345,18 +433,15 @@ func (context *upgradeContext) uploadTools() (err error) {
 func (context *upgradeContext) validate() (err error) {
 	if context.chosen == version.Zero {
 		// No explicitly specified version, so find the version to which we
-		// need to upgrade. If the CLI and agent major versions match, we find
-		// next available stable release to upgrade to by incrementing the
-		// minor version, starting from the current agent version and doing
-		// major.minor+1.patch=0. If the CLI has a greater major version,
-		// we just use the CLI version as is.
+		// need to upgrade. We find next available stable release to upgrade
+		// to by incrementing the minor version, starting from the current
+		// agent version and doing major.minor+1.patch=0.
+
+		// Upgrading across a major release boundary requires that the version
+		// be specified with --version.
 		nextVersion := context.agent
-		if nextVersion.Major == context.client.Major {
-			nextVersion.Minor += 1
-			nextVersion.Patch = 0
-		} else {
-			nextVersion = context.client
-		}
+		nextVersion.Minor += 1
+		nextVersion.Patch = 0
 
 		newestNextStable, found := context.tools.NewestCompatible(nextVersion)
 		if found {
@@ -396,7 +481,7 @@ func (context *upgradeContext) validate() (err error) {
 		// any of our tools detect an incompatible version, they should act to
 		// minimize damage: the CLI should abort politely, and the agents should
 		// run an Upgrader but no other tasks.
-		return fmt.Errorf("cannot change version from %s to %s", context.agent, context.chosen)
+		return fmt.Errorf(downgradeErrMsg, context.agent, context.chosen)
 	}
 
 	return nil

--- a/cmd/juju/commands/upgradejuju_test.go
+++ b/cmd/juju/commands/upgradejuju_test.go
@@ -70,6 +70,7 @@ var upgradeJujuTests = []struct {
 	expectErr      string
 	expectVersion  string
 	expectUploaded []string
+	upgradeMap     map[int]version.Number
 }{{
 	about:          "unwanted extra argument",
 	currentVersion: "1.0.0-quantal-amd64",
@@ -93,18 +94,21 @@ var upgradeJujuTests = []struct {
 }, {
 	about:          "major version upgrade to incompatible version",
 	currentVersion: "2.0.0-quantal-amd64",
+	agentVersion:   "2.0.0",
 	args:           []string{"--version", "5.2.0"},
-	expectInitErr:  "cannot upgrade to version incompatible with CLI",
+	expectErr:      `unknown version "5.2.0"`,
 }, {
 	about:          "major version downgrade to incompatible version",
 	currentVersion: "4.2.0-quantal-amd64",
+	agentVersion:   "4.2.0",
 	args:           []string{"--version", "3.2.0"},
-	expectInitErr:  "cannot upgrade to version incompatible with CLI",
+	expectErr:      "cannot change version from 4.2.0 to 3.2.0",
 }, {
 	about:          "--upload-tools with inappropriate version 1",
 	currentVersion: "4.2.0-quantal-amd64",
+	agentVersion:   "4.2.0",
 	args:           []string{"--upload-tools", "--version", "3.1.0"},
-	expectInitErr:  "cannot upgrade to version incompatible with CLI",
+	expectErr:      "cannot change version from 4.2.0 to 3.1.0",
 }, {
 	about:          "--upload-tools with inappropriate version 2",
 	currentVersion: "3.2.7-quantal-amd64",
@@ -123,23 +127,17 @@ var upgradeJujuTests = []struct {
 	agentVersion:   "2.0.0",
 	expectVersion:  "2.0.5",
 }, {
-	about:          "latest current release matching CLI, major version",
-	tools:          []string{"3.2.0-quantal-amd64"},
-	currentVersion: "3.2.0-quantal-amd64",
-	agentVersion:   "2.8.2",
-	expectVersion:  "3.2.0",
-}, {
 	about:          "latest current release matching CLI, major version, no matching major tools",
 	tools:          []string{"2.8.2-quantal-amd64"},
-	currentVersion: "3.2.0-quantal-amd64",
+	currentVersion: "3.0.2-quantal-amd64",
 	agentVersion:   "2.8.2",
-	expectErr:      "no matching tools available",
+	expectVersion:  "2.8.2",
 }, {
 	about:          "latest current release matching CLI, major version, no matching tools",
 	tools:          []string{"3.3.0-quantal-amd64"},
-	currentVersion: "3.2.0-quantal-amd64",
+	currentVersion: "3.0.2-quantal-amd64",
 	agentVersion:   "2.8.2",
-	expectErr:      "no compatible tools available",
+	expectVersion:  "2.8.2",
 }, {
 	about:          "no next supported available",
 	tools:          []string{"2.2.0-quantal-amd64", "2.2.5-quantal-i386", "2.3.3-quantal-amd64", "2.1-dev1-quantal-amd64"},
@@ -167,11 +165,12 @@ var upgradeJujuTests = []struct {
 	expectVersion:  "2.3-dev0",
 }, {
 	about:          "specified major version",
-	tools:          []string{"3.2.0-quantal-amd64"},
-	currentVersion: "3.2.0-quantal-amd64",
+	tools:          []string{"3.0.2-quantal-amd64"},
+	currentVersion: "3.0.2-quantal-amd64",
 	agentVersion:   "2.8.2",
-	args:           []string{"--version", "3.2.0"},
-	expectVersion:  "3.2.0",
+	args:           []string{"--version", "3.0.2"},
+	expectVersion:  "3.0.2",
+	upgradeMap:     map[int]version.Number{3: version.MustParse("2.8.2")},
 }, {
 	about:          "specified version missing, but already set",
 	currentVersion: "3.0.0-quantal-amd64",
@@ -213,12 +212,26 @@ var upgradeJujuTests = []struct {
 	args:           []string{"--version", "3.2.0"},
 	expectErr:      "no matching tools available",
 }, {
-	about:          "major version downgrade to incompatible version",
+	about:          "incompatible version (minor != 0)",
+	tools:          []string{"3.2.0-quantal-amd64"},
+	currentVersion: "4.2.0-quantal-amd64",
+	agentVersion:   "3.2.0",
+	args:           []string{"--version", "3.2.0"},
+	expectErr:      "cannot upgrade a 3.2.0 environment with a 4.2.0 client",
+}, {
+	about:          "incompatible version (env major > client major)",
 	tools:          []string{"3.2.0-quantal-amd64"},
 	currentVersion: "3.2.0-quantal-amd64",
 	agentVersion:   "4.2.0",
 	args:           []string{"--version", "3.2.0"},
-	expectErr:      "cannot change version from 4.2.0 to 3.2.0",
+	expectErr:      "cannot upgrade a 4.2.0 environment with a 3.2.0 client",
+}, {
+	about:          "incompatible version (env major < client major - 1)",
+	tools:          []string{"3.2.0-quantal-amd64"},
+	currentVersion: "4.0.2-quantal-amd64",
+	agentVersion:   "2.0.0",
+	args:           []string{"--version", "3.2.0"},
+	expectErr:      "cannot upgrade a 2.0.0 environment with a 4.0.2 client",
 }, {
 	about:          "minor version downgrade to incompatible version",
 	tools:          []string{"3.2.0-quantal-amd64"},
@@ -301,8 +314,8 @@ func (s *UpgradeJujuSuite) TestUpgradeJuju(c *gc.C) {
 		s.PatchValue(&version.Current, current.Number)
 		s.PatchValue(&arch.HostArch, func() string { return current.Arch })
 		s.PatchValue(&series.HostSeries, func() string { return current.Series })
-		var com upgradeJujuCommand
-		if err := coretesting.InitCommand(envcmd.Wrap(&com), test.args); err != nil {
+		com := newUpgradeJujuCommand(test.upgradeMap)
+		if err := coretesting.InitCommand(com, test.args); err != nil {
 			if test.expectInitErr != "" {
 				c.Check(err, gc.ErrorMatches, test.expectInitErr)
 			} else {
@@ -329,7 +342,7 @@ func (s *UpgradeJujuSuite) TestUpgradeJuju(c *gc.C) {
 			envtesting.MustUploadFakeToolsVersions(stor, s.Environ.Config().AgentStream(), versions...)
 		}
 
-		err = envcmd.Wrap(&com).Run(coretesting.Context(c))
+		err = com.Run(coretesting.Context(c))
 		if test.expectErr != "" {
 			c.Check(err, gc.ErrorMatches, test.expectErr)
 			continue
@@ -427,7 +440,8 @@ func (s *UpgradeJujuSuite) Reset(c *gc.C) {
 
 func (s *UpgradeJujuSuite) TestUpgradeJujuWithRealUpload(c *gc.C) {
 	s.Reset(c)
-	cmd := envcmd.Wrap(&upgradeJujuCommand{})
+	s.PatchValue(&version.Current, version.MustParse("1.99.99"))
+	cmd := newUpgradeJujuCommand(map[int]version.Number{2: version.MustParse("1.99.99")})
 	_, err := coretesting.RunCommand(c, cmd, "--upload-tools")
 	c.Assert(err, jc.ErrorIsNil)
 	vers := version.Binary{
@@ -441,7 +455,8 @@ func (s *UpgradeJujuSuite) TestUpgradeJujuWithRealUpload(c *gc.C) {
 
 func (s *UpgradeJujuSuite) TestBlockUpgradeJujuWithRealUpload(c *gc.C) {
 	s.Reset(c)
-	cmd := envcmd.Wrap(&upgradeJujuCommand{})
+	s.PatchValue(&version.Current, version.MustParse("1.99.99"))
+	cmd := newUpgradeJujuCommand(map[int]version.Number{2: version.MustParse("1.99.99")})
 	// Block operation
 	s.BlockAllChanges(c, "TestBlockUpgradeJujuWithRealUpload")
 	_, err := coretesting.RunCommand(c, cmd, "--upload-tools")
@@ -463,14 +478,10 @@ func (s *UpgradeJujuSuite) TestUpgradeDryRun(c *gc.C) {
 			about:          "dry run outputs and doesn't change anything when uploading tools",
 			cmdArgs:        []string{"--upload-tools", "--dry-run"},
 			tools:          []string{"2.1.0-quantal-amd64", "2.1.2-quantal-i386", "2.1.3-quantal-amd64", "2.1-dev1-quantal-amd64", "2.2.3-quantal-amd64"},
-			currentVersion: "2.0.0-quantal-amd64",
+			currentVersion: "2.1.3-quantal-amd64",
 			agentVersion:   "2.0.0",
 			expectedCmdOutput: `available tools:
-    2.1-dev1-quantal-amd64
-    2.1.0-quantal-amd64
-    2.1.2-quantal-i386
     2.1.3-quantal-amd64
-    2.2.3-quantal-amd64
 best version:
     2.1.3
 upgrade to this version by running
@@ -518,36 +529,14 @@ upgrade to this version by running
 		s.Reset(c)
 		tools.DefaultBaseURL = ""
 
-		current := version.MustParseBinary(test.currentVersion)
-		s.PatchValue(&version.Current, current.Number)
-		s.PatchValue(&arch.HostArch, func() string { return current.Arch })
-		s.PatchValue(&series.HostSeries, func() string { return current.Series })
-		var com upgradeJujuCommand
-		err := coretesting.InitCommand(envcmd.Wrap(&com), test.cmdArgs)
-		c.Assert(err, jc.ErrorIsNil)
-		toolsDir := c.MkDir()
-		updateAttrs := map[string]interface{}{
-			"agent-version":      test.agentVersion,
-			"agent-metadata-url": "file://" + toolsDir + "/tools",
-		}
+		s.setUpEnvAndTools(c, test.currentVersion, test.agentVersion, test.tools)
 
-		err = s.State.UpdateEnvironConfig(updateAttrs, nil, nil)
+		com := newUpgradeJujuCommand(nil)
+		err := coretesting.InitCommand(com, test.cmdArgs)
 		c.Assert(err, jc.ErrorIsNil)
-		versions := make([]version.Binary, len(test.tools))
-		for i, v := range test.tools {
-			versions[i], err = version.ParseBinary(v)
-			if err != nil {
-				c.Assert(err, jc.Satisfies, series.IsUnknownOSForSeriesError)
-			}
-		}
-		if len(versions) > 0 {
-			stor, err := filestorage.NewFileStorageWriter(toolsDir)
-			c.Assert(err, jc.ErrorIsNil)
-			envtesting.MustUploadFakeToolsVersions(stor, s.Environ.Config().AgentStream(), versions...)
-		}
 
 		ctx := coretesting.Context(c)
-		err = envcmd.Wrap(&com).Run(ctx)
+		err = com.Run(ctx)
 		c.Assert(err, jc.ErrorIsNil)
 
 		// Check agent version doesn't change
@@ -558,6 +547,173 @@ upgrade to this version by running
 		c.Assert(agentVer, gc.Equals, version.MustParse(test.agentVersion))
 		output := coretesting.Stderr(ctx)
 		c.Assert(output, gc.Equals, test.expectedCmdOutput)
+	}
+}
+
+func (s *UpgradeJujuSuite) setUpEnvAndTools(c *gc.C, currentVersion string, agentVersion string, tools []string) {
+	current := version.MustParseBinary(currentVersion)
+	s.PatchValue(&version.Current, current.Number)
+	s.PatchValue(&arch.HostArch, func() string { return current.Arch })
+	s.PatchValue(&series.HostSeries, func() string { return current.Series })
+
+	toolsDir := c.MkDir()
+	updateAttrs := map[string]interface{}{
+		"agent-version":      agentVersion,
+		"agent-metadata-url": "file://" + toolsDir + "/tools",
+	}
+
+	err := s.State.UpdateEnvironConfig(updateAttrs, nil, nil)
+	c.Assert(err, jc.ErrorIsNil)
+	versions := make([]version.Binary, len(tools))
+	for i, v := range tools {
+		versions[i], err = version.ParseBinary(v)
+		if err != nil {
+			c.Assert(err, jc.Satisfies, series.IsUnknownOSForSeriesError)
+		}
+	}
+	if len(versions) > 0 {
+		stor, err := filestorage.NewFileStorageWriter(toolsDir)
+		c.Assert(err, jc.ErrorIsNil)
+		envtesting.MustUploadFakeToolsVersions(stor, s.Environ.Config().AgentStream(), versions...)
+	}
+}
+
+func (s *UpgradeJujuSuite) TestUpgradesDifferentMajor(c *gc.C) {
+	toolsList49Only := `available tools:
+    4.9.0-trusty-amd64
+best version:
+    4.9.0
+`
+	tests := []struct {
+		about             string
+		cmdArgs           []string
+		tools             []string
+		currentVersion    string
+		agentVersion      string
+		expectedVersion   string
+		expectedCmdOutput string
+		expectedLogOutput string
+		excludedLogOutput string
+		expectedErr       string
+		upgradeMap        map[int]version.Number
+	}{{
+		about:             "upgrade previous major to latest previous major",
+		tools:             []string{"5.0.1-trusty-amd64", "4.9.0-trusty-amd64"},
+		currentVersion:    "5.0.0-trusty-amd64",
+		agentVersion:      "4.8.5",
+		expectedVersion:   "4.9.0",
+		expectedCmdOutput: toolsList49Only,
+		expectedLogOutput: `.*version 4.9.0 incompatible with this client \(5.0.0\).*started upgrade to 4.9.0.*`,
+	}, {
+		about:             "upgrade previous major to latest previous major --dry-run still warns",
+		tools:             []string{"5.0.1-trusty-amd64", "4.9.0-trusty-amd64"},
+		currentVersion:    "5.0.1-trusty-amd64",
+		agentVersion:      "4.8.5",
+		expectedVersion:   "4.9.0",
+		expectedCmdOutput: toolsList49Only,
+		expectedLogOutput: `.*version 4.9.0 incompatible with this client \(5.0.1\).*started upgrade to 4.9.0.*`,
+	}, {
+		about:             "upgrade previous major to latest previous major with --version",
+		cmdArgs:           []string{"--version=4.9.0"},
+		tools:             []string{"5.0.2-trusty-amd64", "4.9.0-trusty-amd64", "4.8.0-trusty-amd64"},
+		currentVersion:    "5.0.2-trusty-amd64",
+		agentVersion:      "4.7.5",
+		expectedVersion:   "4.9.0",
+		expectedCmdOutput: toolsList49Only,
+		expectedLogOutput: `.*version 4.9.0 incompatible with this client \(5.0.2\).*started upgrade to 4.9.0.*`,
+	}, {
+		about:             "can upgrade lower major version to current major version at minimum level",
+		cmdArgs:           []string{"--version=6.0.5"},
+		tools:             []string{"6.0.5-trusty-amd64", "5.9.9-trusty-amd64"},
+		currentVersion:    "6.0.0-trusty-amd64",
+		agentVersion:      "5.9.8",
+		expectedVersion:   "6.0.5",
+		excludedLogOutput: `incompatible with this client (6.0.0)`,
+		upgradeMap:        map[int]version.Number{6: version.MustParse("5.9.8")},
+	}, {
+		about:             "can upgrade lower major version to current major version above minimum level",
+		cmdArgs:           []string{"--version=6.0.5"},
+		tools:             []string{"6.0.5-trusty-amd64", "5.11.0-trusty-amd64"},
+		currentVersion:    "6.0.1-trusty-amd64",
+		agentVersion:      "5.10.8",
+		expectedVersion:   "6.0.5",
+		excludedLogOutput: `incompatible with this client (6.0.1)`,
+		upgradeMap:        map[int]version.Number{6: version.MustParse("5.9.8")},
+	}, {
+		about:           "can upgrade current to next major version",
+		cmdArgs:         []string{"--version=6.0.5"},
+		tools:           []string{"6.0.5-trusty-amd64", "5.11.0-trusty-amd64"},
+		currentVersion:  "5.10.8-trusty-amd64",
+		agentVersion:    "5.10.8",
+		expectedVersion: "6.0.5",
+		upgradeMap:      map[int]version.Number{6: version.MustParse("5.9.8")},
+	}, {
+		about:             "upgrade fails if not at minimum version",
+		cmdArgs:           []string{"--version=7.0.1"},
+		tools:             []string{"7.0.1-trusty-amd64"},
+		currentVersion:    "7.0.1-trusty-amd64",
+		agentVersion:      "6.0.0",
+		expectedVersion:   "6.0.0",
+		expectedCmdOutput: "upgrades to a new major version must first go through 6.7.8\n",
+		expectedErr:       "unable to upgrade to requested version",
+		upgradeMap:        map[int]version.Number{7: version.MustParse("6.7.8")},
+	}, {
+		about:             "upgrade fails if not a minor of 0",
+		cmdArgs:           []string{"--version=7.1.1"},
+		tools:             []string{"7.0.1-trusty-amd64", "7.1.1-trusty-amd64"},
+		currentVersion:    "7.0.1-trusty-amd64",
+		agentVersion:      "6.7.8",
+		expectedVersion:   "6.7.8",
+		expectedCmdOutput: "upgrades to 7.1.1 must first go through juju 7.0\n",
+		expectedErr:       "unable to upgrade to requested version",
+		upgradeMap:        map[int]version.Number{7: version.MustParse("6.7.8")},
+	}, {
+		about:           "upgrade fails if not at minimum version and not a minor of 0",
+		cmdArgs:         []string{"--version=7.1.1"},
+		tools:           []string{"7.0.1-trusty-amd64", "7.1.1-trusty-amd64"},
+		currentVersion:  "7.0.1-trusty-amd64",
+		agentVersion:    "6.0.0",
+		expectedVersion: "6.0.0",
+		expectedCmdOutput: "upgrades to 7.1.1 must first go through juju 7.0\n" +
+			"upgrades to a new major version must first go through 6.7.8\n",
+		expectedErr: "unable to upgrade to requested version",
+		upgradeMap:  map[int]version.Number{7: version.MustParse("6.7.8")},
+	}}
+	for i, test := range tests {
+		c.Logf("\ntest %d: %s", i, test.about)
+		s.Reset(c)
+		tools.DefaultBaseURL = ""
+
+		s.setUpEnvAndTools(c, test.currentVersion, test.agentVersion, test.tools)
+
+		com := newUpgradeJujuCommand(test.upgradeMap)
+		err := coretesting.InitCommand(com, test.cmdArgs)
+		c.Assert(err, jc.ErrorIsNil)
+
+		ctx := coretesting.Context(c)
+		err = com.Run(ctx)
+		if test.expectedErr != "" {
+			c.Check(err, gc.ErrorMatches, test.expectedErr)
+		} else if !c.Check(err, jc.ErrorIsNil) {
+			continue
+		}
+
+		// Check agent version doesn't change
+		cfg, err := s.State.EnvironConfig()
+		c.Assert(err, jc.ErrorIsNil)
+		agentVer, ok := cfg.AgentVersion()
+		c.Assert(ok, jc.IsTrue)
+		c.Check(agentVer, gc.Equals, version.MustParse(test.expectedVersion))
+		output := coretesting.Stderr(ctx)
+		if test.expectedCmdOutput != "" {
+			c.Check(output, gc.Equals, test.expectedCmdOutput)
+		}
+		if test.expectedLogOutput != "" {
+			c.Check(strings.Replace(c.GetTestLog(), "\n", " ", -1), gc.Matches, test.expectedLogOutput)
+		}
+		if test.excludedLogOutput != "" {
+			c.Check(c.GetTestLog(), gc.Not(jc.Contains), test.excludedLogOutput)
+		}
 	}
 }
 

--- a/scripts/win-installer/setup.iss
+++ b/scripts/win-installer/setup.iss
@@ -2,7 +2,7 @@
 ; SEE THE DOCUMENTATION FOR DETAILS ON CREATING INNO SETUP SCRIPT FILES!
 
 #define MyAppName "Juju"
-#define MyAppVersion "1.26-alpha4"
+#define MyAppVersion "2.0-alpha1"
 #define MyAppPublisher "Canonical, Ltd"
 #define MyAppURL "http://juju.ubuntu.com/"
 #define MyAppExeName "juju.exe"

--- a/version/version.go
+++ b/version/version.go
@@ -23,7 +23,7 @@ import (
 // The presence and format of this constant is very important.
 // The debian/rules build recipe uses this value for the version
 // number of the release package.
-const version = "1.26-alpha4"
+const version = "2.0-alpha1"
 
 // The version that we switched over from old style numbering to new style.
 var switchOverVersion = MustParse("1.19.9")


### PR DESCRIPTION
This patch updates the upgrade-juju command to
generically allow upgrades between major versions
with the following restrictions:

- A client may upgrade a juju environment of a
different major number if:
    - The client has a minor of 0.
    - The major of the environment is
      the previous major number than
      the client.
- An upgrade to a new major version is allowed if:
    - It was explicitly requested by the user
      by either --version or --upload-tools.
    - The environment is running the minimum
      version (or later) to upgrade from.  For
      2.0, the minimum version is 1.25.2.
    - The version requested has a minor number
      of 0.

This patch also increments the juju version to
2.0-alpha1

(Review request: http://reviews.vapour.ws/r/3490/)