### PR TITLE
support --resource on upgrade-charm

### DIFF
--- a/api/service/client.go
+++ b/api/service/client.go
@@ -135,7 +135,7 @@ func (c *Client) GetCharmURL(serviceName string) (*charm.URL, error) {
 	return charm.ParseURL(result.Result)
 }
 
-// SetCharmConfig holds the configuration for setting a new version of a charm
+// SetCharmConfig holds the configuration for setting a new revision of a charm
 // on a service.
 type SetCharmConfig struct {
 	// ServiceName is the name of the service to set the charm on.

--- a/api/service/client.go
+++ b/api/service/client.go
@@ -138,10 +138,17 @@ func (c *Client) GetCharmURL(serviceName string) (*charm.URL, error) {
 // SetCharmConfig holds the configuration for setting a new version of a charm
 // on a service.
 type SetCharmConfig struct {
+	// ServiceName is the name of the service to set the charm on.
 	ServiceName string
-	CharmUrl    string
+	// CharmUrl is the url for the charm.
+	CharmUrl string
+	// ForceSeries forces the use of the charm even if it doesn't match the
+	// series of the unit.
 	ForceSeries bool
-	ForceUnits  bool
+	// ForceUnits forces the upgrade on units in an error state.
+	ForceUnits bool
+	// ResourceIDs is a map of resource names to resource IDs to activate during
+	// the upgrade.
 	ResourceIDs map[string]string
 }
 

--- a/api/service/client.go
+++ b/api/service/client.go
@@ -135,13 +135,24 @@ func (c *Client) GetCharmURL(serviceName string) (*charm.URL, error) {
 	return charm.ParseURL(result.Result)
 }
 
+// SetCharmConfig holds the configuration for setting a new version of a charm
+// on a service.
+type SetCharmConfig struct {
+	ServiceName string
+	CharmUrl    string
+	ForceSeries bool
+	ForceUnits  bool
+	ResourceIDs map[string]string
+}
+
 // SetCharm sets the charm for a given service.
-func (c *Client) SetCharm(serviceName string, charmUrl string, forceSeries, forceUnits bool) error {
+func (c *Client) SetCharm(cfg SetCharmConfig) error {
 	args := params.ServiceSetCharm{
-		ServiceName: serviceName,
-		CharmUrl:    charmUrl,
-		ForceSeries: forceSeries,
-		ForceUnits:  forceUnits,
+		ServiceName: cfg.ServiceName,
+		CharmUrl:    cfg.CharmUrl,
+		ForceSeries: cfg.ForceSeries,
+		ForceUnits:  cfg.ForceUnits,
+		ResourceIDs: cfg.ResourceIDs,
 	}
 	return c.facade.FacadeCall("SetCharm", args, nil)
 }

--- a/api/service/client_test.go
+++ b/api/service/client_test.go
@@ -149,7 +149,13 @@ func (s *serviceSuite) TestServiceSetCharm(c *gc.C) {
 		c.Assert(args.ForceUnits, gc.Equals, true)
 		return nil
 	})
-	err := s.client.SetCharm("service", "charmURL", true, true)
+	cfg := service.SetCharmConfig{
+		ServiceName: "service",
+		CharmUrl:    "charmURL",
+		ForceSeries: true,
+		ForceUnits:  true,
+	}
+	err := s.client.SetCharm(cfg)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(called, jc.IsTrue)
 }

--- a/apiserver/charmrevisionupdater/updater_test.go
+++ b/apiserver/charmrevisionupdater/updater_test.go
@@ -109,7 +109,7 @@ func (s *charmVersionSuite) TestUpdateRevisions(c *gc.C) {
 	svc, err := s.State.Service("mysql")
 	c.Assert(err, jc.ErrorIsNil)
 	ch := s.AddCharmWithRevision(c, "mysql", 23)
-	err = svc.SetCharm(ch, false, true)
+	err = svc.SetCharm(ch, false, true, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	result, err = s.charmrevisionupdater.UpdateLatestRevisions()

--- a/apiserver/charmrevisionupdater/updater_test.go
+++ b/apiserver/charmrevisionupdater/updater_test.go
@@ -109,7 +109,11 @@ func (s *charmVersionSuite) TestUpdateRevisions(c *gc.C) {
 	svc, err := s.State.Service("mysql")
 	c.Assert(err, jc.ErrorIsNil)
 	ch := s.AddCharmWithRevision(c, "mysql", 23)
-	err = svc.SetCharm(ch, false, true, nil)
+	cfg := state.SetCharmConfig{
+		Charm:      ch,
+		ForceUnits: true,
+	}
+	err = svc.SetCharm(cfg)
 	c.Assert(err, jc.ErrorIsNil)
 
 	result, err = s.charmrevisionupdater.UpdateLatestRevisions()

--- a/apiserver/client/perm_test.go
+++ b/apiserver/client/perm_test.go
@@ -347,7 +347,11 @@ func opClientServiceUpdate(c *gc.C, st api.Connection, mst *state.State) (func()
 }
 
 func opClientServiceSetCharm(c *gc.C, st api.Connection, mst *state.State) (func(), error) {
-	err := service.NewClient(st).SetCharm("nosuch", "local:quantal/wordpress", false, false)
+	cfg := service.SetCharmConfig{
+		ServiceName: "nosuch",
+		CharmUrl:    "local:quantal/wordpress",
+	}
+	err := service.NewClient(st).SetCharm(cfg)
 	if params.IsCodeNotFound(err) {
 		err = nil
 	}

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -224,10 +224,17 @@ type ServiceUpdate struct {
 
 // ServiceSetCharm sets the charm for a given service.
 type ServiceSetCharm struct {
-	ServiceName string            `json:"servicename"`
-	CharmUrl    string            `json:"charmurl"`
-	ForceUnits  bool              `json:"forceunits"`
-	ForceSeries bool              `json:"forceseries"`
+	// ServiceName is the name of the service to set the charm on.
+	ServiceName string `json:"servicename"`
+	// CharmUrl is the new url for the charm.
+	CharmUrl string `json:"charmurl"`
+	// ForceUnits forces the upgrade on units in an error state.
+	ForceUnits bool `json:"forceunits"`
+	// ForceSeries forces the use of the charm even if it doesn't match the
+	// series of the unit.
+	ForceSeries bool `json:"forceseries"`
+	// ResourceIDs is a map of resource names to resource IDs to activate during
+	// the upgrade.
 	ResourceIDs map[string]string `json:"resourceids"`
 }
 

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -224,10 +224,11 @@ type ServiceUpdate struct {
 
 // ServiceSetCharm sets the charm for a given service.
 type ServiceSetCharm struct {
-	ServiceName string `json:"servicename"`
-	CharmUrl    string `json:"charmurl"`
-	ForceUnits  bool   `json:"forceunits"`
-	ForceSeries bool   `json:"forceseries"`
+	ServiceName string            `json:"servicename"`
+	CharmUrl    string            `json:"charmurl"`
+	ForceUnits  bool              `json:"forceunits"`
+	ForceSeries bool              `json:"forceseries"`
+	ResourceIDs map[string]string `json:"resourceids"`
 }
 
 // ServiceExpose holds the parameters for making the service Expose call.

--- a/apiserver/service/service.go
+++ b/apiserver/service/service.go
@@ -250,7 +250,7 @@ func (api *API) Update(args params.ServiceUpdate) error {
 	}
 	// Set the charm for the given service.
 	if args.CharmUrl != "" {
-		if err = api.serviceSetCharm(svc, args.CharmUrl, args.ForceSeries, args.ForceCharmUrl); err != nil {
+		if err = api.serviceSetCharm(svc, args.CharmUrl, args.ForceSeries, args.ForceCharmUrl, nil); err != nil {
 			return errors.Trace(err)
 		}
 	}
@@ -289,11 +289,11 @@ func (api *API) SetCharm(args params.ServiceSetCharm) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	return api.serviceSetCharm(service, args.CharmUrl, args.ForceSeries, args.ForceUnits)
+	return api.serviceSetCharm(service, args.CharmUrl, args.ForceSeries, args.ForceUnits, args.ResourceIDs)
 }
 
 // serviceSetCharm sets the charm for the given service.
-func (api *API) serviceSetCharm(service *state.Service, url string, forceSeries, forceUnits bool) error {
+func (api *API) serviceSetCharm(service *state.Service, url string, forceSeries, forceUnits bool, resourceIDs map[string]string) error {
 	curl, err := charm.ParseURL(url)
 	if err != nil {
 		return errors.Trace(err)
@@ -302,7 +302,7 @@ func (api *API) serviceSetCharm(service *state.Service, url string, forceSeries,
 	if err != nil {
 		return errors.Trace(err)
 	}
-	return service.SetCharm(sch, forceSeries, forceUnits)
+	return service.SetCharm(sch, forceSeries, forceUnits, resourceIDs)
 }
 
 // settingsYamlFromGetYaml will parse a yaml produced by juju get and generate

--- a/apiserver/service/service.go
+++ b/apiserver/service/service.go
@@ -302,7 +302,13 @@ func (api *API) serviceSetCharm(service *state.Service, url string, forceSeries,
 	if err != nil {
 		return errors.Trace(err)
 	}
-	return service.SetCharm(sch, forceSeries, forceUnits, resourceIDs)
+	cfg := state.SetCharmConfig{
+		Charm:       sch,
+		ForceSeries: forceSeries,
+		ForceUnits:  forceUnits,
+		ResourceIDs: resourceIDs,
+	}
+	return service.SetCharm(cfg)
 }
 
 // settingsYamlFromGetYaml will parse a yaml produced by juju get and generate

--- a/cmd/juju/service/bundle.go
+++ b/cmd/juju/service/bundle.go
@@ -691,7 +691,11 @@ func upgradeCharm(client *apiservice.Client, log deploymentLogger, service, id s
 	if url.WithRevision(-1).Path() != existing.WithRevision(-1).Path() {
 		return errors.Errorf("bundle charm %q is incompatible with existing charm %q", id, existing)
 	}
-	if err := client.SetCharm(service, id, false, false); err != nil {
+	cfg := apiservice.SetCharmConfig{
+		ServiceName: service,
+		CharmUrl:    id,
+	}
+	if err := client.SetCharm(cfg); err != nil {
 		return errors.Annotatef(err, "cannot upgrade charm to %q", id)
 	}
 	log.Infof("upgraded charm for existing service %s (from %s to %s)", service, existing, id)

--- a/cmd/juju/service/deploy.go
+++ b/cmd/juju/service/deploy.go
@@ -563,7 +563,7 @@ func (c *DeployCommand) deployCharm(
 		}
 	}()
 
-	ids, err := c.handleResources(serviceName, charmInfo.Meta.Resources)
+	ids, err := handleResources(c, c.Resources, serviceName, charmInfo.Meta.Resources)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -597,8 +597,12 @@ func (c *DeployCommand) deployCharm(
 	return err
 }
 
-func (c *DeployCommand) handleResources(serviceName string, metaResources map[string]charmresource.Meta) (map[string]string, error) {
-	if len(c.Resources) == 0 && len(metaResources) == 0 {
+type APICmd interface {
+	NewAPIRoot() (api.Connection, error)
+}
+
+func handleResources(c APICmd, resources map[string]string, serviceName string, metaResources map[string]charmresource.Meta) (map[string]string, error) {
+	if len(resources) == 0 && len(metaResources) == 0 {
 		return nil, nil
 	}
 
@@ -607,7 +611,7 @@ func (c *DeployCommand) handleResources(serviceName string, metaResources map[st
 		return nil, errors.Trace(err)
 	}
 
-	ids, err := resourceadapters.DeployResources(serviceName, c.Resources, metaResources, api)
+	ids, err := resourceadapters.DeployResources(serviceName, resources, metaResources, api)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/cmd/juju/service/upgradecharm.go
+++ b/cmd/juju/service/upgradecharm.go
@@ -193,7 +193,15 @@ func (c *upgradeCharmCommand) Run(ctx *cmd.Context) error {
 		return err
 	}
 
-	ids, err := handleResources(c, c.Resources, c.ServiceName, charmInfo.Meta.Resources)
+	metaRes := charmInfo.Meta.Resources
+	// only include resource metadata for the files we're actually uploading
+	for name, _ := range charmInfo.Meta.Resources {
+		if _, ok := c.Resources[name]; !ok {
+			delete(metaRes, name)
+		}
+	}
+
+	ids, err := handleResources(c, c.Resources, c.ServiceName, metaRes)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/cmd/juju/service/upgradecharm_resources_test.go
+++ b/cmd/juju/service/upgradecharm_resources_test.go
@@ -1,0 +1,111 @@
+// Copyright 2013 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package service_test
+
+import (
+	"bytes"
+	"io/ioutil"
+	"path"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	charmresource "gopkg.in/juju/charm.v6-unstable/resource"
+
+	"github.com/juju/juju/cmd/juju/service"
+	"github.com/juju/juju/component/all"
+	jujutesting "github.com/juju/juju/juju/testing"
+	"github.com/juju/juju/testcharms"
+	"github.com/juju/juju/testing"
+)
+
+type UpgradeCharmResourceSuite struct {
+	jujutesting.RepoSuite
+}
+
+var _ = gc.Suite(&UpgradeCharmResourceSuite{})
+
+func (s *UpgradeCharmResourceSuite) SetUpSuite(c *gc.C) {
+	s.RepoSuite.SetUpSuite(c)
+	all.RegisterForServer()
+}
+
+func (s *UpgradeCharmResourceSuite) SetUpTest(c *gc.C) {
+	s.RepoSuite.SetUpTest(c)
+	testcharms.Repo.ClonedDirPath(s.SeriesPath, "riak")
+
+	_, err := testing.RunCommand(c, service.NewDeployCommand(), "local:riak", "riak")
+	c.Assert(err, jc.ErrorIsNil)
+	riak, err := s.State.Service("riak")
+	c.Assert(err, jc.ErrorIsNil)
+	ch, forced, err := riak.Charm()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ch.Revision(), gc.Equals, 7)
+	c.Assert(forced, jc.IsFalse)
+}
+
+var riakResourceMeta = []byte(`
+name: riakresource
+summary: "K/V storage engine"
+description: "Scalable K/V Store in Erlang with Clocks :-)"
+provides:
+  endpoint:
+    interface: http
+  admin:
+    interface: http
+peers:
+  ring:
+    interface: riak
+resources:
+  data:
+    type: file
+    filename: foo.lib
+    description: some comment
+`)
+
+func (s *UpgradeCharmResourceSuite) TestUpgradeWithResources(c *gc.C) {
+	myriakPath := testcharms.Repo.ClonedDir(c.MkDir(), "riak")
+	err := ioutil.WriteFile(path.Join(myriakPath.Path, "metadata.yaml"), riakResourceMeta, 0644)
+	c.Assert(err, jc.ErrorIsNil)
+
+	data := []byte("some-data")
+	resourceFile := path.Join(c.MkDir(), "data.lib")
+	err = ioutil.WriteFile(resourceFile, data, 0644)
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, err = testing.RunCommand(c, service.NewUpgradeCharmCommand(),
+		"riak", "--path="+myriakPath.Path, "--resource", "data="+resourceFile)
+	c.Assert(err, jc.ErrorIsNil)
+
+	resources, err := s.State.Resources()
+	c.Assert(err, jc.ErrorIsNil)
+
+	sr, err := resources.ListResources("riak")
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(sr.Resources, gc.HasLen, 1)
+
+	c.Assert(sr.Resources[0].ServiceID, gc.Equals, "riak")
+
+	// Most of this is just a sanity check... this is all tested elsewhere.
+	c.Assert(sr.Resources[0].PendingID, gc.Equals, "")
+	c.Assert(sr.Resources[0].Username, gc.Not(gc.Equals), "")
+	c.Assert(sr.Resources[0].ID, gc.Not(gc.Equals), "")
+	c.Assert(sr.Resources[0].Timestamp.IsZero(), jc.IsFalse)
+
+	fp, err := charmresource.GenerateFingerprint(bytes.NewReader(data))
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Ensure we get the data we passed in from the metadata.yaml.
+	c.Assert(sr.Resources[0].Resource, gc.DeepEquals, charmresource.Resource{
+		Meta: charmresource.Meta{
+			Name:        "data",
+			Type:        charmresource.TypeFile,
+			Path:        "foo.lib",
+			Description: "some comment",
+		},
+		Origin:      charmresource.OriginUpload,
+		Fingerprint: fp,
+		Size:        int64(len(data)),
+	})
+}

--- a/cmd/juju/service/upgradecharm_test.go
+++ b/cmd/juju/service/upgradecharm_test.go
@@ -5,6 +5,7 @@ package service
 
 import (
 	"bytes"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -21,6 +22,7 @@ import (
 	"gopkg.in/juju/charmstore.v5-unstable"
 
 	"github.com/juju/juju/cmd/juju/common"
+	"github.com/juju/juju/cmd/modelcmd"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/rpc"
 	"github.com/juju/juju/state"
@@ -271,6 +273,31 @@ func (s *UpgradeCharmSuccessSuite) TestForcedSeriesUpgrade(c *gc.C) {
 	c.Assert(force, gc.Equals, false)
 	s.AssertCharmUploaded(c, ch.URL())
 	c.Assert(ch.URL().String(), gc.Equals, "local:precise/multi-series2-8")
+}
+
+func (s *UpgradeCharmSuccessSuite) TestInitWithResources(c *gc.C) {
+	testcharms.Repo.CharmArchivePath(s.SeriesPath, "dummy")
+	dir := c.MkDir()
+
+	foopath := path.Join(dir, "foo")
+	barpath := path.Join(dir, "bar")
+	err := ioutil.WriteFile(foopath, []byte("foo"), 0600)
+	c.Assert(err, jc.ErrorIsNil)
+	err = ioutil.WriteFile(barpath, []byte("bar"), 0600)
+	c.Assert(err, jc.ErrorIsNil)
+
+	res1 := fmt.Sprintf("foo=%s", foopath)
+	res2 := fmt.Sprintf("bar=%s", barpath)
+
+	d := upgradeCharmCommand{}
+	args := []string{"dummy", "--resource", res1, "--resource", res2}
+
+	err = testing.InitCommand(modelcmd.Wrap(&d), args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(d.Resources, gc.DeepEquals, map[string]string{
+		"foo": foopath,
+		"bar": barpath,
+	})
 }
 
 func (s *UpgradeCharmSuccessSuite) TestForcedUnitsUpgrade(c *gc.C) {

--- a/cmd/juju/status/status_test.go
+++ b/cmd/juju/status/status_test.go
@@ -2477,7 +2477,8 @@ func (ssc setServiceCharm) step(c *gc.C, ctx *context) {
 	c.Assert(err, jc.ErrorIsNil)
 	s, err := ctx.st.Service(ssc.name)
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.SetCharm(ch, false, false, nil)
+	cfg := state.SetCharmConfig{Charm: ch}
+	err = s.SetCharm(cfg)
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/cmd/juju/status/status_test.go
+++ b/cmd/juju/status/status_test.go
@@ -2477,7 +2477,7 @@ func (ssc setServiceCharm) step(c *gc.C, ctx *context) {
 	c.Assert(err, jc.ErrorIsNil)
 	s, err := ctx.st.Service(ssc.name)
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.SetCharm(ch, false, false)
+	err = s.SetCharm(ch, false, false, nil)
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/state/service.go
+++ b/state/service.go
@@ -543,11 +543,7 @@ func (s *Service) changeCharmOps(ch *Charm, forceUnits bool, resourceIDs map[str
 
 	if len(resourceIDs) > 0 {
 		// Collect pending resource resolution operations.
-		resources, err := s.st.Resources()
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		resOps, err := resources.NewResolvePendingResourcesOps(s.doc.Name, resourceIDs)
+		resOps, err := s.resolveResourceOps(resourceIDs)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -599,6 +595,15 @@ func (s *Service) changeCharmOps(ch *Charm, forceUnits bool, resourceIDs map[str
 
 	// And finally, decrement the old settings.
 	return append(ops, decOps...), nil
+}
+
+func (s *Service) resolveResourceOps(resourceIDs map[string]string) ([]txn.Op, error) {
+	// Collect pending resource resolution operations.
+	resources, err := s.st.Resources()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return resources.NewResolvePendingResourcesOps(s.doc.Name, resourceIDs)
 }
 
 // SetCharmConfig sets the charm for the service.

--- a/state/service.go
+++ b/state/service.go
@@ -601,25 +601,39 @@ func (s *Service) changeCharmOps(ch *Charm, forceUnits bool, resourceIDs map[str
 	return append(ops, decOps...), nil
 }
 
+// SetCharmConfig sets the charm for the service.
+type SetCharmConfig struct {
+	// Charm is the new charm to use for the service.
+	Charm *Charm
+	// ForceUnits forces the upgrade on units in an error state.
+	ForceUnits bool `json:"forceunits"`
+	// ForceSeries forces the use of the charm even if it doesn't match the
+	// series of the unit.
+	ForceSeries bool `json:"forceseries"`
+	// ResourceIDs is a map of resource names to resource IDs to activate during
+	// the upgrade.
+	ResourceIDs map[string]string `json:"resourceids"`
+}
+
 // SetCharm changes the charm for the service. New units will be started with
 // this charm, and existing units will be upgraded to use it.
 // If forceUnits is true, units will be upgraded even if they are in an error state.
 // If forceSeries is true, the charm will be used even if it's the service's series
 // is not supported by the charm.
-func (s *Service) SetCharm(ch *Charm, forceSeries, forceUnits bool, resourceIDs map[string]string) error {
-	if ch.Meta().Subordinate != s.doc.Subordinate {
+func (s *Service) SetCharm(cfg SetCharmConfig) error {
+	if cfg.Charm.Meta().Subordinate != s.doc.Subordinate {
 		return errors.Errorf("cannot change a service's subordinacy")
 	}
 	// For old style charms written for only one series, we still retain
 	// this check. Newer charms written for multi-series have a URL
 	// with series = "".
-	if ch.URL().Series != "" {
-		if ch.URL().Series != s.doc.Series {
+	if cfg.Charm.URL().Series != "" {
+		if cfg.Charm.URL().Series != s.doc.Series {
 			return errors.Errorf("cannot change a service's series")
 		}
-	} else if !forceSeries {
+	} else if !cfg.ForceSeries {
 		supported := false
-		for _, series := range ch.Meta().Series {
+		for _, series := range cfg.Charm.Meta().Series {
 			if series == s.doc.Series {
 				supported = true
 				break
@@ -627,8 +641,8 @@ func (s *Service) SetCharm(ch *Charm, forceSeries, forceUnits bool, resourceIDs 
 		}
 		if !supported {
 			supportedSeries := "no series"
-			if len(ch.Meta().Series) > 0 {
-				supportedSeries = strings.Join(ch.Meta().Series, ", ")
+			if len(cfg.Charm.Meta().Series) > 0 {
+				supportedSeries = strings.Join(cfg.Charm.Meta().Series, ", ")
 			}
 			return errors.Errorf("cannot upgrade charm, only these series are supported: %v", supportedSeries)
 		}
@@ -642,7 +656,7 @@ func (s *Service) SetCharm(ch *Charm, forceSeries, forceUnits bool, resourceIDs 
 			return err
 		}
 		supportedOS := false
-		for _, chSeries := range ch.Meta().Series {
+		for _, chSeries := range cfg.Charm.Meta().Series {
 			charmSeriesOS, err := series.GetOSFromSeries(chSeries)
 			if err != nil {
 				return nil
@@ -705,23 +719,23 @@ func (s *Service) SetCharm(ch *Charm, forceSeries, forceUnits bool, resourceIDs 
 		}}
 
 		// Make sure the service doesn't have this charm already.
-		sel := bson.D{{"_id", s.doc.DocID}, {"charmurl", ch.URL()}}
+		sel := bson.D{{"_id", s.doc.DocID}, {"charmurl", cfg.Charm.URL()}}
 		count, err := services.Find(sel).Count()
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
 		if count > 0 {
 			// Charm URL already set; just update the force flag.
-			sameCharm := bson.D{{"charmurl", ch.URL()}}
+			sameCharm := bson.D{{"charmurl", cfg.Charm.URL()}}
 			ops = append(ops, []txn.Op{{
 				C:      servicesC,
 				Id:     s.doc.DocID,
 				Assert: append(notDeadDoc, sameCharm...),
-				Update: bson.D{{"$set", bson.D{{"forcecharm", forceUnits}}}},
+				Update: bson.D{{"$set", bson.D{{"forcecharm", cfg.ForceUnits}}}},
 			}}...)
 		} else {
 			// Change the charm URL.
-			chng, err := s.changeCharmOps(ch, forceUnits, resourceIDs)
+			chng, err := s.changeCharmOps(cfg.Charm, cfg.ForceUnits, cfg.ResourceIDs)
 			if err != nil {
 				return nil, errors.Trace(err)
 			}
@@ -732,8 +746,8 @@ func (s *Service) SetCharm(ch *Charm, forceSeries, forceUnits bool, resourceIDs 
 	}
 	err := s.st.run(buildTxn)
 	if err == nil {
-		s.doc.CharmURL = ch.URL()
-		s.doc.ForceCharm = forceUnits
+		s.doc.CharmURL = cfg.Charm.URL()
+		s.doc.ForceCharm = cfg.ForceUnits
 		s.doc.CharmModifiedVersion = charmModifiedVersion + 1
 	}
 	return err

--- a/state/service_test.go
+++ b/state/service_test.go
@@ -622,10 +622,7 @@ func (s *ServiceSuite) TestSetCharmRetriesWithSameCharmURL(c *gc.C) {
 				c.Assert(force, jc.IsFalse)
 				c.Assert(currentCh.URL(), jc.DeepEquals, s.charm.URL())
 
-				cfg := state.SetCharmConfig{
-					Charm:      sch,
-					ForceUnits: true,
-				}
+				cfg := state.SetCharmConfig{Charm: sch}
 				err = s.mysql.SetCharm(cfg)
 				c.Assert(err, jc.ErrorIsNil)
 			},
@@ -651,7 +648,11 @@ func (s *ServiceSuite) TestSetCharmRetriesWithSameCharmURL(c *gc.C) {
 		},
 	).Check()
 
-	err := s.mysql.SetCharm(sch, false, true)
+	cfg := state.SetCharmConfig{
+		Charm:      sch,
+		ForceUnits: true,
+	}
+	err := s.mysql.SetCharm(cfg)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -659,7 +660,8 @@ func (s *ServiceSuite) TestSetCharmRetriesWhenOldSettingsChanged(c *gc.C) {
 	revno := 2 // revno 1 is used by SetUpSuite
 	oldCh := s.AddConfigCharm(c, "mysql", stringConfig, revno)
 	newCh := s.AddConfigCharm(c, "mysql", stringConfig, revno+1)
-	err := s.mysql.SetCharm(oldCh, false, false)
+	cfg := state.SetCharmConfig{Charm: oldCh}
+	err := s.mysql.SetCharm(cfg)
 	c.Assert(err, jc.ErrorIsNil)
 
 	defer state.SetBeforeHooks(c, s.State,
@@ -670,7 +672,7 @@ func (s *ServiceSuite) TestSetCharmRetriesWhenOldSettingsChanged(c *gc.C) {
 		nil, // Ensure there will be a retry.
 	).Check()
 
-	cfg := state.SetCharmConfig{
+	cfg = state.SetCharmConfig{
 		Charm:      newCh,
 		ForceUnits: true,
 	}

--- a/state/service_test.go
+++ b/state/service_test.go
@@ -57,7 +57,12 @@ func (s *ServiceSuite) TestSetCharm(c *gc.C) {
 
 	// Add a compatible charm and force it.
 	sch := s.AddMetaCharm(c, "mysql", metaBase, 2)
-	err = s.mysql.SetCharm(sch, false, true)
+
+	cfg := state.SetCharmConfig{
+		Charm:      sch,
+		ForceUnits: true,
+	}
+	err = s.mysql.SetCharm(cfg)
 	c.Assert(err, jc.ErrorIsNil)
 	ch, force, err = s.mysql.Charm()
 	c.Assert(err, jc.ErrorIsNil)
@@ -71,7 +76,11 @@ func (s *ServiceSuite) TestSetCharm(c *gc.C) {
 func (s *ServiceSuite) TestSetCharmLegacy(c *gc.C) {
 	chDifferentSeries := state.AddTestingCharmForSeries(c, s.State, "precise", "mysql")
 
-	err := s.mysql.SetCharm(chDifferentSeries, true, false)
+	cfg := state.SetCharmConfig{
+		Charm:       chDifferentSeries,
+		ForceSeries: true,
+	}
+	err := s.mysql.SetCharm(cfg)
 	c.Assert(err, gc.ErrorMatches, "cannot change a service's series")
 }
 
@@ -80,7 +89,10 @@ func (s *ServiceSuite) TestClientServiceSetCharmUnsupportedSeries(c *gc.C) {
 	svc := state.AddTestingServiceForSeries(c, s.State, "precise", "service", ch, s.Owner)
 
 	chDifferentSeries := state.AddTestingCharmMultiSeries(c, s.State, "multi-series2")
-	err := svc.SetCharm(chDifferentSeries, false, false)
+	cfg := state.SetCharmConfig{
+		Charm: chDifferentSeries,
+	}
+	err := svc.SetCharm(cfg)
 	c.Assert(err, gc.ErrorMatches, "cannot upgrade charm, only these series are supported: trusty, wily")
 }
 
@@ -89,7 +101,11 @@ func (s *ServiceSuite) TestClientServiceSetCharmUnsupportedSeriesForce(c *gc.C) 
 	svc := state.AddTestingServiceForSeries(c, s.State, "precise", "service", ch, s.Owner)
 
 	chDifferentSeries := state.AddTestingCharmMultiSeries(c, s.State, "multi-series2")
-	err := svc.SetCharm(chDifferentSeries, true, false)
+	cfg := state.SetCharmConfig{
+		Charm:       chDifferentSeries,
+		ForceSeries: true,
+	}
+	err := svc.SetCharm(cfg)
 	c.Assert(err, jc.ErrorIsNil)
 	svc, err = s.State.Service("service")
 	c.Assert(err, jc.ErrorIsNil)
@@ -103,17 +119,23 @@ func (s *ServiceSuite) TestClientServiceSetCharmWrongOS(c *gc.C) {
 	svc := state.AddTestingServiceForSeries(c, s.State, "precise", "service", ch, s.Owner)
 
 	chDifferentSeries := state.AddTestingCharmMultiSeries(c, s.State, "multi-series-windows")
-	err := svc.SetCharm(chDifferentSeries, true, false)
+	cfg := state.SetCharmConfig{
+		Charm:       chDifferentSeries,
+		ForceSeries: true,
+	}
+	err := svc.SetCharm(cfg)
 	c.Assert(err, gc.ErrorMatches, `cannot upgrade charm, OS "Ubuntu" not supported by charm`)
 }
 
 func (s *ServiceSuite) TestSetCharmPreconditions(c *gc.C) {
 	logging := s.AddTestingCharm(c, "logging")
-	err := s.mysql.SetCharm(logging, false, false)
+	cfg := state.SetCharmConfig{Charm: logging}
+	err := s.mysql.SetCharm(cfg)
 	c.Assert(err, gc.ErrorMatches, "cannot change a service's subordinacy")
 
 	othermysql := s.AddSeriesCharm(c, "mysql", "otherseries")
-	err = s.mysql.SetCharm(othermysql, false, false)
+	cfg2 := state.SetCharmConfig{Charm: othermysql}
+	err = s.mysql.SetCharm(cfg2)
 	c.Assert(err, gc.ErrorMatches, "cannot change a service's series")
 }
 
@@ -135,7 +157,8 @@ func (s *ServiceSuite) TestSetCharmUpdatesBindings(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	newCharm := s.AddMetaCharm(c, "mysql", metaExtraEndpoints, 43)
-	err = service.SetCharm(newCharm, false, false)
+	cfg := state.SetCharmConfig{Charm: newCharm}
+	err = service.SetCharm(cfg)
 	c.Assert(err, jc.ErrorIsNil)
 	updatedBindings, err := service.EndpointBindings()
 	c.Assert(err, jc.ErrorIsNil)
@@ -207,7 +230,8 @@ peers:
 	}
 	c.Check(readBindings, jc.DeepEquals, expectedBindings)
 
-	err = weirdService.SetCharm(weirdNewCharm, false, false)
+	cfg := state.SetCharmConfig{Charm: weirdNewCharm}
+	err = weirdService.SetCharm(cfg)
 	c.Assert(err, jc.ErrorIsNil)
 	readBindings, err = weirdService.EndpointBindings()
 	c.Assert(err, jc.ErrorIsNil)
@@ -308,14 +332,16 @@ func (s *ServiceSuite) TestSetCharmChecksEndpointsWithoutRelations(c *gc.C) {
 	revno := 2
 	ms := s.AddMetaCharm(c, "mysql", metaBase, revno)
 	svc := s.AddTestingService(c, "fakemysql", ms)
-	err := svc.SetCharm(ms, false, false)
+	cfg := state.SetCharmConfig{Charm: ms}
+	err := svc.SetCharm(cfg)
 	c.Assert(err, jc.ErrorIsNil)
 
 	for i, t := range setCharmEndpointsTests {
 		c.Logf("test %d: %s", i, t.summary)
 
 		newCh := s.AddMetaCharm(c, "mysql", t.meta, revno+i+1)
-		err = svc.SetCharm(newCh, false, false)
+		cfg := state.SetCharmConfig{Charm: newCh}
+		err = svc.SetCharm(cfg)
 		if t.err != "" {
 			c.Assert(err, gc.ErrorMatches, t.err)
 		} else {
@@ -331,13 +357,16 @@ func (s *ServiceSuite) TestSetCharmChecksEndpointsWithRelations(c *gc.C) {
 	revno := 2
 	providerCharm := s.AddMetaCharm(c, "mysql", metaDifferentProvider, revno)
 	providerSvc := s.AddTestingService(c, "myprovider", providerCharm)
-	err := providerSvc.SetCharm(providerCharm, false, false)
+
+	cfg := state.SetCharmConfig{Charm: providerCharm}
+	err := providerSvc.SetCharm(cfg)
 	c.Assert(err, jc.ErrorIsNil)
 
 	revno++
 	requirerCharm := s.AddMetaCharm(c, "mysql", metaDifferentRequirer, revno)
 	requirerSvc := s.AddTestingService(c, "myrequirer", requirerCharm)
-	err = requirerSvc.SetCharm(requirerCharm, false, false)
+	cfg = state.SetCharmConfig{Charm: requirerCharm}
+	err = requirerSvc.SetCharm(cfg)
 	c.Assert(err, jc.ErrorIsNil)
 
 	eps, err := s.State.InferEndpoints("myprovider:kludge", "myrequirer:kludge")
@@ -347,9 +376,10 @@ func (s *ServiceSuite) TestSetCharmChecksEndpointsWithRelations(c *gc.C) {
 
 	revno++
 	baseCharm := s.AddMetaCharm(c, "mysql", metaBase, revno)
-	err = providerSvc.SetCharm(baseCharm, false, false)
+	cfg = state.SetCharmConfig{Charm: baseCharm}
+	err = providerSvc.SetCharm(cfg)
 	c.Assert(err, gc.ErrorMatches, `cannot upgrade service "myprovider" to charm "local:quantal/quantal-mysql-4": would break relation "myrequirer:kludge myprovider:kludge"`)
-	err = requirerSvc.SetCharm(baseCharm, false, false)
+	err = requirerSvc.SetCharm(cfg)
 	c.Assert(err, gc.ErrorMatches, `cannot upgrade service "myrequirer" to charm "local:quantal/quantal-mysql-4": would break relation "myrequirer:kludge myprovider:kludge"`)
 }
 
@@ -429,7 +459,8 @@ func (s *ServiceSuite) TestSetCharmConfig(c *gc.C) {
 		c.Assert(err, jc.ErrorIsNil)
 
 		newCh := charms[t.endconfig]
-		err = svc.SetCharm(newCh, false, false)
+		cfg := state.SetCharmConfig{Charm: newCh}
+		err = svc.SetCharm(cfg)
 		var expectVals charm.Settings
 		var expectCh *state.Charm
 		if t.err != "" {
@@ -466,7 +497,11 @@ func (s *ServiceSuite) TestSetCharmWithDyingService(c *gc.C) {
 	err = s.mysql.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
 	assertLife(c, s.mysql, state.Dying)
-	err = s.mysql.SetCharm(sch, false, true)
+	cfg := state.SetCharmConfig{
+		Charm:      sch,
+		ForceUnits: true,
+	}
+	err = s.mysql.SetCharm(cfg)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -515,7 +550,11 @@ func (s *ServiceSuite) TestSetCharmWhenDead(c *gc.C) {
 		assertLife(c, s.mysql, state.Dead)
 	}).Check()
 
-	err := s.mysql.SetCharm(sch, false, true)
+	cfg := state.SetCharmConfig{
+		Charm:      sch,
+		ForceUnits: true,
+	}
+	err := s.mysql.SetCharm(cfg)
 	c.Assert(err, gc.Equals, state.ErrDead)
 }
 
@@ -525,7 +564,13 @@ func (s *ServiceSuite) TestSetCharmWithRemovedService(c *gc.C) {
 	err := s.mysql.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
 	assertRemoved(c, s.mysql)
-	err = s.mysql.SetCharm(sch, false, true)
+
+	cfg := state.SetCharmConfig{
+		Charm:      sch,
+		ForceUnits: true,
+	}
+
+	err = s.mysql.SetCharm(cfg)
 	c.Assert(err, gc.Equals, state.ErrDead)
 }
 
@@ -538,7 +583,11 @@ func (s *ServiceSuite) TestSetCharmWhenRemoved(c *gc.C) {
 		assertRemoved(c, s.mysql)
 	}).Check()
 
-	err := s.mysql.SetCharm(sch, false, true)
+	cfg := state.SetCharmConfig{
+		Charm:      sch,
+		ForceUnits: true,
+	}
+	err := s.mysql.SetCharm(cfg)
 	c.Assert(err, gc.Equals, state.ErrDead)
 }
 
@@ -553,7 +602,11 @@ func (s *ServiceSuite) TestSetCharmWhenDyingIsOK(c *gc.C) {
 		assertLife(c, s.mysql, state.Dying)
 	}).Check()
 
-	err := s.mysql.SetCharm(sch, false, true)
+	cfg := state.SetCharmConfig{
+		Charm:      sch,
+		ForceUnits: true,
+	}
+	err := s.mysql.SetCharm(cfg)
 	c.Assert(err, jc.ErrorIsNil)
 	assertLife(c, s.mysql, state.Dying)
 }
@@ -569,7 +622,11 @@ func (s *ServiceSuite) TestSetCharmRetriesWithSameCharmURL(c *gc.C) {
 				c.Assert(force, jc.IsFalse)
 				c.Assert(currentCh.URL(), jc.DeepEquals, s.charm.URL())
 
-				err = s.mysql.SetCharm(sch, false, false)
+				cfg := state.SetCharmConfig{
+					Charm:      sch,
+					ForceUnits: true,
+				}
+				err = s.mysql.SetCharm(cfg)
 				c.Assert(err, jc.ErrorIsNil)
 			},
 			After: func() {
@@ -613,7 +670,11 @@ func (s *ServiceSuite) TestSetCharmRetriesWhenOldSettingsChanged(c *gc.C) {
 		nil, // Ensure there will be a retry.
 	).Check()
 
-	err = s.mysql.SetCharm(newCh, false, true)
+	cfg := state.SetCharmConfig{
+		Charm:      newCh,
+		ForceUnits: true,
+	}
+	err = s.mysql.SetCharm(cfg)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -633,7 +694,8 @@ func (s *ServiceSuite) TestSetCharmRetriesWhenBothOldAndNewSettingsChanged(c *gc
 				c.Assert(err, jc.ErrorIsNil)
 				unit2, err := s.mysql.AddUnit()
 				c.Assert(err, jc.ErrorIsNil)
-				err = s.mysql.SetCharm(newCh, false, false)
+				cfg := state.SetCharmConfig{Charm: newCh}
+				err = s.mysql.SetCharm(cfg)
 				c.Assert(err, jc.ErrorIsNil)
 				assertSettingsRef(c, s.State, "mysql", newCh, 1)
 				assertNoSettingsRef(c, s.State, "mysql", oldCh)
@@ -645,7 +707,9 @@ func (s *ServiceSuite) TestSetCharmRetriesWhenBothOldAndNewSettingsChanged(c *gc
 				// settings as well.
 				err = s.mysql.UpdateConfigSettings(charm.Settings{"key": "value1"})
 				c.Assert(err, jc.ErrorIsNil)
-				err = s.mysql.SetCharm(oldCh, false, false)
+				cfg = state.SetCharmConfig{Charm: oldCh}
+
+				err = s.mysql.SetCharm(cfg)
 				c.Assert(err, jc.ErrorIsNil)
 				assertSettingsRef(c, s.State, "mysql", newCh, 1)
 				assertSettingsRef(c, s.State, "mysql", oldCh, 1)
@@ -673,13 +737,17 @@ func (s *ServiceSuite) TestSetCharmRetriesWhenBothOldAndNewSettingsChanged(c *gc
 				// SetCharm has refreshed its cached settings for oldCh
 				// and newCh. Change them again to trigger another
 				// attempt.
-				err := s.mysql.SetCharm(newCh, false, false)
+				cfg := state.SetCharmConfig{Charm: newCh}
+
+				err := s.mysql.SetCharm(cfg)
 				c.Assert(err, jc.ErrorIsNil)
 				assertSettingsRef(c, s.State, "mysql", newCh, 2)
 				assertSettingsRef(c, s.State, "mysql", oldCh, 1)
 				err = s.mysql.UpdateConfigSettings(charm.Settings{"key": "value3"})
 				c.Assert(err, jc.ErrorIsNil)
-				err = s.mysql.SetCharm(oldCh, false, false)
+
+				cfg = state.SetCharmConfig{Charm: oldCh}
+				err = s.mysql.SetCharm(cfg)
 				c.Assert(err, jc.ErrorIsNil)
 				assertSettingsRef(c, s.State, "mysql", newCh, 1)
 				assertSettingsRef(c, s.State, "mysql", oldCh, 2)
@@ -714,7 +782,11 @@ func (s *ServiceSuite) TestSetCharmRetriesWhenBothOldAndNewSettingsChanged(c *gc
 		},
 	).Check()
 
-	err := s.mysql.SetCharm(newCh, false, true)
+	cfg := state.SetCharmConfig{
+		Charm:      newCh,
+		ForceUnits: true,
+	}
+	err := s.mysql.SetCharm(cfg)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -723,7 +795,9 @@ func (s *ServiceSuite) TestSetCharmRetriesWhenOldBindingsChanged(c *gc.C) {
 	mysqlKey := state.ServiceGlobalKey(s.mysql.Name())
 	oldCharm := s.AddMetaCharm(c, "mysql", metaDifferentRequirer, revno)
 	newCharm := s.AddMetaCharm(c, "mysql", metaExtraEndpoints, revno+1)
-	err := s.mysql.SetCharm(oldCharm, false, false)
+
+	cfg := state.SetCharmConfig{Charm: oldCharm}
+	err := s.mysql.SetCharm(cfg)
 	c.Assert(err, jc.ErrorIsNil)
 
 	oldBindings, err := s.mysql.EndpointBindings()
@@ -782,7 +856,11 @@ func (s *ServiceSuite) TestSetCharmRetriesWhenOldBindingsChanged(c *gc.C) {
 		},
 	).Check()
 
-	err = s.mysql.SetCharm(newCharm, false, true)
+	cfg = state.SetCharmConfig{
+		Charm:      newCharm,
+		ForceUnits: true,
+	}
+	err = s.mysql.SetCharm(cfg)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -892,7 +970,8 @@ func (s *ServiceSuite) TestSettingsRefCountWorks(c *gc.C) {
 	assertNoSettingsRef(c, s.State, svcName, newCh)
 
 	// Changing to the same charm does not change the refcount.
-	err := svc.SetCharm(oldCh, false, false)
+	cfg := state.SetCharmConfig{Charm: oldCh}
+	err := svc.SetCharm(cfg)
 	c.Assert(err, jc.ErrorIsNil)
 	assertSettingsRef(c, s.State, svcName, oldCh, 1)
 	assertNoSettingsRef(c, s.State, svcName, newCh)
@@ -901,13 +980,15 @@ func (s *ServiceSuite) TestSettingsRefCountWorks(c *gc.C) {
 	// settings to be decremented, while newCh's settings is
 	// incremented. Consequently, because oldCh's refcount is 0, the
 	// settings doc will be removed.
-	err = svc.SetCharm(newCh, false, false)
+	cfg = state.SetCharmConfig{Charm: newCh}
+	err = svc.SetCharm(cfg)
 	c.Assert(err, jc.ErrorIsNil)
 	assertNoSettingsRef(c, s.State, svcName, oldCh)
 	assertSettingsRef(c, s.State, svcName, newCh, 1)
 
 	// The same but newCh swapped with oldCh.
-	err = svc.SetCharm(oldCh, false, false)
+	cfg = state.SetCharmConfig{Charm: oldCh}
+	err = svc.SetCharm(cfg)
 	c.Assert(err, jc.ErrorIsNil)
 	assertSettingsRef(c, s.State, svcName, oldCh, 1)
 	assertNoSettingsRef(c, s.State, svcName, newCh)
@@ -991,11 +1072,13 @@ func (s *ServiceSuite) TestNewPeerRelationsAddedOnUpgrade(c *gc.C) {
 	// No relations joined yet.
 	s.assertServiceRelations(c, s.mysql)
 
-	err := s.mysql.SetCharm(oldCh, false, false)
+	cfg := state.SetCharmConfig{Charm: oldCh}
+	err := s.mysql.SetCharm(cfg)
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertServiceRelations(c, s.mysql, "mysql:cluster")
 
-	err = s.mysql.SetCharm(newCh, false, false)
+	cfg = state.SetCharmConfig{Charm: newCh}
+	err = s.mysql.SetCharm(cfg)
 	c.Assert(err, jc.ErrorIsNil)
 	rels := s.assertServiceRelations(c, s.mysql, "mysql:cluster", "mysql:loadbalancer")
 
@@ -1185,7 +1268,12 @@ func (s *ServiceSuite) TestServiceRefresh(c *gc.C) {
 	s1, err := s.State.Service(s.mysql.Name())
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = s.mysql.SetCharm(s.charm, false, true)
+	cfg := state.SetCharmConfig{
+		Charm:      s.charm,
+		ForceUnits: true,
+	}
+
+	err = s.mysql.SetCharm(cfg)
 	c.Assert(err, jc.ErrorIsNil)
 
 	testch, force, err := s1.Charm()
@@ -1925,7 +2013,12 @@ func (s *ServiceSuite) TestWatchService(c *gc.C) {
 	// Make two changes, check one event.
 	err = service.ClearExposed()
 	c.Assert(err, jc.ErrorIsNil)
-	err = service.SetCharm(s.charm, false, true)
+
+	cfg := state.SetCharmConfig{
+		Charm:      s.charm,
+		ForceUnits: true,
+	}
+	err = service.SetCharm(cfg)
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertOneChange()
 
@@ -2123,7 +2216,9 @@ func (s *ServiceSuite) setCharmFromMeta(c *gc.C, oldMeta, newMeta string) error 
 	oldCh := s.AddMetaCharm(c, "mysql", oldMeta, 2)
 	newCh := s.AddMetaCharm(c, "mysql", newMeta, 3)
 	svc := s.AddTestingService(c, "test", oldCh)
-	return svc.SetCharm(newCh, false, false)
+
+	cfg := state.SetCharmConfig{Charm: newCh}
+	return svc.SetCharm(cfg)
 }
 
 func (s *ServiceSuite) TestSetCharmStorageRemoved(c *gc.C) {
@@ -2315,7 +2410,9 @@ func (s *ServiceSuite) TestSetCharmExtraBindingsUseDefaults(c *gc.C) {
 	c.Assert(setBindings, jc.DeepEquals, effectiveOld)
 
 	newCharm := s.AddMetaCharm(c, "mysql", metaExtraEndpoints, 43)
-	err = service.SetCharm(newCharm, false, false)
+
+	cfg := state.SetCharmConfig{Charm: newCharm}
+	err = service.SetCharm(cfg)
 	c.Assert(err, jc.ErrorIsNil)
 	setBindings, err = service.EndpointBindings()
 	c.Assert(err, jc.ErrorIsNil)
@@ -2341,7 +2438,9 @@ func (s *ServiceSuite) TestSetCharmHandlesMissingBindingsAsDefaults(c *gc.C) {
 	state.RemoveEndpointBindingsForService(c, service)
 
 	newCharm := s.AddMetaCharm(c, "mysql", metaExtraEndpoints, 70)
-	err := service.SetCharm(newCharm, false, false)
+
+	cfg := state.SetCharmConfig{Charm: newCharm}
+	err := service.SetCharm(cfg)
 	c.Assert(err, jc.ErrorIsNil)
 	setBindings, err := service.EndpointBindings()
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/unit_test.go
+++ b/state/unit_test.go
@@ -88,7 +88,8 @@ func (s *UnitSuite) TestConfigSettingsReflectCharm(c *gc.C) {
 	err := s.unit.SetCharmURL(s.charm.URL())
 	c.Assert(err, jc.ErrorIsNil)
 	newCharm := s.AddConfigCharm(c, "wordpress", "options: {}", 123)
-	err = s.service.SetCharm(newCharm, false, false)
+	cfg := state.SetCharmConfig{Charm: newCharm}
+	err = s.service.SetCharm(cfg)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Settings still reflect charm set on unit.
@@ -140,7 +141,8 @@ func (s *UnitSuite) TestWatchConfigSettings(c *gc.C) {
 
 	// Change service's charm; nothing detected.
 	newCharm := s.AddConfigCharm(c, "wordpress", floatConfig, 123)
-	err = s.service.SetCharm(newCharm, false, false)
+	cfg := state.SetCharmConfig{Charm: newCharm}
+	err = s.service.SetCharm(cfg)
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertNoChange()
 
@@ -645,7 +647,8 @@ func (s *UnitSuite) TestSetCharmURLRetriesWithDifferentURL(c *gc.C) {
 				// Set a different charm to force a retry: first on
 				// the service, so the settings are created, then on
 				// the unit.
-				err := s.service.SetCharm(sch, false, false)
+				cfg := state.SetCharmConfig{Charm: sch}
+				err := s.service.SetCharm(cfg)
 				c.Assert(err, jc.ErrorIsNil)
 				err = s.unit.SetCharmURL(sch.URL())
 				c.Assert(err, jc.ErrorIsNil)
@@ -653,7 +656,8 @@ func (s *UnitSuite) TestSetCharmURLRetriesWithDifferentURL(c *gc.C) {
 			After: func() {
 				// Set back the same charm on the service, so the
 				// settings refcount is correct..
-				err := s.service.SetCharm(s.charm, false, false)
+				cfg := state.SetCharmConfig{Charm: s.charm}
+				err := s.service.SetCharm(cfg)
 				c.Assert(err, jc.ErrorIsNil)
 			},
 		},
@@ -702,7 +706,8 @@ func (s *UnitSuite) TestDestroyChangeCharmRetry(c *gc.C) {
 	err := s.unit.SetCharmURL(s.charm.URL())
 	c.Assert(err, jc.ErrorIsNil)
 	newCharm := s.AddConfigCharm(c, "mysql", "options: {}", 99)
-	err = s.service.SetCharm(newCharm, false, false)
+	cfg := state.SetCharmConfig{Charm: newCharm}
+	err = s.service.SetCharm(cfg)
 	c.Assert(err, jc.ErrorIsNil)
 
 	defer state.SetRetryHooks(c, s.State, func() {

--- a/worker/uniter/util_test.go
+++ b/worker/uniter/util_test.go
@@ -945,7 +945,11 @@ func (s upgradeCharm) step(c *gc.C, ctx *context) {
 	curl := curl(s.revision)
 	sch, err := ctx.st.Charm(curl)
 	c.Assert(err, jc.ErrorIsNil)
-	err = ctx.svc.SetCharm(sch, false, s.forced)
+	cfg := state.SetCharmConfig{
+		Charm:      sch,
+		ForceUnits: s.forced,
+	}
+	err = ctx.svc.SetCharm(cfg)
 	c.Assert(err, jc.ErrorIsNil)
 	serveCharm{}.step(c, ctx)
 }


### PR DESCRIPTION
This change reuses the infrastructure written for `juju deploy --resource` to add a --resource flag to upgrade-charm.  

There's a key difference for upgrade-charm, though.  During deploy, we need to upload metadata for all resources, but during upgrade-charm, we already have metadata for all the resources, and we only need to upload metadata for resources that are being changed.

(Review request: http://reviews.vapour.ws/r/3974/)