### PR TITLE
cmd/juju/commands/bootstrap: always test sentinel value when retrying

### DIFF
--- a/apiserver/admin_test.go
+++ b/apiserver/admin_test.go
@@ -641,7 +641,7 @@ func (s *loginSuite) TestLoginValidationDuringUpgrade(c *gc.C) {
 		c.Assert(err, jc.ErrorIsNil)
 
 		err = st.APICall("Client", 1, "", "DestroyModel", nil, nil)
-		c.Assert(err, gc.ErrorMatches, ".*upgrade in progress - Juju functionality is limited.*")
+		c.Assert(err, gc.ErrorMatches, ".*upgrade in progress")
 	}
 	s.checkLoginWithValidator(c, validator, checker)
 }

--- a/apiserver/params/apierror.go
+++ b/apiserver/params/apierror.go
@@ -90,8 +90,7 @@ const (
 // the given error, or the empty string if there
 // is none.
 func ErrCode(err error) string {
-	err = errors.Cause(err)
-	if err, _ := err.(rpc.ErrorCoder); err != nil {
+	if err, ok := errors.Cause(err).(rpc.ErrorCoder); ok {
 		return err.ErrorCode()
 	}
 	return ""

--- a/apiserver/upgrading_root.go
+++ b/apiserver/upgrading_root.go
@@ -4,8 +4,6 @@
 package apiserver
 
 import (
-	"errors"
-
 	"github.com/juju/utils/set"
 
 	"github.com/juju/juju/rpc"
@@ -21,8 +19,6 @@ type upgradingRoot struct {
 func newUpgradingRoot(finder rpc.MethodFinder) *upgradingRoot {
 	return &upgradingRoot{finder}
 }
-
-var inUpgradeError = errors.New("upgrade in progress - Juju functionality is limited")
 
 var allowedMethodsDuringUpgrades = set.NewStrings(
 	"FullStatus",     // for "juju status"
@@ -47,7 +43,7 @@ func (r *upgradingRoot) FindMethod(rootName string, version int, methodName stri
 		return nil, err
 	}
 	if !IsMethodAllowedDuringUpgrade(rootName, methodName) {
-		return nil, inUpgradeError
+		return nil, UpgradeInProgressError
 	}
 	return caller, nil
 }

--- a/apiserver/upgrading_root_test.go
+++ b/apiserver/upgrading_root_test.go
@@ -35,7 +35,7 @@ func (r *upgradingRootSuite) TestFindDisallowedMethod(c *gc.C) {
 
 	caller, err := root.FindMethod("Client", 1, "ModelSet")
 
-	c.Assert(err, gc.ErrorMatches, "upgrade in progress - Juju functionality is limited")
+	c.Assert(err, gc.Equals, apiserver.UpgradeInProgressError)
 	c.Assert(caller, gc.IsNil)
 }
 

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/juju/utils/series"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/apiserver"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/juju/block"
 	"github.com/juju/juju/cmd/modelcmd"
@@ -116,13 +117,13 @@ type mockBlockClient struct {
 func (c *mockBlockClient) List() ([]params.Block, error) {
 	c.retryCount += 1
 	if c.retryCount == 5 {
-		return nil, fmt.Errorf("upgrade in progress")
+		return nil, apiserver.UpgradeInProgressError
 	}
 	if c.numRetries < 0 {
 		return nil, fmt.Errorf("other error")
 	}
 	if c.retryCount < c.numRetries {
-		return nil, fmt.Errorf("upgrade in progress")
+		return nil, apiserver.UpgradeInProgressError
 	}
 	return []params.Block{}, nil
 }

--- a/featuretests/upgrade_test.go
+++ b/featuretests/upgrade_test.go
@@ -7,7 +7,6 @@
 package featuretests
 
 import (
-	"strings"
 	"time"
 
 	"github.com/juju/names"
@@ -19,6 +18,7 @@ import (
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/api"
+	"github.com/juju/juju/apiserver"
 	"github.com/juju/juju/apiserver/params"
 	agentcmd "github.com/juju/juju/cmd/jujud/agent"
 	agenttesting "github.com/juju/juju/cmd/jujud/agent/testing"
@@ -297,7 +297,7 @@ func (s *upgradeSuite) checkLoginToAPIAsUser(c *gc.C, conf agent.Config, expectF
 				return
 			}
 		case RestrictedAPIExposed:
-			if err != nil && strings.HasPrefix(err.Error(), "upgrade in progress") {
+			if err != nil && err == apiserver.UpgradeInProgressError {
 				return
 			}
 		}


### PR DESCRIPTION
Update LP#1538583

During bootstrap cmd/juju would inspect the string value of an error to
determine if the error was one it could retry or not. All the errors it
was testing against have known sentinel values, so use those instead.

Also, unify all the places that apiserver.UpgradeInProcessError is used
rather than strings which look the same, plus some other information for
the user. If the text is to be changed, now we'll change it only in one
place.

(Review request: http://reviews.vapour.ws/r/3768/)