### PR TITLE
state/lease: drive by cleanups

### DIFF
--- a/state/lease/config.go
+++ b/state/lease/config.go
@@ -46,8 +46,8 @@ type ClientConfig struct {
 	Clock clock.Clock
 }
 
-// Validate returns an error if the supplied config is not valid.
-func (config ClientConfig) Validate() error {
+// validate returns an error if the supplied config is not valid.
+func (config ClientConfig) validate() error {
 	if err := lease.ValidateString(config.Id); err != nil {
 		return errors.Annotatef(err, "invalid id")
 	}


### PR DESCRIPTION
state/lease: drive by cleanups

A few small gardening nits.

* ensureClockDoc: use switch rather than a sequence of if conditions.
* expireLeaseOp: wrap ErrInvalid with the cause of why it's invalid,
  rather than logging the error at trace level. The only called of
  expireLeaseOp is the public ExpireLease method which makes looser
  guarentees on the error value returned, so this is probably ok.
* client.Validate: unexport

(Review request: http://reviews.vapour.ws/r/3602/)