### PR TITLE
state/metricsmanager: We just use a fixed doc id rather than take in the model uuid as this collection works across models

### DIFF
--- a/state/metricsmanager.go
+++ b/state/metricsmanager.go
@@ -28,21 +28,9 @@ type MetricsManager struct {
 }
 
 type metricsManagerDoc struct {
-	DocID              string        `bson:"_id"`
-	ModelUUID          string        `bson:"model-uuid"`
 	LastSuccessfulSend time.Time     `bson:"lastsuccessfulsend"`
 	ConsecutiveErrors  int           `bson:"consecutiveerrors"`
 	GracePeriod        time.Duration `bson:"graceperiod"`
-}
-
-// DocID returns the Document id of the MetricsManager.
-func (m *MetricsManager) DocID() string {
-	return m.doc.DocID
-}
-
-// ModelUUID returns the model UUID of the Metrics Manager.
-func (m *MetricsManager) ModelUUID() string {
-	return m.doc.ModelUUID
 }
 
 // LastSuccessfulSend returns the time of the last successful send.
@@ -75,24 +63,17 @@ func (st *State) newMetricsManager() (*MetricsManager, error) {
 	mm := &MetricsManager{
 		st: st,
 		doc: metricsManagerDoc{
-			DocID:              st.docID(metricsManagerKey),
-			ModelUUID:          st.ModelUUID(),
 			LastSuccessfulSend: time.Time{},
 			ConsecutiveErrors:  0,
 			GracePeriod:        defaultGracePeriod,
 		}}
-	buildTxn := func(attempt int) ([]txn.Op, error) {
-		if attempt > 0 {
-			return nil, errors.NotFoundf("metrics manager")
-		}
-		return []txn.Op{{
-			C:      metricsManagerC,
-			Id:     st.docID(metricsManagerKey),
-			Assert: txn.DocMissing,
-			Insert: mm.doc,
-		}}, nil
-	}
-	err := st.run(buildTxn)
+	ops := []txn.Op{{
+		C:      metricsManagerC,
+		Id:     metricsManagerKey,
+		Assert: txn.DocMissing,
+		Insert: mm.doc,
+	}}
+	err := st.runTransaction(ops)
 	if err != nil {
 		return nil, onAbort(err, errors.NotFoundf("metrics manager"))
 	}
@@ -103,7 +84,7 @@ func (st *State) getMetricsManager() (*MetricsManager, error) {
 	coll, closer := st.getCollection(metricsManagerC)
 	defer closer()
 	var doc metricsManagerDoc
-	err := coll.FindId(st.docID(metricsManagerKey)).One(&doc)
+	err := coll.FindId(metricsManagerKey).One(&doc)
 	if err == mgo.ErrNotFound {
 		return nil, errors.NotFoundf("metrics manager")
 	} else if err != nil {
@@ -113,15 +94,13 @@ func (st *State) getMetricsManager() (*MetricsManager, error) {
 }
 
 func (m *MetricsManager) updateMetricsManager(update bson.M) error {
-	buildTxn := func(attempt int) ([]txn.Op, error) {
-		return []txn.Op{{
-			C:      metricsManagerC,
-			Id:     m.st.docID(metricsManagerKey),
-			Assert: txn.DocExists,
-			Update: update,
-		}}, nil
-	}
-	err := m.st.run(buildTxn)
+	ops := []txn.Op{{
+		C:      metricsManagerC,
+		Id:     metricsManagerKey,
+		Assert: txn.DocExists,
+		Update: update,
+	}}
+	err := m.st.runTransaction(ops)
 	if err == txn.ErrAborted {
 		err = errors.NotFoundf("metrics manager")
 	}

--- a/state/metricsmanager_test.go
+++ b/state/metricsmanager_test.go
@@ -4,7 +4,6 @@
 package state_test
 
 import (
-	"fmt"
 	"time"
 
 	jc "github.com/juju/testing/checkers"
@@ -23,11 +22,9 @@ var _ = gc.Suite(&metricsManagerSuite{})
 func (s *metricsManagerSuite) TestDefaultsWritten(c *gc.C) {
 	mm, err := s.State.MetricsManager()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(mm.DocID(), gc.Equals, fmt.Sprintf("%s:metricsManagerKey", s.State.ModelUUID()))
 	c.Assert(mm.LastSuccessfulSend(), gc.DeepEquals, time.Time{})
 	c.Assert(mm.ConsecutiveErrors(), gc.Equals, 0)
 	c.Assert(mm.GracePeriod(), gc.Equals, 24*7*time.Hour)
-	c.Assert(mm.ModelUUID(), gc.Equals, s.State.ModelUUID())
 }
 
 func (s *metricsManagerSuite) TestMetricsManagerCreatesThenReturns(c *gc.C) {

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -1502,7 +1502,7 @@ func (u *Unit) WatchMeterStatus() NotifyWatcher {
 			u.st.docID(u.globalMeterStatusKey()),
 		}, {
 			metricsManagerC,
-			u.st.docID(metricsManagerKey),
+			metricsManagerKey,
 		},
 	})
 }


### PR DESCRIPTION


(Review request: http://reviews.vapour.ws/r/4085/)