### PR TITLE
MADE: Logseynder Fix bug

### DIFF
--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -38,7 +38,6 @@ import (
 	"github.com/juju/juju/agent/tools"
 	"github.com/juju/juju/api"
 	apideployer "github.com/juju/juju/api/deployer"
-	apilogsender "github.com/juju/juju/api/logsender"
 	"github.com/juju/juju/api/metricsmanager"
 	"github.com/juju/juju/api/statushistory"
 	apistorageprovisioner "github.com/juju/juju/api/storageprovisioner"
@@ -700,10 +699,6 @@ func (a *MachineAgent) startAPIWorkers(apiConn api.Connection) (_ worker.Worker,
 			worker.Stop(runner)
 		}
 	}()
-
-	runner.StartWorker("logsender", func() (worker.Worker, error) {
-		return logsender.New(a.bufferedLogs, apilogsender.NewAPI(apiConn)), nil
-	})
 
 	envConfig, err := apiConn.Environment().EnvironConfig()
 	if err != nil {

--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -229,6 +229,7 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 		logSenderName: logsender.Manifold(logsender.ManifoldConfig{
 			LogSource: config.LogSource,
 			PostUpgradeManifoldConfig: util.PostUpgradeManifoldConfig{
+				AgentName:         agentName,
 				APICallerName:     apiCallerName,
 				UpgradeWaiterName: upgradeWaiterName,
 			},

--- a/cmd/jujud/agent/unit/manifolds.go
+++ b/cmd/jujud/agent/unit/manifolds.go
@@ -77,6 +77,7 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 		// these in a consolidated agent.
 		LogSenderName: logsender.Manifold(logsender.ManifoldConfig{
 			PostUpgradeManifoldConfig: util.PostUpgradeManifoldConfig{
+				AgentName:         AgentName,
 				APICallerName:     APICallerName,
 				UpgradeWaiterName: util.UpgradeWaitNotRequired,
 			},


### PR DESCRIPTION
The log sender worker was not converted to the dep engine correctly. Tests
were passing because the worker was still being started in the machine agent
runner.

(Review request: http://reviews.vapour.ws/r/3573/)