### PR TITLE
Rename environments http endpoint

### DIFF
--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -58,8 +58,8 @@ type state struct {
 	// will be associated with (specifically macaroon auth cookies).
 	cookieURL *url.URL
 
-	// environTag holds the environment tag once we're connected
-	environTag string
+	// modelTag holds the model tag once we're connected
+	modelTag string
 
 	// controllerTag holds the controller tag once we're connected.
 	// This is only set with newer apiservers where they are using
@@ -329,8 +329,8 @@ func (st *state) connectStream(path string, attrs url.Values) (base.Stream, erro
 	}
 	if _, ok := st.ServerVersion(); ok {
 		// If the server version is set, then we know the server is capable of
-		// serving streams at the environment path. We also fully expect
-		// that the server has returned a valid environment tag.
+		// serving streams at the model path. We also fully expect
+		// that the server has returned a valid model tag.
 		envTag, err := st.EnvironTag()
 		if err != nil {
 			return nil, errors.Annotate(err, "cannot get model tag, perhaps connected to system not model")
@@ -412,7 +412,7 @@ func (st *state) addCookiesToHeader(h http.Header) {
 func (st *state) apiEndpoint(path, query string) (*url.URL, error) {
 	if _, err := st.ControllerTag(); err == nil {
 		// The controller tag is set, so the agent version is >= 1.23,
-		// so we can use the environment endpoint.
+		// so we can use the model endpoint.
 		envTag, err := st.EnvironTag()
 		if err != nil {
 			return nil, errors.Annotate(err, "cannot get API endpoint address")
@@ -428,18 +428,18 @@ func (st *state) apiEndpoint(path, query string) (*url.URL, error) {
 }
 
 // apiPath returns the given API endpoint path relative
-// to the given environment tag. The caller is responsible
-// for ensuring that the environment tag is valid and
+// to the given model tag. The caller is responsible
+// for ensuring that the model tag is valid and
 // that the path is slash-prefixed.
-func apiPath(envTag names.EnvironTag, path string) string {
+func apiPath(modelTag names.EnvironTag, path string) string {
 	if !strings.HasPrefix(path, "/") {
 		panic(fmt.Sprintf("apiPath called with non-slash-prefixed path %q", path))
 	}
-	if envTag.Id() == "" {
+	if modelTag.Id() == "" {
 		panic("apiPath called with empty model tag")
 	}
-	if envUUID := envTag.Id(); envUUID != "" {
-		return "/environment/" + envUUID + path
+	if modelUUID := modelTag.Id(); modelUUID != "" {
+		return "/model/" + modelUUID + path
 	}
 	return path
 }
@@ -576,9 +576,9 @@ func (s *state) Addr() string {
 	return s.addr
 }
 
-// EnvironTag returns the tag of the environment we are connected to.
+// EnvironTag returns the tag of the model we are connected to.
 func (s *state) EnvironTag() (names.EnvironTag, error) {
-	return names.ParseEnvironTag(s.environTag)
+	return names.ParseEnvironTag(s.modelTag)
 }
 
 // ControllerTag returns the tag of the server we are connected to.
@@ -592,7 +592,7 @@ func (s *state) ControllerTag() (names.EnvironTag, error) {
 // The addresses are scoped (public, cloud-internal, etc.), so
 // the client may choose which addresses to attempt. For the
 // Juju CLI, all addresses must be attempted, as the CLI may
-// be invoked both within and outside the environment (think
+// be invoked both within and outside the model (think
 // private clouds).
 func (s *state) APIHostPorts() [][]network.HostPort {
 	// NOTE: We're making a copy of s.hostPorts before returning it,

--- a/api/apiclient_test.go
+++ b/api/apiclient_test.go
@@ -95,7 +95,7 @@ func (s *apiclientSuite) TestConnectWebsocketMultipleError(c *gc.C) {
 	addr := listener.Addr().String()
 	info.Addrs = []string{addr, addr, addr}
 	_, _, err = api.ConnectWebsocket(info, api.DialOpts{})
-	c.Assert(err, gc.ErrorMatches, `unable to connect to API: websocket.Dial wss://.*/environment/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}/api: .*`)
+	c.Assert(err, gc.ErrorMatches, `unable to connect to API: websocket.Dial wss://.*/model/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}/api: .*`)
 	c.Assert(atomic.LoadInt32(&count), gc.Equals, int32(3))
 }
 
@@ -159,7 +159,7 @@ func (s *apiclientSuite) TestDialWebsocketStopped(c *gc.C) {
 }
 
 func assertConnAddrForEnv(c *gc.C, conn *websocket.Conn, addr, envUUID, tail string) {
-	c.Assert(conn.RemoteAddr(), gc.Matches, "^wss://"+addr+"/environment/"+envUUID+tail+"$")
+	c.Assert(conn.RemoteAddr(), gc.Matches, "^wss://"+addr+"/model/"+envUUID+tail+"$")
 }
 
 func assertConnAddrForRoot(c *gc.C, conn *websocket.Conn, addr string) {

--- a/api/backups/download_test.go
+++ b/api/backups/download_test.go
@@ -43,7 +43,7 @@ func (s *downloadSuite) TestSuccessfulRequest(c *gc.C) {
 
 func (s *downloadSuite) TestFailedRequest(c *gc.C) {
 	resultArchive, err := s.client.Download("unknown")
-	c.Assert(err, gc.ErrorMatches, `GET https://.*/environment/.*/backups: backup metadata "unknown" not found`)
+	c.Assert(err, gc.ErrorMatches, `GET https://.*/model/.*/backups: backup metadata "unknown" not found`)
 	c.Assert(err, jc.Satisfies, params.IsCodeNotFound)
 	c.Assert(resultArchive, gc.Equals, nil)
 }

--- a/api/backups/upload_test.go
+++ b/api/backups/upload_test.go
@@ -61,6 +61,6 @@ func (s *uploadSuite) TestFailedRequest(c *gc.C) {
 	meta.Environment = ""
 
 	id, err := s.client.Upload(archive, meta)
-	c.Assert(err, gc.ErrorMatches, `PUT https://.*/environment/.*/backups: while storing backup archive: missing Model`)
+	c.Assert(err, gc.ErrorMatches, `PUT https://.*/model/.*/backups: while storing backup archive: missing Model`)
 	c.Assert(id, gc.Equals, "")
 }

--- a/api/client_macaroon_test.go
+++ b/api/client_macaroon_test.go
@@ -51,7 +51,7 @@ func (s *clientMacaroonSuite) TestAddLocalCharmWithFailedDischarge(c *gc.C) {
 		fmt.Sprintf("local:quantal/%s-%d", charmArchive.Meta().Name, charmArchive.Revision()),
 	)
 	savedURL, err := s.client.AddLocalCharm(curl, charmArchive)
-	c.Assert(err, gc.ErrorMatches, `POST https://.*/environment/deadbeef-0bad-400d-8000-4b1d0d06f00d/charms\?series=quantal: cannot get discharge from "https://.*": third party refused discharge: cannot discharge: login denied by discharger`)
+	c.Assert(err, gc.ErrorMatches, `POST https://.*/model/deadbeef-0bad-400d-8000-4b1d0d06f00d/charms\?series=quantal: cannot get discharge from "https://.*": third party refused discharge: cannot discharge: login denied by discharger`)
 	c.Assert(savedURL, gc.IsNil)
 }
 
@@ -74,5 +74,5 @@ func (s *clientMacaroonSuite) TestAddLocalCharmUnauthorized(c *gc.C) {
 	)
 	// Upload an archive with its original revision.
 	_, err := s.client.AddLocalCharm(curl, charmArchive)
-	c.Assert(err, gc.ErrorMatches, `POST https://.*/environment/deadbeef-0bad-400d-8000-4b1d0d06f00d/charms\?series=quantal: invalid entity name or password`)
+	c.Assert(err, gc.ErrorMatches, `POST https://.*/model/deadbeef-0bad-400d-8000-4b1d0d06f00d/charms\?series=quantal: invalid entity name or password`)
 }

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -167,7 +167,7 @@ func (s *clientSuite) TestAddLocalCharmError(c *gc.C) {
 	)
 
 	_, err := client.AddLocalCharm(curl, charmArchive)
-	c.Assert(err, gc.ErrorMatches, `POST http://.*/environment/deadbeef-0bad-400d-8000-4b1d0d06f00d/charms\?series=quantal: the POST method is not allowed`)
+	c.Assert(err, gc.ErrorMatches, `POST http://.*/model/deadbeef-0bad-400d-8000-4b1d0d06f00d/charms\?series=quantal: the POST method is not allowed`)
 }
 
 func fakeAPIEndpoint(c *gc.C, client *api.Client, address, method string, handle func(http.ResponseWriter, *http.Request)) net.Listener {
@@ -186,11 +186,11 @@ func fakeAPIEndpoint(c *gc.C, client *api.Client, address, method string, handle
 	return lis
 }
 
-// envEndpoint returns "/environment/<env-uuid>/<destination>"
+// envEndpoint returns "/model/<model-uuid>/<destination>"
 func envEndpoint(c *gc.C, apiState api.Connection, destination string) string {
 	envTag, err := apiState.EnvironTag()
 	c.Assert(err, jc.ErrorIsNil)
-	return path.Join("/environment", envTag.Id(), destination)
+	return path.Join("/model", envTag.Id(), destination)
 }
 
 func (s *clientSuite) TestClientEnvironmentUUID(c *gc.C) {
@@ -486,7 +486,7 @@ func (s *clientSuite) TestConnectStreamRootPath(c *gc.C) {
 
 func (s *clientSuite) TestConnectStreamAtUUIDPath(c *gc.C) {
 	s.PatchValue(api.WebsocketDialConfig, echoURL(c))
-	// If the server supports it, we should log at "/environment/UUID/log"
+	// If the server supports it, we should log at "/model/UUID/log"
 	environ, err := s.State.Environment()
 	c.Assert(err, jc.ErrorIsNil)
 	info := s.APIInfo(c)
@@ -497,7 +497,7 @@ func (s *clientSuite) TestConnectStreamAtUUIDPath(c *gc.C) {
 	reader, err := apistate.ConnectStream("/path", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	connectURL := connectURLFromReader(c, reader)
-	c.Assert(connectURL.Path, gc.Matches, fmt.Sprintf("/environment/%s/path", environ.UUID()))
+	c.Assert(connectURL.Path, gc.Matches, fmt.Sprintf("/model/%s/path", environ.UUID()))
 }
 
 func (s *clientSuite) TestOpenUsesEnvironUUIDPaths(c *gc.C) {

--- a/api/export_test.go
+++ b/api/export_test.go
@@ -48,7 +48,7 @@ type TestingStateParams struct {
 func NewTestingState(params TestingStateParams) Connection {
 	st := &state{
 		addr:              params.Address,
-		environTag:        params.EnvironTag,
+		modelTag:          params.EnvironTag,
 		hostPorts:         params.APIHostPorts,
 		facadeVersions:    params.FacadeVersions,
 		serverScheme:      params.ServerScheme,

--- a/api/state.go
+++ b/api/state.go
@@ -179,9 +179,9 @@ func (st *state) loginV1(tag names.Tag, password, nonce string) error {
 	return nil
 }
 
-func (st *state) setLoginResult(tag names.Tag, environTag, controllerTag string, servers [][]network.HostPort, facades []params.FacadeVersions) error {
+func (st *state) setLoginResult(tag names.Tag, modelTag, controllerTag string, servers [][]network.HostPort, facades []params.FacadeVersions) error {
 	st.authTag = tag
-	st.environTag = environTag
+	st.modelTag = modelTag
 	st.controllerTag = controllerTag
 
 	hostPorts, err := addAddress(servers, st.addr)

--- a/api/state_macaroon_test.go
+++ b/api/state_macaroon_test.go
@@ -74,7 +74,7 @@ func (s *macaroonLoginSuite) TestConnectStream(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 	defer conn.Close()
 	connectURL := connectURLFromReader(c, conn)
-	c.Assert(connectURL.Path, gc.Equals, "/environment/"+s.State.EnvironTag().Id()+"/path")
+	c.Assert(connectURL.Path, gc.Equals, "/model/"+s.State.EnvironTag().Id()+"/path")
 	c.Assert(dischargeCount, gc.Equals, 1)
 }
 

--- a/api/uniter/charm_test.go
+++ b/api/uniter/charm_test.go
@@ -50,7 +50,7 @@ func (s *charmSuite) TestURL(c *gc.C) {
 func (s *charmSuite) TestArchiveURLs(c *gc.C) {
 	apiInfo := s.APIInfo(c)
 	url, err := url.Parse(fmt.Sprintf(
-		"https://0.1.2.3:1234/environment/%s/charms?file=%s&url=%s",
+		"https://0.1.2.3:1234/model/%s/charms?file=%s&url=%s",
 		apiInfo.EnvironTag.Id(),
 		url.QueryEscape("*"),
 		url.QueryEscape(s.apiCharm.URL().String()),

--- a/api/upgrader/upgrader_test.go
+++ b/api/upgrader/upgrader_test.go
@@ -102,7 +102,7 @@ func (s *machineUpgraderSuite) TestTools(c *gc.C) {
 	stateTools, err := s.st.Tools(s.rawMachine.Tag().String())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(stateTools.Version, gc.Equals, current)
-	url := fmt.Sprintf("https://%s/environment/%s/tools/%s",
+	url := fmt.Sprintf("https://%s/model/%s/tools/%s",
 		s.stateAPI.Addr(), coretesting.EnvironmentTag.Id(), current)
 	c.Assert(stateTools.URL, gc.Equals, url)
 }

--- a/api/usermanager/client_test.go
+++ b/api/usermanager/client_test.go
@@ -104,7 +104,7 @@ func (s *usermanagerSuite) TestEnableUserBadName(c *gc.C) {
 
 func (s *usermanagerSuite) TestCantRemoveAdminUser(c *gc.C) {
 	err := s.usermanager.DisableUser(s.AdminUserTag(c).Name())
-	c.Assert(err, gc.ErrorMatches, "failed to disable user: cannot disable state server model owner")
+	c.Assert(err, gc.ErrorMatches, "failed to disable user: cannot disable controller model owner")
 }
 
 func (s *usermanagerSuite) TestUserInfo(c *gc.C) {

--- a/apiserver/admin.go
+++ b/apiserver/admin.go
@@ -83,7 +83,7 @@ func (a *admin) doLogin(req params.LoginRequest, loginVersion int) (params.Login
 		isUser = true
 	}
 
-	serverOnlyLogin := loginVersion > 1 && a.root.envUUID == ""
+	serverOnlyLogin := loginVersion > 1 && a.root.modelUUID == ""
 
 	entity, lastConnection, err := doCheckCreds(a.root.state, req, !serverOnlyLogin, a.srv.authCtxt)
 	if err != nil {

--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -48,7 +48,7 @@ type Server struct {
 	validator         LoginValidator
 	adminApiFactories map[int]adminApiFactory
 	mongoUnavailable  uint32 // non zero if mongoUnavailable
-	environUUID       string
+	modelUUID         string
 	authCtxt          *authContext
 }
 
@@ -341,11 +341,11 @@ func (srv *Server) run(lis net.Listener) {
 	httpCtxt := httpContext{
 		srv: srv,
 	}
-	handleAll(mux, "/environment/:envuuid/logsink",
+	handleAll(mux, "/model/:modeluuid/logsink",
 		newLogSinkHandler(httpCtxt, srv.logDir))
-	handleAll(mux, "/environment/:envuuid/log",
+	handleAll(mux, "/model/:modeluuid/log",
 		newDebugLogDBHandler(httpCtxt, srvDying))
-	handleAll(mux, "/environment/:envuuid/charms",
+	handleAll(mux, "/model/:modeluuid/charms",
 		&charmsHandler{
 			ctxt:    httpCtxt,
 			dataDir: srv.dataDir},
@@ -354,27 +354,27 @@ func (srv *Server) run(lis net.Listener) {
 	// where we only want to support specific request methods. However, our
 	// tests currently assert that errors come back as application/json and
 	// pat only does "text/plain" responses.
-	handleAll(mux, "/environment/:envuuid/tools",
+	handleAll(mux, "/model/:modeluuid/tools",
 		&toolsUploadHandler{
 			ctxt: httpCtxt,
 		},
 	)
-	handleAll(mux, "/environment/:envuuid/tools/:version",
+	handleAll(mux, "/model/:modeluuid/tools/:version",
 		&toolsDownloadHandler{
 			ctxt: httpCtxt,
 		},
 	)
 	strictCtxt := httpCtxt
 	strictCtxt.strictValidation = true
-	strictCtxt.stateServerEnvOnly = true
-	handleAll(mux, "/environment/:envuuid/backups",
+	strictCtxt.controllerModelOnly = true
+	handleAll(mux, "/model/:modeluuid/backups",
 		&backupHandler{
 			ctxt: strictCtxt,
 		},
 	)
-	handleAll(mux, "/environment/:envuuid/api", http.HandlerFunc(srv.apiHandler))
+	handleAll(mux, "/model/:modeluuid/api", http.HandlerFunc(srv.apiHandler))
 
-	handleAll(mux, "/environment/:envuuid/images/:kind/:series/:arch/:filename",
+	handleAll(mux, "/model/:modeluuid/images/:kind/:series/:arch/:filename",
 		&imagesDownloadHandler{
 			ctxt:    httpCtxt,
 			dataDir: srv.dataDir,
@@ -426,9 +426,9 @@ func (srv *Server) apiHandler(w http.ResponseWriter, req *http.Request) {
 			if srv.tomb.Err() != tomb.ErrStillAlive {
 				return
 			}
-			envUUID := req.URL.Query().Get(":envuuid")
-			logger.Tracef("got a request for env %q", envUUID)
-			if err := srv.serveConn(conn, reqNotifier, envUUID); err != nil {
+			modelUUID := req.URL.Query().Get(":modeluuid")
+			logger.Tracef("got a request for model %q", modelUUID)
+			if err := srv.serveConn(conn, reqNotifier, modelUUID); err != nil {
 				logger.Errorf("error serving RPCs: %v", err)
 			}
 		},
@@ -441,7 +441,7 @@ func (srv *Server) Addr() *net.TCPAddr {
 	return srv.addr
 }
 
-func (srv *Server) serveConn(wsConn *websocket.Conn, reqNotifier *requestNotifier, envUUID string) error {
+func (srv *Server) serveConn(wsConn *websocket.Conn, reqNotifier *requestNotifier, modelUUID string) error {
 	codec := jsoncodec.NewWebsocket(wsConn)
 	if loggo.GetLogger("juju.rpc.jsoncodec").EffectiveLogLevel() <= loggo.TRACE {
 		codec.SetLogging(true)
@@ -454,7 +454,7 @@ func (srv *Server) serveConn(wsConn *websocket.Conn, reqNotifier *requestNotifie
 	}
 	conn := rpc.NewConn(codec, notifier)
 
-	h, err := srv.newAPIHandler(conn, reqNotifier, envUUID)
+	h, err := srv.newAPIHandler(conn, reqNotifier, modelUUID)
 	if err != nil {
 		conn.Serve(&errRoot{err}, serverError)
 	} else {
@@ -472,22 +472,22 @@ func (srv *Server) serveConn(wsConn *websocket.Conn, reqNotifier *requestNotifie
 	return conn.Close()
 }
 
-func (srv *Server) newAPIHandler(conn *rpc.Conn, reqNotifier *requestNotifier, envUUID string) (*apiHandler, error) {
-	// Note that we don't overwrite envUUID here because
-	// newAPIHandler treats an empty envUUID as signifying
+func (srv *Server) newAPIHandler(conn *rpc.Conn, reqNotifier *requestNotifier, modelUUID string) (*apiHandler, error) {
+	// Note that we don't overwrite modelUUID here because
+	// newAPIHandler treats an empty modelUUID as signifying
 	// the API version used.
-	resolvedEnvUUID, err := validateEnvironUUID(validateArgs{
+	resolvedModelUUID, err := validateModelUUID(validateArgs{
 		statePool: srv.statePool,
-		envUUID:   envUUID,
+		modelUUID: modelUUID,
 	})
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	st, err := srv.statePool.Get(resolvedEnvUUID)
+	st, err := srv.statePool.Get(resolvedModelUUID)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return newApiHandler(srv, st, conn, reqNotifier, envUUID)
+	return newApiHandler(srv, st, conn, reqNotifier, modelUUID)
 }
 
 func (srv *Server) mongoPinger() error {

--- a/apiserver/backup_test.go
+++ b/apiserver/backup_test.go
@@ -47,7 +47,7 @@ func (s *backupsCommonSuite) backupURL(c *gc.C) string {
 	environ, err := s.State.Environment()
 	c.Assert(err, jc.ErrorIsNil)
 	uri := s.baseURL(c)
-	uri.Path = fmt.Sprintf("/environment/%s/backups", environ.UUID())
+	uri.Path = fmt.Sprintf("/model/%s/backups", environ.UUID())
 	return uri.String()
 }
 

--- a/apiserver/charms_test.go
+++ b/apiserver/charms_test.go
@@ -39,7 +39,7 @@ func (s *charmsCommonSuite) charmsURL(c *gc.C, query string) *url.URL {
 	if s.envUUID == "" {
 		uri.Path = "/charms"
 	} else {
-		uri.Path = fmt.Sprintf("/environment/%s/charms", s.envUUID)
+		uri.Path = fmt.Sprintf("/model/%s/charms", s.envUUID)
 	}
 	uri.RawQuery = query
 	return uri
@@ -246,7 +246,7 @@ func (s *charmsSuite) TestUploadAllowsEnvUUIDPath(c *gc.C) {
 	// Check that we can upload charms to https://host:port/ENVUUID/charms
 	ch := testcharms.Repo.CharmArchive(c.MkDir(), "dummy")
 	url := s.charmsURL(c, "series=quantal")
-	url.Path = fmt.Sprintf("/environment/%s/charms", s.envUUID)
+	url.Path = fmt.Sprintf("/model/%s/charms", s.envUUID)
 	resp := s.uploadRequest(c, url.String(), "application/zip", ch.Path)
 	expectedURL := charm.MustParseURL("local:quantal/dummy-1")
 	s.assertUploadResponse(c, resp, expectedURL.String())
@@ -257,7 +257,7 @@ func (s *charmsSuite) TestUploadAllowsOtherEnvUUIDPath(c *gc.C) {
 	// Check that we can upload charms to https://host:port/ENVUUID/charms
 	ch := testcharms.Repo.CharmArchive(c.MkDir(), "dummy")
 	url := s.charmsURL(c, "series=quantal")
-	url.Path = fmt.Sprintf("/environment/%s/charms", envState.EnvironUUID())
+	url.Path = fmt.Sprintf("/model/%s/charms", envState.EnvironUUID())
 	resp := s.uploadRequest(c, url.String(), "application/zip", ch.Path)
 	expectedURL := charm.MustParseURL("local:quantal/dummy-1")
 	s.assertUploadResponse(c, resp, expectedURL.String())
@@ -266,7 +266,7 @@ func (s *charmsSuite) TestUploadAllowsOtherEnvUUIDPath(c *gc.C) {
 func (s *charmsSuite) TestUploadRejectsWrongEnvUUIDPath(c *gc.C) {
 	// Check that we cannot upload charms to https://host:port/BADENVUUID/charms
 	url := s.charmsURL(c, "series=quantal")
-	url.Path = "/environment/dead-beef-123456/charms"
+	url.Path = "/model/dead-beef-123456/charms"
 	resp := s.authRequest(c, httpRequestParams{method: "POST", url: url.String()})
 	s.assertErrorResponse(c, resp, http.StatusNotFound, `unknown model: "dead-beef-123456"`)
 }
@@ -429,7 +429,7 @@ func (s *charmsSuite) TestGetAllowsEnvUUIDPath(c *gc.C) {
 	ch := testcharms.Repo.CharmArchive(c.MkDir(), "dummy")
 	s.uploadRequest(c, s.charmsURI(c, "?series=quantal"), "application/zip", ch.Path)
 	url := s.charmsURL(c, "url=local:quantal/dummy-1&file=revision")
-	url.Path = fmt.Sprintf("/environment/%s/charms", s.envUUID)
+	url.Path = fmt.Sprintf("/model/%s/charms", s.envUUID)
 	resp := s.authRequest(c, httpRequestParams{method: "GET", url: url.String()})
 	s.assertGetFileResponse(c, resp, "1", "text/plain; charset=utf-8")
 }
@@ -440,14 +440,14 @@ func (s *charmsSuite) TestGetAllowsOtherEnvironment(c *gc.C) {
 	ch := testcharms.Repo.CharmArchive(c.MkDir(), "dummy")
 	s.uploadRequest(c, s.charmsURI(c, "?series=quantal"), "application/zip", ch.Path)
 	url := s.charmsURL(c, "url=local:quantal/dummy-1&file=revision")
-	url.Path = fmt.Sprintf("/environment/%s/charms", envState.EnvironUUID())
+	url.Path = fmt.Sprintf("/model/%s/charms", envState.EnvironUUID())
 	resp := s.authRequest(c, httpRequestParams{method: "GET", url: url.String()})
 	s.assertGetFileResponse(c, resp, "1", "text/plain; charset=utf-8")
 }
 
 func (s *charmsSuite) TestGetRejectsWrongEnvUUIDPath(c *gc.C) {
 	url := s.charmsURL(c, "url=local:quantal/dummy-1&file=revision")
-	url.Path = "/environment/dead-beef-123456/charms"
+	url.Path = "/model/dead-beef-123456/charms"
 	resp := s.authRequest(c, httpRequestParams{method: "GET", url: url.String()})
 	s.assertErrorResponse(c, resp, http.StatusNotFound, `unknown model: "dead-beef-123456"`)
 }

--- a/apiserver/client/client_test.go
+++ b/apiserver/client/client_test.go
@@ -2216,7 +2216,7 @@ func (s *clientSuite) TestClientFindTools(c *gc.C) {
 	c.Assert(result.Error, gc.IsNil)
 	c.Assert(result.List, gc.HasLen, 1)
 	c.Assert(result.List[0].Version, gc.Equals, version.MustParseBinary("2.99.0-precise-amd64"))
-	url := fmt.Sprintf("https://%s/environment/%s/tools/%s",
+	url := fmt.Sprintf("https://%s/model/%s/tools/%s",
 		s.APIState.Addr(), coretesting.EnvironmentTag.Id(), result.List[0].Version)
 	c.Assert(result.List[0].URL, gc.Equals, url)
 }

--- a/apiserver/client/instanceconfig_test.go
+++ b/apiserver/client/instanceconfig_test.go
@@ -55,7 +55,7 @@ func (s *machineConfigSuite) TestMachineConfig(c *gc.C) {
 
 	c.Check(instanceConfig.MongoInfo.Addrs, gc.DeepEquals, mongoAddrs)
 	c.Check(instanceConfig.APIInfo.Addrs, gc.DeepEquals, apiAddrs)
-	toolsURL := fmt.Sprintf("https://%s/environment/%s/tools/%s",
+	toolsURL := fmt.Sprintf("https://%s/model/%s/tools/%s",
 		apiAddrs[0], jujutesting.EnvironmentTag.Id(), instanceConfig.Tools.Version)
 	c.Assert(instanceConfig.Tools.URL, gc.Equals, toolsURL)
 	c.Assert(instanceConfig.AgentEnvironment[agent.AllowsSecureConnection], gc.Equals, "true")

--- a/apiserver/common/errors.go
+++ b/apiserver/common/errors.go
@@ -50,20 +50,20 @@ func IsNoAddressSetError(err error) bool {
 	return ok
 }
 
-type unknownEnvironmentError struct {
+type unknownModelError struct {
 	uuid string
 }
 
-func (e *unknownEnvironmentError) Error() string {
+func (e *unknownModelError) Error() string {
 	return fmt.Sprintf("unknown model: %q", e.uuid)
 }
 
-func UnknownEnvironmentError(uuid string) error {
-	return &unknownEnvironmentError{uuid: uuid}
+func UnknownModelError(uuid string) error {
+	return &unknownModelError{uuid: uuid}
 }
 
-func IsUnknownEnviromentError(err error) bool {
-	_, ok := err.(*unknownEnvironmentError)
+func IsUnknownModelError(err error) bool {
+	_, ok := err.(*unknownModelError)
 	return ok
 }
 
@@ -212,7 +212,7 @@ func ServerError(err error) *params.Error {
 		code = params.CodeUpgradeInProgress
 	case state.IsHasAttachmentsError(err):
 		code = params.CodeMachineHasAttachedStorage
-	case IsUnknownEnviromentError(err):
+	case IsUnknownModelError(err):
 		code = params.CodeNotFound
 	case errors.IsNotSupported(err):
 		code = params.CodeNotSupported
@@ -277,7 +277,7 @@ func RestoreError(err error) (error, bool) {
 	case params.IsCodeUnauthorized(err):
 		return errors.NewUnauthorized(nil, msg), true
 	case params.IsCodeNotFound(err):
-		// TODO(ericsnow) unknownEnvironmentError should be handled here too.
+		// TODO(ericsnow) UnknownModelError should be handled here too.
 		// ...by parsing msg?
 		return errors.NewNotFound(nil, msg), true
 	case params.IsCodeAlreadyExists(err):

--- a/apiserver/common/errors_test.go
+++ b/apiserver/common/errors_test.go
@@ -180,7 +180,7 @@ var errorTransformTests = []struct {
 	status: http.StatusInternalServerError,
 	code:   "",
 }, {
-	err:        common.UnknownEnvironmentError("dead-beef-123456"),
+	err:        common.UnknownModelError("dead-beef-123456"),
 	code:       params.CodeNotFound,
 	status:     http.StatusNotFound,
 	helperFunc: params.IsCodeNotFound,
@@ -234,7 +234,7 @@ func (s *errorsSuite) TestErrorTransform(c *gc.C) {
 			params.CodeDischargeRequired:
 			continue
 		case params.CodeNotFound:
-			if common.IsUnknownEnviromentError(t.err) {
+			if common.IsUnknownModelError(t.err) {
 				continue
 			}
 		case params.CodeOperationBlocked:
@@ -259,8 +259,8 @@ func (s *errorsSuite) TestErrorTransform(c *gc.C) {
 	}
 }
 
-func (s *errorsSuite) TestUnknownEnvironment(c *gc.C) {
-	err := common.UnknownEnvironmentError("dead-beef")
+func (s *errorsSuite) TestUnknownModel(c *gc.C) {
+	err := common.UnknownModelError("dead-beef")
 	c.Check(err, gc.ErrorMatches, `unknown model: "dead-beef"`)
 }
 

--- a/apiserver/common/tools.go
+++ b/apiserver/common/tools.go
@@ -366,7 +366,7 @@ func (t *toolsURLGetter) ToolsURL(v version.Binary) (string, error) {
 	if apiAddress == "" {
 		return "", errors.Errorf("no suitable API server address to pick from %v", hostPorts)
 	}
-	serverRoot := fmt.Sprintf("https://%s/environment/%s", apiAddress, t.envUUID)
+	serverRoot := fmt.Sprintf("https://%s/model/%s", apiAddress, t.envUUID)
 	return ToolsURL(serverRoot, v), nil
 }
 

--- a/apiserver/common/tools_test.go
+++ b/apiserver/common/tools_test.go
@@ -300,7 +300,7 @@ func (s *toolsSuite) TestToolsURLGetter(c *gc.C) {
 	})
 	url, err := g.ToolsURL(current)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(url, gc.Equals, "https://0.1.2.3:1234/environment/my-uuid/tools/"+current.String())
+	c.Assert(url, gc.Equals, "https://0.1.2.3:1234/model/my-uuid/tools/"+current.String())
 }
 
 type sprintfURLGetter string

--- a/apiserver/httpcontext.go
+++ b/apiserver/httpcontext.go
@@ -24,8 +24,8 @@ import (
 type httpContext struct {
 	// strictValidation means that empty envUUID values are not valid.
 	strictValidation bool
-	// stateServerEnvOnly only validates the state server environment
-	stateServerEnvOnly bool
+	// controllerModelOnly only validates the controller model.
+	controllerModelOnly bool
 	// srv holds the API server instance.
 	srv *Server
 }
@@ -37,19 +37,19 @@ type errorSender interface {
 var errUnauthorized = errors.NewUnauthorized(nil, "unauthorized")
 
 // stateForRequestUnauthenticated returns a state instance appropriate for
-// using for the environment implicit in the given request
+// using for the model implicit in the given request
 // without checking any authentication information.
 func (ctxt *httpContext) stateForRequestUnauthenticated(r *http.Request) (*state.State, error) {
-	envUUID, err := validateEnvironUUID(validateArgs{
-		statePool:          ctxt.srv.statePool,
-		envUUID:            r.URL.Query().Get(":envuuid"),
-		strict:             ctxt.strictValidation,
-		stateServerEnvOnly: ctxt.stateServerEnvOnly,
+	modelUUID, err := validateModelUUID(validateArgs{
+		statePool:           ctxt.srv.statePool,
+		modelUUID:           r.URL.Query().Get(":modeluuid"),
+		strict:              ctxt.strictValidation,
+		controllerModelOnly: ctxt.controllerModelOnly,
 	})
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	st, err := ctxt.srv.statePool.Get(envUUID)
+	st, err := ctxt.srv.statePool.Get(modelUUID)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -57,7 +57,7 @@ func (ctxt *httpContext) stateForRequestUnauthenticated(r *http.Request) (*state
 }
 
 // stateForRequestAuthenticated returns a state instance appropriate for
-// using for the environment implicit in the given request.
+// using for the model implicit in the given request.
 // It also returns the authenticated entity.
 func (ctxt *httpContext) stateForRequestAuthenticated(r *http.Request) (*state.State, state.Entity, error) {
 	st, err := ctxt.stateForRequestUnauthenticated(r)

--- a/apiserver/images.go
+++ b/apiserver/images.go
@@ -55,7 +55,7 @@ func (h *imagesDownloadHandler) processGet(r *http.Request, resp http.ResponseWr
 	kind := r.URL.Query().Get(":kind")
 	series := r.URL.Query().Get(":series")
 	arch := r.URL.Query().Get(":arch")
-	envuuid := r.URL.Query().Get(":envuuid")
+	envuuid := r.URL.Query().Get(":modeluuid")
 
 	// Get the image details from storage.
 	metadata, imageReader, err := h.loadImage(st, envuuid, kind, series, arch)

--- a/apiserver/images_test.go
+++ b/apiserver/images_test.go
@@ -47,7 +47,7 @@ func (s *imageSuite) TestDownloadMissingEnvUUIDPath(c *gc.C) {
 
 	s.envUUID = ""
 	url := s.imageURL(c, "lxc", "trusty", "amd64")
-	c.Assert(url.Path, jc.HasPrefix, "/environment//images")
+	c.Assert(url.Path, jc.HasPrefix, "/model//images")
 
 	response := s.downloadRequest(c, url)
 	s.testDownload(c, response)
@@ -57,7 +57,7 @@ func (s *imageSuite) TestDownloadEnvironmentPath(c *gc.C) {
 	s.storeFakeImage(c, s.State, "lxc", "trusty", "amd64")
 
 	url := s.imageURL(c, "lxc", "trusty", "amd64")
-	c.Assert(url.Path, jc.HasPrefix, fmt.Sprintf("/environment/%s/", s.State.EnvironUUID()))
+	c.Assert(url.Path, jc.HasPrefix, fmt.Sprintf("/model/%s/", s.State.EnvironUUID()))
 
 	response := s.downloadRequest(c, url)
 	s.testDownload(c, response)
@@ -68,7 +68,7 @@ func (s *imageSuite) TestDownloadOtherEnvironmentPath(c *gc.C) {
 	s.storeFakeImage(c, envState, "lxc", "trusty", "amd64")
 
 	url := s.imageURL(c, "lxc", "trusty", "amd64")
-	c.Assert(url.Path, jc.HasPrefix, fmt.Sprintf("/environment/%s/", envState.EnvironUUID()))
+	c.Assert(url.Path, jc.HasPrefix, fmt.Sprintf("/model/%s/", envState.EnvironUUID()))
 
 	response := s.downloadRequest(c, url)
 	s.testDownload(c, response)
@@ -253,7 +253,7 @@ func (s *imageSuite) getImageFromStorage(c *gc.C, st *state.State, kind, series,
 
 func (s *imageSuite) imageURL(c *gc.C, kind, series, arch string) *url.URL {
 	uri := s.baseURL(c)
-	uri.Path = fmt.Sprintf("/environment/%s/images/%s/%s/%s/trusty-released-amd64-root.tar.gz", s.envUUID, kind, series, arch)
+	uri.Path = fmt.Sprintf("/model/%s/images/%s/%s/%s/trusty-released-amd64-root.tar.gz", s.envUUID, kind, series, arch)
 	return uri
 }
 

--- a/apiserver/logsink_test.go
+++ b/apiserver/logsink_test.go
@@ -32,7 +32,7 @@ type logsinkBaseSuite struct {
 }
 
 func (s *logsinkBaseSuite) logsinkURL(c *gc.C, scheme string) *url.URL {
-	return s.makeURL(c, scheme, "/environment/"+s.State.EnvironUUID()+"/logsink", nil)
+	return s.makeURL(c, scheme, "/model/"+s.State.EnvironUUID()+"/logsink", nil)
 }
 
 type logsinkSuite struct {
@@ -59,7 +59,7 @@ func (s *logsinkSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *logsinkSuite) TestRejectsBadEnvironUUID(c *gc.C) {
-	reader := s.openWebsocketCustomPath(c, "/environment/does-not-exist/logsink")
+	reader := s.openWebsocketCustomPath(c, "/model/does-not-exist/logsink")
 	assertJSONError(c, reader, `unknown model: "does-not-exist"`)
 	s.assertWebsocketClosed(c, reader)
 }

--- a/apiserver/provisioner/provisioner_test.go
+++ b/apiserver/provisioner/provisioner_test.go
@@ -1615,7 +1615,7 @@ func (s *withoutStateServerSuite) TestFindTools(c *gc.C) {
 	c.Assert(result.Error, gc.IsNil)
 	c.Assert(result.List, gc.Not(gc.HasLen), 0)
 	for _, tools := range result.List {
-		url := fmt.Sprintf("https://%s/environment/%s/tools/%s",
+		url := fmt.Sprintf("https://%s/model/%s/tools/%s",
 			s.APIState.Addr(), coretesting.EnvironmentTag.Id(), tools.Version)
 		c.Assert(tools.URL, gc.Equals, url)
 	}

--- a/apiserver/root.go
+++ b/apiserver/root.go
@@ -48,21 +48,21 @@ type apiHandler struct {
 	entity           state.Entity
 	mongoUnavailable *uint32
 	// An empty envUUID means that the user has logged in through the
-	// root of the API server rather than the /environment/:env-uuid/api
+	// root of the API server rather than the /model/:env-uuid/api
 	// path, logins processed with v2 or later will only offer the
-	// user manager and environment manager api endpoints from here.
-	envUUID string
+	// user manager and model manager api endpoints from here.
+	modelUUID string
 }
 
 var _ = (*apiHandler)(nil)
 
 // newApiHandler returns a new apiHandler.
-func newApiHandler(srv *Server, st *state.State, rpcConn *rpc.Conn, reqNotifier *requestNotifier, envUUID string) (*apiHandler, error) {
+func newApiHandler(srv *Server, st *state.State, rpcConn *rpc.Conn, reqNotifier *requestNotifier, modelUUID string) (*apiHandler, error) {
 	r := &apiHandler{
 		state:            st,
 		resources:        common.NewResources(),
 		rpcConn:          rpcConn,
-		envUUID:          envUUID,
+		modelUUID:        modelUUID,
 		mongoUnavailable: &srv.mongoUnavailable,
 	}
 	if err := r.resources.RegisterNamed("machineID", common.StringResource(srv.tag.Id())); err != nil {

--- a/apiserver/server_test.go
+++ b/apiserver/server_test.go
@@ -291,8 +291,8 @@ func (s *serverSuite) TestNonCompatiblePathsAre404(c *gc.C) {
 	conn, err := dialWebsocket(c, addr, "/")
 	c.Assert(err, jc.ErrorIsNil)
 	conn.Close()
-	// '/environment/ENVIRONUUID/api' should be fine
-	conn, err = dialWebsocket(c, addr, "/environment/dead-beef-123456/api")
+	// '/model/MODELUUID/api' should be fine
+	conn, err = dialWebsocket(c, addr, "/model/dead-beef-123456/api")
 	c.Assert(err, jc.ErrorIsNil)
 	conn.Close()
 

--- a/apiserver/tools.go
+++ b/apiserver/tools.go
@@ -223,7 +223,7 @@ func (h *toolsUploadHandler) processPost(r *http.Request, st *state.State) (*too
 }
 
 func (h *toolsUploadHandler) getServerRoot(r *http.Request, query url.Values, st *state.State) (string, error) {
-	uuid := query.Get(":envuuid")
+	uuid := query.Get(":modeluuid")
 	if uuid == "" {
 		env, err := st.Environment()
 		if err != nil {
@@ -231,7 +231,7 @@ func (h *toolsUploadHandler) getServerRoot(r *http.Request, query url.Values, st
 		}
 		uuid = env.UUID()
 	}
-	return fmt.Sprintf("https://%s/environment/%s", r.Host, uuid), nil
+	return fmt.Sprintf("https://%s/model/%s", r.Host, uuid), nil
 }
 
 // handleUpload uploads the tools data from the reader to env storage as the specified version.

--- a/apiserver/tools_test.go
+++ b/apiserver/tools_test.go
@@ -41,7 +41,7 @@ type toolsCommonSuite struct {
 
 func (s *toolsCommonSuite) toolsURL(c *gc.C, query string) *url.URL {
 	uri := s.baseURL(c)
-	uri.Path = fmt.Sprintf("/environment/%s/tools", s.envUUID)
+	uri.Path = fmt.Sprintf("/model/%s/tools", s.envUUID)
 	uri.RawQuery = query
 	return uri
 }
@@ -58,7 +58,7 @@ func (s *toolsCommonSuite) downloadRequest(c *gc.C, version version.Binary, uuid
 	if uuid == "" {
 		url.Path = fmt.Sprintf("/tools/%s", version)
 	} else {
-		url.Path = fmt.Sprintf("/environment/%s/tools/%s", uuid, version)
+		url.Path = fmt.Sprintf("/model/%s/tools/%s", uuid, version)
 	}
 	return s.sendRequest(c, httpRequestParams{method: "GET", url: url.String()})
 }
@@ -182,7 +182,7 @@ func (s *toolsSuite) TestUpload(c *gc.C) {
 		c, s.toolsURI(c, "?binaryVersion="+vers.String()), "application/x-tar-gz", toolPath)
 
 	// Check the response.
-	expectedTools[0].URL = fmt.Sprintf("%s/environment/%s/tools/%s", s.baseURL(c), s.State.EnvironUUID(), vers)
+	expectedTools[0].URL = fmt.Sprintf("%s/model/%s/tools/%s", s.baseURL(c), s.State.EnvironUUID(), vers)
 	s.assertUploadResponse(c, resp, expectedTools[0])
 
 	// Check the contents.
@@ -221,7 +221,7 @@ func (s *toolsSuite) TestUploadAllowsTopLevelPath(c *gc.C) {
 	url.Path = "/tools"
 	resp := s.uploadRequest(c, url.String(), "application/x-tar-gz", toolPath)
 	// Check the response.
-	expectedTools[0].URL = fmt.Sprintf("%s/environment/%s/tools/%s", s.baseURL(c), s.State.EnvironUUID(), vers)
+	expectedTools[0].URL = fmt.Sprintf("%s/model/%s/tools/%s", s.baseURL(c), s.State.EnvironUUID(), vers)
 	s.assertUploadResponse(c, resp, expectedTools[0])
 }
 
@@ -229,10 +229,10 @@ func (s *toolsSuite) TestUploadAllowsEnvUUIDPath(c *gc.C) {
 	// Check that we can upload tools to https://host:port/ENVUUID/tools
 	expectedTools, vers, toolPath := s.setupToolsForUpload(c)
 	url := s.toolsURL(c, "binaryVersion="+vers.String())
-	url.Path = fmt.Sprintf("/environment/%s/tools", s.State.EnvironUUID())
+	url.Path = fmt.Sprintf("/model/%s/tools", s.State.EnvironUUID())
 	resp := s.uploadRequest(c, url.String(), "application/x-tar-gz", toolPath)
 	// Check the response.
-	expectedTools[0].URL = fmt.Sprintf("%s/environment/%s/tools/%s", s.baseURL(c), s.State.EnvironUUID(), vers)
+	expectedTools[0].URL = fmt.Sprintf("%s/model/%s/tools/%s", s.baseURL(c), s.State.EnvironUUID(), vers)
 	s.assertUploadResponse(c, resp, expectedTools[0])
 }
 
@@ -241,17 +241,17 @@ func (s *toolsSuite) TestUploadAllowsOtherEnvUUIDPath(c *gc.C) {
 	// Check that we can upload tools to https://host:port/ENVUUID/tools
 	expectedTools, vers, toolPath := s.setupToolsForUpload(c)
 	url := s.toolsURL(c, "binaryVersion="+vers.String())
-	url.Path = fmt.Sprintf("/environment/%s/tools", envState.EnvironUUID())
+	url.Path = fmt.Sprintf("/model/%s/tools", envState.EnvironUUID())
 	resp := s.uploadRequest(c, url.String(), "application/x-tar-gz", toolPath)
 	// Check the response.
-	expectedTools[0].URL = fmt.Sprintf("%s/environment/%s/tools/%s", s.baseURL(c), envState.EnvironUUID(), vers)
+	expectedTools[0].URL = fmt.Sprintf("%s/model/%s/tools/%s", s.baseURL(c), envState.EnvironUUID(), vers)
 	s.assertUploadResponse(c, resp, expectedTools[0])
 }
 
 func (s *toolsSuite) TestUploadRejectsWrongEnvUUIDPath(c *gc.C) {
 	// Check that we cannot access the tools at https://host:port/BADENVUUID/tools
 	url := s.toolsURL(c, "")
-	url.Path = "/environment/dead-beef-123456/tools"
+	url.Path = "/model/dead-beef-123456/tools"
 	resp := s.authRequest(c, httpRequestParams{method: "POST", url: url.String()})
 	s.assertErrorResponse(c, resp, http.StatusNotFound, `unknown model: "dead-beef-123456"`)
 }
@@ -267,7 +267,7 @@ func (s *toolsSuite) TestUploadSeriesExpanded(c *gc.C) {
 
 	// Check the response.
 	info := s.APIInfo(c)
-	expectedTools[0].URL = fmt.Sprintf("%s/environment/%s/tools/%s", s.baseURL(c), info.EnvironTag.Id(), vers)
+	expectedTools[0].URL = fmt.Sprintf("%s/model/%s/tools/%s", s.baseURL(c), info.EnvironTag.Id(), vers)
 	s.assertUploadResponse(c, resp, expectedTools[0])
 
 	// Check the contents.

--- a/apiserver/uniter/uniter_base.go
+++ b/apiserver/uniter/uniter_base.go
@@ -730,7 +730,7 @@ func (u *uniterBaseAPI) CharmArchiveURLs(args params.CharmURLs) (params.StringsR
 	if err != nil {
 		return params.StringsResults{}, err
 	}
-	envUUID := u.st.EnvironUUID()
+	modelUUID := u.st.EnvironUUID()
 	result := params.StringsResults{
 		Results: make([]params.StringsResult, len(args.URLs)),
 	}
@@ -740,8 +740,8 @@ func (u *uniterBaseAPI) CharmArchiveURLs(args params.CharmURLs) (params.StringsR
 			continue
 		}
 		urlPath := "/"
-		if envUUID != "" {
-			urlPath = path.Join(urlPath, "environment", envUUID)
+		if modelUUID != "" {
+			urlPath = path.Join(urlPath, "model", modelUUID)
 		}
 		urlPath = path.Join(urlPath, "charms")
 		archiveURLs := make([]string, len(apiHostPorts))

--- a/apiserver/uniter/uniter_base_test.go
+++ b/apiserver/uniter/uniter_base_test.go
@@ -1218,12 +1218,12 @@ func (s *uniterBaseSuite) testCharmArchiveURLs(
 	c.Assert(err, jc.ErrorIsNil)
 
 	wordpressURLs := []string{
-		fmt.Sprintf("https://0.1.2.3:1234/environment/%s/charms?file=%%2A&url=cs%%3Aquantal%%2Fwordpress-3", coretesting.EnvironmentTag.Id()),
-		fmt.Sprintf("https://1.2.3.5:1234/environment/%s/charms?file=%%2A&url=cs%%3Aquantal%%2Fwordpress-3", coretesting.EnvironmentTag.Id()),
+		fmt.Sprintf("https://0.1.2.3:1234/model/%s/charms?file=%%2A&url=cs%%3Aquantal%%2Fwordpress-3", coretesting.EnvironmentTag.Id()),
+		fmt.Sprintf("https://1.2.3.5:1234/model/%s/charms?file=%%2A&url=cs%%3Aquantal%%2Fwordpress-3", coretesting.EnvironmentTag.Id()),
 	}
 	dummyURLs := []string{
-		fmt.Sprintf("https://0.1.2.3:1234/environment/%s/charms?file=%%2A&url=local%%3Aquantal%%2Fdummy-1", coretesting.EnvironmentTag.Id()),
-		fmt.Sprintf("https://1.2.3.5:1234/environment/%s/charms?file=%%2A&url=local%%3Aquantal%%2Fdummy-1", coretesting.EnvironmentTag.Id()),
+		fmt.Sprintf("https://0.1.2.3:1234/model/%s/charms?file=%%2A&url=local%%3Aquantal%%2Fdummy-1", coretesting.EnvironmentTag.Id()),
+		fmt.Sprintf("https://1.2.3.5:1234/model/%s/charms?file=%%2A&url=local%%3Aquantal%%2Fdummy-1", coretesting.EnvironmentTag.Id()),
 	}
 
 	c.Assert(result, jc.DeepEquals, params.StringsResults{

--- a/apiserver/upgrader/upgrader_test.go
+++ b/apiserver/upgrader/upgrader_test.go
@@ -168,7 +168,7 @@ func (s *upgraderSuite) TestToolsForAgent(c *gc.C) {
 		c.Check(results.Results, gc.HasLen, 1)
 		c.Assert(results.Results[0].Error, gc.IsNil)
 		agentTools := results.Results[0].Tools
-		url := fmt.Sprintf("https://%s/environment/%s/tools/%s",
+		url := fmt.Sprintf("https://%s/model/%s/tools/%s",
 			s.APIState.Addr(), coretesting.EnvironmentTag.Id(), current)
 		c.Check(agentTools.URL, gc.Equals, url)
 		c.Check(agentTools.Version, gc.DeepEquals, current)

--- a/apiserver/utils.go
+++ b/apiserver/utils.go
@@ -37,49 +37,49 @@ func setPassword(e state.Authenticator, password string) error {
 
 type validateArgs struct {
 	statePool *state.StatePool
-	envUUID   string
+	modelUUID string
 	// strict validation does not allow empty UUID values
 	strict bool
-	// stateServerEnvOnly only validates the state server environment
-	stateServerEnvOnly bool
+	// controllerModelOnly only validates the controller model
+	controllerModelOnly bool
 }
 
-// validateEnvironUUID is the common validator for the various
-// apiserver components that need to check for a valid environment
-// UUID.  An empty envUUID means that the connection has come in at
-// the root of the URL space and refers to the state server
-// environment.
+// validateModelUUID is the common validator for the various
+// apiserver components that need to check for a valid model
+// UUID.  An empty modelUUID means that the connection has come in at
+// the root of the URL space and refers to the controller
+// model.
 //
-// It returns the validated environment UUID.
-func validateEnvironUUID(args validateArgs) (string, error) {
+// It returns the validated model UUID.
+func validateModelUUID(args validateArgs) (string, error) {
 	ssState := args.statePool.SystemState()
-	if args.envUUID == "" {
+	if args.modelUUID == "" {
 		// We allow the environUUID to be empty for 2 cases
 		// 1) Compatibility with older clients
-		// 2) TODO: server a limited API at the root (empty envUUID)
-		//    with just the user manager and environment manager
+		// 2) TODO: server a limited API at the root (empty modelUUID)
+		//    with just the user manager and model manager
 		//    if the connection comes over a sufficiently up to date
 		//    login command.
 		if args.strict {
-			return "", errors.Trace(common.UnknownEnvironmentError(args.envUUID))
+			return "", errors.Trace(common.UnknownModelError(args.modelUUID))
 		}
-		logger.Debugf("validate model uuid: empty envUUID")
+		logger.Debugf("validate model uuid: empty modelUUID")
 		return ssState.EnvironUUID(), nil
 	}
-	if args.envUUID == ssState.EnvironUUID() {
-		logger.Debugf("validate model uuid: state server model - %s", args.envUUID)
-		return args.envUUID, nil
+	if args.modelUUID == ssState.EnvironUUID() {
+		logger.Debugf("validate model uuid: controller model - %s", args.modelUUID)
+		return args.modelUUID, nil
 	}
-	if args.stateServerEnvOnly {
-		return "", errors.Unauthorizedf("requested model %q is not the state server model", args.envUUID)
+	if args.controllerModelOnly {
+		return "", errors.Unauthorizedf("requested model %q is not the controller model", args.modelUUID)
 	}
-	if !names.IsValidEnvironment(args.envUUID) {
-		return "", errors.Trace(common.UnknownEnvironmentError(args.envUUID))
+	if !names.IsValidEnvironment(args.modelUUID) {
+		return "", errors.Trace(common.UnknownModelError(args.modelUUID))
 	}
-	envTag := names.NewEnvironTag(args.envUUID)
+	envTag := names.NewEnvironTag(args.modelUUID)
 	if _, err := ssState.GetEnvironment(envTag); err != nil {
-		return "", errors.Wrap(err, common.UnknownEnvironmentError(args.envUUID))
+		return "", errors.Wrap(err, common.UnknownModelError(args.modelUUID))
 	}
-	logger.Debugf("validate model uuid: %s", args.envUUID)
-	return args.envUUID, nil
+	logger.Debugf("validate model uuid: %s", args.modelUUID)
+	return args.modelUUID, nil
 }

--- a/apiserver/utils_test.go
+++ b/apiserver/utils_test.go
@@ -25,7 +25,7 @@ func (s *utilsSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *utilsSuite) TestValidateEmpty(c *gc.C) {
-	uuid, err := validateEnvironUUID(
+	uuid, err := validateModelUUID(
 		validateArgs{
 			statePool: s.pool,
 		})
@@ -34,7 +34,7 @@ func (s *utilsSuite) TestValidateEmpty(c *gc.C) {
 }
 
 func (s *utilsSuite) TestValidateEmptyStrict(c *gc.C) {
-	_, err := validateEnvironUUID(
+	_, err := validateModelUUID(
 		validateArgs{
 			statePool: s.pool,
 			strict:    true,
@@ -42,58 +42,58 @@ func (s *utilsSuite) TestValidateEmptyStrict(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `unknown model: ""`)
 }
 
-func (s *utilsSuite) TestValidateStateServer(c *gc.C) {
-	uuid, err := validateEnvironUUID(
+func (s *utilsSuite) TestValidateController(c *gc.C) {
+	uuid, err := validateModelUUID(
 		validateArgs{
 			statePool: s.pool,
-			envUUID:   s.State.EnvironUUID(),
+			modelUUID: s.State.EnvironUUID(),
 		})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(uuid, gc.Equals, s.State.EnvironUUID())
 }
 
-func (s *utilsSuite) TestValidateStateServerStrict(c *gc.C) {
-	uuid, err := validateEnvironUUID(
+func (s *utilsSuite) TestValidateControllerStrict(c *gc.C) {
+	uuid, err := validateModelUUID(
 		validateArgs{
 			statePool: s.pool,
-			envUUID:   s.State.EnvironUUID(),
+			modelUUID: s.State.EnvironUUID(),
 			strict:    true,
 		})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(uuid, gc.Equals, s.State.EnvironUUID())
 }
 
-func (s *utilsSuite) TestValidateBadEnvUUID(c *gc.C) {
-	_, err := validateEnvironUUID(
+func (s *utilsSuite) TestValidateBadModelUUID(c *gc.C) {
+	_, err := validateModelUUID(
 		validateArgs{
 			statePool: s.pool,
-			envUUID:   "bad",
+			modelUUID: "bad",
 		})
 	c.Assert(err, gc.ErrorMatches, `unknown model: "bad"`)
 }
 
-func (s *utilsSuite) TestValidateOtherEnvironment(c *gc.C) {
+func (s *utilsSuite) TestValidateOtherModel(c *gc.C) {
 	envState := s.Factory.MakeEnvironment(c, nil)
 	defer envState.Close()
 
-	uuid, err := validateEnvironUUID(
+	uuid, err := validateModelUUID(
 		validateArgs{
 			statePool: s.pool,
-			envUUID:   envState.EnvironUUID(),
+			modelUUID: envState.EnvironUUID(),
 		})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(uuid, gc.Equals, envState.EnvironUUID())
 }
 
-func (s *utilsSuite) TestValidateOtherEnvironmentStateServerOnly(c *gc.C) {
+func (s *utilsSuite) TestValidateOtherModelControllerOnly(c *gc.C) {
 	envState := s.Factory.MakeEnvironment(c, nil)
 	defer envState.Close()
 
-	_, err := validateEnvironUUID(
+	_, err := validateModelUUID(
 		validateArgs{
-			statePool:          s.pool,
-			envUUID:            envState.EnvironUUID(),
-			stateServerEnvOnly: true,
+			statePool:           s.pool,
+			modelUUID:           envState.EnvironUUID(),
+			controllerModelOnly: true,
 		})
-	c.Assert(err, gc.ErrorMatches, `requested model ".*" is not the state server model`)
+	c.Assert(err, gc.ErrorMatches, `requested model ".*" is not the controller model`)
 }

--- a/container/image.go
+++ b/container/image.go
@@ -54,7 +54,7 @@ func (ug *imageURLGetter) ImageURL(kind instance.ContainerType, series, arch str
 	imageFilename := path.Base(imageURL)
 
 	imageUrl := fmt.Sprintf(
-		"https://%s/environment/%s/images/%v/%s/%s/%s", ug.config.ServerRoot, ug.config.EnvUUID, kind, series, arch, imageFilename,
+		"https://%s/model/%s/images/%v/%s/%s/%s", ug.config.ServerRoot, ug.config.EnvUUID, kind, series, arch, imageFilename,
 	)
 	return imageUrl, nil
 }

--- a/container/image_test.go
+++ b/container/image_test.go
@@ -33,7 +33,7 @@ func (s *imageURLSuite) TestImageURL(c *gc.C) {
 		})
 	imageURL, err := imageURLGetter.ImageURL(instance.LXC, "trusty", "amd64")
 	c.Assert(err, gc.IsNil)
-	c.Assert(imageURL, gc.Equals, "https://host:port/environment/12345/images/lxc/trusty/amd64/trusty-released-amd64-root.tar.gz")
+	c.Assert(imageURL, gc.Equals, "https://host:port/model/12345/images/lxc/trusty/amd64/trusty-released-amd64-root.tar.gz")
 	c.Assert(imageURLGetter.CACert(), gc.DeepEquals, []byte("cert"))
 }
 
@@ -50,7 +50,7 @@ func (s *imageURLSuite) TestImageURLOtherBase(c *gc.C) {
 		})
 	imageURL, err := imageURLGetter.ImageURL(instance.LXC, "trusty", "amd64")
 	c.Assert(err, gc.IsNil)
-	c.Assert(imageURL, gc.Equals, "https://host:port/environment/12345/images/lxc/trusty/amd64/trusty-released-amd64-root.tar.gz")
+	c.Assert(imageURL, gc.Equals, "https://host:port/model/12345/images/lxc/trusty/amd64/trusty-released-amd64-root.tar.gz")
 	c.Assert(imageURLGetter.CACert(), gc.DeepEquals, []byte("cert"))
 	c.Assert(calledBaseURL, gc.Equals, baseURL)
 }

--- a/doc/logging-in-to-the-apiserver.txt
+++ b/doc/logging-in-to-the-apiserver.txt
@@ -34,7 +34,7 @@ Server struct has a map of adminApiFactories. This currently has keys of
 The Server instance is created with NewServer, and listens on the API port.
 
 The incoming socket connection is handled inside the (*Server).run method.
- - "/environment/:envuuid/api" -> srv.apiHandler
+ - "/model/:modeluuid/api" -> srv.apiHandler
  - "/" -> srv.apiHandler
 
 The apiHandler creates a go routine for handling the socket connection, and

--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -231,7 +231,7 @@ const (
 	HarvestUnknown
 	// HarvestDestroyed signifies that Juju should only harvest
 	// machines which have been explicitly released by the user
-	// through a destroy of a service/environment/unit.
+	// through a destroy of a service/model/unit.
 	HarvestDestroyed
 	// HarvestAll signifies that Juju should harvest both unknown and
 	// destroyed instances. ♫ Don't fear the reaper. ♫

--- a/state/environ.go
+++ b/state/environ.go
@@ -132,7 +132,7 @@ func (st *State) NewEnvironment(cfg *config.Config, owner names.UserTag) (_ *Env
 
 	ssEnv, err := st.ControllerEnvironment()
 	if err != nil {
-		return nil, nil, errors.Annotate(err, "could not load state server model")
+		return nil, nil, errors.Annotate(err, "could not load controller model")
 	}
 
 	uuid, ok := cfg.UUID()

--- a/state/open.go
+++ b/state/open.go
@@ -132,7 +132,7 @@ func Initialize(owner names.UserTag, info *mongo.MongoInfo, cfg *config.Config, 
 
 	// When creating the state server environment, the new environment
 	// UUID is also used as the state server UUID.
-	logger.Infof("initializing state server model %s", uuid)
+	logger.Infof("initializing controller model %s", uuid)
 	ops, err := st.envSetupOps(cfg, uuid, uuid, owner)
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/state/user.go
+++ b/state/user.go
@@ -361,7 +361,7 @@ func (u *User) Disable() error {
 		return errors.Trace(err)
 	}
 	if u.doc.Name == environment.Owner().Name() {
-		return errors.Unauthorizedf("cannot disable state server model owner")
+		return errors.Unauthorizedf("cannot disable controller model owner")
 	}
 	return errors.Annotatef(u.setDeactivated(true), "cannot disable user %q", u.Name())
 }

--- a/state/user_test.go
+++ b/state/user_test.go
@@ -205,7 +205,7 @@ func (s *UserSuite) TestCantDisableAdmin(c *gc.C) {
 	user, err := s.State.User(s.Owner)
 	c.Assert(err, jc.ErrorIsNil)
 	err = user.Disable()
-	c.Assert(err, gc.ErrorMatches, "cannot disable state server model owner")
+	c.Assert(err, gc.ErrorMatches, "cannot disable controller model owner")
 }
 
 func (s *UserSuite) TestCaseSensitiveUsersErrors(c *gc.C) {

--- a/worker/provisioner/provisioner_test.go
+++ b/worker/provisioner/provisioner_test.go
@@ -261,7 +261,7 @@ func (s *CommonProvisionerSuite) checkStartInstanceCustom(
 
 				if checkPossibleTools != nil {
 					for _, t := range o.PossibleTools {
-						url := fmt.Sprintf("https://%s/environment/%s/tools/%s",
+						url := fmt.Sprintf("https://%s/model/%s/tools/%s",
 							s.st.Addr(), coretesting.EnvironmentTag.Id(), t.Version)
 						c.Check(t.URL, gc.Equals, url)
 						t.URL = ""

--- a/worker/upgrader/upgrader_test.go
+++ b/worker/upgrader/upgrader_test.go
@@ -182,7 +182,7 @@ func (s *UpgraderSuite) TestUpgraderUpgradesImmediately(c *gc.C) {
 	})
 	foundTools, err := agenttools.ReadTools(s.DataDir(), newTools.Version)
 	c.Assert(err, jc.ErrorIsNil)
-	newTools.URL = fmt.Sprintf("https://%s/environment/%s/tools/5.4.5-precise-amd64",
+	newTools.URL = fmt.Sprintf("https://%s/model/%s/tools/5.4.5-precise-amd64",
 		s.APIState.Addr(), coretesting.EnvironmentTag.Id())
 	envtesting.CheckTools(c, foundTools, newTools)
 }
@@ -333,7 +333,7 @@ func (s *UpgraderSuite) TestUpgraderAllowsDowngradingPatchVersions(c *gc.C) {
 	})
 	foundTools, err := agenttools.ReadTools(s.DataDir(), downgradeTools.Version)
 	c.Assert(err, jc.ErrorIsNil)
-	downgradeTools.URL = fmt.Sprintf("https://%s/environment/%s/tools/5.4.2-precise-amd64",
+	downgradeTools.URL = fmt.Sprintf("https://%s/model/%s/tools/5.4.2-precise-amd64",
 		s.APIState.Addr(), coretesting.EnvironmentTag.Id())
 	envtesting.CheckTools(c, foundTools, downgradeTools)
 }
@@ -363,7 +363,7 @@ func (s *UpgraderSuite) TestUpgraderAllowsDowngradeToOrigVersionIfUpgradeInProgr
 	})
 	foundTools, err := agenttools.ReadTools(s.DataDir(), downgradeTools.Version)
 	c.Assert(err, jc.ErrorIsNil)
-	downgradeTools.URL = fmt.Sprintf("https://%s/environment/%s/tools/5.3.0-precise-amd64",
+	downgradeTools.URL = fmt.Sprintf("https://%s/model/%s/tools/5.3.0-precise-amd64",
 		s.APIState.Addr(), coretesting.EnvironmentTag.Id())
 	envtesting.CheckTools(c, foundTools, downgradeTools)
 }


### PR DESCRIPTION
Rename the controller http endpoints from ipaddress/environment/blah to ipaddress/model/blah
Misc other associated changes.
Subsequent branches have or will take care of the other renames eg EnvironTag -> ModelTag

(Review request: http://reviews.vapour.ws/r/3617/)