### PR TITLE
Frontend for user registration

### DIFF
--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -247,33 +247,15 @@ func connectWebsocket(info *Info, opts DialOpts) (*websocket.Conn, *tls.Config, 
 	if err != nil {
 		return nil, nil, errors.Annotatef(err, "cannot make TLS configuration")
 	}
+	tlsConfig.InsecureSkipVerify = opts.InsecureSkipVerify
 	path := "/"
 	if info.ModelTag.Id() != "" {
 		path = apiPath(info.ModelTag, "/api")
 	}
-
-	// Dial all addresses at reasonable intervals.
-	try := parallel.NewTry(0, nil)
-	defer try.Kill()
-	for _, addr := range info.Addrs {
-		err := dialWebsocket(addr, path, opts, tlsConfig, try)
-		if err == parallel.ErrStopped {
-			break
-		}
-		if err != nil {
-			return nil, nil, errors.Trace(err)
-		}
-		select {
-		case <-time.After(opts.DialAddressInterval):
-		case <-try.Dead():
-		}
-	}
-	try.Close()
-	result, err := try.Result()
+	conn, err := dialWebSocket(info.Addrs, path, tlsConfig, opts)
 	if err != nil {
 		return nil, nil, errors.Trace(err)
 	}
-	conn := result.(*websocket.Conn)
 	logger.Infof("connection established to %q", conn.RemoteAddr())
 	return conn, tlsConfig, nil
 }
@@ -289,6 +271,35 @@ func tlsConfigForCACert(caCert string) (*tls.Config, error) {
 		// See commit 7fc118f015d8480dfad7831788e4b8c0432205e8 (PR 899).
 		ServerName: "juju-apiserver",
 	}, nil
+}
+
+// dialWebSocket dials a websocket with one of the provided addresses, the
+// specified URL path, TLS configuration, and dial options. Each of the
+// specified addresses will be attempted concurrently, and the first
+// successful connection will be returned.
+func dialWebSocket(addrs []string, path string, tlsConfig *tls.Config, opts DialOpts) (*websocket.Conn, error) {
+	// Dial all addresses at reasonable intervals.
+	try := parallel.NewTry(0, nil)
+	defer try.Kill()
+	for _, addr := range addrs {
+		err := dialWebsocket(addr, path, opts, tlsConfig, try)
+		if err == parallel.ErrStopped {
+			break
+		}
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		select {
+		case <-time.After(opts.DialAddressInterval):
+		case <-try.Dead():
+		}
+	}
+	try.Close()
+	result, err := try.Result()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return result.(*websocket.Conn), nil
 }
 
 // ConnectStream implements Connection.ConnectStream.

--- a/api/interface.go
+++ b/api/interface.go
@@ -92,6 +92,12 @@ type DialOpts struct {
 	// by Open, and any RoundTripper field
 	// the HTTP client is ignored.
 	BakeryClient *httpbakery.Client
+
+	// InsecureSkipVerify skips TLS certificate verification
+	// when connecting to the controller. This should only
+	// be used in tests, or when verification cannot be
+	// performed and the communication need not be secure.
+	InsecureSkipVerify bool
 }
 
 // DefaultDialOpts returns a DialOpts representing the default

--- a/api/usermanager/client_test.go
+++ b/api/usermanager/client_test.go
@@ -29,7 +29,7 @@ func (s *usermanagerSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *usermanagerSuite) TestAddUser(c *gc.C) {
-	tag, err := s.usermanager.AddUser("foobar", "Foo Bar", "password")
+	tag, _, err := s.usermanager.AddUser("foobar", "Foo Bar", "password")
 	c.Assert(err, jc.ErrorIsNil)
 
 	user, err := s.State.User(tag)
@@ -42,7 +42,7 @@ func (s *usermanagerSuite) TestAddUser(c *gc.C) {
 func (s *usermanagerSuite) TestAddExistingUser(c *gc.C) {
 	s.Factory.MakeUser(c, &factory.UserParams{Name: "foobar"})
 
-	_, err := s.usermanager.AddUser("foobar", "Foo Bar", "password")
+	_, _, err := s.usermanager.AddUser("foobar", "Foo Bar", "password")
 	c.Assert(err, gc.ErrorMatches, "failed to create user: user already exists")
 }
 
@@ -52,7 +52,7 @@ func (s *usermanagerSuite) TestAddUserResponseError(c *gc.C) {
 			return errors.New("call error")
 		},
 	)
-	_, err := s.usermanager.AddUser("foobar", "Foo Bar", "password")
+	_, _, err := s.usermanager.AddUser("foobar", "Foo Bar", "password")
 	c.Assert(err, gc.ErrorMatches, "call error")
 }
 
@@ -66,7 +66,7 @@ func (s *usermanagerSuite) TestAddUserResultCount(c *gc.C) {
 			return errors.New("wrong result type")
 		},
 	)
-	_, err := s.usermanager.AddUser("foobar", "Foo Bar", "password")
+	_, _, err := s.usermanager.AddUser("foobar", "Foo Bar", "password")
 	c.Assert(err, gc.ErrorMatches, "expected 1 result, got 2")
 }
 

--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -248,6 +248,7 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 	r.Register(controller.NewListCommand())
 	r.Register(controller.NewListBlocksCommand())
 	r.Register(controller.NewLoginCommand())
+	r.Register(controller.NewRegisterCommand())
 	r.Register(controller.NewRemoveBlocksCommand())
 	r.Register(controller.NewUseModelCommand())
 

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -252,6 +252,7 @@ var commandNames = []string{
 	"login",
 	"machine",
 	"publish",
+	"register",
 	"remove-all-blocks",
 	"remove-machine",  // alias for destroy-machine
 	"remove-relation", // alias for destroy-relation

--- a/cmd/juju/controller/export_test.go
+++ b/cmd/juju/controller/export_test.go
@@ -58,6 +58,12 @@ func NewLoginCommandForTest(apiOpen api.OpenFunc, getUserManager GetUserManagerF
 	}
 }
 
+// NewRegisterCommandForTest returns a RegisterCommand with the function used
+// to open the API connection mocked out.
+func NewRegisterCommandForTest(apiOpen api.OpenFunc) *registerCommand {
+	return &registerCommand{apiOpen: apiOpen}
+}
+
 type UseModelCommand struct {
 	*useModelCommand
 }

--- a/cmd/juju/controller/export_test.go
+++ b/cmd/juju/controller/export_test.go
@@ -60,8 +60,8 @@ func NewLoginCommandForTest(apiOpen api.OpenFunc, getUserManager GetUserManagerF
 
 // NewRegisterCommandForTest returns a RegisterCommand with the function used
 // to open the API connection mocked out.
-func NewRegisterCommandForTest(apiOpen api.OpenFunc) *registerCommand {
-	return &registerCommand{apiOpen: apiOpen}
+func NewRegisterCommandForTest(apiOpen api.OpenFunc, newAPIRoot modelcmd.OpenFunc) *registerCommand {
+	return &registerCommand{apiOpen: apiOpen, newAPIRoot: newAPIRoot}
 }
 
 type UseModelCommand struct {

--- a/cmd/juju/controller/register.go
+++ b/cmd/juju/controller/register.go
@@ -194,7 +194,7 @@ func (c *registerCommand) getParameters(ctx *cmd.Context) (*registrationParams, 
 
 	// Decode key, username, controller addresses from the string supplied
 	// on the command line.
-	decodedData, err := base64.RawURLEncoding.DecodeString(c.EncodedData)
+	decodedData, err := base64.URLEncoding.DecodeString(c.EncodedData)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/cmd/juju/controller/register.go
+++ b/cmd/juju/controller/register.go
@@ -1,0 +1,386 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package controller
+
+import (
+	"bufio"
+	"bytes"
+	"crypto/rand"
+	"encoding/asn1"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+	"github.com/juju/names"
+	"github.com/juju/utils"
+	"golang.org/x/crypto/nacl/secretbox"
+	"golang.org/x/crypto/ssh/terminal"
+
+	"github.com/juju/juju/api"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/controller"
+	"github.com/juju/juju/environs/configstore"
+	"github.com/juju/juju/juju"
+	"github.com/juju/juju/network"
+)
+
+// NewRegisterCommand returns a command to allow the user to register a controller.
+func NewRegisterCommand() cmd.Command {
+	cmd := &registerCommand{}
+	cmd.apiOpen = cmd.APIOpen
+	return modelcmd.WrapBase(cmd)
+}
+
+// registerCommand logs in to a Juju controller and caches the connection
+// information.
+type registerCommand struct {
+	modelcmd.JujuCommandBase
+	apiOpen     api.OpenFunc
+	EncodedData string
+}
+
+var registerDoc = `
+register connects to a Juju controller and completes the user registration
+process started with "juju add-user". The user must supply the string that
+was printed out by "juju add-user", which embeds the username to register,
+a secret key, and the addresses of the Juju controller.
+
+Executing "juju register" will prompt for a password, and set this as the
+initial password for the user. After setting this password, the registration
+string will be void and standard login and user management commands will
+become usable.
+
+See Also:
+    juju help add-user
+    juju help list-models
+    juju help use-models
+    juju help create-model
+    juju help switch
+`
+
+// Info implements Command.Info
+func (c *registerCommand) Info() *cmd.Info {
+	return &cmd.Info{
+		Name:    "register",
+		Args:    "<name>",
+		Purpose: "register a Juju Controller",
+		Doc:     registerDoc,
+	}
+}
+
+// SetFlags implements Command.Init.
+func (c *registerCommand) Init(args []string) error {
+	if len(args) < 1 {
+		return errors.New("registration data missing")
+	}
+	c.EncodedData, args = args[0], args[1:]
+	if err := cmd.CheckEmpty(args); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *registerCommand) Run(ctx *cmd.Context) error {
+
+	registrationParams, err := c.getParameters(ctx)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	// During registration we must set a new password. This has to be done
+	// atomically with the clearing of the secret key.
+	payloadBytes, err := json.Marshal(params.SecretKeyLoginRequestPayload{
+		registrationParams.newPassword,
+	})
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	// Make the registration call.
+	req := params.SecretKeyLoginRequest{
+		Nonce: registrationParams.nonce[:],
+		User:  registrationParams.userTag.String(),
+		PayloadCiphertext: secretbox.Seal(
+			nil, payloadBytes,
+			&registrationParams.nonce,
+			&registrationParams.key,
+		),
+	}
+	resp, err := c.secretKeyLogin(registrationParams.controllerAddrs, req)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	// Decrypt the response to authenticate the controller and
+	// obtain its CA certificate.
+	if len(resp.Nonce) != len(registrationParams.nonce) {
+		return errors.NotValidf("response nonce")
+	}
+	var respNonce [24]byte
+	copy(respNonce[:], resp.Nonce)
+	payloadBytes, ok := secretbox.Open(nil, resp.PayloadCiphertext, &respNonce, &registrationParams.key)
+	if !ok {
+		return errors.NotValidf("response payload")
+	}
+	var responsePayload params.SecretKeyLoginResponsePayload
+	if err := json.Unmarshal(payloadBytes, &responsePayload); err != nil {
+		return errors.Annotate(err, "unmarshalling response payload")
+	}
+	apiConn, err := c.passwordLogin(
+		registrationParams.userTag,
+		responsePayload.CACert,
+		registrationParams.newPassword,
+		registrationParams.controllerAddrs,
+	)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	defer apiConn.Close()
+
+	// Finally, record the credentials.
+	if _, err := c.cacheConnectionInfo(
+		registrationParams.controllerName,
+		registrationParams.userTag.Id(),
+		responsePayload.CACert,
+		registrationParams.newPassword,
+		apiConn,
+	); err != nil {
+		return errors.Trace(err)
+	}
+	return errors.Trace(modelcmd.SetCurrentController(
+		ctx, registrationParams.controllerName,
+	))
+}
+
+type registrationParams struct {
+	userTag         names.UserTag
+	controllerName  string
+	controllerAddrs []string
+	key             [32]byte
+	nonce           [24]byte
+	newPassword     string
+}
+
+// getParameters gets all of the parameters required for registering, prompting
+// the user as necessary.
+func (c *registerCommand) getParameters(ctx *cmd.Context) (*registrationParams, error) {
+
+	// Decode key, username, controller addresses from the string supplied
+	// on the command line.
+	decodedData, err := base64.RawURLEncoding.DecodeString(c.EncodedData)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	var info controller.RegistrationInfo
+	if _, err := asn1.Unmarshal(decodedData, &info); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	params := registrationParams{
+		controllerAddrs: info.Addrs,
+		userTag:         names.NewUserTag(info.User),
+	}
+	if len(info.SecretKey) != len(params.key) {
+		return nil, errors.NotValidf("secret key")
+	}
+	copy(params.key[:], info.SecretKey)
+
+	// Prompt the user for the controller name.
+	controllerName, err := c.promptControllerName(ctx.Stderr, ctx.Stdin)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	params.controllerName = controllerName
+
+	// Prompt the user for the new password to set.
+	newPassword, err := c.promptNewPassword(ctx.Stderr, ctx.Stdin)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	params.newPassword = newPassword
+
+	// Generate a random nonce for encrypting the request.
+	if _, err := rand.Read(params.nonce[:]); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	return &params, nil
+}
+
+func (c *registerCommand) secretKeyLogin(addrs []string, request params.SecretKeyLoginRequest) (*params.SecretKeyLoginResponse, error) {
+	buf, err := json.Marshal(&request)
+	if err != nil {
+		return nil, errors.Annotate(err, "marshalling request")
+	}
+	r := bytes.NewReader(buf)
+
+	// Determine which address to use by attempting to open an API
+	// connection with each of the addresses. Note that we don't
+	// set a username/password, so no login will be attempted; and
+	// we skip verification, because we don't know the CA certificate
+	// and we do not send anything sensitive.
+	opts := api.DefaultDialOpts()
+	opts.InsecureSkipVerify = true
+	conn, err := c.apiOpen(&api.Info{Addrs: addrs}, opts)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	apiAddr := conn.Addr()
+	if err := conn.Close(); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	// Using the address we connected to above, perform the request.
+	urlString := fmt.Sprintf("https://%s/register", apiAddr)
+	httpReq, err := http.NewRequest("POST", urlString, r)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpClient := utils.GetNonValidatingHTTPClient()
+	httpResp, err := httpClient.Do(httpReq)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	defer httpResp.Body.Close()
+
+	if httpResp.StatusCode != http.StatusOK {
+		var resp params.ErrorResult
+		if err := json.NewDecoder(httpResp.Body).Decode(&resp); err != nil {
+			return nil, errors.Trace(err)
+		}
+		return nil, resp.Error
+	}
+
+	var resp params.SecretKeyLoginResponse
+	if err := json.NewDecoder(httpResp.Body).Decode(&resp); err != nil {
+		return nil, errors.Trace(err)
+	}
+	return &resp, nil
+}
+
+func (c *registerCommand) passwordLogin(userTag names.UserTag, caCert, password string, addrs []string) (api.Connection, error) {
+	info := api.Info{
+		Addrs:    addrs,
+		CACert:   caCert,
+		Tag:      userTag,
+		Password: password,
+	}
+	apiConn, err := c.apiOpen(&info, api.DefaultDialOpts())
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return apiConn, nil
+}
+
+func (c *registerCommand) promptNewPassword(stderr io.Writer, stdin io.Reader) (string, error) {
+	password, err := c.readPassword("Enter password: ", stderr, stdin)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	if password == "" {
+		return "", errors.NewNotValid(nil, "you must specify a non-empty password")
+	}
+	passwordConfirmation, err := c.readPassword("Confirm password: ", stderr, stdin)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	if password != passwordConfirmation {
+		return "", errors.Errorf("passwords do not match")
+	}
+	return password, nil
+}
+
+func (c *registerCommand) promptControllerName(stderr io.Writer, stdin io.Reader) (string, error) {
+	fmt.Fprintf(stderr, "Please set a name for this controller: ")
+	defer stderr.Write([]byte{'\n'})
+	name, err := c.readLine(stdin)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return "", errors.NewNotValid(nil, "you must specify a non-empty controller name")
+	}
+	return name, nil
+}
+
+func (c *registerCommand) readPassword(prompt string, stderr io.Writer, stdin io.Reader) (string, error) {
+	fmt.Fprintf(stderr, "%s", prompt)
+	defer stderr.Write([]byte{'\n'})
+	if f, ok := stdin.(*os.File); ok && terminal.IsTerminal(int(f.Fd())) {
+		password, err := terminal.ReadPassword(int(f.Fd()))
+		if err != nil {
+			return "", errors.Trace(err)
+		}
+		return string(password), nil
+	}
+	return c.readLine(stdin)
+}
+
+func (c *registerCommand) readLine(stdin io.Reader) (string, error) {
+	// Read one byte at a time to avoid reading beyond the delimiter.
+	line, err := bufio.NewReader(byteAtATimeReader{stdin}).ReadString('\n')
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	return line[:len(line)-1], nil
+}
+
+func (c *registerCommand) cacheConnectionInfo(controllerName, user, caCert, password string, apiConn api.Connection) (configstore.EnvironInfo, error) {
+	store, err := configstore.Default()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	controllerTag, err := apiConn.ControllerTag()
+	if err != nil {
+		return nil, errors.Wrap(err, errors.New("juju controller too old to support login"))
+	}
+
+	connectedAddresses, err := network.ParseHostPorts(apiConn.Addr())
+	if err != nil {
+		// Should never happen, since we've just connected with it.
+		return nil, errors.Annotatef(err, "invalid API address %q", apiConn.Addr())
+	}
+	addressConnectedTo := connectedAddresses[0]
+
+	controllerInfo := store.CreateInfo(controllerName)
+	addrs, hosts, changed := juju.PrepareEndpointsForCaching(controllerInfo, apiConn.APIHostPorts(), addressConnectedTo)
+	if !changed {
+		logger.Infof("api addresses: %v", apiConn.APIHostPorts())
+		logger.Infof("address connected to: %v", addressConnectedTo)
+		return nil, errors.New("no addresses returned from prepare for caching")
+	}
+
+	controllerInfo.SetAPICredentials(configstore.APICredentials{
+		User:     user,
+		Password: password,
+	})
+	controllerInfo.SetAPIEndpoint(configstore.APIEndpoint{
+		Addresses:  addrs,
+		Hostnames:  hosts,
+		CACert:     caCert,
+		ServerUUID: controllerTag.Id(),
+	})
+	if err = controllerInfo.Write(); err != nil {
+		return nil, errors.Trace(err)
+	}
+	return controllerInfo, nil
+}
+
+type byteAtATimeReader struct {
+	io.Reader
+}
+
+func (r byteAtATimeReader) Read(out []byte) (int, error) {
+	return r.Reader.Read(out[:1])
+}

--- a/cmd/juju/controller/register_test.go
+++ b/cmd/juju/controller/register_test.go
@@ -102,7 +102,11 @@ func (s *RegisterSuite) encodeRegistrationData(c *gc.C, user string, secretKey [
 		SecretKey: secretKey,
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	return base64.RawURLEncoding.EncodeToString(data)
+	// Append some junk to the end of the encoded data to
+	// ensure that, if we have to pad the data in add-user,
+	// register can still decode it.
+	data = append(data, 0, 0, 0)
+	return base64.URLEncoding.EncodeToString(data)
 }
 
 func (s *RegisterSuite) seal(c *gc.C, message, key, nonce []byte) []byte {
@@ -181,9 +185,8 @@ func (s *RegisterSuite) TestRegister(c *gc.C) {
 		Password: "hunter2",
 	})
 	c.Assert(info.APIEndpoint(), jc.DeepEquals, configstore.APIEndpoint{
-		Addresses:  []string{s.apiConnection.addr},
-		CACert:     testing.CACert,
-		ServerUUID: testing.ModelTag.Id(),
+		Addresses: []string{s.apiConnection.addr},
+		CACert:    testing.CACert,
 	})
 
 	// The command should have logged into the controller with the

--- a/cmd/juju/controller/register_test.go
+++ b/cmd/juju/controller/register_test.go
@@ -1,0 +1,251 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package controller_test
+
+import (
+	"bytes"
+	"encoding/asn1"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+	"github.com/juju/names"
+	jc "github.com/juju/testing/checkers"
+	"golang.org/x/crypto/nacl/secretbox"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/api"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/juju/controller"
+	jujucontroller "github.com/juju/juju/controller"
+	"github.com/juju/juju/environs/configstore"
+	"github.com/juju/juju/testing"
+)
+
+type RegisterSuite struct {
+	testing.FakeJujuXDGDataHomeSuite
+	apiConnection *mockAPIConnection
+	store         configstore.Storage
+	apiOpenError  error
+	server        *httptest.Server
+	httpHandler   http.Handler
+}
+
+var _ = gc.Suite(&RegisterSuite{})
+
+func (s *RegisterSuite) SetUpTest(c *gc.C) {
+	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
+
+	s.apiOpenError = nil
+	s.httpHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+	s.server = httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		s.httpHandler.ServeHTTP(w, r)
+	}))
+
+	serverURL, err := url.Parse(s.server.URL)
+	c.Assert(err, jc.ErrorIsNil)
+	s.apiConnection = &mockAPIConnection{
+		controllerTag: testing.ModelTag,
+		addr:          serverURL.Host,
+	}
+
+	s.store = configstore.NewMem()
+	s.PatchValue(&configstore.Default, func() (configstore.Storage, error) {
+		return s.store, nil
+	})
+}
+
+func (s *RegisterSuite) TearDownTest(c *gc.C) {
+	s.server.Close()
+	s.FakeJujuXDGDataHomeSuite.TearDownTest(c)
+}
+
+func (s *RegisterSuite) apiOpen(info *api.Info, opts api.DialOpts) (api.Connection, error) {
+	if s.apiOpenError != nil {
+		return nil, s.apiOpenError
+	}
+	s.apiConnection.info = info
+	s.apiConnection.opts = opts
+	return s.apiConnection, nil
+}
+
+func (s *RegisterSuite) run(c *gc.C, stdin io.Reader, args ...string) (*cmd.Context, error) {
+	command := controller.NewRegisterCommandForTest(s.apiOpen)
+	err := testing.InitCommand(command, args)
+	c.Assert(err, jc.ErrorIsNil)
+	ctx := testing.Context(c)
+	ctx.Stdin = stdin
+	return ctx, command.Run(ctx)
+}
+
+func (s *RegisterSuite) encodeRegistrationData(c *gc.C, user string, secretKey []byte) string {
+	data, err := asn1.Marshal(jujucontroller.RegistrationInfo{
+		User:      user,
+		Addrs:     []string{s.apiConnection.addr},
+		SecretKey: secretKey,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	return base64.RawURLEncoding.EncodeToString(data)
+}
+
+func (s *RegisterSuite) seal(c *gc.C, message, key, nonce []byte) []byte {
+	var keyArray [32]byte
+	var nonceArray [24]byte
+	c.Assert(copy(keyArray[:], key), gc.Equals, len(keyArray))
+	c.Assert(copy(nonceArray[:], nonce), gc.Equals, len(nonceArray))
+	return secretbox.Seal(nil, message, &nonceArray, &keyArray)
+}
+
+func (s *RegisterSuite) TestInit(c *gc.C) {
+	registerCommand := controller.NewRegisterCommandForTest(nil)
+
+	err := testing.InitCommand(registerCommand, []string{})
+	c.Assert(err, gc.ErrorMatches, "registration data missing")
+
+	err = testing.InitCommand(registerCommand, []string{"foo"})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(registerCommand.EncodedData, gc.Equals, "foo")
+
+	err = testing.InitCommand(registerCommand, []string{"foo", "bar"})
+	c.Assert(err, gc.ErrorMatches, `unrecognized args: \["bar"\]`)
+}
+
+func (s *RegisterSuite) TestRegister(c *gc.C) {
+	secretKey := []byte(strings.Repeat("X", 32))
+	respNonce := []byte(strings.Repeat("X", 24))
+
+	var requests []*http.Request
+	var requestBodies [][]byte
+	responsePayloadPlaintext, err := json.Marshal(params.SecretKeyLoginResponsePayload{
+		testing.CACert,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	response, err := json.Marshal(params.SecretKeyLoginResponse{
+		Nonce:             respNonce,
+		PayloadCiphertext: s.seal(c, responsePayloadPlaintext, secretKey, respNonce),
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	s.httpHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests = append(requests, r)
+		requestBody, err := ioutil.ReadAll(requests[0].Body)
+		c.Check(err, jc.ErrorIsNil)
+		requestBodies = append(requestBodies, requestBody)
+		_, err = w.Write(response)
+		c.Check(err, jc.ErrorIsNil)
+	})
+
+	registrationData := s.encodeRegistrationData(c, "bob", secretKey)
+	stdin := strings.NewReader("controller-name\nhunter2\nhunter2\n")
+	_, err = s.run(c, stdin, registrationData)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// There should have been one POST command to "/register".
+	c.Assert(requests, gc.HasLen, 1)
+	c.Assert(requests[0].Method, gc.Equals, "POST")
+	c.Assert(requests[0].URL.Path, gc.Equals, "/register")
+	var request params.SecretKeyLoginRequest
+	err = json.Unmarshal(requestBodies[0], &request)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(request.User, jc.DeepEquals, "user-bob")
+	c.Assert(request.Nonce, gc.HasLen, 24)
+	requestPayloadPlaintext, err := json.Marshal(params.SecretKeyLoginRequestPayload{
+		"hunter2",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	expectedCiphertext := s.seal(c, requestPayloadPlaintext, secretKey, request.Nonce)
+	c.Assert(request.PayloadCiphertext, jc.DeepEquals, expectedCiphertext)
+
+	// The command should have logged into the controller with the
+	// new password.
+	c.Assert(s.apiConnection.info, jc.DeepEquals, &api.Info{
+		Addrs:    []string{s.apiConnection.addr},
+		CACert:   testing.CACert,
+		Tag:      names.NewUserTag("bob"),
+		Password: "hunter2",
+	})
+
+	// Finally, the controller information should be recorded with
+	// the specified controller name ("controller-name").
+	info, err := s.store.ReadInfo("controller-name")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(info.APICredentials(), jc.DeepEquals, configstore.APICredentials{
+		User:     "bob",
+		Password: "hunter2",
+	})
+	c.Assert(info.APIEndpoint(), jc.DeepEquals, configstore.APIEndpoint{
+		Addresses:  []string{s.apiConnection.addr},
+		Hostnames:  []string{s.apiConnection.addr},
+		CACert:     testing.CACert,
+		ServerUUID: testing.ModelTag.Id(),
+	})
+}
+
+func (s *RegisterSuite) TestRegisterInvalidRegistrationData(c *gc.C) {
+	_, err := s.run(c, bytes.NewReader(nil), "not base64")
+	c.Assert(err, gc.ErrorMatches, "illegal base64 data at input byte 3")
+
+	_, err = s.run(c, bytes.NewReader(nil), "YXNuLjEK")
+	c.Assert(err, gc.ErrorMatches, "asn1: structure error: .*")
+}
+
+func (s *RegisterSuite) TestRegisterEmptyControllerName(c *gc.C) {
+	secretKey := []byte(strings.Repeat("X", 32))
+	registrationData := s.encodeRegistrationData(c, "bob", secretKey)
+	stdin := strings.NewReader("\n")
+	_, err := s.run(c, stdin, registrationData)
+	c.Assert(err, gc.ErrorMatches, "you must specify a non-empty controller name")
+}
+
+func (s *RegisterSuite) TestRegisterEmptyPassword(c *gc.C) {
+	secretKey := []byte(strings.Repeat("X", 32))
+	registrationData := s.encodeRegistrationData(c, "bob", secretKey)
+	stdin := strings.NewReader("controller-name\n\n")
+	_, err := s.run(c, stdin, registrationData)
+	c.Assert(err, gc.ErrorMatches, "you must specify a non-empty password")
+}
+
+func (s *RegisterSuite) TestRegisterPasswordMismatch(c *gc.C) {
+	secretKey := []byte(strings.Repeat("X", 32))
+	registrationData := s.encodeRegistrationData(c, "bob", secretKey)
+	stdin := strings.NewReader("controller-name\nhunter2\nhunter3\n")
+	_, err := s.run(c, stdin, registrationData)
+	c.Assert(err, gc.ErrorMatches, "passwords do not match")
+}
+
+func (s *RegisterSuite) TestAPIOpenError(c *gc.C) {
+	secretKey := []byte(strings.Repeat("X", 32))
+	registrationData := s.encodeRegistrationData(c, "bob", secretKey)
+	stdin := strings.NewReader("controller-name\nhunter2\nhunter2\n")
+	s.apiOpenError = errors.New("open failed")
+	_, err := s.run(c, stdin, registrationData)
+	c.Assert(err, gc.ErrorMatches, `open failed`)
+}
+
+func (s *RegisterSuite) TestRegisterServerError(c *gc.C) {
+	secretKey := []byte(strings.Repeat("X", 32))
+	response, err := json.Marshal(params.ErrorResult{
+		Error: &params.Error{Message: "xyz", Code: "123"},
+	})
+
+	s.httpHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, err = w.Write(response)
+		c.Check(err, jc.ErrorIsNil)
+	})
+
+	registrationData := s.encodeRegistrationData(c, "bob", secretKey)
+	stdin := strings.NewReader("controller-name\nhunter2\nhunter2\n")
+	_, err = s.run(c, stdin, registrationData)
+	c.Assert(err, gc.ErrorMatches, "xyz")
+
+	_, err = s.store.ReadInfo("controller-name")
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+}

--- a/cmd/juju/user/add.go
+++ b/cmd/juju/user/add.go
@@ -116,12 +116,25 @@ func (c *addCommand) Run(ctx *cmd.Context) error {
 		return errors.Trace(err)
 	}
 
+	// Use URLEncoding so we don't get + or / in the string,
+	// and pad with zero bytes so we don't get =; this all
+	// makes it easier to copy & paste in a terminal.
+	//
+	// The embedded ASN.1 data is length-encoded, so the
+	// padding will not complicate decoding.
+	remainder := len(registrationData) % 3
+	for remainder > 0 {
+		registrationData = append(registrationData, 0)
+		remainder--
+	}
+	base64RegistrationData := base64.URLEncoding.EncodeToString(
+		registrationData,
+	)
+
 	fmt.Fprintf(ctx.Stdout, "User %q added\n", displayName)
 	fmt.Fprintf(ctx.Stdout, "Please send this command to %v:\n", c.User)
 	fmt.Fprintf(ctx.Stdout, "    juju register %s\n",
-		// Use RawURLEncoding so we don't get + or = in the string,
-		// making it easier to copy & paste in a terminal.
-		base64.RawURLEncoding.EncodeToString(registrationData),
+		base64RegistrationData,
 	)
 
 	return nil

--- a/cmd/juju/user/add_test.go
+++ b/cmd/juju/user/add_test.go
@@ -21,9 +21,7 @@ import (
 // This suite provides basic tests for the "add-user" command
 type UserAddCommandSuite struct {
 	BaseSuite
-	mockAPI        *mockAddUserAPI
-	randomPassword string
-	serverFilename string
+	mockAPI *mockAddUserAPI
 }
 
 var _ = gc.Suite(&UserAddCommandSuite{})
@@ -31,14 +29,7 @@ var _ = gc.Suite(&UserAddCommandSuite{})
 func (s *UserAddCommandSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 	s.mockAPI = &mockAddUserAPI{}
-	s.randomPassword = ""
-	s.serverFilename = ""
-	s.PatchValue(user.RandomPasswordNotify, func(pwd string) {
-		s.randomPassword = pwd
-	})
-	s.PatchValue(user.ServerFileNotify, func(filename string) {
-		s.serverFilename = filename
-	})
+	s.mockAPI.secretKey = []byte(strings.Repeat("X", 32))
 }
 
 func (s *UserAddCommandSuite) run(c *gc.C, args ...string) (*cmd.Context, error) {
@@ -53,71 +44,66 @@ func (s *UserAddCommandSuite) TestInit(c *gc.C) {
 		displayname string
 		outPath     string
 		errorString string
-	}{
-		{
-			errorString: "no username supplied",
-		}, {
-			args:    []string{"foobar"},
-			user:    "foobar",
-			outPath: "foobar.server",
-		}, {
-			args:        []string{"foobar", "Foo Bar"},
-			user:        "foobar",
-			displayname: "Foo Bar",
-			outPath:     "foobar.server",
-		}, {
-			args:        []string{"foobar", "Foo Bar", "extra"},
-			errorString: `unrecognized args: \["extra"\]`,
-		}, {
-			args:    []string{"foobar", "--output", "somefile"},
-			user:    "foobar",
-			outPath: "somefile",
-		}, {
-			args:    []string{"foobar", "-o", "somefile"},
-			user:    "foobar",
-			outPath: "somefile",
-		},
-	} {
-		c.Logf("test %d", i)
+	}{{
+		errorString: "no username supplied",
+	}, {
+		args: []string{"foobar"},
+		user: "foobar",
+	}, {
+		args:        []string{"foobar", "Foo Bar"},
+		user:        "foobar",
+		displayname: "Foo Bar",
+	}, {
+		args:        []string{"foobar", "Foo Bar", "extra"},
+		errorString: `unrecognized args: \["extra"\]`,
+	}} {
+		c.Logf("test %d (%q)", i, test.args)
 		wrappedCommand, command := user.NewAddCommandForTest(s.mockAPI)
 		err := testing.InitCommand(wrappedCommand, test.args)
 		if test.errorString == "" {
+			c.Check(err, jc.ErrorIsNil)
 			c.Check(command.User, gc.Equals, test.user)
 			c.Check(command.DisplayName, gc.Equals, test.displayname)
-			c.Check(command.OutPath, gc.Equals, test.outPath)
 		} else {
 			c.Check(err, gc.ErrorMatches, test.errorString)
 		}
 	}
 }
 
+/*
 func (s *UserAddCommandSuite) TestRandomPassword(c *gc.C) {
 	_, err := s.run(c, "foobar")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.randomPassword, gc.HasLen, 24)
 }
+*/
 
-func (s *UserAddCommandSuite) TestUsername(c *gc.C) {
+func (s *UserAddCommandSuite) TestAddUserWithWithUsername(c *gc.C) {
 	context, err := s.run(c, "foobar")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.mockAPI.username, gc.Equals, "foobar")
 	c.Assert(s.mockAPI.displayname, gc.Equals, "")
 	expected := `
-user "foobar" added
-server file written to .*foobar.server
+User "foobar" added
+Please send this command to foobar:
+    juju register MD0TBmZvb2JhcjAREw8xMjcuMC4wLjE6MTIzNDUEIFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhY
 `[1:]
-	c.Assert(testing.Stderr(context), gc.Matches, expected)
-	s.assertServerFileMatches(c, s.serverFilename, "foobar", s.randomPassword)
+	c.Assert(testing.Stdout(context), gc.Equals, expected)
+	c.Assert(testing.Stderr(context), gc.Equals, "")
 }
 
-func (s *UserAddCommandSuite) TestUsernameAndDisplayname(c *gc.C) {
+func (s *UserAddCommandSuite) TestAddUserWithUsernameAndDisplayname(c *gc.C) {
 	context, err := s.run(c, "foobar", "Foo Bar")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.mockAPI.username, gc.Equals, "foobar")
 	c.Assert(s.mockAPI.displayname, gc.Equals, "Foo Bar")
-	expected := `user "Foo Bar (foobar)" added`
-	c.Assert(testing.Stderr(context), jc.Contains, expected)
-	s.assertServerFileMatches(c, s.serverFilename, "foobar", s.randomPassword)
+	expected := `
+User "Foo Bar (foobar)" added
+Please send this command to foobar:
+    juju register MD0TBmZvb2JhcjAREw8xMjcuMC4wLjE6MTIzNDUEIFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhY
+`[1:]
+	c.Assert(testing.Stdout(context), gc.Equals, expected)
+	c.Assert(testing.Stderr(context), gc.Equals, "")
 }
 
 func (s *UserAddCommandSuite) TestBlockAddUser(c *gc.C) {
@@ -138,27 +124,25 @@ func (s *UserAddCommandSuite) TestAddUserErrorResponse(c *gc.C) {
 
 type mockAddUserAPI struct {
 	failMessage string
+	blocked     bool
+	secretKey   []byte
+
 	username    string
 	displayname string
 	password    string
-
-	shareFailMsg string
-	sharedUsers  []names.UserTag
-	blocked      bool
 }
 
-func (m *mockAddUserAPI) AddUser(username, displayname, password string) (names.UserTag, error) {
+func (m *mockAddUserAPI) AddUser(username, displayname, password string) (names.UserTag, []byte, error) {
 	if m.blocked {
-		return names.UserTag{}, common.OperationBlockedError("the operation has been blocked")
+		return names.UserTag{}, nil, common.OperationBlockedError("the operation has been blocked")
 	}
-
 	m.username = username
 	m.displayname = displayname
 	m.password = password
-	if m.failMessage == "" {
-		return names.NewLocalUserTag(username), nil
+	if m.failMessage != "" {
+		return names.UserTag{}, nil, errors.New(m.failMessage)
 	}
-	return names.UserTag{}, errors.New(m.failMessage)
+	return names.NewLocalUserTag(username), m.secretKey, nil
 }
 
 func (*mockAddUserAPI) Close() error {

--- a/controller/registration.go
+++ b/controller/registration.go
@@ -1,7 +1,19 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
 package controller
 
+// RegistrationInfo contains the user/controller registration information
+// printed by "juju add-user", and consumed by "juju register".
 type RegistrationInfo struct {
-	User      string
-	Addrs     []string
+	// User is the user name to log in as.
+	User string
+
+	// Addrs contains the "host:port" addresses of the Juju
+	// controller.
+	Addrs []string
+
+	// SecretKey contains the secret key to use when encrypting
+	// and decrypting registration requests and responses.
 	SecretKey []byte
 }

--- a/controller/registration.go
+++ b/controller/registration.go
@@ -1,0 +1,7 @@
+package controller
+
+type RegistrationInfo struct {
+	User      string
+	Addrs     []string
+	SecretKey []byte
+}

--- a/featuretests/cmd_juju_register_test.go
+++ b/featuretests/cmd_juju_register_test.go
@@ -1,0 +1,73 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package featuretests
+
+import (
+	"io"
+	"strings"
+
+	"github.com/juju/cmd"
+	"github.com/juju/loggo"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/cmd/juju/commands"
+	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/juju"
+	jujutesting "github.com/juju/juju/juju/testing"
+	"github.com/juju/juju/testing"
+)
+
+type cmdRegistrationSuite struct {
+	jujutesting.JujuConnSuite
+}
+
+func (s *cmdRegistrationSuite) run(c *gc.C, stdin io.Reader, args ...string) *cmd.Context {
+	context := testing.Context(c)
+	if stdin != nil {
+		context.Stdin = stdin
+	}
+	command := commands.NewJujuCommand(context)
+	c.Assert(testing.InitCommand(command, args), jc.ErrorIsNil)
+	c.Assert(command.Run(context), jc.ErrorIsNil)
+	loggo.RemoveWriter("warning") // remove logger added by main command
+	return context
+}
+
+func (s *cmdRegistrationSuite) TestAddUserAndRegister(c *gc.C) {
+	c.Assert(modelcmd.WriteCurrentController("dummymodel"), jc.ErrorIsNil)
+
+	// First, add user "bob", and record the "juju register" command
+	// that is printed out.
+	context := s.run(c, nil, "add-user", "bob", "Bob Dobbs")
+	c.Check(testing.Stderr(context), gc.Equals, "")
+	stdout := testing.Stdout(context)
+	c.Check(stdout, gc.Matches, `
+User "Bob Dobbs \(bob\)" added
+Please send this command to bob:
+    juju register .*
+`[1:])
+	jujuRegisterCommand := strings.Fields(strings.TrimSpace(
+		stdout[strings.Index(stdout, "juju register"):],
+	))
+	c.Logf("%q", jujuRegisterCommand)
+
+	// Now run the "juju register" command. We need to pass the
+	// controller name and password to set.
+	stdin := strings.NewReader("bob-controller\nhunter2\nhunter2\n")
+	args := jujuRegisterCommand[1:] // drop the "juju"
+	context = s.run(c, stdin, args...)
+	c.Check(testing.Stdout(context), gc.Equals, "")
+	c.Check(testing.Stderr(context), gc.Equals, `
+Enter password: 
+Confirm password: 
+dummymodel (controller) -> bob-controller (controller)
+`[1:])
+
+	// Make sure that the saved server details are sufficient to connect
+	// to the api server.
+	api, err := juju.NewAPIFromName("bob-controller", nil)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(api.Close(), jc.ErrorIsNil)
+}

--- a/featuretests/cmd_juju_register_test.go
+++ b/featuretests/cmd_juju_register_test.go
@@ -60,9 +60,12 @@ Please send this command to bob:
 	context = s.run(c, stdin, args...)
 	c.Check(testing.Stdout(context), gc.Equals, "")
 	c.Check(testing.Stderr(context), gc.Equals, `
+Please set a name for this controller: 
 Enter password: 
 Confirm password: 
 dummymodel (controller) -> bob-controller (controller)
+
+Welcome, bob. You are now logged into "bob-controller".
 `[1:])
 
 	// Make sure that the saved server details are sufficient to connect

--- a/featuretests/cmd_juju_user_test.go
+++ b/featuretests/cmd_juju_user_test.go
@@ -45,7 +45,7 @@ func (s *UserSuite) RunUserCommand(c *gc.C, args ...string) (*cmd.Context, error
 func (s *UserSuite) TestUserAdd(c *gc.C) {
 	ctx, err := s.RunUserCommand(c, "add-user", "test")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(testing.Stderr(ctx), jc.HasPrefix, `user "test" added`)
+	c.Assert(testing.Stdout(ctx), jc.HasPrefix, `User "test" added`)
 	user, err := s.State.User(names.NewLocalUserTag("test"))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(user.IsDisabled(), jc.IsFalse)

--- a/featuretests/package_test.go
+++ b/featuretests/package_test.go
@@ -38,6 +38,7 @@ func init() {
 	gc.Suite(&undertakerSuite{})
 	gc.Suite(&dumpLogsCommandSuite{})
 	gc.Suite(&upgradeSuite{})
+	gc.Suite(&cmdRegistrationSuite{})
 }
 
 func TestPackage(t *stdtesting.T) {


### PR DESCRIPTION
This branch modifies the "add-user" command, and
introduces the "register" command, to enable
adding users and securely registering controllers.

(Review request: http://reviews.vapour.ws/r/3765/)