### PR TITLE
Extract base command from machine show/list

### DIFF
--- a/cmd/juju/machine/base.go
+++ b/cmd/juju/machine/base.go
@@ -1,0 +1,80 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package machine
+
+import (
+	"fmt"
+
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+	"launchpad.net/gnuflag"
+
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/juju/status"
+	"github.com/juju/juju/cmd/modelcmd"
+)
+
+// statusAPI defines the API methods for the list-mahines and show-machine commands.
+type statusAPI interface {
+	Status(pattern []string) (*params.FullStatus, error)
+	Close() error
+}
+
+// baseMachineCommand provides access to information about machines in a model.
+type baselistMachinesCommand struct {
+	modelcmd.ModelCommandBase
+	out           cmd.Output
+	isoTime       bool
+	api           statusAPI
+	machineIds    []string
+	defaultFormat string
+}
+
+// SetFlags sets utc and format flags based on user specified options.
+func (c *baselistMachinesCommand) SetFlags(f *gnuflag.FlagSet) {
+	f.BoolVar(&c.isoTime, "utc", false, "display time as UTC in RFC3339 format")
+	c.out.AddFlags(f, c.defaultFormat, map[string]cmd.Formatter{
+		"yaml":    cmd.FormatYaml,
+		"json":    cmd.FormatJson,
+		"tabular": status.FormatMachineTabular,
+	})
+}
+
+var connectionError = `Unable to connect to model %q.
+Please check your credentials or use 'juju bootstrap' to create a new model.
+
+Error details:
+%v
+`
+var newAPIClientForMachines = func(c *baselistMachinesCommand) (statusAPI, error) {
+	if c.api != nil {
+		return c.api, nil
+	}
+	return c.NewAPIClient()
+}
+
+// Run implements Command.Run for baseMachinesCommand.
+func (c *baselistMachinesCommand) Run(ctx *cmd.Context) error {
+	apiclient, err := newAPIClientForMachines(c)
+	if err != nil {
+		return errors.Errorf(connectionError, c.ConnectionName(), err)
+	}
+	defer apiclient.Close()
+
+	fullStatus, err := apiclient.Status(nil)
+	if err != nil {
+		if fullStatus == nil {
+			// Status call completely failed, there is nothing to report
+			return err
+		}
+		// Display any error, but continue to print status if some was returned
+		fmt.Fprintf(ctx.Stderr, "%v\n", err)
+	} else if fullStatus == nil {
+		return errors.Errorf("unable to obtain the current status")
+	}
+
+	formatter := status.NewStatusFormatter(fullStatus, c.isoTime)
+	formatted := formatter.MachineFormat(c.machineIds)
+	return c.out.Write(ctx, formatted)
+}

--- a/cmd/juju/machine/export_test.go
+++ b/cmd/juju/machine/export_test.go
@@ -29,17 +29,13 @@ func NewAddCommandForTest(api AddMachineAPI, mmApi MachineManagerAPI) (cmd.Comma
 
 // NewListCommandForTest returns a listMachineCommand with specified api
 func NewListCommandForTest(api statusAPI) cmd.Command {
-	cmd := &listMachinesCommand{
-		api: api,
-	}
+	cmd := newListMachinesCommand(api)
 	return modelcmd.Wrap(cmd)
 }
 
 // NewShowCommandForTest returns a showMachineCommand with specified api
 func NewShowCommandForTest(api statusAPI) cmd.Command {
-	cmd := &showMachineCommand{
-		api: api,
-	}
+	cmd := newShowMachineCommand(api)
 	return modelcmd.Wrap(cmd)
 }
 

--- a/cmd/juju/machine/list.go
+++ b/cmd/juju/machine/list.go
@@ -4,14 +4,9 @@
 package machine
 
 import (
-	"fmt"
-
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
-	"launchpad.net/gnuflag"
 
-	"github.com/juju/juju/apiserver/params"
-	"github.com/juju/juju/cmd/juju/status"
 	"github.com/juju/juju/cmd/modelcmd"
 )
 
@@ -23,23 +18,21 @@ ID, STATE, DNS, INS-ID, SERIES, AZ
 Note: AZ above is the cloud region's availability zone.
 `
 
-// statusAPI defines the API methods for the list-mahines and show-machine commands.
-type statusAPI interface {
-	Status(pattern []string) (*params.FullStatus, error)
-	Close() error
-}
-
 // NewListMachineCommand returns a command that lists the machines in a model.
 func NewListMachinesCommand() cmd.Command {
-	return modelcmd.Wrap(&listMachinesCommand{})
+	return modelcmd.Wrap(newListMachinesCommand(nil))
+}
+
+func newListMachinesCommand(api statusAPI) *listMachinesCommand {
+	listCmd := &listMachinesCommand{}
+	listCmd.defaultFormat = "tabular"
+	listCmd.api = api
+	return listCmd
 }
 
 // listMachineCommand holds infomation about machines in a model.
 type listMachinesCommand struct {
-	modelcmd.ModelCommandBase
-	out     cmd.Output
-	isoTime bool
-	api     statusAPI
+	baselistMachinesCommand
 }
 
 // Info implements Command.Info.
@@ -58,52 +51,4 @@ func (c *listMachinesCommand) Init(args []string) (err error) {
 		return errors.Errorf("The list-machines command does not take any arguments")
 	}
 	return nil
-}
-
-// SetFlags sets utc and format flags based on user specified options.
-func (c *listMachinesCommand) SetFlags(f *gnuflag.FlagSet) {
-	f.BoolVar(&c.isoTime, "utc", false, "display time as UTC in RFC3339 format")
-	c.out.AddFlags(f, "tabular", map[string]cmd.Formatter{
-		"yaml":    cmd.FormatYaml,
-		"json":    cmd.FormatJson,
-		"tabular": status.FormatMachineTabular,
-	})
-}
-
-var connectionError = `Unable to connect to model %q.
-Please check your credentials or use 'juju bootstrap' to create a new model.
-
-Error details:
-%v
-`
-var newAPIClientForListMachines = func(c *listMachinesCommand) (statusAPI, error) {
-	if c.api != nil {
-		return c.api, nil
-	}
-	return c.NewAPIClient()
-}
-
-// Run implements Command.Run for listMachineCommand.
-func (c *listMachinesCommand) Run(ctx *cmd.Context) error {
-	apiclient, err := newAPIClientForListMachines(c)
-	if err != nil {
-		return errors.Errorf(connectionError, c.ConnectionName(), err)
-	}
-	defer apiclient.Close()
-
-	fullStatus, err := apiclient.Status(nil)
-	if err != nil {
-		if fullStatus == nil {
-			// Status call completely failed, there is nothing to report
-			return err
-		}
-		// Display any error, but continue to print status if some was returned
-		fmt.Fprintf(ctx.Stderr, "%v\n", err)
-	} else if fullStatus == nil {
-		return errors.Errorf("unable to obtain the current status")
-	}
-
-	formatter := status.NewStatusFormatter(fullStatus, c.isoTime)
-	formatted := formatter.MachineFormat(nil)
-	return c.out.Write(ctx, formatted)
 }

--- a/cmd/juju/machine/show.go
+++ b/cmd/juju/machine/show.go
@@ -4,13 +4,8 @@
 package machine
 
 import (
-	"fmt"
-
 	"github.com/juju/cmd"
-	"github.com/juju/errors"
-	"launchpad.net/gnuflag"
 
-	"github.com/juju/juju/cmd/juju/status"
 	"github.com/juju/juju/cmd/modelcmd"
 )
 
@@ -35,16 +30,19 @@ tabular, and json
 
 // NewShowMachineCommand returns a command that shows details on the specified machine[s].
 func NewShowMachineCommand() cmd.Command {
-	return modelcmd.Wrap(&showMachineCommand{})
+	return modelcmd.Wrap(newShowMachineCommand(nil))
+}
+
+func newShowMachineCommand(api statusAPI) *showMachineCommand {
+	showCmd := &showMachineCommand{}
+	showCmd.defaultFormat = "yaml"
+	showCmd.api = api
+	return showCmd
 }
 
 // showMachineCommand struct holds details on the specified machine[s].
 type showMachineCommand struct {
-	modelcmd.ModelCommandBase
-	out       cmd.Output
-	isoTime   bool
-	machineId []string
-	api       statusAPI
+	baselistMachinesCommand
 }
 
 // Info implements Command.Info.
@@ -60,48 +58,6 @@ func (c *showMachineCommand) Info() *cmd.Info {
 
 // Init captures machineId's to show from CL args.
 func (c *showMachineCommand) Init(args []string) error {
-	c.machineId = args
+	c.machineIds = args
 	return nil
-}
-
-// SetFlags sets utc and format flags based on user specified options.
-func (c *showMachineCommand) SetFlags(f *gnuflag.FlagSet) {
-	f.BoolVar(&c.isoTime, "utc", false, "display time as UTC in RFC3339 format")
-	c.out.AddFlags(f, "yaml", map[string]cmd.Formatter{
-		"yaml":    cmd.FormatYaml,
-		"json":    cmd.FormatJson,
-		"tabular": status.FormatMachineTabular,
-	})
-}
-
-var newAPIClientForShowMachine = func(c *showMachineCommand) (statusAPI, error) {
-	if c.api != nil {
-		return c.api, nil
-	}
-	return c.NewAPIClient()
-}
-
-// Run implements Command.Run for showMachineCommand.
-func (c *showMachineCommand) Run(ctx *cmd.Context) error {
-	apiclient, err := newAPIClientForShowMachine(c)
-	if err != nil {
-		return errors.Errorf(connectionError, c.ConnectionName(), err)
-	}
-	defer apiclient.Close()
-
-	fullStatus, err := apiclient.Status(nil)
-	if err != nil {
-		if fullStatus == nil {
-			// Status call completely failed, there is nothing to report
-			return err
-		}
-		// Display any error, but continue to print status if some was returned
-		fmt.Fprintf(ctx.Stderr, "%v\n", err)
-	} else if fullStatus == nil {
-		return errors.Errorf("unable to obtain the current status")
-	}
-
-	formatter := status.NewStatusFormatter(fullStatus, c.isoTime)
-	formatted := formatter.MachineFormat(c.machineId)
-	return c.out.Write(ctx, formatted)
 }


### PR DESCRIPTION
The machine show and list commands used a lot of the same logic. By copying list.go -> base.go and deleting a bunch of stuff, we can reuse most of the logic between the two commands. List and Show become simple wrappers.

(Review request: http://reviews.vapour.ws/r/3770/)