### PR TITLE
Passing stream to image download (fix from xnox).

### DIFF
--- a/apiserver/images.go
+++ b/apiserver/images.go
@@ -142,7 +142,7 @@ func (h *imagesDownloadHandler) fetchAndCacheLxcImage(storage imagestorage.Stora
 	if err != nil {
 		return errors.Trace(err)
 	}
-	imageURL, err := container.ImageDownloadURL(instance.LXC, series, arch, cfg.CloudImageBaseURL())
+	imageURL, err := container.ImageDownloadURL(instance.LXC, series, arch, cfg.ImageStream(), cfg.CloudImageBaseURL())
 	if err != nil {
 		return errors.Annotatef(err, "cannot determine LXC image URL: %v", err)
 	}

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -1008,7 +1008,7 @@ func (a *MachineAgent) updateSupportedContainers(
 				EnvUUID:           envUUID.Id(),
 				CACert:            []byte(agentConfig.CACert()),
 				CloudimgBaseUrl:   cfg.CloudImageBaseURL(),
-				CloudimgStream:    cfg.ImageStream(),
+				Stream:            cfg.ImageStream(),
 				ImageDownloadFunc: container.ImageDownloadURL,
 			})
 	}

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -1004,8 +1004,12 @@ func (a *MachineAgent) updateSupportedContainers(
 			// Explicitly call the non-named constructor so if anyone
 			// adds additional fields, this fails.
 			container.ImageURLGetterConfig{
-				st.Addr(), envUUID.Id(), []byte(agentConfig.CACert()),
-				cfg.CloudImageBaseURL(), container.ImageDownloadURL,
+				ServerRoot:        st.Addr(),
+				EnvUUID:           envUUID.Id(),
+				CACert:            []byte(agentConfig.CACert()),
+				CloudimgBaseUrl:   cfg.CloudImageBaseURL(),
+				CloudimgStream:    cfg.ImageStream(),
+				ImageDownloadFunc: container.ImageDownloadURL,
 			})
 	}
 	params := provisioner.ContainerSetupParams{

--- a/container/image.go
+++ b/container/image.go
@@ -32,7 +32,8 @@ type ImageURLGetterConfig struct {
 	EnvUUID           string
 	CACert            []byte
 	CloudimgBaseUrl   string
-	ImageDownloadFunc func(kind instance.ContainerType, series, arch, cloudimgBaseUrl string) (string, error)
+	Stream            string
+	ImageDownloadFunc func(kind instance.ContainerType, series, arch, stream, cloudimgBaseUrl string) (string, error)
 }
 
 type imageURLGetter struct {
@@ -47,7 +48,7 @@ func NewImageURLGetter(config ImageURLGetterConfig) ImageURLGetter {
 
 // ImageURL is specified on the NewImageURLGetter interface.
 func (ug *imageURLGetter) ImageURL(kind instance.ContainerType, series, arch string) (string, error) {
-	imageURL, err := ug.config.ImageDownloadFunc(kind, series, arch, ug.config.CloudimgBaseUrl)
+	imageURL, err := ug.config.ImageDownloadFunc(kind, series, arch, ug.config.Stream, ug.config.CloudimgBaseUrl)
 	if err != nil {
 		return "", errors.Annotatef(err, "cannot determine LXC image URL: %v", err)
 	}
@@ -66,7 +67,7 @@ func (ug *imageURLGetter) CACert() []byte {
 
 // ImageDownloadURL determines the public URL which can be used to obtain an
 // image blob with the specified parameters.
-func ImageDownloadURL(kind instance.ContainerType, series, arch, cloudimgBaseUrl string) (string, error) {
+func ImageDownloadURL(kind instance.ContainerType, series, arch, stream, cloudimgBaseUrl string) (string, error) {
 	// TODO - we currently only need to support LXC images - kind is ignored.
 	if kind != instance.LXC {
 		return "", errors.Errorf("unsupported container type: %v", kind)
@@ -74,7 +75,7 @@ func ImageDownloadURL(kind instance.ContainerType, series, arch, cloudimgBaseUrl
 
 	// Use the ubuntu-cloudimg-query command to get the url from which to fetch the image.
 	// This will be somewhere on http://cloud-images.ubuntu.com.
-	cmd := exec.Command("ubuntu-cloudimg-query", series, "released", arch, "--format", "%{url}")
+	cmd := exec.Command("ubuntu-cloudimg-query", series, stream, arch, "--format", "%{url}")
 	if cloudimgBaseUrl != "" {
 		// If the base url isn't specified, we don't need to copy the current
 		// environment, because this is the default behaviour of the exec package.

--- a/container/image_test.go
+++ b/container/image_test.go
@@ -28,8 +28,12 @@ func (s *imageURLSuite) SetUpTest(c *gc.C) {
 func (s *imageURLSuite) TestImageURL(c *gc.C) {
 	imageURLGetter := container.NewImageURLGetter(
 		container.ImageURLGetterConfig{
-			"host:port", "12345", []byte("cert"), "",
-			container.ImageDownloadURL,
+			ServerRoot:        "host:port",
+			EnvUUID:           "12345",
+			CACert:            []byte("cert"),
+			CloudimgBaseUrl:   "",
+			Stream:            "released",
+			ImageDownloadFunc: container.ImageDownloadURL,
 		})
 	imageURL, err := imageURLGetter.ImageURL(instance.LXC, "trusty", "amd64")
 	c.Assert(err, gc.IsNil)
@@ -40,13 +44,18 @@ func (s *imageURLSuite) TestImageURL(c *gc.C) {
 func (s *imageURLSuite) TestImageURLOtherBase(c *gc.C) {
 	var calledBaseURL string
 	baseURL := "other://cloud-images"
-	mockFunc := func(kind instance.ContainerType, series, arch, cloudimgBaseUrl string) (string, error) {
+	mockFunc := func(kind instance.ContainerType, series, arch, stream, cloudimgBaseUrl string) (string, error) {
 		calledBaseURL = cloudimgBaseUrl
 		return "omg://wat/trusty-released-amd64-root.tar.gz", nil
 	}
 	imageURLGetter := container.NewImageURLGetter(
 		container.ImageURLGetterConfig{
-			"host:port", "12345", []byte("cert"), baseURL, mockFunc,
+			ServerRoot:        "host:port",
+			EnvUUID:           "12345",
+			CACert:            []byte("cert"),
+			CloudimgBaseUrl:   baseURL,
+			Stream:            "released",
+			ImageDownloadFunc: mockFunc,
 		})
 	imageURL, err := imageURLGetter.ImageURL(instance.LXC, "trusty", "amd64")
 	c.Assert(err, gc.IsNil)
@@ -56,18 +65,18 @@ func (s *imageURLSuite) TestImageURLOtherBase(c *gc.C) {
 }
 
 func (s *imageURLSuite) TestImageDownloadURL(c *gc.C) {
-	imageDownloadURL, err := container.ImageDownloadURL(instance.LXC, "trusty", "amd64", "")
+	imageDownloadURL, err := container.ImageDownloadURL(instance.LXC, "trusty", "amd64", "released", "")
 	c.Assert(err, gc.IsNil)
 	c.Assert(imageDownloadURL, gc.Equals, "test://cloud-images/trusty-released-amd64-root.tar.gz")
 }
 
 func (s *imageURLSuite) TestImageDownloadURLOtherBase(c *gc.C) {
-	imageDownloadURL, err := container.ImageDownloadURL(instance.LXC, "trusty", "amd64", "other://cloud-images")
+	imageDownloadURL, err := container.ImageDownloadURL(instance.LXC, "trusty", "amd64", "released", "other://cloud-images")
 	c.Assert(err, gc.IsNil)
 	c.Assert(imageDownloadURL, gc.Equals, "other://cloud-images/trusty-released-amd64-root.tar.gz")
 }
 
 func (s *imageURLSuite) TestImageDownloadURLUnsupportedContainer(c *gc.C) {
-	_, err := container.ImageDownloadURL(instance.KVM, "trusty", "amd64", "")
+	_, err := container.ImageDownloadURL(instance.KVM, "trusty", "amd64", "released", "")
 	c.Assert(err, gc.ErrorMatches, "unsupported container .*")
 }

--- a/container/image_test.go
+++ b/container/image_test.go
@@ -6,6 +6,8 @@
 package container_test
 
 import (
+	"fmt"
+
 	"github.com/juju/testing"
 	gc "gopkg.in/check.v1"
 
@@ -24,20 +26,24 @@ var _ = gc.Suite(&imageURLSuite{})
 func (s *imageURLSuite) SetUpTest(c *gc.C) {
 	testing.PatchExecutable(c, s, "ubuntu-cloudimg-query", containertesting.FakeLxcURLScript)
 }
-
 func (s *imageURLSuite) TestImageURL(c *gc.C) {
+	s.assertImageURLForStream(c, "released")
+	s.assertImageURLForStream(c, "daily")
+}
+
+func (s *imageURLSuite) assertImageURLForStream(c *gc.C, stream string) {
 	imageURLGetter := container.NewImageURLGetter(
 		container.ImageURLGetterConfig{
 			ServerRoot:        "host:port",
 			EnvUUID:           "12345",
 			CACert:            []byte("cert"),
 			CloudimgBaseUrl:   "",
-			Stream:            "released",
+			Stream:            stream,
 			ImageDownloadFunc: container.ImageDownloadURL,
 		})
 	imageURL, err := imageURLGetter.ImageURL(instance.LXC, "trusty", "amd64")
 	c.Assert(err, gc.IsNil)
-	c.Assert(imageURL, gc.Equals, "https://host:port/environment/12345/images/lxc/trusty/amd64/trusty-released-amd64-root.tar.gz")
+	c.Assert(imageURL, gc.Equals, fmt.Sprintf("https://host:port/environment/12345/images/lxc/trusty/amd64/trusty-%s-amd64-root.tar.gz", stream))
 	c.Assert(imageURLGetter.CACert(), gc.DeepEquals, []byte("cert"))
 }
 

--- a/provider/local/environ.go
+++ b/provider/local/environ.go
@@ -269,14 +269,16 @@ func (env *localEnviron) SetConfig(cfg *config.Config) error {
 			if cert, ok := cfg.CACert(); ok {
 				caCert = []byte(cert)
 			}
-			baseUrl := ecfg.CloudImageBaseURL()
-
 			imageURLGetter = container.NewImageURLGetter(
 				// Explicitly call the non-named constructor so if anyone
 				// adds additional fields, this fails.
 				container.ImageURLGetterConfig{
-					ecfg.stateServerAddr(), uuid, caCert, baseUrl,
-					container.ImageDownloadURL,
+					ServerRoot:        ecfg.stateServerAddr(),
+					EnvUUID:           uuid,
+					CACert:            caCert,
+					CloudimgBaseUrl:   ecfg.CloudImageBaseURL(),
+					Stream:            ecfg.ImageStream(),
+					ImageDownloadFunc: container.ImageDownloadURL,
 				})
 
 		}


### PR DESCRIPTION
This is a fix that was originally proposed by xnox (https://github.com/juju/juju/pull/4480). Re-capped to make it into 1.25.4 before deadline.

Xnox: This enables using daily stream in juju local provider, for example on s390x.

Addressed review comments:
Fixed tests.
Moved stream to follow arch.
Named properties for construction.

(Review request: http://reviews.vapour.ws/r/4059/)