### PR TITLE
Use HasLXDSupport to fix bug #1545046

### DIFF
--- a/container/factory/factory_test.go
+++ b/container/factory/factory_test.go
@@ -4,9 +4,6 @@
 package factory_test
 
 import (
-	"runtime"
-	"strings"
-
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -44,7 +41,7 @@ func (*factorySuite) TestNewContainerManager(c *gc.C) {
 		valid:         false,
 	}} {
 		/* LXD isn't available in go 1.2 */
-		if test.ContainerType == instance.LXD && !lxd.HasLXDSupport() {
+		if test.containerType == instance.LXD && !lxd.HasLXDSupport() {
 			continue
 		}
 

--- a/container/factory/factory_test.go
+++ b/container/factory/factory_test.go
@@ -44,7 +44,7 @@ func (*factorySuite) TestNewContainerManager(c *gc.C) {
 		valid:         false,
 	}} {
 		/* LXD isn't available in go 1.2 */
-		if lxd.HasLXDSupport() {
+		if !lxd.HasLXDSupport() {
 			continue
 		}
 

--- a/container/factory/factory_test.go
+++ b/container/factory/factory_test.go
@@ -44,7 +44,7 @@ func (*factorySuite) TestNewContainerManager(c *gc.C) {
 		valid:         false,
 	}} {
 		/* LXD isn't available in go 1.2 */
-		if !lxd.HasLXDSupport() {
+		if test.ContainerType == instance.LXD && !lxd.HasLXDSupport() {
 			continue
 		}
 

--- a/container/factory/factory_test.go
+++ b/container/factory/factory_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/juju/juju/container"
 	"github.com/juju/juju/container/factory"
+	"github.com/juju/juju/container/lxd"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/testing"
 )
@@ -43,7 +44,7 @@ func (*factorySuite) TestNewContainerManager(c *gc.C) {
 		valid:         false,
 	}} {
 		/* LXD isn't available in go 1.2 */
-		if test.containerType == instance.LXD && strings.HasPrefix(runtime.Version(), "go1.2") {
+		if lxd.HasLXDSupport() {
 			continue
 		}
 

--- a/container/lxd/lxd.go
+++ b/container/lxd/lxd.go
@@ -170,3 +170,9 @@ func (manager *containerManager) IsInitialized() bool {
 	manager.client, err = ConnectLocal(manager.name)
 	return err == nil
 }
+
+// HasLXDSupport returns false when this juju binary was not built with LXD
+// support (i.e. it was built on a golang version < 1.2
+func HasLXDSupport() bool {
+	return true
+}

--- a/container/lxd/lxd_go12.go
+++ b/container/lxd/lxd_go12.go
@@ -33,3 +33,7 @@ func NewContainerInitialiser(series string) container.Initialiser {
 	 */
 	return nil
 }
+
+func HasLXDSupport() bool {
+	return false
+}


### PR DESCRIPTION
This is just Tycho's patch, but fixed for typos. (we no longer need to import runtime packages, and the name of the attribute is not exported.)

(Review request: http://reviews.vapour.ws/r/4041/)