### PR TITLE
Improved "switch" command

### DIFF
--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -427,12 +427,6 @@ to clean up the model.`[1:])
 	if err := c.SetModelName(cfg.Name()); err != nil {
 		return errors.Trace(err)
 	}
-	// TODO(axw) we need to keep writing current-model until everything
-	// is switched over to jujuclient. The initial model is stored with
-	// the controller's name.
-	if err := modelcmd.SetCurrentModel(ctx, cfg.Name()); err != nil {
-		return errors.Trace(err)
-	}
 
 	err = c.SetBootstrapEndpointAddress(environ)
 	if err != nil {

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -471,10 +471,9 @@ func (s *BootstrapSuite) TestBootstrapTwice(c *gc.C) {
 func (s *BootstrapSuite) TestBootstrapSetsCurrentModel(c *gc.C) {
 	s.patchVersionAndSeries(c, "raring")
 
-	ctx, err := coretesting.RunCommand(c, newBootstrapCommand(), "devcontroller", "dummy", "--auto-upgrade")
+	_, err := coretesting.RunCommand(c, newBootstrapCommand(), "devcontroller", "dummy", "--auto-upgrade")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(coretesting.Stderr(ctx), jc.Contains, "-> local.devcontroller")
-	currentController, err := modelcmd.ReadCurrentModel()
+	currentController, err := modelcmd.ReadCurrentController()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(currentController, gc.Equals, bootstrappedControllerName("devcontroller"))
 }

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -176,9 +176,9 @@ func (s *MainSuite) TestActualRunJujuArgOrder(c *gc.C) {
 	s.PatchEnvironment(osenv.JujuModelEnvKey, "current")
 	logpath := filepath.Join(c.MkDir(), "log")
 	tests := [][]string{
-		{"--log-file", logpath, "--debug", "switch"}, // global flags before
-		{"switch", "--log-file", logpath, "--debug"}, // after
-		{"--log-file", logpath, "switch", "--debug"}, // mixed
+		{"--log-file", logpath, "--debug", "list-controllers"}, // global flags before
+		{"list-controllers", "--log-file", logpath, "--debug"}, // after
+		{"--log-file", logpath, "list-controllers", "--debug"}, // mixed
 	}
 	for i, test := range tests {
 		c.Logf("test %d: %v", i, test)

--- a/cmd/juju/commands/switch.go
+++ b/cmd/juju/commands/switch.go
@@ -1,4 +1,4 @@
-// Copyright 2013 Canonical Ltd.
+// Copyright 2016 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 package commands
@@ -6,145 +6,173 @@ package commands
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
-	"github.com/juju/utils/set"
-	"launchpad.net/gnuflag"
 
 	"github.com/juju/juju/cmd/modelcmd"
-	"github.com/juju/juju/environs/configstore"
+	"github.com/juju/juju/juju/osenv"
+	"github.com/juju/juju/jujuclient"
 )
 
 func newSwitchCommand() cmd.Command {
-	return &switchCommand{}
+	cmd := &switchCommand{
+		Store: jujuclient.NewFileClientStore(),
+		ReadCurrentController:  modelcmd.ReadCurrentController,
+		WriteCurrentController: modelcmd.WriteCurrentController,
+	}
+	cmd.RefreshModels = cmd.JujuCommandBase.RefreshModels
+	return modelcmd.WrapBase(cmd)
 }
 
 type switchCommand struct {
-	cmd.CommandBase
-	ModelName string
-	List      bool
+	modelcmd.JujuCommandBase
+	RefreshModels          func(jujuclient.ClientStore, string) error
+	ReadCurrentController  func() (string, error)
+	WriteCurrentController func(string) error
+
+	Store  jujuclient.ClientStore
+	Target string
 }
 
 var switchDoc = `
-Show or change the default juju model or controller name.
+Switch to the specified model or controller.
 
-If no command line parameters are passed, switch will output the current
-model as defined by the file $JUJU_DATA/current-model.
-
-If a command line parameter is passed in, that value will is stored in the
-current model file if it represents a valid model name.
+If the name identifies controller, the client will switch to the
+active model for that controller. Otherwise, the name must specify
+either the name of a model within the active controller, or a
+fully-qualified model with the format "controller:model".
 `
-
-const controllerSuffix = " (controller)"
 
 func (c *switchCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "switch",
-		Args:    "[model name]",
-		Purpose: "show or change the default juju model or controller name",
+		Args:    "<controller>|<model>|<controller>:<model>",
+		Purpose: "change the active Juju model",
 		Doc:     switchDoc,
 	}
 }
 
-func (c *switchCommand) SetFlags(f *gnuflag.FlagSet) {
-	f.BoolVar(&c.List, "l", false, "list the model names")
-	f.BoolVar(&c.List, "list", false, "")
+func (c *switchCommand) Init(args []string) error {
+	if len(args) == 0 {
+		return errors.Errorf("missing controller or model name")
+	}
+	if err := cmd.CheckEmpty(args[1:]); err != nil {
+		return err
+	}
+	c.Target = args[0]
+	return nil
 }
 
-func (c *switchCommand) Init(args []string) (err error) {
-	c.ModelName, err = cmd.ZeroOrOneArgs(args)
-	return
-}
+func (c *switchCommand) Run(ctx *cmd.Context) (resultErr error) {
 
-func getConfigstoreOptions() (set.Strings, set.Strings, error) {
-	store, err := configstore.Default()
+	// Get the current name for logging the transition.
+	currentControllerName, err := c.ReadCurrentController()
 	if err != nil {
-		return nil, nil, errors.Annotate(err, "failed to get config store")
+		return errors.Trace(err)
 	}
-	environmentNames, err := store.List()
+	currentName, err := c.name(currentControllerName)
 	if err != nil {
-		return nil, nil, errors.Annotate(err, "failed to list models in config store")
+		return errors.Trace(err)
 	}
-	controllerNames, err := store.ListSystems()
-	if err != nil {
-		return nil, nil, errors.Annotate(err, "failed to list controllers in config store")
-	}
-	// Also include the controllers.
-	return set.NewStrings(environmentNames...), set.NewStrings(controllerNames...), nil
-}
+	var newName string
+	defer func() {
+		if resultErr != nil {
+			return
+		}
+		logSwitch(ctx, currentName, &newName)
+	}()
 
-func (c *switchCommand) Run(ctx *cmd.Context) error {
 	// Switch is an alternative way of dealing with environments than using
 	// the JUJU_MODEL environment setting, and as such, doesn't play too well.
 	// If JUJU_MODEL is set we should report that as the current environment,
 	// and not allow switching when it is set.
-
-	// Passing through the empty string reads the default environments.yaml file.
-	// If the environments.yaml file doesn't exist, just list environments in
-	// the configstore.
-	configEnvirons, configControllers, err := getConfigstoreOptions()
-	if err != nil {
-		return err
-	}
-	names := set.NewStrings()
-	names = names.Union(configEnvirons)
-	names = names.Union(configControllers)
-
-	if c.List {
-		// List all environments and controllers.
-		if c.ModelName != "" {
-			return errors.New("cannot switch and list at the same time")
-		}
-		for _, name := range names.SortedValues() {
-			if configControllers.Contains(name) && !configEnvirons.Contains(name) {
-				name += controllerSuffix
-			}
-			fmt.Fprintf(ctx.Stdout, "%s\n", name)
-		}
-		return nil
+	if env := os.Getenv(osenv.JujuModelEnvKey); env != "" {
+		return errors.Errorf("cannot switch when JUJU_MODEL is overriding the model (set to %q)", env)
 	}
 
-	jujuEnv := os.Getenv("JUJU_MODEL")
-	if jujuEnv != "" {
-		if c.ModelName == "" {
-			fmt.Fprintf(ctx.Stdout, "%s\n", jujuEnv)
+	// If the name identifies a controller, then set that as the current one.
+	if _, err := c.Store.ControllerByName(c.Target); err == nil {
+		if c.Target == currentControllerName {
+			newName = currentName
 			return nil
 		} else {
-			return errors.Errorf("cannot switch when JUJU_MODEL is overriding the model (set to %q)", jujuEnv)
+			newName, err = c.name(c.Target)
+			if err != nil {
+				return errors.Trace(err)
+			}
+			return errors.Trace(c.WriteCurrentController(c.Target))
 		}
-	}
-
-	current, isController, err := modelcmd.CurrentConnectionName()
-	if err != nil {
+	} else if !errors.IsNotFound(err) {
 		return errors.Trace(err)
 	}
-	if current != "" && isController {
-		current += controllerSuffix
+
+	// The target is not a controller, so check for a model with
+	// the given name. The name can be qualified with the controller
+	// name (<controller>:<model>), or unqualified; in the latter
+	// case, the model must exist in the current controller.
+	var controllerName, modelName string
+	if i := strings.IndexRune(c.Target, ':'); i > 0 {
+		controllerName, modelName = c.Target[:i], c.Target[i+1:]
+		newName = c.Target
+	} else {
+		if currentControllerName == "" {
+			return unknownSwitchTargetError(c.Target)
+		}
+		controllerName = currentControllerName
+		modelName = c.Target
+		newName = fmt.Sprintf("%s:%s", controllerName, modelName)
 	}
 
-	// Handle the different operation modes.
-	switch {
-	case c.ModelName == "" && current == "":
-		// Nothing specified and nothing to switch to.
-		return errors.New("no currently specified model")
-	case c.ModelName == "":
-		// Simply print the current environment.
-		fmt.Fprintf(ctx.Stdout, "%s\n", current)
-		return nil
-	default:
-		// Switch the environment.
-		if !names.Contains(c.ModelName) {
-			return errors.Errorf("%q is not a name of an existing defined model or controller", c.ModelName)
+	err = c.Store.SetCurrentModel(controllerName, modelName)
+	if errors.IsNotFound(err) {
+		// The model isn't known locally, so we must query the controller.
+		if err := c.RefreshModels(c.Store, controllerName); err != nil {
+			return errors.Annotate(err, "refreshing models cache")
 		}
-		// If the name is not in the environment set, but is in the controller
-		// set, then write the name into the current controller file.
-		logger.Debugf("controllers: %v", configControllers)
-		logger.Debugf("models: %v", configEnvirons)
-		newEnv := c.ModelName
-		if configControllers.Contains(newEnv) && !configEnvirons.Contains(newEnv) {
-			return modelcmd.SetCurrentController(ctx, newEnv)
+		err := c.Store.SetCurrentModel(controllerName, modelName)
+		if errors.IsNotFound(err) {
+			return unknownSwitchTargetError(c.Target)
+		} else if err != nil {
+			return errors.Trace(err)
 		}
-		return modelcmd.SetCurrentModel(ctx, newEnv)
+	} else if err != nil {
+		return errors.Trace(err)
 	}
+	if currentControllerName != controllerName {
+		if err := c.WriteCurrentController(controllerName); err != nil {
+			return errors.Trace(err)
+		}
+	}
+	return nil
+}
+
+func unknownSwitchTargetError(name string) error {
+	return errors.Errorf("%q is not the name of a model or controller", name)
+}
+
+func logSwitch(ctx *cmd.Context, oldName string, newName *string) {
+	if *newName == oldName {
+		ctx.Infof("%s (no change)", oldName)
+	} else {
+		ctx.Infof("%s -> %s", oldName, *newName)
+	}
+}
+
+// name returns the name of the current model for the specified controller
+// if one is set, otherwise the controller name with an indicator that it
+// is the name of a controller and not a model.
+func (c *switchCommand) name(controllerName string) (string, error) {
+	if controllerName == "" {
+		return "", nil
+	}
+	modelName, err := c.Store.CurrentModel(controllerName)
+	if err == nil {
+		return fmt.Sprintf("%s:%s", controllerName, modelName), nil
+	}
+	if errors.IsNotFound(err) {
+		return fmt.Sprintf("%s (controller)", controllerName), nil
+	}
+	return "", errors.Trace(err)
 }

--- a/cmd/juju/controller/createmodel.go
+++ b/cmd/juju/controller/createmodel.go
@@ -18,6 +18,7 @@ import (
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/configstore"
+	"github.com/juju/juju/jujuclient"
 )
 
 // NewCreateModelCommand returns a command to create an model.
@@ -189,8 +190,17 @@ func (c *createModelCommand) Run(ctx *cmd.Context) (return_err error) {
 		if err := info.Write(); err != nil {
 			return errors.Trace(err)
 		}
+		store := c.ClientStore()
+		controllerName := c.ControllerName()
+		if err := store.UpdateModel(controllerName, c.Name, jujuclient.ModelDetails{
+			env.UUID,
+		}); err != nil {
+			return errors.Trace(err)
+		}
+		if err := store.SetCurrentModel(controllerName, c.Name); err != nil {
+			return errors.Trace(err)
+		}
 		ctx.Infof("created model %q", c.Name)
-		return modelcmd.SetCurrentModel(ctx, c.Name)
 	} else {
 		ctx.Infof("created model %q for %q", c.Name, c.Owner)
 	}

--- a/cmd/juju/controller/createmodel_test.go
+++ b/cmd/juju/controller/createmodel_test.go
@@ -33,7 +33,13 @@ var _ = gc.Suite(&createSuite{})
 
 func (s *createSuite) SetUpTest(c *gc.C) {
 	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
-	s.fake = &fakeCreateClient{}
+	s.fake = &fakeCreateClient{
+		env: params.Model{
+			Name:     "test",
+			UUID:     "fake-model-uuid",
+			OwnerTag: "ignored-for-now",
+		},
+	}
 	s.parser = nil
 	store := configstore.Default
 	s.AddCleanup(func(*gc.C) {
@@ -268,11 +274,6 @@ func (s *createSuite) TestCreateErrorRemoveConfigstoreInfo(c *gc.C) {
 }
 
 func (s *createSuite) TestCreateStoresValues(c *gc.C) {
-	s.fake.env = params.Model{
-		Name:     "test",
-		UUID:     "fake-model-uuid",
-		OwnerTag: "ignored-for-now",
-	}
 	_, err := s.run(c, "test")
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -290,11 +291,6 @@ func (s *createSuite) TestCreateStoresValues(c *gc.C) {
 }
 
 func (s *createSuite) TestNoEnvCacheOtherUser(c *gc.C) {
-	s.fake.env = params.Model{
-		Name:     "test",
-		UUID:     "fake-model-uuid",
-		OwnerTag: "ignored-for-now",
-	}
 	_, err := s.run(c, "test", "--owner", "zeus")
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -325,9 +321,8 @@ func (*fakeCreateClient) ConfigSkeleton(provider, region string) (params.ModelCo
 	}, nil
 }
 func (f *fakeCreateClient) CreateModel(owner string, account, config map[string]interface{}) (params.Model, error) {
-	var env params.Model
 	if f.err != nil {
-		return env, f.err
+		return params.Model{}, f.err
 	}
 	f.owner = owner
 	f.account = account

--- a/cmd/juju/controller/register.go
+++ b/cmd/juju/controller/register.go
@@ -170,7 +170,7 @@ func (c *registerCommand) Run(ctx *cmd.Context) error {
 	if err := apiConn.Close(); err != nil {
 		return errors.Trace(err)
 	}
-	if err := modelcmd.SetCurrentController(ctx, registrationParams.controllerName); err != nil {
+	if err := modelcmd.WriteCurrentController(registrationParams.controllerName); err != nil {
 		return errors.Trace(err)
 	}
 

--- a/cmd/juju/user/user_test.go
+++ b/cmd/juju/user/user_test.go
@@ -4,12 +4,10 @@
 package user_test
 
 import (
-	"io/ioutil"
 	"os"
 
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-	goyaml "gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/cmd/juju/user"
 	"github.com/juju/juju/cmd/modelcmd"
@@ -50,17 +48,4 @@ func (s *BaseSuite) SetUpTest(c *gc.C) {
 	})
 	err = modelcmd.WriteCurrentController("testing")
 	c.Assert(err, jc.ErrorIsNil)
-}
-
-func (s *BaseSuite) assertServerFileMatches(c *gc.C, serverfile, username, password string) {
-	yaml, err := ioutil.ReadFile(serverfile)
-	c.Assert(err, jc.ErrorIsNil)
-	var content modelcmd.ServerFile
-	err = goyaml.Unmarshal(yaml, &content)
-	c.Assert(err, jc.ErrorIsNil)
-
-	c.Assert(content.Username, gc.Equals, username)
-	c.Assert(content.Password, gc.Equals, password)
-	c.Assert(content.CACert, gc.Equals, testing.CACert)
-	c.Assert(content.Addresses, jc.DeepEquals, []string{"127.0.0.1:12345"})
 }

--- a/cmd/modelcmd/controller_test.go
+++ b/cmd/modelcmd/controller_test.go
@@ -31,14 +31,6 @@ func (s *ControllerCommandSuite) TestControllerCommandInitSystemFile(c *gc.C) {
 	testEnsureControllerName(c, "fubar")
 }
 
-func (s *ControllerCommandSuite) TestControllerCommandInitEnvFile(c *gc.C) {
-	// The current-model file has no bearing.
-	err := modelcmd.WriteCurrentModel("fubar")
-	c.Assert(err, jc.ErrorIsNil)
-	_, err = initTestControllerCommand(c)
-	c.Assert(err, gc.ErrorMatches, "no controller specified")
-}
-
 func (s *ControllerCommandSuite) TestControllerCommandInitExplicit(c *gc.C) {
 	// Take controller name from command line arg, and it trumps the current-
 	// controller file.

--- a/cmd/modelcmd/export_test.go
+++ b/cmd/modelcmd/export_test.go
@@ -4,7 +4,6 @@
 package modelcmd
 
 var (
-	GetCurrentModelFilePath      = getCurrentModelFilePath
 	GetCurrentControllerFilePath = getCurrentControllerFilePath
 	GetConfigStore               = &getConfigStore
 	EndpointRefresher            = &endpointRefresher

--- a/cmd/modelcmd/files.go
+++ b/cmd/modelcmd/files.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/utils/fslock"
 
@@ -18,12 +17,9 @@ import (
 )
 
 const (
-	CurrentModelFilename      = "current-model"
 	CurrentControllerFilename = "current-controller"
 
 	lockName = "current.lock"
-
-	controllerSuffix = " (controller)"
 )
 
 var (
@@ -32,46 +28,13 @@ var (
 	lockTimeout = 5 * time.Second
 )
 
-// ServerFile describes the information that is needed for a user
-// to connect to an api server.
-type ServerFile struct {
-	Addresses []string `yaml:"addresses"`
-	CACert    string   `yaml:"ca-cert,omitempty"`
-	Username  string   `yaml:"username"`
-	Password  string   `yaml:"password"`
-}
-
 // NOTE: synchronisation across functions in this file.
 //
 // Each of the read and write functions use a fslock to synchronise calls
 // across both the current executable and across different executables.
 
-func getCurrentModelFilePath() string {
-	return filepath.Join(osenv.JujuXDGDataHome(), CurrentModelFilename)
-}
-
 func getCurrentControllerFilePath() string {
 	return filepath.Join(osenv.JujuXDGDataHome(), CurrentControllerFilename)
-}
-
-// ReadCurrentModel reads the file $JUJU_DATA/current-model and
-// return the value stored there.  If the file doesn't exist an empty string
-// is returned and no error.
-func ReadCurrentModel() (string, error) {
-	lock, err := acquireEnvironmentLock("read current-model")
-	if err != nil {
-		return "", errors.Trace(err)
-	}
-	defer lock.Unlock()
-
-	current, err := ioutil.ReadFile(getCurrentModelFilePath())
-	if err != nil {
-		if os.IsNotExist(err) {
-			return "", nil
-		}
-		return "", errors.Trace(err)
-	}
-	return strings.TrimSpace(string(current)), nil
 }
 
 // ReadCurrentController reads the file $JUJU_DATA/current-controller and
@@ -94,30 +57,6 @@ func ReadCurrentController() (string, error) {
 	return strings.TrimSpace(string(current)), nil
 }
 
-// WriteCurrentModel writes the envName to the file
-// $JUJU_DATA/current-model file.
-func WriteCurrentModel(envName string) error {
-	lock, err := acquireEnvironmentLock("write current-model")
-	if err != nil {
-		return errors.Trace(err)
-	}
-	defer lock.Unlock()
-
-	path := getCurrentModelFilePath()
-	err = ioutil.WriteFile(path, []byte(envName+"\n"), 0644)
-	if err != nil {
-		return errors.Errorf("unable to write to the model file: %q, %s", path, err)
-	}
-	// If there is a current controller file, remove it.
-	if err := os.Remove(getCurrentControllerFilePath()); err != nil && !os.IsNotExist(err) {
-		logger.Debugf("removing the current model file due to %s", err)
-		// Best attempt to remove the file we just wrote.
-		os.Remove(path)
-		return err
-	}
-	return nil
-}
-
 // WriteCurrentController writes the controllerName to the file
 // $JUJU_DATA/current-controller file.
 func WriteCurrentController(controllerName string) error {
@@ -131,13 +70,6 @@ func WriteCurrentController(controllerName string) error {
 	err = ioutil.WriteFile(path, []byte(controllerName+"\n"), 0644)
 	if err != nil {
 		return errors.Errorf("unable to write to the controller file: %q, %s", path, err)
-	}
-	// If there is a current environment file, remove it.
-	if err := os.Remove(getCurrentModelFilePath()); err != nil && !os.IsNotExist(err) {
-		logger.Debugf("removing the current controller file due to %s", err)
-		// Best attempt to remove the file we just wrote.
-		os.Remove(path)
-		return err
 	}
 	return nil
 }
@@ -155,70 +87,4 @@ func acquireEnvironmentLock(operation string) (*fslock.Lock, error) {
 		return nil, errors.Trace(err)
 	}
 	return lock, nil
-}
-
-// CurrentConnectionName looks at both the current environment file
-// and the current controller file to determine which is active.
-// The name of the current model or controller is returned along with
-// a boolean to express whether the name refers to a controller or environment.
-func CurrentConnectionName() (name string, is_controller bool, err error) {
-	currentEnv, err := ReadCurrentModel()
-	if err != nil {
-		return "", false, errors.Trace(err)
-	} else if currentEnv != "" {
-		return currentEnv, false, nil
-	}
-
-	currentController, err := ReadCurrentController()
-	if err != nil {
-		return "", false, errors.Trace(err)
-	} else if currentController != "" {
-		return currentController, true, nil
-	}
-
-	return "", false, nil
-}
-
-func currentName() (string, error) {
-	name, isController, err := CurrentConnectionName()
-	if err != nil {
-		return "", errors.Trace(err)
-	}
-	if isController {
-		name = name + controllerSuffix
-	}
-	if name != "" {
-		name += " "
-	}
-	return name, nil
-}
-
-// SetCurrentModel writes out the current environment file and writes a
-// standard message to the command context.
-func SetCurrentModel(context *cmd.Context, modelName string) error {
-	current, err := currentName()
-	if err != nil {
-		return errors.Trace(err)
-	}
-	err = WriteCurrentModel(modelName)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	context.Infof("%s-> %s", current, modelName)
-	return nil
-}
-
-// SetCurrentController writes out the current controller file and writes a standard
-// message to the command context.
-func SetCurrentController(context *cmd.Context, controllerName string) error {
-	current, err := currentName()
-	if err != nil {
-		return errors.Trace(err)
-	}
-	err = WriteCurrentController(controllerName)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	context.Infof("%s-> %s%s", current, controllerName, controllerSuffix)
-	return nil
 }

--- a/cmd/modelcmd/files_test.go
+++ b/cmd/modelcmd/files_test.go
@@ -20,44 +20,20 @@ type filesSuite struct {
 
 var _ = gc.Suite(&filesSuite{})
 
-func (s *filesSuite) assertCurrentModel(c *gc.C, environmentName string) {
-	current, err := modelcmd.ReadCurrentModel()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(current, gc.Equals, environmentName)
-}
-
 func (s *filesSuite) assertCurrentController(c *gc.C, controllerName string) {
 	current, err := modelcmd.ReadCurrentController()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(current, gc.Equals, controllerName)
 }
 
-func (s *filesSuite) TestReadCurrentModelUnset(c *gc.C) {
-	s.assertCurrentModel(c, "")
-}
-
 func (s *filesSuite) TestReadCurrentControllerUnset(c *gc.C) {
 	s.assertCurrentController(c, "")
-}
-
-func (s *filesSuite) TestReadCurrentModelSet(c *gc.C) {
-	err := modelcmd.WriteCurrentModel("fubar")
-	c.Assert(err, jc.ErrorIsNil)
-	s.assertCurrentModel(c, "fubar")
 }
 
 func (s *filesSuite) TestReadCurrentControllerSet(c *gc.C) {
 	err := modelcmd.WriteCurrentController("fubar")
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertCurrentController(c, "fubar")
-}
-
-func (s *filesSuite) TestWriteEnvironmentAddsNewline(c *gc.C) {
-	err := modelcmd.WriteCurrentModel("fubar")
-	c.Assert(err, jc.ErrorIsNil)
-	current, err := ioutil.ReadFile(modelcmd.GetCurrentModelFilePath())
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(string(current), gc.Equals, "fubar\n")
 }
 
 func (s *filesSuite) TestWriteControllerAddsNewline(c *gc.C) {
@@ -68,29 +44,6 @@ func (s *filesSuite) TestWriteControllerAddsNewline(c *gc.C) {
 	c.Assert(string(current), gc.Equals, "fubar\n")
 }
 
-func (s *filesSuite) TestWriteEnvironmentRemovesControllerFile(c *gc.C) {
-	err := modelcmd.WriteCurrentController("baz")
-	c.Assert(err, jc.ErrorIsNil)
-	err = modelcmd.WriteCurrentModel("fubar")
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(modelcmd.GetCurrentControllerFilePath(), jc.DoesNotExist)
-}
-
-func (s *filesSuite) TestWriteControllerRemovesEnvironmentFile(c *gc.C) {
-	err := modelcmd.WriteCurrentModel("fubar")
-	c.Assert(err, jc.ErrorIsNil)
-	err = modelcmd.WriteCurrentController("baz")
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(modelcmd.GetCurrentModelFilePath(), jc.DoesNotExist)
-}
-
-func (*filesSuite) TestErrorWritingCurrentModel(c *gc.C) {
-	// Can't write a file over a directory.
-	os.MkdirAll(modelcmd.GetCurrentModelFilePath(), 0777)
-	err := modelcmd.WriteCurrentModel("fubar")
-	c.Assert(err, gc.ErrorMatches, "unable to write to the model file: .*")
-}
-
 func (*filesSuite) TestErrorWritingCurrentController(c *gc.C) {
 	// Can't write a file over a directory.
 	os.MkdirAll(modelcmd.GetCurrentControllerFilePath(), 0777)
@@ -98,83 +51,10 @@ func (*filesSuite) TestErrorWritingCurrentController(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "unable to write to the controller file: .*")
 }
 
-func (*filesSuite) TestCurrentCommenctionNameMissing(c *gc.C) {
-	name, isController, err := modelcmd.CurrentConnectionName()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(isController, jc.IsFalse)
-	c.Assert(name, gc.Equals, "")
-}
-
-func (*filesSuite) TestCurrentCommenctionNameEnvironment(c *gc.C) {
-	err := modelcmd.WriteCurrentModel("fubar")
-	c.Assert(err, jc.ErrorIsNil)
-	name, isController, err := modelcmd.CurrentConnectionName()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(isController, jc.IsFalse)
-	c.Assert(name, gc.Equals, "fubar")
-}
-
-func (*filesSuite) TestCurrentCommenctionNameController(c *gc.C) {
-	err := modelcmd.WriteCurrentController("baz")
-	c.Assert(err, jc.ErrorIsNil)
-	name, isController, err := modelcmd.CurrentConnectionName()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(isController, jc.IsTrue)
-	c.Assert(name, gc.Equals, "baz")
-}
-
-func (s *filesSuite) TestSetCurrentModel(c *gc.C) {
-	ctx := testing.Context(c)
-	err := modelcmd.SetCurrentModel(ctx, "new-model")
-	c.Assert(err, jc.ErrorIsNil)
-	s.assertCurrentModel(c, "new-model")
-	c.Assert(testing.Stderr(ctx), gc.Equals, "-> new-model\n")
-}
-
-func (s *filesSuite) TestSetCurrentModelExistingEnv(c *gc.C) {
-	err := modelcmd.WriteCurrentModel("fubar")
-	c.Assert(err, jc.ErrorIsNil)
-	ctx := testing.Context(c)
-	err = modelcmd.SetCurrentModel(ctx, "new-model")
-	c.Assert(err, jc.ErrorIsNil)
-	s.assertCurrentModel(c, "new-model")
-	c.Assert(testing.Stderr(ctx), gc.Equals, "fubar -> new-model\n")
-}
-
-func (s *filesSuite) TestSetCurrentModelExistingController(c *gc.C) {
+func (s *filesSuite) TestWriteCurrentControllerExistingController(c *gc.C) {
 	err := modelcmd.WriteCurrentController("fubar")
 	c.Assert(err, jc.ErrorIsNil)
-	ctx := testing.Context(c)
-	err = modelcmd.SetCurrentModel(ctx, "new-model")
-	c.Assert(err, jc.ErrorIsNil)
-	s.assertCurrentModel(c, "new-model")
-	c.Assert(testing.Stderr(ctx), gc.Equals, "fubar (controller) -> new-model\n")
-}
-
-func (s *filesSuite) TestSetCurrentController(c *gc.C) {
-	ctx := testing.Context(c)
-	err := modelcmd.SetCurrentController(ctx, "new-sys")
+	err = modelcmd.WriteCurrentController("new-sys")
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertCurrentController(c, "new-sys")
-	c.Assert(testing.Stderr(ctx), gc.Equals, "-> new-sys (controller)\n")
-}
-
-func (s *filesSuite) TestSetCurrentControllerExistingEnv(c *gc.C) {
-	err := modelcmd.WriteCurrentModel("fubar")
-	c.Assert(err, jc.ErrorIsNil)
-	ctx := testing.Context(c)
-	err = modelcmd.SetCurrentController(ctx, "new-sys")
-	c.Assert(err, jc.ErrorIsNil)
-	s.assertCurrentController(c, "new-sys")
-	c.Assert(testing.Stderr(ctx), gc.Equals, "fubar -> new-sys (controller)\n")
-}
-
-func (s *filesSuite) TestSetCurrentControllerExistingController(c *gc.C) {
-	err := modelcmd.WriteCurrentController("fubar")
-	c.Assert(err, jc.ErrorIsNil)
-	ctx := testing.Context(c)
-	err = modelcmd.SetCurrentController(ctx, "new-sys")
-	c.Assert(err, jc.ErrorIsNil)
-	s.assertCurrentController(c, "new-sys")
-	c.Assert(testing.Stderr(ctx), gc.Equals, "fubar (controller) -> new-sys (controller)\n")
 }

--- a/cmd/modelcmd/modelcommand.go
+++ b/cmd/modelcmd/modelcommand.go
@@ -41,13 +41,6 @@ func GetCurrentModel(store jujuclient.ClientStore) (string, error) {
 		return model, nil
 	}
 
-	// TODO(axw) remove this when all of the tests are updated.
-	if currentModel, err := ReadCurrentModel(); err != nil {
-		return "", errors.Trace(err)
-	} else if currentModel != "" {
-		return currentModel, nil
-	}
-
 	currentController, err := ReadCurrentController()
 	if err != nil {
 		return "", errors.Trace(err)
@@ -58,7 +51,7 @@ func GetCurrentModel(store jujuclient.ClientStore) (string, error) {
 
 	currentModel, err := store.CurrentModel(currentController)
 	if errors.IsNotFound(err) {
-		return "", errors.Errorf("not operating on an model, using controller %q", currentController)
+		return "", nil
 	} else if err != nil {
 		return "", errors.Trace(err)
 	}

--- a/cmd/modelcmd/modelcommand.go
+++ b/cmd/modelcmd/modelcommand.go
@@ -4,6 +4,7 @@
 package modelcmd
 
 import (
+	"fmt"
 	"io"
 	"os"
 	"strings"
@@ -125,15 +126,15 @@ func (c *ModelCommandBase) ClientStore() jujuclient.ClientStore {
 
 // SetModelName implements the ModelCommand interface.
 func (c *ModelCommandBase) SetModelName(modelName string) error {
-	if i := strings.IndexRune(modelName, ':'); i > 0 {
-		c.controllerName, c.modelName = modelName[:i], modelName[i+1:]
-		return nil
+	controllerName, modelName := SplitModelName(modelName)
+	if controllerName == "" {
+		currentController, err := ReadCurrentController()
+		if err != nil {
+			return errors.Trace(err)
+		}
+		controllerName = currentController
 	}
-	currentController, err := ReadCurrentController()
-	if err != nil {
-		return errors.Trace(err)
-	}
-	c.controllerName, c.modelName = currentController, modelName
+	c.controllerName, c.modelName = controllerName, modelName
 	return nil
 }
 
@@ -407,4 +408,21 @@ func BootstrapContextNoVerify(cmdContext *cmd.Context) environs.BootstrapContext
 type ModelGetter interface {
 	ModelGet() (map[string]interface{}, error)
 	Close() error
+}
+
+// SplitModelName splits a model name into its controller
+// and model parts. If the model is unqualified, then the
+// returned controller string will be empty, and the returned
+// model string will be identical to the input.
+func SplitModelName(name string) (controller, model string) {
+	if i := strings.IndexRune(name, ':'); i >= 0 {
+		return name[:i], name[i+1:]
+	}
+	return "", name
+}
+
+// JoinModelName joins a controller and model name into a
+// qualified model name.
+func JoinModelName(controller, model string) string {
+	return fmt.Sprintf("%s:%s", controller, model)
 }

--- a/cmd/modelcmd/modelcommand_test.go
+++ b/cmd/modelcmd/modelcommand_test.go
@@ -126,6 +126,28 @@ func (s *ModelCommandSuite) TestWrapWithoutFlags(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, msg)
 }
 
+func (*ModelCommandSuite) TestSplitModelName(c *gc.C) {
+	assert := func(in, controller, model string) {
+		outController, outModel := modelcmd.SplitModelName(in)
+		c.Assert(outController, gc.Equals, controller)
+		c.Assert(outModel, gc.Equals, model)
+	}
+	assert("model", "", "model")
+	assert("ctrl:model", "ctrl", "model")
+	assert("ctrl:", "ctrl", "")
+	assert(":model", "", "model")
+}
+
+func (*ModelCommandSuite) TestJoinModelName(c *gc.C) {
+	assert := func(controller, model, expect string) {
+		out := modelcmd.JoinModelName(controller, model)
+		c.Assert(out, gc.Equals, expect)
+	}
+	assert("ctrl", "", "ctrl:")
+	assert("", "model", ":model")
+	assert("ctrl", "model", "ctrl:model")
+}
+
 func (s *ModelCommandSuite) testEnsureModelName(c *gc.C, expect string, args ...string) {
 	cmd, err := initTestCommand(c, s.store, args...)
 	c.Assert(err, jc.ErrorIsNil)

--- a/cmd/modelcmd/modelcommand_test.go
+++ b/cmd/modelcmd/modelcommand_test.go
@@ -6,9 +6,7 @@ package modelcmd_test
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
-	"path/filepath"
 
 	"github.com/juju/cmd"
 	"github.com/juju/cmd/cmdtesting"
@@ -16,7 +14,6 @@ import (
 	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-	goyaml "gopkg.in/yaml.v1"
 
 	apitesting "github.com/juju/juju/api/testing"
 	"github.com/juju/juju/cmd/modelcmd"
@@ -46,12 +43,25 @@ func (s *ModelCommandSuite) TestGetCurrentModelNothingSet(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-func (s *ModelCommandSuite) TestGetCurrentModelCurrentModelSet(c *gc.C) {
-	err := modelcmd.WriteCurrentModel("fubar")
+func (s *ModelCommandSuite) TestGetCurrentModelCurrentControllerNoCurrentModel(c *gc.C) {
+	err := modelcmd.WriteCurrentController("fubar")
 	c.Assert(err, jc.ErrorIsNil)
 	env, err := modelcmd.GetCurrentModel(s.store)
-	c.Assert(env, gc.Equals, "fubar")
+	c.Assert(env, gc.Equals, "")
 	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *ModelCommandSuite) TestGetCurrentModelCurrentControllerCurrentModel(c *gc.C) {
+	err := modelcmd.WriteCurrentController("fubar")
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.store.UpdateModel("fubar", "mymodel", jujuclient.ModelDetails{"uuid"})
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.store.SetCurrentModel("fubar", "mymodel")
+	c.Assert(err, jc.ErrorIsNil)
+
+	env, err := modelcmd.GetCurrentModel(s.store)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(env, gc.Equals, "mymodel")
 }
 
 func (s *ModelCommandSuite) TestGetCurrentModelJujuEnvSet(c *gc.C) {
@@ -63,36 +73,37 @@ func (s *ModelCommandSuite) TestGetCurrentModelJujuEnvSet(c *gc.C) {
 
 func (s *ModelCommandSuite) TestGetCurrentModelBothSet(c *gc.C) {
 	os.Setenv(osenv.JujuModelEnvKey, "magic")
-	err := modelcmd.WriteCurrentModel("fubar")
+
+	err := modelcmd.WriteCurrentController("fubar")
 	c.Assert(err, jc.ErrorIsNil)
+	err = s.store.UpdateModel("fubar", "mymodel", jujuclient.ModelDetails{"uuid"})
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.store.SetCurrentModel("fubar", "mymodel")
+	c.Assert(err, jc.ErrorIsNil)
+
 	env, err := modelcmd.GetCurrentModel(s.store)
-	c.Assert(env, gc.Equals, "magic")
 	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(env, gc.Equals, "magic")
 }
 
 func (s *ModelCommandSuite) TestModelCommandInitExplicit(c *gc.C) {
 	// Take model name from command line arg.
-	testEnsureModelName(c, "explicit", "-m", "explicit")
+	s.testEnsureModelName(c, "explicit", "-m", "explicit")
 }
 
 func (s *ModelCommandSuite) TestModelCommandInitExplicitLongForm(c *gc.C) {
 	// Take model name from command line arg.
-	testEnsureModelName(c, "explicit", "--model", "explicit")
+	s.testEnsureModelName(c, "explicit", "--model", "explicit")
 }
 
 func (s *ModelCommandSuite) TestModelCommandInitEnvFile(c *gc.C) {
-	// If there is a current-model file, use that.
-	err := modelcmd.WriteCurrentModel("fubar")
-	c.Assert(err, jc.ErrorIsNil)
-	testEnsureModelName(c, "fubar")
-}
-
-func (s *ModelCommandSuite) TestModelCommandInitControllerFile(c *gc.C) {
-	// If there is a current-controller file, error raised.
 	err := modelcmd.WriteCurrentController("fubar")
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = initTestCommand(c)
-	c.Assert(err, gc.ErrorMatches, `not operating on an model, using controller "fubar"`)
+	err = s.store.UpdateModel("fubar", "mymodel", jujuclient.ModelDetails{"uuid"})
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.store.SetCurrentModel("fubar", "mymodel")
+	c.Assert(err, jc.ErrorIsNil)
+	s.testEnsureModelName(c, "mymodel")
 }
 
 func (s *ModelCommandSuite) TestBootstrapContext(c *gc.C) {
@@ -115,6 +126,12 @@ func (s *ModelCommandSuite) TestWrapWithoutFlags(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, msg)
 }
 
+func (s *ModelCommandSuite) testEnsureModelName(c *gc.C, expect string, args ...string) {
+	cmd, err := initTestCommand(c, s.store, args...)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cmd.ConnectionName(), gc.Equals, expect)
+}
+
 type testCommand struct {
 	modelcmd.ModelCommandBase
 }
@@ -127,16 +144,11 @@ func (c *testCommand) Run(ctx *cmd.Context) error {
 	panic("should not be called")
 }
 
-func initTestCommand(c *gc.C, args ...string) (*testCommand, error) {
+func initTestCommand(c *gc.C, store jujuclient.ClientStore, args ...string) (*testCommand, error) {
 	cmd := new(testCommand)
+	cmd.SetClientStore(store)
 	wrapped := modelcmd.Wrap(cmd)
 	return cmd, cmdtesting.InitCommand(wrapped, args)
-}
-
-func testEnsureModelName(c *gc.C, expect string, args ...string) {
-	cmd, err := initTestCommand(c, args...)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cmd.ConnectionName(), gc.Equals, expect)
 }
 
 type ConnectionEndpointSuite struct {
@@ -170,7 +182,7 @@ func (s *ConnectionEndpointSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *ConnectionEndpointSuite) TestAPIEndpointInStoreCached(c *gc.C) {
-	cmd, err := initTestCommand(c, "-m", "model-name")
+	cmd, err := initTestCommand(c, nil, "-m", "model-name")
 	c.Assert(err, jc.ErrorIsNil)
 	endpoint, err := cmd.ConnectionEndpoint(false)
 	c.Assert(err, jc.ErrorIsNil)
@@ -178,7 +190,7 @@ func (s *ConnectionEndpointSuite) TestAPIEndpointInStoreCached(c *gc.C) {
 }
 
 func (s *ConnectionEndpointSuite) TestAPIEndpointForEnvSuchName(c *gc.C) {
-	cmd, err := initTestCommand(c, "-m", "no-such-model")
+	cmd, err := initTestCommand(c, nil, "-m", "no-such-model")
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = cmd.ConnectionEndpoint(false)
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
@@ -200,7 +212,7 @@ func (s *ConnectionEndpointSuite) TestAPIEndpointRefresh(c *gc.C) {
 		return new(closer), nil
 	})
 
-	cmd, err := initTestCommand(c, "-m", "model-name")
+	cmd, err := initTestCommand(c, nil, "-m", "model-name")
 	c.Assert(err, jc.ErrorIsNil)
 	endpoint, err := cmd.ConnectionEndpoint(true)
 	c.Assert(err, jc.ErrorIsNil)
@@ -217,8 +229,7 @@ var _ = gc.Suite(&macaroonLoginSuite{})
 
 type macaroonLoginSuite struct {
 	apitesting.MacaroonSuite
-	serverFilePath string
-	envName        string
+	envName string
 }
 
 const testUser = "testuser@somewhere"
@@ -232,16 +243,6 @@ func (s *macaroonLoginSuite) SetUpTest(c *gc.C) {
 	s.MacaroonSuite.AddModelUser(c, testUser)
 
 	apiInfo := s.APIInfo(c)
-	var serverDetails modelcmd.ServerFile
-	serverDetails.Addresses = apiInfo.Addrs
-	serverDetails.CACert = apiInfo.CACert
-	content, err := goyaml.Marshal(serverDetails)
-	c.Assert(err, jc.ErrorIsNil)
-
-	s.serverFilePath = filepath.Join(c.MkDir(), "server.yaml")
-
-	err = ioutil.WriteFile(s.serverFilePath, content, 0644)
-	c.Assert(err, jc.ErrorIsNil)
 
 	store, err := configstore.Default()
 	c.Assert(err, jc.ErrorIsNil)

--- a/featuretests/cmd_juju_controller_test.go
+++ b/featuretests/cmd_juju_controller_test.go
@@ -82,10 +82,7 @@ func (s *cmdControllerSuite) TestCreateModel(c *gc.C) {
 	// a config value for 'controller'.
 	context := s.run(c, "create-model", "new-model", "authorized-keys=fake-key", "controller=false")
 	c.Check(testing.Stdout(context), gc.Equals, "")
-	c.Check(testing.Stderr(context), gc.Equals, `
-created model "new-model"
-dummymodel (controller) -> new-model
-`[1:])
+	c.Check(testing.Stderr(context), gc.Equals, "created model \"new-model\"\n")
 
 	// Make sure that the saved server details are sufficient to connect
 	// to the api server.

--- a/featuretests/cmd_juju_register_test.go
+++ b/featuretests/cmd_juju_register_test.go
@@ -63,7 +63,6 @@ Please send this command to bob:
 Please set a name for this controller: 
 Enter password: 
 Confirm password: 
-dummymodel (controller) -> bob-controller (controller)
 
 Welcome, bob. You are now logged into "bob-controller".
 `[1:])


### PR DESCRIPTION
The switch command has been updated to use the new
jujuclient infrastructure, and to automatically
refresh the local model cache if the requested
model is not known locally.

This means you can do (once add-user is updated):

    (as admin) juju add-user bob --share admin
    (as bob)   juju register <registration-string>
               juju switch admin

As part of this work, the cleanup of the old ways
has continued. Notably, we have removed all code
related to the "current-model" file. The current
model is now stored only in the jujuclient store,
and the current controller is recorded in the
current-controller file. The primary difference
is that previously the current-controller file
would be removed when switching to a model, and
now we will not.

Note that the switch command's ability to show
the current controller/model, and list the cache,
have been removed. Listing is now handled by the
list-controllers and list-models commands. We
have yet to implement a replacement for showing
the current, but it is likely that we will add
current-model and current-controller commands.

(Review request: http://reviews.vapour.ws/r/3872/)