### PR TITLE
Bootstrap with (public-)clouds/credentials.yaml

### DIFF
--- a/apiserver/addresser/addresser_test.go
+++ b/apiserver/addresser/addresser_test.go
@@ -275,7 +275,10 @@ func (s *AddresserSuite) TestWatchIPAddresses(c *gc.C) {
 func testingEnvConfig(c *gc.C) *config.Config {
 	cfg, err := config.New(config.NoDefaults, dummy.SampleConfig())
 	c.Assert(err, jc.ErrorIsNil)
-	env, err := environs.Prepare(cfg, envcmd.BootstrapContext(coretesting.Context(c)), configstore.NewMem())
+	env, err := environs.Prepare(
+		envcmd.BootstrapContext(coretesting.Context(c)), configstore.NewMem(),
+		"dummycontroller", environs.PrepareForBootstrapParams{Config: cfg},
+	)
 	c.Assert(err, jc.ErrorIsNil)
 	return env.Config()
 }
@@ -296,7 +299,10 @@ func nonexTestingEnvConfig(c *gc.C) *config.Config {
 func mockTestingEnvConfig(c *gc.C) *config.Config {
 	cfg, err := config.New(config.NoDefaults, mockConfig())
 	c.Assert(err, jc.ErrorIsNil)
-	env, err := environs.Prepare(cfg, envcmd.BootstrapContext(coretesting.Context(c)), configstore.NewMem())
+	env, err := environs.Prepare(
+		envcmd.BootstrapContext(coretesting.Context(c)), configstore.NewMem(),
+		"dummycontroller", environs.PrepareForBootstrapParams{Config: cfg},
+	)
 	c.Assert(err, jc.ErrorIsNil)
 	return env.Config()
 }

--- a/apiserver/common/environwatcher_test.go
+++ b/apiserver/common/environwatcher_test.go
@@ -125,7 +125,10 @@ func (*environWatcherSuite) TestEnvironConfigMaskedSecrets(c *gc.C) {
 func testingEnvConfig(c *gc.C) *config.Config {
 	cfg, err := config.New(config.NoDefaults, dummy.SampleConfig())
 	c.Assert(err, jc.ErrorIsNil)
-	env, err := environs.Prepare(cfg, envcmd.BootstrapContext(testing.Context(c)), configstore.NewMem())
+	env, err := environs.Prepare(
+		envcmd.BootstrapContext(testing.Context(c)), configstore.NewMem(),
+		"dummycontroller", environs.PrepareForBootstrapParams{Config: cfg},
+	)
 	c.Assert(err, jc.ErrorIsNil)
 	return env.Config()
 }

--- a/apiserver/environmentmanager/environmentmanager_test.go
+++ b/apiserver/environmentmanager/environmentmanager_test.go
@@ -211,9 +211,9 @@ func (s *envManagerSuite) TestCreateEnvironmentValidatesConfig(c *gc.C) {
 	admin := s.AdminUserTag(c)
 	s.setAPIUser(c, admin)
 	args := s.createArgs(c, admin)
-	delete(args.Config, "state-server")
+	args.Config["state-server"] = "maybe"
 	_, err := s.envmanager.CreateEnvironment(args)
-	c.Assert(err, gc.ErrorMatches, "provider validation failed: state-server: expected bool, got nothing")
+	c.Assert(err, gc.ErrorMatches, "provider validation failed: state-server: expected bool, got string\\(\"maybe\"\\)")
 }
 
 func (s *envManagerSuite) TestCreateEnvironmentBadConfig(c *gc.C) {

--- a/apiserver/imagemetadata/updatefrompublished_test.go
+++ b/apiserver/imagemetadata/updatefrompublished_test.go
@@ -178,7 +178,10 @@ func (s *imageMetadataUpdateSuite) TestUpdateFromPublishedImages(c *gc.C) {
 		s.calls = append(s.calls, environConfig)
 		cfg, err := config.New(config.NoDefaults, dummy.SampleConfig())
 		c.Assert(err, jc.ErrorIsNil)
-		env, err := environs.Prepare(cfg, envcmd.BootstrapContext(testing.Context(c)), configstore.NewMem())
+		env, err := environs.Prepare(
+			envcmd.BootstrapContext(testing.Context(c)), configstore.NewMem(),
+			"dummycontroller", environs.PrepareForBootstrapParams{Config: cfg},
+		)
 		c.Assert(err, jc.ErrorIsNil)
 		return env.Config(), err
 	}

--- a/cloud/clouds.go
+++ b/cloud/clouds.go
@@ -73,6 +73,30 @@ type Region struct {
 	Endpoint string `yaml:"endpoint,omitempty"`
 }
 
+// CloudByName returns the cloud with the specified name.
+// If there exists no cloud with the specified name, an
+// error satisfying errors.IsNotFound will be returned.
+//
+// TODO(axw) write unit tests for this.
+func CloudByName(name string) (*Cloud, error) {
+	// Personal clouds take precedence.
+	personalClouds, err := PersonalCloudMetadata()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if cloud, ok := personalClouds[name]; ok {
+		return &cloud, nil
+	}
+	clouds, _, err := PublicCloudMetadata(JujuPublicCloudsPath())
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if cloud, ok := clouds[name]; ok {
+		return &cloud, nil
+	}
+	return nil, errors.NotFoundf("cloud %s", name)
+}
+
 // JujuPublicCloudsPath is the location where public cloud information is
 // expected to be found. Requires JUJU_HOME to be set.
 func JujuPublicCloudsPath() string {

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -5,6 +5,7 @@ package commands
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
 	"strings"
 	"time"
@@ -18,11 +19,13 @@ import (
 
 	apiblock "github.com/juju/juju/api/block"
 	"github.com/juju/juju/apiserver"
+	jujucloud "github.com/juju/juju/cloud"
 	"github.com/juju/juju/cmd/envcmd"
 	"github.com/juju/juju/cmd/juju/block"
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/bootstrap"
+	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/configstore"
 	"github.com/juju/juju/feature"
 	"github.com/juju/juju/instance"
@@ -106,6 +109,12 @@ type bootstrapCommand struct {
 	NoAutoUpgrade         bool
 	AgentVersionParam     string
 	AgentVersion          *version.Number
+	Options               map[string]interface{}
+
+	ControllerName string
+	CredentialName string
+	Cloud          string
+	Region         string
 }
 
 func (c *bootstrapCommand) Info() *cmd.Info {
@@ -126,6 +135,8 @@ func (c *bootstrapCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.BoolVar(&c.KeepBrokenEnvironment, "keep-broken", false, "do not destroy the environment if bootstrap fails")
 	f.BoolVar(&c.NoAutoUpgrade, "no-auto-upgrade", false, "do not upgrade to newer tools on first bootstrap")
 	f.StringVar(&c.AgentVersionParam, "agent-version", "", "the version of tools to initially use for Juju agents")
+	f.StringVar(&c.CredentialName, "credential", "", "the credentials to use when bootstrapping")
+	f.Var(optionFlag{&c.Options}, "o", "specify one or more model configuration options (-o k=v [-o k2=v2 ...])")
 }
 
 func (c *bootstrapCommand) Init(args []string) (err error) {
@@ -169,7 +180,18 @@ func (c *bootstrapCommand) Init(args []string) (err error) {
 	if c.AgentVersion != nil && (c.AgentVersion.Major != version.Current.Major || c.AgentVersion.Minor != version.Current.Minor) {
 		return fmt.Errorf("requested agent version major.minor mismatch")
 	}
-	return cmd.CheckEmpty(args)
+
+	// The user must specify two positional arguments: the controller name,
+	// and the cloud name (optionally with region specified).
+	if len(args) < 2 {
+		return errors.New("controller name and cloud name are required")
+	}
+	c.ControllerName = args[0]
+	c.Cloud = args[1]
+	if i := strings.IndexRune(c.Cloud, '/'); i > 0 {
+		c.Cloud, c.Region = c.Cloud[:i], c.Cloud[i+1:]
+	}
+	return cmd.CheckEmpty(args[2:])
 }
 
 type seriesValue struct {
@@ -199,15 +221,10 @@ func (v *seriesValue) Set(s string) error {
 
 // bootstrap functionality that Run calls to support cleaner testing
 type BootstrapInterface interface {
-	EnsureNotBootstrapped(env environs.Environ) error
 	Bootstrap(ctx environs.BootstrapContext, environ environs.Environ, args bootstrap.BootstrapParams) error
 }
 
 type bootstrapFuncs struct{}
-
-func (b bootstrapFuncs) EnsureNotBootstrapped(env environs.Environ) error {
-	return bootstrap.EnsureNotBootstrapped(env)
-}
 
 func (b bootstrapFuncs) Bootstrap(ctx environs.BootstrapContext, env environs.Environ, args bootstrap.BootstrapParams) error {
 	return bootstrap.Bootstrap(ctx, env, args)
@@ -217,9 +234,10 @@ var getBootstrapFuncs = func() BootstrapInterface {
 	return &bootstrapFuncs{}
 }
 
-var getEnvName = func(c *bootstrapCommand) string {
-	return c.ConnectionName()
-}
+var (
+	environsPrepare = environs.Prepare
+	environsDestroy = environs.Destroy
+)
 
 // Run connects to the environment specified on the command line and bootstraps
 // a juju in that environment if none already exists. If there is as yet no environments.yaml file,
@@ -234,55 +252,119 @@ func (c *bootstrapCommand) Run(ctx *cmd.Context) (resultErr error) {
 		fmt.Fprintln(ctx.Stderr, "Use of --upload-series is obsolete. --upload-tools now expands to all supported series of the same operating system.")
 	}
 
-	envName := getEnvName(c)
-	if envName == "" {
-		return errors.Errorf("the name of the environment must be specified")
+	// Get the cloud definition identified by c.Cloud. If c.Cloud does not
+	// identify a cloud in clouds.yaml, but is the name of a provider, we
+	// synthesise a Cloud structure with a single region and no auth-types.
+	cloud, err := c.getCloud()
+	if errors.IsNotFound(err) {
+		ctx.Verbosef("cloud %q not found, trying as a provider name", c.Cloud)
+		_, err := environs.Provider(c.Cloud)
+		if errors.IsNotFound(err) {
+			return errors.NotFoundf("cloud %s", c.Cloud)
+		} else if err != nil {
+			return errors.Trace(err)
+		}
+		// TODO(axw) ask the provider to detect the region and endpoint
+		// from the environment?
+		cloud = &jujucloud.Cloud{
+			Type: c.Cloud,
+			Regions: map[string]jujucloud.Region{
+				c.Cloud: jujucloud.Region{},
+			},
+		}
+	} else if err != nil {
+		return errors.Trace(err)
 	}
-	if err := checkProviderType(envName); errors.IsNotFound(err) {
+	if err := checkProviderType(cloud.Type); errors.IsNotFound(err) {
 		// This error will get handled later.
 	} else if err != nil {
 		return errors.Trace(err)
 	}
 
-	environ, cleanup, err := prepareFromName(
-		ctx,
-		envName,
-		"Bootstrap",
-		bootstrapFuncs.EnsureNotBootstrapped,
+	// Get the credentials and region name.
+	credential, regionName, err := c.getCredentials(c.Cloud, cloud)
+	if errors.IsNotFound(err) && c.CredentialName == "" {
+		// No credential was explicitly specified, and no credential
+		// was found in credentials.yaml; have the provider detect
+		// credentials from the environment.
+		ctx.Verbosef("no credentials found, checking environment")
+		provider, err := environs.Provider(cloud.Type)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		detected, err := provider.DetectCredentials()
+		if err != nil {
+			return errors.Annotate(err, "detecting credentials")
+		}
+		ctx.Verbosef("provider detected credentials: %v", detected)
+		if len(detected) == 0 {
+			return errors.NotFoundf("credentials for cloud %q", c.Cloud)
+		}
+		credential = &detected[0]
+		ctx.Verbosef("authenticating with %v", credential)
+		regionName = c.Region
+		if regionName == "" {
+			regionName = c.Cloud
+		}
+	} else if err != nil {
+		return errors.Trace(err)
+	}
+	region, ok := cloud.Regions[regionName]
+	if !ok {
+		var regionNames []string
+		for name := range cloud.Regions {
+			regionNames = append(regionNames, name)
+		}
+		return errors.NotFoundf(
+			"region %q in cloud %q (expected one of %q)",
+			regionName, c.Cloud, regionNames,
+		)
+	}
+
+	// Create an environment config from the cloud and credentials.
+	configAttrs := map[string]interface{}{
+		"type": cloud.Type,
+		"name": c.ControllerName,
+	}
+	for k, v := range c.Options {
+		configAttrs[k] = v
+	}
+	cfg, err := config.New(config.UseDefaults, configAttrs)
+	if err != nil {
+		return errors.Annotate(err, "creating environment configuration")
+	}
+	store, err := configstore.Default()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	environ, err := environsPrepare(
+		envcmd.BootstrapContext(ctx), store, c.ControllerName,
+		environs.PrepareForBootstrapParams{
+			Config:        cfg,
+			Credentials:   *credential,
+			CloudRegion:   regionName,
+			CloudEndpoint: region.Endpoint,
+		},
 	)
+	if err != nil {
+		return errors.Trace(err)
+	}
 
 	// If we error out for any reason, clean up the environment.
 	defer func() {
-		if resultErr != nil && cleanup != nil {
+		if resultErr != nil {
 			if c.KeepBrokenEnvironment {
-				logger.Warningf("bootstrap failed but --keep-broken was specified so environment is not being destroyed.\n" +
-					"When you are finished diagnosing the problem, remember to run juju destroy-environment --force\n" +
-					"to clean up the environment.")
+				logger.Warningf(`
+bootstrap failed but --keep-broken was specified so environment is not being destroyed.
+When you are finished diagnosing the problem, remember to run juju destroy-environment --force
+to clean up the environment.`[1:])
 			} else {
-				handleBootstrapError(ctx, resultErr, cleanup)
+				handleBootstrapError(ctx, resultErr, func() error {
+					return environsDestroy(environ, store)
+				})
 			}
 		}
 	}()
-
-	// Handle any errors from environFromName(...).
-	if err != nil {
-		if errors.Cause(err) == environs.ErrAlreadyBootstrapped {
-			return err
-		}
-		return errors.Annotatef(err, "there was an issue examining the environment")
-	}
-
-	// Check to see if this environment is already bootstrapped. If it
-	// is, we inform the user and exit early. If an error is returned
-	// but it is not that the environment is already bootstrapped,
-	// then we're in an unknown state.
-	if err := bootstrapFuncs.EnsureNotBootstrapped(environ); nil != err {
-		if environs.ErrAlreadyBootstrapped == err {
-			logger.Warningf("This juju environment is already bootstrapped. If you want to start a new Juju\nenvironment, first run juju destroy-environment to clean up, or switch to an\nalternative environment.")
-			return err
-		}
-		return errors.Annotatef(err, "cannot determine if environment is already bootstrapped.")
-	}
 
 	// Block interruption during bootstrap. Providers may also
 	// register for interrupt notification so they can exit early.
@@ -320,12 +402,14 @@ func (c *bootstrapCommand) Run(ctx *cmd.Context) (resultErr error) {
 	if err != nil {
 		return errors.Annotate(err, "failed to bootstrap environment")
 	}
+
+	c.SetEnvName(c.ControllerName)
 	err = c.SetBootstrapEndpointAddress(environ)
 	if err != nil {
 		return errors.Annotate(err, "saving bootstrap endpoint address")
 	}
 
-	err = envcmd.SetCurrentEnvironment(ctx, envName)
+	err = envcmd.SetCurrentEnvironment(ctx, c.ControllerName)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -334,6 +418,85 @@ func (c *bootstrapCommand) Run(ctx *cmd.Context) (resultErr error) {
 	// for the state server's machine agent to be ready to accept commands
 	// before exiting this bootstrap command.
 	return c.waitForAgentInitialisation(ctx)
+}
+
+func (c *bootstrapCommand) getCloud() (*jujucloud.Cloud, error) {
+	// First, read in cloud metadata and extract the cloud the user wants
+	// to bootstrap. Ensure the cloud type is usable with the current client
+	// configuration.
+	clouds, _, err := jujucloud.PublicCloudMetadata(jujucloud.JujuPublicCloudsPath())
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	personalClouds, err := jujucloud.PersonalCloudMetadata()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	for name, cloud := range personalClouds {
+		clouds[name] = cloud
+	}
+	cloud, ok := clouds[c.Cloud]
+	if !ok {
+		return nil, errors.NotFoundf("cloud %s", c.Cloud)
+	}
+	return &cloud, nil
+}
+
+func (c *bootstrapCommand) getCredentials(
+	cloudName string,
+	cloud *jujucloud.Cloud,
+) (_ *jujucloud.Credential, region string, _ error) {
+	credentialsData, err := ioutil.ReadFile(jujucloud.JujuCredentials())
+	if os.IsNotExist(err) {
+		return nil, "", errors.NotFoundf("credentials file")
+	} else if err != nil {
+		return nil, "", errors.Trace(err)
+	}
+	credentials, err := jujucloud.ParseCredentials(credentialsData)
+	if err != nil {
+		return nil, "", errors.Annotate(err, "parsing credentials")
+	}
+	cloudCredentials, ok := credentials.Credentials[cloudName]
+	if !ok {
+		return nil, "", errors.NotFoundf("credentials for cloud %q", cloudName)
+	}
+	credentialName := c.CredentialName
+	if credentialName == "" {
+		credentialName = cloudCredentials.DefaultCredential
+	}
+	credential, ok := cloudCredentials.AuthCredentials[credentialName]
+	if !ok {
+		return nil, "", errors.NotFoundf(
+			"%q credential for cloud %q", credentialName, cloudName,
+		)
+	}
+	regionName := c.Region
+	if regionName == "" {
+		regionName = cloudCredentials.DefaultRegion
+	}
+	if regionName == "" {
+		// If no region is specified, attempt to bootstrap using the
+		// cloud name as the region name.
+		//
+		// TODO(axw) only do this if there is no cloud definition,
+		// e.g. for lxd.
+		regionName = cloudName
+	}
+
+	// Validate credential by checking schemas supported by the provider.
+	provider, err := environs.Provider(cloud.Type)
+	if err != nil {
+		return nil, "", errors.Trace(err)
+	}
+	if err := jujucloud.ValidateCredential(
+		credential, provider.CredentialSchemas(),
+	); err != nil {
+		return nil, "", errors.Annotatef(
+			err, "validating %q credential for cloud %q",
+			credentialName, cloudName,
+		)
+	}
+	return &credential, regionName, nil
 }
 
 var (
@@ -391,37 +554,19 @@ func (c *bootstrapCommand) waitForAgentInitialisation(ctx *cmd.Context) (err err
 	return err
 }
 
-var environType = func(envName string) (string, error) {
-	store, err := configstore.Default()
-	if err != nil {
-		return "", errors.Trace(err)
-	}
-	cfg, _, err := environs.ConfigForName(envName, store)
-	if err != nil {
-		return "", errors.Trace(err)
-	}
-	return cfg.Type(), nil
-}
-
 // checkProviderType ensures the provider type is okay.
-func checkProviderType(envName string) error {
-	envType, err := environType(envName)
-	if err != nil {
-		return errors.Trace(err)
-	}
-
+func checkProviderType(envType string) error {
 	featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
 	flag, ok := provisionalProviders[envType]
 	if ok && !featureflag.Enabled(flag) {
 		msg := `the %q provider is provisional in this version of Juju. To use it anyway, set JUJU_DEV_FEATURE_FLAGS="%s" in your shell environment`
 		return errors.Errorf(msg, envType, flag)
 	}
-
 	return nil
 }
 
 // handleBootstrapError is called to clean up if bootstrap fails.
-func handleBootstrapError(ctx *cmd.Context, err error, cleanup func()) {
+func handleBootstrapError(ctx *cmd.Context, err error, cleanup func() error) {
 	ch := make(chan os.Signal, 1)
 	ctx.InterruptNotify(ch)
 	defer ctx.StopInterruptNotify(ch)
@@ -431,7 +576,9 @@ func handleBootstrapError(ctx *cmd.Context, err error, cleanup func()) {
 			fmt.Fprintln(ctx.GetStderr(), "Cleaning up failed bootstrap")
 		}
 	}()
-	cleanup()
+	if err := cleanup(); err != nil {
+		logger.Errorf("error cleaning up: %v", err)
+	}
 }
 
 var allInstances = func(environ environs.Environ) ([]instance.Instance, error) {

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -512,7 +512,6 @@ func (s *BootstrapSuite) TestBootstrapPropagatesEnvErrors(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	jenvFile := filepath.Join(environmentsDir, envName+".jenv")
 	err = ioutil.WriteFile(jenvFile, []byte("nonsense"), 0644)
-	//err = os.Chmod(jenvFile, os.FileMode(0200))
 	c.Assert(err, jc.ErrorIsNil)
 
 	_, err = coretesting.RunCommand(c, newBootstrapCommand(), envName, "dummy")

--- a/cmd/juju/commands/common.go
+++ b/cmd/juju/commands/common.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/apiserver/params"
-	"github.com/juju/juju/cmd/envcmd"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/configstore"
@@ -54,49 +53,6 @@ func destroyEnvInfoProductionFunc(
 	if err := environs.DestroyInfo(cfgName, store); err != nil {
 		logger.Errorf("the environment jenv file could not be cleaned up: %v", err)
 	}
-}
-
-// prepareFromName prepares a new environment for bootstrapping. If there are
-// no errors, it returns the environ and a closure to clean up in case we need
-// to further up the stack. If an error has occurred, the environment and
-// cleanup function will be nil, and the error will be filled in.
-var prepareFromName = prepareFromNameProductionFunc
-
-var environsPrepare = environs.Prepare
-
-func prepareFromNameProductionFunc(
-	ctx *cmd.Context,
-	envName string,
-	action string,
-	ensureNotBootstrapped func(environs.Environ) error,
-) (env environs.Environ, cleanup func(), err error) {
-
-	store, err := configstore.Default()
-	if err != nil {
-		return nil, nil, err
-	}
-
-	cfg, _, err := environs.ConfigForName(envName, store)
-	if err != nil {
-		return nil, nil, errors.Trace(err)
-	}
-
-	cleanup = func() {
-		if ensureNotBootstrapped(env) != environs.ErrAlreadyBootstrapped {
-			logger.Debugf("Destroying environment.")
-			destroyPreparedEnviron(ctx, env, store, action)
-		}
-	}
-
-	if env, err = environsPrepare(cfg, envcmd.BootstrapContext(ctx), store); err != nil {
-		if !errors.IsAlreadyExists(err) {
-			logger.Debugf("Destroying environment info.")
-			destroyEnvInfo(ctx, envName, store, action)
-		}
-		return nil, nil, err
-	}
-
-	return env, cleanup, err
 }
 
 type resolveCharmStoreEntityParams struct {

--- a/cmd/juju/commands/flags.go
+++ b/cmd/juju/commands/flags.go
@@ -8,9 +8,40 @@ import (
 	"strings"
 
 	"github.com/juju/errors"
+	"gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/storage"
 )
+
+type optionFlag struct {
+	options *map[string]interface{}
+}
+
+// Set implements gnuflag.Value.Set.
+func (f optionFlag) Set(s string) error {
+	fields := strings.SplitN(s, "=", 2)
+	if len(fields) < 2 {
+		return errors.New("expected <key>=<value>")
+	}
+	var value interface{}
+	if err := yaml.Unmarshal([]byte(fields[1]), &value); err != nil {
+		return errors.Trace(err)
+	}
+	if *f.options == nil {
+		*f.options = make(map[string]interface{})
+	}
+	(*f.options)[fields[0]] = value
+	return nil
+}
+
+// String implements gnuflag.Value.String.
+func (f optionFlag) String() string {
+	strs := make([]string, 0, len(*f.options))
+	for k, v := range *f.options {
+		strs = append(strs, fmt.Sprintf("%s=%v", k, v))
+	}
+	return strings.Join(strs, " ")
+}
 
 type storageFlag struct {
 	stores       *map[string]storage.Constraints

--- a/cmd/plugins/juju-metadata/imagemetadata.go
+++ b/cmd/plugins/juju-metadata/imagemetadata.go
@@ -39,8 +39,14 @@ func (c *imageMetadataCommandBase) prepare(context *cmd.Context) (environs.Envir
 	// We are preparing an environment to access parameters needed to access
 	// image metadata. We don't need, nor want, credential verification.
 	// In most cases, credentials will not be available.
-	ctx := envcmd.BootstrapContextNoVerify(context)
-	return environs.Prepare(cfg, ctx, store)
+	//ctx := envcmd.BootstrapContextNoVerify(context)
+	// TODO(axw) we'll need to revise the metadata commands to work
+	// without preparing an environment. They should take the same
+	// format as bootstrap, i.e. cloud/region, and we'll use that to
+	// identify region and endpoint info that we need. Not sure what
+	// we'll do about simplestreams.MetadataValidator yet. Probably
+	// move it to the EnvironProvider interface.
+	return environs.New(cfg)
 }
 
 func newImageMetadataCommand() cmd.Command {

--- a/cmd/plugins/juju-metadata/toolsmetadata_test.go
+++ b/cmd/plugins/juju-metadata/toolsmetadata_test.go
@@ -50,7 +50,11 @@ func (s *ToolsMetadataSuite) SetUpTest(c *gc.C) {
 		"state-server": true,
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	env, err := environs.Prepare(cfg, envcmd.BootstrapContextNoVerify(coretesting.Context(c)), configstore.NewMem())
+	env, err := environs.Prepare(
+		envcmd.BootstrapContextNoVerify(coretesting.Context(c)),
+		configstore.NewMem(), cfg.Name(),
+		environs.PrepareForBootstrapParams{Config: cfg},
+	)
 	c.Assert(err, jc.ErrorIsNil)
 	s.env = env
 	loggo.GetLogger("").SetLogLevel(loggo.INFO)

--- a/cmd/plugins/juju-metadata/validateimagemetadata_test.go
+++ b/cmd/plugins/juju-metadata/validateimagemetadata_test.go
@@ -101,6 +101,7 @@ environments:
         application-id: bar
         application-password: baz
         tenant-id: qux
+        controller-resource-group: fnord
 `
 
 func (s *ValidateImageMetadataSuite) SetUpTest(c *gc.C) {

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -311,26 +311,3 @@ func validateConstraints(env environs.Environ, cons constraints.Value) error {
 	}
 	return err
 }
-
-// EnsureNotBootstrapped returns nil if the environment is not
-// bootstrapped, and an error if it is or if the function was not able
-// to tell.
-func EnsureNotBootstrapped(env environs.Environ) error {
-	_, err := env.StateServerInstances()
-	// If there is no error determining state server instaces,
-	// then we are bootstrapped.
-	switch errors.Cause(err) {
-	case nil:
-		return environs.ErrAlreadyBootstrapped
-	case environs.ErrNoInstances:
-		// TODO(axw) 2015-02-03 #1417526
-		// We should not be relying on this result,
-		// as it is possible for there to be no
-		// state servers despite the environment
-		// being bootstrapped.
-		fallthrough
-	case environs.ErrNotBootstrapped:
-		return nil
-	}
-	return err
-}

--- a/environs/errors.go
+++ b/environs/errors.go
@@ -8,10 +8,9 @@ import (
 )
 
 var (
-	ErrNotBootstrapped     = errors.New("environment is not bootstrapped")
-	ErrAlreadyBootstrapped = errors.NewAlreadyExists(nil, "environment is already bootstrapped")
-	ErrNoInstances         = errors.NotFoundf("instances")
-	ErrPartialInstances    = errors.New("only some instances were found")
+	ErrNotBootstrapped  = errors.New("environment is not bootstrapped")
+	ErrNoInstances      = errors.NotFoundf("instances")
+	ErrPartialInstances = errors.New("only some instances were found")
 
 	// Errors indicating that the provider can't allocate an IP address to an
 	// instance.

--- a/environs/imagemetadata_test.go
+++ b/environs/imagemetadata_test.go
@@ -45,7 +45,10 @@ func (s *ImageMetadataSuite) env(c *gc.C, imageMetadataURL, stream string) envir
 	}
 	cfg, err := config.New(config.NoDefaults, attrs)
 	c.Assert(err, jc.ErrorIsNil)
-	env, err := environs.Prepare(cfg, envtesting.BootstrapContext(c), configstore.NewMem())
+	env, err := environs.Prepare(
+		envtesting.BootstrapContext(c), configstore.NewMem(),
+		cfg.Name(), environs.PrepareForBootstrapParams{Config: cfg},
+	)
 	c.Assert(err, jc.ErrorIsNil)
 	return env
 }

--- a/environs/jujutest/tests.go
+++ b/environs/jujutest/tests.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/bootstrap"
 	"github.com/juju/juju/environs/config"
@@ -32,7 +33,10 @@ import (
 // is opened once for each test, and some potentially expensive operations
 // may be executed.
 type Tests struct {
-	TestConfig coretesting.Attrs
+	TestConfig    coretesting.Attrs
+	Credential    cloud.Credential
+	CloudEndpoint string
+	CloudRegion   string
 	envtesting.ToolsFixture
 
 	// ConfigStore holds the configuration storage
@@ -57,7 +61,17 @@ func (t *Tests) Open(c *gc.C) environs.Environ {
 func (t *Tests) Prepare(c *gc.C) environs.Environ {
 	cfg, err := config.New(config.NoDefaults, t.TestConfig)
 	c.Assert(err, jc.ErrorIsNil)
-	e, err := environs.Prepare(cfg, envtesting.BootstrapContext(c), t.ConfigStore)
+	credential := t.Credential
+	if credential.AuthType() == "" {
+		credential = cloud.NewEmptyCredential()
+	}
+	args := environs.PrepareForBootstrapParams{
+		Config:        cfg,
+		Credentials:   credential,
+		CloudEndpoint: t.CloudEndpoint,
+		CloudRegion:   t.CloudRegion,
+	}
+	e, err := environs.Prepare(envtesting.BootstrapContext(c), t.ConfigStore, args.Config.Name(), args)
 	c.Assert(err, gc.IsNil, gc.Commentf("preparing environ %#v", t.TestConfig))
 	c.Assert(e, gc.NotNil)
 	return e
@@ -127,22 +141,14 @@ func (t *Tests) TestStartStop(c *gc.C) {
 
 func (t *Tests) TestBootstrap(c *gc.C) {
 	e := t.Prepare(c)
-	err := bootstrap.EnsureNotBootstrapped(e)
-	c.Assert(err, jc.ErrorIsNil)
-	err = bootstrap.Bootstrap(envtesting.BootstrapContext(c), e, bootstrap.BootstrapParams{})
+	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), e, bootstrap.BootstrapParams{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	stateServerInstances, err := e.StateServerInstances()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(stateServerInstances, gc.Not(gc.HasLen), 0)
 
-	err = bootstrap.EnsureNotBootstrapped(e)
-	c.Assert(err, gc.ErrorMatches, "environment is already bootstrapped")
-
 	e2 := t.Open(c)
-	err = bootstrap.EnsureNotBootstrapped(e2)
-	c.Assert(err, gc.ErrorMatches, "environment is already bootstrapped")
-
 	stateServerInstances2, err := e2.StateServerInstances()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(stateServerInstances2, gc.Not(gc.HasLen), 0)
@@ -154,13 +160,8 @@ func (t *Tests) TestBootstrap(c *gc.C) {
 	// Prepare again because Destroy invalidates old environments.
 	e3 := t.Prepare(c)
 
-	err = bootstrap.EnsureNotBootstrapped(e3)
-	c.Assert(err, jc.ErrorIsNil)
 	err = bootstrap.Bootstrap(envtesting.BootstrapContext(c), e3, bootstrap.BootstrapParams{})
 	c.Assert(err, jc.ErrorIsNil)
-
-	err = bootstrap.EnsureNotBootstrapped(e3)
-	c.Assert(err, gc.ErrorMatches, "environment is already bootstrapped")
 
 	err = environs.Destroy(e3, t.ConfigStore)
 	c.Assert(err, jc.ErrorIsNil)

--- a/environs/tools/tools_test.go
+++ b/environs/tools/tools_test.go
@@ -95,7 +95,7 @@ func (s *SimpleStreamsToolsSuite) resetEnv(c *gc.C, attrs map[string]interface{}
 	dummy.Reset()
 	cfg, err := config.New(config.NoDefaults, dummy.SampleConfig().Merge(attrs))
 	c.Assert(err, jc.ErrorIsNil)
-	env, err := environs.Prepare(cfg, envtesting.BootstrapContext(c), configstore.NewMem())
+	env, err := environs.Prepare(envtesting.BootstrapContext(c), configstore.NewMem(), cfg.Name(), environs.PrepareForBootstrapParams{Config: cfg})
 	c.Assert(err, jc.ErrorIsNil)
 	s.env = env
 	s.removeTools(c)

--- a/environs/tools/urls_test.go
+++ b/environs/tools/urls_test.go
@@ -45,7 +45,7 @@ func (s *URLsSuite) env(c *gc.C, toolsMetadataURL string) environs.Environ {
 	}
 	cfg, err := config.New(config.NoDefaults, attrs)
 	c.Assert(err, jc.ErrorIsNil)
-	env, err := environs.Prepare(cfg, envtesting.BootstrapContext(c), configstore.NewMem())
+	env, err := environs.Prepare(envtesting.BootstrapContext(c), configstore.NewMem(), cfg.Name(), environs.PrepareForBootstrapParams{Config: cfg})
 	c.Assert(err, jc.ErrorIsNil)
 	return env
 }

--- a/juju/api_test.go
+++ b/juju/api_test.go
@@ -70,7 +70,7 @@ func (cs *NewAPIStateSuite) TestNewAPIState(c *gc.C) {
 	cfg, err := config.New(config.NoDefaults, dummy.SampleConfig())
 	c.Assert(err, jc.ErrorIsNil)
 	ctx := envtesting.BootstrapContext(c)
-	env, err := environs.Prepare(cfg, ctx, configstore.NewMem())
+	env, err := environs.Prepare(ctx, configstore.NewMem(), cfg.Name(), environs.PrepareForBootstrapParams{Config: cfg})
 	c.Assert(err, jc.ErrorIsNil)
 
 	storageDir := c.MkDir()
@@ -153,7 +153,7 @@ func (s *NewAPIClientSuite) bootstrapEnv(c *gc.C, envName string, store configst
 	c.Logf("env name: %s", envName)
 	cfg, _, err := environs.ConfigForName(envName, store)
 	c.Assert(err, jc.ErrorIsNil)
-	env, err := environs.Prepare(cfg, ctx, store)
+	env, err := environs.Prepare(ctx, store, cfg.Name(), environs.PrepareForBootstrapParams{Config: cfg})
 	c.Assert(err, jc.ErrorIsNil)
 
 	storageDir := c.MkDir()

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/api"
+	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/cmd/envcmd"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/bootstrap"
@@ -234,7 +235,15 @@ func (s *JujuConnSuite) setUpConn(c *gc.C) {
 	s.ConfigStore = store
 
 	ctx := testing.Context(c)
-	environ, err := environs.Prepare(cfg, envcmd.BootstrapContext(ctx), s.ConfigStore)
+	environ, err := environs.Prepare(
+		envcmd.BootstrapContext(ctx),
+		s.ConfigStore,
+		"dummyenv",
+		environs.PrepareForBootstrapParams{
+			Config:      cfg,
+			Credentials: cloud.NewEmptyCredential(),
+		},
+	)
 	c.Assert(err, jc.ErrorIsNil)
 	// sanity check we've got the correct environment.
 	c.Assert(environ.Config().Name(), gc.Equals, "dummyenv")

--- a/provider/dummy/config_test.go
+++ b/provider/dummy/config_test.go
@@ -31,7 +31,10 @@ func (*ConfigSuite) TestSecretAttrs(c *gc.C) {
 	cfg, err := config.New(config.NoDefaults, attrs)
 	c.Assert(err, jc.ErrorIsNil)
 	ctx := envtesting.BootstrapContext(c)
-	env, err := environs.Prepare(cfg, ctx, configstore.NewMem())
+	env, err := environs.Prepare(
+		ctx, configstore.NewMem(), cfg.Name(),
+		environs.PrepareForBootstrapParams{Config: cfg},
+	)
 	c.Assert(err, jc.ErrorIsNil)
 	defer env.Destroy()
 	expected := map[string]string{
@@ -84,7 +87,10 @@ func (s *ConfigSuite) TestFirewallMode(c *gc.C) {
 			continue
 		}
 		ctx := envtesting.BootstrapContext(c)
-		env, err := environs.Prepare(cfg, ctx, configstore.NewMem())
+		env, err := environs.Prepare(
+			ctx, configstore.NewMem(), cfg.Name(),
+			environs.PrepareForBootstrapParams{Config: cfg},
+		)
 		if test.errorMsg != "" {
 			c.Assert(err, gc.ErrorMatches, test.errorMsg)
 			continue

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -492,9 +492,10 @@ var configFields = func() schema.Fields {
 }()
 
 var configDefaults = schema.Defaults{
-	"broken":   "",
-	"secret":   "pork",
-	"state-id": schema.Omit,
+	"broken":       "",
+	"secret":       "pork",
+	"state-id":     schema.Omit,
+	"state-server": false,
 }
 
 type environConfig struct {
@@ -543,11 +544,11 @@ func (p *environProvider) Schema() environschema.Fields {
 }
 
 func (p *environProvider) CredentialSchemas() map[cloud.AuthType]cloud.CredentialSchema {
-	return nil
+	return map[cloud.AuthType]cloud.CredentialSchema{cloud.EmptyAuthType: {}}
 }
 
 func (*environProvider) DetectCredentials() ([]cloud.Credential, error) {
-	return nil, errors.NotFoundf("credentials")
+	return []cloud.Credential{cloud.NewEmptyCredential()}, nil
 }
 
 func (p *environProvider) Validate(cfg, old *config.Config) (valid *config.Config, err error) {

--- a/provider/dummy/environs_test.go
+++ b/provider/dummy/environs_test.go
@@ -114,14 +114,15 @@ func (s *suite) bootstrapTestEnviron(c *gc.C, preferIPv6 bool) environs.Networki
 	s.TestConfig["prefer-ipv6"] = preferIPv6
 	cfg, err := config.New(config.NoDefaults, s.TestConfig)
 	c.Assert(err, jc.ErrorIsNil)
-	env, err := environs.Prepare(cfg, envtesting.BootstrapContext(c), s.ConfigStore)
+	env, err := environs.Prepare(
+		envtesting.BootstrapContext(c), s.ConfigStore, cfg.Name(),
+		environs.PrepareForBootstrapParams{Config: cfg},
+	)
 	c.Assert(err, gc.IsNil, gc.Commentf("preparing environ %#v", s.TestConfig))
 	c.Assert(env, gc.NotNil)
 	netenv, supported := environs.SupportsNetworking(env)
 	c.Assert(supported, jc.IsTrue)
 
-	err = bootstrap.EnsureNotBootstrapped(netenv)
-	c.Assert(err, jc.ErrorIsNil)
 	err = bootstrap.Bootstrap(envtesting.BootstrapContext(c), netenv, bootstrap.BootstrapParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	return netenv

--- a/provider/ec2/config_test.go
+++ b/provider/ec2/config_test.go
@@ -16,6 +16,7 @@ import (
 	"gopkg.in/amz.v3/aws"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	envtesting "github.com/juju/juju/environs/testing"
@@ -348,6 +349,14 @@ func (s *ConfigSuite) TestPrepareInsertsUniqueControlBucket(c *gc.C) {
 	ctx := envtesting.BootstrapContext(c)
 	env0, err := providerInstance.PrepareForBootstrap(ctx, environs.PrepareForBootstrapParams{
 		Config: cfg,
+		Credentials: cloud.NewCredential(
+			cloud.AccessKeyAuthType,
+			map[string]string{
+				"access-key": "x",
+				"secret-key": "y",
+			},
+		),
+		CloudRegion: "test",
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	bucket0 := env0.(*environ).ecfg().controlBucket()
@@ -355,6 +364,14 @@ func (s *ConfigSuite) TestPrepareInsertsUniqueControlBucket(c *gc.C) {
 
 	env1, err := providerInstance.PrepareForBootstrap(ctx, environs.PrepareForBootstrapParams{
 		Config: cfg,
+		Credentials: cloud.NewCredential(
+			cloud.AccessKeyAuthType,
+			map[string]string{
+				"access-key": "x",
+				"secret-key": "y",
+			},
+		),
+		CloudRegion: "test",
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	bucket1 := env1.(*environ).ecfg().controlBucket()
@@ -374,6 +391,14 @@ func (s *ConfigSuite) TestPrepareDoesNotTouchExistingControlBucket(c *gc.C) {
 
 	env, err := providerInstance.PrepareForBootstrap(envtesting.BootstrapContext(c), environs.PrepareForBootstrapParams{
 		Config: cfg,
+		Credentials: cloud.NewCredential(
+			cloud.AccessKeyAuthType,
+			map[string]string{
+				"access-key": "x",
+				"secret-key": "y",
+			},
+		),
+		CloudRegion: "test",
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	bucket := env.(*environ).ecfg().controlBucket()
@@ -390,6 +415,14 @@ func (s *ConfigSuite) TestPrepareSetsDefaultBlockSource(c *gc.C) {
 
 	env, err := providerInstance.PrepareForBootstrap(envtesting.BootstrapContext(c), environs.PrepareForBootstrapParams{
 		Config: cfg,
+		Credentials: cloud.NewCredential(
+			cloud.AccessKeyAuthType,
+			map[string]string{
+				"access-key": "x",
+				"secret-key": "y",
+			},
+		),
+		CloudRegion: "test",
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	source, ok := env.(*environ).ecfg().StorageDefaultBlockSource()

--- a/provider/ec2/ebs_test.go
+++ b/provider/ec2/ebs_test.go
@@ -18,6 +18,7 @@ import (
 	"gopkg.in/amz.v3/ec2/ec2test"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/jujutest"
@@ -55,6 +56,7 @@ var _ = gc.Suite(&ebsVolumeSuite{})
 
 type ebsVolumeSuite struct {
 	testing.BaseSuite
+	// TODO(axw) the EBS tests should not be embedding jujutest.Tests.
 	jujutest.Tests
 	srv                localServer
 	restoreEC2Patching func()
@@ -63,10 +65,23 @@ type ebsVolumeSuite struct {
 }
 
 func (s *ebsVolumeSuite) SetUpSuite(c *gc.C) {
+	s.Credential = cloud.NewCredential(
+		cloud.AccessKeyAuthType,
+		map[string]string{
+			"access-key": "x",
+			"secret-key": "x",
+		},
+	)
+	s.CloudRegion = "test"
+
 	// Upload arches that ec2 supports; add to this
 	// as ec2 coverage expands.
 	s.UploadArches = []string{arch.AMD64, arch.I386}
-	s.TestConfig = localConfigAttrs
+	s.TestConfig = localConfigAttrs.Merge(testing.Attrs{
+		"access-key": "x",
+		"secret-key": "x",
+		"region":     "test",
+	})
 	s.restoreEC2Patching = patchEC2ForTesting()
 	s.BaseSuite.SetUpSuite(c)
 }

--- a/provider/gce/credentials.go
+++ b/provider/gce/credentials.go
@@ -4,8 +4,11 @@
 package gce
 
 import (
+	"os"
+
 	"github.com/juju/errors"
 	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/provider/gce/google"
 )
 
 type environProviderCredentials struct{}
@@ -39,4 +42,24 @@ func (environProviderCredentials) CredentialSchemas() map[cloud.AuthType]cloud.C
 // DetectCredentials is part of the environs.ProviderCredentials interface.
 func (environProviderCredentials) DetectCredentials() ([]cloud.Credential, error) {
 	return nil, errors.NotFoundf("credentials")
+}
+
+// parseJSONAuthFile parses the file with the given path, and extracts
+// the OAuth2 credentials within.
+func parseJSONAuthFile(filename string) (cloud.Credential, error) {
+	authFile, err := os.Open(filename)
+	if err != nil {
+		return cloud.Credential{}, errors.Trace(err)
+	}
+	defer authFile.Close()
+	creds, err := google.ParseJSONKey(authFile)
+	if err != nil {
+		return cloud.Credential{}, errors.Trace(err)
+	}
+	return cloud.NewCredential(cloud.OAuth2AuthType, map[string]string{
+		"project-id":   creds.ProjectID,
+		"client-id":    creds.ClientID,
+		"client-email": creds.ClientEmail,
+		"private-key":  string(creds.PrivateKey),
+	}), nil
 }

--- a/provider/gce/google/config.go
+++ b/provider/gce/google/config.go
@@ -39,6 +39,9 @@ type Credentials struct {
 	// config used in the OAuth-wrapping network transport.
 	ClientID string
 
+	// ProjectID is the GCE project's ID that these credentials relate to.
+	ProjectID string
+
 	// ClientEmail is the email address associatd with the GCE account.
 	// It is used to generate a new OAuth token to use in the
 	// OAuth-wrapping network transport.
@@ -61,6 +64,8 @@ func NewCredentials(values map[string]string) (*Credentials, error) {
 			creds.ClientID = v
 		case OSEnvClientEmail:
 			creds.ClientEmail = v
+		case OSEnvProjectID:
+			creds.ProjectID = v
 		case OSEnvPrivateKey:
 			creds.PrivateKey = []byte(v)
 		default:
@@ -90,8 +95,6 @@ func ParseJSONKey(jsonKeyFile io.Reader) (*Credentials, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	delete(values, "type")
-	delete(values, "private_key_id")
 	creds, err := NewCredentials(values)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -115,16 +118,16 @@ func parseJSONKey(jsonKey []byte) (map[string]string, error) {
 	switch keyType {
 	case jsonKeyTypeServiceAccount:
 		for k, v := range data {
+			delete(data, k)
 			switch k {
 			case "private_key":
 				data[OSEnvPrivateKey] = v
-				delete(data, k)
 			case "client_email":
 				data[OSEnvClientEmail] = v
-				delete(data, k)
 			case "client_id":
 				data[OSEnvClientID] = v
-				delete(data, k)
+			case "project_id":
+				data[OSEnvProjectID] = v
 			}
 		}
 	default:
@@ -151,6 +154,7 @@ func (gc Credentials) Values() map[string]string {
 		OSEnvClientID:    gc.ClientID,
 		OSEnvClientEmail: gc.ClientEmail,
 		OSEnvPrivateKey:  string(gc.PrivateKey),
+		OSEnvProjectID:   gc.ProjectID,
 	}
 }
 

--- a/provider/gce/google/config_credentials_test.go
+++ b/provider/gce/google/config_credentials_test.go
@@ -25,6 +25,7 @@ func (s *credentialsSuite) TestNewCredentials(c *gc.C) {
 		google.OSEnvClientID:    "abc",
 		google.OSEnvClientEmail: "xyz@g.com",
 		google.OSEnvPrivateKey:  "<some-key>",
+		google.OSEnvProjectID:   "yup",
 	}
 	creds, err := google.NewCredentials(values)
 	c.Assert(err, jc.ErrorIsNil)
@@ -35,6 +36,7 @@ func (s *credentialsSuite) TestNewCredentials(c *gc.C) {
 		ClientID:    "abc",
 		ClientEmail: "xyz@g.com",
 		PrivateKey:  []byte("<some-key>"),
+		ProjectID:   "yup",
 	})
 	data := make(map[string]string)
 	err = json.Unmarshal(jsonKey, &data)
@@ -70,6 +72,7 @@ func (s *credentialsSuite) TestParseJSONKey(c *gc.C) {
     "private_key": "<some-key>",
     "client_email": "xyz@g.com",
     "client_id": "abc",
+    "project_id": "yup",
     "type": "service_account"
 }`[1:]
 	creds, err := google.ParseJSONKey(bytes.NewBufferString(original))
@@ -81,6 +84,7 @@ func (s *credentialsSuite) TestParseJSONKey(c *gc.C) {
 		ClientID:    "abc",
 		ClientEmail: "xyz@g.com",
 		PrivateKey:  []byte("<some-key>"),
+		ProjectID:   "yup",
 	})
 	c.Check(string(jsonKey), gc.Equals, original)
 }
@@ -90,6 +94,7 @@ func (s *credentialsSuite) TestCredentialsValues(c *gc.C) {
 		google.OSEnvClientID:    "abc",
 		google.OSEnvClientEmail: "xyz@g.com",
 		google.OSEnvPrivateKey:  "<some-key>",
+		google.OSEnvProjectID:   "yup",
 	}
 	creds, err := google.NewCredentials(original)
 	c.Assert(err, jc.ErrorIsNil)

--- a/provider/gce/provider_test.go
+++ b/provider/gce/provider_test.go
@@ -7,6 +7,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs"
 	envtesting "github.com/juju/juju/environs/testing"
 	"github.com/juju/juju/provider/gce"
@@ -43,6 +44,15 @@ func (s *providerSuite) TestOpen(c *gc.C) {
 func (s *providerSuite) TestPrepareForBootstrap(c *gc.C) {
 	env, err := s.provider.PrepareForBootstrap(envtesting.BootstrapContext(c), environs.PrepareForBootstrapParams{
 		Config: s.Config,
+		Credentials: cloud.NewCredential(
+			cloud.OAuth2AuthType,
+			map[string]string{
+				"project-id":   "x",
+				"client-id":    "y",
+				"client-email": "zz@example.com",
+				"private-key":  "why",
+			},
+		),
 	})
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(env, gc.NotNil)

--- a/provider/joyent/export_test.go
+++ b/provider/joyent/export_test.go
@@ -197,7 +197,10 @@ func CreateContainer(s *JoyentStorage) error {
 func MakeConfig(c *gc.C, attrs testing.Attrs) *environConfig {
 	cfg, err := config.New(config.NoDefaults, attrs)
 	c.Assert(err, jc.ErrorIsNil)
-	env, err := environs.Prepare(cfg, envtesting.BootstrapContext(c), configstore.NewMem())
+	env, err := environs.Prepare(
+		envtesting.BootstrapContext(c), configstore.NewMem(), cfg.Name(),
+		environs.PrepareForBootstrapParams{Config: cfg},
+	)
 	c.Assert(err, jc.ErrorIsNil)
 	return env.(*joyentEnviron).Ecfg()
 }

--- a/provider/openstack/config.go
+++ b/provider/openstack/config.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/url"
 
+	"github.com/juju/errors"
 	"github.com/juju/schema"
 	"gopkg.in/goose.v1/identity"
 	"gopkg.in/juju/environschema.v1"
@@ -188,61 +189,38 @@ func (p EnvironProvider) Validate(cfg, old *config.Config) (valid *config.Config
 
 	ecfg := &environConfig{cfg, validated}
 
-	if ecfg.authURL() != "" {
-		parts, err := url.Parse(ecfg.authURL())
-		if err != nil || parts.Host == "" || parts.Scheme == "" {
-			return nil, fmt.Errorf("invalid auth-url value %q", ecfg.authURL())
-		}
-	}
-	cred := identity.CredentialsFromEnv()
-	format := "required environment variable not set for credentials attribute: %s"
 	switch ecfg.authMode() {
 	case AuthUserPass, AuthLegacy:
 		if ecfg.username() == "" {
-			if cred.User == "" {
-				return nil, fmt.Errorf(format, "User")
-			}
-			ecfg.attrs["username"] = cred.User
+			return nil, errors.NotValidf("missing username")
 		}
 		if ecfg.password() == "" {
-			if cred.Secrets == "" {
-				return nil, fmt.Errorf(format, "Secrets")
-			}
-			ecfg.attrs["password"] = cred.Secrets
+			return nil, errors.NotValidf("missing password")
 		}
 	case AuthKeyPair:
 		if ecfg.accessKey() == "" {
-			if cred.User == "" {
-				return nil, fmt.Errorf(format, "User")
-			}
-			ecfg.attrs["access-key"] = cred.User
+			return nil, errors.NotValidf("missing access-key")
 		}
 		if ecfg.secretKey() == "" {
-			if cred.Secrets == "" {
-				return nil, fmt.Errorf(format, "Secrets")
-			}
-			ecfg.attrs["secret-key"] = cred.Secrets
+			return nil, errors.NotValidf("missing secret-key")
 		}
 	default:
 		return nil, fmt.Errorf("unexpected authentication mode %q", ecfg.authMode())
 	}
+
 	if ecfg.authURL() == "" {
-		if cred.URL == "" {
-			return nil, fmt.Errorf(format, "URL")
-		}
-		ecfg.attrs["auth-url"] = cred.URL
+		return nil, errors.NotValidf("missing auth-url")
 	}
 	if ecfg.tenantName() == "" {
-		if cred.TenantName == "" {
-			return nil, fmt.Errorf(format, "TenantName")
-		}
-		ecfg.attrs["tenant-name"] = cred.TenantName
+		return nil, errors.NotValidf("missing tenant-name")
 	}
 	if ecfg.region() == "" {
-		if cred.Region == "" {
-			return nil, fmt.Errorf(format, "Region")
-		}
-		ecfg.attrs["region"] = cred.Region
+		return nil, errors.NotValidf("missing region")
+	}
+
+	parts, err := url.Parse(ecfg.authURL())
+	if err != nil || parts.Host == "" || parts.Scheme == "" {
+		return nil, fmt.Errorf("invalid auth-url value %q", ecfg.authURL())
 	}
 
 	if old != nil {

--- a/provider/openstack/config_test.go
+++ b/provider/openstack/config_test.go
@@ -9,6 +9,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	envtesting "github.com/juju/juju/environs/testing"
@@ -46,7 +47,7 @@ var _ = gc.Suite(&ConfigSuite{})
 // parse matches the given error.
 type configTest struct {
 	summary                 string
-	config                  map[string]interface{}
+	config                  testing.Attrs
 	change                  map[string]interface{}
 	expect                  map[string]interface{}
 	envVars                 map[string]string
@@ -69,7 +70,13 @@ type configTest struct {
 	blockStorageSource      string
 }
 
-type attrs map[string]interface{}
+var requiredConfig = testing.Attrs{
+	"region":      "configtest",
+	"auth-url":    "http://auth",
+	"username":    "user",
+	"password":    "pass",
+	"tenant-name": "tenant",
+}
 
 func restoreEnvVars(envVars map[string]string) {
 	for k, v := range envVars {
@@ -195,271 +202,238 @@ func (s *ConfigSuite) TearDownTest(c *gc.C) {
 var configTests = []configTest{
 	{
 		summary: "setting region",
-		config: attrs{
+		config: requiredConfig.Merge(testing.Attrs{
 			"region": "testreg",
-		},
+		}),
 		region: "testreg",
 	}, {
 		summary: "setting region (2)",
-		config: attrs{
+		config: requiredConfig.Merge(testing.Attrs{
 			"region": "configtest",
-		},
+		}),
 		region: "configtest",
 	}, {
 		summary: "changing region",
-		config: attrs{
-			"region": "configtest",
+		config:  requiredConfig,
+		change: testing.Attrs{
+			"region": "otherregion",
 		},
-		change: attrs{
-			"region": "somereg",
-		},
-		err: `cannot change region from "configtest" to "somereg"`,
+		err: `cannot change region from "configtest" to "otherregion"`,
 	}, {
 		summary: "invalid region",
-		config: attrs{
+		config: requiredConfig.Merge(testing.Attrs{
 			"region": 666,
-		},
+		}),
 		err: `.*expected string, got int\(666\)`,
 	}, {
 		summary: "missing region in environment",
-		envVars: map[string]string{
-			"OS_REGION_NAME": "",
-			"NOVA_REGION":    "",
-		},
-		err: "required environment variable not set for credentials attribute: Region",
+		config:  requiredConfig.Delete("region"),
+		err:     "missing region not valid",
 	}, {
 		summary: "invalid username",
-		config: attrs{
+		config: requiredConfig.Merge(testing.Attrs{
 			"username": 666,
-		},
+		}),
 		err: `.*expected string, got int\(666\)`,
 	}, {
 		summary: "missing username in environment",
-		err:     "required environment variable not set for credentials attribute: User",
-		envVars: map[string]string{
-			"OS_USERNAME":   "",
-			"NOVA_USERNAME": "",
-		},
+		config:  requiredConfig.Delete("username"),
+		err:     "missing username not valid",
 	}, {
 		summary: "invalid password",
-		config: attrs{
+		config: requiredConfig.Merge(testing.Attrs{
 			"password": 666,
-		},
+		}),
 		err: `.*expected string, got int\(666\)`,
 	}, {
 		summary: "missing password in environment",
-		err:     "required environment variable not set for credentials attribute: Secrets",
-		envVars: map[string]string{
-			"OS_PASSWORD":   "",
-			"NOVA_PASSWORD": "",
-		},
+		config:  requiredConfig.Delete("password"),
+		err:     "missing password not valid",
 	}, {
 		summary: "invalid tenant-name",
-		config: attrs{
+		config: requiredConfig.Merge(testing.Attrs{
 			"tenant-name": 666,
-		},
+		}),
 		err: `.*expected string, got int\(666\)`,
 	}, {
 		summary: "missing tenant in environment",
-		err:     "required environment variable not set for credentials attribute: TenantName",
-		envVars: map[string]string{
-			"OS_TENANT_NAME":  "",
-			"NOVA_PROJECT_ID": "",
-		},
+		config:  requiredConfig.Delete("tenant-name"),
+		err:     "missing tenant-name not valid",
 	}, {
 		summary: "invalid auth-url type",
-		config: attrs{
+		config: requiredConfig.Merge(testing.Attrs{
 			"auth-url": 666,
-		},
+		}),
 		err: `.*expected string, got int\(666\)`,
 	}, {
 		summary: "missing auth-url in environment",
-		err:     "required environment variable not set for credentials attribute: URL",
-		envVars: map[string]string{
-			"OS_AUTH_URL": "",
-		},
+		config:  requiredConfig.Delete("auth-url"),
+		err:     "missing auth-url not valid",
 	}, {
 		summary: "invalid authorization mode",
-		config: attrs{
+		config: requiredConfig.Merge(testing.Attrs{
 			"auth-mode": "invalid-mode",
-		},
+		}),
 		err: `auth-mode: expected one of \[keypair legacy userpass\], got "invalid-mode"`,
 	}, {
 		summary: "keypair authorization mode",
-		config: attrs{
+		config: requiredConfig.Merge(testing.Attrs{
 			"auth-mode":  "keypair",
 			"access-key": "MyAccessKey",
 			"secret-key": "MySecretKey",
-		},
+		}),
 		authMode:  "keypair",
 		accessKey: "MyAccessKey",
 		secretKey: "MySecretKey",
 	}, {
 		summary: "keypair authorization mode without access key",
-		config: attrs{
+		config: requiredConfig.Merge(testing.Attrs{
 			"auth-mode":  "keypair",
 			"secret-key": "MySecretKey",
-		},
-		envVars: map[string]string{
-			"OS_USERNAME": "",
-		},
-		err: "required environment variable not set for credentials attribute: User",
+		}),
+		err: "missing access-key not valid",
 	}, {
 		summary: "keypair authorization mode without secret key",
-		config: attrs{
+		config: requiredConfig.Merge(testing.Attrs{
 			"auth-mode":  "keypair",
 			"access-key": "MyAccessKey",
-		},
-		envVars: map[string]string{
-			"OS_PASSWORD": "",
-		},
-		err: "required environment variable not set for credentials attribute: Secrets",
+		}),
+		err: "missing secret-key not valid",
 	}, {
 		summary: "invalid auth-url format",
-		config: attrs{
+		config: requiredConfig.Merge(testing.Attrs{
 			"auth-url": "invalid",
-		},
+		}),
 		err: `invalid auth-url value "invalid"`,
 	}, {
 		summary: "invalid control-bucket",
-		config: attrs{
+		config: requiredConfig.Merge(testing.Attrs{
 			"control-bucket": 666,
-		},
+		}),
 		err: `.*expected string, got int\(666\)`,
 	}, {
 		summary: "changing control-bucket",
-		change: attrs{
+		config:  requiredConfig,
+		change: testing.Attrs{
 			"control-bucket": "new-x",
 		},
 		err: `cannot change control-bucket from "x" to "new-x"`,
 	}, {
 		summary: "valid auth args",
-		config: attrs{
+		config: requiredConfig.Merge(testing.Attrs{
 			"username":    "jujuer",
 			"password":    "open sesame",
 			"tenant-name": "juju tenant",
 			"auth-mode":   "legacy",
 			"auth-url":    "http://some/url",
-		},
+		}),
 		username:   "jujuer",
 		password:   "open sesame",
 		tenantName: "juju tenant",
 		authURL:    "http://some/url",
 		authMode:   AuthLegacy,
 	}, {
-		summary: "valid auth args in environment",
-		envVars: map[string]string{
-			"OS_USERNAME":    "jujuer",
-			"OS_PASSWORD":    "open sesame",
-			"OS_AUTH_URL":    "http://some/url",
-			"OS_TENANT_NAME": "juju tenant",
-			"OS_REGION_NAME": "region",
-		},
-		username:   "jujuer",
-		password:   "open sesame",
-		tenantName: "juju tenant",
-		authURL:    "http://some/url",
-		region:     "region",
-	}, {
-		summary:  "default auth mode based on environment",
-		authMode: AuthUserPass,
-	}, {
 		summary: "default use floating ip",
+		config:  requiredConfig,
 		// Do not use floating IP's by default.
 		useFloatingIP: false,
 	}, {
 		summary: "use floating ip",
-		config: attrs{
+		config: requiredConfig.Merge(testing.Attrs{
 			"use-floating-ip": true,
-		},
+		}),
 		useFloatingIP: true,
 	}, {
 		summary: "default use default security group",
+		config:  requiredConfig,
 		// Do not use default security group by default.
 		useDefaultSecurityGroup: false,
 	}, {
 		summary: "use default security group",
-		config: attrs{
+		config: requiredConfig.Merge(testing.Attrs{
 			"use-default-secgroup": true,
-		},
+		}),
 		useDefaultSecurityGroup: true,
 	}, {
 		summary: "admin-secret given",
-		config: attrs{
+		config: requiredConfig.Merge(testing.Attrs{
 			"admin-secret": "Futumpsh",
-		},
+		}),
 	}, {
 		summary:      "default firewall-mode",
-		config:       attrs{},
+		config:       requiredConfig,
 		firewallMode: config.FwInstance,
 	}, {
 		summary: "instance firewall-mode",
-		config: attrs{
+		config: requiredConfig.Merge(testing.Attrs{
 			"firewall-mode": "instance",
-		},
+		}),
 		firewallMode: config.FwInstance,
 	}, {
 		summary: "global firewall-mode",
-		config: attrs{
+		config: requiredConfig.Merge(testing.Attrs{
 			"firewall-mode": "global",
-		},
+		}),
 		firewallMode: config.FwGlobal,
 	}, {
 		summary: "none firewall-mode",
-		config: attrs{
+		config: requiredConfig.Merge(testing.Attrs{
 			"firewall-mode": "none",
-		},
+		}),
 		firewallMode: config.FwNone,
 	}, {
-		config: attrs{
+		config: requiredConfig.Merge(testing.Attrs{
 			"future": "hammerstein",
-		},
-		expect: attrs{
-			"future": "hammerstein",
-		},
-	}, {
-		change: attrs{
-			"future": "hammerstein",
-		},
-		expect: attrs{
+		}),
+		expect: testing.Attrs{
 			"future": "hammerstein",
 		},
 	}, {
-		change: attrs{
+		config: requiredConfig,
+		change: testing.Attrs{
+			"future": "hammerstein",
+		},
+		expect: testing.Attrs{
+			"future": "hammerstein",
+		},
+	}, {
+		config: requiredConfig,
+		change: testing.Attrs{
 			"ssl-hostname-verification": false,
 		},
 		sslHostnameVerification: false,
 		sslHostnameSet:          true,
 	}, {
-		change: attrs{
+		config: requiredConfig,
+		change: testing.Attrs{
 			"ssl-hostname-verification": true,
 		},
 		sslHostnameVerification: true,
 		sslHostnameSet:          true,
 	}, {
 		summary: "default network",
+		config:  requiredConfig,
 		network: "",
 	}, {
 		summary: "network",
-		config: attrs{
+		config: requiredConfig.Merge(testing.Attrs{
 			"network": "a-network-label",
-		},
+		}),
 		network: "a-network-label",
 	}, {
 		summary:            "no default block storage specified",
-		config:             attrs{},
+		config:             requiredConfig,
 		blockStorageSource: "cinder",
 	}, {
 		summary: "block storage specified",
-		config: attrs{
+		config: requiredConfig.Merge(testing.Attrs{
 			"storage-default-block-source": "my-cinder",
-		},
+		}),
 		blockStorageSource: "my-cinder",
 	},
 }
 
 func (s *ConfigSuite) TestConfig(c *gc.C) {
-	s.setupEnvCredentials()
 	for i, t := range configTests {
 		c.Logf("test %d: %s (%v)", i, t.summary, t.config)
 		t.check(c)
@@ -467,12 +441,16 @@ func (s *ConfigSuite) TestConfig(c *gc.C) {
 }
 
 func (s *ConfigSuite) TestDeprecatedAttributesRemoved(c *gc.C) {
-	s.setupEnvCredentials()
 	attrs := testing.FakeConfig().Merge(testing.Attrs{
 		"type":                  "openstack",
 		"control-bucket":        "x",
 		"default-image-id":      "id-1234",
 		"default-instance-type": "big",
+		"username":              "u",
+		"password":              "p",
+		"tenant-name":           "t",
+		"region":                "r",
+		"auth-url":              "http://auth",
 	})
 
 	cfg, err := config.New(config.NoDefaults, attrs)
@@ -489,7 +467,6 @@ func (s *ConfigSuite) TestDeprecatedAttributesRemoved(c *gc.C) {
 }
 
 func (s *ConfigSuite) TestPrepareInsertsUniqueControlBucket(c *gc.C) {
-	s.setupEnvCredentials()
 	attrs := testing.FakeConfig().Merge(testing.Attrs{
 		"type": "openstack",
 	})
@@ -497,16 +474,12 @@ func (s *ConfigSuite) TestPrepareInsertsUniqueControlBucket(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	ctx := envtesting.BootstrapContext(c)
-	env0, err := providerInstance.PrepareForBootstrap(ctx, environs.PrepareForBootstrapParams{
-		Config: cfg,
-	})
+	env0, err := providerInstance.PrepareForBootstrap(ctx, s.prepareForBootstrapParams(cfg))
 	c.Assert(err, jc.ErrorIsNil)
 	bucket0 := env0.(*Environ).ecfg().controlBucket()
 	c.Assert(bucket0, gc.Matches, "[a-f0-9]{32}")
 
-	env1, err := providerInstance.PrepareForBootstrap(ctx, environs.PrepareForBootstrapParams{
-		Config: cfg,
-	})
+	env1, err := providerInstance.PrepareForBootstrap(ctx, s.prepareForBootstrapParams(cfg))
 	c.Assert(err, jc.ErrorIsNil)
 	bucket1 := env1.(*Environ).ecfg().controlBucket()
 	c.Assert(bucket1, gc.Matches, "[a-f0-9]{32}")
@@ -515,7 +488,6 @@ func (s *ConfigSuite) TestPrepareInsertsUniqueControlBucket(c *gc.C) {
 }
 
 func (s *ConfigSuite) TestPrepareDoesNotTouchExistingControlBucket(c *gc.C) {
-	s.setupEnvCredentials()
 	attrs := testing.FakeConfig().Merge(testing.Attrs{
 		"type":           "openstack",
 		"control-bucket": "burblefoo",
@@ -523,37 +495,37 @@ func (s *ConfigSuite) TestPrepareDoesNotTouchExistingControlBucket(c *gc.C) {
 	cfg, err := config.New(config.NoDefaults, attrs)
 	c.Assert(err, jc.ErrorIsNil)
 
-	env, err := providerInstance.PrepareForBootstrap(envtesting.BootstrapContext(c), environs.PrepareForBootstrapParams{
-		Config: cfg,
-	})
+	env, err := providerInstance.PrepareForBootstrap(envtesting.BootstrapContext(c), s.prepareForBootstrapParams(cfg))
 	c.Assert(err, jc.ErrorIsNil)
 	bucket := env.(*Environ).ecfg().controlBucket()
 	c.Assert(bucket, gc.Equals, "burblefoo")
 }
 
 func (s *ConfigSuite) TestPrepareSetsDefaultBlockSource(c *gc.C) {
-	s.setupEnvCredentials()
 	attrs := testing.FakeConfig().Merge(testing.Attrs{
 		"type": "openstack",
 	})
 	cfg, err := config.New(config.NoDefaults, attrs)
 	c.Assert(err, jc.ErrorIsNil)
 
-	env, err := providerInstance.PrepareForBootstrap(envtesting.BootstrapContext(c), environs.PrepareForBootstrapParams{
-		Config: cfg,
-	})
+	env, err := providerInstance.PrepareForBootstrap(envtesting.BootstrapContext(c), s.prepareForBootstrapParams(cfg))
 	c.Assert(err, jc.ErrorIsNil)
 	source, ok := env.(*Environ).ecfg().StorageDefaultBlockSource()
 	c.Assert(ok, jc.IsTrue)
 	c.Assert(source, gc.Equals, "cinder")
 }
 
-func (s *ConfigSuite) setupEnvCredentials() {
-	os.Setenv("OS_USERNAME", "user")
-	os.Setenv("OS_PASSWORD", "secret")
-	os.Setenv("OS_AUTH_URL", "http://auth")
-	os.Setenv("OS_TENANT_NAME", "sometenant")
-	os.Setenv("OS_REGION_NAME", "region")
+func (s *ConfigSuite) prepareForBootstrapParams(cfg *config.Config) environs.PrepareForBootstrapParams {
+	return environs.PrepareForBootstrapParams{
+		Config: cfg,
+		Credentials: cloud.NewCredential(cloud.UserPassAuthType, map[string]string{
+			"username":    "user",
+			"password":    "secret",
+			"tenant-name": "sometenant",
+		}),
+		CloudRegion:   "region",
+		CloudEndpoint: "http://auth",
+	}
 }
 
 func (*ConfigSuite) TestSchema(c *gc.C) {


### PR DESCRIPTION
Update bootstrap to use clouds.yaml and credentials.yaml.
The primary difference from the spec is that we will do
an auto-detection of credentials if none are specified
and there is no default.

Full support for cloud credentials has been added to the
following providers so far:
 - dummy (for unit tests)
 - lxd
 - ec2
 - gce
 - openstack

(Review request: http://reviews.vapour.ws/r/3677/)