### PR TITLE
apiserver/common: move RestoreError to resource/api

### DIFF
--- a/apiserver/common/errors.go
+++ b/apiserver/common/errors.go
@@ -103,33 +103,35 @@ func OperationBlockedError(msg string) error {
 	}
 }
 
-var singletonErrorCodes = map[error]string{
-	state.ErrCannotEnterScopeYet: params.CodeCannotEnterScopeYet,
-	state.ErrCannotEnterScope:    params.CodeCannotEnterScope,
-	state.ErrUnitHasSubordinates: params.CodeUnitHasSubordinates,
-	state.ErrDead:                params.CodeDead,
-	txn.ErrExcessiveContention:   params.CodeExcessiveContention,
-	leadership.ErrClaimDenied:    params.CodeLeadershipClaimDenied,
-	lease.ErrClaimDenied:         params.CodeLeaseClaimDenied,
-	ErrBadId:                     params.CodeNotFound,
-	ErrBadCreds:                  params.CodeUnauthorized,
-	ErrPerm:                      params.CodeUnauthorized,
-	ErrNotLoggedIn:               params.CodeUnauthorized,
-	ErrUnknownWatcher:            params.CodeNotFound,
-	ErrStoppedWatcher:            params.CodeStopped,
-	ErrTryAgain:                  params.CodeTryAgain,
-	ErrActionNotAvailable:        params.CodeActionNotAvailable,
-}
-
 func singletonCode(err error) (string, bool) {
-	// All error types may not be hashable; deal with
-	// that by catching the panic if we try to look up
-	// a non-hashable type.
-	defer func() {
-		recover()
-	}()
-	code, ok := singletonErrorCodes[err]
-	return code, ok
+	switch err {
+	case state.ErrCannotEnterScopeYet:
+		return params.CodeCannotEnterScopeYet, true
+	case state.ErrCannotEnterScope:
+		return params.CodeCannotEnterScope, true
+	case state.ErrUnitHasSubordinates:
+		return params.CodeUnitHasSubordinates, true
+	case state.ErrDead:
+		return params.CodeDead, true
+	case txn.ErrExcessiveContention:
+		return params.CodeExcessiveContention, true
+	case leadership.ErrClaimDenied:
+		return params.CodeLeadershipClaimDenied, true
+	case lease.ErrClaimDenied:
+		return params.CodeLeaseClaimDenied, true
+	case ErrBadId, ErrUnknownWatcher:
+		return params.CodeNotFound, true
+	case ErrBadCreds, ErrPerm, ErrNotLoggedIn:
+		return params.CodeUnauthorized, true
+	case ErrStoppedWatcher:
+		return params.CodeStopped, true
+	case ErrTryAgain:
+		return params.CodeTryAgain, true
+	case ErrActionNotAvailable:
+		return params.CodeActionNotAvailable, true
+	default:
+		return "", false
+	}
 }
 
 // ServerErrorAndStatus is like ServerError but also

--- a/apiserver/common/errors.go
+++ b/apiserver/common/errors.go
@@ -53,7 +53,7 @@ func UnknownModelError(uuid string) error {
 	return &unknownModelError{uuid: uuid}
 }
 
-func isUnknownModelError(err error) bool {
+func IsUnknownModelError(err error) bool {
 	_, ok := err.(*unknownModelError)
 	return ok
 }
@@ -196,7 +196,7 @@ func ServerError(err error) *params.Error {
 		code = params.CodeUpgradeInProgress
 	case state.IsHasAttachmentsError(err):
 		code = params.CodeMachineHasAttachedStorage
-	case isUnknownModelError(err):
+	case IsUnknownModelError(err):
 		code = params.CodeNotFound
 	case errors.IsNotSupported(err):
 		code = params.CodeNotSupported

--- a/apiserver/common/export_test.go
+++ b/apiserver/common/export_test.go
@@ -11,7 +11,6 @@ var (
 	EnvtoolsFindTools       = &envtoolsFindTools
 	SendMetrics             = &sendMetrics
 	MockableDestroyMachines = destroyMachines
-	IsUnknownModelError     = isUnknownModelError
 )
 
 type Patcher interface {

--- a/payload/api/private/helpers.go
+++ b/payload/api/private/helpers.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/payload"
 	"github.com/juju/juju/payload/api"
+	resourcesapi "github.com/juju/juju/resource/api"
 )
 
 // NewPayloadResult builds a new PayloadResult from the provided tag
@@ -49,7 +50,7 @@ func API2Result(r PayloadResult) (payload.Result, error) {
 	}
 
 	if r.Error != nil {
-		result.Error = common.RestoreError(r.Error)
+		result.Error = resourcesapi.RestoreError(r.Error)
 	}
 
 	return result, nil

--- a/resource/api/client/client.go
+++ b/resource/api/client/client.go
@@ -12,7 +12,6 @@ import (
 	"github.com/juju/loggo"
 	charmresource "gopkg.in/juju/charm.v6-unstable/resource"
 
-	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/resource"
 	"github.com/juju/juju/resource/api"
 )
@@ -116,7 +115,7 @@ func (c Client) AddPendingResources(serviceID string, resources []charmresource.
 		return nil, errors.Trace(err)
 	}
 	if result.Error != nil {
-		err := common.RestoreError(result.Error)
+		err := api.RestoreError(result.Error)
 		return nil, errors.Trace(err)
 	}
 

--- a/resource/api/helpers.go
+++ b/resource/api/helpers.go
@@ -188,11 +188,9 @@ func API2CharmResource(apiInfo CharmResource) (charmresource.Resource, error) {
 	return res, nil
 }
 
-var singletonErrorCodes = map[error]string{}
-
 func singletonError(err error) (error, bool) {
 	sameErr := func(err2 error) (error, bool) {
-		return err, err.Error() == err2.Error()
+		return err2, err.Error() == err2.Error()
 	}
 	switch params.ErrCode(err) {
 	case params.CodeCannotEnterScopeYet:

--- a/resource/api/private/client/client.go
+++ b/resource/api/private/client/client.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/juju/errors"
 
-	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/resource"
 	"github.com/juju/juju/resource/api"
 	"github.com/juju/juju/resource/api/private"
@@ -88,7 +87,7 @@ func (c *UnitFacadeClient) getResourceInfo(resourceName string) (resource.Resour
 		return resource.Resource{}, errors.Annotate(err, "could not get resource info")
 	}
 	if response.Error != nil {
-		err := common.RestoreError(response.Error)
+		err := api.RestoreError(response.Error)
 		return resource.Resource{}, errors.Annotate(err, "request failed on server")
 	}
 
@@ -96,7 +95,7 @@ func (c *UnitFacadeClient) getResourceInfo(resourceName string) (resource.Resour
 		return resource.Resource{}, errors.New("got bad response from API server")
 	}
 	if response.Resources[0].Error != nil {
-		err := common.RestoreError(response.Error)
+		err := api.RestoreError(response.Error)
 		return resource.Resource{}, errors.Annotate(err, "request failed for resource")
 	}
 	res, err := api.API2Resource(response.Resources[0].Resource)


### PR DESCRIPTION
RestoreError is only used by the resources and payload apis, it is not part of the common api. 

Moving RestoreError to resource/api enables further refactoring of the helpers and constants inside apiserver/common and resource/api, moving as much of the support logic for RestoreError out of apiserver/common.

(Review request: http://reviews.vapour.ws/r/4130/)