### PR TITLE
cloud: add Cloud.DefaultRegion

### DIFF
--- a/cloud/clouds_test.go
+++ b/cloud/clouds_test.go
@@ -60,6 +60,12 @@ func (s *cloudSuite) TestParseCloudsAuthTypes(c *gc.C) {
 	c.Assert(rackspace.AuthTypes, jc.SameContents, []cloud.AuthType{"access-key", "userpass"})
 }
 
+func (s *cloudSuite) TestParseCloudsDefaultRegion(c *gc.C) {
+	clouds := parsePublicClouds(c)
+	aws := clouds["aws"]
+	c.Assert(aws.DefaultRegion, gc.Equals, "us-east-1")
+}
+
 func (s *cloudSuite) TestPublicCloudsMetadataFallback(c *gc.C) {
 	clouds, fallbackUsed, err := cloud.PublicCloudMetadata("badfile.yaml")
 	c.Assert(err, jc.ErrorIsNil)

--- a/cloud/personalclouds.go
+++ b/cloud/personalclouds.go
@@ -11,7 +11,6 @@ import (
 	"os"
 
 	"github.com/juju/errors"
-	"gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/juju/osenv"
 )
@@ -50,9 +49,9 @@ func ParseCloudMetadataFile(file string) (map[string]Cloud, error) {
 // WritePersonalCloudMetadata marshals to YAMl and writes the cloud metadata
 // to the personal cloud file.
 func WritePersonalCloudMetadata(cloudsMap map[string]Cloud) error {
-	data, err := yaml.Marshal(clouds{cloudsMap})
+	data, err := marshalCloudMetadata(cloudsMap)
 	if err != nil {
-		return errors.Annotate(err, "cannot marshal yaml cloud metadata")
+		return errors.Trace(err)
 	}
 	return ioutil.WriteFile(JujuPersonalCloudsPath(), data, os.FileMode(0600))
 }

--- a/cloud/personalclouds_test.go
+++ b/cloud/personalclouds_test.go
@@ -30,6 +30,22 @@ func (s *personalCloudSuite) TestWritePersonalClouds(c *gc.C) {
 				"london": cloud.Region{Endpoint: "http://london/1.0"},
 			},
 		},
+		"azurestack": cloud.Cloud{
+			Type:      "azure",
+			AuthTypes: []cloud.AuthType{"userpass"},
+			Regions: map[string]cloud.Region{
+				"prod": cloud.Region{
+					Endpoint: "http://prod.azurestack.local",
+				},
+				"dev": cloud.Region{
+					Endpoint: "http://dev.azurestack.local",
+				},
+				"test": cloud.Region{
+					Endpoint: "http://test.azurestack.local",
+				},
+			},
+			DefaultRegion: "test",
+		},
 	}
 	err := cloud.WritePersonalCloudMetadata(clouds)
 	c.Assert(err, jc.ErrorIsNil)
@@ -37,6 +53,16 @@ func (s *personalCloudSuite) TestWritePersonalClouds(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(data), gc.Equals, `
 clouds:
+  azurestack:
+    type: azure
+    auth-types: [userpass]
+    regions:
+      test:
+        endpoint: http://test.azurestack.local
+      dev:
+        endpoint: http://dev.azurestack.local
+      prod:
+        endpoint: http://prod.azurestack.local
   homestack:
     type: openstack
     auth-types: [userpass, access-key]
@@ -77,6 +103,7 @@ func (s *personalCloudSuite) assertPersonalClouds(c *gc.C, clouds map[string]clo
 			Regions: map[string]cloud.Region{
 				"london": cloud.Region{Endpoint: "http://london/1.0"},
 			},
+			DefaultRegion: "london",
 		},
 		"azurestack": cloud.Cloud{
 			Type:            "azure",
@@ -88,6 +115,7 @@ func (s *personalCloudSuite) assertPersonalClouds(c *gc.C, clouds map[string]clo
 					StorageEndpoint: "http://storage.azurestack.local",
 				},
 			},
+			DefaultRegion: "local",
 		},
 	})
 }


### PR DESCRIPTION
Add the DefaultRegion to the Cloud type,
which is populated with the name of the
first region in the cloud when parsing
YAML. Used to decide which region is first
when marshalling to YAML.

Bootstrap code has not yet been updated.

(Review request: http://reviews.vapour.ws/r/3899/)