### PR TITLE
Fall back to JUJU_HOME if JUJU_DATA not set

### DIFF
--- a/juju/osenv/home.go
+++ b/juju/osenv/home.go
@@ -61,6 +61,11 @@ func JujuXDGDataHomePath(names ...string) string {
 func JujuXDGDataHomeDir() string {
 	JujuXDGDataHomeDir := os.Getenv(JujuXDGDataHomeEnvKey)
 	if JujuXDGDataHomeDir == "" {
+		// TODO(wallyworld) - remove this legacy support when CI is updated
+		legacyHomeDir := os.Getenv("JUJU_HOME")
+		if legacyHomeDir != "" {
+			return legacyHomeDir
+		}
 		if runtime.GOOS == "windows" {
 			JujuXDGDataHomeDir = jujuXDGDataHomeWin()
 		} else {

--- a/juju/osenv/home_test.go
+++ b/juju/osenv/home_test.go
@@ -25,6 +25,11 @@ func (s *JujuXDGDataHomeSuite) TestStandardHome(c *gc.C) {
 	c.Assert(osenv.JujuXDGDataHome(), gc.Equals, testJujuXDGDataHome)
 }
 
+func (s *JujuXDGDataHomeSuite) TestLegacyHome(c *gc.C) {
+	s.PatchEnvironment("JUJU_HOME", "/some/path")
+	c.Assert(osenv.JujuXDGDataHomeDir(), gc.Equals, "/some/path")
+}
+
 func (s *JujuXDGDataHomeSuite) TestErrorHome(c *gc.C) {
 	// Invalid juju home leads to panic when retrieving.
 	f := func() { _ = osenv.JujuXDGDataHome() }


### PR DESCRIPTION
Until CI scripts are updated, we need to support JUJU_HOME

(Review request: http://reviews.vapour.ws/r/3764/)