### PR TITLE
gce: remove auth-file config, fix map order tests

### DIFF
--- a/provider/gce/credentials.go
+++ b/provider/gce/credentials.go
@@ -56,7 +56,6 @@ func parseJSONAuthFile(filename string) (cloud.Credential, error) {
 	if err != nil {
 		return cloud.Credential{}, errors.Trace(err)
 	}
-	logger.Debugf("%+v", creds)
 	return cloud.NewCredential(cloud.OAuth2AuthType, map[string]string{
 		"project-id":   creds.ProjectID,
 		"client-id":    creds.ClientID,

--- a/provider/gce/credentials.go
+++ b/provider/gce/credentials.go
@@ -56,6 +56,7 @@ func parseJSONAuthFile(filename string) (cloud.Credential, error) {
 	if err != nil {
 		return cloud.Credential{}, errors.Trace(err)
 	}
+	logger.Debugf("%+v", creds)
 	return cloud.NewCredential(cloud.OAuth2AuthType, map[string]string{
 		"project-id":   creds.ProjectID,
 		"client-id":    creds.ClientID,

--- a/provider/gce/google/config.go
+++ b/provider/gce/google/config.go
@@ -106,34 +106,34 @@ func ParseJSONKey(jsonKeyFile io.Reader) (*Credentials, error) {
 // parseJSONKey extracts the auth information from the JSON file
 // downloaded from the GCE console (under /apiui/credential).
 func parseJSONKey(jsonKey []byte) (map[string]string, error) {
-	data := make(map[string]string)
-	if err := json.Unmarshal(jsonKey, &data); err != nil {
+	in := make(map[string]string)
+	if err := json.Unmarshal(jsonKey, &in); err != nil {
 		return nil, errors.Trace(err)
 	}
 
-	keyType, ok := data["type"]
+	keyType, ok := in["type"]
 	if !ok {
 		return nil, errors.New(`missing "type"`)
 	}
 	switch keyType {
 	case jsonKeyTypeServiceAccount:
-		for k, v := range data {
-			delete(data, k)
+		out := make(map[string]string)
+		for k, v := range in {
 			switch k {
 			case "private_key":
-				data[OSEnvPrivateKey] = v
+				out[OSEnvPrivateKey] = v
 			case "client_email":
-				data[OSEnvClientEmail] = v
+				out[OSEnvClientEmail] = v
 			case "client_id":
-				data[OSEnvClientID] = v
+				out[OSEnvClientID] = v
 			case "project_id":
-				data[OSEnvProjectID] = v
+				out[OSEnvProjectID] = v
 			}
 		}
+		return out, nil
 	default:
-		return nil, errors.NotSupportedf("JSON key type %q", data["type"])
+		return nil, errors.NotSupportedf("JSON key type %q", keyType)
 	}
-	return data, nil
 }
 
 // buildJSONKey returns the content of the JSON key file for the

--- a/provider/gce/testing_test.go
+++ b/provider/gce/testing_test.go
@@ -65,7 +65,6 @@ var (
 
 	ConfigAttrs = testing.FakeConfig().Merge(testing.Attrs{
 		"type":           "gce",
-		"auth-file":      "",
 		"private-key":    PrivateKey,
 		"client-id":      ClientID,
 		"client-email":   ClientEmail,


### PR DESCRIPTION
Fix auth-file parsing so it doesn't delete keys it
shouldn't, and drop all of the auth-file related
config. This is now handled by the jsonfile credential
auth-type.

(Review request: http://reviews.vapour.ws/r/3892/)