### PR TITLE
cmd/juju/clouds: list-controllers shows current

### DIFF
--- a/cmd/juju/controller/listcontrollers.go
+++ b/cmd/juju/controller/listcontrollers.go
@@ -52,8 +52,21 @@ func (c *listControllersCommand) Run(ctx *cmd.Context) error {
 	if len(errs) > 0 {
 		fmt.Fprintln(ctx.Stderr, strings.Join(errs, "\n"))
 	}
-	// TODO (anastasiamac 2016-02-13) need to sort out what to do with current-controller.
-	return c.out.Write(ctx, details)
+	currentController, err := modelcmd.ReadCurrentController()
+	if err != nil {
+		return errors.Annotate(err, "getting current controller")
+	}
+	if _, ok := controllers[currentController]; !ok {
+		// TODO(axw) move handling of current-controller to
+		// the jujuclient code, and make sure the file is
+		// kept in-sync with the controllers.yaml file.
+		currentController = ""
+	}
+	controllerSet := ControllerSet{
+		Controllers:       details,
+		CurrentController: currentController,
+	}
+	return c.out.Write(ctx, controllerSet)
 }
 
 type listControllersCommand struct {

--- a/cmd/juju/controller/listcontrollers_test.go
+++ b/cmd/juju/controller/listcontrollers_test.go
@@ -36,7 +36,7 @@ func (s *ListControllersSuite) TestListControllers(c *gc.C) {
 	s.expectedOutput = `
 CONTROLLER                 MODEL     USER         SERVER
 local.aws-test             admin     -            instance-1-2-4.useast.aws.com
-local.mallards             my-model  admin@local  maas-1-05.cluster.mallards
+local.mallards*            my-model  admin@local  maas-1-05.cluster.mallards
 local.mark-test-prodstack  -         -            vm-23532.prodstack.canonical.com
 
 `[1:]
@@ -47,15 +47,17 @@ local.mark-test-prodstack  -         -            vm-23532.prodstack.canonical.c
 
 func (s *ListControllersSuite) TestListControllersYaml(c *gc.C) {
 	s.expectedOutput = `
-local.aws-test:
-  model: admin
-  server: instance-1-2-4.useast.aws.com
-local.mallards:
-  model: my-model
-  user: admin@local
-  server: maas-1-05.cluster.mallards
-local.mark-test-prodstack:
-  server: vm-23532.prodstack.canonical.com
+controllers:
+  local.aws-test:
+    model: admin
+    server: instance-1-2-4.useast.aws.com
+  local.mallards:
+    model: my-model
+    user: admin@local
+    server: maas-1-05.cluster.mallards
+  local.mark-test-prodstack:
+    server: vm-23532.prodstack.canonical.com
+current-controller: local.mallards
 `[1:]
 
 	s.createTestClientStore(c)
@@ -64,7 +66,7 @@ local.mark-test-prodstack:
 
 func (s *ListControllersSuite) TestListControllersJson(c *gc.C) {
 	s.expectedOutput = `
-{"local.aws-test":{"model":"admin","server":"instance-1-2-4.useast.aws.com"},"local.mallards":{"model":"my-model","user":"admin@local","server":"maas-1-05.cluster.mallards"},"local.mark-test-prodstack":{"server":"vm-23532.prodstack.canonical.com"}}
+{"controllers":{"local.aws-test":{"model":"admin","server":"instance-1-2-4.useast.aws.com"},"local.mallards":{"model":"my-model","user":"admin@local","server":"maas-1-05.cluster.mallards"},"local.mark-test-prodstack":{"server":"vm-23532.prodstack.canonical.com"}},"current-controller":"local.mallards"}
 `[1:]
 
 	s.createTestClientStore(c)

--- a/cmd/juju/controller/listcontrollersconverters.go
+++ b/cmd/juju/controller/listcontrollersconverters.go
@@ -11,6 +11,13 @@ import (
 	"github.com/juju/juju/jujuclient"
 )
 
+// ControllerSet contains the set of controllers known to the client,
+// and name of the current controller.
+type ControllerSet struct {
+	Controllers       map[string]ControllerItem `yaml:"controllers" json:"controllers"`
+	CurrentController string                    `yaml:"current-controller" json:"current-controller"`
+}
+
 // ControllerItem defines the serialization behaviour of controller information.
 type ControllerItem struct {
 	ModelName string `yaml:"model,omitempty" json:"model,omitempty"`
@@ -19,8 +26,8 @@ type ControllerItem struct {
 }
 
 // convertControllerDetails takes a map of Controllers and
-// the recently used model for each and
-// creates a list of amalgamated controller and model details.
+// the recently used model for each and creates a list of
+// amalgamated controller and model details.
 func (c *listControllersCommand) convertControllerDetails(storeControllers map[string]jujuclient.ControllerDetails) (map[string]ControllerItem, []string) {
 	if len(storeControllers) == 0 {
 		return nil, nil

--- a/cmd/juju/controller/listcontrollersformatters.go
+++ b/cmd/juju/controller/listcontrollersformatters.go
@@ -16,7 +16,7 @@ import (
 const noValueDisplay = "-"
 
 func formatControllersListTabular(value interface{}) ([]byte, error) {
-	controllers, ok := value.(map[string]ControllerItem)
+	controllers, ok := value.(ControllerSet)
 	if !ok {
 		return nil, errors.Errorf("expected value of type %T, got %T", controllers, value)
 	}
@@ -25,7 +25,7 @@ func formatControllersListTabular(value interface{}) ([]byte, error) {
 
 // formatControllersTabular returns a tabular summary of controller/model items
 // sorted by controller name alphabetically.
-func formatControllersTabular(controllers map[string]ControllerItem) ([]byte, error) {
+func formatControllersTabular(set ControllerSet) ([]byte, error) {
 	var out bytes.Buffer
 
 	const (
@@ -44,13 +44,13 @@ func formatControllersTabular(controllers map[string]ControllerItem) ([]byte, er
 	print("CONTROLLER", "MODEL", "USER", "SERVER")
 
 	names := []string{}
-	for name, _ := range controllers {
+	for name, _ := range set.Controllers {
 		names = append(names, name)
 	}
 	sort.Strings(names)
 
 	for _, name := range names {
-		c := controllers[name]
+		c := set.Controllers[name]
 		modelName := noValueDisplay
 		if c.ModelName != "" {
 			modelName = c.ModelName
@@ -58,6 +58,9 @@ func formatControllersTabular(controllers map[string]ControllerItem) ([]byte, er
 		userName := noValueDisplay
 		if c.User != "" {
 			userName = c.User
+		}
+		if name == set.CurrentController {
+			name += "*"
 		}
 		print(name, modelName, userName, c.Server)
 	}

--- a/cmd/juju/controller/package_test.go
+++ b/cmd/juju/controller/package_test.go
@@ -9,13 +9,14 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	coretesting "github.com/juju/juju/testing"
 )
 
 func TestPackage(t *testing.T) {
-	coretesting.MgoTestPackage(t)
+	gc.TestingT(t)
 }
 
 type baseControllerSuite struct {
@@ -31,6 +32,9 @@ func (s *baseControllerSuite) SetUpTest(c *gc.C) {
 	s.modelsYaml = testModelsYaml
 	s.accountsYaml = testAccountsYaml
 	s.store = nil
+
+	err := modelcmd.WriteCurrentController("local.mallards")
+	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *baseControllerSuite) createTestClientStore(c *gc.C) {

--- a/cmd/juju/controller/showcontroller_test.go
+++ b/cmd/juju/controller/showcontroller_test.go
@@ -186,6 +186,9 @@ func (s *ShowControllerSuite) TestShowControllerNoArgs(c *gc.C) {
 }
 
 func (s *ShowControllerSuite) TestShowControllerNoArgsNoCurrent(c *gc.C) {
+	err := modelcmd.WriteCurrentController("")
+	c.Assert(err, jc.ErrorIsNil)
+
 	s.expectedErr = regexp.QuoteMeta(`there is no active controller`)
 	s.assertShowControllerFailed(c)
 }

--- a/featuretests/cmd_juju_controller_test.go
+++ b/featuretests/cmd_juju_controller_test.go
@@ -57,8 +57,8 @@ func (s *cmdControllerSuite) createEnv(c *gc.C, envname string, isServer bool) {
 func (s *cmdControllerSuite) TestControllerListCommand(c *gc.C) {
 	context := s.run(c, "list-controllers")
 	expectedOutput := `
-CONTROLLER  MODEL       USER         SERVER
-dummymodel  dummymodel  admin@local  
+CONTROLLER   MODEL       USER         SERVER
+dummymodel*  dummymodel  admin@local  
 
 `[1:]
 	c.Assert(testing.Stdout(context), gc.Equals, expectedOutput)


### PR DESCRIPTION
Update list-controllers to show the current controller
in the list by tacking on a "*". The YAML and JSON
output now has top-level "controllers" and "current-
controller" fields.

(Review request: http://reviews.vapour.ws/r/3897/)