### PR TITLE
return unitresources for all units

### DIFF
--- a/apiserver/resource.go
+++ b/apiserver/resource.go
@@ -55,7 +55,11 @@ func newResourceHandler(httpCtxt httpContext) http.Handler {
 			if err != nil {
 				return nil, nil, errors.Trace(err)
 			}
-			return resources, entity.Tag(), nil
+			ds := resourceadapters.DataStore{
+				Resources: resources,
+				State:     st,
+			}
+			return ds, entity.Tag(), nil
 		},
 	)
 }

--- a/component/all/resource.go
+++ b/component/all/resource.go
@@ -71,27 +71,6 @@ func (r resources) registerPublicFacade() {
 	api.RegisterFacadeVersion(resource.ComponentName, server.Version)
 }
 
-type dataStore struct {
-	corestate.Resources
-	st *corestate.State
-}
-
-// Units returns the unitIDs for all units in the service
-func (d dataStore) Units(serviceID string) (unitIDs []string, err error) {
-	svc, err := d.st.Service(serviceID)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	units, err := svc.AllUnits()
-	if err != nil {
-		return errors.Trace(err)
-	}
-	for _, u := range units {
-		unitIDs = append(unitIDs, u.Tag().Id())
-	}
-	return unitIDs
-}
-
 // newPublicFacade is passed into common.RegisterStandardFacade
 // in registerPublicFacade.
 func (resources) newPublicFacade(st *corestate.State, _ *common.Resources, authorizer common.Authorizer) (*server.Facade, error) {
@@ -104,9 +83,9 @@ func (resources) newPublicFacade(st *corestate.State, _ *common.Resources, autho
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	ds := dataStore{
+	ds := resourceadapters.DataStore{
 		Resources: rst,
-		st:        st,
+		State:     st,
 	}
 	return server.NewFacade(ds), nil
 }

--- a/resource/api/helpers.go
+++ b/resource/api/helpers.go
@@ -13,7 +13,6 @@ import (
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/resource"
-	"github.com/juju/juju/resource/api"
 )
 
 // Resource2API converts a resource.Resource into
@@ -77,30 +76,30 @@ func APIResult2ServiceResources(apiResult ResourcesResult) (resource.ServiceReso
 	return result, nil
 }
 
-func ServiceResources2APIResult(tag names.Tag, svcRes resource.ServiceResources, units []names.UnitTag) ResourcesResult {
-	var result api.ResourcesResult
+func ServiceResources2APIResult(svcRes resource.ServiceResources, units []names.UnitTag) ResourcesResult {
+	var result ResourcesResult
 	for _, res := range svcRes.Resources {
-		result.Resources = append(result.Resources, api.Resource2API(res))
+		result.Resources = append(result.Resources, Resource2API(res))
 	}
 	unitResources := make(map[names.UnitTag]resource.UnitResources, len(svcRes.UnitResources))
 	for _, unitRes := range svcRes.UnitResources {
 		unitResources[unitRes.Tag] = unitRes
 	}
 
-	result.UnitResources = make([]api.UnitResources, len(units))
+	result.UnitResources = make([]UnitResources, len(units))
 	for i, tag := range units {
-		apiRes := api.UnitResources{
+		apiRes := UnitResources{
 			Entity: params.Entity{Tag: tag.String()},
 		}
 		for _, res := range unitResources[tag].Resources {
-			apiRes.Resources = append(apiRes.Resources, api.Resource2API(res))
+			apiRes.Resources = append(apiRes.Resources, Resource2API(res))
 		}
 		result.UnitResources[i] = apiRes
 	}
 
-	result.CharmStoreResources = make([]api.CharmResource, len(svcRes.CharmStoreResources))
+	result.CharmStoreResources = make([]CharmResource, len(svcRes.CharmStoreResources))
 	for i, chRes := range svcRes.CharmStoreResources {
-		result.CharmStoreResources[i] = api.CharmResource2API(chRes)
+		result.CharmStoreResources[i] = CharmResource2API(chRes)
 	}
 	return result
 }

--- a/resource/api/helpers_test.go
+++ b/resource/api/helpers_test.go
@@ -27,13 +27,13 @@ func newFingerprint(c *gc.C, data string) charmresource.Fingerprint {
 	return fp
 }
 
-type helpersSuite struct {
+type HelpersSuite struct {
 	testing.IsolationSuite
 }
 
-var _ = gc.Suite(&helpersSuite{})
+var _ = gc.Suite(&HelpersSuite{})
 
-func (helpersSuite) TestResource2API(c *gc.C) {
+func (HelpersSuite) TestResource2API(c *gc.C) {
 	fp, err := charmresource.NewFingerprint([]byte(fingerprint))
 	c.Assert(err, jc.ErrorIsNil)
 	now := time.Now()
@@ -79,7 +79,7 @@ func (helpersSuite) TestResource2API(c *gc.C) {
 	})
 }
 
-func (helpersSuite) TestAPIResult2ServiceResourcesOkay(c *gc.C) {
+func (HelpersSuite) TestAPIResult2ServiceResourcesOkay(c *gc.C) {
 	fp, err := charmresource.NewFingerprint([]byte(fingerprint))
 	c.Assert(err, jc.ErrorIsNil)
 	now := time.Now()
@@ -230,7 +230,7 @@ func (helpersSuite) TestAPIResult2ServiceResourcesOkay(c *gc.C) {
 	c.Check(resources, jc.DeepEquals, serviceResource)
 }
 
-func (helpersSuite) TestAPIResult2ServiceResourcesBadUnitTag(c *gc.C) {
+func (HelpersSuite) TestAPIResult2ServiceResourcesBadUnitTag(c *gc.C) {
 	fp, err := charmresource.NewFingerprint([]byte(fingerprint))
 	c.Assert(err, jc.ErrorIsNil)
 	now := time.Now()
@@ -332,7 +332,7 @@ func (helpersSuite) TestAPIResult2ServiceResourcesBadUnitTag(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, ".*got bad data from server.*")
 }
 
-func (helpersSuite) TestAPIResult2ServiceResourcesFailure(c *gc.C) {
+func (HelpersSuite) TestAPIResult2ServiceResourcesFailure(c *gc.C) {
 	apiRes := api.Resource{
 		CharmResource: api.CharmResource{
 			Name:        "spam",
@@ -363,7 +363,7 @@ func (helpersSuite) TestAPIResult2ServiceResourcesFailure(c *gc.C) {
 	c.Check(errors.Cause(err), gc.Not(gc.Equals), failure)
 }
 
-func (helpersSuite) TestAPIResult2ServiceResourcesNotFound(c *gc.C) {
+func (HelpersSuite) TestAPIResult2ServiceResourcesNotFound(c *gc.C) {
 	apiRes := api.Resource{
 		CharmResource: api.CharmResource{
 			Name:        "spam",
@@ -393,7 +393,7 @@ func (helpersSuite) TestAPIResult2ServiceResourcesNotFound(c *gc.C) {
 	c.Check(err, jc.Satisfies, errors.IsNotFound)
 }
 
-func (helpersSuite) TestAPI2Resource(c *gc.C) {
+func (HelpersSuite) TestAPI2Resource(c *gc.C) {
 	now := time.Now()
 	res, err := api.API2Resource(api.Resource{
 		CharmResource: api.CharmResource{
@@ -441,7 +441,7 @@ func (helpersSuite) TestAPI2Resource(c *gc.C) {
 	c.Check(res, jc.DeepEquals, expected)
 }
 
-func (helpersSuite) TestCharmResource2API(c *gc.C) {
+func (HelpersSuite) TestCharmResource2API(c *gc.C) {
 	fp, err := charmresource.NewFingerprint([]byte(fingerprint))
 	c.Assert(err, jc.ErrorIsNil)
 	res := charmresource.Resource{
@@ -472,7 +472,7 @@ func (helpersSuite) TestCharmResource2API(c *gc.C) {
 	})
 }
 
-func (helpersSuite) TestAPI2CharmResource(c *gc.C) {
+func (HelpersSuite) TestAPI2CharmResource(c *gc.C) {
 	res, err := api.API2CharmResource(api.CharmResource{
 		Name:        "spam",
 		Type:        "file",

--- a/resource/api/server/base_test.go
+++ b/resource/api/server/base_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/juju/errors"
+	"github.com/juju/names"
 	"github.com/juju/testing"
 	gc "gopkg.in/check.v1"
 	charmresource "gopkg.in/juju/charm.v6-unstable/resource"
@@ -67,6 +68,7 @@ type stubDataStore struct {
 	ReturnGetPendingResource    resource.Resource
 	ReturnSetResource           resource.Resource
 	ReturnUpdatePendingResource resource.Resource
+	ReturnUnits                 []names.UnitTag
 }
 
 func (s *stubDataStore) ListResources(service string) (resource.ServiceResources, error) {
@@ -121,4 +123,13 @@ func (s *stubDataStore) UpdatePendingResource(serviceID, pendingID, userID strin
 	}
 
 	return s.ReturnUpdatePendingResource, nil
+}
+
+func (s *stubDataStore) Units(serviceID string) ([]names.UnitTag, error) {
+	s.stub.AddCall("Units", serviceID)
+	if err := s.stub.NextErr(); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	return s.ReturnUnits, nil
 }

--- a/resource/api/server/server.go
+++ b/resource/api/server/server.go
@@ -28,6 +28,7 @@ const (
 type DataStore interface {
 	resourceInfoStore
 	UploadDataStore
+	Units(serviceID string) (unitIDs []string, err error)
 }
 
 // Facade is the public API facade for resources.
@@ -72,6 +73,8 @@ func (f Facade) ListResources(args api.ListResourcesArgs) (api.ResourcesResults,
 			}
 			continue
 		}
+
+		units := f.store.Units(tag.Id())
 
 		svcRes, err := f.store.ListResources(tag.Id())
 		if err != nil {

--- a/resource/api/server/server.go
+++ b/resource/api/server/server.go
@@ -95,14 +95,15 @@ func (f Facade) ListResources(args api.ListResourcesArgs) (api.ResourcesResults,
 			unitResources[unitRes.Tag] = unitRes
 		}
 
-		for _, tag := range units {
+		result.UnitResources = make([]api.UnitResources, len(units))
+		for i, tag := range units {
 			apiRes := api.UnitResources{
 				Entity: params.Entity{Tag: tag.String()},
 			}
 			for _, res := range unitResources[tag].Resources {
 				apiRes.Resources = append(apiRes.Resources, api.Resource2API(res))
 			}
-			result.UnitResources = append(result.UnitResources, apiRes)
+			result.UnitResources[i] = apiRes
 		}
 
 		result.CharmStoreResources = make([]api.CharmResource, len(svcRes.CharmStoreResources))
@@ -111,6 +112,7 @@ func (f Facade) ListResources(args api.ListResourcesArgs) (api.ResourcesResults,
 		}
 
 		r.Results[i] = result
+
 	}
 	return r, nil
 }

--- a/resource/api/server/server.go
+++ b/resource/api/server/server.go
@@ -74,12 +74,6 @@ func (f Facade) ListResources(args api.ListResourcesArgs) (api.ResourcesResults,
 			continue
 		}
 
-		units, err := f.store.Units(tag.Id())
-		if err != nil {
-			r.Results[i] = errorResult(err)
-			continue
-		}
-
 		svcRes, err := f.store.ListResources(tag.Id())
 		if err != nil {
 			r.Results[i] = errorResult(err)
@@ -93,6 +87,12 @@ func (f Facade) ListResources(args api.ListResourcesArgs) (api.ResourcesResults,
 		unitResources := make(map[names.UnitTag]resource.UnitResources, len(svcRes.UnitResources))
 		for _, unitRes := range svcRes.UnitResources {
 			unitResources[unitRes.Tag] = unitRes
+		}
+
+		units, err := f.store.Units(tag.Id())
+		if err != nil {
+			r.Results[i] = errorResult(err)
+			continue
 		}
 
 		result.UnitResources = make([]api.UnitResources, len(units))

--- a/resource/api/server/server.go
+++ b/resource/api/server/server.go
@@ -88,7 +88,7 @@ func (f Facade) ListResources(args api.ListResourcesArgs) (api.ResourcesResults,
 			continue
 		}
 
-		r.Results[i] = ServiceResources2APIResult(tag, svcRes, units)
+		r.Results[i] = api.ServiceResources2APIResult(svcRes, units)
 	}
 	return r, nil
 }

--- a/resource/api/server/server_listresources_test.go
+++ b/resource/api/server/server_listresources_test.go
@@ -91,7 +91,7 @@ func (s *ListResourcesSuite) TestOkay(c *gc.C) {
 			},
 		}},
 	})
-	s.stub.CheckCallNames(c, "ListResources")
+	s.stub.CheckCallNames(c, "ListResources", "Units")
 	s.stub.CheckCall(c, 0, "ListResources", "a-service")
 }
 
@@ -108,7 +108,7 @@ func (s *ListResourcesSuite) TestEmpty(c *gc.C) {
 	c.Check(results, jc.DeepEquals, api.ResourcesResults{
 		Results: []api.ResourcesResult{{}},
 	})
-	s.stub.CheckCallNames(c, "ListResources")
+	s.stub.CheckCallNames(c, "ListResources", "Units")
 }
 
 func (s *ListResourcesSuite) TestError(c *gc.C) {

--- a/resource/api/server/server_listresources_test.go
+++ b/resource/api/server/server_listresources_test.go
@@ -27,6 +27,7 @@ func (s *ListResourcesSuite) TestOkay(c *gc.C) {
 	res2, apiRes2 := newResource(c, "eggs", "a-user", "...")
 
 	tag0 := names.NewUnitTag("a-service/0")
+	tag1 := names.NewUnitTag("a-service/1")
 
 	chres1 := res1.Resource
 	chres2 := res2.Resource
@@ -59,6 +60,11 @@ func (s *ListResourcesSuite) TestOkay(c *gc.C) {
 		},
 	}
 
+	s.data.ReturnUnits = []names.UnitTag{
+		tag0,
+		tag1,
+	}
+
 	facade := server.NewFacade(s.data)
 
 	results, err := facade.ListResources(api.ListResourcesArgs{
@@ -82,6 +88,13 @@ func (s *ListResourcesSuite) TestOkay(c *gc.C) {
 					Resources: []api.Resource{
 						apiRes1,
 						apiRes2,
+					},
+				},
+				{
+					// we should have a listing for every unit, even if they
+					// have no resources.
+					Entity: params.Entity{
+						Tag: "unit-a-service-1",
 					},
 				},
 			},

--- a/resource/resourceadapters/state.go
+++ b/resource/resourceadapters/state.go
@@ -4,6 +4,7 @@
 package resourceadapters
 
 import (
+	"github.com/juju/errors"
 	"github.com/juju/names"
 	"gopkg.in/juju/charm.v6-unstable"
 
@@ -22,4 +23,26 @@ func (s *service) ID() names.ServiceTag {
 func (s *service) CharmURL() *charm.URL {
 	cURL, _ := s.Service.CharmURL()
 	return cURL
+}
+
+// DataStore implements functionality wrapping state for resources.
+type DataStore struct {
+	state.Resources
+	State *state.State
+}
+
+// Units returns the tags for all units in the service.
+func (d DataStore) Units(serviceID string) (tags []names.UnitTag, err error) {
+	svc, err := d.State.Service(serviceID)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	units, err := svc.AllUnits()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	for _, u := range units {
+		tags = append(tags, u.UnitTag())
+	}
+	return tags, nil
 }


### PR DESCRIPTION
This code changes the behavior of ListResources such that it returns a UnitResources for every unit in the system.  Thus, the client code can differentiate between a unit that has no resources and one that doesn't exist.

(Review request: http://reviews.vapour.ws/r/3949/)