### PR TITLE
lp1541473: Don't add new controllers to the replicaset until they are "started"

### DIFF
--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -1077,10 +1077,13 @@ func (a *MachineAgent) StateWorker() (worker.Worker, error) {
 
 			// certChangedChan is shared by multiple workers it's up
 			// to the agent to close it rather than any one of the
-			// workers.
+			// workers.  It is possible that multiple cert changes
+			// come in before the apiserver is up to receive them.
+			// Specify a bigger buffer to prevent deadlock when
+			// the apiserver isn't up yet.
 			//
 			// TODO(ericsnow) For now we simply do not close the channel.
-			certChangedChan := make(chan params.StateServingInfo, 1)
+			certChangedChan := make(chan params.StateServingInfo, 10)
 			// Each time aipserver worker is restarted, we need a fresh copy of state due
 			// to the fact that state holds lease managers which are killed and need to be reset.
 			stateOpener := func() (*state.State, error) {

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -1080,7 +1080,13 @@ func (a *MachineAgent) StateWorker() (worker.Worker, error) {
 			// workers.  It is possible that multiple cert changes
 			// come in before the apiserver is up to receive them.
 			// Specify a bigger buffer to prevent deadlock when
-			// the apiserver isn't up yet.
+			// the apiserver isn't up yet.  Use a size of 10 since we
+			// allow up to 7 controllers, and might also update the
+			// addresses of the local machine (127.0.0.1, ::1, etc).
+			//
+			// TODO(cherylj/waigani) Remove this workaround when
+			// certupdater and apiserver can properly manage dependencies
+			// through the dependency engine.
 			//
 			// TODO(ericsnow) For now we simply do not close the channel.
 			certChangedChan := make(chan params.StateServingInfo, 10)

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -2320,6 +2320,7 @@ func (st *State) watchEnqueuedActionsFilteredBy(receivers ...ActionReceiver) Str
 
 // WatchControllerStatusChanges starts and returns a StringsWatcher that
 // notifies when the status of a controller machine changes.
+// TODO(cherylj) Add unit tests for this, as per bug 1543408.
 func (st *State) WatchControllerStatusChanges() StringsWatcher {
 	return newcollectionWatcher(st, colWCfg{
 		col:    statusesC,
@@ -2346,7 +2347,6 @@ func makeControllerIdFilter(st *State) func(interface{}) bool {
 				machines = info.MachineIds
 			}
 			for _, machine := range machines {
-				// TODO (cherylj) Prepend controller UUID for exact match?
 				if strings.HasSuffix(key.(string), fmt.Sprintf("m#%s", machine)) {
 					return true
 				}

--- a/worker/peergrouper/mock_test.go
+++ b/worker/peergrouper/mock_test.go
@@ -31,6 +31,7 @@ type fakeState struct {
 	errors      errorPatterns
 	machines    map[string]*fakeMachine
 	controllers voyeur.Value // of *state.ControllerInfo
+	statuses    voyeur.Value // of statuses collection
 	session     *fakeMongoSession
 	check       func(st *fakeState) error
 }
@@ -225,6 +226,10 @@ func (st *fakeState) WatchControllerInfo() state.NotifyWatcher {
 	return WatchValue(&st.controllers)
 }
 
+func (st *fakeState) WatchControllerStatusChanges() state.StringsWatcher {
+	return WatchStrings(&st.statuses)
+}
+
 type fakeMachine struct {
 	mu      sync.Mutex
 	errors  *errorPatterns
@@ -301,6 +306,12 @@ func (m *fakeMachine) APIHostPorts() []network.HostPort {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return m.doc.apiHostPorts
+}
+
+func (m *fakeMachine) Status() (state.StatusInfo, error) {
+	return state.StatusInfo{
+		Status: state.StatusStarted,
+	}, nil
 }
 
 // mutate atomically changes the machineDoc of
@@ -511,5 +522,58 @@ func (n *notifier) Wait() error {
 }
 
 func (n *notifier) Stop() error {
+	return worker.Stop(n)
+}
+
+type stringsNotifier struct {
+	tomb    tomb.Tomb
+	w       *voyeur.Watcher
+	changes chan []string
+}
+
+// WatchStrings returns a StringsWatcher that triggers
+// when the given value changes. Its Wait and Err methods
+// never return a non-nil error.
+func WatchStrings(val *voyeur.Value) state.StringsWatcher {
+	n := &stringsNotifier{
+		w:       val.Watch(),
+		changes: make(chan []string),
+	}
+	go n.loop()
+	return n
+}
+
+func (n *stringsNotifier) loop() {
+	defer n.tomb.Done()
+	for n.w.Next() {
+		select {
+		case n.changes <- []string{}:
+		case <-n.tomb.Dying():
+		}
+	}
+}
+
+// Changes returns a channel that sends a value when the value changes.
+// The value itself can be retrieved by calling the value's Get method.
+func (n *stringsNotifier) Changes() <-chan []string {
+	return n.changes
+}
+
+// Kill stops the notifier but does not wait for it to finish.
+func (n *stringsNotifier) Kill() {
+	n.tomb.Kill(nil)
+	n.w.Close()
+}
+
+func (n *stringsNotifier) Err() error {
+	return n.tomb.Err()
+}
+
+// Wait waits for the notifier to finish. It always returns nil.
+func (n *stringsNotifier) Wait() error {
+	return n.tomb.Wait()
+}
+
+func (n *stringsNotifier) Stop() error {
 	return worker.Stop(n)
 }

--- a/worker/peergrouper/suite_test.go
+++ b/worker/peergrouper/suite_test.go
@@ -1,7 +1,7 @@
 // Copyright 2014 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package peergrouper_test
+package peergrouper
 
 import (
 	"testing"

--- a/worker/peergrouper/worker.go
+++ b/worker/peergrouper/worker.go
@@ -446,7 +446,7 @@ func (infow *serverInfoWatcher) updateMachines() (bool, error) {
 		// Don't add the machine unless it is "Started"
 		status, err := stm.Status()
 		if err != nil {
-			return false, fmt.Errorf("cannot get machine status: %q: %v", id, err)
+			return false, errors.Annotatef(err, "cannot get status for machine %q", id)
 		}
 		if status.Status == state.StatusStarted {
 			logger.Tracef("machine %q has started, adding it to peergrouper list", id)

--- a/worker/peergrouper/worker.go
+++ b/worker/peergrouper/worker.go
@@ -22,6 +22,7 @@ import (
 type stateInterface interface {
 	Machine(id string) (stateMachine, error)
 	WatchControllerInfo() state.NotifyWatcher
+	WatchControllerStatusChanges() state.StringsWatcher
 	ControllerInfo() (*state.ControllerInfo, error)
 	MongoSession() mongoSession
 }
@@ -29,6 +30,7 @@ type stateInterface interface {
 type stateMachine interface {
 	Id() string
 	InstanceId() (instance.Id, error)
+	Status() (state.StatusInfo, error)
 	Refresh() error
 	Watch() state.NotifyWatcher
 	WantsVote() bool
@@ -366,14 +368,16 @@ func setHasVote(ms []*machine, hasVote bool) error {
 // serverInfoWatcher watches the controller info and
 // notifies the worker when it changes.
 type serverInfoWatcher struct {
-	worker  *pgWorker
-	watcher state.NotifyWatcher
+	worker               *pgWorker
+	controllerWatcher    state.NotifyWatcher
+	machineStatusWatcher state.StringsWatcher
 }
 
 func (w *pgWorker) watchControllerInfo() *serverInfoWatcher {
 	infow := &serverInfoWatcher{
-		worker:  w,
-		watcher: w.st.WatchControllerInfo(),
+		worker:               w,
+		controllerWatcher:    w.st.WatchControllerInfo(),
+		machineStatusWatcher: w.st.WatchControllerStatusChanges(),
 	}
 	w.start(infow.loop)
 	return infow
@@ -382,9 +386,14 @@ func (w *pgWorker) watchControllerInfo() *serverInfoWatcher {
 func (infow *serverInfoWatcher) loop() error {
 	for {
 		select {
-		case _, ok := <-infow.watcher.Changes():
+		case _, ok := <-infow.machineStatusWatcher.Changes():
 			if !ok {
-				return infow.watcher.Err()
+				return infow.machineStatusWatcher.Err()
+			}
+			infow.worker.notify(infow.updateMachines)
+		case _, ok := <-infow.controllerWatcher.Changes():
+			if !ok {
+				return infow.controllerWatcher.Err()
 			}
 			infow.worker.notify(infow.updateMachines)
 		case <-infow.worker.tomb.Dying():
@@ -394,7 +403,8 @@ func (infow *serverInfoWatcher) loop() error {
 }
 
 func (infow *serverInfoWatcher) stop() {
-	infow.watcher.Stop()
+	infow.machineStatusWatcher.Stop()
+	infow.controllerWatcher.Stop()
 }
 
 // updateMachines is a notifyFunc that updates the current
@@ -432,8 +442,20 @@ func (infow *serverInfoWatcher) updateMachines() (bool, error) {
 			}
 			return false, fmt.Errorf("cannot get machine %q: %v", id, err)
 		}
-		infow.worker.machines[id] = infow.worker.newMachine(stm)
-		changed = true
+
+		// Don't add the machine unless it is "Started"
+		status, err := stm.Status()
+		if err != nil {
+			return false, fmt.Errorf("cannot get machine status: %q: %v", id, err)
+		}
+		if status.Status == state.StatusStarted {
+			logger.Tracef("machine %q has started, adding it to peergrouper list", id)
+			infow.worker.machines[id] = infow.worker.newMachine(stm)
+			changed = true
+		} else {
+			logger.Tracef("machine %q not ready: %v", id, status.Status)
+		}
+
 	}
 	return changed, nil
 }


### PR DESCRIPTION
Machines should be in "started" state before being added
to the mongo replicaset to avoid the deadlock described
in bug 1541473.

It is possible for the certupdater to come
up before the apiserver does, and to send
multiple updates for the certificate.  The
certChangedChan should have a larger size
to accommodate these requests.

I chose 10 as we can allow up to 7 state
servers, and we may update the cert for
each server, plus another update to account
for addresses local to machine 0 (::1,
127.0.0.1, etc).

(Review request: http://reviews.vapour.ws/r/3782/)