### PR TITLE
destroy model doesn't use legacy config store

### DIFF
--- a/cmd/juju/model/destroy_test.go
+++ b/cmd/juju/model/destroy_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/juju/juju/cmd/juju/model"
 	"github.com/juju/juju/cmd/modelcmd"
 	cmdtesting "github.com/juju/juju/cmd/testing"
-	"github.com/juju/juju/environs/configstore"
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	_ "github.com/juju/juju/provider/dummy"
@@ -25,9 +24,8 @@ import (
 
 type DestroySuite struct {
 	testing.FakeJujuXDGDataHomeSuite
-	api         *fakeDestroyAPI
-	configstore configstore.Storage
-	store       *jujuclienttesting.MemStore
+	api   *fakeDestroyAPI
+	store *jujuclienttesting.MemStore
 }
 
 var _ = gc.Suite(&DestroySuite{})
@@ -49,42 +47,20 @@ func (s *DestroySuite) SetUpTest(c *gc.C) {
 	s.api = &fakeDestroyAPI{}
 	s.api.err = nil
 
-	var err error
-	s.configstore, err = configstore.Default()
-	c.Assert(err, jc.ErrorIsNil)
-
-	var envList = []struct {
-		name       string
-		serverUUID string
-		modelUUID  string
-	}{
-		{
-			name:       "test1:test1",
-			serverUUID: "test1-uuid",
-			modelUUID:  "test1-uuid",
-		}, {
-			name:       "test1:test2",
-			serverUUID: "test1-uuid",
-			modelUUID:  "test2-uuid",
-		},
-	}
-	for _, env := range envList {
-		info := s.configstore.CreateInfo(env.name)
-		info.SetAPIEndpoint(configstore.APIEndpoint{
-			Addresses:  []string{"localhost"},
-			CACert:     testing.CACert,
-			ModelUUID:  env.modelUUID,
-			ServerUUID: env.serverUUID,
-		})
-
-		err := info.Write()
-		c.Assert(err, jc.ErrorIsNil)
-	}
-
-	err = modelcmd.WriteCurrentController("test1")
+	err := modelcmd.WriteCurrentController("test1")
 	c.Assert(err, jc.ErrorIsNil)
 	s.store = jujuclienttesting.NewMemStore()
-	s.store.Controllers["test1"] = jujuclient.ControllerDetails{}
+	s.store.Controllers["test1"] = jujuclient.ControllerDetails{ControllerUUID: "test1-uuid"}
+	s.store.Models["test1"] = jujuclient.ControllerAccountModels{
+		AccountModels: map[string]*jujuclient.AccountModels{
+			"admin@local": {
+				Models: map[string]jujuclient.ModelDetails{
+					"test1": {"test1-uuid"},
+					"test2": {"test2-uuid"},
+				},
+			},
+		},
+	}
 	s.store.Accounts["test1"] = &jujuclient.ControllerAccounts{
 		CurrentAccount: "admin@local",
 	}
@@ -99,17 +75,19 @@ func (s *DestroySuite) NewDestroyCommand() cmd.Command {
 	return model.NewDestroyCommandForTest(s.api, s.store)
 }
 
-func checkEnvironmentExistsInStore(c *gc.C, name string, store configstore.Storage) {
-	_, err := store.ReadInfo(name)
+func checkModelExistsInStore(c *gc.C, name string, store jujuclient.ClientStore) {
+	controller, model := modelcmd.SplitModelName(name)
+	_, err := store.ModelByName(controller, "admin@local", model)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-func checkEnvironmentRemovedFromStore(c *gc.C, name string, store configstore.Storage) {
-	_, err := store.ReadInfo(name)
+func checkModelRemovedFromStore(c *gc.C, name string, store jujuclient.ClientStore) {
+	controller, model := modelcmd.SplitModelName(name)
+	_, err := store.ModelByName(controller, "admin@local", model)
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
 
-func (s *DestroySuite) TestDestroyNoEnvironmentNameError(c *gc.C) {
+func (s *DestroySuite) TestDestroyNoModelNameError(c *gc.C) {
 	_, err := s.runDestroyCommand(c)
 	c.Assert(err, gc.ErrorMatches, "no model specified")
 }
@@ -124,9 +102,9 @@ func (s *DestroySuite) TestDestroyUnknownArgument(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `unrecognized args: \["whoops"\]`)
 }
 
-func (s *DestroySuite) TestDestroyUnknownEnvironment(c *gc.C) {
+func (s *DestroySuite) TestDestroyUnknownModel(c *gc.C) {
 	_, err := s.runDestroyCommand(c, "foo")
-	c.Assert(err, gc.ErrorMatches, `cannot read model info: model "test1:foo" not found`)
+	c.Assert(err, gc.ErrorMatches, `cannot read model info: model test1:admin@local:foo not found`)
 }
 
 func (s *DestroySuite) TestDestroyCannotConnectToAPI(c *gc.C) {
@@ -134,39 +112,40 @@ func (s *DestroySuite) TestDestroyCannotConnectToAPI(c *gc.C) {
 	_, err := s.runDestroyCommand(c, "test2", "-y")
 	c.Assert(err, gc.ErrorMatches, "cannot destroy model: connection refused")
 	c.Check(c.GetTestLog(), jc.Contains, "failed to destroy model \"test2\"")
-	checkEnvironmentExistsInStore(c, "test1:test2", s.configstore)
+	checkModelExistsInStore(c, "test1:test2", s.store)
 }
 
 func (s *DestroySuite) TestSystemDestroyFails(c *gc.C) {
 	_, err := s.runDestroyCommand(c, "test1", "-y")
 	c.Assert(err, gc.ErrorMatches, `"test1" is a controller; use 'juju destroy-controller' to destroy it`)
-	checkEnvironmentExistsInStore(c, "test1:test1", s.configstore)
+	checkModelExistsInStore(c, "test1:test1", s.store)
 }
 
 func (s *DestroySuite) TestDestroy(c *gc.C) {
-	checkEnvironmentExistsInStore(c, "test1:test2", s.configstore)
+	checkModelExistsInStore(c, "test1:test2", s.store)
 	_, err := s.runDestroyCommand(c, "test2", "-y")
 	c.Assert(err, jc.ErrorIsNil)
-	checkEnvironmentRemovedFromStore(c, "test1:test2", s.configstore)
+	checkModelRemovedFromStore(c, "test1:test2", s.store)
 }
 
-func (s *DestroySuite) TestFailedDestroyEnvironment(c *gc.C) {
+func (s *DestroySuite) TestFailedDestroyModel(c *gc.C) {
 	s.api.err = errors.New("permission denied")
 	_, err := s.runDestroyCommand(c, "test1:test2", "-y")
 	c.Assert(err, gc.ErrorMatches, "cannot destroy model: permission denied")
-	checkEnvironmentExistsInStore(c, "test1:test2", s.configstore)
+	checkModelExistsInStore(c, "test1:test2", s.store)
 }
 
-func (s *DestroySuite) resetEnvironment(c *gc.C) {
-	info := s.configstore.CreateInfo("test1:test2")
-	info.SetAPIEndpoint(configstore.APIEndpoint{
-		Addresses:  []string{"localhost"},
-		CACert:     testing.CACert,
-		ModelUUID:  "test2-uuid",
-		ServerUUID: "test1-uuid",
-	})
-	err := info.Write()
-	c.Assert(err, jc.ErrorIsNil)
+func (s *DestroySuite) resetModel(c *gc.C) {
+	s.store.Models["test1"] = jujuclient.ControllerAccountModels{
+		AccountModels: map[string]*jujuclient.AccountModels{
+			"admin@local": {
+				Models: map[string]jujuclient.ModelDetails{
+					"test1": {"test1-uuid"},
+					"test2": {"test2-uuid"},
+				},
+			},
+		},
+	}
 }
 
 func (s *DestroySuite) TestDestroyCommandConfirmation(c *gc.C) {
@@ -186,7 +165,7 @@ func (s *DestroySuite) TestDestroyCommandConfirmation(c *gc.C) {
 		c.Fatalf("command took too long")
 	}
 	c.Check(testing.Stdout(ctx), gc.Matches, "WARNING!.*test2(.|\n)*")
-	checkEnvironmentExistsInStore(c, "test1:test1", s.configstore)
+	checkModelExistsInStore(c, "test1:test1", s.store)
 
 	// EOF on stdin: equivalent to answering no.
 	stdin.Reset()
@@ -199,7 +178,7 @@ func (s *DestroySuite) TestDestroyCommandConfirmation(c *gc.C) {
 		c.Fatalf("command took too long")
 	}
 	c.Check(testing.Stdout(ctx), gc.Matches, "WARNING!.*test2(.|\n)*")
-	checkEnvironmentExistsInStore(c, "test1:test2", s.configstore)
+	checkModelExistsInStore(c, "test1:test2", s.store)
 
 	for _, answer := range []string{"y", "Y", "yes", "YES"} {
 		stdin.Reset()
@@ -212,10 +191,10 @@ func (s *DestroySuite) TestDestroyCommandConfirmation(c *gc.C) {
 		case <-time.After(testing.LongWait):
 			c.Fatalf("command took too long")
 		}
-		checkEnvironmentRemovedFromStore(c, "test1:test2", s.configstore)
+		checkModelRemovedFromStore(c, "test1:test2", s.store)
 
-		// Add the test2 environment back into the store for the next test
-		s.resetEnvironment(c)
+		// Add the test2 model back into the store for the next test
+		s.resetModel(c)
 	}
 }
 

--- a/environs/simplestreams/simplestreams.go
+++ b/environs/simplestreams/simplestreams.go
@@ -416,7 +416,7 @@ func getMaybeSignedMetadata(source DataSource, params GetMetadataParams, signed 
 	logger.Tracef("looking for data index using URL %s", indexURL)
 	if errors.IsNotFound(err) || errors.IsUnauthorized(err) {
 		legacyIndexPath := makeIndexPath(defaultLegacyIndexPath)
-		logger.Errorf("%s not accessed, actual error: %v", indexPath, err)
+		logger.Tracef("%s not accessed, actual error: %v", indexPath, err)
 		logger.Tracef("%s not accessed, trying legacy index path: %s", indexPath, legacyIndexPath)
 		indexPath = legacyIndexPath
 		indexRef, indexURL, err = fetchIndex(


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/juju-core/+bug/1550580

juju destroy-model was broken because it still tried to use the legacy config store which we no longer use when creating models


(Review request: http://reviews.vapour.ws/r/3987/)