### PR TITLE
lp1543216 - Use consistent addr for replicaset.

### DIFF
--- a/cmd/jujud/bootstrap.go
+++ b/cmd/jujud/bootstrap.go
@@ -140,6 +140,13 @@ func (c *BootstrapCommand) Run(_ *cmd.Context) error {
 		return err
 	}
 
+	// When machine addresses are reported from state, they have
+	// duplicates removed.  We should do the same here so that
+	// there is not unnecessary churn in the mongo replicaset.
+	// TODO (cherylj) Add explicit unit tests for this - tracked
+	// by bug #1544158.
+	addrs = network.MergedAddresses([]network.Address{}, addrs)
+
 	// Generate a private SSH key for the state servers, and add
 	// the public key to the environment config. We'll add the
 	// private key to StateServingInfo below.

--- a/network/address.go
+++ b/network/address.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 
 	"github.com/juju/errors"
+	"github.com/juju/utils/set"
 )
 
 // Private network ranges for IPv4 and IPv6.
@@ -507,4 +508,26 @@ func ResolvableHostnames(addrs []Address) []Address {
 		resolveableAddrs = append(resolveableAddrs, addr)
 	}
 	return resolveableAddrs
+}
+
+// MergedAddresses provides a single list of addresses without duplicates
+// suitable for returning as an address list for a machine.
+// TODO (cherylj) Add explicit unit tests - tracked with bug #1544158
+func MergedAddresses(machineAddresses, providerAddresses []Address) []Address {
+	merged := make([]Address, 0, len(providerAddresses)+len(machineAddresses))
+	providerValues := set.NewStrings()
+	for _, address := range providerAddresses {
+		// Older versions of Juju may have stored an empty address so ignore it here.
+		if address.Value == "" || providerValues.Contains(address.Value) {
+			continue
+		}
+		providerValues.Add(address.Value)
+		merged = append(merged, address)
+	}
+	for _, address := range machineAddresses {
+		if !providerValues.Contains(address.Value) {
+			merged = append(merged, address)
+		}
+	}
+	return merged
 }

--- a/state/allwatcher.go
+++ b/state/allwatcher.go
@@ -139,7 +139,7 @@ func (m *backingMachine) updated(st *State, store *multiwatcherStore, id string)
 		Life:                     multiwatcher.Life(m.Life.String()),
 		Series:                   m.Series,
 		Jobs:                     paramsJobsFromJobs(m.Jobs),
-		Addresses:                mergedAddresses(m.MachineAddresses, m.Addresses),
+		Addresses:                network.MergedAddresses(networkAddresses(m.MachineAddresses), networkAddresses(m.Addresses)),
 		SupportedContainers:      m.SupportedContainers,
 		SupportedContainersKnown: m.SupportedContainersKnown,
 		HasVote:                  m.HasVote,

--- a/state/machine.go
+++ b/state/machine.go
@@ -1136,25 +1136,6 @@ func (m *Machine) SetInstanceInfo(
 	return m.SetProvisioned(id, nonce, characteristics)
 }
 
-func mergedAddresses(machineAddresses, providerAddresses []address) []network.Address {
-	merged := make([]network.Address, 0, len(providerAddresses)+len(machineAddresses))
-	providerValues := set.NewStrings()
-	for _, address := range providerAddresses {
-		// Older versions of Juju may have stored an empty address so ignore it here.
-		if address.Value == "" || providerValues.Contains(address.Value) {
-			continue
-		}
-		providerValues.Add(address.Value)
-		merged = append(merged, address.networkAddress())
-	}
-	for _, address := range machineAddresses {
-		if !providerValues.Contains(address.Value) {
-			merged = append(merged, address.networkAddress())
-		}
-	}
-	return merged
-}
-
 // Addresses returns any hostnames and ips associated with a machine,
 // determined both by the machine itself, and by asking the provider.
 //
@@ -1163,7 +1144,7 @@ func mergedAddresses(machineAddresses, providerAddresses []address) []network.Ad
 // Provider-reported addresses always come before machine-reported
 // addresses. Duplicates are removed.
 func (m *Machine) Addresses() (addresses []network.Address) {
-	return mergedAddresses(m.doc.MachineAddresses, m.doc.Addresses)
+	return network.MergedAddresses(networkAddresses(m.doc.MachineAddresses), networkAddresses(m.doc.Addresses))
 }
 
 func containsAddress(addresses []address, address address) bool {


### PR DESCRIPTION
The same logic should be used to select an address
for the mongo server during bootstrap and after
the system comes up.

After bootstrap, addresses for a machine are run
though MergedAddresses, which de-duplicates
provider addresses.  We should do the same during
bootstrap to avoid churning mongo by changing the
address after bootstrap completes.

Cherry-pick of https://github.com/juju/juju/pull/4373

(Review request: http://reviews.vapour.ws/r/3934/)