### PR TITLE
Ensure regions are printed in the correct order

### DIFF
--- a/cmd/juju/cloud/list.go
+++ b/cmd/juju/cloud/list.go
@@ -124,7 +124,7 @@ func formatCloudsTabular(value interface{}) ([]byte, error) {
 		info := clouds[name]
 		var regions []string
 		for _, region := range info.Regions {
-			regions = append(regions, region.Name)
+			regions = append(regions, fmt.Sprint(region.Key))
 		}
 		// TODO(wallyworld) - we should be smarter about handling
 		// long region text, for now we'll display the first 7 as

--- a/cmd/juju/cloud/list.go
+++ b/cmd/juju/cloud/list.go
@@ -123,8 +123,8 @@ func formatCloudsTabular(value interface{}) ([]byte, error) {
 	for _, name := range cloudNames {
 		info := clouds[name]
 		var regions []string
-		for name := range info.Regions {
-			regions = append(regions, name)
+		for _, region := range info.Regions {
+			regions = append(regions, region.Name)
 		}
 		// TODO(wallyworld) - we should be smarter about handling
 		// long region text, for now we'll display the first 7 as

--- a/cmd/juju/cloud/list_test.go
+++ b/cmd/juju/cloud/list_test.go
@@ -10,17 +10,19 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	jujucloud "github.com/juju/juju/cloud"
 	"github.com/juju/juju/cmd/juju/cloud"
 	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/testing"
 )
 
-type listSuite struct{}
+type listSuite struct {
+	testing.FakeJujuXDGDataHomeSuite
+}
 
 var _ = gc.Suite(&listSuite{})
 
 func (s *listSuite) TestListPublic(c *gc.C) {
-	defer osenv.SetJujuXDGDataHome(osenv.SetJujuXDGDataHome(c.MkDir()))
 	ctx, err := testing.RunCommand(c, cloud.NewListCloudsCommand())
 	c.Assert(err, jc.ErrorIsNil)
 	out := testing.Stdout(ctx)
@@ -30,8 +32,6 @@ func (s *listSuite) TestListPublic(c *gc.C) {
 }
 
 func (s *listSuite) TestListPublicAndPersonal(c *gc.C) {
-	jujuXDGDataHome := c.MkDir()
-	defer osenv.SetJujuXDGDataHome(osenv.SetJujuXDGDataHome(jujuXDGDataHome))
 	data := `
 clouds:
   homestack:
@@ -55,7 +55,6 @@ clouds:
 }
 
 func (s *listSuite) TestListYAML(c *gc.C) {
-	defer osenv.SetJujuXDGDataHome(osenv.SetJujuXDGDataHome(c.MkDir()))
 	ctx, err := testing.RunCommand(c, cloud.NewListCloudsCommand(), "--format", "yaml")
 	c.Assert(err, jc.ErrorIsNil)
 	out := testing.Stdout(ctx)
@@ -65,11 +64,26 @@ func (s *listSuite) TestListYAML(c *gc.C) {
 }
 
 func (s *listSuite) TestListJSON(c *gc.C) {
-	defer osenv.SetJujuXDGDataHome(osenv.SetJujuXDGDataHome(c.MkDir()))
 	ctx, err := testing.RunCommand(c, cloud.NewListCloudsCommand(), "--format", "json")
 	c.Assert(err, jc.ErrorIsNil)
 	out := testing.Stdout(ctx)
 	out = strings.Replace(out, "\n", "", -1)
 	// Just check a snippet of the output to make sure it looks ok.
 	c.Assert(out, gc.Matches, `.*{"aws":{"defined":"public","type":"ec2","auth-types":\["access-key"\].*`)
+}
+
+func (s *showSuite) TestListPreservesRegionOrder(c *gc.C) {
+	ctx, err := testing.RunCommand(c, cloud.NewListCloudsCommand(), "--format", "yaml")
+	c.Assert(err, jc.ErrorIsNil)
+	lines := strings.Split(testing.Stdout(ctx), "\n")
+	withClouds := "clouds:\n  " + strings.Join(lines, "\n  ")
+
+	parsedClouds, err := jujucloud.ParseCloudMetadata([]byte(withClouds))
+	c.Assert(err, jc.ErrorIsNil)
+	parsedCloud, ok := parsedClouds["aws"]
+	c.Assert(ok, jc.IsTrue) // aws found in output
+
+	aws, err := jujucloud.CloudByName("aws")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(&parsedCloud, jc.DeepEquals, aws)
 }

--- a/cmd/juju/cloud/show.go
+++ b/cmd/juju/cloud/show.go
@@ -100,9 +100,9 @@ func makeCloudDetails(cloud jujucloud.Cloud) *cloudDetails {
 	}
 	result.RegionsMap = make(map[string]regionDetails)
 	for _, region := range cloud.Regions {
-		r := regionDetails{
-			Name:     region.Name,
-			Endpoint: region.Endpoint,
+		r := regionDetails{Name: region.Name}
+		if region.Endpoint != result.Endpoint {
+			r.Endpoint = region.Endpoint
 		}
 		if region.StorageEndpoint != result.StorageEndpoint {
 			r.StorageEndpoint = region.StorageEndpoint

--- a/cmd/juju/cloud/show_test.go
+++ b/cmd/juju/cloud/show_test.go
@@ -8,22 +8,21 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cmd/juju/cloud"
-	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/testing"
 )
 
-type showSuite struct{}
+type showSuite struct {
+	testing.FakeJujuXDGDataHomeSuite
+}
 
 var _ = gc.Suite(&showSuite{})
 
 func (s *showSuite) TestShowBadArgs(c *gc.C) {
-	defer osenv.SetJujuXDGDataHome(osenv.SetJujuXDGDataHome(c.MkDir()))
 	_, err := testing.RunCommand(c, cloud.NewShowCloudCommand())
 	c.Assert(err, gc.ErrorMatches, "no cloud specified")
 }
 
 func (s *showSuite) TestShow(c *gc.C) {
-	defer osenv.SetJujuXDGDataHome(osenv.SetJujuXDGDataHome(c.MkDir()))
 	ctx, err := testing.RunCommand(c, cloud.NewShowCloudCommand(), "aws-china")
 	c.Assert(err, jc.ErrorIsNil)
 	out := testing.Stdout(ctx)
@@ -34,6 +33,5 @@ auth-types: [access-key]
 regions:
   cn-north-1:
     endpoint: https://ec2.cn-north-1.amazonaws.com.cn/
-    storage-endpoint: https://ec2.cn-north-1.amazonaws.com.cn/
 `[1:])
 }


### PR DESCRIPTION
juju list-clouds and juju show-cloud now print regions in the same order as defined in clouds.yaml

(Review request: http://reviews.vapour.ws/r/3911/)