### PR TITLE
state: unexport UpgradeInProgressError

### DIFF
--- a/apiserver/common/errors_test.go
+++ b/apiserver/common/errors_test.go
@@ -129,11 +129,6 @@ var errorTransformTests = []struct {
 	status:     http.StatusInternalServerError,
 	helperFunc: params.IsCodeTryAgain,
 }, {
-	err:        state.UpgradeInProgressError,
-	code:       params.CodeUpgradeInProgress,
-	status:     http.StatusInternalServerError,
-	helperFunc: params.IsCodeUpgradeInProgress,
-}, {
 	err:        leadership.ErrClaimDenied,
 	code:       params.CodeLeadershipClaimDenied,
 	status:     http.StatusInternalServerError,

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -55,6 +55,7 @@ var (
 	CombineMeterStatus     = combineMeterStatus
 	ServiceGlobalKey       = serviceGlobalKey
 	MergeBindings          = mergeBindings
+	UpgradeInProgressError = errUpgradeInProgress
 )
 
 type (

--- a/state/state.go
+++ b/state/state.go
@@ -29,6 +29,7 @@ import (
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
 
+	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/instance"
@@ -464,11 +465,12 @@ func (st *State) checkCanUpgrade(currentVersion, newVersion string) error {
 	return nil
 }
 
-var UpgradeInProgressError = errors.New("an upgrade is already in progress or the last upgrade did not complete")
+var errUpgradeInProgress = errors.New(params.CodeUpgradeInProgress)
 
-// IsUpgradeInProgressError returns true if the error given is UpgradeInProgressError.
+// IsUpgradeInProgressError returns true if the error is cause by an
+// upgrade in progress
 func IsUpgradeInProgressError(err error) bool {
-	return errors.Cause(err) == UpgradeInProgressError
+	return errors.Cause(err) == errUpgradeInProgress
 }
 
 // SetModelAgentVersion changes the agent version for the model to the
@@ -527,7 +529,7 @@ func (st *State) SetModelAgentVersion(newVersion version.Number) (err error) {
 		// return a more helpful error message in the case of an
 		// active upgradeInfo document being in place.
 		if upgrading, _ := st.IsUpgrading(); upgrading {
-			err = UpgradeInProgressError
+			err = errUpgradeInProgress
 		} else {
 			err = errors.Annotate(err, "cannot set agent version")
 		}

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -3875,9 +3875,7 @@ func (s *StateSuite) TestSetEnvironAgentFailsIfUpgrading(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = s.State.SetModelAgentVersion(nextVersion)
-	c.Assert(errors.Cause(err), gc.Equals, state.UpgradeInProgressError)
-	c.Assert(err, gc.ErrorMatches,
-		"an upgrade is already in progress or the last upgrade did not complete")
+	c.Assert(err, jc.Satisfies, state.IsUpgradeInProgressError)
 }
 
 func (s *StateSuite) TestSetEnvironAgentFailsReportsCorrectError(c *gc.C) {


### PR DESCRIPTION
There are too many ways for juju's API server to tell the client that it
is in upgrade state. Some come from state itself, others come from the
API server interpreting other errors from other sources.

This CL is part of a pair of changes that reduce the number of ways the
API server can say it is in upgrade state. Specifically other packages
can only inspect the error they get from state with the supplied helper
method, they cannot inspect it directly.

This CL is less than ideal is state depends on apiserver/params for the
CodeUpgradeInProgress constant. But this source dependency existed
before hand, so it's not the end of the world.

(Review request: http://reviews.vapour.ws/r/4051/)