### PR TITLE
lp1534353 Correct cmd to destroy a controller

### DIFF
--- a/cmd/juju/environment/destroy.go
+++ b/cmd/juju/environment/destroy.go
@@ -53,7 +53,7 @@ func (c *destroyCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "destroy-environment",
 		Args:    "<environment name>",
-		Purpose: "terminate all machines and other associated resources for a non-system environment",
+		Purpose: "terminate all machines and other associated resources for a non-controller environment",
 		Doc:     destroyDoc,
 		Aliases: []string{"destroy-model"},
 	}
@@ -98,10 +98,10 @@ func (c *destroyCommand) Run(ctx *cmd.Context) error {
 		return errors.Annotate(err, "cannot read environment info")
 	}
 
-	// Verify that we're not destroying a system
+	// Verify that we're not destroying a controller
 	apiEndpoint := cfgInfo.APIEndpoint()
 	if apiEndpoint.ServerUUID != "" && apiEndpoint.EnvironUUID == apiEndpoint.ServerUUID {
-		return errors.Errorf("%q is a system; use 'juju system destroy' to destroy it", c.envName)
+		return errors.Errorf("%q is a controller; use 'juju destroy-controller' to destroy it", c.envName)
 	}
 
 	if !c.assumeYes {

--- a/cmd/juju/environment/destroy_test.go
+++ b/cmd/juju/environment/destroy_test.go
@@ -127,7 +127,7 @@ func (s *DestroySuite) TestDestroyCannotConnectToAPI(c *gc.C) {
 
 func (s *DestroySuite) TestSystemDestroyFails(c *gc.C) {
 	_, err := s.runDestroyCommand(c, "test1", "-y")
-	c.Assert(err, gc.ErrorMatches, `"test1" is a system; use 'juju system destroy' to destroy it`)
+	c.Assert(err, gc.ErrorMatches, `"test1" is a controller; use 'juju destroy-controller' to destroy it`)
 	checkEnvironmentExistsInStore(c, "test1", s.store)
 }
 


### PR DESCRIPTION
juju destroy-environment should direct users to
use the destroy-controller command when they
attempt to destroy a controller using
destroy-environment.

(Review request: http://reviews.vapour.ws/r/3546/)