### PR TITLE
Add the --share option to juju add-user

### DIFF
--- a/api/modelmanager/modelmanager.go
+++ b/api/modelmanager/modelmanager.go
@@ -29,6 +29,11 @@ func NewClient(st base.APICallCloser) *Client {
 	return &Client{ClientFacade: frontend, facade: backend}
 }
 
+// Close closes the api connection.
+func (c *Client) Close() error {
+	return c.ClientFacade.Close()
+}
+
 // ConfigSkeleton returns config values to be used as a starting point for the
 // API caller to construct a valid model specific config.  The provider
 // and region params are there for future use, and current behaviour expects

--- a/api/usermanager/client.go
+++ b/api/usermanager/client.go
@@ -32,7 +32,9 @@ func NewClient(st base.APICallCloser) *Client {
 }
 
 // AddUser creates a new local user in the controller, sharing with that user any specified models.
-func (c *Client) AddUser(username, displayName, password string, modelUUIDs ...string) (_ names.UserTag, secretKey []byte, _ error) {
+func (c *Client) AddUser(
+	username, displayName, password string, modelUUIDs ...string,
+) (_ names.UserTag, secretKey []byte, _ error) {
 	if !names.IsValidUser(username) {
 		return names.UserTag{}, nil, fmt.Errorf("invalid user name %q", username)
 	}
@@ -41,7 +43,11 @@ func (c *Client) AddUser(username, displayName, password string, modelUUIDs ...s
 		modelTags[i] = names.NewModelTag(uuid).String()
 	}
 	userArgs := params.AddUsers{
-		Users: []params.AddUser{{Username: username, DisplayName: displayName, Password: password, SharedModelTags: modelTags}},
+		Users: []params.AddUser{{
+			Username:        username,
+			DisplayName:     displayName,
+			Password:        password,
+			SharedModelTags: modelTags}},
 	}
 	var results params.AddUserResults
 	err := c.facade.FacadeCall("AddUser", userArgs, &results)

--- a/api/usermanager/client.go
+++ b/api/usermanager/client.go
@@ -31,13 +31,17 @@ func NewClient(st base.APICallCloser) *Client {
 	return &Client{ClientFacade: frontend, facade: backend}
 }
 
-// AddUser creates a new local user in the juju server.
-func (c *Client) AddUser(username, displayName, password string) (_ names.UserTag, secretKey []byte, _ error) {
+// AddUser creates a new local user in the controller, sharing with that user any specified models.
+func (c *Client) AddUser(username, displayName, password string, modelUUIDs ...string) (_ names.UserTag, secretKey []byte, _ error) {
 	if !names.IsValidUser(username) {
 		return names.UserTag{}, nil, fmt.Errorf("invalid user name %q", username)
 	}
+	modelTags := make([]string, len(modelUUIDs))
+	for i, uuid := range modelUUIDs {
+		modelTags[i] = names.NewModelTag(uuid).String()
+	}
 	userArgs := params.AddUsers{
-		Users: []params.AddUser{{Username: username, DisplayName: displayName, Password: password}},
+		Users: []params.AddUser{{Username: username, DisplayName: displayName, Password: password, SharedModelTags: modelTags}},
 	}
 	var results params.AddUserResults
 	err := c.facade.FacadeCall("AddUser", userArgs, &results)

--- a/api/usermanager/client_test.go
+++ b/api/usermanager/client_test.go
@@ -41,9 +41,7 @@ func (s *usermanagerSuite) TestAddUser(c *gc.C) {
 }
 
 func (s *usermanagerSuite) TestAddUserWithSharedModel(c *gc.C) {
-	sharedModelState := s.Factory.MakeModel(c, &factory.ModelParams{
-		Name: "somesharedmodel",
-	})
+	sharedModelState := s.Factory.MakeModel(c, nil)
 	defer sharedModelState.Close()
 
 	tag, _, err := s.usermanager.AddUser("foobar", "Foo Bar", "password", sharedModelState.ModelUUID())

--- a/api/usermanager/client_test.go
+++ b/api/usermanager/client_test.go
@@ -5,6 +5,7 @@ package usermanager_test
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -37,6 +38,31 @@ func (s *usermanagerSuite) TestAddUser(c *gc.C) {
 	c.Assert(user.Name(), gc.Equals, "foobar")
 	c.Assert(user.DisplayName(), gc.Equals, "Foo Bar")
 	c.Assert(user.PasswordValid("password"), jc.IsTrue)
+}
+
+func (s *usermanagerSuite) TestAddUserWithSharedModel(c *gc.C) {
+	sharedModelState := s.Factory.MakeModel(c, &factory.ModelParams{
+		Name: "somesharedmodel",
+	})
+	defer sharedModelState.Close()
+
+	tag, _, err := s.usermanager.AddUser("foobar", "Foo Bar", "password", sharedModelState.ModelUUID())
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Check model is shared with expected users.
+	sharedModel, err := sharedModelState.Model()
+	c.Assert(err, jc.ErrorIsNil)
+	users, err := sharedModel.Users()
+	c.Assert(err, jc.ErrorIsNil)
+	//c.Assert(users, gc.HasLen, 1)
+	var modelUserTags = make([]names.UserTag, len(users))
+	for i, u := range users {
+		modelUserTags[i] = u.UserTag()
+	}
+	c.Assert(modelUserTags, jc.SameContents, []names.UserTag{
+		tag,
+		names.NewLocalUserTag("admin"),
+	})
 }
 
 func (s *usermanagerSuite) TestAddExistingUser(c *gc.C) {

--- a/api/usermanager/client_test.go
+++ b/api/usermanager/client_test.go
@@ -54,7 +54,7 @@ func (s *usermanagerSuite) TestAddUserWithSharedModel(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	users, err := sharedModel.Users()
 	c.Assert(err, jc.ErrorIsNil)
-	//c.Assert(users, gc.HasLen, 1)
+	c.Assert(users, gc.HasLen, 2)
 	var modelUserTags = make([]names.UserTag, len(users))
 	for i, u := range users {
 		modelUserTags[i] = u.UserTag()

--- a/apiserver/client/client.go
+++ b/apiserver/client/client.go
@@ -16,6 +16,7 @@ import (
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/apiserver/service"
+	"github.com/juju/juju/apiserver/usermanager"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/manual"
@@ -374,23 +375,8 @@ func (c *Client) ShareModel(args params.ModifyModelUsers) (result params.ErrorRe
 			result.Results[i].Error = common.ServerError(errors.Annotate(err, "could not share model"))
 			continue
 		}
-		switch arg.Action {
-		case params.AddModelUser:
-			_, err := c.api.stateAccessor.AddModelUser(
-				state.ModelUserSpec{User: user, CreatedBy: createdBy})
-			if err != nil {
-				err = errors.Annotate(err, "could not share model")
-				result.Results[i].Error = common.ServerError(err)
-			}
-		case params.RemoveModelUser:
-			err := c.api.stateAccessor.RemoveModelUser(user)
-			if err != nil {
-				err = errors.Annotate(err, "could not unshare model")
-				result.Results[i].Error = common.ServerError(err)
-			}
-		default:
-			result.Results[i].Error = common.ServerError(errors.Errorf("unknown action %q", arg.Action))
-		}
+		result.Results[i].Error = common.ServerError(
+			usermanager.ShareModelAction(c.api.stateAccessor, c.api.stateAccessor.ModelTag(), createdBy, user, arg.Action))
 	}
 	return result, nil
 }

--- a/apiserver/client/state.go
+++ b/apiserver/client/state.go
@@ -48,6 +48,7 @@ type stateInterface interface {
 	ModelUUID() string
 	ModelTag() names.ModelTag
 	Model() (*state.Model, error)
+	ForModel(tag names.ModelTag) (*state.State, error)
 	SetModelAgentVersion(version.Number) error
 	SetAnnotations(state.GlobalEntity, map[string]string) error
 	Annotations(state.GlobalEntity) (map[string]string, error)

--- a/apiserver/params/usermanager.go
+++ b/apiserver/params/usermanager.go
@@ -42,8 +42,9 @@ type AddUsers struct {
 
 // AddUser stores the parameters to add one user.
 type AddUser struct {
-	Username    string `json:"username"`
-	DisplayName string `json:"display-name"`
+	Username        string   `json:"username"`
+	DisplayName     string   `json:"display-name"`
+	SharedModelTags []string `json:"shared-model-tags"`
 
 	// Password is optional. If it is empty, then
 	// a secret key will be generated for the user

--- a/apiserver/usermanager/usermanager_test.go
+++ b/apiserver/usermanager/usermanager_test.go
@@ -57,9 +57,7 @@ func (s *userManagerSuite) TestNewUserManagerAPIRefusesNonClient(c *gc.C) {
 }
 
 func (s *userManagerSuite) assertAddUser(c *gc.C, sharedModelTags []string) {
-	sharedModelState := s.Factory.MakeModel(c, &factory.ModelParams{
-		Name: "sharedmodel",
-	})
+	sharedModelState := s.Factory.MakeModel(c, nil)
 	defer sharedModelState.Close()
 
 	args := params.AddUsers{
@@ -121,9 +119,7 @@ func (s *userManagerSuite) TestAddUserWithSecretKey(c *gc.C) {
 }
 
 func (s *userManagerSuite) TestAddUserWithSharedModel(c *gc.C) {
-	sharedModelState := s.Factory.MakeModel(c, &factory.ModelParams{
-		Name: "somesharedmodel",
-	})
+	sharedModelState := s.Factory.MakeModel(c, nil)
 	defer sharedModelState.Close()
 
 	s.assertAddUser(c, []string{sharedModelState.ModelTag().String()})
@@ -133,7 +129,6 @@ func (s *userManagerSuite) TestAddUserWithSharedModel(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	users, err := sharedModel.Users()
 	c.Assert(err, jc.ErrorIsNil)
-	//c.Assert(users, gc.HasLen, 1)
 	var modelUserTags = make([]names.UserTag, len(users))
 	for i, u := range users {
 		modelUserTags[i] = u.UserTag()

--- a/cmd/juju/user/add.go
+++ b/cmd/juju/user/add.go
@@ -19,13 +19,13 @@ import (
 )
 
 const useraddCommandDoc = `
-Add users to a controller to allow them to login to that controller.
-Optionally, share a model hosted by that controller with the user. 
+Add users to a controller to allow them to login to the controller.
+Optionally, share a model hosted by the controller with the user.
 
-The user information is stored within the shared model, and will be
-lost when the model is destroyed.  A "juju register" command will be
-printed out, which must be executed to complete the user registration
-process, setting the user's initial password.
+The user's details are stored with the model being shared, and will be
+removed when the model is destroyed.  A "juju register" command will be
+printed, which must be executed to complete the user registration process,
+setting the user's initial password.
 
 Examples:
     # Add user "foobar"
@@ -37,6 +37,7 @@ Examples:
 
 See Also:
     juju help change-user-password
+    juju help register
 `
 
 // AddUserAPI defines the usermanager API methods that the add command uses.
@@ -102,6 +103,7 @@ func (c *addCommand) Run(ctx *cmd.Context) error {
 		model, err := c.ClientStore().ModelByName(c.ControllerName(), c.ModelName)
 		if errors.IsNotFound(err) {
 			// The model isn't known locally, so query the models available in the controller.
+			ctx.Verbosef("model %q not cached locally, refreshing models from controller", c.ModelName)
 			if err := c.RefreshModels(c.ClientStore(), c.ControllerName()); err != nil {
 				return errors.Annotate(err, "refreshing models")
 			}

--- a/cmd/juju/user/add_test.go
+++ b/cmd/juju/user/add_test.go
@@ -12,8 +12,11 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/cmd/juju/user"
+	"github.com/juju/juju/jujuclient"
+	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	"github.com/juju/juju/testing"
 )
 
@@ -22,6 +25,7 @@ import (
 type UserAddCommandSuite struct {
 	BaseSuite
 	mockAPI *mockAddUserAPI
+	store   jujuclient.ClientStore
 }
 
 var _ = gc.Suite(&UserAddCommandSuite{})
@@ -30,10 +34,21 @@ func (s *UserAddCommandSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 	s.mockAPI = &mockAddUserAPI{}
 	s.mockAPI.secretKey = []byte(strings.Repeat("X", 32))
+	store := jujuclienttesting.NewMemStore()
+	store.Accounts["testing"] = &jujuclient.ControllerAccounts{
+		Accounts: map[string]jujuclient.AccountDetails{
+			"current-user@local": {
+				User:     "current-user@local",
+				Password: "old-password",
+			},
+		},
+		CurrentAccount: "current-user@local",
+	}
+	s.store = store
 }
 
 func (s *UserAddCommandSuite) run(c *gc.C, args ...string) (*cmd.Context, error) {
-	addCommand, _ := user.NewAddCommandForTest(s.mockAPI)
+	addCommand, _ := user.NewAddCommandForTest(s.mockAPI, s.store, &mockModelApi{})
 	return testing.RunCommand(c, addCommand, args...)
 }
 
@@ -58,7 +73,7 @@ func (s *UserAddCommandSuite) TestInit(c *gc.C) {
 		errorString: `unrecognized args: \["extra"\]`,
 	}} {
 		c.Logf("test %d (%q)", i, test.args)
-		wrappedCommand, command := user.NewAddCommandForTest(s.mockAPI)
+		wrappedCommand, command := user.NewAddCommandForTest(s.mockAPI, s.store, &mockModelApi{})
 		err := testing.InitCommand(wrappedCommand, test.args)
 		if test.errorString == "" {
 			c.Check(err, jc.ErrorIsNil)
@@ -78,11 +93,12 @@ func (s *UserAddCommandSuite) TestRandomPassword(c *gc.C) {
 }
 */
 
-func (s *UserAddCommandSuite) TestAddUserWithWithUsername(c *gc.C) {
+func (s *UserAddCommandSuite) TestAddUserWithUsername(c *gc.C) {
 	context, err := s.run(c, "foobar")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.mockAPI.username, gc.Equals, "foobar")
 	c.Assert(s.mockAPI.displayname, gc.Equals, "")
+	c.Assert(s.mockAPI.models, gc.HasLen, 0)
 	expected := `
 User "foobar" added
 Please send this command to foobar:
@@ -97,8 +113,35 @@ func (s *UserAddCommandSuite) TestAddUserWithUsernameAndDisplayname(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.mockAPI.username, gc.Equals, "foobar")
 	c.Assert(s.mockAPI.displayname, gc.Equals, "Foo Bar")
+	c.Assert(s.mockAPI.models, gc.HasLen, 0)
 	expected := `
 User "Foo Bar (foobar)" added
+Please send this command to foobar:
+    juju register MD0TBmZvb2JhcjAREw8xMjcuMC4wLjE6MTIzNDUEIFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhY
+`[1:]
+	c.Assert(testing.Stdout(context), gc.Equals, expected)
+	c.Assert(testing.Stderr(context), gc.Equals, "")
+}
+
+type mockModelApi struct{}
+
+func (m *mockModelApi) ListModels(user string) ([]base.UserModel, error) {
+	return []base.UserModel{{Name: "model", UUID: "modeluuid"}}, nil
+}
+
+func (m *mockModelApi) Close() error {
+	return nil
+}
+
+func (s *UserAddCommandSuite) TestAddUserWithSharedModel(c *gc.C) {
+	context, err := s.run(c, "foobar", "--share", "model")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s.mockAPI.username, gc.Equals, "foobar")
+	c.Assert(s.mockAPI.displayname, gc.Equals, "")
+	c.Assert(s.mockAPI.models, gc.DeepEquals, []string{"modeluuid"})
+	expected := `
+User "foobar" added
+Model  "model" is now shared
 Please send this command to foobar:
     juju register MD0TBmZvb2JhcjAREw8xMjcuMC4wLjE6MTIzNDUEIFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhY
 `[1:]
@@ -130,15 +173,17 @@ type mockAddUserAPI struct {
 	username    string
 	displayname string
 	password    string
+	models      []string
 }
 
-func (m *mockAddUserAPI) AddUser(username, displayname, password string) (names.UserTag, []byte, error) {
+func (m *mockAddUserAPI) AddUser(username, displayname, password string, models ...string) (names.UserTag, []byte, error) {
 	if m.blocked {
 		return names.UserTag{}, nil, common.OperationBlockedError("the operation has been blocked")
 	}
 	m.username = username
 	m.displayname = displayname
 	m.password = password
+	m.models = models
 	if m.failMessage != "" {
 		return names.UserTag{}, nil, errors.New(m.failMessage)
 	}

--- a/cmd/juju/user/export_test.go
+++ b/cmd/juju/user/export_test.go
@@ -27,8 +27,10 @@ type DisenableUserBase struct {
 	*disenableUserBase
 }
 
-func NewAddCommandForTest(api AddUserAPI) (cmd.Command, *AddCommand) {
+func NewAddCommandForTest(api AddUserAPI, store jujuclient.ClientStore, modelApi modelcmd.ModelAPI) (cmd.Command, *AddCommand) {
 	c := &addCommand{api: api}
+	c.SetClientStore(store)
+	c.SetModelApi(modelApi)
 	return modelcmd.WrapController(c), &AddCommand{c}
 }
 

--- a/cmd/modelcmd/base.go
+++ b/cmd/modelcmd/base.go
@@ -14,6 +14,7 @@ import (
 	"launchpad.net/gnuflag"
 
 	"github.com/juju/juju/api"
+	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/api/modelmanager"
 	"github.com/juju/juju/environs/configstore"
 	"github.com/juju/juju/juju"
@@ -31,11 +32,18 @@ type CommandBase interface {
 	closeContext()
 }
 
+// ModelAPI provides access to the model client facade methods.
+type ModelAPI interface {
+	ListModels(user string) ([]base.UserModel, error)
+	Close() error
+}
+
 // JujuCommandBase is a convenience type for embedding that need
 // an API connection.
 type JujuCommandBase struct {
 	cmd.CommandBase
 	apiContext *apiContext
+	modelApi   ModelAPI
 }
 
 // closeContext closes the command's API context
@@ -46,6 +54,23 @@ func (c *JujuCommandBase) closeContext() {
 			logger.Errorf("%v", err)
 		}
 	}
+}
+
+// SetModelApi sets the api used to access model information.
+func (c *JujuCommandBase) SetModelApi(api ModelAPI) {
+	c.modelApi = api
+}
+
+func (c *JujuCommandBase) modelAPI(store jujuclient.ClientStore, controllerName string) (ModelAPI, error) {
+	if c.modelApi != nil {
+		return c.modelApi, nil
+	}
+	conn, err := c.NewAPIRoot(store, controllerName, "")
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	c.modelApi = modelmanager.NewClient(conn)
+	return c.modelApi, nil
 }
 
 // NewAPIRoot returns a new connection to the API server for the given
@@ -92,11 +117,12 @@ func (c *JujuCommandBase) RefreshModels(store jujuclient.ClientStore, controller
 	if err != nil {
 		return errors.Trace(err)
 	}
-	conn, err := c.NewAPIRoot(store, controllerName, "")
+
+	modelManager, err := c.modelAPI(store, controllerName)
 	if err != nil {
 		return errors.Trace(err)
 	}
-	defer conn.Close()
+	defer modelManager.Close()
 
 	// TODO(axw) remove this when we stop using configstore.
 	legacyStore, err := configstore.Default()
@@ -108,7 +134,6 @@ func (c *JujuCommandBase) RefreshModels(store jujuclient.ClientStore, controller
 		return errors.Trace(err)
 	}
 
-	modelManager := modelmanager.NewClient(conn)
 	models, err := modelManager.ListModels(accountDetails.User)
 	if err != nil {
 		return errors.Trace(err)

--- a/cmd/modelcmd/modelcommand.go
+++ b/cmd/modelcmd/modelcommand.go
@@ -307,14 +307,6 @@ func ModelSkipDefault(w *modelCommandWrapper) {
 	w.useDefaultModel = false
 }
 
-// EnvAPIOpener instructs the underlying environment command to use a
-// different Opener strategy.
-func EnvAPIOpener(opener APIOpener) WrapEnvOption {
-	return func(w *modelCommandWrapper) {
-		w.ModelCommand.SetAPIOpener(opener)
-	}
-}
-
 // Wrap wraps the specified ModelCommand, returning a Command
 // that proxies to each of the ModelCommand methods.
 // Any provided options are applied to the wrapped command

--- a/featuretests/cmd_juju_user_test.go
+++ b/featuretests/cmd_juju_user_test.go
@@ -52,6 +52,35 @@ func (s *UserSuite) TestUserAdd(c *gc.C) {
 	c.Assert(user.IsDisabled(), jc.IsFalse)
 }
 
+func (s *UserSuite) TestUserAddShareModel(c *gc.C) {
+	sharedModelState := s.Factory.MakeModel(c, &factory.ModelParams{
+		Name: "amodel",
+	})
+	defer sharedModelState.Close()
+
+	ctx, err := s.RunUserCommand(c, "add-user", "test", "--share", "amodel")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(testing.Stdout(ctx), jc.HasPrefix, `User "test" added`)
+	user, err := s.State.User(names.NewLocalUserTag("test"))
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(user.IsDisabled(), jc.IsFalse)
+
+	// Check model is shared with expected users.
+	sharedModel, err := sharedModelState.Model()
+	c.Assert(err, jc.ErrorIsNil)
+	users, err := sharedModel.Users()
+	c.Assert(err, jc.ErrorIsNil)
+	//c.Assert(users, gc.HasLen, 1)
+	var modelUserTags = make([]names.UserTag, len(users))
+	for i, u := range users {
+		modelUserTags[i] = u.UserTag()
+	}
+	c.Assert(modelUserTags, jc.SameContents, []names.UserTag{
+		user.Tag().(names.UserTag),
+		names.NewLocalUserTag("admin"),
+	})
+}
+
 func (s *UserSuite) TestUserChangePassword(c *gc.C) {
 	user, err := s.State.User(s.AdminUserTag(c))
 	c.Assert(err, jc.ErrorIsNil)

--- a/featuretests/cmd_juju_user_test.go
+++ b/featuretests/cmd_juju_user_test.go
@@ -70,7 +70,6 @@ func (s *UserSuite) TestUserAddShareModel(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	users, err := sharedModel.Users()
 	c.Assert(err, jc.ErrorIsNil)
-	//c.Assert(users, gc.HasLen, 1)
 	var modelUserTags = make([]names.UserTag, len(users))
 	for i, u := range users {
 		modelUserTags[i] = u.UserTag()

--- a/state/model.go
+++ b/state/model.go
@@ -189,69 +189,69 @@ func (st *State) NewModel(cfg *config.Config, owner names.UserTag) (_ *Model, _ 
 // Tag returns a name identifying the model.
 // The returned name will be different from other Tag values returned
 // by any other entities from the same state.
-func (e *Model) Tag() names.Tag {
-	return e.ModelTag()
+func (m *Model) Tag() names.Tag {
+	return m.ModelTag()
 }
 
 // ModelTag is the concrete model tag for this model.
-func (e *Model) ModelTag() names.ModelTag {
-	return names.NewModelTag(e.doc.UUID)
+func (m *Model) ModelTag() names.ModelTag {
+	return names.NewModelTag(m.doc.UUID)
 }
 
 // ControllerTag is the model tag for the controller that the model is
 // running within.
-func (e *Model) ControllerTag() names.ModelTag {
-	return names.NewModelTag(e.doc.ServerUUID)
+func (m *Model) ControllerTag() names.ModelTag {
+	return names.NewModelTag(m.doc.ServerUUID)
 }
 
 // UUID returns the universally unique identifier of the model.
-func (e *Model) UUID() string {
-	return e.doc.UUID
+func (m *Model) UUID() string {
+	return m.doc.UUID
 }
 
 // ControllerUUID returns the universally unique identifier of the controller
 // in which the model is running.
-func (e *Model) ControllerUUID() string {
-	return e.doc.ServerUUID
+func (m *Model) ControllerUUID() string {
+	return m.doc.ServerUUID
 }
 
 // Name returns the human friendly name of the model.
-func (e *Model) Name() string {
-	return e.doc.Name
+func (m *Model) Name() string {
+	return m.doc.Name
 }
 
 // Life returns whether the model is Alive, Dying or Dead.
-func (e *Model) Life() Life {
-	return e.doc.Life
+func (m *Model) Life() Life {
+	return m.doc.Life
 }
 
 // TimeOfDying returns when the model Life was set to Dying.
-func (e *Model) TimeOfDying() time.Time {
-	return e.doc.TimeOfDying
+func (m *Model) TimeOfDying() time.Time {
+	return m.doc.TimeOfDying
 }
 
 // TimeOfDeath returns when the model Life was set to Dead.
-func (e *Model) TimeOfDeath() time.Time {
-	return e.doc.TimeOfDeath
+func (m *Model) TimeOfDeath() time.Time {
+	return m.doc.TimeOfDeath
 }
 
 // Owner returns tag representing the owner of the model.
 // The owner is the user that created the model.
-func (e *Model) Owner() names.UserTag {
-	return names.NewUserTag(e.doc.Owner)
+func (m *Model) Owner() names.UserTag {
+	return names.NewUserTag(m.doc.Owner)
 }
 
 // Config returns the config for the model.
-func (e *Model) Config() (*config.Config, error) {
-	if e.st.modelTag.Id() == e.UUID() {
-		return e.st.ModelConfig()
+func (m *Model) Config() (*config.Config, error) {
+	if m.st.modelTag.Id() == m.UUID() {
+		return m.st.ModelConfig()
 	}
-	envState := e.st
-	if envState.modelTag != e.ModelTag() {
+	envState := m.st
+	if envState.modelTag != m.ModelTag() {
 		// The active model isn't the same as the model
 		// we are querying.
 		var err error
-		envState, err = e.st.ForModel(e.ModelTag())
+		envState, err = m.st.ForModel(m.ModelTag())
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -262,28 +262,28 @@ func (e *Model) Config() (*config.Config, error) {
 
 // UpdateLatestToolsVersion looks up for the latest available version of
 // juju tools and updates environementDoc with it.
-func (e *Model) UpdateLatestToolsVersion(ver version.Number) error {
+func (m *Model) UpdateLatestToolsVersion(ver version.Number) error {
 	v := ver.String()
 	// TODO(perrito666): I need to assert here that there isn't a newer
 	// version in place.
 	ops := []txn.Op{{
 		C:      modelsC,
-		Id:     e.doc.UUID,
+		Id:     m.doc.UUID,
 		Update: bson.D{{"$set", bson.D{{"available-tools", v}}}},
 	}}
-	err := e.st.runTransaction(ops)
+	err := m.st.runTransaction(ops)
 	if err != nil {
 		return errors.Trace(err)
 	}
-	return e.Refresh()
+	return m.Refresh()
 }
 
 // LatestToolsVersion returns the newest version found in the last
 // check in the streams.
 // Bear in mind that the check was performed filtering only
 // new patches for the current major.minor. (major.minor.patch)
-func (e *Model) LatestToolsVersion() version.Number {
-	ver := e.doc.LatestAvailableTools
+func (m *Model) LatestToolsVersion() version.Number {
+	ver := m.doc.LatestAvailableTools
 	if ver == "" {
 		return version.Zero
 	}
@@ -298,18 +298,18 @@ func (e *Model) LatestToolsVersion() version.Number {
 }
 
 // globalKey returns the global database key for the model.
-func (e *Model) globalKey() string {
+func (m *Model) globalKey() string {
 	return modelGlobalKey
 }
 
-func (e *Model) Refresh() error {
-	models, closer := e.st.getCollection(modelsC)
+func (m *Model) Refresh() error {
+	models, closer := m.st.getCollection(modelsC)
 	defer closer()
-	return e.refresh(models.FindId(e.UUID()))
+	return m.refresh(models.FindId(m.UUID()))
 }
 
-func (e *Model) refresh(query *mgo.Query) error {
-	err := query.One(&e.doc)
+func (m *Model) refresh(query *mgo.Query) error {
+	err := query.One(&m.doc)
 	if err == mgo.ErrNotFound {
 		return errors.NotFoundf("model")
 	}
@@ -317,11 +317,11 @@ func (e *Model) refresh(query *mgo.Query) error {
 }
 
 // Users returns a slice of all users for this model.
-func (e *Model) Users() ([]*ModelUser, error) {
-	if e.st.ModelUUID() != e.UUID() {
+func (m *Model) Users() ([]*ModelUser, error) {
+	if m.st.ModelUUID() != m.UUID() {
 		return nil, errors.New("cannot lookup model users outside the current model")
 	}
-	coll, closer := e.st.getCollection(modelUsersC)
+	coll, closer := m.st.getCollection(modelUsersC)
 	defer closer()
 
 	var userDocs []modelUserDoc
@@ -333,7 +333,7 @@ func (e *Model) Users() ([]*ModelUser, error) {
 	var modelUsers []*ModelUser
 	for _, doc := range userDocs {
 		modelUsers = append(modelUsers, &ModelUser{
-			st:  e.st,
+			st:  m.st,
 			doc: doc,
 		})
 	}
@@ -343,18 +343,18 @@ func (e *Model) Users() ([]*ModelUser, error) {
 
 // Destroy sets the models's lifecycle to Dying, preventing
 // addition of services or machines to state.
-func (e *Model) Destroy() (err error) {
-	return e.destroy(false)
+func (m *Model) Destroy() (err error) {
+	return m.destroy(false)
 }
 
 // DestroyIncludingHosted sets the model's lifecycle to Dying, preventing addition of
 // services or machines to state. If this model is a controller hosting
 // other model, they will also be destroyed.
-func (e *Model) DestroyIncludingHosted() error {
-	return e.destroy(true)
+func (m *Model) DestroyIncludingHosted() error {
+	return m.destroy(true)
 }
 
-func (e *Model) destroy(destroyHostedModels bool) (err error) {
+func (m *Model) destroy(destroyHostedModels bool) (err error) {
 	defer errors.DeferredAnnotatef(&err, "failed to destroy model")
 
 	buildTxn := func(attempt int) ([]txn.Op, error) {
@@ -365,12 +365,12 @@ func (e *Model) destroy(destroyHostedModels bool) (err error) {
 			// ...but on subsequent attempts, we read fresh environ
 			// state from the DB. Note that we do *not* refresh `e`
 			// itself, as detailed in doc/hacking-state.txt
-			if e, err = e.st.GetModel(e.ModelTag()); err != nil {
+			if m, err = m.st.GetModel(m.ModelTag()); err != nil {
 				return nil, errors.Trace(err)
 			}
 		}
 
-		ops, err := e.destroyOps(destroyHostedModels)
+		ops, err := m.destroyOps(destroyHostedModels)
 		if err == errModelNotAlive {
 			return nil, jujutxn.ErrNoOperations
 		} else if err != nil {
@@ -380,9 +380,9 @@ func (e *Model) destroy(destroyHostedModels bool) (err error) {
 		return ops, nil
 	}
 
-	st := e.st
-	if e.UUID() != e.st.ModelUUID() {
-		st, err = e.st.ForModel(e.ModelTag())
+	st := m.st
+	if m.UUID() != m.st.ModelUUID() {
+		st, err = m.st.ForModel(m.ModelTag())
 		defer st.Close()
 		if err != nil {
 			return errors.Trace(err)
@@ -408,28 +408,28 @@ func IsHasHostedModelsError(err error) bool {
 
 // destroyOps returns the txn operations necessary to begin model
 // destruction, or an error indicating why it can't.
-func (e *Model) destroyOps(destroyHostedModels bool) ([]txn.Op, error) {
+func (m *Model) destroyOps(destroyHostedModels bool) ([]txn.Op, error) {
 	// Ensure we're using the model's state.
-	st := e.st
+	st := m.st
 	var err error
-	if e.UUID() != e.st.ModelUUID() {
-		st, err = e.st.ForModel(e.ModelTag())
+	if m.UUID() != m.st.ModelUUID() {
+		st, err = m.st.ForModel(m.ModelTag())
 		defer st.Close()
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
 	}
 
-	if e.Life() != Alive {
+	if m.Life() != Alive {
 		return nil, errModelNotAlive
 	}
 
-	err = e.ensureDestroyable()
+	err = m.ensureDestroyable()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 
-	uuid := e.UUID()
+	uuid := m.UUID()
 	ops := []txn.Op{{
 		C:      modelsC,
 		Id:     uuid,
@@ -439,7 +439,7 @@ func (e *Model) destroyOps(destroyHostedModels bool) ([]txn.Op, error) {
 			{"time-of-dying", nowToTheSecond()},
 		}}},
 	}}
-	if uuid == e.doc.ServerUUID && !destroyHostedModels {
+	if uuid == m.doc.ServerUUID && !destroyHostedModels {
 		if count, err := hostedModelCount(st); err != nil {
 			return nil, errors.Trace(err)
 		} else if count != 0 {
@@ -457,7 +457,7 @@ func (e *Model) destroyOps(destroyHostedModels bool) ([]txn.Op, error) {
 	// arbitrarily long delays, we need to make sure every op
 	// causes a state change that's still consistent; so we make
 	// sure the cleanup ops are the last thing that will execute.
-	if uuid == e.doc.ServerUUID {
+	if uuid == m.doc.ServerUUID {
 		cleanupOp := st.newCleanupOp(cleanupModelsForDyingController, uuid)
 		ops = append(ops, cleanupOp)
 	}
@@ -494,7 +494,7 @@ func checkManualMachines(machines []*Machine) error {
 
 // ensureDestroyable an error if any manual machines or persistent volumes are
 // found.
-func (e *Model) ensureDestroyable() error {
+func (m *Model) ensureDestroyable() error {
 
 	// TODO(waigani) bug #1475212: Model destroy can miss manual
 	// machines. We need to be able to assert the absence of these as
@@ -503,7 +503,7 @@ func (e *Model) ensureDestroyable() error {
 
 	// Check for manual machines. We bail out if there are any,
 	// to stop the user from prematurely hobbling the model.
-	machines, err := e.st.AllMachines()
+	machines, err := m.st.AllMachines()
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -591,8 +591,8 @@ func createUniqueOwnerModelNameOp(owner names.UserTag, envName string) txn.Op {
 }
 
 // assertAliveOp returns a txn.Op that asserts the model is alive.
-func (e *Model) assertAliveOp() txn.Op {
-	return assertModelAliveOp(e.UUID())
+func (m *Model) assertAliveOp() txn.Op {
+	return assertModelAliveOp(m.UUID())
 }
 
 // assertModelAliveOp returns a txn.Op that asserts the given


### PR DESCRIPTION
juju add-user now supports using the --share argument to share a specific model with the newly added user.

juju add-user --share <somemodel>

(Review request: http://reviews.vapour.ws/r/3876/)