### PR TITLE
Fix space discovery to use name not provider id

### DIFF
--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -1080,7 +1080,8 @@ func (env *environ) Spaces() ([]network.SpaceInfo, error) {
 		return []network.SpaceInfo{}, err
 	}
 	return []network.SpaceInfo{{
-		ProviderId: network.Id("foo"),
+		Name:       "foo",
+		ProviderId: network.Id("0"),
 		Subnets: []network.SubnetInfo{{
 			ProviderId:        network.Id("1"),
 			AvailabilityZones: []string{"zone1"},
@@ -1088,17 +1089,20 @@ func (env *environ) Spaces() ([]network.SpaceInfo, error) {
 			ProviderId:        network.Id("2"),
 			AvailabilityZones: []string{"zone1"},
 		}}}, {
-		ProviderId: network.Id("Another Foo 99!"),
+		Name:       "Another Foo 99!",
+		ProviderId: "1",
 		Subnets: []network.SubnetInfo{{
 			ProviderId:        network.Id("3"),
 			AvailabilityZones: []string{"zone1"},
 		}}}, {
-		ProviderId: network.Id("foo-"),
+		Name:       "foo-",
+		ProviderId: "2",
 		Subnets: []network.SubnetInfo{{
 			ProviderId:        network.Id("4"),
 			AvailabilityZones: []string{"zone1"},
 		}}}, {
-		ProviderId: network.Id("---"),
+		Name:       "---",
+		ProviderId: "3",
 		Subnets: []network.SubnetInfo{{
 			ProviderId:        network.Id("5"),
 			AvailabilityZones: []string{"zone1"},

--- a/worker/discoverspaces/discoverspaces.go
+++ b/worker/discoverspaces/discoverspaces.go
@@ -177,7 +177,7 @@ func (dw *discoverspacesWorker) handleSubnets(env environs.NetworkingEnviron) er
 		} else {
 			// The space is new, we need to create a valid name for it
 			// in state.
-			spaceName := string(space.ProviderId)
+			spaceName := string(space.Name)
 			// Convert the name into a valid name that isn't already in
 			// use.
 			spaceName = convertSpaceName(spaceName, spaceNames)

--- a/worker/discoverspaces/worker_test.go
+++ b/worker/discoverspaces/worker_test.go
@@ -169,7 +169,7 @@ func (s *workerSuite) TestWorkerDiscoversSpaces(c *gc.C) {
 	c.Assert(spaces, gc.HasLen, 4)
 	expectedSpaces := []network.SpaceInfo{{
 		Name:       "foo",
-		ProviderId: network.Id("foo"),
+		ProviderId: network.Id("0"),
 		Subnets: []network.SubnetInfo{{
 			ProviderId:        network.Id("1"),
 			CIDR:              "192.168.1.0/24",
@@ -180,21 +180,21 @@ func (s *workerSuite) TestWorkerDiscoversSpaces(c *gc.C) {
 			AvailabilityZones: []string{"zone1"},
 		}}}, {
 		Name:       "another-foo-99",
-		ProviderId: network.Id("Another Foo 99!"),
+		ProviderId: network.Id("1"),
 		Subnets: []network.SubnetInfo{{
 			ProviderId:        network.Id("3"),
 			CIDR:              "192.168.3.0/24",
 			AvailabilityZones: []string{"zone1"},
 		}}}, {
 		Name:       "foo-2",
-		ProviderId: network.Id("foo-"),
+		ProviderId: network.Id("2"),
 		Subnets: []network.SubnetInfo{{
 			ProviderId:        network.Id("4"),
 			CIDR:              "192.168.4.0/24",
 			AvailabilityZones: []string{"zone1"},
 		}}}, {
 		Name:       "empty",
-		ProviderId: network.Id("---"),
+		ProviderId: network.Id("3"),
 		Subnets: []network.SubnetInfo{{
 			ProviderId:        network.Id("5"),
 			CIDR:              "192.168.5.0/24",
@@ -296,7 +296,7 @@ func (s *workerSuite) TestWorkerIgnoresExistingSpacesAndSubnets(c *gc.C) {
 		Spaces: []params.CreateSpaceParams{{
 			Public:     false,
 			SpaceTag:   spaceTag.String(),
-			ProviderId: "foo",
+			ProviderId: "0",
 		}}}
 	result, err := s.API.CreateSpaces(args)
 	c.Assert(err, jc.ErrorIsNil)
@@ -325,7 +325,7 @@ func (s *workerSuite) TestWorkerIgnoresExistingSpacesAndSubnets(c *gc.C) {
 			break
 		}
 		if !a.HasNext() {
-			c.Fatalf("spaces not imported")
+			c.Fatalf("spaces not imported, found %v", spaces)
 		}
 	}
 	c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
The maas provider now uses the real maas provider id for space provider id, so space discovery needs to get the name from the space name instead of the provider id.

(Review request: http://reviews.vapour.ws/r/4000/)