### PR TITLE
apiserver/common: standardise on juju/errors

### DIFF
--- a/apiserver/common/errors.go
+++ b/apiserver/common/errors.go
@@ -4,7 +4,6 @@
 package common
 
 import (
-	stderrors "errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -88,16 +87,16 @@ func IsDischargeRequiredError(err error) bool {
 }
 
 var (
-	ErrBadId              = stderrors.New("id not found")
-	ErrBadCreds           = stderrors.New("invalid entity name or password")
-	ErrPerm               = stderrors.New("permission denied")
-	ErrNotLoggedIn        = stderrors.New("not logged in")
-	ErrUnknownWatcher     = stderrors.New("unknown watcher id")
-	ErrUnknownPinger      = stderrors.New("unknown pinger id")
-	ErrStoppedWatcher     = stderrors.New("watcher has been stopped")
-	ErrBadRequest         = stderrors.New("invalid request")
-	ErrTryAgain           = stderrors.New("try again")
-	ErrActionNotAvailable = stderrors.New("action no longer available")
+	ErrBadId              = errors.New("id not found")
+	ErrBadCreds           = errors.New("invalid entity name or password")
+	ErrPerm               = errors.New("permission denied")
+	ErrNotLoggedIn        = errors.New("not logged in")
+	ErrUnknownWatcher     = errors.New("unknown watcher id")
+	ErrUnknownPinger      = errors.New("unknown pinger id")
+	ErrStoppedWatcher     = errors.New("watcher has been stopped")
+	ErrBadRequest         = errors.New("invalid request")
+	ErrTryAgain           = errors.New("try again")
+	ErrActionNotAvailable = errors.New("action no longer available")
 )
 
 // OperationBlockedError returns an error which signifies that


### PR DESCRIPTION
common/errors.go imported both the go errors package, and our
juju/errors superset. This was so sentinel errors were created without
the usual juju/errors file/line tracking.

This is unncessary, juju/errors.New is fully compatible with errors.New;
its sentinel values can still be compared by value.

The only visible change is the error trace, rather that listing no
file/ilne for the final error value, it will list the file/line that the
value was declared at the package level. This distinction is not
important, because what we look for in the error trace is not where the
error was created, but who was the caller -- if we wanted the former,
sentinal errors are not the right tool.

(Review request: http://reviews.vapour.ws/r/4031/)