### PR TITLE
worker/state: Implement StateTracker

### DIFF
--- a/worker/state/export_test.go
+++ b/worker/state/export_test.go
@@ -1,0 +1,6 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+var NewStateTracker = newStateTracker

--- a/worker/state/statetracker.go
+++ b/worker/state/statetracker.go
@@ -1,0 +1,69 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"sync"
+
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/state"
+)
+
+var ErrStateAlreadyClosed = errors.New("state already closed")
+
+// StateTracker wraps a *state.State, closing it when there are no
+// longer any references to it.
+//
+// The Use method will return the wrapped *state.State and increment
+// the reference count. The Done method will decrement the reference
+// count, closing the State when the reference count hits 0. The
+// reference count starts at 1. Done should be called exactly 1 +
+// number of calls to Use.
+type StateTracker struct {
+	mu         sync.Mutex
+	st         *state.State
+	references int
+}
+
+func newStateTracker(st *state.State) *StateTracker {
+	return &StateTracker{
+		st:         st,
+		references: 1,
+	}
+}
+
+// Use increments the reference count for the wrapped State and
+// returns it. ErrStateAlreadyClosed is returned if the State has
+// already been closed.
+func (c *StateTracker) Use() (*state.State, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.references == 0 {
+		return nil, ErrStateAlreadyClosed
+	}
+	c.references++
+	return c.st, nil
+}
+
+// Done decrements the reference count for the wrapped State, closing
+// it if the reference count becomes 0. ErrStateAlreadyClosed is
+// returned if the State has already been closed.
+func (c *StateTracker) Done() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.references == 0 {
+		return ErrStateAlreadyClosed
+	}
+	c.references--
+	if c.references == 0 {
+		err := c.st.Close()
+		if err != nil {
+			logger.Errorf("error when closing state: %v", err)
+		}
+	}
+	return nil
+}

--- a/worker/state/statetracker_test.go
+++ b/worker/state/statetracker_test.go
@@ -1,0 +1,101 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/state"
+	statetesting "github.com/juju/juju/state/testing"
+	workerstate "github.com/juju/juju/worker/state"
+)
+
+type StateTrackerSuite struct {
+	statetesting.StateSuite
+	st           *state.State
+	stateTracker *workerstate.StateTracker
+}
+
+var _ = gc.Suite(&StateTrackerSuite{})
+
+func (s *StateTrackerSuite) SetUpTest(c *gc.C) {
+	s.StateSuite.SetUpTest(c)
+	s.stateTracker = workerstate.NewStateTracker(s.State)
+}
+
+func (s *StateTrackerSuite) TestDoneWithNoUse(c *gc.C) {
+	err := s.stateTracker.Done()
+	c.Assert(err, jc.ErrorIsNil)
+	assertStateClosed(c, s.State)
+}
+
+func (s *StateTrackerSuite) TestTooManyDones(c *gc.C) {
+	err := s.stateTracker.Done()
+	c.Assert(err, jc.ErrorIsNil)
+	assertStateClosed(c, s.State)
+
+	err = s.stateTracker.Done()
+	c.Assert(err, gc.Equals, workerstate.ErrStateAlreadyClosed)
+	assertStateClosed(c, s.State)
+}
+
+func (s *StateTrackerSuite) TestUse(c *gc.C) {
+	st, err := s.stateTracker.Use()
+	c.Check(st, gc.Equals, s.State)
+	c.Check(err, jc.ErrorIsNil)
+
+	st, err = s.stateTracker.Use()
+	c.Check(st, gc.Equals, s.State)
+	c.Check(err, jc.ErrorIsNil)
+}
+
+func (s *StateTrackerSuite) TestUseAndDone(c *gc.C) {
+	// Ref count starts at 1 (the creator/owner)
+
+	_, err := s.stateTracker.Use()
+	// 2
+	c.Check(err, jc.ErrorIsNil)
+
+	_, err = s.stateTracker.Use()
+	// 3
+	c.Check(err, jc.ErrorIsNil)
+
+	c.Check(s.stateTracker.Done(), jc.ErrorIsNil)
+	// 2
+	assertStateNotClosed(c, s.State)
+
+	_, err = s.stateTracker.Use()
+	// 3
+	c.Check(err, jc.ErrorIsNil)
+
+	c.Check(s.stateTracker.Done(), jc.ErrorIsNil)
+	// 2
+	assertStateNotClosed(c, s.State)
+
+	c.Check(s.stateTracker.Done(), jc.ErrorIsNil)
+	// 1
+	assertStateNotClosed(c, s.State)
+
+	c.Check(s.stateTracker.Done(), jc.ErrorIsNil)
+	// 0
+	assertStateClosed(c, s.State)
+}
+
+func (s *StateTrackerSuite) TestUseWhenClosed(c *gc.C) {
+	c.Assert(s.stateTracker.Done(), jc.ErrorIsNil)
+
+	st, err := s.stateTracker.Use()
+	c.Check(st, gc.IsNil)
+	c.Check(err, gc.Equals, workerstate.ErrStateAlreadyClosed)
+}
+
+func assertStateNotClosed(c *gc.C, st *state.State) {
+	err := st.Ping()
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func assertStateClosed(c *gc.C, st *state.State) {
+	c.Assert(st.Ping, gc.PanicMatches, "Session already closed")
+}


### PR DESCRIPTION
StateTracker wraps a *state.State, closing it when there are no longer any references to it. This is output by the state manifold. 

(Review request: http://reviews.vapour.ws/r/3921/)