### PR TITLE
1.25: Update api calls whitelist.

### DIFF
--- a/apiserver/export_test.go
+++ b/apiserver/export_test.go
@@ -27,6 +27,8 @@ var (
 	ParseLogLine          = parseLogLine
 	AgentMatchesFilter    = agentMatchesFilter
 	NewLogTailer          = &newLogTailer
+
+	AllowedMethodsDuringUpgrades = allowedMethodsDuringUpgrades
 )
 
 func ApiHandlerWithEntity(entity state.Entity) *apiHandler {

--- a/apiserver/upgrading_root.go
+++ b/apiserver/upgrading_root.go
@@ -57,7 +57,7 @@ func (r *upgradingRoot) FindMethod(rootName string, version int, methodName stri
 		return nil, err
 	}
 	if !IsMethodAllowedDuringUpgrade(rootName, methodName) {
-		logger.Warningf("Facade (%v) method (%v) was called during the upgrade but it was blocked.\n", rootName, methodName)
+		logger.Debugf("Facade (%v) method (%v) was called during the upgrade but it was blocked.\n", rootName, methodName)
 		return nil, inUpgradeError
 	}
 	return caller, nil

--- a/apiserver/upgrading_root.go
+++ b/apiserver/upgrading_root.go
@@ -24,19 +24,29 @@ func newUpgradingRoot(finder rpc.MethodFinder) *upgradingRoot {
 
 var inUpgradeError = errors.New("upgrade in progress - Juju functionality is limited")
 
-var allowedMethodsDuringUpgrades = set.NewStrings(
-	"FullStatus",     // for "juju status"
-	"EnvironmentGet", // for "juju ssh"
-	"PrivateAddress", // for "juju ssh"
-	"PublicAddress",  // for "juju ssh"
-	"WatchDebugLog",  // for "juju debug-log"
-)
+// allowedMethodsDuringUpgrades stores api calls
+// that are not blocked during the upgrade process
+// as well as  their respective facade names.
+var allowedMethodsDuringUpgrades = map[string]set.Strings{
+	"Client": set.NewStrings(
+		"FullStatus",          // for "juju status"
+		"EnvironmentGet",      // for "juju ssh"
+		"PrivateAddress",      // for "juju ssh"
+		"PublicAddress",       // for "juju ssh"
+		"FindTools",           // for "juju upgrade-juju", before we can reset upgrade to re-run
+		"AbortCurrentUpgrade", // for "juju upgrade-juju", so that we can reset upgrade to re-run
+	),
+	"Pinger": set.NewStrings(
+		"Ping",
+	),
+}
 
 func IsMethodAllowedDuringUpgrade(rootName, methodName string) bool {
-	if rootName != "Client" {
+	methods, ok := allowedMethodsDuringUpgrades[rootName]
+	if !ok {
 		return false
 	}
-	return allowedMethodsDuringUpgrades.Contains(methodName)
+	return methods.Contains(methodName)
 }
 
 // FindMethod returns inUpgradeError for most API calls except those that are
@@ -47,6 +57,7 @@ func (r *upgradingRoot) FindMethod(rootName string, version int, methodName stri
 		return nil, err
 	}
 	if !IsMethodAllowedDuringUpgrade(rootName, methodName) {
+		logger.Warningf("Facade (%v) method (%v) was called during the upgrade but it was blocked.\n", rootName, methodName)
 		return nil, inUpgradeError
 	}
 	return caller, nil

--- a/apiserver/upgrading_root_test.go
+++ b/apiserver/upgrading_root_test.go
@@ -20,13 +20,14 @@ var _ = gc.Suite(&upgradingRootSuite{})
 func (r *upgradingRootSuite) TestClientMethods(c *gc.C) {
 	root := apiserver.TestingUpgradingRoot(nil)
 
-	for _, method := range []string{
-		"FullStatus", "EnvironmentGet", "PrivateAddress",
-		"PublicAddress",
-	} {
-		caller, err := root.FindMethod("Client", 0, method)
-		c.Check(err, jc.ErrorIsNil)
-		c.Check(caller, gc.NotNil)
+	for facadeName, methods := range apiserver.AllowedMethodsDuringUpgrades {
+		for _, method := range methods.Values() {
+			// for now all of the api calls of interest,
+			// reside on version 0 of their respective facade.
+			caller, err := root.FindMethod(facadeName, 0, method)
+			c.Check(err, jc.ErrorIsNil)
+			c.Check(caller, gc.NotNil)
+		}
 	}
 }
 


### PR DESCRIPTION
During upgrade, juju blocks most of API calls. Calls that are allowed to run are white-listed, for e.g. calls that allow status to be shown.

This PR updates this white-listing to match current reality.


(Review request: http://reviews.vapour.ws/r/3958/)