### PR TITLE
cmd/modelcmd: inject jujuclient.ClientStore

### DIFF
--- a/cmd/juju/action/package_test.go
+++ b/cmd/juju/action/package_test.go
@@ -37,13 +37,14 @@ func TestPackage(t *testing.T) {
 }
 
 type BaseActionSuite struct {
-	jujutesting.IsolationSuite
+	coretesting.FakeJujuXDGDataHomeSuite
 	command cmd.Command
 
 	modelFlags []string
 }
 
 func (s *BaseActionSuite) SetUpTest(c *gc.C) {
+	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
 	s.command = action.NewSuperCommand()
 
 	s.modelFlags = []string{"-m", "--model"}

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -114,7 +114,7 @@ type bootstrapCommand struct {
 	AgentVersion          *version.Number
 	config                configFlag
 
-	ControllerName string
+	controllerName string
 	CredentialName string
 	Cloud          string
 	Region         string
@@ -197,7 +197,7 @@ func (c *bootstrapCommand) Init(args []string) (err error) {
 	if len(args) < 2 {
 		return errors.New("controller name and cloud name are required")
 	}
-	c.ControllerName = args[0]
+	c.controllerName = args[0]
 	c.Cloud = args[1]
 	if i := strings.IndexRune(c.Cloud, '/'); i > 0 {
 		c.Cloud, c.Region = c.Cloud[:i], c.Cloud[i+1:]
@@ -329,7 +329,7 @@ func (c *bootstrapCommand) Run(ctx *cmd.Context) (resultErr error) {
 	}
 	controllerStore := jujuclient.NewFileClientStore()
 	environ, err := environsPrepare(
-		modelcmd.BootstrapContext(ctx), store, controllerStore, c.ControllerName,
+		modelcmd.BootstrapContext(ctx), store, controllerStore, c.controllerName,
 		environs.PrepareForBootstrapParams{
 			Config:               cfg,
 			Credentials:          *credential,
@@ -348,7 +348,7 @@ func (c *bootstrapCommand) Run(ctx *cmd.Context) (resultErr error) {
 	}
 	ctx.Infof(
 		"Creating Juju controller %q on %s",
-		c.ControllerName, cloudRegion,
+		c.controllerName, cloudRegion,
 	)
 
 	// If we error out for any reason, clean up the environment.
@@ -361,7 +361,7 @@ When you are finished diagnosing the problem, remember to run juju destroy-model
 to clean up the model.`[1:])
 			} else {
 				handleBootstrapError(ctx, resultErr, func() error {
-					return environsDestroy(c.ControllerName, environ, store)
+					return environsDestroy(c.controllerName, environ, store)
 				})
 			}
 		}
@@ -413,13 +413,13 @@ to clean up the model.`[1:])
 		return errors.Annotate(err, "failed to bootstrap model")
 	}
 
-	c.SetModelName(c.ControllerName)
+	c.SetModelName(c.controllerName)
 	err = c.SetBootstrapEndpointAddress(environ)
 	if err != nil {
 		return errors.Annotate(err, "saving bootstrap endpoint address")
 	}
 
-	err = modelcmd.SetCurrentModel(ctx, c.ControllerName)
+	err = modelcmd.SetCurrentModel(ctx, c.controllerName)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -663,7 +663,7 @@ func (c *bootstrapCommand) SetBootstrapEndpointAddress(environ environs.Environ)
 	}
 
 	controllerStore := jujuclient.NewFileClientStore()
-	err = controllerStore.UpdateController(c.ControllerName, jujuclient.ControllerDetails{
+	err = controllerStore.UpdateController(c.controllerName, jujuclient.ControllerDetails{
 		hosts,
 		endpoint.ServerUUID,
 		addrs,

--- a/cmd/juju/commands/commands_test.go
+++ b/cmd/juju/commands/commands_test.go
@@ -81,11 +81,10 @@ func (c *stubCommand) Run(ctx *cmd.Context) error {
 	return nil
 }
 
-func (c *stubCommand) SetModelName(name string) {
+func (c *stubCommand) SetModelName(name string) error {
 	c.stub.AddCall("SetModelName", name)
-	c.stub.NextErr() // pop one off
-
 	c.envName = name
+	return c.stub.NextErr()
 }
 
 func (c *stubCommand) ModelName() string {

--- a/cmd/juju/commands/synctools_test.go
+++ b/cmd/juju/commands/synctools_test.go
@@ -27,14 +27,14 @@ import (
 )
 
 type syncToolsSuite struct {
-	coretesting.BaseSuite
+	coretesting.FakeJujuXDGDataHomeSuite
 	fakeSyncToolsAPI *fakeSyncToolsAPI
 }
 
 var _ = gc.Suite(&syncToolsSuite{})
 
 func (s *syncToolsSuite) SetUpTest(c *gc.C) {
-	s.BaseSuite.SetUpTest(c)
+	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
 	s.fakeSyncToolsAPI = &fakeSyncToolsAPI{}
 	s.PatchValue(&getSyncToolsAPI, func(c *syncToolsCommand) (syncToolsAPI, error) {
 		return s.fakeSyncToolsAPI, nil

--- a/cmd/juju/controller/createmodel_test.go
+++ b/cmd/juju/controller/createmodel_test.go
@@ -58,7 +58,7 @@ func (s *createSuite) SetUpTest(c *gc.C) {
 	err := info.Write()
 	c.Assert(err, jc.ErrorIsNil)
 	s.server = info
-	err = modelcmd.WriteCurrentModel(envName)
+	err = modelcmd.WriteCurrentController(envName)
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/cmd/juju/controller/createmodel_test.go
+++ b/cmd/juju/controller/createmodel_test.go
@@ -43,11 +43,11 @@ func (s *createSuite) SetUpTest(c *gc.C) {
 	configstore.Default = func() (configstore.Storage, error) {
 		return s.store, nil
 	}
-	// Set up the current environment, and write just enough info
+	// Set up the current controller, and write just enough info
 	// so we don't try to refresh
-	envName := "test-master"
+	controllerName := "test-master"
 	s.serverUUID = "fake-server-uuid"
-	info := s.store.CreateInfo(envName)
+	info := s.store.CreateInfo(controllerName)
 	info.SetAPIEndpoint(configstore.APIEndpoint{
 		Addresses:  []string{"localhost"},
 		CACert:     testing.CACert,
@@ -58,7 +58,7 @@ func (s *createSuite) SetUpTest(c *gc.C) {
 	err := info.Write()
 	c.Assert(err, jc.ErrorIsNil)
 	s.server = info
-	err = modelcmd.WriteCurrentController(envName)
+	err = modelcmd.WriteCurrentController(controllerName)
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/cmd/juju/controller/export_test.go
+++ b/cmd/juju/controller/export_test.go
@@ -82,7 +82,7 @@ func NewKillCommandForTest(
 	clientapi destroyClientAPI,
 	apierr error,
 	clock clock.Clock,
-	apiOpenFunc func(string) (api.Connection, error),
+	apiOpen modelcmd.APIOpener,
 ) cmd.Command {
 	kill := &killCommand{
 		destroyCommandBase: destroyCommandBase{
@@ -91,7 +91,7 @@ func NewKillCommandForTest(
 			apierr:    apierr,
 		},
 	}
-	return wrapKillCommand(kill, apiOpenFunc, clock)
+	return wrapKillCommand(kill, apiOpen, clock)
 }
 
 // NewListBlocksCommandForTest returns a ListBlocksCommand with the controller

--- a/cmd/juju/controller/kill.go
+++ b/cmd/juju/controller/kill.go
@@ -11,7 +11,6 @@ import (
 	"github.com/juju/utils/clock"
 	"launchpad.net/gnuflag"
 
-	"github.com/juju/juju/api"
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/environs"
@@ -43,11 +42,11 @@ func NewKillCommand() cmd.Command {
 
 // wrapKillCommand provides the common wrapping used by tests and
 // the default NewKillCommand above.
-func wrapKillCommand(kill *killCommand, fn func(string) (api.Connection, error), clock clock.Clock) cmd.Command {
-	if fn == nil {
-		fn = kill.JujuCommandBase.NewAPIRoot
+func wrapKillCommand(kill *killCommand, apiOpen modelcmd.APIOpener, clock clock.Clock) cmd.Command {
+	if apiOpen == nil {
+		apiOpen = modelcmd.OpenFunc(kill.JujuCommandBase.NewAPIRoot)
 	}
-	openStrategy := modelcmd.NewTimeoutOpener(fn, clock, 10*time.Second)
+	openStrategy := modelcmd.NewTimeoutOpener(apiOpen, clock, 10*time.Second)
 	return modelcmd.WrapController(
 		kill,
 		modelcmd.ControllerSkipFlags,

--- a/cmd/juju/controller/register.go
+++ b/cmd/juju/controller/register.go
@@ -35,6 +35,7 @@ func NewRegisterCommand() cmd.Command {
 	cmd := &registerCommand{}
 	cmd.apiOpen = cmd.APIOpen
 	cmd.newAPIRoot = cmd.NewAPIRoot
+	cmd.store = jujuclient.NewFileClientStore()
 	return modelcmd.WrapBase(cmd)
 }
 
@@ -44,6 +45,7 @@ type registerCommand struct {
 	modelcmd.JujuCommandBase
 	apiOpen     api.OpenFunc
 	newAPIRoot  modelcmd.OpenFunc
+	store       jujuclient.ClientStore
 	EncodedData string
 }
 
@@ -161,7 +163,7 @@ func (c *registerCommand) Run(ctx *cmd.Context) error {
 
 	// Log into the controller to verify the credentials, and
 	// refresh the connection information.
-	apiConn, err := c.newAPIRoot(registrationParams.controllerName)
+	apiConn, err := c.newAPIRoot(c.store, registrationParams.controllerName, "")
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/cmd/juju/model/users_test.go
+++ b/cmd/juju/model/users_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 type UsersCommandSuite struct {
+	testing.FakeJujuXDGDataHomeSuite
 	fake *fakeModelUsersClient
 }
 
@@ -33,6 +34,7 @@ func (f *fakeModelUsersClient) ModelUserInfo() ([]params.ModelUserInfo, error) {
 }
 
 func (s *UsersCommandSuite) SetUpTest(c *gc.C) {
+	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
 	last1 := time.Date(2015, 3, 20, 0, 0, 0, 0, time.UTC)
 	last2 := time.Date(2015, 3, 1, 0, 0, 0, 0, time.UTC)
 

--- a/cmd/juju/service/cmd_test.go
+++ b/cmd/juju/service/cmd_test.go
@@ -79,6 +79,7 @@ func (*CmdSuite) TestDeployCommandInit(c *gc.C) {
 		// of this test.
 		c.Assert(com.flagSet, gc.NotNil)
 		com.flagSet = nil
+		com.SetClientStore(nil)
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(com, jc.DeepEquals, t.com)
 	}

--- a/cmd/juju/storage/package_test.go
+++ b/cmd/juju/storage/package_test.go
@@ -38,11 +38,11 @@ func (s *BaseStorageSuite) TearDownTest(c *gc.C) {
 }
 
 type SubStorageSuite struct {
-	jujutesting.BaseSuite
+	jujutesting.FakeJujuXDGDataHomeSuite
 }
 
 func (s *SubStorageSuite) SetUpTest(c *gc.C) {
-	s.BaseSuite.SetUpTest(c)
+	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
 
 	memstore := configstore.NewMem()
 	s.PatchValue(&configstore.Default, func() (configstore.Storage, error) {

--- a/cmd/modelcmd/apiopener.go
+++ b/cmd/modelcmd/apiopener.go
@@ -10,56 +10,47 @@ import (
 	"github.com/juju/utils/clock"
 
 	"github.com/juju/juju/api"
+	"github.com/juju/juju/jujuclient"
 )
 
 var ErrConnTimedOut = errors.New("open connection timed out")
 
-type OpenFunc func(string) (api.Connection, error)
-
 // APIOpener provides a way to open a connection to the Juju
 // API Server through the named connection.
 type APIOpener interface {
-	Open(connectionName string) (api.Connection, error)
+	Open(store jujuclient.ClientStore, controllerName, modelName string) (api.Connection, error)
 }
 
-type passthroughOpener struct {
-	fn OpenFunc
-}
+type OpenFunc func(jujuclient.ClientStore, string, string) (api.Connection, error)
 
-// NewPassthroughOpener returns an instance that will just call the opener
-// function when Open is called.
-func NewPassthroughOpener(opener OpenFunc) APIOpener {
-	return &passthroughOpener{fn: opener}
-}
-
-func (p *passthroughOpener) Open(name string) (api.Connection, error) {
-	return p.fn(name)
+func (f OpenFunc) Open(store jujuclient.ClientStore, controllerName, modelName string) (api.Connection, error) {
+	return f(store, controllerName, modelName)
 }
 
 type timeoutOpener struct {
-	fn      OpenFunc
+	opener  APIOpener
 	clock   clock.Clock
 	timeout time.Duration
 }
 
-// NewTimeoutOpener will call the opener function when Open is called, but if
-// the function does not return by the specified timeout, ErrConnTimeOut is
+// NewTimeoutOpener will call the opener when Open is called, but if the
+// openern does not return by the specified timeout, ErrConnTimeOut is
 // returned.
-func NewTimeoutOpener(opener OpenFunc, clock clock.Clock, timeout time.Duration) APIOpener {
+func NewTimeoutOpener(opener APIOpener, clock clock.Clock, timeout time.Duration) APIOpener {
 	return &timeoutOpener{
-		fn:      opener,
+		opener:  opener,
 		clock:   clock,
 		timeout: timeout,
 	}
 }
 
-func (t *timeoutOpener) Open(name string) (api.Connection, error) {
+func (t *timeoutOpener) Open(store jujuclient.ClientStore, controllerName, modelName string) (api.Connection, error) {
 	// Make the channels buffered so the created goroutine is guaranteed
 	// not go get blocked trying to send down the channel.
 	apic := make(chan api.Connection, 1)
 	errc := make(chan error, 1)
 	go func() {
-		api, dialErr := t.fn(name)
+		api, dialErr := t.opener.Open(store, controllerName, modelName)
 		if dialErr != nil {
 			errc <- dialErr
 			return

--- a/cmd/modelcmd/apiopener.go
+++ b/cmd/modelcmd/apiopener.go
@@ -34,7 +34,7 @@ type timeoutOpener struct {
 }
 
 // NewTimeoutOpener will call the opener when Open is called, but if the
-// openern does not return by the specified timeout, ErrConnTimeOut is
+// opener does not return by the specified timeout, ErrConnTimeOut is
 // returned.
 func NewTimeoutOpener(opener APIOpener, clock clock.Clock, timeout time.Duration) APIOpener {
 	return &timeoutOpener{

--- a/cmd/modelcmd/apiopener_test.go
+++ b/cmd/modelcmd/apiopener_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/jujuclient"
 )
 
 type APIOpenerSuite struct {
@@ -22,60 +23,67 @@ type APIOpenerSuite struct {
 var _ = gc.Suite(&APIOpenerSuite{})
 
 func (*APIOpenerSuite) TestPassthrough(c *gc.C) {
-	var name string
-	open := func(connectionName string) (api.Connection, error) {
-		name = connectionName
+	var controllerName, modelName string
+	open := func(_ jujuclient.ClientStore, controllerNameArg, modelNameArg string) (api.Connection, error) {
+		controllerName = controllerNameArg
+		modelName = modelNameArg
 		// Lets do the bad thing and return both a connection instance
 		// and an error to check they both come through.
 		return &mockConnection{}, errors.New("boom")
 	}
-	opener := modelcmd.NewPassthroughOpener(open)
-	conn, err := opener.Open("a-name")
+	opener := modelcmd.OpenFunc(open)
+	conn, err := opener.Open(nil, "a-name", "b-name")
 	c.Assert(err, gc.ErrorMatches, "boom")
 	c.Assert(conn, gc.NotNil)
-	c.Assert(name, gc.Equals, "a-name")
+	c.Assert(controllerName, gc.Equals, "a-name")
+	c.Assert(modelName, gc.Equals, "b-name")
 }
 
 func (*APIOpenerSuite) TestTimoutSuccess(c *gc.C) {
-	var name string
-	open := func(connectionName string) (api.Connection, error) {
-		name = connectionName
+	var controllerName, modelName string
+	open := func(_ jujuclient.ClientStore, controllerNameArg, modelNameArg string) (api.Connection, error) {
+		controllerName = controllerNameArg
+		modelName = modelNameArg
 		return &mockConnection{}, nil
 	}
-	opener := modelcmd.NewTimeoutOpener(open, clock.WallClock, 10*time.Second)
-	conn, err := opener.Open("a-name")
+	opener := modelcmd.NewTimeoutOpener(modelcmd.OpenFunc(open), clock.WallClock, 10*time.Second)
+	conn, err := opener.Open(nil, "a-name", "b-name")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(conn, gc.NotNil)
-	c.Assert(name, gc.Equals, "a-name")
+	c.Assert(controllerName, gc.Equals, "a-name")
+	c.Assert(modelName, gc.Equals, "b-name")
 }
 
 func (*APIOpenerSuite) TestTimoutErrors(c *gc.C) {
-	var name string
-	open := func(connectionName string) (api.Connection, error) {
-		name = connectionName
+	var controllerName, modelName string
+	open := func(_ jujuclient.ClientStore, controllerNameArg, modelNameArg string) (api.Connection, error) {
+		controllerName = controllerNameArg
+		modelName = modelNameArg
 		return nil, errors.New("boom")
 	}
-	opener := modelcmd.NewTimeoutOpener(open, clock.WallClock, 10*time.Second)
-	conn, err := opener.Open("a-name")
+	opener := modelcmd.NewTimeoutOpener(modelcmd.OpenFunc(open), clock.WallClock, 10*time.Second)
+	conn, err := opener.Open(nil, "a-name", "b-name")
 	c.Assert(err, gc.ErrorMatches, "boom")
 	c.Assert(conn, gc.IsNil)
-	c.Assert(name, gc.Equals, "a-name")
+	c.Assert(controllerName, gc.Equals, "a-name")
+	c.Assert(modelName, gc.Equals, "b-name")
 }
 
 func (*APIOpenerSuite) TestTimoutClosesAPIOnTimeout(c *gc.C) {
-	var name string
+	var controllerName, modelName string
 	finished := make(chan struct{})
 	mockConn := &mockConnection{closed: make(chan struct{})}
-	open := func(connectionName string) (api.Connection, error) {
+	open := func(_ jujuclient.ClientStore, controllerNameArg, modelNameArg string) (api.Connection, error) {
 		<-finished
-		name = connectionName
+		controllerName = controllerNameArg
+		modelName = modelNameArg
 		return mockConn, nil
 	}
 	// have the mock clock only wait a microsecond
 	clock := &mockClock{wait: time.Microsecond}
 	// but tell it to wait five seconds
-	opener := modelcmd.NewTimeoutOpener(open, clock, 5*time.Second)
-	conn, err := opener.Open("a-name")
+	opener := modelcmd.NewTimeoutOpener(modelcmd.OpenFunc(open), clock, 5*time.Second)
+	conn, err := opener.Open(nil, "a-name", "b-name")
 	c.Assert(errors.Cause(err), gc.Equals, modelcmd.ErrConnTimedOut)
 	c.Assert(conn, gc.IsNil)
 	// check it was told to wait for 5 seconds
@@ -89,7 +97,8 @@ func (*APIOpenerSuite) TestTimoutClosesAPIOnTimeout(c *gc.C) {
 	case <-time.After(5 * time.Second):
 		c.Error("API connection was not closed.")
 	}
-	c.Assert(name, gc.Equals, "a-name")
+	c.Assert(controllerName, gc.Equals, "a-name")
+	c.Assert(modelName, gc.Equals, "b-name")
 }
 
 // mockConnection will panic if anything but close is called.

--- a/cmd/modelcmd/base.go
+++ b/cmd/modelcmd/base.go
@@ -80,7 +80,8 @@ func (c *JujuCommandBase) APIOpen(info *api.Info, opts api.DialOpts) (api.Connec
 	return c.apiContext.apiOpen(info, opts)
 }
 
-// RefreshModelsCache refreshes the local models cache for the current user.
+// RefreshModels refreshes the local models cache for the current user
+// on the specified controller.
 func (c *JujuCommandBase) RefreshModels(store jujuclient.ClientStore, controllerName string) error {
 	accountName, err := store.CurrentAccount(controllerName)
 	if err != nil {

--- a/cmd/modelcmd/base.go
+++ b/cmd/modelcmd/base.go
@@ -14,7 +14,9 @@ import (
 	"launchpad.net/gnuflag"
 
 	"github.com/juju/juju/api"
+	"github.com/juju/juju/api/modelmanager"
 	"github.com/juju/juju/juju"
+	"github.com/juju/juju/jujuclient"
 )
 
 var errNoNameSpecified = errors.New("no name specified")
@@ -46,12 +48,15 @@ func (c *JujuCommandBase) closeContext() {
 }
 
 // NewAPIRoot returns a new connection to the API server for the given
-// model or system.
-func (c *JujuCommandBase) NewAPIRoot(modelOrControllerName string) (api.Connection, error) {
+// model or controller.
+func (c *JujuCommandBase) NewAPIRoot(
+	store jujuclient.ClientStore,
+	controllerName, modelName string,
+) (api.Connection, error) {
 	if err := c.initAPIContext(); err != nil {
 		return nil, errors.Trace(err)
 	}
-	return c.apiContext.newAPIRoot(modelOrControllerName)
+	return c.apiContext.newAPIRoot(store, controllerName, modelName)
 }
 
 // HTTPClient returns an http.Client that contains the loaded
@@ -73,6 +78,37 @@ func (c *JujuCommandBase) APIOpen(info *api.Info, opts api.DialOpts) (api.Connec
 		return nil, errors.Trace(err)
 	}
 	return c.apiContext.apiOpen(info, opts)
+}
+
+// RefreshModelsCache refreshes the local models cache for the current user.
+func (c *JujuCommandBase) RefreshModels(store jujuclient.ClientStore, controllerName string) error {
+	accountName, err := store.CurrentAccount(controllerName)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	accountDetails, err := store.AccountByName(controllerName, accountName)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	conn, err := c.NewAPIRoot(store, controllerName, "")
+	if err != nil {
+		return errors.Trace(err)
+	}
+	defer conn.Close()
+
+	modelManager := modelmanager.NewClient(conn)
+	models, err := modelManager.ListModels(accountDetails.User)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	for _, model := range models {
+		modelDetails := jujuclient.ModelDetails{model.UUID}
+		err := store.UpdateModel(controllerName, model.Name, modelDetails)
+		if err != nil {
+			return errors.Trace(err)
+		}
+	}
+	return nil
 }
 
 // initAPIContext lazily initializes c.apiContext. Doing this lazily means that
@@ -174,7 +210,13 @@ func (ctx *apiContext) apiOpen(info *api.Info, opts api.DialOpts) (api.Connectio
 
 // newAPIRoot establishes a connection to the API server for
 // the named system or model.
-func (ctx *apiContext) newAPIRoot(name string) (api.Connection, error) {
+func (ctx *apiContext) newAPIRoot(store jujuclient.ClientStore, controllerName, modelName string) (api.Connection, error) {
+	// TODO(axw) pass controller and model name through to
+	// juju.NewAPIFromName, as well as the jujuclient.ClientStore.
+	name := modelName
+	if modelName == "" {
+		name = controllerName
+	}
 	if name == "" {
 		return nil, errors.Trace(errNoNameSpecified)
 	}

--- a/cmd/modelcmd/controller.go
+++ b/cmd/modelcmd/controller.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/juju/api/modelmanager"
 	"github.com/juju/juju/api/usermanager"
 	"github.com/juju/juju/environs/configstore"
+	"github.com/juju/juju/jujuclient"
 )
 
 // ErrNoControllerSpecified is returned by commands that operate on
@@ -24,6 +25,15 @@ var ErrNoControllerSpecified = errors.New("no controller specified")
 // that need to operate on controllers as opposed to models.
 type ControllerCommand interface {
 	CommandBase
+
+	// SetClientStore is called prior to the wrapped command's Init method
+	// with the default controller store. It may also be called to override the
+	// default controller store for testing.
+	SetClientStore(jujuclient.ClientStore)
+
+	// ClientStore returns the controller store that the command is
+	// associated with.
+	ClientStore() jujuclient.ClientStore
 
 	// SetControllerName is called prior to the wrapped command's Init method with
 	// the active controller name. The controller name is guaranteed to be non-empty
@@ -45,10 +55,21 @@ type ControllerCommand interface {
 type ControllerCommandBase struct {
 	JujuCommandBase
 
+	store          jujuclient.ClientStore
 	controllerName string
 
 	// opener is the strategy used to open the API connection.
 	opener APIOpener
+}
+
+// SetClientStore implements the ControllerCommand interface.
+func (c *ControllerCommandBase) SetClientStore(store jujuclient.ClientStore) {
+	c.store = store
+}
+
+// ClientStore implements the ControllerCommand interface.
+func (c *ControllerCommandBase) ClientStore() jujuclient.ClientStore {
+	return c.store
 }
 
 // SetControllerName implements the ControllerCommand interface.
@@ -106,9 +127,9 @@ func (c *ControllerCommandBase) NewAPIRoot() (api.Connection, error) {
 	}
 	opener := c.opener
 	if opener == nil {
-		opener = NewPassthroughOpener(c.JujuCommandBase.NewAPIRoot)
+		opener = OpenFunc(c.JujuCommandBase.NewAPIRoot)
 	}
-	return opener.Open(c.controllerName)
+	return opener.Open(c.store, c.controllerName, "")
 }
 
 // ConnectionCredentials returns the credentials used to connect to the API for
@@ -211,11 +232,6 @@ func (w *sysCommandWrapper) getDefaultControllerName() (string, error) {
 	} else if currentController != "" {
 		return currentController, nil
 	}
-	if currentEnv, err := ReadCurrentModel(); err != nil {
-		return "", errors.Trace(err)
-	} else if currentEnv != "" {
-		return currentEnv, nil
-	}
 	return "", errors.Trace(ErrNoControllerSpecified)
 }
 
@@ -232,6 +248,11 @@ func (w *sysCommandWrapper) Init(args []string) error {
 		if w.controllerName == "" && !w.useDefaultControllerName {
 			return ErrNoControllerSpecified
 		}
+	}
+	store := w.ClientStore()
+	if store == nil {
+		store = jujuclient.NewFileClientStore()
+		w.SetClientStore(store)
 	}
 	w.SetControllerName(w.controllerName)
 	return w.ControllerCommand.Init(args)

--- a/cmd/modelcmd/controller_test.go
+++ b/cmd/modelcmd/controller_test.go
@@ -30,11 +30,13 @@ func (s *ControllerCommandSuite) TestControllerCommandInitSystemFile(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	testEnsureControllerName(c, "fubar")
 }
+
 func (s *ControllerCommandSuite) TestControllerCommandInitEnvFile(c *gc.C) {
-	// If there is a current-environment file, use that.
+	// The current-model file has no bearing.
 	err := modelcmd.WriteCurrentModel("fubar")
 	c.Assert(err, jc.ErrorIsNil)
-	testEnsureControllerName(c, "fubar")
+	_, err = initTestControllerCommand(c)
+	c.Assert(err, gc.ErrorMatches, "no controller specified")
 }
 
 func (s *ControllerCommandSuite) TestControllerCommandInitExplicit(c *gc.C) {

--- a/cmd/modelcmd/modelcommand.go
+++ b/cmd/modelcmd/modelcommand.go
@@ -6,6 +6,7 @@ package modelcmd
 import (
 	"io"
 	"os"
+	"strings"
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
@@ -17,6 +18,7 @@ import (
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/configstore"
 	"github.com/juju/juju/juju/osenv"
+	"github.com/juju/juju/jujuclient"
 )
 
 var logger = loggo.GetLogger("juju.cmd.envcmd")
@@ -26,40 +28,70 @@ var logger = loggo.GetLogger("juju.cmd.envcmd")
 // has been explicitly specified, and there is no default model.
 var ErrNoModelSpecified = errors.New("no model specified")
 
-// GetDefaultModel returns the name of the Juju default model.
-// There is simple ordering for the default model.  Firstly check the
-// JUJU_MODEL environment variable.  If that is set, it gets used.  If it isn't
-// set, look in the $JUJU_DATA/current-environment file.  If neither are
-// available, an empty string is returned; not having a default model
-// specified is not an error.
-func GetDefaultModel() (string, error) {
-	if defaultEnv := os.Getenv(osenv.JujuModelEnvKey); defaultEnv != "" {
-		return defaultEnv, nil
+// GetDefaultModel returns the name of the current Juju model.
+//
+// If $JUJU_MODEL is set, use that. Otherwise, get the current
+// controller by reading $XDG_DATA_HOME/juju/current-controller,
+// and then identifying the current model for that controller
+// in models.yaml. If there is no current controller, or no
+// current model for that controller, then an empty string is
+// returned. It is not an error to have no default model.
+func GetDefaultModel(store jujuclient.ClientStore) (string, error) {
+	if model := os.Getenv(osenv.JujuModelEnvKey); model != "" {
+		return model, nil
 	}
+
+	// TODO(axw) remove this when all of the tests are updated.
 	if currentModel, err := ReadCurrentModel(); err != nil {
 		return "", errors.Trace(err)
 	} else if currentModel != "" {
 		return currentModel, nil
 	}
-	if currentController, err := ReadCurrentController(); err != nil {
+
+	currentController, err := ReadCurrentController()
+	if err != nil {
 		return "", errors.Trace(err)
-	} else if currentController != "" {
-		return "", errors.Errorf("not operating on an model, using controller %q", currentController)
 	}
-	return "", nil
+	if currentController == "" {
+		return "", nil
+	}
+
+	currentModel, err := store.CurrentModel(currentController)
+	if errors.IsNotFound(err) {
+		return "", errors.Errorf("not operating on an model, using controller %q", currentController)
+	} else if err != nil {
+		return "", errors.Trace(err)
+	}
+	return currentModel, nil
 }
 
 // ModelCommand extends cmd.Command with a SetModelName method.
 type ModelCommand interface {
 	CommandBase
 
+	// SetClientStore is called prior to the wrapped command's Init method
+	// with the default controller store. It may also be called to override the
+	// default controller store for testing.
+	SetClientStore(jujuclient.ClientStore)
+
+	// ClientStore returns the controller store that the command is
+	// associated with.
+	ClientStore() jujuclient.ClientStore
+
+	// SetModelName sets the model name for this command. Setting the model
+	// name will also set the related controller name.
+	//
 	// SetModelName is called prior to the wrapped command's Init method
 	// with the active model name. The model name is guaranteed
 	// to be non-empty at entry of Init.
-	SetModelName(modelName string)
+	SetModelName(modelName string) error
 
 	// ModelName returns the name of the model.
 	ModelName() string
+
+	// ControllerName returns the name of the controller that contains
+	// the model returned by ModelName().
+	ControllerName() string
 
 	// SetAPIOpener allows the replacement of the default API opener,
 	// which ends up calling NewAPIRoot
@@ -71,10 +103,12 @@ type ModelCommand interface {
 type ModelCommandBase struct {
 	JujuCommandBase
 
-	// ModelName will very soon be package visible only as we want to be able
-	// to specify an model in multiple ways, and not always referencing
-	// a file on disk based on the ModelName.
-	modelName string
+	// store is the client controller store that contains information
+	// about controllers, models, etc.
+	store jujuclient.ClientStore
+
+	modelName      string
+	controllerName string
 
 	// opener is the strategy used to open the API connection.
 	opener APIOpener
@@ -83,14 +117,38 @@ type ModelCommandBase struct {
 	envGetterErr    error
 }
 
+// SetClientStore implements the ModelCommand interface.
+func (c *ModelCommandBase) SetClientStore(store jujuclient.ClientStore) {
+	c.store = store
+}
+
+// ClientStore implements the ModelCommand interface.
+func (c *ModelCommandBase) ClientStore() jujuclient.ClientStore {
+	return c.store
+}
+
 // SetModelName implements the ModelCommand interface.
-func (c *ModelCommandBase) SetModelName(modelName string) {
-	c.modelName = modelName
+func (c *ModelCommandBase) SetModelName(modelName string) error {
+	if i := strings.IndexRune(modelName, ':'); i > 0 {
+		c.controllerName, c.modelName = modelName[:i], modelName[i+1:]
+		return nil
+	}
+	currentController, err := ReadCurrentController()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	c.controllerName, c.modelName = currentController, modelName
+	return nil
 }
 
 // ModelName implements the ModelCommand interface.
 func (c *ModelCommandBase) ModelName() string {
 	return c.modelName
+}
+
+// ControllerName implements the ModelCommand interface.
+func (c *ModelCommandBase) ControllerName() string {
+	return c.controllerName
 }
 
 // SetAPIOpener specifies the strategy used by the command to open
@@ -131,9 +189,26 @@ func (c *ModelCommandBase) NewAPIRoot() (api.Connection, error) {
 	}
 	opener := c.opener
 	if opener == nil {
-		opener = NewPassthroughOpener(c.JujuCommandBase.NewAPIRoot)
+		opener = OpenFunc(c.JujuCommandBase.NewAPIRoot)
 	}
-	return opener.Open(c.modelName)
+	// TODO(axw) stop checking c.store != nil once we've updated all the
+	// tests, and have excised configstore.
+	if c.modelName != "" && c.controllerName != "" && c.store != nil {
+		// The user has specified a model that the client does not
+		// know about. Refresh the client's model cache.
+		_, err := c.store.ModelByName(c.controllerName, c.modelName)
+		if err != nil {
+			if !errors.IsNotFound(err) {
+				return nil, errors.Trace(err)
+			}
+			// The model isn't known locally, so query the models
+			// available in the controller, and cache them locally.
+			if err := c.RefreshModels(c.store, c.controllerName); err != nil {
+				return nil, errors.Annotate(err, "refreshing models")
+			}
+		}
+	}
+	return opener.Open(c.store, c.controllerName, c.modelName)
 }
 
 // ConnectionCredentials returns the credentials used to connect to the API for
@@ -280,10 +355,15 @@ func (w *modelCommandWrapper) SetFlags(f *gnuflag.FlagSet) {
 }
 
 func (w *modelCommandWrapper) Init(args []string) error {
+	store := w.ClientStore()
+	if store == nil {
+		store = jujuclient.NewFileClientStore()
+		w.SetClientStore(store)
+	}
 	if !w.skipFlags {
 		if w.modelName == "" && w.useDefaultModel {
 			// Look for the default.
-			defaultModel, err := GetDefaultModel()
+			defaultModel, err := GetDefaultModel(store)
 			if err != nil {
 				return err
 			}
@@ -297,7 +377,9 @@ func (w *modelCommandWrapper) Init(args []string) error {
 			}
 		}
 	}
-	w.SetModelName(w.modelName)
+	if err := w.SetModelName(w.modelName); err != nil {
+		return errors.Annotate(err, "setting model name")
+	}
 	return w.ModelCommand.Init(args)
 }
 

--- a/cmd/modelcmd/modelcommand_test.go
+++ b/cmd/modelcmd/modelcommand_test.go
@@ -40,32 +40,32 @@ func (s *ModelCommandSuite) SetUpTest(c *gc.C) {
 
 var _ = gc.Suite(&ModelCommandSuite{})
 
-func (s *ModelCommandSuite) TestGetDefaultModelNothingSet(c *gc.C) {
-	env, err := modelcmd.GetDefaultModel(s.store)
+func (s *ModelCommandSuite) TestGetCurrentModelNothingSet(c *gc.C) {
+	env, err := modelcmd.GetCurrentModel(s.store)
 	c.Assert(env, gc.Equals, "")
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-func (s *ModelCommandSuite) TestGetDefaultModelCurrentModelSet(c *gc.C) {
+func (s *ModelCommandSuite) TestGetCurrentModelCurrentModelSet(c *gc.C) {
 	err := modelcmd.WriteCurrentModel("fubar")
 	c.Assert(err, jc.ErrorIsNil)
-	env, err := modelcmd.GetDefaultModel(s.store)
+	env, err := modelcmd.GetCurrentModel(s.store)
 	c.Assert(env, gc.Equals, "fubar")
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-func (s *ModelCommandSuite) TestGetDefaultModelJujuEnvSet(c *gc.C) {
+func (s *ModelCommandSuite) TestGetCurrentModelJujuEnvSet(c *gc.C) {
 	os.Setenv(osenv.JujuModelEnvKey, "magic")
-	env, err := modelcmd.GetDefaultModel(s.store)
+	env, err := modelcmd.GetCurrentModel(s.store)
 	c.Assert(env, gc.Equals, "magic")
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-func (s *ModelCommandSuite) TestGetDefaultModelBothSet(c *gc.C) {
+func (s *ModelCommandSuite) TestGetCurrentModelBothSet(c *gc.C) {
 	os.Setenv(osenv.JujuModelEnvKey, "magic")
 	err := modelcmd.WriteCurrentModel("fubar")
 	c.Assert(err, jc.ErrorIsNil)
-	env, err := modelcmd.GetDefaultModel(s.store)
+	env, err := modelcmd.GetCurrentModel(s.store)
 	c.Assert(env, gc.Equals, "magic")
 	c.Assert(err, jc.ErrorIsNil)
 }

--- a/cmd/modelcmd/modelcommand_test.go
+++ b/cmd/modelcmd/modelcommand_test.go
@@ -22,22 +22,26 @@ import (
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/environs/configstore"
 	"github.com/juju/juju/juju/osenv"
+	"github.com/juju/juju/jujuclient"
+	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	"github.com/juju/juju/testing"
 )
 
 type ModelCommandSuite struct {
 	testing.FakeJujuXDGDataHomeSuite
+	store jujuclient.ClientStore
 }
 
 func (s *ModelCommandSuite) SetUpTest(c *gc.C) {
 	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
 	s.PatchEnvironment("JUJU_CLI_VERSION", "")
+	s.store = jujuclienttesting.NewMemStore()
 }
 
 var _ = gc.Suite(&ModelCommandSuite{})
 
 func (s *ModelCommandSuite) TestGetDefaultModelNothingSet(c *gc.C) {
-	env, err := modelcmd.GetDefaultModel()
+	env, err := modelcmd.GetDefaultModel(s.store)
 	c.Assert(env, gc.Equals, "")
 	c.Assert(err, jc.ErrorIsNil)
 }
@@ -45,14 +49,14 @@ func (s *ModelCommandSuite) TestGetDefaultModelNothingSet(c *gc.C) {
 func (s *ModelCommandSuite) TestGetDefaultModelCurrentModelSet(c *gc.C) {
 	err := modelcmd.WriteCurrentModel("fubar")
 	c.Assert(err, jc.ErrorIsNil)
-	env, err := modelcmd.GetDefaultModel()
+	env, err := modelcmd.GetDefaultModel(s.store)
 	c.Assert(env, gc.Equals, "fubar")
 	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *ModelCommandSuite) TestGetDefaultModelJujuEnvSet(c *gc.C) {
 	os.Setenv(osenv.JujuModelEnvKey, "magic")
-	env, err := modelcmd.GetDefaultModel()
+	env, err := modelcmd.GetDefaultModel(s.store)
 	c.Assert(env, gc.Equals, "magic")
 	c.Assert(err, jc.ErrorIsNil)
 }
@@ -61,7 +65,7 @@ func (s *ModelCommandSuite) TestGetDefaultModelBothSet(c *gc.C) {
 	os.Setenv(osenv.JujuModelEnvKey, "magic")
 	err := modelcmd.WriteCurrentModel("fubar")
 	c.Assert(err, jc.ErrorIsNil)
-	env, err := modelcmd.GetDefaultModel()
+	env, err := modelcmd.GetDefaultModel(s.store)
 	c.Assert(env, gc.Equals, "magic")
 	c.Assert(err, jc.ErrorIsNil)
 }
@@ -144,7 +148,7 @@ type ConnectionEndpointSuite struct {
 var _ = gc.Suite(&ConnectionEndpointSuite{})
 
 func (s *ConnectionEndpointSuite) SetUpTest(c *gc.C) {
-	s.FakeHomeSuite.SetUpTest(c)
+	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
 	s.store = configstore.NewMem()
 	s.PatchValue(modelcmd.GetConfigStore, func() (configstore.Storage, error) {
 		return s.store, nil

--- a/cmd/plugins/juju-metadata/listimages_test.go
+++ b/cmd/plugins/juju-metadata/listimages_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 type BaseCloudImageMetadataSuite struct {
-	testing.BaseSuite
+	testing.FakeJujuXDGDataHomeSuite
 }
 
 func (s *BaseCloudImageMetadataSuite) SetUpTest(c *gc.C) {
@@ -28,7 +28,7 @@ func (s *BaseCloudImageMetadataSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *BaseCloudImageMetadataSuite) setupBaseSuite(c *gc.C) {
-	s.BaseSuite.SetUpTest(c)
+	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
 
 	memstore := configstore.NewMem()
 	s.PatchValue(&configstore.Default, func() (configstore.Storage, error) {

--- a/featuretests/cmd_juju_user_test.go
+++ b/featuretests/cmd_juju_user_test.go
@@ -30,7 +30,8 @@ var _ = gc.Suite(&UserSuite{})
 
 func (s *UserSuite) SetUpTest(c *gc.C) {
 	s.JujuConnSuite.SetUpTest(c)
-	modelcmd.WriteCurrentModel("dummymodel")
+	err := modelcmd.WriteCurrentController("dummymodel")
+	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *UserSuite) RunUserCommand(c *gc.C, args ...string) (*cmd.Context, error) {


### PR DESCRIPTION
And some related changes to prepare for using jujuclient everywhere:

- change APIOpener to take a controller name
  and a model name. Model names are relative
  to controller names, and a client can know
  about two models with the same name for
  different controllers
- add JujuCommandBase.RefreshModels method,
  which will refresh the client's knowledge
  of models in the specified controller for
  the current user
- ModelCommandBase.NewAPIRoot is updated to
  refresh the client's model cache if an
  unknown model is specified. This means you
  can do "juju status -m <model>" for a model
  that you haven't previously switched to.
- change GetDefaultModel to take a ClientStore,
  and use it to get the current model for the
  current controller. We still honour the
  current-model file, until all of the tests
  stop relying on it
- ModelCommandBase.SetModelName now accepts
  model names in either format "model", or
  "controller:model". In the first format,
  the current controller is assumed. This
  method now records the controller name for
  use when opening API connections.

(Review request: http://reviews.vapour.ws/r/3859/)