### PR TITLE
Allow state.Space and Subnet with duplicate ProviderIds across models

### DIFF
--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -293,6 +293,17 @@ func allCollections() collectionSchema {
 		},
 		openedPortsC:       {},
 		requestedNetworksC: {},
+		spacesC: {
+			indexes: []mgo.Index{{
+				// NOTE: Like the DocID field, ProviderId also has the model
+				// UUID as prefix to ensure uniqueness per model. However since
+				// not all providers support spaces, it can be empty, hence both
+				// unique and sparse.
+				Key:    []string{"providerid"},
+				Unique: true,
+				Sparse: true,
+			}},
+		},
 		subnetsC: {
 			indexes: []mgo.Index{{
 				// TODO(dimitern): make unique per-model, not globally.
@@ -344,18 +355,6 @@ func allCollections() collectionSchema {
 		statusesHistoryC: {
 			indexes: []mgo.Index{{
 				Key: []string{"model-uuid", "globalkey"},
-			}},
-		},
-		spacesC: {
-			indexes: []mgo.Index{{
-				// TODO(mfood): make unique per-environment, not globally.
-				// Note: currently in Mongodb sparse and unique
-				// indexes don't work for compound indexes.
-				Key: []string{"providerid"},
-				// Not always present; but, if present, must be unique; hence
-				// both unique and sparse.
-				Unique: true,
-				Sparse: true,
 			}},
 		},
 

--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -306,12 +306,11 @@ func allCollections() collectionSchema {
 		},
 		subnetsC: {
 			indexes: []mgo.Index{{
-				// TODO(dimitern): make unique per-model, not globally.
-				// Note: currently in Mongodb sparse and unique
-				// indexes don't work for compound indexes.
-				Key: []string{"providerid"},
-				// Not always present; but, if present, must be unique; hence
-				// both unique and sparse.
+				// NOTE: Like the DocID field, ProviderId also has the model
+				// UUID as prefix to ensure uniqueness per model. However since
+				// not all providers support subnets, it can be empty, hence both
+				// unique and sparse.
+				Key:    []string{"providerid"},
 				Unique: true,
 				Sparse: true,
 			}},

--- a/state/conn_test.go
+++ b/state/conn_test.go
@@ -5,11 +5,14 @@ package state_test
 
 import (
 	"github.com/juju/names"
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/mgo.v2"
 
 	"github.com/juju/juju/state"
 	statetesting "github.com/juju/juju/state/testing"
+	"github.com/juju/juju/testing"
 )
 
 // ConnSuite provides the infrastructure for all other
@@ -98,4 +101,19 @@ func (s *ConnSuite) AddMetaCharm(c *gc.C, name, metaYaml string, revsion int) *s
 // given YAML string and adds it to the state, using the given revision.
 func (s *ConnSuite) AddMetricsCharm(c *gc.C, name, metricsYaml string, revsion int) *state.Charm {
 	return state.AddCustomCharm(c, s.State, name, "metrics.yaml", metricsYaml, "quantal", revsion)
+}
+
+// NewStateForModelNamed returns an new model with the given modelName, which
+// has a unique UUID, and does not need to be closed when the test completes.
+func (s *ConnSuite) NewStateForModelNamed(c *gc.C, modelName string) *state.State {
+	cfg := testing.CustomModelConfig(c, testing.Attrs{
+		"name": modelName,
+		"uuid": utils.MustNewUUID().String(),
+	})
+	otherOwner := names.NewLocalUserTag("test-admin")
+	_, otherState, err := s.State.NewModel(cfg, otherOwner)
+
+	c.Assert(err, jc.ErrorIsNil)
+	s.AddCleanup(func(*gc.C) { otherState.Close() })
+	return otherState
 }

--- a/state/spaces.go
+++ b/state/spaces.go
@@ -178,7 +178,7 @@ func (st *State) AllSpaces() ([]*Space, error) {
 	return spaces, nil
 }
 
-// EnsureDead sets the Life of the space to Dead, if it's Alive. If spaces is
+// EnsureDead sets the Life of the space to Dead, if it's Alive. If the space is
 // already Dead, no error is returned. When the space is no longer Alive or
 // already removed, errNotAlive is returned.
 func (s *Space) EnsureDead() (err error) {

--- a/state/spaces.go
+++ b/state/spaces.go
@@ -5,11 +5,12 @@ package state
 
 import (
 	"github.com/juju/errors"
-	"github.com/juju/juju/network"
 	"github.com/juju/names"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
+
+	"github.com/juju/juju/network"
 )
 
 // Space represents the state of a juju network space.

--- a/state/spaces_test.go
+++ b/state/spaces_test.go
@@ -290,10 +290,9 @@ func (s *SpacesSuite) addTwoSpacesReturnSecond(c *gc.C, args1, args2 addSpaceArg
 	s.assertSpaceMatchesArgs(c, space1, args1)
 
 	return s.addSpaceWithSubnets(c, args2)
-
 }
 
-func (s *SpacesSuite) TestAddTwoSpaceWithDifferentNamesButSameProviderIdFailsInSameModel(c *gc.C) {
+func (s *SpacesSuite) TestAddTwoSpacesWithDifferentNamesButSameProviderIdFailsInSameModel(c *gc.C) {
 	args1 := addSpaceArgs{
 		Name:       "my-space",
 		ProviderId: network.Id("provider id"),
@@ -337,7 +336,6 @@ func (s *SpacesSuite) newStateForModelNamed(c *gc.C, modelName string) *state.St
 	c.Assert(err, jc.ErrorIsNil)
 	s.AddCleanup(func(*gc.C) { otherState.Close() })
 	return otherState
-
 }
 
 func (s *SpacesSuite) TestAddTwoSpacesWithDifferentNamesAndEmptyProviderIdSucceedsInSameModel(c *gc.C) {
@@ -351,7 +349,6 @@ func (s *SpacesSuite) TestAddTwoSpacesWithDifferentNamesAndEmptyProviderIdSuccee
 	space2, err := s.addTwoSpacesReturnSecond(c, args1, args2)
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertSpaceMatchesArgs(c, space2, args2)
-
 }
 
 func (s *SpacesSuite) TestAddTwoSpacesWithDifferentNamesAndEmptyProviderIdSucceedsInDifferentModels(c *gc.C) {
@@ -370,7 +367,7 @@ func (s *SpacesSuite) TestAddTwoSpacesWithDifferentNamesAndEmptyProviderIdSuccee
 	s.assertSpaceMatchesArgs(c, space2, args2)
 }
 
-func (s *SpacesSuite) TestAddTwoSpaceWithSameNamesAndEmptyProviderIdsFailsInSameModel(c *gc.C) {
+func (s *SpacesSuite) TestAddTwoSpacesWithSameNamesAndEmptyProviderIdsFailsInSameModel(c *gc.C) {
 	args := addSpaceArgs{
 		Name:       "my-space",
 		ProviderId: "",

--- a/state/spaces_test.go
+++ b/state/spaces_test.go
@@ -547,8 +547,6 @@ func (s *SpacesSuite) TestEnsureDeadSetsLifeToDeadWhenNotAlive(c *gc.C) {
 	s.ensureDeadAndAssertLifeIsDead(c, space)
 
 	s.ensureDeadAndAssertLifeIsDead(c, space)
-	// TODO(dimitern): With txn hooks, test the case when it gets dead between
-	// the doc.Life == Dead and runTransaction.
 }
 
 func (s *SpacesSuite) TestRemoveFailsIfStillAlive(c *gc.C) {

--- a/state/spaces_test.go
+++ b/state/spaces_test.go
@@ -9,10 +9,14 @@ import (
 	"strings"
 
 	"github.com/juju/errors"
+	"github.com/juju/names"
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils"
+	gc "gopkg.in/check.v1"
+
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
-	jc "github.com/juju/testing/checkers"
-	gc "gopkg.in/check.v1"
+	"github.com/juju/juju/testing"
 )
 
 type SpacesSuite struct {
@@ -22,6 +26,21 @@ type SpacesSuite struct {
 var _ = gc.Suite(&SpacesSuite{})
 
 func (s *SpacesSuite) addSubnets(c *gc.C, CIDRs []string) {
+	s.addSubnetsForState(c, CIDRs, s.State)
+}
+
+func (s *SpacesSuite) addSubnetsForState(c *gc.C, CIDRs []string, st *state.State) {
+	if len(CIDRs) == 0 {
+		return
+	}
+	for _, info := range s.makeSubnetInfosForCIDRs(c, CIDRs) {
+		_, err := st.AddSubnet(info)
+		c.Assert(err, jc.ErrorIsNil)
+	}
+}
+
+func (s *SpacesSuite) makeSubnetInfosForCIDRs(c *gc.C, CIDRs []string) []state.SubnetInfo {
+	infos := make([]state.SubnetInfo, len(CIDRs))
 	for i, cidr := range CIDRs {
 		ip, ipNet, err := net.ParseCIDR(cidr)
 		c.Assert(err, jc.ErrorIsNil)
@@ -39,172 +58,434 @@ func (s *SpacesSuite) addSubnets(c *gc.C, CIDRs []string) {
 
 		// To generate a high IP address we bitwise not each byte of the subnet
 		// mask and OR it to the low IP address.
-		for i, b := range ipNet.Mask {
-			if i < len(ip) {
-				highIp[i] |= ^b
+		for j, b := range ipNet.Mask {
+			if j < len(ip) {
+				highIp[j] |= ^b
 			}
 		}
 
-		providerId := network.Id(fmt.Sprintf("ProviderId%d", i))
-		subnetInfo := state.SubnetInfo{
-			ProviderId:        providerId,
+		infos[i] = state.SubnetInfo{
 			CIDR:              cidr,
 			VLANTag:           79,
 			AllocatableIPLow:  ip.String(),
 			AllocatableIPHigh: highIp.String(),
 			AvailabilityZone:  "AvailabilityZone",
 		}
-		_, err = s.State.AddSubnet(subnetInfo)
-		c.Assert(err, jc.ErrorIsNil)
+
 	}
+	return infos
 }
 
-func (s *SpacesSuite) assertNoSpace(c *gc.C, name string) {
-	_, err := s.State.Space(name)
-	c.Assert(err, gc.ErrorMatches, "space \""+name+"\" not found")
+type addSpaceArgs struct {
+	Name        string
+	ProviderId  network.Id
+	SubnetCIDRs []string
+	IsPublic    bool
+	ForState    *state.State
+}
+
+func (s *SpacesSuite) addSpaceWithSubnets(c *gc.C, args addSpaceArgs) (*state.Space, error) {
+	if args.ForState == nil {
+		args.ForState = s.State
+	}
+	s.addSubnetsForState(c, args.SubnetCIDRs, args.ForState)
+	return args.ForState.AddSpace(args.Name, args.ProviderId, args.SubnetCIDRs, args.IsPublic)
+}
+
+func (s *SpacesSuite) assertSpaceNotFound(c *gc.C, name string) {
+	s.assertSpaceNotFoundForState(c, name, s.State)
+}
+
+func (s *SpacesSuite) assertSpaceNotFoundForState(c *gc.C, name string, st *state.State) {
+	_, err := st.Space(name)
+	s.assertSpaceNotFoundError(c, err, name)
+}
+
+func (s *SpacesSuite) assertSpaceNotFoundError(c *gc.C, err error, name string) {
+	c.Assert(err, gc.ErrorMatches, fmt.Sprintf("space %q not found", name))
+
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
 
-func assertSpace(c *gc.C, space *state.Space, name string, providerId network.Id, subnets []string, isPublic bool) {
-	c.Assert(space.Name(), gc.Equals, name)
-	c.Assert(space.ProviderId(), gc.Equals, providerId)
+func (s *SpacesSuite) assertSpaceMatchesArgs(c *gc.C, space *state.Space, args addSpaceArgs) {
+	c.Assert(space.Name(), gc.Equals, args.Name)
+	c.Assert(space.ProviderId(), gc.Equals, args.ProviderId)
+
 	actualSubnets, err := space.Subnets()
 	c.Assert(err, jc.ErrorIsNil)
 	actualSubnetIds := make([]string, len(actualSubnets))
 	for i, subnet := range actualSubnets {
 		actualSubnetIds[i] = subnet.CIDR()
 	}
-	c.Assert(actualSubnetIds, jc.SameContents, subnets)
-	c.Assert(state.SpaceDoc(space).IsPublic, gc.Equals, isPublic)
+	c.Assert(actualSubnetIds, jc.SameContents, args.SubnetCIDRs)
+	c.Assert(state.SpaceDoc(space).IsPublic, gc.Equals, args.IsPublic)
 
 	c.Assert(space.Life(), gc.Equals, state.Alive)
-	c.Assert(strings.HasSuffix(space.ID(), name), jc.IsTrue)
-	c.Assert(space.String(), gc.Equals, name)
+	c.Assert(strings.HasSuffix(space.ID(), args.Name), jc.IsTrue)
+	c.Assert(space.String(), gc.Equals, args.Name)
 }
 
-func (s *SpacesSuite) TestAddSpace(c *gc.C) {
-	name := "my-space"
-	providerId := network.Id("My Space")
-	subnets := []string{"1.1.1.0/24"}
-	isPublic := false
-	s.addSubnets(c, subnets)
-
-	space, err := s.State.AddSpace(name, providerId, subnets, isPublic)
+func (s *SpacesSuite) TestAddSpaceWithNoSubnetsAndEmptyProviderId(c *gc.C) {
+	args := addSpaceArgs{
+		Name:        "my-space",
+		ProviderId:  "",
+		SubnetCIDRs: nil,
+	}
+	space, err := s.addSpaceWithSubnets(c, args)
 	c.Assert(err, jc.ErrorIsNil)
-	assertSpace(c, space, name, providerId, subnets, isPublic)
+	s.assertSpaceMatchesArgs(c, space, args)
 
-	// We should get the same space back from the database
-	id := space.ID()
-	space, err = s.State.Space(name)
-	c.Assert(err, jc.ErrorIsNil)
-	assertSpace(c, space, name, providerId, subnets, isPublic)
-	c.Assert(id, gc.Equals, space.ID())
 }
 
-func (s *SpacesSuite) TestAddSpaceUnique(c *gc.C) {
-	name := "my-space"
-	providerId := network.Id("My Space")
-	subnets := []string{"1.1.1.0/24"}
-	isPublic := false
-	s.addSubnets(c, subnets)
-
-	space, err := s.State.AddSpace(name, providerId, subnets, isPublic)
+func (s *SpacesSuite) TestAddSpaceWithNoSubnetsAndNonEmptyProviderId(c *gc.C) {
+	args := addSpaceArgs{
+		Name:        "my-space",
+		ProviderId:  network.Id("my provider id"),
+		SubnetCIDRs: nil,
+	}
+	space, err := s.addSpaceWithSubnets(c, args)
 	c.Assert(err, jc.ErrorIsNil)
-	assertSpace(c, space, name, providerId, subnets, isPublic)
-
-	_, err = s.State.AddSpace("different", providerId, subnets, isPublic)
-	c.Assert(err, gc.ErrorMatches, `adding space "different": ProviderId "My Space" not unique`)
+	s.assertSpaceMatchesArgs(c, space, args)
 }
 
-func (s *SpacesSuite) TestAddSpaceManySubnets(c *gc.C) {
-	name := "my-space"
-	subnets := []string{"1.1.1.0/24", "2.1.1.0/24", "3.1.1.0/24", "4.1.1.0/24", "5.1.1.0/24"}
-	isPublic := false
-	s.addSubnets(c, subnets)
-
-	space, err := s.State.AddSpace(name, "", subnets, isPublic)
+func (s *SpacesSuite) TestAddSpaceWithOneIPv4SubnetAndEmptyProviderId(c *gc.C) {
+	args := addSpaceArgs{
+		Name:        "my-space",
+		ProviderId:  "",
+		SubnetCIDRs: []string{"1.1.1.0/24"},
+	}
+	space, err := s.addSpaceWithSubnets(c, args)
 	c.Assert(err, jc.ErrorIsNil)
-	assertSpace(c, space, name, "", subnets, isPublic)
-
-	// We should get the same space back from the database
-	id := space.ID()
-	space, err = s.State.Space(name)
-	c.Assert(err, jc.ErrorIsNil)
-	assertSpace(c, space, name, "", subnets, isPublic)
-	c.Assert(id, gc.Equals, space.ID())
+	s.assertSpaceMatchesArgs(c, space, args)
 }
 
-func (s *SpacesSuite) TestAddSpaceSubnetsDoNotExist(c *gc.C) {
+func (s *SpacesSuite) TestAddSpaceWithOneIPv4SubnetAndNonEmptyProviderId(c *gc.C) {
+	args := addSpaceArgs{
+		Name:        "my-space",
+		ProviderId:  network.Id("some id"),
+		SubnetCIDRs: []string{"1.1.1.0/24"},
+	}
+	space, err := s.addSpaceWithSubnets(c, args)
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertSpaceMatchesArgs(c, space, args)
+}
+
+func (s *SpacesSuite) TestAddSpaceWithOneIPv6SubnetAndEmptyProviderId(c *gc.C) {
+	args := addSpaceArgs{
+		Name:        "my-space",
+		ProviderId:  "",
+		SubnetCIDRs: []string{"fc00:123::/64"},
+	}
+	space, err := s.addSpaceWithSubnets(c, args)
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertSpaceMatchesArgs(c, space, args)
+}
+
+func (s *SpacesSuite) TestAddSpaceWithOneIPv6SubnetAndNonEmptyProviderId(c *gc.C) {
+	args := addSpaceArgs{
+		Name:        "my-space",
+		ProviderId:  network.Id("provider id"),
+		SubnetCIDRs: []string{"fc00:123::/64"},
+	}
+	space, err := s.addSpaceWithSubnets(c, args)
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertSpaceMatchesArgs(c, space, args)
+}
+
+func (s *SpacesSuite) TestAddSpaceWithOneIPv4AndOneIPv6SubnetAndEmptyProviderId(c *gc.C) {
+	args := addSpaceArgs{
+		Name:        "my-space",
+		ProviderId:  "",
+		SubnetCIDRs: []string{"1.1.1.0/24", "fc00::123/64"},
+	}
+	space, err := s.addSpaceWithSubnets(c, args)
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertSpaceMatchesArgs(c, space, args)
+}
+
+func (s *SpacesSuite) TestAddSpaceWithOneIPv4AndOneIPv6SubnetAndNonEmptyProviderId(c *gc.C) {
+	args := addSpaceArgs{
+		Name:        "my-space",
+		ProviderId:  network.Id("foo bar"),
+		SubnetCIDRs: []string{"1.1.1.0/24", "fc00::123/64"},
+	}
+	space, err := s.addSpaceWithSubnets(c, args)
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertSpaceMatchesArgs(c, space, args)
+}
+
+func (s *SpacesSuite) TestAddSpaceWithMultipleIPv4SubnetsAndEmptyProviderId(c *gc.C) {
+	args := addSpaceArgs{
+		Name:        "my-space",
+		ProviderId:  "",
+		SubnetCIDRs: []string{"1.1.1.0/24", "1.2.2.0/24"},
+	}
+	space, err := s.addSpaceWithSubnets(c, args)
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertSpaceMatchesArgs(c, space, args)
+}
+
+func (s *SpacesSuite) TestAddSpaceWithMultipleIPv4SubnetsAndNonEmptyProviderId(c *gc.C) {
+	args := addSpaceArgs{
+		Name:        "my-space",
+		ProviderId:  network.Id("My Provider ID"),
+		SubnetCIDRs: []string{"1.1.1.0/24", "1.2.2.0/24"},
+	}
+	space, err := s.addSpaceWithSubnets(c, args)
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertSpaceMatchesArgs(c, space, args)
+}
+
+func (s *SpacesSuite) TestAddSpaceWithMultipleIPv6SubnetsAndEmptyProviderId(c *gc.C) {
+	args := addSpaceArgs{
+		Name:        "my-space",
+		ProviderId:  "",
+		SubnetCIDRs: []string{"fc00:123::/64", "fc00:321::/64"},
+	}
+	space, err := s.addSpaceWithSubnets(c, args)
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertSpaceMatchesArgs(c, space, args)
+}
+
+func (s *SpacesSuite) TestAddSpaceWithMultipleIPv6SubnetsAndNonEmptyProviderId(c *gc.C) {
+	args := addSpaceArgs{
+		Name:        "my-space",
+		ProviderId:  network.Id("My Provider ID"),
+		SubnetCIDRs: []string{"fc00:123::/64", "fc00:321::/64"},
+	}
+	space, err := s.addSpaceWithSubnets(c, args)
+
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertSpaceMatchesArgs(c, space, args)
+}
+
+func (s *SpacesSuite) TestAddSpaceWithMultipleIPv4AndIPv6SubnetsAndEmptyProviderId(c *gc.C) {
+	args := addSpaceArgs{
+		Name:        "my-space",
+		ProviderId:  "",
+		SubnetCIDRs: []string{"fc00:123::/64", "2.2.2.0/20", "fc00:321::/64", "1.1.1.0/24"},
+	}
+	space, err := s.addSpaceWithSubnets(c, args)
+
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertSpaceMatchesArgs(c, space, args)
+
+}
+
+func (s *SpacesSuite) TestAddSpaceWithMultipleIPv4AndIPv6SubnetsAndNonEmptyProviderId(c *gc.C) {
+	args := addSpaceArgs{
+		Name:        "my-space",
+		ProviderId:  network.Id("My Provider ID"),
+		SubnetCIDRs: []string{"fc00:123::/64", "2.2.2.0/20", "fc00:321::/64", "1.1.1.0/24"},
+	}
+	space, err := s.addSpaceWithSubnets(c, args)
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertSpaceMatchesArgs(c, space, args)
+}
+
+func (s *SpacesSuite) addTwoSpacesReturnSecond(c *gc.C, args1, args2 addSpaceArgs) (*state.Space, error) {
+	space1, err := s.addSpaceWithSubnets(c, args1)
+
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertSpaceMatchesArgs(c, space1, args1)
+
+	return s.addSpaceWithSubnets(c, args2)
+
+}
+
+func (s *SpacesSuite) TestAddTwoSpaceWithDifferentNamesButSameProviderIdFailsInSameModel(c *gc.C) {
+	args1 := addSpaceArgs{
+		Name:       "my-space",
+		ProviderId: network.Id("provider id"),
+	}
+	args2 := args1
+	args2.Name = "different"
+
+	_, err := s.addTwoSpacesReturnSecond(c, args1, args2)
+	s.assertProviderIdNotUniqueErrorForArgs(c, err, args2)
+}
+
+func (s *SpacesSuite) assertProviderIdNotUniqueErrorForArgs(c *gc.C, err error, args addSpaceArgs) {
+	expectedError := fmt.Sprintf("adding space %q: ProviderId %q not unique", args.Name, args.ProviderId)
+	c.Assert(err, gc.ErrorMatches, expectedError)
+}
+
+func (s *SpacesSuite) TestAddTwoSpacesWithDifferentNamesButSameProviderIdSucceedsInDifferentModels(c *gc.C) {
+	args1 := addSpaceArgs{
+		Name:       "my-space",
+		ProviderId: network.Id("provider id"),
+		ForState:   s.State,
+	}
+	args2 := args1
+	args2.Name = "different"
+	args2.ForState = s.newStateForModelNamed(c, "other")
+
+	space2, err := s.addTwoSpacesReturnSecond(c, args1, args2)
+
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertSpaceMatchesArgs(c, space2, args2)
+}
+
+func (s *SpacesSuite) newStateForModelNamed(c *gc.C, modelName string) *state.State {
+	cfg := testing.CustomModelConfig(c, testing.Attrs{
+		"name": modelName,
+		"uuid": utils.MustNewUUID().String(),
+	})
+	otherOwner := names.NewLocalUserTag("test-admin")
+	_, otherState, err := s.State.NewModel(cfg, otherOwner)
+
+	c.Assert(err, jc.ErrorIsNil)
+	s.AddCleanup(func(*gc.C) { otherState.Close() })
+	return otherState
+
+}
+
+func (s *SpacesSuite) TestAddTwoSpacesWithDifferentNamesAndEmptyProviderIdSucceedsInSameModel(c *gc.C) {
+	args1 := addSpaceArgs{
+		Name:       "my-space",
+		ProviderId: "",
+	}
+	args2 := args1
+	args2.Name = "different"
+
+	space2, err := s.addTwoSpacesReturnSecond(c, args1, args2)
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertSpaceMatchesArgs(c, space2, args2)
+
+}
+
+func (s *SpacesSuite) TestAddTwoSpacesWithDifferentNamesAndEmptyProviderIdSucceedsInDifferentModels(c *gc.C) {
+	args1 := addSpaceArgs{
+		Name:       "my-space",
+		ProviderId: "",
+		ForState:   s.State,
+	}
+	args2 := args1
+	args2.Name = "different"
+	args2.ForState = s.newStateForModelNamed(c, "other")
+
+	space2, err := s.addTwoSpacesReturnSecond(c, args1, args2)
+
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertSpaceMatchesArgs(c, space2, args2)
+}
+
+func (s *SpacesSuite) TestAddTwoSpaceWithSameNamesAndEmptyProviderIdsFailsInSameModel(c *gc.C) {
+	args := addSpaceArgs{
+		Name:       "my-space",
+		ProviderId: "",
+	}
+
+	_, err := s.addTwoSpacesReturnSecond(c, args, args)
+	s.assertSpaceAlreadyExistsErrorForArgs(c, err, args)
+}
+
+func (s *SpacesSuite) assertSpaceAlreadyExistsErrorForArgs(c *gc.C, err error, args addSpaceArgs) {
+	expectedError := fmt.Sprintf("adding space %q: space %q already exists", args.Name, args.Name)
+	c.Assert(err, gc.ErrorMatches, expectedError)
+	c.Assert(err, jc.Satisfies, errors.IsAlreadyExists)
+}
+
+func (s *SpacesSuite) TestAddTwoSpacesWithSameNamesAndProviderIdsFailsInTheSameModel(c *gc.C) {
+	args := addSpaceArgs{
+		Name:       "my-space",
+		ProviderId: network.Id("does not matter if not empty"),
+	}
+
+	_, err := s.addTwoSpacesReturnSecond(c, args, args)
+	s.assertSpaceAlreadyExistsErrorForArgs(c, err, args)
+}
+
+func (s *SpacesSuite) TestAddTwoSpacesWithSameNamesAndEmptyProviderIdsSuccedsInDifferentModels(c *gc.C) {
+	args1 := addSpaceArgs{
+		Name:       "my-space",
+		ProviderId: "",
+		ForState:   s.State,
+	}
+	args2 := args1
+	args2.ForState = s.newStateForModelNamed(c, "other")
+
+	space2, err := s.addTwoSpacesReturnSecond(c, args1, args2)
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertSpaceMatchesArgs(c, space2, args2)
+}
+
+func (s *SpacesSuite) TestAddTwoSpacesWithSameNamesAndProviderIdsSuccedsInDifferentModels(c *gc.C) {
+	args1 := addSpaceArgs{
+		Name:       "my-space",
+		ProviderId: network.Id("same provider id"),
+		ForState:   s.State,
+	}
+	args2 := args1
+	args2.ForState = s.newStateForModelNamed(c, "other")
+
+	space2, err := s.addTwoSpacesReturnSecond(c, args1, args2)
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertSpaceMatchesArgs(c, space2, args2)
+}
+
+func (s *SpacesSuite) TestAddSpaceWhenSubnetNotFound(c *gc.C) {
 	name := "my-space"
 	subnets := []string{"1.1.1.0/24"}
 	isPublic := false
 
 	_, err := s.State.AddSpace(name, "", subnets, isPublic)
-	c.Assert(err, gc.ErrorMatches, "adding space \"my-space\": subnet \"1.1.1.0/24\" not found")
-	s.assertNoSpace(c, name)
+	c.Assert(err, gc.ErrorMatches, `adding space "my-space": subnet "1.1.1.0/24" not found`)
+	s.assertSpaceNotFound(c, name)
 }
 
-func (s *SpacesSuite) TestAddSpaceDuplicateSpace(c *gc.C) {
-	name := "my-space"
-	subnets := []string{"1.1.1.0/24"}
-	isPublic := false
-	s.addSubnets(c, subnets)
-
-	space, err := s.State.AddSpace(name, "", subnets, isPublic)
-	c.Assert(err, jc.ErrorIsNil)
-	assertSpace(c, space, name, "", subnets, isPublic)
-
-	// We should get the same space back from the database
-	id := space.ID()
-	space, err = s.State.Space(name)
-	c.Assert(err, jc.ErrorIsNil)
-	assertSpace(c, space, name, "", subnets, isPublic)
-	c.Assert(id, gc.Equals, space.ID())
-
-	// Trying to add the same space again should fail
-	space, err = s.State.AddSpace(name, "", subnets, isPublic)
-	c.Assert(err, gc.ErrorMatches, "adding space \"my-space\": space \"my-space\" already exists")
-
-	// The space should still be there
-	space, err = s.State.Space(name)
-	c.Assert(err, jc.ErrorIsNil)
-	assertSpace(c, space, name, "", subnets, isPublic)
-	c.Assert(id, gc.Equals, space.ID())
+func (s *SpacesSuite) TestAddSpaceWithNonEmptyProviderIdAndInvalidNameFails(c *gc.C) {
+	args := addSpaceArgs{
+		Name:       "-bad name-",
+		ProviderId: network.Id("My Provider ID"),
+	}
+	_, err := s.addSpaceWithSubnets(c, args)
+	s.assertInvalidSpaceNameErrorAndWasNotAdded(c, err, args.Name)
 }
 
-func (s *SpacesSuite) TestAddSpaceInvalidName(c *gc.C) {
-	name := "-"
-	subnets := []string{"1.1.1.0/24"}
-	isPublic := false
-	s.addSubnets(c, subnets)
-
-	_, err := s.State.AddSpace(name, "", subnets, isPublic)
-	c.Assert(err, gc.ErrorMatches, "adding space \"-\": invalid space name")
-	s.assertNoSpace(c, name)
+func (s *SpacesSuite) assertInvalidSpaceNameErrorAndWasNotAdded(c *gc.C, err error, name string) {
+	expectedError := fmt.Sprintf("adding space %q: invalid space name", name)
+	c.Assert(err, gc.ErrorMatches, expectedError)
+	s.assertSpaceNotFound(c, name)
 }
 
-func (s *SpacesSuite) TestAddSpaceEmptyName(c *gc.C) {
-	name := ""
-	subnets := []string{"1.1.1.0/24"}
-	isPublic := false
-	s.addSubnets(c, subnets)
-
-	_, err := s.State.AddSpace(name, "", subnets, isPublic)
-	c.Assert(err, gc.ErrorMatches, "adding space \"\": invalid space name")
-	s.assertNoSpace(c, name)
+func (s *SpacesSuite) TestAddSpaceWithEmptyProviderIdAndInvalidNameFails(c *gc.C) {
+	args := addSpaceArgs{
+		Name:       "-bad name-",
+		ProviderId: "",
+	}
+	_, err := s.addSpaceWithSubnets(c, args)
+	s.assertInvalidSpaceNameErrorAndWasNotAdded(c, err, args.Name)
 }
 
-func (s *SpacesSuite) TestSpaceSubnets(c *gc.C) {
-	name := "my-space"
-	subnets := []string{"1.1.1.0/24", "2.1.1.0/24", "3.1.1.0/24", "4.1.1.0/24", "5.1.1.0/24"}
-	isPublic := false
-	s.addSubnets(c, subnets)
+func (s *SpacesSuite) TestAddSpaceWithEmptyNameAndProviderIdFails(c *gc.C) {
+	args := addSpaceArgs{
+		Name:       "",
+		ProviderId: "",
+	}
+	_, err := s.addSpaceWithSubnets(c, args)
+	s.assertInvalidSpaceNameErrorAndWasNotAdded(c, err, args.Name)
+}
 
-	space, err := s.State.AddSpace(name, "", subnets, isPublic)
+func (s *SpacesSuite) TestAddSpaceWithEmptyNameAndNonEmptyProviderIdFails(c *gc.C) {
+	args := addSpaceArgs{
+		Name:       "",
+		ProviderId: network.Id("doesn't matter"),
+	}
+	_, err := s.addSpaceWithSubnets(c, args)
+	s.assertInvalidSpaceNameErrorAndWasNotAdded(c, err, args.Name)
+}
+
+func (s *SpacesSuite) TestSubnetsReturnsExpectedSubnets(c *gc.C) {
+	args := addSpaceArgs{
+		Name:        "my-space",
+		SubnetCIDRs: []string{"1.1.1.0/24", "2.1.1.0/24", "3.1.1.0/24", "4.1.1.0/24", "5.1.1.0/24"},
+	}
+	space, err := s.addSpaceWithSubnets(c, args)
 	c.Assert(err, jc.ErrorIsNil)
 
 	expected := []*state.Subnet{}
-	for _, cidr := range subnets {
+	for _, cidr := range args.SubnetCIDRs {
 		subnet, err := s.State.Subnet(cidr)
 		c.Assert(err, jc.ErrorIsNil)
 		expected = append(expected, subnet)
@@ -233,4 +514,92 @@ func (s *SpacesSuite) TestAllSpaces(c *gc.C) {
 	actual, err := s.State.AllSpaces()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(actual, jc.SameContents, []*state.Space{first, second, third})
+}
+
+func (s *SpacesSuite) TestEnsureDeadSetsLifeToDeadWhenAlive(c *gc.C) {
+	space := s.addAliveSpace(c, "alive")
+
+	s.ensureDeadAndAssertLifeIsDead(c, space)
+	s.refreshAndAssertSpaceLifeIs(c, space, state.Dead)
+}
+
+func (s *SpacesSuite) addAliveSpace(c *gc.C, name string) *state.Space {
+	space, err := s.State.AddSpace(name, "", nil, false)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(space.Life(), gc.Equals, state.Alive)
+	return space
+}
+
+func (s *SpacesSuite) ensureDeadAndAssertLifeIsDead(c *gc.C, space *state.Space) {
+	err := space.EnsureDead()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(space.Life(), gc.Equals, state.Dead)
+}
+
+func (s *SpacesSuite) refreshAndAssertSpaceLifeIs(c *gc.C, space *state.Space, expectedLife state.Life) {
+	err := space.Refresh()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(space.Life(), gc.Equals, expectedLife)
+}
+
+func (s *SpacesSuite) TestEnsureDeadSetsLifeToDeadWhenNotAlive(c *gc.C) {
+	space := s.addAliveSpace(c, "soon-dead")
+	s.ensureDeadAndAssertLifeIsDead(c, space)
+
+	s.ensureDeadAndAssertLifeIsDead(c, space)
+	// TODO(dimitern): With txn hooks, test the case when it gets dead between
+	// the doc.Life == Dead and runTransaction.
+}
+
+func (s *SpacesSuite) TestRemoveFailsIfStillAlive(c *gc.C) {
+	space := s.addAliveSpace(c, "still-alive")
+
+	err := space.Remove()
+	c.Assert(err, gc.ErrorMatches, `cannot remove space "still-alive": space is not dead`)
+
+	s.refreshAndAssertSpaceLifeIs(c, space, state.Alive)
+}
+
+func (s *SpacesSuite) TestRemoveSucceedsWhenSpaceIsNotAlive(c *gc.C) {
+	space := s.addAliveSpace(c, "not-alive-soon")
+	s.ensureDeadAndAssertLifeIsDead(c, space)
+
+	s.removeSpaceAndAssertNotFound(c, space)
+}
+
+func (s *SpacesSuite) removeSpaceAndAssertNotFound(c *gc.C, space *state.Space) {
+	err := space.Remove()
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertSpaceNotFound(c, space.Name())
+}
+
+func (s *SpacesSuite) TestRemoveSucceedsWhenCalledTwice(c *gc.C) {
+	space := s.addAliveSpace(c, "twice-deleted")
+	s.ensureDeadAndAssertLifeIsDead(c, space)
+	s.removeSpaceAndAssertNotFound(c, space)
+
+	err := space.Remove()
+	c.Assert(err, gc.ErrorMatches, `cannot remove space "twice-deleted": not found or not dead`)
+}
+
+func (s *SpacesSuite) TestRefreshUpdatesStaleDocData(c *gc.C) {
+	space := s.addAliveSpace(c, "original")
+	spaceCopy, err := s.State.Space(space.Name())
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.ensureDeadAndAssertLifeIsDead(c, space)
+	c.Assert(spaceCopy.Life(), gc.Equals, state.Alive)
+
+	err = spaceCopy.Refresh()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(spaceCopy.Life(), gc.Equals, state.Dead)
+}
+
+func (s *SpacesSuite) TestRefreshFailsWithNotFoundWhenRemoved(c *gc.C) {
+	space := s.addAliveSpace(c, "soon-removed")
+	s.ensureDeadAndAssertLifeIsDead(c, space)
+	s.removeSpaceAndAssertNotFound(c, space)
+
+	err := space.Refresh()
+	s.assertSpaceNotFoundError(c, err, "soon-removed")
 }

--- a/state/spaces_test.go
+++ b/state/spaces_test.go
@@ -9,14 +9,11 @@ import (
 	"strings"
 
 	"github.com/juju/errors"
-	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
-	"github.com/juju/juju/testing"
 )
 
 type SpacesSuite struct {
@@ -317,25 +314,12 @@ func (s *SpacesSuite) TestAddTwoSpacesWithDifferentNamesButSameProviderIdSucceed
 	}
 	args2 := args1
 	args2.Name = "different"
-	args2.ForState = s.newStateForModelNamed(c, "other")
+	args2.ForState = s.NewStateForModelNamed(c, "other")
 
 	space2, err := s.addTwoSpacesReturnSecond(c, args1, args2)
 
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertSpaceMatchesArgs(c, space2, args2)
-}
-
-func (s *SpacesSuite) newStateForModelNamed(c *gc.C, modelName string) *state.State {
-	cfg := testing.CustomModelConfig(c, testing.Attrs{
-		"name": modelName,
-		"uuid": utils.MustNewUUID().String(),
-	})
-	otherOwner := names.NewLocalUserTag("test-admin")
-	_, otherState, err := s.State.NewModel(cfg, otherOwner)
-
-	c.Assert(err, jc.ErrorIsNil)
-	s.AddCleanup(func(*gc.C) { otherState.Close() })
-	return otherState
 }
 
 func (s *SpacesSuite) TestAddTwoSpacesWithDifferentNamesAndEmptyProviderIdSucceedsInSameModel(c *gc.C) {
@@ -359,7 +343,7 @@ func (s *SpacesSuite) TestAddTwoSpacesWithDifferentNamesAndEmptyProviderIdSuccee
 	}
 	args2 := args1
 	args2.Name = "different"
-	args2.ForState = s.newStateForModelNamed(c, "other")
+	args2.ForState = s.NewStateForModelNamed(c, "other")
 
 	space2, err := s.addTwoSpacesReturnSecond(c, args1, args2)
 
@@ -400,7 +384,7 @@ func (s *SpacesSuite) TestAddTwoSpacesWithSameNamesAndEmptyProviderIdsSuccedsInD
 		ForState:   s.State,
 	}
 	args2 := args1
-	args2.ForState = s.newStateForModelNamed(c, "other")
+	args2.ForState = s.NewStateForModelNamed(c, "other")
 
 	space2, err := s.addTwoSpacesReturnSecond(c, args1, args2)
 	c.Assert(err, jc.ErrorIsNil)
@@ -414,7 +398,7 @@ func (s *SpacesSuite) TestAddTwoSpacesWithSameNamesAndProviderIdsSuccedsInDiffer
 		ForState:   s.State,
 	}
 	args2 := args1
-	args2.ForState = s.newStateForModelNamed(c, "other")
+	args2.ForState = s.NewStateForModelNamed(c, "other")
 
 	space2, err := s.addTwoSpacesReturnSecond(c, args1, args2)
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/subnets.go
+++ b/state/subnets.go
@@ -40,7 +40,7 @@ type SubnetInfo struct {
 	AvailabilityZone string
 
 	// SpaceName is the name of the space the subnet is associated with. It
-	// can be empty if the subnet is in the default space.
+	// can be empty if the subnet is not associated with a space yet.
 	SpaceName string
 }
 
@@ -84,8 +84,9 @@ func (s *Subnet) GoString() string {
 	return s.String()
 }
 
-// EnsureDead sets the Life of the subnet to Dead, if it's Alive. It
-// does nothing otherwise.
+// EnsureDead sets the Life of the subnet to Dead, if it's Alive. If the subnet
+// is already Dead, no error is returned. When the subnet is no longer Alive or
+// already removed, errNotAlive is returned.
 func (s *Subnet) EnsureDead() (err error) {
 	defer errors.DeferredAnnotatef(&err, "cannot set subnet %q to dead", s)
 
@@ -99,26 +100,29 @@ func (s *Subnet) EnsureDead() (err error) {
 		Update: bson.D{{"$set", bson.D{{"life", Dead}}}},
 		Assert: isAliveDoc,
 	}}
-	if err = s.st.runTransaction(ops); err != nil {
-		// Ignore ErrAborted if it happens, otherwise return err.
-		return onAbort(err, nil)
+
+	txnErr := s.st.runTransaction(ops)
+	if txnErr == nil {
+		s.doc.Life = Dead
+		return nil
 	}
-	s.doc.Life = Dead
-	return nil
+	return onAbort(txnErr, errNotAlive)
 }
 
-// Remove removes a dead subnet. If the subnet is not dead it returns an error.
-// It also removes any IP addresses associated with the subnet.
+// Remove removes a Dead subnet. If the subnet is not Dead or it is already
+// removed, an error is returned. On success, all IP addresses added to the
+// subnet are also removed.
 func (s *Subnet) Remove() (err error) {
 	defer errors.DeferredAnnotatef(&err, "cannot remove subnet %q", s)
 
 	if s.doc.Life != Dead {
 		return errors.New("subnet is not dead")
 	}
+
 	addresses, closer := s.st.getCollection(ipaddressesC)
 	defer closer()
 
-	ops := []txn.Op{}
+	var ops []txn.Op
 	id := s.ID()
 	var doc struct {
 		DocID string `bson:"_id"`
@@ -139,8 +143,14 @@ func (s *Subnet) Remove() (err error) {
 		C:      subnetsC,
 		Id:     s.doc.DocID,
 		Remove: true,
+		Assert: isDeadDoc,
 	})
-	return s.st.runTransaction(ops)
+
+	txnErr := s.st.runTransaction(ops)
+	if txnErr == nil {
+		return nil
+	}
+	return onAbort(txnErr, errors.New("not found or not dead"))
 }
 
 // ProviderId returns the provider-specific id of the subnet.
@@ -176,7 +186,7 @@ func (s *Subnet) AvailabilityZone() string {
 }
 
 // SpaceName returns the space the subnet is associated with. If the subnet is
-// in the default space it will be the empty string.
+// not associated with a space it will be the empty string.
 func (s *Subnet) SpaceName() string {
 	return s.doc.SpaceName
 }

--- a/state/subnets.go
+++ b/state/subnets.go
@@ -155,7 +155,7 @@ func (s *Subnet) Remove() (err error) {
 
 // ProviderId returns the provider-specific id of the subnet.
 func (s *Subnet) ProviderId() network.Id {
-	return network.Id(s.doc.ProviderId)
+	return network.Id(s.st.localID(s.doc.ProviderId))
 }
 
 // CIDR returns the subnet CIDR (e.g. 192.168.50.0/24).

--- a/state/subnets_test.go
+++ b/state/subnets_test.go
@@ -4,6 +4,7 @@
 package state_test
 
 import (
+	"fmt"
 	"sort"
 	"sync"
 	"sync/atomic"
@@ -22,7 +23,7 @@ type SubnetSuite struct {
 
 var _ = gc.Suite(&SubnetSuite{})
 
-func (s *SubnetSuite) TestAddSubnet(c *gc.C) {
+func (s *SubnetSuite) TestAddSubnetSucceedsWithFullyPopulatedInfo(c *gc.C) {
 	subnetInfo := state.SubnetInfo{
 		ProviderId:        "foo",
 		CIDR:              "192.168.1.0/24",
@@ -33,188 +34,264 @@ func (s *SubnetSuite) TestAddSubnet(c *gc.C) {
 		SpaceName:         "foo",
 	}
 
-	assertSubnet := func(subnet *state.Subnet) {
-		c.Assert(subnet.ProviderId(), gc.Equals, network.Id("foo"))
-		c.Assert(subnet.CIDR(), gc.Equals, "192.168.1.0/24")
-		c.Assert(subnet.VLANTag(), gc.Equals, 79)
-		c.Assert(subnet.AllocatableIPLow(), gc.Equals, "192.168.1.0")
-		c.Assert(subnet.AllocatableIPHigh(), gc.Equals, "192.168.1.1")
-		c.Assert(subnet.AvailabilityZone(), gc.Equals, "Timbuktu")
-		c.Assert(subnet.String(), gc.Equals, "192.168.1.0/24")
-		c.Assert(subnet.GoString(), gc.Equals, "192.168.1.0/24")
-		c.Assert(subnet.SpaceName(), gc.Equals, "foo")
-	}
-
 	subnet, err := s.State.AddSubnet(subnetInfo)
 	c.Assert(err, jc.ErrorIsNil)
-	assertSubnet(subnet)
+	s.assertSubnetMatchesInfo(c, subnet, subnetInfo)
 
 	// check it's been stored in state by fetching it back again
 	subnetFromDB, err := s.State.Subnet("192.168.1.0/24")
 	c.Assert(err, jc.ErrorIsNil)
-	assertSubnet(subnetFromDB)
+	s.assertSubnetMatchesInfo(c, subnetFromDB, subnetInfo)
 }
 
-func (s *SubnetSuite) TestAddSubnetErrors(c *gc.C) {
+func (s *SubnetSuite) assertSubnetMatchesInfo(c *gc.C, subnet *state.Subnet, info state.SubnetInfo) {
+	c.Assert(subnet.ProviderId(), gc.Equals, info.ProviderId)
+	c.Assert(subnet.CIDR(), gc.Equals, info.CIDR)
+	c.Assert(subnet.VLANTag(), gc.Equals, info.VLANTag)
+	c.Assert(subnet.AllocatableIPLow(), gc.Equals, info.AllocatableIPLow)
+	c.Assert(subnet.AllocatableIPHigh(), gc.Equals, info.AllocatableIPHigh)
+	c.Assert(subnet.AvailabilityZone(), gc.Equals, info.AvailabilityZone)
+	c.Assert(subnet.String(), gc.Equals, info.CIDR)
+	c.Assert(subnet.GoString(), gc.Equals, info.CIDR)
+	c.Assert(subnet.SpaceName(), gc.Equals, info.SpaceName)
+}
+
+func (s *SubnetSuite) TestAddSubnetFailsWithEmptyCIDR(c *gc.C) {
 	subnetInfo := state.SubnetInfo{}
-	_, err := s.State.AddSubnet(subnetInfo)
-	c.Assert(err, gc.ErrorMatches, `adding subnet "": missing CIDR`)
-
-	subnetInfo.CIDR = "foobar"
-	_, err = s.State.AddSubnet(subnetInfo)
-	c.Assert(err, gc.ErrorMatches,
-		`adding subnet "foobar": invalid CIDR address: foobar`,
-	)
-
-	errPrefix := `adding subnet "192.168.0.1/24": `
-	subnetInfo.CIDR = "192.168.0.1/24"
-	subnetInfo.VLANTag = 4095
-	_, err = s.State.AddSubnet(subnetInfo)
-	c.Assert(err, gc.ErrorMatches,
-		errPrefix+"invalid VLAN tag 4095: must be between 0 and 4094",
-	)
-
-	eitherOrMsg := errPrefix + "either both AllocatableIPLow and AllocatableIPHigh must be set or neither set"
-	subnetInfo.VLANTag = 0
-	subnetInfo.AllocatableIPHigh = "192.168.0.1"
-	_, err = s.State.AddSubnet(subnetInfo)
-	c.Assert(err, gc.ErrorMatches, eitherOrMsg)
-
-	subnetInfo.AllocatableIPLow = "192.168.0.1"
-	subnetInfo.AllocatableIPHigh = ""
-	_, err = s.State.AddSubnet(subnetInfo)
-	c.Assert(err, gc.ErrorMatches, eitherOrMsg)
-
-	// invalid IP address
-	subnetInfo.AllocatableIPHigh = "foobar"
-	_, err = s.State.AddSubnet(subnetInfo)
-	c.Assert(err, gc.ErrorMatches, errPrefix+`invalid AllocatableIPHigh "foobar"`)
-
-	// invalid IP address
-	subnetInfo.AllocatableIPLow = "foobar"
-	subnetInfo.AllocatableIPHigh = "192.168.0.1"
-	_, err = s.State.AddSubnet(subnetInfo)
-	c.Assert(err, gc.ErrorMatches, errPrefix+`invalid AllocatableIPLow "foobar"`)
-
-	// IP address out of range
-	subnetInfo.AllocatableIPHigh = "172.168.1.0"
-	_, err = s.State.AddSubnet(subnetInfo)
-	c.Assert(err, gc.ErrorMatches, errPrefix+`invalid AllocatableIPHigh "172.168.1.0"`)
-
-	// IP address out of range
-	subnetInfo.AllocatableIPHigh = "192.168.0.1"
-	subnetInfo.AllocatableIPLow = "172.168.1.0"
-	_, err = s.State.AddSubnet(subnetInfo)
-	c.Assert(err, gc.ErrorMatches, errPrefix+`invalid AllocatableIPLow "172.168.1.0"`)
-
-	// valid case
-	subnetInfo.AllocatableIPLow = "192.168.0.1"
-	subnetInfo.ProviderId = "testing uniqueness"
-	_, err = s.State.AddSubnet(subnetInfo)
-	c.Assert(err, jc.ErrorIsNil)
-
-	_, err = s.State.AddSubnet(subnetInfo)
-	c.Assert(err, jc.Satisfies, errors.IsAlreadyExists)
-
-	// ProviderId should be unique as well as CIDR
-	subnetInfo.CIDR = "192.0.0.0/0"
-	_, err = s.State.AddSubnet(subnetInfo)
-	c.Assert(err, gc.ErrorMatches,
-		`adding subnet "192.0.0.0/0": ProviderId "testing uniqueness" not unique`,
-	)
-
-	// empty provider id should be allowed to be not unique
-	subnetInfo.ProviderId = ""
-	_, err = s.State.AddSubnet(subnetInfo)
-	c.Assert(err, jc.ErrorIsNil)
-	subnetInfo.CIDR = "192.0.0.1/1"
-	_, err = s.State.AddSubnet(subnetInfo)
-	c.Assert(err, jc.ErrorIsNil)
+	s.assertAddSubnetForInfoFailsWithSuffix(c, subnetInfo, "missing CIDR")
 }
 
-func (s *SubnetSuite) TestSubnetEnsureDeadRemove(c *gc.C) {
-	subnetInfo := state.SubnetInfo{CIDR: "192.168.1.0/24"}
+func (s *SubnetSuite) assertAddSubnetForInfoFailsWithSuffix(c *gc.C, subnetInfo state.SubnetInfo, errorSuffix string) error {
+	subnet, err := s.State.AddSubnet(subnetInfo)
+	errorMessage := fmt.Sprintf("adding subnet %q: %s", subnetInfo.CIDR, errorSuffix)
+	c.Assert(err, gc.ErrorMatches, errorMessage)
+	c.Assert(subnet, gc.IsNil)
+	return err
+}
 
+func (s *SubnetSuite) TestAddSubnetFailsWithInvalidCIDR(c *gc.C) {
+	subnetInfo := state.SubnetInfo{CIDR: "foobar"}
+	s.assertAddSubnetForInfoFailsWithSuffix(c, subnetInfo, "invalid CIDR address: foobar")
+}
+
+func (s *SubnetSuite) TestAddSubnetFailsWithOutOfRangeVLANTag(c *gc.C) {
+	subnetInfo := state.SubnetInfo{CIDR: "192.168.0.1/24", VLANTag: 4095}
+	s.assertAddSubnetForInfoFailsWithSuffix(c, subnetInfo, "invalid VLAN tag 4095: must be between 0 and 4094")
+}
+
+func (s *SubnetSuite) TestAddSubnetFailsWhenAllocatableIPHighSetButAllocatableIPLowNotSet(c *gc.C) {
+	subnetInfo := state.SubnetInfo{CIDR: "192.168.0.1/24", AllocatableIPHigh: "192.168.0.1"}
+	s.assertAddSubnetForInfoFailsWithSuffix(
+		c, subnetInfo,
+		"either both AllocatableIPLow and AllocatableIPHigh must be set or neither set",
+	)
+}
+
+func (s *SubnetSuite) TestAddSubnetFailsWhenAllocatableIPLowSetButAllocatableIPHighNotSet(c *gc.C) {
+	subnetInfo := state.SubnetInfo{CIDR: "192.168.0.1/24", AllocatableIPLow: "192.168.0.1"}
+	s.assertAddSubnetForInfoFailsWithSuffix(
+		c, subnetInfo,
+		"either both AllocatableIPLow and AllocatableIPHigh must be set or neither set",
+	)
+}
+
+func (s *SubnetSuite) TestAddSubnetFailsWithInvalidAllocatableIPHigh(c *gc.C) {
+	subnetInfo := state.SubnetInfo{
+		CIDR:              "192.168.0.1/24",
+		AllocatableIPLow:  "192.168.0.1",
+		AllocatableIPHigh: "foobar",
+	}
+	s.assertAddSubnetForInfoFailsWithSuffix(c, subnetInfo, `invalid AllocatableIPHigh "foobar"`)
+}
+
+func (s *SubnetSuite) TestAddSubnetFailsWithInvalidAllocatableIPLow(c *gc.C) {
+	subnetInfo := state.SubnetInfo{
+		CIDR:              "192.168.0.1/24",
+		AllocatableIPLow:  "foobar",
+		AllocatableIPHigh: "192.168.0.1",
+	}
+	s.assertAddSubnetForInfoFailsWithSuffix(c, subnetInfo, `invalid AllocatableIPLow "foobar"`)
+}
+
+func (s *SubnetSuite) TestAddSubnetFailsWithOutOfRangeAllocatableIPHigh(c *gc.C) {
+	subnetInfo := state.SubnetInfo{
+		CIDR:              "192.168.0.1/24",
+		AllocatableIPLow:  "192.168.0.1",
+		AllocatableIPHigh: "172.168.1.0",
+	}
+	s.assertAddSubnetForInfoFailsWithSuffix(c, subnetInfo, `invalid AllocatableIPHigh "172.168.1.0"`)
+}
+
+func (s *SubnetSuite) TestAddSubnetFailsWithOutOfRangeAllocatableIPLow(c *gc.C) {
+	subnetInfo := state.SubnetInfo{
+		CIDR:              "192.168.0.1/24",
+		AllocatableIPLow:  "172.168.1.0",
+		AllocatableIPHigh: "192.168.0.10",
+	}
+	s.assertAddSubnetForInfoFailsWithSuffix(c, subnetInfo, `invalid AllocatableIPLow "172.168.1.0"`)
+}
+
+func (s *SubnetSuite) TestAddSubnetFailsWithAlreadyExistsForDuplicateCIDR(c *gc.C) {
+	subnetInfo := state.SubnetInfo{CIDR: "192.168.0.1/24"}
+	subnet, err := s.State.AddSubnet(subnetInfo)
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertSubnetMatchesInfo(c, subnet, subnetInfo)
+
+	err = s.assertAddSubnetForInfoFailsWithSuffix(c, subnetInfo, `subnet "192.168.0.1/24" already exists`)
+	c.Assert(err, jc.Satisfies, errors.IsAlreadyExists)
+}
+
+func (s *SubnetSuite) TestAddSubnetFailsWhenProviderIdNotUnique(c *gc.C) {
+	subnetInfo1 := state.SubnetInfo{CIDR: "192.168.0.1/24", ProviderId: "foo"}
+	subnetInfo2 := state.SubnetInfo{CIDR: "10.0.0.0/24", ProviderId: "foo"}
+
+	s.addTwoSubnetsAndAssertSecondFailsWithSuffix(c, subnetInfo1, subnetInfo2, `ProviderId "foo" not unique`)
+}
+
+func (s *SubnetSuite) addTwoSubnetsAndAssertSecondFailsWithSuffix(c *gc.C, info1, info2 state.SubnetInfo, errorSuffix string) {
+	_, err := s.State.AddSubnet(info1)
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.assertAddSubnetForInfoFailsWithSuffix(c, info2, errorSuffix)
+}
+
+func (s *SubnetSuite) TestAddSubnetSucceedsForDifferentCIDRsAndEmptyProviderId(c *gc.C) {
+	subnetInfo1 := state.SubnetInfo{CIDR: "192.168.0.1/24", ProviderId: ""}
+	subnetInfo2 := state.SubnetInfo{CIDR: "10.0.0.0/24", ProviderId: ""}
+
+	subnet1, subnet2 := s.addTwoSubnetsAssertSuccessAndReturnBoth(c, subnetInfo1, subnetInfo2)
+	s.assertSubnetMatchesInfo(c, subnet1, subnetInfo1)
+	s.assertSubnetMatchesInfo(c, subnet2, subnetInfo2)
+}
+
+func (s *SubnetSuite) addTwoSubnetsAssertSuccessAndReturnBoth(c *gc.C, info1, info2 state.SubnetInfo) (*state.Subnet, *state.Subnet) {
+	subnet1, err := s.State.AddSubnet(info1)
+	c.Assert(err, jc.ErrorIsNil)
+	subnet2, err := s.State.AddSubnet(info2)
+	c.Assert(err, jc.ErrorIsNil)
+
+	return subnet1, subnet2
+}
+
+func (s *SubnetSuite) TestEnsureDeadSetsLifeToDeadWhenAlive(c *gc.C) {
+	subnet := s.addAliveSubnet(c, "192.168.0.1/24")
+
+	s.ensureDeadAndAssertLifeIsDead(c, subnet)
+	s.refreshAndAssertSubnetLifeIs(c, subnet, state.Dead)
+}
+
+func (s *SubnetSuite) addAliveSubnet(c *gc.C, cidr string) *state.Subnet {
+	subnetInfo := state.SubnetInfo{CIDR: cidr}
 	subnet, err := s.State.AddSubnet(subnetInfo)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(subnet.Life(), gc.Equals, state.Alive)
 
-	// This should fail - not dead yet!
-	err = subnet.Remove()
-	c.Assert(err, gc.ErrorMatches,
-		`cannot remove subnet "192.168.1.0/24": subnet is not dead`,
-	)
-
-	err = subnet.EnsureDead()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(subnet.Life(), gc.Equals, state.Dead)
-
-	// EnsureDead a second time should also not be an error
-	err = subnet.EnsureDead()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(subnet.Life(), gc.Equals, state.Dead)
-
-	// check the change was persisted
-	subnetCopy, err := s.State.Subnet("192.168.1.0/24")
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(subnetCopy.Life(), gc.Equals, state.Dead)
-
-	// Remove should now work
-	err = subnet.Remove()
-	c.Assert(err, jc.ErrorIsNil)
-
-	_, err = s.State.Subnet("192.168.1.0/24")
-	c.Assert(err, gc.ErrorMatches, `subnet "192.168.1.0/24" not found`)
-	c.Assert(err, jc.Satisfies, errors.IsNotFound)
-
-	// removing a second time should be a no-op
-	err = subnet.Remove()
-	c.Assert(err, jc.ErrorIsNil)
+	return subnet
 }
 
-func (s *SubnetSuite) TestSubnetRemoveKillsAddresses(c *gc.C) {
-	subnetInfo := state.SubnetInfo{CIDR: "192.168.1.0/24"}
-	subnet, err := s.State.AddSubnet(subnetInfo)
+func (s *SubnetSuite) ensureDeadAndAssertLifeIsDead(c *gc.C, subnet *state.Subnet) {
+	err := subnet.EnsureDead()
 	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(subnet.Life(), gc.Equals, state.Dead)
+}
 
-	_, err = s.State.AddIPAddress(
-		network.NewAddress("192.168.1.0"),
-		subnet.ID(),
-	)
+func (s *SubnetSuite) refreshAndAssertSubnetLifeIs(c *gc.C, subnet *state.Subnet, expectedLife state.Life) {
+	err := subnet.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = s.State.AddIPAddress(
-		network.NewAddress("192.168.1.1"),
-		subnet.ID(),
-	)
-	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(subnet.Life(), gc.Equals, expectedLife)
+}
 
-	err = subnet.EnsureDead()
-	c.Assert(err, jc.ErrorIsNil)
-	err = subnet.Remove()
-	c.Assert(err, jc.ErrorIsNil)
+func (s *SubnetSuite) TestEnsureDeadSetsLifeToDeadWhenNotAlive(c *gc.C) {
+	subnet := s.addAliveSubnet(c, "192.168.0.1/24")
+	s.ensureDeadAndAssertLifeIsDead(c, subnet)
 
-	_, err = s.State.IPAddress("192.168.1.0")
-	c.Assert(err, jc.Satisfies, errors.IsNotFound)
-	_, err = s.State.IPAddress("192.168.1.1")
+	s.ensureDeadAndAssertLifeIsDead(c, subnet)
+}
+
+func (s *SubnetSuite) TestRemoveFailsIfStillAlive(c *gc.C) {
+	subnet := s.addAliveSubnet(c, "192.168.0.1/24")
+
+	err := subnet.Remove()
+	c.Assert(err, gc.ErrorMatches, `cannot remove subnet "192.168.0.1/24": subnet is not dead`)
+	s.refreshAndAssertSubnetLifeIs(c, subnet, state.Alive)
+}
+
+func (s *SubnetSuite) TestRemoveSucceedsWhenSubnetIsNotAlive(c *gc.C) {
+	subnet := s.addAliveSubnet(c, "192.168.0.1/24")
+	s.ensureDeadAndAssertLifeIsDead(c, subnet)
+
+	s.removeSubnetAndAssertNotFound(c, subnet)
+}
+
+func (s *SubnetSuite) removeSubnetAndAssertNotFound(c *gc.C, subnet *state.Subnet) {
+	err := subnet.Remove()
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertSubnetWithCIDRNotFound(c, subnet.CIDR())
+}
+
+func (s *SubnetSuite) assertSubnetWithCIDRNotFound(c *gc.C, cidr string) {
+	_, err := s.State.Subnet(cidr)
+	s.assertSubnetNotFoundError(c, err)
+}
+
+func (s *SubnetSuite) assertSubnetNotFoundError(c *gc.C, err error) {
+	c.Assert(err, gc.ErrorMatches, "subnet .* not found")
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
 
-func (s *SubnetSuite) TestRefresh(c *gc.C) {
-	subnetInfo := state.SubnetInfo{CIDR: "192.168.1.0/24"}
+func (s *SubnetSuite) TestRemoveSucceedsWhenCalledTwice(c *gc.C) {
+	subnet := s.addAliveSubnet(c, "192.168.0.1/24")
+	s.ensureDeadAndAssertLifeIsDead(c, subnet)
+	s.removeSubnetAndAssertNotFound(c, subnet)
 
-	subnet, err := s.State.AddSubnet(subnetInfo)
+	err := subnet.Remove()
+	c.Assert(err, gc.ErrorMatches, `cannot remove subnet "192.168.0.1/24": not found or not dead`)
+}
+
+func (s *SubnetSuite) TestRemoveKillsAddedIPAddresses(c *gc.C) {
+	subnet := s.addAliveSubnet(c, "192.168.1.0/24")
+	s.addIPAddressForSubnet(c, "192.168.1.0", subnet)
+	s.addIPAddressForSubnet(c, "192.168.1.1", subnet)
+
+	err := subnet.EnsureDead()
+	c.Assert(err, jc.ErrorIsNil)
+	err = subnet.Remove()
 	c.Assert(err, jc.ErrorIsNil)
 
-	subnetCopy, err := s.State.Subnet("192.168.1.0/24")
+	s.assertIPAddressNotFound(c, "192.168.1.0")
+	s.assertIPAddressNotFound(c, "192.168.1.1")
+}
+
+func (s *SubnetSuite) addIPAddressForSubnet(c *gc.C, ipAddress string, subnet *state.Subnet) {
+	_, err := s.State.AddIPAddress(network.NewAddress(ipAddress), subnet.ID())
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *SubnetSuite) assertIPAddressNotFound(c *gc.C, ipAddress string) {
+	_, err := s.State.IPAddress(ipAddress)
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+}
+
+func (s *SubnetSuite) TestRefreshUpdatesStaleDocData(c *gc.C) {
+	subnet := s.addAliveSubnet(c, "fc00::/64")
+	subnetCopy, err := s.State.Subnet("fc00::/64")
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = subnet.EnsureDead()
-	c.Assert(err, jc.ErrorIsNil)
-
+	s.ensureDeadAndAssertLifeIsDead(c, subnet)
 	c.Assert(subnetCopy.Life(), gc.Equals, state.Alive)
+
 	err = subnetCopy.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(subnetCopy.Life(), gc.Equals, state.Dead)
+}
+
+func (s *SubnetSuite) TestRefreshFailsWithNotFoundWhenRemoved(c *gc.C) {
+	subnet := s.addAliveSubnet(c, "192.168.1.0/24")
+	s.ensureDeadAndAssertLifeIsDead(c, subnet)
+	s.removeSubnetAndAssertNotFound(c, subnet)
+
+	err := subnet.Refresh()
+	s.assertSubnetNotFoundError(c, err)
 }
 
 func (s *SubnetSuite) TestAllSubnets(c *gc.C) {
@@ -243,19 +320,23 @@ func (s *SubnetSuite) TestAllSubnets(c *gc.C) {
 }
 
 func (s *SubnetSuite) TestPickNewAddressNoAddresses(c *gc.C) {
-	subnetInfo := state.SubnetInfo{
-		CIDR:              "192.168.1.0/24",
-		AllocatableIPLow:  "",
-		AllocatableIPHigh: "",
-	}
-	subnet, err := s.State.AddSubnet(subnetInfo)
-	c.Assert(err, jc.ErrorIsNil)
+	subnet := s.addAliveSubnet(c, "192.168.1.0/24")
 
-	_, err = subnet.PickNewAddress()
+	_, err := subnet.PickNewAddress()
 	c.Assert(err, gc.ErrorMatches, "no allocatable IP addresses for subnet .*")
 }
 
-func (s *SubnetSuite) getSubnetForAddressPicking(c *gc.C, allocatableHigh string) *state.Subnet {
+func (s *SubnetSuite) TestPickNewAddressWhenSubnetIsDead(c *gc.C) {
+	subnet := s.addSubnetWithAllocatableIPHigh(c, "192.168.1.0")
+	s.ensureDeadAndAssertLifeIsDead(c, subnet)
+
+	_, err := subnet.PickNewAddress()
+	c.Assert(err, gc.ErrorMatches,
+		`cannot pick address: subnet "192.168.1.0/24" is not alive`,
+	)
+}
+
+func (s *SubnetSuite) addSubnetWithAllocatableIPHigh(c *gc.C, allocatableHigh string) *state.Subnet {
 	subnetInfo := state.SubnetInfo{
 		CIDR:              "192.168.1.0/24",
 		AllocatableIPLow:  "192.168.1.0",
@@ -266,32 +347,16 @@ func (s *SubnetSuite) getSubnetForAddressPicking(c *gc.C, allocatableHigh string
 	return subnet
 }
 
-func (s *SubnetSuite) TestPickNewAddressWhenSubnetIsDead(c *gc.C) {
-	subnet := s.getSubnetForAddressPicking(c, "192.168.1.0")
-	err := subnet.EnsureDead()
-	c.Assert(err, jc.ErrorIsNil)
-
-	// Calling it twice is ok.
-	err = subnet.EnsureDead()
-	c.Assert(err, jc.ErrorIsNil)
-
-	_, err = subnet.PickNewAddress()
-	c.Assert(err, gc.ErrorMatches,
-		`cannot pick address: subnet "192.168.1.0/24" is not alive`,
-	)
-}
-
 func (s *SubnetSuite) TestPickNewAddressAddressesExhausted(c *gc.C) {
-	subnet := s.getSubnetForAddressPicking(c, "192.168.1.0")
-	addr := network.NewAddress("192.168.1.0")
-	_, err := s.State.AddIPAddress(addr, subnet.ID())
+	subnet := s.addSubnetWithAllocatableIPHigh(c, "192.168.1.0")
+	s.addIPAddressForSubnet(c, "192.168.1.0", subnet)
 
-	_, err = subnet.PickNewAddress()
+	_, err := subnet.PickNewAddress()
 	c.Assert(err, gc.ErrorMatches, "allocatable IP addresses exhausted for subnet .*")
 }
 
 func (s *SubnetSuite) TestPickNewAddressOneAddress(c *gc.C) {
-	subnet := s.getSubnetForAddressPicking(c, "192.168.1.0")
+	subnet := s.addSubnetWithAllocatableIPHigh(c, "192.168.1.0")
 
 	addr, err := subnet.PickNewAddress()
 	c.Assert(err, jc.ErrorIsNil)
@@ -299,10 +364,8 @@ func (s *SubnetSuite) TestPickNewAddressOneAddress(c *gc.C) {
 }
 
 func (s *SubnetSuite) TestPickNewAddressSkipsAllocated(c *gc.C) {
-	subnet := s.getSubnetForAddressPicking(c, "192.168.1.1")
-
-	addr := network.NewAddress("192.168.1.0")
-	_, err := s.State.AddIPAddress(addr, subnet.ID())
+	subnet := s.addSubnetWithAllocatableIPHigh(c, "192.168.1.1")
+	s.addIPAddressForSubnet(c, "192.168.1.0", subnet)
 
 	ipAddr, err := subnet.PickNewAddress()
 	c.Assert(err, jc.ErrorIsNil)
@@ -327,7 +390,7 @@ func (s *SubnetSuite) TestPickNewAddressRace(c *gc.C) {
 	s.PatchValue(&state.PickAddress, &mockPickAddress)
 
 	// 192.168.1.0 and 192.168.1.1 are the only valid addresses
-	subnet := s.getSubnetForAddressPicking(c, "192.168.1.1")
+	subnet := s.addSubnetWithAllocatableIPHigh(c, "192.168.1.1")
 
 	waiter := sync.WaitGroup{}
 	waiter.Add(2)


### PR DESCRIPTION
Needed to allow discoverspaces to work in models other than the
controller model.

Also includes some improvements to tests.

(Review request: http://reviews.vapour.ws/r/3798/)