### PR TITLE
Changed --bind syntax from relation@space to relation=space

### DIFF
--- a/cmd/juju/commands/deploy.go
+++ b/cmd/juju/commands/deploy.go
@@ -505,8 +505,8 @@ func (c *DeployCommand) deployCharm(
 }
 
 // parseBind parses the --bind option. Valid forms are:
-// * relation-name@space-name
-// * @space-name
+// * relation-name=space-name
+// * =space-name
 // * The above in a space separated list to specify multiple bindings,
 //   e.g. "rel1@space1 rel2@space2 @space3"
 func (c *DeployCommand) parseBind() error {
@@ -521,18 +521,18 @@ func (c *DeployCommand) parseBind() error {
 			continue
 		}
 
-		e := "--bind must be in the form '[<relation-name>]@<space> [[<relation2-name>]@<space2> ...]'. "
-		v := strings.Split(s, "@")
+		e := "--bind must be in the form '[<relation-name>]=<space> [[<relation2-name>]=<space2> ...]'. "
+		v := strings.Split(s, "=")
 		switch len(v) {
 		case 1:
-			return errors.New(e + "Could not find '@'.")
+			return errors.New(e + "Could not find '='.")
 		case 2:
 			if !names.IsValidSpace(v[1]) {
 				return errors.New(e + "Space name invalid.")
 			}
 			bindings[v[0]] = v[1]
 		default:
-			return errors.New(e + "Found multiple @ in binding. Did you forget to space-separate the binding list?")
+			return errors.New(e + "Found multiple = in binding. Did you forget to space-separate the binding list?")
 		}
 	}
 	c.Bindings = bindings

--- a/cmd/juju/commands/deploy.go
+++ b/cmd/juju/commands/deploy.go
@@ -508,9 +508,9 @@ const parseBindErrorPrefix = "--bind must be in the form '[<default-space>] [<re
 
 // parseBind parses the --bind option. Valid forms are:
 // * relation-name=space-name
-// * =space-name
+// * space-name
 // * The above in a space separated list to specify multiple bindings,
-//   e.g. "rel1@space1 rel2@space2 @space3"
+//   e.g. "rel1=space1 rel2=space2 space3"
 func (c *DeployCommand) parseBind() error {
 	bindings := make(map[string]string)
 	if c.BindToSpaces == "" {

--- a/cmd/juju/commands/deploy_test.go
+++ b/cmd/juju/commands/deploy_test.go
@@ -1025,7 +1025,7 @@ type ParseBindSuite struct {
 
 var _ = gc.Suite(&ParseBindSuite{})
 
-const bindErrPrefix = "--bind must be in the form '[<relation-name>]@<space> [[<relation2-name>]@<space2> ...]'. "
+const bindErrPrefix = "--bind must be in the form '[<relation-name>]=<space> [[<relation2-name>]=<space2> ...]'. "
 
 func (s *ParseBindSuite) TestBindParseEmpty(c *gc.C) {
 	deploy := &DeployCommand{BindToSpaces: ""}
@@ -1035,14 +1035,14 @@ func (s *ParseBindSuite) TestBindParseEmpty(c *gc.C) {
 }
 
 func (s *ParseBindSuite) TestBindParseOK(c *gc.C) {
-	deploy := &DeployCommand{BindToSpaces: "foo@a bar@b"}
+	deploy := &DeployCommand{BindToSpaces: "foo=a bar=b"}
 	err := deploy.parseBind()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(deploy.Bindings, jc.DeepEquals, map[string]string{"foo": "a", "bar": "b"})
 }
 
 func (s *ParseBindSuite) TestBindParseNoRelation(c *gc.C) {
-	deploy := &DeployCommand{BindToSpaces: "@default"}
+	deploy := &DeployCommand{BindToSpaces: "=default"}
 	err := deploy.parseBind()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(deploy.Bindings, jc.DeepEquals, map[string]string{"": "default"})
@@ -1051,26 +1051,26 @@ func (s *ParseBindSuite) TestBindParseNoRelation(c *gc.C) {
 func (s *ParseBindSuite) TestBindParseNoAt(c *gc.C) {
 	deploy := &DeployCommand{BindToSpaces: "foo"}
 	err := deploy.parseBind()
-	c.Assert(err.Error(), gc.Equals, bindErrPrefix+"Could not find '@'.")
+	c.Assert(err.Error(), gc.Equals, bindErrPrefix+"Could not find '='.")
 	c.Assert(deploy.Bindings, gc.IsNil)
 }
 
 func (s *ParseBindSuite) TestBindParseBadList(c *gc.C) {
-	deploy := &DeployCommand{BindToSpaces: "foo@bar@baz"}
+	deploy := &DeployCommand{BindToSpaces: "foo=bar=baz"}
 	err := deploy.parseBind()
-	c.Assert(err.Error(), gc.Equals, bindErrPrefix+"Found multiple @ in binding. Did you forget to space-separate the binding list?")
+	c.Assert(err.Error(), gc.Equals, bindErrPrefix+"Found multiple = in binding. Did you forget to space-separate the binding list?")
 	c.Assert(deploy.Bindings, gc.IsNil)
 }
 
 func (s *ParseBindSuite) TestBindParseDoc(c *gc.C) {
-	deploy := &DeployCommand{BindToSpaces: "rel1@space1 rel2@space2 @space3"}
+	deploy := &DeployCommand{BindToSpaces: "rel1=space1 rel2=space2 =space3"}
 	err := deploy.parseBind()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(deploy.Bindings, jc.DeepEquals, map[string]string{"rel1": "space1", "rel2": "space2", "": "space3"})
 }
 
 func (s *ParseBindSuite) TestBindParseBadSpace(c *gc.C) {
-	deploy := &DeployCommand{BindToSpaces: "rel1@spa#ce1"}
+	deploy := &DeployCommand{BindToSpaces: "rel1=spa#ce1"}
 	err := deploy.parseBind()
 	c.Assert(err.Error(), gc.Equals, bindErrPrefix+"Space name invalid.")
 	c.Assert(deploy.Bindings, gc.IsNil)

--- a/cmd/juju/commands/deploy_test.go
+++ b/cmd/juju/commands/deploy_test.go
@@ -1061,7 +1061,21 @@ func (s *ParseBindSuite) TestBindParseBadList(c *gc.C) {
 }
 
 func (s *ParseBindSuite) TestBindParseDefaultAndEndpoints(c *gc.C) {
-	deploy := &DeployCommand{BindToSpaces: "rel1=space1 rel2=space2 space3"}
+	deploy := &DeployCommand{BindToSpaces: "rel1=space1  rel2=space2 space3"}
+	err := deploy.parseBind()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(deploy.Bindings, jc.DeepEquals, map[string]string{"rel1": "space1", "rel2": "space2", "": "space3"})
+}
+
+func (s *ParseBindSuite) TestBindParseDefaultAndEndpoints2(c *gc.C) {
+	deploy := &DeployCommand{BindToSpaces: "rel1=space1  space3 rel2=space2"}
+	err := deploy.parseBind()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(deploy.Bindings, jc.DeepEquals, map[string]string{"rel1": "space1", "rel2": "space2", "": "space3"})
+}
+
+func (s *ParseBindSuite) TestBindParseDefaultAndEndpoints3(c *gc.C) {
+	deploy := &DeployCommand{BindToSpaces: "space3  rel1=space1 rel2=space2"}
 	err := deploy.parseBind()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(deploy.Bindings, jc.DeepEquals, map[string]string{"rel1": "space1", "rel2": "space2", "": "space3"})

--- a/cmd/juju/commands/deploy_test.go
+++ b/cmd/juju/commands/deploy_test.go
@@ -1025,8 +1025,6 @@ type ParseBindSuite struct {
 
 var _ = gc.Suite(&ParseBindSuite{})
 
-const bindErrPrefix = "--bind must be in the form '[<relation-name>]=<space> [[<relation2-name>]=<space2> ...]'. "
-
 func (s *ParseBindSuite) TestBindParseEmpty(c *gc.C) {
 	deploy := &DeployCommand{BindToSpaces: ""}
 	err := deploy.parseBind()
@@ -1041,29 +1039,29 @@ func (s *ParseBindSuite) TestBindParseOK(c *gc.C) {
 	c.Assert(deploy.Bindings, jc.DeepEquals, map[string]string{"foo": "a", "bar": "b"})
 }
 
-func (s *ParseBindSuite) TestBindParseNoRelation(c *gc.C) {
-	deploy := &DeployCommand{BindToSpaces: "=default"}
+func (s *ParseBindSuite) TestBindParseDefault(c *gc.C) {
+	deploy := &DeployCommand{BindToSpaces: "default"}
 	err := deploy.parseBind()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(deploy.Bindings, jc.DeepEquals, map[string]string{"": "default"})
 }
 
-func (s *ParseBindSuite) TestBindParseNoAt(c *gc.C) {
-	deploy := &DeployCommand{BindToSpaces: "foo"}
+func (s *ParseBindSuite) TestBindParseNoEndpoint(c *gc.C) {
+	deploy := &DeployCommand{BindToSpaces: "=bad"}
 	err := deploy.parseBind()
-	c.Assert(err.Error(), gc.Equals, bindErrPrefix+"Could not find '='.")
+	c.Assert(err.Error(), gc.Equals, parseBindErrorPrefix+"Found = without relation name. Use a lone space name to set the default.")
 	c.Assert(deploy.Bindings, gc.IsNil)
 }
 
 func (s *ParseBindSuite) TestBindParseBadList(c *gc.C) {
 	deploy := &DeployCommand{BindToSpaces: "foo=bar=baz"}
 	err := deploy.parseBind()
-	c.Assert(err.Error(), gc.Equals, bindErrPrefix+"Found multiple = in binding. Did you forget to space-separate the binding list?")
+	c.Assert(err.Error(), gc.Equals, parseBindErrorPrefix+"Found multiple = in binding. Did you forget to space-separate the binding list?")
 	c.Assert(deploy.Bindings, gc.IsNil)
 }
 
-func (s *ParseBindSuite) TestBindParseDoc(c *gc.C) {
-	deploy := &DeployCommand{BindToSpaces: "rel1=space1 rel2=space2 =space3"}
+func (s *ParseBindSuite) TestBindParseDefaultAndEndpoints(c *gc.C) {
+	deploy := &DeployCommand{BindToSpaces: "rel1=space1 rel2=space2 space3"}
 	err := deploy.parseBind()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(deploy.Bindings, jc.DeepEquals, map[string]string{"rel1": "space1", "rel2": "space2", "": "space3"})
@@ -1072,6 +1070,6 @@ func (s *ParseBindSuite) TestBindParseDoc(c *gc.C) {
 func (s *ParseBindSuite) TestBindParseBadSpace(c *gc.C) {
 	deploy := &DeployCommand{BindToSpaces: "rel1=spa#ce1"}
 	err := deploy.parseBind()
-	c.Assert(err.Error(), gc.Equals, bindErrPrefix+"Space name invalid.")
+	c.Assert(err.Error(), gc.Equals, parseBindErrorPrefix+"Space name invalid.")
 	c.Assert(deploy.Bindings, gc.IsNil)
 }


### PR DESCRIPTION
A simple replace of @ with = where needed.
deploy --bind "endpoint=space endpoint2=space2"

Changed the default space syntax so no symbol is needed:
deploy --bind defaultSpace

(Review request: http://reviews.vapour.ws/r/3569/)