### PR TITLE
Watch machine provisioning status

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -45,30 +45,21 @@ func (c *Client) Status(patterns []string) (*params.FullStatus, error) {
 	return &result, nil
 }
 
-// UnitStatusHistory retrieves the last <size> results of <kind:combined|agent|workload> status
-// for <unitName> unit
-func (c *Client) UnitStatusHistory(kind params.HistoryKind, unitName string, size int) (*params.UnitStatusHistory, error) {
-	var results params.UnitStatusHistory
-	args := params.StatusHistory{
+// StatusHistory retrieves the last <size> results of
+// <kind:combined|agent|workload|machine|machineinstance|container|containerinstance> status
+// for <name> unit
+func (c *Client) StatusHistory(kind params.HistoryKind, name string, size int) (*params.StatusHistoryResults, error) {
+	var results params.StatusHistoryResults
+	args := params.StatusHistoryArgs{
 		Kind: kind,
 		Size: size,
-		Name: unitName,
+		Name: name,
 	}
-	err := c.facade.FacadeCall("UnitStatusHistory", args, &results)
+	err := c.facade.FacadeCall("StatusHistory", args, &results)
 	if err != nil {
-		return &params.UnitStatusHistory{}, errors.Trace(err)
+		return &params.StatusHistoryResults{}, errors.Trace(err)
 	}
 	return &results, nil
-}
-
-// LegacyStatus is a stub version of Status that 1.16 introduced. Should be
-// removed along with structs when api versioning makes it safe to do so.
-func (c *Client) LegacyStatus() (*params.LegacyStatus, error) {
-	var result params.LegacyStatus
-	if err := c.facade.FacadeCall("Status", nil, &result); err != nil {
-		return nil, err
-	}
-	return &result, nil
 }
 
 // Resolved clears errors on a unit.

--- a/api/machiner/machine.go
+++ b/api/machiner/machine.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/juju/api/common"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/network"
+	"github.com/juju/juju/status"
 	"github.com/juju/juju/watcher"
 )
 
@@ -41,7 +42,7 @@ func (m *Machine) Refresh() error {
 }
 
 // SetStatus sets the status of the machine.
-func (m *Machine) SetStatus(status params.Status, info string, data map[string]interface{}) error {
+func (m *Machine) SetStatus(status status.Status, info string, data map[string]interface{}) error {
 	var result params.ErrorResults
 	args := params.SetStatus{
 		Entities: []params.EntityStatusArgs{

--- a/api/machiner/machiner_test.go
+++ b/api/machiner/machiner_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/status"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/watcher/watchertest"
 )
@@ -70,16 +71,16 @@ func (s *machinerSuite) TestSetStatus(c *gc.C) {
 
 	statusInfo, err := s.machine.Status()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(statusInfo.Status, gc.Equals, state.StatusPending)
+	c.Assert(statusInfo.Status, gc.Equals, status.StatusPending)
 	c.Assert(statusInfo.Message, gc.Equals, "")
 	c.Assert(statusInfo.Data, gc.HasLen, 0)
 
-	err = machine.SetStatus(params.StatusStarted, "blah", nil)
+	err = machine.SetStatus(status.StatusStarted, "blah", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	statusInfo, err = s.machine.Status()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(statusInfo.Status, gc.Equals, state.StatusStarted)
+	c.Assert(statusInfo.Status, gc.Equals, status.StatusStarted)
 	c.Assert(statusInfo.Message, gc.Equals, "blah")
 	c.Assert(statusInfo.Data, gc.HasLen, 0)
 	c.Assert(statusInfo.Since, gc.NotNil)
@@ -192,7 +193,7 @@ func (s *machinerSuite) TestWatch(c *gc.C) {
 
 	// Change something other than the lifecycle and make sure it's
 	// not detected.
-	err = machine.SetStatus(params.StatusStarted, "not really", nil)
+	err = machine.SetStatus(status.StatusStarted, "not really", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertNoChange()
 

--- a/api/provisioner/provisioner_test.go
+++ b/api/provisioner/provisioner_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/status"
 	"github.com/juju/juju/storage/poolmanager"
 	"github.com/juju/juju/storage/provider"
 	coretools "github.com/juju/juju/tools"
@@ -117,17 +118,17 @@ func (s *provisionerSuite) TestGetSetStatus(c *gc.C) {
 	apiMachine, err := s.provisioner.Machine(s.machine.Tag().(names.MachineTag))
 	c.Assert(err, jc.ErrorIsNil)
 
-	status, info, err := apiMachine.Status()
+	machineStatus, info, err := apiMachine.Status()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(status, gc.Equals, params.StatusPending)
+	c.Assert(machineStatus, gc.Equals, status.StatusPending)
 	c.Assert(info, gc.Equals, "")
 
-	err = apiMachine.SetStatus(params.StatusStarted, "blah", nil)
+	err = apiMachine.SetStatus(status.StatusStarted, "blah", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
-	status, info, err = apiMachine.Status()
+	machineStatus, info, err = apiMachine.Status()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(status, gc.Equals, params.StatusStarted)
+	c.Assert(machineStatus, gc.Equals, status.StatusStarted)
 	c.Assert(info, gc.Equals, "blah")
 	statusInfo, err := s.machine.Status()
 	c.Assert(err, jc.ErrorIsNil)
@@ -138,12 +139,12 @@ func (s *provisionerSuite) TestGetSetStatusWithData(c *gc.C) {
 	apiMachine, err := s.provisioner.Machine(s.machine.Tag().(names.MachineTag))
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = apiMachine.SetStatus(params.StatusError, "blah", map[string]interface{}{"foo": "bar"})
+	err = apiMachine.SetStatus(status.StatusError, "blah", map[string]interface{}{"foo": "bar"})
 	c.Assert(err, jc.ErrorIsNil)
 
-	status, info, err := apiMachine.Status()
+	machineStatus, info, err := apiMachine.Status()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(status, gc.Equals, params.StatusError)
+	c.Assert(machineStatus, gc.Equals, status.StatusError)
 	c.Assert(info, gc.Equals, "blah")
 	statusInfo, err := s.machine.Status()
 	c.Assert(err, jc.ErrorIsNil)
@@ -153,7 +154,7 @@ func (s *provisionerSuite) TestGetSetStatusWithData(c *gc.C) {
 func (s *provisionerSuite) TestMachinesWithTransientErrors(c *gc.C) {
 	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
-	err = machine.SetStatus(state.StatusError, "blah", map[string]interface{}{"transient": true})
+	err = machine.SetStatus(status.StatusError, "blah", map[string]interface{}{"transient": true})
 	c.Assert(err, jc.ErrorIsNil)
 	machines, info, err := s.provisioner.MachinesWithTransientErrors()
 	c.Assert(err, jc.ErrorIsNil)
@@ -547,7 +548,7 @@ func (s *provisionerSuite) TestWatchContainers(c *gc.C) {
 
 	// Change something other than the containers and make sure it's
 	// not detected.
-	err = apiMachine.SetStatus(params.StatusStarted, "not really", nil)
+	err = apiMachine.SetStatus(status.StatusStarted, "not really", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertNoChange()
 

--- a/api/uniter/service.go
+++ b/api/uniter/service.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/juju/api/common"
 	apiwatcher "github.com/juju/juju/api/watcher"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/status"
 	"github.com/juju/juju/watcher"
 )
 
@@ -143,14 +144,14 @@ func (s *Service) serviceOwnerTag() (names.UserTag, error) {
 
 // SetStatus sets the status of the service if the passed unitName,
 // corresponding to the calling unit, is of the leader.
-func (s *Service) SetStatus(unitName string, status params.Status, info string, data map[string]interface{}) error {
+func (s *Service) SetStatus(unitName string, unitStatus status.Status, info string, data map[string]interface{}) error {
 	tag := names.NewUnitTag(unitName)
 	var result params.ErrorResults
 	args := params.SetStatus{
 		Entities: []params.EntityStatusArgs{
 			{
 				Tag:    tag.String(),
-				Status: status,
+				Status: unitStatus,
 				Info:   info,
 				Data:   data,
 			},

--- a/api/uniter/service_test.go
+++ b/api/uniter/service_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/juju/api/uniter"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/status"
 	"github.com/juju/juju/watcher/watchertest"
 )
 
@@ -124,20 +125,20 @@ func (s *serviceSuite) TestSetServiceStatus(c *gc.C) {
 	message := "a test message"
 	stat, err := s.wordpressService.Status()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(stat.Status, gc.Not(gc.Equals), state.Status(params.StatusActive))
+	c.Assert(stat.Status, gc.Not(gc.Equals), status.StatusActive)
 	c.Assert(stat.Message, gc.Not(gc.Equals), message)
 
-	err = s.apiService.SetStatus(s.wordpressUnit.Name(), params.StatusActive, message, map[string]interface{}{})
+	err = s.apiService.SetStatus(s.wordpressUnit.Name(), status.StatusActive, message, map[string]interface{}{})
 	c.Check(err, gc.ErrorMatches, `"wordpress/0" is not leader of "wordpress"`)
 
 	s.claimLeadership(c, s.wordpressUnit, s.wordpressService)
 
-	err = s.apiService.SetStatus(s.wordpressUnit.Name(), params.StatusActive, message, map[string]interface{}{})
+	err = s.apiService.SetStatus(s.wordpressUnit.Name(), status.StatusActive, message, map[string]interface{}{})
 	c.Check(err, jc.ErrorIsNil)
 
 	stat, err = s.wordpressService.Status()
 	c.Check(err, jc.ErrorIsNil)
-	c.Check(stat.Status, gc.Equals, state.Status(params.StatusActive))
+	c.Check(stat.Status, gc.Equals, status.StatusActive)
 	c.Check(stat.Message, gc.Equals, message)
 }
 
@@ -145,15 +146,15 @@ func (s *serviceSuite) TestServiceStatus(c *gc.C) {
 	message := "a test message"
 	stat, err := s.wordpressService.Status()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(stat.Status, gc.Not(gc.Equals), state.Status(params.StatusActive))
+	c.Assert(stat.Status, gc.Not(gc.Equals), status.StatusActive)
 	c.Assert(stat.Message, gc.Not(gc.Equals), message)
 
-	err = s.wordpressService.SetStatus(state.Status(params.StatusActive), message, map[string]interface{}{})
+	err = s.wordpressService.SetStatus(status.StatusActive, message, map[string]interface{}{})
 	c.Check(err, jc.ErrorIsNil)
 
 	stat, err = s.wordpressService.Status()
 	c.Check(err, jc.ErrorIsNil)
-	c.Check(stat.Status, gc.Equals, state.Status(params.StatusActive))
+	c.Check(stat.Status, gc.Equals, status.StatusActive)
 	c.Check(stat.Message, gc.Equals, message)
 
 	result, err := s.apiService.Status(s.wordpressUnit.Name())
@@ -162,7 +163,7 @@ func (s *serviceSuite) TestServiceStatus(c *gc.C) {
 	s.claimLeadership(c, s.wordpressUnit, s.wordpressService)
 	result, err = s.apiService.Status(s.wordpressUnit.Name())
 	c.Check(err, jc.ErrorIsNil)
-	c.Check(result.Service.Status, gc.Equals, params.StatusActive)
+	c.Check(result.Service.Status, gc.Equals, status.StatusActive)
 }
 
 func (s *serviceSuite) claimLeadership(c *gc.C, unit *state.Unit, service *state.Service) {

--- a/api/uniter/unit.go
+++ b/api/uniter/unit.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/juju/api/common"
 	apiwatcher "github.com/juju/juju/api/watcher"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/status"
 	"github.com/juju/juju/watcher"
 )
 
@@ -54,14 +55,14 @@ func (u *Unit) Refresh() error {
 }
 
 // SetUnitStatus sets the status of the unit.
-func (u *Unit) SetUnitStatus(status params.Status, info string, data map[string]interface{}) error {
+func (u *Unit) SetUnitStatus(unitStatus status.Status, info string, data map[string]interface{}) error {
 	if u.st.facade.BestAPIVersion() < 2 {
 		return errors.NotImplementedf("SetUnitStatus")
 	}
 	var result params.ErrorResults
 	args := params.SetStatus{
 		Entities: []params.EntityStatusArgs{
-			{Tag: u.tag.String(), Status: status, Info: info, Data: data},
+			{Tag: u.tag.String(), Status: unitStatus, Info: info, Data: data},
 		},
 	}
 	err := u.st.facade.FacadeCall("SetUnitStatus", args, &result)
@@ -94,11 +95,11 @@ func (u *Unit) UnitStatus() (params.StatusResult, error) {
 }
 
 // SetAgentStatus sets the status of the unit agent.
-func (u *Unit) SetAgentStatus(status params.Status, info string, data map[string]interface{}) error {
+func (u *Unit) SetAgentStatus(agentStatus status.Status, info string, data map[string]interface{}) error {
 	var result params.ErrorResults
 	args := params.SetStatus{
 		Entities: []params.EntityStatusArgs{
-			{Tag: u.tag.String(), Status: status, Info: info, Data: data},
+			{Tag: u.tag.String(), Status: agentStatus, Info: info, Data: data},
 		},
 	}
 	setStatusFacadeCall := "SetAgentStatus"

--- a/api/uniter/unit_test.go
+++ b/api/uniter/unit_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/status"
 	jujufactory "github.com/juju/juju/testing/factory"
 	"github.com/juju/juju/watcher/watchertest"
 )
@@ -62,22 +63,22 @@ func (s *unitSuite) TestUnitAndUnitTag(c *gc.C) {
 func (s *unitSuite) TestSetAgentStatus(c *gc.C) {
 	statusInfo, err := s.wordpressUnit.AgentStatus()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(statusInfo.Status, gc.Equals, state.StatusAllocating)
+	c.Assert(statusInfo.Status, gc.Equals, status.StatusAllocating)
 	c.Assert(statusInfo.Message, gc.Equals, "")
 	c.Assert(statusInfo.Data, gc.HasLen, 0)
 
 	unitStatusInfo, err := s.wordpressUnit.Status()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(unitStatusInfo.Status, gc.Equals, state.StatusUnknown)
+	c.Assert(unitStatusInfo.Status, gc.Equals, status.StatusUnknown)
 	c.Assert(unitStatusInfo.Message, gc.Equals, "Waiting for agent initialization to finish")
 	c.Assert(unitStatusInfo.Data, gc.HasLen, 0)
 
-	err = s.apiUnit.SetAgentStatus(params.StatusIdle, "blah", nil)
+	err = s.apiUnit.SetAgentStatus(status.StatusIdle, "blah", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	statusInfo, err = s.wordpressUnit.AgentStatus()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(statusInfo.Status, gc.Equals, state.StatusIdle)
+	c.Assert(statusInfo.Status, gc.Equals, status.StatusIdle)
 	c.Assert(statusInfo.Message, gc.Equals, "blah")
 	c.Assert(statusInfo.Data, gc.HasLen, 0)
 	c.Assert(statusInfo.Since, gc.NotNil)
@@ -85,7 +86,7 @@ func (s *unitSuite) TestSetAgentStatus(c *gc.C) {
 	// Ensure that unit has not changed.
 	unitStatusInfo, err = s.wordpressUnit.Status()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(unitStatusInfo.Status, gc.Equals, state.StatusUnknown)
+	c.Assert(unitStatusInfo.Status, gc.Equals, status.StatusUnknown)
 	c.Assert(unitStatusInfo.Message, gc.Equals, "Waiting for agent initialization to finish")
 	c.Assert(unitStatusInfo.Data, gc.HasLen, 0)
 }
@@ -93,22 +94,22 @@ func (s *unitSuite) TestSetAgentStatus(c *gc.C) {
 func (s *unitSuite) TestSetUnitStatus(c *gc.C) {
 	statusInfo, err := s.wordpressUnit.Status()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(statusInfo.Status, gc.Equals, state.StatusUnknown)
+	c.Assert(statusInfo.Status, gc.Equals, status.StatusUnknown)
 	c.Assert(statusInfo.Message, gc.Equals, "Waiting for agent initialization to finish")
 	c.Assert(statusInfo.Data, gc.HasLen, 0)
 
 	agentStatusInfo, err := s.wordpressUnit.AgentStatus()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(agentStatusInfo.Status, gc.Equals, state.StatusAllocating)
+	c.Assert(agentStatusInfo.Status, gc.Equals, status.StatusAllocating)
 	c.Assert(agentStatusInfo.Message, gc.Equals, "")
 	c.Assert(agentStatusInfo.Data, gc.HasLen, 0)
 
-	err = s.apiUnit.SetUnitStatus(params.StatusActive, "blah", nil)
+	err = s.apiUnit.SetUnitStatus(status.StatusActive, "blah", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	statusInfo, err = s.wordpressUnit.Status()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(statusInfo.Status, gc.Equals, state.StatusActive)
+	c.Assert(statusInfo.Status, gc.Equals, status.StatusActive)
 	c.Assert(statusInfo.Message, gc.Equals, "blah")
 	c.Assert(statusInfo.Data, gc.HasLen, 0)
 	c.Assert(statusInfo.Since, gc.NotNil)
@@ -116,13 +117,13 @@ func (s *unitSuite) TestSetUnitStatus(c *gc.C) {
 	// Ensure unit's agent has not changed.
 	agentStatusInfo, err = s.wordpressUnit.AgentStatus()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(agentStatusInfo.Status, gc.Equals, state.StatusAllocating)
+	c.Assert(agentStatusInfo.Status, gc.Equals, status.StatusAllocating)
 	c.Assert(agentStatusInfo.Message, gc.Equals, "")
 	c.Assert(agentStatusInfo.Data, gc.HasLen, 0)
 }
 
 func (s *unitSuite) TestUnitStatus(c *gc.C) {
-	err := s.wordpressUnit.SetStatus(state.StatusMaintenance, "blah", nil)
+	err := s.wordpressUnit.SetStatus(status.StatusMaintenance, "blah", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	result, err := s.apiUnit.UnitStatus()
@@ -130,7 +131,7 @@ func (s *unitSuite) TestUnitStatus(c *gc.C) {
 	c.Assert(result.Since, gc.NotNil)
 	result.Since = nil
 	c.Assert(result, gc.DeepEquals, params.StatusResult{
-		Status: params.StatusMaintenance,
+		Status: status.StatusMaintenance,
 		Info:   "blah",
 		Data:   map[string]interface{}{},
 	})
@@ -222,7 +223,7 @@ func (s *unitSuite) TestWatch(c *gc.C) {
 
 	// Change something other than the lifecycle and make sure it's
 	// not detected.
-	err = s.apiUnit.SetAgentStatus(params.StatusIdle, "not really", nil)
+	err = s.apiUnit.SetAgentStatus(status.StatusIdle, "not really", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertNoChange()
 

--- a/apiserver/client/client_test.go
+++ b/apiserver/client/client_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/multiwatcher"
 	"github.com/juju/juju/state/presence"
+	"github.com/juju/juju/status"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/testing/factory"
 	"github.com/juju/juju/version"
@@ -573,7 +574,8 @@ func clearSinceTimes(status *params.FullStatus) {
 		status.Services[serviceId] = service
 	}
 	for id, machine := range status.Machines {
-		machine.Agent.Since = nil
+		machine.JujuStatus.Since = nil
+		machine.MachineStatus.Since = nil
 		status.Machines[id] = machine
 	}
 }
@@ -736,7 +738,7 @@ func (s *clientSuite) testClientUnitResolved(c *gc.C, retry bool, expectedResolv
 	s.setUpScenario(c)
 	u, err := s.State.Unit("wordpress/0")
 	c.Assert(err, jc.ErrorIsNil)
-	err = u.SetAgentStatus(state.StatusError, "gaaah", nil)
+	err = u.SetAgentStatus(status.StatusError, "gaaah", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	// Code under test:
 	err = s.APIState.Client().Resolved("wordpress/0", retry)
@@ -762,7 +764,7 @@ func (s *clientSuite) setupResolved(c *gc.C) *state.Unit {
 	s.setUpScenario(c)
 	u, err := s.State.Unit("wordpress/0")
 	c.Assert(err, jc.ErrorIsNil)
-	err = u.SetAgentStatus(state.StatusError, "gaaah", nil)
+	err = u.SetAgentStatus(status.StatusError, "gaaah", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	return u
 }
@@ -848,13 +850,24 @@ func (s *clientSuite) TestClientWatchAll(c *gc.C) {
 	}()
 	deltas, err := watcher.Next()
 	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(len(deltas), gc.Equals, 1)
+	d0, ok := deltas[0].Entity.(*multiwatcher.MachineInfo)
+	c.Assert(ok, jc.IsTrue)
+	d0.JujuStatus.Since = nil
+	d0.MachineStatus.Since = nil
 	if !c.Check(deltas, gc.DeepEquals, []multiwatcher.Delta{{
 		Entity: &multiwatcher.MachineInfo{
-			ModelUUID:               s.State.ModelUUID(),
-			Id:                      m.Id(),
-			InstanceId:              "i-0",
-			Status:                  multiwatcher.Status("pending"),
-			StatusData:              map[string]interface{}{},
+			ModelUUID:  s.State.ModelUUID(),
+			Id:         m.Id(),
+			InstanceId: "i-0",
+			JujuStatus: multiwatcher.StatusInfo{
+				Current: status.StatusPending,
+				Data:    map[string]interface{}{},
+			},
+			MachineStatus: multiwatcher.StatusInfo{
+				Current: status.StatusPending,
+				Data:    map[string]interface{}{},
+			},
 			Life:                    multiwatcher.Life("alive"),
 			Series:                  "quantal",
 			Jobs:                    []multiwatcher.MachineJob{state.JobManageModel.ToParams()},
@@ -1607,14 +1620,14 @@ func (s *clientRepoSuite) TestResolveCharm(c *gc.C) {
 func (s *clientSuite) TestRetryProvisioning(c *gc.C) {
 	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
-	err = machine.SetStatus(state.StatusError, "error", nil)
+	err = machine.SetStatus(status.StatusError, "error", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = s.APIState.Client().RetryProvisioning(machine.Tag().(names.MachineTag))
 	c.Assert(err, jc.ErrorIsNil)
 
 	statusInfo, err := machine.Status()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(statusInfo.Status, gc.Equals, state.StatusError)
+	c.Assert(statusInfo.Status, gc.Equals, status.StatusError)
 	c.Assert(statusInfo.Message, gc.Equals, "error")
 	c.Assert(statusInfo.Data["transient"], jc.IsTrue)
 }
@@ -1622,7 +1635,7 @@ func (s *clientSuite) TestRetryProvisioning(c *gc.C) {
 func (s *clientSuite) setupRetryProvisioning(c *gc.C) *state.Machine {
 	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
-	err = machine.SetStatus(state.StatusError, "error", nil)
+	err = machine.SetStatus(status.StatusError, "error", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	return machine
 }
@@ -1632,7 +1645,7 @@ func (s *clientSuite) assertRetryProvisioning(c *gc.C, machine *state.Machine) {
 	c.Assert(err, jc.ErrorIsNil)
 	statusInfo, err := machine.Status()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(statusInfo.Status, gc.Equals, state.StatusError)
+	c.Assert(statusInfo.Status, gc.Equals, status.StatusError)
 	c.Assert(statusInfo.Message, gc.Equals, "error")
 	c.Assert(statusInfo.Data["transient"], jc.IsTrue)
 }

--- a/apiserver/client/filtering.go
+++ b/apiserver/client/filtering.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/status"
 )
 
 var InvalidFormatErr = errors.Errorf("the given filter did not match any known patterns.")
@@ -335,11 +336,11 @@ func matchExposure(patterns []string, s *state.Service) (bool, bool, error) {
 	return false, false, nil
 }
 
-func matchWorkloadStatus(patterns []string, workloadStatus state.Status, agentStatus state.Status) (bool, bool, error) {
+func matchWorkloadStatus(patterns []string, workloadStatus status.Status, agentStatus status.Status) (bool, bool, error) {
 	oneValidStatus := false
 	for _, p := range patterns {
 		// If the pattern isn't a known status, ignore it.
-		ps := state.Status(p)
+		ps := status.Status(p)
 		if !ps.KnownWorkloadStatus() {
 			continue
 		}
@@ -347,24 +348,24 @@ func matchWorkloadStatus(patterns []string, workloadStatus state.Status, agentSt
 		oneValidStatus = true
 		// To preserve current expected behaviour, we only report on workload status
 		// if the agent itself is not in error.
-		if agentStatus != state.StatusError && workloadStatus.WorkloadMatches(ps) {
+		if agentStatus != status.StatusError && workloadStatus.WorkloadMatches(ps) {
 			return true, true, nil
 		}
 	}
 	return false, oneValidStatus, nil
 }
 
-func matchAgentStatus(patterns []string, status state.Status) (bool, bool, error) {
+func matchAgentStatus(patterns []string, agentStatus status.Status) (bool, bool, error) {
 	oneValidStatus := false
 	for _, p := range patterns {
 		// If the pattern isn't a known status, ignore it.
-		ps := state.Status(p)
+		ps := status.Status(p)
 		if !ps.KnownAgentStatus() {
 			continue
 		}
 
 		oneValidStatus = true
-		if status.Matches(ps) {
+		if agentStatus.Matches(ps) {
 			return true, true, nil
 		}
 	}

--- a/apiserver/client/state.go
+++ b/apiserver/client/state.go
@@ -12,19 +12,20 @@ import (
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/status"
 	"github.com/juju/juju/version"
 )
 
 // Unit represents a state.Unit.
 type Unit interface {
-	state.StatusHistoryGetter
+	status.StatusHistoryGetter
 	Life() state.Life
 	Destroy() (err error)
 	IsPrincipal() bool
 	PublicAddress() (network.Address, error)
 	PrivateAddress() (network.Address, error)
 	Resolve(retryHooks bool) error
-	AgentHistory() state.StatusHistoryGetter
+	AgentHistory() status.StatusHistoryGetter
 }
 
 // stateInterface contains the state.State methods used in this package,

--- a/apiserver/client/status.go
+++ b/apiserver/client/status.go
@@ -18,14 +18,15 @@ import (
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/multiwatcher"
+	"github.com/juju/juju/status"
 	"github.com/juju/juju/worker/uniter/operation"
 )
 
-func agentStatusFromStatusInfo(s []state.StatusInfo, kind params.HistoryKind) []params.AgentStatus {
+func agentStatusFromStatusInfo(s []status.StatusInfo, kind params.HistoryKind) []params.AgentStatus {
 	result := []params.AgentStatus{}
 	for _, v := range s {
 		result = append(result, params.AgentStatus{
-			Status: params.Status(v.Status),
+			Status: v.Status,
 			Info:   v.Message,
 			Data:   v.Data,
 			Since:  v.Since,
@@ -48,40 +49,105 @@ func (s sortableStatuses) Less(i, j int) bool {
 	return s[i].Since.Before(*s[j].Since)
 }
 
-// UnitStatusHistory returns a slice of past statuses for a given unit.
-func (c *Client) UnitStatusHistory(args params.StatusHistory) (params.UnitStatusHistory, error) {
-	if args.Size < 1 {
-		return params.UnitStatusHistory{}, errors.Errorf("invalid history size: %d", args.Size)
-	}
-	unit, err := c.api.stateAccessor.Unit(args.Name)
+// unitStatus returns a list of status history entries for unit agents or workloads.
+func (c *Client) unitStatus(unitName string, size int, kind params.HistoryKind) ([]params.AgentStatus, error) {
+	unit, err := c.api.stateAccessor.Unit(unitName)
 	if err != nil {
-		return params.UnitStatusHistory{}, errors.Trace(err)
+		return nil, errors.Trace(err)
 	}
-	statuses := params.UnitStatusHistory{}
-	if args.Kind == params.KindCombined || args.Kind == params.KindWorkload {
-		unitStatuses, err := unit.StatusHistory(args.Size)
+	statuses := []params.AgentStatus{}
+	if kind == params.KindCombined || kind == params.KindWorkload {
+		unitStatuses, err := unit.StatusHistory(size)
 		if err != nil {
-			return params.UnitStatusHistory{}, errors.Trace(err)
+			return nil, errors.Trace(err)
 		}
-		statuses.Statuses = append(statuses.Statuses, agentStatusFromStatusInfo(unitStatuses, params.KindWorkload)...)
+		statuses = agentStatusFromStatusInfo(unitStatuses, params.KindWorkload)
+
 	}
-	if args.Kind == params.KindCombined || args.Kind == params.KindAgent {
-		agentStatuses, err := unit.AgentHistory().StatusHistory(args.Size)
+	if kind == params.KindCombined || kind == params.KindAgent {
+		agentStatuses, err := unit.AgentHistory().StatusHistory(size)
 		if err != nil {
-			return params.UnitStatusHistory{}, errors.Trace(err)
+			return nil, errors.Trace(err)
 		}
-		statuses.Statuses = append(statuses.Statuses, agentStatusFromStatusInfo(agentStatuses, params.KindAgent)...)
+		statuses = append(statuses, agentStatusFromStatusInfo(agentStatuses, params.KindAgent)...)
 	}
 
-	sort.Sort(sortableStatuses(statuses.Statuses))
-	if args.Kind == params.KindCombined {
-
-		if len(statuses.Statuses) > args.Size {
-			statuses.Statuses = statuses.Statuses[len(statuses.Statuses)-args.Size:]
+	sort.Sort(sortableStatuses(statuses))
+	if kind == params.KindCombined {
+		if len(statuses) > size {
+			statuses = statuses[len(statuses)-size:]
 		}
-
 	}
+
 	return statuses, nil
+}
+
+func (c *Client) machineInstanceStatus(machineName string, size int, kind params.HistoryKind) ([]params.AgentStatus, error) {
+	machine, err := c.api.stateAccessor.Machine(machineName)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	sInfo, err := machine.InstanceStatusHistory(size)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return agentStatusFromStatusInfo(sInfo, kind), nil
+}
+
+func (c *Client) machineStatus(machineName string, size int, kind params.HistoryKind) ([]params.AgentStatus, error) {
+	machine, err := c.api.stateAccessor.Machine(machineName)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	sInfo, err := machine.StatusHistory(size)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return agentStatusFromStatusInfo(sInfo, kind), nil
+}
+
+// StatusHistory returns a slice of past statuses for several entities.
+func (c *Client) StatusHistory(args params.StatusHistoryArgs) (params.StatusHistoryResults, error) {
+	if args.Size < 1 {
+		return params.StatusHistoryResults{}, errors.Errorf("invalid history size: %d", args.Size)
+	}
+	history := params.StatusHistoryResults{}
+	statuses := []params.AgentStatus{}
+	var err error
+	switch args.Kind {
+	case params.KindCombined, params.KindWorkload, params.KindAgent:
+		statuses, err = c.unitStatus(args.Name, args.Size, args.Kind)
+		if err != nil {
+			return params.StatusHistoryResults{}, errors.Annotate(err, "fetching unit status history")
+		}
+	case params.KindMachineInstance:
+		mIStatuses, err := c.machineInstanceStatus(args.Name, args.Size, params.KindMachineInstance)
+		if err != nil {
+			return params.StatusHistoryResults{}, errors.Annotate(err, "fetching machine instance status history")
+		}
+		statuses = mIStatuses
+	case params.KindMachine:
+		mStatuses, err := c.machineStatus(args.Name, args.Size, params.KindMachine)
+		if err != nil {
+			return params.StatusHistoryResults{}, errors.Annotate(err, "fetching machine status history")
+		}
+		statuses = mStatuses
+	case params.KindContainerInstance:
+		cIStatuses, err := c.machineStatus(args.Name, args.Size, params.KindContainerInstance)
+		if err != nil {
+			return params.StatusHistoryResults{}, errors.Annotate(err, "fetching machine status history")
+		}
+		statuses = cIStatuses
+	case params.KindContainer:
+		cStatuses, err := c.machineStatus(args.Name, args.Size, params.KindContainer)
+		if err != nil {
+			return params.StatusHistoryResults{}, errors.Annotate(err, "fetching machine status history")
+		}
+		statuses = cStatuses
+	}
+	history.Statuses = statuses
+	sort.Sort(sortableStatuses(history.Statuses))
+	return history, nil
 }
 
 // FullStatus gives the information needed for juju status over the api
@@ -421,21 +487,20 @@ func processMachines(idToMachines map[string][]*state.Machine) map[string]params
 }
 
 func makeMachineStatus(machine *state.Machine) (status params.MachineStatus) {
+	var err error
 	status.Id = machine.Id()
 	agentStatus := processMachine(machine)
-	status.Agent = agentStatus
+	status.JujuStatus = agentStatus
 
 	status.Series = machine.Series()
 	status.Jobs = paramsJobsFromJobs(machine.Jobs())
 	status.WantsVote = machine.WantsVote()
 	status.HasVote = machine.HasVote()
+	sInfo, err := machine.InstanceStatus()
+	populateStatusFromStatusInfoAndErr(&status.MachineStatus, sInfo, err)
 	instid, err := machine.InstanceId()
 	if err == nil {
 		status.InstanceId = instid
-		status.InstanceState, err = machine.InstanceStatus()
-		if err != nil {
-			status.InstanceState = "error"
-		}
 		addr, err := machine.PublicAddress()
 		if err != nil {
 			// Usually this indicates that no addresses have been set on the
@@ -554,25 +619,25 @@ func (context *statusContext) processServices() map[string]params.ServiceStatus 
 	return servicesMap
 }
 
-func (context *statusContext) processService(service *state.Service) (status params.ServiceStatus) {
+func (context *statusContext) processService(service *state.Service) (processedStatus params.ServiceStatus) {
 	serviceCharmURL, _ := service.CharmURL()
-	status.Charm = serviceCharmURL.String()
-	status.Exposed = service.IsExposed()
-	status.Life = processLife(service)
+	processedStatus.Charm = serviceCharmURL.String()
+	processedStatus.Exposed = service.IsExposed()
+	processedStatus.Life = processLife(service)
 
 	latestCharm, ok := context.latestCharms[*serviceCharmURL.WithRevision(-1)]
 	if ok && latestCharm != serviceCharmURL.String() {
-		status.CanUpgradeTo = latestCharm
+		processedStatus.CanUpgradeTo = latestCharm
 	}
 	var err error
-	status.Relations, status.SubordinateTo, err = context.processServiceRelations(service)
+	processedStatus.Relations, processedStatus.SubordinateTo, err = context.processServiceRelations(service)
 	if err != nil {
-		status.Err = err
+		processedStatus.Err = err
 		return
 	}
 	networks, err := service.Networks()
 	if err != nil {
-		status.Err = err
+		processedStatus.Err = err
 		return
 	}
 	var cons constraints.Value
@@ -580,7 +645,7 @@ func (context *statusContext) processService(service *state.Service) (status par
 		// Only principals can have constraints.
 		cons, err = service.Constraints()
 		if err != nil {
-			status.Err = err
+			processedStatus.Err = err
 			return
 		}
 	}
@@ -590,26 +655,26 @@ func (context *statusContext) processService(service *state.Service) (status par
 		// <svc> --networks=...") will be enabled, and altough when
 		// specified, networks constraints will be used for instance
 		// selection, they won't be actually enabled.
-		status.Networks = params.NetworksSpecification{
+		processedStatus.Networks = params.NetworksSpecification{
 			Enabled:  networks,
 			Disabled: append(cons.IncludeNetworks(), cons.ExcludeNetworks()...),
 		}
 	}
 	if service.IsPrincipal() {
-		status.Units = context.processUnits(context.units[service.Name()], serviceCharmURL.String())
+		processedStatus.Units = context.processUnits(context.units[service.Name()], serviceCharmURL.String())
 		serviceStatus, err := service.Status()
 		if err != nil {
-			status.Err = err
+			processedStatus.Err = err
 			return
 		}
-		status.Status.Status = params.Status(serviceStatus.Status)
-		status.Status.Info = serviceStatus.Message
-		status.Status.Data = serviceStatus.Data
-		status.Status.Since = serviceStatus.Since
+		processedStatus.Status.Status = serviceStatus.Status
+		processedStatus.Status.Info = serviceStatus.Message
+		processedStatus.Status.Data = serviceStatus.Data
+		processedStatus.Status.Since = serviceStatus.Since
 
-		status.MeterStatuses = context.processUnitMeterStatuses(context.units[service.Name()])
+		processedStatus.MeterStatuses = context.processUnitMeterStatuses(context.units[service.Name()])
 	}
-	return status
+	return processedStatus
 }
 
 func isColorStatus(code state.MeterStatusCode) bool {
@@ -619,12 +684,12 @@ func isColorStatus(code state.MeterStatusCode) bool {
 func (context *statusContext) processUnitMeterStatuses(units map[string]*state.Unit) map[string]params.MeterStatus {
 	unitsMap := make(map[string]params.MeterStatus)
 	for _, unit := range units {
-		status, err := unit.GetMeterStatus()
+		meterStatus, err := unit.GetMeterStatus()
 		if err != nil {
 			continue
 		}
-		if isColorStatus(status.Code) {
-			unitsMap[unit.Name()] = params.MeterStatus{Color: strings.ToLower(status.Code.String()), Message: status.Info}
+		if isColorStatus(meterStatus.Code) {
+			unitsMap[unit.Name()] = params.MeterStatus{Color: strings.ToLower(meterStatus.Code.String()), Message: meterStatus.Info}
 		}
 	}
 	if len(unitsMap) > 0 {
@@ -715,40 +780,29 @@ type lifer interface {
 }
 
 // processUnitAndAgentStatus retrieves status information for both unit and unitAgents.
-func processUnitAndAgentStatus(unit *state.Unit, status *params.UnitStatus) {
-	status.UnitAgent, status.Workload = processUnitStatus(unit)
+func processUnitAndAgentStatus(unit *state.Unit, unitStatus *params.UnitStatus) {
+	unitStatus.UnitAgent, unitStatus.Workload = processUnitStatus(unit)
 
-	// Legacy fields required until Juju 2.0.
-	// We only display pending, started, error, stopped.
-	var ok bool
-	legacyState, ok := state.TranslateToLegacyAgentState(
-		state.Status(status.UnitAgent.Status),
-		state.Status(status.Workload.Status),
-		status.Workload.Info,
-	)
-	if !ok {
-		logger.Warningf(
-			"translate to legacy status encounted unexpected workload status %q and agent status %q",
-			status.Workload.Status, status.UnitAgent.Status)
-	}
-	status.AgentState = params.Status(legacyState)
-	if status.AgentState == params.StatusError {
-		status.AgentStateInfo = status.Workload.Info
-	}
-	status.AgentVersion = status.UnitAgent.Version
-	status.Life = status.UnitAgent.Life
-	status.Err = status.UnitAgent.Err
+	unitStatus.AgentVersion = unitStatus.UnitAgent.Version
+	unitStatus.Life = unitStatus.UnitAgent.Life
+	unitStatus.Err = unitStatus.UnitAgent.Err
 
-	processUnitLost(unit, status)
+	processUnitLost(unit, unitStatus)
 
 	return
 }
 
 // populateStatusFromGetter creates status information for machines, units.
-func populateStatusFromGetter(agent *params.AgentStatus, getter state.StatusGetter) {
+func populateStatusFromGetter(agent *params.AgentStatus, getter status.StatusGetter) {
 	statusInfo, err := getter.Status()
+	populateStatusFromStatusInfoAndErr(agent, statusInfo, err)
+}
+
+// populateStatusFromStatusInfoAndErr creates AgentStatus from the typical output
+// of a status getter.
+func populateStatusFromStatusInfoAndErr(agent *params.AgentStatus, statusInfo status.StatusInfo, err error) {
 	agent.Err = err
-	agent.Status = params.Status(statusInfo.Status)
+	agent.Status = statusInfo.Status
 	agent.Info = statusInfo.Message
 	agent.Data = filterStatusData(statusInfo.Data)
 	agent.Since = statusInfo.Since
@@ -768,7 +822,7 @@ func processMachine(machine *state.Machine) (out params.AgentStatus) {
 	if out.Err != nil {
 		return
 	}
-	if out.Status == params.StatusPending {
+	if out.Status == status.StatusPending || out.Status == status.StatusAllocating {
 		// The status is pending - there's no point
 		// in enquiring about the agent liveness.
 		return
@@ -792,25 +846,25 @@ func processUnitStatus(unit *state.Unit) (agentStatus, workloadStatus params.Age
 	return
 }
 
-func canBeLost(status *params.UnitStatus) bool {
-	switch status.UnitAgent.Status {
-	case params.StatusAllocating:
+func canBeLost(unitStatus *params.UnitStatus) bool {
+	switch unitStatus.UnitAgent.Status {
+	case status.StatusAllocating:
 		return false
-	case params.StatusExecuting:
-		return status.UnitAgent.Info != operation.RunningHookMessage(string(hooks.Install))
+	case status.StatusExecuting:
+		return unitStatus.UnitAgent.Info != operation.RunningHookMessage(string(hooks.Install))
 	}
 	// TODO(fwereade/wallyworld): we should have an explicit place in the model
 	// to tell us when we've hit this point, instead of piggybacking on top of
 	// status and/or status history.
-	isInstalled := status.Workload.Status != params.StatusMaintenance || status.Workload.Info != state.MessageInstalling
+	isInstalled := unitStatus.Workload.Status != status.StatusMaintenance || unitStatus.Workload.Info != status.MessageInstalling
 	return isInstalled
 }
 
 // processUnitLost determines whether the given unit should be marked as lost.
 // TODO(fwereade/wallyworld): this is also model-level code and should sit in
 // between state and this package.
-func processUnitLost(unit *state.Unit, status *params.UnitStatus) {
-	if !canBeLost(status) {
+func processUnitLost(unit *state.Unit, unitStatus *params.UnitStatus) {
+	if !canBeLost(unitStatus) {
 		// The status is allocating or installing - there's no point
 		// in enquiring about the agent liveness.
 		return
@@ -824,12 +878,12 @@ func processUnitLost(unit *state.Unit, status *params.UnitStatus) {
 		// If the unit is in error, it would be bad to throw away
 		// the error information as when the agent reconnects, that
 		// error information would then be lost.
-		if status.Workload.Status != params.StatusError {
-			status.Workload.Status = params.StatusUnknown
-			status.Workload.Info = fmt.Sprintf("agent is lost, sorry! See 'juju status-history %s'", unit.Name())
+		if unitStatus.Workload.Status != status.StatusError {
+			unitStatus.Workload.Status = status.StatusUnknown
+			unitStatus.Workload.Info = fmt.Sprintf("agent is lost, sorry! See 'juju status-history %s'", unit.Name())
 		}
-		status.UnitAgent.Status = params.StatusLost
-		status.UnitAgent.Info = "agent is not communicating with the server"
+		unitStatus.UnitAgent.Status = status.StatusLost
+		unitStatus.UnitAgent.Info = "agent is not communicating with the server"
 	}
 }
 

--- a/apiserver/client/status_test.go
+++ b/apiserver/client/status_test.go
@@ -46,22 +46,6 @@ func (s *statusSuite) TestFullStatus(c *gc.C) {
 	c.Check(resultMachine.Series, gc.Equals, machine.Series())
 }
 
-func (s *statusSuite) TestLegacyStatus(c *gc.C) {
-	machine := s.addMachine(c)
-	instanceId := "i-fakeinstance"
-	err := machine.SetProvisioned(instance.Id(instanceId), "fakenonce", nil)
-	c.Assert(err, jc.ErrorIsNil)
-	client := s.APIState.Client()
-	status, err := client.LegacyStatus()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Check(status.Machines, gc.HasLen, 1)
-	resultMachine, ok := status.Machines[machine.Id()]
-	if !ok {
-		c.Fatalf("Missing machine with id %q", machine.Id())
-	}
-	c.Check(resultMachine.InstanceId, gc.Equals, instanceId)
-}
-
 var _ = gc.Suite(&statusUnitTestSuite{})
 
 type statusUnitTestSuite struct {

--- a/apiserver/client/statushistory_test.go
+++ b/apiserver/client/statushistory_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/juju/juju/apiserver/client"
 	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
-	"github.com/juju/juju/state"
+	"github.com/juju/juju/status"
 	"github.com/juju/juju/testing"
 )
 
@@ -36,12 +36,12 @@ func (s *statusHistoryTestSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-func statusInfoWithDates(si []state.StatusInfo) []state.StatusInfo {
+func statusInfoWithDates(si []status.StatusInfo) []status.StatusInfo {
 	// Add timestamps to input status info records.
 	// Timestamps will be in descending order so that we can
 	// check that sorting has occurred and the output should
 	// be in ascending order.
-	result := make([]state.StatusInfo, len(si))
+	result := make([]status.StatusInfo, len(si))
 	for i, s := range si {
 		t := time.Unix(int64(1000-i), 0)
 		s.Since = &t
@@ -50,29 +50,30 @@ func statusInfoWithDates(si []state.StatusInfo) []state.StatusInfo {
 	return result
 }
 
-func reverseStatusInfo(si []state.StatusInfo) []state.StatusInfo {
-	result := make([]state.StatusInfo, len(si))
+func reverseStatusInfo(si []status.StatusInfo) []status.StatusInfo {
+	result := make([]status.StatusInfo, len(si))
 	for i, s := range si {
 		result[len(si)-i-1] = s
 	}
 	return result
 }
 
-func checkStatusInfo(c *gc.C, obtained []params.AgentStatus, expected []state.StatusInfo) {
+func checkStatusInfo(c *gc.C, obtained []params.AgentStatus, expected []status.StatusInfo) {
 	c.Assert(len(obtained), gc.Equals, len(expected))
 	lastTimestamp := int64(0)
 	for i, obtainedInfo := range obtained {
+		c.Logf("Checking status %q with info %q", obtainedInfo.Status, obtainedInfo.Info)
 		thisTimeStamp := obtainedInfo.Since.Unix()
 		c.Assert(thisTimeStamp >= lastTimestamp, jc.IsTrue)
 		lastTimestamp = thisTimeStamp
 		obtainedInfo.Since = nil
-		c.Assert(obtainedInfo.Status, gc.Equals, params.Status(expected[i].Status))
+		c.Assert(obtainedInfo.Status, gc.Equals, status.Status(expected[i].Status))
 		c.Assert(obtainedInfo.Info, gc.Equals, expected[i].Message)
 	}
 }
 
 func (s *statusHistoryTestSuite) TestSizeRequired(c *gc.C) {
-	_, err := s.api.UnitStatusHistory(params.StatusHistory{
+	_, err := s.api.StatusHistory(params.StatusHistoryArgs{
 		Name: "unit",
 		Kind: params.KindCombined,
 		Size: 0,
@@ -81,22 +82,22 @@ func (s *statusHistoryTestSuite) TestSizeRequired(c *gc.C) {
 }
 
 func (s *statusHistoryTestSuite) TestStatusHistoryUnitOnly(c *gc.C) {
-	s.st.unitHistory = statusInfoWithDates([]state.StatusInfo{
+	s.st.unitHistory = statusInfoWithDates([]status.StatusInfo{
 		{
-			Status:  state.StatusMaintenance,
+			Status:  status.StatusMaintenance,
 			Message: "working",
 		},
 		{
-			Status:  state.StatusActive,
+			Status:  status.StatusActive,
 			Message: "running",
 		},
 	})
-	s.st.agentHistory = statusInfoWithDates([]state.StatusInfo{
+	s.st.agentHistory = statusInfoWithDates([]status.StatusInfo{
 		{
-			Status: state.StatusIdle,
+			Status: status.StatusIdle,
 		},
 	})
-	h, err := s.api.UnitStatusHistory(params.StatusHistory{
+	h, err := s.api.StatusHistory(params.StatusHistoryArgs{
 		Name: "unit/0",
 		Kind: params.KindWorkload,
 		Size: 10,
@@ -106,25 +107,25 @@ func (s *statusHistoryTestSuite) TestStatusHistoryUnitOnly(c *gc.C) {
 }
 
 func (s *statusHistoryTestSuite) TestStatusHistoryAgentOnly(c *gc.C) {
-	s.st.unitHistory = statusInfoWithDates([]state.StatusInfo{
+	s.st.unitHistory = statusInfoWithDates([]status.StatusInfo{
 		{
-			Status:  state.StatusMaintenance,
+			Status:  status.StatusMaintenance,
 			Message: "working",
 		},
 		{
-			Status:  state.StatusActive,
+			Status:  status.StatusActive,
 			Message: "running",
 		},
 	})
-	s.st.agentHistory = statusInfoWithDates([]state.StatusInfo{
+	s.st.agentHistory = statusInfoWithDates([]status.StatusInfo{
 		{
-			Status: state.StatusExecuting,
+			Status: status.StatusExecuting,
 		},
 		{
-			Status: state.StatusIdle,
+			Status: status.StatusIdle,
 		},
 	})
-	h, err := s.api.UnitStatusHistory(params.StatusHistory{
+	h, err := s.api.StatusHistory(params.StatusHistoryArgs{
 		Name: "unit/0",
 		Kind: params.KindAgent,
 		Size: 10,
@@ -134,46 +135,47 @@ func (s *statusHistoryTestSuite) TestStatusHistoryAgentOnly(c *gc.C) {
 }
 
 func (s *statusHistoryTestSuite) TestStatusHistoryCombined(c *gc.C) {
-	s.st.unitHistory = statusInfoWithDates([]state.StatusInfo{
+	s.st.unitHistory = statusInfoWithDates([]status.StatusInfo{
 		{
-			Status:  state.StatusMaintenance,
+			Status:  status.StatusMaintenance,
 			Message: "working",
 		},
 		{
-			Status:  state.StatusActive,
+			Status:  status.StatusActive,
 			Message: "running",
 		},
 		{
-			Status:  state.StatusBlocked,
+			Status:  status.StatusBlocked,
 			Message: "waiting",
 		},
 	})
-	s.st.agentHistory = statusInfoWithDates([]state.StatusInfo{
+	s.st.agentHistory = statusInfoWithDates([]status.StatusInfo{
 		{
-			Status: state.StatusExecuting,
+			Status: status.StatusExecuting,
 		},
 		{
-			Status: state.StatusIdle,
+			Status: status.StatusIdle,
 		},
 	})
-	h, err := s.api.UnitStatusHistory(params.StatusHistory{
+	h, err := s.api.StatusHistory(params.StatusHistoryArgs{
 		Name: "unit/0",
 		Kind: params.KindCombined,
 		Size: 3,
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	expected := []state.StatusInfo{
+	expected := []status.StatusInfo{
 		s.st.agentHistory[1],
 		s.st.unitHistory[0],
 		s.st.agentHistory[0],
 	}
+	c.Logf("%v", h.Statuses)
 	checkStatusInfo(c, h.Statuses, expected)
 }
 
 type mockState struct {
 	client.StateInterface
-	unitHistory  []state.StatusInfo
-	agentHistory []state.StatusInfo
+	unitHistory  []status.StatusInfo
+	agentHistory []status.StatusInfo
 }
 
 func (m *mockState) ModelUUID() string {
@@ -196,11 +198,11 @@ type mockUnit struct {
 	client.Unit
 }
 
-func (m *mockUnit) StatusHistory(size int) ([]state.StatusInfo, error) {
+func (m *mockUnit) StatusHistory(size int) ([]status.StatusInfo, error) {
 	return m.status.StatusHistory(size)
 }
 
-func (m *mockUnit) AgentHistory() state.StatusHistoryGetter {
+func (m *mockUnit) AgentHistory() status.StatusHistoryGetter {
 	return m.agent
 }
 
@@ -208,9 +210,9 @@ type mockUnitAgent struct {
 	statuses
 }
 
-type statuses []state.StatusInfo
+type statuses []status.StatusInfo
 
-func (s statuses) StatusHistory(size int) ([]state.StatusInfo, error) {
+func (s statuses) StatusHistory(size int) ([]status.StatusInfo, error) {
 	if size > len(s) {
 		size = len(s)
 	}

--- a/apiserver/common/getstatus.go
+++ b/apiserver/common/getstatus.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/status"
 )
 
 // ErrIsNotLeader is an error for operations that require for a
@@ -46,9 +47,9 @@ func (s *StatusGetter) getEntityStatus(tag names.Tag) params.StatusResult {
 		return result
 	}
 	switch getter := entity.(type) {
-	case state.StatusGetter:
+	case status.StatusGetter:
 		statusInfo, err := getter.Status()
-		result.Status = params.Status(statusInfo.Status)
+		result.Status = statusInfo.Status
 		result.Info = statusInfo.Message
 		result.Data = statusInfo.Data
 		result.Since = statusInfo.Since
@@ -170,7 +171,7 @@ func (s *ServiceStatusGetter) Status(args params.Entities) (params.ServiceStatus
 			result.Results[i].Error = ServerError(err)
 			continue
 		}
-		result.Results[i].Service.Status = params.Status(serviceStatus.Status)
+		result.Results[i].Service.Status = serviceStatus.Status
 		result.Results[i].Service.Info = serviceStatus.Message
 		result.Results[i].Service.Data = serviceStatus.Data
 		result.Results[i].Service.Since = serviceStatus.Since
@@ -178,7 +179,7 @@ func (s *ServiceStatusGetter) Status(args params.Entities) (params.ServiceStatus
 		result.Results[i].Units = make(map[string]params.StatusResult, len(unitStatuses))
 		for uTag, r := range unitStatuses {
 			ur := params.StatusResult{
-				Status: params.Status(r.Status),
+				Status: r.Status,
 				Info:   r.Message,
 				Data:   r.Data,
 				Since:  r.Since,
@@ -190,9 +191,9 @@ func (s *ServiceStatusGetter) Status(args params.Entities) (params.ServiceStatus
 }
 
 // EntityStatusFromState converts a state.StatusInfo into a params.EntityStatus.
-func EntityStatusFromState(status state.StatusInfo) params.EntityStatus {
+func EntityStatusFromState(status status.StatusInfo) params.EntityStatus {
 	return params.EntityStatus{
-		params.Status(status.Status),
+		status.Status,
 		status.Message,
 		status.Data,
 		status.Since,

--- a/apiserver/common/getstatus_test.go
+++ b/apiserver/common/getstatus_test.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
-	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/testing"
+	"github.com/juju/juju/status"
 	"github.com/juju/juju/testing/factory"
 )
 
@@ -68,40 +68,40 @@ func (s *statusGetterSuite) TestGetMachineStatus(c *gc.C) {
 	}}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, 1)
-	status := result.Results[0]
-	c.Assert(status.Error, gc.IsNil)
-	c.Assert(status.Status, gc.Equals, params.Status(state.StatusPending))
+	machineStatus := result.Results[0]
+	c.Assert(machineStatus.Error, gc.IsNil)
+	c.Assert(machineStatus.Status, gc.Equals, status.StatusPending)
 }
 
 func (s *statusGetterSuite) TestGetUnitStatus(c *gc.C) {
 	// The status has to be a valid workload status, because get status
 	// on the unit returns the workload status not the agent status as it
 	// does on a machine.
-	unit := s.Factory.MakeUnit(c, &factory.UnitParams{Status: &state.StatusInfo{
-		Status: state.StatusMaintenance,
+	unit := s.Factory.MakeUnit(c, &factory.UnitParams{Status: &status.StatusInfo{
+		Status: status.StatusMaintenance,
 	}})
 	result, err := s.getter.Status(params.Entities{[]params.Entity{{
 		unit.Tag().String(),
 	}}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, 1)
-	status := result.Results[0]
-	c.Assert(status.Error, gc.IsNil)
-	c.Assert(status.Status, gc.Equals, params.Status(state.StatusMaintenance))
+	unitStatus := result.Results[0]
+	c.Assert(unitStatus.Error, gc.IsNil)
+	c.Assert(unitStatus.Status, gc.Equals, status.StatusMaintenance)
 }
 
 func (s *statusGetterSuite) TestGetServiceStatus(c *gc.C) {
-	service := s.Factory.MakeService(c, &factory.ServiceParams{Status: &state.StatusInfo{
-		Status: state.StatusMaintenance,
+	service := s.Factory.MakeService(c, &factory.ServiceParams{Status: &status.StatusInfo{
+		Status: status.StatusMaintenance,
 	}})
 	result, err := s.getter.Status(params.Entities{[]params.Entity{{
 		service.Tag().String(),
 	}}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, 1)
-	status := result.Results[0]
-	c.Assert(status.Error, gc.IsNil)
-	c.Assert(status.Status, gc.Equals, params.Status(state.StatusMaintenance))
+	serviceStatus := result.Results[0]
+	c.Assert(serviceStatus.Error, gc.IsNil)
+	c.Assert(serviceStatus.Status, gc.Equals, status.StatusMaintenance)
 }
 
 func (s *statusGetterSuite) TestBulk(c *gc.C) {
@@ -118,7 +118,7 @@ func (s *statusGetterSuite) TestBulk(c *gc.C) {
 	c.Assert(result.Results, gc.HasLen, 3)
 	c.Assert(result.Results[0].Error, jc.Satisfies, params.IsCodeUnauthorized)
 	c.Assert(result.Results[1].Error, gc.IsNil)
-	c.Assert(result.Results[1].Status, gc.Equals, params.Status(state.StatusPending))
+	c.Assert(result.Results[1].Status, gc.Equals, status.StatusPending)
 	c.Assert(result.Results[2].Error, gc.ErrorMatches, `"bad-tag" is not a valid tag`)
 }
 
@@ -179,8 +179,8 @@ func (s *serviceStatusGetterSuite) TestGetMachineStatus(c *gc.C) {
 }
 
 func (s *serviceStatusGetterSuite) TestGetServiceStatus(c *gc.C) {
-	service := s.Factory.MakeService(c, &factory.ServiceParams{Status: &state.StatusInfo{
-		Status: state.StatusMaintenance,
+	service := s.Factory.MakeService(c, &factory.ServiceParams{Status: &status.StatusInfo{
+		Status: status.StatusMaintenance,
 	}})
 	result, err := s.getter.Status(params.Entities{[]params.Entity{{
 		service.Tag().String(),
@@ -193,8 +193,8 @@ func (s *serviceStatusGetterSuite) TestGetServiceStatus(c *gc.C) {
 
 func (s *serviceStatusGetterSuite) TestGetUnitStatusNotLeader(c *gc.C) {
 	// If the unit isn't the leader, it can't get it.
-	unit := s.Factory.MakeUnit(c, &factory.UnitParams{Status: &state.StatusInfo{
-		Status: state.StatusMaintenance,
+	unit := s.Factory.MakeUnit(c, &factory.UnitParams{Status: &status.StatusInfo{
+		Status: status.StatusMaintenance,
 	}})
 	result, err := s.getter.Status(params.Entities{[]params.Entity{{
 		unit.Tag().String(),
@@ -207,8 +207,8 @@ func (s *serviceStatusGetterSuite) TestGetUnitStatusNotLeader(c *gc.C) {
 
 func (s *serviceStatusGetterSuite) TestGetUnitStatusIsLeader(c *gc.C) {
 	// If the unit isn't the leader, it can't get it.
-	unit := s.Factory.MakeUnit(c, &factory.UnitParams{Status: &state.StatusInfo{
-		Status: state.StatusMaintenance,
+	unit := s.Factory.MakeUnit(c, &factory.UnitParams{Status: &status.StatusInfo{
+		Status: status.StatusMaintenance,
 	}})
 	service, err := unit.Service()
 	c.Assert(err, jc.ErrorIsNil)
@@ -224,13 +224,13 @@ func (s *serviceStatusGetterSuite) TestGetUnitStatusIsLeader(c *gc.C) {
 	r := result.Results[0]
 	c.Assert(r.Error, gc.IsNil)
 	c.Assert(r.Service.Error, gc.IsNil)
-	c.Assert(r.Service.Status, gc.Equals, params.Status(state.StatusMaintenance))
+	c.Assert(r.Service.Status, gc.Equals, status.StatusMaintenance)
 	units := r.Units
 	c.Assert(units, gc.HasLen, 1)
-	status, ok := units[unit.Name()]
+	unitStatus, ok := units[unit.Name()]
 	c.Assert(ok, jc.IsTrue)
-	c.Assert(status.Error, gc.IsNil)
-	c.Assert(status.Status, gc.Equals, params.Status(state.StatusMaintenance))
+	c.Assert(unitStatus.Error, gc.IsNil)
+	c.Assert(unitStatus.Status, gc.Equals, status.StatusMaintenance)
 }
 
 func (s *serviceStatusGetterSuite) TestBulk(c *gc.C) {

--- a/apiserver/instancepoller/instancepoller.go
+++ b/apiserver/instancepoller/instancepoller.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/status"
 )
 
 func init() {
@@ -156,9 +157,9 @@ func (a *InstancePollerAPI) SetProviderAddresses(args params.SetMachinesAddresse
 
 // InstanceStatus returns the instance status for each given entity.
 // Only machine tags are accepted.
-func (a *InstancePollerAPI) InstanceStatus(args params.Entities) (params.StringResults, error) {
-	result := params.StringResults{
-		Results: make([]params.StringResult, len(args.Entities)),
+func (a *InstancePollerAPI) InstanceStatus(args params.Entities) (params.StatusResults, error) {
+	result := params.StatusResults{
+		Results: make([]params.StatusResult, len(args.Entities)),
 	}
 	canAccess, err := a.accessMachine()
 	if err != nil {
@@ -167,7 +168,12 @@ func (a *InstancePollerAPI) InstanceStatus(args params.Entities) (params.StringR
 	for i, arg := range args.Entities {
 		machine, err := a.getOneMachine(arg.Tag, canAccess)
 		if err == nil {
-			result.Results[i].Result, err = machine.InstanceStatus()
+			var statusInfo status.StatusInfo
+			statusInfo, err = machine.InstanceStatus()
+			result.Results[i].Status = statusInfo.Status
+			result.Results[i].Info = statusInfo.Message
+			result.Results[i].Data = statusInfo.Data
+			result.Results[i].Since = statusInfo.Since
 		}
 		result.Results[i].Error = common.ServerError(err)
 	}
@@ -176,7 +182,7 @@ func (a *InstancePollerAPI) InstanceStatus(args params.Entities) (params.StringR
 
 // SetInstanceStatus updates the instance status for each given
 // entity. Only machine tags are accepted.
-func (a *InstancePollerAPI) SetInstanceStatus(args params.SetInstancesStatus) (params.ErrorResults, error) {
+func (a *InstancePollerAPI) SetInstanceStatus(args params.SetStatus) (params.ErrorResults, error) {
 	result := params.ErrorResults{
 		Results: make([]params.ErrorResult, len(args.Entities)),
 	}
@@ -187,7 +193,7 @@ func (a *InstancePollerAPI) SetInstanceStatus(args params.SetInstancesStatus) (p
 	for i, arg := range args.Entities {
 		machine, err := a.getOneMachine(arg.Tag, canAccess)
 		if err == nil {
-			err = machine.SetInstanceStatus(arg.Status)
+			err = machine.SetInstanceStatus(arg.Status, arg.Info, arg.Data)
 		}
 		result.Results[i].Error = common.ServerError(err)
 	}

--- a/apiserver/instancepoller/instancepoller_test.go
+++ b/apiserver/instancepoller/instancepoller_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
 	statetesting "github.com/juju/juju/state/testing"
+	"github.com/juju/juju/status"
 	coretesting "github.com/juju/juju/testing"
 )
 
@@ -336,8 +337,8 @@ func (s *InstancePollerSuite) TestInstanceIdFailure(c *gc.C) {
 
 func (s *InstancePollerSuite) TestStatusSuccess(c *gc.C) {
 	now := time.Now()
-	s1 := state.StatusInfo{
-		Status:  state.StatusError,
+	s1 := status.StatusInfo{
+		Status:  status.StatusError,
 		Message: "not really",
 		Data: map[string]interface{}{
 			"price": 4.2,
@@ -346,7 +347,7 @@ func (s *InstancePollerSuite) TestStatusSuccess(c *gc.C) {
 		},
 		Since: &now,
 	}
-	s2 := state.StatusInfo{}
+	s2 := status.StatusInfo{}
 	s.st.SetMachineInfo(c, machineInfo{id: "1", status: s1})
 	s.st.SetMachineInfo(c, machineInfo{id: "2", status: s2})
 
@@ -355,7 +356,7 @@ func (s *InstancePollerSuite) TestStatusSuccess(c *gc.C) {
 	c.Assert(result, jc.DeepEquals, params.StatusResults{
 		Results: []params.StatusResult{
 			{
-				Status: params.StatusError,
+				Status: status.StatusError,
 				Info:   s1.Message,
 				Data:   s1.Data,
 				Since:  s1.Since,
@@ -528,22 +529,23 @@ func (s *InstancePollerSuite) TestSetProviderAddressesFailure(c *gc.C) {
 }
 
 func (s *InstancePollerSuite) TestInstanceStatusSuccess(c *gc.C) {
-	s.st.SetMachineInfo(c, machineInfo{id: "1", instanceStatus: "foo"})
-	s.st.SetMachineInfo(c, machineInfo{id: "2", instanceStatus: ""})
+	s.st.SetMachineInfo(c, machineInfo{id: "1", instanceStatus: status.StatusInfo{Status: status.Status("foo")}})
+	s.st.SetMachineInfo(c, machineInfo{id: "2", instanceStatus: status.StatusInfo{Status: status.Status("")}})
 
 	result, err := s.api.InstanceStatus(s.mixedEntities)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(result, jc.DeepEquals, params.StringResults{
-		Results: []params.StringResult{
-			{Result: "foo"},
-			{Result: ""},
+	c.Assert(result, jc.DeepEquals, params.StatusResults{
+		Results: []params.StatusResult{
+			{Status: status.Status("foo")},
+			{Status: status.Status("")},
 			{Error: apiservertesting.NotFoundError("machine 42")},
 			{Error: apiservertesting.ServerError(`"service-unknown" is not a valid machine tag`)},
 			{Error: apiservertesting.ServerError(`"invalid-tag" is not a valid tag`)},
 			{Error: apiservertesting.ServerError(`"unit-missing-1" is not a valid machine tag`)},
 			{Error: apiservertesting.ServerError(`"" is not a valid tag`)},
 			{Error: apiservertesting.ServerError(`"42" is not a valid tag`)},
-		}},
+		},
+	},
 	)
 
 	s.st.CheckFindEntityCall(c, 0, "1")
@@ -560,13 +562,13 @@ func (s *InstancePollerSuite) TestInstanceStatusFailure(c *gc.C) {
 		errors.New("FAIL"),                   // m2.InstanceStatus()
 		errors.NotProvisionedf("machine 42"), // FindEntity("3") (ensure wrapping is preserved)
 	)
-	s.st.SetMachineInfo(c, machineInfo{id: "1", instanceStatus: "foo"})
-	s.st.SetMachineInfo(c, machineInfo{id: "2", instanceStatus: ""})
+	s.st.SetMachineInfo(c, machineInfo{id: "1", instanceStatus: status.StatusInfo{Status: status.Status("foo")}})
+	s.st.SetMachineInfo(c, machineInfo{id: "2", instanceStatus: status.StatusInfo{Status: status.Status("")}})
 
 	result, err := s.api.InstanceStatus(s.machineEntities)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(result, jc.DeepEquals, params.StringResults{
-		Results: []params.StringResult{
+	c.Assert(result, jc.DeepEquals, params.StatusResults{
+		Results: []params.StatusResult{
 			{Error: apiservertesting.ServerError("pow!")},
 			{Error: apiservertesting.ServerError("FAIL")},
 			{Error: apiservertesting.NotProvisionedError("42")},
@@ -580,28 +582,28 @@ func (s *InstancePollerSuite) TestInstanceStatusFailure(c *gc.C) {
 }
 
 func (s *InstancePollerSuite) TestSetInstanceStatusSuccess(c *gc.C) {
-	s.st.SetMachineInfo(c, machineInfo{id: "1", instanceStatus: "foo"})
-	s.st.SetMachineInfo(c, machineInfo{id: "2", instanceStatus: ""})
+	s.st.SetMachineInfo(c, machineInfo{id: "1", instanceStatus: status.StatusInfo{Status: status.Status("foo")}})
+	s.st.SetMachineInfo(c, machineInfo{id: "2", instanceStatus: status.StatusInfo{Status: status.Status("")}})
 
-	result, err := s.api.SetInstanceStatus(params.SetInstancesStatus{
-		Entities: []params.InstanceStatus{
-			{Tag: "machine-1", Status: ""},
-			{Tag: "machine-2", Status: "new status"},
-			{Tag: "machine-42"},
-			{Tag: "service-unknown"},
-			{Tag: "invalid-tag"},
-			{Tag: "unit-missing-1"},
-			{Tag: ""},
-			{Tag: "42"},
+	result, err := s.api.SetInstanceStatus(params.SetStatus{
+		Entities: []params.EntityStatusArgs{
+			{Tag: "machine-1", Status: status.Status("")},
+			{Tag: "machine-2", Status: status.Status("new status")},
+			{Tag: "machine-42", Status: status.Status("")},
+			{Tag: "service-unknown", Status: status.Status("")},
+			{Tag: "invalid-tag", Status: status.Status("")},
+			{Tag: "unit-missing-1", Status: status.Status("")},
+			{Tag: "", Status: status.Status("")},
+			{Tag: "42", Status: status.Status("")},
 		}},
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, s.mixedErrorResults)
 
 	s.st.CheckFindEntityCall(c, 0, "1")
-	s.st.CheckCall(c, 1, "SetInstanceStatus", "")
+	s.st.CheckCall(c, 1, "SetInstanceStatus", status.Status(""))
 	s.st.CheckFindEntityCall(c, 2, "2")
-	s.st.CheckCall(c, 3, "SetInstanceStatus", "new status")
+	s.st.CheckCall(c, 3, "SetInstanceStatus", status.Status("new status"))
 	s.st.CheckFindEntityCall(c, 4, "42")
 
 	// Ensure machines were updated.
@@ -609,13 +611,13 @@ func (s *InstancePollerSuite) TestSetInstanceStatusSuccess(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	setStatus, err := machine.InstanceStatus()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(setStatus, gc.Equals, "")
+	c.Assert(setStatus, gc.DeepEquals, status.StatusInfo{})
 
 	machine, err = s.st.Machine("2")
 	c.Assert(err, jc.ErrorIsNil)
 	setStatus, err = machine.InstanceStatus()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(setStatus, gc.Equals, "new status")
+	c.Assert(setStatus, gc.DeepEquals, status.StatusInfo{Status: "new status"})
 }
 
 func (s *InstancePollerSuite) TestSetInstanceStatusFailure(c *gc.C) {
@@ -625,14 +627,14 @@ func (s *InstancePollerSuite) TestSetInstanceStatusFailure(c *gc.C) {
 		errors.New("FAIL"),                   // m2.SetInstanceStatus()
 		errors.NotProvisionedf("machine 42"), // FindEntity("3") (ensure wrapping is preserved)
 	)
-	s.st.SetMachineInfo(c, machineInfo{id: "1", instanceStatus: "foo"})
-	s.st.SetMachineInfo(c, machineInfo{id: "2", instanceStatus: ""})
+	s.st.SetMachineInfo(c, machineInfo{id: "1", instanceStatus: status.StatusInfo{Status: status.Status("foo")}})
+	s.st.SetMachineInfo(c, machineInfo{id: "2", instanceStatus: status.StatusInfo{Status: status.Status("")}})
 
-	result, err := s.api.SetInstanceStatus(params.SetInstancesStatus{
-		Entities: []params.InstanceStatus{
-			{Tag: "machine-1", Status: "new"},
-			{Tag: "machine-2", Status: "invalid"},
-			{Tag: "machine-3", Status: ""},
+	result, err := s.api.SetInstanceStatus(params.SetStatus{
+		Entities: []params.EntityStatusArgs{
+			{Tag: "machine-1", Status: status.Status("new")},
+			{Tag: "machine-2", Status: status.Status("invalid")},
+			{Tag: "machine-3", Status: status.Status("")},
 		}},
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -640,7 +642,7 @@ func (s *InstancePollerSuite) TestSetInstanceStatusFailure(c *gc.C) {
 
 	s.st.CheckFindEntityCall(c, 0, "1")
 	s.st.CheckFindEntityCall(c, 1, "2")
-	s.st.CheckCall(c, 2, "SetInstanceStatus", "invalid")
+	s.st.CheckCall(c, 2, "SetInstanceStatus", status.Status("invalid"))
 	s.st.CheckFindEntityCall(c, 3, "3")
 }
 

--- a/apiserver/instancepoller/state.go
+++ b/apiserver/instancepoller/state.go
@@ -7,6 +7,7 @@ import (
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/status"
 )
 
 type StateMachine interface {
@@ -16,12 +17,12 @@ type StateMachine interface {
 	InstanceId() (instance.Id, error)
 	ProviderAddresses() []network.Address
 	SetProviderAddresses(...network.Address) error
-	InstanceStatus() (string, error)
-	SetInstanceStatus(status string) error
+	InstanceStatus() (status.StatusInfo, error)
+	SetInstanceStatus(status.Status, string, map[string]interface{}) error
 	String() string
 	Refresh() error
 	Life() state.Life
-	Status() (state.StatusInfo, error)
+	Status() (status.StatusInfo, error)
 	IsManual() (bool, error)
 }
 

--- a/apiserver/machine/machiner_test.go
+++ b/apiserver/machine/machiner_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/multiwatcher"
 	statetesting "github.com/juju/juju/state/testing"
+	"github.com/juju/juju/status"
 )
 
 type machinerSuite struct {
@@ -54,16 +55,16 @@ func (s *machinerSuite) TestMachinerFailsWithNonMachineAgentUser(c *gc.C) {
 }
 
 func (s *machinerSuite) TestSetStatus(c *gc.C) {
-	err := s.machine0.SetStatus(state.StatusStarted, "blah", nil)
+	err := s.machine0.SetStatus(status.StatusStarted, "blah", nil)
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.machine1.SetStatus(state.StatusStopped, "foo", nil)
+	err = s.machine1.SetStatus(status.StatusStopped, "foo", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	args := params.SetStatus{
 		Entities: []params.EntityStatusArgs{
-			{Tag: "machine-1", Status: params.StatusError, Info: "not really"},
-			{Tag: "machine-0", Status: params.StatusStopped, Info: "foobar"},
-			{Tag: "machine-42", Status: params.StatusStarted, Info: "blah"},
+			{Tag: "machine-1", Status: status.StatusError, Info: "not really"},
+			{Tag: "machine-0", Status: status.StatusStopped, Info: "foobar"},
+			{Tag: "machine-42", Status: status.StatusStarted, Info: "blah"},
 		}}
 	result, err := s.machiner.SetStatus(args)
 	c.Assert(err, jc.ErrorIsNil)
@@ -78,12 +79,12 @@ func (s *machinerSuite) TestSetStatus(c *gc.C) {
 	// Verify machine 0 - no change.
 	statusInfo, err := s.machine0.Status()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(statusInfo.Status, gc.Equals, state.StatusStarted)
+	c.Assert(statusInfo.Status, gc.Equals, status.StatusStarted)
 	c.Assert(statusInfo.Message, gc.Equals, "blah")
 	// ...machine 1 is fine though.
 	statusInfo, err = s.machine1.Status()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(statusInfo.Status, gc.Equals, state.StatusError)
+	c.Assert(statusInfo.Status, gc.Equals, status.StatusError)
 	c.Assert(statusInfo.Message, gc.Equals, "not really")
 }
 

--- a/apiserver/params/internal.go
+++ b/apiserver/params/internal.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/state/multiwatcher"
+	"github.com/juju/juju/status"
 	"github.com/juju/juju/tools"
 	"github.com/juju/juju/version"
 )
@@ -317,7 +318,7 @@ type InstancesInfo struct {
 
 // EntityStatus holds the status of an entity.
 type EntityStatus struct {
-	Status Status
+	Status status.Status
 	Info   string
 	Data   map[string]interface{}
 	Since  *time.Time
@@ -326,7 +327,7 @@ type EntityStatus struct {
 // EntityStatus holds parameters for setting the status of a single entity.
 type EntityStatusArgs struct {
 	Tag    string
-	Status Status
+	Status status.Status
 	Info   string
 	Data   map[string]interface{}
 }
@@ -334,18 +335,6 @@ type EntityStatusArgs struct {
 // SetStatus holds the parameters for making a SetStatus/UpdateStatus call.
 type SetStatus struct {
 	Entities []EntityStatusArgs
-}
-
-// InstanceStatus holds an entity tag and instance status.
-type InstanceStatus struct {
-	Tag    string
-	Status string
-}
-
-// SetInstancesStatus holds parameters for making a
-// SetInstanceStatus() call.
-type SetInstancesStatus struct {
-	Entities []InstanceStatus
 }
 
 // ConstraintsResult holds machine constraints or an error.

--- a/apiserver/params/params_test.go
+++ b/apiserver/params/params_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/multiwatcher"
+	"github.com/juju/juju/status"
 	"github.com/juju/juju/testing"
 )
 
@@ -39,11 +40,16 @@ var marshalTestCases = []struct {
 	about: "MachineInfo Delta",
 	value: multiwatcher.Delta{
 		Entity: &multiwatcher.MachineInfo{
-			ModelUUID:               "uuid",
-			Id:                      "Benji",
-			InstanceId:              "Shazam",
-			Status:                  "error",
-			StatusInfo:              "foo",
+			ModelUUID:  "uuid",
+			Id:         "Benji",
+			InstanceId: "Shazam",
+			JujuStatus: multiwatcher.StatusInfo{
+				Current: status.StatusError,
+				Message: "foo",
+			},
+			MachineStatus: multiwatcher.StatusInfo{
+				Current: status.StatusPending,
+			},
 			Life:                    multiwatcher.Life("alive"),
 			Series:                  "trusty",
 			SupportedContainers:     []instance.ContainerType{instance.LXC},
@@ -52,7 +58,7 @@ var marshalTestCases = []struct {
 			HardwareCharacteristics: &instance.HardwareCharacteristics{},
 		},
 	},
-	json: `["machine","change",{"ModelUUID": "uuid", "Id":"Benji","InstanceId":"Shazam","HasVote":false,"WantsVote":false,"Status":"error","StatusInfo":"foo","StatusData":null,"Life":"alive","Series":"trusty","SupportedContainers":["lxc"],"SupportedContainersKnown":false,"Jobs":["JobManageModel"],"Addresses":[],"HardwareCharacteristics":{}}]`,
+	json: `["machine","change",{"ModelUUID":"uuid","Id":"Benji","InstanceId":"Shazam","JujuStatus":{"Err":null,"Current":"error","Message":"foo","Since":null,"Version":"","Data":null},"MachineStatus":{"Err":null,"Current":"pending","Message":"","Since":null,"Version":"","Data":null},"Life":"alive","Series":"trusty","SupportedContainers":["lxc"],"SupportedContainersKnown":false,"HardwareCharacteristics":{},"Jobs":["JobManageModel"],"Addresses":[],"HasVote":false,"WantsVote":false}]`,
 }, {
 	about: "ServiceInfo Delta",
 	value: multiwatcher.Delta{
@@ -70,7 +76,7 @@ var marshalTestCases = []struct {
 				"foo":   false,
 			},
 			Status: multiwatcher.StatusInfo{
-				Current: multiwatcher.Status("active"),
+				Current: status.StatusActive,
 				Message: "all good",
 			},
 		},
@@ -97,18 +103,16 @@ var marshalTestCases = []struct {
 			PublicAddress:  "testing.invalid",
 			PrivateAddress: "10.0.0.1",
 			MachineId:      "1",
-			Status:         "error",
-			StatusInfo:     "foo",
 			WorkloadStatus: multiwatcher.StatusInfo{
-				Current: multiwatcher.Status("active"),
+				Current: status.StatusActive,
 				Message: "all good",
 			},
 			AgentStatus: multiwatcher.StatusInfo{
-				Current: multiwatcher.Status("idle"),
+				Current: status.StatusIdle,
 			},
 		},
 	},
-	json: `["unit", "change", {"ModelUUID": "uuid", "CharmURL": "cs:~user/precise/wordpress-42", "MachineId": "1", "Series": "precise", "Name": "Benji", "PublicAddress": "testing.invalid", "Service": "Shazam", "PrivateAddress": "10.0.0.1", "Ports": [{"Protocol": "http", "Number": 80}], "PortRanges": [{"FromPort": 80, "ToPort": 80, "Protocol": "http"}], "Status": "error", "StatusInfo": "foo", "StatusData": null, "WorkloadStatus":{"Current":"active", "Message":"all good", "Version": "", "Err": null, "Data": null, "Since": null}, "AgentStatus":{"Current":"idle", "Message":"", "Version": "", "Err": null, "Data": null, "Since": null}, "Subordinate": false}]`,
+	json: `["unit","change",{"ModelUUID":"uuid","Name":"Benji","Service":"Shazam","Series":"precise","CharmURL":"cs:~user/precise/wordpress-42","PublicAddress":"testing.invalid","PrivateAddress":"10.0.0.1","MachineId":"1","Ports":[{"Protocol":"http","Number":80}],"PortRanges":[{"FromPort":80,"ToPort":80,"Protocol":"http"}],"Subordinate":false,"WorkloadStatus":{"Err":null,"Current":"active","Message":"all good","Since":null,"Version":"","Data":null},"AgentStatus":{"Err":null,"Current":"idle","Message":"","Since":null,"Version":"","Data":null}}]`,
 }, {
 	about: "RelationInfo Delta",
 	value: multiwatcher.Delta{

--- a/apiserver/provisioner/provisioner.go
+++ b/apiserver/provisioner/provisioner.go
@@ -23,6 +23,7 @@ import (
 	"github.com/juju/juju/provider"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/watcher"
+	"github.com/juju/juju/status"
 	"github.com/juju/juju/storage"
 	"github.com/juju/juju/storage/poolmanager"
 	"github.com/juju/juju/storage/provider/registry"
@@ -39,6 +40,15 @@ func init() {
 	// receive this additional information; otherwise they are
 	// compatible.
 	common.RegisterStandardFacade("Provisioner", 2, NewProvisionerAPI)
+}
+
+// InstanceStateCapableMachine represents a machine whose instance status
+// can be set and queried.
+type InstanceStateCapableMachine interface {
+	state.Entity
+
+	InstanceStatus() (status.StatusInfo, error)
+	SetInstanceStatus(status.Status, string, map[string]interface{}) error
 }
 
 // ProvisionerAPI provides access to the Provisioner API facade.
@@ -335,10 +345,10 @@ func (p *ProvisionerAPI) MachinesWithTransientErrors() (params.StatusResults, er
 		if err != nil {
 			continue
 		}
-		result.Status = params.Status(statusInfo.Status)
+		result.Status = status.Status(statusInfo.Status)
 		result.Info = statusInfo.Message
 		result.Data = statusInfo.Data
-		if result.Status != params.StatusError {
+		if result.Status != status.StatusError {
 			continue
 		}
 		// Transient errors are marked as such in the status data.

--- a/apiserver/provisioner/provisioner_test.go
+++ b/apiserver/provisioner/provisioner_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/state"
 	statetesting "github.com/juju/juju/state/testing"
+	"github.com/juju/juju/status"
 	"github.com/juju/juju/storage/poolmanager"
 	coretesting "github.com/juju/juju/testing"
 )
@@ -326,22 +327,22 @@ func (s *withoutControllerSuite) TestRemove(c *gc.C) {
 }
 
 func (s *withoutControllerSuite) TestSetStatus(c *gc.C) {
-	err := s.machines[0].SetStatus(state.StatusStarted, "blah", nil)
+	err := s.machines[0].SetStatus(status.StatusStarted, "blah", nil)
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.machines[1].SetStatus(state.StatusStopped, "foo", nil)
+	err = s.machines[1].SetStatus(status.StatusStopped, "foo", nil)
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.machines[2].SetStatus(state.StatusError, "not really", nil)
+	err = s.machines[2].SetStatus(status.StatusError, "not really", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	args := params.SetStatus{
 		Entities: []params.EntityStatusArgs{
-			{Tag: s.machines[0].Tag().String(), Status: params.StatusError, Info: "not really",
+			{Tag: s.machines[0].Tag().String(), Status: status.StatusError, Info: "not really",
 				Data: map[string]interface{}{"foo": "bar"}},
-			{Tag: s.machines[1].Tag().String(), Status: params.StatusStopped, Info: "foobar"},
-			{Tag: s.machines[2].Tag().String(), Status: params.StatusStarted, Info: "again"},
-			{Tag: "machine-42", Status: params.StatusStarted, Info: "blah"},
-			{Tag: "unit-foo-0", Status: params.StatusStopped, Info: "foobar"},
-			{Tag: "service-bar", Status: params.StatusStopped, Info: "foobar"},
+			{Tag: s.machines[1].Tag().String(), Status: status.StatusStopped, Info: "foobar"},
+			{Tag: s.machines[2].Tag().String(), Status: status.StatusStarted, Info: "again"},
+			{Tag: "machine-42", Status: status.StatusStarted, Info: "blah"},
+			{Tag: "unit-foo-0", Status: status.StatusStopped, Info: "foobar"},
+			{Tag: "service-bar", Status: status.StatusStopped, Info: "foobar"},
 		}}
 	result, err := s.provisioner.SetStatus(args)
 	c.Assert(err, jc.ErrorIsNil)
@@ -357,23 +358,23 @@ func (s *withoutControllerSuite) TestSetStatus(c *gc.C) {
 	})
 
 	// Verify the changes.
-	s.assertStatus(c, 0, state.StatusError, "not really", map[string]interface{}{"foo": "bar"})
-	s.assertStatus(c, 1, state.StatusStopped, "foobar", map[string]interface{}{})
-	s.assertStatus(c, 2, state.StatusStarted, "again", map[string]interface{}{})
+	s.assertStatus(c, 0, status.StatusError, "not really", map[string]interface{}{"foo": "bar"})
+	s.assertStatus(c, 1, status.StatusStopped, "foobar", map[string]interface{}{})
+	s.assertStatus(c, 2, status.StatusStarted, "again", map[string]interface{}{})
 }
 
 func (s *withoutControllerSuite) TestMachinesWithTransientErrors(c *gc.C) {
-	err := s.machines[0].SetStatus(state.StatusStarted, "blah", nil)
+	err := s.machines[0].SetStatus(status.StatusStarted, "blah", nil)
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.machines[1].SetStatus(state.StatusError, "transient error",
+	err = s.machines[1].SetStatus(status.StatusError, "transient error",
 		map[string]interface{}{"transient": true, "foo": "bar"})
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.machines[2].SetStatus(state.StatusError, "error", map[string]interface{}{"transient": false})
+	err = s.machines[2].SetStatus(status.StatusError, "error", map[string]interface{}{"transient": false})
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.machines[3].SetStatus(state.StatusError, "error", nil)
+	err = s.machines[3].SetStatus(status.StatusError, "error", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	// Machine 4 is provisioned but error not reset yet.
-	err = s.machines[4].SetStatus(state.StatusError, "transient error",
+	err = s.machines[4].SetStatus(status.StatusError, "transient error",
 		map[string]interface{}{"transient": true, "foo": "bar"})
 	c.Assert(err, jc.ErrorIsNil)
 	hwChars := instance.MustParseHardware("arch=i386", "mem=4G")
@@ -397,14 +398,14 @@ func (s *withoutControllerSuite) TestMachinesWithTransientErrorsPermission(c *gc
 	anAuthorizer.Tag = names.NewMachineTag("1")
 	aProvisioner, err := provisioner.NewProvisionerAPI(s.State, s.resources,
 		anAuthorizer)
-	err = s.machines[0].SetStatus(state.StatusStarted, "blah", nil)
+	err = s.machines[0].SetStatus(status.StatusStarted, "blah", nil)
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.machines[1].SetStatus(state.StatusError, "transient error",
+	err = s.machines[1].SetStatus(status.StatusError, "transient error",
 		map[string]interface{}{"transient": true, "foo": "bar"})
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.machines[2].SetStatus(state.StatusError, "error", map[string]interface{}{"transient": false})
+	err = s.machines[2].SetStatus(status.StatusError, "error", map[string]interface{}{"transient": false})
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.machines[3].SetStatus(state.StatusError, "error", nil)
+	err = s.machines[3].SetStatus(status.StatusError, "error", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	result, err := aProvisioner.MachinesWithTransientErrors()
@@ -457,7 +458,7 @@ func (s *withoutControllerSuite) assertLife(c *gc.C, index int, expectLife state
 	c.Assert(s.machines[index].Life(), gc.Equals, expectLife)
 }
 
-func (s *withoutControllerSuite) assertStatus(c *gc.C, index int, expectStatus state.Status, expectInfo string,
+func (s *withoutControllerSuite) assertStatus(c *gc.C, index int, expectStatus status.Status, expectInfo string,
 	expectData map[string]interface{}) {
 
 	statusInfo, err := s.machines[index].Status()
@@ -554,11 +555,11 @@ func (s *withoutControllerSuite) TestModelConfigNonManager(c *gc.C) {
 }
 
 func (s *withoutControllerSuite) TestStatus(c *gc.C) {
-	err := s.machines[0].SetStatus(state.StatusStarted, "blah", nil)
+	err := s.machines[0].SetStatus(status.StatusStarted, "blah", nil)
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.machines[1].SetStatus(state.StatusStopped, "foo", nil)
+	err = s.machines[1].SetStatus(status.StatusStopped, "foo", nil)
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.machines[2].SetStatus(state.StatusError, "not really", map[string]interface{}{"foo": "bar"})
+	err = s.machines[2].SetStatus(status.StatusError, "not really", map[string]interface{}{"foo": "bar"})
 	c.Assert(err, jc.ErrorIsNil)
 
 	args := params.Entities{Entities: []params.Entity{
@@ -582,9 +583,9 @@ func (s *withoutControllerSuite) TestStatus(c *gc.C) {
 	}
 	c.Assert(result, gc.DeepEquals, params.StatusResults{
 		Results: []params.StatusResult{
-			{Status: params.StatusStarted, Info: "blah", Data: map[string]interface{}{}},
-			{Status: params.StatusStopped, Info: "foo", Data: map[string]interface{}{}},
-			{Status: params.StatusError, Info: "not really", Data: map[string]interface{}{"foo": "bar"}},
+			{Status: status.StatusStarted, Info: "blah", Data: map[string]interface{}{}},
+			{Status: status.StatusStopped, Info: "foo", Data: map[string]interface{}{}},
+			{Status: status.StatusError, Info: "not really", Data: map[string]interface{}{"foo": "bar"}},
 			{Error: apiservertesting.NotFoundError("machine 42")},
 			{Error: apiservertesting.ErrUnauthorized},
 			{Error: apiservertesting.ErrUnauthorized},

--- a/apiserver/read_only_calls.go
+++ b/apiserver/read_only_calls.go
@@ -41,7 +41,7 @@ var readOnlyCalls = set.NewStrings(
 	// ResolveCharms, while being technically read only, isn't a useful
 	// command for a read only user to run.
 	// Status is so old it shouldn't be used.
-	"Client.UnitStatusHistory",
+	"Client.StatusHistory",
 	"Client.WatchAll",
 	// TODO: add controller work.
 	"KeyManager.ListKeys",

--- a/apiserver/service/service_test.go
+++ b/apiserver/service/service_test.go
@@ -28,6 +28,7 @@ import (
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/state"
 	statestorage "github.com/juju/juju/state/storage"
+	"github.com/juju/juju/status"
 	"github.com/juju/juju/storage"
 	"github.com/juju/juju/storage/poolmanager"
 	"github.com/juju/juju/storage/provider"
@@ -2031,7 +2032,7 @@ func (s *serviceSuite) TestDestroyPrincipalUnits(c *gc.C) {
 	for i := range units {
 		unit, err := wordpress.AddUnit()
 		c.Assert(err, jc.ErrorIsNil)
-		err = unit.SetAgentStatus(state.StatusIdle, "", nil)
+		err = unit.SetAgentStatus(status.StatusIdle, "", nil)
 		c.Assert(err, jc.ErrorIsNil)
 		units[i] = unit
 	}
@@ -2108,7 +2109,7 @@ func (s *serviceSuite) setupDestroyPrincipalUnits(c *gc.C) []*state.Unit {
 	for i := range units {
 		unit, err := wordpress.AddUnit()
 		c.Assert(err, jc.ErrorIsNil)
-		err = unit.SetAgentStatus(state.StatusIdle, "", nil)
+		err = unit.SetAgentStatus(status.StatusIdle, "", nil)
 		c.Assert(err, jc.ErrorIsNil)
 		units[i] = unit
 	}

--- a/apiserver/storage/mock_test.go
+++ b/apiserver/storage/mock_test.go
@@ -9,6 +9,7 @@ import (
 	"gopkg.in/juju/charm.v6-unstable"
 
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/status"
 	jujustorage "github.com/juju/juju/storage"
 )
 
@@ -202,8 +203,8 @@ func (m *mockVolume) Info() (state.VolumeInfo, error) {
 	return state.VolumeInfo{}, errors.NotProvisionedf("%v", m.tag)
 }
 
-func (m *mockVolume) Status() (state.StatusInfo, error) {
-	return state.StatusInfo{Status: state.StatusAttached}, nil
+func (m *mockVolume) Status() (status.StatusInfo, error) {
+	return status.StatusInfo{Status: status.StatusAttached}, nil
 }
 
 type mockFilesystem struct {
@@ -239,8 +240,8 @@ func (m *mockFilesystem) Info() (state.FilesystemInfo, error) {
 	return state.FilesystemInfo{}, errors.NotProvisionedf("filesystem")
 }
 
-func (m *mockFilesystem) Status() (state.StatusInfo, error) {
-	return state.StatusInfo{Status: state.StatusAttached}, nil
+func (m *mockFilesystem) Status() (status.StatusInfo, error) {
+	return status.StatusInfo{Status: status.StatusAttached}, nil
 }
 
 type mockFilesystemAttachment struct {

--- a/apiserver/storage/storage.go
+++ b/apiserver/storage/storage.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/juju/apiserver/common/storagecommon"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/status"
 	"github.com/juju/juju/storage"
 	"github.com/juju/juju/storage/poolmanager"
 	"github.com/juju/juju/storage/provider/registry"
@@ -132,7 +133,7 @@ func (api *API) listStorageDetails(filter params.StorageFilter) ([]params.Storag
 func createStorageDetails(st storageAccess, si state.StorageInstance) (*params.StorageDetails, error) {
 	// Get information from underlying volume or filesystem.
 	var persistent bool
-	var statusEntity state.StatusGetter
+	var statusEntity status.StatusGetter
 	if si.Kind() != state.StorageKindBlock {
 		// TODO(axw) when we support persistent filesystems,
 		// e.g. CephFS, we'll need to do set "persistent"

--- a/apiserver/storage/storage_test.go
+++ b/apiserver/storage/storage_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/status"
 )
 
 type storageSuite struct {
@@ -83,7 +84,7 @@ func (s *storageSuite) TestStorageListVolume(c *gc.C) {
 	c.Assert(found.Results[0].Result, gc.HasLen, 1)
 	wantedDetails := s.createTestStorageDetails()
 	wantedDetails.Kind = params.StorageKindBlock
-	wantedDetails.Status.Status = params.StatusAttached
+	wantedDetails.Status.Status = status.StatusAttached
 	c.Assert(found.Results[0].Result[0], jc.DeepEquals, wantedDetails)
 }
 

--- a/apiserver/storage/volumelist_test.go
+++ b/apiserver/storage/volumelist_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/status"
 )
 
 type volumeSuite struct {
@@ -150,7 +151,7 @@ func (s *volumeSuite) TestListVolumesStorageLocationNoBlockDevice(c *gc.C) {
 	}
 	expected := s.expectedVolumeDetails()
 	expected.Storage.Kind = params.StorageKindBlock
-	expected.Storage.Status.Status = params.StatusAttached
+	expected.Storage.Status.Status = status.StatusAttached
 	expected.MachineAttachments[s.machineTag.String()] = params.VolumeAttachmentInfo{
 		ReadOnly: true,
 	}
@@ -176,7 +177,7 @@ func (s *volumeSuite) TestListVolumesStorageLocationBlockDevicePath(c *gc.C) {
 	}
 	expected := s.expectedVolumeDetails()
 	expected.Storage.Kind = params.StorageKindBlock
-	expected.Storage.Status.Status = params.StatusAttached
+	expected.Storage.Status.Status = status.StatusAttached
 	storageAttachmentDetails := expected.Storage.Attachments["unit-mysql-0"]
 	storageAttachmentDetails.Location = filepath.FromSlash("/dev/sdd")
 	expected.Storage.Attachments["unit-mysql-0"] = storageAttachmentDetails

--- a/apiserver/uniter/uniter_test.go
+++ b/apiserver/uniter/uniter_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/multiwatcher"
 	statetesting "github.com/juju/juju/state/testing"
+	"github.com/juju/juju/status"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/testing/factory"
 	jujuFactory "github.com/juju/juju/testing/factory"
@@ -134,16 +135,16 @@ func (s *uniterSuite) TestUniterFailsWithNonUnitAgentUser(c *gc.C) {
 }
 
 func (s *uniterSuite) TestSetStatus(c *gc.C) {
-	err := s.wordpressUnit.SetAgentStatus(state.StatusExecuting, "blah", nil)
+	err := s.wordpressUnit.SetAgentStatus(status.StatusExecuting, "blah", nil)
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.mysqlUnit.SetAgentStatus(state.StatusExecuting, "foo", nil)
+	err = s.mysqlUnit.SetAgentStatus(status.StatusExecuting, "foo", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	args := params.SetStatus{
 		Entities: []params.EntityStatusArgs{
-			{Tag: "unit-mysql-0", Status: params.StatusError, Info: "not really"},
-			{Tag: "unit-wordpress-0", Status: params.StatusRebooting, Info: "foobar"},
-			{Tag: "unit-foo-42", Status: params.StatusActive, Info: "blah"},
+			{Tag: "unit-mysql-0", Status: status.StatusError, Info: "not really"},
+			{Tag: "unit-wordpress-0", Status: status.StatusRebooting, Info: "foobar"},
+			{Tag: "unit-foo-42", Status: status.StatusActive, Info: "blah"},
 		}}
 	result, err := s.uniter.SetStatus(args)
 	c.Assert(err, jc.ErrorIsNil)
@@ -158,26 +159,26 @@ func (s *uniterSuite) TestSetStatus(c *gc.C) {
 	// Verify mysqlUnit - no change.
 	statusInfo, err := s.mysqlUnit.AgentStatus()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(statusInfo.Status, gc.Equals, state.StatusExecuting)
+	c.Assert(statusInfo.Status, gc.Equals, status.StatusExecuting)
 	c.Assert(statusInfo.Message, gc.Equals, "foo")
 	// ...wordpressUnit is fine though.
 	statusInfo, err = s.wordpressUnit.AgentStatus()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(statusInfo.Status, gc.Equals, state.StatusRebooting)
+	c.Assert(statusInfo.Status, gc.Equals, status.StatusRebooting)
 	c.Assert(statusInfo.Message, gc.Equals, "foobar")
 }
 
 func (s *uniterSuite) TestSetAgentStatus(c *gc.C) {
-	err := s.wordpressUnit.SetAgentStatus(state.StatusExecuting, "blah", nil)
+	err := s.wordpressUnit.SetAgentStatus(status.StatusExecuting, "blah", nil)
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.mysqlUnit.SetAgentStatus(state.StatusExecuting, "foo", nil)
+	err = s.mysqlUnit.SetAgentStatus(status.StatusExecuting, "foo", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	args := params.SetStatus{
 		Entities: []params.EntityStatusArgs{
-			{Tag: "unit-mysql-0", Status: params.StatusError, Info: "not really"},
-			{Tag: "unit-wordpress-0", Status: params.StatusExecuting, Info: "foobar"},
-			{Tag: "unit-foo-42", Status: params.StatusRebooting, Info: "blah"},
+			{Tag: "unit-mysql-0", Status: status.StatusError, Info: "not really"},
+			{Tag: "unit-wordpress-0", Status: status.StatusExecuting, Info: "foobar"},
+			{Tag: "unit-foo-42", Status: status.StatusRebooting, Info: "blah"},
 		}}
 	result, err := s.uniter.SetAgentStatus(args)
 	c.Assert(err, jc.ErrorIsNil)
@@ -192,26 +193,26 @@ func (s *uniterSuite) TestSetAgentStatus(c *gc.C) {
 	// Verify mysqlUnit - no change.
 	statusInfo, err := s.mysqlUnit.AgentStatus()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(statusInfo.Status, gc.Equals, state.StatusExecuting)
+	c.Assert(statusInfo.Status, gc.Equals, status.StatusExecuting)
 	c.Assert(statusInfo.Message, gc.Equals, "foo")
 	// ...wordpressUnit is fine though.
 	statusInfo, err = s.wordpressUnit.AgentStatus()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(statusInfo.Status, gc.Equals, state.StatusExecuting)
+	c.Assert(statusInfo.Status, gc.Equals, status.StatusExecuting)
 	c.Assert(statusInfo.Message, gc.Equals, "foobar")
 }
 
 func (s *uniterSuite) TestSetUnitStatus(c *gc.C) {
-	err := s.wordpressUnit.SetStatus(state.StatusActive, "blah", nil)
+	err := s.wordpressUnit.SetStatus(status.StatusActive, "blah", nil)
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.mysqlUnit.SetStatus(state.StatusTerminated, "foo", nil)
+	err = s.mysqlUnit.SetStatus(status.StatusTerminated, "foo", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	args := params.SetStatus{
 		Entities: []params.EntityStatusArgs{
-			{Tag: "unit-mysql-0", Status: params.StatusError, Info: "not really"},
-			{Tag: "unit-wordpress-0", Status: params.StatusTerminated, Info: "foobar"},
-			{Tag: "unit-foo-42", Status: params.StatusActive, Info: "blah"},
+			{Tag: "unit-mysql-0", Status: status.StatusError, Info: "not really"},
+			{Tag: "unit-wordpress-0", Status: status.StatusTerminated, Info: "foobar"},
+			{Tag: "unit-foo-42", Status: status.StatusActive, Info: "blah"},
 		}}
 	result, err := s.uniter.SetUnitStatus(args)
 	c.Assert(err, jc.ErrorIsNil)
@@ -226,12 +227,12 @@ func (s *uniterSuite) TestSetUnitStatus(c *gc.C) {
 	// Verify mysqlUnit - no change.
 	statusInfo, err := s.mysqlUnit.Status()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(statusInfo.Status, gc.Equals, state.StatusTerminated)
+	c.Assert(statusInfo.Status, gc.Equals, status.StatusTerminated)
 	c.Assert(statusInfo.Message, gc.Equals, "foo")
 	// ...wordpressUnit is fine though.
 	statusInfo, err = s.wordpressUnit.Status()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(statusInfo.Status, gc.Equals, state.StatusTerminated)
+	c.Assert(statusInfo.Status, gc.Equals, status.StatusTerminated)
 	c.Assert(statusInfo.Message, gc.Equals, "foobar")
 }
 
@@ -2060,9 +2061,9 @@ func (s *uniterSuite) TestStorageAttachments(c *gc.C) {
 }
 
 func (s *uniterSuite) TestUnitStatus(c *gc.C) {
-	err := s.wordpressUnit.SetStatus(state.StatusMaintenance, "blah", nil)
+	err := s.wordpressUnit.SetStatus(status.StatusMaintenance, "blah", nil)
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.mysqlUnit.SetStatus(state.StatusTerminated, "foo", nil)
+	err = s.mysqlUnit.SetStatus(status.StatusTerminated, "foo", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	args := params.Entities{
@@ -2087,7 +2088,7 @@ func (s *uniterSuite) TestUnitStatus(c *gc.C) {
 	c.Assert(result, gc.DeepEquals, params.StatusResults{
 		Results: []params.StatusResult{
 			{Error: apiservertesting.ErrUnauthorized},
-			{Status: params.StatusMaintenance, Info: "blah", Data: map[string]interface{}{}},
+			{Status: status.StatusMaintenance, Info: "blah", Data: map[string]interface{}{}},
 			{Error: apiservertesting.ErrUnauthorized},
 			{Error: apiservertesting.ErrUnauthorized},
 			{Error: apiservertesting.ServerError(`"invalid" is not a valid tag`)},

--- a/cmd/juju/commands/resolved_test.go
+++ b/cmd/juju/commands/resolved_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/juju/cmd/juju/service"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/status"
 	"github.com/juju/juju/testcharms"
 	"github.com/juju/juju/testing"
 )
@@ -95,7 +96,7 @@ func (s *ResolvedSuite) TestResolved(c *gc.C) {
 	for _, name := range []string{"dummy/2", "dummy/3", "dummy/4"} {
 		u, err := s.State.Unit(name)
 		c.Assert(err, jc.ErrorIsNil)
-		err = u.SetAgentStatus(state.StatusError, "lol borken", nil)
+		err = u.SetAgentStatus(status.StatusError, "lol borken", nil)
 		c.Assert(err, jc.ErrorIsNil)
 	}
 
@@ -123,7 +124,7 @@ func (s *ResolvedSuite) TestBlockResolved(c *gc.C) {
 	for _, name := range []string{"dummy/2", "dummy/3", "dummy/4"} {
 		u, err := s.State.Unit(name)
 		c.Assert(err, jc.ErrorIsNil)
-		err = u.SetAgentStatus(state.StatusError, "lol borken", nil)
+		err = u.SetAgentStatus(status.StatusError, "lol borken", nil)
 		c.Assert(err, jc.ErrorIsNil)
 	}
 

--- a/cmd/juju/machine/list_test.go
+++ b/cmd/juju/machine/list_test.go
@@ -31,7 +31,7 @@ func (*fakeStatusAPI) Status(c []string) (*params.FullStatus, error) {
 		Machines: map[string]params.MachineStatus{
 			"0": {
 				Id: "0",
-				Agent: params.AgentStatus{
+				JujuStatus: params.AgentStatus{
 					Status: "started",
 				},
 				DNSName:    "10.0.0.1",
@@ -41,7 +41,7 @@ func (*fakeStatusAPI) Status(c []string) (*params.FullStatus, error) {
 			},
 			"1": {
 				Id: "1",
-				Agent: params.AgentStatus{
+				JujuStatus: params.AgentStatus{
 					Status: "pending",
 				},
 				DNSName:    "10.0.0.2",
@@ -80,13 +80,15 @@ func (s *MachineListCommandSuite) TestListMachineYaml(c *gc.C) {
 		"model: dummyenv\n"+
 		"machines:\n"+
 		"  \"0\":\n"+
-		"    agent-state: started\n"+
+		"    juju-status:\n"+
+		"      current: started\n"+
 		"    dns-name: 10.0.0.1\n"+
 		"    instance-id: juju-dummy-machine-0\n"+
 		"    series: trusty\n"+
 		"    hardware: availability-zone=us-east-1\n"+
 		"  \"1\":\n"+
-		"    agent-state: pending\n"+
+		"    juju-status:\n"+
+		"      current: pending\n"+
 		"    dns-name: 10.0.0.2\n"+
 		"    instance-id: juju-dummy-machine-1\n"+
 		"    series: trusty\n")
@@ -96,7 +98,7 @@ func (s *MachineListCommandSuite) TestListMachineJson(c *gc.C) {
 	context, err := testing.RunCommand(c, newMachineListCommand(), "--format", "json")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(testing.Stdout(context), gc.Equals, ""+
-		"{\"model\":\"dummyenv\",\"machines\":{\"0\":{\"agent-state\":\"started\",\"dns-name\":\"10.0.0.1\",\"instance-id\":\"juju-dummy-machine-0\",\"series\":\"trusty\",\"hardware\":\"availability-zone=us-east-1\"},\"1\":{\"agent-state\":\"pending\",\"dns-name\":\"10.0.0.2\",\"instance-id\":\"juju-dummy-machine-1\",\"series\":\"trusty\"}}}\n")
+		"{\"model\":\"dummyenv\",\"machines\":{\"0\":{\"juju-status\":{\"current\":\"started\"},\"dns-name\":\"10.0.0.1\",\"instance-id\":\"juju-dummy-machine-0\",\"machine-status\":{},\"series\":\"trusty\",\"hardware\":\"availability-zone=us-east-1\"},\"1\":{\"juju-status\":{\"current\":\"pending\"},\"dns-name\":\"10.0.0.2\",\"instance-id\":\"juju-dummy-machine-1\",\"machine-status\":{},\"series\":\"trusty\"}}}\n")
 }
 
 func (s *MachineListCommandSuite) TestListMachineArgsError(c *gc.C) {

--- a/cmd/juju/machine/show_test.go
+++ b/cmd/juju/machine/show_test.go
@@ -33,13 +33,15 @@ func (s *MachineShowCommandSuite) TestShowMachine(c *gc.C) {
 		"model: dummyenv\n"+
 		"machines:\n"+
 		"  \"0\":\n"+
-		"    agent-state: started\n"+
+		"    juju-status:\n"+
+		"      current: started\n"+
 		"    dns-name: 10.0.0.1\n"+
 		"    instance-id: juju-dummy-machine-0\n"+
 		"    series: trusty\n"+
 		"    hardware: availability-zone=us-east-1\n"+
 		"  \"1\":\n"+
-		"    agent-state: pending\n"+
+		"    juju-status:\n"+
+		"      current: pending\n"+
 		"    dns-name: 10.0.0.2\n"+
 		"    instance-id: juju-dummy-machine-1\n"+
 		"    series: trusty\n")
@@ -51,7 +53,8 @@ func (s *MachineShowCommandSuite) TestShowSingleMachine(c *gc.C) {
 		"model: dummyenv\n"+
 		"machines:\n"+
 		"  \"0\":\n"+
-		"    agent-state: started\n"+
+		"    juju-status:\n"+
+		"      current: started\n"+
 		"    dns-name: 10.0.0.1\n"+
 		"    instance-id: juju-dummy-machine-0\n"+
 		"    series: trusty\n"+
@@ -74,6 +77,5 @@ func (s *MachineShowCommandSuite) TestShowJsonMachine(c *gc.C) {
 	context, err := testing.RunCommand(c, newMachineShowCommand(), "--format", "json", "0", "1")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(testing.Stdout(context), gc.Equals, ""+
-		"{\"model\":\"dummyenv\",\"machines\":{\"0\":{\"agent-state\":\"started\",\"dns-name\":\"10.0.0.1\",\"instance-id\":\"juju-dummy-machine-0\",\"series\":\"trusty\",\"hardware\":\"availability-zone=us-east-1\"},\"1\":{\"agent-state\":\"pending\",\"dns-name\":\"10.0.0.2\",\"instance-id\":\"juju-dummy-machine-1\",\"series\":\"trusty\"}}}\n")
-
+		"{\"model\":\"dummyenv\",\"machines\":{\"0\":{\"juju-status\":{\"current\":\"started\"},\"dns-name\":\"10.0.0.1\",\"instance-id\":\"juju-dummy-machine-0\",\"machine-status\":{},\"series\":\"trusty\",\"hardware\":\"availability-zone=us-east-1\"},\"1\":{\"juju-status\":{\"current\":\"pending\"},\"dns-name\":\"10.0.0.2\",\"instance-id\":\"juju-dummy-machine-1\",\"machine-status\":{},\"series\":\"trusty\"}}}\n")
 }

--- a/cmd/juju/status/formatted.go
+++ b/cmd/juju/status/formatted.go
@@ -6,9 +6,9 @@ package status
 import (
 	"encoding/json"
 
-	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/network"
+	"github.com/juju/juju/status"
 )
 
 type formattedStatus struct {
@@ -33,19 +33,17 @@ type modelStatus struct {
 }
 
 type machineStatus struct {
-	Err            error                    `json:"-" yaml:",omitempty"`
-	AgentState     params.Status            `json:"agent-state,omitempty" yaml:"agent-state,omitempty"`
-	AgentStateInfo string                   `json:"agent-state-info,omitempty" yaml:"agent-state-info,omitempty"`
-	AgentVersion   string                   `json:"agent-version,omitempty" yaml:"agent-version,omitempty"`
-	DNSName        string                   `json:"dns-name,omitempty" yaml:"dns-name,omitempty"`
-	InstanceId     instance.Id              `json:"instance-id,omitempty" yaml:"instance-id,omitempty"`
-	InstanceState  string                   `json:"instance-state,omitempty" yaml:"instance-state,omitempty"`
-	Life           string                   `json:"life,omitempty" yaml:"life,omitempty"`
-	Series         string                   `json:"series,omitempty" yaml:"series,omitempty"`
-	Id             string                   `json:"-" yaml:"-"`
-	Containers     map[string]machineStatus `json:"containers,omitempty" yaml:"containers,omitempty"`
-	Hardware       string                   `json:"hardware,omitempty" yaml:"hardware,omitempty"`
-	HAStatus       string                   `json:"controller-member-status,omitempty" yaml:"controller-member-status,omitempty"`
+	Err           error                    `json:"-" yaml:",omitempty"`
+	JujuStatus    statusInfoContents       `json:"juju-status,omitempty" yaml:"juju-status,omitempty"`
+	DNSName       string                   `json:"dns-name,omitempty" yaml:"dns-name,omitempty"`
+	InstanceId    instance.Id              `json:"instance-id,omitempty" yaml:"instance-id,omitempty"`
+	MachineStatus statusInfoContents       `json:"machine-status,omitempty" yaml:"machine-status,omitempty"`
+	Life          string                   `json:"life,omitempty" yaml:"life,omitempty"`
+	Series        string                   `json:"series,omitempty" yaml:"series,omitempty"`
+	Id            string                   `json:"-" yaml:"-"`
+	Containers    map[string]machineStatus `json:"containers,omitempty" yaml:"containers,omitempty"`
+	Hardware      string                   `json:"hardware,omitempty" yaml:"hardware,omitempty"`
+	HAStatus      string                   `json:"controller-member-status,omitempty" yaml:"controller-member-status,omitempty"`
 }
 
 // A goyaml bug means we can't declare these types
@@ -115,10 +113,11 @@ type unitStatus struct {
 
 type statusInfoContents struct {
 	Err     error         `json:"-" yaml:",omitempty"`
-	Current params.Status `json:"current,omitempty" yaml:"current,omitempty"`
+	Current status.Status `json:"current,omitempty" yaml:"current,omitempty"`
 	Message string        `json:"message,omitempty" yaml:"message,omitempty"`
 	Since   string        `json:"since,omitempty" yaml:"since,omitempty"`
 	Version string        `json:"version,omitempty" yaml:"version,omitempty"`
+	Life    string        `json:"life,omitempty" yaml:"life,omitempty"`
 }
 
 type statusInfoContentsNoMarshal statusInfoContents

--- a/cmd/juju/status/output_tabular.go
+++ b/cmd/juju/status/output_tabular.go
@@ -15,9 +15,9 @@ import (
 	"github.com/juju/utils/set"
 	"gopkg.in/juju/charm.v6-unstable/hooks"
 
-	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/juju/common"
 	"github.com/juju/juju/instance"
+	"github.com/juju/juju/status"
 )
 
 type statusRelation struct {
@@ -178,7 +178,7 @@ func FormatTabular(value interface{}) ([]byte, error) {
 		if hw.AvailabilityZone != nil {
 			az = *hw.AvailabilityZone
 		}
-		p(m.Id, m.AgentState, m.DNSName, m.InstanceId, m.Series, az)
+		p(m.Id, m.JujuStatus.Current, m.DNSName, m.InstanceId, m.Series, az)
 	}
 	tw.Flush()
 	return out.Bytes(), nil
@@ -213,7 +213,7 @@ func FormatMachineTabular(value interface{}) ([]byte, error) {
 		if hw.AvailabilityZone != nil {
 			az = *hw.AvailabilityZone
 		}
-		p(m.Id, m.AgentState, m.DNSName, m.InstanceId, m.Series, az)
+		p(m.Id, m.JujuStatus.Current, m.DNSName, m.InstanceId, m.Series, az)
 	}
 	tw.Flush()
 
@@ -223,8 +223,8 @@ func FormatMachineTabular(value interface{}) ([]byte, error) {
 // agentDoing returns what hook or action, if any,
 // the agent is currently executing.
 // The hook name or action is extracted from the agent message.
-func agentDoing(status statusInfoContents) string {
-	if status.Current != params.StatusExecuting {
+func agentDoing(agentStatus statusInfoContents) string {
+	if agentStatus.Current != status.StatusExecuting {
 		return ""
 	}
 	// First see if we can determine a hook name.
@@ -236,13 +236,13 @@ func agentDoing(status statusInfoContents) string {
 		hookNames = append(hookNames, string(h))
 	}
 	hookExp := regexp.MustCompile(fmt.Sprintf(`running (?P<hook>%s?) hook`, strings.Join(hookNames, "|")))
-	match := hookExp.FindStringSubmatch(status.Message)
+	match := hookExp.FindStringSubmatch(agentStatus.Message)
 	if len(match) > 0 {
 		return match[1]
 	}
 	// Now try for an action name.
 	actionExp := regexp.MustCompile(`running action (?P<action>.*)`)
-	match = actionExp.FindStringSubmatch(status.Message)
+	match = actionExp.FindStringSubmatch(agentStatus.Message)
 	if len(match) > 0 {
 		return match[1]
 	}

--- a/cmd/juju/status/status_test.go
+++ b/cmd/juju/status/status_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/multiwatcher"
 	"github.com/juju/juju/state/presence"
+	"github.com/juju/juju/status"
 	"github.com/juju/juju/testcharms"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/version"
@@ -141,83 +142,162 @@ func (s *StatusSuite) resetContext(c *gc.C, ctx *context) {
 // shortcuts for expected output.
 var (
 	machine0 = M{
-		"agent-state":              "started",
-		"dns-name":                 "dummymodel-0.dns",
-		"instance-id":              "dummymodel-0",
+		"juju-status": M{
+			"current": "started",
+			"since":   "01 Apr 15 01:23+10:00",
+		},
+		"dns-name":    "dummymodel-0.dns",
+		"instance-id": "dummymodel-0",
+		"machine-status": M{
+			"current": "pending",
+			"since":   "01 Apr 15 01:23+10:00",
+		},
 		"series":                   "quantal",
 		"hardware":                 "arch=amd64 cpu-cores=1 mem=1024M root-disk=8192M",
 		"controller-member-status": "adding-vote",
 	}
 	machine1 = M{
-		"agent-state": "started",
+		"juju-status": M{
+			"current": "started",
+			"since":   "01 Apr 15 01:23+10:00",
+		},
 		"dns-name":    "dummymodel-1.dns",
 		"instance-id": "dummymodel-1",
-		"series":      "quantal",
-		"hardware":    "arch=amd64 cpu-cores=1 mem=1024M root-disk=8192M",
+		"machine-status": M{
+			"current": "pending",
+			"since":   "01 Apr 15 01:23+10:00",
+		},
+
+		"series":   "quantal",
+		"hardware": "arch=amd64 cpu-cores=1 mem=1024M root-disk=8192M",
 	}
 	machine2 = M{
-		"agent-state": "started",
+		"juju-status": M{
+			"current": "started",
+			"since":   "01 Apr 15 01:23+10:00",
+		},
 		"dns-name":    "dummymodel-2.dns",
 		"instance-id": "dummymodel-2",
-		"series":      "quantal",
-		"hardware":    "arch=amd64 cpu-cores=1 mem=1024M root-disk=8192M",
+		"machine-status": M{
+			"current": "pending",
+			"since":   "01 Apr 15 01:23+10:00",
+		},
+		"series":   "quantal",
+		"hardware": "arch=amd64 cpu-cores=1 mem=1024M root-disk=8192M",
 	}
 	machine3 = M{
-		"agent-state": "started",
+		"juju-status": M{
+			"current": "started",
+			"since":   "01 Apr 15 01:23+10:00",
+		},
 		"dns-name":    "dummymodel-3.dns",
 		"instance-id": "dummymodel-3",
-		"series":      "quantal",
-		"hardware":    "arch=amd64 cpu-cores=1 mem=1024M root-disk=8192M",
+		"machine-status": M{
+			"current": "pending",
+			"since":   "01 Apr 15 01:23+10:00",
+		},
+		"series":   "quantal",
+		"hardware": "arch=amd64 cpu-cores=1 mem=1024M root-disk=8192M",
 	}
 	machine4 = M{
-		"agent-state": "started",
+		"juju-status": M{
+			"current": "started",
+			"since":   "01 Apr 15 01:23+10:00",
+		},
 		"dns-name":    "dummymodel-4.dns",
 		"instance-id": "dummymodel-4",
-		"series":      "quantal",
-		"hardware":    "arch=amd64 cpu-cores=1 mem=1024M root-disk=8192M",
+		"machine-status": M{
+			"current": "pending",
+			"since":   "01 Apr 15 01:23+10:00",
+		},
+		"series":   "quantal",
+		"hardware": "arch=amd64 cpu-cores=1 mem=1024M root-disk=8192M",
 	}
 	machine1WithContainers = M{
-		"agent-state": "started",
+		"juju-status": M{
+			"current": "started",
+			"since":   "01 Apr 15 01:23+10:00",
+		},
 		"containers": M{
 			"1/lxc/0": M{
-				"agent-state": "started",
+				"juju-status": M{
+					"current": "started",
+					"since":   "01 Apr 15 01:23+10:00",
+				},
 				"containers": M{
 					"1/lxc/0/lxc/0": M{
-						"agent-state": "started",
+						"juju-status": M{
+							"current": "started",
+							"since":   "01 Apr 15 01:23+10:00",
+						},
 						"dns-name":    "dummymodel-3.dns",
 						"instance-id": "dummymodel-3",
-						"series":      "quantal",
+						"machine-status": M{
+							"current": "pending",
+							"since":   "01 Apr 15 01:23+10:00",
+						},
+						"series": "quantal",
 					},
 				},
 				"dns-name":    "dummymodel-2.dns",
 				"instance-id": "dummymodel-2",
-				"series":      "quantal",
+				"machine-status": M{
+					"current": "pending",
+					"since":   "01 Apr 15 01:23+10:00",
+				},
+				"series": "quantal",
 			},
 			"1/lxc/1": M{
-				"agent-state": "pending",
+				"juju-status": M{
+					"current": "pending",
+					"since":   "01 Apr 15 01:23+10:00",
+				},
 				"instance-id": "pending",
-				"series":      "quantal",
+				"machine-status": M{
+					"current": "pending",
+					"since":   "01 Apr 15 01:23+10:00",
+				},
+				"series": "quantal",
 			},
 		},
 		"dns-name":    "dummymodel-1.dns",
 		"instance-id": "dummymodel-1",
-		"series":      "quantal",
-		"hardware":    "arch=amd64 cpu-cores=1 mem=1024M root-disk=8192M",
+		"machine-status": M{
+			"current": "pending",
+			"since":   "01 Apr 15 01:23+10:00",
+		},
+
+		"series":   "quantal",
+		"hardware": "arch=amd64 cpu-cores=1 mem=1024M root-disk=8192M",
 	}
 	machine1WithContainersScoped = M{
-		"agent-state": "started",
+		"juju-status": M{
+			"current": "started",
+			"since":   "01 Apr 15 01:23+10:00",
+		},
 		"containers": M{
 			"1/lxc/0": M{
-				"agent-state": "started",
+				"juju-status": M{
+					"current": "started",
+					"since":   "01 Apr 15 01:23+10:00",
+				},
 				"dns-name":    "dummymodel-2.dns",
 				"instance-id": "dummymodel-2",
-				"series":      "quantal",
+				"machine-status": M{
+					"current": "pending",
+					"since":   "01 Apr 15 01:23+10:00",
+				},
+				"series": "quantal",
 			},
 		},
 		"dns-name":    "dummymodel-1.dns",
 		"instance-id": "dummymodel-1",
-		"series":      "quantal",
-		"hardware":    "arch=amd64 cpu-cores=1 mem=1024M root-disk=8192M",
+		"machine-status": M{
+			"current": "pending",
+			"since":   "01 Apr 15 01:23+10:00",
+		},
+		"series":   "quantal",
+		"hardware": "arch=amd64 cpu-cores=1 mem=1024M root-disk=8192M",
 	}
 	unexposedService = M{
 		"service-status": M{
@@ -266,8 +346,15 @@ var statusTests = []testCase{
 				"model": "dummymodel",
 				"machines": M{
 					"0": M{
-						"agent-state":              "pending",
-						"instance-id":              "pending",
+						"juju-status": M{
+							"current": "pending",
+							"since":   "01 Apr 15 01:23+10:00",
+						},
+						"instance-id": "pending",
+						"machine-status": M{
+							"current": "pending",
+							"since":   "01 Apr 15 01:23+10:00",
+						},
 						"series":                   "quantal",
 						"controller-member-status": "adding-vote",
 					},
@@ -287,9 +374,16 @@ var statusTests = []testCase{
 				"model": "dummymodel",
 				"machines": M{
 					"0": M{
-						"agent-state":              "pending",
-						"dns-name":                 "dummymodel-0.dns",
-						"instance-id":              "dummymodel-0",
+						"juju-status": M{
+							"current": "pending",
+							"since":   "01 Apr 15 01:23+10:00",
+						},
+						"dns-name":    "dummymodel-0.dns",
+						"instance-id": "dummymodel-0",
+						"machine-status": M{
+							"current": "pending",
+							"since":   "01 Apr 15 01:23+10:00",
+						},
 						"series":                   "quantal",
 						"hardware":                 "arch=amd64 cpu-cores=1 mem=1024M root-disk=8192M",
 						"controller-member-status": "adding-vote",
@@ -299,7 +393,7 @@ var statusTests = []testCase{
 			},
 		},
 
-		setMachineStatus{"0", state.StatusStarted, ""},
+		setMachineStatus{"0", status.StatusStarted, ""},
 		expect{
 			"simulate the MA started and set the machine status",
 			M{
@@ -318,10 +412,17 @@ var statusTests = []testCase{
 				"model": "dummymodel",
 				"machines": M{
 					"0": M{
-						"dns-name":                 "dummymodel-0.dns",
-						"instance-id":              "dummymodel-0",
-						"agent-version":            "1.2.3",
-						"agent-state":              "started",
+						"dns-name":    "dummymodel-0.dns",
+						"instance-id": "dummymodel-0",
+						"machine-status": M{
+							"current": "pending",
+							"since":   "01 Apr 15 01:23+10:00",
+						},
+						"juju-status": M{
+							"current": "started",
+							"since":   "01 Apr 15 01:23+10:00",
+							"version": "1.2.3",
+						},
 						"series":                   "quantal",
 						"hardware":                 "arch=amd64 cpu-cores=1 mem=1024M root-disk=8192M",
 						"controller-member-status": "adding-vote",
@@ -339,16 +440,23 @@ var statusTests = []testCase{
 			network.NewScopedAddress("dummymodel-0.dns", network.ScopePublic),
 		}},
 		startAliveMachine{"0"},
-		setMachineStatus{"0", state.StatusStarted, ""},
+		setMachineStatus{"0", status.StatusStarted, ""},
 		expect{
 			"machine 0 has specific hardware characteristics",
 			M{
 				"model": "dummymodel",
 				"machines": M{
 					"0": M{
-						"agent-state":              "started",
-						"dns-name":                 "dummymodel-0.dns",
-						"instance-id":              "dummymodel-0",
+						"juju-status": M{
+							"current": "started",
+							"since":   "01 Apr 15 01:23+10:00",
+						},
+						"dns-name":    "dummymodel-0.dns",
+						"instance-id": "dummymodel-0",
+						"machine-status": M{
+							"current": "pending",
+							"since":   "01 Apr 15 01:23+10:00",
+						},
 						"series":                   "quantal",
 						"hardware":                 "arch=amd64 cpu-cores=2 mem=8192M root-disk=8192M",
 						"controller-member-status": "adding-vote",
@@ -362,15 +470,22 @@ var statusTests = []testCase{
 		"instance without addresses",
 		addMachine{machineId: "0", cons: machineCons, job: state.JobManageModel},
 		startAliveMachine{"0"},
-		setMachineStatus{"0", state.StatusStarted, ""},
+		setMachineStatus{"0", status.StatusStarted, ""},
 		expect{
 			"machine 0 has no dns-name",
 			M{
 				"model": "dummymodel",
 				"machines": M{
 					"0": M{
-						"agent-state":              "started",
-						"instance-id":              "dummymodel-0",
+						"juju-status": M{
+							"current": "started",
+							"since":   "01 Apr 15 01:23+10:00",
+						},
+						"instance-id": "dummymodel-0",
+						"machine-status": M{
+							"current": "pending",
+							"since":   "01 Apr 15 01:23+10:00",
+						},
 						"series":                   "quantal",
 						"hardware":                 "arch=amd64 cpu-cores=2 mem=8192M root-disk=8192M",
 						"controller-member-status": "adding-vote",
@@ -389,8 +504,15 @@ var statusTests = []testCase{
 				"model": "dummymodel",
 				"machines": M{
 					"0": M{
-						"agent-state":              "pending",
-						"instance-id":              "pending",
+						"juju-status": M{
+							"current": "pending",
+							"since":   "01 Apr 15 01:23+10:00",
+						},
+						"instance-id": "pending",
+						"machine-status": M{
+							"current": "pending",
+							"since":   "01 Apr 15 01:23+10:00",
+						},
 						"series":                   "quantal",
 						"controller-member-status": "adding-vote",
 					},
@@ -406,9 +528,17 @@ var statusTests = []testCase{
 				"model": "dummymodel",
 				"machines": M{
 					"0": M{
-						"instance-state":           "missing",
-						"instance-id":              "i-missing",
-						"agent-state":              "pending",
+						"instance-id": "i-missing",
+						"juju-status": M{
+							"current": "pending",
+							"message": "missing",
+							"since":   "01 Apr 15 01:23+10:00",
+						},
+						"machine-status": M{
+							"current": "unknown",
+							"message": "missing",
+							"since":   "01 Apr 15 01:23+10:00",
+						},
 						"series":                   "quantal",
 						"hardware":                 "arch=amd64 cpu-cores=1 mem=1024M root-disk=8192M",
 						"controller-member-status": "adding-vote",
@@ -424,7 +554,7 @@ var statusTests = []testCase{
 		addMachine{machineId: "0", job: state.JobManageModel},
 		setAddresses{"0", network.NewAddresses("dummymodel-0.dns")},
 		startAliveMachine{"0"},
-		setMachineStatus{"0", state.StatusStarted, ""},
+		setMachineStatus{"0", status.StatusStarted, ""},
 		addCharm{"dummy"},
 		addService{name: "dummy-service", charm: "dummy"},
 		addService{name: "exposed-service", charm: "dummy"},
@@ -462,11 +592,11 @@ var statusTests = []testCase{
 		addMachine{machineId: "1", job: state.JobHostUnits},
 		setAddresses{"1", network.NewAddresses("dummymodel-1.dns")},
 		startAliveMachine{"1"},
-		setMachineStatus{"1", state.StatusStarted, ""},
+		setMachineStatus{"1", status.StatusStarted, ""},
 		addMachine{machineId: "2", job: state.JobHostUnits},
 		setAddresses{"2", network.NewAddresses("dummymodel-2.dns")},
 		startAliveMachine{"2"},
-		setMachineStatus{"2", state.StatusStarted, ""},
+		setMachineStatus{"2", status.StatusStarted, ""},
 		expect{
 			"two more machines added",
 			M{
@@ -486,7 +616,7 @@ var statusTests = []testCase{
 		// step 19
 		addAliveUnit{"dummy-service", "1"},
 		addAliveUnit{"exposed-service", "2"},
-		setAgentStatus{"exposed-service/0", state.StatusError, "You Require More Vespene Gas", nil},
+		setAgentStatus{"exposed-service/0", status.StatusError, "You Require More Vespene Gas", nil},
 		// Open multiple ports with different protocols,
 		// ensure they're sorted on protocol, then number.
 		openUnitPort{"exposed-service/0", "udp", 10},
@@ -496,8 +626,8 @@ var statusTests = []testCase{
 		// Simulate some status with no info, while the agent is down.
 		// Status used to be down, we no longer support said state.
 		// now is one of: pending, started, error.
-		setUnitStatus{"dummy-service/0", state.StatusTerminated, "", nil},
-		setAgentStatus{"dummy-service/0", state.StatusIdle, "", nil},
+		setUnitStatus{"dummy-service/0", status.StatusTerminated, "", nil},
+		setAgentStatus{"dummy-service/0", status.StatusIdle, "", nil},
 
 		expect{
 			"add two units, one alive (in error state), one started",
@@ -567,11 +697,11 @@ var statusTests = []testCase{
 		startMachine{"3"},
 		// Simulate some status with info, while the agent is down.
 		setAddresses{"3", network.NewAddresses("dummymodel-3.dns")},
-		setMachineStatus{"3", state.StatusStopped, "Really?"},
+		setMachineStatus{"3", status.StatusStopped, "Really?"},
 		addMachine{machineId: "4", job: state.JobHostUnits},
 		setAddresses{"4", network.NewAddresses("dummymodel-4.dns")},
 		startAliveMachine{"4"},
-		setMachineStatus{"4", state.StatusError, "Beware the red toys"},
+		setMachineStatus{"4", status.StatusError, "Beware the red toys"},
 		ensureDyingUnit{"dummy-service/0"},
 		addMachine{machineId: "5", job: state.JobHostUnits},
 		ensureDeadMachine{"5"},
@@ -584,26 +714,47 @@ var statusTests = []testCase{
 					"1": machine1,
 					"2": machine2,
 					"3": M{
-						"dns-name":         "dummymodel-3.dns",
-						"instance-id":      "dummymodel-3",
-						"agent-state":      "stopped",
-						"agent-state-info": "Really?",
-						"series":           "quantal",
-						"hardware":         "arch=amd64 cpu-cores=1 mem=1024M root-disk=8192M",
+						"dns-name":    "dummymodel-3.dns",
+						"instance-id": "dummymodel-3",
+						"machine-status": M{
+							"current": "pending",
+							"since":   "01 Apr 15 01:23+10:00",
+						},
+						"juju-status": M{
+							"current": "stopped",
+							"message": "Really?",
+							"since":   "01 Apr 15 01:23+10:00",
+						},
+						"series":   "quantal",
+						"hardware": "arch=amd64 cpu-cores=1 mem=1024M root-disk=8192M",
 					},
 					"4": M{
-						"dns-name":         "dummymodel-4.dns",
-						"instance-id":      "dummymodel-4",
-						"agent-state":      "error",
-						"agent-state-info": "Beware the red toys",
-						"series":           "quantal",
-						"hardware":         "arch=amd64 cpu-cores=1 mem=1024M root-disk=8192M",
+						"dns-name":    "dummymodel-4.dns",
+						"instance-id": "dummymodel-4",
+						"machine-status": M{
+							"current": "pending",
+							"since":   "01 Apr 15 01:23+10:00",
+						},
+						"juju-status": M{
+							"current": "error",
+							"message": "Beware the red toys",
+							"since":   "01 Apr 15 01:23+10:00",
+						},
+						"series":   "quantal",
+						"hardware": "arch=amd64 cpu-cores=1 mem=1024M root-disk=8192M",
 					},
 					"5": M{
-						"agent-state": "pending",
-						"life":        "dead",
+						"juju-status": M{
+							"current": "pending",
+							"since":   "01 Apr 15 01:23+10:00",
+							"life":    "dead",
+						},
 						"instance-id": "pending",
-						"series":      "quantal",
+						"machine-status": M{
+							"current": "pending",
+							"since":   "01 Apr 15 01:23+10:00",
+						},
+						"series": "quantal",
 					},
 				},
 				"services": M{
@@ -875,12 +1026,12 @@ var statusTests = []testCase{
 		addMachine{machineId: "0", job: state.JobManageModel},
 		setAddresses{"0", network.NewAddresses("dummymodel-0.dns")},
 		startAliveMachine{"0"},
-		setMachineStatus{"0", state.StatusStarted, ""},
+		setMachineStatus{"0", status.StatusStarted, ""},
 
 		addMachine{machineId: "1", job: state.JobHostUnits},
 		setAddresses{"1", network.NewAddresses("dummymodel-1.dns")},
 		startAliveMachine{"1"},
-		setMachineStatus{"1", state.StatusStarted, ""},
+		setMachineStatus{"1", status.StatusStarted, ""},
 
 		addCharm{"wordpress"},
 		addService{name: "wordpress", charm: "wordpress"},
@@ -892,7 +1043,7 @@ var statusTests = []testCase{
 
 		relateServices{"wordpress", "mysql"},
 
-		setAgentStatus{"wordpress/0", state.StatusError,
+		setAgentStatus{"wordpress/0", status.StatusError,
 			"hook failed: some-relation-changed",
 			map[string]interface{}{"relation-id": 0}},
 
@@ -968,12 +1119,12 @@ var statusTests = []testCase{
 		addMachine{machineId: "0", job: state.JobManageModel},
 		setAddresses{"0", network.NewAddresses("dummymodel-0.dns")},
 		startAliveMachine{"0"},
-		setMachineStatus{"0", state.StatusStarted, ""},
+		setMachineStatus{"0", status.StatusStarted, ""},
 
 		addMachine{machineId: "1", job: state.JobHostUnits},
 		setAddresses{"1", network.NewAddresses("dummymodel-1.dns")},
 		startAliveMachine{"1"},
-		setMachineStatus{"1", state.StatusStarted, ""},
+		setMachineStatus{"1", status.StatusStarted, ""},
 
 		addCharm{"wordpress"},
 		addService{name: "wordpress", charm: "wordpress"},
@@ -985,7 +1136,7 @@ var statusTests = []testCase{
 
 		relateServices{"wordpress", "mysql"},
 
-		setAgentStatus{"wordpress/0", state.StatusError,
+		setAgentStatus{"wordpress/0", status.StatusError,
 			"hook failed: some-relation-changed",
 			map[string]interface{}{"relation-id": 0}},
 
@@ -1069,9 +1220,17 @@ var statusTests = []testCase{
 				"model": "dummymodel",
 				"machines": M{
 					"0": M{
-						"agent-state": "pending",
+						"juju-status": M{
+							"current": "pending",
+							"since":   "01 Apr 15 01:23+10:00",
+						},
 						"instance-id": "pending",
-						"series":      "quantal",
+						"machine-status": M{
+							"current": "pending",
+							"since":   "01 Apr 15 01:23+10:00",
+						},
+
+						"series": "quantal",
 					},
 				},
 				"services": M{
@@ -1109,20 +1268,28 @@ var statusTests = []testCase{
 		addService{name: "dummy-service", charm: "dummy"},
 		addMachine{machineId: "0", job: state.JobHostUnits},
 		startAliveMachine{"0"},
-		setMachineStatus{"0", state.StatusStarted, ""},
+		setMachineStatus{"0", status.StatusStarted, ""},
 		addUnit{"dummy-service", "0"},
-		setAgentStatus{"dummy-service/0", state.StatusIdle, "", nil},
-		setUnitStatus{"dummy-service/0", state.StatusActive, "", nil},
+		setAgentStatus{"dummy-service/0", status.StatusIdle, "", nil},
+		setUnitStatus{"dummy-service/0", status.StatusActive, "", nil},
 		expect{
 			"unit shows that agent is lost",
 			M{
 				"model": "dummymodel",
 				"machines": M{
 					"0": M{
-						"agent-state": "started",
+						"juju-status": M{
+							"current": "started",
+							"since":   "01 Apr 15 01:23+10:00",
+						},
 						"instance-id": "dummymodel-0",
-						"series":      "quantal",
-						"hardware":    "arch=amd64 cpu-cores=1 mem=1024M root-disk=8192M",
+						"machine-status": M{
+							"current": "pending",
+							"since":   "01 Apr 15 01:23+10:00",
+						},
+
+						"series":   "quantal",
+						"hardware": "arch=amd64 cpu-cores=1 mem=1024M root-disk=8192M",
 					},
 				},
 				"services": M{
@@ -1160,7 +1327,7 @@ var statusTests = []testCase{
 		addMachine{machineId: "0", job: state.JobManageModel},
 		setAddresses{"0", network.NewAddresses("dummymodel-0.dns")},
 		startAliveMachine{"0"},
-		setMachineStatus{"0", state.StatusStarted, ""},
+		setMachineStatus{"0", status.StatusStarted, ""},
 		addCharm{"wordpress"},
 		addCharm{"mysql"},
 		addCharm{"varnish"},
@@ -1170,27 +1337,27 @@ var statusTests = []testCase{
 		addMachine{machineId: "1", job: state.JobHostUnits},
 		setAddresses{"1", network.NewAddresses("dummymodel-1.dns")},
 		startAliveMachine{"1"},
-		setMachineStatus{"1", state.StatusStarted, ""},
+		setMachineStatus{"1", status.StatusStarted, ""},
 		addAliveUnit{"project", "1"},
-		setAgentStatus{"project/0", state.StatusIdle, "", nil},
-		setUnitStatus{"project/0", state.StatusActive, "", nil},
+		setAgentStatus{"project/0", status.StatusIdle, "", nil},
+		setUnitStatus{"project/0", status.StatusActive, "", nil},
 
 		addService{name: "mysql", charm: "mysql"},
 		setServiceExposed{"mysql", true},
 		addMachine{machineId: "2", job: state.JobHostUnits},
 		setAddresses{"2", network.NewAddresses("dummymodel-2.dns")},
 		startAliveMachine{"2"},
-		setMachineStatus{"2", state.StatusStarted, ""},
+		setMachineStatus{"2", status.StatusStarted, ""},
 		addAliveUnit{"mysql", "2"},
-		setAgentStatus{"mysql/0", state.StatusIdle, "", nil},
-		setUnitStatus{"mysql/0", state.StatusActive, "", nil},
+		setAgentStatus{"mysql/0", status.StatusIdle, "", nil},
+		setUnitStatus{"mysql/0", status.StatusActive, "", nil},
 
 		addService{name: "varnish", charm: "varnish"},
 		setServiceExposed{"varnish", true},
 		addMachine{machineId: "3", job: state.JobHostUnits},
 		setAddresses{"3", network.NewAddresses("dummymodel-3.dns")},
 		startAliveMachine{"3"},
-		setMachineStatus{"3", state.StatusStarted, ""},
+		setMachineStatus{"3", status.StatusStarted, ""},
 		addAliveUnit{"varnish", "3"},
 
 		addService{name: "private", charm: "wordpress"},
@@ -1198,7 +1365,7 @@ var statusTests = []testCase{
 		addMachine{machineId: "4", job: state.JobHostUnits},
 		setAddresses{"4", network.NewAddresses("dummymodel-4.dns")},
 		startAliveMachine{"4"},
-		setMachineStatus{"4", state.StatusStarted, ""},
+		setMachineStatus{"4", status.StatusStarted, ""},
 		addAliveUnit{"private", "4"},
 
 		relateServices{"project", "mysql"},
@@ -1331,7 +1498,7 @@ var statusTests = []testCase{
 		addMachine{machineId: "0", job: state.JobManageModel},
 		setAddresses{"0", network.NewAddresses("dummymodel-0.dns")},
 		startAliveMachine{"0"},
-		setMachineStatus{"0", state.StatusStarted, ""},
+		setMachineStatus{"0", status.StatusStarted, ""},
 		addCharm{"riak"},
 		addCharm{"wordpress"},
 
@@ -1340,24 +1507,24 @@ var statusTests = []testCase{
 		addMachine{machineId: "1", job: state.JobHostUnits},
 		setAddresses{"1", network.NewAddresses("dummymodel-1.dns")},
 		startAliveMachine{"1"},
-		setMachineStatus{"1", state.StatusStarted, ""},
+		setMachineStatus{"1", status.StatusStarted, ""},
 		addAliveUnit{"riak", "1"},
-		setAgentStatus{"riak/0", state.StatusIdle, "", nil},
-		setUnitStatus{"riak/0", state.StatusActive, "", nil},
+		setAgentStatus{"riak/0", status.StatusIdle, "", nil},
+		setUnitStatus{"riak/0", status.StatusActive, "", nil},
 		addMachine{machineId: "2", job: state.JobHostUnits},
 		setAddresses{"2", network.NewAddresses("dummymodel-2.dns")},
 		startAliveMachine{"2"},
-		setMachineStatus{"2", state.StatusStarted, ""},
+		setMachineStatus{"2", status.StatusStarted, ""},
 		addAliveUnit{"riak", "2"},
-		setAgentStatus{"riak/1", state.StatusIdle, "", nil},
-		setUnitStatus{"riak/1", state.StatusActive, "", nil},
+		setAgentStatus{"riak/1", status.StatusIdle, "", nil},
+		setUnitStatus{"riak/1", status.StatusActive, "", nil},
 		addMachine{machineId: "3", job: state.JobHostUnits},
 		setAddresses{"3", network.NewAddresses("dummymodel-3.dns")},
 		startAliveMachine{"3"},
-		setMachineStatus{"3", state.StatusStarted, ""},
+		setMachineStatus{"3", status.StatusStarted, ""},
 		addAliveUnit{"riak", "3"},
-		setAgentStatus{"riak/2", state.StatusIdle, "", nil},
-		setUnitStatus{"riak/2", state.StatusActive, "", nil},
+		setAgentStatus{"riak/2", status.StatusIdle, "", nil},
+		setUnitStatus{"riak/2", status.StatusActive, "", nil},
 
 		expect{
 			"multiples related peer units",
@@ -1430,7 +1597,7 @@ var statusTests = []testCase{
 		addMachine{machineId: "0", job: state.JobManageModel},
 		setAddresses{"0", network.NewAddresses("dummymodel-0.dns")},
 		startAliveMachine{"0"},
-		setMachineStatus{"0", state.StatusStarted, ""},
+		setMachineStatus{"0", status.StatusStarted, ""},
 		addCharm{"wordpress"},
 		addCharm{"mysql"},
 		addCharm{"logging"},
@@ -1440,20 +1607,20 @@ var statusTests = []testCase{
 		addMachine{machineId: "1", job: state.JobHostUnits},
 		setAddresses{"1", network.NewAddresses("dummymodel-1.dns")},
 		startAliveMachine{"1"},
-		setMachineStatus{"1", state.StatusStarted, ""},
+		setMachineStatus{"1", status.StatusStarted, ""},
 		addAliveUnit{"wordpress", "1"},
-		setAgentStatus{"wordpress/0", state.StatusIdle, "", nil},
-		setUnitStatus{"wordpress/0", state.StatusActive, "", nil},
+		setAgentStatus{"wordpress/0", status.StatusIdle, "", nil},
+		setUnitStatus{"wordpress/0", status.StatusActive, "", nil},
 
 		addService{name: "mysql", charm: "mysql"},
 		setServiceExposed{"mysql", true},
 		addMachine{machineId: "2", job: state.JobHostUnits},
 		setAddresses{"2", network.NewAddresses("dummymodel-2.dns")},
 		startAliveMachine{"2"},
-		setMachineStatus{"2", state.StatusStarted, ""},
+		setMachineStatus{"2", status.StatusStarted, ""},
 		addAliveUnit{"mysql", "2"},
-		setAgentStatus{"mysql/0", state.StatusIdle, "", nil},
-		setUnitStatus{"mysql/0", state.StatusActive, "", nil},
+		setAgentStatus{"mysql/0", status.StatusIdle, "", nil},
+		setUnitStatus{"mysql/0", status.StatusActive, "", nil},
 
 		addService{name: "logging", charm: "logging"},
 		setServiceExposed{"logging", true},
@@ -1466,9 +1633,9 @@ var statusTests = []testCase{
 		addSubordinate{"mysql/0", "logging"},
 
 		setUnitsAlive{"logging"},
-		setAgentStatus{"logging/0", state.StatusIdle, "", nil},
-		setUnitStatus{"logging/0", state.StatusActive, "", nil},
-		setAgentStatus{"logging/1", state.StatusError, "somehow lost in all those logs", nil},
+		setAgentStatus{"logging/0", status.StatusIdle, "", nil},
+		setUnitStatus{"logging/0", status.StatusActive, "", nil},
+		setAgentStatus{"logging/1", status.StatusError, "somehow lost in all those logs", nil},
 
 		expect{
 			"multiples related peer units",
@@ -1746,7 +1913,7 @@ var statusTests = []testCase{
 		addMachine{machineId: "0", job: state.JobManageModel},
 		setAddresses{"0", network.NewAddresses("dummymodel-0.dns")},
 		startAliveMachine{"0"},
-		setMachineStatus{"0", state.StatusStarted, ""},
+		setMachineStatus{"0", status.StatusStarted, ""},
 		addCharm{"mysql"},
 		addService{name: "mysql", charm: "mysql"},
 		setServiceExposed{"mysql", true},
@@ -1755,26 +1922,26 @@ var statusTests = []testCase{
 		addMachine{machineId: "1", job: state.JobHostUnits},
 		setAddresses{"1", network.NewAddresses("dummymodel-1.dns")},
 		startAliveMachine{"1"},
-		setMachineStatus{"1", state.StatusStarted, ""},
+		setMachineStatus{"1", status.StatusStarted, ""},
 		addAliveUnit{"mysql", "1"},
-		setAgentStatus{"mysql/0", state.StatusIdle, "", nil},
-		setUnitStatus{"mysql/0", state.StatusActive, "", nil},
+		setAgentStatus{"mysql/0", status.StatusIdle, "", nil},
+		setUnitStatus{"mysql/0", status.StatusActive, "", nil},
 
 		// step 14: A container on machine 1.
 		addContainer{"1", "1/lxc/0", state.JobHostUnits},
 		setAddresses{"1/lxc/0", network.NewAddresses("dummymodel-2.dns")},
 		startAliveMachine{"1/lxc/0"},
-		setMachineStatus{"1/lxc/0", state.StatusStarted, ""},
+		setMachineStatus{"1/lxc/0", status.StatusStarted, ""},
 		addAliveUnit{"mysql", "1/lxc/0"},
-		setAgentStatus{"mysql/1", state.StatusIdle, "", nil},
-		setUnitStatus{"mysql/1", state.StatusActive, "", nil},
+		setAgentStatus{"mysql/1", status.StatusIdle, "", nil},
+		setUnitStatus{"mysql/1", status.StatusActive, "", nil},
 		addContainer{"1", "1/lxc/1", state.JobHostUnits},
 
 		// step 22: A nested container.
 		addContainer{"1/lxc/0", "1/lxc/0/lxc/0", state.JobHostUnits},
 		setAddresses{"1/lxc/0/lxc/0", network.NewAddresses("dummymodel-3.dns")},
 		startAliveMachine{"1/lxc/0/lxc/0"},
-		setMachineStatus{"1/lxc/0/lxc/0", state.StatusStarted, ""},
+		setMachineStatus{"1/lxc/0/lxc/0", status.StatusStarted, ""},
 
 		expect{
 			"machines with nested containers",
@@ -1825,25 +1992,41 @@ var statusTests = []testCase{
 
 		// step 27: once again, with a scope on mysql/1
 		scopedExpect{
-			"machines with nested containers",
+			"machines with nested containers 2",
 			[]string{"mysql/1"},
 			M{
 				"model": "dummymodel",
 				"machines": M{
 					"1": M{
-						"agent-state": "started",
+						"juju-status": M{
+							"current": "started",
+							"since":   "01 Apr 15 01:23+10:00",
+						},
 						"containers": M{
 							"1/lxc/0": M{
-								"agent-state": "started",
+								"juju-status": M{
+									"current": "started",
+									"since":   "01 Apr 15 01:23+10:00",
+								},
 								"dns-name":    "dummymodel-2.dns",
 								"instance-id": "dummymodel-2",
-								"series":      "quantal",
+								"machine-status": M{
+									"current": "pending",
+									"since":   "01 Apr 15 01:23+10:00",
+								},
+
+								"series": "quantal",
 							},
 						},
 						"dns-name":    "dummymodel-1.dns",
 						"instance-id": "dummymodel-1",
-						"series":      "quantal",
-						"hardware":    "arch=amd64 cpu-cores=1 mem=1024M root-disk=8192M",
+						"machine-status": M{
+							"current": "pending",
+							"since":   "01 Apr 15 01:23+10:00",
+						},
+
+						"series":   "quantal",
+						"hardware": "arch=amd64 cpu-cores=1 mem=1024M root-disk=8192M",
 					},
 				},
 				"services": M{
@@ -1878,11 +2061,11 @@ var statusTests = []testCase{
 		addMachine{machineId: "0", job: state.JobManageModel},
 		setAddresses{"0", network.NewAddresses("dummymodel-0.dns")},
 		startAliveMachine{"0"},
-		setMachineStatus{"0", state.StatusStarted, ""},
+		setMachineStatus{"0", status.StatusStarted, ""},
 		addMachine{machineId: "1", job: state.JobHostUnits},
 		setAddresses{"1", network.NewAddresses("dummymodel-1.dns")},
 		startAliveMachine{"1"},
-		setMachineStatus{"1", state.StatusStarted, ""},
+		setMachineStatus{"1", status.StatusStarted, ""},
 		addCharm{"mysql"},
 		addService{name: "mysql", charm: "mysql"},
 		setServiceExposed{"mysql", true},
@@ -1932,11 +2115,11 @@ var statusTests = []testCase{
 		addMachine{machineId: "0", job: state.JobManageModel},
 		setAddresses{"0", network.NewAddresses("dummymodel-0.dns")},
 		startAliveMachine{"0"},
-		setMachineStatus{"0", state.StatusStarted, ""},
+		setMachineStatus{"0", status.StatusStarted, ""},
 		addMachine{machineId: "1", job: state.JobHostUnits},
 		setAddresses{"1", network.NewAddresses("dummymodel-1.dns")},
 		startAliveMachine{"1"},
-		setMachineStatus{"1", state.StatusStarted, ""},
+		setMachineStatus{"1", status.StatusStarted, ""},
 		addCharm{"mysql"},
 		addService{name: "mysql", charm: "mysql"},
 		setServiceExposed{"mysql", true},
@@ -1986,11 +2169,11 @@ var statusTests = []testCase{
 		addMachine{machineId: "0", job: state.JobManageModel},
 		setAddresses{"0", network.NewAddresses("dummymodel-0.dns")},
 		startAliveMachine{"0"},
-		setMachineStatus{"0", state.StatusStarted, ""},
+		setMachineStatus{"0", status.StatusStarted, ""},
 		addMachine{machineId: "1", job: state.JobHostUnits},
 		setAddresses{"1", network.NewAddresses("dummymodel-1.dns")},
 		startAliveMachine{"1"},
-		setMachineStatus{"1", state.StatusStarted, ""},
+		setMachineStatus{"1", status.StatusStarted, ""},
 		addCharm{"mysql"},
 		addService{name: "mysql", charm: "mysql"},
 		setServiceExposed{"mysql", true},
@@ -2042,11 +2225,11 @@ var statusTests = []testCase{
 		addMachine{machineId: "0", job: state.JobManageModel},
 		setAddresses{"0", network.NewAddresses("dummymodel-0.dns")},
 		startAliveMachine{"0"},
-		setMachineStatus{"0", state.StatusStarted, ""},
+		setMachineStatus{"0", status.StatusStarted, ""},
 		addMachine{machineId: "1", job: state.JobHostUnits},
 		setAddresses{"1", network.NewAddresses("dummymodel-1.dns")},
 		startAliveMachine{"1"},
-		setMachineStatus{"1", state.StatusStarted, ""},
+		setMachineStatus{"1", status.StatusStarted, ""},
 		addCharm{"mysql"},
 		addService{name: "mysql", charm: "mysql"},
 		setServiceExposed{"mysql", true},
@@ -2097,27 +2280,27 @@ var statusTests = []testCase{
 		addMachine{machineId: "0", job: state.JobManageModel},
 		setAddresses{"0", network.NewAddresses("dummymodel-0.dns")},
 		startAliveMachine{"0"},
-		setMachineStatus{"0", state.StatusStarted, ""},
+		setMachineStatus{"0", status.StatusStarted, ""},
 
 		addMachine{machineId: "1", job: state.JobHostUnits},
 		setAddresses{"1", network.NewAddresses("dummymodel-1.dns")},
 		startAliveMachine{"1"},
-		setMachineStatus{"1", state.StatusStarted, ""},
+		setMachineStatus{"1", status.StatusStarted, ""},
 
 		addMachine{machineId: "2", job: state.JobHostUnits},
 		setAddresses{"2", network.NewAddresses("dummymodel-2.dns")},
 		startAliveMachine{"2"},
-		setMachineStatus{"2", state.StatusStarted, ""},
+		setMachineStatus{"2", status.StatusStarted, ""},
 
 		addMachine{machineId: "3", job: state.JobHostUnits},
 		setAddresses{"3", network.NewAddresses("dummymodel-3.dns")},
 		startAliveMachine{"3"},
-		setMachineStatus{"3", state.StatusStarted, ""},
+		setMachineStatus{"3", status.StatusStarted, ""},
 
 		addMachine{machineId: "4", job: state.JobHostUnits},
 		setAddresses{"4", network.NewAddresses("dummymodel-4.dns")},
 		startAliveMachine{"4"},
-		setMachineStatus{"4", state.StatusStarted, ""},
+		setMachineStatus{"4", status.StatusStarted, ""},
 
 		addCharm{"mysql"},
 		addService{name: "mysql", charm: "mysql"},
@@ -2132,14 +2315,14 @@ var statusTests = []testCase{
 
 		setServiceExposed{"mysql", true},
 
-		setAgentStatus{"mysql/0", state.StatusIdle, "", nil},
-		setUnitStatus{"mysql/0", state.StatusActive, "", nil},
-		setAgentStatus{"servicewithmeterstatus/0", state.StatusIdle, "", nil},
-		setUnitStatus{"servicewithmeterstatus/0", state.StatusActive, "", nil},
-		setAgentStatus{"servicewithmeterstatus/1", state.StatusIdle, "", nil},
-		setUnitStatus{"servicewithmeterstatus/1", state.StatusActive, "", nil},
-		setAgentStatus{"servicewithmeterstatus/2", state.StatusIdle, "", nil},
-		setUnitStatus{"servicewithmeterstatus/2", state.StatusActive, "", nil},
+		setAgentStatus{"mysql/0", status.StatusIdle, "", nil},
+		setUnitStatus{"mysql/0", status.StatusActive, "", nil},
+		setAgentStatus{"servicewithmeterstatus/0", status.StatusIdle, "", nil},
+		setUnitStatus{"servicewithmeterstatus/0", status.StatusActive, "", nil},
+		setAgentStatus{"servicewithmeterstatus/1", status.StatusIdle, "", nil},
+		setUnitStatus{"servicewithmeterstatus/1", status.StatusActive, "", nil},
+		setAgentStatus{"servicewithmeterstatus/2", status.StatusIdle, "", nil},
+		setUnitStatus{"servicewithmeterstatus/2", status.StatusActive, "", nil},
 
 		setUnitMeterStatus{"servicewithmeterstatus/1", "GREEN", "test green status"},
 		setUnitMeterStatus{"servicewithmeterstatus/2", "RED", "test red status"},
@@ -2332,7 +2515,7 @@ func (sm startMissingMachine) step(c *gc.C, ctx *context) {
 	_, hc := testing.AssertStartInstanceWithConstraints(c, ctx.env, m.Id(), cons)
 	err = m.SetProvisioned("i-missing", "fake_nonce", hc)
 	c.Assert(err, jc.ErrorIsNil)
-	err = m.SetInstanceStatus("missing")
+	err = m.SetInstanceStatus(status.StatusUnknown, "missing", nil)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -2557,7 +2740,7 @@ func (s setUnitMeterStatus) step(c *gc.C, ctx *context) {
 
 type setUnitStatus struct {
 	unitName   string
-	status     state.Status
+	status     status.Status
 	statusInfo string
 	statusData map[string]interface{}
 }
@@ -2571,7 +2754,7 @@ func (sus setUnitStatus) step(c *gc.C, ctx *context) {
 
 type setAgentStatus struct {
 	unitName   string
-	status     state.Status
+	status     status.Status
 	statusInfo string
 	statusData map[string]interface{}
 }
@@ -2594,9 +2777,9 @@ func (uc setUnitCharmURL) step(c *gc.C, ctx *context) {
 	curl := charm.MustParseURL(uc.charm)
 	err = u.SetCharmURL(curl)
 	c.Assert(err, jc.ErrorIsNil)
-	err = u.SetStatus(state.StatusActive, "", nil)
+	err = u.SetStatus(status.StatusActive, "", nil)
 	c.Assert(err, jc.ErrorIsNil)
-	err = u.SetAgentStatus(state.StatusIdle, "", nil)
+	err = u.SetAgentStatus(status.StatusIdle, "", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 }
@@ -2654,7 +2837,7 @@ func (e ensureDeadMachine) step(c *gc.C, ctx *context) {
 
 type setMachineStatus struct {
 	machineId  string
-	status     state.Status
+	status     status.Status
 	statusInfo string
 }
 
@@ -2821,7 +3004,7 @@ func (s *StatusSuite) TestStatusWithFormatSummary(c *gc.C) {
 		addMachine{machineId: "0", job: state.JobManageModel},
 		setAddresses{"0", network.NewAddresses("localhost")},
 		startAliveMachine{"0"},
-		setMachineStatus{"0", state.StatusStarted, ""},
+		setMachineStatus{"0", status.StatusStarted, ""},
 		addCharm{"wordpress"},
 		addCharm{"mysql"},
 		addCharm{"logging"},
@@ -2830,19 +3013,19 @@ func (s *StatusSuite) TestStatusWithFormatSummary(c *gc.C) {
 		addMachine{machineId: "1", job: state.JobHostUnits},
 		setAddresses{"1", network.NewAddresses("localhost")},
 		startAliveMachine{"1"},
-		setMachineStatus{"1", state.StatusStarted, ""},
+		setMachineStatus{"1", status.StatusStarted, ""},
 		addAliveUnit{"wordpress", "1"},
-		setAgentStatus{"wordpress/0", state.StatusIdle, "", nil},
-		setUnitStatus{"wordpress/0", state.StatusActive, "", nil},
+		setAgentStatus{"wordpress/0", status.StatusIdle, "", nil},
+		setUnitStatus{"wordpress/0", status.StatusActive, "", nil},
 		addService{name: "mysql", charm: "mysql"},
 		setServiceExposed{"mysql", true},
 		addMachine{machineId: "2", job: state.JobHostUnits},
 		setAddresses{"2", network.NewAddresses("10.0.0.1")},
 		startAliveMachine{"2"},
-		setMachineStatus{"2", state.StatusStarted, ""},
+		setMachineStatus{"2", status.StatusStarted, ""},
 		addAliveUnit{"mysql", "2"},
-		setAgentStatus{"mysql/0", state.StatusIdle, "", nil},
-		setUnitStatus{"mysql/0", state.StatusActive, "", nil},
+		setAgentStatus{"mysql/0", status.StatusIdle, "", nil},
+		setUnitStatus{"mysql/0", status.StatusActive, "", nil},
 		addService{name: "logging", charm: "logging"},
 		setServiceExposed{"logging", true},
 		relateServices{"wordpress", "mysql"},
@@ -2851,9 +3034,9 @@ func (s *StatusSuite) TestStatusWithFormatSummary(c *gc.C) {
 		addSubordinate{"wordpress/0", "logging"},
 		addSubordinate{"mysql/0", "logging"},
 		setUnitsAlive{"logging"},
-		setAgentStatus{"logging/0", state.StatusIdle, "", nil},
-		setUnitStatus{"logging/0", state.StatusActive, "", nil},
-		setAgentStatus{"logging/1", state.StatusError, "somehow lost in all those logs", nil},
+		setAgentStatus{"logging/0", status.StatusIdle, "", nil},
+		setUnitStatus{"logging/0", status.StatusActive, "", nil},
+		setAgentStatus{"logging/1", status.StatusError, "somehow lost in all those logs", nil},
 	}
 	for _, s := range steps {
 		s.step(c, ctx)
@@ -2885,7 +3068,7 @@ func (s *StatusSuite) TestStatusWithFormatOneline(c *gc.C) {
 		addMachine{machineId: "0", job: state.JobManageModel},
 		setAddresses{"0", network.NewAddresses("dummymodel-0.dns")},
 		startAliveMachine{"0"},
-		setMachineStatus{"0", state.StatusStarted, ""},
+		setMachineStatus{"0", status.StatusStarted, ""},
 		addCharm{"wordpress"},
 		addCharm{"mysql"},
 		addCharm{"logging"},
@@ -2895,20 +3078,20 @@ func (s *StatusSuite) TestStatusWithFormatOneline(c *gc.C) {
 		addMachine{machineId: "1", job: state.JobHostUnits},
 		setAddresses{"1", network.NewAddresses("dummymodel-1.dns")},
 		startAliveMachine{"1"},
-		setMachineStatus{"1", state.StatusStarted, ""},
+		setMachineStatus{"1", status.StatusStarted, ""},
 		addAliveUnit{"wordpress", "1"},
-		setAgentStatus{"wordpress/0", state.StatusIdle, "", nil},
-		setUnitStatus{"wordpress/0", state.StatusActive, "", nil},
+		setAgentStatus{"wordpress/0", status.StatusIdle, "", nil},
+		setUnitStatus{"wordpress/0", status.StatusActive, "", nil},
 
 		addService{name: "mysql", charm: "mysql"},
 		setServiceExposed{"mysql", true},
 		addMachine{machineId: "2", job: state.JobHostUnits},
 		setAddresses{"2", network.NewAddresses("dummymodel-2.dns")},
 		startAliveMachine{"2"},
-		setMachineStatus{"2", state.StatusStarted, ""},
+		setMachineStatus{"2", status.StatusStarted, ""},
 		addAliveUnit{"mysql", "2"},
-		setAgentStatus{"mysql/0", state.StatusIdle, "", nil},
-		setUnitStatus{"mysql/0", state.StatusActive, "", nil},
+		setAgentStatus{"mysql/0", status.StatusIdle, "", nil},
+		setUnitStatus{"mysql/0", status.StatusActive, "", nil},
 
 		addService{name: "logging", charm: "logging"},
 		setServiceExposed{"logging", true},
@@ -2921,9 +3104,9 @@ func (s *StatusSuite) TestStatusWithFormatOneline(c *gc.C) {
 		addSubordinate{"mysql/0", "logging"},
 
 		setUnitsAlive{"logging"},
-		setAgentStatus{"logging/0", state.StatusIdle, "", nil},
-		setUnitStatus{"logging/0", state.StatusActive, "", nil},
-		setAgentStatus{"logging/1", state.StatusError, "somehow lost in all those logs", nil},
+		setAgentStatus{"logging/0", status.StatusIdle, "", nil},
+		setUnitStatus{"logging/0", status.StatusActive, "", nil},
+		setAgentStatus{"logging/1", status.StatusError, "somehow lost in all those logs", nil},
 	}
 
 	ctx.run(c, steps)
@@ -2963,7 +3146,7 @@ func (s *StatusSuite) prepareTabularData(c *gc.C) *context {
 		addMachine{machineId: "0", job: state.JobManageModel},
 		setAddresses{"0", network.NewAddresses("dummymodel-0.dns")},
 		startMachineWithHardware{"0", instance.MustParseHardware("availability-zone=us-east-1a")},
-		setMachineStatus{"0", state.StatusStarted, ""},
+		setMachineStatus{"0", status.StatusStarted, ""},
 		addCharm{"wordpress"},
 		addCharm{"mysql"},
 		addCharm{"logging"},
@@ -2972,22 +3155,22 @@ func (s *StatusSuite) prepareTabularData(c *gc.C) *context {
 		addMachine{machineId: "1", job: state.JobHostUnits},
 		setAddresses{"1", network.NewAddresses("dummymodel-1.dns")},
 		startAliveMachine{"1"},
-		setMachineStatus{"1", state.StatusStarted, ""},
+		setMachineStatus{"1", status.StatusStarted, ""},
 		addAliveUnit{"wordpress", "1"},
-		setAgentStatus{"wordpress/0", state.StatusIdle, "", nil},
-		setUnitStatus{"wordpress/0", state.StatusActive, "", nil},
+		setAgentStatus{"wordpress/0", status.StatusIdle, "", nil},
+		setUnitStatus{"wordpress/0", status.StatusActive, "", nil},
 		setUnitTools{"wordpress/0", version.MustParseBinary("1.2.3-trusty-ppc")},
 		addService{name: "mysql", charm: "mysql"},
 		setServiceExposed{"mysql", true},
 		addMachine{machineId: "2", job: state.JobHostUnits},
 		setAddresses{"2", network.NewAddresses("dummymodel-2.dns")},
 		startAliveMachine{"2"},
-		setMachineStatus{"2", state.StatusStarted, ""},
+		setMachineStatus{"2", status.StatusStarted, ""},
 		addAliveUnit{"mysql", "2"},
-		setAgentStatus{"mysql/0", state.StatusIdle, "", nil},
+		setAgentStatus{"mysql/0", status.StatusIdle, "", nil},
 		setUnitStatus{
 			"mysql/0",
-			state.StatusMaintenance,
+			status.StatusMaintenance,
 			"installing all the things", nil},
 		setUnitTools{"mysql/0", version.MustParseBinary("1.2.3-trusty-ppc")},
 		addService{name: "logging", charm: "logging"},
@@ -2998,9 +3181,9 @@ func (s *StatusSuite) prepareTabularData(c *gc.C) *context {
 		addSubordinate{"wordpress/0", "logging"},
 		addSubordinate{"mysql/0", "logging"},
 		setUnitsAlive{"logging"},
-		setAgentStatus{"logging/0", state.StatusIdle, "", nil},
-		setUnitStatus{"logging/0", state.StatusActive, "", nil},
-		setAgentStatus{"logging/1", state.StatusError, "somehow lost in all those logs", nil},
+		setAgentStatus{"logging/0", status.StatusIdle, "", nil},
+		setUnitStatus{"logging/0", status.StatusActive, "", nil},
+		setAgentStatus{"logging/1", status.StatusError, "somehow lost in all those logs", nil},
 	}
 	for _, s := range steps {
 		s.step(c, ctx)
@@ -3068,21 +3251,21 @@ func (s *StatusSuite) TestFormatTabularHookActionName(c *gc.C) {
 				Units: map[string]unitStatus{
 					"foo/0": unitStatus{
 						AgentStatusInfo: statusInfoContents{
-							Current: params.StatusExecuting,
+							Current: status.StatusExecuting,
 							Message: "running config-changed hook",
 						},
 						WorkloadStatusInfo: statusInfoContents{
-							Current: params.StatusMaintenance,
+							Current: status.StatusMaintenance,
 							Message: "doing some work",
 						},
 					},
 					"foo/1": unitStatus{
 						AgentStatusInfo: statusInfoContents{
-							Current: params.StatusExecuting,
+							Current: status.StatusExecuting,
 							Message: "running action backup database",
 						},
 						WorkloadStatusInfo: statusInfoContents{
-							Current: params.StatusMaintenance,
+							Current: status.StatusMaintenance,
 							Message: "doing some work",
 						},
 					},
@@ -3114,7 +3297,7 @@ func (s *StatusSuite) TestStatusWithNilStatusApi(c *gc.C) {
 		addMachine{machineId: "0", job: state.JobManageModel},
 		setAddresses{"0", network.NewAddresses("dummymodel-0.dns")},
 		startAliveMachine{"0"},
-		setMachineStatus{"0", state.StatusStarted, ""},
+		setMachineStatus{"0", status.StatusStarted, ""},
 	}
 
 	for _, s := range steps {
@@ -3148,7 +3331,7 @@ func (s *StatusSuite) FilteringTestSetup(c *gc.C) *context {
 		// And the machine's job is to manage the environment
 		addMachine{machineId: "0", job: state.JobManageModel},
 		startAliveMachine{"0"},
-		setMachineStatus{"0", state.StatusStarted, ""},
+		setMachineStatus{"0", status.StatusStarted, ""},
 		// And the machine's address is "dummymodel-0.dns"
 		setAddresses{"0", network.NewAddresses("dummymodel-0.dns")},
 		// And the "wordpress" charm is available
@@ -3164,28 +3347,28 @@ func (s *StatusSuite) FilteringTestSetup(c *gc.C) *context {
 		// And the machine's job is to host units
 		addMachine{machineId: "1", job: state.JobHostUnits},
 		startAliveMachine{"1"},
-		setMachineStatus{"1", state.StatusStarted, ""},
+		setMachineStatus{"1", status.StatusStarted, ""},
 		// And the machine's address is "dummymodel-1.dns"
 		setAddresses{"1", network.NewAddresses("dummymodel-1.dns")},
 		// And a unit of "wordpress" is deployed to machine "1"
 		addAliveUnit{"wordpress", "1"},
 		// And the unit is started
-		setAgentStatus{"wordpress/0", state.StatusIdle, "", nil},
-		setUnitStatus{"wordpress/0", state.StatusActive, "", nil},
+		setAgentStatus{"wordpress/0", status.StatusIdle, "", nil},
+		setUnitStatus{"wordpress/0", status.StatusActive, "", nil},
 		// And a machine is started
 
 		// And the machine's ID is "2"
 		// And the machine's job is to host units
 		addMachine{machineId: "2", job: state.JobHostUnits},
 		startAliveMachine{"2"},
-		setMachineStatus{"2", state.StatusStarted, ""},
+		setMachineStatus{"2", status.StatusStarted, ""},
 		// And the machine's address is "dummymodel-2.dns"
 		setAddresses{"2", network.NewAddresses("dummymodel-2.dns")},
 		// And a unit of "mysql" is deployed to machine "2"
 		addAliveUnit{"mysql", "2"},
 		// And the unit is started
-		setAgentStatus{"mysql/0", state.StatusIdle, "", nil},
-		setUnitStatus{"mysql/0", state.StatusActive, "", nil},
+		setAgentStatus{"mysql/0", status.StatusIdle, "", nil},
+		setUnitStatus{"mysql/0", status.StatusActive, "", nil},
 		// And the "logging" service is added
 		addService{name: "logging", charm: "logging"},
 		// And the service is exposed
@@ -3198,12 +3381,12 @@ func (s *StatusSuite) FilteringTestSetup(c *gc.C) *context {
 		relateServices{"mysql", "logging"},
 		// And the "logging" service is a subordinate to unit 0 of the "wordpress" service
 		addSubordinate{"wordpress/0", "logging"},
-		setAgentStatus{"logging/0", state.StatusIdle, "", nil},
-		setUnitStatus{"logging/0", state.StatusActive, "", nil},
+		setAgentStatus{"logging/0", status.StatusIdle, "", nil},
+		setUnitStatus{"logging/0", status.StatusActive, "", nil},
 		// And the "logging" service is a subordinate to unit 0 of the "mysql" service
 		addSubordinate{"mysql/0", "logging"},
-		setAgentStatus{"logging/1", state.StatusIdle, "", nil},
-		setUnitStatus{"logging/1", state.StatusActive, "", nil},
+		setAgentStatus{"logging/1", status.StatusIdle, "", nil},
+		setUnitStatus{"logging/1", status.StatusActive, "", nil},
 		setUnitsAlive{"logging"},
 	}
 
@@ -3211,17 +3394,17 @@ func (s *StatusSuite) FilteringTestSetup(c *gc.C) *context {
 	return ctx
 }
 
-// Scenario: One unit is in an errored state and user filters to started
-func (s *StatusSuite) TestFilterToStarted(c *gc.C) {
+// Scenario: One unit is in an errored state and user filters to active
+func (s *StatusSuite) TestFilterToActive(c *gc.C) {
 	ctx := s.FilteringTestSetup(c)
 	defer s.resetContext(c, ctx)
 
 	// Given unit 1 of the "logging" service has an error
-	setAgentStatus{"logging/1", state.StatusError, "mock error", nil}.step(c, ctx)
+	setAgentStatus{"logging/1", status.StatusError, "mock error", nil}.step(c, ctx)
 	// And unit 0 of the "mysql" service has an error
-	setAgentStatus{"mysql/0", state.StatusError, "mock error", nil}.step(c, ctx)
+	setAgentStatus{"mysql/0", status.StatusError, "mock error", nil}.step(c, ctx)
 	// When I run juju status --format oneline started
-	_, stdout, stderr := runStatus(c, "--format", "oneline", "started")
+	_, stdout, stderr := runStatus(c, "--format", "oneline", "active")
 	c.Assert(string(stderr), gc.Equals, "")
 	// Then I should receive output prefixed with:
 	const expected = `
@@ -3238,7 +3421,7 @@ func (s *StatusSuite) TestFilterToErrored(c *gc.C) {
 	defer s.resetContext(c, ctx)
 
 	// Given unit 1 of the "logging" service has an error
-	setAgentStatus{"logging/1", state.StatusError, "mock error", nil}.step(c, ctx)
+	setAgentStatus{"logging/1", status.StatusError, "mock error", nil}.step(c, ctx)
 	// When I run juju status --format oneline error
 	_, stdout, stderr := runStatus(c, "--format", "oneline", "error")
 	c.Assert(stderr, gc.IsNil)
@@ -3412,7 +3595,7 @@ func (s *StatusSuite) TestFilterMultipleHeterogenousPatterns(c *gc.C) {
 	ctx := s.FilteringTestSetup(c)
 	defer s.resetContext(c, ctx)
 
-	_, stdout, stderr := runStatus(c, "--format", "oneline", "wordpress/0", "started")
+	_, stdout, stderr := runStatus(c, "--format", "oneline", "wordpress/0", "active")
 	c.Assert(stderr, gc.IsNil)
 	// Then I should receive output prefixed with:
 	const expected = `
@@ -3478,14 +3661,14 @@ var statusTimeTest = test(
 	addMachine{machineId: "0", job: state.JobManageModel},
 	setAddresses{"0", network.NewAddresses("dummymodel-0.dns")},
 	startAliveMachine{"0"},
-	setMachineStatus{"0", state.StatusStarted, ""},
+	setMachineStatus{"0", status.StatusStarted, ""},
 	addCharm{"dummy"},
 	addService{name: "dummy-service", charm: "dummy"},
 
 	addMachine{machineId: "1", job: state.JobHostUnits},
 	startAliveMachine{"1"},
 	setAddresses{"1", network.NewAddresses("dummymodel-1.dns")},
-	setMachineStatus{"1", state.StatusStarted, ""},
+	setMachineStatus{"1", status.StatusStarted, ""},
 
 	addAliveUnit{"dummy-service", "1"},
 	expect{
@@ -3540,12 +3723,12 @@ func (s *StatusSuite) TestFormatProvisioningError(c *gc.C) {
 	status := &params.FullStatus{
 		Machines: map[string]params.MachineStatus{
 			"1": params.MachineStatus{
-				Agent: params.AgentStatus{
+				JujuStatus: params.AgentStatus{
 					Status: "error",
 					Info:   "<error while provisioning>",
 				},
 				InstanceId:    "pending",
-				InstanceState: "",
+				MachineStatus: params.AgentStatus{},
 				Series:        "trusty",
 				Id:            "1",
 				Jobs:          []multiwatcher.MachineJob{"JobHostUnits"},
@@ -3558,12 +3741,11 @@ func (s *StatusSuite) TestFormatProvisioningError(c *gc.C) {
 	c.Check(formatted, jc.DeepEquals, formattedStatus{
 		Machines: map[string]machineStatus{
 			"1": machineStatus{
-				AgentState:     "error",
-				AgentStateInfo: "<error while provisioning>",
-				InstanceId:     "pending",
-				Series:         "trusty",
-				Id:             "1",
-				Containers:     map[string]machineStatus{},
+				JujuStatus: statusInfoContents{Current: "error", Message: "<error while provisioning>"},
+				InstanceId: "pending",
+				Series:     "trusty",
+				Id:         "1",
+				Containers: map[string]machineStatus{},
 			},
 		},
 		Services: map[string]serviceStatus{},

--- a/cmd/juju/storage/filesystemlist_test.go
+++ b/cmd/juju/storage/filesystemlist_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/juju/storage"
+	"github.com/juju/juju/status"
 	"github.com/juju/juju/testing"
 )
 
@@ -203,7 +204,7 @@ func (s mockFilesystemListAPI) ListFilesystems(machines []string) ([]params.File
 				FilesystemId: "provider-supplied-filesystem-0-0",
 				Size:         512,
 			},
-			Status: createTestStatus(params.StatusAttached, ""),
+			Status: createTestStatus(status.StatusAttached, ""),
 			MachineAttachments: map[string]params.FilesystemAttachmentInfo{
 				"machine-0": params.FilesystemAttachmentInfo{
 					MountPoint: "/mnt/fuji",
@@ -213,7 +214,7 @@ func (s mockFilesystemListAPI) ListFilesystems(machines []string) ([]params.File
 				StorageTag: "storage-db-dir-1001",
 				OwnerTag:   "unit-abc-0",
 				Kind:       params.StorageKindBlock,
-				Status:     createTestStatus(params.StatusAttached, ""),
+				Status:     createTestStatus(status.StatusAttached, ""),
 				Attachments: map[string]params.StorageAttachmentDetails{
 					"unit-abc-0": params.StorageAttachmentDetails{
 						StorageTag: "storage-db-dir-1001",
@@ -232,7 +233,7 @@ func (s mockFilesystemListAPI) ListFilesystems(machines []string) ([]params.File
 				FilesystemId: "provider-supplied-filesystem-1",
 				Size:         2048,
 			},
-			Status: createTestStatus(params.StatusAttaching, "failed to attach, will retry"),
+			Status: createTestStatus(status.StatusAttaching, "failed to attach, will retry"),
 			MachineAttachments: map[string]params.FilesystemAttachmentInfo{
 				"machine-0": params.FilesystemAttachmentInfo{},
 			},
@@ -244,7 +245,7 @@ func (s mockFilesystemListAPI) ListFilesystems(machines []string) ([]params.File
 			Info: params.FilesystemInfo{
 				Size: 42,
 			},
-			Status: createTestStatus(params.StatusPending, ""),
+			Status: createTestStatus(status.StatusPending, ""),
 			MachineAttachments: map[string]params.FilesystemAttachmentInfo{
 				"machine-1": params.FilesystemAttachmentInfo{},
 			},
@@ -257,7 +258,7 @@ func (s mockFilesystemListAPI) ListFilesystems(machines []string) ([]params.File
 				FilesystemId: "provider-supplied-filesystem-2",
 				Size:         3,
 			},
-			Status: createTestStatus(params.StatusAttached, ""),
+			Status: createTestStatus(status.StatusAttached, ""),
 			MachineAttachments: map[string]params.FilesystemAttachmentInfo{
 				"machine-1": params.FilesystemAttachmentInfo{
 					MountPoint: "/mnt/zion",
@@ -272,7 +273,7 @@ func (s mockFilesystemListAPI) ListFilesystems(machines []string) ([]params.File
 				FilesystemId: "provider-supplied-filesystem-4",
 				Size:         1024,
 			},
-			Status: createTestStatus(params.StatusAttached, ""),
+			Status: createTestStatus(status.StatusAttached, ""),
 			MachineAttachments: map[string]params.FilesystemAttachmentInfo{
 				"machine-0": params.FilesystemAttachmentInfo{
 					MountPoint: "/mnt/doom",
@@ -287,7 +288,7 @@ func (s mockFilesystemListAPI) ListFilesystems(machines []string) ([]params.File
 				StorageTag: "storage-shared-fs-0",
 				OwnerTag:   "service-transcode",
 				Kind:       params.StorageKindBlock,
-				Status:     createTestStatus(params.StatusAttached, ""),
+				Status:     createTestStatus(status.StatusAttached, ""),
 				Attachments: map[string]params.StorageAttachmentDetails{
 					"unit-transcode-0": params.StorageAttachmentDetails{
 						StorageTag: "storage-shared-fs-0",

--- a/cmd/juju/storage/list_test.go
+++ b/cmd/juju/storage/list_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/juju/storage"
 	_ "github.com/juju/juju/provider/dummy"
+	"github.com/juju/juju/status"
 	"github.com/juju/juju/testing"
 )
 
@@ -151,7 +152,7 @@ func (s mockListAPI) ListStorageDetails() ([]params.StorageDetails, error) {
 		OwnerTag:   "unit-transcode-0",
 		Kind:       params.StorageKindBlock,
 		Status: params.EntityStatus{
-			Status: params.StatusPending,
+			Status: status.StatusPending,
 			Since:  &epoch,
 		},
 		Attachments: map[string]params.StorageAttachmentDetails{
@@ -164,7 +165,7 @@ func (s mockListAPI) ListStorageDetails() ([]params.StorageDetails, error) {
 		OwnerTag:   "unit-postgresql-0",
 		Kind:       params.StorageKindBlock,
 		Status: params.EntityStatus{
-			Status: params.StatusAttached,
+			Status: status.StatusAttached,
 			Since:  &epoch,
 		},
 		Persistent: true,
@@ -178,7 +179,7 @@ func (s mockListAPI) ListStorageDetails() ([]params.StorageDetails, error) {
 		OwnerTag:   "service-transcode",
 		Kind:       params.StorageKindFilesystem,
 		Status: params.EntityStatus{
-			Status: params.StatusAttached,
+			Status: status.StatusAttached,
 			Since:  &epoch,
 		},
 		Persistent: true,

--- a/cmd/juju/storage/volume.go
+++ b/cmd/juju/storage/volume.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	jujucmd "github.com/juju/juju/cmd"
 	"github.com/juju/juju/cmd/juju/common"
+	"github.com/juju/juju/status"
 )
 
 const volumeCmdDoc = `
@@ -64,7 +65,7 @@ type VolumeInfo struct {
 }
 
 type EntityStatus struct {
-	Current params.Status `json:"current,omitempty" yaml:"current,omitempty"`
+	Current status.Status `json:"current,omitempty" yaml:"current,omitempty"`
 	Message string        `json:"message,omitempty" yaml:"message,omitempty"`
 	Since   string        `json:"since,omitempty" yaml:"since,omitempty"`
 }

--- a/cmd/juju/storage/volumelist_test.go
+++ b/cmd/juju/storage/volumelist_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/juju/storage"
+	"github.com/juju/juju/status"
 	"github.com/juju/juju/testing"
 )
 
@@ -203,7 +204,7 @@ func (s mockVolumeListAPI) ListVolumes(machines []string) ([]params.VolumeDetail
 				VolumeId: "provider-supplied-volume-0-0",
 				Size:     512,
 			},
-			Status: createTestStatus(params.StatusAttached, ""),
+			Status: createTestStatus(status.StatusAttached, ""),
 			MachineAttachments: map[string]params.VolumeAttachmentInfo{
 				"machine-0": params.VolumeAttachmentInfo{
 					DeviceName: "loop0",
@@ -213,7 +214,7 @@ func (s mockVolumeListAPI) ListVolumes(machines []string) ([]params.VolumeDetail
 				StorageTag: "storage-db-dir-1001",
 				OwnerTag:   "unit-abc-0",
 				Kind:       params.StorageKindBlock,
-				Status:     createTestStatus(params.StatusAttached, ""),
+				Status:     createTestStatus(status.StatusAttached, ""),
 				Attachments: map[string]params.StorageAttachmentDetails{
 					"unit-abc-0": params.StorageAttachmentDetails{
 						StorageTag: "storage-db-dir-1001",
@@ -234,7 +235,7 @@ func (s mockVolumeListAPI) ListVolumes(machines []string) ([]params.VolumeDetail
 				Persistent: true,
 				Size:       2048,
 			},
-			Status: createTestStatus(params.StatusAttaching, "failed to attach, will retry"),
+			Status: createTestStatus(status.StatusAttaching, "failed to attach, will retry"),
 			MachineAttachments: map[string]params.VolumeAttachmentInfo{
 				"machine-0": params.VolumeAttachmentInfo{},
 			},
@@ -246,7 +247,7 @@ func (s mockVolumeListAPI) ListVolumes(machines []string) ([]params.VolumeDetail
 			Info: params.VolumeInfo{
 				Size: 42,
 			},
-			Status: createTestStatus(params.StatusPending, ""),
+			Status: createTestStatus(status.StatusPending, ""),
 			MachineAttachments: map[string]params.VolumeAttachmentInfo{
 				"machine-1": params.VolumeAttachmentInfo{},
 			},
@@ -259,7 +260,7 @@ func (s mockVolumeListAPI) ListVolumes(machines []string) ([]params.VolumeDetail
 				VolumeId: "provider-supplied-volume-2",
 				Size:     3,
 			},
-			Status: createTestStatus(params.StatusAttached, ""),
+			Status: createTestStatus(status.StatusAttached, ""),
 			MachineAttachments: map[string]params.VolumeAttachmentInfo{
 				"machine-1": params.VolumeAttachmentInfo{
 					DeviceName: "xvdf1",
@@ -275,7 +276,7 @@ func (s mockVolumeListAPI) ListVolumes(machines []string) ([]params.VolumeDetail
 				Persistent: true,
 				Size:       1024,
 			},
-			Status: createTestStatus(params.StatusAttached, ""),
+			Status: createTestStatus(status.StatusAttached, ""),
 			MachineAttachments: map[string]params.VolumeAttachmentInfo{
 				"machine-0": params.VolumeAttachmentInfo{
 					DeviceName: "xvdf2",
@@ -290,7 +291,7 @@ func (s mockVolumeListAPI) ListVolumes(machines []string) ([]params.VolumeDetail
 				StorageTag: "storage-shared-fs-0",
 				OwnerTag:   "service-transcode",
 				Kind:       params.StorageKindBlock,
-				Status:     createTestStatus(params.StatusAttached, ""),
+				Status:     createTestStatus(status.StatusAttached, ""),
 				Attachments: map[string]params.StorageAttachmentDetails{
 					"unit-transcode-0": params.StorageAttachmentDetails{
 						StorageTag: "storage-shared-fs-0",
@@ -311,9 +312,9 @@ func (s mockVolumeListAPI) ListVolumes(machines []string) ([]params.VolumeDetail
 	return results, nil
 }
 
-func createTestStatus(status params.Status, message string) params.EntityStatus {
+func createTestStatus(testStatus status.Status, message string) params.EntityStatus {
 	return params.EntityStatus{
-		Status: status,
+		Status: testStatus,
 		Info:   message,
 		Since:  &time.Time{},
 	}

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -63,6 +63,7 @@ import (
 	"github.com/juju/juju/service/upstart"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/watcher"
+	"github.com/juju/juju/status"
 	"github.com/juju/juju/storage"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/testing/factory"
@@ -466,7 +467,7 @@ func (s *MachineSuite) TestHostUnits(c *gc.C) {
 
 	// "start the agent" for u0 to prevent short-circuited remove-on-destroy;
 	// check that it's kept deployed despite being Dying.
-	err = u0.SetAgentStatus(state.StatusIdle, "", nil)
+	err = u0.SetAgentStatus(status.StatusIdle, "", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	err = u0.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
@@ -711,7 +712,8 @@ func (s *MachineSuite) TestManageModelRunsInstancePoller(c *gc.C) {
 		c.Assert(err, jc.ErrorIsNil)
 		instStatus, err := m.InstanceStatus()
 		c.Assert(err, jc.ErrorIsNil)
-		if reflect.DeepEqual(m.Addresses(), addrs) && instStatus == "running" {
+		c.Logf("found status is %q %q", instStatus.Status, instStatus.Message)
+		if reflect.DeepEqual(m.Addresses(), addrs) && instStatus.Message == "running" {
 			break
 		}
 	}

--- a/cmd/jujud/agent/unit_test.go
+++ b/cmd/jujud/agent/unit_test.go
@@ -26,6 +26,7 @@ import (
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/status"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/tools"
 	"github.com/juju/juju/version"
@@ -150,13 +151,13 @@ func waitForUnitActive(stateConn *state.State, unit *state.Unit, c *gc.C) {
 			statusInfo, err := unit.Status()
 			c.Assert(err, jc.ErrorIsNil)
 			switch statusInfo.Status {
-			case state.StatusMaintenance, state.StatusWaiting, state.StatusBlocked:
+			case status.StatusMaintenance, status.StatusWaiting, status.StatusBlocked:
 				c.Logf("waiting...")
 				continue
-			case state.StatusActive:
+			case status.StatusActive:
 				c.Logf("active!")
 				return
-			case state.StatusUnknown:
+			case status.StatusUnknown:
 				// Active units may have a status of unknown if they have
 				// started but not run status-set.
 				c.Logf("unknown but active!")
@@ -167,10 +168,10 @@ func waitForUnitActive(stateConn *state.State, unit *state.Unit, c *gc.C) {
 			statusInfo, err = unit.AgentStatus()
 			c.Assert(err, jc.ErrorIsNil)
 			switch statusInfo.Status {
-			case state.StatusAllocating, state.StatusExecuting, state.StatusRebooting, state.StatusIdle:
+			case status.StatusAllocating, status.StatusExecuting, status.StatusRebooting, status.StatusIdle:
 				c.Logf("waiting...")
 				continue
-			case state.StatusError:
+			case status.StatusError:
 				stateConn.StartSync()
 				c.Logf("unit is still down")
 			default:

--- a/container/interface.go
+++ b/container/interface.go
@@ -6,6 +6,7 @@ package container
 import (
 	"github.com/juju/juju/cloudconfig/instancecfg"
 	"github.com/juju/juju/instance"
+	"github.com/juju/juju/status"
 )
 
 const (
@@ -45,7 +46,8 @@ type Manager interface {
 		instanceConfig *instancecfg.InstanceConfig,
 		series string,
 		network *NetworkConfig,
-		storage *StorageConfig) (instance.Instance, *instance.HardwareCharacteristics, error)
+		storage *StorageConfig,
+		callback func(settableStatus status.Status, info string, data map[string]interface{}) error) (instance.Instance, *instance.HardwareCharacteristics, error)
 
 	// DestroyContainer stops and destroyes the container identified by
 	// instance id.

--- a/container/kvm/instance.go
+++ b/container/kvm/instance.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/network"
+	"github.com/juju/juju/status"
 )
 
 type kvmInstance struct {
@@ -23,11 +24,17 @@ func (kvm *kvmInstance) Id() instance.Id {
 }
 
 // Status implements instance.Instance.Status.
-func (kvm *kvmInstance) Status() string {
+func (kvm *kvmInstance) Status() instance.InstanceStatus {
 	if kvm.container.IsRunning() {
-		return "running"
+		return instance.InstanceStatus{
+			Status:  status.StatusRunning,
+			Message: "running",
+		}
 	}
-	return "stopped"
+	return instance.InstanceStatus{
+		Status:  status.StatusRunning,
+		Message: "stopped",
+	}
 }
 
 func (*kvmInstance) Refresh() error {

--- a/container/kvm/kvm.go
+++ b/container/kvm/kvm.go
@@ -21,6 +21,7 @@ import (
 	"github.com/juju/juju/container"
 	"github.com/juju/juju/environs/imagemetadata"
 	"github.com/juju/juju/instance"
+	"github.com/juju/juju/status"
 )
 
 var (
@@ -106,12 +107,19 @@ func (manager *containerManager) CreateContainer(
 	series string,
 	networkConfig *container.NetworkConfig,
 	storageConfig *container.StorageConfig,
-) (instance.Instance, *instance.HardwareCharacteristics, error) {
+	callback func(status status.Status, info string, data map[string]interface{}) error,
+) (_ instance.Instance, _ *instance.HardwareCharacteristics, err error) {
 
 	name := names.NewMachineTag(instanceConfig.MachineId).String()
 	if manager.name != "" {
 		name = fmt.Sprintf("%s-%s", manager.name, name)
 	}
+
+	defer func() {
+		if err != nil {
+			callback(status.StatusProvisioningError, fmt.Sprintf("Creating container: %v", err), nil)
+		}
+	}()
 
 	// Set the MachineContainerHostname to match the name returned by virsh list
 	instanceConfig.MachineContainerHostname = name
@@ -155,6 +163,7 @@ func (manager *containerManager) CreateContainer(
 		logger.Warningf("failed to parse hardware: %v", err)
 	}
 
+	callback(status.StatusProvisioning, "Creating container; it might take some time", nil)
 	logger.Tracef("create the container, constraints: %v", instanceConfig.Constraints)
 	if err := kvmContainer.Start(startParams); err != nil {
 		err = errors.Annotate(err, "kvm container creation failed")

--- a/container/kvm/live_test.go
+++ b/container/kvm/live_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/juju/juju/environs/imagemetadata"
 	"github.com/juju/juju/instance"
 	jujutesting "github.com/juju/juju/juju/testing"
+	"github.com/juju/juju/status"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/tools"
 	"github.com/juju/juju/version"
@@ -97,8 +98,8 @@ func createContainer(c *gc.C, manager container.Manager, machineId string) insta
 	environConfig := dummyConfig(c)
 	err = instancecfg.FinishInstanceConfig(instanceConfig, environConfig)
 	c.Assert(err, jc.ErrorIsNil)
-
-	inst, hardware, err := manager.CreateContainer(instanceConfig, "precise", network, nil)
+	callback := func(settableStatus status.Status, info string, data map[string]interface{}) error { return nil }
+	inst, hardware, err := manager.CreateContainer(instanceConfig, "precise", network, nil, callback)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(hardware, gc.NotNil)
 	expected := fmt.Sprintf("arch=%s cpu-cores=1 mem=512M root-disk=8192M", arch.HostArch())

--- a/container/lxc/clonetemplate.go
+++ b/container/lxc/clonetemplate.go
@@ -20,6 +20,7 @@ import (
 	"github.com/juju/juju/cloudconfig/containerinit"
 	"github.com/juju/juju/container"
 	"github.com/juju/juju/instance"
+	"github.com/juju/juju/status"
 	"github.com/juju/juju/utils/filelock"
 )
 
@@ -56,8 +57,15 @@ func EnsureCloneTemplate(
 	enableOSUpgrades bool,
 	imageURLGetter container.ImageURLGetter,
 	useAUFS bool,
-) (golxc.Container, error) {
+	callback func(containerStatus status.Status, info string, data map[string]interface{}) error,
+) (_ golxc.Container, err error) {
 	name := fmt.Sprintf("juju-%s-lxc-template", series)
+
+	defer func() {
+		if err != nil {
+			callback(status.StatusProvisioningError, fmt.Sprintf("Creating container: %v", err), nil)
+		}
+	}()
 	containerDirectory, err := container.NewDirectory(name)
 	if err != nil {
 		return nil, err
@@ -76,6 +84,8 @@ func EnsureCloneTemplate(
 		return lxcContainer, nil
 	}
 	logger.Infof("template does not exist, creating")
+
+	callback(status.StatusProvisioning, "Creating template container; downloading image may take some time", nil)
 
 	userData, err := containerinit.TemplateUserData(
 		series,
@@ -151,6 +161,7 @@ func EnsureCloneTemplate(
 		return nil, err
 	}
 	logger.Infof("template container started, now wait for it to stop")
+	callback(status.StatusProvisioning, "Template container created; waiting for cloud-init to complete", nil)
 	// Perhaps we should wait for it to finish, and the question becomes "how
 	// long do we wait for it to complete?"
 
@@ -170,6 +181,7 @@ func EnsureCloneTemplate(
 	for lxcContainer.IsRunning() {
 		if tailWriter.lastTick().Before(time.Now().Add(-TemplateStopTimeout)) {
 			logger.Infof("not heard anything from the template log for five minutes")
+			callback(status.StatusProvisioningError, "Container creation failed: template container has not stopped", nil)
 			return nil, fmt.Errorf("template container %q did not stop", name)
 		}
 		time.Sleep(time.Second)

--- a/container/lxc/instance.go
+++ b/container/lxc/instance.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/network"
+	"github.com/juju/juju/status"
 )
 
 type lxcInstance struct {
@@ -26,10 +27,13 @@ func (lxc *lxcInstance) Id() instance.Id {
 }
 
 // Status implements instance.Instance.Status.
-func (lxc *lxcInstance) Status() string {
+func (lxc *lxcInstance) Status() instance.InstanceStatus {
 	// On error, the state will be "unknown".
 	state, _, _ := lxc.Info()
-	return string(state)
+	return instance.InstanceStatus{
+		Status:  status.StatusUnknown,
+		Message: string(state),
+	}
 }
 
 func (*lxcInstance) Refresh() error {

--- a/container/lxc/lxc.go
+++ b/container/lxc/lxc.go
@@ -33,6 +33,7 @@ import (
 	"github.com/juju/juju/container"
 	"github.com/juju/juju/container/lxc/lxcutils"
 	"github.com/juju/juju/instance"
+	"github.com/juju/juju/status"
 	"github.com/juju/juju/storage/looputil"
 )
 
@@ -185,6 +186,7 @@ func (manager *containerManager) CreateContainer(
 	series string,
 	networkConfig *container.NetworkConfig,
 	storageConfig *container.StorageConfig,
+	callback func(containerStatus status.Status, info string, data map[string]interface{}) error,
 ) (inst instance.Instance, _ *instance.HardwareCharacteristics, err error) {
 	// Check our preconditions
 	if manager == nil {
@@ -194,6 +196,8 @@ func (manager *containerManager) CreateContainer(
 	} else if networkConfig == nil {
 		panic("networkConfig is nil")
 	} else if storageConfig == nil {
+		panic("storageConfig is nil")
+	} else if callback == nil {
 		panic("storageConfig is nil")
 	}
 
@@ -233,6 +237,7 @@ func (manager *containerManager) CreateContainer(
 			instanceConfig.EnableOSUpgrade,
 			manager.imageURLGetter,
 			manager.useAUFS,
+			callback,
 		)
 		if err != nil {
 			return nil, nil, errors.Annotate(err, "failed to retrieve the template to clone")
@@ -266,6 +271,10 @@ func (manager *containerManager) CreateContainer(
 			return nil, nil, errors.Annotate(err, "failed to reorder network settings")
 		}
 
+		err = callback(status.StatusProvisioning, "Cloning template container", nil)
+		if err != nil {
+			logger.Warningf("---------------- Cannot set instance status for container: %v", err)
+		}
 		lxcContainer, err = templateContainer.Clone(name, extraCloneArgs, templateParams)
 		if err != nil {
 			return nil, nil, errors.Wrap(err, instance.NewRetryableCreationError("lxc container cloning failed"))
@@ -303,6 +312,8 @@ func (manager *containerManager) CreateContainer(
 			return nil, nil, errors.Trace(err)
 		}
 	}
+
+	callback(status.StatusProvisioning, "Configuring container", nil)
 
 	if err := autostartContainer(name); err != nil {
 		return nil, nil, errors.Annotate(err, "failed to configure the container for autostart")
@@ -360,6 +371,7 @@ func (manager *containerManager) CreateContainer(
 	consoleFile := filepath.Join(directory, "console.log")
 	lxcContainer.SetLogFile(filepath.Join(directory, "container.log"), golxc.LogDebug)
 	logger.Tracef("start the container")
+	callback(status.StatusProvisioning, "Starting container", nil)
 
 	// We explicitly don't pass through the config file to the container.Start
 	// method as we have passed it through at container creation time.  This
@@ -389,6 +401,7 @@ func (manager *containerManager) CreateContainer(
 		Arch: &arch,
 	}
 
+	callback(status.StatusRunning, "Container started", nil)
 	return &lxcInstance{lxcContainer, name}, hardware, nil
 }
 

--- a/container/testing/common.go
+++ b/container/testing/common.go
@@ -22,6 +22,7 @@ import (
 	"github.com/juju/juju/instance"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/provider/dummy"
+	"github.com/juju/juju/status"
 	"github.com/juju/juju/tools"
 	"github.com/juju/juju/version"
 )
@@ -77,7 +78,8 @@ func CreateContainerWithMachineAndNetworkAndStorageConfig(
 		name := "test-" + names.NewMachineTag(instanceConfig.MachineId).String()
 		EnsureLXCRootFSEtcNetwork(c, name)
 	}
-	inst, hardware, err := manager.CreateContainer(instanceConfig, "quantal", networkConfig, storageConfig)
+	callback := func(settableStatus status.Status, info string, data map[string]interface{}) error { return nil }
+	inst, hardware, err := manager.CreateContainer(instanceConfig, "quantal", networkConfig, storageConfig, callback)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(hardware, gc.NotNil)
 	c.Assert(hardware.String(), gc.Not(gc.Equals), "")
@@ -121,7 +123,8 @@ func CreateContainerTest(c *gc.C, manager container.Manager, machineId string) (
 	network := container.BridgeNetworkConfig("nic42", 0, nil)
 	storage := &container.StorageConfig{}
 
-	inst, hardware, err := manager.CreateContainer(instanceConfig, "quantal", network, storage)
+	callback := func(settableStatus status.Status, info string, data map[string]interface{}) error { return nil }
+	inst, hardware, err := manager.CreateContainer(instanceConfig, "quantal", network, storage, callback)
 
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/environs/broker.go
+++ b/environs/broker.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/juju/environs/imagemetadata"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/network"
+	"github.com/juju/juju/status"
 	"github.com/juju/juju/storage"
 	"github.com/juju/juju/tools"
 )
@@ -65,6 +66,8 @@ type StartInstanceParams struct {
 	// ImageMetadata is a collection of image metadata
 	// that may be used to start this instance.
 	ImageMetadata []*imagemetadata.ImageMetadata
+
+	StatusCallback func(settableStatus status.Status, info string, data map[string]interface{}) error
 }
 
 // StartInstanceResult holds the result of an

--- a/instance/instance.go
+++ b/instance/instance.go
@@ -12,11 +12,17 @@ import (
 	"github.com/juju/utils/arch"
 
 	"github.com/juju/juju/network"
+	"github.com/juju/juju/status"
 )
 
 // An instance Id is a provider-specific identifier associated with an
 // instance (physical or virtual machine allocated in the provider).
 type Id string
+
+type InstanceStatus struct {
+	Status  status.Status
+	Message string
+}
 
 // UnknownId can be used to explicitly specify the instance ID does not matter.
 const UnknownId Id = ""
@@ -27,7 +33,7 @@ type Instance interface {
 	Id() Id
 
 	// Status returns the provider-specific status for the instance.
-	Status() string
+	Status() InstanceStatus
 
 	// Addresses returns a list of hostnames or ip addresses
 	// associated with the instance.

--- a/provider/azure/instance.go
+++ b/provider/azure/instance.go
@@ -15,6 +15,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/juju/instance"
 	jujunetwork "github.com/juju/juju/network"
+	"github.com/juju/juju/status"
 	"github.com/juju/names"
 )
 
@@ -34,13 +35,17 @@ func (inst *azureInstance) Id() instance.Id {
 }
 
 // Status is specified in the Instance interface.
-func (inst *azureInstance) Status() string {
+func (inst *azureInstance) Status() instance.InstanceStatus {
 	// NOTE(axw) ideally we would use the power state, but that is only
 	// available when using the "instance view". Instance view is only
 	// delivered when explicitly requested, and you can only request it
 	// when querying a single VM. This means the results of AllInstances
 	// or Instances would have the instance view missing.
-	return to.String(inst.Properties.ProvisioningState)
+	return instance.InstanceStatus{
+		Status:  status.StatusUnknown,
+		Message: to.String(inst.Properties.ProvisioningState),
+	}
+
 }
 
 // setInstanceAddresses queries Azure for the NICs and public IPs associated

--- a/provider/azure/instance_test.go
+++ b/provider/azure/instance_test.go
@@ -164,13 +164,13 @@ func networkSecurityGroupSender(rules []network.SecurityRule) *azuretesting.Mock
 
 func (s *instanceSuite) TestInstanceStatus(c *gc.C) {
 	inst := s.getInstance(c)
-	c.Assert(inst.Status(), gc.Equals, "Successful")
+	c.Assert(inst.Status().Message, gc.Equals, "Successful")
 }
 
 func (s *instanceSuite) TestInstanceStatusNilProvisioningState(c *gc.C) {
 	s.virtualMachines[0].Properties.ProvisioningState = nil
 	inst := s.getInstance(c)
-	c.Assert(inst.Status(), gc.Equals, "")
+	c.Assert(inst.Status().Message, gc.Equals, "")
 }
 
 func (s *instanceSuite) TestInstanceStatusNoVM(c *gc.C) {
@@ -179,7 +179,7 @@ func (s *instanceSuite) TestInstanceStatusNoVM(c *gc.C) {
 	// "Partially Deleted" from Instance.Status().
 	s.virtualMachines = nil
 	inst := s.getInstance(c)
-	c.Assert(inst.Status(), gc.Equals, "Partially Deleted")
+	c.Assert(inst.Status().Message, gc.Equals, "Partially Deleted")
 }
 
 func (s *instanceSuite) TestInstanceAddressesEmpty(c *gc.C) {

--- a/provider/cloudsigma/instance.go
+++ b/provider/cloudsigma/instance.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/network"
+	"github.com/juju/juju/status"
 )
 
 var _ instance.Instance = (*sigmaInstance)(nil)
@@ -27,10 +28,14 @@ func (i sigmaInstance) Id() instance.Id {
 }
 
 // Status returns the provider-specific status for the instance.
-func (i sigmaInstance) Status() string {
-	status := i.server.Status()
-	logger.Tracef("sigmaInstance.Status: %s", status)
-	return status
+func (i sigmaInstance) Status() instance.InstanceStatus {
+	entityStatus := i.server.Status()
+	logger.Tracef("sigmaInstance.Status: %s", entityStatus)
+	return instance.InstanceStatus{
+		Status:  status.StatusUnknown,
+		Message: entityStatus,
+	}
+
 }
 
 // Addresses returns a list of hostnames or ip addresses

--- a/provider/cloudsigma/instance_test.go
+++ b/provider/cloudsigma/instance_test.go
@@ -71,7 +71,7 @@ func (s *instanceSuite) TestInstanceId(c *gc.C) {
 }
 
 func (s *instanceSuite) TestInstanceStatus(c *gc.C) {
-	c.Check(s.inst.Status(), gc.Equals, "running")
+	c.Check(s.inst.Status().Message, gc.Equals, "running")
 }
 
 func (s *instanceSuite) TestInstanceAddresses(c *gc.C) {

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -52,6 +52,7 @@ import (
 	"github.com/juju/juju/provider/common"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/multiwatcher"
+	"github.com/juju/juju/status"
 	"github.com/juju/juju/storage"
 	"github.com/juju/juju/testing"
 	coretools "github.com/juju/juju/tools"
@@ -1525,10 +1526,14 @@ func (inst *dummyInstance) Id() instance.Id {
 	return inst.id
 }
 
-func (inst *dummyInstance) Status() string {
+func (inst *dummyInstance) Status() instance.InstanceStatus {
 	inst.mu.Lock()
 	defer inst.mu.Unlock()
-	return inst.status
+	return instance.InstanceStatus{
+		Status:  status.StatusUnknown,
+		Message: inst.status,
+	}
+
 }
 
 // SetInstanceAddresses sets the addresses associated with the given

--- a/provider/ec2/instance.go
+++ b/provider/ec2/instance.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/network"
+	"github.com/juju/juju/status"
 )
 
 type ec2Instance struct {
@@ -29,8 +30,12 @@ func (inst *ec2Instance) Id() instance.Id {
 	return instance.Id(inst.InstanceId)
 }
 
-func (inst *ec2Instance) Status() string {
-	return inst.State.Name
+func (inst *ec2Instance) Status() instance.InstanceStatus {
+	return instance.InstanceStatus{
+		Status:  status.StatusUnknown,
+		Message: inst.State.Name,
+	}
+
 }
 
 // Addresses implements network.Addresses() returning generic address

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -321,7 +321,7 @@ func (t *localServerSuite) TestInstanceStatus(c *gc.C) {
 	t.srv.ec2srv.SetInitialInstanceState(ec2test.Terminated)
 	inst, _ := testing.AssertStartInstance(c, env, "1")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(inst.Status(), gc.Equals, "terminated")
+	c.Assert(inst.Status().Message, gc.Equals, "terminated")
 }
 
 func (t *localServerSuite) TestStartInstanceHardwareCharacteristics(c *gc.C) {

--- a/provider/gce/instance.go
+++ b/provider/gce/instance.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/provider/common"
 	"github.com/juju/juju/provider/gce/google"
+	"github.com/juju/juju/status"
 )
 
 type environInstance struct {
@@ -32,8 +33,12 @@ func (inst *environInstance) Id() instance.Id {
 }
 
 // Status implements instance.Instance.
-func (inst *environInstance) Status() string {
-	return inst.base.Status()
+func (inst *environInstance) Status() instance.InstanceStatus {
+	return instance.InstanceStatus{
+		Status:  status.StatusUnknown,
+		Message: inst.base.Status(),
+	}
+
 }
 
 // Addresses implements instance.Instance.

--- a/provider/gce/instance_test.go
+++ b/provider/gce/instance_test.go
@@ -34,7 +34,7 @@ func (s *instanceSuite) TestID(c *gc.C) {
 }
 
 func (s *instanceSuite) TestStatus(c *gc.C) {
-	status := s.Instance.Status()
+	status := s.Instance.Status().Message
 
 	c.Check(status, gc.Equals, google.StatusRunning)
 	s.CheckNoAPI(c)

--- a/provider/joyent/instance.go
+++ b/provider/joyent/instance.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/network"
+	"github.com/juju/juju/status"
 )
 
 type joyentInstance struct {
@@ -21,8 +22,12 @@ func (inst *joyentInstance) Id() instance.Id {
 	return instance.Id(inst.machine.Id)
 }
 
-func (inst *joyentInstance) Status() string {
-	return inst.machine.State
+func (inst *joyentInstance) Status() instance.InstanceStatus {
+	return instance.InstanceStatus{
+		Status:  status.StatusUnknown,
+		Message: inst.machine.State,
+	}
+
 }
 
 func (inst *joyentInstance) Addresses() ([]network.Address, error) {

--- a/provider/joyent/local_test.go
+++ b/provider/joyent/local_test.go
@@ -268,7 +268,7 @@ var instanceGathering = []struct {
 func (s *localServerSuite) TestInstanceStatus(c *gc.C) {
 	env := s.Prepare(c)
 	inst, _ := testing.AssertStartInstance(c, env, "100")
-	c.Assert(inst.Status(), gc.Equals, "running")
+	c.Assert(inst.Status().Message, gc.Equals, "running")
 	err := env.StopInstances(inst.Id())
 	c.Assert(err, jc.ErrorIsNil)
 }

--- a/provider/lxd/instance.go
+++ b/provider/lxd/instance.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/provider/common"
 	"github.com/juju/juju/provider/lxd/lxdclient"
+	"github.com/juju/juju/status"
 )
 
 type environInstance struct {
@@ -34,8 +35,12 @@ func (inst *environInstance) Id() instance.Id {
 }
 
 // Status implements instance.Instance.
-func (inst *environInstance) Status() string {
-	return inst.raw.Status()
+func (inst *environInstance) Status() instance.InstanceStatus {
+	return instance.InstanceStatus{
+		Status:  status.StatusUnknown,
+		Message: inst.raw.Status(),
+	}
+
 }
 
 // Addresses implements instance.Instance.

--- a/provider/lxd/instance_test.go
+++ b/provider/lxd/instance_test.go
@@ -37,9 +37,9 @@ func (s *instanceSuite) TestID(c *gc.C) {
 }
 
 func (s *instanceSuite) TestStatus(c *gc.C) {
-	status := s.Instance.Status()
+	instanceStatus := s.Instance.Status()
 
-	c.Check(status, gc.Equals, lxdclient.StatusRunning)
+	c.Check(instanceStatus.Message, gc.Equals, lxdclient.StatusRunning)
 	s.CheckNoAPI(c)
 }
 

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -804,7 +804,10 @@ func (environ *maasEnviron) StartInstance(args environs.StartInstanceParams) (
 		return nil, errors.Errorf("cannot run instances: %v", err)
 	}
 
-	inst := &maasInstance{selectedNode}
+	inst := &maasInstance{
+		maasObject:   selectedNode,
+		statusGetter: environ.deploymentStatusOne,
+	}
 	defer func() {
 		if err != nil {
 			if err := environ.StopInstances(inst.Id()); err != nil {
@@ -940,6 +943,48 @@ func (environ *maasEnviron) waitForNodeDeployment(id instance.Id) error {
 		}
 	}
 	return errors.Errorf("instance %q is started but not deployed", id)
+}
+
+func (environ *maasEnviron) deploymentStatusOne(id instance.Id) (string, string) {
+	results, err := environ.deploymentStatus(id)
+	if err != nil {
+		return "", ""
+	}
+	systemId := extractSystemId(id)
+	substatus := environ.getDeploymentSubstatus(systemId)
+	return results[systemId], substatus
+}
+
+func (environ *maasEnviron) getDeploymentSubstatus(systemId string) string {
+	nodesAPI := environ.getMAASClient().GetSubObject("nodes")
+	result, err := nodesAPI.CallGet("list", nil)
+	if err != nil {
+		return ""
+	}
+	slices, err := result.GetArray()
+	if err != nil {
+		return ""
+	}
+	for _, slice := range slices {
+		resultMap, err := slice.GetMap()
+		if err != nil {
+			continue
+		}
+		sysId, err := resultMap["system_id"].GetString()
+		if err != nil {
+			continue
+		}
+		if sysId == systemId {
+			message, err := resultMap["substatus_message"].GetString()
+			if err != nil {
+				logger.Warningf("COULD NOT GET STRING for substatus_message: %v", resultMap["substatus_message"])
+				return ""
+			}
+			return message
+		}
+	}
+
+	return ""
 }
 
 // deploymentStatus returns the deployment state of MAAS instances with
@@ -1160,7 +1205,10 @@ func (environ *maasEnviron) instances(filter url.Values) ([]instance.Instance, e
 		if err != nil {
 			return nil, err
 		}
-		instances[index] = &maasInstance{&node}
+		instances[index] = &maasInstance{
+			maasObject:   &node,
+			statusGetter: environ.deploymentStatusOne,
+		}
 	}
 	return instances, nil
 }

--- a/provider/maas/environ_whitebox_test.go
+++ b/provider/maas/environ_whitebox_test.go
@@ -265,7 +265,11 @@ var testNetworkValues = []struct {
 func (suite *environSuite) getInstance(systemId string) *maasInstance {
 	input := fmt.Sprintf(`{"system_id": %q}`, systemId)
 	node := suite.testMAASObject.TestServer.NewNode(input)
-	return &maasInstance{&node}
+	statusGetter := func(instance.Id) (string, string) {
+		return "unknown", "FAKE"
+	}
+
+	return &maasInstance{&node, statusGetter}
 }
 
 func (suite *environSuite) newNetwork(name string, id int, vlanTag int, defaultGateway string) *gomaasapi.MAASObject {

--- a/provider/maas/instance.go
+++ b/provider/maas/instance.go
@@ -12,10 +12,12 @@ import (
 
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/network"
+	"github.com/juju/juju/status"
 )
 
 type maasInstance struct {
-	maasObject *gomaasapi.MAASObject
+	maasObject   *gomaasapi.MAASObject
+	statusGetter func(instance.Id) (string, string)
 }
 
 var _ instance.Instance = (*maasInstance)(nil)
@@ -43,13 +45,33 @@ func maasObjectId(maasObject *gomaasapi.MAASObject) instance.Id {
 	return instance.Id(maasObject.URI().String())
 }
 
-func (mi *maasInstance) Status() string {
-	// MAAS does not track node status once they're allocated.
-	// Since any instance that juju knows about will be an
-	// allocated one, it doesn't make sense to report any
-	// state unless we obtain it through some means other than
-	// through the MAAS API.
-	return ""
+// Status returns a juju status based on the maas instance returned
+// status message.
+func (mi *maasInstance) Status() instance.InstanceStatus {
+	maasInstanceStatus := status.StatusUnknown
+	statusMsg, substatus := mi.statusGetter(mi.Id())
+	switch statusMsg {
+	case "":
+		logger.Debugf("unable to obtain status of instance %s", mi.Id())
+		statusMsg = "error in getting status"
+	case "Deployed":
+		maasInstanceStatus = status.StatusRunning
+	case "Deploying":
+		maasInstanceStatus = status.StatusProvisioning
+		if substatus != "" {
+			statusMsg = fmt.Sprintf("%s: %s", statusMsg, substatus)
+		}
+	case "Failed Deployment":
+		maasInstanceStatus = status.StatusProvisioningError
+		if substatus != "" {
+			statusMsg = fmt.Sprintf("%s: %s", statusMsg, substatus)
+		}
+	}
+
+	return instance.InstanceStatus{
+		Status:  maasInstanceStatus,
+		Message: statusMsg,
+	}
 }
 
 func (mi *maasInstance) Addresses() ([]network.Address, error) {

--- a/provider/maas/instance_test.go
+++ b/provider/maas/instance_test.go
@@ -10,6 +10,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/instance"
 	"github.com/juju/juju/network"
 )
 
@@ -23,7 +24,11 @@ func (s *instanceTest) TestId(c *gc.C) {
 	jsonValue := `{"system_id": "system_id", "test": "test"}`
 	obj := s.testMAASObject.TestServer.NewNode(jsonValue)
 	resourceURI, _ := obj.GetField("resource_uri")
-	instance := maasInstance{&obj}
+	// TODO(perrito666) make a decent mock status getter
+	statusGetter := func(instance.Id) (string, string) {
+		return "unknown", "FAKE"
+	}
+	instance := maasInstance{&obj, statusGetter}
 
 	c.Check(string(instance.Id()), gc.Equals, resourceURI)
 }
@@ -31,7 +36,11 @@ func (s *instanceTest) TestId(c *gc.C) {
 func (s *instanceTest) TestString(c *gc.C) {
 	jsonValue := `{"hostname": "thethingintheplace", "system_id": "system_id", "test": "test"}`
 	obj := s.testMAASObject.TestServer.NewNode(jsonValue)
-	instance := &maasInstance{&obj}
+	statusGetter := func(instance.Id) (string, string) {
+		return "unknown", "FAKE"
+	}
+
+	instance := &maasInstance{&obj, statusGetter}
 	hostname, err := instance.hostname()
 	c.Assert(err, jc.ErrorIsNil)
 	expected := hostname + ":" + string(instance.Id())
@@ -42,7 +51,11 @@ func (s *instanceTest) TestStringWithoutHostname(c *gc.C) {
 	// For good measure, test what happens if we don't have a hostname.
 	jsonValue := `{"system_id": "system_id", "test": "test"}`
 	obj := s.testMAASObject.TestServer.NewNode(jsonValue)
-	instance := &maasInstance{&obj}
+	statusGetter := func(instance.Id) (string, string) {
+		return "unknown", "FAKE"
+	}
+
+	instance := &maasInstance{&obj, statusGetter}
 	_, err := instance.hostname()
 	c.Assert(err, gc.NotNil)
 	expected := fmt.Sprintf("<DNSName failed: %q>", err) + ":" + string(instance.Id())
@@ -59,7 +72,11 @@ func (s *instanceTest) TestAddressesLegacy(c *gc.C) {
 			"ip_addresses": [ "1.2.3.4", "fe80::d806:dbff:fe23:1199" ]
 		}`
 	obj := s.testMAASObject.TestServer.NewNode(jsonValue)
-	inst := maasInstance{&obj}
+	statusGetter := func(instance.Id) (string, string) {
+		return "unknown", "FAKE"
+	}
+
+	inst := maasInstance{&obj, statusGetter}
 
 	expected := []network.Address{
 		network.NewScopedAddress("testing.invalid", network.ScopePublic),
@@ -100,7 +117,11 @@ func (s *instanceTest) TestAddressesViaInterfaces(c *gc.C) {
 			"ip_addresses": [ "anything", "foo", "0.1.2.3" ]
 		}`
 	obj := s.testMAASObject.TestServer.NewNode(jsonValue)
-	inst := maasInstance{&obj}
+	statusGetter := func(instance.Id) (string, string) {
+		return "unknown", "FAKE"
+	}
+
+	inst := maasInstance{&obj, statusGetter}
 	// Since gomaasapi treats "interface_set" specially and the only way to
 	// change it is via SetNodeNetworkLink(), which in turn does not allow you
 	// to specify ip_address, we need to patch the call which gets a fresh copy
@@ -130,7 +151,11 @@ func (s *instanceTest) TestAddressesMissing(c *gc.C) {
 		"system_id": "system_id"
 		}`
 	obj := s.testMAASObject.TestServer.NewNode(jsonValue)
-	inst := maasInstance{&obj}
+	statusGetter := func(instance.Id) (string, string) {
+		return "unknown", "FAKE"
+	}
+
+	inst := maasInstance{&obj, statusGetter}
 
 	addr, err := inst.Addresses()
 	c.Assert(err, jc.ErrorIsNil)
@@ -147,7 +172,11 @@ func (s *instanceTest) TestAddressesInvalid(c *gc.C) {
 		"ip_addresses": "incompatible"
 		}`
 	obj := s.testMAASObject.TestServer.NewNode(jsonValue)
-	inst := maasInstance{&obj}
+	statusGetter := func(instance.Id) (string, string) {
+		return "unknown", "FAKE"
+	}
+
+	inst := maasInstance{&obj, statusGetter}
 
 	_, err := inst.Addresses()
 	c.Assert(err, gc.NotNil)
@@ -160,7 +189,11 @@ func (s *instanceTest) TestAddressesInvalidContents(c *gc.C) {
 		"ip_addresses": [42]
 		}`
 	obj := s.testMAASObject.TestServer.NewNode(jsonValue)
-	inst := maasInstance{&obj}
+	statusGetter := func(instance.Id) (string, string) {
+		return "unknown", "FAKE"
+	}
+
+	inst := maasInstance{&obj, statusGetter}
 
 	_, err := inst.Addresses()
 	c.Assert(err, gc.NotNil)
@@ -174,7 +207,11 @@ func (s *instanceTest) TestHardwareCharacteristics(c *gc.C) {
         "memory": 16384
 	}`
 	obj := s.testMAASObject.TestServer.NewNode(jsonValue)
-	inst := maasInstance{&obj}
+	statusGetter := func(instance.Id) (string, string) {
+		return "unknown", "FAKE"
+	}
+
+	inst := maasInstance{&obj, statusGetter}
 	hc, err := inst.hardwareCharacteristics()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(hc, gc.NotNil)
@@ -190,7 +227,11 @@ func (s *instanceTest) TestHardwareCharacteristicsWithTags(c *gc.C) {
         "tag_names": ["a", "b"]
 	}`
 	obj := s.testMAASObject.TestServer.NewNode(jsonValue)
-	inst := maasInstance{&obj}
+	statusGetter := func(instance.Id) (string, string) {
+		return "unknown", "FAKE"
+	}
+
+	inst := maasInstance{&obj, statusGetter}
 	hc, err := inst.hardwareCharacteristics()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(hc, gc.NotNil)
@@ -210,7 +251,11 @@ func (s *instanceTest) TestHardwareCharacteristicsMissing(c *gc.C) {
 
 func (s *instanceTest) testHardwareCharacteristicsMissing(c *gc.C, json, expect string) {
 	obj := s.testMAASObject.TestServer.NewNode(json)
-	inst := maasInstance{&obj}
+	statusGetter := func(instance.Id) (string, string) {
+		return "unknown", "FAKE"
+	}
+
+	inst := maasInstance{&obj, statusGetter}
 	_, err := inst.hardwareCharacteristics()
 	c.Assert(err, gc.ErrorMatches, expect)
 }

--- a/provider/maas/maas_test.go
+++ b/provider/maas/maas_test.go
@@ -117,7 +117,10 @@ func (suite *providerSuite) addNode(jsonText string) instance.Id {
 func (suite *providerSuite) getInstance(systemId string) *maasInstance {
 	input := fmt.Sprintf(`{"system_id": %q}`, systemId)
 	node := suite.testMAASObject.TestServer.NewNode(input)
-	return &maasInstance{&node}
+	statusGetter := func(instance.Id) (string, string) {
+		return "unknown", "FAKE"
+	}
+	return &maasInstance{&node, statusGetter}
 }
 
 func (suite *providerSuite) getNetwork(name string, id int, vlanTag int) *gomaasapi.MAASObject {

--- a/provider/maas/volumes_test.go
+++ b/provider/maas/volumes_test.go
@@ -9,6 +9,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/constraints"
+	"github.com/juju/juju/instance"
 	"github.com/juju/juju/storage"
 	"github.com/juju/juju/testing"
 )
@@ -74,7 +75,11 @@ func (s *volumeSuite) TestBuildMAASVolumeParametersWithTags(c *gc.C) {
 
 func (s *volumeSuite) TestInstanceVolumes(c *gc.C) {
 	obj := s.testMAASObject.TestServer.NewNode(validVolumeJson)
-	instance := maasInstance{&obj}
+	statusGetter := func(instance.Id) (string, string) {
+		return "unknown", "FAKE"
+	}
+
+	instance := maasInstance{&obj, statusGetter}
 	mTag := names.NewMachineTag("1")
 	volumes, attachments, err := instance.volumes(mTag, []names.VolumeTag{
 		names.NewVolumeTag("1"),
@@ -128,7 +133,11 @@ func (s *volumeSuite) TestInstanceVolumes(c *gc.C) {
 
 func (s *volumeSuite) TestInstanceVolumesOldMass(c *gc.C) {
 	obj := s.testMAASObject.TestServer.NewNode(`{"system_id": "node0"}`)
-	instance := maasInstance{&obj}
+	statusGetter := func(instance.Id) (string, string) {
+		return "unknown", "FAKE"
+	}
+
+	instance := maasInstance{&obj, statusGetter}
 	volumes, attachments, err := instance.volumes(names.NewMachineTag("1"), []names.VolumeTag{
 		names.NewVolumeTag("1"),
 		names.NewVolumeTag("2"),

--- a/provider/manual/instance.go
+++ b/provider/manual/instance.go
@@ -7,6 +7,7 @@ import (
 	"github.com/juju/juju/environs/manual"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/network"
+	"github.com/juju/juju/status"
 )
 
 type manualBootstrapInstance struct {
@@ -17,8 +18,11 @@ func (manualBootstrapInstance) Id() instance.Id {
 	return BootstrapInstanceId
 }
 
-func (manualBootstrapInstance) Status() string {
-	return ""
+func (manualBootstrapInstance) Status() instance.InstanceStatus {
+	return instance.InstanceStatus{
+		Status:  status.StatusUnknown,
+		Message: "",
+	}
 }
 
 func (manualBootstrapInstance) Refresh() error {

--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -606,7 +606,7 @@ func (s *localServerSuite) TestInstanceStatus(c *gc.C) {
 	env := s.Prepare(c)
 	// goose's test service always returns ACTIVE state.
 	inst, _ := testing.AssertStartInstance(c, env, "100")
-	c.Assert(inst.Status(), gc.Equals, nova.StatusActive)
+	c.Assert(inst.Status().Message, gc.Equals, nova.StatusActive)
 	err := env.StopInstances(inst.Id())
 	c.Assert(err, jc.ErrorIsNil)
 }
@@ -717,7 +717,7 @@ func (s *localServerSuite) TestInstancesBuildSpawning(c *gc.C) {
 
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(instances, gc.HasLen, 1)
-	c.Assert(instances[0].Status(), gc.Equals, nova.StatusBuildSpawning)
+	c.Assert(instances[0].Status().Message, gc.Equals, nova.StatusBuildSpawning)
 }
 
 func (s *localServerSuite) TestInstancesShutoffSuspended(c *gc.C) {
@@ -751,8 +751,8 @@ func (s *localServerSuite) TestInstancesShutoffSuspended(c *gc.C) {
 
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(instances, gc.HasLen, 2)
-	c.Assert(instances[0].Status(), gc.Equals, nova.StatusShutoff)
-	c.Assert(instances[1].Status(), gc.Equals, nova.StatusSuspended)
+	c.Assert(instances[0].Status().Message, gc.Equals, nova.StatusShutoff)
+	c.Assert(instances[1].Status().Message, gc.Equals, nova.StatusSuspended)
 }
 
 func (s *localServerSuite) TestInstancesErrorResponse(c *gc.C) {

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -36,6 +36,7 @@ import (
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/provider/common"
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/status"
 	"github.com/juju/juju/tools"
 )
 
@@ -410,8 +411,11 @@ func (inst *openstackInstance) Id() instance.Id {
 	return instance.Id(inst.getServerDetail().Id)
 }
 
-func (inst *openstackInstance) Status() string {
-	return inst.getServerDetail().Status
+func (inst *openstackInstance) Status() instance.InstanceStatus {
+	return instance.InstanceStatus{
+		Status:  status.StatusUnknown,
+		Message: inst.getServerDetail().Status,
+	}
 }
 
 func (inst *openstackInstance) hardwareCharacteristics() *instance.HardwareCharacteristics {

--- a/provider/rackspace/environ_test.go
+++ b/provider/rackspace/environ_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/provider/common"
 	"github.com/juju/juju/provider/rackspace"
+	"github.com/juju/juju/status"
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/tools"
 	"github.com/juju/juju/version"
@@ -258,9 +259,12 @@ func (e *fakeInstance) Id() instance.Id {
 	return instance.Id("")
 }
 
-func (e *fakeInstance) Status() string {
+func (e *fakeInstance) Status() instance.InstanceStatus {
 	e.Push("Status")
-	return ""
+	return instance.InstanceStatus{
+		Status:  status.StatusUnknown,
+		Message: "A MESSAGE",
+	}
 }
 
 func (e *fakeInstance) Refresh() error {

--- a/provider/vsphere/instance.go
+++ b/provider/vsphere/instance.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/provider/common"
+	"github.com/juju/juju/status"
 )
 
 type environInstance struct {
@@ -34,9 +35,12 @@ func (inst *environInstance) Id() instance.Id {
 }
 
 // Status implements instance.Instance.
-func (inst *environInstance) Status() string {
+func (inst *environInstance) Status() instance.InstanceStatus {
 	//return inst.base.Status()
-	return ""
+	return instance.InstanceStatus{
+		Status:  status.StatusUnknown,
+		Message: "",
+	}
 }
 
 // Addresses implements instance.Instance.

--- a/state/allwatcher.go
+++ b/state/allwatcher.go
@@ -15,6 +15,7 @@ import (
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state/multiwatcher"
 	"github.com/juju/juju/state/watcher"
+	"github.com/juju/juju/status"
 )
 
 // allWatcherStateBacking implements Backing by fetching entities for
@@ -145,25 +146,34 @@ func (m *backingMachine) updated(st *State, store *multiwatcherStore, id string)
 		SupportedContainersKnown: m.SupportedContainersKnown,
 		HasVote:                  m.HasVote,
 		WantsVote:                wantsVote(m.Jobs, m.NoVote),
-		StatusData:               make(map[string]interface{}),
 	}
 
 	oldInfo := store.Get(info.EntityId())
 	if oldInfo == nil {
 		// We're adding the entry for the first time,
 		// so fetch the associated machine status.
-		statusInfo, err := getStatus(st, machineGlobalKey(m.Id), "machine")
+		entity, err := st.FindEntity(names.NewMachineTag(m.Id))
 		if err != nil {
-			return err
+			return errors.Annotatef(err, "retrieving machine %q", m.Id)
 		}
-		info.Status = multiwatcher.Status(statusInfo.Status)
-		info.StatusInfo = statusInfo.Message
+		machine := entity.(*Machine)
+		jujuStatus, err := machine.Status()
+		if err != nil {
+			return errors.Annotatef(err, "retrieving juju status for machine %q", m.Id)
+		}
+		info.JujuStatus = multiwatcher.NewStatusInfo(jujuStatus, err)
+
+		machineStatus, err := machine.InstanceStatus()
+		if err != nil {
+			return errors.Annotatef(err, "retrieving instance status for machine %q", m.Id)
+		}
+		info.MachineStatus = multiwatcher.NewStatusInfo(machineStatus, err)
 	} else {
 		// The entry already exists, so preserve the current status and
 		// instance data.
 		oldInfo := oldInfo.(*multiwatcher.MachineInfo)
-		info.Status = oldInfo.Status
-		info.StatusInfo = oldInfo.StatusInfo
+		info.JujuStatus = oldInfo.JujuStatus
+		info.MachineStatus = oldInfo.MachineStatus
 		info.InstanceId = oldInfo.InstanceId
 		info.HardwareCharacteristics = oldInfo.HardwareCharacteristics
 	}
@@ -236,7 +246,7 @@ func getUnitPortRangesAndPorts(st *State, unitName string) ([]network.PortRange,
 	return portRanges, compatiblePorts, nil
 }
 
-func unitAndAgentStatus(st *State, name string) (unitStatus, agentStatus *StatusInfo, err error) {
+func unitAndAgentStatus(st *State, name string) (unitStatus, agentStatus *status.StatusInfo, err error) {
 	unit, err := st.Unit(name)
 	if err != nil {
 		return nil, nil, errors.Trace(err)
@@ -260,7 +270,6 @@ func (u *backingUnit) updated(st *State, store *multiwatcherStore, id string) er
 		Series:      u.Series,
 		MachineId:   u.MachineId,
 		Subordinate: u.Principal != "",
-		StatusData:  make(map[string]interface{}),
 	}
 	if u.CharmURL != nil {
 		info.CharmURL = u.CharmURL.String()
@@ -276,7 +285,7 @@ func (u *backingUnit) updated(st *State, store *multiwatcherStore, id string) er
 		}
 		// Unit and workload status.
 		info.WorkloadStatus = multiwatcher.StatusInfo{
-			Current: multiwatcher.Status(unitStatus.Status),
+			Current: status.Status(unitStatus.Status),
 			Message: unitStatus.Message,
 			Data:    normaliseStatusData(unitStatus.Data),
 			Since:   unitStatus.Since,
@@ -285,26 +294,10 @@ func (u *backingUnit) updated(st *State, store *multiwatcherStore, id string) er
 			info.AgentStatus.Version = u.Tools.Version.Number.String()
 		}
 		info.AgentStatus = multiwatcher.StatusInfo{
-			Current: multiwatcher.Status(agentStatus.Status),
+			Current: status.Status(agentStatus.Status),
 			Message: agentStatus.Message,
 			Data:    normaliseStatusData(agentStatus.Data),
 			Since:   agentStatus.Since,
-		}
-		// Legacy status info.
-		if unitStatus.Status == StatusError {
-			info.Status = multiwatcher.Status(unitStatus.Status)
-			info.StatusInfo = unitStatus.Message
-			info.StatusData = normaliseStatusData(unitStatus.Data)
-		} else {
-			legacyStatus, ok := TranslateToLegacyAgentState(agentStatus.Status, unitStatus.Status, unitStatus.Message)
-			if !ok {
-				logger.Warningf(
-					"translate to legacy status encounted unexpected workload status %q and agent status %q",
-					unitStatus.Status, agentStatus.Status)
-			}
-			info.Status = multiwatcher.Status(legacyStatus)
-			info.StatusInfo = agentStatus.Message
-			info.StatusData = normaliseStatusData(agentStatus.Data)
 		}
 
 		portRanges, compatiblePorts, err := getUnitPortRangesAndPorts(st, u.Name)
@@ -317,9 +310,6 @@ func (u *backingUnit) updated(st *State, store *multiwatcherStore, id string) er
 	} else {
 		// The entry already exists, so preserve the current status and ports.
 		oldInfo := oldInfo.(*multiwatcher.UnitInfo)
-		// Legacy status.
-		info.Status = oldInfo.Status
-		info.StatusInfo = oldInfo.StatusInfo
 		// Unit and workload status.
 		info.AgentStatus = oldInfo.AgentStatus
 		info.WorkloadStatus = oldInfo.WorkloadStatus
@@ -418,7 +408,7 @@ func (svc *backingService) updated(st *State, store *multiwatcherStore, id strin
 		}
 		if err == nil {
 			info.Status = multiwatcher.StatusInfo{
-				Current: multiwatcher.Status(serviceStatus.Status),
+				Current: serviceStatus.Status,
 				Message: serviceStatus.Message,
 				Data:    normaliseStatusData(serviceStatus.Data),
 				Since:   serviceStatus.Since,
@@ -431,7 +421,7 @@ func (svc *backingService) updated(st *State, store *multiwatcherStore, id strin
 			// the above and return Unknown.
 			now := time.Now()
 			info.Status = multiwatcher.StatusInfo{
-				Current: multiwatcher.Status(StatusUnknown),
+				Current: status.StatusUnknown,
 				Since:   &now,
 				Data:    normaliseStatusData(nil),
 			}
@@ -631,16 +621,26 @@ func (s *backingStatus) updated(st *State, store *multiwatcherStore, id string) 
 		info0 = &newInfo
 	case *multiwatcher.ServiceInfo:
 		newInfo := *info
-		newInfo.Status.Current = multiwatcher.Status(s.Status)
+		newInfo.Status.Current = s.Status
 		newInfo.Status.Message = s.StatusInfo
 		newInfo.Status.Data = normaliseStatusData(s.StatusData)
 		newInfo.Status.Since = unixNanoToTime(s.Updated)
 		info0 = &newInfo
 	case *multiwatcher.MachineInfo:
 		newInfo := *info
-		newInfo.Status = multiwatcher.Status(s.Status)
-		newInfo.StatusInfo = s.StatusInfo
-		newInfo.StatusData = normaliseStatusData(s.StatusData)
+		// lets dissambiguate between juju machine agent and provider instance statuses.
+		if strings.HasSuffix(id, "#instance") {
+			newInfo.MachineStatus.Current = s.Status
+			newInfo.MachineStatus.Message = s.StatusInfo
+			newInfo.MachineStatus.Data = normaliseStatusData(s.StatusData)
+			newInfo.MachineStatus.Since = unixNanoToTime(s.Updated)
+
+		} else {
+			newInfo.JujuStatus.Current = s.Status
+			newInfo.JujuStatus.Message = s.StatusInfo
+			newInfo.JujuStatus.Data = normaliseStatusData(s.StatusData)
+			newInfo.JujuStatus.Since = unixNanoToTime(s.Updated)
+		}
 		info0 = &newInfo
 	default:
 		return errors.Errorf("status for unexpected entity with id %q; type %T", id, info)
@@ -649,46 +649,26 @@ func (s *backingStatus) updated(st *State, store *multiwatcherStore, id string) 
 	return nil
 }
 
-func (s *backingStatus) updatedUnitStatus(st *State, store *multiwatcherStore, id string, unitStatus StatusInfo, newInfo *multiwatcher.UnitInfo) error {
+func (s *backingStatus) updatedUnitStatus(st *State, store *multiwatcherStore, id string, unitStatus status.StatusInfo, newInfo *multiwatcher.UnitInfo) error {
 	// Unit or workload status - display the agent status or any error.
-	if strings.HasSuffix(id, "#charm") || s.Status == StatusError {
-		newInfo.WorkloadStatus.Current = multiwatcher.Status(s.Status)
+	if strings.HasSuffix(id, "#charm") || s.Status == status.StatusError {
+		newInfo.WorkloadStatus.Current = s.Status
 		newInfo.WorkloadStatus.Message = s.StatusInfo
 		newInfo.WorkloadStatus.Data = normaliseStatusData(s.StatusData)
 		newInfo.WorkloadStatus.Since = unixNanoToTime(s.Updated)
 	} else {
-		newInfo.AgentStatus.Current = multiwatcher.Status(s.Status)
+		newInfo.AgentStatus.Current = s.Status
 		newInfo.AgentStatus.Message = s.StatusInfo
 		newInfo.AgentStatus.Data = normaliseStatusData(s.StatusData)
 		newInfo.AgentStatus.Since = unixNanoToTime(s.Updated)
 		// If the unit was in error and now it's not, we need to reset its
 		// status back to what was previously recorded.
-		if newInfo.WorkloadStatus.Current == multiwatcher.Status(StatusError) {
-			newInfo.WorkloadStatus.Current = multiwatcher.Status(unitStatus.Status)
+		if newInfo.WorkloadStatus.Current == status.StatusError {
+			newInfo.WorkloadStatus.Current = unitStatus.Status
 			newInfo.WorkloadStatus.Message = unitStatus.Message
 			newInfo.WorkloadStatus.Data = normaliseStatusData(unitStatus.Data)
 			newInfo.WorkloadStatus.Since = unixNanoToTime(s.Updated)
 		}
-	}
-
-	// Legacy status info - it is an aggregated value between workload and agent statuses.
-	legacyStatus, ok := TranslateToLegacyAgentState(
-		Status(newInfo.AgentStatus.Current),
-		Status(newInfo.WorkloadStatus.Current),
-		newInfo.WorkloadStatus.Message,
-	)
-	if !ok {
-		logger.Warningf(
-			"translate to legacy status encounted unexpected workload status %q and agent status %q",
-			newInfo.WorkloadStatus.Current, newInfo.AgentStatus.Current)
-	}
-	newInfo.Status = multiwatcher.Status(legacyStatus)
-	if newInfo.Status == multiwatcher.Status(StatusError) {
-		newInfo.StatusInfo = newInfo.WorkloadStatus.Message
-		newInfo.StatusData = normaliseStatusData(newInfo.WorkloadStatus.Data)
-	} else {
-		newInfo.StatusInfo = newInfo.AgentStatus.Message
-		newInfo.StatusData = normaliseStatusData(newInfo.AgentStatus.Data)
 	}
 
 	// A change in a unit's status might also affect it's service.
@@ -709,7 +689,7 @@ func (s *backingStatus) updatedUnitStatus(st *State, store *multiwatcherStore, i
 		return errors.Trace(err)
 	}
 	newServiceInfo := *serviceInfo.(*multiwatcher.ServiceInfo)
-	newServiceInfo.Status.Current = multiwatcher.Status(status.Status)
+	newServiceInfo.Status.Current = status.Status
 	newServiceInfo.Status.Message = status.Message
 	newServiceInfo.Status.Data = normaliseStatusData(status.Data)
 	newServiceInfo.Status.Since = status.Since

--- a/state/filesystem.go
+++ b/state/filesystem.go
@@ -18,6 +18,7 @@ import (
 	"gopkg.in/mgo.v2/txn"
 
 	"github.com/juju/juju/juju/paths"
+	"github.com/juju/juju/status"
 	"github.com/juju/juju/storage"
 )
 
@@ -31,8 +32,8 @@ var ErrNoBackingVolume = errors.New("filesystem has no backing volume")
 type Filesystem interface {
 	GlobalEntity
 	LifeBinder
-	StatusGetter
-	StatusSetter
+	status.StatusGetter
+	status.StatusSetter
 
 	// FilesystemTag returns the tag for the filesystem.
 	FilesystemTag() names.FilesystemTag
@@ -269,13 +270,13 @@ func (f *filesystem) Params() (FilesystemParams, bool) {
 }
 
 // Status is required to implement StatusGetter.
-func (f *filesystem) Status() (StatusInfo, error) {
+func (f *filesystem) Status() (status.StatusInfo, error) {
 	return f.st.FilesystemStatus(f.FilesystemTag())
 }
 
 // SetStatus is required to implement StatusSetter.
-func (f *filesystem) SetStatus(status Status, info string, data map[string]interface{}) error {
-	return f.st.SetFilesystemStatus(f.FilesystemTag(), status, info, data)
+func (f *filesystem) SetStatus(fsStatus status.Status, info string, data map[string]interface{}) error {
+	return f.st.SetFilesystemStatus(f.FilesystemTag(), fsStatus, info, data)
 }
 
 // Filesystem is required to implement FilesystemAttachment.
@@ -754,7 +755,7 @@ func (st *State) addFilesystemOps(params FilesystemParams, machineId string) ([]
 
 	filesystemOps := []txn.Op{
 		createStatusOp(st, filesystemGlobalKey(filesystemId), statusDoc{
-			Status:  StatusPending,
+			Status:  status.StatusPending,
 			Updated: time.Now().UnixNano(),
 		}),
 		{
@@ -1133,19 +1134,19 @@ func filesystemGlobalKey(name string) string {
 }
 
 // FilesystemStatus returns the status of the specified filesystem.
-func (st *State) FilesystemStatus(tag names.FilesystemTag) (StatusInfo, error) {
+func (st *State) FilesystemStatus(tag names.FilesystemTag) (status.StatusInfo, error) {
 	return getStatus(st, filesystemGlobalKey(tag.Id()), "filesystem")
 }
 
 // SetFilesystemStatus sets the status of the specified filesystem.
-func (st *State) SetFilesystemStatus(tag names.FilesystemTag, status Status, info string, data map[string]interface{}) error {
-	switch status {
-	case StatusAttaching, StatusAttached, StatusDetaching, StatusDetached, StatusDestroying:
-	case StatusError:
+func (st *State) SetFilesystemStatus(tag names.FilesystemTag, fsStatus status.Status, info string, data map[string]interface{}) error {
+	switch fsStatus {
+	case status.StatusAttaching, status.StatusAttached, status.StatusDetaching, status.StatusDetached, status.StatusDestroying:
+	case status.StatusError:
 		if info == "" {
-			return errors.Errorf("cannot set status %q without info", status)
+			return errors.Errorf("cannot set status %q without info", fsStatus)
 		}
-	case StatusPending:
+	case status.StatusPending:
 		// If a filesystem is not yet provisioned, we allow its status
 		// to be set back to pending (when a retry is to occur).
 		v, err := st.Filesystem(tag)
@@ -1156,14 +1157,14 @@ func (st *State) SetFilesystemStatus(tag names.FilesystemTag, status Status, inf
 		if errors.IsNotProvisioned(err) {
 			break
 		}
-		return errors.Errorf("cannot set status %q", status)
+		return errors.Errorf("cannot set status %q", fsStatus)
 	default:
-		return errors.Errorf("cannot set invalid status %q", status)
+		return errors.Errorf("cannot set invalid status %q", fsStatus)
 	}
 	return setStatus(st, setStatusParams{
 		badge:     "filesystem",
 		globalKey: filesystemGlobalKey(tag.Id()),
-		status:    status,
+		status:    fsStatus,
 		message:   info,
 		rawData:   data,
 	})

--- a/state/interface.go
+++ b/state/interface.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/instance"
+	"github.com/juju/juju/status"
 	"github.com/juju/juju/tools"
 	"github.com/juju/juju/version"
 )
@@ -88,7 +89,7 @@ type AgentEntity interface {
 	Lifer
 	Authenticator
 	AgentTooler
-	StatusSetter
+	status.StatusSetter
 	EnsureDeader
 	Remover
 	NotifyWatcherFactory

--- a/state/machine.go
+++ b/state/machine.go
@@ -24,6 +24,7 @@ import (
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state/multiwatcher"
 	"github.com/juju/juju/state/presence"
+	"github.com/juju/juju/status"
 	"github.com/juju/juju/tools"
 	"github.com/juju/juju/version"
 )
@@ -33,6 +34,8 @@ type Machine struct {
 	st  *State
 	doc machineDoc
 	presence.Presencer
+	status.StatusHistoryGetter
+	status.InstanceStatusHistoryGetter
 }
 
 // MachineJob values define responsibilities that machines may be
@@ -177,6 +180,16 @@ func (m *Machine) ContainerType() instance.ContainerType {
 // machineGlobalKey returns the global database key for the identified machine.
 func machineGlobalKey(id string) string {
 	return "m#" + id
+}
+
+// machineGlobalKey returns the global database key for the identified machine.
+func machineGlobalInstanceKey(id string) string {
+	return machineGlobalKey(id) + "#instance"
+}
+
+// globalKey returns the global database key for the machine.
+func (m *Machine) globalInstanceKey() string {
+	return machineGlobalInstanceKey(m.doc.Id)
 }
 
 // globalKey returns the global database key for the machine.
@@ -864,12 +877,8 @@ func (m *Machine) Remove() (err error) {
 			Id:     m.doc.DocID,
 			Assert: isDeadDoc,
 		},
-		{
-			C:      instanceDataC,
-			Id:     m.doc.DocID,
-			Remove: true,
-		},
 		removeStatusOp(m.st, m.globalKey()),
+		removeStatusOp(m.st, m.globalInstanceKey()),
 		removeConstraintsOp(m.st, m.globalKey()),
 		removeRequestedNetworksOp(m.st, m.globalKey()),
 		annotationRemoveOp(m.st, m.globalKey()),
@@ -990,36 +999,37 @@ func (m *Machine) InstanceId() (instance.Id, error) {
 
 // InstanceStatus returns the provider specific instance status for this machine,
 // or a NotProvisionedError if instance is not yet provisioned.
-func (m *Machine) InstanceStatus() (string, error) {
-	instData, err := getInstanceData(m.st, m.Id())
-	if errors.IsNotFound(err) {
-		err = errors.NotProvisionedf("machine %v", m.Id())
-	}
+func (m *Machine) InstanceStatus() (status.StatusInfo, error) {
+	machineStatus, err := getStatus(m.st, m.globalInstanceKey(), "instance")
 	if err != nil {
-		return "", err
+		logger.Warningf("error when retrieving instance status for machine: %s, %v", m.Id(), err)
+		return status.StatusInfo{}, err
 	}
-	return instData.Status, err
+	return machineStatus, nil
 }
 
 // SetInstanceStatus sets the provider specific instance status for a machine.
-func (m *Machine) SetInstanceStatus(status string) (err error) {
-	defer errors.DeferredAnnotatef(&err, "cannot set instance status for machine %q", m)
+func (m *Machine) SetInstanceStatus(instanceStatus status.Status, info string, data map[string]interface{}) (err error) {
+	return setStatus(m.st, setStatusParams{
+		badge:     "instance",
+		globalKey: m.globalInstanceKey(),
+		status:    instanceStatus,
+		message:   info,
+		rawData:   data,
+	})
 
-	ops := []txn.Op{
-		{
-			C:      instanceDataC,
-			Id:     m.doc.DocID,
-			Assert: txn.DocExists,
-			Update: bson.D{{"$set", bson.D{{"status", status}}}},
-		},
-	}
+}
 
-	if err = m.st.runTransaction(ops); err == nil {
-		return nil
-	} else if err != txn.ErrAborted {
-		return err
-	}
-	return errors.NotProvisionedf("machine %v", m.Id())
+// InstanceStatusHistory returns a slice of at most <size> StatusInfo items
+// representing past statuses for this machine instance.
+func (u *Machine) InstanceStatusHistory(size int) ([]status.StatusInfo, error) {
+	return statusHistory(u.st, u.globalInstanceKey(), size)
+}
+
+// StatusHistory returns a slice of at most <size> StatusInfo items
+// representing past statuses for this machine.
+func (u *Machine) StatusHistory(size int) ([]status.StatusInfo, error) {
+	return statusHistory(u.st, u.globalKey(), size)
 }
 
 // AvailabilityZone returns the provier-specific instance availability
@@ -1664,19 +1674,31 @@ func (m *Machine) SetConstraints(cons constraints.Value) (err error) {
 }
 
 // Status returns the status of the machine.
-func (m *Machine) Status() (StatusInfo, error) {
-	return getStatus(m.st, m.globalKey(), "machine")
+func (m *Machine) Status() (status.StatusInfo, error) {
+	mStatus, err := getStatus(m.st, m.globalKey(), "machine")
+	if err != nil {
+		return mStatus, err
+	}
+	if mStatus.Status == status.StatusPending {
+		instStatus, err := getStatus(m.st, m.globalInstanceKey(), "instance")
+		if err != nil {
+			return mStatus, err
+		}
+		mStatus.Message = instStatus.Message
+	}
+
+	return mStatus, nil
 }
 
 // SetStatus sets the status of the machine.
-func (m *Machine) SetStatus(status Status, info string, data map[string]interface{}) error {
-	switch status {
-	case StatusStarted, StatusStopped:
-	case StatusError:
+func (m *Machine) SetStatus(machineStatus status.Status, info string, data map[string]interface{}) error {
+	switch machineStatus {
+	case status.StatusStarted, status.StatusStopped:
+	case status.StatusError:
 		if info == "" {
-			return errors.Errorf("cannot set status %q without info", status)
+			return errors.Errorf("cannot set status %q without info", machineStatus)
 		}
-	case StatusPending:
+	case status.StatusPending:
 		// If a machine is not yet provisioned, we allow its status
 		// to be set back to pending (when a retry is to occur).
 		_, err := m.InstanceId()
@@ -1685,15 +1707,15 @@ func (m *Machine) SetStatus(status Status, info string, data map[string]interfac
 			break
 		}
 		fallthrough
-	case StatusDown:
-		return errors.Errorf("cannot set status %q", status)
+	case status.StatusDown:
+		return errors.Errorf("cannot set status %q", machineStatus)
 	default:
-		return errors.Errorf("cannot set invalid status %q", status)
+		return errors.Errorf("cannot set invalid status %q", machineStatus)
 	}
 	return setStatus(m.st, setStatusParams{
 		badge:     "machine",
 		globalKey: m.globalKey(),
-		status:    status,
+		status:    machineStatus,
 		message:   info,
 		rawData:   data,
 	})
@@ -1788,10 +1810,10 @@ func (m *Machine) markInvalidContainers() error {
 				logger.Errorf("finding status of container %v to mark as invalid: %v", containerId, err)
 				continue
 			}
-			if statusInfo.Status == StatusPending {
+			if statusInfo.Status == status.StatusPending {
 				containerType := ContainerTypeFromId(containerId)
 				container.SetStatus(
-					StatusError, "unsupported container", map[string]interface{}{"type": containerType})
+					status.StatusError, "unsupported container", map[string]interface{}{"type": containerType})
 			} else {
 				logger.Errorf("unsupported container %v has unexpected status %v", containerId, statusInfo.Status)
 			}

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/testing"
+	"github.com/juju/juju/status"
 	"github.com/juju/juju/storage/poolmanager"
 	"github.com/juju/juju/storage/provider"
 	"github.com/juju/juju/storage/provider/registry"
@@ -1175,25 +1176,16 @@ func (s *MachineSuite) TestMachineSetInstanceStatus(c *gc.C) {
 	err := s.machine.SetProvisioned("umbrella/0", "fake_nonce", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = s.machine.SetInstanceStatus("ALIVE")
+	err = s.machine.SetInstanceStatus(status.StatusRunning, "ALIVE", map[string]interface{}{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Reload machine and check result.
 	err = s.machine.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
-	status, err := s.machine.InstanceStatus()
+	machineStatus, err := s.machine.InstanceStatus()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(status, gc.DeepEquals, "ALIVE")
-}
-
-func (s *MachineSuite) TestNotProvisionedMachineSetInstanceStatus(c *gc.C) {
-	err := s.machine.SetInstanceStatus("ALIVE")
-	c.Assert(err, gc.ErrorMatches, ".* not provisioned")
-}
-
-func (s *MachineSuite) TestNotProvisionedMachineInstanceStatus(c *gc.C) {
-	_, err := s.machine.InstanceStatus()
-	c.Assert(err, jc.Satisfies, errors.IsNotProvisioned)
+	c.Assert(machineStatus.Status, gc.DeepEquals, status.StatusRunning)
+	c.Assert(machineStatus.Message, gc.DeepEquals, "ALIVE")
 }
 
 func (s *MachineSuite) TestMachineRefresh(c *gc.C) {
@@ -1431,7 +1423,7 @@ func (s *MachineSuite) TestWatchPrincipalUnits(c *gc.C) {
 	wc.AssertNoChange()
 
 	// Change the unit; no change.
-	err = mysql0.SetAgentStatus(state.StatusIdle, "", nil)
+	err = mysql0.SetAgentStatus(status.StatusIdle, "", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertNoChange()
 
@@ -1460,7 +1452,7 @@ func (s *MachineSuite) TestWatchPrincipalUnits(c *gc.C) {
 	wc.AssertNoChange()
 
 	// Change the subordinate; no change.
-	err = logging0.SetAgentStatus(state.StatusIdle, "", nil)
+	err = logging0.SetAgentStatus(status.StatusIdle, "", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertNoChange()
 
@@ -1535,7 +1527,7 @@ func (s *MachineSuite) TestWatchUnits(c *gc.C) {
 	wc.AssertNoChange()
 
 	// Change the unit; no change.
-	err = mysql0.SetAgentStatus(state.StatusIdle, "", nil)
+	err = mysql0.SetAgentStatus(status.StatusIdle, "", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertNoChange()
 
@@ -1565,7 +1557,7 @@ func (s *MachineSuite) TestWatchUnits(c *gc.C) {
 	wc.AssertNoChange()
 
 	// Change the subordinate; no change.
-	err = logging0.SetAgentStatus(state.StatusIdle, "", nil)
+	err = logging0.SetAgentStatus(status.StatusIdle, "", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertNoChange()
 
@@ -2495,14 +2487,14 @@ func (s *MachineSuite) TestSetSupportedContainersSetsUnknownToError(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	statusInfo, err := supportedContainer.Status()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(statusInfo.Status, gc.Equals, state.StatusPending)
+	c.Assert(statusInfo.Status, gc.Equals, status.StatusPending)
 
 	// An unsupported (lxc) container will have an error status.
 	err = container.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
 	statusInfo, err = container.Status()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(statusInfo.Status, gc.Equals, state.StatusError)
+	c.Assert(statusInfo.Status, gc.Equals, status.StatusError)
 	c.Assert(statusInfo.Message, gc.Equals, "unsupported container")
 	c.Assert(statusInfo.Data, gc.DeepEquals, map[string]interface{}{"type": "lxc"})
 }
@@ -2530,7 +2522,7 @@ func (s *MachineSuite) TestSupportsNoContainersSetsAllToError(c *gc.C) {
 		c.Assert(err, jc.ErrorIsNil)
 		statusInfo, err := container.Status()
 		c.Assert(err, jc.ErrorIsNil)
-		c.Assert(statusInfo.Status, gc.Equals, state.StatusError)
+		c.Assert(statusInfo.Status, gc.Equals, status.StatusError)
 		c.Assert(statusInfo.Message, gc.Equals, "unsupported container")
 		containerType := state.ContainerTypeFromId(container.Id())
 		c.Assert(statusInfo.Data, gc.DeepEquals, map[string]interface{}{"type": string(containerType)})

--- a/state/multiwatcher/multiwatcher.go
+++ b/state/multiwatcher/multiwatcher.go
@@ -9,20 +9,21 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	"gopkg.in/juju/charm.v6-unstable"
 
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/network"
+	"github.com/juju/juju/status"
 )
+
+var logger = loggo.GetLogger("juju.state.multiwatcher")
 
 // Life describes the lifecycle state of an entity ("alive", "dying"
 // or "dead").
 type Life string
-
-// Status represents the status of an entity.
-// It could be a service, unit, machine or its agent.
-type Status string
 
 // EntityInfo is implemented by all entity Info types.
 type EntityInfo interface {
@@ -107,7 +108,7 @@ func (d *Delta) UnmarshalJSON(data []byte) error {
 	case "action":
 		d.Entity = new(ActionInfo)
 	default:
-		return fmt.Errorf("Unexpected entity name %q", entityKind)
+		return errors.Errorf("Unexpected entity name %q", entityKind)
 	}
 	return json.Unmarshal(elements[2], &d.Entity)
 }
@@ -118,9 +119,8 @@ type MachineInfo struct {
 	ModelUUID                string
 	Id                       string
 	InstanceId               string
-	Status                   Status
-	StatusInfo               string
-	StatusData               map[string]interface{}
+	JujuStatus               StatusInfo
+	MachineStatus            StatusInfo
 	Life                     Life
 	Series                   string
 	SupportedContainers      []instance.ContainerType
@@ -146,11 +146,23 @@ func (i *MachineInfo) EntityId() EntityId {
 // used by ServiceInfo and UnitInfo.
 type StatusInfo struct {
 	Err     error
-	Current Status
+	Current status.Status
 	Message string
 	Since   *time.Time
 	Version string
 	Data    map[string]interface{}
+}
+
+// NewStatusInfo return a new multiwatcher StatusInfo from a
+// status StatusInfo.
+func NewStatusInfo(s status.StatusInfo, err error) StatusInfo {
+	return StatusInfo{
+		Err:     err,
+		Current: s.Status,
+		Message: s.Message,
+		Since:   s.Since,
+		Data:    s.Data,
+	}
 }
 
 // ServiceInfo holds the information about a service that is tracked
@@ -193,10 +205,6 @@ type UnitInfo struct {
 	Ports          []network.Port
 	PortRanges     []network.PortRange
 	Subordinate    bool
-	// The following 3 status values are deprecated.
-	Status     Status
-	StatusInfo string
-	StatusData map[string]interface{}
 	// Workload and agent state are modelled separately.
 	WorkloadStatus StatusInfo
 	AgentStatus    StatusInfo

--- a/state/service.go
+++ b/state/service.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/core/leadership"
+	"github.com/juju/juju/status"
 )
 
 // Service represents the state of a service.
@@ -805,13 +806,13 @@ func (s *Service) addUnitOpsWithCons(args addUnitOpsArgs) (string, []txn.Op, err
 	}
 	now := time.Now()
 	agentStatusDoc := statusDoc{
-		Status:    StatusAllocating,
+		Status:    status.StatusAllocating,
 		Updated:   now.UnixNano(),
 		ModelUUID: s.st.ModelUUID(),
 	}
 	unitStatusDoc := statusDoc{
 		// TODO(fwereade): this violates the spec. Should be "waiting".
-		Status:     StatusUnknown,
+		Status:     status.StatusUnknown,
 		StatusInfo: MessageWaitForAgentInit,
 		Updated:    now.UnixNano(),
 		ModelUUID:  s.st.ModelUUID(),
@@ -1373,12 +1374,12 @@ type settingsRefsDoc struct {
 // Only unit leaders are allowed to set the status of the service.
 // If no status is recorded, then there are no unit leaders and the
 // status is derived from the unit status values.
-func (s *Service) Status() (StatusInfo, error) {
+func (s *Service) Status() (status.StatusInfo, error) {
 	statuses, closer := s.st.getCollection(statusesC)
 	defer closer()
 	query := statuses.Find(bson.D{{"_id", s.globalKey()}, {"neverset", true}})
 	if count, err := query.Count(); err != nil {
-		return StatusInfo{}, errors.Trace(err)
+		return status.StatusInfo{}, errors.Trace(err)
 	} else if count != 0 {
 		// This indicates that SetStatus has never been called on this service.
 		// This in turn implies the service status document is likely to be
@@ -1392,7 +1393,7 @@ func (s *Service) Status() (StatusInfo, error) {
 		// the right places rather than being applied at seeming random.
 		units, err := s.AllUnits()
 		if err != nil {
-			return StatusInfo{}, err
+			return status.StatusInfo{}, err
 		}
 		logger.Tracef("service %q has %d units", s.Name(), len(units))
 		if len(units) > 0 {
@@ -1403,34 +1404,34 @@ func (s *Service) Status() (StatusInfo, error) {
 }
 
 // SetStatus sets the status for the service.
-func (s *Service) SetStatus(status Status, info string, data map[string]interface{}) error {
-	if !ValidWorkloadStatus(status) {
-		return errors.Errorf("cannot set invalid status %q", status)
+func (s *Service) SetStatus(serviceStatus status.Status, info string, data map[string]interface{}) error {
+	if !status.ValidWorkloadStatus(serviceStatus) {
+		return errors.Errorf("cannot set invalid status %q", serviceStatus)
 	}
 	return setStatus(s.st, setStatusParams{
 		badge:     "service",
 		globalKey: s.globalKey(),
-		status:    status,
+		status:    serviceStatus,
 		message:   info,
 		rawData:   data,
 	})
 }
 
 // ServiceAndUnitsStatus returns the status for this service and all its units.
-func (s *Service) ServiceAndUnitsStatus() (StatusInfo, map[string]StatusInfo, error) {
+func (s *Service) ServiceAndUnitsStatus() (status.StatusInfo, map[string]status.StatusInfo, error) {
 	serviceStatus, err := s.Status()
 	if err != nil {
-		return StatusInfo{}, nil, errors.Trace(err)
+		return status.StatusInfo{}, nil, errors.Trace(err)
 	}
 	units, err := s.AllUnits()
 	if err != nil {
-		return StatusInfo{}, nil, err
+		return status.StatusInfo{}, nil, err
 	}
-	results := make(map[string]StatusInfo, len(units))
+	results := make(map[string]status.StatusInfo, len(units))
 	for _, unit := range units {
 		unitStatus, err := unit.Status()
 		if err != nil {
-			return StatusInfo{}, nil, err
+			return status.StatusInfo{}, nil, err
 		}
 		results[unit.Name()] = unitStatus
 	}
@@ -1438,13 +1439,13 @@ func (s *Service) ServiceAndUnitsStatus() (StatusInfo, map[string]StatusInfo, er
 
 }
 
-func (s *Service) deriveStatus(units []*Unit) (StatusInfo, error) {
-	var result StatusInfo
+func (s *Service) deriveStatus(units []*Unit) (status.StatusInfo, error) {
+	var result status.StatusInfo
 	for _, unit := range units {
 		currentSeverity := statusServerities[result.Status]
 		unitStatus, err := unit.Status()
 		if err != nil {
-			return StatusInfo{}, errors.Annotatef(err, "deriving service status from %q", unit.Name())
+			return status.StatusInfo{}, errors.Annotatef(err, "deriving service status from %q", unit.Name())
 		}
 		unitSeverity := statusServerities[unitStatus.Status]
 		if unitSeverity > currentSeverity {
@@ -1459,12 +1460,12 @@ func (s *Service) deriveStatus(units []*Unit) (StatusInfo, error) {
 
 // statusSeverities holds status values with a severity measure.
 // Status values with higher severity are used in preference to others.
-var statusServerities = map[Status]int{
-	StatusError:       100,
-	StatusBlocked:     90,
-	StatusWaiting:     80,
-	StatusMaintenance: 70,
-	StatusTerminated:  60,
-	StatusActive:      50,
-	StatusUnknown:     40,
+var statusServerities = map[status.Status]int{
+	status.StatusError:       100,
+	status.StatusBlocked:     90,
+	status.StatusWaiting:     80,
+	status.StatusMaintenance: 70,
+	status.StatusTerminated:  60,
+	status.StatusActive:      50,
+	status.StatusUnknown:     40,
 }

--- a/state/service_test.go
+++ b/state/service_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/testing"
+	"github.com/juju/juju/status"
 	"github.com/juju/juju/storage/provider"
 	"github.com/juju/juju/storage/provider/registry"
 )
@@ -1992,7 +1993,7 @@ func (s *ServiceSuite) TestMetricCredentialsOnDying(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "cannot update metric credentials: service not found or not alive")
 }
 
-func (s *ServiceSuite) testStatus(c *gc.C, status1, status2, expected state.Status) {
+func (s *ServiceSuite) testStatus(c *gc.C, status1, status2, expected status.Status) {
 	u1, err := s.mysql.AddUnit()
 	c.Assert(err, jc.ErrorIsNil)
 	err = u1.SetStatus(status1, "status 1", nil)
@@ -2000,7 +2001,7 @@ func (s *ServiceSuite) testStatus(c *gc.C, status1, status2, expected state.Stat
 
 	u2, err := s.mysql.AddUnit()
 	c.Assert(err, jc.ErrorIsNil)
-	if status2 == state.StatusError {
+	if status2 == status.StatusError {
 		err = u2.SetAgentStatus(status2, "status 2", nil)
 	} else {
 		err = u2.SetStatus(status2, "status 2", nil)
@@ -2011,7 +2012,7 @@ func (s *ServiceSuite) testStatus(c *gc.C, status1, status2, expected state.Stat
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(statusInfo.Since, gc.NotNil)
 	statusInfo.Since = nil
-	c.Assert(statusInfo, jc.DeepEquals, state.StatusInfo{
+	c.Assert(statusInfo, jc.DeepEquals, status.StatusInfo{
 		Status:  expected,
 		Message: "status 2",
 		Data:    map[string]interface{}{},
@@ -2019,16 +2020,16 @@ func (s *ServiceSuite) testStatus(c *gc.C, status1, status2, expected state.Stat
 }
 
 func (s *ServiceSuite) TestStatus(c *gc.C) {
-	for _, t := range []struct{ status1, status2, expected state.Status }{
-		{state.StatusActive, state.StatusWaiting, state.StatusWaiting},
-		{state.StatusMaintenance, state.StatusWaiting, state.StatusWaiting},
-		{state.StatusActive, state.StatusBlocked, state.StatusBlocked},
-		{state.StatusWaiting, state.StatusBlocked, state.StatusBlocked},
-		{state.StatusMaintenance, state.StatusBlocked, state.StatusBlocked},
-		{state.StatusMaintenance, state.StatusError, state.StatusError},
-		{state.StatusBlocked, state.StatusError, state.StatusError},
-		{state.StatusWaiting, state.StatusError, state.StatusError},
-		{state.StatusActive, state.StatusError, state.StatusError},
+	for _, t := range []struct{ status1, status2, expected status.Status }{
+		{status.StatusActive, status.StatusWaiting, status.StatusWaiting},
+		{status.StatusMaintenance, status.StatusWaiting, status.StatusWaiting},
+		{status.StatusActive, status.StatusBlocked, status.StatusBlocked},
+		{status.StatusWaiting, status.StatusBlocked, status.StatusBlocked},
+		{status.StatusMaintenance, status.StatusBlocked, status.StatusBlocked},
+		{status.StatusMaintenance, status.StatusError, status.StatusError},
+		{status.StatusBlocked, status.StatusError, status.StatusError},
+		{status.StatusWaiting, status.StatusError, status.StatusError},
+		{status.StatusActive, status.StatusError, status.StatusError},
 	} {
 		s.testStatus(c, t.status1, t.status2, t.expected)
 	}

--- a/state/state.go
+++ b/state/state.go
@@ -38,6 +38,7 @@ import (
 	statelease "github.com/juju/juju/state/lease"
 	"github.com/juju/juju/state/presence"
 	"github.com/juju/juju/state/watcher"
+	"github.com/juju/juju/status"
 	"github.com/juju/juju/version"
 	"github.com/juju/juju/worker/lease"
 )
@@ -1296,7 +1297,7 @@ func (st *State) AddService(args AddServiceArgs) (service *Service, err error) {
 		// TODO(fwereade): this violates the spec. Should be "waiting".
 		// Implemented like this to be consistent with incorrect add-unit
 		// behaviour.
-		Status:     StatusUnknown,
+		Status:     status.StatusUnknown,
 		StatusInfo: MessageWaitForAgentInit,
 		Updated:    time.Now().UnixNano(),
 		// This exists to preserve questionable unit-aggregation behaviour

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/multiwatcher"
 	statetesting "github.com/juju/juju/state/testing"
+	"github.com/juju/juju/status"
 	"github.com/juju/juju/storage/poolmanager"
 	"github.com/juju/juju/storage/provider"
 	"github.com/juju/juju/storage/provider/registry"
@@ -54,7 +55,7 @@ var alternatePassword = "bar-12345678901234567890"
 // asserting the behaviour of a given method in each state, and the unit quick-
 // remove change caused many of these to fail.
 func preventUnitDestroyRemove(c *gc.C, u *state.Unit) {
-	err := u.SetAgentStatus(state.StatusIdle, "", nil)
+	err := u.SetAgentStatus(status.StatusIdle, "", nil)
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/state/status.go
+++ b/state/status.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/juju/juju/core/leadership"
 	"github.com/juju/juju/mongo"
+	"github.com/juju/juju/status"
 )
 
 // statusDoc represents a entity status in Mongodb.  The implicit
@@ -22,7 +23,7 @@ import (
 // direct use of the document in both create and update transactions.
 type statusDoc struct {
 	ModelUUID  string                 `bson:"model-uuid"`
-	Status     Status                 `bson:"status"`
+	Status     status.Status          `bson:"status"`
 	StatusInfo string                 `bson:"statusinfo"`
 	StatusData map[string]interface{} `bson:"statusdata"`
 
@@ -72,7 +73,7 @@ func unescapeKeys(input map[string]interface{}) map[string]interface{} {
 // getStatus retrieves the status document associated with the given
 // globalKey and converts it to a StatusInfo. If the status document
 // is not found, a NotFoundError referencing badge will be returned.
-func getStatus(st *State, globalKey, badge string) (_ StatusInfo, err error) {
+func getStatus(st *State, globalKey, badge string) (_ status.StatusInfo, err error) {
 	defer errors.DeferredAnnotatef(&err, "cannot get status")
 	statuses, closer := st.getCollection(statusesC)
 	defer closer()
@@ -80,12 +81,12 @@ func getStatus(st *State, globalKey, badge string) (_ StatusInfo, err error) {
 	var doc statusDoc
 	err = statuses.FindId(globalKey).One(&doc)
 	if err == mgo.ErrNotFound {
-		return StatusInfo{}, errors.NotFoundf(badge)
+		return status.StatusInfo{}, errors.NotFoundf(badge)
 	} else if err != nil {
-		return StatusInfo{}, errors.Trace(err)
+		return status.StatusInfo{}, errors.Trace(err)
 	}
 
-	return StatusInfo{
+	return status.StatusInfo{
 		Status:  doc.Status,
 		Message: doc.StatusInfo,
 		Data:    unescapeKeys(doc.StatusData),
@@ -104,7 +105,7 @@ type setStatusParams struct {
 	globalKey string
 
 	// status is the status value.
-	status Status
+	status status.Status
 
 	// message is an optional string elaborating upon the status.
 	message string
@@ -191,7 +192,7 @@ func removeStatusOp(st *State, globalKey string) txn.Op {
 type historicalStatusDoc struct {
 	ModelUUID  string                 `bson:"model-uuid"`
 	GlobalKey  string                 `bson:"globalkey"`
-	Status     Status                 `bson:"status"`
+	Status     status.Status          `bson:"status"`
 	StatusInfo string                 `bson:"statusinfo"`
 	StatusData map[string]interface{} `bson:"statusdata"`
 
@@ -217,7 +218,7 @@ func probablyUpdateStatusHistory(st *State, globalKey string, doc statusDoc) {
 	}
 }
 
-func statusHistory(st *State, globalKey string, size int) ([]StatusInfo, error) {
+func statusHistory(st *State, globalKey string, size int) ([]status.StatusInfo, error) {
 	statusHistory, closer := st.getCollection(statusesHistoryC)
 	defer closer()
 
@@ -225,14 +226,14 @@ func statusHistory(st *State, globalKey string, size int) ([]StatusInfo, error) 
 	query := statusHistory.Find(bson.D{{"globalkey", globalKey}})
 	err := query.Sort("-updated").Limit(size).All(&docs)
 	if err == mgo.ErrNotFound {
-		return []StatusInfo{}, errors.NotFoundf("status history")
+		return []status.StatusInfo{}, errors.NotFoundf("status history")
 	} else if err != nil {
-		return []StatusInfo{}, errors.Annotatef(err, "cannot get status history")
+		return []status.StatusInfo{}, errors.Annotatef(err, "cannot get status history")
 	}
 
-	results := make([]StatusInfo, len(docs))
+	results := make([]status.StatusInfo, len(docs))
 	for i, doc := range docs {
-		results[i] = StatusInfo{
+		results[i] = status.StatusInfo{
 			Status:  doc.Status,
 			Message: doc.StatusInfo,
 			Data:    unescapeKeys(doc.StatusData),

--- a/state/status_filesystem_test.go
+++ b/state/status_filesystem_test.go
@@ -8,6 +8,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/status"
 )
 
 type FilesystemStatusSuite struct {
@@ -50,28 +51,28 @@ func (s *FilesystemStatusSuite) TestInitialStatus(c *gc.C) {
 func (s *FilesystemStatusSuite) checkInitialStatus(c *gc.C) {
 	statusInfo, err := s.filesystem.Status()
 	c.Check(err, jc.ErrorIsNil)
-	c.Check(statusInfo.Status, gc.Equals, state.StatusPending)
+	c.Check(statusInfo.Status, gc.Equals, status.StatusPending)
 	c.Check(statusInfo.Message, gc.Equals, "")
 	c.Check(statusInfo.Data, gc.HasLen, 0)
 	c.Check(statusInfo.Since, gc.NotNil)
 }
 
 func (s *FilesystemStatusSuite) TestSetErrorStatusWithoutInfo(c *gc.C) {
-	err := s.filesystem.SetStatus(state.StatusError, "", nil)
+	err := s.filesystem.SetStatus(status.StatusError, "", nil)
 	c.Check(err, gc.ErrorMatches, `cannot set status "error" without info`)
 
 	s.checkInitialStatus(c)
 }
 
 func (s *FilesystemStatusSuite) TestSetUnknownStatus(c *gc.C) {
-	err := s.filesystem.SetStatus(state.Status("vliegkat"), "orville", nil)
+	err := s.filesystem.SetStatus(status.Status("vliegkat"), "orville", nil)
 	c.Assert(err, gc.ErrorMatches, `cannot set invalid status "vliegkat"`)
 
 	s.checkInitialStatus(c)
 }
 
 func (s *FilesystemStatusSuite) TestSetOverwritesData(c *gc.C) {
-	err := s.filesystem.SetStatus(state.StatusAttaching, "blah", map[string]interface{}{
+	err := s.filesystem.SetStatus(status.StatusAttaching, "blah", map[string]interface{}{
 		"pew.pew": "zap",
 	})
 	c.Check(err, jc.ErrorIsNil)
@@ -84,7 +85,7 @@ func (s *FilesystemStatusSuite) TestGetSetStatusAlive(c *gc.C) {
 }
 
 func (s *FilesystemStatusSuite) checkGetSetStatus(c *gc.C) {
-	err := s.filesystem.SetStatus(state.StatusAttaching, "blah", map[string]interface{}{
+	err := s.filesystem.SetStatus(status.StatusAttaching, "blah", map[string]interface{}{
 		"$foo.bar.baz": map[string]interface{}{
 			"pew.pew": "zap",
 		},
@@ -96,7 +97,7 @@ func (s *FilesystemStatusSuite) checkGetSetStatus(c *gc.C) {
 
 	statusInfo, err := filesystem.Status()
 	c.Check(err, jc.ErrorIsNil)
-	c.Check(statusInfo.Status, gc.Equals, state.StatusAttaching)
+	c.Check(statusInfo.Status, gc.Equals, status.StatusAttaching)
 	c.Check(statusInfo.Message, gc.Equals, "blah")
 	c.Check(statusInfo.Data, jc.DeepEquals, map[string]interface{}{
 		"$foo.bar.baz": map[string]interface{}{
@@ -134,16 +135,16 @@ func (s *FilesystemStatusSuite) TestGetSetStatusDead(c *gc.C) {
 func (s *FilesystemStatusSuite) TestGetSetStatusGone(c *gc.C) {
 	s.obliterateFilesystem(c, s.filesystem.FilesystemTag())
 
-	err := s.filesystem.SetStatus(state.StatusAttaching, "not really", nil)
+	err := s.filesystem.SetStatus(status.StatusAttaching, "not really", nil)
 	c.Check(err, gc.ErrorMatches, `cannot set status: filesystem not found`)
 
 	statusInfo, err := s.filesystem.Status()
 	c.Check(err, gc.ErrorMatches, `cannot get status: filesystem not found`)
-	c.Check(statusInfo, gc.DeepEquals, state.StatusInfo{})
+	c.Check(statusInfo, gc.DeepEquals, status.StatusInfo{})
 }
 
 func (s *FilesystemStatusSuite) TestSetStatusPendingUnprovisioned(c *gc.C) {
-	err := s.filesystem.SetStatus(state.StatusPending, "still", nil)
+	err := s.filesystem.SetStatus(status.StatusPending, "still", nil)
 	c.Check(err, jc.ErrorIsNil)
 }
 
@@ -152,6 +153,6 @@ func (s *FilesystemStatusSuite) TestSetStatusPendingProvisioned(c *gc.C) {
 		FilesystemId: "fs-id",
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.filesystem.SetStatus(state.StatusPending, "", nil)
+	err = s.filesystem.SetStatus(status.StatusPending, "", nil)
 	c.Check(err, gc.ErrorMatches, `cannot set status "pending"`)
 }

--- a/state/status_machine_test.go
+++ b/state/status_machine_test.go
@@ -8,6 +8,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/status"
 )
 
 type MachineStatusSuite struct {
@@ -29,35 +30,35 @@ func (s *MachineStatusSuite) TestInitialStatus(c *gc.C) {
 func (s *MachineStatusSuite) checkInitialStatus(c *gc.C) {
 	statusInfo, err := s.machine.Status()
 	c.Check(err, jc.ErrorIsNil)
-	c.Check(statusInfo.Status, gc.Equals, state.StatusPending)
+	c.Check(statusInfo.Status, gc.Equals, status.StatusPending)
 	c.Check(statusInfo.Message, gc.Equals, "")
 	c.Check(statusInfo.Data, gc.HasLen, 0)
 	c.Check(statusInfo.Since, gc.NotNil)
 }
 
 func (s *MachineStatusSuite) TestSetErrorStatusWithoutInfo(c *gc.C) {
-	err := s.machine.SetStatus(state.StatusError, "", nil)
+	err := s.machine.SetStatus(status.StatusError, "", nil)
 	c.Check(err, gc.ErrorMatches, `cannot set status "error" without info`)
 
 	s.checkInitialStatus(c)
 }
 
 func (s *MachineStatusSuite) TestSetDownStatus(c *gc.C) {
-	err := s.machine.SetStatus(state.StatusDown, "", nil)
+	err := s.machine.SetStatus(status.StatusDown, "", nil)
 	c.Check(err, gc.ErrorMatches, `cannot set status "down"`)
 
 	s.checkInitialStatus(c)
 }
 
 func (s *MachineStatusSuite) TestSetUnknownStatus(c *gc.C) {
-	err := s.machine.SetStatus(state.Status("vliegkat"), "orville", nil)
+	err := s.machine.SetStatus(status.Status("vliegkat"), "orville", nil)
 	c.Assert(err, gc.ErrorMatches, `cannot set invalid status "vliegkat"`)
 
 	s.checkInitialStatus(c)
 }
 
 func (s *MachineStatusSuite) TestSetOverwritesData(c *gc.C) {
-	err := s.machine.SetStatus(state.StatusStarted, "blah", map[string]interface{}{
+	err := s.machine.SetStatus(status.StatusStarted, "blah", map[string]interface{}{
 		"pew.pew": "zap",
 	})
 	c.Check(err, jc.ErrorIsNil)
@@ -70,7 +71,7 @@ func (s *MachineStatusSuite) TestGetSetStatusAlive(c *gc.C) {
 }
 
 func (s *MachineStatusSuite) checkGetSetStatus(c *gc.C) {
-	err := s.machine.SetStatus(state.StatusStarted, "blah", map[string]interface{}{
+	err := s.machine.SetStatus(status.StatusStarted, "blah", map[string]interface{}{
 		"$foo.bar.baz": map[string]interface{}{
 			"pew.pew": "zap",
 		},
@@ -82,7 +83,7 @@ func (s *MachineStatusSuite) checkGetSetStatus(c *gc.C) {
 
 	statusInfo, err := machine.Status()
 	c.Check(err, jc.ErrorIsNil)
-	c.Check(statusInfo.Status, gc.Equals, state.StatusStarted)
+	c.Check(statusInfo.Status, gc.Equals, status.StatusStarted)
 	c.Check(statusInfo.Message, gc.Equals, "blah")
 	c.Check(statusInfo.Data, jc.DeepEquals, map[string]interface{}{
 		"$foo.bar.baz": map[string]interface{}{
@@ -115,22 +116,22 @@ func (s *MachineStatusSuite) TestGetSetStatusGone(c *gc.C) {
 	err = s.machine.Remove()
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = s.machine.SetStatus(state.StatusStarted, "not really", nil)
+	err = s.machine.SetStatus(status.StatusStarted, "not really", nil)
 	c.Check(err, gc.ErrorMatches, `cannot set status: machine not found`)
 
 	statusInfo, err := s.machine.Status()
 	c.Check(err, gc.ErrorMatches, `cannot get status: machine not found`)
-	c.Check(statusInfo, gc.DeepEquals, state.StatusInfo{})
+	c.Check(statusInfo, gc.DeepEquals, status.StatusInfo{})
 }
 
 func (s *MachineStatusSuite) TestSetStatusPendingProvisioned(c *gc.C) {
-	err := s.machine.SetStatus(state.StatusPending, "", nil)
+	err := s.machine.SetStatus(status.StatusPending, "", nil)
 	c.Check(err, gc.ErrorMatches, `cannot set status "pending"`)
 }
 
 func (s *MachineStatusSuite) TestSetStatusPendingUnprovisioned(c *gc.C) {
 	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
-	err = machine.SetStatus(state.StatusPending, "", nil)
+	err = machine.SetStatus(status.StatusPending, "", nil)
 	c.Check(err, jc.ErrorIsNil)
 }

--- a/state/status_model_test.go
+++ b/state/status_model_test.go
@@ -7,8 +7,8 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/state"
 	statetesting "github.com/juju/juju/state/testing"
+	"github.com/juju/juju/status"
 )
 
 type StatusModelSuite struct {
@@ -17,84 +17,46 @@ type StatusModelSuite struct {
 
 var _ = gc.Suite(&StatusModelSuite{})
 
-func (s *StatusModelSuite) TestTranslateLegacyAgentState(c *gc.C) {
-	for i, test := range []struct {
-		agentStatus     state.Status
-		workloadStatus  state.Status
-		workloadMessage string
-		expected        state.Status
-	}{{
-		agentStatus: state.StatusAllocating,
-		expected:    state.StatusPending,
-	}, {
-		agentStatus: state.StatusError,
-		expected:    state.StatusError,
-	}, {
-		agentStatus:     state.StatusIdle,
-		workloadStatus:  state.StatusMaintenance,
-		expected:        state.StatusPending,
-		workloadMessage: "installing charm software",
-	}, {
-		agentStatus:     state.StatusIdle,
-		workloadStatus:  state.StatusMaintenance,
-		expected:        state.StatusStarted,
-		workloadMessage: "backing up",
-	}, {
-		agentStatus:    state.StatusIdle,
-		workloadStatus: state.StatusTerminated,
-		expected:       state.StatusStopped,
-	}, {
-		agentStatus:    state.StatusIdle,
-		workloadStatus: state.StatusBlocked,
-		expected:       state.StatusStarted,
-	}} {
-		c.Logf("test %d", i)
-		legacy, ok := state.TranslateToLegacyAgentState(test.agentStatus, test.workloadStatus, test.workloadMessage)
-		c.Check(ok, jc.IsTrue)
-		c.Check(legacy, gc.Equals, test.expected)
-	}
-}
-
 func (s *StatusModelSuite) TestUnitAgentStatusDocValidation(c *gc.C) {
 	unit := s.Factory.MakeUnit(c, nil)
 	for i, test := range []struct {
-		status state.Status
+		status status.Status
 		info   string
 		err    string
 	}{{
-		status: state.StatusPending,
+		status: status.StatusPending,
 		err:    `cannot set invalid status "pending"`,
 	}, {
-		status: state.StatusDown,
+		status: status.StatusDown,
 		err:    `cannot set invalid status "down"`,
 	}, {
-		status: state.StatusStarted,
+		status: status.StatusStarted,
 		err:    `cannot set invalid status "started"`,
 	}, {
-		status: state.StatusStopped,
+		status: status.StatusStopped,
 		err:    `cannot set invalid status "stopped"`,
 	}, {
-		status: state.StatusAllocating,
+		status: status.StatusAllocating,
 		err:    `cannot set status "allocating"`,
 	}, {
-		status: state.StatusAllocating,
+		status: status.StatusAllocating,
 		info:   "any message",
 		err:    `cannot set status "allocating"`,
 	}, {
-		status: state.StatusLost,
+		status: status.StatusLost,
 		err:    `cannot set status "lost"`,
 	}, {
-		status: state.StatusLost,
+		status: status.StatusLost,
 		info:   "any message",
 		err:    `cannot set status "lost"`,
 	}, {
-		status: state.StatusError,
+		status: status.StatusError,
 		err:    `cannot set status "error" without info`,
 	}, {
-		status: state.StatusError,
+		status: status.StatusError,
 		info:   "some error info",
 	}, {
-		status: state.Status("bogus"),
+		status: status.Status("bogus"),
 		err:    `cannot set invalid status "bogus"`,
 	}} {
 		c.Logf("test %d", i)

--- a/state/status_unit_test.go
+++ b/state/status_unit_test.go
@@ -10,6 +10,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/status"
 )
 
 type UnitStatusSuite struct {
@@ -35,14 +36,14 @@ func (s *UnitStatusSuite) checkInitialStatus(c *gc.C) {
 }
 
 func (s *UnitStatusSuite) TestSetUnknownStatus(c *gc.C) {
-	err := s.unit.SetStatus(state.Status("vliegkat"), "orville", nil)
+	err := s.unit.SetStatus(status.Status("vliegkat"), "orville", nil)
 	c.Check(err, gc.ErrorMatches, `cannot set invalid status "vliegkat"`)
 
 	s.checkInitialStatus(c)
 }
 
 func (s *UnitStatusSuite) TestSetOverwritesData(c *gc.C) {
-	err := s.unit.SetStatus(state.StatusActive, "healthy", map[string]interface{}{
+	err := s.unit.SetStatus(status.StatusActive, "healthy", map[string]interface{}{
 		"pew.pew": "zap",
 	})
 	c.Check(err, jc.ErrorIsNil)
@@ -55,7 +56,7 @@ func (s *UnitStatusSuite) TestGetSetStatusAlive(c *gc.C) {
 }
 
 func (s *UnitStatusSuite) checkGetSetStatus(c *gc.C) {
-	err := s.unit.SetStatus(state.StatusActive, "healthy", map[string]interface{}{
+	err := s.unit.SetStatus(status.StatusActive, "healthy", map[string]interface{}{
 		"$ping": map[string]interface{}{
 			"foo.bar": 123,
 		},
@@ -67,7 +68,7 @@ func (s *UnitStatusSuite) checkGetSetStatus(c *gc.C) {
 
 	statusInfo, err := unit.Status()
 	c.Check(err, jc.ErrorIsNil)
-	c.Check(statusInfo.Status, gc.Equals, state.StatusActive)
+	c.Check(statusInfo.Status, gc.Equals, status.StatusActive)
 	c.Check(statusInfo.Message, gc.Equals, "healthy")
 	c.Check(statusInfo.Data, jc.DeepEquals, map[string]interface{}{
 		"$ping": map[string]interface{}{
@@ -102,17 +103,17 @@ func (s *UnitStatusSuite) TestGetSetStatusGone(c *gc.C) {
 	err := s.unit.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = s.unit.SetStatus(state.StatusActive, "not really", nil)
+	err = s.unit.SetStatus(status.StatusActive, "not really", nil)
 	c.Check(err, gc.ErrorMatches, `cannot set status: unit not found`)
 
 	statusInfo, err := s.unit.Status()
 	c.Check(err, gc.ErrorMatches, `cannot get status: unit not found`)
-	c.Check(statusInfo, gc.DeepEquals, state.StatusInfo{})
+	c.Check(statusInfo, gc.DeepEquals, status.StatusInfo{})
 }
 
 func (s *UnitStatusSuite) TestSetUnitStatusSince(c *gc.C) {
 	now := time.Now()
-	err := s.unit.SetStatus(state.StatusMaintenance, "", nil)
+	err := s.unit.SetStatus(status.StatusMaintenance, "", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	statusInfo, err := s.unit.Status()
 	c.Assert(err, jc.ErrorIsNil)
@@ -121,7 +122,7 @@ func (s *UnitStatusSuite) TestSetUnitStatusSince(c *gc.C) {
 	c.Assert(timeBeforeOrEqual(now, *firstTime), jc.IsTrue)
 
 	// Setting the same status a second time also updates the timestamp.
-	err = s.unit.SetStatus(state.StatusMaintenance, "", nil)
+	err = s.unit.SetStatus(status.StatusMaintenance, "", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	statusInfo, err = s.unit.Status()
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/status_unitagent_test.go
+++ b/state/status_unitagent_test.go
@@ -10,6 +10,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/status"
 )
 
 type StatusUnitAgentSuite struct {
@@ -37,21 +38,21 @@ func (s *StatusUnitAgentSuite) checkInitialStatus(c *gc.C) {
 }
 
 func (s *StatusUnitAgentSuite) TestSetUnknownStatus(c *gc.C) {
-	err := s.agent.SetStatus(state.Status("vliegkat"), "orville", nil)
+	err := s.agent.SetStatus(status.Status("vliegkat"), "orville", nil)
 	c.Check(err, gc.ErrorMatches, `cannot set invalid status "vliegkat"`)
 
 	s.checkInitialStatus(c)
 }
 
 func (s *StatusUnitAgentSuite) TestSetErrorStatusWithoutInfo(c *gc.C) {
-	err := s.agent.SetStatus(state.StatusError, "", nil)
+	err := s.agent.SetStatus(status.StatusError, "", nil)
 	c.Check(err, gc.ErrorMatches, `cannot set status "error" without info`)
 
 	s.checkInitialStatus(c)
 }
 
 func (s *StatusUnitAgentSuite) TestSetOverwritesData(c *gc.C) {
-	err := s.agent.SetStatus(state.StatusIdle, "something", map[string]interface{}{
+	err := s.agent.SetStatus(status.StatusIdle, "something", map[string]interface{}{
 		"pew.pew": "zap",
 	})
 	c.Check(err, jc.ErrorIsNil)
@@ -64,7 +65,7 @@ func (s *StatusUnitAgentSuite) TestGetSetStatusAlive(c *gc.C) {
 }
 
 func (s *StatusUnitAgentSuite) checkGetSetStatus(c *gc.C) {
-	err := s.agent.SetStatus(state.StatusIdle, "something", map[string]interface{}{
+	err := s.agent.SetStatus(status.StatusIdle, "something", map[string]interface{}{
 		"$foo":    "bar",
 		"baz.qux": "ping",
 		"pong": map[string]interface{}{
@@ -79,7 +80,7 @@ func (s *StatusUnitAgentSuite) checkGetSetStatus(c *gc.C) {
 
 	statusInfo, err := agent.Status()
 	c.Check(err, jc.ErrorIsNil)
-	c.Check(statusInfo.Status, gc.Equals, state.StatusIdle)
+	c.Check(statusInfo.Status, gc.Equals, status.StatusIdle)
 	c.Check(statusInfo.Message, gc.Equals, "something")
 	c.Check(statusInfo.Data, jc.DeepEquals, map[string]interface{}{
 		"$foo":    "bar",
@@ -116,16 +117,16 @@ func (s *StatusUnitAgentSuite) TestGetSetStatusGone(c *gc.C) {
 	err := s.unit.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = s.agent.SetStatus(state.StatusIdle, "not really", nil)
+	err = s.agent.SetStatus(status.StatusIdle, "not really", nil)
 	c.Check(err, gc.ErrorMatches, `cannot set status: agent not found`)
 
 	statusInfo, err := s.agent.Status()
 	c.Check(err, gc.ErrorMatches, `cannot get status: agent not found`)
-	c.Check(statusInfo, gc.DeepEquals, state.StatusInfo{})
+	c.Check(statusInfo, gc.DeepEquals, status.StatusInfo{})
 }
 
 func (s *StatusUnitAgentSuite) TestGetSetErrorStatus(c *gc.C) {
-	err := s.agent.SetStatus(state.StatusError, "test-hook failed", map[string]interface{}{
+	err := s.agent.SetStatus(status.StatusError, "test-hook failed", map[string]interface{}{
 		"foo": "bar",
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -133,7 +134,7 @@ func (s *StatusUnitAgentSuite) TestGetSetErrorStatus(c *gc.C) {
 	// Agent error is reported as unit error.
 	statusInfo, err := s.unit.Status()
 	c.Check(err, jc.ErrorIsNil)
-	c.Check(statusInfo.Status, gc.Equals, state.StatusError)
+	c.Check(statusInfo.Status, gc.Equals, status.StatusError)
 	c.Check(statusInfo.Message, gc.Equals, "test-hook failed")
 	c.Check(statusInfo.Data, gc.DeepEquals, map[string]interface{}{
 		"foo": "bar",
@@ -142,7 +143,7 @@ func (s *StatusUnitAgentSuite) TestGetSetErrorStatus(c *gc.C) {
 	// For agents, error is reported as idle.
 	statusInfo, err = s.agent.Status()
 	c.Check(err, jc.ErrorIsNil)
-	c.Check(statusInfo.Status, gc.Equals, state.StatusIdle)
+	c.Check(statusInfo.Status, gc.Equals, status.StatusIdle)
 	c.Check(statusInfo.Message, gc.Equals, "")
 	c.Check(statusInfo.Data, gc.HasLen, 0)
 }
@@ -153,7 +154,7 @@ func timeBeforeOrEqual(timeBefore, timeOther time.Time) bool {
 
 func (s *StatusUnitAgentSuite) TestSetAgentStatusSince(c *gc.C) {
 	now := time.Now()
-	err := s.agent.SetStatus(state.StatusIdle, "", nil)
+	err := s.agent.SetStatus(status.StatusIdle, "", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	statusInfo, err := s.agent.Status()
 	c.Assert(err, jc.ErrorIsNil)
@@ -162,7 +163,7 @@ func (s *StatusUnitAgentSuite) TestSetAgentStatusSince(c *gc.C) {
 	c.Assert(timeBeforeOrEqual(now, *firstTime), jc.IsTrue)
 
 	// Setting the same status a second time also updates the timestamp.
-	err = s.agent.SetStatus(state.StatusIdle, "", nil)
+	err = s.agent.SetStatus(status.StatusIdle, "", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	statusInfo, err = s.agent.Status()
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/status_util_test.go
+++ b/state/status_util_test.go
@@ -8,12 +8,13 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/status"
 )
 
-type statusHistoryFunc func(int) ([]state.StatusInfo, error)
+type statusHistoryFunc func(int) ([]status.StatusInfo, error)
 
-func checkInitialWorkloadStatus(c *gc.C, statusInfo state.StatusInfo) {
-	c.Check(statusInfo.Status, gc.Equals, state.StatusUnknown)
+func checkInitialWorkloadStatus(c *gc.C, statusInfo status.StatusInfo) {
+	c.Check(statusInfo.Status, gc.Equals, status.StatusUnknown)
 	c.Check(statusInfo.Message, gc.Equals, "Waiting for agent initialization to finish")
 	c.Check(statusInfo.Data, gc.HasLen, 0)
 	c.Check(statusInfo.Since, gc.NotNil)
@@ -21,20 +22,20 @@ func checkInitialWorkloadStatus(c *gc.C, statusInfo state.StatusInfo) {
 
 func primeUnitStatusHistory(c *gc.C, unit *state.Unit, count int) {
 	for i := 0; i < count; i++ {
-		err := unit.SetStatus(state.StatusActive, "", map[string]interface{}{"$foo": i})
+		err := unit.SetStatus(status.StatusActive, "", map[string]interface{}{"$foo": i})
 		c.Assert(err, gc.IsNil)
 	}
 }
 
-func checkPrimedUnitStatus(c *gc.C, statusInfo state.StatusInfo, expect int) {
-	c.Check(statusInfo.Status, gc.Equals, state.StatusActive)
+func checkPrimedUnitStatus(c *gc.C, statusInfo status.StatusInfo, expect int) {
+	c.Check(statusInfo.Status, gc.Equals, status.StatusActive)
 	c.Check(statusInfo.Message, gc.Equals, "")
 	c.Check(statusInfo.Data, jc.DeepEquals, map[string]interface{}{"$foo": expect})
 	c.Check(statusInfo.Since, gc.NotNil)
 }
 
-func checkInitialUnitAgentStatus(c *gc.C, statusInfo state.StatusInfo) {
-	c.Check(statusInfo.Status, gc.Equals, state.StatusAllocating)
+func checkInitialUnitAgentStatus(c *gc.C, statusInfo status.StatusInfo) {
+	c.Check(statusInfo.Status, gc.Equals, status.StatusAllocating)
 	c.Check(statusInfo.Message, gc.Equals, "")
 	c.Check(statusInfo.Data, gc.HasLen, 0)
 	c.Assert(statusInfo.Since, gc.NotNil)
@@ -42,13 +43,13 @@ func checkInitialUnitAgentStatus(c *gc.C, statusInfo state.StatusInfo) {
 
 func primeUnitAgentStatusHistory(c *gc.C, agent *state.UnitAgent, count int) {
 	for i := 0; i < count; i++ {
-		err := agent.SetStatus(state.StatusExecuting, "", map[string]interface{}{"$bar": i})
+		err := agent.SetStatus(status.StatusExecuting, "", map[string]interface{}{"$bar": i})
 		c.Assert(err, gc.IsNil)
 	}
 }
 
-func checkPrimedUnitAgentStatus(c *gc.C, statusInfo state.StatusInfo, expect int) {
-	c.Check(statusInfo.Status, gc.Equals, state.StatusExecuting)
+func checkPrimedUnitAgentStatus(c *gc.C, statusInfo status.StatusInfo, expect int) {
+	c.Check(statusInfo.Status, gc.Equals, status.StatusExecuting)
 	c.Check(statusInfo.Message, gc.Equals, "")
 	c.Check(statusInfo.Data, jc.DeepEquals, map[string]interface{}{"$bar": expect})
 	c.Check(statusInfo.Since, gc.NotNil)

--- a/state/unit.go
+++ b/state/unit.go
@@ -23,6 +23,7 @@ import (
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state/presence"
+	"github.com/juju/juju/status"
 	"github.com/juju/juju/tools"
 	"github.com/juju/juju/version"
 )
@@ -112,7 +113,7 @@ type Unit struct {
 	st  *State
 	doc unitDoc
 	presence.Presencer
-	StatusHistoryGetter
+	status.StatusHistoryGetter
 }
 
 func newUnit(st *State, udoc *unitDoc) *Unit {
@@ -395,14 +396,14 @@ func (u *Unit) destroyOps() ([]txn.Op, error) {
 	} else if agentErr != nil {
 		return nil, errors.Trace(agentErr)
 	}
-	if agentStatusInfo.Status != StatusAllocating {
+	if agentStatusInfo.Status != status.StatusAllocating {
 		return setDyingOps, nil
 	}
 
 	ops := []txn.Op{{
 		C:      statusesC,
 		Id:     u.st.docID(agentStatusDocId),
-		Assert: bson.D{{"status", StatusAllocating}},
+		Assert: bson.D{{"status", status.StatusAllocating}},
 	}, minUnitsOp}
 	removeAsserts := append(isAliveDoc, bson.DocElem{
 		"$and", []bson.D{
@@ -787,29 +788,29 @@ func (u *Unit) Agent() *UnitAgent {
 
 // AgentHistory returns an StatusHistoryGetter which can
 //be used to query the status history of the unit's agent.
-func (u *Unit) AgentHistory() StatusHistoryGetter {
+func (u *Unit) AgentHistory() status.StatusHistoryGetter {
 	return u.Agent()
 }
 
 // SetAgentStatus calls SetStatus for this unit's agent, this call
 // is equivalent to the former call to SetStatus when Agent and Unit
 // where not separate entities.
-func (u *Unit) SetAgentStatus(status Status, info string, data map[string]interface{}) error {
+func (u *Unit) SetAgentStatus(agentStatus status.Status, info string, data map[string]interface{}) error {
 	agent := newUnitAgent(u.st, u.Tag(), u.Name())
-	return agent.SetStatus(status, info, data)
+	return agent.SetStatus(agentStatus, info, data)
 }
 
 // AgentStatus calls Status for this unit's agent, this call
 // is equivalent to the former call to Status when Agent and Unit
 // where not separate entities.
-func (u *Unit) AgentStatus() (StatusInfo, error) {
+func (u *Unit) AgentStatus() (status.StatusInfo, error) {
 	agent := newUnitAgent(u.st, u.Tag(), u.Name())
 	return agent.Status()
 }
 
 // StatusHistory returns a slice of at most <size> StatusInfo items
 // representing past statuses for this unit.
-func (u *Unit) StatusHistory(size int) ([]StatusInfo, error) {
+func (u *Unit) StatusHistory(size int) ([]status.StatusInfo, error) {
 	return statusHistory(u.st, u.globalKey(), size)
 }
 
@@ -817,7 +818,7 @@ func (u *Unit) StatusHistory(size int) ([]StatusInfo, error) {
 // This method relies on globalKey instead of globalAgentKey since it is part of
 // the effort to separate Unit from UnitAgent. Now the Status for UnitAgent is in
 // the UnitAgent struct.
-func (u *Unit) Status() (StatusInfo, error) {
+func (u *Unit) Status() (status.StatusInfo, error) {
 	// The current health spec says when a hook error occurs, the workload should
 	// be in error state, but the state model more correctly records the agent
 	// itself as being in error. So we'll do that model translation here.
@@ -825,12 +826,12 @@ func (u *Unit) Status() (StatusInfo, error) {
 	// For now, pretend we're always reading the unit status.
 	info, err := getStatus(u.st, u.globalAgentKey(), "unit")
 	if err != nil {
-		return StatusInfo{}, err
+		return status.StatusInfo{}, err
 	}
-	if info.Status != StatusError {
+	if info.Status != status.StatusError {
 		info, err = getStatus(u.st, u.globalKey(), "unit")
 		if err != nil {
-			return StatusInfo{}, err
+			return status.StatusInfo{}, err
 		}
 	}
 	return info, nil
@@ -841,14 +842,14 @@ func (u *Unit) Status() (StatusInfo, error) {
 // This method relies on globalKey instead of globalAgentKey since it is part of
 // the effort to separate Unit from UnitAgent. Now the SetStatus for UnitAgent is in
 // the UnitAgent struct.
-func (u *Unit) SetStatus(status Status, info string, data map[string]interface{}) error {
-	if !ValidWorkloadStatus(status) {
-		return errors.Errorf("cannot set invalid status %q", status)
+func (u *Unit) SetStatus(unitStatus status.Status, info string, data map[string]interface{}) error {
+	if !status.ValidWorkloadStatus(unitStatus) {
+		return errors.Errorf("cannot set invalid status %q", unitStatus)
 	}
 	return setStatus(u.st, setStatusParams{
 		badge:     "unit",
 		globalKey: u.globalKey(),
-		status:    status,
+		status:    unitStatus,
 		message:   info,
 		rawData:   data,
 	})
@@ -2133,7 +2134,7 @@ func (u *Unit) Resolve(retryHooks bool) error {
 	if err != nil {
 		return err
 	}
-	if statusInfo.Status != StatusError {
+	if statusInfo.Status != status.StatusError {
 		return errors.Errorf("unit %q is not in an error state", u)
 	}
 	mode := ResolvedNoHooks

--- a/state/unit_test.go
+++ b/state/unit_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/testing"
+	"github.com/juju/juju/status"
 	coretesting "github.com/juju/juju/testing"
 )
 
@@ -676,7 +677,7 @@ func (s *UnitSuite) TestSetCharmURLRetriesWithDifferentURL(c *gc.C) {
 
 func (s *UnitSuite) TestDestroySetStatusRetry(c *gc.C) {
 	defer state.SetRetryHooks(c, s.State, func() {
-		err := s.unit.SetAgentStatus(state.StatusIdle, "", nil)
+		err := s.unit.SetAgentStatus(status.StatusIdle, "", nil)
 		c.Assert(err, jc.ErrorIsNil)
 	}, func() {
 		assertLife(c, s.unit, state.Dying)
@@ -779,16 +780,16 @@ func (s *UnitSuite) TestCannotShortCircuitDestroyWithSubordinates(c *gc.C) {
 
 func (s *UnitSuite) TestCannotShortCircuitDestroyWithAgentStatus(c *gc.C) {
 	for i, test := range []struct {
-		status state.Status
+		status status.Status
 		info   string
 	}{{
-		state.StatusExecuting, "blah",
+		status.StatusExecuting, "blah",
 	}, {
-		state.StatusIdle, "blah",
+		status.StatusIdle, "blah",
 	}, {
-		state.StatusFailed, "blah",
+		status.StatusFailed, "blah",
 	}, {
-		state.StatusRebooting, "blah",
+		status.StatusRebooting, "blah",
 	}} {
 		c.Logf("test %d: %s", i, test.status)
 		unit, err := s.service.AddUnit()
@@ -905,7 +906,7 @@ func (s *UnitSuite) TestResolve(c *gc.C) {
 	err = s.unit.Resolve(true)
 	c.Assert(err, gc.ErrorMatches, `unit "wordpress/0" is not in an error state`)
 
-	err = s.unit.SetAgentStatus(state.StatusError, "gaaah", nil)
+	err = s.unit.SetAgentStatus(status.StatusError, "gaaah", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.unit.Resolve(false)
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/juju/errors"
+	"github.com/juju/juju/status"
 	"github.com/juju/loggo"
 	"github.com/juju/names"
 	"gopkg.in/mgo.v2/bson"
@@ -125,9 +126,9 @@ func AddFilesystemStatus(st *State) error {
 // If the filesystem has not been provisioned, then it should be Pending;
 // if it has been provisioned, but there is an unprovisioned attachment, then
 // it should be Attaching; otherwise it is Attached.
-func upgradingFilesystemStatus(st *State, filesystem Filesystem) (Status, error) {
+func upgradingFilesystemStatus(st *State, filesystem Filesystem) (status.Status, error) {
 	if _, err := filesystem.Info(); errors.IsNotProvisioned(err) {
-		return StatusPending, nil
+		return status.StatusPending, nil
 	}
 	attachments, err := st.FilesystemAttachments(filesystem.FilesystemTag())
 	if err != nil {
@@ -136,10 +137,10 @@ func upgradingFilesystemStatus(st *State, filesystem Filesystem) (Status, error)
 	for _, attachment := range attachments {
 		_, err := attachment.Info()
 		if errors.IsNotProvisioned(err) {
-			return StatusAttaching, nil
+			return status.StatusAttaching, nil
 		}
 	}
-	return StatusAttached, nil
+	return status.StatusAttached, nil
 }
 
 // MigrateSettingsSchema migrates the schema of the settings collection,

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -12,6 +12,7 @@ import (
 	"gopkg.in/mgo.v2/txn"
 
 	"github.com/juju/juju/network"
+	"github.com/juju/juju/status"
 	"github.com/juju/juju/storage/provider"
 	"github.com/juju/juju/storage/provider/registry"
 )
@@ -263,16 +264,16 @@ func (s *upgradesSuite) TestAddFilesystemStatus(c *gc.C) {
 	removeStatusDoc(c, s.state, filesystem)
 	_, err := filesystem.Status()
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
-	s.assertAddFilesystemStatus(c, filesystem, StatusPending)
+	s.assertAddFilesystemStatus(c, filesystem, status.StatusPending)
 }
 
 func (s *upgradesSuite) TestAddFilesystemStatusDoesNotOverwrite(c *gc.C) {
 	_, _, filesystem, cleanup := setupMachineBoundStorageTests(c, s.state)
 	defer cleanup()
 
-	err := filesystem.SetStatus(StatusDestroying, "", nil)
+	err := filesystem.SetStatus(status.StatusDestroying, "", nil)
 	c.Assert(err, jc.ErrorIsNil)
-	s.assertAddFilesystemStatus(c, filesystem, StatusDestroying)
+	s.assertAddFilesystemStatus(c, filesystem, status.StatusDestroying)
 }
 
 func (s *upgradesSuite) TestAddFilesystemStatusProvisioned(c *gc.C) {
@@ -284,7 +285,7 @@ func (s *upgradesSuite) TestAddFilesystemStatusProvisioned(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	removeStatusDoc(c, s.state, filesystem)
-	s.assertAddFilesystemStatus(c, filesystem, StatusAttaching)
+	s.assertAddFilesystemStatus(c, filesystem, status.StatusAttaching)
 }
 
 func (s *upgradesSuite) TestAddFilesystemStatusAttached(c *gc.C) {
@@ -307,10 +308,10 @@ func (s *upgradesSuite) TestAddFilesystemStatusAttached(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	removeStatusDoc(c, s.state, filesystem)
-	s.assertAddFilesystemStatus(c, filesystem, StatusAttached)
+	s.assertAddFilesystemStatus(c, filesystem, status.StatusAttached)
 }
 
-func (s *upgradesSuite) assertAddFilesystemStatus(c *gc.C, filesystem Filesystem, expect Status) {
+func (s *upgradesSuite) assertAddFilesystemStatus(c *gc.C, filesystem Filesystem, expect status.Status) {
 	err := AddFilesystemStatus(s.state)
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/state/volume.go
+++ b/state/volume.go
@@ -15,6 +15,7 @@ import (
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
 
+	"github.com/juju/juju/status"
 	"github.com/juju/juju/storage"
 )
 
@@ -22,8 +23,8 @@ import (
 type Volume interface {
 	GlobalEntity
 	LifeBinder
-	StatusGetter
-	StatusSetter
+	status.StatusGetter
+	status.StatusSetter
 
 	// VolumeTag returns the tag for the volume.
 	VolumeTag() names.VolumeTag
@@ -236,13 +237,13 @@ func (v *volume) Params() (VolumeParams, bool) {
 }
 
 // Status is required to implement StatusGetter.
-func (v *volume) Status() (StatusInfo, error) {
+func (v *volume) Status() (status.StatusInfo, error) {
 	return v.st.VolumeStatus(v.VolumeTag())
 }
 
 // SetStatus is required to implement StatusSetter.
-func (v *volume) SetStatus(status Status, info string, data map[string]interface{}) error {
-	return v.st.SetVolumeStatus(v.VolumeTag(), status, info, data)
+func (v *volume) SetStatus(volumeStatus status.Status, info string, data map[string]interface{}) error {
+	return v.st.SetVolumeStatus(v.VolumeTag(), volumeStatus, info, data)
 }
 
 // Volume is required to implement VolumeAttachment.
@@ -747,7 +748,7 @@ func (st *State) addVolumeOps(params VolumeParams, machineId string) ([]txn.Op, 
 	}
 	ops := []txn.Op{
 		createStatusOp(st, volumeGlobalKey(name), statusDoc{
-			Status:  StatusPending,
+			Status:  status.StatusPending,
 			Updated: time.Now().UnixNano(),
 		}),
 		{
@@ -1026,19 +1027,19 @@ func volumeGlobalKey(name string) string {
 }
 
 // VolumeStatus returns the status of the specified volume.
-func (st *State) VolumeStatus(tag names.VolumeTag) (StatusInfo, error) {
+func (st *State) VolumeStatus(tag names.VolumeTag) (status.StatusInfo, error) {
 	return getStatus(st, volumeGlobalKey(tag.Id()), "volume")
 }
 
 // SetVolumeStatus sets the status of the specified volume.
-func (st *State) SetVolumeStatus(tag names.VolumeTag, status Status, info string, data map[string]interface{}) error {
-	switch status {
-	case StatusAttaching, StatusAttached, StatusDetaching, StatusDetached, StatusDestroying:
-	case StatusError:
+func (st *State) SetVolumeStatus(tag names.VolumeTag, volumeStatus status.Status, info string, data map[string]interface{}) error {
+	switch volumeStatus {
+	case status.StatusAttaching, status.StatusAttached, status.StatusDetaching, status.StatusDetached, status.StatusDestroying:
+	case status.StatusError:
 		if info == "" {
-			return errors.Errorf("cannot set status %q without info", status)
+			return errors.Errorf("cannot set status %q without info", volumeStatus)
 		}
-	case StatusPending:
+	case status.StatusPending:
 		// If a volume is not yet provisioned, we allow its status
 		// to be set back to pending (when a retry is to occur).
 		v, err := st.Volume(tag)
@@ -1049,14 +1050,14 @@ func (st *State) SetVolumeStatus(tag names.VolumeTag, status Status, info string
 		if errors.IsNotProvisioned(err) {
 			break
 		}
-		return errors.Errorf("cannot set status %q", status)
+		return errors.Errorf("cannot set status %q", volumeStatus)
 	default:
-		return errors.Errorf("cannot set invalid status %q", status)
+		return errors.Errorf("cannot set invalid status %q", volumeStatus)
 	}
 	return setStatus(st, setStatusParams{
 		badge:     "volume",
 		globalKey: volumeGlobalKey(tag.Id()),
-		status:    status,
+		status:    volumeStatus,
 		message:   info,
 		rawData:   data,
 	})

--- a/status/status.go
+++ b/status/status.go
@@ -1,11 +1,9 @@
-// Copyright 2014 Canonical Ltd.
+// Copyright 2013 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package state
+package status
 
-import (
-	"time"
-)
+import "time"
 
 // Status used to represent the status of an entity, but has recently become
 // and applies to "workloads" as well, which we don't currently model, for no
@@ -38,13 +36,19 @@ type StatusHistoryGetter interface {
 	StatusHistory(size int) ([]StatusInfo, error)
 }
 
-// Status values common to machine and unit agents.
-const (
+// InstanceStatusHistoryGetter instances can fetch their instance status history.
+type InstanceStatusHistoryGetter interface {
+	InstanceStatusHistory(size int) ([]StatusInfo, error)
+}
 
-	// The entity requires human intervention in order to operate
-	// correctly.
+const (
+	// Status values common to machine and unit agents.
+
+	// StatusError means the entity requires human intervention
+	// in order to operate correctly.
 	StatusError Status = "error"
 
+	// StatusStarted is set when:
 	// The entity is actively participating in the model.
 	// For unit agents, this is a state we preserve for backwards
 	// compatibility with scripts during the life of Juju 1.x.
@@ -53,108 +57,124 @@ const (
 	StatusStarted Status = "started"
 )
 
-// Status values specific to machine agents.
 const (
+	// Status values specific to machine agents.
 
+	// StatusPending is set when:
 	// The machine is not yet participating in the model.
 	StatusPending Status = "pending"
 
+	// StatusStopped is set when:
 	// The machine's agent will perform no further action, other than
 	// to set the unit to Dead at a suitable moment.
 	StatusStopped Status = "stopped"
 
+	// StatusDown is set when:
 	// The machine ought to be signalling activity, but it cannot be
 	// detected.
 	StatusDown Status = "down"
 )
 
-// Status values specific to unit agents.
 const (
+	// Status values specific to unit agents.
 
+	// StatusAllocating is set when:
 	// The machine on which a unit is to be hosted is still being
 	// spun up in the cloud.
 	StatusAllocating Status = "allocating"
 
+	// StatusRebooting is set when:
 	// The machine on which this agent is running is being rebooted.
 	// The juju-agent should move from rebooting to idle when the reboot is complete.
 	StatusRebooting Status = "rebooting"
 
+	// StatusExecuting is set when:
 	// The agent is running a hook or action. The human-readable message should reflect
 	// which hook or action is being run.
 	StatusExecuting Status = "executing"
 
+	// StatusIdle is set when:
 	// Once the agent is installed and running it will notify the Juju server and its state
 	// becomes "idle". It will stay "idle" until some action (e.g. it needs to run a hook) or
 	// error (e.g it loses contact with the Juju server) moves it to a different state.
 	StatusIdle Status = "idle"
 
+	// StatusFailed is set when:
 	// The unit agent has failed in some way,eg the agent ought to be signalling
 	// activity, but it cannot be detected. It might also be that the unit agent
 	// detected an unrecoverable condition and managed to tell the Juju server about it.
 	StatusFailed Status = "failed"
 
+	// StatusLost is set when:
 	// The juju agent has has not communicated with the juju server for an unexpectedly long time;
 	// the unit agent ought to be signalling activity, but none has been detected.
 	StatusLost Status = "lost"
-
-	// ---- Outdated ----
-	// The unit agent is downloading the charm and running the install hook.
-	StatusInstalling Status = "installing"
-
-	// The unit is being destroyed; the agent will soon mark the unit as “dead”.
-	// In Juju 2.x this will describe the state of the agent rather than a unit.
-	StatusStopping Status = "stopping"
 )
 
-// Status values specific to services and units, reflecting the
-// state of the software itself.
 const (
+	// Status values specific to services and units, reflecting the
+	// state of the software itself.
 
+	// StatusMaintenance is set when:
 	// The unit is not yet providing services, but is actively doing stuff
 	// in preparation for providing those services.
 	// This is a "spinning" state, not an error state.
 	// It reflects activity on the unit itself, not on peers or related units.
 	StatusMaintenance Status = "maintenance"
 
+	// StatusTerminated is set when:
 	// This unit used to exist, we have a record of it (perhaps because of storage
 	// allocated for it that was flagged to survive it). Nonetheless, it is now gone.
 	StatusTerminated Status = "terminated"
 
+	// StatusUnknown is set when:
 	// A unit-agent has finished calling install, config-changed, and start,
 	// but the charm has not called status-set yet.
 	StatusUnknown Status = "unknown"
 
+	// StatusWaiting is set when:
 	// The unit is unable to progress to an active state because a service to
 	// which it is related is not running.
 	StatusWaiting Status = "waiting"
 
-	// The unit needs manual intervention to get back to the Active state.
+	// StatusBlocked is set when:
+	// The unit needs manual intervention to get back to the Running state.
 	StatusBlocked Status = "blocked"
 
+	// StatusActive is set when:
 	// The unit believes it is correctly offering all the services it has
 	// been asked to offer.
 	StatusActive Status = "active"
 )
 
-// Status values specific to storage.
 const (
-	// StatusAttaching indicates that the storage is being attached to a
-	// machine.
+	// Status values specific to storage.
+
+	// StatusAttaching indicates that the storage is being attached
+	// to a machine.
 	StatusAttaching Status = "attaching"
 
-	// StatusDetaching indicates that the storage is attached to a machine.
+	// StatusAttached indicates that the storage is attached to a
+	// machine.
 	StatusAttached Status = "attached"
 
 	// StatusDetaching indicates that the storage is being detached
 	// from a machine.
 	StatusDetaching Status = "detaching"
 
-	// StatusDetached indicates that the storage is not attached to any
-	// machine.
+	// StatusDetached indicates that the storage is not attached to
+	// any machine.
 	StatusDetached Status = "detached"
 
 	// StatusDestroying indicates that the storage is being destroyed.
 	StatusDestroying Status = "destroying"
+)
+
+// InstanceStatus
+const (
+	StatusProvisioning      Status = "allocating"
+	StatusRunning           Status = "running"
+	StatusProvisioningError Status = "provisioning error"
 )
 
 const (
@@ -182,15 +202,6 @@ func (status Status) KnownAgentStatus() bool {
 		StatusExecuting,
 		StatusIdle:
 		return true
-	case //Deprecated status vales
-		StatusPending,
-		StatusStarted,
-		StatusStopped,
-		StatusInstalling,
-		StatusActive,
-		StatusStopping,
-		StatusDown:
-		return true
 	default:
 		return false
 	}
@@ -205,13 +216,6 @@ func (status Status) KnownWorkloadStatus() bool {
 	}
 	switch status {
 	case StatusError: // include error so that we can filter on what the spec says is valid
-		return true
-	case // Deprecated statuses
-		StatusPending,
-		StatusInstalling,
-		StatusStarted,
-		StatusStopped,
-		StatusDown:
 		return true
 	default:
 		return false
@@ -239,16 +243,6 @@ func ValidWorkloadStatus(status Status) bool {
 // taking into account that the candidate may be a legacy
 // status value which has been deprecated.
 func (status Status) WorkloadMatches(candidate Status) bool {
-	switch candidate {
-	case status: // We could be holding an old status ourselves
-		return true
-	case StatusDown, StatusStopped:
-		candidate = StatusTerminated
-	case StatusInstalling:
-		candidate = StatusMaintenance
-	case StatusStarted:
-		candidate = StatusActive
-	}
 	return status == candidate
 }
 
@@ -256,55 +250,5 @@ func (status Status) WorkloadMatches(candidate Status) bool {
 // taking into account that the candidate may be a legacy
 // status value which has been deprecated.
 func (status Status) Matches(candidate Status) bool {
-	switch candidate {
-	case StatusDown:
-		candidate = StatusLost
-	case StatusStarted:
-		candidate = StatusActive
-	case StatusStopped:
-		candidate = StatusStopping
-	}
 	return status == candidate
-}
-
-// TranslateLegacyAgentStatus returns the status value clients expect to see for
-// agent-state in versions prior to 1.24
-func TranslateToLegacyAgentState(agentStatus, workloadStatus Status, workloadMessage string) (Status, bool) {
-	// Originally AgentState (a member of api.UnitStatus) could hold one of:
-	// StatusPending
-	// StatusInstalled
-	// StatusStarted
-	// StatusStopped
-	// StatusError
-	// StatusDown
-	// For compatibility reasons we convert modern states (from V2 uniter) into
-	// four of the old ones: StatusPending, StatusStarted, StatusStopped, or StatusError.
-
-	// For the purposes of deriving the legacy status, there's currently no better
-	// way to determine if a unit is installed.
-	// TODO(wallyworld) - use status history to see if start hook has run.
-	isInstalled := workloadStatus != StatusMaintenance || workloadMessage != MessageInstalling
-
-	switch agentStatus {
-	case StatusAllocating:
-		return StatusPending, true
-	case StatusError:
-		return StatusError, true
-	case StatusRebooting, StatusExecuting, StatusIdle, StatusLost, StatusFailed:
-		switch workloadStatus {
-		case StatusError:
-			return StatusError, true
-		case StatusTerminated:
-			return StatusStopped, true
-		case StatusMaintenance:
-			if isInstalled {
-				return StatusStarted, true
-			} else {
-				return StatusPending, true
-			}
-		default:
-			return StatusStarted, true
-		}
-	}
-	return "", false
 }

--- a/testing/factory/factory.go
+++ b/testing/factory/factory.go
@@ -21,6 +21,7 @@ import (
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/status"
 	"github.com/juju/juju/testcharms"
 	"github.com/juju/juju/testing"
 )
@@ -83,7 +84,7 @@ type ServiceParams struct {
 	Name    string
 	Charm   *state.Charm
 	Creator names.Tag
-	Status  *state.StatusInfo
+	Status  *status.StatusInfo
 }
 
 // UnitParams are used to create units.
@@ -92,7 +93,7 @@ type UnitParams struct {
 	Machine     *state.Machine
 	Password    string
 	SetCharmURL bool
-	Status      *state.StatusInfo
+	Status      *status.StatusInfo
 }
 
 // RelationParams are used to create relations.

--- a/worker/deployer/deployer_test.go
+++ b/worker/deployer/deployer_test.go
@@ -16,6 +16,7 @@ import (
 	apideployer "github.com/juju/juju/api/deployer"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/status"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/deployer"
@@ -76,7 +77,7 @@ func (s *deployerSuite) TestDeployRecallRemovePrincipals(c *gc.C) {
 	s.waitFor(c, isDeployed(ctx, u0.Name(), u1.Name()))
 
 	// Cause a unit to become Dying, and check no change.
-	err = u1.SetAgentStatus(state.StatusIdle, "", nil)
+	err = u1.SetAgentStatus(status.StatusIdle, "", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	err = u1.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
@@ -119,7 +120,7 @@ func (s *deployerSuite) TestRemoveNonAlivePrincipals(c *gc.C) {
 	// note: this is not a sane state; for the unit to have a status it must
 	// have been deployed. But it's instructive to check that the right thing
 	// would happen if it were possible to have a dying unit in this situation.
-	err = u1.SetAgentStatus(state.StatusIdle, "", nil)
+	err = u1.SetAgentStatus(status.StatusIdle, "", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	err = u1.Destroy()
 	c.Assert(err, jc.ErrorIsNil)

--- a/worker/instancepoller/aggregate_test.go
+++ b/worker/instancepoller/aggregate_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/network"
+	"github.com/juju/juju/status"
 	"github.com/juju/juju/testing"
 )
 
@@ -46,8 +47,8 @@ func (t *testInstance) Addresses() ([]network.Address, error) {
 	return t.addresses, nil
 }
 
-func (t *testInstance) Status() string {
-	return t.status
+func (t *testInstance) Status() instance.InstanceStatus {
+	return instance.InstanceStatus{Status: status.StatusUnknown, Message: t.status}
 }
 
 type testInstanceGetter struct {
@@ -91,7 +92,7 @@ func (s *aggregateSuite) TestSingleRequest(c *gc.C) {
 	info, err := aggregator.instanceInfo("foo")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(info, gc.DeepEquals, instanceInfo{
-		status:    "foobar",
+		status:    instance.InstanceStatus{Status: status.StatusUnknown, Message: "foobar"},
 		addresses: instance1.addresses,
 	})
 	c.Assert(testGetter.ids, gc.DeepEquals, []instance.Id{"foo"})
@@ -120,7 +121,7 @@ func (s *aggregateSuite) TestMultipleResponseHandling(c *gc.C) {
 	checkInfo := func(id instance.Id, expectStatus string) {
 		info, err := aggregator.instanceInfo(id)
 		c.Check(err, jc.ErrorIsNil)
-		c.Check(info.status, gc.Equals, expectStatus)
+		c.Check(info.status.Message, gc.Equals, expectStatus)
 		wg.Done()
 	}
 

--- a/worker/instancepoller/updater.go
+++ b/worker/instancepoller/updater.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/network"
+	"github.com/juju/juju/status"
 	"github.com/juju/juju/watcher"
 )
 
@@ -38,8 +39,8 @@ type machine interface {
 	InstanceId() (instance.Id, error)
 	ProviderAddresses() ([]network.Address, error)
 	SetProviderAddresses(...network.Address) error
-	InstanceStatus() (string, error)
-	SetInstanceStatus(status string) error
+	InstanceStatus() (params.StatusResult, error)
+	SetInstanceStatus(status.Status, string, map[string]interface{}) error
 	String() string
 	Refresh() error
 	Life() params.Life
@@ -49,7 +50,7 @@ type machine interface {
 
 type instanceInfo struct {
 	addresses []network.Address
-	status    string
+	status    instance.InstanceStatus
 }
 
 // lifetimeContext was extracted to allow the various context clients to get
@@ -189,7 +190,7 @@ func machineLoop(context machineContext, m machine, changed <-chan struct{}) err
 			if err != nil && !params.IsCodeNotProvisioned(err) {
 				return err
 			}
-			machineStatus := params.StatusPending
+			machineStatus := status.StatusPending
 			if err == nil {
 				if statusInfo, err := m.Status(); err != nil {
 					logger.Warningf("cannot get current machine status for machine %v: %v", m.Id(), err)
@@ -197,13 +198,15 @@ func machineLoop(context machineContext, m machine, changed <-chan struct{}) err
 					machineStatus = statusInfo.Status
 				}
 			}
-			if len(instInfo.addresses) > 0 && instInfo.status != "" && machineStatus == params.StatusStarted {
-				// We've got at least one address and a status and instance is started, so poll infrequently.
-				pollInterval = LongPoll
-			} else if pollInterval < LongPoll {
-				// We have no addresses or not started - poll increasingly rarely
-				// until we do.
-				pollInterval = time.Duration(float64(pollInterval) * ShortPollBackoff)
+			if instInfo.status.Status != status.StatusProvisioning && instInfo.status.Status != status.StatusPending {
+				if len(instInfo.addresses) > 0 && machineStatus == status.StatusStarted {
+					// We've got at least one address and a status and instance is started, so poll infrequently.
+					pollInterval = LongPoll
+				} else if pollInterval < LongPoll {
+					// We have no addresses or not started - poll increasingly rarely
+					// until we do.
+					pollInterval = time.Duration(float64(pollInterval) * ShortPollBackoff)
+				}
 			}
 			pollInstance = false
 		}
@@ -244,16 +247,20 @@ func pollInstanceInfo(context machineContext, m machine) (instInfo instanceInfo,
 		logger.Warningf("cannot get instance info for instance %q: %v", instId, err)
 		return instInfo, nil
 	}
-	currentInstStatus, err := m.InstanceStatus()
+	instStat, err := m.InstanceStatus()
 	if err != nil {
 		// This should never occur since the machine is provisioned.
 		// But just in case, we reset polled status so we try again next time.
 		logger.Warningf("cannot get current instance status for machine %v: %v", m.Id(), err)
-		instInfo.status = ""
+		instInfo.status = instance.InstanceStatus{status.StatusUnknown, ""}
 	} else {
+		currentInstStatus := instance.InstanceStatus{
+			Status:  instStat.Status,
+			Message: instStat.Info,
+		}
 		if instInfo.status != currentInstStatus {
 			logger.Infof("machine %q instance status changed from %q to %q", m.Id(), currentInstStatus, instInfo.status)
-			if err = m.SetInstanceStatus(instInfo.status); err != nil {
+			if err = m.SetInstanceStatus(instInfo.status.Status, instInfo.status.Message, nil); err != nil {
 				logger.Errorf("cannot set instance status on %q: %v", m, err)
 			}
 		}

--- a/worker/instancepoller/updater_test.go
+++ b/worker/instancepoller/updater_test.go
@@ -12,6 +12,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/status"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/watcher"
 )
@@ -96,7 +97,7 @@ func (s *updaterSuite) TestManualMachinesIgnored(c *gc.C) {
 		// Signal that we're in Status.
 		waitStatus <- struct{}{}
 		return params.StatusResult{
-			Status: params.StatusPending,
+			Status: status.StatusPending,
 			Info:   "",
 			Data:   map[string]interface{}{},
 			Since:  nil,

--- a/worker/machiner/machiner.go
+++ b/worker/machiner/machiner.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/network"
+	"github.com/juju/juju/status"
 	"github.com/juju/juju/watcher"
 	"github.com/juju/juju/worker"
 )
@@ -95,7 +96,7 @@ func (mr *Machiner) SetUp() (watcher.NotifyWatcher, error) {
 	}
 
 	// Mark the machine as started and log it.
-	if err := m.SetStatus(params.StatusStarted, "", nil); err != nil {
+	if err := m.SetStatus(status.StatusStarted, "", nil); err != nil {
 		return nil, errors.Annotatef(err, "%s failed to set status started", mr.config.Tag)
 	}
 	logger.Infof("%q started", mr.config.Tag)
@@ -155,7 +156,7 @@ func (mr *Machiner) Handle(_ <-chan struct{}) error {
 		return nil
 	}
 	logger.Debugf("%q is now %s", mr.config.Tag, life)
-	if err := mr.machine.SetStatus(params.StatusStopped, "", nil); err != nil {
+	if err := mr.machine.SetStatus(status.StatusStopped, "", nil); err != nil {
 		return errors.Annotatef(err, "%s failed to set status stopped", mr.config.Tag)
 	}
 

--- a/worker/machiner/machiner_test.go
+++ b/worker/machiner/machiner_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/status"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/machiner"
@@ -126,7 +127,7 @@ func (s *MachinerSuite) TestMachinerSetStatusStopped(c *gc.C) {
 	)
 	s.accessor.machine.CheckCall(
 		c, 5, "SetStatus",
-		params.StatusStopped,
+		status.StatusStopped,
 		"",
 		map[string]interface{}(nil),
 	)
@@ -227,7 +228,7 @@ func (s *MachinerSuite) TestMachinerStorageAttached(c *gc.C) {
 	}, {
 		FuncName: "SetStatus",
 		Args: []interface{}{
-			params.StatusStarted,
+			status.StatusStarted,
 			"",
 			map[string]interface{}(nil),
 		},
@@ -240,7 +241,7 @@ func (s *MachinerSuite) TestMachinerStorageAttached(c *gc.C) {
 	}, {
 		FuncName: "SetStatus",
 		Args: []interface{}{
-			params.StatusStopped,
+			status.StatusStopped,
 			"",
 			map[string]interface{}(nil),
 		},
@@ -290,7 +291,7 @@ func (s *MachinerStateSuite) SetUpTest(c *gc.C) {
 
 }
 
-func (s *MachinerStateSuite) waitMachineStatus(c *gc.C, m *state.Machine, expectStatus state.Status) {
+func (s *MachinerStateSuite) waitMachineStatus(c *gc.C, m *state.Machine, expectStatus status.Status) {
 	timeout := time.After(worstCase)
 	for {
 		select {
@@ -361,20 +362,20 @@ func (s *MachinerStateSuite) TestRunStop(c *gc.C) {
 func (s *MachinerStateSuite) TestStartSetsStatus(c *gc.C) {
 	statusInfo, err := s.machine.Status()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(statusInfo.Status, gc.Equals, state.StatusPending)
+	c.Assert(statusInfo.Status, gc.Equals, status.StatusPending)
 	c.Assert(statusInfo.Message, gc.Equals, "")
 
 	mr := s.makeMachiner(c, false, nil)
 	defer worker.Stop(mr)
 
-	s.waitMachineStatus(c, s.machine, state.StatusStarted)
+	s.waitMachineStatus(c, s.machine, status.StatusStarted)
 }
 
 func (s *MachinerStateSuite) TestSetsStatusWhenDying(c *gc.C) {
 	mr := s.makeMachiner(c, false, nil)
 	defer worker.Stop(mr)
 	c.Assert(s.machine.Destroy(), jc.ErrorIsNil)
-	s.waitMachineStatus(c, s.machine, state.StatusStopped)
+	s.waitMachineStatus(c, s.machine, status.StatusStopped)
 }
 
 func (s *MachinerStateSuite) TestSetDead(c *gc.C) {

--- a/worker/machiner/mock_test.go
+++ b/worker/machiner/mock_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/network"
+	"github.com/juju/juju/status"
 	"github.com/juju/juju/watcher"
 	"github.com/juju/juju/worker/machiner"
 )
@@ -54,7 +55,7 @@ func (m *mockMachine) SetMachineAddresses(addresses []network.Address) error {
 	return m.NextErr()
 }
 
-func (m *mockMachine) SetStatus(status params.Status, info string, data map[string]interface{}) error {
+func (m *mockMachine) SetStatus(status status.Status, info string, data map[string]interface{}) error {
 	m.MethodCall(m, "SetStatus", status, info, data)
 	return m.NextErr()
 }

--- a/worker/machiner/state.go
+++ b/worker/machiner/state.go
@@ -9,6 +9,7 @@ import (
 	"github.com/juju/juju/api/machiner"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/network"
+	"github.com/juju/juju/status"
 	"github.com/juju/juju/watcher"
 )
 
@@ -21,7 +22,7 @@ type Machine interface {
 	Life() params.Life
 	EnsureDead() error
 	SetMachineAddresses(addresses []network.Address) error
-	SetStatus(status params.Status, info string, data map[string]interface{}) error
+	SetStatus(machineStatus status.Status, info string, data map[string]interface{}) error
 	Watch() (watcher.NotifyWatcher, error)
 }
 

--- a/worker/peergrouper/mock_test.go
+++ b/worker/peergrouper/mock_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/status"
 	"github.com/juju/juju/worker"
 )
 
@@ -308,9 +309,9 @@ func (m *fakeMachine) APIHostPorts() []network.HostPort {
 	return m.doc.apiHostPorts
 }
 
-func (m *fakeMachine) Status() (state.StatusInfo, error) {
-	return state.StatusInfo{
-		Status: state.StatusStarted,
+func (m *fakeMachine) Status() (status.StatusInfo, error) {
+	return status.StatusInfo{
+		Status: status.StatusStarted,
 	}, nil
 }
 

--- a/worker/peergrouper/worker.go
+++ b/worker/peergrouper/worker.go
@@ -16,6 +16,7 @@ import (
 	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/status"
 	"github.com/juju/juju/worker"
 )
 
@@ -30,7 +31,7 @@ type stateInterface interface {
 type stateMachine interface {
 	Id() string
 	InstanceId() (instance.Id, error)
-	Status() (state.StatusInfo, error)
+	Status() (status.StatusInfo, error)
 	Refresh() error
 	Watch() state.NotifyWatcher
 	WantsVote() bool
@@ -444,16 +445,16 @@ func (infow *serverInfoWatcher) updateMachines() (bool, error) {
 		}
 
 		// Don't add the machine unless it is "Started"
-		status, err := stm.Status()
+		machineStatus, err := stm.Status()
 		if err != nil {
 			return false, errors.Annotatef(err, "cannot get status for machine %q", id)
 		}
-		if status.Status == state.StatusStarted {
+		if machineStatus.Status == status.StatusStarted {
 			logger.Tracef("machine %q has started, adding it to peergrouper list", id)
 			infow.worker.machines[id] = infow.worker.newMachine(stm)
 			changed = true
 		} else {
-			logger.Tracef("machine %q not ready: %v", id, status.Status)
+			logger.Tracef("machine %q not ready: %v", id, machineStatus.Status)
 		}
 
 	}

--- a/worker/provisioner/kvm-broker.go
+++ b/worker/provisioner/kvm-broker.go
@@ -113,7 +113,7 @@ func (broker *kvmBroker) StartInstance(args environs.StartInstanceParams) (*envi
 	storageConfig := &container.StorageConfig{
 		AllowMount: true,
 	}
-	inst, hardware, err := broker.manager.CreateContainer(args.InstanceConfig, series, network, storageConfig)
+	inst, hardware, err := broker.manager.CreateContainer(args.InstanceConfig, series, network, storageConfig, args.StatusCallback)
 	if err != nil {
 		kvmLogger.Errorf("failed to start container: %v", err)
 		return nil, err

--- a/worker/provisioner/kvm-broker_test.go
+++ b/worker/provisioner/kvm-broker_test.go
@@ -31,6 +31,7 @@ import (
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/status"
 	coretesting "github.com/juju/juju/testing"
 	coretools "github.com/juju/juju/tools"
 	"github.com/juju/juju/version"
@@ -116,10 +117,14 @@ func (s *kvmBrokerSuite) startInstance(c *gc.C, machineId string) instance.Insta
 		Version: version.MustParseBinary("2.3.4-quantal-amd64"),
 		URL:     "http://tools.testing.invalid/2.3.4-quantal-amd64.tgz",
 	}}
+	callback := func(settableStatus status.Status, info string, data map[string]interface{}) error {
+		return nil
+	}
 	result, err := s.broker.StartInstance(environs.StartInstanceParams{
 		Constraints:    cons,
 		Tools:          possibleTools,
 		InstanceConfig: instanceConfig,
+		StatusCallback: callback,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	return result.Instance
@@ -136,10 +141,14 @@ func (s *kvmBrokerSuite) maintainInstance(c *gc.C, machineId string) {
 		Version: version.MustParseBinary("2.3.4-quantal-amd64"),
 		URL:     "http://tools.testing.invalid/2.3.4-quantal-amd64.tgz",
 	}}
+	callback := func(settableStatus status.Status, info string, data map[string]interface{}) error {
+		return nil
+	}
 	err = s.broker.MaintainInstance(environs.StartInstanceParams{
 		Constraints:    cons,
 		Tools:          possibleTools,
 		InstanceConfig: instanceConfig,
+		StatusCallback: callback,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 }
@@ -253,10 +262,14 @@ func (s *kvmBrokerSuite) TestStartInstancePopulatesNetworkInfo(c *gc.C) {
 		Version: version.MustParseBinary("2.3.4-quantal-amd64"),
 		URL:     "http://tools.testing.invalid/2.3.4-quantal-amd64.tgz",
 	}}
+	callback := func(settableStatus status.Status, info string, data map[string]interface{}) error {
+		return nil
+	}
 	result, err := s.broker.StartInstance(environs.StartInstanceParams{
 		Constraints:    constraints.Value{},
 		Tools:          possibleTools,
 		InstanceConfig: instanceConfig,
+		StatusCallback: callback,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.NetworkInfo, gc.HasLen, 1)

--- a/worker/provisioner/lxc-broker.go
+++ b/worker/provisioner/lxc-broker.go
@@ -162,7 +162,7 @@ func (broker *lxcBroker) StartInstance(args environs.StartInstanceParams) (*envi
 		return nil, err
 	}
 
-	inst, hardware, err := broker.manager.CreateContainer(args.InstanceConfig, series, network, storageConfig)
+	inst, hardware, err := broker.manager.CreateContainer(args.InstanceConfig, series, network, storageConfig, args.StatusCallback)
 	if err != nil {
 		lxcLogger.Errorf("failed to start container: %v", err)
 		return nil, err

--- a/worker/provisioner/lxc-broker_test.go
+++ b/worker/provisioner/lxc-broker_test.go
@@ -36,6 +36,7 @@ import (
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/status"
 	"github.com/juju/juju/storage"
 	"github.com/juju/juju/storage/provider"
 	coretesting "github.com/juju/juju/testing"
@@ -129,11 +130,15 @@ func (s *lxcBrokerSuite) startInstance(c *gc.C, machineId string, volumes []stor
 		Version: version.MustParseBinary("2.3.4-quantal-amd64"),
 		URL:     "http://tools.testing.invalid/2.3.4-quantal-amd64.tgz",
 	}}
+	callback := func(settableStatus status.Status, info string, data map[string]interface{}) error {
+		return nil
+	}
 	result, err := s.broker.StartInstance(environs.StartInstanceParams{
 		Constraints:    cons,
 		Tools:          possibleTools,
 		InstanceConfig: instanceConfig,
 		Volumes:        volumes,
+		StatusCallback: callback,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	return result.Instance
@@ -146,11 +151,15 @@ func (s *lxcBrokerSuite) maintainInstance(c *gc.C, machineId string, volumes []s
 		Version: version.MustParseBinary("2.3.4-quantal-amd64"),
 		URL:     "http://tools.testing.invalid/2.3.4-quantal-amd64.tgz",
 	}}
+	callback := func(settableStatus status.Status, info string, data map[string]interface{}) error {
+		return nil
+	}
 	err := s.broker.MaintainInstance(environs.StartInstanceParams{
 		Constraints:    cons,
 		Tools:          possibleTools,
 		InstanceConfig: instanceConfig,
 		Volumes:        volumes,
+		StatusCallback: callback,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 }
@@ -283,10 +292,15 @@ func (s *lxcBrokerSuite) TestStartInstanceHostArch(c *gc.C) {
 		Version: version.MustParseBinary("2.3.4-quantal-ppc64el"),
 		URL:     "http://tools.testing.invalid/2.3.4-quantal-ppc64el.tgz",
 	}}
+	callback := func(settableStatus status.Status, info string, data map[string]interface{}) error {
+		return nil
+	}
+
 	_, err := s.broker.StartInstance(environs.StartInstanceParams{
 		Constraints:    constraints.Value{},
 		Tools:          possibleTools,
 		InstanceConfig: instanceConfig,
+		StatusCallback: callback,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(instanceConfig.Tools.Version.Arch, gc.Equals, arch.PPC64EL)
@@ -301,10 +315,15 @@ func (s *lxcBrokerSuite) TestStartInstanceToolsArchNotFound(c *gc.C) {
 		Version: version.MustParseBinary("2.3.4-quantal-amd64"),
 		URL:     "http://tools.testing.invalid/2.3.4-quantal-amd64.tgz",
 	}}
+	callback := func(settableStatus status.Status, info string, data map[string]interface{}) error {
+		return nil
+	}
+
 	_, err := s.broker.StartInstance(environs.StartInstanceParams{
 		Constraints:    constraints.Value{},
 		Tools:          possibleTools,
 		InstanceConfig: instanceConfig,
+		StatusCallback: callback,
 	})
 	c.Assert(err, gc.ErrorMatches, "need tools for arch ppc64el, only found \\[amd64\\]")
 }
@@ -345,10 +364,15 @@ func (s *lxcBrokerSuite) startInstancePopulatesNetworkInfo(c *gc.C) (*environs.S
 		Version: version.MustParseBinary("2.3.4-quantal-amd64"),
 		URL:     "http://tools.testing.invalid/2.3.4-quantal-amd64.tgz",
 	}}
+	callback := func(settableStatus status.Status, info string, data map[string]interface{}) error {
+		return nil
+	}
+
 	return s.broker.StartInstance(environs.StartInstanceParams{
 		Constraints:    constraints.Value{},
 		Tools:          possibleTools,
 		InstanceConfig: instanceConfig,
+		StatusCallback: callback,
 	})
 }
 

--- a/worker/provisioner/provisioner_task.go
+++ b/worker/provisioner/provisioner_task.go
@@ -24,6 +24,7 @@ import (
 	"github.com/juju/juju/environs/simplestreams"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/network"
+	"github.com/juju/juju/status"
 	"github.com/juju/juju/storage"
 	coretools "github.com/juju/juju/tools"
 	"github.com/juju/juju/version"
@@ -196,14 +197,14 @@ func (task *provisionerTask) processMachinesWithTransientErrors() error {
 	}
 	logger.Tracef("processMachinesWithTransientErrors(%v)", statusResults)
 	var pending []*apiprovisioner.Machine
-	for i, status := range statusResults {
-		if status.Error != nil {
-			logger.Errorf("cannot retry provisioning of machine %q: %v", status.Id, status.Error)
+	for i, statusResult := range statusResults {
+		if statusResult.Error != nil {
+			logger.Errorf("cannot retry provisioning of machine %q: %v", statusResult.Id, statusResult.Error)
 			continue
 		}
 		machine := machines[i]
-		if err := machine.SetStatus(params.StatusPending, "", nil); err != nil {
-			logger.Errorf("cannot reset status of machine %q: %v", status.Id, err)
+		if err := machine.SetStatus(status.StatusPending, "", nil); err != nil {
+			logger.Errorf("cannot reset status of machine %q: %v", statusResult.Id, err)
 			continue
 		}
 		task.machines[machine.Tag().String()] = machine
@@ -355,7 +356,7 @@ type ClassifiableMachine interface {
 	Life() params.Life
 	InstanceId() (instance.Id, error)
 	EnsureDead() error
-	Status() (params.Status, string, error)
+	Status() (status.Status, string, error)
 	Id() string
 }
 
@@ -389,12 +390,12 @@ func classifyMachine(machine ClassifiableMachine) (
 		if !params.IsCodeNotProvisioned(err) {
 			return None, errors.Annotatef(err, "failed to load machine id:%s, details:%v", machine.Id(), machine)
 		}
-		status, _, err := machine.Status()
+		machineStatus, _, err := machine.Status()
 		if err != nil {
 			logger.Infof("cannot get machine id:%s, details:%v, err:%v", machine.Id(), machine, err)
 			return None, nil
 		}
-		if status == params.StatusPending {
+		if machineStatus == status.StatusPending {
 			logger.Infof("found machine pending provisioning id:%s, details:%v", machine.Id(), machine)
 			return Pending, nil
 		}
@@ -597,6 +598,7 @@ func constructStartInstanceParams(
 		SubnetsToZones:    subnetsToZones,
 		EndpointBindings:  endpointBindings,
 		ImageMetadata:     possibleImageMetadata,
+		StatusCallback:    machine.SetInstanceStatus,
 	}, nil
 }
 
@@ -661,7 +663,7 @@ func (task *provisionerTask) startMachines(machines []*apiprovisioner.Machine) e
 
 func (task *provisionerTask) setErrorStatus(message string, machine *apiprovisioner.Machine, err error) error {
 	logger.Errorf(message, machine, err)
-	if err1 := machine.SetStatus(params.StatusError, err.Error(), nil); err1 != nil {
+	if err1 := machine.SetStatus(status.StatusError, err.Error(), nil); err1 != nil {
 		// Something is wrong with this machine, better report it back.
 		return errors.Annotatef(err1, "cannot set error status for machine %q", machine)
 	}

--- a/worker/unitassigner/unitassigner.go
+++ b/worker/unitassigner/unitassigner.go
@@ -6,6 +6,7 @@ package unitassigner
 import (
 	"github.com/juju/errors"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/status"
 	"github.com/juju/juju/watcher"
 	"github.com/juju/juju/worker"
 	"github.com/juju/loggo"
@@ -76,7 +77,7 @@ func (u unitAssignerHandler) Handle(_ <-chan struct{}, ids []string) error {
 		for unit, err := range failures {
 			args.Entities[x] = params.EntityStatusArgs{
 				Tag:    unit,
-				Status: params.StatusError,
+				Status: status.StatusError,
 				Info:   err.Error(),
 			}
 			x++

--- a/worker/unitassigner/unitassigner_test.go
+++ b/worker/unitassigner/unitassigner_test.go
@@ -11,6 +11,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/status"
 	"github.com/juju/juju/watcher"
 )
 
@@ -62,7 +63,7 @@ func (testsuite) TestHandleError(c *gc.C) {
 	c.Assert(entities, gc.HasLen, 1)
 	c.Assert(entities[0], gc.DeepEquals, params.EntityStatusArgs{
 		Tag:    "unit-foo-0",
-		Status: params.StatusError,
+		Status: status.StatusError,
 		Info:   e.Error(),
 	})
 }

--- a/worker/uniter/agent.go
+++ b/worker/uniter/agent.go
@@ -3,21 +3,19 @@
 
 package uniter
 
-import (
-	"github.com/juju/juju/apiserver/params"
-)
+import "github.com/juju/juju/status"
 
 // setAgentStatus sets the unit's status if it has changed since last time this method was called.
-func setAgentStatus(u *Uniter, status params.Status, info string, data map[string]interface{}) error {
+func setAgentStatus(u *Uniter, agentStatus status.Status, info string, data map[string]interface{}) error {
 	u.setStatusMutex.Lock()
 	defer u.setStatusMutex.Unlock()
-	if u.lastReportedStatus == status && u.lastReportedMessage == info {
+	if u.lastReportedStatus == agentStatus && u.lastReportedMessage == info {
 		return nil
 	}
-	u.lastReportedStatus = status
+	u.lastReportedStatus = agentStatus
 	u.lastReportedMessage = info
-	logger.Debugf("[AGENT-STATUS] %s: %s", status, info)
-	return u.unit.SetAgentStatus(status, info, data)
+	logger.Debugf("[AGENT-STATUS] %s: %s", agentStatus, info)
+	return u.unit.SetAgentStatus(agentStatus, info, data)
 }
 
 // reportAgentError reports if there was an error performing an agent operation.
@@ -27,7 +25,7 @@ func reportAgentError(u *Uniter, userMessage string, err error) {
 	if err == nil {
 		return
 	}
-	err2 := setAgentStatus(u, params.StatusFailed, userMessage, nil)
+	err2 := setAgentStatus(u, status.StatusFailed, userMessage, nil)
 	if err2 != nil {
 		logger.Errorf("updating agent status: %v", err2)
 	}

--- a/worker/uniter/op_callbacks.go
+++ b/worker/uniter/op_callbacks.go
@@ -12,6 +12,7 @@ import (
 	"gopkg.in/juju/charm.v6-unstable/hooks"
 
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/status"
 	"github.com/juju/juju/worker/uniter/charm"
 	"github.com/juju/juju/worker/uniter/hook"
 	"github.com/juju/juju/worker/uniter/runner"
@@ -119,5 +120,5 @@ func (opc *operationCallbacks) SetCurrentCharm(charmURL *corecharm.URL) error {
 
 // SetExecutingStatus is part of the operation.Callbacks interface.
 func (opc *operationCallbacks) SetExecutingStatus(message string) error {
-	return setAgentStatus(opc.u, params.StatusExecuting, message, nil)
+	return setAgentStatus(opc.u, status.StatusExecuting, message, nil)
 }

--- a/worker/uniter/operation/runhook.go
+++ b/worker/uniter/operation/runhook.go
@@ -9,7 +9,7 @@ import (
 	"github.com/juju/errors"
 	"gopkg.in/juju/charm.v6-unstable/hooks"
 
-	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/status"
 	"github.com/juju/juju/worker/uniter/hook"
 	"github.com/juju/juju/worker/uniter/runner"
 	"github.com/juju/juju/worker/uniter/runner/context"
@@ -134,12 +134,12 @@ func (rh *runHook) beforeHook() error {
 	switch rh.info.Kind {
 	case hooks.Install:
 		err = rh.runner.Context().SetUnitStatus(jujuc.StatusInfo{
-			Status: string(params.StatusMaintenance),
+			Status: string(status.StatusMaintenance),
 			Info:   "installing charm software",
 		})
 	case hooks.Stop:
 		err = rh.runner.Context().SetUnitStatus(jujuc.StatusInfo{
-			Status: string(params.StatusMaintenance),
+			Status: string(status.StatusMaintenance),
 			Info:   "cleaning up prior to charm deletion",
 		})
 	}
@@ -161,7 +161,7 @@ func (rh *runHook) afterHook(state State) (bool, error) {
 	case hooks.Stop:
 		// Charm is no longer of this world.
 		err = rh.runner.Context().SetUnitStatus(jujuc.StatusInfo{
-			Status: string(params.StatusTerminated),
+			Status: string(status.StatusTerminated),
 		})
 	case hooks.Start:
 		if hasRunStatusSet {
@@ -171,7 +171,7 @@ func (rh *runHook) afterHook(state State) (bool, error) {
 		// We've finished the start hook and the charm has not updated its
 		// own status so we'll set it to unknown.
 		err = rh.runner.Context().SetUnitStatus(jujuc.StatusInfo{
-			Status: string(params.StatusUnknown),
+			Status: string(status.StatusUnknown),
 		})
 	}
 	if err != nil {

--- a/worker/uniter/runner/context/context.go
+++ b/worker/uniter/runner/context/context.go
@@ -22,6 +22,7 @@ import (
 	"github.com/juju/juju/api/uniter"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/network"
+	"github.com/juju/juju/status"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
 )
 
@@ -341,20 +342,20 @@ func (ctx *HookContext) ServiceStatus() (jujuc.ServiceStatusInfo, error) {
 }
 
 // SetUnitStatus will set the given status for this unit.
-func (ctx *HookContext) SetUnitStatus(status jujuc.StatusInfo) error {
+func (ctx *HookContext) SetUnitStatus(unitStatus jujuc.StatusInfo) error {
 	ctx.hasRunStatusSet = true
-	logger.Tracef("[WORKLOAD-STATUS] %s: %s", status.Status, status.Info)
+	logger.Tracef("[WORKLOAD-STATUS] %s: %s", unitStatus.Status, unitStatus.Info)
 	return ctx.unit.SetUnitStatus(
-		params.Status(status.Status),
-		status.Info,
-		status.Data,
+		status.Status(unitStatus.Status),
+		unitStatus.Info,
+		unitStatus.Data,
 	)
 }
 
 // SetServiceStatus will set the given status to the service to which this
 // unit's belong, only if this unit is the leader.
-func (ctx *HookContext) SetServiceStatus(status jujuc.StatusInfo) error {
-	logger.Tracef("[SERVICE-STATUS] %s: %s", status.Status, status.Info)
+func (ctx *HookContext) SetServiceStatus(serviceStatus jujuc.StatusInfo) error {
+	logger.Tracef("[SERVICE-STATUS] %s: %s", serviceStatus.Status, serviceStatus.Info)
 	isLeader, err := ctx.IsLeader()
 	if err != nil {
 		return errors.Annotatef(err, "cannot determine leadership")
@@ -369,9 +370,9 @@ func (ctx *HookContext) SetServiceStatus(status jujuc.StatusInfo) error {
 	}
 	return service.SetStatus(
 		ctx.unit.Name(),
-		params.Status(status.Status),
-		status.Info,
-		status.Data,
+		status.Status(serviceStatus.Status),
+		serviceStatus.Info,
+		serviceStatus.Data,
 	)
 }
 
@@ -615,7 +616,7 @@ func (ctx *HookContext) handleReboot(err *error) {
 	case jujuc.RebootNow:
 		*err = ErrRequeueAndReboot
 	}
-	err2 := ctx.unit.SetUnitStatus(params.StatusRebooting, "", nil)
+	err2 := ctx.unit.SetUnitStatus(status.StatusRebooting, "", nil)
 	if err2 != nil {
 		logger.Errorf("updating agent status: %v", err2)
 	}

--- a/worker/uniter/runner/context/context_test.go
+++ b/worker/uniter/runner/context/context_test.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/network"
-	"github.com/juju/juju/state"
+	"github.com/juju/juju/status"
 	"github.com/juju/juju/worker/uniter/runner"
 	"github.com/juju/juju/worker/uniter/runner/context"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
@@ -127,20 +127,20 @@ func (s *InterfaceSuite) TestSetUnitStatusUpdatesFlag(c *gc.C) {
 
 func (s *InterfaceSuite) TestUnitStatusCaching(c *gc.C) {
 	ctx := s.GetContext(c, -1, "")
-	status, err := ctx.UnitStatus()
+	unitStatus, err := ctx.UnitStatus()
 	c.Check(err, jc.ErrorIsNil)
-	c.Check(status.Status, gc.Equals, "unknown")
-	c.Check(status.Data, gc.DeepEquals, map[string]interface{}{})
+	c.Check(unitStatus.Status, gc.Equals, "unknown")
+	c.Check(unitStatus.Data, gc.DeepEquals, map[string]interface{}{})
 
 	// Change remote state.
-	err = s.unit.SetStatus(state.StatusActive, "it works", nil)
+	err = s.unit.SetStatus(status.StatusActive, "it works", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Local view is unchanged.
-	status, err = ctx.UnitStatus()
+	unitStatus, err = ctx.UnitStatus()
 	c.Check(err, jc.ErrorIsNil)
-	c.Check(status.Status, gc.Equals, "unknown")
-	c.Check(status.Data, gc.DeepEquals, map[string]interface{}{})
+	c.Check(unitStatus.Status, gc.Equals, "unknown")
+	c.Check(unitStatus.Data, gc.DeepEquals, map[string]interface{}{})
 }
 
 func (s *InterfaceSuite) TestUnitCaching(c *gc.C) {

--- a/worker/uniter/runner/jujuc/status-get.go
+++ b/worker/uniter/runner/jujuc/status-get.go
@@ -8,7 +8,7 @@ import (
 	"github.com/juju/errors"
 	"launchpad.net/gnuflag"
 
-	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/status"
 )
 
 // StatusGetCommand implements the status-get command.
@@ -79,7 +79,7 @@ func (c *StatusGetCommand) ServiceStatus(ctx *cmd.Context) error {
 	serviceStatus, err := c.ctx.ServiceStatus()
 	if err != nil {
 		if errors.IsNotImplemented(err) {
-			return c.out.Write(ctx, params.StatusUnknown)
+			return c.out.Write(ctx, status.StatusUnknown)
 		}
 		return errors.Annotatef(err, "finding service status")
 	}
@@ -111,7 +111,7 @@ func (c *StatusGetCommand) unitOrServiceStatus(ctx *cmd.Context) error {
 	unitStatus, err := c.ctx.UnitStatus()
 	if err != nil {
 		if errors.IsNotImplemented(err) {
-			return c.out.Write(ctx, params.StatusUnknown)
+			return c.out.Write(ctx, status.StatusUnknown)
 		}
 		return errors.Annotatef(err, "finding workload status")
 	}

--- a/worker/uniter/runner/jujuc/status-set.go
+++ b/worker/uniter/runner/jujuc/status-set.go
@@ -8,7 +8,7 @@ import (
 	"github.com/juju/errors"
 	"launchpad.net/gnuflag"
 
-	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/status"
 )
 
 // StatusSetCommand implements the status-set command.
@@ -39,11 +39,11 @@ status and message are the same as what's already set.
 	}
 }
 
-var validStatus = []params.Status{
-	params.StatusMaintenance,
-	params.StatusBlocked,
-	params.StatusWaiting,
-	params.StatusActive,
+var validStatus = []status.Status{
+	status.StatusMaintenance,
+	status.StatusBlocked,
+	status.StatusWaiting,
+	status.StatusActive,
 }
 
 func (c *StatusSetCommand) SetFlags(f *gnuflag.FlagSet) {

--- a/worker/uniter/uniter.go
+++ b/worker/uniter/uniter.go
@@ -22,6 +22,7 @@ import (
 	"github.com/juju/juju/api/uniter"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/leadership"
+	"github.com/juju/juju/status"
 	"github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/catacomb"
 	"github.com/juju/juju/worker/fortress"
@@ -74,7 +75,7 @@ type Uniter struct {
 	// Cache the last reported status information
 	// so we don't make unnecessary api calls.
 	setStatusMutex      sync.Mutex
-	lastReportedStatus  params.Status
+	lastReportedStatus  status.Status
 	lastReportedMessage string
 
 	deployer             *deployerProxy
@@ -246,7 +247,7 @@ func (u *Uniter) loop(unitTag names.UnitTag) (err error) {
 			// error state.
 			return nil
 		}
-		return setAgentStatus(u, params.StatusIdle, "", nil)
+		return setAgentStatus(u, status.StatusIdle, "", nil)
 	}
 
 	clearResolved := func() error {
@@ -319,7 +320,7 @@ func (u *Uniter) loop(unitTag names.UnitTag) (err error) {
 				// handling is outside of the resolver's control.
 				if operation.IsDeployConflictError(cause) {
 					localState.Conflicted = true
-					err = setAgentStatus(u, params.StatusError, "upgrade failed", nil)
+					err = setAgentStatus(u, status.StatusError, "upgrade failed", nil)
 				} else {
 					reportAgentError(u, "resolver loop error", err)
 				}
@@ -559,5 +560,5 @@ func (u *Uniter) reportHookError(hookInfo hook.Info) error {
 	}
 	statusData["hook"] = hookName
 	statusMessage := fmt.Sprintf("hook failed: %q", hookName)
-	return setAgentStatus(u, params.StatusError, statusMessage, statusData)
+	return setAgentStatus(u, status.StatusError, statusMessage, statusData)
 }

--- a/worker/uniter/uniter_test.go
+++ b/worker/uniter/uniter_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/status"
 	"github.com/juju/juju/testcharms"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/uniter/operation"
@@ -184,11 +185,11 @@ func (s *UniterSuite) TestUniterInstallHook(c *gc.C) {
 
 			resolveError{state.ResolvedNoHooks},
 			waitUnitAgent{
-				status: params.StatusIdle,
+				status: status.StatusIdle,
 			},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       params.StatusUnknown,
+				status:       status.StatusUnknown,
 			},
 			waitHooks{"leader-elected", "config-changed", "start"},
 		), ut(
@@ -199,7 +200,7 @@ func (s *UniterSuite) TestUniterInstallHook(c *gc.C) {
 			resolveError{state.ResolvedRetryHooks},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       params.StatusError,
+				status:       status.StatusError,
 				info:         `hook failed: "install"`,
 				data: map[string]interface{}{
 					"hook": "install",
@@ -211,7 +212,7 @@ func (s *UniterSuite) TestUniterInstallHook(c *gc.C) {
 
 			resolveError{state.ResolvedRetryHooks},
 			waitUnitAgent{
-				status: params.StatusIdle,
+				status: status.StatusIdle,
 			},
 			waitHooks{"install", "leader-elected", "config-changed", "start"},
 		),
@@ -226,7 +227,7 @@ func (s *UniterSuite) TestUniterUpdateStatusHook(c *gc.C) {
 			serveCharm{},
 			createUniter{},
 			waitHooks(startupHooks(false)),
-			waitUnitAgent{status: params.StatusIdle},
+			waitUnitAgent{status: status.StatusIdle},
 			updateStatusHookTick{},
 			waitHooks{"update-status"},
 		),
@@ -245,7 +246,7 @@ func (s *UniterSuite) TestNoUniterUpdateStatusHookInError(c *gc.C) {
 			// Resolve and hook should run.
 			resolveError{state.ResolvedNoHooks},
 			waitUnitAgent{
-				status: params.StatusIdle,
+				status: status.StatusIdle,
 			},
 			waitHooks{},
 			updateStatusHookTick{},
@@ -263,11 +264,11 @@ func (s *UniterSuite) TestUniterStartHook(c *gc.C) {
 
 			resolveError{state.ResolvedNoHooks},
 			waitUnitAgent{
-				status: params.StatusIdle,
+				status: status.StatusIdle,
 			},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       params.StatusMaintenance,
+				status:       status.StatusMaintenance,
 				info:         "installing charm software",
 			},
 			waitHooks{"config-changed"},
@@ -280,7 +281,7 @@ func (s *UniterSuite) TestUniterStartHook(c *gc.C) {
 			resolveError{state.ResolvedRetryHooks},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       params.StatusError,
+				status:       status.StatusError,
 				info:         `hook failed: "start"`,
 				data: map[string]interface{}{
 					"hook": "start",
@@ -292,7 +293,7 @@ func (s *UniterSuite) TestUniterStartHook(c *gc.C) {
 			fixHook{"start"},
 			resolveError{state.ResolvedRetryHooks},
 			waitUnitAgent{
-				status: params.StatusIdle,
+				status: status.StatusIdle,
 			},
 			waitHooks{"start", "config-changed"},
 			verifyRunning{},
@@ -309,7 +310,7 @@ func (s *UniterSuite) TestUniterMultipleErrors(c *gc.C) {
 			createUniter{},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       params.StatusError,
+				status:       status.StatusError,
 				info:         `hook failed: "install"`,
 				data: map[string]interface{}{
 					"hook": "install",
@@ -318,7 +319,7 @@ func (s *UniterSuite) TestUniterMultipleErrors(c *gc.C) {
 			resolveError{state.ResolvedNoHooks},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       params.StatusError,
+				status:       status.StatusError,
 				info:         `hook failed: "leader-elected"`,
 				data: map[string]interface{}{
 					"hook": "leader-elected",
@@ -327,7 +328,7 @@ func (s *UniterSuite) TestUniterMultipleErrors(c *gc.C) {
 			resolveError{state.ResolvedNoHooks},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       params.StatusError,
+				status:       status.StatusError,
 				info:         `hook failed: "config-changed"`,
 				data: map[string]interface{}{
 					"hook": "config-changed",
@@ -336,7 +337,7 @@ func (s *UniterSuite) TestUniterMultipleErrors(c *gc.C) {
 			resolveError{state.ResolvedNoHooks},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       params.StatusError,
+				status:       status.StatusError,
 				info:         `hook failed: "start"`,
 				data: map[string]interface{}{
 					"hook": "start",
@@ -359,11 +360,11 @@ func (s *UniterSuite) TestUniterConfigChangedHook(c *gc.C) {
 			fixHook{"config-changed"},
 			resolveError{state.ResolvedNoHooks},
 			waitUnitAgent{
-				status: params.StatusIdle,
+				status: status.StatusIdle,
 			},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       params.StatusUnknown,
+				status:       status.StatusUnknown,
 			},
 			// TODO(axw) confirm with fwereade that this is correct.
 			// Previously we would see "start", "config-changed".
@@ -383,7 +384,7 @@ func (s *UniterSuite) TestUniterConfigChangedHook(c *gc.C) {
 			resolveError{state.ResolvedRetryHooks},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       params.StatusError,
+				status:       status.StatusError,
 				info:         `hook failed: "config-changed"`,
 				data: map[string]interface{}{
 					"hook": "config-changed",
@@ -395,7 +396,7 @@ func (s *UniterSuite) TestUniterConfigChangedHook(c *gc.C) {
 			fixHook{"config-changed"},
 			resolveError{state.ResolvedRetryHooks},
 			waitUnitAgent{
-				status: params.StatusIdle,
+				status: status.StatusIdle,
 			},
 			waitHooks{"config-changed", "start"},
 			verifyRunning{},
@@ -409,7 +410,7 @@ func (s *UniterSuite) TestUniterConfigChangedHook(c *gc.C) {
 			serveCharm{},
 			createUniter{},
 			waitUnitAgent{
-				status: params.StatusIdle,
+				status: status.StatusIdle,
 			},
 			waitHooks{"install", "leader-elected", "config-changed", "start"},
 			assertYaml{"charm/config.out", map[string]interface{}{
@@ -453,7 +454,7 @@ func (s *UniterSuite) TestUniterHookSynchronisation(c *gc.C) {
 			waitHooks{},
 			verifyHookSyncLockLocked,
 			releaseHookSyncLock,
-			waitUnitAgent{status: params.StatusIdle},
+			waitUnitAgent{status: status.StatusIdle},
 			waitHooks{"install", "leader-elected", "config-changed", "start"},
 		),
 	})
@@ -502,12 +503,12 @@ func (s *UniterSuite) TestUniterSteadyStateUpgrade(c *gc.C) {
 			createCharm{revision: 1},
 			upgradeCharm{revision: 1},
 			waitUnitAgent{
-				status: params.StatusIdle,
+				status: status.StatusIdle,
 				charm:  1,
 			},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       params.StatusUnknown,
+				status:       status.StatusUnknown,
 				charm:        1,
 			},
 			waitHooks{"upgrade-charm", "config-changed"},
@@ -519,12 +520,12 @@ func (s *UniterSuite) TestUniterSteadyStateUpgrade(c *gc.C) {
 			createCharm{revision: 1},
 			upgradeCharm{revision: 1, forced: true},
 			waitUnitAgent{
-				status: params.StatusIdle,
+				status: status.StatusIdle,
 				charm:  1,
 			},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       params.StatusUnknown,
+				status:       status.StatusUnknown,
 				charm:        1,
 			},
 			waitHooks{"upgrade-charm", "config-changed"},
@@ -537,7 +538,7 @@ func (s *UniterSuite) TestUniterSteadyStateUpgrade(c *gc.C) {
 			upgradeCharm{revision: 1},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       params.StatusError,
+				status:       status.StatusError,
 				info:         `hook failed: "upgrade-charm"`,
 				data: map[string]interface{}{
 					"hook": "upgrade-charm",
@@ -550,12 +551,12 @@ func (s *UniterSuite) TestUniterSteadyStateUpgrade(c *gc.C) {
 
 			resolveError{state.ResolvedNoHooks},
 			waitUnitAgent{
-				status: params.StatusIdle,
+				status: status.StatusIdle,
 				charm:  1,
 			},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       params.StatusUnknown,
+				status:       status.StatusUnknown,
 				charm:        1,
 			},
 			waitHooks{"config-changed"},
@@ -567,7 +568,7 @@ func (s *UniterSuite) TestUniterSteadyStateUpgrade(c *gc.C) {
 			upgradeCharm{revision: 1},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       params.StatusError,
+				status:       status.StatusError,
 				info:         `hook failed: "upgrade-charm"`,
 				data: map[string]interface{}{
 					"hook": "upgrade-charm",
@@ -581,7 +582,7 @@ func (s *UniterSuite) TestUniterSteadyStateUpgrade(c *gc.C) {
 			resolveError{state.ResolvedRetryHooks},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       params.StatusError,
+				status:       status.StatusError,
 				info:         `hook failed: "upgrade-charm"`,
 				data: map[string]interface{}{
 					"hook": "upgrade-charm",
@@ -594,7 +595,7 @@ func (s *UniterSuite) TestUniterSteadyStateUpgrade(c *gc.C) {
 			fixHook{"upgrade-charm"},
 			resolveError{state.ResolvedRetryHooks},
 			waitUnitAgent{
-				status: params.StatusIdle,
+				status: status.StatusIdle,
 				charm:  1,
 			},
 			waitHooks{"upgrade-charm", "config-changed"},
@@ -648,11 +649,11 @@ func (s *UniterSuite) TestUniterUpgradeOverwrite(c *gc.C) {
 			serveCharm{},
 			createUniter{},
 			waitUnitAgent{
-				status: params.StatusIdle,
+				status: status.StatusIdle,
 			},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       params.StatusUnknown,
+				status:       status.StatusUnknown,
 			},
 			waitHooks{"install", "leader-elected", "config-changed", "start"},
 
@@ -665,12 +666,12 @@ func (s *UniterSuite) TestUniterUpgradeOverwrite(c *gc.C) {
 			serveCharm{},
 			upgradeCharm{revision: 1},
 			waitUnitAgent{
-				status: params.StatusIdle,
+				status: status.StatusIdle,
 				charm:  1,
 			},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       params.StatusUnknown,
+				status:       status.StatusUnknown,
 				charm:        1,
 			},
 			waitHooks{"upgrade-charm", "config-changed"},
@@ -730,7 +731,7 @@ func (s *UniterSuite) TestUniterErrorStateUnforcedUpgrade(c *gc.C) {
 			upgradeCharm{revision: 1},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       params.StatusError,
+				status:       status.StatusError,
 				info:         `hook failed: "start"`,
 				data: map[string]interface{}{
 					"hook": "start",
@@ -742,12 +743,12 @@ func (s *UniterSuite) TestUniterErrorStateUnforcedUpgrade(c *gc.C) {
 
 			resolveError{state.ResolvedNoHooks},
 			waitUnitAgent{
-				status: params.StatusIdle,
+				status: status.StatusIdle,
 				charm:  1,
 			},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       params.StatusMaintenance,
+				status:       status.StatusMaintenance,
 				info:         "installing charm software",
 				charm:        1,
 			},
@@ -771,7 +772,7 @@ func (s *UniterSuite) TestUniterErrorStateForcedUpgrade(c *gc.C) {
 			// useful to wait until that point...
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       params.StatusError,
+				status:       status.StatusError,
 				info:         `hook failed: "start"`,
 				data: map[string]interface{}{
 					"hook": "start",
@@ -787,7 +788,7 @@ func (s *UniterSuite) TestUniterErrorStateForcedUpgrade(c *gc.C) {
 
 			resolveError{state.ResolvedNoHooks},
 			waitUnitAgent{
-				status: params.StatusIdle,
+				status: status.StatusIdle,
 				charm:  1,
 			},
 			waitHooks{"config-changed"},
@@ -824,12 +825,12 @@ func (s *UniterSuite) TestUniterDeployerConversion(c *gc.C) {
 			upgradeCharm{revision: 1},
 			waitHooks{"upgrade-charm", "config-changed"},
 			waitUnitAgent{
-				status: params.StatusIdle,
+				status: status.StatusIdle,
 				charm:  1,
 			},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       params.StatusUnknown,
+				status:       status.StatusUnknown,
 				charm:        1,
 			},
 			verifyCharm{
@@ -848,12 +849,12 @@ func (s *UniterSuite) TestUniterDeployerConversion(c *gc.C) {
 			resolveError{state.ResolvedNoHooks},
 			waitHooks{"upgrade-charm", "config-changed"},
 			waitUnitAgent{
-				status: params.StatusIdle,
+				status: status.StatusIdle,
 				charm:  1,
 			},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       params.StatusUnknown,
+				status:       status.StatusUnknown,
 				charm:        1,
 			},
 			verifyCharm{revision: 1},
@@ -867,12 +868,12 @@ func (s *UniterSuite) TestUniterDeployerConversion(c *gc.C) {
 			upgradeCharm{revision: 2},
 			waitHooks{"upgrade-charm", "config-changed"},
 			waitUnitAgent{
-				status: params.StatusIdle,
+				status: status.StatusIdle,
 				charm:  2,
 			},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       params.StatusUnknown,
+				status:       status.StatusUnknown,
 				charm:        2,
 			},
 			verifyCharm{
@@ -898,7 +899,7 @@ func (s *UniterSuite) TestUniterDeployerConversion(c *gc.C) {
 			upgradeCharm{revision: 2, forced: true},
 			waitHooks{"upgrade-charm", "config-changed"},
 			waitUnitAgent{
-				status: params.StatusIdle,
+				status: status.StatusIdle,
 				charm:  2,
 			},
 
@@ -934,12 +935,12 @@ func (s *UniterSuite) TestUniterUpgradeConflicts(c *gc.C) {
 			resolveError{state.ResolvedNoHooks},
 			waitHooks{"upgrade-charm", "config-changed"},
 			waitUnitAgent{
-				status: params.StatusIdle,
+				status: status.StatusIdle,
 				charm:  1,
 			},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       params.StatusUnknown,
+				status:       status.StatusUnknown,
 				charm:        1,
 			},
 			verifyCharm{revision: 1},
@@ -954,12 +955,12 @@ func (s *UniterSuite) TestUniterUpgradeConflicts(c *gc.C) {
 			upgradeCharm{revision: 2, forced: true},
 			waitHooks{"upgrade-charm", "config-changed"},
 			waitUnitAgent{
-				status: params.StatusIdle,
+				status: status.StatusIdle,
 				charm:  2,
 			},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       params.StatusUnknown,
+				status:       status.StatusUnknown,
 				charm:        2,
 			},
 			verifyCharm{revision: 2},
@@ -1007,12 +1008,12 @@ func (s *UniterSuite) TestUniterUpgradeGitConflicts(c *gc.C) {
 			resolveError{state.ResolvedNoHooks},
 			waitHooks{"upgrade-charm", "config-changed"},
 			waitUnitAgent{
-				status: params.StatusIdle,
+				status: status.StatusIdle,
 				charm:  1,
 			},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       params.StatusUnknown,
+				status:       status.StatusUnknown,
 				charm:        1,
 			},
 			verifyGitCharm{revision: 1},
@@ -1028,11 +1029,11 @@ func (s *UniterSuite) TestUniterUpgradeGitConflicts(c *gc.C) {
 			serveCharm{},
 			createUniter{},
 			waitUnitAgent{
-				status: params.StatusIdle,
+				status: status.StatusIdle,
 			},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       params.StatusUnknown,
+				status:       status.StatusUnknown,
 			},
 			waitHooks{"install", "leader-elected", "config-changed", "start"},
 			verifyGitCharm{dirty: true},
@@ -1049,7 +1050,7 @@ func (s *UniterSuite) TestUniterUpgradeGitConflicts(c *gc.C) {
 			upgradeCharm{revision: 1},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       params.StatusError,
+				status:       status.StatusError,
 				info:         "upgrade failed",
 				charm:        1,
 			},
@@ -1059,7 +1060,7 @@ func (s *UniterSuite) TestUniterUpgradeGitConflicts(c *gc.C) {
 			resolveError{state.ResolvedNoHooks},
 			waitHooks{"upgrade-charm", "config-changed"},
 			waitUnitAgent{
-				status: params.StatusIdle,
+				status: status.StatusIdle,
 				charm:  1,
 			},
 			verifyGitCharm{revision: 1},
@@ -1077,11 +1078,11 @@ func (s *UniterSuite) TestUniterUpgradeGitConflicts(c *gc.C) {
 			serveCharm{},
 			upgradeCharm{revision: 2, forced: true},
 			waitUnitAgent{
-				status: params.StatusIdle,
+				status: status.StatusIdle,
 				charm:  2,
 			}, waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       params.StatusUnknown,
+				status:       status.StatusUnknown,
 				charm:        2,
 			},
 			waitHooks{"upgrade-charm", "config-changed"},
@@ -1236,11 +1237,11 @@ func (s *UniterSuite) TestUniterRelations(c *gc.C) {
 			serveCharm{},
 			createUniter{},
 			waitUnitAgent{
-				status: params.StatusIdle,
+				status: status.StatusIdle,
 			},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       params.StatusUnknown,
+				status:       status.StatusUnknown,
 			},
 			waitHooks{"install", "leader-elected", "config-changed", "start"},
 			addRelation{waitJoin: true},
@@ -1277,7 +1278,7 @@ func (s *UniterSuite) TestUniterRelationErrors(c *gc.C) {
 			startupRelationError{"db-relation-joined"},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       params.StatusError,
+				status:       status.StatusError,
 				info:         `hook failed: "db-relation-joined"`,
 				data: map[string]interface{}{
 					"hook":        "db-relation-joined",
@@ -1290,7 +1291,7 @@ func (s *UniterSuite) TestUniterRelationErrors(c *gc.C) {
 			startupRelationError{"db-relation-changed"},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       params.StatusError,
+				status:       status.StatusError,
 				info:         `hook failed: "db-relation-changed"`,
 				data: map[string]interface{}{
 					"hook":        "db-relation-changed",
@@ -1305,7 +1306,7 @@ func (s *UniterSuite) TestUniterRelationErrors(c *gc.C) {
 			removeRelationUnit{"mysql/0"},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       params.StatusError,
+				status:       status.StatusError,
 				info:         `hook failed: "db-relation-departed"`,
 				data: map[string]interface{}{
 					"hook":        "db-relation-departed",
@@ -1321,7 +1322,7 @@ func (s *UniterSuite) TestUniterRelationErrors(c *gc.C) {
 			relationDying,
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       params.StatusError,
+				status:       status.StatusError,
 				info:         `hook failed: "db-relation-broken"`,
 				data: map[string]interface{}{
 					"hook":        "db-relation-broken",
@@ -1347,10 +1348,10 @@ func (s *UniterSuite) TestActionEvents(c *gc.C) {
 			createServiceAndUnit{},
 			startUniter{},
 			waitAddresses{},
-			waitUnitAgent{status: params.StatusIdle},
+			waitUnitAgent{status: status.StatusIdle},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       params.StatusUnknown,
+				status:       status.StatusUnknown,
 			},
 			waitHooks{"install", "leader-elected", "config-changed", "start"},
 			verifyCharm{},
@@ -1360,10 +1361,10 @@ func (s *UniterSuite) TestActionEvents(c *gc.C) {
 				results: map[string]interface{}{},
 				status:  params.ActionCompleted,
 			}}},
-			waitUnitAgent{status: params.StatusIdle},
+			waitUnitAgent{status: status.StatusIdle},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       params.StatusUnknown,
+				status:       status.StatusUnknown,
 			},
 		), ut(
 			"action-fail causes the action to fail with a message",
@@ -1378,10 +1379,10 @@ func (s *UniterSuite) TestActionEvents(c *gc.C) {
 			createServiceAndUnit{},
 			startUniter{},
 			waitAddresses{},
-			waitUnitAgent{status: params.StatusIdle},
+			waitUnitAgent{status: status.StatusIdle},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       params.StatusUnknown,
+				status:       status.StatusUnknown,
 			},
 			waitHooks{"install", "leader-elected", "config-changed", "start"},
 			verifyCharm{},
@@ -1394,9 +1395,9 @@ func (s *UniterSuite) TestActionEvents(c *gc.C) {
 				message: "I'm afraid I can't let you do that, Dave.",
 				status:  params.ActionFailed,
 			}}},
-			waitUnitAgent{status: params.StatusIdle}, waitUnitAgent{
+			waitUnitAgent{status: status.StatusIdle}, waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       params.StatusUnknown,
+				status:       status.StatusUnknown,
 			},
 		), ut(
 			"action-fail with the wrong arguments fails but is not an error",
@@ -1411,10 +1412,10 @@ func (s *UniterSuite) TestActionEvents(c *gc.C) {
 			createServiceAndUnit{},
 			startUniter{},
 			waitAddresses{},
-			waitUnitAgent{status: params.StatusIdle},
+			waitUnitAgent{status: status.StatusIdle},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       params.StatusUnknown,
+				status:       status.StatusUnknown,
 			},
 			waitHooks{"install", "leader-elected", "config-changed", "start"},
 			verifyCharm{},
@@ -1427,10 +1428,10 @@ func (s *UniterSuite) TestActionEvents(c *gc.C) {
 				message: "A real message",
 				status:  params.ActionFailed,
 			}}},
-			waitUnitAgent{status: params.StatusIdle},
+			waitUnitAgent{status: status.StatusIdle},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       params.StatusUnknown,
+				status:       status.StatusUnknown,
 			},
 		), ut(
 			"actions with correct params passed are not an error",
@@ -1445,10 +1446,10 @@ func (s *UniterSuite) TestActionEvents(c *gc.C) {
 			createServiceAndUnit{},
 			startUniter{},
 			waitAddresses{},
-			waitUnitAgent{status: params.StatusIdle},
+			waitUnitAgent{status: status.StatusIdle},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       params.StatusUnknown,
+				status:       status.StatusUnknown,
 			},
 			waitHooks{"install", "leader-elected", "config-changed", "start"},
 			verifyCharm{},
@@ -1470,10 +1471,10 @@ func (s *UniterSuite) TestActionEvents(c *gc.C) {
 				},
 				status: params.ActionCompleted,
 			}}},
-			waitUnitAgent{status: params.StatusIdle},
+			waitUnitAgent{status: status.StatusIdle},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       params.StatusUnknown,
+				status:       status.StatusUnknown,
 			},
 		), ut(
 			"actions with incorrect params passed are not an error but fail",
@@ -1488,10 +1489,10 @@ func (s *UniterSuite) TestActionEvents(c *gc.C) {
 			createServiceAndUnit{},
 			startUniter{},
 			waitAddresses{},
-			waitUnitAgent{status: params.StatusIdle},
+			waitUnitAgent{status: status.StatusIdle},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       params.StatusUnknown,
+				status:       status.StatusUnknown,
 			},
 			waitHooks{"install", "leader-elected", "config-changed", "start"},
 			verifyCharm{},
@@ -1505,10 +1506,10 @@ func (s *UniterSuite) TestActionEvents(c *gc.C) {
 				status:  params.ActionFailed,
 				message: `cannot run "snapshot" action: validation failed: (root).outfile : must be of type string, given 2`,
 			}}},
-			waitUnitAgent{status: params.StatusIdle},
+			waitUnitAgent{status: status.StatusIdle},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       params.StatusUnknown,
+				status:       status.StatusUnknown,
 			},
 		), ut(
 			"actions not defined in actions.yaml fail without causing a uniter error",
@@ -1522,10 +1523,10 @@ func (s *UniterSuite) TestActionEvents(c *gc.C) {
 			createServiceAndUnit{},
 			startUniter{},
 			waitAddresses{},
-			waitUnitAgent{status: params.StatusIdle},
+			waitUnitAgent{status: status.StatusIdle},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       params.StatusUnknown,
+				status:       status.StatusUnknown,
 			},
 			waitHooks{"install", "leader-elected", "config-changed", "start"},
 			verifyCharm{},
@@ -1536,10 +1537,10 @@ func (s *UniterSuite) TestActionEvents(c *gc.C) {
 				status:  params.ActionFailed,
 				message: `cannot run "snapshot" action: not defined`,
 			}}},
-			waitUnitAgent{status: params.StatusIdle},
+			waitUnitAgent{status: status.StatusIdle},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       params.StatusUnknown,
+				status:       status.StatusUnknown,
 			},
 		), ut(
 			"pending actions get consumed",
@@ -1557,10 +1558,10 @@ func (s *UniterSuite) TestActionEvents(c *gc.C) {
 			addAction{"action-log", nil},
 			startUniter{},
 			waitAddresses{},
-			waitUnitAgent{status: params.StatusIdle},
+			waitUnitAgent{status: status.StatusIdle},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       params.StatusUnknown,
+				status:       status.StatusUnknown,
 			},
 			waitHooks{"install", "leader-elected", "config-changed", "start"},
 			verifyCharm{},
@@ -1577,10 +1578,10 @@ func (s *UniterSuite) TestActionEvents(c *gc.C) {
 				results: map[string]interface{}{},
 				status:  params.ActionCompleted,
 			}}},
-			waitUnitAgent{status: params.StatusIdle},
+			waitUnitAgent{status: status.StatusIdle},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       params.StatusUnknown,
+				status:       status.StatusUnknown,
 			},
 		), ut(
 			"actions not implemented fail but are not errors",
@@ -1594,10 +1595,10 @@ func (s *UniterSuite) TestActionEvents(c *gc.C) {
 			createServiceAndUnit{},
 			startUniter{},
 			waitAddresses{},
-			waitUnitAgent{status: params.StatusIdle},
+			waitUnitAgent{status: status.StatusIdle},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       params.StatusUnknown,
+				status:       status.StatusUnknown,
 			},
 			waitHooks{"install", "leader-elected", "config-changed", "start"},
 			verifyCharm{},
@@ -1608,10 +1609,10 @@ func (s *UniterSuite) TestActionEvents(c *gc.C) {
 				status:  params.ActionFailed,
 				message: `action not implemented on unit "u/0"`,
 			}}},
-			waitUnitAgent{status: params.StatusIdle},
+			waitUnitAgent{status: status.StatusIdle},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       params.StatusUnknown,
+				status:       status.StatusUnknown,
 			},
 		), ut(
 			"actions may run from ModeHookError, but do not clear the error",
@@ -1625,7 +1626,7 @@ func (s *UniterSuite) TestActionEvents(c *gc.C) {
 			addAction{"action-log", nil},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       params.StatusError,
+				status:       status.StatusError,
 				info:         `hook failed: "start"`,
 				data: map[string]interface{}{
 					"hook": "start",
@@ -1638,16 +1639,16 @@ func (s *UniterSuite) TestActionEvents(c *gc.C) {
 			}}},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       params.StatusError,
+				status:       status.StatusError,
 				info:         `hook failed: "start"`,
 				data:         map[string]interface{}{"hook": "start"},
 			},
 			verifyWaiting{},
 			resolveError{state.ResolvedNoHooks},
-			waitUnitAgent{status: params.StatusIdle},
+			waitUnitAgent{status: status.StatusIdle},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       params.StatusMaintenance,
+				status:       status.StatusMaintenance,
 				info:         "installing charm software",
 			},
 		),
@@ -1754,11 +1755,11 @@ func (s *UniterSuite) TestRebootDisabledInActions(c *gc.C) {
 			startUniter{},
 			waitAddresses{},
 			waitUnitAgent{
-				status: params.StatusIdle,
+				status: status.StatusIdle,
 			},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       params.StatusUnknown,
+				status:       status.StatusUnknown,
 			},
 			waitActionResults{[]actionResult{{
 				name: "action-reboot",
@@ -1790,11 +1791,11 @@ func (s *UniterSuite) TestRebootFinishesHook(c *gc.C) {
 			waitHooks{"install"},
 			startUniter{},
 			waitUnitAgent{
-				status: params.StatusIdle,
+				status: status.StatusIdle,
 			},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       params.StatusUnknown,
+				status:       status.StatusUnknown,
 			},
 			waitHooks{"leader-elected", "config-changed", "start"},
 		)})
@@ -1819,11 +1820,11 @@ func (s *UniterSuite) TestRebootNowKillsHook(c *gc.C) {
 			waitHooks{"install"},
 			startUniter{},
 			waitUnitAgent{
-				status: params.StatusIdle,
+				status: status.StatusIdle,
 			},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       params.StatusUnknown,
+				status:       status.StatusUnknown,
 			},
 			waitHooks{"install", "leader-elected", "config-changed", "start"},
 		)})
@@ -1846,7 +1847,7 @@ func (s *UniterSuite) TestRebootDisabledOnHookError(c *gc.C) {
 			waitAddresses{},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       params.StatusError,
+				status:       status.StatusError,
 				info:         fmt.Sprintf(`hook failed: "install"`),
 			},
 		),
@@ -1862,7 +1863,7 @@ func (s *UniterSuite) TestJujuRunExecutionSerialized(c *gc.C) {
 			createUniter{},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       params.StatusError,
+				status:       status.StatusError,
 				info:         `hook failed: "config-changed"`,
 				data: map[string]interface{}{
 					"hook": "config-changed",
@@ -1871,7 +1872,7 @@ func (s *UniterSuite) TestJujuRunExecutionSerialized(c *gc.C) {
 			runCommands{"exit 0"},
 			waitUnitAgent{
 				statusGetter: unitStatusGetter,
-				status:       params.StatusError,
+				status:       status.StatusError,
 				info:         `hook failed: "config-changed"`,
 				data: map[string]interface{}{
 					"hook": "config-changed",
@@ -2086,7 +2087,7 @@ func (s *UniterSuite) TestOperationErrorReported(c *gc.C) {
 			serveCharm{},
 			createUniter{executorFunc: executorFunc},
 			waitUnitAgent{
-				status: params.StatusFailed,
+				status: status.StatusFailed,
 				info:   "resolver loop error",
 			},
 			expectError{".*some error occurred.*"},

--- a/worker/uniter/util_test.go
+++ b/worker/uniter/util_test.go
@@ -32,7 +32,6 @@ import (
 	goyaml "gopkg.in/yaml.v2"
 
 	apiuniter "github.com/juju/juju/api/uniter"
-	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/leadership"
 	coreleadership "github.com/juju/juju/core/leadership"
 	"github.com/juju/juju/juju/sockets"
@@ -40,6 +39,7 @@ import (
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/storage"
+	"github.com/juju/juju/status"
 	"github.com/juju/juju/testcharms"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/worker"
@@ -600,7 +600,7 @@ func (s startupErrorWithCustomCharm) step(c *gc.C, ctx *context) {
 	step(c, ctx, createUniter{})
 	step(c, ctx, waitUnitAgent{
 		statusGetter: unitStatusGetter,
-		status:       params.StatusError,
+		status:       status.StatusError,
 		info:         fmt.Sprintf(`hook failed: %q`, s.badHook),
 	})
 	for _, hook := range startupHooks(false) {
@@ -623,7 +623,7 @@ func (s startupError) step(c *gc.C, ctx *context) {
 	step(c, ctx, createUniter{})
 	step(c, ctx, waitUnitAgent{
 		statusGetter: unitStatusGetter,
-		status:       params.StatusError,
+		status:       status.StatusError,
 		info:         fmt.Sprintf(`hook failed: %q`, s.badHook),
 	})
 	for _, hook := range startupHooks(false) {
@@ -644,7 +644,7 @@ func (s quickStart) step(c *gc.C, ctx *context) {
 	step(c, ctx, createCharm{})
 	step(c, ctx, serveCharm{})
 	step(c, ctx, createUniter{minion: s.minion})
-	step(c, ctx, waitUnitAgent{status: params.StatusIdle})
+	step(c, ctx, waitUnitAgent{status: status.StatusIdle})
 	step(c, ctx, waitHooks(startupHooks(s.minion)))
 	step(c, ctx, verifyCharm{})
 }
@@ -667,7 +667,7 @@ func (s startupRelationError) step(c *gc.C, ctx *context) {
 	step(c, ctx, createCharm{badHooks: []string{s.badHook}})
 	step(c, ctx, serveCharm{})
 	step(c, ctx, createUniter{})
-	step(c, ctx, waitUnitAgent{status: params.StatusIdle})
+	step(c, ctx, waitUnitAgent{status: status.StatusIdle})
 	step(c, ctx, waitHooks(startupHooks(false)))
 	step(c, ctx, verifyCharm{})
 	step(c, ctx, addRelation{})
@@ -683,25 +683,25 @@ func (s resolveError) step(c *gc.C, ctx *context) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-type statusfunc func() (state.StatusInfo, error)
+type statusfunc func() (status.StatusInfo, error)
 
 type statusfuncGetter func(ctx *context) statusfunc
 
 var unitStatusGetter = func(ctx *context) statusfunc {
-	return func() (state.StatusInfo, error) {
+	return func() (status.StatusInfo, error) {
 		return ctx.unit.Status()
 	}
 }
 
 var agentStatusGetter = func(ctx *context) statusfunc {
-	return func() (state.StatusInfo, error) {
+	return func() (status.StatusInfo, error) {
 		return ctx.unit.AgentStatus()
 	}
 }
 
 type waitUnitAgent struct {
 	statusGetter func(ctx *context) statusfunc
-	status       params.Status
+	status       status.Status
 	info         string
 	data         map[string]interface{}
 	charm        int
@@ -984,7 +984,7 @@ func (s startUpgradeError) step(c *gc.C, ctx *context) {
 		serveCharm{},
 		createUniter{},
 		waitUnitAgent{
-			status: params.StatusIdle,
+			status: status.StatusIdle,
 		},
 		waitHooks(startupHooks(false)),
 		verifyCharm{},
@@ -994,7 +994,7 @@ func (s startUpgradeError) step(c *gc.C, ctx *context) {
 		upgradeCharm{revision: 1},
 		waitUnitAgent{
 			statusGetter: unitStatusGetter,
-			status:       params.StatusError,
+			status:       status.StatusError,
 			info:         "upgrade failed",
 			charm:        1,
 		},
@@ -1014,7 +1014,7 @@ func (s verifyWaitingUpgradeError) step(c *gc.C, ctx *context) {
 	verifyCharmSteps := []stepper{
 		waitUnitAgent{
 			statusGetter: unitStatusGetter,
-			status:       params.StatusError,
+			status:       status.StatusError,
 			info:         "upgrade failed",
 			charm:        s.revision,
 		},
@@ -1027,7 +1027,7 @@ func (s verifyWaitingUpgradeError) step(c *gc.C, ctx *context) {
 			// to reset the error status, we can avoid a race in which a subsequent
 			// fixUpgradeError lands just before the restarting uniter retries the
 			// upgrade; and thus puts us in an unexpected state for future steps.
-			err := ctx.unit.SetAgentStatus(state.StatusIdle, "", nil)
+			err := ctx.unit.SetAgentStatus(status.StatusIdle, "", nil)
 			c.Check(err, jc.ErrorIsNil)
 		}},
 		startUniter{},
@@ -1734,7 +1734,7 @@ func (s startGitUpgradeError) step(c *gc.C, ctx *context) {
 		serveCharm{},
 		createUniter{},
 		waitUnitAgent{
-			status: params.StatusIdle,
+			status: status.StatusIdle,
 		},
 		waitHooks(startupHooks(false)),
 		verifyGitCharm{dirty: true},
@@ -1750,7 +1750,7 @@ func (s startGitUpgradeError) step(c *gc.C, ctx *context) {
 		upgradeCharm{revision: 1},
 		waitUnitAgent{
 			statusGetter: unitStatusGetter,
-			status:       params.StatusError,
+			status:       status.StatusError,
 			info:         "upgrade failed",
 			charm:        1,
 		},

--- a/worker/upgradesteps/worker.go
+++ b/worker/upgradesteps/worker.go
@@ -15,11 +15,11 @@ import (
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/api"
-	"github.com/juju/juju/apiserver/params"
 	cmdutil "github.com/juju/juju/cmd/jujud/util"
 	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/multiwatcher"
+	"github.com/juju/juju/status"
 	"github.com/juju/juju/upgrades"
 	"github.com/juju/juju/version"
 	"github.com/juju/juju/worker"
@@ -86,7 +86,7 @@ func NewLock(a agent.Agent) (gate.Lock, error) {
 // StatusSetter defines the single method required to set an agent's
 // status.
 type StatusSetter interface {
-	SetStatus(status params.Status, info string, data map[string]interface{}) error
+	SetStatus(setableStatus status.Status, info string, data map[string]interface{}) error
 }
 
 // NewWorker returns a new instance of the upgradesteps worker. It
@@ -223,7 +223,7 @@ func (w *upgradesteps) run() error {
 	} else {
 		// Upgrade succeeded - signal that the upgrade is complete.
 		logger.Infof("upgrade to %v completed successfully.", w.toVersion)
-		w.machine.SetStatus(params.StatusStarted, "", nil)
+		w.machine.SetStatus(status.StatusStarted, "", nil)
 		w.upgradeComplete.Unlock()
 	}
 	return nil
@@ -343,7 +343,7 @@ func (w *upgradesteps) waitForOtherControllers(info *state.UpgradeInfo) error {
 // designed to be called via a machine agent's ChangeConfig method.
 func (w *upgradesteps) runUpgradeSteps(agentConfig agent.ConfigSetter) error {
 	var upgradeErr error
-	w.machine.SetStatus(params.StatusStarted, fmt.Sprintf("upgrading to %v", w.toVersion), nil)
+	w.machine.SetStatus(status.StatusStarted, fmt.Sprintf("upgrading to %v", w.toVersion), nil)
 
 	context := upgrades.NewContext(agentConfig, w.apiConn, w.st)
 	logger.Infof("starting upgrade from %v to %v for %q", w.fromVersion, w.toVersion, w.tag)
@@ -377,7 +377,7 @@ func (w *upgradesteps) reportUpgradeFailure(err error, willRetry bool) {
 	}
 	logger.Errorf("upgrade from %v to %v for %q failed (%s): %v",
 		w.fromVersion, w.toVersion, w.tag, retryText, err)
-	w.machine.SetStatus(params.StatusError,
+	w.machine.SetStatus(status.StatusError,
 		fmt.Sprintf("upgrade to %v failed (%s): %v", w.toVersion, retryText, err), nil)
 }
 

--- a/worker/upgradesteps/worker_test.go
+++ b/worker/upgradesteps/worker_test.go
@@ -17,7 +17,6 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/agent"
-	"github.com/juju/juju/apiserver/params"
 	cmdutil "github.com/juju/juju/cmd/jujud/util"
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs"
@@ -26,6 +25,7 @@ import (
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/multiwatcher"
 	statetesting "github.com/juju/juju/state/testing"
+	"github.com/juju/juju/status"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/testing/factory"
 	"github.com/juju/juju/upgrades"
@@ -289,7 +289,7 @@ func (s *UpgradeSuite) TestAbortWhenOtherControllerDoesntStartUpgrade(c *gc.C) {
 			"aborted wait for other controllers:" + causeMsg},
 	})
 	c.Assert(statusCalls, jc.DeepEquals, []StatusCall{{
-		params.StatusError,
+		status.StatusError,
 		fmt.Sprintf(
 			"upgrade to %s failed (giving up): aborted wait for other controllers:"+causeMsg,
 			version.Current),
@@ -386,7 +386,7 @@ func (s *UpgradeSuite) TestPreUpgradeFail(c *gc.C) {
 	statusMessage := fmt.Sprintf(
 		`upgrade to %s failed (giving up): %s`, version.Current, causeMessage)
 	c.Assert(statusCalls, jc.DeepEquals, []StatusCall{{
-		params.StatusError, statusMessage,
+		status.StatusError, statusMessage,
 	}})
 }
 
@@ -493,22 +493,22 @@ func (s *UpgradeSuite) setInstantRetryStrategy(c *gc.C) {
 
 func (s *UpgradeSuite) makeExpectedStatusCalls(retryCount int, expectFail bool, failReason string) []StatusCall {
 	calls := []StatusCall{{
-		params.StatusStarted,
+		status.StatusStarted,
 		fmt.Sprintf("upgrading to %s", version.Current),
 	}}
 	for i := 0; i < retryCount; i++ {
 		calls = append(calls, StatusCall{
-			params.StatusError,
+			status.StatusError,
 			fmt.Sprintf("upgrade to %s failed (will retry): %s", version.Current, failReason),
 		})
 	}
 	if expectFail {
 		calls = append(calls, StatusCall{
-			params.StatusError,
+			status.StatusError,
 			fmt.Sprintf("upgrade to %s failed (giving up): %s", version.Current, failReason),
 		})
 	} else {
-		calls = append(calls, StatusCall{params.StatusStarted, ""})
+		calls = append(calls, StatusCall{status.StatusStarted, ""})
 	}
 	return calls
 }
@@ -610,7 +610,7 @@ func (a *fakeAgent) ChangeConfig(mutate agent.ConfigMutator) error {
 }
 
 type StatusCall struct {
-	Status params.Status
+	Status status.Status
 	Info   string
 }
 
@@ -618,7 +618,7 @@ type testStatusSetter struct {
 	Calls []StatusCall
 }
 
-func (s *testStatusSetter) SetStatus(status params.Status, info string, _ map[string]interface{}) error {
+func (s *testStatusSetter) SetStatus(status status.Status, info string, _ map[string]interface{}) error {
 	s.Calls = append(s.Calls, StatusCall{status, info})
 	return nil
 }


### PR DESCRIPTION
Machine provisioning status is now watched and reported
for machines and cotainers as machine status.
Former Status is represented in an unified format under
the name Juju Status.
Some status representations where moved to the base status
package, ideally future modifications will move more parts
of the remaining status into the package.