### PR TITLE
apiserver: remove incorrect non error handling

### DIFF
--- a/apiserver/logsink.go
+++ b/apiserver/logsink.go
@@ -6,13 +6,11 @@ package apiserver
 import (
 	"io"
 	"net/http"
-	"os"
 	"path/filepath"
 	"strings"
 	"time"
 
 	"github.com/juju/errors"
-	"github.com/juju/utils"
 	"golang.org/x/net/websocket"
 	"gopkg.in/natefinch/lumberjack.v2"
 
@@ -22,14 +20,7 @@ import (
 )
 
 func newLogSinkHandler(h httpContext, logDir string) http.Handler {
-
 	logPath := filepath.Join(logDir, "logsink.log")
-	if err := primeLogFile(logPath); err != nil {
-		// This isn't a fatal error so log and continue if priming
-		// fails.
-		logger.Errorf("Unable to prime %s (proceeding anyway): %v", logPath, err)
-	}
-
 	return &logSinkHandler{
 		ctxt: h,
 		fileLogger: &lumberjack.Logger{
@@ -38,18 +29,6 @@ func newLogSinkHandler(h httpContext, logDir string) http.Handler {
 			MaxBackups: 2,
 		},
 	}
-}
-
-// primeLogFile ensures the logsink log file is created with the
-// correct mode and ownership.
-func primeLogFile(path string) error {
-	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY, 0600)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	f.Close()
-	err = utils.ChownPath(path, "syslog")
-	return errors.Trace(err)
 }
 
 type logSinkHandler struct {

--- a/apiserver/logsink_test.go
+++ b/apiserver/logsink_test.go
@@ -8,9 +8,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
-	"os"
 	"path/filepath"
-	"runtime"
 	"time"
 
 	"github.com/juju/loggo"
@@ -185,15 +183,6 @@ func (s *logsinkSuite) TestLogging(c *gc.C) {
 	line0 := modelUUID + " machine-0: 2015-06-01 23:02:01 INFO some.where foo.go:42 all is well\n"
 	line1 := modelUUID + " machine-0: 2015-06-01 23:02:02 ERROR else.where bar.go:99 oh noes\n"
 	c.Assert(string(logContents), gc.Equals, line0+line1)
-
-	// Check the file mode is as expected. This doesn't work on
-	// Windows (but this code is very unlikely to run on Windows so
-	// it's ok).
-	if runtime.GOOS != "windows" {
-		info, err := os.Stat(logPath)
-		c.Assert(err, jc.ErrorIsNil)
-		c.Assert(info.Mode(), gc.Equals, os.FileMode(0600))
-	}
 }
 
 func (s *logsinkSuite) dialWebsocket(c *gc.C) *websocket.Conn {


### PR DESCRIPTION
logsink called primeLogFile, but then discarded the error, which it
said was not an error, but logged it at error level anyway.

There was also a test for this code, which did not exercise the error
condition - and, in working on an unrelated bug I spotted this line

    [LOG] 0:00.175 ERROR juju.apiserver Unable to prime /tmp/check-6129484611666145821/9/logsink.log (proceeding anyway): chown /tmp/check-6129484611666145821/9/logsink.log: operation not permitted

This code failed, logged, and continued on unperturbed.

Bottom line, a failure to prime the log file is either an error, and
the code should return at this point -- or -- priming the log file is
not necessary, so we can just delete the whole thing.

(Review request: http://reviews.vapour.ws/r/3734/)