### PR TITLE
cloud: support reading credential field from file

### DIFF
--- a/cloud/credentials.go
+++ b/cloud/credentials.go
@@ -128,13 +128,15 @@ func (s CredentialSchema) Finalize(
 			newAttrs[name] = resultMap[name].(string)
 			continue
 		}
-		if _, ok := resultMap[name]; ok {
+		if fieldVal, ok := resultMap[name]; ok {
 			if _, ok := resultMap[field.FileAttr]; ok {
 				return nil, errors.NotValidf(
 					"specifying both %q and %q",
 					name, field.FileAttr,
 				)
 			}
+			newAttrs[name] = fieldVal.(string)
+			continue
 		}
 		fieldVal, ok := resultMap[field.FileAttr]
 		if !ok {

--- a/cloud/credentials.go
+++ b/cloud/credentials.go
@@ -4,6 +4,7 @@
 package cloud
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"strings"
@@ -75,32 +76,83 @@ func NewEmptyCredential() Credential {
 // are specific to cloud providers.
 type CredentialSchema map[string]CredentialAttr
 
-// ValidateCredential validates a credential against the provided credential
-// schemas. If there is no schema with the matching auth-type, and error
-// satisfying errors.IsNotSupported will be returned.
-func ValidateCredential(credential Credential, schemas map[AuthType]CredentialSchema) error {
+// FinalizeCredential finalizes a credential by matching it with one of the
+// provided credential schemas, and reading any file attributes into their
+// corresponding non-file attributes. This will also validate the credential.
+//
+// If there is no schema with the matching auth-type, and error satisfying
+// errors.IsNotSupported will be returned.
+func FinalizeCredential(
+	credential Credential,
+	schemas map[AuthType]CredentialSchema,
+	readFile func(string) ([]byte, error),
+) (*Credential, error) {
 	schema, ok := schemas[credential.authType]
 	if !ok {
-		return errors.NotSupportedf("auth-type %q", credential.authType)
+		return nil, errors.NotSupportedf("auth-type %q", credential.authType)
 	}
-	return schema.Validate(credential.attributes)
+	attrs, err := schema.Finalize(credential.attributes, readFile)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return &Credential{credential.authType, attrs}, nil
 }
 
-// Validate validates the given credential attributes against the credential
-// schema.
-func (s CredentialSchema) Validate(attrs map[string]string) error {
+// Finalize finalizes the given credential attributes against the credential
+// schema. If the attributes are invalid, Finalize will return an error.
+//
+// An updated attribute map will be returned, having any file attributes
+// deleted, and replaced by their non-file counterparts with the values set
+// to the contents of the files.
+func (s CredentialSchema) Finalize(
+	attrs map[string]string,
+	readFile func(string) ([]byte, error),
+) (map[string]string, error) {
 	checker, err := s.schemaChecker()
 	if err != nil {
-		return errors.Trace(err)
+		return nil, errors.Trace(err)
 	}
 	m := make(map[string]interface{})
 	for k, v := range attrs {
 		m[k] = v
 	}
-	if _, err := checker.Coerce(m, nil); err != nil {
-		return errors.Trace(err)
+	result, err := checker.Coerce(m, nil)
+	if err != nil {
+		return nil, errors.Trace(err)
 	}
-	return nil
+
+	resultMap := result.(map[string]interface{})
+	newAttrs := make(map[string]string)
+	for name, field := range s {
+		if field.FileAttr == "" {
+			newAttrs[name] = resultMap[name].(string)
+			continue
+		}
+		if _, ok := resultMap[name]; ok {
+			if _, ok := resultMap[field.FileAttr]; ok {
+				return nil, errors.NotValidf(
+					"specifying both %q and %q",
+					name, field.FileAttr,
+				)
+			}
+		}
+		fieldVal, ok := resultMap[field.FileAttr]
+		if !ok {
+			return nil, errors.NewNotValid(nil, fmt.Sprintf(
+				"either %q or %q must be specified",
+				name, field.FileAttr,
+			))
+		}
+		data, err := readFile(fieldVal.(string))
+		if err != nil {
+			return nil, errors.Annotatef(err, "reading file for %q", name)
+		}
+		if len(data) == 0 {
+			return nil, errors.NotValidf("empty file for %q", name)
+		}
+		newAttrs[name] = string(data)
+	}
+	return newAttrs, nil
 }
 
 func (s CredentialSchema) schemaChecker() (schema.Checker, error) {
@@ -110,8 +162,25 @@ func (s CredentialSchema) schemaChecker() (schema.Checker, error) {
 			Description: field.Description,
 			Type:        environschema.Tstring,
 			Group:       environschema.AccountGroup,
-			Mandatory:   true,
+			Mandatory:   field.FileAttr == "",
 			Secret:      field.Hidden,
+		}
+	}
+	// TODO(axw) add support to environschema for attributes whose values
+	// can be read in from a file.
+	for _, field := range s {
+		if field.FileAttr == "" {
+			continue
+		}
+		if _, ok := fields[field.FileAttr]; ok {
+			return nil, errors.Errorf("duplicate field %q", field.FileAttr)
+		}
+		fields[field.FileAttr] = environschema.Attr{
+			Description: field.Description + " (file)",
+			Type:        environschema.Tstring,
+			Group:       environschema.AccountGroup,
+			Mandatory:   false,
+			Secret:      false,
 		}
 	}
 	schemaFields, schemaDefaults, err := fields.ValidationSchema()
@@ -131,6 +200,11 @@ type CredentialAttr struct {
 	// when being entered interactively. Regardless of this, all credential
 	// attributes are provided only to the Juju controllers.
 	Hidden bool
+
+	// FileAttr is the name of an attribute that may be specified instead
+	// of this one, which points to a file that will be read in and its
+	// value used for this attribute.
+	FileAttr string
 }
 
 type cloudCredentialChecker struct{}

--- a/cloud/credentials_test.go
+++ b/cloud/credentials_test.go
@@ -260,7 +260,7 @@ credentials:
 
 func (s *credentialsSuite) TestParseCredentialsUnknownAuthType(c *gc.C) {
 	// Unknown auth-type is not validated by ParseCredentials.
-	// Validation is deferred to ValidateCredential.
+	// Validation is deferred to FinalizeCredential.
 	s.testParseCredentials(c, []byte(`
 credentials:
   cloud-name:
@@ -304,7 +304,7 @@ func (s *credentialsSuite) testParseCredentialsError(c *gc.C, input []byte, expe
 	c.Assert(err, gc.ErrorMatches, expect)
 }
 
-func (s *credentialsSuite) TestValidateCredential(c *gc.C) {
+func (s *credentialsSuite) TestFinalizeCredential(c *gc.C) {
 	cred := cloud.NewCredential(
 		cloud.UserPassAuthType,
 		map[string]string{
@@ -317,13 +317,100 @@ func (s *credentialsSuite) TestValidateCredential(c *gc.C) {
 			Hidden:      true,
 		},
 	}
-	err := cloud.ValidateCredential(cred, map[cloud.AuthType]cloud.CredentialSchema{
+	_, err := cloud.FinalizeCredential(cred, map[cloud.AuthType]cloud.CredentialSchema{
 		cloud.UserPassAuthType: schema,
-	})
+	}, readFileNotSupported)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-func (s *credentialsSuite) TestValidateCredentialInvalid(c *gc.C) {
+func (s *credentialsSuite) TestFinalizeCredentialFileAttr(c *gc.C) {
+	cred := cloud.NewCredential(
+		cloud.UserPassAuthType,
+		map[string]string{
+			"key-file": "path",
+		},
+	)
+	schema := cloud.CredentialSchema{
+		"key": {
+			Description: "key credential",
+			Hidden:      true,
+			FileAttr:    "key-file",
+		},
+	}
+	readFile := func(s string) ([]byte, error) {
+		c.Assert(s, gc.Equals, "path")
+		return []byte("file-value"), nil
+	}
+	newCred, err := cloud.FinalizeCredential(cred, map[cloud.AuthType]cloud.CredentialSchema{
+		cloud.UserPassAuthType: schema,
+	}, readFile)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(newCred.Attributes(), jc.DeepEquals, map[string]string{"key": "file-value"})
+}
+
+func (s *credentialsSuite) TestFinalizeCredentialFileEmpty(c *gc.C) {
+	cred := cloud.NewCredential(
+		cloud.UserPassAuthType,
+		map[string]string{
+			"key-file": "path",
+		},
+	)
+	schema := cloud.CredentialSchema{
+		"key": {
+			Description: "key credential",
+			Hidden:      true,
+			FileAttr:    "key-file",
+		},
+	}
+	readFile := func(string) ([]byte, error) {
+		return nil, nil
+	}
+	_, err := cloud.FinalizeCredential(cred, map[cloud.AuthType]cloud.CredentialSchema{
+		cloud.UserPassAuthType: schema,
+	}, readFile)
+	c.Assert(err, gc.ErrorMatches, `empty file for "key" not valid`)
+}
+
+func (s *credentialsSuite) TestFinalizeCredentialFileAttrNeither(c *gc.C) {
+	cred := cloud.NewCredential(
+		cloud.UserPassAuthType,
+		map[string]string{},
+	)
+	schema := cloud.CredentialSchema{
+		"key": {
+			Description: "key credential",
+			Hidden:      true,
+			FileAttr:    "key-file",
+		},
+	}
+	_, err := cloud.FinalizeCredential(cred, map[cloud.AuthType]cloud.CredentialSchema{
+		cloud.UserPassAuthType: schema,
+	}, readFileNotSupported)
+	c.Assert(err, gc.ErrorMatches, `either "key" or "key-file" must be specified`)
+}
+
+func (s *credentialsSuite) TestFinalizeCredentialFileAttrBoth(c *gc.C) {
+	cred := cloud.NewCredential(
+		cloud.UserPassAuthType,
+		map[string]string{
+			"key":      "value",
+			"key-file": "path",
+		},
+	)
+	schema := cloud.CredentialSchema{
+		"key": {
+			Description: "key credential",
+			Hidden:      true,
+			FileAttr:    "key-file",
+		},
+	}
+	_, err := cloud.FinalizeCredential(cred, map[cloud.AuthType]cloud.CredentialSchema{
+		cloud.UserPassAuthType: schema,
+	}, readFileNotSupported)
+	c.Assert(err, gc.ErrorMatches, `specifying both "key" and "key-file" not valid`)
+}
+
+func (s *credentialsSuite) TestFinalizeCredentialInvalid(c *gc.C) {
 	cred := cloud.NewCredential(
 		cloud.UserPassAuthType,
 		map[string]string{},
@@ -334,9 +421,9 @@ func (s *credentialsSuite) TestValidateCredentialInvalid(c *gc.C) {
 			Hidden:      true,
 		},
 	}
-	err := cloud.ValidateCredential(cred, map[cloud.AuthType]cloud.CredentialSchema{
+	_, err := cloud.FinalizeCredential(cred, map[cloud.AuthType]cloud.CredentialSchema{
 		cloud.UserPassAuthType: schema,
-	})
+	}, readFileNotSupported)
 	c.Assert(err, gc.ErrorMatches, "key: expected string, got nothing")
 }
 
@@ -345,7 +432,13 @@ func (s *credentialsSuite) TestValidateCredentialNotSupported(c *gc.C) {
 		cloud.OAuth2AuthType,
 		map[string]string{},
 	)
-	err := cloud.ValidateCredential(cred, map[cloud.AuthType]cloud.CredentialSchema{})
+	_, err := cloud.FinalizeCredential(
+		cred, map[cloud.AuthType]cloud.CredentialSchema{}, readFileNotSupported,
+	)
 	c.Assert(err, jc.Satisfies, errors.IsNotSupported)
 	c.Assert(err, gc.ErrorMatches, `auth-type "oauth2" not supported`)
+}
+
+func readFileNotSupported(f string) ([]byte, error) {
+	return nil, errors.NotSupportedf("reading file %q", f)
 }

--- a/cloud/credentials_test.go
+++ b/cloud/credentials_test.go
@@ -328,6 +328,7 @@ func (s *credentialsSuite) TestFinalizeCredentialFileAttr(c *gc.C) {
 		cloud.UserPassAuthType,
 		map[string]string{
 			"key-file": "path",
+			"quay":     "value",
 		},
 	)
 	schema := cloud.CredentialSchema{
@@ -335,6 +336,9 @@ func (s *credentialsSuite) TestFinalizeCredentialFileAttr(c *gc.C) {
 			Description: "key credential",
 			Hidden:      true,
 			FileAttr:    "key-file",
+		},
+		"quay": {
+			FileAttr: "quay-file",
 		},
 	}
 	readFile := func(s string) ([]byte, error) {
@@ -345,7 +349,10 @@ func (s *credentialsSuite) TestFinalizeCredentialFileAttr(c *gc.C) {
 		cloud.UserPassAuthType: schema,
 	}, readFile)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(newCred.Attributes(), jc.DeepEquals, map[string]string{"key": "file-value"})
+	c.Assert(newCred.Attributes(), jc.DeepEquals, map[string]string{
+		"key":  "file-value",
+		"quay": "value",
+	})
 }
 
 func (s *credentialsSuite) TestFinalizeCredentialFileEmpty(c *gc.C) {

--- a/environs/testing/credentials.go
+++ b/environs/testing/credentials.go
@@ -4,6 +4,8 @@
 package testing
 
 import (
+	"fmt"
+
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -47,7 +49,14 @@ func AssertProviderCredentialsValid(c *gc.C, p environs.EnvironProvider, authTyp
 			}
 		}
 		err := validate(reducedAttrs)
-		c.Assert(err, gc.ErrorMatches, excludedKey+": expected string, got nothing")
+		field := schema[excludedKey]
+		if field.FileAttr != "" {
+			c.Assert(err, gc.ErrorMatches, fmt.Sprintf(
+				`either %q or %q must be specified`, excludedKey, field.FileAttr),
+			)
+		} else {
+			c.Assert(err, gc.ErrorMatches, excludedKey+": expected string, got nothing")
+		}
 	}
 }
 

--- a/environs/testing/credentials.go
+++ b/environs/testing/credentials.go
@@ -4,6 +4,7 @@
 package testing
 
 import (
+	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -28,7 +29,14 @@ func AssertProviderAuthTypes(c *gc.C, p environs.EnvironProvider, expectedAuthTy
 func AssertProviderCredentialsValid(c *gc.C, p environs.EnvironProvider, authType cloud.AuthType, attrs map[string]string) {
 	schema, ok := p.CredentialSchemas()[authType]
 	c.Assert(ok, jc.IsTrue, gc.Commentf("missing schema for %q auth-type", authType))
-	err := schema.Validate(attrs)
+	validate := func(attrs map[string]string) error {
+		_, err := schema.Finalize(attrs, func(string) ([]byte, error) {
+			return nil, errors.NotSupportedf("reading files")
+		})
+		return err
+	}
+
+	err := validate(attrs)
 	c.Assert(err, jc.ErrorIsNil)
 
 	for excludedKey := range attrs {
@@ -38,7 +46,7 @@ func AssertProviderCredentialsValid(c *gc.C, p environs.EnvironProvider, authTyp
 				reducedAttrs[key] = value
 			}
 		}
-		err := schema.Validate(reducedAttrs)
+		err := validate(reducedAttrs)
 		c.Assert(err, gc.ErrorMatches, excludedKey+": expected string, got nothing")
 	}
 }

--- a/provider/joyent/credentials.go
+++ b/provider/joyent/credentials.go
@@ -14,13 +14,6 @@ type environProviderCredentials struct{}
 // CredentialSchemas is part of the environs.ProviderCredentials interface.
 func (environProviderCredentials) CredentialSchemas() map[cloud.AuthType]cloud.CredentialSchema {
 	return map[cloud.AuthType]cloud.CredentialSchema{
-		// TODO(axw) The current implementation expects the user to pass in
-		//           private-key-path and the config validation reads that
-		//           file to extract the private key. We should consider
-		//           supporting specifying the key itself in the credentials.
-		//           But the key itself is not a value I'd expect we'd prompt
-		//           a user to enter interactively.
-		//
 		// TODO(axw) we need a more appropriate name for this authentication
 		//           type. ssh?
 		cloud.UserPassAuthType: {
@@ -36,8 +29,10 @@ func (environProviderCredentials) CredentialSchemas() map[cloud.AuthType]cloud.C
 			mantaKeyId: {
 				Description: "Manta key ID",
 			},
-			privateKeyPath: {
-				Description: "Path to private key used to sign requests",
+			privateKey: {
+				Description: "Private key used to sign requests",
+				Hidden:      true,
+				FileAttr:    privateKeyPath,
 			},
 			algorithm: {
 				Description: "Algorithm used to generate the private key",

--- a/provider/joyent/credentials_test.go
+++ b/provider/joyent/credentials_test.go
@@ -34,17 +34,17 @@ func (s *credentialsSuite) TestCredentialSchemas(c *gc.C) {
 
 func (s *credentialsSuite) TestUserPassCredentialsValid(c *gc.C) {
 	envtesting.AssertProviderCredentialsValid(c, s.provider, "userpass", map[string]string{
-		"sdc-user":         "sdc-user",
-		"sdc-key-id":       "sdc-key-id",
-		"manta-user":       "manta-user",
-		"manta-key-id":     "manta-key-id",
-		"private-key-path": "private-key-path",
-		"algorithm":        "algorithm",
+		"sdc-user":     "sdc-user",
+		"sdc-key-id":   "sdc-key-id",
+		"manta-user":   "manta-user",
+		"manta-key-id": "manta-key-id",
+		"private-key":  "private-key",
+		"algorithm":    "algorithm",
 	})
 }
 
 func (s *credentialsSuite) TestUserPassHiddenAttributes(c *gc.C) {
-	envtesting.AssertProviderCredentialsAttributesHidden(c, s.provider, "userpass")
+	envtesting.AssertProviderCredentialsAttributesHidden(c, s.provider, "userpass", "private-key")
 }
 
 func (s *credentialsSuite) TestDetectCredentialsNotFound(c *gc.C) {


### PR DESCRIPTION
Add the FileAttr field to CredentialAttr, which
identifies the name of a field that, if present
instead, holds the path to a file that will be
read into the field with the FileAttr.

Used in the Joyent provider.

(Review request: http://reviews.vapour.ws/r/3827/)