### PR TITLE
Fix region handling for joyent

### DIFF
--- a/provider/joyent/config_test.go
+++ b/provider/joyent/config_test.go
@@ -359,6 +359,7 @@ func validPrepareAttrs() coretesting.Attrs {
 	return validAttrs().Delete("private-key")
 }
 
+// TODO(wallyworld) - add tests for cloud endpoint passed in via bootstrap args
 var prepareConfigTests = []struct {
 	info   string
 	insert coretesting.Attrs

--- a/provider/joyent/provider.go
+++ b/provider/joyent/provider.go
@@ -59,9 +59,7 @@ func (p joyentProvider) PrepareForBootstrap(ctx environs.BootstrapContext, args 
 	// https://us-east.manta.joyent.com, so for now,
 	// if the default value is not correct, it's necessary
 	// to specify the URL in bootstrap config.
-	attrs := map[string]interface{}{
-		SdcUrl: args.CloudEndpoint,
-	}
+	attrs := map[string]interface{}{}
 	// Add the credential attributes to config.
 	switch authType := args.Credentials.AuthType(); authType {
 	case cloud.UserPassAuthType:
@@ -71,6 +69,9 @@ func (p joyentProvider) PrepareForBootstrap(ctx environs.BootstrapContext, args 
 		}
 	default:
 		return nil, errors.NotSupportedf("%q auth-type", authType)
+	}
+	if args.CloudEndpoint != "" {
+		attrs[sdcUrl] = args.CloudEndpoint
 	}
 	cfg, err := args.Config.Apply(attrs)
 	if err != nil {


### PR DESCRIPTION
The region passed in by bootstrap args cloud/region is now used instead of the default.

(Review request: http://reviews.vapour.ws/r/3888/)