### PR TITLE
Store lists of image metadata atomically

### DIFF
--- a/api/imagemetadata/client.go
+++ b/api/imagemetadata/client.go
@@ -48,14 +48,22 @@ func (c *Client) List(
 
 // Save saves specified image metadata.
 // Supports bulk saves for scenarios like cloud image metadata caching at bootstrap.
-func (c *Client) Save(metadata []params.CloudImageMetadata) ([]params.ErrorResult, error) {
-	in := params.MetadataSaveParams{Metadata: metadata}
+func (c *Client) Save(metadata []params.CloudImageMetadata) error {
+	in := params.MetadataSaveParams{
+		Metadata: []params.CloudImageMetadataList{{metadata}},
+	}
 	out := params.ErrorResults{}
 	err := c.facade.FacadeCall("Save", in, &out)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return errors.Trace(err)
 	}
-	return out.Results, nil
+	if len(out.Results) != 1 {
+		return errors.Errorf("exected 1 result, got %d", len(out.Results))
+	}
+	if out.Results[0].Error != nil {
+		return errors.Trace(out.Results[0].Error)
+	}
+	return nil
 }
 
 // UpdateFromPublishedImages retrieves currently published image metadata and

--- a/apiserver/imagemetadata/metadata_test.go
+++ b/apiserver/imagemetadata/metadata_test.go
@@ -114,9 +114,10 @@ func (s *metadataSuite) TestSave(c *gc.C) {
 	msg := "save error"
 
 	saveCalls := 0
-	s.state.saveMetadata = func(m cloudimagemetadata.Metadata) error {
+	s.state.saveMetadata = func(m []cloudimagemetadata.Metadata) error {
 		s.calls = append(s.calls, saveMetadata)
 		saveCalls += 1
+		c.Assert(m, gc.HasLen, saveCalls)
 		if saveCalls == 1 {
 			// don't err on first call
 			return nil
@@ -124,7 +125,13 @@ func (s *metadataSuite) TestSave(c *gc.C) {
 		return errors.New(msg)
 	}
 
-	errs, err := s.api.Save(params.MetadataSaveParams{Metadata: []params.CloudImageMetadata{m, m}})
+	errs, err := s.api.Save(params.MetadataSaveParams{
+		Metadata: []params.CloudImageMetadataList{{
+			Metadata: []params.CloudImageMetadata{m},
+		}, {
+			Metadata: []params.CloudImageMetadata{m, m},
+		}},
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(errs.Results, gc.HasLen, 2)
 	c.Assert(errs.Results[0].Error, gc.IsNil)

--- a/apiserver/imagemetadata/package_test.go
+++ b/apiserver/imagemetadata/package_test.go
@@ -77,7 +77,7 @@ func (s *baseImageMetadataSuite) constructState(cfg *config.Config) *mockState {
 			s.calls = append(s.calls, findMetadata)
 			return nil, nil
 		},
-		saveMetadata: func(m cloudimagemetadata.Metadata) error {
+		saveMetadata: func(m []cloudimagemetadata.Metadata) error {
 			s.calls = append(s.calls, saveMetadata)
 			return nil
 		},
@@ -90,7 +90,7 @@ func (s *baseImageMetadataSuite) constructState(cfg *config.Config) *mockState {
 
 type mockState struct {
 	findMetadata  func(f cloudimagemetadata.MetadataFilter) (map[string][]cloudimagemetadata.Metadata, error)
-	saveMetadata  func(m cloudimagemetadata.Metadata) error
+	saveMetadata  func(m []cloudimagemetadata.Metadata) error
 	environConfig func() (*config.Config, error)
 }
 
@@ -98,7 +98,7 @@ func (st *mockState) FindMetadata(f cloudimagemetadata.MetadataFilter) (map[stri
 	return st.findMetadata(f)
 }
 
-func (st *mockState) SaveMetadata(m cloudimagemetadata.Metadata) error {
+func (st *mockState) SaveMetadata(m []cloudimagemetadata.Metadata) error {
 	return st.saveMetadata(m)
 }
 

--- a/apiserver/imagemetadata/state.go
+++ b/apiserver/imagemetadata/state.go
@@ -11,7 +11,7 @@ import (
 
 type metadataAcess interface {
 	FindMetadata(cloudimagemetadata.MetadataFilter) (map[string][]cloudimagemetadata.Metadata, error)
-	SaveMetadata(cloudimagemetadata.Metadata) error
+	SaveMetadata([]cloudimagemetadata.Metadata) error
 	EnvironConfig() (*config.Config, error)
 }
 
@@ -27,6 +27,6 @@ func (s stateShim) FindMetadata(f cloudimagemetadata.MetadataFilter) (map[string
 	return s.State.CloudImageMetadataStorage.FindMetadata(f)
 }
 
-func (s stateShim) SaveMetadata(m cloudimagemetadata.Metadata) error {
+func (s stateShim) SaveMetadata(m []cloudimagemetadata.Metadata) error {
 	return s.State.CloudImageMetadataStorage.SaveMetadata(m)
 }

--- a/apiserver/imagemetadata/updatefrompublished_test.go
+++ b/apiserver/imagemetadata/updatefrompublished_test.go
@@ -171,9 +171,9 @@ func (s *imageMetadataUpdateSuite) TestUpdateFromPublishedImagesForProviderWithN
 		return env.Config(), err
 	}
 
-	s.state.saveMetadata = func(m cloudimagemetadata.Metadata) error {
+	s.state.saveMetadata = func(m []cloudimagemetadata.Metadata) error {
 		s.calls = append(s.calls, saveMetadata)
-		saved = append(saved, m)
+		saved = append(saved, m...)
 		return nil
 	}
 
@@ -296,9 +296,9 @@ func (s *regionMetadataSuite) setExpectations(c *gc.C) {
 		return s.env.Config(), nil
 	}
 
-	s.state.saveMetadata = func(m cloudimagemetadata.Metadata) error {
+	s.state.saveMetadata = func(m []cloudimagemetadata.Metadata) error {
 		s.calls = append(s.calls, saveMetadata)
-		s.saved = append(s.saved, m)
+		s.saved = append(s.saved, m...)
 		return nil
 	}
 }
@@ -307,10 +307,7 @@ func (s *regionMetadataSuite) checkStoredPublished(c *gc.C) {
 	err := s.api.UpdateFromPublishedImages()
 	c.Assert(err, jc.ErrorIsNil)
 
-	tempCalls := []string{environConfig, environConfig}
-	for _ = range s.expected {
-		tempCalls = append(tempCalls, saveMetadata)
-	}
+	tempCalls := []string{environConfig, environConfig, saveMetadata}
 	s.assertCalls(c, tempCalls)
 
 	c.Assert(s.saved, jc.SameContents, s.expected)
@@ -427,7 +424,7 @@ func (s *regionMetadataSuite) TestUpdateFromPublishedImagesMultipleDS(c *gc.C) {
 
 	err = s.api.UpdateFromPublishedImages()
 	c.Assert(err, jc.ErrorIsNil)
-	calls := []string{environConfig, environConfig, saveMetadata, environConfig, saveMetadata, saveMetadata}
+	calls := []string{environConfig, environConfig, saveMetadata, environConfig, saveMetadata}
 	s.assertCalls(c, calls)
 	c.Assert(s.saved, jc.SameContents, s.expected)
 }

--- a/apiserver/params/image_metadata.go
+++ b/apiserver/params/image_metadata.go
@@ -72,7 +72,13 @@ type ListCloudImageMetadataResult struct {
 	Result []CloudImageMetadata `json:"result"`
 }
 
-// MetadataSaveParams holds cloud image metadata details to save.
+// MetadataSaveParams holds lists of cloud image metadata to save. Each list
+// will be saved atomically.
 type MetadataSaveParams struct {
-	Metadata []CloudImageMetadata `json:"metadata"`
+	Metadata []CloudImageMetadataList `json:"metadata,omitempty"`
+}
+
+// CloudImageMetadataList holds a list of cloud image metadata.
+type CloudImageMetadataList struct {
+	Metadata []CloudImageMetadata `json:"metadata,omitempty"`
 }

--- a/apiserver/provisioner/imagemetadata_test.go
+++ b/apiserver/provisioner/imagemetadata_test.go
@@ -99,7 +99,9 @@ func (s *ImageMetadataSuite) TestMetadataFromState(c *gc.C) {
 	// Write metadata to state.
 	metadata := s.convertCloudImageMetadata(expected[0])
 	for _, m := range metadata {
-		err := s.State.CloudImageMetadataStorage.SaveMetadata(m)
+		err := s.State.CloudImageMetadataStorage.SaveMetadata(
+			[]cloudimagemetadata.Metadata{m},
+		)
 		c.Assert(err, jc.ErrorIsNil)
 	}
 

--- a/cmd/jujud/bootstrap.go
+++ b/cmd/jujud/bootstrap.go
@@ -473,8 +473,8 @@ func storeImageMetadataInState(st *state.State, source string, priority int, exi
 	if len(existingMetadata) == 0 {
 		return nil
 	}
-	msg := ""
-	for _, one := range existingMetadata {
+	metadataState := make([]cloudimagemetadata.Metadata, len(existingMetadata))
+	for i, one := range existingMetadata {
 		m := cloudimagemetadata.Metadata{
 			cloudimagemetadata.MetadataAttributes{
 				Stream:          one.Stream,
@@ -492,13 +492,10 @@ func storeImageMetadataInState(st *state.State, source string, priority int, exi
 			return errors.Annotatef(err, "cannot determine series for version %v", one.Version)
 		}
 		m.Series = s
-		err = st.CloudImageMetadataStorage.SaveMetadata(m)
-		if err != nil {
-			return errors.Annotatef(err, "cannot cache image metadata %v", m)
-		}
+		metadataState[i] = m
 	}
-	if len(msg) > 0 {
-		return errors.New(msg)
+	if err := st.CloudImageMetadataStorage.SaveMetadata(metadataState); err != nil {
+		return errors.Annotatef(err, "cannot cache image metadata")
 	}
 	return nil
 }

--- a/cmd/plugins/juju-metadata/addimage.go
+++ b/cmd/plugins/juju-metadata/addimage.go
@@ -4,8 +4,6 @@
 package main
 
 import (
-	"fmt"
-
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/utils/series"
@@ -108,18 +106,8 @@ func (c *addImageMetadataCommand) Run(ctx *cmd.Context) (err error) {
 	defer api.Close()
 
 	m := c.constructMetadataParam()
-	found, err := api.Save([]params.CloudImageMetadata{m})
-	if err != nil {
-		return err
-	}
-	if len(found) == 0 {
-		return nil
-	}
-	if len(found) > 1 {
-		return errors.New(fmt.Sprintf("expected one result, got %d", len(found)))
-	}
-	if found[0].Error != nil {
-		return errors.New(found[0].Error.GoString())
+	if err := api.Save([]params.CloudImageMetadata{m}); err != nil {
+		return errors.Trace(err)
 	}
 	return nil
 }
@@ -127,7 +115,7 @@ func (c *addImageMetadataCommand) Run(ctx *cmd.Context) (err error) {
 // MetadataAddAPI defines the API methods that add image metadata command uses.
 type MetadataAddAPI interface {
 	Close() error
-	Save(metadata []params.CloudImageMetadata) ([]params.ErrorResult, error)
+	Save(metadata []params.CloudImageMetadata) error
 }
 
 var getImageMetadataAddAPI = (*addImageMetadataCommand).getImageMetadataAddAPI

--- a/featuretests/cloudimagemetadata_test.go
+++ b/featuretests/cloudimagemetadata_test.go
@@ -56,10 +56,8 @@ func (s *cloudImageMetadataSuite) TestSaveAndFindMetadata(c *gc.C) {
 		ImageId:         "1",
 	}
 
-	errs, err := s.client.Save([]params.CloudImageMetadata{m})
+	err = s.client.Save([]params.CloudImageMetadata{m})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(errs, gc.HasLen, 1)
-	c.Assert(errs[0].Error, gc.IsNil)
 
 	added, err := s.client.List("", "", nil, nil, "", "")
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/cloudimagemetadata/image_test.go
+++ b/state/cloudimagemetadata/image_test.go
@@ -42,18 +42,29 @@ func (s *cloudImageMetadataSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *cloudImageMetadataSuite) TestSaveMetadata(c *gc.C) {
-	attrs := cloudimagemetadata.MetadataAttributes{
+	attrs1 := cloudimagemetadata.MetadataAttributes{
 		Stream:          "stream",
 		Region:          "region-test",
 		Version:         "14.04",
 		Series:          "trusty",
 		Arch:            "arch",
 		VirtType:        "virtType-test",
-		RootStorageType: "rootStorageType-test"}
-
-	added := cloudimagemetadata.Metadata{attrs, 0, "1"}
-	s.assertRecordMetadata(c, added)
-	s.assertMetadataRecorded(c, attrs, added)
+		RootStorageType: "rootStorageType-test",
+	}
+	attrs2 := cloudimagemetadata.MetadataAttributes{
+		Stream:  "chalk",
+		Region:  "nether",
+		Version: "12.04",
+		Series:  "precise",
+		Arch:    "amd64",
+	}
+	added := []cloudimagemetadata.Metadata{
+		{attrs1, 0, "1"},
+		{attrs2, 0, "2"},
+	}
+	s.assertRecordMetadata(c, added[0])
+	s.assertRecordMetadata(c, added[1])
+	s.assertMetadataRecorded(c, cloudimagemetadata.MetadataAttributes{}, added...)
 }
 
 func (s *cloudImageMetadataSuite) TestFindMetadataNotFound(c *gc.C) {
@@ -251,7 +262,7 @@ func (s *cloudImageMetadataSuite) TestSaveMetadataNoSeriesPassed(c *gc.C) {
 		Arch:   "arch",
 	}
 	metadata0 := cloudimagemetadata.Metadata{attrs, 0, "1"}
-	err := s.storage.SaveMetadata(metadata0)
+	err := s.storage.SaveMetadata([]cloudimagemetadata.Metadata{metadata0})
 	c.Assert(err, gc.ErrorMatches, regexp.QuoteMeta(`missing series: metadata for image 1 not valid`))
 }
 
@@ -262,7 +273,7 @@ func (s *cloudImageMetadataSuite) TestSaveMetadataUnsupportedSeriesPassed(c *gc.
 		Arch:   "arch",
 	}
 	metadata0 := cloudimagemetadata.Metadata{attrs, 0, "1"}
-	err := s.storage.SaveMetadata(metadata0)
+	err := s.storage.SaveMetadata([]cloudimagemetadata.Metadata{metadata0})
 	c.Assert(err, gc.ErrorMatches, regexp.QuoteMeta(`unknown version for series: "blah"`))
 }
 
@@ -276,7 +287,7 @@ func (s *cloudImageMetadataSuite) assertConcurrentSave(c *gc.C, metadata0, metad
 }
 
 func (s *cloudImageMetadataSuite) assertRecordMetadata(c *gc.C, m cloudimagemetadata.Metadata) {
-	err := s.storage.SaveMetadata(m)
+	err := s.storage.SaveMetadata([]cloudimagemetadata.Metadata{m})
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/state/cloudimagemetadata/interface.go
+++ b/state/cloudimagemetadata/interface.go
@@ -57,7 +57,7 @@ type Metadata struct {
 type Storage interface {
 	// SaveMetadata adds cloud images metadata into state if it's new or
 	// updates metadata if it already exists,
-	SaveMetadata(Metadata) error
+	SaveMetadata([]Metadata) error
 
 	// FindMetadata returns all Metadata that match specified
 	// criteria or a "not found" error if none match.

--- a/worker/provisioner/provisioner_test.go
+++ b/worker/provisioner/provisioner_test.go
@@ -124,7 +124,7 @@ func (s *CommonProvisionerSuite) SetUpTest(c *gc.C) {
 	// We do not want to pull published image metadata for tests...
 	imagetesting.PatchOfficialDataSources(&s.CleanupSuite, "")
 	// We want an image to start test instances
-	m := cloudimagemetadata.Metadata{
+	err := s.State.CloudImageMetadataStorage.SaveMetadata([]cloudimagemetadata.Metadata{{
 		cloudimagemetadata.MetadataAttributes{
 			Region:          "region",
 			Series:          "trusty",
@@ -135,8 +135,7 @@ func (s *CommonProvisionerSuite) SetUpTest(c *gc.C) {
 		},
 		10,
 		"-999",
-	}
-	err := s.State.CloudImageMetadataStorage.SaveMetadata(m)
+	}})
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Create the operations channel with more than enough space


### PR DESCRIPTION
The provisioner will fetch image metadata from state,
and if there is some, use that. Only if there are no
metadata matching the search criteria will it fall
back to searching the public image metadata.

Therefore, the provisioner should not be allowed to
see partial sets of image metadata, or it may not
see the subset that it is interested in. We are
currently saving image metadata one at a time; we
change it to save sets of metadata atomically.

Fixes https://bugs.launchpad.net/juju-core/+bug/1528932

(Review request: http://reviews.vapour.ws/r/3491/)