### PR TITLE
Link-layer parent devices cannot be created along with their children

### DIFF
--- a/state/errors.go
+++ b/state/errors.go
@@ -104,19 +104,18 @@ func IsProviderIDNotUniqueError(err interface{}) bool {
 // link-layer device cannot be removed because other existing devices refer to
 // it as their parent.
 type ErrParentDeviceHasChildren struct {
-	parentName    string
-	childrenNames []string
+	parentName  string
+	numChildren int
 }
 
 func (e *ErrParentDeviceHasChildren) Error() string {
-	children := strings.Join(e.childrenNames, ", ")
-	return fmt.Sprintf("parent device %q has children: %s", e.parentName, children)
+	return fmt.Sprintf("parent device %q has %d children", e.parentName, e.numChildren)
 }
 
-func newParentDeviceHasChildrenError(parentName string, childrenNames []string) error {
+func newParentDeviceHasChildrenError(parentName string, numChildren int) error {
 	return &ErrParentDeviceHasChildren{
-		parentName:    parentName,
-		childrenNames: childrenNames,
+		parentName:  parentName,
+		numChildren: numChildren,
 	}
 }
 

--- a/state/linklayerdevices_test.go
+++ b/state/linklayerdevices_test.go
@@ -444,7 +444,7 @@ func (s *linkLayerDevicesStateSuite) TestLinkLayerDeviceRemoveFailsWithExistingC
 
 	err := parent.Remove()
 	expectedError := fmt.Sprintf(
-		"cannot remove %s: parent device %q has children: another-child, one-child",
+		"cannot remove %s: parent device %q has 2 children",
 		parent, parent.Name(),
 	)
 	c.Assert(err, gc.ErrorMatches, expectedError)

--- a/state/linklayerdevices_test.go
+++ b/state/linklayerdevices_test.go
@@ -5,7 +5,6 @@ package state_test
 
 import (
 	"fmt"
-	"sync"
 
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
@@ -267,7 +266,7 @@ func (s *linkLayerDevicesStateSuite) TestAddLinkLayerDevicesMultipleArgsWithSame
 	c.Assert(err, jc.Satisfies, errors.IsNotValid)
 }
 
-func (s *linkLayerDevicesStateSuite) TestAddLinkLayerDevicesMultipleArgsChildParentOrderDoesNotMatter(c *gc.C) {
+func (s *linkLayerDevicesStateSuite) TestAddLinkLayerDevicesRefusesToAddParentAndChildrenInTheSameCall(c *gc.C) {
 	allArgs := []state.LinkLayerDeviceArgs{{
 		Name:       "child1",
 		Type:       state.EthernetDevice,
@@ -275,54 +274,65 @@ func (s *linkLayerDevicesStateSuite) TestAddLinkLayerDevicesMultipleArgsChildPar
 	}, {
 		Name: "parent1",
 		Type: state.BridgeDevice,
-	}, {
-		Name: "parent2",
-		Type: state.BondDevice,
-	}, {
-		Name:       "child2",
-		Type:       state.VLAN_8021QDevice,
-		ParentName: "parent2",
 	}}
 
-	s.addLinkLayerDevicesMultipleArgsSucceedsAndEnsureAllAdded(c, allArgs)
+	err := s.machine.AddLinkLayerDevices(allArgs...)
+	c.Assert(err, gc.ErrorMatches, `cannot add link-layer devices to machine "0": `+
+		`parent device "parent1" of device "child1" not found`)
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
 
-func (s *linkLayerDevicesStateSuite) addLinkLayerDevicesMultipleArgsSucceedsAndEnsureAllAdded(c *gc.C, allArgs []state.LinkLayerDeviceArgs) {
+func (s *linkLayerDevicesStateSuite) addLinkLayerDevicesMultipleArgsSucceedsAndEnsureAllAdded(c *gc.C, allArgs []state.LinkLayerDeviceArgs) []*state.LinkLayerDevice {
 	err := s.machine.AddLinkLayerDevices(allArgs...)
 	c.Assert(err, jc.ErrorIsNil)
 
+	var results []*state.LinkLayerDevice
 	machineID, modelUUID := s.machine.Id(), s.State.ModelUUID()
 	for _, args := range allArgs {
 		device, err := s.machine.LinkLayerDevice(args.Name)
 		c.Check(err, jc.ErrorIsNil)
 		s.checkAddedDeviceMatchesArgs(c, device, args)
 		s.checkAddedDeviceMatchesMachineIDAndModelUUID(c, device, machineID, modelUUID)
+		results = append(results, device)
 	}
+	return results
 }
 
 func (s *linkLayerDevicesStateSuite) TestAddLinkLayerDevicesMultipleChildrenOfExistingParentSucceeds(c *gc.C) {
-	parent := s.addSimpleDevice(c)
-	childrenArgs := []state.LinkLayerDeviceArgs{{
-		Name:       "child1",
-		Type:       state.EthernetDevice,
-		ParentName: parent.Name(),
-	}, {
-		Name:       "child2",
-		Type:       state.EthernetDevice,
-		ParentName: parent.Name(),
-	}}
+	s.addNamedParentDeviceWithChildren(c, "parent", "child1", "child2")
+}
 
-	s.addLinkLayerDevicesMultipleArgsSucceedsAndEnsureAllAdded(c, childrenArgs)
+func (s *linkLayerDevicesStateSuite) addNamedParentDeviceWithChildren(c *gc.C, parentName string, childrenNames ...string) (
+	parent *state.LinkLayerDevice,
+	children []*state.LinkLayerDevice,
+) {
+	parent = s.addNamedDevice(c, parentName)
+	childrenArgs := make([]state.LinkLayerDeviceArgs, len(childrenNames))
+	for i, childName := range childrenNames {
+		childrenArgs[i] = state.LinkLayerDeviceArgs{
+			Name:       childName,
+			Type:       state.EthernetDevice,
+			ParentName: parentName,
+		}
+	}
+
+	children = s.addLinkLayerDevicesMultipleArgsSucceedsAndEnsureAllAdded(c, childrenArgs)
+	c.Check(children, gc.HasLen, len(childrenNames))
+	return parent, children
 }
 
 func (s *linkLayerDevicesStateSuite) addSimpleDevice(c *gc.C) *state.LinkLayerDevice {
+	return s.addNamedDevice(c, "foo")
+}
+
+func (s *linkLayerDevicesStateSuite) addNamedDevice(c *gc.C, name string) *state.LinkLayerDevice {
 	args := state.LinkLayerDeviceArgs{
-		Name: "foo",
+		Name: name,
 		Type: state.EthernetDevice,
 	}
 	err := s.machine.AddLinkLayerDevices(args)
 	c.Assert(err, jc.ErrorIsNil)
-	device, err := s.machine.LinkLayerDevice(args.Name)
+	device, err := s.machine.LinkLayerDevice(name)
 	c.Assert(err, jc.ErrorIsNil)
 	return device
 }
@@ -350,22 +360,12 @@ func (s *linkLayerDevicesStateSuite) TestMachineMethodReturnsMachine(c *gc.C) {
 }
 
 func (s *linkLayerDevicesStateSuite) TestParentDeviceReturnsLinkLayerDevice(c *gc.C) {
-	args := []state.LinkLayerDeviceArgs{{
-		Name: "br-eth0",
-		Type: state.BridgeDevice,
-	}, {
-		Name:       "eth0",
-		Type:       state.EthernetDevice,
-		ParentName: "br-eth0",
-	}}
-	s.addLinkLayerDevicesMultipleArgsSucceedsAndEnsureAllAdded(c, args)
+	parent, children := s.addNamedParentDeviceWithChildren(c, "br-eth0", "eth0")
 
-	child, err := s.machine.LinkLayerDevice("eth0")
+	child := children[0]
+	parentCopy, err := child.ParentDevice()
 	c.Assert(err, jc.ErrorIsNil)
-	parent, err := child.ParentDevice()
-	c.Assert(err, jc.ErrorIsNil)
-	s.checkAddedDeviceMatchesArgs(c, parent, args[0])
-	s.checkAddedDeviceMatchesMachineIDAndModelUUID(c, parent, s.machine.Id(), s.State.ModelUUID())
+	c.Assert(parentCopy, jc.DeepEquals, parent)
 }
 
 func (s *linkLayerDevicesStateSuite) TestMachineLinkLayerDeviceReturnsNotFoundErrorWhenMissing(c *gc.C) {
@@ -385,24 +385,19 @@ func (s *linkLayerDevicesStateSuite) TestMachineLinkLayerDeviceReturnsLinkLayerD
 
 func (s *linkLayerDevicesStateSuite) TestMachineAllLinkLayerDevices(c *gc.C) {
 	s.assertNoDevicesOnMachine(c, s.machine)
+	topParent, secondLevelParents := s.addNamedParentDeviceWithChildren(c, "br-bond0", "bond0")
+	secondLevelParent := secondLevelParents[0]
 
-	args := []state.LinkLayerDeviceArgs{{
-		Name: "br-bond0",
-		Type: state.BridgeDevice,
-	}, {
-		Name:       "bond0",
-		Type:       state.BondDevice,
-		ParentName: "br-bond0",
-	}, {
+	secondLevelChildrenArgs := []state.LinkLayerDeviceArgs{{
 		Name:       "eth0",
 		Type:       state.EthernetDevice,
-		ParentName: "bond0",
+		ParentName: secondLevelParent.Name(),
 	}, {
 		Name:       "eth1",
 		Type:       state.EthernetDevice,
-		ParentName: "bond0",
+		ParentName: secondLevelParent.Name(),
 	}}
-	s.addLinkLayerDevicesMultipleArgsSucceedsAndEnsureAllAdded(c, args)
+	s.addLinkLayerDevicesMultipleArgsSucceedsAndEnsureAllAdded(c, secondLevelChildrenArgs)
 
 	results, err := s.machine.AllLinkLayerDevices()
 	c.Assert(err, jc.ErrorIsNil)
@@ -411,7 +406,7 @@ func (s *linkLayerDevicesStateSuite) TestMachineAllLinkLayerDevices(c *gc.C) {
 		c.Check(result, gc.NotNil)
 		c.Check(result.MachineID(), gc.Equals, s.machine.Id())
 		c.Check(result.Name(), gc.Matches, `(br-bond0|bond0|eth0|eth1)`)
-		if result.Name() == "br-bond0" {
+		if result.Name() == topParent.Name() {
 			c.Check(result.ParentName(), gc.Equals, "")
 			continue
 		}
@@ -433,15 +428,7 @@ func (s *linkLayerDevicesStateSuite) TestMachineAllLinkLayerDevicesOnlyReturnsSa
 	s.assertNoDevicesOnMachine(c, s.machine)
 	s.assertNoDevicesOnMachine(c, s.otherStateMachine)
 
-	args := []state.LinkLayerDeviceArgs{{
-		Name: "foo",
-		Type: state.EthernetDevice,
-	}, {
-		Name:       "foo.42",
-		Type:       state.VLAN_8021QDevice,
-		ParentName: "foo",
-	}}
-	s.addLinkLayerDevicesMultipleArgsSucceedsAndEnsureAllAdded(c, args)
+	s.addNamedParentDeviceWithChildren(c, "foo", "foo.42")
 
 	results, err := s.machine.AllLinkLayerDevices()
 	c.Assert(err, jc.ErrorIsNil)
@@ -453,24 +440,9 @@ func (s *linkLayerDevicesStateSuite) TestMachineAllLinkLayerDevicesOnlyReturnsSa
 }
 
 func (s *linkLayerDevicesStateSuite) TestLinkLayerDeviceRemoveFailsWithExistingChildren(c *gc.C) {
-	args := []state.LinkLayerDeviceArgs{{
-		Name: "parent",
-		Type: state.BridgeDevice,
-	}, {
-		Name:       "one-child",
-		Type:       state.EthernetDevice,
-		ParentName: "parent",
-	}, {
-		Name:       "another-child",
-		Type:       state.EthernetDevice,
-		ParentName: "parent",
-	}}
-	s.addLinkLayerDevicesMultipleArgsSucceedsAndEnsureAllAdded(c, args)
+	parent, _ := s.addNamedParentDeviceWithChildren(c, "parent", "one-child", "another-child")
 
-	parent, err := s.machine.LinkLayerDevice("parent")
-	c.Assert(err, jc.ErrorIsNil)
-
-	err = parent.Remove()
+	err := parent.Remove()
 	expectedError := fmt.Sprintf(
 		"cannot remove %s: parent device %q has children: another-child, one-child",
 		parent, parent.Name(),
@@ -501,16 +473,7 @@ func (s *linkLayerDevicesStateSuite) TestLinkLayerDeviceRemoveTwiceStillSucceeds
 
 func (s *linkLayerDevicesStateSuite) TestMachineRemoveAllLinkLayerDevicesSuccess(c *gc.C) {
 	s.assertNoDevicesOnMachine(c, s.machine)
-
-	args := []state.LinkLayerDeviceArgs{{
-		Name: "foo",
-		Type: state.EthernetDevice,
-	}, {
-		Name:       "bar",
-		Type:       state.VLAN_8021QDevice,
-		ParentName: "foo",
-	}}
-	s.addLinkLayerDevicesMultipleArgsSucceedsAndEnsureAllAdded(c, args)
+	s.addNamedParentDeviceWithChildren(c, "foo", "bar")
 
 	err := s.machine.RemoveAllLinkLayerDevices()
 	c.Assert(err, jc.ErrorIsNil)
@@ -525,193 +488,112 @@ func (s *linkLayerDevicesStateSuite) TestMachineRemoveAllLinkLayerDevicesNoError
 }
 
 func (s *linkLayerDevicesStateSuite) TestAddLinkLayerDevicesRollbackWithDuplicateProviderIDs(c *gc.C) {
+	parent := s.addNamedDevice(c, "parent")
 	insertingArgs := []state.LinkLayerDeviceArgs{{
-		Name:       "child",
+		Name:       "child1",
 		Type:       state.EthernetDevice,
-		ProviderID: "child-id",
-		ParentName: "parent",
+		ProviderID: "child1-id",
+		ParentName: parent.Name(),
 	}, {
-		Name:       "parent",
+		Name:       "child2",
 		Type:       state.BridgeDevice,
-		ProviderID: "parent-id",
+		ProviderID: "child2-id",
+		ParentName: parent.Name(),
 	}}
 
-	assertTwoExistAndRemoveAll := func() {
-		s.assertAllLinkLayerDevicesOnMachineMatchCount(c, s.machine, 2)
-		err := s.machine.RemoveAllLinkLayerDevices()
-		c.Assert(err, jc.ErrorIsNil)
+	assertThreeExistAndRemoveChildren := func(childrenNames ...string) {
+		s.assertAllLinkLayerDevicesOnMachineMatchCount(c, s.machine, 3)
+		for _, childName := range childrenNames {
+			child, err := s.machine.LinkLayerDevice(childName)
+			c.Check(err, jc.ErrorIsNil)
+			c.Check(child.Remove(), jc.ErrorIsNil)
+		}
 	}
 
 	hooks := []jujutxn.TestHook{{
 		Before: func() {
 			// Add the same devices to trigger ErrAborted in the first attempt.
-			s.assertNoDevicesOnMachine(c, s.machine)
+			s.assertAllLinkLayerDevicesOnMachineMatchCount(c, s.machine, 1) // only the parent exists
 			err := s.machine.AddLinkLayerDevices(insertingArgs...)
 			c.Assert(err, jc.ErrorIsNil)
 		},
-		After: assertTwoExistAndRemoveAll,
+		After: func() {
+			assertThreeExistAndRemoveChildren("child1", "child2")
+		},
 	}, {
 		Before: func() {
 			// Add devices with same ProviderIDs but different names.
-			s.assertNoDevicesOnMachine(c, s.machine)
+			s.assertAllLinkLayerDevicesOnMachineMatchCount(c, s.machine, 1) // only the parent exists
 			insertingAlternateArgs := insertingArgs
-			insertingAlternateArgs[0].Name = "other-child"
-			insertingAlternateArgs[0].ParentName = "other-parent"
-			insertingAlternateArgs[1].Name = "other-parent"
+			insertingAlternateArgs[0].Name = "other-child1"
+			insertingAlternateArgs[1].Name = "other-child2"
 			err := s.machine.AddLinkLayerDevices(insertingAlternateArgs...)
 			c.Assert(err, jc.ErrorIsNil)
 		},
-		After: assertTwoExistAndRemoveAll,
+		After: func() {
+			assertThreeExistAndRemoveChildren("other-child1", "other-child2")
+		},
 	}}
 	defer state.SetTestHooks(c, s.State, hooks...).Check()
 
 	err := s.machine.AddLinkLayerDevices(insertingArgs...)
-	c.Assert(err, gc.ErrorMatches, `.*ProviderID\(s\) not unique: child-id, parent-id`)
+	c.Assert(err, gc.ErrorMatches, `.*ProviderID\(s\) not unique: child1-id, child2-id`)
 	c.Assert(err, jc.Satisfies, state.IsProviderIDNotUniqueError)
-	s.assertNoDevicesOnMachine(c, s.machine) // Rollback worked.
+	s.assertAllLinkLayerDevicesOnMachineMatchCount(c, s.machine, 1) // only the parent exists and rollback worked.
 }
 
 func (s *linkLayerDevicesStateSuite) TestAddLinkLayerDevicesWithLightStateChurn(c *gc.C) {
-	allArgs, churnHook := s.prepareAddLinkLayerDevicesWithStateChurn(c)
+	childArgs, churnHook := s.prepareAddLinkLayerDevicesWithStateChurn(c)
 	defer state.SetTestHooks(c, s.State, churnHook).Check()
-	s.assertNoDevicesOnMachine(c, s.machine)
+	s.assertAllLinkLayerDevicesOnMachineMatchCount(c, s.machine, 1) // parent only
 
-	s.addLinkLayerDevicesMultipleArgsSucceedsAndEnsureAllAdded(c, allArgs)
+	err := s.machine.AddLinkLayerDevices(childArgs)
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertAllLinkLayerDevicesOnMachineMatchCount(c, s.machine, 2) // both parent and child remain
 }
 
-func (s *linkLayerDevicesStateSuite) prepareAddLinkLayerDevicesWithStateChurn(c *gc.C) ([]state.LinkLayerDeviceArgs, jujutxn.TestHook) {
-	parentArgs := state.LinkLayerDeviceArgs{
-		Name: "parent",
-		Type: state.BridgeDevice,
-	}
+func (s *linkLayerDevicesStateSuite) prepareAddLinkLayerDevicesWithStateChurn(c *gc.C) (state.LinkLayerDeviceArgs, jujutxn.TestHook) {
+	parent := s.addNamedDevice(c, "parent")
 	childArgs := state.LinkLayerDeviceArgs{
 		Name:       "child",
 		Type:       state.EthernetDevice,
-		ParentName: "parent",
+		ParentName: parent.Name(),
 	}
 
 	churnHook := jujutxn.TestHook{
 		Before: func() {
-			s.assertNoDevicesOnMachine(c, s.machine)
-			err := s.machine.AddLinkLayerDevices(parentArgs)
+			s.assertAllLinkLayerDevicesOnMachineMatchCount(c, s.machine, 1) // just the parent
+			err := s.machine.AddLinkLayerDevices(childArgs)
 			c.Assert(err, jc.ErrorIsNil)
 		},
 		After: func() {
-			s.assertAllLinkLayerDevicesOnMachineMatchCount(c, s.machine, 1)
-			parent, err := s.machine.LinkLayerDevice("parent")
+			s.assertAllLinkLayerDevicesOnMachineMatchCount(c, s.machine, 2) // parent and child
+			child, err := s.machine.LinkLayerDevice("child")
 			c.Assert(err, jc.ErrorIsNil)
-			err = parent.Remove()
+			err = child.Remove()
 			c.Assert(err, jc.ErrorIsNil)
 		},
 	}
 
-	return []state.LinkLayerDeviceArgs{parentArgs, childArgs}, churnHook
+	return childArgs, churnHook
 }
 
 func (s *linkLayerDevicesStateSuite) TestAddLinkLayerDevicesWithModerateStateChurn(c *gc.C) {
-	allArgs, churnHook := s.prepareAddLinkLayerDevicesWithStateChurn(c)
+	childArgs, churnHook := s.prepareAddLinkLayerDevicesWithStateChurn(c)
 	defer state.SetTestHooks(c, s.State, churnHook, churnHook).Check()
-	s.assertNoDevicesOnMachine(c, s.machine)
+	s.assertAllLinkLayerDevicesOnMachineMatchCount(c, s.machine, 1) // parent only
 
-	s.addLinkLayerDevicesMultipleArgsSucceedsAndEnsureAllAdded(c, allArgs)
+	err := s.machine.AddLinkLayerDevices(childArgs)
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertAllLinkLayerDevicesOnMachineMatchCount(c, s.machine, 2) // both parent and child remain
 }
 
 func (s *linkLayerDevicesStateSuite) TestAddLinkLayerDevicesWithTooMuchStateChurn(c *gc.C) {
-	allArgs, churnHook := s.prepareAddLinkLayerDevicesWithStateChurn(c)
+	childArgs, churnHook := s.prepareAddLinkLayerDevicesWithStateChurn(c)
 	defer state.SetTestHooks(c, s.State, churnHook, churnHook, churnHook).Check()
-	s.assertNoDevicesOnMachine(c, s.machine)
+	s.assertAllLinkLayerDevicesOnMachineMatchCount(c, s.machine, 1) // parent only
 
-	err := s.machine.AddLinkLayerDevices(allArgs...)
+	err := s.machine.AddLinkLayerDevices(childArgs)
 	c.Assert(errors.Cause(err), gc.Equals, jujutxn.ErrExcessiveContention)
-
-	s.assertNoDevicesOnMachine(c, s.machine)
-}
-
-func (s *linkLayerDevicesStateSuite) TestAddLinkLayerDevicesWithHighConcurrency(c *gc.C) {
-	// Tested successfully multiple times with:
-	// $ cd $GOPATH/src/github.com/juju/juju/state; go test -c
-	// $ for i in {1..100}; do ./state.test -check.v -check.f HighCon & done
-	// The only observed issue (even with 500 vs 100 runs) is MgoSuite.SetUpTest()
-	// panicking due to/ "address already in use" coming from the test mongod
-	// instance, not the production code being tested below. And even then it
-	// happens in 1 or 2 out of 100 (or even 500) test runs.
-	parentArgs := state.LinkLayerDeviceArgs{
-		Name: "parent",
-		Type: state.BridgeDevice,
-	}
-	parentArgsWithID := parentArgs
-	parentArgsWithID.ProviderID = "parent-id"
-	childArgs := state.LinkLayerDeviceArgs{
-		Name:       "child",
-		Type:       state.EthernetDevice,
-		ParentName: "parent",
-	}
-	childArgsWithID := childArgs
-	childArgsWithID.ProviderID = "child-id"
-	// Use a map to randomize iteration order.
-	argsPermutations := map[string][]state.LinkLayerDeviceArgs{
-		"parent-child-no-ids":        []state.LinkLayerDeviceArgs{parentArgs, childArgs},
-		"child-parent-no-ids":        []state.LinkLayerDeviceArgs{childArgs, parentArgs},
-		"child-parent-with-ids":      []state.LinkLayerDeviceArgs{childArgsWithID, parentArgsWithID},
-		"parent-child-with-ids":      []state.LinkLayerDeviceArgs{parentArgsWithID, childArgsWithID},
-		"parent-with-id-child-no-id": []state.LinkLayerDeviceArgs{parentArgsWithID, childArgs},
-		"child-no-id-parent-with-id": []state.LinkLayerDeviceArgs{childArgs, parentArgsWithID},
-		"child-with-id-parent-no-id": []state.LinkLayerDeviceArgs{childArgsWithID, parentArgs},
-	}
-	isAlreadyExistsOrProviderIDNotUniqueError := func(err error) bool {
-		return err != nil && (errors.IsAlreadyExists(err) || state.IsProviderIDNotUniqueError(err))
-	}
-
-	var wg sync.WaitGroup
-	wg.Add(len(argsPermutations))
-	waitAllStarted := make(chan struct{})                       // sync all goroutines to start simultaneously.
-	successfulArgs := make(chan []state.LinkLayerDeviceArgs, 1) // only 1 success expected.
-	for about, args := range argsPermutations {
-		go func(testAbout string, testArgs []state.LinkLayerDeviceArgs) {
-			defer wg.Done()
-			<-waitAllStarted
-
-			err := s.machine.AddLinkLayerDevices(testArgs...)
-			c.Logf("testing %q -> %v", testAbout, err)
-			if err != nil {
-				c.Assert(err, jc.Satisfies, isAlreadyExistsOrProviderIDNotUniqueError)
-			} else {
-				select {
-				case successfulArgs <- testArgs:
-				default:
-					// successfulArgs is buffered, so if we can't send there was
-					// more than on success.
-					c.Fatalf("unexpected: more than one success for args %+v", testArgs)
-				}
-			}
-		}(about, args)
-	}
-	close(waitAllStarted)
-	wg.Wait()
-
-	// Extract the successful parent and child args.
-	addedArgs := <-successfulArgs
-	c.Check(addedArgs, gc.HasLen, 2)
-	var addedChildArgs, addedParentArgs state.LinkLayerDeviceArgs
-	for _, args := range addedArgs {
-		if args.ParentName == "" {
-			addedParentArgs = args
-		} else {
-			addedChildArgs = args
-		}
-	}
-
-	addedDevices, err := s.machine.AllLinkLayerDevices()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(addedDevices, gc.HasLen, 2)
-	machineID, modelUUID := s.machine.Id(), s.State.ModelUUID()
-	for _, device := range addedDevices {
-		c.Check(device.Name(), gc.Matches, `(parent|child)`)
-		if device.Name() == "child" {
-			s.checkAddedDeviceMatchesArgs(c, device, addedChildArgs)
-		} else {
-			s.checkAddedDeviceMatchesArgs(c, device, addedParentArgs)
-		}
-		s.checkAddedDeviceMatchesMachineIDAndModelUUID(c, device, machineID, modelUUID)
-	}
+	s.assertAllLinkLayerDevicesOnMachineMatchCount(c, s.machine, 1) // only the parent remains
 }

--- a/state/linklayerdevices_test.go
+++ b/state/linklayerdevices_test.go
@@ -282,7 +282,7 @@ func (s *linkLayerDevicesStateSuite) TestAddLinkLayerDevicesRefusesToAddParentAn
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
 
-func (s *linkLayerDevicesStateSuite) addLinkLayerDevicesMultipleArgsSucceedsAndEnsureAllAdded(c *gc.C, allArgs []state.LinkLayerDeviceArgs) []*state.LinkLayerDevice {
+func (s *linkLayerDevicesStateSuite) addMultipleDevicesSucceedsAndCheckAllAdded(c *gc.C, allArgs []state.LinkLayerDeviceArgs) []*state.LinkLayerDevice {
 	err := s.machine.AddLinkLayerDevices(allArgs...)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -299,10 +299,10 @@ func (s *linkLayerDevicesStateSuite) addLinkLayerDevicesMultipleArgsSucceedsAndE
 }
 
 func (s *linkLayerDevicesStateSuite) TestAddLinkLayerDevicesMultipleChildrenOfExistingParentSucceeds(c *gc.C) {
-	s.addNamedParentDeviceWithChildren(c, "parent", "child1", "child2")
+	s.addNamedParentDeviceWithChildrenAndCheckAllAdded(c, "parent", "child1", "child2")
 }
 
-func (s *linkLayerDevicesStateSuite) addNamedParentDeviceWithChildren(c *gc.C, parentName string, childrenNames ...string) (
+func (s *linkLayerDevicesStateSuite) addNamedParentDeviceWithChildrenAndCheckAllAdded(c *gc.C, parentName string, childrenNames ...string) (
 	parent *state.LinkLayerDevice,
 	children []*state.LinkLayerDevice,
 ) {
@@ -316,8 +316,7 @@ func (s *linkLayerDevicesStateSuite) addNamedParentDeviceWithChildren(c *gc.C, p
 		}
 	}
 
-	children = s.addLinkLayerDevicesMultipleArgsSucceedsAndEnsureAllAdded(c, childrenArgs)
-	c.Check(children, gc.HasLen, len(childrenNames))
+	children = s.addMultipleDevicesSucceedsAndCheckAllAdded(c, childrenArgs)
 	return parent, children
 }
 
@@ -360,7 +359,7 @@ func (s *linkLayerDevicesStateSuite) TestMachineMethodReturnsMachine(c *gc.C) {
 }
 
 func (s *linkLayerDevicesStateSuite) TestParentDeviceReturnsLinkLayerDevice(c *gc.C) {
-	parent, children := s.addNamedParentDeviceWithChildren(c, "br-eth0", "eth0")
+	parent, children := s.addNamedParentDeviceWithChildrenAndCheckAllAdded(c, "br-eth0", "eth0")
 
 	child := children[0]
 	parentCopy, err := child.ParentDevice()
@@ -385,7 +384,7 @@ func (s *linkLayerDevicesStateSuite) TestMachineLinkLayerDeviceReturnsLinkLayerD
 
 func (s *linkLayerDevicesStateSuite) TestMachineAllLinkLayerDevices(c *gc.C) {
 	s.assertNoDevicesOnMachine(c, s.machine)
-	topParent, secondLevelParents := s.addNamedParentDeviceWithChildren(c, "br-bond0", "bond0")
+	topParent, secondLevelParents := s.addNamedParentDeviceWithChildrenAndCheckAllAdded(c, "br-bond0", "bond0")
 	secondLevelParent := secondLevelParents[0]
 
 	secondLevelChildrenArgs := []state.LinkLayerDeviceArgs{{
@@ -397,7 +396,7 @@ func (s *linkLayerDevicesStateSuite) TestMachineAllLinkLayerDevices(c *gc.C) {
 		Type:       state.EthernetDevice,
 		ParentName: secondLevelParent.Name(),
 	}}
-	s.addLinkLayerDevicesMultipleArgsSucceedsAndEnsureAllAdded(c, secondLevelChildrenArgs)
+	s.addMultipleDevicesSucceedsAndCheckAllAdded(c, secondLevelChildrenArgs)
 
 	results, err := s.machine.AllLinkLayerDevices()
 	c.Assert(err, jc.ErrorIsNil)
@@ -428,7 +427,7 @@ func (s *linkLayerDevicesStateSuite) TestMachineAllLinkLayerDevicesOnlyReturnsSa
 	s.assertNoDevicesOnMachine(c, s.machine)
 	s.assertNoDevicesOnMachine(c, s.otherStateMachine)
 
-	s.addNamedParentDeviceWithChildren(c, "foo", "foo.42")
+	s.addNamedParentDeviceWithChildrenAndCheckAllAdded(c, "foo", "foo.42")
 
 	results, err := s.machine.AllLinkLayerDevices()
 	c.Assert(err, jc.ErrorIsNil)
@@ -440,7 +439,7 @@ func (s *linkLayerDevicesStateSuite) TestMachineAllLinkLayerDevicesOnlyReturnsSa
 }
 
 func (s *linkLayerDevicesStateSuite) TestLinkLayerDeviceRemoveFailsWithExistingChildren(c *gc.C) {
-	parent, _ := s.addNamedParentDeviceWithChildren(c, "parent", "one-child", "another-child")
+	parent, _ := s.addNamedParentDeviceWithChildrenAndCheckAllAdded(c, "parent", "one-child", "another-child")
 
 	err := parent.Remove()
 	expectedError := fmt.Sprintf(
@@ -473,7 +472,7 @@ func (s *linkLayerDevicesStateSuite) TestLinkLayerDeviceRemoveTwiceStillSucceeds
 
 func (s *linkLayerDevicesStateSuite) TestMachineRemoveAllLinkLayerDevicesSuccess(c *gc.C) {
 	s.assertNoDevicesOnMachine(c, s.machine)
-	s.addNamedParentDeviceWithChildren(c, "foo", "bar")
+	s.addNamedParentDeviceWithChildrenAndCheckAllAdded(c, "foo", "bar")
 
 	err := s.machine.RemoveAllLinkLayerDevices()
 	c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
This is a prerequisite step to adding reference counting to track the
number of children a parent device has. Machine.AddLinkLayerDevices()
was simplified to not allow adding parent and its children in the same
call, as this will simplify the follow-up to add refcounts for parent
devices. Related to that, ErrParentDeviceHasChildren now takes a number
of children rather than a list of names.

(Review request: http://reviews.vapour.ws/r/3969/)