### PR TITLE
Add helpers for testing PostUpgradeManifold based manifolds

### DIFF
--- a/worker/proxyupdater/manifold_test.go
+++ b/worker/proxyupdater/manifold_test.go
@@ -1,0 +1,104 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package proxyupdater_test
+
+import (
+	"github.com/juju/names"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/agent"
+	"github.com/juju/juju/api/environment"
+	"github.com/juju/juju/worker"
+	proxyup "github.com/juju/juju/worker/proxyupdater"
+	workertesting "github.com/juju/juju/worker/testing"
+)
+
+type ManifoldSuite struct {
+	testing.IsolationSuite
+	newCalled, writeSystemFiles bool
+}
+
+var _ = gc.Suite(&ManifoldSuite{})
+
+func (s *ManifoldSuite) SetUpTest(c *gc.C) {
+	s.newCalled = false
+	s.PatchValue(&proxyup.New,
+		func(_ *environment.Facade, writeSystemFiles bool) (worker.Worker, error) {
+			s.newCalled = true
+			s.writeSystemFiles = writeSystemFiles
+			return nil, nil
+		},
+	)
+}
+
+func (s *ManifoldSuite) makeConfig(writeFunc func(agent.Config) bool) proxyup.ManifoldConfig {
+	return proxyup.ManifoldConfig{
+		PostUpgradeManifoldConfig: workertesting.PostUpgradeManifoldTestConfig(),
+		ShouldWriteProxyFiles:     writeFunc,
+	}
+}
+
+func (s *ManifoldSuite) TestMachineShouldWrite(c *gc.C) {
+	config := s.makeConfig(func(agent.Config) bool { return true })
+	_, err := workertesting.RunPostUpgradeManifold(
+		proxyup.Manifold(config),
+		&fakeAgent{tag: names.NewMachineTag("42")},
+		nil)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s.newCalled, jc.IsTrue)
+	c.Assert(s.writeSystemFiles, jc.IsTrue)
+}
+
+func (s *ManifoldSuite) TestMachineShouldntWrite(c *gc.C) {
+	config := s.makeConfig(func(agent.Config) bool { return false })
+	_, err := workertesting.RunPostUpgradeManifold(
+		proxyup.Manifold(config),
+		&fakeAgent{tag: names.NewMachineTag("42")},
+		nil)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s.newCalled, jc.IsTrue)
+	c.Assert(s.writeSystemFiles, jc.IsFalse)
+}
+
+func (s *ManifoldSuite) TestUnit(c *gc.C) {
+	config := s.makeConfig(nil)
+	_, err := workertesting.RunPostUpgradeManifold(
+		proxyup.Manifold(config),
+		&fakeAgent{tag: names.NewUnitTag("foo/0")},
+		nil)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s.newCalled, jc.IsTrue)
+	c.Assert(s.writeSystemFiles, jc.IsFalse)
+}
+
+func (s *ManifoldSuite) TestNonAgent(c *gc.C) {
+	config := s.makeConfig(nil)
+	_, err := workertesting.RunPostUpgradeManifold(
+		proxyup.Manifold(config),
+		&fakeAgent{tag: names.NewUserTag("foo")},
+		nil)
+	c.Assert(err, gc.ErrorMatches, "unknown agent type:.+")
+	c.Assert(s.newCalled, jc.IsFalse)
+	c.Assert(s.writeSystemFiles, jc.IsFalse)
+}
+
+type fakeAgent struct {
+	agent.Agent
+	tag names.Tag
+}
+
+func (a *fakeAgent) CurrentConfig() agent.Config {
+	return &fakeConfig{tag: a.tag}
+}
+
+type fakeConfig struct {
+	agent.Config
+	tag names.Tag
+}
+
+func (c *fakeConfig) Tag() names.Tag {
+	return c.tag
+}

--- a/worker/testing/postupgrade.go
+++ b/worker/testing/postupgrade.go
@@ -28,7 +28,7 @@ func PostUpgradeManifoldTestConfig() util.PostUpgradeManifoldConfig {
 // required to successfully pass PostUpgradeManifold's checks and then
 // runs the manifold start func.
 //
-// An agent and apiCaller maybe optionally provided. If they are nil,
+// An agent and apiCaller may be optionally provided. If they are nil,
 // dummy barely-good-enough default will be used (these dummies are
 // fine not actually used for much).
 func RunPostUpgradeManifold(

--- a/worker/testing/postupgrade.go
+++ b/worker/testing/postupgrade.go
@@ -1,0 +1,56 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package testing
+
+import (
+	"github.com/juju/juju/agent"
+	"github.com/juju/juju/api/base"
+	basetesting "github.com/juju/juju/api/base/testing"
+	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/dependency"
+	dt "github.com/juju/juju/worker/dependency/testing"
+	"github.com/juju/juju/worker/util"
+)
+
+// PostUpgradeManifoldTestConfig returns a PostUpgradeManifoldConfig
+// suitable for use with RunPostUpgradeManifold.
+func PostUpgradeManifoldTestConfig() util.PostUpgradeManifoldConfig {
+	return util.PostUpgradeManifoldConfig{
+		AgentName:         "agent-name",
+		APICallerName:     "api-caller-name",
+		UpgradeWaiterName: "upgradewaiter-name",
+	}
+}
+
+// RunPostUpgradeManifold is useful for testing manifolds based on
+// PostUpgradeManifold. It takes the manifold, sets up the resources
+// required to successfully pass PostUpgradeManifold's checks and then
+// runs the manifold start func.
+//
+// An agent and apiCaller maybe optionally provided. If they are nil,
+// dummy barely-good-enough default will be used (these dummies are
+// fine not actually used for much).
+func RunPostUpgradeManifold(
+	manifold dependency.Manifold, agent agent.Agent, apiCaller base.APICaller,
+) (worker.Worker, error) {
+	if agent == nil {
+		agent = new(dummyAgent)
+	}
+	if apiCaller == nil {
+		apiCaller = basetesting.APICallerFunc(
+			func(string, int, string, string, interface{}, interface{}) error {
+				return nil
+			})
+	}
+	getResource := dt.StubGetResource(dt.StubResources{
+		"upgradewaiter-name": dt.StubResource{Output: true},
+		"agent-name":         dt.StubResource{Output: agent},
+		"api-caller-name":    dt.StubResource{Output: apiCaller},
+	})
+	return manifold.Start(getResource)
+}
+
+type dummyAgent struct {
+	agent.Agent
+}


### PR DESCRIPTION
worker/testing: Add helpers for testing PostUpgradeManifold based manifolds

These helpers simplify writing unit tests for manifolds based on PostUpgradeManifold.

---

worker/proxyupdater: Add unit tests for proxyupdater manifold

Tests like this are now easier to write thanks to the RunPostUpgradeManifold helper.



(Review request: http://reviews.vapour.ws/r/3715/)