### PR TITLE
Finished extra-bindings support for uniter API and network-get

### DIFF
--- a/api/uniter/relationunit.go
+++ b/api/uniter/relationunit.go
@@ -167,8 +167,3 @@ func (ru *RelationUnit) ReadSettings(uname string) (params.Settings, error) {
 func (ru *RelationUnit) Watch() (watcher.RelationUnitsWatcher, error) {
 	return ru.st.WatchRelationUnits(ru.relation.tag, ru.unit.tag)
 }
-
-// NetworkConfig requests network config information from the server.
-func (ru *RelationUnit) NetworkConfig() ([]params.NetworkConfig, error) {
-	return nil, nil
-}

--- a/api/uniter/relationunit.go
+++ b/api/uniter/relationunit.go
@@ -170,27 +170,5 @@ func (ru *RelationUnit) Watch() (watcher.RelationUnitsWatcher, error) {
 
 // NetworkConfig requests network config information from the server.
 func (ru *RelationUnit) NetworkConfig() ([]params.NetworkConfig, error) {
-	var results params.UnitNetworkConfigResults
-	args := params.RelationUnits{
-		RelationUnits: []params.RelationUnit{{
-			Relation: ru.relation.tag.String(),
-			Unit:     ru.unit.tag.String(),
-		}},
-	}
-
-	err := ru.st.facade.FacadeCall("NetworkConfig", args, &results)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	if len(results.Results) != 1 {
-		return nil, fmt.Errorf("expected 1 result, got %d", len(results.Results))
-	}
-
-	result := results.Results[0]
-	if result.Error != nil {
-		return nil, result.Error
-	}
-
-	return result.Config, nil
+	return nil, nil
 }

--- a/api/uniter/relationunit_test.go
+++ b/api/uniter/relationunit_test.go
@@ -74,29 +74,6 @@ func (s *relationUnitSuite) TestRelation(c *gc.C) {
 	c.Assert(apiRel.String(), gc.Equals, "wordpress:db mysql:server")
 }
 
-func (s *relationUnitSuite) TestNetworkConfig(c *gc.C) {
-	// Set some provider addresses bound to both "public" and "internal"
-	// spaces.
-	addresses := []network.Address{
-		network.NewAddressOnSpace("public", "8.8.8.8"),
-		network.NewAddressOnSpace("", "8.8.4.4"),
-		network.NewAddressOnSpace("internal", "10.0.0.1"),
-		network.NewAddressOnSpace("internal", "10.0.0.2"),
-		network.NewAddressOnSpace("public", "fc00::1"),
-	}
-	err := s.wordpressMachine.SetProviderAddresses(addresses...)
-	c.Assert(err, jc.ErrorIsNil)
-
-	_, apiRelUnit := s.getRelationUnits(c)
-
-	netConfig, err := apiRelUnit.NetworkConfig()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(netConfig, jc.DeepEquals, []params.NetworkConfig{
-		{Address: "10.0.0.1"},
-		{Address: "10.0.0.2"},
-	})
-}
-
 func (s *relationUnitSuite) TestEndpoint(c *gc.C) {
 	_, apiRelUnit := s.getRelationUnits(c)
 

--- a/api/uniter/unit.go
+++ b/api/uniter/unit.go
@@ -709,3 +709,31 @@ func (u *Unit) AddStorage(constraints map[string][]params.StorageConstraints) er
 
 	return results.Combine()
 }
+
+// NetworkConfig requests network config information for the unit and the given
+// bindingName.
+func (u *Unit) NetworkConfig(bindingName string) ([]params.NetworkConfig, error) {
+	var results params.UnitNetworkConfigResults
+	args := params.UnitsNetworkConfig{
+		Args: []params.UnitNetworkConfig{{
+			BindingName: bindingName,
+			UnitTag:     u.tag.String(),
+		}},
+	}
+
+	err := u.st.facade.FacadeCall("NetworkConfig", args, &results)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	if len(results.Results) != 1 {
+		return nil, fmt.Errorf("expected 1 result, got %d", len(results.Results))
+	}
+
+	result := results.Results[0]
+	if result.Error != nil {
+		return nil, result.Error
+	}
+
+	return result.Config, nil
+}

--- a/api/uniter/unit_test.go
+++ b/api/uniter/unit_test.go
@@ -302,6 +302,42 @@ func (s *unitSuite) TestPrivateAddress(c *gc.C) {
 	c.Assert(address, gc.Equals, "1.2.3.4")
 }
 
+func (s *unitSuite) TestNetworkConfig(c *gc.C) {
+	// Set some provider addresses bound to both "public" and "internal"
+	// spaces.
+	addresses := []network.Address{
+		network.NewAddressOnSpace("public", "8.8.8.8"),
+		network.NewAddressOnSpace("", "8.8.4.4"),
+		network.NewAddressOnSpace("internal", "10.0.0.1"),
+		network.NewAddressOnSpace("internal", "10.0.0.2"),
+		network.NewAddressOnSpace("public", "fc00::1"),
+	}
+	err := s.wordpressMachine.SetProviderAddresses(addresses...)
+	c.Assert(err, jc.ErrorIsNil)
+
+	netConfig, err := s.apiUnit.NetworkConfig("db") // relation name, bound to "internal"
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(netConfig, jc.DeepEquals, []params.NetworkConfig{
+		{Address: "10.0.0.1"},
+		{Address: "10.0.0.2"},
+	})
+
+	netConfig, err = s.apiUnit.NetworkConfig("admin-api") // extra-binding name, bound to "public"
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(netConfig, jc.DeepEquals, []params.NetworkConfig{
+		{Address: "8.8.8.8"},
+		{Address: "fc00::1"},
+	})
+
+	netConfig, err = s.apiUnit.NetworkConfig("unknown")
+	c.Assert(err, gc.ErrorMatches, `binding name "unknown" not defined by the unit's charm`)
+	c.Assert(netConfig, gc.IsNil)
+
+	netConfig, err = s.apiUnit.NetworkConfig("")
+	c.Assert(err, gc.ErrorMatches, "binding name cannot be empty")
+	c.Assert(netConfig, gc.IsNil)
+}
+
 func (s *unitSuite) TestAvailabilityZone(c *gc.C) {
 	uniter.PatchUnitResponse(s, s.apiUnit, "AvailabilityZone",
 		func(result interface{}) error {

--- a/api/uniter/uniter_test.go
+++ b/api/uniter/uniter_test.go
@@ -45,9 +45,11 @@ func (s *uniterSuite) setUpTest(c *gc.C, addController bool) {
 		s.controllerMachine = testing.AddControllerMachine(c, s.State)
 	}
 
-	// Bind wordpress:db to space "internal"
+	// Bind "db" relation of wordpress to space "internal",
+	// and the "admin-api" extra-binding to space "public".
 	bindings := map[string]string{
-		"db": "internal",
+		"db":        "internal",
+		"admin-api": "public",
 	}
 	_, err := s.State.AddSpace("internal", "", nil, false)
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/params/network.go
+++ b/apiserver/params/network.go
@@ -366,6 +366,18 @@ func NetworkHostsPorts(hpm [][]HostPort) [][]network.HostPort {
 	return nhpm
 }
 
+// UnitsNetworkConfig holds the parameters for calling Uniter.NetworkConfig()
+// API.
+type UnitsNetworkConfig struct {
+	Args []UnitNetworkConfig `json:"Args"`
+}
+
+// UnitNetworkConfig holds a unit tag and an endpoint binding name.
+type UnitNetworkConfig struct {
+	UnitTag     string `json:"UnitTag"`
+	BindingName string `json:"BindingName"`
+}
+
 // MachineAddresses holds an machine tag and addresses.
 type MachineAddresses struct {
 	Tag       string    `json:"Tag"`

--- a/apiserver/uniter/uniter.go
+++ b/apiserver/uniter/uniter.go
@@ -1735,8 +1735,9 @@ func (u *UniterAPIV3) getOneNetworkConfig(canAccess common.AuthFunc, unitTagArg,
 			Address: privateAddress.Value,
 		})
 		return results, nil
+	} else {
+		logger.Debugf("endpoint %q is explicitly bound to space %q", bindingName, boundSpace)
 	}
-	logger.Debugf("endpoint %q is explicitly bound to space %q", bindingName, boundSpace)
 
 	// TODO(dimitern): Use NetworkInterfaces() instead later, this is just for
 	// the PoC to enable minimal network-get implementation returning just the

--- a/apiserver/uniter/uniter_test.go
+++ b/apiserver/uniter/uniter_test.go
@@ -2375,15 +2375,16 @@ func (s *uniterNetworkConfigSuite) SetUpTest(c *gc.C) {
 
 	factory := jujuFactory.NewFactory(s.base.State)
 	s.base.wpCharm = factory.MakeCharm(c, &jujuFactory.CharmParams{
-		Name: "wordpress",
-		URL:  "cs:quantal/wordpress-3",
+		Name: "wordpress-extra-bindings",
+		URL:  "cs:quantal/wordpress-extra-bindings-4",
 	})
 	s.base.wordpress, err = s.base.State.AddService(state.AddServiceArgs{
 		Name:  "wordpress",
 		Charm: s.base.wpCharm,
 		Owner: s.base.AdminUserTag(c).String(),
 		EndpointBindings: map[string]string{
-			"db": "internal",
+			"db":        "internal", // relation name
+			"admin-api": "public",   // extra-binding name
 		},
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -2446,13 +2447,14 @@ func (s *uniterNetworkConfigSuite) setupUniterAPIForUnit(c *gc.C, givenUnit *sta
 }
 
 func (s *uniterNetworkConfigSuite) TestNetworkConfigPermissions(c *gc.C) {
-	rel := s.addRelationAndAssertInScope(c)
+	s.addRelationAndAssertInScope(c)
 
-	args := params.RelationUnits{RelationUnits: []params.RelationUnit{
-		{Relation: "relation-42", Unit: "unit-foo-0"},
-		{Relation: rel.Tag().String(), Unit: "invalid"},
-		{Relation: rel.Tag().String(), Unit: "unit-mysql-0"},
-		{Relation: "relation-42", Unit: s.base.wordpressUnit.Tag().String()},
+	args := params.UnitsNetworkConfig{Args: []params.UnitNetworkConfig{
+		{BindingName: "foo", UnitTag: "unit-foo-0"},
+		{BindingName: "db-client", UnitTag: "invalid"},
+		{BindingName: "juju-info", UnitTag: "unit-mysql-0"},
+		{BindingName: "", UnitTag: s.base.wordpressUnit.Tag().String()},
+		{BindingName: "unknown", UnitTag: s.base.wordpressUnit.Tag().String()},
 	}}
 
 	result, err := s.base.uniter.NetworkConfig(args)
@@ -2462,12 +2464,13 @@ func (s *uniterNetworkConfigSuite) TestNetworkConfigPermissions(c *gc.C) {
 			{Error: apiservertesting.ErrUnauthorized},
 			{Error: apiservertesting.ServerError(`"invalid" is not a valid tag`)},
 			{Error: apiservertesting.ErrUnauthorized},
-			{Error: apiservertesting.ServerError(`"relation-42" is not a valid relation tag`)},
+			{Error: apiservertesting.ServerError(`binding name cannot be empty`)},
+			{Error: apiservertesting.ServerError(`binding name "unknown" not defined by the unit's charm`)},
 		},
 	})
 }
 
-func (s *uniterNetworkConfigSuite) addRelationAndAssertInScope(c *gc.C) *state.Relation {
+func (s *uniterNetworkConfigSuite) addRelationAndAssertInScope(c *gc.C) {
 	// Add a relation between wordpress and mysql and enter scope with
 	// mysqlUnit.
 	rel := s.base.addRelation(c, "wordpress", "mysql")
@@ -2476,36 +2479,42 @@ func (s *uniterNetworkConfigSuite) addRelationAndAssertInScope(c *gc.C) *state.R
 	err = wpRelUnit.EnterScope(nil)
 	c.Assert(err, jc.ErrorIsNil)
 	s.base.assertInScope(c, wpRelUnit, true)
-	return rel
 }
 
 func (s *uniterNetworkConfigSuite) TestNetworkConfigForExplicitlyBoundEndpoint(c *gc.C) {
-	rel := s.addRelationAndAssertInScope(c)
+	s.addRelationAndAssertInScope(c)
 
-	args := params.RelationUnits{RelationUnits: []params.RelationUnit{
-		{Relation: rel.Tag().String(), Unit: s.base.wordpressUnit.Tag().String()},
+	args := params.UnitsNetworkConfig{Args: []params.UnitNetworkConfig{
+		{BindingName: "db", UnitTag: s.base.wordpressUnit.Tag().String()},
+		{BindingName: "admin-api", UnitTag: s.base.wordpressUnit.Tag().String()},
 	}}
 
 	// For the relation "wordpress:db mysql:server" we expect to see only
 	// addresses bound to the "internal" space, where the "db" endpoint itself
 	// is bound to.
-	expectedConfig := []params.NetworkConfig{{
+	expectedConfigWithRelationName := []params.NetworkConfig{{
 		Address: "10.0.0.1",
 	}, {
 		Address: "10.0.0.2",
+	}}
+	// For the "admin-api" extra-binding we expect to see only addresses from
+	// the "public" space.
+	expectedConfigWithExtraBindingName := []params.NetworkConfig{{
+		Address: "8.8.8.8",
 	}}
 
 	result, err := s.base.uniter.NetworkConfig(args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, params.UnitNetworkConfigResults{
 		Results: []params.UnitNetworkConfigResult{
-			{Config: expectedConfig},
+			{Config: expectedConfigWithRelationName},
+			{Config: expectedConfigWithExtraBindingName},
 		},
 	})
 }
 
 func (s *uniterNetworkConfigSuite) TestNetworkConfigForImplicitlyBoundEndpoint(c *gc.C) {
-	// Since wordpressUnit as explicit binding for "db", switch the API to
+	// Since wordpressUnit has explicit binding for "db", switch the API to
 	// mysqlUnit and check "mysql:server" uses the machine preferred private
 	// address.
 	s.setupUniterAPIForUnit(c, s.base.mysqlUnit)
@@ -2516,8 +2525,8 @@ func (s *uniterNetworkConfigSuite) TestNetworkConfigForImplicitlyBoundEndpoint(c
 	c.Assert(err, jc.ErrorIsNil)
 	s.base.assertInScope(c, mysqlRelUnit, true)
 
-	args := params.RelationUnits{RelationUnits: []params.RelationUnit{
-		{Relation: rel.Tag().String(), Unit: s.base.mysqlUnit.Tag().String()},
+	args := params.UnitsNetworkConfig{Args: []params.UnitNetworkConfig{
+		{BindingName: "server", UnitTag: s.base.mysqlUnit.Tag().String()},
 	}}
 
 	privateAddress, err := s.base.machine1.PrivateAddress()

--- a/juju/deploy_test.go
+++ b/juju/deploy_test.go
@@ -102,7 +102,7 @@ func (s *DeployLocalSuite) TestDeploySeries(c *gc.C) {
 }
 
 func (s *DeployLocalSuite) TestDeployWithImplicitBindings(c *gc.C) {
-	wordpressCharm := s.addWordpressCharm(c)
+	wordpressCharm := s.addWordpressCharmWithExtraBindings(c)
 
 	service, err := juju.DeployService(s.State,
 		juju.DeployServiceParams{
@@ -113,11 +113,17 @@ func (s *DeployLocalSuite) TestDeployWithImplicitBindings(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.assertBindings(c, service, map[string]string{
+		// relation names
 		"url":             "",
 		"logging-dir":     "",
 		"monitoring-port": "",
 		"db":              "",
 		"cache":           "",
+		"cluster":         "",
+		// extra-bindings names
+		"db-client": "",
+		"admin-api": "",
+		"foo-bar":   "",
 	})
 }
 
@@ -162,11 +168,16 @@ func (s *DeployLocalSuite) TestDeployWithSomeSpecifiedBindings(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.assertBindings(c, service, map[string]string{
+		// relation names
 		"url":             "public",
 		"logging-dir":     "public",
 		"monitoring-port": "public",
 		"db":              "db",
 		"cache":           "public",
+		// extra-bindings names
+		"db-client": "public",
+		"admin-api": "public",
+		"foo-bar":   "public",
 	})
 }
 

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -519,11 +519,16 @@ func (s *upgradesSuite) testAddDefaultEndpointBindingsToServices(c *gc.C, runTwi
 	services := s.setupAddDefaultEndpointBindingsToServices(c)
 	initialBindings := s.getServicesBindings(c, services)
 	wpAllDefaults := map[string]string{
+		// relation names
 		"url":             "",
 		"logging-dir":     "",
 		"monitoring-port": "",
 		"db":              "",
 		"cache":           "",
+		// extra-bindings
+		"db-client": "",
+		"admin-api": "",
+		"foo-bar":   "",
 	}
 	msAllDefaults := map[string]string{
 		"server": "",
@@ -537,6 +542,9 @@ func (s *upgradesSuite) testAddDefaultEndpointBindingsToServices(c *gc.C, runTwi
 			"monitoring-port": "",
 			"db":              "db",
 			"cache":           "",
+			"db-client":       "",
+			"admin-api":       "",
+			"foo-bar":         "",
 		},
 
 		"ms-no-bindings":      msAllDefaults,

--- a/testcharms/charm-repo/quantal/wordpress/metadata.yaml
+++ b/testcharms/charm-repo/quantal/wordpress/metadata.yaml
@@ -21,3 +21,7 @@ requires:
     interface: varnish
     limit: 2
     optional: true
+extra-bindings:
+    db-client:
+    admin-api:
+    foo-bar:

--- a/worker/uniter/runner/context/context.go
+++ b/worker/uniter/runner/context/context.go
@@ -785,3 +785,8 @@ func (ctx *HookContext) killCharmHook() error {
 		tick = ctx.clock.After(100 * time.Millisecond)
 	}
 }
+
+// NetworkConfig returns the network config for the given bindingName.
+func (ctx *HookContext) NetworkConfig(bindingName string) ([]params.NetworkConfig, error) {
+	return ctx.unit.NetworkConfig(bindingName)
+}

--- a/worker/uniter/runner/context/context_test.go
+++ b/worker/uniter/runner/context/context_test.go
@@ -88,6 +88,16 @@ func (s *InterfaceSuite) TestAvailabilityZone(c *gc.C) {
 	c.Check(zone, gc.Equals, "a-zone")
 }
 
+func (s *InterfaceSuite) TestUnitNetworkConfig(c *gc.C) {
+	// Only the error case is tested to ensure end-to-end integration, the rest
+	// of the cases are tested separately for network-get, api/uniter, and
+	// apiserver/uniter, respectively.
+	ctx := s.GetContext(c, -1, "")
+	netConfig, err := ctx.NetworkConfig("unknown")
+	c.Check(err, gc.ErrorMatches, `binding name "unknown" not defined by the unit's charm`)
+	c.Check(netConfig, gc.IsNil)
+}
+
 func (s *InterfaceSuite) TestUnitStatus(c *gc.C) {
 	ctx := s.GetContext(c, -1, "")
 	defer context.PatchCachedStatus(ctx.(runner.Context), "maintenance", "working", map[string]interface{}{"hello": "world"})()

--- a/worker/uniter/runner/context/relation.go
+++ b/worker/uniter/runner/context/relation.go
@@ -78,8 +78,3 @@ func (ctx *ContextRelation) WriteSettings() (err error) {
 	}
 	return
 }
-
-// NetworkConfig returns the network config for the relation.
-func (ctx *ContextRelation) NetworkConfig() ([]params.NetworkConfig, error) {
-	return ctx.ru.NetworkConfig()
-}

--- a/worker/uniter/runner/jujuc/context.go
+++ b/worker/uniter/runner/jujuc/context.go
@@ -157,6 +157,15 @@ type ContextNetworking interface {
 	// unit on its assigned machine. The result is sorted first by
 	// protocol, then by number.
 	OpenedPorts() []network.PortRange
+
+	// NetworkConfig returns the network configuration for the unit and the
+	// given bindingName.
+	//
+	// TODO(dimitern): Currently, only the Address is populated, add the
+	// rest later.
+	//
+	// LKK Card: https://canonical.leankit.com/Boards/View/101652562/119258804
+	NetworkConfig(bindingName string) ([]params.NetworkConfig, error)
 }
 
 // ContextLeadership is the part of a hook context related to the
@@ -260,14 +269,6 @@ type ContextRelation interface {
 
 	// ReadSettings returns the settings of any remote unit in the relation.
 	ReadSettings(unit string) (params.Settings, error)
-
-	// NetworkConfig returns the network configuration for the relation.
-	//
-	// TODO(dimitern): Currently, only the Address is populated, add the
-	// rest later.
-	//
-	// LKK Card: https://canonical.leankit.com/Boards/View/101652562/119258804
-	NetworkConfig() ([]params.NetworkConfig, error)
 }
 
 // ContextStorageAttachment expresses the capabilities of a hook with

--- a/worker/uniter/runner/jujuc/network-get.go
+++ b/worker/uniter/runner/jujuc/network-get.go
@@ -16,31 +16,24 @@ type NetworkGetCommand struct {
 	cmd.CommandBase
 	ctx Context
 
-	RelationId      int
-	relationIdProxy gnuflag.Value
-	primaryAddress  bool
+	bindingName    string
+	primaryAddress bool
 
 	out cmd.Output
 }
 
 func NewNetworkGetCommand(ctx Context) (cmd.Command, error) {
-	var err error
 	cmd := &NetworkGetCommand{ctx: ctx}
-	cmd.relationIdProxy, err = newRelationIdValue(ctx, &cmd.RelationId)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
 	return cmd, nil
 }
 
 // Info is part of the cmd.Command interface.
 func (c *NetworkGetCommand) Info() *cmd.Info {
-	args := "--primary-address"
+	args := "<binding-name> --primary-address"
 	doc := `
-network-get returns the network config for a relation. The only supported
-flag for now is --primary-address, which is required and returns the IP
-address the local unit should advertise as its endpoint to its peers.
+network-get returns the network config for a given binding name. The only
+supported flag for now is --primary-address, which is required and returns
+the IP address the local unit should advertise as its endpoint to its peers.
 `
 	return &cmd.Info{
 		Name:    "network-get",
@@ -53,41 +46,39 @@ address the local unit should advertise as its endpoint to its peers.
 // SetFlags is part of the cmd.Command interface.
 func (c *NetworkGetCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.out.AddFlags(f, "smart", cmd.DefaultFormatters)
-	f.Var(c.relationIdProxy, "r", "specify a relation by id")
-	f.Var(c.relationIdProxy, "relation", "")
-	f.BoolVar(&c.primaryAddress, "primary-address", false, "get the primary address for the relation")
+	f.BoolVar(&c.primaryAddress, "primary-address", false, "get the primary address for the binding")
 }
 
 // Init is part of the cmd.Command interface.
 func (c *NetworkGetCommand) Init(args []string) error {
 
-	if c.RelationId == -1 {
-		return fmt.Errorf("no relation id specified")
+	if len(args) < 1 {
+		return errors.New("no arguments specified")
+	}
+	c.bindingName = args[0]
+	if c.bindingName == "" {
+		return fmt.Errorf("no binding name specified")
 	}
 
 	if !c.primaryAddress {
 		return fmt.Errorf("--primary-address is currently required")
 	}
 
-	return cmd.CheckEmpty(args)
+	return cmd.CheckEmpty(args[1:])
 }
 
 func (c *NetworkGetCommand) Run(ctx *cmd.Context) error {
-	r, err := c.ctx.Relation(c.RelationId)
+	netConfig, err := c.ctx.NetworkConfig(c.bindingName)
 	if err != nil {
 		return errors.Trace(err)
 	}
-
-	netconfig, err := r.NetworkConfig()
-	if err != nil {
-		return err
-	}
-	if len(netconfig) < 1 {
-		return fmt.Errorf("no network config available")
+	if len(netConfig) < 1 {
+		return fmt.Errorf("no network config found for binding %q", c.bindingName)
 	}
 
 	if c.primaryAddress {
-		return c.out.Write(ctx, netconfig[0].Address)
+		return c.out.Write(ctx, netConfig[0].Address)
 	}
-	return c.out.Write(ctx, nil)
+
+	return nil // never reached as --primary-address is required.
 }

--- a/worker/uniter/runner/jujuc/network-get_test.go
+++ b/worker/uniter/runner/jujuc/network-get_test.go
@@ -13,73 +13,84 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
-	jujuctesting "github.com/juju/juju/worker/uniter/runner/jujuc/testing"
 )
 
 type NetworkGetSuite struct {
-	relationSuite
+	ContextSuite
 }
 
 var _ = gc.Suite(&NetworkGetSuite{})
 
-func (s *NetworkGetSuite) newHookContext(relid int) (jujuc.Context, *relationInfo) {
-	netConfig := []params.NetworkConfig{
-		{Address: "8.8.8.8"},
-		{Address: "10.0.0.1"},
-	}
+func (s *NetworkGetSuite) createCommand(c *gc.C) cmd.Command {
+	hctx := s.GetHookContext(c, -1, "")
 
-	hctx, info := s.relationSuite.newHookContext(relid, "remote")
-	info.rels[0].Units["u/0"]["private-address"] = "foo: bar\n"
-	info.rels[1].SetRelated("m/0", jujuctesting.Settings{"pew": "pew\npew\n"}, netConfig)
-	info.rels[1].SetRelated("u/1", jujuctesting.Settings{"value": "12345"}, netConfig)
-	return hctx, info
+	presetBindings := make(map[string][]params.NetworkConfig)
+	presetBindings["known-relation"] = []params.NetworkConfig{
+		{Address: "10.10.0.23"},
+		{Address: "192.168.1.111"},
+	}
+	presetBindings["known-extra"] = []params.NetworkConfig{
+		{Address: "10.20.1.42"},
+		{Address: "fc00::1/64"},
+	}
+	presetBindings["valid-no-config"] = nil
+	// Simulate known but unspecified bindings.
+	presetBindings["known-unbound"] = []params.NetworkConfig{
+		{Address: "10.33.1.8"}, // Simulate preferred private address will be used for these.
+	}
+	hctx.info.NetworkInterface.BindingsToNetworkConfigs = presetBindings
+
+	com, err := jujuc.NewCommand(hctx, cmdString("network-get"))
+	c.Assert(err, jc.ErrorIsNil)
+	return com
 }
 
 func (s *NetworkGetSuite) TestNetworkGet(c *gc.C) {
 	for i, t := range []struct {
 		summary  string
-		relid    int
 		args     []string
 		code     int
 		out      string
 		checkctx func(*gc.C, *cmd.Context)
 	}{{
-		summary: "no default relation",
-		relid:   -1,
+		summary: "no arguments",
 		code:    2,
-		out:     `no relation id specified`,
+		out:     `no arguments specified`,
 	}, {
-		summary: "explicit relation, not known",
-		relid:   -1,
+		summary: "empty binding name specified",
 		code:    2,
-		args:    []string{"-r", "burble:123"},
-		out:     `invalid value "burble:123" for flag -r: relation not found`,
+		args:    []string{""},
+		out:     `no binding name specified`,
 	}, {
-		summary: "default relation, no --primary-address given",
-		relid:   1,
+		summary: "binding name given, no --primary-address given",
 		code:    2,
+		args:    []string{"foo"},
 		out:     `--primary-address is currently required`,
 	}, {
-		summary: "explicit relation, no --primary-address given",
-		relid:   -1,
-		code:    2,
-		args:    []string{"-r", "burble:1"},
-		out:     `--primary-address is currently required`,
+		summary: "unknown binding given, with --primary-address",
+		args:    []string{"unknown", "--primary-address"},
+		code:    1,
+		out:     "insert server error for unknown binding here",
 	}, {
-		summary: "explicit relation with --primary-address",
-		relid:   1,
-		args:    []string{"-r", "burble:1", "--primary-address"},
-		out:     "8.8.8.8",
+		summary: "valid arguments, API server returns no config",
+		args:    []string{"valid-no-config", "--primary-address"},
+		code:    1,
+		out:     `no network config found for binding "valid-no-config"`,
 	}, {
-		summary: "default relation with --primary-address",
-		relid:   1,
-		args:    []string{"--primary-address"},
-		out:     "8.8.8.8",
+		summary: "explicitly bound, extra-binding name given with --primary-address",
+		args:    []string{"known-extra", "--primary-address"},
+		out:     "10.20.1.42",
+	}, {
+		summary: "explicitly bound relation name given with --primary-address",
+		args:    []string{"known-relation", "--primary-address"},
+		out:     "10.10.0.23",
+	}, {
+		summary: "implicitly bound binding name given with --primary-address",
+		args:    []string{"known-unbound", "--primary-address"},
+		out:     "10.33.1.8", // preferred private address used for unspecified bindings.
 	}} {
 		c.Logf("test %d: %s", i, t.summary)
-		hctx, _ := s.newHookContext(t.relid)
-		com, err := jujuc.NewCommand(hctx, cmdString("network-get"))
-		c.Assert(err, jc.ErrorIsNil)
+		com := s.createCommand(c)
 		ctx := testing.Context(c)
 		code := cmd.Main(com, ctx, t.args)
 		c.Check(code, gc.Equals, t.code)
@@ -101,7 +112,7 @@ func (s *NetworkGetSuite) TestNetworkGet(c *gc.C) {
 func (s *NetworkGetSuite) TestHelp(c *gc.C) {
 
 	var helpTemplate = `
-usage: network-get [options] --primary-address
+usage: network-get [options] <binding-name> --primary-address
 purpose: get network config
 
 options:
@@ -110,38 +121,18 @@ options:
 -o, --output (= "")
     specify an output file
 --primary-address  (= false)
-    get the primary address for the relation
--r, --relation  (= %s)
-    specify a relation by id
+    get the primary address for the binding
 
-network-get returns the network config for a relation. The only supported
-flag for now is --primary-address, which is required and returns the IP
-address the local unit should advertise as its endpoint to its peers.
+network-get returns the network config for a given binding name. The only
+supported flag for now is --primary-address, which is required and returns
+the IP address the local unit should advertise as its endpoint to its peers.
 `[1:]
 
-	for i, t := range []struct {
-		summary string
-		relid   int
-		usage   string
-		rel     string
-	}{{
-		summary: "no default relation",
-		relid:   -1,
-	}, {
-		summary: "default relation",
-		relid:   1,
-		rel:     "peer1:1",
-	}} {
-		c.Logf("test %d", i)
-		hctx, _ := s.newHookContext(t.relid)
-		com, err := jujuc.NewCommand(hctx, cmdString("network-get"))
-		c.Check(err, jc.ErrorIsNil)
-		ctx := testing.Context(c)
-		code := cmd.Main(com, ctx, []string{"--help"})
-		c.Check(code, gc.Equals, 0)
+	com := s.createCommand(c)
+	ctx := testing.Context(c)
+	code := cmd.Main(com, ctx, []string{"--help"})
+	c.Check(code, gc.Equals, 0)
 
-		expect := fmt.Sprintf(helpTemplate, t.rel)
-		c.Check(bufferString(ctx.Stdout), gc.Equals, expect)
-		c.Check(bufferString(ctx.Stderr), gc.Equals, "")
-	}
+	c.Check(bufferString(ctx.Stdout), gc.Equals, helpTemplate)
+	c.Check(bufferString(ctx.Stderr), gc.Equals, "")
 }

--- a/worker/uniter/runner/jujuc/relation-get_test.go
+++ b/worker/uniter/runner/jujuc/relation-get_test.go
@@ -27,8 +27,8 @@ var _ = gc.Suite(&RelationGetSuite{})
 func (s *RelationGetSuite) newHookContext(relid int, remote string) (jujuc.Context, *relationInfo) {
 	hctx, info := s.relationSuite.newHookContext(relid, remote)
 	info.rels[0].Units["u/0"]["private-address"] = "foo: bar\n"
-	info.rels[1].SetRelated("m/0", jujuctesting.Settings{"pew": "pew\npew\n"}, nil)
-	info.rels[1].SetRelated("u/1", jujuctesting.Settings{"value": "12345"}, nil)
+	info.rels[1].SetRelated("m/0", jujuctesting.Settings{"pew": "pew\npew\n"})
+	info.rels[1].SetRelated("u/1", jujuctesting.Settings{"value": "12345"})
 	return hctx, info
 }
 

--- a/worker/uniter/runner/jujuc/relation-ids_test.go
+++ b/worker/uniter/runner/jujuc/relation-ids_test.go
@@ -24,8 +24,8 @@ var _ = gc.Suite(&RelationIdsSuite{})
 func (s *RelationIdsSuite) newHookContext(relid int, remote string) (jujuc.Context, *relationInfo) {
 	hctx, info := s.relationSuite.newHookContext(-1, "")
 	info.reset()
-	info.addRelatedServices("x", 3, nil)
-	info.addRelatedServices("y", 1, nil)
+	info.addRelatedServices("x", 3)
+	info.addRelatedServices("y", 1)
 	if relid >= 0 {
 		info.SetAsRelationHook(relid, remote)
 	}

--- a/worker/uniter/runner/jujuc/relation-list_test.go
+++ b/worker/uniter/runner/jujuc/relation-list_test.go
@@ -111,8 +111,8 @@ func (s *RelationListSuite) TestRelationList(c *gc.C) {
 	for i, t := range relationListTests {
 		c.Logf("test %d: %s", i, t.summary)
 		hctx, info := s.newHookContext(t.relid, "")
-		info.setRelations(0, t.members0, nil)
-		info.setRelations(1, t.members1, nil)
+		info.setRelations(0, t.members0)
+		info.setRelations(1, t.members1)
 		c.Logf("%#v %#v", info.rels[t.relid], t.members1)
 		com, err := jujuc.NewCommand(hctx, cmdString("relation-list"))
 		c.Assert(err, jc.ErrorIsNil)

--- a/worker/uniter/runner/jujuc/relation_test.go
+++ b/worker/uniter/runner/jujuc/relation_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/juju/testing"
 
-	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
 	jujuctesting "github.com/juju/juju/worker/uniter/runner/jujuc/testing"
 )
@@ -23,8 +22,8 @@ func (s *relationSuite) newHookContext(relid int, remote string) (jujuc.Context,
 	settings := jujuctesting.Settings{
 		"private-address": "u-0.testing.invalid",
 	}
-	rInfo.setNextRelation("", s.Unit, settings, nil) // peer0
-	rInfo.setNextRelation("", s.Unit, settings, nil) // peer1
+	rInfo.setNextRelation("", s.Unit, settings) // peer0
+	rInfo.setNextRelation("", s.Unit, settings) // peer1
 	if relid >= 0 {
 		rInfo.SetAsRelationHook(relid, remote)
 	}
@@ -45,11 +44,7 @@ func (ri *relationInfo) reset() {
 	ri.rels = nil
 }
 
-func (ri *relationInfo) setNextRelation(
-	name, unit string,
-	settings jujuctesting.Settings,
-	netConfig []params.NetworkConfig,
-) int {
+func (ri *relationInfo) setNextRelation(name, unit string, settings jujuctesting.Settings) int {
 	if ri.rels == nil {
 		ri.rels = make(map[int]*jujuctesting.Relation)
 	}
@@ -60,25 +55,25 @@ func (ri *relationInfo) setNextRelation(
 	relation := ri.SetNewRelation(id, name, ri.stub)
 	if unit != "" {
 		relation.UnitName = unit
-		relation.SetRelated(unit, settings, netConfig)
+		relation.SetRelated(unit, settings)
 	}
 	ri.rels[id] = relation
 	return id
 }
 
-func (ri *relationInfo) addRelatedServices(relname string, count int, netConfig []params.NetworkConfig) {
+func (ri *relationInfo) addRelatedServices(relname string, count int) {
 	if ri.rels == nil {
 		ri.rels = make(map[int]*jujuctesting.Relation)
 	}
 	for i := 0; i < count; i++ {
-		ri.setNextRelation(relname, "", nil, netConfig)
+		ri.setNextRelation(relname, "", nil)
 	}
 }
 
-func (ri *relationInfo) setRelations(id int, members []string, netConfig []params.NetworkConfig) {
+func (ri *relationInfo) setRelations(id int, members []string) {
 	relation := ri.rels[id]
 	relation.Reset()
 	for _, name := range members {
-		relation.SetRelated(name, nil, netConfig)
+		relation.SetRelated(name, nil)
 	}
 }

--- a/worker/uniter/runner/jujuc/restricted.go
+++ b/worker/uniter/runner/jujuc/restricted.go
@@ -64,6 +64,11 @@ func (*RestrictedContext) ClosePorts(protocol string, fromPort, toPort int) erro
 // OpenedPorts implements jujuc.Context.
 func (*RestrictedContext) OpenedPorts() []network.PortRange { return nil }
 
+// NetworkConfig implements jujuc.Context.
+func (*RestrictedContext) NetworkConfig(bindingName string) ([]params.NetworkConfig, error) {
+	return nil, ErrRestrictedContext
+}
+
 // IsLeader implements jujuc.Context.
 func (*RestrictedContext) IsLeader() (bool, error) { return false, ErrRestrictedContext }
 

--- a/worker/uniter/runner/jujuc/testing/relation.go
+++ b/worker/uniter/runner/jujuc/testing/relation.go
@@ -23,8 +23,6 @@ type Relation struct {
 	Units map[string]Settings
 	// UnitName is data for jujuc.ContextRelation.
 	UnitName string
-	// NetworkConfig is data for jujuc.ContextRelation.
-	NetworkConfig []params.NetworkConfig
 }
 
 // Reset clears the Relation's settings.
@@ -33,12 +31,11 @@ func (r *Relation) Reset() {
 }
 
 // SetRelated adds the relation settings for the unit.
-func (r *Relation) SetRelated(name string, settings Settings, netConfig []params.NetworkConfig) {
+func (r *Relation) SetRelated(name string, settings Settings) {
 	if r.Units == nil {
 		r.Units = make(map[string]Settings)
 	}
 	r.Units[name] = settings
-	r.NetworkConfig = netConfig
 }
 
 // ContextRelation is a test double for jujuc.ContextRelation.
@@ -110,14 +107,4 @@ func (r *ContextRelation) ReadSettings(name string) (params.Settings, error) {
 		return nil, fmt.Errorf("unknown unit %s", name)
 	}
 	return s.Map(), nil
-}
-
-func (r *ContextRelation) NetworkConfig() ([]params.NetworkConfig, error) {
-	r.stub.AddCall("NetworkConfig")
-
-	if err := r.stub.NextErr(); err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	return r.info.NetworkConfig, nil
 }

--- a/worker/uniter/runner/jujuc/testing/relations.go
+++ b/worker/uniter/runner/jujuc/testing/relations.go
@@ -9,7 +9,6 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/testing"
 
-	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
 )
 
@@ -48,9 +47,9 @@ func (r *Relations) SetNewRelation(id int, name string, stub *testing.Stub) *Rel
 }
 
 // SetRelated adds the provided unit information to the relation.
-func (r *Relations) SetRelated(id int, unit string, settings Settings, netConfig []params.NetworkConfig) {
+func (r *Relations) SetRelated(id int, unit string, settings Settings) {
 	relation := r.Relations[id].(*ContextRelation).info
-	relation.SetRelated(unit, settings, netConfig)
+	relation.SetRelated(unit, settings)
 }
 
 // ContextRelations is a test double for jujuc.ContextRelations.


### PR DESCRIPTION
Uniter NetworkConfig() API changed to take unit tag and binding name.
The network-get hook command now takes a binding name as first positional argument,
instead of a -r <relation-id>. Updated a few of the used testing charms.

Depends on https://github.com/juju/juju/pull/4598

Live tested on MAAS 1.9.0 with both charm and bundle deployments.
Used the test charms and bundle available here: 
https://github.com/dimitern/testcharms

(Review request: http://reviews.vapour.ws/r/4042/)