### PR TITLE
Pass ImageStream to ubuntu-cloudimage-query command.

### DIFF
--- a/apiserver/images.go
+++ b/apiserver/images.go
@@ -142,7 +142,7 @@ func (h *imagesDownloadHandler) fetchAndCacheLxcImage(storage imagestorage.Stora
 	if err != nil {
 		return errors.Trace(err)
 	}
-	imageURL, err := container.ImageDownloadURL(instance.LXC, series, arch, cfg.CloudImageBaseURL())
+	imageURL, err := container.ImageDownloadURL(instance.LXC, series, arch, cfg.CloudImageBaseURL(), cfg.ImageStream())
 	if err != nil {
 		return errors.Annotatef(err, "cannot determine LXC image URL: %v", err)
 	}

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -1005,7 +1005,8 @@ func (a *MachineAgent) updateSupportedContainers(
 			// adds additional fields, this fails.
 			container.ImageURLGetterConfig{
 				st.Addr(), envUUID.Id(), []byte(agentConfig.CACert()),
-				cfg.CloudImageBaseURL(), container.ImageDownloadURL,
+				cfg.CloudImageBaseURL(), cfg.ImageStream(),
+				container.ImageDownloadURL,
 			})
 	}
 	params := provisioner.ContainerSetupParams{

--- a/provider/local/environ.go
+++ b/provider/local/environ.go
@@ -270,13 +270,14 @@ func (env *localEnviron) SetConfig(cfg *config.Config) error {
 				caCert = []byte(cert)
 			}
 			baseUrl := ecfg.CloudImageBaseURL()
+			stream := ecfg.ImageStream()
 
 			imageURLGetter = container.NewImageURLGetter(
 				// Explicitly call the non-named constructor so if anyone
 				// adds additional fields, this fails.
 				container.ImageURLGetterConfig{
 					ecfg.stateServerAddr(), uuid, caCert, baseUrl,
-					container.ImageDownloadURL,
+					stream, container.ImageDownloadURL,
 				})
 
 		}


### PR DESCRIPTION
This enables using daily stream in juju local provider, for example on s390x.