### PR TITLE
apiserver: Fix Bug 1535165

### DIFF
--- a/apiserver/environmentmanager/environmentmanager.go
+++ b/apiserver/environmentmanager/environmentmanager.go
@@ -254,6 +254,18 @@ func (em *EnvironmentManagerAPI) newEnvironmentConfig(args params.EnvironmentCre
 		}
 	}
 
+	// Generate the UUID for the server.
+	uuid, err := utils.NewUUID()
+	if err != nil {
+		return nil, errors.Annotate(err, "failed to generate environment uuid")
+	}
+	joint["uuid"] = uuid.String()
+
+	if err := em.checkVersion(joint); err != nil {
+		return nil, errors.Annotate(err, "failed to create config")
+	}
+
+	// validConfig must only be called once.
 	cfg, err := em.validConfig(joint)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -271,18 +283,8 @@ func (em *EnvironmentManagerAPI) newEnvironmentConfig(args params.EnvironmentCre
 			}
 		}
 	}
-	if err := em.checkVersion(attrs); err != nil {
-		return nil, errors.Trace(err)
-	}
 
-	// Generate the UUID for the server.
-	uuid, err := utils.NewUUID()
-	if err != nil {
-		return nil, errors.Annotate(err, "failed to generate environment uuid")
-	}
-	attrs["uuid"] = uuid.String()
-
-	return em.validConfig(attrs)
+	return cfg, nil
 }
 
 // CreateEnvironment creates a new environment using the account and

--- a/apiserver/environmentmanager/environmentmanager_test.go
+++ b/apiserver/environmentmanager/environmentmanager_test.go
@@ -280,16 +280,16 @@ func (s *envManagerSuite) TestCreateEnvironmentBadAgentVersion(c *gc.C) {
 	}{
 		{
 			value:    42,
-			errMatch: `creating config from values failed: agent-version: expected string, got int\(42\)`,
+			errMatch: `failed to create config: agent-version must be a string but has type 'int'`,
 		}, {
 			value:    "not a number",
-			errMatch: `creating config from values failed: invalid agent version in environment configuration: "not a number"`,
+			errMatch: `failed to create config: invalid version \"not a number\"`,
 		}, {
 			value:    bigger.String(),
-			errMatch: "agent-version cannot be greater than the server: .*",
+			errMatch: "failed to create config: agent-version cannot be greater than the server: .*",
 		}, {
 			value:    smaller.String(),
-			errMatch: "no tools found for version .*",
+			errMatch: "failed to create config: no tools found for version .*",
 		},
 	} {
 		c.Logf("test %d", i)

--- a/provider/azure/environprovider.go
+++ b/provider/azure/environprovider.go
@@ -87,12 +87,6 @@ func (prov *azureEnvironProvider) RestrictedConfigAttributes() []string {
 
 // PrepareForCreateEnvironment is specified in the EnvironProvider interface.
 func (prov *azureEnvironProvider) PrepareForCreateEnvironment(cfg *config.Config) (*config.Config, error) {
-	if _, ok := cfg.UUID(); !ok {
-		// TODO(axw) PrepareForCreateEnvironment is called twice; once before
-		// the UUID is set, and once after. It probably should just be called
-		// after?
-		return cfg, nil
-	}
 	env, err := newEnviron(prov, cfg)
 	if err != nil {
 		return nil, errors.Annotate(err, "opening environment")


### PR DESCRIPTION
When creating a new environment, PrepareForCreateEnvironment was being called
twice. For MaaS this method first checked that maas-agent-name was not set and
then set it. This would then fail the second time it was called.

Refactor EnvironmentManagerAPI.newEnvironmentConfig so
PrepareForCreateEnvironment is only called once.

(Review request: http://reviews.vapour.ws/r/3621/)