### PR TITLE
servicescaler server, client, worker

### DIFF
--- a/api/base/testing/apicaller.go
+++ b/api/base/testing/apicaller.go
@@ -27,6 +27,8 @@ func (f APICallerFunc) APICall(objType string, version int, id, request string, 
 }
 
 func (APICallerFunc) BestFacadeVersion(facade string) int {
+	// TODO(fwereade): this should return something arbitrary (e.g. 37)
+	// so that it can't be confused with mere uninitialized data.
 	return 0
 }
 

--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -58,6 +58,7 @@ var facadeVersions = map[string]int{
 	"RelationUnitsWatcher":         1,
 	"Resumer":                      2,
 	"Service":                      3,
+	"ServiceScaler":                1,
 	"Storage":                      2,
 	"Spaces":                       2,
 	"Subnets":                      2,

--- a/api/servicescaler/api.go
+++ b/api/servicescaler/api.go
@@ -1,0 +1,79 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package servicescaler
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	"github.com/juju/names"
+
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/watcher"
+)
+
+var logger = loggo.GetLogger("juju.api.servicescaler")
+
+// NewWatcherFunc exists to let us test Watch properly.
+type NewWatcherFunc func(base.APICaller, params.StringsWatchResult) watcher.StringsWatcher
+
+// API makes calls to the ServiceScaler facade.
+type API struct {
+	caller     base.FacadeCaller
+	newWatcher NewWatcherFunc
+}
+
+// NewAPI returns a new API using the supplied caller.
+func NewAPI(caller base.APICaller, newWatcher NewWatcherFunc) *API {
+	return &API{
+		caller:     base.NewFacadeCaller(caller, "ServiceScaler"),
+		newWatcher: newWatcher,
+	}
+}
+
+// Watch returns a StringsWatcher that delivers the names of services
+// that may need to be rescaled.
+func (api *API) Watch() (watcher.StringsWatcher, error) {
+	var result params.StringsWatchResult
+	err := api.caller.FacadeCall("Watch", nil, &result)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if result.Error != nil {
+		return nil, errors.Trace(result.Error)
+	}
+	w := api.newWatcher(api.caller.RawAPICaller(), result)
+	return w, nil
+}
+
+// Rescale requests that all supplied service names be rescaled to
+// their minimum configured sizes. It returns the first error it
+// encounters.
+func (api *API) Rescale(services []string) error {
+	args := params.Entities{
+		Entities: make([]params.Entity, len(services)),
+	}
+	for i, service := range services {
+		if !names.IsValidService(service) {
+			return errors.NotValidf("service name %q", service)
+		}
+		tag := names.NewServiceTag(service)
+		args.Entities[i].Tag = tag.String()
+	}
+	var results params.ErrorResults
+	err := api.caller.FacadeCall("Rescale", args, &results)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	for _, result := range results.Results {
+		if result.Error != nil {
+			if err == nil {
+				err = result.Error
+			} else {
+				logger.Errorf("additional rescale error: %v", err)
+			}
+		}
+	}
+	return errors.Trace(err)
+}

--- a/api/servicescaler/api_test.go
+++ b/api/servicescaler/api_test.go
@@ -1,0 +1,172 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package servicescaler_test
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/api/base"
+	apitesting "github.com/juju/juju/api/base/testing"
+	"github.com/juju/juju/api/servicescaler"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/watcher"
+)
+
+type APISuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&APISuite{})
+
+func (s *APISuite) TestRescaleMethodName(c *gc.C) {
+	var called bool
+	caller := apiCaller(c, func(request string, _, _ interface{}) error {
+		called = true
+		c.Check(request, gc.Equals, "Rescale")
+		return nil
+	})
+	api := servicescaler.NewAPI(caller, nil)
+
+	api.Rescale(nil)
+	c.Check(called, jc.IsTrue)
+}
+
+func (s *APISuite) TestRescaleBadArgs(c *gc.C) {
+	caller := apiCaller(c, func(_ string, _, _ interface{}) error {
+		panic("should not be called")
+	})
+	api := servicescaler.NewAPI(caller, nil)
+
+	err := api.Rescale([]string{"good-name", "bad/name"})
+	c.Check(err, gc.ErrorMatches, `service name "bad/name" not valid`)
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+}
+
+func (s *APISuite) TestRescaleConvertArgs(c *gc.C) {
+	var called bool
+	caller := apiCaller(c, func(_ string, arg, _ interface{}) error {
+		called = true
+		c.Check(arg, gc.DeepEquals, params.Entities{
+			Entities: []params.Entity{{
+				"service-foo",
+			}, {
+				"service-bar-baz",
+			}},
+		})
+		return nil
+	})
+	api := servicescaler.NewAPI(caller, nil)
+
+	api.Rescale([]string{"foo", "bar-baz"})
+	c.Check(called, jc.IsTrue)
+}
+
+func (s *APISuite) TestRescaleCallError(c *gc.C) {
+	caller := apiCaller(c, func(_ string, _, _ interface{}) error {
+		return errors.New("snorble flip")
+	})
+	api := servicescaler.NewAPI(caller, nil)
+
+	err := api.Rescale(nil)
+	c.Check(err, gc.ErrorMatches, "snorble flip")
+}
+
+func (s *APISuite) TestRescaleFirstError(c *gc.C) {
+	caller := apiCaller(c, func(_ string, _, result interface{}) error {
+		resultPtr, ok := result.(*params.ErrorResults)
+		c.Assert(ok, jc.IsTrue)
+		*resultPtr = params.ErrorResults{Results: []params.ErrorResult{{
+			nil,
+		}, {
+			&params.Error{Message: "expect this error"},
+		}, {
+			&params.Error{Message: "not this one"},
+		}, {
+			nil,
+		}}}
+		return nil
+	})
+	api := servicescaler.NewAPI(caller, nil)
+
+	err := api.Rescale(nil)
+	c.Check(err, gc.ErrorMatches, "expect this error")
+}
+
+func (s *APISuite) TestRescaleNoError(c *gc.C) {
+	caller := apiCaller(c, func(_ string, _, _ interface{}) error {
+		return nil
+	})
+	api := servicescaler.NewAPI(caller, nil)
+
+	err := api.Rescale(nil)
+	c.Check(err, jc.ErrorIsNil)
+}
+
+func (s *APISuite) TestWatchMethodName(c *gc.C) {
+	var called bool
+	caller := apiCaller(c, func(request string, _, _ interface{}) error {
+		called = true
+		c.Check(request, gc.Equals, "Watch")
+		return errors.New("irrelevant")
+	})
+	api := servicescaler.NewAPI(caller, nil)
+
+	api.Watch()
+	c.Check(called, jc.IsTrue)
+}
+
+func (s *APISuite) TestWatchError(c *gc.C) {
+	var called bool
+	caller := apiCaller(c, func(request string, _, _ interface{}) error {
+		called = true
+		c.Check(request, gc.Equals, "Watch")
+		return errors.New("blam pow")
+	})
+	api := servicescaler.NewAPI(caller, nil)
+
+	watcher, err := api.Watch()
+	c.Check(watcher, gc.IsNil)
+	c.Check(err, gc.ErrorMatches, "blam pow")
+	c.Check(called, jc.IsTrue)
+}
+
+func (s *APISuite) TestWatchSuccess(c *gc.C) {
+	expectResult := params.StringsWatchResult{
+		StringsWatcherId: "123",
+		Changes:          []string{"ping", "pong", "pung"},
+	}
+	caller := apiCaller(c, func(_ string, _, result interface{}) error {
+		resultPtr, ok := result.(*params.StringsWatchResult)
+		c.Assert(ok, jc.IsTrue)
+		*resultPtr = expectResult
+		return nil
+	})
+	expectWatcher := &stubWatcher{}
+	newWatcher := func(gotCaller base.APICaller, gotResult params.StringsWatchResult) watcher.StringsWatcher {
+		c.Check(gotCaller, gc.NotNil) // uncomparable
+		c.Check(gotResult, jc.DeepEquals, expectResult)
+		return expectWatcher
+	}
+	api := servicescaler.NewAPI(caller, newWatcher)
+
+	watcher, err := api.Watch()
+	c.Check(watcher, gc.Equals, expectWatcher)
+	c.Check(err, jc.ErrorIsNil)
+}
+
+func apiCaller(c *gc.C, check func(request string, arg, result interface{}) error) base.APICaller {
+	return apitesting.APICallerFunc(func(facade string, version int, id, request string, arg, result interface{}) error {
+		c.Check(facade, gc.Equals, "ServiceScaler")
+		c.Check(version, gc.Equals, 0)
+		c.Check(id, gc.Equals, "")
+		return check(request, arg, result)
+	})
+}
+
+type stubWatcher struct {
+	watcher.StringsWatcher
+}

--- a/api/servicescaler/package_test.go
+++ b/api/servicescaler/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package servicescaler_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -6,6 +6,9 @@ package apiserver
 // This file imports all of the facades so they get registered at runtime.
 // When adding a new facade implementation, import it here so that its init()
 // function will get called to register it.
+//
+// TODO(fwereade): this is silly. We should be declaring our full API in *one*
+// place, not scattering it across packages and depending on magic import lists.
 import (
 	_ "github.com/juju/juju/apiserver/action"
 	_ "github.com/juju/juju/apiserver/addresser"
@@ -42,6 +45,7 @@ import (
 	_ "github.com/juju/juju/apiserver/reboot"
 	_ "github.com/juju/juju/apiserver/resumer"
 	_ "github.com/juju/juju/apiserver/service"
+	_ "github.com/juju/juju/apiserver/servicescaler"
 	_ "github.com/juju/juju/apiserver/spaces"
 	_ "github.com/juju/juju/apiserver/statushistory"
 	_ "github.com/juju/juju/apiserver/storage"

--- a/apiserver/servicescaler/facade.go
+++ b/apiserver/servicescaler/facade.go
@@ -1,0 +1,83 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package servicescaler
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/state/watcher"
+	"github.com/juju/names"
+)
+
+// Backend exposes functionality required by Facade.
+type Backend interface {
+
+	// WatchScaledServices returns a watcher that sends service ids
+	// that might not have enough units.
+	WatchScaledServices() state.StringsWatcher
+
+	// RescaleService ensures that the named service has at least its
+	// configured minimum unit count.
+	RescaleService(name string) error
+}
+
+// Facade allows model-manager clients to watch and rescale services.
+type Facade struct {
+	backend   Backend
+	resources *common.Resources
+}
+
+// NewFacade creates a new authorized Facade.
+func NewFacade(backend Backend, res *common.Resources, auth common.Authorizer) (*Facade, error) {
+	if !auth.AuthModelManager() {
+		return nil, common.ErrPerm
+	}
+	return &Facade{
+		backend:   backend,
+		resources: res,
+	}, nil
+}
+
+// Watch returns a watcher that sends the names of services whose
+// unit count may be below their configured minimum.
+func (facade *Facade) Watch() (params.StringsWatchResult, error) {
+	watch := facade.backend.WatchScaledServices()
+	if changes, ok := <-watch.Changes(); ok {
+		id := facade.resources.Register(watch)
+		return params.StringsWatchResult{
+			StringsWatcherId: id,
+			Changes:          changes,
+		}, nil
+	}
+	return params.StringsWatchResult{}, watcher.EnsureErr(watch)
+}
+
+// Rescale causes any supplied services to be scaled up to their
+// minimum size.
+func (facade *Facade) Rescale(args params.Entities) params.ErrorResults {
+	result := params.ErrorResults{
+		Results: make([]params.ErrorResult, len(args.Entities)),
+	}
+	for i, entity := range args.Entities {
+		err := facade.rescaleOne(entity.Tag)
+		result.Results[i].Error = common.ServerError(err)
+	}
+	return result
+}
+
+// rescaleOne scales up the supplied service, if necessary; or returns a
+// suitable error.
+func (facade *Facade) rescaleOne(tagString string) error {
+	tag, err := names.ParseTag(tagString)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	serviceTag, ok := tag.(names.ServiceTag)
+	if !ok {
+		return common.ErrPerm
+	}
+	return facade.backend.RescaleService(serviceTag.Id())
+}

--- a/apiserver/servicescaler/facade_test.go
+++ b/apiserver/servicescaler/facade_test.go
@@ -1,0 +1,102 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package servicescaler_test
+
+import (
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/apiserver/servicescaler"
+)
+
+type FacadeSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&FacadeSuite{})
+
+func (s *FacadeSuite) TestModelManager(c *gc.C) {
+	facade, err := servicescaler.NewFacade(nil, nil, auth(true))
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(facade, gc.NotNil)
+}
+
+func (s *FacadeSuite) TestNotModelManager(c *gc.C) {
+	facade, err := servicescaler.NewFacade(nil, nil, auth(false))
+	c.Check(err, gc.Equals, common.ErrPerm)
+	c.Check(facade, gc.IsNil)
+}
+
+func (s *FacadeSuite) TestWatchError(c *gc.C) {
+	fix := newWatchFixture(c, false)
+	result, err := fix.Facade.Watch()
+	c.Check(err, gc.ErrorMatches, "blammo")
+	c.Check(result, gc.DeepEquals, params.StringsWatchResult{})
+	c.Check(fix.Resources.Count(), gc.Equals, 0)
+}
+
+func (s *FacadeSuite) TestWatchSuccess(c *gc.C) {
+	fix := newWatchFixture(c, true)
+	result, err := fix.Facade.Watch()
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(result.Changes, jc.DeepEquals, []string{"pow", "zap", "kerblooie"})
+	c.Check(fix.Resources.Count(), gc.Equals, 1)
+	resource := fix.Resources.Get(result.StringsWatcherId)
+	c.Check(resource, gc.NotNil)
+}
+
+func (s *FacadeSuite) TestRescaleNonsense(c *gc.C) {
+	fix := newRescaleFixture(c)
+	result := fix.Facade.Rescale(entities("burble plink"))
+	c.Assert(result.Results, gc.HasLen, 1)
+	err := result.Results[0].Error
+	c.Check(err, gc.ErrorMatches, `"burble plink" is not a valid tag`)
+}
+
+func (s *FacadeSuite) TestRescaleUnauthorized(c *gc.C) {
+	fix := newRescaleFixture(c)
+	result := fix.Facade.Rescale(entities("unit-foo-27"))
+	c.Assert(result.Results, gc.HasLen, 1)
+	err := result.Results[0].Error
+	c.Check(err, gc.ErrorMatches, "permission denied")
+	c.Check(err, jc.Satisfies, params.IsCodeUnauthorized)
+}
+
+func (s *FacadeSuite) TestRescaleNotFound(c *gc.C) {
+	fix := newRescaleFixture(c)
+	result := fix.Facade.Rescale(entities("service-missing"))
+	c.Assert(result.Results, gc.HasLen, 1)
+	err := result.Results[0].Error
+	c.Check(err, gc.ErrorMatches, "service not found")
+	c.Check(err, jc.Satisfies, params.IsCodeNotFound)
+}
+
+func (s *FacadeSuite) TestRescaleError(c *gc.C) {
+	fix := newRescaleFixture(c)
+	result := fix.Facade.Rescale(entities("service-error"))
+	c.Assert(result.Results, gc.HasLen, 1)
+	err := result.Results[0].Error
+	c.Check(err, gc.ErrorMatches, "blammo")
+}
+
+func (s *FacadeSuite) TestRescaleSuccess(c *gc.C) {
+	fix := newRescaleFixture(c)
+	result := fix.Facade.Rescale(entities("service-expected"))
+	c.Assert(result.Results, gc.HasLen, 1)
+	err := result.Results[0].Error
+	c.Check(err, gc.IsNil)
+}
+
+func (s *FacadeSuite) TestRescaleMultiple(c *gc.C) {
+	fix := newRescaleFixture(c)
+	result := fix.Facade.Rescale(entities("service-error", "service-expected"))
+	c.Assert(result.Results, gc.HasLen, 2)
+	err0 := result.Results[0].Error
+	c.Check(err0, gc.ErrorMatches, "blammo")
+	err1 := result.Results[1].Error
+	c.Check(err1, gc.IsNil)
+}

--- a/apiserver/servicescaler/package_test.go
+++ b/apiserver/servicescaler/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package servicescaler_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/apiserver/servicescaler/shim.go
+++ b/apiserver/servicescaler/shim.go
@@ -1,0 +1,50 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package servicescaler
+
+import (
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/state"
+)
+
+// This file contains untested shims to let us wrap state in a sensible
+// interface and avoid writing tests that depend on mongodb. If you were
+// to change any part of it so that it were no longer *obviously* and
+// *trivially* correct, you would be Doing It Wrong.
+
+func init() {
+	common.RegisterStandardFacade("ServiceScaler", 1, newFacade)
+}
+
+// newFacade wraps the supplied *state.State for the use of the Facade.
+func newFacade(st *state.State, res *common.Resources, auth common.Authorizer) (*Facade, error) {
+	return NewFacade(backendShim{st}, res, auth)
+}
+
+// backendShim wraps a *State to implement Backend without pulling in direct
+// mongodb dependencies. It would be awesome if we were to put this in state
+// and test it properly there, where we have no choice but to test against
+// mongodb anyway, but that's relatively low priority...
+//
+// ...so long as it stays simple, and the full functionality remains tested
+// elsewhere.
+type backendShim struct {
+	st *state.State
+}
+
+// WatchScaledServices is part of the Backend interface.
+func (shim backendShim) WatchScaledServices() state.StringsWatcher {
+	return shim.st.WatchMinUnits()
+}
+
+// RescaleService is part of the Backend interface.
+func (shim backendShim) RescaleService(name string) error {
+	service, err := shim.st.Service(name)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return service.EnsureMinUnits()
+}

--- a/apiserver/servicescaler/util_test.go
+++ b/apiserver/servicescaler/util_test.go
@@ -1,0 +1,112 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package servicescaler_test
+
+import (
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/apiserver/servicescaler"
+	"github.com/juju/juju/state"
+)
+
+// mockAuth implements common.Authorizer for the tests' convenience.
+type mockAuth struct {
+	common.Authorizer
+	modelManager bool
+}
+
+func (mock mockAuth) AuthModelManager() bool {
+	return mock.modelManager
+}
+
+// auth is a convenience constructor for a mockAuth.
+func auth(modelManager bool) common.Authorizer {
+	return mockAuth{modelManager: modelManager}
+}
+
+// mockWatcher implements state.StringsWatcher for the tests' convenience.
+type mockWatcher struct {
+	state.StringsWatcher
+	working bool
+}
+
+func (mock *mockWatcher) Changes() <-chan []string {
+	ch := make(chan []string, 1)
+	if mock.working {
+		ch <- []string{"pow", "zap", "kerblooie"}
+	} else {
+		close(ch)
+	}
+	return ch
+}
+
+func (mock *mockWatcher) Err() error {
+	return errors.New("blammo")
+}
+
+// watchBackend implements servicescaler.Backend for the convenience of
+// the tests for the Watch method.
+type watchBackend struct {
+	servicescaler.Backend
+	working bool
+}
+
+func (backend *watchBackend) WatchScaledServices() state.StringsWatcher {
+	return &mockWatcher{working: backend.working}
+}
+
+// watchFixture collects components needed to test the Watch method.
+type watchFixture struct {
+	Facade    *servicescaler.Facade
+	Resources *common.Resources
+}
+
+func newWatchFixture(c *gc.C, working bool) *watchFixture {
+	backend := &watchBackend{working: working}
+	resources := common.NewResources()
+	facade, err := servicescaler.NewFacade(backend, resources, auth(true))
+	c.Assert(err, jc.ErrorIsNil)
+	return &watchFixture{facade, resources}
+}
+
+// rescaleBackend implements servicescaler.Backend for the convenience of
+// the tests for the Rescale method.
+type rescaleBackend struct {
+	servicescaler.Backend
+}
+
+func (rescaleBackend) RescaleService(name string) error {
+	switch name {
+	case "expected":
+		return nil
+	case "missing":
+		return errors.NotFoundf("service")
+	default:
+		return errors.New("blammo")
+	}
+}
+
+// rescaleFixture collects components needed to test the Rescale method.
+type rescaleFixture struct {
+	Facade *servicescaler.Facade
+}
+
+func newRescaleFixture(c *gc.C) *rescaleFixture {
+	facade, err := servicescaler.NewFacade(rescaleBackend{}, nil, auth(true))
+	c.Assert(err, jc.ErrorIsNil)
+	return &rescaleFixture{facade}
+}
+
+// entities is a convenience constructor for params.Entities.
+func entities(tags ...string) params.Entities {
+	entities := params.Entities{Entities: make([]params.Entity, len(tags))}
+	for i, tag := range tags {
+		entities.Entities[i].Tag = tag
+	}
+	return entities
+}

--- a/worker/servicescaler/fixture_test.go
+++ b/worker/servicescaler/fixture_test.go
@@ -1,0 +1,106 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package servicescaler_test
+
+import (
+	"time"
+
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/watcher"
+	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/servicescaler"
+	"github.com/juju/juju/worker/workertest"
+)
+
+// fixture is used to test the operation of a servicescaler worker.
+type fixture struct {
+	testing.Stub
+}
+
+func newFixture(c *gc.C, callErrors ...error) *fixture {
+	fix := &fixture{}
+	fix.SetErrors(callErrors...)
+	return fix
+}
+
+// Run will create a servicescaler worker; start recording the calls
+// it makes; and pass it to the supplied test func, which will be invoked
+// on a new goroutine. If Run returns, it is safe to inspect the recorded
+// calls via the embedded testing.Stub.
+func (fix *fixture) Run(c *gc.C, test func(worker.Worker)) {
+	stubFacade := newFacade(&fix.Stub)
+	scaler, err := servicescaler.New(servicescaler.Config{
+		Facade: stubFacade,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		defer worker.Stop(scaler)
+		test(scaler)
+	}()
+	select {
+	case <-done:
+	case <-time.After(coretesting.LongWait):
+		c.Fatalf("test func timed out")
+	}
+}
+
+// stubFacade implements servicescaler.Facade and records calls to its
+// interface methods.
+type stubFacade struct {
+	stub    *testing.Stub
+	watcher *stubWatcher
+}
+
+func newFacade(stub *testing.Stub) *stubFacade {
+	return &stubFacade{
+		stub:    stub,
+		watcher: newStubWatcher(),
+	}
+}
+
+// Watch is part of the servicescaler.Facade interface.
+func (facade *stubFacade) Watch() (watcher.StringsWatcher, error) {
+	facade.stub.AddCall("Watch")
+	err := facade.stub.NextErr()
+	if err != nil {
+		return nil, err
+	}
+	return facade.watcher, nil
+}
+
+// Rescale is part of the servicescaler.Facade interface.
+func (facade *stubFacade) Rescale(serviceNames []string) error {
+	facade.stub.AddCall("Rescale", serviceNames)
+	return facade.stub.NextErr()
+}
+
+// stubWatcher implements watcher.StringsWatcher and supplied canned
+// data over the Changes() channel.
+type stubWatcher struct {
+	worker.Worker
+	changes chan []string
+}
+
+func newStubWatcher() *stubWatcher {
+	changes := make(chan []string, 3)
+	changes <- []string{"expected", "first"}
+	changes <- []string{"expected", "second"}
+	changes <- []string{"unexpected?"}
+	return &stubWatcher{
+		Worker:  workertest.NewErrorWorker(nil),
+		changes: changes,
+	}
+}
+
+// Changes is part of the watcher.StringsWatcher interface.
+func (stubWatcher *stubWatcher) Changes() watcher.StringsChannel {
+	return stubWatcher.changes
+}

--- a/worker/servicescaler/manifold.go
+++ b/worker/servicescaler/manifold.go
@@ -1,0 +1,40 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package servicescaler
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/dependency"
+	"github.com/juju/juju/worker/util"
+)
+
+// ManifoldConfig holds dependencies and configuration for a
+// servicescaler worker.
+type ManifoldConfig struct {
+	APICallerName string
+	NewFacade     func(base.APICaller) (Facade, error)
+	NewWorker     func(Config) (worker.Worker, error)
+}
+
+// start is a method on ManifoldConfig because that feels a bit cleaner
+// than closing over config in Manifold.
+func (config ManifoldConfig) start(apiCaller base.APICaller) (worker.Worker, error) {
+	facade, err := config.NewFacade(apiCaller)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return config.NewWorker(Config{
+		Facade: facade,
+	})
+}
+
+// Manifold returns a dependency.Manifold that runs a servicescaler worker.
+func Manifold(config ManifoldConfig) dependency.Manifold {
+	return util.ApiManifold(
+		util.ApiManifoldConfig{config.APICallerName},
+		config.start,
+	)
+}

--- a/worker/servicescaler/manifold_test.go
+++ b/worker/servicescaler/manifold_test.go
@@ -1,0 +1,120 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package servicescaler_test
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/dependency"
+	dt "github.com/juju/juju/worker/dependency/testing"
+	"github.com/juju/juju/worker/servicescaler"
+)
+
+type ManifoldSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&ManifoldSuite{})
+
+func (s *ManifoldSuite) TestInputs(c *gc.C) {
+	manifold := servicescaler.Manifold(servicescaler.ManifoldConfig{
+		APICallerName: "washington the terrible",
+	})
+	c.Check(manifold.Inputs, jc.DeepEquals, []string{"washington the terrible"})
+}
+
+func (s *ManifoldSuite) TestOutput(c *gc.C) {
+	manifold := servicescaler.Manifold(servicescaler.ManifoldConfig{})
+	c.Check(manifold.Output, gc.IsNil)
+}
+
+func (s *ManifoldSuite) TestStartMissingAPICaller(c *gc.C) {
+	manifold := servicescaler.Manifold(servicescaler.ManifoldConfig{
+		APICallerName: "api-caller",
+	})
+	getResource := dt.StubGetResource(dt.StubResources{
+		"api-caller": dt.StubResource{Error: dependency.ErrMissing},
+	})
+
+	worker, err := manifold.Start(getResource)
+	c.Check(errors.Cause(err), gc.Equals, dependency.ErrMissing)
+	c.Check(worker, gc.IsNil)
+}
+
+func (s *ManifoldSuite) TestStartFacadeError(c *gc.C) {
+	expectCaller := &fakeCaller{}
+	manifold := servicescaler.Manifold(servicescaler.ManifoldConfig{
+		APICallerName: "api-caller",
+		NewFacade: func(apiCaller base.APICaller) (servicescaler.Facade, error) {
+			c.Check(apiCaller, gc.Equals, expectCaller)
+			return nil, errors.New("blort")
+		},
+	})
+	getResource := dt.StubGetResource(dt.StubResources{
+		"api-caller": dt.StubResource{Output: expectCaller},
+	})
+
+	worker, err := manifold.Start(getResource)
+	c.Check(err, gc.ErrorMatches, "blort")
+	c.Check(worker, gc.IsNil)
+}
+
+func (s *ManifoldSuite) TestStartWorkerError(c *gc.C) {
+	expectFacade := &fakeFacade{}
+	manifold := servicescaler.Manifold(servicescaler.ManifoldConfig{
+		APICallerName: "api-caller",
+		NewFacade: func(_ base.APICaller) (servicescaler.Facade, error) {
+			return expectFacade, nil
+		},
+		NewWorker: func(config servicescaler.Config) (worker.Worker, error) {
+			c.Check(config.Validate(), jc.ErrorIsNil)
+			c.Check(config.Facade, gc.Equals, expectFacade)
+			return nil, errors.New("splot")
+		},
+	})
+	getResource := dt.StubGetResource(dt.StubResources{
+		"api-caller": dt.StubResource{Output: &fakeCaller{}},
+	})
+
+	worker, err := manifold.Start(getResource)
+	c.Check(err, gc.ErrorMatches, "splot")
+	c.Check(worker, gc.IsNil)
+}
+
+func (s *ManifoldSuite) TestSuccess(c *gc.C) {
+	expectWorker := &fakeWorker{}
+	manifold := servicescaler.Manifold(servicescaler.ManifoldConfig{
+		APICallerName: "api-caller",
+		NewFacade: func(_ base.APICaller) (servicescaler.Facade, error) {
+			return &fakeFacade{}, nil
+		},
+		NewWorker: func(_ servicescaler.Config) (worker.Worker, error) {
+			return expectWorker, nil
+		},
+	})
+	getResource := dt.StubGetResource(dt.StubResources{
+		"api-caller": dt.StubResource{Output: &fakeCaller{}},
+	})
+
+	worker, err := manifold.Start(getResource)
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(worker, gc.Equals, expectWorker)
+}
+
+type fakeCaller struct {
+	base.APICaller
+}
+
+type fakeFacade struct {
+	servicescaler.Facade
+}
+
+type fakeWorker struct {
+	worker.Worker
+}

--- a/worker/servicescaler/package_test.go
+++ b/worker/servicescaler/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package servicescaler_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/worker/servicescaler/shim.go
+++ b/worker/servicescaler/shim.go
@@ -1,0 +1,19 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package servicescaler
+
+import (
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/api/servicescaler"
+	"github.com/juju/juju/api/watcher"
+)
+
+// NewFacade creates a Facade from a base.APICaller.
+// It's a sensible value for ManifoldConfig.NewFacade.
+func NewFacade(apiCaller base.APICaller) (Facade, error) {
+	return servicescaler.NewAPI(
+		apiCaller,
+		watcher.NewStringsWatcher,
+	), nil
+}

--- a/worker/servicescaler/worker.go
+++ b/worker/servicescaler/worker.go
@@ -1,0 +1,70 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package servicescaler
+
+import (
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/watcher"
+	"github.com/juju/juju/worker"
+)
+
+// Facade defines the capabilities required by the worker.
+type Facade interface {
+
+	// Watch returns a StringsWatcher reporting names of
+	// services which may have insufficient units.
+	Watch() (watcher.StringsWatcher, error)
+
+	// Rescale scales up any named service observed to be
+	// running too few units.
+	Rescale(services []string) error
+}
+
+// Config defines a worker's dependencies.
+type Config struct {
+	Facade Facade
+}
+
+// Validate returns an error if the config can't be expected
+// to run a functional worker.
+func (config Config) Validate() error {
+	if config.Facade == nil {
+		return errors.NotValidf("nil Facade")
+	}
+	return nil
+}
+
+// New returns a worker that will attempt to rescale any
+// services that might be undersized.
+func New(config Config) (worker.Worker, error) {
+	if err := config.Validate(); err != nil {
+		return nil, errors.Trace(err)
+	}
+	swConfig := watcher.StringsConfig{
+		Handler: &handler{config},
+	}
+	return watcher.NewStringsWorker(swConfig)
+}
+
+// handler implements watcher.StringsHandler, backed by the
+// configured facade.
+type handler struct {
+	config Config
+}
+
+// SetUp is part of the watcher.StringsHandler interface.
+func (handler *handler) SetUp() (watcher.StringsWatcher, error) {
+	return handler.config.Facade.Watch()
+}
+
+// Handle is part of the watcher.StringsHandler interface.
+func (handler *handler) Handle(_ <-chan struct{}, services []string) error {
+	return handler.config.Facade.Rescale(services)
+}
+
+// TearDown is part of the watcher.StringsHandler interface.
+func (handler *handler) TearDown() error {
+	return nil
+}

--- a/worker/servicescaler/worker_test.go
+++ b/worker/servicescaler/worker_test.go
@@ -1,0 +1,61 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package servicescaler_test
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/servicescaler"
+)
+
+type WorkerSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&WorkerSuite{})
+
+func (s *WorkerSuite) TestValidate(c *gc.C) {
+	config := servicescaler.Config{}
+	check := func(err error) {
+		c.Check(err, gc.ErrorMatches, "nil Facade not valid")
+		c.Check(err, jc.Satisfies, errors.IsNotValid)
+	}
+
+	err := config.Validate()
+	check(err)
+
+	worker, err := servicescaler.New(config)
+	check(err)
+	c.Check(worker, gc.IsNil)
+}
+
+func (s *WorkerSuite) TestWatchError(c *gc.C) {
+	fix := newFixture(c, errors.New("zap ouch"))
+	fix.Run(c, func(worker worker.Worker) {
+		err := worker.Wait()
+		c.Check(err, gc.ErrorMatches, "zap ouch")
+	})
+	fix.CheckCallNames(c, "Watch")
+}
+
+func (s *WorkerSuite) TestRescaleThenError(c *gc.C) {
+	fix := newFixture(c, nil, nil, errors.New("pew squish"))
+	fix.Run(c, func(worker worker.Worker) {
+		err := worker.Wait()
+		c.Check(err, gc.ErrorMatches, "pew squish")
+	})
+	fix.CheckCalls(c, []testing.StubCall{{
+		FuncName: "Watch",
+	}, {
+		FuncName: "Rescale",
+		Args:     []interface{}{[]string{"expected", "first"}},
+	}, {
+		FuncName: "Rescale",
+		Args:     []interface{}{[]string{"expected", "second"}},
+	}})
+}


### PR DESCRIPTION
Add pieces necessary to maintain minimum service unit count via the API, rather than directly via state.

As reviewed in RB3743, RB3792.