### PR TITLE
lp1538303: Retry with EOF error from API Open

### DIFF
--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -355,14 +355,13 @@ func (c *BootstrapCommand) waitForAgentInitialisation(ctx *cmd.Context) (err err
 	var client block.BlockListAPI
 	for attempt := attempts.Start(); attempt.Next(); {
 		client, err = blockAPI(&c.EnvCommandBase)
-		if err != nil {
-			return err
-		}
-		_, err = client.List()
-		client.Close()
 		if err == nil {
-			ctx.Infof("Bootstrap complete")
-			return nil
+			_, err = client.List()
+			client.Close()
+			if err == nil {
+				ctx.Infof("Bootstrap complete")
+				return nil
+			}
 		}
 		// As the API server is coming up, it goes through a number of steps.
 		// Initially the upgrade steps run, but the api server allows some

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -344,6 +344,17 @@ func getBlockAPI(c *envcmd.EnvCommandBase) (block.BlockListAPI, error) {
 	return apiblock.NewClient(root), nil
 }
 
+// tryAPI attempts to open the API and makes a trivial call
+// to check if the API is available yet.
+func (c *BootstrapCommand) tryAPI() error {
+	client, err := blockAPI(&c.EnvCommandBase)
+	if err == nil {
+		_, err = client.List()
+		client.Close()
+	}
+	return err
+}
+
 // waitForAgentInitialisation polls the bootstrapped state server with a read-only
 // command which will fail until the state server is fully initialised.
 // TODO(wallyworld) - add a bespoke command to maybe the admin facade for this purpose.
@@ -352,16 +363,11 @@ func (c *BootstrapCommand) waitForAgentInitialisation(ctx *cmd.Context) (err err
 		Min:   bootstrapReadyPollCount,
 		Delay: bootstrapReadyPollDelay,
 	}
-	var client block.BlockListAPI
 	for attempt := attempts.Start(); attempt.Next(); {
-		client, err = blockAPI(&c.EnvCommandBase)
+		err = c.tryAPI()
 		if err == nil {
-			_, err = client.List()
-			client.Close()
-			if err == nil {
-				ctx.Infof("Bootstrap complete")
-				return nil
-			}
+			ctx.Infof("Bootstrap complete")
+			return nil
 		}
 		// As the API server is coming up, it goes through a number of steps.
 		// Initially the upgrade steps run, but the api server allows some

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -196,9 +196,9 @@ func (s *BootstrapSuite) TestBootstrapAPIReadyStopsRetriesWithOpenErr(c *gc.C) {
 
 	s.mockBlockClient.num_retries = 0
 	s.mockBlockClient.retry_count = 0
-	s.mockBlockClient.loginError = errors.New("invalid entity name or password")
+	s.mockBlockClient.loginError = errors.NewUnauthorized(nil, "")
 	_, err := coretesting.RunCommand(c, envcmd.Wrap(&BootstrapCommand{}), "-e", "devenv")
-	c.Check(err, gc.ErrorMatches, "invalid entity name or password")
+	c.Check(err, jc.Satisfies, errors.IsUnauthorized)
 
 	c.Check(s.mockBlockClient.retry_count, gc.Equals, 0)
 }

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -76,6 +76,11 @@ func (s *BootstrapSuite) SetUpTest(c *gc.C) {
 
 	s.mockBlockClient = &mockBlockClient{}
 	s.PatchValue(&blockAPI, func(c *envcmd.EnvCommandBase) (block.BlockListAPI, error) {
+		err := s.mockBlockClient.loginError
+		if err != nil {
+			s.mockBlockClient.loginError = nil
+			return nil, err
+		}
 		return s.mockBlockClient, nil
 	})
 }
@@ -95,6 +100,7 @@ func (s *BootstrapSuite) TearDownTest(c *gc.C) {
 type mockBlockClient struct {
 	retry_count int
 	num_retries int
+	loginError  error
 }
 
 func (c *mockBlockClient) List() ([]params.Block, error) {
@@ -153,6 +159,48 @@ func (s *BootstrapSuite) TestBootstrapAPIReadyRetries(c *gc.C) {
 		}
 		c.Check(s.mockBlockClient.retry_count, gc.Equals, expectedRetries)
 	}
+}
+
+func (s *BootstrapSuite) TestBootstrapAPIReadyRetriesWithOpenEOFErr(c *gc.C) {
+	s.PatchValue(&bootstrapReadyPollDelay, 1*time.Millisecond)
+	s.PatchValue(&bootstrapReadyPollCount, 5)
+	defaultSeriesVersion := version.Current
+	// Force a dev version by having a non zero build number.
+	// This is because we have not uploaded any tools and auto
+	// upload is only enabled for dev versions.
+	defaultSeriesVersion.Build = 1234
+	s.PatchValue(&version.Current, defaultSeriesVersion)
+
+	resetJujuHome(c, "devenv")
+
+	s.mockBlockClient.num_retries = 0
+	s.mockBlockClient.retry_count = 0
+	s.mockBlockClient.loginError = errors.New("EOF")
+	_, err := coretesting.RunCommand(c, envcmd.Wrap(&BootstrapCommand{}), "-e", "devenv")
+	c.Check(err, jc.ErrorIsNil)
+
+	c.Check(s.mockBlockClient.retry_count, gc.Equals, 1)
+}
+
+func (s *BootstrapSuite) TestBootstrapAPIReadyStopsRetriesWithOpenErr(c *gc.C) {
+	s.PatchValue(&bootstrapReadyPollDelay, 1*time.Millisecond)
+	s.PatchValue(&bootstrapReadyPollCount, 5)
+	defaultSeriesVersion := version.Current
+	// Force a dev version by having a non zero build number.
+	// This is because we have not uploaded any tools and auto
+	// upload is only enabled for dev versions.
+	defaultSeriesVersion.Build = 1234
+	s.PatchValue(&version.Current, defaultSeriesVersion)
+
+	resetJujuHome(c, "devenv")
+
+	s.mockBlockClient.num_retries = 0
+	s.mockBlockClient.retry_count = 0
+	s.mockBlockClient.loginError = errors.New("invalid entity name or password")
+	_, err := coretesting.RunCommand(c, envcmd.Wrap(&BootstrapCommand{}), "-e", "devenv")
+	c.Check(err, gc.ErrorMatches, "invalid entity name or password")
+
+	c.Check(s.mockBlockClient.retry_count, gc.Equals, 0)
 }
 
 func (s *BootstrapSuite) TestRunTests(c *gc.C) {


### PR DESCRIPTION
During bootstrap, we may get EOF or upgrade in
progress errors while juju is still coming up.
We would retry when we got those errors from
the blocks.List call, but it is also possible
to get an EOF error from the Login (apiOpen).

Those should be retried as well.

(Review request: http://reviews.vapour.ws/r/3686/)