### PR TITLE
Rename Service facade methods: ServiceFoo becomes Foo

### DIFF
--- a/api/service/client.go
+++ b/api/service/client.go
@@ -59,13 +59,13 @@ func (c *Client) ModelUUID() string {
 	return tag.Id()
 }
 
-// ServiceDeploy obtains the charm, either locally or from
+// Deploy obtains the charm, either locally or from
 // the charm store, and deploys it. It allows the specification of
 // requested networks that must be present on the machines where the
 // service is deployed. Another way to specify networks to include/exclude
 // is using constraints. Placement directives, if provided, specify the
 // machine on which the charm is deployed.
-func (c *Client) ServiceDeploy(
+func (c *Client) Deploy(
 	charmURL string,
 	serviceName string,
 	series string,
@@ -91,19 +91,19 @@ func (c *Client) ServiceDeploy(
 	}
 	var results params.ErrorResults
 	var err error
-	err = c.facade.FacadeCall("ServicesDeploy", args, &results)
+	err = c.facade.FacadeCall("Deploy", args, &results)
 	if err != nil {
 		return err
 	}
 	return results.OneError()
 }
 
-// ServiceGetCharmURL returns the charm URL the given service is
+// GetCharmURL returns the charm URL the given service is
 // running at present.
-func (c *Client) ServiceGetCharmURL(serviceName string) (*charm.URL, error) {
+func (c *Client) GetCharmURL(serviceName string) (*charm.URL, error) {
 	result := new(params.StringResult)
 	args := params.ServiceGet{ServiceName: serviceName}
-	err := c.facade.FacadeCall("ServiceGetCharmURL", args, result)
+	err := c.facade.FacadeCall("GetCharmURL", args, result)
 	if err != nil {
 		return nil, err
 	}
@@ -113,134 +113,111 @@ func (c *Client) ServiceGetCharmURL(serviceName string) (*charm.URL, error) {
 	return charm.ParseURL(result.Result)
 }
 
-// ServiceSetCharm sets the charm for a given service.
-func (c *Client) ServiceSetCharm(serviceName string, charmUrl string, forceSeries, forceUnits bool) error {
+// SetCharm sets the charm for a given service.
+func (c *Client) SetCharm(serviceName string, charmUrl string, forceSeries, forceUnits bool) error {
 	args := params.ServiceSetCharm{
 		ServiceName: serviceName,
 		CharmUrl:    charmUrl,
 		ForceSeries: forceSeries,
 		ForceUnits:  forceUnits,
 	}
-	return c.facade.FacadeCall("ServiceSetCharm", args, nil)
+	return c.facade.FacadeCall("SetCharm", args, nil)
 }
 
-// ServiceUpdate updates the service attributes, including charm URL,
+// Update updates the service attributes, including charm URL,
 // minimum number of units, settings and constraints.
-func (c *Client) ServiceUpdate(args params.ServiceUpdate) error {
-	return c.facade.FacadeCall("ServiceUpdate", args, nil)
+func (c *Client) Update(args params.ServiceUpdate) error {
+	return c.facade.FacadeCall("Update", args, nil)
 }
 
-// AddServiceUnits adds a given number of units to a service using the specified
+// AddUnits adds a given number of units to a service using the specified
 // placement directives to assign units to machines.
-func (c *Client) AddServiceUnits(service string, numUnits int, placement []*instance.Placement) ([]string, error) {
+func (c *Client) AddUnits(service string, numUnits int, placement []*instance.Placement) ([]string, error) {
 	args := params.AddServiceUnits{
 		ServiceName: service,
 		NumUnits:    numUnits,
 		Placement:   placement,
 	}
 	results := new(params.AddServiceUnitsResults)
-	err := c.facade.FacadeCall("AddServiceUnits", args, results)
+	err := c.facade.FacadeCall("AddUnits", args, results)
 	return results.Units, err
 }
 
-// DestroyServiceUnits decreases the number of units dedicated to a service.
-func (c *Client) DestroyServiceUnits(unitNames ...string) error {
+// DestroyUnits decreases the number of units dedicated to a service.
+func (c *Client) DestroyUnits(unitNames ...string) error {
 	params := params.DestroyServiceUnits{unitNames}
-	return c.facade.FacadeCall("DestroyServiceUnits", params, nil)
+	return c.facade.FacadeCall("DestroyUnits", params, nil)
 }
 
-// ServiceDestroy destroys a given service.
-func (c *Client) ServiceDestroy(service string) error {
+// Destroy destroys a given service.
+func (c *Client) Destroy(service string) error {
 	params := params.ServiceDestroy{
 		ServiceName: service,
 	}
-	return c.facade.FacadeCall("ServiceDestroy", params, nil)
+	return c.facade.FacadeCall("Destroy", params, nil)
 }
 
-// GetServiceConstraints returns the constraints for the given service.
-func (c *Client) GetServiceConstraints(service string) (constraints.Value, error) {
+// GetConstraints returns the constraints for the given service.
+func (c *Client) GetConstraints(service string) (constraints.Value, error) {
 	results := new(params.GetConstraintsResults)
-	err := c.facade.FacadeCall("GetServiceConstraints", params.GetServiceConstraints{service}, results)
+	err := c.facade.FacadeCall("GetConstraints", params.GetServiceConstraints{service}, results)
 	return results.Constraints, err
 }
 
-// SetServiceConstraints specifies the constraints for the given service.
-func (c *Client) SetServiceConstraints(service string, constraints constraints.Value) error {
+// SetConstraints specifies the constraints for the given service.
+func (c *Client) SetConstraints(service string, constraints constraints.Value) error {
 	params := params.SetConstraints{
 		ServiceName: service,
 		Constraints: constraints,
 	}
-	return c.facade.FacadeCall("SetServiceConstraints", params, nil)
+	return c.facade.FacadeCall("SetConstraints", params, nil)
 }
 
-// ServiceExpose changes the juju-managed firewall to expose any ports that
+// Expose changes the juju-managed firewall to expose any ports that
 // were also explicitly marked by units as open.
-func (c *Client) ServiceExpose(service string) error {
+func (c *Client) Expose(service string) error {
 	params := params.ServiceExpose{ServiceName: service}
-	return c.facade.FacadeCall("ServiceExpose", params, nil)
+	return c.facade.FacadeCall("Expose", params, nil)
 }
 
-// ServiceUnexpose changes the juju-managed firewall to unexpose any ports that
+// Unexpose changes the juju-managed firewall to unexpose any ports that
 // were also explicitly marked by units as open.
-func (c *Client) ServiceUnexpose(service string) error {
+func (c *Client) Unexpose(service string) error {
 	params := params.ServiceUnexpose{ServiceName: service}
-	return c.facade.FacadeCall("ServiceUnexpose", params, nil)
+	return c.facade.FacadeCall("Unexpose", params, nil)
 }
 
-// ServiceDeployWithNetworks works exactly like ServiceDeploy, but
-// allows the specification of requested networks that must be present
-// on the machines where the service is deployed. Another way to specify
-// networks to include/exclude is using constraints.
-func (c *Client) ServiceDeployWithNetworks(
-	charmURL string,
-	serviceName string,
-	numUnits int,
-	configYAML string,
-	cons constraints.Value,
-	networks []string,
-) error {
-	params := params.ServiceDeploy{
-		ServiceName: serviceName,
-		CharmUrl:    charmURL,
-		NumUnits:    numUnits,
-		ConfigYAML:  configYAML,
-		Constraints: cons,
-		Networks:    networks,
-	}
-	return c.facade.FacadeCall("ServiceDeployWithNetworks", params, nil)
-}
-
-// ServiceGet returns the configuration for the named service.
-func (c *Client) ServiceGet(service string) (*params.ServiceGetResults, error) {
+// Get returns the configuration for the named service.
+func (c *Client) Get(service string) (*params.ServiceGetResults, error) {
 	var results params.ServiceGetResults
 	params := params.ServiceGet{ServiceName: service}
-	err := c.facade.FacadeCall("ServiceGet", params, &results)
+	err := c.facade.FacadeCall("Get", params, &results)
 	return &results, err
 }
 
-// ServiceSet sets configuration options on a service.
-func (c *Client) ServiceSet(service string, options map[string]string) error {
+// Set sets configuration options on a service.
+func (c *Client) Set(service string, options map[string]string) error {
 	p := params.ServiceSet{
 		ServiceName: service,
 		Options:     options,
 	}
-	return c.facade.FacadeCall("ServiceSet", p, nil)
+	return c.facade.FacadeCall("Set", p, nil)
 }
 
-// ServiceUnset resets configuration options on a service.
-func (c *Client) ServiceUnset(service string, options []string) error {
+// Unset resets configuration options on a service.
+func (c *Client) Unset(service string, options []string) error {
 	p := params.ServiceUnset{
 		ServiceName: service,
 		Options:     options,
 	}
-	return c.facade.FacadeCall("ServiceUnset", p, nil)
+	return c.facade.FacadeCall("Unset", p, nil)
 }
 
-// ServiceCharmRelations returns the service's charms relation names.
-func (c *Client) ServiceCharmRelations(service string) ([]string, error) {
+// CharmRelations returns the service's charms relation names.
+func (c *Client) CharmRelations(service string) ([]string, error) {
 	var results params.ServiceCharmRelationsResults
 	params := params.ServiceCharmRelations{ServiceName: service}
-	err := c.facade.FacadeCall("ServiceCharmRelations", params, &results)
+	err := c.facade.FacadeCall("CharmRelations", params, &results)
 	return results.CharmRelations, err
 }
 

--- a/api/service/client_test.go
+++ b/api/service/client_test.go
@@ -79,7 +79,7 @@ func (s *serviceSuite) TestSetServiceDeploy(c *gc.C) {
 	var called bool
 	service.PatchFacadeCall(s, s.client, func(request string, a, response interface{}) error {
 		called = true
-		c.Assert(request, gc.Equals, "ServicesDeploy")
+		c.Assert(request, gc.Equals, "Deploy")
 		args, ok := a.(params.ServicesDeploy)
 		c.Assert(ok, jc.IsTrue)
 		c.Assert(args.Services, gc.HasLen, 1)
@@ -97,7 +97,7 @@ func (s *serviceSuite) TestSetServiceDeploy(c *gc.C) {
 		result.Results = make([]params.ErrorResult, 1)
 		return nil
 	})
-	err := s.client.ServiceDeploy("charmURL", "serviceA", "series", 2, "configYAML", constraints.MustParse("mem=4G"),
+	err := s.client.Deploy("charmURL", "serviceA", "series", 2, "configYAML", constraints.MustParse("mem=4G"),
 		[]*instance.Placement{{"scope", "directive"}}, []string{"neta"},
 		map[string]storage.Constraints{"data": storage.Constraints{Pool: "pool"}})
 	c.Assert(err, jc.ErrorIsNil)
@@ -108,7 +108,7 @@ func (s *serviceSuite) TestServiceGetCharmURL(c *gc.C) {
 	var called bool
 	service.PatchFacadeCall(s, s.client, func(request string, a, response interface{}) error {
 		called = true
-		c.Assert(request, gc.Equals, "ServiceGetCharmURL")
+		c.Assert(request, gc.Equals, "GetCharmURL")
 		args, ok := a.(params.ServiceGet)
 		c.Assert(ok, jc.IsTrue)
 		c.Assert(args.ServiceName, gc.Equals, "service")
@@ -117,7 +117,7 @@ func (s *serviceSuite) TestServiceGetCharmURL(c *gc.C) {
 		result.Result = "curl"
 		return nil
 	})
-	curl, err := s.client.ServiceGetCharmURL("service")
+	curl, err := s.client.GetCharmURL("service")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(curl, gc.DeepEquals, charm.MustParseURL("curl"))
 	c.Assert(called, jc.IsTrue)
@@ -127,7 +127,7 @@ func (s *serviceSuite) TestServiceSetCharm(c *gc.C) {
 	var called bool
 	service.PatchFacadeCall(s, s.client, func(request string, a, response interface{}) error {
 		called = true
-		c.Assert(request, gc.Equals, "ServiceSetCharm")
+		c.Assert(request, gc.Equals, "SetCharm")
 		args, ok := a.(params.ServiceSetCharm)
 		c.Assert(ok, jc.IsTrue)
 		c.Assert(args.ServiceName, gc.Equals, "service")
@@ -136,7 +136,7 @@ func (s *serviceSuite) TestServiceSetCharm(c *gc.C) {
 		c.Assert(args.ForceUnits, gc.Equals, true)
 		return nil
 	})
-	err := s.client.ServiceSetCharm("service", "charmURL", true, true)
+	err := s.client.SetCharm("service", "charmURL", true, true)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(called, jc.IsTrue)
 }

--- a/apiserver/client/perm_test.go
+++ b/apiserver/client/perm_test.go
@@ -74,11 +74,11 @@ func (s *permSuite) TestOperationPerm(c *gc.C) {
 		op:    opClientStatus,
 		allow: []names.Tag{userAdmin, userOther},
 	}, {
-		about: "Service.ServiceSet",
+		about: "Service.Set",
 		op:    opClientServiceSet,
 		allow: []names.Tag{userAdmin, userOther},
 	}, {
-		about: "Service.ServiceGet",
+		about: "Service.Get",
 		op:    opClientServiceGet,
 		allow: []names.Tag{userAdmin, userOther},
 	}, {
@@ -86,19 +86,19 @@ func (s *permSuite) TestOperationPerm(c *gc.C) {
 		op:    opClientResolved,
 		allow: []names.Tag{userAdmin, userOther},
 	}, {
-		about: "Service.ServiceExpose",
+		about: "Service.Expose",
 		op:    opClientServiceExpose,
 		allow: []names.Tag{userAdmin, userOther},
 	}, {
-		about: "Service.ServiceUnexpose",
+		about: "Service.Unexpose",
 		op:    opClientServiceUnexpose,
 		allow: []names.Tag{userAdmin, userOther},
 	}, {
-		about: "Service.ServiceUpdate",
+		about: "Service.Update",
 		op:    opClientServiceUpdate,
 		allow: []names.Tag{userAdmin, userOther},
 	}, {
-		about: "Service.ServiceSetCharm",
+		about: "Service.SetCharm",
 		op:    opClientServiceSetCharm,
 		allow: []names.Tag{userAdmin, userOther},
 	}, {
@@ -110,23 +110,23 @@ func (s *permSuite) TestOperationPerm(c *gc.C) {
 		op:    opClientSetAnnotations,
 		allow: []names.Tag{userAdmin, userOther},
 	}, {
-		about: "Client.AddServiceUnits",
+		about: "Service.AddUnits",
 		op:    opClientAddServiceUnits,
 		allow: []names.Tag{userAdmin, userOther},
 	}, {
-		about: "Client.DestroyServiceUnits",
+		about: "Service.DestroyUnits",
 		op:    opClientDestroyServiceUnits,
 		allow: []names.Tag{userAdmin, userOther},
 	}, {
-		about: "Client.ServiceDestroy",
+		about: "Service.Destroy",
 		op:    opClientServiceDestroy,
 		allow: []names.Tag{userAdmin, userOther},
 	}, {
-		about: "Client.GetServiceConstraints",
+		about: "Service.GetConstraints",
 		op:    opClientGetServiceConstraints,
 		allow: []names.Tag{userAdmin, userOther},
 	}, {
-		about: "Client.SetServiceConstraints",
+		about: "Service.SetConstraints",
 		op:    opClientSetServiceConstraints,
 		allow: []names.Tag{userAdmin, userOther},
 	}, {
@@ -233,7 +233,7 @@ func opClientStatus(c *gc.C, st api.Connection, mst *state.State) (func(), error
 
 func resetBlogTitle(c *gc.C, st api.Connection) func() {
 	return func() {
-		err := service.NewClient(st).ServiceSet("wordpress", map[string]string{
+		err := service.NewClient(st).Set("wordpress", map[string]string{
 			"blog-title": "",
 		})
 		c.Assert(err, jc.ErrorIsNil)
@@ -241,7 +241,7 @@ func resetBlogTitle(c *gc.C, st api.Connection) func() {
 }
 
 func opClientServiceSet(c *gc.C, st api.Connection, mst *state.State) (func(), error) {
-	err := service.NewClient(st).ServiceSet("wordpress", map[string]string{
+	err := service.NewClient(st).Set("wordpress", map[string]string{
 		"blog-title": "foo",
 	})
 	if err != nil {
@@ -251,7 +251,7 @@ func opClientServiceSet(c *gc.C, st api.Connection, mst *state.State) (func(), e
 }
 
 func opClientServiceGet(c *gc.C, st api.Connection, mst *state.State) (func(), error) {
-	_, err := service.NewClient(st).ServiceGet("wordpress")
+	_, err := service.NewClient(st).Get("wordpress")
 	if err != nil {
 		return func() {}, err
 	}
@@ -259,7 +259,7 @@ func opClientServiceGet(c *gc.C, st api.Connection, mst *state.State) (func(), e
 }
 
 func opClientServiceExpose(c *gc.C, st api.Connection, mst *state.State) (func(), error) {
-	err := service.NewClient(st).ServiceExpose("wordpress")
+	err := service.NewClient(st).Expose("wordpress")
 	if err != nil {
 		return func() {}, err
 	}
@@ -271,7 +271,7 @@ func opClientServiceExpose(c *gc.C, st api.Connection, mst *state.State) (func()
 }
 
 func opClientServiceUnexpose(c *gc.C, st api.Connection, mst *state.State) (func(), error) {
-	err := service.NewClient(st).ServiceUnexpose("wordpress")
+	err := service.NewClient(st).Unexpose("wordpress")
 	if err != nil {
 		return func() {}, err
 	}
@@ -334,7 +334,7 @@ func opClientServiceUpdate(c *gc.C, st api.Connection, mst *state.State) (func()
 		SettingsStrings: map[string]string{"blog-title": "foo"},
 		SettingsYAML:    `"wordpress": {"blog-title": "foo"}`,
 	}
-	err := service.NewClient(st).ServiceUpdate(args)
+	err := service.NewClient(st).Update(args)
 	if params.IsCodeNotFound(err) {
 		err = nil
 	}
@@ -342,7 +342,7 @@ func opClientServiceUpdate(c *gc.C, st api.Connection, mst *state.State) (func()
 }
 
 func opClientServiceSetCharm(c *gc.C, st api.Connection, mst *state.State) (func(), error) {
-	err := service.NewClient(st).ServiceSetCharm("nosuch", "local:quantal/wordpress", false, false)
+	err := service.NewClient(st).SetCharm("nosuch", "local:quantal/wordpress", false, false)
 	if params.IsCodeNotFound(err) {
 		err = nil
 	}
@@ -350,7 +350,7 @@ func opClientServiceSetCharm(c *gc.C, st api.Connection, mst *state.State) (func
 }
 
 func opClientAddServiceUnits(c *gc.C, st api.Connection, mst *state.State) (func(), error) {
-	_, err := service.NewClient(st).AddServiceUnits("nosuch", 1, nil)
+	_, err := service.NewClient(st).AddUnits("nosuch", 1, nil)
 	if params.IsCodeNotFound(err) {
 		err = nil
 	}
@@ -358,7 +358,7 @@ func opClientAddServiceUnits(c *gc.C, st api.Connection, mst *state.State) (func
 }
 
 func opClientDestroyServiceUnits(c *gc.C, st api.Connection, mst *state.State) (func(), error) {
-	err := service.NewClient(st).DestroyServiceUnits("wordpress/99")
+	err := service.NewClient(st).DestroyUnits("wordpress/99")
 	if err != nil && strings.HasPrefix(err.Error(), "no units were destroyed") {
 		err = nil
 	}
@@ -366,7 +366,7 @@ func opClientDestroyServiceUnits(c *gc.C, st api.Connection, mst *state.State) (
 }
 
 func opClientServiceDestroy(c *gc.C, st api.Connection, mst *state.State) (func(), error) {
-	err := service.NewClient(st).ServiceDestroy("non-existent")
+	err := service.NewClient(st).Destroy("non-existent")
 	if params.IsCodeNotFound(err) {
 		err = nil
 	}
@@ -374,13 +374,13 @@ func opClientServiceDestroy(c *gc.C, st api.Connection, mst *state.State) (func(
 }
 
 func opClientGetServiceConstraints(c *gc.C, st api.Connection, mst *state.State) (func(), error) {
-	_, err := service.NewClient(st).GetServiceConstraints("wordpress")
+	_, err := service.NewClient(st).GetConstraints("wordpress")
 	return func() {}, err
 }
 
 func opClientSetServiceConstraints(c *gc.C, st api.Connection, mst *state.State) (func(), error) {
 	nullConstraints := constraints.Value{}
-	err := service.NewClient(st).SetServiceConstraints("wordpress", nullConstraints)
+	err := service.NewClient(st).SetConstraints("wordpress", nullConstraints)
 	if err != nil {
 		return func() {}, err
 	}

--- a/apiserver/client_auth_root_test.go
+++ b/apiserver/client_auth_root_test.go
@@ -43,7 +43,7 @@ func (s *clientAuthRootSuite) AssertCallErrPerm(c *gc.C, client *clientAuthRoot,
 func (s *clientAuthRootSuite) TestNormalUser(c *gc.C) {
 	envUser := s.Factory.MakeModelUser(c, nil)
 	client := newClientAuthRoot(&fakeFinder{}, envUser)
-	s.AssertCallGood(c, client, "Service", 3, "ServicesDeploy")
+	s.AssertCallGood(c, client, "Service", 3, "Deploy")
 	s.AssertCallGood(c, client, "UserManager", 1, "UserInfo")
 	s.AssertCallNotImplemented(c, client, "Client", 1, "Unknown")
 	s.AssertCallNotImplemented(c, client, "Unknown", 1, "Method")
@@ -53,7 +53,7 @@ func (s *clientAuthRootSuite) TestReadOnlyUser(c *gc.C) {
 	envUser := s.Factory.MakeModelUser(c, &factory.ModelUserParams{ReadOnly: true})
 	client := newClientAuthRoot(&fakeFinder{}, envUser)
 	// deploys are bad
-	s.AssertCallErrPerm(c, client, "Service", 3, "ServicesDeploy")
+	s.AssertCallErrPerm(c, client, "Service", 3, "Deploy")
 	// read only commands are fine
 	s.AssertCallGood(c, client, "Client", 1, "FullStatus")
 	// calls on the restricted root is also fine

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -191,7 +191,7 @@ type ServicesDeploy struct {
 	Services []ServiceDeploy
 }
 
-// ServiceDeploy holds the parameters for making the ServiceDeploy call.
+// ServiceDeploy holds the parameters for making the service Deploy call.
 type ServiceDeploy struct {
 	ServiceName string
 	Series      string
@@ -205,7 +205,7 @@ type ServiceDeploy struct {
 	Storage     map[string]storage.Constraints
 }
 
-// ServiceUpdate holds the parameters for making the ServiceUpdate call.
+// ServiceUpdate holds the parameters for making the service update call.
 type ServiceUpdate struct {
 	ServiceName     string
 	CharmUrl        string
@@ -225,19 +225,19 @@ type ServiceSetCharm struct {
 	ForceSeries bool   `json:"forceseries"`
 }
 
-// ServiceExpose holds the parameters for making the ServiceExpose call.
+// ServiceExpose holds the parameters for making the service Expose call.
 type ServiceExpose struct {
 	ServiceName string
 }
 
-// ServiceSet holds the parameters for a ServiceSet
+// ServiceSet holds the parameters for a service Set
 // command. Options contains the configuration data.
 type ServiceSet struct {
 	ServiceName string
 	Options     map[string]string
 }
 
-// ServiceUnset holds the parameters for a ServiceUnset
+// ServiceUnset holds the parameters for a service Unset
 // command. Options contains the option attribute names
 // to unset.
 type ServiceUnset struct {
@@ -245,13 +245,13 @@ type ServiceUnset struct {
 	Options     []string
 }
 
-// ServiceGet holds parameters for making the ServiceGet or
-// ServiceGetCharmURL calls.
+// ServiceGet holds parameters for making the Get or
+// GetCharmURL calls.
 type ServiceGet struct {
 	ServiceName string
 }
 
-// ServiceGetResults holds results of the ServiceGet call.
+// ServiceGetResults holds results of the service Get call.
 type ServiceGetResults struct {
 	Service     string
 	Charm       string
@@ -259,17 +259,17 @@ type ServiceGetResults struct {
 	Constraints constraints.Value
 }
 
-// ServiceCharmRelations holds parameters for making the ServiceCharmRelations call.
+// ServiceCharmRelations holds parameters for making the service CharmRelations call.
 type ServiceCharmRelations struct {
 	ServiceName string
 }
 
-// ServiceCharmRelationsResults holds the results of the ServiceCharmRelations call.
+// ServiceCharmRelationsResults holds the results of the service CharmRelations call.
 type ServiceCharmRelationsResults struct {
 	CharmRelations []string
 }
 
-// ServiceUnexpose holds parameters for the ServiceUnexpose call.
+// ServiceUnexpose holds parameters for the service Unexpose call.
 type ServiceUnexpose struct {
 	ServiceName string
 }
@@ -319,7 +319,7 @@ type ResolvedResults struct {
 }
 
 // AddServiceUnitsResults holds the names of the units added by the
-// AddServiceUnits call.
+// AddUnits call.
 type AddServiceUnitsResults struct {
 	Units []string
 }
@@ -336,7 +336,7 @@ type DestroyServiceUnits struct {
 	UnitNames []string
 }
 
-// ServiceDestroy holds the parameters for making the ServiceDestroy call.
+// ServiceDestroy holds the parameters for making the service Destroy call.
 type ServiceDestroy struct {
 	ServiceName string
 }

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -205,7 +205,7 @@ type ServiceDeploy struct {
 	Storage     map[string]storage.Constraints
 }
 
-// ServiceUpdate holds the parameters for making the service update call.
+// ServiceUpdate holds the parameters for making the service Update call.
 type ServiceUpdate struct {
 	ServiceName     string
 	CharmUrl        string

--- a/apiserver/read_only_calls.go
+++ b/apiserver/read_only_calls.go
@@ -45,9 +45,9 @@ var readOnlyCalls = set.NewStrings(
 	"Client.WatchAll",
 	// TODO: add controller work.
 	"KeyManager.ListKeys",
-	"Service.GetServiceConstraints",
-	"Service.ServiceCharmRelations",
-	"Service.ServiceGet",
+	"Service.GetConstraints",
+	"Service.CharmRelations",
+	"Service.Get",
 	"Spaces.ListSpaces",
 	"Storage.ListStorageDetails",
 	"Storage.ListFilesystems",

--- a/apiserver/read_only_calls_test.go
+++ b/apiserver/read_only_calls_test.go
@@ -50,7 +50,7 @@ func (*readOnlyCallsSuite) TestReadOnlyCall(c *gc.C) {
 	}{
 		{"Action", "Actions"},
 		{"Client", "FullStatus"},
-		{"Service", "ServiceGet"},
+		{"Service", "Get"},
 		{"Storage", "ListStorageDetails"},
 	} {
 		c.Logf("check %s.%s", test.facade, test.method)
@@ -64,7 +64,7 @@ func (*readOnlyCallsSuite) TestWritableCalls(c *gc.C) {
 		method string
 	}{
 		{"Client", "UnknownMethod"},
-		{"Service", "ServiceDeploy"},
+		{"Service", "Deploy"},
 		{"UnknownFacade", "List"},
 	} {
 		c.Logf("check %s.%s", test.facade, test.method)

--- a/apiserver/restoring_root_test.go
+++ b/apiserver/restoring_root_test.go
@@ -30,7 +30,7 @@ func (r *restoreRootSuite) TestFindAllowedMethodWhenPreparing(c *gc.C) {
 func (r *restoreRootSuite) TestNothingAllowedMethodWhenPreparing(c *gc.C) {
 	root := apiserver.TestingRestoreInProgressRoot(nil)
 
-	caller, err := root.FindMethod("Service", 3, "ServiceDeploy")
+	caller, err := root.FindMethod("Service", 3, "Deploy")
 
 	c.Assert(err, gc.ErrorMatches, "juju restore is in progress - Juju api is off to prevent data loss")
 	c.Assert(caller, gc.IsNil)
@@ -39,7 +39,7 @@ func (r *restoreRootSuite) TestNothingAllowedMethodWhenPreparing(c *gc.C) {
 func (r *restoreRootSuite) TestFindDisallowedMethodWhenPreparing(c *gc.C) {
 	root := apiserver.TestingAboutToRestoreRoot(nil)
 
-	caller, err := root.FindMethod("Service", 3, "ServiceDeploy")
+	caller, err := root.FindMethod("Service", 3, "Deploy")
 
 	c.Assert(err, gc.ErrorMatches, "juju restore is in progress - Juju functionality is limited to avoid data loss")
 	c.Assert(caller, gc.IsNil)
@@ -48,7 +48,7 @@ func (r *restoreRootSuite) TestFindDisallowedMethodWhenPreparing(c *gc.C) {
 func (r *restoreRootSuite) TestFindDisallowedMethodWhenRestoring(c *gc.C) {
 	root := apiserver.TestingRestoreInProgressRoot(nil)
 
-	caller, err := root.FindMethod("Service", 3, "ServiceDeploy")
+	caller, err := root.FindMethod("Service", 3, "Deploy")
 
 	c.Assert(err, gc.ErrorMatches, "juju restore is in progress - Juju api is off to prevent data loss")
 	c.Assert(caller, gc.IsNil)

--- a/apiserver/service/get.go
+++ b/apiserver/service/get.go
@@ -10,8 +10,8 @@ import (
 	"github.com/juju/juju/constraints"
 )
 
-// ServiceGet returns the configuration for a service.
-func (api *API) ServiceGet(args params.ServiceGet) (params.ServiceGetResults, error) {
+// Get returns the configuration for a service.
+func (api *API) Get(args params.ServiceGet) (params.ServiceGetResults, error) {
 	service, err := api.state.Service(args.ServiceName)
 	if err != nil {
 		return params.ServiceGetResults{}, err

--- a/apiserver/service/get_test.go
+++ b/apiserver/service/get_test.go
@@ -40,7 +40,7 @@ func (s *getSuite) SetUpTest(c *gc.C) {
 
 func (s *getSuite) TestClientServiceGetSmoketest(c *gc.C) {
 	s.AddTestingService(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
-	results, err := s.serviceApi.ServiceGet(params.ServiceGet{"wordpress"})
+	results, err := s.serviceApi.Get(params.ServiceGet{"wordpress"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.ServiceGetResults{
 		Service: "wordpress",
@@ -57,7 +57,7 @@ func (s *getSuite) TestClientServiceGetSmoketest(c *gc.C) {
 }
 
 func (s *getSuite) TestServiceGetUnknownService(c *gc.C) {
-	_, err := s.serviceApi.ServiceGet(params.ServiceGet{"unknown"})
+	_, err := s.serviceApi.Get(params.ServiceGet{"unknown"})
 	c.Assert(err, gc.ErrorMatches, `service "unknown" not found`)
 }
 
@@ -176,15 +176,15 @@ func (s *getSuite) TestServiceGet(c *gc.C) {
 		expect.Service = svc.Name()
 		expect.Charm = ch.Meta().Name
 		client := apiservice.NewClient(s.APIState)
-		got, err := client.ServiceGet(svc.Name())
+		got, err := client.Get(svc.Name())
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(*got, gc.DeepEquals, expect)
 	}
 }
 
-func (s *getSuite) TestServiceGetMaxResolutionInt(c *gc.C) {
+func (s *getSuite) TestGetMaxResolutionInt(c *gc.C) {
 	// See the bug http://pad.lv/1217742
-	// ServiceGet ends up pushing a map[string]interface{} which containts
+	// Get ends up pushing a map[string]interface{} which containts
 	// an int64 through a JSON Marshal & Unmarshal which ends up changing
 	// the int64 into a float64. We will fix it if we find it is actually a
 	// problem.
@@ -199,7 +199,7 @@ func (s *getSuite) TestServiceGetMaxResolutionInt(c *gc.C) {
 	err := svc.UpdateConfigSettings(map[string]interface{}{"skill-level": nonFloatInt})
 	c.Assert(err, jc.ErrorIsNil)
 	client := apiservice.NewClient(s.APIState)
-	got, err := client.ServiceGet(svc.Name())
+	got, err := client.Get(svc.Name())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(got.Config["skill-level"], jc.DeepEquals, map[string]interface{}{
 		"description": "A number indicating skill.",

--- a/apiserver/service/service_test.go
+++ b/apiserver/service/service_test.go
@@ -212,7 +212,7 @@ func (s *serviceSuite) TestServiceDeployWithStorage(c *gc.C) {
 		Constraints: cons,
 		Storage:     storageConstraints,
 	}
-	results, err := s.serviceApi.ServicesDeploy(params.ServicesDeploy{
+	results, err := s.serviceApi.Deploy(params.ServicesDeploy{
 		Services: []params.ServiceDeploy{args}},
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -255,7 +255,7 @@ func (s *serviceSuite) TestServiceDeployWithInvalidStoragePool(c *gc.C) {
 		Constraints: cons,
 		Storage:     storageConstraints,
 	}
-	results, err := s.serviceApi.ServicesDeploy(params.ServicesDeploy{
+	results, err := s.serviceApi.Deploy(params.ServicesDeploy{
 		Services: []params.ServiceDeploy{args}},
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -286,7 +286,7 @@ func (s *serviceSuite) TestServiceDeployWithUnsupportedStoragePool(c *gc.C) {
 		Constraints: cons,
 		Storage:     storageConstraints,
 	}
-	results, err := s.serviceApi.ServicesDeploy(params.ServicesDeploy{
+	results, err := s.serviceApi.Deploy(params.ServicesDeploy{
 		Services: []params.ServiceDeploy{args}},
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -305,7 +305,7 @@ func (s *serviceSuite) TestServiceDeployDefaultFilesystemStorage(c *gc.C) {
 		NumUnits:    1,
 		Constraints: cons,
 	}
-	results, err := s.serviceApi.ServicesDeploy(params.ServicesDeploy{
+	results, err := s.serviceApi.Deploy(params.ServicesDeploy{
 		Services: []params.ServiceDeploy{args}},
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -338,7 +338,7 @@ func (s *serviceSuite) TestServiceDeploy(c *gc.C) {
 			{"deadbeef-0bad-400d-8000-4b1d0d06f00d", "valid"},
 		},
 	}
-	results, err := s.serviceApi.ServicesDeploy(params.ServicesDeploy{
+	results, err := s.serviceApi.Deploy(params.ServicesDeploy{
 		Services: []params.ServiceDeploy{args}},
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -365,7 +365,7 @@ func (s *serviceSuite) TestServiceDeployWithInvalidPlacement(c *gc.C) {
 			{"deadbeef-0bad-400d-8000-4b1d0d06f00d", "invalid"},
 		},
 	}
-	results, err := s.serviceApi.ServicesDeploy(params.ServicesDeploy{
+	results, err := s.serviceApi.Deploy(params.ServicesDeploy{
 		Services: []params.ServiceDeploy{args}},
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -547,7 +547,7 @@ func (s *serviceSuite) TestAddCharmOverwritesPlaceholders(c *gc.C) {
 
 func (s *serviceSuite) TestServiceGetCharmURL(c *gc.C) {
 	s.AddTestingService(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
-	result, err := s.serviceApi.ServiceGetCharmURL(params.ServiceGet{"wordpress"})
+	result, err := s.serviceApi.GetCharmURL(params.ServiceGet{"wordpress"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Error, gc.IsNil)
 	c.Assert(result.Result, gc.Equals, "local:quantal/wordpress-3")
@@ -557,7 +557,7 @@ func (s *serviceSuite) TestServiceSetCharm(c *gc.C) {
 	curl, _ := s.UploadCharm(c, "precise/dummy-0", "dummy")
 	err := service.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{URL: curl.String()})
 	c.Assert(err, jc.ErrorIsNil)
-	results, err := s.serviceApi.ServicesDeploy(params.ServicesDeploy{
+	results, err := s.serviceApi.Deploy(params.ServicesDeploy{
 		Services: []params.ServiceDeploy{{
 			CharmUrl:    curl.String(),
 			ServiceName: "service",
@@ -569,7 +569,7 @@ func (s *serviceSuite) TestServiceSetCharm(c *gc.C) {
 	curl, _ = s.UploadCharm(c, "precise/wordpress-3", "wordpress")
 	err = service.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{URL: curl.String()})
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.serviceApi.ServiceSetCharm(params.ServiceSetCharm{
+	err = s.serviceApi.SetCharm(params.ServiceSetCharm{
 		ServiceName: "service",
 		CharmUrl:    curl.String(),
 	})
@@ -588,7 +588,7 @@ func (s *serviceSuite) setupServiceSetCharm(c *gc.C) {
 	curl, _ := s.UploadCharm(c, "precise/dummy-0", "dummy")
 	err := service.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{URL: curl.String()})
 	c.Assert(err, jc.ErrorIsNil)
-	results, err := s.serviceApi.ServicesDeploy(params.ServicesDeploy{
+	results, err := s.serviceApi.Deploy(params.ServicesDeploy{
 		Services: []params.ServiceDeploy{{
 			CharmUrl:    curl.String(),
 			ServiceName: "service",
@@ -603,7 +603,7 @@ func (s *serviceSuite) setupServiceSetCharm(c *gc.C) {
 }
 
 func (s *serviceSuite) assertServiceSetCharm(c *gc.C, forceUnits bool) {
-	err := s.serviceApi.ServiceSetCharm(params.ServiceSetCharm{
+	err := s.serviceApi.SetCharm(params.ServiceSetCharm{
 		ServiceName: "service",
 		CharmUrl:    "cs:~who/precise/wordpress-3",
 		ForceUnits:  forceUnits,
@@ -618,7 +618,7 @@ func (s *serviceSuite) assertServiceSetCharm(c *gc.C, forceUnits bool) {
 }
 
 func (s *serviceSuite) assertServiceSetCharmBlocked(c *gc.C, msg string) {
-	err := s.serviceApi.ServiceSetCharm(params.ServiceSetCharm{
+	err := s.serviceApi.SetCharm(params.ServiceSetCharm{
 		ServiceName: "service",
 		CharmUrl:    "cs:~who/precise/wordpress-3",
 	})
@@ -647,7 +647,7 @@ func (s *serviceSuite) TestServiceSetCharmForceUnits(c *gc.C) {
 	curl, _ := s.UploadCharm(c, "precise/dummy-0", "dummy")
 	err := service.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{URL: curl.String()})
 	c.Assert(err, jc.ErrorIsNil)
-	results, err := s.serviceApi.ServicesDeploy(params.ServicesDeploy{
+	results, err := s.serviceApi.Deploy(params.ServicesDeploy{
 		Services: []params.ServiceDeploy{{
 			CharmUrl:    curl.String(),
 			ServiceName: "service",
@@ -659,7 +659,7 @@ func (s *serviceSuite) TestServiceSetCharmForceUnits(c *gc.C) {
 	curl, _ = s.UploadCharm(c, "precise/wordpress-3", "wordpress")
 	err = service.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{URL: curl.String()})
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.serviceApi.ServiceSetCharm(params.ServiceSetCharm{
+	err = s.serviceApi.SetCharm(params.ServiceSetCharm{
 		ServiceName: "service",
 		CharmUrl:    curl.String(),
 		ForceUnits:  true,
@@ -687,7 +687,7 @@ func (s *serviceSuite) TestBlockServiceSetCharmForce(c *gc.C) {
 }
 
 func (s *serviceSuite) TestServiceSetCharmInvalidService(c *gc.C) {
-	err := s.serviceApi.ServiceSetCharm(params.ServiceSetCharm{
+	err := s.serviceApi.SetCharm(params.ServiceSetCharm{
 		ServiceName: "badservice",
 		CharmUrl:    "cs:precise/wordpress-3",
 		ForceSeries: true,
@@ -715,7 +715,7 @@ func (s *serviceSuite) TestServiceSetCharmLegacy(c *gc.C) {
 	curl, _ := s.UploadCharm(c, "precise/dummy-0", "dummy")
 	err := service.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{URL: curl.String()})
 	c.Assert(err, jc.ErrorIsNil)
-	results, err := s.serviceApi.ServicesDeploy(params.ServicesDeploy{
+	results, err := s.serviceApi.Deploy(params.ServicesDeploy{
 		Services: []params.ServiceDeploy{{
 			CharmUrl:    curl.String(),
 			ServiceName: "service",
@@ -729,7 +729,7 @@ func (s *serviceSuite) TestServiceSetCharmLegacy(c *gc.C) {
 
 	// Even with forceSeries = true, we can't change a charm where
 	// the series is sepcified in the URL.
-	err = s.serviceApi.ServiceSetCharm(params.ServiceSetCharm{
+	err = s.serviceApi.SetCharm(params.ServiceSetCharm{
 		ServiceName: "service",
 		CharmUrl:    curl.String(),
 		ForceSeries: true,
@@ -741,7 +741,7 @@ func (s *serviceSuite) TestServiceSetCharmUnsupportedSeries(c *gc.C) {
 	curl, _ := s.UploadCharmMultiSeries(c, "~who/multi-series", "multi-series")
 	err := service.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{URL: curl.String()})
 	c.Assert(err, jc.ErrorIsNil)
-	results, err := s.serviceApi.ServicesDeploy(params.ServicesDeploy{
+	results, err := s.serviceApi.Deploy(params.ServicesDeploy{
 		Services: []params.ServiceDeploy{{
 			CharmUrl:    curl.String(),
 			ServiceName: "service",
@@ -754,7 +754,7 @@ func (s *serviceSuite) TestServiceSetCharmUnsupportedSeries(c *gc.C) {
 	err = service.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{URL: curl.String()})
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = s.serviceApi.ServiceSetCharm(params.ServiceSetCharm{
+	err = s.serviceApi.SetCharm(params.ServiceSetCharm{
 		ServiceName: "service",
 		CharmUrl:    curl.String(),
 	})
@@ -765,7 +765,7 @@ func (s *serviceSuite) TestServiceSetCharmUnsupportedSeriesForce(c *gc.C) {
 	curl, _ := s.UploadCharmMultiSeries(c, "~who/multi-series", "multi-series")
 	err := service.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{URL: curl.String()})
 	c.Assert(err, jc.ErrorIsNil)
-	results, err := s.serviceApi.ServicesDeploy(params.ServicesDeploy{
+	results, err := s.serviceApi.Deploy(params.ServicesDeploy{
 		Services: []params.ServiceDeploy{{
 			CharmUrl:    curl.String(),
 			ServiceName: "service",
@@ -778,7 +778,7 @@ func (s *serviceSuite) TestServiceSetCharmUnsupportedSeriesForce(c *gc.C) {
 	err = service.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{URL: curl.String()})
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = s.serviceApi.ServiceSetCharm(params.ServiceSetCharm{
+	err = s.serviceApi.SetCharm(params.ServiceSetCharm{
 		ServiceName: "service",
 		CharmUrl:    curl.String(),
 		ForceSeries: true,
@@ -795,7 +795,7 @@ func (s *serviceSuite) TestServiceSetCharmWrongOS(c *gc.C) {
 	curl, _ := s.UploadCharmMultiSeries(c, "~who/multi-series", "multi-series")
 	err := service.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{URL: curl.String()})
 	c.Assert(err, jc.ErrorIsNil)
-	results, err := s.serviceApi.ServicesDeploy(params.ServicesDeploy{
+	results, err := s.serviceApi.Deploy(params.ServicesDeploy{
 		Services: []params.ServiceDeploy{{
 			CharmUrl:    curl.String(),
 			ServiceName: "service",
@@ -808,7 +808,7 @@ func (s *serviceSuite) TestServiceSetCharmWrongOS(c *gc.C) {
 	err = service.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{URL: curl.String()})
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = s.serviceApi.ServiceSetCharm(params.ServiceSetCharm{
+	err = s.serviceApi.SetCharm(params.ServiceSetCharm{
 		ServiceName: "service",
 		CharmUrl:    curl.String(),
 		ForceSeries: true,
@@ -838,11 +838,11 @@ func (s *serviceSuite) TestSpecializeStoreOnDeployServiceSetCharmAndAddCharm(c *
 	err := s.State.UpdateModelConfig(attrs, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
-	// Check that the store's test mode is enabled when calling ServiceDeploy.
+	// Check that the store's test mode is enabled when calling service Deploy.
 	curl, _ := s.UploadCharm(c, "trusty/dummy-1", "dummy")
 	err = service.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{URL: curl.String()})
 	c.Assert(err, jc.ErrorIsNil)
-	results, err := s.serviceApi.ServicesDeploy(params.ServicesDeploy{
+	results, err := s.serviceApi.Deploy(params.ServicesDeploy{
 		Services: []params.ServiceDeploy{{
 			CharmUrl:    curl.String(),
 			ServiceName: "service",
@@ -853,9 +853,9 @@ func (s *serviceSuite) TestSpecializeStoreOnDeployServiceSetCharmAndAddCharm(c *
 	c.Assert(results.Results[0].Error, gc.IsNil)
 	c.Assert(repo.testMode, jc.IsTrue)
 
-	// Check that the store's test mode is enabled when calling ServiceSetCharm.
+	// Check that the store's test mode is enabled when calling SetCharm.
 	curl, _ = s.UploadCharm(c, "trusty/wordpress-2", "wordpress")
-	err = s.serviceApi.ServiceSetCharm(params.ServiceSetCharm{
+	err = s.serviceApi.SetCharm(params.ServiceSetCharm{
 		ServiceName: "service",
 		CharmUrl:    curl.String(),
 	})
@@ -877,7 +877,7 @@ func (s *serviceSuite) setupServiceDeploy(c *gc.C, args string) (*charm.URL, cha
 }
 
 func (s *serviceSuite) assertServiceDeployPrincipal(c *gc.C, curl *charm.URL, ch charm.Charm, mem4g constraints.Value) {
-	results, err := s.serviceApi.ServicesDeploy(params.ServicesDeploy{
+	results, err := s.serviceApi.Deploy(params.ServicesDeploy{
 		Services: []params.ServiceDeploy{{
 			CharmUrl:    curl.String(),
 			ServiceName: "service",
@@ -891,7 +891,7 @@ func (s *serviceSuite) assertServiceDeployPrincipal(c *gc.C, curl *charm.URL, ch
 }
 
 func (s *serviceSuite) assertServiceDeployPrincipalBlocked(c *gc.C, msg string, curl *charm.URL, mem4g constraints.Value) {
-	_, err := s.serviceApi.ServicesDeploy(params.ServicesDeploy{
+	_, err := s.serviceApi.Deploy(params.ServicesDeploy{
 		Services: []params.ServiceDeploy{{
 			CharmUrl:    curl.String(),
 			ServiceName: "service",
@@ -923,7 +923,7 @@ func (s *serviceSuite) TestServiceDeploySubordinate(c *gc.C) {
 	curl, ch := s.UploadCharm(c, "utopic/logging-47", "logging")
 	err := service.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{URL: curl.String()})
 	c.Assert(err, jc.ErrorIsNil)
-	results, err := s.serviceApi.ServicesDeploy(params.ServicesDeploy{
+	results, err := s.serviceApi.Deploy(params.ServicesDeploy{
 		Services: []params.ServiceDeploy{{
 			CharmUrl:    curl.String(),
 			ServiceName: "service-name",
@@ -950,7 +950,7 @@ func (s *serviceSuite) TestServiceDeployConfig(c *gc.C) {
 	curl, _ := s.UploadCharm(c, "precise/dummy-0", "dummy")
 	err := service.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{URL: curl.String()})
 	c.Assert(err, jc.ErrorIsNil)
-	results, err := s.serviceApi.ServicesDeploy(params.ServicesDeploy{
+	results, err := s.serviceApi.Deploy(params.ServicesDeploy{
 		Services: []params.ServiceDeploy{{
 			CharmUrl:    curl.String(),
 			ServiceName: "service-name",
@@ -974,7 +974,7 @@ func (s *serviceSuite) TestServiceDeployConfigError(c *gc.C) {
 	curl, _ := s.UploadCharm(c, "precise/dummy-0", "dummy")
 	err := service.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{URL: curl.String()})
 	c.Assert(err, jc.ErrorIsNil)
-	results, err := s.serviceApi.ServicesDeploy(params.ServicesDeploy{
+	results, err := s.serviceApi.Deploy(params.ServicesDeploy{
 		Services: []params.ServiceDeploy{{
 			CharmUrl:    curl.String(),
 			ServiceName: "service-name",
@@ -995,7 +995,7 @@ func (s *serviceSuite) TestServiceDeployToMachine(c *gc.C) {
 
 	machine, err := s.State.AddMachine("precise", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
-	results, err := s.serviceApi.ServicesDeploy(params.ServicesDeploy{
+	results, err := s.serviceApi.Deploy(params.ServicesDeploy{
 		Services: []params.ServiceDeploy{{
 			CharmUrl:    curl.String(),
 			ServiceName: "service-name",
@@ -1029,7 +1029,7 @@ func (s *serviceSuite) TestServiceDeployToMachine(c *gc.C) {
 }
 
 func (s *serviceSuite) TestServiceDeployToMachineNotFound(c *gc.C) {
-	results, err := s.serviceApi.ServicesDeploy(params.ServicesDeploy{
+	results, err := s.serviceApi.Deploy(params.ServicesDeploy{
 		Services: []params.ServiceDeploy{{
 			CharmUrl:    "cs:precise/service-name-1",
 			ServiceName: "service-name",
@@ -1049,7 +1049,7 @@ func (s *serviceSuite) TestServiceDeployServiceOwner(c *gc.C) {
 	err := service.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{URL: curl.String()})
 	c.Assert(err, jc.ErrorIsNil)
 
-	results, err := s.serviceApi.ServicesDeploy(params.ServicesDeploy{
+	results, err := s.serviceApi.Deploy(params.ServicesDeploy{
 		Services: []params.ServiceDeploy{{
 			CharmUrl:    curl.String(),
 			ServiceName: "service",
@@ -1068,7 +1068,7 @@ func (s *serviceSuite) deployServiceForUpdateTests(c *gc.C) {
 	curl, _ := s.UploadCharm(c, "precise/dummy-1", "dummy")
 	err := service.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{URL: curl.String()})
 	c.Assert(err, jc.ErrorIsNil)
-	results, err := s.serviceApi.ServicesDeploy(params.ServicesDeploy{
+	results, err := s.serviceApi.Deploy(params.ServicesDeploy{
 		Services: []params.ServiceDeploy{{
 			CharmUrl:    curl.String(),
 			ServiceName: "service",
@@ -1091,7 +1091,7 @@ func (s *serviceSuite) checkClientServiceUpdateSetCharm(c *gc.C, forceCharmUrl b
 		CharmUrl:      curl.String(),
 		ForceCharmUrl: forceCharmUrl,
 	}
-	err = s.serviceApi.ServiceUpdate(args)
+	err = s.serviceApi.Update(args)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Ensure the charm has been updated and and the force flag correctly set.
@@ -1134,7 +1134,7 @@ func (s *serviceSuite) TestBlockChangeServiceUpdate(c *gc.C) {
 		CharmUrl:      curl,
 		ForceCharmUrl: false,
 	}
-	err := s.serviceApi.ServiceUpdate(args)
+	err := s.serviceApi.Update(args)
 	s.AssertBlocked(c, err, "TestBlockChangeServiceUpdate")
 }
 
@@ -1156,7 +1156,7 @@ func (s *serviceSuite) TestBlockServiceUpdateForced(c *gc.C) {
 		CharmUrl:      curl,
 		ForceCharmUrl: true,
 	}
-	err := s.serviceApi.ServiceUpdate(args)
+	err := s.serviceApi.Update(args)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Ensure the charm has been updated and and the force flag correctly set.
@@ -1174,7 +1174,7 @@ func (s *serviceSuite) TestServiceUpdateSetCharmNotFound(c *gc.C) {
 		ServiceName: "wordpress",
 		CharmUrl:    "cs:precise/wordpress-999999",
 	}
-	err := s.serviceApi.ServiceUpdate(args)
+	err := s.serviceApi.Update(args)
 	c.Check(err, gc.ErrorMatches, `charm "cs:precise/wordpress-999999" not found`)
 }
 
@@ -1187,7 +1187,7 @@ func (s *serviceSuite) TestServiceUpdateSetMinUnits(c *gc.C) {
 		ServiceName: "dummy",
 		MinUnits:    &minUnits,
 	}
-	err := s.serviceApi.ServiceUpdate(args)
+	err := s.serviceApi.Update(args)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Ensure the minimum number of units has been set.
@@ -1204,7 +1204,7 @@ func (s *serviceSuite) TestServiceUpdateSetMinUnitsError(c *gc.C) {
 		ServiceName: "dummy",
 		MinUnits:    &minUnits,
 	}
-	err := s.serviceApi.ServiceUpdate(args)
+	err := s.serviceApi.Update(args)
 	c.Assert(err, gc.ErrorMatches,
 		`cannot set minimum units for service "dummy": cannot set a negative minimum number of units`)
 
@@ -1221,7 +1221,7 @@ func (s *serviceSuite) TestServiceUpdateSetSettingsStrings(c *gc.C) {
 		ServiceName:     "dummy",
 		SettingsStrings: map[string]string{"title": "s-title", "username": "s-user"},
 	}
-	err := s.serviceApi.ServiceUpdate(args)
+	err := s.serviceApi.Update(args)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Ensure the settings have been correctly updated.
@@ -1239,7 +1239,7 @@ func (s *serviceSuite) TestServiceUpdateSetSettingsYAML(c *gc.C) {
 		ServiceName:  "dummy",
 		SettingsYAML: "dummy:\n  title: y-title\n  username: y-user",
 	}
-	err := s.serviceApi.ServiceUpdate(args)
+	err := s.serviceApi.Update(args)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Ensure the settings have been correctly updated.
@@ -1259,7 +1259,7 @@ func (s *serviceSuite) TestServiceUpdateSetConstraints(c *gc.C) {
 		ServiceName: "dummy",
 		Constraints: &cons,
 	}
-	err = s.serviceApi.ServiceUpdate(args)
+	err = s.serviceApi.Update(args)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Ensure the constraints have been correctly updated.
@@ -1287,7 +1287,7 @@ func (s *serviceSuite) TestServiceUpdateAllParams(c *gc.C) {
 		SettingsYAML:    "service:\n  blog-title: yaml-title\n",
 		Constraints:     &cons,
 	}
-	err = s.serviceApi.ServiceUpdate(args)
+	err = s.serviceApi.Update(args)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Ensure the service has been correctly updated.
@@ -1319,20 +1319,20 @@ func (s *serviceSuite) TestServiceUpdateAllParams(c *gc.C) {
 func (s *serviceSuite) TestServiceUpdateNoParams(c *gc.C) {
 	s.AddTestingService(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
 
-	// Calling ServiceUpdate with no parameters set is a no-op.
+	// Calling Update with no parameters set is a no-op.
 	args := params.ServiceUpdate{ServiceName: "wordpress"}
-	err := s.serviceApi.ServiceUpdate(args)
+	err := s.serviceApi.Update(args)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *serviceSuite) TestServiceUpdateNoService(c *gc.C) {
-	err := s.serviceApi.ServiceUpdate(params.ServiceUpdate{})
+	err := s.serviceApi.Update(params.ServiceUpdate{})
 	c.Assert(err, gc.ErrorMatches, `"" is not a valid service name`)
 }
 
 func (s *serviceSuite) TestServiceUpdateInvalidService(c *gc.C) {
 	args := params.ServiceUpdate{ServiceName: "no-such-service"}
-	err := s.serviceApi.ServiceUpdate(args)
+	err := s.serviceApi.Update(args)
 	c.Assert(err, gc.ErrorMatches, `service "no-such-service" not found`)
 }
 
@@ -1343,7 +1343,7 @@ var (
 func (s *serviceSuite) TestServiceSet(c *gc.C) {
 	dummy := s.AddTestingService(c, "dummy", s.AddTestingCharm(c, "dummy"))
 
-	err := s.serviceApi.ServiceSet(params.ServiceSet{ServiceName: "dummy", Options: map[string]string{
+	err := s.serviceApi.Set(params.ServiceSet{ServiceName: "dummy", Options: map[string]string{
 		"title":    "foobar",
 		"username": validSetTestValue,
 	}})
@@ -1355,7 +1355,7 @@ func (s *serviceSuite) TestServiceSet(c *gc.C) {
 		"username": validSetTestValue,
 	})
 
-	err = s.serviceApi.ServiceSet(params.ServiceSet{ServiceName: "dummy", Options: map[string]string{
+	err = s.serviceApi.Set(params.ServiceSet{ServiceName: "dummy", Options: map[string]string{
 		"title":    "barfoo",
 		"username": "",
 	}})
@@ -1369,7 +1369,7 @@ func (s *serviceSuite) TestServiceSet(c *gc.C) {
 }
 
 func (s *serviceSuite) assertServiceSetBlocked(c *gc.C, dummy *state.Service, msg string) {
-	err := s.serviceApi.ServiceSet(params.ServiceSet{
+	err := s.serviceApi.Set(params.ServiceSet{
 		ServiceName: "dummy",
 		Options: map[string]string{
 			"title":    "foobar",
@@ -1378,7 +1378,7 @@ func (s *serviceSuite) assertServiceSetBlocked(c *gc.C, dummy *state.Service, ms
 }
 
 func (s *serviceSuite) assertServiceSet(c *gc.C, dummy *state.Service) {
-	err := s.serviceApi.ServiceSet(params.ServiceSet{
+	err := s.serviceApi.Set(params.ServiceSet{
 		ServiceName: "dummy",
 		Options: map[string]string{
 			"title":    "foobar",
@@ -1413,7 +1413,7 @@ func (s *serviceSuite) TestBlockChangesServiceSet(c *gc.C) {
 func (s *serviceSuite) TestServerUnset(c *gc.C) {
 	dummy := s.AddTestingService(c, "dummy", s.AddTestingCharm(c, "dummy"))
 
-	err := s.serviceApi.ServiceSet(params.ServiceSet{ServiceName: "dummy", Options: map[string]string{
+	err := s.serviceApi.Set(params.ServiceSet{ServiceName: "dummy", Options: map[string]string{
 		"title":    "foobar",
 		"username": "user name",
 	}})
@@ -1425,7 +1425,7 @@ func (s *serviceSuite) TestServerUnset(c *gc.C) {
 		"username": "user name",
 	})
 
-	err = s.serviceApi.ServiceUnset(params.ServiceUnset{ServiceName: "dummy", Options: []string{"username"}})
+	err = s.serviceApi.Unset(params.ServiceUnset{ServiceName: "dummy", Options: []string{"username"}})
 	c.Assert(err, jc.ErrorIsNil)
 	settings, err = dummy.ConfigSettings()
 	c.Assert(err, jc.ErrorIsNil)
@@ -1437,7 +1437,7 @@ func (s *serviceSuite) TestServerUnset(c *gc.C) {
 func (s *serviceSuite) setupServerUnsetBlocked(c *gc.C) *state.Service {
 	dummy := s.AddTestingService(c, "dummy", s.AddTestingCharm(c, "dummy"))
 
-	err := s.serviceApi.ServiceSet(params.ServiceSet{
+	err := s.serviceApi.Set(params.ServiceSet{
 		ServiceName: "dummy",
 		Options: map[string]string{
 			"title":    "foobar",
@@ -1454,7 +1454,7 @@ func (s *serviceSuite) setupServerUnsetBlocked(c *gc.C) *state.Service {
 }
 
 func (s *serviceSuite) assertServerUnset(c *gc.C, dummy *state.Service) {
-	err := s.serviceApi.ServiceUnset(params.ServiceUnset{
+	err := s.serviceApi.Unset(params.ServiceUnset{
 		ServiceName: "dummy",
 		Options:     []string{"username"},
 	})
@@ -1467,7 +1467,7 @@ func (s *serviceSuite) assertServerUnset(c *gc.C, dummy *state.Service) {
 }
 
 func (s *serviceSuite) assertServerUnsetBlocked(c *gc.C, dummy *state.Service, msg string) {
-	err := s.serviceApi.ServiceUnset(params.ServiceUnset{
+	err := s.serviceApi.Unset(params.ServiceUnset{
 		ServiceName: "dummy",
 		Options:     []string{"username"},
 	})
@@ -1536,7 +1536,7 @@ func (s *serviceSuite) TestClientAddServiceUnits(c *gc.C) {
 		if t.to != "" {
 			args.Placement = []*instance.Placement{instance.MustParsePlacement(t.to)}
 		}
-		result, err := s.serviceApi.AddServiceUnits(args)
+		result, err := s.serviceApi.AddUnits(args)
 		if t.err != "" {
 			c.Assert(err, gc.ErrorMatches, t.err)
 			continue
@@ -1557,7 +1557,7 @@ func (s *serviceSuite) TestAddServiceUnitsToNewContainer(c *gc.C) {
 	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = s.serviceApi.AddServiceUnits(params.AddServiceUnits{
+	_, err = s.serviceApi.AddUnits(params.AddServiceUnits{
 		ServiceName: "dummy",
 		NumUnits:    1,
 		Placement:   []*instance.Placement{instance.MustParsePlacement("lxc:" + machine.Id())},
@@ -1608,7 +1608,7 @@ func (s *serviceSuite) TestAddServiceUnits(c *gc.C) {
 		if serviceName == "" {
 			serviceName = "dummy"
 		}
-		result, err := s.serviceApi.AddServiceUnits(params.AddServiceUnits{
+		result, err := s.serviceApi.AddUnits(params.AddServiceUnits{
 			ServiceName: serviceName,
 			NumUnits:    len(t.expected),
 			Placement:   t.placement,
@@ -1630,7 +1630,7 @@ func (s *serviceSuite) TestAddServiceUnits(c *gc.C) {
 }
 
 func (s *serviceSuite) assertAddServiceUnits(c *gc.C) {
-	result, err := s.serviceApi.AddServiceUnits(params.AddServiceUnits{
+	result, err := s.serviceApi.AddUnits(params.AddServiceUnits{
 		ServiceName: "dummy",
 		NumUnits:    3,
 	})
@@ -1653,10 +1653,10 @@ func (s *serviceSuite) TestServiceCharmRelations(c *gc.C) {
 	_, err = s.State.AddRelation(eps...)
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = s.serviceApi.ServiceCharmRelations(params.ServiceCharmRelations{"blah"})
+	_, err = s.serviceApi.CharmRelations(params.ServiceCharmRelations{"blah"})
 	c.Assert(err, gc.ErrorMatches, `service "blah" not found`)
 
-	result, err := s.serviceApi.ServiceCharmRelations(params.ServiceCharmRelations{"wordpress"})
+	result, err := s.serviceApi.CharmRelations(params.ServiceCharmRelations{"wordpress"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.CharmRelations, gc.DeepEquals, []string{
 		"cache", "db", "juju-info", "logging-dir", "monitoring-port", "url",
@@ -1664,7 +1664,7 @@ func (s *serviceSuite) TestServiceCharmRelations(c *gc.C) {
 }
 
 func (s *serviceSuite) assertAddServiceUnitsBlocked(c *gc.C, msg string) {
-	_, err := s.serviceApi.AddServiceUnits(params.AddServiceUnits{
+	_, err := s.serviceApi.AddUnits(params.AddServiceUnits{
 		ServiceName: "dummy",
 		NumUnits:    3,
 	})
@@ -1691,7 +1691,7 @@ func (s *serviceSuite) TestBlockChangeAddServiceUnits(c *gc.C) {
 
 func (s *serviceSuite) TestAddUnitToMachineNotFound(c *gc.C) {
 	s.AddTestingService(c, "dummy", s.AddTestingCharm(c, "dummy"))
-	_, err := s.serviceApi.AddServiceUnits(params.AddServiceUnits{
+	_, err := s.serviceApi.AddUnits(params.AddServiceUnits{
 		ServiceName: "dummy",
 		NumUnits:    3,
 		Placement:   []*instance.Placement{instance.MustParsePlacement("42")},
@@ -1713,7 +1713,7 @@ func (s *serviceSuite) TestServiceExpose(c *gc.C) {
 	c.Assert(svcs[1].IsExposed(), jc.IsTrue)
 	for i, t := range serviceExposeTests {
 		c.Logf("test %d. %s", i, t.about)
-		err = s.serviceApi.ServiceExpose(params.ServiceExpose{t.service})
+		err = s.serviceApi.Expose(params.ServiceExpose{t.service})
 		if t.err != "" {
 			c.Assert(err, gc.ErrorMatches, t.err)
 		} else {
@@ -1765,7 +1765,7 @@ var serviceExposeTests = []struct {
 func (s *serviceSuite) assertServiceExpose(c *gc.C) {
 	for i, t := range serviceExposeTests {
 		c.Logf("test %d. %s", i, t.about)
-		err := s.serviceApi.ServiceExpose(params.ServiceExpose{t.service})
+		err := s.serviceApi.Expose(params.ServiceExpose{t.service})
 		if t.err != "" {
 			c.Assert(err, gc.ErrorMatches, t.err)
 		} else {
@@ -1780,7 +1780,7 @@ func (s *serviceSuite) assertServiceExpose(c *gc.C) {
 func (s *serviceSuite) assertServiceExposeBlocked(c *gc.C, msg string) {
 	for i, t := range serviceExposeTests {
 		c.Logf("test %d. %s", i, t.about)
-		err := s.serviceApi.ServiceExpose(params.ServiceExpose{t.service})
+		err := s.serviceApi.Expose(params.ServiceExpose{t.service})
 		s.AssertBlocked(c, err, msg)
 	}
 }
@@ -1838,7 +1838,7 @@ func (s *serviceSuite) TestServiceUnexpose(c *gc.C) {
 			svc.SetExposed()
 		}
 		c.Assert(svc.IsExposed(), gc.Equals, t.initial)
-		err := s.serviceApi.ServiceUnexpose(params.ServiceUnexpose{t.service})
+		err := s.serviceApi.Unexpose(params.ServiceUnexpose{t.service})
 		if t.err == "" {
 			c.Assert(err, jc.ErrorIsNil)
 			svc.Refresh()
@@ -1860,7 +1860,7 @@ func (s *serviceSuite) setupServiceUnexpose(c *gc.C) *state.Service {
 }
 
 func (s *serviceSuite) assertServiceUnexpose(c *gc.C, svc *state.Service) {
-	err := s.serviceApi.ServiceUnexpose(params.ServiceUnexpose{"dummy-service"})
+	err := s.serviceApi.Unexpose(params.ServiceUnexpose{"dummy-service"})
 	c.Assert(err, jc.ErrorIsNil)
 	svc.Refresh()
 	c.Assert(svc.IsExposed(), gc.Equals, false)
@@ -1869,7 +1869,7 @@ func (s *serviceSuite) assertServiceUnexpose(c *gc.C, svc *state.Service) {
 }
 
 func (s *serviceSuite) assertServiceUnexposeBlocked(c *gc.C, svc *state.Service, msg string) {
-	err := s.serviceApi.ServiceUnexpose(params.ServiceUnexpose{"dummy-service"})
+	err := s.serviceApi.Unexpose(params.ServiceUnexpose{"dummy-service"})
 	s.AssertBlocked(c, err, msg)
 	err = svc.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
@@ -1918,7 +1918,7 @@ func (s *serviceSuite) TestServiceDestroy(c *gc.C) {
 	s.AddTestingService(c, "dummy-service", s.AddTestingCharm(c, "dummy"))
 	for i, t := range serviceDestroyTests {
 		c.Logf("test %d. %s", i, t.about)
-		err := s.serviceApi.ServiceDestroy(params.ServiceDestroy{t.service})
+		err := s.serviceApi.Destroy(params.ServiceDestroy{t.service})
 		if t.err != "" {
 			c.Assert(err, gc.ErrorMatches, t.err)
 		} else {
@@ -1926,14 +1926,14 @@ func (s *serviceSuite) TestServiceDestroy(c *gc.C) {
 		}
 	}
 
-	// Now do ServiceDestroy on a service with units. Destroy will
+	// Now do Destroy on a service with units. Destroy will
 	// cause the service to be not-Alive, but will not remove its
 	// document.
 	s.AddTestingService(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
 	serviceName := "wordpress"
 	service, err := s.State.Service(serviceName)
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.serviceApi.ServiceDestroy(params.ServiceDestroy{serviceName})
+	err = s.serviceApi.Destroy(params.ServiceDestroy{serviceName})
 	c.Assert(err, jc.ErrorIsNil)
 	err = service.Refresh()
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
@@ -1950,7 +1950,7 @@ func (s *serviceSuite) TestBlockServiceDestroy(c *gc.C) {
 
 	// block remove-objects
 	s.BlockRemoveObject(c, "TestBlockServiceDestroy")
-	err := s.serviceApi.ServiceDestroy(params.ServiceDestroy{"dummy-service"})
+	err := s.serviceApi.Destroy(params.ServiceDestroy{"dummy-service"})
 	s.AssertBlocked(c, err, "TestBlockServiceDestroy")
 	// Tests may have invalid service names.
 	service, err := s.State.Service("dummy-service")
@@ -1990,7 +1990,7 @@ func (s *serviceSuite) TestDestroySubordinateUnits(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Try to destroy the subordinate alone; check it fails.
-	err = s.serviceApi.DestroyServiceUnits(params.DestroyServiceUnits{
+	err = s.serviceApi.DestroyUnits(params.DestroyServiceUnits{
 		UnitNames: []string{"logging/0"},
 	})
 	c.Assert(err, gc.ErrorMatches, `no units were destroyed: unit "logging/0" is a subordinate`)
@@ -2001,7 +2001,7 @@ func (s *serviceSuite) TestDestroySubordinateUnits(c *gc.C) {
 
 func (s *serviceSuite) assertDestroyPrincipalUnits(c *gc.C, units []*state.Unit) {
 	// Destroy 2 of them; check they become Dying.
-	err := s.serviceApi.DestroyServiceUnits(params.DestroyServiceUnits{
+	err := s.serviceApi.DestroyUnits(params.DestroyServiceUnits{
 		UnitNames: []string{"wordpress/0", "wordpress/1"},
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -2010,7 +2010,7 @@ func (s *serviceSuite) assertDestroyPrincipalUnits(c *gc.C, units []*state.Unit)
 
 	// Try to destroy an Alive one and a Dying one; check
 	// it destroys the Alive one and ignores the Dying one.
-	err = s.serviceApi.DestroyServiceUnits(params.DestroyServiceUnits{
+	err = s.serviceApi.DestroyUnits(params.DestroyServiceUnits{
 		UnitNames: []string{"wordpress/2", "wordpress/0"},
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -2018,7 +2018,7 @@ func (s *serviceSuite) assertDestroyPrincipalUnits(c *gc.C, units []*state.Unit)
 
 	// Try to destroy an Alive one along with a nonexistent one; check that
 	// the valid instruction is followed but the invalid one is warned about.
-	err = s.serviceApi.DestroyServiceUnits(params.DestroyServiceUnits{
+	err = s.serviceApi.DestroyUnits(params.DestroyServiceUnits{
 		UnitNames: []string{"boojum/123", "wordpress/3"},
 	})
 	c.Assert(err, gc.ErrorMatches, `some units were not destroyed: unit "boojum/123" does not exist`)
@@ -2029,7 +2029,7 @@ func (s *serviceSuite) assertDestroyPrincipalUnits(c *gc.C, units []*state.Unit)
 	c.Assert(err, jc.ErrorIsNil)
 	err = wp0.EnsureDead()
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.serviceApi.DestroyServiceUnits(params.DestroyServiceUnits{
+	err = s.serviceApi.DestroyUnits(params.DestroyServiceUnits{
 		UnitNames: []string{"wordpress/0", "wordpress/4"},
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -2069,7 +2069,7 @@ func (s *serviceSuite) assertBlockedErrorAndLiveliness(
 func (s *serviceSuite) TestBlockChangesDestroyPrincipalUnits(c *gc.C) {
 	units := s.setupDestroyPrincipalUnits(c)
 	s.BlockAllChanges(c, "TestBlockChangesDestroyPrincipalUnits")
-	err := s.serviceApi.DestroyServiceUnits(params.DestroyServiceUnits{
+	err := s.serviceApi.DestroyUnits(params.DestroyServiceUnits{
 		UnitNames: []string{"wordpress/0", "wordpress/1"},
 	})
 	s.assertBlockedErrorAndLiveliness(c, err, "TestBlockChangesDestroyPrincipalUnits", units[0], units[1], units[2], units[3])
@@ -2078,7 +2078,7 @@ func (s *serviceSuite) TestBlockChangesDestroyPrincipalUnits(c *gc.C) {
 func (s *serviceSuite) TestBlockRemoveDestroyPrincipalUnits(c *gc.C) {
 	units := s.setupDestroyPrincipalUnits(c)
 	s.BlockRemoveObject(c, "TestBlockRemoveDestroyPrincipalUnits")
-	err := s.serviceApi.DestroyServiceUnits(params.DestroyServiceUnits{
+	err := s.serviceApi.DestroyUnits(params.DestroyServiceUnits{
 		UnitNames: []string{"wordpress/0", "wordpress/1"},
 	})
 	s.assertBlockedErrorAndLiveliness(c, err, "TestBlockRemoveDestroyPrincipalUnits", units[0], units[1], units[2], units[3])
@@ -2087,7 +2087,7 @@ func (s *serviceSuite) TestBlockRemoveDestroyPrincipalUnits(c *gc.C) {
 func (s *serviceSuite) TestBlockDestroyDestroyPrincipalUnits(c *gc.C) {
 	units := s.setupDestroyPrincipalUnits(c)
 	s.BlockDestroyModel(c, "TestBlockDestroyDestroyPrincipalUnits")
-	err := s.serviceApi.DestroyServiceUnits(params.DestroyServiceUnits{
+	err := s.serviceApi.DestroyUnits(params.DestroyServiceUnits{
 		UnitNames: []string{"wordpress/0", "wordpress/1"},
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -2099,7 +2099,7 @@ func (s *serviceSuite) assertDestroySubordinateUnits(c *gc.C, wordpress0, loggin
 	// Try to destroy the principal and the subordinate together; check it warns
 	// about the subordinate, but destroys the one it can. (The principal unit
 	// agent will be responsible for destroying the subordinate.)
-	err := s.serviceApi.DestroyServiceUnits(params.DestroyServiceUnits{
+	err := s.serviceApi.DestroyUnits(params.DestroyServiceUnits{
 		UnitNames: []string{"wordpress/0", "logging/0"},
 	})
 	c.Assert(err, gc.ErrorMatches, `some units were not destroyed: unit "logging/0" is a subordinate`)
@@ -2125,7 +2125,7 @@ func (s *serviceSuite) TestBlockRemoveDestroySubordinateUnits(c *gc.C) {
 
 	s.BlockRemoveObject(c, "TestBlockRemoveDestroySubordinateUnits")
 	// Try to destroy the subordinate alone; check it fails.
-	err = s.serviceApi.DestroyServiceUnits(params.DestroyServiceUnits{
+	err = s.serviceApi.DestroyUnits(params.DestroyServiceUnits{
 		UnitNames: []string{"logging/0"},
 	})
 	s.AssertBlocked(c, err, "TestBlockRemoveDestroySubordinateUnits")
@@ -2133,7 +2133,7 @@ func (s *serviceSuite) TestBlockRemoveDestroySubordinateUnits(c *gc.C) {
 	assertLife(c, wordpress0, state.Alive)
 	assertLife(c, logging0, state.Alive)
 
-	err = s.serviceApi.DestroyServiceUnits(params.DestroyServiceUnits{
+	err = s.serviceApi.DestroyUnits(params.DestroyServiceUnits{
 		UnitNames: []string{"wordpress/0", "logging/0"},
 	})
 	s.AssertBlocked(c, err, "TestBlockRemoveDestroySubordinateUnits")
@@ -2160,7 +2160,7 @@ func (s *serviceSuite) TestBlockChangesDestroySubordinateUnits(c *gc.C) {
 
 	s.BlockAllChanges(c, "TestBlockChangesDestroySubordinateUnits")
 	// Try to destroy the subordinate alone; check it fails.
-	err = s.serviceApi.DestroyServiceUnits(params.DestroyServiceUnits{
+	err = s.serviceApi.DestroyUnits(params.DestroyServiceUnits{
 		UnitNames: []string{"logging/0"},
 	})
 	s.AssertBlocked(c, err, "TestBlockChangesDestroySubordinateUnits")
@@ -2168,7 +2168,7 @@ func (s *serviceSuite) TestBlockChangesDestroySubordinateUnits(c *gc.C) {
 	assertLife(c, wordpress0, state.Alive)
 	assertLife(c, logging0, state.Alive)
 
-	err = s.serviceApi.DestroyServiceUnits(params.DestroyServiceUnits{
+	err = s.serviceApi.DestroyUnits(params.DestroyServiceUnits{
 		UnitNames: []string{"wordpress/0", "logging/0"},
 	})
 	s.AssertBlocked(c, err, "TestBlockChangesDestroySubordinateUnits")
@@ -2195,7 +2195,7 @@ func (s *serviceSuite) TestBlockDestroyDestroySubordinateUnits(c *gc.C) {
 
 	s.BlockDestroyModel(c, "TestBlockDestroyDestroySubordinateUnits")
 	// Try to destroy the subordinate alone; check it fails.
-	err = s.serviceApi.DestroyServiceUnits(params.DestroyServiceUnits{
+	err = s.serviceApi.DestroyUnits(params.DestroyServiceUnits{
 		UnitNames: []string{"logging/0"},
 	})
 	c.Assert(err, gc.ErrorMatches, `no units were destroyed: unit "logging/0" is a subordinate`)
@@ -2210,7 +2210,7 @@ func (s *serviceSuite) TestClientSetServiceConstraints(c *gc.C) {
 	// Update constraints for the service.
 	cons, err := constraints.Parse("mem=4096", "cpu-cores=2")
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.serviceApi.SetServiceConstraints(params.SetConstraints{ServiceName: "dummy", Constraints: cons})
+	err = s.serviceApi.SetConstraints(params.SetConstraints{ServiceName: "dummy", Constraints: cons})
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Ensure the constraints have been correctly updated.
@@ -2228,7 +2228,7 @@ func (s *serviceSuite) setupSetServiceConstraints(c *gc.C) (*state.Service, cons
 }
 
 func (s *serviceSuite) assertSetServiceConstraints(c *gc.C, service *state.Service, cons constraints.Value) {
-	err := s.serviceApi.SetServiceConstraints(params.SetConstraints{ServiceName: "dummy", Constraints: cons})
+	err := s.serviceApi.SetConstraints(params.SetConstraints{ServiceName: "dummy", Constraints: cons})
 	c.Assert(err, jc.ErrorIsNil)
 	// Ensure the constraints have been correctly updated.
 	obtained, err := service.Constraints()
@@ -2237,7 +2237,7 @@ func (s *serviceSuite) assertSetServiceConstraints(c *gc.C, service *state.Servi
 }
 
 func (s *serviceSuite) assertSetServiceConstraintsBlocked(c *gc.C, msg string, service *state.Service, cons constraints.Value) {
-	err := s.serviceApi.SetServiceConstraints(params.SetConstraints{ServiceName: "dummy", Constraints: cons})
+	err := s.serviceApi.SetConstraints(params.SetConstraints{ServiceName: "dummy", Constraints: cons})
 	s.AssertBlocked(c, err, msg)
 }
 
@@ -2269,7 +2269,7 @@ func (s *serviceSuite) TestClientGetServiceConstraints(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Check we can get the constraints.
-	result, err := s.serviceApi.GetServiceConstraints(params.GetServiceConstraints{"dummy"})
+	result, err := s.serviceApi.GetConstraints(params.GetServiceConstraints{"dummy"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Constraints, gc.DeepEquals, cons)
 }

--- a/cmd/juju/commands/debughooks.go
+++ b/cmd/juju/commands/debughooks.go
@@ -62,7 +62,7 @@ func (c *debugHooksCommand) Init(args []string) error {
 }
 
 type charmRelationsApi interface {
-	ServiceCharmRelations(serviceName string) ([]string, error)
+	CharmRelations(serviceName string) ([]string, error)
 }
 
 func (c *debugHooksCommand) getServiceAPI() (charmRelationsApi, error) {
@@ -85,7 +85,7 @@ func (c *debugHooksCommand) validateHooks() error {
 	if err != nil {
 		return err
 	}
-	relations, err := serviceApi.ServiceCharmRelations(service)
+	relations, err := serviceApi.CharmRelations(service)
 	if err != nil {
 		return err
 	}

--- a/cmd/juju/service/addunit.go
+++ b/cmd/juju/service/addunit.go
@@ -131,7 +131,7 @@ func (c *addUnitCommand) Init(args []string) error {
 type serviceAddUnitAPI interface {
 	Close() error
 	ModelUUID() string
-	AddServiceUnits(service string, numUnits int, placement []*instance.Placement) ([]string, error)
+	AddUnits(service string, numUnits int, placement []*instance.Placement) ([]string, error)
 }
 
 func (c *addUnitCommand) getAPI() (serviceAddUnitAPI, error) {
@@ -146,7 +146,7 @@ func (c *addUnitCommand) getAPI() (serviceAddUnitAPI, error) {
 }
 
 // Run connects to the environment specified on the command line
-// and calls AddServiceUnits for the given service.
+// and calls AddUnits for the given service.
 func (c *addUnitCommand) Run(_ *cmd.Context) error {
 	apiclient, err := c.getAPI()
 	if err != nil {
@@ -160,7 +160,7 @@ func (c *addUnitCommand) Run(_ *cmd.Context) error {
 		}
 		c.Placement[i] = p
 	}
-	_, err = apiclient.AddServiceUnits(c.ServiceName, c.NumUnits, c.Placement)
+	_, err = apiclient.AddUnits(c.ServiceName, c.NumUnits, c.Placement)
 	return block.ProcessBlockedError(err, block.BlockChange)
 }
 

--- a/cmd/juju/service/addunit_test.go
+++ b/cmd/juju/service/addunit_test.go
@@ -38,7 +38,7 @@ func (f *fakeServiceAddUnitAPI) ModelUUID() string {
 	return "fake-uuid"
 }
 
-func (f *fakeServiceAddUnitAPI) AddServiceUnits(service string, numUnits int, placement []*instance.Placement) ([]string, error) {
+func (f *fakeServiceAddUnitAPI) AddUnits(service string, numUnits int, placement []*instance.Placement) ([]string, error) {
 	if f.err != nil {
 		return nil, f.err
 	}

--- a/cmd/juju/service/bundle.go
+++ b/cmd/juju/service/bundle.go
@@ -280,19 +280,19 @@ func (h *bundleHandler) addService(id string, p bundlechanges.AddServiceParams) 
 	}
 	// Update service configuration.
 	if configYAML != "" {
-		if err := h.serviceClient.ServiceUpdate(params.ServiceUpdate{
+		if err := h.serviceClient.Update(params.ServiceUpdate{
 			ServiceName:  p.Service,
 			SettingsYAML: configYAML,
 		}); err != nil {
 			// This should never happen as possible errors are already returned
-			// by the ServiceDeploy call above.
+			// by the service Deploy call above.
 			return errors.Annotatef(err, "cannot update options for service %q", p.Service)
 		}
 		h.log.Infof("configuration updated for service %s", p.Service)
 	}
 	// Update service constraints.
 	if p.Constraints != "" {
-		if err := h.serviceClient.SetServiceConstraints(p.Service, cons); err != nil {
+		if err := h.serviceClient.SetConstraints(p.Service, cons); err != nil {
 			// This should never happen, as the bundle is already verified.
 			return errors.Annotatef(err, "cannot update constraints for service %q", p.Service)
 		}
@@ -431,7 +431,7 @@ func (h *bundleHandler) addUnit(id string, p bundlechanges.AddUnitParams) error 
 		}
 		placementArg = append(placementArg, placement)
 	}
-	r, err := h.serviceClient.AddServiceUnits(service, 1, placementArg)
+	r, err := h.serviceClient.AddUnits(service, 1, placementArg)
 	if err != nil {
 		return errors.Annotatef(err, "cannot add unit for service %q", service)
 	}
@@ -456,7 +456,7 @@ func (h *bundleHandler) addUnit(id string, p bundlechanges.AddUnitParams) error 
 // exposeService exposes a service.
 func (h *bundleHandler) exposeService(id string, p bundlechanges.ExposeParams) error {
 	service := resolve(p.Service, h.results)
-	if err := h.serviceClient.ServiceExpose(service); err != nil {
+	if err := h.serviceClient.Expose(service); err != nil {
 		return errors.Annotatef(err, "cannot expose service %s", service)
 	}
 	h.log.Infof("service %s exposed", service)
@@ -675,7 +675,7 @@ func resolve(placeholder string, results map[string]string) string {
 // This function returns an error if the existing charm and the target one are
 // incompatible, meaning an upgrade from one to the other is not allowed.
 func upgradeCharm(client *apiservice.Client, log deploymentLogger, service, id string) error {
-	existing, err := client.ServiceGetCharmURL(service)
+	existing, err := client.GetCharmURL(service)
 	if err != nil {
 		return errors.Annotatef(err, "cannot retrieve info for service %q", service)
 	}
@@ -690,7 +690,7 @@ func upgradeCharm(client *apiservice.Client, log deploymentLogger, service, id s
 	if url.WithRevision(-1).Path() != existing.WithRevision(-1).Path() {
 		return errors.Errorf("bundle charm %q is incompatible with existing charm %q", id, existing)
 	}
-	if err := client.ServiceSetCharm(service, id, false, false); err != nil {
+	if err := client.SetCharm(service, id, false, false); err != nil {
 		return errors.Annotatef(err, "cannot upgrade charm to %q", id)
 	}
 	log.Infof("upgraded charm for existing service %s (from %s to %s)", service, existing, id)

--- a/cmd/juju/service/constraints.go
+++ b/cmd/juju/service/constraints.go
@@ -69,8 +69,8 @@ func NewServiceGetConstraintsCommand() cmd.Command {
 
 type serviceConstraintsAPI interface {
 	Close() error
-	GetServiceConstraints(string) (constraints.Value, error)
-	SetServiceConstraints(string, constraints.Value) error
+	GetConstraints(string) (constraints.Value, error)
+	SetConstraints(string, constraints.Value) error
 }
 
 type serviceConstraintsCommand struct {
@@ -135,7 +135,7 @@ func (c *serviceGetConstraintsCommand) Run(ctx *cmd.Context) error {
 	}
 	defer apiclient.Close()
 
-	cons, err := apiclient.GetServiceConstraints(c.ServiceName)
+	cons, err := apiclient.GetConstraints(c.ServiceName)
 	if err != nil {
 		return err
 	}
@@ -182,6 +182,6 @@ func (c *serviceSetConstraintsCommand) Run(_ *cmd.Context) (err error) {
 	}
 	defer apiclient.Close()
 
-	err = apiclient.SetServiceConstraints(c.ServiceName, c.Constraints)
+	err = apiclient.SetConstraints(c.ServiceName, c.Constraints)
 	return block.ProcessBlockedError(err, block.BlockChange)
 }

--- a/cmd/juju/service/deploy.go
+++ b/cmd/juju/service/deploy.go
@@ -585,7 +585,7 @@ func (c *serviceDeployer) serviceDeploy(args serviceDeployParams) error {
 		}
 		args.placement[i] = p
 	}
-	return serviceClient.ServiceDeploy(
+	return serviceClient.Deploy(
 		args.charmURL,
 		args.serviceName,
 		args.series,

--- a/cmd/juju/service/deploy_test.go
+++ b/cmd/juju/service/deploy_test.go
@@ -203,7 +203,7 @@ func (s *DeploySuite) TestUpgradeReportsDeprecated(c *gc.C) {
 
 func (s *DeploySuite) TestUpgradeCharmDir(c *gc.C) {
 	// Add the charm, so the url will exist and a new revision will be
-	// picked in ServiceDeploy.
+	// picked in service Deploy.
 	dummyCharm := s.AddTestingCharm(c, "dummy")
 
 	dirPath := testcharms.Repo.ClonedDirPath(s.SeriesPath, "dummy")

--- a/cmd/juju/service/expose.go
+++ b/cmd/juju/service/expose.go
@@ -48,8 +48,8 @@ func (c *exposeCommand) Init(args []string) error {
 
 type serviceExposeAPI interface {
 	Close() error
-	ServiceExpose(serviceName string) error
-	ServiceUnexpose(serviceName string) error
+	Expose(serviceName string) error
+	Unexpose(serviceName string) error
 }
 
 func (c *exposeCommand) getAPI() (serviceExposeAPI, error) {
@@ -68,5 +68,5 @@ func (c *exposeCommand) Run(_ *cmd.Context) error {
 		return err
 	}
 	defer client.Close()
-	return block.ProcessBlockedError(client.ServiceExpose(c.ServiceName), block.BlockChange)
+	return block.ProcessBlockedError(client.Expose(c.ServiceName), block.BlockChange)
 }

--- a/cmd/juju/service/fakeservice_test.go
+++ b/cmd/juju/service/fakeservice_test.go
@@ -21,7 +21,7 @@ type fakeServiceAPI struct {
 	err         error
 }
 
-func (f *fakeServiceAPI) ServiceUpdate(args params.ServiceUpdate) error {
+func (f *fakeServiceAPI) Update(args params.ServiceUpdate) error {
 	if f.err != nil {
 		return f.err
 	}
@@ -38,7 +38,7 @@ func (f *fakeServiceAPI) Close() error {
 	return nil
 }
 
-func (f *fakeServiceAPI) ServiceGet(service string) (*params.ServiceGetResults, error) {
+func (f *fakeServiceAPI) Get(service string) (*params.ServiceGetResults, error) {
 	if service != f.serviceName {
 		return nil, errors.NotFoundf("service %q", service)
 	}
@@ -59,7 +59,7 @@ func (f *fakeServiceAPI) ServiceGet(service string) (*params.ServiceGetResults, 
 	}, nil
 }
 
-func (f *fakeServiceAPI) ServiceSet(service string, options map[string]string) error {
+func (f *fakeServiceAPI) Set(service string, options map[string]string) error {
 	if f.err != nil {
 		return f.err
 	}
@@ -78,7 +78,7 @@ func (f *fakeServiceAPI) ServiceSet(service string, options map[string]string) e
 	return nil
 }
 
-func (f *fakeServiceAPI) ServiceUnset(service string, options []string) error {
+func (f *fakeServiceAPI) Unset(service string, options []string) error {
 	if f.err != nil {
 		return f.err
 	}

--- a/cmd/juju/service/get.go
+++ b/cmd/juju/service/get.go
@@ -84,7 +84,7 @@ func (c *getCommand) Init(args []string) error {
 // that the service get command calls.
 type getServiceAPI interface {
 	Close() error
-	ServiceGet(service string) (*params.ServiceGetResults, error)
+	Get(service string) (*params.ServiceGetResults, error)
 }
 
 func (c *getCommand) getAPI() (getServiceAPI, error) {
@@ -107,7 +107,7 @@ func (c *getCommand) Run(ctx *cmd.Context) error {
 	}
 	defer apiclient.Close()
 
-	results, err := apiclient.ServiceGet(c.ServiceName)
+	results, err := apiclient.Get(c.ServiceName)
 	if err != nil {
 		return err
 	}

--- a/cmd/juju/service/removeservice.go
+++ b/cmd/juju/service/removeservice.go
@@ -59,8 +59,8 @@ func (c *removeServiceCommand) Init(args []string) error {
 
 type ServiceRemoveAPI interface {
 	Close() error
-	ServiceDestroy(serviceName string) error
-	DestroyServiceUnits(unitNames ...string) error
+	Destroy(serviceName string) error
+	DestroyUnits(unitNames ...string) error
 }
 
 func (c *removeServiceCommand) getAPI() (ServiceRemoveAPI, error) {
@@ -77,5 +77,5 @@ func (c *removeServiceCommand) Run(_ *cmd.Context) error {
 		return err
 	}
 	defer client.Close()
-	return block.ProcessBlockedError(client.ServiceDestroy(c.ServiceName), block.BlockRemove)
+	return block.ProcessBlockedError(client.Destroy(c.ServiceName), block.BlockRemove)
 }

--- a/cmd/juju/service/removeunit.go
+++ b/cmd/juju/service/removeunit.go
@@ -75,5 +75,5 @@ func (c *removeUnitCommand) Run(_ *cmd.Context) error {
 		return err
 	}
 	defer client.Close()
-	return block.ProcessBlockedError(client.DestroyServiceUnits(c.UnitNames...), block.BlockRemove)
+	return block.ProcessBlockedError(client.DestroyUnits(c.UnitNames...), block.BlockRemove)
 }

--- a/cmd/juju/service/set.go
+++ b/cmd/juju/service/set.go
@@ -95,10 +95,10 @@ func (c *setCommand) Init(args []string) error {
 // that the service set command calls.
 type serviceAPI interface {
 	Close() error
-	ServiceUpdate(args params.ServiceUpdate) error
-	ServiceGet(service string) (*params.ServiceGetResults, error)
-	ServiceSet(service string, options map[string]string) error
-	ServiceUnset(service string, options []string) error
+	Update(args params.ServiceUpdate) error
+	Get(service string) (*params.ServiceGetResults, error)
+	Set(service string, options map[string]string) error
+	Unset(service string, options []string) error
 }
 
 func (c *setCommand) getServiceAPI() (serviceAPI, error) {
@@ -125,12 +125,12 @@ func (c *setCommand) Run(ctx *cmd.Context) error {
 		if err != nil {
 			return err
 		}
-		return block.ProcessBlockedError(apiclient.ServiceUpdate(params.ServiceUpdate{
+		return block.ProcessBlockedError(apiclient.Update(params.ServiceUpdate{
 			ServiceName:  c.ServiceName,
 			SettingsYAML: string(b),
 		}), block.BlockChange)
 	} else if c.SetDefault {
-		return block.ProcessBlockedError(apiclient.ServiceUnset(c.ServiceName, c.Options), block.BlockChange)
+		return block.ProcessBlockedError(apiclient.Unset(c.ServiceName, c.Options), block.BlockChange)
 	} else if len(c.SettingsStrings) == 0 {
 		return nil
 	}
@@ -159,7 +159,7 @@ func (c *setCommand) Run(ctx *cmd.Context) error {
 		settings[k] = nv
 	}
 
-	result, err := apiclient.ServiceGet(c.ServiceName)
+	result, err := apiclient.Get(c.ServiceName)
 	if err != nil {
 		return err
 	}
@@ -176,7 +176,7 @@ func (c *setCommand) Run(ctx *cmd.Context) error {
 		}
 	}
 
-	return block.ProcessBlockedError(apiclient.ServiceSet(c.ServiceName, settings), block.BlockChange)
+	return block.ProcessBlockedError(apiclient.Set(c.ServiceName, settings), block.BlockChange)
 }
 
 // readValue reads the value of an option out of the named file.

--- a/cmd/juju/service/unexpose.go
+++ b/cmd/juju/service/unexpose.go
@@ -55,5 +55,5 @@ func (c *unexposeCommand) Run(_ *cmd.Context) error {
 		return err
 	}
 	defer client.Close()
-	return block.ProcessBlockedError(client.ServiceUnexpose(c.ServiceName), block.BlockChange)
+	return block.ProcessBlockedError(client.Unexpose(c.ServiceName), block.BlockChange)
 }

--- a/cmd/juju/service/upgradecharm.go
+++ b/cmd/juju/service/upgradecharm.go
@@ -160,7 +160,7 @@ func (c *upgradeCharmCommand) Run(ctx *cmd.Context) error {
 		return err
 	}
 
-	oldURL, err := serviceClient.ServiceGetCharmURL(c.ServiceName)
+	oldURL, err := serviceClient.GetCharmURL(c.ServiceName)
 	if err != nil {
 		return err
 	}
@@ -186,7 +186,7 @@ func (c *upgradeCharmCommand) Run(ctx *cmd.Context) error {
 	}
 
 	return block.ProcessBlockedError(
-		serviceClient.ServiceSetCharm(c.ServiceName, addedURL.String(), c.ForceSeries, c.ForceUnits),
+		serviceClient.SetCharm(c.ServiceName, addedURL.String(), c.ForceSeries, c.ForceUnits),
 		block.BlockChange)
 }
 

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -31,7 +31,7 @@ github.com/juju/persistent-cookiejar	git	c1502e864932ca865fc79c94bb39e7ccd7edf7e
 github.com/juju/ratelimit	git	aa5bb718d4d435629821789cb90970319f57bfe5	2015-03-30T01:41:32Z
 github.com/juju/replicaset	git	fb7294cf57a1e2f08a57691f1246d129a87ab7e8	2015-05-08T02:21:43Z
 github.com/juju/retry	git	62c62032529169c7ec02fa48f93349604c345e1f	2015-10-29T02:48:21Z
-github.com/juju/romulus	git	b1f6548d9e3f265d7c414d06d6b13e9ad6512d41	2016-02-03T20:09:25Z
+github.com/juju/romulus	git	0deb16c33672da011b3302c0e0e24f285cec788c	2016-02-05T05:56:18Z
 github.com/juju/schema	git	afe1151cb49d1d7ed3c75592dfc6f38703f2e988	2015-08-07T07:58:08Z
 github.com/juju/testing	git	3a4202497a8bff67966ecb327a0505fea8bb6ead	2015-11-23T15:50:06Z
 github.com/juju/txn	git	99ec629d0066a4d73c54d8e021a7fc1dc07df614	2015-06-09T16:58:27Z


### PR DESCRIPTION
When service facade methods were on the Client facade, they needed to be called ServiceGet or ServiceDeploy etc. Now that they're on the Service facade, this is unnecessary. 

Also remove an obsolete method.

(Review request: http://reviews.vapour.ws/r/3749/)