### PR TITLE
cloud: add StorageEndpoint to Cloud/Region

### DIFF
--- a/cloud/clouds.go
+++ b/cloud/clouds.go
@@ -63,14 +63,23 @@ type Cloud struct {
 	// overridden by a region.
 	Endpoint string `yaml:"endpoint,omitempty"`
 
+	// StorageEndpoint is the default storage endpoint for the cloud
+	// regions, may be overridden by a region.
+	StorageEndpoint string `yaml:"storage-endpoint,omitempty"`
+
 	// Regions are the regions available in the cloud.
 	Regions map[string]Region `yaml:"regions,omitempty"`
 }
 
 // Region is a cloud region.
 type Region struct {
-	// Endpoint is the region's endpoint URL.
+	// Endpoint is the region's primary endpoint URL.
 	Endpoint string `yaml:"endpoint,omitempty"`
+
+	// StorageEndpoint is the region's storage endpoint URL.
+	// If the cloud/region does not have a storage-specific
+	// endpoint URL, this will be empty.
+	StorageEndpoint string `yaml:"storage-endpoint,omitempty"`
 }
 
 // CloudByName returns the cloud with the specified name.

--- a/cloud/fallback-public-cloud.yaml
+++ b/cloud/fallback-public-cloud.yaml
@@ -52,48 +52,68 @@ clouds:
     regions:
       Central US:
         endpoint: https://management.azure.com
+        storage-endpoint: https://core.windows.net
       East US:
         endpoint: https://management.azure.com
+        storage-endpoint: https://core.windows.net
       East US 2:
         endpoint: https://management.azure.com
+        storage-endpoint: https://core.windows.net
       North Central US:
         endpoint: https://management.azure.com
+        storage-endpoint: https://core.windows.net
       South Central US:
         endpoint: https://management.azure.com
+        storage-endpoint: https://core.windows.net
       West US:
         endpoint: https://management.azure.com
+        storage-endpoint: https://core.windows.net
       North Europe:
         endpoint: https://management.azure.com
+        storage-endpoint: https://core.windows.net
       West Europe:
         endpoint: https://management.azure.com
+        storage-endpoint: https://core.windows.net
       East Asia:
         endpoint: https://management.azure.com
+        storage-endpoint: https://core.windows.net
       Southeast Asia:
         endpoint: https://management.azure.com
+        storage-endpoint: https://core.windows.net
       Japan East:
         endpoint: https://management.azure.com
+        storage-endpoint: https://core.windows.net
       Japan West:
         endpoint: https://management.azure.com
+        storage-endpoint: https://core.windows.net
       Brazil South:
         endpoint: https://management.azure.com
+        storage-endpoint: https://core.windows.net
       Australia East:
         endpoint: https://management.azure.com
+        storage-endpoint: https://core.windows.net
       Australia Southeast:
         endpoint: https://management.azure.com
+        storage-endpoint: https://core.windows.net
       Central India:
         endpoint: https://management.azure.com
+        storage-endpoint: https://core.windows.net
       South India:
         endpoint: https://management.azure.com
+        storage-endpoint: https://core.windows.net
       West India:
         endpoint: https://management.azure.com
+        storage-endpoint: https://core.windows.net
   azure-china:
     type: azure
     auth-types: [ userpass ]
     regions:
       China East:
         endpoint: https://management.chinacloudapi.cn
+        storage-endpoint: https://core.chinacloudapi.cn
       China North:
         endpoint: https://management.chinacloudapi.cn
+        storage-endpoint: https://core.chinacloudapi.cn
   rackspace:
     type: openstack
     auth-types: [ access-key, userpass ]

--- a/cloud/fallback_public_cloud.go
+++ b/cloud/fallback_public_cloud.go
@@ -60,48 +60,68 @@ clouds:
     regions:
       Central US:
         endpoint: https://management.azure.com
+        storage-endpoint: https://core.windows.net
       East US:
         endpoint: https://management.azure.com
+        storage-endpoint: https://core.windows.net
       East US 2:
         endpoint: https://management.azure.com
+        storage-endpoint: https://core.windows.net
       North Central US:
         endpoint: https://management.azure.com
+        storage-endpoint: https://core.windows.net
       South Central US:
         endpoint: https://management.azure.com
+        storage-endpoint: https://core.windows.net
       West US:
         endpoint: https://management.azure.com
+        storage-endpoint: https://core.windows.net
       North Europe:
         endpoint: https://management.azure.com
+        storage-endpoint: https://core.windows.net
       West Europe:
         endpoint: https://management.azure.com
+        storage-endpoint: https://core.windows.net
       East Asia:
         endpoint: https://management.azure.com
+        storage-endpoint: https://core.windows.net
       Southeast Asia:
         endpoint: https://management.azure.com
+        storage-endpoint: https://core.windows.net
       Japan East:
         endpoint: https://management.azure.com
+        storage-endpoint: https://core.windows.net
       Japan West:
         endpoint: https://management.azure.com
+        storage-endpoint: https://core.windows.net
       Brazil South:
         endpoint: https://management.azure.com
+        storage-endpoint: https://core.windows.net
       Australia East:
         endpoint: https://management.azure.com
+        storage-endpoint: https://core.windows.net
       Australia Southeast:
         endpoint: https://management.azure.com
+        storage-endpoint: https://core.windows.net
       Central India:
         endpoint: https://management.azure.com
+        storage-endpoint: https://core.windows.net
       South India:
         endpoint: https://management.azure.com
+        storage-endpoint: https://core.windows.net
       West India:
         endpoint: https://management.azure.com
+        storage-endpoint: https://core.windows.net
   azure-china:
     type: azure
     auth-types: [ userpass ]
     regions:
       China East:
         endpoint: https://management.chinacloudapi.cn
+        storage-endpoint: https://core.chinacloudapi.cn
       China North:
         endpoint: https://management.chinacloudapi.cn
+        storage-endpoint: https://core.chinacloudapi.cn
   rackspace:
     type: openstack
     auth-types: [ access-key, userpass ]

--- a/cloud/personalclouds_test.go
+++ b/cloud/personalclouds_test.go
@@ -77,7 +77,18 @@ func (s *personalCloudSuite) assertPersonalClouds(c *gc.C, clouds map[string]clo
 			AuthTypes: []cloud.AuthType{"userpass", "access-key"},
 			Endpoint:  "http://homestack",
 			Regions: map[string]cloud.Region{
-				"london": cloud.Region{"http://london/1.0"},
+				"london": cloud.Region{Endpoint: "http://london/1.0"},
+			},
+		},
+		"azurestack": cloud.Cloud{
+			Type:            "azure",
+			AuthTypes:       []cloud.AuthType{"userpass"},
+			StorageEndpoint: "http://storage.azurestack.local",
+			Regions: map[string]cloud.Region{
+				"local": cloud.Region{
+					Endpoint:        "http://azurestack.local",
+					StorageEndpoint: "http://storage.azurestack.local",
+				},
 			},
 		},
 	})
@@ -93,6 +104,13 @@ clouds:
     regions:
       london:
         endpoint: http://london/1.0
+  azurestack:
+    type: azure
+    auth-types: [userpass]
+    storage-endpoint: http://storage.azurestack.local
+    regions:
+      local:
+        endpoint: http://azurestack.local
 `[1:]
 	err := ioutil.WriteFile(destPath, []byte(data), 0600)
 	c.Assert(err, jc.ErrorIsNil)

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -345,10 +345,11 @@ func (c *bootstrapCommand) Run(ctx *cmd.Context) (resultErr error) {
 	environ, err := environsPrepare(
 		modelcmd.BootstrapContext(ctx), store, controllerStore, c.ControllerName,
 		environs.PrepareForBootstrapParams{
-			Config:        cfg,
-			Credentials:   *credential,
-			CloudRegion:   regionName,
-			CloudEndpoint: region.Endpoint,
+			Config:               cfg,
+			Credentials:          *credential,
+			CloudRegion:          regionName,
+			CloudEndpoint:        region.Endpoint,
+			CloudStorageEndpoint: region.StorageEndpoint,
 		},
 	)
 	if err != nil {

--- a/cmd/plugins/juju-metadata/validateimagemetadata_test.go
+++ b/cmd/plugins/juju-metadata/validateimagemetadata_test.go
@@ -102,6 +102,7 @@ func cacheTestEnvConfig(c *gc.C) {
 		"default-series":            "raring",
 		"location":                  "West US",
 		"endpoint":                  "https://management.azure.com",
+		"storage-endpoint":          "https://core.windows.net",
 		"subscription-id":           "foo",
 		"application-id":            "bar",
 		"application-password":      "baz",

--- a/environs/interface.go
+++ b/environs/interface.go
@@ -67,9 +67,14 @@ type PrepareForBootstrapParams struct {
 	// regions.
 	CloudRegion string
 
-	// CloudEndpoint is the location of the API endpoint to use when
-	// communicating with the cloud.
+	// CloudEndpoint is the location of the primary API endpoint to
+	// use when communicating with the cloud.
 	CloudEndpoint string
+
+	// CloudStorageEndpoint is the location of the API endpoint to use
+	// when communicating with the cloud's storage service. This will
+	// be empty for clouds that have no cloud-specific API endpoint.
+	CloudStorageEndpoint string
 }
 
 // ProviderCredentials is an interface that an EnvironProvider implements

--- a/provider/azure/config_test.go
+++ b/provider/azure/config_test.go
@@ -104,7 +104,8 @@ func makeTestModelConfig(c *gc.C, extra ...testing.Attrs) *config.Config {
 		"application-password":      "opensezme",
 		"subscription-id":           fakeSubscriptionId,
 		"location":                  "westus",
-		"endpoint":                  "httsp://api.azurestack.local",
+		"endpoint":                  "https://api.azurestack.local",
+		"storage-endpoint":          "https://storage.azurestack.local",
 		"controller-resource-group": "arbitrary",
 		"agent-version":             "1.2.3",
 	}

--- a/provider/azure/environ.go
+++ b/provider/azure/environ.go
@@ -420,6 +420,7 @@ func (env *azureEnviron) StartInstance(args environs.StartInstanceParams) (*envi
 	vmExtensionClient := compute.VirtualMachineExtensionsClient{env.compute}
 	subscriptionId := env.config.subscriptionId
 	imageStream := env.config.ImageStream()
+	storageEndpoint := env.config.storageEndpoint
 	storageAccountName := env.config.storageAccount
 	instanceTypes, err := env.getInstanceTypesLocked()
 	if err != nil {
@@ -481,9 +482,9 @@ func (env *azureEnviron) StartInstance(args environs.StartInstanceParams) (*envi
 		args.DistributionGroup,
 		env.Instances,
 		apiPortPtr, internalNetworkSubnet, nsgID,
-		storageAccountName, networkClient,
-		vmClient, availabilitySetClient,
-		vmExtensionClient,
+		storageEndpoint, storageAccountName,
+		networkClient, vmClient,
+		availabilitySetClient, vmExtensionClient,
 	)
 	if err != nil {
 		logger.Errorf("creating instance failed, destroying: %v", err)
@@ -523,7 +524,7 @@ func createVirtualMachine(
 	instancesFunc func([]instance.Id) ([]instance.Instance, error),
 	apiPort *int,
 	internalNetworkSubnet *network.Subnet,
-	nsgID, storageAccountName string,
+	nsgID, storageEndpoint, storageAccountName string,
 	networkClient network.ManagementClient,
 	vmClient compute.VirtualMachinesClient,
 	availabilitySetClient compute.AvailabilitySetsClient,
@@ -532,7 +533,7 @@ func createVirtualMachine(
 
 	storageProfile, err := newStorageProfile(
 		vmName, instanceConfig.Series,
-		instanceSpec, location, storageAccountName,
+		instanceSpec, storageEndpoint, storageAccountName,
 	)
 	if err != nil {
 		return compute.VirtualMachine{}, errors.Annotate(err, "creating storage profile")
@@ -696,7 +697,7 @@ func newStorageProfile(
 	vmName string,
 	series string,
 	instanceSpec *instances.InstanceSpec,
-	location, storageAccountName string,
+	storageEndpoint, storageAccountName string,
 ) (*compute.StorageProfile, error) {
 	logger.Debugf("creating storage profile for %q", vmName)
 
@@ -709,7 +710,7 @@ func newStorageProfile(
 	sku := urnParts[2]
 	version := urnParts[3]
 
-	osDisksRoot := osDiskVhdRoot(location, storageAccountName)
+	osDisksRoot := osDiskVhdRoot(storageEndpoint, storageAccountName)
 	osDiskName := vmName
 	osDisk := &compute.OSDisk{
 		Name:         to.StringPtr(osDiskName),

--- a/provider/azure/environ_test.go
+++ b/provider/azure/environ_test.go
@@ -99,7 +99,7 @@ func (s *environSuite) SetUpTest(c *gc.C) {
 		Type: to.StringPtr("Standard_LRS"),
 		Properties: &storage.AccountProperties{
 			PrimaryEndpoints: &storage.Endpoints{
-				Blob: to.StringPtr(fmt.Sprintf("https://%s.blob.core.windows.net/", fakeStorageAccount)),
+				Blob: to.StringPtr(fmt.Sprintf("https://%s.blob.storage.azurestack.local/", fakeStorageAccount)),
 			},
 		},
 	}
@@ -241,7 +241,7 @@ func (s *environSuite) SetUpTest(c *gc.C) {
 					Caching:      compute.ReadWrite,
 					Vhd: &compute.VirtualHardDisk{
 						URI: to.StringPtr(fmt.Sprintf(
-							"https://%s.blob.core.windows.net/osvhds/machine-0.vhd",
+							"https://%s.blob.storage.azurestack.local/osvhds/machine-0.vhd",
 							fakeStorageAccount,
 						)),
 					},
@@ -306,10 +306,11 @@ func prepareForBootstrap(
 	c.Assert(err, jc.ErrorIsNil)
 	*sender = azuretesting.Senders{tokenRefreshSender()}
 	env, err := provider.PrepareForBootstrap(ctx, environs.PrepareForBootstrapParams{
-		Config:        cfg,
-		CloudRegion:   "westus",
-		CloudEndpoint: "https://management.azure.com",
-		Credentials:   fakeUserPassCredential(),
+		Config:               cfg,
+		CloudRegion:          "westus",
+		CloudEndpoint:        "https://management.azure.com",
+		CloudStorageEndpoint: "https://core.windows.net",
+		Credentials:          fakeUserPassCredential(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	return env

--- a/provider/azure/environprovider.go
+++ b/provider/azure/environprovider.go
@@ -111,8 +111,9 @@ func (prov *azureEnvironProvider) PrepareForBootstrap(ctx environs.BootstrapCont
 	}
 
 	attrs := map[string]interface{}{
-		configAttrLocation: args.CloudRegion,
-		configAttrEndpoint: args.CloudEndpoint,
+		configAttrLocation:        args.CloudRegion,
+		configAttrEndpoint:        args.CloudEndpoint,
+		configAttrStorageEndpoint: args.CloudStorageEndpoint,
 
 		// Record the UUID that will be used for the controller
 		// model, which contains shared resources.

--- a/provider/azure/environprovider_test.go
+++ b/provider/azure/environprovider_test.go
@@ -76,10 +76,11 @@ func (s *environProviderSuite) TestPrepareForBootstrap(c *gc.C) {
 
 	s.sender = azuretesting.Senders{tokenRefreshSender()}
 	env, err := s.provider.PrepareForBootstrap(ctx, environs.PrepareForBootstrapParams{
-		Config:        cfg,
-		CloudRegion:   "westus",
-		CloudEndpoint: "https://api.azurestack.local",
-		Credentials:   fakeUserPassCredential(),
+		Config:               cfg,
+		CloudRegion:          "westus",
+		CloudEndpoint:        "https://api.azurestack.local",
+		CloudStorageEndpoint: "https://storage.azurestack.local",
+		Credentials:          fakeUserPassCredential(),
 	})
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(env, gc.NotNil)

--- a/provider/azure/storage.go
+++ b/provider/azure/storage.go
@@ -183,7 +183,7 @@ func (v *azureVolumeSource) createVolume(
 		return nil, nil, errors.Annotate(err, "choosing LUN")
 	}
 
-	dataDisksRoot := dataDiskVhdRoot(v.env.config.location, v.env.config.storageAccount)
+	dataDisksRoot := dataDiskVhdRoot(v.env.config.storageEndpoint, v.env.config.storageAccount)
 	dataDiskName := p.Tag.String()
 	vhdURI := dataDisksRoot + dataDiskName + vhdExtension
 
@@ -399,7 +399,7 @@ func (v *azureVolumeSource) attachVolume(
 	p storage.VolumeAttachmentParams,
 ) (_ *storage.VolumeAttachment, updated bool, _ error) {
 
-	dataDisksRoot := dataDiskVhdRoot(v.env.config.location, v.env.config.storageAccount)
+	dataDisksRoot := dataDiskVhdRoot(v.env.config.storageEndpoint, v.env.config.storageAccount)
 	dataDiskName := p.VolumeId
 	vhdURI := dataDisksRoot + dataDiskName + vhdExtension
 
@@ -509,7 +509,7 @@ func (v *azureVolumeSource) detachVolume(
 	p storage.VolumeAttachmentParams,
 ) (updated bool) {
 
-	dataDisksRoot := dataDiskVhdRoot(v.env.config.location, v.env.config.storageAccount)
+	dataDisksRoot := dataDiskVhdRoot(v.env.config.storageEndpoint, v.env.config.storageAccount)
 	dataDiskName := p.VolumeId
 	vhdURI := dataDisksRoot + dataDiskName + vhdExtension
 
@@ -642,36 +642,24 @@ func gibToMib(g uint64) uint64 {
 	return g * 1024
 }
 
-// locationStorageEndpoint returns the hostname to supply to NewStorageClient
-// for the given location.
-func locationStorageEndpoint(location string) string {
-	// TODO(axw) we need a way of specifying the storage endpoint in
-	// clouds.yaml. The storage endpoint is not necessarily based on
-	// the resource manager endpoint.
-	if strings.Contains(location, "china") {
-		return "core.chinacloudapi.cn"
-	}
-	return "core.windows.net"
-}
-
 // osDiskVhdRoot returns the URL to the blob container in which we store the
 // VHDs for OS disks for the environment.
-func osDiskVhdRoot(location, storageAccountName string) string {
-	return blobContainerURL(location, storageAccountName, osDiskVHDContainer)
+func osDiskVhdRoot(storageEndpoint, storageAccountName string) string {
+	return blobContainerURL(storageEndpoint, storageAccountName, osDiskVHDContainer)
 }
 
 // dataDiskVhdRoot returns the URL to the blob container in which we store the
 // VHDs for data disks for the environment.
-func dataDiskVhdRoot(location, storageAccountName string) string {
-	return blobContainerURL(location, storageAccountName, dataDiskVHDContainer)
+func dataDiskVhdRoot(storageEndpoint, storageAccountName string) string {
+	return blobContainerURL(storageEndpoint, storageAccountName, dataDiskVHDContainer)
 }
 
 // blobContainer returns the URL to the named blob container.
-func blobContainerURL(location, storageAccountName, container string) string {
+func blobContainerURL(storageEndpoint, storageAccountName, container string) string {
 	return fmt.Sprintf(
 		"https://%s.blob.%s/%s/",
 		storageAccountName,
-		locationStorageEndpoint(location),
+		storageEndpoint,
 		container,
 	)
 }
@@ -697,7 +685,7 @@ func getStorageClient(
 ) (internalazurestorage.Client, error) {
 	storageAccountName := cfg.storageAccount
 	storageAccountKey := cfg.storageAccountKey
-	storageEndpoint := locationStorageEndpoint(cfg.location)
+	storageEndpoint := cfg.storageEndpoint
 	const useHTTPS = true
 	return newClient(
 		storageAccountName, storageAccountKey,

--- a/provider/azure/storage_test.go
+++ b/provider/azure/storage_test.go
@@ -196,7 +196,7 @@ func (s *storageSuite) TestCreateVolumes(c *gc.C) {
 		DiskSizeGB: to.IntPtr(1),
 		Name:       to.StringPtr("volume-0"),
 		Vhd: &compute.VirtualHardDisk{URI: to.StringPtr(fmt.Sprintf(
-			"https://%s.blob.core.windows.net/datavhds/volume-0.vhd",
+			"https://%s.blob.storage.azurestack.local/datavhds/volume-0.vhd",
 			fakeStorageAccount,
 		))},
 		Caching:      compute.ReadWrite,
@@ -206,7 +206,7 @@ func (s *storageSuite) TestCreateVolumes(c *gc.C) {
 		DiskSizeGB: to.IntPtr(1),
 		Name:       to.StringPtr("volume-2"),
 		Vhd: &compute.VirtualHardDisk{URI: to.StringPtr(fmt.Sprintf(
-			"https://%s.blob.core.windows.net/datavhds/volume-2.vhd",
+			"https://%s.blob.storage.azurestack.local/datavhds/volume-2.vhd",
 			fakeStorageAccount,
 		))},
 		Caching:      compute.ReadWrite,
@@ -220,7 +220,7 @@ func (s *storageSuite) TestCreateVolumes(c *gc.C) {
 		DiskSizeGB: to.IntPtr(2),
 		Name:       to.StringPtr("volume-1"),
 		Vhd: &compute.VirtualHardDisk{URI: to.StringPtr(fmt.Sprintf(
-			"https://%s.blob.core.windows.net/datavhds/volume-1.vhd",
+			"https://%s.blob.storage.azurestack.local/datavhds/volume-1.vhd",
 			fakeStorageAccount,
 		))},
 		Caching:      compute.ReadWrite,
@@ -259,7 +259,7 @@ func (s *storageSuite) TestListVolumes(c *gc.C) {
 	s.storageClient.CheckCallNames(c, "NewClient", "ListBlobs")
 	s.storageClient.CheckCall(
 		c, 0, "NewClient", fakeStorageAccount, fakeStorageAccountKey,
-		"core.windows.net", azurestorage.DefaultAPIVersion, true,
+		"storage.azurestack.local", azurestorage.DefaultAPIVersion, true,
 	)
 	s.storageClient.CheckCall(c, 1, "ListBlobs", "datavhds", azurestorage.ListBlobsParameters{})
 	c.Assert(volumeIds, jc.DeepEquals, []string{"volume-1", "volume-0"})
@@ -302,7 +302,7 @@ func (s *storageSuite) TestDescribeVolumes(c *gc.C) {
 	s.storageClient.CheckCallNames(c, "NewClient", "ListBlobs")
 	s.storageClient.CheckCall(
 		c, 0, "NewClient", fakeStorageAccount, fakeStorageAccountKey,
-		"core.windows.net", azurestorage.DefaultAPIVersion, true,
+		"storage.azurestack.local", azurestorage.DefaultAPIVersion, true,
 	)
 	c.Assert(results, gc.HasLen, 4)
 	c.Assert(results[:3], jc.DeepEquals, []storage.DescribeVolumesResult{{
@@ -346,7 +346,7 @@ func (s *storageSuite) TestAttachVolumes(c *gc.C) {
 		Name: to.StringPtr("volume-1"),
 		Vhd: &compute.VirtualHardDisk{
 			URI: to.StringPtr(fmt.Sprintf(
-				"https://%s.blob.core.windows.net/datavhds/volume-1.vhd",
+				"https://%s.blob.storage.azurestack.local/datavhds/volume-1.vhd",
 				fakeStorageAccount,
 			)),
 		},
@@ -358,7 +358,7 @@ func (s *storageSuite) TestAttachVolumes(c *gc.C) {
 		machine2DataDisks[i].Name = to.StringPtr(fmt.Sprintf("volume-%d", i))
 		machine2DataDisks[i].Vhd = &compute.VirtualHardDisk{
 			URI: to.StringPtr(fmt.Sprintf(
-				"https://%s.blob.core.windows.net/datavhds/volume-%d.vhd",
+				"https://%s.blob.storage.azurestack.local/datavhds/volume-%d.vhd",
 				fakeStorageAccount, i,
 			)),
 		}
@@ -448,7 +448,7 @@ func (s *storageSuite) TestAttachVolumes(c *gc.C) {
 		Lun:  to.IntPtr(0),
 		Name: to.StringPtr("volume-0"),
 		Vhd: &compute.VirtualHardDisk{URI: to.StringPtr(fmt.Sprintf(
-			"https://%s.blob.core.windows.net/datavhds/volume-0.vhd",
+			"https://%s.blob.storage.azurestack.local/datavhds/volume-0.vhd",
 			fakeStorageAccount,
 		))},
 		Caching:      compute.ReadWrite,
@@ -457,7 +457,7 @@ func (s *storageSuite) TestAttachVolumes(c *gc.C) {
 		Lun:  to.IntPtr(1),
 		Name: to.StringPtr("volume-2"),
 		Vhd: &compute.VirtualHardDisk{URI: to.StringPtr(fmt.Sprintf(
-			"https://%s.blob.core.windows.net/datavhds/volume-2.vhd",
+			"https://%s.blob.storage.azurestack.local/datavhds/volume-2.vhd",
 			fakeStorageAccount,
 		))},
 		Caching:      compute.ReadWrite,
@@ -474,7 +474,7 @@ func (s *storageSuite) TestDetachVolumes(c *gc.C) {
 		Name: to.StringPtr("volume-0"),
 		Vhd: &compute.VirtualHardDisk{
 			URI: to.StringPtr(fmt.Sprintf(
-				"https://%s.blob.core.windows.net/datavhds/volume-0.vhd",
+				"https://%s.blob.storage.azurestack.local/datavhds/volume-0.vhd",
 				fakeStorageAccount,
 			)),
 		},
@@ -483,7 +483,7 @@ func (s *storageSuite) TestDetachVolumes(c *gc.C) {
 		Name: to.StringPtr("volume-1"),
 		Vhd: &compute.VirtualHardDisk{
 			URI: to.StringPtr(fmt.Sprintf(
-				"https://%s.blob.core.windows.net/datavhds/volume-1.vhd",
+				"https://%s.blob.storage.azurestack.local/datavhds/volume-1.vhd",
 				fakeStorageAccount,
 			)),
 		},
@@ -492,7 +492,7 @@ func (s *storageSuite) TestDetachVolumes(c *gc.C) {
 		Name: to.StringPtr("volume-2"),
 		Vhd: &compute.VirtualHardDisk{
 			URI: to.StringPtr(fmt.Sprintf(
-				"https://%s.blob.core.windows.net/datavhds/volume-2.vhd",
+				"https://%s.blob.storage.azurestack.local/datavhds/volume-2.vhd",
 				fakeStorageAccount,
 			)),
 		},

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -98,7 +98,11 @@ func (EnvironProvider) DetectRegions() (map[string]cloud.Region, error) {
 	if creds.URL == "" {
 		return nil, errors.NewNotFound(nil, "OS_AUTH_URL environment variable not set")
 	}
-	return map[string]cloud.Region{creds.Region: {creds.URL}}, nil
+	return map[string]cloud.Region{
+		creds.Region: {
+			Endpoint: creds.URL,
+		},
+	}, nil
 }
 
 // PrepareForCreateEnvironment is specified in the EnvironProvider interface.

--- a/provider/openstack/provider_test.go
+++ b/provider/openstack/provider_test.go
@@ -369,7 +369,7 @@ func (s *localTests) TestDetectRegions(c *gc.C) {
 	regions, err := s.detectRegions(c)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(regions, jc.DeepEquals, map[string]cloud.Region{
-		"oceania": {"http://keystone.internal"},
+		"oceania": {Endpoint: "http://keystone.internal"},
 	})
 }
 


### PR DESCRIPTION
Add storage-endpoint to the cloud definition, which
is needed by Azure. Azure has separate endpoints for
storage and everything else, and you can't derive
one from the other.

Also updated the azure cloud definition in
fallback-public-cloud.yaml, and updated the Azure
provider to use the new field. In the YAML file
the endpoint is specified as a URL for consistency,
despite the Azure code only needing the host name
to use as a domain-name suffix.

(Review request: http://reviews.vapour.ws/r/3806/)