### PR TITLE
Forward-porting to master: passing stream to image download 

### DIFF
--- a/apiserver/images.go
+++ b/apiserver/images.go
@@ -116,7 +116,7 @@ func (h *imagesDownloadHandler) fetchAndCacheLxcImage(storage imagestorage.Stora
 	if err != nil {
 		return errors.Trace(err)
 	}
-	imageURL, err := container.ImageDownloadURL(instance.LXC, series, arch, cfg.CloudImageBaseURL())
+	imageURL, err := container.ImageDownloadURL(instance.LXC, series, arch, cfg.ImageStream(), cfg.CloudImageBaseURL())
 	if err != nil {
 		return errors.Annotatef(err, "cannot determine LXC image URL: %v", err)
 	}

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -884,8 +884,12 @@ func (a *MachineAgent) updateSupportedContainers(
 			// Explicitly call the non-named constructor so if anyone
 			// adds additional fields, this fails.
 			container.ImageURLGetterConfig{
-				st.Addr(), modelUUID.Id(), []byte(agentConfig.CACert()),
-				cfg.CloudImageBaseURL(), container.ImageDownloadURL,
+				ServerRoot:        st.Addr(),
+				ModelUUID:         modelUUID.Id(),
+				CACert:            []byte(agentConfig.CACert()),
+				CloudimgBaseUrl:   cfg.CloudImageBaseURL(),
+				Stream:            cfg.ImageStream(),
+				ImageDownloadFunc: container.ImageDownloadURL,
 			})
 	}
 	params := provisioner.ContainerSetupParams{

--- a/container/image.go
+++ b/container/image.go
@@ -32,7 +32,8 @@ type ImageURLGetterConfig struct {
 	ModelUUID         string
 	CACert            []byte
 	CloudimgBaseUrl   string
-	ImageDownloadFunc func(kind instance.ContainerType, series, arch, cloudimgBaseUrl string) (string, error)
+	Stream            string
+	ImageDownloadFunc func(kind instance.ContainerType, series, arch, stream, cloudimgBaseUrl string) (string, error)
 }
 
 type imageURLGetter struct {
@@ -47,7 +48,7 @@ func NewImageURLGetter(config ImageURLGetterConfig) ImageURLGetter {
 
 // ImageURL is specified on the NewImageURLGetter interface.
 func (ug *imageURLGetter) ImageURL(kind instance.ContainerType, series, arch string) (string, error) {
-	imageURL, err := ug.config.ImageDownloadFunc(kind, series, arch, ug.config.CloudimgBaseUrl)
+	imageURL, err := ug.config.ImageDownloadFunc(kind, series, arch, ug.config.Stream, ug.config.CloudimgBaseUrl)
 	if err != nil {
 		return "", errors.Annotatef(err, "cannot determine LXC image URL: %v", err)
 	}
@@ -66,7 +67,7 @@ func (ug *imageURLGetter) CACert() []byte {
 
 // ImageDownloadURL determines the public URL which can be used to obtain an
 // image blob with the specified parameters.
-func ImageDownloadURL(kind instance.ContainerType, series, arch, cloudimgBaseUrl string) (string, error) {
+func ImageDownloadURL(kind instance.ContainerType, series, arch, stream, cloudimgBaseUrl string) (string, error) {
 	// TODO - we currently only need to support LXC images - kind is ignored.
 	if kind != instance.LXC {
 		return "", errors.Errorf("unsupported container type: %v", kind)
@@ -74,7 +75,7 @@ func ImageDownloadURL(kind instance.ContainerType, series, arch, cloudimgBaseUrl
 
 	// Use the ubuntu-cloudimg-query command to get the url from which to fetch the image.
 	// This will be somewhere on http://cloud-images.ubuntu.com.
-	cmd := exec.Command("ubuntu-cloudimg-query", series, "released", arch, "--format", "%{url}")
+	cmd := exec.Command("ubuntu-cloudimg-query", series, stream, arch, "--format", "%{url}")
 	if cloudimgBaseUrl != "" {
 		// If the base url isn't specified, we don't need to copy the current
 		// environment, because this is the default behaviour of the exec package.

--- a/container/image_test.go
+++ b/container/image_test.go
@@ -6,6 +6,8 @@
 package container_test
 
 import (
+	"fmt"
+
 	"github.com/juju/testing"
 	gc "gopkg.in/check.v1"
 
@@ -26,18 +28,23 @@ func (s *imageURLSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *imageURLSuite) TestImageURL(c *gc.C) {
+	s.assertImageURLForStream(c, "released")
+	s.assertImageURLForStream(c, "daily")
+}
+
+func (s *imageURLSuite) assertImageURLForStream(c *gc.C, stream string) {
 	imageURLGetter := container.NewImageURLGetter(
 		container.ImageURLGetterConfig{
 			ServerRoot:        "host:port",
 			ModelUUID:         "12345",
 			CACert:            []byte("cert"),
 			CloudimgBaseUrl:   "",
-			Stream:            "released",
+			Stream:            stream,
 			ImageDownloadFunc: container.ImageDownloadURL,
 		})
 	imageURL, err := imageURLGetter.ImageURL(instance.LXC, "trusty", "amd64")
 	c.Assert(err, gc.IsNil)
-	c.Assert(imageURL, gc.Equals, "https://host:port/model/12345/images/lxc/trusty/amd64/trusty-released-amd64-root.tar.gz")
+	c.Assert(imageURL, gc.Equals, fmt.Sprintf("https://host:port/model/12345/images/lxc/trusty/amd64/trusty-%s-amd64-root.tar.gz", stream))
 	c.Assert(imageURLGetter.CACert(), gc.DeepEquals, []byte("cert"))
 }
 


### PR DESCRIPTION
https://github.com/juju/juju/pull/4619

Enables specifying streams in image download when calling ubuntu-cloudimage-query command. 

(Review request: http://reviews.vapour.ws/r/4061/)