### PR TITLE
Fix TestDeployBundleWatcherTimeout

### DIFF
--- a/cmd/juju/commands/bundle.go
+++ b/cmd/juju/commands/bundle.go
@@ -27,8 +27,7 @@ import (
 )
 
 var watchAll = func(c *api.Client) (allWatcher, error) {
-	w, err := c.WatchAll()
-	return w, err
+	return c.WatchAll()
 }
 
 type allWatcher interface {

--- a/cmd/juju/commands/bundle.go
+++ b/cmd/juju/commands/bundle.go
@@ -26,6 +26,16 @@ import (
 	"github.com/juju/juju/storage"
 )
 
+var watchAll = func(c *api.Client) (allWatcher, error) {
+	w, err := c.WatchAll()
+	return w, err
+}
+
+type allWatcher interface {
+	Next() ([]multiwatcher.Delta, error)
+	Stop() error
+}
+
 // deploymentLogger is used to notify clients about the bundle deployment
 // progress.
 type deploymentLogger interface {
@@ -70,7 +80,7 @@ func deployBundle(
 	}
 
 	// Instantiate a watcher used to follow the deployment progress.
-	watcher, err := client.WatchAll()
+	watcher, err := watchAll(client)
 	if err != nil {
 		return errors.Annotate(err, "cannot watch environment")
 	}
@@ -176,7 +186,7 @@ type bundleHandler struct {
 	ignoredUnits    map[string]bool
 	// watcher holds an environment mega-watcher used to keep the environment
 	// status up to date.
-	watcher *api.AllWatcher
+	watcher allWatcher
 }
 
 // addCharm adds a charm to the environment.


### PR DESCRIPTION
TestDeployBundleWatcherTimeout expects a timeout,
but is racy due to the possibility of a watcher
event being delivered before the timeout occurs.
We fix this by injecting a mock "AllWatcher" that
will not deliver a result.

(Review request: http://reviews.vapour.ws/r/3499/)