### PR TITLE
state: Reference counting for parent/child devices

### DIFF
--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -295,10 +295,6 @@ func allCollections() collectionSchema {
 		requestedNetworksC: {},
 		spacesC: {
 			indexes: []mgo.Index{{
-				// NOTE: Like the DocID field, ProviderId also has the model
-				// UUID as prefix to ensure uniqueness per model. However since
-				// not all providers support spaces, it can be empty, hence both
-				// unique and sparse.
 				Key:    []string{"providerid"},
 				Unique: true,
 				Sparse: true,
@@ -306,10 +302,6 @@ func allCollections() collectionSchema {
 		},
 		subnetsC: {
 			indexes: []mgo.Index{{
-				// NOTE: Like the DocID field, ProviderId also has the model
-				// UUID as prefix to ensure uniqueness per model. However since
-				// not all providers support subnets, it can be empty, hence both
-				// unique and sparse.
 				Key:    []string{"providerid"},
 				Unique: true,
 				Sparse: true,
@@ -317,16 +309,13 @@ func allCollections() collectionSchema {
 		},
 		linkLayerDevicesC: {
 			indexes: []mgo.Index{{
-				// NOTE: Like the DocID field, ProviderID also has the model
-				// UUID as prefix to ensure uniqueness per model. However since
-				// not all providers support devices with IDs, it can be
-				// empty, hence both unique and sparse.
 				Key:    []string{"providerid"},
 				Unique: true,
 				Sparse: true,
 			}},
 		},
-		endpointBindingsC: {},
+		linkLayerDevicesRefsC: {},
+		endpointBindingsC:     {},
 
 		// -----
 
@@ -440,6 +429,7 @@ const (
 	storageInstancesC        = "storageinstances"
 	subnetsC                 = "subnets"
 	linkLayerDevicesC        = "linklayerdevices"
+	linkLayerDevicesRefsC    = "linklayerdevicesrefs"
 	toolsmetadataC           = "toolsmetadata"
 	txnLogC                  = "txns.log"
 	txnsC                    = "txns"

--- a/state/linklayerdevices.go
+++ b/state/linklayerdevices.go
@@ -207,12 +207,12 @@ func (dev *LinkLayerDevice) Remove() (err error) {
 
 func (dev *LinkLayerDevice) errNoOperationsIfMissing() error {
 	_, err := dev.machineProxy().LinkLayerDevice(dev.doc.Name)
-	if err != nil && !errors.IsNotFound(err) {
+	if errors.IsNotFound(err) {
+		return jujutxn.ErrNoOperations
+	} else if err != nil {
 		return errors.Trace(err)
-	} else if err == nil {
-		return nil
 	}
-	return jujutxn.ErrNoOperations
+	return nil
 }
 
 // removeLinkLayerDeviceOps returns the list of operations needed to remove the

--- a/state/linklayerdevices.go
+++ b/state/linklayerdevices.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	"github.com/juju/errors"
-	"gopkg.in/mgo.v2/bson"
+	jujutxn "github.com/juju/txn"
 	"gopkg.in/mgo.v2/txn"
 
 	"github.com/juju/juju/network"
@@ -170,6 +170,18 @@ func (dev *LinkLayerDevice) ParentDevice() (*LinkLayerDevice, error) {
 	return dev.machineProxy().LinkLayerDevice(dev.doc.ParentName)
 }
 
+func (dev *LinkLayerDevice) parentDocID() string {
+	parentGlobalKey := dev.parentGlobalKey()
+	if parentGlobalKey == "" {
+		return ""
+	}
+	return dev.st.docID(parentGlobalKey)
+}
+
+func (dev *LinkLayerDevice) parentGlobalKey() string {
+	return linkLayerDeviceGlobalKey(dev.doc.MachineID, dev.doc.ParentName)
+}
+
 // machineProxy is a convenience wrapper for calling Machine.LinkLayerDevice()
 // or Machine.forEachLinkLayerDeviceDoc() from a *LinkLayerDevice.
 func (dev *LinkLayerDevice) machineProxy() *Machine {
@@ -182,29 +194,92 @@ func (dev *LinkLayerDevice) machineProxy() *Machine {
 func (dev *LinkLayerDevice) Remove() (err error) {
 	defer errors.DeferredAnnotatef(&err, "cannot remove %s", dev)
 
-	if numChildren, err := dev.numChildren(); err != nil {
-		return errors.Trace(err)
-	} else if numChildren > 0 {
-		return newParentDeviceHasChildrenError(dev.doc.Name, numChildren)
+	buildTxn := func(attempt int) ([]txn.Op, error) {
+		if attempt > 0 {
+			if err = dev.errNoOperationsIfMissing(); err != nil {
+				return nil, err
+			}
+		}
+		return removeLinkLayerDeviceOps(dev.st, dev.DocID(), dev.parentDocID())
 	}
-
-	ops := []txn.Op{removeLinkLayerDeviceOp(dev.doc.DocID)}
-	return dev.st.runTransaction(ops)
+	return dev.st.run(buildTxn)
 }
 
-func (dev *LinkLayerDevice) numChildren() (int, error) {
-	allChildren := 0
-	countAllChildren := func(resultDoc *linkLayerDeviceDoc) {
-		if resultDoc.ParentName == dev.doc.Name {
-			allChildren++
+func (dev *LinkLayerDevice) errNoOperationsIfMissing() error {
+	_, err := dev.machineProxy().LinkLayerDevice(dev.doc.Name)
+	if err != nil && !errors.IsNotFound(err) {
+		return errors.Trace(err)
+	} else if err == nil {
+		return nil
+	}
+	return jujutxn.ErrNoOperations
+}
+
+// removeLinkLayerDeviceOps returns the list of operations needed to remove the
+// device with the given linkLayerDeviceDocID, asserting it still exists and has
+// no children referring to it. If the device is a child, parentDeviceDocID will
+// be non-empty and the operations includes decrementing the parent's
+// NumChildren.
+func removeLinkLayerDeviceOps(st *State, linkLayerDeviceDocID, parentDeviceDocID string) ([]txn.Op, error) {
+	var numChildren int
+	if parentDeviceDocID == "" {
+		// If not a child, verify it has no children.
+		var err error
+		numChildren, err = getParentDeviceNumChildrenRefs(st, linkLayerDeviceDocID)
+		if err != nil {
+			return nil, errors.Trace(err)
 		}
 	}
-	selectOnly := bson.D{{"_id", 1}, {"name", 1}, {"parent-name", 1}}
-	err := dev.machineProxy().forEachLinkLayerDeviceDoc(selectOnly, countAllChildren)
-	if err != nil {
-		return 0, errors.Trace(err)
+
+	if numChildren > 0 {
+		deviceName := linkLayerDeviceNameFromDocID(linkLayerDeviceDocID)
+		return nil, newParentDeviceHasChildrenError(deviceName, numChildren)
 	}
-	return allChildren, nil
+
+	var ops []txn.Op
+	if parentDeviceDocID != "" {
+		ops = append(ops, decrementDeviceNumChildrenOp(parentDeviceDocID))
+	}
+	return append(ops,
+		removeLinkLayerDeviceDocOp(linkLayerDeviceDocID),
+		removeLinkLayerDevicesRefsOp(linkLayerDeviceDocID),
+	), nil
+}
+
+// linkLayerDeviceNameFromDocID extracts the last part of linkLayerDeviceDocID - the name.
+func linkLayerDeviceNameFromDocID(linkLayerDeviceDocID string) string {
+	lastHash := strings.LastIndex(linkLayerDeviceDocID, "#")
+	deviceName := linkLayerDeviceDocID[lastHash+1:]
+	return deviceName
+}
+
+// removeLinkLayerDeviceDocOp returns an operation to remove the
+// linkLayerDeviceDoc matching the given linkLayerDeviceDocID, asserting it
+// still exists.
+func removeLinkLayerDeviceDocOp(linkLayerDeviceDocID string) txn.Op {
+	return txn.Op{
+		C:      linkLayerDevicesC,
+		Id:     linkLayerDeviceDocID,
+		Assert: txn.DocExists,
+		Remove: true,
+	}
+}
+
+// removeLinkLayerDeviceUnconditionallyOps returns the list of operations to
+// unconditionally remove the device matching the given linkLayerDeviceDocID,
+// along with its linkLayerDevicesRefsDoc. No asserts are included for the
+// existence of both documents.
+func removeLinkLayerDeviceUnconditionallyOps(linkLayerDeviceDocID string) []txn.Op {
+	// Reuse the regular remove ops, but drop their asserts.
+	removeDeviceDocOp := removeLinkLayerDeviceDocOp(linkLayerDeviceDocID)
+	removeDeviceDocOp.Assert = nil
+	removeRefsOp := removeLinkLayerDevicesRefsOp(linkLayerDeviceDocID)
+	removeRefsOp.Assert = nil
+
+	return []txn.Op{
+		removeDeviceDocOp,
+		removeRefsOp,
+	}
 }
 
 // insertLinkLayerDeviceDocOp returns an operation inserting the given newDoc,
@@ -215,16 +290,6 @@ func insertLinkLayerDeviceDocOp(newDoc *linkLayerDeviceDoc) txn.Op {
 		Id:     newDoc.DocID,
 		Assert: txn.DocMissing,
 		Insert: *newDoc,
-	}
-}
-
-// removeLinkLayerDeviceOp returns the operation needed to remove the document
-// matching the given linkLayerDeviceDocID.
-func removeLinkLayerDeviceOp(linkLayerDeviceDocID string) txn.Op {
-	return txn.Op{
-		C:      linkLayerDevicesC,
-		Id:     linkLayerDeviceDocID,
-		Remove: true,
 	}
 }
 

--- a/state/linklayerdevices_refs.go
+++ b/state/linklayerdevices_refs.go
@@ -1,0 +1,98 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"github.com/juju/errors"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
+	"gopkg.in/mgo.v2/txn"
+)
+
+// linkLayerDevicesRefsDoc associates each known link-layer network device with
+// the number of its "children" devices, if any.
+type linkLayerDevicesRefsDoc struct {
+	// DocID is the (parent) device DocID (global key prefixed by ModelUUID).
+	DocID string `bson:"_id"`
+
+	// ModelUUID is the UUID of the model this interface belongs to.
+	ModelUUID string `bson:"model-uuid"`
+
+	// NumChildren is number of devices on the same machine which refer to this
+	// device as their parent.
+	NumChildren int `bson:"num-children"`
+}
+
+// insertLinkLayerDevicesRefsOp returns an operation to insert a new
+// linkLayerDevicesRefsDoc for the given modelUUID and linkLayerDeviceDocID,
+// with NumChildren=0.
+func insertLinkLayerDevicesRefsOp(modelUUID, linkLayerDeviceDocID string) txn.Op {
+	refsDoc := &linkLayerDevicesRefsDoc{
+		DocID:       linkLayerDeviceDocID,
+		ModelUUID:   modelUUID,
+		NumChildren: 0,
+	}
+	return txn.Op{
+		C:      linkLayerDevicesRefsC,
+		Id:     linkLayerDeviceDocID,
+		Assert: txn.DocMissing,
+		Insert: refsDoc,
+	}
+}
+
+// removeLinkLayerDevicesRefsOp returns an operation to remove the
+// linkLayerDevicesRefsDoc for the given linkLayerDeviceDocID, asserting the
+// document has NumChildren == 0.
+func removeLinkLayerDevicesRefsOp(linkLayerDeviceDocID string) txn.Op {
+	hasNoChildren := bson.D{{"num-children", 0}}
+	return txn.Op{
+		C:      linkLayerDevicesRefsC,
+		Id:     linkLayerDeviceDocID,
+		Assert: hasNoChildren,
+		Remove: true,
+	}
+}
+
+// getParentDeviceNumChildrenRefs returns the NumChildren value for the given
+// parentDeviceDocID. If the interfacesRefsDoc is missing, a NotFoundError and
+// zero children are returned.
+func getParentDeviceNumChildrenRefs(st *State, linkLayerDeviceDocID string) (int, error) {
+	devicesRefs, closer := st.getCollection(linkLayerDevicesRefsC)
+	defer closer()
+
+	var doc linkLayerDevicesRefsDoc
+	err := devicesRefs.FindId(linkLayerDeviceDocID).One(&doc)
+	if err == mgo.ErrNotFound {
+		return 0, errors.NotFoundf("number of children for device %q", linkLayerDeviceDocID)
+	} else if err != nil {
+		return 0, errors.Trace(err)
+	}
+	return doc.NumChildren, nil
+}
+
+// incrementDeviceNumChildrenOp returns an operation that increments the
+// NumChildren value of the linkLayerDevicesRefsDoc matching the given
+// linkLayerDeviceDocID, and asserting the document has NumChildren >= 0.
+func incrementDeviceNumChildrenOp(linkLayerDeviceDocID string) txn.Op {
+	hasZeroOrMoreChildren := bson.D{{"$gte", bson.D{{"num-children", 0}}}}
+	return txn.Op{
+		C:      linkLayerDevicesRefsC,
+		Id:     linkLayerDeviceDocID,
+		Assert: hasZeroOrMoreChildren,
+		Update: bson.D{{"$inc", bson.D{{"num-children", 1}}}},
+	}
+}
+
+// decrementDeviceNumChildrenOp returns an operation that decrements the
+// NumChildren value of the linkLayerDevicesRefsDoc matching the given
+// linkLayerDeviceDocID, and asserting the document has NumChildren >= 1.
+func decrementDeviceNumChildrenOp(linkLayerDeviceDocID string) txn.Op {
+	hasAtLeastOneMoreChild := bson.D{{"$gte", bson.D{{"num-children", 1}}}}
+	return txn.Op{
+		C:      linkLayerDevicesRefsC,
+		Id:     linkLayerDeviceDocID,
+		Assert: hasAtLeastOneMoreChild,
+		Update: bson.D{{"$inc", bson.D{{"num-children", -1}}}},
+	}
+}


### PR DESCRIPTION
Added linkLayerDevicesRefsC to track the number of children a parent device has.
For each created device an associated document is created with the same DocID in
the new collection. Inserting a new child device increments its parent's NumChildren
field of the linkLayerDevicesRefsDoc. Removing a child decrements NumChildren, if
it's still >= 1. Removing any device also checks for NumChildren > 0 and refuses to
remove when true. 

A few simplifications were made to tests and the code around AddLinkLayerDevices().

(Review request: http://reviews.vapour.ws/r/3972/)