### PR TITLE
1494726 - Check for x-javascript type with centos

### DIFF
--- a/apiserver/charms.go
+++ b/apiserver/charms.go
@@ -164,6 +164,11 @@ func (h *charmsHandler) archiveEntrySender(filePath string) bundleContentSenderF
 			defer contents.Close()
 			ctype := mime.TypeByExtension(filepath.Ext(filePath))
 			if ctype != "" {
+				// Older mime.types may map .js to x-javascript.
+				// Map it to javascript for consistency.
+				if ctype == apihttp.CTypeXJS {
+					ctype = apihttp.CTypeJS
+				}
 				w.Header().Set("Content-Type", ctype)
 			}
 			w.Header().Set("Content-Length", strconv.FormatInt(fileInfo.Size(), 10))

--- a/apiserver/charms_test.go
+++ b/apiserver/charms_test.go
@@ -470,7 +470,8 @@ func (s *charmsSuite) TestGetUsesCache(c *gc.C) {
 	uri := s.charmsURI(c, "?url=local:trusty/django-42&file=utils.js")
 	resp, err := s.authRequest(c, "GET", uri, "", nil)
 	c.Assert(err, jc.ErrorIsNil)
-	s.assertGetFileResponse(c, resp, contents, "application/javascript")
+	// Bug 1494726 - Centos generates a content-type of "application/x-javascript"
+	s.assertGetFileResponse(c, resp, contents, `application/(x-javascript|javascript)`)
 }
 
 func (s *charmsSuite) charmsURL(c *gc.C, query string) *url.URL {
@@ -516,7 +517,7 @@ func assertResponse(c *gc.C, resp *http.Response, expCode int, expContentType st
 	defer resp.Body.Close()
 	c.Assert(err, jc.ErrorIsNil)
 	ctype := resp.Header.Get("Content-Type")
-	c.Assert(ctype, gc.Equals, expContentType)
+	c.Assert(ctype, gc.Matches, expContentType)
 	return body
 }
 

--- a/apiserver/charms_test.go
+++ b/apiserver/charms_test.go
@@ -470,8 +470,7 @@ func (s *charmsSuite) TestGetUsesCache(c *gc.C) {
 	uri := s.charmsURI(c, "?url=local:trusty/django-42&file=utils.js")
 	resp, err := s.authRequest(c, "GET", uri, "", nil)
 	c.Assert(err, jc.ErrorIsNil)
-	// Bug 1494726 - Centos generates a content-type of "application/x-javascript"
-	s.assertGetFileResponse(c, resp, contents, `application/(x-javascript|javascript)`)
+	s.assertGetFileResponse(c, resp, contents, apihttp.CTypeJS)
 }
 
 func (s *charmsSuite) charmsURL(c *gc.C, query string) *url.URL {
@@ -517,7 +516,7 @@ func assertResponse(c *gc.C, resp *http.Response, expCode int, expContentType st
 	defer resp.Body.Close()
 	c.Assert(err, jc.ErrorIsNil)
 	ctype := resp.Header.Get("Content-Type")
-	c.Assert(ctype, gc.Matches, expContentType)
+	c.Assert(ctype, gc.Equals, expContentType)
 	return body
 }
 

--- a/apiserver/http/http.go
+++ b/apiserver/http/http.go
@@ -15,6 +15,13 @@ const (
 
 	// CTypeJSON is the HTTP content-type value used for JSON content.
 	CTypeJSON = "application/json"
+
 	// CTypeRaw is the HTTP content-type value used for raw, unformattedcontent.
 	CTypeRaw = "application/octet-stream"
+
+	// CTypeJS is the HTTP content-type value used for javascript.
+	CTypeJS = "application/javascript"
+
+	// CTypeXJS is the outdated HTTP content-type value used for javascript.
+	CTypeXJS = "application/x-javascript"
 )


### PR DESCRIPTION
Centos will generate a content type of x-javascript,
so the check should be updated to accept either
application/javascript or application/x-javascript.

(Review request: http://reviews.vapour.ws/r/3599/)