### PR TITLE
cmd/juju/commands: temporarily drop local. prefix

### DIFF
--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -206,7 +206,9 @@ func (c *bootstrapCommand) Init(args []string) (err error) {
 }
 
 var bootstrappedControllerName = func(controllerName string) string {
-	return fmt.Sprintf("local.%s", controllerName)
+	// TODO(axw) re-enable this once we've got CI updated.
+	return controllerName
+	//return fmt.Sprintf("local.%s", controllerName)
 }
 
 // BootstrapInterface provides bootstrap functionality that Run calls to support cleaner testing.

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -465,7 +465,7 @@ func (s *BootstrapSuite) TestBootstrapTwice(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	_, err = coretesting.RunCommand(c, newBootstrapCommand(), controllerName, "dummy", "--auto-upgrade")
-	c.Assert(err, gc.ErrorMatches, `controller "local.dev" already exists`)
+	c.Assert(err, gc.ErrorMatches, `controller "dev" already exists`)
 }
 
 func (s *BootstrapSuite) TestBootstrapSetsCurrentModel(c *gc.C) {
@@ -498,7 +498,7 @@ func (s *BootstrapSuite) TestBootstrapPropagatesStoreErrors(c *gc.C) {
 	cmd := &bootstrapCommand{}
 	cmd.SetClientStore(store)
 	_, err := coretesting.RunCommand(c, modelcmd.Wrap(cmd), controllerName, "dummy", "--auto-upgrade")
-	c.Assert(err, gc.ErrorMatches, `error reading controller "local.devcontroller" info: oh noes`)
+	c.Assert(err, gc.ErrorMatches, `error reading controller "devcontroller" info: oh noes`)
 }
 
 // When attempting to bootstrap, check that when prepare errors out,
@@ -536,7 +536,7 @@ func (s *BootstrapSuite) TestBootstrapAlreadyExists(c *gc.C) {
 	s.patchVersionAndSeries(c, "raring")
 
 	store := jujuclient.NewFileClientStore()
-	err := store.UpdateController("local.devcontroller", jujuclient.ControllerDetails{
+	err := store.UpdateController("devcontroller", jujuclient.ControllerDetails{
 		CACert:         "x",
 		ControllerUUID: "y",
 	})
@@ -752,7 +752,7 @@ func (s *BootstrapSuite) TestMissingToolsUploadFailedError(c *gc.C) {
 	)
 
 	c.Check(coretesting.Stderr(ctx), gc.Equals, fmt.Sprintf(`
-Creating Juju controller "local.devcontroller" on dummy-cloud/region-1
+Creating Juju controller "devcontroller" on dummy-cloud/region-1
 Bootstrapping model "devcontroller"
 Starting new instance for initial controller
 Building tools to upload (1.7.3.1-raring-%s)
@@ -836,7 +836,7 @@ func (s *BootstrapSuite) TestBootstrapProviderNoRegions(c *gc.C) {
 		c, newBootstrapCommand(), "ctrl", "no-cloud-regions",
 		"--config", "default-series=precise",
 	)
-	c.Check(coretesting.Stderr(ctx), gc.Matches, "Creating Juju controller \"local.ctrl\" on no-cloud-regions(.|\n)*")
+	c.Check(coretesting.Stderr(ctx), gc.Matches, "Creating Juju controller \"ctrl\" on no-cloud-regions(.|\n)*")
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -846,7 +846,7 @@ func (s *BootstrapSuite) TestBootstrapCloudNoRegions(c *gc.C) {
 		c, newBootstrapCommand(), "ctrl", "dummy-cloud-without-regions",
 		"--config", "default-series=precise",
 	)
-	c.Check(coretesting.Stderr(ctx), gc.Matches, "Creating Juju controller \"local.ctrl\" on dummy-cloud-without-regions(.|\n)*")
+	c.Check(coretesting.Stderr(ctx), gc.Matches, "Creating Juju controller \"ctrl\" on dummy-cloud-without-regions(.|\n)*")
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -862,7 +862,7 @@ func (s *BootstrapSuite) TestBootstrapCloudNoRegionsOneSpecified(c *gc.C) {
 	// enable the lxd provider to take the lxd remote from the region
 	// name.
 	c.Check(coretesting.Stderr(ctx), gc.Matches,
-		"Creating Juju controller \"local.ctrl\" on dummy-cloud-without-regions/my-region(.|\n)*")
+		"Creating Juju controller \"ctrl\" on dummy-cloud-without-regions/my-region(.|\n)*")
 	c.Assert(err, jc.ErrorIsNil)
 }
 


### PR DESCRIPTION
The local. prefix on controllers is causing problems
in CI. To get through CI, we'll drop this, and then
work with QA to get their scripts updated.

(Review request: http://reviews.vapour.ws/r/3881/)