### PR TITLE
provider/maas: DNS entries do not demarcate stanzas

### DIFF
--- a/provider/maas/add-juju-bridge.py
+++ b/provider/maas/add-juju-bridge.py
@@ -79,7 +79,7 @@ class NetworkInterfaceParser(object):
 
     @classmethod
     def is_stanza(cls, s):
-        return re.match(r'^(iface|mapping|auto|allow-|source|dns-)', s)
+        return re.match(r'^(iface|mapping|auto|allow-|source)', s)
 
     def __init__(self, filename):
         self._filename = filename

--- a/provider/maas/bridgescript.go
+++ b/provider/maas/bridgescript.go
@@ -86,7 +86,7 @@ class NetworkInterfaceParser(object):
 
     @classmethod
     def is_stanza(cls, s):
-        return re.match(r'^(iface|mapping|auto|allow-|source|dns-)', s)
+        return re.match(r'^(iface|mapping|auto|allow-|source)', s)
 
     def __init__(self, filename):
         self._filename = filename


### PR DESCRIPTION
When parsing an interfaces file, entries beginning with 'dns-' do not
demarcate stanzas. DNS entries are now considered part of the iface
stanza that is being parsed.

For example, the following interfaces file:

    auto eth0
    iface eth0 inet dhcp

    dns-nameservers 10.10.19.2
    dns-search maas-19

we would previously bridge and render as:

    iface eth0 inet manual

    auto br-eth0
    iface br-eth0 inet dhcp
       bridge_ports eth0

    dns-nameservers 10.10.19.2
    dns-search maas-19

but is now parsed and rendered as:

    iface eth0 inet manual

    auto br-eth0
    iface br-eth0 inet dhcp
        dns-nameservers 10.10.19.2
        dns-search maas-19
        bridge_ports eth0

Fixes [LP:#1534795](https://bugs.launchpad.net/juju-core/+bug/1534795)

(Review request: http://reviews.vapour.ws/r/3550/)