### PR TITLE
jujuclient: add AccountStore

### DIFF
--- a/jujuclient/accounts_test.go
+++ b/jujuclient/accounts_test.go
@@ -1,0 +1,186 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package jujuclient_test
+
+import (
+	"os"
+
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/jujuclient"
+	"github.com/juju/juju/testing"
+)
+
+type AccountsSuite struct {
+	testing.FakeJujuXDGDataHomeSuite
+	store jujuclient.AccountStore
+}
+
+var _ = gc.Suite(&AccountsSuite{})
+
+func (s *AccountsSuite) SetUpTest(c *gc.C) {
+	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
+	s.store = jujuclient.NewFileClientStore()
+	writeTestAccountsFile(c)
+}
+
+func (s *AccountsSuite) TestAccountByNameNoFile(c *gc.C) {
+	err := os.Remove(jujuclient.JujuAccountsPath())
+	c.Assert(err, jc.ErrorIsNil)
+	details, err := s.store.AccountByName("not-found", "admin@local")
+	c.Assert(err, gc.ErrorMatches, "controller not-found not found")
+	c.Assert(details, gc.IsNil)
+}
+
+func (s *AccountsSuite) TestAccountByNameControllerNotFound(c *gc.C) {
+	details, err := s.store.AccountByName("not-found", "admin@local")
+	c.Assert(err, gc.ErrorMatches, "controller not-found not found")
+	c.Assert(details, gc.IsNil)
+}
+
+func (s *AccountsSuite) TestAccountByNameAccountNotFound(c *gc.C) {
+	details, err := s.store.AccountByName("kontroll", "admin@nowhere")
+	c.Assert(err, gc.ErrorMatches, "account kontroll:admin@nowhere not found")
+	c.Assert(details, gc.IsNil)
+}
+
+func (s *AccountsSuite) TestAccountByName(c *gc.C) {
+	details, err := s.store.AccountByName("kontroll", "admin@local")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(details, gc.NotNil)
+	c.Assert(*details, jc.DeepEquals, testControllerAccounts["kontroll"].Accounts["admin@local"])
+}
+
+func (s *AccountsSuite) TestAllAccountsNoFile(c *gc.C) {
+	err := os.Remove(jujuclient.JujuAccountsPath())
+	c.Assert(err, jc.ErrorIsNil)
+	accounts, err := s.store.AllAccounts("not-found")
+	c.Assert(err, gc.ErrorMatches, "accounts for controller not-found not found")
+	c.Assert(accounts, gc.HasLen, 0)
+}
+
+func (s *AccountsSuite) TestAllAccounts(c *gc.C) {
+	accounts, err := s.store.AllAccounts("kontroll")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(accounts, jc.DeepEquals, testControllerAccounts["kontroll"].Accounts)
+}
+
+func (s *AccountsSuite) TestCurrentAccount(c *gc.C) {
+	current, err := s.store.CurrentAccount("kontroll")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(current, gc.Equals, "admin@local")
+}
+
+func (s *AccountsSuite) TestCurrentAccountNotSet(c *gc.C) {
+	_, err := s.store.CurrentAccount("ctrl")
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+}
+
+func (s *AccountsSuite) TestCurrentAccountControllerNotFound(c *gc.C) {
+	_, err := s.store.CurrentAccount("not-found")
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+}
+
+func (s *AccountsSuite) TestSetCurrentAccountControllerNotFound(c *gc.C) {
+	err := s.store.SetCurrentAccount("not-found", "admin@local")
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+}
+
+func (s *AccountsSuite) TestSetCurrentAccountAccountNotFound(c *gc.C) {
+	err := s.store.SetCurrentAccount("kontroll", "admin@nowhere")
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+}
+
+func (s *AccountsSuite) TestSetCurrentAccount(c *gc.C) {
+	err := s.store.SetCurrentAccount("kontroll", "admin@local")
+	c.Assert(err, jc.ErrorIsNil)
+	accounts, err := jujuclient.ReadAccountsFile(jujuclient.JujuAccountsPath())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(accounts["kontroll"].CurrentAccount, gc.Equals, "admin@local")
+}
+
+func (s *AccountsSuite) TestUpdateAccountNewController(c *gc.C) {
+	testAccountDetails := jujuclient.AccountDetails{User: "admin@local"}
+	err := s.store.UpdateAccount("new-controller", "admin@local", testAccountDetails)
+	c.Assert(err, jc.ErrorIsNil)
+	accounts, err := s.store.AllAccounts("new-controller")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(accounts, jc.DeepEquals, map[string]jujuclient.AccountDetails{
+		"admin@local": testAccountDetails,
+	})
+}
+
+func (s *AccountsSuite) TestUpdateAccountExistingControllerNewAccount(c *gc.C) {
+	testAccountDetails := jujuclient.AccountDetails{User: "bob@environs"}
+	err := s.store.UpdateAccount("kontroll", "bob@environs", testAccountDetails)
+	c.Assert(err, jc.ErrorIsNil)
+	accounts, err := s.store.AllAccounts("kontroll")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(accounts, jc.DeepEquals, map[string]jujuclient.AccountDetails{
+		"admin@local":  kontrollAdminAccountDetails,
+		"bob@local":    kontrollBobLocalAccountDetails,
+		"bob@remote":   kontrollBobRemoteAccountDetails,
+		"bob@environs": testAccountDetails,
+	})
+}
+
+func (s *AccountsSuite) TestUpdateAccountOverwrites(c *gc.C) {
+	testAccountDetails := jujuclient.AccountDetails{
+		User:     "admin@local",
+		Password: "fnord",
+	}
+	for i := 0; i < 2; i++ {
+		// Twice so we exercise the code path of updating with
+		// identical details.
+		err := s.store.UpdateAccount("kontroll", "admin@local", testAccountDetails)
+		c.Assert(err, jc.ErrorIsNil)
+		details, err := s.store.AccountByName("kontroll", "admin@local")
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(*details, jc.DeepEquals, testAccountDetails)
+	}
+}
+
+func (s *AccountsSuite) TestRemoveAccountNoFile(c *gc.C) {
+	err := os.Remove(jujuclient.JujuAccountsPath())
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.store.RemoveAccount("not-found", "admin@nowhere")
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+}
+
+func (s *AccountsSuite) TestRemoveAccountControllerNotFound(c *gc.C) {
+	err := s.store.RemoveAccount("not-found", "admin@nowhere")
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+}
+
+func (s *AccountsSuite) TestRemoveAccountNotFound(c *gc.C) {
+	err := s.store.RemoveAccount("kontroll", "admin@nowhere")
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+}
+
+func (s *AccountsSuite) TestRemoveAccount(c *gc.C) {
+	err := s.store.RemoveAccount("kontroll", "admin@local")
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = s.store.AccountByName("kontroll", "admin@local")
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+}
+
+func (s *AccountsSuite) TestRemoveControllerRemovesaccounts(c *gc.C) {
+	store := jujuclient.NewFileClientStore()
+	err := store.RemoveController("kontroll")
+	c.Assert(err, jc.ErrorIsNil)
+
+	accounts, err := jujuclient.ReadAccountsFile(jujuclient.JujuAccountsPath())
+	c.Assert(err, jc.ErrorIsNil)
+	_, ok := accounts["kontroll"]
+	c.Assert(ok, jc.IsFalse) // kontroll accounts are removed
+}
+
+func (s *AccountsSuite) accountDetails(c *gc.C, controller, account string) jujuclient.AccountDetails {
+	details, err := s.store.AccountByName(controller, account)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(details, gc.IsNil)
+	return *details
+}

--- a/jujuclient/accountsfile.go
+++ b/jujuclient/accountsfile.go
@@ -1,0 +1,66 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package jujuclient
+
+import (
+	"io/ioutil"
+	"os"
+
+	"github.com/juju/errors"
+	"gopkg.in/yaml.v2"
+
+	"github.com/juju/juju/juju/osenv"
+)
+
+// JujuAccountsPath is the location where accounts information is
+// expected to be found.
+func JujuAccountsPath() string {
+	return osenv.JujuXDGDataHomePath("accounts.yaml")
+}
+
+// ReadAccountsFile loads all accounts defined in a given file.
+// If the file is not found, it is not an error.
+func ReadAccountsFile(file string) (map[string]*ControllerAccounts, error) {
+	data, err := ioutil.ReadFile(file)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	accounts, err := ParseAccounts(data)
+	if err != nil {
+		return nil, err
+	}
+	return accounts, nil
+}
+
+// WriteAccountsFile marshals to YAML details of the given accounts
+// and writes it to the accounts file.
+func WriteAccountsFile(controllerAccounts map[string]*ControllerAccounts) error {
+	data, err := yaml.Marshal(accountsCollection{controllerAccounts})
+	if err != nil {
+		return errors.Annotate(err, "cannot marshal accounts")
+	}
+	return ioutil.WriteFile(JujuAccountsPath(), data, os.FileMode(0600))
+}
+
+// ParseAccounts parses the given YAML bytes into accounts metadata.
+func ParseAccounts(data []byte) (map[string]*ControllerAccounts, error) {
+	var result accountsCollection
+	err := yaml.Unmarshal(data, &result)
+	if err != nil {
+		return nil, errors.Annotate(err, "cannot unmarshal accounts")
+	}
+	return result.ControllerAccounts, nil
+}
+
+type accountsCollection struct {
+	ControllerAccounts map[string]*ControllerAccounts `yaml:"controllers"`
+}
+
+type ControllerAccounts struct {
+	Accounts       map[string]AccountDetails `yaml:"accounts"`
+	CurrentAccount string                    `yaml:"current-account,omitempty"`
+}

--- a/jujuclient/accountsfile.go
+++ b/jujuclient/accountsfile.go
@@ -60,7 +60,11 @@ type accountsCollection struct {
 	ControllerAccounts map[string]*ControllerAccounts `yaml:"controllers"`
 }
 
+// ControllerAccounts stores per-controller account information.
 type ControllerAccounts struct {
-	Accounts       map[string]AccountDetails `yaml:"accounts"`
-	CurrentAccount string                    `yaml:"current-account,omitempty"`
+	// Accounts is the collection of accounts for the controller.
+	Accounts map[string]AccountDetails `yaml:"accounts"`
+
+	// CurrentAccount is the name of the active account for the controller.
+	CurrentAccount string `yaml:"current-account,omitempty"`
 }

--- a/jujuclient/accountsfile_test.go
+++ b/jujuclient/accountsfile_test.go
@@ -1,0 +1,117 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package jujuclient_test
+
+import (
+	"io/ioutil"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/juju/osenv"
+	"github.com/juju/juju/jujuclient"
+	"github.com/juju/juju/testing"
+)
+
+type AccountsFileSuite struct {
+	testing.FakeJujuXDGDataHomeSuite
+}
+
+var _ = gc.Suite(&AccountsFileSuite{})
+
+const testAccountsYAML = `
+controllers:
+  ctrl:
+    accounts:
+      admin@local:
+        user: admin@local
+        password: hunter2
+  kontroll:
+    accounts:
+      admin@local:
+        user: admin@local
+        password: hunter2
+      bob@local:
+        user: bob@local
+        password: huntert00
+      bob@remote:
+        user: bob@remote
+    current-account: admin@local
+`
+
+var testControllerAccounts = map[string]*jujuclient.ControllerAccounts{
+	"kontroll": {
+		Accounts: map[string]jujuclient.AccountDetails{
+			"admin@local": kontrollAdminAccountDetails,
+			"bob@local":   kontrollBobLocalAccountDetails,
+			"bob@remote":  kontrollBobRemoteAccountDetails,
+		},
+		CurrentAccount: "admin@local",
+	},
+	"ctrl": {
+		Accounts: map[string]jujuclient.AccountDetails{
+			"admin@local": ctrlAdminAccountDetails,
+		},
+	},
+}
+
+var (
+	kontrollAdminAccountDetails = jujuclient.AccountDetails{
+		User:     "admin@local",
+		Password: "hunter2",
+	}
+	kontrollBobLocalAccountDetails = jujuclient.AccountDetails{
+		User:     "bob@local",
+		Password: "huntert00",
+	}
+	kontrollBobRemoteAccountDetails = jujuclient.AccountDetails{
+		User: "bob@remote",
+	}
+	ctrlAdminAccountDetails = jujuclient.AccountDetails{
+		User:     "admin@local",
+		Password: "hunter2",
+	}
+)
+
+func (s *AccountsFileSuite) TestWriteFile(c *gc.C) {
+	writeTestAccountsFile(c)
+	data, err := ioutil.ReadFile(osenv.JujuXDGDataHomePath("accounts.yaml"))
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(string(data), gc.Equals, testAccountsYAML[1:])
+}
+
+func (s *AccountsFileSuite) TestReadNoFile(c *gc.C) {
+	accounts, err := jujuclient.ReadAccountsFile("nowhere.yaml")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(accounts, gc.IsNil)
+}
+
+func (s *AccountsFileSuite) TestReadEmptyFile(c *gc.C) {
+	err := ioutil.WriteFile(osenv.JujuXDGDataHomePath("accounts.yaml"), []byte(""), 0600)
+	c.Assert(err, jc.ErrorIsNil)
+	accounts, err := jujuclient.ReadAccountsFile(jujuclient.JujuAccountsPath())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(accounts, gc.HasLen, 0)
+}
+
+func writeTestAccountsFile(c *gc.C) {
+	err := jujuclient.WriteAccountsFile(testControllerAccounts)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *AccountsFileSuite) TestParseAccounts(c *gc.C) {
+	accounts, err := jujuclient.ParseAccounts([]byte(testAccountsYAML))
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(accounts, jc.DeepEquals, testControllerAccounts)
+}
+
+func (s *AccountsFileSuite) TestParseAccountMetadataError(c *gc.C) {
+	accounts, err := jujuclient.ParseAccounts([]byte("fail me now"))
+	c.Assert(err, gc.ErrorMatches,
+		"cannot unmarshal accounts: yaml: unmarshal errors:"+
+			"\n  line 1: cannot unmarshal !!str `fail me...` into "+
+			"jujuclient.accountsCollection",
+	)
+	c.Assert(accounts, gc.IsNil)
+}

--- a/jujuclient/interface.go
+++ b/jujuclient/interface.go
@@ -25,6 +25,15 @@ type ModelDetails struct {
 	ModelUUID string `yaml:"uuid"`
 }
 
+// AccountDetails holds details of an account.
+type AccountDetails struct {
+	// User is the username for the account.
+	User string `yaml:"user"`
+
+	// Password is the password for the account.
+	Password string `yaml:"password,omitempty"`
+}
+
 // ControllerUpdater stores controller details.
 type ControllerUpdater interface {
 	// UpdateController adds the given controller to the controller
@@ -98,6 +107,51 @@ type ModelGetter interface {
 	ModelByName(controllerName, modelName string) (*ModelDetails, error)
 }
 
+// AccountUpdater stores account details.
+type AccountUpdater interface {
+	// UpdateAccount adds the given account to the account collection.
+	//
+	// If the account does not already exist, it will be added.
+	// Otherwise, it will be overwritten with the new details.
+	UpdateAccount(controllerName, accountName string, details AccountDetails) error
+
+	// SetCurrentAccount sets the name of the current account for
+	// the specified controller. If there exists no account with
+	// the specified names, an error satisfing errors.IsNotFound
+	// will be returned.
+	SetCurrentAccount(controllerName, accountName string) error
+}
+
+// AccountRemover removes accounts.
+type AccountRemover interface {
+	// RemoveAccount removes the account with the given controller and account
+	// names from the accounts collection. If there is no account with the
+	// specified names, an errors satisfying errors.IsNotFound will be
+	// returned.
+	RemoveAccount(controllerName, accountName string) error
+}
+
+// AccountGetter gets accounts.
+type AccountGetter interface {
+	// AllAccounts gets all accounts for the specified controller.
+	//
+	// If there is no controller with the specified name, or
+	// no accounts cached for the controller, an error satisfying
+	// errors.IsNotFound will be returned.
+	AllAccounts(controllerName string) (map[string]AccountDetails, error)
+
+	// CurrentAccount returns the name of the current account for
+	// the specified controller. If there is no current account
+	// for the controller, an error satisfying errors.IsNotFound
+	// is returned.
+	CurrentAccount(controllerName string) (string, error)
+
+	// AccountByName returns the account with the specified controller
+	// and account names. If there exists no account with the specified
+	// names, an error satisfying errors.IsNotFound will be returned.
+	AccountByName(controllerName, accountName string) (*AccountDetails, error)
+}
+
 // ControllerStore is an amalgamation of ControllerUpdater, ControllerRemover,
 // and ControllerGetter.
 type ControllerStore interface {
@@ -113,8 +167,16 @@ type ModelStore interface {
 	ModelGetter
 }
 
-// ClientStore is an amalgamation of ControllerStore and ModelStore.
+// AccountStore is an amalgamation of AccountUpdater, AccountRemover, and AccountGetter.
+type AccountStore interface {
+	AccountUpdater
+	AccountRemover
+	AccountGetter
+}
+
+// ClientStore is an amalgamation of AccountStore, ControllerStore, and ModelStore.
 type ClientStore interface {
+	AccountStore
 	ControllerStore
 	ModelStore
 }

--- a/jujuclient/modelsfile.go
+++ b/jujuclient/modelsfile.go
@@ -61,7 +61,13 @@ type modelsCollection struct {
 	ControllerModels map[string]*ControllerModels `yaml:"controllers"`
 }
 
+// ControllerAccounts stores per-controller model information.
 type ControllerModels struct {
-	Models       map[string]ModelDetails `yaml:"models"`
-	CurrentModel string                  `yaml:"current-model,omitempty"`
+	// Models is the collection of models for the controller. This should
+	// be treated as a cache only, and not the complete set of models for
+	// the controller.
+	Models map[string]ModelDetails `yaml:"models"`
+
+	// CurrentModel is the name of the active model for the controller.
+	CurrentModel string `yaml:"current-model,omitempty"`
 }


### PR DESCRIPTION
Basically just a find/replace of Model with
Account.

Accounts are currently keyed by user name,
but we also store the user name in the account
details in case we want to separate the name
of the account from the user.

(Review request: http://reviews.vapour.ws/r/3822/)