### PR TITLE
cmd/juju/backups: fix issue 1546826

### DIFF
--- a/cmd/juju/backups/backups.go
+++ b/cmd/juju/backups/backups.go
@@ -16,7 +16,6 @@ import (
 	apiserverbackups "github.com/juju/juju/apiserver/backups"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/modelcmd"
-	"github.com/juju/juju/juju/osenv"
 	statebackups "github.com/juju/juju/state/backups"
 )
 
@@ -32,16 +31,11 @@ const backupsPurpose = "create, manage, and restore backups of juju's state"
 
 // NewSuperCommand returns a new backups super-command.
 func NewSuperCommand() cmd.Command {
-	log := &cmd.Log{
-		DefaultConfig: os.Getenv(osenv.JujuLoggingConfigEnvKey),
-	}
-
 	backupsCmd := cmd.NewSuperCommand(cmd.SuperCommandParams{
 		Name:        "backups",
 		Doc:         backupsDoc,
 		UsagePrefix: "juju",
 		Purpose:     backupsPurpose,
-		Log:         log,
 	})
 	backupsCmd.Register(newCreateCommand())
 	backupsCmd.Register(newInfoCommand())


### PR DESCRIPTION
Fixes LP # 1546826

Remove the duplicate configuration of the logger in the backups
subcommand.

There is no test because of the way that the logging configuration
passed to the test runner interacts with logger -- in debug mode the
warning logger is not redefined, but in real use it failed.

This has been manually tested.

We should have an integration test asserting that backup and restore
work as specified.

(Review request: http://reviews.vapour.ws/r/3895/)