### PR TITLE
lp1538868 - Use env command, not switch

### DIFF
--- a/provider/local/environ.go
+++ b/provider/local/environ.go
@@ -469,7 +469,7 @@ func (env *localEnviron) Destroy() error {
 			return err
 		}
 		args := []string{
-			"switch", osenv.JujuHomeEnvKey + "=" + osenv.JujuHome(),
+			"env", osenv.JujuHomeEnvKey + "=" + osenv.JujuHome(),
 			juju, "kill-controller", "-y", env.Config().Name(),
 		}
 		cmd := exec.Command("sudo", args...)

--- a/provider/local/environ_test.go
+++ b/provider/local/environ_test.go
@@ -266,7 +266,7 @@ func (s *localJujuTestSuite) TestDestroyCallSudo(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	expected := []string{
 		s.fakesudo,
-		"switch",
+		"env",
 		"JUJU_HOME=" + osenv.JujuHome(),
 		os.Args[0],
 		"kill-controller",


### PR DESCRIPTION
This env command is setting the JUJU_HOME
for the sudo kill-controller command.  It
shouldn't be renamed to switch.

(Review request: http://reviews.vapour.ws/r/3673/)