### PR TITLE
add lifeflag stack

### DIFF
--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -42,6 +42,7 @@ var facadeVersions = map[string]int{
 	"KeyManager":                   1,
 	"KeyUpdater":                   1,
 	"LeadershipService":            2,
+	"LifeFlag":                     1,
 	"Logger":                       1,
 	"MachineManager":               2,
 	"Machiner":                     1,

--- a/api/lifeflag/facade.go
+++ b/api/lifeflag/facade.go
@@ -1,0 +1,88 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package lifeflag
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	"github.com/juju/names"
+
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/life"
+	"github.com/juju/juju/watcher"
+)
+
+var logger = loggo.GetLogger("juju.api.servicescaler")
+
+// NewWatcherFunc exists to let us test Watch properly.
+type NewWatcherFunc func(base.APICaller, params.NotifyWatchResult) watcher.NotifyWatcher
+
+// Facade makes calls to the LifeFlag facade.
+type Facade struct {
+	caller     base.FacadeCaller
+	newWatcher NewWatcherFunc
+}
+
+// NewFacade returns a new Facade using the supplied caller.
+func NewFacade(caller base.APICaller, newWatcher NewWatcherFunc) *Facade {
+	return &Facade{
+		caller:     base.NewFacadeCaller(caller, "LifeFlag"),
+		newWatcher: newWatcher,
+	}
+}
+
+// ErrNotFound indicates that the requested entity no longer exists.
+var ErrNotFound = errors.New("entity not found")
+
+// Watch returns a NotifyWatcher that sends a value whenever the
+// entity's life value may have changed.
+func (facade *Facade) Watch(entity names.Tag) (watcher.NotifyWatcher, error) {
+	args := params.Entities{
+		Entities: []params.Entity{{Tag: entity.String()}},
+	}
+	var results params.NotifyWatchResults
+	err := facade.caller.FacadeCall("Watch", args, &results)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if count := len(results.Results); count != 1 {
+		return nil, errors.Errorf("expected 1 Watch result, got %d", count)
+	}
+	result := results.Results[0]
+	if err := result.Error; err != nil {
+		if params.IsCodeNotFound(err) {
+			return nil, ErrNotFound
+		}
+		return nil, errors.Trace(result.Error)
+	}
+	w := facade.newWatcher(facade.caller.RawAPICaller(), result)
+	return w, nil
+}
+
+func (facade *Facade) Life(entity names.Tag) (life.Value, error) {
+	args := params.Entities{
+		Entities: []params.Entity{{Tag: entity.String()}},
+	}
+	var results params.LifeResults
+	err := facade.caller.FacadeCall("Life", args, &results)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	if count := len(results.Results); count != 1 {
+		return "", errors.Errorf("expected 1 Life result, got %d", count)
+	}
+	result := results.Results[0]
+	if err := result.Error; err != nil {
+		if params.IsCodeNotFound(err) {
+			return "", ErrNotFound
+		}
+		return "", errors.Trace(result.Error)
+	}
+	life := life.Value(result.Life)
+	if err := life.Validate(); err != nil {
+		return "", errors.Trace(err)
+	}
+	return life, nil
+}

--- a/api/lifeflag/facade.go
+++ b/api/lifeflag/facade.go
@@ -5,7 +5,6 @@ package lifeflag
 
 import (
 	"github.com/juju/errors"
-	"github.com/juju/loggo"
 	"github.com/juju/names"
 
 	"github.com/juju/juju/api/base"
@@ -13,8 +12,6 @@ import (
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/watcher"
 )
-
-var logger = loggo.GetLogger("juju.api.servicescaler")
 
 // NewWatcherFunc exists to let us test Watch properly.
 type NewWatcherFunc func(base.APICaller, params.NotifyWatchResult) watcher.NotifyWatcher
@@ -34,10 +31,21 @@ func NewFacade(caller base.APICaller, newWatcher NewWatcherFunc) *Facade {
 }
 
 // ErrNotFound indicates that the requested entity no longer exists.
+//
+// We avoid errors.NotFound, because errors.NotFound is non-specific, and
+// it's our job to communicate *this specific condition*. There are many
+// possible sources of errors.NotFound in the world, and it's not safe or
+// sane for a client to treat a generic NotFound as specific to the entity
+// in question.
+//
+// We're still vulnerable to apiservers returning unjustified CodeNotFound
+// but at least we're safe from accidental errors.NotFound injection in
+// the api client mechanism.
 var ErrNotFound = errors.New("entity not found")
 
 // Watch returns a NotifyWatcher that sends a value whenever the
-// entity's life value may have changed.
+// entity's life value may have changed; or ErrNotFound; or some
+// other error.
 func (facade *Facade) Watch(entity names.Tag) (watcher.NotifyWatcher, error) {
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: entity.String()}},
@@ -61,6 +69,8 @@ func (facade *Facade) Watch(entity names.Tag) (watcher.NotifyWatcher, error) {
 	return w, nil
 }
 
+// Life returns the entity's life value; or ErrNotFound; or some
+// other error.
 func (facade *Facade) Life(entity names.Tag) (life.Value, error) {
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: entity.String()}},

--- a/api/lifeflag/facade_test.go
+++ b/api/lifeflag/facade_test.go
@@ -1,0 +1,236 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package lifeflag_test
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/names"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/api/base"
+	apitesting "github.com/juju/juju/api/base/testing"
+	"github.com/juju/juju/api/lifeflag"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/life"
+	"github.com/juju/juju/watcher"
+)
+
+type FacadeSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&FacadeSuite{})
+
+func (*FacadeSuite) TestLifeCall(c *gc.C) {
+	var called bool
+	caller := apiCaller(c, func(request string, args, _ interface{}) error {
+		called = true
+		c.Check(request, gc.Equals, "Life")
+		c.Check(args, jc.DeepEquals, params.Entities{
+			Entities: []params.Entity{{Tag: "service-blah"}},
+		})
+		return nil
+	})
+	facade := lifeflag.NewFacade(caller, nil)
+
+	facade.Life(names.NewServiceTag("blah"))
+	c.Check(called, jc.IsTrue)
+}
+
+func (*FacadeSuite) TestLifeCallError(c *gc.C) {
+	caller := apiCaller(c, func(_ string, _, _ interface{}) error {
+		return errors.New("crunch belch")
+	})
+	facade := lifeflag.NewFacade(caller, nil)
+
+	result, err := facade.Life(names.NewServiceTag("blah"))
+	c.Check(err, gc.ErrorMatches, "crunch belch")
+	c.Check(result, gc.Equals, life.Value(""))
+}
+
+func (*FacadeSuite) TestLifeNoResultsError(c *gc.C) {
+	caller := apiCaller(c, func(_ string, _, _ interface{}) error {
+		return nil
+	})
+	facade := lifeflag.NewFacade(caller, nil)
+
+	result, err := facade.Life(names.NewServiceTag("blah"))
+	c.Check(err, gc.ErrorMatches, "expected 1 Life result, got 0")
+	c.Check(result, gc.Equals, life.Value(""))
+}
+
+func (*FacadeSuite) TestLifeExtraResultsError(c *gc.C) {
+	caller := apiCaller(c, func(_ string, _, results interface{}) error {
+		typed, ok := results.(*params.LifeResults)
+		c.Assert(ok, jc.IsTrue)
+		*typed = params.LifeResults{
+			Results: make([]params.LifeResult, 2),
+		}
+		return nil
+	})
+	facade := lifeflag.NewFacade(caller, nil)
+
+	result, err := facade.Life(names.NewServiceTag("blah"))
+	c.Check(err, gc.ErrorMatches, "expected 1 Life result, got 2")
+	c.Check(result, gc.Equals, life.Value(""))
+}
+
+func (*FacadeSuite) TestLifeNotFoundError(c *gc.C) {
+	caller := apiCaller(c, func(_ string, _, results interface{}) error {
+		typed, ok := results.(*params.LifeResults)
+		c.Assert(ok, jc.IsTrue)
+		*typed = params.LifeResults{
+			Results: []params.LifeResult{{
+				Error: &params.Error{Code: params.CodeNotFound},
+			}},
+		}
+		return nil
+	})
+	facade := lifeflag.NewFacade(caller, nil)
+
+	result, err := facade.Life(names.NewServiceTag("blah"))
+	c.Check(err, gc.Equals, lifeflag.ErrNotFound)
+	c.Check(result, gc.Equals, life.Value(""))
+}
+
+func (*FacadeSuite) TestLifeInvalidResultError(c *gc.C) {
+	caller := apiCaller(c, func(_ string, _, results interface{}) error {
+		typed, ok := results.(*params.LifeResults)
+		c.Assert(ok, jc.IsTrue)
+		*typed = params.LifeResults{
+			Results: []params.LifeResult{{Life: "decomposed"}},
+		}
+		return nil
+	})
+	facade := lifeflag.NewFacade(caller, nil)
+
+	result, err := facade.Life(names.NewServiceTag("blah"))
+	c.Check(err, gc.ErrorMatches, `life value "decomposed" not valid`)
+	c.Check(result, gc.Equals, life.Value(""))
+}
+
+func (*FacadeSuite) TestLifeSuccess(c *gc.C) {
+	caller := apiCaller(c, func(_ string, _, results interface{}) error {
+		typed, ok := results.(*params.LifeResults)
+		c.Assert(ok, jc.IsTrue)
+		*typed = params.LifeResults{
+			Results: []params.LifeResult{{Life: "dying"}},
+		}
+		return nil
+	})
+	facade := lifeflag.NewFacade(caller, nil)
+
+	result, err := facade.Life(names.NewServiceTag("blah"))
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(result, gc.Equals, life.Dying)
+}
+
+func (*FacadeSuite) TestWatchCall(c *gc.C) {
+	var called bool
+	caller := apiCaller(c, func(request string, args, _ interface{}) error {
+		called = true
+		c.Check(request, gc.Equals, "Watch")
+		c.Check(args, jc.DeepEquals, params.Entities{
+			Entities: []params.Entity{{Tag: "service-blah"}},
+		})
+		return nil
+	})
+	facade := lifeflag.NewFacade(caller, nil)
+
+	facade.Watch(names.NewServiceTag("blah"))
+	c.Check(called, jc.IsTrue)
+}
+
+func (*FacadeSuite) TestWatchCallError(c *gc.C) {
+	caller := apiCaller(c, func(_ string, _, _ interface{}) error {
+		return errors.New("crunch belch")
+	})
+	facade := lifeflag.NewFacade(caller, nil)
+
+	watcher, err := facade.Watch(names.NewServiceTag("blah"))
+	c.Check(err, gc.ErrorMatches, "crunch belch")
+	c.Check(watcher, gc.IsNil)
+}
+
+func (*FacadeSuite) TestWatchNoResultsError(c *gc.C) {
+	caller := apiCaller(c, func(_ string, _, _ interface{}) error {
+		return nil
+	})
+	facade := lifeflag.NewFacade(caller, nil)
+
+	watcher, err := facade.Watch(names.NewServiceTag("blah"))
+	c.Check(err, gc.ErrorMatches, "expected 1 Watch result, got 0")
+	c.Check(watcher, gc.IsNil)
+}
+
+func (*FacadeSuite) TestWatchExtraResultsError(c *gc.C) {
+	caller := apiCaller(c, func(_ string, _, results interface{}) error {
+		typed, ok := results.(*params.NotifyWatchResults)
+		c.Assert(ok, jc.IsTrue)
+		*typed = params.NotifyWatchResults{
+			Results: make([]params.NotifyWatchResult, 2),
+		}
+		return nil
+	})
+	facade := lifeflag.NewFacade(caller, nil)
+
+	watcher, err := facade.Watch(names.NewServiceTag("blah"))
+	c.Check(err, gc.ErrorMatches, "expected 1 Watch result, got 2")
+	c.Check(watcher, gc.IsNil)
+}
+
+func (*FacadeSuite) TestWatchNotFoundError(c *gc.C) {
+	caller := apiCaller(c, func(_ string, _, results interface{}) error {
+		typed, ok := results.(*params.NotifyWatchResults)
+		c.Assert(ok, jc.IsTrue)
+		*typed = params.NotifyWatchResults{
+			Results: []params.NotifyWatchResult{{
+				Error: &params.Error{Code: params.CodeNotFound},
+			}},
+		}
+		return nil
+	})
+	facade := lifeflag.NewFacade(caller, nil)
+
+	watcher, err := facade.Watch(names.NewServiceTag("blah"))
+	c.Check(err, gc.Equals, lifeflag.ErrNotFound)
+	c.Check(watcher, gc.IsNil)
+}
+
+func (*FacadeSuite) TestWatchSuccess(c *gc.C) {
+	caller := apiCaller(c, func(_ string, _, results interface{}) error {
+		typed, ok := results.(*params.NotifyWatchResults)
+		c.Assert(ok, jc.IsTrue)
+		*typed = params.NotifyWatchResults{
+			Results: []params.NotifyWatchResult{{
+				NotifyWatcherId: "123",
+			}},
+		}
+		return nil
+	})
+	expectWatcher := &struct{ watcher.NotifyWatcher }{}
+	newWatcher := func(apiCaller base.APICaller, result params.NotifyWatchResult) watcher.NotifyWatcher {
+		c.Check(apiCaller, gc.NotNil) // uncomparable
+		c.Check(result, jc.DeepEquals, params.NotifyWatchResult{
+			NotifyWatcherId: "123",
+		})
+		return expectWatcher
+	}
+	facade := lifeflag.NewFacade(caller, newWatcher)
+
+	watcher, err := facade.Watch(names.NewServiceTag("blah"))
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(watcher, gc.Equals, expectWatcher)
+}
+
+func apiCaller(c *gc.C, check func(request string, arg, result interface{}) error) base.APICaller {
+	return apitesting.APICallerFunc(func(facade string, version int, id, request string, arg, result interface{}) error {
+		c.Check(facade, gc.Equals, "LifeFlag")
+		c.Check(version, gc.Equals, 0)
+		c.Check(id, gc.Equals, "")
+		return check(request, arg, result)
+	})
+}

--- a/api/lifeflag/package_test.go
+++ b/api/lifeflag/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package lifeflag_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -32,6 +32,7 @@ import (
 	_ "github.com/juju/juju/apiserver/instancepoller"
 	_ "github.com/juju/juju/apiserver/keymanager"
 	_ "github.com/juju/juju/apiserver/keyupdater"
+	_ "github.com/juju/juju/apiserver/lifeflag"
 	_ "github.com/juju/juju/apiserver/logger"
 	_ "github.com/juju/juju/apiserver/machine"
 	_ "github.com/juju/juju/apiserver/machinemanager"

--- a/apiserver/lifeflag/facade.go
+++ b/apiserver/lifeflag/facade.go
@@ -1,0 +1,39 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package lifeflag
+
+import (
+	"github.com/juju/names"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/state"
+)
+
+type Backend interface {
+	ModelUUID() string
+	state.EntityFinder
+}
+
+func NewFacade(backend Backend, resources *common.Resources, authorizer common.Authorizer) (*Facade, error) {
+	if !authorizer.AuthModelManager() {
+		return nil, common.ErrPerm
+	}
+	expect := names.NewModelTag(backend.ModelUUID())
+	getCanAccess := func() (common.AuthFunc, error) {
+		return func(tag names.Tag) bool {
+			return tag == expect
+		}, nil
+	}
+	life := common.NewLifeGetter(backend, getCanAccess)
+	watch := common.NewAgentEntityWatcher(backend, resources, getCanAccess)
+	return &Facade{
+		LifeGetter:         life,
+		AgentEntityWatcher: watch,
+	}, nil
+}
+
+type Facade struct {
+	*common.LifeGetter
+	*common.AgentEntityWatcher
+}

--- a/apiserver/lifeflag/facade_test.go
+++ b/apiserver/lifeflag/facade_test.go
@@ -1,0 +1,148 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package lifeflag_test
+
+import (
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/lifeflag"
+	"github.com/juju/juju/apiserver/params"
+)
+
+type FacadeSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&FacadeSuite{})
+
+func (*FacadeSuite) TestFacadeAuthFailure(c *gc.C) {
+	facade, err := lifeflag.NewFacade(nil, nil, auth(false))
+	c.Check(facade, gc.IsNil)
+	c.Check(err, gc.Equals, common.ErrPerm)
+}
+
+func (*FacadeSuite) TestLifeBadEntity(c *gc.C) {
+	backend := &mockBackend{}
+	facade, err := lifeflag.NewFacade(backend, nil, auth(true))
+	c.Assert(err, jc.ErrorIsNil)
+
+	results, err := facade.Life(entities("archibald snookums"))
+	c.Check(err, jc.ErrorIsNil)
+	c.Assert(results.Results, gc.HasLen, 1)
+	result := results.Results[0]
+	c.Check(result.Life, gc.Equals, params.Life(""))
+
+	// TODO(fwereade): this is DUMB. should just be a parse error.
+	// but I'm not fixing the underlying implementation as well.
+	c.Check(result.Error, jc.Satisfies, params.IsCodeUnauthorized)
+}
+
+func (*FacadeSuite) TestLifeAuthFailure(c *gc.C) {
+	backend := &mockBackend{}
+	facade, err := lifeflag.NewFacade(backend, nil, auth(true))
+	c.Assert(err, jc.ErrorIsNil)
+
+	results, err := facade.Life(entities("unit-foo-1"))
+	c.Check(err, jc.ErrorIsNil)
+	c.Assert(results.Results, gc.HasLen, 1)
+	result := results.Results[0]
+	c.Check(result.Life, gc.Equals, params.Life(""))
+	c.Check(result.Error, jc.Satisfies, params.IsCodeUnauthorized)
+}
+
+func (*FacadeSuite) TestLifeNotFound(c *gc.C) {
+	backend := &mockBackend{}
+	facade, err := lifeflag.NewFacade(backend, nil, auth(true))
+	c.Assert(err, jc.ErrorIsNil)
+
+	results, err := facade.Life(modelEntity())
+	c.Check(err, jc.ErrorIsNil)
+	c.Assert(results.Results, gc.HasLen, 1)
+	result := results.Results[0]
+	c.Check(result.Life, gc.Equals, params.Life(""))
+	c.Check(result.Error, jc.Satisfies, params.IsCodeNotFound)
+}
+
+func (*FacadeSuite) TestLifeSuccess(c *gc.C) {
+	backend := &mockBackend{exist: true}
+	facade, err := lifeflag.NewFacade(backend, nil, auth(true))
+	c.Check(err, jc.ErrorIsNil)
+
+	results, err := facade.Life(modelEntity())
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(results, jc.DeepEquals, params.LifeResults{
+		Results: []params.LifeResult{{Life: params.Dying}},
+	})
+}
+
+func (*FacadeSuite) TestWatchBadEntity(c *gc.C) {
+	backend := &mockBackend{}
+	facade, err := lifeflag.NewFacade(backend, nil, auth(true))
+	c.Assert(err, jc.ErrorIsNil)
+
+	results, err := facade.Watch(entities("archibald snookums"))
+	c.Check(err, jc.ErrorIsNil)
+	c.Assert(results.Results, gc.HasLen, 1)
+	result := results.Results[0]
+	c.Check(result.NotifyWatcherId, gc.Equals, "")
+
+	// TODO(fwereade): this is DUMB. should just be a parse error.
+	// but I'm not fixing the underlying implementation as well.
+	c.Check(result.Error, jc.Satisfies, params.IsCodeUnauthorized)
+}
+
+func (*FacadeSuite) TestWatchAuthFailure(c *gc.C) {
+	backend := &mockBackend{}
+	facade, err := lifeflag.NewFacade(backend, nil, auth(true))
+	c.Assert(err, jc.ErrorIsNil)
+
+	results, err := facade.Watch(entities("unit-foo-1"))
+	c.Check(err, jc.ErrorIsNil)
+	c.Assert(results.Results, gc.HasLen, 1)
+	result := results.Results[0]
+	c.Check(result.NotifyWatcherId, gc.Equals, "")
+	c.Check(result.Error, jc.Satisfies, params.IsCodeUnauthorized)
+}
+
+func (*FacadeSuite) TestWatchNotFound(c *gc.C) {
+	backend := &mockBackend{}
+	facade, err := lifeflag.NewFacade(backend, nil, auth(true))
+	c.Assert(err, jc.ErrorIsNil)
+
+	results, err := facade.Watch(modelEntity())
+	c.Check(err, jc.ErrorIsNil)
+	c.Assert(results.Results, gc.HasLen, 1)
+	result := results.Results[0]
+	c.Check(result.NotifyWatcherId, gc.Equals, "")
+	c.Check(result.Error, jc.Satisfies, params.IsCodeNotFound)
+}
+
+func (*FacadeSuite) TestWatchBadWatcher(c *gc.C) {
+	backend := &mockBackend{exist: true}
+	facade, err := lifeflag.NewFacade(backend, nil, auth(true))
+	c.Check(err, jc.ErrorIsNil)
+
+	results, err := facade.Watch(modelEntity())
+	c.Check(err, jc.ErrorIsNil)
+	c.Assert(results.Results, gc.HasLen, 1)
+	result := results.Results[0]
+	c.Check(result.NotifyWatcherId, gc.Equals, "")
+	c.Check(result.Error, gc.ErrorMatches, "blammo")
+}
+
+func (*FacadeSuite) TestWatchSuccess(c *gc.C) {
+	backend := &mockBackend{exist: true, watch: true}
+	resources := common.NewResources()
+	facade, err := lifeflag.NewFacade(backend, resources, auth(true))
+	c.Check(err, jc.ErrorIsNil)
+
+	results, err := facade.Watch(modelEntity())
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(results, jc.DeepEquals, params.NotifyWatchResults{
+		Results: []params.NotifyWatchResult{{NotifyWatcherId: "1"}},
+	})
+}

--- a/apiserver/lifeflag/package_test.go
+++ b/apiserver/lifeflag/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package lifeflag_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/apiserver/lifeflag/shim.go
+++ b/apiserver/lifeflag/shim.go
@@ -1,0 +1,18 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package lifeflag
+
+import (
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/state"
+)
+
+func init() {
+	common.RegisterStandardFacade(
+		"LifeFlag", 1,
+		func(st *state.State, resources *common.Resources, authorizer common.Authorizer) (*Facade, error) {
+			return NewFacade(st, resources, authorizer)
+		},
+	)
+}

--- a/apiserver/lifeflag/util_test.go
+++ b/apiserver/lifeflag/util_test.go
@@ -1,0 +1,101 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package lifeflag_test
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/names"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/state"
+	coretesting "github.com/juju/juju/testing"
+)
+
+// mockAuth implements common.Authorizer for the tests' convenience.
+type mockAuth struct {
+	common.Authorizer
+	modelManager bool
+}
+
+func (mock mockAuth) AuthModelManager() bool {
+	return mock.modelManager
+}
+
+// auth is a convenience constructor for a mockAuth.
+func auth(modelManager bool) common.Authorizer {
+	return mockAuth{modelManager: modelManager}
+}
+
+// mockBackend implements lifeflag.Backend for the tests' convenience.
+type mockBackend struct {
+	exist bool
+	watch bool
+}
+
+func (mock *mockBackend) ModelUUID() string {
+	return coretesting.ModelTag.Id()
+}
+
+func (mock *mockBackend) FindEntity(tag names.Tag) (state.Entity, error) {
+	if tag != coretesting.ModelTag {
+		panic("should never happen -- bad auth somewhere")
+	}
+	if !mock.exist {
+		return nil, errors.NotFoundf("model")
+	}
+	return &mockEntity{
+		watch: mock.watch,
+	}, nil
+}
+
+// mockEntity implements state.Entity for the tests' convenience.
+type mockEntity struct {
+	watch bool
+}
+
+func (mock *mockEntity) Tag() names.Tag {
+	return coretesting.ModelTag
+}
+
+func (mock *mockEntity) Life() state.Life {
+	return state.Dying
+}
+
+func (mock *mockEntity) Watch() state.NotifyWatcher {
+	changes := make(chan struct{}, 1)
+	if mock.watch {
+		changes <- struct{}{}
+	} else {
+		close(changes)
+	}
+	return &mockWatcher{changes: changes}
+}
+
+// mockWatcher implements state.NotifyWatcher for the tests' convenience.
+type mockWatcher struct {
+	state.NotifyWatcher
+	changes chan struct{}
+}
+
+func (mock *mockWatcher) Changes() <-chan struct{} {
+	return mock.changes
+}
+
+func (mock *mockWatcher) Err() error {
+	return errors.New("blammo")
+}
+
+// entities is a convenience constructor for params.Entities.
+func entities(tags ...string) params.Entities {
+	entities := params.Entities{Entities: make([]params.Entity, len(tags))}
+	for i, tag := range tags {
+		entities.Entities[i].Tag = tag
+	}
+	return entities
+}
+
+func modelEntity() params.Entities {
+	return entities(coretesting.ModelTag.String())
+}

--- a/core/life/life.go
+++ b/core/life/life.go
@@ -1,0 +1,54 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package life
+
+import (
+	"github.com/juju/errors"
+)
+
+// Value indicates the state of some entity.
+type Value string
+
+const (
+	// Alive indicates that some entity is meant to exist.
+	Alive Value = "alive"
+
+	// Dying indicates that some entity should be removed.
+	Dying Value = "dying"
+
+	// Dead indicates that some entity is no longer useful,
+	// and can be destroyed unconditionally.
+	Dead Value = "dead"
+)
+
+// Validate returns an error if the value is not known.
+func (v Value) Validate() error {
+	switch v {
+	case Alive, Dying, Dead:
+		return nil
+	}
+	return errors.NotValidf("life value %q", v)
+}
+
+// Predicate is a predicate.
+type Predicate func(Value) bool
+
+// IsNotAlive is a Predicate that returns true if the supplied value
+// is not Alive.
+//
+// This generally indicates that the entity in question is at some
+// stage of destruction/cleanup.
+func IsNotAlive(v Value) bool {
+	return v != Alive
+}
+
+// IsNotDead is a Predicate that returns true if the supplied value
+// is not Dead.
+//
+// This generally indicates that the entity in question is active in
+// some way, and can probably not be completely destroyed without
+// consequences.
+func IsNotDead(v Value) bool {
+	return v != Dead
+}

--- a/core/life/life_test.go
+++ b/core/life/life_test.go
@@ -1,0 +1,67 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package life_test
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/core/life"
+)
+
+type LifeSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&LifeSuite{})
+
+func (*LifeSuite) TestValidateValid(c *gc.C) {
+	for i, test := range []life.Value{
+		life.Alive, life.Dying, life.Dead,
+	} {
+		c.Logf("test %d: %s", i, test)
+		err := test.Validate()
+		c.Check(err, jc.ErrorIsNil)
+	}
+}
+
+func (*LifeSuite) TestValidateInvalid(c *gc.C) {
+	for i, test := range []life.Value{
+		"", "bad", "resurrected",
+		" alive", "alive ", "Alive",
+	} {
+		c.Logf("test %d: %s", i, test)
+		err := life.Value(test).Validate()
+		c.Check(err, jc.Satisfies, errors.IsNotValid)
+		c.Check(err, gc.ErrorMatches, `life value ".*" not valid`)
+	}
+}
+
+func (*LifeSuite) TestIsNotAliveFailure(c *gc.C) {
+	c.Check(life.IsNotAlive(life.Alive), jc.IsFalse)
+}
+
+func (*LifeSuite) TestIsNotAliveSuccess(c *gc.C) {
+	for i, test := range []life.Value{
+		life.Dying, life.Dead, "", "bad", "ALIVE",
+	} {
+		c.Logf("test %d: %s", i, test)
+		c.Check(life.IsNotAlive(test), jc.IsTrue)
+	}
+}
+
+func (*LifeSuite) TestIsNotDeadFailure(c *gc.C) {
+	c.Check(life.IsNotDead(life.Dead), jc.IsFalse)
+}
+
+func (*LifeSuite) TestIsNotDeadSuccess(c *gc.C) {
+	for i, test := range []life.Value{
+		life.Alive, life.Dying, "", "bad", "DEAD",
+	} {
+		c.Logf("test %d: %s", i, test)
+		c.Check(life.IsNotDead(test), jc.IsTrue)
+	}
+}

--- a/core/life/package_test.go
+++ b/core/life/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package life_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/worker/lifeflag/manifold.go
+++ b/worker/lifeflag/manifold.go
@@ -13,6 +13,8 @@ import (
 	"github.com/juju/juju/worker/dependency"
 )
 
+// ManifoldConfig describes how to configure and construct a Worker,
+// and what registered resources it may depend upon.
 type ManifoldConfig struct {
 	APICallerName string
 	Entity        names.Tag
@@ -45,6 +47,8 @@ func (config ManifoldConfig) start(getResource dependency.GetResourceFunc) (work
 	return worker, nil
 }
 
+// Manifold returns a dependency.Manifold that will run a Worker as
+// configured.
 func Manifold(config ManifoldConfig) dependency.Manifold {
 	return dependency.Manifold{
 		Inputs: []string{config.APICallerName},

--- a/worker/lifeflag/manifold.go
+++ b/worker/lifeflag/manifold.go
@@ -1,0 +1,68 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package lifeflag
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/names"
+
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/core/life"
+	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/dependency"
+)
+
+type ManifoldConfig struct {
+	APICallerName string
+	Entity        names.Tag
+	Result        life.Predicate
+	Filter        dependency.FilterFunc
+
+	NewFacade func(base.APICaller) (Facade, error)
+	NewWorker func(Config) (worker.Worker, error)
+}
+
+func (config ManifoldConfig) start(getResource dependency.GetResourceFunc) (worker.Worker, error) {
+
+	var apiCaller base.APICaller
+	if err := getResource(config.APICallerName, &apiCaller); err != nil {
+		return nil, errors.Trace(err)
+	}
+	facade, err := config.NewFacade(apiCaller)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	worker, err := config.NewWorker(Config{
+		Facade: facade,
+		Entity: config.Entity,
+		Result: config.Result,
+	})
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return worker, nil
+}
+
+func Manifold(config ManifoldConfig) dependency.Manifold {
+	return dependency.Manifold{
+		Inputs: []string{config.APICallerName},
+		Start:  config.start,
+		Output: manifoldOutput,
+		Filter: config.Filter,
+	}
+}
+
+func manifoldOutput(in worker.Worker, out interface{}) error {
+	inWorker, ok := in.(*Worker)
+	if !ok {
+		return errors.Errorf("expected in to be a *Worker, got a %T", in)
+	}
+	outFlag, ok := out.(*dependency.Flag)
+	if !ok {
+		return errors.Errorf("expected out to be a *dependency.Flag, got a %T", out)
+	}
+	*outFlag = inWorker
+	return nil
+}

--- a/worker/lifeflag/manifold_test.go
+++ b/worker/lifeflag/manifold_test.go
@@ -1,0 +1,143 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package lifeflag_test
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/names"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/core/life"
+	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/dependency"
+	dt "github.com/juju/juju/worker/dependency/testing"
+	"github.com/juju/juju/worker/lifeflag"
+)
+
+type ManifoldSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&ManifoldSuite{})
+
+func (*ManifoldSuite) TestInputs(c *gc.C) {
+	manifold := lifeflag.Manifold(lifeflag.ManifoldConfig{
+		APICallerName: "boris",
+	})
+	c.Check(manifold.Inputs, jc.DeepEquals, []string{"boris"})
+}
+
+func (*ManifoldSuite) TestFilter(c *gc.C) {
+	expect := errors.New("squish")
+	manifold := lifeflag.Manifold(lifeflag.ManifoldConfig{
+		Filter: func(error) error { return expect },
+	})
+	actual := manifold.Filter(errors.New("blarg"))
+	c.Check(actual, gc.Equals, expect)
+}
+
+func (*ManifoldSuite) TestOutputBadWorker(c *gc.C) {
+	manifold := lifeflag.Manifold(lifeflag.ManifoldConfig{})
+	worker := struct{ worker.Worker }{}
+	var flag dependency.Flag
+	err := manifold.Output(worker, &flag)
+	c.Check(err, gc.ErrorMatches, "expected in to be a \\*Worker, got a .*")
+}
+
+func (*ManifoldSuite) TestOutputBadTarget(c *gc.C) {
+	manifold := lifeflag.Manifold(lifeflag.ManifoldConfig{})
+	worker := &lifeflag.Worker{}
+	var flag interface{}
+	err := manifold.Output(worker, &flag)
+	c.Check(err, gc.ErrorMatches, "expected out to be a \\*dependency\\.Flag, got a .*")
+}
+
+func (*ManifoldSuite) TestOutputSuccess(c *gc.C) {
+	manifold := lifeflag.Manifold(lifeflag.ManifoldConfig{})
+	worker := &lifeflag.Worker{}
+	var flag dependency.Flag
+	err := manifold.Output(worker, &flag)
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(flag, gc.Equals, worker)
+}
+
+func (*ManifoldSuite) TestMissingAPICaller(c *gc.C) {
+	getResource := dt.StubGetResource(dt.StubResources{
+		"api-caller": dt.StubResource{Error: dependency.ErrMissing},
+	})
+	manifold := lifeflag.Manifold(lifeflag.ManifoldConfig{
+		APICallerName: "api-caller",
+	})
+
+	worker, err := manifold.Start(getResource)
+	c.Check(worker, gc.IsNil)
+	c.Check(errors.Cause(err), gc.Equals, dependency.ErrMissing)
+}
+
+func (*ManifoldSuite) TestNewFacadeError(c *gc.C) {
+	expect := struct{ base.APICaller }{}
+	getResource := dt.StubGetResource(dt.StubResources{
+		"api-caller": dt.StubResource{Output: expect},
+	})
+	manifold := lifeflag.Manifold(lifeflag.ManifoldConfig{
+		APICallerName: "api-caller",
+		NewFacade: func(actual base.APICaller) (lifeflag.Facade, error) {
+			c.Check(actual, gc.Equals, expect)
+			return nil, errors.New("splort")
+		},
+	})
+
+	worker, err := manifold.Start(getResource)
+	c.Check(worker, gc.IsNil)
+	c.Check(err, gc.ErrorMatches, "splort")
+}
+
+func (*ManifoldSuite) TestNewWorkerError(c *gc.C) {
+	expectFacade := struct{ lifeflag.Facade }{}
+	expectEntity := names.NewMachineTag("33")
+	getResource := dt.StubGetResource(dt.StubResources{
+		"api-caller": dt.StubResource{Output: struct{ base.APICaller }{}},
+	})
+	manifold := lifeflag.Manifold(lifeflag.ManifoldConfig{
+		APICallerName: "api-caller",
+		Entity:        expectEntity,
+		Result:        life.IsNotAlive,
+		NewFacade: func(_ base.APICaller) (lifeflag.Facade, error) {
+			return expectFacade, nil
+		},
+		NewWorker: func(config lifeflag.Config) (worker.Worker, error) {
+			c.Check(config.Facade, gc.Equals, expectFacade)
+			c.Check(config.Entity, gc.Equals, expectEntity)
+			c.Check(config.Result, gc.NotNil) // uncomparable
+			return nil, errors.New("boof")
+		},
+	})
+
+	worker, err := manifold.Start(getResource)
+	c.Check(worker, gc.IsNil)
+	c.Check(err, gc.ErrorMatches, "boof")
+}
+
+func (*ManifoldSuite) TestNewWorkerSuccess(c *gc.C) {
+	expectWorker := &struct{ worker.Worker }{}
+	getResource := dt.StubGetResource(dt.StubResources{
+		"api-caller": dt.StubResource{Output: struct{ base.APICaller }{}},
+	})
+	manifold := lifeflag.Manifold(lifeflag.ManifoldConfig{
+		APICallerName: "api-caller",
+		NewFacade: func(_ base.APICaller) (lifeflag.Facade, error) {
+			return struct{ lifeflag.Facade }{}, nil
+		},
+		NewWorker: func(_ lifeflag.Config) (worker.Worker, error) {
+			return expectWorker, nil
+		},
+	})
+
+	worker, err := manifold.Start(getResource)
+	c.Check(worker, gc.Equals, expectWorker)
+	c.Check(err, jc.ErrorIsNil)
+}

--- a/worker/lifeflag/package_test.go
+++ b/worker/lifeflag/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package lifeflag_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/worker/lifeflag/shim.go
+++ b/worker/lifeflag/shim.go
@@ -1,0 +1,26 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package lifeflag
+
+import (
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/api/lifeflag"
+	"github.com/juju/juju/api/watcher"
+	"github.com/juju/juju/worker"
+)
+
+func NewWorker(config Config) (worker.Worker, error) {
+	worker, err := New(config)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return worker, nil
+}
+
+func NewFacade(apiCaller base.APICaller) (Facade, error) {
+	facade := lifeflag.NewFacade(apiCaller, watcher.NewNotifyWatcher)
+	return facade, nil
+}

--- a/worker/lifeflag/util_test.go
+++ b/worker/lifeflag/util_test.go
@@ -1,0 +1,69 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package lifeflag_test
+
+import (
+	"github.com/juju/names"
+	"github.com/juju/testing"
+
+	"github.com/juju/juju/core/life"
+	"github.com/juju/juju/watcher"
+	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/workertest"
+)
+
+func newMockFacade(stub *testing.Stub, lifeResults ...life.Value) *mockFacade {
+	return &mockFacade{
+		stub:        stub,
+		lifeResults: lifeResults,
+	}
+}
+
+type mockFacade struct {
+	stub        *testing.Stub
+	lifeResults []life.Value
+}
+
+func (mock *mockFacade) Life(entity names.Tag) (life.Value, error) {
+	mock.stub.AddCall("Life", entity)
+	if err := mock.stub.NextErr(); err != nil {
+		return "", err
+	}
+	return mock.nextLife(), nil
+}
+
+func (mock *mockFacade) nextLife() life.Value {
+	result := mock.lifeResults[0]
+	mock.lifeResults = mock.lifeResults[1:]
+	return result
+}
+
+func (mock *mockFacade) Watch(entity names.Tag) (watcher.NotifyWatcher, error) {
+	mock.stub.AddCall("Watch", entity)
+	if err := mock.stub.NextErr(); err != nil {
+		return nil, err
+	}
+	const count = 2
+	changes := make(chan struct{}, count)
+	for i := 0; i < count; i++ {
+		changes <- struct{}{}
+	}
+	return newMockWatcher(changes), nil
+}
+
+type mockWatcher struct {
+	worker.Worker
+	changes chan struct{}
+}
+
+func newMockWatcher(changes chan struct{}) *mockWatcher {
+	return &mockWatcher{
+		Worker:  workertest.NewErrorWorker(nil),
+		changes: changes,
+	}
+}
+
+func (mock *mockWatcher) Changes() watcher.NotifyChannel {
+	return mock.changes
+}

--- a/worker/lifeflag/validate_test.go
+++ b/worker/lifeflag/validate_test.go
@@ -1,0 +1,63 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package lifeflag_test
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/juju/worker/lifeflag"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+)
+
+type ValidateSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&ValidateSuite{})
+
+func (*ValidateSuite) TestValidConfig(c *gc.C) {
+	config := validConfig()
+	err := config.Validate()
+	c.Check(err, jc.ErrorIsNil)
+}
+
+func (*ValidateSuite) TestNilFacade(c *gc.C) {
+	config := validConfig()
+	config.Facade = nil
+	checkInvalid(c, config, "nil Facade not valid")
+}
+
+func (*ValidateSuite) TestNilEntity(c *gc.C) {
+	config := validConfig()
+	config.Entity = nil
+	checkInvalid(c, config, "nil Entity not valid")
+}
+
+func (*ValidateSuite) TestNilResult(c *gc.C) {
+	config := validConfig()
+	config.Result = nil
+	checkInvalid(c, config, "nil Result not valid")
+}
+
+func checkInvalid(c *gc.C, config lifeflag.Config, message string) {
+	check := func(err error) {
+		c.Check(err, jc.Satisfies, errors.IsNotValid)
+		c.Check(err, gc.ErrorMatches, message)
+	}
+	err := config.Validate()
+	check(err)
+
+	worker, err := lifeflag.New(config)
+	c.Check(worker, gc.IsNil)
+	check(err)
+}
+
+func validConfig() lifeflag.Config {
+	return lifeflag.Config{
+		Facade: struct{ lifeflag.Facade }{},
+		Entity: testEntity,
+		Result: explode,
+	}
+}

--- a/worker/lifeflag/worker.go
+++ b/worker/lifeflag/worker.go
@@ -1,0 +1,143 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package lifeflag
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/names"
+
+	"github.com/juju/juju/api/lifeflag"
+	"github.com/juju/juju/core/life"
+	"github.com/juju/juju/watcher"
+	"github.com/juju/juju/worker/catacomb"
+)
+
+// Facade exposes capabilities required by the worker.
+type Facade interface {
+	Watch(names.Tag) (watcher.NotifyWatcher, error)
+	Life(names.Tag) (life.Value, error)
+}
+
+// Config holds the configuration and dependencies for a worker.
+type Config struct {
+	Facade Facade
+	Entity names.Tag
+	Result life.Predicate
+}
+
+// Validate returns an error if the config cannot be expected
+// to drive a functional worker.
+func (config Config) Validate() error {
+	if config.Facade == nil {
+		return errors.NotValidf("nil Facade")
+	}
+	if config.Entity == nil {
+		return errors.NotValidf("nil Entity")
+	}
+	if config.Result == nil {
+		return errors.NotValidf("nil Result")
+	}
+	return nil
+}
+
+var (
+	// ErrNotFound indicates that the worker cannot run because
+	// the configured entity does not exist.
+	ErrNotFound = errors.New("entity not found")
+
+	// ErrValueChanged indicates that the result of Check is
+	// outdated, and the worker should be restarted.
+	ErrValueChanged = errors.New("flag value changed")
+)
+
+// filter is used to wrap errors that might have come from the api,
+// so that we can return an error appropriate to our level. Was
+// tempted to make it a manifold-level thing, but that'd be even
+// worse (because the worker should not be emitting api errors for
+// conditions it knows about, full stop).
+func filter(err error) error {
+	if cause := errors.Cause(err); cause == lifeflag.ErrNotFound {
+		return ErrNotFound
+	}
+	return err
+}
+
+// New returns a worker that exposes the result of the configured
+// predicate when applied to the configured entity's life value,
+// and fails with ErrValueChanged when the result changes.
+func New(config Config) (*Worker, error) {
+	if err := config.Validate(); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	// Read it before the worker starts, so that we have a value
+	// guaranteed before we return the worker. Because we read this
+	// before we start the internal watcher, we'll need an additional
+	// read triggered by the first change event; this will *probably*
+	// be the same value, but we can't assume it.
+	life, err := config.Facade.Life(config.Entity)
+	if err != nil {
+		return nil, filter(errors.Trace(err))
+	}
+
+	w := &Worker{
+		config: config,
+		life:   life,
+	}
+	err = catacomb.Invoke(catacomb.Plan{
+		Site: &w.catacomb,
+		Work: w.loop,
+	})
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return w, nil
+}
+
+// Worker holds the result of some predicate regarding an entity's life,
+// and fails with ErrValueChanged when the result of the predicate changes.
+type Worker struct {
+	catacomb catacomb.Catacomb
+	config   Config
+	life     life.Value
+}
+
+// Kill is part of the worker.Worker interface.
+func (w *Worker) Kill() {
+	w.catacomb.Kill(nil)
+}
+
+// Wait is part of the worker.Worker interface.
+func (w *Worker) Wait() error {
+	return filter(w.catacomb.Wait())
+}
+
+// Check is part of the dependency.Flag interface.
+func (w *Worker) Check() bool {
+	return w.config.Result(w.life)
+}
+
+func (w *Worker) loop() error {
+	watcher, err := w.config.Facade.Watch(w.config.Entity)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if err := w.catacomb.Add(watcher); err != nil {
+		return errors.Trace(err)
+	}
+	for {
+		select {
+		case <-w.catacomb.Dying():
+			return w.catacomb.ErrDying()
+		case <-watcher.Changes():
+			life, err := w.config.Facade.Life(w.config.Entity)
+			if err != nil {
+				return errors.Trace(err)
+			}
+			if w.config.Result(life) != w.Check() {
+				return ErrValueChanged
+			}
+		}
+	}
+}

--- a/worker/lifeflag/worker_test.go
+++ b/worker/lifeflag/worker_test.go
@@ -1,0 +1,187 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package lifeflag_test
+
+import (
+	"errors"
+
+	"github.com/juju/names"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	apilifeflag "github.com/juju/juju/api/lifeflag"
+	"github.com/juju/juju/core/life"
+	"github.com/juju/juju/worker/lifeflag"
+	"github.com/juju/juju/worker/workertest"
+)
+
+type WorkerSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&WorkerSuite{})
+
+func (*WorkerSuite) TestCreateNotFoundError(c *gc.C) {
+	stub := &testing.Stub{}
+	stub.SetErrors(apilifeflag.ErrNotFound)
+	config := lifeflag.Config{
+		Facade: newMockFacade(stub),
+		Entity: testEntity,
+		Result: explode,
+	}
+
+	worker, err := lifeflag.New(config)
+	c.Check(worker, gc.IsNil)
+	c.Check(err, gc.Equals, lifeflag.ErrNotFound)
+	checkCalls(c, stub, "Life")
+}
+
+func (*WorkerSuite) TestCreateRandomError(c *gc.C) {
+	stub := &testing.Stub{}
+	stub.SetErrors(errors.New("boom splat"))
+	config := lifeflag.Config{
+		Facade: newMockFacade(stub),
+		Entity: testEntity,
+		Result: explode,
+	}
+
+	worker, err := lifeflag.New(config)
+	c.Check(worker, gc.IsNil)
+	c.Check(err, gc.ErrorMatches, "boom splat")
+	checkCalls(c, stub, "Life")
+}
+
+func (*WorkerSuite) TestWatchNotFoundError(c *gc.C) {
+	stub := &testing.Stub{}
+	stub.SetErrors(nil, apilifeflag.ErrNotFound)
+	config := lifeflag.Config{
+		Facade: newMockFacade(stub, life.Alive),
+		Entity: testEntity,
+		Result: never,
+	}
+
+	worker, err := lifeflag.New(config)
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(worker.Check(), jc.IsFalse)
+
+	err = workertest.CheckKilled(c, worker)
+	c.Check(err, gc.Equals, lifeflag.ErrNotFound)
+	checkCalls(c, stub, "Life", "Watch")
+}
+
+func (*WorkerSuite) TestWatchRandomError(c *gc.C) {
+	stub := &testing.Stub{}
+	stub.SetErrors(nil, errors.New("pew pew"))
+	config := lifeflag.Config{
+		Facade: newMockFacade(stub, life.Alive),
+		Entity: testEntity,
+		Result: never,
+	}
+
+	worker, err := lifeflag.New(config)
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(worker.Check(), jc.IsFalse)
+
+	err = workertest.CheckKilled(c, worker)
+	c.Check(err, gc.ErrorMatches, "pew pew")
+	checkCalls(c, stub, "Life", "Watch")
+}
+
+func (*WorkerSuite) TestLifeNotFoundError(c *gc.C) {
+	stub := &testing.Stub{}
+	stub.SetErrors(nil, nil, apilifeflag.ErrNotFound)
+	config := lifeflag.Config{
+		Facade: newMockFacade(stub, life.Alive),
+		Entity: testEntity,
+		Result: never,
+	}
+
+	worker, err := lifeflag.New(config)
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(worker.Check(), jc.IsFalse)
+
+	err = workertest.CheckKilled(c, worker)
+	c.Check(err, gc.Equals, lifeflag.ErrNotFound)
+	checkCalls(c, stub, "Life", "Watch", "Life")
+}
+
+func (*WorkerSuite) TestLifeRandomError(c *gc.C) {
+	stub := &testing.Stub{}
+	stub.SetErrors(nil, nil, errors.New("rawr"))
+	config := lifeflag.Config{
+		Facade: newMockFacade(stub, life.Alive),
+		Entity: testEntity,
+		Result: never,
+	}
+
+	worker, err := lifeflag.New(config)
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(worker.Check(), jc.IsFalse)
+
+	err = workertest.CheckKilled(c, worker)
+	c.Check(err, gc.ErrorMatches, "rawr")
+	checkCalls(c, stub, "Life", "Watch", "Life")
+}
+
+func (*WorkerSuite) TestResultImmediateRealChange(c *gc.C) {
+	stub := &testing.Stub{}
+	config := lifeflag.Config{
+		Facade: newMockFacade(stub, life.Alive, life.Dead),
+		Entity: testEntity,
+		Result: life.IsNotAlive,
+	}
+
+	worker, err := lifeflag.New(config)
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(worker.Check(), jc.IsFalse)
+
+	err = workertest.CheckKilled(c, worker)
+	c.Check(err, gc.Equals, lifeflag.ErrValueChanged)
+	checkCalls(c, stub, "Life", "Watch", "Life")
+}
+
+func (*WorkerSuite) TestResultSubsequentRealChange(c *gc.C) {
+	stub := &testing.Stub{}
+	config := lifeflag.Config{
+		Facade: newMockFacade(stub, life.Dying, life.Dying, life.Dead),
+		Entity: testEntity,
+		Result: life.IsNotDead,
+	}
+	worker, err := lifeflag.New(config)
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(worker.Check(), jc.IsTrue)
+
+	err = workertest.CheckKilled(c, worker)
+	c.Check(err, gc.Equals, lifeflag.ErrValueChanged)
+	checkCalls(c, stub, "Life", "Watch", "Life", "Life")
+}
+
+func (*WorkerSuite) TestResultNoRealChange(c *gc.C) {
+	stub := &testing.Stub{}
+	config := lifeflag.Config{
+		Facade: newMockFacade(stub, life.Alive, life.Alive, life.Dying),
+		Entity: testEntity,
+		Result: life.IsNotDead,
+	}
+	worker, err := lifeflag.New(config)
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(worker.Check(), jc.IsTrue)
+
+	workertest.CheckAlive(c, worker)
+	workertest.CleanKill(c, worker)
+	checkCalls(c, stub, "Life", "Watch", "Life", "Life")
+}
+
+var testEntity = names.NewUnitTag("blah/123")
+
+func checkCalls(c *gc.C, stub *testing.Stub, names ...string) {
+	stub.CheckCallNames(c, names...)
+	for _, call := range stub.Calls() {
+		c.Check(call.Args, gc.DeepEquals, []interface{}{testEntity})
+	}
+}
+
+func explode(life.Value) bool { panic("unexpected") }
+func never(life.Value) bool   { return false }


### PR DESCRIPTION
...and independent representation of life values, for use in upcoming jujud/agent/model manifolds to simplify worker/modelworkermanager and model/undertaker implementation and plumbing

(Review request: http://reviews.vapour.ws/r/4142/)