### PR TITLE
apiserver: remove dependency on resource/api

### DIFF
--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
-	resourceapi "github.com/juju/juju/resource/api"
 	"github.com/juju/juju/rpc"
 	"github.com/juju/juju/rpc/jsoncodec"
 	"github.com/juju/juju/state"
@@ -383,7 +382,7 @@ func (srv *Server) run() {
 	logSinkHandler := srv.trackRequests(newLogSinkHandler(httpCtxt, srv.logDir))
 	debugLogHandler := srv.trackRequests(newDebugLogDBHandler(httpCtxt))
 
-	handleAll(mux, "/model/:modeluuid"+resourceapi.HTTPEndpointPattern,
+	handleAll(mux, "/model/:modeluuid/services/:service/resources/:resource",
 		newResourceHandler(httpCtxt),
 	)
 	handleAll(mux, "/model/:modeluuid/units/:unit/resources/:resource",

--- a/resource/api/http.go
+++ b/resource/api/http.go
@@ -21,12 +21,6 @@ import (
 var logger = loggo.GetLogger("juju.resource.api")
 
 const (
-	// HTTPEndpointPattern is the URL path pattern registered with
-	// the API server. This includes wildcards (starting with ":") that
-	// are converted into URL query values by the pattern mux. Also see
-	// apiserver/apiserver.go.
-	HTTPEndpointPattern = "/services/:service/resources/:resource"
-
 	// HTTPEndpointPath is the URL path, with substitutions, for
 	// a resource request.
 	HTTPEndpointPath = "/services/%s/resources/%s"


### PR DESCRIPTION
The apiserver was importing resource/api to get one constant to
construct a URL path. This made the apiserver depend on all the code
that the resource/api package depends on, and flirted with an import
loop.

Given that the line directly below the one affected by this change does
the same thing, but without a constant in another package, it seems
simpler to remove the dependency and just write the literal string in
the one place it is used, and has test coverage.

(Review request: http://reviews.vapour.ws/r/4112/)