### PR TITLE
cmd/jujud/agent/machine: Introduce stateworkers manifold

### DIFF
--- a/cmd/jujud/agent/machine/apiworkers_test.go
+++ b/cmd/jujud/agent/machine/apiworkers_test.go
@@ -6,6 +6,7 @@ package machine_test
 import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+	"launchpad.net/tomb"
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/cmd/jujud/agent/machine"
@@ -101,5 +102,14 @@ type mockAPIConn struct {
 }
 
 type mockWorker struct {
-	worker.Worker
+	tomb tomb.Tomb
+}
+
+func (w *mockWorker) Kill() {
+	w.tomb.Kill(nil)
+	w.tomb.Done()
+}
+
+func (w *mockWorker) Wait() error {
+	return w.tomb.Wait()
 }

--- a/cmd/jujud/agent/machine/manifolds_test.go
+++ b/cmd/jujud/agent/machine/manifolds_test.go
@@ -46,6 +46,7 @@ func (s *ManifoldsSuite) TestManifoldNames(c *gc.C) {
 		"serving-info-setter",
 		"state",
 		"state-config-watcher",
+		"stateworkers",
 		"termination",
 		"uninstaller",
 		"upgrade-check-gate",

--- a/cmd/jujud/agent/machine/stateworkers.go
+++ b/cmd/jujud/agent/machine/stateworkers.go
@@ -1,0 +1,65 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package machine
+
+import (
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/dependency"
+	workerstate "github.com/juju/juju/worker/state"
+)
+
+// StateWorkersConfig provides the dependencies for the
+// stateworkers manifold.
+type StateWorkersConfig struct {
+	StateName         string
+	StartStateWorkers func(*state.State) (worker.Worker, error)
+}
+
+// StateWorkersManifold starts workers that rely on a *state.State
+// using a function provided to it.
+//
+// This manifold exists to start State-using workers which have not
+// yet been ported to work directly with the dependency engine. Once
+// all state workers started by StartStateWorkers have been migrated
+// to the dependency engine, this manifold can be removed.
+func StateWorkersManifold(config StateWorkersConfig) dependency.Manifold {
+	return dependency.Manifold{
+		Inputs: []string{
+			config.StateName,
+		},
+		Start: func(getResource dependency.GetResourceFunc) (worker.Worker, error) {
+			if config.StartStateWorkers == nil {
+				return nil, errors.New("StartStateWorkers not specified")
+			}
+
+			var stTracker workerstate.StateTracker
+			if err := getResource(config.StateName, &stTracker); err != nil {
+				return nil, err
+			}
+
+			st, err := stTracker.Use()
+			if err != nil {
+				return nil, errors.Annotate(err, "acquiring state")
+			}
+
+			w, err := config.StartStateWorkers(st)
+			if err != nil {
+				stTracker.Done()
+				return nil, errors.Annotate(err, "worker startup")
+			}
+
+			// When the state workers are done, indicate that we no
+			// longer need the State.
+			go func() {
+				w.Wait()
+				stTracker.Done()
+			}()
+
+			return w, nil
+		},
+	}
+}

--- a/cmd/jujud/agent/machine/stateworkers_test.go
+++ b/cmd/jujud/agent/machine/stateworkers_test.go
@@ -1,0 +1,121 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package machine_test
+
+import (
+	"errors"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/cmd/jujud/agent/machine"
+	"github.com/juju/juju/state"
+	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/dependency"
+	dt "github.com/juju/juju/worker/dependency/testing"
+)
+
+type StateWorkersSuite struct {
+	coretesting.BaseSuite
+	manifold    dependency.Manifold
+	startError  error
+	startCalled bool
+}
+
+var _ = gc.Suite(&StateWorkersSuite{})
+
+func (s *StateWorkersSuite) SetUpTest(c *gc.C) {
+	s.startError = nil
+	s.startCalled = false
+	s.manifold = machine.StateWorkersManifold(machine.StateWorkersConfig{
+		StateName:         "state",
+		StartStateWorkers: s.startStateWorkers,
+	})
+}
+
+func (s *StateWorkersSuite) startStateWorkers(st *state.State) (worker.Worker, error) {
+	s.startCalled = true
+	if s.startError != nil {
+		return nil, s.startError
+	}
+	return new(mockWorker), nil
+}
+
+func (s *StateWorkersSuite) TestInputs(c *gc.C) {
+	c.Assert(s.manifold.Inputs, jc.SameContents, []string{
+		"state",
+	})
+}
+
+func (s *StateWorkersSuite) TestNoStartStateWorkers(c *gc.C) {
+	manifold := machine.StateWorkersManifold(machine.StateWorkersConfig{})
+	worker, err := manifold.Start(dt.StubGetResource(nil))
+	c.Check(worker, gc.IsNil)
+	c.Check(err, gc.ErrorMatches, "StartStateWorkers not specified")
+	c.Check(s.startCalled, jc.IsFalse)
+}
+
+func (s *StateWorkersSuite) TestStateMissing(c *gc.C) {
+	getResource := dt.StubGetResource(dt.StubResources{
+		"state": dt.StubResource{Error: dependency.ErrMissing},
+	})
+	worker, err := s.manifold.Start(getResource)
+	c.Check(worker, gc.IsNil)
+	c.Check(err, gc.Equals, dependency.ErrMissing)
+	c.Check(s.startCalled, jc.IsFalse)
+}
+
+func (s *StateWorkersSuite) TestStartError(c *gc.C) {
+	tracker := new(mockStateTracker)
+	getResource := dt.StubGetResource(dt.StubResources{
+		"state": dt.StubResource{Output: tracker},
+	})
+	s.startError = errors.New("boom")
+
+	worker, err := s.manifold.Start(getResource)
+	c.Check(worker, gc.IsNil)
+	c.Check(err, gc.ErrorMatches, "worker startup: boom")
+	c.Check(s.startCalled, jc.IsTrue)
+	tracker.assertDoneCalled(c)
+}
+
+func (s *StateWorkersSuite) TestStartSuccess(c *gc.C) {
+	tracker := new(mockStateTracker)
+	getResource := dt.StubGetResource(dt.StubResources{
+		"state": dt.StubResource{Output: tracker},
+	})
+	w, err := s.manifold.Start(getResource)
+	c.Check(w, gc.Not(gc.IsNil))
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(s.startCalled, jc.IsTrue)
+	c.Check(tracker.doneCalled, jc.IsFalse)
+
+	// Ensure Done is called on tracker when worker exits.
+	worker.Stop(w)
+	tracker.assertDoneCalled(c)
+}
+
+// Implements StateTracker.
+type mockStateTracker struct {
+	doneCalled bool
+}
+
+func (t *mockStateTracker) Use() (*state.State, error) {
+	return new(state.State), nil
+}
+
+func (t *mockStateTracker) Done() error {
+	t.doneCalled = true
+	return nil
+}
+
+func (t *mockStateTracker) assertDoneCalled(c *gc.C) {
+	for a := coretesting.LongAttempt.Start(); a.Next(); {
+		if t.doneCalled {
+			return
+		}
+	}
+	c.Fatal("Done() not called on tracker")
+}

--- a/worker/state/manifold_test.go
+++ b/worker/state/manifold_test.go
@@ -140,7 +140,7 @@ func (s *ManifoldSuite) TestOutputWrongType(c *gc.C) {
 func (s *ManifoldSuite) TestOutputSuccess(c *gc.C) {
 	w := s.mustStartManifold(c)
 
-	var stTracker *workerstate.StateTracker
+	var stTracker workerstate.StateTracker
 	err := s.manifold.Output(w, &stTracker)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -157,7 +157,7 @@ func (s *ManifoldSuite) TestOutputSuccess(c *gc.C) {
 func (s *ManifoldSuite) TestStateStillInUse(c *gc.C) {
 	w := s.mustStartManifold(c)
 
-	var stTracker *workerstate.StateTracker
+	var stTracker workerstate.StateTracker
 	err := s.manifold.Output(w, &stTracker)
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/worker/state/statetracker_test.go
+++ b/worker/state/statetracker_test.go
@@ -15,7 +15,7 @@ import (
 type StateTrackerSuite struct {
 	statetesting.StateSuite
 	st           *state.State
-	stateTracker *workerstate.StateTracker
+	stateTracker workerstate.StateTracker
 }
 
 var _ = gc.Suite(&StateTrackerSuite{})
@@ -37,7 +37,7 @@ func (s *StateTrackerSuite) TestTooManyDones(c *gc.C) {
 	assertStateClosed(c, s.State)
 
 	err = s.stateTracker.Done()
-	c.Assert(err, gc.Equals, workerstate.ErrStateAlreadyClosed)
+	c.Assert(err, gc.Equals, workerstate.ErrStateClosed)
 	assertStateClosed(c, s.State)
 }
 
@@ -88,7 +88,7 @@ func (s *StateTrackerSuite) TestUseWhenClosed(c *gc.C) {
 
 	st, err := s.stateTracker.Use()
 	c.Check(st, gc.IsNil)
-	c.Check(err, gc.Equals, workerstate.ErrStateAlreadyClosed)
+	c.Check(err, gc.Equals, workerstate.ErrStateClosed)
 }
 
 func assertStateNotClosed(c *gc.C, st *state.State) {


### PR DESCRIPTION
"stateworkers" is a temporary manifold that runs workers which have not yet been converted to run directly under the dependency engine. It obtains a *state.State from the "state" manifold and passes it to a function which starts the workers.

As part of this change the old "state-starter" and "state" workers have been removed from the machine agent. They have been replaced by equivalent dependency engine manifolds.


(Review request: http://reviews.vapour.ws/r/3964/)