### PR TITLE
apiserver/migrationmaster: Add SetPhase API

### DIFF
--- a/apiserver/migrationmaster/migrationmaster_test.go
+++ b/apiserver/migrationmaster/migrationmaster_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/juju/apiserver/migrationmaster"
 	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
+	"github.com/juju/juju/core/modelmigration"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/testing"
 )
@@ -22,7 +23,7 @@ var _ migrationmaster.Backend = (*state.State)(nil)
 type Suite struct {
 	testing.BaseSuite
 
-	backend    *fakeBackend
+	backend    *stubBackend
 	resources  *common.Resources
 	authorizer apiservertesting.FakeAuthorizer
 }
@@ -32,7 +33,9 @@ var _ = gc.Suite(&Suite{})
 func (s *Suite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 
-	s.backend = &fakeBackend{}
+	s.backend = &stubBackend{
+		migration: new(stubMigration),
+	}
 	migrationmaster.PatchState(s, s.backend)
 
 	s.resources = common.NewResources()
@@ -43,14 +46,12 @@ func (s *Suite) SetUpTest(c *gc.C) {
 	}
 }
 
-func (s *Suite) makeAPI() (*migrationmaster.API, error) {
-	return migrationmaster.NewAPI(nil, s.resources, s.authorizer)
-}
+func (s *Suite) TestNotEnvironManager(c *gc.C) {
+	s.authorizer.EnvironManager = false
 
-func (s *Suite) mustMakeAPI(c *gc.C) *migrationmaster.API {
-	api, err := migrationmaster.NewAPI(nil, s.resources, s.authorizer)
-	c.Assert(err, jc.ErrorIsNil)
-	return api
+	api, err := s.makeAPI()
+	c.Assert(api, gc.IsNil)
+	c.Assert(err, gc.Equals, common.ErrPerm)
 }
 
 func (s *Suite) TestWatch(c *gc.C) {
@@ -70,21 +71,78 @@ func (s *Suite) TestWatchError(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "boom")
 }
 
-func (s *Suite) TestWatchNotEnvironManager(c *gc.C) {
-	s.authorizer.EnvironManager = false
+func (s *Suite) TestSetPhase(c *gc.C) {
+	api := s.mustMakeAPI(c)
 
-	api, err := s.makeAPI()
-	c.Assert(api, gc.IsNil)
-	c.Assert(err, gc.Equals, common.ErrPerm)
+	err := api.SetPhase(params.SetMigrationPhaseArgs{Phase: "ABORT"})
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(s.backend.migration.phaseSet, gc.Equals, modelmigration.ABORT)
 }
 
-type fakeBackend struct {
+func (s *Suite) TestSetPhaseNoMigration(c *gc.C) {
+	s.backend.getErr = errors.New("boom")
+	api := s.mustMakeAPI(c)
+
+	err := api.SetPhase(params.SetMigrationPhaseArgs{Phase: "ABORT"})
+	c.Assert(err, gc.ErrorMatches, "could not get migration: boom")
+}
+
+func (s *Suite) TestSetPhaseBadPhase(c *gc.C) {
+	api := s.mustMakeAPI(c)
+
+	err := api.SetPhase(params.SetMigrationPhaseArgs{Phase: "wat"})
+	c.Assert(err, gc.ErrorMatches, `invalid phase: "wat"`)
+}
+
+func (s *Suite) TestSetPhaseError(c *gc.C) {
+	s.backend.migration.setPhaseErr = errors.New("blam")
+	api := s.mustMakeAPI(c)
+
+	err := api.SetPhase(params.SetMigrationPhaseArgs{Phase: "ABORT"})
+	c.Assert(err, gc.ErrorMatches, "failed to set phase: blam")
+}
+
+func (s *Suite) makeAPI() (*migrationmaster.API, error) {
+	return migrationmaster.NewAPI(nil, s.resources, s.authorizer)
+}
+
+func (s *Suite) mustMakeAPI(c *gc.C) *migrationmaster.API {
+	api, err := migrationmaster.NewAPI(nil, s.resources, s.authorizer)
+	c.Assert(err, jc.ErrorIsNil)
+	return api
+}
+
+type stubBackend struct {
 	watchError error
+	getErr     error
+	migration  *stubMigration
 }
 
-func (b *fakeBackend) WatchForModelMigration() (state.NotifyWatcher, error) {
+func (b *stubBackend) WatchForModelMigration() (state.NotifyWatcher, error) {
 	if b.watchError != nil {
 		return nil, b.watchError
 	}
 	return apiservertesting.NewFakeNotifyWatcher(), nil
+}
+
+func (b *stubBackend) GetModelMigration() (state.ModelMigration, error) {
+	if b.getErr != nil {
+		return nil, b.getErr
+	}
+	return b.migration, nil
+}
+
+type stubMigration struct {
+	state.ModelMigration
+	setPhaseErr error
+	phaseSet    modelmigration.Phase
+}
+
+func (m *stubMigration) SetPhase(phase modelmigration.Phase) error {
+	if m.setPhaseErr != nil {
+		return m.setPhaseErr
+	}
+	m.phaseSet = phase
+	return nil
 }

--- a/apiserver/migrationmaster/state.go
+++ b/apiserver/migrationmaster/state.go
@@ -13,4 +13,5 @@ var getBackend = func(st *state.State) Backend {
 // migrationmaster facade.
 type Backend interface {
 	WatchForModelMigration() (state.NotifyWatcher, error)
+	GetModelMigration() (state.ModelMigration, error)
 }

--- a/apiserver/params/migrationmaster.go
+++ b/apiserver/params/migrationmaster.go
@@ -1,0 +1,10 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package params
+
+// SetMigrationPhaseArgs provides a migration phase to the
+// migrationmaster.SetPhase API method.
+type SetMigrationPhaseArgs struct {
+	Phase string `json:"phase"`
+}


### PR DESCRIPTION
This allows the migrationmaster worker to advance the model migration state.

(Review request: http://reviews.vapour.ws/r/4095/)