### PR TITLE
bootstrap: providers detect regions

### DIFF
--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -231,24 +231,37 @@ func (c *bootstrapCommand) Run(ctx *cmd.Context) (resultErr error) {
 	bootstrapFuncs := getBootstrapFuncs()
 
 	// Get the cloud definition identified by c.Cloud. If c.Cloud does not
-	// identify a cloud in clouds.yaml, but is the name of a provider, we
-	// synthesise a Cloud structure with a single region and no auth-types.
+	// identify a cloud in clouds.yaml, but is the name of a provider, and
+	// that provider implements environs.CloudRegionDetector, we'll
+	// synthesise a Cloud structure with the detected regions and no auth-
+	// types.
 	cloud, err := jujucloud.CloudByName(c.Cloud)
 	if errors.IsNotFound(err) {
 		ctx.Verbosef("cloud %q not found, trying as a provider name", c.Cloud)
-		_, err := environs.Provider(c.Cloud)
+		provider, err := environs.Provider(c.Cloud)
 		if errors.IsNotFound(err) {
-			return errors.NotFoundf("cloud %s", c.Cloud)
+			return errors.NotFoundf("cloud %q", c.Cloud)
 		} else if err != nil {
 			return errors.Trace(err)
 		}
-		// TODO(axw) ask the provider to detect the region and endpoint
-		// from the environment?
+		detector, ok := provider.(environs.CloudRegionDetector)
+		if !ok {
+			ctx.Verbosef(
+				"provider %q does not support detecting regions",
+				c.Cloud,
+			)
+			return errors.NotFoundf("cloud %q", c.Cloud)
+		}
+		regions, err := detector.DetectRegions()
+		if err != nil {
+			return errors.Annotatef(err,
+				"detecting regions for %q cloud provider",
+				c.Cloud,
+			)
+		}
 		cloud = &jujucloud.Cloud{
-			Type: c.Cloud,
-			Regions: map[string]jujucloud.Region{
-				c.Cloud: jujucloud.Region{},
-			},
+			Type:    c.Cloud,
+			Regions: regions,
 		}
 	} else if err != nil {
 		return errors.Trace(err)
@@ -272,24 +285,24 @@ func (c *bootstrapCommand) Run(ctx *cmd.Context) (resultErr error) {
 		}
 		detected, err := provider.DetectCredentials()
 		if err != nil {
-			return errors.Annotate(err, "detecting credentials")
+			return errors.Annotatef(err, "detecting credentials for %q cloud provider", c.Cloud)
 		}
 		ctx.Verbosef("provider detected credentials: %v", detected)
 		if len(detected) == 0 {
 			return errors.NotFoundf("credentials for cloud %q", c.Cloud)
 		}
 		credential = &detected[0]
-		ctx.Verbosef("authenticating with %v", credential)
 		regionName = c.Region
-		if regionName == "" {
-			// TODO(axw) see TODO(axw) above, where we synthesise
-			// the cloud. We need to set the region to the same.
-			// We should defer to the provider to detect the region
-			// and endpoint.
-			regionName = c.Cloud
-		}
+		ctx.Verbosef("authenticating with %v", credential)
 	} else if err != nil {
 		return errors.Trace(err)
+	}
+
+	if regionName == "" && len(cloud.Regions) == 1 {
+		// If no region is specified and there is only one in the
+		// cloud, use it.
+		for regionName = range cloud.Regions {
+		}
 	}
 	region, ok := cloud.Regions[regionName]
 	if !ok {
@@ -297,10 +310,10 @@ func (c *bootstrapCommand) Run(ctx *cmd.Context) (resultErr error) {
 		for name := range cloud.Regions {
 			regionNames = append(regionNames, name)
 		}
-		return errors.NotFoundf(
-			"region %q in cloud %q (expected one of %q)",
+		return errors.NewNotFound(nil, fmt.Sprintf(
+			"region %q in cloud %q not found (expected one of %q)",
 			regionName, c.Cloud, regionNames,
-		)
+		))
 	}
 
 	// Create an environment config from the cloud and credentials. The
@@ -334,6 +347,11 @@ func (c *bootstrapCommand) Run(ctx *cmd.Context) (resultErr error) {
 	if err != nil {
 		return errors.Trace(err)
 	}
+
+	ctx.Infof(
+		"Creating Juju controller %q on %s/%s",
+		c.ControllerName, c.Cloud, regionName,
+	)
 
 	// If we error out for any reason, clean up the environment.
 	defer func() {
@@ -436,14 +454,6 @@ func (c *bootstrapCommand) getCredentials(
 	regionName := c.Region
 	if regionName == "" {
 		regionName = defaultRegion
-	}
-	if regionName == "" {
-		// If no region is specified, attempt to bootstrap using the
-		// cloud name as the region name.
-		//
-		// TODO(axw) this is a hack to support lxd. We should instead
-		// be asking the provider to auto-detect the region/endpoint.
-		regionName = cloudName
 	}
 
 	// Validate credential by checking schemas supported by the provider.

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -57,6 +57,12 @@ type BootstrapSuite struct {
 
 var _ = gc.Suite(&BootstrapSuite{})
 
+func init() {
+	environs.RegisterProvider("no-cloud-region-detection", noCloudRegionDetectionProvider{})
+	environs.RegisterProvider("no-cloud-regions", noCloudRegionsProvider{})
+	environs.RegisterProvider("no-credentials", noCredentialsProvider{})
+}
+
 func (s *BootstrapSuite) SetUpSuite(c *gc.C) {
 	s.FakeJujuHomeSuite.SetUpSuite(c)
 	s.MgoSuite.SetUpSuite(c)
@@ -722,6 +728,7 @@ func (s *BootstrapSuite) TestMissingToolsUploadFailedError(c *gc.C) {
 	)
 
 	c.Check(coretesting.Stderr(ctx), gc.Equals, fmt.Sprintf(`
+Creating Juju controller "devenv" on dummy-cloud/region-1
 Bootstrapping environment "admin"
 Starting new instance for initial state server
 Building tools to upload (1.7.3.1-raring-%s)
@@ -788,6 +795,36 @@ func (s *BootstrapSuite) TestBootstrapKeepBroken(c *gc.C) {
 			break
 		}
 	}
+}
+
+func (s *BootstrapSuite) TestBootstrapUnknownCloudOrProvider(c *gc.C) {
+	s.patchVersionAndSeries(c, "raring")
+	_, err := coretesting.RunCommand(c, newBootstrapCommand(), "ctrl", "no-such-provider")
+	c.Assert(err, gc.ErrorMatches, `cloud "no-such-provider" not found`)
+}
+
+func (s *BootstrapSuite) TestBootstrapProviderNoRegionDetection(c *gc.C) {
+	s.patchVersionAndSeries(c, "raring")
+	_, err := coretesting.RunCommand(c, newBootstrapCommand(), "ctrl", "no-cloud-region-detection")
+	c.Assert(err, gc.ErrorMatches, `cloud "no-cloud-region-detection" not found`)
+}
+
+func (s *BootstrapSuite) TestBootstrapProviderNoRegions(c *gc.C) {
+	s.patchVersionAndSeries(c, "raring")
+	_, err := coretesting.RunCommand(c, newBootstrapCommand(), "ctrl", "no-cloud-regions")
+	c.Assert(err, gc.ErrorMatches, `detecting regions for "no-cloud-regions" cloud provider: regions not found`)
+}
+
+func (s *BootstrapSuite) TestBootstrapProviderNoCredentials(c *gc.C) {
+	s.patchVersionAndSeries(c, "raring")
+	_, err := coretesting.RunCommand(c, newBootstrapCommand(), "ctrl", "no-credentials")
+	c.Assert(err, gc.ErrorMatches, `detecting credentials for "no-credentials" cloud provider: credentials not found`)
+}
+
+func (s *BootstrapSuite) TestBootstrapProviderDetectRegions(c *gc.C) {
+	s.patchVersionAndSeries(c, "raring")
+	_, err := coretesting.RunCommand(c, newBootstrapCommand(), "ctrl", "dummy/not-dummy")
+	c.Assert(err, gc.ErrorMatches, `region "not-dummy" in cloud "dummy" not found \(expected one of \["dummy"\]\)`)
 }
 
 // createToolsSource writes the mock tools and metadata into a temporary
@@ -878,4 +915,28 @@ type fakeBootstrapFuncs struct {
 func (fake *fakeBootstrapFuncs) Bootstrap(ctx environs.BootstrapContext, env environs.Environ, args bootstrap.BootstrapParams) error {
 	fake.args = args
 	return nil
+}
+
+type noCloudRegionDetectionProvider struct {
+	environs.EnvironProvider
+}
+
+type noCloudRegionsProvider struct {
+	environs.EnvironProvider
+}
+
+func (noCloudRegionsProvider) DetectRegions() (map[string]cloud.Region, error) {
+	return nil, errors.NotFoundf("regions")
+}
+
+type noCredentialsProvider struct {
+	environs.EnvironProvider
+}
+
+func (noCredentialsProvider) DetectRegions() (map[string]cloud.Region, error) {
+	return map[string]cloud.Region{"region": {}}, nil
+}
+
+func (noCredentialsProvider) DetectCredentials() ([]cloud.Credential, error) {
+	return nil, errors.NotFoundf("credentials")
 }

--- a/environs/config.go
+++ b/environs/config.go
@@ -85,7 +85,9 @@ func (r *globalProviderRegistry) Provider(providerType string) (EnvironProvider,
 	}
 	p, ok := r.providers[providerType]
 	if !ok {
-		return nil, errors.Errorf("no registered provider for %q", providerType)
+		return nil, errors.NewNotFound(
+			nil, fmt.Sprintf("no registered provider for %q", providerType),
+		)
 	}
 	return p, nil
 }

--- a/environs/interface.go
+++ b/environs/interface.go
@@ -59,9 +59,6 @@ type PrepareForBootstrapParams struct {
 	// be updated with the region, endpoint and credentials.
 	Config *config.Config
 
-	// TODO(axw) the attributes below will be populated in a
-	// follow-up.
-
 	// Credentials is the set of credentials to use to bootstrap.
 	Credentials cloud.Credential
 
@@ -94,9 +91,22 @@ type ProviderCredentials interface {
 	// environment variables, or reading configuration files in
 	// well-defined locations.
 	//
-	// If the no credentials can be detected, DetectCredentials should
+	// If no credentials can be detected, DetectCredentials should
 	// return an error satisfying errors.IsNotFound.
 	DetectCredentials() ([]cloud.Credential, error)
+}
+
+// CloudRegionDetector is an interface that an EnvironProvider implements
+// in order to automatically detect cloud regions from the environment.
+type CloudRegionDetector interface {
+	// DetectRetions automatically detects one or more regions
+	// from the environment. This may involve, for example, inspecting
+	// environment variables, or returning special hard-coded regions
+	// (e.g. "localhost" for lxd).
+	//
+	// If no regions can be detected, DetectRegions should return
+	// an error satisfying errors.IsNotFound.
+	DetectRegions() (map[string]cloud.Region, error)
 }
 
 // EnvironConfigUpgrader is an interface that an EnvironProvider may

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -514,6 +514,10 @@ func (*environProvider) DetectCredentials() ([]cloud.Credential, error) {
 	return []cloud.Credential{cloud.NewEmptyCredential()}, nil
 }
 
+func (*environProvider) DetectRegions() (map[string]cloud.Region, error) {
+	return map[string]cloud.Region{"dummy": {}}, nil
+}
+
 func (p *environProvider) Validate(cfg, old *config.Config) (valid *config.Config, err error) {
 	// Check for valid changes for the base config values.
 	if err := config.Validate(cfg, old); err != nil {

--- a/provider/lxd/provider.go
+++ b/provider/lxd/provider.go
@@ -8,6 +8,7 @@ package lxd
 import (
 	"github.com/juju/errors"
 
+	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 )
@@ -97,4 +98,12 @@ func (environProvider) SecretAttrs(cfg *config.Config) (map[string]string, error
 		return nil, errors.Trace(err)
 	}
 	return ecfg.secret(), nil
+}
+
+// DetectRegions implements environs.CloudRegionDetector.
+func (environProvider) DetectRegions() (map[string]cloud.Region, error) {
+	// For now we just return a hard-coded "localhost" region,
+	// i.e. the local LXD daemon. We may later want to detect
+	// locally-configured remotes.
+	return map[string]cloud.Region{"localhost": {}}, nil
 }

--- a/provider/lxd/provider_test.go
+++ b/provider/lxd/provider_test.go
@@ -9,6 +9,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs"
 	envtesting "github.com/juju/juju/environs/testing"
 	"github.com/juju/juju/provider/lxd"
@@ -31,6 +32,15 @@ func (s *providerSuite) SetUpTest(c *gc.C) {
 	provider, err := environs.Provider("lxd")
 	c.Assert(err, jc.ErrorIsNil)
 	s.provider = provider
+}
+
+func (s *providerSuite) TestDetectRegions(c *gc.C) {
+	c.Assert(s.provider, gc.Implements, new(environs.CloudRegionDetector))
+	regions, err := s.provider.(environs.CloudRegionDetector).DetectRegions()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(regions, jc.DeepEquals, map[string]cloud.Region{
+		"localhost": {},
+	})
 }
 
 func (s *providerSuite) TestRegistered(c *gc.C) {

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -87,6 +87,20 @@ func (p EnvironProvider) RestrictedConfigAttributes() []string {
 	return []string{"region", "auth-url", "auth-mode"}
 }
 
+// DetectRegions implements environs.CloudRegionDetector.
+func (EnvironProvider) DetectRegions() (map[string]cloud.Region, error) {
+	// If OS_REGION_NAME and OS_AUTH_URL are both set,
+	// return return a region using them.
+	creds := identity.CredentialsFromEnv()
+	if creds.Region == "" {
+		return nil, errors.NewNotFound(nil, "OS_REGION_NAME environment variable not set")
+	}
+	if creds.URL == "" {
+		return nil, errors.NewNotFound(nil, "OS_AUTH_URL environment variable not set")
+	}
+	return map[string]cloud.Region{creds.Region: {creds.URL}}, nil
+}
+
 // PrepareForCreateEnvironment is specified in the EnvironProvider interface.
 func (p EnvironProvider) PrepareForCreateEnvironment(cfg *config.Config) (*config.Config, error) {
 	return cfg, nil

--- a/provider/openstack/provider_test.go
+++ b/provider/openstack/provider_test.go
@@ -4,15 +4,21 @@
 package openstack_test
 
 import (
+	gitjujutesting "github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/goose.v1/nova"
 
+	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/environs"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/provider/openstack"
 )
 
 // localTests contains tests which do not require a live service or test double to run.
-type localTests struct{}
+type localTests struct {
+	gitjujutesting.IsolationSuite
+}
 
 var _ = gc.Suite(&localTests{})
 
@@ -344,4 +350,32 @@ func (*localTests) TestRuleMatchesPortRange(c *gc.C) {
 		c.Logf("test %d: %s", i, t.about)
 		c.Check(openstack.RuleMatchesPortRange(t.rule, t.ports), gc.Equals, t.expected)
 	}
+}
+
+func (s *localTests) TestDetectRegionsNoRegionName(c *gc.C) {
+	_, err := s.detectRegions(c)
+	c.Assert(err, gc.ErrorMatches, "OS_REGION_NAME environment variable not set")
+}
+
+func (s *localTests) TestDetectRegionsNoAuthURL(c *gc.C) {
+	s.PatchEnvironment("OS_REGION_NAME", "oceania")
+	_, err := s.detectRegions(c)
+	c.Assert(err, gc.ErrorMatches, "OS_AUTH_URL environment variable not set")
+}
+
+func (s *localTests) TestDetectRegions(c *gc.C) {
+	s.PatchEnvironment("OS_REGION_NAME", "oceania")
+	s.PatchEnvironment("OS_AUTH_URL", "http://keystone.internal")
+	regions, err := s.detectRegions(c)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(regions, jc.DeepEquals, map[string]cloud.Region{
+		"oceania": {"http://keystone.internal"},
+	})
+}
+
+func (s *localTests) detectRegions(c *gc.C) (map[string]cloud.Region, error) {
+	provider, err := environs.Provider("openstack")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(provider, gc.Implements, new(environs.CloudRegionDetector))
+	return provider.(environs.CloudRegionDetector).DetectRegions()
 }


### PR DESCRIPTION
If you specify the name of a provider, rather than
a cloud, during bootstrap, then we will check to
see if that provider is capable of detecting regions.
If the specified provider is capable of detecting
regions, we'll ask it to do so and then use the
result to synthesise a "cloud".

In addition, we will now automatically select a
region if it is the only one, and there is not
one specified and no default either. This means
that if a provider detects a single region, then
we will use it without having to specify it by
name. We may later want to revise the detection
interface so that providers can specify which one
is the default (e.g. for lxd, that would be
"localhost", even if there are registered remotes).

(Review request: http://reviews.vapour.ws/r/3702/)