### PR TITLE
worker/undertaker: avoid double channel close in tests

### DIFF
--- a/worker/undertaker/mock_test.go
+++ b/worker/undertaker/mock_test.go
@@ -70,8 +70,9 @@ func (m *mockClient) WatchEnvironResources() (watcher.NotifyWatcher, error) {
 }
 
 type mockEnvironResourceWatcher struct {
-	events chan struct{}
-	err    error
+	events    chan struct{}
+	closeOnce sync.Once
+	err       error
 }
 
 func (w *mockEnvironResourceWatcher) Changes() watcher.NotifyChannel {
@@ -79,7 +80,7 @@ func (w *mockEnvironResourceWatcher) Changes() watcher.NotifyChannel {
 }
 
 func (w *mockEnvironResourceWatcher) Kill() {
-	close(w.events)
+	w.closeOnce.Do(func() { close(w.events) })
 }
 
 func (w *mockEnvironResourceWatcher) Wait() error {


### PR DESCRIPTION
A recent test change made during the undertaker's catacomb conversion introduced the possibility of a double channel close which seems to happen quite often under Go 1.5. This is now fixed using sync.Once to ensure that channel is only closed once.

(Review request: http://reviews.vapour.ws/r/3511/)