### PR TITLE
Test space discovery on providers without NetworkingEnviron support

### DIFF
--- a/environs/networking.go
+++ b/environs/networking.go
@@ -11,6 +11,9 @@ import (
 	"github.com/juju/juju/network"
 )
 
+// SupportsNetworking is a convenience helper to check if an environment
+// supports networking. It returns an interface containing Environ and
+// Networking in this case.
 var SupportsNetworking = supportsNetworking
 
 // Networking interface defines methods that environments
@@ -68,9 +71,6 @@ type NetworkingEnviron interface {
 	Networking
 }
 
-// SupportsNetworking is a convenience helper to check if an environment
-// supports networking. It returns an interface containing Environ and
-// Networking in this case.
 func supportsNetworking(environ Environ) (NetworkingEnviron, bool) {
 	ne, ok := environ.(NetworkingEnviron)
 	return ne, ok

--- a/environs/networking.go
+++ b/environs/networking.go
@@ -11,6 +11,8 @@ import (
 	"github.com/juju/juju/network"
 )
 
+var SupportsNetworking = supportsNetworking
+
 // Networking interface defines methods that environments
 // with networking capabilities must implement.
 type Networking interface {
@@ -69,7 +71,7 @@ type NetworkingEnviron interface {
 // SupportsNetworking is a convenience helper to check if an environment
 // supports networking. It returns an interface containing Environ and
 // Networking in this case.
-func SupportsNetworking(environ Environ) (NetworkingEnviron, bool) {
+func supportsNetworking(environ Environ) (NetworkingEnviron, bool) {
 	ne, ok := environ.(NetworkingEnviron)
 	return ne, ok
 }

--- a/worker/discoverspaces/discoverspaces.go
+++ b/worker/discoverspaces/discoverspaces.go
@@ -85,10 +85,12 @@ func (dw *discoverspacesWorker) Wait() error {
 func (dw *discoverspacesWorker) loop() (err error) {
 	modelCfg, err := dw.api.ModelConfig()
 	if err != nil {
+		close(dw.discoveringSpaces)
 		return err
 	}
 	model, err := environs.New(modelCfg)
 	if err != nil {
+		close(dw.discoveringSpaces)
 		return err
 	}
 	networkingModel, ok := environs.SupportsNetworking(model)

--- a/worker/discoverspaces/discoverspaces.go
+++ b/worker/discoverspaces/discoverspaces.go
@@ -83,7 +83,7 @@ func (dw *discoverspacesWorker) Wait() error {
 }
 
 func (dw *discoverspacesWorker) loop() (err error) {
-	maybeClose := func() {
+	ensureClosed := func() {
 		select {
 		case <-dw.discoveringSpaces:
 			// Already closed.
@@ -92,7 +92,7 @@ func (dw *discoverspacesWorker) loop() (err error) {
 			close(dw.discoveringSpaces)
 		}
 	}
-	defer maybeClose()
+	defer ensureClosed()
 	modelCfg, err := dw.api.ModelConfig()
 	if err != nil {
 		return err

--- a/worker/discoverspaces/worker_test.go
+++ b/worker/discoverspaces/worker_test.go
@@ -93,7 +93,7 @@ func (s *workerSuite) TestWorkerIsStringsWorker(c *gc.C) {
 	c.Assert(s.Worker, gc.Not(gc.FitsTypeOf), worker.FinishedWorker{})
 }
 
-func (s *workerSuite) assertSpacesDiscovered(c *gc.C) {
+func (s *workerSuite) assertSpaceDiscoveryCompleted(c *gc.C) {
 	c.Assert(s.spacesDiscovered, gc.NotNil)
 	select {
 	case <-s.spacesDiscovered:
@@ -126,7 +126,7 @@ func (s *workerSuite) TestWorkerSupportsNetworkingFalse(c *gc.C) {
 			break
 		}
 	}
-	s.assertSpacesDiscovered(c)
+	s.assertSpaceDiscoveryCompleted(c)
 }
 
 func (s *workerSuite) TestWorkerSupportsSpaceDiscoveryFalse(c *gc.C) {
@@ -143,7 +143,7 @@ func (s *workerSuite) TestWorkerSupportsSpaceDiscoveryFalse(c *gc.C) {
 			break
 		}
 	}
-	s.assertSpacesDiscovered(c)
+	s.assertSpaceDiscoveryCompleted(c)
 }
 
 func (s *workerSuite) TestWorkerDiscoversSpaces(c *gc.C) {
@@ -220,7 +220,7 @@ func (s *workerSuite) TestWorkerDiscoversSpaces(c *gc.C) {
 			c.Check(subnet.CIDR(), gc.Equals, expectedSubnet.CIDR)
 		}
 	}
-	s.assertSpacesDiscovered(c)
+	s.assertSpaceDiscoveryCompleted(c)
 }
 
 func (s *workerSuite) TestWorkerIdempotent(c *gc.C) {
@@ -271,7 +271,7 @@ func (s *workerSuite) TestSupportsSpaceDiscoveryBroken(c *gc.C) {
 	s.spacesDiscovered = spacesDiscovered
 	err := worker.Stop(newWorker)
 	c.Assert(err, gc.ErrorMatches, "dummy.SupportsSpaceDiscovery is broken")
-	s.assertSpacesDiscovered(c)
+	s.assertSpaceDiscoveryCompleted(c)
 }
 
 func (s *workerSuite) TestSpacesBroken(c *gc.C) {
@@ -282,7 +282,7 @@ func (s *workerSuite) TestSpacesBroken(c *gc.C) {
 	s.spacesDiscovered = spacesDiscovered
 	err := worker.Stop(newWorker)
 	c.Assert(err, gc.ErrorMatches, "dummy.Spaces is broken")
-	s.assertSpacesDiscovered(c)
+	s.assertSpaceDiscoveryCompleted(c)
 }
 
 func (s *workerSuite) TestWorkerIgnoresExistingSpacesAndSubnets(c *gc.C) {


### PR DESCRIPTION
Test space discovery correctly closes the channel (completes) on providers without NetworkingEnviron support.

(Review request: http://reviews.vapour.ws/r/3735/)