### PR TITLE
Complete the removal NewStorage & registerSimplestreamsDataSource calls

### DIFF
--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -55,7 +55,7 @@ type ManifoldsConfig struct {
 
 	// OpenStateForUpgrade is a function the upgradesteps worker can
 	// use to establish a connection to state.
-	OpenStateForUpgrade func() (*state.State, func(), error)
+	OpenStateForUpgrade func() (*state.State, error)
 
 	// WriteUninstallFile is a function the uninstaller manifold uses
 	// to write the agent uninstall file.

--- a/cmd/jujud/agent/simplestreams.go
+++ b/cmd/jujud/agent/simplestreams.go
@@ -10,7 +10,6 @@ import (
 	"io/ioutil"
 	"path"
 
-	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/simplestreams"
 	"github.com/juju/juju/state/storage"
 )
@@ -80,17 +79,4 @@ func (d environmentStorageDataSource) Priority() int {
 // RequireSigned is defined in simplestreams.DataSource.
 func (d environmentStorageDataSource) RequireSigned() bool {
 	return d.requireSigned
-}
-
-// registerSimplestreamsDataSource registers a environmentStorageDataSource.
-func registerSimplestreamsDataSource(stor storage.Storage, requireSigned bool) {
-	ds := NewModelStorageDataSource(stor, simplestreams.DEFAULT_CLOUD_DATA, requireSigned)
-	environs.RegisterUserImageDataSourceFunc(storageDataSourceId, func(environs.Environ) (simplestreams.DataSource, error) {
-		return ds, nil
-	})
-}
-
-// unregisterSimplestreamsDataSource de-registers an environmentStorageDataSource.
-func unregisterSimplestreamsDataSource() {
-	environs.UnregisterImageDataSourceFunc(storageDataSourceId)
 }

--- a/worker/upgradesteps/manifold.go
+++ b/worker/upgradesteps/manifold.go
@@ -21,7 +21,7 @@ type ManifoldConfig struct {
 	AgentName            string
 	APICallerName        string
 	UpgradeStepsGateName string
-	OpenStateForUpgrade  func() (*state.State, func(), error)
+	OpenStateForUpgrade  func() (*state.State, error)
 	PreUpgradeSteps      func(*state.State, agent.Config, bool, bool) error
 }
 

--- a/worker/upgradesteps/worker.go
+++ b/worker/upgradesteps/worker.go
@@ -97,7 +97,7 @@ func NewWorker(
 	agent agent.Agent,
 	apiConn api.Connection,
 	jobs []multiwatcher.MachineJob,
-	openState func() (*state.State, func(), error),
+	openState func() (*state.State, error),
 	preUpgradeSteps func(st *state.State, agentConf agent.Config, isController, isMasterServer bool) error,
 	machine StatusSetter,
 ) (worker.Worker, error) {
@@ -128,7 +128,7 @@ type upgradesteps struct {
 	agent           agent.Agent
 	apiConn         api.Connection
 	jobs            []multiwatcher.MachineJob
-	openState       func() (*state.State, func(), error)
+	openState       func() (*state.State, error)
 	preUpgradeSteps func(st *state.State, agentConf agent.Config, isController, isMaster bool) error
 	machine         StatusSetter
 
@@ -194,12 +194,11 @@ func (w *upgradesteps) run() error {
 	// of StateWorker, because we have no guarantees about when
 	// and how often StateWorker might run.
 	if w.isController {
-		var closer func()
 		var err error
-		if w.st, closer, err = w.openState(); err != nil {
+		if w.st, err = w.openState(); err != nil {
 			return err
 		}
-		defer closer()
+		defer w.st.Close()
 
 		if w.isMaster, err = IsMachineMaster(w.st, w.tag.Id()); err != nil {
 			return errors.Trace(err)

--- a/worker/upgradesteps/worker_test.go
+++ b/worker/upgradesteps/worker_test.go
@@ -406,13 +406,13 @@ func (s *UpgradeSuite) runUpgradeWorker(c *gc.C, jobs ...multiwatcher.MachineJob
 	return worker.Wait(), config, machineStatus.Calls, doneLock
 }
 
-func (s *UpgradeSuite) openStateForUpgrade() (*state.State, func(), error) {
+func (s *UpgradeSuite) openStateForUpgrade() (*state.State, error) {
 	mongoInfo := s.State.MongoConnectionInfo()
 	st, err := state.Open(s.State.ModelTag(), mongoInfo, mongo.DefaultDialOpts(), environs.NewStatePolicy())
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
-	return st, func() { st.Close() }, nil
+	return st, nil
 }
 
 func (s *UpgradeSuite) preUpgradeSteps(st *state.State, agentConf agent.Config, isController, isMasterController bool) error {


### PR DESCRIPTION
.. in the machine agent.

The NewStorage and registerSimplestreamsDataSource calls has been removed from StateWorker, but the related unregisterSimplestreamsDataSource call had been left behind. Similar updated hadn't been made to openStateForUpgrade either.

All this allows the call signature for openStateForUpgrade to be simplified. This flowed through to the upgradesteps manifold.

registerSimplestreamsDataSource and unregisterSimplestreamsDataSource aren't used any more so they've been removed.


(Review request: http://reviews.vapour.ws/r/3922/)