### PR TITLE
state: Allow parent link-layer bridge devices for container child devices

### DIFF
--- a/state/linklayerdevices.go
+++ b/state/linklayerdevices.go
@@ -57,9 +57,6 @@ type linkLayerDeviceDoc struct {
 type LinkLayerDeviceType string
 
 const (
-	// UnknownDevice represents a device of unknown type.
-	UnknownDevice LinkLayerDeviceType = "unknown"
-
 	// LoopbackDevice is used for loopback devices.
 	LoopbackDevice LinkLayerDeviceType = "loopback"
 

--- a/state/linklayerdevices.go
+++ b/state/linklayerdevices.go
@@ -49,7 +49,10 @@ type linkLayerDeviceDoc struct {
 	// IsUp is true when the device is up (enabled).
 	IsUp bool `bson:"is-up"`
 
-	// ParentName is the name of the parent device, which may be empty.
+	// ParentName is the name of the parent device, which may be empty. When set
+	// the parent device must be on the same machine, unless the current device
+	// is inside a container, in which case ParentName can be a global key of a
+	// BridgeDevice on the host machine of the container.
 	ParentName string `bson:"parent-name"`
 }
 

--- a/state/linklayerdevices.go
+++ b/state/linklayerdevices.go
@@ -171,7 +171,7 @@ func (dev *LinkLayerDevice) ParentDevice() (*LinkLayerDevice, error) {
 		return nil, nil
 	}
 
-	hostMachineID, parentDeviceName, err := parseParentNameAsGlobalKey(dev.doc.ParentName)
+	hostMachineID, parentDeviceName, err := parseLinkLayerDeviceParentNameAsGlobalKey(dev.doc.ParentName)
 	if err != nil {
 		return nil, errors.Trace(err)
 	} else if hostMachineID != "" {

--- a/state/linklayerdevices_internal_test.go
+++ b/state/linklayerdevices_internal_test.go
@@ -153,7 +153,7 @@ func (s *linkLayerDevicesInternalSuite) TestIsValidLinkLayerDeviceTypeWithInvali
 	result = IsValidLinkLayerDeviceType(" ")
 	c.Check(result, jc.IsFalse)
 
-	result = IsValidLinkLayerDeviceType(string(UnknownDevice))
+	result = IsValidLinkLayerDeviceType("unknown")
 	c.Check(result, jc.IsFalse)
 }
 

--- a/state/linklayerdevices_test.go
+++ b/state/linklayerdevices_test.go
@@ -667,7 +667,8 @@ func (s *linkLayerDevicesStateSuite) TestAddLinkLayerDevicesRefusesToAddContaine
 	s.addContainerMachine(c)
 
 	// Now try adding an EthernetDevice on the container specifying each of the
-	// hostDevices as parent and expect only last one to succeed.
+	// hostDevices as parent and expect none of them to succeed, as none of the
+	// hostDevices is a BridgeDevice.
 	for _, hostDevice := range hostDevices {
 		parentDeviceGlobalKey := hostMachineParentDeviceGlobalKeyPrefix + hostDevice.Name()
 		containerDeviceArgs := state.LinkLayerDeviceArgs{

--- a/state/machine_linklayerdevices.go
+++ b/state/machine_linklayerdevices.go
@@ -286,12 +286,12 @@ func (m *Machine) validateAddLinkLayerDeviceArgs(args *LinkLayerDeviceArgs) erro
 }
 
 func (m *Machine) maybeValidateParentAsGlobalKey(args *LinkLayerDeviceArgs) error {
-	hostMachineID, parentDeviceName, err := parseParentNameAsGlobalKey(args.ParentName)
+	hostMachineID, parentDeviceName, err := parseLinkLayerDeviceParentNameAsGlobalKey(args.ParentName)
 	if err != nil {
 		return errors.Trace(err)
 	} else if hostMachineID == "" {
 		// Not a global key, so validate as usual.
-		return validateParentNameWhenItIsNotAGlobalKey(args)
+		return m.validateParentDeviceNameWhenNotAGlobalKey(args)
 	}
 	ourParentMachineID, hasParent := m.ParentId()
 	if !hasParent {
@@ -309,7 +309,7 @@ func (m *Machine) maybeValidateParentAsGlobalKey(args *LinkLayerDeviceArgs) erro
 	return errors.Trace(err)
 }
 
-func parseParentNameAsGlobalKey(parentName string) (hostMachineID, parentDeviceName string, err error) {
+func parseLinkLayerDeviceParentNameAsGlobalKey(parentName string) (hostMachineID, parentDeviceName string, err error) {
 	if !strings.Contains(parentName, "#") {
 		// Can't be a global key.
 		return "", "", nil
@@ -342,7 +342,7 @@ func (m *Machine) verifyHostMachineParentDeviceExistsAndIsABridgeDevice(hostMach
 	return nil
 }
 
-func validateParentNameWhenItIsNotAGlobalKey(args *LinkLayerDeviceArgs) error {
+func (m *Machine) validateParentDeviceNameWhenNotAGlobalKey(args *LinkLayerDeviceArgs) error {
 	if !IsValidLinkLayerDeviceName(args.ParentName) {
 		return errors.NotValidf("ParentName %q", args.ParentName)
 	}
@@ -401,7 +401,7 @@ func (m *Machine) areLinkLayerDeviceDocsStillValid(newDocs []linkLayerDeviceDoc)
 }
 
 func (m *Machine) verifyParentDeviceExists(name, parentName string) error {
-	hostMachineID, parentDeviceName, err := parseParentNameAsGlobalKey(parentName)
+	hostMachineID, parentDeviceName, err := parseLinkLayerDeviceParentNameAsGlobalKey(parentName)
 	if err != nil {
 		return errors.Trace(err)
 	} else if hostMachineID != "" {
@@ -449,7 +449,7 @@ func (m *Machine) insertLinkLayerDeviceOps(newDoc *linkLayerDeviceDoc) ([]txn.Op
 	if newDoc.ParentName != "" {
 		var parentDocID string
 
-		hostMachineID, parentDeviceName, err := parseParentNameAsGlobalKey(newDoc.ParentName)
+		hostMachineID, parentDeviceName, err := parseLinkLayerDeviceParentNameAsGlobalKey(newDoc.ParentName)
 		if err != nil {
 			return nil, errors.Trace(err)
 		} else if hostMachineID != "" {

--- a/state/machine_linklayerdevices.go
+++ b/state/machine_linklayerdevices.go
@@ -268,7 +268,7 @@ func (m *Machine) validateAddLinkLayerDeviceArgs(args *LinkLayerDeviceArgs) erro
 	}
 
 	if args.ParentName != "" {
-		if err := m.maybeValidateParentAsGlobalKey(args); err != nil {
+		if err := m.validateLinkLayerDeviceParent(args); err != nil {
 			return errors.Trace(err)
 		}
 	}
@@ -285,7 +285,7 @@ func (m *Machine) validateAddLinkLayerDeviceArgs(args *LinkLayerDeviceArgs) erro
 	return nil
 }
 
-func (m *Machine) maybeValidateParentAsGlobalKey(args *LinkLayerDeviceArgs) error {
+func (m *Machine) validateLinkLayerDeviceParent(args *LinkLayerDeviceArgs) error {
 	hostMachineID, parentDeviceName, err := parseLinkLayerDeviceParentNameAsGlobalKey(args.ParentName)
 	if err != nil {
 		return errors.Trace(err)

--- a/state/machine_linklayerdevices.go
+++ b/state/machine_linklayerdevices.go
@@ -122,7 +122,9 @@ type LinkLayerDeviceArgs struct {
 	IsUp bool
 
 	// ParentName is the name of the parent device, which may be empty. If set,
-	// it needs to be an existing device on the same machine. Traffic
+	// it needs to be an existing device on the same machine, unless the current
+	// device is inside a container, in which case ParentName can be a global
+	// key of a BridgeDevice on the host machine of the container. Traffic
 	// originating from a device egresses from its parent device.
 	ParentName string
 }


### PR DESCRIPTION
Support adding a link-layer device on a container machine using a link-
layer bridge device on the container's host machine as a parent. This
scenario is needed to properly model the relationship between each of
the multiple bridge devices created on the host machine (by the bridge
script) and containers' network interfaces that need those bridges.

Includes removing of the no longer necessary state.UnknownDevice type.

(Review request: http://reviews.vapour.ws/r/4064/)