### PR TITLE
provider/azure: add win81, win10 image sources

### DIFF
--- a/provider/azure/internal/imageutils/images.go
+++ b/provider/azure/internal/imageutils/images.go
@@ -30,8 +30,11 @@ const (
 	ubuntuPublisher = "Canonical"
 	ubuntuOffering  = "UbuntuServer"
 
-	windowsPublisher = "MicrosoftWindowsServer"
-	windowsOffering  = "WindowsServer"
+	windowsServerPublisher = "MicrosoftWindowsServer"
+	windowsServerOffering  = "WindowsServer"
+
+	windowsPublisher = "MicrosoftVisualStudio"
+	windowsOffering  = "Windows"
 
 	dailyStream = "daily"
 )
@@ -62,12 +65,22 @@ func SeriesImage(
 		}
 
 	case os.Windows:
-		publisher = windowsPublisher
-		offering = windowsOffering
 		switch series {
+		case "win81":
+			publisher = windowsPublisher
+			offering = windowsOffering
+			sku = "8.1-Enterprise-N"
+		case "win10":
+			publisher = windowsPublisher
+			offering = windowsOffering
+			sku = "10-Enterprise"
 		case "win2012":
+			publisher = windowsServerPublisher
+			offering = windowsServerOffering
 			sku = "2012-Datacenter"
 		case "win2012r2":
+			publisher = windowsServerPublisher
+			offering = windowsServerOffering
 			sku = "2012-R2-Datacenter"
 		default:
 			return nil, errors.NotSupportedf("deploying %s", series)

--- a/provider/azure/internal/imageutils/images_test.go
+++ b/provider/azure/internal/imageutils/images_test.go
@@ -61,6 +61,8 @@ func (s *imageutilsSuite) TestSeriesImageInvalidSKU(c *gc.C) {
 func (s *imageutilsSuite) TestSeriesImageWindows(c *gc.C) {
 	s.assertImageId(c, "win2012r2", "daily", "MicrosoftWindowsServer:WindowsServer:2012-R2-Datacenter:latest")
 	s.assertImageId(c, "win2012", "daily", "MicrosoftWindowsServer:WindowsServer:2012-Datacenter:latest")
+	s.assertImageId(c, "win81", "daily", "MicrosoftVisualStudio:Windows:8.1-Enterprise-N:latest")
+	s.assertImageId(c, "win10", "daily", "MicrosoftVisualStudio:Windows:10-Enterprise:latest")
 }
 
 func (s *imageutilsSuite) TestSeriesImageCentOS(c *gc.C) {


### PR DESCRIPTION
This PR adds win81 and win10 series to azure. Ideally, we want to be able to use custom data, and we have a bug for that, but these are some sane defaults.

I tested them on azure. The reason we use 8.1-N and not 8.1 is that there have been no stock 8.1 images up since I started working on this. 

(Review request: http://reviews.vapour.ws/r/3545/)