### PR TITLE
apiserver/{client,charms}: do not import types from the client api

### DIFF
--- a/api/charms/client_test.go
+++ b/api/charms/client_test.go
@@ -9,7 +9,6 @@ import (
 
 	basetesting "github.com/juju/juju/api/base/testing"
 	"github.com/juju/juju/api/charms"
-	"github.com/juju/juju/apiserver/params"
 	coretesting "github.com/juju/juju/testing"
 )
 
@@ -26,17 +25,13 @@ func (s *charmsMockSuite) TestIsMeteredFalse(c *gc.C) {
 	var called bool
 	curl := "local:quantal/dummy-1"
 	apiCaller := basetesting.APICallerFunc(
-		func(objType string,
-			version int,
-			id, request string,
-			a, result interface{},
-		) error {
+		func(objType string, version int, id, request string, a, result interface{}) error {
 			called = true
 			c.Check(objType, gc.Equals, "Charms")
 			c.Check(id, gc.Equals, "")
 			c.Check(request, gc.Equals, "IsMetered")
 
-			args, ok := a.(params.CharmInfo)
+			args, ok := a.(struct{ CharmURL string })
 			c.Assert(ok, jc.IsTrue)
 			c.Assert(args.CharmURL, gc.DeepEquals, curl)
 			return nil

--- a/api/client.go
+++ b/api/client.go
@@ -158,23 +158,16 @@ func (c *Client) SetModelConstraints(constraints constraints.Value) error {
 	return c.facade.FacadeCall("SetModelConstraints", params, nil)
 }
 
-// CharmInfo holds information about a charm.
-type CharmInfo struct {
-	Revision int
-	URL      string
-	Config   *charm.Config
-	Meta     *charm.Meta
-	Actions  *charm.Actions
-}
-
 // CharmInfo returns information about the requested charm.
-func (c *Client) CharmInfo(charmURL string) (*CharmInfo, error) {
-	args := params.CharmInfo{CharmURL: charmURL}
-	info := new(CharmInfo)
-	if err := c.facade.FacadeCall("CharmInfo", args, info); err != nil {
+func (c *Client) CharmInfo(charmURL string) (*params.CharmInfo, error) {
+	args := struct {
+		CharmURL string
+	}{charmURL}
+	var info params.CharmInfo
+	if err := c.facade.FacadeCall("CharmInfo", args, &info); err != nil {
 		return nil, err
 	}
-	return info, nil
+	return &info, nil
 }
 
 // ModelInfo returns details about the Juju model.

--- a/apiserver/charms/client.go
+++ b/apiserver/charms/client.go
@@ -8,7 +8,6 @@ import (
 	"github.com/juju/utils/set"
 	"gopkg.in/juju/charm.v6-unstable"
 
-	"github.com/juju/juju/api"
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
@@ -25,8 +24,8 @@ var getState = func(st *state.State) charmsAccess {
 // Charms defines the methods on the charms API end point.
 type Charms interface {
 	List(args params.CharmsList) (params.CharmsListResult, error)
-	CharmInfo(args params.CharmInfo) (api.CharmInfo, error)
-	IsMetered(args params.CharmInfo) (bool, error)
+	CharmInfo(CharmInfo) (params.CharmInfo, error)
+	IsMetered(CharmInfo) (bool, error)
 }
 
 // API implements the charms interface and is the concrete
@@ -52,17 +51,22 @@ func NewAPI(
 	}, nil
 }
 
+// CharmInfo holds the url of the requested charm.
+type CharmInfo struct {
+	CharmURL string
+}
+
 // CharmInfo returns information about the requested charm.
-func (a *API) CharmInfo(args params.CharmInfo) (api.CharmInfo, error) {
+func (a *API) CharmInfo(args CharmInfo) (params.CharmInfo, error) {
 	curl, err := charm.ParseURL(args.CharmURL)
 	if err != nil {
-		return api.CharmInfo{}, err
+		return params.CharmInfo{}, err
 	}
 	aCharm, err := a.access.Charm(curl)
 	if err != nil {
-		return api.CharmInfo{}, err
+		return params.CharmInfo{}, err
 	}
-	info := api.CharmInfo{
+	info := params.CharmInfo{
 		Revision: aCharm.Revision(),
 		URL:      curl.String(),
 		Config:   aCharm.Config(),
@@ -97,7 +101,7 @@ func (a *API) List(args params.CharmsList) (params.CharmsListResult, error) {
 }
 
 // IsMetered returns whether or not the charm is metered.
-func (a *API) IsMetered(args params.CharmInfo) (params.IsMeteredResult, error) {
+func (a *API) IsMetered(args CharmInfo) (params.IsMeteredResult, error) {
 	curl, err := charm.ParseURL(args.CharmURL)
 	if err != nil {
 		return params.IsMeteredResult{false}, err

--- a/apiserver/charms/client_test.go
+++ b/apiserver/charms/client_test.go
@@ -8,7 +8,6 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v6-unstable"
 
-	"github.com/juju/juju/api"
 	"github.com/juju/juju/apiserver/charms"
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
@@ -121,7 +120,7 @@ func (s *baseCharmsSuite) TestClientCharmInfo(c *gc.C) {
 			continue
 		}
 		c.Assert(err, jc.ErrorIsNil)
-		expected := &api.CharmInfo{
+		expected := &params.CharmInfo{
 			Revision: aCharm.Revision(),
 			URL:      aCharm.URL().String(),
 			Config:   aCharm.Config(),
@@ -156,7 +155,7 @@ func (s *charmsSuite) assertListCharms(c *gc.C, someCharms, args, expected []str
 
 func (s *charmsSuite) TestIsMeteredFalse(c *gc.C) {
 	charm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "wordpress"})
-	metered, err := s.api.IsMetered(params.CharmInfo{
+	metered, err := s.api.IsMetered(charms.CharmInfo{
 		CharmURL: charm.URL().String(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -165,7 +164,7 @@ func (s *charmsSuite) TestIsMeteredFalse(c *gc.C) {
 
 func (s *charmsSuite) TestIsMeteredTrue(c *gc.C) {
 	meteredCharm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "cs:quantal/metered"})
-	metered, err := s.api.IsMetered(params.CharmInfo{
+	metered, err := s.api.IsMetered(charms.CharmInfo{
 		CharmURL: meteredCharm.URL().String(),
 	})
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/client/client.go
+++ b/apiserver/client/client.go
@@ -12,7 +12,6 @@ import (
 	"github.com/juju/names"
 	"gopkg.in/juju/charm.v6-unstable"
 
-	"github.com/juju/juju/api"
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/apiserver/service"
@@ -310,17 +309,22 @@ func (c *Client) DestroyMachines(args params.DestroyMachines) error {
 	return common.DestroyMachines(c.api.stateAccessor, args.Force, args.MachineNames...)
 }
 
+// CharmInfo holds the url of the requested charm.
+type CharmInfo struct {
+	CharmURL string
+}
+
 // CharmInfo returns information about the requested charm.
-func (c *Client) CharmInfo(args params.CharmInfo) (api.CharmInfo, error) {
+func (c *Client) CharmInfo(args CharmInfo) (params.CharmInfo, error) {
 	curl, err := charm.ParseURL(args.CharmURL)
 	if err != nil {
-		return api.CharmInfo{}, err
+		return params.CharmInfo{}, err
 	}
 	charm, err := c.api.stateAccessor.Charm(curl)
 	if err != nil {
-		return api.CharmInfo{}, err
+		return params.CharmInfo{}, err
 	}
-	info := api.CharmInfo{
+	info := params.CharmInfo{
 		Revision: charm.Revision(),
 		URL:      curl.String(),
 		Config:   charm.Config(),

--- a/apiserver/client/client_test.go
+++ b/apiserver/client/client_test.go
@@ -18,7 +18,6 @@ import (
 	"gopkg.in/juju/charm.v6-unstable"
 
 	"github.com/juju/juju/agent"
-	"github.com/juju/juju/api"
 	"github.com/juju/juju/apiserver/client"
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
@@ -663,7 +662,7 @@ func (s *clientSuite) TestClientCharmInfo(c *gc.C) {
 			continue
 		}
 		c.Assert(err, jc.ErrorIsNil)
-		expected := &api.CharmInfo{
+		expected := &params.CharmInfo{
 			Revision: charm.Revision(),
 			URL:      charm.URL().String(),
 			Config:   charm.Config(),

--- a/apiserver/params/charms.go
+++ b/apiserver/params/charms.go
@@ -3,11 +3,6 @@
 
 package params
 
-// CharmInfo stores parameters for a charms.CharmInfo call.
-type CharmInfo struct {
-	CharmURL string
-}
-
 // CharmsList stores parameters for a charms.List call
 type CharmsList struct {
 	Names []string

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -825,3 +825,12 @@ type MeterStatusParam struct {
 type MeterStatusParams struct {
 	Statuses []MeterStatusParam `json:"statues"`
 }
+
+// CharmInfo holds information about a charm.
+type CharmInfo struct {
+	Revision int
+	URL      string
+	Config   *charm.Config
+	Meta     *charm.Meta
+	Actions  *charm.Actions
+}

--- a/provider/ec2/credentials.go
+++ b/provider/ec2/credentials.go
@@ -11,7 +11,6 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/utils"
 	"gopkg.in/amz.v3/aws"
-	"gopkg.in/ini.v1"
 
 	"github.com/juju/juju/cloud"
 )

--- a/provider/ec2/credentials_test.go
+++ b/provider/ec2/credentials_test.go
@@ -14,10 +14,11 @@ import (
 	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
 
+	"io/ioutil"
+
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs"
 	envtesting "github.com/juju/juju/environs/testing"
-	"io/ioutil"
 )
 
 type credentialsSuite struct {


### PR DESCRIPTION
Various apiserver packages import types from api packages, _its client_.

- Move ClientInfo to apiserver/params where it belongs.
- Replace the previous apiserver/params.CharmInfo type with a local
  struct; it only needs to have field called `CharmURL`, the rest is
  unimportant.

(Review request: http://reviews.vapour.ws/r/3913/)