### PR TITLE
Block major upgrade unless using compatible client

### DIFF
--- a/api/client_test.go
+++ b/api/client_test.go
@@ -528,7 +528,8 @@ func (s *clientSuite) TestSetEnvironAgentVersionDuringUpgrade(c *gc.C) {
 	})
 	err = machine.SetAgentVersion(version.MustParseBinary(agentVersion.String() + "-quantal-amd64"))
 	c.Assert(err, jc.ErrorIsNil)
-	nextVersion := version.MustParse("9.8.7")
+	nextVersion := version.Current.Number
+	nextVersion.Minor++
 	_, err = s.State.EnsureUpgradeInfo(machine.Id(), agentVersion, nextVersion)
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/apiserver/client/client.go
+++ b/apiserver/client/client.go
@@ -969,6 +969,10 @@ func (c *Client) SetEnvironAgentVersion(args params.SetEnvironAgentVersion) erro
 	if err := c.check.ChangeAllowed(); err != nil {
 		return errors.Trace(err)
 	}
+	if args.Version.Major > version.Current.Major && !args.MajorUpgradeAllowed {
+		return fmt.Errorf("major version upgrades must be initiated through a compatible client")
+	}
+
 	return c.api.state.SetEnvironAgentVersion(args.Version)
 }
 

--- a/apiserver/params/environment.go
+++ b/apiserver/params/environment.go
@@ -50,8 +50,8 @@ type ModifyEnvironUser struct {
 // SetEnvironAgentVersion contains the arguments for
 // SetEnvironAgentVersion client API call.
 type SetEnvironAgentVersion struct {
-	Version             version.Number
-	MajorUpgradeAllowed bool
+	Version             version.Number `json:"version"`
+	MajorUpgradeAllowed bool           `json:"majorupgradeallowed"`
 }
 
 // EnvUserInfo holds information on a user.

--- a/apiserver/params/environment.go
+++ b/apiserver/params/environment.go
@@ -50,7 +50,8 @@ type ModifyEnvironUser struct {
 // SetEnvironAgentVersion contains the arguments for
 // SetEnvironAgentVersion client API call.
 type SetEnvironAgentVersion struct {
-	Version version.Number
+	Version             version.Number
+	MajorUpgradeAllowed bool
 }
 
 // EnvUserInfo holds information on a user.


### PR DESCRIPTION
Major upgrades from 1.x to 2.x are not yet supported.

This PR backs out the commits to allow a major upgrade
in the client, and adds in an extra field in params for
SetEnvironAgentVersion that indicates a major upgrade
can be attempted.

Clients will not be updated to set that field until we
support upgrades from 1.x to 2.x

(Review request: http://reviews.vapour.ws/r/3985/)