### PR TITLE
apiserver/params: remove ClientError helper

### DIFF
--- a/api/agent/machine_test.go
+++ b/api/agent/machine_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/mongo"
+	"github.com/juju/juju/rpc"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/multiwatcher"
 	coretesting "github.com/juju/juju/testing"
@@ -61,7 +62,10 @@ func (s *servingInfoSuite) TestStateServingInfoPermission(c *gc.C) {
 	st, _ := s.OpenAPIAsNewMachine(c)
 
 	_, err := st.Agent().StateServingInfo()
-	c.Assert(err, gc.ErrorMatches, "permission denied")
+	c.Assert(errors.Cause(err), gc.DeepEquals, &rpc.RequestError{
+		Message: "permission denied",
+		Code:    "unauthorized access",
+	})
 }
 
 func (s *servingInfoSuite) TestIsMaster(c *gc.C) {
@@ -84,7 +88,10 @@ func (s *servingInfoSuite) TestIsMaster(c *gc.C) {
 func (s *servingInfoSuite) TestIsMasterPermission(c *gc.C) {
 	st, _ := s.OpenAPIAsNewMachine(c)
 	_, err := st.Agent().IsMaster()
-	c.Assert(err, gc.ErrorMatches, "permission denied")
+	c.Assert(errors.Cause(err), gc.DeepEquals, &rpc.RequestError{
+		Message: "permission denied",
+		Code:    "unauthorized access",
+	})
 }
 
 type machineSuite struct {

--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -545,7 +545,7 @@ func (s *state) APICall(facade string, version int, id, method string, args, res
 		Id:      id,
 		Action:  method,
 	}, args, response)
-	return params.ClientError(err)
+	return errors.Trace(err)
 }
 
 func (s *state) Close() error {

--- a/api/apiclient_test.go
+++ b/api/apiclient_test.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"sync/atomic"
 
+	"github.com/juju/errors"
 	"github.com/juju/names"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -17,6 +18,7 @@ import (
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/apiserver/params"
 	jujutesting "github.com/juju/juju/juju/testing"
+	"github.com/juju/juju/rpc"
 	"github.com/juju/juju/version"
 )
 
@@ -127,7 +129,10 @@ func (s *apiclientSuite) TestOpenHonorsModelTag(c *gc.C) {
 	// We start by ensuring we have an invalid tag, and Open should fail.
 	info.ModelTag = names.NewModelTag("bad-tag")
 	_, err := api.Open(info, api.DialOpts{})
-	c.Check(err, gc.ErrorMatches, `unknown model: "bad-tag"`)
+	c.Assert(errors.Cause(err), gc.DeepEquals, &rpc.RequestError{
+		Message: `unknown model: "bad-tag"`,
+		Code:    "not found",
+	})
 	c.Check(params.ErrCode(err), gc.Equals, params.CodeNotFound)
 
 	// Now set it to the right tag, and we should succeed.

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	jujunames "github.com/juju/juju/juju/names"
 	jujutesting "github.com/juju/juju/juju/testing"
+	"github.com/juju/juju/rpc"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/testcharms"
 	coretesting "github.com/juju/juju/testing"
@@ -504,7 +505,10 @@ func (s *clientSuite) TestOpenUsesEnvironUUIDPaths(c *gc.C) {
 	// Passing in a bad model UUID should fail with a known error
 	info.ModelTag = names.NewModelTag("dead-beef-123456")
 	apistate, err = api.Open(info, api.DialOpts{})
-	c.Check(err, gc.ErrorMatches, `unknown model: "dead-beef-123456"`)
+	c.Assert(errors.Cause(err), gc.DeepEquals, &rpc.RequestError{
+		Message: `unknown model: "dead-beef-123456"`,
+		Code:    "not found",
+	})
 	c.Check(err, jc.Satisfies, params.IsCodeNotFound)
 	c.Assert(apistate, gc.IsNil)
 }

--- a/api/keymanager/client_test.go
+++ b/api/keymanager/client_test.go
@@ -6,6 +6,7 @@ package keymanager_test
 import (
 	"strings"
 
+	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/ssh"
 	sshtesting "github.com/juju/utils/ssh/testing"
@@ -16,6 +17,7 @@ import (
 	keymanagertesting "github.com/juju/juju/apiserver/keymanager/testing"
 	"github.com/juju/juju/apiserver/params"
 	jujutesting "github.com/juju/juju/juju/testing"
+	"github.com/juju/juju/rpc"
 	"github.com/juju/juju/state"
 )
 
@@ -116,7 +118,10 @@ func (s *keymanagerSuite) TestAddSystemKeyWrongUser(c *gc.C) {
 	defer keyManager.Close()
 	newKey := sshtesting.ValidKeyTwo.Key
 	_, err := keyManager.AddKeys("some-user", newKey)
-	c.Assert(err, gc.ErrorMatches, "permission denied")
+	c.Assert(errors.Cause(err), gc.DeepEquals, &rpc.RequestError{
+		Message: "permission denied",
+		Code:    "unauthorized access",
+	})
 	s.assertModelKeys(c, []string{key1})
 }
 

--- a/api/state_macaroon_test.go
+++ b/api/state_macaroon_test.go
@@ -6,11 +6,13 @@ package api_test
 import (
 	"net/url"
 
+	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/api"
 	apitesting "github.com/juju/juju/api/testing"
+	"github.com/juju/juju/rpc"
 )
 
 var _ = gc.Suite(&macaroonLoginSuite{})
@@ -52,7 +54,10 @@ func (s *macaroonLoginSuite) TestUnknownUserLogin(c *gc.C) {
 		return "testUnknown"
 	}
 	err := s.client.Login(nil, "", "")
-	c.Assert(err, gc.ErrorMatches, "invalid entity name or password")
+	c.Assert(errors.Cause(err), gc.DeepEquals, &rpc.RequestError{
+		Message: "invalid entity name or password",
+		Code:    "unauthorized access",
+	})
 }
 
 func (s *macaroonLoginSuite) TestConnectStream(c *gc.C) {

--- a/apiserver/adminv2_test.go
+++ b/apiserver/adminv2_test.go
@@ -4,12 +4,14 @@
 package apiserver_test
 
 import (
+	"github.com/juju/errors"
 	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/apiserver"
+	"github.com/juju/juju/rpc"
 	"github.com/juju/juju/testing/factory"
 )
 
@@ -53,7 +55,10 @@ func (s *loginV2Suite) TestClientLoginToServer(c *gc.C) {
 
 	client := apiState.Client()
 	_, err = client.GetModelConstraints()
-	c.Assert(err, gc.ErrorMatches, `logged in to server, no model, "Client" not supported`)
+	c.Assert(errors.Cause(err), gc.DeepEquals, &rpc.RequestError{
+		Message: `logged in to server, no model, "Client" not supported`,
+		Code:    "not supported",
+	})
 }
 
 func (s *loginV2Suite) TestClientLoginToServerNoAccessToControllerEnv(c *gc.C) {

--- a/apiserver/charms/client_test.go
+++ b/apiserver/charms/client_test.go
@@ -108,7 +108,7 @@ func (s *baseCharmsSuite) TestClientCharmInfo(c *gc.C) {
 			about: "unknown charm",
 			charm: "wordpress",
 			url:   "cs:missing/one-1",
-			err:   `charm "cs:missing/one-1" not found`,
+			err:   `charm "cs:missing/one-1" not found \(not found\)`,
 		},
 	}
 

--- a/apiserver/client/perm_test.go
+++ b/apiserver/client/perm_test.go
@@ -6,6 +6,7 @@ package client_test
 import (
 	"strings"
 
+	"github.com/juju/errors"
 	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -16,6 +17,7 @@ import (
 	"github.com/juju/juju/api/service"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/constraints"
+	"github.com/juju/juju/rpc"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/version"
 )
@@ -170,7 +172,10 @@ func (s *permSuite) TestOperationPerm(c *gc.C) {
 			if allow[e] {
 				c.Check(err, jc.ErrorIsNil)
 			} else {
-				c.Check(err, gc.ErrorMatches, "permission denied")
+				c.Check(errors.Cause(err), gc.DeepEquals, &rpc.RequestError{
+					Message: "permission denied",
+					Code:    "unauthorized access",
+				})
 				c.Check(err, jc.Satisfies, params.IsCodeUnauthorized)
 			}
 			reset()

--- a/apiserver/client/run_test.go
+++ b/apiserver/client/run_test.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/juju/errors"
 	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/exec"
@@ -17,6 +18,7 @@ import (
 	"github.com/juju/juju/apiserver/client"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/network"
+	"github.com/juju/juju/rpc"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/testing"
 )
@@ -258,6 +260,14 @@ func (s *runSuite) TestRunOnAllMachines(c *gc.C) {
 	c.Check(string(results[0].Stdout), gc.Equals, expectedCommand[0])
 	c.Check(string(results[1].Stdout), gc.Equals, expectedCommand[0])
 	c.Check(string(results[2].Stdout), gc.Equals, expectedCommand[0])
+}
+
+func (s *runSuite) AssertBlocked(c *gc.C, err error, msg string) {
+	c.Assert(params.IsCodeOperationBlocked(err), jc.IsTrue, gc.Commentf("error: %#v", err))
+	c.Assert(errors.Cause(err), gc.DeepEquals, &rpc.RequestError{
+		Message: msg,
+		Code:    "operation is blocked",
+	})
 }
 
 func (s *runSuite) TestBlockRunOnAllMachines(c *gc.C) {

--- a/apiserver/common/errors.go
+++ b/apiserver/common/errors.go
@@ -108,8 +108,8 @@ func OperationBlockedError(msg string) error {
 		msg = "the operation has been blocked"
 	}
 	return &params.Error{
-		Code:    params.CodeOperationBlocked,
 		Message: msg,
+		Code:    params.CodeOperationBlocked,
 	}
 }
 

--- a/apiserver/common/testing/block.go
+++ b/apiserver/common/testing/block.go
@@ -6,6 +6,7 @@ package testing
 import (
 	"fmt"
 
+	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -35,11 +36,7 @@ func NewBlockHelper(st api.Connection) BlockHelper {
 // on switches on desired block and
 // asserts that no errors were encountered.
 func (s BlockHelper) on(c *gc.C, blockType multiwatcher.BlockType, msg string) {
-	c.Assert(
-		s.client.SwitchBlockOn(
-			fmt.Sprintf("%v", blockType),
-			msg),
-		gc.IsNil)
+	c.Assert(s.client.SwitchBlockOn(fmt.Sprintf("%v", blockType), msg), gc.IsNil)
 }
 
 // BlockAllChanges blocks all operations that could change environment.
@@ -67,5 +64,8 @@ func (s BlockHelper) BlockDestroyModel(c *gc.C, msg string) {
 // related to switched block.
 func (s BlockHelper) AssertBlocked(c *gc.C, err error, msg string) {
 	c.Assert(params.IsCodeOperationBlocked(err), jc.IsTrue, gc.Commentf("error: %#v", err))
-	c.Assert(err, gc.ErrorMatches, msg)
+	c.Assert(errors.Cause(err), gc.DeepEquals, &params.Error{
+		Message: msg,
+		Code:    "operation is blocked",
+	})
 }

--- a/apiserver/params/apierror.go
+++ b/apiserver/params/apierror.go
@@ -97,24 +97,6 @@ func ErrCode(err error) string {
 	return ""
 }
 
-// ClientError maps errors returned from an RPC call into local errors with
-// appropriate values.
-func ClientError(err error) error {
-	switch err := errors.Cause(err).(type) {
-	case *rpc.RequestError:
-		// We use our own error type rather than rpc.ServerError
-		// because we don't want the code or the "server error" prefix
-		// within the error message. Also, it's best not to make clients
-		// know that we're using the rpc package.
-		return &Error{
-			Message: err.Message,
-			Code:    err.Code,
-		}
-	default:
-		return err
-	}
-}
-
 func IsCodeActionNotAvailable(err error) bool {
 	return ErrCode(err) == CodeActionNotAvailable
 }

--- a/apiserver/pinger_test.go
+++ b/apiserver/pinger_test.go
@@ -11,6 +11,7 @@ package apiserver_test
 import (
 	"time"
 
+	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -67,7 +68,7 @@ func (s *pingerSuite) TestPing(c *gc.C) {
 	err = st.Close()
 	c.Assert(err, jc.ErrorIsNil)
 	err = st.Ping()
-	c.Assert(err, gc.Equals, rpc.ErrShutdown)
+	c.Assert(errors.Cause(err), gc.Equals, rpc.ErrShutdown)
 
 	// Make sure that ping messages have not been logged.
 	for _, m := range tw.Log() {

--- a/apiserver/server_test.go
+++ b/apiserver/server_test.go
@@ -143,7 +143,7 @@ func (s *serverSuite) TestOpenAsMachineErrors(c *gc.C) {
 	assertNotProvisioned := func(err error) {
 		c.Assert(err, gc.NotNil)
 		c.Assert(err, jc.Satisfies, params.IsCodeNotProvisioned)
-		c.Assert(err, gc.ErrorMatches, `machine \d+ not provisioned`)
+		c.Assert(err, gc.ErrorMatches, `machine \d+ not provisioned \(not provisioned\)`)
 	}
 
 	machine, password := s.Factory.MakeMachineReturningPassword(

--- a/apiserver/service/service_test.go
+++ b/apiserver/service/service_test.go
@@ -434,7 +434,7 @@ func (s *serviceSuite) TestAddCharmWithAuthorization(c *gc.C) {
 	// Try to add a charm to the environment without authorization.
 	s.DischargeUser = ""
 	err = s.APIState.Client().AddCharm(curl)
-	c.Assert(err, gc.ErrorMatches, `cannot retrieve charm "cs:~restricted/precise/wordpress-3": cannot get archive: cannot get discharge from "https://.*": third party refused discharge: cannot discharge: discharge denied`)
+	c.Assert(err, gc.ErrorMatches, `cannot retrieve charm "cs:~restricted/precise/wordpress-3": cannot get archive: cannot get discharge from "https://.*": third party refused discharge: cannot discharge: discharge denied \(unauthorized access\)`)
 
 	tryAs := func(user string) error {
 		client := csclient.New(csclient.Params{

--- a/apiserver/testing/fakecharmstore.go
+++ b/apiserver/testing/fakecharmstore.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 
-	gitjujutesting "github.com/juju/testing"
+	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v6-unstable"
@@ -24,7 +24,7 @@ import (
 )
 
 type CharmStoreSuite struct {
-	gitjujutesting.CleanupSuite
+	testing.CleanupSuite
 
 	Session *mgo.Session
 	// DischargeUser holds the identity of the user

--- a/cmd/juju/commands/debughooks_test.go
+++ b/cmd/juju/commands/debughooks_test.go
@@ -62,7 +62,7 @@ var debugHooksTests = []struct {
 }, {
 	info:  `invalid unit`,
 	args:  []string{"nonexistent/123"},
-	error: `unit "nonexistent/123" not found`,
+	error: `unit "nonexistent/123" not found \(not found\)`,
 }, {
 	info:  `invalid hook`,
 	args:  []string{"mysql/0", "invalid-hook"},
@@ -94,9 +94,9 @@ func (s *DebugHooksSuite) TestDebugHooksCommand(c *gc.C) {
 			err = modelcmd.Wrap(debugHooksCmd).Run(ctx)
 		}
 		if t.error != "" {
-			c.Assert(err, gc.ErrorMatches, t.error)
+			c.Check(err, gc.ErrorMatches, t.error)
 		} else {
-			c.Assert(err, jc.ErrorIsNil)
+			c.Check(err, jc.ErrorIsNil)
 		}
 	}
 }

--- a/cmd/juju/commands/resolved_test.go
+++ b/cmd/juju/commands/resolved_test.go
@@ -52,7 +52,7 @@ var resolvedTests = []struct {
 		err:  `invalid unit name "jeremy-fisher"`,
 	}, {
 		args: []string{"jeremy-fisher/99"},
-		err:  `unit "jeremy-fisher/99" not found`,
+		err:  `unit "jeremy-fisher/99" not found \(not found\)`,
 	}, {
 		args: []string{"dummy/0"},
 		err:  `unit "dummy/0" is not in an error state`,

--- a/cmd/juju/commands/scp_unix_test.go
+++ b/cmd/juju/commands/scp_unix_test.go
@@ -103,7 +103,7 @@ var scpTests = []struct {
 	}, {
 		about: "scp with no such machine",
 		args:  []string{"5:foo", "bar"},
-		error: "machine 5 not found",
+		error: `machine 5 not found \(not found\)`,
 	},
 }
 

--- a/cmd/juju/service/expose_test.go
+++ b/cmd/juju/service/expose_test.go
@@ -4,12 +4,14 @@
 package service
 
 import (
+	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v6-unstable"
 
 	"github.com/juju/juju/cmd/juju/common"
 	jujutesting "github.com/juju/juju/juju/testing"
+	"github.com/juju/juju/rpc"
 	"github.com/juju/juju/testcharms"
 	"github.com/juju/juju/testing"
 )
@@ -52,7 +54,10 @@ func (s *ExposeSuite) TestExpose(c *gc.C) {
 	s.assertExposed(c, "some-service-name")
 
 	err = runExpose(c, "nonexistent-service")
-	c.Assert(err, gc.ErrorMatches, `service "nonexistent-service" not found`)
+	c.Assert(errors.Cause(err), gc.DeepEquals, &rpc.RequestError{
+		Message: `service "nonexistent-service" not found`,
+		Code:    "not found",
+	})
 }
 
 func (s *ExposeSuite) TestBlockExpose(c *gc.C) {

--- a/cmd/juju/service/removerelation_test.go
+++ b/cmd/juju/service/removerelation_test.go
@@ -4,11 +4,13 @@
 package service
 
 import (
+	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cmd/juju/common"
 	jujutesting "github.com/juju/juju/juju/testing"
+	"github.com/juju/juju/rpc"
 	"github.com/juju/juju/testcharms"
 	"github.com/juju/juju/testing"
 )
@@ -51,11 +53,17 @@ func (s *RemoveRelationSuite) TestRemoveRelation(c *gc.C) {
 
 	// Destroy a relation that used to exist.
 	err = runRemoveRelation(c, "riak", "logging")
-	c.Assert(err, gc.ErrorMatches, `relation "logging:info riak:juju-info" not found`)
+	c.Assert(errors.Cause(err), gc.DeepEquals, &rpc.RequestError{
+		Message: `relation "logging:info riak:juju-info" not found`,
+		Code:    "not found",
+	})
 
 	// Invalid removes.
 	err = runRemoveRelation(c, "ping", "pong")
-	c.Assert(err, gc.ErrorMatches, `service "ping" not found`)
+	c.Assert(errors.Cause(err), gc.DeepEquals, &rpc.RequestError{
+		Message: `service "ping" not found`,
+		Code:    "not found",
+	})
 	err = runRemoveRelation(c, "riak")
 	c.Assert(err, gc.ErrorMatches, `a relation must involve two services`)
 }

--- a/cmd/juju/service/removeservice_test.go
+++ b/cmd/juju/service/removeservice_test.go
@@ -7,12 +7,14 @@ import (
 	"net/http"
 
 	"github.com/juju/cmd"
+	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cmd/juju/common"
 	"github.com/juju/juju/cmd/modelcmd"
 	jujutesting "github.com/juju/juju/juju/testing"
+	"github.com/juju/juju/rpc"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/testcharms"
 	"github.com/juju/juju/testing"
@@ -88,7 +90,10 @@ func (s *RemoveServiceSuite) TestBlockRemoveService(c *gc.C) {
 func (s *RemoveServiceSuite) TestFailure(c *gc.C) {
 	// Destroy a service that does not exist.
 	err := runRemoveService(c, "gargleblaster")
-	c.Assert(err, gc.ErrorMatches, `service "gargleblaster" not found`)
+	c.Assert(errors.Cause(err), gc.DeepEquals, &rpc.RequestError{
+		Message: `service "gargleblaster" not found`,
+		Code:    "not found",
+	})
 	s.stub.CheckNoCalls(c)
 }
 

--- a/cmd/juju/service/unexpose_test.go
+++ b/cmd/juju/service/unexpose_test.go
@@ -4,12 +4,14 @@
 package service
 
 import (
+	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v6-unstable"
 
 	"github.com/juju/juju/cmd/juju/common"
 	jujutesting "github.com/juju/juju/juju/testing"
+	"github.com/juju/juju/rpc"
 	"github.com/juju/juju/testcharms"
 	"github.com/juju/juju/testing"
 )
@@ -56,7 +58,10 @@ func (s *UnexposeSuite) TestUnexpose(c *gc.C) {
 	s.assertExposed(c, "some-service-name", false)
 
 	err = runUnexpose(c, "nonexistent-service")
-	c.Assert(err, gc.ErrorMatches, `service "nonexistent-service" not found`)
+	c.Assert(errors.Cause(err), gc.DeepEquals, &rpc.RequestError{
+		Message: `service "nonexistent-service" not found`,
+		Code:    "not found",
+	})
 }
 
 func (s *UnexposeSuite) TestBlockUnexpose(c *gc.C) {

--- a/cmd/juju/service/upgradecharm_test.go
+++ b/cmd/juju/service/upgradecharm_test.go
@@ -12,6 +12,7 @@ import (
 	"path"
 	"path/filepath"
 
+	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
@@ -21,6 +22,7 @@ import (
 
 	"github.com/juju/juju/cmd/juju/common"
 	jujutesting "github.com/juju/juju/juju/testing"
+	"github.com/juju/juju/rpc"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/testcharms"
 	"github.com/juju/juju/testing"
@@ -90,7 +92,10 @@ func (s *UpgradeCharmErrorsSuite) TestWithInvalidRepository(c *gc.C) {
 
 func (s *UpgradeCharmErrorsSuite) TestInvalidService(c *gc.C) {
 	err := runUpgradeCharm(c, "phony")
-	c.Assert(err, gc.ErrorMatches, `service "phony" not found`)
+	c.Assert(errors.Cause(err), gc.DeepEquals, &rpc.RequestError{
+		Message: `service "phony" not found`,
+		Code:    "not found",
+	})
 }
 
 func (s *UpgradeCharmErrorsSuite) deployService(c *gc.C) {

--- a/featuretests/api_undertaker_test.go
+++ b/featuretests/api_undertaker_test.go
@@ -4,6 +4,7 @@
 package featuretests
 
 import (
+	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
@@ -12,6 +13,7 @@ import (
 	"github.com/juju/juju/api/undertaker"
 	"github.com/juju/juju/apiserver/params"
 	jujutesting "github.com/juju/juju/juju/testing"
+	"github.com/juju/juju/rpc"
 	"github.com/juju/juju/state"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/testing/factory"
@@ -32,7 +34,10 @@ func (s *undertakerSuite) TestPermDenied(c *gc.C) {
 		c.Assert(undertakerClient, gc.NotNil)
 
 		_, err := undertakerClient.ModelInfo()
-		c.Assert(err, gc.ErrorMatches, "permission denied")
+		c.Assert(errors.Cause(err), gc.DeepEquals, &rpc.RequestError{
+			Message: "permission denied",
+			Code:    "unauthorized access",
+		})
 	}
 }
 

--- a/featuretests/cloudimagemetadata_test.go
+++ b/featuretests/cloudimagemetadata_test.go
@@ -4,6 +4,7 @@
 package featuretests
 
 import (
+	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -11,6 +12,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/mongo"
+	"github.com/juju/juju/rpc"
 )
 
 type cloudImageMetadataSuite struct {
@@ -33,7 +35,10 @@ func (s *cloudImageMetadataSuite) TearDownTest(c *gc.C) {
 
 func (s *cloudImageMetadataSuite) TestSaveAndFindAndDeleteMetadata(c *gc.C) {
 	metadata, err := s.client.List("", "", nil, nil, "", "")
-	c.Assert(err, gc.ErrorMatches, "matching cloud image metadata not found")
+	c.Assert(errors.Cause(err), gc.DeepEquals, &rpc.RequestError{
+		Message: "matching cloud image metadata not found",
+		Code:    "not found",
+	})
 	c.Assert(metadata, gc.HasLen, 0)
 
 	//	check db too

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -145,18 +145,7 @@ func (call *Call) done() {
 // may be nil to indicate that any result should be discarded.
 func (conn *Conn) Call(req Request, params, response interface{}) error {
 	call := <-conn.Go(req, params, response, make(chan *Call, 1)).Done
-	switch call.Error.(type) {
-	case *RequestError:
-		// TODO(dfc) many callers assert the error.Error() value has a
-		// "request error: " prefix. Rather than encoding this text in
-		// the .Error() string value itself, use Annotate. This lets callers
-		// unwrap the error if needed to assert it by type or value or
-		// test its expected string value if required. The latter behaviour
-		// should be removed.
-		return errors.Annotate(call.Error, "request error")
-	default:
-		return errors.Trace(call.Error)
-	}
+	return errors.Trace(call.Error)
 }
 
 // Go invokes the request asynchronously.  It returns the Call structure representing
@@ -166,14 +155,13 @@ func (conn *Conn) Call(req Request, params, response interface{}) error {
 func (conn *Conn) Go(req Request, args, response interface{}, done chan *Call) *Call {
 	if done == nil {
 		done = make(chan *Call, 1)
-	} else {
-		// If caller passes done != nil, it must arrange that
-		// done has enough buffer for the number of simultaneous
-		// RPCs that will be using that channel.  If the channel
-		// is totally unbuffered, it's best not to run at all.
-		if cap(done) == 0 {
-			panic("github.com/juju/juju/rpc: done channel is unbuffered")
-		}
+	}
+	// If caller passes done != nil, it must arrange that
+	// done has enough buffer for the number of simultaneous
+	// RPCs that will be using that channel.  If the channel
+	// is totally unbuffered, it's best not to run at all.
+	if cap(done) == 0 {
+		panic("github.com/juju/juju/rpc: done channel is unbuffered")
 	}
 	call := &Call{
 		Request:  req,

--- a/rpc/rpc_test.go
+++ b/rpc/rpc_test.go
@@ -770,7 +770,7 @@ func (*rpcSuite) TestErrorCode(c *gc.C) {
 	client, srvDone, _, _ := newRPCClientServer(c, root, nil, false)
 	defer closeClient(c, client, srvDone)
 	err := client.Call(rpc.Request{"ErrorMethods", 0, "", "Call"}, nil, nil)
-	c.Assert(err, gc.ErrorMatches, `request error: message \(code\)`)
+	c.Assert(err, gc.ErrorMatches, `message \(code\)`)
 	c.Assert(errors.Cause(err).(rpc.ErrorCoder).ErrorCode(), gc.Equals, "code")
 }
 
@@ -952,7 +952,7 @@ func testBadCall(
 	if expectedErrCode != "" {
 		msg += " (" + expectedErrCode + ")"
 	}
-	c.Assert(err, gc.ErrorMatches, regexp.QuoteMeta("request error: "+msg))
+	c.Assert(err, gc.ErrorMatches, regexp.QuoteMeta(msg))
 
 	// Test that there was a notification for the client request.
 	c.Assert(clientNotifier.clientRequests, gc.HasLen, 1)
@@ -1026,10 +1026,10 @@ func (*rpcSuite) TestContinueAfterReadBodyError(c *gc.C) {
 		X: map[string]int{"hello": 65},
 	}
 	err := client.Call(rpc.Request{"SimpleMethods", 0, "a0", "SliceArg"}, arg0, &ret)
-	c.Assert(err, gc.ErrorMatches, `request error: json: cannot unmarshal object into Go value of type \[\]string`)
+	c.Assert(err, gc.ErrorMatches, `json: cannot unmarshal object into Go value of type \[\]string`)
 
 	err = client.Call(rpc.Request{"SimpleMethods", 0, "a0", "SliceArg"}, arg0, &ret)
-	c.Assert(err, gc.ErrorMatches, `request error: json: cannot unmarshal object into Go value of type \[\]string`)
+	c.Assert(err, gc.ErrorMatches, `json: cannot unmarshal object into Go value of type \[\]string`)
 
 	arg1 := struct {
 		X []string
@@ -1103,7 +1103,7 @@ func (*rpcSuite) TestServerRequestWhenNotServing(c *gc.C) {
 	defer closeClient(c, client, srvDone)
 	var r int64val
 	err := client.Call(rpc.Request{"CallbackMethods", 0, "", "Factorial"}, int64val{12}, &r)
-	c.Assert(err, gc.ErrorMatches, "request error: request error: no service")
+	c.Assert(err, gc.ErrorMatches, "no service")
 }
 
 func (*rpcSuite) TestChangeAPI(c *gc.C) {
@@ -1112,11 +1112,11 @@ func (*rpcSuite) TestChangeAPI(c *gc.C) {
 	defer closeClient(c, client, srvDone)
 	var s stringVal
 	err := client.Call(rpc.Request{"NewlyAvailable", 0, "", "NewMethod"}, nil, &s)
-	c.Assert(err, gc.ErrorMatches, `request error: unknown object type "NewlyAvailable" \(not implemented\)`)
+	c.Assert(err, gc.ErrorMatches, `unknown object type "NewlyAvailable" \(not implemented\)`)
 	err = client.Call(rpc.Request{"ChangeAPIMethods", 0, "", "ChangeAPI"}, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	err = client.Call(rpc.Request{"ChangeAPIMethods", 0, "", "ChangeAPI"}, nil, nil)
-	c.Assert(err, gc.ErrorMatches, `request error: unknown object type "ChangeAPIMethods" \(not implemented\)`)
+	c.Assert(err, gc.ErrorMatches, `unknown object type "ChangeAPIMethods" \(not implemented\)`)
 	err = client.Call(rpc.Request{"NewlyAvailable", 0, "", "NewMethod"}, nil, &s)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s, gc.Equals, stringVal{"new method result"})
@@ -1131,7 +1131,7 @@ func (*rpcSuite) TestChangeAPIToNil(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = client.Call(rpc.Request{"ChangeAPIMethods", 0, "", "RemoveAPI"}, nil, nil)
-	c.Assert(err, gc.ErrorMatches, "request error: no service")
+	c.Assert(err, gc.ErrorMatches, "no service")
 }
 
 func (*rpcSuite) TestChangeAPIWhileServingRequest(c *gc.C) {
@@ -1162,7 +1162,7 @@ func (*rpcSuite) TestChangeAPIWhileServingRequest(c *gc.C) {
 	done <- fmt.Errorf("an error")
 	select {
 	case r := <-result:
-		c.Assert(r, gc.ErrorMatches, "request error: transformed: an error")
+		c.Assert(r, gc.ErrorMatches, "transformed: an error")
 	case <-time.After(3 * time.Second):
 		c.Fatalf("timeout on channel read")
 	}

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -4,12 +4,12 @@
 package rpc
 
 import (
-	"fmt"
 	"io"
 	"reflect"
 	"sync"
 	"time"
 
+	"github.com/juju/errors"
 	"github.com/juju/loggo"
 
 	"github.com/juju/juju/rpc/rpcreflect"
@@ -527,7 +527,7 @@ func (conn *Conn) bindRequest(hdr *Header) (boundRequest, error) {
 	conn.mutex.Unlock()
 
 	if methodFinder == nil {
-		return boundRequest{}, fmt.Errorf("no service")
+		return boundRequest{}, errors.New("no service")
 	}
 	caller, err := methodFinder.FindMethod(
 		hdr.Request.Type, hdr.Request.Version, hdr.Request.Action)


### PR DESCRIPTION
Updates LP#1538583

api/apiclient.APICall was the sole caller of params.ClientError.
params.Client error would rewrite the error value iff it was
rpc.RequestError, claiming that it was leaking unnecessary information
to the caller, specfically the "request error: " prefix. In b4e2785
the error prefix was convered to an errors.Annotate wrapper removing
the requirement to convert the error type.

Now, by removing params.ClientError, we can also remove the
errors.Annotate wrapper as the _type of the error_ tells us what it is.

So, callers get

a. A nice annotated backtrace using errors.Trace
b. Access to the original *rpc.RequestError to inspect if they want.