### PR TITLE
provider/maas: ensure bridge script works on xenial

### DIFF
--- a/provider/maas/add-juju-bridge.py
+++ b/provider/maas/add-juju-bridge.py
@@ -345,12 +345,12 @@ def main(args):
         if not os.path.isfile(backup_file):
             shutil.copy2(args.filename, backup_file)
 
-    ifquery = "$(ifquery -i {} --exclude=lo -l)".format(args.filename)
+    ifquery = "$(ifquery --interfaces={} --exclude=lo --list)".format(args.filename)
 
     print("**** Original configuration")
     print_shell_cmd("cat {}".format(args.filename))
     print_shell_cmd("ifconfig -a")
-    print_shell_cmd("ifdown --exclude=lo -i {} {}".format(args.filename, ifquery))
+    print_shell_cmd("ifdown --exclude=lo --interfaces={} {}".format(args.filename, ifquery))
 
     print("**** Activating new configuration")
 
@@ -359,7 +359,7 @@ def main(args):
         f.close()
 
     print_shell_cmd("cat {}".format(args.filename))
-    print_shell_cmd("ifup --exclude=lo -i {} {}".format(args.filename, ifquery))
+    print_shell_cmd("ifup --exclude=lo --interfaces={} {}".format(args.filename, ifquery))
     print_shell_cmd("ip link show up")
     print_shell_cmd("ifconfig -a")
     print_shell_cmd("ip route show")

--- a/provider/maas/add-juju-bridge.py
+++ b/provider/maas/add-juju-bridge.py
@@ -167,7 +167,7 @@ class NetworkInterfaceParser(object):
 
     def __init__(self, filename):
         self._stanzas = []
-        with open(filename) as f:
+        with open(filename, 'r') as f:
             lines = f.readlines()
         line_iterator = SeekableIterator(lines)
         for line in line_iterator:
@@ -276,9 +276,9 @@ def print_shell_cmd(s, verbose=True, exit_on_error=False):
         print(s)
     out, err, retcode = shell_cmd(s)
     if out and len(out) > 0:
-        print(out.rstrip('\n'))
+        print(out.decode().rstrip('\n'))
     if err and len(err) > 0:
-        print(err.rstrip('\n'))
+        print(err.decode().rstrip('\n'))
     if exit_on_error and retcode != 0:
         exit(1)
 

--- a/provider/maas/bridgescript.go
+++ b/provider/maas/bridgescript.go
@@ -179,7 +179,7 @@ class NetworkInterfaceParser(object):
 
     def __init__(self, filename):
         self._stanzas = []
-        with open(filename) as f:
+        with open(filename, 'r') as f:
             lines = f.readlines()
         line_iterator = SeekableIterator(lines)
         for line in line_iterator:
@@ -288,9 +288,9 @@ def print_shell_cmd(s, verbose=True, exit_on_error=False):
         print(s)
     out, err, retcode = shell_cmd(s)
     if out and len(out) > 0:
-        print(out.rstrip('\n'))
+        print(out.decode().rstrip('\n'))
     if err and len(err) > 0:
-        print(err.rstrip('\n'))
+        print(err.decode().rstrip('\n'))
     if exit_on_error and retcode != 0:
         exit(1)
 
@@ -357,12 +357,12 @@ def main(args):
         if not os.path.isfile(backup_file):
             shutil.copy2(args.filename, backup_file)
 
-    ifquery = "$(ifquery -i {} --exclude=lo -l)".format(args.filename)
+    ifquery = "$(ifquery --interfaces={} --exclude=lo --list)".format(args.filename)
 
     print("**** Original configuration")
     print_shell_cmd("cat {}".format(args.filename))
     print_shell_cmd("ifconfig -a")
-    print_shell_cmd("ifdown --exclude=lo -i {} {}".format(args.filename, ifquery))
+    print_shell_cmd("ifdown --exclude=lo --interfaces={} {}".format(args.filename, ifquery))
 
     print("**** Activating new configuration")
 
@@ -371,7 +371,7 @@ def main(args):
         f.close()
 
     print_shell_cmd("cat {}".format(args.filename))
-    print_shell_cmd("ifup --exclude=lo -i {} {}".format(args.filename, ifquery))
+    print_shell_cmd("ifup --exclude=lo --interfaces={} {}".format(args.filename, ifquery))
     print_shell_cmd("ip link show up")
     print_shell_cmd("ifconfig -a")
     print_shell_cmd("ip route show")

--- a/provider/maas/bridgescript_test.go
+++ b/provider/maas/bridgescript_test.go
@@ -6,6 +6,7 @@ package maas
 import (
 	"fmt"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -20,9 +21,10 @@ import (
 type bridgeConfigSuite struct {
 	coretesting.BaseSuite
 
-	testConfig       string
-	testConfigPath   string
-	testPythonScript string
+	testConfig         string
+	testConfigPath     string
+	testPythonScript   string
+	testPythonVersions []string
 }
 
 var _ = gc.Suite(&bridgeConfigSuite{})
@@ -32,28 +34,44 @@ func (s *bridgeConfigSuite) SetUpSuite(c *gc.C) {
 		c.Skip("Skipping bridge config tests on windows")
 	}
 	s.BaseSuite.SetUpSuite(c)
+
+	for _, version := range []string{
+		"/usr/bin/python2",
+		"/usr/bin/python3",
+		"/usr/bin/python",
+	} {
+		if _, err := os.Stat(version); err == nil {
+			s.testPythonVersions = append(s.testPythonVersions, version)
+		}
+	}
 }
 
 func (s *bridgeConfigSuite) SetUpTest(c *gc.C) {
+	// We need at least one Python package installed.
+	c.Assert(s.testPythonVersions, gc.Not(gc.HasLen), 0)
+
 	s.testConfigPath = filepath.Join(c.MkDir(), "network-config")
 	s.testPythonScript = filepath.Join(c.MkDir(), bridgeScriptName)
 	s.testConfig = "# test network config\n"
 	err := ioutil.WriteFile(s.testConfigPath, []byte(s.testConfig), 0644)
 	c.Assert(err, jc.ErrorIsNil)
-	err = ioutil.WriteFile(s.testPythonScript, []byte(bridgeScriptPython), 0755)
+	err = ioutil.WriteFile(s.testPythonScript, []byte(bridgeScriptPython), 0644)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *bridgeConfigSuite) assertScript(c *gc.C, initialConfig, expectedConfig, bridgePrefix, bridgeName, interfaceToBridge string) {
-	// To simplify most cases, trim trailing new lines.
-	initialConfig = strings.TrimSuffix(initialConfig, "\n")
-	expectedConfig = strings.TrimSuffix(expectedConfig, "\n")
-	err := ioutil.WriteFile(s.testConfigPath, []byte(initialConfig), 0644)
-	c.Check(err, jc.ErrorIsNil)
-	// Run the script and verify the modified config.
-	output, retcode := s.runScript(c, s.testConfigPath, bridgePrefix, bridgeName, interfaceToBridge)
-	c.Check(retcode, gc.Equals, 0)
-	c.Check(strings.Trim(output, "\n"), gc.Equals, expectedConfig)
+	for i, python := range s.testPythonVersions {
+		c.Logf("test #%v using %s", i, python)
+		// To simplify most cases, trim trailing new lines.
+		initialConfig = strings.TrimSuffix(initialConfig, "\n")
+		expectedConfig = strings.TrimSuffix(expectedConfig, "\n")
+		err := ioutil.WriteFile(s.testConfigPath, []byte(initialConfig), 0644)
+		c.Check(err, jc.ErrorIsNil)
+		// Run the script and verify the modified config.
+		output, retcode := s.runScript(c, python, s.testConfigPath, bridgePrefix, bridgeName, interfaceToBridge)
+		c.Check(retcode, gc.Equals, 0)
+		c.Check(strings.Trim(output, "\n"), gc.Equals, expectedConfig)
+	}
 }
 
 func (s *bridgeConfigSuite) assertScriptWithPrefix(c *gc.C, initial, expected, prefix string) {
@@ -69,8 +87,11 @@ func (s *bridgeConfigSuite) assertScriptWithoutPrefix(c *gc.C, initial, expected
 }
 
 func (s *bridgeConfigSuite) TestBridgeScriptWithUndefinedArgs(c *gc.C) {
-	_, code := s.runScript(c, "", "", "", "")
-	c.Check(code, gc.Equals, 1)
+	for i, python := range s.testPythonVersions {
+		c.Logf("test #%v using %s", i, python)
+		_, code := s.runScript(c, python, "", "", "", "")
+		c.Check(code, gc.Equals, 1)
+	}
 }
 
 func (s *bridgeConfigSuite) TestBridgeScriptDHCP(c *gc.C) {
@@ -146,15 +167,21 @@ func (s *bridgeConfigSuite) TestBridgeScriptMismatchedBridgeNameAndInterfaceArgs
 }
 
 func (s *bridgeConfigSuite) TestBridgeScriptInterfaceNameArgumentRequired(c *gc.C) {
-	output, code := s.runScript(c, "# no content", "", "juju-br0", "")
-	c.Check(code, gc.Equals, 1)
-	c.Check(strings.Trim(output, "\n"), gc.Equals, "error: --interface-to-bridge required when using --bridge-name")
+	for i, python := range s.testPythonVersions {
+		c.Logf("test #%v using %s", i, python)
+		output, code := s.runScript(c, python, "# no content", "", "juju-br0", "")
+		c.Check(code, gc.Equals, 1)
+		c.Check(strings.Trim(output, "\n"), gc.Equals, "error: --interface-to-bridge required when using --bridge-name")
+	}
 }
 
 func (s *bridgeConfigSuite) TestBridgeScriptBridgeNameArgumentRequired(c *gc.C) {
-	output, code := s.runScript(c, "# no content", "", "", "eth0")
-	c.Check(code, gc.Equals, 1)
-	c.Check(strings.Trim(output, "\n"), gc.Equals, "error: --bridge-name required when using --interface-to-bridge")
+	for i, python := range s.testPythonVersions {
+		c.Logf("test #%v using %s", i, python)
+		output, code := s.runScript(c, python, "# no content", "", "", "eth0")
+		c.Check(code, gc.Equals, 1)
+		c.Check(strings.Trim(output, "\n"), gc.Equals, "error: --bridge-name required when using --interface-to-bridge")
+	}
 }
 
 func (s *bridgeConfigSuite) TestBridgeScriptMatchingNonExistentSpecificIface(c *gc.C) {
@@ -169,7 +196,7 @@ func (s *bridgeConfigSuite) TestBridgeScriptMatchingExistingSpecificIface2(c *gc
 	s.assertScriptWithoutPrefix(c, networkLP1532167Initial, networkLP1532167Expected, "juju-br0", "bond0")
 }
 
-func (s *bridgeConfigSuite) runScript(c *gc.C, configFile, bridgePrefix, bridgeName, interfaceToBridge string) (output string, exitCode int) {
+func (s *bridgeConfigSuite) runScript(c *gc.C, pythonBinary, configFile, bridgePrefix, bridgeName, interfaceToBridge string) (output string, exitCode int) {
 	if bridgePrefix != "" {
 		bridgePrefix = fmt.Sprintf("--bridge-prefix=%q", bridgePrefix)
 	}
@@ -182,7 +209,8 @@ func (s *bridgeConfigSuite) runScript(c *gc.C, configFile, bridgePrefix, bridgeN
 		interfaceToBridge = fmt.Sprintf("--interface-to-bridge=%q", interfaceToBridge)
 	}
 
-	script := fmt.Sprintf("%q %s %s %s %q\n", s.testPythonScript, bridgePrefix, bridgeName, interfaceToBridge, configFile)
+	script := fmt.Sprintf("%q %q %s %s %s %q\n", pythonBinary, s.testPythonScript, bridgePrefix, bridgeName, interfaceToBridge, configFile)
+	c.Log(script)
 	result, err := exec.RunCommands(exec.RunParams{Commands: script})
 	c.Assert(err, jc.ErrorIsNil, gc.Commentf("script failed unexpectedly"))
 	stdout := string(result.Stdout)

--- a/provider/maas/bridgescript_test.go
+++ b/provider/maas/bridgescript_test.go
@@ -21,10 +21,10 @@ import (
 type bridgeConfigSuite struct {
 	coretesting.BaseSuite
 
-	testConfig         string
-	testConfigPath     string
-	testPythonScript   string
-	testPythonVersions []string
+	testConfig       string
+	testConfigPath   string
+	testPythonScript string
+	pythonVersions   []string
 }
 
 var _ = gc.Suite(&bridgeConfigSuite{})
@@ -41,14 +41,14 @@ func (s *bridgeConfigSuite) SetUpSuite(c *gc.C) {
 		"/usr/bin/python",
 	} {
 		if _, err := os.Stat(version); err == nil {
-			s.testPythonVersions = append(s.testPythonVersions, version)
+			s.pythonVersions = append(s.pythonVersions, version)
 		}
 	}
 }
 
 func (s *bridgeConfigSuite) SetUpTest(c *gc.C) {
 	// We need at least one Python package installed.
-	c.Assert(s.testPythonVersions, gc.Not(gc.HasLen), 0)
+	c.Assert(s.pythonVersions, gc.Not(gc.HasLen), 0)
 
 	s.testConfigPath = filepath.Join(c.MkDir(), "network-config")
 	s.testPythonScript = filepath.Join(c.MkDir(), bridgeScriptName)
@@ -60,7 +60,7 @@ func (s *bridgeConfigSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *bridgeConfigSuite) assertScript(c *gc.C, initialConfig, expectedConfig, bridgePrefix, bridgeName, interfaceToBridge string) {
-	for i, python := range s.testPythonVersions {
+	for i, python := range s.pythonVersions {
 		c.Logf("test #%v using %s", i, python)
 		// To simplify most cases, trim trailing new lines.
 		initialConfig = strings.TrimSuffix(initialConfig, "\n")
@@ -87,7 +87,7 @@ func (s *bridgeConfigSuite) assertScriptWithoutPrefix(c *gc.C, initial, expected
 }
 
 func (s *bridgeConfigSuite) TestBridgeScriptWithUndefinedArgs(c *gc.C) {
-	for i, python := range s.testPythonVersions {
+	for i, python := range s.pythonVersions {
 		c.Logf("test #%v using %s", i, python)
 		_, code := s.runScript(c, python, "", "", "", "")
 		c.Check(code, gc.Equals, 1)
@@ -167,7 +167,7 @@ func (s *bridgeConfigSuite) TestBridgeScriptMismatchedBridgeNameAndInterfaceArgs
 }
 
 func (s *bridgeConfigSuite) TestBridgeScriptInterfaceNameArgumentRequired(c *gc.C) {
-	for i, python := range s.testPythonVersions {
+	for i, python := range s.pythonVersions {
 		c.Logf("test #%v using %s", i, python)
 		output, code := s.runScript(c, python, "# no content", "", "juju-br0", "")
 		c.Check(code, gc.Equals, 1)
@@ -176,7 +176,7 @@ func (s *bridgeConfigSuite) TestBridgeScriptInterfaceNameArgumentRequired(c *gc.
 }
 
 func (s *bridgeConfigSuite) TestBridgeScriptBridgeNameArgumentRequired(c *gc.C) {
-	for i, python := range s.testPythonVersions {
+	for i, python := range s.pythonVersions {
 		c.Logf("test #%v using %s", i, python)
 		output, code := s.runScript(c, python, "# no content", "", "", "eth0")
 		c.Check(code, gc.Equals, 1)

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -1014,7 +1014,39 @@ func (environ *maasEnviron) selectNode(args selectNodeArgs) (*gomaasapi.MAASObje
 // setupJujuNetworking returns a string representing the script to run
 // in order to prepare the Juju-specific networking config on a node.
 func setupJujuNetworking() string {
-	return fmt.Sprintf("trap 'rm -f %[1]q' EXIT; if [ -f %[1]q ]; then %[1]q --bridge-prefix=%q --one-time-backup --activate %q; fi\n",
+	// For ubuntu series < xenial we prefer python2 over python3
+	// as we don't want to invalidate lots of testing against
+	// known cloud-image contents. A summary of Ubuntu releases
+	// and python inclusion in the default install of Ubuntu
+	// Server is as follows:
+	//
+	// 12.04 precise:  python 2 (2.7.3)
+	// 14.04 trusty:   python 2 (2.7.5) and python3 (3.4.0)
+	// 14.10 utopic:   python 2 (2.7.8) and python3 (3.4.2)
+	// 15.04 vivid:    python 2 (2.7.9) and python3 (3.4.3)
+	// 15.10 wily:     python 2 (2.7.9) and python3 (3.4.3)
+	// 16.04 xenial:   python 3 only (3.5.1)
+	//
+	// going forward:  python 3 only
+
+	return fmt.Sprintf(`
+trap 'rm -f %[1]q' EXIT
+
+if [ -x /usr/bin/python2 ]; then
+    juju_networking_preferred_python_binary=/usr/bin/python2
+elif [ -x /usr/bin/python3 ]; then
+    juju_networking_preferred_python_binary=/usr/bin/python3
+elif [ -x /usr/bin/python ]; then
+    juju_networking_preferred_python_binary=/usr/bin/python
+fi
+
+if [ ! -z "${juju_networking_preferred_python_binary:-}" ]; then
+    if [ -f %[1]q ]; then
+        ${juju_networking_preferred_python_binary} %[1]q --bridge-prefix=%q --one-time-backup --activate %q
+    fi
+else
+    echo "error: no Python installation found; cannot run Juju's bridge script"
+fi`,
 		bridgeScriptPath,
 		instancecfg.DefaultBridgePrefix,
 		"/etc/network/interfaces")


### PR DESCRIPTION
Xenial only has Python 3.5 and there is no /usr/bin/python only
/usr/bin/python3, however the bridge script was reliant on just python.

We now detect what python versions are available before invoking the
script, preferring python 2 over 3 as we don't want to invalidate lots
of existing testing with known cloud-image contents for series older
than xenial.

A summary of Ubuntu releases and the python version included in the
default install of Ubuntu Server is as follows:

 12.04 precise:  python 2 only (2.7.3)
 14.04 trusty:   python 2 only (2.7.5) and python3 (3.4.0)
 14.10 utopic:   python 2 (2.7.8) and python3 (3.4.2)
 15.04 vivid:    python 2 (2.7.9) and python3 (3.4.3)
 15.10 wily:     python 2 (2.7.9) and python3 (3.4.3)
 16.04 xenial:   python 3 only (3.5.1)
 going forward:  python 3 only

This has been tested by bootstrapping with precise (where some extra
fixes where required), trusty, wily and xenial.

Fixes [LP:#1550306](https://bugs.launchpad.net/juju-core/+bug/1550306)


(Review request: http://reviews.vapour.ws/r/4021/)