### PR TITLE
Remove duplicated unused assignments, collapse err return.

### DIFF
--- a/cmd/juju/service/deploy.go
+++ b/cmd/juju/service/deploy.go
@@ -586,20 +586,7 @@ func (c *DeployCommand) deployCharm(
 		spaceBindings: c.Bindings,
 		resources:     ids,
 	}
-	if err := deployer.serviceDeploy(params); err != nil {
-		return err
-	}
-
-	state, err = c.NewAPIRoot()
-	if err != nil {
-		return errors.Trace(err)
-	}
-	httpClient, err = c.HTTPClient()
-	if err != nil {
-		return errors.Trace(err)
-	}
-
-	return err
+	return deployer.serviceDeploy(params)
 }
 
 func (c *DeployCommand) handleResources(serviceName string, metaResources map[string]charmresource.Meta) (map[string]string, error) {


### PR DESCRIPTION
Possible left overs from a prior merge? Noticed this earlier today and it bothered me.

(Review request: http://reviews.vapour.ws/r/4028/)