### PR TITLE
apiserver/params: remove ClientError helper

### DIFF
--- a/api/agent/machine_test.go
+++ b/api/agent/machine_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/mongo"
+	"github.com/juju/juju/rpc"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/multiwatcher"
 	coretesting "github.com/juju/juju/testing"
@@ -61,7 +62,10 @@ func (s *servingInfoSuite) TestStateServingInfoPermission(c *gc.C) {
 	st, _ := s.OpenAPIAsNewMachine(c)
 
 	_, err := st.Agent().StateServingInfo()
-	c.Assert(err, gc.ErrorMatches, "permission denied")
+	c.Assert(errors.Cause(err), gc.DeepEquals, &rpc.RequestError{
+		Message: "permission denied",
+		Code:    "unauthorized access",
+	})
 }
 
 func (s *servingInfoSuite) TestIsMaster(c *gc.C) {
@@ -84,7 +88,10 @@ func (s *servingInfoSuite) TestIsMaster(c *gc.C) {
 func (s *servingInfoSuite) TestIsMasterPermission(c *gc.C) {
 	st, _ := s.OpenAPIAsNewMachine(c)
 	_, err := st.Agent().IsMaster()
-	c.Assert(err, gc.ErrorMatches, "permission denied")
+	c.Assert(errors.Cause(err), gc.DeepEquals, &rpc.RequestError{
+		Message: "permission denied",
+		Code:    "unauthorized access",
+	})
 }
 
 type machineSuite struct {

--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -18,7 +18,6 @@ import (
 	"github.com/juju/utils/parallel"
 	"golang.org/x/net/websocket"
 
-	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/rpc"
 	"github.com/juju/juju/rpc/jsoncodec"
@@ -304,7 +303,7 @@ func (s *State) APICall(facade string, version int, id, method string, args, res
 		Id:      id,
 		Action:  method,
 	}, args, response)
-	return params.ClientError(err)
+	return errors.Trace(err)
 }
 
 func (s *State) Close() error {

--- a/api/apiclient_test.go
+++ b/api/apiclient_test.go
@@ -4,7 +4,6 @@
 package api_test
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -12,6 +11,7 @@ import (
 
 	"golang.org/x/net/websocket"
 
+	"github.com/juju/errors"
 	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
@@ -21,6 +21,7 @@ import (
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/apiserver/params"
 	jujutesting "github.com/juju/juju/juju/testing"
+	"github.com/juju/juju/rpc"
 	"github.com/juju/juju/version"
 )
 
@@ -200,7 +201,10 @@ func (s *apiclientSuite) TestOpenHonorsEnvironTag(c *gc.C) {
 	// We start by ensuring we have an invalid tag, and Open should fail.
 	info.EnvironTag = names.NewEnvironTag("bad-tag")
 	_, err := api.Open(info, api.DialOpts{})
-	c.Check(err, gc.ErrorMatches, `unknown environment: "bad-tag"`)
+	c.Assert(errors.Cause(err), gc.DeepEquals, &rpc.RequestError{
+		Message: `unknown environment: "bad-tag"`,
+		Code:    "not found",
+	})
 	c.Check(params.ErrCode(err), gc.Equals, params.CodeNotFound)
 
 	// Now set it to the right tag, and we should succeed.

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	jujunames "github.com/juju/juju/juju/names"
 	jujutesting "github.com/juju/juju/juju/testing"
+	"github.com/juju/juju/rpc"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/testcharms"
 	coretesting "github.com/juju/juju/testing"
@@ -510,7 +511,10 @@ func (s *clientSuite) TestOpenUsesEnvironUUIDPaths(c *gc.C) {
 	// Passing in a bad environment UUID should fail with a known error
 	info.EnvironTag = names.NewEnvironTag("dead-beef-123456")
 	apistate, err = api.Open(info, api.DialOpts{})
-	c.Check(err, gc.ErrorMatches, `unknown environment: "dead-beef-123456"`)
+	c.Assert(errors.Cause(err), gc.DeepEquals, &rpc.RequestError{
+		Message: `unknown environment: "dead-beef-123456"`,
+		Code:    "not found",
+	})
 	c.Check(err, jc.Satisfies, params.IsCodeNotFound)
 	c.Assert(apistate, gc.IsNil)
 }

--- a/api/environmentmanager/environmentmanager_test.go
+++ b/api/environmentmanager/environmentmanager_test.go
@@ -66,7 +66,7 @@ func (s *environmentmanagerSuite) TestCreateEnvironmentBadUser(c *gc.C) {
 func (s *environmentmanagerSuite) TestCreateEnvironmentFeatureNotEnabled(c *gc.C) {
 	envManager := s.OpenAPI(c)
 	_, err := envManager.CreateEnvironment("owner", nil, nil)
-	c.Assert(err, gc.ErrorMatches, `unknown object type "EnvironmentManager"`)
+	c.Assert(err, gc.ErrorMatches, `unknown object type "EnvironmentManager" \(not implemented\)`)
 }
 
 func (s *environmentmanagerSuite) TestCreateEnvironmentMissingConfig(c *gc.C) {

--- a/api/keymanager/client_test.go
+++ b/api/keymanager/client_test.go
@@ -6,6 +6,7 @@ package keymanager_test
 import (
 	"strings"
 
+	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -14,6 +15,7 @@ import (
 	keymanagertesting "github.com/juju/juju/apiserver/keymanager/testing"
 	"github.com/juju/juju/apiserver/params"
 	jujutesting "github.com/juju/juju/juju/testing"
+	"github.com/juju/juju/rpc"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/utils/ssh"
 	sshtesting "github.com/juju/juju/utils/ssh/testing"
@@ -116,7 +118,10 @@ func (s *keymanagerSuite) TestAddSystemKeyWrongUser(c *gc.C) {
 	defer keyManager.Close()
 	newKey := sshtesting.ValidKeyTwo.Key
 	_, err := keyManager.AddKeys("some-user", newKey)
-	c.Assert(err, gc.ErrorMatches, "permission denied")
+	c.Assert(errors.Cause(err), gc.DeepEquals, &rpc.RequestError{
+		Message: "permission denied",
+		Code:    "unauthorized access",
+	})
 	s.assertEnvironKeys(c, []string{key1})
 }
 

--- a/api/provisioner/provisioner_test.go
+++ b/api/provisioner/provisioner_test.go
@@ -89,7 +89,7 @@ func (s *provisionerSuite) SetUpTest(c *gc.C) {
 func (s *provisionerSuite) TestPrepareContainerInterfaceInfoNoFeatureFlag(c *gc.C) {
 	s.SetFeatureFlags() // clear the flag
 	ifaceInfo, err := s.provisioner.PrepareContainerInterfaceInfo(names.NewMachineTag("42"))
-	c.Assert(err, gc.ErrorMatches, "address allocation not supported")
+	c.Assert(err, gc.ErrorMatches, `address allocation not supported \(not supported\)`)
 	c.Assert(ifaceInfo, gc.HasLen, 0)
 }
 
@@ -97,7 +97,7 @@ func (s *provisionerSuite) TestReleaseContainerAddressNoFeatureFlag(c *gc.C) {
 	s.SetFeatureFlags() // clear the flag
 	err := s.provisioner.ReleaseContainerAddresses(names.NewMachineTag("42"))
 	c.Assert(err, gc.ErrorMatches,
-		`cannot release static addresses for "42": address allocation not supported`,
+		`cannot release static addresses for "42": address allocation not supported \(not supported\)`,
 	)
 }
 

--- a/apiserver/admin_test.go
+++ b/apiserver/admin_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/network"
+	"github.com/juju/juju/rpc"
 	"github.com/juju/juju/state"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/testing/factory"
@@ -125,22 +126,28 @@ func (s *loginSuite) TestBadLogin(c *gc.C) {
 	for i, t := range []struct {
 		tag      string
 		password string
-		err      string
+		err      error
 		code     string
 	}{{
 		tag:      adminUser.String(),
 		password: "wrong password",
-		err:      "invalid entity name or password",
-		code:     params.CodeUnauthorized,
+		err: &rpc.RequestError{
+			Message: "invalid entity name or password",
+			Code:    "unauthorized access",
+		},
+		code: params.CodeUnauthorized,
 	}, {
 		tag:      "user-unknown",
 		password: "password",
-		err:      "invalid entity name or password",
-		code:     params.CodeUnauthorized,
+		err: &rpc.RequestError{
+			Message: "invalid entity name or password",
+			Code:    "unauthorized access",
+		},
+		code: params.CodeUnauthorized,
 	}, {
 		tag:      "bar",
 		password: "password",
-		err:      `"bar" is not a valid tag`,
+		err:      &rpc.RequestError{Message: "\"bar\" is not a valid tag", Code: ""},
 	}} {
 		c.Logf("test %d; entity %q; password %q", i, t.tag, t.password)
 		// Note that Open does not log in if the tag and password
@@ -155,15 +162,21 @@ func (s *loginSuite) TestBadLogin(c *gc.C) {
 			defer st.Close()
 
 			_, err = st.Machiner().Machine(names.NewMachineTag("0"))
-			c.Assert(err, gc.ErrorMatches, `.*unknown object type "Machiner"`)
+			c.Assert(errors.Cause(err), gc.DeepEquals, &rpc.RequestError{
+				Message: `unknown object type "Machiner"`,
+				Code:    "not implemented",
+			})
 
 			// Since these are user login tests, the nonce is empty.
 			err = st.Login(t.tag, t.password, "")
-			c.Assert(err, gc.ErrorMatches, t.err)
+			c.Assert(errors.Cause(err), gc.DeepEquals, t.err)
 			c.Assert(params.ErrCode(err), gc.Equals, t.code)
 
 			_, err = st.Machiner().Machine(names.NewMachineTag("0"))
-			c.Assert(err, gc.ErrorMatches, `.*unknown object type "Machiner"`)
+			c.Assert(errors.Cause(err), gc.DeepEquals, &rpc.RequestError{
+				Message: `unknown object type "Machiner"`,
+				Code:    "not implemented",
+			})
 		}()
 	}
 }
@@ -181,14 +194,23 @@ func (s *loginSuite) TestLoginAsDeactivatedUser(c *gc.C) {
 	u := s.Factory.MakeUser(c, &factory.UserParams{Password: password, Disabled: true})
 
 	_, err = st.Client().Status([]string{})
-	c.Assert(err, gc.ErrorMatches, `.*unknown object type "Client"`)
+	c.Assert(errors.Cause(err), gc.DeepEquals, &rpc.RequestError{
+		Message: `unknown object type "Client"`,
+		Code:    "not implemented",
+	})
 
 	// Since these are user login tests, the nonce is empty.
 	err = st.Login(u.Tag().String(), password, "")
-	c.Assert(err, gc.ErrorMatches, "invalid entity name or password")
+	c.Assert(errors.Cause(err), gc.DeepEquals, &rpc.RequestError{
+		Message: "invalid entity name or password",
+		Code:    "unauthorized access",
+	})
 
 	_, err = st.Client().Status([]string{})
-	c.Assert(err, gc.ErrorMatches, `.*unknown object type "Client"`)
+	c.Assert(errors.Cause(err), gc.DeepEquals, &rpc.RequestError{
+		Message: `unknown object type "Client"`,
+		Code:    "not implemented",
+	})
 }
 
 func (s *loginV0Suite) TestLoginSetsLogIdentifier(c *gc.C) {
@@ -495,7 +517,10 @@ func (s *loginSuite) TestNonEnvironUserLoginFails(c *gc.C) {
 	info.Password = "dummy-password"
 	info.Tag = user.UserTag()
 	_, err := api.Open(info, fastDialOpts)
-	c.Assert(err, gc.ErrorMatches, "invalid entity name or password")
+	c.Assert(errors.Cause(err), gc.DeepEquals, &rpc.RequestError{
+		Message: "invalid entity name or password",
+		Code:    "unauthorized access",
+	})
 }
 
 func (s *loginV0Suite) TestLoginReportsEnvironTag(c *gc.C) {
@@ -635,7 +660,10 @@ func (s *baseLoginSuite) checkLoginWithValidator(c *gc.C, validator apiserver.Lo
 
 	// Ensure not already logged in.
 	_, err := st.Machiner().Machine(names.NewMachineTag("0"))
-	c.Assert(err, gc.ErrorMatches, `*.unknown object type "Machiner"`)
+	c.Assert(errors.Cause(err), gc.DeepEquals, &rpc.RequestError{
+		Message: `unknown object type "Machiner"`,
+		Code:    "not implemented",
+	})
 
 	adminUser := s.AdminUserTag(c)
 	// Since these are user login tests, the nonce is empty.
@@ -786,7 +814,10 @@ func (s *loginSuite) TestStateServerEnvironmentBadCreds(c *gc.C) {
 
 	adminUser := s.AdminUserTag(c)
 	err = st.Login(adminUser.String(), "bad-password", "")
-	c.Assert(err, gc.ErrorMatches, `invalid entity name or password`)
+	c.Assert(errors.Cause(err), gc.DeepEquals, &rpc.RequestError{
+		Message: `invalid entity name or password`,
+		Code:    "unauthorized access",
+	})
 }
 
 func (s *loginSuite) TestNonExistentEnvironment(c *gc.C) {
@@ -802,8 +833,10 @@ func (s *loginSuite) TestNonExistentEnvironment(c *gc.C) {
 
 	adminUser := s.AdminUserTag(c)
 	err = st.Login(adminUser.String(), "dummy-secret", "")
-	expectedError := fmt.Sprintf("unknown environment: %q", uuid)
-	c.Assert(err, gc.ErrorMatches, expectedError)
+	c.Assert(errors.Cause(err), gc.DeepEquals, &rpc.RequestError{
+		Message: fmt.Sprintf("unknown environment: %q", uuid),
+		Code:    "not found",
+	})
 }
 
 func (s *loginSuite) TestInvalidEnvironment(c *gc.C) {
@@ -817,7 +850,10 @@ func (s *loginSuite) TestInvalidEnvironment(c *gc.C) {
 
 	adminUser := s.AdminUserTag(c)
 	err = st.Login(adminUser.String(), "dummy-secret", "")
-	c.Assert(err, gc.ErrorMatches, `unknown environment: "rubbish"`)
+	c.Assert(errors.Cause(err), gc.DeepEquals, &rpc.RequestError{
+		Message: `unknown environment: "rubbish"`,
+		Code:    "not found",
+	})
 }
 
 func (s *loginSuite) TestOtherEnvironment(c *gc.C) {
@@ -904,7 +940,10 @@ func (s *loginSuite) TestOtherEnvironmentWhenNotStateServer(c *gc.C) {
 	defer st.Close()
 
 	err = st.Login(machine.Tag().String(), password, "nonce")
-	c.Assert(err, gc.ErrorMatches, `invalid entity name or password`)
+	c.Assert(errors.Cause(err), gc.DeepEquals, &rpc.RequestError{
+		Message: "invalid entity name or password",
+		Code:    "unauthorized access",
+	})
 }
 
 func (s *loginSuite) assertRemoteEnvironment(c *gc.C, st api.Connection, expected names.EnvironTag) {

--- a/apiserver/adminv2_test.go
+++ b/apiserver/adminv2_test.go
@@ -4,12 +4,14 @@
 package apiserver_test
 
 import (
+	"github.com/juju/errors"
 	"github.com/juju/juju/api"
 	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver"
+	"github.com/juju/juju/rpc"
 	"github.com/juju/juju/testing/factory"
 )
 
@@ -53,7 +55,10 @@ func (s *loginV2Suite) TestClientLoginToServer(c *gc.C) {
 
 	client := apiState.Client()
 	_, err = client.GetEnvironmentConstraints()
-	c.Assert(err, gc.ErrorMatches, `logged in to server, no environment, "Client" not supported`)
+	c.Assert(errors.Cause(err), gc.DeepEquals, &rpc.RequestError{
+		Message: `logged in to server, no environment, "Client" not supported`,
+		Code:    "not supported",
+	})
 }
 
 func (s *loginV2Suite) TestClientLoginToServerNoAccessToStateServerEnv(c *gc.C) {

--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -48,9 +48,9 @@ type Server struct {
 	limiter           utils.Limiter
 	validator         LoginValidator
 	adminApiFactories map[int]adminApiFactory
-
-	mu          sync.Mutex // protects the fields that follow
-	environUUID string
+	mu                sync.Mutex // protects the fields that follow
+	environUUID       string
+	connections       int32 // count of active websocket connections
 }
 
 // LoginValidator functions are used to decide whether login requests
@@ -222,15 +222,20 @@ type requestNotifier struct {
 
 	mu   sync.Mutex
 	tag_ string
+
+	// count is incremented by calls to join, and deincremented
+	// by calls to leave.
+	count *int32
 }
 
 var globalCounter int64
 
-func newRequestNotifier() *requestNotifier {
+func newRequestNotifier(count *int32) *requestNotifier {
 	return &requestNotifier{
 		id:    atomic.AddInt64(&globalCounter, 1),
 		tag_:  "<unknown>",
 		start: time.Now(),
+		count: count,
 	}
 }
 
@@ -276,11 +281,13 @@ func (n *requestNotifier) ServerReply(req rpc.Request, hdr *rpc.Header, body int
 }
 
 func (n *requestNotifier) join(req *http.Request) {
-	logger.Infof("[%X] API connection from %s", n.id, req.RemoteAddr)
+	active := atomic.AddInt32(n.count, 1)
+	logger.Infof("[%X] API connection from %s, active connections: %d", n.id, req.RemoteAddr, active)
 }
 
 func (n *requestNotifier) leave() {
-	logger.Infof("[%X] %s API connection terminated after %v", n.id, n.tag(), time.Since(n.start))
+	active := atomic.AddInt32(n.count, -1)
+	logger.Infof("[%X] %s API connection terminated after %v, active connections: %d", n.id, n.tag(), time.Since(n.start), active)
 }
 
 func (n *requestNotifier) ClientRequest(hdr *rpc.Header, body interface{}) {
@@ -300,6 +307,12 @@ func handleAll(mux *pat.PatternServeMux, pattern string, handler http.Handler) {
 
 func (srv *Server) run() {
 	logger.Infof("listening on %q", srv.lis.Addr())
+	defer func() {
+		addr := srv.lis.Addr().String() // Addr not valid after close
+		err := srv.lis.Close()
+		logger.Infof("closed listening socket %q with final error: %v", addr, err)
+	}()
+
 	defer func() {
 		srv.state.HackLeadership() // Break deadlocks caused by BlockUntil... calls.
 		srv.wg.Wait()              // wait for any outstanding requests to complete.
@@ -392,16 +405,20 @@ func (srv *Server) run() {
 	handleAll(mux, "/", http.HandlerFunc(srv.apiHandler))
 
 	go func() {
-		// The error from http.Serve is not interesting.
-		http.Serve(srv.lis, mux)
+		addr := srv.lis.Addr() // not valid after addr closed
+		logger.Debugf("Starting API http server on address %q", addr)
+		err := http.Serve(srv.lis, mux)
+		// normally logging an error at debug level would be grounds for a beating,
+		// however in this case the error is *expected* to be non nil, and does not
+		// affect the operation of the apiserver, but for completeness log it anyway.
+		logger.Debugf("API http server exited, final error was: %v", err)
 	}()
 
 	<-srv.tomb.Dying()
-	srv.lis.Close()
 }
 
 func (srv *Server) apiHandler(w http.ResponseWriter, req *http.Request) {
-	reqNotifier := newRequestNotifier()
+	reqNotifier := newRequestNotifier(&srv.connections)
 	reqNotifier.join(req)
 	defer reqNotifier.leave()
 	wsServer := websocket.Server{

--- a/apiserver/charms/client_test.go
+++ b/apiserver/charms/client_test.go
@@ -111,7 +111,7 @@ func (s *baseCharmsSuite) TestClientCharmInfo(c *gc.C) {
 			charm:           "wordpress",
 			expectedActions: &charm.Actions{ActionSpecs: nil},
 			url:             "cs:missing/one-1",
-			err:             `charm "cs:missing/one-1" not found`,
+			err:             `charm "cs:missing/one-1" not found \(not found\)`,
 		},
 	}
 

--- a/apiserver/client/client_test.go
+++ b/apiserver/client/client_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/apiserver/service"
 	"github.com/juju/juju/apiserver/testing"
-	apiservertesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/manual"
@@ -33,6 +32,7 @@ import (
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/provider/dummy"
+	"github.com/juju/juju/rpc"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/multiwatcher"
 	"github.com/juju/juju/state/presence"
@@ -1597,7 +1597,7 @@ func (s *clientSuite) TestBlockChangeUnitResolved(c *gc.C) {
 
 type clientRepoSuite struct {
 	baseSuite
-	apiservertesting.CharmStoreSuite
+	testing.CharmStoreSuite
 }
 
 var _ = gc.Suite(&clientRepoSuite{})
@@ -1679,7 +1679,7 @@ func (s *clientRepoSuite) TestClientServiceDeployPrincipal(c *gc.C) {
 		curl.String(), "service", 3, "", mem4g, "",
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	apiservertesting.AssertPrincipalServiceDeployed(c, s.State, "service", curl, false, ch, mem4g)
+	testing.AssertPrincipalServiceDeployed(c, s.State, "service", curl, false, ch, mem4g)
 }
 
 func (s *clientRepoSuite) assertServiceDeployPrincipal(c *gc.C, curl *charm.URL, ch charm.Charm, mem4g constraints.Value) {
@@ -1687,7 +1687,7 @@ func (s *clientRepoSuite) assertServiceDeployPrincipal(c *gc.C, curl *charm.URL,
 		curl.String(), "service", 3, "", mem4g, "",
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	apiservertesting.AssertPrincipalServiceDeployed(c, s.State, "service", curl, false, ch, mem4g)
+	testing.AssertPrincipalServiceDeployed(c, s.State, "service", curl, false, ch, mem4g)
 }
 
 func (s *clientRepoSuite) assertServiceDeployPrincipalBlocked(c *gc.C, msg string, curl *charm.URL, mem4g constraints.Value) {
@@ -3467,6 +3467,14 @@ func (s *clientSuite) assertBlockedErrorAndLiveliness(
 	assertLife(c, living2, state.Alive)
 	assertLife(c, living3, state.Alive)
 	assertLife(c, living4, state.Alive)
+}
+
+func (s *clientSuite) AssertBlocked(c *gc.C, err error, msg string) {
+	c.Assert(params.IsCodeOperationBlocked(err), jc.IsTrue, gc.Commentf("error: %#v", err))
+	c.Assert(errors.Cause(err), gc.DeepEquals, &rpc.RequestError{
+		Message: msg,
+		Code:    "operation is blocked",
+	})
 }
 
 func (s *clientSuite) TestBlockRemoveDestroyMachines(c *gc.C) {

--- a/apiserver/client/perm_test.go
+++ b/apiserver/client/perm_test.go
@@ -6,6 +6,7 @@ package client_test
 import (
 	"strings"
 
+	"github.com/juju/errors"
 	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -14,6 +15,7 @@ import (
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/constraints"
+	"github.com/juju/juju/rpc"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/version"
 )
@@ -180,7 +182,10 @@ func (s *permSuite) TestOperationPerm(c *gc.C) {
 			if allow[e] {
 				c.Check(err, jc.ErrorIsNil)
 			} else {
-				c.Check(err, gc.ErrorMatches, "permission denied")
+				c.Check(errors.Cause(err), gc.DeepEquals, &rpc.RequestError{
+					Message: "permission denied",
+					Code:    "unauthorized access",
+				})
 				c.Check(err, jc.Satisfies, params.IsCodeUnauthorized)
 			}
 			reset()

--- a/apiserver/client/run_test.go
+++ b/apiserver/client/run_test.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/juju/errors"
 	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/exec"
@@ -16,6 +17,7 @@ import (
 	"github.com/juju/juju/apiserver/client"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/network"
+	"github.com/juju/juju/rpc"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/utils/ssh"
@@ -258,6 +260,14 @@ func (s *runSuite) TestRunOnAllMachines(c *gc.C) {
 	c.Check(string(results[0].Stdout), gc.Equals, expectedCommand[0])
 	c.Check(string(results[1].Stdout), gc.Equals, expectedCommand[0])
 	c.Check(string(results[2].Stdout), gc.Equals, expectedCommand[0])
+}
+
+func (s *runSuite) AssertBlocked(c *gc.C, err error, msg string) {
+	c.Assert(params.IsCodeOperationBlocked(err), jc.IsTrue, gc.Commentf("error: %#v", err))
+	c.Assert(errors.Cause(err), gc.DeepEquals, &rpc.RequestError{
+		Message: msg,
+		Code:    "operation is blocked",
+	})
 }
 
 func (s *runSuite) TestBlockRunOnAllMachines(c *gc.C) {

--- a/apiserver/common/testing/block.go
+++ b/apiserver/common/testing/block.go
@@ -6,6 +6,7 @@ package testing
 import (
 	"fmt"
 
+	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -35,11 +36,7 @@ func NewBlockHelper(st api.Connection) BlockHelper {
 // on switches on desired block and
 // asserts that no errors were encountered.
 func (s BlockHelper) on(c *gc.C, blockType multiwatcher.BlockType, msg string) {
-	c.Assert(
-		s.client.SwitchBlockOn(
-			fmt.Sprintf("%v", blockType),
-			msg),
-		gc.IsNil)
+	c.Assert(s.client.SwitchBlockOn(fmt.Sprintf("%v", blockType), msg), gc.IsNil)
 }
 
 // BlockAllChanges blocks all operations that could change environment.
@@ -67,5 +64,8 @@ func (s BlockHelper) BlockDestroyEnvironment(c *gc.C, msg string) {
 // related to switched block.
 func (s BlockHelper) AssertBlocked(c *gc.C, err error, msg string) {
 	c.Assert(params.IsCodeOperationBlocked(err), jc.IsTrue)
-	c.Assert(err, gc.ErrorMatches, msg)
+	c.Assert(errors.Cause(err), gc.DeepEquals, &params.Error{
+		Message: msg,
+		Code:    "operation is blocked",
+	})
 }

--- a/apiserver/export_test.go
+++ b/apiserver/export_test.go
@@ -5,6 +5,7 @@ package apiserver
 
 import (
 	"fmt"
+	"net"
 	"reflect"
 	"time"
 
@@ -172,4 +173,9 @@ func (logFileLine *logFileLine) LogLineAgentTag() string {
 // LogLineAgentName gives tests access to an internal logFileLine attribute
 func (logFileLine *logFileLine) LogLineAgentName() string {
 	return logFileLine.agentName
+}
+
+// Addr returns the address that the server is listening on.
+func (srv *Server) Addr() *net.TCPAddr {
+	return srv.lis.Addr().(*net.TCPAddr) // cannot fail
 }

--- a/apiserver/params/apierror.go
+++ b/apiserver/params/apierror.go
@@ -69,24 +69,6 @@ func ErrCode(err error) string {
 	return ""
 }
 
-// ClientError maps errors returned from an RPC call into local errors with
-// appropriate values.
-func ClientError(err error) error {
-	switch err := errors.Cause(err).(type) {
-	case *rpc.RequestError:
-		// We use our own error type rather than rpc.ServerError
-		// because we don't want the code or the "server error" prefix
-		// within the error message. Also, it's best not to make clients
-		// know that we're using the rpc package.
-		return &Error{
-			Message: err.Message,
-			Code:    err.Code,
-		}
-	default:
-		return err
-	}
-}
-
 func IsCodeActionNotAvailable(err error) bool {
 	return ErrCode(err) == CodeActionNotAvailable
 }

--- a/apiserver/params/apierror.go
+++ b/apiserver/params/apierror.go
@@ -72,17 +72,18 @@ func ErrCode(err error) string {
 // ClientError maps errors returned from an RPC call into local errors with
 // appropriate values.
 func ClientError(err error) error {
-	rerr, ok := err.(*rpc.RequestError)
-	if !ok {
+	switch err := errors.Cause(err).(type) {
+	case *rpc.RequestError:
+		// We use our own error type rather than rpc.ServerError
+		// because we don't want the code or the "server error" prefix
+		// within the error message. Also, it's best not to make clients
+		// know that we're using the rpc package.
+		return &Error{
+			Message: err.Message,
+			Code:    err.Code,
+		}
+	default:
 		return err
-	}
-	// We use our own error type rather than rpc.ServerError
-	// because we don't want the code or the "server error" prefix
-	// within the error message. Also, it's best not to make clients
-	// know that we're using the rpc package.
-	return &Error{
-		Message: rerr.Message,
-		Code:    rerr.Code,
 	}
 }
 

--- a/apiserver/pinger_test.go
+++ b/apiserver/pinger_test.go
@@ -11,6 +11,7 @@ package apiserver_test
 import (
 	"time"
 
+	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -67,7 +68,7 @@ func (s *pingerSuite) TestPing(c *gc.C) {
 	err = st.Close()
 	c.Assert(err, jc.ErrorIsNil)
 	err = st.Ping()
-	c.Assert(err, gc.Equals, rpc.ErrShutdown)
+	c.Assert(errors.Cause(err), gc.Equals, rpc.ErrShutdown)
 
 	// Make sure that ping messages have not been logged.
 	for _, m := range tw.Log() {

--- a/apiserver/server_test.go
+++ b/apiserver/server_test.go
@@ -154,7 +154,7 @@ func (s *serverSuite) TestOpenAsMachineErrors(c *gc.C) {
 	assertNotProvisioned := func(err error) {
 		c.Assert(err, gc.NotNil)
 		c.Assert(err, jc.Satisfies, params.IsCodeNotProvisioned)
-		c.Assert(err, gc.ErrorMatches, `machine \d+ not provisioned`)
+		c.Assert(err, gc.ErrorMatches, `machine \d+ not provisioned \(not provisioned\)`)
 	}
 
 	machine, password := s.Factory.MakeMachineReturningPassword(

--- a/apiserver/service/service_test.go
+++ b/apiserver/service/service_test.go
@@ -432,7 +432,7 @@ func (s *serviceSuite) TestAddCharmWithAuthorization(c *gc.C) {
 	// Try to add a charm to the environment without authorization.
 	s.DischargeUser = ""
 	err = s.APIState.Client().AddCharm(curl)
-	c.Assert(err, gc.ErrorMatches, `cannot retrieve charm "cs:~restricted/precise/wordpress-3": cannot get archive: cannot get discharge from ".*": third party refused discharge: cannot discharge: discharge denied`)
+	c.Assert(err, gc.ErrorMatches, `cannot retrieve charm "cs:~restricted/precise/wordpress-3": cannot get archive: cannot get discharge from ".*": third party refused discharge: cannot discharge: discharge denied \(unauthorized access\)`)
 
 	tryAs := func(user string) error {
 		client := csclient.New(csclient.Params{

--- a/apiserver/testing/fakecharmstore.go
+++ b/apiserver/testing/fakecharmstore.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"net/http"
 
-	gitjujutesting "github.com/juju/testing"
+	"github.com/juju/testing"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v5"
 	"gopkg.in/juju/charm.v5/charmrepo"
@@ -22,7 +22,7 @@ import (
 )
 
 type CharmStoreSuite struct {
-	gitjujutesting.CleanupSuite
+	testing.CleanupSuite
 
 	Session *mgo.Session
 	// DischargeUser holds the identity of the user

--- a/cmd/juju/commands/debughooks_test.go
+++ b/cmd/juju/commands/debughooks_test.go
@@ -62,7 +62,7 @@ var debugHooksTests = []struct {
 }, {
 	info:  `invalid unit`,
 	args:  []string{"nonexistent/123"},
-	error: `unit "nonexistent/123" not found`,
+	error: `unit "nonexistent/123" not found \(not found\)`,
 }, {
 	info:  `invalid hook`,
 	args:  []string{"mysql/0", "invalid-hook"},
@@ -94,9 +94,9 @@ func (s *DebugHooksSuite) TestDebugHooksCommand(c *gc.C) {
 			err = debugHooksCmd.Run(ctx)
 		}
 		if t.error != "" {
-			c.Assert(err, gc.ErrorMatches, t.error)
+			c.Check(err, gc.ErrorMatches, t.error)
 		} else {
-			c.Assert(err, jc.ErrorIsNil)
+			c.Check(err, jc.ErrorIsNil)
 		}
 	}
 }

--- a/cmd/juju/commands/expose_test.go
+++ b/cmd/juju/commands/expose_test.go
@@ -4,12 +4,14 @@
 package commands
 
 import (
+	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v5"
 
 	"github.com/juju/juju/cmd/envcmd"
 	jujutesting "github.com/juju/juju/juju/testing"
+	"github.com/juju/juju/rpc"
 	"github.com/juju/juju/testcharms"
 	"github.com/juju/juju/testing"
 )
@@ -52,7 +54,10 @@ func (s *ExposeSuite) TestExpose(c *gc.C) {
 	s.assertExposed(c, "some-service-name")
 
 	err = runExpose(c, "nonexistent-service")
-	c.Assert(err, gc.ErrorMatches, `service "nonexistent-service" not found`)
+	c.Assert(errors.Cause(err), gc.DeepEquals, &rpc.RequestError{
+		Message: `service "nonexistent-service" not found`,
+		Code:    "not found",
+	})
 }
 
 func (s *ExposeSuite) TestBlockExpose(c *gc.C) {

--- a/cmd/juju/commands/removerelation_test.go
+++ b/cmd/juju/commands/removerelation_test.go
@@ -4,11 +4,13 @@
 package commands
 
 import (
+	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cmd/envcmd"
 	jujutesting "github.com/juju/juju/juju/testing"
+	"github.com/juju/juju/rpc"
 	"github.com/juju/juju/testcharms"
 	"github.com/juju/juju/testing"
 )
@@ -51,11 +53,17 @@ func (s *RemoveRelationSuite) TestRemoveRelation(c *gc.C) {
 
 	// Destroy a relation that used to exist.
 	err = runRemoveRelation(c, "riak", "logging")
-	c.Assert(err, gc.ErrorMatches, `relation "logging:info riak:juju-info" not found`)
+	c.Assert(errors.Cause(err), gc.DeepEquals, &rpc.RequestError{
+		Message: `relation "logging:info riak:juju-info" not found`,
+		Code:    "not found",
+	})
 
 	// Invalid removes.
 	err = runRemoveRelation(c, "ping", "pong")
-	c.Assert(err, gc.ErrorMatches, `service "ping" not found`)
+	c.Assert(errors.Cause(err), gc.DeepEquals, &rpc.RequestError{
+		Message: `service "ping" not found`,
+		Code:    "not found",
+	})
 	err = runRemoveRelation(c, "riak")
 	c.Assert(err, gc.ErrorMatches, `a relation must involve two services`)
 }

--- a/cmd/juju/commands/removeservice_test.go
+++ b/cmd/juju/commands/removeservice_test.go
@@ -4,11 +4,13 @@
 package commands
 
 import (
+	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cmd/envcmd"
 	jujutesting "github.com/juju/juju/juju/testing"
+	"github.com/juju/juju/rpc"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/testcharms"
 	"github.com/juju/juju/testing"
@@ -64,7 +66,11 @@ func (s *RemoveServiceSuite) TestBlockRemoveService(c *gc.C) {
 func (s *RemoveServiceSuite) TestFailure(c *gc.C) {
 	// Destroy a service that does not exist.
 	err := runRemoveService(c, "gargleblaster")
-	c.Assert(err, gc.ErrorMatches, `service "gargleblaster" not found`)
+	c.Assert(errors.Cause(err), gc.DeepEquals, &rpc.RequestError{
+		Message: `service "gargleblaster" not found`,
+		Code:    "not found",
+	})
+	s.stub.CheckNoCalls(c)
 }
 
 func (s *RemoveServiceSuite) TestInvalidArgs(c *gc.C) {

--- a/cmd/juju/commands/resolved_test.go
+++ b/cmd/juju/commands/resolved_test.go
@@ -46,7 +46,7 @@ var resolvedTests = []struct {
 		err:  `invalid unit name "jeremy-fisher"`,
 	}, {
 		args: []string{"jeremy-fisher/99"},
-		err:  `unit "jeremy-fisher/99" not found`,
+		err:  `unit "jeremy-fisher/99" not found \(not found\)`,
 	}, {
 		args: []string{"dummy/0"},
 		err:  `unit "dummy/0" is not in an error state`,

--- a/cmd/juju/commands/scp_unix_test.go
+++ b/cmd/juju/commands/scp_unix_test.go
@@ -103,7 +103,7 @@ var scpTests = []struct {
 	}, {
 		about: "scp with no such machine",
 		args:  []string{"5:foo", "bar"},
-		error: "machine 5 not found",
+		error: `machine 5 not found \(not found\)`,
 	},
 }
 

--- a/cmd/juju/commands/unexpose_test.go
+++ b/cmd/juju/commands/unexpose_test.go
@@ -4,12 +4,14 @@
 package commands
 
 import (
+	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v5"
 
 	"github.com/juju/juju/cmd/envcmd"
 	jujutesting "github.com/juju/juju/juju/testing"
+	"github.com/juju/juju/rpc"
 	"github.com/juju/juju/testcharms"
 	"github.com/juju/juju/testing"
 )
@@ -56,7 +58,10 @@ func (s *UnexposeSuite) TestUnexpose(c *gc.C) {
 	s.assertExposed(c, "some-service-name", false)
 
 	err = runUnexpose(c, "nonexistent-service")
-	c.Assert(err, gc.ErrorMatches, `service "nonexistent-service" not found`)
+	c.Assert(errors.Cause(err), gc.DeepEquals, &rpc.RequestError{
+		Message: `service "nonexistent-service" not found`,
+		Code:    "not found",
+	})
 }
 
 func (s *UnexposeSuite) TestBlockUnexpose(c *gc.C) {

--- a/cmd/juju/commands/upgradecharm_test.go
+++ b/cmd/juju/commands/upgradecharm_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path"
 
+	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v5"
@@ -18,6 +19,7 @@ import (
 
 	"github.com/juju/juju/cmd/envcmd"
 	jujutesting "github.com/juju/juju/juju/testing"
+	"github.com/juju/juju/rpc"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/testcharms"
 	"github.com/juju/juju/testing"
@@ -78,7 +80,10 @@ func (s *UpgradeCharmErrorsSuite) TestWithInvalidRepository(c *gc.C) {
 
 func (s *UpgradeCharmErrorsSuite) TestInvalidService(c *gc.C) {
 	err := runUpgradeCharm(c, "phony")
-	c.Assert(err, gc.ErrorMatches, `service "phony" not found`)
+	c.Assert(errors.Cause(err), gc.DeepEquals, &rpc.RequestError{
+		Message: `service "phony" not found`,
+		Code:    "not found",
+	})
 }
 
 func (s *UpgradeCharmErrorsSuite) deployService(c *gc.C) {

--- a/featuretests/cloudimagemetadata_test.go
+++ b/featuretests/cloudimagemetadata_test.go
@@ -4,6 +4,7 @@
 package featuretests
 
 import (
+	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -11,6 +12,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/mongo"
+	"github.com/juju/juju/rpc"
 )
 
 type cloudImageMetadataSuite struct {
@@ -33,7 +35,10 @@ func (s *cloudImageMetadataSuite) TearDownTest(c *gc.C) {
 
 func (s *cloudImageMetadataSuite) TestSaveAndFindMetadata(c *gc.C) {
 	metadata, err := s.client.List("", "", nil, nil, "", "")
-	c.Assert(err, gc.ErrorMatches, "matching cloud image metadata not found")
+	c.Assert(errors.Cause(err), gc.DeepEquals, &rpc.RequestError{
+		Message: "matching cloud image metadata not found",
+		Code:    "not found",
+	})
 	c.Assert(metadata, gc.HasLen, 0)
 
 	//	check db too

--- a/featuretests/cmd_juju_space_test.go
+++ b/featuretests/cmd_juju_space_test.go
@@ -6,6 +6,7 @@ package featuretests
 import (
 	"fmt"
 	"math/rand"
+	"regexp"
 
 	"github.com/juju/cmd"
 	jc "github.com/juju/testing/checkers"
@@ -104,8 +105,8 @@ func (s *cmdSpaceSuite) TestSpaceCreateNotSupported(c *gc.C) {
 	isEnabled := dummy.SetSupportsSpaces(false)
 	defer dummy.SetSupportsSpaces(isEnabled)
 
-	expectedError := "cannot create space \"foo\": spaces not supported"
-	context := s.RunCreate(c, expectedError, "foo")
+	expectedError := `cannot create space "foo": spaces not supported (not supported)`
+	context := s.RunCreate(c, regexp.QuoteMeta(expectedError), "foo")
 	s.AssertOutput(c, context,
 		"", // No stdout output.
 		expectedError+"\n",
@@ -224,8 +225,8 @@ func (s *cmdSpaceSuite) TestSpaceListNotSupported(c *gc.C) {
 	isEnabled := dummy.SetSupportsSpaces(false)
 	defer dummy.SetSupportsSpaces(isEnabled)
 
-	expectedError := "cannot list spaces: spaces not supported"
-	context := s.RunList(c, expectedError)
+	expectedError := `cannot list spaces: spaces not supported (not supported)`
+	context := s.RunList(c, regexp.QuoteMeta(expectedError))
 	s.AssertOutput(c, context,
 		"", // No stdout output.
 		expectedError+"\n",

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -4,8 +4,9 @@
 package rpc
 
 import (
-	"errors"
 	"strings"
+
+	"github.com/juju/errors"
 )
 
 var ErrShutdown = errors.New("connection is shut down")
@@ -26,11 +27,10 @@ type RequestError struct {
 }
 
 func (e *RequestError) Error() string {
-	m := "request error: " + e.Message
 	if e.Code != "" {
-		m += " (" + e.Code + ")"
+		return e.Message + " (" + e.Code + ")"
 	}
-	return m
+	return e.Message
 }
 
 func (e *RequestError) ErrorCode() string {
@@ -124,7 +124,7 @@ func (conn *Conn) handleResponse(hdr *Header) error {
 		}
 		call.done()
 	}
-	return err
+	return errors.Annotate(err, "error handling response")
 }
 
 func (call *Call) done() {
@@ -138,15 +138,25 @@ func (call *Call) done() {
 	}
 }
 
-// Call invokes the named action on the object of the given type with
-// the given id.  The returned values will be stored in response, which
-// should be a pointer.  If the action fails remotely, the returned
-// error will be of type RequestError.  The params value may be nil if
-// no parameters are provided; the response value may be nil to indicate
-// that any result should be discarded.
+// Call invokes the named action on the object of the given type with the given
+// id. The returned values will be stored in response, which should be a pointer.
+// If the action fails remotely, the error will have a cause of type RequestError.
+// The params value may be nil if no parameters are provided; the response value
+// may be nil to indicate that any result should be discarded.
 func (conn *Conn) Call(req Request, params, response interface{}) error {
 	call := <-conn.Go(req, params, response, make(chan *Call, 1)).Done
-	return call.Error
+	switch call.Error.(type) {
+	case *RequestError:
+		// TODO(dfc) many callers assert the error.Error() value has a
+		// "request error: " prefix. Rather than encoding this text in
+		// the .Error() string value itself, use Annotate. This lets callers
+		// unwrap the error if needed to assert it by type or value or
+		// test its expected string value if required. The latter behaviour
+		// should be removed.
+		return errors.Annotate(call.Error, "request error")
+	default:
+		return errors.Trace(call.Error)
+	}
 }
 
 // Go invokes the request asynchronously.  It returns the Call structure representing

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -145,18 +145,7 @@ func (call *Call) done() {
 // may be nil to indicate that any result should be discarded.
 func (conn *Conn) Call(req Request, params, response interface{}) error {
 	call := <-conn.Go(req, params, response, make(chan *Call, 1)).Done
-	switch call.Error.(type) {
-	case *RequestError:
-		// TODO(dfc) many callers assert the error.Error() value has a
-		// "request error: " prefix. Rather than encoding this text in
-		// the .Error() string value itself, use Annotate. This lets callers
-		// unwrap the error if needed to assert it by type or value or
-		// test its expected string value if required. The latter behaviour
-		// should be removed.
-		return errors.Annotate(call.Error, "request error")
-	default:
-		return errors.Trace(call.Error)
-	}
+	return errors.Trace(call.Error)
 }
 
 // Go invokes the request asynchronously.  It returns the Call structure representing
@@ -166,14 +155,13 @@ func (conn *Conn) Call(req Request, params, response interface{}) error {
 func (conn *Conn) Go(req Request, args, response interface{}, done chan *Call) *Call {
 	if done == nil {
 		done = make(chan *Call, 1)
-	} else {
-		// If caller passes done != nil, it must arrange that
-		// done has enough buffer for the number of simultaneous
-		// RPCs that will be using that channel.  If the channel
-		// is totally unbuffered, it's best not to run at all.
-		if cap(done) == 0 {
-			panic("github.com/juju/juju/rpc: done channel is unbuffered")
-		}
+	}
+	// If caller passes done != nil, it must arrange that
+	// done has enough buffer for the number of simultaneous
+	// RPCs that will be using that channel.  If the channel
+	// is totally unbuffered, it's best not to run at all.
+	if cap(done) == 0 {
+		panic("github.com/juju/juju/rpc: done channel is unbuffered")
 	}
 	call := &Call{
 		Request:  req,

--- a/rpc/rpc_test.go
+++ b/rpc/rpc_test.go
@@ -770,7 +770,7 @@ func (*rpcSuite) TestErrorCode(c *gc.C) {
 	client, srvDone, _, _ := newRPCClientServer(c, root, nil, false)
 	defer closeClient(c, client, srvDone)
 	err := client.Call(rpc.Request{"ErrorMethods", 0, "", "Call"}, nil, nil)
-	c.Assert(err, gc.ErrorMatches, `request error: message \(code\)`)
+	c.Assert(err, gc.ErrorMatches, `message \(code\)`)
 	c.Assert(errors.Cause(err).(rpc.ErrorCoder).ErrorCode(), gc.Equals, "code")
 }
 
@@ -952,7 +952,7 @@ func testBadCall(
 	if expectedErrCode != "" {
 		msg += " (" + expectedErrCode + ")"
 	}
-	c.Assert(err, gc.ErrorMatches, regexp.QuoteMeta("request error: "+msg))
+	c.Assert(err, gc.ErrorMatches, regexp.QuoteMeta(msg))
 
 	// Test that there was a notification for the client request.
 	c.Assert(clientNotifier.clientRequests, gc.HasLen, 1)
@@ -1026,10 +1026,10 @@ func (*rpcSuite) TestContinueAfterReadBodyError(c *gc.C) {
 		X: map[string]int{"hello": 65},
 	}
 	err := client.Call(rpc.Request{"SimpleMethods", 0, "a0", "SliceArg"}, arg0, &ret)
-	c.Assert(err, gc.ErrorMatches, `request error: json: cannot unmarshal object into Go value of type \[\]string`)
+	c.Assert(err, gc.ErrorMatches, `json: cannot unmarshal object into Go value of type \[\]string`)
 
 	err = client.Call(rpc.Request{"SimpleMethods", 0, "a0", "SliceArg"}, arg0, &ret)
-	c.Assert(err, gc.ErrorMatches, `request error: json: cannot unmarshal object into Go value of type \[\]string`)
+	c.Assert(err, gc.ErrorMatches, `json: cannot unmarshal object into Go value of type \[\]string`)
 
 	arg1 := struct {
 		X []string
@@ -1103,7 +1103,7 @@ func (*rpcSuite) TestServerRequestWhenNotServing(c *gc.C) {
 	defer closeClient(c, client, srvDone)
 	var r int64val
 	err := client.Call(rpc.Request{"CallbackMethods", 0, "", "Factorial"}, int64val{12}, &r)
-	c.Assert(err, gc.ErrorMatches, "request error: request error: no service")
+	c.Assert(err, gc.ErrorMatches, "no service")
 }
 
 func (*rpcSuite) TestChangeAPI(c *gc.C) {
@@ -1112,11 +1112,11 @@ func (*rpcSuite) TestChangeAPI(c *gc.C) {
 	defer closeClient(c, client, srvDone)
 	var s stringVal
 	err := client.Call(rpc.Request{"NewlyAvailable", 0, "", "NewMethod"}, nil, &s)
-	c.Assert(err, gc.ErrorMatches, `request error: unknown object type "NewlyAvailable" \(not implemented\)`)
+	c.Assert(err, gc.ErrorMatches, `unknown object type "NewlyAvailable" \(not implemented\)`)
 	err = client.Call(rpc.Request{"ChangeAPIMethods", 0, "", "ChangeAPI"}, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	err = client.Call(rpc.Request{"ChangeAPIMethods", 0, "", "ChangeAPI"}, nil, nil)
-	c.Assert(err, gc.ErrorMatches, `request error: unknown object type "ChangeAPIMethods" \(not implemented\)`)
+	c.Assert(err, gc.ErrorMatches, `unknown object type "ChangeAPIMethods" \(not implemented\)`)
 	err = client.Call(rpc.Request{"NewlyAvailable", 0, "", "NewMethod"}, nil, &s)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s, gc.Equals, stringVal{"new method result"})
@@ -1131,7 +1131,7 @@ func (*rpcSuite) TestChangeAPIToNil(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = client.Call(rpc.Request{"ChangeAPIMethods", 0, "", "RemoveAPI"}, nil, nil)
-	c.Assert(err, gc.ErrorMatches, "request error: no service")
+	c.Assert(err, gc.ErrorMatches, "no service")
 }
 
 func (*rpcSuite) TestChangeAPIWhileServingRequest(c *gc.C) {
@@ -1162,7 +1162,7 @@ func (*rpcSuite) TestChangeAPIWhileServingRequest(c *gc.C) {
 	done <- fmt.Errorf("an error")
 	select {
 	case r := <-result:
-		c.Assert(r, gc.ErrorMatches, "request error: transformed: an error")
+		c.Assert(r, gc.ErrorMatches, "transformed: an error")
 	case <-time.After(3 * time.Second):
 		c.Fatalf("timeout on channel read")
 	}

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -531,8 +531,7 @@ func (conn *Conn) bindRequest(hdr *Header) (boundRequest, error) {
 	if err != nil {
 		if _, ok := err.(*rpcreflect.CallNotImplementedError); ok {
 			err = &serverError{
-				Message: err.Error(),
-				Code:    CodeNotImplemented,
+				error: err,
 			}
 		} else {
 			err = transformErrors(err)
@@ -574,12 +573,11 @@ func (conn *Conn) runRequest(req boundRequest, arg reflect.Value, startTime time
 	}
 }
 
-type serverError RequestError
-
-func (e *serverError) Error() string {
-	return e.Message
+type serverError struct {
+	error
 }
 
 func (e *serverError) ErrorCode() string {
-	return e.Code
+	// serverError only knows one error code.
+	return CodeNotImplemented
 }

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -4,12 +4,12 @@
 package rpc
 
 import (
-	"fmt"
 	"io"
 	"reflect"
 	"sync"
 	"time"
 
+	"github.com/juju/errors"
 	"github.com/juju/loggo"
 
 	"github.com/juju/juju/rpc/rpcreflect"
@@ -524,7 +524,7 @@ func (conn *Conn) bindRequest(hdr *Header) (boundRequest, error) {
 	conn.mutex.Unlock()
 
 	if methodFinder == nil {
-		return boundRequest{}, fmt.Errorf("no service")
+		return boundRequest{}, errors.New("no service")
 	}
 	caller, err := methodFinder.FindMethod(
 		hdr.Request.Type, hdr.Request.Version, hdr.Request.Action)


### PR DESCRIPTION
This is a backport from master to 1.25

Updates LP#1538583

api/apiclient.APICall was the sole caller of params.ClientError.
params.Client error would rewrite the error value iff it was
rpc.RequestError, claiming that it was leaking unnecessary information
to the caller, specfically the "request error: " prefix. In b4e2785
the error prefix was convered to an errors.Annotate wrapper removing
the requirement to convert the error type.

Now, by removing params.ClientError, we can also remove the
errors.Annotate wrapper as the _type of the error_ tells us what it is.

So, callers get

a. A nice annotate error backtrace using errors.Trace
b. Access to the original *rpc.RequestError to inspect if they want.

(Review request: http://reviews.vapour.ws/r/3870/)