### PR TITLE
Update api calls whitelist.

### DIFF
--- a/apiserver/export_test.go
+++ b/apiserver/export_test.go
@@ -22,10 +22,11 @@ import (
 )
 
 var (
-	NewPingTimeout        = newPingTimeout
-	MaxClientPingInterval = &maxClientPingInterval
-	MongoPingInterval     = &mongoPingInterval
-	NewBackups            = &newBackups
+	NewPingTimeout               = newPingTimeout
+	MaxClientPingInterval        = &maxClientPingInterval
+	MongoPingInterval            = &mongoPingInterval
+	NewBackups                   = &newBackups
+	AllowedMethodsDuringUpgrades = allowedMethodsDuringUpgrades
 )
 
 func ServerMacaroon(srv *Server) (*macaroon.Macaroon, error) {

--- a/apiserver/upgrading_root.go
+++ b/apiserver/upgrading_root.go
@@ -60,7 +60,7 @@ func (r *upgradingRoot) FindMethod(rootName string, version int, methodName stri
 		return nil, err
 	}
 	if !IsMethodAllowedDuringUpgrade(rootName, methodName) {
-		logger.Warningf("Facade (%v) method (%v) was called during the upgrade but it was blocked.\n", rootName, methodName)
+		logger.Debugf("Facade (%v) method (%v) was called during the upgrade but it was blocked.\n", rootName, methodName)
 		return nil, inUpgradeError
 	}
 	return caller, nil

--- a/apiserver/upgrading_root.go
+++ b/apiserver/upgrading_root.go
@@ -24,19 +24,32 @@ func newUpgradingRoot(finder rpc.MethodFinder) *upgradingRoot {
 
 var inUpgradeError = errors.New("upgrade in progress - Juju functionality is limited")
 
-var allowedMethodsDuringUpgrades = set.NewStrings(
-	"FullStatus",     // for "juju status"
-	"ModelGet",       // for "juju ssh"
-	"PrivateAddress", // for "juju ssh"
-	"PublicAddress",  // for "juju ssh"
-	"WatchDebugLog",  // for "juju debug-log"
-)
+// allowedMethodsDuringUpgrades stores api calls
+// that are not blocked during the upgrade process
+// as well as  their respective facade names.
+// When needed, at some future point, this solution
+// will need to be adjusted to cater for different
+// facade versions as well.
+var allowedMethodsDuringUpgrades = map[string]set.Strings{
+	"Client": set.NewStrings(
+		"FullStatus",          // for "juju status"
+		"ModelGet",            // for "juju ssh"
+		"PrivateAddress",      // for "juju ssh"
+		"PublicAddress",       // for "juju ssh"
+		"FindTools",           // for "juju upgrade-juju", before we can reset upgrade to re-run
+		"AbortCurrentUpgrade", // for "juju upgrade-juju", so that we can reset upgrade to re-run
+	),
+	"Pinger": set.NewStrings(
+		"Ping",
+	),
+}
 
 func IsMethodAllowedDuringUpgrade(rootName, methodName string) bool {
-	if rootName != "Client" {
+	methods, ok := allowedMethodsDuringUpgrades[rootName]
+	if !ok {
 		return false
 	}
-	return allowedMethodsDuringUpgrades.Contains(methodName)
+	return methods.Contains(methodName)
 }
 
 // FindMethod returns inUpgradeError for most API calls except those that are
@@ -47,6 +60,7 @@ func (r *upgradingRoot) FindMethod(rootName string, version int, methodName stri
 		return nil, err
 	}
 	if !IsMethodAllowedDuringUpgrade(rootName, methodName) {
+		logger.Warningf("Facade (%v) method (%v) was called during the upgrade but it was blocked.\n", rootName, methodName)
 		return nil, inUpgradeError
 	}
 	return caller, nil

--- a/apiserver/upgrading_root_test.go
+++ b/apiserver/upgrading_root_test.go
@@ -20,13 +20,14 @@ var _ = gc.Suite(&upgradingRootSuite{})
 func (r *upgradingRootSuite) TestClientMethods(c *gc.C) {
 	root := apiserver.TestingUpgradingRoot(nil)
 
-	for _, method := range []string{
-		"FullStatus", "ModelGet", "PrivateAddress",
-		"PublicAddress",
-	} {
-		caller, err := root.FindMethod("Client", 1, method)
-		c.Check(err, jc.ErrorIsNil)
-		c.Check(caller, gc.NotNil)
+	for facadeName, methods := range apiserver.AllowedMethodsDuringUpgrades {
+		for _, method := range methods.Values() {
+			// for now all of the api calls of interest,
+			// reside on version 1 of their respective facade.
+			caller, err := root.FindMethod(facadeName, 1, method)
+			c.Check(err, jc.ErrorIsNil)
+			c.Check(caller, gc.NotNil)
+		}
 	}
 }
 


### PR DESCRIPTION
During upgrade, juju blocks most of API calls. Calls that are allowed to run are white-listed, for e.g. calls that allow status to be shown.

This PR updates this white-listing to match current reality.

(Review request: http://reviews.vapour.ws/r/3957/)