### PR TITLE
resource/api/server: move UnitResourceHandler to public api/server package

### DIFF
--- a/apiserver/resource.go
+++ b/apiserver/resource.go
@@ -11,7 +11,6 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/names"
 
-	internalserver "github.com/juju/juju/resource/api/private/server"
 	"github.com/juju/juju/resource/api/server"
 	"github.com/juju/juju/resource/resourceadapters"
 	"github.com/juju/juju/state"
@@ -68,6 +67,6 @@ func newUnitResourceHandler(httpCtxt httpContext) http.Handler {
 	extractor := resourceadapters.HTTPDownloadRequestExtractor{
 		Connector: &resourcesHandlerDeps{httpCtxt},
 	}
-	deps := internalserver.NewLegacyHTTPHandlerDeps(extractor)
-	return internalserver.NewLegacyHTTPHandler(deps)
+	deps := server.NewUnitResourceHandlerDeps(extractor)
+	return server.NewUnitResourceHandler(deps)
 }

--- a/apiserver/resource.go
+++ b/apiserver/resource.go
@@ -45,7 +45,7 @@ func (deps resourcesHandlerDeps) ConnectForUnitAgent(req *http.Request) (*state.
 
 func newResourceHandler(httpCtxt httpContext) http.Handler {
 	deps := resourcesHandlerDeps{httpCtxt}
-	return server.NewLegacyHTTPHandler(
+	return server.NewResourceHandler(
 		func(req *http.Request) (server.DataStore, names.Tag, error) {
 			st, entity, err := deps.ConnectForUser(req)
 			if err != nil {

--- a/resource/api/server/handler.go
+++ b/resource/api/server/handler.go
@@ -15,10 +15,10 @@ import (
 // TODO(ericsnow) Define the HTTPHandlerConstraints here? Perhaps
 // even the HTTPHandlerSpec?
 
-// LegacyHTTPHandler is the HTTP handler for the resources endpoint. We
+// ResourceHandler is the HTTP handler for the resources endpoint. We
 // use it rather having a separate handler for each HTTP method since
 // registered API handlers must handle *all* HTTP methods currently.
-type LegacyHTTPHandler struct {
+type ResourceHandler struct {
 	// Connect opens a connection to state resources.
 	Connect func(*http.Request) (DataStore, names.Tag, error)
 
@@ -28,9 +28,9 @@ type LegacyHTTPHandler struct {
 
 // TODO(ericsnow) Can username be extracted from the request?
 
-// NewLegacyHTTPHandler creates a new http.Handler for the resources endpoint.
-func NewLegacyHTTPHandler(connect func(*http.Request) (DataStore, names.Tag, error)) *LegacyHTTPHandler {
-	return &LegacyHTTPHandler{
+// NewResourceHandler creates a new http.Handler for the resources endpoint.
+func NewResourceHandler(connect func(*http.Request) (DataStore, names.Tag, error)) *ResourceHandler {
+	return &ResourceHandler{
 		Connect: connect,
 		HandleUpload: func(username string, st DataStore, req *http.Request) (*api.UploadResult, error) {
 			uh := UploadHandler{
@@ -43,7 +43,7 @@ func NewLegacyHTTPHandler(connect func(*http.Request) (DataStore, names.Tag, err
 }
 
 // ServeHTTP implements http.Handler.
-func (h *LegacyHTTPHandler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
+func (h *ResourceHandler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 	st, tag, err := h.Connect(req)
 	if err != nil {
 		api.SendHTTPError(resp, err)

--- a/resource/api/server/handler_test.go
+++ b/resource/api/server/handler_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/juju/juju/resource/api/server"
 )
 
-type LegacyHTTPHandlerSuite struct {
+type ResourceHandlerSuite struct {
 	BaseSuite
 
 	username string
@@ -31,9 +31,9 @@ type LegacyHTTPHandlerSuite struct {
 	result   *api.UploadResult
 }
 
-var _ = gc.Suite(&LegacyHTTPHandlerSuite{})
+var _ = gc.Suite(&ResourceHandlerSuite{})
 
-func (s *LegacyHTTPHandlerSuite) SetUpTest(c *gc.C) {
+func (s *ResourceHandlerSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 
 	method := "..."
@@ -51,7 +51,7 @@ func (s *LegacyHTTPHandlerSuite) SetUpTest(c *gc.C) {
 	s.result = &api.UploadResult{}
 }
 
-func (s *LegacyHTTPHandlerSuite) connect(req *http.Request) (server.DataStore, names.Tag, error) {
+func (s *ResourceHandlerSuite) connect(req *http.Request) (server.DataStore, names.Tag, error) {
 	s.stub.AddCall("Connect", req)
 	if err := s.stub.NextErr(); err != nil {
 		return nil, nil, errors.Trace(err)
@@ -61,7 +61,7 @@ func (s *LegacyHTTPHandlerSuite) connect(req *http.Request) (server.DataStore, n
 	return s.data, tag, nil
 }
 
-func (s *LegacyHTTPHandlerSuite) handleUpload(username string, st server.DataStore, req *http.Request) (*api.UploadResult, error) {
+func (s *ResourceHandlerSuite) handleUpload(username string, st server.DataStore, req *http.Request) (*api.UploadResult, error) {
 	s.stub.AddCall("HandleUpload", username, st, req)
 	if err := s.stub.NextErr(); err != nil {
 		return nil, errors.Trace(err)
@@ -70,9 +70,9 @@ func (s *LegacyHTTPHandlerSuite) handleUpload(username string, st server.DataSto
 	return s.result, nil
 }
 
-func (s *LegacyHTTPHandlerSuite) TestServeHTTPConnectFailure(c *gc.C) {
+func (s *ResourceHandlerSuite) TestServeHTTPConnectFailure(c *gc.C) {
 	s.username = "youknowwho"
-	handler := server.LegacyHTTPHandler{
+	handler := server.ResourceHandler{
 		Connect:      s.connect,
 		HandleUpload: s.handleUpload,
 	}
@@ -100,9 +100,9 @@ func (s *LegacyHTTPHandlerSuite) TestServeHTTPConnectFailure(c *gc.C) {
 	})
 }
 
-func (s *LegacyHTTPHandlerSuite) TestServeHTTPUnsupportedMethod(c *gc.C) {
+func (s *ResourceHandlerSuite) TestServeHTTPUnsupportedMethod(c *gc.C) {
 	s.username = "youknowwho"
-	handler := server.LegacyHTTPHandler{
+	handler := server.ResourceHandler{
 		Connect:      s.connect,
 		HandleUpload: s.handleUpload,
 	}
@@ -130,12 +130,12 @@ func (s *LegacyHTTPHandlerSuite) TestServeHTTPUnsupportedMethod(c *gc.C) {
 	})
 }
 
-func (s *LegacyHTTPHandlerSuite) TestServeHTTPPutSuccess(c *gc.C) {
+func (s *ResourceHandlerSuite) TestServeHTTPPutSuccess(c *gc.C) {
 	s.result.Resource.Name = "spam"
 	expected, err := json.Marshal(s.result)
 	c.Assert(err, jc.ErrorIsNil)
 	s.username = "youknowwho"
-	handler := server.LegacyHTTPHandler{
+	handler := server.ResourceHandler{
 		Connect:      s.connect,
 		HandleUpload: s.handleUpload,
 	}
@@ -164,9 +164,9 @@ func (s *LegacyHTTPHandlerSuite) TestServeHTTPPutSuccess(c *gc.C) {
 	})
 }
 
-func (s *LegacyHTTPHandlerSuite) TestServeHTTPPutHandleUploadFailure(c *gc.C) {
+func (s *ResourceHandlerSuite) TestServeHTTPPutHandleUploadFailure(c *gc.C) {
 	s.username = "youknowwho"
-	handler := server.LegacyHTTPHandler{
+	handler := server.ResourceHandler{
 		Connect:      s.connect,
 		HandleUpload: s.handleUpload,
 	}

--- a/resource/api/server/unithandler.go
+++ b/resource/api/server/unithandler.go
@@ -18,23 +18,23 @@ import (
 // TODO(ericsnow) Define the HTTPHandlerConstraints here? Perhaps
 // even the HTTPHandlerSpec?
 
-// LegacyHTTPHandler is the HTTP handler for the resources
+// UnitResourceHandler is the HTTP handler for the resources
 // endpoint. We use it rather having a separate handler for each HTTP
 // method since registered API handlers must handle *all* HTTP methods
 // currently.
-type LegacyHTTPHandler struct {
-	LegacyHTTPHandlerDeps
+type UnitResourceHandler struct {
+	UnitResourceHandlerDeps
 }
 
-// NewLegacyHTTPHandler creates a new http.Handler for the resources endpoint.
-func NewLegacyHTTPHandler(deps LegacyHTTPHandlerDeps) *LegacyHTTPHandler {
-	return &LegacyHTTPHandler{
-		LegacyHTTPHandlerDeps: deps,
+// NewUnitResourceHandler creates a new http.Handler for the resources endpoint.
+func NewUnitResourceHandler(deps UnitResourceHandlerDeps) *UnitResourceHandler {
+	return &UnitResourceHandler{
+		UnitResourceHandlerDeps: deps,
 	}
 }
 
 // ServeHTTP implements http.Handler.
-func (h *LegacyHTTPHandler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
+func (h *UnitResourceHandler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 	opener, err := h.NewResourceOpener(req)
 	if err != nil {
 		h.SendHTTPError(resp, err)
@@ -71,20 +71,20 @@ func (h *LegacyHTTPHandler) ServeHTTP(resp http.ResponseWriter, req *http.Reques
 	}
 }
 
-// LegacyHTTPHandlerDeps exposes the external dependencies
-// of LegacyHTTPHandler.
-type LegacyHTTPHandlerDeps interface {
-	baseLegacyHTTPHandlerDeps
+// UnitResourceHandlerDeps exposes the external dependencies
+// of UnitResourceHandler.
+type UnitResourceHandlerDeps interface {
+	baseUnitResourceHandlerDeps
 	ExtraDeps
 }
 
-//ExtraDeps exposes the non-superficial dependencies of LegacyHTTPHandler.
+//ExtraDeps exposes the non-superficial dependencies of UnitResourceHandler.
 type ExtraDeps interface {
 	// NewResourceOpener returns a new opener for the request.
 	NewResourceOpener(*http.Request) (resource.Opener, error)
 }
 
-type baseLegacyHTTPHandlerDeps interface {
+type baseUnitResourceHandlerDeps interface {
 	// UpdateDownloadResponse updates the HTTP response with the info
 	// from the resource.
 	UpdateDownloadResponse(http.ResponseWriter, resource.Resource)
@@ -99,36 +99,36 @@ type baseLegacyHTTPHandlerDeps interface {
 	Copy(io.Writer, io.Reader) error
 }
 
-// NewLegacyHTTPHandlerDeps returns an implementation of LegacyHTTPHandlerDeps.
-func NewLegacyHTTPHandlerDeps(extraDeps ExtraDeps) LegacyHTTPHandlerDeps {
-	return &legacyHTTPHandlerDeps{
+// NewUnitResourceHandlerDeps returns an implementation of UnitResourceHandlerDeps.
+func NewUnitResourceHandlerDeps(extraDeps ExtraDeps) UnitResourceHandlerDeps {
+	return &unitResourceHandlerDeps{
 		ExtraDeps: extraDeps,
 	}
 }
 
-// legacyHTTPHandlerDeps is a partial implementation of LegacyHandlerDeps.
-type legacyHTTPHandlerDeps struct {
+// unitResourceHandlerDeps is a partial implementation of LegacyHandlerDeps.
+type unitResourceHandlerDeps struct {
 	ExtraDeps
 }
 
-// SendHTTPError implements LegacyHTTPHandlerDeps.
-func (deps legacyHTTPHandlerDeps) SendHTTPError(resp http.ResponseWriter, err error) {
+// SendHTTPError implements UnitResourceHandlerDeps.
+func (deps unitResourceHandlerDeps) SendHTTPError(resp http.ResponseWriter, err error) {
 	api.SendHTTPError(resp, err)
 }
 
-// UpdateDownloadResponse implements LegacyHTTPHandlerDeps.
-func (deps legacyHTTPHandlerDeps) UpdateDownloadResponse(resp http.ResponseWriter, info resource.Resource) {
+// UpdateDownloadResponse implements UnitResourceHandlerDeps.
+func (deps unitResourceHandlerDeps) UpdateDownloadResponse(resp http.ResponseWriter, info resource.Resource) {
 	api.UpdateDownloadResponse(resp, info)
 }
 
-// HandleDownload implements LegacyHTTPHandlerDeps.
-func (deps legacyHTTPHandlerDeps) HandleDownload(opener resource.Opener, req *http.Request) (resource.Opened, error) {
+// HandleDownload implements UnitResourceHandlerDeps.
+func (deps unitResourceHandlerDeps) HandleDownload(opener resource.Opener, req *http.Request) (resource.Opened, error) {
 	name := api.ExtractDownloadRequest(req)
 	return opener.OpenResource(name)
 }
 
-// Copy implements LegacyHTTPHandlerDeps.
-func (deps legacyHTTPHandlerDeps) Copy(w io.Writer, r io.Reader) error {
+// Copy implements UnitResourceHandlerDeps.
+func (deps unitResourceHandlerDeps) Copy(w io.Writer, r io.Reader) error {
 	_, err := io.Copy(w, r)
 	return err
 }

--- a/resource/api/server/unithandler_test.go
+++ b/resource/api/server/unithandler_test.go
@@ -18,36 +18,36 @@ import (
 
 	"github.com/juju/juju/resource"
 	"github.com/juju/juju/resource/api"
-	"github.com/juju/juju/resource/api/private/server"
+	"github.com/juju/juju/resource/api/server"
 	"github.com/juju/juju/resource/resourcetesting"
 )
 
-var _ = gc.Suite(&LegacyHTTPHandlerSuite{})
+var _ = gc.Suite(&UnitResourceHandlerSuite{})
 
-type LegacyHTTPHandlerSuite struct {
+type UnitResourceHandlerSuite struct {
 	testing.IsolationSuite
 
 	stub   *testing.Stub
 	opener *stubResourceOpener
-	deps   *stubLegacyHTTPHandlerDeps
+	deps   *stubUnitResourceHandlerDeps
 	resp   *stubResponseWriter
 }
 
-func (s *LegacyHTTPHandlerSuite) SetUpTest(c *gc.C) {
+func (s *UnitResourceHandlerSuite) SetUpTest(c *gc.C) {
 	s.IsolationSuite.SetUpTest(c)
 
 	s.stub = &testing.Stub{}
 	s.opener = &stubResourceOpener{Stub: s.stub}
-	s.deps = &stubLegacyHTTPHandlerDeps{Stub: s.stub}
+	s.deps = &stubUnitResourceHandlerDeps{Stub: s.stub}
 	s.resp = newStubResponseWriter(s.stub)
 }
 
-func (s *LegacyHTTPHandlerSuite) TestIntegration(c *gc.C) {
+func (s *UnitResourceHandlerSuite) TestIntegration(c *gc.C) {
 	opened := resourcetesting.NewResource(c, s.stub, "spam", "a-service", "some data")
 	s.opener.ReturnOpenResource = opened
 	s.deps.ReturnNewResourceOpener = s.opener
-	deps := server.NewLegacyHTTPHandlerDeps(s.deps)
-	h := server.NewLegacyHTTPHandler(deps)
+	deps := server.NewUnitResourceHandlerDeps(s.deps)
+	h := server.NewUnitResourceHandler(deps)
 	req, err := api.NewHTTPDownloadRequest("spam")
 	c.Assert(err, jc.ErrorIsNil)
 	req.URL, err = url.ParseRequestURI("https://api:17018/units/eggs/1/resources/spam?:resource=spam")
@@ -66,19 +66,19 @@ func (s *LegacyHTTPHandlerSuite) TestIntegration(c *gc.C) {
 	})
 }
 
-func (s *LegacyHTTPHandlerSuite) TestNewLegacyHTTPHandler(c *gc.C) {
-	h := server.NewLegacyHTTPHandler(s.deps)
+func (s *UnitResourceHandlerSuite) TestNewUnitResourceHandler(c *gc.C) {
+	h := server.NewUnitResourceHandler(s.deps)
 
 	s.stub.CheckNoCalls(c)
 	c.Check(h, gc.NotNil)
 }
 
-func (s *LegacyHTTPHandlerSuite) TestServeHTTPDownloadOkay(c *gc.C) {
+func (s *UnitResourceHandlerSuite) TestServeHTTPDownloadOkay(c *gc.C) {
 	s.deps.ReturnNewResourceOpener = s.opener
 	opened := resourcetesting.NewResource(c, s.stub, "spam", "a-service", "some data")
 	s.deps.ReturnHandleDownload = opened
-	h := &server.LegacyHTTPHandler{
-		LegacyHTTPHandlerDeps: s.deps,
+	h := &server.UnitResourceHandler{
+		UnitResourceHandlerDeps: s.deps,
 	}
 	req, err := http.NewRequest("GET", "...", nil)
 	c.Assert(err, jc.ErrorIsNil)
@@ -100,9 +100,9 @@ func (s *LegacyHTTPHandlerSuite) TestServeHTTPDownloadOkay(c *gc.C) {
 	s.stub.CheckCall(c, 4, "Copy", s.resp, opened)
 }
 
-func (s *LegacyHTTPHandlerSuite) TestServeHTTPDownloadHandlerFailed(c *gc.C) {
-	h := &server.LegacyHTTPHandler{
-		LegacyHTTPHandlerDeps: s.deps,
+func (s *UnitResourceHandlerSuite) TestServeHTTPDownloadHandlerFailed(c *gc.C) {
+	h := &server.UnitResourceHandler{
+		UnitResourceHandlerDeps: s.deps,
 	}
 	failure := errors.New("<failure>")
 	s.stub.SetErrors(nil, failure)
@@ -119,10 +119,10 @@ func (s *LegacyHTTPHandlerSuite) TestServeHTTPDownloadHandlerFailed(c *gc.C) {
 	s.stub.CheckCall(c, 2, "SendHTTPError", s.resp, failure)
 }
 
-func (s *LegacyHTTPHandlerSuite) TestServeHTTPDownloadCopyFailed(c *gc.C) {
+func (s *UnitResourceHandlerSuite) TestServeHTTPDownloadCopyFailed(c *gc.C) {
 	s.deps.ReturnHandleDownload = resourcetesting.NewResource(c, s.stub, "spam", "a-service", "some data")
-	h := &server.LegacyHTTPHandler{
-		LegacyHTTPHandlerDeps: s.deps,
+	h := &server.UnitResourceHandler{
+		UnitResourceHandlerDeps: s.deps,
 	}
 	failure := errors.New("<failure>")
 	s.stub.SetErrors(nil, nil, failure)
@@ -141,9 +141,9 @@ func (s *LegacyHTTPHandlerSuite) TestServeHTTPDownloadCopyFailed(c *gc.C) {
 	)
 }
 
-func (s *LegacyHTTPHandlerSuite) TestServeHTTPConnectFailed(c *gc.C) {
-	h := &server.LegacyHTTPHandler{
-		LegacyHTTPHandlerDeps: s.deps,
+func (s *UnitResourceHandlerSuite) TestServeHTTPConnectFailed(c *gc.C) {
+	h := &server.UnitResourceHandler{
+		UnitResourceHandlerDeps: s.deps,
 	}
 	failure := errors.New("<failure>")
 	s.stub.SetErrors(failure)
@@ -159,9 +159,9 @@ func (s *LegacyHTTPHandlerSuite) TestServeHTTPConnectFailed(c *gc.C) {
 	s.stub.CheckCall(c, 1, "SendHTTPError", s.resp, failure)
 }
 
-func (s *LegacyHTTPHandlerSuite) TestServeHTTPUnsupportedMethod(c *gc.C) {
-	h := &server.LegacyHTTPHandler{
-		LegacyHTTPHandlerDeps: s.deps,
+func (s *UnitResourceHandlerSuite) TestServeHTTPUnsupportedMethod(c *gc.C) {
+	h := &server.UnitResourceHandler{
+		UnitResourceHandlerDeps: s.deps,
 	}
 	req, err := http.NewRequest("HEAD", "...", nil)
 	c.Assert(err, jc.ErrorIsNil)
@@ -174,14 +174,14 @@ func (s *LegacyHTTPHandlerSuite) TestServeHTTPUnsupportedMethod(c *gc.C) {
 	)
 }
 
-type stubLegacyHTTPHandlerDeps struct {
+type stubUnitResourceHandlerDeps struct {
 	*testing.Stub
 
 	ReturnNewResourceOpener resource.Opener
 	ReturnHandleDownload    resource.Opened
 }
 
-func (s *stubLegacyHTTPHandlerDeps) NewResourceOpener(req *http.Request) (resource.Opener, error) {
+func (s *stubUnitResourceHandlerDeps) NewResourceOpener(req *http.Request) (resource.Opener, error) {
 	s.AddCall("NewResourceOpener", req)
 	if err := s.NextErr(); err != nil {
 		return nil, err
@@ -190,17 +190,17 @@ func (s *stubLegacyHTTPHandlerDeps) NewResourceOpener(req *http.Request) (resour
 	return s.ReturnNewResourceOpener, nil
 }
 
-func (s *stubLegacyHTTPHandlerDeps) SendHTTPError(resp http.ResponseWriter, err error) {
+func (s *stubUnitResourceHandlerDeps) SendHTTPError(resp http.ResponseWriter, err error) {
 	s.AddCall("SendHTTPError", resp, err)
 	s.NextErr() // Pop one off.
 }
 
-func (s *stubLegacyHTTPHandlerDeps) UpdateDownloadResponse(resp http.ResponseWriter, info resource.Resource) {
+func (s *stubUnitResourceHandlerDeps) UpdateDownloadResponse(resp http.ResponseWriter, info resource.Resource) {
 	s.AddCall("UpdateDownloadResponse", resp, info)
 	s.NextErr() // Pop one off.
 }
 
-func (s *stubLegacyHTTPHandlerDeps) HandleDownload(opener resource.Opener, req *http.Request) (resource.Opened, error) {
+func (s *stubUnitResourceHandlerDeps) HandleDownload(opener resource.Opener, req *http.Request) (resource.Opened, error) {
 	s.AddCall("HandleDownload", opener, req)
 	if err := s.NextErr(); err != nil {
 		return resource.Opened{}, err
@@ -224,7 +224,7 @@ func (s *stubResourceOpener) OpenResource(name string) (resource.Opened, error) 
 	return s.ReturnOpenResource, nil
 }
 
-func (s *stubLegacyHTTPHandlerDeps) Copy(w io.Writer, r io.Reader) error {
+func (s *stubUnitResourceHandlerDeps) Copy(w io.Writer, r io.Reader) error {
 	s.AddCall("Copy", w, r)
 	if err := s.NextErr(); err != nil {
 		return err


### PR DESCRIPTION
The resources' API had two http handlers, one for services one for units, implemented in two different ways one living inside a _private_ (whatever that means) package. This meant the apiserver had a dependency on apiserver/common via it's import of resources/api/private/server even though the type it was importing did not have anything to do with this transitive dependency.

This change moves both handlers to the public resources/api/server package, renaming them to something more descriptive.

(Review request: http://reviews.vapour.ws/r/4127/)