### PR TITLE
lp1541473: Don't add new controllers to the replicaset until they are "started"

### DIFF
--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -1078,10 +1078,13 @@ func (a *MachineAgent) StateWorker() (worker.Worker, error) {
 
 			// certChangedChan is shared by multiple workers it's up
 			// to the agent to close it rather than any one of the
-			// workers.
+			// workers.  It is possible that multiple cert changes
+			// come in before the apiserver is up to receive them.
+			// Specify a bigger buffer to prevent deadlock when
+			// the apiserver isn't up yet.
 			//
 			// TODO(ericsnow) For now we simply do not close the channel.
-			certChangedChan := make(chan params.StateServingInfo, 1)
+			certChangedChan := make(chan params.StateServingInfo, 10)
 			// Each time aipserver worker is restarted, we need a fresh copy of state due
 			// to the fact that state holds lease managers which are killed and need to be reset.
 			stateOpener := func() (*state.State, error) {

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -1081,7 +1081,9 @@ func (a *MachineAgent) StateWorker() (worker.Worker, error) {
 			// workers.  It is possible that multiple cert changes
 			// come in before the apiserver is up to receive them.
 			// Specify a bigger buffer to prevent deadlock when
-			// the apiserver isn't up yet.
+			// the apiserver isn't up yet.  Use a size of 10 since we
+			// allow up to 7 controllers, and might also update the
+			// addresses of the local machine (127.0.0.1, ::1, etc).
 			//
 			// TODO(ericsnow) For now we simply do not close the channel.
 			certChangedChan := make(chan params.StateServingInfo, 10)

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -2235,10 +2235,7 @@ func (st *State) watchEnqueuedActionsFilteredBy(receivers ...ActionReceiver) Str
 // notifies when the status of a state server changes.
 // TODO(cherylj) Add unit tests for this, as per bug 1543408.
 func (st *State) WatchStateServerStatusChanges() StringsWatcher {
-	return newcollectionWatcher(st, colWCfg{
-		col:    statusesC,
-		filter: makeStateServerIdFilter(st),
-	})
+	return newIdPrefixWatcher(st, statusesC, makeStateServerIdFilter(st))
 }
 
 func makeStateServerIdFilter(st *State) func(interface{}) bool {

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -2233,6 +2233,7 @@ func (st *State) watchEnqueuedActionsFilteredBy(receivers ...ActionReceiver) Str
 
 // WatchStateServerStatusChanges starts and returns a StringsWatcher that
 // notifies when the status of a state server changes.
+// TODO(cherylj) Add unit tests for this, as per bug 1543408.
 func (st *State) WatchStateServerStatusChanges() StringsWatcher {
 	return newcollectionWatcher(st, colWCfg{
 		col:    statusesC,

--- a/worker/peergrouper/suite_test.go
+++ b/worker/peergrouper/suite_test.go
@@ -1,7 +1,7 @@
 // Copyright 2014 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package peergrouper_test
+package peergrouper
 
 import (
 	stdtesting "testing"

--- a/worker/peergrouper/worker.go
+++ b/worker/peergrouper/worker.go
@@ -446,7 +446,7 @@ func (infow *serverInfoWatcher) updateMachines() (bool, error) {
 		// Don't add the machine unless it is "Started"
 		status, err := stm.Status()
 		if err != nil {
-			return false, fmt.Errorf("cannot get machine status: %q: %v", id, err)
+			return false, errors.Annotatef(err, "cannot get status for machine %q", id)
 		}
 		if status.Status == state.StatusStarted {
 			logger.Tracef("machine %q has started, adding it to peergrouper list", id)


### PR DESCRIPTION
Backport of PR https://github.com/juju/juju/pull/4338

Had to update terminology to reference "state servers" rather than controllers.  Also had to use the old newIdPrefixWatcher for the new watcher.