### PR TITLE
provider/maas: make dns options unique when rendering /e/n/i

### DIFF
--- a/provider/maas/add-juju-bridge.py
+++ b/provider/maas/add-juju-bridge.py
@@ -199,9 +199,52 @@ class NetworkInterfaceParser(object):
             yield s
 
 
+def uniq_append(dst, src):
+    for x in src:
+        if x not in dst:
+            dst.append(x)
+    return dst
+
+
 def IfaceStanza(name, family, method, options):
-    # Convenience function to create a new "iface" stanza.
-    return Stanza("iface {} {} {}".format(name, family, method), options)
+    """Convenience function to create a new "iface" stanza.
+
+Maintains original options order but removes duplicates with the
+exception of 'dns-*' options which are normlised as required by
+resolvconf(8) and all the dns-* options are moved to the end.
+
+    """
+
+    dns_search = []
+    dns_nameserver = []
+    dns_sortlist = []
+    unique_options = []
+
+    for o in options:
+        words = o.split()
+        ident = words[0]
+        if ident == "dns-nameservers":
+            dns_nameserver = uniq_append(dns_nameserver, words[1:])
+        elif ident == "dns-search":
+            dns_search = uniq_append(dns_search, words[1:])
+        elif ident == "dns-sortlist":
+            dns_sortlist = uniq_append(dns_sortlist, words[1:])
+        elif o not in unique_options:
+            unique_options.append(o)
+
+    if dns_nameserver:
+        option = "dns-nameservers " + " ".join(dns_nameserver)
+        unique_options.append(option)
+
+    if dns_search:
+        option = "dns-search " + " ".join(dns_search)
+        unique_options.append(option)
+
+    if dns_sortlist:
+        option = "dns-sortlist " + " ".join(dns_sortlist)
+        unique_options.append(option)
+
+    return Stanza("iface {} {} {}".format(name, family, method), unique_options)
 
 
 def AutoStanza(name):
@@ -303,7 +346,8 @@ def main(args):
 
 # This script re-renders an interfaces(5) file to add a bridge to all
 # active interfaces; active interfaces are those that are declared as
-# either 'static' or 'dhcp'.
+# either 'static' or 'dhcp'. It also considers whether the iface is a
+# VLAN or a bond.
 
 if __name__ == '__main__':
     main(arg_parser().parse_args())

--- a/provider/maas/bridgescript_test.go
+++ b/provider/maas/bridgescript_test.go
@@ -121,6 +121,14 @@ func (s *bridgeConfigSuite) TestBridgeScriptVLANWithActiveDHCPDevice(c *gc.C) {
 	s.assertScript(c, networkVLANWithActiveDHCPDeviceInitial, networkVLANWithActiveDHCPDeviceExpected, "br-")
 }
 
+func (s *bridgeConfigSuite) TestBridgeScriptMultipleDNSValues(c *gc.C) {
+	s.assertScript(c, networkWithMultipleDNSValuesInitial, networkWithMultipleDNSValuesExpected, "br-")
+}
+
+func (s *bridgeConfigSuite) TestBridgeScriptEmptyDNSValues(c *gc.C) {
+	s.assertScript(c, networkWithEmptyDNSValuesInitial, networkWithEmptyDNSValuesExpected, "br-")
+}
+
 func (s *bridgeConfigSuite) runScript(c *gc.C, configFile string, bridgePrefix string) (output string, exitCode int) {
 	script := fmt.Sprintf("%q --bridge-prefix=%q %q\n",
 		s.testPythonScript,
@@ -384,9 +392,9 @@ auto test-br-bond0
 iface test-br-bond0 inet dhcp
     mtu 1500
     hwaddress 52:54:00:1c:f1:5b
+    bridge_ports bond0
     dns-nameservers 10.17.20.200
-    dns-search maas19
-    bridge_ports bond0`
+    dns-search maas19`
 
 const networkMultipleAliasesInitial = `auto eth0
 iface eth0 inet dhcp
@@ -656,9 +664,9 @@ auto juju-br-bond1
 iface juju-br-bond1 inet dhcp
     mtu 1500
     hwaddress 52:54:00:8e:6e:b0
+    bridge_ports bond1
     dns-nameservers 10.17.20.200
-    dns-search maas19
-    bridge_ports bond1`
+    dns-search maas19`
 
 const networkVLANInitial = `auto eth0
 iface eth0 inet static
@@ -724,9 +732,9 @@ auto vlan-br-eth1.3
 iface vlan-br-eth1.3 inet static
     address 192.168.3.3/24
     mtu 1500
+    bridge_ports eth1.3
     dns-nameservers 10.17.20.200
-    dns-search maas19
-    bridge_ports eth1.3`
+    dns-search maas19`
 
 const networkVLANWithMultipleNameserversInitial = `auto eth0
 iface eth0 inet static
@@ -786,11 +794,11 @@ const networkVLANWithMultipleNameserversExpected = `iface eth0 inet manual
 
 auto br-eth0
 iface br-eth0 inet static
-    dns-nameservers 10.245.168.2
     gateway 10.245.168.1
     address 10.245.168.11/21
     mtu 1500
     bridge_ports eth0
+    dns-nameservers 10.245.168.2
 
 auto eth1
 iface eth1 inet manual
@@ -805,49 +813,48 @@ iface eth3 inet manual
     mtu 1500
 
 iface eth1.2667 inet manual
-    dns-nameservers 10.245.168.2
     address 10.245.184.2/24
     vlan-raw-device eth1
     mtu 1500
     vlan_id 2667
+    dns-nameservers 10.245.168.2
 
 auto br-eth1.2667
 iface br-eth1.2667 inet static
-    dns-nameservers 10.245.168.2
     address 10.245.184.2/24
     mtu 1500
     bridge_ports eth1.2667
+    dns-nameservers 10.245.168.2
 
 iface eth1.2668 inet manual
-    dns-nameservers 10.245.168.2
     address 10.245.185.1/24
     vlan-raw-device eth1
     mtu 1500
     vlan_id 2668
+    dns-nameservers 10.245.168.2
 
 auto br-eth1.2668
 iface br-eth1.2668 inet static
-    dns-nameservers 10.245.168.2
     address 10.245.185.1/24
     mtu 1500
     bridge_ports eth1.2668
+    dns-nameservers 10.245.168.2
 
 iface eth1.2669 inet manual
-    dns-nameservers 10.245.168.2
     address 10.245.186.1/24
     vlan-raw-device eth1
     mtu 1500
     vlan_id 2669
+    dns-nameservers 10.245.168.2
 
 auto br-eth1.2669
 iface br-eth1.2669 inet static
-    dns-nameservers 10.245.168.2
     address 10.245.186.1/24
     mtu 1500
     bridge_ports eth1.2669
+    dns-nameservers 10.245.168.2
 
 iface eth1.2670 inet manual
-    dns-nameservers 10.245.168.2
     address 10.245.187.2/24
     vlan-raw-device eth1
     mtu 1500
@@ -857,12 +864,11 @@ iface eth1.2670 inet manual
 
 auto br-eth1.2670
 iface br-eth1.2670 inet static
-    dns-nameservers 10.245.168.2
     address 10.245.187.2/24
     mtu 1500
+    bridge_ports eth1.2670
     dns-nameservers 10.245.168.2
-    dns-search dellstack
-    bridge_ports eth1.2670`
+    dns-search dellstack`
 
 const networkLoopbackOnlyInitial = `auto lo
 iface lo inet loopback`
@@ -940,7 +946,6 @@ auto bond0
 iface bond0 inet manual
     address 10.17.20.211/24
     gateway 10.17.20.1
-    dns-nameservers 10.17.20.200
     bond-slaves none
     bond-mode active-backup
     bond-xmit_hash_policy layer2
@@ -948,15 +953,16 @@ iface bond0 inet manual
     mtu 1500
     hwaddress 52:54:00:1c:f1:5b
     bond-lacp_rate slow
+    dns-nameservers 10.17.20.200
 
 auto br-bond0
 iface br-bond0 inet static
     address 10.17.20.211/24
     gateway 10.17.20.1
-    dns-nameservers 10.17.20.200
     mtu 1500
     hwaddress 52:54:00:1c:f1:5b
     bridge_ports bond0
+    dns-nameservers 10.17.20.200
 
 iface bond0.2 inet manual
     address 192.168.2.102/24
@@ -982,9 +988,9 @@ auto br-bond0.3
 iface br-bond0.3 inet static
     address 192.168.3.101/24
     mtu 1500
+    bridge_ports bond0.3
     dns-nameservers 10.17.20.200
-    dns-search maas19
-    bridge_ports bond0.3`
+    dns-search maas19`
 
 const networkVLANWithInactiveDeviceInitial = `auto eth0
 iface eth0 inet static
@@ -1011,11 +1017,11 @@ const networkVLANWithInactiveDeviceExpected = `iface eth0 inet manual
 
 auto br-eth0
 iface br-eth0 inet static
-    dns-nameservers 10.17.20.200
     gateway 10.17.20.1
     address 10.17.20.211/24
     mtu 1500
     bridge_ports eth0
+    dns-nameservers 10.17.20.200
 
 auto eth1
 iface eth1 inet manual
@@ -1031,10 +1037,9 @@ iface eth1.2 inet manual
 auto br-eth1.2
 iface br-eth1.2 inet dhcp
     mtu 1500
-    dns-nameservers 10.17.20.200
-    dns-search maas19
     bridge_ports eth1.2
-`
+    dns-nameservers 10.17.20.200
+    dns-search maas19`
 
 const networkVLANWithActiveDHCPDeviceInitial = `auto eth0
 iface eth0 inet static
@@ -1061,11 +1066,11 @@ const networkVLANWithActiveDHCPDeviceExpected = `iface eth0 inet manual
 
 auto br-eth0
 iface br-eth0 inet static
-    dns-nameservers 10.17.20.200
     gateway 10.17.20.1
     address 10.17.20.211/24
     mtu 1500
     bridge_ports eth0
+    dns-nameservers 10.17.20.200
 
 iface eth1 inet manual
 
@@ -1084,6 +1089,128 @@ iface eth1.2 inet manual
 auto br-eth1.2
 iface br-eth1.2 inet dhcp
     mtu 1500
+    bridge_ports eth1.2
     dns-nameservers 10.17.20.200
-    dns-search maas19
-    bridge_ports eth1.2`
+    dns-search maas19`
+
+const networkWithMultipleDNSValuesInitial = `auto eth0
+iface eth0 inet static
+    dns-nameservers 10.245.168.2
+    gateway 10.245.168.1
+    address 10.245.168.11/21
+    mtu 1500
+    dns-nameservers 192.168.1.1
+    dns-nameservers 10.245.168.2 192.168.1.1 10.245.168.2
+
+auto eth1
+iface eth1 inet static
+    gateway 10.245.168.1
+    address 10.245.168.12/21
+    mtu 1500
+    dns-sortlist 192.168.1.0/24 10.245.168.0/21 192.168.1.0/24
+    dns-sortlist 10.245.168.0/21 192.168.1.0/24
+
+auto eth2
+iface eth2 inet static
+    gateway 10.245.168.1
+    address 10.245.168.13/21
+    mtu 1500
+    dns-search juju ubuntu
+    dns-search dellstack ubuntu dellstack
+
+auto eth3
+iface eth3 inet static
+    gateway 10.245.168.1
+    address 10.245.168.14/21
+    mtu 1500
+    dns-nameservers 192.168.1.1
+    dns-nameservers 10.245.168.2 192.168.1.1 10.245.168.2
+    dns-sortlist 192.168.1.0/24 10.245.168.0/21 192.168.1.0/24
+    dns-sortlist 10.245.168.0/21 192.168.1.0/24
+    dns-search juju ubuntu
+    dns-search dellstack ubuntu dellstack
+
+dns-search ubuntu juju
+dns-search dellstack ubuntu dellstack`
+
+const networkWithMultipleDNSValuesExpected = `iface eth0 inet manual
+
+auto br-eth0
+iface br-eth0 inet static
+    gateway 10.245.168.1
+    address 10.245.168.11/21
+    mtu 1500
+    bridge_ports eth0
+    dns-nameservers 10.245.168.2 192.168.1.1
+
+iface eth1 inet manual
+
+auto br-eth1
+iface br-eth1 inet static
+    gateway 10.245.168.1
+    address 10.245.168.12/21
+    mtu 1500
+    bridge_ports eth1
+    dns-sortlist 192.168.1.0/24 10.245.168.0/21
+
+iface eth2 inet manual
+
+auto br-eth2
+iface br-eth2 inet static
+    gateway 10.245.168.1
+    address 10.245.168.13/21
+    mtu 1500
+    bridge_ports eth2
+    dns-search juju ubuntu dellstack
+
+iface eth3 inet manual
+
+auto br-eth3
+iface br-eth3 inet static
+    gateway 10.245.168.1
+    address 10.245.168.14/21
+    mtu 1500
+    bridge_ports eth3
+    dns-nameservers 192.168.1.1 10.245.168.2
+    dns-search juju ubuntu dellstack
+    dns-sortlist 192.168.1.0/24 10.245.168.0/21`
+
+const networkWithEmptyDNSValuesInitial = `auto eth0
+iface eth0 inet static
+    dns-nameservers
+    dns-search
+    dns-sortlist
+    gateway 10.245.168.1
+    address 10.245.168.11/21
+    mtu 1500
+
+auto eth1
+iface eth1 inet static
+    dns-nameservers
+    dns-search
+    dns-sortlist
+    gateway 10.245.168.1
+    address 10.245.168.12/21
+    mtu 1500
+
+dns-nameservers
+dns-search
+dns-sortlist`
+
+const networkWithEmptyDNSValuesExpected = `iface eth0 inet manual
+
+auto br-eth0
+iface br-eth0 inet static
+    gateway 10.245.168.1
+    address 10.245.168.11/21
+    mtu 1500
+    bridge_ports eth0
+
+iface eth1 inet manual
+
+auto br-eth1
+iface br-eth1 inet static
+    gateway 10.245.168.1
+    address 10.245.168.12/21
+    mtu 1500
+    bridge_ports eth1`


### PR DESCRIPTION
When the bridge script renders an original /etc/network/interfaces file
like:

    auto eth0
      iface eth0 inet static
      gateway 10.245.168.1
      address 10.245.168.11/21
      mtu 1500

    auto eth1
    iface eth1 inet static
      dns-nameservers 10.245.168.2
      gateway 10.245.168.1
      address 10.245.168.12/21
      mtu 1500

    dns-nameservers 192.168.1.1

into:

    iface eth0 inet manual

    auto br-eth0
    iface br-eth0 inet static
      gateway 10.245.168.1
      address 10.245.168.11/21
      mtu 1500
      bridge_ports eth0

    iface eth1 inet manual

    auto br-eth1
    iface br-eth1 inet static
      dns-nameservers 10.245.168.2
      gateway 10.245.168.1
      address 10.245.168.12/21
      mtu 1500
      dns-nameservers 192.168.1.1
      bridge_ports eth1

the script needs to ensure that the dns-* options are de-duplicated and
become a single line. This knowledge gained from our understanding and
resolution to:

    https://bugs.launchpad.net/juju-core/+bug/1534795

The resolvconf(8) man page also spells this out:

    To add nameserver addresses, add a single line beginning with dns-name‐
    servers.

        dns-nameservers 192.168.1.254 8.8.8.8

    Note that one or more addresses can be given on this line, separated
    by spaces, and note the "s" at the end of the option name, in
    contrast with the resolv.conf(5) option name nameserver. Remember
    that in interfaces(5) each option can be used at most once per
    stanza.

Taking the 'iface br-eth1 inet static' example it should become:

    auto br-eth1
    iface br-eth1 inet static
      gateway 10.245.168.1
      address 10.245.168.12/21
      mtu 1500
      bridge_ports eth1
      dns-nameservers 10.245.168.2 192.168.1.1

This change is also carried through to dns-search and dns-sortlist
options.

Fixes [LP #1536728](https://bugs.launchpad.net/juju-core/+bug/1536728)