### PR TITLE
MADE: machiner

### DIFF
--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -14,11 +14,13 @@ import (
 	"github.com/juju/juju/worker/dependency"
 	"github.com/juju/juju/worker/gate"
 	"github.com/juju/juju/worker/logger"
+	"github.com/juju/juju/worker/machiner"
 	"github.com/juju/juju/worker/reboot"
 	"github.com/juju/juju/worker/terminationworker"
 	"github.com/juju/juju/worker/upgrader"
 	"github.com/juju/juju/worker/upgradesteps"
 	"github.com/juju/juju/worker/upgradewaiter"
+	"github.com/juju/juju/worker/util"
 )
 
 // ManifoldsConfig allows specialisation of the result of Manifolds.
@@ -178,6 +180,18 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 			APICallerName:     apiCallerName,
 			UpgradeWaiterName: upgradeWaiterName,
 		}),
+
+		// The machiner Worker will wait for the identified machine to become
+		// Dying and make it Dead; or until the machine becomes Dead by other
+		// means.
+		machinerName: machiner.Manifold(machiner.ManifoldConfig{
+			PostUpgradeManifoldConfig: util.PostUpgradeManifoldConfig{
+				AgentName:         agentName,
+				APICallerName:     apiCallerName,
+				UpgradeWaiterName: upgradeWaiterName,
+			},
+			WriteUninstallFile: config.WriteUninstallFile,
+		}),
 	}
 }
 
@@ -196,4 +210,5 @@ const (
 	apiWorkersName           = "apiworkers"
 	rebootName               = "reboot"
 	loggingConfigUpdaterName = "logging-config-updater"
+	machinerName             = "machiner"
 )

--- a/cmd/jujud/agent/machine/manifolds_test.go
+++ b/cmd/jujud/agent/machine/manifolds_test.go
@@ -51,6 +51,7 @@ func (s *ManifoldsSuite) TestManifoldNames(c *gc.C) {
 		"apiworkers",
 		"reboot",
 		"logging-config-updater",
+		"machiner",
 	}
 	c.Assert(keys, jc.SameContents, expectedKeys)
 }

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -1819,12 +1819,15 @@ func (s *MachineSuite) TestMachineAgentNetworkerMode(c *gc.C) {
 
 func (s *MachineSuite) setupIgnoreAddresses(c *gc.C, expectedIgnoreValue bool) chan bool {
 	ignoreAddressCh := make(chan bool, 1)
-	s.AgentSuite.PatchValue(&newMachiner, func(cfg machiner.Config) (worker.Worker, error) {
+	s.AgentSuite.PatchValue(&machiner.NewMachiner, func(cfg machiner.Config) (worker.Worker, error) {
 		select {
 		case ignoreAddressCh <- cfg.ClearMachineAddressesOnStart:
 		default:
 		}
-		return machiner.NewMachiner(cfg)
+
+		// The test just cares that NewMachiner is called with the correct
+		// value, nothing else is done with the worker.
+		return newDummyWorker(), nil
 	})
 
 	attrs := coretesting.Attrs{"ignore-machine-addresses": expectedIgnoreValue}

--- a/worker/machiner/machiner.go
+++ b/worker/machiner/machiner.go
@@ -58,7 +58,7 @@ type Machiner struct {
 //
 // The machineDead function will be called immediately after the machine's
 // lifecycle is updated to Dead.
-func NewMachiner(cfg Config) (worker.Worker, error) {
+var NewMachiner = func(cfg Config) (worker.Worker, error) {
 	if err := cfg.Validate(); err != nil {
 		return nil, errors.Annotate(err, "validating config")
 	}

--- a/worker/machiner/manifold.go
+++ b/worker/machiner/manifold.go
@@ -1,0 +1,72 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package machiner
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/juju/agent"
+	"github.com/juju/juju/api"
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/dependency"
+	"github.com/juju/juju/worker/util"
+	"github.com/juju/names"
+)
+
+// ManifoldConfig defines the names of the manifolds on which a
+// Manifold will depend.
+type ManifoldConfig struct {
+	util.PostUpgradeManifoldConfig
+	WriteUninstallFile func() error
+}
+
+// Manifold returns a dependency manifold that runs a machiner worker, using
+// the resource names defined in the supplied config.
+func Manifold(config ManifoldConfig) dependency.Manifold {
+
+	// TODO(waigani) This function is currently covered by functional tests
+	// under the machine agent. Add unit tests once infrastructure to do so is
+	// in place.
+
+	// newWorker trivially wraps NewMachiner to specialise a PostUpgradeManifold.
+	var newWorker = func(a agent.Agent, apiCaller base.APICaller) (worker.Worker, error) {
+		currentConfig := a.CurrentConfig()
+
+		apiConn, ok := apiCaller.(api.Connection)
+		if !ok {
+			return nil, errors.New("unable to obtain api.Connection")
+		}
+
+		envConfig, err := apiConn.Environment().EnvironConfig()
+		if err != nil {
+			return nil, errors.Errorf("cannot read environment config: %v", err)
+		}
+
+		ignoreMachineAddresses, _ := envConfig.IgnoreMachineAddresses()
+		// Containers only have machine addresses, so we can't ignore them.
+		tag := currentConfig.Tag()
+		if names.IsContainerMachine(tag.Id()) {
+			ignoreMachineAddresses = false
+		}
+		if ignoreMachineAddresses {
+			logger.Infof("machine addresses not used, only addresses from provider")
+		}
+		accessor := APIMachineAccessor{apiConn.Machiner()}
+		w, err := NewMachiner(Config{
+			MachineAccessor: accessor,
+			Tag:             tag.(names.MachineTag),
+			ClearMachineAddressesOnStart: ignoreMachineAddresses,
+			NotifyMachineDead: func() error {
+
+				return config.WriteUninstallFile()
+			},
+		})
+		if err != nil {
+			return nil, errors.Annotate(err, "cannot start machiner worker")
+		}
+		return w, err
+	}
+
+	return util.PostUpgradeManifold(config.PostUpgradeManifoldConfig, newWorker)
+}


### PR DESCRIPTION
Move the machiner worker from the machine agent runner to under the dependency engine.

(Review request: http://reviews.vapour.ws/r/3528/)