### PR TITLE
Fix typo in Joyent regions

### DIFF
--- a/cloud/fallback-public-cloud.yaml
+++ b/cloud/fallback-public-cloud.yaml
@@ -142,9 +142,9 @@ clouds:
       us-sw-1: 
         endpoint: https://us-sw-1.api.joyentcloud.com
       us-east-1: 
-        endpoint: https://us-east-.api.joyentcloud.com
+        endpoint: https://us-east-1.api.joyentcloud.com
       us-east-2: 
-        endpoint: https://us-east--2.api.joyentcloud.com
+        endpoint: https://us-east-2.api.joyentcloud.com
       us-east-3: 
         endpoint: https://us-east-3.api.joyentcloud.com
       us-west-1: 

--- a/cloud/fallback_public_cloud.go
+++ b/cloud/fallback_public_cloud.go
@@ -150,9 +150,9 @@ clouds:
       us-sw-1: 
         endpoint: https://us-sw-1.api.joyentcloud.com
       us-east-1: 
-        endpoint: https://us-east-.api.joyentcloud.com
+        endpoint: https://us-east-1.api.joyentcloud.com
       us-east-2: 
-        endpoint: https://us-east--2.api.joyentcloud.com
+        endpoint: https://us-east-2.api.joyentcloud.com
       us-east-3: 
         endpoint: https://us-east-3.api.joyentcloud.com
       us-west-1: 


### PR DESCRIPTION
Joyent regions us-east-1 and us-east-2 were misconfigured.

(Review request: http://reviews.vapour.ws/r/4010/)