### PR TITLE
worker/voyeur: Added voyeur worker manifold

### DIFF
--- a/worker/voyeur/manifold.go
+++ b/worker/voyeur/manifold.go
@@ -1,0 +1,98 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package voyeur
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	"github.com/juju/utils/voyeur"
+	"launchpad.net/tomb"
+
+	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/dependency"
+)
+
+var logger = loggo.GetLogger("juju.worker.voyeur")
+
+type ManifoldConfig struct {
+	Value *voyeur.Value
+}
+
+// Manifold returns a dependency.Manifold which wraps a voyeur.Value
+// from github.com/juju/utils for use within the dependency engine
+// framework. It will watch the voyeur.Value and restart itself
+// whenever Set is called the voyeur.Value.
+//
+// The manifold assumes that the the voyeur.Value has been created
+// with an initial value (using voyeur.NewValue) or already has a
+// value set (using the Set method). The initial event from the
+// Value's Next() is consumed to avoid unnecessary worker restarts.
+//
+// NOTE: the manifold currently provides no way to access the voyeur's
+// value as this was not required for the initial use case. An output
+// function could be added to faciliate this if necessary.
+func Manifold(config ManifoldConfig) dependency.Manifold {
+	return dependency.Manifold{
+		Start: func(dependency.GetResourceFunc) (worker.Worker, error) {
+			if config.Value == nil {
+				return nil, errors.NotValidf("nil Value")
+			}
+
+			w := &valueWatcher{
+				value: config.Value,
+			}
+			go func() {
+				defer w.tomb.Done()
+				w.tomb.Kill(w.watch())
+			}()
+			return w, nil
+		},
+	}
+}
+
+type valueWatcher struct {
+	tomb  tomb.Tomb
+	value *voyeur.Value
+}
+
+func (w *valueWatcher) watch() error {
+	watch := w.value.Watch()
+	defer watch.Close()
+
+	watchCh := make(chan bool)
+	go func() {
+		// Consume the initial event to avoid unnecessary worker
+		// restart churn.
+		if !watch.Next() {
+			return
+		}
+
+		if watch.Next() {
+			select {
+			case watchCh <- true:
+			case <-w.tomb.Dying():
+			}
+		}
+	}()
+
+	select {
+	case <-watchCh:
+		// The voyeur changed, restart so that dependents get
+		// restarted too. ErrBounce ensures that the manifold is
+		// restarted quickly.
+		return dependency.ErrBounce
+	case <-w.tomb.Dying():
+		return tomb.ErrDying
+	}
+}
+
+// Kill is part of the worker.Worker interface.
+func (w *valueWatcher) Kill() {
+	w.tomb.Kill(nil)
+}
+
+// Wait is part of the worker.Worker interface.
+func (w *valueWatcher) Wait() error {
+	return w.tomb.Wait()
+}

--- a/worker/voyeur/manifold_test.go
+++ b/worker/voyeur/manifold_test.go
@@ -1,0 +1,102 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package voyeur_test
+
+import (
+	"time"
+
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/voyeur"
+	gc "gopkg.in/check.v1"
+
+	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/dependency"
+	workervoyeur "github.com/juju/juju/worker/voyeur"
+)
+
+type ManifoldSuite struct {
+	testing.IsolationSuite
+	value    *voyeur.Value
+	manifold dependency.Manifold
+	worker   worker.Worker
+}
+
+var _ = gc.Suite(&ManifoldSuite{})
+
+func (s *ManifoldSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+	s.value = voyeur.NewValue(0)
+	s.manifold = workervoyeur.Manifold(workervoyeur.ManifoldConfig{
+		Value: s.value,
+	})
+}
+
+func (s *ManifoldSuite) TestInputs(c *gc.C) {
+	c.Assert(s.manifold.Inputs, jc.SameContents, []string{})
+}
+
+func (s *ManifoldSuite) TestNilValue(c *gc.C) {
+	manifold := workervoyeur.Manifold(workervoyeur.ManifoldConfig{})
+	_, err := manifold.Start(nilGetResource)
+	c.Assert(err, gc.ErrorMatches, "nil Value .+")
+}
+
+func (s *ManifoldSuite) TestStart(c *gc.C) {
+	w, err := s.manifold.Start(nilGetResource)
+	c.Assert(err, jc.ErrorIsNil)
+	checkStop(c, w)
+}
+
+func (s *ManifoldSuite) TestBounceOnChange(c *gc.C) {
+	w, err := s.manifold.Start(nilGetResource)
+	c.Assert(err, jc.ErrorIsNil)
+	checkNotExiting(c, w)
+	s.value.Set(true)
+	checkExitsWithError(c, w, dependency.ErrBounce)
+
+	w, err = s.manifold.Start(nilGetResource)
+	c.Assert(err, jc.ErrorIsNil)
+	checkNotExiting(c, w)
+	s.value.Set(false) // The actual value doesn't matter.
+	checkExitsWithError(c, w, dependency.ErrBounce)
+}
+
+func checkStop(c *gc.C, w worker.Worker) {
+	err := worker.Stop(w)
+	c.Check(err, jc.ErrorIsNil)
+}
+
+func checkNotExiting(c *gc.C, w worker.Worker) {
+	exited := make(chan bool)
+	go func() {
+		w.Wait()
+		close(exited)
+	}()
+
+	select {
+	case <-exited:
+		c.Fatal("worker exited unexpectedly")
+	case <-time.After(coretesting.ShortWait):
+		// Worker didn't exit (good)
+	}
+}
+
+func checkExitsWithError(c *gc.C, w worker.Worker, expectedErr error) {
+	errCh := make(chan error)
+	go func() {
+		errCh <- w.Wait()
+	}()
+	select {
+	case err := <-errCh:
+		c.Check(err, gc.Equals, expectedErr)
+	case <-time.After(coretesting.LongWait):
+		c.Fatal("timed out waiting for worker to exit")
+	}
+}
+
+func nilGetResource(name string, out interface{}) error {
+	return nil
+}

--- a/worker/voyeur/package_test.go
+++ b/worker/voyeur/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package voyeur_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}


### PR DESCRIPTION
This wraps a voyeur.Value for use within the dependency engine framework. It will watch the voyeur.Value and restart itself whenever Set is called voyeur.Value.

(Review request: http://reviews.vapour.ws/r/3860/)