### PR TITLE
Show current model in list-models; various renames

### DIFF
--- a/cmd/juju/controller/createmodel.go
+++ b/cmd/juju/controller/createmodel.go
@@ -27,7 +27,7 @@ func NewCreateModelCommand() cmd.Command {
 // createModelCommand calls the API to create a new model.
 type createModelCommand struct {
 	modelcmd.ControllerCommandBase
-	api CreateEnvironmentAPI
+	api CreateModelAPI
 
 	Name         string
 	Owner        string
@@ -36,7 +36,7 @@ type createModelCommand struct {
 	configParser func(interface{}) (interface{}, error)
 }
 
-const createEnvHelpDoc = `
+const createModelHelpDoc = `
 This command will create another model within the current Juju
 Controller. The provider has to match, and the model config must
 specify all the required configuration values for the provider. In the cases
@@ -61,7 +61,7 @@ func (c *createModelCommand) Info() *cmd.Info {
 		Name:    "create-model",
 		Args:    "<name> [key=[value] ...]",
 		Purpose: "create an model within the Juju Model Server",
-		Doc:     strings.TrimSpace(createEnvHelpDoc),
+		Doc:     strings.TrimSpace(createModelHelpDoc),
 	}
 }
 
@@ -93,13 +93,13 @@ func (c *createModelCommand) Init(args []string) error {
 	return nil
 }
 
-type CreateEnvironmentAPI interface {
+type CreateModelAPI interface {
 	Close() error
 	ConfigSkeleton(provider, region string) (params.ModelConfig, error)
 	CreateModel(owner string, account, config map[string]interface{}) (params.Model, error)
 }
 
-func (c *createModelCommand) getAPI() (CreateEnvironmentAPI, error) {
+func (c *createModelCommand) getAPI() (CreateModelAPI, error) {
 	if c.api != nil {
 		return c.api, nil
 	}

--- a/cmd/juju/controller/createmodel_test.go
+++ b/cmd/juju/controller/createmodel_test.go
@@ -300,7 +300,7 @@ type fakeCreateClient struct {
 	env     params.Model
 }
 
-var _ controller.CreateEnvironmentAPI = (*fakeCreateClient)(nil)
+var _ controller.CreateModelAPI = (*fakeCreateClient)(nil)
 
 func (*fakeCreateClient) Close() error {
 	return nil

--- a/cmd/juju/controller/destroy.go
+++ b/cmd/juju/controller/destroy.go
@@ -44,7 +44,7 @@ func NewDestroyCommand() cmd.Command {
 // destroyCommand destroys the specified controller.
 type destroyCommand struct {
 	destroyCommandBase
-	destroyEnvs bool
+	destroyModels bool
 }
 
 var destroyDoc = `Destroys the specified controller`
@@ -59,9 +59,9 @@ Continue [y/N]? `[1:]
 type destroyControllerAPI interface {
 	Close() error
 	ModelConfig() (map[string]interface{}, error)
-	DestroyController(destroyEnvs bool) error
+	DestroyController(destroyModels bool) error
 	ListBlockedModels() ([]params.ModelBlockInfo, error)
-	ModelStatus(envs ...names.ModelTag) ([]base.ModelStatus, error)
+	ModelStatus(models ...names.ModelTag) ([]base.ModelStatus, error)
 	AllModels() ([]base.UserModel, error)
 }
 
@@ -85,7 +85,7 @@ func (c *destroyCommand) Info() *cmd.Info {
 
 // SetFlags implements Command.SetFlags.
 func (c *destroyCommand) SetFlags(f *gnuflag.FlagSet) {
-	f.BoolVar(&c.destroyEnvs, "destroy-all-models", false, "destroy all hosted models in the controller")
+	f.BoolVar(&c.destroyModels, "destroy-all-models", false, "destroy all hosted models in the controller")
 	c.destroyCommandBase.SetFlags(f)
 }
 
@@ -128,32 +128,32 @@ func (c *destroyCommand) Run(ctx *cmd.Context) error {
 	if err != nil {
 		return errors.Annotate(err, "cannot read controller info")
 	}
-	controllerEnviron, err := c.getControllerEnviron(cfgInfo, api)
+	controllerModel, err := c.getControllerModel(cfgInfo, api)
 	if err != nil {
 		return errors.Annotate(err, "cannot obtain bootstrap information")
 	}
 
 	// Attempt to destroy the controller.
-	err = api.DestroyController(c.destroyEnvs)
+	err = api.DestroyController(c.destroyModels)
 	if err != nil {
 		return c.ensureUserFriendlyErrorLog(errors.Annotate(err, "cannot destroy controller"), ctx, api)
 	}
 
 	ctx.Infof("Destroying controller %q", c.ControllerName())
-	if c.destroyEnvs {
+	if c.destroyModels {
 		ctx.Infof("Waiting for hosted model resources to be reclaimed.")
 
 		updateStatus := newTimedStatusUpdater(ctx, api, controllerDetails.ControllerUUID)
-		for ctrStatus, envsStatus := updateStatus(0); hasUnDeadEnvirons(envsStatus); ctrStatus, envsStatus = updateStatus(2 * time.Second) {
+		for ctrStatus, modelsStatus := updateStatus(0); hasUnDeadModels(modelsStatus); ctrStatus, modelsStatus = updateStatus(2 * time.Second) {
 			ctx.Infof(fmtCtrStatus(ctrStatus))
-			for _, envStatus := range envsStatus {
-				ctx.Verbosef(fmtEnvStatus(envStatus))
+			for _, model := range modelsStatus {
+				ctx.Verbosef(fmtModelStatus(model))
 			}
 		}
 
 		ctx.Infof("All hosted models reclaimed, cleaning up controller machines")
 	}
-	return environs.Destroy(c.ControllerName(), controllerEnviron, legacyStore, store)
+	return environs.Destroy(c.ControllerName(), controllerModel, legacyStore, store)
 }
 
 // ensureUserFriendlyErrorLog ensures that error will be logged and displayed
@@ -170,10 +170,10 @@ To remove all blocks in the controller, please run:
 
 `)
 		if api != nil {
-			envs, err := api.ListBlockedModels()
+			models, err := api.ListBlockedModels()
 			var bytes []byte
 			if err == nil {
-				bytes, err = formatTabularBlockedEnvironments(envs)
+				bytes, err = formatTabularBlockedModels(models)
 			}
 
 			if err != nil {
@@ -199,10 +199,10 @@ your model provider console for any resources that need
 to be cleaned up.
 `
 
-func formatTabularBlockedEnvironments(value interface{}) ([]byte, error) {
-	envs, ok := value.([]params.ModelBlockInfo)
+func formatTabularBlockedModels(value interface{}) ([]byte, error) {
+	models, ok := value.([]params.ModelBlockInfo)
 	if !ok {
-		return nil, errors.Errorf("expected value of type %T, got %T", envs, value)
+		return nil, errors.Errorf("expected value of type %T, got %T", models, value)
 	}
 
 	var out bytes.Buffer
@@ -216,8 +216,8 @@ func formatTabularBlockedEnvironments(value interface{}) ([]byte, error) {
 	)
 	tw := tabwriter.NewWriter(&out, minwidth, tabwidth, padding, padchar, flags)
 	fmt.Fprintf(tw, "NAME\tMODEL UUID\tOWNER\tBLOCKS\n")
-	for _, env := range envs {
-		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", env.Name, env.UUID, env.OwnerTag, blocksToStr(env.Blocks))
+	for _, model := range models {
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", model.Name, model.UUID, model.OwnerTag, blocksToStr(model.Blocks))
 	}
 	tw.Flush()
 	return out.Bytes(), nil
@@ -287,10 +287,10 @@ func (c *destroyCommandBase) Init(args []string) error {
 	}
 }
 
-// getControllerEnviron gets the bootstrap information required to destroy the
-// environment by first checking the config store, then querying the API if
+// getControllerModel gets the bootstrap information required to destroy the
+// model by first checking the config store, then querying the API if
 // the information is not in the store.
-func (c *destroyCommandBase) getControllerEnviron(info configstore.EnvironInfo, sysAPI destroyControllerAPI) (_ environs.Environ, err error) {
+func (c *destroyCommandBase) getControllerModel(info configstore.EnvironInfo, sysAPI destroyControllerAPI) (_ environs.Environ, err error) {
 	bootstrapCfg := info.BootstrapConfig()
 	if bootstrapCfg == nil {
 		if sysAPI == nil {

--- a/cmd/juju/controller/export_test.go
+++ b/cmd/juju/controller/export_test.go
@@ -35,7 +35,7 @@ type CreateModelCommand struct {
 // NewCreateModelCommandForTest returns a CreateModelCommand with
 // the api provided as specified.
 func NewCreateModelCommandForTest(
-	api CreateEnvironmentAPI,
+	api CreateModelAPI,
 	store jujuclient.ClientStore,
 	parser func(interface{}) (interface{}, error),
 ) (cmd.Command, *CreateModelCommand) {
@@ -47,10 +47,10 @@ func NewCreateModelCommandForTest(
 	return modelcmd.WrapController(c), &CreateModelCommand{c}
 }
 
-// NewModelsCommandForTest returns a EnvironmentsCommand with the API
+// NewModelsCommandForTest returns a ModelsCommand with the API
 // and userCreds provided as specified.
 func NewModelsCommandForTest(modelAPI ModelManagerAPI, sysAPI ModelsSysAPI, store jujuclient.ClientStore) cmd.Command {
-	c := &environmentsCommand{
+	c := &modelsCommand{
 		modelAPI: modelAPI,
 		sysAPI:   sysAPI,
 	}
@@ -130,16 +130,16 @@ func NewListBlocksCommandForTest(api listBlocksAPI, apierr error, store jujuclie
 }
 
 type CtrData ctrData
-type EnvData envData
+type ModelData modelData
 
 func FmtCtrStatus(data CtrData) string {
 	return fmtCtrStatus(ctrData(data))
 }
 
-func FmtEnvStatus(data EnvData) string {
-	return fmtEnvStatus(envData(data))
+func FmtModelStatus(data ModelData) string {
+	return fmtModelStatus(modelData(data))
 }
 
-func NewData(api destroyControllerAPI, ctrUUID string) (ctrData, []envData, error) {
+func NewData(api destroyControllerAPI, ctrUUID string) (ctrData, []modelData, error) {
 	return newData(api, ctrUUID)
 }

--- a/cmd/juju/controller/kill.go
+++ b/cmd/juju/controller/kill.go
@@ -127,7 +127,7 @@ func (c *killCommand) Run(ctx *cmd.Context) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	controllerEnviron, err := c.getControllerEnviron(cfgInfo, api)
+	controllerEnviron, err := c.getControllerModel(cfgInfo, api)
 	if err != nil {
 		return errors.Annotate(err, "cannot obtain bootstrap information")
 	}
@@ -149,10 +149,10 @@ func (c *killCommand) Run(ctx *cmd.Context) error {
 	ctx.Infof("Destroying controller %q\nWaiting for resources to be reclaimed", controllerName)
 
 	updateStatus := newTimedStatusUpdater(ctx, api, controllerDetails.ControllerUUID)
-	for ctrStatus, envsStatus := updateStatus(0); hasUnDeadEnvirons(envsStatus); ctrStatus, envsStatus = updateStatus(2 * time.Second) {
+	for ctrStatus, envsStatus := updateStatus(0); hasUnDeadModels(envsStatus); ctrStatus, envsStatus = updateStatus(2 * time.Second) {
 		ctx.Infof(fmtCtrStatus(ctrStatus))
 		for _, envStatus := range envsStatus {
-			ctx.Verbosef(fmtEnvStatus(envStatus))
+			ctx.Verbosef(fmtModelStatus(envStatus))
 		}
 	}
 

--- a/cmd/juju/controller/kill_test.go
+++ b/cmd/juju/controller/kill_test.go
@@ -196,7 +196,7 @@ func (s *KillSuite) TestControllerStatus(c *gc.C) {
 
 	ctrStatus, envsStatus, err := controller.NewData(s.api, "123")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(ctrStatus.HostedEnvCount, gc.Equals, 2)
+	c.Assert(ctrStatus.HostedModelCount, gc.Equals, 2)
 	c.Assert(ctrStatus.HostedMachineCount, gc.Equals, 6)
 	c.Assert(ctrStatus.ServiceCount, gc.Equals, 3)
 	c.Assert(envsStatus, gc.HasLen, 2)
@@ -242,7 +242,7 @@ func (s *KillSuite) TestFmtControllerStatus(c *gc.C) {
 }
 
 func (s *KillSuite) TestFmtEnvironStatus(c *gc.C) {
-	data := controller.EnvData{
+	data := controller.ModelData{
 		"owner@local",
 		"envname",
 		params.Dying,
@@ -250,6 +250,6 @@ func (s *KillSuite) TestFmtEnvironStatus(c *gc.C) {
 		1,
 	}
 
-	out := controller.FmtEnvStatus(data)
+	out := controller.FmtModelStatus(data)
 	c.Assert(out, gc.Equals, "owner@local/envname (dying), 8 machines, 1 service")
 }

--- a/cmd/juju/controller/listblocks.go
+++ b/cmd/juju/controller/listblocks.go
@@ -48,7 +48,7 @@ func (c *listBlocksCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.out.AddFlags(f, "tabular", map[string]cmd.Formatter{
 		"yaml":    cmd.FormatYaml,
 		"json":    cmd.FormatJson,
-		"tabular": formatTabularBlockedEnvironments,
+		"tabular": formatTabularBlockedModels,
 	})
 }
 

--- a/cmd/juju/controller/listmodels.go
+++ b/cmd/juju/controller/listmodels.go
@@ -18,12 +18,12 @@ import (
 	"github.com/juju/juju/cmd/modelcmd"
 )
 
-// NewModelsCommand returns a command to list environments.
+// NewModelsCommand returns a command to list models.
 func NewModelsCommand() cmd.Command {
 	return modelcmd.WrapController(&modelsCommand{})
 }
 
-// environmentsCommand returns the list of all the environments the
+// modelsCommand returns the list of all the models the
 // current user can access on the current controller.
 type modelsCommand struct {
 	modelcmd.ControllerCommandBase
@@ -36,7 +36,7 @@ type modelsCommand struct {
 	sysAPI    ModelsSysAPI
 }
 
-var envsDoc = `
+var modelsDoc = `
 List all the models the user can access on the current controller.
 
 The models listed here are either models you have created
@@ -68,11 +68,11 @@ func (c *modelsCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "list-models",
 		Purpose: "list all models the user can access on the current controller",
-		Doc:     envsDoc,
+		Doc:     modelsDoc,
 	}
 }
 
-func (c *modelsCommand) getEnvAPI() (ModelManagerAPI, error) {
+func (c *modelsCommand) getModelManagerAPI() (ModelManagerAPI, error) {
 	if c.modelAPI != nil {
 		return c.modelAPI, nil
 	}
@@ -168,7 +168,7 @@ func (c *modelsCommand) getAllModels() ([]base.UserModel, error) {
 }
 
 func (c *modelsCommand) getUserModels() ([]base.UserModel, error) {
-	client, err := c.getEnvAPI()
+	client, err := c.getModelManagerAPI()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/cmd/juju/controller/listmodels.go
+++ b/cmd/juju/controller/listmodels.go
@@ -20,12 +20,12 @@ import (
 
 // NewModelsCommand returns a command to list environments.
 func NewModelsCommand() cmd.Command {
-	return modelcmd.WrapController(&environmentsCommand{})
+	return modelcmd.WrapController(&modelsCommand{})
 }
 
 // environmentsCommand returns the list of all the environments the
 // current user can access on the current controller.
-type environmentsCommand struct {
+type modelsCommand struct {
 	modelcmd.ControllerCommandBase
 	out       cmd.Output
 	all       bool
@@ -64,7 +64,7 @@ type ModelsSysAPI interface {
 }
 
 // Info implements Command.Info
-func (c *environmentsCommand) Info() *cmd.Info {
+func (c *modelsCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "list-models",
 		Purpose: "list all models the user can access on the current controller",
@@ -72,14 +72,14 @@ func (c *environmentsCommand) Info() *cmd.Info {
 	}
 }
 
-func (c *environmentsCommand) getEnvAPI() (ModelManagerAPI, error) {
+func (c *modelsCommand) getEnvAPI() (ModelManagerAPI, error) {
 	if c.modelAPI != nil {
 		return c.modelAPI, nil
 	}
 	return c.NewModelManagerAPIClient()
 }
 
-func (c *environmentsCommand) getSysAPI() (ModelsSysAPI, error) {
+func (c *modelsCommand) getSysAPI() (ModelsSysAPI, error) {
 	if c.sysAPI != nil {
 		return c.sysAPI, nil
 	}
@@ -87,7 +87,7 @@ func (c *environmentsCommand) getSysAPI() (ModelsSysAPI, error) {
 }
 
 // SetFlags implements Command.SetFlags.
-func (c *environmentsCommand) SetFlags(f *gnuflag.FlagSet) {
+func (c *modelsCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.StringVar(&c.user, "user", "", "the user to list models for (administrative users only)")
 	f.BoolVar(&c.all, "all", false, "show all models  (administrative users only)")
 	f.BoolVar(&c.listUUID, "uuid", false, "display UUID for models")
@@ -99,6 +99,13 @@ func (c *environmentsCommand) SetFlags(f *gnuflag.FlagSet) {
 	})
 }
 
+// ModelSet contains the set of models known to the client,
+// and UUID of the current model.
+type ModelSet struct {
+	Models       []UserModel `yaml:"models" json:"models"`
+	CurrentModel string      `yaml:"current-model,omitempty" json:"current-model,omitempty"`
+}
+
 // Local structure that controls the output structure.
 type UserModel struct {
 	Name           string `json:"name"`
@@ -108,7 +115,7 @@ type UserModel struct {
 }
 
 // Run implements Command.Run
-func (c *environmentsCommand) Run(ctx *cmd.Context) error {
+func (c *modelsCommand) Run(ctx *cmd.Context) error {
 	if c.user == "" {
 		accountDetails, err := c.ClientStore().AccountByName(
 			c.ControllerName(), c.AccountName(),
@@ -119,32 +126,39 @@ func (c *environmentsCommand) Run(ctx *cmd.Context) error {
 		c.user = accountDetails.User
 	}
 
-	var envs []base.UserModel
+	var models []base.UserModel
 	var err error
 	if c.all {
-		envs, err = c.getAllModels()
+		models, err = c.getAllModels()
 	} else {
-		envs, err = c.getUserModels()
+		models, err = c.getUserModels()
 	}
 	if err != nil {
 		return errors.Annotate(err, "cannot list models")
 	}
 
-	output := make([]UserModel, len(envs))
+	modelDetails := make([]UserModel, len(models))
 	now := time.Now()
-	for i, env := range envs {
-		output[i] = UserModel{
-			Name:           env.Name,
-			UUID:           env.UUID,
-			Owner:          env.Owner,
-			LastConnection: user.LastConnection(env.LastConnection, now, c.exactTime),
+	for i, model := range models {
+		modelDetails[i] = UserModel{
+			Name:           model.Name,
+			UUID:           model.UUID,
+			Owner:          model.Owner,
+			LastConnection: user.LastConnection(model.LastConnection, now, c.exactTime),
 		}
 	}
-
-	return c.out.Write(ctx, output)
+	modelSet := ModelSet{
+		Models: modelDetails,
+	}
+	current, err := c.ClientStore().CurrentModel(c.ControllerName(), c.AccountName())
+	if err != nil && !errors.IsNotFound(err) {
+		return err
+	}
+	modelSet.CurrentModel = current
+	return c.out.Write(ctx, modelSet)
 }
 
-func (c *environmentsCommand) getAllModels() ([]base.UserModel, error) {
+func (c *modelsCommand) getAllModels() ([]base.UserModel, error) {
 	client, err := c.getSysAPI()
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -153,7 +167,7 @@ func (c *environmentsCommand) getAllModels() ([]base.UserModel, error) {
 	return client.AllModels()
 }
 
-func (c *environmentsCommand) getUserModels() ([]base.UserModel, error) {
+func (c *modelsCommand) getUserModels() ([]base.UserModel, error) {
 	client, err := c.getEnvAPI()
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -163,10 +177,10 @@ func (c *environmentsCommand) getUserModels() ([]base.UserModel, error) {
 }
 
 // formatTabular takes an interface{} to adhere to the cmd.Formatter interface
-func (c *environmentsCommand) formatTabular(value interface{}) ([]byte, error) {
-	envs, ok := value.([]UserModel)
+func (c *modelsCommand) formatTabular(value interface{}) ([]byte, error) {
+	modelSet, ok := value.(ModelSet)
 	if !ok {
-		return nil, errors.Errorf("expected value of type %T, got %T", envs, value)
+		return nil, errors.Errorf("expected value of type %T, got %T", modelSet, value)
 	}
 	var out bytes.Buffer
 	const (
@@ -183,12 +197,16 @@ func (c *environmentsCommand) formatTabular(value interface{}) ([]byte, error) {
 		fmt.Fprintf(tw, "\tMODEL UUID")
 	}
 	fmt.Fprintf(tw, "\tOWNER\tLAST CONNECTION\n")
-	for _, env := range envs {
-		fmt.Fprintf(tw, "%s", env.Name)
-		if c.listUUID {
-			fmt.Fprintf(tw, "\t%s", env.UUID)
+	for _, model := range modelSet.Models {
+		name := model.Name
+		if name == modelSet.CurrentModel {
+			name += "*"
 		}
-		fmt.Fprintf(tw, "\t%s\t%s\n", env.Owner, env.LastConnection)
+		fmt.Fprintf(tw, "%s", name)
+		if c.listUUID {
+			fmt.Fprintf(tw, "\t%s", model.UUID)
+		}
+		fmt.Fprintf(tw, "\t%s\t%s\n", model.Owner, model.LastConnection)
 	}
 	tw.Flush()
 	return out.Bytes(), nil

--- a/cmd/juju/controller/listmodels_test.go
+++ b/cmd/juju/controller/listmodels_test.go
@@ -86,6 +86,13 @@ func (s *ModelsSuite) SetUpTest(c *gc.C) {
 	s.api = &fakeModelMgrAPIClient{models: models}
 	s.store = jujuclienttesting.NewMemStore()
 	s.store.Controllers["fake"] = jujuclient.ControllerDetails{}
+	s.store.Models["fake"] = jujuclient.ControllerAccountModels{
+		AccountModels: map[string]*jujuclient.AccountModels{
+			"admin@local": {
+				CurrentModel: "test-model1",
+			},
+		},
+	}
 	s.store.Accounts["fake"] = &jujuclient.ControllerAccounts{
 		Accounts: map[string]jujuclient.AccountDetails{
 			"admin@local": {
@@ -106,10 +113,10 @@ func (s *ModelsSuite) checkSuccess(c *gc.C, user string, args ...string) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.api.user, gc.Equals, user)
 	c.Assert(testing.Stdout(context), gc.Equals, ""+
-		"NAME         OWNER             LAST CONNECTION\n"+
-		"test-model1  user-admin@local  2015-03-20\n"+
-		"test-model2  user-admin@local  2015-03-01\n"+
-		"test-model3  user-admin@local  never connected\n"+
+		"NAME          OWNER             LAST CONNECTION\n"+
+		"test-model1*  user-admin@local  2015-03-20\n"+
+		"test-model2   user-admin@local  2015-03-01\n"+
+		"test-model3   user-admin@local  never connected\n"+
 		"\n")
 }
 
@@ -123,10 +130,10 @@ func (s *ModelsSuite) TestAllModels(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.api.all, jc.IsTrue)
 	c.Assert(testing.Stdout(context), gc.Equals, ""+
-		"NAME         OWNER             LAST CONNECTION\n"+
-		"test-model1  user-admin@local  2015-03-20\n"+
-		"test-model2  user-admin@local  2015-03-01\n"+
-		"test-model3  user-admin@local  never connected\n"+
+		"NAME          OWNER             LAST CONNECTION\n"+
+		"test-model1*  user-admin@local  2015-03-20\n"+
+		"test-model2   user-admin@local  2015-03-01\n"+
+		"test-model3   user-admin@local  never connected\n"+
 		"\n")
 }
 
@@ -135,10 +142,10 @@ func (s *ModelsSuite) TestModelsUUID(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.api.user, gc.Equals, "admin@local")
 	c.Assert(testing.Stdout(context), gc.Equals, ""+
-		"NAME         MODEL UUID        OWNER             LAST CONNECTION\n"+
-		"test-model1  test-model1-UUID  user-admin@local  2015-03-20\n"+
-		"test-model2  test-model2-UUID  user-admin@local  2015-03-01\n"+
-		"test-model3  test-model3-UUID  user-admin@local  never connected\n"+
+		"NAME          MODEL UUID        OWNER             LAST CONNECTION\n"+
+		"test-model1*  test-model1-UUID  user-admin@local  2015-03-20\n"+
+		"test-model2   test-model2-UUID  user-admin@local  2015-03-01\n"+
+		"test-model3   test-model3-UUID  user-admin@local  never connected\n"+
 		"\n")
 }
 

--- a/cmd/juju/controller/listmodels_test.go
+++ b/cmd/juju/controller/listmodels_test.go
@@ -137,6 +137,18 @@ func (s *ModelsSuite) TestAllModels(c *gc.C) {
 		"\n")
 }
 
+func (s *ModelsSuite) TestAllModelsNoneCurrent(c *gc.C) {
+	delete(s.store.Models, "fake")
+	context, err := testing.RunCommand(c, s.newCommand())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(testing.Stdout(context), gc.Equals, ""+
+		"NAME         OWNER             LAST CONNECTION\n"+
+		"test-model1  user-admin@local  2015-03-20\n"+
+		"test-model2  user-admin@local  2015-03-01\n"+
+		"test-model3  user-admin@local  never connected\n"+
+		"\n")
+}
+
 func (s *ModelsSuite) TestModelsUUID(c *gc.C) {
 	context, err := testing.RunCommand(c, s.newCommand(), "--uuid")
 	c.Assert(err, jc.ErrorIsNil)

--- a/featuretests/cmd_juju_controller_test.go
+++ b/featuretests/cmd_juju_controller_test.go
@@ -64,7 +64,7 @@ func (s *cmdControllerSuite) TestControllerModelsCommand(c *gc.C) {
 	context := s.run(c, "list-models")
 	c.Assert(testing.Stdout(context), gc.Equals, ""+
 		"NAME       OWNER        LAST CONNECTION\n"+
-		"admin      admin@local  just now\n"+
+		"admin*     admin@local  just now\n"+
 		"new-model  admin@local  never connected\n"+
 		"\n")
 }


### PR DESCRIPTION
The main purpose here is to indicate the current model when the user runs juju list-models. Implementation is as per list-controllers.

As a driveby, rename some legacy environment apis and vars to model.

(Review request: http://reviews.vapour.ws/r/3999/)