### PR TITLE
api/migrationmaster: Add SetPhase client API

### DIFF
--- a/api/migrationmaster/client.go
+++ b/api/migrationmaster/client.go
@@ -7,6 +7,7 @@ import (
 	"github.com/juju/juju/api/base"
 	apiwatcher "github.com/juju/juju/api/watcher"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/migration"
 	"github.com/juju/juju/watcher"
 )
 
@@ -16,6 +17,10 @@ type Client interface {
 	// Watch returns a watcher which reports when a migration is
 	// active for the model associated with the API connection.
 	Watch() (watcher.MigrationMasterWatcher, error)
+
+	// SetPhase updates the phase of the currently active model
+	// migration.
+	SetPhase(migration.Phase) error
 }
 
 // NewClient returns a new Client based on an existing API connection.
@@ -40,4 +45,12 @@ func (c *client) Watch() (watcher.MigrationMasterWatcher, error) {
 	}
 	w := apiwatcher.NewMigrationMasterWatcher(c.caller.RawAPICaller(), result.NotifyWatcherId)
 	return w, nil
+}
+
+// SetPhase implements Client.
+func (c *client) SetPhase(phase migration.Phase) error {
+	args := params.SetMigrationPhaseArgs{
+		Phase: phase.String(),
+	}
+	return c.caller.FacadeCall("SetPhase", args, nil)
 }

--- a/api/watcher/watcher.go
+++ b/api/watcher/watcher.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/apiserver/params"
-	"github.com/juju/juju/core/modelmigration"
+	"github.com/juju/juju/core/migration"
 	"github.com/juju/juju/watcher"
 )
 
@@ -449,7 +449,7 @@ func NewMigrationMasterWatcher(caller base.APICaller, watcherId string) watcher.
 	w := &migrationMasterWatcher{
 		caller: caller,
 		id:     watcherId,
-		out:    make(chan modelmigration.TargetInfo),
+		out:    make(chan migration.TargetInfo),
 	}
 	go func() {
 		defer w.tomb.Done()
@@ -462,7 +462,7 @@ type migrationMasterWatcher struct {
 	commonWatcher
 	caller base.APICaller
 	id     string
-	out    chan modelmigration.TargetInfo
+	out    chan migration.TargetInfo
 }
 
 func (w *migrationMasterWatcher) loop() error {
@@ -495,7 +495,7 @@ func (w *migrationMasterWatcher) loop() error {
 		if err != nil {
 			return errors.Annotatef(err, "unable to parse %q", info.AuthTag)
 		}
-		outInfo := modelmigration.TargetInfo{
+		outInfo := migration.TargetInfo{
 			ControllerTag: controllerTag,
 			Addrs:         info.Addrs,
 			CACert:        info.CACert,
@@ -512,6 +512,6 @@ func (w *migrationMasterWatcher) loop() error {
 
 // Changes returns a channel that reports the details of an active
 // migration for the model associated with the API connection.
-func (w *migrationMasterWatcher) Changes() <-chan modelmigration.TargetInfo {
+func (w *migrationMasterWatcher) Changes() <-chan migration.TargetInfo {
 	return w.out
 }

--- a/api/watcher/watcher_test.go
+++ b/api/watcher/watcher_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/juju/juju/api/migrationmaster"
 	"github.com/juju/juju/api/watcher"
 	"github.com/juju/juju/apiserver/params"
-	"github.com/juju/juju/core/modelmigration"
+	"github.com/juju/juju/core/migration"
 	"github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/storage"
@@ -303,7 +303,7 @@ func (s *migrationWatcherSuite) TestWatch(c *gc.C) {
 	}
 
 	// Now create a migration.
-	targetInfo := modelmigration.TargetInfo{
+	targetInfo := migration.TargetInfo{
 		ControllerTag: names.NewModelTag(utils.MustNewUUID().String()),
 		Addrs:         []string{"1.2.3.4:5"},
 		CACert:        "trust me I'm an authority",

--- a/apiserver/controller/controller.go
+++ b/apiserver/controller/controller.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
-	migration "github.com/juju/juju/core/modelmigration"
+	"github.com/juju/juju/core/migration"
 	"github.com/juju/juju/state"
 )
 

--- a/apiserver/migrationmaster/migrationmaster.go
+++ b/apiserver/migrationmaster/migrationmaster.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
-	"github.com/juju/juju/core/modelmigration"
+	"github.com/juju/juju/core/migration"
 	"github.com/juju/juju/state"
 )
 
@@ -56,14 +56,14 @@ func (api *API) Watch() (params.NotifyWatchResult, error) {
 
 // SetPhase sets the phase of the active model migration. The provided
 // phase must be a valid phase value, for example QUIESCE" or
-// "ABORT". See the core/modelmigration package for the complete list.
+// "ABORT". See the core/migration package for the complete list.
 func (api *API) SetPhase(args params.SetMigrationPhaseArgs) error {
 	mig, err := api.state.GetModelMigration()
 	if err != nil {
 		return errors.Annotate(err, "could not get migration")
 	}
 
-	phase, ok := modelmigration.ParsePhase(args.Phase)
+	phase, ok := migration.ParsePhase(args.Phase)
 	if !ok {
 		return errors.Errorf("invalid phase: %q", args.Phase)
 	}

--- a/apiserver/migrationmaster/migrationmaster_test.go
+++ b/apiserver/migrationmaster/migrationmaster_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/juju/juju/apiserver/migrationmaster"
 	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
-	"github.com/juju/juju/core/modelmigration"
+	"github.com/juju/juju/core/migration"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/testing"
 )
@@ -77,7 +77,7 @@ func (s *Suite) TestSetPhase(c *gc.C) {
 	err := api.SetPhase(params.SetMigrationPhaseArgs{Phase: "ABORT"})
 	c.Assert(err, jc.ErrorIsNil)
 
-	c.Assert(s.backend.migration.phaseSet, gc.Equals, modelmigration.ABORT)
+	c.Assert(s.backend.migration.phaseSet, gc.Equals, migration.ABORT)
 }
 
 func (s *Suite) TestSetPhaseNoMigration(c *gc.C) {
@@ -136,10 +136,10 @@ func (b *stubBackend) GetModelMigration() (state.ModelMigration, error) {
 type stubMigration struct {
 	state.ModelMigration
 	setPhaseErr error
-	phaseSet    modelmigration.Phase
+	phaseSet    migration.Phase
 }
 
-func (m *stubMigration) SetPhase(phase modelmigration.Phase) error {
+func (m *stubMigration) SetPhase(phase migration.Phase) error {
 	if m.setPhaseErr != nil {
 		return m.setPhaseErr
 	}

--- a/apiserver/watcher_test.go
+++ b/apiserver/watcher_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
-	migration "github.com/juju/juju/core/modelmigration"
+	"github.com/juju/juju/core/migration"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/testing"
 )

--- a/core/migration/package_test.go
+++ b/core/migration/package_test.go
@@ -1,7 +1,7 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package modelmigration_test
+package migration_test
 
 import (
 	"testing"

--- a/core/migration/phase.go
+++ b/core/migration/phase.go
@@ -1,7 +1,7 @@
 // Copyright 2016 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package modelmigration
+package migration
 
 // Phase values specify model migration phases.
 type Phase int

--- a/core/migration/phase_internal_test.go
+++ b/core/migration/phase_internal_test.go
@@ -1,7 +1,7 @@
 // Copyright 2016 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package modelmigration
+package migration
 
 import (
 	"github.com/juju/utils/set"

--- a/core/migration/phase_test.go
+++ b/core/migration/phase_test.go
@@ -1,13 +1,13 @@
 // Copyright 2016 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package modelmigration_test
+package migration_test
 
 import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	migration "github.com/juju/juju/core/modelmigration"
+	"github.com/juju/juju/core/migration"
 	coretesting "github.com/juju/juju/testing"
 )
 

--- a/core/migration/targetinfo.go
+++ b/core/migration/targetinfo.go
@@ -1,7 +1,7 @@
 // Copyright 2016 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package modelmigration
+package migration
 
 import (
 	"github.com/juju/errors"

--- a/core/migration/targetinfo_test.go
+++ b/core/migration/targetinfo_test.go
@@ -1,7 +1,7 @@
 // Copyright 2016 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package modelmigration_test
+package migration_test
 
 import (
 	"github.com/juju/errors"
@@ -10,7 +10,7 @@ import (
 	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
 
-	migration "github.com/juju/juju/core/modelmigration"
+	"github.com/juju/juju/core/migration"
 	coretesting "github.com/juju/juju/testing"
 )
 

--- a/state/modelmigration.go
+++ b/state/modelmigration.go
@@ -13,7 +13,7 @@ import (
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
 
-	migration "github.com/juju/juju/core/modelmigration"
+	"github.com/juju/juju/core/migration"
 )
 
 // This file contains functionality for managing the state documents

--- a/state/modelmigration_test.go
+++ b/state/modelmigration_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/juju/utils/clock"
 	gc "gopkg.in/check.v1"
 
-	migration "github.com/juju/juju/core/modelmigration"
+	"github.com/juju/juju/core/migration"
 	"github.com/juju/juju/state"
 	statetesting "github.com/juju/juju/state/testing"
 	coretesting "github.com/juju/juju/testing"

--- a/watcher/migrationmaster.go
+++ b/watcher/migrationmaster.go
@@ -3,11 +3,11 @@
 
 package watcher
 
-import "github.com/juju/juju/core/modelmigration"
+import "github.com/juju/juju/core/migration"
 
 // MigrationMasterWatcher describes a watcher that reports the target
 // controller details for an active model migration.
 type MigrationMasterWatcher interface {
 	CoreWatcher
-	Changes() <-chan modelmigration.TargetInfo
+	Changes() <-chan migration.TargetInfo
 }

--- a/worker/migrationmaster/worker.go
+++ b/worker/migrationmaster/worker.go
@@ -8,7 +8,7 @@ import (
 	"launchpad.net/tomb"
 
 	masterapi "github.com/juju/juju/api/migrationmaster"
-	"github.com/juju/juju/core/modelmigration"
+	"github.com/juju/juju/core/migration"
 	"github.com/juju/juju/worker"
 )
 
@@ -49,7 +49,7 @@ func (w *migrationMaster) run() error {
 	return errors.New("migration seen")
 }
 
-func (w *migrationMaster) waitForMigration() (*modelmigration.TargetInfo, error) {
+func (w *migrationMaster) waitForMigration() (*migration.TargetInfo, error) {
 	watcher, err := w.client.Watch()
 	if err != nil {
 		return nil, errors.Annotate(err, "watching for migration")

--- a/worker/migrationmaster/worker_test.go
+++ b/worker/migrationmaster/worker_test.go
@@ -12,7 +12,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	masterapi "github.com/juju/juju/api/migrationmaster"
-	"github.com/juju/juju/core/modelmigration"
+	"github.com/juju/juju/core/migration"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/watcher"
 	"github.com/juju/juju/worker/migrationmaster"
@@ -52,7 +52,7 @@ func (s *Suite) TestWatchesForMigration(c *gc.C) {
 	}
 
 	// Trigger migration.
-	client.watcher.changes <- modelmigration.TargetInfo{}
+	client.watcher.changes <- migration.TargetInfo{}
 
 	// Worker should exit for now (TEMPORARY)
 	select {
@@ -105,13 +105,13 @@ func (c *mockClient) Watch() (watcher.MigrationMasterWatcher, error) {
 
 func newMockWatcher() *mockWatcher {
 	return &mockWatcher{
-		changes: make(chan modelmigration.TargetInfo, 1),
+		changes: make(chan migration.TargetInfo, 1),
 	}
 }
 
 type mockWatcher struct {
 	tomb    tomb.Tomb
-	changes chan modelmigration.TargetInfo
+	changes chan migration.TargetInfo
 }
 
 func (w *mockWatcher) Kill() {
@@ -123,6 +123,6 @@ func (w *mockWatcher) Wait() error {
 	return w.tomb.Wait()
 }
 
-func (w *mockWatcher) Changes() <-chan modelmigration.TargetInfo {
+func (w *mockWatcher) Changes() <-chan migration.TargetInfo {
 	return w.changes
 }


### PR DESCRIPTION
The client side of the API to allow the migrationmaster worker to set the active model migration's phase

(Review request: http://reviews.vapour.ws/r/4108/)