### PR TITLE
Remove incorrect config item

### DIFF
--- a/provider/rackspace/provider_configurator.go
+++ b/provider/rackspace/provider_configurator.go
@@ -46,7 +46,6 @@ func (c *rackspaceConfigurator) GetConfigDefaults() schema.Defaults {
 		"access-key":           "",
 		"secret-key":           "",
 		"region":               "",
-		"control-bucket":       "",
 		"use-floating-ip":      false,
 		"use-default-secgroup": false,
 		"network":              "",


### PR DESCRIPTION
Looks like a cut and paste error. This prevented create-model from working on rackspace. Fix tested by Rick in his demo.

(Review request: http://reviews.vapour.ws/r/3858/)