### PR TITLE
cleanup a bunch of code that we weren't using

### DIFF
--- a/tools/lxdclient/client.go
+++ b/tools/lxdclient/client.go
@@ -51,7 +51,6 @@ func Connect(cfg Config) (*Client, error) {
 }
 
 var lxdNewClientFromInfo = lxd.NewClientFromInfo
-var lxdLoadConfig = lxd.LoadConfig
 
 func newRawClient(cfg Config) (*lxd.Client, error) {
 	logger.Debugf("using LXD remote %q", cfg.Remote.ID())

--- a/tools/lxdclient/client_test.go
+++ b/tools/lxdclient/client_test.go
@@ -18,7 +18,6 @@ type ConnectSuite struct {
 
 func (cs ConnectSuite) TestLocalConnectError(c *gc.C) {
 	cs.PatchValue(lxdNewClientFromInfo, fakeNewClientFromInfo)
-	cs.PatchValue(lxdLoadConfig, fakeLoadConfig)
 
 	cfg := Config{
 		Remote: Local,
@@ -32,7 +31,6 @@ func (cs ConnectSuite) TestLocalConnectError(c *gc.C) {
 
 func (cs ConnectSuite) TestRemoteConnectError(c *gc.C) {
 	cs.PatchValue(lxdNewClientFromInfo, fakeNewClientFromInfo)
-	cs.PatchValue(lxdLoadConfig, fakeLoadConfig)
 
 	cfg := Config{
 		Remote: Remote{
@@ -49,8 +47,4 @@ var testerr = errors.Errorf("boo!")
 
 func fakeNewClientFromInfo(config *lxd.Config, remote string) (*lxd.Client, error) {
 	return nil, testerr
-}
-
-func fakeLoadConfig() (*lxd.Config, error) {
-	return nil, nil
 }

--- a/tools/lxdclient/testing_test.go
+++ b/tools/lxdclient/testing_test.go
@@ -6,29 +6,19 @@
 package lxdclient
 
 import (
-	"crypto/x509"
-	"os"
-
-	"github.com/juju/errors"
 	"github.com/juju/testing"
-	"github.com/lxc/lxd"
-	"github.com/lxc/lxd/shared"
 	gc "gopkg.in/check.v1"
 )
 
 type BaseSuite struct {
 	testing.IsolationSuite
 
-	Stub   *testing.Stub
-	Client *stubClient
 	Cert   *Cert
 }
 
 func (s *BaseSuite) SetUpTest(c *gc.C) {
 	s.IsolationSuite.SetUpTest(c)
 
-	s.Stub = &testing.Stub{}
-	s.Client = &stubClient{stub: s.Stub}
 	s.Cert = &Cert{
 		Name:    "some cert",
 		CertPEM: []byte("<a valid PEM-encoded x.509 cert>"),
@@ -36,101 +26,3 @@ func (s *BaseSuite) SetUpTest(c *gc.C) {
 	}
 }
 
-type stubClient struct {
-	stub *testing.Stub
-
-	Instance   *shared.ContainerState
-	Instances  []shared.ContainerInfo
-	ReturnCode int
-	Response   *lxd.Response
-}
-
-func (s *stubClient) WaitForSuccess(waitURL string) error {
-	s.stub.AddCall("WaitForSuccess", waitURL)
-	if err := s.stub.NextErr(); err != nil {
-		return errors.Trace(err)
-	}
-
-	return nil
-}
-
-func (s *stubClient) SetServerConfig(key string, value string) (*lxd.Response, error) {
-	s.stub.AddCall("SetServerConfig", key, value)
-	if err := s.stub.NextErr(); err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	return s.Response, nil
-}
-
-func (s *stubClient) CertificateAdd(cert *x509.Certificate, name string) error {
-	s.stub.AddCall("CertificateAdd", cert, name)
-	if err := s.stub.NextErr(); err != nil {
-		return errors.Trace(err)
-	}
-
-	return nil
-}
-
-func (s *stubClient) ContainerState(name string) (*shared.ContainerState, error) {
-	s.stub.AddCall("ContainerState", name)
-	if err := s.stub.NextErr(); err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	return s.Instance, nil
-}
-
-func (s *stubClient) ListContainers() ([]shared.ContainerInfo, error) {
-	s.stub.AddCall("ListContainers")
-	if err := s.stub.NextErr(); err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	return s.Instances, nil
-}
-
-func (s *stubClient) Init(name, remote, image string, profiles *[]string, ephem bool) (*lxd.Response, error) {
-	s.stub.AddCall("AddInstance", name, remote, image, profiles, ephem)
-	if err := s.stub.NextErr(); err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	return s.Response, nil
-}
-
-func (s *stubClient) Delete(name string) (*lxd.Response, error) {
-	s.stub.AddCall("Delete", name)
-	if err := s.stub.NextErr(); err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	return s.Response, nil
-}
-
-func (s *stubClient) Action(name string, action shared.ContainerAction, timeout int, force bool) (*lxd.Response, error) {
-	s.stub.AddCall("Action", name, action, timeout, force)
-	if err := s.stub.NextErr(); err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	return s.Response, nil
-}
-
-func (s *stubClient) Exec(name string, cmd []string, env map[string]string, stdin *os.File, stdout *os.File, stderr *os.File) (int, error) {
-	s.stub.AddCall("Exec", name, cmd, env, stdin, stdout, stderr)
-	if err := s.stub.NextErr(); err != nil {
-		return -1, errors.Trace(err)
-	}
-
-	return s.ReturnCode, nil
-}
-
-func (s *stubClient) SetContainerConfig(name, key, value string) error {
-	s.stub.AddCall("SetContainerConfig", name, key, value)
-	if err := s.stub.NextErr(); err != nil {
-		return errors.Trace(err)
-	}
-
-	return nil
-}


### PR DESCRIPTION
This is just a cleanup pass on tools/lxdclient

We had a bunch of stuff in the test code that we weren't using (Stub objects, etc). And then we also no longer need lxd.LoadConfig so we don't need our local var or to override our local variable.

(Review request: http://reviews.vapour.ws/r/4080/)