### PR TITLE
Fix intermittent test bug #1552589.

### DIFF
--- a/worker/provisioner/provisioner.go
+++ b/worker/provisioner/provisioner.go
@@ -135,7 +135,7 @@ func (p *provisioner) getStartTask(harvestMode config.HarvestMode) (ProvisionerT
 	tag := p.agentConfig.Tag()
 	machineTag, ok := tag.(names.MachineTag)
 	if !ok {
-		errors.Errorf("expacted names.MachineTag, got %T", tag)
+		errors.Errorf("expected names.MachineTag, got %T", tag)
 	}
 
 	envCfg, err := p.st.ModelConfig()
@@ -210,7 +210,9 @@ func (p *environProvisioner) loop() error {
 	}
 	p.broker = p.environ
 
-	harvestMode := p.environ.Config().ProvisionerHarvestMode()
+	modelConfig := p.environ.Config()
+	p.configObserver.notify(modelConfig)
+	harvestMode := modelConfig.ProvisionerHarvestMode()
 	task, err := p.getStartTask(harvestMode)
 	if err != nil {
 		return loggedErrorStack(errors.Trace(err))
@@ -227,14 +229,14 @@ func (p *environProvisioner) loop() error {
 			if !ok {
 				return errors.New("model configuration watcher closed")
 			}
-			environConfig, err := p.st.ModelConfig()
+			modelConfig, err := p.st.ModelConfig()
 			if err != nil {
 				return errors.Annotate(err, "cannot load model configuration")
 			}
-			if err := p.setConfig(environConfig); err != nil {
+			if err := p.setConfig(modelConfig); err != nil {
 				return errors.Annotate(err, "loaded invalid model configuration")
 			}
-			task.SetHarvestMode(environConfig.ProvisionerHarvestMode())
+			task.SetHarvestMode(modelConfig.ProvisionerHarvestMode())
 		}
 	}
 }
@@ -249,11 +251,11 @@ func (p *environProvisioner) getRetryWatcher() (watcher.NotifyWatcher, error) {
 
 // setConfig updates the environment configuration and notifies
 // the config observer.
-func (p *environProvisioner) setConfig(environConfig *config.Config) error {
-	if err := p.environ.SetConfig(environConfig); err != nil {
+func (p *environProvisioner) setConfig(modelConfig *config.Config) error {
+	if err := p.environ.SetConfig(modelConfig); err != nil {
 		return err
 	}
-	p.configObserver.notify(environConfig)
+	p.configObserver.notify(modelConfig)
 	return nil
 }
 
@@ -299,11 +301,12 @@ func (p *containerProvisioner) loop() error {
 		return errors.Trace(err)
 	}
 
-	config, err := p.st.ModelConfig()
+	modelConfig, err := p.st.ModelConfig()
 	if err != nil {
 		return err
 	}
-	harvestMode := config.ProvisionerHarvestMode()
+	p.configObserver.notify(modelConfig)
+	harvestMode := modelConfig.ProvisionerHarvestMode()
 
 	task, err := p.getStartTask(harvestMode)
 	if err != nil {


### PR DESCRIPTION
It was possible to change the configuration before the provisioner task
was started, and thus there was never any change to observe.
Now we always observer the initial config. It means the test itself
is slightly weaker, because sometimes we never observer the *change*,
but at least the test doesn't accidentally fail.
A better fix would be to wait to change the config until you know
that the config has already been seen. However, we can't do that
via the Observer interface, because there is a race that we
could have already started the Task before we get a chance to
set the observer.

(Review request: http://reviews.vapour.ws/r/4054/)