### PR TITLE
Fixes lp:1533469 -  reboot build failure.

### DIFF
--- a/api/interface.go
+++ b/api/interface.go
@@ -172,7 +172,7 @@ type Connection interface {
 	Firewaller() *firewaller.State
 	Agent() *agent.State
 	Upgrader() *upgrader.State
-	Reboot() (*reboot.State, error)
+	Reboot() (reboot.State, error)
 	Deployer() *deployer.State
 	Environment() *environment.Facade
 	Logger() *apilogger.State

--- a/api/reboot/export_test.go
+++ b/api/reboot/export_test.go
@@ -7,6 +7,7 @@ import (
 // PatchFacadeCall patches the State's facade such that
 // FacadeCall method calls are diverted to the provided
 // function.
-func PatchFacadeCall(p testing.Patcher, st *State, f func(request string, params, response interface{}) error) {
-	testing.PatchFacadeCall(p, &st.facade, f)
+func PatchFacadeCall(p testing.Patcher, st State, f func(request string, params, response interface{}) error) {
+	st0 := st.(*state) // *state is the only implementation of State.
+	testing.PatchFacadeCall(p, &st0.facade, f)
 }

--- a/api/reboot/reboot.go
+++ b/api/reboot/reboot.go
@@ -14,24 +14,42 @@ import (
 )
 
 // State provides access to an reboot worker's view of the state.
-type State struct {
+// NOTE: This is defined as an interface due to PPC64 bug #1533469 -
+// if it were a type build errors happen (due to a linker bug).
+type State interface {
+	// WatchForRebootEvent returns a watcher.NotifyWatcher that
+	// reacts to reboot flag changes.
+	WatchForRebootEvent() (watcher.NotifyWatcher, error)
+
+	// RequestReboot sets the reboot flag for the calling machine.
+	RequestReboot() error
+
+	// ClearReboot clears the reboot flag for the calling machine.
+	ClearReboot() error
+
+	// GetRebootAction returns the reboot action for the calling machine.
+	GetRebootAction() (params.RebootAction, error)
+}
+
+var _ State = (*state)(nil)
+
+// state implements State.
+type state struct {
 	machineTag names.Tag
 	facade     base.FacadeCaller
 }
 
 // NewState returns a version of the state that provides functionality
 // required by the reboot worker.
-func NewState(caller base.APICaller, machineTag names.MachineTag) *State {
-
-	return &State{
+func NewState(caller base.APICaller, machineTag names.MachineTag) State {
+	return &state{
 		facade:     base.NewFacadeCaller(caller, "Reboot"),
 		machineTag: machineTag,
 	}
 }
 
-// WatchForRebootEvent returns a watcher.NotifyWatcher that reacts to reboot flag
-// changes
-func (st *State) WatchForRebootEvent() (watcher.NotifyWatcher, error) {
+// WatchForRebootEvent implements State.WatchForRebootEvent
+func (st *state) WatchForRebootEvent() (watcher.NotifyWatcher, error) {
 	var result params.NotifyWatchResult
 
 	if err := st.facade.FacadeCall("WatchForRebootEvent", nil, &result); err != nil {
@@ -45,8 +63,8 @@ func (st *State) WatchForRebootEvent() (watcher.NotifyWatcher, error) {
 	return w, nil
 }
 
-// RequestReboot sets the reboot flag for the calling machine
-func (st *State) RequestReboot() error {
+// RequestReboot implements State.RequestReboot
+func (st *state) RequestReboot() error {
 	var results params.ErrorResults
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: st.machineTag.String()}},
@@ -66,8 +84,8 @@ func (st *State) RequestReboot() error {
 	return nil
 }
 
-// ClearReboot clears the reboot flag for the calling machine
-func (st *State) ClearReboot() error {
+// ClearReboot implements State.ClearReboot
+func (st *state) ClearReboot() error {
 	var results params.ErrorResults
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: st.machineTag.String()}},
@@ -89,8 +107,8 @@ func (st *State) ClearReboot() error {
 	return nil
 }
 
-// GetRebootAction returns the reboot action for the calling machine
-func (st *State) GetRebootAction() (params.RebootAction, error) {
+// GetRebootAction implements State.GetRebootAction
+func (st *state) GetRebootAction() (params.RebootAction, error) {
 	var results params.RebootActionResults
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: st.machineTag.String()}},

--- a/api/reboot/reboot_test.go
+++ b/api/reboot/reboot_test.go
@@ -30,7 +30,7 @@ type machineRebootSuite struct {
 
 	machine *state.Machine
 	st      api.Connection
-	reboot  *reboot.State
+	reboot  reboot.State
 }
 
 var _ = gc.Suite(&machineRebootSuite{})

--- a/api/state.go
+++ b/api/state.go
@@ -348,7 +348,7 @@ func (st *state) Upgrader() *upgrader.State {
 }
 
 // Reboot returns access to the Reboot API
-func (st *state) Reboot() (*reboot.State, error) {
+func (st *state) Reboot() (reboot.State, error) {
 	switch tag := st.authTag.(type) {
 	case names.MachineTag:
 		return reboot.NewState(st, tag), nil

--- a/cmd/jujud/reboot/reboot.go
+++ b/cmd/jujud/reboot/reboot.go
@@ -45,7 +45,7 @@ type Reboot struct {
 	acfg     agent.Config
 	apistate api.Connection
 	tag      names.MachineTag
-	st       *reboot.State
+	st       reboot.State
 }
 
 func NewRebootWaiter(apistate api.Connection, acfg agent.Config) (*Reboot, error) {

--- a/worker/reboot/reboot.go
+++ b/worker/reboot/reboot.go
@@ -27,12 +27,12 @@ var _ worker.NotifyWatchHandler = (*Reboot)(nil)
 // right thing (reboot or shutdown)
 type Reboot struct {
 	tomb        tomb.Tomb
-	st          *reboot.State
+	st          reboot.State
 	tag         names.MachineTag
 	machineLock *fslock.Lock
 }
 
-func NewReboot(st *reboot.State, agentConfig agent.Config, machineLock *fslock.Lock) (worker.Worker, error) {
+func NewReboot(st reboot.State, agentConfig agent.Config, machineLock *fslock.Lock) (worker.Worker, error) {
 	tag, ok := agentConfig.Tag().(names.MachineTag)
 	if !ok {
 		return nil, errors.Errorf("Expected names.MachineTag, got %T: %v", agentConfig.Tag(), agentConfig.Tag())

--- a/worker/reboot/reboot_test.go
+++ b/worker/reboot/reboot_test.go
@@ -25,7 +25,7 @@ func TestPackage(t *stdtesting.T) {
 type machines struct {
 	machine     *state.Machine
 	stateAPI    api.Connection
-	rebootState *apireboot.State
+	rebootState apireboot.State
 }
 
 type rebootSuite struct {
@@ -33,10 +33,10 @@ type rebootSuite struct {
 
 	machine     *state.Machine
 	stateAPI    api.Connection
-	rebootState *apireboot.State
+	rebootState apireboot.State
 
 	ct            *state.Machine
-	ctRebootState *apireboot.State
+	ctRebootState apireboot.State
 
 	lock       *fslock.Lock
 	lockReboot *fslock.Lock


### PR DESCRIPTION
As per similar issue described in lp:1424669, changed State struct to interface in reboot package.

I have tested it locally, including  with gccgo [go test -compiler gccgo ./...]

(Review request: http://reviews.vapour.ws/r/3512/)