### PR TITLE
lp:1542336 Revert PR #4131 from tych0/bump-lxd-api

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -38,7 +38,7 @@ github.com/juju/txn	git	99ec629d0066a4d73c54d8e021a7fc1dc07df614	2015-06-09T16:5
 github.com/juju/utils	git	93acdddf8455dcb95aa63f2e2f707e5f8c199754	2016-01-20T00:56:23Z
 github.com/juju/xml	git	eb759a627588d35166bc505fceb51b88500e291e	2015-04-13T13:11:21Z
 github.com/julienschmidt/httprouter	git	109e267447e95ad1bb48b758e40dd7453eb7b039	2015-09-05T17:25:33Z
-github.com/lxc/lxd	git	a65b71bfe278458fc5ded4bc92f7ccc082e335e4	2015-10-27T22:33:42Z
+github.com/lxc/lxd	git	42b4c228e84cba622f221e04a1fa7164a416a440	2015-10-27T22:33:42Z
 github.com/mattn/go-colorable	git	40e4aedc8fabf8c23e040057540867186712faa5	2015-06-25T15:46:42Z
 github.com/mattn/go-runewidth	git	d96d1bd051f2bd9e7e43d602782b37b93b1b5666	2015-11-18T07:21:59Z
 github.com/mattn/go-isatty	git	d6aaa2f596ae91a0a58d8e7f2c79670991468e4f	2015-11-07T15:36:48Z

--- a/provider/lxd/config.go
+++ b/provider/lxd/config.go
@@ -63,6 +63,7 @@ lxd:
     #
     # You will also need to prepare the "ubuntu" images that Juju uses:
     #
+    #   lxc remote add images images.linuxcontainers.org
     #   lxd-images import ubuntu --alias ubuntu-wily wily
     #
     # (Also consider the --stream and --sync options.)

--- a/provider/lxd/config_test.go
+++ b/provider/lxd/config_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 
 	jc "github.com/juju/testing/checkers"
+	lxdlib "github.com/lxc/lxd"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/environs"
@@ -60,7 +61,7 @@ func (s *configSuite) TestClientConfigLocal(c *gc.C) {
 
 	c.Check(clientCfg, jc.DeepEquals, lxdclient.Config{
 		Namespace: cfg.Name(),
-		Dirname:   lxdclient.ConfigPath("juju-testenv"),
+		Dirname:   lxdlib.ConfigPath("juju-testenv"),
 		Remote: lxdclient.Remote{
 			Name: "juju-remote",
 			Host: "",
@@ -83,7 +84,7 @@ func (s *configSuite) TestClientConfigNonLocal(c *gc.C) {
 
 	c.Check(clientCfg, jc.DeepEquals, lxdclient.Config{
 		Namespace: cfg.Name(),
-		Dirname:   lxdclient.ConfigPath("juju-testenv"),
+		Dirname:   lxdlib.ConfigPath("juju-testenv"),
 		Remote: lxdclient.Remote{
 			Name: "juju-remote",
 			Host: "10.0.0.1",

--- a/provider/lxd/lxdclient/client.go
+++ b/provider/lxd/lxdclient/client.go
@@ -6,8 +6,6 @@
 package lxdclient
 
 import (
-	"path"
-
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/lxc/lxd"
@@ -54,7 +52,11 @@ var lxdLoadConfig = lxd.LoadConfig
 func newRawClient(remote, configDir string) (*lxd.Client, error) {
 	logger.Debugf("loading LXD client config from %q", configDir)
 
-	cfg, err := lxdLoadConfig(path.Join(configDir, "config.yml"))
+	// This will go away once LoadConfig takes a dirname argument.
+	origDirname := updateLXDVars(configDir)
+	defer updateLXDVars(origDirname)
+
+	cfg, err := lxdLoadConfig()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/provider/lxd/lxdclient/client_raw.go
+++ b/provider/lxd/lxdclient/client_raw.go
@@ -63,7 +63,7 @@ type rawImageMethods interface {
 	//PutImageProperties(name string, p shared.ImageProperties) error
 
 	// image data (create, upload, download, destroy)
-	CopyImage(image string, dest *lxd.Client, copy_aliases bool, aliases []string, public bool, progressHandler func(string)) error
+	CopyImage(image string, dest *lxd.Client, copy_aliases bool, aliases []string, public bool) error
 	ImageFromContainer(cname string, public bool, aliases []string, properties map[string]string) (string, error)
 	PostImage(imageFile string, rootfsFile string, properties []string, public bool, aliases []string) (string, error)
 	ExportImage(image string, target string) (*lxd.Response, string, error)
@@ -90,7 +90,7 @@ type rawContainerMethods interface {
 	// container data (create, actions, destroy)
 	Init(name string, imgremote string, image string, profiles *[]string, config map[string]string, ephem bool) (*lxd.Response, error)
 	LocalCopy(source string, name string, config map[string]string, profiles []string, ephemeral bool) (*lxd.Response, error)
-	MigrateFrom(name string, operation string, secrets map[string]string, architecture int, config map[string]string, devices shared.Devices, profiles []string, baseImage string, ephemeral bool) (*lxd.Response, error)
+	MigrateFrom(name string, operation string, secrets map[string]string, config map[string]string, profiles []string, baseImage string, ephemeral bool) (*lxd.Response, error)
 	Action(name string, action shared.ContainerAction, timeout int, force bool) (*lxd.Response, error)
 	Delete(name string) (*lxd.Response, error)
 

--- a/provider/lxd/lxdclient/config_test.go
+++ b/provider/lxd/lxdclient/config_test.go
@@ -7,7 +7,6 @@ package lxdclient_test
 
 import (
 	"io/ioutil"
-	"path"
 	"path/filepath"
 
 	"github.com/juju/errors"
@@ -65,8 +64,6 @@ func (s *configSuite) TestWithDefaultsMissingDirname(c *gc.C) {
 	}
 	updated, err := cfg.WithDefaults()
 	c.Assert(err, jc.ErrorIsNil)
-
-	c.Logf("path.Clean of dirname is %s (dirname is %s)", path.Clean(updated.Dirname), updated.Dirname)
 
 	c.Check(updated, jc.DeepEquals, lxdclient.Config{
 		Namespace: "my-ns",
@@ -175,6 +172,11 @@ func (s *configFunctionalSuite) SetUpTest(c *gc.C) {
 
 	s.client = newLocalClient(c)
 
+	origConfigDir := lxd.ConfigDir
+	s.AddCleanup(func(c *gc.C) {
+		lxd.ConfigDir = origConfigDir
+	})
+
 	if s.client != nil {
 		origCerts, err := s.client.ListCerts()
 		c.Assert(err, jc.ErrorIsNil)
@@ -234,6 +236,11 @@ func (s *configFunctionalSuite) TestUsingTCPRemote(c *gc.C) {
 }
 
 func newLocalClient(c *gc.C) *lxdclient.Client {
+	origConfigDir := lxd.ConfigDir
+	defer func() {
+		lxd.ConfigDir = origConfigDir
+	}()
+
 	client, err := lxdclient.Connect(lxdclient.Config{
 		Namespace: "my-ns",
 		Dirname:   c.MkDir(),

--- a/provider/lxd/lxdclient/lxd_client.go
+++ b/provider/lxd/lxdclient/lxd_client.go
@@ -20,29 +20,29 @@ const (
 	StatusStopping = "Stopping"
 	StatusStopped  = "Stopped"
 
-	StatusOperationCreated = "Operation created"
-	StatusPending          = "Pending"
-	StatusAborting         = "Aborting"
-	StatusCancelling       = "Canceling"
-	StatusCancelled        = "Canceled"
-	StatusSuccess          = "Success"
-	StatusFailure          = "Failure"
+	StatusOK         = "OK"
+	StatusPending    = "Pending"
+	StatusAborting   = "Aborting"
+	StatusCancelling = "Canceling"
+	StatusCancelled  = "Canceled"
+	StatusSuccess    = "Success"
+	StatusFailure    = "Failure"
 )
 
 var allStatuses = map[string]shared.StatusCode{
-	StatusStarting:         shared.Starting,
-	StatusStarted:          shared.Started,
-	StatusRunning:          shared.Running,
-	StatusFreezing:         shared.Freezing,
-	StatusFrozen:           shared.Frozen,
-	StatusThawed:           shared.Thawed,
-	StatusStopping:         shared.Stopping,
-	StatusStopped:          shared.Stopped,
-	StatusOperationCreated: shared.OperationCreated,
-	StatusPending:          shared.Pending,
-	StatusAborting:         shared.Aborting,
-	StatusCancelling:       shared.Cancelling,
-	StatusCancelled:        shared.Cancelled,
-	StatusSuccess:          shared.Success,
-	StatusFailure:          shared.Failure,
+	StatusStarting:   shared.Starting,
+	StatusStarted:    shared.Started,
+	StatusRunning:    shared.Running,
+	StatusFreezing:   shared.Freezing,
+	StatusFrozen:     shared.Frozen,
+	StatusThawed:     shared.Thawed,
+	StatusStopping:   shared.Stopping,
+	StatusStopped:    shared.Stopped,
+	StatusOK:         shared.OK,
+	StatusPending:    shared.Pending,
+	StatusAborting:   shared.Aborting,
+	StatusCancelling: shared.Cancelling,
+	StatusCancelled:  shared.Cancelled,
+	StatusSuccess:    shared.Success,
+	StatusFailure:    shared.Failure,
 }

--- a/provider/lxd/provider_test.go
+++ b/provider/lxd/provider_test.go
@@ -89,6 +89,7 @@ lxd:
     #
     # You will also need to prepare the "ubuntu" images that Juju uses:
     #
+    #   lxc remote add images images.linuxcontainers.org
     #   lxd-images import ubuntu --alias ubuntu-wily wily
     #
     # (Also consider the --stream and --sync options.)

--- a/provider/lxd/testing_test.go
+++ b/provider/lxd/testing_test.go
@@ -14,6 +14,7 @@ import (
 	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/arch"
+	lxdlib "github.com/lxc/lxd"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cloudconfig/instancecfg"
@@ -123,6 +124,8 @@ func (s *BaseSuiteUnpatched) SetUpSuite(c *gc.C) {
 
 func (s *BaseSuiteUnpatched) SetUpTest(c *gc.C) {
 	s.IsolationSuite.SetUpTest(c)
+
+	s.PatchValue(&lxdlib.ConfigDir, c.MkDir())
 
 	s.initEnv(c)
 	s.initInst(c)


### PR DESCRIPTION
This reverts commit 0f406618bf782ddd6a28e85ff425ebbd2ae4eec5, reversing
changes made to e437afc06b04d98f71fedf42ca7b6864c92e250c.

PR 4131 brought in a new dependency that wasn't included
in dependencies.tsv.  tych0 was working on updating lxd
to not pull in "github.com/gosexy/gettext", so I am
reverting this patch until his work is done.

(Review request: http://reviews.vapour.ws/r/3752/)