### PR TITLE
Add gce credential detection, improve autoload command

### DIFF
--- a/cloud/credentials.go
+++ b/cloud/credentials.go
@@ -69,6 +69,12 @@ func NewEmptyCredential() Credential {
 	return Credential{EmptyAuthType, nil}
 }
 
+// NewEmptyCloudCredential returns a new CloudCredential with an empty
+// default credential.
+func NewEmptyCloudCredential() *CloudCredential {
+	return &CloudCredential{AuthCredentials: map[string]Credential{"default": NewEmptyCredential()}}
+}
+
 // CredentialSchema describes the schema of a credential. Credential schemas
 // are specific to cloud providers.
 type CredentialSchema map[string]CredentialAttr

--- a/cmd/juju/cloud/detectcredentials.go
+++ b/cmd/juju/cloud/detectcredentials.go
@@ -8,16 +8,18 @@ import (
 	"github.com/juju/errors"
 	"launchpad.net/gnuflag"
 
+	"fmt"
 	jujucloud "github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/jujuclient"
+	"github.com/juju/utils/set"
 )
 
 type detectCredentialsCommand struct {
 	cmd.CommandBase
 	out cmd.Output
 
-	store jujuclient.CredentialUpdater
+	store jujuclient.CredentialStore
 
 	// Replace, if true, existing credential information is overwritten.
 	Replace bool
@@ -44,6 +46,7 @@ GCE
   Credentials are located in:
     1. A JSON file whose path is specified by the GOOGLE_APPLICATION_CREDENTIALS environment variable
     2. A JSON file in a knowm location eg on Linux $HOME/.config/gcloud/application_default_credentials.json
+  Default region is specified by the CLOUDSDK_COMPUTE_REGION environment variable.  
     
 OpenStack (see below)
   Credentials are located in:
@@ -53,6 +56,10 @@ OpenStack (see below)
 Some standard credentials locations may apply for more than one cloud. For example, there may be more than one
 OpenStack cloud defined. In such cases, the cloud name may be specified and only credentials for that cloud are
 searched, and when found, applied to that cloud specifically.
+
+If the detected credentials contain labeled credential values which already exist, the --replace option
+may be used to force the overwrite of any existing values. The --replace option is also used to specify
+that any default region value is overwritten.
 
 Example:
    juju autoload-credentials
@@ -94,6 +101,7 @@ func (c *detectCredentialsCommand) Init(args []string) (err error) {
 }
 
 func (c *detectCredentialsCommand) Run(ctxt *cmd.Context) error {
+	fmt.Fprintf(ctxt.Stdout, "Looking for cloud and credential information locally...")
 	clouds, _, err := jujucloud.PublicCloudMetadata(jujucloud.JujuPublicCloudsPath())
 	if err != nil {
 		return err
@@ -116,27 +124,55 @@ func (c *detectCredentialsCommand) Run(ctxt *cmd.Context) error {
 			logger.Warningf("cloud %q not available on this platform", cloud.Type)
 			continue
 		}
-		// TODO(wallyworld) - use --replace option
-		var creds []environs.LabeledCredential
 		if detectCredentials, ok := provider.(environs.ProviderCredentials); ok {
-			creds, err = detectCredentials.DetectCredentials()
+			detected, err := detectCredentials.DetectCredentials()
 			if err != nil && !errors.IsNotFound(err) {
 				logger.Warningf("could not detect credentials for %q: %v", cloudName, err)
 			}
-			if errors.IsNotFound(err) {
+			if errors.IsNotFound(err) || len(detected.AuthCredentials) == 0 {
 				continue
 			}
-			// TODO(wallyworld) - add default credentials and region
-			cloudCredential := jujucloud.CloudCredential{
-				AuthCredentials: make(map[string]jujucloud.Credential),
+			credentials, err := c.store.CredentialForCloud(cloudName)
+			if err != nil && !errors.IsNotFound(err) {
+				return errors.Trace(err)
 			}
-			for _, cred := range creds {
-				cloudCredential.AuthCredentials[cred.Label] = cred.Credential
+			if !c.Replace && err == nil {
+				existingCredNames := set.NewStrings()
+				for n := range credentials.AuthCredentials {
+					existingCredNames.Add(n)
+				}
+				newCredNames := set.NewStrings()
+				for n := range detected.AuthCredentials {
+					newCredNames.Add(credentialLabel(n))
+				}
+				if !existingCredNames.Intersection(newCredNames).IsEmpty() {
+					fmt.Fprintf(ctxt.Stdout, "Detected credentials would overwrite existing credentials.\nUse the --replace option.\n")
+					return nil
+				}
 			}
-			if err := c.store.UpdateCredential(cloudName, cloudCredential); err != nil {
+			if credentials == nil {
+				credentials = detected
+			} else {
+				for name, cred := range detected.AuthCredentials {
+					credName := credentialLabel(name)
+					fmt.Fprintf(ctxt.Stdout, "New %s cloud credential %q found", cloudName, credName)
+					credentials.AuthCredentials[credName] = cred
+				}
+			}
+			if c.Replace && detected.DefaultRegion != "" {
+				credentials.DefaultRegion = detected.DefaultRegion
+			}
+			if err := c.store.UpdateCredential(cloudName, *credentials); err != nil {
 				return errors.Annotatef(err, "cannot add credentials for cloud %q", cloudName)
 			}
 		}
 	}
 	return nil
+}
+
+func credentialLabel(name string) string {
+	if name != "" {
+		return name
+	}
+	return "default"
 }

--- a/cmd/juju/cloud/detectcredentials.go
+++ b/cmd/juju/cloud/detectcredentials.go
@@ -142,7 +142,10 @@ func (c *detectCredentialsCommand) Run(ctxt *cmd.Context) error {
 					existingCredNames.Add(n)
 				}
 				newCredNames := set.NewStrings()
-				for n := range detected.AuthCredentials {
+				for n, cred := range detected.AuthCredentials {
+					if cred.AuthType() == jujucloud.EmptyAuthType {
+						continue
+					}
 					newCredNames.Add(credentialLabel(n))
 				}
 				if !existingCredNames.Intersection(newCredNames).IsEmpty() {

--- a/cmd/juju/cloud/detectcredentials_test.go
+++ b/cmd/juju/cloud/detectcredentials_test.go
@@ -4,6 +4,8 @@
 package cloud_test
 
 import (
+	"strings"
+
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -18,28 +20,32 @@ import (
 type detectCredentialsSuite struct {
 	testing.FakeJujuXDGDataHomeSuite
 	store       jujuclient.CredentialStore
-	aCredential jujucloud.Credential
+	aCredential jujucloud.CloudCredential
 }
 
 var _ = gc.Suite(&detectCredentialsSuite{})
 
 type mockProvider struct {
 	environs.EnvironProvider
-	aCredential jujucloud.Credential
+	detectedCreds jujucloud.CloudCredential
 }
 
-func (p *mockProvider) DetectCredentials() ([]environs.LabeledCredential, error) {
-	return []environs.LabeledCredential{{
-		Label:      "label",
-		Credential: p.aCredential,
-	}}, nil
+func (p *mockProvider) DetectCredentials() (*jujucloud.CloudCredential, error) {
+	return &p.detectedCreds, nil
+}
+
+func (s *detectCredentialsSuite) SetUpSuite(c *gc.C) {
+	s.aCredential = jujucloud.CloudCredential{
+		DefaultRegion: "detected region",
+		AuthCredentials: map[string]jujucloud.Credential{
+			"test": jujucloud.NewCredential(jujucloud.AccessKeyAuthType, nil)},
+	}
+	environs.RegisterProvider("test", &mockProvider{detectedCreds: s.aCredential})
 }
 
 func (s *detectCredentialsSuite) SetUpTest(c *gc.C) {
 	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
 	s.store = jujuclienttesting.NewMemStore()
-	s.aCredential = jujucloud.NewCredential(jujucloud.AccessKeyAuthType, nil)
-	environs.RegisterProvider("test", &mockProvider{aCredential: s.aCredential})
 	err := jujucloud.WritePersonalCloudMetadata(map[string]jujucloud.Cloud{
 		"test": jujucloud.Cloud{Type: "test"},
 	})
@@ -50,7 +56,44 @@ func (s *detectCredentialsSuite) TestDetectCredentials(c *gc.C) {
 	s.detectCredentials(c, "test")
 	creds, err := s.store.CredentialForCloud("test")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(creds.AuthCredentials["label"], jc.DeepEquals, s.aCredential)
+	c.Assert(creds, jc.DeepEquals, &s.aCredential)
+}
+
+func (s *detectCredentialsSuite) TestDetectPromptsForOverwrite(c *gc.C) {
+	inital := jujucloud.CloudCredential{
+		AuthCredentials: map[string]jujucloud.Credential{
+			"test": jujucloud.NewCredential(jujucloud.UserPassAuthType, nil)},
+	}
+	s.store.UpdateCredential("test", inital)
+	out := s.detectCredentials(c, "test")
+	out = strings.Replace(out, "\n", "", -1)
+	c.Assert(out, gc.Equals, "Looking for cloud and credential information locally...Detected credentials would overwrite existing credentials.Use the --replace option.")
+
+	// Has not been replaced.
+	creds, err := s.store.CredentialForCloud("test")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(creds, jc.DeepEquals, &inital)
+}
+
+func (s *detectCredentialsSuite) TestDetectForceOverwrite(c *gc.C) {
+	inital := jujucloud.CloudCredential{
+		DefaultRegion: "region",
+		AuthCredentials: map[string]jujucloud.Credential{
+			"test":    jujucloud.NewCredential(jujucloud.UserPassAuthType, nil),
+			"another": jujucloud.NewCredential(jujucloud.AccessKeyAuthType, nil)},
+	}
+	s.store.UpdateCredential("test", inital)
+	out := s.detectCredentials(c, "test", "--replace")
+	out = strings.Replace(out, "\n", "", -1)
+	c.Assert(out, gc.Equals, `Looking for cloud and credential information locally...New test cloud credential "test" found`)
+
+	// Has been replaced.
+	creds, err := s.store.CredentialForCloud("test")
+	c.Assert(err, jc.ErrorIsNil)
+	replaced := inital
+	replaced.DefaultRegion = "detected region"
+	replaced.AuthCredentials["test"] = s.aCredential.AuthCredentials["test"]
+	c.Assert(creds, jc.DeepEquals, &replaced)
 }
 
 // TODO(wallyworld) - add more test coverage

--- a/cmd/juju/cloud/detectcredentials_test.go
+++ b/cmd/juju/cloud/detectcredentials_test.go
@@ -67,7 +67,7 @@ func (s *detectCredentialsSuite) TestDetectPromptsForOverwrite(c *gc.C) {
 	s.store.UpdateCredential("test", inital)
 	out := s.detectCredentials(c, "test")
 	out = strings.Replace(out, "\n", "", -1)
-	c.Assert(out, gc.Equals, "Looking for cloud and credential information locally...Detected credentials would overwrite existing credentials.Use the --replace option.")
+	c.Assert(out, gc.Equals, `Detected credentials [test] would overwrite existing credentials for cloud test.Use the --replace option.`)
 
 	// Has not been replaced.
 	creds, err := s.store.CredentialForCloud("test")
@@ -85,7 +85,7 @@ func (s *detectCredentialsSuite) TestDetectForceOverwrite(c *gc.C) {
 	s.store.UpdateCredential("test", inital)
 	out := s.detectCredentials(c, "test", "--replace")
 	out = strings.Replace(out, "\n", "", -1)
-	c.Assert(out, gc.Equals, `Looking for cloud and credential information locally...New test cloud credential "test" found`)
+	c.Assert(out, gc.Equals, `test cloud credential "test" found`)
 
 	// Has been replaced.
 	creds, err := s.store.CredentialForCloud("test")

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -242,7 +242,7 @@ var (
 
 var ambiguousCredentialError = errors.New(`
 more than one credential detected
-run juju autload-credentials and specify a credential using the --credential argument`[1:],
+run juju autoload-credentials and specify a credential using the --credential argument`[1:],
 )
 
 // Run connects to the environment specified on the command line and bootstraps
@@ -316,6 +316,7 @@ func (c *bootstrapCommand) Run(ctx *cmd.Context) (resultErr error) {
 		if len(detected.AuthCredentials) > 1 {
 			return ambiguousCredentialError
 		}
+		// We have one credential so extract it from the map.
 		var oneCredential jujucloud.Credential
 		for _, oneCredential = range detected.AuthCredentials {
 		}

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -240,6 +240,11 @@ var (
 	environsDestroy = environs.Destroy
 )
 
+var ambiguousCredentialError = errors.New(`
+more than one credential detected
+run juju autload-credentials and specify a credential using the --credential argument`[1:],
+)
+
 // Run connects to the environment specified on the command line and bootstraps
 // a juju in that environment if none already exists. If there is as yet no environments.yaml file,
 // the user is informed how to create one.
@@ -305,12 +310,21 @@ func (c *bootstrapCommand) Run(ctx *cmd.Context) (resultErr error) {
 			return errors.Annotatef(err, "detecting credentials for %q cloud provider", c.Cloud)
 		}
 		logger.Tracef("provider detected credentials: %v", detected)
-		if len(detected) == 0 {
+		if len(detected.AuthCredentials) == 0 {
 			return errors.NotFoundf("credentials for cloud %q", c.Cloud)
 		}
-		credential = &detected[0].Credential
+		if len(detected.AuthCredentials) > 1 {
+			return ambiguousCredentialError
+		}
+		var oneCredential jujucloud.Credential
+		for _, oneCredential = range detected.AuthCredentials {
+		}
+		credential = &oneCredential
 		regionName = c.Region
-		logger.Tracef("authenticating with %v", credential)
+		if regionName == "" {
+			regionName = detected.DefaultRegion
+		}
+		logger.Tracef("authenticating with region %q and %v", regionName, credential)
 	} else if err != nil {
 		return errors.Trace(err)
 	}

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -52,6 +52,7 @@ gopkg.in/check.v1	git	b3d3430320d4260e5fea99841af984b3badcea63	2015-06-26T10:50:
 gopkg.in/errgo.v1	git	66cb46252b94c1f3d65646f54ee8043ab38d766c	2015-10-07T15:31:57Z
 gopkg.in/goose.v1	git	33121bddecedb2c9f9053c5c84ee729c379ab5ac	2015-11-13T22:25:24Z
 gopkg.in/inconshreveable/log15.v2	git	b105bd37f74e5d9dc7b6ad7806715c7a2b83fd3f	2015-09-21T21:38:54Z
+gopkg.in/ini.v1	git	776aa739ce9373377cd16f526cdf06cb4c89b40f	2016-02-22T23:24:41Z
 gopkg.in/juju/charm.v6-unstable	git	a53382ef6e1940abf20f1150bd203d0d57ac1a44	2016-02-09T19:49:50Z
 gopkg.in/juju/blobstore.v2	git	51fa6e26128d74e445c72d3a91af555151cc3654	2016-01-25T02:37:03Z
 gopkg.in/juju/charmrepo.v2-unstable	git	b17697d8bb60cdac7d8ffd61e1357c9977cc2096	2015-11-30T13:55:09Z

--- a/environs/interface.go
+++ b/environs/interface.go
@@ -77,19 +77,6 @@ type PrepareForBootstrapParams struct {
 	CloudStorageEndpoint string
 }
 
-// LabeledCredential defines a cloud credential with a label
-// The label may come from a well known config file for the
-// cloud, where credentials are listed for named users, or may
-// be empty if just a set of credential attributes are known.
-type LabeledCredential struct {
-	// Label is an optional tag defining the origin of the credential.
-	// Typically this is the user to whom the credential belongs.
-	Label string
-
-	// Credential is the credential value.
-	Credential cloud.Credential
-}
-
 // ProviderCredentials is an interface that an EnvironProvider implements
 // in order to validate and automatically detect credentials for clouds
 // supported by the provider.
@@ -111,7 +98,7 @@ type ProviderCredentials interface {
 	//
 	// If no credentials can be detected, DetectCredentials should
 	// return an error satisfying errors.IsNotFound.
-	DetectCredentials() ([]LabeledCredential, error)
+	DetectCredentials() (*cloud.CloudCredential, error)
 }
 
 // CloudRegionDetector is an interface that an EnvironProvider implements

--- a/provider/azure/credentials.go
+++ b/provider/azure/credentials.go
@@ -7,7 +7,6 @@ import (
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/cloud"
-	"github.com/juju/juju/environs"
 )
 
 // environPoviderCredentials is an implementation of
@@ -37,6 +36,6 @@ func (environProviderCredentials) CredentialSchemas() map[cloud.AuthType]cloud.C
 }
 
 // DetectCredentials is part of the environs.ProviderCredentials interface.
-func (environProviderCredentials) DetectCredentials() ([]environs.LabeledCredential, error) {
+func (environProviderCredentials) DetectCredentials() (*cloud.CloudCredential, error) {
 	return nil, errors.NotFoundf("credentials")
 }

--- a/provider/azure/credentials_test.go
+++ b/provider/azure/credentials_test.go
@@ -51,7 +51,6 @@ func (s *credentialsSuite) TestUserPassHiddenAttributes(c *gc.C) {
 }
 
 func (s *credentialsSuite) TestDetectCredentials(c *gc.C) {
-	credentials, err := s.provider.DetectCredentials()
+	_, err := s.provider.DetectCredentials()
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
-	c.Assert(credentials, gc.HasLen, 0)
 }

--- a/provider/cloudsigma/credentials.go
+++ b/provider/cloudsigma/credentials.go
@@ -6,7 +6,6 @@ package cloudsigma
 import (
 	"github.com/juju/errors"
 	"github.com/juju/juju/cloud"
-	"github.com/juju/juju/environs"
 )
 
 type environProviderCredentials struct{}
@@ -27,6 +26,6 @@ func (environProviderCredentials) CredentialSchemas() map[cloud.AuthType]cloud.C
 }
 
 // DetectCredentials is part of the environs.ProviderCredentials interface.
-func (environProviderCredentials) DetectCredentials() ([]environs.LabeledCredential, error) {
+func (environProviderCredentials) DetectCredentials() (*cloud.CloudCredential, error) {
 	return nil, errors.NotFoundf("credentials")
 }

--- a/provider/cloudsigma/credentials_test.go
+++ b/provider/cloudsigma/credentials_test.go
@@ -44,7 +44,6 @@ func (s *credentialsSuite) TestUserPassHiddenAttributes(c *gc.C) {
 }
 
 func (s *credentialsSuite) TestDetectCredentialsNotFound(c *gc.C) {
-	credentials, err := s.provider.DetectCredentials()
+	_, err := s.provider.DetectCredentials()
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
-	c.Assert(credentials, gc.HasLen, 0)
 }

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -514,8 +514,8 @@ func (p *environProvider) CredentialSchemas() map[cloud.AuthType]cloud.Credentia
 	return map[cloud.AuthType]cloud.CredentialSchema{cloud.EmptyAuthType: {}}
 }
 
-func (*environProvider) DetectCredentials() ([]environs.LabeledCredential, error) {
-	return []environs.LabeledCredential{{Credential: cloud.NewEmptyCredential()}}, nil
+func (*environProvider) DetectCredentials() (*cloud.CloudCredential, error) {
+	return cloud.NewEmptyCloudCredential(), nil
 }
 
 func (*environProvider) DetectRegions() ([]cloud.Region, error) {

--- a/provider/ec2/credentials.go
+++ b/provider/ec2/credentials.go
@@ -4,9 +4,14 @@
 package ec2
 
 import (
+	"os"
+	"path/filepath"
+	"runtime"
+
 	"github.com/juju/errors"
 	"github.com/juju/utils"
 	"gopkg.in/amz.v3/aws"
+	"gopkg.in/ini.v1"
 
 	"github.com/juju/juju/cloud"
 )
@@ -29,9 +34,69 @@ func (environProviderCredentials) CredentialSchemas() map[cloud.AuthType]cloud.C
 }
 
 // DetectCredentials is part of the environs.ProviderCredentials interface.
-func (environProviderCredentials) DetectCredentials() (*cloud.CloudCredential, error) {
-	// TODO(axw) check for credentials file as described at
-	// http://blogs.aws.amazon.com/security/post/Tx3D6U6WSFGOK2H/A-New-and-Standardized-Way-to-Manage-Credentials-in-the-AWS-SDKs
+func (e environProviderCredentials) DetectCredentials() (*cloud.CloudCredential, error) {
+	dir := credentialsDir()
+	credsFile := filepath.Join(dir, "credentials")
+	credInfo, err := ini.LooseLoad(credsFile)
+	if err != nil {
+		return nil, errors.Annotate(err, "loading AWS credentials file")
+	}
+	credInfo.NameMapper = ini.TitleUnderscore
+
+	if len(credInfo.Sections()) == 1 {
+		// No standard AWS credentials so try environment variables.
+		return e.detectEnvCredentials()
+	}
+
+	type accessKeyValues struct {
+		AwsAccessKeyId     string
+		AwsSecretAccessKey string
+	}
+	result := cloud.CloudCredential{
+		AuthCredentials: make(map[string]cloud.Credential),
+	}
+	for _, credName := range credInfo.SectionStrings() {
+		// No credentials at top level.
+		if credName == ini.DEFAULT_SECTION {
+			continue
+		}
+		values := new(accessKeyValues)
+		if err := credInfo.Section(credName).MapTo(values); err != nil {
+			return nil, errors.Annotatef(err, "invalid credential attributes in section %q", credName)
+		}
+		// Basic validation check
+		if values.AwsAccessKeyId == "" || values.AwsSecretAccessKey == "" {
+			logger.Warningf("missing aws credential attributes in credentials file section %q", credName)
+			continue
+		}
+		accessKeyCredential := cloud.NewCredential(
+			cloud.AccessKeyAuthType,
+			map[string]string{
+				"access-key": values.AwsAccessKeyId,
+				"secret-key": values.AwsSecretAccessKey,
+			},
+		)
+		result.AuthCredentials[credName] = accessKeyCredential
+	}
+
+	// See if there's also a default region defined.
+	configFile := filepath.Join(dir, "config")
+	configInfo, err := ini.LooseLoad(configFile)
+	if err != nil {
+		return nil, errors.Annotate(err, "loading AWS config file")
+	}
+	result.DefaultRegion = configInfo.Section("default").Key("region").String()
+	return &result, nil
+}
+
+func credentialsDir() string {
+	if runtime.GOOS == "windows" {
+		return filepath.Join(os.Getenv("USERPROFILE"), ".aws")
+	}
+	return filepath.Join(utils.Home(), ".aws")
+}
+
+func (environProviderCredentials) detectEnvCredentials() (*cloud.CloudCredential, error) {
 	auth, err := aws.EnvAuth()
 	if err != nil {
 		return nil, errors.NewNotFound(err, "credentials not found")

--- a/provider/ec2/credentials.go
+++ b/provider/ec2/credentials.go
@@ -43,6 +43,7 @@ func (e environProviderCredentials) DetectCredentials() (*cloud.CloudCredential,
 	}
 	credInfo.NameMapper = ini.TitleUnderscore
 
+	// There's always a section called "DEFAULT" for top level items.
 	if len(credInfo.Sections()) == 1 {
 		// No standard AWS credentials so try environment variables.
 		return e.detectEnvCredentials()
@@ -56,8 +57,8 @@ func (e environProviderCredentials) DetectCredentials() (*cloud.CloudCredential,
 		AuthCredentials: make(map[string]cloud.Credential),
 	}
 	for _, credName := range credInfo.SectionStrings() {
-		// No credentials at top level.
 		if credName == ini.DEFAULT_SECTION {
+			// No credentials at top level.
 			continue
 		}
 		values := new(accessKeyValues)

--- a/provider/ec2/credentials_test.go
+++ b/provider/ec2/credentials_test.go
@@ -46,24 +46,22 @@ func (s *credentialsSuite) TestAccessKeyHiddenAttributes(c *gc.C) {
 
 func (s *credentialsSuite) TestDetectCredentialsNotFound(c *gc.C) {
 	// No environment variables set, so no credentials should be found.
-	credentials, err := s.provider.DetectCredentials()
+	_, err := s.provider.DetectCredentials()
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
-	c.Assert(credentials, gc.HasLen, 0)
 }
 
 func (s *credentialsSuite) TestDetectCredentialsEnvironmentVariables(c *gc.C) {
+	s.PatchEnvironment("USER", "fred")
 	s.PatchEnvironment("AWS_ACCESS_KEY_ID", "key-id")
 	s.PatchEnvironment("AWS_SECRET_ACCESS_KEY", "secret-access-key")
 
 	credentials, err := s.provider.DetectCredentials()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(credentials, gc.HasLen, 1)
-	c.Assert(credentials[0], jc.DeepEquals, environs.LabeledCredential{
-		Credential: cloud.NewCredential(
-			cloud.AccessKeyAuthType, map[string]string{
-				"access-key": "key-id",
-				"secret-key": "secret-access-key",
-			},
-		),
-	})
+	c.Assert(credentials.AuthCredentials["fred"], jc.DeepEquals, cloud.NewCredential(
+		cloud.AccessKeyAuthType, map[string]string{
+			"access-key": "key-id",
+			"secret-key": "secret-access-key",
+		},
+	),
+	)
 }

--- a/provider/ec2/credentials_test.go
+++ b/provider/ec2/credentials_test.go
@@ -4,14 +4,20 @@
 package ec2_test
 
 import (
+	"os"
+	"path/filepath"
+	"runtime"
+
 	"github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs"
 	envtesting "github.com/juju/juju/environs/testing"
+	"io/ioutil"
 )
 
 type credentialsSuite struct {
@@ -51,6 +57,12 @@ func (s *credentialsSuite) TestDetectCredentialsNotFound(c *gc.C) {
 }
 
 func (s *credentialsSuite) TestDetectCredentialsEnvironmentVariables(c *gc.C) {
+	home := utils.Home()
+	dir := c.MkDir()
+	utils.SetHome(dir)
+	s.AddCleanup(func(*gc.C) {
+		utils.SetHome(home)
+	})
 	s.PatchEnvironment("USER", "fred")
 	s.PatchEnvironment("AWS_ACCESS_KEY_ID", "key-id")
 	s.PatchEnvironment("AWS_SECRET_ACCESS_KEY", "secret-access-key")
@@ -62,6 +74,63 @@ func (s *credentialsSuite) TestDetectCredentialsEnvironmentVariables(c *gc.C) {
 			"access-key": "key-id",
 			"secret-key": "secret-access-key",
 		},
-	),
-	)
+	))
+}
+
+func (s *credentialsSuite) assertDetectCredentialsKnownLocation(c *gc.C, dir string) {
+	location := filepath.Join(dir, ".aws")
+	err := os.MkdirAll(location, 0700)
+	c.Assert(err, jc.ErrorIsNil)
+	path := filepath.Join(location, "credentials")
+	credData := `
+[fred]
+aws_access_key_id=aws-key-id
+aws_secret_access_key=aws-secret-access-key
+`[1:]
+	err = ioutil.WriteFile(path, []byte(credData), 0600)
+	c.Assert(err, jc.ErrorIsNil)
+
+	path = filepath.Join(location, "config")
+	regionData := `
+[default]
+region=region
+`[1:]
+	err = ioutil.WriteFile(path, []byte(regionData), 0600)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Ensure any env vars are ignored.
+	s.PatchEnvironment("AWS_ACCESS_KEY_ID", "key-id")
+	s.PatchEnvironment("AWS_SECRET_ACCESS_KEY", "secret-access-key")
+
+	credentials, err := s.provider.DetectCredentials()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(credentials.DefaultRegion, gc.Equals, "region")
+	c.Assert(credentials.AuthCredentials["fred"], jc.DeepEquals, cloud.NewCredential(
+		cloud.AccessKeyAuthType, map[string]string{
+			"access-key": "aws-key-id",
+			"secret-key": "aws-secret-access-key",
+		},
+	))
+}
+
+func (s *credentialsSuite) TestDetectCredentialsKnownLocationUnix(c *gc.C) {
+	if runtime.GOOS == "windows" {
+		c.Skip("skipping on Windows")
+	}
+	home := utils.Home()
+	dir := c.MkDir()
+	utils.SetHome(dir)
+	s.AddCleanup(func(*gc.C) {
+		utils.SetHome(home)
+	})
+	s.assertDetectCredentialsKnownLocation(c, dir)
+}
+
+func (s *credentialsSuite) TestDetectCredentialsKnownLocationWindows(c *gc.C) {
+	if runtime.GOOS != "windows" {
+		c.Skip("skipping on non-Windows platform")
+	}
+	dir := c.MkDir()
+	s.PatchEnvironment("APPDATA", dir)
+	s.assertDetectCredentialsKnownLocation(c, dir)
 }

--- a/provider/gce/credentials.go
+++ b/provider/gce/credentials.go
@@ -5,10 +5,13 @@ package gce
 
 import (
 	"os"
+	"path/filepath"
+	"runtime"
 
 	"github.com/juju/errors"
+	"github.com/juju/utils"
+
 	"github.com/juju/juju/cloud"
-	"github.com/juju/juju/environs"
 	"github.com/juju/juju/provider/gce/google"
 )
 
@@ -41,8 +44,52 @@ func (environProviderCredentials) CredentialSchemas() map[cloud.AuthType]cloud.C
 }
 
 // DetectCredentials is part of the environs.ProviderCredentials interface.
-func (environProviderCredentials) DetectCredentials() ([]environs.LabeledCredential, error) {
-	return nil, errors.NotFoundf("credentials")
+func (environProviderCredentials) DetectCredentials() (*cloud.CloudCredential, error) {
+	// Google recommends credentials in a json file:
+	// 1. whose path is specified by the GOOGLE_APPLICATION_CREDENTIALS environment variable.
+	// 2. whose location is known to the gcloud command-line tool.
+	//   On Windows, this is %APPDATA%/gcloud/application_default_credentials.json.
+	//   On other systems, $HOME/.config/gcloud/application_default_credentials.json.
+
+	validatePath := func(possbleFilePath string) string {
+		if possbleFilePath == "" {
+			return ""
+		}
+		fi, err := os.Stat(possbleFilePath)
+		if err != nil || fi.IsDir() {
+			return ""
+		}
+		return possbleFilePath
+	}
+
+	possbleFilePath := validatePath(os.Getenv("GOOGLE_APPLICATION_CREDENTIALS"))
+	if possbleFilePath == "" {
+		possbleFilePath = validatePath(wellKnownCredentialsFile())
+	}
+	if _, err := parseJSONAuthFile(possbleFilePath); err != nil {
+		return nil, errors.Annotatef(err, "invalid json credential file %s", possbleFilePath)
+	}
+
+	user, err := utils.LocalUsername()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	cred := cloud.NewCredential(cloud.JSONFileAuthType, map[string]string{
+		"file": possbleFilePath,
+	})
+	return &cloud.CloudCredential{
+		DefaultRegion: os.Getenv("CLOUDSDK_COMPUTE_REGION"),
+		AuthCredentials: map[string]cloud.Credential{
+			user: cred,
+		}}, nil
+}
+
+func wellKnownCredentialsFile() string {
+	const f = "application_default_credentials.json"
+	if runtime.GOOS == "windows" {
+		return filepath.Join(os.Getenv("APPDATA"), "gcloud", f)
+	}
+	return filepath.Join(utils.Home(), ".config", "gcloud", f)
 }
 
 // parseJSONAuthFile parses the file with the given path, and extracts

--- a/provider/gce/credentials.go
+++ b/provider/gce/credentials.go
@@ -66,6 +66,9 @@ func (environProviderCredentials) DetectCredentials() (*cloud.CloudCredential, e
 	if possbleFilePath == "" {
 		possbleFilePath = validatePath(wellKnownCredentialsFile())
 	}
+	if possbleFilePath == "" {
+		return nil, errors.NotFoundf("gce credentials")
+	}
 	if _, err := parseJSONAuthFile(possbleFilePath); err != nil {
 		return nil, errors.Annotatef(err, "invalid json credential file %s", possbleFilePath)
 	}

--- a/provider/gce/credentials_test.go
+++ b/provider/gce/credentials_test.go
@@ -4,13 +4,20 @@
 package gce_test
 
 import (
-	"github.com/juju/errors"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"runtime"
+
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs"
 	envtesting "github.com/juju/juju/environs/testing"
+	"github.com/juju/juju/provider/gce/google"
 )
 
 type credentialsSuite struct {
@@ -33,10 +40,10 @@ func (s *credentialsSuite) TestCredentialSchemas(c *gc.C) {
 }
 
 var sampleCredentialAttributes = map[string]string{
-	"client-id":    "123",
-	"client-email": "test@example.com",
-	"project-id":   "fourfivesix",
-	"private-key":  "sewen",
+	"GCE_CLIENT_ID":    "123",
+	"GCE_CLIENT_EMAIL": "test@example.com",
+	"GCE_PROJECT_ID":   "fourfivesix",
+	"GCE_PRIVATE_KEY":  "sewen",
 }
 
 func (s *credentialsSuite) TestOAuth2CredentialsValid(c *gc.C) {
@@ -60,8 +67,52 @@ func (s *credentialsSuite) TestJSONFileCredentialsValid(c *gc.C) {
 	})
 }
 
-func (s *credentialsSuite) TestDetectCredentialsNotFound(c *gc.C) {
+func createCredsFile(c *gc.C, path string) string {
+	if path == "" {
+		dir := c.MkDir()
+		path = filepath.Join(dir, "creds.json")
+	}
+	creds, err := google.NewCredentials(sampleCredentialAttributes)
+	c.Assert(err, jc.ErrorIsNil)
+	err = ioutil.WriteFile(path, creds.JSONKey, 0644)
+	c.Assert(err, jc.ErrorIsNil)
+	return path
+}
+
+func (s *credentialsSuite) TestDetectCredentialsFromEnvVar(c *gc.C) {
+	jsonpath := createCredsFile(c, "")
+	s.PatchEnvironment("USER", "fred")
+	s.PatchEnvironment("GOOGLE_APPLICATION_CREDENTIALS", jsonpath)
+	s.PatchEnvironment("CLOUDSDK_COMPUTE_REGION", "region")
 	credentials, err := s.provider.DetectCredentials()
-	c.Assert(err, jc.Satisfies, errors.IsNotFound)
-	c.Assert(credentials, gc.HasLen, 0)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(credentials.DefaultRegion, gc.Equals, "region")
+	c.Assert(
+		credentials.AuthCredentials["fred"], jc.DeepEquals,
+		cloud.NewCredential(cloud.JSONFileAuthType, map[string]string{"file": jsonpath}))
+}
+
+func (s *credentialsSuite) TestDetectCredentialsKnownLocation(c *gc.C) {
+	if runtime.GOOS == "windows" {
+		c.Skip("test only works on Linux")
+	}
+	home := utils.Home()
+	dir := c.MkDir()
+	utils.SetHome(dir)
+	s.AddCleanup(func(*gc.C) {
+		utils.SetHome(home)
+	})
+	path := filepath.Join(dir, ".config", "gcloud")
+	err := os.MkdirAll(path, 0700)
+	c.Assert(err, jc.ErrorIsNil)
+	jsonpath := createCredsFile(c, filepath.Join(path, "application_default_credentials.json"))
+
+	s.PatchEnvironment("USER", "fred")
+	s.PatchEnvironment("CLOUDSDK_COMPUTE_REGION", "region")
+	credentials, err := s.provider.DetectCredentials()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(credentials.DefaultRegion, gc.Equals, "region")
+	c.Assert(
+		credentials.AuthCredentials["fred"], jc.DeepEquals,
+		cloud.NewCredential(cloud.JSONFileAuthType, map[string]string{"file": jsonpath}))
 }

--- a/provider/joyent/credentials.go
+++ b/provider/joyent/credentials.go
@@ -7,7 +7,6 @@ import (
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/cloud"
-	"github.com/juju/juju/environs"
 )
 
 type environProviderCredentials struct{}
@@ -43,6 +42,6 @@ func (environProviderCredentials) CredentialSchemas() map[cloud.AuthType]cloud.C
 }
 
 // DetectCredentials is part of the environs.ProviderCredentials interface.
-func (environProviderCredentials) DetectCredentials() ([]environs.LabeledCredential, error) {
+func (environProviderCredentials) DetectCredentials() (*cloud.CloudCredential, error) {
 	return nil, errors.NotFoundf("credentials")
 }

--- a/provider/joyent/credentials_test.go
+++ b/provider/joyent/credentials_test.go
@@ -49,7 +49,6 @@ func (s *credentialsSuite) TestUserPassHiddenAttributes(c *gc.C) {
 
 func (s *credentialsSuite) TestDetectCredentialsNotFound(c *gc.C) {
 	// No environment variables set, so no credentials should be found.
-	credentials, err := s.provider.DetectCredentials()
+	_, err := s.provider.DetectCredentials()
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
-	c.Assert(credentials, gc.HasLen, 0)
 }

--- a/provider/lxd/credentials.go
+++ b/provider/lxd/credentials.go
@@ -7,7 +7,6 @@ package lxd
 
 import (
 	"github.com/juju/juju/cloud"
-	"github.com/juju/juju/environs"
 )
 
 type environProviderCredentials struct{}
@@ -18,7 +17,6 @@ func (environProviderCredentials) CredentialSchemas() map[cloud.AuthType]cloud.C
 }
 
 // DetectCredentials is part of the environs.ProviderCredentials interface.
-func (environProviderCredentials) DetectCredentials() ([]environs.LabeledCredential, error) {
-	emptyCredential := cloud.NewEmptyCredential()
-	return []environs.LabeledCredential{{Credential: emptyCredential}}, nil
+func (environProviderCredentials) DetectCredentials() (*cloud.CloudCredential, error) {
+	return cloud.NewEmptyCloudCredential(), nil
 }

--- a/provider/lxd/credentials_test.go
+++ b/provider/lxd/credentials_test.go
@@ -35,6 +35,5 @@ func (s *credentialsSuite) TestCredentialSchemas(c *gc.C) {
 func (s *credentialsSuite) TestDetectCredentials(c *gc.C) {
 	credentials, err := s.provider.DetectCredentials()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(credentials, gc.HasLen, 1)
-	c.Assert(credentials[0], jc.DeepEquals, environs.LabeledCredential{Credential: cloud.NewEmptyCredential()})
+	c.Assert(credentials, jc.DeepEquals, cloud.NewEmptyCloudCredential())
 }

--- a/provider/maas/credentials.go
+++ b/provider/maas/credentials.go
@@ -6,7 +6,6 @@ package maas
 import (
 	"github.com/juju/errors"
 	"github.com/juju/juju/cloud"
-	"github.com/juju/juju/environs"
 )
 
 type environProviderCredentials struct{}
@@ -24,7 +23,7 @@ func (environProviderCredentials) CredentialSchemas() map[cloud.AuthType]cloud.C
 }
 
 // DetectCredentials is part of the environs.ProviderCredentials interface.
-func (environProviderCredentials) DetectCredentials() ([]environs.LabeledCredential, error) {
+func (environProviderCredentials) DetectCredentials() (*cloud.CloudCredential, error) {
 	// TODO(axw) find out where the MAAS CLI stores credentials.
 	return nil, errors.NotFoundf("credentials")
 }

--- a/provider/maas/credentials_test.go
+++ b/provider/maas/credentials_test.go
@@ -43,7 +43,6 @@ func (s *credentialsSuite) TestOAuth1HiddenAttributes(c *gc.C) {
 }
 
 func (s *credentialsSuite) TestDetectCredentialsNotFound(c *gc.C) {
-	credentials, err := s.provider.DetectCredentials()
+	_, err := s.provider.DetectCredentials()
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
-	c.Assert(credentials, gc.HasLen, 0)
 }

--- a/provider/manual/credentials.go
+++ b/provider/manual/credentials.go
@@ -5,7 +5,6 @@ package manual
 
 import (
 	"github.com/juju/juju/cloud"
-	"github.com/juju/juju/environs"
 )
 
 type environProviderCredentials struct{}
@@ -16,7 +15,6 @@ func (environProviderCredentials) CredentialSchemas() map[cloud.AuthType]cloud.C
 }
 
 // DetectCredentials is part of the environs.ProviderCredentials interface.
-func (environProviderCredentials) DetectCredentials() ([]environs.LabeledCredential, error) {
-	emptyCredential := cloud.NewEmptyCredential()
-	return []environs.LabeledCredential{{Credential: emptyCredential}}, nil
+func (environProviderCredentials) DetectCredentials() (*cloud.CloudCredential, error) {
+	return cloud.NewEmptyCloudCredential(), nil
 }

--- a/provider/manual/credentials_test.go
+++ b/provider/manual/credentials_test.go
@@ -35,6 +35,5 @@ func (s *credentialsSuite) TestCredentialSchemas(c *gc.C) {
 func (s *credentialsSuite) TestDetectCredentials(c *gc.C) {
 	credentials, err := s.provider.DetectCredentials()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(credentials, gc.HasLen, 1)
-	c.Assert(credentials[0], jc.DeepEquals, environs.LabeledCredential{Credential: cloud.NewEmptyCredential()})
+	c.Assert(credentials, jc.DeepEquals, cloud.NewEmptyCloudCredential())
 }

--- a/provider/openstack/credentials.go
+++ b/provider/openstack/credentials.go
@@ -7,10 +7,10 @@ import (
 	"os"
 
 	"github.com/juju/errors"
+	"github.com/juju/utils"
 	"gopkg.in/goose.v1/identity"
 
 	"github.com/juju/juju/cloud"
-	"github.com/juju/juju/environs"
 )
 
 type OpenstackCredentials struct{}
@@ -46,7 +46,7 @@ func (OpenstackCredentials) CredentialSchemas() map[cloud.AuthType]cloud.Credent
 }
 
 // DetectCredentials is part of the environs.ProviderCredentials interface.
-func (OpenstackCredentials) DetectCredentials() ([]environs.LabeledCredential, error) {
+func (OpenstackCredentials) DetectCredentials() (*cloud.CloudCredential, error) {
 	creds := identity.CredentialsFromEnv()
 	if creds.TenantName == "" {
 		return nil, errors.NewNotFound(nil, "OS_TENANT_NAME environment variable not set")
@@ -78,5 +78,13 @@ func (OpenstackCredentials) DetectCredentials() ([]environs.LabeledCredential, e
 			},
 		)
 	}
-	return []environs.LabeledCredential{{Credential: credential}}, nil
+
+	user, err := utils.LocalUsername()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return &cloud.CloudCredential{
+		AuthCredentials: map[string]cloud.Credential{
+			user: credential,
+		}}, nil
 }

--- a/provider/openstack/credentials_test.go
+++ b/provider/openstack/credentials_test.go
@@ -59,41 +59,40 @@ func (s *credentialsSuite) TestUserPassHiddenAttributes(c *gc.C) {
 
 func (s *credentialsSuite) TestDetectCredentialsNotFound(c *gc.C) {
 	// No environment variables set, so no credentials should be found.
-	credentials, err := s.provider.DetectCredentials()
+	_, err := s.provider.DetectCredentials()
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
-	c.Assert(credentials, gc.HasLen, 0)
 }
 
 func (s *credentialsSuite) TestDetectCredentialsAccessKeyEnvironmentVariables(c *gc.C) {
+	s.PatchEnvironment("USER", "fred")
 	s.PatchEnvironment("OS_TENANT_NAME", "gary")
 	s.PatchEnvironment("OS_ACCESS_KEY", "key-id")
 	s.PatchEnvironment("OS_SECRET_KEY", "secret-access-key")
 
 	credentials, err := s.provider.DetectCredentials()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(credentials, gc.HasLen, 1)
-	c.Assert(credentials[0], jc.DeepEquals, environs.LabeledCredential{Credential: cloud.NewCredential(
+	c.Assert(credentials.AuthCredentials["fred"], jc.DeepEquals, cloud.NewCredential(
 		cloud.AccessKeyAuthType, map[string]string{
 			"access-key":  "key-id",
 			"secret-key":  "secret-access-key",
 			"tenant-name": "gary",
 		},
-	)})
+	))
 }
 
 func (s *credentialsSuite) TestDetectCredentialsUserPassEnvironmentVariables(c *gc.C) {
+	s.PatchEnvironment("USER", "fred")
 	s.PatchEnvironment("OS_TENANT_NAME", "gary")
 	s.PatchEnvironment("OS_USERNAME", "bob")
 	s.PatchEnvironment("OS_PASSWORD", "dobbs")
 
 	credentials, err := s.provider.DetectCredentials()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(credentials, gc.HasLen, 1)
-	c.Assert(credentials[0], jc.DeepEquals, environs.LabeledCredential{Credential: cloud.NewCredential(
+	c.Assert(credentials.AuthCredentials["fred"], jc.DeepEquals, cloud.NewCredential(
 		cloud.UserPassAuthType, map[string]string{
 			"username":    "bob",
 			"password":    "dobbs",
 			"tenant-name": "gary",
 		},
-	)})
+	))
 }

--- a/provider/rackspace/provider_test.go
+++ b/provider/rackspace/provider_test.go
@@ -86,7 +86,7 @@ func (p *fakeProvider) CredentialSchemas() map[cloud.AuthType]cloud.CredentialSc
 	return nil
 }
 
-func (p *fakeProvider) DetectCredentials() ([]environs.LabeledCredential, error) {
+func (p *fakeProvider) DetectCredentials() (*cloud.CloudCredential, error) {
 	p.Push("DetectCredentials")
 	return nil, errors.NotFoundf("credentials")
 }

--- a/provider/vsphere/credentials.go
+++ b/provider/vsphere/credentials.go
@@ -9,7 +9,6 @@ import (
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/cloud"
-	"github.com/juju/juju/environs"
 )
 
 type environProviderCredentials struct{}
@@ -30,6 +29,6 @@ func (environProviderCredentials) CredentialSchemas() map[cloud.AuthType]cloud.C
 }
 
 // DetectCredentials is part of the environs.ProviderCredentials interface.
-func (environProviderCredentials) DetectCredentials() ([]environs.LabeledCredential, error) {
+func (environProviderCredentials) DetectCredentials() (*cloud.CloudCredential, error) {
 	return nil, errors.NotFoundf("credentials")
 }

--- a/provider/vsphere/credentials_test.go
+++ b/provider/vsphere/credentials_test.go
@@ -44,7 +44,6 @@ func (s *credentialsSuite) TestUserPassHiddenAttributes(c *gc.C) {
 }
 
 func (s *credentialsSuite) TestDetectCredentialsNotFound(c *gc.C) {
-	credentials, err := s.provider.DetectCredentials()
+	_, err := s.provider.DetectCredentials()
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
-	c.Assert(credentials, gc.HasLen, 0)
 }


### PR DESCRIPTION
The GCE provider now detects credentials by looking for the json file in known google locations.
The detect credentials method signature is reworked to allow detection to include region.
The autoload credentials command supports the --replace option.
Bootstrap complains if auto credential detection finds > 1 credentials.

Still todo: present detected credentials to user and allow them to choose which to import

(Review request: http://reviews.vapour.ws/r/3971/)