### PR TITLE
Backend for user/controller registration

### DIFF
--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -400,6 +400,11 @@ func (srv *Server) run(lis net.Listener) {
 			ctxt: httpCtxt,
 		},
 	)
+	handleAll(mux, "/register",
+		&registerUserHandler{
+			ctxt: httpCtxt,
+		},
+	)
 	handleAll(mux, "/", http.HandlerFunc(srv.apiHandler))
 
 	go func() {

--- a/apiserver/params/registration.go
+++ b/apiserver/params/registration.go
@@ -1,0 +1,53 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package params
+
+// SecretKeyLoginRequest contains the parameters for completing
+// the registration of a user. The request contains the tag of
+// the user, and an encrypted and authenticated payload that
+// proves that the requester has a secret key recorded on the
+// controller.
+type SecretKeyLoginRequest struct {
+	// User is the tag-representation of the user that the
+	// requester wishes to authenticate as.
+	User string `json:"user"`
+
+	// Nonce is the nonce used by the client to encrypt
+	// and authenticate PayloadCiphertext.
+	Nonce []byte `json:"nonce"`
+
+	// PayloadCiphertext is the encrypted and authenticated
+	// payload. The payload is encrypted/authenticated using
+	// NaCl Secretbox.
+	PayloadCiphertext []byte `json:"ciphertext"`
+}
+
+// SecretKeyLoginRequestPayload is JSON-encoded and then encrypted
+// and authenticated with the NaCl Secretbox algorithm.
+type SecretKeyLoginRequestPayload struct {
+	// Password is the new password to set for the user.
+	Password string `json:"password"`
+}
+
+// SecretKeyLoginResponse contains the result of completing a user
+// registration. This contains an encrypted and authenticated payload,
+// containing the information necessary to securely log into the
+// controller via the standard password authentication method.
+type SecretKeyLoginResponse struct {
+	// Nonce is the nonce used by the server to encrypt and
+	// authenticate PayloadCiphertext.
+	Nonce []byte `json:"nonce"`
+
+	// PayloadCiphertext is the encrypted and authenticated
+	// payload, which is a JSON-encoded SecretKeyLoginResponsePayload.
+	PayloadCiphertext []byte `json:"ciphertext"`
+}
+
+// SecretKeyLoginResponsePayload is JSON-encoded and then encrypted
+// and authenticated with the NaCl Secretbox algorithm.
+type SecretKeyLoginResponsePayload struct {
+	// CACert is the CA certificate, required to establish a secure
+	// TLS connection to the Juju controller
+	CACert string `json:"ca-cert"`
+}

--- a/apiserver/params/usermanager.go
+++ b/apiserver/params/usermanager.go
@@ -44,7 +44,17 @@ type AddUsers struct {
 type AddUser struct {
 	Username    string `json:"username"`
 	DisplayName string `json:"display-name"`
-	Password    string `json:"password"`
+
+	// Password is optional. If it is empty, then
+	// a secret key will be generated for the user
+	// and returned in AddUserResult. It will not
+	// be possible to login with a password until
+	// registration with the secret key is completed.
+	Password string `json:"password,omitempty"`
+
+	// Disable controls whether or not the user should
+	// be disabled at creation time.
+	Disable bool `json:"disable,omitempty"`
 }
 
 // AddUserResults holds the results of the bulk AddUser API call.
@@ -52,8 +62,11 @@ type AddUserResults struct {
 	Results []AddUserResult `json:"results"`
 }
 
-// AddUserResult returns the tag of the newly created user, or an error.
+// AddUserResult returns the tag of the newly created user
+// and the secret key required to complete registration,
+// or an error.
 type AddUserResult struct {
-	Tag   string `json:"tag,omitempty"`
-	Error *Error `json:"error,omitempty"`
+	Tag       string `json:"tag,omitempty"`
+	SecretKey []byte `json:"secret-key,omitempty"`
+	Error     *Error `json:"error,omitempty"`
 }

--- a/apiserver/params/usermanager.go
+++ b/apiserver/params/usermanager.go
@@ -51,10 +51,6 @@ type AddUser struct {
 	// be possible to login with a password until
 	// registration with the secret key is completed.
 	Password string `json:"password,omitempty"`
-
-	// Disable controls whether or not the user should
-	// be disabled at creation time.
-	Disable bool `json:"disable,omitempty"`
 }
 
 // AddUserResults holds the results of the bulk AddUser API call.

--- a/apiserver/registration.go
+++ b/apiserver/registration.go
@@ -1,0 +1,159 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package apiserver
+
+import (
+	"crypto/rand"
+	"encoding/json"
+	"io"
+	"io/ioutil"
+	"net/http"
+
+	"golang.org/x/crypto/nacl/secretbox"
+
+	"github.com/juju/errors"
+	"github.com/juju/names"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/state"
+)
+
+const (
+	secretboxNonceLength = 24
+	secretboxKeyLength   = 32
+)
+
+// registerUserHandler is an http.Handler for the "/register" endpoint. This is
+// used to complete a secure user registration process, and provide controller
+// login credentials.
+type registerUserHandler struct {
+	ctxt httpContext
+}
+
+// ServeHTTP implements the http.Handler interface.
+func (h *registerUserHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	if req.Method != "POST" {
+		sendError(w, errors.MethodNotAllowedf("unsupported method: %q", req.Method))
+		return
+	}
+	st, err := h.ctxt.stateForRequestUnauthenticated(req)
+	if err != nil {
+		sendError(w, err)
+		return
+	}
+	response, err := h.processPost(req, st)
+	if err != nil {
+		sendError(w, err)
+		return
+	}
+	sendStatusAndJSON(w, http.StatusOK, response)
+}
+
+// The client will POST to the "/register" endpoint with a JSON-encoded
+// params.SecretKeyLoginRequest. This contains the tag of the user they
+// are registering, a (supposedly) unique nonce, and a ciphertext which
+// is the result of concatenating the user and nonce values, and then
+// encrypting and authenticating them with the NaCl Secretbox algorithm.
+//
+// If the server can decrypt the ciphertext, then it knows the client
+// has the required secret key; thus they are authenticated. The client
+// does not have the CA certificate for communicating securely with the
+// server, and so must also authenticate the server. The server will
+// similarly generate a unique nonce and encrypt the response payload
+// using the same secret key as the client. If the client can decrypt
+// the payload, it knows the server has the required secret key; thus
+// it is also authenticated.
+//
+// NOTE(axw) it is important that the client and server choose their
+// own nonces, because reusing a nonce means that the key-stream can
+// be revealed.
+func (h *registerUserHandler) processPost(req *http.Request, st *state.State) (*params.SecretKeyLoginResponse, error) {
+
+	data, err := ioutil.ReadAll(req.Body)
+	if err != nil {
+		return nil, err
+	}
+	var loginRequest params.SecretKeyLoginRequest
+	if err := json.Unmarshal(data, &loginRequest); err != nil {
+		return nil, err
+	}
+
+	// Basic validation: ensure that the request contains a valid user tag,
+	// nonce, and ciphertext of the expected length.
+	userTag, err := names.ParseUserTag(loginRequest.User)
+	if err != nil {
+		return nil, err
+	}
+	if len(loginRequest.Nonce) != secretboxNonceLength {
+		return nil, errors.NotValidf("nonce")
+	}
+
+	// Decrypt the ciphertext with the user's secret key (if it has one).
+	user, err := st.User(userTag)
+	if err != nil {
+		return nil, err
+	}
+	if len(user.SecretKey()) != secretboxKeyLength {
+		return nil, errors.NotFoundf("secret key for user %q", user.Name())
+	}
+	var key [secretboxKeyLength]byte
+	var nonce [secretboxNonceLength]byte
+	copy(key[:], user.SecretKey())
+	copy(nonce[:], loginRequest.Nonce)
+	payloadBytes, ok := secretbox.Open(nil, loginRequest.PayloadCiphertext, &nonce, &key)
+	if !ok {
+		// Cannot decrypt the ciphertext, which implies that the secret
+		// key specified by the client is invalid.
+		return nil, errors.NotValidf("secret key")
+	}
+
+	// Unmarshal the request payload, which contains the new password to
+	// set for the user.
+	var requestPayload params.SecretKeyLoginRequestPayload
+	if err := json.Unmarshal(payloadBytes, &requestPayload); err != nil {
+		return nil, errors.Annotate(err, "cannot unmarshal payload")
+	}
+	if err := user.SetPassword(requestPayload.Password); err != nil {
+		return nil, errors.Annotate(err, "setting new password")
+	}
+
+	// Respond with the CA-cert and password, encrypted again with the
+	// secret key.
+	responsePayload, err := h.getSecretKeyLoginResponsePayload(st)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	payloadBytes, err = json.Marshal(responsePayload)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if _, err := rand.Read(nonce[:]); err != nil {
+		return nil, errors.Trace(err)
+	}
+	response := &params.SecretKeyLoginResponse{
+		Nonce:             nonce[:],
+		PayloadCiphertext: secretbox.Seal(nil, payloadBytes, &nonce, &key),
+	}
+	return response, nil
+}
+
+// getSecretKeyLoginResponsePayload returns the information required by the
+// client to login to the controller securely.
+func (h *registerUserHandler) getSecretKeyLoginResponsePayload(
+	st *state.State,
+) (*params.SecretKeyLoginResponsePayload, error) {
+	payload := params.SecretKeyLoginResponsePayload{
+		CACert: st.CACert(),
+	}
+	return &payload, nil
+}
+
+// sendError sends a JSON-encoded error response.
+func (h *registerUserHandler) sendError(w io.Writer, req *http.Request, err error) {
+	if err != nil {
+		logger.Errorf("returning error from %s %s: %s", req.Method, req.URL.Path, errors.Details(err))
+	}
+	sendJSON(w, &params.ErrorResult{Error: common.ServerError(err)})
+}

--- a/apiserver/registration.go
+++ b/apiserver/registration.go
@@ -10,10 +10,9 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	"golang.org/x/crypto/nacl/secretbox"
-
 	"github.com/juju/errors"
 	"github.com/juju/names"
+	"golang.org/x/crypto/nacl/secretbox"
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"

--- a/apiserver/registration_test.go
+++ b/apiserver/registration_test.go
@@ -1,0 +1,207 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package apiserver_test
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+
+	"golang.org/x/crypto/nacl/secretbox"
+
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/testing/httptesting"
+	"github.com/juju/utils"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/state"
+)
+
+type registrationSuite struct {
+	authHttpSuite
+	bob *state.User
+}
+
+var _ = gc.Suite(&registrationSuite{})
+
+func (s *registrationSuite) SetUpTest(c *gc.C) {
+	s.authHttpSuite.SetUpTest(c)
+	bob, err := s.BackingState.AddUserWithSecretKey("bob", "", "admin")
+	c.Assert(err, jc.ErrorIsNil)
+	s.bob = bob
+}
+
+func (s *registrationSuite) assertErrorResponse(c *gc.C, resp *http.Response, expCode int, expError string) {
+	body := assertResponse(c, resp, expCode, params.ContentTypeJSON)
+	var result params.ErrorResult
+	s.unmarshal(c, body, &result)
+	c.Assert(result.Error, gc.NotNil)
+	c.Assert(result.Error, gc.Matches, expError)
+}
+
+func (s *registrationSuite) assertResponse(c *gc.C, resp *http.Response) params.SecretKeyLoginResponse {
+	body := assertResponse(c, resp, http.StatusOK, params.ContentTypeJSON)
+	var response params.SecretKeyLoginResponse
+	s.unmarshal(c, body, &response)
+	return response
+}
+
+func (*registrationSuite) unmarshal(c *gc.C, body []byte, out interface{}) {
+	err := json.Unmarshal(body, out)
+	c.Assert(err, jc.ErrorIsNil, gc.Commentf("body: %s", body))
+}
+
+func (s *registrationSuite) registrationURL(c *gc.C) string {
+	url := s.baseURL(c)
+	url.Path = "/register"
+	return url.String()
+}
+
+func (s *registrationSuite) TestRegister(c *gc.C) {
+	validNonce := []byte(strings.Repeat("X", 24))
+	secretKey := s.bob.SecretKey()
+	ciphertext := s.sealBox(c, validNonce, secretKey, `{"password": "hunter2"}`)
+	resp := httptesting.Do(c, httptesting.DoRequestParams{
+		Do:     utils.GetNonValidatingHTTPClient().Do,
+		URL:    s.registrationURL(c),
+		Method: "POST",
+		JSONBody: &params.SecretKeyLoginRequest{
+			User:              "user-bob",
+			Nonce:             validNonce,
+			PayloadCiphertext: ciphertext,
+		},
+	})
+	c.Assert(resp.StatusCode, gc.Equals, http.StatusOK)
+	defer resp.Body.Close()
+
+	// It should be possible to log in as bob with the
+	// password "hunter2" now, and there should be no
+	// secret key any longer.
+	err := s.bob.Refresh()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s.bob.PasswordValid("hunter2"), jc.IsTrue)
+	c.Assert(s.bob.SecretKey(), gc.IsNil)
+
+	var response params.SecretKeyLoginResponse
+	bodyData, err := ioutil.ReadAll(resp.Body)
+	c.Assert(err, jc.ErrorIsNil)
+	err = json.Unmarshal(bodyData, &response)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(response.Nonce, gc.HasLen, len(validNonce))
+	plaintext := s.openBox(c, response.PayloadCiphertext, response.Nonce, secretKey)
+
+	var responsePayload params.SecretKeyLoginResponsePayload
+	err = json.Unmarshal(plaintext, &responsePayload)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(responsePayload.CACert, gc.Equals, s.BackingState.CACert())
+}
+
+func (s *registrationSuite) TestRegisterInvalidMethod(c *gc.C) {
+	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
+		Do:           utils.GetNonValidatingHTTPClient().Do,
+		URL:          s.registrationURL(c),
+		Method:       "GET",
+		ExpectStatus: http.StatusMethodNotAllowed,
+		ExpectBody: &params.ErrorResult{
+			Error: &params.Error{
+				Message: `unsupported method: "GET"`,
+				Code:    params.CodeMethodNotAllowed,
+			},
+		},
+	})
+}
+
+func (s *registrationSuite) TestRegisterInvalidFormat(c *gc.C) {
+	s.testInvalidRequest(
+		c, "[]", "json: cannot unmarshal array into Go value of type params.SecretKeyLoginRequest", "",
+		http.StatusInternalServerError,
+	)
+}
+
+func (s *registrationSuite) TestRegisterInvalidUserTag(c *gc.C) {
+	s.testInvalidRequest(
+		c, `{"user": "service-bob"}`, `"service-bob" is not a valid user tag`, "",
+		http.StatusInternalServerError,
+	)
+}
+
+func (s *registrationSuite) TestRegisterInvalidNonce(c *gc.C) {
+	s.testInvalidRequest(
+		c, `{"user": "user-bob", "nonce": ""}`, `nonce not valid`, "",
+		http.StatusInternalServerError,
+	)
+}
+
+func (s *registrationSuite) TestRegisterInvalidCiphertext(c *gc.C) {
+	validNonce := []byte(strings.Repeat("X", 24))
+	s.testInvalidRequest(c,
+		fmt.Sprintf(
+			`{"user": "user-bob", "nonce": "%s"}`,
+			base64.StdEncoding.EncodeToString(validNonce),
+		), `secret key not valid`, "",
+		http.StatusInternalServerError,
+	)
+}
+
+func (s *registrationSuite) TestRegisterNoSecretKey(c *gc.C) {
+	err := s.bob.SetPassword("anything")
+	c.Assert(err, jc.ErrorIsNil)
+	validNonce := []byte(strings.Repeat("X", 24))
+	s.testInvalidRequest(c,
+		fmt.Sprintf(
+			`{"user": "user-bob", "nonce": "%s"}`,
+			base64.StdEncoding.EncodeToString(validNonce),
+		), `secret key for user "bob" not found`, params.CodeNotFound,
+		http.StatusNotFound,
+	)
+}
+
+func (s *registrationSuite) TestRegisterInvalidRequestPayload(c *gc.C) {
+	validNonce := []byte(strings.Repeat("X", 24))
+	ciphertext := s.sealBox(c, validNonce, s.bob.SecretKey(), "[]")
+	s.testInvalidRequest(c,
+		fmt.Sprintf(
+			`{"user": "user-bob", "nonce": "%s", "ciphertext": "%s"}`,
+			base64.StdEncoding.EncodeToString(validNonce),
+			base64.StdEncoding.EncodeToString(ciphertext),
+		),
+		`cannot unmarshal payload: json: cannot unmarshal array into Go value of type params.SecretKeyLoginRequestPayload`, "",
+		http.StatusInternalServerError,
+	)
+}
+
+func (s *registrationSuite) testInvalidRequest(c *gc.C, requestBody, errorMessage, errorCode string, statusCode int) {
+	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
+		Do:           utils.GetNonValidatingHTTPClient().Do,
+		URL:          s.registrationURL(c),
+		Method:       "POST",
+		Body:         strings.NewReader(requestBody),
+		ExpectStatus: statusCode,
+		ExpectBody: &params.ErrorResult{
+			Error: &params.Error{Message: errorMessage, Code: errorCode},
+		},
+	})
+}
+
+func (s *registrationSuite) sealBox(c *gc.C, nonce, key []byte, message string) []byte {
+	var nonceArray [24]byte
+	var keyArray [32]byte
+	c.Assert(copy(nonceArray[:], nonce), gc.Equals, len(nonceArray))
+	c.Assert(copy(keyArray[:], key), gc.Equals, len(keyArray))
+	return secretbox.Seal(nil, []byte(message), &nonceArray, &keyArray)
+}
+
+func (s *registrationSuite) openBox(c *gc.C, ciphertext, nonce, key []byte) []byte {
+	var nonceArray [24]byte
+	var keyArray [32]byte
+	c.Assert(copy(nonceArray[:], nonce), gc.Equals, len(nonceArray))
+	c.Assert(copy(keyArray[:], key), gc.Equals, len(keyArray))
+	message, ok := secretbox.Open(nil, ciphertext, &nonceArray, &keyArray)
+	c.Assert(ok, jc.IsTrue)
+	return message
+}

--- a/apiserver/registration_test.go
+++ b/apiserver/registration_test.go
@@ -11,11 +11,10 @@ import (
 	"net/http"
 	"strings"
 
-	"golang.org/x/crypto/nacl/secretbox"
-
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/testing/httptesting"
 	"github.com/juju/utils"
+	"golang.org/x/crypto/nacl/secretbox"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/params"

--- a/state/user_test.go
+++ b/state/user_test.go
@@ -265,3 +265,28 @@ func (s *UserSuite) TestAllUsers(c *gc.C) {
 	c.Check(users[5].Name(), gc.Equals, "fred")
 	c.Check(users[6].Name(), gc.Equals, "test-admin")
 }
+
+func (s *UserSuite) TestAddUserNoSecretKey(c *gc.C) {
+	u, err := s.State.AddUser("bob", "display", "pass", "admin")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(u.SecretKey(), gc.IsNil)
+}
+
+func (s *UserSuite) TestAddUserSecretKey(c *gc.C) {
+	u, err := s.State.AddUserWithSecretKey("bob", "display", "admin")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(u.SecretKey(), gc.HasLen, 32)
+	c.Assert(u.PasswordValid(""), jc.IsFalse)
+}
+
+func (s *UserSuite) TestSetPasswordClearsSecretKey(c *gc.C) {
+	u, err := s.State.AddUserWithSecretKey("bob", "display", "admin")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(u.SecretKey(), gc.HasLen, 32)
+	err = u.SetPassword("anything")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(u.SecretKey(), gc.IsNil)
+	err = u.Refresh()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(u.SecretKey(), gc.IsNil)
+}


### PR DESCRIPTION
"juju add-user" will now assign a secret key to
the user initially, and no password. This will
be presented to the caller, which then provides
that to the user so they can complete the registration
process by setting their initial password.

(Review request: http://reviews.vapour.ws/r/3748/)