### PR TITLE
Deploy resource flag

### DIFF
--- a/api/service/client.go
+++ b/api/service/client.go
@@ -55,19 +55,31 @@ func (c *Client) EnvironmentUUID() string {
 	return tag.Id()
 }
 
-// ServiceDelpoyArgs holds the arguments to be sent to Client.ServiceDeploy.
+// ServiceDeployArgs holds the arguments to be sent to Client.ServiceDeploy.
 type ServiceDeployArgs struct {
-	CharmURL      string
-	ServiceName   string
-	Series        string
-	NumUnits      int
-	ConfigYAML    string
-	Cons          constraints.Value
+	// Url of the charm to deploy.
+	CharmURL string
+	// Name to give the service.
+	ServiceName string
+	// Series to be used for the machine.
+	Series string
+	// Number of units to deploy.
+	NumUnits int
+	// A YAML string that overrides the default config.yml.
+	ConfigYAML string
+	// Constraints on where units of this service may be placed.
+	Cons constraints.Value
+	// Specification of a specific machine to deploy to.
 	ToMachineSpec string
-	Placement     []*instance.Placement
-	Networks      []string
-	Storage       map[string]storage.Constraints
-	Resources     map[string]string
+	// Placement directives on where the machines for the unit must be created.
+	Placement []*instance.Placement
+	// Names of networks to deploy on.
+	Networks []string
+	// Constraints specifying how storage should be handled.
+	Storage map[string]storage.Constraints
+	// Collection of resource names for the service, with the value being the
+	// unique ID of a pre-uploaded resources in storage.
+	Resources map[string]string
 }
 
 // ServiceDeploy obtains the charm, either locally or from

--- a/api/service/client_test.go
+++ b/api/service/client_test.go
@@ -91,13 +91,27 @@ func (s *serviceSuite) TestSetServiceDeploy(c *gc.C) {
 		c.Assert(args.Services[0].ToMachineSpec, gc.Equals, "machineSpec")
 		c.Assert(args.Services[0].Networks, gc.DeepEquals, []string{"neta"})
 		c.Assert(args.Services[0].Storage, gc.DeepEquals, map[string]storage.Constraints{"data": storage.Constraints{Pool: "pool"}})
+		c.Assert(args.Services[0].Resources, gc.DeepEquals, map[string]string{"foo": "bar"})
 
 		result := response.(*params.ErrorResults)
 		result.Results = make([]params.ErrorResult, 1)
 		return nil
 	})
-	err := s.client.ServiceDeploy("charmURL", "serviceA", "series", 2, "configYAML", constraints.MustParse("mem=4G"),
-		"machineSpec", nil, []string{"neta"}, map[string]storage.Constraints{"data": storage.Constraints{Pool: "pool"}})
+
+	args := service.ServiceDeployArgs{
+		CharmURL:      "charmURL",
+		ServiceName:   "serviceA",
+		Series:        "series",
+		NumUnits:      2,
+		ConfigYAML:    "configYAML",
+		Cons:          constraints.MustParse("mem=4G"),
+		ToMachineSpec: "machineSpec",
+		Placement:     nil,
+		Networks:      []string{"neta"},
+		Storage:       map[string]storage.Constraints{"data": storage.Constraints{Pool: "pool"}},
+		Resources:     map[string]string{"foo": "bar"},
+	}
+	err := s.client.ServiceDeploy(args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(called, jc.IsTrue)
 }

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -205,6 +205,7 @@ type ServiceDeploy struct {
 	Placement     []*instance.Placement
 	Networks      []string
 	Storage       map[string]storage.Constraints
+	Resources     map[string]string
 }
 
 // ServiceUpdate holds the parameters for making the ServiceUpdate call.

--- a/apiserver/service/service.go
+++ b/apiserver/service/service.go
@@ -170,6 +170,7 @@ func DeployService(st *state.State, owner string, args params.ServiceDeploy) err
 			Placement:      args.Placement,
 			Networks:       requestedNetworks,
 			Storage:        args.Storage,
+			Resources:      args.Resources,
 		})
 	return err
 }

--- a/cmd/juju/commands/deploy.go
+++ b/cmd/juju/commands/deploy.go
@@ -261,19 +261,6 @@ func (c *DeployCommand) newServiceAPIClient() (*apiservice.Client, error) {
 	return apiservice.NewClient(root), nil
 }
 
-func (c *DeployCommand) checkResources() error {
-	for name, path := range c.Resources {
-		_, err := os.Stat(path)
-		if os.IsNotExist(err) {
-			return errors.Annotatef(err, "file for resource %q", name)
-		}
-		if err != nil {
-			return errors.Annotatef(err, "can't read file for resource %q", name)
-		}
-	}
-	return nil
-}
-
 func (c *DeployCommand) deployCharmOrBundle(ctx *cmd.Context, client *api.Client) error {
 	deployer := serviceDeployer{ctx, c.newServiceAPIClient}
 
@@ -293,10 +280,6 @@ func (c *DeployCommand) deployCharmOrBundle(ctx *cmd.Context, client *api.Client
 		// Charm may have been supplied via a path reference.
 		ch, curl, charmErr := charmrepo.NewCharmAtPathForceSeries(c.CharmOrBundle, c.Series, c.Force)
 		if charmErr == nil {
-			if err := c.checkResources(); err != nil {
-				return err
-			}
-
 			if curl, charmErr = client.AddLocalCharm(curl, ch); charmErr != nil {
 				return charmErr
 			}
@@ -380,10 +363,6 @@ func (c *DeployCommand) deployCharmOrBundle(ctx *cmd.Context, client *api.Client
 	}
 
 	// Handle a charm.
-
-	if err := c.checkResources(); err != nil {
-		return err
-	}
 
 	// Get the series to use.
 	series, message, err := charmSeries(c.Series, charmOrBundleURL.Series, supportedSeries, c.Force, conf)

--- a/cmd/juju/commands/deploy.go
+++ b/cmd/juju/commands/deploy.go
@@ -528,7 +528,7 @@ func (c *DeployCommand) deployCharm(
 		if err != nil {
 			return errors.Trace(err)
 		}
-		ids, err = resourcecmd.Upload(serviceName, c.Resources, charmInfo.Meta.Resources, api)
+		ids, err = resourcecmd.DeployResources(serviceName, c.Resources, charmInfo.Meta.Resources, api)
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/cmd/juju/commands/deploy.go
+++ b/cmd/juju/commands/deploy.go
@@ -252,7 +252,7 @@ func (c *DeployCommand) Init(args []string) error {
 	for name, path := range c.Resources {
 		_, err := os.Stat(path)
 		if os.IsNotExist(err) {
-			return errors.Errorf("file for resource %q not found: %v", name, path)
+			return errors.Annotatef(err, "file for resource %q", name)
 		}
 		if err != nil {
 			return errors.Annotatef(err, "can't read file for resource %q", name)

--- a/cmd/juju/commands/deploy.go
+++ b/cmd/juju/commands/deploy.go
@@ -125,11 +125,11 @@ flag.  When used with deploy, service-specific constraints are set so that later
 machines provisioned with add-unit will use the same constraints (unless changed
 by set-constraints).
 
-Resources may be uploaded at deploy time by specifying the --resources flag.
-Following the resources flag should be resources specifying by name=filepath
-pairs, separated by semicolons, for example:
+Resources may be uploaded at deploy time by specifying the --resource flag.
+Following the resource flag should be name=filepath pair.  This flag may be
+repeated more than once to upload more than one resource.
   
-  juju deploy foo --resources "bar=/some/path/file.tgz;baz=./my docs/cfg.xml"
+  juju deploy foo --resource bar=/some/file.tgz --resource baz=./docs/cfg.xml
 
 Where bar and baz are resources named in the metadata for the foo charm.
 
@@ -224,7 +224,7 @@ func (c *DeployCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.StringVar(&c.Series, "series", "", "the series on which to deploy")
 	f.BoolVar(&c.Force, "force", false, "allow a charm to be deployed to a machine running an unsupported series")
 	f.Var(storageFlag{&c.Storage, &c.BundleStorage}, "storage", "charm storage constraints")
-	f.Var(stringMap{&c.Resources}, "resources", "resources to be uploaded to the controller")
+	f.Var(stringMap{&c.Resources}, "resource", "resource to be uploaded to the controller")
 
 	for _, step := range c.Steps {
 		step.SetFlags(f)
@@ -296,6 +296,7 @@ func (c *DeployCommand) deployCharmOrBundle(ctx *cmd.Context, client *api.Client
 			if err := c.checkResources(); err != nil {
 				return err
 			}
+
 			if curl, charmErr = client.AddLocalCharm(curl, ch); charmErr != nil {
 				return charmErr
 			}

--- a/cmd/juju/commands/deploy_test.go
+++ b/cmd/juju/commands/deploy_test.go
@@ -289,27 +289,18 @@ func (s *DeploySuite) TestResources(c *gc.C) {
 	err = ioutil.WriteFile(barpath, []byte("bar"), 0600)
 	c.Assert(err, jc.ErrorIsNil)
 
-	res := fmt.Sprintf("foo=%s;bar=%s", foopath, barpath)
+	res1 := fmt.Sprintf("foo=%s", foopath)
+	res2 := fmt.Sprintf("bar=%s", barpath)
 
 	d := DeployCommand{}
-	err = coretesting.InitCommand(envcmd.Wrap(&d),
-		[]string{"local:dummy", "--resources", res})
+	args := []string{"local:dummy", "--resource", res1, "--resource", res2}
+
+	err = coretesting.InitCommand(envcmd.Wrap(&d), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(d.Resources, gc.DeepEquals, map[string]string{
 		"foo": foopath,
 		"bar": barpath,
 	})
-}
-
-func (s *DeploySuite) TestResourceNotFound(c *gc.C) {
-	testcharms.Repo.CharmArchivePath(s.SeriesPath, "dummy")
-	res := "foo=" + path.Join(c.MkDir(), "foo")
-
-	d := DeployCommand{}
-	err := coretesting.InitCommand(envcmd.Wrap(&d),
-		[]string{"local:dummy", "--resources", res})
-	c.Assert(errors.Cause(err), jc.Satisfies, os.IsNotExist)
-	c.Assert(err, gc.ErrorMatches, "file for resource foo.*")
 }
 
 func (s *DeploySuite) TestNetworksIsDeprecated(c *gc.C) {

--- a/cmd/juju/commands/deploy_test.go
+++ b/cmd/juju/commands/deploy_test.go
@@ -303,17 +303,13 @@ func (s *DeploySuite) TestResources(c *gc.C) {
 
 func (s *DeploySuite) TestResourceNotFound(c *gc.C) {
 	testcharms.Repo.CharmArchivePath(s.SeriesPath, "dummy")
-	dir := c.MkDir()
-
-	foopath := path.Join(dir, "foo")
-
-	res := fmt.Sprintf("foo=", foopath)
+	res := "foo=" + path.Join(c.MkDir(), "foo")
 
 	d := DeployCommand{}
 	err := coretesting.InitCommand(envcmd.Wrap(&d),
 		[]string{"local:dummy", "--resources", res})
 	c.Assert(errors.Cause(err), jc.Satisfies, os.IsNotExist)
-	c.Assert(err, gc.ErrorMatches, ".*foo.*")
+	c.Assert(err, gc.ErrorMatches, "file for resource foo.*")
 }
 
 func (s *DeploySuite) TestNetworksIsDeprecated(c *gc.C) {

--- a/cmd/juju/commands/deploy_test.go
+++ b/cmd/juju/commands/deploy_test.go
@@ -301,6 +301,21 @@ func (s *DeploySuite) TestResources(c *gc.C) {
 	})
 }
 
+func (s *DeploySuite) TestResourceNotFound(c *gc.C) {
+	testcharms.Repo.CharmArchivePath(s.SeriesPath, "dummy")
+	dir := c.MkDir()
+
+	foopath := path.Join(dir, "foo")
+
+	res := fmt.Sprintf("foo=", foopath)
+
+	d := DeployCommand{}
+	err := coretesting.InitCommand(envcmd.Wrap(&d),
+		[]string{"local:dummy", "--resources", res})
+	c.Assert(errors.Cause(err), jc.Satisfies, os.IsNotExist)
+	c.Assert(err, gc.ErrorMatches, ".*foo.*")
+}
+
 func (s *DeploySuite) TestNetworksIsDeprecated(c *gc.C) {
 	testcharms.Repo.CharmArchivePath(s.SeriesPath, "dummy")
 	err := runDeploy(c, "local:dummy", "--networks", ", net1, net2 , ", "--constraints", "mem=2G cpu-cores=2 networks=net1,net0,^net3,^net4")

--- a/cmd/juju/commands/flags.go
+++ b/cmd/juju/commands/flags.go
@@ -67,3 +67,39 @@ func (f storageFlag) String() string {
 	}
 	return strings.Join(strs, " ")
 }
+
+// stringMap is a type that deserializes a CLI string using gnuflag's Value
+// semantics.  It expects a single string input, with name=value pairs, semicolon
+// delimited. e.g. "foo=somevalue;bar=othervalue"
+type stringMap struct {
+	mapping *map[string]string
+}
+
+// Set implements gnuflag.Value's Set method.
+func (m stringMap) Set(s string) error {
+	if *m.mapping == nil {
+		*m.mapping = map[string]string{}
+	}
+	pairs := strings.Split(s, ";")
+	for _, pair := range pairs {
+		vals := strings.SplitN(pair, "=", 2)
+		if len(vals) != 2 {
+			return errors.NewNotValid(nil, "badly formatted name value pair: "+pair)
+		}
+		name, value := vals[0], vals[1]
+		if _, ok := (*m.mapping)[name]; ok {
+			return errors.Errorf("duplicate name specified: %q", name)
+		}
+		(*m.mapping)[name] = value
+	}
+	return nil
+}
+
+// String implements gnuflag.Value's String method
+func (m stringMap) String() string {
+	pairs := make([]string, 0, len(*m.mapping))
+	for name, value := range *m.mapping {
+		pairs = append(pairs, name+"="+value)
+	}
+	return strings.Join(pairs, ";")
+}

--- a/cmd/juju/commands/flags.go
+++ b/cmd/juju/commands/flags.go
@@ -69,8 +69,8 @@ func (f storageFlag) String() string {
 }
 
 // stringMap is a type that deserializes a CLI string using gnuflag's Value
-// semantics.  It expects a single string input, with name=value pairs, semicolon
-// delimited. e.g. "foo=somevalue;bar=othervalue"
+// semantics.  It expects a name=value pair, and supports multiple copies of the
+// flag adding more pairs, though the names must be unique.
 type stringMap struct {
 	mapping *map[string]string
 }
@@ -82,18 +82,16 @@ func (m stringMap) Set(s string) error {
 	}
 	// make a copy so the following code is less ugly with dereferencing.
 	mapping := *m.mapping
-	pairs := strings.Split(s, ";")
-	for _, pair := range pairs {
-		vals := strings.SplitN(pair, "=", 2)
-		if len(vals) != 2 {
-			return errors.NewNotValid(nil, "badly formatted name value pair: "+pair)
-		}
-		name, value := vals[0], vals[1]
-		if _, ok := mapping[name]; ok {
-			return errors.Errorf("duplicate name specified: %q", name)
-		}
-		mapping[name] = value
+
+	vals := strings.SplitN(s, "=", 2)
+	if len(vals) != 2 {
+		return errors.NewNotValid(nil, "badly formatted name value pair: "+pair)
 	}
+	name, value := vals[0], vals[1]
+	if _, ok := mapping[name]; ok {
+		return errors.Errorf("duplicate name specified: %q", name)
+	}
+	mapping[name] = value
 	return nil
 }
 

--- a/cmd/juju/commands/flags.go
+++ b/cmd/juju/commands/flags.go
@@ -80,6 +80,8 @@ func (m stringMap) Set(s string) error {
 	if *m.mapping == nil {
 		*m.mapping = map[string]string{}
 	}
+	// make a copy so the following code is less ugly with dereferencing.
+	mapping := *m.mapping
 	pairs := strings.Split(s, ";")
 	for _, pair := range pairs {
 		vals := strings.SplitN(pair, "=", 2)
@@ -87,10 +89,10 @@ func (m stringMap) Set(s string) error {
 			return errors.NewNotValid(nil, "badly formatted name value pair: "+pair)
 		}
 		name, value := vals[0], vals[1]
-		if _, ok := (*m.mapping)[name]; ok {
+		if _, ok := mapping[name]; ok {
 			return errors.Errorf("duplicate name specified: %q", name)
 		}
-		(*m.mapping)[name] = value
+		mapping[name] = value
 	}
 	return nil
 }

--- a/cmd/juju/commands/flags.go
+++ b/cmd/juju/commands/flags.go
@@ -85,7 +85,7 @@ func (m stringMap) Set(s string) error {
 
 	vals := strings.SplitN(s, "=", 2)
 	if len(vals) != 2 {
-		return errors.NewNotValid(nil, "badly formatted name value pair: "+pair)
+		return errors.NewNotValid(nil, "badly formatted name value pair: "+s)
 	}
 	name, value := vals[0], vals[1]
 	if _, ok := mapping[name]; ok {

--- a/cmd/juju/commands/flags_test.go
+++ b/cmd/juju/commands/flags_test.go
@@ -1,0 +1,49 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package commands
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+)
+
+var _ = gc.Suite(&FlagSuite{})
+
+type FlagSuite struct {
+	testing.IsolationSuite
+}
+
+func (FlagSuite) TestStringMapNilOk(c *gc.C) {
+	// note that the map may start out nil
+	var values map[string]string
+	c.Assert(values, gc.IsNil)
+	sm := stringMap{&values}
+	err := sm.Set("foo=foovalue")
+	c.Assert(err, jc.ErrorIsNil)
+	err = sm.Set("bar=barvalue")
+	c.Assert(err, jc.ErrorIsNil)
+
+	// now the map is non-nil and filled
+	c.Assert(values, gc.DeepEquals, map[string]string{
+		"foo": "foovalue",
+		"bar": "barvalue",
+	})
+}
+
+func (FlagSuite) TestStringMapBadVal(c *gc.C) {
+	sm := stringMap{&map[string]string{}}
+	err := sm.Set("foo")
+	c.Assert(err, jc.Satisfies, errors.IsNotValid)
+	c.Assert(err, gc.ErrorMatches, "badly formatted name value pair: foo")
+}
+
+func (FlagSuite) TestStringMapDupVal(c *gc.C) {
+	sm := stringMap{&map[string]string{}}
+	err := sm.Set("bar=somevalue")
+	c.Assert(err, jc.ErrorIsNil)
+	err = sm.Set("bar=someothervalue")
+	c.Assert(err, gc.ErrorMatches, ".*duplicate.*bar.*")
+}

--- a/juju/deploy.go
+++ b/juju/deploy.go
@@ -39,9 +39,7 @@ type DeployServiceParams struct {
 	// TODO(dimitern): Drop this in a follow-up in favor of constraints.
 	Networks []string
 	Storage  map[string]storage.Constraints
-	// Resources is a map of resource name to unique ID, resources that were
-	// uploaded before the deploy call was made, which should be associated with
-	// this service.
+	// Resources is a map of resource name to IDs of pending resources.
 	Resources map[string]string
 }
 

--- a/juju/deploy.go
+++ b/juju/deploy.go
@@ -39,6 +39,10 @@ type DeployServiceParams struct {
 	// TODO(dimitern): Drop this in a follow-up in favor of constraints.
 	Networks []string
 	Storage  map[string]storage.Constraints
+	// Resources is a map of resource name to unique ID, resources that were
+	// uploaded before the deploy call was made, which should be associated with
+	// this service.
+	Resources map[string]string
 }
 
 type ServiceDeployer interface {
@@ -94,6 +98,7 @@ func DeployService(st ServiceDeployer, args DeployServiceParams) (*state.Service
 		Settings:  settings,
 		NumUnits:  args.NumUnits,
 		Placement: args.Placement,
+		Resources: args.Resources,
 	}
 
 	if !args.Charm.Meta().Subordinate {

--- a/juju/deploy_test.go
+++ b/juju/deploy_test.go
@@ -101,6 +101,22 @@ func (s *DeployLocalSuite) TestDeploySeries(c *gc.C) {
 	c.Assert(f.args.Series, gc.Equals, "aseries")
 }
 
+func (s *DeployLocalSuite) TestDeployResources(c *gc.C) {
+	f := &fakeDeployer{State: s.State}
+
+	_, err := juju.DeployService(f,
+		juju.DeployServiceParams{
+			ServiceName: "bob",
+			Charm:       s.charm,
+			Resources:   map[string]string{"foo": "bar"},
+		})
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(f.args.Name, gc.Equals, "bob")
+	c.Assert(f.args.Charm, gc.DeepEquals, s.charm)
+	c.Assert(f.args.Resources, gc.DeepEquals, map[string]string{"foo": "bar"})
+}
+
 func (s *DeployLocalSuite) TestDeploySettings(c *gc.C) {
 	service, err := juju.DeployService(s.State,
 		juju.DeployServiceParams{

--- a/resource/cmd/deploy.go
+++ b/resource/cmd/deploy.go
@@ -10,41 +10,47 @@ import (
 	charmresource "gopkg.in/juju/charm.v6-unstable/resource"
 
 	"github.com/juju/juju/api"
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/resource"
+	"github.com/juju/juju/resource/api/client"
+	"github.com/juju/juju/resource/api/server"
 )
 
 var logger = loggo.GetLogger("resource/cmd")
 
 type uploadClient interface {
+	// AddPendingResources adds pending metadata for store-based resources.
 	AddPendingResources(serviceID string, resources []charmresource.Resource) (ids []string, err error)
-	AddPendingResource(serviceID string, resource charmresource.Resource, r io.Reader) (id string, err error)
+	// AddPendingResource uploads data and metadata for a pending resource for the given service.
+	AddPendingResource(serviceID string, resource charmresource.Resource, r io.ReadSeeker) (id string, err error)
 }
 
 type deployUploader struct {
 	serviceID string
 	resources map[string]charmresource.Meta
 	client    uploadClient
-	osOpen    func(path string) (io.ReadCloser, error)
+	osOpen    func(path string) (ReadSeekCloser, error)
 }
 
-// Upload uploads the bytes and metadata for the given resourcename - filename
-// pairs, returning a map of resource name to uniqueIDs, to be passed along with
-// the ServiceDeploy API command.
-func Upload(serviceId string, files map[string]string, resources map[string]charmresource.Meta, api api.Connection) (ids map[string]string, err error) {
-	// TODO: hook up with
-	return nil, nil
-
+// DeployResources uploads the bytes and metadata for the given resourcename -
+// filename pairs, as well as uploading metadata for any resources not mentioned
+// in the files. It returns a map of resource name to pending resource IDs.
+func DeployResources(serviceID string, files map[string]string, resources map[string]charmresource.Meta, conn api.Connection) (ids map[string]string, err error) {
 	d := deployUploader{
-		serviceID: serviceId,
-		client:    nil,
+		serviceID: serviceID,
+		client:    newClient(conn),
 		resources: resources,
-		osOpen:    func(s string) (io.ReadCloser, error) { return os.Open(s) },
+		osOpen:    func(s string) (ReadSeekCloser, error) { return os.Open(s) },
 	}
 
-	// TODO(natefinch): hook up with uploadClient code!
 	return d.upload(files)
 }
 
 func (d deployUploader) upload(files map[string]string) (map[string]string, error) {
+	if err := d.validateResources(); err != nil {
+		return errors.Trace(err)
+	}
+
 	if err := d.checkExpectedResources(files); err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -73,6 +79,26 @@ func (d deployUploader) upload(files map[string]string) (map[string]string, erro
 	return pending, nil
 }
 
+func (d deployUploader) validateResources() error {
+	var errs []error
+	for _, meta := range d.resources {
+		if err := meta.Validate(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if len(errs) == 1 {
+		return errors.Trace(errs[0])
+	}
+	if len(errs) > 1 {
+		msgs := make([]string, len(errs))
+		for i, err := range errs {
+			msgs = append(msgs, err.Error())
+		}
+		return errors.NewNotValid(nil, strings.Join(msgs, ", "))
+	}
+	return nil
+}
+
 func (d deployUploader) storeResources(uploads map[string]string) []charmresource.Resource {
 	var resources []charmresource.Resource
 	for name, meta := range d.resources {
@@ -80,6 +106,8 @@ func (d deployUploader) storeResources(uploads map[string]string) []charmresourc
 			resources = append(resources, charmresource.Resource{
 				Meta:   meta,
 				Origin: charmresource.OriginStore,
+				// Revision, Fingerprint, and Size will be added server-side,
+				// when we download the bytes from the store.
 			})
 		}
 	}
@@ -119,4 +147,18 @@ func (d deployUploader) checkExpectedResources(provided map[string]string) error
 		return errors.Errorf("unrecognized resources: %s", strings.Join(unknown, ", "))
 	}
 	return nil
+}
+
+// newClient is mostly a copy of the newClient code in
+// component/all/resources.go.  It lives here because it simplifies this code
+// immensely.
+func newClient(conn api.Connection) (*client.Client, error) {
+	caller := base.NewFacadeCallerForVersion(conn, resource.ComponentName, server.Version)
+
+	cl, err := conn.HTTPClient()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	// The apiCaller takes care of prepending /environment/<envUUID>.
+	return client.NewClient(caller, cl, conn), nil
 }

--- a/resource/cmd/deploy.go
+++ b/resource/cmd/deploy.go
@@ -1,0 +1,122 @@
+package cmd
+
+import (
+	"io"
+	"os"
+	"strings"
+
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	charmresource "gopkg.in/juju/charm.v6-unstable/resource"
+
+	"github.com/juju/juju/api"
+)
+
+var logger = loggo.GetLogger("resource/cmd")
+
+type uploadClient interface {
+	AddPendingResources(serviceID string, resources []charmresource.Resource) (ids []string, err error)
+	AddPendingResource(serviceID string, resource charmresource.Resource, r io.Reader) (id string, err error)
+}
+
+type deployUploader struct {
+	serviceID string
+	resources map[string]charmresource.Meta
+	client    uploadClient
+	osOpen    func(path string) (io.ReadCloser, error)
+}
+
+// Upload uploads the bytes and metadata for the given resourcename - filename
+// pairs, returning a map of resource name to uniqueIDs, to be passed along with
+// the ServiceDeploy API command.
+func Upload(serviceId string, files map[string]string, resources map[string]charmresource.Meta, api api.Connection) (ids map[string]string, err error) {
+	// TODO: hook up with
+	return nil, nil
+
+	d := deployUploader{
+		serviceID: serviceId,
+		client:    nil,
+		resources: resources,
+		osOpen:    func(s string) (io.ReadCloser, error) { return os.Open(s) },
+	}
+
+	// TODO(natefinch): hook up with uploadClient code!
+	return d.upload(files)
+}
+
+func (d deployUploader) upload(files map[string]string) (map[string]string, error) {
+	if err := d.checkExpectedResources(files); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	storeResources := d.storeResources(files)
+	pending := map[string]string{}
+	if len(storeResources) > 0 {
+		ids, err := d.client.AddPendingResources(d.serviceID, storeResources)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		// guaranteed 1:1 correlation between ids and resources.
+		for i, res := range storeResources {
+			pending[res.Name] = ids[i]
+		}
+	}
+
+	for name, filename := range files {
+		id, err := d.uploadFile(name, filename)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		pending[name] = id
+	}
+
+	return pending, nil
+}
+
+func (d deployUploader) storeResources(uploads map[string]string) []charmresource.Resource {
+	var resources []charmresource.Resource
+	for name, meta := range d.resources {
+		if _, ok := uploads[name]; !ok {
+			resources = append(resources, charmresource.Resource{
+				Meta:   meta,
+				Origin: charmresource.OriginStore,
+			})
+		}
+	}
+	return resources
+}
+
+func (d deployUploader) uploadFile(resourcename, filename string) (id string, err error) {
+	f, err := d.osOpen(filename)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	defer f.Close()
+	res := charmresource.Resource{
+		Meta:   d.resources[resourcename],
+		Origin: charmresource.OriginUpload,
+	}
+
+	id, err = d.client.AddPendingResource(d.serviceID, res, f)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	return id, err
+}
+
+func (d deployUploader) checkExpectedResources(provided map[string]string) error {
+	var unknown []string
+
+	for name := range provided {
+		if _, ok := d.resources[name]; !ok {
+			unknown = append(unknown, name)
+		}
+	}
+	if len(unknown) == 1 {
+		return errors.Errorf("unrecognized resource %q", unknown[0])
+	}
+	if len(unknown) > 1 {
+		return errors.Errorf("unrecognized resources: %s", strings.Join(unknown, ", "))
+	}
+	return nil
+}

--- a/resource/cmd/deploy_test.go
+++ b/resource/cmd/deploy_test.go
@@ -36,9 +36,13 @@ func (s DeploySuite) TestUploadOK(c *gc.C) {
 		resources: map[string]charmresource.Meta{
 			"upload": {
 				Name: "upload",
+				Type: charmresource.TypeFile,
+				Path: "upload",
 			},
 			"store": {
 				Name: "store",
+				Type: charmresource.TypeFile,
+				Path: "store",
 			},
 		},
 		osOpen: deps.Open,
@@ -49,7 +53,7 @@ func (s DeploySuite) TestUploadOK(c *gc.C) {
 	}
 	ids, err := du.upload(files)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(ids, gc.DeepEquals, map[string]string{
+	c.Check(ids, gc.DeepEquals, map[string]string{
 		"upload": "id-upload",
 		"store":  "id-store",
 	})
@@ -85,7 +89,7 @@ func (s DeploySuite) TestUploadUnexpectedResource(c *gc.C) {
 
 	files := map[string]string{"some bad resource": "foobar.txt"}
 	_, err := du.upload(files)
-	c.Assert(err, gc.ErrorMatches, `unrecognized resource "some bad resource"`)
+	c.Check(err, gc.ErrorMatches, `unrecognized resource "some bad resource"`)
 
 	s.stub.CheckNoCalls(c)
 }

--- a/resource/cmd/deploy_test.go
+++ b/resource/cmd/deploy_test.go
@@ -1,0 +1,124 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cmd
+
+import (
+	"bytes"
+	"io"
+	"io/ioutil"
+
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	charmresource "gopkg.in/juju/charm.v6-unstable/resource"
+)
+
+type DeploySuite struct {
+	testing.IsolationSuite
+
+	stub *testing.Stub
+}
+
+var _ = gc.Suite(&DeploySuite{})
+
+func (s *DeploySuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+
+	s.stub = &testing.Stub{}
+}
+
+func (s DeploySuite) TestUploadOK(c *gc.C) {
+	deps := uploadDeps{s.stub, ioutil.NopCloser(&bytes.Buffer{})}
+	du := deployUploader{
+		serviceID: "mysql",
+		client:    deps,
+		resources: map[string]charmresource.Meta{
+			"upload": {
+				Name: "upload",
+			},
+			"store": {
+				Name: "store",
+			},
+		},
+		osOpen: deps.Open,
+	}
+
+	files := map[string]string{
+		"upload": "foobar.txt",
+	}
+	ids, err := du.upload(files)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ids, gc.DeepEquals, map[string]string{
+		"upload": "id-upload",
+		"store":  "id-store",
+	})
+
+	expectedStore := []charmresource.Resource{
+		{
+			Meta:   du.resources["store"],
+			Origin: charmresource.OriginStore,
+		},
+	}
+	s.stub.CheckCall(c, 0, "AddPendingResources", "mysql", expectedStore)
+	s.stub.CheckCall(c, 1, "Open", "foobar.txt")
+
+	expectedUpload := charmresource.Resource{
+		Meta:   du.resources["upload"],
+		Origin: charmresource.OriginUpload,
+	}
+	s.stub.CheckCall(c, 2, "AddPendingResource", "mysql", expectedUpload, deps.readCloser)
+}
+
+func (s DeploySuite) TestUploadUnexpectedResource(c *gc.C) {
+	deps := uploadDeps{s.stub, ioutil.NopCloser(&bytes.Buffer{})}
+	du := deployUploader{
+		serviceID: "mysql",
+		client:    deps,
+		resources: map[string]charmresource.Meta{
+			"res1": {
+				Name: "res1",
+			},
+		},
+		osOpen: deps.Open,
+	}
+
+	files := map[string]string{"some bad resource": "foobar.txt"}
+	_, err := du.upload(files)
+	c.Assert(err, gc.ErrorMatches, `unrecognized resource "some bad resource"`)
+
+	s.stub.CheckNoCalls(c)
+}
+
+type uploadDeps struct {
+	stub       *testing.Stub
+	readCloser io.ReadCloser
+}
+
+func (s uploadDeps) AddPendingResources(serviceID string, resources []charmresource.Resource) (ids []string, err error) {
+	s.stub.AddCall("AddPendingResources", serviceID, resources)
+	if err := s.stub.NextErr(); err != nil {
+		return nil, err
+	}
+	ids = make([]string, len(resources))
+	for i, res := range resources {
+		ids[i] = "id-" + res.Name
+	}
+	return ids, nil
+}
+
+func (s uploadDeps) AddPendingResource(serviceID string, resource charmresource.Resource, r io.Reader) (id string, err error) {
+	s.stub.AddCall("AddPendingResource", serviceID, resource, r)
+	if err := s.stub.NextErr(); err != nil {
+		return "", err
+	}
+	return "id-" + resource.Name, nil
+}
+
+func (s uploadDeps) Open(name string) (io.ReadCloser, error) {
+	s.stub.AddCall("Open", name)
+	if err := s.stub.NextErr(); err != nil {
+		return nil, err
+	}
+	return s.readCloser, nil
+}

--- a/state/state.go
+++ b/state/state.go
@@ -1139,6 +1139,7 @@ type AddServiceArgs struct {
 	NumUnits    int
 	Placement   []*instance.Placement
 	Constraints constraints.Value
+	Resources   map[string]string
 }
 
 // AddService creates a new service, running the supplied charm, with the

--- a/testcharms/charm-repo/quantal/starsay/metadata.yaml
+++ b/testcharms/charm-repo/quantal/starsay/metadata.yaml
@@ -2,8 +2,6 @@ name: starsay
 summary: A dumb little test charm for resources.
 maintainer: Nate Finch <nate.finch@gmail.com>
 description: Doesn't do anything at all.
-series: 
-  - trusty
 tags:
   - application
 resources:


### PR DESCRIPTION
add --resources flag to juju deploy.  Doesn't actually use the resources for anything yet, but does all the CLI checks, and checks that the files exist.

(Review request: http://reviews.vapour.ws/r/3699/)