### PR TITLE
Add detail to list-controllers --format yaml

### DIFF
--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -244,7 +244,7 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 	// Manage controllers
 	r.Register(controller.NewCreateModelCommand())
 	r.Register(controller.NewDestroyCommand())
-	r.Register(controller.NewModelsCommand())
+	r.Register(controller.NewListModelsCommand())
 	r.Register(controller.NewKillCommand())
 	r.Register(controller.NewListControllersCommand())
 	r.Register(controller.NewListBlocksCommand())

--- a/cmd/juju/controller/export_test.go
+++ b/cmd/juju/controller/export_test.go
@@ -48,10 +48,10 @@ func NewCreateModelCommandForTest(
 	return modelcmd.WrapController(c), &CreateModelCommand{c}
 }
 
-// NewModelsCommandForTest returns a EnvironmentsCommand with the API
+// NewListModelsCommandForTest returns a EnvironmentsCommand with the API
 // and userCreds provided as specified.
-func NewModelsCommandForTest(modelAPI ModelManagerAPI, sysAPI ModelsSysAPI, store jujuclient.ClientStore, userCreds *configstore.APICredentials) cmd.Command {
-	c := &environmentsCommand{
+func NewListModelsCommandForTest(modelAPI ModelManagerAPI, sysAPI ModelsSysAPI, store jujuclient.ClientStore, userCreds *configstore.APICredentials) cmd.Command {
+	c := &modelsCommand{
 		modelAPI:  modelAPI,
 		sysAPI:    sysAPI,
 		userCreds: userCreds,

--- a/cmd/juju/controller/listcontrollers_test.go
+++ b/cmd/juju/controller/listcontrollers_test.go
@@ -4,8 +4,8 @@
 package controller_test
 
 import (
-	"fmt"
 	"encoding/json"
+	"fmt"
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"

--- a/cmd/juju/controller/listcontrollers_test.go
+++ b/cmd/juju/controller/listcontrollers_test.go
@@ -5,13 +5,13 @@ package controller_test
 
 import (
 	"fmt"
+	"encoding/json"
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"encoding/json"
 	"github.com/juju/juju/cmd/juju/controller"
 	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	"github.com/juju/juju/testing"

--- a/cmd/juju/controller/listcontrollersconverters.go
+++ b/cmd/juju/controller/listcontrollersconverters.go
@@ -20,9 +20,13 @@ type ControllerSet struct {
 
 // ControllerItem defines the serialization behaviour of controller information.
 type ControllerItem struct {
-	ModelName string `yaml:"model,omitempty" json:"model,omitempty"`
-	User      string `yaml:"user,omitempty" json:"user,omitempty"`
-	Server    string `yaml:"server,omitempty" json:"server,omitempty"`
+	ModelName      string   `yaml:"current-model,omitempty" json:"current-model,omitempty"`
+	User           string   `yaml:"user,omitempty" json:"user,omitempty"`
+	Server         string   `yaml:"recent-server,omitempty" json:"recent-server,omitempty"`
+	Servers        []string `yaml:"servers,flow" json:"servers"`
+	ControllerUUID string   `yaml:"uuid" json:"uuid"`
+	APIEndpoints   []string `yaml:"api-endpoints,flow" json:"api-endpoints"`
+	CACert         string   `yaml:"ca-cert" json:"ca-cert"`
 }
 
 // convertControllerDetails takes a map of Controllers and
@@ -74,9 +78,13 @@ func (c *listControllersCommand) convertControllerDetails(storeControllers map[s
 		}
 
 		controllers[controllerName] = ControllerItem{
-			modelName,
-			userName,
-			serverName,
+			ModelName:      modelName,
+			User:           userName,
+			Server:         serverName,
+			Servers:        details.Servers,
+			APIEndpoints:   details.APIEndpoints,
+			ControllerUUID: details.ControllerUUID,
+			CACert:         details.CACert,
 		}
 	}
 	return controllers, errs

--- a/cmd/juju/controller/listmodels_test.go
+++ b/cmd/juju/controller/listmodels_test.go
@@ -90,7 +90,7 @@ func (s *ModelsSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *ModelsSuite) newCommand() cmd.Command {
-	return controller.NewModelsCommandForTest(s.api, s.api, s.store, s.creds)
+	return controller.NewListModelsCommandForTest(s.api, s.api, s.store, s.creds)
 }
 
 func (s *ModelsSuite) checkSuccess(c *gc.C, user string, args ...string) {


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/bugs/1551743

juju list-controllers --format yaml now displays all the details for the yaml file

As a drive by, rename models.go to listmodels.go. And rename env stuff to model stuff. No new code, just file rename and variable renames.

(Review request: http://reviews.vapour.ws/r/4037/)