### PR TITLE
cmd/jujud/reboot: fix LP 1556630

### DIFF
--- a/cmd/jujud/reboot/reboot.go
+++ b/cmd/jujud/reboot/reboot.go
@@ -24,19 +24,13 @@ var timeout = time.Duration(10 * time.Minute)
 var rebootAfter = 15
 
 func runCommand(args []string) error {
-	_, err := exec.Command(args[0], args[1:]...).Output()
-	if err != nil {
-		return errors.Trace(err)
-	}
-	return nil
+	err := exec.Command(args[0], args[1:]...).Run()
+	return errors.Trace(err)
 }
 
 var tmpFile = func() (*os.File, error) {
 	f, err := ioutil.TempFile(os.TempDir(), "juju-reboot")
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	return f, nil
+	return f, errors.Trace(err)
 }
 
 // Reboot implements the ExecuteReboot command which will reboot a machine
@@ -68,25 +62,20 @@ func NewRebootWaiter(apistate api.Connection, acfg agent.Config) (*Reboot, error
 // ExecuteReboot will wait for all running containers to stop, and then execute
 // a shutdown or a reboot (based on the action param)
 func (r *Reboot) ExecuteReboot(action params.RebootAction) error {
-	err := r.waitForContainersOrTimeout()
-	if err != nil {
+	if err := r.waitForContainersOrTimeout(); err != nil {
 		return errors.Trace(err)
 	}
 
-	err = scheduleAction(action, rebootAfter)
-	if err != nil {
+	if err := scheduleAction(action, rebootAfter); err != nil {
 		return errors.Trace(err)
 	}
 
-	err = r.st.ClearReboot()
-	if err != nil {
-		return errors.Trace(err)
-	}
-	return nil
+	err := r.st.ClearReboot()
+	return errors.Trace(err)
 }
 
 func (r *Reboot) runningContainers() ([]instance.Instance, error) {
-	runningInstances := []instance.Instance{}
+	var runningInstances []instance.Instance
 
 	for _, val := range instance.ContainerTypes {
 		managerConfig := container.ManagerConfig{container.ConfigName: container.DefaultNamespace}
@@ -96,15 +85,15 @@ func (r *Reboot) runningContainers() ([]instance.Instance, error) {
 		cfg := container.ManagerConfig(managerConfig)
 		manager, err := factory.NewContainerManager(val, cfg, nil)
 		if err != nil {
-			logger.Warningf("Failed to get manager for container type %v: %v", val, err)
-			continue
+			return nil, errors.Annotatef(err, "failed to get manager for container type %v", val)
 		}
 		if !manager.IsInitialized() {
+			logger.Infof("container type %q not supported", val)
 			continue
 		}
 		instances, err := manager.ListContainers()
 		if err != nil {
-			logger.Warningf("Failed to list containers: %v", err)
+			return nil, errors.Annotate(err, "failed to list containers")
 		}
 		runningInstances = append(runningInstances, instances...)
 	}
@@ -138,13 +127,12 @@ func (r *Reboot) waitForContainersOrTimeout() error {
 
 	select {
 	case <-time.After(timeout):
-
 		// Containers are still up after timeout. C'est la vie
-		logger.Infof("Timeout reached waiting for containers to shutdown")
 		quit <- true
+		return errors.New("Timeout reached waiting for containers to shutdown")
 	case err := <-c:
 		return errors.Trace(err)
-
+	default:
+		return nil
 	}
-	return nil
 }

--- a/cmd/jujud/reboot/reboot_test.go
+++ b/cmd/jujud/reboot/reboot_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/api"
-	// "github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/jujud/reboot"
 	jujutesting "github.com/juju/juju/juju/testing"
 	coretesting "github.com/juju/juju/testing"
@@ -37,7 +36,6 @@ type RebootSuite struct {
 var _ = gc.Suite(&RebootSuite{})
 
 func (s *RebootSuite) SetUpTest(c *gc.C) {
-	var err error
 	s.JujuConnSuite.SetUpTest(c)
 	testing.PatchExecutableAsEchoArgs(c, s, rebootBin)
 	s.PatchEnvironment("TEMP", c.MkDir())
@@ -50,7 +48,7 @@ func (s *RebootSuite) SetUpTest(c *gc.C) {
 	})
 
 	s.mgoInst.EnableAuth = true
-	err = s.mgoInst.Start(coretesting.Certs)
+	err := s.mgoInst.Start(coretesting.Certs)
 	c.Assert(err, jc.ErrorIsNil)
 
 	configParams := agent.AgentConfigParams{

--- a/worker/reboot/reboot.go
+++ b/worker/reboot/reboot.go
@@ -43,22 +43,17 @@ func NewReboot(st reboot.State, agentConfig agent.Config, machineLock *fslock.Lo
 	w, err := watcher.NewNotifyWorker(watcher.NotifyConfig{
 		Handler: r,
 	})
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	return w, nil
+	return w, errors.Trace(err)
 }
 
 func (r *Reboot) checkForRebootState() error {
-	var err error
 	if r.machineLock.IsLocked() == false {
 		return nil
 	}
 
 	if r.machineLock.Message() == RebootMessage {
 		// Not a lock held by the machne agent in order to reboot
-		err = r.machineLock.BreakLock()
-		if err != nil {
+		if err := r.machineLock.BreakLock(); err != nil {
 			return errors.Trace(err)
 		}
 	}
@@ -66,16 +61,11 @@ func (r *Reboot) checkForRebootState() error {
 }
 
 func (r *Reboot) SetUp() (watcher.NotifyWatcher, error) {
-	logger.Debugf("Reboot worker setup")
-	err := r.checkForRebootState()
-	if err != nil {
+	if err := r.checkForRebootState(); err != nil {
 		return nil, errors.Trace(err)
 	}
 	watcher, err := r.st.WatchForRebootEvent()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	return watcher, nil
+	return watcher, errors.Trace(err)
 }
 
 func (r *Reboot) Handle(_ <-chan struct{}) error {


### PR DESCRIPTION
Fixes LP 1556630

The code was skipping a lot of error conditions which the test code was
relying on to exit the test cleanly.

Also:

- reduce the failure timeouts for all tests below the 10m go test dead
  man switch
- tidy up error handling in general.

This reduced the run time on some of the tests from 3 and 5 seconds to
200ms each.

(Review request: http://reviews.vapour.ws/r/4144/)