### PR TITLE
provider/manual: take host from region/endpoint

### DIFF
--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -484,25 +484,25 @@ func (c *bootstrapCommand) getCredentials(
 // and just pass this on to the provider. In this case, the returned
 // region name will be empty.
 func getRegion(cloud *jujucloud.Cloud, cloudName, regionName string) (string, jujucloud.Region, error) {
+	if len(cloud.Regions) == 0 {
+		// The cloud does not specify regions, so assume
+		// that the cloud provider does not have a concept
+		// of regions, or has no pre-defined regions, and
+		// defer validation to the provider.
+		region := jujucloud.Region{
+			cloud.Endpoint,
+			cloud.StorageEndpoint,
+		}
+		return regionName, region, nil
+	}
 	if regionName == "" {
-		switch len(cloud.Regions) {
-		case 0:
-			// The cloud has no regions, and no region was
-			// specified, so assume that the cloud provider
-			// does not have a concept of regions, and defer
-			// validation to the provider.
-			region := jujucloud.Region{
-				cloud.Endpoint,
-				cloud.StorageEndpoint,
-			}
-			return "", region, nil
-		case 1:
+		if len(cloud.Regions) == 1 {
 			// No region was specified and there is
 			// only one in the cloud; use it.
 			for regionName, region := range cloud.Regions {
 				return regionName, region, nil
 			}
-		default:
+		} else {
 			return "", jujucloud.Region{}, errors.Errorf(
 				"no region specified, and no default set (expected one of %q)",
 				cloudRegionNames(cloud),

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -835,6 +835,22 @@ func (s *BootstrapSuite) TestBootstrapCloudNoRegions(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
+func (s *BootstrapSuite) TestBootstrapCloudNoRegionsOneSpecified(c *gc.C) {
+	resetJujuXDGDataHome(c)
+	ctx, err := coretesting.RunCommand(
+		c, newBootstrapCommand(), "ctrl/my-region", "dummy-cloud-without-regions",
+		"--config", "default-series=precise",
+	)
+	// If the cloud doesn't have any regions defined, we still allow the
+	// user to pass a region through. This enables the manual provider to
+	// take the bootstrap-host from the region name, and later, will
+	// enable the lxd provider to take the lxd remote from the region
+	// name.
+	c.Check(coretesting.Stderr(ctx), gc.Matches,
+		"Creating Juju controller \"ctrl/my-region\" on dummy-cloud-without-regions(.|\n)*")
+	c.Assert(err, jc.ErrorIsNil)
+}
+
 func (s *BootstrapSuite) TestBootstrapProviderNoCredentials(c *gc.C) {
 	s.patchVersionAndSeries(c, "raring")
 	_, err := coretesting.RunCommand(c, newBootstrapCommand(), "ctrl", "no-credentials")


### PR DESCRIPTION
The manual provider is updated to support DetectRegions,
which just returns "NotFound" to indicate that there are
no pre-defined regions. This allows the provider to be
used without a clouds.yaml entry.

In addition, we now support taking the bootstrap-host
value from the endpoint (if specified in clouds.yaml),
or the "region name" (if specified on the command line
with no corresponding clouds.yaml entry).

i.e. you can now do:

    juju bootstrap manual/<host>

(Review request: http://reviews.vapour.ws/r/3854/)