### PR TITLE
Maas bootstrap improvement

### DIFF
--- a/cloud/clouds.go
+++ b/cloud/clouds.go
@@ -123,7 +123,7 @@ type region struct {
 }
 
 // BuiltInProviderNames work out of the box.
-var BuiltInProviderNames = []string{"lxd", "manual"}
+var BuiltInProviderNames = []string{"lxd", "manual", "maas"}
 
 // CloudByName returns the cloud with the specified name.
 // If there exists no cloud with the specified name, an

--- a/provider/maas/environprovider.go
+++ b/provider/maas/environprovider.go
@@ -4,6 +4,7 @@
 package maas
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/juju/errors"
@@ -11,7 +12,6 @@ import (
 	"github.com/juju/loggo"
 	"github.com/juju/utils"
 
-	"fmt"
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"

--- a/provider/maas/environprovider.go
+++ b/provider/maas/environprovider.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/loggo"
 	"github.com/juju/utils"
 
+	"fmt"
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
@@ -60,9 +61,20 @@ func (p maasEnvironProvider) PrepareForCreateEnvironment(cfg *config.Config) (*c
 }
 
 func (p maasEnvironProvider) PrepareForBootstrap(ctx environs.BootstrapContext, args environs.PrepareForBootstrapParams) (environs.Environ, error) {
-	// For MAAS, the endpoint from the cloud definition defines the MAAS server.
+	// For MAAS, either:
+	// 1. the endpoint from the cloud definition defines the MAAS server URL
+	//    (if a full cloud definition had been set up)
+	// 2. the region defines the MAAS server ip/host
+	//    (if the bootstrap shortcut is used)
+	server := args.CloudEndpoint
+	if server == "" && args.CloudRegion != "" {
+		server = fmt.Sprintf("http://%s/MAAS", args.CloudRegion)
+	}
+	if server == "" {
+		return nil, errors.New("MAAS server not specified")
+	}
 	attrs := map[string]interface{}{
-		"maas-server": args.CloudEndpoint,
+		"maas-server": server,
 	}
 	// Add the credentials.
 	switch authType := args.Credentials.AuthType(); authType {
@@ -116,4 +128,9 @@ func (prov maasEnvironProvider) SecretAttrs(cfg *config.Config) (map[string]stri
 	}
 	secretAttrs["maas-oauth"] = maasCfg.maasOAuth()
 	return secretAttrs, nil
+}
+
+// DetectRegions is specified in the environs.CloudRegionDetector interface.
+func (p maasEnvironProvider) DetectRegions() ([]cloud.Region, error) {
+	return nil, errors.NotFoundf("regions")
 }


### PR DESCRIPTION
MAAS becomes a built-in provider, so it's possible to do:

$ juju bootstrap maas/<server-ip>

You can still create a cloud.yaml entry if needed.

(Review request: http://reviews.vapour.ws/r/4115/)