### PR TITLE
Singular dependency flag

### DIFF
--- a/worker/singular/fixture_test.go
+++ b/worker/singular/fixture_test.go
@@ -1,0 +1,152 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package singular_test
+
+import (
+	"sync"
+	"time"
+
+	"github.com/juju/errors"
+	"github.com/juju/names"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/clock"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/agent"
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/core/lease"
+	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/singular"
+)
+
+type fixture struct {
+	testing.Stub
+}
+
+func newFixture(c *gc.C, errs ...error) *fixture {
+	fix := &fixture{}
+	fix.Stub.SetErrors(errs...)
+	return fix
+}
+
+type testFunc func(*singular.FlagWorker, *coretesting.Clock, func())
+
+func (fix *fixture) Run(c *gc.C, test testFunc) {
+	facade := newStubFacade(&fix.Stub)
+	clock := coretesting.NewClock(time.Now())
+	flagWorker, err := singular.NewFlagWorker(singular.FlagConfig{
+		Facade:   facade,
+		Clock:    clock,
+		Duration: time.Minute,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		defer worker.Stop(flagWorker)
+		defer facade.unblock()
+		test(flagWorker, clock, facade.unblock)
+	}()
+	select {
+	case <-done:
+	case <-time.After(coretesting.LongWait):
+		c.Fatalf("test timed out")
+	}
+}
+
+func (fix *fixture) CheckClaimWait(c *gc.C) {
+	fix.CheckCalls(c, []testing.StubCall{{
+		FuncName: "Claim",
+		Args:     []interface{}{time.Minute},
+	}, {
+		FuncName: "Wait",
+	}})
+}
+
+func (fix *fixture) CheckClaims(c *gc.C, count int) {
+	expect := make([]testing.StubCall, count)
+	for i := 0; i < count; i++ {
+		expect[i] = testing.StubCall{
+			FuncName: "Claim",
+			Args:     []interface{}{time.Minute},
+		}
+	}
+	fix.CheckCalls(c, expect)
+}
+
+type stubFacade struct {
+	stub  *testing.Stub
+	mu    sync.Mutex
+	block chan struct{}
+}
+
+func newStubFacade(stub *testing.Stub) *stubFacade {
+	return &stubFacade{
+		stub:  stub,
+		block: make(chan struct{}),
+	}
+}
+
+func (facade *stubFacade) unblock() {
+	facade.mu.Lock()
+	defer facade.mu.Unlock()
+	select {
+	case <-facade.block:
+	default:
+		close(facade.block)
+	}
+}
+
+func (facade *stubFacade) Claim(duration time.Duration) error {
+	facade.stub.AddCall("Claim", duration)
+	return facade.stub.NextErr()
+}
+
+func (facade *stubFacade) Wait() error {
+	facade.stub.AddCall("Wait")
+	<-facade.block
+	return facade.stub.NextErr()
+}
+
+var errClaimDenied = errors.Trace(lease.ErrClaimDenied)
+
+type mockAgent struct {
+	agent.Agent
+	wrongKind bool
+}
+
+func (mock *mockAgent) CurrentConfig() agent.Config {
+	return &mockAgentConfig{wrongKind: mock.wrongKind}
+}
+
+type mockAgentConfig struct {
+	agent.Config
+	wrongKind bool
+}
+
+func (mock *mockAgentConfig) Tag() names.Tag {
+	if mock.wrongKind {
+		return names.NewUnitTag("foo/1")
+	}
+	return names.NewMachineTag("123")
+}
+
+type fakeClock struct {
+	clock.Clock
+}
+
+type fakeFacade struct {
+	singular.Facade
+}
+
+type fakeWorker struct {
+	worker.Worker
+}
+
+type fakeAPICaller struct {
+	base.APICaller
+}

--- a/worker/singular/flag.go
+++ b/worker/singular/flag.go
@@ -1,0 +1,159 @@
+// Copyright 2015-2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package singular
+
+import (
+	"time"
+
+	"github.com/juju/errors"
+	"github.com/juju/juju/core/lease"
+	"github.com/juju/juju/worker/catacomb"
+	"github.com/juju/utils/clock"
+)
+
+// Facade exposes the capabilities required by a FlagWorker.
+type Facade interface {
+	Claim(duration time.Duration) error
+	Wait() error
+}
+
+// FlagConfig holds a FlagWorker's dependencies and resources.
+type FlagConfig struct {
+	Clock    clock.Clock
+	Facade   Facade
+	Duration time.Duration
+}
+
+// Validate returns an error if the config cannot be expected to run a
+// FlagWorker.
+func (config FlagConfig) Validate() error {
+	if config.Clock == nil {
+		return errors.NotValidf("nil Clock")
+	}
+	if config.Facade == nil {
+		return errors.NotValidf("nil Facade")
+	}
+	if config.Duration <= 0 {
+		return errors.NotValidf("non-positive Duration")
+	}
+	return nil
+}
+
+// ErrRefresh indicates that the flag's Check result is no longer valid,
+// and a new FlagWorker must be started to get a valid result.
+var ErrRefresh = errors.New("model responsibility unclear, please retry")
+
+// FlagWorker implements worker.Worker and dependency.Flag, representing
+// controller ownership of a model, such that the Flag's validity is tied
+// to the Worker's lifetime.
+type FlagWorker struct {
+	catacomb catacomb.Catacomb
+	config   FlagConfig
+	runFunc  func(FlagConfig, <-chan struct{}) error
+	valid    bool
+}
+
+func NewFlagWorker(config FlagConfig) (*FlagWorker, error) {
+	if err := config.Validate(); err != nil {
+		return nil, errors.Trace(err)
+	}
+	valid, err := claim(config)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	flag := &FlagWorker{
+		config: config,
+		valid:  valid,
+	}
+	if valid {
+		flag.runFunc = keepOccupied
+	} else {
+		flag.runFunc = waitVacant
+	}
+
+	err = catacomb.Invoke(catacomb.Plan{
+		Site: &flag.catacomb,
+		Work: flag.run,
+	})
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return flag, nil
+}
+
+// Kill is part of the worker.Worker interface.
+func (flag *FlagWorker) Kill() {
+	flag.catacomb.Kill(nil)
+}
+
+// Wait is part of the worker.Worker interface.
+func (flag *FlagWorker) Wait() error {
+	return flag.catacomb.Wait()
+}
+
+// Check is part of the dependency.Flag interface.
+//
+// Check returns true if the flag indicates that the configured Identity
+// (i.e. this controller) has taken control of the configured Scope (i.e.
+// the model we want to manage exclusively).
+//
+// The validity of this result is tied to the lifetime of the FlagWorker;
+// once the worker has stopped, no inferences may be drawn from any Check
+// result.
+func (flag *FlagWorker) Check() bool {
+	return flag.valid
+}
+
+// run invokes runFunc.
+func (flag *FlagWorker) run() error {
+	err := flag.runFunc(flag.config, flag.catacomb.Dying())
+	return errors.Trace(err)
+}
+
+// keepOccupied is a runFunc that tries to keep a flag valid.
+func keepOccupied(config FlagConfig, abort <-chan struct{}) error {
+	for {
+		select {
+		case <-abort:
+			return nil
+		case <-sleep(config):
+			success, err := claim(config)
+			if err != nil {
+				return errors.Trace(err)
+			}
+			if !success {
+				return ErrRefresh
+			}
+		}
+	}
+}
+
+// claim claims model ownership on behalf of a controller, and returns
+// true if the attempt succeeded.
+func claim(config FlagConfig) (bool, error) {
+	err := config.Facade.Claim(config.Duration)
+	cause := errors.Cause(err)
+	switch cause {
+	case nil:
+		return true, nil
+	case lease.ErrClaimDenied:
+		return false, nil
+	}
+	return false, errors.Trace(err)
+}
+
+// sleep waits for half the duration of a (presumed) earlier successful claim.
+func sleep(config FlagConfig) <-chan time.Time {
+	return config.Clock.After(config.Duration / 2)
+}
+
+// wait is a runFunc that ignores its abort chan and always returns an error;
+// either because of a failed api call, or a successful one, which indicates
+// that no lease is held; hence, that the worker should be bounced.
+func waitVacant(config FlagConfig, _ <-chan struct{}) error {
+	if err := config.Facade.Wait(); err != nil {
+		return errors.Trace(err)
+	}
+	return ErrRefresh
+}

--- a/worker/singular/flag_test.go
+++ b/worker/singular/flag_test.go
@@ -1,0 +1,100 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package singular_test
+
+import (
+	"time"
+
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/worker/singular"
+	"github.com/juju/juju/worker/workertest"
+)
+
+type FlagSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&FlagSuite{})
+
+func (s *FlagSuite) TestClaimError(c *gc.C) {
+	var stub testing.Stub
+	stub.SetErrors(errors.New("squish"))
+
+	worker, err := singular.NewFlagWorker(singular.FlagConfig{
+		Facade:   newStubFacade(&stub),
+		Clock:    &fakeClock{},
+		Duration: time.Hour,
+	})
+	c.Check(worker, gc.IsNil)
+	c.Check(err, gc.ErrorMatches, "squish")
+}
+
+func (s *FlagSuite) TestClaimFailure(c *gc.C) {
+	fix := newFixture(c, errClaimDenied, nil)
+	fix.Run(c, func(flag *singular.FlagWorker, _ *coretesting.Clock, _ func()) {
+		c.Check(flag.Check(), jc.IsFalse)
+		workertest.CheckAlive(c, flag)
+	})
+	fix.CheckClaimWait(c)
+}
+
+func (s *FlagSuite) TestClaimFailureWaitError(c *gc.C) {
+	fix := newFixture(c, errClaimDenied, errors.New("glug"))
+	fix.Run(c, func(flag *singular.FlagWorker, _ *coretesting.Clock, unblock func()) {
+		c.Check(flag.Check(), jc.IsFalse)
+		unblock()
+		err := workertest.CheckKilled(c, flag)
+		c.Check(err, gc.ErrorMatches, "glug")
+	})
+	fix.CheckClaimWait(c)
+}
+
+func (s *FlagSuite) TestClaimFailureWaitSuccess(c *gc.C) {
+	fix := newFixture(c, errClaimDenied, nil)
+	fix.Run(c, func(flag *singular.FlagWorker, _ *coretesting.Clock, unblock func()) {
+		c.Check(flag.Check(), jc.IsFalse)
+		unblock()
+		err := workertest.CheckKilled(c, flag)
+		c.Check(errors.Cause(err), gc.Equals, singular.ErrRefresh)
+	})
+	fix.CheckClaimWait(c)
+}
+
+func (s *FlagSuite) TestClaimSuccess(c *gc.C) {
+	fix := newFixture(c, nil, errors.New("should not happen"))
+	fix.Run(c, func(flag *singular.FlagWorker, clock *coretesting.Clock, unblock func()) {
+		<-clock.Alarms()
+		clock.Advance(29 * time.Second)
+		workertest.CheckAlive(c, flag)
+	})
+	fix.CheckClaims(c, 1)
+}
+
+func (s *FlagSuite) TestClaimSuccessThenFailure(c *gc.C) {
+	fix := newFixture(c, nil, errClaimDenied)
+	fix.Run(c, func(flag *singular.FlagWorker, clock *coretesting.Clock, unblock func()) {
+		<-clock.Alarms()
+		clock.Advance(30 * time.Second)
+		err := workertest.CheckKilled(c, flag)
+		c.Check(errors.Cause(err), gc.Equals, singular.ErrRefresh)
+	})
+	fix.CheckClaims(c, 2)
+}
+
+func (s *FlagSuite) TestClaimSuccessesThenError(c *gc.C) {
+	fix := newFixture(c)
+	fix.Run(c, func(flag *singular.FlagWorker, clock *coretesting.Clock, unblock func()) {
+		<-clock.Alarms()
+		clock.Advance(time.Minute)
+		<-clock.Alarms()
+		clock.Advance(time.Minute)
+		workertest.CheckAlive(c, flag)
+	})
+	fix.CheckClaims(c, 3)
+}

--- a/worker/singular/manifold.go
+++ b/worker/singular/manifold.go
@@ -1,0 +1,92 @@
+// Copyright 2015-2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package singular
+
+import (
+	"time"
+
+	"github.com/juju/errors"
+	"github.com/juju/juju/agent"
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/dependency"
+	"github.com/juju/names"
+	"github.com/juju/utils/clock"
+)
+
+// ManifoldConfig holds the information necessary to run a FlagWorker in
+// a dependency.Engine.
+type ManifoldConfig struct {
+	ClockName     string
+	APICallerName string
+	AgentName     string
+	Duration      time.Duration
+
+	NewFacade func(base.APICaller, names.MachineTag) (Facade, error)
+	NewWorker func(FlagConfig) (worker.Worker, error)
+}
+
+// start is a method on ManifoldConfig because it's more readable than a closure.
+func (config ManifoldConfig) start(getResource dependency.GetResourceFunc) (worker.Worker, error) {
+	var clock clock.Clock
+	if err := getResource(config.ClockName, &clock); err != nil {
+		return nil, errors.Trace(err)
+	}
+	var apiCaller base.APICaller
+	if err := getResource(config.APICallerName, &apiCaller); err != nil {
+		return nil, errors.Trace(err)
+	}
+	var agent agent.Agent
+	if err := getResource(config.AgentName, &agent); err != nil {
+		return nil, errors.Trace(err)
+	}
+	agentTag := agent.CurrentConfig().Tag()
+	machineTag, ok := agentTag.(names.MachineTag)
+	if !ok {
+		return nil, errors.New("singular flag expected a machine agent")
+	}
+
+	// TODO(fwereade): model id is implicit in apiCaller, would
+	// be better if explicit.
+	facade, err := config.NewFacade(apiCaller, machineTag)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	flag, err := config.NewWorker(FlagConfig{
+		Clock:    clock,
+		Facade:   facade,
+		Duration: config.Duration,
+	})
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return flag, nil
+}
+
+// Manifold returns a dependency.Manifold that will run a FlagWorker and
+// expose it to clients as a dependency.Flag resource.
+func Manifold(config ManifoldConfig) dependency.Manifold {
+	return dependency.Manifold{
+		Inputs: []string{
+			config.ClockName,
+			config.APICallerName,
+			config.AgentName,
+		},
+		Start:  config.start,
+		Output: manifoldOutput,
+	}
+}
+
+func manifoldOutput(in worker.Worker, out interface{}) error {
+	inWorker, ok := in.(*FlagWorker)
+	if !ok {
+		return errors.Errorf("expected in to be a *FlagWorker, got a %T", in)
+	}
+	outFlag, ok := out.(*dependency.Flag)
+	if !ok {
+		return errors.Errorf("expected out to be a *dependency.Flag, got a %T", out)
+	}
+	*outFlag = inWorker
+	return nil
+}

--- a/worker/singular/manifold_test.go
+++ b/worker/singular/manifold_test.go
@@ -1,0 +1,207 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package singular_test
+
+import (
+	"time"
+
+	"github.com/juju/errors"
+	"github.com/juju/names"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/api/base"
+	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/dependency"
+	dt "github.com/juju/juju/worker/dependency/testing"
+	"github.com/juju/juju/worker/singular"
+)
+
+type ManifoldSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&ManifoldSuite{})
+
+func (s *ManifoldSuite) TestInputs(c *gc.C) {
+	manifold := singular.Manifold(singular.ManifoldConfig{
+		ClockName:     "harriet",
+		APICallerName: "kim",
+		AgentName:     "jenny",
+	})
+	expectInputs := []string{"harriet", "kim", "jenny"}
+	c.Check(manifold.Inputs, jc.DeepEquals, expectInputs)
+}
+
+func (s *ManifoldSuite) TestOutputBadWorker(c *gc.C) {
+	manifold := singular.Manifold(singular.ManifoldConfig{})
+	var out dependency.Flag
+	err := manifold.Output(&fakeWorker{}, &out)
+	c.Check(err, gc.ErrorMatches, `expected in to be a \*FlagWorker, got a .*`)
+	c.Check(out, gc.IsNil)
+}
+
+func (s *ManifoldSuite) TestOutputBadResult(c *gc.C) {
+	manifold := singular.Manifold(singular.ManifoldConfig{})
+	fix := newFixture(c)
+	fix.Run(c, func(flag *singular.FlagWorker, _ *coretesting.Clock, _ func()) {
+		var out interface{}
+		err := manifold.Output(flag, &out)
+		c.Check(err, gc.ErrorMatches, `expected out to be a \*dependency.Flag, got a .*`)
+		c.Check(out, gc.IsNil)
+	})
+}
+
+func (s *ManifoldSuite) TestOutputSuccess(c *gc.C) {
+	manifold := singular.Manifold(singular.ManifoldConfig{})
+	fix := newFixture(c)
+	fix.Run(c, func(flag *singular.FlagWorker, _ *coretesting.Clock, _ func()) {
+		var out dependency.Flag
+		err := manifold.Output(flag, &out)
+		c.Check(err, jc.ErrorIsNil)
+		c.Check(out, gc.Equals, flag)
+	})
+}
+
+func (s *ManifoldSuite) TestStartMissingClock(c *gc.C) {
+	manifold := singular.Manifold(singular.ManifoldConfig{
+		ClockName:     "clock",
+		APICallerName: "api-caller",
+		AgentName:     "agent",
+	})
+	getResource := dt.StubGetResource(dt.StubResources{
+		"clock": dt.StubResource{Error: dependency.ErrMissing},
+	})
+
+	worker, err := manifold.Start(getResource)
+	c.Check(errors.Cause(err), gc.Equals, dependency.ErrMissing)
+	c.Check(worker, gc.IsNil)
+}
+
+func (s *ManifoldSuite) TestStartMissingAgent(c *gc.C) {
+	manifold := singular.Manifold(singular.ManifoldConfig{
+		ClockName:     "clock",
+		APICallerName: "api-caller",
+		AgentName:     "agent",
+	})
+	getResource := dt.StubGetResource(dt.StubResources{
+		"clock":      dt.StubResource{Output: &fakeClock{}},
+		"api-caller": dt.StubResource{Error: dependency.ErrMissing},
+	})
+
+	worker, err := manifold.Start(getResource)
+	c.Check(errors.Cause(err), gc.Equals, dependency.ErrMissing)
+	c.Check(worker, gc.IsNil)
+}
+
+func (s *ManifoldSuite) TestStartMissingAPICaller(c *gc.C) {
+	manifold := singular.Manifold(singular.ManifoldConfig{
+		ClockName:     "clock",
+		APICallerName: "api-caller",
+		AgentName:     "agent",
+	})
+	getResource := dt.StubGetResource(dt.StubResources{
+		"clock":      dt.StubResource{Output: &fakeClock{}},
+		"api-caller": dt.StubResource{Output: &fakeAPICaller{}},
+		"agent":      dt.StubResource{Error: dependency.ErrMissing},
+	})
+
+	worker, err := manifold.Start(getResource)
+	c.Check(errors.Cause(err), gc.Equals, dependency.ErrMissing)
+	c.Check(worker, gc.IsNil)
+}
+
+func (s *ManifoldSuite) TestStartWrongAgent(c *gc.C) {
+	manifold := singular.Manifold(singular.ManifoldConfig{
+		ClockName:     "clock",
+		APICallerName: "api-caller",
+		AgentName:     "agent",
+	})
+	getResource := dt.StubGetResource(dt.StubResources{
+		"clock":      dt.StubResource{Output: &fakeClock{}},
+		"api-caller": dt.StubResource{Output: &fakeAPICaller{}},
+		"agent":      dt.StubResource{Output: &mockAgent{wrongKind: true}},
+	})
+
+	worker, err := manifold.Start(getResource)
+	c.Check(err, gc.ErrorMatches, "singular flag expected a machine agent")
+	c.Check(worker, gc.IsNil)
+}
+
+func (s *ManifoldSuite) TestStartNewFacadeError(c *gc.C) {
+	expectAPICaller := &fakeAPICaller{}
+	manifold := singular.Manifold(singular.ManifoldConfig{
+		ClockName:     "clock",
+		APICallerName: "api-caller",
+		AgentName:     "agent",
+		NewFacade: func(apiCaller base.APICaller, tag names.MachineTag) (singular.Facade, error) {
+			c.Check(apiCaller, gc.Equals, expectAPICaller)
+			c.Check(tag.String(), gc.Equals, "machine-123")
+			return nil, errors.New("grark plop")
+		},
+	})
+	getResource := dt.StubGetResource(dt.StubResources{
+		"clock":      dt.StubResource{Output: &fakeClock{}},
+		"api-caller": dt.StubResource{Output: expectAPICaller},
+		"agent":      dt.StubResource{Output: &mockAgent{}},
+	})
+
+	worker, err := manifold.Start(getResource)
+	c.Check(err, gc.ErrorMatches, "grark plop")
+	c.Check(worker, gc.IsNil)
+}
+
+func (s *ManifoldSuite) TestStartNewWorkerError(c *gc.C) {
+	expectFacade := &fakeFacade{}
+	manifold := singular.Manifold(singular.ManifoldConfig{
+		ClockName:     "clock",
+		APICallerName: "api-caller",
+		AgentName:     "agent",
+		Duration:      time.Minute,
+		NewFacade: func(_ base.APICaller, _ names.MachineTag) (singular.Facade, error) {
+			return expectFacade, nil
+		},
+		NewWorker: func(config singular.FlagConfig) (worker.Worker, error) {
+			c.Check(config.Facade, gc.Equals, expectFacade)
+			err := config.Validate()
+			c.Check(err, jc.ErrorIsNil)
+			return nil, errors.New("blomp tik")
+		},
+	})
+	getResource := dt.StubGetResource(dt.StubResources{
+		"clock":      dt.StubResource{Output: &fakeClock{}},
+		"api-caller": dt.StubResource{Output: &fakeAPICaller{}},
+		"agent":      dt.StubResource{Output: &mockAgent{}},
+	})
+
+	worker, err := manifold.Start(getResource)
+	c.Check(err, gc.ErrorMatches, "blomp tik")
+	c.Check(worker, gc.IsNil)
+}
+
+func (s *ManifoldSuite) TestStartSuccess(c *gc.C) {
+	expectWorker := &fakeWorker{}
+	manifold := singular.Manifold(singular.ManifoldConfig{
+		ClockName:     "clock",
+		APICallerName: "api-caller",
+		AgentName:     "agent",
+		NewFacade: func(_ base.APICaller, _ names.MachineTag) (singular.Facade, error) {
+			return &fakeFacade{}, nil
+		},
+		NewWorker: func(_ singular.FlagConfig) (worker.Worker, error) {
+			return expectWorker, nil
+		},
+	})
+	getResource := dt.StubGetResource(dt.StubResources{
+		"clock":      dt.StubResource{Output: &fakeClock{}},
+		"api-caller": dt.StubResource{Output: &fakeAPICaller{}},
+		"agent":      dt.StubResource{Output: &mockAgent{}},
+	})
+
+	worker, err := manifold.Start(getResource)
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(worker, gc.Equals, expectWorker)
+}

--- a/worker/singular/mongo_test.go
+++ b/worker/singular/mongo_test.go
@@ -102,10 +102,10 @@ func (*mongoSuite) TestMongoMastership(c *gc.C) {
 	assertAgentsQuit(c, globalState)
 }
 
-func startAgents(c *gc.C, notifyCh chan<- event, insts []*gitjujutesting.MgoInstance) []*agent {
-	agents := make([]*agent, len(insts))
+func startAgents(c *gc.C, notifyCh chan<- event, insts []*gitjujutesting.MgoInstance) []*testAgent {
+	agents := make([]*testAgent, len(insts))
 	for i, inst := range insts {
-		a := &agent{
+		a := &testAgent{
 			// Note: we use ids starting from 1 to match
 			// the replica set ids.
 			notify: &notifier{
@@ -153,18 +153,18 @@ func assertAgentsQuit(c *gc.C, globalState *globalAgentState) {
 	}
 }
 
-type agent struct {
+type testAgent struct {
 	notify *notifier
 	worker.Runner
 	hostPort string
 }
 
-func (a *agent) run() error {
+func (a *testAgent) run() error {
 	a.Runner.StartWorker(fmt.Sprint("mongo-", a.notify.id), a.mongoWorker)
 	return a.Runner.Wait()
 }
 
-func (a *agent) mongoWorker() (worker.Worker, error) {
+func (a *testAgent) mongoWorker() (worker.Worker, error) {
 	dialInfo := gitjujutesting.MgoDialInfo(coretesting.Certs, a.hostPort)
 	session, err := mgo.DialWithInfo(dialInfo)
 	if err != nil {
@@ -190,7 +190,7 @@ func (a *agent) mongoWorker() (worker.Worker, error) {
 	return runner, nil
 }
 
-func (a *agent) worker(session *mgo.Session, stop <-chan struct{}) error {
+func (a *testAgent) worker(session *mgo.Session, stop <-chan struct{}) error {
 	a.notify.workerStarted()
 	defer a.notify.workerStopped()
 	coll := session.DB("foo").C("bar")

--- a/worker/singular/mongo_test.go
+++ b/worker/singular/mongo_test.go
@@ -29,9 +29,9 @@ type mongoSuite struct {
 	testing.BaseSuite
 }
 
-var enableUnreliableTests = flag.Bool("juju.unreliabletests", false, "enable unreliable and slow tests")
-
 var _ = gc.Suite(&mongoSuite{})
+
+var enableUnreliableTests = flag.Bool("juju.unreliabletests", false, "enable unreliable and slow tests")
 
 func (*mongoSuite) SetUpSuite(c *gc.C) {
 	if !*enableUnreliableTests {

--- a/worker/singular/package_test.go
+++ b/worker/singular/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2014-2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package singular_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/worker/singular/shim.go
+++ b/worker/singular/shim.go
@@ -1,0 +1,29 @@
+// Copyright 2015-2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package singular
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/names"
+
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/api/singular"
+	"github.com/juju/juju/worker"
+)
+
+func NewFacade(apiCaller base.APICaller, controllerTag names.MachineTag) (Facade, error) {
+	facade, err := singular.NewAPI(apiCaller, controllerTag)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return facade, nil
+}
+
+func NewWorker(config FlagConfig) (worker.Worker, error) {
+	worker, err := NewFlagWorker(config)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return worker, nil
+}

--- a/worker/singular/singular_test.go
+++ b/worker/singular/singular_test.go
@@ -6,7 +6,6 @@ package singular_test
 import (
 	"fmt"
 	"sync"
-	stdtesting "testing"
 	"time"
 
 	jc "github.com/juju/testing/checkers"
@@ -17,15 +16,11 @@ import (
 	"github.com/juju/juju/worker/singular"
 )
 
-var _ = gc.Suite(&singularSuite{})
-
-func TestPackage(t *stdtesting.T) {
-	gc.TestingT(t)
-}
-
 type singularSuite struct {
 	testing.BaseSuite
 }
+
+var _ = gc.Suite(&singularSuite{})
 
 func (*singularSuite) TestWithMasterError(c *gc.C) {
 	expectErr := fmt.Errorf("an error")


### PR DESCRIPTION
API-based worker for tracking whether a controller has responsibility for a given model.

Added to worker/singular because I can't think of a better name, and we can just delete the mongo bits from the package when we switch over.

(Review request: http://reviews.vapour.ws/r/3830/)