### PR TITLE
Fix lp1525280 - disambiguate container hostnames for devices on MAAS

### DIFF
--- a/apiserver/provisioner/container_test.go
+++ b/apiserver/provisioner/container_test.go
@@ -218,17 +218,23 @@ func (s *prepareSuite) TestErrorWithNoFeatureFlagAllocateSuccess(c *gc.C) {
 	container := s.newCustomAPI(c, "i-alloc-me", true, false)
 	args := s.makeArgs(container)
 	_, testLog := s.assertCall(c, args, s.makeResults([]params.NetworkConfig{{
-		DeviceIndex:   0,
-		InterfaceName: "eth0",
-		ConfigType:    "dhcp",
-		MACAddress:    "regex:" + regexpMACAddress,
-		ProviderId:    "juju-private",
-		NetworkName:   "juju-private",
+		DeviceIndex:    0,
+		NetworkName:    "juju-private",
+		ProviderId:     "dummy-eth0",
+		InterfaceName:  "eth0",
+		DNSServers:     []string{"ns1.dummy", "ns2.dummy"},
+		GatewayAddress: "0.10.0.1",
+		ConfigType:     "static",
+		MACAddress:     "regex:" + regexpMACAddress,
+		Address:        "regex:0.10.0.[0-9]{1,3}", // we don't care about the actual value.
 	}}), "")
 
 	c.Assert(testLog, jc.LogMatches, jc.SimpleMessages{{
 		loggo.INFO,
-		`reserved address for container "0/lxc/0" with MAC address ".+" \(using DHCP\)`,
+		`allocated address ".+" on instance "i-alloc-me" for container "juju-machine-0-lxc-0"`,
+	}, {
+		loggo.INFO,
+		`assigned address ".+" to container "0/lxc/0"`,
 	}})
 }
 

--- a/apiserver/provisioner/provisioner.go
+++ b/apiserver/provisioner/provisioner.go
@@ -842,12 +842,6 @@ func (p *ProvisionerAPI) ReleaseContainerAddresses(args params.Entities) (params
 		Results: make([]params.ErrorResult, len(args.Entities)),
 	}
 
-	logger.Tracef("checking if the environment supports releasing addresses")
-	netEnviron, err := p.maybeGetNetworkingEnviron()
-	if err != nil {
-		return result, errors.Trace(err)
-	}
-
 	canAccess, err := p.getAuthFunc()
 	if err != nil {
 		logger.Errorf("failed to get an authorisation function: %v", err)
@@ -875,32 +869,6 @@ func (p *ProvisionerAPI) ReleaseContainerAddresses(args params.Entities) (params
 			result.Results[i].Error = common.ServerError(err)
 			continue
 		}
-
-		if !environs.AddressAllocationEnabled() {
-			logger.Tracef("trying to release all addresses for container %q", container.Id())
-			// Even if the address allocation feature flag is not enabled, we
-			// might be running on MAAS 1.8+ with devices support, which we
-			// detected earlier when the container has started and registered a
-			// device for it. Now we can just call ReleaseAddress with the
-			// hostname set and the rest left empty.
-			zeroIP, zeroMAC := network.Address{}, ""
-			hostname := containerHostname(container.Tag())
-			err := netEnviron.ReleaseAddress(
-				instance.UnknownId,
-				network.AnySubnet,
-				zeroIP,
-				zeroMAC,
-				hostname,
-			)
-			logger.Tracef("ReleaseAddress for hostname %q returned: %v", hostname, err)
-			if err != nil {
-				// Likely not using MAAS 1.8+, just record the error.
-				result.Results[i].Error = common.ServerError(err)
-			}
-			continue
-		}
-		// With addressable containers feature flag enabled, the addresser will
-		// release the IPs once they are set to dead.
 
 		id := container.Id()
 		addresses, err := p.st.AllocatedIPAddresses(id)
@@ -998,6 +966,18 @@ func (p *ProvisionerAPI) prepareOrGetContainerInterfaceInfo(
 		if err != nil {
 			return result, errors.Annotate(err, "cannot allocate addresses")
 		}
+	} else {
+		var allInterfaceInfos []network.InterfaceInfo
+		allInterfaceInfos, err = environ.NetworkInterfaces(instId)
+		if err != nil {
+			return result, errors.Annotatef(err, "cannot instance %q interfaces", instId)
+		} else if len(allInterfaceInfos) == 0 {
+			return result, errors.New("no interfaces available")
+		}
+		// Currently we only support a single NIC per container, so we only need
+		// the information from the host instance's first NIC.
+		logger.Tracef("interfaces for instance %q: %v", instId, allInterfaceInfos)
+		interfaceInfo = allInterfaceInfos[0]
 	}
 
 	// Loop over the passed container tags.
@@ -1043,37 +1023,6 @@ func (p *ProvisionerAPI) prepareOrGetContainerInterfaceInfo(
 				result.Results[i].Error = common.ServerError(err)
 				continue
 			}
-			if address == nil {
-				// This is only an issue when the address allocation is enabled,
-				// as it should've been reported as an error after retrying a
-				// few times.
-				if !environs.AddressAllocationEnabled() {
-					// Without the feature flag, we might be running on MAAS
-					// 1.8+ in which case the container will use DHCP to get its
-					// IP, and it needs to use the generated MAC address.
-					result.Results[i] = params.MachineNetworkConfigResult{
-						Config: []params.NetworkConfig{{
-							DeviceIndex:   0,
-							InterfaceName: "eth0",
-							ConfigType:    string(network.ConfigDHCP),
-							MACAddress:    macAddress,
-							// The following should not be needed anymore, but the
-							// worker still validates them on SetProvisioned.
-							NetworkName: network.DefaultPrivate,
-							ProviderId:  network.DefaultPrivate,
-						}},
-					}
-					logger.Infof(
-						"reserved address for container %q with MAC address %q (using DHCP)",
-						container, macAddress,
-					)
-					continue
-				} else {
-					err = errors.New("expected allocated address, got nil and no error")
-					result.Results[i].Error = common.ServerError(err)
-					continue
-				}
-			}
 		} else {
 			id := container.Id()
 			addresses, err := p.st.AllocatedIPAddresses(id)
@@ -1094,15 +1043,17 @@ func (p *ProvisionerAPI) prepareOrGetContainerInterfaceInfo(
 			address = addresses[0]
 			macAddress = address.MACAddress()
 		}
+
 		// Store it on the machine, construct and set an interface result.
 		dnsServers := make([]string, len(interfaceInfo.DNSServers))
-		for i, dns := range interfaceInfo.DNSServers {
-			dnsServers[i] = dns.Value
+		for l, dns := range interfaceInfo.DNSServers {
+			dnsServers[l] = dns.Value
 		}
 
 		if macAddress == "" {
 			macAddress = interfaceInfo.MACAddress
 		}
+
 		// TODO(dimitern): Support allocating one address per NIC on
 		// the host, effectively creating the same number of NICs in
 		// the container.
@@ -1121,9 +1072,8 @@ func (p *ProvisionerAPI) prepareOrGetContainerInterfaceInfo(
 				DNSServers:       dnsServers,
 				ConfigType:       string(network.ConfigStatic),
 				Address:          address.Value(),
-				// container's gateway is the host's primary NIC's IP.
-				GatewayAddress: interfaceInfo.Address.Value,
-				ExtraConfig:    interfaceInfo.ExtraConfig,
+				GatewayAddress:   interfaceInfo.GatewayAddress.Value,
+				ExtraConfig:      interfaceInfo.ExtraConfig,
 			}},
 		}
 	}
@@ -1193,7 +1143,7 @@ func (p *ProvisionerAPI) prepareAllocationNetwork(
 	if err != nil {
 		return nil, subnetInfo, interfaceInfo, errors.Trace(err)
 	} else if len(interfaces) == 0 {
-		return nil, subnetInfo, interfaceInfo, errors.Errorf("no interfaces available")
+		return nil, subnetInfo, interfaceInfo, errors.New("no interfaces available")
 	}
 	logger.Tracef("interfaces for instance %q: %v", instId, interfaces)
 
@@ -1251,6 +1201,12 @@ func (p *ProvisionerAPI) prepareAllocationNetwork(
 		if err == nil && ok {
 			subnetInfo = sub
 			interfaceInfo = subnetIdToInterface[sub.ProviderId]
+
+			// Since with addressable containers the host acts like a gateway
+			// for the containers, instead of using the same gateway for the
+			// containers as their host's
+			interfaceInfo.GatewayAddress.Value = interfaceInfo.Address.Value
+
 			success = true
 			break
 		}
@@ -1301,15 +1257,30 @@ func (p *ProvisionerAPI) allocateAddress(
 		// register containers getting IPs via DHCP. However, most of the usual
 		// allocation code can be bypassed, we just need the parent instance ID
 		// and a MAC address (no subnet or IP address).
-		zeroIP := network.Address{}
-		err := environ.AllocateAddress(instId, network.AnySubnet, zeroIP, macAddress, hostname)
+		allocatedAddress := network.Address{}
+		err := environ.AllocateAddress(instId, network.AnySubnet, &allocatedAddress, macAddress, hostname)
 		if err != nil {
 			// Not using MAAS 1.8+ or some other error.
 			return nil, errors.Trace(err)
 		}
-		// No address to return since the container will be using DHCP (but the
-		// reserved address will be logged).
-		return nil, nil
+
+		logger.Infof(
+			"allocated address %q on instance %q for container %q",
+			allocatedAddress.String(), instId, hostname,
+		)
+
+		// Add the address to state, so we can look it up later by MAC address.
+		stateAddr, err := p.st.AddIPAddress(allocatedAddress, string(network.AnySubnet))
+		if err != nil {
+			return nil, errors.Annotatef(err, "failed to save address %q", allocatedAddress)
+		}
+
+		err = p.setAllocatedOrRelease(stateAddr, environ, instId, container, network.AnySubnet, macAddress)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+
+		return stateAddr, nil
 	}
 
 	subnetId := network.Id(subnet.ProviderId())
@@ -1318,9 +1289,10 @@ func (p *ProvisionerAPI) allocateAddress(
 		if err != nil {
 			return nil, err
 		}
+		netAddr := addr.Address()
 		logger.Tracef("picked new address %q on subnet %q", addr.String(), subnetId)
 		// Attempt to allocate with environ.
-		err = environ.AllocateAddress(instId, subnetId, addr.Address(), macAddress, hostname)
+		err = environ.AllocateAddress(instId, subnetId, &netAddr, macAddress, hostname)
 		if err != nil {
 			logger.Warningf(
 				"allocating address %q on instance %q and subnet %q failed: %v (retrying)",

--- a/apiserver/provisioner/provisioner.go
+++ b/apiserver/provisioner/provisioner.go
@@ -962,7 +962,7 @@ func (p *ProvisionerAPI) prepareOrGetContainerInterfaceInfo(
 	var interfaceInfo network.InterfaceInfo
 	if environs.AddressAllocationEnabled() {
 		// We don't need a subnet unless we need to allocate a static IP.
-		subnet, subnetInfo, interfaceInfo, err = p.prepareAllocationNetwork(environ, host, instId)
+		subnet, subnetInfo, interfaceInfo, err = p.prepareAllocationNetwork(environ, instId)
 		if err != nil {
 			return result, errors.Annotate(err, "cannot allocate addresses")
 		}
@@ -1128,7 +1128,6 @@ func (p *ProvisionerAPI) prepareContainerAccessEnvironment() (environs.Networkin
 // for the allocations.
 func (p *ProvisionerAPI) prepareAllocationNetwork(
 	environ environs.NetworkingEnviron,
-	host *state.Machine,
 	instId instance.Id,
 ) (
 	*state.Subnet,

--- a/environs/networking.go
+++ b/environs/networking.go
@@ -14,9 +14,12 @@ import (
 // Networking interface defines methods that environments
 // with networking capabilities must implement.
 type Networking interface {
-	// AllocateAddress requests a specific address to be allocated for the
-	// given instance on the given subnet.
-	AllocateAddress(instId instance.Id, subnetId network.Id, addr network.Address, macAddress, hostname string) error
+	// AllocateAddress requests a specific address to be allocated for the given
+	// instance on the given subnet, using the specified macAddress and
+	// hostnameSuffix. If addr is empty, this is interpreted as an output
+	// argument, which will contain the allocated address. Otherwise, addr must
+	// be non-empty and will be allocated as specified, if possible.
+	AllocateAddress(instId instance.Id, subnetId network.Id, addr *network.Address, macAddress, hostnameSuffix string) error
 
 	// ReleaseAddress releases a specific address previously allocated with
 	// AllocateAddress.

--- a/provider/dummy/environs_test.go
+++ b/provider/dummy/environs_test.go
@@ -225,25 +225,25 @@ func (s *suite) TestAllocateAddress(c *gc.C) {
 
 	// Test allocating a couple of addresses.
 	newAddress := network.NewScopedAddress("0.1.2.1", network.ScopeCloudLocal)
-	err := e.AllocateAddress(inst.Id(), subnetId, newAddress, "foo", "bar")
+	err := e.AllocateAddress(inst.Id(), subnetId, &newAddress, "foo", "bar")
 	c.Assert(err, jc.ErrorIsNil)
 	assertAllocateAddress(c, e, opc, inst.Id(), subnetId, newAddress, "foo", "bar")
 
 	newAddress = network.NewScopedAddress("0.1.2.2", network.ScopeCloudLocal)
-	err = e.AllocateAddress(inst.Id(), subnetId, newAddress, "foo", "bar")
+	err = e.AllocateAddress(inst.Id(), subnetId, &newAddress, "foo", "bar")
 	c.Assert(err, jc.ErrorIsNil)
 	assertAllocateAddress(c, e, opc, inst.Id(), subnetId, newAddress, "foo", "bar")
 
 	// Test we can induce errors.
 	s.breakMethods(c, e, "AllocateAddress")
 	newAddress = network.NewScopedAddress("0.1.2.3", network.ScopeCloudLocal)
-	err = e.AllocateAddress(inst.Id(), subnetId, newAddress, "foo", "bar")
+	err = e.AllocateAddress(inst.Id(), subnetId, &newAddress, "foo", "bar")
 	c.Assert(err, gc.ErrorMatches, `dummy\.AllocateAddress is broken`)
 
 	// Finally, test the method respects the feature flag when
 	// disabled.
 	s.SetFeatureFlags() // clear the flags.
-	err = e.AllocateAddress(inst.Id(), subnetId, newAddress, "foo", "bar")
+	err = e.AllocateAddress(inst.Id(), subnetId, &newAddress, "foo", "bar")
 	c.Assert(err, gc.ErrorMatches, "address allocation not supported")
 	c.Assert(err, jc.Satisfies, errors.IsNotSupported)
 }

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -903,9 +903,12 @@ func (e *environ) fetchNetworkInterfaceId(ec2Inst *ec2.EC2, instId instance.Id) 
 
 // AllocateAddress requests an address to be allocated for the given
 // instance on the given subnet. Implements NetworkingEnviron.AllocateAddress.
-func (e *environ) AllocateAddress(instId instance.Id, _ network.Id, addr network.Address, _, _ string) (err error) {
+func (e *environ) AllocateAddress(instId instance.Id, _ network.Id, addr *network.Address, _, _ string) (err error) {
 	if !environs.AddressAllocationEnabled() {
 		return errors.NotSupportedf("address allocation")
+	}
+	if addr == nil || addr.Value == "" {
+		return errors.NewNotValid(nil, "invalid address: nil or empty")
 	}
 
 	defer errors.DeferredAnnotatef(&err, "failed to allocate address %q for instance %q", addr, instId)
@@ -917,17 +920,17 @@ func (e *environ) AllocateAddress(instId instance.Id, _ network.Id, addr network
 		return errors.Trace(err)
 	}
 	for a := shortAttempt.Start(); a.Next(); {
-		err = AssignPrivateIPAddress(ec2Inst, nicId, addr)
-		logger.Tracef("AssignPrivateIPAddresses(%v, %v) returned: %v", nicId, addr, err)
+		err = AssignPrivateIPAddress(ec2Inst, nicId, *addr)
+		logger.Tracef("AssignPrivateIPAddresses(%v, %v) returned: %v", nicId, *addr, err)
 		if err == nil {
-			logger.Tracef("allocated address %v for instance %v, NIC %v", addr, instId, nicId)
+			logger.Tracef("allocated address %v for instance %v, NIC %v", *addr, instId, nicId)
 			break
 		}
 		if ec2Err, ok := err.(*ec2.Error); ok {
 			if ec2Err.Code == invalidParameterValue {
 				// Note: this Code is also used if we specify
 				// an IP address outside the subnet. Take care!
-				logger.Tracef("address %q not available for allocation", addr)
+				logger.Tracef("address %q not available for allocation", *addr)
 				return environs.ErrIPAddressUnavailable
 			} else if ec2Err.Code == privateAddressLimitExceeded {
 				logger.Tracef("no more addresses available on the subnet")

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -57,6 +57,8 @@ var (
 	ReleaseNodes             = releaseNodes
 	ReserveIPAddress         = reserveIPAddress
 	ReserveIPAddressOnDevice = reserveIPAddressOnDevice
+	NewDeviceParams          = newDeviceParams
+	UpdateDeviceHostname     = updateDeviceHostname
 	ReleaseIPAddress         = releaseIPAddress
 	DeploymentStatusCall     = deploymentStatusCall
 )
@@ -74,15 +76,21 @@ func reserveIPAddress(ipaddresses gomaasapi.MAASObject, cidr string, addr networ
 	return err
 }
 
-func reserveIPAddressOnDevice(devices gomaasapi.MAASObject, deviceId string, addr network.Address) (network.Address, error) {
-	device := devices.GetSubObject(deviceId)
+func reserveIPAddressOnDevice(devices gomaasapi.MAASObject, deviceID, macAddress string, addr network.Address) (network.Address, error) {
+	device := devices.GetSubObject(deviceID)
 	params := url.Values{}
 	if addr.Value != "" {
 		params.Add("requested_address", addr.Value)
 	}
+	if macAddress != "" {
+		params.Add("mac_address", macAddress)
+	}
 	resp, err := device.CallPost("claim_sticky_ip_address", params)
 	if err != nil {
-		return network.Address{}, errors.Annotatef(err, "failed to reserve sticky IP address for device %q", deviceId)
+		return network.Address{}, errors.Annotatef(
+			err, "failed to reserve sticky IP address for device %q",
+			deviceID,
+		)
 	}
 	respMap, err := resp.GetMap()
 	if err != nil {
@@ -95,7 +103,7 @@ func reserveIPAddressOnDevice(devices gomaasapi.MAASObject, deviceId string, add
 	if len(addresses) == 0 {
 		return network.Address{}, errors.Errorf(
 			"expected to find a sticky IP address for device %q: MAAS API response contains no IP addresses",
-			deviceId,
+			deviceID,
 		)
 	}
 	var firstAddress network.Address
@@ -104,20 +112,20 @@ func reserveIPAddressOnDevice(devices gomaasapi.MAASObject, deviceId string, add
 		if err != nil {
 			return network.Address{}, errors.Annotatef(err,
 				"failed to parse reserved IP address for device %q",
-				deviceId,
+				deviceID,
 			)
 		}
 		if ip := net.ParseIP(value); ip == nil {
 			return network.Address{}, errors.Annotatef(err,
 				"failed to parse reserved IP address %q for device %q",
-				value, deviceId,
+				value, deviceID,
 			)
 		}
 		if firstAddress.Value == "" {
 			// We only need the first address, but we're logging all we got.
 			firstAddress = network.NewAddress(value)
 		}
-		logger.Debugf("reserved address %q for device %q", value, deviceId)
+		logger.Debugf("reserved address %q for device %q and MAC %q", value, deviceID, macAddress)
 	}
 	return firstAddress, nil
 }
@@ -875,17 +883,24 @@ func (environ *maasEnviron) setupNetworks(inst instance.Instance, networksToDisa
 			return nil, "", errors.Annotatef(err, "getNetworkMACs failed")
 		}
 		logger.Debugf("network %q has MACs: %v", netw.Name, macs)
+
+		var defaultGateway network.Address
+		if netw.DefaultGateway != "" {
+			defaultGateway = network.NewAddress(netw.DefaultGateway)
+		}
+
 		for _, mac := range macs {
 			if ifinfo, ok := interfaces[mac]; ok {
 				tempInterfaceInfo = append(tempInterfaceInfo, network.InterfaceInfo{
-					MACAddress:    mac,
-					InterfaceName: ifinfo.InterfaceName,
-					DeviceIndex:   ifinfo.DeviceIndex,
-					CIDR:          netCIDR.String(),
-					VLANTag:       netw.VLANTag,
-					ProviderId:    network.Id(netw.Name),
-					NetworkName:   netw.Name,
-					Disabled:      disabled || ifinfo.Disabled,
+					MACAddress:     mac,
+					InterfaceName:  ifinfo.InterfaceName,
+					DeviceIndex:    ifinfo.DeviceIndex,
+					CIDR:           netCIDR.String(),
+					VLANTag:        netw.VLANTag,
+					ProviderId:     network.Id(netw.Name),
+					NetworkName:    netw.Name,
+					Disabled:       disabled || ifinfo.Disabled,
+					GatewayAddress: defaultGateway,
 				})
 			}
 		}
@@ -1386,16 +1401,62 @@ func (environ *maasEnviron) Instances(ids []instance.Id) ([]instance.Instance, e
 	return result, nil
 }
 
-// newDevice creates a new MAAS device for a MAC address, returning the Id of
-// the new device.
-func (environ *maasEnviron) newDevice(macAddress string, instId instance.Id, hostname string) (string, error) {
+// transformDeviceHostname transforms deviceHostname to include hostnameSuffix
+// after the first "." in deviceHostname. Returns errors if deviceHostname does
+// not contain any "." or hostnameSuffix is empty.
+func transformDeviceHostname(deviceID, deviceHostname, hostnameSuffix string) (string, error) {
+	if hostnameSuffix == "" {
+		return "", errors.New("hostname suffix cannot be empty")
+	}
+	parts := strings.SplitN(deviceHostname, ".", 2)
+	if len(parts) != 2 {
+		return "", errors.Errorf("unexpected device %q hostname %q", deviceID, deviceHostname)
+	}
+	return fmt.Sprintf("%s-%s.%s", parts[0], hostnameSuffix, parts[1]), nil
+}
+
+// updateDeviceHostname updates the hostname of a MAAS device to be unique and
+// to contain the given hostnameSuffix.
+func updateDeviceHostname(client *gomaasapi.MAASObject, deviceID, deviceHostname, hostnameSuffix string) (string, error) {
+
+	newHostname, err := transformDeviceHostname(deviceID, deviceHostname, hostnameSuffix)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+
+	deviceObj := client.GetSubObject("devices").GetSubObject(deviceID)
+	params := make(url.Values)
+	params.Add("hostname", newHostname)
+	if _, err := deviceObj.Update(params); err != nil {
+		return "", errors.Annotatef(err, "updating device %q hostname to %q", deviceID, newHostname)
+	}
+	return newHostname, nil
+}
+
+// newDeviceParams prepares the params to call "devices new" API. Declared
+// separately so it can be mocked out in the test to work around the gomaasapi's
+// testservice limitation.
+func newDeviceParams(macAddress string, instId instance.Id, _ string) url.Values {
+	params := make(url.Values)
+	params.Add("mac_addresses", macAddress)
+	// We create the device without a hostname, to allow MAAS to create a unique
+	// hostname first.
+	params.Add("parent", extractSystemId(instId))
+
+	return params
+}
+
+// newDevice creates a new MAAS device with parent instance instId, using the
+// given macAddress and hostnameSuffix, returning the ID of the new device.
+func (environ *maasEnviron) newDevice(macAddress string, instId instance.Id, hostnameSuffix string) (string, error) {
 	client := environ.getMAASClient()
 	devices := client.GetSubObject("devices")
-	params := url.Values{}
-	params.Add("mac_addresses", macAddress)
-	params.Add("hostname", hostname)
-	params.Add("parent", extractSystemId(instId))
-	logger.Tracef("creating a new MAAS device for MAC %q, hostname %q, parent %q", macAddress, hostname, string(instId))
+	// Work around the limitation of gomaasapi's testservice expecting all 3
+	// arguments (parent, mac_addresses, and hostname) to be filled in.
+	params := NewDeviceParams(macAddress, instId, hostnameSuffix)
+	logger.Tracef(
+		"creating a new MAAS device for MAC %q, parent %q", macAddress, instId,
+	)
 	result, err := devices.CallPost("new", params)
 	if err != nil {
 		return "", errors.Trace(err)
@@ -1406,85 +1467,101 @@ func (environ *maasEnviron) newDevice(macAddress string, instId instance.Id, hos
 		return "", errors.Trace(err)
 	}
 
-	device, err := resultMap["system_id"].GetString()
+	deviceID, err := resultMap["system_id"].GetString()
 	if err != nil {
 		return "", errors.Trace(err)
 	}
-	logger.Tracef("created device %q", device)
-	return device, nil
+	deviceHostname, err := resultMap["hostname"].GetString()
+	if err != nil {
+		return deviceID, errors.Trace(err)
+	}
+
+	logger.Tracef("created device %q with MAC %q and hostname %q", deviceID, macAddress, deviceHostname)
+
+	newHostname, err := UpdateDeviceHostname(client, deviceID, deviceHostname, hostnameSuffix)
+	if err != nil {
+		return deviceID, errors.Trace(err)
+	}
+	logger.Tracef("updated device %q hostname to %q", deviceID, newHostname)
+
+	return deviceID, nil
 }
 
-// fetchFullDevice fetches an existing device Id associated with a MAC address
-// and/or hostname, or returns an error if there is no device.
-func (environ *maasEnviron) fetchFullDevice(macAddress, hostname string) (map[string]gomaasapi.JSONObject, error) {
+// fetchFullDevice fetches an existing device ID associated with the given
+// macAddress, or returns an error if there is no device.
+func (environ *maasEnviron) fetchFullDevice(macAddress string) (map[string]gomaasapi.JSONObject, error) {
+	if macAddress == "" {
+		return nil, errors.Errorf("given MAC address is empty")
+	}
+
 	client := environ.getMAASClient()
 	devices := client.GetSubObject("devices")
 	params := url.Values{}
-	if macAddress != "" {
-		params.Add("mac_address", macAddress)
-	}
-	if hostname != "" {
-		params.Add("hostname", hostname)
-	}
+	params.Add("mac_address", macAddress)
+
 	result, err := devices.CallGet("list", params)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+
 	resultArray, err := result.GetArray()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+
 	if len(resultArray) == 0 {
-		return nil, errors.NotFoundf("no device for MAC %q and/or hostname %q", macAddress, hostname)
+		return nil, errors.NotFoundf("no device for MAC address %q", macAddress)
 	}
+
 	if len(resultArray) != 1 {
 		return nil, errors.Errorf("unexpected response, expected 1 device got %d", len(resultArray))
 	}
+
 	resultMap, err := resultArray[0].GetMap()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+
 	logger.Tracef("device found as %+v", resultMap)
 	return resultMap, nil
 }
 
-func (environ *maasEnviron) fetchDevice(macAddress, hostname string) (string, error) {
-	deviceMap, err := environ.fetchFullDevice(macAddress, hostname)
+func (environ *maasEnviron) fetchDevice(macAddress string) (string, error) {
+	deviceMap, err := environ.fetchFullDevice(macAddress)
 	if err != nil {
 		return "", errors.Trace(err)
 	}
 
-	deviceId, err := deviceMap["system_id"].GetString()
+	deviceID, err := deviceMap["system_id"].GetString()
 	if err != nil {
 		return "", errors.Trace(err)
 	}
-	return deviceId, nil
+	return deviceID, nil
 }
 
 // createOrFetchDevice returns a device Id associated with a MAC address. If
 // there is not already one it will create one.
 func (environ *maasEnviron) createOrFetchDevice(macAddress string, instId instance.Id, hostname string) (string, error) {
-	device, err := environ.fetchDevice(macAddress, hostname)
+	device, err := environ.fetchDevice(macAddress)
 	if err == nil {
 		return device, nil
 	}
 	if !errors.IsNotFound(err) {
 		return "", errors.Trace(err)
 	}
-	device, err = environ.newDevice(macAddress, instId, hostname)
-	if err != nil {
-		return "", errors.Trace(err)
-	}
-	return device, nil
+	return environ.newDevice(macAddress, instId, hostname)
 }
 
 // AllocateAddress requests an address to be allocated for the
 // given instance on the given network.
-func (environ *maasEnviron) AllocateAddress(instId instance.Id, subnetId network.Id, addr network.Address, macAddress, hostname string) (err error) {
+func (environ *maasEnviron) AllocateAddress(instId instance.Id, subnetId network.Id, addr *network.Address, macAddress, hostname string) (err error) {
 	logger.Tracef(
 		"AllocateAddress for instId %q, subnet %q, addr %q, MAC %q, hostname %q",
 		instId, subnetId, addr, macAddress, hostname,
 	)
+	if addr == nil {
+		return errors.NewNotValid(nil, "invalid address: cannot be nil")
+	}
 
 	if !environs.AddressAllocationEnabled() {
 		if !environ.supportsDevices {
@@ -1508,14 +1585,15 @@ func (environ *maasEnviron) AllocateAddress(instId instance.Id, subnetId network
 			deviceID, hostname, macAddress, instId,
 		)
 		devices := environ.getMAASClient().GetSubObject("devices")
-		addr, err := ReserveIPAddressOnDevice(devices, deviceID, network.Address{})
+		newAddr, err := ReserveIPAddressOnDevice(devices, deviceID, macAddress, network.Address{})
 		if err != nil {
 			return errors.Trace(err)
 		}
 		logger.Infof(
-			"reserved sticky IP address %q for device %q representing container %q",
-			addr, deviceID, hostname,
+			"reserved sticky IP address %q for device %q with MAC address %q representing container %q",
+			newAddr, deviceID, macAddress, hostname,
 		)
+		*addr = newAddr
 		return nil
 	}
 	defer errors.DeferredAnnotatef(&err, "failed to allocate address %q for instance %q", addr, instId)
@@ -1523,14 +1601,18 @@ func (environ *maasEnviron) AllocateAddress(instId instance.Id, subnetId network
 	client := environ.getMAASClient()
 	var maasErr gomaasapi.ServerError
 	if environ.supportsDevices {
-		device, err := environ.createOrFetchDevice(macAddress, instId, hostname)
+		deviceID, err := environ.createOrFetchDevice(macAddress, instId, hostname)
 		if err != nil {
 			return err
 		}
 
 		devices := client.GetSubObject("devices")
-		if gotAddr, err := ReserveIPAddressOnDevice(devices, device, addr); err == nil {
-			logger.Infof("allocated address %q for instance %q on device %q (asked for address %q)", addr, instId, device, gotAddr)
+		newAddr, err := ReserveIPAddressOnDevice(devices, deviceID, macAddress, *addr)
+		if err == nil {
+			logger.Infof(
+				"allocated address %q for instance %q on device %q (asked for address %q)",
+				addr, instId, deviceID, newAddr,
+			)
 			return nil
 		}
 
@@ -1544,7 +1626,7 @@ func (environ *maasEnviron) AllocateAddress(instId instance.Id, subnetId network
 		var subnets []network.SubnetInfo
 
 		subnets, err = environ.Subnets(instId, []network.Id{subnetId})
-		logger.Tracef("Subnets(%q, %q, %q) returned: %v (%v)", instId, subnetId, addr, subnets, err)
+		logger.Tracef("Subnets(%q, %q, %q) returned: %v (%v)", instId, subnetId, *addr, subnets, err)
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -1556,9 +1638,9 @@ func (environ *maasEnviron) AllocateAddress(instId instance.Id, subnetId network
 
 		cidr := foundSub.CIDR
 		ipaddresses := client.GetSubObject("ipaddresses")
-		err = ReserveIPAddress(ipaddresses, cidr, addr)
+		err = ReserveIPAddress(ipaddresses, cidr, *addr)
 		if err == nil {
-			logger.Infof("allocated address %q for instance %q on subnet %q", addr, instId, cidr)
+			logger.Infof("allocated address %q for instance %q on subnet %q", *addr, instId, cidr)
 			return nil
 		}
 
@@ -1598,7 +1680,7 @@ func (environ *maasEnviron) ReleaseAddress(instId instance.Id, _ network.Id, add
 			return errors.NotSupportedf("address allocation")
 		}
 		logger.Tracef("getting device ID for container %q with MAC %q", macAddress, hostname)
-		deviceID, err := environ.fetchDevice(macAddress, hostname)
+		deviceID, err := environ.fetchDevice(macAddress)
 		if err != nil {
 			return errors.Annotatef(
 				err,
@@ -1628,7 +1710,7 @@ func (environ *maasEnviron) ReleaseAddress(instId instance.Id, _ network.Id, add
 	// Addresses originally allocated without a device will have macAddress
 	// set to "". We shouldn't look for a device for these addresses.
 	if environ.supportsDevices && macAddress != "" {
-		device, err := environ.fetchFullDevice(macAddress, hostname)
+		device, err := environ.fetchFullDevice(macAddress)
 		if err == nil {
 			addresses, err := device["ip_addresses"].GetArray()
 			if err != nil {
@@ -1733,9 +1815,15 @@ func (environ *maasEnviron) NetworkInterfaces(instId instance.Id) ([]network.Int
 			ifaceInfo.VLANTag = details.VLANTag
 			ifaceInfo.ProviderSubnetId = network.Id(details.Name)
 			mask := net.IPMask(net.ParseIP(details.Mask))
-			cidr := net.IPNet{net.ParseIP(details.IP), mask}
+			cidr := net.IPNet{
+				IP:   net.ParseIP(details.IP),
+				Mask: mask,
+			}
 			ifaceInfo.CIDR = cidr.String()
 			ifaceInfo.Address = network.NewAddress(cidr.IP.String())
+			if details.DefaultGateway != "" {
+				ifaceInfo.GatewayAddress = network.NewAddress(details.DefaultGateway)
+			}
 			result = append(result, ifaceInfo)
 		}
 	}
@@ -1915,11 +2003,12 @@ func (*maasEnviron) Provider() environs.EnvironProvider {
 
 // networkDetails holds information about a MAAS network.
 type networkDetails struct {
-	Name        string
-	IP          string
-	Mask        string
-	VLANTag     int
-	Description string
+	Name           string
+	IP             string
+	Mask           string
+	VLANTag        int
+	Description    string
+	DefaultGateway string
 }
 
 // getInstanceNetworks returns a list of all MAAS networks for a given node.
@@ -1945,41 +2034,57 @@ func (environ *maasEnviron) getInstanceNetworks(inst instance.Instance) ([]netwo
 	for i, jsonNet := range jsonNets {
 		fields, err := jsonNet.GetMap()
 		if err != nil {
-			return nil, err
+			return nil, errors.Annotate(err, "parsing network details")
 		}
+
 		name, err := fields["name"].GetString()
 		if err != nil {
-			return nil, fmt.Errorf("cannot get name: %v", err)
+			return nil, errors.Annotate(err, "cannot get name")
 		}
+
 		ip, err := fields["ip"].GetString()
 		if err != nil {
-			return nil, fmt.Errorf("cannot get ip: %v", err)
+			return nil, errors.Annotate(err, "cannot get ip")
 		}
+
+		defaultGateway := ""
+		defaultGatewayField, ok := fields["default_gateway"]
+		if ok && !defaultGatewayField.IsNil() {
+			// default_gateway is optional, so ignore it when unset or null.
+			defaultGateway, err = defaultGatewayField.GetString()
+			if err != nil {
+				return nil, errors.Annotate(err, "cannot get default_gateway")
+			}
+		}
+
 		netmask, err := fields["netmask"].GetString()
 		if err != nil {
-			return nil, fmt.Errorf("cannot get netmask: %v", err)
+			return nil, errors.Annotate(err, "cannot get netmask")
 		}
+
 		vlanTag := 0
 		vlanTagField, ok := fields["vlan_tag"]
 		if ok && !vlanTagField.IsNil() {
 			// vlan_tag is optional, so assume it's 0 when missing or nil.
 			vlanTagFloat, err := vlanTagField.GetFloat64()
 			if err != nil {
-				return nil, fmt.Errorf("cannot get vlan_tag: %v", err)
+				return nil, errors.Annotate(err, "cannot get vlan_tag")
 			}
 			vlanTag = int(vlanTagFloat)
 		}
+
 		description, err := fields["description"].GetString()
 		if err != nil {
-			return nil, fmt.Errorf("cannot get description: %v", err)
+			return nil, errors.Annotate(err, "cannot get description")
 		}
 
 		networks[i] = networkDetails{
-			Name:        name,
-			IP:          ip,
-			Mask:        netmask,
-			VLANTag:     vlanTag,
-			Description: description,
+			Name:           name,
+			IP:             ip,
+			Mask:           netmask,
+			DefaultGateway: defaultGateway,
+			VLANTag:        vlanTag,
+			Description:    description,
 		}
 	}
 	return networks, nil

--- a/provider/maas/environ_whitebox_test.go
+++ b/provider/maas/environ_whitebox_test.go
@@ -1341,6 +1341,8 @@ func (suite *environSuite) TestSubnetsNoDuplicates(c *gc.C) {
 }
 
 func (suite *environSuite) TestAllocateAddress(c *gc.C) {
+	suite.testMAASObject.TestServer.SetVersionJSON(`{"capabilities": ["networks-management","static-ipaddresses"]}`)
+
 	testInstance := suite.createSubnets(c, false)
 	env := suite.makeEnviron()
 
@@ -1627,6 +1629,7 @@ func (suite *environSuite) TestReleaseAddress(c *gc.C) {
 }
 
 func (suite *environSuite) TestReleaseAddressRetry(c *gc.C) {
+	suite.testMAASObject.TestServer.SetVersionJSON(`{"capabilities": ["networks-management","static-ipaddresses"]}`)
 	// Patch short attempt params.
 	suite.PatchValue(&shortAttempt, utils.AttemptStrategy{
 		Min: 5,

--- a/provider/maas/environ_whitebox_test.go
+++ b/provider/maas/environ_whitebox_test.go
@@ -563,7 +563,7 @@ func (suite *environSuite) newNetwork(name string, id int, vlanTag int, defaultG
 	}
 
 	if defaultGateway != "null" {
-		/// since we use %s below only "null" (if passed) should remain unquoted.
+		// since we use %s below only "null" (if passed) should remain unquoted.
 		defaultGateway = fmt.Sprintf("%q", defaultGateway)
 	}
 

--- a/provider/maas/environ_whitebox_test.go
+++ b/provider/maas/environ_whitebox_test.go
@@ -554,16 +554,35 @@ func (suite *environSuite) getInstance(systemId string) *maasInstance {
 	return &maasInstance{&node}
 }
 
-func (suite *environSuite) getNetwork(name string, id int, vlanTag int) *gomaasapi.MAASObject {
+func (suite *environSuite) newNetwork(name string, id int, vlanTag int, defaultGateway string) *gomaasapi.MAASObject {
 	var vlan string
 	if vlanTag == 0 {
 		vlan = "null"
 	} else {
 		vlan = fmt.Sprintf("%d", vlanTag)
 	}
-	var input string
-	input = fmt.Sprintf(`{"name": %q, "ip":"192.168.%d.1", "netmask": "255.255.255.0",`+
-		`"vlan_tag": %s, "description": "%s_%d_%d" }`, name, id, vlan, name, id, vlanTag)
+
+	if defaultGateway != "null" {
+		/// since we use %s below only "null" (if passed) should remain unquoted.
+		defaultGateway = fmt.Sprintf("%q", defaultGateway)
+	}
+
+	// TODO(dimitern): Use JSON tags on structs, JSON encoder, or at least
+	// text/template below and in similar cases.
+	input := fmt.Sprintf(`{
+		"name": %q,
+		"ip":"192.168.%d.2",
+		"netmask": "255.255.255.0",
+		"vlan_tag": %s,
+		"description": "%s_%d_%d",
+		"default_gateway": %s
+	}`,
+		name,
+		id,
+		vlan,
+		name, id, vlanTag,
+		defaultGateway,
+	)
 	network := suite.testMAASObject.TestServer.NewNetwork(input)
 	return &network
 }
@@ -851,15 +870,19 @@ func (suite *environSuite) TestGetNetworkMACs(c *gc.C) {
 }
 
 func (suite *environSuite) TestGetInstanceNetworks(c *gc.C) {
-	suite.getNetwork("test_network", 123, 321)
+	suite.newNetwork("test_network", 123, 321, "null")
 	testInstance := suite.getInstance("instance_for_network")
 	suite.testMAASObject.TestServer.ConnectNodeToNetwork("instance_for_network", "test_network")
 	networks, err := suite.makeEnviron().getInstanceNetworks(testInstance)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Check(networks, gc.DeepEquals, []networkDetails{
-		{Name: "test_network", IP: "192.168.123.1", Mask: "255.255.255.0", VLANTag: 321,
-			Description: "test_network_123_321"},
-	})
+	c.Check(networks, jc.DeepEquals, []networkDetails{{
+		Name:           "test_network",
+		IP:             "192.168.123.2",
+		Mask:           "255.255.255.0",
+		VLANTag:        321,
+		Description:    "test_network_123_321",
+		DefaultGateway: "", // "null" and "" are treated as N/A.
+	}})
 }
 
 // A typical lshw XML dump with lots of things left out.
@@ -978,11 +1001,11 @@ func (suite *environSuite) TestSetupNetworks(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	suite.testMAASObject.TestServer.AddNodeDetails("node1", lshwXML)
-	suite.getNetwork("LAN", 2, 42)
+	suite.newNetwork("LAN", 2, 42, "null")
 	suite.testMAASObject.TestServer.ConnectNodeToNetworkWithMACAddress("node1", "LAN", "aa:bb:cc:dd:ee:f1")
-	suite.getNetwork("Virt", 3, 0)
+	suite.newNetwork("Virt", 3, 0, "0.1.2.3") // primary + gateway
 	suite.testMAASObject.TestServer.ConnectNodeToNetworkWithMACAddress("node1", "Virt", "aa:bb:cc:dd:ee:f2")
-	suite.getNetwork("WLAN", 1, 0)
+	suite.newNetwork("WLAN", 1, 0, "") // "" same as "null" for gateway
 	suite.testMAASObject.TestServer.ConnectNodeToNetworkWithMACAddress("node1", "WLAN", "aa:bb:cc:dd:ee:ff")
 	networkInfo, primaryIface, err := suite.makeEnviron().setupNetworks(
 		testInstance,
@@ -1000,7 +1023,7 @@ func (suite *environSuite) TestSetupNetworks(c *gc.C) {
 		case 0:
 			c.Check(info, jc.DeepEquals, network.InterfaceInfo{
 				MACAddress:    "aa:bb:cc:dd:ee:ff",
-				CIDR:          "192.168.1.1/24",
+				CIDR:          "192.168.1.2/24",
 				NetworkName:   "WLAN",
 				ProviderId:    "WLAN",
 				VLANTag:       0,
@@ -1012,7 +1035,7 @@ func (suite *environSuite) TestSetupNetworks(c *gc.C) {
 			c.Check(info, jc.DeepEquals, network.InterfaceInfo{
 				DeviceIndex:   1,
 				MACAddress:    "aa:bb:cc:dd:ee:f1",
-				CIDR:          "192.168.2.1/24",
+				CIDR:          "192.168.2.2/24",
 				NetworkName:   "LAN",
 				ProviderId:    "LAN",
 				VLANTag:       42,
@@ -1021,14 +1044,15 @@ func (suite *environSuite) TestSetupNetworks(c *gc.C) {
 			})
 		case 2:
 			c.Check(info, jc.DeepEquals, network.InterfaceInfo{
-				MACAddress:    "aa:bb:cc:dd:ee:f2",
-				CIDR:          "192.168.3.1/24",
-				NetworkName:   "Virt",
-				ProviderId:    "Virt",
-				VLANTag:       0,
-				DeviceIndex:   2,
-				InterfaceName: "vnet1",
-				Disabled:      false,
+				MACAddress:     "aa:bb:cc:dd:ee:f2",
+				CIDR:           "192.168.3.2/24",
+				NetworkName:    "Virt",
+				ProviderId:     "Virt",
+				VLANTag:        0,
+				DeviceIndex:    2,
+				InterfaceName:  "vnet1",
+				Disabled:       false,
+				GatewayAddress: network.NewAddress("0.1.2.3"), // from newNetwork("Virt", 3, 0, "0.1.2.3")
 			})
 		}
 	}
@@ -1046,9 +1070,9 @@ func (suite *environSuite) TestSetupNetworksPartialMatch(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	suite.testMAASObject.TestServer.AddNodeDetails("node1", lshwXML)
-	suite.getNetwork("LAN", 2, 42)
+	suite.newNetwork("LAN", 2, 42, "192.168.2.1")
 	suite.testMAASObject.TestServer.ConnectNodeToNetworkWithMACAddress("node1", "LAN", "aa:bb:cc:dd:ee:f1")
-	suite.getNetwork("Virt", 3, 0)
+	suite.newNetwork("Virt", 3, 0, "")
 	suite.testMAASObject.TestServer.ConnectNodeToNetworkWithMACAddress("node1", "Virt", "aa:bb:cc:dd:ee:f3")
 	networkInfo, primaryIface, err := suite.makeEnviron().setupNetworks(
 		testInstance,
@@ -1059,14 +1083,15 @@ func (suite *environSuite) TestSetupNetworksPartialMatch(c *gc.C) {
 	// Note: order of networks is based on lshwXML
 	c.Check(primaryIface, gc.Equals, "eth0")
 	c.Check(networkInfo, jc.DeepEquals, []network.InterfaceInfo{{
-		MACAddress:    "aa:bb:cc:dd:ee:f1",
-		CIDR:          "192.168.2.1/24",
-		NetworkName:   "LAN",
-		ProviderId:    "LAN",
-		VLANTag:       42,
-		DeviceIndex:   1,
-		InterfaceName: "eth0",
-		Disabled:      false,
+		MACAddress:     "aa:bb:cc:dd:ee:f1",
+		CIDR:           "192.168.2.2/24",
+		NetworkName:    "LAN",
+		ProviderId:     "LAN",
+		VLANTag:        42,
+		DeviceIndex:    1,
+		InterfaceName:  "eth0",
+		Disabled:       false,
+		GatewayAddress: network.NewAddress("192.168.2.1"),
 	}})
 }
 
@@ -1082,7 +1107,7 @@ func (suite *environSuite) TestSetupNetworksNoMatch(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	suite.testMAASObject.TestServer.AddNodeDetails("node1", lshwXML)
-	suite.getNetwork("Virt", 3, 0)
+	suite.newNetwork("Virt", 3, 0, "")
 	suite.testMAASObject.TestServer.ConnectNodeToNetworkWithMACAddress("node1", "Virt", "aa:bb:cc:dd:ee:f3")
 	networkInfo, primaryIface, err := suite.makeEnviron().setupNetworks(
 		testInstance,
@@ -1110,6 +1135,7 @@ func (suite *environSuite) TestSupportsAddressAllocation(c *gc.C) {
 
 func (suite *environSuite) createSubnets(c *gc.C, duplicates bool) instance.Instance {
 	testInstance := suite.getInstance("node1")
+	testServer := suite.testMAASObject.TestServer
 	templateInterfaces := map[string]ifaceInfo{
 		"aa:bb:cc:dd:ee:ff": {0, "wlan0", true},
 		"aa:bb:cc:dd:ee:f1": {1, "eth0", false},
@@ -1122,24 +1148,24 @@ func (suite *environSuite) createSubnets(c *gc.C, duplicates bool) instance.Inst
 	lshwXML, err := suite.generateHWTemplate(templateInterfaces)
 	c.Assert(err, jc.ErrorIsNil)
 
-	suite.testMAASObject.TestServer.AddNodeDetails("node1", lshwXML)
-	// resulting CIDR 192.168.2.1/24
-	suite.getNetwork("LAN", 2, 42)
-	suite.testMAASObject.TestServer.ConnectNodeToNetworkWithMACAddress("node1", "LAN", "aa:bb:cc:dd:ee:f1")
-	// resulting CIDR 192.168.3.1/24
-	suite.getNetwork("Virt", 3, 0)
-	suite.testMAASObject.TestServer.ConnectNodeToNetworkWithMACAddress("node1", "Virt", "aa:bb:cc:dd:ee:f2")
-	// resulting CIDR 192.168.1.1/24
-	suite.getNetwork("WLAN", 1, 0)
-	suite.testMAASObject.TestServer.ConnectNodeToNetworkWithMACAddress("node1", "WLAN", "aa:bb:cc:dd:ee:ff")
+	testServer.AddNodeDetails("node1", lshwXML)
+	// resulting CIDR 192.168.2.2/24
+	suite.newNetwork("LAN", 2, 42, "192.168.2.1") // primary + gateway
+	testServer.ConnectNodeToNetworkWithMACAddress("node1", "LAN", "aa:bb:cc:dd:ee:f1")
+	// resulting CIDR 192.168.3.2/24
+	suite.newNetwork("Virt", 3, 0, "")
+	testServer.ConnectNodeToNetworkWithMACAddress("node1", "Virt", "aa:bb:cc:dd:ee:f2")
+	// resulting CIDR 192.168.1.2/24
+	suite.newNetwork("WLAN", 1, 0, "")
+	testServer.ConnectNodeToNetworkWithMACAddress("node1", "WLAN", "aa:bb:cc:dd:ee:ff")
 	if duplicates {
-		suite.testMAASObject.TestServer.ConnectNodeToNetworkWithMACAddress("node1", "LAN", "aa:bb:cc:dd:ee:f3")
-		suite.testMAASObject.TestServer.ConnectNodeToNetworkWithMACAddress("node1", "Virt", "aa:bb:cc:dd:ee:f4")
+		testServer.ConnectNodeToNetworkWithMACAddress("node1", "LAN", "aa:bb:cc:dd:ee:f3")
+		testServer.ConnectNodeToNetworkWithMACAddress("node1", "Virt", "aa:bb:cc:dd:ee:f4")
 	}
 
 	// needed for getNodeGroups to work
-	suite.testMAASObject.TestServer.AddBootImage("uuid-0", `{"architecture": "amd64", "release": "precise"}`)
-	suite.testMAASObject.TestServer.AddBootImage("uuid-1", `{"architecture": "amd64", "release": "precise"}`)
+	testServer.AddBootImage("uuid-0", `{"architecture": "amd64", "release": "precise"}`)
+	testServer.AddBootImage("uuid-1", `{"architecture": "amd64", "release": "precise"}`)
 
 	jsonText1 := `{
 		"ip_range_high":        "192.168.2.255",
@@ -1189,10 +1215,10 @@ func (suite *environSuite) createSubnets(c *gc.C, duplicates bool) instance.Inst
 		"static_ip_range_high": "172.16.8.255",
 		"interface":            "eth3"
 	}`
-	suite.testMAASObject.TestServer.NewNodegroupInterface("uuid-0", jsonText1)
-	suite.testMAASObject.TestServer.NewNodegroupInterface("uuid-0", jsonText2)
-	suite.testMAASObject.TestServer.NewNodegroupInterface("uuid-1", jsonText3)
-	suite.testMAASObject.TestServer.NewNodegroupInterface("uuid-1", jsonText4)
+	testServer.NewNodegroupInterface("uuid-0", jsonText1)
+	testServer.NewNodegroupInterface("uuid-0", jsonText2)
+	testServer.NewNodegroupInterface("uuid-1", jsonText3)
+	testServer.NewNodegroupInterface("uuid-1", jsonText4)
 	return testInstance
 }
 
@@ -1205,7 +1231,7 @@ func (suite *environSuite) TestNetworkInterfaces(c *gc.C) {
 	expectedInfo := []network.InterfaceInfo{{
 		DeviceIndex:      0,
 		MACAddress:       "aa:bb:cc:dd:ee:ff",
-		CIDR:             "192.168.1.1/24",
+		CIDR:             "192.168.1.2/24",
 		ProviderSubnetId: "WLAN",
 		VLANTag:          0,
 		InterfaceName:    "wlan0",
@@ -1214,11 +1240,11 @@ func (suite *environSuite) TestNetworkInterfaces(c *gc.C) {
 		ConfigType:       network.ConfigDHCP,
 		ExtraConfig:      nil,
 		GatewayAddress:   network.Address{},
-		Address:          network.NewScopedAddress("192.168.1.1", network.ScopeCloudLocal),
+		Address:          network.NewScopedAddress("192.168.1.2", network.ScopeCloudLocal),
 	}, {
 		DeviceIndex:      1,
 		MACAddress:       "aa:bb:cc:dd:ee:f1",
-		CIDR:             "192.168.2.1/24",
+		CIDR:             "192.168.2.2/24",
 		ProviderSubnetId: "LAN",
 		VLANTag:          42,
 		InterfaceName:    "eth0",
@@ -1226,12 +1252,12 @@ func (suite *environSuite) TestNetworkInterfaces(c *gc.C) {
 		NoAutoStart:      false,
 		ConfigType:       network.ConfigDHCP,
 		ExtraConfig:      nil,
-		GatewayAddress:   network.Address{},
-		Address:          network.NewScopedAddress("192.168.2.1", network.ScopeCloudLocal),
+		GatewayAddress:   network.NewScopedAddress("192.168.2.1", network.ScopeCloudLocal),
+		Address:          network.NewScopedAddress("192.168.2.2", network.ScopeCloudLocal),
 	}, {
 		DeviceIndex:      2,
 		MACAddress:       "aa:bb:cc:dd:ee:f2",
-		CIDR:             "192.168.3.1/24",
+		CIDR:             "192.168.3.2/24",
 		ProviderSubnetId: "Virt",
 		VLANTag:          0,
 		InterfaceName:    "vnet1",
@@ -1240,7 +1266,7 @@ func (suite *environSuite) TestNetworkInterfaces(c *gc.C) {
 		ConfigType:       network.ConfigDHCP,
 		ExtraConfig:      nil,
 		GatewayAddress:   network.Address{},
-		Address:          network.NewScopedAddress("192.168.3.1", network.ScopeCloudLocal),
+		Address:          network.NewScopedAddress("192.168.3.2", network.ScopeCloudLocal),
 	}}
 	network.SortInterfaceInfo(netInfo)
 	c.Assert(netInfo, jc.DeepEquals, expectedInfo)
@@ -1252,10 +1278,25 @@ func (suite *environSuite) TestSubnets(c *gc.C) {
 	netInfo, err := suite.makeEnviron().Subnets(testInstance.Id(), []network.Id{"LAN", "Virt", "WLAN"})
 	c.Assert(err, jc.ErrorIsNil)
 
-	expectedInfo := []network.SubnetInfo{
-		{CIDR: "192.168.2.1/24", ProviderId: "LAN", VLANTag: 42, AllocatableIPLow: net.ParseIP("192.168.2.0"), AllocatableIPHigh: net.ParseIP("192.168.2.127")},
-		{CIDR: "192.168.3.1/24", ProviderId: "Virt", VLANTag: 0},
-		{CIDR: "192.168.1.1/24", ProviderId: "WLAN", VLANTag: 0, AllocatableIPLow: net.ParseIP("192.168.1.129"), AllocatableIPHigh: net.ParseIP("192.168.1.255")}}
+	expectedInfo := []network.SubnetInfo{{
+		CIDR:              "192.168.2.2/24",
+		ProviderId:        "LAN",
+		VLANTag:           42,
+		AllocatableIPLow:  net.ParseIP("192.168.2.0"),
+		AllocatableIPHigh: net.ParseIP("192.168.2.127"),
+	}, {
+		CIDR:              "192.168.3.2/24",
+		ProviderId:        "Virt",
+		VLANTag:           0,
+		AllocatableIPLow:  nil,
+		AllocatableIPHigh: nil,
+	}, {
+		CIDR:              "192.168.1.2/24",
+		ProviderId:        "WLAN",
+		VLANTag:           0,
+		AllocatableIPLow:  net.ParseIP("192.168.1.129"),
+		AllocatableIPHigh: net.ParseIP("192.168.1.255"),
+	}}
 	c.Assert(netInfo, jc.DeepEquals, expectedInfo)
 }
 
@@ -1277,10 +1318,25 @@ func (suite *environSuite) TestSubnetsNoDuplicates(c *gc.C) {
 	netInfo, err := suite.makeEnviron().Subnets(testInstance.Id(), []network.Id{"LAN", "Virt", "WLAN"})
 	c.Assert(err, jc.ErrorIsNil)
 
-	expectedInfo := []network.SubnetInfo{
-		{CIDR: "192.168.2.1/24", ProviderId: "LAN", VLANTag: 42, AllocatableIPLow: net.ParseIP("192.168.2.0"), AllocatableIPHigh: net.ParseIP("192.168.2.127")},
-		{CIDR: "192.168.3.1/24", ProviderId: "Virt", VLANTag: 0},
-		{CIDR: "192.168.1.1/24", ProviderId: "WLAN", VLANTag: 0, AllocatableIPLow: net.ParseIP("192.168.1.129"), AllocatableIPHigh: net.ParseIP("192.168.1.255")}}
+	expectedInfo := []network.SubnetInfo{{
+		CIDR:              "192.168.2.2/24",
+		ProviderId:        "LAN",
+		VLANTag:           42,
+		AllocatableIPLow:  net.ParseIP("192.168.2.0"),
+		AllocatableIPHigh: net.ParseIP("192.168.2.127"),
+	}, {
+		CIDR:              "192.168.3.2/24",
+		ProviderId:        "Virt",
+		VLANTag:           0,
+		AllocatableIPLow:  nil,
+		AllocatableIPHigh: nil,
+	}, {
+		CIDR:              "192.168.1.2/24",
+		ProviderId:        "WLAN",
+		VLANTag:           0,
+		AllocatableIPLow:  net.ParseIP("192.168.1.129"),
+		AllocatableIPHigh: net.ParseIP("192.168.1.255"),
+	}}
 	c.Assert(netInfo, jc.DeepEquals, expectedInfo)
 }
 
@@ -1290,7 +1346,7 @@ func (suite *environSuite) TestAllocateAddress(c *gc.C) {
 
 	// note that the default test server always succeeds if we provide a
 	// valid instance id and net id
-	err := env.AllocateAddress(testInstance.Id(), "LAN", network.Address{Value: "192.168.2.1"}, "foo", "bar")
+	err := env.AllocateAddress(testInstance.Id(), "LAN", &network.Address{Value: "192.168.2.1"}, "foo", "bar")
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -1299,9 +1355,37 @@ func (suite *environSuite) TestAllocateAddressDevices(c *gc.C) {
 	testInstance := suite.createSubnets(c, false)
 	env := suite.makeEnviron()
 
+	// Work around the lack of support for devices PUT and POST without hostname
+	// set in gomaasapi's testservices
+	newParams := func(macAddress string, instId instance.Id, hostnameSuffix string) url.Values {
+		c.Check(macAddress, gc.Equals, "aa:bb:cc:dd:ee:f0") // passed to AllocateAddress() below
+		c.Check(instId, gc.Equals, testInstance.Id())
+		c.Check(hostnameSuffix, gc.Equals, "juju-machine-0-kvm-5") // passed to AllocateAddress() below
+		params := make(url.Values)
+		params.Add("mac_addresses", macAddress)
+		params.Add("hostname", "auto-generated.maas")
+		params.Add("parent", extractSystemId(instId))
+		return params
+	}
+	suite.PatchValue(&NewDeviceParams, newParams)
+	updateHostname := func(client *gomaasapi.MAASObject, deviceID, deviceHostname, hostnameSuffix string) (string, error) {
+		c.Check(client, gc.NotNil)
+		c.Check(deviceID, gc.Matches, `node-[0-9a-f-]+`)
+		c.Check(deviceHostname, gc.Equals, "auto-generated.maas")  // "generated" above in NewDeviceParams()
+		c.Check(hostnameSuffix, gc.Equals, "juju-machine-0-kvm-5") // passed to AllocateAddress() below
+		return "auto-generated-juju-lxc.maas", nil
+	}
+	suite.PatchValue(&UpdateDeviceHostname, updateHostname)
+
 	// note that the default test server always succeeds if we provide a
 	// valid instance id and net id
-	err := env.AllocateAddress(testInstance.Id(), "LAN", network.Address{Value: "192.168.2.1"}, "foo", "bar")
+	err := env.AllocateAddress(
+		testInstance.Id(),
+		"LAN",
+		&network.Address{Value: "192.168.2.1"},
+		"aa:bb:cc:dd:ee:f0",
+		"juju-machine-0-kvm-5",
+	)
 	c.Assert(err, jc.ErrorIsNil)
 
 	devicesArray := suite.getDeviceArray(c)
@@ -1312,7 +1396,7 @@ func (suite *environSuite) TestAllocateAddressDevices(c *gc.C) {
 
 	hostname, err := device["hostname"].GetString()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(hostname, gc.Equals, "bar")
+	c.Assert(hostname, gc.Equals, "auto-generated.maas")
 
 	parent, err := device["parent"].GetString()
 	c.Assert(err, jc.ErrorIsNil)
@@ -1335,7 +1419,72 @@ func (suite *environSuite) TestAllocateAddressDevices(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	mac, err := macMap["mac_address"].GetString()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(mac, gc.Equals, "foo")
+	c.Assert(mac, gc.Equals, "aa:bb:cc:dd:ee:f0")
+}
+
+func (suite *environSuite) TestTransformDeviceHostname(c *gc.C) {
+	for i, test := range []struct {
+		deviceHostname string
+		hostnameSuffix string
+
+		expectedOutput string
+		expectedError  string
+	}{{
+		deviceHostname: "shiny-town.maas",
+		hostnameSuffix: "juju-machine-1-lxc-2",
+		expectedOutput: "shiny-town-juju-machine-1-lxc-2.maas",
+	}, {
+		deviceHostname: "foo.subdomain.example.com",
+		hostnameSuffix: "suffix",
+		expectedOutput: "foo-suffix.subdomain.example.com",
+	}, {
+		deviceHostname: "bad-food.example.com",
+		hostnameSuffix: "suffix.example.org",
+		expectedOutput: "bad-food-suffix.example.org.example.com",
+	}, {
+		deviceHostname: "strangers-and.freaks",
+		hostnameSuffix: "just-this",
+		expectedOutput: "strangers-and-just-this.freaks",
+	}, {
+		deviceHostname: "no-dot-hostname",
+		hostnameSuffix: "anything",
+		expectedError:  `unexpected device "dev-id" hostname "no-dot-hostname"`,
+	}, {
+		deviceHostname: "anything",
+		hostnameSuffix: "",
+		expectedError:  "hostname suffix cannot be empty",
+	}} {
+		c.Logf(
+			"test #%d: %q + %q -> %q (err: %s)",
+			i, test.deviceHostname, test.hostnameSuffix,
+			test.expectedOutput, test.expectedError,
+		)
+		output, err := transformDeviceHostname("dev-id", test.deviceHostname, test.hostnameSuffix)
+		if test.expectedError != "" {
+			c.Check(err, gc.ErrorMatches, test.expectedError)
+			c.Check(output, gc.Equals, "")
+			continue
+		}
+		c.Check(err, jc.ErrorIsNil)
+		c.Check(output, gc.Equals, test.expectedOutput)
+	}
+}
+
+func (suite *environSuite) patchDeviceCreation() {
+	// Work around the lack of support for devices PUT and POST without hostname
+	// set in gomaasapi's testservices
+	newParams := func(macAddress string, instId instance.Id, _ string) url.Values {
+		params := make(url.Values)
+		params.Add("mac_addresses", macAddress)
+		params.Add("hostname", "auto-generated.maas")
+		params.Add("parent", extractSystemId(instId))
+		return params
+	}
+	suite.PatchValue(&NewDeviceParams, newParams)
+	updateHostname := func(_ *gomaasapi.MAASObject, _, _, _ string) (string, error) {
+		return "auto-generated-juju-lxc.maas", nil
+	}
+	suite.PatchValue(&UpdateDeviceHostname, updateHostname)
 }
 
 func (suite *environSuite) TestAllocateAddressDevicesFailures(c *gc.C) {
@@ -1343,6 +1492,7 @@ func (suite *environSuite) TestAllocateAddressDevicesFailures(c *gc.C) {
 	suite.testMAASObject.TestServer.SetVersionJSON(`{"capabilities": ["devices-management"]}`)
 	testInstance := suite.createSubnets(c, false)
 	env := suite.makeEnviron()
+	suite.patchDeviceCreation()
 
 	responses := []string{
 		"claim_sticky_ip_address failed",
@@ -1351,8 +1501,9 @@ func (suite *environSuite) TestAllocateAddressDevicesFailures(c *gc.C) {
 		"unexpected ip_addresses in response",
 		"IP in ip_addresses not a string",
 	}
-	reserveIP := func(devices gomaasapi.MAASObject, deviceId string, addr network.Address) (network.Address, error) {
-		c.Check(deviceId, gc.Matches, "node-[a-f0-9]+")
+	reserveIP := func(_ gomaasapi.MAASObject, deviceID, macAddress string, addr network.Address) (network.Address, error) {
+		c.Check(deviceID, gc.Matches, "node-[a-f0-9]+")
+		c.Check(macAddress, gc.Matches, "aa:bb:cc:dd:ee:f0")
 		c.Check(addr, jc.DeepEquals, network.Address{})
 		nextError := responses[0]
 		return network.Address{}, errors.New(nextError)
@@ -1360,7 +1511,11 @@ func (suite *environSuite) TestAllocateAddressDevicesFailures(c *gc.C) {
 	suite.PatchValue(&ReserveIPAddressOnDevice, reserveIP)
 
 	for len(responses) > 0 {
-		err := env.AllocateAddress(testInstance.Id(), network.AnySubnet, network.Address{}, "mac-address", "hostname")
+		addr := &network.Address{}
+		err := env.AllocateAddress(
+			testInstance.Id(), network.AnySubnet, addr,
+			"aa:bb:cc:dd:ee:f0", "juju-lxc",
+		)
 		c.Check(err, gc.ErrorMatches, responses[0])
 		responses = responses[1:]
 	}
@@ -1387,14 +1542,20 @@ func (suite *environSuite) TestReleaseAddressDeletesDevice(c *gc.C) {
 	suite.testMAASObject.TestServer.SetVersionJSON(`{"capabilities": ["networks-management","static-ipaddresses", "devices-management"]}`)
 	testInstance := suite.createSubnets(c, false)
 	env := suite.makeEnviron()
+	suite.patchDeviceCreation()
+
 	addr := network.NewAddress("192.168.2.1")
-	err := env.AllocateAddress(testInstance.Id(), "LAN", addr, "foo", "bar")
+	err := env.AllocateAddress(testInstance.Id(), "LAN", &addr, "foo", "juju-lxc")
 	c.Assert(err, jc.ErrorIsNil)
 
 	devicesArray := suite.getDeviceArray(c)
 	c.Assert(devicesArray, gc.HasLen, 1)
 
-	err = env.ReleaseAddress(testInstance.Id(), "LAN", addr, "foo", "bar")
+	// Since we're mocking out updateDeviceHostname, no need to check if the
+	// hostname was updated (only manually tested for now until we change
+	// gomaasapi).
+
+	err = env.ReleaseAddress(testInstance.Id(), "LAN", addr, "foo", "juju-lxc")
 	c.Assert(err, jc.ErrorIsNil)
 
 	devicesArray = suite.getDeviceArray(c)
@@ -1406,7 +1567,7 @@ func (suite *environSuite) TestAllocateAddressInvalidInstance(c *gc.C) {
 	env := suite.makeEnviron()
 	addr := network.Address{Value: "192.168.2.1"}
 	instId := instance.Id("foo")
-	err := env.AllocateAddress(instId, "bar", addr, "foo", "bar")
+	err := env.AllocateAddress(instId, "bar", &addr, "foo", "juju-lxc")
 	expected := fmt.Sprintf("failed to allocate address %q for instance %q.*", addr, instId)
 	c.Assert(err, gc.ErrorMatches, expected)
 }
@@ -1415,7 +1576,7 @@ func (suite *environSuite) TestAllocateAddressMissingSubnet(c *gc.C) {
 	suite.testMAASObject.TestServer.SetVersionJSON(`{"capabilities": ["networks-management","static-ipaddresses"]}`)
 	testInstance := suite.createSubnets(c, false)
 	env := suite.makeEnviron()
-	err := env.AllocateAddress(testInstance.Id(), "bar", network.Address{Value: "192.168.2.1"}, "foo", "bar")
+	err := env.AllocateAddress(testInstance.Id(), "bar", &network.Address{Value: "192.168.2.1"}, "foo", "bar")
 	c.Assert(errors.Cause(err), gc.ErrorMatches, "failed to find the following subnets: \\[bar\\]")
 }
 
@@ -1430,7 +1591,7 @@ func (suite *environSuite) TestAllocateAddressIPAddressUnavailable(c *gc.C) {
 	suite.PatchValue(&ReserveIPAddress, reserveIPAddress)
 
 	ipAddress := network.Address{Value: "192.168.2.1"}
-	err := env.AllocateAddress(testInstance.Id(), "LAN", ipAddress, "foo", "bar")
+	err := env.AllocateAddress(testInstance.Id(), "LAN", &ipAddress, "foo", "bar")
 	c.Assert(errors.Cause(err), gc.Equals, environs.ErrIPAddressUnavailable)
 	expected := fmt.Sprintf("failed to allocate address %q for instance %q.*", ipAddress, testInstance.Id())
 	c.Assert(err, gc.ErrorMatches, expected)
@@ -1449,7 +1610,7 @@ func (suite *environSuite) TestReleaseAddress(c *gc.C) {
 	testInstance := suite.createSubnets(c, false)
 	env := suite.makeEnviron()
 
-	err := env.AllocateAddress(testInstance.Id(), "LAN", network.Address{Value: "192.168.2.1"}, "foo", "bar")
+	err := env.AllocateAddress(testInstance.Id(), "LAN", &network.Address{Value: "192.168.2.1"}, "foo", "bar")
 	c.Assert(err, jc.ErrorIsNil)
 
 	ipAddress := network.Address{Value: "192.168.2.1"}
@@ -1484,7 +1645,7 @@ func (suite *environSuite) TestReleaseAddressRetry(c *gc.C) {
 	testInstance := suite.createSubnets(c, false)
 	env := suite.makeEnviron()
 
-	err := env.AllocateAddress(testInstance.Id(), "LAN", network.Address{Value: "192.168.2.1"}, "foo", "bar")
+	err := env.AllocateAddress(testInstance.Id(), "LAN", &network.Address{Value: "192.168.2.1"}, "foo", "bar")
 	c.Assert(err, jc.ErrorIsNil)
 
 	// ReleaseAddress must fail with 5 retries.

--- a/provider/maas/maas_test.go
+++ b/provider/maas/maas_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/juju/gomaasapi"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	envtesting "github.com/juju/juju/environs/testing"
 	"github.com/juju/juju/feature"
@@ -19,9 +18,6 @@ import (
 	"github.com/juju/utils/arch"
 	"github.com/juju/utils/series"
 )
-
-// Ensure maasEnviron supports environs.NetworkingEnviron.
-var _ environs.NetworkingEnviron = (*maasEnviron)(nil)
 
 type providerSuite struct {
 	coretesting.FakeJujuHomeSuite

--- a/provider/vsphere/environ_network.go
+++ b/provider/vsphere/environ_network.go
@@ -13,8 +13,8 @@ import (
 )
 
 // AllocateAddress implements environs.Environ.
-func (env *environ) AllocateAddress(instID instance.Id, subnetID network.Id, addr network.Address, _, _ string) error {
-	return env.changeAddress(instID, subnetID, addr, true)
+func (env *environ) AllocateAddress(instID instance.Id, subnetID network.Id, addr *network.Address, _, _ string) error {
+	return env.changeAddress(instID, subnetID, *addr, true)
 }
 
 // ReleaseAddress implements environs.Environ.

--- a/worker/provisioner/provisioner_task.go
+++ b/worker/provisioner/provisioner_task.go
@@ -671,6 +671,21 @@ func (task *provisionerTask) prepareNetworkAndInterfaces(networkInfo []network.I
 	}
 	visitedNetworks := set.NewStrings()
 	for _, info := range networkInfo {
+		// TODO(dimitern): The following few fields are required, but no longer
+		// matter and will be dropped or changed soon as part of making spaces
+		// and subnets usable across the board.
+		if info.NetworkName == "" {
+			info.NetworkName = network.DefaultPrivate
+		}
+		if info.ProviderId == "" {
+			info.ProviderId = network.DefaultPrivate
+		}
+		if info.CIDR == "" {
+			// TODO(dimitern): This is only when NOT using addressable
+			// containers, as we don't fetch the subnet details, but since
+			// networks in state are going away real soon, it's not important.
+			info.CIDR = "0.0.0.0/32"
+		}
 		if !names.IsValidNetwork(info.NetworkName) {
 			return nil, nil, errors.Errorf("invalid network name %q", info.NetworkName)
 		}


### PR DESCRIPTION
This is a forward port from 1.25 of PR #3966.

 Fixes [LP:#1525280](https://bugs.launchpad.net/juju-core/+bug/1525280)

(Review request: http://reviews.vapour.ws/r/3497/)