### PR TITLE
cloud: represent regions as a slice in API

### DIFF
--- a/cloud/clouds_test.go
+++ b/cloud/clouds_test.go
@@ -43,9 +43,9 @@ func (s *cloudSuite) TestParseCloudsEndpointDenormalisation(c *gc.C) {
 	c.Assert(rackspace.Type, gc.Equals, "rackspace")
 	c.Assert(rackspace.Endpoint, gc.Equals, "https://identity.api.rackspacecloud.com/v2.0")
 	var regionNames []string
-	for name, region := range rackspace.Regions {
-		regionNames = append(regionNames, name)
-		if name == "LON" {
+	for _, region := range rackspace.Regions {
+		regionNames = append(regionNames, region.Name)
+		if region.Name == "LON" {
 			c.Assert(region.Endpoint, gc.Equals, "https://lon.identity.api.rackspacecloud.com/v2.0")
 		} else {
 			c.Assert(region.Endpoint, gc.Equals, "https://identity.api.rackspacecloud.com/v2.0")

--- a/cloud/personalclouds.go
+++ b/cloud/personalclouds.go
@@ -11,7 +11,6 @@ import (
 	"os"
 
 	"github.com/juju/errors"
-	"gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/juju/osenv"
 )
@@ -50,9 +49,9 @@ func ParseCloudMetadataFile(file string) (map[string]Cloud, error) {
 // WritePersonalCloudMetadata marshals to YAMl and writes the cloud metadata
 // to the personal cloud file.
 func WritePersonalCloudMetadata(cloudsMap map[string]Cloud) error {
-	data, err := yaml.Marshal(clouds{cloudsMap})
+	data, err := marshalCloudMetadata(cloudsMap)
 	if err != nil {
-		return errors.Annotate(err, "cannot marshal yaml cloud metadata")
+		return errors.Trace(err)
 	}
 	return ioutil.WriteFile(JujuPersonalCloudsPath(), data, os.FileMode(0600))
 }

--- a/cloud/personalclouds_test.go
+++ b/cloud/personalclouds_test.go
@@ -26,9 +26,23 @@ func (s *personalCloudSuite) TestWritePersonalClouds(c *gc.C) {
 			Type:      "openstack",
 			AuthTypes: []cloud.AuthType{"userpass", "access-key"},
 			Endpoint:  "http://homestack",
-			Regions: map[string]cloud.Region{
-				"london": cloud.Region{Endpoint: "http://london/1.0"},
+			Regions: []cloud.Region{
+				cloud.Region{Name: "london", Endpoint: "http://london/1.0"},
 			},
+		},
+		"azurestack": cloud.Cloud{
+			Type:      "azure",
+			AuthTypes: []cloud.AuthType{"userpass"},
+			Regions: []cloud.Region{{
+				Name:     "prod",
+				Endpoint: "http://prod.azurestack.local",
+			}, {
+				Name:     "dev",
+				Endpoint: "http://dev.azurestack.local",
+			}, {
+				Name:     "test",
+				Endpoint: "http://test.azurestack.local",
+			}},
 		},
 	}
 	err := cloud.WritePersonalCloudMetadata(clouds)
@@ -37,6 +51,16 @@ func (s *personalCloudSuite) TestWritePersonalClouds(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(data), gc.Equals, `
 clouds:
+  azurestack:
+    type: azure
+    auth-types: [userpass]
+    regions:
+      prod:
+        endpoint: http://prod.azurestack.local
+      dev:
+        endpoint: http://dev.azurestack.local
+      test:
+        endpoint: http://test.azurestack.local
   homestack:
     type: openstack
     auth-types: [userpass, access-key]
@@ -74,16 +98,17 @@ func (s *personalCloudSuite) assertPersonalClouds(c *gc.C, clouds map[string]clo
 			Type:      "openstack",
 			AuthTypes: []cloud.AuthType{"userpass", "access-key"},
 			Endpoint:  "http://homestack",
-			Regions: map[string]cloud.Region{
-				"london": cloud.Region{Endpoint: "http://london/1.0"},
+			Regions: []cloud.Region{
+				cloud.Region{Name: "london", Endpoint: "http://london/1.0"},
 			},
 		},
 		"azurestack": cloud.Cloud{
 			Type:            "azure",
 			AuthTypes:       []cloud.AuthType{"userpass"},
 			StorageEndpoint: "http://storage.azurestack.local",
-			Regions: map[string]cloud.Region{
-				"local": cloud.Region{
+			Regions: []cloud.Region{
+				cloud.Region{
+					Name:            "local",
 					Endpoint:        "http://azurestack.local",
 					StorageEndpoint: "http://storage.azurestack.local",
 				},

--- a/cmd/juju/cloud/list_test.go
+++ b/cmd/juju/cloud/list_test.go
@@ -61,7 +61,7 @@ func (s *listSuite) TestListYAML(c *gc.C) {
 	out := testing.Stdout(ctx)
 	out = strings.Replace(out, "\n", "", -1)
 	// Just check a snippet of the output to make sure it looks ok.
-	c.Assert(out, gc.Matches, `.*aws:[ ]*type: ec2[ ]*auth-types: \[access-key\].*`)
+	c.Assert(out, gc.Matches, `.*aws:[ ]*defined: public[ ]*type: ec2[ ]*auth-types: \[access-key\].*`)
 }
 
 func (s *listSuite) TestListJSON(c *gc.C) {
@@ -71,5 +71,5 @@ func (s *listSuite) TestListJSON(c *gc.C) {
 	out := testing.Stdout(ctx)
 	out = strings.Replace(out, "\n", "", -1)
 	// Just check a snippet of the output to make sure it looks ok.
-	c.Assert(out, gc.Matches, `.*{"aws":{"Type":"ec2","AuthTypes":\["access-key"\].*`)
+	c.Assert(out, gc.Matches, `.*{"aws":{"defined":"public","type":"ec2","auth-types":\["access-key"\].*`)
 }

--- a/cmd/juju/cloud/show.go
+++ b/cmd/juju/cloud/show.go
@@ -69,30 +69,35 @@ func (c *showCloudCommand) Run(ctxt *cmd.Context) error {
 }
 
 type regionDetails struct {
-	Endpoint  string   `yaml:"auth-url"`
-	AuthTypes []string `yaml:"auth-type,omitempty"`
+	Endpoint        string `yaml:"endpoint,omitempty" json:"endpoint,omitempty"`
+	StorageEndpoint string `yaml:"storage-endpoint,omitempty" json:"storage-endpoint,omitempty"`
 }
 
 type cloudDetails struct {
-	Source    string                   `yaml:"defined"`
-	CloudType string                   `yaml:"type"`
-	AuthTypes []string                 `yaml:"auth-type,omitempty,flow"`
-	Regions   map[string]regionDetails `yaml:"regions,omitempty"`
+	Source          string                   `yaml:"defined,omitempty" json:"defined,omitempty"`
+	CloudType       string                   `yaml:"type" json:"type"`
+	AuthTypes       []string                 `yaml:"auth-types,omitempty,flow" json:"auth-types,omitempty"`
+	Endpoint        string                   `yaml:"endpoint,omitempty" json:"endpoint,omitempty"`
+	StorageEndpoint string                   `yaml:"storage-endpoint,omitempty" json:"storage-endpoint,omitempty"`
+	Regions         map[string]regionDetails `yaml:"regions,omitempty" json:"regions,omitempty"`
 }
 
 func makeCloudDetails(cloud jujucloud.Cloud) *cloudDetails {
 	result := &cloudDetails{
-		Source:    "public",
-		CloudType: cloud.Type,
+		Source:          "public",
+		CloudType:       cloud.Type,
+		Endpoint:        cloud.Endpoint,
+		StorageEndpoint: cloud.StorageEndpoint,
 	}
 	result.AuthTypes = make([]string, len(cloud.AuthTypes))
 	for i, at := range cloud.AuthTypes {
 		result.AuthTypes[i] = string(at)
 	}
 	result.Regions = make(map[string]regionDetails)
-	for name, region := range cloud.Regions {
-		result.Regions[name] = regionDetails{
-			Endpoint: region.Endpoint,
+	for _, region := range cloud.Regions {
+		result.Regions[region.Name] = regionDetails{
+			Endpoint:        region.Endpoint,
+			StorageEndpoint: region.Endpoint,
 		}
 	}
 	return result

--- a/cmd/juju/cloud/show_test.go
+++ b/cmd/juju/cloud/show_test.go
@@ -30,9 +30,10 @@ func (s *showSuite) TestShow(c *gc.C) {
 	c.Assert(out, gc.Equals, `
 defined: public
 type: ec2
-auth-type: [access-key]
+auth-types: [access-key]
 regions:
   cn-north-1:
-    auth-url: https://ec2.cn-north-1.amazonaws.com.cn/
+    endpoint: https://ec2.cn-north-1.amazonaws.com.cn/
+    storage-endpoint: https://ec2.cn-north-1.amazonaws.com.cn/
 `[1:])
 }

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -1034,7 +1034,7 @@ type noCloudRegionsProvider struct {
 	environs.EnvironProvider
 }
 
-func (noCloudRegionsProvider) DetectRegions() (map[string]cloud.Region, error) {
+func (noCloudRegionsProvider) DetectRegions() ([]cloud.Region, error) {
 	return nil, errors.NotFoundf("regions")
 }
 
@@ -1042,8 +1042,8 @@ type noCredentialsProvider struct {
 	environs.EnvironProvider
 }
 
-func (noCredentialsProvider) DetectRegions() (map[string]cloud.Region, error) {
-	return map[string]cloud.Region{"region": {}}, nil
+func (noCredentialsProvider) DetectRegions() ([]cloud.Region, error) {
+	return []cloud.Region{{Name: "region"}}, nil
 }
 
 func (noCredentialsProvider) DetectCredentials() ([]cloud.Credential, error) {

--- a/environs/interface.go
+++ b/environs/interface.go
@@ -107,11 +107,13 @@ type CloudRegionDetector interface {
 	// DetectRetions automatically detects one or more regions
 	// from the environment. This may involve, for example, inspecting
 	// environment variables, or returning special hard-coded regions
-	// (e.g. "localhost" for lxd).
+	// (e.g. "localhost" for lxd). The first item in the list will be
+	// considered the default region for bootstrapping if the user
+	// does not specify one.
 	//
 	// If no regions can be detected, DetectRegions should return
 	// an error satisfying errors.IsNotFound.
-	DetectRegions() (map[string]cloud.Region, error)
+	DetectRegions() ([]cloud.Region, error)
 }
 
 // ModelConfigUpgrader is an interface that an EnvironProvider may

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -518,8 +518,8 @@ func (*environProvider) DetectCredentials() ([]cloud.Credential, error) {
 	return []cloud.Credential{cloud.NewEmptyCredential()}, nil
 }
 
-func (*environProvider) DetectRegions() (map[string]cloud.Region, error) {
-	return map[string]cloud.Region{"dummy": {}}, nil
+func (*environProvider) DetectRegions() ([]cloud.Region, error) {
+	return []cloud.Region{{Name: "dummy"}}, nil
 }
 
 func (p *environProvider) Validate(cfg, old *config.Config) (valid *config.Config, err error) {

--- a/provider/lxd/provider.go
+++ b/provider/lxd/provider.go
@@ -101,9 +101,9 @@ func (environProvider) SecretAttrs(cfg *config.Config) (map[string]string, error
 }
 
 // DetectRegions implements environs.CloudRegionDetector.
-func (environProvider) DetectRegions() (map[string]cloud.Region, error) {
+func (environProvider) DetectRegions() ([]cloud.Region, error) {
 	// For now we just return a hard-coded "localhost" region,
 	// i.e. the local LXD daemon. We may later want to detect
 	// locally-configured remotes.
-	return map[string]cloud.Region{"localhost": {}}, nil
+	return []cloud.Region{{Name: "localhost"}}, nil
 }

--- a/provider/lxd/provider_test.go
+++ b/provider/lxd/provider_test.go
@@ -38,9 +38,7 @@ func (s *providerSuite) TestDetectRegions(c *gc.C) {
 	c.Assert(s.provider, gc.Implements, new(environs.CloudRegionDetector))
 	regions, err := s.provider.(environs.CloudRegionDetector).DetectRegions()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(regions, jc.DeepEquals, map[string]cloud.Region{
-		"localhost": {},
-	})
+	c.Assert(regions, jc.DeepEquals, []cloud.Region{{Name: "localhost"}})
 }
 
 func (s *providerSuite) TestRegistered(c *gc.C) {

--- a/provider/manual/provider.go
+++ b/provider/manual/provider.go
@@ -41,7 +41,7 @@ func (p manualProvider) RestrictedConfigAttributes() []string {
 }
 
 // DetectRegions is specified in the environs.CloudRegionDetector interface.
-func (p manualProvider) DetectRegions() (map[string]cloud.Region, error) {
+func (p manualProvider) DetectRegions() ([]cloud.Region, error) {
 	return nil, errors.NotFoundf("regions")
 }
 

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -88,7 +88,7 @@ func (p EnvironProvider) RestrictedConfigAttributes() []string {
 }
 
 // DetectRegions implements environs.CloudRegionDetector.
-func (EnvironProvider) DetectRegions() (map[string]cloud.Region, error) {
+func (EnvironProvider) DetectRegions() ([]cloud.Region, error) {
 	// If OS_REGION_NAME and OS_AUTH_URL are both set,
 	// return return a region using them.
 	creds := identity.CredentialsFromEnv()
@@ -98,11 +98,10 @@ func (EnvironProvider) DetectRegions() (map[string]cloud.Region, error) {
 	if creds.URL == "" {
 		return nil, errors.NewNotFound(nil, "OS_AUTH_URL environment variable not set")
 	}
-	return map[string]cloud.Region{
-		creds.Region: {
-			Endpoint: creds.URL,
-		},
-	}, nil
+	return []cloud.Region{{
+		Name:     creds.Region,
+		Endpoint: creds.URL,
+	}}, nil
 }
 
 // PrepareForCreateEnvironment is specified in the EnvironProvider interface.

--- a/provider/openstack/provider_test.go
+++ b/provider/openstack/provider_test.go
@@ -368,12 +368,12 @@ func (s *localTests) TestDetectRegions(c *gc.C) {
 	s.PatchEnvironment("OS_AUTH_URL", "http://keystone.internal")
 	regions, err := s.detectRegions(c)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(regions, jc.DeepEquals, map[string]cloud.Region{
-		"oceania": {Endpoint: "http://keystone.internal"},
+	c.Assert(regions, jc.DeepEquals, []cloud.Region{
+		{Name: "oceania", Endpoint: "http://keystone.internal"},
 	})
 }
 
-func (s *localTests) detectRegions(c *gc.C) (map[string]cloud.Region, error) {
+func (s *localTests) detectRegions(c *gc.C) ([]cloud.Region, error) {
 	provider, err := environs.Provider("openstack")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(provider, gc.Implements, new(environs.CloudRegionDetector))

--- a/scripts/win-installer/setup.iss
+++ b/scripts/win-installer/setup.iss
@@ -2,7 +2,7 @@
 ; SEE THE DOCUMENTATION FOR DETAILS ON CREATING INNO SETUP SCRIPT FILES!
 
 #define MyAppName "Juju"
-#define MyAppVersion "2.0-delta1"
+#define MyAppVersion "2.0-beta1"
 #define MyAppPublisher "Canonical, Ltd"
 #define MyAppURL "http://juju.ubuntu.com/"
 #define MyAppExeName "juju.exe"

--- a/version/version.go
+++ b/version/version.go
@@ -22,7 +22,7 @@ import (
 // The presence and format of this constant is very important.
 // The debian/rules build recipe uses this value for the version
 // number of the release package.
-const version = "2.0-delta1"
+const version = "2.0-beta1"
 
 // The version that we switched over from old style numbering to new style.
 var switchOverVersion = MustParse("1.19.9")


### PR DESCRIPTION
cloud.Cloud.Regions is now a slice, with the name in the Region type. The
first region in the slice is the default for bootstrap if none is
specified.

Also, update version to 2.0-beta1

(Review request: http://reviews.vapour.ws/r/3905/)