### PR TITLE
1550770: Add DefaultSeries tools for current arch

### DIFF
--- a/worker/provisioner/lxc-broker_test.go
+++ b/worker/provisioner/lxc-broker_test.go
@@ -1098,7 +1098,7 @@ func (s *lxcProvisionerSuite) maybeUploadTools(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	defaultTools := version.Binary{
-		Number: version.Current,
+		Number: version.Current.Number,
 		Arch:   arch.HostArch(),
 		Series: coretesting.FakeDefaultSeries,
 	}

--- a/worker/provisioner/lxc-broker_test.go
+++ b/worker/provisioner/lxc-broker_test.go
@@ -29,6 +29,9 @@ import (
 	lxctesting "github.com/juju/juju/container/lxc/testing"
 	containertesting "github.com/juju/juju/container/testing"
 	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/filestorage"
+	envtesting "github.com/juju/juju/environs/testing"
+	"github.com/juju/juju/environs/tools"
 	"github.com/juju/juju/feature"
 	"github.com/juju/juju/instance"
 	instancetest "github.com/juju/juju/instance/testing"
@@ -1082,8 +1085,30 @@ func (s *lxcProvisionerSuite) addContainer(c *gc.C) *state.Machine {
 	return container
 }
 
+func (s *lxcProvisionerSuite) maybeUploadTools(c *gc.C) {
+	// The default series tools are already uploaded
+	// for amd64 in the base suite.
+	if arch.HostArch() == arch.AMD64 {
+		return
+	}
+
+	storageDir := c.MkDir()
+	s.CommonProvisionerSuite.PatchValue(&tools.DefaultBaseURL, storageDir)
+	stor, err := filestorage.NewFileStorageWriter(storageDir)
+	c.Assert(err, jc.ErrorIsNil)
+
+	defaultTools := version.Binary{
+		Number: version.Current,
+		Arch:   arch.HostArch(),
+		Series: coretesting.FakeDefaultSeries,
+	}
+
+	envtesting.AssertUploadFakeToolsVersions(c, stor, "devel", "devel", defaultTools)
+}
+
 func (s *lxcProvisionerSuite) TestContainerStartedAndStopped(c *gc.C) {
 	coretesting.SkipIfI386(c, "lp:1425569")
+	s.maybeUploadTools(c)
 
 	p := s.newLxcProvisioner(c)
 	defer stop(c, p)


### PR DESCRIPTION
TestContainerStartedAndStopped starts a container with
the default series, but does not upload tools for non
amd64 arches.  As a result the tests fail because
tools cannot be found.
  
This patch uploads tools for the default series and
the current arch if the arch is not amd64 (as amd64
tools with the default series are already uploaded
in the base suite)

(backport of https://github.com/juju/juju/pull/4579)