### PR TITLE
worker/migrationmaster: Finalise skeleton worker

### DIFF
--- a/worker/migrationmaster/export_test.go
+++ b/worker/migrationmaster/export_test.go
@@ -1,0 +1,6 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package migrationmaster
+
+var ApiOpen = &apiOpen

--- a/worker/migrationmaster/worker.go
+++ b/worker/migrationmaster/worker.go
@@ -45,8 +45,15 @@ func (w *migrationMaster) run() error {
 	if err != nil {
 		return errors.Trace(err)
 	}
+
+	// For now just abort the migration (this is a work in progress)
+	err = w.client.SetPhase(migration.ABORT)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
 	var _ = targetInfo
-	return errors.New("migration seen")
+	return errors.New("migration seen and aborted")
 }
 
 func (w *migrationMaster) waitForMigration() (*migration.TargetInfo, error) {

--- a/worker/migrationmaster/worker.go
+++ b/worker/migrationmaster/worker.go
@@ -7,10 +7,13 @@ import (
 	"github.com/juju/errors"
 	"launchpad.net/tomb"
 
+	"github.com/juju/juju/api"
 	masterapi "github.com/juju/juju/api/migrationmaster"
 	"github.com/juju/juju/core/migration"
 	"github.com/juju/juju/worker"
 )
+
+var apiOpen = api.Open
 
 // New starts a migration master worker using the supplied migration
 // master API facade.
@@ -46,13 +49,18 @@ func (w *migrationMaster) run() error {
 		return errors.Trace(err)
 	}
 
+	conn, err := openAPIConn(targetInfo)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	conn.Close()
+
 	// For now just abort the migration (this is a work in progress)
 	err = w.client.SetPhase(migration.ABORT)
 	if err != nil {
 		return errors.Trace(err)
 	}
 
-	var _ = targetInfo
 	return errors.New("migration seen and aborted")
 }
 
@@ -69,4 +77,14 @@ func (w *migrationMaster) waitForMigration() (*migration.TargetInfo, error) {
 	case info := <-watcher.Changes():
 		return &info, nil
 	}
+}
+
+func openAPIConn(targetInfo *migration.TargetInfo) (api.Connection, error) {
+	apiInfo := &api.Info{
+		Addrs:    targetInfo.Addrs,
+		CACert:   targetInfo.CACert,
+		Tag:      targetInfo.AuthTag,
+		Password: targetInfo.Password,
+	}
+	return apiOpen(apiInfo, api.DefaultDialOpts())
 }

--- a/worker/migrationmaster/worker_test.go
+++ b/worker/migrationmaster/worker_test.go
@@ -7,10 +7,12 @@ import (
 	"errors"
 	"time"
 
+	"github.com/juju/names"
+	jujutesting "github.com/juju/testing"
+	gc "gopkg.in/check.v1"
 	"launchpad.net/tomb"
 
-	gc "gopkg.in/check.v1"
-
+	"github.com/juju/juju/api"
 	masterapi "github.com/juju/juju/api/migrationmaster"
 	"github.com/juju/juju/core/migration"
 	coretesting "github.com/juju/juju/testing"
@@ -20,15 +22,26 @@ import (
 
 type Suite struct {
 	coretesting.BaseSuite
+	stub       *jujutesting.Stub
+	connection stubConnection
 }
 
 var _ = gc.Suite(&Suite{})
 
 func (s *Suite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
+
+	s.stub = new(jujutesting.Stub)
+	s.connection.stub = s.stub
+	s.PatchValue(migrationmaster.ApiOpen, s.apiOpen)
 }
 
-func (s *Suite) TestWatchesForMigration(c *gc.C) {
+func (s *Suite) apiOpen(info *api.Info, dialOpts api.DialOpts) (api.Connection, error) {
+	s.stub.AddCall("apiOpen", info, dialOpts)
+	return &s.connection, nil
+}
+
+func (s *Suite) TestMigrationHandling(c *gc.C) {
 	client := newMockClient()
 	w := migrationmaster.New(client)
 
@@ -52,7 +65,13 @@ func (s *Suite) TestWatchesForMigration(c *gc.C) {
 	}
 
 	// Trigger migration.
-	client.watcher.changes <- migration.TargetInfo{}
+	client.watcher.changes <- migration.TargetInfo{
+		ControllerTag: names.NewModelTag("uuid"),
+		Addrs:         []string{"1.2.3.4:5"},
+		CACert:        "cert",
+		AuthTag:       names.NewUserTag("admin"),
+		Password:      "secret",
+	}
 
 	// Worker should exit for now (TEMPORARY)
 	select {
@@ -61,6 +80,18 @@ func (s *Suite) TestWatchesForMigration(c *gc.C) {
 	case <-time.After(coretesting.LongWait):
 		c.Fatal("timed out waiting for worker to stop")
 	}
+
+	// API connection should have been established and closed.
+	expectedApiInfo := &api.Info{
+		Addrs:    []string{"1.2.3.4:5"},
+		CACert:   "cert",
+		Tag:      names.NewUserTag("admin"),
+		Password: "secret",
+	}
+	s.stub.CheckCalls(c, []jujutesting.StubCall{
+		{"apiOpen", []interface{}{expectedApiInfo, api.DefaultDialOpts()}},
+		{"Connection.Close", []interface{}{}},
+	})
 
 	// The migration should have been aborted.
 	c.Assert(client.phaseSet, gc.Equals, migration.ABORT)
@@ -134,4 +165,14 @@ func (w *mockWatcher) Wait() error {
 
 func (w *mockWatcher) Changes() <-chan migration.TargetInfo {
 	return w.changes
+}
+
+type stubConnection struct {
+	api.Connection
+	stub *jujutesting.Stub
+}
+
+func (c *stubConnection) Close() error {
+	c.stub.AddCall("Connection.Close")
+	return nil
 }


### PR DESCRIPTION
Migrations are now aborted when seen and an API connection to the target controller is opened and closed.

(Review request: http://reviews.vapour.ws/r/4113/)