### PR TITLE
Implement "juju migrate" command

### DIFF
--- a/api/controller/controller.go
+++ b/api/controller/controller.go
@@ -134,15 +134,35 @@ func (c *Client) ModelStatus(tags ...names.ModelTag) ([]base.ModelStatus, error)
 	return results, nil
 }
 
+// ModelMigrationSpec holds the details required to start the
+// migration of a single model.
+type ModelMigrationSpec struct {
+	ModelUUID            string
+	TargetControllerUUID string
+	TargetAddrs          []string
+	TargetCACert         string
+	TargetUser           string
+	TargetPassword       string
+}
+
 // InitiateModelMigration attempts to start a migration for the
 // specified model, returning the migration's ID.
 //
 // The API server supports starting multiple migrations in one request
 // but we don't need that at the client side yet (and may never) so
 // this call just supports starting one migration at a time.
-func (c *Client) InitiateModelMigration(spec params.ModelMigrationSpec) (string, error) {
+func (c *Client) InitiateModelMigration(spec ModelMigrationSpec) (string, error) {
 	args := params.InitiateModelMigrationArgs{
-		Specs: []params.ModelMigrationSpec{spec},
+		Specs: []params.ModelMigrationSpec{{
+			ModelTag: names.NewModelTag(spec.ModelUUID).String(),
+			TargetInfo: params.ModelMigrationTargetInfo{
+				ControllerTag: names.NewModelTag(spec.TargetControllerUUID).String(),
+				Addrs:         spec.TargetAddrs,
+				CACert:        spec.TargetCACert,
+				AuthTag:       names.NewUserTag(spec.TargetUser).String(),
+				Password:      spec.TargetPassword,
+			},
+		}},
 	}
 	response := params.InitiateModelMigrationResults{}
 	if err := c.facade.FacadeCall("InitiateModelMigration", args, &response); err != nil {

--- a/api/controller/controller_test.go
+++ b/api/controller/controller_test.go
@@ -175,16 +175,13 @@ func (s *controllerSuite) TestInitiateModelMigration(c *gc.C) {
 	_, err := state.GetModelMigration(st)
 	c.Assert(errors.IsNotFound(err), jc.IsTrue)
 
-	targetInfo := params.ModelMigrationTargetInfo{
-		ControllerTag: randomModelTag(),
-		Addrs:         []string{"1.2.3.4:5"},
-		CACert:        "cert",
-		AuthTag:       names.NewUserTag("someone").String(),
-		Password:      "secret",
-	}
-	spec := params.ModelMigrationSpec{
-		ModelTag:   st.ModelTag().String(),
-		TargetInfo: targetInfo,
+	spec := controller.ModelMigrationSpec{
+		ModelUUID:            st.ModelUUID(),
+		TargetControllerUUID: randomUUID(),
+		TargetAddrs:          []string{"1.2.3.4:5"},
+		TargetCACert:         "cert",
+		TargetUser:           "someone",
+		TargetPassword:       "secret",
 	}
 
 	controller := s.OpenAPI(c)
@@ -200,16 +197,13 @@ func (s *controllerSuite) TestInitiateModelMigration(c *gc.C) {
 }
 
 func (s *controllerSuite) TestInitiateModelMigrationError(c *gc.C) {
-	targetInfo := params.ModelMigrationTargetInfo{
-		ControllerTag: randomModelTag(),
-		Addrs:         []string{"1.2.3.4:5"},
-		CACert:        "cert",
-		AuthTag:       names.NewUserTag("someone").String(),
-		Password:      "secret",
-	}
-	spec := params.ModelMigrationSpec{
-		ModelTag:   randomModelTag(), // Model doesn't exist.
-		TargetInfo: targetInfo,
+	spec := controller.ModelMigrationSpec{
+		ModelUUID:            randomUUID(), // Model doesn't exist.
+		TargetControllerUUID: randomUUID(),
+		TargetAddrs:          []string{"1.2.3.4:5"},
+		TargetCACert:         "cert",
+		TargetUser:           "someone",
+		TargetPassword:       "secret",
 	}
 
 	controller := s.OpenAPI(c)
@@ -218,7 +212,6 @@ func (s *controllerSuite) TestInitiateModelMigrationError(c *gc.C) {
 	c.Check(err, gc.ErrorMatches, "unable to read model: .+")
 }
 
-func randomModelTag() string {
-	uuid := utils.MustNewUUID().String()
-	return names.NewModelTag(uuid).String()
+func randomUUID() string {
+	return utils.MustNewUUID().String()
 }

--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -199,6 +199,8 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 	r.Register(model.NewUnshareCommand())
 	r.Register(model.NewUsersCommand())
 
+	r.Register(newMigrateCommand())
+
 	// Manage and control actions
 	r.Register(action.NewSuperCommand())
 	r.RegisterSuperAlias("run-action", "action", "do", nil)

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -259,6 +259,7 @@ var commandNames = []string{
 	"login",
 	"machine",
 	"machines",
+	"migrate",
 	"publish",
 	"remove-all-blocks",
 	"remove-machine",

--- a/cmd/juju/commands/migrate.go
+++ b/cmd/juju/commands/migrate.go
@@ -1,0 +1,134 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package commands
+
+import (
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+	"github.com/juju/names"
+
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/modelcmd"
+)
+
+func newMigrateCommand() cmd.Command {
+	return modelcmd.WrapController(&migrateCommand{})
+}
+
+// migrateCommand initiates a model migration.
+type migrateCommand struct {
+	modelcmd.ControllerCommandBase
+	api migrateAPI
+
+	model            string
+	targetController string
+}
+
+type migrateAPI interface {
+	InitiateModelMigration(spec params.ModelMigrationSpec) (string, error)
+}
+
+const migrateDoc = `
+migrate begins the migration of a model from its current controller to
+a new controller. This is useful for load balancing when a controller
+is too busy, or as a way to upgrade a model's controller to a newer
+Juju version. Once complete, the model's machine and and unit agents
+will be connected to the new controller. The model will no longer be
+available at the source controller.
+
+Note that only hosted models can be migrated. Controller models can
+not be migrated.
+
+If the migration fails for some reason, the model be returned to its
+original state with the model being managed by the original
+controller.
+
+In order to start a migration, the target controller must be in the
+juju client's local configuration cache. See the juju "login" command
+for details of how to do this.
+
+This command only starts a model migration - it does not wait for its
+completion. The progress of a migration can be tracked using the
+"status" command and by consulting the logs.
+
+See Also:
+   juju help login
+   juju help controllers
+   juju help status
+`
+
+// Info implements cmd.Command.
+func (c *migrateCommand) Info() *cmd.Info {
+	return &cmd.Info{
+		Name:    "migrate",
+		Args:    "<model-name> <target-controller-name>",
+		Purpose: "migrate a hosted model to another controller",
+		Doc:     migrateDoc,
+	}
+}
+
+// Init implements cmd.Command.
+func (c *migrateCommand) Init(args []string) error {
+	if len(args) < 1 {
+		return errors.New("model not specified")
+	}
+	if len(args) < 2 {
+		return errors.New("target controller not specified")
+	}
+	if len(args) > 2 {
+		return errors.New("too many arguments specified")
+	}
+
+	c.model = args[0]
+	c.targetController = args[1]
+	return nil
+}
+
+var connectionInfoForName = modelcmd.ConnectionInfoForName
+
+// Run implements cmd.Command.
+func (c *migrateCommand) Run(ctx *cmd.Context) error {
+	modelInfo, err := connectionInfoForName(c.model)
+	if err != nil {
+		return errors.Annotate(err, "model config lookup")
+	}
+
+	targetInfo, err := connectionInfoForName(c.targetController)
+	if err != nil {
+		return errors.Annotate(err, "target controller config lookup")
+	}
+
+	modelUUID := modelInfo.APIEndpoint().ModelUUID
+	targetEndpoint := targetInfo.APIEndpoint()
+	targetCreds := targetInfo.APICredentials()
+
+	args := params.ModelMigrationSpec{
+		ModelTag: names.NewModelTag(modelUUID).String(),
+		TargetInfo: params.ModelMigrationTargetInfo{
+			ControllerTag: names.NewModelTag(targetEndpoint.ModelUUID).String(),
+			Addrs:         targetEndpoint.Addresses,
+			CACert:        targetEndpoint.CACert,
+			AuthTag:       names.NewUserTag(targetCreds.User).String(),
+			Password:      targetCreds.Password,
+		},
+	}
+
+	api, err := c.getAPI()
+	if err != nil {
+		return err
+	}
+	id, err := api.InitiateModelMigration(args)
+	if err != nil {
+		return err
+	}
+	ctx.Infof("Migration started with ID %q", id)
+	return nil
+}
+
+func (c *migrateCommand) getAPI() (migrateAPI, error) {
+	if c.api != nil {
+		return c.api, nil
+	}
+	return c.NewControllerAPIClient()
+}

--- a/cmd/juju/commands/migrate_test.go
+++ b/cmd/juju/commands/migrate_test.go
@@ -1,0 +1,141 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package commands
+
+import (
+	"errors"
+
+	"github.com/juju/cmd"
+	"github.com/juju/names"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/environs/configstore"
+	"github.com/juju/juju/testing"
+)
+
+type MigrateSuite struct {
+	testing.FakeJujuXDGDataHomeSuite
+	api *fakeMigrateAPI
+}
+
+var _ = gc.Suite(&MigrateSuite{})
+
+const sourceModelUUID = "deadbeef-0bad-400d-8000-4b1d0d06f00d"
+const targetControllerUUID = "beefdead-0bad-400d-8000-4b1d0d06f00d"
+
+func (s *MigrateSuite) SetUpTest(c *gc.C) {
+	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
+
+	err := modelcmd.WriteCurrentController("fake")
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.api = &fakeMigrateAPI{}
+}
+
+func (s *MigrateSuite) TestMissingModel(c *gc.C) {
+	_, err := s.runCommand(c)
+	c.Assert(err, gc.ErrorMatches, "model not specified")
+}
+
+func (s *MigrateSuite) TestMissingTargetController(c *gc.C) {
+	_, err := s.runCommand(c, "mymodel")
+	c.Assert(err, gc.ErrorMatches, "target controller not specified")
+}
+
+func (s *MigrateSuite) TestTooManyArgs(c *gc.C) {
+	_, err := s.runCommand(c, "one", "too", "many")
+	c.Assert(err, gc.ErrorMatches, "too many arguments specified")
+}
+
+func (s *MigrateSuite) TestSuccess(c *gc.C) {
+	// Set up fake connection info for a source model and a target controller.
+	s.PatchValue(&connectionInfoForName, func(name string) (configstore.EnvironInfo, error) {
+		if name == "source-model" {
+			return &fakeEnvironInfo{modelUUID: sourceModelUUID}, nil
+		} else if name == "target-controller" {
+			return &fakeEnvironInfo{modelUUID: targetControllerUUID}, nil
+		} else {
+			panic("unknown model/controller name")
+		}
+	})
+
+	ctx, err := s.runCommand(c, "source-model", "target-controller")
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(testing.Stderr(ctx), gc.Matches, "Migration started with ID \"uuid:0\"\n")
+	c.Check(s.api.specSeen, jc.DeepEquals, &params.ModelMigrationSpec{
+		ModelTag: names.NewModelTag(sourceModelUUID).String(),
+		TargetInfo: params.ModelMigrationTargetInfo{
+			ControllerTag: names.NewModelTag(targetControllerUUID).String(),
+			Addrs:         []string{"1.2.3.4:5"},
+			CACert:        "cert",
+			AuthTag:       names.NewUserTag("admin").String(),
+			Password:      "secret",
+		}})
+}
+
+func (s *MigrateSuite) TestModelDoesntExist(c *gc.C) {
+	// Have the connection info lookup for the source model fail.
+	s.PatchValue(&connectionInfoForName, func(string) (configstore.EnvironInfo, error) {
+		return nil, errors.New("nope")
+	})
+
+	_, err := s.runCommand(c, "source-model", "target-controller")
+	c.Check(err, gc.ErrorMatches, "model config lookup: .+")
+	c.Check(s.api.specSeen, gc.IsNil) // API shouldn't have been called
+}
+
+func (s *MigrateSuite) TestControllerDoesntExist(c *gc.C) {
+	// Have the connection info lookup for the source model succeed,
+	// but fail for the controller.
+	s.PatchValue(&connectionInfoForName, func(name string) (configstore.EnvironInfo, error) {
+		if name == "source-model" {
+			return &fakeEnvironInfo{modelUUID: sourceModelUUID}, nil
+		}
+		return nil, errors.New("nope")
+	})
+
+	_, err := s.runCommand(c, "source-model", "target-controller")
+	c.Check(err, gc.ErrorMatches, "target controller config lookup: .+")
+	c.Check(s.api.specSeen, gc.IsNil) // API shouldn't have been called
+}
+
+func (s *MigrateSuite) runCommand(c *gc.C, args ...string) (*cmd.Context, error) {
+	cmd := modelcmd.WrapController(&migrateCommand{
+		api: s.api,
+	})
+	return testing.RunCommand(c, cmd, args...)
+}
+
+type fakeMigrateAPI struct {
+	specSeen *params.ModelMigrationSpec
+}
+
+func (a *fakeMigrateAPI) InitiateModelMigration(spec params.ModelMigrationSpec) (string, error) {
+	a.specSeen = &spec
+	return "uuid:0", nil
+}
+
+type fakeEnvironInfo struct {
+	configstore.EnvironInfo
+	modelUUID string
+}
+
+func (i *fakeEnvironInfo) APIEndpoint() configstore.APIEndpoint {
+	return configstore.APIEndpoint{
+		ModelUUID: i.modelUUID,
+		Addresses: []string{"1.2.3.4:5"},
+		CACert:    "cert",
+	}
+}
+
+func (i *fakeEnvironInfo) APICredentials() configstore.APICredentials {
+	return configstore.APICredentials{
+		User:     "admin",
+		Password: "secret",
+	}
+}


### PR DESCRIPTION
Make InitiateModelMigration's API more convenient and implement the "juju migrate" command.

(Review request: http://reviews.vapour.ws/r/3839/)