### PR TITLE
AddInstanceTags to ignore manually provisioned machines on upgrade.

### DIFF
--- a/upgrades/tags.go
+++ b/upgrades/tags.go
@@ -27,6 +27,13 @@ func addInstanceTags(env environs.Environ, machines []*state.Machine) error {
 		if names.IsContainerMachine(m.Id()) {
 			continue
 		}
+		isManual, err := m.IsManual()
+		if err != nil {
+			return errors.Annotatef(err, "determining if machine %v is manually provisioned", m.Id())
+		}
+		if isManual {
+			continue
+		}
 		instId, err := m.InstanceId()
 		if errors.IsNotProvisioned(err) {
 			continue


### PR DESCRIPTION
We should exclude any manually provisioned machines when adding instance tags during upgrades.

Bug https://bugs.launchpad.net/juju-core/+bug/1546100


(Review request: http://reviews.vapour.ws/r/3893/)