### PR TITLE
fix-1515289

### DIFF
--- a/apiserver/metricsender/sender.go
+++ b/apiserver/metricsender/sender.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 
 	"github.com/juju/errors"
+	"github.com/juju/utils"
 
 	"github.com/juju/juju/apiserver/metricsender/wireformat"
 )
@@ -32,7 +33,7 @@ func (s *HttpSender) Send(metrics []*wireformat.MetricBatch) (*wireformat.Respon
 		return nil, errors.Trace(err)
 	}
 	r := bytes.NewBuffer(b)
-	t := &http.Transport{TLSClientConfig: &tls.Config{RootCAs: metricsCertsPool}}
+	t := utils.NewHttpTLSTransport(&tls.Config{RootCAs: metricsCertsPool})
 	client := &http.Client{Transport: t}
 	resp, err := client.Post(metricsHost, "application/json", r)
 	if err != nil {

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -34,7 +34,7 @@ github.com/juju/schema	git	afe1151cb49d1d7ed3c75592dfc6f38703f2e988	2015-08-07T0
 github.com/juju/syslog	git	6be94e8b718766e9ff7a37342157fe4795da7cfa	2015-02-05T15:59:36Z
 github.com/juju/testing	git	3a4202497a8bff67966ecb327a0505fea8bb6ead	2015-11-23T15:50:06Z
 github.com/juju/txn	git	99ec629d0066a4d73c54d8e021a7fc1dc07df614	2015-06-09T16:58:27Z
-github.com/juju/utils	git	7a81685981edd1e510a64157df96026782cd4b04	2015-12-11T00:56:23Z
+github.com/juju/utils	git	a4bedbf2b50e967af653c6ed6b0994c8633899cf	2016-01-14T03:39:01Z
 github.com/juju/xml	git	eb759a627588d35166bc505fceb51b88500e291e	2015-04-13T13:11:21Z
 github.com/julienschmidt/httprouter	git	109e267447e95ad1bb48b758e40dd7453eb7b039	2015-09-05T17:25:33Z
 github.com/lxc/lxd	git	42b4c228e84cba622f221e04a1fa7164a416a440	2015-10-27T22:33:42Z


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/juju-core/+bug/1515289

use the new utils that has the tls proxy fix for downloading tools, and make sure the metricsender uses the same transport, to avoid the same bug of not using the proxy.

(Review request: http://reviews.vapour.ws/r/3530/)