### PR TITLE
api: Add client side APIs for the migration master worker

### DIFF
--- a/api/migrationmaster/client.go
+++ b/api/migrationmaster/client.go
@@ -1,0 +1,37 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package migrationmaster
+
+import (
+	"github.com/juju/juju/api/base"
+	apiwatcher "github.com/juju/juju/api/watcher"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/watcher"
+)
+
+// NewClient returns a new Client based on an existing API connection.
+func NewClient(caller base.APICaller) *Client {
+	return &Client{base.NewFacadeCaller(caller, "MigrationMaster")}
+}
+
+// Client provides the client side API for the MigrationMaster facade
+// (to be used by the migration master worker).
+type Client struct {
+	caller base.FacadeCaller
+}
+
+// Watch returns a watcher which reports when a migration is active
+// for the model associated with the API connection.
+func (c *Client) Watch() (watcher.MigrationMasterWatcher, error) {
+	var result params.NotifyWatchResult
+	err := c.caller.FacadeCall("Watch", nil, &result)
+	if err != nil {
+		return nil, err
+	}
+	if result.Error != nil {
+		return nil, result.Error
+	}
+	w := apiwatcher.NewMigrationMasterWatcher(c.caller.RawAPICaller(), result.NotifyWatcherId)
+	return w, nil
+}

--- a/api/migrationmaster/client_test.go
+++ b/api/migrationmaster/client_test.go
@@ -27,7 +27,7 @@ var _ = gc.Suite(&ClientSuite{})
 func (s *ClientSuite) TestWatch(c *gc.C) {
 	var stub jujutesting.Stub
 	apiCaller := apitesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
-		stub.AddCall("call", objType, version, id, request, arg)
+		stub.AddCall("call", objType, id, request, arg)
 		switch request {
 		case "Watch":
 			*(result.(*params.NotifyWatchResult)) = params.NotifyWatchResult{
@@ -55,9 +55,9 @@ func (s *ClientSuite) TestWatch(c *gc.C) {
 	case err := <-errC:
 		c.Assert(err, gc.ErrorMatches, "boom")
 		stub.CheckCalls(c, []jujutesting.StubCall{
-			{"call", []interface{}{"MigrationMaster", 0, "", "Watch", nil}},
-			{"call", []interface{}{"MigrationMasterWatcher", 0, "abc", "Next", nil}},
-			{"call", []interface{}{"MigrationMasterWatcher", 0, "abc", "Stop", nil}},
+			{"call", []interface{}{"MigrationMaster", "", "Watch", nil}},
+			{"call", []interface{}{"MigrationMasterWatcher", "abc", "Next", nil}},
+			{"call", []interface{}{"MigrationMasterWatcher", "abc", "Stop", nil}},
 		})
 	case <-time.After(coretesting.LongWait):
 		c.Fatal("timed out waiting for watcher to die")

--- a/api/migrationmaster/client_test.go
+++ b/api/migrationmaster/client_test.go
@@ -1,0 +1,75 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package migrationmaster_test
+
+import (
+	"time"
+
+	"github.com/juju/errors"
+	jujutesting "github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	apitesting "github.com/juju/juju/api/base/testing"
+	"github.com/juju/juju/api/migrationmaster"
+	"github.com/juju/juju/apiserver/params"
+	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/worker"
+)
+
+type ClientSuite struct {
+	jujutesting.IsolationSuite
+}
+
+var _ = gc.Suite(&ClientSuite{})
+
+func (s *ClientSuite) TestWatch(c *gc.C) {
+	var stub jujutesting.Stub
+	apiCaller := apitesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		stub.AddCall("call", objType, version, id, request, arg)
+		switch request {
+		case "Watch":
+			*(result.(*params.NotifyWatchResult)) = params.NotifyWatchResult{
+				NotifyWatcherId: "abc",
+			}
+		case "Next":
+			// The full success case is tested in api/watcher.
+			return errors.New("boom")
+		case "Stop":
+		}
+		return nil
+	})
+
+	client := migrationmaster.NewClient(apiCaller)
+	w, err := client.Watch()
+	c.Assert(err, jc.ErrorIsNil)
+	defer worker.Stop(w)
+
+	errC := make(chan error)
+	go func() {
+		errC <- w.Wait()
+	}()
+
+	select {
+	case err := <-errC:
+		c.Assert(err, gc.ErrorMatches, "boom")
+		stub.CheckCalls(c, []jujutesting.StubCall{
+			{"call", []interface{}{"MigrationMaster", 0, "", "Watch", nil}},
+			{"call", []interface{}{"MigrationMasterWatcher", 0, "abc", "Next", nil}},
+			{"call", []interface{}{"MigrationMasterWatcher", 0, "abc", "Stop", nil}},
+		})
+	case <-time.After(coretesting.LongWait):
+		c.Fatal("timed out waiting for watcher to die")
+	}
+}
+
+func (s *ClientSuite) TestWatchErr(c *gc.C) {
+	apiCaller := apitesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		return errors.New("boom")
+	})
+
+	client := migrationmaster.NewClient(apiCaller)
+	_, err := client.Watch()
+	c.Assert(err, gc.ErrorMatches, "boom")
+}

--- a/api/migrationmaster/package_test.go
+++ b/api/migrationmaster/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package migrationmaster_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/api/watcher/watcher_test.go
+++ b/api/watcher/watcher_test.go
@@ -6,12 +6,16 @@ package watcher_test
 import (
 	"time"
 
+	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/api"
+	"github.com/juju/juju/api/migrationmaster"
 	"github.com/juju/juju/api/watcher"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/modelmigration"
 	"github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/storage"
@@ -21,6 +25,7 @@ import (
 	"github.com/juju/juju/testing/factory"
 	corewatcher "github.com/juju/juju/watcher"
 	"github.com/juju/juju/watcher/watchertest"
+	"github.com/juju/juju/worker"
 )
 
 type watcherSuite struct {
@@ -254,5 +259,69 @@ func (s *watcherSuite) TestWatchMachineStorage(c *gc.C) {
 	case <-w.Changes():
 		c.Fatalf("received unexpected change")
 	case <-time.After(coretesting.ShortWait):
+	}
+}
+
+type migrationWatcherSuite struct {
+	testing.JujuConnSuite
+}
+
+func (s *migrationWatcherSuite) TestWatch(c *gc.C) {
+	// Create a state server
+	m, password := s.Factory.MakeMachineReturningPassword(c, &factory.MachineParams{
+		Jobs:  []state.MachineJob{state.JobManageModel},
+		Nonce: "noncey",
+	})
+
+	// Create a model to migrate.
+	hostedState := s.Factory.MakeModel(c, nil)
+
+	// Connect as a state server to the hosted environment.
+	apiInfo := s.APIInfo(c)
+	apiInfo.Tag = m.Tag()
+	apiInfo.Password = password
+	apiInfo.ModelTag = hostedState.ModelTag()
+	apiInfo.Nonce = "noncey"
+
+	apiConn, err := api.Open(apiInfo, api.DialOpts{})
+	c.Assert(err, jc.ErrorIsNil)
+	defer apiConn.Close()
+
+	// Start watching for a migration.
+	client := migrationmaster.NewClient(apiConn)
+	w, err := client.Watch()
+	c.Assert(err, jc.ErrorIsNil)
+	defer func() {
+		c.Assert(worker.Stop(w), jc.ErrorIsNil)
+	}()
+
+	// Should be no initial events.
+	select {
+	case _, ok := <-w.Changes():
+		c.Fatalf("watcher sent unexpected change: (_, %v)", ok)
+	case <-time.After(coretesting.ShortWait):
+	}
+
+	// Now create a migration.
+	targetInfo := modelmigration.TargetInfo{
+		ControllerTag: names.NewModelTag(utils.MustNewUUID().String()),
+		Addrs:         []string{"1.2.3.4:5"},
+		CACert:        "trust me I'm an authority",
+		AuthTag:       names.NewUserTag("dog"),
+		Password:      "sekret",
+	}
+	_, err = hostedState.CreateModelMigration(state.ModelMigrationSpec{
+		InitiatedBy: names.NewUserTag("someone"),
+		TargetInfo:  targetInfo,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Event with correct target details should be emitted.
+	select {
+	case reportedTargetInfo, ok := <-w.Changes():
+		c.Assert(ok, jc.IsTrue)
+		c.Assert(reportedTargetInfo, jc.DeepEquals, targetInfo)
+	case <-time.After(coretesting.LongWait):
+		c.Fatalf("watcher didn't emit an event")
 	}
 }

--- a/watcher/migrationmaster.go
+++ b/watcher/migrationmaster.go
@@ -1,0 +1,13 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package watcher
+
+import "github.com/juju/juju/core/modelmigration"
+
+// MigrationMasterWatcher describes a watcher that reports the target
+// controller details for an active model migration.
+type MigrationMasterWatcher interface {
+	CoreWatcher
+	Changes() <-chan modelmigration.TargetInfo
+}


### PR DESCRIPTION
This covers the MigrationMaster and MigrationMasterWatcher facades.

(Review request: http://reviews.vapour.ws/r/4058/)