### PR TITLE
Add alias for restore-backup

### DIFF
--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -161,6 +161,7 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 	// Manage backups.
 	r.Register(backups.NewSuperCommand())
 	r.RegisterSuperAlias("create-backup", "backups", "create", nil)
+	r.RegisterSuperAlias("restore-backup", "backups", "restore", nil)
 
 	// Manage authorized ssh keys.
 	r.Register(newAuthorizedKeysCommand())

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -256,6 +256,7 @@ var commandNames = []string{
 	"remove-service",  // alias for destroy-service
 	"remove-unit",     // alias for destroy-unit
 	"resolved",
+	"restore-backup",
 	"retry-provisioning",
 	"run",
 	"run-action",


### PR DESCRIPTION
CI scripts are using the new command so we need an alias for now.

(Review request: http://reviews.vapour.ws/r/3679/)