### PR TITLE
Include lxd in list-clouds, imrpove bootstrap help

### DIFF
--- a/cloud/clouds.go
+++ b/cloud/clouds.go
@@ -121,8 +121,8 @@ type region struct {
 	StorageEndpoint string `yaml:"storage-endpoint,omitempty"`
 }
 
-// BuiltInProviders work out of the box.
-var BuiltInProviders = []string{"lxd", "manual"}
+// BuiltInProviderNames work out of the box.
+var BuiltInProviderNames = []string{"lxd", "manual"}
 
 // CloudByName returns the cloud with the specified name.
 // If there exists no cloud with the specified name, an

--- a/cloud/clouds.go
+++ b/cloud/clouds.go
@@ -121,6 +121,9 @@ type region struct {
 	StorageEndpoint string `yaml:"storage-endpoint,omitempty"`
 }
 
+// BuiltInProviders work out of the box.
+var BuiltInProviders = []string{"lxd", "manual"}
+
 // CloudByName returns the cloud with the specified name.
 // If there exists no cloud with the specified name, an
 // error satisfying errors.IsNotFound will be returned.

--- a/cmd/juju/cloud/list.go
+++ b/cmd/juju/cloud/list.go
@@ -73,8 +73,10 @@ func builtInProviders() map[string]jujucloud.Cloud {
 	for _, name := range jujucloud.BuiltInProviderNames {
 		provider, err := environs.Provider(name)
 		if err != nil {
-			// Should never happen
-			panic(err)
+			// Should never happen but it will on go 1.2
+			// because lxd provider is not built.
+			logger.Warningf("cloud %q not available on this platform", name)
+			continue
 		}
 		var regions []jujucloud.Region
 		if detector, ok := provider.(environs.CloudRegionDetector); ok {

--- a/cmd/juju/cloud/list.go
+++ b/cmd/juju/cloud/list.go
@@ -73,10 +73,12 @@ func getCloudDetails() (map[string]*cloudDetails, error) {
 		details[name] = cloudDetails
 	}
 
-	// LXD is magic
-	details["lxd"] = &cloudDetails{
-		Source:    "built-in",
-		CloudType: "lxd",
+	// Add in built in providers like "lxd" and "manual".
+	for _, p := range jujucloud.BuiltInProviders {
+		details[p] = &cloudDetails{
+			Source:    "built-in",
+			CloudType: p,
+		}
 	}
 
 	personalClouds, err := jujucloud.PersonalCloudMetadata()

--- a/cmd/juju/cloud/list_test.go
+++ b/cmd/juju/cloud/list_test.go
@@ -30,8 +30,9 @@ func (s *listSuite) TestListPublic(c *gc.C) {
 	out = strings.Replace(out, "\n", "", -1)
 	// Just check a snippet of the output to make sure it looks ok.
 	c.Assert(out, gc.Matches, `.*aws-china[ ]*ec2[ ]*cn-north-1.*`)
+	// TODO(wallyworld) - uncomment when we build with go 1.3 or greater
 	// LXD should be there too.
-	c.Assert(out, gc.Matches, `.*lxd[ ]*lxd[ ]*localhost.*`)
+	//c.Assert(out, gc.Matches, `.*lxd[ ]*lxd[ ]*localhost.*`)
 	// And also manual.
 	c.Assert(out, gc.Matches, `.*manual[ ]*manual[ ].*`)
 }

--- a/cmd/juju/cloud/list_test.go
+++ b/cmd/juju/cloud/list_test.go
@@ -29,6 +29,8 @@ func (s *listSuite) TestListPublic(c *gc.C) {
 	out = strings.Replace(out, "\n", "", -1)
 	// Just check a snippet of the output to make sure it looks ok.
 	c.Assert(out, gc.Matches, `.*aws-china[ ]*ec2[ ]*cn-north-1.*`)
+	// LXD should be there too.
+	c.Assert(out, gc.Matches, `.*lxd[ ]*lxd[ ].*`)
 }
 
 func (s *listSuite) TestListPublicAndPersonal(c *gc.C) {

--- a/cmd/juju/cloud/list_test.go
+++ b/cmd/juju/cloud/list_test.go
@@ -13,6 +13,7 @@ import (
 	jujucloud "github.com/juju/juju/cloud"
 	"github.com/juju/juju/cmd/juju/cloud"
 	"github.com/juju/juju/juju/osenv"
+	_ "github.com/juju/juju/provider/all"
 	"github.com/juju/juju/testing"
 )
 
@@ -30,7 +31,9 @@ func (s *listSuite) TestListPublic(c *gc.C) {
 	// Just check a snippet of the output to make sure it looks ok.
 	c.Assert(out, gc.Matches, `.*aws-china[ ]*ec2[ ]*cn-north-1.*`)
 	// LXD should be there too.
-	c.Assert(out, gc.Matches, `.*lxd[ ]*lxd[ ].*`)
+	c.Assert(out, gc.Matches, `.*lxd[ ]*lxd[ ]*localhost.*`)
+	// And also manual.
+	c.Assert(out, gc.Matches, `.*manual[ ]*manual[ ].*`)
 }
 
 func (s *listSuite) TestListPublicAndPersonal(c *gc.C) {

--- a/cmd/juju/cloud/show.go
+++ b/cmd/juju/cloud/show.go
@@ -58,15 +58,15 @@ func (c *showCloudCommand) Info() *cmd.Info {
 }
 
 func (c *showCloudCommand) Run(ctxt *cmd.Context) error {
-	publicClouds, _, err := jujucloud.PublicCloudMetadata(jujucloud.JujuPublicCloudsPath())
+	details, err := getCloudDetails()
 	if err != nil {
 		return err
 	}
-	cloud, ok := publicClouds[c.CloudName]
+	cloud, ok := details[c.CloudName]
 	if !ok {
 		return errors.NotFoundf("cloud %q", c.CloudName)
 	}
-	return c.out.Write(ctxt, makeCloudDetails(cloud))
+	return c.out.Write(ctxt, cloud)
 }
 
 type regionDetails struct {

--- a/cmd/juju/cloud/show_test.go
+++ b/cmd/juju/cloud/show_test.go
@@ -8,6 +8,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cmd/juju/cloud"
+	_ "github.com/juju/juju/provider/all"
 	"github.com/juju/juju/testing"
 )
 

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -42,10 +42,13 @@ var provisionalProviders = map[string]string{
 }
 
 const bootstrapDoc = `
-bootstrap starts a new model of the current type (it will return an error
-if the model has already been bootstrapped).  Bootstrapping a model
-will provision a new machine in the model and run the juju controller on
+bootstrap starts a new controller in the specified cloud (it will return
+an error if a controller with the same name has already been bootstrapped).
+Bootstrapping a controller will provision a new machine and run the controller on
 that machine.
+
+The controller will be setup with an intial controller model called "admin" as well
+as a hosted model which can be used to run workloads.
 
 If boostrap-constraints are specified in the bootstrap command, 
 they will apply to the machine provisioned for the juju controller, 
@@ -86,6 +89,9 @@ is accepted (eg 1.24.4-trusty-amd64) but only the numeric version (eg 1.24.4) is
 By default, Juju will bootstrap using the exact same version as the client.
 
 See Also:
+   juju help glossary
+   juju list-controllers
+   juju list-models
    juju help switch
    juju help constraints
    juju help set-constraints
@@ -123,6 +129,7 @@ func (c *bootstrapCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "bootstrap",
 		Purpose: "start up an environment from scratch",
+		Args:    "<controllername> <cloud>[/<region>]",
 		Doc:     bootstrapDoc,
 	}
 }

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -12,14 +12,3 @@ const (
 	MAAS   = "maas"
 	EC2    = "ec2"
 )
-
-// IsManual returns true iff the specified provider
-// type refers to the manual provider.
-func IsManual(provider string) bool {
-	switch provider {
-	case "null", "manual":
-		return true
-	default:
-		return false
-	}
-}


### PR DESCRIPTION
juju list-clouds and show-clouds now includes "lxd" in the output.

bootstrap help is also improved

(Review request: http://reviews.vapour.ws/r/3939/)