### PR TITLE
MADE: authentication worker

### DIFF
--- a/api/interface.go
+++ b/api/interface.go
@@ -19,7 +19,6 @@ import (
 	"github.com/juju/juju/api/firewaller"
 	"github.com/juju/juju/api/imagemetadata"
 	"github.com/juju/juju/api/instancepoller"
-	"github.com/juju/juju/api/keyupdater"
 	"github.com/juju/juju/api/machiner"
 	"github.com/juju/juju/api/networker"
 	"github.com/juju/juju/api/provisioner"
@@ -170,7 +169,6 @@ type Connection interface {
 	Reboot() (reboot.State, error)
 	Deployer() *deployer.State
 	Environment() *environment.Facade
-	KeyUpdater() *keyupdater.State
 	Addresser() *addresser.API
 	InstancePoller() *instancepoller.API
 	CharmRevisionUpdater() *charmrevisionupdater.State

--- a/api/keyupdater/authorisedkeys_test.go
+++ b/api/keyupdater/authorisedkeys_test.go
@@ -32,7 +32,7 @@ func (s *keyupdaterSuite) SetUpTest(c *gc.C) {
 	var stateAPI api.Connection
 	stateAPI, s.rawMachine = s.OpenAPIAsNewMachine(c)
 	c.Assert(stateAPI, gc.NotNil)
-	s.keyupdater = stateAPI.KeyUpdater()
+	s.keyupdater = keyupdater.NewState(stateAPI)
 	c.Assert(s.keyupdater, gc.NotNil)
 }
 

--- a/api/state.go
+++ b/api/state.go
@@ -21,7 +21,6 @@ import (
 	"github.com/juju/juju/api/firewaller"
 	"github.com/juju/juju/api/imagemetadata"
 	"github.com/juju/juju/api/instancepoller"
-	"github.com/juju/juju/api/keyupdater"
 	"github.com/juju/juju/api/machiner"
 	"github.com/juju/juju/api/networker"
 	"github.com/juju/juju/api/provisioner"
@@ -347,11 +346,6 @@ func (st *state) Addresser() *addresser.API {
 // Environment returns access to the Environment API
 func (st *state) Environment() *environment.Facade {
 	return environment.NewFacade(st)
-}
-
-// KeyUpdater returns access to the KeyUpdater API
-func (st *state) KeyUpdater() *keyupdater.State {
-	return keyupdater.NewState(st)
 }
 
 // InstancePoller returns access to the InstancePoller API

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -73,7 +73,6 @@ import (
 	"github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/addresser"
 	"github.com/juju/juju/worker/apicaller"
-	"github.com/juju/juju/worker/authenticationworker"
 	"github.com/juju/juju/worker/certupdater"
 	"github.com/juju/juju/worker/charmrevision"
 	"github.com/juju/juju/worker/cleaner"
@@ -484,6 +483,8 @@ func (a *MachineAgent) makeEngineCreator(previousAgentVersion version.Number) fu
 			PreUpgradeSteps:       upgrades.PreUpgradeSteps,
 			ShouldWriteProxyFiles: shouldWriteProxyFiles,
 			LogSource:             a.bufferedLogs,
+			MachineID:             a.machineId,
+			BootstrapMachineID:    bootstrapMachineId,
 		})
 		if err := dependency.Install(engine, manifolds); err != nil {
 			if err := worker.Stop(engine); err != nil {
@@ -761,19 +762,6 @@ func (a *MachineAgent) startAPIWorkers(apiConn api.Connection) (_ worker.Worker,
 		}
 		return w, nil
 	})
-
-	// If not a local provider bootstrap machine, start the worker to
-	// manage SSH keys.
-	providerType := agentConfig.Value(agent.ProviderType)
-	if providerType != provider.Local || a.machineId != bootstrapMachineId {
-		runner.StartWorker("authenticationworker", func() (worker.Worker, error) {
-			w, err := authenticationworker.NewWorker(apiConn.KeyUpdater(), agentConfig)
-			if err != nil {
-				return nil, errors.Annotate(err, "cannot start ssh auth-keys updater worker")
-			}
-			return w, nil
-		})
-	}
 
 	// Perform the operations needed to set up hosting for containers.
 	if err := a.setupContainerSupport(runner, apiConn, agentConfig); err != nil {

--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/juju/worker/agent"
 	"github.com/juju/juju/worker/apiaddressupdater"
 	"github.com/juju/juju/worker/apicaller"
+	"github.com/juju/juju/worker/authenticationworker"
 	"github.com/juju/juju/worker/dependency"
 	"github.com/juju/juju/worker/diskmanager"
 	"github.com/juju/juju/worker/gate"
@@ -73,6 +74,14 @@ type ManifoldsConfig struct {
 	// LogSource defines the channel type used to send log message
 	// structs within the machine agent.
 	LogSource logsender.LogRecordCh
+
+	// MachineID is the id of the machine agent, used by the
+	// authenticationworker.
+	MachineID string
+
+	// BootstrapMachineID is the id of the bootstrap machine. It is used by the
+	// authenticationworker.
+	BootstrapMachineID string
 }
 
 // Manifolds returns a set of co-configured manifolds covering the
@@ -246,6 +255,15 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 				UpgradeWaiterName: upgradeWaiterName,
 			},
 		}),
+
+		authenticationworkerName: authenticationworker.Manifold(authenticationworker.ManifoldConfig{
+			MachineID: config.MachineID,
+			PostUpgradeManifoldConfig: util.PostUpgradeManifoldConfig{
+				AgentName:         agentName,
+				APICallerName:     apiCallerName,
+				UpgradeWaiterName: upgradeWaiterName,
+			},
+		}),
 	}
 }
 
@@ -269,4 +287,5 @@ const (
 	apiAddressUpdaterName    = "api-address-updater"
 	machinerName             = "machiner"
 	logSenderName            = "log-sender"
+	authenticationworkerName = "authenticationworker"
 )

--- a/cmd/jujud/agent/machine/manifolds_test.go
+++ b/cmd/jujud/agent/machine/manifolds_test.go
@@ -56,6 +56,7 @@ func (s *ManifoldsSuite) TestManifoldNames(c *gc.C) {
 		"log-sender",
 		"api-address-updater",
 		"machiner",
+		"authenticationworker",
 	}
 	c.Assert(keys, jc.SameContents, expectedKeys)
 }

--- a/worker/authenticationworker/manifold.go
+++ b/worker/authenticationworker/manifold.go
@@ -1,0 +1,53 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package authenticationworker
+
+import (
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/agent"
+	"github.com/juju/juju/api"
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/api/keyupdater"
+	"github.com/juju/juju/provider"
+	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/dependency"
+	"github.com/juju/juju/worker/util"
+)
+
+// ManifoldConfig defines the names of the manifolds on which a Manifold will depend.
+type ManifoldConfig struct {
+	util.PostUpgradeManifoldConfig
+	MachineID          string
+	BootstrapMachineID string
+}
+
+// Manifold returns a dependency manifold that runs a authenticationworker worker,
+// using the resource names defined in the supplied config.
+func Manifold(config ManifoldConfig) dependency.Manifold {
+
+	newWorker := func(a agent.Agent, apiCaller base.APICaller) (worker.Worker, error) {
+		// If not a local provider bootstrap machine, start the worker to
+		// manage SSH keys.
+		agentConfig := a.CurrentConfig()
+		providerType := agentConfig.Value(agent.ProviderType)
+		if providerType == provider.Local && config.MachineID == config.BootstrapMachineID {
+			return nil, nil
+		}
+		apiConn, ok := apiCaller.(api.Connection)
+		if !ok {
+			return nil, errors.New("unable to obtain api.Connection")
+		}
+
+		w, err := NewWorker(keyupdater.NewState(apiConn), agentConfig)
+		if err != nil {
+			return nil, errors.Annotate(err, "cannot start ssh auth-keys updater worker")
+		}
+		return w, nil
+
+		return nil, nil
+	}
+
+	return util.PostUpgradeManifold(config.PostUpgradeManifoldConfig, newWorker)
+}

--- a/worker/authenticationworker/worker_test.go
+++ b/worker/authenticationworker/worker_test.go
@@ -61,7 +61,7 @@ func (s *workerSuite) SetUpTest(c *gc.C) {
 	var apiRoot api.Connection
 	apiRoot, s.machine = s.OpenAPIAsNewMachine(c)
 	c.Assert(apiRoot, gc.NotNil)
-	s.keyupdaterApi = apiRoot.KeyUpdater()
+	s.keyupdaterApi = keyupdater.NewState(apiRoot)
 	c.Assert(s.keyupdaterApi, gc.NotNil)
 }
 


### PR DESCRIPTION
Move the authentication worker from the machine agent runner to a machine
dep engine manifold.

(Review request: http://reviews.vapour.ws/r/3674/)