### PR TITLE
Revert injecting PR #4093

### DIFF
--- a/cmd/plugins/juju-metadata/metadata.go
+++ b/cmd/plugins/juju-metadata/metadata.go
@@ -9,11 +9,8 @@ import (
 
 	"github.com/juju/cmd"
 	"github.com/juju/loggo"
-	"github.com/juju/utils/featureflag"
 
-	"github.com/juju/juju/feature"
 	"github.com/juju/juju/juju"
-	"github.com/juju/juju/juju/osenv"
 	_ "github.com/juju/juju/provider/all"
 )
 
@@ -49,16 +46,10 @@ func Main(args []string) {
 	metadatacmd.Register(newToolsMetadataCommand())
 	metadatacmd.Register(newValidateToolsMetadataCommand())
 	metadatacmd.Register(newSignMetadataCommand())
-	if featureflag.Enabled(feature.ImageMetadata) {
-		metadatacmd.Register(newListImagesCommand())
-		metadatacmd.Register(newAddImageMetadataCommand())
-	}
+	metadatacmd.Register(newListImagesCommand())
+	metadatacmd.Register(newAddImageMetadataCommand())
 
 	os.Exit(cmd.Main(metadatacmd, ctx, args[1:]))
-}
-
-func init() {
-	featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
 }
 
 func main() {

--- a/feature/flags.go
+++ b/feature/flags.go
@@ -39,3 +39,6 @@ const DisableRsyslog = "disable-rsyslog"
 
 // VSphereProvider enables the generic vmware provider.
 const VSphereProvider = "vsphere-provider"
+
+// ImageMetadata allows custom image metadata to be recorded in state.
+const ImageMetadata = "image-metadata"

--- a/feature/flags.go
+++ b/feature/flags.go
@@ -39,6 +39,3 @@ const DisableRsyslog = "disable-rsyslog"
 
 // VSphereProvider enables the generic vmware provider.
 const VSphereProvider = "vsphere-provider"
-
-// ImageMetadata allows custom image metadata to be recorded in state.
-const ImageMetadata = "image-metadata"


### PR DESCRIPTION
Reverted the addition of the feature flag setting in the plugin, but left the feature flag as a later commit depended on it.

(Review request: http://reviews.vapour.ws/r/3539/)