### PR TITLE
Fix panics during apiserver shutdown

### DIFF
--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -309,6 +309,31 @@ func (n *requestNotifier) ClientRequest(hdr *rpc.Header, body interface{}) {
 func (n *requestNotifier) ClientReply(req rpc.Request, hdr *rpc.Header, body interface{}) {
 }
 
+// trackRequests wraps a http.Handler, incrementing and decrementing
+// the apiserver's WaitGroup and blocking request when the apiserver
+// is shutting down.
+//
+// Note: It is only safe to use trackRequests with API handlers which
+// are interruptible (i.e. they pay attention to the apiserver tomb)
+// or are guaranteed to be short-lived. If it's used with long running
+// API handlers which don't watch the apiserver's tomb, apiserver
+// shutdown will be blocked until the API handler returns.
+func (srv *Server) trackRequests(handler http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		srv.wg.Add(1)
+		defer srv.wg.Done()
+		// If we've got to this stage and the tomb is still
+		// alive, we know that any tomb.Kill must occur after we
+		// have called wg.Add, so we avoid the possibility of a
+		// handler goroutine running after Stop has returned.
+		if srv.tomb.Err() != tomb.ErrStillAlive {
+			return
+		}
+
+		handler.ServeHTTP(w, r)
+	})
+}
+
 func handleAll(mux *pat.PatternServeMux, pattern string, handler http.Handler) {
 	mux.Get(pattern, handler)
 	mux.Post(pattern, handler)
@@ -354,16 +379,19 @@ func (srv *Server) run() {
 	httpCtxt := httpContext{
 		srv: srv,
 	}
+
+	mainAPIHandler := srv.trackRequests(http.HandlerFunc(srv.apiHandler))
+	logSinkHandler := srv.trackRequests(newLogSinkHandler(httpCtxt, srv.logDir))
+	debugLogHandler := srv.trackRequests(newDebugLogDBHandler(httpCtxt, srvDying))
+
 	handleAll(mux, "/model/:modeluuid"+resourceapi.HTTPEndpointPattern,
 		newResourceHandler(httpCtxt),
 	)
 	handleAll(mux, "/model/:modeluuid/units/:unit/resources/:resource",
 		newUnitResourceHandler(httpCtxt),
 	)
-	handleAll(mux, "/model/:modeluuid/logsink",
-		newLogSinkHandler(httpCtxt, srv.logDir))
-	handleAll(mux, "/model/:modeluuid/log",
-		newDebugLogDBHandler(httpCtxt, srvDying))
+	handleAll(mux, "/model/:modeluuid/logsink", logSinkHandler)
+	handleAll(mux, "/model/:modeluuid/log", debugLogHandler)
 	handleAll(mux, "/model/:modeluuid/charms",
 		&charmsHandler{
 			ctxt:    httpCtxt,
@@ -391,7 +419,7 @@ func (srv *Server) run() {
 			ctxt: strictCtxt,
 		},
 	)
-	handleAll(mux, "/model/:modeluuid/api", http.HandlerFunc(srv.apiHandler))
+	handleAll(mux, "/model/:modeluuid/api", mainAPIHandler)
 
 	handleAll(mux, "/model/:modeluuid/images/:kind/:series/:arch/:filename",
 		&imagesDownloadHandler{
@@ -401,7 +429,7 @@ func (srv *Server) run() {
 		},
 	)
 	// For backwards compatibility we register all the old paths
-	handleAll(mux, "/log", newDebugLogDBHandler(httpCtxt, srvDying))
+	handleAll(mux, "/log", debugLogHandler)
 
 	handleAll(mux, "/charms",
 		&charmsHandler{
@@ -424,7 +452,7 @@ func (srv *Server) run() {
 			ctxt: httpCtxt,
 		},
 	)
-	handleAll(mux, "/", http.HandlerFunc(srv.apiHandler))
+	handleAll(mux, "/", mainAPIHandler)
 
 	go func() {
 		addr := srv.lis.Addr() // not valid after addr closed
@@ -445,15 +473,6 @@ func (srv *Server) apiHandler(w http.ResponseWriter, req *http.Request) {
 	defer reqNotifier.leave()
 	wsServer := websocket.Server{
 		Handler: func(conn *websocket.Conn) {
-			srv.wg.Add(1)
-			defer srv.wg.Done()
-			// If we've got to this stage and the tomb is still
-			// alive, we know that any tomb.Kill must occur after we
-			// have called wg.Add, so we avoid the possibility of a
-			// handler goroutine running after Stop has returned.
-			if srv.tomb.Err() != tomb.ErrStillAlive {
-				return
-			}
 			modelUUID := req.URL.Query().Get(":modeluuid")
 			logger.Tracef("got a request for model %q", modelUUID)
 			if err := srv.serveConn(conn, reqNotifier, modelUUID); err != nil {

--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -320,13 +320,12 @@ func handleAll(mux *pat.PatternServeMux, pattern string, handler http.Handler) {
 
 func (srv *Server) run() {
 	logger.Infof("listening on %q", srv.lis.Addr())
+
 	defer func() {
 		addr := srv.lis.Addr().String() // Addr not valid after close
 		err := srv.lis.Close()
 		logger.Infof("closed listening socket %q with final error: %v", addr, err)
-	}()
 
-	defer func() {
 		srv.state.HackLeadership() // Break deadlocks caused by BlockUntil... calls.
 		srv.wg.Wait()              // wait for any outstanding requests to complete.
 		srv.tomb.Done()

--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -375,14 +375,13 @@ func (srv *Server) run() {
 	// registered first.
 	mux := pat.New()
 
-	srvDying := srv.tomb.Dying()
 	httpCtxt := httpContext{
 		srv: srv,
 	}
 
 	mainAPIHandler := srv.trackRequests(http.HandlerFunc(srv.apiHandler))
 	logSinkHandler := srv.trackRequests(newLogSinkHandler(httpCtxt, srv.logDir))
-	debugLogHandler := srv.trackRequests(newDebugLogDBHandler(httpCtxt, srvDying))
+	debugLogHandler := srv.trackRequests(newDebugLogDBHandler(httpCtxt))
 
 	handleAll(mux, "/model/:modeluuid"+resourceapi.HTTPEndpointPattern,
 		newResourceHandler(httpCtxt),

--- a/apiserver/debuglog.go
+++ b/apiserver/debuglog.go
@@ -27,7 +27,6 @@ import (
 // requests.
 type debugLogHandler struct {
 	ctxt   httpContext
-	stop   <-chan struct{}
 	handle debugLogHandlerFunc
 }
 
@@ -40,12 +39,10 @@ type debugLogHandlerFunc func(
 
 func newDebugLogHandler(
 	ctxt httpContext,
-	stop <-chan struct{},
 	handle debugLogHandlerFunc,
 ) *debugLogHandler {
 	return &debugLogHandler{
 		ctxt:   ctxt,
-		stop:   stop,
 		handle: handle,
 	}
 }
@@ -91,7 +88,7 @@ func (h *debugLogHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 				return
 			}
 
-			if err := h.handle(st, params, socket, h.stop); err != nil {
+			if err := h.handle(st, params, socket, h.ctxt.stop()); err != nil {
 				if isBrokenPipe(err) {
 					logger.Tracef("debug-log handler stopped (client disconnected)")
 				} else {

--- a/apiserver/debuglog_db.go
+++ b/apiserver/debuglog_db.go
@@ -13,8 +13,8 @@ import (
 	"github.com/juju/juju/state"
 )
 
-func newDebugLogDBHandler(ctxt httpContext, stop <-chan struct{}) http.Handler {
-	return newDebugLogHandler(ctxt, stop, handleDebugLogDBRequest)
+func newDebugLogDBHandler(ctxt httpContext) http.Handler {
+	return newDebugLogHandler(ctxt, handleDebugLogDBRequest)
 }
 
 func handleDebugLogDBRequest(

--- a/apiserver/httpcontext.go
+++ b/apiserver/httpcontext.go
@@ -149,6 +149,12 @@ func (ctxt *httpContext) loginRequest(r *http.Request) (params.LoginRequest, err
 	}, nil
 }
 
+// stop returns a channel which will be closed when a handler should
+// exit.
+func (ctxt *httpContext) stop() <-chan struct{} {
+	return ctxt.srv.tomb.Dying()
+}
+
 // sendJSON writes a JSON-encoded response value
 // to the given writer along with a trailing newline.
 func sendJSON(w io.Writer, response interface{}) {

--- a/apiserver/logsink.go
+++ b/apiserver/logsink.go
@@ -5,6 +5,7 @@ package apiserver
 
 import (
 	"io"
+	"net"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -62,6 +63,7 @@ func (h *logSinkHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	server := websocket.Server{
 		Handler: func(socket *websocket.Conn) {
 			defer socket.Close()
+
 			st, entity, err := h.ctxt.stateForRequestAuthenticatedAgent(req)
 			if err != nil {
 				h.sendError(socket, req, err)
@@ -69,39 +71,79 @@ func (h *logSinkHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 			}
 			tag := entity.Tag()
 
+			filePrefix := st.ModelUUID() + " " + tag.String() + ":"
+			dbLogger := state.NewDbLogger(st, tag)
+			defer dbLogger.Close()
+
 			// If we get to here, no more errors to report, so we report a nil
 			// error.  This way the first line of the socket is always a json
 			// formatted simple error.
 			h.sendError(socket, req, nil)
 
-			filePrefix := st.ModelUUID() + " " + tag.String() + ":"
-			dbLogger := state.NewDbLogger(st, tag)
-			defer dbLogger.Close()
-			m := new(params.LogRecord)
+			logCh := h.receiveLogs(socket)
 			for {
-				if err := websocket.JSON.Receive(socket, m); err != nil {
-					if err != io.EOF {
-						logger.Errorf("error while receiving logs: %v", err)
+				select {
+				case <-h.ctxt.stop():
+					return
+				case m := <-logCh:
+					fileErr := h.logToFile(filePrefix, m)
+					if fileErr != nil {
+						logger.Errorf("logging to logsink.log failed: %v", fileErr)
 					}
-					break
-				}
-
-				fileErr := h.logToFile(filePrefix, m)
-				if fileErr != nil {
-					logger.Errorf("logging to logsink.log failed: %v", fileErr)
-				}
-
-				dbErr := dbLogger.Log(m.Time, m.Module, m.Location, m.Level, m.Message)
-				if dbErr != nil {
-					logger.Errorf("logging to DB failed: %v", err)
-				}
-
-				if fileErr != nil || dbErr != nil {
-					break
+					dbErr := dbLogger.Log(m.Time, m.Module, m.Location, m.Level, m.Message)
+					if dbErr != nil {
+						logger.Errorf("logging to DB failed: %v", err)
+					}
+					if fileErr != nil || dbErr != nil {
+						return
+					}
 				}
 			}
-		}}
+		},
+	}
 	server.ServeHTTP(w, req)
+}
+
+func (h *logSinkHandler) receiveLogs(socket *websocket.Conn) <-chan params.LogRecord {
+	logCh := make(chan params.LogRecord)
+
+	go func() {
+		var m params.LogRecord
+		for {
+			// The read deadline is used to allow the goroutine to
+			// come up for air (even when the other end is not
+			// sending) and check if it should stop.
+			socket.SetReadDeadline(time.Now().Add(time.Second))
+			if err := websocket.JSON.Receive(socket, &m); err != nil {
+				if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
+					if h.running() {
+						continue
+					}
+				} else if err != io.EOF {
+					logger.Errorf("error while receiving logs: %v", err)
+				}
+				return
+			}
+
+			// Send the log message.
+			select {
+			case <-h.ctxt.stop():
+				return
+			case logCh <- m:
+			}
+		}
+	}()
+
+	return logCh
+}
+
+func (h *logSinkHandler) running() bool {
+	select {
+	case <-h.ctxt.stop():
+		return false
+	default:
+		return true
+	}
 }
 
 // sendError sends a JSON-encoded error response.
@@ -115,7 +157,7 @@ func (h *logSinkHandler) sendError(w io.Writer, req *http.Request, err error) {
 }
 
 // logToFile writes a single log message to the logsink log file.
-func (h *logSinkHandler) logToFile(prefix string, m *params.LogRecord) error {
+func (h *logSinkHandler) logToFile(prefix string, m params.LogRecord) error {
 	_, err := h.fileLogger.Write([]byte(strings.Join([]string{
 		prefix,
 		m.Time.In(time.UTC).Format("2006-01-02 15:04:05"),


### PR DESCRIPTION
This is a series of fixes to resolve "Session already closed" panics which were observed in API handlers as the apiserver was being shut down. The root cause is that the "streaming" style API handlers don't contribute towards the apiserver's request tracking WaitGroup and don't check if the apiserver is shutting down before proceeding, meaning they can end up running after the apiserver goroutine has shut down and closed its *state.State.

This problem have always been there but recent changes to worker start up due to the dependency engine conversion has made them visible.

Note that at this stage only the /logsink and /log handlers have been completely fixed to avoid errors. Due to it always being in constant use, /logsink was the one specifically causing the panics observed. Fixing  all streaming style APIs to remove the possibility of all apiserver shutdown panics is a huge job (and may not even be possible for some handlers).

Here's the specific changes:

apiserver: Close listener before cleaning up apiserver

A recent change made it so the apiserver's listener was closed *after* the cleanup of the apiserver's resources, instead of before. The previous order is now restored, preventing new connections when the apiserver is on its way down.

---

apiserver: Use request WaitGroup for /log & /logsink

The code to increment and decrement the apiserver's request WaitGroup, and prevent requests from starting when the apiserver is shutting down, has been extracted from apiHandler and is now also used with the /log and /logsink API handlers. This prevents "Session already closed" panics when requests to these handlers have just started as the apiserver is shutting down.

---

apiserver: Expose server dying channel from httpContext

This can be used by long running API request handlers to abort.

---

apiserver: Have the debug log handler use the httpContext stop channel

Now that httpContext.stop() exists the debug log API handler no longer needs to be passed a stop channel separately.

---

apiserver: Make logsink handler stop when apiserver does

The logsink API handler will now stop when the apiserver's tomb goes to dying. This is required now that apiserver waits for logsink API requests to complete before stopping.



(Review request: http://reviews.vapour.ws/r/3965/)