### PR TITLE
Revert to crypto version that compiles on armhf

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -42,7 +42,7 @@ github.com/lxc/lxd	git	e471e1b8d18d1477f5c421e5de3ba2cfa0684290	2016-02-18T03:41
 github.com/mattn/go-colorable	git	40e4aedc8fabf8c23e040057540867186712faa5	2015-06-25T15:46:42Z
 github.com/mattn/go-runewidth	git	d96d1bd051f2bd9e7e43d602782b37b93b1b5666	2015-11-18T07:21:59Z
 github.com/mattn/go-isatty	git	d6aaa2f596ae91a0a58d8e7f2c79670991468e4f	2015-11-07T15:36:48Z
-golang.org/x/crypto	git	aedad9a179ec1ea11b7064c57cbc6dc30d7724ec	2015-08-30T18:06:42Z
+golang.org/x/crypto	git	e3f150b4372fce47109dbd8fef5f03cd2af08700	2015-05-14T18:39:32Z
 golang.org/x/net	git	ea47fc708ee3e20177f3ca3716217c4ab75942cb	2015-08-29T23:03:18Z
 golang.org/x/oauth2	git	11c60b6f71a6ad48ed6f93c65fa4c6f9b1b5b46a	2015-03-25T02:00:22Z
 google.golang.org/api	git	0d3983fb069cb6651353fc44c5cb604e263f2a93	2014-12-10T23:51:26Z


### PR DESCRIPTION
Fixes lp:1547741 by switching to a golang.org/x/crypto
version that predates inclusion of arm assembly code.

This avoids the compilation error on go 1.2:

  poly1305/poly1305_arm.s:26 syntax error, last name: R9

Juju itself builds fine with this crypto version, other branches
may have dependencies on code only found in more recent copies.

(Review request: http://reviews.vapour.ws/r/4140/)