### PR TITLE
cmd/juju/backups: remove -b flag from restore

### DIFF
--- a/cmd/juju/backups/restore_test.go
+++ b/cmd/juju/backups/restore_test.go
@@ -29,7 +29,4 @@ func (s *restoreSuite) TestRestoreArgs(c *gc.C) {
 
 	_, err = testing.RunCommand(c, s.command, "restore", "--id", "anid", "--file", "afile")
 	c.Assert(err, gc.ErrorMatches, "you must specify either a file or a backup id but not both.")
-
-	_, err = testing.RunCommand(c, s.command, "restore", "--id", "anid", "-b")
-	c.Assert(err, gc.ErrorMatches, "it is not possible to rebootstrap and restore from an id.")
 }


### PR DESCRIPTION
Remove the ability to bootstrap in the restore-boostrap
command. You must now bootstrap and then restore.

(Review request: http://reviews.vapour.ws/r/3845/)