### PR TITLE
MADE stateconverter worker

### DIFF
--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -25,6 +25,7 @@ import (
 	"github.com/juju/juju/worker/proxyupdater"
 	"github.com/juju/juju/worker/reboot"
 	"github.com/juju/juju/worker/resumer"
+	"github.com/juju/juju/worker/stateconverter"
 	"github.com/juju/juju/worker/storageprovisioner"
 	"github.com/juju/juju/worker/terminationworker"
 	"github.com/juju/juju/worker/upgrader"
@@ -85,6 +86,9 @@ type ManifoldsConfig struct {
 
 	// Clock is used by the storageprovisioner worker.
 	Clock clock.Clock
+
+	// Restart restarts the agent's service.
+	AgentRestart func() error
 }
 
 // Manifolds returns a set of co-configured manifolds covering the
@@ -297,6 +301,14 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 			APICallerName:     apiCallerName,
 			UpgradeWaiterName: upgradeWaiterName,
 		}),
+
+		stateconverterName: stateconverter.Manifold(stateconverter.ManifoldConfig{
+			PostUpgradeManifoldConfig: util.PostUpgradeManifoldConfig{
+				AgentName:         agentName,
+				APICallerName:     apiCallerName,
+				UpgradeWaiterName: upgradeWaiterName},
+			AgentRestart: config.AgentRestart,
+		}),
 	}
 }
 
@@ -325,4 +337,5 @@ const (
 	storageprovisionerName   = "storage-provisioner-machine"
 	resumerName              = "resumer"
 	identityFileWriterName   = "identity-file-writer"
+	stateconverterName       = "stateconverter"
 )

--- a/cmd/jujud/agent/machine/manifolds_test.go
+++ b/cmd/jujud/agent/machine/manifolds_test.go
@@ -61,6 +61,7 @@ func (s *ManifoldsSuite) TestManifoldNames(c *gc.C) {
 		"storage-provisioner-machine",
 		"resumer",
 		"identity-file-writer",
+		"stateconverter",
 	}
 	c.Assert(keys, jc.SameContents, expectedKeys)
 }

--- a/worker/stateconverter/manifold.go
+++ b/worker/stateconverter/manifold.go
@@ -1,0 +1,80 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package stateconverter
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/names"
+
+	"github.com/juju/juju/agent"
+	apiagent "github.com/juju/juju/api/agent"
+	"github.com/juju/juju/api/base"
+	apimachiner "github.com/juju/juju/api/machiner"
+	"github.com/juju/juju/state/multiwatcher"
+	"github.com/juju/juju/watcher"
+	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/conv2state"
+	"github.com/juju/juju/worker/dependency"
+	"github.com/juju/juju/worker/util"
+)
+
+// ManifoldConfig defines the names of the manifolds on which a Manifold will depend.
+type ManifoldConfig struct {
+	util.PostUpgradeManifoldConfig
+	AgentRestart func() error
+}
+
+// Manifold returns a dependency manifold that runs a stateconverter worker,
+// using the resource names defined in the supplied config.
+func Manifold(config ManifoldConfig) dependency.Manifold {
+
+	// newWorker trivially wraps NewWorker for use in a util.PostUpgradeManifold.
+	var newWorker = func(a agent.Agent, apiCaller base.APICaller) (worker.Worker, error) {
+		cfg := a.CurrentConfig()
+
+		// Grab the tag and ensure that it's for a machine.
+		tag, ok := cfg.Tag().(names.MachineTag)
+		if !ok {
+			return nil, errors.New("this manifold may only be used inside a machine agent")
+		}
+
+		isMM, err := isModelManager(apiCaller, tag)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		if isMM {
+			return nil, dependency.ErrMissing
+		}
+
+		handler := conv2state.New(apimachiner.NewState(apiCaller), tag, config.AgentRestart)
+		return NewWorker(handler)
+	}
+
+	return util.PostUpgradeManifold(config.PostUpgradeManifoldConfig, newWorker)
+}
+
+var NewWorker = func(handler watcher.NotifyHandler) (worker.Worker, error) {
+	// TODO(fwereade): this worker needs its own facade.
+	w, err := watcher.NewNotifyWorker(watcher.NotifyConfig{
+		Handler: handler,
+	})
+	if err != nil {
+		return nil, errors.Annotate(err, "cannot start controller promoter worker")
+	}
+	return w, nil
+}
+
+func isModelManager(apiCaller base.APICaller, tag names.Tag) (bool, error) {
+	entity, err := apiagent.NewState(apiCaller).Entity(tag)
+	if err != nil {
+		return false, err
+	}
+
+	for _, job := range entity.Jobs() {
+		if job == multiwatcher.JobManageModel {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/worker/stateconverter/manifold_test.go
+++ b/worker/stateconverter/manifold_test.go
@@ -1,0 +1,105 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package stateconverter_test
+
+import (
+	"github.com/juju/names"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/agent"
+	apitesting "github.com/juju/juju/api/base/testing"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/state/multiwatcher"
+	"github.com/juju/juju/watcher"
+	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/dependency"
+	"github.com/juju/juju/worker/stateconverter"
+	workertesting "github.com/juju/juju/worker/testing"
+)
+
+type ManifoldSuite struct {
+	testing.IsolationSuite
+	newCalled bool
+}
+
+var _ = gc.Suite(&ManifoldSuite{})
+
+func (s *ManifoldSuite) SetUpTest(c *gc.C) {
+	s.newCalled = false
+	s.PatchValue(&stateconverter.NewWorker,
+		func(handler watcher.NotifyHandler) (worker.Worker, error) {
+			s.newCalled = true
+			return nil, nil
+		},
+	)
+}
+
+func (s *ManifoldSuite) TestMachine(c *gc.C) {
+	config := fakeManifloldConfig()
+	_, err := workertesting.RunPostUpgradeManifold(
+		stateconverter.Manifold(config),
+		&fakeAgent{tag: names.NewMachineTag("42")},
+		mockAPICaller(multiwatcher.JobHostUnits))
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s.newCalled, jc.IsTrue)
+}
+
+func (s *ManifoldSuite) TestMachineModelManagerErrors(c *gc.C) {
+	config := fakeManifloldConfig()
+	_, err := workertesting.RunPostUpgradeManifold(
+		stateconverter.Manifold(config),
+		&fakeAgent{tag: names.NewMachineTag("42")},
+		mockAPICaller(multiwatcher.JobManageModel))
+	c.Assert(err, gc.Equals, dependency.ErrMissing)
+	c.Assert(s.newCalled, jc.IsFalse)
+}
+
+func (s *ManifoldSuite) TestNonMachineAgent(c *gc.C) {
+	config := fakeManifloldConfig()
+	_, err := workertesting.RunPostUpgradeManifold(
+		stateconverter.Manifold(config),
+		&fakeAgent{tag: names.NewUnitTag("foo/0")},
+		mockAPICaller(""))
+	c.Assert(err, gc.ErrorMatches, "this manifold may only be used inside a machine agent")
+	c.Assert(s.newCalled, jc.IsFalse)
+}
+
+func fakeManifloldConfig() stateconverter.ManifoldConfig {
+	return stateconverter.ManifoldConfig{
+		PostUpgradeManifoldConfig: workertesting.PostUpgradeManifoldTestConfig(),
+		AgentRestart:              func() error { return nil },
+	}
+}
+
+type fakeAgent struct {
+	agent.Agent
+	tag names.Tag
+}
+
+func (a *fakeAgent) CurrentConfig() agent.Config {
+	return &fakeConfig{tag: a.tag}
+}
+
+type fakeConfig struct {
+	agent.Config
+	tag names.Tag
+}
+
+func (c *fakeConfig) Tag() names.Tag {
+	return c.tag
+}
+
+func mockAPICaller(job multiwatcher.MachineJob) apitesting.APICallerFunc {
+	return apitesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		if res, ok := result.(*params.AgentGetEntitiesResults); ok {
+			res.Entities = []params.AgentGetEntitiesResult{
+				{Jobs: []multiwatcher.MachineJob{
+					job,
+				}}}
+		}
+		return nil
+	})
+}

--- a/worker/stateconverter/package_test.go
+++ b/worker/stateconverter/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package stateconverter_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}


### PR DESCRIPTION
Move the stateconverter worker from the machine agent runner to the dependency engine.

(Review request: http://reviews.vapour.ws/r/4049/)