### PR TITLE
put add-/list-image behind a feature flag

### DIFF
--- a/cmd/plugins/juju-metadata/metadata.go
+++ b/cmd/plugins/juju-metadata/metadata.go
@@ -9,8 +9,11 @@ import (
 
 	"github.com/juju/cmd"
 	"github.com/juju/loggo"
+	"github.com/juju/utils/featureflag"
 
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/juju"
+	"github.com/juju/juju/juju/osenv"
 	_ "github.com/juju/juju/provider/all"
 )
 
@@ -46,10 +49,16 @@ func Main(args []string) {
 	metadatacmd.Register(newToolsMetadataCommand())
 	metadatacmd.Register(newValidateToolsMetadataCommand())
 	metadatacmd.Register(newSignMetadataCommand())
-	metadatacmd.Register(newListImagesCommand())
-	metadatacmd.Register(newAddImageMetadataCommand())
+	if featureflag.Enabled(feature.ImageMetadata) {
+		metadatacmd.Register(newListImagesCommand())
+		metadatacmd.Register(newAddImageMetadataCommand())
+	}
 
 	os.Exit(cmd.Main(metadatacmd, ctx, args[1:]))
+}
+
+func init() {
+	featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
 }
 
 func main() {

--- a/cmd/plugins/juju-metadata/metadataplugin_test.go
+++ b/cmd/plugins/juju-metadata/metadataplugin_test.go
@@ -11,8 +11,11 @@ import (
 	"strings"
 	stdtesting "testing"
 
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/set"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/testing"
 )
@@ -55,7 +58,7 @@ func badrun(c *gc.C, exit int, args ...string) string {
 
 	ps := exec.Command(os.Args[0], localArgs...)
 
-	ps.Env = append(os.Environ(), osenv.JujuHomeEnvKey+"="+osenv.JujuHome())
+	ps.Env = append(os.Environ(), osenv.JujuHomeEnvKey+"="+osenv.JujuHome(), os.Getenv(osenv.JujuFeatureFlagEnvKey))
 	output, err := ps.CombinedOutput()
 	if exit != 0 {
 		c.Assert(err, gc.ErrorMatches, fmt.Sprintf("exit status %d", exit))
@@ -63,9 +66,7 @@ func badrun(c *gc.C, exit int, args ...string) string {
 	return string(output)
 }
 
-func (s *MetadataSuite) TestHelpCommands(c *gc.C) {
-	// Check that we have correctly registered all the sub commands
-	// by checking the help output.
+func getHelpCommandNames(c *gc.C) []string {
 	out := badrun(c, 0, "--help")
 	c.Log(out)
 	var names []string
@@ -74,8 +75,29 @@ func (s *MetadataSuite) TestHelpCommands(c *gc.C) {
 	for _, line := range strings.Split(commandHelp, "\n") {
 		names = append(names, strings.TrimSpace(strings.Split(line, " - ")[0]))
 	}
+	return names
+}
+
+func (s *MetadataSuite) TestHelpCommands(c *gc.C) {
+	// Check that we have correctly registered all the sub commands
+	// by checking the help output.
+
+	// Remove add/list-image for the first test because the feature is not
+	// enabled by default.
+	devFeatures := set.NewStrings("add-image", "list-images")
+
+	// Remove features behind dev_flag for the first test since they are not
+	// enabled.
+	cmdSet := set.NewStrings(metadataCommandNames...).Difference(devFeatures)
+
+	// Test default commands.
 	// The names should be output in alphabetical order, so don't sort.
-	c.Assert(names, gc.DeepEquals, metadataCommandNames)
+	c.Assert(getHelpCommandNames(c), jc.SameContents, cmdSet.Values())
+
+	// Enable development features, and test again. We should now see the
+	// development commands.
+	s.SetFeatureFlags(feature.ImageMetadata)
+	c.Assert(getHelpCommandNames(c), gc.DeepEquals, metadataCommandNames)
 }
 
 func (s *MetadataSuite) assertHelpOutput(c *gc.C, cmd string) {
@@ -98,9 +120,11 @@ func (s *MetadataSuite) TestHelpGenerateImage(c *gc.C) {
 }
 
 func (s *MetadataSuite) TestHelpListImages(c *gc.C) {
+	s.SetFeatureFlags(feature.ImageMetadata)
 	s.assertHelpOutput(c, "list-images")
 }
 
 func (s *MetadataSuite) TestHelpAddImage(c *gc.C) {
+	s.SetFeatureFlags(feature.ImageMetadata)
 	s.assertHelpOutput(c, "add-image")
 }

--- a/feature/flags.go
+++ b/feature/flags.go
@@ -62,3 +62,6 @@ const DisableRsyslog = "disable-rsyslog"
 
 // VSphereProvider enables the generic vmware provider.
 const VSphereProvider = "vsphere-provider"
+
+// ImageMetadata allows custom image metadata to be recorded in state.
+const ImageMetadata = "image-metadata"


### PR DESCRIPTION
Do not expose add/list-image by default - use a "image-metadata" feature flag.

(Review request: http://reviews.vapour.ws/r/3514/)