### PR TITLE
Remove secrets by default from listed credentials

### DIFF
--- a/cloud/credentials.go
+++ b/cloud/credentials.go
@@ -285,3 +285,21 @@ func ParseCredentials(data []byte) (map[string]CloudCredential, error) {
 	}
 	return credentials, nil
 }
+
+// RemoveSecrets returns a copy of the given credential with secret fields removed.
+func RemoveSecrets(
+	credential Credential,
+	schemas map[AuthType]CredentialSchema,
+) (*Credential, error) {
+	schema, ok := schemas[credential.authType]
+	if !ok {
+		return nil, errors.NotSupportedf("auth-type %q", credential.authType)
+	}
+	redactedAttrs := credential.Attributes()
+	for attrName, attr := range schema {
+		if attr.Hidden {
+			delete(redactedAttrs, attrName)
+		}
+	}
+	return &Credential{credential.authType, redactedAttrs}, nil
+}

--- a/cloud/credentials.go
+++ b/cloud/credentials.go
@@ -305,5 +305,5 @@ func RemoveSecrets(
 			delete(redactedAttrs, attrName)
 		}
 	}
-	return &Credential{credential.authType, redactedAttrs}, nil
+	return &Credential{authType: credential.authType, attributes: redactedAttrs}, nil
 }

--- a/cloud/credentials_test.go
+++ b/cloud/credentials_test.go
@@ -452,3 +452,26 @@ func (s *credentialsSuite) TestFinalizeCredentialNotSupported(c *gc.C) {
 func readFileNotSupported(f string) ([]byte, error) {
 	return nil, errors.NotSupportedf("reading file %q", f)
 }
+
+func (s *credentialsSuite) TestRemoveSecrets(c *gc.C) {
+	cred := cloud.NewCredential(
+		cloud.UserPassAuthType,
+		map[string]string{
+			"username": "user",
+			"password": "secret",
+		},
+	)
+	schema := cloud.CredentialSchema{
+		"username": {},
+		"password": {
+			Hidden: true,
+		},
+	}
+	sanitisedCred, err := cloud.RemoveSecrets(cred, map[cloud.AuthType]cloud.CredentialSchema{
+		cloud.UserPassAuthType: schema,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(sanitisedCred.Attributes(), jc.DeepEquals, map[string]string{
+		"username": "user",
+	})
+}

--- a/cmd/juju/cloud/detectcredentials_test.go
+++ b/cmd/juju/cloud/detectcredentials_test.go
@@ -34,6 +34,34 @@ func (p *mockProvider) DetectCredentials() (*jujucloud.CloudCredential, error) {
 	return &p.detectedCreds, nil
 }
 
+func (p *mockProvider) CredentialSchemas() map[jujucloud.AuthType]jujucloud.CredentialSchema {
+	return map[jujucloud.AuthType]jujucloud.CredentialSchema{
+		jujucloud.AccessKeyAuthType: {
+			"access-key": {},
+			"secret-key": {
+				Hidden: true,
+			},
+		},
+		jujucloud.UserPassAuthType: {
+			"username": {},
+			"password": {
+				Hidden: true,
+			},
+			"application-password": {
+				Hidden: true,
+			},
+		},
+		jujucloud.OAuth2AuthType: {
+			"client-id":    {},
+			"client-email": {},
+			"private-key": {
+				Hidden: true,
+			},
+			"project-id": {},
+		},
+	}
+}
+
 func (s *detectCredentialsSuite) SetUpSuite(c *gc.C) {
 	s.aCredential = jujucloud.CloudCredential{
 		DefaultRegion: "detected region",

--- a/cmd/juju/cloud/export_test.go
+++ b/cmd/juju/cloud/export_test.go
@@ -4,12 +4,19 @@
 package cloud
 
 import (
+	jujucloud "github.com/juju/juju/cloud"
 	"github.com/juju/juju/jujuclient"
 )
 
-func NewListCredentialsCommandForTest(testStore jujuclient.CredentialGetter) *listCredentialsCommand {
+func NewListCredentialsCommandForTest(
+	testStore jujuclient.CredentialGetter,
+	personalCloudsFunc func() (map[string]jujucloud.Cloud, error),
+	cloudByNameFunc func(string) (*jujucloud.Cloud, error),
+) *listCredentialsCommand {
 	return &listCredentialsCommand{
-		store: testStore,
+		store:              testStore,
+		personalCloudsFunc: personalCloudsFunc,
+		cloudByNameFunc:    cloudByNameFunc,
 	}
 }
 

--- a/cmd/juju/cloud/listcredentials.go
+++ b/cmd/juju/cloud/listcredentials.go
@@ -53,7 +53,8 @@ type credentialsMap struct {
 // NewListCredentialsCommand returns a command to list cloud credentials.
 func NewListCredentialsCommand() cmd.Command {
 	return &listCredentialsCommand{
-		store: jujuclient.NewFileCredentialStore(),
+		store:           jujuclient.NewFileCredentialStore(),
+		cloudByNameFunc: jujucloud.CloudByName,
 	}
 }
 
@@ -138,15 +139,8 @@ func (c *listCredentialsCommand) Run(ctxt *cmd.Context) error {
 	return c.out.Write(ctxt, credentialsMap{displayCredentials})
 }
 
-func (c *listCredentialsCommand) cloudByName(name string) (*jujucloud.Cloud, error) {
-	if c.cloudByNameFunc == nil {
-		return jujucloud.CloudByName(name)
-	}
-	return c.cloudByNameFunc(name)
-}
-
 func (c *listCredentialsCommand) removeSecrets(cloudName string, cloudCred *jujucloud.CloudCredential) error {
-	cloud, err := c.cloudByName(cloudName)
+	cloud, err := c.cloudByNameFunc(cloudName)
 	if err != nil {
 		return err
 	}

--- a/cmd/juju/cloud/listcredentials.go
+++ b/cmd/juju/cloud/listcredentials.go
@@ -15,14 +15,19 @@ import (
 	"launchpad.net/gnuflag"
 
 	jujucloud "github.com/juju/juju/cloud"
+	"github.com/juju/juju/environs"
 	"github.com/juju/juju/jujuclient"
 )
 
 type listCredentialsCommand struct {
 	cmd.CommandBase
-	out       cmd.Output
-	cloudName string
-	store     jujuclient.CredentialGetter
+	out         cmd.Output
+	cloudName   string
+	showSecrets bool
+
+	store              jujuclient.CredentialGetter
+	personalCloudsFunc func() (map[string]jujucloud.Cloud, error)
+	cloudByNameFunc    func(string) (*jujucloud.Cloud, error)
 }
 
 var listCredentialsDoc = `
@@ -36,6 +41,9 @@ Example:
 
    # List credentials for the aws cloud only.
    juju list-credentials aws
+   
+   # List detailed credential information including passwords.
+   juju list-credentials --format yaml --show-secrets
 `
 
 type credentialsMap struct {
@@ -59,6 +67,7 @@ func (c *listCredentialsCommand) Info() *cmd.Info {
 }
 
 func (c *listCredentialsCommand) SetFlags(f *gnuflag.FlagSet) {
+	f.BoolVar(&c.showSecrets, "show-secrets", false, "show secrets for displayed credentials")
 	c.out.AddFlags(f, "tabular", map[string]cmd.Formatter{
 		"yaml":    cmd.FormatYaml,
 		"json":    cmd.FormatJson,
@@ -75,6 +84,24 @@ func (c *listCredentialsCommand) Init(args []string) error {
 	return nil
 }
 
+func (c *listCredentialsCommand) personalClouds() (map[string]jujucloud.Cloud, error) {
+	if c.personalCloudsFunc == nil {
+		return jujucloud.PersonalCloudMetadata()
+	}
+	return c.personalCloudsFunc()
+}
+
+// displayCloudName returns the provided cloud name prefixed
+// with "local:" if it is a local cloud.
+func displayCloudName(cloudName string, personalCloudNames []string) string {
+	for _, name := range personalCloudNames {
+		if cloudName == name {
+			return localPrefix + cloudName
+		}
+	}
+	return cloudName
+}
+
 func (c *listCredentialsCommand) Run(ctxt *cmd.Context) error {
 	var credentials map[string]jujucloud.CloudCredential
 	credentials, err := c.store.AllCredentials()
@@ -88,7 +115,54 @@ func (c *listCredentialsCommand) Run(ctxt *cmd.Context) error {
 			}
 		}
 	}
-	return c.out.Write(ctxt, credentialsMap{credentials})
+
+	// Find local cloud names.
+	personalClouds, err := c.personalClouds()
+	if err != nil {
+		return err
+	}
+	var personalCloudNames []string
+	for name := range personalClouds {
+		personalCloudNames = append(personalCloudNames, name)
+	}
+
+	displayCredentials := make(map[string]jujucloud.CloudCredential)
+	for cloudName, cred := range credentials {
+		if !c.showSecrets {
+			if err := c.removeSecrets(cloudName, &cred); err != nil {
+				return errors.Annotatef(err, "removing secrets from credentials for cloud %v", cloudName)
+			}
+		}
+		displayCredentials[displayCloudName(cloudName, personalCloudNames)] = cred
+	}
+	return c.out.Write(ctxt, credentialsMap{displayCredentials})
+}
+
+func (c *listCredentialsCommand) cloudByName(name string) (*jujucloud.Cloud, error) {
+	if c.cloudByNameFunc == nil {
+		return jujucloud.CloudByName(name)
+	}
+	return c.cloudByNameFunc(name)
+}
+
+func (c *listCredentialsCommand) removeSecrets(cloudName string, cloudCred *jujucloud.CloudCredential) error {
+	cloud, err := c.cloudByName(cloudName)
+	if err != nil {
+		return err
+	}
+	provider, err := environs.Provider(cloud.Type)
+	if err != nil {
+		return err
+	}
+	schemas := provider.CredentialSchemas()
+	for name, cred := range cloudCred.AuthCredentials {
+		sanitisedCred, err := jujucloud.RemoveSecrets(cred, schemas)
+		if err != nil {
+			return err
+		}
+		cloudCred.AuthCredentials[name] = *sanitisedCred
+	}
+	return nil
 }
 
 // formatCredentialsTabular returns a tabular summary of cloud information.

--- a/cmd/juju/cloud/listcredentials_test.go
+++ b/cmd/juju/cloud/listcredentials_test.go
@@ -11,6 +11,7 @@ import (
 
 	jujucloud "github.com/juju/juju/cloud"
 	"github.com/juju/juju/cmd/juju/cloud"
+	"github.com/juju/juju/environs"
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	"github.com/juju/juju/testing"
@@ -18,61 +19,98 @@ import (
 
 type listCredentialsSuite struct {
 	testing.BaseSuite
-	store jujuclient.CredentialGetter
+	store              jujuclient.CredentialGetter
+	personalCloudsFunc func() (map[string]jujucloud.Cloud, error)
+	cloudByNameFunc    func(string) (*jujucloud.Cloud, error)
 }
 
-var _ = gc.Suite(&listCredentialsSuite{})
+var _ = gc.Suite(&listCredentialsSuite{
+	personalCloudsFunc: func() (map[string]jujucloud.Cloud, error) {
+		return map[string]jujucloud.Cloud{
+			"mycloud": {},
+		}, nil
+	},
+	cloudByNameFunc: func(string) (*jujucloud.Cloud, error) {
+		return &jujucloud.Cloud{Type: "test-provider"}, nil
+	},
+})
 
-var sampleCredentials = map[string]jujucloud.CloudCredential{
-	"aws": {
-		DefaultRegion:     "ap-southeast-2",
-		DefaultCredential: "down",
-		AuthCredentials: map[string]jujucloud.Credential{
-			"bob": jujucloud.NewCredential(
-				jujucloud.AccessKeyAuthType,
-				map[string]string{
-					"access-key": "key",
-					"secret-key": "secret",
-				},
-			),
-			"down": jujucloud.NewCredential(
-				jujucloud.OAuth2AuthType,
-				map[string]string{
-					"client-id":    "id",
-					"client-email": "email",
-					"private-key":  "key",
-				},
-			),
-		},
-	},
-	"azure": {
-		AuthCredentials: map[string]jujucloud.Credential{
-			"azhja": jujucloud.NewCredential(
-				jujucloud.UserPassAuthType,
-				map[string]string{
-					"application-id":       "app-id",
-					"application-password": "app-secret",
-					"subscription-id":      "subscription-id",
-					"tenant-id":            "tenant-id",
-				},
-			),
-		},
-	},
+func (s *listCredentialsSuite) SetUpSuite(c *gc.C) {
+	environs.RegisterProvider("test-provider", &mockProvider{})
 }
 
 func (s *listCredentialsSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 	s.store = &jujuclienttesting.MemStore{
-		Credentials: sampleCredentials,
+		Credentials: map[string]jujucloud.CloudCredential{
+			"aws": {
+				DefaultRegion:     "ap-southeast-2",
+				DefaultCredential: "down",
+				AuthCredentials: map[string]jujucloud.Credential{
+					"bob": jujucloud.NewCredential(
+						jujucloud.AccessKeyAuthType,
+						map[string]string{
+							"access-key": "key",
+							"secret-key": "secret",
+						},
+					),
+					"down": jujucloud.NewCredential(
+						jujucloud.UserPassAuthType,
+						map[string]string{
+							"username": "user",
+							"password": "password",
+						},
+					),
+				},
+			},
+			"google": {
+				AuthCredentials: map[string]jujucloud.Credential{
+					"default": jujucloud.NewCredential(
+						jujucloud.OAuth2AuthType,
+						map[string]string{
+							"client-id":    "id",
+							"client-email": "email",
+							"private-key":  "key",
+						},
+					),
+				},
+			},
+			"azure": {
+				AuthCredentials: map[string]jujucloud.Credential{
+					"azhja": jujucloud.NewCredential(
+						jujucloud.UserPassAuthType,
+						map[string]string{
+							"application-id":       "app-id",
+							"application-password": "app-secret",
+							"subscription-id":      "subscription-id",
+							"tenant-id":            "tenant-id",
+						},
+					),
+				},
+			},
+			"mycloud": {
+				AuthCredentials: map[string]jujucloud.Credential{
+					"me": jujucloud.NewCredential(
+						jujucloud.AccessKeyAuthType,
+						map[string]string{
+							"access-key": "key",
+							"secret-key": "secret",
+						},
+					),
+				},
+			},
+		},
 	}
 }
 
 func (s *listCredentialsSuite) TestListCredentialsTabular(c *gc.C) {
 	out := s.listCredentials(c)
 	c.Assert(out, gc.Equals, `
-CLOUD  CREDENTIALS
-aws    down*, bob
-azure  azhja
+CLOUD          CREDENTIALS
+aws            down*, bob
+azure          azhja
+google         default
+local:mycloud  me
 
 `[1:])
 }
@@ -86,8 +124,8 @@ aws    down*, bob
 `[1:])
 }
 
-func (s *listCredentialsSuite) TestListCredentialsYAML(c *gc.C) {
-	out := s.listCredentials(c, "--format", "yaml")
+func (s *listCredentialsSuite) TestListCredentialsYAMLWithSecrets(c *gc.C) {
+	out := s.listCredentials(c, "--format", "yaml", "--show-secrets")
 	c.Assert(out, gc.Equals, `
 credentials:
   aws:
@@ -98,10 +136,9 @@ credentials:
       access-key: key
       secret-key: secret
     down:
-      auth-type: oauth2
-      client-email: email
-      client-id: id
-      private-key: key
+      auth-type: userpass
+      password: password
+      username: user
   azure:
     azhja:
       auth-type: userpass
@@ -109,6 +146,48 @@ credentials:
       application-password: app-secret
       subscription-id: subscription-id
       tenant-id: tenant-id
+  google:
+    default:
+      auth-type: oauth2
+      client-email: email
+      client-id: id
+      private-key: key
+  local:mycloud:
+    me:
+      auth-type: access-key
+      access-key: key
+      secret-key: secret
+`[1:])
+}
+
+func (s *listCredentialsSuite) TestListCredentialsYAMLNoSecrets(c *gc.C) {
+	out := s.listCredentials(c, "--format", "yaml")
+	c.Assert(out, gc.Equals, `
+credentials:
+  aws:
+    default-credential: down
+    default-region: ap-southeast-2
+    bob:
+      auth-type: access-key
+      access-key: key
+    down:
+      auth-type: userpass
+      username: user
+  azure:
+    azhja:
+      auth-type: userpass
+      application-id: app-id
+      subscription-id: subscription-id
+      tenant-id: tenant-id
+  google:
+    default:
+      auth-type: oauth2
+      client-email: email
+      client-id: id
+  local:mycloud:
+    me:
+      auth-type: access-key
+      access-key: key
 `[1:])
 }
 
@@ -120,7 +199,6 @@ credentials:
     azhja:
       auth-type: userpass
       application-id: app-id
-      application-password: app-secret
       subscription-id: subscription-id
       tenant-id: tenant-id
 `[1:])
@@ -132,7 +210,7 @@ func (s *listCredentialsSuite) TestListCredentialsJSON(c *gc.C) {
 }
 
 func (s *listCredentialsSuite) TestListCredentialsNone(c *gc.C) {
-	listCmd := cloud.NewListCredentialsCommandForTest(jujuclienttesting.NewMemStore())
+	listCmd := cloud.NewListCredentialsCommandForTest(jujuclienttesting.NewMemStore(), s.personalCloudsFunc, s.cloudByNameFunc)
 	ctx, err := testing.RunCommand(c, listCmd)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(testing.Stderr(ctx), gc.Equals, "")
@@ -149,7 +227,7 @@ func (s *listCredentialsSuite) TestListCredentialsNone(c *gc.C) {
 }
 
 func (s *listCredentialsSuite) listCredentials(c *gc.C, args ...string) string {
-	ctx, err := testing.RunCommand(c, cloud.NewListCredentialsCommandForTest(s.store), args...)
+	ctx, err := testing.RunCommand(c, cloud.NewListCredentialsCommandForTest(s.store, s.personalCloudsFunc, s.cloudByNameFunc), args...)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(testing.Stderr(ctx), gc.Equals, "")
 	return testing.Stdout(ctx)

--- a/cmd/juju/controller/showcontroller.go
+++ b/cmd/juju/controller/showcontroller.go
@@ -39,7 +39,7 @@ func (c *showControllerCommand) Info() *cmd.Info {
 // SetFlags implements Command.SetFlags.
 func (c *showControllerCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.JujuCommandBase.SetFlags(f)
-	f.BoolVar(&c.includePasswords, "include-passwords", false, "show passwords for displayed accounts")
+	f.BoolVar(&c.showPasswords, "show-passwords", false, "show passwords for displayed accounts")
 	c.out.AddFlags(f, "yaml", map[string]cmd.Formatter{
 		"yaml": cmd.FormatYaml,
 		"json": cmd.FormatJson,
@@ -149,7 +149,7 @@ func (c *showControllerCommand) convertAccountsForShow(controllerName string, co
 		for accountName, account := range accounts {
 			details := &AccountDetails{User: account.User}
 			controller.Accounts[accountName] = details
-			if c.includePasswords {
+			if c.showPasswords {
 				details.Password = account.Password
 			}
 			if err := c.convertModelsForShow(controllerName, accountName, details); err != nil {
@@ -190,8 +190,8 @@ type showControllerCommand struct {
 	out   cmd.Output
 	store jujuclient.ClientStore
 
-	controllerNames  []string
-	includePasswords bool
+	controllerNames []string
+	showPasswords   bool
 }
 
 const showControllerDoc = `

--- a/cmd/juju/controller/showcontroller_test.go
+++ b/cmd/juju/controller/showcontroller_test.go
@@ -94,7 +94,7 @@ local.mallards:
   current-account: admin@local
 `[1:]
 
-	s.assertShowController(c, "local.mallards", "--include-passwords")
+	s.assertShowController(c, "local.mallards", "--show-passwords")
 }
 
 func (s *ShowControllerSuite) TestShowOneControllerManyInStore(c *gc.C) {


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/juju-core/+bug/1552408

and also

add a --show-secrets flag to list-credentials. 
Now, by default, secrets are hidden unless --show-secrets is used.

Also as a drive by, fix the --include-passwords flag for show-controller - rename to show-passwords

(Review request: http://reviews.vapour.ws/r/4053/)