### PR TITLE
Backport fuzzy time check to 1.25

### DIFF
--- a/state/lease/client.go
+++ b/state/lease/client.go
@@ -271,18 +271,18 @@ func (client *client) readEntries(collection mongo.Collection) (map[string]entry
 func (client *client) readSkews(collection mongo.Collection) (map[string]Skew, error) {
 
 	// Read the clock document, recording the time before and after completion.
-	readBefore := client.config.Clock.Now()
+	beginning := client.config.Clock.Now()
 	var clockDoc clockDoc
 	if err := collection.FindId(client.clockDocId()).One(&clockDoc); err != nil {
 		return nil, errors.Trace(err)
 	}
-	readAfter := client.config.Clock.Now()
+	end := client.config.Clock.Now()
 	if err := clockDoc.validate(); err != nil {
 		return nil, errors.Annotatef(err, "corrupt clock document")
 	}
 
 	// Create skew entries for each known writer...
-	skews, err := clockDoc.skews(readBefore, readAfter)
+	skews, err := clockDoc.skews(beginning, end)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/state/lease/schema.go
+++ b/state/lease/schema.go
@@ -213,9 +213,9 @@ func (doc clockDoc) skews(beginning, end time.Time) (map[string]Skew, error) {
 	skews := make(map[string]Skew)
 	for writer, written := range doc.Writers {
 		skews[writer] = Skew{
-			LastWrite:  toTime(written),
-			ReadAfter:  beginning,
-			ReadBefore: end,
+			LastWrite: toTime(written),
+			Beginning: beginning,
+			End:       end,
 		}
 	}
 	return skews, nil

--- a/state/lease/schema.go
+++ b/state/lease/schema.go
@@ -194,19 +194,28 @@ func (doc clockDoc) validate() error {
 // document, given that the document was read between the supplied local
 // times. It will return an error if the clock document is not valid, or
 // if the times don't make sense.
-func (doc clockDoc) skews(readAfter, readBefore time.Time) (map[string]Skew, error) {
+func (doc clockDoc) skews(beginning, end time.Time) (map[string]Skew, error) {
 	if err := doc.validate(); err != nil {
 		return nil, errors.Trace(err)
 	}
-	if readBefore.Before(readAfter) {
-		return nil, errors.New("end of read window preceded beginning")
+	// beginning is expected to be earlier than end.
+	// If it isn't, it could be ntp rolling the clock back slowly, so we add
+	// a little wiggle room here.
+	if end.Before(beginning) {
+		// A later time, subtract an earlier time will give a positive duration.
+		difference := beginning.Sub(end)
+		if difference > 10*time.Millisecond {
+			return nil, errors.Errorf("end of read window preceded beginning (%s)", difference)
+
+		}
+		beginning = end
 	}
 	skews := make(map[string]Skew)
 	for writer, written := range doc.Writers {
 		skews[writer] = Skew{
 			LastWrite:  toTime(written),
-			ReadAfter:  readAfter,
-			ReadBefore: readBefore,
+			ReadAfter:  beginning,
+			ReadBefore: end,
 		}
 	}
 	return skews, nil

--- a/state/lease/skew.go
+++ b/state/lease/skew.go
@@ -14,13 +14,13 @@ type Skew struct {
 	// by the skewed writer.
 	LastWrite time.Time
 
-	// ReadAfter should be the latest known local time before LastWrite
+	// Beginning should be the latest known local time before LastWrite
 	// was read.
-	ReadAfter time.Time
+	Beginning time.Time
 
-	// ReadBefore should be the earliest known local time after LastWrite
+	// End should be the earliest known local time after LastWrite
 	// was read.
-	ReadBefore time.Time
+	End time.Time
 }
 
 // Earliest returns the earliest local time after which we can be confident
@@ -30,7 +30,7 @@ func (skew Skew) Earliest(remote time.Time) (local time.Time) {
 		return remote
 	}
 	delta := remote.Sub(skew.LastWrite)
-	return skew.ReadAfter.Add(delta)
+	return skew.Beginning.Add(delta)
 }
 
 // Latest returns the latest local time after which we can be confident that
@@ -40,11 +40,11 @@ func (skew Skew) Latest(remote time.Time) (local time.Time) {
 		return remote
 	}
 	delta := remote.Sub(skew.LastWrite)
-	return skew.ReadBefore.Add(delta)
+	return skew.End.Add(delta)
 }
 
 // isZero lets us shortcut Earliest and Latest when the skew represents a
 // perfect unskewed clock (such as for a local writer).
 func (skew Skew) isZero() bool {
-	return skew.LastWrite.IsZero() && skew.ReadAfter.IsZero() && skew.ReadBefore.IsZero()
+	return skew.LastWrite.IsZero() && skew.Beginning.IsZero() && skew.End.IsZero()
 }

--- a/state/lease/skew_test.go
+++ b/state/lease/skew_test.go
@@ -40,9 +40,9 @@ func (s *SkewSuite) TestApparentPastWrite(c *gc.C) {
 	// Where T is the current local time:
 	// between T-3 and T-1, we read T-9 from the remote clock.
 	skew := lease.Skew{
-		LastWrite:  nineSecondsAgo,
-		ReadAfter:  threeSecondsAgo,
-		ReadBefore: oneSecondAgo,
+		LastWrite: nineSecondsAgo,
+		Beginning: threeSecondsAgo,
+		End:       oneSecondAgo,
 	}
 
 	// If the remote wrote a long time ago -- say, 20 minutes ago it thought it
@@ -71,9 +71,9 @@ func (s *SkewSuite) TestApparentFutureWrite(c *gc.C) {
 	// Where T is the current local time:
 	// between T-3 and T-1, we read T+9 from the remote clock.
 	skew := lease.Skew{
-		LastWrite:  nineSecondsLater,
-		ReadAfter:  threeSecondsAgo,
-		ReadBefore: oneSecondAgo,
+		LastWrite: nineSecondsLater,
+		Beginning: threeSecondsAgo,
+		End:       oneSecondAgo,
 	}
 
 	// If the remote wrote a long time ago -- say, 20 minutes ago it thought
@@ -103,9 +103,9 @@ func (s *SkewSuite) TestBracketedWrite(c *gc.C) {
 	// Where T is the current local time:
 	// between T-5 and T-1, we read T-2 from the remote clock.
 	skew := lease.Skew{
-		LastWrite:  twoSecondsAgo,
-		ReadAfter:  fiveSecondsAgo,
-		ReadBefore: oneSecondAgo,
+		LastWrite: twoSecondsAgo,
+		Beginning: fiveSecondsAgo,
+		End:       oneSecondAgo,
 	}
 
 	// If the remote wrote a long time ago -- say, 20 minutes ago it thought
@@ -141,9 +141,9 @@ func (s *SkewSuite) TestMixedTimezones(c *gc.C) {
 	// Where T is the current local time:
 	// between T-5 and T-1, we read T-2 from the remote clock.
 	skew := lease.Skew{
-		LastWrite:  twoSecondsAgo.In(here),
-		ReadAfter:  fiveSecondsAgo.In(there),
-		ReadBefore: oneSecondAgo.In(elsewhere),
+		LastWrite: twoSecondsAgo.In(here),
+		Beginning: fiveSecondsAgo.In(there),
+		End:       oneSecondAgo.In(elsewhere),
 	}
 
 	// If the remote wrote a long time ago -- say, 20 minutes ago it thought

--- a/state/lease/util_test.go
+++ b/state/lease/util_test.go
@@ -39,6 +39,7 @@ func (clock *Clock) Now() time.Time {
 // NewClock(now, step).
 func (clock *Clock) Reset(now time.Time, step time.Duration) {
 	clock.now = now
+	clock.step = step
 }
 
 // Advance advances the clock by the supplied time.


### PR DESCRIPTION
Cherry-pick of commits from:  https://github.com/juju/juju/pull/3941

Addresses failure seen in latest CI runs on 1.25:  http://reports.vapour.ws/releases/3688/job/local-deploy-trusty-amd64/attempt/2064

(Review request: http://reviews.vapour.ws/r/4046/)