### PR TITLE
Fix typo in windows test

### DIFF
--- a/provider/ec2/credentials_test.go
+++ b/provider/ec2/credentials_test.go
@@ -131,6 +131,6 @@ func (s *credentialsSuite) TestDetectCredentialsKnownLocationWindows(c *gc.C) {
 		c.Skip("skipping on non-Windows platform")
 	}
 	dir := c.MkDir()
-	s.PatchEnvironment("APPDATA", dir)
+	s.PatchEnvironment("USERPROFILE", dir)
 	s.assertDetectCredentialsKnownLocation(c, dir)
 }


### PR DESCRIPTION
Wrong env var was patched, should have been USERPROFILE

(Review request: http://reviews.vapour.ws/r/3990/)