### PR TITLE
lxd: skip tests if binary wasn't built with LXD support

### DIFF
--- a/container/factory/factory_test.go
+++ b/container/factory/factory_test.go
@@ -44,7 +44,7 @@ func (*factorySuite) TestNewContainerManager(c *gc.C) {
 		valid:         false,
 	}} {
 		/* LXD isn't available in go 1.2 */
-		if lxd.HasLXDSupport() {
+		if !lxd.HasLXDSupport() {
 			continue
 		}
 

--- a/container/factory/factory_test.go
+++ b/container/factory/factory_test.go
@@ -44,7 +44,7 @@ func (*factorySuite) TestNewContainerManager(c *gc.C) {
 		valid:         false,
 	}} {
 		/* LXD isn't available in go 1.2 */
-		if !lxd.HasLXDSupport() {
+		if test.ContainerType == instance.LXD && !lxd.HasLXDSupport() {
 			continue
 		}
 

--- a/container/factory/factory_test.go
+++ b/container/factory/factory_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/juju/juju/container"
 	"github.com/juju/juju/container/factory"
+	"github.com/juju/juju/container/lxd"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/testing"
 )
@@ -43,7 +44,7 @@ func (*factorySuite) TestNewContainerManager(c *gc.C) {
 		valid:         false,
 	}} {
 		/* LXD isn't available in go 1.2 */
-		if test.containerType == instance.LXD && strings.HasPrefix(runtime.Version(), "go1.2") {
+		if lxd.HasLXDSupport() {
 			continue
 		}
 

--- a/container/lxd/lxd.go
+++ b/container/lxd/lxd.go
@@ -170,3 +170,9 @@ func (manager *containerManager) IsInitialized() bool {
 	manager.client, err = ConnectLocal(manager.name)
 	return err == nil
 }
+
+// HasLXDSupport returns false when this juju binary was not built with LXD
+// support (i.e. it was built on a golang version < 1.2
+func HasLXDSupport() bool {
+	return true
+}

--- a/container/lxd/lxd_go12.go
+++ b/container/lxd/lxd_go12.go
@@ -33,3 +33,7 @@ func NewContainerInitialiser(series string) container.Initialiser {
 	 */
 	return nil
 }
+
+func HasLXDSupport() bool {
+	return false
+}


### PR DESCRIPTION
It seems like the juju tests are built and run on two different go
versions? If so, this is probably the right way to fix lp1545046.

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>

(Review request: http://reviews.vapour.ws/r/4003/)