### PR TITLE
apiserver/params: remove dependency on rpc package

### DIFF
--- a/apiserver/params/apierror.go
+++ b/apiserver/params/apierror.go
@@ -8,8 +8,6 @@ import (
 
 	"github.com/juju/errors"
 	"gopkg.in/macaroon.v1"
-
-	"github.com/juju/juju/rpc"
 )
 
 // Error is the type of error returned by any call to the state API.
@@ -48,8 +46,6 @@ func (e Error) ErrorCode() string {
 	return e.Code
 }
 
-var _ rpc.ErrorCoder = (*Error)(nil)
-
 // GoString implements fmt.GoStringer.  It means that a *Error shows its
 // contents correctly when printed with %#v.
 func (e Error) GoString() string {
@@ -72,7 +68,7 @@ const (
 	CodeNotProvisioned            = "not provisioned"
 	CodeNoAddressSet              = "no address set"
 	CodeTryAgain                  = "try again"
-	CodeNotImplemented            = rpc.CodeNotImplemented
+	CodeNotImplemented            = "not implemented" // asserted to match rpc.codeNotImplemented in rpc/rpc_test.go
 	CodeAlreadyExists             = "already exists"
 	CodeUpgradeInProgress         = "upgrade in progress"
 	CodeActionNotAvailable        = "action no longer available"
@@ -90,11 +86,15 @@ const (
 // the given error, or the empty string if there
 // is none.
 func ErrCode(err error) string {
-	err = errors.Cause(err)
-	if err, _ := err.(rpc.ErrorCoder); err != nil {
-		return err.ErrorCode()
+	type ErrorCoder interface {
+		ErrorCode() string
 	}
-	return ""
+	switch err := errors.Cause(err).(type) {
+	case ErrorCoder:
+		return err.ErrorCode()
+	default:
+		return ""
+	}
 }
 
 func IsCodeActionNotAvailable(err error) bool {

--- a/apiserver/params/apierror_test.go
+++ b/apiserver/params/apierror_test.go
@@ -8,9 +8,12 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/rpc"
 )
 
 type errorSuite struct{}
+
+var _ rpc.ErrorCoder = (*params.Error)(nil)
 
 var _ = gc.Suite(&errorSuite{})
 

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -107,7 +107,7 @@ func (conn *Conn) handleResponse(hdr *Header) error {
 	case hdr.Error != "":
 		// Report rpcreflect.NoSuchMethodError with CodeNotImplemented.
 		if strings.HasPrefix(hdr.Error, "no such request ") && hdr.ErrorCode == "" {
-			hdr.ErrorCode = CodeNotImplemented
+			hdr.ErrorCode = codeNotImplemented
 		}
 		// We've got an error response. Give this to the request;
 		// any subsequent requests will get the ReadResponseBody

--- a/rpc/export_test.go
+++ b/rpc/export_test.go
@@ -1,0 +1,6 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package rpc
+
+const CodeNotImplemented = codeNotImplemented

--- a/rpc/rpc_test.go
+++ b/rpc/rpc_test.go
@@ -18,6 +18,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/rpc"
 	"github.com/juju/juju/rpc/jsoncodec"
 	"github.com/juju/juju/rpc/rpcreflect"
@@ -1166,6 +1167,10 @@ func (*rpcSuite) TestChangeAPIWhileServingRequest(c *gc.C) {
 	case <-time.After(3 * time.Second):
 		c.Fatalf("timeout on channel read")
 	}
+}
+
+func (*rpcSuite) TestCodeNotImplementedMatchesApiserverParams(c *gc.C) {
+	c.Assert(rpc.CodeNotImplemented, gc.Equals, params.CodeNotImplemented)
 }
 
 func chanReadError(c *gc.C, ch <-chan error, what string) error {

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -15,7 +15,7 @@ import (
 	"github.com/juju/juju/rpc/rpcreflect"
 )
 
-const CodeNotImplemented = "not implemented"
+const codeNotImplemented = "not implemented"
 
 var logger = loggo.GetLogger("juju.rpc")
 
@@ -582,5 +582,5 @@ type serverError struct {
 
 func (e *serverError) ErrorCode() string {
 	// serverError only knows one error code.
-	return CodeNotImplemented
+	return codeNotImplemented
 }


### PR DESCRIPTION
There was only one constant that tied apiserver/params to the rpc
package, so copy the constant and add a test to make sure it doesn't
change in the future.

This means the millions of packages that import apiserver/params no
longer depend on the rpc package.

(Review request: http://reviews.vapour.ws/r/4013/)