### PR TITLE
Tools metadata multi version

### DIFF
--- a/cmd/plugins/juju-metadata/toolsmetadata.go
+++ b/cmd/plugins/juju-metadata/toolsmetadata.go
@@ -18,7 +18,6 @@ import (
 	envtools "github.com/juju/juju/environs/tools"
 	"github.com/juju/juju/juju/osenv"
 	coretools "github.com/juju/juju/tools"
-	"github.com/juju/juju/version"
 )
 
 func newToolsMetadataCommand() cmd.Command {
@@ -116,8 +115,7 @@ func (c *toolsMetadataCommand) Run(context *cmd.Context) error {
 		toolsDir = envtools.LegacyReleaseDirectory
 	}
 	fmt.Fprintf(context.Stdout, "Finding tools in %s for stream %s.\n", c.metadataDir, c.stream)
-	const minorVersion = -1
-	toolsList, err := envtools.ReadList(sourceStorage, toolsDir, version.Current.Major, minorVersion)
+	toolsList, err := envtools.ReadList(sourceStorage, toolsDir, -1, -1)
 	if err == envtools.ErrNoTools {
 		var source string
 		source, err = envtools.ToolsURL(envtools.DefaultBaseURL)
@@ -126,8 +124,7 @@ func (c *toolsMetadataCommand) Run(context *cmd.Context) error {
 		}
 		sourceDataSource := simplestreams.NewURLDataSource("local source", source, utils.VerifySSLHostnames, simplestreams.CUSTOM_CLOUD_DATA, false)
 		toolsList, err = envtools.FindToolsForCloud(
-			[]simplestreams.DataSource{sourceDataSource}, simplestreams.CloudSpec{}, c.stream,
-			version.Current.Major, minorVersion, coretools.Filter{})
+			[]simplestreams.DataSource{sourceDataSource}, simplestreams.CloudSpec{}, c.stream, -1, -1, coretools.Filter{})
 	}
 	if err != nil {
 		return err

--- a/cmd/plugins/juju-metadata/toolsmetadata_test.go
+++ b/cmd/plugins/juju-metadata/toolsmetadata_test.go
@@ -66,7 +66,7 @@ var versionStrings = append([]string{
 	fmt.Sprintf("%d.12.0-precise-i386", version.Current.Major),
 	fmt.Sprintf("%d.12.0-raring-amd64", version.Current.Major),
 	fmt.Sprintf("%d.12.0-raring-i386", version.Current.Major),
-	fmt.Sprintf("%d.13.0-precise-amd64", version.Current.Major),
+	fmt.Sprintf("%d.13.0-precise-amd64", version.Current.Major+1),
 }, currentVersionStrings...)
 
 var expectedOutputCommon = makeExpectedOutputCommon()
@@ -262,7 +262,7 @@ func (s *ToolsMetadataSuite) TestGenerateWithPublicFallback(c *gc.C) {
 	code := cmd.Main(newToolsMetadataCommand(), ctx, []string{"-d", metadataDir, "--stream", "released"})
 	c.Assert(code, gc.Equals, 0)
 	metadata := toolstesting.ParseMetadataFromDir(c, metadataDir, "released", false)
-	c.Assert(metadata, gc.HasLen, len(versionStrings))
+	//c.Assert(metadata, gc.HasLen, len(versionStrings))
 	obtainedVersionStrings := make([]string, len(versionStrings))
 	for i, metadata := range metadata {
 		s := fmt.Sprintf("%s-%s-%s", metadata.Version, metadata.Release, metadata.Arch)

--- a/cmd/plugins/juju-metadata/toolsmetadata_test.go
+++ b/cmd/plugins/juju-metadata/toolsmetadata_test.go
@@ -262,7 +262,7 @@ func (s *ToolsMetadataSuite) TestGenerateWithPublicFallback(c *gc.C) {
 	code := cmd.Main(newToolsMetadataCommand(), ctx, []string{"-d", metadataDir, "--stream", "released"})
 	c.Assert(code, gc.Equals, 0)
 	metadata := toolstesting.ParseMetadataFromDir(c, metadataDir, "released", false)
-	//c.Assert(metadata, gc.HasLen, len(versionStrings))
+	c.Assert(metadata, gc.HasLen, len(versionStrings))
 	obtainedVersionStrings := make([]string, len(versionStrings))
 	for i, metadata := range metadata {
 		s := fmt.Sprintf("%s-%s-%s", metadata.Version, metadata.Release, metadata.Arch)

--- a/environs/tools/storage.go
+++ b/environs/tools/storage.go
@@ -34,6 +34,7 @@ func storagePrefix(stream string) string {
 
 // ReadList returns a List of the tools in store with the given major.minor version.
 // If minorVersion = -1, then only majorVersion is considered.
+// If majorVersion is -1, then all tools tarballs are used.
 // If store contains no such tools, it returns ErrNoMatches.
 func ReadList(stor storage.StorageReader, toolsDir string, majorVersion, minorVersion int) (coretools.List, error) {
 	if minorVersion >= 0 {
@@ -60,8 +61,8 @@ func ReadList(stor storage.StorageReader, toolsDir string, majorVersion, minorVe
 			continue
 		}
 		foundAnyTools = true
-		// Major version must match specified value.
-		if t.Version.Major != majorVersion {
+		// If specified major version value supplied, major version must match.
+		if majorVersion >= 0 && t.Version.Major != majorVersion {
 			continue
 		}
 		// If specified minor version value supplied, minor version must match.

--- a/environs/tools/storage_test.go
+++ b/environs/tools/storage_test.go
@@ -37,22 +37,22 @@ func (s *StorageSuite) TestReadListEmpty(c *gc.C) {
 func (s *StorageSuite) TestReadList(c *gc.C) {
 	stor, err := filestorage.NewFileStorageWriter(c.MkDir())
 	c.Assert(err, jc.ErrorIsNil)
-	v001 := version.MustParseBinary("0.0.1-precise-amd64")
 	v100 := version.MustParseBinary("1.0.0-precise-amd64")
 	v101 := version.MustParseBinary("1.0.1-precise-amd64")
 	v111 := version.MustParseBinary("1.1.1-precise-amd64")
-	agentTools := envtesting.AssertUploadFakeToolsVersions(c, stor, "proposed", "proposed", v001, v100, v101, v111)
-	t001 := agentTools[0]
-	t100 := agentTools[1]
-	t101 := agentTools[2]
-	t111 := agentTools[3]
+	v201 := version.MustParseBinary("2.0.1-precise-amd64")
+	agentTools := envtesting.AssertUploadFakeToolsVersions(c, stor, "proposed", "proposed", v100, v101, v111, v201)
+	t100 := agentTools[0]
+	t101 := agentTools[1]
+	t111 := agentTools[2]
+	t201 := agentTools[3]
 
 	for i, t := range []struct {
 		majorVersion,
 		minorVersion int
 		list coretools.List
 	}{{
-		0, 0, coretools.List{t001},
+		-1, -1, coretools.List{t100, t101, t111, t201},
 	}, {
 		1, 0, coretools.List{t100, t101},
 	}, {
@@ -62,7 +62,7 @@ func (s *StorageSuite) TestReadList(c *gc.C) {
 	}, {
 		1, 2, nil,
 	}, {
-		2, 0, nil,
+		3, 0, nil,
 	}} {
 		c.Logf("test %d", i)
 		list, err := envtools.ReadList(stor, "proposed", t.majorVersion, t.minorVersion)


### PR DESCRIPTION
Don't just generate metadata for tools tarballs where the major version matches; generate metadata for all tools found.

Fixes: https://bugs.launchpad.net/juju-core/+bug/1536426

(Review request: http://reviews.vapour.ws/r/3583/)