### PR TITLE
cloudconfig/sshinit: base64 encode initial script

### DIFF
--- a/cloudconfig/sshinit/configure.go
+++ b/cloudconfig/sshinit/configure.go
@@ -5,10 +5,13 @@
 package sshinit
 
 import (
+	"encoding/base64"
+	"fmt"
 	"io"
 	"strings"
 
 	"github.com/juju/loggo"
+	"github.com/juju/utils"
 	"github.com/juju/utils/ssh"
 
 	"github.com/juju/juju/cloudconfig/cloudinit"
@@ -55,19 +58,30 @@ func Configure(params ConfigureParams) error {
 func RunConfigureScript(script string, params ConfigureParams) error {
 	logger.Tracef("Running script on %s: %s", params.Host, script)
 
+	encoded := base64.StdEncoding.EncodeToString([]byte(`
+set -e
+tmpfile=$(mktemp)
+trap "rm -f $tmpfile" EXIT
+cat > $tmpfile
+/bin/bash $tmpfile
+`))
+
 	// bash will read a byte at a time when consuming commands
 	// from stdin. We avoid sending the entire script -- which
 	// will be very large when uploading tools -- directly to
 	// bash for this reason. Instead, run cat which will write
 	// the script to disk, and then execute it from there.
 	cmd := ssh.Command(params.Host, []string{
-		`sudo /bin/bash -c '
-set -e
-tmpfile=$(mktemp)
-trap "rm -f $tmpfile" EXIT
-cat > $tmpfile
-/bin/bash $tmpfile
-'`}, nil)
+		"sudo", "/bin/bash", "-c",
+		// The outer bash interprets the $(...), and executes
+		// the decoded script in the nested bash. This avoids
+		// linebreaks in the commandline, which the go.crypto-
+		// based client has trouble with.
+		fmt.Sprintf(
+			`/bin/bash -c "$(echo %s | base64 -d)"`,
+			utils.ShQuote(encoded),
+		),
+	}, nil)
 
 	cmd.Stdin = strings.NewReader(script)
 	cmd.Stderr = params.ProgressWriter


### PR DESCRIPTION
Yet another variation on the cloud-config sshinit
script dance. The go.crypto-based ssh client doesn't
like whitespace in the command, so we base64-encode
it and decode on the remote side.

Live-tested with both openssh- and go.crypto-based
clients.

(Review request: http://reviews.vapour.ws/r/3950/)