### PR TITLE
lp1494726 - Convert x-javascript to javascript

### DIFF
--- a/apiserver/charms.go
+++ b/apiserver/charms.go
@@ -179,6 +179,11 @@ func (h *charmsHandler) archiveEntrySender(filePath string) bundleContentSenderF
 			defer contents.Close()
 			ctype := mime.TypeByExtension(filepath.Ext(filePath))
 			if ctype != "" {
+				// Older mime.types may map .js to x-javascript.
+				// Map it to javascript for consistency.
+				if ctype == params.ContentTypeXJS {
+					ctype = params.ContentTypeJS
+				}
 				w.Header().Set("Content-Type", ctype)
 			}
 			w.Header().Set("Content-Length", strconv.FormatInt(fileInfo.Size(), 10))

--- a/apiserver/charms_test.go
+++ b/apiserver/charms_test.go
@@ -491,7 +491,7 @@ func (s *charmsSuite) TestGetUsesCache(c *gc.C) {
 	// Ensure the cached contents are properly retrieved.
 	uri := s.charmsURI(c, "?url=local:trusty/django-42&file=utils.js")
 	resp := s.authRequest(c, httpRequestParams{method: "GET", url: uri})
-	s.assertGetFileResponse(c, resp, contents, "application/javascript")
+	s.assertGetFileResponse(c, resp, contents, params.ContentTypeJS)
 }
 
 type charmsWithMacaroonsSuite struct {

--- a/apiserver/params/http.go
+++ b/apiserver/params/http.go
@@ -21,6 +21,13 @@ const (
 
 	// ContentTypeJSON is the HTTP content-type value used for JSON content.
 	ContentTypeJSON = "application/json"
+
 	// ContentTypeRaw is the HTTP content-type value used for raw, unformattedcontent.
 	ContentTypeRaw = "application/octet-stream"
+
+	// ContentTypeJS is the HTTP content-type value used for javascript.
+	ContentTypeJS = "application/javascript"
+
+	// ContentTypeXJS is the outdated HTTP content-type value used for javascript.
+	ContentTypeXJS = "application/x-javascript"
 )


### PR DESCRIPTION
Older mime.types will map the .js file
extension to x-javascript.  Convert to
javascript for consistency.

(Review request: http://reviews.vapour.ws/r/3627/)