### PR TITLE
Make bootstrap with auto version upgrade an option

### DIFF
--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -144,7 +144,7 @@ func (s *BootstrapSuite) TestBootstrapAPIReadyRetries(c *gc.C) {
 
 		s.mockBlockClient.num_retries = t.num_retries
 		s.mockBlockClient.retry_count = 0
-		_, err := coretesting.RunCommand(c, newBootstrapCommand(), "-e", "devenv")
+		_, err := coretesting.RunCommand(c, newBootstrapCommand(), "-e", "devenv", "--auto-upgrade")
 		if t.err == "" {
 			c.Check(err, jc.ErrorIsNil)
 		} else {
@@ -296,7 +296,7 @@ var bootstrapTests = []bootstrapTest{{
 }, {
 	info:    "bad environment",
 	version: "1.2.3-%LTS%-amd64",
-	args:    []string{"-e", "brokenenv"},
+	args:    []string{"-e", "brokenenv", "--auto-upgrade"},
 	err:     `failed to bootstrap environment: dummy.Bootstrap is broken`,
 }, {
 	info:        "constraints",
@@ -352,10 +352,6 @@ var bootstrapTests = []bootstrapTest{{
 	info: "--agent-version with --upload-tools",
 	args: []string{"--agent-version", "1.1.0", "--upload-tools"},
 	err:  `--agent-version and --upload-tools can't be used together`,
-}, {
-	info: "--agent-version with --no-auto-upgrade",
-	args: []string{"--agent-version", "1.1.0", "--no-auto-upgrade"},
-	err:  `--agent-version and --no-auto-upgrade can't be used together`,
 }, {
 	info: "invalid --agent-version value",
 	args: []string{"--agent-version", "foo"},
@@ -416,10 +412,10 @@ func (s *BootstrapSuite) TestBootstrapTwice(c *gc.C) {
 	const envName = "devenv"
 	s.patchVersionAndSeries(c, envName)
 
-	_, err := coretesting.RunCommand(c, newBootstrapCommand(), "-e", envName)
+	_, err := coretesting.RunCommand(c, newBootstrapCommand(), "-e", envName, "--auto-upgrade")
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = coretesting.RunCommand(c, newBootstrapCommand(), "-e", envName)
+	_, err = coretesting.RunCommand(c, newBootstrapCommand(), "-e", envName, "--auto-upgrade")
 	c.Assert(err, gc.ErrorMatches, "environment is already bootstrapped")
 }
 
@@ -428,7 +424,7 @@ func (s *BootstrapSuite) TestBootstrapSetsCurrentEnvironment(c *gc.C) {
 	s.patchVersionAndSeries(c, envName)
 
 	coretesting.WriteEnvironments(c, coretesting.MultipleEnvConfig)
-	ctx, err := coretesting.RunCommand(c, newBootstrapCommand(), "-e", "devenv")
+	ctx, err := coretesting.RunCommand(c, newBootstrapCommand(), "-e", "devenv", "--auto-upgrade")
 	c.Assert(coretesting.Stderr(ctx), jc.Contains, "-> devenv")
 	currentEnv, err := envcmd.ReadCurrentEnvironment()
 	c.Assert(err, jc.ErrorIsNil)
@@ -455,7 +451,7 @@ func (s *BootstrapSuite) TestBootstrapPropagatesEnvErrors(c *gc.C) {
 	s.patchVersionAndSeries(c, envName)
 	s.PatchValue(&environType, func(string) (string, error) { return "", nil })
 
-	_, err := coretesting.RunCommand(c, newBootstrapCommand(), "-e", envName)
+	_, err := coretesting.RunCommand(c, newBootstrapCommand(), "-e", envName, "--auto-upgrade")
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Change permissions on the jenv file to simulate some kind of
@@ -572,7 +568,7 @@ func (s *BootstrapSuite) TestBootstrapJenvWarning(c *gc.C) {
 	loggo.RegisterWriter(logger, &testWriter, loggo.WARNING)
 	defer loggo.RemoveWriter(logger)
 
-	_, errc := cmdtesting.RunCommand(ctx, newBootstrapCommand(), "-e", envName)
+	_, errc := cmdtesting.RunCommand(ctx, newBootstrapCommand(), "-e", envName, "--auto-upgrade")
 	c.Assert(<-errc, gc.IsNil)
 	c.Assert(testWriter.Log(), jc.LogMatches, []string{"ignoring environments.yaml: using bootstrap config in .*"})
 }
@@ -660,27 +656,18 @@ func (s *BootstrapSuite) TestBootstrapWithBinaryVersionNumber(c *gc.C) {
 	s.checkBootstrapWithVersion(c, "2.3.4-trusty-ppc64", "2.3.4")
 }
 
-func (s *BootstrapSuite) TestBootstrapWithNoAutoUpgrade(c *gc.C) {
+func (s *BootstrapSuite) TestBootstrapWithAutoUpgrade(c *gc.C) {
 	resetJujuHome(c, "devenv")
 
 	var bootstrap fakeBootstrapFuncs
 	s.PatchValue(&getBootstrapFuncs, func() BootstrapInterface {
 		return &bootstrap
 	})
-
-	num := version.Number{
-		Major: 2,
-		Minor: 22,
-		Patch: 46,
-	}
-	s.PatchValue(&version.Current, num)
-	s.PatchValue(&series.HostSeries, func() string { return "trusty" })
-	s.PatchValue(&arch.HostArch, func() string { return "amd64" })
 	coretesting.RunCommand(
 		c, newBootstrapCommand(),
-		"--no-auto-upgrade",
+		"--auto-upgrade",
 	)
-	c.Assert(*bootstrap.args.AgentVersion, gc.Equals, version.MustParse("2.22.46"))
+	c.Assert(bootstrap.args.AgentVersion, gc.IsNil)
 }
 
 func (s *BootstrapSuite) TestAutoSyncLocalSource(c *gc.C) {
@@ -720,7 +707,7 @@ func (s *BootstrapSuite) TestAutoUploadAfterFailedSync(c *gc.C) {
 	s.setupAutoUploadTest(c, "1.7.3", "quantal")
 	// Run command and check for that upload has been run for tools matching
 	// the current juju version.
-	opc, errc := cmdtesting.RunCommand(cmdtesting.NullContext(c), newBootstrapCommand(), "-e", "devenv")
+	opc, errc := cmdtesting.RunCommand(cmdtesting.NullContext(c), newBootstrapCommand(), "-e", "devenv", "--auto-upgrade")
 	c.Assert(<-errc, gc.IsNil)
 	c.Check((<-opc).(dummy.OpBootstrap).Env, gc.Equals, "devenv")
 	icfg := (<-opc).(dummy.OpFinalizeBootstrap).InstanceConfig
@@ -753,7 +740,7 @@ func (s *BootstrapSuite) TestMissingToolsUploadFailedError(c *gc.C) {
 	s.setupAutoUploadTest(c, "1.7.3", "precise")
 	s.PatchValue(&sync.BuildToolsTarball, buildToolsTarballAlwaysFails)
 
-	ctx, err := coretesting.RunCommand(c, newBootstrapCommand(), "-e", "devenv")
+	ctx, err := coretesting.RunCommand(c, newBootstrapCommand(), "-e", "devenv", "--auto-upgrade")
 
 	c.Check(coretesting.Stderr(ctx), gc.Equals, fmt.Sprintf(`
 Bootstrapping environment "devenv"
@@ -767,7 +754,7 @@ func (s *BootstrapSuite) TestBootstrapDestroy(c *gc.C) {
 	resetJujuHome(c, "devenv")
 	s.patchVersion(c)
 
-	opc, errc := cmdtesting.RunCommand(cmdtesting.NullContext(c), newBootstrapCommand(), "-e", "brokenenv")
+	opc, errc := cmdtesting.RunCommand(cmdtesting.NullContext(c), newBootstrapCommand(), "-e", "brokenenv", "--auto-upgrade")
 	err := <-errc
 	c.Assert(err, gc.ErrorMatches, "failed to bootstrap environment: dummy.Bootstrap is broken")
 	var opDestroy *dummy.OpDestroy
@@ -790,7 +777,7 @@ func (s *BootstrapSuite) TestBootstrapKeepBroken(c *gc.C) {
 	resetJujuHome(c, "devenv")
 	s.patchVersion(c)
 
-	opc, errc := cmdtesting.RunCommand(cmdtesting.NullContext(c), newBootstrapCommand(), "-e", "brokenenv", "--keep-broken")
+	opc, errc := cmdtesting.RunCommand(cmdtesting.NullContext(c), newBootstrapCommand(), "-e", "brokenenv", "--keep-broken", "--auto-upgrade")
 	err := <-errc
 	c.Assert(err, gc.ErrorMatches, "failed to bootstrap environment: dummy.Bootstrap is broken")
 	done := false


### PR DESCRIPTION
We flip the behaviour of the bootstrap auto upgrade semantic so that by default, we use an agent/tools  version matching the CLI rather than automatically selecting the most recent patch version.

(Review request: http://reviews.vapour.ws/r/3576/)