### PR TITLE
MADE resumer worker

### DIFF
--- a/api/interface.go
+++ b/api/interface.go
@@ -22,7 +22,6 @@ import (
 	"github.com/juju/juju/api/machiner"
 	"github.com/juju/juju/api/provisioner"
 	"github.com/juju/juju/api/reboot"
-	"github.com/juju/juju/api/resumer"
 	"github.com/juju/juju/api/unitassigner"
 	"github.com/juju/juju/api/uniter"
 	"github.com/juju/juju/api/upgrader"
@@ -163,7 +162,6 @@ type Connection interface {
 	// prohibitively ugly to do so.
 	Client() *Client
 	Machiner() *machiner.State
-	Resumer() *resumer.API
 	Provisioner() *provisioner.State
 	Uniter() (*uniter.State, error)
 	Firewaller() *firewaller.State

--- a/api/state.go
+++ b/api/state.go
@@ -25,7 +25,6 @@ import (
 	"github.com/juju/juju/api/machiner"
 	"github.com/juju/juju/api/provisioner"
 	"github.com/juju/juju/api/reboot"
-	"github.com/juju/juju/api/resumer"
 	"github.com/juju/juju/api/unitassigner"
 	"github.com/juju/juju/api/uniter"
 	"github.com/juju/juju/api/upgrader"
@@ -191,12 +190,6 @@ func (st *state) Machiner() *machiner.State {
 // required by the unitassigner worker.
 func (st *state) UnitAssigner() unitassigner.API {
 	return unitassigner.New(st)
-}
-
-// Resumer returns a version of the state that provides functionality
-// required by the resumer worker.
-func (st *state) Resumer() *resumer.API {
-	return resumer.NewAPI(st)
 }
 
 // Provisioner returns a version of the state that provides functionality

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -92,7 +92,6 @@ import (
 	"github.com/juju/juju/worker/mongoupgrader"
 	"github.com/juju/juju/worker/peergrouper"
 	"github.com/juju/juju/worker/provisioner"
-	"github.com/juju/juju/worker/resumer"
 	"github.com/juju/juju/worker/singular"
 	"github.com/juju/juju/worker/statushistorypruner"
 	"github.com/juju/juju/worker/storageprovisioner"
@@ -123,7 +122,6 @@ var (
 	newFirewaller            = firewaller.NewFirewaller
 	newStorageWorker         = storageprovisioner.NewStorageProvisioner
 	newCertificateUpdater    = certupdater.NewCertificateUpdater
-	newResumer               = resumer.NewResumer
 	newInstancePoller        = instancepoller.NewWorker
 	newCleaner               = cleaner.NewCleaner
 	newAddresser             = addresser.NewWorker
@@ -767,13 +765,6 @@ func (a *MachineAgent) startAPIWorkers(apiConn api.Connection) (_ worker.Worker,
 	}
 
 	if isModelManager {
-		runner.StartWorker("resumer", func() (worker.Worker, error) {
-			// The action of resumer is so subtle that it is not tested,
-			// because we can't figure out how to do so without
-			// brutalising the transaction log.
-			return newResumer(apiConn.Resumer()), nil
-		})
-
 		runner.StartWorker("identity-file-writer", func() (worker.Worker, error) {
 			inner := func(<-chan struct{}) error {
 				agentConfig := a.CurrentConfig()

--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -23,6 +23,7 @@ import (
 	"github.com/juju/juju/worker/machiner"
 	"github.com/juju/juju/worker/proxyupdater"
 	"github.com/juju/juju/worker/reboot"
+	"github.com/juju/juju/worker/resumer"
 	"github.com/juju/juju/worker/terminationworker"
 	"github.com/juju/juju/worker/upgrader"
 	"github.com/juju/juju/worker/upgradesteps"
@@ -261,7 +262,14 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 				UpgradeWaiterName: upgradeWaiterName,
 			},
 		}),
+
 		authenticationworkerName: authenticationworker.Manifold(authenticationworker.ManifoldConfig{
+			AgentName:         agentName,
+			APICallerName:     apiCallerName,
+			UpgradeWaiterName: upgradeWaiterName,
+		}),
+
+		resumerName: resumer.Manifold(resumer.ManifoldConfig{
 			AgentName:         agentName,
 			APICallerName:     apiCallerName,
 			UpgradeWaiterName: upgradeWaiterName,
@@ -291,4 +299,5 @@ const (
 	logSenderName            = "log-sender"
 	deployerName             = "deployer"
 	authenticationworkerName = "authenticationworker"
+	resumerName              = "resumer"
 )

--- a/cmd/jujud/agent/machine/manifolds_test.go
+++ b/cmd/jujud/agent/machine/manifolds_test.go
@@ -58,6 +58,7 @@ func (s *ManifoldsSuite) TestManifoldNames(c *gc.C) {
 		"machiner",
 		"deployer",
 		"authenticationworker",
+		"resumer",
 	}
 	c.Assert(keys, jc.SameContents, expectedKeys)
 }

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -602,9 +602,9 @@ func (s *MachineSuite) TestManageModel(c *gc.C) {
 
 func (s *MachineSuite) TestManageModelRunsResumer(c *gc.C) {
 	started := newSignal()
-	s.AgentSuite.PatchValue(&newResumer, func(st resumer.TransactionResumer) *resumer.Resumer {
+	s.AgentSuite.PatchValue(&resumer.NewResumer, func(st resumer.TransactionResumer) worker.Worker {
 		started.trigger()
-		return resumer.NewResumer(st)
+		return newDummyWorker()
 	})
 
 	m, _, _ := s.primeAgent(c, state.JobManageModel)

--- a/worker/dependency/engine.go
+++ b/worker/dependency/engine.go
@@ -425,6 +425,7 @@ func (engine *engine) runWorker(name string, delay time.Duration, start StartFun
 			<-engine.tomb.Dying()
 			return tomb.ErrDying
 		}
+
 		return worker.Wait()
 	}
 

--- a/worker/resumer/manifold.go
+++ b/worker/resumer/manifold.go
@@ -1,0 +1,61 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package resumer
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/names"
+
+	"github.com/juju/juju/agent"
+	"github.com/juju/juju/api"
+	"github.com/juju/juju/api/base"
+	apiresumer "github.com/juju/juju/api/resumer"
+	"github.com/juju/juju/state/multiwatcher"
+	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/dependency"
+	"github.com/juju/juju/worker/util"
+)
+
+// ManifoldConfig defines the names of the manifolds on which a Manifold will depend.
+type ManifoldConfig util.PostUpgradeManifoldConfig
+
+// Manifold returns a dependency manifold that runs a resumer worker,
+// using the api connection resource named in the supplied config.
+func Manifold(config ManifoldConfig) dependency.Manifold {
+	return util.PostUpgradeManifold(util.PostUpgradeManifoldConfig(config), newWorker)
+}
+
+func newWorker(a agent.Agent, apiCaller base.APICaller) (worker.Worker, error) {
+	cfg := a.CurrentConfig()
+	// Grab the tag and ensure that it's for a machine.
+	tag, ok := cfg.Tag().(names.MachineTag)
+	if !ok {
+		return nil, errors.New("this manifold may only be used inside a machine agent")
+	}
+
+	// Get API connection.
+	apiConn, ok := apiCaller.(api.Connection)
+	if !ok {
+		return nil, errors.New("unable to obtain api.Connection")
+	}
+
+	// Get the machine agent's jobs.
+	entity, err := apiConn.Agent().Entity(tag)
+	if err != nil {
+		return nil, err
+	}
+
+	var isModelManager bool
+	for _, job := range entity.Jobs() {
+		if job == multiwatcher.JobManageModel {
+			isModelManager = true
+			break
+		}
+	}
+	if !isModelManager {
+		return nil, dependency.ErrMissing
+	}
+
+	return NewResumer(apiresumer.NewAPI(apiCaller)), nil
+}

--- a/worker/resumer/manifold_test.go
+++ b/worker/resumer/manifold_test.go
@@ -1,0 +1,119 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package resumer_test
+
+import (
+	"github.com/juju/names"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/agent"
+	"github.com/juju/juju/api"
+	apiagent "github.com/juju/juju/api/agent"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/state/multiwatcher"
+	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/dependency"
+	resumer "github.com/juju/juju/worker/resumer"
+	workertesting "github.com/juju/juju/worker/testing"
+)
+
+type ManifoldSuite struct {
+	testing.IsolationSuite
+	newCalled bool
+}
+
+var _ = gc.Suite(&ManifoldSuite{})
+
+func (s *ManifoldSuite) SetUpTest(c *gc.C) {
+	s.newCalled = false
+	s.PatchValue(&resumer.NewResumer,
+		func(tr resumer.TransactionResumer) worker.Worker {
+			s.newCalled = true
+			return nil
+		},
+	)
+}
+
+func (s *ManifoldSuite) TestMachine(c *gc.C) {
+	config := resumer.ManifoldConfig(workertesting.PostUpgradeManifoldTestConfig())
+	_, err := workertesting.RunPostUpgradeManifold(
+		resumer.Manifold(config),
+		&fakeAgent{tag: names.NewMachineTag("42")},
+		&fakeAPIConn{machineJob: multiwatcher.JobManageModel})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s.newCalled, jc.IsTrue)
+}
+
+func (s *ManifoldSuite) TestMachineNonManagerErrors(c *gc.C) {
+	config := resumer.ManifoldConfig(workertesting.PostUpgradeManifoldTestConfig())
+	_, err := workertesting.RunPostUpgradeManifold(
+		resumer.Manifold(config),
+		&fakeAgent{tag: names.NewMachineTag("42")},
+		&fakeAPIConn{machineJob: multiwatcher.JobHostUnits})
+	c.Assert(err, gc.Equals, dependency.ErrMissing)
+	c.Assert(s.newCalled, jc.IsFalse)
+}
+
+func (s *ManifoldSuite) TestUnitErrors(c *gc.C) {
+	config := resumer.ManifoldConfig(workertesting.PostUpgradeManifoldTestConfig())
+	_, err := workertesting.RunPostUpgradeManifold(
+		resumer.Manifold(config),
+		&fakeAgent{tag: names.NewUnitTag("foo/0")},
+		&fakeAPIConn{})
+	c.Assert(err, gc.ErrorMatches, "this manifold may only be used inside a machine agent")
+	c.Assert(s.newCalled, jc.IsFalse)
+}
+
+func (s *ManifoldSuite) TestNonAgentErrors(c *gc.C) {
+	config := resumer.ManifoldConfig(workertesting.PostUpgradeManifoldTestConfig())
+	_, err := workertesting.RunPostUpgradeManifold(
+		resumer.Manifold(config),
+		&fakeAgent{tag: names.NewUserTag("foo")},
+		&fakeAPIConn{})
+	c.Assert(err, gc.ErrorMatches, "this manifold may only be used inside a machine agent")
+	c.Assert(s.newCalled, jc.IsFalse)
+}
+
+type fakeAgent struct {
+	agent.Agent
+	tag names.Tag
+}
+
+func (a *fakeAgent) CurrentConfig() agent.Config {
+	return &fakeConfig{tag: a.tag}
+}
+
+type fakeConfig struct {
+	agent.Config
+	tag names.Tag
+}
+
+func (c *fakeConfig) Tag() names.Tag {
+	return c.tag
+}
+
+type fakeAPIConn struct {
+	api.Connection
+	machineJob multiwatcher.MachineJob
+}
+
+func (f *fakeAPIConn) APICall(objType string, version int, id, request string, args interface{}, response interface{}) error {
+	if res, ok := response.(*params.AgentGetEntitiesResults); ok {
+		res.Entities = []params.AgentGetEntitiesResult{
+			{Jobs: []multiwatcher.MachineJob{f.machineJob}},
+		}
+	}
+
+	return nil
+}
+
+func (*fakeAPIConn) BestFacadeVersion(facade string) int {
+	return 42
+}
+
+func (f *fakeAPIConn) Agent() *apiagent.State {
+	return apiagent.NewState(f)
+}

--- a/worker/resumer/resumer.go
+++ b/worker/resumer/resumer.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/juju/juju/worker"
 	"github.com/juju/loggo"
 	"launchpad.net/tomb"
 )
@@ -33,7 +34,7 @@ type Resumer struct {
 }
 
 // NewResumer periodically resumes pending transactions.
-func NewResumer(tr TransactionResumer) *Resumer {
+var NewResumer = func(tr TransactionResumer) worker.Worker {
 	rr := &Resumer{tr: tr}
 	go func() {
 		defer rr.tomb.Done()
@@ -48,11 +49,6 @@ func (rr *Resumer) String() string {
 
 func (rr *Resumer) Kill() {
 	rr.tomb.Kill(nil)
-}
-
-func (rr *Resumer) Stop() error {
-	rr.tomb.Kill(nil)
-	return rr.tomb.Wait()
 }
 
 func (rr *Resumer) Wait() error {


### PR DESCRIPTION
Move the resumer worker from the machine agent runner to the dependency engine.

(Review request: http://reviews.vapour.ws/r/3918/)