### PR TITLE
provider/maas: ensure bridge script works on xenial

### DIFF
--- a/provider/maas/add-juju-bridge.py
+++ b/provider/maas/add-juju-bridge.py
@@ -167,7 +167,7 @@ class NetworkInterfaceParser(object):
 
     def __init__(self, filename):
         self._stanzas = []
-        with open(filename) as f:
+        with open(filename, 'r') as f:
             lines = f.readlines()
         line_iterator = SeekableIterator(lines)
         for line in line_iterator:
@@ -276,9 +276,9 @@ def print_shell_cmd(s, verbose=True, exit_on_error=False):
         print(s)
     out, err, retcode = shell_cmd(s)
     if out and len(out) > 0:
-        print(out.rstrip('\n'))
+        print(out.decode().rstrip('\n'))
     if err and len(err) > 0:
-        print(err.rstrip('\n'))
+        print(err.decode().rstrip('\n'))
     if exit_on_error and retcode != 0:
         exit(1)
 
@@ -345,12 +345,12 @@ def main(args):
         if not os.path.isfile(backup_file):
             shutil.copy2(args.filename, backup_file)
 
-    ifquery = "$(ifquery -i {} --exclude=lo -l)".format(args.filename)
+    ifquery = "$(ifquery --interfaces={} --exclude=lo --list)".format(args.filename)
 
     print("**** Original configuration")
     print_shell_cmd("cat {}".format(args.filename))
     print_shell_cmd("ifconfig -a")
-    print_shell_cmd("ifdown --exclude=lo -i {} {}".format(args.filename, ifquery))
+    print_shell_cmd("ifdown --exclude=lo --interfaces={} {}".format(args.filename, ifquery))
 
     print("**** Activating new configuration")
 
@@ -359,7 +359,7 @@ def main(args):
         f.close()
 
     print_shell_cmd("cat {}".format(args.filename))
-    print_shell_cmd("ifup --exclude=lo -i {} {}".format(args.filename, ifquery))
+    print_shell_cmd("ifup --exclude=lo --interfaces={} {}".format(args.filename, ifquery))
     print_shell_cmd("ip link show up")
     print_shell_cmd("ifconfig -a")
     print_shell_cmd("ip route show")

--- a/provider/maas/bridgescript.go
+++ b/provider/maas/bridgescript.go
@@ -179,7 +179,7 @@ class NetworkInterfaceParser(object):
 
     def __init__(self, filename):
         self._stanzas = []
-        with open(filename) as f:
+        with open(filename, 'r') as f:
             lines = f.readlines()
         line_iterator = SeekableIterator(lines)
         for line in line_iterator:
@@ -288,9 +288,9 @@ def print_shell_cmd(s, verbose=True, exit_on_error=False):
         print(s)
     out, err, retcode = shell_cmd(s)
     if out and len(out) > 0:
-        print(out.rstrip('\n'))
+        print(out.decode().rstrip('\n'))
     if err and len(err) > 0:
-        print(err.rstrip('\n'))
+        print(err.decode().rstrip('\n'))
     if exit_on_error and retcode != 0:
         exit(1)
 
@@ -357,12 +357,12 @@ def main(args):
         if not os.path.isfile(backup_file):
             shutil.copy2(args.filename, backup_file)
 
-    ifquery = "$(ifquery -i {} --exclude=lo -l)".format(args.filename)
+    ifquery = "$(ifquery --interfaces={} --exclude=lo --list)".format(args.filename)
 
     print("**** Original configuration")
     print_shell_cmd("cat {}".format(args.filename))
     print_shell_cmd("ifconfig -a")
-    print_shell_cmd("ifdown --exclude=lo -i {} {}".format(args.filename, ifquery))
+    print_shell_cmd("ifdown --exclude=lo --interfaces={} {}".format(args.filename, ifquery))
 
     print("**** Activating new configuration")
 
@@ -371,7 +371,7 @@ def main(args):
         f.close()
 
     print_shell_cmd("cat {}".format(args.filename))
-    print_shell_cmd("ifup --exclude=lo -i {} {}".format(args.filename, ifquery))
+    print_shell_cmd("ifup --exclude=lo --interfaces={} {}".format(args.filename, ifquery))
     print_shell_cmd("ip link show up")
     print_shell_cmd("ifconfig -a")
     print_shell_cmd("ip route show")

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -1057,7 +1057,39 @@ func (environ *maasEnviron) selectNode(args selectNodeArgs) (*gomaasapi.MAASObje
 // setupJujuNetworking returns a string representing the script to run
 // in order to prepare the Juju-specific networking config on a node.
 func setupJujuNetworking() string {
-	return fmt.Sprintf("trap 'rm -f %[1]q' EXIT; if [ -f %[1]q ]; then %[1]q --bridge-prefix=%q --one-time-backup --activate %q; fi\n",
+	// For ubuntu series < xenial we prefer python2 over python3
+	// as we don't want to invalidate lots of testing against
+	// known cloud-image contents. A summary of Ubuntu releases
+	// and python inclusion in the default install of Ubuntu
+	// Server is as follows:
+	//
+	// 12.04 precise:  python 2 (2.7.3)
+	// 14.04 trusty:   python 2 (2.7.5) and python3 (3.4.0)
+	// 14.10 utopic:   python 2 (2.7.8) and python3 (3.4.2)
+	// 15.04 vivid:    python 2 (2.7.9) and python3 (3.4.3)
+	// 15.10 wily:     python 2 (2.7.9) and python3 (3.4.3)
+	// 16.04 xenial:   python 3 only (3.5.1)
+	//
+	// going forward:  python 3 only
+
+	return fmt.Sprintf(`
+trap 'rm -f %[1]q' EXIT
+
+if [ -x /usr/bin/python2 ]; then
+    juju_networking_preferred_python_binary=/usr/bin/python2
+elif [ -x /usr/bin/python3 ]; then
+    juju_networking_preferred_python_binary=/usr/bin/python3
+elif [ -x /usr/bin/python ]; then
+    juju_networking_preferred_python_binary=/usr/bin/python
+fi
+
+if [ ! -z "${juju_networking_preferred_python_binary:-}" ]; then
+    if [ -f %[1]q ]; then
+        ${juju_networking_preferred_python_binary} %[1]q --bridge-prefix=%q --one-time-backup --activate %q
+    fi
+else
+    echo "error: no Python installation found; cannot run Juju's bridge script"
+fi`,
 		bridgeScriptPath,
 		instancecfg.DefaultBridgePrefix,
 		"/etc/network/interfaces")


### PR DESCRIPTION
Original PR done on master: http://reviews.vapour.ws/r/4021/

Xenial only has Python 3.5 and there is no /usr/bin/python only
/usr/bin/python3, however the bridge script was reliant on just python.

We now detect what python versions are available before invoking the
script, preferring python 2 over 3 as we don't want to invalidate lots
of existing testing with known cloud-image contents for series older
than xenial.

A summary of Ubuntu releases and the python version included in the
default install of Ubuntu Server is as follows:

 12.04 precise:  python 2 only (2.7.3)
 14.04 trusty:   python 2 only (2.7.5) and python3 (3.4.0)
 14.10 utopic:   python 2 (2.7.8) and python3 (3.4.2)
 15.04 vivid:    python 2 (2.7.9) and python3 (3.4.3)
 15.10 wily:     python 2 (2.7.9) and python3 (3.4.3)
 16.04 xenial:   python 3 only (3.5.1)
 going forward:  python 3 only

This has been tested by bootstrapping with precise (where some extra
fixes where required), trusty, wily and xenial.

Fixes [LP:#1550306](https://bugs.launchpad.net/juju-core/+bug/1550306)

(cherry picked from commit e530e9427763a0d00e97aff52ccbd800e5c66ab9)

(Review request: http://reviews.vapour.ws/r/4081/)