### PR TITLE
Make discovery more resiliient against deadlock and fix a couple of tests

### DIFF
--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -1262,9 +1262,8 @@ func (a *MachineAgent) startEnvWorkers(
 		return w, nil
 	})
 	singularRunner.StartWorker("discoverspaces", func() (worker.Worker, error) {
-		a.discoveringSpacesMutex.Lock()
-		defer a.discoveringSpacesMutex.Unlock()
 		w, discoveringSpaces := newDiscoverSpaces(apiSt.DiscoverSpaces())
+		a.discoveringSpacesMutex.Lock()
 		if a.discoveringSpaces == nil {
 			// If the discovery channel has not been set, set it here. If
 			// it has been set then the worker has been restarted and we
@@ -1272,6 +1271,7 @@ func (a *MachineAgent) startEnvWorkers(
 			// will block the api.
 			a.discoveringSpaces = discoveringSpaces
 		}
+		a.discoveringSpacesMutex.Unlock()
 		return w, nil
 	})
 
@@ -1483,8 +1483,6 @@ func (a *MachineAgent) limitLogins(req params.LoginRequest) error {
 // limitLoginsUntilSpacesDiscovered will prevent logins from clients until
 // space discovery is completed.
 func (a *MachineAgent) limitLoginsUntilSpacesDiscovered(req params.LoginRequest) error {
-	a.discoveringSpacesMutex.Lock()
-	defer a.discoveringSpacesMutex.Unlock()
 	if a.discoveringSpaces == nil {
 		// Space discovery not started.
 		return nil

--- a/featuretests/upgrade_test.go
+++ b/featuretests/upgrade_test.go
@@ -313,7 +313,11 @@ func (s *upgradeSuite) attemptRestrictedAPIAsUser(c *gc.C, conf agent.Config) er
 	info.Nonce = ""
 
 	apiState, err := api.Open(info, upgradeTestDialOpts)
-	c.Assert(err, jc.ErrorIsNil)
+	if err != nil {
+		// If space discovery is in progress we'll get an error here
+		// and need to retry.
+		return err
+	}
 	defer apiState.Close()
 
 	// this call should always work

--- a/worker/discoverspaces/worker_test.go
+++ b/worker/discoverspaces/worker_test.go
@@ -164,9 +164,7 @@ func (s *workerSuite) TestWorkerDiscoversSpaces(c *gc.C) {
 		}
 	}
 
-	var err error
-	var spaces []*state.Space
-	spaces, err = s.State.AllSpaces()
+	spaces, err := s.State.AllSpaces()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(spaces, gc.HasLen, 4)
 	expectedSpaces := []network.SpaceInfo{{


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/juju-core/+bug/1545057
Also fixes an intermittent failure in upgrade_test.

Tightens the scope of the locking around discoverspaces worker to remove possibility of deadlock.

(Review request: http://reviews.vapour.ws/r/3848/)