### PR TITLE
dependencies.tsv: update to latest juju/gomaasapi

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -20,7 +20,7 @@ github.com/juju/errors	git	1b5e39b83d1835fa480e0c2ddefb040ee82d58b3	2015-09-16T1
 github.com/juju/gojsonpointer	git	afe8b77aa08f272b49e01b82de78510c11f61500	2015-02-04T19:46:29Z
 github.com/juju/gojsonreference	git	f0d24ac5ee330baa21721cdff56d45e4ee42628e	2015-02-04T19:46:33Z
 github.com/juju/gojsonschema	git	e1ad140384f254c82f89450d9a7c8dd38a632838	2015-03-12T17:00:16Z
-github.com/juju/gomaasapi	git	f342599c61c3303e707660701430297f229cdf6c	2015-12-05T00:14:25Z
+github.com/juju/gomaasapi	git	e173bc8d8d3304ff11b0ded5f6d4eea0cb560a40	2016-01-19T00:14:25Z
 github.com/juju/govmomi	git	4354a88d4b34abe467215f77c2fc1cb9f78b66f7	2015-04-24T01:54:48Z
 github.com/juju/httpprof	git	14bf14c307672fd2456bdbf35d19cf0ccd3cf565	2014-12-17T16:00:36Z
 github.com/juju/httprequest	git	1015665b66c26101695f2f51407b3b1e000176fd	2015-10-07T14:02:54Z


### PR DESCRIPTION
Fixes LP 1468972
Fixes LP 1497802

Update gomaasapi dependency to pick up fix for data race in mock server.

(Review request: http://reviews.vapour.ws/r/3567/)