### PR TITLE
Fix Bundle deploys fail at lxc-start when bridge br-eth1 is created

### DIFF
--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -1042,13 +1042,20 @@ fi
 
 if [ ! -z "${juju_networking_preferred_python_binary:-}" ]; then
     if [ -f %[1]q ]; then
-        ${juju_networking_preferred_python_binary} %[1]q --bridge-prefix=%q --one-time-backup --activate %q
+        juju_bridge_all_interfaces=0
+        if [ $juju_bridge_all_interfaces -eq 1 ]; then
+            $juju_networking_preferred_python_binary %[1]q --bridge-prefix=%[2]q --one-time-backup --activate %[4]q
+        else
+            juju_ipv4_interface_to_bridge=$(ip -4 route list exact default | head -n1 | cut -d' ' -f5)
+            $juju_networking_preferred_python_binary %[1]q --bridge-name=%[3]q --interface-to-bridge="${juju_ipv4_interface_to_bridge:-unknown}" --one-time-backup --activate %[4]q
+        fi
     fi
 else
     echo "error: no Python installation found; cannot run Juju's bridge script"
 fi`,
 		bridgeScriptPath,
 		instancecfg.DefaultBridgePrefix,
+		instancecfg.DefaultBridgeName,
 		"/etc/network/interfaces")
 }
 

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -1042,6 +1042,10 @@ fi
 
 if [ ! -z "${juju_networking_preferred_python_binary:-}" ]; then
     if [ -f %[1]q ]; then
+# We are sharing this code between master, maas-spaces2 and 1.25.
+# For the moment we want master and 1.25 to not bridge all interfaces.
+# This setting allows us to easily switch the behaviour when merging
+# the code between those various branches.
         juju_bridge_all_interfaces=0
         if [ $juju_bridge_all_interfaces -eq 1 ]; then
             $juju_networking_preferred_python_binary %[1]q --bridge-prefix=%[2]q --one-time-backup --activate %[4]q

--- a/worker/provisioner/export_test.go
+++ b/worker/provisioner/export_test.go
@@ -29,23 +29,25 @@ func GetRetryWatcher(p Provisioner) (watcher.NotifyWatcher, error) {
 }
 
 var (
-	ContainerManagerConfig     = containerManagerConfig
-	GetToolsFinder             = &getToolsFinder
-	SysctlConfig               = &sysctlConfig
-	ResolvConf                 = &resolvConf
-	LocalDNSServers            = localDNSServers
-	MustParseTemplate          = mustParseTemplate
-	RunTemplateCommand         = runTemplateCommand
-	IptablesRules              = &iptablesRules
-	NetInterfaces              = &netInterfaces
-	InterfaceAddrs             = &interfaceAddrs
-	DiscoverPrimaryNIC         = discoverPrimaryNIC
-	ConfigureContainerNetwork  = configureContainerNetwork
-	MaybeOverrideDefaultLXCNet = maybeOverrideDefaultLXCNet
-	EtcDefaultLXCNetPath       = &etcDefaultLXCNetPath
-	EtcDefaultLXCNet           = etcDefaultLXCNet
-	RetryStrategyDelay         = &retryStrategyDelay
-	RetryStrategyCount         = &retryStrategyCount
+	ContainerManagerConfig       = containerManagerConfig
+	GetToolsFinder               = &getToolsFinder
+	SysctlConfig                 = &sysctlConfig
+	ResolvConf                   = &resolvConf
+	LocalDNSServers              = localDNSServers
+	MustParseTemplate            = mustParseTemplate
+	RunTemplateCommand           = runTemplateCommand
+	IptablesRules                = &iptablesRules
+	NetInterfaceByName           = &netInterfaceByName
+	NetInterfaces                = &netInterfaces
+	InterfaceAddrs               = &interfaceAddrs
+	DiscoverPrimaryNIC           = discoverPrimaryNIC
+	DiscoverIPv4InterfaceAddress = discoverIPv4InterfaceAddress
+	ConfigureContainerNetwork    = configureContainerNetwork
+	MaybeOverrideDefaultLXCNet   = maybeOverrideDefaultLXCNet
+	EtcDefaultLXCNetPath         = &etcDefaultLXCNetPath
+	EtcDefaultLXCNet             = etcDefaultLXCNet
+	RetryStrategyDelay           = &retryStrategyDelay
+	RetryStrategyCount           = &retryStrategyCount
 )
 
 const (

--- a/worker/provisioner/lxc-broker.go
+++ b/worker/provisioner/lxc-broker.go
@@ -508,7 +508,6 @@ func discoverIPv4InterfaceAddress(ifaceName string) (*network.Address, error) {
 	}
 
 	for _, addr := range addrs {
-		// We found it.
 		// Check if it's an IP or a CIDR.
 
 		ip := net.ParseIP(addr.String())

--- a/worker/provisioner/lxc-broker.go
+++ b/worker/provisioner/lxc-broker.go
@@ -488,8 +488,9 @@ var setupRoutesAndIPTables = func(
 }
 
 var (
-	netInterfaces  = net.Interfaces
-	interfaceAddrs = (*net.Interface).Addrs
+	netInterfaceByName = net.InterfaceByName
+	netInterfaces      = net.Interfaces
+	interfaceAddrs     = (*net.Interface).Addrs
 )
 
 // discoverIPv4InterfaceAddress returns the address for ifaceName
@@ -497,12 +498,13 @@ var (
 // master CI failures and will be removed once multi-NIC container
 // support is landed from the maas-spaces2 feature branch.
 func discoverIPv4InterfaceAddress(ifaceName string) (*network.Address, error) {
-	iface, err := net.InterfaceByName(ifaceName)
+	iface, err := netInterfaceByName(ifaceName)
 	if err != nil {
 		return nil, errors.Annotatef(err, "cannot get interface %q", ifaceName)
 	}
 
-	addrs, err := iface.Addrs()
+	addrs, err := interfaceAddrs(iface)
+
 	if err != nil {
 		return nil, errors.Annotatef(err, "cannot get network addresses for interface %q", ifaceName)
 	}
@@ -532,7 +534,7 @@ func discoverIPv4InterfaceAddress(ifaceName string) (*network.Address, error) {
 		addr := network.NewAddress(ip.String())
 		return &addr, nil
 	}
-	return nil, errors.Annotatef(err, "no addresses found for %q", ifaceName)
+	return nil, errors.Errorf("no addresses found for %q", ifaceName)
 }
 
 func discoverPrimaryNIC() (string, network.Address, error) {

--- a/worker/provisioner/lxc-broker_test.go
+++ b/worker/provisioner/lxc-broker_test.go
@@ -770,24 +770,28 @@ func (s *lxcBrokerSuite) TestSetupRoutesAndIPTablesAddsRuleIfMissing(c *gc.C) {
 	gitjujutesting.AssertEchoArgs(c, "ip", "route", "add", "0.1.2.3", "dev", "bridge")
 }
 
-func (s *lxcBrokerSuite) TestDiscoverIPv4InterfaceByNameUnknownInterfaceNameError(c *gc.C) {
-	s.PatchValue(provisioner.NetInterfaceByName, func(ifaceName string) (*net.Interface, error) {
-		c.Assert(ifaceName, gc.Matches, "ka")
-		return nil, errors.New("boom!")
+func (s *lxcBrokerSuite) patchNetInterfaceByName(c *gc.C, interfaceName string) {
+	s.PatchValue(provisioner.NetInterfaceByName, func(name string) (*net.Interface, error) {
+		if interfaceName != name {
+			return nil, errors.New("no such network interface")
+		}
+		return &net.Interface{
+			Index: 0,
+			Name:  name,
+			Flags: net.FlagUp,
+		}, nil
 	})
-	addr, err := provisioner.DiscoverIPv4InterfaceAddress("ka")
-	c.Assert(err, gc.ErrorMatches, `cannot get interface "ka": boom!`)
+}
+
+func (s *lxcBrokerSuite) TestDiscoverIPv4InterfaceByNameUnknownInterfaceNameError(c *gc.C) {
+	s.patchNetInterfaceByName(c, "fake")
+	addr, err := provisioner.DiscoverIPv4InterfaceAddress("fake2")
+	c.Assert(err, gc.ErrorMatches, `cannot get interface "fake2": no such network interface`)
 	c.Assert(addr, gc.IsNil)
 }
 
 func (s *lxcBrokerSuite) TestDiscoverIPv4InterfaceByNameAddressError(c *gc.C) {
-	s.PatchValue(provisioner.NetInterfaceByName, func(ifaceName string) (*net.Interface, error) {
-		return &net.Interface{
-			Index: 0,
-			Name:  "fake",
-			Flags: net.FlagUp,
-		}, nil
-	})
+	s.patchNetInterfaceByName(c, "fake")
 	s.PatchValue(provisioner.InterfaceAddrs, func(i *net.Interface) ([]net.Addr, error) {
 		c.Assert(i.Name, gc.Matches, "fake")
 		return nil, errors.New("boom!")
@@ -798,13 +802,7 @@ func (s *lxcBrokerSuite) TestDiscoverIPv4InterfaceByNameAddressError(c *gc.C) {
 }
 
 func (s *lxcBrokerSuite) TestDiscoverIPv4InterfaceByNameInvalidAddr(c *gc.C) {
-	s.PatchValue(provisioner.NetInterfaceByName, func(ifaceName string) (*net.Interface, error) {
-		return &net.Interface{
-			Index: 0,
-			Name:  "fake",
-			Flags: net.FlagUp,
-		}, nil
-	})
+	s.patchNetInterfaceByName(c, "fake")
 	s.PatchValue(provisioner.InterfaceAddrs, func(i *net.Interface) ([]net.Addr, error) {
 		c.Assert(i.Name, gc.Matches, "fake")
 		return []net.Addr{&fakeAddr{}}, nil
@@ -815,13 +813,7 @@ func (s *lxcBrokerSuite) TestDiscoverIPv4InterfaceByNameInvalidAddr(c *gc.C) {
 }
 
 func (s *lxcBrokerSuite) TestDiscoverIPv4InterfaceByNameZeroAddresses(c *gc.C) {
-	s.PatchValue(provisioner.NetInterfaceByName, func(ifaceName string) (*net.Interface, error) {
-		return &net.Interface{
-			Index: 0,
-			Name:  "fake",
-			Flags: net.FlagUp,
-		}, nil
-	})
+	s.patchNetInterfaceByName(c, "fake")
 	s.PatchValue(provisioner.InterfaceAddrs, func(i *net.Interface) ([]net.Addr, error) {
 		c.Assert(i, gc.NotNil)
 		c.Assert(i.Name, gc.Matches, "fake")
@@ -833,13 +825,7 @@ func (s *lxcBrokerSuite) TestDiscoverIPv4InterfaceByNameZeroAddresses(c *gc.C) {
 }
 
 func (s *lxcBrokerSuite) TestDiscoverIPv4InterfaceByNameIPv6CIDRAddrError(c *gc.C) {
-	s.PatchValue(provisioner.NetInterfaceByName, func(ifaceName string) (*net.Interface, error) {
-		return &net.Interface{
-			Index: 0,
-			Name:  "fake",
-			Flags: net.FlagUp,
-		}, nil
-	})
+	s.patchNetInterfaceByName(c, "fake")
 	s.PatchValue(provisioner.InterfaceAddrs, func(i *net.Interface) ([]net.Addr, error) {
 		c.Assert(i, gc.NotNil)
 		c.Assert(i.Name, gc.Matches, "fake")
@@ -851,13 +837,7 @@ func (s *lxcBrokerSuite) TestDiscoverIPv4InterfaceByNameIPv6CIDRAddrError(c *gc.
 }
 
 func (s *lxcBrokerSuite) TestDiscoverIPv4InterfaceByNameOnlyHasIPv6AddrError(c *gc.C) {
-	s.PatchValue(provisioner.NetInterfaceByName, func(ifaceName string) (*net.Interface, error) {
-		return &net.Interface{
-			Index: 0,
-			Name:  "fake",
-			Flags: net.FlagUp,
-		}, nil
-	})
+	s.patchNetInterfaceByName(c, "fake")
 	s.PatchValue(provisioner.InterfaceAddrs, func(i *net.Interface) ([]net.Addr, error) {
 		c.Assert(i, gc.NotNil)
 		c.Assert(i.Name, gc.Matches, "fake")
@@ -871,13 +851,7 @@ func (s *lxcBrokerSuite) TestDiscoverIPv4InterfaceByNameOnlyHasIPv6AddrError(c *
 }
 
 func (s *lxcBrokerSuite) TestDiscoverIPv4InterfaceByNameIPv4CIDRAddrError(c *gc.C) {
-	s.PatchValue(provisioner.NetInterfaceByName, func(ifaceName string) (*net.Interface, error) {
-		return &net.Interface{
-			Index: 0,
-			Name:  "fake",
-			Flags: net.FlagUp,
-		}, nil
-	})
+	s.patchNetInterfaceByName(c, "fake")
 	s.PatchValue(provisioner.InterfaceAddrs, func(i *net.Interface) ([]net.Addr, error) {
 		c.Assert(i, gc.NotNil)
 		c.Assert(i.Name, gc.Matches, "fake")
@@ -889,61 +863,43 @@ func (s *lxcBrokerSuite) TestDiscoverIPv4InterfaceByNameIPv4CIDRAddrError(c *gc.
 }
 
 func (s *lxcBrokerSuite) TestDiscoverIPv4InterfaceByNameSuccessWithCIDRAddress(c *gc.C) {
-	s.PatchValue(provisioner.NetInterfaceByName, func(ifaceName string) (*net.Interface, error) {
-		return &net.Interface{
-			Index: 0,
-			Name:  "good",
-			Flags: net.FlagUp,
-		}, nil
-	})
+	s.patchNetInterfaceByName(c, "fake")
 	s.PatchValue(provisioner.InterfaceAddrs, func(i *net.Interface) ([]net.Addr, error) {
 		c.Assert(i, gc.NotNil)
-		c.Assert(i.Name, gc.Matches, "good")
+		c.Assert(i.Name, gc.Matches, "fake")
 		return []net.Addr{&fakeAddr{"192.168.1.42/24"}}, nil
 	})
-	addr, err := provisioner.DiscoverIPv4InterfaceAddress("good")
+	addr, err := provisioner.DiscoverIPv4InterfaceAddress("fake")
 	c.Assert(err, gc.IsNil)
 	c.Assert(addr, gc.Not(gc.IsNil))
 	c.Assert(*addr, jc.DeepEquals, network.NewAddress("192.168.1.42"))
 }
 
 func (s *lxcBrokerSuite) TestDiscoverIPv4InterfaceByNameSuccess(c *gc.C) {
-	s.PatchValue(provisioner.NetInterfaceByName, func(ifaceName string) (*net.Interface, error) {
-		return &net.Interface{
-			Index: 0,
-			Name:  "good",
-			Flags: net.FlagUp,
-		}, nil
-	})
+	s.patchNetInterfaceByName(c, "fake")
 	s.PatchValue(provisioner.InterfaceAddrs, func(i *net.Interface) ([]net.Addr, error) {
 		c.Assert(i, gc.NotNil)
-		c.Assert(i.Name, gc.Matches, "good")
+		c.Assert(i.Name, gc.Matches, "fake")
 		return []net.Addr{&fakeAddr{"192.168.1.42"}}, nil
 	})
-	addr, err := provisioner.DiscoverIPv4InterfaceAddress("good")
+	addr, err := provisioner.DiscoverIPv4InterfaceAddress("fake")
 	c.Assert(err, gc.IsNil)
 	c.Assert(addr, gc.NotNil)
 	c.Assert(*addr, jc.DeepEquals, network.NewAddress("192.168.1.42"))
 }
 
 func (s *lxcBrokerSuite) TestDiscoverIPv4InterfaceByNameMixtureOfIPv6AndIPv4Success(c *gc.C) {
-	s.PatchValue(provisioner.NetInterfaceByName, func(ifaceName string) (*net.Interface, error) {
-		return &net.Interface{
-			Index: 0,
-			Name:  "good",
-			Flags: net.FlagUp,
-		}, nil
-	})
+	s.patchNetInterfaceByName(c, "fake")
 	s.PatchValue(provisioner.InterfaceAddrs, func(i *net.Interface) ([]net.Addr, error) {
 		c.Assert(i, gc.NotNil)
-		c.Assert(i.Name, gc.Matches, "good")
+		c.Assert(i.Name, gc.Matches, "fake")
 		return []net.Addr{
 			&fakeAddr{"::1"},
 			&fakeAddr{"f000::1"},
 			&fakeAddr{"192.168.1.42"},
 		}, nil
 	})
-	addr, err := provisioner.DiscoverIPv4InterfaceAddress("good")
+	addr, err := provisioner.DiscoverIPv4InterfaceAddress("fake")
 	c.Assert(err, gc.IsNil)
 	c.Assert(addr, gc.NotNil)
 	c.Assert(*addr, jc.DeepEquals, network.NewAddress("192.168.1.42"))

--- a/worker/provisioner/lxc-broker_test.go
+++ b/worker/provisioner/lxc-broker_test.go
@@ -804,13 +804,13 @@ func (s *lxcBrokerSuite) checkDiscoverIPv4InterfaceAddressesFails(c *gc.C, iface
 	c.Assert(addr, gc.IsNil)
 }
 
-func (s *lxcBrokerSuite) checkDiscoverIPv4InterfaceAddress(c *gc.C, ifaceName string, expectedAddress network.Address, fakeAddrs ...string) {
+func (s *lxcBrokerSuite) checkDiscoverIPv4InterfaceAddress(c *gc.C, ifaceName, expectedAddress string, fakeAddrs ...string) {
 	s.patchNetInterfaceByName(c, ifaceName)
 	s.patchNetInterfaceByNameAddrs(c, ifaceName, fakeAddrs...)
 	addr, err := provisioner.DiscoverIPv4InterfaceAddress(ifaceName)
 	c.Assert(err, gc.IsNil)
 	c.Assert(addr, gc.Not(gc.IsNil))
-	c.Assert(*addr, gc.Equals, expectedAddress)
+	c.Assert(*addr, gc.Equals, network.NewAddress(expectedAddress))
 }
 
 func (s *lxcBrokerSuite) TestDiscoverIPv4InterfaceByNameUnknownInterfaceNameError(c *gc.C) {
@@ -852,15 +852,15 @@ func (s *lxcBrokerSuite) TestDiscoverIPv4InterfaceByNameIPv4CIDRAddrError(c *gc.
 }
 
 func (s *lxcBrokerSuite) TestDiscoverIPv4InterfaceByNameSuccessWithCIDRAddress(c *gc.C) {
-	s.checkDiscoverIPv4InterfaceAddress(c, "fake", network.NewAddress("192.168.1.42"), "192.168.1.42/24")
+	s.checkDiscoverIPv4InterfaceAddress(c, "fake", "192.168.1.42", "192.168.1.42/24")
 }
 
 func (s *lxcBrokerSuite) TestDiscoverIPv4InterfaceByNameSuccess(c *gc.C) {
-	s.checkDiscoverIPv4InterfaceAddress(c, "fake", network.NewAddress("192.168.1.42"), "192.168.1.42")
+	s.checkDiscoverIPv4InterfaceAddress(c, "fake", "192.168.1.42", "192.168.1.42")
 }
 
 func (s *lxcBrokerSuite) TestDiscoverIPv4InterfaceByNameMixtureOfIPv6AndIPv4Success(c *gc.C) {
-	s.checkDiscoverIPv4InterfaceAddress(c, "fake", network.NewAddress("192.168.1.42"), "::1", "f000::1", "192.168.1.42")
+	s.checkDiscoverIPv4InterfaceAddress(c, "fake", "192.168.1.42", "::1", "f000::1", "192.168.1.42")
 }
 
 func (s *lxcBrokerSuite) TestDiscoverPrimaryNICNetInterfacesError(c *gc.C) {

--- a/worker/provisioner/lxc-broker_test.go
+++ b/worker/provisioner/lxc-broker_test.go
@@ -784,10 +784,10 @@ func (s *lxcBrokerSuite) patchNetInterfaceByName(c *gc.C, interfaceName string) 
 }
 
 func (s *lxcBrokerSuite) patchNetInterfaceByNameAddrs(c *gc.C, interfaceName string, fakeAddrs ...string) {
-	addrs := make([]net.Addr, 0)
+	addrs := make([]net.Addr, len(fakeAddrs))
 
-	for _, a := range fakeAddrs {
-		addrs = append(addrs, &fakeAddr{a})
+	for i, a := range fakeAddrs {
+		addrs[i] = &fakeAddr{a}
 	}
 
 	s.PatchValue(provisioner.InterfaceAddrs, func(i *net.Interface) ([]net.Addr, error) {


### PR DESCRIPTION
These changes are to facilitate the unblocking of CI testing on master
and will go away once the full multi-NIC container solution is merged
from maas-spaces2.
    
Fixes [LP:#1549545](https://bugs.launchpad.net/juju-core/+bug/1549545)

(Review request: http://reviews.vapour.ws/r/4055/)