### PR TITLE
state: Turn model migration funcs into methods

### DIFF
--- a/api/controller/controller_test.go
+++ b/api/controller/controller_test.go
@@ -167,7 +167,7 @@ func (s *controllerSuite) TestInitiateModelMigration(c *gc.C) {
 	st := s.Factory.MakeModel(c, nil)
 	defer st.Close()
 
-	_, err := state.GetModelMigration(st)
+	_, err := st.GetModelMigration()
 	c.Assert(errors.IsNotFound(err), jc.IsTrue)
 
 	spec := controller.ModelMigrationSpec{
@@ -186,7 +186,7 @@ func (s *controllerSuite) TestInitiateModelMigration(c *gc.C) {
 	c.Check(id, gc.Equals, expectedId)
 
 	// Check database.
-	mig, err := state.GetModelMigration(st)
+	mig, err := st.GetModelMigration()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(mig.Id(), gc.Equals, expectedId)
 }

--- a/apiserver/controller/controller.go
+++ b/apiserver/controller/controller.go
@@ -320,7 +320,7 @@ func (c *ControllerAPI) initiateOneModelMigration(spec params.ModelMigrationSpec
 			Password:      targetInfo.Password,
 		},
 	}
-	mig, err := state.CreateModelMigration(hostedState, args)
+	mig, err := hostedState.CreateModelMigration(args)
 	if err != nil {
 		return "", errors.Trace(err)
 	}

--- a/apiserver/controller/controller_test.go
+++ b/apiserver/controller/controller_test.go
@@ -316,7 +316,7 @@ func (s *controllerSuite) TestInitiateModelMigration(c *gc.C) {
 		c.Check(result.Id, gc.Equals, expectedId)
 
 		// Ensure the migration made it into the DB correctly.
-		mig, err := state.GetModelMigration(st)
+		mig, err := st.GetModelMigration()
 		c.Assert(err, jc.ErrorIsNil)
 		c.Check(mig.Id(), gc.Equals, expectedId)
 		c.Check(mig.ModelUUID(), gc.Equals, st.ModelUUID())

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -2694,7 +2694,7 @@ func (w *modelMigrationWatcher) loop() error {
 	var out chan<- struct{}
 
 	// Check if a migration is already in progress and if so, report it immediately.
-	if active, err := IsModelMigrationActive(w.st, w.st.ModelUUID()); err != nil {
+	if active, err := w.st.IsModelMigrationActive(); err != nil {
 		return errors.Trace(err)
 	} else if active {
 		out = w.sink


### PR DESCRIPTION
There's no reason not to and this makes it easier to provide fakes for testing of model migration functionality in the API server.

(Review request: http://reviews.vapour.ws/r/4035/)