### PR TITLE
cloud: unexport the Clouds and Credentials types

### DIFF
--- a/cloud/clouds_test.go
+++ b/cloud/clouds_test.go
@@ -21,17 +21,17 @@ var publicCloudNames = []string{
 	"aws", "aws-china", "aws-gov", "google", "azure", "azure-china", "rackspace", "joyent", "cloudsigma",
 }
 
-func parsePublicClouds(c *gc.C) *cloud.Clouds {
+func parsePublicClouds(c *gc.C) map[string]cloud.Cloud {
 	clouds, err := cloud.ParseCloudMetadata([]byte(cloud.FallbackPublicCloudInfo))
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(clouds.Clouds, gc.HasLen, len(publicCloudNames))
+	c.Assert(clouds, gc.HasLen, len(publicCloudNames))
 	return clouds
 }
 
 func (s *cloudSuite) TestParseClouds(c *gc.C) {
 	clouds := parsePublicClouds(c)
 	var cloudNames []string
-	for name, _ := range clouds.Clouds {
+	for name, _ := range clouds {
 		cloudNames = append(cloudNames, name)
 	}
 	c.Assert(cloudNames, jc.SameContents, publicCloudNames)
@@ -39,7 +39,7 @@ func (s *cloudSuite) TestParseClouds(c *gc.C) {
 
 func (s *cloudSuite) TestParseCloudsEndpointDenormalisation(c *gc.C) {
 	clouds := parsePublicClouds(c)
-	rackspace := clouds.Clouds["rackspace"]
+	rackspace := clouds["rackspace"]
 	c.Assert(rackspace.Type, gc.Equals, "openstack")
 	c.Assert(rackspace.Endpoint, gc.Equals, "https://identity.api.rackspacecloud.com/v2.0")
 	var regionNames []string
@@ -57,7 +57,7 @@ func (s *cloudSuite) TestParseCloudsEndpointDenormalisation(c *gc.C) {
 
 func (s *cloudSuite) TestParseCloudsAuthTypes(c *gc.C) {
 	clouds := parsePublicClouds(c)
-	rackspace := clouds.Clouds["rackspace"]
+	rackspace := clouds["rackspace"]
 	c.Assert(rackspace.AuthTypes, jc.SameContents, []cloud.AuthType{"access-key", "userpass"})
 }
 

--- a/cloud/credentials_test.go
+++ b/cloud/credentials_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-	"gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/cloud"
 )
@@ -16,27 +15,25 @@ type credentialsSuite struct{}
 
 var _ = gc.Suite(&credentialsSuite{})
 
-func (s *credentialsSuite) TestMarshallAccessKey(c *gc.C) {
-	creds := cloud.Credentials{
-		Credentials: map[string]cloud.CloudCredential{
-			"aws": {
-				DefaultCredential: "default-cred",
-				DefaultRegion:     "us-west-2",
-				AuthCredentials: map[string]cloud.Credential{
-					"peter": cloud.NewCredential(cloud.AccessKeyAuthType, map[string]string{
-						"access-key": "key",
-						"secret-key": "secret",
-					}),
-					// TODO(wallyworld) - add anther credential once goyaml.v2 supports inline MapSlice.
-					//"paul": &cloud.AccessKeyCredentials{
-					//	Key: "paulkey",
-					//	Secret: "paulsecret",
-					//},
-				},
+func (s *credentialsSuite) TestMarshalAccessKey(c *gc.C) {
+	creds := map[string]cloud.CloudCredential{
+		"aws": {
+			DefaultCredential: "default-cred",
+			DefaultRegion:     "us-west-2",
+			AuthCredentials: map[string]cloud.Credential{
+				"peter": cloud.NewCredential(cloud.AccessKeyAuthType, map[string]string{
+					"access-key": "key",
+					"secret-key": "secret",
+				}),
+				// TODO(wallyworld) - add anther credential once goyaml.v2 supports inline MapSlice.
+				//"paul": &cloud.AccessKeyCredentials{
+				//	Key: "paulkey",
+				//	Secret: "paulsecret",
+				//},
 			},
 		},
 	}
-	out, err := yaml.Marshal(creds)
+	out, err := cloud.MarshalCredentials(creds)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(out), gc.Equals, `
 credentials:
@@ -50,23 +47,21 @@ credentials:
 `[1:])
 }
 
-func (s *credentialsSuite) TestMarshallOpenstackAccessKey(c *gc.C) {
-	creds := cloud.Credentials{
-		Credentials: map[string]cloud.CloudCredential{
-			"openstack": {
-				DefaultCredential: "default-cred",
-				DefaultRegion:     "region-a",
-				AuthCredentials: map[string]cloud.Credential{
-					"peter": cloud.NewCredential(cloud.AccessKeyAuthType, map[string]string{
-						"access-key":  "key",
-						"secret-key":  "secret",
-						"tenant-name": "tenant",
-					}),
-				},
+func (s *credentialsSuite) TestMarshalOpenstackAccessKey(c *gc.C) {
+	creds := map[string]cloud.CloudCredential{
+		"openstack": {
+			DefaultCredential: "default-cred",
+			DefaultRegion:     "region-a",
+			AuthCredentials: map[string]cloud.Credential{
+				"peter": cloud.NewCredential(cloud.AccessKeyAuthType, map[string]string{
+					"access-key":  "key",
+					"secret-key":  "secret",
+					"tenant-name": "tenant",
+				}),
 			},
 		},
 	}
-	out, err := yaml.Marshal(creds)
+	out, err := cloud.MarshalCredentials(creds)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(out), gc.Equals, `
 credentials:
@@ -81,23 +76,21 @@ credentials:
 `[1:])
 }
 
-func (s *credentialsSuite) TestMarshallOpenstackUserPass(c *gc.C) {
-	creds := cloud.Credentials{
-		Credentials: map[string]cloud.CloudCredential{
-			"openstack": {
-				DefaultCredential: "default-cred",
-				DefaultRegion:     "region-a",
-				AuthCredentials: map[string]cloud.Credential{
-					"peter": cloud.NewCredential(cloud.UserPassAuthType, map[string]string{
-						"username":    "user",
-						"password":    "secret",
-						"tenant-name": "tenant",
-					}),
-				},
+func (s *credentialsSuite) TestMarshalOpenstackUserPass(c *gc.C) {
+	creds := map[string]cloud.CloudCredential{
+		"openstack": {
+			DefaultCredential: "default-cred",
+			DefaultRegion:     "region-a",
+			AuthCredentials: map[string]cloud.Credential{
+				"peter": cloud.NewCredential(cloud.UserPassAuthType, map[string]string{
+					"username":    "user",
+					"password":    "secret",
+					"tenant-name": "tenant",
+				}),
 			},
 		},
 	}
-	out, err := yaml.Marshal(creds)
+	out, err := cloud.MarshalCredentials(creds)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(out), gc.Equals, `
 credentials:
@@ -112,24 +105,22 @@ credentials:
 `[1:])
 }
 
-func (s *credentialsSuite) TestMarshallAzureCredntials(c *gc.C) {
-	creds := cloud.Credentials{
-		Credentials: map[string]cloud.CloudCredential{
-			"azure": {
-				DefaultCredential: "default-cred",
-				DefaultRegion:     "Central US",
-				AuthCredentials: map[string]cloud.Credential{
-					"peter": cloud.NewCredential(cloud.UserPassAuthType, map[string]string{
-						"application-id":       "app-id",
-						"application-password": "app-secret",
-						"subscription-id":      "subscription-id",
-						"tenant-id":            "tenant-id",
-					}),
-				},
+func (s *credentialsSuite) TestMarshalAzureCredntials(c *gc.C) {
+	creds := map[string]cloud.CloudCredential{
+		"azure": {
+			DefaultCredential: "default-cred",
+			DefaultRegion:     "Central US",
+			AuthCredentials: map[string]cloud.Credential{
+				"peter": cloud.NewCredential(cloud.UserPassAuthType, map[string]string{
+					"application-id":       "app-id",
+					"application-password": "app-secret",
+					"subscription-id":      "subscription-id",
+					"tenant-id":            "tenant-id",
+				}),
 			},
 		},
 	}
-	out, err := yaml.Marshal(creds)
+	out, err := cloud.MarshalCredentials(creds)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(out), gc.Equals, `
 credentials:
@@ -145,24 +136,22 @@ credentials:
 `[1:])
 }
 
-func (s *credentialsSuite) TestMarshallOAuth1(c *gc.C) {
-	creds := cloud.Credentials{
-		Credentials: map[string]cloud.CloudCredential{
-			"maas": {
-				DefaultCredential: "default-cred",
-				DefaultRegion:     "region-default",
-				AuthCredentials: map[string]cloud.Credential{
-					"peter": cloud.NewCredential(cloud.OAuth1AuthType, map[string]string{
-						"consumer-key":    "consumer-key",
-						"consumer-secret": "consumer-secret",
-						"access-token":    "access-token",
-						"token-secret":    "token-secret",
-					}),
-				},
+func (s *credentialsSuite) TestMarshalOAuth1(c *gc.C) {
+	creds := map[string]cloud.CloudCredential{
+		"maas": {
+			DefaultCredential: "default-cred",
+			DefaultRegion:     "region-default",
+			AuthCredentials: map[string]cloud.Credential{
+				"peter": cloud.NewCredential(cloud.OAuth1AuthType, map[string]string{
+					"consumer-key":    "consumer-key",
+					"consumer-secret": "consumer-secret",
+					"access-token":    "access-token",
+					"token-secret":    "token-secret",
+				}),
 			},
 		},
 	}
-	out, err := yaml.Marshal(creds)
+	out, err := cloud.MarshalCredentials(creds)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(out), gc.Equals, `
 credentials:
@@ -178,23 +167,21 @@ credentials:
 `[1:])
 }
 
-func (s *credentialsSuite) TestMarshallOAuth2(c *gc.C) {
-	creds := cloud.Credentials{
-		Credentials: map[string]cloud.CloudCredential{
-			"google": {
-				DefaultCredential: "default-cred",
-				DefaultRegion:     "West US",
-				AuthCredentials: map[string]cloud.Credential{
-					"peter": cloud.NewCredential(cloud.OAuth2AuthType, map[string]string{
-						"client-id":    "client-id",
-						"client-email": "client-email",
-						"private-key":  "secret",
-					}),
-				},
+func (s *credentialsSuite) TestMarshalOAuth2(c *gc.C) {
+	creds := map[string]cloud.CloudCredential{
+		"google": {
+			DefaultCredential: "default-cred",
+			DefaultRegion:     "West US",
+			AuthCredentials: map[string]cloud.Credential{
+				"peter": cloud.NewCredential(cloud.OAuth2AuthType, map[string]string{
+					"client-id":    "client-id",
+					"client-email": "client-email",
+					"private-key":  "secret",
+				}),
 			},
 		},
 	}
-	out, err := yaml.Marshal(creds)
+	out, err := cloud.MarshalCredentials(creds)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(out), gc.Equals, `
 credentials:
@@ -235,39 +222,37 @@ credentials:
       auth-type: access-key
       access-key: super
       secret-key: sekrit
-`[1:]), &cloud.Credentials{
-		Credentials: map[string]cloud.CloudCredential{
-			"aws": cloud.CloudCredential{
-				DefaultCredential: "peter",
-				DefaultRegion:     "us-east-2",
-				AuthCredentials: map[string]cloud.Credential{
-					"peter": cloud.NewCredential(cloud.AccessKeyAuthType, map[string]string{
-						"access-key": "key",
-						"secret-key": "secret",
-					}),
-				},
+`[1:]), map[string]cloud.CloudCredential{
+		"aws": cloud.CloudCredential{
+			DefaultCredential: "peter",
+			DefaultRegion:     "us-east-2",
+			AuthCredentials: map[string]cloud.Credential{
+				"peter": cloud.NewCredential(cloud.AccessKeyAuthType, map[string]string{
+					"access-key": "key",
+					"secret-key": "secret",
+				}),
 			},
-			"aws-china": cloud.CloudCredential{
-				DefaultCredential: "zhu8jie",
-				AuthCredentials: map[string]cloud.Credential{
-					"zhu8jie": cloud.NewCredential(cloud.AccessKeyAuthType, map[string]string{
-						"access-key": "key",
-						"secret-key": "secret",
-					}),
-					"sun5kong": cloud.NewCredential(cloud.AccessKeyAuthType, map[string]string{
-						"access-key": "quay",
-						"secret-key": "sekrit",
-					}),
-				},
+		},
+		"aws-china": cloud.CloudCredential{
+			DefaultCredential: "zhu8jie",
+			AuthCredentials: map[string]cloud.Credential{
+				"zhu8jie": cloud.NewCredential(cloud.AccessKeyAuthType, map[string]string{
+					"access-key": "key",
+					"secret-key": "secret",
+				}),
+				"sun5kong": cloud.NewCredential(cloud.AccessKeyAuthType, map[string]string{
+					"access-key": "quay",
+					"secret-key": "sekrit",
+				}),
 			},
-			"aws-gov": cloud.CloudCredential{
-				DefaultRegion: "us-gov-west-1",
-				AuthCredentials: map[string]cloud.Credential{
-					"supersekrit": cloud.NewCredential(cloud.AccessKeyAuthType, map[string]string{
-						"access-key": "super",
-						"secret-key": "sekrit",
-					}),
-				},
+		},
+		"aws-gov": cloud.CloudCredential{
+			DefaultRegion: "us-gov-west-1",
+			AuthCredentials: map[string]cloud.Credential{
+				"supersekrit": cloud.NewCredential(cloud.AccessKeyAuthType, map[string]string{
+					"access-key": "super",
+					"secret-key": "sekrit",
+				}),
 			},
 		},
 	})
@@ -281,18 +266,16 @@ credentials:
   cloud-name:
     credential-name:
       auth-type: woop
-`[1:]), &cloud.Credentials{
-		Credentials: map[string]cloud.CloudCredential{
-			"cloud-name": cloud.CloudCredential{
-				AuthCredentials: map[string]cloud.Credential{
-					"credential-name": cloud.NewCredential("woop", nil),
-				},
+`[1:]), map[string]cloud.CloudCredential{
+		"cloud-name": cloud.CloudCredential{
+			AuthCredentials: map[string]cloud.Credential{
+				"credential-name": cloud.NewCredential("woop", nil),
 			},
 		},
 	})
 }
 
-func (s *credentialsSuite) testParseCredentials(c *gc.C, input []byte, expect *cloud.Credentials) {
+func (s *credentialsSuite) testParseCredentials(c *gc.C, input []byte, expect map[string]cloud.CloudCredential) {
 	output, err := cloud.ParseCredentials(input)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(output, jc.DeepEquals, expect)

--- a/cloud/personalclouds.go
+++ b/cloud/personalclouds.go
@@ -44,13 +44,13 @@ func ParseCloudMetadataFile(file string) (map[string]Cloud, error) {
 	if err != nil {
 		return nil, err
 	}
-	return clouds.Clouds, err
+	return clouds, err
 }
 
 // WritePersonalCloudMetadata marshals to YAMl and writes the cloud metadata
 // to the personal cloud file.
-func WritePersonalCloudMetadata(clouds *Clouds) error {
-	data, err := yaml.Marshal(clouds)
+func WritePersonalCloudMetadata(cloudsMap map[string]Cloud) error {
+	data, err := yaml.Marshal(clouds{cloudsMap})
 	if err != nil {
 		return errors.Annotate(err, "cannot marshal yaml cloud metadata")
 	}

--- a/cloud/personalclouds_test.go
+++ b/cloud/personalclouds_test.go
@@ -21,19 +21,17 @@ type personalCloudSuite struct {
 var _ = gc.Suite(&personalCloudSuite{})
 
 func (s *personalCloudSuite) TestWritePersonalClouds(c *gc.C) {
-	clouds := cloud.Clouds{
-		Clouds: map[string]cloud.Cloud{
-			"homestack": cloud.Cloud{
-				Type:      "openstack",
-				AuthTypes: []cloud.AuthType{"userpass", "access-key"},
-				Endpoint:  "http://homestack",
-				Regions: map[string]cloud.Region{
-					"london": cloud.Region{Endpoint: "http://london/1.0"},
-				},
+	clouds := map[string]cloud.Cloud{
+		"homestack": cloud.Cloud{
+			Type:      "openstack",
+			AuthTypes: []cloud.AuthType{"userpass", "access-key"},
+			Endpoint:  "http://homestack",
+			Regions: map[string]cloud.Region{
+				"london": cloud.Region{Endpoint: "http://london/1.0"},
 			},
 		},
 	}
-	err := cloud.WritePersonalCloudMetadata(&clouds)
+	err := cloud.WritePersonalCloudMetadata(clouds)
 	c.Assert(err, jc.ErrorIsNil)
 	data, err := ioutil.ReadFile(osenv.JujuXDGDataHomePath("clouds.yaml"))
 	c.Assert(err, jc.ErrorIsNil)

--- a/cmd/juju/cloud/add.go
+++ b/cmd/juju/cloud/add.go
@@ -97,5 +97,5 @@ func (c *addCloudCommand) Run(ctxt *cmd.Context) error {
 		personalClouds = make(map[string]cloud.Cloud)
 	}
 	personalClouds[c.Cloud] = newCloud
-	return cloud.WritePersonalCloudMetadata(&cloud.Clouds{Clouds: personalClouds})
+	return cloud.WritePersonalCloudMetadata(personalClouds)
 }

--- a/cmd/juju/cloud/listcredentials_test.go
+++ b/cmd/juju/cloud/listcredentials_test.go
@@ -11,7 +11,6 @@ import (
 
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-	"gopkg.in/yaml.v2"
 
 	jujucloud "github.com/juju/juju/cloud"
 	"github.com/juju/juju/cmd/juju/cloud"
@@ -27,41 +26,39 @@ type listCredentialsSuite struct {
 
 var _ = gc.Suite(&listCredentialsSuite{})
 
-var sampleCredentials = &jujucloud.Credentials{
-	Credentials: map[string]jujucloud.CloudCredential{
-		"aws": {
-			DefaultRegion:     "ap-southeast-2",
-			DefaultCredential: "down",
-			AuthCredentials: map[string]jujucloud.Credential{
-				"bob": jujucloud.NewCredential(
-					jujucloud.AccessKeyAuthType,
-					map[string]string{
-						"access-key": "key",
-						"secret-key": "secret",
-					},
-				),
-				"down": jujucloud.NewCredential(
-					jujucloud.OAuth2AuthType,
-					map[string]string{
-						"client-id":    "id",
-						"client-email": "email",
-						"private-key":  "key",
-					},
-				),
-			},
+var sampleCredentials = map[string]jujucloud.CloudCredential{
+	"aws": {
+		DefaultRegion:     "ap-southeast-2",
+		DefaultCredential: "down",
+		AuthCredentials: map[string]jujucloud.Credential{
+			"bob": jujucloud.NewCredential(
+				jujucloud.AccessKeyAuthType,
+				map[string]string{
+					"access-key": "key",
+					"secret-key": "secret",
+				},
+			),
+			"down": jujucloud.NewCredential(
+				jujucloud.OAuth2AuthType,
+				map[string]string{
+					"client-id":    "id",
+					"client-email": "email",
+					"private-key":  "key",
+				},
+			),
 		},
-		"azure": {
-			AuthCredentials: map[string]jujucloud.Credential{
-				"azhja": jujucloud.NewCredential(
-					jujucloud.UserPassAuthType,
-					map[string]string{
-						"application-id":       "app-id",
-						"application-password": "app-secret",
-						"subscription-id":      "subscription-id",
-						"tenant-id":            "tenant-id",
-					},
-				),
-			},
+	},
+	"azure": {
+		AuthCredentials: map[string]jujucloud.Credential{
+			"azhja": jujucloud.NewCredential(
+				jujucloud.UserPassAuthType,
+				map[string]string{
+					"application-id":       "app-id",
+					"application-password": "app-secret",
+					"subscription-id":      "subscription-id",
+					"tenant-id":            "tenant-id",
+				},
+			),
 		},
 	},
 }
@@ -75,8 +72,8 @@ func (s *listCredentialsSuite) SetUpTest(c *gc.C) {
 		osenv.SetJujuXDGDataHome(oldJujuXDGDataHome)
 	})
 
-	// Write $JUJU_HOME/credentials.yaml.
-	data, err := yaml.Marshal(sampleCredentials)
+	// Write $XDG_DATA_HOME/juju/credentials.yaml.
+	data, err := jujucloud.MarshalCredentials(sampleCredentials)
 	c.Assert(err, jc.ErrorIsNil)
 	err = ioutil.WriteFile(filepath.Join(s.jujuXDGDataHome, "credentials.yaml"), data, 0600)
 	c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
These types are used only for un/marshalling, and do not deserve
to be part of the external API.

(Review request: http://reviews.vapour.ws/r/3794/)