### PR TITLE
state/leadership: leadership.Manager wakes/checks at least every config.MaxSleep

### DIFF
--- a/constraints/constraints_test.go
+++ b/constraints/constraints_test.go
@@ -358,8 +358,7 @@ func (s *ConstraintsSuite) TestMerge(c *gc.C) {
 	c.Assert(merged, jc.DeepEquals, con1)
 	merged, err = constraints.Merge(con1, con2, con3)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(merged, jc.DeepEquals, constraints.
-		MustParse(
+	c.Assert(merged, jc.DeepEquals, constraints.MustParse(
 		"arch=amd64 mem=4G cpu-cores=42 root-disk=8G container=lxc spaces=space1,^space2 networks=net1,^net2"),
 	)
 	merged, err = constraints.Merge()

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -28,7 +28,7 @@ github.com/juju/schema	git	afe1151cb49d1d7ed3c75592dfc6f38703f2e988	2015-08-07T0
 github.com/juju/syslog	git	6be94e8b718766e9ff7a37342157fe4795da7cfa	2015-02-05T15:59:36Z
 github.com/juju/testing	git	f521911d9a79aeb62c051fe18e689796369c5564	2015-05-29T04:40:43Z
 github.com/juju/txn	git	99ec629d0066a4d73c54d8e021a7fc1dc07df614	2015-06-09T16:58:27Z
-github.com/juju/utils	git	a8a6b302e967fa0ab41dd762256cab18bf20f90a	2015-09-22T08:36:00Z
+github.com/juju/utils	git	e0e40df1d4bf972c28dcafcca7788934e21e33ba	2015-11-09T08:36:00Z
 github.com/juju/xml	git	eb759a627588d35166bc505fceb51b88500e291e	2015-04-13T13:11:21Z
 golang.org/x/crypto	git	c57d4a71915a248dbad846d60825145062b4c18e	2015-03-27T05:11:19Z
 golang.org/x/net	git	bb64f4dc73d4ab97978d5e1cb34515dcc570361b	2015-05-18T01:39:50Z
@@ -48,6 +48,7 @@ gopkg.in/mgo.v2	git	3569c88678d88179dcbd68d02ab081cbca3cd4d0	2015-06-04T15:26:27
 gopkg.in/natefinch/lumberjack.v2	git	588a21fb0fa0ebdfde42670fa214576b6f0f22df	2015-05-21T01:59:18Z
 gopkg.in/natefinch/npipe.v2	git	e562d4ae5c2f838f9e7e406f7d9890d5b02467a9	2014-08-11T16:19:00Z
 gopkg.in/yaml.v1	git	9f9df34309c04878acc86042b16630b0f696e1de	2014-09-24T16:16:07Z
+gopkg.in/yaml.v2	git	53feefa2559fb8dfa8d81baad31be332c97d6c77	2015-09-24T14:23:14Z
 launchpad.net/gnuflag	bzr	roger.peppe@canonical.com-20140716064605-pk32dnmfust02yab	13
 launchpad.net/golxc	bzr	ian.booth@canonical.com-20141121040613-ztm1q0iy9rune3zt	13
 launchpad.net/gomaasapi	bzr	michael.foord@canonical.com-20150703101140-oo7493pkzlzg7l6u	63

--- a/state/leadership/config.go
+++ b/state/leadership/config.go
@@ -4,6 +4,8 @@
 package leadership
 
 import (
+	"time"
+
 	"github.com/juju/errors"
 	"github.com/juju/utils/clock"
 
@@ -13,18 +15,29 @@ import (
 // ManagerConfig contains the resources and information required to create a
 // Manager.
 type ManagerConfig struct {
+
+	// Client reads and writes lease data.
 	Client lease.Client
-	Clock  clock.Clock
+
+	// Clock supplies time services.
+	Clock clock.Clock
+
+	// MaxSleep is the longest time the Manager should sleep before
+	// refreshing its client's leases and checking for expiries.
+	MaxSleep time.Duration
 }
 
 // Validate returns an error if the configuration contains invalid information
 // or missing resources.
 func (config ManagerConfig) Validate() error {
 	if config.Client == nil {
-		return errors.New("missing client")
+		return errors.NotValidf("nil Client")
 	}
 	if config.Clock == nil {
-		return errors.New("missing clock")
+		return errors.NotValidf("nil Clock")
+	}
+	if config.MaxSleep <= 0 {
+		return errors.NotValidf("non-positive MaxSleep")
 	}
 	return nil
 }

--- a/state/leadership/manager.go
+++ b/state/leadership/manager.go
@@ -101,8 +101,8 @@ func (manager *manager) choose(blocks blocks) error {
 	select {
 	case <-manager.tomb.Dying():
 		return tomb.ErrDying
-	case <-manager.nextExpiry():
-		return manager.expire()
+	case <-manager.nextTick():
+		return manager.tick()
 	case claim := <-manager.claims:
 		return manager.handleClaim(claim)
 	case check := <-manager.checks:
@@ -198,35 +198,37 @@ func (manager *manager) BlockUntilLeadershipReleased(serviceName string) error {
 	}.invoke(manager.blocks)
 }
 
-// nextExpiry returns a channel that will send a value at some point when we
-// expect at least one lease to be ready to expire. If no leases are known,
-// it will return nil.
-func (manager *manager) nextExpiry() <-chan time.Time {
-	var nextExpiry *time.Time
+// nextTick returns a channel that will send a value at some point when
+// we expect to have to do some work; either because at least one lease
+// may be ready to expire, or because enough enough time has passed that
+// it's worth checking for stalled collaborators.
+func (manager *manager) nextTick() <-chan time.Time {
+	now := manager.config.Clock.Now()
+	nextTick := now.Add(manager.config.MaxSleep)
 	for _, info := range manager.config.Client.Leases() {
-		if nextExpiry != nil {
-			if info.Expiry.After(*nextExpiry) {
-				continue
-			}
+		if info.Expiry.After(nextTick) {
+			continue
 		}
-		nextExpiry = &info.Expiry
+		nextTick = info.Expiry
 	}
-	if nextExpiry == nil {
-		logger.Tracef("no leases recorded; never waking for expiry")
-		return nil
-	}
-	logger.Tracef("waking to expire leases at %s", *nextExpiry)
-	return clock.Alarm(manager.config.Clock, *nextExpiry)
+	logger.Debugf("waking to check leases at %s", nextTick)
+	return clock.Alarm(manager.config.Clock, nextTick)
 }
 
-// expire will attempt to expire all leases that may have expired. There might
-// be none; they might have been extended or expired already by someone else; so
-// ErrInvalid is expected, and ignored, in the comfortable knowledge that the
-// client will have been updated and we'll see fresh info when we scan for new
-// expiries next time through the loop. It will return only unrecoverable errors.
-func (manager *manager) expire() error {
-	logger.Tracef("expiring leases...")
+// tick snapshots recent leases and expires any that it can. There
+// might be none that need attention; or those that do might already
+// have been extended or expired by someone else; so ErrInvalid is
+// expected, and ignored, comfortable that the client will have been
+// updated in the background; and that we'll see fresh info when we
+// subsequently check nextWake().
+//
+// It will return only unrecoverable errors.
+func (manager *manager) tick() error {
+	logger.Tracef("refreshing leases...")
 	client := manager.config.Client
+	if err := client.Refresh(); err != nil {
+		return errors.Trace(err)
+	}
 	leases := client.Leases()
 
 	// Sort lease names so we expire in a predictable order for the tests.
@@ -235,8 +237,10 @@ func (manager *manager) expire() error {
 		names = append(names, name)
 	}
 	sort.Strings(names)
+
+	logger.Tracef("expiring leases...")
+	now := manager.config.Clock.Now()
 	for _, name := range names {
-		now := manager.config.Clock.Now()
 		if leases[name].Expiry.After(now) {
 			continue
 		}

--- a/state/leadership/manager_block_test.go
+++ b/state/leadership/manager_block_test.go
@@ -39,6 +39,8 @@ func (s *BlockUntilLeadershipReleasedSuite) TestLeadershipExpires(c *gc.C) {
 			},
 		},
 		expectCalls: []call{{
+			method: "Refresh",
+		}, {
 			method: "ExpireLease",
 			args:   []interface{}{"redis"},
 			callback: func(leases map[string]lease.Info) {
@@ -66,6 +68,8 @@ func (s *BlockUntilLeadershipReleasedSuite) TestLeadershipChanged(c *gc.C) {
 			},
 		},
 		expectCalls: []call{{
+			method: "Refresh",
+		}, {
 			method: "ExpireLease",
 			args:   []interface{}{"redis"},
 			err:    lease.ErrInvalid,
@@ -127,6 +131,8 @@ func (s *BlockUntilLeadershipReleasedSuite) TestMultiple(c *gc.C) {
 			},
 		},
 		expectCalls: []call{{
+			method: "Refresh",
+		}, {
 			method: "ExpireLease",
 			args:   []interface{}{"redis"},
 			err:    lease.ErrInvalid,

--- a/state/leadership/manager_expire_test.go
+++ b/state/leadership/manager_expire_test.go
@@ -28,6 +28,8 @@ func (s *ExpireLeadershipSuite) TestStartup_ExpiryInPast(c *gc.C) {
 			"redis": lease.Info{Expiry: offset(-time.Second)},
 		},
 		expectCalls: []call{{
+			method: "Refresh",
+		}, {
 			method: "ExpireLease",
 			args:   []interface{}{"redis"},
 			callback: func(leases map[string]lease.Info) {
@@ -55,6 +57,8 @@ func (s *ExpireLeadershipSuite) TestStartup_ExpiryInFuture_TimePasses(c *gc.C) {
 			"redis": lease.Info{Expiry: offset(time.Second)},
 		},
 		expectCalls: []call{{
+			method: "Refresh",
+		}, {
 			method: "ExpireLease",
 			args:   []interface{}{"redis"},
 			callback: func(leases map[string]lease.Info) {
@@ -67,12 +71,46 @@ func (s *ExpireLeadershipSuite) TestStartup_ExpiryInFuture_TimePasses(c *gc.C) {
 	})
 }
 
+func (s *ExpireLeadershipSuite) TestStartup_NoExpiry_NotLongEnough(c *gc.C) {
+	fix := &Fixture{}
+	fix.RunTest(c, func(_ leadership.ManagerWorker, clock *coretesting.Clock) {
+		clock.Advance(almostSeconds(3600))
+	})
+}
+
+func (s *ExpireLeadershipSuite) TestStartup_NoExpiry_LongEnough(c *gc.C) {
+	fix := &Fixture{
+		leases: map[string]lease.Info{
+			"goose": lease.Info{Expiry: offset(3 * time.Hour)},
+		},
+		expectCalls: []call{{
+			method: "Refresh",
+			callback: func(leases map[string]lease.Info) {
+				leases["redis"] = lease.Info{
+					Expiry: offset(time.Minute),
+				}
+			},
+		}, {
+			method: "ExpireLease",
+			args:   []interface{}{"redis"},
+			callback: func(leases map[string]lease.Info) {
+				delete(leases, "redis")
+			},
+		}},
+	}
+	fix.RunTest(c, func(_ leadership.ManagerWorker, clock *coretesting.Clock) {
+		clock.Advance(time.Hour)
+	})
+}
+
 func (s *ExpireLeadershipSuite) TestExpire_ErrInvalid_Expired(c *gc.C) {
 	fix := &Fixture{
 		leases: map[string]lease.Info{
 			"redis": lease.Info{Expiry: offset(time.Second)},
 		},
 		expectCalls: []call{{
+			method: "Refresh",
+		}, {
 			method: "ExpireLease",
 			args:   []interface{}{"redis"},
 			err:    lease.ErrInvalid,
@@ -92,6 +130,8 @@ func (s *ExpireLeadershipSuite) TestExpire_ErrInvalid_Updated(c *gc.C) {
 			"redis": lease.Info{Expiry: offset(time.Second)},
 		},
 		expectCalls: []call{{
+			method: "Refresh",
+		}, {
 			method: "ExpireLease",
 			args:   []interface{}{"redis"},
 			err:    lease.ErrInvalid,
@@ -111,6 +151,8 @@ func (s *ExpireLeadershipSuite) TestExpire_OtherError(c *gc.C) {
 			"redis": lease.Info{Expiry: offset(time.Second)},
 		},
 		expectCalls: []call{{
+			method: "Refresh",
+		}, {
 			method: "ExpireLease",
 			args:   []interface{}{"redis"},
 			err:    errors.New("snarfblat hobalob"),
@@ -156,6 +198,8 @@ func (s *ExpireLeadershipSuite) TestClaim_ExpiryInFuture_TimePasses(c *gc.C) {
 					Expiry: offset(63 * time.Second),
 				}
 			},
+		}, {
+			method: "Refresh",
 		}, {
 			method: "ExpireLease",
 			args:   []interface{}{"redis"},
@@ -217,6 +261,8 @@ func (s *ExpireLeadershipSuite) TestExtend_ExpiryInFuture_TimePasses(c *gc.C) {
 				}
 			},
 		}, {
+			method: "Refresh",
+		}, {
 			method: "ExpireLease",
 			args:   []interface{}{"redis"},
 			callback: func(leases map[string]lease.Info) {
@@ -257,6 +303,8 @@ func (s *ExpireLeadershipSuite) TestExpire_Multiple(c *gc.C) {
 			},
 		},
 		expectCalls: []call{{
+			method: "Refresh",
+		}, {
 			method: "ExpireLease",
 			args:   []interface{}{"redis"},
 			callback: func(leases map[string]lease.Info) {

--- a/state/state.go
+++ b/state/state.go
@@ -207,8 +207,9 @@ func (st *State) start(serverTag names.EnvironTag) error {
 	}
 	logger.Infof("starting leadership manager")
 	leadershipManager, err := leadership.NewManager(leadership.ManagerConfig{
-		Client: leaseClient,
-		Clock:  clock,
+		Client:   leaseClient,
+		Clock:    clock,
+		MaxSleep: time.Minute,
 	})
 	if err != nil {
 		return errors.Annotatef(err, "cannot create leadership manager")

--- a/testing/clock.go
+++ b/testing/clock.go
@@ -7,18 +7,59 @@ import (
 	"sort"
 	"sync"
 	"time"
+
+	"github.com/juju/utils/clock"
 )
+
+// timerClock exposes the underlying Clock's capabilities to a Timer.
+type timerClock interface {
+	reset(id int, d time.Duration) bool
+	stop(id int) bool
+}
+
+// Timer implements a mock clock.Timer for testing purposes.
+type Timer struct {
+	ID    int
+	clock timerClock
+}
+
+// Reset is part of the clock.Timer interface.
+func (t *Timer) Reset(d time.Duration) bool {
+	return t.clock.reset(t.ID, d)
+}
+
+// Stop is part of the clock.Timer interface.
+func (t *Timer) Stop() bool {
+	return t.clock.stop(t.ID)
+}
+
+// stoppedTimer is a no-op implementation of clock.Timer.
+type stoppedTimer struct{}
+
+// Reset is part of the clock.Timer interface.
+func (stoppedTimer) Reset(time.Duration) bool { return false }
+
+// Stop is part of the clock.Timer interface.
+func (stoppedTimer) Stop() bool { return false }
 
 // Clock implements a mock clock.Clock for testing purposes.
 type Clock struct {
-	mu     sync.Mutex
-	now    time.Time
-	alarms []alarm
+	mu             sync.Mutex
+	now            time.Time
+	alarms         []alarm
+	currentAlarmID int
+	notifyAlarms   chan struct{}
 }
 
-// NewClock returns a new clock set to the supplied time.
+// NewClock returns a new clock set to the supplied time. If your SUT needs to
+// call After, AfterFunc, or Timer.Reset more than 1024 times: (1) you have
+// probably written a bad test; and (2) you'll need to read from the Alarms
+// chan to keep the buffer clear.
 func NewClock(now time.Time) *Clock {
-	return &Clock{now: now}
+	return &Clock{
+		now:          now,
+		notifyAlarms: make(chan struct{}, 1024),
+	}
 }
 
 // Now is part of the clock.Clock interface.
@@ -30,16 +71,29 @@ func (clock *Clock) Now() time.Time {
 
 // After is part of the clock.Clock interface.
 func (clock *Clock) After(d time.Duration) <-chan time.Time {
+	defer clock.notifyAlarm()
 	clock.mu.Lock()
 	defer clock.mu.Unlock()
 	notify := make(chan time.Time, 1)
 	if d <= 0 {
 		notify <- clock.now
 	} else {
-		clock.alarms = append(clock.alarms, alarm{clock.now.Add(d), notify})
-		sort.Sort(byTime(clock.alarms))
+		clock.setAlarm(clock.now.Add(d), func() { notify <- clock.now })
 	}
 	return notify
+}
+
+// AfterFunc is part of the clock.Clock interface.
+func (clock *Clock) AfterFunc(d time.Duration, f func()) clock.Timer {
+	defer clock.notifyAlarm()
+	clock.mu.Lock()
+	defer clock.mu.Unlock()
+	if d <= 0 {
+		f()
+		return &stoppedTimer{}
+	}
+	id := clock.setAlarm(clock.now.Add(d), f)
+	return &Timer{id, clock}
 }
 
 // Advance advances the result of Now by the supplied duration, and sends
@@ -48,21 +102,85 @@ func (clock *Clock) Advance(d time.Duration) {
 	clock.mu.Lock()
 	defer clock.mu.Unlock()
 	clock.now = clock.now.Add(d)
-	rung := 0
+	triggered := 0
 	for _, alarm := range clock.alarms {
 		if clock.now.Before(alarm.time) {
 			break
 		}
-		alarm.notify <- clock.now
-		rung++
+		alarm.trigger()
+		triggered++
 	}
-	clock.alarms = clock.alarms[rung:]
+	clock.alarms = clock.alarms[triggered:]
 }
 
-// alarm records the time at which we're expected to send on notify.
+// Alarms returns a channel on which you can read one value for every call to
+// After and AfterFunc; and for every successful Timer.Reset backed by this
+// Clock. It might not be elegant but it's necessary when testing time logic
+// that runs on a goroutine other than that of the test.
+func (clock *Clock) Alarms() <-chan struct{} {
+	return clock.notifyAlarms
+}
+
+// reset is the underlying implementation of clock.Timer.Reset, which may be
+// called by any Timer backed by this Clock.
+func (clock *Clock) reset(id int, d time.Duration) bool {
+	clock.mu.Lock()
+	defer clock.mu.Unlock()
+
+	for i, alarm := range clock.alarms {
+		if id == alarm.ID {
+			defer clock.notifyAlarm()
+			clock.alarms[i].time = clock.now.Add(d)
+			sort.Sort(byTime(clock.alarms))
+			return true
+		}
+	}
+	return false
+}
+
+// stop is the underlying implementation of clock.Timer.Reset, which may be
+// called by any Timer backed by this Clock.
+func (clock *Clock) stop(id int) bool {
+	clock.mu.Lock()
+	defer clock.mu.Unlock()
+
+	for i, alarm := range clock.alarms {
+		if id == alarm.ID {
+			clock.alarms = removeFromSlice(clock.alarms, i)
+			return true
+		}
+	}
+	return false
+}
+
+// setAlarm adds an alarm at time t.
+// It also sorts the alarms and increments the current ID by 1.
+func (clock *Clock) setAlarm(t time.Time, trigger func()) int {
+	alarm := alarm{
+		time:    t,
+		trigger: trigger,
+		ID:      clock.currentAlarmID,
+	}
+	clock.alarms = append(clock.alarms, alarm)
+	sort.Sort(byTime(clock.alarms))
+	clock.currentAlarmID = clock.currentAlarmID + 1
+	return alarm.ID
+}
+
+// notifyAlarm sends a value on the channel exposed by Alarms().
+func (clock *Clock) notifyAlarm() {
+	select {
+	case clock.notifyAlarms <- struct{}{}:
+	default:
+		panic("alarm notification buffer full")
+	}
+}
+
+// alarm records the time at which we're expected to execute trigger.
 type alarm struct {
-	time   time.Time
-	notify chan time.Time
+	ID      int
+	time    time.Time
+	trigger func()
 }
 
 // byTime is used to sort alarms by time.
@@ -71,3 +189,8 @@ type byTime []alarm
 func (a byTime) Len() int           { return len(a) }
 func (a byTime) Less(i, j int) bool { return a[i].time.Before(a[j].time) }
 func (a byTime) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+
+// removeFromSlice removes item at the specified index from the slice.
+func removeFromSlice(sl []alarm, index int) []alarm {
+	return append(sl[:index], sl[index+1:]...)
+}


### PR DESCRIPTION
Fixes LP 1511659

Backport for 1.25

From @fwereade
> Eliminate sleep-forever case in leadership manager worker; config struct now expects a positive MaxSleep duration, which is (in effect) the longest time the manager will go without explicitly resyncing its cache.

Prior to this change, as soon as the leadership.Manager started it would check to see if any of the leases it managed were about to expire and if so it would go through the expiration cycle. However if there were no leases currently under management, then it would return nil, thus removing itself from the selectable set -- the manager would sleep until either a claim or check operation happened, or the tomb was killed.

Electing a new leader requires that the old leadership lease is expired; not just out of date. It's the act of expiration which triggers a new election. Hence expiring the lease is required to trigger a re-election which then triggers the claim or check operation -- if there is no expiration then the manager sleeps because nobody will issues claims or checks.

To rectify this, the manager now wakes periodically and refreshes it's cache from the database, this causes the next pass of the loop to find leases to expire, which it then does, triggering re-election and unblocking the whole shebang.

(Review request: http://reviews.vapour.ws/r/3645/)