### PR TITLE
rcp: simplify serverError type

### DIFF
--- a/rpc/server.go
+++ b/rpc/server.go
@@ -534,8 +534,7 @@ func (conn *Conn) bindRequest(hdr *Header) (boundRequest, error) {
 	if err != nil {
 		if _, ok := err.(*rpcreflect.CallNotImplementedError); ok {
 			err = &serverError{
-				Message: err.Error(),
-				Code:    CodeNotImplemented,
+				error: err,
 			}
 		} else {
 			err = transformErrors(err)
@@ -577,12 +576,11 @@ func (conn *Conn) runRequest(req boundRequest, arg reflect.Value, startTime time
 	}
 }
 
-type serverError RequestError
-
-func (e *serverError) Error() string {
-	return e.Message
+type serverError struct {
+	error
 }
 
 func (e *serverError) ErrorCode() string {
-	return e.Code
+	// serverError only knows one error code.
+	return CodeNotImplemented
 }


### PR DESCRIPTION
serverError was over compliated. It did not need to inherit from
requestError, and the way it did was overengineered. serverError just
needs to extend the error interface to match the ErrorCoder interface,
and as serverError only knows one status code, we can hard code that as
well.

(Review request: http://reviews.vapour.ws/r/3802/)