### PR TITLE
bootstrap: write current-controller earlier

### DIFF
--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -358,6 +358,12 @@ func (c *bootstrapCommand) Run(ctx *cmd.Context) (resultErr error) {
 		return errors.Trace(err)
 	}
 
+	// Set the current controller so "juju status" can be run while
+	// bootstrapping is underway.
+	if err := modelcmd.WriteCurrentController(c.controllerName); err != nil {
+		return errors.Trace(err)
+	}
+
 	cloudRegion := c.Cloud
 	if region.Name != "" {
 		cloudRegion = fmt.Sprintf("%s/%s", cloudRegion, region.Name)
@@ -431,9 +437,6 @@ to clean up the model.`[1:])
 		return errors.Annotate(err, "failed to bootstrap model")
 	}
 
-	if err := modelcmd.WriteCurrentController(c.controllerName); err != nil {
-		return errors.Trace(err)
-	}
 	if err := c.SetModelName(cfg.Name()); err != nil {
 		return errors.Trace(err)
 	}


### PR DESCRIPTION
Write the current-controller file earlier
in the bootstrap process, so we can run
"juju status" while bootstrap is ongoing.

(Review request: http://reviews.vapour.ws/r/3953/)