### PR TITLE
juju: only use configstore for bootstrap config

### DIFF
--- a/api/controller/controller_test.go
+++ b/api/controller/controller_test.go
@@ -11,12 +11,10 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/api/controller"
 	commontesting "github.com/juju/juju/apiserver/common/testing"
 	"github.com/juju/juju/apiserver/params"
-	"github.com/juju/juju/juju"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/multiwatcher"
@@ -36,10 +34,7 @@ func (s *controllerSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *controllerSuite) OpenAPI(c *gc.C) *controller.Client {
-	conn, err := juju.NewAPIState(s.AdminUserTag(c), s.Environ, api.DialOpts{})
-	c.Assert(err, jc.ErrorIsNil)
-	s.AddCleanup(func(*gc.C) { conn.Close() })
-	return controller.NewClient(conn)
+	return controller.NewClient(s.APIState)
 }
 
 func (s *controllerSuite) TestAllModels(c *gc.C) {

--- a/api/modelmanager/modelmanager_test.go
+++ b/api/modelmanager/modelmanager_test.go
@@ -9,10 +9,8 @@ import (
 	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/modelmanager"
 	"github.com/juju/juju/apiserver/params"
-	"github.com/juju/juju/juju"
 	jujutesting "github.com/juju/juju/juju/testing"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/testing/factory"
@@ -29,10 +27,7 @@ func (s *modelmanagerSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *modelmanagerSuite) OpenAPI(c *gc.C) *modelmanager.Client {
-	conn, err := juju.NewAPIState(s.AdminUserTag(c), s.Environ, api.DialOpts{})
-	c.Assert(err, jc.ErrorIsNil)
-	s.AddCleanup(func(*gc.C) { conn.Close() })
-	return modelmanager.NewClient(conn)
+	return modelmanager.NewClient(s.APIState)
 }
 
 func (s *modelmanagerSuite) TestConfigSkeleton(c *gc.C) {

--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -180,6 +180,7 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 	r.Register(user.NewListCommand())
 	r.Register(user.NewEnableCommand())
 	r.Register(user.NewDisableCommand())
+	r.Register(user.NewSwitchUserCommand())
 
 	// Manage cached images
 	r.Register(cachedimages.NewSuperCommand())

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -303,6 +303,7 @@ var commandNames = []string{
 	"storage",
 	"subnet",
 	"switch",
+	"switch-user",
 	"sync-tools",
 	"unblock",
 	"unexpose",

--- a/cmd/juju/controller/register.go
+++ b/cmd/juju/controller/register.go
@@ -27,9 +27,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/environs/configstore"
-	"github.com/juju/juju/juju"
 	"github.com/juju/juju/jujuclient"
-	"github.com/juju/juju/network"
 )
 
 // NewRegisterCommand returns a command to allow the user to register a controller.
@@ -169,19 +167,11 @@ func (c *registerCommand) Run(ctx *cmd.Context) error {
 
 	// Store the controller and account details.
 	controllerDetails := jujuclient.ControllerDetails{
+		APIEndpoints:   registrationParams.controllerAddrs,
 		ControllerUUID: responsePayload.ControllerUUID,
 		CACert:         responsePayload.CACert,
 	}
 	if err := c.store.UpdateController(registrationParams.controllerName, controllerDetails); err != nil {
-		return errors.Trace(err)
-	}
-	hostPorts, err := network.ParseHostPorts(registrationParams.controllerAddrs...)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	if err := juju.UpdateControllerAddresses(
-		c.store, legacyStore, registrationParams.controllerName, nil, hostPorts...,
-	); err != nil {
 		return errors.Trace(err)
 	}
 	accountDetails := jujuclient.AccountDetails{
@@ -190,6 +180,11 @@ func (c *registerCommand) Run(ctx *cmd.Context) error {
 	}
 	if err := c.store.UpdateAccount(
 		registrationParams.controllerName, accountDetails.User, accountDetails,
+	); err != nil {
+		return errors.Trace(err)
+	}
+	if err := c.store.SetCurrentAccount(
+		registrationParams.controllerName, accountDetails.User,
 	); err != nil {
 		return errors.Trace(err)
 	}

--- a/cmd/juju/controller/register_test.go
+++ b/cmd/juju/controller/register_test.go
@@ -184,26 +184,14 @@ func (s *RegisterSuite) TestRegister(c *gc.C) {
 	expectedCiphertext := s.seal(c, requestPayloadPlaintext, secretKey, request.Nonce)
 	c.Assert(request.PayloadCiphertext, jc.DeepEquals, expectedCiphertext)
 
-	// The controller information should be recorded with
-	// the specified controller name ("controller-name").
-	info, err := s.legacystore.ReadInfo("controller-name:controller-name")
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(info.APICredentials(), jc.DeepEquals, configstore.APICredentials{
-		User:     "bob",
-		Password: "hunter2",
-	})
-	c.Assert(info.APIEndpoint(), jc.DeepEquals, configstore.APIEndpoint{
-		ServerUUID: controllerUUID,
-		Hostnames:  []string{s.apiConnection.addr},
-		Addresses:  []string{s.apiConnection.addr},
-		CACert:     testing.CACert,
-	})
+	// The controller and account details should be recorded with
+	// the specified controller name ("controller-name") and user
+	// name from the registration string.
 
 	controller, err := s.store.ControllerByName("controller-name")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(controller, jc.DeepEquals, &jujuclient.ControllerDetails{
 		ControllerUUID: controllerUUID,
-		Servers:        []string{s.apiConnection.addr},
 		APIEndpoints:   []string{s.apiConnection.addr},
 		CACert:         testing.CACert,
 	})

--- a/cmd/juju/user/export_test.go
+++ b/cmd/juju/user/export_test.go
@@ -27,6 +27,10 @@ type DisenableUserBase struct {
 	*disenableUserBase
 }
 
+type SwitchUserCommand struct {
+	*switchUserCommand
+}
+
 func NewAddCommandForTest(api AddUserAPI, store jujuclient.ClientStore, modelApi modelcmd.ModelAPI) (cmd.Command, *AddCommand) {
 	c := &addCommand{api: api}
 	c.SetClientStore(store)
@@ -49,6 +53,14 @@ func NewChangePasswordCommandForTest(api ChangePasswordAPI, store jujuclient.Cli
 	}
 	c.SetClientStore(store)
 	return modelcmd.WrapController(c), &ChangePasswordCommand{c}
+}
+
+// NewSwitchUserCommand returns a SwitchUserCommand using the
+// specified client store.
+func NewSwitchUserCommandForTest(store jujuclient.ClientStore) (cmd.Command, *SwitchUserCommand) {
+	cmd := &switchUserCommand{}
+	cmd.SetClientStore(store)
+	return modelcmd.WrapController(cmd), &SwitchUserCommand{cmd}
 }
 
 // NewDisableCommand returns a DisableCommand with the api provided as

--- a/cmd/juju/user/switch.go
+++ b/cmd/juju/user/switch.go
@@ -1,0 +1,70 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for infos.
+
+package user
+
+import (
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+	"github.com/juju/names"
+
+	"github.com/juju/juju/cmd/modelcmd"
+)
+
+const switchUserCommandDoc = `
+Switch to a different user in the controller.
+`
+
+type switchUserCommand struct {
+	modelcmd.ControllerCommandBase
+	User string
+}
+
+func NewSwitchUserCommand() cmd.Command {
+	return modelcmd.WrapController(&switchUserCommand{})
+}
+
+// Info implements Command.Info.
+func (c *switchUserCommand) Info() *cmd.Info {
+	return &cmd.Info{
+		Name:    "switch-user",
+		Args:    "<username>",
+		Purpose: "switches to a different user in the controller",
+		Doc:     switchUserCommandDoc,
+	}
+}
+
+// Init implements Command.Init.
+func (c *switchUserCommand) Init(args []string) error {
+	if len(args) == 0 {
+		return errors.New("you must specify a user to switch to")
+	}
+	if err := cmd.CheckEmpty(args[1:]); err != nil {
+		return errors.Trace(err)
+	}
+	c.User = args[0]
+	return nil
+}
+
+// Run implements Command.Run.
+func (c *switchUserCommand) Run(ctx *cmd.Context) error {
+	if !names.IsValidUser(c.User) {
+		return errors.NotValidf("user %q", c.User)
+	}
+	store := c.ClientStore()
+	controllerName := c.ControllerName()
+	accountName := names.NewUserTag(c.User).Canonical()
+	currentAccountName, err := store.CurrentAccount(controllerName)
+	if err != nil && !errors.IsNotFound(err) {
+		return errors.Trace(err)
+	}
+	if accountName == currentAccountName {
+		ctx.Infof("%s (no change)", accountName)
+		return nil
+	}
+	if err := store.SetCurrentAccount(controllerName, accountName); err != nil {
+		return errors.Trace(err)
+	}
+	ctx.Infof("%s -> %s", currentAccountName, accountName)
+	return nil
+}

--- a/cmd/juju/user/switch_test.go
+++ b/cmd/juju/user/switch_test.go
@@ -1,0 +1,117 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package user_test
+
+import (
+	"github.com/juju/cmd"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/cmd/juju/user"
+	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/jujuclient"
+	"github.com/juju/juju/jujuclient/jujuclienttesting"
+	coretesting "github.com/juju/juju/testing"
+)
+
+type SwitchUserCommandSuite struct {
+	coretesting.FakeJujuXDGDataHomeSuite
+	store *jujuclienttesting.MemStore
+}
+
+var _ = gc.Suite(&SwitchUserCommandSuite{})
+
+func (s *SwitchUserCommandSuite) SetUpTest(c *gc.C) {
+	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
+
+	s.store = jujuclienttesting.NewMemStore()
+	s.store.Accounts["testing"] = &jujuclient.ControllerAccounts{
+		Accounts: map[string]jujuclient.AccountDetails{
+			"current-user@local": {
+				User:     "current-user@local",
+				Password: "old-password",
+			},
+			"other@local": {
+				User:     "other@local",
+				Password: "old-password",
+			},
+		},
+		CurrentAccount: "current-user@local",
+	}
+	err := modelcmd.WriteCurrentController("testing")
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *SwitchUserCommandSuite) run(c *gc.C, args ...string) (*cmd.Context, error) {
+	cmd, _ := user.NewSwitchUserCommandForTest(s.store)
+	return coretesting.RunCommand(c, cmd, args...)
+}
+
+func (s *SwitchUserCommandSuite) TestInit(c *gc.C) {
+	for i, test := range []struct {
+		args        []string
+		user        string
+		generate    bool
+		errorString string
+	}{
+		{
+			errorString: "you must specify a user to switch to",
+		}, {
+			args: []string{"bob"},
+			user: "bob",
+		}, {
+			args: []string{"bob@local"},
+			user: "bob@local",
+		}, {
+			args:        []string{"--foobar"},
+			errorString: "flag provided but not defined: --foobar",
+		}, {
+			args:        []string{"bob", "dobbs"},
+			errorString: `unrecognized args: \["dobbs"\]`,
+		},
+	} {
+		c.Logf("test %d", i)
+		wrappedCommand, command := user.NewSwitchUserCommandForTest(nil)
+		err := coretesting.InitCommand(wrappedCommand, test.args)
+		if test.errorString == "" {
+			c.Check(err, jc.ErrorIsNil)
+			c.Check(command.User, gc.Equals, test.user)
+		} else {
+			c.Check(err, gc.ErrorMatches, test.errorString)
+		}
+	}
+}
+
+func (s *SwitchUserCommandSuite) assertCurrentUser(c *gc.C, user string) {
+	current, err := s.store.CurrentAccount("testing")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(current, gc.Equals, user)
+}
+
+func (s *SwitchUserCommandSuite) TestSwitchUser(c *gc.C) {
+	s.assertCurrentUser(c, "current-user@local")
+	context, err := s.run(c, "other")
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertCurrentUser(c, "other@local")
+	c.Assert(coretesting.Stdout(context), gc.Equals, "")
+	c.Assert(coretesting.Stderr(context), gc.Equals, "current-user@local -> other@local\n")
+}
+
+func (s *SwitchUserCommandSuite) TestSwitchUserNoChange(c *gc.C) {
+	s.assertCurrentUser(c, "current-user@local")
+	context, err := s.run(c, "current-user@local")
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertCurrentUser(c, "current-user@local")
+	c.Assert(coretesting.Stdout(context), gc.Equals, "")
+	c.Assert(coretesting.Stderr(context), gc.Equals, "current-user@local (no change)\n")
+}
+
+func (s *SwitchUserCommandSuite) TestSwitchUserUnknown(c *gc.C) {
+	s.assertCurrentUser(c, "current-user@local")
+	context, err := s.run(c, "unknown@local")
+	c.Assert(err, gc.ErrorMatches, "account testing:unknown@local not found")
+	s.assertCurrentUser(c, "current-user@local")
+	c.Assert(coretesting.Stdout(context), gc.Equals, "")
+	c.Assert(coretesting.Stderr(context), gc.Equals, "")
+}

--- a/cmd/modelcmd/export_test.go
+++ b/cmd/modelcmd/export_test.go
@@ -3,20 +3,20 @@
 
 package modelcmd
 
+import "github.com/juju/juju/jujuclient"
+
 var (
 	GetCurrentControllerFilePath = getCurrentControllerFilePath
 	GetConfigStore               = &getConfigStore
 	EndpointRefresher            = &endpointRefresher
 )
 
-// NewModelCommandBase returns a new ModelCommandBase with the model name, client,
-// and error as specified for testing purposes.
-// If getterErr != nil then the NewModelGetter returns the specified error.
-func NewModelCommandBase(controller, model string, client ModelGetter, getterErr error) *ModelCommandBase {
+// NewModelCommandBase returns a new ModelCommandBase with the given client
+// store, controller name, and model name.
+func NewModelCommandBase(store jujuclient.ClientStore, controller, model string) *ModelCommandBase {
 	return &ModelCommandBase{
-		controllerName:  controller,
-		modelName:       model,
-		envGetterClient: client,
-		envGetterErr:    getterErr,
+		store:          store,
+		controllerName: controller,
+		modelName:      model,
 	}
 }

--- a/cmd/modelcmd/modelcommand.go
+++ b/cmd/modelcmd/modelcommand.go
@@ -109,9 +109,6 @@ type ModelCommandBase struct {
 
 	// opener is the strategy used to open the API connection.
 	opener APIOpener
-
-	envGetterClient ModelGetter
-	envGetterErr    error
 }
 
 // SetClientStore implements the ModelCommand interface.
@@ -160,20 +157,6 @@ func (c *ModelCommandBase) NewAPIClient() (*api.Client, error) {
 		return nil, errors.Trace(err)
 	}
 	return root.Client(), nil
-}
-
-// NewModelGetter returns a new object which implements the
-// ModelGetter interface.
-func (c *ModelCommandBase) NewModelGetter() (ModelGetter, error) {
-	if c.envGetterErr != nil {
-		return nil, c.envGetterErr
-	}
-
-	if c.envGetterClient != nil {
-		return c.envGetterClient, nil
-	}
-
-	return c.NewAPIClient()
 }
 
 // NewAPIRoot returns a new connection to the API server for the environment.

--- a/cmd/modelcmd/modelcommand_test.go
+++ b/cmd/modelcmd/modelcommand_test.go
@@ -298,7 +298,6 @@ func (s *macaroonLoginSuite) TestsFailToObtainDischargeLogin(c *gc.C) {
 
 	cmd := modelcmd.NewModelCommandBase(s.store, s.controllerName, s.modelName)
 	_, err := cmd.NewAPIRoot()
-	// TODO(rog) is this really the right error here?
 	c.Assert(err, gc.ErrorMatches, `getting controller info: model "my-controller:my-model" not found`)
 }
 
@@ -309,6 +308,5 @@ func (s *macaroonLoginSuite) TestsUnknownUserLogin(c *gc.C) {
 
 	cmd := modelcmd.NewModelCommandBase(s.store, s.controllerName, s.modelName)
 	_, err := cmd.NewAPIRoot()
-	// TODO(rog) is this really the right error here?
 	c.Assert(err, gc.ErrorMatches, `getting controller info: model "my-controller:my-model" not found`)
 }

--- a/cmd/modelcmd/modelcommand_test.go
+++ b/cmd/modelcmd/modelcommand_test.go
@@ -260,32 +260,20 @@ const testUser = "testuser@somewhere"
 
 func (s *macaroonLoginSuite) SetUpTest(c *gc.C) {
 	s.MacaroonSuite.SetUpTest(c)
-
-	modelTag := names.NewModelTag(s.State.ModelUUID())
-	s.controllerName = "my-controller"
-	s.modelName = modelTag.Id()
-
 	s.MacaroonSuite.AddModelUser(c, testUser)
 
+	s.controllerName = "my-controller"
+	s.modelName = "my-model"
+	modelTag := names.NewModelTag(s.State.ModelUUID())
 	apiInfo := s.APIInfo(c)
 
-	store, err := configstore.Default()
-	c.Assert(err, jc.ErrorIsNil)
-	cfg := store.CreateInfo(s.controllerName + ":" + s.modelName)
-	cfg.SetAPIEndpoint(configstore.APIEndpoint{
-		Addresses: apiInfo.Addrs,
-		Hostnames: []string{"0.1.2.3"},
-		CACert:    apiInfo.CACert,
-		ModelUUID: modelTag.Id(),
-	})
-	err = cfg.Write()
-	cfg.SetAPICredentials(configstore.APICredentials{
-		User:     "",
-		Password: "",
-	})
-	c.Assert(err, jc.ErrorIsNil)
-
 	s.store = jujuclienttesting.NewMemStore()
+	s.store.Controllers[s.controllerName] = jujuclient.ControllerDetails{
+		Servers:        []string{"0.1.2.3"},
+		APIEndpoints:   apiInfo.Addrs,
+		ControllerUUID: apiInfo.ModelTag.Id(),
+		CACert:         apiInfo.CACert,
+	}
 	s.store.Models[s.controllerName] = &jujuclient.ControllerModels{
 		Models: map[string]jujuclient.ModelDetails{
 			s.modelName: {modelTag.Id()},
@@ -298,8 +286,7 @@ func (s *macaroonLoginSuite) TestsSuccessfulLogin(c *gc.C) {
 		return testUser
 	}
 
-	cmd := modelcmd.NewModelCommandBase(s.controllerName, s.modelName, nil, nil)
-	cmd.SetClientStore(s.store)
+	cmd := modelcmd.NewModelCommandBase(s.store, s.controllerName, s.modelName)
 	_, err := cmd.NewAPIRoot()
 	c.Assert(err, jc.ErrorIsNil)
 }
@@ -309,10 +296,10 @@ func (s *macaroonLoginSuite) TestsFailToObtainDischargeLogin(c *gc.C) {
 		return ""
 	}
 
-	cmd := modelcmd.NewModelCommandBase(s.controllerName, s.modelName, nil, nil)
+	cmd := modelcmd.NewModelCommandBase(s.store, s.controllerName, s.modelName)
 	_, err := cmd.NewAPIRoot()
 	// TODO(rog) is this really the right error here?
-	c.Assert(err, gc.ErrorMatches, `bootstrap config not found`)
+	c.Assert(err, gc.ErrorMatches, `getting controller info: model "my-controller:my-model" not found`)
 }
 
 func (s *macaroonLoginSuite) TestsUnknownUserLogin(c *gc.C) {
@@ -320,8 +307,8 @@ func (s *macaroonLoginSuite) TestsUnknownUserLogin(c *gc.C) {
 		return "testUnknown@nowhere"
 	}
 
-	cmd := modelcmd.NewModelCommandBase(s.controllerName, s.modelName, nil, nil)
+	cmd := modelcmd.NewModelCommandBase(s.store, s.controllerName, s.modelName)
 	_, err := cmd.NewAPIRoot()
 	// TODO(rog) is this really the right error here?
-	c.Assert(err, gc.ErrorMatches, `bootstrap config not found`)
+	c.Assert(err, gc.ErrorMatches, `getting controller info: model "my-controller:my-model" not found`)
 }

--- a/environs/jujutest/livetests.go
+++ b/environs/jujutest/livetests.go
@@ -457,7 +457,11 @@ func (t *LiveTests) TestBootstrapAndDeploy(c *gc.C) {
 	owner := env.Owner()
 
 	c.Logf("opening API connection")
-	apiState, err := juju.NewAPIState(owner, t.Env, api.DefaultDialOpts())
+	apiInfo, err := environs.APIInfo(t.Env)
+	c.Assert(err, jc.ErrorIsNil)
+	apiInfo.Tag = owner
+	apiInfo.Password = t.Env.Config().AdminSecret()
+	apiState, err := api.Open(apiInfo, api.DefaultDialOpts())
 	c.Assert(err, jc.ErrorIsNil)
 	defer apiState.Close()
 

--- a/featuretests/cmd_juju_controller_test.go
+++ b/featuretests/cmd_juju_controller_test.go
@@ -14,7 +14,6 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/modelmanager"
 	undertakerapi "github.com/juju/juju/api/undertaker"
 	"github.com/juju/juju/cmd/juju/commands"
@@ -42,11 +41,8 @@ func (s *cmdControllerSuite) run(c *gc.C, args ...string) *cmd.Context {
 }
 
 func (s *cmdControllerSuite) createEnv(c *gc.C, envname string, isServer bool) {
-	conn, err := juju.NewAPIState(s.AdminUserTag(c), s.Environ, api.DialOpts{})
-	c.Assert(err, jc.ErrorIsNil)
-	s.AddCleanup(func(*gc.C) { conn.Close() })
-	modelManager := modelmanager.NewClient(conn)
-	_, err = modelManager.CreateModel(s.AdminUserTag(c).Id(), nil, map[string]interface{}{
+	modelManager := modelmanager.NewClient(s.APIState)
+	_, err := modelManager.CreateModel(s.AdminUserTag(c).Id(), nil, map[string]interface{}{
 		"name":            envname,
 		"authorized-keys": "ssh-key",
 		"controller":      isServer,
@@ -188,10 +184,7 @@ func (s *cmdControllerSuite) TestSystemKillCallsEnvironDestroyOnHostedEnviron(c 
 	opc := make(chan dummy.Operation, 200)
 	dummy.Listen(opc)
 
-	conn, err := juju.NewAPIState(s.AdminUserTag(c), s.Environ, api.DialOpts{})
-	c.Assert(err, jc.ErrorIsNil)
-	s.AddCleanup(func(*gc.C) { conn.Close() })
-	client := undertakerapi.NewClient(conn)
+	client := undertakerapi.NewClient(s.APIState)
 
 	startTime := time.Date(2015, time.September, 1, 17, 2, 1, 0, time.UTC)
 	mClock := testing.NewClock(startTime)

--- a/featuretests/cmd_juju_register_test.go
+++ b/featuretests/cmd_juju_register_test.go
@@ -69,7 +69,7 @@ Welcome, bob. You are now logged into "bob-controller".
 
 	// Make sure that the saved server details are sufficient to connect
 	// to the api server.
-	api, err := juju.NewAPIConnection(s.ControllerStore, "bob-controller", "bob-controller", nil)
+	api, err := juju.NewAPIConnection(s.ControllerStore, "bob-controller", "", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(api.Close(), jc.ErrorIsNil)
 }

--- a/juju/api.go
+++ b/juju/api.go
@@ -39,22 +39,6 @@ type apiStateCachedInfo struct {
 
 var errAborted = fmt.Errorf("aborted")
 
-// NewAPIState creates an api.State object from an Environ
-// This is almost certainly the wrong thing to do as it assumes
-// the old admin password (stored as admin-secret in the config).
-func NewAPIState(user names.Tag, environ environs.Environ, dialOpts api.DialOpts) (api.Connection, error) {
-	info, err := environAPIInfo(environ, user)
-	if err != nil {
-		return nil, err
-	}
-
-	st, err := api.Open(info, dialOpts)
-	if err != nil {
-		return nil, err
-	}
-	return st, nil
-}
-
 var defaultAPIOpen = api.Open
 
 // NewAPIConnection returns an api.Connection to the specified Juju controller,
@@ -87,17 +71,40 @@ var serverAddress = func(hostPort string) (network.HostPort, error) {
 
 // newAPIFromStore implements the bulk of NewAPIConnection but is separate for
 // testing purposes.
-func newAPIFromStore(controllerName, modelName string, legacyStore configstore.Storage, store jujuclient.ControllerStore, apiOpen api.OpenFunc, bClient *httpbakery.Client) (api.Connection, error) {
+func newAPIFromStore(
+	controllerName, modelName string,
+	legacyStore configstore.Storage,
+	store jujuclient.ClientStore,
+	apiOpen api.OpenFunc,
+	bClient *httpbakery.Client,
+) (api.Connection, error) {
 
-	// TODO(axw) this should be unnecessary once we've removed the legacy
-	// configstore code. If no model name is specified, then we should
-	// use the controller UUID in the login instead.
-	if modelName == "" {
-		modelName = configstore.AdminModelName(controllerName)
-	}
-	info, err := legacyStore.ReadInfo(configstore.EnvironInfoName(controllerName, modelName))
+	controllerDetails, err := store.ControllerByName(controllerName)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Annotate(err, "getting controller details")
+	}
+
+	// There may be no current account, in which case we'll use macaroons.
+	// TODO(axw) allow the account name to be specified.
+	// TODO(axw) store macaroons in the account details? Need to check with
+	// rogpeppe/cmars/ashipika.
+	accountName, err := store.CurrentAccount(controllerName)
+	if err != nil && !errors.IsNotFound(err) {
+		return nil, errors.Annotate(err, "getting current account name")
+	}
+	var accountDetails *jujuclient.AccountDetails
+	if accountName != "" {
+		accountDetails, err = store.AccountByName(controllerName, accountName)
+		if err != nil {
+			return nil, errors.Annotate(err, "getting account details")
+		}
+	}
+	var modelDetails *jujuclient.ModelDetails
+	if modelName != "" {
+		modelDetails, err = store.ModelByName(controllerName, modelName)
+		if err != nil {
+			return nil, errors.Annotate(err, "getting model details")
+		}
 	}
 
 	// Try to connect to the API concurrently using two different
@@ -124,13 +131,12 @@ func newAPIFromStore(controllerName, modelName string, legacyStore configstore.S
 	try := parallel.NewTry(0, chooseError)
 
 	var delay time.Duration
-	if len(info.APIEndpoint().Addresses) > 0 {
-		logger.Debugf(
-			"trying cached API connection settings - endpoints %v",
-			info.APIEndpoint().Addresses,
-		)
+	if len(controllerDetails.APIEndpoints) > 0 {
 		try.Start(func(stop <-chan struct{}) (io.Closer, error) {
-			return apiInfoConnect(info, apiOpen, stop, bClient)
+			return apiInfoConnect(
+				controllerDetails, accountDetails, modelDetails,
+				apiOpen, stop, bClient,
+			)
 		})
 		// Delay the config connection until we've spent
 		// some time trying to connect to the cached info.
@@ -139,11 +145,14 @@ func newAPIFromStore(controllerName, modelName string, legacyStore configstore.S
 		logger.Debugf("no cached API connection settings found")
 	}
 	try.Start(func(stop <-chan struct{}) (io.Closer, error) {
-		cfg, err := getConfig(info)
+		cfg, err := getBootstrapConfig(legacyStore, controllerName, modelName)
 		if err != nil {
 			return nil, err
 		}
-		return apiConfigConnect(cfg, apiOpen, stop, delay, environInfoUserTag(info))
+		return apiConfigConnect(
+			cfg, accountDetails, modelDetails,
+			apiOpen, stop, delay, bClient,
+		)
 	})
 	try.Close()
 	val0, err := try.Result()
@@ -190,44 +199,33 @@ type infoConnectError struct {
 	error
 }
 
-func environInfoUserTag(info configstore.EnvironInfo) names.Tag {
-	var username string
-	if info != nil {
-		username = info.APICredentials().User
-	}
-	if username == "" {
-		return nil
-	}
-	return names.NewUserTag(username)
-}
-
 // apiInfoConnect looks for endpoint on the given environment and
 // tries to connect to it, sending the result on the returned channel.
-func apiInfoConnect(info configstore.EnvironInfo, apiOpen api.OpenFunc, stop <-chan struct{}, bClient *httpbakery.Client) (api.Connection, error) {
-	endpoint := info.APIEndpoint()
-	if info == nil || len(endpoint.Addresses) == 0 {
-		return nil, &infoConnectError{fmt.Errorf("no cached addresses")}
-	}
-	logger.Infof("connecting to API addresses: %v", endpoint.Addresses)
-	var modelTag names.ModelTag
-	if names.IsValidModel(endpoint.ModelUUID) {
-		modelTag = names.NewModelTag(endpoint.ModelUUID)
-	}
+func apiInfoConnect(
+	controller *jujuclient.ControllerDetails,
+	account *jujuclient.AccountDetails,
+	model *jujuclient.ModelDetails,
+	apiOpen api.OpenFunc,
+	stop <-chan struct{},
+	bClient *httpbakery.Client,
+) (api.Connection, error) {
 
+	logger.Infof("connecting to API addresses: %v", controller.APIEndpoints)
 	apiInfo := &api.Info{
-		Addrs:    endpoint.Addresses,
-		CACert:   endpoint.CACert,
-		Tag:      environInfoUserTag(info),
-		Password: info.APICredentials().Password,
-		ModelTag: modelTag,
+		Addrs:  controller.APIEndpoints,
+		CACert: controller.CACert,
 	}
-	if apiInfo.Tag == nil {
+	if account != nil {
+		apiInfo.Tag = names.NewUserTag(account.User)
+		apiInfo.Password = account.Password
+	} else {
 		apiInfo.UseMacaroons = true
 	}
-
+	if model != nil {
+		apiInfo.ModelTag = names.NewModelTag(model.ModelUUID)
+	}
 	dialOpts := api.DefaultDialOpts()
 	dialOpts.BakeryClient = bClient
-
 	st, err := apiOpen(apiInfo, dialOpts)
 	if err != nil {
 		return nil, &infoConnectError{err}
@@ -240,7 +238,15 @@ func apiInfoConnect(info configstore.EnvironInfo, apiOpen api.OpenFunc, stop <-c
 // its endpoint. It only starts the attempt after the given delay,
 // to allow the faster apiInfoConnect to hopefully succeed first.
 // It returns nil if there was no configuration information found.
-func apiConfigConnect(cfg *config.Config, apiOpen api.OpenFunc, stop <-chan struct{}, delay time.Duration, user names.Tag) (api.Connection, error) {
+func apiConfigConnect(
+	cfg *config.Config,
+	accountDetails *jujuclient.AccountDetails,
+	modelDetails *jujuclient.ModelDetails,
+	apiOpen api.OpenFunc,
+	stop <-chan struct{},
+	delay time.Duration,
+	bClient *httpbakery.Client,
+) (api.Connection, error) {
 	select {
 	case <-time.After(delay):
 	case <-stop:
@@ -250,21 +256,38 @@ func apiConfigConnect(cfg *config.Config, apiOpen api.OpenFunc, stop <-chan stru
 	if err != nil {
 		return nil, err
 	}
-	apiInfo, err := environAPIInfo(environ, user)
+	apiInfo, err := environs.APIInfo(environ)
 	if err != nil {
 		return nil, err
 	}
-
-	st, err := apiOpen(apiInfo, api.DefaultDialOpts())
-	// TODO(rog): handle errUnauthorized when the API handles passwords.
+	if accountDetails != nil {
+		apiInfo.Tag = names.NewUserTag(accountDetails.User)
+		apiInfo.Password = accountDetails.Password
+	} else {
+		apiInfo.UseMacaroons = true
+	}
+	dialOpts := api.DefaultDialOpts()
+	dialOpts.BakeryClient = bClient
+	st, err := apiOpen(apiInfo, dialOpts)
 	if err != nil {
-		return nil, err
+		return nil, errors.Trace(err)
 	}
 	return apiStateCachedInfo{st, apiInfo}, nil
 }
 
-// getConfig looks for configuration info on the given environment
-func getConfig(info configstore.EnvironInfo) (*config.Config, error) {
+// getBootstrapConfig looks for configuration info on the given environment
+func getBootstrapConfig(legacyStore configstore.Storage, controllerName, modelName string) (*config.Config, error) {
+	// TODO(axw) model name will be unnecessary when we stop using
+	// configstore.
+	if modelName == "" {
+		modelName = configstore.AdminModelName(controllerName)
+	}
+	// TODO(axw) we need to store bootstrap config, or enough information
+	// to derive it, in jujuclient.
+	info, err := legacyStore.ReadInfo(configstore.EnvironInfoName(controllerName, modelName))
+	if err != nil {
+		return nil, errors.Annotate(err, "getting controller info")
+	}
 	if len(info.BootstrapConfig()) == 0 {
 		return nil, errors.NotFoundf("bootstrap config")
 	}
@@ -273,21 +296,6 @@ func getConfig(info configstore.EnvironInfo) (*config.Config, error) {
 		logger.Warningf("failed to parse bootstrap-config: %v", err)
 	}
 	return cfg, err
-}
-
-func environAPIInfo(environ environs.Environ, user names.Tag) (*api.Info, error) {
-	config := environ.Config()
-	password := config.AdminSecret()
-	info, err := environs.APIInfo(environ)
-	if err != nil {
-		return nil, err
-	}
-	info.Tag = user
-	info.Password = password
-	if info.Tag == nil {
-		info.UseMacaroons = true
-	}
-	return info, nil
 }
 
 var maybePreferIPv6 = func(info configstore.EnvironInfo) bool {

--- a/juju/api_test.go
+++ b/juju/api_test.go
@@ -36,82 +36,6 @@ import (
 	"github.com/juju/juju/version"
 )
 
-type NewAPIStateSuite struct {
-	coretesting.FakeJujuXDGDataHomeSuite
-	testing.MgoSuite
-	envtesting.ToolsFixture
-}
-
-var _ = gc.Suite(&NewAPIStateSuite{})
-
-func (cs *NewAPIStateSuite) SetUpSuite(c *gc.C) {
-	cs.FakeJujuXDGDataHomeSuite.SetUpSuite(c)
-	cs.MgoSuite.SetUpSuite(c)
-	cs.PatchValue(&simplestreams.SimplestreamsJujuPublicKey, sstesting.SignedMetadataPublicKey)
-}
-
-func (cs *NewAPIStateSuite) TearDownSuite(c *gc.C) {
-	cs.MgoSuite.TearDownSuite(c)
-	cs.FakeJujuXDGDataHomeSuite.TearDownSuite(c)
-}
-
-func (cs *NewAPIStateSuite) SetUpTest(c *gc.C) {
-	cs.FakeJujuXDGDataHomeSuite.SetUpTest(c)
-	cs.MgoSuite.SetUpTest(c)
-	cs.ToolsFixture.SetUpTest(c)
-	cs.PatchValue(&dummy.LogDir, c.MkDir())
-}
-
-func (cs *NewAPIStateSuite) TearDownTest(c *gc.C) {
-	dummy.Reset()
-	cs.ToolsFixture.TearDownTest(c)
-	cs.MgoSuite.TearDownTest(c)
-	cs.FakeJujuXDGDataHomeSuite.TearDownTest(c)
-}
-
-func (cs *NewAPIStateSuite) TestNewAPIState(c *gc.C) {
-	cs.PatchValue(&version.Current, coretesting.FakeVersionNumber)
-	cfg, err := config.New(config.NoDefaults, dummy.SampleConfig())
-	c.Assert(err, jc.ErrorIsNil)
-	ctx := envtesting.BootstrapContext(c)
-	cache := jujuclienttesting.NewMemStore()
-	env, err := environs.Prepare(ctx, configstore.NewMem(), cache, cfg.Name(), environs.PrepareForBootstrapParams{Config: cfg})
-	c.Assert(err, jc.ErrorIsNil)
-
-	storageDir := c.MkDir()
-	cs.PatchValue(&envtools.DefaultBaseURL, storageDir)
-	stor, err := filestorage.NewFileStorageWriter(storageDir)
-	c.Assert(err, jc.ErrorIsNil)
-	envtesting.UploadFakeTools(c, stor, "released", "released")
-
-	err = bootstrap.Bootstrap(ctx, env, bootstrap.BootstrapParams{})
-	c.Assert(err, jc.ErrorIsNil)
-
-	// At this stage, only controller record should exist,
-	// without connection details.
-	foundController, err := cache.ControllerByName(cfg.Name())
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(foundController.Servers, gc.HasLen, 0)
-	c.Assert(foundController.APIEndpoints, gc.HasLen, 0)
-
-	cfg = env.Config()
-	cfg, err = cfg.Apply(map[string]interface{}{
-		"secret": "fnord",
-	})
-	c.Assert(err, jc.ErrorIsNil)
-	err = env.SetConfig(cfg)
-	c.Assert(err, jc.ErrorIsNil)
-
-	st, err := juju.NewAPIState(names.NewUserTag("admin@local"), env, api.DialOpts{})
-	c.Assert(st, gc.NotNil)
-
-	// the secrets will not be updated, as they already exist
-	attrs, err := st.Client().ModelGet()
-	c.Assert(attrs["secret"], gc.Equals, "pork")
-
-	c.Assert(st.Close(), gc.IsNil)
-}
-
 type NewAPIClientSuite struct {
 	coretesting.FakeJujuXDGDataHomeSuite
 	testing.MgoSuite
@@ -159,21 +83,18 @@ func (cs *NewAPIClientSuite) TearDownTest(c *gc.C) {
 	cs.FakeJujuXDGDataHomeSuite.TearDownTest(c)
 }
 
-func (s *NewAPIClientSuite) bootstrapEnv(c *gc.C, store configstore.Storage, controllerStore jujuclient.ClientStore) {
+func (s *NewAPIClientSuite) bootstrapEnv(c *gc.C) (configstore.Storage, jujuclient.ClientStore) {
 	const controllerName = "local.my-controller"
-	if store == nil {
-		store = configstore.NewMem()
-	}
-	if controllerStore == nil {
-		controllerStore = jujuclienttesting.NewMemStore()
-	}
+
+	legacyStore := configstore.NewMem()
+	store := jujuclienttesting.NewMemStore()
 
 	ctx := envtesting.BootstrapContext(c)
 	cfg, err := config.New(config.UseDefaults, dummy.SampleConfig())
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(err, jc.ErrorIsNil)
-	env, err := environs.Prepare(ctx, store, controllerStore, controllerName, environs.PrepareForBootstrapParams{Config: cfg})
+	env, err := environs.Prepare(ctx, legacyStore, store, controllerName, environs.PrepareForBootstrapParams{Config: cfg})
 	c.Assert(err, jc.ErrorIsNil)
 
 	storageDir := c.MkDir()
@@ -184,11 +105,12 @@ func (s *NewAPIClientSuite) bootstrapEnv(c *gc.C, store configstore.Storage, con
 
 	err = bootstrap.Bootstrap(ctx, env, bootstrap.BootstrapParams{})
 	c.Assert(err, jc.ErrorIsNil)
+	return legacyStore, store
 }
 
 func (s *NewAPIClientSuite) TestWithInfoOnly(c *gc.C) {
-	store := newConfigStore("noconfig", dummyStoreInfo)
-	controllerStore := newControllerStore("noconfig", dummyStoreInfo)
+	legacyStore := newConfigStore("noconfig", dummyStoreInfo)
+	store := newClientStore(c, "noconfig", dummyStoreInfo)
 
 	called := 0
 	expectState := mockedAPIState(mockedHostPort | mockedModelTag)
@@ -201,13 +123,13 @@ func (s *NewAPIClientSuite) TestWithInfoOnly(c *gc.C) {
 
 	// Give NewAPIFromStore a store interface that can report when the
 	// config was written to, to check if the cache is updated.
-	mockStore := &storageWithWriteNotify{store: store}
-	st, err := juju.NewAPIFromStore("noconfig", "noconfig", mockStore, controllerStore, apiOpen)
+	mockStore := &storageWithWriteNotify{store: legacyStore}
+	st, err := juju.NewAPIFromStore("noconfig", "noconfig", mockStore, store, apiOpen)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(st, gc.Equals, expectState)
 	c.Assert(called, gc.Equals, 1)
 	c.Assert(mockStore.written, jc.IsTrue)
-	info, err := store.ReadInfo("noconfig:noconfig")
+	info, err := legacyStore.ReadInfo("noconfig:noconfig")
 	c.Assert(err, jc.ErrorIsNil)
 	ep := info.APIEndpoint()
 	c.Check(ep.Addresses, jc.DeepEquals, []string{
@@ -216,25 +138,31 @@ func (s *NewAPIClientSuite) TestWithInfoOnly(c *gc.C) {
 	c.Check(ep.ModelUUID, gc.Equals, fakeUUID)
 	mockStore.written = false
 
-	controllerBefore, err := controllerStore.ControllerByName("noconfig")
+	controllerBefore, err := store.ControllerByName("noconfig")
 	c.Assert(err, jc.ErrorIsNil)
 
 	// If APIHostPorts haven't changed, then the store won't be updated.
-	st, err = juju.NewAPIFromStore("noconfig", "noconfig", mockStore, controllerStore, apiOpen)
+	st, err = juju.NewAPIFromStore("noconfig", "noconfig", mockStore, store, apiOpen)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(st, gc.Equals, expectState)
 	c.Assert(called, gc.Equals, 2)
 	c.Assert(mockStore.written, jc.IsFalse)
 
-	controllerAfter, err := controllerStore.ControllerByName("noconfig")
+	controllerAfter, err := store.ControllerByName("noconfig")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(controllerBefore, gc.DeepEquals, controllerAfter)
 }
 
 func (s *NewAPIClientSuite) TestWithInfoError(c *gc.C) {
 	expectErr := fmt.Errorf("an error")
-	store := newConfigStoreWithError(expectErr)
-	client, err := juju.NewAPIFromStore("noconfig", "noconfig", store, jujuclienttesting.NewMemStore(), panicAPIOpen)
+	legacyStore := newConfigStoreWithError(expectErr)
+	store := newClientStore(c, "noconfig", &environInfo{
+		endpoint: configstore.APIEndpoint{
+			ServerUUID: "valid.uuid",
+			CACert:     "certificated",
+		},
+	})
+	client, err := juju.NewAPIFromStore("noconfig", "", legacyStore, store, panicAPIOpen)
 	c.Assert(errors.Cause(err), gc.Equals, expectErr)
 	c.Assert(client, gc.IsNil)
 }
@@ -246,10 +174,11 @@ func (s *NewAPIClientSuite) TestWithInfoNoAddresses(c *gc.C) {
 			CACert:    "certificated",
 		},
 	})
-	cache := newControllerStore("noconfig", &environInfo{
+	cache := newClientStore(c, "noconfig", &environInfo{
 		endpoint: configstore.APIEndpoint{
 			Addresses:  []string{},
 			ServerUUID: "valid.uuid",
+			ModelUUID:  "valid.uuid",
 			CACert:     "certificated",
 		},
 	})
@@ -313,7 +242,7 @@ func mockedAPIState(flags mockedStateFlags) *mockAPIState {
 }
 
 func checkCommonAPIInfoAttrs(c *gc.C, apiInfo *api.Info, opts api.DialOpts) {
-	c.Check(apiInfo.Tag, gc.Equals, names.NewUserTag("foo"))
+	c.Check(apiInfo.Tag, gc.Equals, names.NewUserTag("foo@local"))
 	c.Check(string(apiInfo.CACert), gc.Equals, "certificated")
 	c.Check(apiInfo.Password, gc.Equals, "foopass")
 	c.Check(opts, gc.DeepEquals, api.DefaultDialOpts())
@@ -322,7 +251,8 @@ func checkCommonAPIInfoAttrs(c *gc.C, apiInfo *api.Info, opts api.DialOpts) {
 func (s *NewAPIClientSuite) TestWithInfoNoAPIHostports(c *gc.C) {
 	// The API doesn't have apiHostPorts, we don't want to
 	// override the local cache with bad endpoints.
-	store := newConfigStore("noconfig", noTagStoreInfo)
+	legacyStore := newConfigStore("noconfig", noTagStoreInfo)
+	store := newClientStore(c, "noconfig", dummyStoreInfo)
 
 	called := 0
 	expectState := mockedAPIState(mockedModelTag | mockedPreferIPv6)
@@ -333,15 +263,22 @@ func (s *NewAPIClientSuite) TestWithInfoNoAPIHostports(c *gc.C) {
 		return expectState, nil
 	}
 
-	mockStore := &storageWithWriteNotify{store: store}
-	st, err := juju.NewAPIFromStore("noconfig", "noconfig", mockStore, jujuclienttesting.NewMemStore(), apiOpen)
+	mockStore := &storageWithWriteNotify{store: legacyStore}
+	st, err := juju.NewAPIFromStore("noconfig", "", mockStore, store, apiOpen)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(st, gc.Equals, expectState)
 	c.Assert(called, gc.Equals, 1)
-	info, err := store.ReadInfo("noconfig:noconfig")
+
+	// We should not have disturbed the Addresses
+
+	details, err := store.ControllerByName("noconfig")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(details.APIEndpoints, gc.HasLen, 1)
+	c.Check(details.APIEndpoints[0], gc.Matches, `foo\.invalid`)
+
+	info, err := legacyStore.ReadInfo("noconfig:noconfig")
 	c.Assert(err, jc.ErrorIsNil)
 	ep := info.APIEndpoint()
-	// We should not have disturbed the Addresses
 	c.Check(ep.Addresses, gc.HasLen, 1)
 	c.Check(ep.Addresses[0], gc.Matches, `foo\.invalid`)
 }
@@ -352,7 +289,7 @@ func (s *NewAPIClientSuite) TestWithInfoAPIOpenError(c *gc.C) {
 			Addresses: []string{"foo.invalid"},
 		},
 	})
-	jujuClient := newControllerStore("noconfig", &environInfo{
+	jujuClient := newClientStore(c, "noconfig", &environInfo{
 		endpoint: configstore.APIEndpoint{
 			Addresses:  []string{"foo.invalid"},
 			ServerUUID: "some.uuid",
@@ -363,7 +300,7 @@ func (s *NewAPIClientSuite) TestWithInfoAPIOpenError(c *gc.C) {
 	apiOpen := func(apiInfo *api.Info, opts api.DialOpts) (api.Connection, error) {
 		return nil, errors.Errorf("an error")
 	}
-	st, err := juju.NewAPIFromStore("noconfig", "noconfig", store, jujuClient, apiOpen)
+	st, err := juju.NewAPIFromStore("noconfig", "", store, jujuClient, apiOpen)
 	// We expect to  get the isNotFound error as it is more important than the
 	// infoConnectError "an error"
 	c.Assert(err, gc.ErrorMatches, "bootstrap config not found")
@@ -373,9 +310,7 @@ func (s *NewAPIClientSuite) TestWithInfoAPIOpenError(c *gc.C) {
 func (s *NewAPIClientSuite) TestWithSlowInfoConnect(c *gc.C) {
 	c.Skip("wallyworld - this is a dumb test relying on an arbitary 50ms delay to pass")
 	s.PatchValue(&version.Current, coretesting.FakeVersionNumber)
-	store := configstore.NewMem()
-	controllerStore := jujuclienttesting.NewMemStore()
-	s.bootstrapEnv(c, store, controllerStore)
+	legacyStore, store := s.bootstrapEnv(c)
 	setEndpointAddressAndHostname(c, store, "0.1.2.3", "infoapi.invalid")
 
 	infoOpenedState := mockedAPIState(noFlags)
@@ -401,7 +336,7 @@ func (s *NewAPIClientSuite) TestWithSlowInfoConnect(c *gc.C) {
 	cfgOpenedState.close = infoOpenedState.close
 
 	startTime := time.Now()
-	st, err := juju.NewAPIFromStore("local.my-controller", "only", store, controllerStore, apiOpen)
+	st, err := juju.NewAPIFromStore("local.my-controller", "only", legacyStore, store, apiOpen)
 	c.Assert(err, jc.ErrorIsNil)
 	// The connection logic should wait for some time before opening
 	// the API from the configuration.
@@ -423,19 +358,30 @@ func (s *NewAPIClientSuite) TestWithSlowInfoConnect(c *gc.C) {
 	}
 }
 
-type badBootstrapInfo struct {
-	configstore.EnvironInfo
+func (s *NewAPIClientSuite) TestGetBootstrapConfigNoLegacyInfo(c *gc.C) {
+	store := configstore.NewMem()
+	cfg, err := juju.GetBootstrapConfig(store, "whatever", "")
+	c.Assert(err, gc.ErrorMatches, `getting controller info: model "whatever:whatever" not found`)
+	c.Assert(cfg, gc.IsNil)
 }
 
-// BootstrapConfig is returned as a map with real content, but the content
-// isn't actually valid configuration, causing config.New to fail
-func (m *badBootstrapInfo) BootstrapConfig() map[string]interface{} {
-	return map[string]interface{}{"something": "else"}
+func (s *NewAPIClientSuite) TestGetBootstrapConfigNoBootstrapConfig(c *gc.C) {
+	store := configstore.NewMem()
+	info := store.CreateInfo("whatever:whatever")
+	err := info.Write()
+	c.Assert(err, jc.ErrorIsNil)
+	cfg, err := juju.GetBootstrapConfig(store, "whatever", "")
+	c.Assert(err, gc.ErrorMatches, "bootstrap config not found")
+	c.Assert(cfg, gc.IsNil)
 }
 
-func (s *NewAPIClientSuite) TestBadConfigDoesntPanic(c *gc.C) {
-	badInfo := &badBootstrapInfo{}
-	cfg, err := juju.GetConfig(badInfo)
+func (s *NewAPIClientSuite) TestGetBootstrapConfigBadConfigDoesntPanic(c *gc.C) {
+	store := configstore.NewMem()
+	info := store.CreateInfo("whatever:whatever")
+	info.SetBootstrapConfig(map[string]interface{}{"something": "else"})
+	err := info.Write()
+	c.Assert(err, jc.ErrorIsNil)
+	cfg, err := juju.GetBootstrapConfig(store, "whatever", "")
 	// The specific error we get depends on what key is invalid, which is a
 	// bit spurious, but what we care about is that we didn't get a panic,
 	// but instead got an error
@@ -443,26 +389,20 @@ func (s *NewAPIClientSuite) TestBadConfigDoesntPanic(c *gc.C) {
 	c.Assert(cfg, gc.IsNil)
 }
 
-func setEndpointAddressAndHostname(c *gc.C, store configstore.Storage, addr, host string) {
-	// Populate the environment's info with an endpoint
-	// with a known address and hostname.
-	info, err := store.ReadInfo("local.my-controller:only")
+func setEndpointAddressAndHostname(c *gc.C, store jujuclient.ControllerStore, addr, host string) {
+	// Populate the controller details with known address and hostname.
+	details, err := store.ControllerByName("local.my-controller")
 	c.Assert(err, jc.ErrorIsNil)
-	info.SetAPIEndpoint(configstore.APIEndpoint{
-		Addresses: []string{addr},
-		Hostnames: []string{host},
-		CACert:    "certificated",
-	})
-	err = info.Write()
+	details.APIEndpoints = []string{addr}
+	details.Servers = []string{host}
+	err = store.UpdateController("local.my-controller", *details)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *NewAPIClientSuite) TestWithSlowConfigConnect(c *gc.C) {
 	s.PatchValue(&version.Current, coretesting.FakeVersionNumber)
 
-	store := configstore.NewMem()
-	controllerStore := jujuclienttesting.NewMemStore()
-	s.bootstrapEnv(c, store, controllerStore)
+	legacyStore, store := s.bootstrapEnv(c)
 	setEndpointAddressAndHostname(c, store, "0.1.2.3", "infoapi.invalid")
 
 	infoOpenedState := mockedAPIState(noFlags)
@@ -491,7 +431,7 @@ func (s *NewAPIClientSuite) TestWithSlowConfigConnect(c *gc.C) {
 
 	done := make(chan struct{})
 	go func() {
-		st, err := juju.NewAPIFromStore("local.my-controller", "only", store, controllerStore, apiOpen)
+		st, err := juju.NewAPIFromStore("local.my-controller", "only", legacyStore, store, apiOpen)
 		c.Check(err, jc.ErrorIsNil)
 		c.Check(st, gc.Equals, infoOpenedState)
 		close(done)
@@ -530,9 +470,7 @@ func (s *NewAPIClientSuite) TestWithSlowConfigConnect(c *gc.C) {
 
 func (s *NewAPIClientSuite) TestBothError(c *gc.C) {
 	s.PatchValue(&version.Current, coretesting.FakeVersionNumber)
-	store := configstore.NewMem()
-	controllerStore := jujuclienttesting.NewMemStore()
-	s.bootstrapEnv(c, store, controllerStore)
+	legacyStore, store := s.bootstrapEnv(c)
 	setEndpointAddressAndHostname(c, store, "0.1.2.3", "infoapi.invalid")
 
 	s.PatchValue(juju.ProviderConnectDelay, 0*time.Second)
@@ -542,7 +480,7 @@ func (s *NewAPIClientSuite) TestBothError(c *gc.C) {
 		}
 		return nil, fmt.Errorf("config connect failed")
 	}
-	st, err := juju.NewAPIFromStore("local.my-controller", "only", store, controllerStore, apiOpen)
+	st, err := juju.NewAPIFromStore("local.my-controller", "only", legacyStore, store, apiOpen)
 	c.Check(err, gc.ErrorMatches, "config connect failed")
 	c.Check(st, gc.IsNil)
 }
@@ -555,10 +493,13 @@ func defaultConfigStore(c *gc.C) configstore.Storage {
 
 func (s *NewAPIClientSuite) TestWithBootstrapConfigAndNoEnvironmentsFile(c *gc.C) {
 	s.PatchValue(&version.Current, coretesting.FakeVersionNumber)
-	store := configstore.NewMem()
-	controllerStore := jujuclienttesting.NewMemStore()
-	s.bootstrapEnv(c, store, controllerStore)
-	info, err := store.ReadInfo("local.my-controller:only")
+	legacyStore, store := s.bootstrapEnv(c)
+
+	details, err := store.ControllerByName("local.my-controller")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(details.APIEndpoints, gc.HasLen, 0)
+
+	info, err := legacyStore.ReadInfo("local.my-controller:only")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(info.BootstrapConfig(), gc.NotNil)
 	c.Assert(info.APIEndpoint().Addresses, gc.HasLen, 0)
@@ -566,15 +507,9 @@ func (s *NewAPIClientSuite) TestWithBootstrapConfigAndNoEnvironmentsFile(c *gc.C
 	apiOpen := func(*api.Info, api.DialOpts) (api.Connection, error) {
 		return mockedAPIState(noFlags), nil
 	}
-	st, err := juju.NewAPIFromStore("local.my-controller", "only", store, controllerStore, apiOpen)
+	st, err := juju.NewAPIFromStore("local.my-controller", "only", legacyStore, store, apiOpen)
 	c.Check(err, jc.ErrorIsNil)
 	st.Close()
-}
-
-func assertEnvironmentName(c *gc.C, client *api.Client, expectName string) {
-	envInfo, err := client.ModelInfo()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(envInfo.Name, gc.Equals, expectName)
 }
 
 // newConfigStoreWithError that will return the given
@@ -616,21 +551,37 @@ func newConfigStore(envName string, info *environInfo) configstore.Storage {
 	return store
 }
 
-// newControllerStore returns controller store that contains information
-// for the controller name.
-func newControllerStore(controllerName string, info *environInfo) jujuclient.ClientStore {
-	controllerStore := jujuclienttesting.NewMemStore()
-
-	err := controllerStore.UpdateController(controllerName, jujuclient.ControllerDetails{
+// newClientStore returns a client store that contains information
+// based on the given controller namd and info.
+func newClientStore(c *gc.C, controllerName string, info *environInfo) jujuclient.ClientStore {
+	store := jujuclienttesting.NewMemStore()
+	err := store.UpdateController(controllerName, jujuclient.ControllerDetails{
 		info.endpoint.Hostnames,
 		info.endpoint.ServerUUID,
 		info.endpoint.Addresses,
 		info.endpoint.CACert,
 	})
-	if err != nil {
-		panic(err)
+	c.Assert(err, jc.ErrorIsNil)
+
+	if info.endpoint.ModelUUID != "" {
+		err = store.UpdateModel(controllerName, controllerName, jujuclient.ModelDetails{
+			info.endpoint.ModelUUID,
+		})
+		c.Assert(err, jc.ErrorIsNil)
 	}
-	return controllerStore
+
+	if info.creds.User != "" {
+		user := names.NewUserTag(info.creds.User).Canonical()
+		err = store.UpdateAccount(controllerName, user, jujuclient.AccountDetails{
+			User:     user,
+			Password: info.creds.Password,
+		})
+		c.Assert(err, jc.ErrorIsNil)
+		err = store.SetCurrentAccount(controllerName, user)
+		c.Assert(err, jc.ErrorIsNil)
+	}
+
+	return store
 }
 
 type storageWithWriteNotify struct {
@@ -1135,24 +1086,4 @@ var dummyStoreInfo = &environInfo{
 		ModelUUID:  fakeUUID,
 		ServerUUID: fakeUUID,
 	},
-}
-
-type EnvironInfoTest struct {
-	coretesting.FakeJujuXDGDataHomeSuite
-}
-
-var _ = gc.Suite(&EnvironInfoTest{})
-
-type fakeEnvironInfo struct {
-	configstore.EnvironInfo
-	user string
-}
-
-func (fake *fakeEnvironInfo) APICredentials() configstore.APICredentials {
-	return configstore.APICredentials{User: fake.user}
-}
-
-func (*EnvironInfoTest) TestRealUser(c *gc.C) {
-	info := &fakeEnvironInfo{user: "eric"}
-	c.Assert(juju.EnvironInfoUserTag(info), gc.Equals, names.NewUserTag("eric"))
 }

--- a/juju/export_test.go
+++ b/juju/export_test.go
@@ -8,8 +8,7 @@ import (
 
 var (
 	ProviderConnectDelay   = &providerConnectDelay
-	GetConfig              = getConfig
-	EnvironInfoUserTag     = environInfoUserTag
+	GetBootstrapConfig     = getBootstrapConfig
 	MaybePreferIPv6        = &maybePreferIPv6
 	ResolveOrDropHostnames = &resolveOrDropHostnames
 	ServerAddress          = &serverAddress

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -36,7 +36,6 @@ import (
 	"github.com/juju/juju/environs/storage"
 	envtesting "github.com/juju/juju/environs/testing"
 	"github.com/juju/juju/environs/tools"
-	"github.com/juju/juju/juju"
 	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/mongo"
@@ -289,7 +288,11 @@ func (s *JujuConnSuite) setUpConn(c *gc.C) {
 	s.State, err = newState(environ, s.BackingState.MongoConnectionInfo())
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.APIState, err = juju.NewAPIState(s.AdminUserTag(c), environ, api.DialOpts{})
+	apiInfo, err := environs.APIInfo(environ)
+	c.Assert(err, jc.ErrorIsNil)
+	apiInfo.Tag = s.AdminUserTag(c)
+	apiInfo.Password = environ.Config().AdminSecret()
+	s.APIState, err = api.Open(apiInfo, api.DialOpts{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = s.State.SetAPIHostPorts(s.APIState.APIHostPorts())

--- a/jujuclient/file.go
+++ b/jujuclient/file.go
@@ -436,7 +436,7 @@ func (s *store) SetCurrentAccount(controllerName, accountName string) error {
 	}
 	accounts, ok := controllerAccounts[controllerName]
 	if !ok {
-		return errors.NotFoundf("controller %s", controllerName)
+		return errors.NotFoundf("account %s:%s", controllerName, accountName)
 	}
 	if accounts.CurrentAccount == accountName {
 		return nil


### PR DESCRIPTION
In juju/api.go, we now only use configstore for
the bootstrap config address resolution fallback.

juju.NewAPIState has been removed, and inlined
into the few tests that required it.

cmd/juju/register.go no longer calls
juju.UpdateControllerAddresses directly, but
first records the addresses used to contact the
controller in the first place, and then relies
on the proceeding API connection to update the
store.

Finally, we add a "switch-user" command, which
was the reason behind this branch in the first
place.

(Review request: http://reviews.vapour.ws/r/3923/)