### PR TITLE
Fixes critical bug 1542131 and related 1542127.

### DIFF
--- a/cmd/jujud/bootstrap.go
+++ b/cmd/jujud/bootstrap.go
@@ -450,15 +450,7 @@ var seriesFromVersion = series.VersionSeries
 func (c *BootstrapCommand) saveCustomImageMetadata(st *state.State, env environs.Environ) error {
 	logger.Debugf("saving custom image metadata from %q", c.ImageMetadataDir)
 	baseURL := fmt.Sprintf("file://%s", filepath.ToSlash(c.ImageMetadataDir))
-
-	// This data source does not require to contain signed data.
-	// However, it may still contain it.
-	// Since we will always try to read signed data first,
-	// we want to be able to try to read this signed data
-	// with a public key.
-	// Bugs #1542127, #1542131
 	datasource := simplestreams.NewURLSignedDataSource("custom", baseURL, imagemetadata.ImagePublicKey(), utils.NoVerifySSLHostnames, simplestreams.CUSTOM_CLOUD_DATA, false)
-
 	return storeImageMetadataFromFiles(st, env, datasource)
 }
 

--- a/cmd/jujud/bootstrap.go
+++ b/cmd/jujud/bootstrap.go
@@ -450,7 +450,8 @@ var seriesFromVersion = series.VersionSeries
 func (c *BootstrapCommand) saveCustomImageMetadata(st *state.State, env environs.Environ) error {
 	logger.Debugf("saving custom image metadata from %q", c.ImageMetadataDir)
 	baseURL := fmt.Sprintf("file://%s", filepath.ToSlash(c.ImageMetadataDir))
-	datasource := simplestreams.NewURLSignedDataSource("custom", baseURL, imagemetadata.ImagePublicKey(), utils.NoVerifySSLHostnames, simplestreams.CUSTOM_CLOUD_DATA, false)
+	publicKey, _ := simplestreams.UserPublicSigningKey()
+	datasource := simplestreams.NewURLSignedDataSource("custom", baseURL, publicKey, utils.NoVerifySSLHostnames, simplestreams.CUSTOM_CLOUD_DATA, false)
 	return storeImageMetadataFromFiles(st, env, datasource)
 }
 

--- a/cmd/jujud/bootstrap_test.go
+++ b/cmd/jujud/bootstrap_test.go
@@ -37,7 +37,6 @@ import (
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/configstore"
 	"github.com/juju/juju/environs/filestorage"
-	"github.com/juju/juju/environs/imagemetadata"
 	"github.com/juju/juju/environs/simplestreams"
 	sstesting "github.com/juju/juju/environs/simplestreams/testing"
 	"github.com/juju/juju/environs/storage"
@@ -793,9 +792,9 @@ func (s *BootstrapSuite) TestCustomDataSourceHasKey(c *gc.C) {
 		// However, it may still contain it.
 		// Since we will always try to read signed data first,
 		// we want to be able to try to read this signed data
-		// with a public key.
+		// with a user provided public key. For this test, none is provided.
 		// Bugs #1542127, #1542131
-		c.Assert(source.PublicSigningKey(), gc.DeepEquals, imagemetadata.SimplestreamsImagesPublicKey)
+		c.Assert(source.PublicSigningKey(), gc.Equals, "")
 		return nil
 	})
 	err = cmd.Run(nil)

--- a/cmd/jujud/bootstrap_test.go
+++ b/cmd/jujud/bootstrap_test.go
@@ -789,6 +789,12 @@ func (s *BootstrapSuite) TestCustomDataSourceHasKey(c *gc.C) {
 	called := false
 	s.PatchValue(&storeImageMetadataFromFiles, func(st *state.State, env environs.Environ, source simplestreams.DataSource) error {
 		called = true
+		// This data source does not require to contain signed data.
+		// However, it may still contain it.
+		// Since we will always try to read signed data first,
+		// we want to be able to try to read this signed data
+		// with a public key.
+		// Bugs #1542127, #1542131
 		c.Assert(source.PublicSigningKey(), gc.DeepEquals, imagemetadata.SimplestreamsImagesPublicKey)
 		return nil
 	})

--- a/cmd/plugins/juju-metadata/toolsmetadata.go
+++ b/cmd/plugins/juju-metadata/toolsmetadata.go
@@ -143,12 +143,6 @@ func (c *toolsMetadataCommand) Run(context *cmd.Context) error {
 // extracted into a var for testing banefit
 var toolsDataSources = func(urls ...string) []simplestreams.DataSource {
 	dataSources := make([]simplestreams.DataSource, len(urls))
-	// This data source does not require to contain signed data.
-	// However, it may still contain it.
-	// Since we will always try to read signed data first,
-	// we want to be able to try to read this signed data
-	// with public key with Juju-known public key for tools.
-	// Bugs #1542127, #1542131
 	for i, url := range urls {
 		dataSources[i] = simplestreams.NewURLSignedDataSource(
 			"local source",

--- a/cmd/plugins/juju-metadata/toolsmetadata.go
+++ b/cmd/plugins/juju-metadata/toolsmetadata.go
@@ -123,9 +123,7 @@ func (c *toolsMetadataCommand) Run(context *cmd.Context) error {
 		if err != nil {
 			return err
 		}
-		sourceDataSource := simplestreams.NewURLDataSource("local source", source, utils.VerifySSLHostnames, simplestreams.CUSTOM_CLOUD_DATA, false)
-		toolsList, err = envtools.FindToolsForCloud(
-			[]simplestreams.DataSource{sourceDataSource}, simplestreams.CloudSpec{}, c.stream, -1, -1, coretools.Filter{})
+		toolsList, err = envtools.FindToolsForCloud(toolsDataSources(source), simplestreams.CloudSpec{}, c.stream, -1, -1, coretools.Filter{})
 	}
 	if err != nil {
 		return err
@@ -140,6 +138,27 @@ func (c *toolsMetadataCommand) Run(context *cmd.Context) error {
 		writeMirrors = envtools.WriteMirrors
 	}
 	return mergeAndWriteMetadata(targetStorage, toolsDir, c.stream, c.clean, toolsList, writeMirrors)
+}
+
+// extracted into a var for testing banefit
+var toolsDataSources = func(urls ...string) []simplestreams.DataSource {
+	dataSources := make([]simplestreams.DataSource, len(urls))
+	// This data source does not require to contain signed data.
+	// However, it may still contain it.
+	// Since we will always try to read signed data first,
+	// we want to be able to try to read this signed data
+	// with public key with Juju-known public key for tools.
+	// Bugs #1542127, #1542131
+	for i, url := range urls {
+		dataSources[i] = simplestreams.NewURLSignedDataSource(
+			"local source",
+			url,
+			simplestreams.SimplestreamsJujuPublicKey,
+			utils.VerifySSLHostnames,
+			simplestreams.CUSTOM_CLOUD_DATA,
+			false)
+	}
+	return dataSources
 }
 
 // This is essentially the same as tools.MergeAndWriteMetadata, but also

--- a/cmd/plugins/juju-metadata/toolsmetadata.go
+++ b/cmd/plugins/juju-metadata/toolsmetadata.go
@@ -140,8 +140,7 @@ func (c *toolsMetadataCommand) Run(context *cmd.Context) error {
 	return mergeAndWriteMetadata(targetStorage, toolsDir, c.stream, c.clean, toolsList, writeMirrors)
 }
 
-// extracted into a var for testing banefit
-var toolsDataSources = func(urls ...string) []simplestreams.DataSource {
+func toolsDataSources(urls ...string) []simplestreams.DataSource {
 	dataSources := make([]simplestreams.DataSource, len(urls))
 	for i, url := range urls {
 		dataSources[i] = simplestreams.NewURLSignedDataSource(

--- a/cmd/plugins/juju-metadata/toolsmetadata_test.go
+++ b/cmd/plugins/juju-metadata/toolsmetadata_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/configstore"
+	"github.com/juju/juju/environs/simplestreams"
 	"github.com/juju/juju/environs/tools"
 	toolstesting "github.com/juju/juju/environs/tools/testing"
 	"github.com/juju/juju/juju/osenv"
@@ -347,4 +348,9 @@ Finding tools in .*
 		FileType: "tar.gz",
 		SHA256:   sha256,
 	})
+}
+
+func (s *ToolsMetadataSuite) TestToolsDataSourceHasKey(c *gc.C) {
+	ds := toolsDataSources("test.me")
+	c.Assert(ds[0].PublicSigningKey(), gc.DeepEquals, simplestreams.SimplestreamsJujuPublicKey)
 }

--- a/cmd/plugins/juju-metadata/toolsmetadata_test.go
+++ b/cmd/plugins/juju-metadata/toolsmetadata_test.go
@@ -352,5 +352,11 @@ Finding tools in .*
 
 func (s *ToolsMetadataSuite) TestToolsDataSourceHasKey(c *gc.C) {
 	ds := toolsDataSources("test.me")
+	// This data source does not require to contain signed data.
+	// However, it may still contain it.
+	// Since we will always try to read signed data first,
+	// we want to be able to try to read this signed data
+	// with public key with Juju-known public key for tools.
+	// Bugs #1542127, #1542131
 	c.Assert(ds[0].PublicSigningKey(), gc.DeepEquals, simplestreams.SimplestreamsJujuPublicKey)
 }

--- a/cmd/plugins/juju-metadata/validateimagemetadata.go
+++ b/cmd/plugins/juju-metadata/validateimagemetadata.go
@@ -134,65 +134,10 @@ func (oes *overrideEnvStream) Config() *config.Config {
 }
 
 func (c *validateImageMetadataCommand) Run(context *cmd.Context) error {
-	var params *simplestreams.MetadataLookupParams
-
-	if c.providerType == "" {
-		store, err := configstore.Default()
-		if err != nil {
-			return err
-		}
-		environ, err := c.prepare(context, store)
-		if err != nil {
-			return err
-		}
-		mdLookup, ok := environ.(simplestreams.MetadataValidator)
-		if !ok {
-			return fmt.Errorf("%s provider does not support image metadata validation", environ.Config().Type())
-		}
-		params, err = mdLookup.MetadataLookupParams(c.region)
-		if err != nil {
-			return err
-		}
-		oes := &overrideEnvStream{environ, c.stream}
-		params.Sources, err = environs.ImageMetadataSources(oes)
-		if err != nil {
-			return err
-		}
-	} else {
-		prov, err := environs.Provider(c.providerType)
-		if err != nil {
-			return err
-		}
-		mdLookup, ok := prov.(simplestreams.MetadataValidator)
-		if !ok {
-			return fmt.Errorf("%s provider does not support image metadata validation", c.providerType)
-		}
-		params, err = mdLookup.MetadataLookupParams(c.region)
-		if err != nil {
-			return err
-		}
+	params, err := c.createLookupParams(context)
+	if err != nil {
+		return err
 	}
-
-	if c.series != "" {
-		params.Series = c.series
-	}
-	if c.region != "" {
-		params.Region = c.region
-	}
-	if c.endpoint != "" {
-		params.Endpoint = c.endpoint
-	}
-	if c.metadataDir != "" {
-		dir := filepath.Join(c.metadataDir, "images")
-		if _, err := os.Stat(dir); err != nil {
-			return err
-		}
-		params.Sources = []simplestreams.DataSource{
-			simplestreams.NewURLDataSource(
-				"local metadata directory", "file://"+dir, utils.VerifySSLHostnames, simplestreams.CUSTOM_CLOUD_DATA, false),
-		}
-	}
-	params.Stream = c.stream
 
 	image_ids, resolveInfo, err := imagemetadata.ValidateImageMetadata(params)
 	if err != nil {
@@ -226,4 +171,78 @@ func (c *validateImageMetadataCommand) Run(context *cmd.Context) error {
 			params.Region, strings.Join(sources, "\n"))
 	}
 	return nil
+}
+
+func (c *validateImageMetadataCommand) createLookupParams(context *cmd.Context) (*simplestreams.MetadataLookupParams, error) {
+	params := &simplestreams.MetadataLookupParams{Stream: c.stream}
+
+	if c.providerType == "" {
+		store, err := configstore.Default()
+		if err != nil {
+			return nil, err
+		}
+		environ, err := c.prepare(context, store)
+		if err != nil {
+			return nil, err
+		}
+		mdLookup, ok := environ.(simplestreams.MetadataValidator)
+		if !ok {
+			return nil, fmt.Errorf("%s provider does not support image metadata validation", environ.Config().Type())
+		}
+		params, err = mdLookup.MetadataLookupParams(c.region)
+		if err != nil {
+			return nil, err
+		}
+		oes := &overrideEnvStream{environ, c.stream}
+		params.Sources, err = environs.ImageMetadataSources(oes)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		prov, err := environs.Provider(c.providerType)
+		if err != nil {
+			return nil, err
+		}
+		mdLookup, ok := prov.(simplestreams.MetadataValidator)
+		if !ok {
+			return nil, fmt.Errorf("%s provider does not support image metadata validation", c.providerType)
+		}
+		params, err = mdLookup.MetadataLookupParams(c.region)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if c.series != "" {
+		params.Series = c.series
+	}
+	if c.region != "" {
+		params.Region = c.region
+	}
+	if c.endpoint != "" {
+		params.Endpoint = c.endpoint
+	}
+	if c.metadataDir != "" {
+		dir := filepath.Join(c.metadataDir, "images")
+		if _, err := os.Stat(dir); err != nil {
+			return nil, err
+		}
+		params.Sources = imagesDataSources(dir)
+	}
+	return params, nil
+}
+
+var imagesDataSources = func(urls ...string) []simplestreams.DataSource {
+	// This data source does not require to contain signed data.
+	// However, it may still contain it.
+	// Since we will always try to read signed data first,
+	// we want to be able to try to read this signed data
+	// with a public key.
+	// Bugs #1542127, #1542131
+	dataSources := make([]simplestreams.DataSource, len(urls))
+	for i, url := range urls {
+		dataSources[i] = simplestreams.NewURLSignedDataSource(
+			"local metadata directory", "file://"+url, imagemetadata.ImagePublicKey(), utils.VerifySSLHostnames, simplestreams.CUSTOM_CLOUD_DATA, false)
+	}
+	return dataSources
 }

--- a/cmd/plugins/juju-metadata/validateimagemetadata.go
+++ b/cmd/plugins/juju-metadata/validateimagemetadata.go
@@ -234,9 +234,10 @@ func (c *validateImageMetadataCommand) createLookupParams(context *cmd.Context) 
 
 var imagesDataSources = func(urls ...string) []simplestreams.DataSource {
 	dataSources := make([]simplestreams.DataSource, len(urls))
+	publicKey, _ := simplestreams.UserPublicSigningKey()
 	for i, url := range urls {
 		dataSources[i] = simplestreams.NewURLSignedDataSource(
-			"local metadata directory", "file://"+url, imagemetadata.ImagePublicKey(), utils.VerifySSLHostnames, simplestreams.CUSTOM_CLOUD_DATA, false)
+			"local metadata directory", "file://"+url, publicKey, utils.VerifySSLHostnames, simplestreams.CUSTOM_CLOUD_DATA, false)
 	}
 	return dataSources
 }

--- a/cmd/plugins/juju-metadata/validateimagemetadata.go
+++ b/cmd/plugins/juju-metadata/validateimagemetadata.go
@@ -233,12 +233,6 @@ func (c *validateImageMetadataCommand) createLookupParams(context *cmd.Context) 
 }
 
 var imagesDataSources = func(urls ...string) []simplestreams.DataSource {
-	// This data source does not require to contain signed data.
-	// However, it may still contain it.
-	// Since we will always try to read signed data first,
-	// we want to be able to try to read this signed data
-	// with a public key.
-	// Bugs #1542127, #1542131
 	dataSources := make([]simplestreams.DataSource, len(urls))
 	for i, url := range urls {
 		dataSources[i] = simplestreams.NewURLSignedDataSource(

--- a/cmd/plugins/juju-metadata/validateimagemetadata_test.go
+++ b/cmd/plugins/juju-metadata/validateimagemetadata_test.go
@@ -235,3 +235,8 @@ func (s *ValidateImageMetadataSuite) TestOpenstackLocalMetadataNoMatch(c *gc.C) 
 	strippedOut = strings.Replace(errOut, "\n", "", -1)
 	c.Check(strippedOut, gc.Matches, `.*Resolve Metadata:.*`)
 }
+
+func (s *ValidateImageMetadataSuite) TestImagesDataSourceHasKey(c *gc.C) {
+	ds := imagesDataSources("test.me")
+	c.Assert(ds[0].PublicSigningKey(), gc.DeepEquals, imagemetadata.SimplestreamsImagesPublicKey)
+}

--- a/cmd/plugins/juju-metadata/validateimagemetadata_test.go
+++ b/cmd/plugins/juju-metadata/validateimagemetadata_test.go
@@ -242,7 +242,7 @@ func (s *ValidateImageMetadataSuite) TestImagesDataSourceHasKey(c *gc.C) {
 	// However, it may still contain it.
 	// Since we will always try to read signed data first,
 	// we want to be able to try to read this signed data
-	// with a public key.
+	// with a user provided public key. For this test, none is provided.
 	// Bugs #1542127, #1542131
-	c.Assert(ds[0].PublicSigningKey(), gc.DeepEquals, imagemetadata.SimplestreamsImagesPublicKey)
+	c.Assert(ds[0].PublicSigningKey(), gc.Equals, "")
 }

--- a/cmd/plugins/juju-metadata/validateimagemetadata_test.go
+++ b/cmd/plugins/juju-metadata/validateimagemetadata_test.go
@@ -238,5 +238,11 @@ func (s *ValidateImageMetadataSuite) TestOpenstackLocalMetadataNoMatch(c *gc.C) 
 
 func (s *ValidateImageMetadataSuite) TestImagesDataSourceHasKey(c *gc.C) {
 	ds := imagesDataSources("test.me")
+	// This data source does not require to contain signed data.
+	// However, it may still contain it.
+	// Since we will always try to read signed data first,
+	// we want to be able to try to read this signed data
+	// with a public key.
+	// Bugs #1542127, #1542131
 	c.Assert(ds[0].PublicSigningKey(), gc.DeepEquals, imagemetadata.SimplestreamsImagesPublicKey)
 }

--- a/cmd/plugins/juju-metadata/validatetoolsmetadata.go
+++ b/cmd/plugins/juju-metadata/validatetoolsmetadata.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/juju/cmd"
-	"github.com/juju/utils"
 	"github.com/juju/utils/arch"
 	"launchpad.net/gnuflag"
 
@@ -208,9 +207,7 @@ func (c *validateToolsMetadataCommand) Run(context *cmd.Context) error {
 		if err != nil {
 			return err
 		}
-		params.Sources = []simplestreams.DataSource{simplestreams.NewURLDataSource(
-			"local metadata directory", toolsURL, utils.VerifySSLHostnames, simplestreams.CUSTOM_CLOUD_DATA, false),
-		}
+		params.Sources = toolsDataSources(toolsURL)
 	}
 	params.Stream = c.stream
 

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -411,7 +411,13 @@ func setPrivateMetadataSources(env environs.Environ, metadataDir string) ([]*ima
 	}
 
 	baseURL := fmt.Sprintf("file://%s", filepath.ToSlash(imageMetadataDir))
-	datasource := simplestreams.NewURLDataSource("bootstrap metadata", baseURL, utils.NoVerifySSLHostnames, simplestreams.CUSTOM_CLOUD_DATA, false)
+	// This data source does not require to contain signed data.
+	// However, it may still contain it.
+	// Since we will always try to read signed data first,
+	// we want to be able to try to read this signed data
+	// with a public key.
+	// Bugs #1542127, #1542131
+	datasource := simplestreams.NewURLSignedDataSource("bootstrap metadata", baseURL, imagemetadata.ImagePublicKey(), utils.NoVerifySSLHostnames, simplestreams.CUSTOM_CLOUD_DATA, false)
 
 	// Read the image metadata, as we'll want to upload it to the environment.
 	imageConstraint := imagemetadata.NewImageConstraint(simplestreams.LookupParams{})

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -411,12 +411,6 @@ func setPrivateMetadataSources(env environs.Environ, metadataDir string) ([]*ima
 	}
 
 	baseURL := fmt.Sprintf("file://%s", filepath.ToSlash(imageMetadataDir))
-	// This data source does not require to contain signed data.
-	// However, it may still contain it.
-	// Since we will always try to read signed data first,
-	// we want to be able to try to read this signed data
-	// with a public key.
-	// Bugs #1542127, #1542131
 	datasource := simplestreams.NewURLSignedDataSource("bootstrap metadata", baseURL, imagemetadata.ImagePublicKey(), utils.NoVerifySSLHostnames, simplestreams.CUSTOM_CLOUD_DATA, false)
 
 	// Read the image metadata, as we'll want to upload it to the environment.

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -411,7 +411,8 @@ func setPrivateMetadataSources(env environs.Environ, metadataDir string) ([]*ima
 	}
 
 	baseURL := fmt.Sprintf("file://%s", filepath.ToSlash(imageMetadataDir))
-	datasource := simplestreams.NewURLSignedDataSource("bootstrap metadata", baseURL, imagemetadata.ImagePublicKey(), utils.NoVerifySSLHostnames, simplestreams.CUSTOM_CLOUD_DATA, false)
+	publicKey, _ := simplestreams.UserPublicSigningKey()
+	datasource := simplestreams.NewURLSignedDataSource("bootstrap metadata", baseURL, publicKey, utils.NoVerifySSLHostnames, simplestreams.CUSTOM_CLOUD_DATA, false)
 
 	// Read the image metadata, as we'll want to upload it to the environment.
 	imageConstraint := imagemetadata.NewImageConstraint(simplestreams.LookupParams{})

--- a/environs/bootstrap/bootstrap_test.go
+++ b/environs/bootstrap/bootstrap_test.go
@@ -306,9 +306,10 @@ func (s *bootstrapSuite) TestBootstrapMetadata(c *gc.C) {
 	// However, it may still contain it.
 	// Since we will always try to read signed data first,
 	// we want to be able to try to read this signed data
-	// with a public key.
+	// with a user provided key.
+	// for this test, user provided key is empty.
 	// Bugs #1542127, #1542131
-	c.Assert(datasources[0].PublicSigningKey(), gc.Not(gc.Equals), "")
+	c.Assert(datasources[0].PublicSigningKey(), gc.Equals, "")
 	c.Assert(env.instanceConfig, gc.NotNil)
 	c.Assert(env.instanceConfig.CustomImageMetadata, gc.HasLen, 1)
 	c.Assert(env.instanceConfig.CustomImageMetadata[0], gc.DeepEquals, metadata[0])

--- a/environs/bootstrap/bootstrap_test.go
+++ b/environs/bootstrap/bootstrap_test.go
@@ -302,6 +302,12 @@ func (s *bootstrapSuite) TestBootstrapMetadata(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(datasources, gc.HasLen, 3)
 	c.Assert(datasources[0].Description(), gc.Equals, "bootstrap metadata")
+	// This data source does not require to contain signed data.
+	// However, it may still contain it.
+	// Since we will always try to read signed data first,
+	// we want to be able to try to read this signed data
+	// with a public key.
+	// Bugs #1542127, #1542131
 	c.Assert(datasources[0].PublicSigningKey(), gc.Not(gc.Equals), "")
 	c.Assert(env.instanceConfig, gc.NotNil)
 	c.Assert(env.instanceConfig.CustomImageMetadata, gc.HasLen, 1)

--- a/environs/bootstrap/bootstrap_test.go
+++ b/environs/bootstrap/bootstrap_test.go
@@ -302,6 +302,7 @@ func (s *bootstrapSuite) TestBootstrapMetadata(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(datasources, gc.HasLen, 3)
 	c.Assert(datasources[0].Description(), gc.Equals, "bootstrap metadata")
+	c.Assert(datasources[0].PublicSigningKey(), gc.Not(gc.Equals), "")
 	c.Assert(env.instanceConfig, gc.NotNil)
 	c.Assert(env.instanceConfig.CustomImageMetadata, gc.HasLen, 1)
 	c.Assert(env.instanceConfig.CustomImageMetadata[0], gc.DeepEquals, metadata[0])

--- a/environs/imagemetadata.go
+++ b/environs/imagemetadata.go
@@ -90,7 +90,13 @@ func ImageMetadataSources(env Environ) ([]simplestreams.DataSource, error) {
 		if !config.SSLHostnameVerification() {
 			verify = utils.NoVerifySSLHostnames
 		}
-		sources = append(sources, simplestreams.NewURLDataSource("image-metadata-url", userURL, verify, simplestreams.SPECIFIC_CLOUD_DATA, false))
+		// This data source does not require to contain signed data.
+		// However, it may still contain it.
+		// Since we will always try to read signed data first,
+		// we want to be able to try to read this signed data
+		// with a public key.
+		// Bugs #1542127, #1542131
+		sources = append(sources, simplestreams.NewURLSignedDataSource("image-metadata-url", userURL, imagemetadata.ImagePublicKey(), verify, simplestreams.SPECIFIC_CLOUD_DATA, false))
 	}
 
 	envDataSources, err := environmentDataSources(env)

--- a/environs/imagemetadata.go
+++ b/environs/imagemetadata.go
@@ -90,12 +90,6 @@ func ImageMetadataSources(env Environ) ([]simplestreams.DataSource, error) {
 		if !config.SSLHostnameVerification() {
 			verify = utils.NoVerifySSLHostnames
 		}
-		// This data source does not require to contain signed data.
-		// However, it may still contain it.
-		// Since we will always try to read signed data first,
-		// we want to be able to try to read this signed data
-		// with a public key.
-		// Bugs #1542127, #1542131
 		sources = append(sources, simplestreams.NewURLSignedDataSource("image-metadata-url", userURL, imagemetadata.ImagePublicKey(), verify, simplestreams.SPECIFIC_CLOUD_DATA, false))
 	}
 

--- a/environs/imagemetadata.go
+++ b/environs/imagemetadata.go
@@ -90,7 +90,8 @@ func ImageMetadataSources(env Environ) ([]simplestreams.DataSource, error) {
 		if !config.SSLHostnameVerification() {
 			verify = utils.NoVerifySSLHostnames
 		}
-		sources = append(sources, simplestreams.NewURLSignedDataSource("image-metadata-url", userURL, imagemetadata.ImagePublicKey(), verify, simplestreams.SPECIFIC_CLOUD_DATA, false))
+		publicKey, _ := simplestreams.UserPublicSigningKey()
+		sources = append(sources, simplestreams.NewURLSignedDataSource("image-metadata-url", userURL, publicKey, verify, simplestreams.SPECIFIC_CLOUD_DATA, false))
 	}
 
 	envDataSources, err := environmentDataSources(env)

--- a/environs/imagemetadata/simplestreams.go
+++ b/environs/imagemetadata/simplestreams.go
@@ -151,15 +151,6 @@ func OfficialDataSources(stream string) ([]simplestreams.DataSource, error) {
 	return result, nil
 }
 
-// ImagePublicKey returns a public key to use to decode signed image data.
-func ImagePublicKey() string {
-	publicKey, _ := simplestreams.UserPublicSigningKey()
-	if publicKey == "" {
-		publicKey = SimplestreamsImagesPublicKey
-	}
-	return publicKey
-}
-
 // ImageConstraint defines criteria used to find an image metadata record.
 type ImageConstraint struct {
 	simplestreams.LookupParams

--- a/environs/imagemetadata/simplestreams.go
+++ b/environs/imagemetadata/simplestreams.go
@@ -151,6 +151,15 @@ func OfficialDataSources(stream string) ([]simplestreams.DataSource, error) {
 	return result, nil
 }
 
+// ImagePublicKey returns a public key to use to decode signed image data.
+func ImagePublicKey() string {
+	publicKey, _ := simplestreams.UserPublicSigningKey()
+	if publicKey == "" {
+		publicKey = SimplestreamsImagesPublicKey
+	}
+	return publicKey
+}
+
 // ImageConstraint defines criteria used to find an image metadata record.
 type ImageConstraint struct {
 	simplestreams.LookupParams

--- a/environs/imagemetadata_test.go
+++ b/environs/imagemetadata_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/configstore"
+	"github.com/juju/juju/environs/imagemetadata"
 	"github.com/juju/juju/environs/simplestreams"
 	sstesting "github.com/juju/juju/environs/simplestreams/testing"
 	envtesting "github.com/juju/juju/environs/testing"
@@ -54,9 +55,9 @@ func (s *ImageMetadataSuite) TestImageMetadataURLsNoConfigURL(c *gc.C) {
 	env := s.env(c, "", "")
 	sources, err := environs.ImageMetadataSources(env)
 	c.Assert(err, jc.ErrorIsNil)
-	sstesting.AssertExpectedSources(c, sources, []string{
-		"https://streams.canonical.com/juju/images/releases/",
-		"http://cloud-images.ubuntu.com/releases/",
+	sstesting.AssertExpectedSources(c, sources, []sstesting.SourceDetails{
+		{"https://streams.canonical.com/juju/images/releases/", imagemetadata.SimplestreamsImagesPublicKey},
+		{"http://cloud-images.ubuntu.com/releases/", imagemetadata.SimplestreamsImagesPublicKey},
 	})
 }
 
@@ -64,10 +65,10 @@ func (s *ImageMetadataSuite) TestImageMetadataURLs(c *gc.C) {
 	env := s.env(c, "config-image-metadata-url", "")
 	sources, err := environs.ImageMetadataSources(env)
 	c.Assert(err, jc.ErrorIsNil)
-	sstesting.AssertExpectedSources(c, sources, []string{
-		"config-image-metadata-url/",
-		"https://streams.canonical.com/juju/images/releases/",
-		"http://cloud-images.ubuntu.com/releases/",
+	sstesting.AssertExpectedSources(c, sources, []sstesting.SourceDetails{
+		{"config-image-metadata-url/", imagemetadata.SimplestreamsImagesPublicKey},
+		{"https://streams.canonical.com/juju/images/releases/", imagemetadata.SimplestreamsImagesPublicKey},
+		{"http://cloud-images.ubuntu.com/releases/", imagemetadata.SimplestreamsImagesPublicKey},
 	})
 }
 
@@ -92,12 +93,12 @@ func (s *ImageMetadataSuite) TestImageMetadataURLsRegisteredFuncs(c *gc.C) {
 	env := s.env(c, "config-image-metadata-url", "")
 	sources, err := environs.ImageMetadataSources(env)
 	c.Assert(err, jc.ErrorIsNil)
-	sstesting.AssertExpectedSources(c, sources, []string{
-		"config-image-metadata-url/",
-		"foobar/",
-		"betwixt/releases/",
-		"https://streams.canonical.com/juju/images/releases/",
-		"http://cloud-images.ubuntu.com/releases/",
+	sstesting.AssertExpectedSources(c, sources, []sstesting.SourceDetails{
+		{"config-image-metadata-url/", imagemetadata.SimplestreamsImagesPublicKey},
+		{"foobar/", ""},
+		{"betwixt/releases/", ""},
+		{"https://streams.canonical.com/juju/images/releases/", imagemetadata.SimplestreamsImagesPublicKey},
+		{"http://cloud-images.ubuntu.com/releases/", imagemetadata.SimplestreamsImagesPublicKey},
 	})
 }
 
@@ -116,8 +117,8 @@ func (s *ImageMetadataSuite) TestImageMetadataURLsNonReleaseStream(c *gc.C) {
 	env := s.env(c, "", "daily")
 	sources, err := environs.ImageMetadataSources(env)
 	c.Assert(err, jc.ErrorIsNil)
-	sstesting.AssertExpectedSources(c, sources, []string{
-		"https://streams.canonical.com/juju/images/daily/",
-		"http://cloud-images.ubuntu.com/daily/",
+	sstesting.AssertExpectedSources(c, sources, []sstesting.SourceDetails{
+		{"https://streams.canonical.com/juju/images/daily/", imagemetadata.SimplestreamsImagesPublicKey},
+		{"http://cloud-images.ubuntu.com/daily/", imagemetadata.SimplestreamsImagesPublicKey},
 	})
 }

--- a/environs/imagemetadata_test.go
+++ b/environs/imagemetadata_test.go
@@ -66,7 +66,7 @@ func (s *ImageMetadataSuite) TestImageMetadataURLs(c *gc.C) {
 	sources, err := environs.ImageMetadataSources(env)
 	c.Assert(err, jc.ErrorIsNil)
 	sstesting.AssertExpectedSources(c, sources, []sstesting.SourceDetails{
-		{"config-image-metadata-url/", imagemetadata.SimplestreamsImagesPublicKey},
+		{"config-image-metadata-url/", ""},
 		{"https://streams.canonical.com/juju/images/releases/", imagemetadata.SimplestreamsImagesPublicKey},
 		{"http://cloud-images.ubuntu.com/releases/", imagemetadata.SimplestreamsImagesPublicKey},
 	})
@@ -94,7 +94,7 @@ func (s *ImageMetadataSuite) TestImageMetadataURLsRegisteredFuncs(c *gc.C) {
 	sources, err := environs.ImageMetadataSources(env)
 	c.Assert(err, jc.ErrorIsNil)
 	sstesting.AssertExpectedSources(c, sources, []sstesting.SourceDetails{
-		{"config-image-metadata-url/", imagemetadata.SimplestreamsImagesPublicKey},
+		{"config-image-metadata-url/", ""},
 		{"foobar/", ""},
 		{"betwixt/releases/", ""},
 		{"https://streams.canonical.com/juju/images/releases/", imagemetadata.SimplestreamsImagesPublicKey},

--- a/environs/simplestreams/decode_test.go
+++ b/environs/simplestreams/decode_test.go
@@ -1,4 +1,4 @@
-// Copyright 2013,2016 Canonical Ltd.
+// Copyright 2016 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 package simplestreams_test

--- a/environs/simplestreams/decode_test.go
+++ b/environs/simplestreams/decode_test.go
@@ -1,0 +1,111 @@
+// Copyright 2013,2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package simplestreams_test
+
+import (
+	"bytes"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/environs/simplestreams"
+)
+
+type decodeSuite struct{}
+
+var _ = gc.Suite(&decodeSuite{})
+
+func (s *decodeSuite) TestDecodeCheckValidSignature(c *gc.C) {
+	r := bytes.NewReader([]byte(signedData))
+	txt, err := simplestreams.DecodeCheckSignature(r, testSigningKey)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(txt, gc.DeepEquals, []byte(unsignedData[1:]))
+}
+
+func (s *decodeSuite) TestDecodeCheckInvalidSignature(c *gc.C) {
+	r := bytes.NewReader([]byte(invalidClearsignInput + signSuffix))
+	_, err := simplestreams.DecodeCheckSignature(r, testSigningKey)
+	c.Assert(err, gc.Not(gc.IsNil))
+	_, ok := err.(*simplestreams.NotPGPSignedError)
+	c.Assert(ok, jc.IsFalse)
+}
+
+func (s *decodeSuite) TestDecodeCheckMissingSignature(c *gc.C) {
+	r := bytes.NewReader([]byte("foo"))
+	_, err := simplestreams.DecodeCheckSignature(r, testSigningKey)
+	_, ok := err.(*simplestreams.NotPGPSignedError)
+	c.Assert(ok, jc.IsTrue)
+}
+
+func (s *decodeSuite) TestDecodeCheckMissingKey(c *gc.C) {
+	r := bytes.NewReader([]byte(signedData))
+	_, err := simplestreams.DecodeCheckSignature(r, "")
+	c.Assert(err, gc.ErrorMatches, "failed to parse public key: openpgp: invalid argument: no armored data found")
+}
+
+const (
+	testSigningKey = `-----BEGIN PGP PRIVATE KEY BLOCK-----
+Version: GnuPG v1.4.10 (GNU/Linux)
+
+lQHYBE2rFNoBBADFwqWQIW/DSqcB4yCQqnAFTJ27qS5AnB46ccAdw3u4Greeu3Bp
+idpoHdjULy7zSKlwR1EA873dO/k/e11Ml3dlAFUinWeejWaK2ugFP6JjiieSsrKn
+vWNicdCS4HTWn0X4sjl0ZiAygw6GNhqEQ3cpLeL0g8E9hnYzJKQ0LWJa0QARAQAB
+AAP/TB81EIo2VYNmTq0pK1ZXwUpxCrvAAIG3hwKjEzHcbQznsjNvPUihZ+NZQ6+X
+0HCfPAdPkGDCLCb6NavcSW+iNnLTrdDnSI6+3BbIONqWWdRDYJhqZCkqmG6zqSfL
+IdkJgCw94taUg5BWP/AAeQrhzjChvpMQTVKQL5mnuZbUCeMCAN5qrYMP2S9iKdnk
+VANIFj7656ARKt/nf4CBzxcpHTyB8+d2CtPDKCmlJP6vL8t58Jmih+kHJMvC0dzn
+gr5f5+sCAOOe5gt9e0am7AvQWhdbHVfJU0TQJx+m2OiCJAqGTB1nvtBLHdJnfdC9
+TnXXQ6ZXibqLyBies/xeY2sCKL5qtTMCAKnX9+9d/5yQxRyrQUHt1NYhaXZnJbHx
+q4ytu0eWz+5i68IYUSK69jJ1NWPM0T6SkqpB3KCAIv68VFm9PxqG1KmhSrQIVGVz
+dCBLZXmIuAQTAQIAIgUCTasU2gIbAwYLCQgHAwIGFQgCCQoLBBYCAwECHgECF4AA
+CgkQO9o98PRieSoLhgQAkLEZex02Qt7vGhZzMwuN0R22w3VwyYyjBx+fM3JFETy1
+ut4xcLJoJfIaF5ZS38UplgakHG0FQ+b49i8dMij0aZmDqGxrew1m4kBfjXw9B/v+
+eIqpODryb6cOSwyQFH0lQkXC040pjq9YqDsO5w0WYNXYKDnzRV0p4H1pweo2VDid
+AdgETasU2gEEAN46UPeWRqKHvA99arOxee38fBt2CI08iiWyI8T3J6ivtFGixSqV
+bRcPxYO/qLpVe5l84Nb3X71GfVXlc9hyv7CD6tcowL59hg1E/DC5ydI8K8iEpUmK
+/UnHdIY5h8/kqgGxkY/T/hgp5fRQgW1ZoZxLajVlMRZ8W4tFtT0DeA+JABEBAAEA
+A/0bE1jaaZKj6ndqcw86jd+QtD1SF+Cf21CWRNeLKnUds4FRRvclzTyUMuWPkUeX
+TaNNsUOFqBsf6QQ2oHUBBK4VCHffHCW4ZEX2cd6umz7mpHW6XzN4DECEzOVksXtc
+lUC1j4UB91DC/RNQqwX1IV2QLSwssVotPMPqhOi0ZLNY7wIA3n7DWKInxYZZ4K+6
+rQ+POsz6brEoRHwr8x6XlHenq1Oki855pSa1yXIARoTrSJkBtn5oI+f8AzrnN0BN
+oyeQAwIA/7E++3HDi5aweWrViiul9cd3rcsS0dEnksPhvS0ozCJiHsq/6GFmy7J8
+QSHZPteedBnZyNp5jR+H7cIfVN3KgwH/Skq4PsuPhDq5TKK6i8Pc1WW8MA6DXTdU
+nLkX7RGmMwjC0DBf7KWAlPjFaONAX3a8ndnz//fy1q7u2l9AZwrj1qa1iJ8EGAEC
+AAkFAk2rFNoCGwwACgkQO9o98PRieSo2/QP/WTzr4ioINVsvN1akKuekmEMI3LAp
+BfHwatufxxP1U+3Si/6YIk7kuPB9Hs+pRqCXzbvPRrI8NHZBmc8qIGthishdCYad
+AHcVnXjtxrULkQFGbGvhKURLvS9WnzD/m1K2zzwxzkPTzT9/Yf06O6Mal5AdugPL
+VrM0m72/jnpKo04=
+=zNCn
+-----END PGP PRIVATE KEY BLOCK-----
+`
+
+	signPrefix = `
+-----BEGIN PGP SIGNED MESSAGE-----
+Hash: SHA1
+`
+
+	signSuffix = `-----BEGIN PGP SIGNATURE-----
+Version: GnuPG v1.4.10 (GNU/Linux)
+
+iJwEAQECAAYFAk8kMuEACgkQO9o98PRieSpMsAQAhmY/vwmNpflrPgmfWsYhk5O8
+pjnBUzZwqTDoDeINjZEoPDSpQAHGhjFjgaDx/Gj4fAl0dM4D0wuUEBb6QOrwflog
+2A2k9kfSOMOtk0IH/H5VuFN1Mie9L/erYXjTQIptv9t9J7NoRBMU0QOOaFU0JaO9
+MyTpno24AjIAGb+mH1U=
+=hIJ6
+-----END PGP SIGNATURE-----
+`
+
+	unsignedData = `
+Hello world
+line 2
+`
+	signedData = signPrefix + unsignedData + signSuffix
+
+	invalidClearsignInput = `
+-----BEGIN PGP SIGNED MESSAGE-----
+Hash: SHA1
+
+Invalid
+`
+)

--- a/environs/simplestreams/export_test.go
+++ b/environs/simplestreams/export_test.go
@@ -1,4 +1,4 @@
-// Copyright 2013 Canonical Ltd.
+// Copyright 2013,2016 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 package simplestreams
@@ -22,3 +22,5 @@ func HasProduct(metadata IndexMetadata, prodIds []string) bool {
 func Filter(entries IndexMetadataSlice, match func(*IndexMetadata) bool) IndexMetadataSlice {
 	return entries.filter(match)
 }
+
+var FetchData = fetchData

--- a/environs/simplestreams/fetchdata_test.go
+++ b/environs/simplestreams/fetchdata_test.go
@@ -1,0 +1,144 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package simplestreams_test
+
+import (
+	"bytes"
+	"io"
+	"io/ioutil"
+
+	gitjujutesting "github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/environs/simplestreams"
+	"github.com/juju/juju/environs/simplestreams/testing"
+)
+
+type fetchDataSuite struct {
+	gitjujutesting.CleanupSuite
+
+	requireSigned bool
+	source        *testing.StubDataSource
+
+	readerData, expectedData string
+	expectedCalls            []string
+}
+
+var _ = gc.Suite(&fetchDataSuite{})
+
+func (s *fetchDataSuite) SetUpTest(c *gc.C) {
+	s.CleanupSuite.SetUpTest(c)
+	s.source = testing.NewStubDataSource()
+}
+
+func (s *fetchDataSuite) TestFetchSignedDataWithRequireSignedDataSourceWithoutPublicKey(c *gc.C) {
+	s.requireSigned = true
+	s.expectedCalls = []string{"Fetch", "PublicSigningKey"}
+	s.readerData = signedData
+	s.expectedData = unsignedData[1:]
+	s.setupDataSource("")
+
+	s.PatchValue(&simplestreams.SimplestreamsJujuPublicKey, testSigningKey)
+	// even though the data source does not specify public key,
+	// the code should try to figure out a public key to use.
+	// Bugs #1542127, #1542131
+	s.assertFetchData(c)
+}
+
+func (s *fetchDataSuite) TestFetchSignedDataWithRequireSignedDataSourceWithPublicKey(c *gc.C) {
+	s.requireSigned = true
+	s.expectedCalls = []string{"Fetch", "PublicSigningKey"}
+	s.readerData = signedData
+	s.expectedData = unsignedData[1:]
+	s.setupDataSource(testSigningKey)
+	s.assertFetchData(c)
+}
+
+func (s *fetchDataSuite) TestFetchSignedDataWithNotRequireSignedDataSourceWithPublicKey(c *gc.C) {
+	s.requireSigned = false
+	s.expectedCalls = []string{"Fetch"}
+	s.readerData = signedData
+	// Current implementation will return the full signed data
+	// without stripping signature prefix and suffix.
+	// In order to return strip signing information, we need to be able to detect if file
+	// contents are signed and act accordingly. We do not do this now, we hard-code "requireSigned".
+	s.expectedData = signedData
+	s.setupDataSource(testSigningKey)
+	s.assertFetchData(c)
+}
+
+func (s *fetchDataSuite) TestFetchSignedDataWithNotRequireSignedDataSourceWithoutPublicKey(c *gc.C) {
+	s.requireSigned = false
+	s.expectedCalls = []string{"Fetch"}
+	s.readerData = signedData
+	// Current implementation will return the full signed data
+	// without stripping signature prefix and suffix.
+	// In order to return strip signing information, we need to be able to detect if file
+	// contents are signed and act accordingly. We do not do this now, we hard-code "requireSigned".
+	s.expectedData = signedData
+	s.setupDataSource("")
+	s.assertFetchData(c)
+}
+
+func (s *fetchDataSuite) TestFetchUnsignedDataWithRequireSignedDataSourceWithoutPublicKey(c *gc.C) {
+	s.requireSigned = true
+	s.expectedCalls = []string{"Fetch", "PublicSigningKey", "Description"}
+	s.expectedData = unsignedData
+	s.readerData = unsignedData
+	s.setupDataSource("")
+	s.assertFetchDataFail(c, `cannot read data for source "" at URL this.path.doesnt.matter.for.test.either: no PGP signature embedded in plain text data`)
+}
+
+func (s *fetchDataSuite) TestFetchUnsignedDataWithRequireSignedDataSourceWithPublicKey(c *gc.C) {
+	s.requireSigned = true
+	s.expectedCalls = []string{"Fetch", "PublicSigningKey", "Description"}
+	s.expectedData = unsignedData
+	s.readerData = unsignedData
+	s.setupDataSource(testSigningKey)
+	s.assertFetchDataFail(c, `cannot read data for source "" at URL this.path.doesnt.matter.for.test.either: no PGP signature embedded in plain text data`)
+}
+
+func (s *fetchDataSuite) TestFetchUnsignedDataWithNotRequireSignedDataSourceWithPublicKey(c *gc.C) {
+	s.requireSigned = false
+	s.expectedCalls = []string{"Fetch"}
+	s.expectedData = unsignedData
+	s.readerData = unsignedData
+	s.setupDataSource(testSigningKey)
+	s.assertFetchData(c)
+}
+
+func (s *fetchDataSuite) TestFetchUnsignedDataWithNotRequireSignedDataSourceWithoutPublicKey(c *gc.C) {
+	s.requireSigned = false
+	s.expectedCalls = []string{"Fetch"}
+	s.readerData = unsignedData
+	s.expectedData = unsignedData
+	s.setupDataSource("")
+	s.assertFetchData(c)
+}
+
+func (s *fetchDataSuite) setupDataSource(key string) {
+	s.source = testing.NewStubDataSource()
+	s.source.FetchFunc = func(path string) (io.ReadCloser, string, error) {
+		r := bytes.NewReader([]byte(s.readerData))
+		return ioutil.NopCloser(r), path, nil
+	}
+	s.source.PublicSigningKeyFunc = func() string {
+		return key
+	}
+}
+
+func (s *fetchDataSuite) assertFetchData(c *gc.C) {
+	data, _, err := simplestreams.FetchData(s.source, "this.path.doesnt.matter.for.test.either", s.requireSigned)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert([]byte(s.expectedData), gc.DeepEquals, data)
+	s.source.CheckCallNames(c, s.expectedCalls...)
+}
+
+func (s *fetchDataSuite) assertFetchDataFail(c *gc.C, msg string) {
+	data, _, err := simplestreams.FetchData(s.source, "this.path.doesnt.matter.for.test.either", s.requireSigned)
+	c.Assert(err, gc.ErrorMatches, msg)
+	c.Assert(data, gc.IsNil)
+	s.source.CheckCallNames(c, s.expectedCalls...)
+}

--- a/environs/simplestreams/simplestreams.go
+++ b/environs/simplestreams/simplestreams.go
@@ -478,10 +478,13 @@ func fetchData(source DataSource, path string, requireSigned bool) (data []byte,
 			// These data sources may also not provide public key.
 			// However, they may still contain signed data.
 			// Since we will always try to read signed data first,
-			// we want to be able to try to read this signed data with public key known to Juju.
+			// we want to be able to try to read this signed data
+			// with public key known to Juju.
 			//
-			// When public key is not provided by the data source but signed data has been supplied,
-			// let's use user supplied public key or fall back to other-juju-known public key.
+			// When public key is not provided by the data source
+			// but signed data has been supplied,
+			// let's use user supplied public key or
+			// fall back to other-juju-known public key.
 			// Bugs #1542127, #1542131
 			publicKey, _ = UserPublicSigningKey()
 			if publicKey == "" {

--- a/environs/simplestreams/simplestreams.go
+++ b/environs/simplestreams/simplestreams.go
@@ -370,38 +370,14 @@ type GetMetadataParams struct {
 // If onlySigned is false and no signed metadata is found in a source, the source is used to look for unsigned metadata.
 // Each source is tried in turn until at least one signed (or unsigned) match is found.
 func GetMetadata(sources []DataSource, params GetMetadataParams) (items []interface{}, resolveInfo *ResolveInfo, err error) {
-	fmt.Printf("\n IN GETMETADATA %d \n", countGetMetadata)
-
 	for _, source := range sources {
-		logger.Tracef("searching for metadata in datasource %q", source.Description())
-		fmt.Printf("searching for metadata in datasource %q", source.Description())
+		logger.Tracef("searching for signed metadata in datasource %q", source.Description())
 		items, resolveInfo, err = getMaybeSignedMetadata(source, params, true)
-		fmt.Printf("\n ITEMS (%d)\n INFO %v \n ERR %v\n\n", len(items), resolveInfo, err)
 		// If no items are found using signed metadata, check unsigned.
 		if err != nil && len(items) == 0 && !source.RequireSigned() {
-			fmt.Printf("\n")
+			logger.Tracef("falling back to search for unsigned metadata in datasource %q", source.Description())
 			items, resolveInfo, err = getMaybeSignedMetadata(source, params, false)
-			fmt.Printf("\nFELL THRU\n ITEMS (%d)\n INFO %v \n ERR %v\n\n", len(items), resolveInfo, err)
 		}
-
-		//		if source.RequireSigned() {
-		//			if err != nil {
-		//				return nil, resolveInfo, errors.Annotatef(err, "datasource %q only valid for signed data", source.Description())
-		//			}
-		//			// if err == nil
-		//			if len(items) == 0 {
-		//				// did not find any items in this data source, skip to next one or error?
-		//				continue
-		//			}
-		//			return items, resolveInfo, nil
-		//		} else {
-		//			if len(items) > 0 {
-		//				return items, resolveInfo, nil
-		//			}
-		//			items, resolveInfo, err = getMaybeSignedMetadata(source, params, false)
-		//			fmt.Printf("\nFELL THRU\n ITEMS (%d)\n INFO %v \n ERR %v\n\n", len(items), resolveInfo, err)
-		//		}
-
 		if err == nil {
 			break
 		}
@@ -412,9 +388,6 @@ func GetMetadata(sources []DataSource, params GetMetadataParams) (items []interf
 	}
 	return items, resolveInfo, err
 }
-
-var countGetMetadata = 1
-var countMe = 1
 
 // getMaybeSignedMetadata returns metadata records matching the specified constraint in params.
 func getMaybeSignedMetadata(source DataSource, params GetMetadataParams, signed bool) ([]interface{}, *ResolveInfo, error) {
@@ -433,19 +406,18 @@ func getMaybeSignedMetadata(source DataSource, params GetMetadataParams, signed 
 	resolveInfo.Signed = signed
 	indexPath := makeIndexPath(defaultIndexPath)
 
-	fmt.Printf("\n INDEXPATH %d %v \n", countMe, indexPath)
-
+	logger.Tracef("looking for data index using path %s", indexPath)
 	mirrorsPath := fmt.Sprintf(defaultMirrorsPath, params.StreamsVersion)
 	cons := params.LookupConstraint
 
 	indexRef, indexURL, err := fetchIndex(
 		source, indexPath, mirrorsPath, cons.Params().CloudSpec, signed, params.ValueParams,
 	)
-	fmt.Printf("\n INDEXURL %d %v \n", countMe, indexURL)
+	logger.Tracef("looking for data index using URL %s", indexURL)
 	if errors.IsNotFound(err) || errors.IsUnauthorized(err) {
 		legacyIndexPath := makeIndexPath(defaultLegacyIndexPath)
-		fmt.Printf("%s not found (actual error = %v), trying legacy index path: %s", indexPath, err, legacyIndexPath)
-		logger.Tracef("%s not found, trying legacy index path: %s", indexPath, legacyIndexPath)
+		logger.Errorf("%s not accessed, actual error: %v", indexPath, err)
+		logger.Tracef("%s not accessed, trying legacy index path: %s", indexPath, legacyIndexPath)
 		indexPath = legacyIndexPath
 		indexRef, indexURL, err = fetchIndex(
 			source, indexPath, mirrorsPath, cons.Params().CloudSpec, signed, params.ValueParams,
@@ -458,10 +430,7 @@ func getMaybeSignedMetadata(source DataSource, params GetMetadataParams, signed 
 		}
 		return nil, resolveInfo, err
 	}
-	fmt.Printf("\n RESOLVE INFO %d %v \n", countMe, resolveInfo)
-
 	logger.Debugf("read metadata index at %q", indexURL)
-	countMe++
 	items, err := indexRef.getLatestMetadataWithFormat(cons, ProductFormat, signed)
 	if err != nil {
 		if errors.IsNotFound(err) {
@@ -503,7 +472,20 @@ func fetchData(source DataSource, path string, requireSigned bool) (data []byte,
 	}
 	defer rc.Close()
 	if requireSigned {
-		data, err = DecodeCheckSignature(rc, source.PublicSigningKey())
+		publicKey := source.PublicSigningKey()
+		if publicKey == "" {
+			// Data sources may not require signing. These data source may not provide public key.
+			// However, these data source may still contain signed data
+			// Since we will always try to read signed data first, we want to be able
+			// to try to read this signed data with public key known to Juju.
+			// Bugs #1542127, #1542131
+			publicKey, _ = UserPublicSigningKey()
+			if publicKey == "" {
+				// TODO (anastasiamac 2016-02-16) Do I need to consider imagemetadata.SimplestreamsImagesPublicKey here as well?
+				publicKey = SimplestreamsJujuPublicKey
+			}
+		}
+		data, err = DecodeCheckSignature(rc, publicKey)
 	} else {
 		data, err = ioutil.ReadAll(rc)
 	}

--- a/environs/simplestreams/simplestreams.go
+++ b/environs/simplestreams/simplestreams.go
@@ -474,10 +474,14 @@ func fetchData(source DataSource, path string, requireSigned bool) (data []byte,
 	if requireSigned {
 		publicKey := source.PublicSigningKey()
 		if publicKey == "" {
-			// Data sources may not require signing. These data source may not provide public key.
-			// However, these data source may still contain signed data
-			// Since we will always try to read signed data first, we want to be able
-			// to try to read this signed data with public key known to Juju.
+			// Data sources may not require to contain signed data.
+			// These data sources may also not provide public key.
+			// However, they may still contain signed data.
+			// Since we will always try to read signed data first,
+			// we want to be able to try to read this signed data with public key known to Juju.
+			//
+			// When public key is not provided by the data source but signed data has been supplied,
+			// let's use user supplied public key or fall back to other-juju-known public key.
 			// Bugs #1542127, #1542131
 			publicKey, _ = UserPublicSigningKey()
 			if publicKey == "" {

--- a/environs/simplestreams/simplestreams_test.go
+++ b/environs/simplestreams/simplestreams_test.go
@@ -4,7 +4,6 @@
 package simplestreams_test
 
 import (
-	"bytes"
 	"strings"
 	"testing"
 
@@ -12,14 +11,12 @@ import (
 	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
 
-	"fmt"
 	"github.com/juju/juju/environs/simplestreams"
 	sstesting "github.com/juju/juju/environs/simplestreams/testing"
 )
 
 func Test(t *testing.T) {
 	registerSimpleStreamsTests()
-	gc.Suite(&signingSuite{})
 	gc.Suite(&jsonSuite{})
 	gc.TestingT(t)
 }
@@ -321,156 +318,11 @@ func (*simplestreamsSuite) TestFilterCombinesMatchesAndNonMatches(c *gc.C) {
 type countingSource struct {
 	simplestreams.DataSource
 	count int
-
-	urls []string
 }
 
 func (s *countingSource) URL(path string) (string, error) {
 	s.count++
-	if len(s.urls) == 0 {
-		s.urls = []string{}
-	}
-	url, err := s.DataSource.URL(path)
-	s.urls = append(s.urls, url)
-	return url, err
-}
-
-func (s *simplestreamsSuite) TestGetMetadataNoVerifyNotSigned(c *gc.C) {
-	source := &countingSource{
-		DataSource: simplestreams.NewURLDataSource(
-			"test",
-			"test:/daily",
-			utils.NoVerifySSLHostnames,
-			simplestreams.DEFAULT_CLOUD_DATA,
-			false,
-		),
-	}
-	sources := []simplestreams.DataSource{source, source, source}
-	constraint := sstesting.NewTestConstraint(simplestreams.LookupParams{
-		CloudSpec: simplestreams.CloudSpec{
-			Region:   "us-east-1",
-			Endpoint: "https://ec2.us-east-1.amazonaws.com",
-		},
-		Series: []string{"precise"},
-		Arches: []string{"not-a-real-arch"}, // never matches
-	})
-	params := simplestreams.GetMetadataParams{
-		StreamsVersion:   s.StreamsVersion,
-		LookupConstraint: constraint,
-		ValueParams:      simplestreams.ValueParams{DataType: "image-ids"},
-	}
-
-	items, resolveInfo, err := simplestreams.GetMetadata(sources, params)
-	fmt.Printf("\nLOGS \n %v\n\n", c.GetTestLog())
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(items, gc.HasLen, 0)
-	c.Assert(resolveInfo, gc.DeepEquals, &simplestreams.ResolveInfo{
-		Source:    "test",
-		Signed:    false,
-		IndexURL:  "test:/daily/streams/v1/index.json",
-		MirrorURL: "",
-	})
-
-	// There should be 4 calls to each data-source:
-	// one for .sjson, one for .json, repeated for legacy vs new index files.
-	c.Assert(source.count, gc.Equals, 4*len(sources))
-
-	fmt.Println("\n COUNTED URLS\n")
-	for i, url := range source.urls {
-		fmt.Printf("\n %d %v\n", i, url)
-	}
-}
-
-func (s *simplestreamsSuite) TestGetMetadataNoVerifySigned(c *gc.C) {
-	source := &countingSource{
-		DataSource: simplestreams.NewURLDataSource(
-			"test",
-			"test:/daily",
-			utils.NoVerifySSLHostnames,
-			simplestreams.DEFAULT_CLOUD_DATA,
-			true,
-		),
-	}
-	sources := []simplestreams.DataSource{source, source, source}
-	constraint := sstesting.NewTestConstraint(simplestreams.LookupParams{
-		CloudSpec: simplestreams.CloudSpec{
-			Region:   "us-east-1",
-			Endpoint: "https://ec2.us-east-1.amazonaws.com",
-		},
-		Series: []string{"precise"},
-		Arches: []string{"not-a-real-arch"}, // never matches
-	})
-	params := simplestreams.GetMetadataParams{
-		StreamsVersion:   s.StreamsVersion,
-		LookupConstraint: constraint,
-		ValueParams:      simplestreams.ValueParams{DataType: "image-ids"},
-	}
-
-	items, resolveInfo, err := simplestreams.GetMetadata(sources, params)
-	fmt.Printf("\nLOGS \n %v\n\n", c.GetTestLog())
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(items, gc.HasLen, 0)
-	c.Assert(resolveInfo, gc.DeepEquals, &simplestreams.ResolveInfo{
-		Source:    "test",
-		Signed:    false,
-		IndexURL:  "test:/daily/streams/v1/index.json",
-		MirrorURL: "",
-	})
-
-	// There should be 4 calls to each data-source:
-	// one for .sjson, one for .json, repeated for legacy vs new index files.
-	c.Assert(source.count, gc.Equals, 4*len(sources))
-
-	fmt.Println("\n COUNTED URLS\n")
-	for i, url := range source.urls {
-		fmt.Printf("\n %d %v\n", i, url)
-	}
-}
-
-func (s *simplestreamsSuite) TestGetMetadataVerifySigned(c *gc.C) {
-	source := &countingSource{
-		DataSource: simplestreams.NewURLDataSource(
-			"test",
-			"test:/daily",
-			utils.VerifySSLHostnames,
-			simplestreams.DEFAULT_CLOUD_DATA,
-			true,
-		),
-	}
-	sources := []simplestreams.DataSource{source, source, source}
-	constraint := sstesting.NewTestConstraint(simplestreams.LookupParams{
-		CloudSpec: simplestreams.CloudSpec{
-			Region:   "us-east-1",
-			Endpoint: "https://ec2.us-east-1.amazonaws.com",
-		},
-		Series: []string{"precise"},
-		Arches: []string{"not-a-real-arch"}, // never matches
-	})
-	params := simplestreams.GetMetadataParams{
-		StreamsVersion:   s.StreamsVersion,
-		LookupConstraint: constraint,
-		ValueParams:      simplestreams.ValueParams{DataType: "image-ids"},
-	}
-
-	items, resolveInfo, err := simplestreams.GetMetadata(sources, params)
-	fmt.Printf("\nLOGS \n %v\n\n", c.GetTestLog())
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(items, gc.HasLen, 0)
-	c.Assert(resolveInfo, gc.DeepEquals, &simplestreams.ResolveInfo{
-		Source:    "test",
-		Signed:    false,
-		IndexURL:  "test:/daily/streams/v1/index.json",
-		MirrorURL: "",
-	})
-
-	// There should be 4 calls to each data-source:
-	// one for .sjson, one for .json, repeated for legacy vs new index files.
-	c.Assert(source.count, gc.Equals, 4*len(sources))
-
-	fmt.Println("\n COUNTED URLS\n")
-	for i, url := range source.urls {
-		fmt.Printf("\n %d %v\n", i, url)
-	}
+	return s.DataSource.URL(path)
 }
 
 func (s *simplestreamsSuite) TestGetMetadataNoMatching(c *gc.C) {
@@ -511,10 +363,6 @@ func (s *simplestreamsSuite) TestGetMetadataNoMatching(c *gc.C) {
 	// There should be 4 calls to each data-source:
 	// one for .sjson, one for .json, repeated for legacy vs new index files.
 	c.Assert(source.count, gc.Equals, 4*len(sources))
-	fmt.Println("\n COUNTED URLS\n")
-	for i, url := range source.urls {
-		fmt.Printf("\n %d %v\n", i, url)
-	}
 }
 
 func (s *simplestreamsSuite) TestMetadataCatalog(c *gc.C) {
@@ -635,89 +483,4 @@ func (s *simplestreamsSuite) TestGetMirrorMetadata(c *gc.C) {
 		c.Check(mirrorURL, gc.Equals, t.mirrorURL)
 		c.Check(indexRef.MirroredProductsPath, gc.Equals, t.path)
 	}
-}
-
-var testSigningKey = `-----BEGIN PGP PRIVATE KEY BLOCK-----
-Version: GnuPG v1.4.10 (GNU/Linux)
-
-lQHYBE2rFNoBBADFwqWQIW/DSqcB4yCQqnAFTJ27qS5AnB46ccAdw3u4Greeu3Bp
-idpoHdjULy7zSKlwR1EA873dO/k/e11Ml3dlAFUinWeejWaK2ugFP6JjiieSsrKn
-vWNicdCS4HTWn0X4sjl0ZiAygw6GNhqEQ3cpLeL0g8E9hnYzJKQ0LWJa0QARAQAB
-AAP/TB81EIo2VYNmTq0pK1ZXwUpxCrvAAIG3hwKjEzHcbQznsjNvPUihZ+NZQ6+X
-0HCfPAdPkGDCLCb6NavcSW+iNnLTrdDnSI6+3BbIONqWWdRDYJhqZCkqmG6zqSfL
-IdkJgCw94taUg5BWP/AAeQrhzjChvpMQTVKQL5mnuZbUCeMCAN5qrYMP2S9iKdnk
-VANIFj7656ARKt/nf4CBzxcpHTyB8+d2CtPDKCmlJP6vL8t58Jmih+kHJMvC0dzn
-gr5f5+sCAOOe5gt9e0am7AvQWhdbHVfJU0TQJx+m2OiCJAqGTB1nvtBLHdJnfdC9
-TnXXQ6ZXibqLyBies/xeY2sCKL5qtTMCAKnX9+9d/5yQxRyrQUHt1NYhaXZnJbHx
-q4ytu0eWz+5i68IYUSK69jJ1NWPM0T6SkqpB3KCAIv68VFm9PxqG1KmhSrQIVGVz
-dCBLZXmIuAQTAQIAIgUCTasU2gIbAwYLCQgHAwIGFQgCCQoLBBYCAwECHgECF4AA
-CgkQO9o98PRieSoLhgQAkLEZex02Qt7vGhZzMwuN0R22w3VwyYyjBx+fM3JFETy1
-ut4xcLJoJfIaF5ZS38UplgakHG0FQ+b49i8dMij0aZmDqGxrew1m4kBfjXw9B/v+
-eIqpODryb6cOSwyQFH0lQkXC040pjq9YqDsO5w0WYNXYKDnzRV0p4H1pweo2VDid
-AdgETasU2gEEAN46UPeWRqKHvA99arOxee38fBt2CI08iiWyI8T3J6ivtFGixSqV
-bRcPxYO/qLpVe5l84Nb3X71GfVXlc9hyv7CD6tcowL59hg1E/DC5ydI8K8iEpUmK
-/UnHdIY5h8/kqgGxkY/T/hgp5fRQgW1ZoZxLajVlMRZ8W4tFtT0DeA+JABEBAAEA
-A/0bE1jaaZKj6ndqcw86jd+QtD1SF+Cf21CWRNeLKnUds4FRRvclzTyUMuWPkUeX
-TaNNsUOFqBsf6QQ2oHUBBK4VCHffHCW4ZEX2cd6umz7mpHW6XzN4DECEzOVksXtc
-lUC1j4UB91DC/RNQqwX1IV2QLSwssVotPMPqhOi0ZLNY7wIA3n7DWKInxYZZ4K+6
-rQ+POsz6brEoRHwr8x6XlHenq1Oki855pSa1yXIARoTrSJkBtn5oI+f8AzrnN0BN
-oyeQAwIA/7E++3HDi5aweWrViiul9cd3rcsS0dEnksPhvS0ozCJiHsq/6GFmy7J8
-QSHZPteedBnZyNp5jR+H7cIfVN3KgwH/Skq4PsuPhDq5TKK6i8Pc1WW8MA6DXTdU
-nLkX7RGmMwjC0DBf7KWAlPjFaONAX3a8ndnz//fy1q7u2l9AZwrj1qa1iJ8EGAEC
-AAkFAk2rFNoCGwwACgkQO9o98PRieSo2/QP/WTzr4ioINVsvN1akKuekmEMI3LAp
-BfHwatufxxP1U+3Si/6YIk7kuPB9Hs+pRqCXzbvPRrI8NHZBmc8qIGthishdCYad
-AHcVnXjtxrULkQFGbGvhKURLvS9WnzD/m1K2zzwxzkPTzT9/Yf06O6Mal5AdugPL
-VrM0m72/jnpKo04=
-=zNCn
------END PGP PRIVATE KEY BLOCK-----
-`
-
-var validClearsignInput = `
------BEGIN PGP SIGNED MESSAGE-----
-Hash: SHA1
-
-Hello world
-line 2
-`
-
-var invalidClearsignInput = `
------BEGIN PGP SIGNED MESSAGE-----
-Hash: SHA1
-
-Invalid
-`
-
-var testSig = `-----BEGIN PGP SIGNATURE-----
-Version: GnuPG v1.4.10 (GNU/Linux)
-
-iJwEAQECAAYFAk8kMuEACgkQO9o98PRieSpMsAQAhmY/vwmNpflrPgmfWsYhk5O8
-pjnBUzZwqTDoDeINjZEoPDSpQAHGhjFjgaDx/Gj4fAl0dM4D0wuUEBb6QOrwflog
-2A2k9kfSOMOtk0IH/H5VuFN1Mie9L/erYXjTQIptv9t9J7NoRBMU0QOOaFU0JaO9
-MyTpno24AjIAGb+mH1U=
-=hIJ6
------END PGP SIGNATURE-----
-`
-
-type signingSuite struct{}
-
-func (s *signingSuite) TestDecodeCheckValidSignature(c *gc.C) {
-	r := bytes.NewReader([]byte(validClearsignInput + testSig))
-	txt, err := simplestreams.DecodeCheckSignature(r, testSigningKey)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(txt, gc.DeepEquals, []byte("Hello world\nline 2\n"))
-}
-
-func (s *signingSuite) TestDecodeCheckInvalidSignature(c *gc.C) {
-	r := bytes.NewReader([]byte(invalidClearsignInput + testSig))
-	_, err := simplestreams.DecodeCheckSignature(r, testSigningKey)
-	c.Assert(err, gc.Not(gc.IsNil))
-	_, ok := err.(*simplestreams.NotPGPSignedError)
-	c.Assert(ok, jc.IsFalse)
-}
-
-func (s *signingSuite) TestDecodeCheckMissingSignature(c *gc.C) {
-	r := bytes.NewReader([]byte("foo"))
-	_, err := simplestreams.DecodeCheckSignature(r, testSigningKey)
-	_, ok := err.(*simplestreams.NotPGPSignedError)
-	c.Assert(ok, jc.IsTrue)
 }

--- a/environs/simplestreams/testing/stub.go
+++ b/environs/simplestreams/testing/stub.go
@@ -24,25 +24,25 @@ type StubDataSource struct {
 func NewStubDataSource() *StubDataSource {
 	result := &StubDataSource{
 		Stub: &testing.Stub{},
-	}
-	result.DescriptionFunc = func() string {
-		return ""
+		DescriptionFunc: func() string {
+			return ""
+		},
+		PublicSigningKeyFunc: func() string {
+			return ""
+		},
+		SetAllowRetryFunc: func(allow bool) {},
+		PriorityFunc: func() int {
+			return 0
+		},
+		RequireSignedFunc: func() bool {
+			return false
+		},
 	}
 	result.FetchFunc = func(path string) (io.ReadCloser, string, error) {
 		return nil, "", result.Stub.NextErr()
 	}
 	result.URLFunc = func(path string) (string, error) {
 		return "", result.Stub.NextErr()
-	}
-	result.PublicSigningKeyFunc = func() string {
-		return ""
-	}
-	result.SetAllowRetryFunc = func(allow bool) {}
-	result.PriorityFunc = func() int {
-		return 0
-	}
-	result.RequireSignedFunc = func() bool {
-		return false
 	}
 	return result
 }

--- a/environs/simplestreams/testing/stub.go
+++ b/environs/simplestreams/testing/stub.go
@@ -10,7 +10,7 @@ import (
 )
 
 type StubDataSource struct {
-	*testing.Stub
+	testing.Stub
 
 	DescriptionFunc      func() string
 	FetchFunc            func(path string) (io.ReadCloser, string, error)
@@ -23,7 +23,7 @@ type StubDataSource struct {
 
 func NewStubDataSource() *StubDataSource {
 	result := &StubDataSource{
-		Stub: &testing.Stub{},
+		Stub: testing.Stub{},
 		DescriptionFunc: func() string {
 			return ""
 		},

--- a/environs/simplestreams/testing/stub.go
+++ b/environs/simplestreams/testing/stub.go
@@ -1,0 +1,90 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package testing
+
+import (
+	"io"
+
+	"github.com/juju/testing"
+)
+
+type StubDataSource struct {
+	*testing.Stub
+
+	DescriptionFunc      func() string
+	FetchFunc            func(path string) (io.ReadCloser, string, error)
+	URLFunc              func(path string) (string, error)
+	PublicSigningKeyFunc func() string
+	SetAllowRetryFunc    func(allow bool)
+	PriorityFunc         func() int
+	RequireSignedFunc    func() bool
+}
+
+func NewStubDataSource() *StubDataSource {
+	result := &StubDataSource{
+		Stub: &testing.Stub{},
+	}
+	result.DescriptionFunc = func() string {
+		return ""
+	}
+	result.FetchFunc = func(path string) (io.ReadCloser, string, error) {
+		return nil, "", result.Stub.NextErr()
+	}
+	result.URLFunc = func(path string) (string, error) {
+		return "", result.Stub.NextErr()
+	}
+	result.PublicSigningKeyFunc = func() string {
+		return ""
+	}
+	result.SetAllowRetryFunc = func(allow bool) {}
+	result.PriorityFunc = func() int {
+		return 0
+	}
+	result.RequireSignedFunc = func() bool {
+		return false
+	}
+	return result
+}
+
+// Description implements simplestreams.DataSource.
+func (s *StubDataSource) Description() string {
+	s.MethodCall(s, "Description")
+	return s.DescriptionFunc()
+}
+
+// Description implements simplestreams.DataSource.
+func (s *StubDataSource) Fetch(path string) (io.ReadCloser, string, error) {
+	s.MethodCall(s, "Fetch", path)
+	return s.FetchFunc(path)
+}
+
+// Description implements simplestreams.DataSource.
+func (s *StubDataSource) URL(path string) (string, error) {
+	s.MethodCall(s, "URL", path)
+	return s.URLFunc(path)
+}
+
+// Description implements simplestreams.DataSource.
+func (s *StubDataSource) PublicSigningKey() string {
+	s.MethodCall(s, "PublicSigningKey")
+	return s.PublicSigningKeyFunc()
+}
+
+// Description implements simplestreams.DataSource.
+func (s *StubDataSource) SetAllowRetry(allow bool) {
+	s.MethodCall(s, "SetAllowRetry", allow)
+	s.SetAllowRetryFunc(allow)
+}
+
+// Description implements simplestreams.DataSource.
+func (s *StubDataSource) Priority() int {
+	s.MethodCall(s, "Priority")
+	return s.PriorityFunc()
+}
+
+// Description implements simplestreams.DataSource.
+func (s *StubDataSource) RequireSigned() bool {
+	s.MethodCall(s, "RequireSigned")
+	return s.RequireSignedFunc()
+}

--- a/environs/simplestreams/testing/stub.go
+++ b/environs/simplestreams/testing/stub.go
@@ -23,7 +23,6 @@ type StubDataSource struct {
 
 func NewStubDataSource() *StubDataSource {
 	result := &StubDataSource{
-		Stub: testing.Stub{},
 		DescriptionFunc: func() string {
 			return ""
 		},

--- a/environs/simplestreams/testing/testing.go
+++ b/environs/simplestreams/testing/testing.go
@@ -598,6 +598,12 @@ type SourceDetails struct {
 }
 
 func AssertExpectedSources(c *gc.C, obtained []simplestreams.DataSource, dsDetails []SourceDetails) {
+	// Some data sources do not require to contain signed data.
+	// However, they may still contain it.
+	// Since we will always try to read signed data first,
+	// we want to be able to try to read this signed data
+	// with a public key. Check keys are provided where needed.
+	// Bugs #1542127, #1542131
 	for i, source := range obtained {
 		url, err := source.URL("")
 		c.Assert(err, jc.ErrorIsNil)

--- a/environs/simplestreams/testing/testing.go
+++ b/environs/simplestreams/testing/testing.go
@@ -591,14 +591,21 @@ func SignMetadata(fileName string, fileData []byte) (string, []byte, error) {
 	return signString(fileName), signedBytes, nil
 }
 
-func AssertExpectedSources(c *gc.C, obtained []simplestreams.DataSource, baseURLs []string) {
-	var obtainedURLs = make([]string, len(baseURLs))
+// SourceDetails stored some details that need to be checked about data source.
+type SourceDetails struct {
+	URL string
+	Key string
+}
+
+func AssertExpectedSources(c *gc.C, obtained []simplestreams.DataSource, dsDetails []SourceDetails) {
 	for i, source := range obtained {
 		url, err := source.URL("")
 		c.Assert(err, jc.ErrorIsNil)
-		obtainedURLs[i] = url
+		expected := dsDetails[i]
+		c.Assert(url, gc.DeepEquals, expected.URL)
+		c.Assert(source.PublicSigningKey(), gc.DeepEquals, expected.Key)
 	}
-	c.Assert(obtainedURLs, gc.DeepEquals, baseURLs)
+	c.Assert(obtained, gc.HasLen, len(dsDetails))
 }
 
 type LocalLiveSimplestreamsSuite struct {

--- a/environs/sync/export_test.go
+++ b/environs/sync/export_test.go
@@ -4,5 +4,6 @@
 package sync
 
 var (
-	SyncBuiltTools = syncBuiltTools
+	SyncBuiltTools         = syncBuiltTools
+	SelectSourceDatasource = selectSourceDatasource
 )

--- a/environs/sync/sync.go
+++ b/environs/sync/sync.go
@@ -159,7 +159,14 @@ func selectSourceDatasource(syncContext *SyncContext) (simplestreams.DataSource,
 		return nil, err
 	}
 	logger.Infof("using sync tools source: %v", sourceURL)
-	return simplestreams.NewURLDataSource("sync tools source", sourceURL, utils.VerifySSLHostnames, simplestreams.CUSTOM_CLOUD_DATA, false), nil
+
+	// This data source does not require to contain signed data.
+	// However, it may still contain it.
+	// Since we will always try to read signed data first,
+	// we want to be able to try to read this signed data
+	// with public key with Juju-known public key for tools.
+	// Bugs #1542127, #1542131
+	return simplestreams.NewURLSignedDataSource("sync tools source", sourceURL, simplestreams.SimplestreamsJujuPublicKey, utils.VerifySSLHostnames, simplestreams.CUSTOM_CLOUD_DATA, false), nil
 }
 
 // copyTools copies a set of tools from the source to the target.

--- a/environs/sync/sync.go
+++ b/environs/sync/sync.go
@@ -159,13 +159,6 @@ func selectSourceDatasource(syncContext *SyncContext) (simplestreams.DataSource,
 		return nil, err
 	}
 	logger.Infof("using sync tools source: %v", sourceURL)
-
-	// This data source does not require to contain signed data.
-	// However, it may still contain it.
-	// Since we will always try to read signed data first,
-	// we want to be able to try to read this signed data
-	// with public key with Juju-known public key for tools.
-	// Bugs #1542127, #1542131
 	return simplestreams.NewURLSignedDataSource("sync tools source", sourceURL, simplestreams.SimplestreamsJujuPublicKey, utils.VerifySSLHostnames, simplestreams.CUSTOM_CLOUD_DATA, false), nil
 }
 

--- a/environs/sync/sync_test.go
+++ b/environs/sync/sync_test.go
@@ -169,6 +169,13 @@ func (s *syncSuite) TestSyncing(c *gc.C) {
 
 			ds, err := sync.SelectSourceDatasource(test.ctx)
 			c.Assert(err, jc.ErrorIsNil)
+
+			// This data source does not require to contain signed data.
+			// However, it may still contain it.
+			// Since we will always try to read signed data first,
+			// we want to be able to try to read this signed data
+			// with public key with Juju-known public key for tools.
+			// Bugs #1542127, #1542131
 			c.Assert(ds.PublicSigningKey(), gc.Not(gc.Equals), "")
 
 			var uploaded []version.Binary

--- a/environs/sync/sync_test.go
+++ b/environs/sync/sync_test.go
@@ -167,6 +167,10 @@ func (s *syncSuite) TestSyncing(c *gc.C) {
 			err := sync.SyncTools(test.ctx)
 			c.Assert(err, jc.ErrorIsNil)
 
+			ds, err := sync.SelectSourceDatasource(test.ctx)
+			c.Assert(err, jc.ErrorIsNil)
+			c.Assert(ds.PublicSigningKey(), gc.Not(gc.Equals), "")
+
 			var uploaded []version.Binary
 			for v := range uploader.uploaded {
 				uploaded = append(uploaded, v)

--- a/environs/tools/urls.go
+++ b/environs/tools/urls.go
@@ -76,7 +76,14 @@ func GetMetadataSources(env environs.Environ) ([]simplestreams.DataSource, error
 		if !config.SSLHostnameVerification() {
 			verify = utils.NoVerifySSLHostnames
 		}
-		sources = append(sources, simplestreams.NewURLDataSource(conf.AgentMetadataURLKey, userURL, verify, simplestreams.SPECIFIC_CLOUD_DATA, false))
+
+		// This data source does not require to contain signed data.
+		// However, it may still contain it.
+		// Since we will always try to read signed data first,
+		// we want to be able to try to read this signed data
+		// with public key with Juju-known public key for tools.
+		// Bugs #1542127, #1542131
+		sources = append(sources, simplestreams.NewURLSignedDataSource(conf.AgentMetadataURLKey, userURL, simplestreams.SimplestreamsJujuPublicKey, verify, simplestreams.SPECIFIC_CLOUD_DATA, false))
 	}
 
 	envDataSources, err := environmentDataSources(env)

--- a/environs/tools/urls.go
+++ b/environs/tools/urls.go
@@ -76,13 +76,6 @@ func GetMetadataSources(env environs.Environ) ([]simplestreams.DataSource, error
 		if !config.SSLHostnameVerification() {
 			verify = utils.NoVerifySSLHostnames
 		}
-
-		// This data source does not require to contain signed data.
-		// However, it may still contain it.
-		// Since we will always try to read signed data first,
-		// we want to be able to try to read this signed data
-		// with public key with Juju-known public key for tools.
-		// Bugs #1542127, #1542131
 		sources = append(sources, simplestreams.NewURLSignedDataSource(conf.AgentMetadataURLKey, userURL, simplestreams.SimplestreamsJujuPublicKey, verify, simplestreams.SPECIFIC_CLOUD_DATA, false))
 	}
 

--- a/environs/tools/urls_test.go
+++ b/environs/tools/urls_test.go
@@ -54,15 +54,17 @@ func (s *URLsSuite) TestToolsURLsNoConfigURL(c *gc.C) {
 	env := s.env(c, "")
 	sources, err := tools.GetMetadataSources(env)
 	c.Assert(err, jc.ErrorIsNil)
-	sstesting.AssertExpectedSources(c, sources, []string{"https://streams.canonical.com/juju/tools/"})
+	sstesting.AssertExpectedSources(c, sources, []sstesting.SourceDetails{{"https://streams.canonical.com/juju/tools/", simplestreams.SimplestreamsJujuPublicKey}})
 }
 
 func (s *URLsSuite) TestToolsSources(c *gc.C) {
 	env := s.env(c, "config-tools-metadata-url")
 	sources, err := tools.GetMetadataSources(env)
 	c.Assert(err, jc.ErrorIsNil)
-	sstesting.AssertExpectedSources(c, sources, []string{
-		"config-tools-metadata-url/", "https://streams.canonical.com/juju/tools/"})
+	sstesting.AssertExpectedSources(c, sources, []sstesting.SourceDetails{
+		{"config-tools-metadata-url/", simplestreams.SimplestreamsJujuPublicKey},
+		{"https://streams.canonical.com/juju/tools/", simplestreams.SimplestreamsJujuPublicKey},
+	})
 }
 
 func (s *URLsSuite) TestToolsMetadataURLsRegisteredFuncs(c *gc.C) {
@@ -84,10 +86,10 @@ func (s *URLsSuite) TestToolsMetadataURLsRegisteredFuncs(c *gc.C) {
 	env := s.env(c, "config-tools-metadata-url")
 	sources, err := tools.GetMetadataSources(env)
 	c.Assert(err, jc.ErrorIsNil)
-	sstesting.AssertExpectedSources(c, sources, []string{
-		"config-tools-metadata-url/",
-		"betwixt/releases/",
-		"https://streams.canonical.com/juju/tools/",
+	sstesting.AssertExpectedSources(c, sources, []sstesting.SourceDetails{
+		{"config-tools-metadata-url/", simplestreams.SimplestreamsJujuPublicKey},
+		{"betwixt/releases/", ""},
+		{"https://streams.canonical.com/juju/tools/", simplestreams.SimplestreamsJujuPublicKey},
 	})
 }
 


### PR DESCRIPTION
Data sources may not require to contain signed data. These data source may also not provide public key. However, these data source may still contain signed data.  Since we will always try to read signed data first, we want to be able to try to read this signed data with public key known to Juju.

When public key is not provided by the data source but signed data has been supplied, let's use user supplied public key or fall back to other-juju-known public key.



(Review request: http://reviews.vapour.ws/r/3877/)