### PR TITLE
Preserve resource size across the API.

### DIFF
--- a/resource/api/data.go
+++ b/resource/api/data.go
@@ -111,6 +111,9 @@ type CharmResource struct {
 
 	// Fingerprint is the SHA-384 checksum for the resource blob.
 	Fingerprint []byte `json:"fingerprint"`
+
+	// Size is the size of the resource, in bytes.
+	Size int64
 }
 
 func resolveErrors(errs []error) error {

--- a/resource/api/helpers.go
+++ b/resource/api/helpers.go
@@ -99,6 +99,7 @@ func CharmResource2API(res charmresource.Resource) CharmResource {
 		Origin:      res.Origin.String(),
 		Revision:    res.Revision,
 		Fingerprint: res.Fingerprint.Bytes(),
+		Size:        res.Size,
 	}
 }
 
@@ -135,6 +136,7 @@ func API2CharmResource(apiInfo CharmResource) (charmresource.Resource, error) {
 		Origin:      origin,
 		Revision:    apiInfo.Revision,
 		Fingerprint: fp,
+		Size:        apiInfo.Size,
 	}
 
 	if err := res.Validate(); err != nil {

--- a/resource/api/helpers_test.go
+++ b/resource/api/helpers_test.go
@@ -46,6 +46,7 @@ func (helpersSuite) TestResource2API(c *gc.C) {
 			Origin:      charmresource.OriginUpload,
 			Revision:    1,
 			Fingerprint: fp,
+			Size:        10,
 		},
 		Username:  "a-user",
 		Timestamp: now,
@@ -63,6 +64,7 @@ func (helpersSuite) TestResource2API(c *gc.C) {
 			Origin:      "upload",
 			Revision:    1,
 			Fingerprint: []byte(fingerprint),
+			Size:        10,
 		},
 		Username:  "a-user",
 		Timestamp: now,
@@ -84,6 +86,7 @@ func (helpersSuite) TestAPIResult2ResourcesOkay(c *gc.C) {
 			Origin:      charmresource.OriginUpload,
 			Revision:    1,
 			Fingerprint: fp,
+			Size:        10,
 		},
 		Username:  "a-user",
 		Timestamp: now,
@@ -99,6 +102,7 @@ func (helpersSuite) TestAPIResult2ResourcesOkay(c *gc.C) {
 			Origin:      "upload",
 			Revision:    1,
 			Fingerprint: []byte(fingerprint),
+			Size:        10,
 		},
 		Username:  "a-user",
 		Timestamp: now,
@@ -125,6 +129,7 @@ func (helpersSuite) TestAPIResult2ResourcesFailure(c *gc.C) {
 			Origin:      "upload",
 			Revision:    1,
 			Fingerprint: []byte(fingerprint),
+			Size:        10,
 		},
 	}
 	failure := errors.New("<failure>")
@@ -153,6 +158,7 @@ func (helpersSuite) TestAPIResult2ResourcesNotFound(c *gc.C) {
 			Origin:      "upload",
 			Revision:    1,
 			Fingerprint: []byte(fingerprint),
+			Size:        10,
 		},
 	}
 
@@ -182,6 +188,7 @@ func (helpersSuite) TestAPI2Resource(c *gc.C) {
 			Origin:      "upload",
 			Revision:    1,
 			Fingerprint: []byte(fingerprint),
+			Size:        10,
 		},
 		Username:  "a-user",
 		Timestamp: now,
@@ -201,6 +208,7 @@ func (helpersSuite) TestAPI2Resource(c *gc.C) {
 			Origin:      charmresource.OriginUpload,
 			Revision:    1,
 			Fingerprint: fp,
+			Size:        10,
 		},
 		Username:  "a-user",
 		Timestamp: now,
@@ -224,6 +232,7 @@ func (helpersSuite) TestCharmResource2API(c *gc.C) {
 		Origin:      charmresource.OriginUpload,
 		Revision:    1,
 		Fingerprint: fp,
+		Size:        10,
 	}
 	err = res.Validate()
 	c.Assert(err, jc.ErrorIsNil)
@@ -237,6 +246,7 @@ func (helpersSuite) TestCharmResource2API(c *gc.C) {
 		Origin:      "upload",
 		Revision:    1,
 		Fingerprint: []byte(fingerprint),
+		Size:        10,
 	})
 }
 
@@ -249,6 +259,7 @@ func (helpersSuite) TestAPI2CharmResource(c *gc.C) {
 		Origin:      "upload",
 		Revision:    1,
 		Fingerprint: []byte(fingerprint),
+		Size:        10,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -264,6 +275,7 @@ func (helpersSuite) TestAPI2CharmResource(c *gc.C) {
 		Origin:      charmresource.OriginUpload,
 		Revision:    1,
 		Fingerprint: fp,
+		Size:        10,
 	}
 	err = expected.Validate()
 	c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
This bit slipped through when we added the size field.

(Review request: http://reviews.vapour.ws/r/3495/)