### PR TITLE
juju deploy: do not ignore charm-only flags when deploying bundles

### DIFF
--- a/cmd/juju/service/bundle_test.go
+++ b/cmd/juju/service/bundle_test.go
@@ -43,6 +43,18 @@ func (s *DeployCharmStoreSuite) TestDeployBundleNotFoundCharmStore(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `cannot resolve URL "cs:bundle/no-such": bundle not found`)
 }
 
+func (s *DeployCharmStoreSuite) TestDeployBundleInvalidFlags(c *gc.C) {
+	testcharms.UploadCharm(c, s.client, "trusty/mysql-42", "mysql")
+	testcharms.UploadCharm(c, s.client, "trusty/wordpress-47", "wordpress")
+	testcharms.UploadBundle(c, s.client, "bundle/wordpress-simple-1", "wordpress-simple")
+	_, err := runDeployCommand(c, "bundle/wordpress-simple", "--config", "config.yaml")
+	c.Assert(err, gc.ErrorMatches, "Flags provided but not supported when deploying a bundle: --config.")
+	_, err = runDeployCommand(c, "bundle/wordpress-simple", "-n", "2")
+	c.Assert(err, gc.ErrorMatches, "Flags provided but not supported when deploying a bundle: -n.")
+	_, err = runDeployCommand(c, "bundle/wordpress-simple", "--series", "trusty", "--force")
+	c.Assert(err, gc.ErrorMatches, "Flags provided but not supported when deploying a bundle: --force, --series.")
+}
+
 func (s *DeployCharmStoreSuite) TestDeployBundleSuccess(c *gc.C) {
 	testcharms.UploadCharm(c, s.client, "trusty/mysql-42", "mysql")
 	testcharms.UploadCharm(c, s.client, "trusty/wordpress-47", "wordpress")

--- a/cmd/juju/service/cmd_test.go
+++ b/cmd/juju/service/cmd_test.go
@@ -113,8 +113,12 @@ func (*CmdSuite) TestDeployCommandInit(c *gc.C) {
 	for _, t := range deployTests {
 		initExpectations(t.com)
 		com, err := initDeployCommand(t.args...)
+		// Testing that the flag set is populated is good enough for the scope
+		// of this test.
+		c.Assert(com.flagSet, gc.NotNil)
+		com.flagSet = nil
 		c.Assert(err, jc.ErrorIsNil)
-		c.Assert(com, gc.DeepEquals, t.com)
+		c.Assert(com, jc.DeepEquals, t.com)
 	}
 
 	// test relative --config path

--- a/cmd/juju/service/deploy.go
+++ b/cmd/juju/service/deploy.go
@@ -71,7 +71,8 @@ type DeployCommand struct {
 	// the storage name defined in that service's charm storage metadata.
 	BundleStorage map[string]map[string]storage.Constraints
 
-	Steps []DeployStep
+	Steps   []DeployStep
+	flagSet *gnuflag.FlagSet
 }
 
 const deployDoc = `
@@ -89,7 +90,7 @@ For cs:~user/trusty/mysql
 For cs:bundle/mediawiki-single
   mediawiki-single
   bundle/mediawiki-single
-  
+
 The current series for charms is determined first by the default-series model
 setting, followed by the preferred series for the charm in the charm store.
 
@@ -210,7 +211,16 @@ func (c *DeployCommand) Info() *cmd.Info {
 	}
 }
 
+var (
+	// charmOnlyFlags and bundleOnlyFlags are used to validate flags based on
+	// whether we are deploying a charm or a bundle.
+	charmOnlyFlags  = []string{"config", "constraints", "force", "n", "networks", "num-units", "series", "to", "u", "upgrade"}
+	bundleOnlyFlags = []string{}
+)
+
 func (c *DeployCommand) SetFlags(f *gnuflag.FlagSet) {
+	// Keep above charmOnlyFlags and bundleOnlyFlags lists updated when adding
+	// new flags.
 	c.UnitCommandBase.SetFlags(f)
 	f.IntVar(&c.NumUnits, "n", 1, "number of service units to deploy for principal charms")
 	f.BoolVar(&c.BumpRevision, "u", false, "increment local charm directory revision (DEPRECATED)")
@@ -225,6 +235,7 @@ func (c *DeployCommand) SetFlags(f *gnuflag.FlagSet) {
 	for _, step := range c.Steps {
 		step.SetFlags(f)
 	}
+	c.flagSet = f
 }
 
 func (c *DeployCommand) Init(args []string) error {
@@ -366,6 +377,9 @@ func (c *DeployCommand) deployCharmOrBundle(ctx *cmd.Context, client *api.Client
 	}
 	// Handle a bundle.
 	if bundleData != nil {
+		if flags := getFlags(c.flagSet, charmOnlyFlags); len(flags) > 0 {
+			return errors.Errorf("Flags provided but not supported when deploying a bundle: %s.", strings.Join(flags, ", "))
+		}
 		if err := deployBundle(
 			bundleData, client, &deployer, csClient,
 			repoPath, conf, ctx, c.BundleStorage,
@@ -376,6 +390,9 @@ func (c *DeployCommand) deployCharmOrBundle(ctx *cmd.Context, client *api.Client
 		return nil
 	}
 	// Handle a charm.
+	if flags := getFlags(c.flagSet, bundleOnlyFlags); len(flags) > 0 {
+		return errors.Errorf("Flags provided but not supported when deploying a charm: %s.", strings.Join(flags, ", "))
+	}
 	// Get the series to use.
 	series, message, err := charmSeries(c.Series, charmOrBundleURL.Series, supportedSeries, c.Force, conf)
 	if charm.IsUnsupportedSeriesError(err) {
@@ -635,4 +652,25 @@ func (s *metricsCredentialsAPIImpl) Close() error {
 
 var getMetricCredentialsAPI = func(state api.Connection) (metricCredentialsAPI, error) {
 	return &metricsCredentialsAPIImpl{api: apiservice.NewClient(state), state: state}, nil
+}
+
+// getFlags returns the flags with the given names. Only flags that are set and
+// whose name is included in flagNames are included.
+func getFlags(flagSet *gnuflag.FlagSet, flagNames []string) []string {
+	flags := make([]string, 0, flagSet.NFlag())
+	flagSet.Visit(func(flag *gnuflag.Flag) {
+		for _, name := range flagNames {
+			if flag.Name == name {
+				flags = append(flags, flagWithMinus(name))
+			}
+		}
+	})
+	return flags
+}
+
+func flagWithMinus(name string) string {
+	if len(name) > 1 {
+		return "--" + name
+	}
+	return "-" + name
 }

--- a/cmd/juju/service/deploy_test.go
+++ b/cmd/juju/service/deploy_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"sort"
 	"strings"
 
 	"github.com/juju/errors"
@@ -27,6 +28,7 @@ import (
 	"gopkg.in/macaroon-bakery.v1/bakery/checkers"
 	"gopkg.in/macaroon-bakery.v1/bakerytest"
 	"gopkg.in/macaroon-bakery.v1/httpbakery"
+	"launchpad.net/gnuflag"
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/apiserver/params"
@@ -1024,6 +1026,24 @@ func (s *DeploySuite) TestAddMetricCredentialsDefaultForUnmeteredCharm(c *gc.C) 
 	curl := charm.MustParseURL("local:trusty/dummy-1")
 	s.AssertService(c, "dummy", curl, 1, 0)
 	c.Assert(called, jc.IsFalse)
+}
+
+func (s *DeploySuite) TestDeployFlags(c *gc.C) {
+	command := DeployCommand{}
+	flagSet := gnuflag.NewFlagSet(command.Info().Name, gnuflag.ContinueOnError)
+	command.SetFlags(flagSet)
+	c.Assert(command.flagSet, jc.DeepEquals, flagSet)
+	// Add to the slice below if a new flag is introduced which is valid for
+	// both charms and bundles.
+	charmAndBundleFlags := []string{"repository", "storage"}
+	var allFlags []string
+	flagSet.VisitAll(func(flag *gnuflag.Flag) {
+		allFlags = append(allFlags, flag.Name)
+	})
+	declaredFlags := append(charmAndBundleFlags, charmOnlyFlags...)
+	declaredFlags = append(declaredFlags, bundleOnlyFlags...)
+	sort.Strings(declaredFlags)
+	c.Assert(declaredFlags, jc.DeepEquals, allFlags)
 }
 
 func (s *DeployCharmStoreSuite) TestDeployCharmsEndpointNotImplemented(c *gc.C) {


### PR DESCRIPTION
... and vice versa.
This fixes https://bugs.launchpad.net/juju-core/+bug/1540701


(Review request: http://reviews.vapour.ws/r/3719/)