### PR TITLE
lp1533751 - Update minimum 2.0 upgrade version

### DIFF
--- a/cmd/juju/commands/upgradejuju.go
+++ b/cmd/juju/commands/upgradejuju.go
@@ -181,7 +181,7 @@ func (c *UpgradeJujuCommand) Run(ctx *cmd.Context) (err error) {
 	}
 
 	if c.Version.Major > agentVersion.Major {
-		// We can only upgrade a major version if we're currently on 1.25.2 or later
+		// We can only upgrade a major version if we're currently on 1.25.3 or later
 		// and we're going to 2.0.x, and the version was explicitly requested.
 		if agentVersion.Major != 1 {
 			return fmt.Errorf("cannot upgrade to version incompatible with CLI")
@@ -191,8 +191,8 @@ func (c *UpgradeJujuCommand) Run(ctx *cmd.Context) (err error) {
 			ctx.Infof("Upgrades to %s must first go through juju 2.0.", c.Version)
 			retErr = true
 		}
-		if agentVersion.Minor < 25 || (agentVersion.Minor == 25 && agentVersion.Patch < 2) {
-			ctx.Infof("Upgrades to juju 2.0 must first go through juju 1.25.2 or higher.")
+		if comp := agentVersion.Compare(version.MustParse("1.25.3")); comp < 0 {
+			ctx.Infof("Upgrades to juju 2.0 must first go through juju 1.25.3 or higher.")
 			retErr = true
 		}
 		if retErr {

--- a/cmd/juju/commands/upgradejuju_test.go
+++ b/cmd/juju/commands/upgradejuju_test.go
@@ -174,24 +174,24 @@ var upgradeJujuTests = []struct {
 	args:           []string{"--version", "2.3-dev0"},
 	expectVersion:  "2.3-dev0",
 }, {
-	about:          "specified major version from 1.25.2",
+	about:          "specified major version from 1.25.3",
 	tools:          []string{"2.0.1-quantal-amd64"},
-	currentVersion: "1.25.2-quantal-amd64",
-	agentVersion:   "1.25.2",
+	currentVersion: "1.25.3-quantal-amd64",
+	agentVersion:   "1.25.3",
 	args:           []string{"--version", "2.0.1"},
 	expectVersion:  "2.0.1",
 }, {
 	about:          "specified major version from 1.26-alpha2",
 	tools:          []string{"2.0.0-quantal-amd64"},
-	currentVersion: "1.25.2-quantal-amd64",
+	currentVersion: "1.25.3-quantal-amd64",
 	agentVersion:   "1.26-alpha2",
 	args:           []string{"--version", "2.0.0"},
 	expectVersion:  "2.0.0",
 }, {
 	about:          "specified valid major upgrade with no tools available",
-	tools:          []string{"1.25.2-quantal-amd64"},
-	currentVersion: "1.25.2-quantal-amd64",
-	agentVersion:   "1.25.2",
+	tools:          []string{"1.25.3-quantal-amd64"},
+	currentVersion: "1.25.3-quantal-amd64",
+	agentVersion:   "1.25.3",
 	args:           []string{"--version", "2.0.0"},
 	expectErr:      "no matching tools available",
 }, {
@@ -705,7 +705,7 @@ func (s *UpgradeJujuSuite) TestResetPreviousUpgrade(c *gc.C) {
 
 func (s *UpgradeJujuSuite) TestMinimumVersionForMajorUpgrade(c *gc.C) {
 	versions := []version.Binary{
-		version.MustParseBinary("1.25.1-trusty-amd64"),
+		version.MustParseBinary("1.25.2-trusty-amd64"),
 		version.MustParseBinary("1.24.7-trusty-amd64"),
 	}
 	for _, vers := range versions {
@@ -726,16 +726,16 @@ func (s *UpgradeJujuSuite) TestMinimumVersionForMajorUpgrade(c *gc.C) {
 		c.Assert(err, gc.ErrorMatches, "cannot upgrade to version incompatible with CLI")
 
 		output := coretesting.Stderr(ctx)
-		c.Assert(output, gc.Equals, "Upgrades to juju 2.0 must first go through juju 1.25.2 or higher.\n")
+		c.Assert(output, gc.Equals, "Upgrades to juju 2.0 must first go through juju 1.25.3 or higher.\n")
 	}
 }
 
 func (s *UpgradeJujuSuite) TestMajorVersionRestriction(c *gc.C) {
 	for _, vers := range []string{"2.1.4", "3.0.0"} {
 		c.Logf("testing TestMajorVersionRestriction with version: %s", vers)
-		s.PatchValue(&version.Current, version.MustParseBinary("1.25.2-trusty-amd64"))
+		s.PatchValue(&version.Current, version.MustParseBinary("1.25.3-trusty-amd64"))
 		updateAttrs := map[string]interface{}{
-			"agent-version": "1.25.2",
+			"agent-version": "1.25.3",
 		}
 		err := s.State.UpdateEnvironConfig(updateAttrs, nil, nil)
 		c.Assert(err, jc.ErrorIsNil)
@@ -769,7 +769,7 @@ func (s *UpgradeJujuSuite) TestMinFromAndMaxToMajorVersion(c *gc.C) {
 
 	output := coretesting.Stderr(ctx)
 	c.Assert(output, gc.Equals, "Upgrades to 2.1.4 must first go through juju 2.0.\n"+
-		"Upgrades to juju 2.0 must first go through juju 1.25.2 or higher.\n")
+		"Upgrades to juju 2.0 must first go through juju 1.25.3 or higher.\n")
 }
 
 func NewFakeUpgradeJujuAPI(c *gc.C, st *state.State) *fakeUpgradeJujuAPI {


### PR DESCRIPTION
Due to some recent discussions, 1.25.2 will not
be a sufficient minimum version to upgrade from
when moving to 2.0.  Incrementing the minimum
version to 1.25.3.

(Review request: http://reviews.vapour.ws/r/3519/)