### PR TITLE
Remove JUJU_HOME fallback

### DIFF
--- a/cmd/modelcmd/modelcommand.go
+++ b/cmd/modelcmd/modelcommand.go
@@ -31,7 +31,7 @@ var ErrNoModelSpecified = errors.New("no model specified")
 // GetDefaultModel returns the name of the Juju default model.
 // There is simple ordering for the default model.  Firstly check the
 // JUJU_MODEL environment variable.  If that is set, it gets used.  If it isn't
-// set, look in the $JUJU_HOME/current-model file.  If neither are
+// set, look in the $JUJU_DATA/current-model file.  If neither are
 // available, read environments.yaml and use the default model therein.
 // If no default is specified in the environments file, an empty string is returned.
 // Not having a default model specified is not an error.

--- a/juju/osenv/home.go
+++ b/juju/osenv/home.go
@@ -61,11 +61,6 @@ func JujuXDGDataHomePath(names ...string) string {
 func JujuXDGDataHomeDir() string {
 	JujuXDGDataHomeDir := os.Getenv(JujuXDGDataHomeEnvKey)
 	if JujuXDGDataHomeDir == "" {
-		// TODO(wallyworld) - remove this legacy support when CI is updated
-		legacyHomeDir := os.Getenv("JUJU_HOME")
-		if legacyHomeDir != "" {
-			return legacyHomeDir
-		}
 		if runtime.GOOS == "windows" {
 			JujuXDGDataHomeDir = jujuXDGDataHomeWin()
 		} else {

--- a/juju/osenv/home_test.go
+++ b/juju/osenv/home_test.go
@@ -25,11 +25,6 @@ func (s *JujuXDGDataHomeSuite) TestStandardHome(c *gc.C) {
 	c.Assert(osenv.JujuXDGDataHome(), gc.Equals, testJujuXDGDataHome)
 }
 
-func (s *JujuXDGDataHomeSuite) TestLegacyHome(c *gc.C) {
-	s.PatchEnvironment("JUJU_HOME", "/some/path")
-	c.Assert(osenv.JujuXDGDataHomeDir(), gc.Equals, "/some/path")
-}
-
 func (s *JujuXDGDataHomeSuite) TestErrorHome(c *gc.C) {
 	// Invalid juju home leads to panic when retrieving.
 	f := func() { _ = osenv.JujuXDGDataHome() }

--- a/juju/osenv/vars_test.go
+++ b/juju/osenv/vars_test.go
@@ -28,8 +28,6 @@ func (s *varsSuite) TestJujuXDGDataHomeEnvVar(c *gc.C) {
 
 func (s *varsSuite) TestBlankJujuXDGDataHomeEnvVar(c *gc.C) {
 	s.PatchEnvironment(osenv.JujuXDGDataHomeEnvKey, "")
-	// TODO(wallyworld) - remove this when support for legacy juju_home is gone
-	s.PatchEnvironment("JUJU_HOME", "")
 
 	if runtime.GOOS == "windows" {
 		s.PatchEnvironment("APPDATA", `P:\foobar`)

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -585,7 +585,7 @@ func (s *JujuConnSuite) ConfDir() string {
 // WriteConfig writes a juju config file to the "home" directory.
 func (s *JujuConnSuite) WriteConfig(configData string) {
 	if s.RootDir == "" {
-		panic("SetUpTest has not been called; will not overwrite $JUJU_HOME/environments.yaml")
+		panic("SetUpTest has not been called; will not overwrite $JUJU_DATA/environments.yaml")
 	}
 	path := osenv.JujuXDGDataHomePath("environments.yaml")
 	err := ioutil.WriteFile(path, []byte(configData), 0600)


### PR DESCRIPTION
CI is now updated with scripts that support $JUJU_DATA so we can remove the $JUJU_HOME fallback.

(Review request: http://reviews.vapour.ws/r/3781/)