### PR TITLE
cmd/juju/commands: add --config to bootstrap

### DIFF
--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -251,8 +251,7 @@ func (s *BootstrapSuite) run(c *gc.C, test bootstrapTest) testing.Restorer {
 	// Run command and check for uploads.
 	args := append([]string{
 		"peckham-controller", "dummy",
-		// TODO(axw) use --config when we have it
-		"-o", "default-series=raring",
+		"--config", "default-series=raring",
 	}, test.args...)
 	opc, errc := cmdtesting.RunCommand(cmdtesting.NullContext(c), newBootstrapCommand(), args...)
 	// Check for remaining operations/errors.
@@ -318,9 +317,8 @@ var bootstrapTests = []bootstrapTest{{
 }, {
 	info:    "bad model",
 	version: "1.2.3-%LTS%-amd64",
-	// TODO(axw) use --config when we have it
-	args: []string{"-o", "broken=Bootstrap Destroy", "--auto-upgrade"},
-	err:  `failed to bootstrap model: dummy.Bootstrap is broken`,
+	args:    []string{"--config", "broken=Bootstrap Destroy", "--auto-upgrade"},
+	err:     `failed to bootstrap model: dummy.Bootstrap is broken`,
 }, {
 	info:        "constraints",
 	args:        []string{"--constraints", "mem=4G cpu-cores=4"},
@@ -570,8 +568,7 @@ func (s *BootstrapSuite) TestBootstrapCalledWithMetadataDir(c *gc.C) {
 		c, newBootstrapCommand(),
 		"--metadata-source", sourceDir, "--constraints", "mem=4G",
 		"devenv", "dummy-cloud/region-1",
-		// TODO(axw) use --config when we have it
-		"-o", "default-series=raring",
+		"--config", "default-series=raring",
 	)
 	c.Assert(bootstrap.args.MetadataDir, gc.Equals, sourceDir)
 }
@@ -592,8 +589,7 @@ func (s *BootstrapSuite) checkBootstrapWithVersion(c *gc.C, vers, expect string)
 		c, newBootstrapCommand(),
 		"--agent-version", vers,
 		"devenv", "dummy-cloud/region-1",
-		// TODO(axw) use --config when we have it
-		"-o", "default-series=raring",
+		"--config", "default-series=raring",
 	)
 	c.Assert(bootstrap.args.AgentVersion, gc.NotNil)
 	c.Assert(*bootstrap.args.AgentVersion, gc.Equals, version.MustParse(expect))
@@ -675,8 +671,7 @@ func (s *BootstrapSuite) TestAutoUploadAfterFailedSync(c *gc.C) {
 	opc, errc := cmdtesting.RunCommand(
 		cmdtesting.NullContext(c), newBootstrapCommand(),
 		"devenv", "dummy-cloud/region-1",
-		// TODO(axw) use --config when we have it
-		"-o", "default-series=raring",
+		"--config", "default-series=raring",
 		"--auto-upgrade",
 	)
 	c.Assert(<-errc, gc.IsNil)
@@ -702,8 +697,7 @@ func (s *BootstrapSuite) TestMissingToolsError(c *gc.C) {
 
 	_, err := coretesting.RunCommand(c, newBootstrapCommand(),
 		"devenv", "dummy-cloud/region-1",
-		// TODO(axw) use --config when we have it
-		"-o", "default-series=raring",
+		"--config", "default-series=raring",
 	)
 	c.Assert(err, gc.ErrorMatches,
 		"failed to bootstrap model: Juju cannot bootstrap because no tools are available for your model(.|\n)*")
@@ -721,9 +715,8 @@ func (s *BootstrapSuite) TestMissingToolsUploadFailedError(c *gc.C) {
 	ctx, err := coretesting.RunCommand(
 		c, newBootstrapCommand(),
 		"devenv", "dummy-cloud/region-1",
-		// TODO(axw) use --config when we have it
-		"-o", "default-series=raring",
-		"-o", "agent-stream=proposed",
+		"--config", "default-series=raring",
+		"--config", "agent-stream=proposed",
 		"--auto-upgrade",
 	)
 
@@ -743,8 +736,7 @@ func (s *BootstrapSuite) TestBootstrapDestroy(c *gc.C) {
 	opc, errc := cmdtesting.RunCommand(
 		cmdtesting.NullContext(c), newBootstrapCommand(),
 		"devenv", "dummy-cloud/region-1",
-		// TODO(axw) use --config when we have it
-		"-o", "broken=Bootstrap Destroy",
+		"--config", "broken=Bootstrap Destroy",
 		"--auto-upgrade",
 	)
 	err := <-errc
@@ -772,8 +764,7 @@ func (s *BootstrapSuite) TestBootstrapKeepBroken(c *gc.C) {
 	opc, errc := cmdtesting.RunCommand(cmdtesting.NullContext(c), newBootstrapCommand(),
 		"--keep-broken",
 		"devenv", "dummy-cloud/region-1",
-		// TODO(axw) use --config when we have it
-		"-o", "broken=Bootstrap Destroy",
+		"--config", "broken=Bootstrap Destroy",
 		"--auto-upgrade",
 	)
 	err := <-errc
@@ -825,6 +816,63 @@ func (s *BootstrapSuite) TestBootstrapProviderDetectRegions(c *gc.C) {
 	s.patchVersionAndSeries(c, "raring")
 	_, err := coretesting.RunCommand(c, newBootstrapCommand(), "ctrl", "dummy/not-dummy")
 	c.Assert(err, gc.ErrorMatches, `region "not-dummy" in cloud "dummy" not found \(expected one of \["dummy"\]\)`)
+}
+
+func (s *BootstrapSuite) TestBootstrapConfigFile(c *gc.C) {
+	tmpdir := c.MkDir()
+	configFile := filepath.Join(tmpdir, "config.yaml")
+	err := ioutil.WriteFile(configFile, []byte("controller: not-a-bool\n"), 0644)
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.patchVersionAndSeries(c, "raring")
+	_, err = coretesting.RunCommand(
+		c, newBootstrapCommand(), "ctrl", "dummy",
+		"--config", configFile,
+	)
+	c.Assert(err, gc.ErrorMatches, `controller: expected bool, got string.*`)
+}
+
+func (s *BootstrapSuite) TestBootstrapMultipleConfigFiles(c *gc.C) {
+	tmpdir := c.MkDir()
+	configFile1 := filepath.Join(tmpdir, "config-1.yaml")
+	err := ioutil.WriteFile(configFile1, []byte(
+		"controller: not-a-bool\nbroken: Bootstrap\n",
+	), 0644)
+	c.Assert(err, jc.ErrorIsNil)
+	configFile2 := filepath.Join(tmpdir, "config-2.yaml")
+	err = ioutil.WriteFile(configFile2, []byte(
+		"controller: false\n",
+	), 0644)
+
+	s.patchVersionAndSeries(c, "raring")
+	_, err = coretesting.RunCommand(
+		c, newBootstrapCommand(), "ctrl", "dummy",
+		"--auto-upgrade",
+		// the second config file should replace attributes
+		// with the same name from the first, but leave the
+		// others alone.
+		"--config", configFile1,
+		"--config", configFile2,
+	)
+	c.Assert(err, gc.ErrorMatches, "failed to bootstrap model: dummy.Bootstrap is broken")
+}
+
+func (s *BootstrapSuite) TestBootstrapConfigFileAndAdHoc(c *gc.C) {
+	tmpdir := c.MkDir()
+	configFile := filepath.Join(tmpdir, "config.yaml")
+	err := ioutil.WriteFile(configFile, []byte("controller: not-a-bool\n"), 0644)
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.patchVersionAndSeries(c, "raring")
+	_, err = coretesting.RunCommand(
+		c, newBootstrapCommand(), "ctrl", "dummy",
+		"--auto-upgrade",
+		// Configuration specified on the command line overrides
+		// anything specified in files, no matter what the order.
+		"--config", "controller=false",
+		"--config", configFile,
+	)
+	c.Assert(err, jc.ErrorIsNil)
 }
 
 // createToolsSource writes the mock tools and metadata into a temporary

--- a/cmd/juju/commands/flags.go
+++ b/cmd/juju/commands/flags.go
@@ -5,37 +5,73 @@ package commands
 
 import (
 	"fmt"
+	"io/ioutil"
 	"strings"
 
+	"github.com/juju/cmd"
 	"github.com/juju/errors"
+	"github.com/juju/utils"
 	"gopkg.in/yaml.v2"
 )
 
-type optionFlag struct {
-	options *map[string]interface{}
+type configFlag struct {
+	files []string
+	attrs map[string]interface{}
 }
 
 // Set implements gnuflag.Value.Set.
-func (f optionFlag) Set(s string) error {
+func (f *configFlag) Set(s string) error {
 	fields := strings.SplitN(s, "=", 2)
-	if len(fields) < 2 {
-		return errors.New("expected <key>=<value>")
+	switch len(fields) {
+	case 1:
+		f.files = append(f.files, fields[0])
+		return nil
+	case 2:
+		break
+	default:
+		return errors.New("expected <file> or <key>=<value>")
 	}
 	var value interface{}
 	if err := yaml.Unmarshal([]byte(fields[1]), &value); err != nil {
 		return errors.Trace(err)
 	}
-	if *f.options == nil {
-		*f.options = make(map[string]interface{})
+	if f.attrs == nil {
+		f.attrs = make(map[string]interface{})
 	}
-	(*f.options)[fields[0]] = value
+	f.attrs[fields[0]] = value
 	return nil
 }
 
+// ReadAttrs reads attributes from the specified files, and then overlays
+// the results with the k=v attributes.
+func (f *configFlag) ReadAttrs(ctx *cmd.Context) (map[string]interface{}, error) {
+	attrs := make(map[string]interface{})
+	for _, f := range f.files {
+		path, err := utils.NormalizePath(f)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		data, err := ioutil.ReadFile(ctx.AbsPath(path))
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		if err := yaml.Unmarshal(data, &attrs); err != nil {
+			return nil, err
+		}
+	}
+	for k, v := range f.attrs {
+		attrs[k] = v
+	}
+	return attrs, nil
+}
+
 // String implements gnuflag.Value.String.
-func (f optionFlag) String() string {
-	strs := make([]string, 0, len(*f.options))
-	for k, v := range *f.options {
+func (f *configFlag) String() string {
+	strs := make([]string, 0, len(f.attrs)+len(f.files))
+	for _, f := range f.files {
+		strs = append(strs, f)
+	}
+	for k, v := range f.attrs {
 		strs = append(strs, fmt.Sprintf("%s=%v", k, v))
 	}
 	return strings.Join(strs, " ")

--- a/cmd/juju/commands/flags.go
+++ b/cmd/juju/commands/flags.go
@@ -21,15 +21,13 @@ type configFlag struct {
 
 // Set implements gnuflag.Value.Set.
 func (f *configFlag) Set(s string) error {
+	if s == "" {
+		return errors.NotValidf("empty string")
+	}
 	fields := strings.SplitN(s, "=", 2)
-	switch len(fields) {
-	case 1:
+	if len(fields) == 1 {
 		f.files = append(f.files, fields[0])
 		return nil
-	case 2:
-		break
-	default:
-		return errors.New("expected <file> or <key>=<value>")
 	}
 	var value interface{}
 	if err := yaml.Unmarshal([]byte(fields[1]), &value); err != nil {

--- a/cmd/juju/commands/flags_test.go
+++ b/cmd/juju/commands/flags_test.go
@@ -1,0 +1,98 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package commands
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/testing"
+)
+
+type FlagsSuite struct {
+	testing.FakeJujuXDGDataHomeSuite
+}
+
+var _ = gc.Suite(&FlagsSuite{})
+
+func (*FlagsSuite) TestConfigFlagSet(c *gc.C) {
+	var f configFlag
+	c.Assert(f.Set("a.yaml"), jc.ErrorIsNil)
+	assertConfigFlag(c, f, []string{"a.yaml"}, nil)
+	c.Assert(f.Set("b.yaml"), jc.ErrorIsNil)
+	assertConfigFlag(c, f, []string{"a.yaml", "b.yaml"}, nil)
+	c.Assert(f.Set("k1=v1"), jc.ErrorIsNil)
+	assertConfigFlag(c, f, []string{"a.yaml", "b.yaml"}, map[string]interface{}{"k1": "v1"})
+	c.Assert(f.Set("k1==v2"), jc.ErrorIsNil)
+	assertConfigFlag(c, f, []string{"a.yaml", "b.yaml"}, map[string]interface{}{"k1": "=v2"})
+	c.Assert(f.Set("k2=3"), jc.ErrorIsNil)
+	assertConfigFlag(c, f, []string{"a.yaml", "b.yaml"}, map[string]interface{}{"k1": "=v2", "k2": 3})
+}
+
+func (*FlagsSuite) TestConfigFlagSetErrors(c *gc.C) {
+	var f configFlag
+	c.Assert(f.Set(""), gc.ErrorMatches, "empty string not valid")
+	c.Assert(f.Set("x=!"), gc.ErrorMatches, "yaml: did not find URI escaped octet")
+}
+
+func (*FlagsSuite) TestConfigFlagString(c *gc.C) {
+	var f configFlag
+	c.Assert(f.String(), gc.Equals, "")
+	f.files = append(f.files, "a.yaml")
+	c.Assert(f.String(), gc.Equals, "a.yaml")
+	f.files = append(f.files, "b.yaml")
+	c.Assert(f.String(), gc.Equals, "a.yaml b.yaml")
+	f.files = append(f.files, "x=y")
+	c.Assert(f.String(), gc.Equals, "a.yaml b.yaml x=y")
+	f.files = append(f.files, "zz=y")
+	c.Assert(f.String(), gc.Equals, "a.yaml b.yaml x=y zz=y")
+}
+
+func (*FlagsSuite) TestConfigFlagReadAttrs(c *gc.C) {
+	tmpdir := c.MkDir()
+	configFile1 := filepath.Join(tmpdir, "config-1.yaml")
+	configFile2 := filepath.Join(tmpdir, "config-2.yaml")
+	err := ioutil.WriteFile(configFile1, []byte(`over: "'n'out"`+"\n"), 0644)
+	c.Assert(err, jc.ErrorIsNil)
+	err = ioutil.WriteFile(configFile2, []byte(`over: "'n'under"`+"\n"), 0644)
+	c.Assert(err, jc.ErrorIsNil)
+
+	var f configFlag
+	assertConfigFlagReadAttrs(c, f, map[string]interface{}{})
+	f.files = append(f.files, configFile1)
+	assertConfigFlagReadAttrs(c, f, map[string]interface{}{"over": "'n'out"})
+	f.files = append(f.files, configFile2)
+	assertConfigFlagReadAttrs(c, f, map[string]interface{}{"over": "'n'under"})
+	f.attrs = map[string]interface{}{"over": "ridden"}
+	assertConfigFlagReadAttrs(c, f, map[string]interface{}{"over": "ridden"})
+}
+
+func (*FlagsSuite) TestConfigFlagReadAttrsErrors(c *gc.C) {
+	tmpdir := c.MkDir()
+	configFile := filepath.Join(tmpdir, "config.yaml")
+
+	var f configFlag
+	f.files = append(f.files, configFile)
+	ctx := testing.Context(c)
+	attrs, err := f.ReadAttrs(ctx)
+	c.Assert(errors.Cause(err), jc.Satisfies, os.IsNotExist)
+	c.Assert(attrs, gc.IsNil)
+}
+
+func assertConfigFlag(c *gc.C, f configFlag, files []string, attrs map[string]interface{}) {
+	c.Assert(f.files, jc.DeepEquals, files)
+	c.Assert(f.attrs, jc.DeepEquals, attrs)
+}
+
+func assertConfigFlagReadAttrs(c *gc.C, f configFlag, expect map[string]interface{}) {
+	ctx := testing.Context(c)
+	attrs, err := f.ReadAttrs(ctx)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(attrs, jc.DeepEquals, expect)
+}


### PR DESCRIPTION
Add the --config flag to the bootstrap command,
so users can define controller-specific config
at bootstrap time.

The flag accepts one of two forms:
 1. a filename, which points to a YAML file
    having config attributes within
 2. a string with the syntax key=value

Files are read in the order specified on the
command line, and then ad-hoc key=value pairs
are added in the order they are specified.

(Review request: http://reviews.vapour.ws/r/3783/)