### PR TITLE
Minor changes/fixes to jujuclienttesting

### DIFF
--- a/apiserver/addresser/addresser_test.go
+++ b/apiserver/addresser/addresser_test.go
@@ -278,7 +278,7 @@ func testingEnvConfig(c *gc.C) *config.Config {
 	c.Assert(err, jc.ErrorIsNil)
 	env, err := environs.Prepare(
 		modelcmd.BootstrapContext(coretesting.Context(c)), configstore.NewMem(),
-		jujuclienttesting.NewMemControllerStore(),
+		jujuclienttesting.NewMemStore(),
 		"dummycontroller", environs.PrepareForBootstrapParams{Config: cfg},
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -303,7 +303,7 @@ func mockTestingEnvConfig(c *gc.C) *config.Config {
 	c.Assert(err, jc.ErrorIsNil)
 	env, err := environs.Prepare(
 		modelcmd.BootstrapContext(coretesting.Context(c)), configstore.NewMem(),
-		jujuclienttesting.NewMemControllerStore(),
+		jujuclienttesting.NewMemStore(),
 		"dummycontroller", environs.PrepareForBootstrapParams{Config: cfg},
 	)
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/common/modelwatcher_test.go
+++ b/apiserver/common/modelwatcher_test.go
@@ -128,7 +128,7 @@ func testingEnvConfig(c *gc.C) *config.Config {
 	c.Assert(err, jc.ErrorIsNil)
 	env, err := environs.Prepare(
 		modelcmd.BootstrapContext(testing.Context(c)), configstore.NewMem(),
-		jujuclienttesting.NewMemControllerStore(),
+		jujuclienttesting.NewMemStore(),
 		"dummycontroller", environs.PrepareForBootstrapParams{Config: cfg},
 	)
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/imagemetadata/functions_test.go
+++ b/apiserver/imagemetadata/functions_test.go
@@ -36,7 +36,7 @@ func (s *funcSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	s.env, err = environs.Prepare(
 		envtesting.BootstrapContext(c), configstore.NewMem(),
-		jujuclienttesting.NewMemControllerStore(),
+		jujuclienttesting.NewMemStore(),
 		"dummycontroller", environs.PrepareForBootstrapParams{Config: cfg},
 	)
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/imagemetadata/package_test.go
+++ b/apiserver/imagemetadata/package_test.go
@@ -128,7 +128,7 @@ func testConfig(c *gc.C) *config.Config {
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = environs.Prepare(
 		envtesting.BootstrapContext(c), configstore.NewMem(),
-		jujuclienttesting.NewMemControllerStore(),
+		jujuclienttesting.NewMemStore(),
 		"dummycontroller", environs.PrepareForBootstrapParams{Config: cfg},
 	)
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/imagemetadata/updatefrompublished_test.go
+++ b/apiserver/imagemetadata/updatefrompublished_test.go
@@ -168,7 +168,7 @@ func (s *imageMetadataUpdateSuite) TestUpdateFromPublishedImagesForProviderWithN
 		c.Assert(err, jc.ErrorIsNil)
 		env, err := environs.Prepare(
 			modelcmd.BootstrapContext(testing.Context(c)), configstore.NewMem(),
-			jujuclienttesting.NewMemControllerStore(),
+			jujuclienttesting.NewMemStore(),
 			"dummycontroller", environs.PrepareForBootstrapParams{Config: cfg},
 		)
 		c.Assert(err, jc.ErrorIsNil)

--- a/cmd/juju/controller/listcontrollers_test.go
+++ b/cmd/juju/controller/listcontrollers_test.go
@@ -28,7 +28,7 @@ CONTROLLER  MODEL  USER  SERVER
 
 `[1:]
 
-	s.store = jujuclienttesting.NewMemControllerStore()
+	s.store = jujuclienttesting.NewMemStore()
 	s.assertListControllers(c)
 }
 

--- a/cmd/jujud/bootstrap_test.go
+++ b/cmd/jujud/bootstrap_test.go
@@ -35,7 +35,6 @@ import (
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
-	"github.com/juju/juju/environs/configstore"
 	"github.com/juju/juju/environs/filestorage"
 	"github.com/juju/juju/environs/simplestreams"
 	sstesting "github.com/juju/juju/environs/simplestreams/testing"
@@ -57,8 +56,6 @@ import (
 	"github.com/juju/juju/tools"
 	"github.com/juju/juju/version"
 )
-
-var _ = configstore.Default
 
 // We don't want to use JujuConnSuite because it gives us
 // an already-bootstrapped environment.

--- a/cmd/plugins/juju-metadata/toolsmetadata_test.go
+++ b/cmd/plugins/juju-metadata/toolsmetadata_test.go
@@ -53,7 +53,7 @@ func (s *ToolsMetadataSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	env, err := environs.Prepare(
 		modelcmd.BootstrapContextNoVerify(coretesting.Context(c)),
-		configstore.NewMem(), jujuclienttesting.NewMemControllerStore(), cfg.Name(),
+		configstore.NewMem(), jujuclienttesting.NewMemStore(), cfg.Name(),
 		environs.PrepareForBootstrapParams{Config: cfg},
 	)
 	c.Assert(err, jc.ErrorIsNil)

--- a/environs/imagemetadata_test.go
+++ b/environs/imagemetadata_test.go
@@ -48,7 +48,7 @@ func (s *ImageMetadataSuite) env(c *gc.C, imageMetadataURL, stream string) envir
 	c.Assert(err, jc.ErrorIsNil)
 	env, err := environs.Prepare(
 		envtesting.BootstrapContext(c), configstore.NewMem(),
-		jujuclienttesting.NewMemControllerStore(),
+		jujuclienttesting.NewMemStore(),
 		cfg.Name(), environs.PrepareForBootstrapParams{Config: cfg},
 	)
 	c.Assert(err, jc.ErrorIsNil)

--- a/environs/jujutest/livetests.go
+++ b/environs/jujutest/livetests.go
@@ -105,7 +105,7 @@ func (t *LiveTests) SetUpSuite(c *gc.C) {
 	t.CleanupSuite.SetUpSuite(c)
 	t.TestDataSuite.SetUpSuite(c)
 	t.ConfigStore = configstore.NewMem()
-	t.ControllerStore = jujuclienttesting.NewMemControllerStore()
+	t.ControllerStore = jujuclienttesting.NewMemStore()
 	t.PatchValue(&simplestreams.SimplestreamsJujuPublicKey, sstesting.SignedMetadataPublicKey)
 }
 
@@ -822,7 +822,7 @@ func (t *LiveTests) TestBootstrapWithDefaultSeries(c *gc.C) {
 	args.Config = dummyCfg
 	dummyenv, err := environs.Prepare(envtesting.BootstrapContext(c),
 		configstore.NewMem(),
-		jujuclienttesting.NewMemControllerStore(),
+		jujuclienttesting.NewMemStore(),
 		dummyCfg.Name(),
 		args)
 	c.Assert(err, jc.ErrorIsNil)

--- a/environs/jujutest/tests.go
+++ b/environs/jujutest/tests.go
@@ -84,7 +84,7 @@ func (t *Tests) SetUpTest(c *gc.C) {
 	t.ToolsFixture.SetUpTest(c)
 	t.UploadFakeToolsToDirectory(c, storageDir, "released", "released")
 	t.ConfigStore = configstore.NewMem()
-	t.ControllerStore = jujuclienttesting.NewMemControllerStore()
+	t.ControllerStore = jujuclienttesting.NewMemStore()
 }
 
 func (t *Tests) TearDownTest(c *gc.C) {

--- a/environs/open_test.go
+++ b/environs/open_test.go
@@ -49,7 +49,7 @@ func (s *OpenSuite) TestNewDummyEnviron(c *gc.C) {
 	cfg, err := config.New(config.NoDefaults, dummySampleConfig())
 	c.Assert(err, jc.ErrorIsNil)
 	ctx := envtesting.BootstrapContext(c)
-	cache := jujuclienttesting.NewMemControllerStore()
+	cache := jujuclienttesting.NewMemStore()
 	env, err := environs.Prepare(ctx, configstore.NewMem(), cache, cfg.Name(), environs.PrepareForBootstrapParams{Config: cfg})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -72,7 +72,7 @@ func (s *OpenSuite) TestNewDummyEnviron(c *gc.C) {
 
 func (s *OpenSuite) TestUpdateEnvInfo(c *gc.C) {
 	store := configstore.NewMem()
-	cache := jujuclienttesting.NewMemControllerStore()
+	cache := jujuclienttesting.NewMemStore()
 	ctx := envtesting.BootstrapContext(c)
 	cfg, err := config.New(config.UseDefaults, map[string]interface{}{
 		"type": "dummy",
@@ -133,7 +133,7 @@ func (*OpenSuite) TestPrepare(c *gc.C) {
 	cfg, err := config.New(config.NoDefaults, baselineAttrs)
 	c.Assert(err, jc.ErrorIsNil)
 	store := configstore.NewMem()
-	controllerStore := jujuclienttesting.NewMemControllerStore()
+	controllerStore := jujuclienttesting.NewMemStore()
 	ctx := envtesting.BootstrapContext(c)
 	env, err := environs.Prepare(ctx, store, controllerStore, cfg.Name(), environs.PrepareForBootstrapParams{Config: cfg})
 	c.Assert(err, jc.ErrorIsNil)
@@ -188,13 +188,13 @@ func (*OpenSuite) TestPrepareGeneratesDifferentAdminSecrets(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	ctx := envtesting.BootstrapContext(c)
-	env0, err := environs.Prepare(ctx, configstore.NewMem(), jujuclienttesting.NewMemControllerStore(), cfg.Name(), environs.PrepareForBootstrapParams{Config: cfg})
+	env0, err := environs.Prepare(ctx, configstore.NewMem(), jujuclienttesting.NewMemStore(), cfg.Name(), environs.PrepareForBootstrapParams{Config: cfg})
 	c.Assert(err, jc.ErrorIsNil)
 	adminSecret0 := env0.Config().AdminSecret()
 	c.Assert(adminSecret0, gc.HasLen, 32)
 	c.Assert(adminSecret0, gc.Matches, "^[0-9a-f]*$")
 
-	env1, err := environs.Prepare(ctx, configstore.NewMem(), jujuclienttesting.NewMemControllerStore(), cfg.Name(), environs.PrepareForBootstrapParams{Config: cfg})
+	env1, err := environs.Prepare(ctx, configstore.NewMem(), jujuclienttesting.NewMemStore(), cfg.Name(), environs.PrepareForBootstrapParams{Config: cfg})
 	c.Assert(err, jc.ErrorIsNil)
 	adminSecret1 := env1.Config().AdminSecret()
 	c.Assert(adminSecret1, gc.HasLen, 32)
@@ -213,7 +213,7 @@ func (*OpenSuite) TestPrepareWithMissingKey(c *gc.C) {
 	))
 	c.Assert(err, jc.ErrorIsNil)
 	store := configstore.NewMem()
-	controllerStore := jujuclienttesting.NewMemControllerStore()
+	controllerStore := jujuclienttesting.NewMemStore()
 	env, err := environs.Prepare(envtesting.BootstrapContext(c), store, controllerStore, cfg.Name(), environs.PrepareForBootstrapParams{Config: cfg})
 	c.Assert(err, gc.ErrorMatches, "cannot ensure CA certificate: controller configuration with a certificate but no CA private key")
 	c.Assert(env, gc.IsNil)
@@ -233,7 +233,7 @@ func (*OpenSuite) TestPrepareWithExistingKeyPair(c *gc.C) {
 	))
 	c.Assert(err, jc.ErrorIsNil)
 	ctx := envtesting.BootstrapContext(c)
-	env, err := environs.Prepare(ctx, configstore.NewMem(), jujuclienttesting.NewMemControllerStore(), cfg.Name(), environs.PrepareForBootstrapParams{Config: cfg})
+	env, err := environs.Prepare(ctx, configstore.NewMem(), jujuclienttesting.NewMemStore(), cfg.Name(), environs.PrepareForBootstrapParams{Config: cfg})
 	c.Assert(err, jc.ErrorIsNil)
 	cfgCertPEM, cfgCertOK := env.Config().CACert()
 	cfgKeyPEM, cfgKeyOK := env.Config().CAPrivateKey()
@@ -253,7 +253,7 @@ func (*OpenSuite) TestDestroy(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	store := configstore.NewMem()
-	controllerStore := jujuclienttesting.NewMemControllerStore()
+	controllerStore := jujuclienttesting.NewMemStore()
 	// Prepare the environment and sanity-check that
 	// the config storage info has been made.
 	ctx := envtesting.BootstrapContext(c)

--- a/environs/tools/tools_test.go
+++ b/environs/tools/tools_test.go
@@ -100,7 +100,7 @@ func (s *SimpleStreamsToolsSuite) resetEnv(c *gc.C, attrs map[string]interface{}
 	cfg, err := config.New(config.NoDefaults, dummy.SampleConfig().Merge(attrs))
 	c.Assert(err, jc.ErrorIsNil)
 	env, err := environs.Prepare(envtesting.BootstrapContext(c), configstore.NewMem(),
-		jujuclienttesting.NewMemControllerStore(),
+		jujuclienttesting.NewMemStore(),
 		cfg.Name(), environs.PrepareForBootstrapParams{Config: cfg})
 	c.Assert(err, jc.ErrorIsNil)
 	s.env = env

--- a/environs/tools/urls_test.go
+++ b/environs/tools/urls_test.go
@@ -47,7 +47,7 @@ func (s *URLsSuite) env(c *gc.C, toolsMetadataURL string) environs.Environ {
 	cfg, err := config.New(config.NoDefaults, attrs)
 	c.Assert(err, jc.ErrorIsNil)
 	env, err := environs.Prepare(envtesting.BootstrapContext(c), configstore.NewMem(),
-		jujuclienttesting.NewMemControllerStore(),
+		jujuclienttesting.NewMemStore(),
 		cfg.Name(), environs.PrepareForBootstrapParams{Config: cfg})
 	c.Assert(err, jc.ErrorIsNil)
 	return env

--- a/provider/dummy/config_test.go
+++ b/provider/dummy/config_test.go
@@ -34,7 +34,7 @@ func (*ConfigSuite) TestSecretAttrs(c *gc.C) {
 	ctx := envtesting.BootstrapContext(c)
 	env, err := environs.Prepare(
 		ctx, configstore.NewMem(),
-		jujuclienttesting.NewMemControllerStore(), cfg.Name(),
+		jujuclienttesting.NewMemStore(), cfg.Name(),
 		environs.PrepareForBootstrapParams{Config: cfg},
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -91,7 +91,7 @@ func (s *ConfigSuite) TestFirewallMode(c *gc.C) {
 		ctx := envtesting.BootstrapContext(c)
 		env, err := environs.Prepare(
 			ctx, configstore.NewMem(),
-			jujuclienttesting.NewMemControllerStore(),
+			jujuclienttesting.NewMemStore(),
 			cfg.Name(),
 			environs.PrepareForBootstrapParams{Config: cfg},
 		)

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -1263,7 +1263,7 @@ func (t *localNonUSEastSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	env, err := environs.Prepare(
 		envtesting.BootstrapContext(c), configstore.NewMem(),
-		jujuclienttesting.NewMemControllerStore(),
+		jujuclienttesting.NewMemStore(),
 		cfg.Name(), environs.PrepareForBootstrapParams{
 			Config: cfg,
 			Credentials: cloud.NewCredential(

--- a/provider/joyent/export_test.go
+++ b/provider/joyent/export_test.go
@@ -202,7 +202,7 @@ func MakeConfig(c *gc.C, attrs testing.Attrs) *environConfig {
 	c.Assert(err, jc.ErrorIsNil)
 	env, err := environs.Prepare(
 		envtesting.BootstrapContext(c), configstore.NewMem(),
-		jujuclienttesting.NewMemControllerStore(),
+		jujuclienttesting.NewMemStore(),
 		cfg.Name(),
 		environs.PrepareForBootstrapParams{
 			Config: cfg,

--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -1174,7 +1174,7 @@ func (s *localHTTPSServerSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	s.env, err = environs.Prepare(
 		envtesting.BootstrapContext(c), configstore.NewMem(),
-		jujuclienttesting.NewMemControllerStore(),
+		jujuclienttesting.NewMemStore(),
 		cfg.Name(), prepareForBootstrapParams(cfg, s.cred),
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1790,7 +1790,7 @@ func (s *noSwiftSuite) SetUpTest(c *gc.C) {
 	configStore := configstore.NewMem()
 	env, err := environs.Prepare(
 		envtesting.BootstrapContext(c), configStore,
-		jujuclienttesting.NewMemControllerStore(),
+		jujuclienttesting.NewMemStore(),
 		cfg.Name(), prepareForBootstrapParams(cfg, s.cred),
 	)
 	c.Assert(err, jc.ErrorIsNil)

--- a/worker/undertaker/undertaker_test.go
+++ b/worker/undertaker/undertaker_test.go
@@ -273,7 +273,7 @@ func testingEnvConfig(c *gc.C) *config.Config {
 	c.Assert(err, jc.ErrorIsNil)
 	env, err := environs.Prepare(
 		modelcmd.BootstrapContext(testing.Context(c)), configstore.NewMem(),
-		jujuclienttesting.NewMemControllerStore(),
+		jujuclienttesting.NewMemStore(),
 		"dummycontroller", environs.PrepareForBootstrapParams{Config: cfg},
 	)
 	c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
- Rename NewMemControllerStore to NewMemStore
- Rename inMemory to MemStore (exported)
- Export fields of MemStore to enable unit tests
  to initialise test stores succinctly
- Change type of Models and Accounts fields of
  MemStore to store pointer-to-struct for models
  and accounts; we weren't persisting updates.

(Review request: http://reviews.vapour.ws/r/3857/)