### PR TITLE
Delete CodeNotImplemented fallback to old facades where appropriate.

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -56,9 +56,6 @@ func (c *Client) UnitStatusHistory(kind params.HistoryKind, unitName string, siz
 	}
 	err := c.facade.FacadeCall("UnitStatusHistory", args, &results)
 	if err != nil {
-		if params.IsCodeNotImplemented(err) {
-			return &params.UnitStatusHistory{}, errors.NotImplementedf("UnitStatusHistory")
-		}
 		return &params.UnitStatusHistory{}, errors.Trace(err)
 	}
 	return &results, nil
@@ -363,8 +360,7 @@ func (c *Client) DestroyModel() error {
 
 // AddLocalCharm prepares the given charm with a local: schema in its
 // URL, and uploads it via the API server, returning the assigned
-// charm URL. If the API server does not support charm uploads, an
-// error satisfying params.IsCodeNotImplemented() is returned.
+// charm URL.
 func (c *Client) AddLocalCharm(curl *charm.URL, ch charm.Charm) (*charm.URL, error) {
 	if curl.Schema != "local" {
 		return nil, errors.Errorf("expected charm URL with local: schema, got %q", curl.String())

--- a/api/networker/networker.go
+++ b/api/networker/networker.go
@@ -46,10 +46,6 @@ func (st *state) MachineNetworkConfig(tag names.MachineTag) ([]network.Interface
 	var results params.MachineNetworkConfigResults
 	err := st.facade.FacadeCall("MachineNetworkConfig", args, &results)
 	if err != nil {
-		if params.IsCodeNotImplemented(err) {
-			// Fallback to former name.
-			err = st.facade.FacadeCall("MachineNetworkInfo", args, &results)
-		}
 		if err != nil {
 			// TODO: Not directly tested.
 			return nil, err

--- a/api/networker/networker_test.go
+++ b/api/networker/networker_test.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/networker"
-	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/juju/testing"
@@ -172,34 +171,6 @@ func (s *networkerSuite) SetUpTest(c *gc.C) {
 
 func (s *networkerSuite) TestMachineNetworkConfigPermissionDenied(c *gc.C) {
 	info, err := s.networker.MachineNetworkConfig(names.NewMachineTag("1"))
-	c.Assert(err, gc.ErrorMatches, "permission denied")
-	c.Assert(err, jc.Satisfies, params.IsCodeUnauthorized)
-	c.Assert(info, gc.IsNil)
-}
-
-func (s *networkerSuite) TestMachineNetworkConfigNameChange(c *gc.C) {
-	var called bool
-	networker.PatchFacadeCall(s, s.networker, func(request string, args, response interface{}) error {
-		if !called {
-			called = true
-			c.Assert(request, gc.Equals, "MachineNetworkConfig")
-			return &params.Error{
-				Message: "MachineNetworkConfig",
-				Code:    params.CodeNotImplemented,
-			}
-		}
-		c.Assert(request, gc.Equals, "MachineNetworkInfo")
-		expected := params.Entities{
-			Entities: []params.Entity{{Tag: names.NewMachineTag("42").String()}},
-		}
-		c.Assert(args, gc.DeepEquals, expected)
-		result := response.(*params.MachineNetworkConfigResults)
-		result.Results = make([]params.MachineNetworkConfigResult, 1)
-		result.Results[0].Error = common.ServerError(common.ErrPerm)
-		return nil
-	})
-	// Make a call, in this case result is "permission denied".
-	info, err := s.networker.MachineNetworkConfig(names.NewMachineTag("42"))
 	c.Assert(err, gc.ErrorMatches, "permission denied")
 	c.Assert(err, jc.Satisfies, params.IsCodeUnauthorized)
 	c.Assert(info, gc.IsNil)

--- a/api/uniter/service.go
+++ b/api/uniter/service.go
@@ -158,9 +158,6 @@ func (s *Service) SetStatus(unitName string, status params.Status, info string, 
 	}
 	err := s.st.facade.FacadeCall("SetServiceStatus", args, &result)
 	if err != nil {
-		if params.IsCodeNotImplemented(err) {
-			return errors.NotImplementedf("SetServiceStatus")
-		}
 		return errors.Trace(err)
 	}
 	return result.OneError()
@@ -180,9 +177,6 @@ func (s *Service) Status(unitName string) (params.ServiceStatusResult, error) {
 	}
 	err := s.st.facade.FacadeCall("ServiceStatus", args, &results)
 	if err != nil {
-		if params.IsCodeNotImplemented(err) {
-			return params.ServiceStatusResult{}, errors.NotImplementedf("ServiceStatus")
-		}
 		return params.ServiceStatusResult{}, errors.Trace(err)
 	}
 	result := results.Results[0]

--- a/api/uniter/unit.go
+++ b/api/uniter/unit.go
@@ -81,9 +81,6 @@ func (u *Unit) UnitStatus() (params.StatusResult, error) {
 	}
 	err := u.st.facade.FacadeCall("UnitStatus", args, &results)
 	if err != nil {
-		if params.IsCodeNotImplemented(err) {
-			return params.StatusResult{}, errors.NotImplementedf("UnitStatus")
-		}
 		return params.StatusResult{}, errors.Trace(err)
 	}
 	if len(results.Results) != 1 {
@@ -147,15 +144,7 @@ func (u *Unit) AddMetricBatches(batches []params.MetricBatch) (map[string]error,
 	}
 	results := new(params.ErrorResults)
 	err := u.st.facade.FacadeCall("AddMetricBatches", p, results)
-	if params.IsCodeNotImplemented(err) {
-		for _, batch := range batches {
-			err = u.AddMetrics(batch.Metrics)
-			if err != nil {
-				batchResults[batch.UUID] = errors.Annotate(err, "failed to send metric batch")
-			}
-		}
-		return batchResults, nil
-	} else if err != nil {
+	if err != nil {
 		return nil, errors.Annotate(err, "failed to send metric batches")
 	}
 	for i, result := range results.Results {

--- a/api/uniter/unit_test.go
+++ b/api/uniter/unit_test.go
@@ -814,40 +814,6 @@ func (s *unitMetricBatchesSuite) TestSendMetricBatchFail(c *gc.C) {
 	c.Assert(called, jc.IsTrue)
 }
 
-func (s *unitMetricBatchesSuite) TestSendMetricBatchNotImplemented(c *gc.C) {
-	var called bool
-	uniter.PatchUnitFacadeCall(s, s.apiUnit, func(request string, args, response interface{}) error {
-		switch request {
-		case "AddMetricBatches":
-			result := response.(*params.ErrorResults)
-			result.Results = make([]params.ErrorResult, 1)
-			return &params.Error{Message: "not implemented", Code: params.CodeNotImplemented}
-		case "AddMetrics":
-			called = true
-			result := response.(*params.ErrorResults)
-			result.Results = make([]params.ErrorResult, 1)
-			return nil
-		default:
-			panic(fmt.Errorf("unexpected request %q received", request))
-		}
-	})
-
-	metrics := []params.Metric{{"pings", "5", time.Now().UTC()}}
-	uuid := utils.MustNewUUID().String()
-	batch := params.MetricBatch{
-		UUID:     uuid,
-		CharmURL: s.charm.URL().String(),
-		Created:  time.Now(),
-		Metrics:  metrics,
-	}
-
-	results, err := s.apiUnit.AddMetricBatches([]params.MetricBatch{batch})
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(called, jc.IsTrue)
-	c.Assert(results, gc.HasLen, 1)
-	c.Assert(results[batch.UUID], gc.IsNil)
-}
-
 func (s *unitMetricBatchesSuite) TestSendMetricBatch(c *gc.C) {
 	uuid := utils.MustNewUUID().String()
 	now := time.Now().Round(time.Second).UTC()

--- a/cmd/juju/backups/restore.go
+++ b/cmd/juju/backups/restore.go
@@ -13,7 +13,6 @@ import (
 	"launchpad.net/gnuflag"
 
 	"github.com/juju/juju/api/backups"
-	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs"
@@ -25,7 +24,7 @@ func newRestoreCommand() cmd.Command {
 	return modelcmd.Wrap(&restoreCommand{})
 }
 
-// restoreCommand is a subcommand of backups that implement the restore behaior
+// restoreCommand is a subcommand of backups that implement the restore behavior
 // it is invoked with "juju backups restore".
 type restoreCommand struct {
 	CommandBase
@@ -97,9 +96,6 @@ func (c *restoreCommand) Init(args []string) error {
 	return nil
 }
 
-const restoreAPIIncompatibility = "server version not compatible for " +
-	"restore with client version"
-
 // runRestore will implement the actual calls to the different Client parts
 // of restore.
 func (c *restoreCommand) runRestore(ctx *cmd.Context) error {
@@ -122,11 +118,6 @@ func (c *restoreCommand) runRestore(ctx *cmd.Context) error {
 	} else {
 		target = c.backupId
 		rErr = client.Restore(c.backupId, c.newClient)
-	}
-	if params.IsCodeNotImplemented(rErr) {
-		// TODO (anastasiamac 2016-02-01) This seems reasonable...
-		// Does it no longer make sense for 2.0 and should be removed?
-		return errors.Errorf(restoreAPIIncompatibility)
 	}
 	if rErr != nil {
 		return errors.Trace(rErr)

--- a/cmd/juju/backups/restore.go
+++ b/cmd/juju/backups/restore.go
@@ -124,6 +124,8 @@ func (c *restoreCommand) runRestore(ctx *cmd.Context) error {
 		rErr = client.Restore(c.backupId, c.newClient)
 	}
 	if params.IsCodeNotImplemented(rErr) {
+		// TODO (anastasiamac 2016-02-01) This seems reasonable...
+		// Does it no longer make sense for 2.0 and should be removed?
 		return errors.Errorf(restoreAPIIncompatibility)
 	}
 	if rErr != nil {

--- a/cmd/juju/controller/destroy.go
+++ b/cmd/juju/controller/destroy.go
@@ -129,13 +129,6 @@ func (c *destroyCommand) Run(ctx *cmd.Context) error {
 
 	// Attempt to destroy the controller.
 	err = api.DestroyController(c.destroyEnvs)
-	if params.IsCodeNotImplemented(err) {
-		// TODO (anastasiamac 2016-02-01) This seems to be valid for 2.0 as well.
-		// Not removing yet...
-		// Fall back to using the client endpoint to destroy the controller,
-		// sending the info we were already able to collect.
-		return c.destroyControllerViaClient(ctx, cfgInfo, controllerEnviron, store)
-	}
 	if err != nil {
 		return c.ensureUserFriendlyErrorLog(errors.Annotate(err, "cannot destroy controller"), ctx, api)
 	}
@@ -316,21 +309,7 @@ func (c *destroyCommandBase) getControllerEnviron(info configstore.EnvironInfo, 
 			return nil, errors.New("unable to get bootstrap information from API")
 		}
 		bootstrapCfg, err = sysAPI.ModelConfig()
-		if params.IsCodeNotImplemented(err) {
-			// TODO (anastasiamac 2016-02-01) This seems to be valid for 2.0 as well.
-			// Not removing yet...
-			// Fallback to the client API. Better to encapsulate the logic for
-			// old servers than worry about connecting twice.
-			client, err := c.getClientAPI()
-			if err != nil {
-				return nil, errors.Trace(err)
-			}
-			defer client.Close()
-			bootstrapCfg, err = client.ModelGet()
-			if err != nil {
-				return nil, errors.Trace(err)
-			}
-		} else if err != nil {
+		if err != nil {
 			return nil, errors.Trace(err)
 		}
 	}

--- a/cmd/juju/controller/destroy.go
+++ b/cmd/juju/controller/destroy.go
@@ -130,6 +130,8 @@ func (c *destroyCommand) Run(ctx *cmd.Context) error {
 	// Attempt to destroy the controller.
 	err = api.DestroyController(c.destroyEnvs)
 	if params.IsCodeNotImplemented(err) {
+		// TODO (anastasiamac 2016-02-01) This seems to be valid for 2.0 as well.
+		// Not removing yet...
 		// Fall back to using the client endpoint to destroy the controller,
 		// sending the info we were already able to collect.
 		return c.destroyControllerViaClient(ctx, cfgInfo, controllerEnviron, store)
@@ -315,6 +317,8 @@ func (c *destroyCommandBase) getControllerEnviron(info configstore.EnvironInfo, 
 		}
 		bootstrapCfg, err = sysAPI.ModelConfig()
 		if params.IsCodeNotImplemented(err) {
+			// TODO (anastasiamac 2016-02-01) This seems to be valid for 2.0 as well.
+			// Not removing yet...
 			// Fallback to the client API. Better to encapsulate the logic for
 			// old servers than worry about connecting twice.
 			client, err := c.getClientAPI()

--- a/cmd/juju/controller/kill.go
+++ b/cmd/juju/controller/kill.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/apiserver/common"
-	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/configstore"
@@ -137,15 +136,6 @@ func (c *killCommand) Run(ctx *cmd.Context) error {
 
 	// Attempt to destroy the controller and all environments.
 	err = api.DestroyController(true)
-	if params.IsCodeNotImplemented(err) {
-		// TODO (anastasiamac 2016-02-01) This seems to be valid for 2.0 as well.
-		// Not removing yet...
-		// Fall back to using the client endpoint to destroy the controller,
-		// sending the info we were already able to collect.
-		ctx.Infof("Unable to destroy controller through the API: %s.  Destroying through provider.", err)
-		return c.killControllerViaClient(ctx, cfgInfo, controllerEnviron, store)
-	}
-
 	if err != nil {
 		ctx.Infof("Unable to destroy controller through the API: %s.  Destroying through provider.", err)
 		return environs.Destroy(controllerEnviron, store)

--- a/cmd/juju/controller/kill.go
+++ b/cmd/juju/controller/kill.go
@@ -138,6 +138,8 @@ func (c *killCommand) Run(ctx *cmd.Context) error {
 	// Attempt to destroy the controller and all environments.
 	err = api.DestroyController(true)
 	if params.IsCodeNotImplemented(err) {
+		// TODO (anastasiamac 2016-02-01) This seems to be valid for 2.0 as well.
+		// Not removing yet...
 		// Fall back to using the client endpoint to destroy the controller,
 		// sending the info we were already able to collect.
 		ctx.Infof("Unable to destroy controller through the API: %s.  Destroying through provider.", err)

--- a/cmd/juju/controller/kill_test.go
+++ b/cmd/juju/controller/kill_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 type KillSuite struct {
-	DestroySuite
+	baseDestroySuite
 }
 
 var _ = gc.Suite(&KillSuite{})
@@ -93,24 +93,6 @@ func (s *KillSuite) TestKillEnvironmentGetFailsWithAPIConnection(c *gc.C) {
 	_, err := s.runKillCommand(c, "test3", "-y")
 	c.Assert(err, gc.ErrorMatches, "cannot obtain bootstrap information: controller \"test3\" not found")
 	checkControllerExistsInStore(c, "test3", s.store)
-}
-
-func (s *KillSuite) TestKillFallsBackToClient(c *gc.C) {
-	s.api.err = &params.Error{Message: "DestroyController", Code: params.CodeNotImplemented}
-	_, err := s.runKillCommand(c, "test1", "-y")
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(s.clientapi.destroycalled, jc.IsTrue)
-	checkControllerRemovedFromStore(c, "test1", s.store)
-}
-
-func (s *KillSuite) TestClientKillDestroysControllerWithAPIError(c *gc.C) {
-	s.api.err = &params.Error{Message: "DestroyController", Code: params.CodeNotImplemented}
-	s.clientapi.err = errors.New("some destroy error")
-	ctx, err := s.runKillCommand(c, "test1", "-y")
-	c.Assert(err, jc.ErrorIsNil)
-	c.Check(testing.Stderr(ctx), jc.Contains, "Unable to destroy controller through the API: some destroy error.  Destroying through provider.")
-	c.Assert(s.clientapi.destroycalled, jc.IsTrue)
-	checkControllerRemovedFromStore(c, "test1", s.store)
 }
 
 func (s *KillSuite) TestKillDestroysControllerWithAPIError(c *gc.C) {

--- a/cmd/juju/service/register.go
+++ b/cmd/juju/service/register.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/charms"
-	"github.com/juju/juju/apiserver/params"
 )
 
 type metricRegistrationPost struct {
@@ -45,12 +44,7 @@ func (r *RegisterMeteredCharm) RunPre(state api.Connection, client *http.Client,
 	charmsClient := charms.NewClient(state)
 	defer charmsClient.Close()
 	metered, err := charmsClient.IsMetered(deployInfo.CharmURL.String())
-	if params.IsCodeNotImplemented(err) {
-		// The state server is too old to support metering.  Warn
-		// the user, but don't return an error.
-		logger.Tracef("current state server version does not support charm metering")
-		return nil
-	} else if err != nil {
+	if err != nil {
 		return err
 	}
 	if !metered {
@@ -95,12 +89,7 @@ func (r *RegisterMeteredCharm) RunPost(state api.Connection, client *http.Client
 	defer api.Close()
 
 	err := api.SetMetricCredentials(deployInfo.ServiceName, r.credentials)
-	if params.IsCodeNotImplemented(err) {
-		// The state server is too old to support metering.  Warn
-		// the user, but don't return an error.
-		logger.Warningf("current state server version does not support charm metering")
-		return nil
-	} else if err != nil {
+	if err != nil {
 		logger.Infof("failed to set metric credentials: %v", err)
 		return err
 	}

--- a/worker/instancepoller/updater.go
+++ b/worker/instancepoller/updater.go
@@ -194,7 +194,6 @@ func machineLoop(context machineContext, m machine, changed <-chan struct{}) err
 				// (and hopefully the local provider will implement
 				// Addresses/Status in the not-too-distant future),
 				// so we won't need to worry about this case at all.
-				// TODO (anastasiamac 2016-02-01) Should this be removed now?
 				if params.IsCodeNotImplemented(err) {
 					pollInterval = 365 * 24 * time.Hour
 				} else {

--- a/worker/instancepoller/updater.go
+++ b/worker/instancepoller/updater.go
@@ -194,6 +194,7 @@ func machineLoop(context machineContext, m machine, changed <-chan struct{}) err
 				// (and hopefully the local provider will implement
 				// Addresses/Status in the not-too-distant future),
 				// so we won't need to worry about this case at all.
+				// TODO (anastasiamac 2016-02-01) Should this be removed now?
 				if params.IsCodeNotImplemented(err) {
 					pollInterval = 365 * 24 * time.Hour
 				} else {
@@ -248,6 +249,7 @@ func pollInstanceInfo(context machineContext, m machine) (instInfo instanceInfo,
 	}
 	instInfo, err = context.instanceInfo(instId)
 	if err != nil {
+		// TODO (anastasiamac 2016-02-01) This does not look like it needs to be removed now.
 		if params.IsCodeNotImplemented(err) {
 			return instInfo, err
 		}

--- a/worker/provisioner/container_initialisation.go
+++ b/worker/provisioner/container_initialisation.go
@@ -324,12 +324,6 @@ func containerManagerConfig(
 	managerConfigResult, err := provisioner.ContainerManagerConfig(
 		params.ContainerManagerConfigParams{Type: containerType},
 	)
-	if params.IsCodeNotImplemented(err) {
-		// We currently don't support upgrading;
-		// revert to the old configuration.
-		// TODO (anastasiamac 2016-02-01) This looks like it still makes sense for 2.0 :D no need to remove, right?
-		managerConfigResult.ManagerConfig = container.ManagerConfig{container.ConfigName: container.DefaultNamespace}
-	}
 	if err != nil {
 		return nil, err
 	}

--- a/worker/provisioner/container_initialisation.go
+++ b/worker/provisioner/container_initialisation.go
@@ -327,6 +327,7 @@ func containerManagerConfig(
 	if params.IsCodeNotImplemented(err) {
 		// We currently don't support upgrading;
 		// revert to the old configuration.
+		// TODO (anastasiamac 2016-02-01) This looks like it still makes sense for 2.0 :D no need to remove, right?
 		managerConfigResult.ManagerConfig = container.ManagerConfig{container.ConfigName: container.DefaultNamespace}
 	}
 	if err != nil {

--- a/worker/provisioner/provisioner_task.go
+++ b/worker/provisioner/provisioner_task.go
@@ -607,7 +607,7 @@ func (task *provisionerTask) maintainMachines(machines []*apiprovisioner.Machine
 func (task *provisionerTask) startMachines(machines []*apiprovisioner.Machine) error {
 	for _, m := range machines {
 
-		pInfo, err := task.blockUntilProvisioned(m.ProvisioningInfo)
+		pInfo, err := m.ProvisioningInfo()
 		if err != nil {
 			return task.setErrorStatus("fetching provisioning info for machine %q: %v", m, err)
 		}
@@ -832,12 +832,4 @@ func volumeAttachmentsToApiserver(attachments []storage.VolumeAttachment) map[st
 		}
 	}
 	return result
-}
-
-func (task *provisionerTask) blockUntilProvisioned(provision func() (*params.ProvisioningInfo, error)) (*params.ProvisioningInfo, error) {
-	pInfo, err := provision()
-	if err != nil {
-		return nil, err
-	}
-	return pInfo, nil
 }

--- a/worker/provisioner/provisioner_task.go
+++ b/worker/provisioner/provisioner_task.go
@@ -757,9 +757,7 @@ func (task *provisionerTask) startMachine(
 	// for each interface, so we can later manage interfaces
 	// dynamically at run-time.
 	err = machine.SetInstanceInfo(inst.Id(), nonce, hardware, networks, ifaces, volumes, volumeAttachments)
-	if err != nil && params.IsCodeNotImplemented(err) {
-		return fmt.Errorf("cannot provision instance %v for machine %q with networks: not implemented", inst.Id(), machine)
-	} else if err == nil {
+	if err == nil {
 		logger.Infof(
 			"started machine %s as instance %s with hardware %q, networks %v, interfaces %v, volumes %v, volume attachments %v, subnets to zones %v",
 			machine, inst.Id(), hardware,
@@ -848,6 +846,7 @@ func (task *provisionerTask) blockUntilProvisioned(
 		if pInfo, err = provision(); err == nil {
 			break
 		}
+		// TODO (anastasiamac 2016-02-01) This looks like a permanent fix rather than fallback. Does it need to go for 2.0?
 		if params.IsCodeNotImplemented(err) {
 			logger.Infof("waiting for state server to be upgraded")
 			select {


### PR DESCRIPTION
There seems to be some places where CodeNotImplemented is not used as a fallback to old facades. I have added TODOs to these places to clarify as part of the review on this PR.

For 2,0 we assume that everything is implemented. Hence, everywhere where this check was used as a mechanism to fallback to old facades, it has been removed.

(Review request: http://reviews.vapour.ws/r/3689/)