### PR TITLE
Ensure VLANs get bridged

### DIFF
--- a/provider/maas/add-juju-bridge.py
+++ b/provider/maas/add-juju-bridge.py
@@ -201,7 +201,12 @@ class NetworkInterfaceParser(object):
 
 def IfaceStanza(name, family, method, options):
     # Convenience function to create a new "iface" stanza.
-    return Stanza("iface {} {} {}".format(name, family, method), options)
+    # Maintain original options order, but remove any duplicates.
+    unique_options = []
+    for o in options:
+        if o not in unique_options:
+            unique_options.append(o)
+    return Stanza("iface {} {} {}".format(name, family, method), unique_options)
 
 
 def AutoStanza(name):

--- a/provider/maas/add-juju-bridge.py
+++ b/provider/maas/add-juju-bridge.py
@@ -67,12 +67,7 @@ class LogicalInterface(object):
         self.is_bonded = [x for x in self.options if "bond-" in x]
         self.is_alias = ":" in self.name
         self.is_vlan = [x for x in self.options if x.startswith("vlan-raw-device")]
-
-    def is_active(self):
-        for o in self.options:
-            if o.startswith('bond-master '):
-                return False
-        return self.method == "dhcp" or self.method == "static"
+        self.is_active = self.method == "dhcp" or self.method == "static"
 
     def __str__(self):
         return self.name
@@ -80,7 +75,7 @@ class LogicalInterface(object):
     # Returns an ordered set of stanzas to bridge this interface.
     def bridge(self, prefix, add_auto_stanza):
         # Note: the testing order here is significant.
-        if not self.is_active():
+        if not self.is_active:
             return self._bridge_inactive(add_auto_stanza)
         elif self.is_alias:
             return self._bridge_alias(add_auto_stanza)

--- a/provider/maas/add-juju-bridge.py
+++ b/provider/maas/add-juju-bridge.py
@@ -201,12 +201,7 @@ class NetworkInterfaceParser(object):
 
 def IfaceStanza(name, family, method, options):
     # Convenience function to create a new "iface" stanza.
-    # Maintain original options order, but remove any duplicates.
-    unique_options = []
-    for o in options:
-        if o not in unique_options:
-            unique_options.append(o)
-    return Stanza("iface {} {} {}".format(name, family, method), unique_options)
+    return Stanza("iface {} {} {}".format(name, family, method), options)
 
 
 def AutoStanza(name):

--- a/provider/maas/add-juju-bridge.py
+++ b/provider/maas/add-juju-bridge.py
@@ -194,9 +194,6 @@ class NetworkInterfaceParser(object):
     def physical_interfaces(self):
         return {x.phy.name: x.phy for x in [y for y in self._stanzas if y.is_physical_interface]}
 
-    def logical_interfaces(self):
-        return {x.iface.name: x.iface for x in [y for y in self._stanzas if y.is_logical_interface]}
-
     def __iter__(self):  # class iter
         for s in self._stanzas:
             yield s

--- a/provider/maas/bridgescript.go
+++ b/provider/maas/bridgescript.go
@@ -206,9 +206,6 @@ class NetworkInterfaceParser(object):
     def physical_interfaces(self):
         return {x.phy.name: x.phy for x in [y for y in self._stanzas if y.is_physical_interface]}
 
-    def logical_interfaces(self):
-        return {x.iface.name: x.iface for x in [y for y in self._stanzas if y.is_logical_interface]}
-
     def __iter__(self):  # class iter
         for s in self._stanzas:
             yield s

--- a/provider/maas/bridgescript.go
+++ b/provider/maas/bridgescript.go
@@ -213,12 +213,7 @@ class NetworkInterfaceParser(object):
 
 def IfaceStanza(name, family, method, options):
     # Convenience function to create a new "iface" stanza.
-    # Maintain original options order, but remove any duplicates.
-    unique_options = []
-    for o in options:
-        if o not in unique_options:
-            unique_options.append(o)
-    return Stanza("iface {} {} {}".format(name, family, method), unique_options)
+    return Stanza("iface {} {} {}".format(name, family, method), options)
 
 
 def AutoStanza(name):

--- a/provider/maas/bridgescript.go
+++ b/provider/maas/bridgescript.go
@@ -213,7 +213,12 @@ class NetworkInterfaceParser(object):
 
 def IfaceStanza(name, family, method, options):
     # Convenience function to create a new "iface" stanza.
-    return Stanza("iface {} {} {}".format(name, family, method), options)
+    # Maintain original options order, but remove any duplicates.
+    unique_options = []
+    for o in options:
+        if o not in unique_options:
+            unique_options.append(o)
+    return Stanza("iface {} {} {}".format(name, family, method), unique_options)
 
 
 def AutoStanza(name):

--- a/provider/maas/bridgescript.go
+++ b/provider/maas/bridgescript.go
@@ -79,12 +79,7 @@ class LogicalInterface(object):
         self.is_bonded = [x for x in self.options if "bond-" in x]
         self.is_alias = ":" in self.name
         self.is_vlan = [x for x in self.options if x.startswith("vlan-raw-device")]
-
-    def is_active(self):
-        for o in self.options:
-            if o.startswith('bond-master '):
-                return False
-        return self.method == "dhcp" or self.method == "static"
+        self.is_active = self.method == "dhcp" or self.method == "static"
 
     def __str__(self):
         return self.name
@@ -92,7 +87,7 @@ class LogicalInterface(object):
     # Returns an ordered set of stanzas to bridge this interface.
     def bridge(self, prefix, add_auto_stanza):
         # Note: the testing order here is significant.
-        if not self.is_active():
+        if not self.is_active:
             return self._bridge_inactive(add_auto_stanza)
         elif self.is_alias:
             return self._bridge_alias(add_auto_stanza)

--- a/provider/maas/bridgescript.go
+++ b/provider/maas/bridgescript.go
@@ -79,20 +79,25 @@ class LogicalInterface(object):
         self.is_bonded = [x for x in self.options if "bond-" in x]
         self.is_alias = ":" in self.name
         self.is_vlan = [x for x in self.options if x.startswith("vlan-raw-device")]
-        self.is_active = self.method == "dhcp" or self.method == "static"
+
+    def is_active(self):
+        for o in self.options:
+            if o.startswith('bond-master '):
+                return False
+        return self.method == "dhcp" or self.method == "static"
 
     def __str__(self):
         return self.name
 
     # Returns an ordered set of stanzas to bridge this interface.
-    def bridge(self, prefix, add_auto_stanza, active_interfaces):
+    def bridge(self, prefix, add_auto_stanza):
         # Note: the testing order here is significant.
-        if not self.is_active:
+        if not self.is_active():
             return self._bridge_inactive(add_auto_stanza)
         elif self.is_alias:
             return self._bridge_alias(add_auto_stanza)
         elif self.is_vlan:
-            return self._bridge_vlan(prefix, add_auto_stanza, active_interfaces)
+            return self._bridge_vlan(prefix, add_auto_stanza)
         elif self.is_bonded:
             return self._bridge_bond(prefix, add_auto_stanza)
         else:
@@ -107,17 +112,8 @@ class LogicalInterface(object):
         s3 = IfaceStanza(bridge_name, self.family, self.method, options)
         return [s1, s2, s3]
 
-    def _bridge_vlan(self, prefix, add_auto_stanza, active_interfaces):
+    def _bridge_vlan(self, prefix, add_auto_stanza):
         stanzas = []
-        device = None
-        for o in self.options:
-            if o.startswith('vlan-raw-device'):
-                device = o.split()[1]
-                break
-        # Should vlans of inactive raw devices be bridged? If so
-        # remove the next two lines.
-        if device not in active_interfaces:
-            return self._bridge_inactive(add_auto_stanza)
         s1 = IfaceStanza(self.name, self.family, "manual", self.options)
         stanzas.append(s1)
         bridge_name = prefix + self.name
@@ -218,9 +214,6 @@ class NetworkInterfaceParser(object):
     def logical_interfaces(self):
         return {x.iface.name: x.iface for x in [y for y in self._stanzas if y.is_logical_interface]}
 
-    def active_interfaces(self):
-        return [x.name for x in self.logical_interfaces().values() if x.is_active]
-
     def __iter__(self):  # class iter
         for s in self._stanzas:
             yield s
@@ -290,12 +283,11 @@ def main(args):
     stanzas = []
     config_parser = NetworkInterfaceParser(args.filename)
     physical_interfaces = config_parser.physical_interfaces()
-    active_interfaces = config_parser.active_interfaces()
 
     for s in config_parser.stanzas():
         if s.is_logical_interface:
             add_auto_stanza = s.iface.name in physical_interfaces
-            bridged_stanzas = s.iface.bridge(args.bridge_prefix, add_auto_stanza, active_interfaces)
+            bridged_stanzas = s.iface.bridge(args.bridge_prefix, add_auto_stanza)
             stanzas.extend(bridged_stanzas)
         elif not s.is_physical_interface:
             stanzas.append(s)

--- a/provider/maas/bridgescript_test.go
+++ b/provider/maas/bridgescript_test.go
@@ -852,7 +852,6 @@ iface eth1.2670 inet manual
     vlan-raw-device eth1
     mtu 1500
     vlan_id 2670
-    dns-nameservers 10.245.168.2
     dns-search dellstack
 
 auto br-eth1.2670
@@ -860,7 +859,6 @@ iface br-eth1.2670 inet static
     dns-nameservers 10.245.168.2
     address 10.245.187.2/24
     mtu 1500
-    dns-nameservers 10.245.168.2
     dns-search dellstack
     bridge_ports eth1.2670`
 

--- a/provider/maas/bridgescript_test.go
+++ b/provider/maas/bridgescript_test.go
@@ -105,6 +105,10 @@ func (s *bridgeConfigSuite) TestBridgeScriptWithMultipleNameservers(c *gc.C) {
 	s.assertScript(c, networkVLANWithMultipleNameserversInitial, networkVLANWithMultipleNameserversExpected, "br-")
 }
 
+func (s *bridgeConfigSuite) TestBridgeScriptWithLoopbackOnly(c *gc.C) {
+	s.assertScript(c, networkLoopbackOnlyInitial, networkLoopbackOnlyExpected, "br-")
+}
+
 func (s *bridgeConfigSuite) runScript(c *gc.C, configFile string, bridgePrefix string) (output string, exitCode int) {
 	script := fmt.Sprintf("%q --bridge-prefix=%q %q\n",
 		s.testPythonScript,
@@ -696,14 +700,21 @@ iface vlan-br-eth0.2 inet static
     mtu 1500
     bridge_ports eth0.2
 
-auto eth1.3
-iface eth1.3 inet static
+iface eth1.3 inet manual
     address 192.168.3.3/24
     vlan-raw-device eth1
     mtu 1500
     vlan_id 3
     dns-nameservers 10.17.20.200
-    dns-search maas19`
+    dns-search maas19
+
+auto vlan-br-eth1.3
+iface vlan-br-eth1.3 inet static
+    address 192.168.3.3/24
+    mtu 1500
+    dns-nameservers 10.17.20.200
+    dns-search maas19
+    bridge_ports eth1.3`
 
 const networkVLANWithMultipleNameserversInitial = `auto eth0
 iface eth0 inet static
@@ -781,36 +792,68 @@ auto eth3
 iface eth3 inet manual
     mtu 1500
 
-auto eth1.2667
-iface eth1.2667 inet static
+iface eth1.2667 inet manual
     dns-nameservers 10.245.168.2
     address 10.245.184.2/24
     vlan-raw-device eth1
     mtu 1500
     vlan_id 2667
 
-auto eth1.2668
-iface eth1.2668 inet static
+auto br-eth1.2667
+iface br-eth1.2667 inet static
+    dns-nameservers 10.245.168.2
+    address 10.245.184.2/24
+    mtu 1500
+    bridge_ports eth1.2667
+
+iface eth1.2668 inet manual
     dns-nameservers 10.245.168.2
     address 10.245.185.1/24
     vlan-raw-device eth1
     mtu 1500
     vlan_id 2668
 
-auto eth1.2669
-iface eth1.2669 inet static
+auto br-eth1.2668
+iface br-eth1.2668 inet static
+    dns-nameservers 10.245.168.2
+    address 10.245.185.1/24
+    mtu 1500
+    bridge_ports eth1.2668
+
+iface eth1.2669 inet manual
     dns-nameservers 10.245.168.2
     address 10.245.186.1/24
     vlan-raw-device eth1
     mtu 1500
     vlan_id 2669
 
-auto eth1.2670
-iface eth1.2670 inet static
+auto br-eth1.2669
+iface br-eth1.2669 inet static
+    dns-nameservers 10.245.168.2
+    address 10.245.186.1/24
+    mtu 1500
+    bridge_ports eth1.2669
+
+iface eth1.2670 inet manual
     dns-nameservers 10.245.168.2
     address 10.245.187.2/24
     vlan-raw-device eth1
     mtu 1500
     vlan_id 2670
     dns-nameservers 10.245.168.2
-    dns-search dellstack`
+    dns-search dellstack
+
+auto br-eth1.2670
+iface br-eth1.2670 inet static
+    dns-nameservers 10.245.168.2
+    address 10.245.187.2/24
+    mtu 1500
+    dns-nameservers 10.245.168.2
+    dns-search dellstack
+    bridge_ports eth1.2670`
+
+const networkLoopbackOnlyInitial = `auto lo
+iface lo inet loopback`
+
+const networkLoopbackOnlyExpected = `auto lo
+iface lo inet loopback`

--- a/provider/maas/bridgescript_test.go
+++ b/provider/maas/bridgescript_test.go
@@ -852,6 +852,7 @@ iface eth1.2670 inet manual
     vlan-raw-device eth1
     mtu 1500
     vlan_id 2670
+    dns-nameservers 10.245.168.2
     dns-search dellstack
 
 auto br-eth1.2670
@@ -859,6 +860,7 @@ iface br-eth1.2670 inet static
     dns-nameservers 10.245.168.2
     address 10.245.187.2/24
     mtu 1500
+    dns-nameservers 10.245.168.2
     dns-search dellstack
     bridge_ports eth1.2670`
 


### PR DESCRIPTION
We were previously only creating a bridge for active interfaces where
'active' == 'dhcp' || 'static' but that approach omits VLANs where the
underlying raw device is not 'active'.

VLANs are now bridged irrespective of the 'active' state of the
underlying raw device.

(Review request: http://reviews.vapour.ws/r/3570/)