### PR TITLE
rpc: refactor error handling to use juju/errors

### DIFF
--- a/rpc/jsoncodec/codec.go
+++ b/rpc/jsoncodec/codec.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"github.com/juju/errors"
 	"github.com/juju/loggo"
 
 	"github.com/juju/juju/rpc"
@@ -120,7 +121,7 @@ func (c *Codec) ReadHeader(hdr *rpc.Header) error {
 		if c.isClosing() || err == io.EOF {
 			return io.EOF
 		}
-		return fmt.Errorf("error receiving message: %v", err)
+		return errors.Annotate(err, "error receiving message")
 	}
 	hdr.RequestId = c.msg.RequestId
 	hdr.Request = rpc.Request{

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -402,23 +402,23 @@ func (conn *Conn) input() {
 
 // loop implements the looping part of Conn.input.
 func (conn *Conn) loop() error {
-	var hdr Header
 	for {
-		hdr = Header{}
+		var hdr Header
 		err := conn.codec.ReadHeader(&hdr)
-		if err != nil {
-			logger.Tracef("codec.ReadHeader error: %v", err)
+		switch {
+		case err == io.EOF:
+			// handle sentinel error specially
 			return err
-		}
-		if hdr.IsRequest() {
-			err = conn.handleRequest(&hdr)
-			logger.Tracef("codec.handleRequest %#v error: %v", hdr, err)
-		} else {
-			err = conn.handleResponse(&hdr)
-			logger.Tracef("codec.handleResponse %#v error: %v", hdr, err)
-		}
-		if err != nil {
-			return err
+		case err != nil:
+			return errors.Annotate(err, "codec.ReadHeader error")
+		case hdr.IsRequest():
+			if err := conn.handleRequest(&hdr); err != nil {
+				return errors.Annotatef(err, "codec.handleRequest %#v error", hdr)
+			}
+		default:
+			if err := conn.handleResponse(&hdr); err != nil {
+				return errors.Annotatef(err, "codec.handleResponse %#v error", hdr)
+			}
 		}
 	}
 }


### PR DESCRIPTION
Use the juju/errors package more consistantly in the rpc package to
provide better error stack traces.

(Review request: http://reviews.vapour.ws/r/4009/)