### PR TITLE
apiserver/controller: Add InitiateModelMigration API

### DIFF
--- a/apiserver/controller/controller.go
+++ b/apiserver/controller/controller.go
@@ -296,12 +296,12 @@ func (c *ControllerAPI) initiateOneModelMigration(spec params.ModelMigrationSpec
 	// Start the migration.
 	targetInfo := spec.TargetInfo
 	args := state.ModelMigrationSpec{
-		InitiatedBy: c.authorizer.GetAuthTag().Id(),
+		InitiatedBy: c.apiUser,
 		TargetInfo: migration.TargetInfo{
 			ControllerTag: targetInfo.ControllerTag,
 			Addrs:         targetInfo.Addrs,
 			CACert:        targetInfo.CACert,
-			EntityTag:     targetInfo.EntityTag,
+			AuthTag:       targetInfo.AuthTag,
 			Password:      targetInfo.Password,
 		},
 	}

--- a/apiserver/controller/controller.go
+++ b/apiserver/controller/controller.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
+	migration "github.com/juju/juju/core/modelmigration"
 	"github.com/juju/juju/state"
 )
 
@@ -33,6 +34,7 @@ type Controller interface {
 	RemoveBlocks(args params.RemoveBlocksArgs) error
 	WatchAllModels() (params.AllWatcherId, error)
 	ModelStatus(req params.Entities) (params.ModelStatusResults, error)
+	InitiateModelMigration(params.InitiateModelMigrationArgs) (params.InitiateModelMigrationResults, error)
 }
 
 // ControllerAPI implements the environment manager interface and is
@@ -255,6 +257,59 @@ func (c *ControllerAPI) ModelStatus(req params.Entities) (params.ModelStatusResu
 	}
 	results.Results = status
 	return results, nil
+}
+
+// InitiateModelMigration attempts to begin the migration of one or
+// more models to other controllers.
+func (c *ControllerAPI) InitiateModelMigration(reqArgs params.InitiateModelMigrationArgs) (
+	params.InitiateModelMigrationResults, error,
+) {
+	out := params.InitiateModelMigrationResults{
+		Results: make([]params.InitiateModelMigrationResult, len(reqArgs.Specs)),
+	}
+	for i, spec := range reqArgs.Specs {
+		result := &out.Results[i]
+		result.ModelTag = spec.ModelTag
+		id, err := c.initiateOneModelMigration(spec)
+		if err != nil {
+			result.Error = common.ServerError(err)
+		} else {
+			result.Id = id
+		}
+	}
+	return out, nil
+}
+
+func (c *ControllerAPI) initiateOneModelMigration(spec params.ModelMigrationSpec) (string, error) {
+	// Ensure the model exists.
+	if _, err := c.state.GetModel(spec.ModelTag); err != nil {
+		return "", errors.Annotate(err, "unable to read model")
+	}
+
+	// Get State for model.
+	hostedState, err := c.state.ForModel(spec.ModelTag)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	defer hostedState.Close()
+
+	// Start the migration.
+	targetInfo := spec.TargetInfo
+	args := state.ModelMigrationSpec{
+		InitiatedBy: c.authorizer.GetAuthTag().Id(),
+		TargetInfo: migration.TargetInfo{
+			ControllerTag: targetInfo.ControllerTag,
+			Addrs:         targetInfo.Addrs,
+			CACert:        targetInfo.CACert,
+			EntityTag:     targetInfo.EntityTag,
+			Password:      targetInfo.Password,
+		},
+	}
+	mig, err := state.CreateModelMigration(hostedState, args)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	return mig.Id(), nil
 }
 
 func (c *ControllerAPI) environStatus(tag string) (params.ModelStatus, error) {

--- a/apiserver/controller/controller_test.go
+++ b/apiserver/controller/controller_test.go
@@ -286,7 +286,7 @@ func (s *controllerSuite) TestInitiateModelMigration(c *gc.C) {
 					ControllerTag: randomModelTag(),
 					Addrs:         []string{"1.1.1.1:1111", "2.2.2.2:2222"},
 					CACert:        "cert1",
-					EntityTag:     names.NewUserTag("admin1"),
+					AuthTag:       names.NewUserTag("admin1"),
 					Password:      "secret1",
 				},
 			}, {
@@ -295,7 +295,7 @@ func (s *controllerSuite) TestInitiateModelMigration(c *gc.C) {
 					ControllerTag: randomModelTag(),
 					Addrs:         []string{"3.3.3.3:3333"},
 					CACert:        "cert2",
-					EntityTag:     names.NewUserTag("admin2"),
+					AuthTag:       names.NewUserTag("admin2"),
 					Password:      "secret2",
 				},
 			},
@@ -326,7 +326,7 @@ func (s *controllerSuite) TestInitiateModelMigration(c *gc.C) {
 		c.Check(targetInfo.ControllerTag, gc.Equals, spec.TargetInfo.ControllerTag)
 		c.Check(targetInfo.Addrs, jc.SameContents, spec.TargetInfo.Addrs)
 		c.Check(targetInfo.CACert, gc.Equals, spec.TargetInfo.CACert)
-		c.Check(targetInfo.EntityTag, gc.Equals, spec.TargetInfo.EntityTag)
+		c.Check(targetInfo.AuthTag, gc.Equals, spec.TargetInfo.AuthTag)
 		c.Check(targetInfo.Password, gc.Equals, spec.TargetInfo.Password)
 	}
 }
@@ -364,7 +364,7 @@ func (s *controllerSuite) TestInitiateModelMigrationPartialFailure(c *gc.C) {
 					ControllerTag: randomModelTag(),
 					Addrs:         []string{"1.1.1.1:1111", "2.2.2.2:2222"},
 					CACert:        "cert",
-					EntityTag:     names.NewUserTag("admin"),
+					AuthTag:       names.NewUserTag("admin"),
 					Password:      "secret",
 				},
 			}, {

--- a/apiserver/params/systemmanager.go
+++ b/apiserver/params/systemmanager.go
@@ -68,7 +68,7 @@ type ModelMigrationTargetInfo struct {
 	ControllerTag names.ModelTag `json:"controller-tag"`
 	Addrs         []string       `json:"addrs"`
 	CACert        string         `json:"ca-cert"`
-	EntityTag     names.Tag      `json:"entity-tag"`
+	AuthTag       names.UserTag  `json:"auth-tag"`
 	Password      string         `json:"password"`
 }
 

--- a/apiserver/params/systemmanager.go
+++ b/apiserver/params/systemmanager.go
@@ -3,6 +3,8 @@
 
 package params
 
+import "github.com/juju/names"
+
 // DestroyControllerArgs holds the arguments for destroying a controller.
 type DestroyControllerArgs struct {
 	// DestroyModels specifies whether or not the hosted models
@@ -45,4 +47,41 @@ type ModelStatus struct {
 // ModelStatusResults holds status information about a group of models.
 type ModelStatusResults struct {
 	Results []ModelStatus `json:"models"`
+}
+
+// InitiateModelMigrationArgs holds the details required to start one
+// or more model migrations.
+type InitiateModelMigrationArgs struct {
+	Specs []ModelMigrationSpec `json:"specs"`
+}
+
+// ModelMigrationSpec holds the details required to start the
+// migration of a single model.
+type ModelMigrationSpec struct {
+	ModelTag   names.ModelTag           `json:"model-tag"`
+	TargetInfo ModelMigrationTargetInfo `json:"target-info"`
+}
+
+// ModelMigrationTargetInfo holds the details required to connect to
+// and authenticate with a remote controller for model migration.
+type ModelMigrationTargetInfo struct {
+	ControllerTag names.ModelTag `json:"controller-tag"`
+	Addrs         []string       `json:"addrs"`
+	CACert        string         `json:"ca-cert"`
+	EntityTag     names.Tag      `json:"entity-tag"`
+	Password      string         `json:"password"`
+}
+
+// InitiateModelMigrationResults is used to return the result of one
+// or more attempts to start model migrations.
+type InitiateModelMigrationResults struct {
+	Results []InitiateModelMigrationResult `json:"results"`
+}
+
+// InitiateModelMigrationResult is used to return the result of one
+// model migration initiation attempt.
+type InitiateModelMigrationResult struct {
+	ModelTag names.ModelTag `json:"model-tag"`
+	Error    *Error         `json:"error"`
+	Id       string         `json:"id"` // the ID for the migration attempt
 }

--- a/core/modelmigration/targetinfo.go
+++ b/core/modelmigration/targetinfo.go
@@ -28,11 +28,11 @@ type TargetInfo struct {
 	// the target API server's certificate, in PEM format.
 	CACert string
 
-	// EntityTag holds the entity to authenticate with to the target
+	// AuthTag holds the user tag to authenticate with to the target
 	// controller.
-	EntityTag names.Tag
+	AuthTag names.UserTag
 
-	// Password holds the password to use with TargetEntityTag.
+	// Password holds the password to use with AuthTag.
 	Password string
 }
 
@@ -57,8 +57,8 @@ func (info *TargetInfo) Validate() error {
 		return errors.NotValidf("empty CACert")
 	}
 
-	if info.EntityTag.Id() == "" {
-		return errors.NotValidf("empty EntityTag")
+	if info.AuthTag.Id() == "" {
+		return errors.NotValidf("empty AuthTag")
 	}
 
 	if info.Password == "" {

--- a/core/modelmigration/targetinfo_test.go
+++ b/core/modelmigration/targetinfo_test.go
@@ -56,11 +56,11 @@ func (s *TargetInfoSuite) TestValidation(c *gc.C) {
 		},
 		"empty CACert not valid",
 	}, {
-		"EntityTag",
+		"AuthTag",
 		func(info *migration.TargetInfo) {
-			info.EntityTag = names.NewMachineTag("")
+			info.AuthTag = names.UserTag{}
 		},
-		"empty EntityTag not valid",
+		"empty AuthTag not valid",
 	}, {
 		"Password",
 		func(info *migration.TargetInfo) {
@@ -81,7 +81,7 @@ func (s *TargetInfoSuite) TestValidation(c *gc.C) {
 			ControllerTag: modelTag,
 			Addrs:         []string{"1.2.3.4:5555", "4.3.2.1:6666"},
 			CACert:        "cert",
-			EntityTag:     names.NewUserTag("user"),
+			AuthTag:       names.NewUserTag("user"),
 			Password:      "password",
 		}
 		test.tweakInfo(&info)

--- a/state/modelmigration_test.go
+++ b/state/modelmigration_test.go
@@ -41,12 +41,12 @@ func (s *ModelMigrationSuite) SetUpTest(c *gc.C) {
 
 	// Plausible migration arguments to test with.
 	s.stdSpec = state.ModelMigrationSpec{
-		InitiatedBy: "admin",
+		InitiatedBy: names.NewUserTag("admin"),
 		TargetInfo: migration.TargetInfo{
 			ControllerTag: s.State.ModelTag(),
 			Addrs:         []string{"1.2.3.4:5555", "4.3.2.1:6666"},
 			CACert:        "cert",
-			EntityTag:     names.NewUserTag("user"),
+			AuthTag:       names.NewUserTag("user"),
 			Password:      "password",
 		},
 	}
@@ -133,15 +133,9 @@ func (s *ModelMigrationSuite) TestSpecValidation(c *gc.C) {
 		tweakSpec    func(*state.ModelMigrationSpec)
 		errorPattern string
 	}{{
-		"empty InitiatedBy",
-		func(spec *state.ModelMigrationSpec) {
-			spec.InitiatedBy = ""
-		},
-		"InitiatedBy not valid",
-	}, {
 		"invalid InitiatedBy",
 		func(spec *state.ModelMigrationSpec) {
-			spec.InitiatedBy = "!"
+			spec.InitiatedBy = names.UserTag{}
 		},
 		"InitiatedBy not valid",
 	}, {


### PR DESCRIPTION
This will be used by clients to start a model migration.

(Review request: http://reviews.vapour.ws/r/3804/)