### PR TITLE
apiserver: fix test to stop writing to source dir

### DIFF
--- a/apiserver/server_test.go
+++ b/apiserver/server_test.go
@@ -283,14 +283,7 @@ func dialWebsocket(c *gc.C, addr, path string, tlsVersion uint16) (*websocket.Co
 
 func (s *serverSuite) TestMinTLSVersion(c *gc.C) {
 	loggo.GetLogger("juju.apiserver").SetLogLevel(loggo.TRACE)
-	listener, err := net.Listen("tcp", ":0")
-	c.Assert(err, jc.ErrorIsNil)
-	srv, err := apiserver.NewServer(s.State, listener, apiserver.ServerConfig{
-		Cert: []byte(coretesting.ServerCert),
-		Key:  []byte(coretesting.ServerKey),
-		Tag:  names.NewMachineTag("0"),
-	})
-	c.Assert(err, jc.ErrorIsNil)
+	srv := newServer(c, s.State)
 	defer srv.Stop()
 
 	// We have to use 'localhost' because that is what the TLS cert says.


### PR DESCRIPTION
One of the tests was failing to override the log
directory, and so was writing to the source dir.

Fixes https://bugs.launchpad.net/juju-core/+bug/1546043

(Review request: http://reviews.vapour.ws/r/3882/)