### PR TITLE
apiserver/servicescaler

### DIFF
--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -41,6 +41,7 @@ import (
 	_ "github.com/juju/juju/apiserver/reboot"
 	_ "github.com/juju/juju/apiserver/resumer"
 	_ "github.com/juju/juju/apiserver/service"
+	_ "github.com/juju/juju/apiserver/servicescaler"
 	_ "github.com/juju/juju/apiserver/spaces"
 	_ "github.com/juju/juju/apiserver/statushistory"
 	_ "github.com/juju/juju/apiserver/storage"

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -6,6 +6,9 @@ package apiserver
 // This file imports all of the facades so they get registered at runtime.
 // When adding a new facade implementation, import it here so that its init()
 // function will get called to register it.
+//
+// TODO(fwereade): this is silly. We should be declaring our full API in *one*
+// place, not scattering it across packages and depending on magic import lists.
 import (
 	_ "github.com/juju/juju/apiserver/action"
 	_ "github.com/juju/juju/apiserver/addresser"

--- a/apiserver/servicescaler/facade.go
+++ b/apiserver/servicescaler/facade.go
@@ -1,0 +1,83 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package servicescaler
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/state/watcher"
+	"github.com/juju/names"
+)
+
+// Backend exposes functionality required by Facade.
+type Backend interface {
+
+	// WatchScaledServices returns a watcher that sends service ids
+	// that might not have enough units.
+	WatchScaledServices() state.StringsWatcher
+
+	// RescaleService ensures that the named service has at least its
+	// configured minimum unit count.
+	RescaleService(name string) error
+}
+
+// Facade allows model-manager clients to watch and rescale services.
+type Facade struct {
+	backend   Backend
+	resources *common.Resources
+}
+
+// NewFacade creates a new authorized Facade.
+func NewFacade(backend Backend, res *common.Resources, auth common.Authorizer) (*Facade, error) {
+	if !auth.AuthModelManager() {
+		return nil, common.ErrPerm
+	}
+	return &Facade{
+		backend:   backend,
+		resources: res,
+	}, nil
+}
+
+// Watch returns a watcher that sends the names of services whose
+// unit count may be below their configured minimum.
+func (facade *Facade) Watch() (params.StringsWatchResult, error) {
+	watch := facade.backend.WatchScaledServices()
+	if changes, ok := <-watch.Changes(); ok {
+		id := facade.resources.Register(watch)
+		return params.StringsWatchResult{
+			StringsWatcherId: id,
+			Changes:          changes,
+		}, nil
+	}
+	return params.StringsWatchResult{}, watcher.EnsureErr(watch)
+}
+
+// Rescale causes any supplied services to be scaled up to their
+// minimum size.
+func (facade *Facade) Rescale(args params.Entities) params.ErrorResults {
+	result := params.ErrorResults{
+		Results: make([]params.ErrorResult, len(args.Entities)),
+	}
+	for i, entity := range args.Entities {
+		err := facade.rescaleOne(entity.Tag)
+		result.Results[i].Error = common.ServerError(err)
+	}
+	return result
+}
+
+// rescaleOne scales up the supplied service, if necessary; or returns a
+// suitable error.
+func (facade *Facade) rescaleOne(tagString string) error {
+	tag, err := names.ParseTag(tagString)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	serviceTag, ok := tag.(names.ServiceTag)
+	if !ok {
+		return common.ErrPerm
+	}
+	return facade.backend.RescaleService(serviceTag.Id())
+}

--- a/apiserver/servicescaler/facade_test.go
+++ b/apiserver/servicescaler/facade_test.go
@@ -1,0 +1,102 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package servicescaler_test
+
+import (
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/apiserver/servicescaler"
+)
+
+type FacadeSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&FacadeSuite{})
+
+func (s *FacadeSuite) TestModelManager(c *gc.C) {
+	facade, err := servicescaler.NewFacade(nil, nil, auth(true))
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(facade, gc.NotNil)
+}
+
+func (s *FacadeSuite) TestNotModelManager(c *gc.C) {
+	facade, err := servicescaler.NewFacade(nil, nil, auth(false))
+	c.Check(err, gc.Equals, common.ErrPerm)
+	c.Check(facade, gc.IsNil)
+}
+
+func (s *FacadeSuite) TestWatchError(c *gc.C) {
+	fix := newWatchFixture(c, false)
+	result, err := fix.Facade.Watch()
+	c.Check(err, gc.ErrorMatches, "blammo")
+	c.Check(result, gc.DeepEquals, params.StringsWatchResult{})
+	c.Check(fix.Resources.Count(), gc.Equals, 0)
+}
+
+func (s *FacadeSuite) TestWatchSuccess(c *gc.C) {
+	fix := newWatchFixture(c, true)
+	result, err := fix.Facade.Watch()
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(result.Changes, jc.DeepEquals, []string{"pow", "zap", "kerblooie"})
+	c.Check(fix.Resources.Count(), gc.Equals, 1)
+	resource := fix.Resources.Get(result.StringsWatcherId)
+	c.Check(resource, gc.NotNil)
+}
+
+func (s *FacadeSuite) TestRescaleNonsense(c *gc.C) {
+	fix := newRescaleFixture(c)
+	result := fix.Facade.Rescale(entities("burble plink"))
+	c.Assert(result.Results, gc.HasLen, 1)
+	err := result.Results[0].Error
+	c.Check(err, gc.ErrorMatches, `"burble plink" is not a valid tag`)
+}
+
+func (s *FacadeSuite) TestRescaleUnauthorized(c *gc.C) {
+	fix := newRescaleFixture(c)
+	result := fix.Facade.Rescale(entities("unit-foo-27"))
+	c.Assert(result.Results, gc.HasLen, 1)
+	err := result.Results[0].Error
+	c.Check(err, gc.ErrorMatches, "permission denied")
+	c.Check(err, jc.Satisfies, params.IsCodeUnauthorized)
+}
+
+func (s *FacadeSuite) TestRescaleNotFound(c *gc.C) {
+	fix := newRescaleFixture(c)
+	result := fix.Facade.Rescale(entities("service-missing"))
+	c.Assert(result.Results, gc.HasLen, 1)
+	err := result.Results[0].Error
+	c.Check(err, gc.ErrorMatches, "service not found")
+	c.Check(err, jc.Satisfies, params.IsCodeNotFound)
+}
+
+func (s *FacadeSuite) TestRescaleError(c *gc.C) {
+	fix := newRescaleFixture(c)
+	result := fix.Facade.Rescale(entities("service-error"))
+	c.Assert(result.Results, gc.HasLen, 1)
+	err := result.Results[0].Error
+	c.Check(err, gc.ErrorMatches, "blammo")
+}
+
+func (s *FacadeSuite) TestRescaleSuccess(c *gc.C) {
+	fix := newRescaleFixture(c)
+	result := fix.Facade.Rescale(entities("service-expected"))
+	c.Assert(result.Results, gc.HasLen, 1)
+	err := result.Results[0].Error
+	c.Check(err, gc.IsNil)
+}
+
+func (s *FacadeSuite) TestRescaleMultiple(c *gc.C) {
+	fix := newRescaleFixture(c)
+	result := fix.Facade.Rescale(entities("service-error", "service-expected"))
+	c.Assert(result.Results, gc.HasLen, 2)
+	err0 := result.Results[0].Error
+	c.Check(err0, gc.ErrorMatches, "blammo")
+	err1 := result.Results[1].Error
+	c.Check(err1, gc.IsNil)
+}

--- a/apiserver/servicescaler/package_test.go
+++ b/apiserver/servicescaler/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package servicescaler_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/apiserver/servicescaler/shim.go
+++ b/apiserver/servicescaler/shim.go
@@ -15,35 +15,34 @@ import (
 // to change any part of it so that it were no longer *obviously* and
 // *trivially* correct, you would be Doing It Wrong.
 
-// init really ought to live somewhere else: we should be declaring our API
-// in *one* place, not scattered all over the place.
 func init() {
 	common.RegisterStandardFacade("ServiceScaler", 1, newFacade)
 }
 
 // newFacade wraps the supplied *state.State for the use of the Facade.
 func newFacade(st *state.State, res *common.Resources, auth common.Authorizer) (*Facade, error) {
-	return NewFacade(backend{st}, res, auth)
+	return NewFacade(backendShim{st}, res, auth)
 }
 
-// backend wraps a *State to implement Backend without pulling in dependencies
-// on the state package. It would be awesome if we were to put this in state
+// backendShim wraps a *State to implement Backend without pulling in direct
+// mongodb dependencies. It would be awesome if we were to put this in state
 // and test it properly there, where we have no choice but to test against
 // mongodb anyway, but that's relatively low priority...
 //
-// ...so long as it stays simple.
-type backend struct {
+// ...so long as it stays simple, and the full functionality remains tested
+// elsewhere.
+type backendShim struct {
 	st *state.State
 }
 
 // WatchScaledServices is part of the Backend interface.
-func (backend backend) WatchScaledServices() state.StringsWatcher {
-	return backend.st.WatchMinUnits()
+func (shim backendShim) WatchScaledServices() state.StringsWatcher {
+	return shim.st.WatchMinUnits()
 }
 
 // RescaleService is part of the Backend interface.
-func (backend backend) RescaleService(name string) error {
-	service, err := backend.st.Service(name)
+func (shim backendShim) RescaleService(name string) error {
+	service, err := shim.st.Service(name)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/apiserver/servicescaler/shim.go
+++ b/apiserver/servicescaler/shim.go
@@ -1,0 +1,51 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package servicescaler
+
+import (
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/state"
+)
+
+// This file contains untested shims to let us wrap state in a sensible
+// interface and avoid writing tests that depend on mongodb. If you were
+// to change any part of it so that it were no longer *obviously* and
+// *trivially* correct, you would be Doing It Wrong.
+
+// init really ought to live somewhere else: we should be declaring our API
+// in *one* place, not scattered all over the place.
+func init() {
+	common.RegisterStandardFacade("ServiceScaler", 1, newFacade)
+}
+
+// newFacade wraps the supplied *state.State for the use of the Facade.
+func newFacade(st *state.State, res *common.Resources, auth common.Authorizer) (*Facade, error) {
+	return NewFacade(backend{st}, res, auth)
+}
+
+// backend wraps a *State to implement Backend without pulling in dependencies
+// on the state package. It would be awesome if we were to put this in state
+// and test it properly there, where we have no choice but to test against
+// mongodb anyway, but that's relatively low priority...
+//
+// ...so long as it stays simple.
+type backend struct {
+	st *state.State
+}
+
+// WatchScaledServices is part of the Backend interface.
+func (backend backend) WatchScaledServices() state.StringsWatcher {
+	return backend.st.WatchMinUnits()
+}
+
+// RescaleService is part of the Backend interface.
+func (backend backend) RescaleService(name string) error {
+	service, err := backend.st.Service(name)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return service.EnsureMinUnits()
+}

--- a/apiserver/servicescaler/util_test.go
+++ b/apiserver/servicescaler/util_test.go
@@ -91,7 +91,7 @@ func (rescaleBackend) RescaleService(name string) error {
 	}
 }
 
-// watchFixture collects components needed to test the Rescale method.
+// rescaleFixture collects components needed to test the Rescale method.
 type rescaleFixture struct {
 	Facade *servicescaler.Facade
 }

--- a/apiserver/servicescaler/util_test.go
+++ b/apiserver/servicescaler/util_test.go
@@ -1,0 +1,112 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package servicescaler_test
+
+import (
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/apiserver/servicescaler"
+	"github.com/juju/juju/state"
+)
+
+// mockAuth implements common.Authorizer for the tests' convenience.
+type mockAuth struct {
+	common.Authorizer
+	modelManager bool
+}
+
+func (mock mockAuth) AuthModelManager() bool {
+	return mock.modelManager
+}
+
+// auth is a convenience constructor for a mockAuth.
+func auth(modelManager bool) common.Authorizer {
+	return mockAuth{modelManager: modelManager}
+}
+
+// mockWatcher implements state.StringsWatcher for the tests' convenience.
+type mockWatcher struct {
+	state.StringsWatcher
+	working bool
+}
+
+func (mock *mockWatcher) Changes() <-chan []string {
+	ch := make(chan []string, 1)
+	if mock.working {
+		ch <- []string{"pow", "zap", "kerblooie"}
+	} else {
+		close(ch)
+	}
+	return ch
+}
+
+func (mock *mockWatcher) Err() error {
+	return errors.New("blammo")
+}
+
+// watchBackend implements servicescaler.Backend for the convenience of
+// the tests for the Watch method.
+type watchBackend struct {
+	servicescaler.Backend
+	working bool
+}
+
+func (backend *watchBackend) WatchScaledServices() state.StringsWatcher {
+	return &mockWatcher{working: backend.working}
+}
+
+// watchFixture collects components needed to test the Watch method.
+type watchFixture struct {
+	Facade    *servicescaler.Facade
+	Resources *common.Resources
+}
+
+func newWatchFixture(c *gc.C, working bool) *watchFixture {
+	backend := &watchBackend{working: working}
+	resources := common.NewResources()
+	facade, err := servicescaler.NewFacade(backend, resources, auth(true))
+	c.Assert(err, jc.ErrorIsNil)
+	return &watchFixture{facade, resources}
+}
+
+// rescaleBackend implements servicescaler.Backend for the convenience of
+// the tests for the Rescale method.
+type rescaleBackend struct {
+	servicescaler.Backend
+}
+
+func (rescaleBackend) RescaleService(name string) error {
+	switch name {
+	case "expected":
+		return nil
+	case "missing":
+		return errors.NotFoundf("service")
+	default:
+		return errors.New("blammo")
+	}
+}
+
+// watchFixture collects components needed to test the Rescale method.
+type rescaleFixture struct {
+	Facade *servicescaler.Facade
+}
+
+func newRescaleFixture(c *gc.C) *rescaleFixture {
+	facade, err := servicescaler.NewFacade(rescaleBackend{}, nil, auth(true))
+	c.Assert(err, jc.ErrorIsNil)
+	return &rescaleFixture{facade}
+}
+
+// entities is a convenience constructor for params.Entities.
+func entities(tags ...string) params.Entities {
+	entities := params.Entities{Entities: make([]params.Entity, len(tags))}
+	for i, tag := range tags {
+		entities.Entities[i].Tag = tag
+	}
+	return entities
+}


### PR DESCRIPTION
will replace minunitsworker, which today still uses state directly

(Review request: http://reviews.vapour.ws/r/3743/)