### PR TITLE
Add interactive autoload credentials

### DIFF
--- a/cloud/credentials.go
+++ b/cloud/credentials.go
@@ -29,6 +29,10 @@ type CloudCredential struct {
 type Credential struct {
 	authType   AuthType
 	attributes map[string]string
+
+	// Label is optionally set to describe the credentials
+	// to a user.
+	Label string
 }
 
 // AuthType returns the authentication type.
@@ -60,13 +64,13 @@ func (c Credential) MarshalYAML() (interface{}, error) {
 // NewCredential returns a new, immutable, Credential with the supplied
 // auth-type and attributes.
 func NewCredential(authType AuthType, attributes map[string]string) Credential {
-	return Credential{authType, copyStringMap(attributes)}
+	return Credential{authType: authType, attributes: copyStringMap(attributes)}
 }
 
 // NewEmptyCredential returns a new Credential with the EmptyAuthType
 // auth-type.
 func NewEmptyCredential() Credential {
-	return Credential{EmptyAuthType, nil}
+	return Credential{authType: EmptyAuthType, attributes: nil}
 }
 
 // NewEmptyCloudCredential returns a new CloudCredential with an empty
@@ -98,7 +102,7 @@ func FinalizeCredential(
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return &Credential{credential.authType, attrs}, nil
+	return &Credential{authType: credential.authType, attributes: attrs}, nil
 }
 
 // Finalize finalizes the given credential attributes against the credential
@@ -260,7 +264,7 @@ func (c cloudCredentialValueChecker) Coerce(v interface{}, path []string) (inter
 	for k, v := range mapv {
 		attrs[k] = v.(string)
 	}
-	return Credential{AuthType(authType), attrs}, nil
+	return Credential{authType: AuthType(authType), attributes: attrs}, nil
 }
 
 // ParseCredentials parses the given yaml bytes into Credentials, but does

--- a/cmd/juju/cloud/detectcredentials.go
+++ b/cmd/juju/cloud/detectcredentials.go
@@ -4,12 +4,16 @@
 package cloud
 
 import (
+	"bufio"
 	"fmt"
+	"io"
+	"sort"
+	"strconv"
+	"strings"
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/utils/set"
-	"launchpad.net/gnuflag"
 
 	jujucloud "github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs"
@@ -22,17 +26,17 @@ type detectCredentialsCommand struct {
 
 	store jujuclient.CredentialStore
 
-	// Replace, if true, existing credential information is overwritten.
-	Replace bool
+	// registeredProvidersFunc is set by tests to return all registered environ providers
+	registeredProvdersFunc func() []string
 
-	// The cloud for which to load credentials.
-	CloudName string
+	// allCloudsFunc is set by tests to return all public and personal clouds
+	allCloudsFunc func() (map[string]jujucloud.Cloud, error)
 }
 
 var detectCredentialsDoc = `
 The autoload-credentials command looks for well known locations for supported clouds and
-loads any credentials and default regions found into the Juju credentials store and makes
-these available when bootstrapping new controllers.
+allows the user to interactively save these into the Juju credentials store to make these
+available when bootstrapping new controllers and creating new models.
 
 The resulting credentials may be viewed with juju list-credentials.
 
@@ -49,27 +53,17 @@ GCE
     2. A JSON file in a knowm location eg on Linux $HOME/.config/gcloud/application_default_credentials.json
   Default region is specified by the CLOUDSDK_COMPUTE_REGION environment variable.  
     
-OpenStack (see below)
+OpenStack
   Credentials are located in:
     1. On Linux, $HOME/.novarc
     2. Environment variables OS_USERNAME, OS_PASSWORD, OS_TENANT_NAME 
     
-Some standard credentials locations may apply for more than one cloud. For example, there may be more than one
-OpenStack cloud defined. In such cases, the cloud name may be specified and only credentials for that cloud are
-searched, and when found, applied to that cloud specifically.
-
-If the detected credentials contain labeled credential values which already exist, the --replace option
-may be used to force the overwrite of any existing values. The --replace option is also used to specify
-that any default region value is overwritten.
-
 Example:
    juju autoload-credentials
-   juju autoload-credentials rackspace
-   juju autoload-credentials --replace
    
 See Also:
    juju list-credentials
-   juju add-credentials
+   juju add-credential
 `
 
 // NewDetectCredentialsCommand returns a command to add credential information to credentials.yaml.
@@ -83,114 +77,317 @@ func (c *detectCredentialsCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "autoload-credentials",
 		Purpose: "looks for cloud credentials and caches those for use by Juju when bootstrapping",
-		Args:    "[<cloud-name>]",
 		Doc:     detectCredentialsDoc,
 	}
 }
 
-func (c *detectCredentialsCommand) SetFlags(f *gnuflag.FlagSet) {
-	f.BoolVar(&c.Replace, "replace", false, "overwrite any existing credential information")
+type discoveredCredential struct {
+	defaultCloudName string
+	cloudType        string
+	region           string
+	credentialName   string
+	credential       jujucloud.Credential
+	isNew            bool
 }
 
-func (c *detectCredentialsCommand) Init(args []string) (err error) {
-	if len(args) > 1 {
-		return errors.New("Usage: juju autoload-credentials [--replace] [<cloud-name>]")
+func (c *detectCredentialsCommand) registeredProviders() []string {
+	if c.registeredProvdersFunc != nil {
+		return c.registeredProvdersFunc()
 	}
-	if len(args) == 1 {
-		c.CloudName = args[0]
-	}
-	return nil
+	return environs.RegisteredProviders()
 }
 
-// TODO(wallyworld) - temporary only, we'll add prompting as per spec and this will go away
-// unambiguousClouds represents those clouds for which we will detect credentials
-// without user disambiguation.
-var unambiguousClouds = []string{"aws", "azure", "google", "joyent", "cloudsigma"}
-
-func (c *detectCredentialsCommand) Run(ctxt *cmd.Context) error {
-	ctxt.Verbosef("Looking for cloud and credential information locally...")
+func (c *detectCredentialsCommand) allClouds() (map[string]jujucloud.Cloud, error) {
+	if c.allCloudsFunc != nil {
+		return c.allCloudsFunc()
+	}
 	clouds, _, err := jujucloud.PublicCloudMetadata(jujucloud.JujuPublicCloudsPath())
 	if err != nil {
-		return err
+		return nil, err
 	}
 	personalClouds, err := jujucloud.PersonalCloudMetadata()
 	if err != nil {
-		return err
+		return nil, err
 	}
 	for k, v := range personalClouds {
 		clouds[k] = v
 	}
-	okClouds := set.NewStrings(unambiguousClouds...)
-	for cloudName, cloud := range clouds {
-		if c.CloudName != "" && c.CloudName != cloudName {
-			continue
-		} else if c.CloudName == "" && !okClouds.Contains(cloudName) {
+	return clouds, nil
+}
+
+func (c *detectCredentialsCommand) Run(ctxt *cmd.Context) error {
+	fmt.Fprintln(ctxt.Stderr, "\nLooking for cloud and credential information locally...")
+
+	clouds, err := c.allClouds()
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	// Let's ensure a consistent order.
+	var sortedCloudNames []string
+	for cloudName := range clouds {
+		sortedCloudNames = append(sortedCloudNames, cloudName)
+	}
+	sort.Strings(sortedCloudNames)
+
+	// The default cloud name for each provider type is the
+	// first cloud in the sorted list.
+	defaultCloudNames := make(map[string]string)
+	for _, cloudName := range sortedCloudNames {
+		cloud := clouds[cloudName]
+		if _, ok := defaultCloudNames[cloud.Type]; ok {
 			continue
 		}
-		provider, err := environs.Provider(cloud.Type)
+		defaultCloudNames[cloud.Type] = cloudName
+	}
+
+	providerNames := c.registeredProviders()
+	sort.Strings(providerNames)
+
+	var discovered []discoveredCredential
+	discoveredLabels := set.NewStrings()
+	for _, providerName := range providerNames {
+		provider, err := environs.Provider(providerName)
 		if err != nil {
 			// Should never happen but it will on go 1.2
 			// because lxd provider is not built.
-			logger.Warningf("cloud %q not available on this platform", cloud.Type)
+			logger.Warningf("provider %q not available on this platform", providerName)
 			continue
 		}
 		if detectCredentials, ok := provider.(environs.ProviderCredentials); ok {
 			detected, err := detectCredentials.DetectCredentials()
 			if err != nil && !errors.IsNotFound(err) {
-				logger.Warningf("could not detect credentials for %q: %v", cloudName, err)
+				logger.Warningf("could not detect credentials for provider %q: %v", providerName, err)
 				continue
 			}
 			if errors.IsNotFound(err) || len(detected.AuthCredentials) == 0 {
 				continue
 			}
-			credentials, err := c.store.CredentialForCloud(cloudName)
-			if err != nil && !errors.IsNotFound(err) {
-				return errors.Trace(err)
-			}
-			if !c.Replace && err == nil {
-				existingCredNames := set.NewStrings()
-				for name := range credentials.AuthCredentials {
-					existingCredNames.Add(name)
-				}
-				newCredNames := set.NewStrings()
-				for n, cred := range detected.AuthCredentials {
-					if n == "" || cred.AuthType() == jujucloud.EmptyAuthType {
-						continue
-					}
-					newCredNames.Add(n)
-				}
-				wouldBeOverwriten := existingCredNames.Intersection(newCredNames)
-				if !wouldBeOverwriten.IsEmpty() {
-					fmt.Fprintf(ctxt.Stdout,
-						"Detected credentials %v would overwrite existing credentials for cloud %s.\nUse the --replace option.\n",
-						wouldBeOverwriten.Values(), cloudName)
-					return nil
-				}
-			}
-			for name := range detected.AuthCredentials {
-				if name == "" {
-					logger.Warningf("ignoring unnamed credential for clous %s", cloudName)
+
+			// For each credential, construct meta info for which cloud it may pertain to etc.
+			for credName, newCred := range detected.AuthCredentials {
+				if credName == "" {
+					logger.Warningf("ignoring unnamed credential for provider %s", providerName)
 					continue
 				}
-				fmt.Fprintf(ctxt.Stdout, "%s cloud credential %q found\n", cloudName, name)
-			}
-			if credentials == nil {
-				credentials = detected
-			} else {
-				for name, cred := range detected.AuthCredentials {
-					if name == "" {
-						continue
-					}
-					credentials.AuthCredentials[name] = cred
+				// Ignore empty credentials.
+				if newCred.AuthType() == jujucloud.EmptyAuthType {
+					continue
 				}
-			}
-			if (c.Replace || credentials.DefaultRegion == "") && detected.DefaultRegion != "" {
-				credentials.DefaultRegion = detected.DefaultRegion
-			}
-			if err := c.store.UpdateCredential(cloudName, *credentials); err != nil {
-				return errors.Annotatef(err, "cannot add credentials for cloud %q", cloudName)
+				// Check that another provider hasn't loaded the same credential.
+				if discoveredLabels.Contains(newCred.Label) {
+					continue
+				}
+				discoveredLabels.Add(newCred.Label)
+
+				credInfo := discoveredCredential{
+					cloudType:      providerName,
+					credentialName: credName,
+					credential:     newCred,
+				}
+
+				// Fill in the default cloud and other meta information.
+				defaultCloud, existingDefaultRegion, isNew, err := c.guessCloudInfo(sortedCloudNames, clouds, providerName, credName)
+				if err != nil {
+					return errors.Trace(err)
+				}
+				if defaultCloud == "" {
+					defaultCloud = defaultCloudNames[providerName]
+				}
+				credInfo.defaultCloudName = defaultCloud
+				if isNew {
+					credInfo.defaultCloudName = defaultCloudNames[providerName]
+				}
+				if (isNew || existingDefaultRegion == "") && detected.DefaultRegion != "" {
+					credInfo.region = detected.DefaultRegion
+				}
+				credInfo.isNew = isNew
+				discovered = append(discovered, credInfo)
 			}
 		}
 	}
-	return nil
+	if len(discovered) == 0 {
+		fmt.Fprintln(ctxt.Stderr, "No cloud credentials found.")
+		return nil
+	}
+	return c.interactiveCredentialsUpdate(ctxt, discovered)
+}
+
+// guessCloudInfo looks at all the compatible clouds for the provider name and
+// looks to see whether the credential name exists already.
+// The first match allows the default cloud and region to be set. The default
+// cloud is used when prompting to save a credential. The sorted cloud names
+// ensures that "aws" is preferred over "aws-china".
+func (c *detectCredentialsCommand) guessCloudInfo(sortedCloudNames []string, clouds map[string]jujucloud.Cloud, providerName, credName string) (string, string, bool, error) {
+	var defaultCloud, defaultRegion string
+	isNew := true
+	for _, cloudName := range sortedCloudNames {
+		cloud := clouds[cloudName]
+		if cloud.Type != providerName {
+			continue
+		}
+		credentials, err := c.store.CredentialForCloud(cloudName)
+		if err != nil && !errors.IsNotFound(err) {
+			return "", "", false, errors.Trace(err)
+		}
+		if err != nil {
+			// None found.
+			continue
+		}
+		existingCredNames := set.NewStrings()
+		for name := range credentials.AuthCredentials {
+			existingCredNames.Add(name)
+		}
+		isNew = !existingCredNames.Contains(credName)
+		if defaultRegion == "" && credentials.DefaultRegion != "" {
+			defaultRegion = credentials.DefaultRegion
+		}
+		if defaultCloud == "" {
+			defaultCloud = cloudName
+		}
+	}
+	return defaultCloud, defaultRegion, isNew, nil
+}
+
+// interactiveCredentialsUpdate prints a list of the discovered credentials
+// and prompts the user to update their local credentials.
+func (c *detectCredentialsCommand) interactiveCredentialsUpdate(ctxt *cmd.Context, discovered []discoveredCredential) error {
+	for {
+		// Prompt for a credential to save.
+		c.printCredentialOptions(ctxt, discovered)
+		var input string
+		for {
+			var err error
+			input, err = c.promptCredentialNumber(ctxt.Stderr, ctxt.Stdin)
+			if err != nil {
+				return errors.Trace(err)
+			}
+			if strings.ToLower(input) == "q" {
+				return nil
+			}
+			if input != "" {
+				break
+			}
+		}
+
+		// Check the entered number.
+		num, err := strconv.Atoi(input)
+		if err != nil || num < 1 || num > len(discovered) {
+			fmt.Fprintf(ctxt.Stderr, "Invalid choice, enter a number between 1 and %v\n", len(discovered))
+			continue
+		}
+		cred := discovered[num-1]
+		// Prompt for the cloud for which to save the credential.
+		cloudName, err := c.promptCloudName(ctxt.Stderr, ctxt.Stdin, cred.defaultCloudName, cred.cloudType)
+		if err != nil {
+			fmt.Fprintln(ctxt.Stderr, err.Error())
+			continue
+		}
+		if cloudName == "" {
+			fmt.Fprintln(ctxt.Stderr, "No cloud name entered.")
+			continue
+		}
+
+		// Reading existing info so we can apply updated values.
+		existing, err := c.store.CredentialForCloud(cloudName)
+		if err != nil && !errors.IsNotFound(err) {
+			fmt.Fprintf(ctxt.Stderr, "error reading credential file: %v\n", err)
+			continue
+		}
+		if errors.IsNotFound(err) {
+			existing = &jujucloud.CloudCredential{
+				AuthCredentials: make(map[string]jujucloud.Credential),
+			}
+		}
+		if cred.region != "" {
+			existing.DefaultRegion = cred.region
+		}
+		existing.AuthCredentials[cred.credentialName] = cred.credential
+		if err := c.store.UpdateCredential(cloudName, *existing); err != nil {
+			fmt.Fprintf(ctxt.Stderr, "error saving credential: %v\n", err)
+		} else {
+			// Update so we display correctly next time list is printed.
+			cred.isNew = false
+			discovered[num-1] = cred
+			fmt.Fprintf(ctxt.Stderr, "Saved %s to cloud %s\n", cred.credential.Label, cloudName)
+		}
+	}
+}
+
+func (c *detectCredentialsCommand) printCredentialOptions(ctxt *cmd.Context, discovered []discoveredCredential) {
+	fmt.Fprintln(ctxt.Stderr)
+	for i, cred := range discovered {
+		suffixText := " (existing, will overwrite)"
+		if cred.isNew {
+			suffixText = " (new)"
+		}
+		fmt.Fprintf(ctxt.Stderr, "%d. %s%s\n", i+1, cred.credential.Label, suffixText)
+	}
+}
+
+func (c *detectCredentialsCommand) promptCredentialNumber(out io.Writer, stdin io.Reader) (string, error) {
+	fmt.Fprint(out, "Save any? Type number, or Q to quit, then enter. ")
+	defer out.Write([]byte{'\n'})
+	input, err := c.readLine(stdin)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	return strings.TrimSpace(input), nil
+}
+
+func (c *detectCredentialsCommand) cloudByName(cloudName string) (*jujucloud.Cloud, error) {
+	if c.allCloudsFunc == nil {
+		return jujucloud.CloudByName(cloudName)
+	}
+	// We get here in tests only.
+	clouds, err := c.allCloudsFunc()
+	if err != nil {
+		return nil, err
+	}
+	if cloud, ok := clouds[cloudName]; ok {
+		return &cloud, nil
+	}
+	return nil, errors.NotFoundf("cloud %s", cloudName)
+}
+
+func (c *detectCredentialsCommand) promptCloudName(out io.Writer, stdin io.Reader, defaultCloudName, cloudType string) (string, error) {
+	text := fmt.Sprintf(`Enter cloud to which the credential belongs, or Q to quit [%s] `, defaultCloudName)
+	fmt.Fprint(out, text)
+	defer out.Write([]byte{'\n'})
+	input, err := c.readLine(stdin)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	cloudName := strings.TrimSpace(input)
+	if strings.ToLower(input) == "q" {
+		return "", nil
+	}
+	if cloudName == "" {
+		return defaultCloudName, nil
+	}
+	cloud, err := c.cloudByName(cloudName)
+	if err != nil {
+		return "", err
+	}
+	if cloud.Type != cloudType {
+		return "", errors.Errorf("chosen credentials not compatible with a %s cloud", cloud.Type)
+	}
+	return cloudName, nil
+}
+
+func (c *detectCredentialsCommand) readLine(stdin io.Reader) (string, error) {
+	// Read one byte at a time to avoid reading beyond the delimiter.
+	line, err := bufio.NewReader(byteAtATimeReader{stdin}).ReadString('\n')
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	return line[:len(line)-1], nil
+}
+
+type byteAtATimeReader struct {
+	io.Reader
+}
+
+func (r byteAtATimeReader) Read(out []byte) (int, error) {
+	return r.Reader.Read(out[:1])
 }

--- a/cmd/juju/cloud/detectcredentials_test.go
+++ b/cmd/juju/cloud/detectcredentials_test.go
@@ -56,7 +56,13 @@ func (s *detectCredentialsSuite) run(c *gc.C, stdin io.Reader, clouds map[string
 	allCloudsFunc := func() (map[string]jujucloud.Cloud, error) {
 		return clouds, nil
 	}
-	command := cloud.NewDetectCredentialsCommandForTest(s.store, registeredProvidersFunc, allCloudsFunc)
+	cloudByNameFunc := func(cloudName string) (*jujucloud.Cloud, error) {
+		if cloud, ok := clouds[cloudName]; ok {
+			return &cloud, nil
+		}
+		return nil, errors.NotFoundf("cloud %s", cloudName)
+	}
+	command := cloud.NewDetectCredentialsCommandForTest(s.store, registeredProvidersFunc, allCloudsFunc, cloudByNameFunc)
 	err := testing.InitCommand(command, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	ctx := testing.Context(c)

--- a/cmd/juju/cloud/detectcredentials_test.go
+++ b/cmd/juju/cloud/detectcredentials_test.go
@@ -4,22 +4,25 @@
 package cloud_test
 
 import (
+	"fmt"
+	"io"
+	"regexp"
 	"strings"
 
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	jujucloud "github.com/juju/juju/cloud"
 	"github.com/juju/juju/cmd/juju/cloud"
 	"github.com/juju/juju/environs"
-	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	"github.com/juju/juju/testing"
 )
 
 type detectCredentialsSuite struct {
-	testing.FakeJujuXDGDataHomeSuite
-	store       jujuclient.CredentialStore
+	store       *jujuclienttesting.MemStore
 	aCredential jujucloud.CloudCredential
 }
 
@@ -27,80 +30,135 @@ var _ = gc.Suite(&detectCredentialsSuite{})
 
 type mockProvider struct {
 	environs.EnvironProvider
-	detectedCreds jujucloud.CloudCredential
+	detectedCreds *jujucloud.CloudCredential
 }
 
 func (p *mockProvider) DetectCredentials() (*jujucloud.CloudCredential, error) {
-	return &p.detectedCreds, nil
+	if len(p.detectedCreds.AuthCredentials) == 0 {
+		return nil, errors.NotFoundf("credentials")
+	}
+	return p.detectedCreds, nil
 }
 
 func (s *detectCredentialsSuite) SetUpSuite(c *gc.C) {
-	s.aCredential = jujucloud.CloudCredential{
-		DefaultRegion: "detected region",
-		AuthCredentials: map[string]jujucloud.Credential{
-			"test": jujucloud.NewCredential(jujucloud.AccessKeyAuthType, nil)},
-	}
-	environs.RegisterProvider("test", &mockProvider{detectedCreds: s.aCredential})
+	environs.RegisterProvider("mock-provider", &mockProvider{detectedCreds: &s.aCredential})
 }
 
 func (s *detectCredentialsSuite) SetUpTest(c *gc.C) {
-	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
 	s.store = jujuclienttesting.NewMemStore()
-	err := jujucloud.WritePersonalCloudMetadata(map[string]jujucloud.Cloud{
-		"test": jujucloud.Cloud{Type: "test"},
-	})
-	c.Assert(err, jc.ErrorIsNil)
+	s.aCredential = jujucloud.CloudCredential{}
 }
 
-func (s *detectCredentialsSuite) TestDetectCredentials(c *gc.C) {
-	s.detectCredentials(c, "test")
-	creds, err := s.store.CredentialForCloud("test")
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(creds, jc.DeepEquals, &s.aCredential)
-}
-
-func (s *detectCredentialsSuite) TestDetectPromptsForOverwrite(c *gc.C) {
-	inital := jujucloud.CloudCredential{
-		AuthCredentials: map[string]jujucloud.Credential{
-			"test": jujucloud.NewCredential(jujucloud.UserPassAuthType, nil)},
+func (s *detectCredentialsSuite) run(c *gc.C, stdin io.Reader, clouds map[string]jujucloud.Cloud) (*cmd.Context, error) {
+	registeredProvidersFunc := func() []string {
+		return []string{"mock-provider"}
 	}
-	s.store.UpdateCredential("test", inital)
-	out := s.detectCredentials(c, "test")
-	out = strings.Replace(out, "\n", "", -1)
-	c.Assert(out, gc.Equals, `Detected credentials [test] would overwrite existing credentials for cloud test.Use the --replace option.`)
-
-	// Has not been replaced.
-	creds, err := s.store.CredentialForCloud("test")
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(creds, jc.DeepEquals, &inital)
-}
-
-func (s *detectCredentialsSuite) TestDetectForceOverwrite(c *gc.C) {
-	inital := jujucloud.CloudCredential{
-		DefaultRegion: "region",
-		AuthCredentials: map[string]jujucloud.Credential{
-			"test":    jujucloud.NewCredential(jujucloud.UserPassAuthType, nil),
-			"another": jujucloud.NewCredential(jujucloud.AccessKeyAuthType, nil)},
+	allCloudsFunc := func() (map[string]jujucloud.Cloud, error) {
+		return clouds, nil
 	}
-	s.store.UpdateCredential("test", inital)
-	out := s.detectCredentials(c, "test", "--replace")
-	out = strings.Replace(out, "\n", "", -1)
-	c.Assert(out, gc.Equals, `test cloud credential "test" found`)
-
-	// Has been replaced.
-	creds, err := s.store.CredentialForCloud("test")
+	command := cloud.NewDetectCredentialsCommandForTest(s.store, registeredProvidersFunc, allCloudsFunc)
+	err := testing.InitCommand(command, nil)
 	c.Assert(err, jc.ErrorIsNil)
-	replaced := inital
-	replaced.DefaultRegion = "detected region"
-	replaced.AuthCredentials["test"] = s.aCredential.AuthCredentials["test"]
-	c.Assert(creds, jc.DeepEquals, &replaced)
+	ctx := testing.Context(c)
+	ctx.Stdin = stdin
+	return ctx, command.Run(ctx)
 }
 
-// TODO(wallyworld) - add more test coverage
+func (s *detectCredentialsSuite) credentialWithLabel(authType jujucloud.AuthType, label string) jujucloud.Credential {
+	cred := jujucloud.NewCredential(authType, nil)
+	cred.Label = label
+	return cred
+}
 
-func (s *detectCredentialsSuite) detectCredentials(c *gc.C, args ...string) string {
-	ctx, err := testing.RunCommand(c, cloud.NewDetectCredentialsCommandForTest(s.store), args...)
+func (s *detectCredentialsSuite) assertDetectCredential(c *gc.C, cloudName, expectedRegion, errText string) {
+	s.aCredential = jujucloud.CloudCredential{
+		DefaultRegion: "default region",
+		AuthCredentials: map[string]jujucloud.Credential{
+			"test": s.credentialWithLabel(jujucloud.AccessKeyAuthType, "credential")},
+	}
+	clouds := map[string]jujucloud.Cloud{
+		"test-cloud": {
+			Type: "mock-provider",
+		},
+		"another-cloud": {
+			Type: "another-provider",
+		},
+	}
+
+	stdin := strings.NewReader(fmt.Sprintf("1\n%s\nQ\n", cloudName))
+	ctx, err := s.run(c, stdin, clouds)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(testing.Stderr(ctx), gc.Equals, "")
-	return testing.Stdout(ctx)
+	if errText == "" {
+		if expectedRegion != "" {
+			s.aCredential.DefaultRegion = expectedRegion
+		}
+		c.Assert(s.store.Credentials["test-cloud"], jc.DeepEquals, s.aCredential)
+	} else {
+		output := strings.Replace(testing.Stderr(ctx), "\n", "", -1)
+		c.Assert(output, gc.Matches, ".*"+regexp.QuoteMeta(errText)+".*")
+	}
+}
+
+func (s *detectCredentialsSuite) TestDetectNewCredential(c *gc.C) {
+	s.assertDetectCredential(c, "test-cloud", "", "")
+}
+
+func (s *detectCredentialsSuite) TestDetectCredentialOverwrites(c *gc.C) {
+	s.store.Credentials = map[string]jujucloud.CloudCredential{
+		"test-cloud": {
+			AuthCredentials: map[string]jujucloud.Credential{
+				"test": jujucloud.NewCredential(jujucloud.AccessKeyAuthType, nil),
+			},
+		},
+	}
+	s.assertDetectCredential(c, "test-cloud", "", "")
+}
+
+func (s *detectCredentialsSuite) TestDetectCredentialKeepsExistingRegion(c *gc.C) {
+	s.store.Credentials = map[string]jujucloud.CloudCredential{
+		"test-cloud": {
+			DefaultRegion: "west",
+			AuthCredentials: map[string]jujucloud.Credential{
+				"test": jujucloud.NewCredential(jujucloud.AccessKeyAuthType, nil),
+			},
+		},
+	}
+	s.assertDetectCredential(c, "test-cloud", "west", "")
+}
+
+func (s *detectCredentialsSuite) TestDetectCredentialDefaultCloud(c *gc.C) {
+	s.assertDetectCredential(c, "", "", "")
+}
+
+func (s *detectCredentialsSuite) TestDetectCredentialUnknownCloud(c *gc.C) {
+	s.assertDetectCredential(c, "foo", "", "cloud foo not found")
+}
+
+func (s *detectCredentialsSuite) TestDetectCredentialInvalidCloud(c *gc.C) {
+	s.assertDetectCredential(c, "another-cloud", "", "chosen credentials not compatible with a another-provider cloud")
+}
+
+func (s *detectCredentialsSuite) TestNewDetectCredentialNoneFound(c *gc.C) {
+	stdin := strings.NewReader("")
+	ctx, err := s.run(c, stdin, nil)
+	c.Assert(err, jc.ErrorIsNil)
+	output := strings.Replace(testing.Stderr(ctx), "\n", "", -1)
+	c.Assert(output, gc.Matches, ".*No cloud credentials found.*")
+	c.Assert(s.store.Credentials, gc.HasLen, 0)
+}
+
+func (s *detectCredentialsSuite) TestDetectCredentialInvalidChoice(c *gc.C) {
+	s.aCredential = jujucloud.CloudCredential{
+		DefaultRegion: "detected region",
+		AuthCredentials: map[string]jujucloud.Credential{
+			"test":    s.credentialWithLabel(jujucloud.AccessKeyAuthType, "credential 1"),
+			"another": s.credentialWithLabel(jujucloud.AccessKeyAuthType, "credential 2")},
+	}
+
+	stdin := strings.NewReader("3\nQ\n")
+	ctx, err := s.run(c, stdin, nil)
+	c.Assert(err, jc.ErrorIsNil)
+	output := strings.Replace(testing.Stderr(ctx), "\n", "", -1)
+	c.Assert(output, gc.Matches, ".*Invalid choice, enter a number between 1 and 2.*")
+	c.Assert(s.store.Credentials, gc.HasLen, 0)
 }

--- a/cmd/juju/cloud/export_test.go
+++ b/cmd/juju/cloud/export_test.go
@@ -4,6 +4,7 @@
 package cloud
 
 import (
+	jujucloud "github.com/juju/juju/cloud"
 	"github.com/juju/juju/jujuclient"
 )
 
@@ -13,8 +14,14 @@ func NewListCredentialsCommandForTest(testStore jujuclient.CredentialGetter) *li
 	}
 }
 
-func NewDetectCredentialsCommandForTest(testStore jujuclient.CredentialStore) *detectCredentialsCommand {
+func NewDetectCredentialsCommandForTest(
+	testStore jujuclient.CredentialStore,
+	registeredProvidersFunc func() []string,
+	allCloudsFunc func() (map[string]jujucloud.Cloud, error),
+) *detectCredentialsCommand {
 	return &detectCredentialsCommand{
 		store: testStore,
+		registeredProvdersFunc: registeredProvidersFunc,
+		allCloudsFunc:          allCloudsFunc,
 	}
 }

--- a/cmd/juju/cloud/export_test.go
+++ b/cmd/juju/cloud/export_test.go
@@ -18,10 +18,12 @@ func NewDetectCredentialsCommandForTest(
 	testStore jujuclient.CredentialStore,
 	registeredProvidersFunc func() []string,
 	allCloudsFunc func() (map[string]jujucloud.Cloud, error),
+	cloudsByNameFunc func(string) (*jujucloud.Cloud, error),
 ) *detectCredentialsCommand {
 	return &detectCredentialsCommand{
 		store: testStore,
-		registeredProvdersFunc: registeredProvidersFunc,
-		allCloudsFunc:          allCloudsFunc,
+		registeredProvidersFunc: registeredProvidersFunc,
+		allCloudsFunc:           allCloudsFunc,
+		cloudByNameFunc:         cloudsByNameFunc,
 	}
 }

--- a/cmd/juju/cloud/listcredentials.go
+++ b/cmd/juju/cloud/listcredentials.go
@@ -27,8 +27,7 @@ type listCredentialsCommand struct {
 
 var listCredentialsDoc = `
 The list-credentials command lists the credentials for clouds on which Juju workloads
-can be deployed. The credentials listed are those added with the add-credentials
-command.
+can be deployed. The credentials listed are those added with the add-credential command.
 
 Example:
    # List all credentials.

--- a/provider/ec2/credentials.go
+++ b/provider/ec2/credentials.go
@@ -4,6 +4,7 @@
 package ec2
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -77,6 +78,7 @@ func (e environProviderCredentials) DetectCredentials() (*cloud.CloudCredential,
 				"secret-key": values.AwsSecretAccessKey,
 			},
 		)
+		accessKeyCredential.Label = fmt.Sprintf("aws credential %q", credName)
 		result.AuthCredentials[credName] = accessKeyCredential
 	}
 
@@ -113,6 +115,7 @@ func (environProviderCredentials) detectEnvCredentials() (*cloud.CloudCredential
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+	accessKeyCredential.Label = fmt.Sprintf("aws credential %q", user)
 	return &cloud.CloudCredential{
 		AuthCredentials: map[string]cloud.Credential{
 			user: accessKeyCredential,

--- a/provider/ec2/credentials_test.go
+++ b/provider/ec2/credentials_test.go
@@ -69,12 +69,14 @@ func (s *credentialsSuite) TestDetectCredentialsEnvironmentVariables(c *gc.C) {
 
 	credentials, err := s.provider.DetectCredentials()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(credentials.AuthCredentials["fred"], jc.DeepEquals, cloud.NewCredential(
+	expected := cloud.NewCredential(
 		cloud.AccessKeyAuthType, map[string]string{
 			"access-key": "key-id",
 			"secret-key": "secret-access-key",
 		},
-	))
+	)
+	expected.Label = `aws credential "fred"`
+	c.Assert(credentials.AuthCredentials["fred"], jc.DeepEquals, expected)
 }
 
 func (s *credentialsSuite) assertDetectCredentialsKnownLocation(c *gc.C, dir string) {
@@ -105,12 +107,14 @@ region=region
 	credentials, err := s.provider.DetectCredentials()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(credentials.DefaultRegion, gc.Equals, "region")
-	c.Assert(credentials.AuthCredentials["fred"], jc.DeepEquals, cloud.NewCredential(
+	expected := cloud.NewCredential(
 		cloud.AccessKeyAuthType, map[string]string{
 			"access-key": "aws-key-id",
 			"secret-key": "aws-secret-access-key",
 		},
-	))
+	)
+	expected.Label = `aws credential "fred"`
+	c.Assert(credentials.AuthCredentials["fred"], jc.DeepEquals, expected)
 }
 
 func (s *credentialsSuite) TestDetectCredentialsKnownLocationUnix(c *gc.C) {

--- a/provider/gce/credentials_test.go
+++ b/provider/gce/credentials_test.go
@@ -87,9 +87,9 @@ func (s *credentialsSuite) TestDetectCredentialsFromEnvVar(c *gc.C) {
 	credentials, err := s.provider.DetectCredentials()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(credentials.DefaultRegion, gc.Equals, "region")
-	c.Assert(
-		credentials.AuthCredentials["fred"], jc.DeepEquals,
-		cloud.NewCredential(cloud.JSONFileAuthType, map[string]string{"file": jsonpath}))
+	expected := cloud.NewCredential(cloud.JSONFileAuthType, map[string]string{"file": jsonpath})
+	expected.Label = `google credential "test@example.com"`
+	c.Assert(credentials.AuthCredentials["fred"], jc.DeepEquals, expected)
 }
 
 func (s *credentialsSuite) assertDetectCredentialsKnownLocation(c *gc.C, jsonpath string) {
@@ -98,9 +98,9 @@ func (s *credentialsSuite) assertDetectCredentialsKnownLocation(c *gc.C, jsonpat
 	credentials, err := s.provider.DetectCredentials()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(credentials.DefaultRegion, gc.Equals, "region")
-	c.Assert(
-		credentials.AuthCredentials["fred"], jc.DeepEquals,
-		cloud.NewCredential(cloud.JSONFileAuthType, map[string]string{"file": jsonpath}))
+	expected := cloud.NewCredential(cloud.JSONFileAuthType, map[string]string{"file": jsonpath})
+	expected.Label = `google credential "test@example.com"`
+	c.Assert(credentials.AuthCredentials["fred"], jc.DeepEquals, expected)
 }
 
 func (s *credentialsSuite) TestDetectCredentialsKnownLocationUnix(c *gc.C) {

--- a/provider/openstack/credentials.go
+++ b/provider/openstack/credentials.go
@@ -4,11 +4,14 @@
 package openstack
 
 import (
+	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/juju/errors"
 	"github.com/juju/utils"
 	"gopkg.in/goose.v1/identity"
+	"gopkg.in/ini.v1"
 
 	"github.com/juju/juju/cloud"
 )
@@ -46,20 +49,62 @@ func (OpenstackCredentials) CredentialSchemas() map[cloud.AuthType]cloud.Credent
 }
 
 // DetectCredentials is part of the environs.ProviderCredentials interface.
-func (OpenstackCredentials) DetectCredentials() (*cloud.CloudCredential, error) {
+func (c OpenstackCredentials) DetectCredentials() (*cloud.CloudCredential, error) {
+	result := cloud.CloudCredential{
+		AuthCredentials: make(map[string]cloud.Credential),
+	}
+
+	// Try just using environment variables
+	creds, user, region, err := c.detectCredential()
+	if err == nil {
+		result.DefaultRegion = region
+		result.AuthCredentials[user] = *creds
+	}
+
+	// Now look for .novarc file in home dir.
+	novarc := filepath.Join(utils.Home(), ".novarc")
+	novaInfo, err := ini.LooseLoad(novarc)
+	if err != nil {
+		return nil, errors.Annotate(err, "loading novarc file")
+	}
+	keyValues := novaInfo.Section(ini.DEFAULT_SECTION).KeysHash()
+	if len(keyValues) > 0 {
+		for k, v := range keyValues {
+			os.Setenv(k, v)
+		}
+		creds, user, region, err := c.detectCredential()
+		if err == nil {
+			result.DefaultRegion = region
+			result.AuthCredentials[user] = *creds
+		}
+	}
+	if len(result.AuthCredentials) == 0 {
+		return nil, errors.NotFoundf("openstack credentials")
+	}
+	return &result, nil
+}
+
+func (c OpenstackCredentials) detectCredential() (*cloud.Credential, string, string, error) {
 	creds := identity.CredentialsFromEnv()
 	if creds.TenantName == "" {
-		return nil, errors.NewNotFound(nil, "OS_TENANT_NAME environment variable not set")
+		return nil, "", "", errors.NewNotFound(nil, "OS_TENANT_NAME environment variable not set")
 	}
 	if creds.User == "" {
-		return nil, errors.NewNotFound(nil, "neither OS_USERNAME nor OS_ACCESS_KEY environment variable not set")
+		return nil, "", "", errors.NewNotFound(nil, "neither OS_USERNAME nor OS_ACCESS_KEY environment variable not set")
 	}
 	if creds.Secrets == "" {
-		return nil, errors.NewNotFound(nil, "neither OS_PASSWORD nor OS_SECRET_KEY environment variable not set")
+		return nil, "", "", errors.NewNotFound(nil, "neither OS_PASSWORD nor OS_SECRET_KEY environment variable not set")
 	}
+
+	user, err := utils.LocalUsername()
+	if err != nil {
+		return nil, "", "", errors.Trace(err)
+	}
+
 	// If OS_USERNAME or NOVA_USERNAME is set, assume userpass.
 	var credential cloud.Credential
 	if os.Getenv("OS_USERNAME") != "" || os.Getenv("NOVA_USERNAME") != "" {
+		user = creds.User
 		credential = cloud.NewCredential(
 			cloud.UserPassAuthType,
 			map[string]string{
@@ -78,13 +123,10 @@ func (OpenstackCredentials) DetectCredentials() (*cloud.CloudCredential, error) 
 			},
 		)
 	}
-
-	user, err := utils.LocalUsername()
-	if err != nil {
-		return nil, errors.Trace(err)
+	region := creds.Region
+	if region == "" {
+		region = "<unspecified>"
 	}
-	return &cloud.CloudCredential{
-		AuthCredentials: map[string]cloud.Credential{
-			user: credential,
-		}}, nil
+	credential.Label = fmt.Sprintf("openstack region %q project %q user %q", region, creds.TenantName, user)
+	return &credential, user, creds.Region, nil
 }

--- a/provider/openstack/credentials_test.go
+++ b/provider/openstack/credentials_test.go
@@ -6,6 +6,7 @@ package openstack_test
 import (
 	"io/ioutil"
 	"path/filepath"
+	"runtime"
 
 	"github.com/juju/errors"
 	"github.com/juju/testing"
@@ -110,6 +111,9 @@ func (s *credentialsSuite) TestDetectCredentialsUserPassEnvironmentVariables(c *
 }
 
 func (s *credentialsSuite) TestDetectCredentialsNovarc(c *gc.C) {
+	if runtime.GOOS != "linux" {
+		c.Skip("not running linux")
+	}
 	home := utils.Home()
 	dir := c.MkDir()
 	utils.SetHome(dir)

--- a/provider/openstack/credentials_test.go
+++ b/provider/openstack/credentials_test.go
@@ -4,9 +4,13 @@
 package openstack_test
 
 import (
+	"io/ioutil"
+	"path/filepath"
+
 	"github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cloud"
@@ -68,16 +72,20 @@ func (s *credentialsSuite) TestDetectCredentialsAccessKeyEnvironmentVariables(c 
 	s.PatchEnvironment("OS_TENANT_NAME", "gary")
 	s.PatchEnvironment("OS_ACCESS_KEY", "key-id")
 	s.PatchEnvironment("OS_SECRET_KEY", "secret-access-key")
+	s.PatchEnvironment("OS_REGION_NAME", "east")
 
 	credentials, err := s.provider.DetectCredentials()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(credentials.AuthCredentials["fred"], jc.DeepEquals, cloud.NewCredential(
+	c.Assert(credentials.DefaultRegion, gc.Equals, "east")
+	expected := cloud.NewCredential(
 		cloud.AccessKeyAuthType, map[string]string{
 			"access-key":  "key-id",
 			"secret-key":  "secret-access-key",
 			"tenant-name": "gary",
 		},
-	))
+	)
+	expected.Label = `openstack region "east" project "gary" user "fred"`
+	c.Assert(credentials.AuthCredentials["fred"], jc.DeepEquals, expected)
 }
 
 func (s *credentialsSuite) TestDetectCredentialsUserPassEnvironmentVariables(c *gc.C) {
@@ -85,14 +93,49 @@ func (s *credentialsSuite) TestDetectCredentialsUserPassEnvironmentVariables(c *
 	s.PatchEnvironment("OS_TENANT_NAME", "gary")
 	s.PatchEnvironment("OS_USERNAME", "bob")
 	s.PatchEnvironment("OS_PASSWORD", "dobbs")
+	s.PatchEnvironment("OS_REGION_NAME", "west")
 
 	credentials, err := s.provider.DetectCredentials()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(credentials.AuthCredentials["fred"], jc.DeepEquals, cloud.NewCredential(
+	c.Assert(credentials.DefaultRegion, gc.Equals, "west")
+	expected := cloud.NewCredential(
 		cloud.UserPassAuthType, map[string]string{
 			"username":    "bob",
 			"password":    "dobbs",
 			"tenant-name": "gary",
 		},
-	))
+	)
+	expected.Label = `openstack region "west" project "gary" user "bob"`
+	c.Assert(credentials.AuthCredentials["bob"], jc.DeepEquals, expected)
+}
+
+func (s *credentialsSuite) TestDetectCredentialsNovarc(c *gc.C) {
+	home := utils.Home()
+	dir := c.MkDir()
+	utils.SetHome(dir)
+	s.AddCleanup(func(*gc.C) {
+		utils.SetHome(home)
+	})
+
+	content := `
+# Some secrets
+OS_TENANT_NAME=gary
+OS_USERNAME=bob
+OS_PASSWORD=dobbs
+`[1:]
+	novarc := filepath.Join(dir, ".novarc")
+	err := ioutil.WriteFile(novarc, []byte(content), 0600)
+
+	credentials, err := s.provider.DetectCredentials()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(credentials.DefaultRegion, gc.Equals, "")
+	expected := cloud.NewCredential(
+		cloud.UserPassAuthType, map[string]string{
+			"username":    "bob",
+			"password":    "dobbs",
+			"tenant-name": "gary",
+		},
+	)
+	expected.Label = `openstack region "<unspecified>" project "gary" user "bob"`
+	c.Assert(credentials.AuthCredentials["bob"], jc.DeepEquals, expected)
 }


### PR DESCRIPTION
juju autoload-credentials is now interactive.

openstack detection now supports ~/.novarc files

Detected credentials have a label (based on the spec) so that this can be presented to the user to allow them to make a choice as to what they want to save.

(Review request: http://reviews.vapour.ws/r/4052/)