### PR TITLE
show api info during verbose tests

### DIFF
--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"testing"
 	"time"
 
 	"github.com/bmizerany/pat"
@@ -268,12 +269,16 @@ func (n *requestNotifier) ServerRequest(hdr *rpc.Header, body interface{}) {
 	if hdr.Request.Type == "Pinger" && hdr.Request.Action == "Ping" {
 		return
 	}
-	// TODO(rog) 2013-10-11 remove secrets from some requests.
-	// Until secrets are removed, we only log the body of the requests at trace level
-	// which is below the default level of debug.
-	if logger.IsTraceEnabled() {
+
+	switch {
+	case testing.Verbose():
+		logger.Debugf("<- [%X] %s %s", n.id, n.tag(), jsoncodec.DumpRequest(hdr, body))
+	case logger.IsTraceEnabled():
+		// TODO(rog) 2013-10-11 remove secrets from some requests.
+		// Until secrets are removed, we only log the body of the requests at trace level
+		// which is below the default level of debug.
 		logger.Tracef("<- [%X] %s %s", n.id, n.tag(), jsoncodec.DumpRequest(hdr, body))
-	} else {
+	default:
 		logger.Debugf("<- [%X] %s %s", n.id, n.tag(), jsoncodec.DumpRequest(hdr, "'params redacted'"))
 	}
 }
@@ -282,12 +287,16 @@ func (n *requestNotifier) ServerReply(req rpc.Request, hdr *rpc.Header, body int
 	if req.Type == "Pinger" && req.Action == "Ping" {
 		return
 	}
-	// TODO(rog) 2013-10-11 remove secrets from some responses.
-	// Until secrets are removed, we only log the body of the requests at trace level
-	// which is below the default level of debug.
-	if logger.IsTraceEnabled() {
+
+	switch {
+	case testing.Verbose():
+		logger.Debugf("-> [%X] %s %s", n.id, n.tag(), jsoncodec.DumpRequest(hdr, body))
+	case logger.IsTraceEnabled():
+		// TODO(rog) 2013-10-11 remove secrets from some responses.
+		// Until secrets are removed, we only log the body of the requests at trace level
+		// which is below the default level of debug.
 		logger.Tracef("-> [%X] %s %s", n.id, n.tag(), jsoncodec.DumpRequest(hdr, body))
-	} else {
+	default:
 		logger.Debugf("-> [%X] %s %s %s %s[%q].%s", n.id, n.tag(), timeSpent, jsoncodec.DumpRequest(hdr, "'body redacted'"), req.Type, req.Id, req.Action)
 	}
 }


### PR DESCRIPTION
It's really hard to debug the test output if the API info is all redacted.  Since it's just during testing, there's obviously no secrets to worry about.  Use the verbose flag during go test to turn it on.

(Review request: http://reviews.vapour.ws/r/3887/)