### PR TITLE
Add rpc logging

### DIFF
--- a/rpc/client.go
+++ b/rpc/client.go
@@ -124,6 +124,10 @@ func (conn *Conn) handleResponse(hdr *Header) error {
 		}
 		call.done()
 	}
+	if err != nil {
+		logger.Errorf("error handling response: %v", err)
+	}
+
 	return err
 }
 


### PR DESCRIPTION
Some CI tests have been failing recently with
"connection is shut down" errors.  This can be
caused by errors when unmarshalling the
response from the state server.  Adding some
extra logging to help debug this issue.

(Review request: http://reviews.vapour.ws/r/3676/)