### PR TITLE
add discoverspaces manifold; drop space-discovery login-blocking

### DIFF
--- a/worker/discoverspaces/config_test.go
+++ b/worker/discoverspaces/config_test.go
@@ -1,0 +1,80 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package discoverspaces_test
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/worker/discoverspaces"
+)
+
+type ConfigSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&ConfigSuite{})
+
+func (*ConfigSuite) TestAllSet(c *gc.C) {
+	config := discoverspaces.Config{
+		Facade:   fakeFacade{},
+		Environ:  fakeEnviron{},
+		NewName:  fakeNewName,
+		Unlocker: fakeUnlocker{},
+	}
+	checkConfigValid(c, config)
+}
+
+func (*ConfigSuite) TestNilUnlocker(c *gc.C) {
+	config := discoverspaces.Config{
+		Facade:  fakeFacade{},
+		Environ: fakeEnviron{},
+		NewName: fakeNewName,
+	}
+	checkConfigValid(c, config)
+}
+
+func checkConfigValid(c *gc.C, config discoverspaces.Config) {
+	c.Check(config.Validate(), jc.ErrorIsNil)
+}
+
+func (*ConfigSuite) TestNilFacade(c *gc.C) {
+	config := discoverspaces.Config{
+		Environ: fakeEnviron{},
+		NewName: fakeNewName,
+	}
+	checkAlwaysInvalid(c, config, "nil Facade not valid")
+}
+
+func (*ConfigSuite) TestNilEnviron(c *gc.C) {
+	config := discoverspaces.Config{
+		Facade:  fakeFacade{},
+		NewName: fakeNewName,
+	}
+	checkAlwaysInvalid(c, config, "nil Environ not valid")
+}
+
+func (*ConfigSuite) TestNilNewName(c *gc.C) {
+	config := discoverspaces.Config{
+		Facade:  fakeFacade{},
+		Environ: fakeEnviron{},
+	}
+	checkAlwaysInvalid(c, config, "nil NewName not valid")
+}
+
+func checkAlwaysInvalid(c *gc.C, config discoverspaces.Config, message string) {
+	check := func(err error) {
+		c.Check(err.Error(), gc.Equals, message)
+		c.Check(err, jc.Satisfies, errors.IsNotValid)
+	}
+
+	err := config.Validate()
+	check(err)
+
+	worker, err := discoverspaces.NewWorker(config)
+	c.Check(worker, gc.IsNil)
+	check(err)
+}

--- a/worker/discoverspaces/discoverspaces.go
+++ b/worker/discoverspaces/discoverspaces.go
@@ -16,8 +16,8 @@ import (
 	"github.com/juju/juju/worker/gate"
 )
 
-// Facade apes a *discoverspaces.API; it's a bit raw but at
-// least it's easily mockable.
+// Facade exposes the relevant capabilities of a *discoverspaces.API; it's
+// a bit raw but at least it's easily mockable.
 type Facade interface {
 	CreateSpaces(params.CreateSpacesParams) (params.ErrorResults, error)
 	AddSubnets(params.AddSubnetsParams) (params.ErrorResults, error)
@@ -125,6 +125,7 @@ func (dw *discoverspacesWorker) loop() (err error) {
 			if err := dw.handleSubnets(); err != nil {
 				return errors.Trace(err)
 			}
+			logger.Debugf("space discovery complete")
 			if gate != nil {
 				gate.Unlock()
 				gate = nil
@@ -136,13 +137,13 @@ func (dw *discoverspacesWorker) loop() (err error) {
 func (dw *discoverspacesWorker) handleSubnets() error {
 	environ, ok := environs.SupportsNetworking(dw.config.Environ)
 	if !ok {
-		// Nothing to do.
+		logger.Debugf("not a networking environ")
 		return nil
 	}
 	if supported, err := environ.SupportsSpaceDiscovery(); err != nil {
 		return errors.Trace(err)
 	} else if !supported {
-		// Nothing to do.
+		logger.Debugf("environ does not support space discovery")
 		return nil
 	}
 	providerSpaces, err := environ.Spaces()

--- a/worker/discoverspaces/discoverspaces.go
+++ b/worker/discoverspaces/discoverspaces.go
@@ -4,147 +4,162 @@
 package discoverspaces
 
 import (
-	"fmt"
-	"regexp"
-	"strings"
-
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names"
 	"github.com/juju/utils/set"
-	"launchpad.net/tomb"
 
-	"github.com/juju/juju/api/discoverspaces"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/environs"
-	"github.com/juju/juju/network"
 	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/catacomb"
+	"github.com/juju/juju/worker/gate"
 )
+
+// Facade apes a *discoverspaces.API; it's a bit raw but at
+// least it's easily mockable.
+type Facade interface {
+	CreateSpaces(params.CreateSpacesParams) (params.ErrorResults, error)
+	AddSubnets(params.AddSubnetsParams) (params.ErrorResults, error)
+	ListSpaces() (params.DiscoverSpacesResults, error)
+	ListSubnets(params.SubnetsFilters) (params.ListSubnetsResults, error)
+}
+
+// NameFunc returns a string derived from base that is not contained in used.
+type NameFunc func(base string, used set.Strings) string
+
+// Config defines the operation of a space discovery worker.
+type Config struct {
+
+	// Facade exposes the capabilities of a controller.
+	Facade Facade
+
+	// Environ exposes the capabilities of a compute substrate.
+	Environ environs.Environ
+
+	// NewName is used to sanitise, and make unique, space names as
+	// reported by an Environ (for use in juju, via the Facade). You
+	// should probably set it to ConvertSpaceName.
+	NewName NameFunc
+
+	// Unlocker, if not nil, will be unlocked when the first discovery
+	// attempt completes successfully.
+	Unlocker gate.Unlocker
+}
+
+// Validate returns an error if the config cannot be expected to
+// drive a functional worker.
+func (config Config) Validate() error {
+	if config.Facade == nil {
+		return errors.NotValidf("nil Facade")
+	}
+	if config.Environ == nil {
+		return errors.NotValidf("nil Environ")
+	}
+	if config.NewName == nil {
+		return errors.NotValidf("nil NewName")
+	}
+	// missing Unlocker gate just means "don't bother notifying"
+	return nil
+}
 
 var logger = loggo.GetLogger("juju.discoverspaces")
 
 type discoverspacesWorker struct {
-	api               *discoverspaces.API
-	tomb              tomb.Tomb
-	discoveringSpaces chan struct{}
+	catacomb catacomb.Catacomb
+	config   Config
 }
 
-var dashPrefix = regexp.MustCompile("^-*")
-var dashSuffix = regexp.MustCompile("-*$")
-var multipleDashes = regexp.MustCompile("--+")
-
-func convertSpaceName(name string, existing set.Strings) string {
-	// First lower case and replace spaces with dashes.
-	name = strings.Replace(name, " ", "-", -1)
-	name = strings.ToLower(name)
-	// Replace any character that isn't in the set "-", "a-z", "0-9".
-	name = network.SpaceInvalidChars.ReplaceAllString(name, "")
-	// Get rid of any dashes at the start as that isn't valid.
-	name = dashPrefix.ReplaceAllString(name, "")
-	// And any at the end.
-	name = dashSuffix.ReplaceAllString(name, "")
-	// Repleace multiple dashes with a single dash.
-	name = multipleDashes.ReplaceAllString(name, "-")
-	// Special case of when the space name was only dashes or invalid
-	// characters!
-	if name == "" {
-		name = "empty"
+// NewWorker returns a worker that will attempt to discover the
+// configured Environ's spaces, and update the controller via the
+// configured Facade. Names are sanitised with NewName, and any
+// supplied Unlocker will be Unlock()ed when the first complete
+// discovery and update succeeds.
+//
+// Once that update completes, the worker just waits to be Kill()ed.
+// We should probably poll for changes, really, but I'm making an
+// effort to preserve existing behaviour where possible.
+func NewWorker(config Config) (worker.Worker, error) {
+	if err := config.Validate(); err != nil {
+		return nil, errors.Trace(err)
 	}
-	// If this name is in use add a numerical suffix.
-	if existing.Contains(name) {
-		counter := 2
-		for existing.Contains(name + fmt.Sprintf("-%d", counter)) {
-			counter += 1
-		}
-		name = name + fmt.Sprintf("-%d", counter)
-	}
-	return name
-}
-
-// NewWorker returns a worker
-func NewWorker(api *discoverspaces.API) (worker.Worker, chan struct{}) {
 	dw := &discoverspacesWorker{
-		api:               api,
-		discoveringSpaces: make(chan struct{}),
+		config: config,
 	}
-	go func() {
-		defer dw.tomb.Done()
-		dw.tomb.Kill(dw.loop())
-	}()
-	return dw, dw.discoveringSpaces
+	err := catacomb.Invoke(catacomb.Plan{
+		Site: &dw.catacomb,
+		Work: dw.loop,
+	})
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return dw, nil
 }
 
+// Kill is part of the worker.Worker interface.
 func (dw *discoverspacesWorker) Kill() {
-	dw.tomb.Kill(nil)
+	dw.catacomb.Kill(nil)
 }
 
+// Wait is part of the worker.Worker interface.
 func (dw *discoverspacesWorker) Wait() error {
-	return dw.tomb.Wait()
+	return dw.catacomb.Wait()
 }
 
 func (dw *discoverspacesWorker) loop() (err error) {
-	ensureClosed := func() {
-		select {
-		case <-dw.discoveringSpaces:
-			// Already closed.
-			return
-		default:
-			close(dw.discoveringSpaces)
-		}
-	}
-	defer ensureClosed()
-	modelCfg, err := dw.api.ModelConfig()
-	if err != nil {
-		return err
-	}
-	model, err := environs.New(modelCfg)
-	if err != nil {
-		return err
-	}
-	networkingModel, ok := environs.SupportsNetworking(model)
-
-	if ok {
-		err = dw.handleSubnets(networkingModel)
-		if err != nil {
-			return errors.Trace(err)
-		}
-	}
-	close(dw.discoveringSpaces)
 
 	// TODO(mfoord): we'll have a watcher here checking if we need to
 	// update the spaces/subnets definition.
-	dying := dw.tomb.Dying()
+	// TODO(fwereade): for now, use a changes channel that apes the
+	// standard initial event behaviour, so we can make the loop
+	// follow the standard structure.
+	changes := make(chan struct{}, 1)
+	changes <- struct{}{}
+
+	gate := dw.config.Unlocker
 	for {
 		select {
-		case <-dying:
-			return nil
+		case <-dw.catacomb.Dying():
+			return dw.catacomb.ErrDying()
+		case <-changes:
+			if err := dw.handleSubnets(); err != nil {
+				return errors.Trace(err)
+			}
+			if gate != nil {
+				gate.Unlock()
+				gate = nil
+			}
 		}
 	}
-	return nil
 }
 
-func (dw *discoverspacesWorker) handleSubnets(env environs.NetworkingEnviron) error {
-	ok, err := env.SupportsSpaceDiscovery()
-	if err != nil {
-		return errors.Trace(err)
-	}
+func (dw *discoverspacesWorker) handleSubnets() error {
+	environ, ok := environs.SupportsNetworking(dw.config.Environ)
 	if !ok {
 		// Nothing to do.
 		return nil
 	}
-	providerSpaces, err := env.Spaces()
-	if err != nil {
+	if supported, err := environ.SupportsSpaceDiscovery(); err != nil {
 		return errors.Trace(err)
+	} else if !supported {
+		// Nothing to do.
+		return nil
 	}
-	listSpacesResult, err := dw.api.ListSpaces()
+	providerSpaces, err := environ.Spaces()
 	if err != nil {
 		return errors.Trace(err)
 	}
 
-	stateSubnets, err := dw.api.ListSubnets(params.SubnetsFilters{})
+	facade := dw.config.Facade
+	listSpacesResult, err := facade.ListSpaces()
 	if err != nil {
 		return errors.Trace(err)
 	}
+	stateSubnets, err := facade.ListSubnets(params.SubnetsFilters{})
+	if err != nil {
+		return errors.Trace(err)
+	}
+
 	stateSubnetIds := make(set.Strings)
 	for _, subnet := range stateSubnets.Results {
 		stateSubnetIds.Add(subnet.ProviderId)
@@ -180,7 +195,7 @@ func (dw *discoverspacesWorker) handleSubnets(env environs.NetworkingEnviron) er
 			spaceName := string(space.ProviderId)
 			// Convert the name into a valid name that isn't already in
 			// use.
-			spaceName = convertSpaceName(spaceName, spaceNames)
+			spaceName = dw.config.NewName(spaceName, spaceNames)
 			spaceNames.Add(spaceName)
 			spaceTag = names.NewSpaceTag(spaceName)
 			// We need to create the space.
@@ -190,7 +205,7 @@ func (dw *discoverspacesWorker) handleSubnets(env environs.NetworkingEnviron) er
 					SpaceTag:   spaceTag.String(),
 					ProviderId: string(space.ProviderId),
 				}}}
-			result, err := dw.api.CreateSpaces(args)
+			result, err := facade.CreateSpaces(args)
 			if err != nil {
 				logger.Errorf("error creating space %v", err)
 				return errors.Trace(err)
@@ -221,7 +236,7 @@ func (dw *discoverspacesWorker) handleSubnets(env environs.NetworkingEnviron) er
 					Zones:            zones,
 				}}}
 			logger.Tracef("Adding subnet %v", subnet.CIDR)
-			result, err := dw.api.AddSubnets(args)
+			result, err := facade.AddSubnets(args)
 			if err != nil {
 				logger.Errorf("invalid creating subnet %v", err)
 				return errors.Trace(err)

--- a/worker/discoverspaces/export_test.go
+++ b/worker/discoverspaces/export_test.go
@@ -1,6 +1,0 @@
-// Copyright 2016 Canonical Ltd.
-// Licensed under the AGPLv3, see LICENCE file for details.
-
-package discoverspaces
-
-var ConvertSpaceName = convertSpaceName

--- a/worker/discoverspaces/fake_test.go
+++ b/worker/discoverspaces/fake_test.go
@@ -1,0 +1,38 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package discoverspaces_test
+
+import (
+	"github.com/juju/utils/set"
+
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/discoverspaces"
+	"github.com/juju/juju/worker/gate"
+)
+
+type fakeWorker struct {
+	worker.Worker
+}
+
+type fakeAPICaller struct {
+	base.APICaller
+}
+
+type fakeFacade struct {
+	discoverspaces.Facade
+}
+
+type fakeEnviron struct {
+	environs.NetworkingEnviron
+}
+
+func fakeNewName(_ string, _ set.Strings) string {
+	panic("fake")
+}
+
+type fakeUnlocker struct {
+	gate.Unlocker
+}

--- a/worker/discoverspaces/manifold.go
+++ b/worker/discoverspaces/manifold.go
@@ -1,0 +1,72 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package discoverspaces
+
+import (
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/dependency"
+	"github.com/juju/juju/worker/gate"
+)
+
+type ManifoldConfig struct {
+	APICallerName string
+	EnvironName   string
+	UnlockerName  string
+
+	NewFacade func(base.APICaller) (Facade, error)
+	NewWorker func(Config) (worker.Worker, error)
+}
+
+func Manifold(config ManifoldConfig) dependency.Manifold {
+	inputs := []string{config.APICallerName, config.EnvironName}
+	if config.UnlockerName != "" {
+		inputs = append(inputs, config.UnlockerName)
+	}
+	return dependency.Manifold{
+		Inputs: inputs,
+		Start:  startFunc(config),
+	}
+}
+
+func startFunc(config ManifoldConfig) dependency.StartFunc {
+	return func(getResource dependency.GetResourceFunc) (worker.Worker, error) {
+
+		// optional unlocker, might stay nil
+		var unlocker gate.Unlocker
+		if config.UnlockerName != "" {
+			if err := getResource(config.UnlockerName, &unlocker); err != nil {
+				return nil, errors.Trace(err)
+			}
+		}
+
+		var environ environs.Environ
+		if err := getResource(config.EnvironName, &environ); err != nil {
+			return nil, errors.Trace(err)
+		}
+
+		var apiCaller base.APICaller
+		if err := getResource(config.APICallerName, &apiCaller); err != nil {
+			return nil, errors.Trace(err)
+		}
+		facade, err := config.NewFacade(apiCaller)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+
+		w, err := config.NewWorker(Config{
+			Facade:   facade,
+			Environ:  environ,
+			NewName:  ConvertSpaceName,
+			Unlocker: unlocker,
+		})
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		return w, nil
+	}
+}

--- a/worker/discoverspaces/manifold_test.go
+++ b/worker/discoverspaces/manifold_test.go
@@ -1,0 +1,166 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package discoverspaces_test
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/dependency"
+	dt "github.com/juju/juju/worker/dependency/testing"
+	"github.com/juju/juju/worker/discoverspaces"
+)
+
+type ManifoldSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&ManifoldSuite{})
+
+func (*ManifoldSuite) TestInputsWithUnlocker(c *gc.C) {
+	config := namesConfig()
+	manifold := discoverspaces.Manifold(config)
+	c.Check(manifold.Inputs, jc.SameContents, []string{
+		"api-caller", "environ", "unlocker",
+	})
+}
+
+func (*ManifoldSuite) TestInputsWithoutUnlocker(c *gc.C) {
+	config := namesConfig()
+	config.UnlockerName = ""
+	manifold := discoverspaces.Manifold(config)
+	c.Check(manifold.Inputs, jc.SameContents, []string{
+		"api-caller", "environ",
+	})
+}
+
+func (*ManifoldSuite) TestOutput(c *gc.C) {
+	manifold := discoverspaces.Manifold(namesConfig())
+	c.Check(manifold.Output, gc.IsNil)
+}
+
+func (*ManifoldSuite) TestAPICallerMissing(c *gc.C) {
+	resources := resourcesMissing("api-caller")
+	manifold := discoverspaces.Manifold(namesConfig())
+
+	worker, err := manifold.Start(dt.StubGetResource(resources))
+	c.Check(errors.Cause(err), gc.Equals, dependency.ErrMissing)
+	c.Check(worker, gc.IsNil)
+}
+
+func (*ManifoldSuite) TestEnvironMissing(c *gc.C) {
+	resources := resourcesMissing("environ")
+	manifold := discoverspaces.Manifold(namesConfig())
+
+	worker, err := manifold.Start(dt.StubGetResource(resources))
+	c.Check(errors.Cause(err), gc.Equals, dependency.ErrMissing)
+	c.Check(worker, gc.IsNil)
+}
+
+func (*ManifoldSuite) TestUnlockerMissing(c *gc.C) {
+	resources := resourcesMissing("unlocker")
+	manifold := discoverspaces.Manifold(namesConfig())
+
+	worker, err := manifold.Start(dt.StubGetResource(resources))
+	c.Check(errors.Cause(err), gc.Equals, dependency.ErrMissing)
+	c.Check(worker, gc.IsNil)
+}
+
+func (*ManifoldSuite) TestNewFacadeError(c *gc.C) {
+	resources := resourcesMissing()
+	config := namesConfig()
+	config.NewFacade = func(apiCaller base.APICaller) (discoverspaces.Facade, error) {
+		checkResource(c, apiCaller, resources, "api-caller")
+		return nil, errors.New("blort")
+	}
+	manifold := discoverspaces.Manifold(config)
+
+	worker, err := manifold.Start(dt.StubGetResource(resources))
+	c.Check(err, gc.ErrorMatches, "blort")
+	c.Check(worker, gc.IsNil)
+}
+
+func (*ManifoldSuite) TestNewWorkerError(c *gc.C) {
+	resources := resourcesMissing()
+	expectFacade := &fakeFacade{}
+	config := namesConfig()
+	config.NewFacade = func(_ base.APICaller) (discoverspaces.Facade, error) {
+		return expectFacade, nil
+	}
+	config.NewWorker = func(cfg discoverspaces.Config) (worker.Worker, error) {
+		c.Check(cfg.Facade, gc.Equals, expectFacade)
+		checkResource(c, cfg.Environ, resources, "environ")
+		c.Check(cfg.NewName, gc.NotNil) // uncomparable
+		checkResource(c, cfg.Unlocker, resources, "unlocker")
+		return nil, errors.New("lhiis")
+	}
+	manifold := discoverspaces.Manifold(config)
+
+	worker, err := manifold.Start(dt.StubGetResource(resources))
+	c.Check(err, gc.ErrorMatches, "lhiis")
+	c.Check(worker, gc.IsNil)
+}
+
+func (*ManifoldSuite) TestNewWorkerNoUnlocker(c *gc.C) {
+	resources := resourcesMissing()
+	config := namesConfig()
+	config.UnlockerName = ""
+	config.NewFacade = func(_ base.APICaller) (discoverspaces.Facade, error) {
+		return &fakeFacade{}, nil
+	}
+	config.NewWorker = func(cfg discoverspaces.Config) (worker.Worker, error) {
+		c.Check(cfg.Unlocker, gc.IsNil)
+		return nil, errors.New("mrrg")
+	}
+	manifold := discoverspaces.Manifold(config)
+
+	worker, err := manifold.Start(dt.StubGetResource(resources))
+	c.Check(err, gc.ErrorMatches, "mrrg")
+	c.Check(worker, gc.IsNil)
+}
+
+func (*ManifoldSuite) TestNewWorkerSuccess(c *gc.C) {
+	expectWorker := &fakeWorker{}
+	config := namesConfig()
+	config.NewFacade = func(_ base.APICaller) (discoverspaces.Facade, error) {
+		return &fakeFacade{}, nil
+	}
+	config.NewWorker = func(_ discoverspaces.Config) (worker.Worker, error) {
+		return expectWorker, nil
+	}
+	manifold := discoverspaces.Manifold(config)
+	resources := resourcesMissing()
+
+	worker, err := manifold.Start(dt.StubGetResource(resources))
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(worker, gc.Equals, expectWorker)
+}
+
+func namesConfig() discoverspaces.ManifoldConfig {
+	return discoverspaces.ManifoldConfig{
+		APICallerName: "api-caller",
+		EnvironName:   "environ",
+		UnlockerName:  "unlocker",
+	}
+}
+
+func resourcesMissing(missing ...string) dt.StubResources {
+	resources := dt.StubResources{
+		"api-caller": dt.StubResource{Output: &fakeAPICaller{}},
+		"environ":    dt.StubResource{Output: &fakeEnviron{}},
+		"unlocker":   dt.StubResource{Output: &fakeUnlocker{}},
+	}
+	for _, name := range missing {
+		resources[name] = dt.StubResource{Error: dependency.ErrMissing}
+	}
+	return resources
+}
+
+func checkResource(c *gc.C, actual interface{}, resources dt.StubResources, name string) {
+	c.Check(actual, gc.Equals, resources[name].Output)
+}

--- a/worker/discoverspaces/names.go
+++ b/worker/discoverspaces/names.go
@@ -1,0 +1,47 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package discoverspaces
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/juju/juju/network"
+	"github.com/juju/utils/set"
+)
+
+var dashPrefix = regexp.MustCompile("^-*")
+var dashSuffix = regexp.MustCompile("-*$")
+var multipleDashes = regexp.MustCompile("--+")
+
+// ConvertSpaceName returns a string derived from name that does not
+// already exist in existing. It does not modify existing.
+func ConvertSpaceName(name string, existing set.Strings) string {
+	// First lower case and replace spaces with dashes.
+	name = strings.Replace(name, " ", "-", -1)
+	name = strings.ToLower(name)
+	// Replace any character that isn't in the set "-", "a-z", "0-9".
+	name = network.SpaceInvalidChars.ReplaceAllString(name, "")
+	// Get rid of any dashes at the start as that isn't valid.
+	name = dashPrefix.ReplaceAllString(name, "")
+	// And any at the end.
+	name = dashSuffix.ReplaceAllString(name, "")
+	// Repleace multiple dashes with a single dash.
+	name = multipleDashes.ReplaceAllString(name, "-")
+	// Special case of when the space name was only dashes or invalid
+	// characters!
+	if name == "" {
+		name = "empty"
+	}
+	// If this name is in use add a numerical suffix.
+	if existing.Contains(name) {
+		counter := 2
+		for existing.Contains(name + fmt.Sprintf("-%d", counter)) {
+			counter += 1
+		}
+		name = name + fmt.Sprintf("-%d", counter)
+	}
+	return name
+}

--- a/worker/discoverspaces/names_test.go
+++ b/worker/discoverspaces/names_test.go
@@ -1,0 +1,46 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package discoverspaces_test
+
+import (
+	"github.com/juju/testing"
+	"github.com/juju/utils/set"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/worker/discoverspaces"
+)
+
+type NamesSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&NamesSuite{})
+
+func (*NamesSuite) TestConvertSpaceName(c *gc.C) {
+	empty := set.Strings{}
+	nameTests := []struct {
+		name     string
+		existing set.Strings
+		expected string
+	}{
+		{"foo", empty, "foo"},
+		{"foo1", empty, "foo1"},
+		{"Foo Thing", empty, "foo-thing"},
+		{"foo^9*//++!!!!", empty, "foo9"},
+		{"--Foo", empty, "foo"},
+		{"---^^&*()!", empty, "empty"},
+		{" ", empty, "empty"},
+		{"", empty, "empty"},
+		{"foo\u2318", empty, "foo"},
+		{"foo--", empty, "foo"},
+		{"-foo--foo----bar-", empty, "foo-foo-bar"},
+		{"foo-", set.NewStrings("foo", "bar", "baz"), "foo-2"},
+		{"foo", set.NewStrings("foo", "foo-2"), "foo-3"},
+		{"---", set.NewStrings("empty"), "empty-2"},
+	}
+	for _, test := range nameTests {
+		result := discoverspaces.ConvertSpaceName(test.name, test.existing)
+		c.Check(result, gc.Equals, test.expected)
+	}
+}

--- a/worker/discoverspaces/worker_test.go
+++ b/worker/discoverspaces/worker_test.go
@@ -4,9 +4,10 @@
 package discoverspaces_test
 
 import (
+	"time"
+
 	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/utils/set"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/api"
@@ -15,27 +16,27 @@ import (
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/network"
-	"github.com/juju/juju/provider/common"
 	"github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/state"
+	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/discoverspaces"
+	"github.com/juju/juju/worker/gate"
+	"github.com/juju/juju/worker/workertest"
 )
 
-type workerSuite struct {
+type WorkerSuite struct {
+	// TODO(fwereade): we *really* should not be using
+	// JujuConnSuite in new code.
 	testing.JujuConnSuite
 
-	Worker  worker.Worker
-	OpsChan chan dummy.Operation
-
-	APIConnection    api.Connection
-	API              *apidiscoverspaces.API
-	spacesDiscovered chan struct{}
+	APIConnection api.Connection
+	API           *apidiscoverspaces.API
 }
 
-var _ = gc.Suite(&workerSuite{})
+var _ = gc.Suite(&WorkerSuite{})
 
-func (s *workerSuite) SetUpTest(c *gc.C) {
+func (s *WorkerSuite) SetUpTest(c *gc.C) {
 	s.JujuConnSuite.SetUpTest(c)
 
 	// Unbreak dummy provider methods.
@@ -43,127 +44,140 @@ func (s *workerSuite) SetUpTest(c *gc.C) {
 
 	s.APIConnection, _ = s.OpenAPIAsNewMachine(c, state.JobManageModel)
 	s.API = s.APIConnection.DiscoverSpaces()
-
-	s.OpsChan = make(chan dummy.Operation, 10)
-	dummy.Listen(s.OpsChan)
-	s.spacesDiscovered = nil
 }
 
-func (s *workerSuite) startWorker() {
-	s.Worker, s.spacesDiscovered = discoverspaces.NewWorker(s.API)
-}
-
-func (s *workerSuite) TearDownTest(c *gc.C) {
-	if s.Worker != nil {
-		c.Assert(worker.Stop(s.Worker), jc.ErrorIsNil)
+func (s *WorkerSuite) TearDownTest(c *gc.C) {
+	if s.APIConnection != nil {
+		c.Check(s.APIConnection.Close(), jc.ErrorIsNil)
 	}
 	s.JujuConnSuite.TearDownTest(c)
 }
 
-func (s *workerSuite) TestConvertSpaceName(c *gc.C) {
-	empty := set.Strings{}
-	nameTests := []struct {
-		name     string
-		existing set.Strings
-		expected string
-	}{
-		{"foo", empty, "foo"},
-		{"foo1", empty, "foo1"},
-		{"Foo Thing", empty, "foo-thing"},
-		{"foo^9*//++!!!!", empty, "foo9"},
-		{"--Foo", empty, "foo"},
-		{"---^^&*()!", empty, "empty"},
-		{" ", empty, "empty"},
-		{"", empty, "empty"},
-		{"foo\u2318", empty, "foo"},
-		{"foo--", empty, "foo"},
-		{"-foo--foo----bar-", empty, "foo-foo-bar"},
-		{"foo-", set.NewStrings("foo", "bar", "baz"), "foo-2"},
-		{"foo", set.NewStrings("foo", "foo-2"), "foo-3"},
-		{"---", set.NewStrings("empty"), "empty-2"},
-	}
-	for _, test := range nameTests {
-		result := discoverspaces.ConvertSpaceName(test.name, test.existing)
-		c.Check(result, gc.Equals, test.expected)
-	}
-}
+func (s *WorkerSuite) TestSupportsSpaceDiscoveryBroken(c *gc.C) {
+	s.AssertConfigParameterUpdated(c, "broken", "SupportsSpaceDiscovery")
 
-func (s *workerSuite) TestWorkerIsStringsWorker(c *gc.C) {
-	s.startWorker()
-	c.Assert(s.Worker, gc.Not(gc.FitsTypeOf), worker.FinishedWorker{})
-}
+	worker, lock := s.startWorker(c)
+	err := workertest.CheckKilled(c, worker)
+	c.Assert(err, gc.ErrorMatches, "dummy.SupportsSpaceDiscovery is broken")
 
-func (s *workerSuite) assertSpaceDiscoveryCompleted(c *gc.C) {
-	c.Assert(s.spacesDiscovered, gc.NotNil)
 	select {
-	case <-s.spacesDiscovered:
-		// The channel was closed as it should be
-		return
-	default:
-		c.Fatalf("Space discovery channel not closed")
+	case <-time.After(coretesting.ShortWait):
+	case <-lock.Unlocked():
+		c.Fatalf("gate unlocked despite worker failure")
 	}
 }
 
-func (s *workerSuite) TestWorkerSupportsNetworkingFalse(c *gc.C) {
+func (s *WorkerSuite) TestSpacesBroken(c *gc.C) {
+	dummy.SetSupportsSpaceDiscovery(true)
+	s.AssertConfigParameterUpdated(c, "broken", "Spaces")
+
+	worker, lock := s.startWorker(c)
+	err := workertest.CheckKilled(c, worker)
+	c.Assert(err, gc.ErrorMatches, "dummy.Spaces is broken")
+
+	select {
+	case <-time.After(coretesting.ShortWait):
+	case <-lock.Unlocked():
+		c.Fatalf("gate unlocked despite worker failure")
+	}
+}
+
+func (s *WorkerSuite) TestWorkerSupportsNetworkingFalse(c *gc.C) {
 	// We set SupportsSpaceDiscovery to true so that spaces *would* be
 	// discovered if networking was supported. So we know that if they're
 	// discovered it must be because networking is not supported.
 	dummy.SetSupportsSpaceDiscovery(true)
+
+	// TODO(fwereade): monkey-patching remote packages is even worse
+	// than monkey-patching local packages, please don't do it.
 	noNetworking := func(environs.Environ) (environs.NetworkingEnviron, bool) {
 		return nil, false
 	}
 	s.PatchValue(&environs.SupportsNetworking, noNetworking)
-	s.startWorker()
 
-	// No spaces will have been created, worker does nothing.
-	for a := common.ShortAttempt.Start(); a.Next(); {
-		spaces, err := s.State.AllSpaces()
-		c.Assert(err, jc.ErrorIsNil)
-		if len(spaces) != 0 {
-			c.Fatalf("spaces should not be created, we have %v", len(spaces))
-		}
-		if !a.HasNext() {
-			break
-		}
-	}
-	s.assertSpaceDiscoveryCompleted(c)
+	s.unlockCheck(c, s.assertDiscoveredNoSpaces)
 }
 
-func (s *workerSuite) TestWorkerSupportsSpaceDiscoveryFalse(c *gc.C) {
-	s.startWorker()
-
-	// No spaces will have been created, worker does nothing.
-	for a := common.ShortAttempt.Start(); a.Next(); {
-		spaces, err := s.State.AllSpaces()
-		c.Assert(err, jc.ErrorIsNil)
-		if len(spaces) != 0 {
-			c.Fatalf("spaces should not be created, we have %v", len(spaces))
-		}
-		if !a.HasNext() {
-			break
-		}
-	}
-	s.assertSpaceDiscoveryCompleted(c)
+func (s *WorkerSuite) TestWorkerSupportsSpaceDiscoveryFalse(c *gc.C) {
+	s.unlockCheck(c, s.assertDiscoveredNoSpaces)
 }
 
-func (s *workerSuite) TestWorkerDiscoversSpaces(c *gc.C) {
+func (s *WorkerSuite) TestWorkerDiscoversSpaces(c *gc.C) {
 	dummy.SetSupportsSpaceDiscovery(true)
-	s.startWorker()
-	for a := common.ShortAttempt.Start(); a.Next(); {
-		var found bool
-		select {
-		case <-s.spacesDiscovered:
-			// The channel was closed so discovery has completed.
-			found = true
-		}
-		if found {
-			break
-		}
-		if !a.HasNext() {
-			c.Fatalf("discovery not completed")
-		}
-	}
+	s.unlockCheck(c, s.assertDiscoveredSpaces)
+}
 
+func (s *WorkerSuite) TestWorkerIdempotent(c *gc.C) {
+	dummy.SetSupportsSpaceDiscovery(true)
+	s.unlockCheck(c, s.assertDiscoveredSpaces)
+	s.unlockCheck(c, s.assertDiscoveredSpaces)
+}
+
+func (s *WorkerSuite) TestWorkerIgnoresExistingSpacesAndSubnets(c *gc.C) {
+	dummy.SetSupportsSpaceDiscovery(true)
+	spaceTag := names.NewSpaceTag("foo")
+	args := params.CreateSpacesParams{
+		Spaces: []params.CreateSpaceParams{{
+			Public:     false,
+			SpaceTag:   spaceTag.String(),
+			ProviderId: "foo",
+		}}}
+	result, err := s.API.CreateSpaces(args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.Results, gc.HasLen, 1)
+	c.Assert(result.Results[0].Error, gc.IsNil)
+
+	subnetArgs := params.AddSubnetsParams{
+		Subnets: []params.AddSubnetParams{{
+			SubnetProviderId: "1",
+			SpaceTag:         spaceTag.String(),
+			Zones:            []string{"zone1"},
+		}}}
+	subnetResult, err := s.API.AddSubnets(subnetArgs)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(subnetResult.Results, gc.HasLen, 1)
+	c.Assert(subnetResult.Results[0].Error, gc.IsNil)
+
+	s.unlockCheck(c, s.assertDiscoveredSpaces)
+}
+
+func (s *WorkerSuite) startWorker(c *gc.C) (worker.Worker, gate.Lock) {
+	// create fresh environ to see any injected broken-ness
+	config, err := s.State.ModelConfig()
+	c.Assert(err, jc.ErrorIsNil)
+	environ, err := environs.New(config)
+	c.Assert(err, jc.ErrorIsNil)
+
+	lock := gate.NewLock()
+	worker, err := discoverspaces.NewWorker(discoverspaces.Config{
+		Facade:   s.API,
+		Environ:  environ,
+		NewName:  discoverspaces.ConvertSpaceName,
+		Unlocker: lock,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	return worker, lock
+}
+
+func (s *WorkerSuite) unlockCheck(c *gc.C, check func(c *gc.C)) {
+	worker, lock := s.startWorker(c)
+	defer workertest.CleanKill(c, worker)
+	select {
+	case <-time.After(coretesting.LongWait):
+		c.Fatalf("discovery never completed")
+	case <-lock.Unlocked():
+		check(c)
+	}
+	workertest.CheckAlive(c, worker)
+}
+
+func (s *WorkerSuite) assertDiscoveredNoSpaces(c *gc.C) {
+	spaces, err := s.State.AllSpaces()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(spaces, gc.HasLen, 0)
+}
+
+func (s *WorkerSuite) assertDiscoveredSpaces(c *gc.C) {
 	spaces, err := s.State.AllSpaces()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(spaces, gc.HasLen, 4)
@@ -224,109 +238,4 @@ func (s *workerSuite) TestWorkerDiscoversSpaces(c *gc.C) {
 			c.Check(subnet.CIDR(), gc.Equals, expectedSubnet.CIDR)
 		}
 	}
-	s.assertSpaceDiscoveryCompleted(c)
-}
-
-func (s *workerSuite) TestWorkerIdempotent(c *gc.C) {
-	dummy.SetSupportsSpaceDiscovery(true)
-	s.startWorker()
-	var err error
-	var spaces []*state.Space
-	for a := common.ShortAttempt.Start(); a.Next(); {
-		spaces, err = s.State.AllSpaces()
-		if err != nil {
-			break
-		}
-		if len(spaces) == 4 {
-			// All spaces have been created.
-			break
-		}
-		if !a.HasNext() {
-			c.Fatalf("spaces not imported")
-		}
-	}
-	c.Assert(err, jc.ErrorIsNil)
-	newWorker, _ := discoverspaces.NewWorker(s.API)
-
-	// This ensures that the worker can handle re-importing without error.
-	defer func() {
-		c.Assert(worker.Stop(newWorker), jc.ErrorIsNil)
-	}()
-
-	// Check that no extra spaces are imported.
-	for a := common.ShortAttempt.Start(); a.Next(); {
-		spaces, err = s.State.AllSpaces()
-		if err != nil {
-			break
-		}
-		if len(spaces) != 4 {
-			c.Fatalf("unexpected number of spaces: %v", len(spaces))
-		}
-		if !a.HasNext() {
-			break
-		}
-	}
-}
-
-func (s *workerSuite) TestSupportsSpaceDiscoveryBroken(c *gc.C) {
-	s.AssertConfigParameterUpdated(c, "broken", "SupportsSpaceDiscovery")
-
-	newWorker, spacesDiscovered := discoverspaces.NewWorker(s.API)
-	s.spacesDiscovered = spacesDiscovered
-	err := worker.Stop(newWorker)
-	c.Assert(err, gc.ErrorMatches, "dummy.SupportsSpaceDiscovery is broken")
-	s.assertSpaceDiscoveryCompleted(c)
-}
-
-func (s *workerSuite) TestSpacesBroken(c *gc.C) {
-	dummy.SetSupportsSpaceDiscovery(true)
-	s.AssertConfigParameterUpdated(c, "broken", "Spaces")
-
-	newWorker, spacesDiscovered := discoverspaces.NewWorker(s.API)
-	s.spacesDiscovered = spacesDiscovered
-	err := worker.Stop(newWorker)
-	c.Assert(err, gc.ErrorMatches, "dummy.Spaces is broken")
-	s.assertSpaceDiscoveryCompleted(c)
-}
-
-func (s *workerSuite) TestWorkerIgnoresExistingSpacesAndSubnets(c *gc.C) {
-	dummy.SetSupportsSpaceDiscovery(true)
-	spaceTag := names.NewSpaceTag("foo")
-	args := params.CreateSpacesParams{
-		Spaces: []params.CreateSpaceParams{{
-			Public:     false,
-			SpaceTag:   spaceTag.String(),
-			ProviderId: "foo",
-		}}}
-	result, err := s.API.CreateSpaces(args)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(result.Results, gc.HasLen, 1)
-	c.Assert(result.Results[0].Error, gc.IsNil)
-
-	subnetArgs := params.AddSubnetsParams{
-		Subnets: []params.AddSubnetParams{{
-			SubnetProviderId: "1",
-			SpaceTag:         spaceTag.String(),
-			Zones:            []string{"zone1"},
-		}}}
-	subnetResult, err := s.API.AddSubnets(subnetArgs)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(subnetResult.Results, gc.HasLen, 1)
-	c.Assert(subnetResult.Results[0].Error, gc.IsNil)
-
-	s.startWorker()
-	for a := common.ShortAttempt.Start(); a.Next(); {
-		spaces, err := s.State.AllSpaces()
-		if err != nil {
-			break
-		}
-		if len(spaces) == 4 {
-			// All spaces have been created.
-			break
-		}
-		if !a.HasNext() {
-			c.Fatalf("spaces not imported")
-		}
-	}
-	c.Assert(err, jc.ErrorIsNil)
 }


### PR DESCRIPTION
Also included adding a config struct, correcting unlocking behaviour so it doesn't report the task complete if it fails, and quite a lot of test cleanup. Didn't replace JujuConnSuite because it's quite useful for verifying things work in reality, and I don't want to change *everything*.

The login-blocking was dropped because it's currently not reliable (starts late) and can't be easily tweaked into reliable correctness.

(Review request: http://reviews.vapour.ws/r/4060/)