### PR TITLE
Add support for EC2 region ap-northeast-2

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -35,7 +35,7 @@ golang.org/x/net	git	bb64f4dc73d4ab97978d5e1cb34515dcc570361b	2015-05-18T01:39:5
 golang.org/x/oauth2	git	11c60b6f71a6ad48ed6f93c65fa4c6f9b1b5b46a	2015-03-25T02:00:22Z
 google.golang.org/api	git	0d3983fb069cb6651353fc44c5cb604e263f2a93	2014-12-10T23:51:26Z
 google.golang.org/cloud	git	f20d6dcccb44ed49de45ae3703312cb46e627db1	2015-03-19T22:36:35Z
-gopkg.in/amz.v3	git	bff3a097c4108da57bb8cbe3aad2990d74d23676	2015-08-20T12:28:33Z
+gopkg.in/amz.v3	git	3aee5f74227ef76f5fb9328abaf097eb1da6b22d	2016-01-21T15:57:44Z
 gopkg.in/check.v1	git	b3d3430320d4260e5fea99841af984b3badcea63	2015-06-26T10:50:28Z
 gopkg.in/errgo.v1	git	15098963088579c1cd9eb1a7da285831e548390b	2015-07-07T18:34:45Z
 gopkg.in/goose.v1	git	e4a91e8b8323b8eef6fe41a66fd3ac6120520bb0	2015-11-13T22:25:24Z

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -35,7 +35,7 @@ golang.org/x/net	git	bb64f4dc73d4ab97978d5e1cb34515dcc570361b	2015-05-18T01:39:5
 golang.org/x/oauth2	git	11c60b6f71a6ad48ed6f93c65fa4c6f9b1b5b46a	2015-03-25T02:00:22Z
 google.golang.org/api	git	0d3983fb069cb6651353fc44c5cb604e263f2a93	2014-12-10T23:51:26Z
 google.golang.org/cloud	git	f20d6dcccb44ed49de45ae3703312cb46e627db1	2015-03-19T22:36:35Z
-gopkg.in/amz.v3	git	3aee5f74227ef76f5fb9328abaf097eb1da6b22d	2016-01-21T15:57:44Z
+gopkg.in/amz.v3	git	eeb872b6f9d1da6e1ab7bcffe3ffc33e20c3b213	2016-01-25T18:30:43Z
 gopkg.in/check.v1	git	b3d3430320d4260e5fea99841af984b3badcea63	2015-06-26T10:50:28Z
 gopkg.in/errgo.v1	git	15098963088579c1cd9eb1a7da285831e548390b	2015-07-07T18:34:45Z
 gopkg.in/goose.v1	git	e4a91e8b8323b8eef6fe41a66fd3ac6120520bb0	2015-11-13T22:25:24Z

--- a/provider/ec2/instancetype.go
+++ b/provider/ec2/instancetype.go
@@ -500,9 +500,7 @@ var allRegionCosts = regionCosts{
 		"i2.2xlarge": 2001,
 		"i2.4xlarge": 4002,
 		"i2.8xlarge": 8004,
-		// XXX: d2 types not included as instance constraints can't
-		// distinguish between fast disk and dense disk, so look
-		// identical to i2 types but cheaper and probably not wanted?
+		// TODO(gz): Add d2 types below per lp:1535838
 		//"d2.xlarge":  844,
 		//"d2.2xlarge": 1688,
 		//"d2.4xlarge": 3376,

--- a/provider/ec2/instancetype.go
+++ b/provider/ec2/instancetype.go
@@ -471,6 +471,43 @@ var allRegionCosts = regionCosts{
 		"c4.4xlarge": 1176,
 		"c4.8xlarge": 2352,
 	},
+	"ap-northeast-2": { // Seoul.
+		"t2.nano":   10,
+		"t2.micro":  20,
+		"t2.small":  40,
+		"t2.medium": 80,
+		"t2.large":  160,
+
+		"m4.large":    165,
+		"m4.xlarge":   331,
+		"m4.2xlarge":  660,
+		"m4.4xlarge":  1321,
+		"m4.10xlarge": 3303,
+
+		"c4.large":   120,
+		"c4.xlarge":  239,
+		"c4.2xlarge": 478,
+		"c4.4xlarge": 955,
+		"c4.8xlarge": 1910,
+
+		"r3.large":   200,
+		"r3.xlarge":  399,
+		"r3.2xlarge": 798,
+		"r3.4xlarge": 1596,
+		"r3.8xlarge": 3192,
+
+		"i2.xlarge":  1001,
+		"i2.2xlarge": 2001,
+		"i2.4xlarge": 4002,
+		"i2.8xlarge": 8004,
+		// XXX: d2 types not included as instance constraints can't
+		// distinguish between fast disk and dense disk, so look
+		// identical to i2 types but cheaper and probably not wanted?
+		//"d2.xlarge":  844,
+		//"d2.2xlarge": 1688,
+		//"d2.4xlarge": 3376,
+		//"d2.8xlarge": 6752,
+	},
 	"ap-southeast-1": { // Singapore.
 		"m1.small":  58,
 		"m1.medium": 117,
@@ -830,11 +867,18 @@ var allRegionCosts = regionCosts{
 		"t2.micro":  15,
 		"t2.small":  30,
 		"t2.medium": 60,
+		"t2.large":  120,
 
-		"m3.medium":  83,
-		"m3.large":   166,
-		"m3.xlarge":  332,
-		"m3.2xlarge": 665,
+		"m3.medium":  79,
+		"m3.large":   158,
+		"m3.xlarge":  315,
+		"m3.2xlarge": 632,
+
+		"m4.large":    143,
+		"m4.xlarge":   285,
+		"m4.2xlarge":  570,
+		"m4.4xlarge":  1140,
+		"m4.10xlarge": 2850,
 
 		"c3.large":   129,
 		"c3.xlarge":  258,
@@ -842,11 +886,17 @@ var allRegionCosts = regionCosts{
 		"c3.4xlarge": 1032,
 		"c3.8xlarge": 2064,
 
-		"r3.large":   210,
-		"r3.xlarge":  421,
-		"r3.2xlarge": 842,
-		"r3.4xlarge": 1684,
-		"r3.8xlarge": 3369,
+		"c4.large":   134,
+		"c4.xlarge":  267,
+		"c4.2xlarge": 534,
+		"c4.4xlarge": 1069,
+		"c4.8xlarge": 2138,
+
+		"r3.large":   200,
+		"r3.xlarge":  420,
+		"r3.2xlarge": 800,
+		"r3.4xlarge": 1600,
+		"r3.8xlarge": 3201,
 
 		"i2.xlarge":  1013,
 		"i2.2xlarge": 2026,


### PR DESCRIPTION
New AWS region in Korea. Updates to newer amz.v3 revision
for endpoints, and adds instance-type/pricing information
to the EC2 provider.

Drive-by update to eu-central-1 pricing and instance types.

(Review request: http://reviews.vapour.ws/r/3597/)