### PR TITLE
Fixes bug 1533896 - some providers do not need update metadata worker.

### DIFF
--- a/apiserver/imagemetadata/metadata.go
+++ b/apiserver/imagemetadata/metadata.go
@@ -208,7 +208,10 @@ func (api *API) retrievePublished() error {
 
 	cons := envmetadata.NewImageConstraint(simplestreams.LookupParams{})
 	if inst, ok := env.(simplestreams.HasRegion); !ok {
-		return errors.Errorf("environment cloud specification cannot be determined")
+		// Published image metadata for some providers are in simple streams.
+		// Providers that do not rely on simplestreams, don't need to do anything here.
+		// LP bug #1533896.
+		return nil
 	} else {
 		// If we can determine current region,
 		// we want only metadata specific to this region.

--- a/apiserver/imagemetadata/metadata.go
+++ b/apiserver/imagemetadata/metadata.go
@@ -210,7 +210,6 @@ func (api *API) retrievePublished() error {
 	if inst, ok := env.(simplestreams.HasRegion); !ok {
 		// Published image metadata for some providers are in simple streams.
 		// Providers that do not rely on simplestreams, don't need to do anything here.
-		// LP bug #1533896.
 		return nil
 	} else {
 		// If we can determine current region,

--- a/apiserver/imagemetadata/updatefrompublished_test.go
+++ b/apiserver/imagemetadata/updatefrompublished_test.go
@@ -178,9 +178,8 @@ func (s *imageMetadataUpdateSuite) TestUpdateFromPublishedImagesForProviderWithN
 	}
 
 	err := s.api.UpdateFromPublishedImages()
-	c.Assert(err, gc.ErrorMatches, ".*environment cloud specification cannot be determined.*")
+	c.Assert(err, jc.ErrorIsNil)
 	s.assertCalls(c, []string{environConfig})
-
 	c.Assert(saved, jc.SameContents, []cloudimagemetadata.Metadata{})
 }
 

--- a/cmd/jujud/agent/imagemetadataworker_test.go
+++ b/cmd/jujud/agent/imagemetadataworker_test.go
@@ -4,8 +4,6 @@
 package agent
 
 import (
-	"time"
-
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -14,10 +12,11 @@ import (
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/simplestreams"
 	"github.com/juju/juju/state"
-	"github.com/juju/juju/testing"
 	"github.com/juju/juju/worker"
 )
 
+// MachineMockProviderSuite runs worker tests that depend
+// on provider that has cloud region support.
 type MachineMockProviderSuite struct {
 	commonMachineSuite
 }
@@ -47,12 +46,7 @@ func (s *MachineMockProviderSuite) TestMachineAgentRunsMetadataWorker(c *gc.C) {
 	go func() { c.Check(a.Run(nil), jc.ErrorIsNil) }()
 	defer func() { c.Check(a.Stop(), jc.ErrorIsNil) }()
 
-	// Wait for worker to be started.
-	select {
-	case <-started:
-	case <-time.After(testing.LongWait):
-		c.Fatalf("timeout while waiting for metadata update worker to start")
-	}
+	s.assertChannelActive(c, started, "metadata update worker to start")
 }
 
 // dummyEnviron is an environment with region support.

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -835,10 +835,9 @@ func (a *MachineAgent) postUpgradeAPIWorker(
 	if isEnvironManager {
 		// Published image metadata for some providers are in simple streams.
 		// Providers that do not depend on simple streams do not need this worker.
-		// LP bug #1533896.
 		env, err := newEnvirons(envConfig)
 		if err != nil {
-			return nil, errors.Annotatef(err, "getting environ")
+			return nil, errors.Annotate(err, "getting environ")
 		}
 		if _, ok := env.(simplestreams.HasRegion); ok {
 			// Start worker that stores published image metadata in state.

--- a/cmd/jujud/agent/machineworker_test.go
+++ b/cmd/jujud/agent/machineworker_test.go
@@ -1,0 +1,69 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package agent
+
+import (
+	"time"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/api/imagemetadata"
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/environs/simplestreams"
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/testing"
+	"github.com/juju/juju/worker"
+)
+
+type MachineMockProviderSuite struct {
+	commonMachineSuite
+}
+
+var _ = gc.Suite(&MachineMockProviderSuite{})
+
+func (s *MachineMockProviderSuite) SetUpTest(c *gc.C) {
+	// Change to environ that supports HasRegion
+	s.commonMachineSuite.SetUpTest(c)
+}
+
+func (s *MachineMockProviderSuite) TestMachineAgentRunsMetadataWorker(c *gc.C) {
+	// Patch out the worker func before starting the agent.
+	started := make(chan struct{})
+	newWorker := func(cl *imagemetadata.Client) worker.Worker {
+		close(started)
+		return worker.NewNoOpWorker()
+	}
+	s.PatchValue(&newMetadataUpdater, newWorker)
+	s.PatchValue(&newEnvirons, func(config *config.Config) (environs.Environ, error) {
+		return &dummyEnviron{}, nil
+	})
+
+	// Start the machine agent.
+	m, _, _ := s.primeAgent(c, state.JobManageEnviron)
+	a := s.newAgent(c, m)
+	go func() { c.Check(a.Run(nil), jc.ErrorIsNil) }()
+	defer func() { c.Check(a.Stop(), jc.ErrorIsNil) }()
+
+	// Wait for worker to be started.
+	select {
+	case <-started:
+	case <-time.After(testing.LongWait):
+		c.Fatalf("timeout while waiting for metadata update worker to start")
+	}
+}
+
+// dummyEnviron is an environment with region support.
+type dummyEnviron struct {
+	environs.Environ
+}
+
+// Region is specified in the HasRegion interface.
+func (e *dummyEnviron) Region() (simplestreams.CloudSpec, error) {
+	return simplestreams.CloudSpec{
+		Region:   "dummy_region",
+		Endpoint: "https://anywhere",
+	}, nil
+}


### PR DESCRIPTION
Published image metadata for some providers are in simple streams. 

This proposal changes fetching of published images as follows:
1.  providers that do not use simplestreams for image metadata, do not  start the worker that updates stored images from simplestreams;
2. if despite all precaution, an api call that allows to store published meatadata has been made, do not error... 


(Review request: http://reviews.vapour.ws/r/3535/)
(Bug lp#1533896)