### PR TITLE
add-juju-bridge: add argument that specifies which iface to bridge

### DIFF
--- a/provider/maas/add-juju-bridge.py
+++ b/provider/maas/add-juju-bridge.py
@@ -73,21 +73,22 @@ class LogicalInterface(object):
         return self.name
 
     # Returns an ordered set of stanzas to bridge this interface.
-    def bridge(self, prefix, add_auto_stanza):
+    def bridge(self, prefix, bridge_name, add_auto_stanza):
         # Note: the testing order here is significant.
         if not self.is_active:
             return self._bridge_inactive(add_auto_stanza)
         elif self.is_alias:
             return self._bridge_alias(add_auto_stanza)
         elif self.is_vlan:
-            return self._bridge_vlan(prefix, add_auto_stanza)
+            return self._bridge_vlan(prefix, bridge_name, add_auto_stanza)
         elif self.is_bonded:
-            return self._bridge_bond(prefix, add_auto_stanza)
+            return self._bridge_bond(prefix, bridge_name, add_auto_stanza)
         else:
-            return self._bridge_device(prefix)
+            return self._bridge_device(prefix, bridge_name)
 
-    def _bridge_device(self, prefix):
-        bridge_name = prefix + self.name
+    def _bridge_device(self, prefix, bridge_name):
+        if bridge_name is None:
+            bridge_name = prefix + self.name
         s1 = IfaceStanza(self.name, self.family, "manual", [])
         s2 = AutoStanza(bridge_name)
         options = list(self.options)
@@ -95,11 +96,12 @@ class LogicalInterface(object):
         s3 = IfaceStanza(bridge_name, self.family, self.method, options)
         return [s1, s2, s3]
 
-    def _bridge_vlan(self, prefix, add_auto_stanza):
+    def _bridge_vlan(self, prefix, bridge_name, add_auto_stanza):
         stanzas = []
         s1 = IfaceStanza(self.name, self.family, "manual", self.options)
         stanzas.append(s1)
-        bridge_name = prefix + self.name
+        if bridge_name is None:
+            bridge_name = prefix + self.name
         if add_auto_stanza:
             stanzas.append(AutoStanza(bridge_name))
         options = [x for x in self.options if not x.startswith("vlan")]
@@ -116,9 +118,10 @@ class LogicalInterface(object):
         stanzas.append(s1)
         return stanzas
 
-    def _bridge_bond(self, prefix, add_auto_stanza):
+    def _bridge_bond(self, prefix, bridge_name, add_auto_stanza):
         stanzas = []
-        bridge_name = prefix + self.name
+        if bridge_name is None:
+            bridge_name = prefix + self.name
         if add_auto_stanza:
             stanzas.append(AutoStanza(self.name))
         s1 = IfaceStanza(self.name, self.family, "manual", list(self.options))
@@ -298,20 +301,41 @@ def arg_parser():
     parser.add_argument('--bridge-prefix', help="bridge prefix", type=str, required=False, default='br-')
     parser.add_argument('--one-time-backup', help='A one time backup of filename', action='store_true', default=True, required=False)
     parser.add_argument('--activate', help='activate new configuration', action='store_true', default=False, required=False)
+    parser.add_argument('--interface-to-bridge', help="interface to bridge", type=str, required=False)
+    parser.add_argument('--bridge-name', help="bridge name", type=str, required=False)
     parser.add_argument('filename', help="interfaces(5) based filename")
     return parser
 
 
 def main(args):
+    if args.bridge_name and args.interface_to_bridge is None:
+        sys.stderr.write("error: --interface-to-bridge required when using --bridge-name\n")
+        exit(1)
+
+    if args.interface_to_bridge and args.bridge_name is None:
+        sys.stderr.write("error: --bridge-name required when using --interface-to-bridge\n")
+        exit(1)
+
     stanzas = []
     config_parser = NetworkInterfaceParser(args.filename)
     physical_interfaces = config_parser.physical_interfaces()
 
+    # Bridging requires modifying 'auto' and 'iface' stanzas only.
+    # Calling <iface>.bridge() will return a set of stanzas that cover
+    # both of those stanzas. The 'elif' clause catches all the other
+    # stanza types. The args.interface_to_bridge test is to bridge a
+    # single interface only, which is only used for juju < 2.0. And if
+    # that argument is specified then args.bridge_name takes
+    # precendence over any args.bridge_prefix.
+
     for s in config_parser.stanzas():
         if s.is_logical_interface:
             add_auto_stanza = s.iface.name in physical_interfaces
-            bridged_stanzas = s.iface.bridge(args.bridge_prefix, add_auto_stanza)
-            stanzas.extend(bridged_stanzas)
+            if args.interface_to_bridge and args.interface_to_bridge != s.iface.name:
+                stanzas.append(AutoStanza(s.iface.name))
+                stanzas.append(s)
+            else:
+                stanzas.extend(s.iface.bridge(args.bridge_prefix, args.bridge_name, add_auto_stanza))
         elif not s.is_physical_interface:
             stanzas.append(s)
 
@@ -344,10 +368,8 @@ def main(args):
     print_shell_cmd("ip route show")
     print_shell_cmd("brctl show")
 
-# This script re-renders an interfaces(5) file to add a bridge to all
-# active interfaces; active interfaces are those that are declared as
-# either 'static' or 'dhcp'. It also considers whether the iface is a
-# VLAN or a bond.
+# This script re-renders an interfaces(5) file to add a bridge to
+# either all active interfaces, or a specific interface.
 
 if __name__ == '__main__':
     main(arg_parser().parse_args())

--- a/provider/maas/add-juju-bridge.py
+++ b/provider/maas/add-juju-bridge.py
@@ -332,7 +332,8 @@ def main(args):
         if s.is_logical_interface:
             add_auto_stanza = s.iface.name in physical_interfaces
             if args.interface_to_bridge and args.interface_to_bridge != s.iface.name:
-                stanzas.append(AutoStanza(s.iface.name))
+                if add_auto_stanza:
+                    stanzas.append(AutoStanza(s.iface.name))
                 stanzas.append(s)
             else:
                 stanzas.extend(s.iface.bridge(args.bridge_prefix, args.bridge_name, add_auto_stanza))

--- a/provider/maas/add-juju-bridge.py
+++ b/provider/maas/add-juju-bridge.py
@@ -74,6 +74,8 @@ class LogicalInterface(object):
 
     # Returns an ordered set of stanzas to bridge this interface.
     def bridge(self, prefix, bridge_name, add_auto_stanza):
+        if bridge_name is None:
+            bridge_name = prefix + self.name
         # Note: the testing order here is significant.
         if not self.is_active:
             return self._bridge_inactive(add_auto_stanza)
@@ -87,8 +89,6 @@ class LogicalInterface(object):
             return self._bridge_device(prefix, bridge_name)
 
     def _bridge_device(self, prefix, bridge_name):
-        if bridge_name is None:
-            bridge_name = prefix + self.name
         s1 = IfaceStanza(self.name, self.family, "manual", [])
         s2 = AutoStanza(bridge_name)
         options = list(self.options)
@@ -100,8 +100,6 @@ class LogicalInterface(object):
         stanzas = []
         s1 = IfaceStanza(self.name, self.family, "manual", self.options)
         stanzas.append(s1)
-        if bridge_name is None:
-            bridge_name = prefix + self.name
         if add_auto_stanza:
             stanzas.append(AutoStanza(bridge_name))
         options = [x for x in self.options if not x.startswith("vlan")]
@@ -120,8 +118,6 @@ class LogicalInterface(object):
 
     def _bridge_bond(self, prefix, bridge_name, add_auto_stanza):
         stanzas = []
-        if bridge_name is None:
-            bridge_name = prefix + self.name
         if add_auto_stanza:
             stanzas.append(AutoStanza(self.name))
         s1 = IfaceStanza(self.name, self.family, "manual", list(self.options))

--- a/provider/maas/bridgescript.go
+++ b/provider/maas/bridgescript.go
@@ -86,6 +86,8 @@ class LogicalInterface(object):
 
     # Returns an ordered set of stanzas to bridge this interface.
     def bridge(self, prefix, bridge_name, add_auto_stanza):
+        if bridge_name is None:
+            bridge_name = prefix + self.name
         # Note: the testing order here is significant.
         if not self.is_active:
             return self._bridge_inactive(add_auto_stanza)
@@ -99,8 +101,6 @@ class LogicalInterface(object):
             return self._bridge_device(prefix, bridge_name)
 
     def _bridge_device(self, prefix, bridge_name):
-        if bridge_name is None:
-            bridge_name = prefix + self.name
         s1 = IfaceStanza(self.name, self.family, "manual", [])
         s2 = AutoStanza(bridge_name)
         options = list(self.options)
@@ -112,8 +112,6 @@ class LogicalInterface(object):
         stanzas = []
         s1 = IfaceStanza(self.name, self.family, "manual", self.options)
         stanzas.append(s1)
-        if bridge_name is None:
-            bridge_name = prefix + self.name
         if add_auto_stanza:
             stanzas.append(AutoStanza(bridge_name))
         options = [x for x in self.options if not x.startswith("vlan")]
@@ -132,8 +130,6 @@ class LogicalInterface(object):
 
     def _bridge_bond(self, prefix, bridge_name, add_auto_stanza):
         stanzas = []
-        if bridge_name is None:
-            bridge_name = prefix + self.name
         if add_auto_stanza:
             stanzas.append(AutoStanza(self.name))
         s1 = IfaceStanza(self.name, self.family, "manual", list(self.options))

--- a/provider/maas/bridgescript.go
+++ b/provider/maas/bridgescript.go
@@ -344,7 +344,8 @@ def main(args):
         if s.is_logical_interface:
             add_auto_stanza = s.iface.name in physical_interfaces
             if args.interface_to_bridge and args.interface_to_bridge != s.iface.name:
-                stanzas.append(AutoStanza(s.iface.name))
+                if add_auto_stanza:
+                    stanzas.append(AutoStanza(s.iface.name))
                 stanzas.append(s)
             else:
                 stanzas.extend(s.iface.bridge(args.bridge_prefix, args.bridge_name, add_auto_stanza))

--- a/provider/maas/bridgescript.go
+++ b/provider/maas/bridgescript.go
@@ -85,21 +85,22 @@ class LogicalInterface(object):
         return self.name
 
     # Returns an ordered set of stanzas to bridge this interface.
-    def bridge(self, prefix, add_auto_stanza):
+    def bridge(self, prefix, bridge_name, add_auto_stanza):
         # Note: the testing order here is significant.
         if not self.is_active:
             return self._bridge_inactive(add_auto_stanza)
         elif self.is_alias:
             return self._bridge_alias(add_auto_stanza)
         elif self.is_vlan:
-            return self._bridge_vlan(prefix, add_auto_stanza)
+            return self._bridge_vlan(prefix, bridge_name, add_auto_stanza)
         elif self.is_bonded:
-            return self._bridge_bond(prefix, add_auto_stanza)
+            return self._bridge_bond(prefix, bridge_name, add_auto_stanza)
         else:
-            return self._bridge_device(prefix)
+            return self._bridge_device(prefix, bridge_name)
 
-    def _bridge_device(self, prefix):
-        bridge_name = prefix + self.name
+    def _bridge_device(self, prefix, bridge_name):
+        if bridge_name is None:
+            bridge_name = prefix + self.name
         s1 = IfaceStanza(self.name, self.family, "manual", [])
         s2 = AutoStanza(bridge_name)
         options = list(self.options)
@@ -107,11 +108,12 @@ class LogicalInterface(object):
         s3 = IfaceStanza(bridge_name, self.family, self.method, options)
         return [s1, s2, s3]
 
-    def _bridge_vlan(self, prefix, add_auto_stanza):
+    def _bridge_vlan(self, prefix, bridge_name, add_auto_stanza):
         stanzas = []
         s1 = IfaceStanza(self.name, self.family, "manual", self.options)
         stanzas.append(s1)
-        bridge_name = prefix + self.name
+        if bridge_name is None:
+            bridge_name = prefix + self.name
         if add_auto_stanza:
             stanzas.append(AutoStanza(bridge_name))
         options = [x for x in self.options if not x.startswith("vlan")]
@@ -128,9 +130,10 @@ class LogicalInterface(object):
         stanzas.append(s1)
         return stanzas
 
-    def _bridge_bond(self, prefix, add_auto_stanza):
+    def _bridge_bond(self, prefix, bridge_name, add_auto_stanza):
         stanzas = []
-        bridge_name = prefix + self.name
+        if bridge_name is None:
+            bridge_name = prefix + self.name
         if add_auto_stanza:
             stanzas.append(AutoStanza(self.name))
         s1 = IfaceStanza(self.name, self.family, "manual", list(self.options))
@@ -310,20 +313,41 @@ def arg_parser():
     parser.add_argument('--bridge-prefix', help="bridge prefix", type=str, required=False, default='br-')
     parser.add_argument('--one-time-backup', help='A one time backup of filename', action='store_true', default=True, required=False)
     parser.add_argument('--activate', help='activate new configuration', action='store_true', default=False, required=False)
+    parser.add_argument('--interface-to-bridge', help="interface to bridge", type=str, required=False)
+    parser.add_argument('--bridge-name', help="bridge name", type=str, required=False)
     parser.add_argument('filename', help="interfaces(5) based filename")
     return parser
 
 
 def main(args):
+    if args.bridge_name and args.interface_to_bridge is None:
+        sys.stderr.write("error: --interface-to-bridge required when using --bridge-name\n")
+        exit(1)
+
+    if args.interface_to_bridge and args.bridge_name is None:
+        sys.stderr.write("error: --bridge-name required when using --interface-to-bridge\n")
+        exit(1)
+
     stanzas = []
     config_parser = NetworkInterfaceParser(args.filename)
     physical_interfaces = config_parser.physical_interfaces()
 
+    # Bridging requires modifying 'auto' and 'iface' stanzas only.
+    # Calling <iface>.bridge() will return a set of stanzas that cover
+    # both of those stanzas. The 'elif' clause catches all the other
+    # stanza types. The args.interface_to_bridge test is to bridge a
+    # single interface only, which is only used for juju < 2.0. And if
+    # that argument is specified then args.bridge_name takes
+    # precendence over any args.bridge_prefix.
+
     for s in config_parser.stanzas():
         if s.is_logical_interface:
             add_auto_stanza = s.iface.name in physical_interfaces
-            bridged_stanzas = s.iface.bridge(args.bridge_prefix, add_auto_stanza)
-            stanzas.extend(bridged_stanzas)
+            if args.interface_to_bridge and args.interface_to_bridge != s.iface.name:
+                stanzas.append(AutoStanza(s.iface.name))
+                stanzas.append(s)
+            else:
+                stanzas.extend(s.iface.bridge(args.bridge_prefix, args.bridge_name, add_auto_stanza))
         elif not s.is_physical_interface:
             stanzas.append(s)
 
@@ -356,10 +380,8 @@ def main(args):
     print_shell_cmd("ip route show")
     print_shell_cmd("brctl show")
 
-# This script re-renders an interfaces(5) file to add a bridge to all
-# active interfaces; active interfaces are those that are declared as
-# either 'static' or 'dhcp'. It also considers whether the iface is a
-# VLAN or a bond.
+# This script re-renders an interfaces(5) file to add a bridge to
+# either all active interfaces, or a specific interface.
 
 if __name__ == '__main__':
     main(arg_parser().parse_args())

--- a/provider/maas/bridgescript_test.go
+++ b/provider/maas/bridgescript_test.go
@@ -44,97 +44,129 @@ func (s *bridgeConfigSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-func (s *bridgeConfigSuite) assertScript(c *gc.C, initialConfig, expectedConfig, bridgePrefix string) {
+func (s *bridgeConfigSuite) assertScript(c *gc.C, initialConfig, expectedConfig, bridgePrefix, bridgeName, interfaceToBridge string) {
 	// To simplify most cases, trim trailing new lines.
 	initialConfig = strings.TrimSuffix(initialConfig, "\n")
 	expectedConfig = strings.TrimSuffix(expectedConfig, "\n")
 	err := ioutil.WriteFile(s.testConfigPath, []byte(initialConfig), 0644)
 	c.Check(err, jc.ErrorIsNil)
 	// Run the script and verify the modified config.
-	output, retcode := s.runScript(c, s.testConfigPath, bridgePrefix)
+	output, retcode := s.runScript(c, s.testConfigPath, bridgePrefix, bridgeName, interfaceToBridge)
 	c.Check(retcode, gc.Equals, 0)
 	c.Check(strings.Trim(output, "\n"), gc.Equals, expectedConfig)
 }
 
 func (s *bridgeConfigSuite) TestBridgeScriptWithUndefinedArgs(c *gc.C) {
-	_, code := s.runScript(c, "", "")
+	_, code := s.runScript(c, "", "", "", "")
 	c.Check(code, gc.Equals, 1)
 }
 
 func (s *bridgeConfigSuite) TestBridgeScriptDHCP(c *gc.C) {
-	s.assertScript(c, networkDHCPInitial, networkDHCPExpected, "test-br-")
+	s.assertScript(c, networkDHCPInitial, networkDHCPExpected, "test-br-", "", "")
 }
 
 func (s *bridgeConfigSuite) TestBridgeScriptStatic(c *gc.C) {
-	s.assertScript(c, networkStaticInitial, networkStaticExpected, "test-br-")
+	s.assertScript(c, networkStaticInitial, networkStaticExpected, "test-br-", "", "")
 }
 
 func (s *bridgeConfigSuite) TestBridgeScriptDualNIC(c *gc.C) {
-	s.assertScript(c, networkDualNICInitial, networkDualNICExpected, "test-br-")
+	s.assertScript(c, networkDualNICInitial, networkDualNICExpected, "test-br-", "", "")
 }
 
 func (s *bridgeConfigSuite) TestBridgeScriptWithAlias(c *gc.C) {
-	s.assertScript(c, networkWithAliasInitial, networkWithAliasExpected, "test-br-")
+	s.assertScript(c, networkWithAliasInitial, networkWithAliasExpected, "test-br-", "", "")
 }
 
 func (s *bridgeConfigSuite) TestBridgeScriptDHCPWithAlias(c *gc.C) {
-	s.assertScript(c, networkDHCPWithAliasInitial, networkDHCPWithAliasExpected, "test-br-")
+	s.assertScript(c, networkDHCPWithAliasInitial, networkDHCPWithAliasExpected, "test-br-", "", "")
 }
 
 func (s *bridgeConfigSuite) TestBridgeScriptMultipleStaticWithAliases(c *gc.C) {
-	s.assertScript(c, networkMultipleStaticWithAliasesInitial, networkMultipleStaticWithAliasesExpected, "test-br-")
+	s.assertScript(c, networkMultipleStaticWithAliasesInitial, networkMultipleStaticWithAliasesExpected, "test-br-", "", "")
 }
 
 func (s *bridgeConfigSuite) TestBridgeScriptDHCPWithBond(c *gc.C) {
-	s.assertScript(c, networkDHCPWithBondInitial, networkDHCPWithBondExpected, "test-br-")
+	s.assertScript(c, networkDHCPWithBondInitial, networkDHCPWithBondExpected, "test-br-", "", "")
 }
 
 func (s *bridgeConfigSuite) TestBridgeScriptMultipleAliases(c *gc.C) {
-	s.assertScript(c, networkMultipleAliasesInitial, networkMultipleAliasesExpected, "test-br-")
+	s.assertScript(c, networkMultipleAliasesInitial, networkMultipleAliasesExpected, "test-br-", "", "")
 }
 
 func (s *bridgeConfigSuite) TestBridgeScriptSmorgasboard(c *gc.C) {
-	s.assertScript(c, networkSmorgasboardInitial, networkSmorgasboardExpected, "juju-br-")
+	s.assertScript(c, networkSmorgasboardInitial, networkSmorgasboardExpected, "juju-br-", "", "")
 }
 
 func (s *bridgeConfigSuite) TestBridgeScriptWithVLANs(c *gc.C) {
-	s.assertScript(c, networkVLANInitial, networkVLANExpected, "vlan-br-")
+	s.assertScript(c, networkVLANInitial, networkVLANExpected, "vlan-br-", "", "")
 }
 
 func (s *bridgeConfigSuite) TestBridgeScriptWithMultipleNameservers(c *gc.C) {
-	s.assertScript(c, networkVLANWithMultipleNameserversInitial, networkVLANWithMultipleNameserversExpected, "br-")
+	s.assertScript(c, networkVLANWithMultipleNameserversInitial, networkVLANWithMultipleNameserversExpected, "br-", "", "")
 }
 
 func (s *bridgeConfigSuite) TestBridgeScriptWithLoopbackOnly(c *gc.C) {
-	s.assertScript(c, networkLoopbackOnlyInitial, networkLoopbackOnlyExpected, "br-")
+	s.assertScript(c, networkLoopbackOnlyInitial, networkLoopbackOnlyExpected, "br-", "", "")
 }
 
 func (s *bridgeConfigSuite) TestBridgeScriptBondWithVLANs(c *gc.C) {
-	s.assertScript(c, networkStaticBondWithVLANsInitial, networkStaticBondWithVLANsExpected, "br-")
+	s.assertScript(c, networkStaticBondWithVLANsInitial, networkStaticBondWithVLANsExpected, "br-", "", "")
 }
 
 func (s *bridgeConfigSuite) TestBridgeScriptVLANWithInactive(c *gc.C) {
-	s.assertScript(c, networkVLANWithInactiveDeviceInitial, networkVLANWithInactiveDeviceExpected, "br-")
+	s.assertScript(c, networkVLANWithInactiveDeviceInitial, networkVLANWithInactiveDeviceExpected, "br-", "", "")
 }
 
 func (s *bridgeConfigSuite) TestBridgeScriptVLANWithActiveDHCPDevice(c *gc.C) {
-	s.assertScript(c, networkVLANWithActiveDHCPDeviceInitial, networkVLANWithActiveDHCPDeviceExpected, "br-")
+	s.assertScript(c, networkVLANWithActiveDHCPDeviceInitial, networkVLANWithActiveDHCPDeviceExpected, "br-", "", "")
 }
 
 func (s *bridgeConfigSuite) TestBridgeScriptMultipleDNSValues(c *gc.C) {
-	s.assertScript(c, networkWithMultipleDNSValuesInitial, networkWithMultipleDNSValuesExpected, "br-")
+	s.assertScript(c, networkWithMultipleDNSValuesInitial, networkWithMultipleDNSValuesExpected, "br-", "", "")
 }
 
 func (s *bridgeConfigSuite) TestBridgeScriptEmptyDNSValues(c *gc.C) {
-	s.assertScript(c, networkWithEmptyDNSValuesInitial, networkWithEmptyDNSValuesExpected, "br-")
+	s.assertScript(c, networkWithEmptyDNSValuesInitial, networkWithEmptyDNSValuesExpected, "br-", "", "")
 }
 
-func (s *bridgeConfigSuite) runScript(c *gc.C, configFile string, bridgePrefix string) (output string, exitCode int) {
-	script := fmt.Sprintf("%q --bridge-prefix=%q %q\n",
-		s.testPythonScript,
-		bridgePrefix,
-		configFile)
+func (s *bridgeConfigSuite) TestBridgeScriptMismatchedBridgeNameAndInterfaceArgs(c *gc.C) {
+	s.assertScript(c, networkWithEmptyDNSValuesInitial, networkWithEmptyDNSValuesExpected, "br-", "", "")
+}
 
+func (s *bridgeConfigSuite) TestBridgeScriptInterfaceNameArgumentRequired(c *gc.C) {
+	output, code := s.runScript(c, "# no content", "", "juju-br0", "")
+	c.Check(code, gc.Equals, 1)
+	c.Check(strings.Trim(output, "\n"), gc.Equals, "error: --interface-to-bridge required when using --bridge-name")
+}
+
+func (s *bridgeConfigSuite) TestBridgeScriptBridgeNameArgumentRequired(c *gc.C) {
+	output, code := s.runScript(c, "# no content", "", "", "eth0")
+	c.Check(code, gc.Equals, 1)
+	c.Check(strings.Trim(output, "\n"), gc.Equals, "error: --bridge-name required when using --interface-to-bridge")
+}
+
+func (s *bridgeConfigSuite) TestBridgeScriptMatchingNonExistentSpecificIface(c *gc.C) {
+	s.assertScript(c, networkStaticInitial, networkStaticInitial, "", "juju-br0", "eth1234567890")
+}
+
+func (s *bridgeConfigSuite) TestBridgeScriptMatchingExistingSpecificIface(c *gc.C) {
+	s.assertScript(c, networkLP1532167Initial, networkLP1532167Expected, "", "juju-br0", "bond0")
+}
+
+func (s *bridgeConfigSuite) runScript(c *gc.C, configFile, bridgePrefix, bridgeName, interfaceToBridge string) (output string, exitCode int) {
+	if bridgePrefix != "" {
+		bridgePrefix = fmt.Sprintf("--bridge-prefix=%q", bridgePrefix)
+	}
+
+	if bridgeName != "" {
+		bridgeName = fmt.Sprintf("--bridge-name=%q", bridgeName)
+	}
+
+	if interfaceToBridge != "" {
+		interfaceToBridge = fmt.Sprintf("--interface-to-bridge=%q", interfaceToBridge)
+	}
+
+	script := fmt.Sprintf("%q %s %s %s %q\n", s.testPythonScript, bridgePrefix, bridgeName, interfaceToBridge, configFile)
 	result, err := exec.RunCommands(exec.RunParams{Commands: script})
 	c.Assert(err, jc.ErrorIsNil, gc.Commentf("script failed unexpectedly"))
 	stdout := string(result.Stdout)
@@ -1214,3 +1246,230 @@ iface br-eth1 inet static
     address 10.245.168.12/21
     mtu 1500
     bridge_ports eth1`
+
+const networkLP1532167Initial = `auto eth0
+iface eth0 inet manual
+    bond-lacp_rate fast
+    bond-xmit_hash_policy layer2+3
+    bond-miimon 100
+    bond-master bond0
+    mtu 1500
+    bond-mode 802.3ad
+
+auto eth1
+iface eth1 inet manual
+    bond-lacp_rate fast
+    bond-xmit_hash_policy layer2+3
+    bond-miimon 100
+    bond-master bond0
+    mtu 1500
+    bond-mode 802.3ad
+
+auto eth2
+iface eth2 inet manual
+    bond-lacp_rate fast
+    bond-xmit_hash_policy layer2+3
+    bond-miimon 100
+    bond-master bond1
+    mtu 1500
+    bond-mode 802.3ad
+
+auto eth3
+iface eth3 inet manual
+    bond-lacp_rate fast
+    bond-xmit_hash_policy layer2+3
+    bond-miimon 100
+    bond-master bond1
+    mtu 1500
+    bond-mode 802.3ad
+
+auto bond0
+iface bond0 inet static
+    gateway 10.38.160.1
+    address 10.38.160.24/24
+    bond-lacp_rate fast
+    bond-xmit_hash_policy layer2+3
+    bond-miimon 100
+    mtu 1500
+    bond-mode 802.3ad
+    hwaddress 44:a8:42:41:ab:37
+    bond-slaves none
+
+auto bond1
+iface bond1 inet manual
+    bond-lacp_rate fast
+    bond-xmit_hash_policy layer2+3
+    bond-miimon 100
+    mtu 1500
+    bond-mode 802.3ad
+    hwaddress 00:0e:1e:b7:b5:50
+    bond-slaves none
+
+auto bond0.1016
+iface bond0.1016 inet static
+    address 172.16.0.21/16
+    vlan-raw-device bond0
+    mtu 1500
+    vlan_id 1016
+
+auto bond0.161
+iface bond0.161 inet static
+    address 10.38.161.21/24
+    vlan-raw-device bond0
+    mtu 1500
+    vlan_id 161
+
+auto bond0.162
+iface bond0.162 inet static
+    address 10.38.162.21/24
+    vlan-raw-device bond0
+    mtu 1500
+    vlan_id 162
+
+auto bond0.163
+iface bond0.163 inet static
+    address 10.38.163.21/24
+    vlan-raw-device bond0
+    mtu 1500
+    vlan_id 163
+
+auto bond1.1017
+iface bond1.1017 inet static
+    address 172.17.0.21/16
+    vlan-raw-device bond1
+    mtu 1500
+    vlan_id 1017
+
+auto bond1.1018
+iface bond1.1018 inet static
+    address 172.18.0.21/16
+    vlan-raw-device bond1
+    mtu 1500
+    vlan_id 1018
+
+auto bond1.1019
+iface bond1.1019 inet static
+    address 172.19.0.21/16
+    vlan-raw-device bond1
+    mtu 1500
+    vlan_id 1019
+
+dns-nameservers 10.38.160.10
+dns-search maas`
+
+const networkLP1532167Expected = `auto eth0
+iface eth0 inet manual
+    bond-lacp_rate fast
+    bond-xmit_hash_policy layer2+3
+    bond-miimon 100
+    bond-master bond0
+    mtu 1500
+    bond-mode 802.3ad
+
+auto eth1
+iface eth1 inet manual
+    bond-lacp_rate fast
+    bond-xmit_hash_policy layer2+3
+    bond-miimon 100
+    bond-master bond0
+    mtu 1500
+    bond-mode 802.3ad
+
+auto eth2
+iface eth2 inet manual
+    bond-lacp_rate fast
+    bond-xmit_hash_policy layer2+3
+    bond-miimon 100
+    bond-master bond1
+    mtu 1500
+    bond-mode 802.3ad
+
+auto eth3
+iface eth3 inet manual
+    bond-lacp_rate fast
+    bond-xmit_hash_policy layer2+3
+    bond-miimon 100
+    bond-master bond1
+    mtu 1500
+    bond-mode 802.3ad
+
+auto bond0
+iface bond0 inet manual
+    gateway 10.38.160.1
+    address 10.38.160.24/24
+    bond-lacp_rate fast
+    bond-xmit_hash_policy layer2+3
+    bond-miimon 100
+    mtu 1500
+    bond-mode 802.3ad
+    hwaddress 44:a8:42:41:ab:37
+    bond-slaves none
+
+auto juju-br0
+iface juju-br0 inet static
+    gateway 10.38.160.1
+    address 10.38.160.24/24
+    mtu 1500
+    hwaddress 44:a8:42:41:ab:37
+    bridge_ports bond0
+
+auto bond1
+iface bond1 inet manual
+    bond-lacp_rate fast
+    bond-xmit_hash_policy layer2+3
+    bond-miimon 100
+    mtu 1500
+    bond-mode 802.3ad
+    hwaddress 00:0e:1e:b7:b5:50
+    bond-slaves none
+
+auto bond0.1016
+iface bond0.1016 inet static
+    address 172.16.0.21/16
+    vlan-raw-device bond0
+    mtu 1500
+    vlan_id 1016
+
+auto bond0.161
+iface bond0.161 inet static
+    address 10.38.161.21/24
+    vlan-raw-device bond0
+    mtu 1500
+    vlan_id 161
+
+auto bond0.162
+iface bond0.162 inet static
+    address 10.38.162.21/24
+    vlan-raw-device bond0
+    mtu 1500
+    vlan_id 162
+
+auto bond0.163
+iface bond0.163 inet static
+    address 10.38.163.21/24
+    vlan-raw-device bond0
+    mtu 1500
+    vlan_id 163
+
+auto bond1.1017
+iface bond1.1017 inet static
+    address 172.17.0.21/16
+    vlan-raw-device bond1
+    mtu 1500
+    vlan_id 1017
+
+auto bond1.1018
+iface bond1.1018 inet static
+    address 172.18.0.21/16
+    vlan-raw-device bond1
+    mtu 1500
+    vlan_id 1018
+
+auto bond1.1019
+iface bond1.1019 inet static
+    address 172.19.0.21/16
+    vlan-raw-device bond1
+    mtu 1500
+    vlan_id 1019
+    dns-nameservers 10.38.160.10
+    dns-search maas`

--- a/provider/maas/bridgescript_test.go
+++ b/provider/maas/bridgescript_test.go
@@ -56,81 +56,93 @@ func (s *bridgeConfigSuite) assertScript(c *gc.C, initialConfig, expectedConfig,
 	c.Check(strings.Trim(output, "\n"), gc.Equals, expectedConfig)
 }
 
+func (s *bridgeConfigSuite) assertScriptWithPrefix(c *gc.C, initial, expected, prefix string) {
+	s.assertScript(c, initial, expected, prefix, "", "")
+}
+
+func (s *bridgeConfigSuite) assertScriptWithDefaultPrefix(c *gc.C, initial, expected string) {
+	s.assertScript(c, initial, expected, "", "", "")
+}
+
+func (s *bridgeConfigSuite) assertScriptWithoutPrefix(c *gc.C, initial, expected, bridgeName, interfaceToBridge string) {
+	s.assertScript(c, initial, expected, "", bridgeName, interfaceToBridge)
+}
+
 func (s *bridgeConfigSuite) TestBridgeScriptWithUndefinedArgs(c *gc.C) {
 	_, code := s.runScript(c, "", "", "", "")
 	c.Check(code, gc.Equals, 1)
 }
 
 func (s *bridgeConfigSuite) TestBridgeScriptDHCP(c *gc.C) {
-	s.assertScript(c, networkDHCPInitial, networkDHCPExpected, "test-br-", "", "")
+	s.assertScriptWithPrefix(c, networkDHCPInitial, networkDHCPExpected, "test-br-")
 }
 
 func (s *bridgeConfigSuite) TestBridgeScriptStatic(c *gc.C) {
-	s.assertScript(c, networkStaticInitial, networkStaticExpected, "test-br-", "", "")
+	s.assertScriptWithPrefix(c, networkStaticInitial, networkStaticExpected, "test-br-")
 }
 
 func (s *bridgeConfigSuite) TestBridgeScriptDualNIC(c *gc.C) {
-	s.assertScript(c, networkDualNICInitial, networkDualNICExpected, "test-br-", "", "")
+	s.assertScriptWithPrefix(c, networkDualNICInitial, networkDualNICExpected, "test-br-")
 }
 
 func (s *bridgeConfigSuite) TestBridgeScriptWithAlias(c *gc.C) {
-	s.assertScript(c, networkWithAliasInitial, networkWithAliasExpected, "test-br-", "", "")
+	s.assertScriptWithPrefix(c, networkWithAliasInitial, networkWithAliasExpected, "test-br-")
 }
 
 func (s *bridgeConfigSuite) TestBridgeScriptDHCPWithAlias(c *gc.C) {
-	s.assertScript(c, networkDHCPWithAliasInitial, networkDHCPWithAliasExpected, "test-br-", "", "")
+	s.assertScriptWithPrefix(c, networkDHCPWithAliasInitial, networkDHCPWithAliasExpected, "test-br-")
 }
 
 func (s *bridgeConfigSuite) TestBridgeScriptMultipleStaticWithAliases(c *gc.C) {
-	s.assertScript(c, networkMultipleStaticWithAliasesInitial, networkMultipleStaticWithAliasesExpected, "test-br-", "", "")
+	s.assertScriptWithPrefix(c, networkMultipleStaticWithAliasesInitial, networkMultipleStaticWithAliasesExpected, "test-br-")
 }
 
 func (s *bridgeConfigSuite) TestBridgeScriptDHCPWithBond(c *gc.C) {
-	s.assertScript(c, networkDHCPWithBondInitial, networkDHCPWithBondExpected, "test-br-", "", "")
+	s.assertScriptWithPrefix(c, networkDHCPWithBondInitial, networkDHCPWithBondExpected, "test-br-")
 }
 
 func (s *bridgeConfigSuite) TestBridgeScriptMultipleAliases(c *gc.C) {
-	s.assertScript(c, networkMultipleAliasesInitial, networkMultipleAliasesExpected, "test-br-", "", "")
+	s.assertScriptWithPrefix(c, networkMultipleAliasesInitial, networkMultipleAliasesExpected, "test-br-")
 }
 
 func (s *bridgeConfigSuite) TestBridgeScriptSmorgasboard(c *gc.C) {
-	s.assertScript(c, networkSmorgasboardInitial, networkSmorgasboardExpected, "juju-br-", "", "")
+	s.assertScriptWithPrefix(c, networkSmorgasboardInitial, networkSmorgasboardExpected, "juju-br-")
 }
 
 func (s *bridgeConfigSuite) TestBridgeScriptWithVLANs(c *gc.C) {
-	s.assertScript(c, networkVLANInitial, networkVLANExpected, "vlan-br-", "", "")
+	s.assertScriptWithPrefix(c, networkVLANInitial, networkVLANExpected, "vlan-br-")
 }
 
 func (s *bridgeConfigSuite) TestBridgeScriptWithMultipleNameservers(c *gc.C) {
-	s.assertScript(c, networkVLANWithMultipleNameserversInitial, networkVLANWithMultipleNameserversExpected, "br-", "", "")
+	s.assertScriptWithDefaultPrefix(c, networkVLANWithMultipleNameserversInitial, networkVLANWithMultipleNameserversExpected)
 }
 
 func (s *bridgeConfigSuite) TestBridgeScriptWithLoopbackOnly(c *gc.C) {
-	s.assertScript(c, networkLoopbackOnlyInitial, networkLoopbackOnlyExpected, "br-", "", "")
+	s.assertScriptWithDefaultPrefix(c, networkLoopbackOnlyInitial, networkLoopbackOnlyExpected)
 }
 
 func (s *bridgeConfigSuite) TestBridgeScriptBondWithVLANs(c *gc.C) {
-	s.assertScript(c, networkStaticBondWithVLANsInitial, networkStaticBondWithVLANsExpected, "br-", "", "")
+	s.assertScriptWithDefaultPrefix(c, networkStaticBondWithVLANsInitial, networkStaticBondWithVLANsExpected)
 }
 
 func (s *bridgeConfigSuite) TestBridgeScriptVLANWithInactive(c *gc.C) {
-	s.assertScript(c, networkVLANWithInactiveDeviceInitial, networkVLANWithInactiveDeviceExpected, "br-", "", "")
+	s.assertScriptWithDefaultPrefix(c, networkVLANWithInactiveDeviceInitial, networkVLANWithInactiveDeviceExpected)
 }
 
 func (s *bridgeConfigSuite) TestBridgeScriptVLANWithActiveDHCPDevice(c *gc.C) {
-	s.assertScript(c, networkVLANWithActiveDHCPDeviceInitial, networkVLANWithActiveDHCPDeviceExpected, "br-", "", "")
+	s.assertScriptWithDefaultPrefix(c, networkVLANWithActiveDHCPDeviceInitial, networkVLANWithActiveDHCPDeviceExpected)
 }
 
 func (s *bridgeConfigSuite) TestBridgeScriptMultipleDNSValues(c *gc.C) {
-	s.assertScript(c, networkWithMultipleDNSValuesInitial, networkWithMultipleDNSValuesExpected, "br-", "", "")
+	s.assertScriptWithDefaultPrefix(c, networkWithMultipleDNSValuesInitial, networkWithMultipleDNSValuesExpected)
 }
 
 func (s *bridgeConfigSuite) TestBridgeScriptEmptyDNSValues(c *gc.C) {
-	s.assertScript(c, networkWithEmptyDNSValuesInitial, networkWithEmptyDNSValuesExpected, "br-", "", "")
+	s.assertScriptWithDefaultPrefix(c, networkWithEmptyDNSValuesInitial, networkWithEmptyDNSValuesExpected)
 }
 
 func (s *bridgeConfigSuite) TestBridgeScriptMismatchedBridgeNameAndInterfaceArgs(c *gc.C) {
-	s.assertScript(c, networkWithEmptyDNSValuesInitial, networkWithEmptyDNSValuesExpected, "br-", "", "")
+	s.assertScriptWithDefaultPrefix(c, networkWithEmptyDNSValuesInitial, networkWithEmptyDNSValuesExpected)
 }
 
 func (s *bridgeConfigSuite) TestBridgeScriptInterfaceNameArgumentRequired(c *gc.C) {
@@ -146,15 +158,15 @@ func (s *bridgeConfigSuite) TestBridgeScriptBridgeNameArgumentRequired(c *gc.C) 
 }
 
 func (s *bridgeConfigSuite) TestBridgeScriptMatchingNonExistentSpecificIface(c *gc.C) {
-	s.assertScript(c, networkStaticInitial, networkStaticInitial, "", "juju-br0", "eth1234567890")
+	s.assertScriptWithoutPrefix(c, networkStaticInitial, networkStaticInitial, "juju-br0", "eth1234567890")
 }
 
 func (s *bridgeConfigSuite) TestBridgeScriptMatchingExistingSpecificIfaceButMissingAutoStanza(c *gc.C) {
-	s.assertScript(c, networkWithExistingSpecificIfaceInitial, networkWithExistingSpecificIfaceExpected, "", "juju-br0", "eth1")
+	s.assertScriptWithoutPrefix(c, networkWithExistingSpecificIfaceInitial, networkWithExistingSpecificIfaceExpected, "juju-br0", "eth1")
 }
 
 func (s *bridgeConfigSuite) TestBridgeScriptMatchingExistingSpecificIface2(c *gc.C) {
-	s.assertScript(c, networkLP1532167Initial, networkLP1532167Expected, "", "juju-br0", "bond0")
+	s.assertScriptWithoutPrefix(c, networkLP1532167Initial, networkLP1532167Expected, "juju-br0", "bond0")
 }
 
 func (s *bridgeConfigSuite) runScript(c *gc.C, configFile, bridgePrefix, bridgeName, interfaceToBridge string) (output string, exitCode int) {

--- a/provider/maas/bridgescript_test.go
+++ b/provider/maas/bridgescript_test.go
@@ -149,7 +149,11 @@ func (s *bridgeConfigSuite) TestBridgeScriptMatchingNonExistentSpecificIface(c *
 	s.assertScript(c, networkStaticInitial, networkStaticInitial, "", "juju-br0", "eth1234567890")
 }
 
-func (s *bridgeConfigSuite) TestBridgeScriptMatchingExistingSpecificIface(c *gc.C) {
+func (s *bridgeConfigSuite) TestBridgeScriptMatchingExistingSpecificIfaceButMissingAutoStanza(c *gc.C) {
+	s.assertScript(c, networkWithExistingSpecificIfaceInitial, networkWithExistingSpecificIfaceExpected, "", "juju-br0", "eth1")
+}
+
+func (s *bridgeConfigSuite) TestBridgeScriptMatchingExistingSpecificIface2(c *gc.C) {
 	s.assertScript(c, networkLP1532167Initial, networkLP1532167Expected, "", "juju-br0", "bond0")
 }
 
@@ -1473,3 +1477,34 @@ iface bond1.1019 inet static
     vlan_id 1019
     dns-nameservers 10.38.160.10
     dns-search maas`
+
+const networkWithExistingSpecificIfaceInitial = `auto lo
+iface lo inet loopback
+
+# Note this has no auto stanza
+iface eth0 inet static
+    address 1.2.3.4
+    netmask 255.255.255.0
+    gateway 4.3.2.1
+
+iface eth1 inet static
+    address 1.2.3.4
+    netmask 255.255.255.0
+    gateway 4.3.2.1`
+
+const networkWithExistingSpecificIfaceExpected = `auto lo
+iface lo inet loopback
+
+iface eth0 inet static
+    address 1.2.3.4
+    netmask 255.255.255.0
+    gateway 4.3.2.1
+
+iface eth1 inet manual
+
+auto juju-br0
+iface juju-br0 inet static
+    address 1.2.3.4
+    netmask 255.255.255.0
+    gateway 4.3.2.1
+    bridge_ports eth1`


### PR DESCRIPTION
Add script arguments (--interface-to-bridge and --bridge-name) to
explicitly specify which interface should be bridged and what name it
should take. These arguments are for juju versions < 2.0 only; it allows
us to maintain compatibility for older juju versions by continuing to
use '--bridge-name=juju-br0' for the interface that is the default
route.

Examples include:

 --bridge-name=juju-br0 --interface-to-bridge=bond0
 --bridge-name=juju-br0 --interface-to-bridge=eth1

(Review request: http://reviews.vapour.ws/r/3630/)