### PR TITLE
apiserver: remove testing helper method

### DIFF
--- a/apiserver/client_auth_root_test.go
+++ b/apiserver/client_auth_root_test.go
@@ -4,10 +4,11 @@
 package apiserver
 
 import (
+	"reflect"
+
 	"github.com/juju/errors"
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/testing/factory"
-	"reflect"
 
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"

--- a/apiserver/export_test.go
+++ b/apiserver/export_test.go
@@ -5,6 +5,7 @@ package apiserver
 
 import (
 	"fmt"
+	"net"
 	"time"
 
 	"github.com/juju/names"
@@ -182,4 +183,9 @@ func TestingRestoreInProgressRoot(st *state.State) *restoreInProgressRoot {
 func TestingAboutToRestoreRoot(st *state.State) *aboutToRestoreRoot {
 	r := TestingApiRoot(st)
 	return newAboutToRestoreRoot(r)
+}
+
+// Addr returns the address that the server is listening on.
+func (srv *Server) Addr() *net.TCPAddr {
+	return srv.lis.Addr().(*net.TCPAddr) // cannot fail
 }


### PR DESCRIPTION
- apiserver.Server.Addr was only used in testing contexts, removed from
the public API.
- Rejig the initialisation to log the "server is listening" message closer
to the point where the server starts listening.

(Review request: http://reviews.vapour.ws/r/3779/)