### PR TITLE
lp1554044 remove juju init from basic help

### DIFF
--- a/cmd/juju/helptopics/basics.go
+++ b/cmd/juju/helptopics/basics.go
@@ -11,7 +11,6 @@ Juju provides easy, intelligent service orchestration on top of models
 such as Amazon EC2, HP Cloud, OpenStack, MaaS, or your own local machine.
 
 Basic commands:
-  juju init             generate boilerplate configuration for juju models
   juju bootstrap        start up a model from scratch
 
   juju deploy           deploy a new service

--- a/tools/lxdclient/client_instance.go
+++ b/tools/lxdclient/client_instance.go
@@ -328,7 +328,7 @@ func (client *instanceClient) Addresses(name string) ([]network.Address, error) 
 
 			addr := network.NewAddress(addr.Address)
 			if addr.Scope == network.ScopeLinkLocal || addr.Scope == network.ScopeMachineLocal {
-				logger.Tracef("for container %q ignoring address", name, addr)
+				logger.Tracef("for container %q ignoring address %q", name, addr)
 				continue
 			}
 			addrs = append(addrs, addr)


### PR DESCRIPTION
The 'juju init' command doesn't exist anymore, but
is still referenced in 'juju help'.

This PR removes that reference, but provider help
pages still refer to that command.  A more
comprehensive update is needed for provider help
pages.

Also includes a drive-by go vet fix.


(Review request: http://reviews.vapour.ws/r/4097/)