### PR TITLE
apiserver/common: cleanup errors.go

### DIFF
--- a/apiserver/common/errors.go
+++ b/apiserver/common/errors.go
@@ -19,17 +19,8 @@ import (
 	"github.com/juju/juju/state"
 )
 
-type notSupportedError struct {
-	tag       names.Tag
-	operation string
-}
-
-func (e *notSupportedError) Error() string {
-	return fmt.Sprintf("entity %q does not support %s", e.tag, e.operation)
-}
-
 func NotSupportedError(tag names.Tag, operation string) error {
-	return &notSupportedError{tag, operation}
+	return errors.Errorf("entity %q does not support %s", tag, operation)
 }
 
 type noAddressSetError struct {
@@ -45,7 +36,7 @@ func NoAddressSetError(unitTag names.UnitTag, addressName string) error {
 	return &noAddressSetError{unitTag, addressName}
 }
 
-func IsNoAddressSetError(err error) bool {
+func isNoAddressSetError(err error) bool {
 	_, ok := err.(*noAddressSetError)
 	return ok
 }
@@ -62,7 +53,7 @@ func UnknownModelError(uuid string) error {
 	return &unknownModelError{uuid: uuid}
 }
 
-func IsUnknownModelError(err error) bool {
+func isUnknownModelError(err error) bool {
 	_, ok := err.(*unknownModelError)
 	return ok
 }
@@ -205,7 +196,7 @@ func ServerError(err error) *params.Error {
 		code = params.CodeNotAssigned
 	case state.IsHasAssignedUnitsError(err):
 		code = params.CodeHasAssignedUnits
-	case IsNoAddressSetError(err):
+	case isNoAddressSetError(err):
 		code = params.CodeNoAddressSet
 	case errors.IsNotProvisioned(err):
 		code = params.CodeNotProvisioned
@@ -213,7 +204,7 @@ func ServerError(err error) *params.Error {
 		code = params.CodeUpgradeInProgress
 	case state.IsHasAttachmentsError(err):
 		code = params.CodeMachineHasAttachedStorage
-	case IsUnknownModelError(err):
+	case isUnknownModelError(err):
 		code = params.CodeNotFound
 	case errors.IsNotSupported(err):
 		code = params.CodeNotSupported

--- a/apiserver/common/export_test.go
+++ b/apiserver/common/export_test.go
@@ -11,6 +11,7 @@ var (
 	EnvtoolsFindTools       = &envtoolsFindTools
 	SendMetrics             = &sendMetrics
 	MockableDestroyMachines = destroyMachines
+	IsUnknownModelError     = isUnknownModelError
 )
 
 type Patcher interface {


### PR DESCRIPTION
Lots of driveby cleanups

- remove unused types
- unexport various isError helpers that were only used internally

(Review request: http://reviews.vapour.ws/r/4040/)