### PR TITLE
Bootstrap controller hosted model

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -37,6 +37,12 @@ const (
 	// dir that, if it exists, will cause a machine agent to uninstall
 	// when it receives the termination signal.
 	UninstallAgentFile = "uninstall-agent"
+
+	// BootstrapNonce is used as a nonce for the initial controller machine.
+	BootstrapNonce = "user-admin:bootstrap"
+
+	// BootstrapMachineId is the ID of the initial controller machine.
+	BootstrapMachineId = "0"
 )
 
 // These are base values used for the corresponding defaults.

--- a/agent/agentbootstrap/bootstrap.go
+++ b/agent/agentbootstrap/bootstrap.go
@@ -137,8 +137,10 @@ func InitializeState(
 	if err != nil {
 		return nil, nil, errors.Annotate(err, "creating hosted model")
 	}
+	if err := hostedModelState.SetModelConstraints(machineCfg.ModelConstraints); err != nil {
+		return nil, nil, errors.Annotate(err, "cannot set initial hosted model constraints")
+	}
 	hostedModelState.Close()
-	// TODO(axw) set hosted model constraints
 
 	return st, m, nil
 }
@@ -157,11 +159,11 @@ func paramsStateServingInfoToStateStateServingInfo(i params.StateServingInfo) st
 
 func initConstraintsAndBootstrapMachine(c agent.ConfigSetter, st *state.State, cfg BootstrapMachineConfig) (*state.Machine, error) {
 	if err := st.SetModelConstraints(cfg.ModelConstraints); err != nil {
-		return nil, errors.Errorf("cannot set initial environ constraints: %v", err)
+		return nil, errors.Annotate(err, "cannot set initial model constraints")
 	}
 	m, err := initBootstrapMachine(c, st, cfg)
 	if err != nil {
-		return nil, errors.Errorf("cannot initialize bootstrap machine: %v", err)
+		return nil, errors.Annotate(err, "cannot initialize bootstrap machine")
 	}
 	return m, nil
 }

--- a/agent/agentbootstrap/bootstrap.go
+++ b/agent/agentbootstrap/bootstrap.go
@@ -1,16 +1,19 @@
 // Copyright 2013 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package agent
+package agentbootstrap
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	"github.com/juju/names"
 	"github.com/juju/utils"
 	"github.com/juju/utils/series"
 
+	"github.com/juju/juju/agent"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/constraints"
+	"github.com/juju/juju/controller/modelmanager"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/mongo"
@@ -19,10 +22,9 @@ import (
 	"github.com/juju/juju/state/multiwatcher"
 )
 
-const (
-	// BootstrapNonce is used as a nonce for the controller machine.
-	BootstrapNonce = "user-admin:bootstrap"
-)
+var logger = loggo.GetLogger("juju.agent.agentbootstrap")
+
+const AdminModelName = "admin"
 
 // BootstrapMachineConfig holds configuration information
 // to attach to the bootstrap machine.
@@ -50,14 +52,12 @@ type BootstrapMachineConfig struct {
 	SharedSecret string
 }
 
-const BootstrapMachineId = "0"
-
 // InitializeState should be called on the bootstrap machine's agent
 // configuration. It uses that information to create the controller, dial the
 // controller, and initialize it. It also generates a new password for the
 // bootstrap machine and calls Write to save the the configuration.
 //
-// The envCfg values will be stored in the state's ModelConfig; the
+// The cfg values will be stored in the state's ModelConfig; the
 // machineCfg values will be used to configure the bootstrap Machine,
 // and its constraints will be also be used for the model-level
 // constraints. The connection to the controller will respect the
@@ -65,8 +65,16 @@ const BootstrapMachineId = "0"
 //
 // InitializeState returns the newly initialized state and bootstrap
 // machine. If it fails, the state may well be irredeemably compromised.
-func InitializeState(adminUser names.UserTag, c ConfigSetter, envCfg *config.Config, machineCfg BootstrapMachineConfig, dialOpts mongo.DialOpts, policy state.Policy) (_ *state.State, _ *state.Machine, resultErr error) {
-	if c.Tag() != names.NewMachineTag(BootstrapMachineId) {
+func InitializeState(
+	adminUser names.UserTag,
+	c agent.ConfigSetter,
+	cfg *config.Config,
+	hostedModelConfigAttrs map[string]interface{},
+	machineCfg BootstrapMachineConfig,
+	dialOpts mongo.DialOpts,
+	policy state.Policy,
+) (_ *state.State, _ *state.Machine, resultErr error) {
+	if c.Tag() != names.NewMachineTag(agent.BootstrapMachineId) {
 		return nil, nil, errors.Errorf("InitializeState not called with bootstrap machine's configuration")
 	}
 	servingInfo, ok := c.StateServingInfo()
@@ -87,7 +95,7 @@ func InitializeState(adminUser names.UserTag, c ConfigSetter, envCfg *config.Con
 	}
 
 	logger.Debugf("initializing address %v", info.Addrs)
-	st, err := state.Initialize(adminUser, info, envCfg, dialOpts, policy)
+	st, err := state.Initialize(adminUser, info, cfg, dialOpts, policy)
 	if err != nil {
 		return nil, nil, errors.Errorf("failed to initialize state: %v", err)
 	}
@@ -114,6 +122,24 @@ func InitializeState(adminUser names.UserTag, c ConfigSetter, envCfg *config.Con
 	if err != nil {
 		return nil, nil, err
 	}
+
+	// Create the initial hosted model, with the model config passed to
+	// bootstrap, which contains the UUID and name for the hosted model.
+	attrs := cfg.AllAttrs()
+	for k, v := range hostedModelConfigAttrs {
+		attrs[k] = v
+	}
+	hostedModelConfig, err := modelmanager.ModelConfigCreator{}.NewModelConfig(cfg, attrs)
+	if err != nil {
+		return nil, nil, errors.Annotate(err, "creating hosted model config")
+	}
+	_, hostedModelState, err := st.NewModel(hostedModelConfig, adminUser)
+	if err != nil {
+		return nil, nil, errors.Annotate(err, "creating hosted model")
+	}
+	hostedModelState.Close()
+	// TODO(axw) set hosted model constraints
+
 	return st, m, nil
 }
 
@@ -129,7 +155,7 @@ func paramsStateServingInfoToStateStateServingInfo(i params.StateServingInfo) st
 	}
 }
 
-func initConstraintsAndBootstrapMachine(c ConfigSetter, st *state.State, cfg BootstrapMachineConfig) (*state.Machine, error) {
+func initConstraintsAndBootstrapMachine(c agent.ConfigSetter, st *state.State, cfg BootstrapMachineConfig) (*state.Machine, error) {
 	if err := st.SetModelConstraints(cfg.ModelConstraints); err != nil {
 		return nil, errors.Errorf("cannot set initial environ constraints: %v", err)
 	}
@@ -152,7 +178,7 @@ func initMongoAdminUser(info mongo.Info, dialOpts mongo.DialOpts, password strin
 }
 
 // initBootstrapMachine initializes the initial bootstrap machine in state.
-func initBootstrapMachine(c ConfigSetter, st *state.State, cfg BootstrapMachineConfig) (*state.Machine, error) {
+func initBootstrapMachine(c agent.ConfigSetter, st *state.State, cfg BootstrapMachineConfig) (*state.Machine, error) {
 	logger.Infof("initialising bootstrap machine with config: %+v", cfg)
 
 	jobs := make([]state.MachineJob, len(cfg.Jobs))
@@ -166,7 +192,7 @@ func initBootstrapMachine(c ConfigSetter, st *state.State, cfg BootstrapMachineC
 	m, err := st.AddOneMachine(state.MachineTemplate{
 		Addresses:               cfg.Addresses,
 		Series:                  series.HostSeries(),
-		Nonce:                   BootstrapNonce,
+		Nonce:                   agent.BootstrapNonce,
 		Constraints:             cfg.BootstrapConstraints,
 		InstanceId:              cfg.InstanceId,
 		HardwareCharacteristics: cfg.Characteristics,
@@ -175,7 +201,7 @@ func initBootstrapMachine(c ConfigSetter, st *state.State, cfg BootstrapMachineC
 	if err != nil {
 		return nil, errors.Errorf("cannot create bootstrap machine in state: %v", err)
 	}
-	if m.Id() != BootstrapMachineId {
+	if m.Id() != agent.BootstrapMachineId {
 		return nil, errors.Errorf("bootstrap machine expected id 0, got %q", m.Id())
 	}
 	// Read the machine agent's password and change it to
@@ -198,7 +224,7 @@ func initBootstrapMachine(c ConfigSetter, st *state.State, cfg BootstrapMachineC
 }
 
 // initAPIHostPorts sets the initial API host/port addresses in state.
-func initAPIHostPorts(c ConfigSetter, st *state.State, addrs []network.Address, apiPort int) error {
+func initAPIHostPorts(c agent.ConfigSetter, st *state.State, addrs []network.Address, apiPort int) error {
 	var hostPorts []network.HostPort
 	// First try to select the correct address using the default space where all
 	// API servers should be accessible on.

--- a/agent/agentbootstrap/bootstrap_test.go
+++ b/agent/agentbootstrap/bootstrap_test.go
@@ -1,7 +1,7 @@
 // Copyright 2012, 2013 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package agent_test
+package agentbootstrap_test
 
 import (
 	"io/ioutil"
@@ -16,6 +16,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/agent"
+	"github.com/juju/juju/agent/agentbootstrap"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs"
@@ -107,7 +108,7 @@ LXC_BRIDGE="ignored"`[1:])
 		"10.0.3.4", // lxc bridge address filtered (-"-).
 		"10.0.3.3", // not a lxc bridge address
 	)
-	mcfg := agent.BootstrapMachineConfig{
+	mcfg := agentbootstrap.BootstrapMachineConfig{
 		Addresses:            initialAddrs,
 		BootstrapConstraints: expectBootstrapConstraints,
 		ModelConstraints:     expectModelConstraints,
@@ -128,8 +129,13 @@ LXC_BRIDGE="ignored"`[1:])
 	envCfg, err := config.New(config.NoDefaults, envAttrs)
 	c.Assert(err, jc.ErrorIsNil)
 
+	hostedModelConfigAttrs := map[string]interface{}{
+		"name": "hosted",
+		"uuid": utils.MustNewUUID().String(),
+	}
+
 	adminUser := names.NewLocalUserTag("agent-admin")
-	st, m, err := agent.InitializeState(adminUser, cfg, envCfg, mcfg, mongo.DefaultDialOpts(), environs.NewStatePolicy())
+	st, m, err := agentbootstrap.InitializeState(adminUser, cfg, envCfg, hostedModelConfigAttrs, mcfg, mongo.DefaultDialOpts(), environs.NewStatePolicy())
 	c.Assert(err, jc.ErrorIsNil)
 	defer st.Close()
 
@@ -139,9 +145,7 @@ LXC_BRIDGE="ignored"`[1:])
 	// Check that the environment has been set up.
 	env, err := st.Model()
 	c.Assert(err, jc.ErrorIsNil)
-	uuid, ok := envCfg.UUID()
-	c.Assert(ok, jc.IsTrue)
-	c.Assert(env.UUID(), gc.Equals, uuid)
+	c.Assert(env.UUID(), gc.Equals, envCfg.UUID())
 
 	// Check that initial admin user has been set up correctly.
 	modelTag := env.Tag().(names.ModelTag)
@@ -199,10 +203,18 @@ LXC_BRIDGE="ignored"`[1:])
 	newCfg, err := agent.ReadConfig(agent.ConfigPath(dataDir, machine0))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(newCfg.Tag(), gc.Equals, machine0)
-	c.Assert(agent.Password(newCfg), gc.Not(gc.Equals), pwHash)
-	c.Assert(agent.Password(newCfg), gc.Not(gc.Equals), testing.DefaultMongoPassword)
 	info, ok := cfg.MongoInfo()
 	c.Assert(ok, jc.IsTrue)
+
+	assertPasswordFails := func(password string) {
+		infoCopy := *info
+		infoCopy.Password = password
+		_, err := state.Open(newCfg.Model(), &infoCopy, mongo.DefaultDialOpts(), environs.NewStatePolicy())
+		c.Assert(err, gc.ErrorMatches, "cannot log in.*auth fails")
+	}
+	assertPasswordFails(pwHash)
+	assertPasswordFails(testing.DefaultMongoPassword)
+
 	st1, err := state.Open(newCfg.Model(), info, mongo.DefaultDialOpts(), environs.NewStatePolicy())
 	c.Assert(err, jc.ErrorIsNil)
 	defer st1.Close()
@@ -225,7 +237,7 @@ func (s *bootstrapSuite) TestInitializeStateWithStateServingInfoNotAvailable(c *
 	c.Assert(available, jc.IsFalse)
 
 	adminUser := names.NewLocalUserTag("agent-admin")
-	_, _, err = agent.InitializeState(adminUser, cfg, nil, agent.BootstrapMachineConfig{}, mongo.DefaultDialOpts(), environs.NewStatePolicy())
+	_, _, err = agentbootstrap.InitializeState(adminUser, cfg, nil, nil, agentbootstrap.BootstrapMachineConfig{}, mongo.DefaultDialOpts(), environs.NewStatePolicy())
 	// InitializeState will fail attempting to get the api port information
 	c.Assert(err, gc.ErrorMatches, "state serving information not available")
 }
@@ -254,7 +266,7 @@ func (s *bootstrapSuite) TestInitializeStateFailsSecondTime(c *gc.C) {
 		SystemIdentity: "qux",
 	})
 	expectHW := instance.MustParseHardware("mem=2048M")
-	mcfg := agent.BootstrapMachineConfig{
+	mcfg := agentbootstrap.BootstrapMachineConfig{
 		BootstrapConstraints: constraints.MustParse("mem=1024M"),
 		Jobs:                 []multiwatcher.MachineJob{multiwatcher.JobManageModel},
 		InstanceId:           "i-bootstrap",
@@ -267,12 +279,17 @@ func (s *bootstrapSuite) TestInitializeStateFailsSecondTime(c *gc.C) {
 	envCfg, err := config.New(config.NoDefaults, envAttrs)
 	c.Assert(err, jc.ErrorIsNil)
 
+	hostedModelConfigAttrs := map[string]interface{}{
+		"name": "hosted",
+		"uuid": utils.MustNewUUID().String(),
+	}
+
 	adminUser := names.NewLocalUserTag("agent-admin")
-	st, _, err := agent.InitializeState(adminUser, cfg, envCfg, mcfg, mongo.DefaultDialOpts(), environs.NewStatePolicy())
+	st, _, err := agentbootstrap.InitializeState(adminUser, cfg, envCfg, hostedModelConfigAttrs, mcfg, mongo.DefaultDialOpts(), environs.NewStatePolicy())
 	c.Assert(err, jc.ErrorIsNil)
 	st.Close()
 
-	st, _, err = agent.InitializeState(adminUser, cfg, envCfg, mcfg, mongo.DefaultDialOpts(), environs.NewStatePolicy())
+	st, _, err = agentbootstrap.InitializeState(adminUser, cfg, envCfg, nil, mcfg, mongo.DefaultDialOpts(), environs.NewStatePolicy())
 	if err == nil {
 		st.Close()
 	}
@@ -299,7 +316,7 @@ func (s *bootstrapSuite) TestMachineJobFromParams(c *gc.C) {
 		err:  `invalid machine job "invalid"`,
 	}}
 	for _, test := range tests {
-		got, err := agent.MachineJobFromParams(test.name)
+		got, err := agentbootstrap.MachineJobFromParams(test.name)
 		if err != nil {
 			c.Check(err, gc.ErrorMatches, test.err)
 		}

--- a/agent/agentbootstrap/export_test.go
+++ b/agent/agentbootstrap/export_test.go
@@ -1,0 +1,8 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package agentbootstrap
+
+var (
+	MachineJobFromParams = machineJobFromParams
+)

--- a/agent/agentbootstrap/package_test.go
+++ b/agent/agentbootstrap/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package agentbootstrap_test
+
+import (
+	stdtesting "testing"
+
+	"github.com/juju/juju/testing"
+)
+
+func Test(t *stdtesting.T) {
+	testing.MgoTestPackage(t)
+}

--- a/agent/export_test.go
+++ b/agent/export_test.go
@@ -10,14 +10,6 @@ import (
 	"github.com/juju/juju/state/multiwatcher"
 )
 
-func Password(config Config) string {
-	c := config.(*configInternal)
-	if c.stateDetails == nil {
-		return c.apiDetails.password
-	}
-	return c.stateDetails.password
-}
-
 func PatchConfig(config Config, fieldName string, value interface{}) error {
 	conf := config.(*configInternal)
 	switch fieldName {
@@ -54,10 +46,6 @@ func ConfigFileExists(config Config) bool {
 	_, err := os.Lstat(conf.configFilePath)
 	return err == nil
 }
-
-var (
-	MachineJobFromParams = machineJobFromParams
-)
 
 func EmptyConfig() Config {
 	return &configInternal{}

--- a/api/modelmanager/modelmanager_test.go
+++ b/api/modelmanager/modelmanager_test.go
@@ -41,10 +41,11 @@ func (s *modelmanagerSuite) TestConfigSkeleton(c *gc.C) {
 
 	// Numbers coming over the api are floats, not ints.
 	c.Assert(result, jc.DeepEquals, params.ModelConfig{
-		"type":       "dummy",
-		"ca-cert":    coretesting.CACert,
-		"state-port": float64(1234),
-		"api-port":   float64(apiPort),
+		"type":            "dummy",
+		"controller-uuid": coretesting.ModelTag.Id(),
+		"ca-cert":         coretesting.CACert,
+		"state-port":      float64(1234),
+		"api-port":        float64(apiPort),
 	})
 
 }
@@ -58,7 +59,7 @@ func (s *modelmanagerSuite) TestCreateModelBadUser(c *gc.C) {
 func (s *modelmanagerSuite) TestCreateModelMissingConfig(c *gc.C) {
 	modelManager := s.OpenAPI(c)
 	_, err := modelManager.CreateModel("owner", nil, nil)
-	c.Assert(err, gc.ErrorMatches, `creating config from values failed: name: expected string, got nothing`)
+	c.Assert(err, gc.ErrorMatches, `failed to create config: creating config from values failed: name: expected string, got nothing`)
 }
 
 func (s *modelmanagerSuite) TestCreateModel(c *gc.C) {

--- a/apiserver/common/storagecommon/storage.go
+++ b/apiserver/common/storagecommon/storage.go
@@ -256,8 +256,7 @@ func storageTags(
 	storageInstance state.StorageInstance,
 	cfg *config.Config,
 ) (map[string]string, error) {
-	uuid, _ := cfg.UUID()
-	storageTags := tags.ResourceTags(names.NewModelTag(uuid), cfg)
+	storageTags := tags.ResourceTags(names.NewModelTag(cfg.UUID()), cfg)
 	if storageInstance != nil {
 		storageTags[tags.JujuStorageInstance] = storageInstance.Tag().Id()
 		storageTags[tags.JujuStorageOwner] = storageInstance.Owner().Id()

--- a/apiserver/modelmanager/export_test.go
+++ b/apiserver/modelmanager/export_test.go
@@ -1,8 +1,0 @@
-// Copyright 2015 Canonical Ltd.
-// Licensed under the AGPLv3, see LICENCE file for details.
-
-package modelmanager
-
-func RestrictedProviderFields(mm *ModelManagerAPI, providerType string) ([]string, error) {
-	return mm.restrictedProviderFields(providerType)
-}

--- a/cloudconfig/cloudinit/renderscript_test.go
+++ b/cloudconfig/cloudinit/renderscript_test.go
@@ -63,6 +63,9 @@ func (s *configureSuite) getCloudConfig(c *gc.C, controller bool, vers version.B
 		)
 		c.Assert(err, jc.ErrorIsNil)
 		icfg.InstanceId = "instance-id"
+		icfg.HostedModelConfig = map[string]interface{}{
+			"name": "hosted-model",
+		}
 		icfg.Jobs = []multiwatcher.MachineJob{multiwatcher.JobManageModel, multiwatcher.JobHostUnits}
 	} else {
 		icfg, err = instancecfg.NewInstanceConfig("0", "ya", imagemetadata.ReleasedStream, vers.Series, "", true, nil, nil, nil)

--- a/cloudconfig/instancecfg/instancecfg.go
+++ b/cloudconfig/instancecfg/instancecfg.go
@@ -138,11 +138,16 @@ type InstanceConfig struct {
 	// Config holds the initial environment configuration.
 	Config *config.Config
 
+	// HostedModelConfig is a set of config attributes to be overlaid
+	// on the controller model config (Config, above) to construct the
+	// initial hosted model config.
+	HostedModelConfig map[string]interface{}
+
 	// Constraints holds the machine constraints.
 	Constraints constraints.Value
 
-	// EnvironConstraints holds the initial environment constraints.
-	EnvironConstraints constraints.Value
+	// ModelConstraints holds the initial model constraints.
+	ModelConstraints constraints.Value
 
 	// DisableSSLHostnameVerification can be set to true to tell cloud-init
 	// that it shouldn't verify SSL certificates
@@ -372,6 +377,9 @@ func (cfg *InstanceConfig) VerifyConfig() (err error) {
 		if cfg.InstanceId == "" {
 			return errors.New("missing instance-id")
 		}
+		if len(cfg.HostedModelConfig) == 0 {
+			return errors.New("missing hosted model config")
+		}
 	} else {
 		if len(cfg.MongoInfo.Addrs) == 0 {
 			return errors.New("missing state hosts")
@@ -387,6 +395,9 @@ func (cfg *InstanceConfig) VerifyConfig() (err error) {
 		}
 		if cfg.StateServingInfo != nil {
 			return errors.New("state serving info unexpectedly present")
+		}
+		if len(cfg.HostedModelConfig) != 0 {
+			return errors.New("hosted model config unexpectedly present")
 		}
 	}
 	if cfg.MachineNonce == "" {
@@ -464,7 +475,10 @@ func NewInstanceConfig(
 // NewBootstrapInstanceConfig sets up a basic machine configuration for a
 // bootstrap node.  You'll still need to supply more information, but this
 // takes care of the fixed entries and the ones that are always needed.
-func NewBootstrapInstanceConfig(cons, environCons constraints.Value, series, publicImageSigningKey string) (*InstanceConfig, error) {
+func NewBootstrapInstanceConfig(
+	cons, modelCons constraints.Value,
+	series, publicImageSigningKey string,
+) (*InstanceConfig, error) {
 	// For a bootstrap instance, FinishInstanceConfig will provide the
 	// state.Info and the api.Info. The machine id must *always* be "0".
 	icfg, err := NewInstanceConfig("0", agent.BootstrapNonce, "", series, publicImageSigningKey, true, nil, nil, nil)
@@ -477,7 +491,7 @@ func NewBootstrapInstanceConfig(cons, environCons constraints.Value, series, pub
 		multiwatcher.JobHostUnits,
 	}
 	icfg.Constraints = cons
-	icfg.EnvironConstraints = environCons
+	icfg.ModelConstraints = modelCons
 	return icfg, nil
 }
 
@@ -568,14 +582,10 @@ func FinishInstanceConfig(icfg *InstanceConfig, cfg *config.Config) (err error) 
 		return errors.New("model configuration has no admin-secret")
 	}
 	passwordHash := utils.UserPasswordHash(password, utils.CompatSalt)
-	modelUUID, uuidSet := cfg.UUID()
-	if !uuidSet {
-		return errors.New("config missing model uuid")
-	}
 	icfg.APIInfo = &api.Info{
 		Password: passwordHash,
 		CACert:   caCert,
-		ModelTag: names.NewModelTag(modelUUID),
+		ModelTag: names.NewModelTag(cfg.UUID()),
 	}
 	icfg.MongoInfo = &mongo.MongoInfo{Password: passwordHash, Info: mongo.Info{CACert: caCert}}
 
@@ -609,8 +619,7 @@ func FinishInstanceConfig(icfg *InstanceConfig, cfg *config.Config) (err error) 
 // InstanceTags returns the minimum set of tags that should be set on a
 // machine instance, if the provider supports them.
 func InstanceTags(cfg *config.Config, jobs []multiwatcher.MachineJob) map[string]string {
-	uuid, _ := cfg.UUID()
-	instanceTags := tags.ResourceTags(names.NewModelTag(uuid), cfg)
+	instanceTags := tags.ResourceTags(names.NewModelTag(cfg.UUID()), cfg)
 	if multiwatcher.AnyJobNeedsState(jobs...) {
 		instanceTags[tags.JujuController] = "true"
 	}

--- a/cloudconfig/instancecfg/instancecfg_test.go
+++ b/cloudconfig/instancecfg/instancecfg_test.go
@@ -32,18 +32,6 @@ func (*instancecfgSuite) TestInstanceTagsController(c *gc.C) {
 	})
 }
 
-func (*instancecfgSuite) TestInstanceTagsNoUUID(c *gc.C) {
-	attrsWithoutUUID := testing.FakeConfig()
-	delete(attrsWithoutUUID, "uuid")
-	cfgWithoutUUID, err := config.New(config.NoDefaults, attrsWithoutUUID)
-	c.Assert(err, jc.ErrorIsNil)
-	testInstanceTags(c,
-		cfgWithoutUUID,
-		[]multiwatcher.MachineJob(nil),
-		map[string]string{"juju-model-uuid": ""},
-	)
-}
-
 func (*instancecfgSuite) TestInstanceTagsUserSpecified(c *gc.C) {
 	cfg := testing.CustomModelConfig(c, testing.Attrs{
 		"resource-tags": "a=b c=",

--- a/cloudconfig/userdatacfg_test.go
+++ b/cloudconfig/userdatacfg_test.go
@@ -164,6 +164,9 @@ func (cfg *testInstanceConfig) setMachineID(id string) *testInstanceConfig {
 func (cfg *testInstanceConfig) maybeSetModelConfig(envConfig *config.Config) *testInstanceConfig {
 	if envConfig != nil {
 		cfg.Config = envConfig
+		if cfg.Bootstrap {
+			cfg.HostedModelConfig = map[string]interface{}{"name": "hosted-model"}
+		}
 	}
 	return cfg
 }
@@ -192,7 +195,7 @@ func (cfg *testInstanceConfig) setSeries(series string) *testInstanceConfig {
 func (cfg *testInstanceConfig) setController() *testInstanceConfig {
 	cfg.setMachineID("0")
 	cfg.Constraints = bootstrapConstraints
-	cfg.EnvironConstraints = envConstraints
+	cfg.ModelConstraints = envConstraints
 	cfg.Bootstrap = true
 	cfg.StateServingInfo = stateServingInfo
 	cfg.Jobs = allMachineJobs
@@ -309,7 +312,7 @@ mkdir -p '/var/lib/juju/agents/machine-0'
 cat > '/var/lib/juju/agents/machine-0/agent\.conf' << 'EOF'\\n.*\\nEOF
 chmod 0600 '/var/lib/juju/agents/machine-0/agent\.conf'
 echo 'Bootstrapping Juju machine agent'.*
-/var/lib/juju/tools/1\.2\.3-precise-amd64/jujud bootstrap-state --data-dir '/var/lib/juju' --model-config '[^']*' --instance-id 'i-bootstrap' --bootstrap-constraints 'mem=4096M' --constraints 'mem=2048M' --debug
+/var/lib/juju/tools/1\.2\.3-precise-amd64/jujud bootstrap-state --data-dir '/var/lib/juju' --model-config '[^']*' --hosted-model-config '[^']*' --instance-id 'i-bootstrap' --bootstrap-constraints 'mem=4096M' --constraints 'mem=2048M' --debug
 ln -s 1\.2\.3-precise-amd64 '/var/lib/juju/tools/machine-0'
 echo 'Starting Juju machine agent \(jujud-machine-0\)'.*
 cat > /etc/init/jujud-machine-0\.conf << 'EOF'\\ndescription "juju agent for machine-0"\\nauthor "Juju Team <juju@lists\.ubuntu\.com>"\\nstart on runlevel \[2345\]\\nstop on runlevel \[!2345\]\\nrespawn\\nnormal exit 0\\n\\nlimit nofile 20000 20000\\n\\nscript\\n\\n\\n  # Ensure log files are properly protected\\n  touch /var/log/juju/machine-0\.log\\n  chown syslog:syslog /var/log/juju/machine-0\.log\\n  chmod 0600 /var/log/juju/machine-0\.log\\n\\n  exec '/var/lib/juju/tools/machine-0/jujud' machine --data-dir '/var/lib/juju' --machine-id 0 --debug >> /var/log/juju/machine-0\.log 2>&1\\nend script\\nEOF\\n
@@ -329,7 +332,7 @@ curl .* '.*' --retry 10 -o \$bin/tools\.tar\.gz 'http://foo\.com/tools/released/
 sha256sum \$bin/tools\.tar\.gz > \$bin/juju1\.2\.3-raring-amd64\.sha256
 grep '1234' \$bin/juju1\.2\.3-raring-amd64.sha256 \|\| \(echo "Tools checksum mismatch"; exit 1\)
 printf %s '{"version":"1\.2\.3-raring-amd64","url":"http://foo\.com/tools/released/juju1\.2\.3-raring-amd64\.tgz","sha256":"1234","size":10}' > \$bin/downloaded-tools\.txt
-/var/lib/juju/tools/1\.2\.3-raring-amd64/jujud bootstrap-state --data-dir '/var/lib/juju' --model-config '[^']*' --instance-id 'i-bootstrap' --bootstrap-constraints 'mem=4096M' --constraints 'mem=2048M' --debug
+/var/lib/juju/tools/1\.2\.3-raring-amd64/jujud bootstrap-state --data-dir '/var/lib/juju' --model-config '[^']*' --hosted-model-config '[^']*' --instance-id 'i-bootstrap' --bootstrap-constraints 'mem=4096M' --constraints 'mem=2048M' --debug
 ln -s 1\.2\.3-raring-amd64 '/var/lib/juju/tools/machine-0'
 rm \$bin/tools\.tar\.gz && rm \$bin/juju1\.2\.3-raring-amd64\.sha256
 `,
@@ -430,19 +433,19 @@ curl .* --noproxy "\*" --insecure -o \$bin/tools\.tar\.gz 'https://state-addr\.t
 		setEnvConfig: true,
 		inexactMatch: true,
 		expectScripts: `
-/var/lib/juju/tools/1\.2\.3-precise-amd64/jujud bootstrap-state --data-dir '/var/lib/juju' --model-config '[^']*' --instance-id 'i-bootstrap' --constraints 'mem=2048M' --debug
+/var/lib/juju/tools/1\.2\.3-precise-amd64/jujud bootstrap-state --data-dir '/var/lib/juju' --model-config '[^']*' --hosted-model-config '[^']*' --instance-id 'i-bootstrap' --constraints 'mem=2048M' --debug
 `,
 	},
 
 	// empty environ contraints.
 	{
 		cfg: makeBootstrapConfig("precise").mutate(func(cfg *testInstanceConfig) {
-			cfg.EnvironConstraints = constraints.Value{}
+			cfg.ModelConstraints = constraints.Value{}
 		}),
 		setEnvConfig: true,
 		inexactMatch: true,
 		expectScripts: `
-/var/lib/juju/tools/1\.2\.3-precise-amd64/jujud bootstrap-state --data-dir '/var/lib/juju' --model-config '[^']*' --instance-id 'i-bootstrap' --bootstrap-constraints 'mem=4096M' --debug
+/var/lib/juju/tools/1\.2\.3-precise-amd64/jujud bootstrap-state --data-dir '/var/lib/juju' --model-config '[^']*' --hosted-model-config '[^']*' --instance-id 'i-bootstrap' --bootstrap-constraints 'mem=4096M' --debug
 `,
 	},
 
@@ -631,6 +634,7 @@ func (*cloudinitSuite) TestCloudInitConfigureBootstrapLogging(c *gc.C) {
 		}
 	}
 	expected := "jujud bootstrap-state --data-dir '.*' --model-config '.*'" +
+		" --hosted-model-config '[^']*'" +
 		" --instance-id '.*' --bootstrap-constraints 'mem=4096M'" +
 		" --constraints 'mem=2048M' --show-log"
 	assertScriptMatch(c, scripts, expected, false)
@@ -976,6 +980,7 @@ func (*cloudinitSuite) TestCloudInitVerify(c *gc.C) {
 			ModelTag: testing.ModelTag,
 		},
 		Config:                  minimalModelConfig(c),
+		HostedModelConfig:       map[string]interface{}{"name": "hosted-model"},
 		DataDir:                 jujuDataDir("quantal"),
 		LogDir:                  jujuLogDir("quantal"),
 		MetricsSpoolDir:         metricsSpoolDir("quantal"),

--- a/cloudconfig/userdatacfg_unix.go
+++ b/cloudconfig/userdatacfg_unix.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/cloudconfig/cloudinit"
-	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/imagemetadata"
 	"github.com/juju/juju/environs/simplestreams"
 	"github.com/juju/juju/service"
@@ -323,9 +322,9 @@ func (w *unixConfigure) ConfigureJuju() error {
 		if bootstrapCons != "" {
 			bootstrapCons = " --bootstrap-constraints " + shquote(bootstrapCons)
 		}
-		environCons := w.icfg.EnvironConstraints.String()
-		if environCons != "" {
-			environCons = " --constraints " + shquote(environCons)
+		modelCons := w.icfg.ModelConstraints.String()
+		if modelCons != "" {
+			modelCons = " --constraints " + shquote(modelCons)
 		}
 		var hardware string
 		if w.icfg.HardwareCharacteristics != nil {
@@ -344,11 +343,12 @@ func (w *unixConfigure) ConfigureJuju() error {
 			// The bootstrapping is always run with debug on.
 			w.icfg.JujuTools() + "/jujud bootstrap-state" +
 				" --data-dir " + shquote(w.icfg.DataDir) +
-				" --model-config " + shquote(base64yaml(w.icfg.Config)) +
+				" --model-config " + shquote(base64yaml(w.icfg.Config.AllAttrs())) +
+				" --hosted-model-config " + shquote(base64yaml(w.icfg.HostedModelConfig)) +
 				" --instance-id " + shquote(string(w.icfg.InstanceId)) +
 				hardware +
 				bootstrapCons +
-				environCons +
+				modelCons +
 				metadataDir +
 				loggingOption,
 		)
@@ -378,8 +378,8 @@ func toolsDownloadCommand(curlCommand string, urls []string) string {
 	return buf.String()
 }
 
-func base64yaml(m *config.Config) string {
-	data, err := goyaml.Marshal(m.AllAttrs())
+func base64yaml(attrs map[string]interface{}) string {
+	data, err := goyaml.Marshal(attrs)
 	if err != nil {
 		// can't happen, these values have been validated a number of times
 		panic(err)

--- a/cmd/juju/backups/restore.go
+++ b/cmd/juju/backups/restore.go
@@ -179,7 +179,7 @@ func (c *restoreCommand) rebootstrap(ctx *cmd.Context) error {
 	}
 
 	cons := c.constraints
-	args := bootstrap.BootstrapParams{EnvironConstraints: cons, UploadTools: c.uploadTools}
+	args := bootstrap.BootstrapParams{ModelConstraints: cons, UploadTools: c.uploadTools}
 	if err := bootstrap.Bootstrap(modelcmd.BootstrapContext(ctx), env, args); err != nil {
 		return errors.Annotatef(err, "cannot bootstrap new instance")
 	}

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -298,7 +298,7 @@ func (s *BootstrapSuite) run(c *gc.C, test bootstrapTest) testing.Restorer {
 
 	opBootstrap := (<-opc).(dummy.OpBootstrap)
 	c.Check(opBootstrap.Env, gc.Equals, "admin")
-	c.Check(opBootstrap.Args.EnvironConstraints, gc.DeepEquals, test.constraints)
+	c.Check(opBootstrap.Args.ModelConstraints, gc.DeepEquals, test.constraints)
 	if test.bootstrapConstraints == (constraints.Value{}) {
 		test.bootstrapConstraints = test.constraints
 	}

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -55,7 +55,7 @@ type BootstrapSuite struct {
 	testing.MgoSuite
 	envtesting.ToolsFixture
 	mockBlockClient *mockBlockClient
-	store           jujuclient.CredentialStore
+	store           *jujuclienttesting.MemStore
 	legacyMemStore  configstore.Storage
 }
 
@@ -126,9 +126,9 @@ func (s *BootstrapSuite) TearDownTest(c *gc.C) {
 }
 
 func (s *BootstrapSuite) newBootstrapCommand() cmd.Command {
-	return modelcmd.Wrap(&bootstrapCommand{
-		CredentialStore: s.store,
-	})
+	c := &bootstrapCommand{CredentialStore: s.store}
+	c.SetClientStore(s.store)
+	return modelcmd.Wrap(c)
 }
 
 type mockBlockClient struct {
@@ -176,6 +176,7 @@ func (s *BootstrapSuite) TestBootstrapAPIReadyRetries(c *gc.C) {
 		resetJujuXDGDataHome(c)
 		dummy.Reset()
 		s.legacyMemStore = configstore.NewMem()
+		s.store = jujuclienttesting.NewMemStore()
 
 		s.mockBlockClient.numRetries = t.numRetries
 		s.mockBlockClient.retryCount = 0
@@ -264,6 +265,7 @@ func (s *BootstrapSuite) run(c *gc.C, test bootstrapTest) testing.Restorer {
 	addrConnectedTo := "localhost:17070"
 	var restore testing.Restorer = func() {
 		s.legacyMemStore = configstore.NewMem()
+		s.store = jujuclienttesting.NewMemStore()
 	}
 	if test.version != "" {
 		useVersion := strings.Replace(test.version, "%LTS%", config.LatestLtsSeries(), 1)
@@ -334,8 +336,7 @@ func (s *BootstrapSuite) run(c *gc.C, test bootstrapTest) testing.Restorer {
 
 	// Check controllers.yaml has controller
 	endpoint := info.APIEndpoint()
-	controllerStore := jujuclient.NewFileClientStore()
-	controller, err := controllerStore.ControllerByName(expectedBootstrappedControllerName)
+	controller, err := s.store.ControllerByName(expectedBootstrappedControllerName)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(controller.CACert, gc.Equals, endpoint.CACert)
 	c.Assert(controller.Servers, gc.DeepEquals, endpoint.Hostnames)
@@ -478,6 +479,26 @@ func (s *BootstrapSuite) TestBootstrapSetsCurrentModel(c *gc.C) {
 	currentController, err := modelcmd.ReadCurrentController()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(currentController, gc.Equals, bootstrappedControllerName("devcontroller"))
+	modelName, err := s.store.CurrentModel(currentController, "admin@local")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(modelName, gc.Equals, "default")
+}
+
+func (s *BootstrapSuite) TestBootstrapDefaultModel(c *gc.C) {
+	s.patchVersionAndSeries(c, "raring")
+
+	var bootstrap fakeBootstrapFuncs
+	s.PatchValue(&getBootstrapFuncs, func() BootstrapInterface {
+		return &bootstrap
+	})
+
+	coretesting.RunCommand(
+		c, s.newBootstrapCommand(),
+		"devcontroller", "dummy",
+		"--auto-upgrade",
+		"--default-model", "mymodel",
+	)
+	c.Assert(bootstrap.args.HostedModelConfig["name"], gc.Equals, "mymodel")
 }
 
 type mockBootstrapInstance struct {
@@ -537,8 +558,7 @@ func (s *BootstrapSuite) TestBootstrapAlreadyExists(c *gc.C) {
 	expectedBootstrappedName := bootstrappedControllerName(controllerName)
 	s.patchVersionAndSeries(c, "raring")
 
-	store := jujuclient.NewFileClientStore()
-	err := store.UpdateController("local.devcontroller", jujuclient.ControllerDetails{
+	err := s.store.UpdateController("local.devcontroller", jujuclient.ControllerDetails{
 		CACert:         "x",
 		ControllerUUID: "y",
 	})
@@ -954,14 +974,6 @@ func resetJujuXDGDataHome(c *gc.C) {
 	jenvDir := testing.JujuXDGDataHomePath("models")
 	err := os.RemoveAll(jenvDir)
 	c.Assert(err, jc.ErrorIsNil)
-
-	for _, path := range []string{
-		jujuclient.JujuControllersPath(),
-		jujuclient.JujuModelsPath(),
-		jujuclient.JujuAccountsPath(),
-	} {
-		os.Remove(path)
-	}
 
 	cloudsPath := cloud.JujuPersonalCloudsPath()
 	err = ioutil.WriteFile(cloudsPath, []byte(`

--- a/cmd/juju/controller/createmodel.go
+++ b/cmd/juju/controller/createmodel.go
@@ -16,7 +16,6 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/juju/common"
 	"github.com/juju/juju/cmd/modelcmd"
-	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/jujuclient"
 )
 
@@ -207,12 +206,5 @@ func (c *createModelCommand) getConfigValues(ctx *cmd.Context, serverSkeleton pa
 		configValues[key] = value
 	}
 	configValues["name"] = c.Name
-
-	// TODO: allow version to be specified on the command line and add here.
-	cfg, err := config.New(config.UseDefaults, configValues)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	return cfg.AllAttrs(), nil
+	return configValues, nil
 }

--- a/cmd/juju/controller/destroy_test.go
+++ b/cmd/juju/controller/destroy_test.go
@@ -107,10 +107,12 @@ func (f *fakeDestroyAPIClient) DestroyModel() error {
 
 func createBootstrapInfo(c *gc.C, name string) map[string]interface{} {
 	cfg, err := config.New(config.UseDefaults, map[string]interface{}{
-		"type":       "dummy",
-		"name":       name,
-		"controller": "true",
-		"state-id":   "1",
+		"type":            "dummy",
+		"name":            name,
+		"uuid":            testing.ModelTag.Id(),
+		"controller-uuid": testing.ModelTag.Id(),
+		"controller":      "true",
+		"state-id":        "1",
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	return cfg.AllAttrs()

--- a/cmd/juju/service/deploy_test.go
+++ b/cmd/juju/service/deploy_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/juju/testing"
+	"github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/storage/poolmanager"
 	"github.com/juju/juju/storage/provider"
@@ -539,15 +540,9 @@ func (s *DeploySuite) TestCharmSeries(c *gc.C) {
 
 	for i, test := range deploySeriesTests {
 		c.Logf("test %d", i)
-		cfg, err := config.New(config.UseDefaults, map[string]interface{}{
-			"name":            "test",
-			"type":            "dummy",
-			"uuid":            coretesting.ModelTag.Id(),
-			"ca-cert":         coretesting.CACert,
-			"ca-private-key":  coretesting.CAKey,
-			"authorized-keys": coretesting.FakeAuthKeys,
-			"default-series":  test.modelSeries,
-		})
+		cfg, err := config.New(config.UseDefaults, dummy.SampleConfig().Merge(coretesting.Attrs{
+			"default-series": test.modelSeries,
+		}))
 		c.Assert(err, jc.ErrorIsNil)
 		series, msg, err := charmSeries(test.requestedSeries, test.seriesFromCharm, test.supportedSeries, test.force, cfg)
 		if test.err != "" {
@@ -986,7 +981,7 @@ func (s *DeployCharmStoreSuite) TestAddMetricCredentials(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ch.URL(), gc.DeepEquals, curl)
 	c.Assert(called, jc.IsTrue)
-	modelUUID, _ := s.Environ.Config().UUID()
+	modelUUID := s.Environ.Config().UUID()
 	stub.CheckCalls(c, []jujutesting.StubCall{{
 		"Authorize", []interface{}{metricRegistrationPost{
 			ModelUUID:   modelUUID,
@@ -1033,7 +1028,7 @@ func (s *DeployCharmStoreSuite) TestAddMetricCredentialsDefaultPlan(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ch.URL(), gc.DeepEquals, curl)
 	c.Assert(called, jc.IsTrue)
-	modelUUID, _ := s.Environ.Config().UUID()
+	modelUUID := s.Environ.Config().UUID()
 	stub.CheckCalls(c, []jujutesting.StubCall{{
 		"DefaultPlan", []interface{}{"cs:quantal/metered-1"},
 	}, {

--- a/cmd/jujud/bootstrap.go
+++ b/cmd/jujud/bootstrap.go
@@ -26,6 +26,7 @@ import (
 	"launchpad.net/gnuflag"
 
 	"github.com/juju/juju/agent"
+	"github.com/juju/juju/agent/agentbootstrap"
 	agenttools "github.com/juju/juju/agent/tools"
 	agentcmd "github.com/juju/juju/cmd/jujud/agent"
 	cmdutil "github.com/juju/juju/cmd/jujud/util"
@@ -51,7 +52,7 @@ import (
 
 var (
 	initiateMongoServer  = peergrouper.InitiateMongoServer
-	agentInitializeState = agent.InitializeState
+	agentInitializeState = agentbootstrap.InitializeState
 	sshGenerateKey       = ssh.GenerateKey
 	newStateStorage      = storage.NewStorage
 	minSocketTimeout     = 1 * time.Minute
@@ -62,13 +63,14 @@ var (
 type BootstrapCommand struct {
 	cmd.CommandBase
 	agentcmd.AgentConf
-	EnvConfig            map[string]interface{}
-	BootstrapConstraints constraints.Value
-	EnvironConstraints   constraints.Value
-	Hardware             instance.HardwareCharacteristics
-	InstanceId           string
-	AdminUsername        string
-	ImageMetadataDir     string
+	ControllerModelConfig map[string]interface{}
+	HostedModelConfig     map[string]interface{}
+	BootstrapConstraints  constraints.Value
+	ModelConstraints      constraints.Value
+	Hardware              instance.HardwareCharacteristics
+	InstanceId            string
+	AdminUsername         string
+	ImageMetadataDir      string
 }
 
 // NewBootstrapCommand returns a new BootstrapCommand that has been initialized.
@@ -89,9 +91,10 @@ func (c *BootstrapCommand) Info() *cmd.Info {
 // SetFlags adds the flags for this command to the passed gnuflag.FlagSet.
 func (c *BootstrapCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.AgentConf.AddFlags(f)
-	yamlBase64Var(f, &c.EnvConfig, "model-config", "", "initial model configuration (yaml, base64 encoded)")
+	yamlBase64Var(f, &c.ControllerModelConfig, "model-config", "", "controller model configuration (yaml, base64 encoded)")
+	yamlBase64Var(f, &c.HostedModelConfig, "hosted-model-config", "", "initial hosted model configuration (yaml, base64 encoded)")
 	f.Var(constraints.ConstraintsValue{Target: &c.BootstrapConstraints}, "bootstrap-constraints", "bootstrap machine constraints (space-separated strings)")
-	f.Var(constraints.ConstraintsValue{Target: &c.EnvironConstraints}, "constraints", "initial constraints (space-separated strings)")
+	f.Var(constraints.ConstraintsValue{Target: &c.ModelConstraints}, "constraints", "initial constraints (space-separated strings)")
 	f.Var(&c.Hardware, "hardware", "hardware characteristics (space-separated strings)")
 	f.StringVar(&c.InstanceId, "instance-id", "", "unique instance-id for bootstrap machine")
 	f.StringVar(&c.AdminUsername, "admin-user", "admin", "set the name for the juju admin user")
@@ -100,8 +103,11 @@ func (c *BootstrapCommand) SetFlags(f *gnuflag.FlagSet) {
 
 // Init initializes the command for running.
 func (c *BootstrapCommand) Init(args []string) error {
-	if len(c.EnvConfig) == 0 {
+	if len(c.ControllerModelConfig) == 0 {
 		return cmdutil.RequiredError("model-config")
+	}
+	if len(c.HostedModelConfig) == 0 {
+		return cmdutil.RequiredError("hosted-model-config")
 	}
 	if c.InstanceId == "" {
 		return cmdutil.RequiredError("instance-id")
@@ -114,7 +120,7 @@ func (c *BootstrapCommand) Init(args []string) error {
 
 // Run initializes state for an environment.
 func (c *BootstrapCommand) Run(_ *cmd.Context) error {
-	envCfg, err := config.New(config.NoDefaults, c.EnvConfig)
+	envCfg, err := config.New(config.NoDefaults, c.ControllerModelConfig)
 	if err != nil {
 		return err
 	}
@@ -271,11 +277,11 @@ func (c *BootstrapCommand) Run(_ *cmd.Context) error {
 		st, m, stateErr = agentInitializeState(
 			adminTag,
 			agentConfig,
-			envCfg,
-			agent.BootstrapMachineConfig{
+			envCfg, c.HostedModelConfig,
+			agentbootstrap.BootstrapMachineConfig{
 				Addresses:            addrs,
 				BootstrapConstraints: c.BootstrapConstraints,
-				ModelConstraints:     c.EnvironConstraints,
+				ModelConstraints:     c.ModelConstraints,
 				Jobs:                 jobs,
 				InstanceId:           instanceId,
 				Characteristics:      c.Hardware,

--- a/cmd/jujud/bootstrap_test.go
+++ b/cmd/jujud/bootstrap_test.go
@@ -27,6 +27,7 @@ import (
 	goyaml "gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/agent"
+	"github.com/juju/juju/agent/agentbootstrap"
 	agenttools "github.com/juju/juju/agent/tools"
 	"github.com/juju/juju/apiserver/params"
 	agenttesting "github.com/juju/juju/cmd/jujud/agent/testing"
@@ -62,14 +63,16 @@ import (
 type BootstrapSuite struct {
 	testing.BaseSuite
 	gitjujutesting.MgoSuite
-	envcfg          *config.Config
-	b64yamlEnvcfg   string
-	instanceId      instance.Id
-	dataDir         string
-	logDir          string
-	mongoOplogSize  string
-	fakeEnsureMongo *agenttesting.FakeEnsureMongo
-	bootstrapName   string
+	envcfg                       *config.Config
+	b64yamlControllerModelConfig string
+	b64yamlHostedModelConfig     string
+	instanceId                   instance.Id
+	dataDir                      string
+	logDir                       string
+	mongoOplogSize               string
+	fakeEnsureMongo              *agenttesting.FakeEnsureMongo
+	bootstrapName                string
+	hostedModelUUID              string
 
 	toolsStorage storage.Storage
 }
@@ -197,7 +200,11 @@ func (s *BootstrapSuite) initBootstrapCommand(c *gc.C, jobs []multiwatcher.Machi
 
 func (s *BootstrapSuite) TestInitializeEnvironment(c *gc.C) {
 	hw := instance.MustParseHardware("arch=amd64 mem=8G")
-	machConf, cmd, err := s.initBootstrapCommand(c, nil, "--model-config", s.b64yamlEnvcfg, "--instance-id", string(s.instanceId), "--hardware", hw.String())
+	machConf, cmd, err := s.initBootstrapCommand(
+		c, nil, "--model-config", s.b64yamlControllerModelConfig,
+		"--hosted-model-config", s.b64yamlHostedModelConfig,
+		"--instance-id", string(s.instanceId), "--hardware", hw.String(),
+	)
 	c.Assert(err, jc.ErrorIsNil)
 	err = cmd.Run(nil)
 	c.Assert(err, jc.ErrorIsNil)
@@ -262,7 +269,11 @@ func (s *BootstrapSuite) TestInitializeEnvironment(c *gc.C) {
 func (s *BootstrapSuite) TestInitializeEnvironmentInvalidOplogSize(c *gc.C) {
 	s.mongoOplogSize = "NaN"
 	hw := instance.MustParseHardware("arch=amd64 mem=8G")
-	_, cmd, err := s.initBootstrapCommand(c, nil, "--model-config", s.b64yamlEnvcfg, "--instance-id", string(s.instanceId), "--hardware", hw.String())
+	_, cmd, err := s.initBootstrapCommand(
+		c, nil, "--model-config", s.b64yamlControllerModelConfig,
+		"--hosted-model-config", s.b64yamlHostedModelConfig,
+		"--instance-id", string(s.instanceId), "--hardware", hw.String(),
+	)
 	c.Assert(err, jc.ErrorIsNil)
 	err = cmd.Run(nil)
 	c.Assert(err, gc.ErrorMatches, `invalid oplog size: "NaN"`)
@@ -274,10 +285,14 @@ func (s *BootstrapSuite) TestInitializeEnvironmentToolsNotFound(c *gc.C) {
 		"agent-version": "1.99.1",
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	b64yamlEnvcfg := b64yaml(envcfg.AllAttrs()).encode()
+	b64yamlControllerModelConfig := b64yaml(envcfg.AllAttrs()).encode()
 
 	hw := instance.MustParseHardware("arch=amd64 mem=8G")
-	_, cmd, err := s.initBootstrapCommand(c, nil, "--model-config", b64yamlEnvcfg, "--instance-id", string(s.instanceId), "--hardware", hw.String())
+	_, cmd, err := s.initBootstrapCommand(
+		c, nil, "--model-config", b64yamlControllerModelConfig,
+		"--hosted-model-config", s.b64yamlHostedModelConfig,
+		"--instance-id", string(s.instanceId), "--hardware", hw.String(),
+	)
 	c.Assert(err, jc.ErrorIsNil)
 	err = cmd.Run(nil)
 	c.Assert(err, jc.ErrorIsNil)
@@ -301,12 +316,13 @@ func (s *BootstrapSuite) TestInitializeEnvironmentToolsNotFound(c *gc.C) {
 
 func (s *BootstrapSuite) TestSetConstraints(c *gc.C) {
 	bootstrapCons := constraints.Value{Mem: uint64p(4096), CpuCores: uint64p(4)}
-	environCons := constraints.Value{Mem: uint64p(2048), CpuCores: uint64p(2)}
+	modelCons := constraints.Value{Mem: uint64p(2048), CpuCores: uint64p(2)}
 	_, cmd, err := s.initBootstrapCommand(c, nil,
-		"--model-config", s.b64yamlEnvcfg,
+		"--model-config", s.b64yamlControllerModelConfig,
+		"--hosted-model-config", s.b64yamlHostedModelConfig,
 		"--instance-id", string(s.instanceId),
 		"--bootstrap-constraints", bootstrapCons.String(),
-		"--constraints", environCons.String(),
+		"--constraints", modelCons.String(),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	err = cmd.Run(nil)
@@ -324,7 +340,7 @@ func (s *BootstrapSuite) TestSetConstraints(c *gc.C) {
 
 	cons, err := st.ModelConstraints()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cons, gc.DeepEquals, environCons)
+	c.Assert(cons, gc.DeepEquals, modelCons)
 
 	machines, err := st.AllMachines()
 	c.Assert(err, jc.ErrorIsNil)
@@ -344,7 +360,11 @@ func (s *BootstrapSuite) TestDefaultMachineJobs(c *gc.C) {
 		state.JobHostUnits,
 		state.JobManageNetworking,
 	}
-	_, cmd, err := s.initBootstrapCommand(c, nil, "--model-config", s.b64yamlEnvcfg, "--instance-id", string(s.instanceId))
+	_, cmd, err := s.initBootstrapCommand(c, nil,
+		"--model-config", s.b64yamlControllerModelConfig,
+		"--hosted-model-config", s.b64yamlHostedModelConfig,
+		"--instance-id", string(s.instanceId),
+	)
 	c.Assert(err, jc.ErrorIsNil)
 	err = cmd.Run(nil)
 	c.Assert(err, jc.ErrorIsNil)
@@ -365,7 +385,11 @@ func (s *BootstrapSuite) TestDefaultMachineJobs(c *gc.C) {
 
 func (s *BootstrapSuite) TestConfiguredMachineJobs(c *gc.C) {
 	jobs := []multiwatcher.MachineJob{multiwatcher.JobManageModel}
-	_, cmd, err := s.initBootstrapCommand(c, jobs, "--model-config", s.b64yamlEnvcfg, "--instance-id", string(s.instanceId))
+	_, cmd, err := s.initBootstrapCommand(c, jobs,
+		"--model-config", s.b64yamlControllerModelConfig,
+		"--hosted-model-config", s.b64yamlHostedModelConfig,
+		"--instance-id", string(s.instanceId),
+	)
 	c.Assert(err, jc.ErrorIsNil)
 	err = cmd.Run(nil)
 	c.Assert(err, jc.ErrorIsNil)
@@ -397,7 +421,11 @@ func testOpenState(c *gc.C, info *mongo.MongoInfo, expectErrType error) {
 }
 
 func (s *BootstrapSuite) TestInitialPassword(c *gc.C) {
-	machineConf, cmd, err := s.initBootstrapCommand(c, nil, "--model-config", s.b64yamlEnvcfg, "--instance-id", string(s.instanceId))
+	machineConf, cmd, err := s.initBootstrapCommand(c, nil,
+		"--model-config", s.b64yamlControllerModelConfig,
+		"--hosted-model-config", s.b64yamlHostedModelConfig,
+		"--instance-id", string(s.instanceId),
+	)
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = cmd.Run(nil)
@@ -468,21 +496,30 @@ var bootstrapArgTests = []struct {
 		input: []string{"--model-config", "name: banana\n"},
 		err:   ".*illegal base64 data at input byte.*",
 	}, {
+		// no value supplied for hosted-model-config
+		input: []string{
+			"--model-config", base64.StdEncoding.EncodeToString([]byte("name: banana\n")),
+		},
+		err: "--hosted-model-config option must be set",
+	}, {
 		// no value supplied for instance-id
 		input: []string{
 			"--model-config", base64.StdEncoding.EncodeToString([]byte("name: banana\n")),
+			"--hosted-model-config", base64.StdEncoding.EncodeToString([]byte("name: banana\n")),
 		},
 		err: "--instance-id option must be set",
 	}, {
 		// empty instance-id
 		input: []string{
 			"--model-config", base64.StdEncoding.EncodeToString([]byte("name: banana\n")),
+			"--hosted-model-config", base64.StdEncoding.EncodeToString([]byte("name: banana\n")),
 			"--instance-id", "",
 		},
 		err: "--instance-id option must be set",
 	}, {
 		input: []string{
 			"--model-config", base64.StdEncoding.EncodeToString([]byte("name: banana\n")),
+			"--hosted-model-config", base64.StdEncoding.EncodeToString([]byte("name: banana\n")),
 			"--instance-id", "anything",
 		},
 		expectedInstanceId: "anything",
@@ -490,6 +527,7 @@ var bootstrapArgTests = []struct {
 	}, {
 		input: []string{
 			"--model-config", base64.StdEncoding.EncodeToString([]byte("name: banana\n")),
+			"--hosted-model-config", base64.StdEncoding.EncodeToString([]byte("name: banana\n")),
 			"--instance-id", "anything",
 			"--hardware", "nonsense",
 		},
@@ -497,6 +535,7 @@ var bootstrapArgTests = []struct {
 	}, {
 		input: []string{
 			"--model-config", base64.StdEncoding.EncodeToString([]byte("name: banana\n")),
+			"--hosted-model-config", base64.StdEncoding.EncodeToString([]byte("name: banana\n")),
 			"--instance-id", "anything",
 			"--hardware", "arch=amd64 cpu-cores=4 root-disk=2T",
 		},
@@ -515,7 +554,7 @@ func (s *BootstrapSuite) TestBootstrapArgs(c *gc.C) {
 		if t.err == "" {
 			c.Assert(cmd, gc.NotNil)
 			c.Assert(err, jc.ErrorIsNil)
-			c.Assert(cmd.EnvConfig, gc.DeepEquals, t.expectedConfig)
+			c.Assert(cmd.ControllerModelConfig, gc.DeepEquals, t.expectedConfig)
 			c.Assert(cmd.InstanceId, gc.Equals, t.expectedInstanceId)
 			c.Assert(cmd.Hardware, gc.DeepEquals, t.expectedHardware)
 		} else {
@@ -526,15 +565,23 @@ func (s *BootstrapSuite) TestBootstrapArgs(c *gc.C) {
 
 func (s *BootstrapSuite) TestInitializeStateArgs(c *gc.C) {
 	var called int
-	initializeState := func(_ names.UserTag, _ agent.ConfigSetter, envCfg *config.Config, machineCfg agent.BootstrapMachineConfig, dialOpts mongo.DialOpts, policy state.Policy) (_ *state.State, _ *state.Machine, resultErr error) {
+	initializeState := func(_ names.UserTag, _ agent.ConfigSetter, envCfg *config.Config, hostedModelConfig map[string]interface{}, machineCfg agentbootstrap.BootstrapMachineConfig, dialOpts mongo.DialOpts, policy state.Policy) (_ *state.State, _ *state.Machine, resultErr error) {
 		called++
 		c.Assert(dialOpts.Direct, jc.IsTrue)
 		c.Assert(dialOpts.Timeout, gc.Equals, 30*time.Second)
 		c.Assert(dialOpts.SocketTimeout, gc.Equals, 123*time.Second)
+		c.Assert(hostedModelConfig, jc.DeepEquals, map[string]interface{}{
+			"name": "hosted-model",
+			"uuid": s.hostedModelUUID,
+		})
 		return nil, nil, errors.New("failed to initialize state")
 	}
 	s.PatchValue(&agentInitializeState, initializeState)
-	_, cmd, err := s.initBootstrapCommand(c, nil, "--model-config", s.b64yamlEnvcfg, "--instance-id", string(s.instanceId))
+	_, cmd, err := s.initBootstrapCommand(c, nil,
+		"--model-config", s.b64yamlControllerModelConfig,
+		"--hosted-model-config", s.b64yamlHostedModelConfig,
+		"--instance-id", string(s.instanceId),
+	)
 	c.Assert(err, jc.ErrorIsNil)
 	err = cmd.Run(nil)
 	c.Assert(err, gc.ErrorMatches, "failed to initialize state")
@@ -543,7 +590,7 @@ func (s *BootstrapSuite) TestInitializeStateArgs(c *gc.C) {
 
 func (s *BootstrapSuite) TestInitializeStateMinSocketTimeout(c *gc.C) {
 	var called int
-	initializeState := func(_ names.UserTag, _ agent.ConfigSetter, envCfg *config.Config, machineCfg agent.BootstrapMachineConfig, dialOpts mongo.DialOpts, policy state.Policy) (_ *state.State, _ *state.Machine, resultErr error) {
+	initializeState := func(_ names.UserTag, _ agent.ConfigSetter, envCfg *config.Config, hostedModelConfig map[string]interface{}, machineCfg agentbootstrap.BootstrapMachineConfig, dialOpts mongo.DialOpts, policy state.Policy) (_ *state.State, _ *state.Machine, resultErr error) {
 		called++
 		c.Assert(dialOpts.Direct, jc.IsTrue)
 		c.Assert(dialOpts.SocketTimeout, gc.Equals, 1*time.Minute)
@@ -554,10 +601,14 @@ func (s *BootstrapSuite) TestInitializeStateMinSocketTimeout(c *gc.C) {
 		"bootstrap-timeout": "13",
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	b64yamlEnvcfg := b64yaml(envcfg.AllAttrs()).encode()
+	b64yamlControllerModelConfig := b64yaml(envcfg.AllAttrs()).encode()
 
 	s.PatchValue(&agentInitializeState, initializeState)
-	_, cmd, err := s.initBootstrapCommand(c, nil, "--model-config", b64yamlEnvcfg, "--instance-id", string(s.instanceId))
+	_, cmd, err := s.initBootstrapCommand(c, nil,
+		"--model-config", b64yamlControllerModelConfig,
+		"--hosted-model-config", s.b64yamlHostedModelConfig,
+		"--instance-id", string(s.instanceId),
+	)
 	c.Assert(err, jc.ErrorIsNil)
 	err = cmd.Run(nil)
 	c.Assert(err, gc.ErrorMatches, "failed to initialize state")
@@ -568,7 +619,11 @@ func (s *BootstrapSuite) TestSystemIdentityWritten(c *gc.C) {
 	_, err := os.Stat(filepath.Join(s.dataDir, agent.SystemIdentity))
 	c.Assert(err, jc.Satisfies, os.IsNotExist)
 
-	_, cmd, err := s.initBootstrapCommand(c, nil, "--model-config", s.b64yamlEnvcfg, "--instance-id", string(s.instanceId))
+	_, cmd, err := s.initBootstrapCommand(c, nil,
+		"--model-config", s.b64yamlControllerModelConfig,
+		"--hosted-model-config", s.b64yamlHostedModelConfig,
+		"--instance-id", string(s.instanceId),
+	)
 	c.Assert(err, jc.ErrorIsNil)
 	err = cmd.Run(nil)
 	c.Assert(err, jc.ErrorIsNil)
@@ -599,7 +654,11 @@ func (s *BootstrapSuite) TestUploadedToolsMetadata(c *gc.C) {
 func (s *BootstrapSuite) testToolsMetadata(c *gc.C, exploded bool) {
 	envtesting.RemoveFakeToolsMetadata(c, s.toolsStorage)
 
-	_, cmd, err := s.initBootstrapCommand(c, nil, "--model-config", s.b64yamlEnvcfg, "--instance-id", string(s.instanceId))
+	_, cmd, err := s.initBootstrapCommand(c, nil,
+		"--model-config", s.b64yamlControllerModelConfig,
+		"--hosted-model-config", s.b64yamlHostedModelConfig,
+		"--instance-id", string(s.instanceId),
+	)
 	c.Assert(err, jc.ErrorIsNil)
 	err = cmd.Run(nil)
 	c.Assert(err, jc.ErrorIsNil)
@@ -759,7 +818,9 @@ func (s *BootstrapSuite) TestStructuredImageMetadataStored(c *gc.C) {
 	dir, m, _ := createImageMetadata(c)
 	_, cmd, err := s.initBootstrapCommand(
 		c, nil,
-		"--model-config", s.b64yamlEnvcfg, "--instance-id", string(s.instanceId),
+		"--model-config", s.b64yamlControllerModelConfig,
+		"--hosted-model-config", s.b64yamlHostedModelConfig,
+		"--instance-id", string(s.instanceId),
 		"--image-metadata", dir,
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -777,7 +838,9 @@ func (s *BootstrapSuite) TestCustomDataSourceHasKey(c *gc.C) {
 	dir, _, _ := createImageMetadata(c)
 	_, cmd, err := s.initBootstrapCommand(
 		c, nil,
-		"--model-config", s.b64yamlEnvcfg, "--instance-id", string(s.instanceId),
+		"--model-config", s.b64yamlControllerModelConfig,
+		"--hosted-model-config", s.b64yamlHostedModelConfig,
+		"--instance-id", string(s.instanceId),
 		"--image-metadata", dir,
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -809,7 +872,9 @@ func (s *BootstrapSuite) TestStructuredImageMetadataInvalidSeries(c *gc.C) {
 
 	_, cmd, err := s.initBootstrapCommand(
 		c, nil,
-		"--model-config", s.b64yamlEnvcfg, "--instance-id", string(s.instanceId),
+		"--model-config", s.b64yamlControllerModelConfig,
+		"--hosted-model-config", s.b64yamlHostedModelConfig,
+		"--instance-id", string(s.instanceId),
 		"--image-metadata", dir,
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -827,7 +892,9 @@ func (s *BootstrapSuite) TestImageMetadata(c *gc.C) {
 
 	_, cmd, err := s.initBootstrapCommand(
 		c, nil,
-		"--model-config", s.b64yamlEnvcfg, "--instance-id", string(s.instanceId),
+		"--model-config", s.b64yamlControllerModelConfig,
+		"--hosted-model-config", s.b64yamlHostedModelConfig,
+		"--instance-id", string(s.instanceId),
 		"--image-metadata", metadataDir,
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -875,7 +942,14 @@ func (s *BootstrapSuite) makeTestEnv(c *gc.C) {
 	addr, _ := network.SelectPublicAddress(addresses)
 	s.bootstrapName = addr.Value
 	s.envcfg = env.Config()
-	s.b64yamlEnvcfg = b64yaml(s.envcfg.AllAttrs()).encode()
+	s.b64yamlControllerModelConfig = b64yaml(s.envcfg.AllAttrs()).encode()
+
+	s.hostedModelUUID = utils.MustNewUUID().String()
+	hostedModelConfigAttrs := map[string]interface{}{
+		"name": "hosted-model",
+		"uuid": s.hostedModelUUID,
+	}
+	s.b64yamlHostedModelConfig = b64yaml(hostedModelConfigAttrs).encode()
 }
 
 func nullContext() environs.BootstrapContext {
@@ -897,7 +971,11 @@ func (m b64yaml) encode() string {
 }
 
 func (s *BootstrapSuite) TestDefaultStoragePools(c *gc.C) {
-	_, cmd, err := s.initBootstrapCommand(c, nil, "--model-config", s.b64yamlEnvcfg, "--instance-id", string(s.instanceId))
+	_, cmd, err := s.initBootstrapCommand(
+		c, nil, "--model-config", s.b64yamlControllerModelConfig,
+		"--hosted-model-config", s.b64yamlHostedModelConfig,
+		"--instance-id", string(s.instanceId),
+	)
 	c.Assert(err, jc.ErrorIsNil)
 	err = cmd.Run(nil)
 	c.Assert(err, jc.ErrorIsNil)

--- a/cmd/jujud/main_test.go
+++ b/cmd/jujud/main_test.go
@@ -102,6 +102,7 @@ func (s *MainSuite) TestParseErrors(c *gc.C) {
 	checkMessage(c, msga,
 		"bootstrap-state",
 		"--model-config", b64yaml{"blah": "blah"}.encode(),
+		"--hosted-model-config", b64yaml{"blah": "blah"}.encode(),
 		"--instance-id", "inst",
 		"toastie")
 	checkMessage(c, msga, "unit",

--- a/cmd/plugins/juju-metadata/imagemetadata_test.go
+++ b/cmd/plugins/juju-metadata/imagemetadata_test.go
@@ -154,9 +154,11 @@ func (s *ImageMetadataSuite) TestImageMetadataFilesDefaultArch(c *gc.C) {
 
 func (s *ImageMetadataSuite) TestImageMetadataFilesLatestLts(c *gc.C) {
 	ec2Config, err := config.New(config.UseDefaults, map[string]interface{}{
-		"name":   "ec2-latest-lts",
-		"type":   "ec2",
-		"region": "us-east-1",
+		"name":            "ec2-latest-lts",
+		"type":            "ec2",
+		"uuid":            testing.ModelTag.Id(),
+		"controller-uuid": testing.ModelTag.Id(),
+		"region":          "us-east-1",
 	})
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/cmd/plugins/juju-metadata/toolsmetadata_test.go
+++ b/cmd/plugins/juju-metadata/toolsmetadata_test.go
@@ -47,9 +47,11 @@ func (s *ToolsMetadataSuite) SetUpTest(c *gc.C) {
 		loggo.ResetLoggers()
 	})
 	cfg, err := config.New(config.UseDefaults, map[string]interface{}{
-		"name":      "erewhemos",
-		"type":      "dummy",
-		"conroller": true,
+		"name":            "erewhemos",
+		"type":            "dummy",
+		"uuid":            coretesting.ModelTag.Id(),
+		"controller-uuid": coretesting.ModelTag.Id(),
+		"conroller":       true,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	env, err := environs.Prepare(

--- a/cmd/plugins/juju-metadata/validateimagemetadata_test.go
+++ b/cmd/plugins/juju-metadata/validateimagemetadata_test.go
@@ -93,16 +93,20 @@ func (s *ValidateImageMetadataSuite) makeLocalMetadata(c *gc.C, id, region, seri
 
 func cacheTestEnvConfig(c *gc.C) {
 	ec2Config, err := config.New(config.UseDefaults, map[string]interface{}{
-		"name":           "ec2",
-		"type":           "ec2",
-		"default-series": "precise",
-		"region":         "us-east-1",
+		"name":            "ec2",
+		"type":            "ec2",
+		"uuid":            coretesting.ModelTag.Id(),
+		"controller-uuid": coretesting.ModelTag.Id(),
+		"default-series":  "precise",
+		"region":          "us-east-1",
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
 	azureConfig, err := config.New(config.UseDefaults, map[string]interface{}{
 		"name":                      "azure",
 		"type":                      "azure",
+		"uuid":                      coretesting.ModelTag.Id(),
+		"controller-uuid":           coretesting.ModelTag.Id(),
 		"default-series":            "raring",
 		"location":                  "West US",
 		"endpoint":                  "https://management.azure.com",

--- a/controller/modelmanager/createmodel.go
+++ b/controller/modelmanager/createmodel.go
@@ -43,7 +43,7 @@ type ModelConfigCreator struct {
 
 // NewModelConfig returns a new model config given a base (controller) config
 // and a set of attributes that will be specific to the new model, overriding
-// and non-restricted attributes in the base configuration. The resulting
+// any non-restricted attributes in the base configuration. The resulting
 // config will be suitable for creating a new model in state.
 //
 // If "attrs" does not include a UUID, a new, random one will be generated

--- a/controller/modelmanager/createmodel.go
+++ b/controller/modelmanager/createmodel.go
@@ -1,0 +1,199 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Package modelmanager provides the business logic for
+// model management operations in the controller.
+package modelmanager
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	"github.com/juju/utils"
+
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/tools"
+	"github.com/juju/juju/version"
+)
+
+var (
+	logger = loggo.GetLogger("juju.controller.modelmanager")
+
+	configValuesFromController = []string{
+		"type",
+		"ca-cert",
+		"state-port",
+		"api-port",
+		config.ControllerUUIDKey,
+	}
+)
+
+// ModelConfigCreator provides a method of creating a new model config.
+//
+// The zero value of ModelConfigCreator is usable with the limitations
+// noted on each struct field.
+type ModelConfigCreator struct {
+	// FindTools, if non-nil, will be used to validate the agent-version
+	// value in NewModelConfig if it differs from the base configuration.
+	//
+	// If FindTools is nil, agent-version may not be different to the
+	// base configuration.
+	FindTools func(version.Number) (tools.List, error)
+}
+
+// NewModelConfig returns a new model config given a base (controller) config
+// and a set of attributes that will be specific to the new model, overriding
+// and non-restricted attributes in the base configuration. The resulting
+// config will be suitable for creating a new model in state.
+//
+// If "attrs" does not include a UUID, a new, random one will be generated
+// and added to the config.
+//
+// The config will be validated with the provider before being returned.
+func (c ModelConfigCreator) NewModelConfig(
+	base *config.Config,
+	attrs map[string]interface{},
+) (*config.Config, error) {
+
+	if err := c.checkVersion(base, attrs); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	// Before comparing any values, we need to push the config through
+	// the provider validation code. One of the reasons for this is that
+	// numbers being serialized through JSON get turned into float64. The
+	// schema code used in config will convert these back into integers.
+	// However, before we can create a valid config, we need to make sure
+	// we copy across fields from the main config that aren't there.
+	baseAttrs := base.AllAttrs()
+	restrictedFields, err := RestrictedProviderFields(base.Type())
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	for _, field := range restrictedFields {
+		if _, ok := attrs[field]; !ok {
+			if baseValue, ok := baseAttrs[field]; ok {
+				attrs[field] = baseValue
+			}
+		}
+	}
+
+	// Generate a new UUID for the model as necessary,
+	// and finalize the new config.
+	if _, ok := attrs[config.UUIDKey]; !ok {
+		uuid, err := utils.NewUUID()
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		attrs[config.UUIDKey] = uuid.String()
+	}
+	cfg, err := finalizeConfig(attrs)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	attrs = cfg.AllAttrs()
+
+	// Any values that would normally be copied from the controller
+	// config can also be defined, but if they differ from the controller
+	// values, an error is returned.
+	for _, field := range restrictedFields {
+		if value, ok := attrs[field]; ok {
+			if serverValue := baseAttrs[field]; value != serverValue {
+				return nil, errors.Errorf(
+					"specified %s \"%v\" does not match controller \"%v\"",
+					field, value, serverValue)
+			}
+		}
+	}
+	return cfg, nil
+}
+
+func (c *ModelConfigCreator) checkVersion(base *config.Config, attrs map[string]interface{}) error {
+	baseVersion, ok := base.AgentVersion()
+	if !ok {
+		return errors.Errorf("agent-version not found in base config")
+	}
+
+	// If there is no agent-version specified, use the current version.
+	// otherwise we need to check for tools
+	value, ok := attrs["agent-version"]
+	if !ok {
+		attrs["agent-version"] = baseVersion.String()
+		return nil
+	}
+	versionStr, ok := value.(string)
+	if !ok {
+		return errors.Errorf("agent-version must be a string but has type '%T'", value)
+	}
+	versionNumber, err := version.Parse(versionStr)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	n := versionNumber.Compare(baseVersion)
+	switch {
+	case n > 0:
+		return errors.Errorf(
+			"agent-version (%s) cannot be greater than the controller (%s)",
+			versionNumber, baseVersion,
+		)
+	case n == 0:
+		// If the version is the same as the base config,
+		// then assume tools are available.
+		return nil
+	case n < 0:
+		if c.FindTools == nil {
+			return errors.New(
+				"agent-version does not match base config, " +
+					"and no tools-finder is supplied",
+			)
+		}
+	}
+
+	// Look to see if we have tools available for that version.
+	list, err := c.FindTools(versionNumber)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if len(list) == 0 {
+		return errors.Errorf("no tools found for version %s", versionNumber)
+	}
+	logger.Tracef("found tools: %#v", list)
+	return nil
+}
+
+// RestrictedProviderFields returns the set of config fields that may not be
+// overridden.
+func RestrictedProviderFields(providerType string) ([]string, error) {
+	provider, err := environs.Provider(providerType)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	var fields []string
+	fields = append(fields, configValuesFromController...)
+	fields = append(fields, provider.RestrictedConfigAttributes()...)
+	return fields, nil
+}
+
+// finalizeConfig creates the config object from attributes, calls
+// PrepareForCreateEnvironment, and then finally validates the config
+// before returning it.
+func finalizeConfig(attrs map[string]interface{}) (*config.Config, error) {
+	cfg, err := config.New(config.UseDefaults, attrs)
+	if err != nil {
+		return nil, errors.Annotate(err, "creating config from values failed")
+	}
+	provider, err := environs.Provider(cfg.Type())
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	cfg, err = provider.PrepareForCreateEnvironment(cfg)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	cfg, err = provider.Validate(cfg, nil)
+	if err != nil {
+		return nil, errors.Annotate(err, "provider validation failed")
+	}
+	return cfg, nil
+}

--- a/controller/modelmanager/createmodel_test.go
+++ b/controller/modelmanager/createmodel_test.go
@@ -13,6 +13,9 @@ import (
 	"github.com/juju/juju/testing"
 )
 
+// TODO(axw) unit tests for ModelConfigCreator.NewModelConfig. Currently,
+// it is exercised via agentbootstrap and apiserver/modelmanager tests.
+
 type RestrictedProviderFieldsSuite struct {
 	testing.BaseSuite
 }

--- a/controller/modelmanager/createmodel_test.go
+++ b/controller/modelmanager/createmodel_test.go
@@ -149,7 +149,9 @@ func (s *ModelConfigCreatorSuite) TestCreateModelLesserAgentVersionNoToolsFinder
 
 func (s *ModelConfigCreatorSuite) TestCreateModelLesserAgentVersionToolsFinderFound(c *gc.C) {
 	s.creator.FindTools = func(version.Number) (tools.List, error) {
-		return tools.List{{ /*contents don't matter, just need a non-empty list*/ }}, nil
+		return tools.List{
+			{}, //contents don't matter, just need a non-empty list
+		}, nil
 	}
 	cfg, err := s.newModelConfig(coretesting.Attrs(
 		s.baseConfig.AllAttrs(),

--- a/controller/modelmanager/createmodel_test.go
+++ b/controller/modelmanager/createmodel_test.go
@@ -1,0 +1,67 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package modelmanager_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/controller/modelmanager"
+	_ "github.com/juju/juju/provider/all"
+	_ "github.com/juju/juju/provider/dummy"
+	"github.com/juju/juju/testing"
+)
+
+type RestrictedProviderFieldsSuite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&RestrictedProviderFieldsSuite{})
+
+func (*RestrictedProviderFieldsSuite) TestRestrictedProviderFields(c *gc.C) {
+	for i, test := range []struct {
+		provider string
+		expected []string
+	}{{
+		provider: "azure",
+		expected: []string{
+			"type", "ca-cert", "state-port", "api-port", "controller-uuid",
+			"subscription-id", "tenant-id", "application-id", "application-password",
+			"location", "controller-resource-group", "storage-account-type",
+		},
+	}, {
+		provider: "dummy",
+		expected: []string{
+			"type", "ca-cert", "state-port", "api-port", "controller-uuid",
+		},
+	}, {
+		provider: "joyent",
+		expected: []string{
+			"type", "ca-cert", "state-port", "api-port", "controller-uuid",
+		},
+	}, {
+		provider: "maas",
+		expected: []string{
+			"type", "ca-cert", "state-port", "api-port", "controller-uuid",
+			"maas-server",
+		},
+	}, {
+		provider: "openstack",
+		expected: []string{
+			"type", "ca-cert", "state-port", "api-port", "controller-uuid",
+			"region", "auth-url", "auth-mode",
+		},
+	}, {
+		provider: "ec2",
+		expected: []string{
+			"type", "ca-cert", "state-port", "api-port", "controller-uuid",
+			"region",
+		},
+	}} {
+		c.Logf("%d: %s provider", i, test.provider)
+		fields, err := modelmanager.RestrictedProviderFields(test.provider)
+		c.Check(err, jc.ErrorIsNil)
+		c.Check(fields, jc.SameContents, test.expected)
+	}
+}

--- a/controller/modelmanager/package_test.go
+++ b/controller/modelmanager/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package modelmanager_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestAll(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/environs/bootstrap.go
+++ b/environs/bootstrap.go
@@ -15,12 +15,12 @@ import (
 
 // BootstrapParams holds the parameters for bootstrapping an environment.
 type BootstrapParams struct {
-	// EnvironConstraints are merged with the bootstrap constraints
+	// ModelConstraints are merged with the bootstrap constraints
 	// to choose the initial instance, and will be stored in the new
 	// environment's state.
-	EnvironConstraints constraints.Value
+	ModelConstraints constraints.Value
 
-	// BootstrapConstraints, in conjunction with EnvironConstraints,
+	// BootstrapConstraints, in conjunction with ModelConstraints,
 	// are used to choose the initial instance. BootstrapConstraints
 	// will not be stored in state for the environment.
 	BootstrapConstraints constraints.Value

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -38,14 +38,13 @@ var (
 
 // BootstrapParams holds the parameters for bootstrapping an environment.
 type BootstrapParams struct {
-	// EnvironConstraints are merged with the bootstrap constraints
-	// to choose the initial instance, and will be stored in the new
-	// environment's state.
-	EnvironConstraints constraints.Value
+	// ModelConstraints are merged with the bootstrap constraints
+	// to choose the initial instance, and will be stored in the
+	// initial models' states.
+	ModelConstraints constraints.Value
 
 	// BootstrapConstraints are used to choose the initial instance.
-	// BootstrapConstraints does not affect the environment-level
-	// constraints.
+	// BootstrapConstraints does not affect the model constraints.
 	BootstrapConstraints constraints.Value
 
 	// BootstrapSeries, if specified, is the series to use for the
@@ -55,6 +54,11 @@ type BootstrapParams struct {
 	// BootstrapImage, if specified, is the image ID to use for the
 	// initial bootstrap machine.
 	BootstrapImage string
+
+	// HostedModelConfig is the set of config attributes to be overlaid
+	// on the controller config to construct the initial hosted model
+	// config.
+	HostedModelConfig map[string]interface{}
 
 	// Placement, if non-empty, holds an environment-specific placement
 	// directive used to choose the initial instance.
@@ -108,7 +112,7 @@ func Bootstrap(ctx environs.BootstrapContext, environ environs.Environ, args Boo
 			return err
 		}
 	}
-	if err := validateConstraints(environ, args.EnvironConstraints); err != nil {
+	if err := validateConstraints(environ, args.ModelConstraints); err != nil {
 		return err
 	}
 	if err := validateConstraints(environ, args.BootstrapConstraints); err != nil {
@@ -120,7 +124,7 @@ func Bootstrap(ctx environs.BootstrapContext, environ environs.Environ, args Boo
 		return err
 	}
 	bootstrapConstraints, err := constraintsValidator.Merge(
-		args.EnvironConstraints, args.BootstrapConstraints,
+		args.ModelConstraints, args.BootstrapConstraints,
 	)
 	if err != nil {
 		return err
@@ -179,7 +183,7 @@ func Bootstrap(ctx environs.BootstrapContext, environ environs.Environ, args Boo
 
 	ctx.Infof("Starting new instance for initial controller")
 	result, err := environ.Bootstrap(ctx, environs.BootstrapParams{
-		EnvironConstraints:   args.EnvironConstraints,
+		ModelConstraints:     args.ModelConstraints,
 		BootstrapConstraints: args.BootstrapConstraints,
 		Placement:            args.Placement,
 		AvailableTools:       availableTools,
@@ -222,13 +226,14 @@ func Bootstrap(ctx environs.BootstrapContext, environ environs.Environ, args Boo
 		return err
 	}
 	instanceConfig, err := instancecfg.NewBootstrapInstanceConfig(
-		args.BootstrapConstraints, args.EnvironConstraints, result.Series, publicKey,
+		args.BootstrapConstraints, args.ModelConstraints, result.Series, publicKey,
 	)
 	if err != nil {
 		return err
 	}
 	instanceConfig.Tools = selectedTools
 	instanceConfig.CustomImageMetadata = customImageMetadata
+	instanceConfig.HostedModelConfig = args.HostedModelConfig
 	if err := result.Finalize(ctx, instanceConfig); err != nil {
 		return err
 	}

--- a/environs/bootstrap/bootstrap_test.go
+++ b/environs/bootstrap/bootstrap_test.go
@@ -105,15 +105,15 @@ func (s *bootstrapSuite) TestBootstrapSpecifiedConstraints(c *gc.C) {
 	env := newEnviron("foo", useDefaultKeys, nil)
 	s.setDummyStorage(c, env)
 	bootstrapCons := constraints.MustParse("cpu-cores=3 mem=7G")
-	environCons := constraints.MustParse("cpu-cores=2 mem=4G")
+	modelCons := constraints.MustParse("cpu-cores=2 mem=4G")
 	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{
 		BootstrapConstraints: bootstrapCons,
-		EnvironConstraints:   environCons,
+		ModelConstraints:     modelCons,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(env.bootstrapCount, gc.Equals, 1)
 	c.Assert(env.args.BootstrapConstraints, gc.DeepEquals, bootstrapCons)
-	c.Assert(env.args.EnvironConstraints, gc.DeepEquals, environCons)
+	c.Assert(env.args.ModelConstraints, gc.DeepEquals, modelCons)
 }
 
 func (s *bootstrapSuite) TestBootstrapSpecifiedPlacement(c *gc.C) {

--- a/environs/config/config_test.go
+++ b/environs/config/config_test.go
@@ -51,6 +51,8 @@ func (s *ConfigSuite) SetUpTest(c *gc.C) {
 var sampleConfig = testing.Attrs{
 	"type":                      "my-type",
 	"name":                      "my-name",
+	"uuid":                      testing.ModelTag.Id(),
+	"controller-uuid":           testing.ModelTag.Id(),
 	"authorized-keys":           testing.FakeAuthKeys,
 	"firewall-mode":             config.FwInstance,
 	"admin-secret":              "foo",
@@ -78,570 +80,444 @@ var testResourceTagsMap = map[string]string{
 
 var quotedPathSeparator = regexp.QuoteMeta(string(os.PathSeparator))
 
+var minimalConfigAttrs = testing.Attrs{
+	"type":            "my-type",
+	"name":            "my-name",
+	"uuid":            testing.ModelTag.Id(),
+	"controller-uuid": testing.ModelTag.Id(),
+}
+
 var configTests = []configTest{
 	{
 		about:       "The minimum good configuration",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type": "my-type",
-			"name": "my-name",
-		},
+		attrs:       minimalConfigAttrs,
 	}, {
 		about:       "Agent Stream",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type":               "my-type",
-			"name":               "my-name",
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"image-metadata-url": "image-url",
 			"agent-stream":       "released",
-		},
+		}),
 	}, {
 		about:       "Deprecated tools-stream used",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type":         "my-type",
-			"name":         "my-name",
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"tools-stream": "tools-stream-value",
-		},
+		}),
 	}, {
 		about:       "Deprecated tools-stream ignored",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type":         "my-type",
-			"name":         "my-name",
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"agent-stream": "released",
 			"tools-stream": "ignore-me",
-		},
+		}),
 	}, {
 		about:       "Metadata URLs",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type":               "my-type",
-			"name":               "my-name",
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"image-metadata-url": "image-url",
 			"agent-metadata-url": "agent-metadata-url-value",
-		},
+		}),
 	}, {
 		about:       "Deprecated tools metadata URL used",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type":               "my-type",
-			"name":               "my-name",
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"tools-metadata-url": "tools-metadata-url-value",
-		},
+		}),
 	}, {
 		about:       "Deprecated tools metadata URL ignored",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type":               "my-type",
-			"name":               "my-name",
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"agent-metadata-url": "agent-metadata-url-value",
 			"tools-metadata-url": "ignore-me",
-		},
+		}),
 	}, {
 		about:       "Explicit series",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type":           "my-type",
-			"name":           "my-name",
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"default-series": "my-series",
-		},
+		}),
 	}, {
 		about:       "Implicit series with empty value",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type":           "my-type",
-			"name":           "my-name",
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"default-series": "",
-		},
+		}),
 	}, {
 		about:       "Explicit logging",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type":           "my-type",
-			"name":           "my-name",
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"logging-config": "juju=INFO",
-		},
+		}),
 	}, {
 		about:       "Explicit authorized-keys",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type":            "my-type",
-			"name":            "my-name",
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"authorized-keys": testing.FakeAuthKeys,
-		},
+		}),
 	}, {
 		about:       "Load authorized-keys from path",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type":                 "my-type",
-			"name":                 "my-name",
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"authorized-keys-path": "~/.ssh/authorized_keys2",
-		},
+		}),
 	}, {
 		about:       "LXC clone values",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type":           "my-type",
-			"name":           "my-name",
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"default-series": "precise",
 			"lxc-clone":      true,
 			"lxc-clone-aufs": true,
-		},
+		}),
 	}, {
 		about:       "Deprecated lxc-use-clone used",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type":          "my-type",
-			"name":          "my-name",
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"lxc-use-clone": true,
-		},
+		}),
 	}, {
 		about:       "Deprecated lxc-use-clone ignored",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type":          "my-type",
-			"name":          "my-name",
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"lxc-use-clone": false,
 			"lxc-clone":     true,
-		},
+		}),
 	}, {
 		about:       "Allow LXC loop mounts true",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type":                  "my-type",
-			"name":                  "my-name",
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"allow-lxc-loop-mounts": "true",
-		},
+		}),
 	}, {
 		about:       "Allow LXC loop mounts default",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type":                  "my-type",
-			"name":                  "my-name",
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"allow-lxc-loop-mounts": "false",
-		},
-		expected: testing.Attrs{
-			"type":                  "my-type",
-			"name":                  "my-name",
+		}),
+		expected: minimalConfigAttrs.Merge(testing.Attrs{
 			"allow-lxc-loop-mounts": false,
-		},
+		}),
 	}, {
 		about:       "LXC default MTU not set",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type": "my-type",
-			"name": "my-name",
-		},
+		attrs:       minimalConfigAttrs,
 	}, {
 		about:       "LXC default MTU set explicitly",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type":            "my-type",
-			"name":            "my-name",
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"lxc-default-mtu": 9000,
-		},
+		}),
 	}, {
 		about:       "LXC default MTU invalid (not a number)",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type":            "my-type",
-			"name":            "my-name",
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"lxc-default-mtu": "foo",
-		},
+		}),
 		err: `lxc-default-mtu: expected number, got string\("foo"\)`,
 	}, {
 		about:       "LXC default MTU invalid (negative)",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type":            "my-type",
-			"name":            "my-name",
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"lxc-default-mtu": -42,
-		},
+		}),
 		err: `lxc-default-mtu: expected positive integer, got -42`,
 	}, {
 		about:       "CA cert & key from path",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type":                "my-type",
-			"name":                "my-name",
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"ca-cert-path":        "cacert2.pem",
 			"ca-private-key-path": "cakey2.pem",
-		},
+		}),
 	}, {
 		about:       "CA cert & key from path; cert attribute set too",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type":                "my-type",
-			"name":                "my-name",
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"ca-cert-path":        "cacert2.pem",
 			"ca-cert":             "ignored",
 			"ca-private-key-path": "cakey2.pem",
-		},
+		}),
 	}, {
 		about:       "CA cert & key from ~ path",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type":                "my-type",
-			"name":                "my-name",
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"ca-cert-path":        "~/othercert.pem",
 			"ca-private-key-path": "~/otherkey.pem",
-		},
+		}),
 	}, {
 		about:       "CA cert and key as attributes",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type":           "my-type",
-			"name":           "my-name",
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"ca-cert":        caCert,
 			"ca-private-key": caKey,
-		},
+		}),
 	}, {
 		about:       "Mismatched CA cert and key",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type":           "my-type",
-			"name":           "my-name",
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"ca-cert":        caCert,
 			"ca-private-key": caKey2,
-		},
+		}),
 		err: "bad CA certificate/key in configuration: crypto/tls: private key does not match public key",
 	}, {
 		about:       "Invalid CA cert",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type":    "my-type",
-			"name":    "my-name",
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"ca-cert": invalidCACert,
-		},
+		}),
 		err: `bad CA certificate/key in configuration: (asn1:|ASN\.1) syntax error:.*`,
 	}, {
 		about:       "Invalid CA key",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type":           "my-type",
-			"name":           "my-name",
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"ca-cert":        caCert,
 			"ca-private-key": invalidCAKey,
-		},
+		}),
 		err: "bad CA certificate/key in configuration: crypto/tls:.*",
 	}, {
 		about:       "CA cert specified as non-existent file",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type":         "my-type",
-			"name":         "my-name",
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"ca-cert-path": "no-such-file",
-		},
+		}),
 		err: fmt.Sprintf(`open .*\.local%sshare%sjuju%sno-such-file: .*`, quotedPathSeparator, quotedPathSeparator, quotedPathSeparator),
 	}, {
 		about:       "CA key specified as non-existent file",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type":                "my-type",
-			"name":                "my-name",
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"ca-private-key-path": "no-such-file",
-		},
+		}),
 		err: fmt.Sprintf(`open .*\.local%sshare%sjuju%sno-such-file: .*`, quotedPathSeparator, quotedPathSeparator, quotedPathSeparator),
 	}, {
 		about:       "Specified agent version",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type":            "my-type",
-			"name":            "my-name",
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"authorized-keys": testing.FakeAuthKeys,
 			"agent-version":   "1.2.3",
-		},
+		}),
 	}, {
 		about:       "Specified development flag",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type":            "my-type",
-			"name":            "my-name",
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"authorized-keys": testing.FakeAuthKeys,
 			"development":     true,
-		},
+		}),
 	}, {
 		about:       "Specified admin secret",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type":            "my-type",
-			"name":            "my-name",
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"authorized-keys": testing.FakeAuthKeys,
 			"development":     false,
 			"admin-secret":    "pork",
-		},
+		}),
 	}, {
 		about:       "Invalid development flag",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type":            "my-type",
-			"name":            "my-name",
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"authorized-keys": testing.FakeAuthKeys,
 			"development":     "invalid",
-		},
+		}),
 		err: `development: expected bool, got string\("invalid"\)`,
 	}, {
 		about:       "Invalid disable-network-management flag",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type":                       "my-type",
-			"name":                       "my-name",
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"authorized-keys":            testing.FakeAuthKeys,
 			"disable-network-management": "invalid",
-		},
+		}),
 		err: `disable-network-management: expected bool, got string\("invalid"\)`,
 	}, {
 		about:       "disable-network-management off",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type": "my-type",
-			"name": "my-name",
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"disable-network-management": false,
-		},
+		}),
 	}, {
 		about:       "disable-network-management on",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type": "my-type",
-			"name": "my-name",
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"disable-network-management": true,
-		},
+		}),
 	}, {
 		about:       "Invalid ignore-machine-addresses flag",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type": "my-type",
-			"name": "my-name",
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"ignore-machine-addresses": "invalid",
-		},
+		}),
 		err: `ignore-machine-addresses: expected bool, got string\("invalid"\)`,
 	}, {
 		about:       "ignore-machine-addresses off",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type": "my-type",
-			"name": "my-name",
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"ignore-machine-addresses": false,
-		},
+		}),
 	}, {
 		about:       "ignore-machine-addresses on",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type": "my-type",
-			"name": "my-name",
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"ignore-machine-addresses": true,
-		},
+		}),
 	}, {
 		about:       "set-numa-control-policy on",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type": "my-type",
-			"name": "my-name",
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"set-numa-control-policy": true,
-		},
+		}),
 	}, {
 		about:       "set-numa-control-policy off",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type": "my-type",
-			"name": "my-name",
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"set-numa-control-policy": false,
-		},
+		}),
 	}, {
 		about:       "block-destroy-model on",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type":                "my-type",
-			"name":                "my-name",
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"block-destroy-model": true,
-		},
+		}),
 	}, {
 		about:       "block-destroy-model off",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type":                "my-type",
-			"name":                "my-name",
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"block-destroy-model": false,
-		},
+		}),
 	}, {
 		about:       "block-remove-object on",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type":                "my-type",
-			"name":                "my-name",
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"block-remove-object": true,
-		},
+		}),
 	}, {
 		about:       "block-remove-object off",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type":                "my-type",
-			"name":                "my-name",
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"block-remove-object": false,
-		},
+		}),
 	}, {
 		about:       "block-all-changes on",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type":              "my-type",
-			"name":              "my-name",
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"block-all-changes": true,
-		},
+		}),
 	}, {
 		about:       "block-all-changes off",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type":               "my-type",
-			"name":               "my-name",
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"block-all-changest": false,
-		},
+		}),
 	}, {
 		about:       "Invalid prefer-ipv6 flag",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type":            "my-type",
-			"name":            "my-name",
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"authorized-keys": testing.FakeAuthKeys,
 			"prefer-ipv6":     "invalid",
-		},
+		}),
 		err: `prefer-ipv6: expected bool, got string\("invalid"\)`,
 	}, {
 		about:       "prefer-ipv6 off",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type":        "my-type",
-			"name":        "my-name",
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"prefer-ipv6": false,
-		},
+		}),
 	}, {
 		about:       "prefer-ipv6 on",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type":        "my-type",
-			"name":        "my-name",
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"prefer-ipv6": true,
-		},
+		}),
 	}, {
 		about:       "Invalid agent version",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type":            "my-type",
-			"name":            "my-name",
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"authorized-keys": testing.FakeAuthKeys,
 			"agent-version":   "2",
-		},
+		}),
 		err: `invalid agent version in model configuration: "2"`,
 	}, {
 		about:       "Missing type",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"name": "my-name",
-		},
-		err: "type: expected string, got nothing",
+		attrs:       minimalConfigAttrs.Delete("type"),
+		err:         "type: expected string, got nothing",
 	}, {
 		about:       "Empty type",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"name": "my-name",
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"type": "",
-		},
+		}),
 		err: "empty type in model configuration",
 	}, {
 		about:       "Missing name",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type": "my-type",
-		},
-		err: "name: expected string, got nothing",
+		attrs:       minimalConfigAttrs.Delete("name"),
+		err:         "name: expected string, got nothing",
 	}, {
 		about:       "Bad name, no slash",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"name": "foo/bar",
-			"type": "my-type",
-		},
+		}),
 		err: "model name contains unsafe characters",
 	}, {
 		about:       "Bad name, no backslash",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"name": "foo\\bar",
-			"type": "my-type",
-		},
+		}),
 		err: "model name contains unsafe characters",
 	}, {
 		about:       "Empty name",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type": "my-type",
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"name": "",
-		},
+		}),
 		err: "empty name in model configuration",
 	}, {
 		about:       "Default firewall mode",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type": "my-type",
-			"name": "my-name",
-		},
+		attrs:       minimalConfigAttrs,
 	}, {
 		about:       "Empty firewall mode",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type":          "my-type",
-			"name":          "my-name",
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"firewall-mode": "",
-		},
+		}),
 	}, {
 		about:       "Instance firewall mode",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type":          "my-type",
-			"name":          "my-name",
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"firewall-mode": config.FwInstance,
-		},
+		}),
 	}, {
 		about:       "Global firewall mode",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type":          "my-type",
-			"name":          "my-name",
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"firewall-mode": config.FwGlobal,
-		},
+		}),
 	}, {
 		about:       "None firewall mode",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type":          "my-type",
-			"name":          "my-name",
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"firewall-mode": config.FwNone,
-		},
+		}),
 	}, {
 		about:       "Illegal firewall mode",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type":          "my-type",
-			"name":          "my-name",
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"firewall-mode": "illegal",
-		},
+		}),
 		err: `firewall-mode: expected one of \[instance global none ], got "illegal"`,
 	}, {
 		about:       "ssl-hostname-verification off",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type": "my-type",
-			"name": "my-name",
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"ssl-hostname-verification": false,
-		},
+		}),
 	}, {
 		about:       "ssl-hostname-verification incorrect",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type": "my-type",
-			"name": "my-name",
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"ssl-hostname-verification": "yes please",
-		},
+		}),
 		err: `ssl-hostname-verification: expected bool, got string\("yes please"\)`,
 	}, {
 		about: fmt.Sprintf(
@@ -650,11 +526,9 @@ var configTests = []configTest{
 			config.HarvestAll.String(),
 		),
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type": "my-type",
-			"name": "my-name",
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"provisioner-harvest-mode": config.HarvestAll.String(),
-		},
+		}),
 	}, {
 		about: fmt.Sprintf(
 			"%s: %s",
@@ -662,11 +536,9 @@ var configTests = []configTest{
 			config.HarvestDestroyed.String(),
 		),
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type": "my-type",
-			"name": "my-name",
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"provisioner-harvest-mode": config.HarvestDestroyed.String(),
-		},
+		}),
 	}, {
 		about: fmt.Sprintf(
 			"%s: %s",
@@ -674,11 +546,9 @@ var configTests = []configTest{
 			config.HarvestUnknown.String(),
 		),
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type": "my-type",
-			"name": "my-name",
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"provisioner-harvest-mode": config.HarvestUnknown.String(),
-		},
+		}),
 	}, {
 		about: fmt.Sprintf(
 			"%s: %s",
@@ -686,136 +556,103 @@ var configTests = []configTest{
 			config.HarvestNone.String(),
 		),
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type": "my-type",
-			"name": "my-name",
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"provisioner-harvest-mode": config.HarvestNone.String(),
-		},
+		}),
 	}, {
 		about:       "provisioner-harvest-mode: incorrect",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type": "my-type",
-			"name": "my-name",
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"provisioner-harvest-mode": "yes please",
-		},
+		}),
 		err: `provisioner-harvest-mode: expected one of \[all none unknown destroyed], got "yes please"`,
 	}, {
 		about:       "default image stream",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type": "my-type",
-			"name": "my-name",
-		},
+		attrs:       minimalConfigAttrs,
 	}, {
 		about:       "explicit image stream",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type":         "my-type",
-			"name":         "my-name",
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"image-stream": "daily",
-		},
+		}),
 	}, {
 		about:       "explicit tools stream",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type":         "my-type",
-			"name":         "my-name",
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"agent-stream": "proposed",
-		},
+		}),
 	}, {
 		about:       "Explicit state port",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type":       "my-type",
-			"name":       "my-name",
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"state-port": 37042,
-		},
+		}),
 	}, {
 		about:       "Invalid state port",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type":       "my-type",
-			"name":       "my-name",
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"state-port": "illegal",
-		},
+		}),
 		err: `state-port: expected number, got string\("illegal"\)`,
 	}, {
 		about:       "Explicit API port",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type":     "my-type",
-			"name":     "my-name",
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"api-port": 77042,
-		},
+		}),
 	}, {
 		about:       "Invalid API port",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type":     "my-type",
-			"name":     "my-name",
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"api-port": "illegal",
-		},
+		}),
 		err: `api-port: expected number, got string\("illegal"\)`,
 	}, {
 		about:       "Explicit bootstrap timeout",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type":              "my-type",
-			"name":              "my-name",
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"bootstrap-timeout": 300,
-		},
+		}),
 	}, {
 		about:       "Invalid bootstrap timeout",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type":              "my-type",
-			"name":              "my-name",
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"bootstrap-timeout": "illegal",
-		},
+		}),
 		err: `bootstrap-timeout: expected number, got string\("illegal"\)`,
 	}, {
 		about:       "Explicit bootstrap retry delay",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type":                  "my-type",
-			"name":                  "my-name",
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"bootstrap-retry-delay": 5,
-		},
+		}),
 	}, {
 		about:       "Invalid bootstrap retry delay",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type":                  "my-type",
-			"name":                  "my-name",
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"bootstrap-retry-delay": "illegal",
-		},
+		}),
 		err: `bootstrap-retry-delay: expected number, got string\("illegal"\)`,
 	}, {
 		about:       "Explicit bootstrap addresses delay",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type": "my-type",
-			"name": "my-name",
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"bootstrap-addresses-delay": 15,
-		},
+		}),
 	}, {
 		about:       "Invalid bootstrap addresses delay",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type": "my-type",
-			"name": "my-name",
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"bootstrap-addresses-delay": "illegal",
-		},
+		}),
 		err: `bootstrap-addresses-delay: expected number, got string\("illegal"\)`,
 	}, {
 		about:       "Invalid logging configuration",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type":           "my-type",
-			"name":           "my-name",
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"logging-config": "foo=bar",
-		},
+		}),
 		err: `unknown severity level "bar"`,
 	}, {
 		about:       "Sample configuration",
@@ -866,56 +703,56 @@ var configTests = []configTest{
 			"ca-cert":                   caCert,
 			"firewall-mode":             "instance",
 			"type":                      "ec2",
+			// These ones weren't actual values, but we require
+			// them now, and have no backwards-compatibility
+			// with the old config.
+			"uuid":            testing.ModelTag.Id(),
+			"controller-uuid": testing.ModelTag.Id(),
 		},
 	}, {
 		about:       "Provider type null is replaced with manual",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"type": "null",
-			"name": "my-name",
-		},
+		}),
 	}, {
 		about:       "TestMode flag specified",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type":      "my-type",
-			"name":      "my-name",
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"test-mode": true,
-		},
+		}),
 	}, {
 		about:       "valid uuid",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type": "my-type",
-			"name": "my-name",
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"uuid": "dcfbdb4a-bca2-49ad-aa7c-f011424e0fe4",
-		},
+		}),
+	}, {
+		about:       "valid controller-uuid",
+		useDefaults: config.UseDefaults,
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
+			"controller-uuid": "dcfbdb4a-bca2-49ad-aa7c-f011424e0fe4",
+		}),
 	}, {
 		about:       "invalid uuid 1",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type": "my-type",
-			"name": "my-name",
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"uuid": "dcfbdb4abca249adaa7cf011424e0fe4",
-		},
-		err: `uuid: expected uuid, got string\("dcfbdb4abca249adaa7cf011424e0fe4"\)`,
+		}),
+		err: `uuid: expected UUID, got string\("dcfbdb4abca249adaa7cf011424e0fe4"\)`,
 	}, {
 		about:       "invalid uuid 2",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type": "my-type",
-			"name": "my-name",
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"uuid": "uuid",
-		},
-		err: `uuid: expected uuid, got string\("uuid"\)`,
+		}),
+		err: `uuid: expected UUID, got string\("uuid"\)`,
 	}, {
 		about:       "blank uuid",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type": "my-type",
-			"name": "my-name",
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"uuid": "",
-		},
+		}),
 		err: `empty uuid in model configuration`,
 	},
 	missingAttributeNoDefault("firewall-mode"),
@@ -928,88 +765,70 @@ var configTests = []configTest{
 	{
 		about:       "Deprecated safe-mode failover",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type":                     "my-type",
-			"name":                     "my-name",
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"provisioner-safe-mode":    true,
 			"provisioner-harvest-mode": config.HarvestNone.String(),
-		},
+		}),
 	},
 	{
 		about:       "Explicit apt-mirror",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type":       "my-type",
-			"name":       "my-name",
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"apt-mirror": "http://my.archive.ubuntu.com",
-		},
+		}),
 	},
 	{
 		about:       "Resource tags as space-separated string",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type":          "my-type",
-			"name":          "my-name",
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"resource-tags": strings.Join(testResourceTags, " "),
-		},
+		}),
 	},
 	{
 		about:       "Resource tags as list of strings",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type":          "my-type",
-			"name":          "my-name",
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"resource-tags": testResourceTags,
-		},
+		}),
 	},
 	{
 		about:       "Resource tags contains non-keyvalues",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type":          "my-type",
-			"name":          "my-name",
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"resource-tags": []string{"a"},
-		},
+		}),
 		err: `resource-tags: expected "key=value", got "a"`,
 	},
 	{
 		about:       "Invalid identity URL value",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type":         "my-type",
-			"name":         "my-name",
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"identity-url": "%",
-		},
+		}),
 		err: `invalid identity URL: parse %: invalid URL escape "%"`,
 	}, {
 		about:       "Not using https in identity URL",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type":         "my-type",
-			"name":         "my-name",
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"identity-url": "http://test-identity",
-		},
+		}),
 		err: `URL needs to be https`,
 	},
 	{
 		about:       "Invalid identity public key",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type":                "my-type",
-			"name":                "my-name",
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"identity-public-key": "_",
-		},
+		}),
 		err: `invalid identity public key: cannot decode base64 key: illegal base64 data at input byte 0`,
 	},
 	{
 		about:       "Valid identity URL and public key values",
 		useDefaults: config.UseDefaults,
-		attrs: testing.Attrs{
-			"type":                "my-type",
-			"name":                "my-name",
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"identity-url":        "https://test-identity",
 			"identity-public-key": "o/yOqSNWncMo1GURWuez/dGR30TscmmuIxgjztpoHEY=",
-		},
+		}),
 	},
 }
 
@@ -1055,6 +874,8 @@ var noCertFilesTests = []configTest{
 		attrs: testing.Attrs{
 			"type":            "my-type",
 			"name":            "my-name",
+			"uuid":            testing.ModelTag.Id(),
+			"controller-uuid": testing.ModelTag.Id(),
 			"authorized-keys": testing.FakeAuthKeys,
 		},
 	}, {
@@ -1063,6 +884,8 @@ var noCertFilesTests = []configTest{
 		attrs: testing.Attrs{
 			"type":            "my-type",
 			"name":            "my-name",
+			"uuid":            testing.ModelTag.Id(),
+			"controller-uuid": testing.ModelTag.Id(),
 			"authorized-keys": testing.FakeAuthKeys,
 			"ca-private-key":  caKey,
 		},
@@ -1084,6 +907,8 @@ var emptyCertFilesTests = []configTest{
 		attrs: testing.Attrs{
 			"type":            "my-type",
 			"name":            "my-name",
+			"uuid":            testing.ModelTag.Id(),
+			"controller-uuid": testing.ModelTag.Id(),
 			"authorized-keys": testing.FakeAuthKeys,
 			"ca-private-key":  caKey,
 		},
@@ -1094,6 +919,8 @@ var emptyCertFilesTests = []configTest{
 		attrs: testing.Attrs{
 			"type":            "my-type",
 			"name":            "my-name",
+			"uuid":            testing.ModelTag.Id(),
+			"controller-uuid": testing.ModelTag.Id(),
 			"authorized-keys": testing.FakeAuthKeys,
 		},
 		err: fmt.Sprintf(`file ".*%smy-name-cert.pem" is empty`, regexp.QuoteMeta(string(os.PathSeparator))),
@@ -1103,6 +930,8 @@ var emptyCertFilesTests = []configTest{
 		attrs: testing.Attrs{
 			"type":            "my-type",
 			"name":            "my-name",
+			"uuid":            testing.ModelTag.Id(),
+			"controller-uuid": testing.ModelTag.Id(),
 			"authorized-keys": testing.FakeAuthKeys,
 			"ca-cert":         caCert,
 		},
@@ -1149,6 +978,8 @@ func (s *ConfigSuite) TestNoDefinedPrivateCert(c *gc.C) {
 	attrs := testing.Attrs{
 		"type":            "my-type",
 		"name":            "my-name",
+		"uuid":            testing.ModelTag.Id(),
+		"controller-uuid": testing.ModelTag.Id(),
 		"authorized-keys": testing.FakeAuthKeys,
 		"ca-cert":         testing.CACert,
 		"ca-private-key":  "",
@@ -1163,6 +994,8 @@ func (s *ConfigSuite) TestSafeModeDeprecatesGracefully(c *gc.C) {
 	cfg, err := config.New(config.UseDefaults, testing.Attrs{
 		"name":                  "name",
 		"type":                  "type",
+		"uuid":                  testing.ModelTag.Id(),
+		"controller-uuid":       testing.ModelTag.Id(),
 		"provisioner-safe-mode": false,
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -1176,6 +1009,8 @@ func (s *ConfigSuite) TestSafeModeDeprecatesGracefully(c *gc.C) {
 	cfg, err = config.New(config.UseDefaults, testing.Attrs{
 		"name":                  "name",
 		"type":                  "type",
+		"uuid":                  testing.ModelTag.Id(),
+		"controller-uuid":       testing.ModelTag.Id(),
 		"provisioner-safe-mode": true,
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -1221,9 +1056,10 @@ func (test configTest) check(c *gc.C, home *gitjujutesting.FakeHome) {
 		c.Assert(cfg.APIPort(), gc.Equals, apiPort)
 	}
 	if expected, ok := test.attrs["uuid"]; ok {
-		got, exists := cfg.UUID()
-		c.Assert(exists, gc.Equals, ok)
-		c.Assert(got, gc.Equals, expected)
+		c.Assert(cfg.UUID(), gc.Equals, expected)
+	}
+	if expected, ok := test.attrs["controller-uuid"]; ok {
+		c.Assert(cfg.ControllerUUID(), gc.Equals, expected)
 	}
 	if identityURL, ok := test.attrs["identity-url"]; ok {
 		c.Assert(cfg.IdentityURL(), gc.Equals, identityURL)
@@ -1425,6 +1261,7 @@ func (s *ConfigSuite) TestConfigAttrs(c *gc.C) {
 		"type":                      "my-type",
 		"name":                      "my-name",
 		"uuid":                      "90168e4c-2f10-4e9c-83c2-1fb55a58e5a9",
+		"controller-uuid":           "90168e4c-2f10-4e9c-83c2-1fb55a58e5a9",
 		"authorized-keys":           testing.FakeAuthKeys,
 		"firewall-mode":             config.FwInstance,
 		"admin-secret":              "foo",
@@ -1466,14 +1303,16 @@ func (s *ConfigSuite) TestConfigAttrs(c *gc.C) {
 	c.Assert(cfg.ProvisionerHarvestMode(), gc.Equals, config.HarvestDestroyed)
 
 	newcfg, err := cfg.Apply(map[string]interface{}{
-		"name":        "new-name",
-		"uuid":        "6216dfc3-6e82-408f-9f74-8565e63e6158",
-		"new-unknown": "my-new-unknown",
+		"name":            "new-name",
+		"uuid":            "6216dfc3-6e82-408f-9f74-8565e63e6158",
+		"controller-uuid": "6216dfc3-6e82-408f-9f74-8565e63e6158",
+		"new-unknown":     "my-new-unknown",
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
 	attrs["name"] = "new-name"
 	attrs["uuid"] = "6216dfc3-6e82-408f-9f74-8565e63e6158"
+	attrs["controller-uuid"] = "6216dfc3-6e82-408f-9f74-8565e63e6158"
 	attrs["new-unknown"] = "my-new-unknown"
 	c.Assert(newcfg.AllAttrs(), jc.DeepEquals, attrs)
 }
@@ -1569,13 +1408,15 @@ var validationTests = []validationTest{{
 	new:   testing.Attrs{"prefer-ipv6": true},
 	err:   `cannot change prefer-ipv6 from false to true`,
 }, {
-	about: "Can change uuid from unset to set",
-	new:   testing.Attrs{"uuid": "dcfbdb4a-bca2-49ad-aa7c-f011424e0fe4"},
-}, {
 	about: "Cannot change uuid",
 	old:   testing.Attrs{"uuid": "90168e4c-2f10-4e9c-83c2-1fb55a58e5a9"},
 	new:   testing.Attrs{"uuid": "dcfbdb4a-bca2-49ad-aa7c-f011424e0fe4"},
 	err:   "cannot change uuid from \"90168e4c-2f10-4e9c-83c2-1fb55a58e5a9\" to \"dcfbdb4a-bca2-49ad-aa7c-f011424e0fe4\"",
+}, {
+	about: "Cannot change controller-uuid",
+	old:   testing.Attrs{"controller-uuid": "90168e4c-2f10-4e9c-83c2-1fb55a58e5a9"},
+	new:   testing.Attrs{"controller-uuid": "dcfbdb4a-bca2-49ad-aa7c-f011424e0fe4"},
+	err:   "cannot change controller-uuid from \"90168e4c-2f10-4e9c-83c2-1fb55a58e5a9\" to \"dcfbdb4a-bca2-49ad-aa7c-f011424e0fe4\"",
 }}
 
 func (s *ConfigSuite) TestValidateChange(c *gc.C) {
@@ -1608,10 +1449,12 @@ func (s *ConfigSuite) addJujuFiles(c *gc.C) {
 func (s *ConfigSuite) TestValidateUnknownAttrs(c *gc.C) {
 	s.addJujuFiles(c)
 	cfg, err := config.New(config.UseDefaults, map[string]interface{}{
-		"name":    "myenv",
-		"type":    "other",
-		"known":   "this",
-		"unknown": "that",
+		"name":            "myenv",
+		"type":            "other",
+		"uuid":            testing.ModelTag.Id(),
+		"controller-uuid": testing.ModelTag.Id(),
+		"known":           "this",
+		"unknown":         "that",
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -1673,8 +1516,10 @@ var emptyAttributeTests = []testAttr{
 func (s *ConfigSuite) TestValidateUnknownEmptyAttr(c *gc.C) {
 	s.addJujuFiles(c)
 	cfg, err := config.New(config.UseDefaults, map[string]interface{}{
-		"name": "myenv",
-		"type": "other",
+		"name":            "myenv",
+		"type":            "other",
+		"uuid":            testing.ModelTag.Id(),
+		"controller-uuid": testing.ModelTag.Id(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	warningTxt := `.* unknown config field %q.*`
@@ -1695,7 +1540,11 @@ func (s *ConfigSuite) TestValidateUnknownEmptyAttr(c *gc.C) {
 }
 
 func newTestConfig(c *gc.C, explicit testing.Attrs) *config.Config {
-	final := testing.Attrs{"type": "my-type", "name": "my-name"}
+	final := testing.Attrs{
+		"type": "my-type", "name": "my-name",
+		"uuid":            testing.ModelTag.Id(),
+		"controller-uuid": testing.ModelTag.Id(),
+	}
 	for key, value := range explicit {
 		final[key] = value
 	}
@@ -1906,30 +1755,38 @@ func (s *ConfigSuite) TestGenerateControllerCertAndKey(c *gc.C) {
 		errMatch     string
 	}{{
 		configValues: map[string]interface{}{
-			"name": "test-no-certs",
-			"type": "dummy",
+			"name":            "test-no-certs",
+			"type":            "dummy",
+			"uuid":            testing.ModelTag.Id(),
+			"controller-uuid": testing.ModelTag.Id(),
 		},
 		errMatch: "model configuration has no ca-cert",
 	}, {
 		configValues: map[string]interface{}{
-			"name":    "test-no-certs",
-			"type":    "dummy",
-			"ca-cert": testing.CACert,
+			"name":            "test-no-certs",
+			"type":            "dummy",
+			"uuid":            testing.ModelTag.Id(),
+			"controller-uuid": testing.ModelTag.Id(),
+			"ca-cert":         testing.CACert,
 		},
 		errMatch: "model configuration has no ca-private-key",
 	}, {
 		configValues: map[string]interface{}{
-			"name":           "test-no-certs",
-			"type":           "dummy",
-			"ca-cert":        testing.CACert,
-			"ca-private-key": testing.CAKey,
+			"name":            "test-no-certs",
+			"type":            "dummy",
+			"uuid":            testing.ModelTag.Id(),
+			"controller-uuid": testing.ModelTag.Id(),
+			"ca-cert":         testing.CACert,
+			"ca-private-key":  testing.CAKey,
 		},
 	}, {
 		configValues: map[string]interface{}{
-			"name":           "test-no-certs",
-			"type":           "dummy",
-			"ca-cert":        testing.CACert,
-			"ca-private-key": testing.CAKey,
+			"name":            "test-no-certs",
+			"type":            "dummy",
+			"uuid":            testing.ModelTag.Id(),
+			"controller-uuid": testing.ModelTag.Id(),
+			"ca-cert":         testing.CACert,
+			"ca-private-key":  testing.CAKey,
 		},
 		sanValues: []string{"10.0.0.1", "192.168.1.1"},
 	}} {

--- a/environs/jujutest/livetests.go
+++ b/environs/jujutest/livetests.go
@@ -188,7 +188,7 @@ func (t *LiveTests) BootstrapOnce(c *gc.C) {
 	}
 	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), t.Env, bootstrap.BootstrapParams{
 		BootstrapConstraints: cons,
-		EnvironConstraints:   cons,
+		ModelConstraints:     cons,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	t.bootstrapped = true

--- a/environs/utils.go
+++ b/environs/utils.go
@@ -89,11 +89,7 @@ func APIInfo(env Environ) (*api.Info, error) {
 	apiAddrs := network.HostPortsToStrings(
 		network.AddressesWithPort(addrs, apiPort),
 	)
-	uuid, uuidSet := config.UUID()
-	if !uuidSet {
-		return nil, errors.New("config has no UUID")
-	}
-	modelTag := names.NewModelTag(uuid)
+	modelTag := names.NewModelTag(config.UUID())
 	apiInfo := &api.Info{Addrs: apiAddrs, CACert: cert, ModelTag: modelTag}
 	return apiInfo, nil
 }

--- a/featuretests/api_undertaker_test.go
+++ b/featuretests/api_undertaker_test.go
@@ -167,9 +167,7 @@ func (s *undertakerSuite) TestHostedModelConfig(c *gc.C) {
 
 	cfg, err := undertakerClient.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
-	uuid, ok := cfg.UUID()
-	c.Assert(ok, jc.IsTrue)
-	c.Assert(uuid, gc.Equals, otherSt.ModelUUID())
+	c.Assert(cfg.UUID(), gc.Equals, otherSt.ModelUUID())
 }
 
 func (s *undertakerSuite) hostedAPI(c *gc.C) (*undertaker.Client, *state.State) {

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -387,11 +387,7 @@ func newState(environ environs.Environ, mongoInfo *mongo.MongoInfo) (*state.Stat
 	if password == "" {
 		return nil, fmt.Errorf("cannot connect without admin-secret")
 	}
-	modelUUID, ok := config.UUID()
-	if !ok {
-		return nil, fmt.Errorf("cannot connect without model UUID")
-	}
-	modelTag := names.NewModelTag(modelUUID)
+	modelTag := names.NewModelTag(config.UUID())
 
 	mongoInfo.Password = password
 	opts := mongo.DefaultDialOpts()

--- a/juju/testing/instance.go
+++ b/juju/testing/instance.go
@@ -205,8 +205,7 @@ func StartInstanceWithParams(
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	eUUID, _ := env.Config().UUID()
-	instanceConfig.Tags[tags.JujuModel] = eUUID
+	instanceConfig.Tags[tags.JujuModel] = env.Config().UUID()
 	params.Tools = possibleTools
 	params.InstanceConfig = instanceConfig
 	return env.StartInstance(params)

--- a/provider/azure/environ.go
+++ b/provider/azure/environ.go
@@ -1097,10 +1097,7 @@ func (env *azureEnviron) Provider() environs.EnvironProvider {
 
 // resourceGroupName returns the name of the environment's resource group.
 func resourceGroupName(cfg *config.Config) string {
-	uuid, _ := cfg.UUID()
-	// UUID is always available for azure environments, since the (new)
-	// provider was introduced after environment UUIDs.
-	modelTag := names.NewModelTag(uuid)
+	modelTag := names.NewModelTag(cfg.UUID())
 	return fmt.Sprintf(
 		"juju-%s-%s", cfg.Name(),
 		resourceName(modelTag),

--- a/provider/cloudsigma/client.go
+++ b/provider/cloudsigma/client.go
@@ -30,11 +30,7 @@ func (tracer) Logf(format string, args ...interface{}) {
 
 // newClient returns an instance of the CloudSigma client.
 var newClient = func(cfg *environConfig) (client *environClient, err error) {
-	uuid, ok := cfg.UUID()
-	if !ok {
-		return nil, errors.New("Environ uuid must not be empty")
-	}
-
+	uuid := cfg.UUID()
 	logger.Debugf("creating CloudSigma client: id=%q", uuid)
 
 	// create connection to CloudSigma

--- a/provider/common/bootstrap.go
+++ b/provider/common/bootstrap.go
@@ -103,7 +103,7 @@ func BootstrapInstance(ctx environs.BootstrapContext, env environs.Environ, args
 		return nil, "", nil, err
 	}
 	instanceConfig, err := instancecfg.NewBootstrapInstanceConfig(
-		args.BootstrapConstraints, args.EnvironConstraints, selectedSeries, publicKey,
+		args.BootstrapConstraints, args.ModelConstraints, selectedSeries, publicKey,
 	)
 	if err != nil {
 		return nil, "", nil, err

--- a/provider/common/bootstrap_test.go
+++ b/provider/common/bootstrap_test.go
@@ -65,6 +65,7 @@ func minimalConfig(c *gc.C) *config.Config {
 		"name":            "whatever",
 		"type":            "anything, really",
 		"uuid":            coretesting.ModelTag.Id(),
+		"controller-uuid": coretesting.ModelTag.Id(),
 		"ca-cert":         coretesting.CACert,
 		"ca-private-key":  coretesting.CAKey,
 		"authorized-keys": coretesting.FakeAuthKeys,
@@ -119,7 +120,7 @@ func (s *BootstrapSuite) TestCannotStartInstance(c *gc.C) {
 	ctx := envtesting.BootstrapContext(c)
 	_, err := common.Bootstrap(ctx, env, environs.BootstrapParams{
 		BootstrapConstraints: checkCons,
-		EnvironConstraints:   checkCons,
+		ModelConstraints:     checkCons,
 		Placement:            checkPlacement,
 		AvailableTools: tools.List{
 			&tools.Tools{

--- a/provider/common/util.go
+++ b/provider/common/util.go
@@ -16,7 +16,7 @@ import (
 // benefits users by helping them quickly identify in their hosting
 // management tools which instances are juju related.
 func EnvFullName(env environs.Environ) string {
-	modelUUID, _ := env.Config().UUID() // Env should have validated this.
+	modelUUID := env.Config().UUID()
 	return fmt.Sprintf("juju-%s", modelUUID)
 }
 

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -78,6 +78,7 @@ func SampleConfig() testing.Attrs {
 		"type":                      "dummy",
 		"name":                      "only",
 		"uuid":                      testing.ModelTag.Id(),
+		"controller-uuid":           testing.ModelTag.Id(),
 		"authorized-keys":           testing.FakeAuthKeys,
 		"firewall-mode":             config.FwInstance,
 		"admin-secret":              testing.DefaultMongoPassword,
@@ -735,7 +736,7 @@ func (e *environ) Bootstrap(ctx environs.BootstrapContext, args environs.Bootstr
 		if err != nil {
 			panic(err)
 		}
-		if err := st.SetModelConstraints(args.EnvironConstraints); err != nil {
+		if err := st.SetModelConstraints(args.ModelConstraints); err != nil {
 			panic(err)
 		}
 		if err := st.SetAdminMongoPassword(password); err != nil {

--- a/provider/ec2/ebs.go
+++ b/provider/ec2/ebs.go
@@ -216,14 +216,10 @@ func (e *ebsProvider) VolumeSource(environConfig *config.Config, cfg *storage.Co
 	if err != nil {
 		return nil, errors.Annotate(err, "creating AWS clients")
 	}
-	uuid, ok := environConfig.UUID()
-	if !ok {
-		return nil, errors.NotFoundf("model UUID")
-	}
 	source := &ebsVolumeSource{
 		ec2:       ec2,
 		envName:   environConfig.Name(),
-		modelUUID: uuid,
+		modelUUID: environConfig.UUID(),
 	}
 	return source, nil
 }

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -646,8 +646,7 @@ func (e *environ) StartInstance(args environs.StartInstanceParams) (_ *environs.
 
 	// Tag the machine's root EBS volume, if it has one.
 	if inst.Instance.RootDeviceType == "ebs" {
-		uuid, _ := cfg.UUID()
-		tags := tags.ResourceTags(names.NewModelTag(uuid), cfg)
+		tags := tags.ResourceTags(names.NewModelTag(cfg.UUID()), cfg)
 		tags[tagName] = instanceName + "-root"
 		if err := tagRootDisk(e.ec2(), tags, inst.Instance); err != nil {
 			return nil, errors.Annotate(err, "tagging root disk")
@@ -1185,10 +1184,7 @@ func (e *environ) AllInstances() ([]instance.Instance, error) {
 	if err != nil {
 		return nil, err
 	}
-	eUUID, ok := e.Config().UUID()
-	if !ok {
-		return nil, errors.NotFoundf("enviroment UUID in configuration")
-	}
+	eUUID := e.Config().UUID()
 	var insts []instance.Instance
 	for _, r := range resp.Reservations {
 		for i := range r.Instances {
@@ -1450,10 +1446,7 @@ func (e *environ) terminateInstances(ids []instance.Id) error {
 }
 
 func (e *environ) uuid() string {
-	// the bool component of uuid is for legacy compatibility
-	// and does not apply in this context.
-	eUUID, _ := e.Config().UUID()
-	return eUUID
+	return e.Config().UUID()
 }
 
 func (e *environ) globalGroupName() string {

--- a/provider/gce/disks.go
+++ b/provider/gce/disks.go
@@ -56,11 +56,6 @@ type volumeSource struct {
 }
 
 func (g *storageProvider) VolumeSource(environConfig *config.Config, cfg *storage.Config) (storage.VolumeSource, error) {
-	uuid, ok := environConfig.UUID()
-	if !ok {
-		return nil, errors.NotFoundf("model UUID")
-	}
-
 	// Connect and authenticate.
 	env, err := newEnviron(environConfig)
 	if err != nil {
@@ -70,7 +65,7 @@ func (g *storageProvider) VolumeSource(environConfig *config.Config, cfg *storag
 	source := &volumeSource{
 		gce:       env.gce,
 		envName:   environConfig.Name(),
-		modelUUID: uuid,
+		modelUUID: environConfig.UUID(),
 	}
 	return source, nil
 }

--- a/provider/gce/environ.go
+++ b/provider/gce/environ.go
@@ -74,11 +74,6 @@ func newEnviron(cfg *config.Config) (*environ, error) {
 		return nil, errors.Annotate(err, "invalid config")
 	}
 
-	uuid, ok := ecfg.UUID()
-	if !ok {
-		return nil, errors.New("UUID not set")
-	}
-
 	// Connect and authenticate.
 	conn, err := newConnection(ecfg)
 	if err != nil {
@@ -87,7 +82,7 @@ func newEnviron(cfg *config.Config) (*environ, error) {
 
 	env := &environ{
 		name: ecfg.Name(),
-		uuid: uuid,
+		uuid: ecfg.UUID(),
 		ecfg: ecfg,
 		gce:  conn,
 	}

--- a/provider/gce/environ_broker.go
+++ b/provider/gce/environ_broker.go
@@ -168,13 +168,9 @@ func (env *environ) newRawInstance(args environs.StartInstanceParams, spec *inst
 		machineID,
 	}
 
-	cfg := env.Config()
-	eUUID, ok := cfg.UUID()
-	if !ok {
-		return nil, errors.NotFoundf("UUID necessary to create the instance disk")
-	}
-
-	disks, err := getDisks(spec, args.Constraints, args.InstanceConfig.Series, eUUID)
+	disks, err := getDisks(
+		spec, args.Constraints, args.InstanceConfig.Series, env.Config().UUID(),
+	)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/provider/gce/environ_network_test.go
+++ b/provider/gce/environ_network_test.go
@@ -17,7 +17,7 @@ type environNetSuite struct {
 var _ = gc.Suite(&environNetSuite{})
 
 func (s *environNetSuite) TestGlobalFirewallName(c *gc.C) {
-	uuid, _ := s.Config.UUID()
+	uuid := s.Config.UUID()
 	fwname := gce.GlobalFirewallName(s.Env)
 
 	c.Check(fwname, gc.Equals, "juju-"+uuid)

--- a/provider/gce/testing_test.go
+++ b/provider/gce/testing_test.go
@@ -166,8 +166,7 @@ func (s *BaseSuiteUnpatched) initInst(c *gc.C) {
 	s.InstanceType = allInstanceTypes[0]
 
 	// Storage
-	eUUID, ok := s.Env.Config().UUID()
-	c.Check(ok, jc.IsTrue)
+	eUUID := s.Env.Config().UUID()
 	s.BaseDisk = &google.Disk{
 		Id:          1234567,
 		Name:        "home-zone--c930380d-8337-4bf5-b07a-9dbb5ae771e4",
@@ -191,7 +190,7 @@ func (s *BaseSuiteUnpatched) setConfig(c *gc.C, cfg *config.Config) {
 	ecfg, err := newValidConfig(cfg, configDefaults)
 	c.Assert(err, jc.ErrorIsNil)
 	s.EnvConfig = ecfg
-	uuid, _ := cfg.UUID()
+	uuid := cfg.UUID()
 	s.Env.uuid = uuid
 	s.Env.ecfg = s.EnvConfig
 	s.Prefix = "juju-" + uuid + "-"

--- a/provider/lxd/environ.go
+++ b/provider/lxd/environ.go
@@ -63,14 +63,9 @@ func newEnviron(cfg *config.Config, newRawProvider newRawProviderFunc) (*environ
 }
 
 func newEnvironRaw(ecfg *environConfig, raw *rawProvider) (*environ, error) {
-	uuid, ok := ecfg.UUID()
-	if !ok {
-		return nil, errors.New("UUID not set")
-	}
-
 	env := &environ{
 		name: ecfg.Name(),
-		uuid: uuid,
+		uuid: ecfg.UUID(),
 		ecfg: ecfg,
 		raw:  raw,
 	}

--- a/provider/lxd/environ_network_test.go
+++ b/provider/lxd/environ_network_test.go
@@ -20,7 +20,7 @@ type environNetSuite struct {
 var _ = gc.Suite(&environNetSuite{})
 
 func (s *environNetSuite) TestGlobalFirewallName(c *gc.C) {
-	uuid, _ := s.Config.UUID()
+	uuid := s.Config.UUID()
 	fwname := lxd.GlobalFirewallName(s.Env)
 
 	c.Check(fwname, gc.Equals, "juju-"+uuid)

--- a/provider/lxd/testing_test.go
+++ b/provider/lxd/testing_test.go
@@ -206,7 +206,7 @@ func (s *BaseSuiteUnpatched) setConfig(c *gc.C, cfg *config.Config) {
 	ecfg, err := newValidConfig(cfg, configDefaults)
 	c.Assert(err, jc.ErrorIsNil)
 	s.EnvConfig = ecfg
-	uuid, _ := cfg.UUID()
+	uuid := cfg.UUID()
 	s.Env.uuid = uuid
 	s.Env.ecfg = s.EnvConfig
 	s.Prefix = "juju-" + uuid + "-"

--- a/provider/manual/config_test.go
+++ b/provider/manual/config_test.go
@@ -22,10 +22,12 @@ var _ = gc.Suite(&configSuite{})
 
 func MinimalConfigValues() map[string]interface{} {
 	return map[string]interface{}{
-		"name":           "test",
-		"type":           "manual",
-		"bootstrap-host": "hostname",
-		"bootstrap-user": "",
+		"name":            "test",
+		"type":            "manual",
+		"uuid":            coretesting.ModelTag.Id(),
+		"controller-uuid": coretesting.ModelTag.Id(),
+		"bootstrap-host":  "hostname",
+		"bootstrap-user":  "",
 		// Not strictly necessary, but simplifies testing by disabling
 		// ssh storage by default.
 		"use-sshstorage": false,

--- a/provider/openstack/cinder.go
+++ b/provider/openstack/cinder.go
@@ -53,14 +53,10 @@ func (p *cinderProvider) VolumeSource(environConfig *config.Config, providerConf
 	if err != nil {
 		return nil, err
 	}
-	uuid, ok := environConfig.UUID()
-	if !ok {
-		return nil, errors.NotFoundf("model UUID")
-	}
 	source := &cinderVolumeSource{
 		storageAdapter: storageAdapter,
 		envName:        environConfig.Name(),
-		modelUUID:      uuid,
+		modelUUID:      environConfig.UUID(),
 	}
 	return source, nil
 }

--- a/provider/openstack/firewaller.go
+++ b/provider/openstack/firewaller.go
@@ -431,6 +431,5 @@ func (c *defaultFirewaller) machineGroupName(machineId string) string {
 
 func (c *defaultFirewaller) jujuGroupName() string {
 	cfg := c.environ.Config()
-	eUUID, _ := cfg.UUID()
-	return fmt.Sprintf("juju-%s", eUUID)
+	return fmt.Sprintf("juju-%s", cfg.UUID())
 }

--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -531,7 +531,7 @@ func (s *localServerSuite) TestStopInstance(c *gc.C) {
 	// Openstack now has three security groups for the server, the default
 	// group, one group for the entire environment, and another for the
 	// new instance.
-	eUUID, _ := env.Config().UUID()
+	eUUID := env.Config().UUID()
 	assertSecurityGroups(c, env, []string{"default", fmt.Sprintf("juju-%v", eUUID), fmt.Sprintf("juju-%v-%v", eUUID, instanceName)})
 	err = env.StopInstances(inst.Id())
 	c.Assert(err, jc.ErrorIsNil)
@@ -561,7 +561,7 @@ func (s *localServerSuite) TestStopInstanceSecurityGroupNotDeleted(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	instanceName := "100"
 	inst, _ := testing.AssertStartInstance(c, env, instanceName)
-	eUUID, _ := env.Config().UUID()
+	eUUID := env.Config().UUID()
 	allSecurityGroups := []string{"default", fmt.Sprintf("juju-%v", eUUID), fmt.Sprintf("juju-%v-%v", eUUID, instanceName)}
 	assertSecurityGroups(c, env, allSecurityGroups)
 	err = env.StopInstances(inst.Id())
@@ -577,7 +577,7 @@ func (s *localServerSuite) TestDestroyEnvironmentDeletesSecurityGroupsFWModeInst
 	c.Assert(err, jc.ErrorIsNil)
 	instanceName := "100"
 	testing.AssertStartInstance(c, env, instanceName)
-	eUUID, _ := env.Config().UUID()
+	eUUID := env.Config().UUID()
 	allSecurityGroups := []string{"default", fmt.Sprintf("juju-%v", eUUID), fmt.Sprintf("juju-%v-%v", eUUID, instanceName)}
 	assertSecurityGroups(c, env, allSecurityGroups)
 	err = env.Destroy()
@@ -593,7 +593,7 @@ func (s *localServerSuite) TestDestroyEnvironmentDeletesSecurityGroupsFWModeGlob
 	c.Assert(err, jc.ErrorIsNil)
 	instanceName := "100"
 	testing.AssertStartInstance(c, env, instanceName)
-	eUUID, _ := env.Config().UUID()
+	eUUID := env.Config().UUID()
 	allSecurityGroups := []string{"default", fmt.Sprintf("juju-%v", eUUID), fmt.Sprintf("juju-%v-global", eUUID)}
 	assertSecurityGroups(c, env, allSecurityGroups)
 	err = env.Destroy()

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -898,13 +898,9 @@ func (e *Environ) StartInstance(args environs.StartInstanceParams) (*environs.St
 	for _, g := range groups {
 		groupNames = append(groupNames, nova.SecurityGroupName{g.Name})
 	}
-	eUUID, ok := e.Config().UUID()
-	if !ok {
-		return nil, errors.NotFoundf("UUID in environ config")
-	}
 	machineName := resourceName(
 		names.NewMachineTag(args.InstanceConfig.MachineId),
-		eUUID,
+		e.Config().UUID(),
 	)
 
 	var server *nova.Entity
@@ -1112,10 +1108,7 @@ func (e *Environ) AllInstances() (insts []instance.Instance, err error) {
 	}
 	instsById := make(map[string]instance.Instance)
 	cfg := e.Config()
-	eUUID, ok := cfg.UUID()
-	if !ok {
-		return nil, errors.NotFoundf("model UUID")
-	}
+	eUUID := cfg.UUID()
 	for _, server := range servers {
 		modelUUID, ok := server.Metadata[tags.JujuModel]
 		if !ok || modelUUID != eUUID {
@@ -1155,7 +1148,7 @@ func resourceName(tag names.Tag, envName string) string {
 // machinesFilter returns a nova.Filter matching all machines in the environment.
 func (e *Environ) machinesFilter() *nova.Filter {
 	filter := nova.NewFilter()
-	eUUID, _ := e.Config().UUID()
+	eUUID := e.Config().UUID()
 	filter.Set(nova.FilterServer, fmt.Sprintf("juju-%s-machine-\\d*", eUUID))
 	return filter
 }

--- a/provider/openstack/upgrade.go
+++ b/provider/openstack/upgrade.go
@@ -47,10 +47,7 @@ func addUUIDToSecurityGroupNames(e *Environ) error {
 	}
 	cfg := e.Config()
 	eName := cfg.Name()
-	eUUID, ok := cfg.UUID()
-	if !ok {
-		return errors.NotFoundf("model uuid for model %q", eName)
-	}
+	eUUID := cfg.UUID()
 	for _, group := range groups {
 		newName, ok, err := replaceNameWithID(group.Name, eName, eUUID)
 		if err != nil {
@@ -85,10 +82,7 @@ func addUUIDToMachineNames(e *Environ) error {
 	}
 	cfg := e.Config()
 	eName := cfg.Name()
-	eUUID, ok := cfg.UUID()
-	if !ok {
-		return errors.NotFoundf("model uuid for model %q", eName)
-	}
+	eUUID := cfg.UUID()
 	for _, server := range servers {
 		newName, ok, err := replaceNameWithID(server.Name, eName, eUUID)
 		if err != nil {

--- a/provider/rackspace/environ_test.go
+++ b/provider/rackspace/environ_test.go
@@ -59,6 +59,8 @@ func (s *environSuite) TestStartInstance(c *gc.C) {
 	config, err := config.New(config.UseDefaults, map[string]interface{}{
 		"name":            "some-name",
 		"type":            "some-type",
+		"uuid":            testing.ModelTag.Id(),
+		"controller-uuid": testing.ModelTag.Id(),
 		"authorized-keys": "key",
 	})
 	c.Assert(err, gc.IsNil)

--- a/provider/rackspace/provider_test.go
+++ b/provider/rackspace/provider_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/provider/rackspace"
+	"github.com/juju/juju/testing"
 )
 
 type providerSuite struct {
@@ -29,6 +30,8 @@ func (s *providerSuite) TestValidate(c *gc.C) {
 	cfg, err := config.New(config.UseDefaults, map[string]interface{}{
 		"name":            "some-name",
 		"type":            "some-type",
+		"uuid":            testing.ModelTag.Id(),
+		"controller-uuid": testing.ModelTag.Id(),
 		"authorized-keys": "key",
 	})
 	c.Check(err, gc.IsNil)

--- a/state/initialize_test.go
+++ b/state/initialize_test.go
@@ -61,7 +61,7 @@ func (s *InitializeSuite) TearDownTest(c *gc.C) {
 
 func (s *InitializeSuite) TestInitialize(c *gc.C) {
 	cfg := testing.ModelConfig(c)
-	uuid, _ := cfg.UUID()
+	uuid := cfg.UUID()
 	initial := cfg.AllAttrs()
 	owner := names.NewLocalUserTag("initialize-admin")
 	st, err := state.Initialize(owner, statetesting.NewMongoInfo(), cfg, statetesting.NewDialOpts(), nil)

--- a/state/model.go
+++ b/state/model.go
@@ -135,10 +135,7 @@ func (st *State) NewModel(cfg *config.Config, owner names.UserTag) (_ *Model, _ 
 		return nil, nil, errors.Annotate(err, "could not load controller model")
 	}
 
-	uuid, ok := cfg.UUID()
-	if !ok {
-		return nil, nil, errors.Errorf("model uuid was not supplied")
-	}
+	uuid := cfg.UUID()
 	newState, err := st.ForModel(names.NewModelTag(uuid))
 	if err != nil {
 		return nil, nil, errors.Annotate(err, "could not create state for new model")

--- a/state/model_test.go
+++ b/state/model_test.go
@@ -184,9 +184,7 @@ func (s *ModelSuite) TestConfigForControllerEnv(c *gc.C) {
 	conf, err := env.Config()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(conf.Name(), gc.Equals, "testenv")
-	uuid, ok := conf.UUID()
-	c.Assert(ok, jc.IsTrue)
-	c.Assert(uuid, gc.Equals, s.modelTag.Id())
+	c.Assert(conf.UUID(), gc.Equals, s.modelTag.Id())
 }
 
 func (s *ModelSuite) TestConfigForOtherEnv(c *gc.C) {
@@ -204,9 +202,7 @@ func (s *ModelSuite) TestConfigForOtherEnv(c *gc.C) {
 	conf, err := env.Config()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(conf.Name(), gc.Equals, "other")
-	uuid, ok := conf.UUID()
-	c.Assert(ok, jc.IsTrue)
-	c.Assert(uuid, gc.Equals, otherEnv.UUID())
+	c.Assert(conf.UUID(), gc.Equals, otherEnv.UUID())
 }
 
 // createTestEnvConfig returns a new model config and its UUID for testing.
@@ -224,9 +220,7 @@ func (s *ModelSuite) TestModelConfigSameEnvAsState(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	cfg, err := env.Config()
 	c.Assert(err, jc.ErrorIsNil)
-	uuid, exists := cfg.UUID()
-	c.Assert(exists, jc.IsTrue)
-	c.Assert(uuid, gc.Equals, s.State.ModelUUID())
+	c.Assert(cfg.UUID(), gc.Equals, s.State.ModelUUID())
 }
 
 func (s *ModelSuite) TestModelConfigDifferentEnvThanState(c *gc.C) {
@@ -236,8 +230,7 @@ func (s *ModelSuite) TestModelConfigDifferentEnvThanState(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	cfg, err := env.Config()
 	c.Assert(err, jc.ErrorIsNil)
-	uuid, exists := cfg.UUID()
-	c.Assert(exists, jc.IsTrue)
+	uuid := cfg.UUID()
 	c.Assert(uuid, gc.Equals, env.UUID())
 	c.Assert(uuid, gc.Not(gc.Equals), s.State.ModelUUID())
 }

--- a/state/open.go
+++ b/state/open.go
@@ -104,10 +104,7 @@ func mongodbLogin(session *mgo.Session, mongoInfo *mongo.MongoInfo) error {
 // This needs to be performed only once for the initial controller model.
 // It returns unauthorizedError if access is unauthorized.
 func Initialize(owner names.UserTag, info *mongo.MongoInfo, cfg *config.Config, opts mongo.DialOpts, policy Policy) (_ *State, err error) {
-	uuid, ok := cfg.UUID()
-	if !ok {
-		return nil, errors.Errorf("model uuid was not supplied")
-	}
+	uuid := cfg.UUID()
 	modelTag := names.NewModelTag(uuid)
 	st, err := open(modelTag, info, opts, policy)
 	if err != nil {

--- a/state/state.go
+++ b/state/state.go
@@ -600,13 +600,13 @@ func (st *State) UpdateModelConfig(updateAttrs map[string]interface{}, removeAtt
 	return errors.Trace(err)
 }
 
-// EnvironConstraints returns the current model constraints.
+// ModelConstraints returns the current model constraints.
 func (st *State) ModelConstraints() (constraints.Value, error) {
 	cons, err := readConstraints(st, modelGlobalKey)
 	return cons, errors.Trace(err)
 }
 
-// SetEnvironConstraints replaces the current model constraints.
+// SetModelConstraints replaces the current model constraints.
 func (st *State) SetModelConstraints(cons constraints.Value) error {
 	unsupported, err := st.validateConstraints(cons)
 	if len(unsupported) > 0 {

--- a/testing/environ.go
+++ b/testing/environ.go
@@ -45,6 +45,7 @@ func FakeConfig() Attrs {
 		"type":                      "someprovider",
 		"name":                      "testenv",
 		"uuid":                      ModelTag.Id(),
+		"controller-uuid":           ModelTag.Id(),
 		"authorized-keys":           FakeAuthKeys,
 		"firewall-mode":             config.FwInstance,
 		"admin-secret":              "fish",

--- a/worker/undertaker/undertaker_test.go
+++ b/worker/undertaker/undertaker_test.go
@@ -261,8 +261,7 @@ func assertNoMoreCalls(c *gc.C, client *mockClient) {
 
 func dummyCfgAndUUID(c *gc.C) (*config.Config, string) {
 	cfg := testingEnvConfig(c)
-	uuid, ok := cfg.UUID()
-	c.Assert(ok, jc.IsTrue)
+	uuid := cfg.UUID()
 	return cfg, uuid
 }
 


### PR DESCRIPTION
Propose axw's work with a typo fixed.

When bootstrapping, we now create a hosted model in addition to the controller model. The hosted model is called "default" unless the name is specified when bootstrapping using the --default-model option.

(Review request: http://reviews.vapour.ws/r/3994/)