### PR TITLE
provider/{azure,cloudsigma,vsphere}: use creds

### DIFF
--- a/cloud/clouds_test.go
+++ b/cloud/clouds_test.go
@@ -17,10 +17,14 @@ type cloudSuite struct{}
 
 var _ = gc.Suite(&cloudSuite{})
 
+var publicCloudNames = []string{
+	"aws", "aws-china", "aws-gov", "google", "azure", "azure-china", "rackspace", "joyent", "cloudsigma",
+}
+
 func parsePublicClouds(c *gc.C) *cloud.Clouds {
 	clouds, err := cloud.ParseCloudMetadata([]byte(cloud.FallbackPublicCloudInfo))
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(clouds.Clouds, gc.HasLen, 8)
+	c.Assert(clouds.Clouds, gc.HasLen, len(publicCloudNames))
 	return clouds
 }
 
@@ -30,8 +34,7 @@ func (s *cloudSuite) TestParseClouds(c *gc.C) {
 	for name, _ := range clouds.Clouds {
 		cloudNames = append(cloudNames, name)
 	}
-	c.Assert(cloudNames, jc.SameContents,
-		[]string{"aws", "aws-china", "aws-gov", "google", "azure", "azure-china", "rackspace", "joyent"})
+	c.Assert(cloudNames, jc.SameContents, publicCloudNames)
 }
 
 func (s *cloudSuite) TestParseCloudsEndpointDenormalisation(c *gc.C) {
@@ -66,8 +69,7 @@ func (s *cloudSuite) TestPublicCloudsMetadataFallback(c *gc.C) {
 	for name, _ := range clouds {
 		cloudNames = append(cloudNames, name)
 	}
-	c.Assert(cloudNames, jc.SameContents,
-		[]string{"aws", "aws-china", "aws-gov", "google", "azure", "azure-china", "rackspace", "joyent"})
+	c.Assert(cloudNames, jc.SameContents, publicCloudNames)
 }
 
 func (s *cloudSuite) TestPublicCloudsMetadata(c *gc.C) {

--- a/cloud/fallback-public-cloud.yaml
+++ b/cloud/fallback-public-cloud.yaml
@@ -51,50 +51,49 @@ clouds:
     auth-types: [ userpass ]
     regions:
       Central US:
-        endpoint: https://management.core.windows.net/
+        endpoint: https://management.azure.com
       East US:
-        endpoint: https://management.core.windows.net/
+        endpoint: https://management.azure.com
       East US 2:
-        endpoint: https://management.core.windows.net/
+        endpoint: https://management.azure.com
       North Central US:
-        endpoint: https://management.core.windows.net/
+        endpoint: https://management.azure.com
       South Central US:
-        endpoint: https://management.core.windows.net/
+        endpoint: https://management.azure.com
       West US:
-        endpoint: https://management.core.windows.net/
+        endpoint: https://management.azure.com
       North Europe:
-        endpoint: https://management.core.windows.net/
+        endpoint: https://management.azure.com
       West Europe:
-        endpoint: https://management.core.windows.net/
+        endpoint: https://management.azure.com
       East Asia:
-        endpoint: https://management.core.windows.net/
+        endpoint: https://management.azure.com
       Southeast Asia:
-        endpoint: https://management.core.windows.net/
+        endpoint: https://management.azure.com
       Japan East:
-        endpoint: https://management.core.windows.net/
+        endpoint: https://management.azure.com
       Japan West:
-        endpoint: https://management.core.windows.net/
+        endpoint: https://management.azure.com
       Brazil South:
-        endpoint: https://management.core.windows.net/
+        endpoint: https://management.azure.com
       Australia East:
-        endpoint: https://management.core.windows.net/
+        endpoint: https://management.azure.com
       Australia Southeast:
-        endpoint: https://management.core.windows.net/
+        endpoint: https://management.azure.com
       Central India:
-        endpoint: https://management.core.windows.net/
+        endpoint: https://management.azure.com
       South India:
-        endpoint: https://management.core.windows.net/
+        endpoint: https://management.azure.com
       West India:
-        endpoint: https://management.core.windows.net/
+        endpoint: https://management.azure.com
   azure-china:
     type: azure
     auth-types: [ userpass ]
-    endpoint: https://management.core.chinacloudapi.cn/
     regions:
       China East:
-        endpoint: https://management.core.chinacloudapi.cn/
+        endpoint: https://management.chinacloudapi.cn
       China North:
-        endpoint: https://management.core.chinacloudapi.cn/
+        endpoint: https://management.chinacloudapi.cn
   rackspace:
     type: openstack
     auth-types: [ access-key, userpass ]
@@ -128,3 +127,17 @@ clouds:
         endpoint: https://us-east-3.api.joyentcloud.com
       us-west-1: 
         endpoint: https://us-west-1.api.joyentcloud.com
+  cloudsigma:
+    type: cloudsigma
+    auth-types: [ userpass ]
+    regions:
+      hnl:
+        endpoint: https://hnl.cloudsigma.com/api/2.0/
+      mia:
+        endpoint: https://mia.cloudsigma.com/api/2.0/
+      sjc:
+        endpoint: https://sjc.cloudsigma.com/api/2.0/
+      wdc:
+        endpoint: https://wdc.cloudsigma.com/api/2.0/
+      zrh:
+        endpoint: https://zrh.cloudsigma.com/api/2.0/

--- a/cloud/fallback_public_cloud.go
+++ b/cloud/fallback_public_cloud.go
@@ -59,50 +59,49 @@ clouds:
     auth-types: [ userpass ]
     regions:
       Central US:
-        endpoint: https://management.core.windows.net/
+        endpoint: https://management.azure.com
       East US:
-        endpoint: https://management.core.windows.net/
+        endpoint: https://management.azure.com
       East US 2:
-        endpoint: https://management.core.windows.net/
+        endpoint: https://management.azure.com
       North Central US:
-        endpoint: https://management.core.windows.net/
+        endpoint: https://management.azure.com
       South Central US:
-        endpoint: https://management.core.windows.net/
+        endpoint: https://management.azure.com
       West US:
-        endpoint: https://management.core.windows.net/
+        endpoint: https://management.azure.com
       North Europe:
-        endpoint: https://management.core.windows.net/
+        endpoint: https://management.azure.com
       West Europe:
-        endpoint: https://management.core.windows.net/
+        endpoint: https://management.azure.com
       East Asia:
-        endpoint: https://management.core.windows.net/
+        endpoint: https://management.azure.com
       Southeast Asia:
-        endpoint: https://management.core.windows.net/
+        endpoint: https://management.azure.com
       Japan East:
-        endpoint: https://management.core.windows.net/
+        endpoint: https://management.azure.com
       Japan West:
-        endpoint: https://management.core.windows.net/
+        endpoint: https://management.azure.com
       Brazil South:
-        endpoint: https://management.core.windows.net/
+        endpoint: https://management.azure.com
       Australia East:
-        endpoint: https://management.core.windows.net/
+        endpoint: https://management.azure.com
       Australia Southeast:
-        endpoint: https://management.core.windows.net/
+        endpoint: https://management.azure.com
       Central India:
-        endpoint: https://management.core.windows.net/
+        endpoint: https://management.azure.com
       South India:
-        endpoint: https://management.core.windows.net/
+        endpoint: https://management.azure.com
       West India:
-        endpoint: https://management.core.windows.net/
+        endpoint: https://management.azure.com
   azure-china:
     type: azure
     auth-types: [ userpass ]
-    endpoint: https://management.core.chinacloudapi.cn/
     regions:
       China East:
-        endpoint: https://management.core.chinacloudapi.cn/
+        endpoint: https://management.chinacloudapi.cn
       China North:
-        endpoint: https://management.core.chinacloudapi.cn/
+        endpoint: https://management.chinacloudapi.cn
   rackspace:
     type: openstack
     auth-types: [ access-key, userpass ]
@@ -136,4 +135,18 @@ clouds:
         endpoint: https://us-east-3.api.joyentcloud.com
       us-west-1: 
         endpoint: https://us-west-1.api.joyentcloud.com
+  cloudsigma:
+    type: cloudsigma
+    auth-types: [ userpass ]
+    regions:
+      hnl:
+        endpoint: https://hnl.cloudsigma.com/api/2.0/
+      mia:
+        endpoint: https://mia.cloudsigma.com/api/2.0/
+      sjc:
+        endpoint: https://sjc.cloudsigma.com/api/2.0/
+      wdc:
+        endpoint: https://wdc.cloudsigma.com/api/2.0/
+      zrh:
+        endpoint: https://zrh.cloudsigma.com/api/2.0/
 `

--- a/cmd/plugins/juju-metadata/validateimagemetadata_test.go
+++ b/cmd/plugins/juju-metadata/validateimagemetadata_test.go
@@ -101,6 +101,7 @@ func cacheTestEnvConfig(c *gc.C) {
 		"type":                      "azure",
 		"default-series":            "raring",
 		"location":                  "West US",
+		"endpoint":                  "https://management.azure.com",
 		"subscription-id":           "foo",
 		"application-id":            "bar",
 		"application-password":      "baz",

--- a/provider/azure/config.go
+++ b/provider/azure/config.go
@@ -20,6 +20,7 @@ const (
 	configAttrTenantId           = "tenant-id"
 	configAttrAppPassword        = "application-password"
 	configAttrLocation           = "location"
+	configAttrEndpoint           = "endpoint"
 	configAttrStorageAccountType = "storage-account-type"
 
 	// The below bits are internal book-keeping things, rather than
@@ -44,6 +45,7 @@ const (
 
 var configFields = schema.Fields{
 	configAttrLocation:                schema.String(),
+	configAttrEndpoint:                schema.String(),
 	configAttrAppId:                   schema.String(),
 	configAttrSubscriptionId:          schema.String(),
 	configAttrTenantId:                schema.String(),
@@ -67,6 +69,7 @@ var requiredConfigAttributes = []string{
 	configAttrSubscriptionId,
 	configAttrTenantId,
 	configAttrLocation,
+	configAttrEndpoint,
 	configAttrControllerResourceGroup,
 }
 
@@ -89,6 +92,7 @@ type azureModelConfig struct {
 	token                   *azure.ServicePrincipalToken
 	subscriptionId          string
 	location                string // canonicalized
+	endpoint                string
 	storageAccount          string
 	storageAccountKey       string
 	storageAccountType      storage.AccountType
@@ -161,6 +165,7 @@ func validateConfig(newCfg, oldCfg *config.Config) (*azureModelConfig, error) {
 	}
 
 	location := canonicalLocation(validated[configAttrLocation].(string))
+	endpoint := validated[configAttrEndpoint].(string)
 	appId := validated[configAttrAppId].(string)
 	subscriptionId := validated[configAttrSubscriptionId].(string)
 	tenantId := validated[configAttrTenantId].(string)
@@ -195,6 +200,7 @@ func validateConfig(newCfg, oldCfg *config.Config) (*azureModelConfig, error) {
 		token,
 		subscriptionId,
 		location,
+		endpoint,
 		storageAccount,
 		storageAccountKey,
 		storage.AccountType(storageAccountType),

--- a/provider/azure/config_test.go
+++ b/provider/azure/config_test.go
@@ -104,6 +104,7 @@ func makeTestModelConfig(c *gc.C, extra ...testing.Attrs) *config.Config {
 		"application-password":      "opensezme",
 		"subscription-id":           fakeSubscriptionId,
 		"location":                  "westus",
+		"endpoint":                  "httsp://api.azurestack.local",
 		"controller-resource-group": "arbitrary",
 		"agent-version":             "1.2.3",
 	}

--- a/provider/azure/environ.go
+++ b/provider/azure/environ.go
@@ -275,14 +275,10 @@ func (env *azureEnviron) SetConfig(cfg *config.Config) error {
 	env.config = ecfg
 
 	// Initialise clients.
-	baseURI := "https://management.azure.com"
-	if strings.Contains(ecfg.location, "china") {
-		baseURI = "https://management.chinacloudapi.cn"
-	}
-	env.compute = compute.NewWithBaseURI(baseURI, env.config.subscriptionId)
-	env.resources = resources.NewWithBaseURI(baseURI, env.config.subscriptionId)
-	env.storage = storage.NewWithBaseURI(baseURI, env.config.subscriptionId)
-	env.network = network.NewWithBaseURI(baseURI, env.config.subscriptionId)
+	env.compute = compute.NewWithBaseURI(ecfg.endpoint, env.config.subscriptionId)
+	env.resources = resources.NewWithBaseURI(ecfg.endpoint, env.config.subscriptionId)
+	env.storage = storage.NewWithBaseURI(ecfg.endpoint, env.config.subscriptionId)
+	env.network = network.NewWithBaseURI(ecfg.endpoint, env.config.subscriptionId)
 	clients := map[string]*autorest.Client{
 		"azure.compute":   &env.compute.Client,
 		"azure.resources": &env.resources.Client,

--- a/provider/azure/environ_test.go
+++ b/provider/azure/environ_test.go
@@ -25,7 +25,6 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/api"
-	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/cloudconfig/instancecfg"
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs"
@@ -310,15 +309,7 @@ func prepareForBootstrap(
 		Config:        cfg,
 		CloudRegion:   "westus",
 		CloudEndpoint: "https://management.azure.com",
-		Credentials: cloud.NewCredential(
-			cloud.UserPassAuthType,
-			map[string]string{
-				"application-id":       "application-id",
-				"subscription-id":      "subscription-id",
-				"tenant-id":            "tenant-id",
-				"application-password": "application-password",
-			},
-		),
+		Credentials:   fakeUserPassCredential(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	return env
@@ -459,11 +450,7 @@ func (s *environSuite) TestOpen(c *gc.C) {
 }
 
 func (s *environSuite) TestCloudEndpointManagementURI(c *gc.C) {
-	s.testLocationManagementURI(c, "West US", "api.azurestack.local")
-}
-
-func (s *environSuite) testLocationManagementURI(c *gc.C, location, host string) {
-	env := s.openEnviron(c) //, testing.Attrs{"location": location})
+	env := s.openEnviron(c)
 
 	sender := mocks.NewSender()
 	sender.EmitContent("{}")
@@ -472,7 +459,7 @@ func (s *environSuite) testLocationManagementURI(c *gc.C, location, host string)
 	env.AllInstances() // trigger a query
 
 	c.Assert(s.requests, gc.HasLen, 1)
-	c.Assert(s.requests[0].URL.Host, gc.Equals, host)
+	c.Assert(s.requests[0].URL.Host, gc.Equals, "api.azurestack.local")
 }
 
 func (s *environSuite) TestStartInstance(c *gc.C) {

--- a/provider/azure/environprovider_test.go
+++ b/provider/azure/environprovider_test.go
@@ -50,18 +50,22 @@ func (s *environProviderSuite) testPrepareForBootstrapWithInternalConfig(c *gc.C
 	cfg := makeTestModelConfig(c, testing.Attrs{key: "whatever"})
 	s.sender = azuretesting.Senders{tokenRefreshSender()}
 	_, err := s.provider.PrepareForBootstrap(ctx, environs.PrepareForBootstrapParams{
-		Config: cfg,
-		Credentials: cloud.NewCredential(
-			cloud.UserPassAuthType,
-			map[string]string{
-				"application-id":       "application-id",
-				"subscription-id":      "subscription-id",
-				"tenant-id":            "tenant-id",
-				"application-password": "application-password",
-			},
-		),
+		Config:      cfg,
+		Credentials: fakeUserPassCredential(),
 	})
 	c.Check(err, gc.ErrorMatches, fmt.Sprintf(`internal config "%s" must not be specified`, key))
+}
+
+func fakeUserPassCredential() cloud.Credential {
+	return cloud.NewCredential(
+		cloud.UserPassAuthType,
+		map[string]string{
+			"application-id":       "application-id",
+			"subscription-id":      "subscription-id",
+			"tenant-id":            "tenant-id",
+			"application-password": "application-password",
+		},
+	)
 }
 
 func (s *environProviderSuite) TestPrepareForBootstrap(c *gc.C) {
@@ -75,15 +79,7 @@ func (s *environProviderSuite) TestPrepareForBootstrap(c *gc.C) {
 		Config:        cfg,
 		CloudRegion:   "westus",
 		CloudEndpoint: "https://api.azurestack.local",
-		Credentials: cloud.NewCredential(
-			cloud.UserPassAuthType,
-			map[string]string{
-				"application-id":       "application-id",
-				"subscription-id":      "subscription-id",
-				"tenant-id":            "tenant-id",
-				"application-password": "application-password",
-			},
-		),
+		Credentials:   fakeUserPassCredential(),
 	})
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(env, gc.NotNil)

--- a/provider/azure/environprovider_test.go
+++ b/provider/azure/environprovider_test.go
@@ -13,6 +13,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs"
 	envtesting "github.com/juju/juju/environs/testing"
 	"github.com/juju/juju/provider/azure"
@@ -50,6 +51,15 @@ func (s *environProviderSuite) testPrepareForBootstrapWithInternalConfig(c *gc.C
 	s.sender = azuretesting.Senders{tokenRefreshSender()}
 	_, err := s.provider.PrepareForBootstrap(ctx, environs.PrepareForBootstrapParams{
 		Config: cfg,
+		Credentials: cloud.NewCredential(
+			cloud.UserPassAuthType,
+			map[string]string{
+				"application-id":       "application-id",
+				"subscription-id":      "subscription-id",
+				"tenant-id":            "tenant-id",
+				"application-password": "application-password",
+			},
+		),
 	})
 	c.Check(err, gc.ErrorMatches, fmt.Sprintf(`internal config "%s" must not be specified`, key))
 }
@@ -62,7 +72,18 @@ func (s *environProviderSuite) TestPrepareForBootstrap(c *gc.C) {
 
 	s.sender = azuretesting.Senders{tokenRefreshSender()}
 	env, err := s.provider.PrepareForBootstrap(ctx, environs.PrepareForBootstrapParams{
-		Config: cfg,
+		Config:        cfg,
+		CloudRegion:   "westus",
+		CloudEndpoint: "https://api.azurestack.local",
+		Credentials: cloud.NewCredential(
+			cloud.UserPassAuthType,
+			map[string]string{
+				"application-id":       "application-id",
+				"subscription-id":      "subscription-id",
+				"tenant-id":            "tenant-id",
+				"application-password": "application-password",
+			},
+		),
 	})
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(env, gc.NotNil)

--- a/provider/azure/storage.go
+++ b/provider/azure/storage.go
@@ -645,6 +645,9 @@ func gibToMib(g uint64) uint64 {
 // locationStorageEndpoint returns the hostname to supply to NewStorageClient
 // for the given location.
 func locationStorageEndpoint(location string) string {
+	// TODO(axw) we need a way of specifying the storage endpoint in
+	// clouds.yaml. The storage endpoint is not necessarily based on
+	// the resource manager endpoint.
 	if strings.Contains(location, "china") {
 		return "core.chinacloudapi.cn"
 	}

--- a/provider/cloudsigma/client.go
+++ b/provider/cloudsigma/client.go
@@ -38,7 +38,7 @@ var newClient = func(cfg *environConfig) (client *environClient, err error) {
 	logger.Debugf("creating CloudSigma client: id=%q", uuid)
 
 	// create connection to CloudSigma
-	conn, err := gosigma.NewClient(cfg.region(), cfg.username(), cfg.password(), nil)
+	conn, err := gosigma.NewClient(cfg.endpoint(), cfg.username(), cfg.password(), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/provider/cloudsigma/client_test.go
+++ b/provider/cloudsigma/client_test.go
@@ -59,7 +59,8 @@ func testNewClient(c *gc.C, endpoint, username, password string) (*environClient
 	ecfg := &environConfig{
 		Config: newConfig(c, testing.Attrs{"name": "client-test", "uuid": "f54aac3a-9dcd-4a0c-86b5-24091478478c"}),
 		attrs: map[string]interface{}{
-			"region":   endpoint,
+			"region":   "testregion",
+			"endpoint": endpoint,
 			"username": username,
 			"password": password,
 		},

--- a/provider/cloudsigma/config.go
+++ b/provider/cloudsigma/config.go
@@ -16,12 +16,14 @@ var configFields = schema.Fields{
 	"username": schema.String(),
 	"password": schema.String(),
 	"region":   schema.String(),
+	"endpoint": schema.String(),
 }
 
 var configDefaultFields = schema.Defaults{
 	"username": "",
 	"password": "",
 	"region":   gosigma.DefaultRegion,
+	"endpoint": "",
 }
 
 var configSecretFields = []string{
@@ -30,6 +32,7 @@ var configSecretFields = []string{
 
 var configImmutableFields = []string{
 	"region",
+	"endpoint",
 }
 
 func prepareConfig(cfg *config.Config) (*config.Config, error) {
@@ -122,6 +125,10 @@ type environConfig struct {
 
 func (c environConfig) region() string {
 	return c.attrs["region"].(string)
+}
+
+func (c environConfig) endpoint() string {
+	return c.attrs["endpoint"].(string)
 }
 
 func (c environConfig) username() string {

--- a/provider/cloudsigma/config_test.go
+++ b/provider/cloudsigma/config_test.go
@@ -25,6 +25,7 @@ func validAttrs() testing.Attrs {
 		"username": "user",
 		"password": "password",
 		"region":   "zrh",
+		"endpoint": "https://0.1.2.3:2000/api/2.0/",
 		"uuid":     "f54aac3a-9dcd-4a0c-86b5-24091478478c",
 	})
 }

--- a/provider/cloudsigma/environinstance_test.go
+++ b/provider/cloudsigma/environinstance_test.go
@@ -35,7 +35,8 @@ func (s *environInstanceSuite) SetUpSuite(c *gc.C) {
 	attrs := testing.Attrs{
 		"name":     "testname",
 		"uuid":     "f54aac3a-9dcd-4a0c-86b5-24091478478c",
-		"region":   mock.Endpoint(""),
+		"region":   "testregion",
+		"endpoint": mock.Endpoint(""),
 		"username": mock.TestUser,
 		"password": mock.TestPassword,
 	}
@@ -127,7 +128,8 @@ func (s *environInstanceSuite) TestInstances(c *gc.C) {
 func (s *environInstanceSuite) TestInstancesFail(c *gc.C) {
 	attrs := testing.Attrs{
 		"name":     "testname",
-		"region":   "https://0.1.2.3:2000/api/2.0/",
+		"region":   "testregion",
+		"endpoint": "https://0.1.2.3:2000/api/2.0/",
 		"username": mock.TestUser,
 		"password": mock.TestPassword,
 	}

--- a/provider/vsphere/provider_test.go
+++ b/provider/vsphere/provider_test.go
@@ -9,6 +9,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs"
 	envtesting "github.com/juju/juju/environs/testing"
 	"github.com/juju/juju/provider/vsphere"
@@ -45,6 +46,10 @@ func (s *providerSuite) TestOpen(c *gc.C) {
 func (s *providerSuite) TestPrepareForBootstrap(c *gc.C) {
 	env, err := s.provider.PrepareForBootstrap(envtesting.BootstrapContext(c), environs.PrepareForBootstrapParams{
 		Config: s.Config,
+		Credentials: cloud.NewCredential(
+			cloud.UserPassAuthType,
+			map[string]string{"user": "u", "password": "p"},
+		),
 	})
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(env, gc.NotNil)


### PR DESCRIPTION
Update the azure, cloudsigma and vsphere providers
to use cloud credentials, region and endpoint info.

Update fallback-public-cloud.yaml with correct
endpoint URLs for Azure, and add CloudSigma info.

There's still the issue of storage endpoint for
Azure, which will be addressed when we have a
storage-endpoint field in clouds.yaml.

(Review request: http://reviews.vapour.ws/r/3790/)