### PR TITLE
apiserver/testing: Introduce FakeNotifyWatcher

### DIFF
--- a/apiserver/common/modelwatcher_test.go
+++ b/apiserver/common/modelwatcher_test.go
@@ -37,10 +37,10 @@ type fakeModelAccessor struct {
 }
 
 func (*fakeModelAccessor) WatchForModelConfigChanges() state.NotifyWatcher {
-	changes := make(chan struct{}, 1)
+	w := apiservertesting.NewFakeNotifyWatcher()
 	// Simulate initial event.
-	changes <- struct{}{}
-	return &fakeNotifyWatcher{changes: changes}
+	w.C <- struct{}{}
+	return w
 }
 
 func (f *fakeModelAccessor) ModelConfig() (*config.Config, error) {

--- a/apiserver/common/storagecommon/mock_test.go
+++ b/apiserver/common/storagecommon/mock_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/names"
 	"github.com/juju/testing"
-	"launchpad.net/tomb"
 
 	"github.com/juju/juju/apiserver/common/storagecommon"
 	"github.com/juju/juju/state"
@@ -141,25 +140,6 @@ type fakePoolManager struct {
 
 func (pm *fakePoolManager) Get(name string) (*storage.Config, error) {
 	return nil, errors.NotFoundf("pool")
-}
-
-type fakeNotifyWatcher struct {
-	tomb.Tomb
-	ch chan struct{}
-}
-
-func (w *fakeNotifyWatcher) Kill() {
-	w.Tomb.Kill(nil)
-	w.Tomb.Done()
-}
-
-func (w *fakeNotifyWatcher) Stop() error {
-	w.Kill()
-	return w.Wait()
-}
-
-func (w *fakeNotifyWatcher) Changes() <-chan struct{} {
-	return w.ch
 }
 
 type nopSyncStarter struct{}

--- a/apiserver/common/storagecommon/storage_test.go
+++ b/apiserver/common/storagecommon/storage_test.go
@@ -12,6 +12,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/common/storagecommon"
+	apiservertesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/state"
 	statetesting "github.com/juju/juju/state/testing"
 	"github.com/juju/juju/storage"
@@ -155,9 +156,9 @@ type watchStorageAttachmentSuite struct {
 	st                       *fakeStorage
 	storageInstance          *fakeStorageInstance
 	volume                   *fakeVolume
-	volumeAttachmentWatcher  *fakeNotifyWatcher
-	blockDevicesWatcher      *fakeNotifyWatcher
-	storageAttachmentWatcher *fakeNotifyWatcher
+	volumeAttachmentWatcher  *apiservertesting.FakeNotifyWatcher
+	blockDevicesWatcher      *apiservertesting.FakeNotifyWatcher
+	storageAttachmentWatcher *apiservertesting.FakeNotifyWatcher
 }
 
 var _ = gc.Suite(&watchStorageAttachmentSuite{})
@@ -172,12 +173,12 @@ func (s *watchStorageAttachmentSuite) SetUpTest(c *gc.C) {
 		kind:  state.StorageKindBlock,
 	}
 	s.volume = &fakeVolume{tag: names.NewVolumeTag("0")}
-	s.volumeAttachmentWatcher = &fakeNotifyWatcher{ch: make(chan struct{}, 1)}
-	s.blockDevicesWatcher = &fakeNotifyWatcher{ch: make(chan struct{}, 1)}
-	s.storageAttachmentWatcher = &fakeNotifyWatcher{ch: make(chan struct{}, 1)}
-	s.volumeAttachmentWatcher.ch <- struct{}{}
-	s.blockDevicesWatcher.ch <- struct{}{}
-	s.storageAttachmentWatcher.ch <- struct{}{}
+	s.volumeAttachmentWatcher = apiservertesting.NewFakeNotifyWatcher()
+	s.volumeAttachmentWatcher.C <- struct{}{}
+	s.blockDevicesWatcher = apiservertesting.NewFakeNotifyWatcher()
+	s.blockDevicesWatcher.C <- struct{}{}
+	s.storageAttachmentWatcher = apiservertesting.NewFakeNotifyWatcher()
+	s.storageAttachmentWatcher.C <- struct{}{}
 	s.st = &fakeStorage{
 		storageInstance: func(tag names.StorageTag) (state.StorageInstance, error) {
 			return s.storageInstance, nil
@@ -199,19 +200,19 @@ func (s *watchStorageAttachmentSuite) SetUpTest(c *gc.C) {
 
 func (s *watchStorageAttachmentSuite) TestWatchStorageAttachmentVolumeAttachmentChanges(c *gc.C) {
 	s.testWatchBlockStorageAttachment(c, func() {
-		s.volumeAttachmentWatcher.ch <- struct{}{}
+		s.volumeAttachmentWatcher.C <- struct{}{}
 	})
 }
 
 func (s *watchStorageAttachmentSuite) TestWatchStorageAttachmentStorageAttachmentChanges(c *gc.C) {
 	s.testWatchBlockStorageAttachment(c, func() {
-		s.storageAttachmentWatcher.ch <- struct{}{}
+		s.storageAttachmentWatcher.C <- struct{}{}
 	})
 }
 
 func (s *watchStorageAttachmentSuite) TestWatchStorageAttachmentBlockDevicesChange(c *gc.C) {
 	s.testWatchBlockStorageAttachment(c, func() {
-		s.blockDevicesWatcher.ch <- struct{}{}
+		s.blockDevicesWatcher.C <- struct{}{}
 	})
 }
 

--- a/apiserver/testing/fakenotifywatcher.go
+++ b/apiserver/testing/fakenotifywatcher.go
@@ -1,0 +1,47 @@
+// Copyright 2013 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package testing
+
+import (
+	"launchpad.net/tomb"
+
+	"github.com/juju/juju/state"
+)
+
+// FakeNotifyWatcher is an implementation of state.NotifyWatcher which
+// is useful in tests.
+type FakeNotifyWatcher struct {
+	tomb tomb.Tomb
+	C    chan struct{}
+}
+
+var _ state.NotifyWatcher = (*FakeNotifyWatcher)(nil)
+
+func NewFakeNotifyWatcher() *FakeNotifyWatcher {
+	return &FakeNotifyWatcher{
+		C: make(chan struct{}, 1),
+	}
+}
+
+func (w *FakeNotifyWatcher) Stop() error {
+	w.Kill()
+	return w.Wait()
+}
+
+func (w *FakeNotifyWatcher) Kill() {
+	w.tomb.Kill(nil)
+	w.tomb.Done()
+}
+
+func (w *FakeNotifyWatcher) Wait() error {
+	return w.tomb.Wait()
+}
+
+func (w *FakeNotifyWatcher) Err() error {
+	return w.tomb.Err()
+}
+
+func (w *FakeNotifyWatcher) Changes() <-chan struct{} {
+	return w.C
+}


### PR DESCRIPTION
FakeNotifyWatcher is a fake state.NotifyWatcher, useful for testing. It already exists in a few places in various apiserver packages. This change consolidates the various implementations.

(Review request: http://reviews.vapour.ws/r/4020/)