### PR TITLE
apiserver: Add MigrationMaster and MigrationMasterWatcher facades

### DIFF
--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -49,6 +49,8 @@ var facadeVersions = map[string]int{
 	"MetricsManager":               1,
 	"MeterStatus":                  1,
 	"MetricsAdder":                 2,
+	"MigrationMaster":              1,
+	"MigrationMasterWatcher":       1,
 	"ModelManager":                 2,
 	"NotifyWatcher":                1,
 	"Pinger":                       1,

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -36,6 +36,7 @@ import (
 	_ "github.com/juju/juju/apiserver/metricsadder"
 	_ "github.com/juju/juju/apiserver/metricsdebug"
 	_ "github.com/juju/juju/apiserver/metricsmanager"
+	_ "github.com/juju/juju/apiserver/migrationmaster"
 	_ "github.com/juju/juju/apiserver/modelmanager"
 	_ "github.com/juju/juju/apiserver/provisioner"
 	_ "github.com/juju/juju/apiserver/proxyupdater"

--- a/apiserver/export_test.go
+++ b/apiserver/export_test.go
@@ -186,3 +186,17 @@ func TestingAboutToRestoreRoot(st *state.State) *aboutToRestoreRoot {
 func (srv *Server) Addr() *net.TCPAddr {
 	return srv.lis.Addr().(*net.TCPAddr) // cannot fail
 }
+
+// PatchMigrationGetter overrides the migrationGetter function to
+// support testing.
+func PatchMigrationGetter(p Patcher, st modelMigrationGetter) {
+	p.PatchValue(&migrationGetter, func(*state.State) modelMigrationGetter {
+		return st
+	})
+}
+
+// Patcher defines an interface that matches the PatchValue method on
+// CleanupSuite
+type Patcher interface {
+	PatchValue(ptr, value interface{})
+}

--- a/apiserver/migrationmaster/doc.go
+++ b/apiserver/migrationmaster/doc.go
@@ -1,0 +1,6 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// This package defines the API facade for use by the migration master
+// worker.
+package migrationmaster

--- a/apiserver/migrationmaster/export_test.go
+++ b/apiserver/migrationmaster/export_test.go
@@ -1,0 +1,16 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package migrationmaster
+
+import "github.com/juju/juju/state"
+
+func PatchState(p Patcher, st Backend) {
+	p.PatchValue(&getBackend, func(*state.State) Backend {
+		return st
+	})
+}
+
+type Patcher interface {
+	PatchValue(ptr, value interface{})
+}

--- a/apiserver/migrationmaster/migrationmaster.go
+++ b/apiserver/migrationmaster/migrationmaster.go
@@ -1,0 +1,54 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package migrationmaster
+
+import (
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/state"
+)
+
+func init() {
+	common.RegisterStandardFacade("MigrationMaster", 1, NewAPI)
+}
+
+// API implements the API required for the model migration
+// master worker.
+type API struct {
+	state      Backend
+	authorizer common.Authorizer
+	resources  *common.Resources
+}
+
+// NewAPI creates a new API server endpoint for the model migration
+// master worker.
+func NewAPI(
+	st *state.State,
+	resources *common.Resources,
+	authorizer common.Authorizer,
+) (*API, error) {
+	if !authorizer.AuthModelManager() {
+		return nil, common.ErrPerm
+	}
+	return &API{
+		state:      getBackend(st),
+		authorizer: authorizer,
+		resources:  resources,
+	}, nil
+}
+
+// Watch starts watching for an active migration for the model
+// associated with the API connection. The returned id should be used
+// with Next on the MigrationMasterWatcher endpoint to receive deltas.
+func (api *API) Watch() (params.NotifyWatchResult, error) {
+	w, err := api.state.WatchForModelMigration()
+	if err != nil {
+		return params.NotifyWatchResult{}, errors.Trace(err)
+	}
+	return params.NotifyWatchResult{
+		NotifyWatcherId: api.resources.Register(w),
+	}, nil
+}

--- a/apiserver/migrationmaster/migrationmaster_test.go
+++ b/apiserver/migrationmaster/migrationmaster_test.go
@@ -1,0 +1,90 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package migrationmaster_test
+
+import (
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/migrationmaster"
+	"github.com/juju/juju/apiserver/params"
+	apiservertesting "github.com/juju/juju/apiserver/testing"
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/testing"
+)
+
+// Ensure that Backend remains compatible with *state.State
+var _ migrationmaster.Backend = (*state.State)(nil)
+
+type Suite struct {
+	testing.BaseSuite
+
+	backend    *fakeBackend
+	resources  *common.Resources
+	authorizer apiservertesting.FakeAuthorizer
+}
+
+var _ = gc.Suite(&Suite{})
+
+func (s *Suite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+
+	s.backend = &fakeBackend{}
+	migrationmaster.PatchState(s, s.backend)
+
+	s.resources = common.NewResources()
+	s.AddCleanup(func(*gc.C) { s.resources.StopAll() })
+
+	s.authorizer = apiservertesting.FakeAuthorizer{
+		EnvironManager: true,
+	}
+}
+
+func (s *Suite) makeAPI() (*migrationmaster.API, error) {
+	return migrationmaster.NewAPI(nil, s.resources, s.authorizer)
+}
+
+func (s *Suite) mustMakeAPI(c *gc.C) *migrationmaster.API {
+	api, err := migrationmaster.NewAPI(nil, s.resources, s.authorizer)
+	c.Assert(err, jc.ErrorIsNil)
+	return api
+}
+
+func (s *Suite) TestWatch(c *gc.C) {
+	api := s.mustMakeAPI(c)
+
+	watchResult, err := api.Watch()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(watchResult.NotifyWatcherId, gc.Not(gc.Equals), "")
+}
+
+func (s *Suite) TestWatchError(c *gc.C) {
+	s.backend.watchError = errors.New("boom")
+	api := s.mustMakeAPI(c)
+
+	w, err := api.Watch()
+	c.Assert(w, gc.Equals, params.NotifyWatchResult{})
+	c.Assert(err, gc.ErrorMatches, "boom")
+}
+
+func (s *Suite) TestWatchNotEnvironManager(c *gc.C) {
+	s.authorizer.EnvironManager = false
+
+	api, err := s.makeAPI()
+	c.Assert(api, gc.IsNil)
+	c.Assert(err, gc.Equals, common.ErrPerm)
+}
+
+type fakeBackend struct {
+	watchError error
+}
+
+func (b *fakeBackend) WatchForModelMigration() (state.NotifyWatcher, error) {
+	if b.watchError != nil {
+		return nil, b.watchError
+	}
+	return apiservertesting.NewFakeNotifyWatcher(), nil
+}

--- a/apiserver/migrationmaster/package_test.go
+++ b/apiserver/migrationmaster/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package migrationmaster_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/apiserver/migrationmaster/state.go
+++ b/apiserver/migrationmaster/state.go
@@ -1,0 +1,16 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package migrationmaster
+
+import "github.com/juju/juju/state"
+
+var getBackend = func(st *state.State) Backend {
+	return st
+}
+
+// Backend defines the state functionality required by the
+// migrationmaster facade.
+type Backend interface {
+	WatchForModelMigration() (state.NotifyWatcher, error)
+}

--- a/apiserver/watcher.go
+++ b/apiserver/watcher.go
@@ -51,6 +51,10 @@ func init() {
 		"EntityWatcher", 2, newEntitiesWatcher,
 		reflect.TypeOf((*srvEntitiesWatcher)(nil)),
 	)
+	common.RegisterFacade(
+		"MigrationMasterWatcher", 1, newMigrationMasterWatcher,
+		reflect.TypeOf((*srvMigrationMasterWatcher)(nil)),
+	)
 }
 
 // NewAllModelWatcher returns a new API server endpoint for interacting
@@ -369,5 +373,77 @@ func (w *srvEntitiesWatcher) Next() (params.EntitiesWatchResult, error) {
 
 // Stop stops the watcher.
 func (w *srvEntitiesWatcher) Stop() error {
+	return w.resources.Stop(w.id)
+}
+
+func newMigrationMasterWatcher(
+	st *state.State,
+	resources *common.Resources,
+	auth common.Authorizer,
+	id string,
+) (interface{}, error) {
+	if !auth.AuthModelManager() {
+		return nil, common.ErrPerm
+	}
+	w, ok := resources.Get(id).(state.NotifyWatcher)
+	if !ok {
+		return nil, common.ErrUnknownWatcher
+	}
+	return &srvMigrationMasterWatcher{
+		watcher:   w,
+		id:        id,
+		resources: resources,
+		st:        migrationGetter(st),
+	}, nil
+}
+
+type srvMigrationMasterWatcher struct {
+	watcher   state.NotifyWatcher
+	id        string
+	resources *common.Resources
+	st        modelMigrationGetter
+}
+
+var migrationGetter = func(st *state.State) modelMigrationGetter {
+	return st
+}
+
+type modelMigrationGetter interface {
+	GetModelMigration() (state.ModelMigration, error)
+}
+
+// Next returns when a model migration is active for the associated
+// model. The details for the migration's target controller are
+// returned.
+func (w *srvMigrationMasterWatcher) Next() (params.ModelMigrationTargetInfo, error) {
+	empty := params.ModelMigrationTargetInfo{}
+
+	if _, ok := <-w.watcher.Changes(); !ok {
+		err := w.watcher.Err()
+		if err == nil {
+			err = common.ErrStoppedWatcher
+		}
+		return empty, err
+	}
+
+	mig, err := w.st.GetModelMigration()
+	if err != nil {
+		return empty, errors.Annotate(err, "migration lookup")
+	}
+	info, err := mig.TargetInfo()
+	if err != nil {
+		return empty, errors.Trace(err)
+	}
+	return params.ModelMigrationTargetInfo{
+		ControllerTag: info.ControllerTag.String(),
+		Addrs:         info.Addrs,
+		CACert:        info.CACert,
+		AuthTag:       info.AuthTag.String(),
+		Password:      info.Password,
+	}, nil
+}
+
+// Stop stops the watcher.
+func (w *srvMigrationMasterWatcher) Stop() error {
 	return w.resources.Stop(w.id)
 }

--- a/apiserver/watcher_test.go
+++ b/apiserver/watcher_test.go
@@ -8,9 +8,11 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/apiserver"
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
+	migration "github.com/juju/juju/core/modelmigration"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/testing"
 )
@@ -75,6 +77,37 @@ func (s *watcherSuite) TestFilesystemAttachmentsWatcher(c *gc.C) {
 	})
 }
 
+func (s *watcherSuite) TestMigrationMasterWatcher(c *gc.C) {
+	w := apiservertesting.NewFakeNotifyWatcher()
+	id := s.resources.Register(w)
+	s.authorizer.EnvironManager = true
+	apiserver.PatchMigrationGetter(s, new(fakeModelMigrationGetter))
+
+	w.C <- struct{}{}
+	facade := s.getFacade(c, "MigrationMasterWatcher", 1, id).(migrationMasterWatcher)
+	result, err := facade.Next()
+	c.Assert(err, jc.ErrorIsNil)
+	defer c.Check(facade.Stop(), jc.ErrorIsNil)
+
+	c.Assert(result, jc.DeepEquals, params.ModelMigrationTargetInfo{
+		ControllerTag: "model-uuid",
+		Addrs:         []string{"1.2.3.4:5555"},
+		CACert:        "trust me",
+		AuthTag:       "user-admin",
+		Password:      "sekret",
+	})
+}
+
+func (s *watcherSuite) TestMigrationNotModelManager(c *gc.C) {
+	id := s.resources.Register(apiservertesting.NewFakeNotifyWatcher())
+	s.authorizer.EnvironManager = false
+
+	factory, err := common.Facades.GetFactory("MigrationMasterWatcher", 1)
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = factory(s.st, s.resources, s.authorizer, id)
+	c.Assert(err, gc.Equals, common.ErrPerm)
+}
+
 type machineStorageIdsWatcher interface {
 	Next() (params.MachineStorageIdsWatchResult, error)
 }
@@ -86,4 +119,29 @@ type fakeStringsWatcher struct {
 
 func (w *fakeStringsWatcher) Changes() <-chan []string {
 	return w.ch
+}
+
+type fakeModelMigrationGetter struct{}
+
+func (g *fakeModelMigrationGetter) GetModelMigration() (state.ModelMigration, error) {
+	return new(fakeModelMigration), nil
+}
+
+type fakeModelMigration struct {
+	state.ModelMigration
+}
+
+func (m *fakeModelMigration) TargetInfo() (*migration.TargetInfo, error) {
+	return &migration.TargetInfo{
+		ControllerTag: names.NewModelTag("uuid"),
+		Addrs:         []string{"1.2.3.4:5555"},
+		CACert:        "trust me",
+		AuthTag:       names.NewUserTag("admin"),
+		Password:      "sekret",
+	}, nil
+}
+
+type migrationMasterWatcher interface {
+	Next() (params.ModelMigrationTargetInfo, error)
+	Stop() error
 }

--- a/state/modelmigration_test.go
+++ b/state/modelmigration_test.go
@@ -357,7 +357,7 @@ func (s *ModelMigrationSuite) TestREAPFAILEDCleanup(c *gc.C) {
 	s.assertMigrationCleanedUp(c, mig)
 }
 
-func (s *ModelMigrationSuite) assertMigrationCleanedUp(c *gc.C, mig *state.ModelMigration) {
+func (s *ModelMigrationSuite) assertMigrationCleanedUp(c *gc.C, mig state.ModelMigration) {
 	c.Assert(mig.PhaseChangedTime(), gc.Equals, s.clock.Now())
 	c.Assert(mig.EndTime(), gc.Equals, s.clock.Now())
 	assertMigrationNotActive(c, s.State2)
@@ -472,7 +472,7 @@ func (s *ModelMigrationSuite) createWatcher(c *gc.C, st *state.State) (
 	return w, statetesting.NewNotifyWatcherC(c, st, w)
 }
 
-func assertPhase(c *gc.C, mig *state.ModelMigration, phase migration.Phase) {
+func assertPhase(c *gc.C, mig state.ModelMigration, phase migration.Phase) {
 	actualPhase, err := mig.Phase()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(actualPhase, gc.Equals, phase)


### PR DESCRIPTION
These will be used by the migration master worker to watch for active migrations for a model.

To make testing easier state.ModelMigration was turned into an interface.

(Review request: http://reviews.vapour.ws/r/4050/)