### PR TITLE
worker/migrationmaster: Add migrationmaster worker skeleton

### DIFF
--- a/api/migrationmaster/client.go
+++ b/api/migrationmaster/client.go
@@ -10,20 +10,26 @@ import (
 	"github.com/juju/juju/watcher"
 )
 
-// NewClient returns a new Client based on an existing API connection.
-func NewClient(caller base.APICaller) *Client {
-	return &Client{base.NewFacadeCaller(caller, "MigrationMaster")}
+// Client describes the client side API for the MigrationMaster facade
+// (used by the migration master worker).
+type Client interface {
+	// Watch returns a watcher which reports when a migration is
+	// active for the model associated with the API connection.
+	Watch() (watcher.MigrationMasterWatcher, error)
 }
 
-// Client provides the client side API for the MigrationMaster facade
-// (to be used by the migration master worker).
-type Client struct {
+// NewClient returns a new Client based on an existing API connection.
+func NewClient(caller base.APICaller) Client {
+	return &client{base.NewFacadeCaller(caller, "MigrationMaster")}
+}
+
+// client implements Client.
+type client struct {
 	caller base.FacadeCaller
 }
 
-// Watch returns a watcher which reports when a migration is active
-// for the model associated with the API connection.
-func (c *Client) Watch() (watcher.MigrationMasterWatcher, error) {
+// Watch implements Client.
+func (c *client) Watch() (watcher.MigrationMasterWatcher, error) {
 	var result params.NotifyWatchResult
 	err := c.caller.FacadeCall("Watch", nil, &result)
 	if err != nil {

--- a/worker/migrationmaster/manifold.go
+++ b/worker/migrationmaster/manifold.go
@@ -1,0 +1,29 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package migrationmaster
+
+import (
+	"github.com/juju/juju/agent"
+	"github.com/juju/juju/api/base"
+	masterapi "github.com/juju/juju/api/migrationmaster"
+	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/dependency"
+	"github.com/juju/juju/worker/util"
+)
+
+// ManifoldConfig defines the names of the manifolds on which a
+// Manifold will depend.
+type ManifoldConfig util.PostUpgradeManifoldConfig
+
+// Manifold returns a dependency manifold that runs the migration
+// worker.
+func Manifold(config ManifoldConfig) dependency.Manifold {
+	return util.PostUpgradeManifold(util.PostUpgradeManifoldConfig(config), newWorker)
+}
+
+// newWorker is a shim to allow New to work with PostUpgradeManifold.
+func newWorker(_ agent.Agent, apiCaller base.APICaller) (worker.Worker, error) {
+	client := masterapi.NewClient(apiCaller)
+	return New(client), nil
+}

--- a/worker/migrationmaster/package_test.go
+++ b/worker/migrationmaster/package_test.go
@@ -1,0 +1,11 @@
+package migrationmaster_test
+
+import (
+	stdtesting "testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *stdtesting.T) {
+	gc.TestingT(t)
+}

--- a/worker/migrationmaster/worker.go
+++ b/worker/migrationmaster/worker.go
@@ -1,0 +1,65 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package migrationmaster
+
+import (
+	"github.com/juju/errors"
+	"launchpad.net/tomb"
+
+	masterapi "github.com/juju/juju/api/migrationmaster"
+	"github.com/juju/juju/core/modelmigration"
+	"github.com/juju/juju/worker"
+)
+
+// New starts a migration master worker using the supplied migration
+// master API facade.
+func New(client masterapi.Client) worker.Worker {
+	w := &migrationMaster{
+		client: client,
+	}
+	go func() {
+		defer w.tomb.Done()
+		w.tomb.Kill(w.run())
+	}()
+	return w
+}
+
+type migrationMaster struct {
+	tomb   tomb.Tomb
+	client masterapi.Client
+}
+
+// Kill implements worker.Worker.
+func (w *migrationMaster) Kill() {
+	w.tomb.Kill(nil)
+}
+
+// Wait implements worker.Worker.
+func (w *migrationMaster) Wait() error {
+	return w.tomb.Wait()
+}
+
+func (w *migrationMaster) run() error {
+	targetInfo, err := w.waitForMigration()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	var _ = targetInfo
+	return errors.New("migration seen")
+}
+
+func (w *migrationMaster) waitForMigration() (*modelmigration.TargetInfo, error) {
+	watcher, err := w.client.Watch()
+	if err != nil {
+		return nil, errors.Annotate(err, "watching for migration")
+	}
+	defer worker.Stop(watcher)
+
+	select {
+	case <-w.tomb.Dying():
+		return nil, tomb.ErrDying
+	case info := <-watcher.Changes():
+		return &info, nil
+	}
+}

--- a/worker/migrationmaster/worker_test.go
+++ b/worker/migrationmaster/worker_test.go
@@ -1,0 +1,128 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package migrationmaster_test
+
+import (
+	"errors"
+	"time"
+
+	"launchpad.net/tomb"
+
+	gc "gopkg.in/check.v1"
+
+	masterapi "github.com/juju/juju/api/migrationmaster"
+	"github.com/juju/juju/core/modelmigration"
+	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/watcher"
+	"github.com/juju/juju/worker/migrationmaster"
+)
+
+type Suite struct {
+	coretesting.BaseSuite
+}
+
+var _ = gc.Suite(&Suite{})
+
+func (s *Suite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+}
+
+func (s *Suite) TestWatchesForMigration(c *gc.C) {
+	client := newMockClient()
+	w := migrationmaster.New(client)
+
+	doneC := make(chan error)
+	go func() {
+		doneC <- w.Wait()
+	}()
+
+	// Wait for Watch to be called
+	select {
+	case <-client.watchCalled:
+	case <-time.After(coretesting.LongWait):
+		c.Fatal("timed out waiting for Watch to be called")
+	}
+
+	// Ensure worker is staying alive
+	select {
+	case <-doneC:
+		c.Fatal("worker terminated prematurely")
+	case <-time.After(coretesting.ShortWait):
+	}
+
+	// Trigger migration.
+	client.watcher.changes <- modelmigration.TargetInfo{}
+
+	// Worker should exit for now (TEMPORARY)
+	select {
+	case err := <-doneC:
+		c.Assert(err, gc.ErrorMatches, "migration seen")
+	case <-time.After(coretesting.LongWait):
+		c.Fatal("timed out waiting for worker to stop")
+	}
+}
+
+func (s *Suite) TestWatchFailure(c *gc.C) {
+	client := newMockClient()
+	client.watchErr = errors.New("boom")
+	w := migrationmaster.New(client)
+
+	doneC := make(chan error)
+	go func() {
+		doneC <- w.Wait()
+	}()
+
+	select {
+	case err := <-doneC:
+		c.Assert(err, gc.ErrorMatches, "watching for migration: boom")
+	case <-time.After(coretesting.LongWait):
+		c.Fatal("timed out waiting for worker to stop")
+	}
+}
+
+func newMockClient() *mockClient {
+	return &mockClient{
+		watchCalled: make(chan bool),
+		watcher:     newMockWatcher(),
+	}
+}
+
+type mockClient struct {
+	masterapi.Client
+	watchCalled chan bool
+	watchErr    error
+	watcher     *mockWatcher
+}
+
+func (c *mockClient) Watch() (watcher.MigrationMasterWatcher, error) {
+	close(c.watchCalled)
+	if c.watchErr != nil {
+		return nil, c.watchErr
+	}
+	return c.watcher, nil
+}
+
+func newMockWatcher() *mockWatcher {
+	return &mockWatcher{
+		changes: make(chan modelmigration.TargetInfo, 1),
+	}
+}
+
+type mockWatcher struct {
+	tomb    tomb.Tomb
+	changes chan modelmigration.TargetInfo
+}
+
+func (w *mockWatcher) Kill() {
+	w.tomb.Kill(nil)
+	w.tomb.Done()
+}
+
+func (w *mockWatcher) Wait() error {
+	return w.tomb.Wait()
+}
+
+func (w *mockWatcher) Changes() <-chan modelmigration.TargetInfo {
+	return w.changes
+}


### PR DESCRIPTION
This uses the migrationmaster facade and waits for an active migration. For now it simply exits when a migration is reported.

(Review request: http://reviews.vapour.ws/r/4092/)