### PR TITLE
upload resource metadata for non-included store charms during upgrade-charm

### DIFF
--- a/cmd/juju/service/export_test.go
+++ b/cmd/juju/service/export_test.go
@@ -4,6 +4,8 @@
 package service
 
 import (
+	"net/http"
+
 	"github.com/juju/cmd"
 
 	"github.com/juju/juju/cmd/modelcmd"
@@ -27,5 +29,18 @@ func NewGetCommandForTest(api getServiceAPI) cmd.Command {
 func NewAddUnitCommandForTest(api serviceAddUnitAPI) cmd.Command {
 	return modelcmd.Wrap(&addUnitCommand{
 		api: api,
+	})
+}
+
+type Patcher interface {
+	PatchValue(dest, value interface{})
+}
+
+func PatchNewCharmStoreClient(s Patcher, url string) {
+	original := newCharmStoreClient
+	s.PatchValue(&newCharmStoreClient, func(httpClient *http.Client) *csClient {
+		csclient := original(httpClient)
+		csclient.params.URL = url
+		return csclient
 	})
 }

--- a/cmd/juju/service/upgradecharm.go
+++ b/cmd/juju/service/upgradecharm.go
@@ -248,8 +248,8 @@ func (c *upgradeCharmCommand) upgradeResources(client *api.Client, cURL *charm.U
 		}
 	}
 
-	// Note: the validity of resources to be uploaded will be checked further
-	// down the stack.
+	// Note: the validity of user-supplied resources to be uploaded will be
+	// checked further down the stack.
 	return handleResources(c, c.Resources, c.ServiceName, metaRes)
 }
 

--- a/cmd/juju/service/upgradecharm.go
+++ b/cmd/juju/service/upgradecharm.go
@@ -235,6 +235,8 @@ func (c *upgradeCharmCommand) upgradeResources(client *api.Client, cURL *charm.U
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+	// ListResources guarantees a number of values returned == number of
+	// services passed in.
 	currentResources := svcs[0].Resources
 	current := make(map[string]resource.Resource, len(currentResources))
 	for _, res := range currentResources {

--- a/cmd/juju/service/upgradecharm.go
+++ b/cmd/juju/service/upgradecharm.go
@@ -215,6 +215,9 @@ func (c *upgradeCharmCommand) Run(ctx *cmd.Context) error {
 	return block.ProcessBlockedError(serviceClient.SetCharm(cfg), block.BlockChange)
 }
 
+// upgradeResources pushes metadata up to the server for each resource defined
+// in the new charm's metadata and returns a map of resource names to pending
+// IDs to include in the upgrage-charm call.
 func (c *upgradeCharmCommand) upgradeResources(client *api.Client, cURL *charm.URL) (map[string]string, error) {
 	charmInfo, err := client.CharmInfo(cURL.String())
 	if err != nil {
@@ -237,7 +240,7 @@ func (c *upgradeCharmCommand) upgradeResources(client *api.Client, cURL *charm.U
 		current[res.Name] = res
 	}
 
-	var metaRes map[string]charmresource.Meta
+	metaRes := make(map[string]charmresource.Meta, len(charmInfo.Meta.Resources))
 	for name, res := range charmInfo.Meta.Resources {
 		if shouldUploadMeta(res, c.Resources, current) {
 			metaRes[name] = res

--- a/cmd/juju/service/upgradecharm.go
+++ b/cmd/juju/service/upgradecharm.go
@@ -219,6 +219,7 @@ func (c *upgradeCharmCommand) Run(ctx *cmd.Context) error {
 // in the new charm's metadata and returns a map of resource names to pending
 // IDs to include in the upgrage-charm call.
 func (c *upgradeCharmCommand) upgradeResources(client *api.Client, cURL *charm.URL) (map[string]string, error) {
+	// this gets the charm info that was added to the controller using addcharm.
 	charmInfo, err := client.CharmInfo(cURL.String())
 	if err != nil {
 		return nil, err
@@ -247,13 +248,15 @@ func (c *upgradeCharmCommand) upgradeResources(client *api.Client, cURL *charm.U
 		}
 	}
 
+	// Note: the validity of resources to be uploaded will be checked further
+	// down the stack.
 	return handleResources(c, c.Resources, c.ServiceName, metaRes)
 }
 
 // shouldUploadMeta reports whether we should upload the metadata for the given
 // resource.  This is always true for resources we're adding with the --resource
 // flag. For resources we're not adding with --resource, we only upload metadata
-// for charmstore resources.  previously uploaded resources stay pinned to the
+// for charmstore resources.  Previously uploaded resources stay pinned to the
 // data the user uploaded.
 func shouldUploadMeta(res charmresource.Meta, uploads map[string]string, current map[string]resource.Resource) bool {
 	// Always upload metadata for resources the user is uploading during
@@ -263,8 +266,7 @@ func shouldUploadMeta(res charmresource.Meta, uploads map[string]string, current
 	}
 	cur, ok := current[res.Name]
 	if !ok {
-		// This should be impossible, but regardless, if there's no information
-		// on the server, there should be.
+		// If there's no information on the server, there should be.
 		return true
 	}
 	// Never override existing resources a user has already uploaded.

--- a/cmd/juju/service/upgradecharm_resources_test.go
+++ b/cmd/juju/service/upgradecharm_resources_test.go
@@ -69,6 +69,9 @@ func (s *UpgradeCharmResourceSuite) TestUpgradeWithResources(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	data := []byte("some-data")
+	fp, err := charmresource.GenerateFingerprint(bytes.NewReader(data))
+	c.Assert(err, jc.ErrorIsNil)
+
 	resourceFile := path.Join(c.MkDir(), "data.lib")
 	err = ioutil.WriteFile(resourceFile, data, 0644)
 	c.Assert(err, jc.ErrorIsNil)
@@ -83,21 +86,18 @@ func (s *UpgradeCharmResourceSuite) TestUpgradeWithResources(c *gc.C) {
 	sr, err := resources.ListResources("riak")
 	c.Assert(err, jc.ErrorIsNil)
 
-	c.Assert(sr.Resources, gc.HasLen, 1)
+	c.Check(sr.Resources, gc.HasLen, 1)
 
-	c.Assert(sr.Resources[0].ServiceID, gc.Equals, "riak")
+	c.Check(sr.Resources[0].ServiceID, gc.Equals, "riak")
 
 	// Most of this is just a sanity check... this is all tested elsewhere.
-	c.Assert(sr.Resources[0].PendingID, gc.Equals, "")
-	c.Assert(sr.Resources[0].Username, gc.Not(gc.Equals), "")
-	c.Assert(sr.Resources[0].ID, gc.Not(gc.Equals), "")
-	c.Assert(sr.Resources[0].Timestamp.IsZero(), jc.IsFalse)
-
-	fp, err := charmresource.GenerateFingerprint(bytes.NewReader(data))
-	c.Assert(err, jc.ErrorIsNil)
+	c.Check(sr.Resources[0].PendingID, gc.Equals, "")
+	c.Check(sr.Resources[0].Username, gc.Not(gc.Equals), "")
+	c.Check(sr.Resources[0].ID, gc.Not(gc.Equals), "")
+	c.Check(sr.Resources[0].Timestamp.IsZero(), jc.IsFalse)
 
 	// Ensure we get the data we passed in from the metadata.yaml.
-	c.Assert(sr.Resources[0].Resource, gc.DeepEquals, charmresource.Resource{
+	c.Check(sr.Resources[0].Resource, gc.DeepEquals, charmresource.Resource{
 		Meta: charmresource.Meta{
 			Name:        "data",
 			Type:        charmresource.TypeFile,

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -32,10 +32,10 @@ github.com/juju/ratelimit	git	aa5bb718d4d435629821789cb90970319f57bfe5	2015-03-3
 github.com/juju/replicaset	git	fb7294cf57a1e2f08a57691f1246d129a87ab7e8	2015-05-08T02:21:43Z
 github.com/juju/retry	git	62c62032529169c7ec02fa48f93349604c345e1f	2015-10-29T02:48:21Z
 github.com/juju/romulus	git	90860c5f2f755a1d36f4382112a78d8cd65ffae4	2016-02-24T20:19:24Z
-github.com/juju/schema	git	47d9b102199f4c67e5bfb28eb07bbe39411754fe	2016-01-19T21:19:26Z
+github.com/juju/schema	git	1e25943f8c6fd6815282d6f1ac87091d21e14e19	2016-03-01T11:16:46Z
 github.com/juju/testing	git	321edad6b2d1ccac4af9ee05c25b8ad734d40546	2016-02-01T15:50:06Z
 github.com/juju/txn	git	99ec629d0066a4d73c54d8e021a7fc1dc07df614	2015-06-09T16:58:27Z
-github.com/juju/utils	git	6a56fe5cf0ae360cb6bf19f287289eaf9e28aea9	2015-12-11T00:56:23Z
+github.com/juju/utils	git	0cac78a34dd1c42d2f2dc718c345fd13e3a264fc	2016-01-29T15:50:19Z
 github.com/juju/xml	git	eb759a627588d35166bc505fceb51b88500e291e	2015-04-13T13:11:21Z
 github.com/julienschmidt/httprouter	git	109e267447e95ad1bb48b758e40dd7453eb7b039	2015-09-05T17:25:33Z
 github.com/lxc/lxd	git	e471e1b8d18d1477f5c421e5de3ba2cfa0684290	2016-02-18T03:41:21Z
@@ -53,8 +53,8 @@ gopkg.in/errgo.v1	git	66cb46252b94c1f3d65646f54ee8043ab38d766c	2015-10-07T15:31:
 gopkg.in/goose.v1	git	33121bddecedb2c9f9053c5c84ee729c379ab5ac	2015-11-13T22:25:24Z
 gopkg.in/inconshreveable/log15.v2	git	b105bd37f74e5d9dc7b6ad7806715c7a2b83fd3f	2015-09-21T21:38:54Z
 gopkg.in/ini.v1	git	776aa739ce9373377cd16f526cdf06cb4c89b40f	2016-02-22T23:24:41Z
-gopkg.in/juju/charm.v6-unstable	git	a53382ef6e1940abf20f1150bd203d0d57ac1a44	2016-02-09T19:49:50Z
 gopkg.in/juju/blobstore.v2	git	51fa6e26128d74e445c72d3a91af555151cc3654	2016-01-25T02:37:03Z
+gopkg.in/juju/charm.v6-unstable	git	4ad4f4ba39affe67785e385c1f49e7ec4206896f	2016-03-09T11:06:06Z
 gopkg.in/juju/charmrepo.v2-unstable	git	b17697d8bb60cdac7d8ffd61e1357c9977cc2096	2015-11-30T13:55:09Z
 gopkg.in/juju/charmstore.v5-unstable	git	c727ba087ec577cd0f9d0eca475279992e7a626f	2015-12-16T15:38:24Z
 gopkg.in/juju/environschema.v1	git	7bea6a9a531586600a7741e9bdd5e3c978ffda15	2015-10-20T16:12:31Z

--- a/state/resources_mongo.go
+++ b/state/resources_mongo.go
@@ -189,10 +189,20 @@ func newResolvePendingResourceOps(pending storedResource, exists bool) []txn.Op 
 		Assert: txn.DocExists,
 		Remove: true,
 	}}
+
+	csRes := charmStoreResource{
+		Resource:   newRes.Resource.Resource,
+		id:         newRes.ID,
+		serviceID:  newRes.ServiceID,
+		lastPolled: time.Now().UTC(),
+	}
+
 	if exists {
-		return append(ops, newUpdateResourceOps(newRes)...)
+		ops = append(ops, newUpdateResourceOps(newRes)...)
+		return append(ops, newUpdateCharmStoreResourceOps(csRes)...)
 	} else {
-		return append(ops, newInsertResourceOps(newRes)...)
+		ops = append(ops, newInsertResourceOps(newRes)...)
+		return append(ops, newInsertCharmStoreResourceOps(csRes)...)
 	}
 }
 

--- a/testcharms/charm-repo/quantal/starsay/metadata.yaml
+++ b/testcharms/charm-repo/quantal/starsay/metadata.yaml
@@ -6,14 +6,14 @@ tags:
   - application
 resources:
   store-resource:
-    Type: file
+    type: file
     filename: filename.tgz
     comment: One line that is useful when operators need to push it.
   install-resource:
-    Type: file
+    type: file
     filename: gotta-have-it.txt
     comment: get things started
   upload-resource:
-    Type: file
+    type: file
     filename: somename.xml
     comment: Who uses xml anymore?


### PR DESCRIPTION
When upgrading, charmstore charms with resources that weren't overridden by an explicit upload either previously or during upgrade-charm should be marked for replacement with the most up-to-date resources from the charmstore.

(Review request: http://reviews.vapour.ws/r/4006/)