### PR TITLE
cloud: restructure cloud credentials types

### DIFF
--- a/cloud/clouds.go
+++ b/cloud/clouds.go
@@ -37,7 +37,7 @@ const (
 	OAuth2AuthType AuthType = "oauth2"
 
 	// EmptyAuthType is the authentication type used for providers
-	// that require no credentials, e.g. "local", "lxd", and "manual".
+	// that require no credentials, e.g. "lxd", and "manual".
 	EmptyAuthType AuthType = "empty"
 )
 

--- a/cloud/clouds.go
+++ b/cloud/clouds.go
@@ -25,16 +25,20 @@ type AuthType string
 
 const (
 	// AccessKeyAuthType is an authentication type using a key and secret.
-	AccessKeyAuthType = AuthType("access-key")
+	AccessKeyAuthType AuthType = "access-key"
 
 	// UserPassAuthType is an authentication type using a username and password.
-	UserPassAuthType = AuthType("userpass")
+	UserPassAuthType AuthType = "userpass"
 
-	// OAuthAuth1Type is an authentication type using oauth1.
-	OAuthAuth1Type = AuthType("oauth1")
+	// OAuth1AuthType is an authentication type using oauth1.
+	OAuth1AuthType AuthType = "oauth1"
 
-	// OAuthAuth2Type is an authentication type using oauth2.
-	OAuthAuth2Type = AuthType("oauth2")
+	// OAuth2AuthType is an authentication type using oauth2.
+	OAuth2AuthType AuthType = "oauth2"
+
+	// EmptyAuthType is the authentication type used for providers
+	// that require no credentials, e.g. "local", "lxd", and "manual".
+	EmptyAuthType AuthType = "empty"
 )
 
 // Clouds is a struct containing cloud definitions.

--- a/cloud/credentials.go
+++ b/cloud/credentials.go
@@ -78,7 +78,7 @@ type CredentialSchema map[string]CredentialAttr
 func ValidateCredential(credential Credential, schemas map[AuthType]CredentialSchema) error {
 	schema, ok := schemas[credential.authType]
 	if !ok {
-		return errors.NotSupportedf("%q auth-type", credential.authType)
+		return errors.NotSupportedf("auth-type %q", credential.authType)
 	}
 	return schema.Validate(credential.attributes)
 }

--- a/cloud/credentials.go
+++ b/cloud/credentials.go
@@ -3,6 +3,17 @@
 
 package cloud
 
+import (
+	"strings"
+
+	"github.com/juju/errors"
+	"github.com/juju/schema"
+	"gopkg.in/juju/environschema.v1"
+	"gopkg.in/yaml.v2"
+
+	"github.com/juju/juju/juju/osenv"
+)
+
 // Credentials is a struct containing cloud credential information.
 type Credentials struct {
 	// Credentials is a map of cloud credentials, keyed on cloud name.
@@ -22,188 +33,180 @@ type CloudCredential struct {
 }
 
 // Credential instances represent cloud credentials.
-type Credential interface {
-	// AuthType is the type of authorisation.
-	AuthType() AuthType
-
-	// Attributes are the credential values.
-	Attributes() map[string]string
+type Credential struct {
+	authType   AuthType
+	attributes map[string]string
 }
 
-type cloudCredentialYAML struct {
-	CloudCredential `yaml:",inline"`
-	AuthCredentials map[string]Credential `yaml:",omitempty,inline"`
+// AuthType returns the authentication type.
+func (c Credential) AuthType() AuthType {
+	return c.authType
 }
 
-var _ Credential = (*AccessKeyCredentials)(nil)
-
-// AccessKeyCredentials represent key/secret credentials.
-type AccessKeyCredentials struct {
-	// Key is the credential access key.
-	Key string `yaml:"key,omitempty"`
-
-	// Secret is the credential access secret.
-	Secret string `yaml:"secret,omitempty"`
+// Attributes returns the credential attributes.
+func (c Credential) Attributes() map[string]string {
+	return copyStringMap(c.attributes)
 }
 
-// AuthType is defined on Credentials interface.
-func (c *AccessKeyCredentials) AuthType() AuthType {
-	return AccessKeyAuthType
+// MarshalYAML implements the yaml.Marshaler interface.
+func (c Credential) MarshalYAML() (interface{}, error) {
+	return struct {
+		AuthType   AuthType          `yaml:"auth-type"`
+		Attributes map[string]string `yaml:",omitempty,inline"`
+	}{c.authType, c.attributes}, nil
 }
 
-// Attributes is defined on Credentials interface.
-func (c *AccessKeyCredentials) Attributes() map[string]string {
-	return map[string]string{
-		"key":    c.Key,
-		"secret": c.Secret,
+// NewCredential returns a new, immutable, Credential with the supplied
+// auth-type and attributes.
+func NewCredential(authType AuthType, attributes map[string]string) Credential {
+	return Credential{authType, copyStringMap(attributes)}
+}
+
+// NewEmptyCredential returns a new Credential with the EmptyAuthType
+// auth-type.
+func NewEmptyCredential() Credential {
+	return Credential{EmptyAuthType, nil}
+}
+
+// CredentialSchema describes the schema of a credential. Credential schemas
+// are specific to cloud providers.
+type CredentialSchema map[string]CredentialAttr
+
+// ValidateCredential validates a credential against the provided credential
+// schemas. If there is no schema with the matching auth-type, and error
+// satisfying errors.IsNotSupported will be returned.
+func ValidateCredential(credential Credential, schemas map[AuthType]CredentialSchema) error {
+	schema, ok := schemas[credential.authType]
+	if !ok {
+		return errors.NotSupportedf("%q auth-type", credential.authType)
 	}
+	return schema.Validate(credential.attributes)
 }
 
-var _ Credential = (*OpenstackAccessKeyCredentials)(nil)
-
-// OpenstackAccessKeyCredentials are key/secret credentials for Openstack clouds.
-type OpenstackAccessKeyCredentials struct {
-	AccessKeyCredentials `yaml:",inline"`
-
-	// Tenant is the openstack account tenant.
-	Tenant string `yaml:"tenant-name,omitempty"`
-}
-
-// AuthType is defined on Credentials interface.
-func (c *OpenstackAccessKeyCredentials) AuthType() AuthType {
-	return AccessKeyAuthType
-}
-
-// Attributes is defined on Credentials interface.
-func (c *OpenstackAccessKeyCredentials) Attributes() map[string]string {
-	return map[string]string{
-		"key":         c.Key,
-		"secret":      c.Secret,
-		"tenant-name": c.Tenant,
+// Validate validates the given credential attributes against the credential
+// schema.
+func (s CredentialSchema) Validate(attrs map[string]string) error {
+	m := make(map[string]interface{})
+	for k, v := range attrs {
+		m[k] = v
 	}
-}
-
-// UserPassCredentials are username/password credentials.
-type UserPassCredentials struct {
-	// User is the credential user name.
-	User string `yaml:"username,omitempty"`
-
-	// Password is the credential password.
-	Password string `yaml:"password,omitempty"`
-}
-
-var _ Credential = (*OpenstackUserPassCredentials)(nil)
-
-// OpenstackUserPassCredentials are user/password credentials for Openstack clouds.
-type OpenstackUserPassCredentials struct {
-	UserPassCredentials `yaml:",inline"`
-
-	// Tenant is the openstack account tenant.
-	Tenant string `yaml:"tenant-name,omitempty"`
-}
-
-// AuthType is defined on Credentials interface.
-func (c *OpenstackUserPassCredentials) AuthType() AuthType {
-	return UserPassAuthType
-}
-
-// Attributes is defined on Credentials interface.
-func (c *OpenstackUserPassCredentials) Attributes() map[string]string {
-	return map[string]string{
-		"username":    c.User,
-		"password":    c.Password,
-		"tenant-name": c.Tenant,
+	fields := make(environschema.Fields)
+	for name, field := range s {
+		fields[name] = environschema.Attr{
+			Description: field.Description,
+			Type:        environschema.Tstring,
+			Group:       environschema.AccountGroup,
+			Mandatory:   true,
+			Secret:      true,
+		}
 	}
-}
-
-var _ Credential = (*AzureUserPassCredentials)(nil)
-
-// AzureUserPassCredentials are user/password credentials for Azure clouds.
-type AzureUserPassCredentials struct {
-	// Subscription Id is the Azure account subscription id.
-	SubscriptionId string `yaml:"subscription-id,omitempty"`
-
-	// TenantId is the Azure Active Directory tenant id.
-	TenantId string `yaml:"tenant-id,omitempty"`
-
-	// Application Id is the Azure account application id.
-	ApplicationId string `yaml:"application-id,omitempty"`
-
-	// Tenant is the Azure account account password.
-	ApplicationPassword string `yaml:"application-password,omitempty"`
-}
-
-// AuthType is defined on Credentials interface.
-func (c *AzureUserPassCredentials) AuthType() AuthType {
-	return UserPassAuthType
-}
-
-// Attributes is defined on Credentials interface.
-func (c *AzureUserPassCredentials) Attributes() map[string]string {
-	return map[string]string{
-		"application-id":       c.ApplicationId,
-		"application-password": c.ApplicationPassword,
-		"subscription-id":      c.SubscriptionId,
-		"tenant-id":            c.TenantId,
+	schemaFields, schemaDefaults, err := fields.ValidationSchema()
+	if err != nil {
+		return errors.Trace(err)
 	}
-}
-
-var _ Credential = (*OAuth1Credentials)(nil)
-
-// OAuth1Credentials are oauth1 credentials.
-type OAuth1Credentials struct {
-	// ConsumerKey is the credential consumer key.
-	ConsumerKey string `yaml:"consumer-key,omitempty"`
-
-	// ConsumerSecret is the credential consumer secret.
-	ConsumerSecret string `yaml:"consumer-secret,omitempty"`
-
-	// AccessToken is the credential access token.
-	AccessToken string `yaml:"access-token,omitempty"`
-
-	// TokenSecret is the credential token secret.
-	TokenSecret string `yaml:"token-secret,omitempty"`
-}
-
-// AuthType is defined on Credentials interface.
-func (c *OAuth1Credentials) AuthType() AuthType {
-	return OAuthAuth1Type
-}
-
-// Attributes is defined on Credentials interface.
-func (c *OAuth1Credentials) Attributes() map[string]string {
-	return map[string]string{
-		"consumer-key":    c.ConsumerKey,
-		"consumer-secret": c.ConsumerSecret,
-		"access-token":    c.AccessToken,
-		"token-secret":    c.TokenSecret,
+	checker := schema.FieldMap(schemaFields, schemaDefaults)
+	if _, err := checker.Coerce(m, nil); err != nil {
+		return errors.Trace(err)
 	}
+	return nil
 }
 
-var _ Credential = (*OAuth2Credentials)(nil)
+// CredentialAttr describes the properties of a credential attribute.
+type CredentialAttr struct {
+	// Description is a human-readable description of the credential
+	// attribute.
+	Description string
 
-// OAuth2Credentials are oauth1 credentials.
-type OAuth2Credentials struct {
-	// Client Id is the credential client id.
-	ClientId string `yaml:"client-id,omitempty"`
-
-	// ClientEmail is the credential client email.
-	ClientEmail string `yaml:"client-email,omitempty"`
-
-	// PrivateKey is the credential private key.
-	PrivateKey string `yaml:"private-key,omitempty"`
+	// Secret controls whether or not the attribute value will be obscured
+	// when being entered interactively. Regardless of this, all credential
+	// attributes are provided only to the Juju controllers.
+	Secret bool
 }
 
-// AuthType is defined on Credentials interface.
-func (c *OAuth2Credentials) AuthType() AuthType {
-	return OAuthAuth2Type
-}
+type cloudCredentialChecker struct{}
 
-// Attributes is defined on Credentials interface.
-func (c *OAuth2Credentials) Attributes() map[string]string {
-	return map[string]string{
-		"client-id":    c.ClientId,
-		"client-email": c.ClientEmail,
-		"private-key":  c.PrivateKey,
+func (c cloudCredentialChecker) Coerce(v interface{}, path []string) (interface{}, error) {
+	out := CloudCredential{
+		AuthCredentials: make(map[string]Credential),
 	}
+	v, err := schema.StringMap(cloudCredentialValueChecker{}).Coerce(v, path)
+	if err != nil {
+		return nil, err
+	}
+	mapv := v.(map[string]interface{})
+	for k, v := range mapv {
+		switch k {
+		case "default-region":
+			out.DefaultRegion = v.(string)
+		case "default-credential":
+			out.DefaultCredential = v.(string)
+		default:
+			out.AuthCredentials[k] = v.(Credential)
+		}
+	}
+	return out, nil
+}
+
+type cloudCredentialValueChecker struct{}
+
+func (c cloudCredentialValueChecker) Coerce(v interface{}, path []string) (interface{}, error) {
+	field := path[len(path)-1]
+	switch field {
+	case "default-region", "default-credential":
+		return schema.String().Coerce(v, path)
+	}
+	v, err := schema.StringMap(schema.String()).Coerce(v, path)
+	if err != nil {
+		return nil, err
+	}
+	mapv := v.(map[string]interface{})
+
+	authType, _ := mapv["auth-type"].(string)
+	if authType == "" {
+		return nil, errors.Errorf("%v: missing auth-type", strings.Join(path, ""))
+	}
+
+	attrs := make(map[string]string)
+	delete(mapv, "auth-type")
+	for k, v := range mapv {
+		attrs[k] = v.(string)
+	}
+	return Credential{AuthType(authType), attrs}, nil
+}
+
+// JujuCredentials is the location where credentials are
+// expected to be found. Requires JUJU_HOME to be set.
+func JujuCredentials() string {
+	return osenv.JujuHomePath("credentials.yaml")
+}
+
+// ParseCredentials parses the given yaml bytes into Credentials, but does
+// not validate the credential attributes.
+func ParseCredentials(data []byte) (*Credentials, error) {
+	var credentialsYAML struct {
+		Credentials map[string]interface{} `yaml:"credentials"`
+	}
+	err := yaml.Unmarshal(data, &credentialsYAML)
+	if err != nil {
+		return nil, errors.Annotate(err, "cannot unmarshal yaml credentials")
+	}
+	credentials := Credentials{make(map[string]CloudCredential)}
+	for cloud, v := range credentialsYAML.Credentials {
+		v, err := cloudCredentialChecker{}.Coerce(
+			v, []string{"credentials." + cloud},
+		)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		credentials.Credentials[cloud] = v.(CloudCredential)
+	}
+	return &credentials, nil
+}
+
+func copyStringMap(in map[string]string) map[string]string {
+	out := make(map[string]string)
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
 }

--- a/cloud/credentials_test.go
+++ b/cloud/credentials_test.go
@@ -22,10 +22,10 @@ func (s *credentialsSuite) TestMarshallAccessKey(c *gc.C) {
 				DefaultCredential: "default-cred",
 				DefaultRegion:     "us-west-2",
 				AuthCredentials: map[string]cloud.Credential{
-					"peter": &cloud.AccessKeyCredentials{
-						Key:    "key",
-						Secret: "secret",
-					},
+					"peter": cloud.NewCredential(cloud.AccessKeyAuthType, map[string]string{
+						"access-key": "key",
+						"secret-key": "secret",
+					}),
 					// TODO(wallyworld) - add anther credential once goyaml.v2 supports inline MapSlice.
 					//"paul": &cloud.AccessKeyCredentials{
 					//	Key: "paulkey",
@@ -43,8 +43,9 @@ credentials:
     default-credential: default-cred
     default-region: us-west-2
     peter:
-      key: key
-      secret: secret
+      auth-type: access-key
+      access-key: key
+      secret-key: secret
 `[1:])
 }
 
@@ -55,13 +56,11 @@ func (s *credentialsSuite) TestMarshallOpenstackAccessKey(c *gc.C) {
 				DefaultCredential: "default-cred",
 				DefaultRegion:     "region-a",
 				AuthCredentials: map[string]cloud.Credential{
-					"peter": &cloud.OpenstackAccessKeyCredentials{
-						AccessKeyCredentials: cloud.AccessKeyCredentials{
-							Key:    "key",
-							Secret: "secret",
-						},
-						Tenant: "tenant",
-					},
+					"peter": cloud.NewCredential(cloud.AccessKeyAuthType, map[string]string{
+						"access-key":  "key",
+						"secret-key":  "secret",
+						"tenant-name": "tenant",
+					}),
 				},
 			},
 		},
@@ -74,8 +73,9 @@ credentials:
     default-credential: default-cred
     default-region: region-a
     peter:
-      key: key
-      secret: secret
+      auth-type: access-key
+      access-key: key
+      secret-key: secret
       tenant-name: tenant
 `[1:])
 }
@@ -87,13 +87,11 @@ func (s *credentialsSuite) TestMarshallOpenstackUserPass(c *gc.C) {
 				DefaultCredential: "default-cred",
 				DefaultRegion:     "region-a",
 				AuthCredentials: map[string]cloud.Credential{
-					"peter": &cloud.OpenstackUserPassCredentials{
-						UserPassCredentials: cloud.UserPassCredentials{
-							User:     "user",
-							Password: "secret",
-						},
-						Tenant: "tenant",
-					},
+					"peter": cloud.NewCredential(cloud.UserPassAuthType, map[string]string{
+						"username":    "user",
+						"password":    "secret",
+						"tenant-name": "tenant",
+					}),
 				},
 			},
 		},
@@ -106,9 +104,10 @@ credentials:
     default-credential: default-cred
     default-region: region-a
     peter:
-      username: user
+      auth-type: userpass
       password: secret
       tenant-name: tenant
+      username: user
 `[1:])
 }
 
@@ -119,12 +118,12 @@ func (s *credentialsSuite) TestMarshallAzureCredntials(c *gc.C) {
 				DefaultCredential: "default-cred",
 				DefaultRegion:     "Central US",
 				AuthCredentials: map[string]cloud.Credential{
-					"peter": &cloud.AzureUserPassCredentials{
-						ApplicationId:       "app-id",
-						ApplicationPassword: "app-secret",
-						SubscriptionId:      "subscription-id",
-						TenantId:            "tenant-id",
-					},
+					"peter": cloud.NewCredential(cloud.UserPassAuthType, map[string]string{
+						"application-id":       "app-id",
+						"application-password": "app-secret",
+						"subscription-id":      "subscription-id",
+						"tenant-id":            "tenant-id",
+					}),
 				},
 			},
 		},
@@ -137,10 +136,11 @@ credentials:
     default-credential: default-cred
     default-region: Central US
     peter:
-      subscription-id: subscription-id
-      tenant-id: tenant-id
+      auth-type: userpass
       application-id: app-id
       application-password: app-secret
+      subscription-id: subscription-id
+      tenant-id: tenant-id
 `[1:])
 }
 
@@ -151,12 +151,12 @@ func (s *credentialsSuite) TestMarshallOAuth1(c *gc.C) {
 				DefaultCredential: "default-cred",
 				DefaultRegion:     "region-default",
 				AuthCredentials: map[string]cloud.Credential{
-					"peter": &cloud.OAuth1Credentials{
-						ConsumerKey:    "consumer-key",
-						ConsumerSecret: "consumer-secret",
-						AccessToken:    "access-token",
-						TokenSecret:    "token-secret",
-					},
+					"peter": cloud.NewCredential(cloud.OAuth1AuthType, map[string]string{
+						"consumer-key":    "consumer-key",
+						"consumer-secret": "consumer-secret",
+						"access-token":    "access-token",
+						"token-secret":    "token-secret",
+					}),
 				},
 			},
 		},
@@ -169,9 +169,10 @@ credentials:
     default-credential: default-cred
     default-region: region-default
     peter:
+      auth-type: oauth1
+      access-token: access-token
       consumer-key: consumer-key
       consumer-secret: consumer-secret
-      access-token: access-token
       token-secret: token-secret
 `[1:])
 }
@@ -183,11 +184,11 @@ func (s *credentialsSuite) TestMarshallOAuth2(c *gc.C) {
 				DefaultCredential: "default-cred",
 				DefaultRegion:     "West US",
 				AuthCredentials: map[string]cloud.Credential{
-					"peter": &cloud.OAuth2Credentials{
-						ClientId:    "client-id",
-						ClientEmail: "client-email",
-						PrivateKey:  "secret",
-					},
+					"peter": cloud.NewCredential(cloud.OAuth2AuthType, map[string]string{
+						"client-id":    "client-id",
+						"client-email": "client-email",
+						"private-key":  "secret",
+					}),
 				},
 			},
 		},
@@ -200,8 +201,121 @@ credentials:
     default-credential: default-cred
     default-region: West US
     peter:
-      client-id: client-id
+      auth-type: oauth2
       client-email: client-email
+      client-id: client-id
       private-key: secret
 `[1:])
+}
+
+func (s *credentialsSuite) TestParseCredentials(c *gc.C) {
+	s.testParseCredentials(c, []byte(`
+credentials:
+  aws:
+    default-credential: peter
+    default-region: us-east-2
+    peter:
+      auth-type: access-key
+      access-key: key
+      secret-key: secret
+  aws-china:
+    default-credential: zhu8jie
+    zhu8jie:
+      auth-type: access-key
+      access-key: key
+      secret-key: secret
+    sun5kong:
+      auth-type: access-key
+      access-key: quay
+      secret-key: sekrit
+  aws-gov:
+    default-region: us-gov-west-1
+    supersekrit:
+      auth-type: access-key
+      access-key: super
+      secret-key: sekrit
+`[1:]), &cloud.Credentials{
+		Credentials: map[string]cloud.CloudCredential{
+			"aws": cloud.CloudCredential{
+				DefaultCredential: "peter",
+				DefaultRegion:     "us-east-2",
+				AuthCredentials: map[string]cloud.Credential{
+					"peter": cloud.NewCredential(cloud.AccessKeyAuthType, map[string]string{
+						"access-key": "key",
+						"secret-key": "secret",
+					}),
+				},
+			},
+			"aws-china": cloud.CloudCredential{
+				DefaultCredential: "zhu8jie",
+				AuthCredentials: map[string]cloud.Credential{
+					"zhu8jie": cloud.NewCredential(cloud.AccessKeyAuthType, map[string]string{
+						"access-key": "key",
+						"secret-key": "secret",
+					}),
+					"sun5kong": cloud.NewCredential(cloud.AccessKeyAuthType, map[string]string{
+						"access-key": "quay",
+						"secret-key": "sekrit",
+					}),
+				},
+			},
+			"aws-gov": cloud.CloudCredential{
+				DefaultRegion: "us-gov-west-1",
+				AuthCredentials: map[string]cloud.Credential{
+					"supersekrit": cloud.NewCredential(cloud.AccessKeyAuthType, map[string]string{
+						"access-key": "super",
+						"secret-key": "sekrit",
+					}),
+				},
+			},
+		},
+	})
+}
+
+func (s *credentialsSuite) TestParseCredentialsUnknownAuthType(c *gc.C) {
+	// Unknown auth-type is not validated by ParseCredentials.
+	// Validation is deferred to ValidateCredential.
+	s.testParseCredentials(c, []byte(`
+credentials:
+  cloud-name:
+    credential-name:
+      auth-type: woop
+`[1:]), &cloud.Credentials{
+		Credentials: map[string]cloud.CloudCredential{
+			"cloud-name": cloud.CloudCredential{
+				AuthCredentials: map[string]cloud.Credential{
+					"credential-name": cloud.NewCredential("woop", nil),
+				},
+			},
+		},
+	})
+}
+
+func (s *credentialsSuite) testParseCredentials(c *gc.C, input []byte, expect *cloud.Credentials) {
+	output, err := cloud.ParseCredentials(input)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(output, jc.DeepEquals, expect)
+}
+
+func (s *credentialsSuite) TestParseCredentialsMissingAuthType(c *gc.C) {
+	s.testParseCredentialsError(c, []byte(`
+credentials:
+  cloud-name:
+    credential-name:
+      doesnt: really-matter
+`[1:]), "credentials.cloud-name.credential-name: missing auth-type")
+}
+
+func (s *credentialsSuite) TestParseCredentialsNonStringValue(c *gc.C) {
+	s.testParseCredentialsError(c, []byte(`
+credentials:
+  cloud-name:
+    credential-name:
+      non-string-value: 123
+`[1:]), `credentials\.cloud-name\.credential-name\.non-string-value: expected string, got int\(123\)`)
+}
+
+func (s *credentialsSuite) testParseCredentialsError(c *gc.C, input []byte, expect string) {
+	_, err := cloud.ParseCredentials(input)
+	c.Assert(err, gc.ErrorMatches, expect)
 }

--- a/cloud/fallback-public-cloud.yaml
+++ b/cloud/fallback-public-cloud.yaml
@@ -1,7 +1,7 @@
 # DO NOT EDIT, will be overwritten, use “juju update-clouds” to refresh.
 clouds:
   aws:
-    type: aws
+    type: ec2
     auth-types: [ access-key ]
     regions:
       us-east-1:
@@ -23,13 +23,13 @@ clouds:
       sa-east-1:
         endpoint: https://sa-east-1.aws.amazon.com/v1.2/
   aws-china:
-    type: aws
+    type: ec2
     auth-types: [ access-key ]
     regions:
       cn-north-1:
         endpoint: https://ec2.cn-north-1.amazonaws.com.cn/
   aws-gov:
-    type: aws
+    type: ec2
     auth-types: [ access-key ]
     regions:
       us-gov-west-1:

--- a/cloud/fallback_public_cloud.go
+++ b/cloud/fallback_public_cloud.go
@@ -9,7 +9,7 @@ const fallbackPublicCloudInfo = `
 # DO NOT EDIT, will be overwritten, use “juju update-clouds” to refresh.
 clouds:
   aws:
-    type: aws
+    type: ec2
     auth-types: [ access-key ]
     regions:
       us-east-1:
@@ -31,13 +31,13 @@ clouds:
       sa-east-1:
         endpoint: https://sa-east-1.aws.amazon.com/v1.2/
   aws-china:
-    type: aws
+    type: ec2
     auth-types: [ access-key ]
     regions:
       cn-north-1:
         endpoint: https://ec2.cn-north-1.amazonaws.com.cn/
   aws-gov:
-    type: aws
+    type: ec2
     auth-types: [ access-key ]
     regions:
       us-gov-west-1:

--- a/cmd/juju/cloud/list_test.go
+++ b/cmd/juju/cloud/list_test.go
@@ -25,7 +25,7 @@ func (s *listSuite) TestList(c *gc.C) {
 	out := testing.Stdout(ctx)
 	out = strings.Replace(out, "\n", "", -1)
 	// Just check a snippet of the output to make sure it looks ok.
-	c.Assert(out, gc.Matches, `.*aws-china[ ]*aws[ ]*cn-north-1.*`)
+	c.Assert(out, gc.Matches, `.*aws-china[ ]*ec2[ ]*cn-north-1.*`)
 }
 
 func (s *listSuite) TestListYAML(c *gc.C) {
@@ -35,7 +35,7 @@ func (s *listSuite) TestListYAML(c *gc.C) {
 	out := testing.Stdout(ctx)
 	out = strings.Replace(out, "\n", "", -1)
 	// Just check a snippet of the output to make sure it looks ok.
-	c.Assert(out, gc.Matches, `.*aws:[ ]*type: aws[ ]*auth-types: \[access-key\].*`)
+	c.Assert(out, gc.Matches, `.*aws:[ ]*type: ec2[ ]*auth-types: \[access-key\].*`)
 }
 
 func (s *listSuite) TestListJSON(c *gc.C) {
@@ -45,5 +45,5 @@ func (s *listSuite) TestListJSON(c *gc.C) {
 	out := testing.Stdout(ctx)
 	out = strings.Replace(out, "\n", "", -1)
 	// Just check a snippet of the output to make sure it looks ok.
-	c.Assert(out, gc.Matches, `.*{"aws":{"Type":"aws","AuthTypes":\["access-key"\].*`)
+	c.Assert(out, gc.Matches, `.*{"aws":{"Type":"ec2","AuthTypes":\["access-key"\].*`)
 }

--- a/cmd/juju/cloud/listcredentials.go
+++ b/cmd/juju/cloud/listcredentials.go
@@ -1,0 +1,146 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cloud
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"sort"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+	"launchpad.net/gnuflag"
+
+	jujucloud "github.com/juju/juju/cloud"
+)
+
+type listCredentialsCommand struct {
+	cmd.CommandBase
+	out cmd.Output
+}
+
+var listCredentialsDoc = `
+The list-credentials command lists the credentials for clouds on which Juju workloads
+can be deployed. The credentials listed are those added with the add-credentials
+command.
+
+Example:
+   # List all credentials.
+   juju list-credentials
+
+   # List credentials for the aws cloud only.
+   juju list-credentials aws
+`
+
+// NewListCredentialsCommand returns a command to list cloud credentials.
+func NewListCredentialsCommand() cmd.Command {
+	return &listCredentialsCommand{}
+}
+
+func (c *listCredentialsCommand) Info() *cmd.Info {
+	return &cmd.Info{
+		Name:    "list-credentials",
+		Purpose: "list credentials available to bootstrap Juju",
+		Doc:     listCredentialsDoc,
+	}
+}
+
+func (c *listCredentialsCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.out.AddFlags(f, "tabular", map[string]cmd.Formatter{
+		"yaml":    cmd.FormatYaml,
+		"json":    cmd.FormatJson,
+		"tabular": formatCredentialsTabular,
+	})
+}
+
+func (c *listCredentialsCommand) Run(ctxt *cmd.Context) error {
+	var credentials *jujucloud.Credentials
+	data, err := ioutil.ReadFile(jujucloud.JujuCredentials())
+	if err == nil {
+		credentials, err = jujucloud.ParseCredentials(data)
+		if err != nil {
+			return err
+		}
+		// TODO(axw) validate credentials
+	} else if os.IsNotExist(err) {
+		credentials = &jujucloud.Credentials{}
+	} else {
+		return err
+	}
+	return c.out.Write(ctxt, credentials)
+}
+
+// formatCredentialsTabular returns a tabular summary of cloud information.
+func formatCredentialsTabular(value interface{}) ([]byte, error) {
+	credentials, ok := value.(*jujucloud.Credentials)
+	if !ok {
+		return nil, errors.Errorf("expected value of type %T, got %T", credentials, value)
+	}
+
+	// For tabular we'll sort alphabetically by cloud, and then by credential name.
+	var cloudNames []string
+	for name := range credentials.Credentials {
+		cloudNames = append(cloudNames, name)
+	}
+	sort.Strings(cloudNames)
+
+	var out bytes.Buffer
+	const (
+		// To format things into columns.
+		minwidth = 0
+		tabwidth = 1
+		padding  = 2
+		padchar  = ' '
+		flags    = 0
+	)
+	tw := tabwriter.NewWriter(&out, minwidth, tabwidth, padding, padchar, flags)
+	p := func(values ...string) {
+		text := strings.Join(values, "\t")
+		fmt.Fprintln(tw, text)
+	}
+	p("CLOUD\tNAME\tTYPE\tATTRS")
+	for _, cloudName := range cloudNames {
+		credentials := credentials.Credentials[cloudName]
+		var credentialNames []string
+		for name := range credentials.AuthCredentials {
+			credentialNames = append(credentialNames, name)
+		}
+		sort.Strings(credentialNames)
+
+		for _, credentialName := range credentialNames {
+			credential := credentials.AuthCredentials[credentialName]
+			if credentialName == credentials.DefaultCredential {
+				credentialName += "*"
+			}
+
+			attrs := credential.Attributes()
+			var attrNames []string
+			for attrName := range attrs {
+				attrNames = append(attrNames, attrName)
+			}
+			sort.Strings(attrNames)
+
+			var kv []string
+			for _, attrName := range attrNames {
+				kv = append(kv, attrName+" = "+attrs[attrName])
+			}
+
+			var kv0 string
+			if len(kv) > 0 {
+				kv0 = kv[0]
+			}
+			p(cloudName, credentialName, string(credential.AuthType()), kv0)
+			for _, kv := range kv[1:] {
+				p("", "", "", kv)
+			}
+		}
+	}
+	tw.Flush()
+
+	return out.Bytes(), nil
+}

--- a/cmd/juju/cloud/listcredentials_test.go
+++ b/cmd/juju/cloud/listcredentials_test.go
@@ -1,0 +1,153 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cloud_test
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/yaml.v2"
+
+	jujucloud "github.com/juju/juju/cloud"
+	"github.com/juju/juju/cmd/juju/cloud"
+	"github.com/juju/juju/juju/osenv"
+	"github.com/juju/juju/testing"
+)
+
+type listCredentialsSuite struct {
+	testing.BaseSuite
+
+	jujuHome string
+}
+
+var _ = gc.Suite(&listCredentialsSuite{})
+
+var sampleCredentials = &jujucloud.Credentials{
+	Credentials: map[string]jujucloud.CloudCredential{
+		"aws": {
+			DefaultRegion:     "ap-southeast-2",
+			DefaultCredential: "down",
+			AuthCredentials: map[string]jujucloud.Credential{
+				"bob": jujucloud.NewCredential(
+					jujucloud.AccessKeyAuthType,
+					map[string]string{
+						"access-key": "key",
+						"secret-key": "secret",
+					},
+				),
+				"down": jujucloud.NewCredential(
+					jujucloud.OAuth2AuthType,
+					map[string]string{
+						"client-id":    "id",
+						"client-email": "email",
+						"private-key":  "key",
+					},
+				),
+			},
+		},
+		"azure": {
+			AuthCredentials: map[string]jujucloud.Credential{
+				"azhja": jujucloud.NewCredential(
+					jujucloud.UserPassAuthType,
+					map[string]string{
+						"application-id":       "app-id",
+						"application-password": "app-secret",
+						"subscription-id":      "subscription-id",
+						"tenant-id":            "tenant-id",
+					},
+				),
+			},
+		},
+	},
+}
+
+func (s *listCredentialsSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+
+	s.jujuHome = c.MkDir()
+	oldJujuHome := osenv.SetJujuHome(s.jujuHome)
+	s.AddCleanup(func(c *gc.C) {
+		osenv.SetJujuHome(oldJujuHome)
+	})
+
+	// Write $JUJU_HOME/credentials.yaml.
+	data, err := yaml.Marshal(sampleCredentials)
+	c.Assert(err, jc.ErrorIsNil)
+	err = ioutil.WriteFile(filepath.Join(s.jujuHome, "credentials.yaml"), data, 0600)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *listCredentialsSuite) TestListCredentialsTabular(c *gc.C) {
+	out := s.listCredentials(c)
+	c.Assert(out, gc.Equals, `
+CLOUD  NAME   TYPE        ATTRS
+aws    bob    access-key  access-key = key
+                          secret-key = secret
+aws    down*  oauth2      client-email = email
+                          client-id = id
+                          private-key = key
+azure  azhja  userpass    application-id = app-id
+                          application-password = app-secret
+                          subscription-id = subscription-id
+                          tenant-id = tenant-id
+
+`[1:])
+}
+
+func (s *listCredentialsSuite) TestListCredentialsYAML(c *gc.C) {
+	out := s.listCredentials(c, "--format", "yaml")
+	c.Assert(out, gc.Equals, `
+credentials:
+  aws:
+    default-credential: down
+    default-region: ap-southeast-2
+    bob:
+      auth-type: access-key
+      access-key: key
+      secret-key: secret
+    down:
+      auth-type: oauth2
+      client-email: email
+      client-id: id
+      private-key: key
+  azure:
+    azhja:
+      auth-type: userpass
+      application-id: app-id
+      application-password: app-secret
+      subscription-id: subscription-id
+      tenant-id: tenant-id
+`[1:])
+}
+
+func (s *listCredentialsSuite) TestListCredentialsJSON(c *gc.C) {
+	// TODO(axw) test once json marshalling works properly
+	c.Skip("not implemented: credentials don't marshal to JSON yet")
+}
+
+func (s *listCredentialsSuite) TestListCredentialsFileMissing(c *gc.C) {
+	err := os.RemoveAll(s.jujuHome)
+	c.Assert(err, jc.ErrorIsNil)
+
+	out := s.listCredentials(c)
+	out = strings.Replace(out, "\n", "", -1)
+	c.Assert(out, gc.Equals, "CLOUD  NAME  TYPE  ATTRS")
+
+	out = s.listCredentials(c, "--format", "yaml")
+	out = strings.Replace(out, "\n", "", -1)
+	c.Assert(out, gc.Equals, "credentials: {}")
+
+	// TODO(axw) test json once json marshaling works properly
+}
+
+func (s *listCredentialsSuite) listCredentials(c *gc.C, args ...string) string {
+	ctx, err := testing.RunCommand(c, cloud.NewListCredentialsCommand(), args...)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(testing.Stderr(ctx), gc.Equals, "")
+	return testing.Stdout(ctx)
+}

--- a/cmd/juju/cloud/listcredentials_test.go
+++ b/cmd/juju/cloud/listcredentials_test.go
@@ -85,16 +85,18 @@ func (s *listCredentialsSuite) SetUpTest(c *gc.C) {
 func (s *listCredentialsSuite) TestListCredentialsTabular(c *gc.C) {
 	out := s.listCredentials(c)
 	c.Assert(out, gc.Equals, `
-CLOUD  NAME   TYPE        ATTRS
-aws    bob    access-key  access-key = key
-                          secret-key = secret
-aws    down*  oauth2      client-email = email
-                          client-id = id
-                          private-key = key
-azure  azhja  userpass    application-id = app-id
-                          application-password = app-secret
-                          subscription-id = subscription-id
-                          tenant-id = tenant-id
+CLOUD  CREDENTIALS
+aws    down*, bob
+azure  azhja
+
+`[1:])
+}
+
+func (s *listCredentialsSuite) TestListCredentialsTabularFiltered(c *gc.C) {
+	out := s.listCredentials(c, "aws")
+	c.Assert(out, gc.Equals, `
+CLOUD  CREDENTIALS
+aws    down*, bob
 
 `[1:])
 }
@@ -125,6 +127,20 @@ credentials:
 `[1:])
 }
 
+func (s *listCredentialsSuite) TestListCredentialsYAMLFiltered(c *gc.C) {
+	out := s.listCredentials(c, "--format", "yaml", "azure")
+	c.Assert(out, gc.Equals, `
+credentials:
+  azure:
+    azhja:
+      auth-type: userpass
+      application-id: app-id
+      application-password: app-secret
+      subscription-id: subscription-id
+      tenant-id: tenant-id
+`[1:])
+}
+
 func (s *listCredentialsSuite) TestListCredentialsJSON(c *gc.C) {
 	// TODO(axw) test once json marshalling works properly
 	c.Skip("not implemented: credentials don't marshal to JSON yet")
@@ -136,7 +152,7 @@ func (s *listCredentialsSuite) TestListCredentialsFileMissing(c *gc.C) {
 
 	out := s.listCredentials(c)
 	out = strings.Replace(out, "\n", "", -1)
-	c.Assert(out, gc.Equals, "CLOUD  NAME  TYPE  ATTRS")
+	c.Assert(out, gc.Equals, "CLOUD  CREDENTIALS")
 
 	out = s.listCredentials(c, "--format", "yaml")
 	out = strings.Replace(out, "\n", "", -1)

--- a/cmd/juju/cloud/show_test.go
+++ b/cmd/juju/cloud/show_test.go
@@ -29,7 +29,7 @@ func (s *showSuite) TestShow(c *gc.C) {
 	out := testing.Stdout(ctx)
 	c.Assert(out, gc.Equals, `
 defined: public
-type: aws
+type: ec2
 auth-type: [access-key]
 regions:
   cn-north-1:

--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -232,9 +232,10 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 		r.RegisterSuperAlias("create-env", "system", "create-env", nil)
 	}
 
-	// Manage clouds
+	// Manage clouds and credentials
 	r.Register(cloud.NewListCloudsCommand())
 	r.Register(cloud.NewShowCloudCommand())
+	r.Register(cloud.NewListCredentialsCommand())
 
 	// Commands registered elsewhere.
 	for _, newCommand := range registeredCommands {

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -230,6 +230,7 @@ var commandNames = []string{
 	"help-tool",
 	"init",
 	"list-clouds",
+	"list-credentials",
 	"machine",
 	"publish",
 	"remove-machine",  // alias for destroy-machine


### PR DESCRIPTION
It does not scale well to have concrete types
for each provider's auth-type, so Credential
has been made into a struct which contains
the raw attributes, and the auth-type constant.

Each provider will later be extended with
methods for returning the credential schemas
they support, and for automatically detecting
credentials from the environment.

An initial implementation of list-credentials
has been added to demonstrate the use of the
ParseCredentials function.

Parsing credentials no longer validates the
attributes. This enables us to lazily validate
only the credentials selected during bootstrap.

(Review request: http://reviews.vapour.ws/r/3587/)