### PR TITLE
cloudconfig: don't limit tools download retries

### DIFF
--- a/cloudconfig/powershell_helpers.go
+++ b/cloudconfig/powershell_helpers.go
@@ -26,12 +26,11 @@ var winPowershellHelperFunctions = `
 
 $ErrorActionPreference = "Stop"
 
-function ExecRetry($command, $maxRetryCount = 5, $retryInterval = 15)
+function ExecRetry($command, $retryInterval = 15)
 {
 	$currErrorActionPreference = $ErrorActionPreference
 	$ErrorActionPreference = "Continue"
 
-	$retryCount = 0
 	while ($true)
 	{
 		try
@@ -41,17 +40,8 @@ function ExecRetry($command, $maxRetryCount = 5, $retryInterval = 15)
 		}
 		catch [System.Exception]
 		{
-			$retryCount++
-			if (($maxRetryCount -gt 0) -and ($retryCount -ge $maxRetryCount))
-			{
-				$ErrorActionPreference = $currErrorActionPreference
-				throw
-			}
-			else
-			{
-				Write-Error $_.Exception
-				Start-Sleep $retryInterval
-			}
+			Write-Error $_.Exception
+			Start-Sleep $retryInterval
 		}
 	}
 

--- a/cloudconfig/powershell_helpers.go
+++ b/cloudconfig/powershell_helpers.go
@@ -26,7 +26,7 @@ var winPowershellHelperFunctions = `
 
 $ErrorActionPreference = "Stop"
 
-function ExecRetry($command, $maxRetryCount = 10, $retryInterval=2)
+function ExecRetry($command, $maxRetryCount = 5, $retryInterval = 15)
 {
 	$currErrorActionPreference = $ErrorActionPreference
 	$ErrorActionPreference = "Continue"
@@ -42,7 +42,7 @@ function ExecRetry($command, $maxRetryCount = 10, $retryInterval=2)
 		catch [System.Exception]
 		{
 			$retryCount++
-			if ($retryCount -ge $maxRetryCount)
+			if (($maxRetryCount -gt 0) -and ($retryCount -ge $maxRetryCount))
 			{
 				$ErrorActionPreference = $currErrorActionPreference
 				throw

--- a/cloudconfig/userdatacfg_test.go
+++ b/cloudconfig/userdatacfg_test.go
@@ -1191,7 +1191,8 @@ func (*cloudinitSuite) TestToolsDownloadCommand(c *gc.C) {
 	command := cloudconfig.ToolsDownloadCommand("download", []string{"a", "b", "c"})
 
 	expected := `
-for n in $(seq 5); do
+n=1
+while true; do
 
     printf "Attempt $n to download tools from %s...\n" 'a'
     download 'a' && echo "Tools downloaded successfully." && break
@@ -1202,10 +1203,9 @@ for n in $(seq 5); do
     printf "Attempt $n to download tools from %s...\n" 'c'
     download 'c' && echo "Tools downloaded successfully." && break
 
-    if [ $n -lt 5 ]; then
-        echo "Download failed..... wait 15s"
-    fi
+    echo "Download failed, retrying in 15s"
     sleep 15
+    n=$((n+1))
 done`
 	c.Assert(command, gc.Equals, expected)
 }

--- a/cloudconfig/userdatacfg_unix.go
+++ b/cloudconfig/userdatacfg_unix.go
@@ -37,10 +37,6 @@ const (
 	// curlCommand is the base curl command used to download tools.
 	curlCommand = "curl -sSfw 'tools from %{url_effective} downloaded: HTTP %{http_code}; time %{time_total}s; size %{size_download} bytes; speed %{speed_download} bytes/s '"
 
-	// toolsDownloadAttempts is the number of attempts to make for
-	// each tools URL when downloading tools.
-	toolsDownloadAttempts = 5
-
 	// toolsDownloadWaitTime is the number of seconds to wait between
 	// each iterations of download attempts.
 	toolsDownloadWaitTime = 15
@@ -48,15 +44,15 @@ const (
 	// toolsDownloadTemplate is a bash template that generates a
 	// bash command to cycle through a list of URLs to download tools.
 	toolsDownloadTemplate = `{{$curl := .ToolsDownloadCommand}}
-for n in $(seq {{.ToolsDownloadAttempts}}); do
+n=1
+while true; do
 {{range .URLs}}
     printf "Attempt $n to download tools from %s...\n" {{shquote .}}
     {{$curl}} {{shquote .}} && echo "Tools downloaded successfully." && break
 {{end}}
-    if [ $n -lt {{.ToolsDownloadAttempts}} ]; then
-        echo "Download failed..... wait {{.ToolsDownloadWaitTime}}s"
-    fi
+    echo "Download failed, retrying in {{.ToolsDownloadWaitTime}}s"
     sleep {{.ToolsDownloadWaitTime}}
+    n=$((n+1))
 done`
 )
 
@@ -373,7 +369,6 @@ func toolsDownloadCommand(curlCommand string, urls []string) string {
 	var buf bytes.Buffer
 	err := parsedTemplate.Execute(&buf, map[string]interface{}{
 		"ToolsDownloadCommand":  curlCommand,
-		"ToolsDownloadAttempts": toolsDownloadAttempts,
 		"ToolsDownloadWaitTime": toolsDownloadWaitTime,
 		"URLs":                  urls,
 	})

--- a/cloudconfig/userdatacfg_win.go
+++ b/cloudconfig/userdatacfg_win.go
@@ -91,7 +91,7 @@ func (w *windowsConfigure) ConfigureJuju() error {
 		`mkdir $binDir`,
 		`$WebClient = New-Object System.Net.WebClient`,
 		`[System.Net.ServicePointManager]::ServerCertificateValidationCallback = {$true}`,
-		fmt.Sprintf(`ExecRetry { $WebClient.DownloadFile('%s', "$binDir\tools.tar.gz") } -1`, w.icfg.Tools.URL),
+		fmt.Sprintf(`ExecRetry { $WebClient.DownloadFile('%s', "$binDir\tools.tar.gz") }`, w.icfg.Tools.URL),
 		`$dToolsHash = Get-FileSHA256 -FilePath "$binDir\tools.tar.gz"`,
 		fmt.Sprintf(`$dToolsHash > "$binDir\juju%s.sha256"`,
 			w.icfg.Tools.Version),

--- a/cloudconfig/userdatacfg_win.go
+++ b/cloudconfig/userdatacfg_win.go
@@ -91,7 +91,7 @@ func (w *windowsConfigure) ConfigureJuju() error {
 		`mkdir $binDir`,
 		`$WebClient = New-Object System.Net.WebClient`,
 		`[System.Net.ServicePointManager]::ServerCertificateValidationCallback = {$true}`,
-		fmt.Sprintf(`ExecRetry { $WebClient.DownloadFile('%s', "$binDir\tools.tar.gz") }`, w.icfg.Tools.URL),
+		fmt.Sprintf(`ExecRetry { $WebClient.DownloadFile('%s', "$binDir\tools.tar.gz") } -1`, w.icfg.Tools.URL),
 		`$dToolsHash = Get-FileSHA256 -FilePath "$binDir\tools.tar.gz"`,
 		fmt.Sprintf(`$dToolsHash > "$binDir\juju%s.sha256"`,
 			w.icfg.Tools.Version),

--- a/cloudconfig/windows_userdata_test.go
+++ b/cloudconfig/windows_userdata_test.go
@@ -19,7 +19,7 @@ var WindowsUserdata = `#ps1_sysnative
 
 $ErrorActionPreference = "Stop"
 
-function ExecRetry($command, $maxRetryCount = 10, $retryInterval=2)
+function ExecRetry($command, $maxRetryCount = 5, $retryInterval = 15)
 {
 	$currErrorActionPreference = $ErrorActionPreference
 	$ErrorActionPreference = "Continue"
@@ -35,7 +35,7 @@ function ExecRetry($command, $maxRetryCount = 10, $retryInterval=2)
 		catch [System.Exception]
 		{
 			$retryCount++
-			if ($retryCount -ge $maxRetryCount)
+			if (($maxRetryCount -gt 0) -and ($retryCount -ge $maxRetryCount))
 			{
 				$ErrorActionPreference = $currErrorActionPreference
 				throw
@@ -861,7 +861,7 @@ mkdir 'C:\Juju\log\juju'
 mkdir $binDir
 $WebClient = New-Object System.Net.WebClient
 [System.Net.ServicePointManager]::ServerCertificateValidationCallback = {$true}
-ExecRetry { $WebClient.DownloadFile('http://foo.com/tools/released/juju1.2.3-win8-amd64.tgz', "$binDir\tools.tar.gz") }
+ExecRetry { $WebClient.DownloadFile('http://foo.com/tools/released/juju1.2.3-win8-amd64.tgz', "$binDir\tools.tar.gz") } -1
 $dToolsHash = Get-FileSHA256 -FilePath "$binDir\tools.tar.gz"
 $dToolsHash > "$binDir\juju1.2.3-win8-amd64.sha256"
 if ($dToolsHash.ToLower() -ne "1234"){ Throw "Tools checksum mismatch"}

--- a/cloudconfig/windows_userdata_test.go
+++ b/cloudconfig/windows_userdata_test.go
@@ -19,12 +19,11 @@ var WindowsUserdata = `#ps1_sysnative
 
 $ErrorActionPreference = "Stop"
 
-function ExecRetry($command, $maxRetryCount = 5, $retryInterval = 15)
+function ExecRetry($command, $retryInterval = 15)
 {
 	$currErrorActionPreference = $ErrorActionPreference
 	$ErrorActionPreference = "Continue"
 
-	$retryCount = 0
 	while ($true)
 	{
 		try
@@ -34,17 +33,8 @@ function ExecRetry($command, $maxRetryCount = 5, $retryInterval = 15)
 		}
 		catch [System.Exception]
 		{
-			$retryCount++
-			if (($maxRetryCount -gt 0) -and ($retryCount -ge $maxRetryCount))
-			{
-				$ErrorActionPreference = $currErrorActionPreference
-				throw
-			}
-			else
-			{
-				Write-Error $_.Exception
-				Start-Sleep $retryInterval
-			}
+			Write-Error $_.Exception
+			Start-Sleep $retryInterval
 		}
 	}
 
@@ -861,7 +851,7 @@ mkdir 'C:\Juju\log\juju'
 mkdir $binDir
 $WebClient = New-Object System.Net.WebClient
 [System.Net.ServicePointManager]::ServerCertificateValidationCallback = {$true}
-ExecRetry { $WebClient.DownloadFile('http://foo.com/tools/released/juju1.2.3-win8-amd64.tgz', "$binDir\tools.tar.gz") } -1
+ExecRetry { $WebClient.DownloadFile('http://foo.com/tools/released/juju1.2.3-win8-amd64.tgz', "$binDir\tools.tar.gz") }
 $dToolsHash = Get-FileSHA256 -FilePath "$binDir\tools.tar.gz"
 $dToolsHash > "$binDir\juju1.2.3-win8-amd64.sha256"
 if ($dToolsHash.ToLower() -ne "1234"){ Throw "Tools checksum mismatch"}


### PR DESCRIPTION
With the new Azure, instances will sometimes fail to download
tools/agent tarballs, and will thus never become active; the
machines just sit in the "idle" status forever. In Azure, it
has been observed that the amount of time that we allow is
not sufficient.

We currently limit the number of download attempts to 5, but
there's really no reason to limit the number of attempts at all.
For bootstrap, we will kill the process after a (configurable)
amount of time has elapsed. For non-bootstrap instance
creation, as mentioned above, the machine will currently just
sit idle if the 5 downloads all fail.

This change is to remove the retry limit for both Linux and
Windows, both of which have been tested live.

Fixes https://bugs.launchpad.net/juju-core/+bug/1533275

(Review request: http://reviews.vapour.ws/r/3575/)