### PR TITLE
Initial support for autoload-crdentials command

### DIFF
--- a/cloud/credentials.go
+++ b/cloud/credentials.go
@@ -5,24 +5,13 @@ package cloud
 
 import (
 	"fmt"
-	"io/ioutil"
-	"os"
 	"strings"
 
 	"github.com/juju/errors"
 	"github.com/juju/schema"
 	"gopkg.in/juju/environschema.v1"
 	"gopkg.in/yaml.v2"
-
-	"github.com/juju/juju/juju/osenv"
 )
-
-// credentials is a struct containing cloud credential information,
-// used marshalling and unmarshalling.
-type credentials struct {
-	// Credentials is a map of cloud credentials, keyed on cloud name.
-	Credentials map[string]CloudCredential `yaml:"credentials"`
-}
 
 // CloudCredential contains attributes used to define credentials for a cloud.
 type CloudCredential struct {
@@ -45,6 +34,14 @@ type Credential struct {
 // AuthType returns the authentication type.
 func (c Credential) AuthType() AuthType {
 	return c.authType
+}
+
+func copyStringMap(in map[string]string) map[string]string {
+	out := make(map[string]string)
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
 }
 
 // Attributes returns the credential attributes.
@@ -260,64 +257,6 @@ func (c cloudCredentialValueChecker) Coerce(v interface{}, path []string) (inter
 	return Credential{AuthType(authType), attrs}, nil
 }
 
-// CredentialByName returns the credential and default region to use for the
-// specified cloud, optionally specifying a credential name. If no credential
-// name is specified, then use the default credential for the cloud if one has
-// been specified. The credential name is returned also, in case the default
-// credential is used. If there is only one credential, it is implicitly the
-// default.
-//
-// If there exists no matching credentials, an error satisfying
-// errors.IsNotFound will be returned.
-//
-// NOTE: the credential returned is not validated. The caller must validate
-//       the credential with the cloud provider.
-//
-// TODO(axw) write unit tests for this.
-func CredentialByName(
-	cloudName, credentialName string,
-) (_ *Credential, credentialNameUsed string, defaultRegion string, _ error) {
-
-	// Parse the credentials, and extract the credentials for the specified
-	// cloud.
-	credentialsData, err := ioutil.ReadFile(JujuCredentials())
-	if os.IsNotExist(err) {
-		return nil, "", "", errors.NotFoundf("credentials file")
-	} else if err != nil {
-		return nil, "", "", errors.Trace(err)
-	}
-	credentials, err := ParseCredentials(credentialsData)
-	if err != nil {
-		return nil, "", "", errors.Annotate(err, "parsing credentials")
-	}
-	cloudCredentials, ok := credentials[cloudName]
-	if !ok {
-		return nil, "", "", errors.NotFoundf("credentials for cloud %q", cloudName)
-	}
-
-	if credentialName == "" {
-		// No credential specified, so use the default for the cloud.
-		credentialName = cloudCredentials.DefaultCredential
-		if credentialName == "" && len(cloudCredentials.AuthCredentials) == 1 {
-			for credentialName = range cloudCredentials.AuthCredentials {
-			}
-		}
-	}
-	credential, ok := cloudCredentials.AuthCredentials[credentialName]
-	if !ok {
-		return nil, "", "", errors.NotFoundf(
-			"%q credential for cloud %q", credentialName, cloudName,
-		)
-	}
-	return &credential, credentialName, cloudCredentials.DefaultRegion, nil
-}
-
-// JujuCredentials is the location where credentials are
-// expected to be found. Requires JUJU_HOME to be set.
-func JujuCredentials() string {
-	return osenv.JujuXDGDataHomePath("credentials.yaml")
-}
-
 // ParseCredentials parses the given yaml bytes into Credentials, but does
 // not validate the credential attributes.
 func ParseCredentials(data []byte) (map[string]CloudCredential, error) {
@@ -339,21 +278,4 @@ func ParseCredentials(data []byte) (map[string]CloudCredential, error) {
 		credentials[cloud] = v.(CloudCredential)
 	}
 	return credentials, nil
-}
-
-// MarshalCredentials marshals the given credentials to YAML
-func MarshalCredentials(credentialsMap map[string]CloudCredential) ([]byte, error) {
-	data, err := yaml.Marshal(credentials{credentialsMap})
-	if err != nil {
-		return nil, errors.Annotate(err, "cannot marshal credentials")
-	}
-	return data, nil
-}
-
-func copyStringMap(in map[string]string) map[string]string {
-	out := make(map[string]string)
-	for k, v := range in {
-		out[k] = v
-	}
-	return out
 }

--- a/cloud/credentials_test.go
+++ b/cloud/credentials_test.go
@@ -4,8 +4,6 @@
 package cloud_test
 
 import (
-	"io/ioutil"
-
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -449,23 +447,6 @@ func (s *credentialsSuite) TestFinalizeCredentialNotSupported(c *gc.C) {
 	)
 	c.Assert(err, jc.Satisfies, errors.IsNotSupported)
 	c.Assert(err, gc.ErrorMatches, `auth-type "oauth2" not supported`)
-}
-
-func (s *credentialsSuite) TestCredentialByNameImplicitDefault(c *gc.C) {
-	data, err := cloud.MarshalCredentials(map[string]cloud.CloudCredential{
-		"cloud-name": {
-			AuthCredentials: map[string]cloud.Credential{
-				"one-and-only": cloud.NewEmptyCredential(),
-			},
-		},
-	})
-	c.Assert(err, jc.ErrorIsNil)
-	err = ioutil.WriteFile(cloud.JujuCredentials(), data, 0644)
-	c.Assert(err, jc.ErrorIsNil)
-
-	_, credentialName, _, err := cloud.CredentialByName("cloud-name", "")
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(credentialName, gc.Equals, "one-and-only")
 }
 
 func readFileNotSupported(f string) ([]byte, error) {

--- a/cloud/export_test.go
+++ b/cloud/export_test.go
@@ -3,6 +3,18 @@
 
 package cloud
 
+import (
+	"gopkg.in/yaml.v2"
+)
+
 var (
 	FallbackPublicCloudInfo = fallbackPublicCloudInfo
 )
+
+func MarshalCredentials(credentialsMap map[string]CloudCredential) ([]byte, error) {
+	var credentialsYAML struct {
+		Credentials map[string]CloudCredential `yaml:"credentials"`
+	}
+	credentialsYAML.Credentials = credentialsMap
+	return yaml.Marshal(credentialsYAML)
+}

--- a/cmd/juju/cloud/detectcredentials.go
+++ b/cmd/juju/cloud/detectcredentials.go
@@ -45,13 +45,13 @@ GCE
     1. A JSON file whose path is specified by the GOOGLE_APPLICATION_CREDENTIALS environment variable
     2. A JSON file in a knowm location eg on Linux $HOME/.config/gcloud/application_default_credentials.json
     
-Openstack (see below)
+OpenStack (see below)
   Credentials are located in:
     1. On Linux, $HOME/.novarc
     2. Environment variables OS_USERNAME, OS_PASSWORD, OS_TENANT_NAME 
     
-Some standard credentials locations may apply for more than one cloud. Fox example, there may be more than one
-Openstack cloud defined. In such cases, the cloud name may be specified and only credentials for that cloud are
+Some standard credentials locations may apply for more than one cloud. For example, there may be more than one
+OpenStack cloud defined. In such cases, the cloud name may be specified and only credentials for that cloud are
 searched, and when found, applied to that cloud specifically.
 
 Example:
@@ -67,7 +67,7 @@ See Also:
 // NewDetectCredentialsCommand returns a command to add credential information to credentials.yaml.
 func NewDetectCredentialsCommand() cmd.Command {
 	return &detectCredentialsCommand{
-		store: jujuclient.NewFileCredentialsStore(),
+		store: jujuclient.NewFileCredentialStore(),
 	}
 }
 
@@ -133,7 +133,7 @@ func (c *detectCredentialsCommand) Run(ctxt *cmd.Context) error {
 			for _, cred := range creds {
 				cloudCredential.AuthCredentials[cred.Label] = cred.Credential
 			}
-			if err := c.store.UpdateCredentials(cloudName, cloudCredential); err != nil {
+			if err := c.store.UpdateCredential(cloudName, cloudCredential); err != nil {
 				return errors.Annotatef(err, "cannot add credentials for cloud %q", cloudName)
 			}
 		}

--- a/cmd/juju/cloud/detectcredentials.go
+++ b/cmd/juju/cloud/detectcredentials.go
@@ -115,16 +115,16 @@ func (c *detectCredentialsCommand) Run(ctxt *cmd.Context) error {
 			continue
 		}
 		// TODO(wallyworld) - use --replace option
-		var creds []environs.NamedCredential
-		if detectCredentils, ok := provider.(environs.ProviderCredentials); ok {
-			creds, err = detectCredentils.DetectCredentials()
+		var creds []environs.LabeledCredential
+		if detectCredentials, ok := provider.(environs.ProviderCredentials); ok {
+			creds, err = detectCredentials.DetectCredentials()
 			if err != nil && !errors.IsNotFound(err) {
 				logger.Warningf("could not detect credentials for %q: %v", cloudName, err)
 			}
 			if errors.IsNotFound(err) {
 				continue
 			}
-			// TOOD(wallyworld) - add default credentials and region
+			// TODO(wallyworld) - add default credentials and region
 			cloudCredential := jujucloud.CloudCredential{
 				AuthCredentials: make(map[string]jujucloud.Credential),
 			}

--- a/cmd/juju/cloud/detectcredentials.go
+++ b/cmd/juju/cloud/detectcredentials.go
@@ -1,0 +1,140 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cloud
+
+import (
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+	"launchpad.net/gnuflag"
+
+	jujucloud "github.com/juju/juju/cloud"
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/jujuclient"
+)
+
+type detectCredentialsCommand struct {
+	cmd.CommandBase
+	out cmd.Output
+
+	store jujuclient.CredentialUpdater
+
+	// Replace, if true, existing credential information is overwritten.
+	Replace bool
+
+	// The cloud for which to load credentials.
+	CloudName string
+}
+
+var detectCredentialsDoc = `
+The autoload-credentials command looks for well known locations for supported clouds and
+loads any credentials and default regions found into the Juju credentials store and makes
+these available when bootstrapping new controllers.
+
+The resulting credentials may be viewed with juju list-credentials.
+
+The clouds for which credentials may be autoloaded are:
+
+AWS
+  Credentials and regions are located in:
+    1. On Linux, $HOME/.aws/credentials and $HOME/.aws/config 
+    2. Environment variables AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY
+    
+GCE
+  Credentials are located in:
+    1. A JSON file whose path is specified by the GOOGLE_APPLICATION_CREDENTIALS environment variable
+    2. A JSON file in a knowm location eg on Linux $HOME/.config/gcloud/application_default_credentials.json
+    
+Openstack (see below)
+  Credentials are located in:
+    1. On Linux, $HOME/.novarc
+    2. Environment variables OS_USERNAME, OS_PASSWORD, OS_TENANT_NAME 
+    
+Some standard credentials locations may apply for more than one cloud. Fox example, there may be more than one
+Openstack cloud defined. In such cases, the cloud name may be specified and only credentials for that cloud are
+searched, and when found, applied to that cloud specifically.
+
+Example:
+   juju autoload-credentials
+   juju autoload-credentials rackspace
+   juju autoload-credentials --replace
+   
+See Also:
+   juju list-credentials
+   juju add-credentials
+`
+
+// NewDetectCredentialsCommand returns a command to add credential information to credentials.yaml.
+func NewDetectCredentialsCommand() cmd.Command {
+	return &detectCredentialsCommand{}
+}
+
+func (c *detectCredentialsCommand) Info() *cmd.Info {
+	return &cmd.Info{
+		Name:    "autoload-credentials",
+		Purpose: "looks for cloud credentials and caches those for use by Juju when bootstrapping",
+		Doc:     detectCredentialsDoc,
+	}
+}
+
+func (c *detectCredentialsCommand) SetFlags(f *gnuflag.FlagSet) {
+	f.BoolVar(&c.Replace, "replace", false, "overwrite any existing credential information")
+}
+
+func (c *detectCredentialsCommand) Init(args []string) (err error) {
+	if len(args) > 1 {
+		return errors.New("Usage: juju autoload-credentials [--replace] [<cloud-name>]")
+	}
+	if len(args) == 1 {
+		c.CloudName = args[0]
+	}
+	return nil
+}
+
+func (c *detectCredentialsCommand) Run(ctxt *cmd.Context) error {
+	clouds, _, err := jujucloud.PublicCloudMetadata(jujucloud.JujuPublicCloudsPath())
+	if err != nil {
+		return err
+	}
+	personalClouds, err := jujucloud.PersonalCloudMetadata()
+	if err != nil {
+		return err
+	}
+	for k, v := range personalClouds {
+		clouds[k] = v
+	}
+	for cloudName, cloud := range clouds {
+		if c.CloudName != "" && c.CloudName != cloudName {
+			continue
+		}
+		provider, err := environs.Provider(cloud.Type)
+		if err != nil {
+			// Should never happen but it will on go 1.2
+			// because lxd provider is not built.
+			logger.Warningf("cloud %q not available on this platform", cloud.Type)
+			continue
+		}
+		// TODO(wallyworld) - use --replace option
+		var creds []environs.NamedCredential
+		if detectCredentils, ok := provider.(environs.ProviderCredentials); ok {
+			creds, err = detectCredentils.DetectCredentials()
+			if err != nil && !errors.IsNotFound(err) {
+				logger.Warningf("could not detect credentials for %q: %v", cloudName, err)
+			}
+			if errors.IsNotFound(err) {
+				continue
+			}
+			// TOOD(wallyworld) - add default credentials and region
+			cloudCredential := jujucloud.CloudCredential{
+				AuthCredentials: make(map[string]jujucloud.Credential),
+			}
+			for _, cred := range creds {
+				cloudCredential.AuthCredentials[cred.Label] = cred.Credential
+			}
+			if err := c.store.UpdateCredentials(cloudName, cloudCredential); err != nil {
+				return errors.Annotatef(err, "cannot add credentials for cloud %q", cloudName)
+			}
+		}
+	}
+	return nil
+}

--- a/cmd/juju/cloud/detectcredentials.go
+++ b/cmd/juju/cloud/detectcredentials.go
@@ -66,7 +66,9 @@ See Also:
 
 // NewDetectCredentialsCommand returns a command to add credential information to credentials.yaml.
 func NewDetectCredentialsCommand() cmd.Command {
-	return &detectCredentialsCommand{}
+	return &detectCredentialsCommand{
+		store: jujuclient.NewFileCredentialsStore(),
+	}
 }
 
 func (c *detectCredentialsCommand) Info() *cmd.Info {

--- a/cmd/juju/cloud/detectcredentials_test.go
+++ b/cmd/juju/cloud/detectcredentials_test.go
@@ -1,0 +1,63 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cloud_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	jujucloud "github.com/juju/juju/cloud"
+	"github.com/juju/juju/cmd/juju/cloud"
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/jujuclient"
+	"github.com/juju/juju/jujuclient/jujuclienttesting"
+	"github.com/juju/juju/testing"
+)
+
+type detectCredentialsSuite struct {
+	testing.FakeJujuXDGDataHomeSuite
+	store       jujuclient.CredentialsStore
+	aCredential jujucloud.Credential
+}
+
+var _ = gc.Suite(&detectCredentialsSuite{})
+
+type mockProvider struct {
+	environs.EnvironProvider
+	aCredential jujucloud.Credential
+}
+
+func (p *mockProvider) DetectCredentials() ([]environs.NamedCredential, error) {
+	return []environs.NamedCredential{{
+		Label:      "label",
+		Credential: p.aCredential,
+	}}, nil
+}
+
+func (s *detectCredentialsSuite) SetUpTest(c *gc.C) {
+	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
+	s.store = jujuclienttesting.NewMemStore()
+	s.aCredential = jujucloud.NewCredential(jujucloud.AccessKeyAuthType, nil)
+	environs.RegisterProvider("test", &mockProvider{aCredential: s.aCredential})
+	err := jujucloud.WritePersonalCloudMetadata(map[string]jujucloud.Cloud{
+		"test": jujucloud.Cloud{Type: "test"},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *detectCredentialsSuite) TestDetectCredentials(c *gc.C) {
+	s.detectCredentials(c, "test")
+	creds, err := s.store.CredentialsForCloud("test")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(creds.AuthCredentials["label"], jc.DeepEquals, s.aCredential)
+}
+
+// TODO(wallyworld) - add more test coverage
+
+func (s *detectCredentialsSuite) detectCredentials(c *gc.C, args ...string) string {
+	ctx, err := testing.RunCommand(c, cloud.NewDetectCredentialsCommandForTest(s.store), args...)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(testing.Stderr(ctx), gc.Equals, "")
+	return testing.Stdout(ctx)
+}

--- a/cmd/juju/cloud/detectcredentials_test.go
+++ b/cmd/juju/cloud/detectcredentials_test.go
@@ -17,7 +17,7 @@ import (
 
 type detectCredentialsSuite struct {
 	testing.FakeJujuXDGDataHomeSuite
-	store       jujuclient.CredentialsStore
+	store       jujuclient.CredentialStore
 	aCredential jujucloud.Credential
 }
 
@@ -48,7 +48,7 @@ func (s *detectCredentialsSuite) SetUpTest(c *gc.C) {
 
 func (s *detectCredentialsSuite) TestDetectCredentials(c *gc.C) {
 	s.detectCredentials(c, "test")
-	creds, err := s.store.CredentialsForCloud("test")
+	creds, err := s.store.CredentialForCloud("test")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(creds.AuthCredentials["label"], jc.DeepEquals, s.aCredential)
 }

--- a/cmd/juju/cloud/detectcredentials_test.go
+++ b/cmd/juju/cloud/detectcredentials_test.go
@@ -28,8 +28,8 @@ type mockProvider struct {
 	aCredential jujucloud.Credential
 }
 
-func (p *mockProvider) DetectCredentials() ([]environs.NamedCredential, error) {
-	return []environs.NamedCredential{{
+func (p *mockProvider) DetectCredentials() ([]environs.LabeledCredential, error) {
+	return []environs.LabeledCredential{{
 		Label:      "label",
 		Credential: p.aCredential,
 	}}, nil

--- a/cmd/juju/cloud/export_test.go
+++ b/cmd/juju/cloud/export_test.go
@@ -13,7 +13,7 @@ func NewListCredentialsCommandForTest(testStore jujuclient.CredentialGetter) *li
 	}
 }
 
-func NewDetectCredentialsCommandForTest(testStore jujuclient.CredentialsStore) *detectCredentialsCommand {
+func NewDetectCredentialsCommandForTest(testStore jujuclient.CredentialStore) *detectCredentialsCommand {
 	return &detectCredentialsCommand{
 		store: testStore,
 	}

--- a/cmd/juju/cloud/export_test.go
+++ b/cmd/juju/cloud/export_test.go
@@ -1,0 +1,20 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cloud
+
+import (
+	"github.com/juju/juju/jujuclient"
+)
+
+func NewListCredentialsCommandForTest(testStore jujuclient.CredentialsGetter) *listCredentialsCommand {
+	return &listCredentialsCommand{
+		store: testStore,
+	}
+}
+
+func NewDetectCredentialsCommandForTest(testStore jujuclient.CredentialsStore) *detectCredentialsCommand {
+	return &detectCredentialsCommand{
+		store: testStore,
+	}
+}

--- a/cmd/juju/cloud/export_test.go
+++ b/cmd/juju/cloud/export_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/juju/juju/jujuclient"
 )
 
-func NewListCredentialsCommandForTest(testStore jujuclient.CredentialsGetter) *listCredentialsCommand {
+func NewListCredentialsCommandForTest(testStore jujuclient.CredentialGetter) *listCredentialsCommand {
 	return &listCredentialsCommand{
 		store: testStore,
 	}

--- a/cmd/juju/cloud/listcredentials.go
+++ b/cmd/juju/cloud/listcredentials.go
@@ -6,8 +6,6 @@ package cloud
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
-	"os"
 	"sort"
 	"strings"
 	"text/tabwriter"
@@ -17,12 +15,14 @@ import (
 	"launchpad.net/gnuflag"
 
 	jujucloud "github.com/juju/juju/cloud"
+	"github.com/juju/juju/jujuclient"
 )
 
 type listCredentialsCommand struct {
 	cmd.CommandBase
 	out       cmd.Output
 	cloudName string
+	store     jujuclient.CredentialsGetter
 }
 
 var listCredentialsDoc = `
@@ -75,13 +75,8 @@ func (c *listCredentialsCommand) Init(args []string) error {
 
 func (c *listCredentialsCommand) Run(ctxt *cmd.Context) error {
 	var credentials map[string]jujucloud.CloudCredential
-	data, err := ioutil.ReadFile(jujucloud.JujuCredentials())
-	if err == nil {
-		credentials, err = jujucloud.ParseCredentials(data)
-		if err != nil {
-			return err
-		}
-	} else if !os.IsNotExist(err) {
+	credentials, err := c.store.AllCredentials()
+	if err != nil && !errors.IsNotFound(err) {
 		return err
 	}
 	if c.cloudName != "" {

--- a/cmd/juju/cloud/listcredentials.go
+++ b/cmd/juju/cloud/listcredentials.go
@@ -45,7 +45,7 @@ type credentialsMap struct {
 // NewListCredentialsCommand returns a command to list cloud credentials.
 func NewListCredentialsCommand() cmd.Command {
 	return &listCredentialsCommand{
-		store: jujuclient.NewFileCredentialsStore(),
+		store: jujuclient.NewFileCredentialStore(),
 	}
 }
 

--- a/cmd/juju/cloud/listcredentials.go
+++ b/cmd/juju/cloud/listcredentials.go
@@ -22,7 +22,7 @@ type listCredentialsCommand struct {
 	cmd.CommandBase
 	out       cmd.Output
 	cloudName string
-	store     jujuclient.CredentialsGetter
+	store     jujuclient.CredentialGetter
 }
 
 var listCredentialsDoc = `
@@ -44,7 +44,9 @@ type credentialsMap struct {
 
 // NewListCredentialsCommand returns a command to list cloud credentials.
 func NewListCredentialsCommand() cmd.Command {
-	return &listCredentialsCommand{}
+	return &listCredentialsCommand{
+		store: jujuclient.NewFileCredentialsStore(),
+	}
 }
 
 func (c *listCredentialsCommand) Info() *cmd.Info {

--- a/cmd/juju/cloud/listcredentials_test.go
+++ b/cmd/juju/cloud/listcredentials_test.go
@@ -18,7 +18,7 @@ import (
 
 type listCredentialsSuite struct {
 	testing.BaseSuite
-	store jujuclient.CredentialsGetter
+	store jujuclient.CredentialGetter
 }
 
 var _ = gc.Suite(&listCredentialsSuite{})

--- a/cmd/juju/cloud/listcredentials_test.go
+++ b/cmd/juju/cloud/listcredentials_test.go
@@ -4,9 +4,6 @@
 package cloud_test
 
 import (
-	"io/ioutil"
-	"os"
-	"path/filepath"
 	"strings"
 
 	jc "github.com/juju/testing/checkers"
@@ -14,14 +11,14 @@ import (
 
 	jujucloud "github.com/juju/juju/cloud"
 	"github.com/juju/juju/cmd/juju/cloud"
-	"github.com/juju/juju/juju/osenv"
+	"github.com/juju/juju/jujuclient"
+	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	"github.com/juju/juju/testing"
 )
 
 type listCredentialsSuite struct {
 	testing.BaseSuite
-
-	jujuXDGDataHome string
+	store jujuclient.CredentialsGetter
 }
 
 var _ = gc.Suite(&listCredentialsSuite{})
@@ -65,18 +62,9 @@ var sampleCredentials = map[string]jujucloud.CloudCredential{
 
 func (s *listCredentialsSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
-
-	s.jujuXDGDataHome = c.MkDir()
-	oldJujuXDGDataHome := osenv.SetJujuXDGDataHome(s.jujuXDGDataHome)
-	s.AddCleanup(func(c *gc.C) {
-		osenv.SetJujuXDGDataHome(oldJujuXDGDataHome)
-	})
-
-	// Write $XDG_DATA_HOME/juju/credentials.yaml.
-	data, err := jujucloud.MarshalCredentials(sampleCredentials)
-	c.Assert(err, jc.ErrorIsNil)
-	err = ioutil.WriteFile(filepath.Join(s.jujuXDGDataHome, "credentials.yaml"), data, 0600)
-	c.Assert(err, jc.ErrorIsNil)
+	s.store = &jujuclienttesting.MemStore{
+		Credentials: sampleCredentials,
+	}
 }
 
 func (s *listCredentialsSuite) TestListCredentialsTabular(c *gc.C) {
@@ -143,23 +131,25 @@ func (s *listCredentialsSuite) TestListCredentialsJSON(c *gc.C) {
 	c.Skip("not implemented: credentials don't marshal to JSON yet")
 }
 
-func (s *listCredentialsSuite) TestListCredentialsFileMissing(c *gc.C) {
-	err := os.RemoveAll(s.jujuXDGDataHome)
+func (s *listCredentialsSuite) TestListCredentialsNone(c *gc.C) {
+	listCmd := cloud.NewListCredentialsCommandForTest(jujuclienttesting.NewMemStore())
+	ctx, err := testing.RunCommand(c, listCmd)
 	c.Assert(err, jc.ErrorIsNil)
-
-	out := s.listCredentials(c)
-	out = strings.Replace(out, "\n", "", -1)
+	c.Assert(testing.Stderr(ctx), gc.Equals, "")
+	out := strings.Replace(testing.Stdout(ctx), "\n", "", -1)
 	c.Assert(out, gc.Equals, "CLOUD  CREDENTIALS")
 
-	out = s.listCredentials(c, "--format", "yaml")
-	out = strings.Replace(out, "\n", "", -1)
+	ctx, err = testing.RunCommand(c, listCmd, "--format", "yaml")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(testing.Stderr(ctx), gc.Equals, "")
+	out = strings.Replace(testing.Stdout(ctx), "\n", "", -1)
 	c.Assert(out, gc.Equals, "credentials: {}")
 
 	// TODO(axw) test json once json marshaling works properly
 }
 
 func (s *listCredentialsSuite) listCredentials(c *gc.C, args ...string) string {
-	ctx, err := testing.RunCommand(c, cloud.NewListCredentialsCommand(), args...)
+	ctx, err := testing.RunCommand(c, cloud.NewListCredentialsCommandForTest(s.store), args...)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(testing.Stderr(ctx), gc.Equals, "")
 	return testing.Stdout(ctx)

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -101,7 +101,7 @@ See Also:
 
 func newBootstrapCommand() cmd.Command {
 	return modelcmd.Wrap(&bootstrapCommand{
-		credentialsStore: jujuclient.NewFileCredentialsStore(),
+		CredentialStore: jujuclient.NewFileCredentialStore(),
 	})
 }
 
@@ -109,7 +109,7 @@ func newBootstrapCommand() cmd.Command {
 // environment, and setting up everything necessary to continue working.
 type bootstrapCommand struct {
 	modelcmd.ModelCommandBase
-	credentialsStore jujuclient.CredentialsStore
+	CredentialStore jujuclient.CredentialStore
 
 	Constraints           constraints.Value
 	BootstrapConstraints  constraints.Value
@@ -467,7 +467,7 @@ func credentialByName(
 	store jujuclient.CredentialGetter, cloudName, credentialName string,
 ) (_ *jujucloud.Credential, credentialNameUsed string, defaultRegion string, _ error) {
 
-	cloudCredentials, err := store.CredentialsForCloud(cloudName)
+	cloudCredentials, err := store.CredentialForCloud(cloudName)
 	if err != nil {
 		return nil, "", "", errors.Annotate(err, "loading credentials")
 	}
@@ -495,7 +495,7 @@ func (c *bootstrapCommand) getCredentials(
 ) (_ *jujucloud.Credential, region string, _ error) {
 
 	credential, credentialName, defaultRegion, err := credentialByName(
-		c.credentialsStore, cloudName, c.CredentialName,
+		c.CredentialStore, cloudName, c.CredentialName,
 	)
 	if err != nil {
 		return nil, "", errors.Trace(err)

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -54,7 +55,8 @@ type BootstrapSuite struct {
 	testing.MgoSuite
 	envtesting.ToolsFixture
 	mockBlockClient *mockBlockClient
-	memstore        configstore.Storage
+	store           jujuclient.CredentialsStore
+	legacyMemStore  configstore.Storage
 }
 
 var _ = gc.Suite(&BootstrapSuite{})
@@ -102,10 +104,13 @@ func (s *BootstrapSuite) SetUpTest(c *gc.C) {
 		}
 		return s.mockBlockClient, nil
 	})
-	s.memstore = configstore.NewMem()
+	s.legacyMemStore = configstore.NewMem()
 	s.PatchValue(&configstore.Default, func() (configstore.Storage, error) {
-		return s.memstore, nil
+		return s.legacyMemStore, nil
 	})
+
+	// TODO(wallyworld) - add test data when tests are improved
+	s.store = jujuclienttesting.NewMemStore()
 }
 
 func (s *BootstrapSuite) TearDownSuite(c *gc.C) {
@@ -118,6 +123,12 @@ func (s *BootstrapSuite) TearDownTest(c *gc.C) {
 	s.MgoSuite.TearDownTest(c)
 	s.FakeJujuXDGDataHomeSuite.TearDownTest(c)
 	dummy.Reset()
+}
+
+func (s *BootstrapSuite) newBootstrapCommand() cmd.Command {
+	return modelcmd.Wrap(&bootstrapCommand{
+		credentialsStore: s.store,
+	})
 }
 
 type mockBlockClient struct {
@@ -164,12 +175,12 @@ func (s *BootstrapSuite) TestBootstrapAPIReadyRetries(c *gc.C) {
 	} {
 		resetJujuXDGDataHome(c)
 		dummy.Reset()
-		s.memstore = configstore.NewMem()
+		s.legacyMemStore = configstore.NewMem()
 
 		s.mockBlockClient.numRetries = t.numRetries
 		s.mockBlockClient.retryCount = 0
 		_, err := coretesting.RunCommand(
-			c, newBootstrapCommand(),
+			c, s.newBootstrapCommand(),
 			"devcontroller", "dummy", "--auto-upgrade",
 		)
 		if t.err == "" {
@@ -199,7 +210,7 @@ func (s *BootstrapSuite) TestBootstrapAPIReadyWaitsForSpaceDiscovery(c *gc.C) {
 	resetJujuXDGDataHome(c)
 
 	s.mockBlockClient.discoveringSpacesError = 2
-	_, err := coretesting.RunCommand(c, newBootstrapCommand(), "devcontroller", "dummy", "--auto-upgrade")
+	_, err := coretesting.RunCommand(c, s.newBootstrapCommand(), "devcontroller", "dummy", "--auto-upgrade")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.mockBlockClient.discoveringSpacesError, gc.Equals, 0)
 }
@@ -252,7 +263,7 @@ func (s *BootstrapSuite) run(c *gc.C, test bootstrapTest) testing.Restorer {
 
 	addrConnectedTo := "localhost:17070"
 	var restore testing.Restorer = func() {
-		s.memstore = configstore.NewMem()
+		s.legacyMemStore = configstore.NewMem()
 	}
 	if test.version != "" {
 		useVersion := strings.Replace(test.version, "%LTS%", config.LatestLtsSeries(), 1)
@@ -272,7 +283,7 @@ func (s *BootstrapSuite) run(c *gc.C, test bootstrapTest) testing.Restorer {
 		controllerName, "dummy",
 		"--config", "default-series=raring",
 	}, test.args...)
-	opc, errc := cmdtesting.RunCommand(cmdtesting.NullContext(c), newBootstrapCommand(), args...)
+	opc, errc := cmdtesting.RunCommand(cmdtesting.NullContext(c), s.newBootstrapCommand(), args...)
 	// Check for remaining operations/errors.
 	if test.err != "" {
 		err := <-errc
@@ -419,12 +430,12 @@ var bootstrapTests = []bootstrapTest{{
 }}
 
 func (s *BootstrapSuite) TestRunControllerNameMissing(c *gc.C) {
-	_, err := coretesting.RunCommand(c, newBootstrapCommand())
+	_, err := coretesting.RunCommand(c, s.newBootstrapCommand())
 	c.Check(err, gc.ErrorMatches, "controller name and cloud name are required")
 }
 
 func (s *BootstrapSuite) TestRunCloudNameMissing(c *gc.C) {
-	_, err := coretesting.RunCommand(c, newBootstrapCommand(), "my-controller")
+	_, err := coretesting.RunCommand(c, s.newBootstrapCommand(), "my-controller")
 	c.Check(err, gc.ErrorMatches, "controller name and cloud name are required")
 }
 
@@ -452,17 +463,17 @@ func (s *BootstrapSuite) TestBootstrapTwice(c *gc.C) {
 	const controllerName = "dev"
 	s.patchVersionAndSeries(c, "raring")
 
-	_, err := coretesting.RunCommand(c, newBootstrapCommand(), controllerName, "dummy", "--auto-upgrade")
+	_, err := coretesting.RunCommand(c, s.newBootstrapCommand(), controllerName, "dummy", "--auto-upgrade")
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = coretesting.RunCommand(c, newBootstrapCommand(), controllerName, "dummy", "--auto-upgrade")
+	_, err = coretesting.RunCommand(c, s.newBootstrapCommand(), controllerName, "dummy", "--auto-upgrade")
 	c.Assert(err, gc.ErrorMatches, `controller "dev" already exists`)
 }
 
 func (s *BootstrapSuite) TestBootstrapSetsCurrentModel(c *gc.C) {
 	s.patchVersionAndSeries(c, "raring")
 
-	_, err := coretesting.RunCommand(c, newBootstrapCommand(), "devcontroller", "dummy", "--auto-upgrade")
+	_, err := coretesting.RunCommand(c, s.newBootstrapCommand(), "devcontroller", "dummy", "--auto-upgrade")
 	c.Assert(err, jc.ErrorIsNil)
 	currentController, err := modelcmd.ReadCurrentController()
 	c.Assert(err, jc.ErrorIsNil)
@@ -486,7 +497,7 @@ func (s *BootstrapSuite) TestBootstrapPropagatesStoreErrors(c *gc.C) {
 
 	store := jujuclienttesting.NewStubStore()
 	store.SetErrors(errors.New("oh noes"))
-	cmd := &bootstrapCommand{}
+	cmd := &bootstrapCommand{credentialsStore: store}
 	cmd.SetClientStore(store)
 	_, err := coretesting.RunCommand(c, modelcmd.Wrap(cmd), controllerName, "dummy", "--auto-upgrade")
 	c.Assert(err, gc.ErrorMatches, `loading credentials: oh noes`)
@@ -514,7 +525,7 @@ func (s *BootstrapSuite) TestBootstrapFailToPrepareDiesGracefully(c *gc.C) {
 
 	ctx := coretesting.Context(c)
 	_, errc := cmdtesting.RunCommand(
-		ctx, newBootstrapCommand(),
+		ctx, s.newBootstrapCommand(),
 		"devcontroller", "dummy",
 	)
 	c.Check(<-errc, gc.ErrorMatches, ".*mock-prepare$")
@@ -534,7 +545,7 @@ func (s *BootstrapSuite) TestBootstrapAlreadyExists(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	ctx := coretesting.Context(c)
-	_, errc := cmdtesting.RunCommand(ctx, newBootstrapCommand(), controllerName, "dummy", "--auto-upgrade")
+	_, errc := cmdtesting.RunCommand(ctx, s.newBootstrapCommand(), controllerName, "dummy", "--auto-upgrade")
 	err = <-errc
 	c.Assert(err, jc.Satisfies, errors.IsAlreadyExists)
 	c.Assert(err, gc.ErrorMatches, fmt.Sprintf(`controller %q already exists`, expectedBootstrappedName))
@@ -547,7 +558,7 @@ func (s *BootstrapSuite) TestInvalidLocalSource(c *gc.C) {
 	// Bootstrap the controller with an invalid source.
 	// The command returns with an error.
 	_, err := coretesting.RunCommand(
-		c, newBootstrapCommand(), "--metadata-source", c.MkDir(),
+		c, s.newBootstrapCommand(), "--metadata-source", c.MkDir(),
 		"devcontroller", "dummy",
 	)
 	c.Check(err, gc.ErrorMatches, `failed to bootstrap model: Juju cannot bootstrap because no tools are available for your model(.|\n)*`)
@@ -587,7 +598,7 @@ func (s *BootstrapSuite) TestBootstrapCalledWithMetadataDir(c *gc.C) {
 	})
 
 	coretesting.RunCommand(
-		c, newBootstrapCommand(),
+		c, s.newBootstrapCommand(),
 		"--metadata-source", sourceDir, "--constraints", "mem=4G",
 		"devcontroller", "dummy-cloud/region-1",
 		"--config", "default-series=raring",
@@ -608,7 +619,7 @@ func (s *BootstrapSuite) checkBootstrapWithVersion(c *gc.C, vers, expect string)
 	num.Minor = 3
 	s.PatchValue(&version.Current, num)
 	coretesting.RunCommand(
-		c, newBootstrapCommand(),
+		c, s.newBootstrapCommand(),
 		"--agent-version", vers,
 		"devcontroller", "dummy-cloud/region-1",
 		"--config", "default-series=raring",
@@ -633,7 +644,7 @@ func (s *BootstrapSuite) TestBootstrapWithAutoUpgrade(c *gc.C) {
 		return &bootstrap
 	})
 	coretesting.RunCommand(
-		c, newBootstrapCommand(),
+		c, s.newBootstrapCommand(),
 		"--auto-upgrade",
 		"devcontroller", "dummy-cloud/region-1",
 	)
@@ -649,7 +660,7 @@ func (s *BootstrapSuite) TestAutoSyncLocalSource(c *gc.C) {
 	// The bootstrapping has to show no error, because the tools
 	// are automatically synchronized.
 	_, err := coretesting.RunCommand(
-		c, newBootstrapCommand(), "--metadata-source", sourceDir,
+		c, s.newBootstrapCommand(), "--metadata-source", sourceDir,
 		"devcontroller", "dummy-cloud/region-1",
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -691,7 +702,7 @@ func (s *BootstrapSuite) TestAutoUploadAfterFailedSync(c *gc.C) {
 	// Run command and check for that upload has been run for tools matching
 	// the current juju version.
 	opc, errc := cmdtesting.RunCommand(
-		cmdtesting.NullContext(c), newBootstrapCommand(),
+		cmdtesting.NullContext(c), s.newBootstrapCommand(),
 		"devcontroller", "dummy-cloud/region-1",
 		"--config", "default-series=raring",
 		"--auto-upgrade",
@@ -706,7 +717,7 @@ func (s *BootstrapSuite) TestAutoUploadAfterFailedSync(c *gc.C) {
 func (s *BootstrapSuite) TestAutoUploadOnlyForDev(c *gc.C) {
 	s.setupAutoUploadTest(c, "1.8.3", "precise")
 	_, errc := cmdtesting.RunCommand(
-		cmdtesting.NullContext(c), newBootstrapCommand(),
+		cmdtesting.NullContext(c), s.newBootstrapCommand(),
 		"devcontroller", "dummy-cloud/region-1",
 	)
 	err := <-errc
@@ -717,7 +728,7 @@ func (s *BootstrapSuite) TestAutoUploadOnlyForDev(c *gc.C) {
 func (s *BootstrapSuite) TestMissingToolsError(c *gc.C) {
 	s.setupAutoUploadTest(c, "1.8.3", "precise")
 
-	_, err := coretesting.RunCommand(c, newBootstrapCommand(),
+	_, err := coretesting.RunCommand(c, s.newBootstrapCommand(),
 		"devcontroller", "dummy-cloud/region-1",
 		"--config", "default-series=raring",
 	)
@@ -735,7 +746,7 @@ func (s *BootstrapSuite) TestMissingToolsUploadFailedError(c *gc.C) {
 	s.PatchValue(&sync.BuildToolsTarball, buildToolsTarballAlwaysFails)
 
 	ctx, err := coretesting.RunCommand(
-		c, newBootstrapCommand(),
+		c, s.newBootstrapCommand(),
 		"devcontroller", "dummy-cloud/region-1",
 		"--config", "default-series=raring",
 		"--config", "agent-stream=proposed",
@@ -756,7 +767,7 @@ func (s *BootstrapSuite) TestBootstrapDestroy(c *gc.C) {
 	s.patchVersion(c)
 
 	opc, errc := cmdtesting.RunCommand(
-		cmdtesting.NullContext(c), newBootstrapCommand(),
+		cmdtesting.NullContext(c), s.newBootstrapCommand(),
 		"devcontroller", "dummy-cloud/region-1",
 		"--config", "broken=Bootstrap Destroy",
 		"--auto-upgrade",
@@ -783,7 +794,7 @@ func (s *BootstrapSuite) TestBootstrapKeepBroken(c *gc.C) {
 	resetJujuXDGDataHome(c)
 	s.patchVersion(c)
 
-	opc, errc := cmdtesting.RunCommand(cmdtesting.NullContext(c), newBootstrapCommand(),
+	opc, errc := cmdtesting.RunCommand(cmdtesting.NullContext(c), s.newBootstrapCommand(),
 		"--keep-broken",
 		"devcontroller", "dummy-cloud/region-1",
 		"--config", "broken=Bootstrap Destroy",
@@ -812,19 +823,19 @@ func (s *BootstrapSuite) TestBootstrapKeepBroken(c *gc.C) {
 
 func (s *BootstrapSuite) TestBootstrapUnknownCloudOrProvider(c *gc.C) {
 	s.patchVersionAndSeries(c, "raring")
-	_, err := coretesting.RunCommand(c, newBootstrapCommand(), "ctrl", "no-such-provider")
+	_, err := coretesting.RunCommand(c, s.newBootstrapCommand(), "ctrl", "no-such-provider")
 	c.Assert(err, gc.ErrorMatches, `cloud "no-such-provider" not found`)
 }
 
 func (s *BootstrapSuite) TestBootstrapProviderNoRegionDetection(c *gc.C) {
 	s.patchVersionAndSeries(c, "raring")
-	_, err := coretesting.RunCommand(c, newBootstrapCommand(), "ctrl", "no-cloud-region-detection")
+	_, err := coretesting.RunCommand(c, s.newBootstrapCommand(), "ctrl", "no-cloud-region-detection")
 	c.Assert(err, gc.ErrorMatches, `cloud "no-cloud-region-detection" not found`)
 }
 
 func (s *BootstrapSuite) TestBootstrapProviderNoRegions(c *gc.C) {
 	ctx, err := coretesting.RunCommand(
-		c, newBootstrapCommand(), "ctrl", "no-cloud-regions",
+		c, s.newBootstrapCommand(), "ctrl", "no-cloud-regions",
 		"--config", "default-series=precise",
 	)
 	c.Check(coretesting.Stderr(ctx), gc.Matches, "Creating Juju controller \"ctrl\" on no-cloud-regions(.|\n)*")
@@ -834,7 +845,7 @@ func (s *BootstrapSuite) TestBootstrapProviderNoRegions(c *gc.C) {
 func (s *BootstrapSuite) TestBootstrapCloudNoRegions(c *gc.C) {
 	resetJujuXDGDataHome(c)
 	ctx, err := coretesting.RunCommand(
-		c, newBootstrapCommand(), "ctrl", "dummy-cloud-without-regions",
+		c, s.newBootstrapCommand(), "ctrl", "dummy-cloud-without-regions",
 		"--config", "default-series=precise",
 	)
 	c.Check(coretesting.Stderr(ctx), gc.Matches, "Creating Juju controller \"ctrl\" on dummy-cloud-without-regions(.|\n)*")
@@ -844,7 +855,7 @@ func (s *BootstrapSuite) TestBootstrapCloudNoRegions(c *gc.C) {
 func (s *BootstrapSuite) TestBootstrapCloudNoRegionsOneSpecified(c *gc.C) {
 	resetJujuXDGDataHome(c)
 	ctx, err := coretesting.RunCommand(
-		c, newBootstrapCommand(), "ctrl", "dummy-cloud-without-regions/my-region",
+		c, s.newBootstrapCommand(), "ctrl", "dummy-cloud-without-regions/my-region",
 		"--config", "default-series=precise",
 	)
 	// If the cloud doesn't have any regions defined, we still allow the
@@ -859,13 +870,13 @@ func (s *BootstrapSuite) TestBootstrapCloudNoRegionsOneSpecified(c *gc.C) {
 
 func (s *BootstrapSuite) TestBootstrapProviderNoCredentials(c *gc.C) {
 	s.patchVersionAndSeries(c, "raring")
-	_, err := coretesting.RunCommand(c, newBootstrapCommand(), "ctrl", "no-credentials")
+	_, err := coretesting.RunCommand(c, s.newBootstrapCommand(), "ctrl", "no-credentials")
 	c.Assert(err, gc.ErrorMatches, `detecting credentials for "no-credentials" cloud provider: credentials not found`)
 }
 
 func (s *BootstrapSuite) TestBootstrapProviderDetectRegions(c *gc.C) {
 	s.patchVersionAndSeries(c, "raring")
-	_, err := coretesting.RunCommand(c, newBootstrapCommand(), "ctrl", "dummy/not-dummy")
+	_, err := coretesting.RunCommand(c, s.newBootstrapCommand(), "ctrl", "dummy/not-dummy")
 	c.Assert(err, gc.ErrorMatches, `region "not-dummy" in cloud "dummy" not found \(expected one of \["dummy"\]\)`)
 }
 
@@ -877,7 +888,7 @@ func (s *BootstrapSuite) TestBootstrapConfigFile(c *gc.C) {
 
 	s.patchVersionAndSeries(c, "raring")
 	_, err = coretesting.RunCommand(
-		c, newBootstrapCommand(), "ctrl", "dummy",
+		c, s.newBootstrapCommand(), "ctrl", "dummy",
 		"--config", configFile,
 	)
 	c.Assert(err, gc.ErrorMatches, `controller: expected bool, got string.*`)
@@ -897,7 +908,7 @@ func (s *BootstrapSuite) TestBootstrapMultipleConfigFiles(c *gc.C) {
 
 	s.patchVersionAndSeries(c, "raring")
 	_, err = coretesting.RunCommand(
-		c, newBootstrapCommand(), "ctrl", "dummy",
+		c, s.newBootstrapCommand(), "ctrl", "dummy",
 		"--auto-upgrade",
 		// the second config file should replace attributes
 		// with the same name from the first, but leave the
@@ -916,7 +927,7 @@ func (s *BootstrapSuite) TestBootstrapConfigFileAndAdHoc(c *gc.C) {
 
 	s.patchVersionAndSeries(c, "raring")
 	_, err = coretesting.RunCommand(
-		c, newBootstrapCommand(), "ctrl", "dummy",
+		c, s.newBootstrapCommand(), "ctrl", "dummy",
 		"--auto-upgrade",
 		// Configuration specified on the command line overrides
 		// anything specified in files, no matter what the order.

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -55,7 +55,7 @@ type BootstrapSuite struct {
 	testing.MgoSuite
 	envtesting.ToolsFixture
 	mockBlockClient *mockBlockClient
-	store           jujuclient.CredentialsStore
+	store           jujuclient.CredentialStore
 	legacyMemStore  configstore.Storage
 }
 
@@ -127,7 +127,7 @@ func (s *BootstrapSuite) TearDownTest(c *gc.C) {
 
 func (s *BootstrapSuite) newBootstrapCommand() cmd.Command {
 	return modelcmd.Wrap(&bootstrapCommand{
-		credentialsStore: s.store,
+		CredentialStore: s.store,
 	})
 }
 
@@ -497,7 +497,7 @@ func (s *BootstrapSuite) TestBootstrapPropagatesStoreErrors(c *gc.C) {
 
 	store := jujuclienttesting.NewStubStore()
 	store.SetErrors(errors.New("oh noes"))
-	cmd := &bootstrapCommand{credentialsStore: store}
+	cmd := &bootstrapCommand{CredentialStore: store}
 	cmd.SetClientStore(store)
 	_, err := coretesting.RunCommand(c, modelcmd.Wrap(cmd), controllerName, "dummy", "--auto-upgrade")
 	c.Assert(err, gc.ErrorMatches, `loading credentials: oh noes`)

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -489,7 +489,7 @@ func (s *BootstrapSuite) TestBootstrapPropagatesStoreErrors(c *gc.C) {
 	cmd := &bootstrapCommand{}
 	cmd.SetClientStore(store)
 	_, err := coretesting.RunCommand(c, modelcmd.Wrap(cmd), controllerName, "dummy", "--auto-upgrade")
-	c.Assert(err, gc.ErrorMatches, `error reading controller "devcontroller" info: oh noes`)
+	c.Assert(err, gc.ErrorMatches, `loading credentials: oh noes`)
 }
 
 // When attempting to bootstrap, check that when prepare errors out,
@@ -1046,6 +1046,6 @@ func (noCredentialsProvider) DetectRegions() ([]cloud.Region, error) {
 	return []cloud.Region{{Name: "region"}}, nil
 }
 
-func (noCredentialsProvider) DetectCredentials() ([]cloud.Credential, error) {
+func (noCredentialsProvider) DetectCredentials() ([]environs.NamedCredential, error) {
 	return nil, errors.NotFoundf("credentials")
 }

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -1046,6 +1046,6 @@ func (noCredentialsProvider) DetectRegions() ([]cloud.Region, error) {
 	return []cloud.Region{{Name: "region"}}, nil
 }
 
-func (noCredentialsProvider) DetectCredentials() ([]environs.NamedCredential, error) {
+func (noCredentialsProvider) DetectCredentials() ([]environs.LabeledCredential, error) {
 	return nil, errors.NotFoundf("credentials")
 }

--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -262,6 +262,7 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 	r.Register(cloud.NewShowCloudCommand())
 	r.Register(cloud.NewAddCloudCommand())
 	r.Register(cloud.NewListCredentialsCommand())
+	r.Register(cloud.NewDetectCredentialsCommand())
 
 	// Commands registered elsewhere.
 	for _, newCommand := range registeredCommands {

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -207,6 +207,7 @@ var commandNames = []string{
 	"add-storage",
 	"add-subnet",
 	"add-user",
+	"autoload-credentials",
 	"backups",
 	"block",
 	"bootstrap",

--- a/environs/interface.go
+++ b/environs/interface.go
@@ -77,12 +77,13 @@ type PrepareForBootstrapParams struct {
 	CloudStorageEndpoint string
 }
 
-// NamedCredential defines a cloud credential with a label.
+// LabeledCredential defines a cloud credential with a label
 // The label may come from a well known config file for the
 // cloud, where credentials are listed for named users, or may
 // be empty if just a set of credential attributes are known.
-type NamedCredential struct {
-	// Label is an optional tag defining who owns the credential.
+type LabeledCredential struct {
+	// Label is an optional tag defining the origin of the credential.
+	// Typically this is the user to whom the credential belongs.
 	Label string
 
 	// Credential is the credential value.
@@ -110,7 +111,7 @@ type ProviderCredentials interface {
 	//
 	// If no credentials can be detected, DetectCredentials should
 	// return an error satisfying errors.IsNotFound.
-	DetectCredentials() ([]NamedCredential, error)
+	DetectCredentials() ([]LabeledCredential, error)
 }
 
 // CloudRegionDetector is an interface that an EnvironProvider implements

--- a/environs/interface.go
+++ b/environs/interface.go
@@ -77,6 +77,18 @@ type PrepareForBootstrapParams struct {
 	CloudStorageEndpoint string
 }
 
+// NamedCredential defines a cloud credential with a label.
+// The label may come from a well known config file for the
+// cloud, where credentials are listed for named users, or may
+// be empty if just a set of credential attributes are known.
+type NamedCredential struct {
+	// Label is an optional tag defining who owns the credential.
+	Label string
+
+	// Credential is the credential value.
+	Credential cloud.Credential
+}
+
 // ProviderCredentials is an interface that an EnvironProvider implements
 // in order to validate and automatically detect credentials for clouds
 // supported by the provider.
@@ -98,7 +110,7 @@ type ProviderCredentials interface {
 	//
 	// If no credentials can be detected, DetectCredentials should
 	// return an error satisfying errors.IsNotFound.
-	DetectCredentials() ([]cloud.Credential, error)
+	DetectCredentials() ([]NamedCredential, error)
 }
 
 // CloudRegionDetector is an interface that an EnvironProvider implements

--- a/jujuclient/credentials.go
+++ b/jujuclient/credentials.go
@@ -1,0 +1,56 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package jujuclient
+
+import (
+	"io/ioutil"
+	"os"
+
+	"github.com/juju/errors"
+	"github.com/juju/utils"
+	"gopkg.in/yaml.v2"
+
+	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/juju/osenv"
+)
+
+// JujuCredentialsPath is the location where controllers information is
+// expected to be found.
+func JujuCredentialsPath() string {
+	return osenv.JujuXDGDataHomePath("credentials.yaml")
+}
+
+// ReadCredentialsFile loads all credentials defined in a given file.
+// If the file is not found, it is not an error.
+func ReadCredentialsFile(file string) (map[string]cloud.CloudCredential, error) {
+	data, err := ioutil.ReadFile(file)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	credentials, err := cloud.ParseCredentials(data)
+	if err != nil {
+		return nil, err
+	}
+	return credentials, nil
+}
+
+// WriteCredentialsFile marshals to YAML details of the given credentials
+// and writes it to the credentials file.
+func WriteCredentialsFile(credentials map[string]cloud.CloudCredential) error {
+	data, err := yaml.Marshal(credentialsCollection{credentials})
+	if err != nil {
+		return errors.Annotate(err, "cannot marshal yaml credentials")
+	}
+	return utils.AtomicWriteFile(JujuCredentialsPath(), data, os.FileMode(0600))
+}
+
+// credentialsCollection is a struct containing cloud credential information,
+// used marshalling and unmarshalling.
+type credentialsCollection struct {
+	// Credentials is a map of cloud credentials, keyed on cloud name.
+	Credentials map[string]cloud.CloudCredential `yaml:"credentials"`
+}

--- a/jujuclient/credentials_test.go
+++ b/jujuclient/credentials_test.go
@@ -23,7 +23,7 @@ var _ = gc.Suite(&CredentialsSuite{})
 
 func (s *CredentialsSuite) SetUpTest(c *gc.C) {
 	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
-	s.store = jujuclient.NewFileClientStore()
+	s.store = jujuclient.NewFileCredentialsStore()
 	s.cloudName = "testcloud"
 	s.credentials = cloud.CloudCredential{
 		DefaultCredential: "peter",
@@ -53,7 +53,7 @@ func (s *CredentialsSuite) TestCredentialsForCloud(c *gc.C) {
 	found, err := s.store.CredentialsForCloud(name)
 	c.Assert(err, jc.ErrorIsNil)
 	expected := s.getCredentials(c)[name]
-	c.Assert(found, gc.DeepEquals, expected)
+	c.Assert(found, gc.DeepEquals, &expected)
 }
 
 func (s *CredentialsSuite) TestUpdateCredentialsAddFirst(c *gc.C) {
@@ -84,10 +84,10 @@ func (s *CredentialsSuite) assertCredentialsNotExists(c *gc.C) {
 }
 
 func (s *CredentialsSuite) assertUpdateSucceeded(c *gc.C) {
-	c.Assert(s.getCredentials(c)[s.cloudName], gc.DeepEquals, &s.credentials)
+	c.Assert(s.getCredentials(c)[s.cloudName], gc.DeepEquals, s.credentials)
 }
 
-func (s *CredentialsSuite) getCredentials(c *gc.C) map[string]*cloud.CloudCredential {
+func (s *CredentialsSuite) getCredentials(c *gc.C) map[string]cloud.CloudCredential {
 	credentials, err := s.store.AllCredentials()
 	c.Assert(err, jc.ErrorIsNil)
 	return credentials

--- a/jujuclient/credentials_test.go
+++ b/jujuclient/credentials_test.go
@@ -1,0 +1,102 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package jujuclient_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/jujuclient"
+	"github.com/juju/juju/testing"
+)
+
+type CredentialsSuite struct {
+	testing.FakeJujuXDGDataHomeSuite
+	store       jujuclient.CredentialsStore
+	cloudName   string
+	credentials cloud.CloudCredential
+}
+
+var _ = gc.Suite(&CredentialsSuite{})
+
+func (s *CredentialsSuite) SetUpTest(c *gc.C) {
+	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
+	s.store = jujuclient.NewFileClientStore()
+	s.cloudName = "testcloud"
+	s.credentials = cloud.CloudCredential{
+		DefaultCredential: "peter",
+		DefaultRegion:     "east",
+		AuthCredentials: map[string]cloud.Credential{
+			"peter": cloud.NewCredential(cloud.AccessKeyAuthType, nil),
+			"paul":  cloud.NewCredential(cloud.AccessKeyAuthType, nil),
+		},
+	}
+}
+
+func (s *CredentialsSuite) TestCredentialsForCloudNoFile(c *gc.C) {
+	found, err := s.store.CredentialsForCloud(s.cloudName)
+	c.Assert(err, gc.ErrorMatches, "credentials for cloud testcloud not found")
+	c.Assert(found, gc.IsNil)
+}
+
+func (s *CredentialsSuite) TestCredentialsForCloudNoneExists(c *gc.C) {
+	writeTestCredentialsFile(c)
+	found, err := s.store.CredentialsForCloud(s.cloudName)
+	c.Assert(err, gc.ErrorMatches, "credentials for cloud testcloud not found")
+	c.Assert(found, gc.IsNil)
+}
+
+func (s *CredentialsSuite) TestCredentialsForCloud(c *gc.C) {
+	name := firstTestCloudName(c)
+	found, err := s.store.CredentialsForCloud(name)
+	c.Assert(err, jc.ErrorIsNil)
+	expected := s.getCredentials(c)[name]
+	c.Assert(found, gc.DeepEquals, expected)
+}
+
+func (s *CredentialsSuite) TestUpdateCredentialsAddFirst(c *gc.C) {
+	err := s.store.UpdateCredentials(s.cloudName, s.credentials)
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertUpdateSucceeded(c)
+}
+
+func (s *CredentialsSuite) TestUpdateCredentialsAddNew(c *gc.C) {
+	s.assertCredentialsNotExists(c)
+	err := s.store.UpdateCredentials(s.cloudName, s.credentials)
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertUpdateSucceeded(c)
+}
+
+func (s *CredentialsSuite) TestUpdateCredentials(c *gc.C) {
+	s.cloudName = firstTestCloudName(c)
+
+	err := s.store.UpdateCredentials(s.cloudName, s.credentials)
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertUpdateSucceeded(c)
+}
+
+func (s *CredentialsSuite) assertCredentialsNotExists(c *gc.C) {
+	all := writeTestCredentialsFile(c)
+	_, exists := all[s.cloudName]
+	c.Assert(exists, jc.IsFalse)
+}
+
+func (s *CredentialsSuite) assertUpdateSucceeded(c *gc.C) {
+	c.Assert(s.getCredentials(c)[s.cloudName], gc.DeepEquals, &s.credentials)
+}
+
+func (s *CredentialsSuite) getCredentials(c *gc.C) map[string]*cloud.CloudCredential {
+	credentials, err := s.store.AllCredentials()
+	c.Assert(err, jc.ErrorIsNil)
+	return credentials
+}
+
+func firstTestCloudName(c *gc.C) string {
+	all := writeTestCredentialsFile(c)
+	for key, _ := range all {
+		return key
+	}
+	return ""
+}

--- a/jujuclient/credentials_test.go
+++ b/jujuclient/credentials_test.go
@@ -14,7 +14,7 @@ import (
 
 type CredentialsSuite struct {
 	testing.FakeJujuXDGDataHomeSuite
-	store       jujuclient.CredentialsStore
+	store       jujuclient.CredentialStore
 	cloudName   string
 	credentials cloud.CloudCredential
 }
@@ -23,7 +23,7 @@ var _ = gc.Suite(&CredentialsSuite{})
 
 func (s *CredentialsSuite) SetUpTest(c *gc.C) {
 	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
-	s.store = jujuclient.NewFileCredentialsStore()
+	s.store = jujuclient.NewFileCredentialStore()
 	s.cloudName = "testcloud"
 	s.credentials = cloud.CloudCredential{
 		DefaultCredential: "peter",
@@ -35,44 +35,44 @@ func (s *CredentialsSuite) SetUpTest(c *gc.C) {
 	}
 }
 
-func (s *CredentialsSuite) TestCredentialsForCloudNoFile(c *gc.C) {
-	found, err := s.store.CredentialsForCloud(s.cloudName)
+func (s *CredentialsSuite) TestCredentialForCloudNoFile(c *gc.C) {
+	found, err := s.store.CredentialForCloud(s.cloudName)
 	c.Assert(err, gc.ErrorMatches, "credentials for cloud testcloud not found")
 	c.Assert(found, gc.IsNil)
 }
 
-func (s *CredentialsSuite) TestCredentialsForCloudNoneExists(c *gc.C) {
+func (s *CredentialsSuite) TestCredentialForCloudNoneExists(c *gc.C) {
 	writeTestCredentialsFile(c)
-	found, err := s.store.CredentialsForCloud(s.cloudName)
+	found, err := s.store.CredentialForCloud(s.cloudName)
 	c.Assert(err, gc.ErrorMatches, "credentials for cloud testcloud not found")
 	c.Assert(found, gc.IsNil)
 }
 
-func (s *CredentialsSuite) TestCredentialsForCloud(c *gc.C) {
+func (s *CredentialsSuite) TestCredentialForCloud(c *gc.C) {
 	name := firstTestCloudName(c)
-	found, err := s.store.CredentialsForCloud(name)
+	found, err := s.store.CredentialForCloud(name)
 	c.Assert(err, jc.ErrorIsNil)
 	expected := s.getCredentials(c)[name]
 	c.Assert(found, gc.DeepEquals, &expected)
 }
 
-func (s *CredentialsSuite) TestUpdateCredentialsAddFirst(c *gc.C) {
-	err := s.store.UpdateCredentials(s.cloudName, s.credentials)
+func (s *CredentialsSuite) TestUpdateCredentialAddFirst(c *gc.C) {
+	err := s.store.UpdateCredential(s.cloudName, s.credentials)
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertUpdateSucceeded(c)
 }
 
-func (s *CredentialsSuite) TestUpdateCredentialsAddNew(c *gc.C) {
+func (s *CredentialsSuite) TestUpdateCredentialAddNew(c *gc.C) {
 	s.assertCredentialsNotExists(c)
-	err := s.store.UpdateCredentials(s.cloudName, s.credentials)
+	err := s.store.UpdateCredential(s.cloudName, s.credentials)
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertUpdateSucceeded(c)
 }
 
-func (s *CredentialsSuite) TestUpdateCredentials(c *gc.C) {
+func (s *CredentialsSuite) TestUpdateCredential(c *gc.C) {
 	s.cloudName = firstTestCloudName(c)
 
-	err := s.store.UpdateCredentials(s.cloudName, s.credentials)
+	err := s.store.UpdateCredential(s.cloudName, s.credentials)
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertUpdateSucceeded(c)
 }

--- a/jujuclient/credentialsfile_test.go
+++ b/jujuclient/credentialsfile_test.go
@@ -59,8 +59,8 @@ func (s *CredentialsFileSuite) TestReadEmptyFile(c *gc.C) {
 	err := ioutil.WriteFile(osenv.JujuXDGDataHomePath("credentials.yaml"), []byte(""), 0600)
 	c.Assert(err, jc.ErrorIsNil)
 
-	credentialstore := jujuclient.NewFileCredentialsStore()
-	_, err = credentialstore.CredentialsForCloud("foo")
+	credentialstore := jujuclient.NewFileCredentialStore()
+	_, err = credentialstore.CredentialForCloud("foo")
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
 

--- a/jujuclient/credentialsfile_test.go
+++ b/jujuclient/credentialsfile_test.go
@@ -59,7 +59,7 @@ func (s *CredentialsFileSuite) TestReadEmptyFile(c *gc.C) {
 	err := ioutil.WriteFile(osenv.JujuXDGDataHomePath("credentials.yaml"), []byte(""), 0600)
 	c.Assert(err, jc.ErrorIsNil)
 
-	credentialstore := jujuclient.NewFileClientStore()
+	credentialstore := jujuclient.NewFileCredentialsStore()
 	_, err = credentialstore.CredentialsForCloud("foo")
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }

--- a/jujuclient/credentialsfile_test.go
+++ b/jujuclient/credentialsfile_test.go
@@ -1,0 +1,78 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package jujuclient_test
+
+import (
+	"io/ioutil"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/errors"
+	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/juju/osenv"
+	"github.com/juju/juju/jujuclient"
+	"github.com/juju/juju/testing"
+)
+
+type CredentialsFileSuite struct {
+	testing.FakeJujuXDGDataHomeSuite
+}
+
+var _ = gc.Suite(&CredentialsFileSuite{})
+
+const testCredentialsYAML = `
+credentials:
+  aws:
+    default-credential: peter
+    default-region: us-west-2
+    paul:
+      auth-type: access-key
+      access-key: paul-key
+      secret-key: paul-secret
+    peter:
+      auth-type: access-key
+      access-key: key
+      secret-key: secret
+  aws-gov:
+    fbi:
+      auth-type: access-key
+      access-key: key
+      secret-key: secret
+`
+
+func (s *CredentialsFileSuite) TestWriteFile(c *gc.C) {
+	writeTestCredentialsFile(c)
+	data, err := ioutil.ReadFile(osenv.JujuXDGDataHomePath("credentials.yaml"))
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(string(data), gc.Equals, testCredentialsYAML[1:])
+}
+
+func (s *CredentialsFileSuite) TestReadNoFile(c *gc.C) {
+	credentials, err := jujuclient.ReadCredentialsFile("nohere.yaml")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(credentials, gc.IsNil)
+}
+
+func (s *CredentialsFileSuite) TestReadEmptyFile(c *gc.C) {
+	err := ioutil.WriteFile(osenv.JujuXDGDataHomePath("credentials.yaml"), []byte(""), 0600)
+	c.Assert(err, jc.ErrorIsNil)
+
+	credentialstore := jujuclient.NewFileClientStore()
+	_, err = credentialstore.CredentialsForCloud("foo")
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+}
+
+func parseCredentials(c *gc.C) map[string]cloud.CloudCredential {
+	credentials, err := cloud.ParseCredentials([]byte(testCredentialsYAML))
+	c.Assert(err, jc.ErrorIsNil)
+	return credentials
+}
+
+func writeTestCredentialsFile(c *gc.C) map[string]cloud.CloudCredential {
+	credentials := parseCredentials(c)
+	err := jujuclient.WriteCredentialsFile(credentials)
+	c.Assert(err, jc.ErrorIsNil)
+	return credentials
+}

--- a/jujuclient/file.go
+++ b/jujuclient/file.go
@@ -35,9 +35,9 @@ func NewFileClientStore() ClientStore {
 	return &store{}
 }
 
-// NewFileCredentialsStore returns a new filesystem-based credentials store
+// NewFileCredentialStore returns a new filesystem-based credentials store
 // that manages credentials in $XDG_DATA_HOME/juju.
-func NewFileCredentialsStore() CredentialsStore {
+func NewFileCredentialStore() CredentialStore {
 	return &store{}
 }
 
@@ -647,8 +647,8 @@ func (s *store) RemoveAccount(controllerName, accountName string) error {
 	return errors.Trace(WriteAccountsFile(controllerAccounts))
 }
 
-// UpdateCredentials implements CredentialsUpdater.
-func (s *store) UpdateCredentials(cloudName string, details cloud.CloudCredential) error {
+// UpdateCredential implements CredentialUpdater.
+func (s *store) UpdateCredential(cloudName string, details cloud.CloudCredential) error {
 	lock, err := s.lock("update-credentials")
 	if err != nil {
 		return errors.Annotatef(err, "cannot update credentials for %v", cloudName)
@@ -668,8 +668,8 @@ func (s *store) UpdateCredentials(cloudName string, details cloud.CloudCredentia
 	return WriteCredentialsFile(all)
 }
 
-// CredentialsForCloud implements CredentialsGetter.
-func (s *store) CredentialsForCloud(cloudName string) (*cloud.CloudCredential, error) {
+// CredentialForCloud implements CredentialGetter.
+func (s *store) CredentialForCloud(cloudName string) (*cloud.CloudCredential, error) {
 	cloudCredentials, err := s.AllCredentials()
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -681,7 +681,7 @@ func (s *store) CredentialsForCloud(cloudName string) (*cloud.CloudCredential, e
 	return &credentials, nil
 }
 
-// AllCredentials implements CredentialsGetter.
+// AllCredentials implements CredentialGetter.
 func (s *store) AllCredentials() (map[string]cloud.CloudCredential, error) {
 	cloudCredentials, err := ReadCredentialsFile(JujuCredentialsPath())
 	if err != nil {

--- a/jujuclient/file.go
+++ b/jujuclient/file.go
@@ -35,6 +35,12 @@ func NewFileClientStore() ClientStore {
 	return &store{}
 }
 
+// NewFileCredentialsStore returns a new filesystem-based credentials store
+// that manages credentials in $XDG_DATA_HOME/juju.
+func NewFileCredentialsStore() CredentialsStore {
+	return &store{}
+}
+
 type store struct{}
 
 func (s *store) lock(operation string) (*fslock.Lock, error) {

--- a/jujuclient/interface.go
+++ b/jujuclient/interface.go
@@ -40,7 +40,7 @@ type AccountDetails struct {
 type CredentialsGetter interface {
 	// CredentialsForCloud gets credentials for the named cloud.
 	CredentialsForCloud(string) (*cloud.CloudCredential, error)
-	
+
 	// AllCredentials gets all credentials.
 	AllCredentials() (map[string]cloud.CloudCredential, error)
 }

--- a/jujuclient/interface.go
+++ b/jujuclient/interface.go
@@ -3,6 +3,8 @@
 
 package jujuclient
 
+import "github.com/juju/juju/cloud"
+
 // ControllerDetails holds the details needed to connect to a controller.
 type ControllerDetails struct {
 	// Servers contains the addresses of hosts that form the Juju controller
@@ -32,6 +34,25 @@ type AccountDetails struct {
 
 	// Password is the password for the account.
 	Password string `yaml:"password,omitempty"`
+}
+
+// CredentialsGetter gets credentials.
+type CredentialsGetter interface {
+	// CredentialsForCloud gets credentials for the named cloud.
+	CredentialsForCloud(string) (*cloud.CloudCredential, error)
+	
+	// AllCredentials gets all credentials.
+	AllCredentials() (map[string]cloud.CloudCredential, error)
+}
+
+// CredentialUpdater stores credentials.
+type CredentialUpdater interface {
+	// UpdateCredentials adds the given credentials to the credentials
+	// collection.
+	//
+	// If the cloud or credential name does not already exist, it will be added.
+	// Otherwise, it will be overwritten with the new details.
+	UpdateCredentials(cloudName string, details cloud.CloudCredential) error
 }
 
 // ControllerUpdater stores controller details.
@@ -176,9 +197,16 @@ type AccountStore interface {
 	AccountGetter
 }
 
+// CredentialsStore is an amalgamation of CredentialsUpdater, and CredentialsGetter.
+type CredentialsStore interface {
+	CredentialsGetter
+	CredentialUpdater
+}
+
 // ClientStore is an amalgamation of AccountStore, ControllerStore, and ModelStore.
 type ClientStore interface {
 	AccountStore
 	ControllerStore
 	ModelStore
+	CredentialsStore
 }

--- a/jujuclient/interface.go
+++ b/jujuclient/interface.go
@@ -187,8 +187,8 @@ type ClientStore interface {
 
 // CredentialGetter gets credentials.
 type CredentialGetter interface {
-	// CredentialsForCloud gets credentials for the named cloud.
-	CredentialsForCloud(string) (*cloud.CloudCredential, error)
+	// CredentialForCloud gets credentials for the named cloud.
+	CredentialForCloud(string) (*cloud.CloudCredential, error)
 
 	// AllCredentials gets all credentials.
 	AllCredentials() (map[string]cloud.CloudCredential, error)
@@ -196,16 +196,16 @@ type CredentialGetter interface {
 
 // CredentialUpdater stores credentials.
 type CredentialUpdater interface {
-	// UpdateCredentials adds the given credentials to the credentials
+	// UpdateCredential adds the given credentials to the credentials
 	// collection.
 	//
 	// If the cloud or credential name does not already exist, it will be added.
 	// Otherwise, it will be overwritten with the new details.
-	UpdateCredentials(cloudName string, details cloud.CloudCredential) error
+	UpdateCredential(cloudName string, details cloud.CloudCredential) error
 }
 
-// CredentialsStore is an amalgamation of CredentialsUpdater, and CredentialsGetter.
-type CredentialsStore interface {
+// CredentialStore is an amalgamation of CredentialsUpdater, and CredentialsGetter.
+type CredentialStore interface {
 	CredentialGetter
 	CredentialUpdater
 }

--- a/jujuclient/interface.go
+++ b/jujuclient/interface.go
@@ -36,25 +36,6 @@ type AccountDetails struct {
 	Password string `yaml:"password,omitempty"`
 }
 
-// CredentialsGetter gets credentials.
-type CredentialsGetter interface {
-	// CredentialsForCloud gets credentials for the named cloud.
-	CredentialsForCloud(string) (*cloud.CloudCredential, error)
-
-	// AllCredentials gets all credentials.
-	AllCredentials() (map[string]cloud.CloudCredential, error)
-}
-
-// CredentialUpdater stores credentials.
-type CredentialUpdater interface {
-	// UpdateCredentials adds the given credentials to the credentials
-	// collection.
-	//
-	// If the cloud or credential name does not already exist, it will be added.
-	// Otherwise, it will be overwritten with the new details.
-	UpdateCredentials(cloudName string, details cloud.CloudCredential) error
-}
-
 // ControllerUpdater stores controller details.
 type ControllerUpdater interface {
 	// UpdateController adds the given controller to the controller
@@ -197,16 +178,34 @@ type AccountStore interface {
 	AccountGetter
 }
 
-// CredentialsStore is an amalgamation of CredentialsUpdater, and CredentialsGetter.
-type CredentialsStore interface {
-	CredentialsGetter
-	CredentialUpdater
-}
-
 // ClientStore is an amalgamation of AccountStore, ControllerStore, and ModelStore.
 type ClientStore interface {
 	AccountStore
 	ControllerStore
 	ModelStore
-	CredentialsStore
+}
+
+// CredentialGetter gets credentials.
+type CredentialGetter interface {
+	// CredentialsForCloud gets credentials for the named cloud.
+	CredentialsForCloud(string) (*cloud.CloudCredential, error)
+
+	// AllCredentials gets all credentials.
+	AllCredentials() (map[string]cloud.CloudCredential, error)
+}
+
+// CredentialUpdater stores credentials.
+type CredentialUpdater interface {
+	// UpdateCredentials adds the given credentials to the credentials
+	// collection.
+	//
+	// If the cloud or credential name does not already exist, it will be added.
+	// Otherwise, it will be overwritten with the new details.
+	UpdateCredentials(cloudName string, details cloud.CloudCredential) error
+}
+
+// CredentialsStore is an amalgamation of CredentialsUpdater, and CredentialsGetter.
+type CredentialsStore interface {
+	CredentialGetter
+	CredentialUpdater
 }

--- a/jujuclient/jujuclienttesting/mem.go
+++ b/jujuclient/jujuclienttesting/mem.go
@@ -330,14 +330,14 @@ func (c *MemStore) RemoveAccount(controllerName, accountName string) error {
 	return nil
 }
 
-// UpdateCredentials implements CredentialsUpdater.
-func (c *MemStore) UpdateCredentials(cloudName string, details cloud.CloudCredential) error {
+// UpdateCredential implements CredentialsUpdater.
+func (c *MemStore) UpdateCredential(cloudName string, details cloud.CloudCredential) error {
 	c.Credentials[cloudName] = details
 	return nil
 }
 
-// CredentialsForCloud implements CredentialsGetter.
-func (c *MemStore) CredentialsForCloud(cloudName string) (*cloud.CloudCredential, error) {
+// CredentialForCloud implements CredentialsGetter.
+func (c *MemStore) CredentialForCloud(cloudName string) (*cloud.CloudCredential, error) {
 	if result, ok := c.Credentials[cloudName]; ok {
 		return &result, nil
 	}

--- a/jujuclient/jujuclienttesting/mem.go
+++ b/jujuclient/jujuclienttesting/mem.go
@@ -6,6 +6,7 @@ package jujuclienttesting
 import (
 	"github.com/juju/errors"
 
+	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/jujuclient"
 )
 
@@ -15,6 +16,7 @@ type MemStore struct {
 	Controllers map[string]jujuclient.ControllerDetails
 	Models      map[string]jujuclient.ControllerAccountModels
 	Accounts    map[string]*jujuclient.ControllerAccounts
+	Credentials map[string]cloud.CloudCredential
 }
 
 func NewMemStore() *MemStore {
@@ -22,6 +24,7 @@ func NewMemStore() *MemStore {
 		make(map[string]jujuclient.ControllerDetails),
 		make(map[string]jujuclient.ControllerAccountModels),
 		make(map[string]*jujuclient.ControllerAccounts),
+		make(map[string]cloud.CloudCredential),
 	}
 }
 
@@ -325,4 +328,27 @@ func (c *MemStore) RemoveAccount(controllerName, accountName string) error {
 	}
 	delete(accounts.Accounts, accountName)
 	return nil
+}
+
+// UpdateCredentials implements CredentialsUpdater.
+func (c *MemStore) UpdateCredentials(cloudName string, details cloud.CloudCredential) error {
+	c.Credentials[cloudName] = details
+	return nil
+}
+
+// CredentialsForCloud implements CredentialsGetter.
+func (c *MemStore) CredentialsForCloud(cloudName string) (*cloud.CloudCredential, error) {
+	if result, ok := c.Credentials[cloudName]; ok {
+		return &result, nil
+	}
+	return nil, errors.NotFoundf("credentials for cloud %s", cloudName)
+}
+
+// AllCredentials implements CredentialsGetter.
+func (c *MemStore) AllCredentials() (map[string]cloud.CloudCredential, error) {
+	result := make(map[string]cloud.CloudCredential)
+	for k, v := range c.Credentials {
+		result[k] = v
+	}
+	return result, nil
 }

--- a/jujuclient/jujuclienttesting/stub.go
+++ b/jujuclient/jujuclienttesting/stub.go
@@ -32,9 +32,9 @@ type StubStore struct {
 	AccountByNameFunc     func(controllerName, accountName string) (*jujuclient.AccountDetails, error)
 	RemoveAccountFunc     func(controllerName, accountName string) error
 
-	CredentialsForCloudFunc func(string) (*cloud.CloudCredential, error)
+	CredentialForCloudFunc func(string) (*cloud.CloudCredential, error)
 	AllCredentialsFunc      func() (map[string]cloud.CloudCredential, error)
-	UpdateCredentialsFunc   func(cloudName string, details cloud.CloudCredential) error
+	UpdateCredentialFunc   func(cloudName string, details cloud.CloudCredential) error
 }
 
 func NewStubStore() *StubStore {
@@ -92,13 +92,13 @@ func NewStubStore() *StubStore {
 		return result.Stub.NextErr()
 	}
 
-	result.CredentialsForCloudFunc = func(string) (*cloud.CloudCredential, error) {
+	result.CredentialForCloudFunc = func(string) (*cloud.CloudCredential, error) {
 		return nil, result.Stub.NextErr()
 	}
 	result.AllCredentialsFunc = func() (map[string]cloud.CloudCredential, error) {
 		return nil, result.Stub.NextErr()
 	}
-	result.UpdateCredentialsFunc = func(cloudName string, details cloud.CloudCredential) error {
+	result.UpdateCredentialFunc = func(cloudName string, details cloud.CloudCredential) error {
 		return result.Stub.NextErr()
 	}
 	return result
@@ -200,10 +200,10 @@ func (c *StubStore) RemoveAccount(controllerName, accountName string) error {
 	return c.RemoveAccountFunc(controllerName, accountName)
 }
 
-// CredentialsForCloud implements CredentialsGetter.
-func (c *StubStore) CredentialsForCloud(cloudName string) (*cloud.CloudCredential, error) {
-	c.MethodCall(c, "CredentialsForCloud", cloudName)
-	return c.CredentialsForCloudFunc(cloudName)
+// CredentialForCloud implements CredentialsGetter.
+func (c *StubStore) CredentialForCloud(cloudName string) (*cloud.CloudCredential, error) {
+	c.MethodCall(c, "CredentialForCloud", cloudName)
+	return c.CredentialForCloudFunc(cloudName)
 }
 
 // AllCredentials implements CredentialsGetter.
@@ -212,8 +212,8 @@ func (c *StubStore) AllCredentials() (map[string]cloud.CloudCredential, error) {
 	return c.AllCredentialsFunc()
 }
 
-// UpdateCredentials implements CredentialsUpdater.
-func (c *StubStore) UpdateCredentials(cloudName string, details cloud.CloudCredential) error {
-	c.MethodCall(c, "UpdateCredentials", cloudName, details)
-	return c.UpdateCredentialsFunc(cloudName, details)
+// UpdateCredential implements CredentialsUpdater.
+func (c *StubStore) UpdateCredential(cloudName string, details cloud.CloudCredential) error {
+	c.MethodCall(c, "UpdateCredential", cloudName, details)
+	return c.UpdateCredentialFunc(cloudName, details)
 }

--- a/jujuclient/jujuclienttesting/stub.go
+++ b/jujuclient/jujuclienttesting/stub.go
@@ -33,7 +33,7 @@ type StubStore struct {
 	RemoveAccountFunc     func(controllerName, accountName string) error
 
 	CredentialForCloudFunc func(string) (*cloud.CloudCredential, error)
-	AllCredentialsFunc      func() (map[string]cloud.CloudCredential, error)
+	AllCredentialsFunc     func() (map[string]cloud.CloudCredential, error)
 	UpdateCredentialFunc   func(cloudName string, details cloud.CloudCredential) error
 }
 

--- a/jujuclient/jujuclienttesting/stub.go
+++ b/jujuclient/jujuclienttesting/stub.go
@@ -26,11 +26,11 @@ type StubStore struct {
 	ModelByNameFunc     func(controller, account, model string) (*jujuclient.ModelDetails, error)
 
 	UpdateAccountFunc     func(controllerName, accountName string, details jujuclient.AccountDetails) error
-	SetCurrentAccountFunc   func(controllerName, accountName string) error
-	AllAccountsFunc         func(controllerName string) (map[string]jujuclient.AccountDetails, error)
-	CurrentAccountFunc      func(controllerName string) (string, error)
-	AccountByNameFunc       func(controllerName, accountName string) (*jujuclient.AccountDetails, error)
-	RemoveAccountFunc       func(controllerName, accountName string) error
+	SetCurrentAccountFunc func(controllerName, accountName string) error
+	AllAccountsFunc       func(controllerName string) (map[string]jujuclient.AccountDetails, error)
+	CurrentAccountFunc    func(controllerName string) (string, error)
+	AccountByNameFunc     func(controllerName, accountName string) (*jujuclient.AccountDetails, error)
+	RemoveAccountFunc     func(controllerName, accountName string) error
 
 	CredentialsForCloudFunc func(string) (*cloud.CloudCredential, error)
 	AllCredentialsFunc      func() (map[string]cloud.CloudCredential, error)

--- a/jujuclient/jujuclienttesting/stub.go
+++ b/jujuclient/jujuclienttesting/stub.go
@@ -6,6 +6,7 @@ package jujuclienttesting
 import (
 	"github.com/juju/testing"
 
+	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/jujuclient"
 )
 
@@ -25,11 +26,15 @@ type StubStore struct {
 	ModelByNameFunc     func(controller, account, model string) (*jujuclient.ModelDetails, error)
 
 	UpdateAccountFunc     func(controllerName, accountName string, details jujuclient.AccountDetails) error
-	SetCurrentAccountFunc func(controllerName, accountName string) error
-	AllAccountsFunc       func(controllerName string) (map[string]jujuclient.AccountDetails, error)
-	CurrentAccountFunc    func(controllerName string) (string, error)
-	AccountByNameFunc     func(controllerName, accountName string) (*jujuclient.AccountDetails, error)
-	RemoveAccountFunc     func(controllerName, accountName string) error
+	SetCurrentAccountFunc   func(controllerName, accountName string) error
+	AllAccountsFunc         func(controllerName string) (map[string]jujuclient.AccountDetails, error)
+	CurrentAccountFunc      func(controllerName string) (string, error)
+	AccountByNameFunc       func(controllerName, accountName string) (*jujuclient.AccountDetails, error)
+	RemoveAccountFunc       func(controllerName, accountName string) error
+
+	CredentialsForCloudFunc func(string) (*cloud.CloudCredential, error)
+	AllCredentialsFunc      func() (map[string]cloud.CloudCredential, error)
+	UpdateCredentialsFunc   func(cloudName string, details cloud.CloudCredential) error
 }
 
 func NewStubStore() *StubStore {
@@ -87,6 +92,15 @@ func NewStubStore() *StubStore {
 		return result.Stub.NextErr()
 	}
 
+	result.CredentialsForCloudFunc = func(string) (*cloud.CloudCredential, error) {
+		return nil, result.Stub.NextErr()
+	}
+	result.AllCredentialsFunc = func() (map[string]cloud.CloudCredential, error) {
+		return nil, result.Stub.NextErr()
+	}
+	result.UpdateCredentialsFunc = func(cloudName string, details cloud.CloudCredential) error {
+		return result.Stub.NextErr()
+	}
 	return result
 }
 
@@ -184,4 +198,22 @@ func (c *StubStore) AccountByName(controllerName, accountName string) (*jujuclie
 func (c *StubStore) RemoveAccount(controllerName, accountName string) error {
 	c.MethodCall(c, "RemoveAccount", controllerName, accountName)
 	return c.RemoveAccountFunc(controllerName, accountName)
+}
+
+// CredentialsForCloud implements CredentialsGetter.
+func (c *StubStore) CredentialsForCloud(cloudName string) (*cloud.CloudCredential, error) {
+	c.MethodCall(c, "CredentialsForCloud", cloudName)
+	return c.CredentialsForCloudFunc(cloudName)
+}
+
+// AllCredentials implements CredentialsGetter.
+func (c *StubStore) AllCredentials() (map[string]cloud.CloudCredential, error) {
+	c.MethodCall(c, "AllCredentials")
+	return c.AllCredentialsFunc()
+}
+
+// UpdateCredentials implements CredentialsUpdater.
+func (c *StubStore) UpdateCredentials(cloudName string, details cloud.CloudCredential) error {
+	c.MethodCall(c, "UpdateCredentials", cloudName, details)
+	return c.UpdateCredentialsFunc(cloudName, details)
 }

--- a/provider/azure/credentials.go
+++ b/provider/azure/credentials.go
@@ -7,6 +7,7 @@ import (
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/environs"
 )
 
 // environPoviderCredentials is an implementation of
@@ -36,6 +37,6 @@ func (environProviderCredentials) CredentialSchemas() map[cloud.AuthType]cloud.C
 }
 
 // DetectCredentials is part of the environs.ProviderCredentials interface.
-func (environProviderCredentials) DetectCredentials() ([]cloud.Credential, error) {
+func (environProviderCredentials) DetectCredentials() ([]environs.NamedCredential, error) {
 	return nil, errors.NotFoundf("credentials")
 }

--- a/provider/azure/credentials.go
+++ b/provider/azure/credentials.go
@@ -37,6 +37,6 @@ func (environProviderCredentials) CredentialSchemas() map[cloud.AuthType]cloud.C
 }
 
 // DetectCredentials is part of the environs.ProviderCredentials interface.
-func (environProviderCredentials) DetectCredentials() ([]environs.NamedCredential, error) {
+func (environProviderCredentials) DetectCredentials() ([]environs.LabeledCredential, error) {
 	return nil, errors.NotFoundf("credentials")
 }

--- a/provider/cloudsigma/credentials.go
+++ b/provider/cloudsigma/credentials.go
@@ -27,6 +27,6 @@ func (environProviderCredentials) CredentialSchemas() map[cloud.AuthType]cloud.C
 }
 
 // DetectCredentials is part of the environs.ProviderCredentials interface.
-func (environProviderCredentials) DetectCredentials() ([]environs.NamedCredential, error) {
+func (environProviderCredentials) DetectCredentials() ([]environs.LabeledCredential, error) {
 	return nil, errors.NotFoundf("credentials")
 }

--- a/provider/cloudsigma/credentials.go
+++ b/provider/cloudsigma/credentials.go
@@ -6,6 +6,7 @@ package cloudsigma
 import (
 	"github.com/juju/errors"
 	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/environs"
 )
 
 type environProviderCredentials struct{}
@@ -26,6 +27,6 @@ func (environProviderCredentials) CredentialSchemas() map[cloud.AuthType]cloud.C
 }
 
 // DetectCredentials is part of the environs.ProviderCredentials interface.
-func (environProviderCredentials) DetectCredentials() ([]cloud.Credential, error) {
+func (environProviderCredentials) DetectCredentials() ([]environs.NamedCredential, error) {
 	return nil, errors.NotFoundf("credentials")
 }

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -514,8 +514,8 @@ func (p *environProvider) CredentialSchemas() map[cloud.AuthType]cloud.Credentia
 	return map[cloud.AuthType]cloud.CredentialSchema{cloud.EmptyAuthType: {}}
 }
 
-func (*environProvider) DetectCredentials() ([]environs.NamedCredential, error) {
-	return []environs.NamedCredential{{Credential: cloud.NewEmptyCredential()}}, nil
+func (*environProvider) DetectCredentials() ([]environs.LabeledCredential, error) {
+	return []environs.LabeledCredential{{Credential: cloud.NewEmptyCredential()}}, nil
 }
 
 func (*environProvider) DetectRegions() ([]cloud.Region, error) {

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -514,8 +514,8 @@ func (p *environProvider) CredentialSchemas() map[cloud.AuthType]cloud.Credentia
 	return map[cloud.AuthType]cloud.CredentialSchema{cloud.EmptyAuthType: {}}
 }
 
-func (*environProvider) DetectCredentials() ([]cloud.Credential, error) {
-	return []cloud.Credential{cloud.NewEmptyCredential()}, nil
+func (*environProvider) DetectCredentials() ([]environs.NamedCredential, error) {
+	return []environs.NamedCredential{{Credential: cloud.NewEmptyCredential()}}, nil
 }
 
 func (*environProvider) DetectRegions() ([]cloud.Region, error) {

--- a/provider/ec2/credentials.go
+++ b/provider/ec2/credentials.go
@@ -29,7 +29,7 @@ func (environProviderCredentials) CredentialSchemas() map[cloud.AuthType]cloud.C
 }
 
 // DetectCredentials is part of the environs.ProviderCredentials interface.
-func (environProviderCredentials) DetectCredentials() ([]environs.NamedCredential, error) {
+func (environProviderCredentials) DetectCredentials() ([]environs.LabeledCredential, error) {
 	// TODO(axw) check for credentials file as described at
 	// http://blogs.aws.amazon.com/security/post/Tx3D6U6WSFGOK2H/A-New-and-Standardized-Way-to-Manage-Credentials-in-the-AWS-SDKs
 	auth, err := aws.EnvAuth()
@@ -43,5 +43,5 @@ func (environProviderCredentials) DetectCredentials() ([]environs.NamedCredentia
 			"secret-key": auth.SecretKey,
 		},
 	)
-	return []environs.NamedCredential{{Credential: accessKeyCredential}}, nil
+	return []environs.LabeledCredential{{Credential: accessKeyCredential}}, nil
 }

--- a/provider/ec2/credentials.go
+++ b/provider/ec2/credentials.go
@@ -8,6 +8,7 @@ import (
 	"gopkg.in/amz.v3/aws"
 
 	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/environs"
 )
 
 type environProviderCredentials struct{}
@@ -28,7 +29,7 @@ func (environProviderCredentials) CredentialSchemas() map[cloud.AuthType]cloud.C
 }
 
 // DetectCredentials is part of the environs.ProviderCredentials interface.
-func (environProviderCredentials) DetectCredentials() ([]cloud.Credential, error) {
+func (environProviderCredentials) DetectCredentials() ([]environs.NamedCredential, error) {
 	// TODO(axw) check for credentials file as described at
 	// http://blogs.aws.amazon.com/security/post/Tx3D6U6WSFGOK2H/A-New-and-Standardized-Way-to-Manage-Credentials-in-the-AWS-SDKs
 	auth, err := aws.EnvAuth()
@@ -42,5 +43,5 @@ func (environProviderCredentials) DetectCredentials() ([]cloud.Credential, error
 			"secret-key": auth.SecretKey,
 		},
 	)
-	return []cloud.Credential{accessKeyCredential}, nil
+	return []environs.NamedCredential{{Credential: accessKeyCredential}}, nil
 }

--- a/provider/ec2/credentials_test.go
+++ b/provider/ec2/credentials_test.go
@@ -58,10 +58,12 @@ func (s *credentialsSuite) TestDetectCredentialsEnvironmentVariables(c *gc.C) {
 	credentials, err := s.provider.DetectCredentials()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(credentials, gc.HasLen, 1)
-	c.Assert(credentials[0], jc.DeepEquals, cloud.NewCredential(
-		cloud.AccessKeyAuthType, map[string]string{
-			"access-key": "key-id",
-			"secret-key": "secret-access-key",
-		},
-	))
+	c.Assert(credentials[0], jc.DeepEquals, environs.NamedCredential{
+		Credential: cloud.NewCredential(
+			cloud.AccessKeyAuthType, map[string]string{
+				"access-key": "key-id",
+				"secret-key": "secret-access-key",
+			},
+		),
+	})
 }

--- a/provider/ec2/credentials_test.go
+++ b/provider/ec2/credentials_test.go
@@ -58,7 +58,7 @@ func (s *credentialsSuite) TestDetectCredentialsEnvironmentVariables(c *gc.C) {
 	credentials, err := s.provider.DetectCredentials()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(credentials, gc.HasLen, 1)
-	c.Assert(credentials[0], jc.DeepEquals, environs.NamedCredential{
+	c.Assert(credentials[0], jc.DeepEquals, environs.LabeledCredential{
 		Credential: cloud.NewCredential(
 			cloud.AccessKeyAuthType, map[string]string{
 				"access-key": "key-id",

--- a/provider/gce/credentials.go
+++ b/provider/gce/credentials.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/environs"
 	"github.com/juju/juju/provider/gce/google"
 )
 
@@ -40,7 +41,7 @@ func (environProviderCredentials) CredentialSchemas() map[cloud.AuthType]cloud.C
 }
 
 // DetectCredentials is part of the environs.ProviderCredentials interface.
-func (environProviderCredentials) DetectCredentials() ([]cloud.Credential, error) {
+func (environProviderCredentials) DetectCredentials() ([]environs.NamedCredential, error) {
 	return nil, errors.NotFoundf("credentials")
 }
 

--- a/provider/gce/credentials.go
+++ b/provider/gce/credentials.go
@@ -41,7 +41,7 @@ func (environProviderCredentials) CredentialSchemas() map[cloud.AuthType]cloud.C
 }
 
 // DetectCredentials is part of the environs.ProviderCredentials interface.
-func (environProviderCredentials) DetectCredentials() ([]environs.NamedCredential, error) {
+func (environProviderCredentials) DetectCredentials() ([]environs.LabeledCredential, error) {
 	return nil, errors.NotFoundf("credentials")
 }
 

--- a/provider/joyent/credentials.go
+++ b/provider/joyent/credentials.go
@@ -43,6 +43,6 @@ func (environProviderCredentials) CredentialSchemas() map[cloud.AuthType]cloud.C
 }
 
 // DetectCredentials is part of the environs.ProviderCredentials interface.
-func (environProviderCredentials) DetectCredentials() ([]environs.NamedCredential, error) {
+func (environProviderCredentials) DetectCredentials() ([]environs.LabeledCredential, error) {
 	return nil, errors.NotFoundf("credentials")
 }

--- a/provider/joyent/credentials.go
+++ b/provider/joyent/credentials.go
@@ -7,6 +7,7 @@ import (
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/environs"
 )
 
 type environProviderCredentials struct{}
@@ -42,6 +43,6 @@ func (environProviderCredentials) CredentialSchemas() map[cloud.AuthType]cloud.C
 }
 
 // DetectCredentials is part of the environs.ProviderCredentials interface.
-func (environProviderCredentials) DetectCredentials() ([]cloud.Credential, error) {
+func (environProviderCredentials) DetectCredentials() ([]environs.NamedCredential, error) {
 	return nil, errors.NotFoundf("credentials")
 }

--- a/provider/lxd/credentials.go
+++ b/provider/lxd/credentials.go
@@ -5,7 +5,10 @@
 
 package lxd
 
-import "github.com/juju/juju/cloud"
+import (
+	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/environs"
+)
 
 type environProviderCredentials struct{}
 
@@ -15,7 +18,7 @@ func (environProviderCredentials) CredentialSchemas() map[cloud.AuthType]cloud.C
 }
 
 // DetectCredentials is part of the environs.ProviderCredentials interface.
-func (environProviderCredentials) DetectCredentials() ([]cloud.Credential, error) {
+func (environProviderCredentials) DetectCredentials() ([]environs.NamedCredential, error) {
 	emptyCredential := cloud.NewEmptyCredential()
-	return []cloud.Credential{emptyCredential}, nil
+	return []environs.NamedCredential{{Credential: emptyCredential}}, nil
 }

--- a/provider/lxd/credentials.go
+++ b/provider/lxd/credentials.go
@@ -18,7 +18,7 @@ func (environProviderCredentials) CredentialSchemas() map[cloud.AuthType]cloud.C
 }
 
 // DetectCredentials is part of the environs.ProviderCredentials interface.
-func (environProviderCredentials) DetectCredentials() ([]environs.NamedCredential, error) {
+func (environProviderCredentials) DetectCredentials() ([]environs.LabeledCredential, error) {
 	emptyCredential := cloud.NewEmptyCredential()
-	return []environs.NamedCredential{{Credential: emptyCredential}}, nil
+	return []environs.LabeledCredential{{Credential: emptyCredential}}, nil
 }

--- a/provider/lxd/credentials_test.go
+++ b/provider/lxd/credentials_test.go
@@ -36,5 +36,5 @@ func (s *credentialsSuite) TestDetectCredentials(c *gc.C) {
 	credentials, err := s.provider.DetectCredentials()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(credentials, gc.HasLen, 1)
-	c.Assert(credentials[0], jc.DeepEquals, cloud.NewEmptyCredential())
+	c.Assert(credentials[0], jc.DeepEquals, environs.NamedCredential{Credential: cloud.NewEmptyCredential()})
 }

--- a/provider/lxd/credentials_test.go
+++ b/provider/lxd/credentials_test.go
@@ -36,5 +36,5 @@ func (s *credentialsSuite) TestDetectCredentials(c *gc.C) {
 	credentials, err := s.provider.DetectCredentials()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(credentials, gc.HasLen, 1)
-	c.Assert(credentials[0], jc.DeepEquals, environs.NamedCredential{Credential: cloud.NewEmptyCredential()})
+	c.Assert(credentials[0], jc.DeepEquals, environs.LabeledCredential{Credential: cloud.NewEmptyCredential()})
 }

--- a/provider/maas/credentials.go
+++ b/provider/maas/credentials.go
@@ -6,6 +6,7 @@ package maas
 import (
 	"github.com/juju/errors"
 	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/environs"
 )
 
 type environProviderCredentials struct{}
@@ -23,7 +24,7 @@ func (environProviderCredentials) CredentialSchemas() map[cloud.AuthType]cloud.C
 }
 
 // DetectCredentials is part of the environs.ProviderCredentials interface.
-func (environProviderCredentials) DetectCredentials() ([]cloud.Credential, error) {
+func (environProviderCredentials) DetectCredentials() ([]environs.NamedCredential, error) {
 	// TODO(axw) find out where the MAAS CLI stores credentials.
 	return nil, errors.NotFoundf("credentials")
 }

--- a/provider/maas/credentials.go
+++ b/provider/maas/credentials.go
@@ -24,7 +24,7 @@ func (environProviderCredentials) CredentialSchemas() map[cloud.AuthType]cloud.C
 }
 
 // DetectCredentials is part of the environs.ProviderCredentials interface.
-func (environProviderCredentials) DetectCredentials() ([]environs.NamedCredential, error) {
+func (environProviderCredentials) DetectCredentials() ([]environs.LabeledCredential, error) {
 	// TODO(axw) find out where the MAAS CLI stores credentials.
 	return nil, errors.NotFoundf("credentials")
 }

--- a/provider/manual/credentials.go
+++ b/provider/manual/credentials.go
@@ -3,7 +3,10 @@
 
 package manual
 
-import "github.com/juju/juju/cloud"
+import (
+	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/environs"
+)
 
 type environProviderCredentials struct{}
 
@@ -13,7 +16,7 @@ func (environProviderCredentials) CredentialSchemas() map[cloud.AuthType]cloud.C
 }
 
 // DetectCredentials is part of the environs.ProviderCredentials interface.
-func (environProviderCredentials) DetectCredentials() ([]cloud.Credential, error) {
+func (environProviderCredentials) DetectCredentials() ([]environs.NamedCredential, error) {
 	emptyCredential := cloud.NewEmptyCredential()
-	return []cloud.Credential{emptyCredential}, nil
+	return []environs.NamedCredential{{Credential: emptyCredential}}, nil
 }

--- a/provider/manual/credentials.go
+++ b/provider/manual/credentials.go
@@ -16,7 +16,7 @@ func (environProviderCredentials) CredentialSchemas() map[cloud.AuthType]cloud.C
 }
 
 // DetectCredentials is part of the environs.ProviderCredentials interface.
-func (environProviderCredentials) DetectCredentials() ([]environs.NamedCredential, error) {
+func (environProviderCredentials) DetectCredentials() ([]environs.LabeledCredential, error) {
 	emptyCredential := cloud.NewEmptyCredential()
-	return []environs.NamedCredential{{Credential: emptyCredential}}, nil
+	return []environs.LabeledCredential{{Credential: emptyCredential}}, nil
 }

--- a/provider/manual/credentials_test.go
+++ b/provider/manual/credentials_test.go
@@ -36,5 +36,5 @@ func (s *credentialsSuite) TestDetectCredentials(c *gc.C) {
 	credentials, err := s.provider.DetectCredentials()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(credentials, gc.HasLen, 1)
-	c.Assert(credentials[0], jc.DeepEquals, cloud.NewEmptyCredential())
+	c.Assert(credentials[0], jc.DeepEquals, environs.NamedCredential{Credential: cloud.NewEmptyCredential()})
 }

--- a/provider/manual/credentials_test.go
+++ b/provider/manual/credentials_test.go
@@ -36,5 +36,5 @@ func (s *credentialsSuite) TestDetectCredentials(c *gc.C) {
 	credentials, err := s.provider.DetectCredentials()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(credentials, gc.HasLen, 1)
-	c.Assert(credentials[0], jc.DeepEquals, environs.NamedCredential{Credential: cloud.NewEmptyCredential()})
+	c.Assert(credentials[0], jc.DeepEquals, environs.LabeledCredential{Credential: cloud.NewEmptyCredential()})
 }

--- a/provider/openstack/credentials.go
+++ b/provider/openstack/credentials.go
@@ -10,6 +10,7 @@ import (
 	"gopkg.in/goose.v1/identity"
 
 	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/environs"
 )
 
 type OpenstackCredentials struct{}
@@ -45,7 +46,7 @@ func (OpenstackCredentials) CredentialSchemas() map[cloud.AuthType]cloud.Credent
 }
 
 // DetectCredentials is part of the environs.ProviderCredentials interface.
-func (OpenstackCredentials) DetectCredentials() ([]cloud.Credential, error) {
+func (OpenstackCredentials) DetectCredentials() ([]environs.NamedCredential, error) {
 	creds := identity.CredentialsFromEnv()
 	if creds.TenantName == "" {
 		return nil, errors.NewNotFound(nil, "OS_TENANT_NAME environment variable not set")
@@ -77,5 +78,5 @@ func (OpenstackCredentials) DetectCredentials() ([]cloud.Credential, error) {
 			},
 		)
 	}
-	return []cloud.Credential{credential}, nil
+	return []environs.NamedCredential{{Credential: credential}}, nil
 }

--- a/provider/openstack/credentials.go
+++ b/provider/openstack/credentials.go
@@ -46,7 +46,7 @@ func (OpenstackCredentials) CredentialSchemas() map[cloud.AuthType]cloud.Credent
 }
 
 // DetectCredentials is part of the environs.ProviderCredentials interface.
-func (OpenstackCredentials) DetectCredentials() ([]environs.NamedCredential, error) {
+func (OpenstackCredentials) DetectCredentials() ([]environs.LabeledCredential, error) {
 	creds := identity.CredentialsFromEnv()
 	if creds.TenantName == "" {
 		return nil, errors.NewNotFound(nil, "OS_TENANT_NAME environment variable not set")
@@ -78,5 +78,5 @@ func (OpenstackCredentials) DetectCredentials() ([]environs.NamedCredential, err
 			},
 		)
 	}
-	return []environs.NamedCredential{{Credential: credential}}, nil
+	return []environs.LabeledCredential{{Credential: credential}}, nil
 }

--- a/provider/openstack/credentials_test.go
+++ b/provider/openstack/credentials_test.go
@@ -72,7 +72,7 @@ func (s *credentialsSuite) TestDetectCredentialsAccessKeyEnvironmentVariables(c 
 	credentials, err := s.provider.DetectCredentials()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(credentials, gc.HasLen, 1)
-	c.Assert(credentials[0], jc.DeepEquals, environs.NamedCredential{Credential: cloud.NewCredential(
+	c.Assert(credentials[0], jc.DeepEquals, environs.LabeledCredential{Credential: cloud.NewCredential(
 		cloud.AccessKeyAuthType, map[string]string{
 			"access-key":  "key-id",
 			"secret-key":  "secret-access-key",
@@ -89,7 +89,7 @@ func (s *credentialsSuite) TestDetectCredentialsUserPassEnvironmentVariables(c *
 	credentials, err := s.provider.DetectCredentials()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(credentials, gc.HasLen, 1)
-	c.Assert(credentials[0], jc.DeepEquals, environs.NamedCredential{Credential: cloud.NewCredential(
+	c.Assert(credentials[0], jc.DeepEquals, environs.LabeledCredential{Credential: cloud.NewCredential(
 		cloud.UserPassAuthType, map[string]string{
 			"username":    "bob",
 			"password":    "dobbs",

--- a/provider/openstack/credentials_test.go
+++ b/provider/openstack/credentials_test.go
@@ -72,13 +72,13 @@ func (s *credentialsSuite) TestDetectCredentialsAccessKeyEnvironmentVariables(c 
 	credentials, err := s.provider.DetectCredentials()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(credentials, gc.HasLen, 1)
-	c.Assert(credentials[0], jc.DeepEquals, cloud.NewCredential(
+	c.Assert(credentials[0], jc.DeepEquals, environs.NamedCredential{Credential: cloud.NewCredential(
 		cloud.AccessKeyAuthType, map[string]string{
 			"access-key":  "key-id",
 			"secret-key":  "secret-access-key",
 			"tenant-name": "gary",
 		},
-	))
+	)})
 }
 
 func (s *credentialsSuite) TestDetectCredentialsUserPassEnvironmentVariables(c *gc.C) {
@@ -89,11 +89,11 @@ func (s *credentialsSuite) TestDetectCredentialsUserPassEnvironmentVariables(c *
 	credentials, err := s.provider.DetectCredentials()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(credentials, gc.HasLen, 1)
-	c.Assert(credentials[0], jc.DeepEquals, cloud.NewCredential(
+	c.Assert(credentials[0], jc.DeepEquals, environs.NamedCredential{Credential: cloud.NewCredential(
 		cloud.UserPassAuthType, map[string]string{
 			"username":    "bob",
 			"password":    "dobbs",
 			"tenant-name": "gary",
 		},
-	))
+	)})
 }

--- a/provider/rackspace/provider_test.go
+++ b/provider/rackspace/provider_test.go
@@ -86,7 +86,7 @@ func (p *fakeProvider) CredentialSchemas() map[cloud.AuthType]cloud.CredentialSc
 	return nil
 }
 
-func (p *fakeProvider) DetectCredentials() ([]environs.NamedCredential, error) {
+func (p *fakeProvider) DetectCredentials() ([]environs.LabeledCredential, error) {
 	p.Push("DetectCredentials")
 	return nil, errors.NotFoundf("credentials")
 }

--- a/provider/rackspace/provider_test.go
+++ b/provider/rackspace/provider_test.go
@@ -86,7 +86,7 @@ func (p *fakeProvider) CredentialSchemas() map[cloud.AuthType]cloud.CredentialSc
 	return nil
 }
 
-func (p *fakeProvider) DetectCredentials() ([]cloud.Credential, error) {
+func (p *fakeProvider) DetectCredentials() ([]environs.NamedCredential, error) {
 	p.Push("DetectCredentials")
 	return nil, errors.NotFoundf("credentials")
 }

--- a/provider/vsphere/credentials.go
+++ b/provider/vsphere/credentials.go
@@ -30,6 +30,6 @@ func (environProviderCredentials) CredentialSchemas() map[cloud.AuthType]cloud.C
 }
 
 // DetectCredentials is part of the environs.ProviderCredentials interface.
-func (environProviderCredentials) DetectCredentials() ([]environs.NamedCredential, error) {
+func (environProviderCredentials) DetectCredentials() ([]environs.LabeledCredential, error) {
 	return nil, errors.NotFoundf("credentials")
 }

--- a/provider/vsphere/credentials.go
+++ b/provider/vsphere/credentials.go
@@ -9,6 +9,7 @@ import (
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/environs"
 )
 
 type environProviderCredentials struct{}
@@ -29,6 +30,6 @@ func (environProviderCredentials) CredentialSchemas() map[cloud.AuthType]cloud.C
 }
 
 // DetectCredentials is part of the environs.ProviderCredentials interface.
-func (environProviderCredentials) DetectCredentials() ([]cloud.Credential, error) {
+func (environProviderCredentials) DetectCredentials() ([]environs.NamedCredential, error) {
 	return nil, errors.NotFoundf("credentials")
 }


### PR DESCRIPTION
An first cut autoload-crdentials command is added. As part of this, some other improvements were made:

- credentials.yaml access has been added to jujuclient.ClientStore
(and old code removed)

The EnvironProvider DetectCredentials method now returns a slice of NamedCredential. A NamedCredential is just a Crdential with a label. This label is option but if provided will be used to give the credentials a name in the yaml file. Otherwise we'll fallback to using the current user (not implemented yet). This allows providers like aws that can detect multiple credentials to be able to update the yaml file accordingly.
 

(Review request: http://reviews.vapour.ws/r/3954/)