### PR TITLE
Revert rename of environments.yaml -> models.yaml

### DIFF
--- a/cmd/envcmd/controller_test.go
+++ b/cmd/envcmd/controller_test.go
@@ -32,7 +32,7 @@ func (s *ControllerCommandSuite) TestControllerCommandInitMultipleConfigs(c *gc.
 func (s *ControllerCommandSuite) TestControllerCommandInitNoEnvFile(c *gc.C) {
 	// Since we ignore the environments.yaml file, we don't care if it isn't
 	// there.
-	envPath := gitjujutesting.HomePath(".juju", "models.yaml")
+	envPath := gitjujutesting.HomePath(".juju", "environments.yaml")
 	err := os.Remove(envPath)
 	_, err = initTestControllerCommand(c)
 	c.Assert(err, gc.ErrorMatches, "no controller specified")

--- a/cmd/envcmd/environmentcommand.go
+++ b/cmd/envcmd/environmentcommand.go
@@ -33,7 +33,7 @@ var ErrNoEnvironmentSpecified = errors.New("no model specified")
 // There is simple ordering for the default environment.  Firstly check the
 // JUJU_MODEL environment variable.  If that is set, it gets used.  If it isn't
 // set, look in the $JUJU_HOME/current-model file.  If neither are
-// available, read models.yaml and use the default environment therein.
+// available, read environments.yaml and use the default environment therein.
 // If no default is specified in the environments file, an empty string is returned.
 // Not having a default environment specified is not an error.
 func GetDefaultEnvironment() (string, error) {

--- a/cmd/envcmd/environmentcommand_test.go
+++ b/cmd/envcmd/environmentcommand_test.go
@@ -46,7 +46,7 @@ func (s *EnvironmentCommandSuite) TestGetDefaultEnvironment(c *gc.C) {
 }
 
 func (s *EnvironmentCommandSuite) TestGetDefaultEnvironmentNothingSet(c *gc.C) {
-	envPath := gitjujutesting.HomePath(".juju", "models.yaml")
+	envPath := gitjujutesting.HomePath(".juju", "environments.yaml")
 	err := os.Remove(envPath)
 	c.Assert(err, jc.ErrorIsNil)
 	env, err := envcmd.GetDefaultEnvironment()
@@ -117,7 +117,7 @@ func (s *EnvironmentCommandSuite) TestEnvironCommandInitControllerFile(c *gc.C) 
 }
 
 func (s *EnvironmentCommandSuite) TestEnvironCommandInitNoEnvFile(c *gc.C) {
-	envPath := gitjujutesting.HomePath(".juju", "models.yaml")
+	envPath := gitjujutesting.HomePath(".juju", "environments.yaml")
 	err := os.Remove(envPath)
 	c.Assert(err, jc.ErrorIsNil)
 	testEnsureEnvName(c, "")

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -63,7 +63,7 @@ about the current installation steps.  The time for bootstrap to complete varies
 across cloud providers from a few seconds to several minutes.  Once bootstrap has
 completed, you can run other juju commands against your model. You can change
 the default timeout and retry delays used during the bootstrap by changing the
-following settings in your models.yaml (all values represent number of seconds):
+following settings in your environments.yaml (all values represent number of seconds):
 
     # How long to wait for a connection to the controller
     bootstrap-timeout: 600 # default: 10 minutes

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -570,7 +570,7 @@ func (s *BootstrapSuite) TestBootstrapJenvWarning(c *gc.C) {
 
 	_, errc := cmdtesting.RunCommand(ctx, newBootstrapCommand(), "-m", envName, "--auto-upgrade")
 	c.Assert(<-errc, gc.IsNil)
-	c.Assert(testWriter.Log(), jc.LogMatches, []string{"ignoring models.yaml: using bootstrap config in .*"})
+	c.Assert(testWriter.Log(), jc.LogMatches, []string{"ignoring environments.yaml: using bootstrap config in .*"})
 }
 
 func (s *BootstrapSuite) TestInvalidLocalSource(c *gc.C) {

--- a/cmd/juju/commands/common.go
+++ b/cmd/juju/commands/common.go
@@ -81,7 +81,7 @@ func environFromNameProductionFunc(
 	if environInfo, err := store.ReadInfo(envName); err == nil {
 		envExisted = true
 		logger.Warningf(
-			"ignoring models.yaml: using bootstrap config in %s",
+			"ignoring environments.yaml: using bootstrap config in %s",
 			environInfo.Location(),
 		)
 	} else if !errors.IsNotFound(err) {

--- a/cmd/juju/commands/init.go
+++ b/cmd/juju/commands/init.go
@@ -32,13 +32,13 @@ func (c *initCommand) Info() *cmd.Info {
 }
 
 func (c *initCommand) SetFlags(f *gnuflag.FlagSet) {
-	f.BoolVar(&c.WriteFile, "f", false, "force overwriting models.yaml file even if it exists (ignored if --show flag specified)")
+	f.BoolVar(&c.WriteFile, "f", false, "force overwriting environments.yaml file even if it exists (ignored if --show flag specified)")
 	f.BoolVar(&c.Show, "show", false, "print the generated configuration data to stdout instead of writing it to a file")
 }
 
 var errJujuEnvExists = fmt.Errorf(`A juju model configuration already exists.
 
-Use -f to overwrite the existing models.yaml.
+Use -f to overwrite the existing environments.yaml.
 `)
 
 // Run checks to see if there is already an environments.yaml file. In one does not exist already,

--- a/cmd/juju/commands/init_test.go
+++ b/cmd/juju/commands/init_test.go
@@ -26,7 +26,7 @@ var _ = gc.Suite(&InitSuite{})
 // The environments.yaml is created by default if it
 // does not already exist.
 func (*InitSuite) TestBoilerPlateEnvironment(c *gc.C) {
-	envPath := gitjujutesting.HomePath(".juju", "models.yaml")
+	envPath := gitjujutesting.HomePath(".juju", "environments.yaml")
 	err := os.Remove(envPath)
 	c.Assert(err, jc.ErrorIsNil)
 	ctx := testing.Context(c)
@@ -35,7 +35,7 @@ func (*InitSuite) TestBoilerPlateEnvironment(c *gc.C) {
 	outStr := ctx.Stdout.(*bytes.Buffer).String()
 	strippedOut := strings.Replace(outStr, "\n", "", -1)
 	c.Check(strippedOut, gc.Matches, ".*A boilerplate model configuration file has been written.*")
-	environpath := gitjujutesting.HomePath(".juju", "models.yaml")
+	environpath := gitjujutesting.HomePath(".juju", "environments.yaml")
 	data, err := ioutil.ReadFile(environpath)
 	c.Assert(err, jc.ErrorIsNil)
 	strippedData := strings.Replace(string(data), "\n", "", -1)
@@ -45,7 +45,7 @@ func (*InitSuite) TestBoilerPlateEnvironment(c *gc.C) {
 // The boilerplate is sent to stdout with --show, and the environments.yaml
 // is not created.
 func (*InitSuite) TestBoilerPlatePrinted(c *gc.C) {
-	envPath := gitjujutesting.HomePath(".juju", "models.yaml")
+	envPath := gitjujutesting.HomePath(".juju", "environments.yaml")
 	err := os.Remove(envPath)
 	c.Assert(err, jc.ErrorIsNil)
 	ctx := testing.Context(c)
@@ -54,7 +54,7 @@ func (*InitSuite) TestBoilerPlatePrinted(c *gc.C) {
 	outStr := ctx.Stdout.(*bytes.Buffer).String()
 	strippedOut := strings.Replace(outStr, "\n", "", -1)
 	c.Check(strippedOut, gc.Matches, ".*# This is the Juju config file, which you can use.*")
-	environpath := gitjujutesting.HomePath(".juju", "models.yaml")
+	environpath := gitjujutesting.HomePath(".juju", "environments.yaml")
 	_, err = ioutil.ReadFile(environpath)
 	c.Assert(err, gc.NotNil)
 }
@@ -78,7 +78,7 @@ func (*InitSuite) TestExistingEnvironmentNotOverwritten(c *gc.C) {
 	errOut := ctx.Stderr.(*bytes.Buffer).String()
 	strippedOut := strings.Replace(errOut, "\n", "", -1)
 	c.Check(strippedOut, gc.Matches, ".*A juju model configuration already exists.*")
-	environpath := gitjujutesting.HomePath(".juju", "models.yaml")
+	environpath := gitjujutesting.HomePath(".juju", "environments.yaml")
 	data, err := ioutil.ReadFile(environpath)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(data), gc.Equals, existingEnv)
@@ -95,7 +95,7 @@ func (*InitSuite) TestExistingEnvironmentOverwritten(c *gc.C) {
 	stdOut := ctx.Stdout.(*bytes.Buffer).String()
 	strippedOut := strings.Replace(stdOut, "\n", "", -1)
 	c.Check(strippedOut, gc.Matches, ".*A boilerplate model configuration file has been written.*")
-	environpath := gitjujutesting.HomePath(".juju", "models.yaml")
+	environpath := gitjujutesting.HomePath(".juju", "environments.yaml")
 	data, err := ioutil.ReadFile(environpath)
 	c.Assert(err, jc.ErrorIsNil)
 	strippedData := strings.Replace(string(data), "\n", "", -1)

--- a/cmd/juju/commands/switch.go
+++ b/cmd/juju/commands/switch.go
@@ -35,7 +35,7 @@ model as defined by the file $JUJU_HOME/current-model.
 
 If a command line parameter is passed in, that value will is stored in the
 current model file if it represents a valid model name as
-specified in the models.yaml file.
+specified in the environments.yaml file.
 `
 
 const controllerSuffix = " (controller)"

--- a/cmd/juju/commands/switch_test.go
+++ b/cmd/juju/commands/switch_test.go
@@ -24,7 +24,7 @@ type SwitchSimpleSuite struct {
 var _ = gc.Suite(&SwitchSimpleSuite{})
 
 func (s *SwitchSimpleSuite) TestNoEnvironmentReadsConfigStore(c *gc.C) {
-	envPath := gitjujutesting.HomePath(".juju", "models.yaml")
+	envPath := gitjujutesting.HomePath(".juju", "environments.yaml")
 	err := os.Remove(envPath)
 	c.Assert(err, jc.ErrorIsNil)
 	s.addTestController(c)
@@ -38,7 +38,7 @@ func (s *SwitchSimpleSuite) TestErrorReadingEnvironmentsFile(c *gc.C) {
 		c.Skip("bug 1496997: os.Chmod doesn't exist on windows, checking this on one platform is sufficent to test this case")
 	}
 
-	envPath := gitjujutesting.HomePath(".juju", "models.yaml")
+	envPath := gitjujutesting.HomePath(".juju", "environments.yaml")
 	err := os.Chmod(envPath, 0)
 	c.Assert(err, jc.ErrorIsNil)
 	s.addTestController(c)
@@ -53,7 +53,7 @@ func (*SwitchSimpleSuite) TestNoDefault(c *gc.C) {
 }
 
 func (*SwitchSimpleSuite) TestNoDefaultNoEnvironmentsFile(c *gc.C) {
-	envPath := gitjujutesting.HomePath(".juju", "models.yaml")
+	envPath := gitjujutesting.HomePath(".juju", "environments.yaml")
 	err := os.Remove(envPath)
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = testing.RunCommand(c, newSwitchCommand())

--- a/cmd/juju/environment/jenv_test.go
+++ b/cmd/juju/environment/jenv_test.go
@@ -182,7 +182,7 @@ func (*jenvSuite) TestSwitchErrorEnvironmentsNotReadable(c *gc.C) {
 	defer f.Close()
 
 	// Remove write permissions to the environments.yaml file.
-	envPath := gitjujutesting.HomePath(".juju", "models.yaml")
+	envPath := gitjujutesting.HomePath(".juju", "environments.yaml")
 	err := os.Chmod(envPath, 0200)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -282,7 +282,7 @@ func (*jenvSuite) TestSuccessNoJujuEnvironments(c *gc.C) {
 	defer f.Close()
 
 	// Remove the Juju environments.yaml file.
-	envPath := gitjujutesting.HomePath(".juju", "models.yaml")
+	envPath := gitjujutesting.HomePath(".juju", "environments.yaml")
 	err := os.Remove(envPath)
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/cmd/juju/helptopics/glossary.go
+++ b/cmd/juju/helptopics/glossary.go
@@ -58,7 +58,7 @@ Model
   a single Model configured, or when a default is explicitly defined.
   Depending on the type of Model, it may have to be bootstrapped before
   interactions with it may take place (e.g. EC2). The local model
-  configuration is defined in the ~/.juju/models.yaml file.
+  configuration is defined in the ~/.juju/environments.yaml file.
 
 Machine Agent
   Software which runs inside each machine that is part of a Model, and is

--- a/cmd/juju/helptopics/logging.go
+++ b/cmd/juju/helptopics/logging.go
@@ -99,7 +99,7 @@ logging setup configured for the model.
 You can configure Juju's logging system using a number of different
 mechanisms:
 
-models.yaml
+environments.yaml
   - all models support 'logging-config' as a key
 model variable
   - export JUJU_LOGGING_CONFIG='...'

--- a/cmd/juju/helptopics/providers.go
+++ b/cmd/juju/helptopics/providers.go
@@ -18,7 +18,7 @@ Start by generating a generic configuration file for Juju, using the command:
   juju init
 
 This will create the '~/.juju/' directory (or $JUJU_HOME, if set) if it doesn't
-already exist and generate a file, 'models.yaml' in that directory.
+already exist and generate a file, 'environments.yaml' in that directory.
 `
 const helpProviderEnd = `
 See Also:
@@ -148,7 +148,7 @@ const helpEC2Provider = `
 Configuring the EC2 model requires telling Juju about your AWS access key
 and secret key. To do this, you can either set the 'AWS_ACCESS_KEY_ID' and
 'AWS_SECRET_ACCESS_KEY' model variables[1] (as usual for other EC2 tools)
-or you can add access-key and secret-key options to your models.yaml.
+or you can add access-key and secret-key options to your environments.yaml.
 These are already in place in the generated config, you just need to uncomment
 them out. For example:
 
@@ -258,7 +258,7 @@ A generic Windows Azure model looks like this:
     #
     # agent-stream: "released"
 
-This is the models.yaml configuration file needed to run on Windows Azure.
+This is the environments.yaml configuration file needed to run on Windows Azure.
 You will need to set application-id, application-password, subscription-id,
 and tenant-id.
 

--- a/cmd/plugins/juju-metadata/imagemetadata.go
+++ b/cmd/plugins/juju-metadata/imagemetadata.go
@@ -62,7 +62,7 @@ var imageMetadataDoc = `
 generate-image creates simplestreams image metadata for the specified cloud.
 
 The cloud specification comes from the current Juju model, as specified in
-the usual way from either ~/.juju/models.yaml, the -m option, or JUJU_MODEL.
+the usual way from either ~/.juju/environments.yaml, the -m option, or JUJU_MODEL.
 
 Using command arguments, it is possible to override cloud attributes region, endpoint, and series.
 By default, "amd64" is used for the architecture but this may also be changed.
@@ -162,7 +162,7 @@ image metadata search path. There are 2 options:
 1. Use the --metadata-source parameter when bootstrapping:
    juju bootstrap --metadata-source %s
 
-2. Use image-metadata-url in $JUJU_HOME/models.yaml
+2. Use image-metadata-url in $JUJU_HOME/environments.yaml
 Configure a http server to serve the contents of
 %s
 and set the value of image-metadata-url accordingly.

--- a/cmd/plugins/juju-metadata/validateimagemetadata.go
+++ b/cmd/plugins/juju-metadata/validateimagemetadata.go
@@ -42,7 +42,7 @@ validate-images loads simplestreams metadata and validates the contents by
 looking for images belonging to the specified cloud.
 
 The cloud specification comes from the current Juju model, as specified in
-the usual way from either ~/.juju/models.yaml, the -m option, or JUJU_MODEL.
+the usual way from either ~/.juju/environments.yaml, the -m option, or JUJU_MODEL.
 Series, Region, and Endpoint are the key attributes.
 
 The key model attributes may be overridden using command arguments, so

--- a/cmd/plugins/juju-metadata/validatetoolsmetadata.go
+++ b/cmd/plugins/juju-metadata/validatetoolsmetadata.go
@@ -49,7 +49,7 @@ version are found. It is also possible to just specify the major (and optionally
 minor) version numbers to search for.
 
 The cloud specification comes from the current Juju model, as specified in
-the usual way from either ~/.juju/models.yaml, the -m option, or JUJU_MODEL.
+the usual way from either ~/.juju/environments.yaml, the -m option, or JUJU_MODEL.
 Series, Region, and Endpoint are the key attributes.
 
 It is possible to specify a local directory containing tools metadata, in which

--- a/doc/glossary.txt
+++ b/doc/glossary.txt
@@ -102,7 +102,7 @@ need to be immutable, and I'm not sure whether that's implemented yet.]
 
 A `models file` is a YAML file containing model configurations.
 Juju cannot operate without a valid models file, which must be saved at
-`~/.juju/models.yaml` on the client machine.
+`~/.juju/environments.yaml` on the client machine.
 
 The simplest functional models file looks like this:
 

--- a/doc/simplestreams-metadata.txt
+++ b/doc/simplestreams-metadata.txt
@@ -123,7 +123,7 @@ and vice versa.
 
 2. User specified URLs
 
-These are initially specified in the models.yaml file (and then subsequently copied to the
+These are initially specified in the environments.yaml file (and then subsequently copied to the
 jenv file when the model is bootstrapped). For images, use "image-metadata-url"; for tools,
 use "agent-metadata-url". The URLs can point to a world readable container/bucket in the cloud,
 an address served by a http server, or even a shared directory accessible by all node instances

--- a/environs/config.go
+++ b/environs/config.go
@@ -294,7 +294,7 @@ func ReadEnvironsBytes(data []byte) (*Environs, error) {
 
 func environsPath(path string) string {
 	if path == "" {
-		path = osenv.JujuHomePath("models.yaml")
+		path = osenv.JujuHomePath("environments.yaml")
 	}
 	return path
 }

--- a/environs/config_test.go
+++ b/environs/config_test.go
@@ -156,7 +156,7 @@ environments:
 }
 
 func (*suite) TestNoEnv(c *gc.C) {
-	envPath := gitjujutesting.HomePath(".juju", "models.yaml")
+	envPath := gitjujutesting.HomePath(".juju", "environments.yaml")
 	err := os.Remove(envPath)
 	c.Assert(err, jc.ErrorIsNil)
 	es, err := environs.ReadEnvirons("")
@@ -227,7 +227,7 @@ environments:
 `
 	outfile, err := environs.WriteEnvirons("", env)
 	c.Assert(err, jc.ErrorIsNil)
-	path := gitjujutesting.HomePath(".juju", "models.yaml")
+	path := gitjujutesting.HomePath(".juju", "environments.yaml")
 	c.Assert(path, gc.Equals, outfile)
 
 	envs, err := environs.ReadEnvirons("")

--- a/juju/api_test.go
+++ b/juju/api_test.go
@@ -717,7 +717,7 @@ func (s *NewAPIClientSuite) TestWithBootstrapConfigAndNoEnvironmentsFile(c *gc.C
 	c.Assert(info.BootstrapConfig(), gc.NotNil)
 	c.Assert(info.APIEndpoint().Addresses, gc.HasLen, 0)
 
-	err = os.Remove(osenv.JujuHomePath("models.yaml"))
+	err = os.Remove(osenv.JujuHomePath("environments.yaml"))
 	c.Assert(err, jc.ErrorIsNil)
 
 	apiOpen := func(*api.Info, api.DialOpts) (api.Connection, error) {

--- a/juju/osenv/home_test.go
+++ b/juju/osenv/home_test.go
@@ -29,15 +29,15 @@ func (s *JujuHomeSuite) TestErrorHome(c *gc.C) {
 	// Invalid juju home leads to panic when retrieving.
 	f := func() { _ = osenv.JujuHome() }
 	c.Assert(f, gc.PanicMatches, "juju home hasn't been initialized")
-	f = func() { _ = osenv.JujuHomePath("models.yaml") }
+	f = func() { _ = osenv.JujuHomePath("environments.yaml") }
 	c.Assert(f, gc.PanicMatches, "juju home hasn't been initialized")
 }
 
 func (s *JujuHomeSuite) TestHomePath(c *gc.C) {
 	testJujuHome := c.MkDir()
 	osenv.SetJujuHome(testJujuHome)
-	envPath := osenv.JujuHomePath("models.yaml")
-	c.Assert(envPath, gc.Equals, filepath.Join(testJujuHome, "models.yaml"))
+	envPath := osenv.JujuHomePath("environments.yaml")
+	c.Assert(envPath, gc.Equals, filepath.Join(testJujuHome, "environments.yaml"))
 }
 
 func (s *JujuHomeSuite) TestIsHomeSet(c *gc.C) {

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -227,7 +227,7 @@ func (s *JujuConnSuite) setUpConn(c *gc.C) {
 
 	// TODO(rog) remove these files and add them only when
 	// the tests specifically need them (in cmd/juju for example)
-	s.writeSampleConfig(c, osenv.JujuHomePath("models.yaml"))
+	s.writeSampleConfig(c, osenv.JujuHomePath("environments.yaml"))
 
 	err = ioutil.WriteFile(osenv.JujuHomePath("dummymodel-cert.pem"), []byte(testing.CACert), 0666)
 	c.Assert(err, jc.ErrorIsNil)
@@ -581,9 +581,9 @@ func (s *JujuConnSuite) ConfDir() string {
 // WriteConfig writes a juju config file to the "home" directory.
 func (s *JujuConnSuite) WriteConfig(configData string) {
 	if s.RootDir == "" {
-		panic("SetUpTest has not been called; will not overwrite $JUJU_HOME/models.yaml")
+		panic("SetUpTest has not been called; will not overwrite $JUJU_HOME/environments.yaml")
 	}
-	path := osenv.JujuHomePath("models.yaml")
+	path := osenv.JujuHomePath("environments.yaml")
 	err := ioutil.WriteFile(path, []byte(configData), 0600)
 	if err != nil {
 		panic(err)

--- a/scripts/jujuman.py
+++ b/scripts/jujuman.py
@@ -144,7 +144,7 @@ such as OpenStack, Amazon AWS, or bare metal.
 man_foot = """\
 .SH "FILES"
 .TP
-.I "~/.juju/models.yaml"
+.I "~/.juju/environments.yaml"
 This is the Juju config file, which you can use to specify multiple
 models in which to deploy.
 

--- a/scripts/win-installer/README.txt
+++ b/scripts/win-installer/README.txt
@@ -10,13 +10,13 @@ This tutorial will show you how to get started with Juju, including installing, 
 
 Configuring
 
-Now the Juju software is installed, it needs to be configured to use your particular cloud provider. This is done by generating and editing a file, "models.yaml", which will live in your %LOCALAPPDATA%\Juju directory. You can generate the models file manually, but Juju also includes a boilerplate configuration option that will flesh out most of the file for you and minimise the amount of work (and potential errors).
+Now the Juju software is installed, it needs to be configured to use your particular cloud provider. This is done by generating and editing a file, "environments.yaml", which will live in your %LOCALAPPDATA%\Juju directory. You can generate the models file manually, but Juju also includes a boilerplate configuration option that will flesh out most of the file for you and minimise the amount of work (and potential errors).
 
 To generate an initial config file, you simply need to run:
 
 > juju generate-config
 
-This causes the file to be written to your %LOCALAPPDATA%\Juju directory if an models.yaml file does not already exist. It will also create the %LOCALAPPDATA%\Juju directory if that does not exist.
+This causes the file to be written to your %LOCALAPPDATA%\Juju directory if an environments.yaml file does not already exist. It will also create the %LOCALAPPDATA%\Juju directory if that does not exist.
 
 This file will contain sample profiles for different types of cloud services, but you will need to edit the files to provide specific information for your cloud provider. Sections are created for Amazon (AWS) services, HPCloud and a generic OpenStack instance. For more specifics on what needs to be changed, see https://juju.ubuntu.com/docs/getting-started.html
 

--- a/testing/environ.go
+++ b/testing/environ.go
@@ -170,7 +170,7 @@ func MakeSampleJujuHome(c *gc.C) {
 // WriteEnvironments creates an environments file with envConfig and certs
 // from certNames.
 func WriteEnvironments(c *gc.C, envConfig string, certNames ...string) {
-	envs := osenv.JujuHomePath("models.yaml")
+	envs := osenv.JujuHomePath("environments.yaml")
 	err := ioutil.WriteFile(envs, []byte(envConfig), 0644)
 	c.Assert(err, jc.ErrorIsNil)
 	for _, name := range certNames {

--- a/testing/environ_test.go
+++ b/testing/environ_test.go
@@ -43,7 +43,7 @@ func (s *fakeHomeSuite) TearDownTest(c *gc.C) {
 func (s *fakeHomeSuite) TestFakeHomeSetsUpJujuHome(c *gc.C) {
 	jujuDir := gitjujutesting.HomePath(".juju")
 	c.Assert(jujuDir, jc.IsDirectory)
-	envFile := filepath.Join(jujuDir, "models.yaml")
+	envFile := filepath.Join(jujuDir, "environments.yaml")
 	c.Assert(envFile, jc.IsNonEmptyFile)
 }
 


### PR DESCRIPTION
In today's Release stand up, it was decided that this
rename causes unnecessary pain for users as this file
will be going away anyway in a later alpha / beta.

(Review request: http://reviews.vapour.ws/r/3629/)