### PR TITLE
provider/maas: backport bridge script from maas-spaces branch

### DIFF
--- a/provider/maas/Makefile
+++ b/provider/maas/Makefile
@@ -1,13 +1,23 @@
 all: bridgescript.go
 
+# TODO add bridgescript_doc.go that explains (in a package comment)
+# what this script (add-juju-bridge.py) does, and why, and how to
+# change it.
+
 bridgescript.go: add-juju-bridge.py Makefile
 	$(RM) $@
 	echo -n '// This file is auto generated. Edits will be lost.\n\n' >> $@
 	echo -n 'package maas\n\n' >> $@
 	echo -n '//go:generate make -q\n\n' >> $@
-	echo -n "const bridgeScriptPythonBashDef = \`python_script=\$$(cat <<'PYTHON_SCRIPT'\n" >> $@
+	echo -n 'import "path"\n\n' >> $@
+	echo -n 'const bridgeScriptName = "add-juju-bridge.py"\n\n' >> $@
+	echo -n 'var bridgeScriptPath = path.Join("/tmp", bridgeScriptName)\n\n' >> $@
+	echo -n "const bridgeScriptPython = \`" >> $@
 	cat add-juju-bridge.py >> $@
-	echo -n 'PYTHON_SCRIPT\n)`\n' >> $@
+	echo -n '`\n' >> $@
+
+format:
+	pyfmt -i add-juju-bridge.py
 
 clean:
 	$(RM) bridgescript.go

--- a/provider/maas/add-juju-bridge.py
+++ b/provider/maas/add-juju-bridge.py
@@ -3,6 +3,10 @@
 # Copyright 2015 Canonical Ltd.
 # Licensed under the AGPLv3, see LICENCE file for details.
 
+#
+# This file has been and should be formatted using pyfmt(1).
+#
+
 from __future__ import print_function
 import argparse
 import os
@@ -11,9 +15,6 @@ import shutil
 import subprocess
 import sys
 
-
-# This script re-renders an interfaces(5) file to enslave the primary
-# NIC with a bridge. It is aware of bond interfaces and aliases.
 
 class SeekableIterator(object):
     """An iterator that supports relative seeking."""
@@ -45,44 +46,126 @@ class SeekableIterator(object):
             raise IndexError
 
 
-class Stanza(object):
-    """Represents one stanza together with all its options."""
+class PhysicalInterface(object):
+    """Represents a physical ('auto') interface."""
+
+    def __init__(self, definition):
+        self.name = definition.split()[1]
+
+    def __str__(self):
+        return self.name
+
+
+class LogicalInterface(object):
+    """Represents a logical ('iface') interface."""
 
     def __init__(self, definition, options=None):
         if not options:
             options = []
-        self._definition = definition
-        self._options = options
+        _, self.name, self.family, self.method = definition.split()
+        self.options = options
+        self.is_bonded = [x for x in self.options if "bond-" in x]
+        self.is_alias = ":" in self.name
+        self.is_vlan = [x for x in self.options if x.startswith("vlan-raw-device")]
+        self.is_active = self.method == "dhcp" or self.method == "static"
 
-    def is_physical_interface(self):
-        return self._definition.startswith('auto ')
+    def __str__(self):
+        return self.name
 
-    def is_logical_interface(self):
-        return self._definition.startswith('iface ')
+    # Returns an ordered set of stanzas to bridge this interface.
+    def bridge(self, prefix, bridge_name, add_auto_stanza):
+        if bridge_name is None:
+            bridge_name = prefix + self.name
+        # Note: the testing order here is significant.
+        if not self.is_active:
+            return self._bridge_inactive(add_auto_stanza)
+        elif self.is_alias:
+            return self._bridge_alias(add_auto_stanza)
+        elif self.is_vlan:
+            return self._bridge_vlan(prefix, bridge_name, add_auto_stanza)
+        elif self.is_bonded:
+            return self._bridge_bond(prefix, bridge_name, add_auto_stanza)
+        else:
+            return self._bridge_device(prefix, bridge_name)
 
-    def options(self):
-        return self._options
+    def _bridge_device(self, prefix, bridge_name):
+        s1 = IfaceStanza(self.name, self.family, "manual", [])
+        s2 = AutoStanza(bridge_name)
+        options = list(self.options)
+        options.append("bridge_ports {}".format(self.name))
+        s3 = IfaceStanza(bridge_name, self.family, self.method, options)
+        return [s1, s2, s3]
 
-    def definition(self):
-        return self._definition
+    def _bridge_vlan(self, prefix, bridge_name, add_auto_stanza):
+        stanzas = []
+        s1 = IfaceStanza(self.name, self.family, "manual", self.options)
+        stanzas.append(s1)
+        if add_auto_stanza:
+            stanzas.append(AutoStanza(bridge_name))
+        options = [x for x in self.options if not x.startswith("vlan")]
+        options.append("bridge_ports {}".format(self.name))
+        s3 = IfaceStanza(bridge_name, self.family, self.method, options)
+        stanzas.append(s3)
+        return stanzas
 
-    def interface_name(self):
-        if self.is_physical_interface():
-            return self._definition.split()[1]
-        if self.is_logical_interface():
-            return self._definition.split()[1]
-        return None
+    def _bridge_alias(self, add_auto_stanza):
+        stanzas = []
+        if add_auto_stanza:
+            stanzas.append(AutoStanza(self.name))
+        s1 = IfaceStanza(self.name, self.family, self.method, list(self.options))
+        stanzas.append(s1)
+        return stanzas
+
+    def _bridge_bond(self, prefix, bridge_name, add_auto_stanza):
+        stanzas = []
+        if add_auto_stanza:
+            stanzas.append(AutoStanza(self.name))
+        s1 = IfaceStanza(self.name, self.family, "manual", list(self.options))
+        s2 = AutoStanza(bridge_name)
+        options = [x for x in self.options if not x.startswith("bond")]
+        options.append("bridge_ports {}".format(self.name))
+        s3 = IfaceStanza(bridge_name, self.family, self.method, options)
+        stanzas.extend([s1, s2, s3])
+        return stanzas
+
+    def _bridge_inactive(self, add_auto_stanza):
+        stanzas = []
+        if add_auto_stanza:
+            stanzas.append(AutoStanza(self.name))
+        s1 = IfaceStanza(self.name, self.family, self.method, list(self.options))
+        stanzas.append(s1)
+        return stanzas
+
+
+class Stanza(object):
+    """Represents one stanza together with all of its options."""
+
+    def __init__(self, definition, options=None):
+        if not options:
+            options = []
+        self.definition = definition
+        self.options = options
+        self.is_logical_interface = definition.startswith('iface ')
+        self.is_physical_interface = definition.startswith('auto ')
+        self.iface = None
+        self.phy = None
+        if self.is_logical_interface:
+            self.iface = LogicalInterface(definition, self.options)
+        if self.is_physical_interface:
+            self.phy = PhysicalInterface(definition)
+
+    def __str__(self):
+        return self.definition
 
 
 class NetworkInterfaceParser(object):
-    """Parse a network interface file into its set of stanzas."""
+    """Parse a network interface file into a set of stanzas."""
 
     @classmethod
     def is_stanza(cls, s):
         return re.match(r'^(iface|mapping|auto|allow-|source)', s)
 
     def __init__(self, filename):
-        self._filename = filename
         self._stanzas = []
         with open(filename) as f:
             lines = f.readlines()
@@ -107,95 +190,79 @@ class NetworkInterfaceParser(object):
     def stanzas(self):
         return [x for x in self._stanzas]
 
+    def physical_interfaces(self):
+        return {x.phy.name: x.phy for x in [y for y in self._stanzas if y.is_physical_interface]}
+
+    def __iter__(self):  # class iter
+        for s in self._stanzas:
+            yield s
+
+
+def uniq_append(dst, src):
+    for x in src:
+        if x not in dst:
+            dst.append(x)
+    return dst
+
+
+def IfaceStanza(name, family, method, options):
+    """Convenience function to create a new "iface" stanza.
+
+Maintains original options order but removes duplicates with the
+exception of 'dns-*' options which are normlised as required by
+resolvconf(8) and all the dns-* options are moved to the end.
+
+    """
+
+    dns_search = []
+    dns_nameserver = []
+    dns_sortlist = []
+    unique_options = []
+
+    for o in options:
+        words = o.split()
+        ident = words[0]
+        if ident == "dns-nameservers":
+            dns_nameserver = uniq_append(dns_nameserver, words[1:])
+        elif ident == "dns-search":
+            dns_search = uniq_append(dns_search, words[1:])
+        elif ident == "dns-sortlist":
+            dns_sortlist = uniq_append(dns_sortlist, words[1:])
+        elif o not in unique_options:
+            unique_options.append(o)
+
+    if dns_nameserver:
+        option = "dns-nameservers " + " ".join(dns_nameserver)
+        unique_options.append(option)
+
+    if dns_search:
+        option = "dns-search " + " ".join(dns_search)
+        unique_options.append(option)
+
+    if dns_sortlist:
+        option = "dns-sortlist " + " ".join(dns_sortlist)
+        unique_options.append(option)
+
+    return Stanza("iface {} {} {}".format(name, family, method), unique_options)
+
+
+def AutoStanza(name):
+    # Convenience function to create a new "auto" stanza.
+    return Stanza("auto {}".format(name))
+
 
 def print_stanza(s, stream=sys.stdout):
-    print(s.definition(), file=stream)
-    for o in s.options():
+    print(s.definition, file=stream)
+    for o in s.options:
         print("   ", o, file=stream)
 
 
 def print_stanzas(stanzas, stream=sys.stdout):
     n = len(stanzas)
-    for i, s in enumerate(stanzas):
-        print_stanza(s, stream)
-        if s.is_logical_interface() and i + 1 < n:
+    for i, stanza in enumerate(stanzas):
+        print_stanza(stanza, stream)
+        if stanza.is_logical_interface and i + 1 < n:
             print(file=stream)
-
-
-# Parses filename and returns a set of stanzas that have the existing
-# primary NIC bridged.
-def add_bridge(filename, bridge_name, primary_nic, bonded):
-    stanzas = []
-
-    for s in NetworkInterfaceParser(filename).stanzas():
-        if not s.is_logical_interface() and not s.is_physical_interface():
-            stanzas.append(s)
-            continue
-
-        if primary_nic != s.interface_name() and \
-                        primary_nic not in s.interface_name():
-            stanzas.append(s)
-            continue
-
-        if bonded:
-            if s.is_physical_interface():
-                stanzas.append(s)
-            else:
-                iface, orig_name, addr_family, method = s.definition().split()
-                stanzas.append(Stanza("iface {} {} manual".format(orig_name, addr_family), s.options()))
-
-                # new auto <bridge_name>
-                stanzas.append(Stanza("auto {}".format(bridge_name)))
-
-                # new iface <bridge_name> ...
-                options = [x for x in s.options() if not x.startswith("bond")]
-                options.insert(0, "bridge_ports {}".format(primary_nic))
-                options.append("pre-up ip link add dev {} name {} type bridge || true".format(orig_name, bridge_name))
-                stanzas.append(Stanza("iface {} {} {}".format(bridge_name, addr_family, method), options))
-            continue
-
-        if primary_nic == s.interface_name():
-            if s.is_physical_interface():
-                # The net change:
-                #   auto eth0
-                # to:
-                #   auto <bridge_name>
-                words = s.definition().split()
-                words[1] = bridge_name
-                stanzas.append(Stanza(" ".join(words)))
-            else:
-                # The net change is:
-                #   auto eth0
-                #   iface eth0 inet <config>
-                # to:
-                #   iface eth0 inet manual
-                #
-                #   auto <bridge_name>
-                #   iface <bridge_name> inet <config>
-                words = s.definition().split()
-                words[3] = "manual"
-                if len(stanzas) > 0:
-                    last_stanza = stanzas.pop()
-                else:
-                    last_stanza = None
-                stanzas.append(Stanza(" ".join(words)))
-                if last_stanza:
-                    stanzas.append(last_stanza)
-                # Replace existing 'iface' line with new <bridge_name>
-                words = s.definition().split()
-                words[1] = bridge_name
-                options = s.options()
-                options.insert(0, "bridge_ports {}".format(primary_nic))
-                stanzas.append(Stanza(" ".join(words), options))
-            continue
-
-        # Aliases, hence the 'eth0' in 'auto eth0:1'.
-
-        if primary_nic in s.definition():
-            definition = s.definition().replace(primary_nic, bridge_name)
-            stanzas.append(Stanza(definition, s.options()))
-
-    return stanzas
 
 
 def shell_cmd(s):
@@ -204,141 +271,102 @@ def shell_cmd(s):
     return [out, err, p.returncode]
 
 
-def print_shell_cmd(s, verbose=True, exitOnError=False):
-    if verbose: print(s)
+def print_shell_cmd(s, verbose=True, exit_on_error=False):
+    if verbose:
+        print(s)
     out, err, retcode = shell_cmd(s)
     if out and len(out) > 0:
-        print(out.rstrip(chr(10)))
+        print(out.rstrip('\n'))
     if err and len(err) > 0:
-        print(err.rstrip(chr(10)))
-    if exitOnError and retcode != 0:
-        sys.exit(1)
+        print(err.rstrip('\n'))
+    if exit_on_error and retcode != 0:
+        exit(1)
 
 
 def check_shell_cmd(s, verbose=False):
-    if verbose: print(s)
+    if verbose:
+        print(s)
     output = subprocess.check_output(s, shell=True, stderr=subprocess.STDOUT).strip().decode("utf-8")
-    if verbose: print(output.rstrip('\n'))
+    if verbose:
+        print(output.rstrip('\n'))
     return output
 
 
-def get_gateway(ver='-4'):
-    return check_shell_cmd("ip {} route list exact default | head -n1 | cut -d' ' -f3".format(ver))
+def arg_parser():
+    parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument('--bridge-prefix', help="bridge prefix", type=str, required=False, default='br-')
+    parser.add_argument('--one-time-backup', help='A one time backup of filename', action='store_true', default=True, required=False)
+    parser.add_argument('--activate', help='activate new configuration', action='store_true', default=False, required=False)
+    parser.add_argument('--interface-to-bridge', help="interface to bridge", type=str, required=False)
+    parser.add_argument('--bridge-name', help="bridge name", type=str, required=False)
+    parser.add_argument('filename', help="interfaces(5) based filename")
+    return parser
 
 
-def get_primary_nic(ver='-4'):
-    return check_shell_cmd("ip {} route list exact default | head -n1 | cut -d' ' -f5".format(ver))
+def main(args):
+    if args.bridge_name and args.interface_to_bridge is None:
+        sys.stderr.write("error: --interface-to-bridge required when using --bridge-name\n")
+        exit(1)
 
+    if args.interface_to_bridge and args.bridge_name is None:
+        sys.stderr.write("error: --bridge-name required when using --interface-to-bridge\n")
+        exit(1)
 
-def is_nic_bonded(name):
-    out, err, retcode = shell_cmd("cat {}".format("/sys/class/net/bonding_masters"))
-    return name in out
+    stanzas = []
+    config_parser = NetworkInterfaceParser(args.filename)
+    physical_interfaces = config_parser.physical_interfaces()
 
+    # Bridging requires modifying 'auto' and 'iface' stanzas only.
+    # Calling <iface>.bridge() will return a set of stanzas that cover
+    # both of those stanzas. The 'elif' clause catches all the other
+    # stanza types. The args.interface_to_bridge test is to bridge a
+    # single interface only, which is only used for juju < 2.0. And if
+    # that argument is specified then args.bridge_name takes
+    # precendence over any args.bridge_prefix.
 
-def is_bridged(name, filename):
-    for s in NetworkInterfaceParser(filename).stanzas():
-        if name in s.definition():
-            return True
-    return False
+    for s in config_parser.stanzas():
+        if s.is_logical_interface:
+            add_auto_stanza = s.iface.name in physical_interfaces
+            if args.interface_to_bridge and args.interface_to_bridge != s.iface.name:
+                if add_auto_stanza:
+                    stanzas.append(AutoStanza(s.iface.name))
+                stanzas.append(s)
+            else:
+                stanzas.extend(s.iface.bridge(args.bridge_prefix, args.bridge_name, add_auto_stanza))
+        elif not s.is_physical_interface:
+            stanzas.append(s)
 
+    if not args.activate:
+        print_stanzas(stanzas)
+        exit(0)
 
-def link_is_up(name):
-    out, err, retcode = shell_cmd('ip link show {} up'.format(name))
-    return re.search(r'\s+{}:\s+.*\s+state\s+UP\s+'.format(name), out)
+    if args.one_time_backup:
+        backup_file = "{}-before-add-juju-bridge".format(args.filename)
+        if not os.path.isfile(backup_file):
+            shutil.copy2(args.filename, backup_file)
 
+    ifquery = "$(ifquery -i {} --exclude=lo -l)".format(args.filename)
 
-def ifup(name, retries=5):
-    if retries < 1:
-        retries = 1
-    i = 1
-    while i <= retries:
-        print("link {} not up, attempt ({}/{})".format(name, i, retries))
-        print_shell_cmd("ifdown -v -a")
-        print_shell_cmd("ifup -v -a")
-        if link_is_up(name):
-            return True
-        print_shell_cmd("ip link")
-        i += 1
-    return False
+    print("**** Original configuration")
+    print_shell_cmd("cat {}".format(args.filename))
+    print_shell_cmd("ifconfig -a")
+    print_shell_cmd("ifdown --exclude=lo -i {} {}".format(args.filename, ifquery))
 
+    print("**** Activating new configuration")
 
-parser = argparse.ArgumentParser()
+    with open(args.filename, 'w') as f:
+        print_stanzas(stanzas, f)
+        f.close()
 
-parser.add_argument('--filename',
-                    help='filename to re-render',
-                    type=str,
-                    required=False,
-                    default="/etc/network/interfaces")
+    print_shell_cmd("cat {}".format(args.filename))
+    print_shell_cmd("ifup --exclude=lo -i {} {}".format(args.filename, ifquery))
+    print_shell_cmd("ip link show up")
+    print_shell_cmd("ifconfig -a")
+    print_shell_cmd("ip route show")
+    print_shell_cmd("brctl show")
 
-parser.add_argument('--bridge-name',
-                    help="bridge name",
-                    type=str,
-                    required=False,
-                    default='juju-br0')
+# This script re-renders an interfaces(5) file to add a bridge to
+# either all active interfaces, or a specific interface.
 
-parser.add_argument('--primary-nic',
-                    help="primary NIC name",
-                    type=str,
-                    required=False)
-
-parser.add_argument('--primary-nic-is-bonded',
-                    help="primary NIC is bonded",
-                    action='store_true',
-                    required=False)
-
-parser.add_argument('--render-only',
-                    help='render to stdout, no network restart',
-                    action='store_true',
-                    required=False)
-
-parser.add_argument('--backup-filename',
-                    help='backup filename',
-                    type=str,
-                    required=False)
-
-args = parser.parse_args()
-
-if is_bridged(args.bridge_name, args.filename):
-    print("already bridged; nothing to do")
-    sys.exit(0)
-
-if not args.primary_nic:
-    args.primary_nic = get_primary_nic()
-
-if not args.primary_nic_is_bonded:
-    args.primary_nic_is_bonded = is_nic_bonded(args.primary_nic)
-
-bridged_stanzas = add_bridge(args.filename,
-                             args.bridge_name,
-                             args.primary_nic,
-                             args.primary_nic_is_bonded)
-
-if args.render_only:
-    print_stanzas(bridged_stanzas)
-    sys.exit(0)
-
-if not get_gateway():
-    print("no default gw; continue continue")
-    sys.exit(1)
-
-if args.backup_filename and not os.path.isfile(args.backup_filename):
-    shutil.copy2(args.filename, args.backup_filename)
-
-print("**** Original configuration")
-print_shell_cmd("cat {}".format(args.filename))
-print_shell_cmd("ifconfig -a")
-print_shell_cmd("ip route show")
-print_shell_cmd("ifdown -v -a")
-
-print("**** Activating new configuration")
-
-with open(args.filename, 'w') as f:
-    print_stanzas(bridged_stanzas, f)
-    f.close()
-
-if not ifup(args.bridge_name):
-    sys.exit(1)
-
-print_shell_cmd("ifconfig -a")
-print_shell_cmd("ip route show")
-print_shell_cmd("brctl show")
+if __name__ == '__main__':
+    main(arg_parser().parse_args())

--- a/provider/maas/bridgescript.go
+++ b/provider/maas/bridgescript.go
@@ -4,11 +4,20 @@ package maas
 
 //go:generate make -q
 
-const bridgeScriptPythonBashDef = `python_script=$(cat <<'PYTHON_SCRIPT'
-#!/usr/bin/env python
+import "path"
+
+const bridgeScriptName = "add-juju-bridge.py"
+
+var bridgeScriptPath = path.Join("/tmp", bridgeScriptName)
+
+const bridgeScriptPython = `#!/usr/bin/env python
 
 # Copyright 2015 Canonical Ltd.
 # Licensed under the AGPLv3, see LICENCE file for details.
+
+#
+# This file has been and should be formatted using pyfmt(1).
+#
 
 from __future__ import print_function
 import argparse
@@ -18,9 +27,6 @@ import shutil
 import subprocess
 import sys
 
-
-# This script re-renders an interfaces(5) file to enslave the primary
-# NIC with a bridge. It is aware of bond interfaces and aliases.
 
 class SeekableIterator(object):
     """An iterator that supports relative seeking."""
@@ -52,44 +58,126 @@ class SeekableIterator(object):
             raise IndexError
 
 
-class Stanza(object):
-    """Represents one stanza together with all its options."""
+class PhysicalInterface(object):
+    """Represents a physical ('auto') interface."""
+
+    def __init__(self, definition):
+        self.name = definition.split()[1]
+
+    def __str__(self):
+        return self.name
+
+
+class LogicalInterface(object):
+    """Represents a logical ('iface') interface."""
 
     def __init__(self, definition, options=None):
         if not options:
             options = []
-        self._definition = definition
-        self._options = options
+        _, self.name, self.family, self.method = definition.split()
+        self.options = options
+        self.is_bonded = [x for x in self.options if "bond-" in x]
+        self.is_alias = ":" in self.name
+        self.is_vlan = [x for x in self.options if x.startswith("vlan-raw-device")]
+        self.is_active = self.method == "dhcp" or self.method == "static"
 
-    def is_physical_interface(self):
-        return self._definition.startswith('auto ')
+    def __str__(self):
+        return self.name
 
-    def is_logical_interface(self):
-        return self._definition.startswith('iface ')
+    # Returns an ordered set of stanzas to bridge this interface.
+    def bridge(self, prefix, bridge_name, add_auto_stanza):
+        if bridge_name is None:
+            bridge_name = prefix + self.name
+        # Note: the testing order here is significant.
+        if not self.is_active:
+            return self._bridge_inactive(add_auto_stanza)
+        elif self.is_alias:
+            return self._bridge_alias(add_auto_stanza)
+        elif self.is_vlan:
+            return self._bridge_vlan(prefix, bridge_name, add_auto_stanza)
+        elif self.is_bonded:
+            return self._bridge_bond(prefix, bridge_name, add_auto_stanza)
+        else:
+            return self._bridge_device(prefix, bridge_name)
 
-    def options(self):
-        return self._options
+    def _bridge_device(self, prefix, bridge_name):
+        s1 = IfaceStanza(self.name, self.family, "manual", [])
+        s2 = AutoStanza(bridge_name)
+        options = list(self.options)
+        options.append("bridge_ports {}".format(self.name))
+        s3 = IfaceStanza(bridge_name, self.family, self.method, options)
+        return [s1, s2, s3]
 
-    def definition(self):
-        return self._definition
+    def _bridge_vlan(self, prefix, bridge_name, add_auto_stanza):
+        stanzas = []
+        s1 = IfaceStanza(self.name, self.family, "manual", self.options)
+        stanzas.append(s1)
+        if add_auto_stanza:
+            stanzas.append(AutoStanza(bridge_name))
+        options = [x for x in self.options if not x.startswith("vlan")]
+        options.append("bridge_ports {}".format(self.name))
+        s3 = IfaceStanza(bridge_name, self.family, self.method, options)
+        stanzas.append(s3)
+        return stanzas
 
-    def interface_name(self):
-        if self.is_physical_interface():
-            return self._definition.split()[1]
-        if self.is_logical_interface():
-            return self._definition.split()[1]
-        return None
+    def _bridge_alias(self, add_auto_stanza):
+        stanzas = []
+        if add_auto_stanza:
+            stanzas.append(AutoStanza(self.name))
+        s1 = IfaceStanza(self.name, self.family, self.method, list(self.options))
+        stanzas.append(s1)
+        return stanzas
+
+    def _bridge_bond(self, prefix, bridge_name, add_auto_stanza):
+        stanzas = []
+        if add_auto_stanza:
+            stanzas.append(AutoStanza(self.name))
+        s1 = IfaceStanza(self.name, self.family, "manual", list(self.options))
+        s2 = AutoStanza(bridge_name)
+        options = [x for x in self.options if not x.startswith("bond")]
+        options.append("bridge_ports {}".format(self.name))
+        s3 = IfaceStanza(bridge_name, self.family, self.method, options)
+        stanzas.extend([s1, s2, s3])
+        return stanzas
+
+    def _bridge_inactive(self, add_auto_stanza):
+        stanzas = []
+        if add_auto_stanza:
+            stanzas.append(AutoStanza(self.name))
+        s1 = IfaceStanza(self.name, self.family, self.method, list(self.options))
+        stanzas.append(s1)
+        return stanzas
+
+
+class Stanza(object):
+    """Represents one stanza together with all of its options."""
+
+    def __init__(self, definition, options=None):
+        if not options:
+            options = []
+        self.definition = definition
+        self.options = options
+        self.is_logical_interface = definition.startswith('iface ')
+        self.is_physical_interface = definition.startswith('auto ')
+        self.iface = None
+        self.phy = None
+        if self.is_logical_interface:
+            self.iface = LogicalInterface(definition, self.options)
+        if self.is_physical_interface:
+            self.phy = PhysicalInterface(definition)
+
+    def __str__(self):
+        return self.definition
 
 
 class NetworkInterfaceParser(object):
-    """Parse a network interface file into its set of stanzas."""
+    """Parse a network interface file into a set of stanzas."""
 
     @classmethod
     def is_stanza(cls, s):
         return re.match(r'^(iface|mapping|auto|allow-|source)', s)
 
     def __init__(self, filename):
-        self._filename = filename
         self._stanzas = []
         with open(filename) as f:
             lines = f.readlines()
@@ -114,95 +202,79 @@ class NetworkInterfaceParser(object):
     def stanzas(self):
         return [x for x in self._stanzas]
 
+    def physical_interfaces(self):
+        return {x.phy.name: x.phy for x in [y for y in self._stanzas if y.is_physical_interface]}
+
+    def __iter__(self):  # class iter
+        for s in self._stanzas:
+            yield s
+
+
+def uniq_append(dst, src):
+    for x in src:
+        if x not in dst:
+            dst.append(x)
+    return dst
+
+
+def IfaceStanza(name, family, method, options):
+    """Convenience function to create a new "iface" stanza.
+
+Maintains original options order but removes duplicates with the
+exception of 'dns-*' options which are normlised as required by
+resolvconf(8) and all the dns-* options are moved to the end.
+
+    """
+
+    dns_search = []
+    dns_nameserver = []
+    dns_sortlist = []
+    unique_options = []
+
+    for o in options:
+        words = o.split()
+        ident = words[0]
+        if ident == "dns-nameservers":
+            dns_nameserver = uniq_append(dns_nameserver, words[1:])
+        elif ident == "dns-search":
+            dns_search = uniq_append(dns_search, words[1:])
+        elif ident == "dns-sortlist":
+            dns_sortlist = uniq_append(dns_sortlist, words[1:])
+        elif o not in unique_options:
+            unique_options.append(o)
+
+    if dns_nameserver:
+        option = "dns-nameservers " + " ".join(dns_nameserver)
+        unique_options.append(option)
+
+    if dns_search:
+        option = "dns-search " + " ".join(dns_search)
+        unique_options.append(option)
+
+    if dns_sortlist:
+        option = "dns-sortlist " + " ".join(dns_sortlist)
+        unique_options.append(option)
+
+    return Stanza("iface {} {} {}".format(name, family, method), unique_options)
+
+
+def AutoStanza(name):
+    # Convenience function to create a new "auto" stanza.
+    return Stanza("auto {}".format(name))
+
 
 def print_stanza(s, stream=sys.stdout):
-    print(s.definition(), file=stream)
-    for o in s.options():
+    print(s.definition, file=stream)
+    for o in s.options:
         print("   ", o, file=stream)
 
 
 def print_stanzas(stanzas, stream=sys.stdout):
     n = len(stanzas)
-    for i, s in enumerate(stanzas):
-        print_stanza(s, stream)
-        if s.is_logical_interface() and i + 1 < n:
+    for i, stanza in enumerate(stanzas):
+        print_stanza(stanza, stream)
+        if stanza.is_logical_interface and i + 1 < n:
             print(file=stream)
-
-
-# Parses filename and returns a set of stanzas that have the existing
-# primary NIC bridged.
-def add_bridge(filename, bridge_name, primary_nic, bonded):
-    stanzas = []
-
-    for s in NetworkInterfaceParser(filename).stanzas():
-        if not s.is_logical_interface() and not s.is_physical_interface():
-            stanzas.append(s)
-            continue
-
-        if primary_nic != s.interface_name() and \
-                        primary_nic not in s.interface_name():
-            stanzas.append(s)
-            continue
-
-        if bonded:
-            if s.is_physical_interface():
-                stanzas.append(s)
-            else:
-                iface, orig_name, addr_family, method = s.definition().split()
-                stanzas.append(Stanza("iface {} {} manual".format(orig_name, addr_family), s.options()))
-
-                # new auto <bridge_name>
-                stanzas.append(Stanza("auto {}".format(bridge_name)))
-
-                # new iface <bridge_name> ...
-                options = [x for x in s.options() if not x.startswith("bond")]
-                options.insert(0, "bridge_ports {}".format(primary_nic))
-                options.append("pre-up ip link add dev {} name {} type bridge || true".format(orig_name, bridge_name))
-                stanzas.append(Stanza("iface {} {} {}".format(bridge_name, addr_family, method), options))
-            continue
-
-        if primary_nic == s.interface_name():
-            if s.is_physical_interface():
-                # The net change:
-                #   auto eth0
-                # to:
-                #   auto <bridge_name>
-                words = s.definition().split()
-                words[1] = bridge_name
-                stanzas.append(Stanza(" ".join(words)))
-            else:
-                # The net change is:
-                #   auto eth0
-                #   iface eth0 inet <config>
-                # to:
-                #   iface eth0 inet manual
-                #
-                #   auto <bridge_name>
-                #   iface <bridge_name> inet <config>
-                words = s.definition().split()
-                words[3] = "manual"
-                if len(stanzas) > 0:
-                    last_stanza = stanzas.pop()
-                else:
-                    last_stanza = None
-                stanzas.append(Stanza(" ".join(words)))
-                if last_stanza:
-                    stanzas.append(last_stanza)
-                # Replace existing 'iface' line with new <bridge_name>
-                words = s.definition().split()
-                words[1] = bridge_name
-                options = s.options()
-                options.insert(0, "bridge_ports {}".format(primary_nic))
-                stanzas.append(Stanza(" ".join(words), options))
-            continue
-
-        # Aliases, hence the 'eth0' in 'auto eth0:1'.
-
-        if primary_nic in s.definition():
-            definition = s.definition().replace(primary_nic, bridge_name)
-            stanzas.append(Stanza(definition, s.options()))
-
-    return stanzas
 
 
 def shell_cmd(s):
@@ -211,143 +283,103 @@ def shell_cmd(s):
     return [out, err, p.returncode]
 
 
-def print_shell_cmd(s, verbose=True, exitOnError=False):
-    if verbose: print(s)
+def print_shell_cmd(s, verbose=True, exit_on_error=False):
+    if verbose:
+        print(s)
     out, err, retcode = shell_cmd(s)
     if out and len(out) > 0:
-        print(out.rstrip(chr(10)))
+        print(out.rstrip('\n'))
     if err and len(err) > 0:
-        print(err.rstrip(chr(10)))
-    if exitOnError and retcode != 0:
-        sys.exit(1)
+        print(err.rstrip('\n'))
+    if exit_on_error and retcode != 0:
+        exit(1)
 
 
 def check_shell_cmd(s, verbose=False):
-    if verbose: print(s)
+    if verbose:
+        print(s)
     output = subprocess.check_output(s, shell=True, stderr=subprocess.STDOUT).strip().decode("utf-8")
-    if verbose: print(output.rstrip('\n'))
+    if verbose:
+        print(output.rstrip('\n'))
     return output
 
 
-def get_gateway(ver='-4'):
-    return check_shell_cmd("ip {} route list exact default | head -n1 | cut -d' ' -f3".format(ver))
+def arg_parser():
+    parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument('--bridge-prefix', help="bridge prefix", type=str, required=False, default='br-')
+    parser.add_argument('--one-time-backup', help='A one time backup of filename', action='store_true', default=True, required=False)
+    parser.add_argument('--activate', help='activate new configuration', action='store_true', default=False, required=False)
+    parser.add_argument('--interface-to-bridge', help="interface to bridge", type=str, required=False)
+    parser.add_argument('--bridge-name', help="bridge name", type=str, required=False)
+    parser.add_argument('filename', help="interfaces(5) based filename")
+    return parser
 
 
-def get_primary_nic(ver='-4'):
-    return check_shell_cmd("ip {} route list exact default | head -n1 | cut -d' ' -f5".format(ver))
+def main(args):
+    if args.bridge_name and args.interface_to_bridge is None:
+        sys.stderr.write("error: --interface-to-bridge required when using --bridge-name\n")
+        exit(1)
 
+    if args.interface_to_bridge and args.bridge_name is None:
+        sys.stderr.write("error: --bridge-name required when using --interface-to-bridge\n")
+        exit(1)
 
-def is_nic_bonded(name):
-    out, err, retcode = shell_cmd("cat {}".format("/sys/class/net/bonding_masters"))
-    return name in out
+    stanzas = []
+    config_parser = NetworkInterfaceParser(args.filename)
+    physical_interfaces = config_parser.physical_interfaces()
 
+    # Bridging requires modifying 'auto' and 'iface' stanzas only.
+    # Calling <iface>.bridge() will return a set of stanzas that cover
+    # both of those stanzas. The 'elif' clause catches all the other
+    # stanza types. The args.interface_to_bridge test is to bridge a
+    # single interface only, which is only used for juju < 2.0. And if
+    # that argument is specified then args.bridge_name takes
+    # precendence over any args.bridge_prefix.
 
-def is_bridged(name, filename):
-    for s in NetworkInterfaceParser(filename).stanzas():
-        if name in s.definition():
-            return True
-    return False
+    for s in config_parser.stanzas():
+        if s.is_logical_interface:
+            add_auto_stanza = s.iface.name in physical_interfaces
+            if args.interface_to_bridge and args.interface_to_bridge != s.iface.name:
+                if add_auto_stanza:
+                    stanzas.append(AutoStanza(s.iface.name))
+                stanzas.append(s)
+            else:
+                stanzas.extend(s.iface.bridge(args.bridge_prefix, args.bridge_name, add_auto_stanza))
+        elif not s.is_physical_interface:
+            stanzas.append(s)
 
+    if not args.activate:
+        print_stanzas(stanzas)
+        exit(0)
 
-def link_is_up(name):
-    out, err, retcode = shell_cmd('ip link show {} up'.format(name))
-    return re.search(r'\s+{}:\s+.*\s+state\s+UP\s+'.format(name), out)
+    if args.one_time_backup:
+        backup_file = "{}-before-add-juju-bridge".format(args.filename)
+        if not os.path.isfile(backup_file):
+            shutil.copy2(args.filename, backup_file)
 
+    ifquery = "$(ifquery -i {} --exclude=lo -l)".format(args.filename)
 
-def ifup(name, retries=5):
-    if retries < 1:
-        retries = 1
-    i = 1
-    while i <= retries:
-        print("link {} not up, attempt ({}/{})".format(name, i, retries))
-        print_shell_cmd("ifdown -v -a")
-        print_shell_cmd("ifup -v -a")
-        if link_is_up(name):
-            return True
-        print_shell_cmd("ip link")
-        i += 1
-    return False
+    print("**** Original configuration")
+    print_shell_cmd("cat {}".format(args.filename))
+    print_shell_cmd("ifconfig -a")
+    print_shell_cmd("ifdown --exclude=lo -i {} {}".format(args.filename, ifquery))
 
+    print("**** Activating new configuration")
 
-parser = argparse.ArgumentParser()
+    with open(args.filename, 'w') as f:
+        print_stanzas(stanzas, f)
+        f.close()
 
-parser.add_argument('--filename',
-                    help='filename to re-render',
-                    type=str,
-                    required=False,
-                    default="/etc/network/interfaces")
+    print_shell_cmd("cat {}".format(args.filename))
+    print_shell_cmd("ifup --exclude=lo -i {} {}".format(args.filename, ifquery))
+    print_shell_cmd("ip link show up")
+    print_shell_cmd("ifconfig -a")
+    print_shell_cmd("ip route show")
+    print_shell_cmd("brctl show")
 
-parser.add_argument('--bridge-name',
-                    help="bridge name",
-                    type=str,
-                    required=False,
-                    default='juju-br0')
+# This script re-renders an interfaces(5) file to add a bridge to
+# either all active interfaces, or a specific interface.
 
-parser.add_argument('--primary-nic',
-                    help="primary NIC name",
-                    type=str,
-                    required=False)
-
-parser.add_argument('--primary-nic-is-bonded',
-                    help="primary NIC is bonded",
-                    action='store_true',
-                    required=False)
-
-parser.add_argument('--render-only',
-                    help='render to stdout, no network restart',
-                    action='store_true',
-                    required=False)
-
-parser.add_argument('--backup-filename',
-                    help='backup filename',
-                    type=str,
-                    required=False)
-
-args = parser.parse_args()
-
-if is_bridged(args.bridge_name, args.filename):
-    print("already bridged; nothing to do")
-    sys.exit(0)
-
-if not args.primary_nic:
-    args.primary_nic = get_primary_nic()
-
-if not args.primary_nic_is_bonded:
-    args.primary_nic_is_bonded = is_nic_bonded(args.primary_nic)
-
-bridged_stanzas = add_bridge(args.filename,
-                             args.bridge_name,
-                             args.primary_nic,
-                             args.primary_nic_is_bonded)
-
-if args.render_only:
-    print_stanzas(bridged_stanzas)
-    sys.exit(0)
-
-if not get_gateway():
-    print("no default gw; continue continue")
-    sys.exit(1)
-
-if args.backup_filename and not os.path.isfile(args.backup_filename):
-    shutil.copy2(args.filename, args.backup_filename)
-
-print("**** Original configuration")
-print_shell_cmd("cat {}".format(args.filename))
-print_shell_cmd("ifconfig -a")
-print_shell_cmd("ip route show")
-print_shell_cmd("ifdown -v -a")
-
-print("**** Activating new configuration")
-
-with open(args.filename, 'w') as f:
-    print_stanzas(bridged_stanzas, f)
-    f.close()
-
-if not ifup(args.bridge_name):
-    sys.exit(1)
-
-print_shell_cmd("ifconfig -a")
-print_shell_cmd("ip route show")
-print_shell_cmd("brctl show")
-PYTHON_SCRIPT
-)`
+if __name__ == '__main__':
+    main(arg_parser().parse_args())
+`

--- a/provider/maas/bridgescript_test.go
+++ b/provider/maas/bridgescript_test.go
@@ -20,9 +20,9 @@ import (
 type bridgeConfigSuite struct {
 	coretesting.BaseSuite
 
-	testConfig     string
-	testConfigPath string
-	testBridgeName string
+	testConfig       string
+	testConfigPath   string
+	testPythonScript string
 }
 
 var _ = gc.Suite(&bridgeConfigSuite{})
@@ -36,84 +36,153 @@ func (s *bridgeConfigSuite) SetUpSuite(c *gc.C) {
 
 func (s *bridgeConfigSuite) SetUpTest(c *gc.C) {
 	s.testConfigPath = filepath.Join(c.MkDir(), "network-config")
+	s.testPythonScript = filepath.Join(c.MkDir(), bridgeScriptName)
 	s.testConfig = "# test network config\n"
-	s.testBridgeName = "test-bridge"
 	err := ioutil.WriteFile(s.testConfigPath, []byte(s.testConfig), 0644)
+	c.Assert(err, jc.ErrorIsNil)
+	err = ioutil.WriteFile(s.testPythonScript, []byte(bridgeScriptPython), 0755)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-func (s *bridgeConfigSuite) assertScript(c *gc.C, initialConfig, expectedConfig, nic, bridge string, isBond bool) {
+func (s *bridgeConfigSuite) assertScript(c *gc.C, initialConfig, expectedConfig, bridgePrefix, bridgeName, interfaceToBridge string) {
 	// To simplify most cases, trim trailing new lines.
 	initialConfig = strings.TrimSuffix(initialConfig, "\n")
 	expectedConfig = strings.TrimSuffix(expectedConfig, "\n")
 	err := ioutil.WriteFile(s.testConfigPath, []byte(initialConfig), 0644)
 	c.Check(err, jc.ErrorIsNil)
 	// Run the script and verify the modified config.
-	output, retcode := s.runScript(c, s.testConfigPath, nic, bridge, isBond)
+	output, retcode := s.runScript(c, s.testConfigPath, bridgePrefix, bridgeName, interfaceToBridge)
 	c.Check(retcode, gc.Equals, 0)
 	c.Check(strings.Trim(output, "\n"), gc.Equals, expectedConfig)
 }
 
+func (s *bridgeConfigSuite) assertScriptWithPrefix(c *gc.C, initial, expected, prefix string) {
+	s.assertScript(c, initial, expected, prefix, "", "")
+}
+
+func (s *bridgeConfigSuite) assertScriptWithDefaultPrefix(c *gc.C, initial, expected string) {
+	s.assertScript(c, initial, expected, "", "", "")
+}
+
+func (s *bridgeConfigSuite) assertScriptWithoutPrefix(c *gc.C, initial, expected, bridgeName, interfaceToBridge string) {
+	s.assertScript(c, initial, expected, "", bridgeName, interfaceToBridge)
+}
+
 func (s *bridgeConfigSuite) TestBridgeScriptWithUndefinedArgs(c *gc.C) {
-	_, code := s.runScript(c, "", "", "", false)
+	_, code := s.runScript(c, "", "", "", "")
 	c.Check(code, gc.Equals, 1)
 }
 
 func (s *bridgeConfigSuite) TestBridgeScriptDHCP(c *gc.C) {
-	s.assertScript(c, networkDHCPInitial, networkDHCPExpected, "eth0", "juju-br0", false)
+	s.assertScriptWithPrefix(c, networkDHCPInitial, networkDHCPExpected, "test-br-")
 }
 
 func (s *bridgeConfigSuite) TestBridgeScriptStatic(c *gc.C) {
-	s.assertScript(c, networkStaticInitial, networkStaticExpected, "eth0", "juju-br0", false)
+	s.assertScriptWithPrefix(c, networkStaticInitial, networkStaticExpected, "test-br-")
 }
 
-func (s *bridgeConfigSuite) TestBridgeScriptMultiple(c *gc.C) {
-	s.assertScript(c, networkMultipleInitial, networkMultipleExpected, "eth0", "juju-br0", false)
+func (s *bridgeConfigSuite) TestBridgeScriptDualNIC(c *gc.C) {
+	s.assertScriptWithPrefix(c, networkDualNICInitial, networkDualNICExpected, "test-br-")
 }
 
 func (s *bridgeConfigSuite) TestBridgeScriptWithAlias(c *gc.C) {
-	s.assertScript(c, networkWithAliasInitial, networkWithAliasExpected, "eth0", "juju-br0", false)
+	s.assertScriptWithPrefix(c, networkWithAliasInitial, networkWithAliasExpected, "test-br-")
 }
 
 func (s *bridgeConfigSuite) TestBridgeScriptDHCPWithAlias(c *gc.C) {
-	s.assertScript(c, networkDHCPWithAliasInitial, networkDHCPWithAliasExpected, "eth0", "juju-br0", false)
+	s.assertScriptWithPrefix(c, networkDHCPWithAliasInitial, networkDHCPWithAliasExpected, "test-br-")
 }
 
 func (s *bridgeConfigSuite) TestBridgeScriptMultipleStaticWithAliases(c *gc.C) {
-	s.assertScript(c, networkMultipleStaticWithAliasesInitial, networkMultipleStaticWithAliasesExpected, "eth0", "juju-br0", false)
+	s.assertScriptWithPrefix(c, networkMultipleStaticWithAliasesInitial, networkMultipleStaticWithAliasesExpected, "test-br-")
 }
 
 func (s *bridgeConfigSuite) TestBridgeScriptDHCPWithBond(c *gc.C) {
-	s.assertScript(c, networkDHCPWithBondInitial, networkDHCPWithBondExpected, "bond0", "juju-br0", true)
+	s.assertScriptWithPrefix(c, networkDHCPWithBondInitial, networkDHCPWithBondExpected, "test-br-")
 }
 
 func (s *bridgeConfigSuite) TestBridgeScriptMultipleAliases(c *gc.C) {
-	s.assertScript(c, networkMultipleAliasesInitial, networkMultipleAliasesExpected, "eth10", "juju-br10", false)
+	s.assertScriptWithPrefix(c, networkMultipleAliasesInitial, networkMultipleAliasesExpected, "test-br-")
 }
 
-func (s *bridgeConfigSuite) TestBridgeScriptPopEmptyStanza(c *gc.C) {
-	s.assertScript(c, networkMinimalInitial, networkMinimalExpected, "eth0", "juju-br0", false)
+func (s *bridgeConfigSuite) TestBridgeScriptSmorgasboard(c *gc.C) {
+	s.assertScriptWithPrefix(c, networkSmorgasboardInitial, networkSmorgasboardExpected, "juju-br-")
 }
 
-func (s *bridgeConfigSuite) TestBridgeScriptInterlacedNameservers(c *gc.C) {
-	s.assertScript(c, networkInterlacedNameserversInitial, networkInterlacedNameserversExpected, "eth0", "juju-br0", false)
+func (s *bridgeConfigSuite) TestBridgeScriptWithVLANs(c *gc.C) {
+	s.assertScriptWithPrefix(c, networkVLANInitial, networkVLANExpected, "vlan-br-")
 }
 
-func (s *bridgeConfigSuite) runScript(c *gc.C, configFile string, nic string, bridge string, isBond bool) (output string, exitCode int) {
-	var primaryNicIsBonded = ""
+func (s *bridgeConfigSuite) TestBridgeScriptWithMultipleNameservers(c *gc.C) {
+	s.assertScriptWithDefaultPrefix(c, networkVLANWithMultipleNameserversInitial, networkVLANWithMultipleNameserversExpected)
+}
 
-	if isBond {
-		primaryNicIsBonded = "--primary-nic-is-bonded"
+func (s *bridgeConfigSuite) TestBridgeScriptWithLoopbackOnly(c *gc.C) {
+	s.assertScriptWithDefaultPrefix(c, networkLoopbackOnlyInitial, networkLoopbackOnlyExpected)
+}
+
+func (s *bridgeConfigSuite) TestBridgeScriptBondWithVLANs(c *gc.C) {
+	s.assertScriptWithDefaultPrefix(c, networkStaticBondWithVLANsInitial, networkStaticBondWithVLANsExpected)
+}
+
+func (s *bridgeConfigSuite) TestBridgeScriptVLANWithInactive(c *gc.C) {
+	s.assertScriptWithDefaultPrefix(c, networkVLANWithInactiveDeviceInitial, networkVLANWithInactiveDeviceExpected)
+}
+
+func (s *bridgeConfigSuite) TestBridgeScriptVLANWithActiveDHCPDevice(c *gc.C) {
+	s.assertScriptWithDefaultPrefix(c, networkVLANWithActiveDHCPDeviceInitial, networkVLANWithActiveDHCPDeviceExpected)
+}
+
+func (s *bridgeConfigSuite) TestBridgeScriptMultipleDNSValues(c *gc.C) {
+	s.assertScriptWithDefaultPrefix(c, networkWithMultipleDNSValuesInitial, networkWithMultipleDNSValuesExpected)
+}
+
+func (s *bridgeConfigSuite) TestBridgeScriptEmptyDNSValues(c *gc.C) {
+	s.assertScriptWithDefaultPrefix(c, networkWithEmptyDNSValuesInitial, networkWithEmptyDNSValuesExpected)
+}
+
+func (s *bridgeConfigSuite) TestBridgeScriptMismatchedBridgeNameAndInterfaceArgs(c *gc.C) {
+	s.assertScriptWithDefaultPrefix(c, networkWithEmptyDNSValuesInitial, networkWithEmptyDNSValuesExpected)
+}
+
+func (s *bridgeConfigSuite) TestBridgeScriptInterfaceNameArgumentRequired(c *gc.C) {
+	output, code := s.runScript(c, "# no content", "", "juju-br0", "")
+	c.Check(code, gc.Equals, 1)
+	c.Check(strings.Trim(output, "\n"), gc.Equals, "error: --interface-to-bridge required when using --bridge-name")
+}
+
+func (s *bridgeConfigSuite) TestBridgeScriptBridgeNameArgumentRequired(c *gc.C) {
+	output, code := s.runScript(c, "# no content", "", "", "eth0")
+	c.Check(code, gc.Equals, 1)
+	c.Check(strings.Trim(output, "\n"), gc.Equals, "error: --bridge-name required when using --interface-to-bridge")
+}
+
+func (s *bridgeConfigSuite) TestBridgeScriptMatchingNonExistentSpecificIface(c *gc.C) {
+	s.assertScriptWithoutPrefix(c, networkStaticInitial, networkStaticInitial, "juju-br0", "eth1234567890")
+}
+
+func (s *bridgeConfigSuite) TestBridgeScriptMatchingExistingSpecificIfaceButMissingAutoStanza(c *gc.C) {
+	s.assertScriptWithoutPrefix(c, networkWithExistingSpecificIfaceInitial, networkWithExistingSpecificIfaceExpected, "juju-br0", "eth1")
+}
+
+func (s *bridgeConfigSuite) TestBridgeScriptMatchingExistingSpecificIface2(c *gc.C) {
+	s.assertScriptWithoutPrefix(c, networkLP1532167Initial, networkLP1532167Expected, "juju-br0", "bond0")
+}
+
+func (s *bridgeConfigSuite) runScript(c *gc.C, configFile, bridgePrefix, bridgeName, interfaceToBridge string) (output string, exitCode int) {
+	if bridgePrefix != "" {
+		bridgePrefix = fmt.Sprintf("--bridge-prefix=%q", bridgePrefix)
 	}
 
-	script := fmt.Sprintf("%s\npython -c %q --render-only --filename=%q --primary-nic=%q --bridge-name=%q %s\n",
-		bridgeScriptPythonBashDef,
-		"$python_script",
-		configFile,
-		nic,
-		bridge,
-		primaryNicIsBonded)
+	if bridgeName != "" {
+		bridgeName = fmt.Sprintf("--bridge-name=%q", bridgeName)
+	}
 
+	if interfaceToBridge != "" {
+		interfaceToBridge = fmt.Sprintf("--interface-to-bridge=%q", interfaceToBridge)
+	}
+
+	script := fmt.Sprintf("%q %s %s %s %q\n", s.testPythonScript, bridgePrefix, bridgeName, interfaceToBridge, configFile)
 	result, err := exec.RunCommands(exec.RunParams{Commands: script})
 	c.Assert(err, jc.ErrorIsNil, gc.Commentf("script failed unexpectedly"))
 	stdout := string(result.Stdout)
@@ -125,9 +194,8 @@ func (s *bridgeConfigSuite) runScript(c *gc.C, configFile string, nic string, br
 }
 
 // The rest of the file contains various forms of network config for
-// both before and after it has been run through the
-// modify_network_config bash function. They are used in individual
-// test functions.
+// both before and after it has been run through the python script.
+// They are used in individual test functions.
 
 const networkStaticInitial = `auto lo
 iface lo inet loopback
@@ -143,12 +211,12 @@ iface lo inet loopback
 
 iface eth0 inet manual
 
-auto juju-br0
-iface juju-br0 inet static
-    bridge_ports eth0
+auto test-br-eth0
+iface test-br-eth0 inet static
     address 1.2.3.4
     netmask 255.255.255.0
-    gateway 4.3.2.1`
+    gateway 4.3.2.1
+    bridge_ports eth0`
 
 const networkDHCPInitial = `auto lo
 iface lo inet loopback
@@ -161,25 +229,15 @@ iface lo inet loopback
 
 iface eth0 inet manual
 
-auto juju-br0
-iface juju-br0 inet dhcp
+auto test-br-eth0
+iface test-br-eth0 inet dhcp
     bridge_ports eth0`
 
-const networkMultipleInitial = networkStaticInitial + `
-auto eth1
-iface eth1 inet static
-    address 1.2.3.5
-    netmask 255.255.255.0
-    gateway 4.3.2.1`
-
-const networkMultipleExpected = `auto lo
+const networkDualNICInitial = `auto lo
 iface lo inet loopback
 
-iface eth0 inet manual
-
-auto juju-br0
-iface juju-br0 inet static
-    bridge_ports eth0
+auto eth0
+iface eth0 inet static
     address 1.2.3.4
     netmask 255.255.255.0
     gateway 4.3.2.1
@@ -190,7 +248,36 @@ iface eth1 inet static
     netmask 255.255.255.0
     gateway 4.3.2.1`
 
-const networkWithAliasInitial = networkStaticInitial + `
+const networkDualNICExpected = `auto lo
+iface lo inet loopback
+
+iface eth0 inet manual
+
+auto test-br-eth0
+iface test-br-eth0 inet static
+    address 1.2.3.4
+    netmask 255.255.255.0
+    gateway 4.3.2.1
+    bridge_ports eth0
+
+iface eth1 inet manual
+
+auto test-br-eth1
+iface test-br-eth1 inet static
+    address 1.2.3.5
+    netmask 255.255.255.0
+    gateway 4.3.2.1
+    bridge_ports eth1`
+
+const networkWithAliasInitial = `auto lo
+iface lo inet loopback
+
+auto eth0
+iface eth0 inet static
+    address 1.2.3.4
+    netmask 255.255.255.0
+    gateway 4.3.2.1
+
 auto eth0:1
 iface eth0:1 inet static
     address 1.2.3.5`
@@ -200,15 +287,15 @@ iface lo inet loopback
 
 iface eth0 inet manual
 
-auto juju-br0
-iface juju-br0 inet static
-    bridge_ports eth0
+auto test-br-eth0
+iface test-br-eth0 inet static
     address 1.2.3.4
     netmask 255.255.255.0
     gateway 4.3.2.1
+    bridge_ports eth0
 
-auto juju-br0:1
-iface juju-br0:1 inet static
+auto eth0:1
+iface eth0:1 inet static
     address 1.2.3.5`
 
 const networkDHCPWithAliasInitial = `auto lo
@@ -234,18 +321,18 @@ iface lo inet loopback
 
 iface eth0 inet manual
 
-auto juju-br0
-iface juju-br0 inet static
-    bridge_ports eth0
+auto test-br-eth0
+iface test-br-eth0 inet static
     gateway 10.14.0.1
     address 10.14.0.102/24
+    bridge_ports eth0
 
-auto juju-br0:1
-iface juju-br0:1 inet static
+auto eth0:1
+iface eth0:1 inet static
     address 10.14.0.103/24
 
-auto juju-br0:2
-iface juju-br0:2 inet static
+auto eth0:2
+iface eth0:2 inet static
     address 10.14.0.100/24
     dns-nameserver 192.168.1.142`
 
@@ -270,15 +357,15 @@ dns-search maas`
 
 const networkMultipleStaticWithAliasesExpected = `iface eth0 inet manual
 
-auto juju-br0
-iface juju-br0 inet static
-    bridge_ports eth0
+auto test-br-eth0
+iface test-br-eth0 inet static
     gateway 10.17.20.1
     address 10.17.20.201/24
     mtu 1500
+    bridge_ports eth0
 
-auto juju-br0:1
-iface juju-br0:1 inet static
+auto eth0:1
+iface eth0:1 inet static
     address 10.17.20.202/24
     mtu 1500
 
@@ -349,47 +436,19 @@ iface bond0 inet manual
     dns-nameservers 10.17.20.200
     dns-search maas19
 
-auto juju-br0
-iface juju-br0 inet dhcp
-    bridge_ports bond0
+auto test-br-bond0
+iface test-br-bond0 inet dhcp
     mtu 1500
     hwaddress 52:54:00:1c:f1:5b
+    bridge_ports bond0
     dns-nameservers 10.17.20.200
-    dns-search maas19
-    pre-up ip link add dev bond0 name juju-br0 type bridge || true`
+    dns-search maas19`
 
 const networkMultipleAliasesInitial = `auto eth0
 iface eth0 inet dhcp
 
 auto eth1
 iface eth1 inet dhcp
-
-auto eth2
-iface eth2 inet dhcp
-
-auto eth3
-iface eth3 inet dhcp
-
-auto eth4
-iface eth4 inet dhcp
-
-auto eth5
-iface eth5 inet dhcp
-
-auto eth5
-iface eth5 inet dhcp
-
-auto eth6
-iface eth6 inet dhcp
-
-auto eth7
-iface eth7 inet dhcp
-
-auto eth8
-iface eth8 inet dhcp
-
-auto eth9
-iface eth9 inet dhcp
 
 auto eth10
 iface eth10 inet static
@@ -407,176 +466,325 @@ iface eth10:2 inet static
     address 10.17.20.203/24
     mtu 1500
 
-auto eth10:3
-iface eth10:3 inet static
-    address 10.17.20.204/24
-    mtu 1500
-
-auto eth10:4
-iface eth10:4 inet static
-    address 10.17.20.205/24
-    mtu 1500
-
-auto eth10:5
-iface eth10:5 inet static
-    address 10.17.20.206/24
-    mtu 1500
-
-auto eth10:6
-iface eth10:6 inet static
-    address 10.17.20.207/24
-    mtu 1500
-
-auto eth10:7
-iface eth10:7 inet static
-    address 10.17.20.208/24
-    mtu 1500
-
-auto eth10:8
-iface eth10:8 inet static
-    address 10.17.20.209/24
-    mtu 1500
-
-auto eth10:9
-iface eth10:9 inet static
-    address 10.17.20.210/24
-    mtu 1500
-
-auto eth10:10
-iface eth10:10 inet static
-    address 10.17.20.211/24
-    mtu 1500
-
-auto eth10:11
-iface eth10:11 inet static
-    address 10.17.20.212/24
-    mtu 1500
-
-auto eth10:12
-iface eth10:12 inet static
-    address 10.17.20.213/24
-    mtu 1500
-
 dns-nameservers 10.17.20.200
 dns-search maas19`
 
-const networkMultipleAliasesExpected = `auto eth0
-iface eth0 inet dhcp
+const networkMultipleAliasesExpected = `iface eth0 inet manual
 
-auto eth1
-iface eth1 inet dhcp
+auto test-br-eth0
+iface test-br-eth0 inet dhcp
+    bridge_ports eth0
 
-auto eth2
-iface eth2 inet dhcp
+iface eth1 inet manual
 
-auto eth3
-iface eth3 inet dhcp
-
-auto eth4
-iface eth4 inet dhcp
-
-auto eth5
-iface eth5 inet dhcp
-
-auto eth5
-iface eth5 inet dhcp
-
-auto eth6
-iface eth6 inet dhcp
-
-auto eth7
-iface eth7 inet dhcp
-
-auto eth8
-iface eth8 inet dhcp
-
-auto eth9
-iface eth9 inet dhcp
+auto test-br-eth1
+iface test-br-eth1 inet dhcp
+    bridge_ports eth1
 
 iface eth10 inet manual
 
-auto juju-br10
-iface juju-br10 inet static
-    bridge_ports eth10
+auto test-br-eth10
+iface test-br-eth10 inet static
     gateway 10.17.20.1
     address 10.17.20.201/24
     mtu 1500
+    bridge_ports eth10
 
-auto juju-br10:1
-iface juju-br10:1 inet static
+auto eth10:1
+iface eth10:1 inet static
     address 10.17.20.202/24
     mtu 1500
 
-auto juju-br10:2
-iface juju-br10:2 inet static
+auto eth10:2
+iface eth10:2 inet static
     address 10.17.20.203/24
-    mtu 1500
-
-auto juju-br10:3
-iface juju-br10:3 inet static
-    address 10.17.20.204/24
-    mtu 1500
-
-auto juju-br10:4
-iface juju-br10:4 inet static
-    address 10.17.20.205/24
-    mtu 1500
-
-auto juju-br10:5
-iface juju-br10:5 inet static
-    address 10.17.20.206/24
-    mtu 1500
-
-auto juju-br10:6
-iface juju-br10:6 inet static
-    address 10.17.20.207/24
-    mtu 1500
-
-auto juju-br10:7
-iface juju-br10:7 inet static
-    address 10.17.20.208/24
-    mtu 1500
-
-auto juju-br10:8
-iface juju-br10:8 inet static
-    address 10.17.20.209/24
-    mtu 1500
-
-auto juju-br10:9
-iface juju-br10:9 inet static
-    address 10.17.20.210/24
-    mtu 1500
-
-auto juju-br10:10
-iface juju-br10:10 inet static
-    address 10.17.20.211/24
-    mtu 1500
-
-auto juju-br10:11
-iface juju-br10:11 inet static
-    address 10.17.20.212/24
-    mtu 1500
-
-auto juju-br10:12
-iface juju-br10:12 inet static
-    address 10.17.20.213/24
     mtu 1500
     dns-nameservers 10.17.20.200
     dns-search maas19`
 
-const networkMinimalInitial = `auto eth0
-iface eth0 inet dhcp`
+const networkSmorgasboardInitial = `auto eth0
+iface eth0 inet manual
+    bond-lacp_rate slow
+    bond-xmit_hash_policy layer2
+    bond-miimon 100
+    bond-master bond0
+    mtu 1500
+    bond-mode active-backup
 
-const networkMinimalExpected = `iface eth0 inet manual
+auto eth1
+iface eth1 inet manual
+    bond-lacp_rate slow
+    bond-xmit_hash_policy layer2
+    bond-miimon 100
+    bond-master bond0
+    mtu 1500
+    bond-mode active-backup
 
-auto juju-br0
-iface juju-br0 inet dhcp
-    bridge_ports eth0`
+auto eth2
+iface eth2 inet manual
+    bond-lacp_rate slow
+    bond-xmit_hash_policy layer2
+    bond-miimon 100
+    bond-master bond1
+    mtu 1500
+    bond-mode active-backup
 
-// This is an example from:
-//   https://bugs.launchpad.net/juju-core/+bug/1534795
+auto eth3
+iface eth3 inet manual
+    bond-lacp_rate slow
+    bond-xmit_hash_policy layer2
+    bond-miimon 100
+    bond-master bond1
+    mtu 1500
+    bond-mode active-backup
 
-const networkInterlacedNameserversInitial = `auto eth0
+auto eth4
+iface eth4 inet static
+    address 10.17.20.202/24
+    mtu 1500
+
+auto eth5
+iface eth5 inet dhcp
+    mtu 1500
+
+auto eth6
+iface eth6 inet static
+    address 10.17.20.203/24
+    mtu 1500
+
+auto eth6:1
+iface eth6:1 inet static
+    address 10.17.20.205/24
+    mtu 1500
+
+auto eth6:2
+iface eth6:2 inet static
+    address 10.17.20.204/24
+    mtu 1500
+
+auto eth6:3
+iface eth6:3 inet static
+    address 10.17.20.206/24
+    mtu 1500
+
+auto eth6:4
+iface eth6:4 inet static
+    address 10.17.20.207/24
+    mtu 1500
+
+auto bond0
+iface bond0 inet static
+    gateway 10.17.20.1
+    address 10.17.20.201/24
+    bond-lacp_rate slow
+    bond-xmit_hash_policy layer2
+    bond-miimon 100
+    mtu 1500
+    bond-mode active-backup
+    hwaddress 52:54:00:6a:4f:fd
+    bond-slaves none
+
+auto bond1
+iface bond1 inet dhcp
+    bond-lacp_rate slow
+    bond-xmit_hash_policy layer2
+    bond-miimon 100
+    mtu 1500
+    bond-mode active-backup
+    hwaddress 52:54:00:8e:6e:b0
+    bond-slaves none
+
+dns-nameservers 10.17.20.200
+dns-search maas19`
+
+const networkSmorgasboardExpected = `auto eth0
+iface eth0 inet manual
+    bond-lacp_rate slow
+    bond-xmit_hash_policy layer2
+    bond-miimon 100
+    bond-master bond0
+    mtu 1500
+    bond-mode active-backup
+
+auto eth1
+iface eth1 inet manual
+    bond-lacp_rate slow
+    bond-xmit_hash_policy layer2
+    bond-miimon 100
+    bond-master bond0
+    mtu 1500
+    bond-mode active-backup
+
+auto eth2
+iface eth2 inet manual
+    bond-lacp_rate slow
+    bond-xmit_hash_policy layer2
+    bond-miimon 100
+    bond-master bond1
+    mtu 1500
+    bond-mode active-backup
+
+auto eth3
+iface eth3 inet manual
+    bond-lacp_rate slow
+    bond-xmit_hash_policy layer2
+    bond-miimon 100
+    bond-master bond1
+    mtu 1500
+    bond-mode active-backup
+
+iface eth4 inet manual
+
+auto juju-br-eth4
+iface juju-br-eth4 inet static
+    address 10.17.20.202/24
+    mtu 1500
+    bridge_ports eth4
+
+iface eth5 inet manual
+
+auto juju-br-eth5
+iface juju-br-eth5 inet dhcp
+    mtu 1500
+    bridge_ports eth5
+
+iface eth6 inet manual
+
+auto juju-br-eth6
+iface juju-br-eth6 inet static
+    address 10.17.20.203/24
+    mtu 1500
+    bridge_ports eth6
+
+auto eth6:1
+iface eth6:1 inet static
+    address 10.17.20.205/24
+    mtu 1500
+
+auto eth6:2
+iface eth6:2 inet static
+    address 10.17.20.204/24
+    mtu 1500
+
+auto eth6:3
+iface eth6:3 inet static
+    address 10.17.20.206/24
+    mtu 1500
+
+auto eth6:4
+iface eth6:4 inet static
+    address 10.17.20.207/24
+    mtu 1500
+
+auto bond0
+iface bond0 inet manual
+    gateway 10.17.20.1
+    address 10.17.20.201/24
+    bond-lacp_rate slow
+    bond-xmit_hash_policy layer2
+    bond-miimon 100
+    mtu 1500
+    bond-mode active-backup
+    hwaddress 52:54:00:6a:4f:fd
+    bond-slaves none
+
+auto juju-br-bond0
+iface juju-br-bond0 inet static
+    gateway 10.17.20.1
+    address 10.17.20.201/24
+    mtu 1500
+    hwaddress 52:54:00:6a:4f:fd
+    bridge_ports bond0
+
+auto bond1
+iface bond1 inet manual
+    bond-lacp_rate slow
+    bond-xmit_hash_policy layer2
+    bond-miimon 100
+    mtu 1500
+    bond-mode active-backup
+    hwaddress 52:54:00:8e:6e:b0
+    bond-slaves none
+    dns-nameservers 10.17.20.200
+    dns-search maas19
+
+auto juju-br-bond1
+iface juju-br-bond1 inet dhcp
+    mtu 1500
+    hwaddress 52:54:00:8e:6e:b0
+    bridge_ports bond1
+    dns-nameservers 10.17.20.200
+    dns-search maas19`
+
+const networkVLANInitial = `auto eth0
+iface eth0 inet static
+    gateway 10.17.20.1
+    address 10.17.20.212/24
+    mtu 1500
+
+auto eth1
+iface eth1 inet manual
+    mtu 1500
+
+auto eth0.2
+iface eth0.2 inet static
+    address 192.168.2.3/24
+    vlan-raw-device eth0
+    mtu 1500
+    vlan_id 2
+
+auto eth1.3
+iface eth1.3 inet static
+    address 192.168.3.3/24
+    vlan-raw-device eth1
+    mtu 1500
+    vlan_id 3
+
+dns-nameservers 10.17.20.200
+dns-search maas19`
+
+const networkVLANExpected = `iface eth0 inet manual
+
+auto vlan-br-eth0
+iface vlan-br-eth0 inet static
+    gateway 10.17.20.1
+    address 10.17.20.212/24
+    mtu 1500
+    bridge_ports eth0
+
+auto eth1
+iface eth1 inet manual
+    mtu 1500
+
+iface eth0.2 inet manual
+    address 192.168.2.3/24
+    vlan-raw-device eth0
+    mtu 1500
+    vlan_id 2
+
+auto vlan-br-eth0.2
+iface vlan-br-eth0.2 inet static
+    address 192.168.2.3/24
+    mtu 1500
+    bridge_ports eth0.2
+
+iface eth1.3 inet manual
+    address 192.168.3.3/24
+    vlan-raw-device eth1
+    mtu 1500
+    vlan_id 3
+    dns-nameservers 10.17.20.200
+    dns-search maas19
+
+auto vlan-br-eth1.3
+iface vlan-br-eth1.3 inet static
+    address 192.168.3.3/24
+    mtu 1500
+    bridge_ports eth1.3
+    dns-nameservers 10.17.20.200
+    dns-search maas19`
+
+const networkVLANWithMultipleNameserversInitial = `auto eth0
 iface eth0 inet static
     dns-nameservers 10.245.168.2
     gateway 10.245.168.1
@@ -595,18 +803,50 @@ auto eth3
 iface eth3 inet manual
     mtu 1500
 
+auto eth1.2667
+iface eth1.2667 inet static
+    dns-nameservers 10.245.168.2
+    address 10.245.184.2/24
+    vlan-raw-device eth1
+    mtu 1500
+    vlan_id 2667
+
+auto eth1.2668
+iface eth1.2668 inet static
+    dns-nameservers 10.245.168.2
+    address 10.245.185.1/24
+    vlan-raw-device eth1
+    mtu 1500
+    vlan_id 2668
+
+auto eth1.2669
+iface eth1.2669 inet static
+    dns-nameservers 10.245.168.2
+    address 10.245.186.1/24
+    vlan-raw-device eth1
+    mtu 1500
+    vlan_id 2669
+
+auto eth1.2670
+iface eth1.2670 inet static
+    dns-nameservers 10.245.168.2
+    address 10.245.187.2/24
+    vlan-raw-device eth1
+    mtu 1500
+    vlan_id 2670
+
 dns-nameservers 10.245.168.2
 dns-search dellstack`
 
-const networkInterlacedNameserversExpected = `iface eth0 inet manual
+const networkVLANWithMultipleNameserversExpected = `iface eth0 inet manual
 
-auto juju-br0
-iface juju-br0 inet static
-    bridge_ports eth0
-    dns-nameservers 10.245.168.2
+auto br-eth0
+iface br-eth0 inet static
     gateway 10.245.168.1
     address 10.245.168.11/21
     mtu 1500
+    bridge_ports eth0
+    dns-nameservers 10.245.168.2
 
 auto eth1
 iface eth1 inet manual
@@ -619,5 +859,664 @@ iface eth2 inet manual
 auto eth3
 iface eth3 inet manual
     mtu 1500
+
+iface eth1.2667 inet manual
+    address 10.245.184.2/24
+    vlan-raw-device eth1
+    mtu 1500
+    vlan_id 2667
+    dns-nameservers 10.245.168.2
+
+auto br-eth1.2667
+iface br-eth1.2667 inet static
+    address 10.245.184.2/24
+    mtu 1500
+    bridge_ports eth1.2667
+    dns-nameservers 10.245.168.2
+
+iface eth1.2668 inet manual
+    address 10.245.185.1/24
+    vlan-raw-device eth1
+    mtu 1500
+    vlan_id 2668
+    dns-nameservers 10.245.168.2
+
+auto br-eth1.2668
+iface br-eth1.2668 inet static
+    address 10.245.185.1/24
+    mtu 1500
+    bridge_ports eth1.2668
+    dns-nameservers 10.245.168.2
+
+iface eth1.2669 inet manual
+    address 10.245.186.1/24
+    vlan-raw-device eth1
+    mtu 1500
+    vlan_id 2669
+    dns-nameservers 10.245.168.2
+
+auto br-eth1.2669
+iface br-eth1.2669 inet static
+    address 10.245.186.1/24
+    mtu 1500
+    bridge_ports eth1.2669
+    dns-nameservers 10.245.168.2
+
+iface eth1.2670 inet manual
+    address 10.245.187.2/24
+    vlan-raw-device eth1
+    mtu 1500
+    vlan_id 2670
+    dns-nameservers 10.245.168.2
+    dns-search dellstack
+
+auto br-eth1.2670
+iface br-eth1.2670 inet static
+    address 10.245.187.2/24
+    mtu 1500
+    bridge_ports eth1.2670
     dns-nameservers 10.245.168.2
     dns-search dellstack`
+
+const networkLoopbackOnlyInitial = `auto lo
+iface lo inet loopback`
+
+const networkLoopbackOnlyExpected = `auto lo
+iface lo inet loopback`
+
+const networkStaticBondWithVLANsInitial = `auto eth0
+iface eth0 inet manual
+    bond-master bond0
+    bond-mode active-backup
+    bond-xmit_hash_policy layer2
+    bond-miimon 100
+    mtu 1500
+    bond-lacp_rate slow
+
+auto eth1
+iface eth1 inet manual
+    bond-master bond0
+    bond-mode active-backup
+    bond-xmit_hash_policy layer2
+    bond-miimon 100
+    mtu 1500
+    bond-lacp_rate slow
+
+auto bond0
+iface bond0 inet static
+    address 10.17.20.211/24
+    gateway 10.17.20.1
+    dns-nameservers 10.17.20.200
+    bond-slaves none
+    bond-mode active-backup
+    bond-xmit_hash_policy layer2
+    bond-miimon 100
+    mtu 1500
+    hwaddress 52:54:00:1c:f1:5b
+    bond-lacp_rate slow
+
+auto bond0.2
+iface bond0.2 inet static
+    address 192.168.2.102/24
+    vlan-raw-device bond0
+    mtu 1500
+    vlan_id 2
+
+auto bond0.3
+iface bond0.3 inet static
+    address 192.168.3.101/24
+    vlan-raw-device bond0
+    mtu 1500
+    vlan_id 3
+
+dns-nameservers 10.17.20.200
+dns-search maas19`
+
+const networkStaticBondWithVLANsExpected = `auto eth0
+iface eth0 inet manual
+    bond-master bond0
+    bond-mode active-backup
+    bond-xmit_hash_policy layer2
+    bond-miimon 100
+    mtu 1500
+    bond-lacp_rate slow
+
+auto eth1
+iface eth1 inet manual
+    bond-master bond0
+    bond-mode active-backup
+    bond-xmit_hash_policy layer2
+    bond-miimon 100
+    mtu 1500
+    bond-lacp_rate slow
+
+auto bond0
+iface bond0 inet manual
+    address 10.17.20.211/24
+    gateway 10.17.20.1
+    bond-slaves none
+    bond-mode active-backup
+    bond-xmit_hash_policy layer2
+    bond-miimon 100
+    mtu 1500
+    hwaddress 52:54:00:1c:f1:5b
+    bond-lacp_rate slow
+    dns-nameservers 10.17.20.200
+
+auto br-bond0
+iface br-bond0 inet static
+    address 10.17.20.211/24
+    gateway 10.17.20.1
+    mtu 1500
+    hwaddress 52:54:00:1c:f1:5b
+    bridge_ports bond0
+    dns-nameservers 10.17.20.200
+
+iface bond0.2 inet manual
+    address 192.168.2.102/24
+    vlan-raw-device bond0
+    mtu 1500
+    vlan_id 2
+
+auto br-bond0.2
+iface br-bond0.2 inet static
+    address 192.168.2.102/24
+    mtu 1500
+    bridge_ports bond0.2
+
+iface bond0.3 inet manual
+    address 192.168.3.101/24
+    vlan-raw-device bond0
+    mtu 1500
+    vlan_id 3
+    dns-nameservers 10.17.20.200
+    dns-search maas19
+
+auto br-bond0.3
+iface br-bond0.3 inet static
+    address 192.168.3.101/24
+    mtu 1500
+    bridge_ports bond0.3
+    dns-nameservers 10.17.20.200
+    dns-search maas19`
+
+const networkVLANWithInactiveDeviceInitial = `auto eth0
+iface eth0 inet static
+    dns-nameservers 10.17.20.200
+    gateway 10.17.20.1
+    address 10.17.20.211/24
+    mtu 1500
+
+auto eth1
+iface eth1 inet manual
+    mtu 1500
+
+auto eth1.2
+iface eth1.2 inet dhcp
+    vlan-raw-device eth1
+    mtu 1500
+    vlan_id 2
+
+dns-nameservers 10.17.20.200
+dns-search maas19
+`
+
+const networkVLANWithInactiveDeviceExpected = `iface eth0 inet manual
+
+auto br-eth0
+iface br-eth0 inet static
+    gateway 10.17.20.1
+    address 10.17.20.211/24
+    mtu 1500
+    bridge_ports eth0
+    dns-nameservers 10.17.20.200
+
+auto eth1
+iface eth1 inet manual
+    mtu 1500
+
+iface eth1.2 inet manual
+    vlan-raw-device eth1
+    mtu 1500
+    vlan_id 2
+    dns-nameservers 10.17.20.200
+    dns-search maas19
+
+auto br-eth1.2
+iface br-eth1.2 inet dhcp
+    mtu 1500
+    bridge_ports eth1.2
+    dns-nameservers 10.17.20.200
+    dns-search maas19`
+
+const networkVLANWithActiveDHCPDeviceInitial = `auto eth0
+iface eth0 inet static
+    dns-nameservers 10.17.20.200
+    gateway 10.17.20.1
+    address 10.17.20.211/24
+    mtu 1500
+
+auto eth1
+iface eth1 inet dhcp
+    mtu 1500
+
+auto eth1.2
+iface eth1.2 inet dhcp
+    vlan-raw-device eth1
+    mtu 1500
+    vlan_id 2
+
+dns-nameservers 10.17.20.200
+dns-search maas19
+`
+
+const networkVLANWithActiveDHCPDeviceExpected = `iface eth0 inet manual
+
+auto br-eth0
+iface br-eth0 inet static
+    gateway 10.17.20.1
+    address 10.17.20.211/24
+    mtu 1500
+    bridge_ports eth0
+    dns-nameservers 10.17.20.200
+
+iface eth1 inet manual
+
+auto br-eth1
+iface br-eth1 inet dhcp
+    mtu 1500
+    bridge_ports eth1
+
+iface eth1.2 inet manual
+    vlan-raw-device eth1
+    mtu 1500
+    vlan_id 2
+    dns-nameservers 10.17.20.200
+    dns-search maas19
+
+auto br-eth1.2
+iface br-eth1.2 inet dhcp
+    mtu 1500
+    bridge_ports eth1.2
+    dns-nameservers 10.17.20.200
+    dns-search maas19`
+
+const networkWithMultipleDNSValuesInitial = `auto eth0
+iface eth0 inet static
+    dns-nameservers 10.245.168.2
+    gateway 10.245.168.1
+    address 10.245.168.11/21
+    mtu 1500
+    dns-nameservers 192.168.1.1
+    dns-nameservers 10.245.168.2 192.168.1.1 10.245.168.2
+
+auto eth1
+iface eth1 inet static
+    gateway 10.245.168.1
+    address 10.245.168.12/21
+    mtu 1500
+    dns-sortlist 192.168.1.0/24 10.245.168.0/21 192.168.1.0/24
+    dns-sortlist 10.245.168.0/21 192.168.1.0/24
+
+auto eth2
+iface eth2 inet static
+    gateway 10.245.168.1
+    address 10.245.168.13/21
+    mtu 1500
+    dns-search juju ubuntu
+    dns-search dellstack ubuntu dellstack
+
+auto eth3
+iface eth3 inet static
+    gateway 10.245.168.1
+    address 10.245.168.14/21
+    mtu 1500
+    dns-nameservers 192.168.1.1
+    dns-nameservers 10.245.168.2 192.168.1.1 10.245.168.2
+    dns-sortlist 192.168.1.0/24 10.245.168.0/21 192.168.1.0/24
+    dns-sortlist 10.245.168.0/21 192.168.1.0/24
+    dns-search juju ubuntu
+    dns-search dellstack ubuntu dellstack
+
+dns-search ubuntu juju
+dns-search dellstack ubuntu dellstack`
+
+const networkWithMultipleDNSValuesExpected = `iface eth0 inet manual
+
+auto br-eth0
+iface br-eth0 inet static
+    gateway 10.245.168.1
+    address 10.245.168.11/21
+    mtu 1500
+    bridge_ports eth0
+    dns-nameservers 10.245.168.2 192.168.1.1
+
+iface eth1 inet manual
+
+auto br-eth1
+iface br-eth1 inet static
+    gateway 10.245.168.1
+    address 10.245.168.12/21
+    mtu 1500
+    bridge_ports eth1
+    dns-sortlist 192.168.1.0/24 10.245.168.0/21
+
+iface eth2 inet manual
+
+auto br-eth2
+iface br-eth2 inet static
+    gateway 10.245.168.1
+    address 10.245.168.13/21
+    mtu 1500
+    bridge_ports eth2
+    dns-search juju ubuntu dellstack
+
+iface eth3 inet manual
+
+auto br-eth3
+iface br-eth3 inet static
+    gateway 10.245.168.1
+    address 10.245.168.14/21
+    mtu 1500
+    bridge_ports eth3
+    dns-nameservers 192.168.1.1 10.245.168.2
+    dns-search juju ubuntu dellstack
+    dns-sortlist 192.168.1.0/24 10.245.168.0/21`
+
+const networkWithEmptyDNSValuesInitial = `auto eth0
+iface eth0 inet static
+    dns-nameservers
+    dns-search
+    dns-sortlist
+    gateway 10.245.168.1
+    address 10.245.168.11/21
+    mtu 1500
+
+auto eth1
+iface eth1 inet static
+    dns-nameservers
+    dns-search
+    dns-sortlist
+    gateway 10.245.168.1
+    address 10.245.168.12/21
+    mtu 1500
+
+dns-nameservers
+dns-search
+dns-sortlist`
+
+const networkWithEmptyDNSValuesExpected = `iface eth0 inet manual
+
+auto br-eth0
+iface br-eth0 inet static
+    gateway 10.245.168.1
+    address 10.245.168.11/21
+    mtu 1500
+    bridge_ports eth0
+
+iface eth1 inet manual
+
+auto br-eth1
+iface br-eth1 inet static
+    gateway 10.245.168.1
+    address 10.245.168.12/21
+    mtu 1500
+    bridge_ports eth1`
+
+const networkLP1532167Initial = `auto eth0
+iface eth0 inet manual
+    bond-lacp_rate fast
+    bond-xmit_hash_policy layer2+3
+    bond-miimon 100
+    bond-master bond0
+    mtu 1500
+    bond-mode 802.3ad
+
+auto eth1
+iface eth1 inet manual
+    bond-lacp_rate fast
+    bond-xmit_hash_policy layer2+3
+    bond-miimon 100
+    bond-master bond0
+    mtu 1500
+    bond-mode 802.3ad
+
+auto eth2
+iface eth2 inet manual
+    bond-lacp_rate fast
+    bond-xmit_hash_policy layer2+3
+    bond-miimon 100
+    bond-master bond1
+    mtu 1500
+    bond-mode 802.3ad
+
+auto eth3
+iface eth3 inet manual
+    bond-lacp_rate fast
+    bond-xmit_hash_policy layer2+3
+    bond-miimon 100
+    bond-master bond1
+    mtu 1500
+    bond-mode 802.3ad
+
+auto bond0
+iface bond0 inet static
+    gateway 10.38.160.1
+    address 10.38.160.24/24
+    bond-lacp_rate fast
+    bond-xmit_hash_policy layer2+3
+    bond-miimon 100
+    mtu 1500
+    bond-mode 802.3ad
+    hwaddress 44:a8:42:41:ab:37
+    bond-slaves none
+
+auto bond1
+iface bond1 inet manual
+    bond-lacp_rate fast
+    bond-xmit_hash_policy layer2+3
+    bond-miimon 100
+    mtu 1500
+    bond-mode 802.3ad
+    hwaddress 00:0e:1e:b7:b5:50
+    bond-slaves none
+
+auto bond0.1016
+iface bond0.1016 inet static
+    address 172.16.0.21/16
+    vlan-raw-device bond0
+    mtu 1500
+    vlan_id 1016
+
+auto bond0.161
+iface bond0.161 inet static
+    address 10.38.161.21/24
+    vlan-raw-device bond0
+    mtu 1500
+    vlan_id 161
+
+auto bond0.162
+iface bond0.162 inet static
+    address 10.38.162.21/24
+    vlan-raw-device bond0
+    mtu 1500
+    vlan_id 162
+
+auto bond0.163
+iface bond0.163 inet static
+    address 10.38.163.21/24
+    vlan-raw-device bond0
+    mtu 1500
+    vlan_id 163
+
+auto bond1.1017
+iface bond1.1017 inet static
+    address 172.17.0.21/16
+    vlan-raw-device bond1
+    mtu 1500
+    vlan_id 1017
+
+auto bond1.1018
+iface bond1.1018 inet static
+    address 172.18.0.21/16
+    vlan-raw-device bond1
+    mtu 1500
+    vlan_id 1018
+
+auto bond1.1019
+iface bond1.1019 inet static
+    address 172.19.0.21/16
+    vlan-raw-device bond1
+    mtu 1500
+    vlan_id 1019
+
+dns-nameservers 10.38.160.10
+dns-search maas`
+
+const networkLP1532167Expected = `auto eth0
+iface eth0 inet manual
+    bond-lacp_rate fast
+    bond-xmit_hash_policy layer2+3
+    bond-miimon 100
+    bond-master bond0
+    mtu 1500
+    bond-mode 802.3ad
+
+auto eth1
+iface eth1 inet manual
+    bond-lacp_rate fast
+    bond-xmit_hash_policy layer2+3
+    bond-miimon 100
+    bond-master bond0
+    mtu 1500
+    bond-mode 802.3ad
+
+auto eth2
+iface eth2 inet manual
+    bond-lacp_rate fast
+    bond-xmit_hash_policy layer2+3
+    bond-miimon 100
+    bond-master bond1
+    mtu 1500
+    bond-mode 802.3ad
+
+auto eth3
+iface eth3 inet manual
+    bond-lacp_rate fast
+    bond-xmit_hash_policy layer2+3
+    bond-miimon 100
+    bond-master bond1
+    mtu 1500
+    bond-mode 802.3ad
+
+auto bond0
+iface bond0 inet manual
+    gateway 10.38.160.1
+    address 10.38.160.24/24
+    bond-lacp_rate fast
+    bond-xmit_hash_policy layer2+3
+    bond-miimon 100
+    mtu 1500
+    bond-mode 802.3ad
+    hwaddress 44:a8:42:41:ab:37
+    bond-slaves none
+
+auto juju-br0
+iface juju-br0 inet static
+    gateway 10.38.160.1
+    address 10.38.160.24/24
+    mtu 1500
+    hwaddress 44:a8:42:41:ab:37
+    bridge_ports bond0
+
+auto bond1
+iface bond1 inet manual
+    bond-lacp_rate fast
+    bond-xmit_hash_policy layer2+3
+    bond-miimon 100
+    mtu 1500
+    bond-mode 802.3ad
+    hwaddress 00:0e:1e:b7:b5:50
+    bond-slaves none
+
+auto bond0.1016
+iface bond0.1016 inet static
+    address 172.16.0.21/16
+    vlan-raw-device bond0
+    mtu 1500
+    vlan_id 1016
+
+auto bond0.161
+iface bond0.161 inet static
+    address 10.38.161.21/24
+    vlan-raw-device bond0
+    mtu 1500
+    vlan_id 161
+
+auto bond0.162
+iface bond0.162 inet static
+    address 10.38.162.21/24
+    vlan-raw-device bond0
+    mtu 1500
+    vlan_id 162
+
+auto bond0.163
+iface bond0.163 inet static
+    address 10.38.163.21/24
+    vlan-raw-device bond0
+    mtu 1500
+    vlan_id 163
+
+auto bond1.1017
+iface bond1.1017 inet static
+    address 172.17.0.21/16
+    vlan-raw-device bond1
+    mtu 1500
+    vlan_id 1017
+
+auto bond1.1018
+iface bond1.1018 inet static
+    address 172.18.0.21/16
+    vlan-raw-device bond1
+    mtu 1500
+    vlan_id 1018
+
+auto bond1.1019
+iface bond1.1019 inet static
+    address 172.19.0.21/16
+    vlan-raw-device bond1
+    mtu 1500
+    vlan_id 1019
+    dns-nameservers 10.38.160.10
+    dns-search maas`
+
+const networkWithExistingSpecificIfaceInitial = `auto lo
+iface lo inet loopback
+
+# Note this has no auto stanza
+iface eth0 inet static
+    address 1.2.3.4
+    netmask 255.255.255.0
+    gateway 4.3.2.1
+
+iface eth1 inet static
+    address 1.2.3.4
+    netmask 255.255.255.0
+    gateway 4.3.2.1`
+
+const networkWithExistingSpecificIfaceExpected = `auto lo
+iface lo inet loopback
+
+iface eth0 inet static
+    address 1.2.3.4
+    netmask 255.255.255.0
+    gateway 4.3.2.1
+
+iface eth1 inet manual
+
+auto juju-br0
+iface juju-br0 inet static
+    address 1.2.3.4
+    netmask 255.255.255.0
+    gateway 4.3.2.1
+    bridge_ports eth1`

--- a/provider/maas/environ_test.go
+++ b/provider/maas/environ_test.go
@@ -236,8 +236,7 @@ func (s *environSuite) TestNewCloudinitConfigNoFeatureFlag(c *gc.C) {
 
 	// Now test with the flag off.
 	s.SetFeatureFlags() // clear the flags.
-	modifyNetworkScript, err := maas.RenderEtcNetworkInterfacesScript()
-	c.Assert(err, jc.ErrorIsNil)
+	modifyNetworkScript := maas.RenderEtcNetworkInterfacesScript()
 	script := expectedCloudinitConfig
 	script = append(script, modifyNetworkScript)
 	testCase(script)


### PR DESCRIPTION
Backport bridge script from maas-spaces / juju 2.0 as it has more
testing for handling bonds, VLANs and VLANs which are part of a bond.

Fixes [LP:#1532167](https://bugs.launchpad.net/juju-core/+bug/1532167)

As a by-product of the backport the script is no longer echoed to the
cloud-init console.

Fixes [LP:#1536587](https://bugs.launchpad.net/juju-core/+bug/1536587)

(Review request: http://reviews.vapour.ws/r/3648/)