### PR TITLE
rpc: use errors.Annotate

### DIFF
--- a/apiserver/params/apierror.go
+++ b/apiserver/params/apierror.go
@@ -100,17 +100,18 @@ func ErrCode(err error) string {
 // ClientError maps errors returned from an RPC call into local errors with
 // appropriate values.
 func ClientError(err error) error {
-	rerr, ok := err.(*rpc.RequestError)
-	if !ok {
+	switch err := errors.Cause(err).(type) {
+	case *rpc.RequestError:
+		// We use our own error type rather than rpc.ServerError
+		// because we don't want the code or the "server error" prefix
+		// within the error message. Also, it's best not to make clients
+		// know that we're using the rpc package.
+		return &Error{
+			Message: err.Message,
+			Code:    err.Code,
+		}
+	default:
 		return err
-	}
-	// We use our own error type rather than rpc.ServerError
-	// because we don't want the code or the "server error" prefix
-	// within the error message. Also, it's best not to make clients
-	// know that we're using the rpc package.
-	return &Error{
-		Message: rerr.Message,
-		Code:    rerr.Code,
 	}
 }
 


### PR DESCRIPTION
Use errors.Annotate to include the "request error: " boilerplate that
other code (almost always tests) expects. This lets callers use
errors.Cause to unwrap the error to recover the *rpc.RequestError type
without having to restort to string inspection of the .Error() value.

(Review request: http://reviews.vapour.ws/r/3809/)