### PR TITLE
cmd/juju/commands: allow bootstrap with no regions

### DIFF
--- a/provider/maas/config.go
+++ b/provider/maas/config.go
@@ -16,6 +16,15 @@ import (
 )
 
 var configSchema = environschema.Fields{
+	"maas-server": {
+		Description: "maas-server specifies the location of the MAAS server. It must specify the base path.",
+		Type:        environschema.Tstring,
+		Example:     "http://192.168.1.1/MAAS/",
+	},
+	"maas-oauth": {
+		Description: "maas-oauth holds the OAuth credentials from MAAS.",
+		Type:        environschema.Tstring,
+	},
 	"maas-agent-name": {
 		Description: "maas-agent-name is an optional UUID to group the instances acquired from MAAS, to support multiple models per MAAS user.",
 		Type:        environschema.Tstring,


### PR DESCRIPTION
If a cloud defines no regions, and no region is
specified, we should just pass an empty region
name to the provider, with the cloud's endpoint
values.

This enables the definition of a MAAS cloud with
no regions. i.e. with this change you can have:

    clouds:
      my-maas:
        type: maas
        auth-types: [oauth1]
        endpoint http://maas-host/MAAS

Also reinstate maas-server and maas-oauth config
attributes. They need to be there or we get spurious
warnings about unknown attributes.

(Review request: http://reviews.vapour.ws/r/3843/)