### PR TITLE
cmd: report compiler version, not just flavor

### DIFF
--- a/cmd/supercommand.go
+++ b/cmd/supercommand.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"runtime"
 
 	"github.com/juju/cmd"
 	"github.com/juju/loggo"
@@ -55,5 +56,5 @@ func NewSubSuperCommand(p cmd.SuperCommandParams) *cmd.SuperCommand {
 }
 
 func runNotifier(name string) {
-	logger.Infof("running %s [%s %s]", name, version.Current, version.Compiler)
+	logger.Infof("running %s [%s %s %s]", name, version.Current, runtime.Compiler, runtime.Version())
 }

--- a/version/version.go
+++ b/version/version.go
@@ -12,7 +12,6 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"runtime"
 	"strconv"
 	"strings"
 
@@ -36,8 +35,6 @@ var osReleaseFile = "/etc/os-release"
 // "FORCE-VERSION" is present in the same directory as the running
 // binary, it will override this.
 var Current = MustParse(version)
-
-var Compiler = runtime.Compiler
 
 func init() {
 	toolsDir := filepath.Dir(os.Args[0])

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -5,7 +5,6 @@ package version_test
 
 import (
 	"encoding/json"
-	"runtime"
 	"strings"
 
 	jc "github.com/juju/testing/checkers"
@@ -319,8 +318,4 @@ func (*suite) TestParseMajorMinor(c *gc.C) {
 			c.Check(minor, gc.Equals, test.expectMinor)
 		}
 	}
-}
-
-func (s *suite) TestCompiler(c *gc.C) {
-	c.Assert(version.Compiler, gc.Equals, runtime.Compiler)
 }


### PR DESCRIPTION
With the advent of Go 1.5 and newer on some build servers it is important
to record the _version_ of the compiler, not simply its flavour: gc or gccgo.

(Review request: http://reviews.vapour.ws/r/3732/)