### PR TITLE
cloudconfig: small tweak to windows userdata

### DIFF
--- a/cloudconfig/powershell_helpers.go
+++ b/cloudconfig/powershell_helpers.go
@@ -844,7 +844,7 @@ if(!(Test-Path $path)){
 New-ItemProperty $path -Name "jujud" -Value 0 -PropertyType "DWord"
 
 $secpasswd = ConvertTo-SecureString $juju_passwd -AsPlainText -Force
-$jujuCreds = New-Object System.Management.Automation.PSCredential ($juju_user, $secpasswd)
+$jujuCreds = New-Object System.Management.Automation.PSCredential (".\jujud", $secpasswd)
 
 `
 

--- a/cloudconfig/windows_userdata_test.go
+++ b/cloudconfig/windows_userdata_test.go
@@ -837,7 +837,7 @@ if(!(Test-Path $path)){
 New-ItemProperty $path -Name "jujud" -Value 0 -PropertyType "DWord"
 
 $secpasswd = ConvertTo-SecureString $juju_passwd -AsPlainText -Force
-$jujuCreds = New-Object System.Management.Automation.PSCredential ($juju_user, $secpasswd)
+$jujuCreds = New-Object System.Management.Automation.PSCredential (".\jujud", $secpasswd)
 
 
 mkdir -Force "C:\Juju"


### PR DESCRIPTION
Turns out on some windows 10 deployments we've tested, using "hostname\jujud" for the credentials doesn't work, while ".\jujud" (. being localhost) does.

The change was also tested on all the other series.

(Review request: http://reviews.vapour.ws/r/3544/)