### PR TITLE
lp1515289 - Use proxy when downloading tools

### DIFF
--- a/apiserver/metricsender/sender.go
+++ b/apiserver/metricsender/sender.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 
 	"github.com/juju/errors"
+	"github.com/juju/utils"
 
 	"github.com/juju/juju/apiserver/metricsender/wireformat"
 )
@@ -32,7 +33,7 @@ func (s *HttpSender) Send(metrics []*wireformat.MetricBatch) (*wireformat.Respon
 		return nil, errors.Trace(err)
 	}
 	r := bytes.NewBuffer(b)
-	t := &http.Transport{TLSClientConfig: &tls.Config{RootCAs: metricsCertsPool}}
+	t := utils.NewHttpTLSTransport(&tls.Config{RootCAs: metricsCertsPool})
 	client := &http.Client{Transport: t}
 	resp, err := client.Post(metricsHost, "application/json", r)
 	if err != nil {

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -28,7 +28,7 @@ github.com/juju/schema	git	afe1151cb49d1d7ed3c75592dfc6f38703f2e988	2015-08-07T0
 github.com/juju/syslog	git	6be94e8b718766e9ff7a37342157fe4795da7cfa	2015-02-05T15:59:36Z
 github.com/juju/testing	git	f521911d9a79aeb62c051fe18e689796369c5564	2015-05-29T04:40:43Z
 github.com/juju/txn	git	99ec629d0066a4d73c54d8e021a7fc1dc07df614	2015-06-09T16:58:27Z
-github.com/juju/utils	git	a8a6b302e967fa0ab41dd762256cab18bf20f90a	2015-09-22T08:36:00Z
+github.com/juju/utils	git	d300cfbfa10388047c779b60e50e7be533cc781d	2016-02-23T05:10:16Z
 github.com/juju/xml	git	eb759a627588d35166bc505fceb51b88500e291e	2015-04-13T13:11:21Z
 golang.org/x/crypto	git	c57d4a71915a248dbad846d60825145062b4c18e	2015-03-27T05:11:19Z
 golang.org/x/net	git	bb64f4dc73d4ab97978d5e1cb34515dcc570361b	2015-05-18T01:39:50Z


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/juju-core/+bug/1515289

use the new utils that has the tls proxy fix for downloading tools, and
make sure the metricsender uses the same transport, to avoid the same
bug of not using the proxy.

2.0 PR:  https://github.com/juju/juju/pull/4108