### PR TITLE
state/leadership: leadership.Manager wakes/checks at least every config.MaxSleep

### DIFF
--- a/state/leadership/config.go
+++ b/state/leadership/config.go
@@ -4,6 +4,8 @@
 package leadership
 
 import (
+	"time"
+
 	"github.com/juju/errors"
 	"github.com/juju/utils/clock"
 
@@ -13,18 +15,29 @@ import (
 // ManagerConfig contains the resources and information required to create a
 // Manager.
 type ManagerConfig struct {
+
+	// Client reads and writes lease data.
 	Client lease.Client
-	Clock  clock.Clock
+
+	// Clock supplies time services.
+	Clock clock.Clock
+
+	// MaxSleep is the longest time the Manager should sleep before
+	// refreshing its client's leases and checking for expiries.
+	MaxSleep time.Duration
 }
 
 // Validate returns an error if the configuration contains invalid information
 // or missing resources.
 func (config ManagerConfig) Validate() error {
 	if config.Client == nil {
-		return errors.New("missing client")
+		return errors.NotValidf("nil Client")
 	}
 	if config.Clock == nil {
-		return errors.New("missing clock")
+		return errors.NotValidf("nil Clock")
+	}
+	if config.MaxSleep <= 0 {
+		return errors.NotValidf("non-positive MaxSleep")
 	}
 	return nil
 }

--- a/state/leadership/fixture_test.go
+++ b/state/leadership/fixture_test.go
@@ -14,9 +14,13 @@ import (
 	"github.com/juju/juju/testing"
 )
 
+const (
+	defaultMaxSleep = time.Hour
+	almostOneSecond = time.Second - time.Nanosecond
+)
+
 var (
 	defaultClockStart time.Time
-	almostOneSecond   = time.Second - time.Nanosecond
 )
 
 func init() {
@@ -33,7 +37,7 @@ func init() {
 }
 
 // offset returns the result of defaultClockStart.Add(d); it exists to make
-// exppiry tests easier to write.
+// expiry tests easier to write.
 func offset(d time.Duration) time.Time {
 	return defaultClockStart.Add(d)
 }
@@ -69,12 +73,12 @@ type Fixture struct {
 // RunTest sets up a Manager and a Clock and passes them into the supplied
 // test function. The manager will be cleaned up afterwards.
 func (fix *Fixture) RunTest(c *gc.C, test func(leadership.ManagerWorker, *testing.Clock)) {
-	waitForAlarm := len(fix.leases) > 0
 	clock := testing.NewClock(defaultClockStart)
 	client := NewClient(fix.leases, fix.expectCalls)
 	manager, err := leadership.NewManager(leadership.ManagerConfig{
-		Clock:  clock,
-		Client: client,
+		Clock:    clock,
+		Client:   client,
+		MaxSleep: defaultMaxSleep,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	defer func() {
@@ -87,10 +91,7 @@ func (fix *Fixture) RunTest(c *gc.C, test func(leadership.ManagerWorker, *testin
 		}
 	}()
 	defer client.Wait(c)
-
-	if waitForAlarm {
-		waitAlarms(c, clock, 1)
-	}
+	waitAlarms(c, clock, 1)
 	test(manager, clock)
 }
 

--- a/state/leadership/manager.go
+++ b/state/leadership/manager.go
@@ -101,8 +101,8 @@ func (manager *manager) choose(blocks blocks) error {
 	select {
 	case <-manager.tomb.Dying():
 		return tomb.ErrDying
-	case <-manager.nextExpiry():
-		return manager.expire()
+	case <-manager.nextTick():
+		return manager.tick()
 	case claim := <-manager.claims:
 		return manager.handleClaim(claim)
 	case check := <-manager.checks:
@@ -198,35 +198,37 @@ func (manager *manager) BlockUntilLeadershipReleased(serviceName string) error {
 	}.invoke(manager.blocks)
 }
 
-// nextExpiry returns a channel that will send a value at some point when we
-// expect at least one lease to be ready to expire. If no leases are known,
-// it will return nil.
-func (manager *manager) nextExpiry() <-chan time.Time {
-	var nextExpiry time.Time
+// nextTick returns a channel that will send a value at some point when
+// we expect to have to do some work; either because at least one lease
+// may be ready to expire, or because enough enough time has passed that
+// it's worth checking for stalled collaborators.
+func (manager *manager) nextTick() <-chan time.Time {
+	now := manager.config.Clock.Now()
+	nextTick := now.Add(manager.config.MaxSleep)
 	for _, info := range manager.config.Client.Leases() {
-		if !nextExpiry.IsZero() {
-			if info.Expiry.After(nextExpiry) {
-				continue
-			}
+		if info.Expiry.After(nextTick) {
+			continue
 		}
-		nextExpiry = info.Expiry
+		nextTick = info.Expiry
 	}
-	if nextExpiry.IsZero() {
-		logger.Tracef("no leases recorded; never waking for expiry")
-		return nil
-	}
-	logger.Tracef("waking to expire leases at %s", nextExpiry)
-	return clock.Alarm(manager.config.Clock, nextExpiry)
+	logger.Debugf("waking to check leases at %s", nextTick)
+	return clock.Alarm(manager.config.Clock, nextTick)
 }
 
-// expire will attempt to expire all leases that may have expired. There might
-// be none; they might have been extended or expired already by someone else; so
-// ErrInvalid is expected, and ignored, in the comfortable knowledge that the
-// client will have been updated and we'll see fresh info when we scan for new
-// expiries next time through the loop. It will return only unrecoverable errors.
-func (manager *manager) expire() error {
-	logger.Tracef("expiring leases...")
+// tick snapshots recent leases and expires any that it can. There
+// might be none that need attention; or those that do might already
+// have been extended or expired by someone else; so ErrInvalid is
+// expected, and ignored, comfortable that the client will have been
+// updated in the background; and that we'll see fresh info when we
+// subsequently check nextWake().
+//
+// It will return only unrecoverable errors.
+func (manager *manager) tick() error {
+	logger.Tracef("refreshing leases...")
 	client := manager.config.Client
+	if err := client.Refresh(); err != nil {
+		return errors.Trace(err)
+	}
 	leases := client.Leases()
 
 	// Sort lease names so we expire in a predictable order for the tests.
@@ -235,8 +237,10 @@ func (manager *manager) expire() error {
 		names = append(names, name)
 	}
 	sort.Strings(names)
+
+	logger.Tracef("expiring leases...")
+	now := manager.config.Clock.Now()
 	for _, name := range names {
-		now := manager.config.Clock.Now()
 		if leases[name].Expiry.After(now) {
 			continue
 		}

--- a/state/leadership/manager_block_test.go
+++ b/state/leadership/manager_block_test.go
@@ -39,6 +39,8 @@ func (s *BlockUntilLeadershipReleasedSuite) TestLeadershipExpires(c *gc.C) {
 			},
 		},
 		expectCalls: []call{{
+			method: "Refresh",
+		}, {
 			method: "ExpireLease",
 			args:   []interface{}{"redis"},
 			callback: func(leases map[string]lease.Info) {
@@ -66,6 +68,8 @@ func (s *BlockUntilLeadershipReleasedSuite) TestLeadershipChanged(c *gc.C) {
 			},
 		},
 		expectCalls: []call{{
+			method: "Refresh",
+		}, {
 			method: "ExpireLease",
 			args:   []interface{}{"redis"},
 			err:    lease.ErrInvalid,
@@ -127,6 +131,8 @@ func (s *BlockUntilLeadershipReleasedSuite) TestMultiple(c *gc.C) {
 			},
 		},
 		expectCalls: []call{{
+			method: "Refresh",
+		}, {
 			method: "ExpireLease",
 			args:   []interface{}{"redis"},
 			err:    lease.ErrInvalid,

--- a/state/leadership/manager_expire_test.go
+++ b/state/leadership/manager_expire_test.go
@@ -28,6 +28,8 @@ func (s *ExpireLeadershipSuite) TestStartup_ExpiryInPast(c *gc.C) {
 			"redis": lease.Info{Expiry: offset(-time.Second)},
 		},
 		expectCalls: []call{{
+			method: "Refresh",
+		}, {
 			method: "ExpireLease",
 			args:   []interface{}{"redis"},
 			callback: func(leases map[string]lease.Info) {
@@ -55,6 +57,8 @@ func (s *ExpireLeadershipSuite) TestStartup_ExpiryInFuture_TimePasses(c *gc.C) {
 			"redis": lease.Info{Expiry: offset(time.Second)},
 		},
 		expectCalls: []call{{
+			method: "Refresh",
+		}, {
 			method: "ExpireLease",
 			args:   []interface{}{"redis"},
 			callback: func(leases map[string]lease.Info) {
@@ -67,12 +71,46 @@ func (s *ExpireLeadershipSuite) TestStartup_ExpiryInFuture_TimePasses(c *gc.C) {
 	})
 }
 
+func (s *ExpireLeadershipSuite) TestStartup_NoExpiry_NotLongEnough(c *gc.C) {
+	fix := &Fixture{}
+	fix.RunTest(c, func(_ leadership.ManagerWorker, clock *coretesting.Clock) {
+		clock.Advance(almostSeconds(3600))
+	})
+}
+
+func (s *ExpireLeadershipSuite) TestStartup_NoExpiry_LongEnough(c *gc.C) {
+	fix := &Fixture{
+		leases: map[string]lease.Info{
+			"goose": lease.Info{Expiry: offset(3 * time.Hour)},
+		},
+		expectCalls: []call{{
+			method: "Refresh",
+			callback: func(leases map[string]lease.Info) {
+				leases["redis"] = lease.Info{
+					Expiry: offset(time.Minute),
+				}
+			},
+		}, {
+			method: "ExpireLease",
+			args:   []interface{}{"redis"},
+			callback: func(leases map[string]lease.Info) {
+				delete(leases, "redis")
+			},
+		}},
+	}
+	fix.RunTest(c, func(_ leadership.ManagerWorker, clock *coretesting.Clock) {
+		clock.Advance(time.Hour)
+	})
+}
+
 func (s *ExpireLeadershipSuite) TestExpire_ErrInvalid_Expired(c *gc.C) {
 	fix := &Fixture{
 		leases: map[string]lease.Info{
 			"redis": lease.Info{Expiry: offset(time.Second)},
 		},
 		expectCalls: []call{{
+			method: "Refresh",
+		}, {
 			method: "ExpireLease",
 			args:   []interface{}{"redis"},
 			err:    lease.ErrInvalid,
@@ -92,6 +130,8 @@ func (s *ExpireLeadershipSuite) TestExpire_ErrInvalid_Updated(c *gc.C) {
 			"redis": lease.Info{Expiry: offset(time.Second)},
 		},
 		expectCalls: []call{{
+			method: "Refresh",
+		}, {
 			method: "ExpireLease",
 			args:   []interface{}{"redis"},
 			err:    lease.ErrInvalid,
@@ -111,6 +151,8 @@ func (s *ExpireLeadershipSuite) TestExpire_OtherError(c *gc.C) {
 			"redis": lease.Info{Expiry: offset(time.Second)},
 		},
 		expectCalls: []call{{
+			method: "Refresh",
+		}, {
 			method: "ExpireLease",
 			args:   []interface{}{"redis"},
 			err:    errors.New("snarfblat hobalob"),
@@ -158,6 +200,8 @@ func (s *ExpireLeadershipSuite) TestClaim_ExpiryInFuture_TimePasses(c *gc.C) {
 					Expiry: offset(63 * time.Second),
 				}
 			},
+		}, {
+			method: "Refresh",
 		}, {
 			method: "ExpireLease",
 			args:   []interface{}{"redis"},
@@ -223,6 +267,8 @@ func (s *ExpireLeadershipSuite) TestExtend_ExpiryInFuture_TimePasses(c *gc.C) {
 				}
 			},
 		}, {
+			method: "Refresh",
+		}, {
 			method: "ExpireLease",
 			args:   []interface{}{"redis"},
 			callback: func(leases map[string]lease.Info) {
@@ -269,6 +315,8 @@ func (s *ExpireLeadershipSuite) TestExpire_Multiple(c *gc.C) {
 			},
 		},
 		expectCalls: []call{{
+			method: "Refresh",
+		}, {
 			method: "ExpireLease",
 			args:   []interface{}{"redis"},
 			callback: func(leases map[string]lease.Info) {

--- a/state/state.go
+++ b/state/state.go
@@ -211,8 +211,9 @@ func (st *State) start(controllerTag names.EnvironTag) error {
 	}
 	logger.Infof("starting leadership manager")
 	leadershipManager, err := leadership.NewManager(leadership.ManagerConfig{
-		Client: leaseClient,
-		Clock:  clock,
+		Client:   leaseClient,
+		Clock:    clock,
+		MaxSleep: time.Minute,
 	})
 	if err != nil {
 		return errors.Annotatef(err, "cannot create leadership manager")


### PR DESCRIPTION
Fixes LP 1511659

From @fwereade 
> Eliminate sleep-forever case in leadership manager worker; config struct now expects a positive MaxSleep duration, which is (in effect) the longest time the manager will go without explicitly resyncing its cache.

Prior to this change, as soon as the leadership.Manager started it would check to see if any of the leases it managed were about to expire and if so it would go through the expiration cycle. However if there were no leases currently under management, then it would return nil, thus removing itself from the selectable set -- the manager would sleep until either a claim or check operation happened, or the tomb was killed.

Electing a new leader requires that the old leadership lease is expired; not just out of date. It's the act of expiration which triggers a new election. Hence expiring the lease is required to trigger a re-election which then triggers the claim or check operation -- if there is no expiration then the manager sleeps because nobody will issues claims or checks. 

To rectify this, the manager now wakes periodically and refreshes it's cache from the database, this causes the next pass of the loop to find leases to expire, which it then does, triggering re-election and unblocking the whole shebang.

/cc @fwereade 

TODO:
- [ ] Why does the lease manager need to call client.Refresh, the documentation on lease/client.Refresh says that it shouldn't be called.
- [ ] Following on from the previous question, calling client.Refresh sounds like a poor man's watcher, why isn't there a watcher for leadership ? Is it incompatible with the direct use of state/lease's transactions ? 
- [ ] Is the sequence of Expire/Check/Claim correct ?

(Review request: http://reviews.vapour.ws/r/3605/)