### PR TITLE
Rewrite AddSubnetsWithTemplate to work around gccgo bug

### DIFF
--- a/juju/testing/utils.go
+++ b/juju/testing/utils.go
@@ -5,8 +5,6 @@ package testing
 
 import (
 	"bytes"
-	"fmt"
-	"reflect"
 	"text/template"
 
 	jc "github.com/juju/testing/checkers"
@@ -75,27 +73,28 @@ func AddStateServerMachine(c *gc.C, st *state.State) *state.Machine {
 //     VLANTag: 42,
 // })
 func AddSubnetsWithTemplate(c *gc.C, st *state.State, numSubnets uint, infoTemplate state.SubnetInfo) {
-	infot := reflect.TypeOf(infoTemplate)
 	for subnetIndex := 0; subnetIndex < int(numSubnets); subnetIndex++ {
 		info := infoTemplate // make a copy each time.
 
-		for fieldIndex := 0; fieldIndex < infot.NumField(); fieldIndex++ {
-			fieldv := reflect.ValueOf(&info).Elem().Field(fieldIndex)
-
-			if fieldv.Kind() != reflect.String {
-				// Skip non string fields.
-				continue
-			}
-
-			text := fmt.Sprint(fieldv.Interface())
-			t, err := template.New("").Parse(text)
+		// permute replaces the contents of *s with the result of interpreting
+		// *s as a template.
+		permute := func(s *string) {
+			t, err := template.New("").Parse(*s)
 			c.Assert(err, jc.ErrorIsNil)
 
 			var buf bytes.Buffer
 			err = t.Execute(&buf, subnetIndex)
 			c.Assert(err, jc.ErrorIsNil)
-			fieldv.SetString(buf.String())
+			*s = buf.String()
 		}
+
+		permute(&info.ProviderId)
+		permute(&info.CIDR)
+		permute(&info.AllocatableIPHigh)
+		permute(&info.AllocatableIPLow)
+		permute(&info.AvailabilityZone)
+		permute(&info.SpaceName)
+
 		_, err := st.AddSubnet(info)
 		c.Assert(err, jc.ErrorIsNil)
 	}


### PR DESCRIPTION
Fixes LP 1533792

gccgo-4.9 as shipped in Trusty has a number of issues when interfaces
and reflection are combined. In an ideal world these bugs would not
happen, but they do, so the most expedient course of action is to
work around them in our code.

This change replaces the reflection driven construction of a state.SubnetInfo
structure with a more straight forward method which permutes the string
fields known to the structure today. This isn't as future proof as the
previous method, but avoiding the Faustian combination of interfaces and
reflection should make this code more reliable on buggy compilers.

(Review request: http://reviews.vapour.ws/r/3527/)