### PR TITLE
rename show-service-resources to list-resources 

### DIFF
--- a/resource/cmd/formatted.go
+++ b/resource/cmd/formatted.go
@@ -41,3 +41,8 @@ type FormattedSvcResource struct {
 	usedYesNo        string
 	combinedOrigin   string
 }
+
+// FormattedUnitResource holds the formatted representation of a resource's info.
+type FormattedUnitResource struct {
+	FormattedSvcResource
+}

--- a/resource/cmd/formatter.go
+++ b/resource/cmd/formatter.go
@@ -79,7 +79,7 @@ func combinedRevision(r resource.Resource) string {
 		return fmt.Sprintf("%d", r.Revision)
 	case charmresource.OriginUpload:
 		if !r.Timestamp.IsZero() {
-			return r.Timestamp.Format("2006-02-01")
+			return r.Timestamp.Format("2006-02-01T15:04")
 		}
 	}
 	return "-"
@@ -88,6 +88,9 @@ func combinedRevision(r resource.Resource) string {
 func combinedOrigin(used bool, r resource.Resource) string {
 	if r.Origin == charmresource.OriginUpload && used && r.Username != "" {
 		return r.Username
+	}
+	if r.Origin == charmresource.OriginStore {
+		return "charmstore"
 	}
 	return r.Origin.String()
 }

--- a/resource/cmd/formatter_test.go
+++ b/resource/cmd/formatter_test.go
@@ -84,7 +84,7 @@ func (s *SvcFormatterSuite) TestFormatSvcResource(c *gc.C) {
 		Username:         r.Username,
 		combinedRevision: "5",
 		usedYesNo:        "yes",
-		combinedOrigin:   "store",
+		combinedOrigin:   "charmstore",
 	})
 
 }

--- a/resource/cmd/output_tabular.go
+++ b/resource/cmd/output_tabular.go
@@ -56,16 +56,15 @@ func FormatSvcTabular(value interface{}) ([]byte, error) {
 
 	// Write the header.
 	// We do not print a section label.
-	fmt.Fprintln(tw, "RESOURCE\tORIGIN\tREV\tUSED\tCOMMENT")
+	fmt.Fprintln(tw, "RESOURCE\tSUPPLIED BY\tREVISION\tCOMMENT")
 
 	// Print each info to its own row.
 	for _, r := range resources {
 		// the column headers must be kept in sync with these.
-		fmt.Fprintf(tw, "%v\t%v\t%v\t%v\t%v\n",
+		fmt.Fprintf(tw, "%v\t%v\t%v\t%v\n",
 			r.Name,
 			r.combinedOrigin,
 			r.combinedRevision,
-			r.usedYesNo,
 			r.Comment,
 		)
 	}

--- a/resource/cmd/output_tabular_test.go
+++ b/resource/cmd/output_tabular_test.go
@@ -96,7 +96,7 @@ type SvcTabularSuite struct {
 	testing.IsolationSuite
 }
 
-func (s *SvcTabularSuite) TestFormatOkay(c *gc.C) {
+func (s *SvcTabularSuite) TestFormatServiceOkay(c *gc.C) {
 	res := resource.Resource{
 
 		Resource: charmresource.Resource{
@@ -118,6 +118,33 @@ func (s *SvcTabularSuite) TestFormatOkay(c *gc.C) {
 	c.Check(string(data), gc.Equals, `
 RESOURCE SUPPLIED BY REVISION COMMENT
 openjdk  charmstore  7        the java runtime
+`[1:])
+}
+
+func (s *SvcTabularSuite) TestFormatUnitOkay(c *gc.C) {
+	res := resource.Resource{
+
+		Resource: charmresource.Resource{
+			Meta: charmresource.Meta{
+				Name:    "openjdk",
+				Comment: "the java runtime",
+			},
+			Origin:   charmresource.OriginStore,
+			Revision: 7,
+		},
+		Timestamp: time.Now(),
+	}
+
+	formatted := []FormattedUnitResource{
+		FormattedUnitResource{FormatSvcResource(res)},
+	}
+
+	data, err := FormatSvcTabular(formatted)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(string(data), gc.Equals, `
+RESOURCE REVISION COMMENT
+openjdk  7        the java runtime
 `[1:])
 }
 

--- a/resource/cmd/output_tabular_test.go
+++ b/resource/cmd/output_tabular_test.go
@@ -116,8 +116,8 @@ func (s *SvcTabularSuite) TestFormatOkay(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(string(data), gc.Equals, `
-RESOURCE ORIGIN REV USED COMMENT
-openjdk  store  7   yes  the java runtime
+RESOURCE SUPPLIED BY REVISION COMMENT
+openjdk  charmstore  7        the java runtime
 `[1:])
 }
 
@@ -176,11 +176,11 @@ func (s *SvcTabularSuite) TestFormatCharmTabularMulti(c *gc.C) {
 
 	// Notes: sorted by name, then by revision, newest first.
 	c.Check(string(data), gc.Equals, `
-RESOURCE ORIGIN    REV        USED COMMENT
-openjdk  store     7          no   the java runtime
-website  upload    -          no   your website data
-openjdk2 store     8          yes  another java runtime
-website2 Bill User 2012-12-12 yes  your website data
+RESOURCE SUPPLIED BY REVISION         COMMENT
+openjdk  charmstore  7                the java runtime
+website  upload      -                your website data
+openjdk2 charmstore  8                another java runtime
+website2 Bill User   2012-12-12T12:12 your website data
 `[1:])
 }
 

--- a/resource/cmd/show_service.go
+++ b/resource/cmd/show_service.go
@@ -46,7 +46,8 @@ func NewShowServiceCommand(deps ShowServiceDeps) *ShowServiceCommand {
 // Info implements cmd.Command.Info.
 func (c *ShowServiceCommand) Info() *cmd.Info {
 	return &cmd.Info{
-		Name:    "show-service-resources",
+		Name:    "list-resources",
+		Aliases: []string{"resources"},
 		Args:    "service",
 		Purpose: "show the resources for a service",
 		Doc: `

--- a/resource/cmd/show_service.go
+++ b/resource/cmd/show_service.go
@@ -6,6 +6,7 @@ package cmd
 import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
+	"github.com/juju/names"
 	"launchpad.net/gnuflag"
 
 	"github.com/juju/juju/cmd/envcmd"
@@ -32,9 +33,9 @@ type ShowServiceDeps struct {
 type ShowServiceCommand struct {
 	envcmd.EnvCommandBase
 
-	deps    ShowServiceDeps
-	out     cmd.Output
-	service string
+	deps   ShowServiceDeps
+	out    cmd.Output
+	target string
 }
 
 // NewShowServiceCommand returns a new command that lists resources defined
@@ -48,10 +49,10 @@ func (c *ShowServiceCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "list-resources",
 		Aliases: []string{"resources"},
-		Args:    "service",
-		Purpose: "show the resources for a service",
+		Args:    "service-or-unit",
+		Purpose: "show the resources for a service or unit",
 		Doc: `
-This command shows the resources required by and those in use by an existing service in your model.
+This command shows the resources required by and those in use by an existing service or unit in your model.
 `,
 	}
 }
@@ -72,7 +73,7 @@ func (c *ShowServiceCommand) Init(args []string) error {
 	if len(args) == 0 {
 		return errors.NewBadRequest(nil, "missing service name")
 	}
-	c.service = args[0]
+	c.target = args[0]
 	if err := cmd.CheckEmpty(args[1:]); err != nil {
 		return errors.NewBadRequest(err, "")
 	}
@@ -87,7 +88,19 @@ func (c *ShowServiceCommand) Run(ctx *cmd.Context) error {
 	}
 	defer apiclient.Close()
 
-	vals, err := apiclient.ListResources([]string{c.service})
+	var unit string
+	var service string
+	if names.IsValidService(c.target) {
+		service = c.target
+	} else {
+		service, err = names.UnitService(c.target)
+		if err != nil {
+			return errors.Errorf("%q is neither a service nor a unit", c.target)
+		}
+		unit = c.target
+	}
+
+	vals, err := apiclient.ListResources([]string{service})
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -95,11 +108,46 @@ func (c *ShowServiceCommand) Run(ctx *cmd.Context) error {
 		return errors.Errorf("bad data returned from server")
 	}
 	v := vals[0]
-	res := make([]FormattedSvcResource, len(v.Resources))
 
-	for i, r := range v.Resources {
+	if unit == "" {
+		return c.formatServiceResources(ctx, v.Resources)
+	}
+	resources, err := unitResources(unit, service, v)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return c.formatUnitResources(ctx, resources)
+}
+
+func (c *ShowServiceCommand) formatServiceResources(ctx *cmd.Context, resources []resource.Resource) error {
+	res := make([]FormattedSvcResource, len(resources))
+
+	for i, r := range resources {
 		res[i] = FormatSvcResource(r)
 	}
 
 	return c.out.Write(ctx, res)
+}
+
+func (c *ShowServiceCommand) formatUnitResources(ctx *cmd.Context, resources []resource.Resource) error {
+	res := make([]FormattedUnitResource, len(resources))
+
+	for i, r := range resources {
+		res[i] = FormattedUnitResource{FormatSvcResource(r)}
+	}
+
+	return c.out.Write(ctx, res)
+
+}
+
+func unitResources(unit, service string, v resource.ServiceResources) ([]resource.Resource, error) {
+	for _, res := range v.UnitResources {
+		if res.Tag.Id() == unit {
+			return res.Resources, nil
+		}
+	}
+	// TODO(natefinch): we need to differentiate between a unit with no
+	// resources and a unit that doesn't exist. This requires a serverside
+	// change.
+	return nil, nil
 }

--- a/resource/cmd/show_service_test.go
+++ b/resource/cmd/show_service_test.go
@@ -128,11 +128,11 @@ func (s *ShowServiceSuite) TestRun(c *gc.C) {
 	c.Assert(stderr, gc.Equals, "")
 
 	c.Check(stdout, gc.Equals, `
-RESOURCE ORIGIN    REV        USED COMMENT
-openjdk  store     7          no   the java runtime
-website  upload    -          no   your website data
-rsc1234  store     15         yes  a big comment
-website2 Bill User 2012-12-12 yes  awesome data
+RESOURCE SUPPLIED BY REVISION         COMMENT
+openjdk  charmstore  7                the java runtime
+website  upload      -                your website data
+rsc1234  charmstore  15               a big comment
+website2 Bill User   2012-12-12T12:12 awesome data
 
 `[1:])
 

--- a/resource/cmd/show_service_test.go
+++ b/resource/cmd/show_service_test.go
@@ -60,7 +60,8 @@ func (s *ShowServiceSuite) TestInfo(c *gc.C) {
 	info := command.Info()
 
 	c.Check(info, jc.DeepEquals, &jujucmd.Info{
-		Name:    "show-service-resources",
+		Name:    "list-resources",
+		Aliases: []string{"resources"},
 		Args:    "service",
 		Purpose: "show the resources for a service",
 		Doc: `

--- a/resource/resource.go
+++ b/resource/resource.go
@@ -105,10 +105,17 @@ func (res Resource) TimestampGranular() time.Time {
 
 // RevisionString returns the human-readable revision for the resource.
 func (res Resource) RevisionString() string {
-	if res.Origin == resource.OriginUpload {
-		return res.TimestampGranular().String()
+	if res.IsPlaceholder() {
+		return "-"
 	}
-	return fmt.Sprintf("%d", res.Revision)
+	switch res.Origin {
+	case resource.OriginUpload:
+		return res.TimestampGranular().UTC().String()
+	case resource.OriginStore:
+		return fmt.Sprintf("%d", res.Revision)
+	default:
+		return "-"
+	}
 }
 
 // ServiceResources contains the list of resources for the service and all its

--- a/resource/resource.go
+++ b/resource/resource.go
@@ -105,15 +105,16 @@ func (res Resource) TimestampGranular() time.Time {
 
 // RevisionString returns the human-readable revision for the resource.
 func (res Resource) RevisionString() string {
-	if res.IsPlaceholder() {
-		return "-"
-	}
 	switch res.Origin {
 	case resource.OriginUpload:
+		if res.IsPlaceholder() {
+			return "-"
+		}
 		return res.TimestampGranular().UTC().String()
 	case resource.OriginStore:
 		return fmt.Sprintf("%d", res.Revision)
 	default:
+		// note: this should probably never happen.
 		return "-"
 	}
 }

--- a/resource/resource_test.go
+++ b/resource/resource_test.go
@@ -152,6 +152,7 @@ func (ResourceSuite) TestRevisionStringNone(c *gc.C) {
 			},
 			Origin: charmresource.OriginUpload,
 		},
+		ServiceID: "svc",
 	}
 
 	err := res.Validate()
@@ -171,6 +172,7 @@ func (ResourceSuite) TestRevisionStringTime(c *gc.C) {
 			},
 			Origin: charmresource.OriginUpload,
 		},
+		ServiceID: "svc",
 		Username:  "a-user",
 		Timestamp: time.Date(2012, 7, 8, 15, 59, 5, 5, time.UTC),
 	}
@@ -193,6 +195,7 @@ func (ResourceSuite) TestRevisionStringNumber(c *gc.C) {
 			Origin:   charmresource.OriginStore,
 			Revision: 7,
 		},
+		ServiceID: "svc",
 		Username:  "a-user",
 		Timestamp: time.Date(2012, 7, 8, 15, 59, 5, 5, time.UTC),
 	}

--- a/resource/resource_test.go
+++ b/resource/resource_test.go
@@ -140,3 +140,65 @@ func (ResourceSuite) TestValidateMissingTimestamp(c *gc.C) {
 	c.Check(errors.Cause(err), jc.Satisfies, errors.IsNotValid)
 	c.Check(err, gc.ErrorMatches, `.*missing timestamp.*`)
 }
+
+func (ResourceSuite) TestRevisionStringNone(c *gc.C) {
+	res := resource.Resource{
+		Resource: charmresource.Resource{
+			Meta: charmresource.Meta{
+				Name:    "foo",
+				Type:    charmresource.TypeFile,
+				Path:    "foo.tgz",
+				Comment: "you need it",
+			},
+			Origin: charmresource.OriginUpload,
+		},
+	}
+
+	err := res.Validate()
+	c.Check(err, jc.ErrorIsNil)
+
+	c.Check(res.RevisionString(), gc.Equals, "-")
+}
+
+func (ResourceSuite) TestRevisionStringTime(c *gc.C) {
+	res := resource.Resource{
+		Resource: charmresource.Resource{
+			Meta: charmresource.Meta{
+				Name:    "foo",
+				Type:    charmresource.TypeFile,
+				Path:    "foo.tgz",
+				Comment: "you need it",
+			},
+			Origin: charmresource.OriginUpload,
+		},
+		Username:  "a-user",
+		Timestamp: time.Date(2012, 7, 8, 15, 59, 5, 5, time.UTC),
+	}
+
+	err := res.Validate()
+	c.Check(err, jc.ErrorIsNil)
+
+	c.Check(res.RevisionString(), gc.Equals, "2012-07-08 15:59:05 +0000 UTC")
+}
+
+func (ResourceSuite) TestRevisionStringNumber(c *gc.C) {
+	res := resource.Resource{
+		Resource: charmresource.Resource{
+			Meta: charmresource.Meta{
+				Name:    "foo",
+				Type:    charmresource.TypeFile,
+				Path:    "foo.tgz",
+				Comment: "you need it",
+			},
+			Origin:   charmresource.OriginStore,
+			Revision: 7,
+		},
+		Username:  "a-user",
+		Timestamp: time.Date(2012, 7, 8, 15, 59, 5, 5, time.UTC),
+	}
+
+	err := res.Validate()
+	c.Check(err, jc.ErrorIsNil)
+
+	c.Check(res.RevisionString(), gc.Equals, "7")
+}


### PR DESCRIPTION
and remove the show-charm-resources command since it's being written in a different commit and conflicts with the alias for list-resources

(Review request: http://reviews.vapour.ws/r/3777/)