### PR TITLE
new package: cmd/pprof

### DIFF
--- a/cmd/jujud/main.go
+++ b/cmd/jujud/main.go
@@ -20,6 +20,7 @@ import (
 
 	jujucmd "github.com/juju/juju/cmd"
 	agentcmd "github.com/juju/juju/cmd/jujud/agent"
+	"github.com/juju/juju/cmd/pprof"
 	components "github.com/juju/juju/component/all"
 	"github.com/juju/juju/juju/names"
 	"github.com/juju/juju/juju/sockets"
@@ -175,22 +176,29 @@ func Main(args []string) int {
 			os.Exit(exit_panic)
 		}
 	}()
-	var code int = 1
+
 	ctx, err := cmd.DefaultContext()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(exit_err)
 	}
+
+	code := 1
 	commandName := filepath.Base(args[0])
-	if commandName == names.Jujud {
+	switch commandName {
+	case names.Jujud:
+		// start pprof server and defer cleanup
+		stop := pprof.Start()
+		defer stop()
+
 		code, err = jujuDMain(args, ctx)
-	} else if commandName == names.Jujuc {
+	case names.Jujuc:
 		fmt.Fprint(os.Stderr, jujudDoc)
 		code = exit_err
 		err = fmt.Errorf("jujuc should not be called directly")
-	} else if commandName == names.JujuRun {
+	case names.JujuRun:
 		code = cmd.Main(&RunCommand{}, ctx, args[1:])
-	} else {
+	default:
 		code, err = jujuCMain(commandName, ctx, args)
 	}
 	if err != nil {

--- a/cmd/pprof/pprof.go
+++ b/cmd/pprof/pprof.go
@@ -1,0 +1,213 @@
+// Copyright 2010 The Go Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package pprof serves via its HTTP server runtime profiling data
+// in the format expected by the pprof visualization tool.
+// For more information about pprof, see
+// http://code.google.com/p/google-perftools/.
+//
+// The package is typically only imported for the side effect of
+// registering its HTTP handlers.
+// The handled paths all begin with /debug/pprof/.
+//
+// To use pprof, link this package into your program:
+//	import _ "net/http/pprof"
+//
+// If your application is not already running an http server, you
+// need to start one.  Add "net/http" and "log" to your imports and
+// the following code to your main function:
+//
+// 	go func() {
+// 		log.Println(http.ListenAndServe("localhost:6060", nil))
+// 	}()
+//
+// Then use the pprof tool to look at the heap profile:
+//
+//	go tool pprof http://localhost:6060/debug/pprof/heap
+//
+// Or to look at a 30-second CPU profile:
+//
+//	go tool pprof http://localhost:6060/debug/pprof/profile
+//
+// Or to look at the goroutine blocking profile:
+//
+//	go tool pprof http://localhost:6060/debug/pprof/block
+//
+// To view all available profiles, open http://localhost:6060/debug/pprof/
+// in your browser.
+//
+// For a study of the facility in action, visit
+//
+//	https://blog.golang.org/2011/06/profiling-go-programs.html
+//
+package pprof
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"html/template"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"runtime"
+	"runtime/pprof"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Cmdline responds with the running program's
+// command line, with arguments separated by NUL bytes.
+// The package initialization registers it as /debug/pprof/cmdline.
+func Cmdline(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	fmt.Fprintf(w, strings.Join(os.Args, "\x00"))
+}
+
+func sleep(w http.ResponseWriter, d time.Duration) {
+	var clientGone <-chan bool
+	if cn, ok := w.(http.CloseNotifier); ok {
+		clientGone = cn.CloseNotify()
+	}
+	select {
+	case <-time.After(d):
+	case <-clientGone:
+	}
+}
+
+// Profile responds with the pprof-formatted cpu profile.
+// The package initialization registers it as /debug/pprof/profile.
+func Profile(w http.ResponseWriter, r *http.Request) {
+	sec, _ := strconv.ParseInt(r.FormValue("seconds"), 10, 64)
+	if sec == 0 {
+		sec = 30
+	}
+
+	// Set Content Type assuming StartCPUProfile will work,
+	// because if it does it starts writing.
+	w.Header().Set("Content-Type", "application/octet-stream")
+	if err := pprof.StartCPUProfile(w); err != nil {
+		// StartCPUProfile failed, so no writes yet.
+		// Can change header back to text content
+		// and send error code.
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprintf(w, "Could not enable CPU profiling: %s\n", err)
+		return
+	}
+	sleep(w, time.Duration(sec)*time.Second)
+	pprof.StopCPUProfile()
+}
+
+// Symbol looks up the program counters listed in the request,
+// responding with a table mapping program counters to function names.
+// The package initialization registers it as /debug/pprof/symbol.
+func Symbol(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+
+	// We have to read the whole POST body before
+	// writing any output.  Buffer the output here.
+	var buf bytes.Buffer
+
+	// We don't know how many symbols we have, but we
+	// do have symbol information.  Pprof only cares whether
+	// this number is 0 (no symbols available) or > 0.
+	fmt.Fprintf(&buf, "num_symbols: 1\n")
+
+	var b *bufio.Reader
+	if r.Method == "POST" {
+		b = bufio.NewReader(r.Body)
+	} else {
+		b = bufio.NewReader(strings.NewReader(r.URL.RawQuery))
+	}
+
+	for {
+		word, err := b.ReadSlice('+')
+		if err == nil {
+			word = word[0 : len(word)-1] // trim +
+		}
+		pc, _ := strconv.ParseUint(string(word), 0, 64)
+		if pc != 0 {
+			f := runtime.FuncForPC(uintptr(pc))
+			if f != nil {
+				fmt.Fprintf(&buf, "%#x %s\n", pc, f.Name())
+			}
+		}
+
+		// Wait until here to check for err; the last
+		// symbol will have an err because it doesn't end in +.
+		if err != nil {
+			if err != io.EOF {
+				fmt.Fprintf(&buf, "reading request: %v\n", err)
+			}
+			break
+		}
+	}
+
+	w.Write(buf.Bytes())
+}
+
+// Handler returns an HTTP handler that serves the named profile.
+func Handler(name string) http.Handler {
+	return handler(name)
+}
+
+type handler string
+
+func (name handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	debug, _ := strconv.Atoi(r.FormValue("debug"))
+	p := pprof.Lookup(string(name))
+	if p == nil {
+		w.WriteHeader(404)
+		fmt.Fprintf(w, "Unknown profile: %s\n", name)
+		return
+	}
+	gc, _ := strconv.Atoi(r.FormValue("gc"))
+	if name == "heap" && gc > 0 {
+		runtime.GC()
+	}
+	p.WriteTo(w, debug)
+	return
+}
+
+// Index responds with the pprof-formatted profile named by the request.
+// For example, "/debug/pprof/heap" serves the "heap" profile.
+// Index responds to a request for "/debug/pprof/" with an HTML page
+// listing the available profiles.
+func Index(w http.ResponseWriter, r *http.Request) {
+	if strings.HasPrefix(r.URL.Path, "/debug/pprof/") {
+		name := strings.TrimPrefix(r.URL.Path, "/debug/pprof/")
+		if name != "" {
+			handler(name).ServeHTTP(w, r)
+			return
+		}
+	}
+
+	profiles := pprof.Profiles()
+	if err := indexTmpl.Execute(w, profiles); err != nil {
+		log.Print(err)
+	}
+}
+
+var indexTmpl = template.Must(template.New("index").Parse(`<html>
+<head>
+<title>/debug/pprof/</title>
+</head>
+<body>
+/debug/pprof/<br>
+<br>
+profiles:<br>
+<table>
+{{range .}}
+<tr><td align=right>{{.Count}}<td><a href="{{.Name}}?debug=1">{{.Name}}</a>
+{{end}}
+</table>
+<br>
+<a href="goroutine?debug=2">full goroutine stack dump</a><br>
+</body>
+</html>
+`))

--- a/cmd/pprof/pprof.go
+++ b/cmd/pprof/pprof.go
@@ -2,6 +2,19 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// Package pprof is a fork of net/http/pprof modified to communicate
+// over a unix socket.
+//
+// Changes from the original version
+//
+// - This fork does not automatically register itself with the default
+//   net/http ServeMux.
+// - To start the pprof handler, see the Start method in socket.go.
+// - For compatability with Go 1.2.1, support for obtaining trace data
+//   has been removed.
+//
+// ---------------------------------------------------------------
+//
 // Package pprof serves via its HTTP server runtime profiling data
 // in the format expected by the pprof visualization tool.
 // For more information about pprof, see

--- a/cmd/pprof/socket.go
+++ b/cmd/pprof/socket.go
@@ -1,0 +1,66 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package pprof
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+
+	"github.com/juju/loggo"
+)
+
+var logger = loggo.GetLogger("juju.cmd.pprof")
+
+// Start starts a pprof server listening on a unix socket in /tmp.
+// The name of the file is derived from the name of the process, as
+// provided by os.Args[0], and the pid of the process.
+// Start returns a function which will stop the pprof server and clean
+// up the socket file.
+func Start() func() error {
+	if runtime.GOOS != "linux" {
+		logger.Infof("pprof debugging not supported on %q", runtime.GOOS)
+		return func() error { return nil }
+	}
+
+	mux := http.NewServeMux()
+	mux.Handle("/debug/pprof/", http.HandlerFunc(Index))
+	mux.Handle("/debug/pprof/cmdline", http.HandlerFunc(Cmdline))
+	mux.Handle("/debug/pprof/profile", http.HandlerFunc(Profile))
+	mux.Handle("/debug/pprof/symbol", http.HandlerFunc(Symbol))
+
+	srv := http.Server{
+		Handler: mux,
+	}
+
+	name := filepath.Base(os.Args[0])
+	path := fmt.Sprintf("/tmp/pprof.%s.%d", name, os.Getpid())
+
+	addr, err := net.ResolveUnixAddr("unix", path)
+	if err != nil {
+		logger.Errorf("unable to resolve unix socket: %v", err)
+		return func() error { return nil }
+	}
+
+	// Try to remove the socket if already present.
+	os.Remove(path)
+
+	l, err := net.ListenUnix("unix", addr)
+	if err != nil {
+		logger.Errorf("unable to listen on unix socket: %v", err)
+		return func() error { return nil }
+	}
+
+	go func() {
+		defer os.Remove(path)
+
+		// Ignore the error from calling l.Close.
+		srv.Serve(l)
+	}()
+
+	return l.Close
+}

--- a/cmd/pprof/socket.go
+++ b/cmd/pprof/socket.go
@@ -37,9 +37,7 @@ func Start() func() error {
 		Handler: mux,
 	}
 
-	name := filepath.Base(os.Args[0])
-	path := fmt.Sprintf("/tmp/pprof.%s.%d", name, os.Getpid())
-
+	path := socketpath()
 	addr, err := net.ResolveUnixAddr("unix", path)
 	if err != nil {
 		logger.Errorf("unable to resolve unix socket: %v", err)
@@ -63,4 +61,12 @@ func Start() func() error {
 	}()
 
 	return l.Close
+}
+
+// socketpath returns the path for this processes' pprof socket.
+func socketpath() string {
+	cmd := filepath.Base(os.Args[0])
+	name := fmt.Sprintf("pprof.%s.%d", cmd, os.Getpid())
+	path := filepath.Join(os.TempDir(), name)
+	return path
 }

--- a/cmd/pprof/socket_test.go
+++ b/cmd/pprof/socket_test.go
@@ -1,0 +1,140 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package pprof
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"testing"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+)
+
+type suite struct {
+}
+
+var _ = gc.Suite(&suite{})
+
+func TestSuite(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skipf("skipping pprof tests, %q not supported", runtime.GOOS)
+	}
+	gc.TestingT(t)
+}
+
+func (s *suite) TestSocketpath(c *gc.C) {
+	got := socketpath()
+	want := filepath.Join(os.TempDir(), fmt.Sprintf("pprof.pprof.test.%d", os.Getpid()))
+	c.Assert(got, gc.Equals, want)
+}
+
+func (s *suite) TestSocketPathIsUnixAddr(c *gc.C) {
+	path := socketpath()
+	addr, err := net.ResolveUnixAddr("unix", path)
+	c.Assert(err, gc.IsNil)
+	c.Assert(addr.Name, gc.Equals, path)
+	c.Assert(addr.Net, gc.Equals, "unix")
+}
+
+func (s *suite) TestPprofStartReturnsNonNilShutdownFn(c *gc.C) {
+	stop := Start()
+	c.Assert(stop, gc.NotNil)
+	defer stop()
+}
+
+func (s *suite) TestPprofStart(c *gc.C) {
+	path := socketpath()
+	_, err := os.Stat(path)
+	c.Assert(os.IsNotExist(err), jc.IsTrue)
+
+	stop := Start()
+	_, err = os.Stat(path)
+	c.Assert(err, gc.IsNil)
+
+	err = stop()
+	c.Assert(err, gc.IsNil)
+	_, err = os.Stat(path)
+	c.Assert(os.IsNotExist(err), jc.IsTrue)
+}
+
+func (s *suite) TestPprofStartWithExistingSocketFile(c *gc.C) {
+	path := socketpath()
+	w, err := os.Create(path)
+	c.Assert(err, gc.IsNil)
+
+	w.Write([]byte("not a socket"))
+	err = w.Close() // can ignore error from w.Write
+	c.Assert(err, gc.IsNil)
+
+	stop := Start()
+	defer stop()
+	fi, err := os.Stat(path)
+	c.Assert(err, gc.IsNil)
+	c.Assert(fi.Mode()&os.ModeSocket != 0, jc.IsTrue)
+}
+
+type pprofSuite struct {
+	stop func() error
+	path string
+}
+
+var _ = gc.Suite(&pprofSuite{})
+
+func (s *pprofSuite) SetUpSuite(c *gc.C) {
+	s.stop = Start()
+	s.path = socketpath()
+}
+
+func (s *pprofSuite) TearDownSuite(c *gc.C) {
+	s.stop()
+}
+
+func (s *pprofSuite) call(c *gc.C, url string) []byte {
+	conn, err := net.Dial("unix", s.path)
+	c.Assert(err, gc.IsNil)
+	defer conn.Close()
+
+	_, err = fmt.Fprintf(conn, "GET %s HTTP/1.0\r\n\r\n", url)
+	c.Assert(err, gc.IsNil)
+
+	buf, err := ioutil.ReadAll(conn)
+	c.Assert(err, gc.IsNil)
+	return buf
+}
+
+func (s *pprofSuite) TestCmdLine(c *gc.C) {
+	buf := s.call(c, "/debug/pprof/cmdline")
+	c.Assert(buf, gc.NotNil)
+	matches(c, buf, ".*github.com/juju/juju/cmd/pprof/_test/pprof.test")
+}
+
+func (s *pprofSuite) TestGoroutineProfile(c *gc.C) {
+	buf := s.call(c, "/debug/pprof/goroutine")
+	c.Assert(buf, gc.NotNil)
+	matches(c, buf, `^goroutine profile: total \d+`)
+}
+
+// matches fails if regex is not found in the contents of b.
+// b is expected to be the response from the pprof http server, and will
+// contain some HTTP preamble that should be ignored.
+func matches(c *gc.C, b []byte, regex string) {
+	re, err := regexp.Compile(regex)
+	c.Assert(err, gc.IsNil)
+	r := bytes.NewReader(b)
+	sc := bufio.NewScanner(r)
+	for sc.Scan() {
+		if re.MatchString(sc.Text()) {
+			return
+		}
+	}
+	c.Fatalf("%q did not match regex %q", string(b), regex)
+}


### PR DESCRIPTION
Backport of #4259 to 1.25

Updates LP #1519473

This PR adds a new package, github.com/juju/juju/cmd/pprof, a fork of
net/http/pprof. The fork is necessary because importing the latter package
automatically registers debug handlers with the default server mux, which
juju does not go to lengths to protect, and exposing this data over http
will set of an explosion of security hand wringing.

Instead, the package provides a way to export the same handlers over a
unix socket owned by the user starting the process. To access the debug
statistics, which are read only, you must have physical access to the host.

These statistics are only enabled in cmd/jujud when it is acting as jujud,
a machine or unit agent.

(Review request: http://reviews.vapour.ws/r/3700/)