### PR TITLE
add dependency.Flag manifold wrapper

### DIFF
--- a/worker/dependency/flag.go
+++ b/worker/dependency/flag.go
@@ -1,0 +1,50 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package dependency
+
+import (
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/worker"
+)
+
+// Flag represents a single boolean used to determine whether a given
+// manifold worker should run.
+type Flag interface {
+
+	// Check returns the flag's value. Check calls must *always* return
+	// the same value for a given instatiation of the type implementing
+	// Flag.
+	Check() bool
+}
+
+// WithFlag returns a manifold, based on that supplied, which will only run
+// a worker when the named flag manifold's worker is active and set.
+func WithFlag(base Manifold, flagName string) Manifold {
+	return Manifold{
+		Inputs: append(base.Inputs, flagName),
+		Start:  flagWrap(base.Start, flagName),
+		Output: base.Output,
+	}
+}
+
+// flagWrap returns a StartFunc that will return ErrMissing if the named flag
+// resource is not active or not set.
+func flagWrap(inner StartFunc, flagName string) StartFunc {
+	return func(getResource GetResourceFunc) (worker.Worker, error) {
+		var flag Flag
+		if err := getResource(flagName, &flag); err != nil {
+			return nil, errors.Trace(err)
+		}
+		if !flag.Check() {
+			return nil, ErrMissing
+		}
+
+		worker, err := inner(getResource)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		return worker, nil
+	}
+}

--- a/worker/dependency/flag_test.go
+++ b/worker/dependency/flag_test.go
@@ -1,0 +1,110 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package dependency_test
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/dependency"
+	dt "github.com/juju/juju/worker/dependency/testing"
+)
+
+type FlagSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&FlagSuite{})
+
+func (s *FlagSuite) TestEmptyInputs(c *gc.C) {
+	wrapped := dependency.WithFlag(dependency.Manifold{}, "blob")
+	c.Check(wrapped.Inputs, jc.DeepEquals, []string{"blob"})
+}
+
+func (s *FlagSuite) TestNonEmptyInputs(c *gc.C) {
+	base := dependency.Manifold{
+		Inputs: []string{"foo", "bar"},
+	}
+	wrapped := dependency.WithFlag(base, "blib")
+	expect := []string{"foo", "bar", "blib"}
+	c.Check(wrapped.Inputs, jc.DeepEquals, expect)
+}
+
+func (s *FlagSuite) TestEmptyOutput(c *gc.C) {
+	wrapped := dependency.WithFlag(dependency.Manifold{}, "blob")
+	c.Check(wrapped.Output, gc.IsNil)
+}
+
+func (s *FlagSuite) TestNonEmptyOutput(c *gc.C) {
+	output := func(_ worker.Worker, _ interface{}) error {
+		panic("splat")
+	}
+	base := dependency.Manifold{
+		Output: output,
+	}
+	wrapped := dependency.WithFlag(base, "blah")
+	tryOutput := func() {
+		wrapped.Output(nil, nil)
+	}
+	c.Check(tryOutput, gc.PanicMatches, "splat")
+}
+
+func (s *FlagSuite) TestStartMissingFlag(c *gc.C) {
+	wrapped := dependency.WithFlag(dependency.Manifold{}, "foo")
+	getResource := dt.StubGetResource(dt.StubResources{
+		"foo": dt.StubResource{Error: dependency.ErrMissing},
+	})
+	worker, err := wrapped.Start(getResource)
+	c.Check(worker, gc.IsNil)
+	c.Check(errors.Cause(err), gc.Equals, dependency.ErrMissing)
+}
+
+func (s *FlagSuite) TestStartNotFlag(c *gc.C) {
+	wrapped := dependency.WithFlag(dependency.Manifold{}, "foo")
+	getResource := dt.StubGetResource(dt.StubResources{
+		"foo": dt.StubResource{Output: true},
+	})
+	worker, err := wrapped.Start(getResource)
+	c.Check(worker, gc.IsNil)
+	c.Check(err, gc.ErrorMatches, `cannot set true into \*dependency.Flag`)
+}
+
+func (s *FlagSuite) TestStartFalseFlag(c *gc.C) {
+	wrapped := dependency.WithFlag(dependency.Manifold{}, "foo")
+	getResource := dt.StubGetResource(dt.StubResources{
+		"foo": dt.StubResource{Output: stubFlag(false)},
+	})
+	worker, err := wrapped.Start(getResource)
+	c.Check(worker, gc.IsNil)
+	c.Check(errors.Cause(err), gc.Equals, dependency.ErrMissing)
+}
+
+func (s *FlagSuite) TestStartTrueFlag(c *gc.C) {
+	expectWorker := &stubWorker{}
+	base := dependency.Manifold{
+		Start: func(_ dependency.GetResourceFunc) (worker.Worker, error) {
+			return expectWorker, nil
+		},
+	}
+	wrapped := dependency.WithFlag(base, "foo")
+	getResource := dt.StubGetResource(dt.StubResources{
+		"foo": dt.StubResource{Output: stubFlag(true)},
+	})
+	worker, err := wrapped.Start(getResource)
+	c.Check(worker, gc.Equals, expectWorker)
+	c.Check(err, jc.ErrorIsNil)
+}
+
+type stubFlag bool
+
+func (flag stubFlag) Check() bool {
+	return bool(flag)
+}
+
+type stubWorker struct {
+	worker.Worker
+}


### PR DESCRIPTION
main intent is to be able to simply wrap a pre-existing manifold with one of these so we can add simple non-resource dependencies without having to rewrite all the manifold configs that already exist.

(Review request: http://reviews.vapour.ws/r/3744/)