### PR TITLE
cmd/juju/controller: show-controller prints active

### DIFF
--- a/cmd/juju/controller/package_test.go
+++ b/cmd/juju/controller/package_test.go
@@ -19,18 +19,17 @@ func TestPackage(t *testing.T) {
 }
 
 type baseControllerSuite struct {
+	coretesting.FakeJujuXDGDataHomeSuite
 	store                                     jujuclient.ClientStore
 	controllersYaml, modelsYaml, accountsYaml string
 	expectedOutput, expectedErr               string
 }
 
 func (s *baseControllerSuite) SetUpTest(c *gc.C) {
+	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
 	s.controllersYaml = testControllersYaml
 	s.modelsYaml = testModelsYaml
 	s.accountsYaml = testAccountsYaml
-}
-
-func (s *baseControllerSuite) TearDownTest(c *gc.C) {
 	s.store = nil
 }
 

--- a/cmd/juju/controller/showcontroller_test.go
+++ b/cmd/juju/controller/showcontroller_test.go
@@ -13,6 +13,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cmd/juju/controller"
+	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	"github.com/juju/juju/testing"
 )
@@ -175,7 +176,17 @@ func (s *ShowControllerSuite) TestShowControllerReadFromStoreErr(c *gc.C) {
 
 func (s *ShowControllerSuite) TestShowControllerNoArgs(c *gc.C) {
 	s.createTestClientStore(c)
-	s.expectedErr = regexp.QuoteMeta(`must specify controller name(s)`)
+
+	s.expectedOutput = `
+{"local.aws-test":{"details":{"servers":["instance-1-2-4.useast.aws.com"],"uuid":"this-is-the-aws-test-uuid","api-endpoints":["this-is-aws-test-of-many-api-endpoints"],"ca-cert":"this-is-aws-test-ca-cert"},"models":{"admin":{"uuid":"ghi"}},"current-model":"admin"}}
+`[1:]
+	err := modelcmd.WriteCurrentController("local.aws-test")
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertShowController(c, "--format", "json")
+}
+
+func (s *ShowControllerSuite) TestShowControllerNoArgsNoCurrent(c *gc.C) {
+	s.expectedErr = regexp.QuoteMeta(`there is no active controller`)
 	s.assertShowControllerFailed(c)
 }
 


### PR DESCRIPTION
If show-controller is run with no arguments, it will
print out the active controller. This replaces the
no-arguments form of "switch".

(Review request: http://reviews.vapour.ws/r/3875/)