### PR TITLE
lp1533338 - put xenial in right order

### DIFF
--- a/version/supportedseries_windows_test.go
+++ b/version/supportedseries_windows_test.go
@@ -53,8 +53,6 @@ func (s *supportedSeriesWindowsSuite) TestSupportedSeries(c *gc.C) {
 		"win81",
 		"xenial",
 	}
-	sort.Strings(expectedSeries)
 	series := version.SupportedSeries()
-	sort.Strings(series)
-	c.Assert(series, gc.DeepEquals, expectedSeries)
+	c.Assert(series, jc.SameContents, expectedSeries)
 }

--- a/version/supportedseries_windows_test.go
+++ b/version/supportedseries_windows_test.go
@@ -43,7 +43,6 @@ func (s *supportedSeriesWindowsSuite) TestSupportedSeries(c *gc.C) {
 		"utopic",
 		"vivid",
 		"wily",
-		"xenial",
 		"win10",
 		"win2012",
 		"win2012hv",
@@ -52,7 +51,9 @@ func (s *supportedSeriesWindowsSuite) TestSupportedSeries(c *gc.C) {
 		"win7",
 		"win8",
 		"win81",
+		"xenial",
 	}
+	sort.Strings(expectedSeries)
 	series := version.SupportedSeries()
 	sort.Strings(series)
 	c.Assert(series, gc.DeepEquals, expectedSeries)

--- a/version/supportedseries_windows_test.go
+++ b/version/supportedseries_windows_test.go
@@ -35,6 +35,7 @@ func (s *supportedSeriesWindowsSuite) TestSupportedSeries(c *gc.C) {
 	expectedSeries := []string{
 		"arch",
 		"centos7",
+
 		"precise",
 		"quantal",
 		"raring",
@@ -43,6 +44,8 @@ func (s *supportedSeriesWindowsSuite) TestSupportedSeries(c *gc.C) {
 		"utopic",
 		"vivid",
 		"wily",
+		"xenial",
+
 		"win10",
 		"win2012",
 		"win2012hv",
@@ -51,7 +54,6 @@ func (s *supportedSeriesWindowsSuite) TestSupportedSeries(c *gc.C) {
 		"win7",
 		"win8",
 		"win81",
-		"xenial",
 	}
 	series := version.SupportedSeries()
 	c.Assert(series, jc.SameContents, expectedSeries)


### PR DESCRIPTION
"X" comes after "W", fixed the order in the
expected strings, and added a sort to prevent
this pain in the future.

(Review request: http://reviews.vapour.ws/r/3504/)