### PR TITLE
cmd/juju/controller: register updates account

### DIFF
--- a/cmd/juju/controller/register.go
+++ b/cmd/juju/controller/register.go
@@ -168,7 +168,7 @@ func (c *registerCommand) Run(ctx *cmd.Context) error {
 		return errors.Trace(err)
 	}
 
-	// Store the controller information.
+	// Store the controller and account details.
 	controllerDetails := jujuclient.ControllerDetails{
 		ControllerUUID: responsePayload.ControllerUUID,
 		CACert:         responsePayload.CACert,
@@ -182,6 +182,15 @@ func (c *registerCommand) Run(ctx *cmd.Context) error {
 	}
 	if err := juju.UpdateControllerAddresses(
 		c.store, legacyStore, registrationParams.controllerName, nil, hostPorts...,
+	); err != nil {
+		return errors.Trace(err)
+	}
+	accountDetails := jujuclient.AccountDetails{
+		User:     registrationParams.userTag.Canonical(),
+		Password: registrationParams.newPassword,
+	}
+	if err := c.store.UpdateAccount(
+		registrationParams.controllerName, accountDetails.User, accountDetails,
 	); err != nil {
 		return errors.Trace(err)
 	}

--- a/cmd/juju/controller/register.go
+++ b/cmd/juju/controller/register.go
@@ -159,7 +159,6 @@ func (c *registerCommand) Run(ctx *cmd.Context) error {
 	endpoint.ServerUUID = responsePayload.ControllerUUID
 	endpoint.CACert = responsePayload.CACert
 	controllerInfo.SetAPIEndpoint(endpoint)
-	// TODO(wallyworld) - update accounts.yaml
 	controllerInfo.SetAPICredentials(configstore.APICredentials{
 		User:     registrationParams.userTag.Id(),
 		Password: registrationParams.newPassword,

--- a/cmd/juju/controller/register_test.go
+++ b/cmd/juju/controller/register_test.go
@@ -207,6 +207,12 @@ func (s *RegisterSuite) TestRegister(c *gc.C) {
 		APIEndpoints:   []string{s.apiConnection.addr},
 		CACert:         testing.CACert,
 	})
+	account, err := s.store.AccountByName("controller-name", "bob@local")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(account, jc.DeepEquals, &jujuclient.AccountDetails{
+		User:     "bob@local",
+		Password: "hunter2",
+	})
 
 	// The command should have logged into the controller with the
 	// information we checked above.


### PR DESCRIPTION
After running "juju register", your username and
password will now be stored in the accounts.yaml
file as well as in the legacy configstore.

(Review request: http://reviews.vapour.ws/r/3908/)