### PR TITLE
Use space name rather than provider id in error message

### DIFF
--- a/provider/maas/constraints.go
+++ b/provider/maas/constraints.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/utils/set"
 
 	"github.com/juju/juju/constraints"
+	"github.com/juju/juju/network"
 )
 
 var unsupportedConstraints = []string{
@@ -132,7 +133,7 @@ var numericLabelLimit uint = 0xffff
 func addInterfaces(
 	params url.Values,
 	bindings []interfaceBinding,
-	positiveSpaces, negativeSpaces []string,
+	positiveSpaces, negativeSpaces []network.SpaceInfo,
 ) error {
 	var (
 		index            uint
@@ -163,11 +164,11 @@ func addInterfaces(
 	}
 
 	for _, space := range positiveSpaces {
-		if spacesSet.Contains(space) {
+		if spacesSet.Contains(string(space.ProviderId)) {
 			// Skip duplicates in positiveSpaces.
 			continue
 		}
-		spacesSet.Add(space)
+		spacesSet.Add(string(space.ProviderId))
 		// Make sure we pick a label that doesn't clash with possible bindings.
 		var label string
 		for {
@@ -181,20 +182,20 @@ func addInterfaces(
 			index++
 		}
 		namesSet.Add(label)
-		item := fmt.Sprintf("%s:space=%s", label, space)
+		item := fmt.Sprintf("%s:space=%s", label, space.ProviderId)
 		combinedBindings = append(combinedBindings, item)
 		index++
 	}
 
 	var negatives []string
 	for _, space := range negativeSpaces {
-		if spacesSet.Contains(space) {
+		if spacesSet.Contains(string(space.ProviderId)) {
 			return errors.NewNotValid(nil, fmt.Sprintf(
 				"negative space %q from constraints clashes with interface bindings",
-				space,
+				space.Name,
 			))
 		}
-		negatives = append(negatives, fmt.Sprintf("space:%s", space))
+		negatives = append(negatives, fmt.Sprintf("space:%s", space.ProviderId))
 	}
 
 	if len(combinedBindings) > 0 {

--- a/provider/maas/constraints_test.go
+++ b/provider/maas/constraints_test.go
@@ -437,10 +437,8 @@ func (suite *environSuite) TestAcquireNodeInterfaces(c *gc.C) {
 		interfaces:    []interfaceBinding{{"", "anything"}},
 		expectedError: "interface bindings cannot have empty names",
 	}, {
-		interfaces: []interfaceBinding{{"shared-db", "6"}},
-		// TODO: (mfoord) we would really prefer to report "bar" rather
-		// than 6 here.
-		expectedError: `negative space "6" from constraints clashes with interface bindings`,
+		interfaces:    []interfaceBinding{{"shared-db", "6"}},
+		expectedError: `negative space "bar" from constraints clashes with interface bindings`,
 	}, {
 		interfaces: []interfaceBinding{
 			{"shared-db", "1"},


### PR DESCRIPTION
Pass SpaceInfo rather than just id to constraints code, for a better error message.

(Review request: http://reviews.vapour.ws/r/4096/)