### PR TITLE
state: Remove link-layer devices along with their Machine

### DIFF
--- a/state/linklayerdevices_test.go
+++ b/state/linklayerdevices_test.go
@@ -785,3 +785,15 @@ func (s *linkLayerDevicesStateSuite) TestAddLinkLayerDevicesToContainerWhenConta
 	c.Assert(err, gc.ErrorMatches, `.*host machine "0" of parent device "br-eth1" not found`)
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
+
+func (s *linkLayerDevicesStateSuite) TestMachineRemoveAlsoRemoveAllLinkLayerDevices(c *gc.C) {
+	s.assertNoDevicesOnMachine(c, s.machine)
+	s.addNamedParentDeviceWithChildrenAndCheckAllAdded(c, "foo", "bar")
+
+	err := s.machine.EnsureDead()
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.machine.Remove()
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.assertNoDevicesOnMachine(c, s.machine)
+}

--- a/state/machine.go
+++ b/state/machine.go
@@ -896,6 +896,10 @@ func (m *Machine) Remove() (err error) {
 	if err != nil {
 		return err
 	}
+	linkLayerDevicesOps, err := m.removeAllLinkLayerDevicesOps()
+	if err != nil {
+		return err
+	}
 	portsOps, err := m.removePortsOps()
 	if err != nil {
 		return err
@@ -909,6 +913,7 @@ func (m *Machine) Remove() (err error) {
 		return err
 	}
 	ops = append(ops, ifacesOps...)
+	ops = append(ops, linkLayerDevicesOps...)
 	ops = append(ops, portsOps...)
 	ops = append(ops, removeContainerRefOps(m.st, m.Id())...)
 	ops = append(ops, filesystemOps...)


### PR DESCRIPTION
Removing a machine now removes all link-layer devices the machine has.

Includes https://github.com/juju/juju/pull/4624 as prerequisite.

(Review request: http://reviews.vapour.ws/r/4077/)