### PR TITLE
Close Space Discovery channel even when networking not supported

### DIFF
--- a/worker/discoverspaces/discoverspaces.go
+++ b/worker/discoverspaces/discoverspaces.go
@@ -96,9 +96,11 @@ func (dw *discoverspacesWorker) loop() (err error) {
 	if ok {
 		err = dw.handleSubnets(networkingEnviron)
 		if err != nil {
+			close(dw.discoveringSpaces)
 			return errors.Trace(err)
 		}
 	}
+	close(dw.discoveringSpaces)
 
 	// TODO(mfoord): we'll have a watcher here checking if we need to
 	// update the spaces/subnets definition.
@@ -113,7 +115,6 @@ func (dw *discoverspacesWorker) loop() (err error) {
 }
 
 func (dw *discoverspacesWorker) handleSubnets(env environs.NetworkingEnviron) error {
-	defer close(dw.discoveringSpaces)
 	ok, err := env.SupportsSpaceDiscovery()
 	if err != nil {
 		return errors.Trace(err)


### PR DESCRIPTION
Properly signal that space discovery has completed (actually not started) when the provider doesn't support networking.

(Review request: http://reviews.vapour.ws/r/3716/)