### PR TITLE
cloud: various fixes

### DIFF
--- a/cloud/clouds_test.go
+++ b/cloud/clouds_test.go
@@ -45,14 +45,13 @@ func (s *cloudSuite) TestParseCloudsEndpointDenormalisation(c *gc.C) {
 	var regionNames []string
 	for name, region := range rackspace.Regions {
 		regionNames = append(regionNames, name)
-		if name == "London" {
+		if name == "LON" {
 			c.Assert(region.Endpoint, gc.Equals, "https://lon.identity.api.rackspacecloud.com/v2.0")
 		} else {
 			c.Assert(region.Endpoint, gc.Equals, "https://identity.api.rackspacecloud.com/v2.0")
 		}
 	}
-	c.Assert(regionNames, jc.SameContents,
-		[]string{"Dallas-Fort Worth", "Chicago", "Northern Virginia", "London", "Sydney", "Hong Kong"})
+	c.Assert(regionNames, jc.SameContents, []string{"DFW", "ORD", "IAD", "LON", "SYD", "HKG"})
 }
 
 func (s *cloudSuite) TestParseCloudsAuthTypes(c *gc.C) {

--- a/cloud/credentials.go
+++ b/cloud/credentials.go
@@ -264,7 +264,8 @@ func (c cloudCredentialValueChecker) Coerce(v interface{}, path []string) (inter
 // specified cloud, optionally specifying a credential name. If no credential
 // name is specified, then use the default credential for the cloud if one has
 // been specified. The credential name is returned also, in case the default
-// credential is used.
+// credential is used. If there is only one credential, it is implicitly the
+// default.
 //
 // If there exists no matching credentials, an error satisfying
 // errors.IsNotFound will be returned.
@@ -297,6 +298,10 @@ func CredentialByName(
 	if credentialName == "" {
 		// No credential specified, so use the default for the cloud.
 		credentialName = cloudCredentials.DefaultCredential
+		if credentialName == "" && len(cloudCredentials.AuthCredentials) == 1 {
+			for credentialName = range cloudCredentials.AuthCredentials {
+			}
+		}
 	}
 	credential, ok := cloudCredentials.AuthCredentials[credentialName]
 	if !ok {

--- a/cloud/fallback-public-cloud.yaml
+++ b/cloud/fallback-public-cloud.yaml
@@ -50,68 +50,68 @@ clouds:
     type: azure
     auth-types: [ userpass ]
     regions:
-      Central US:
+      centralus:
         endpoint: https://management.azure.com
         storage-endpoint: https://core.windows.net
-      East US:
+      eastus:
         endpoint: https://management.azure.com
         storage-endpoint: https://core.windows.net
-      East US 2:
+      eastus2:
         endpoint: https://management.azure.com
         storage-endpoint: https://core.windows.net
-      North Central US:
+      northcentralus:
         endpoint: https://management.azure.com
         storage-endpoint: https://core.windows.net
-      South Central US:
+      southcentralus:
         endpoint: https://management.azure.com
         storage-endpoint: https://core.windows.net
-      West US:
+      westus:
         endpoint: https://management.azure.com
         storage-endpoint: https://core.windows.net
-      North Europe:
+      northeurope:
         endpoint: https://management.azure.com
         storage-endpoint: https://core.windows.net
-      West Europe:
+      westeurope:
         endpoint: https://management.azure.com
         storage-endpoint: https://core.windows.net
-      East Asia:
+      eastasia:
         endpoint: https://management.azure.com
         storage-endpoint: https://core.windows.net
-      Southeast Asia:
+      southeastasia:
         endpoint: https://management.azure.com
         storage-endpoint: https://core.windows.net
-      Japan East:
+      japaneast:
         endpoint: https://management.azure.com
         storage-endpoint: https://core.windows.net
-      Japan West:
+      japanwest:
         endpoint: https://management.azure.com
         storage-endpoint: https://core.windows.net
-      Brazil South:
+      brazilsouth:
         endpoint: https://management.azure.com
         storage-endpoint: https://core.windows.net
-      Australia East:
+      australiaeast:
         endpoint: https://management.azure.com
         storage-endpoint: https://core.windows.net
-      Australia Southeast:
+      australiasoutheast:
         endpoint: https://management.azure.com
         storage-endpoint: https://core.windows.net
-      Central India:
+      centralindia:
         endpoint: https://management.azure.com
         storage-endpoint: https://core.windows.net
-      South India:
+      southindia:
         endpoint: https://management.azure.com
         storage-endpoint: https://core.windows.net
-      West India:
+      westindia:
         endpoint: https://management.azure.com
         storage-endpoint: https://core.windows.net
   azure-china:
     type: azure
     auth-types: [ userpass ]
     regions:
-      China East:
+      chinaeast:
         endpoint: https://management.chinacloudapi.cn
         storage-endpoint: https://core.chinacloudapi.cn
-      China North:
+      chinanorth:
         endpoint: https://management.chinacloudapi.cn
         storage-endpoint: https://core.chinacloudapi.cn
   rackspace:
@@ -119,17 +119,17 @@ clouds:
     auth-types: [ access-key, userpass ]
     endpoint: https://identity.api.rackspacecloud.com/v2.0
     regions:
-      Dallas-Fort Worth:
+      DFW:
         endpoint: https://identity.api.rackspacecloud.com/v2.0
-      Chicago:
+      ORD:
         endpoint: https://identity.api.rackspacecloud.com/v2.0
-      Northern Virginia:
+      IAD:
         endpoint: https://identity.api.rackspacecloud.com/v2.0
-      London:
+      LON:
         endpoint: https://lon.identity.api.rackspacecloud.com/v2.0
-      Sydney:
+      SYD:
         endpoint: https://identity.api.rackspacecloud.com/v2.0
-      Hong Kong:
+      HKG:
         endpoint: https://identity.api.rackspacecloud.com/v2.0
   joyent:
     type: joyent

--- a/cloud/fallback_public_cloud.go
+++ b/cloud/fallback_public_cloud.go
@@ -58,68 +58,68 @@ clouds:
     type: azure
     auth-types: [ userpass ]
     regions:
-      Central US:
+      centralus:
         endpoint: https://management.azure.com
         storage-endpoint: https://core.windows.net
-      East US:
+      eastus:
         endpoint: https://management.azure.com
         storage-endpoint: https://core.windows.net
-      East US 2:
+      eastus2:
         endpoint: https://management.azure.com
         storage-endpoint: https://core.windows.net
-      North Central US:
+      northcentralus:
         endpoint: https://management.azure.com
         storage-endpoint: https://core.windows.net
-      South Central US:
+      southcentralus:
         endpoint: https://management.azure.com
         storage-endpoint: https://core.windows.net
-      West US:
+      westus:
         endpoint: https://management.azure.com
         storage-endpoint: https://core.windows.net
-      North Europe:
+      northeurope:
         endpoint: https://management.azure.com
         storage-endpoint: https://core.windows.net
-      West Europe:
+      westeurope:
         endpoint: https://management.azure.com
         storage-endpoint: https://core.windows.net
-      East Asia:
+      eastasia:
         endpoint: https://management.azure.com
         storage-endpoint: https://core.windows.net
-      Southeast Asia:
+      southeastasia:
         endpoint: https://management.azure.com
         storage-endpoint: https://core.windows.net
-      Japan East:
+      japaneast:
         endpoint: https://management.azure.com
         storage-endpoint: https://core.windows.net
-      Japan West:
+      japanwest:
         endpoint: https://management.azure.com
         storage-endpoint: https://core.windows.net
-      Brazil South:
+      brazilsouth:
         endpoint: https://management.azure.com
         storage-endpoint: https://core.windows.net
-      Australia East:
+      australiaeast:
         endpoint: https://management.azure.com
         storage-endpoint: https://core.windows.net
-      Australia Southeast:
+      australiasoutheast:
         endpoint: https://management.azure.com
         storage-endpoint: https://core.windows.net
-      Central India:
+      centralindia:
         endpoint: https://management.azure.com
         storage-endpoint: https://core.windows.net
-      South India:
+      southindia:
         endpoint: https://management.azure.com
         storage-endpoint: https://core.windows.net
-      West India:
+      westindia:
         endpoint: https://management.azure.com
         storage-endpoint: https://core.windows.net
   azure-china:
     type: azure
     auth-types: [ userpass ]
     regions:
-      China East:
+      chinaeast:
         endpoint: https://management.chinacloudapi.cn
         storage-endpoint: https://core.chinacloudapi.cn
-      China North:
+      chinanorth:
         endpoint: https://management.chinacloudapi.cn
         storage-endpoint: https://core.chinacloudapi.cn
   rackspace:
@@ -127,17 +127,17 @@ clouds:
     auth-types: [ access-key, userpass ]
     endpoint: https://identity.api.rackspacecloud.com/v2.0
     regions:
-      Dallas-Fort Worth:
+      DFW:
         endpoint: https://identity.api.rackspacecloud.com/v2.0
-      Chicago:
+      ORD:
         endpoint: https://identity.api.rackspacecloud.com/v2.0
-      Northern Virginia:
+      IAD:
         endpoint: https://identity.api.rackspacecloud.com/v2.0
-      London:
+      LON:
         endpoint: https://lon.identity.api.rackspacecloud.com/v2.0
-      Sydney:
+      SYD:
         endpoint: https://identity.api.rackspacecloud.com/v2.0
-      Hong Kong:
+      HKG:
         endpoint: https://identity.api.rackspacecloud.com/v2.0
   joyent:
     type: joyent


### PR DESCRIPTION
- Use the lower-case, no-whitespace names for Azure. Better
  for scripts and the command line.
- Correct the region names for RackSpace, now as according to
  https://developer.rackspace.com/docs/cloud-servers/v2/developer-guide/#service-access-endpoints
- If there is only one credential, it is the implied default

(Review request: http://reviews.vapour.ws/r/3841/)