### PR TITLE
add CharmStoreResources to the API and the listresources test

### DIFF
--- a/resource/api/data.go
+++ b/resource/api/data.go
@@ -96,6 +96,10 @@ type ResourcesResult struct {
 	// Resources is the list of resources for the service.
 	Resources []Resource
 
+	// CharmStoreResources is the list of resources associated with the charm in
+	// the charmstore.
+	CharmStoreResources []CharmResource
+
 	// UnitResources contains a list of the resources for each unit in the
 	// service.
 	UnitResources []UnitResources

--- a/resource/api/helpers.go
+++ b/resource/api/helpers.go
@@ -64,6 +64,14 @@ func APIResult2ServiceResources(apiResult ResourcesResult) (resource.ServiceReso
 		result.UnitResources = append(result.UnitResources, unitResources)
 	}
 
+	for _, chRes := range apiResult.CharmStoreResources {
+		res, err := API2CharmResource(chRes)
+		if err != nil {
+			return resource.ServiceResources{}, errors.Annotate(err, "got bad data from server")
+		}
+		result.CharmStoreResources = append(result.CharmStoreResources, res)
+	}
+
 	return result, nil
 }
 

--- a/resource/api/helpers_test.go
+++ b/resource/api/helpers_test.go
@@ -163,9 +163,39 @@ func (helpersSuite) TestAPIResult2ServiceResourcesOkay(c *gc.C) {
 		Timestamp: now,
 	}
 
+	fp2, err := charmresource.GenerateFingerprint(strings.NewReader("boo!"))
+	c.Assert(err, jc.ErrorIsNil)
+
+	chRes := api.CharmResource{
+		Name:        "unitspam2",
+		Type:        "file",
+		Path:        "unitspam.tgz2",
+		Description: "you need it2",
+		Origin:      "upload",
+		Revision:    2,
+		Fingerprint: fp2.Bytes(),
+		Size:        11,
+	}
+
+	chExpected := charmresource.Resource{
+		Meta: charmresource.Meta{
+			Name:        "unitspam2",
+			Type:        charmresource.TypeFile,
+			Path:        "unitspam.tgz2",
+			Description: "you need it2",
+		},
+		Origin:      charmresource.OriginUpload,
+		Revision:    2,
+		Fingerprint: fp2,
+		Size:        11,
+	}
+
 	resources, err := api.APIResult2ServiceResources(api.ResourcesResult{
 		Resources: []api.Resource{
 			apiRes,
+		},
+		CharmStoreResources: []api.CharmResource{
+			chRes,
 		},
 		UnitResources: []api.UnitResources{
 			{
@@ -183,6 +213,9 @@ func (helpersSuite) TestAPIResult2ServiceResourcesOkay(c *gc.C) {
 	serviceResource := resource.ServiceResources{
 		Resources: []resource.Resource{
 			expected,
+		},
+		CharmStoreResources: []charmresource.Resource{
+			chExpected,
 		},
 		UnitResources: []resource.UnitResources{
 			{

--- a/resource/api/server/server.go
+++ b/resource/api/server/server.go
@@ -92,6 +92,12 @@ func (f Facade) ListResources(args api.ListResourcesArgs) (api.ResourcesResults,
 			}
 			result.UnitResources = append(result.UnitResources, unit)
 		}
+
+		result.CharmStoreResources = make([]api.CharmResource, len(svcRes.CharmStoreResources))
+		for i, chRes := range svcRes.CharmStoreResources {
+			result.CharmStoreResources[i] = api.CharmResource2API(chRes)
+		}
+
 		r.Results[i] = result
 	}
 	return r, nil

--- a/resource/api/server/server_listresources_test.go
+++ b/resource/api/server/server_listresources_test.go
@@ -5,8 +5,10 @@ package server_test
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+	charmresource "gopkg.in/juju/charm.v6-unstable/resource"
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/resource"
@@ -23,12 +25,40 @@ type ListResourcesSuite struct {
 func (s *ListResourcesSuite) TestOkay(c *gc.C) {
 	res1, apiRes1 := newResource(c, "spam", "a-user", "spamspamspam")
 	res2, apiRes2 := newResource(c, "eggs", "a-user", "...")
+
+	tag0 := names.NewUnitTag("a-service/0")
+
+	chres1 := res1.Resource
+	chres2 := res2.Resource
+	chres1.Revision++
+	chres2.Revision++
+
+	apiChRes1 := apiRes1.CharmResource
+	apiChRes2 := apiRes2.CharmResource
+	apiChRes1.Revision++
+	apiChRes2.Revision++
+
 	s.data.ReturnListResources = resource.ServiceResources{
 		Resources: []resource.Resource{
 			res1,
 			res2,
 		},
+		UnitResources: []resource.UnitResources{
+			{
+				Tag: tag0,
+				Resources: []resource.Resource{
+					res1,
+					res2,
+				},
+			},
+			// note: nothing for tag1
+		},
+		CharmStoreResources: []charmresource.Resource{
+			chres1,
+			chres2,
+		},
 	}
+
 	facade := server.NewFacade(s.data)
 
 	results, err := facade.ListResources(api.ListResourcesArgs{
@@ -43,6 +73,21 @@ func (s *ListResourcesSuite) TestOkay(c *gc.C) {
 			Resources: []api.Resource{
 				apiRes1,
 				apiRes2,
+			},
+			UnitResources: []api.UnitResources{
+				{
+					Entity: params.Entity{
+						Tag: "unit-a-service-0",
+					},
+					Resources: []api.Resource{
+						apiRes1,
+						apiRes2,
+					},
+				},
+			},
+			CharmStoreResources: []api.CharmResource{
+				apiChRes1,
+				apiChRes2,
 			},
 		}},
 	})


### PR DESCRIPTION
This was forgotten in the last patch... we needed to add the CharmStoreResources to the ListResources API call... also updates the listresources test so we test unitresources, since that was missing from earlier.

(Review request: http://reviews.vapour.ws/r/3961/)