### PR TITLE
lp1553272 - Update cmd help text

### DIFF
--- a/cmd/juju/action/action_test.go
+++ b/cmd/juju/action/action_test.go
@@ -28,14 +28,14 @@ func (s *ActionCommandSuite) TestHelp(c *gc.C) {
 	ctx, err := testing.RunCommand(c, s.command, "--help")
 	c.Assert(err, gc.IsNil)
 
-	expected := "(?s).*^usage: juju action \\[options\\] <command> .+"
+	expected := "(?s).*^Usage: juju action \\[options\\] <command> .+"
 	c.Check(testing.Stdout(ctx), gc.Matches, expected)
 
 	supercommand, ok := s.command.(*cmd.SuperCommand)
 	c.Check(ok, jc.IsTrue)
-	expected = "(?sm).*^purpose: " + supercommand.Purpose + "$.*"
+	expected = "(?sm).*^Summary:\n" + supercommand.Purpose + "$.*"
 	c.Check(testing.Stdout(ctx), gc.Matches, expected)
-	expected = "(?sm).*^" + supercommand.Doc + "$.*"
+	expected = "(?sm).*^Details:" + supercommand.Doc + "$.*"
 	c.Check(testing.Stdout(ctx), gc.Matches, expected)
 
 	// Check that we've properly registered all subcommands

--- a/cmd/juju/action/package_test.go
+++ b/cmd/juju/action/package_test.go
@@ -73,15 +73,15 @@ func (s *BaseActionSuite) checkHelp(c *gc.C, subcmd cmd.Command) {
 	ctx, err := coretesting.RunCommand(c, s.command, subcmd.Info().Name, "--help")
 	c.Assert(err, gc.IsNil)
 
-	expected := "(?sm).*^usage: juju action " +
+	expected := "(?sm).*^Usage: juju action " +
 		regexp.QuoteMeta(subcmd.Info().Name) +
 		` \[options\] ` + regexp.QuoteMeta(subcmd.Info().Args) + ".+"
 	c.Check(coretesting.Stdout(ctx), gc.Matches, expected)
 
-	expected = "(?sm).*^purpose: " + regexp.QuoteMeta(subcmd.Info().Purpose) + "$.*"
+	expected = "(?sm).*^Summary:\n" + regexp.QuoteMeta(subcmd.Info().Purpose) + "$.*"
 	c.Check(coretesting.Stdout(ctx), gc.Matches, expected)
 
-	expected = "(?sm).*^" + regexp.QuoteMeta(subcmd.Info().Doc) + "$.*"
+	expected = "(?sm).*^Details:" + regexp.QuoteMeta(subcmd.Info().Doc) + "$.*"
 	c.Check(coretesting.Stdout(ctx), gc.Matches, expected)
 }
 

--- a/cmd/juju/backups/package_test.go
+++ b/cmd/juju/backups/package_test.go
@@ -80,20 +80,20 @@ func (s *BaseBackupsSuite) checkHelp(c *gc.C, subcmd cmd.Command) {
 
 	var expected string
 	if subcmd.Info().Args != "" {
-		expected = "(?sm).*^usage: juju backups " +
+		expected = "(?sm).*^Usage: juju backups " +
 			regexp.QuoteMeta(subcmd.Info().Name) +
 			` \[options\] ` + regexp.QuoteMeta(subcmd.Info().Args) + ".+"
 	} else {
-		expected = "(?sm).*^usage: juju backups " +
+		expected = "(?sm).*^Usage: juju backups " +
 			regexp.QuoteMeta(subcmd.Info().Name) +
 			` \[options\].+`
 	}
 	c.Check(jujutesting.Stdout(ctx), gc.Matches, expected)
 
-	expected = "(?sm).*^purpose: " + regexp.QuoteMeta(subcmd.Info().Purpose) + "$.*"
+	expected = "(?sm).*^Summary:\n" + regexp.QuoteMeta(subcmd.Info().Purpose) + "$.*"
 	c.Check(jujutesting.Stdout(ctx), gc.Matches, expected)
 
-	expected = "(?sm).*^" + regexp.QuoteMeta(subcmd.Info().Doc) + "$.*"
+	expected = "(?sm).*^Details:" + regexp.QuoteMeta(subcmd.Info().Doc) + "$.*"
 	c.Check(jujutesting.Stdout(ctx), gc.Matches, expected)
 }
 

--- a/cmd/juju/commands/helptool_test.go
+++ b/cmd/juju/commands/helptool_test.go
@@ -21,8 +21,10 @@ var _ = gc.Suite(&HelpToolSuite{})
 
 func (suite *HelpToolSuite) TestHelpToolHelp(c *gc.C) {
 	output := badrun(c, 0, "help", "help-tool")
-	c.Assert(output, gc.Equals, `usage: juju help-tool [tool]
-purpose: show help on a juju charm tool
+	c.Assert(output, gc.Equals, `Usage: juju help-tool [tool]
+
+Summary:
+show help on a juju charm tool
 `)
 }
 
@@ -48,11 +50,15 @@ func (suite *HelpToolSuite) TestHelpToolName(c *gc.C) {
 	} else {
 		output = badrun(c, 0, "help-tool", "relation-get")
 	}
-	expectedHelp := `usage: relation-get \[options\] <key> <unit id>
-purpose: get relation settings
+	expectedHelp := `Usage: relation-get \[options\] <key> <unit id>
 
-options:
+Summary:
+get relation settings
+
+Options:
 (.|\n)*
+
+Details:
 relation-get prints the value(.|\n)*`
 	c.Assert(output, gc.Matches, expectedHelp)
 }

--- a/cmd/juju/commands/sshkeys_test.go
+++ b/cmd/juju/commands/sshkeys_test.go
@@ -29,7 +29,7 @@ func (s *SSHKeysSuite) assertHelpOutput(c *gc.C, cmd, args string) {
 	if args != "" {
 		args = " " + args
 	}
-	expected := fmt.Sprintf("usage: juju %s [options]%s", cmd, args)
+	expected := fmt.Sprintf("Usage: juju %s [options]%s", cmd, args)
 	out := badrun(c, 0, cmd, "--help")
 	lines := strings.Split(out, "\n")
 	c.Assert(lines[0], gc.Equals, expected)

--- a/cmd/juju/space/package_test.go
+++ b/cmd/juju/space/package_test.go
@@ -133,20 +133,20 @@ func (s *BaseSpaceSuite) TestHelp(c *gc.C) {
 	if s.command != nil {
 		// Subcommands embed ModelCommandBase
 		cmdInfo = s.command.Info()
-		expected = "(?sm).*^usage: juju space " +
+		expected = "(?sm).*^Usage: juju space " +
 			regexp.QuoteMeta(cmdInfo.Name) +
 			`( \[options\])? ` + regexp.QuoteMeta(cmdInfo.Args) + ".+"
 	} else {
-		expected = "(?sm).*^usage: juju space" +
+		expected = "(?sm).*^Usage: juju space" +
 			`( \[options\])? ` + regexp.QuoteMeta(cmdInfo.Args) + ".+"
 	}
 	c.Check(cmdInfo, gc.NotNil)
 	c.Check(stderr, gc.Matches, expected)
 
-	expected = "(?sm).*^purpose: " + regexp.QuoteMeta(cmdInfo.Purpose) + "$.*"
+	expected = "(?sm).*^Summary:\n" + regexp.QuoteMeta(cmdInfo.Purpose) + "$.*"
 	c.Check(stderr, gc.Matches, expected)
 
-	expected = "(?sm).*^" + regexp.QuoteMeta(cmdInfo.Doc) + "$.*"
+	expected = "(?sm).*^Details:\n" + regexp.QuoteMeta(cmdInfo.Doc) + "$.*"
 	c.Check(stderr, gc.Matches, expected)
 }
 

--- a/cmd/juju/storage/help_test.go
+++ b/cmd/juju/storage/help_test.go
@@ -33,9 +33,9 @@ func (s *HelpStorageSuite) assertHelp(c *gc.C, expectedNames []string) {
 
 	super, ok := s.command.(*cmd.SuperCommand)
 	c.Assert(ok, jc.IsTrue)
-	expected := "(?sm).*^purpose: " + super.Purpose + "$.*"
+	expected := "(?sm).*^Summary:\n" + super.Purpose + "$.*"
 	c.Check(testing.Stdout(ctx), gc.Matches, expected)
-	expected = "(?sm).*^" + super.Doc + "$.*"
+	expected = "(?sm).*^Details:" + super.Doc + "$.*"
 	c.Check(testing.Stdout(ctx), gc.Matches, expected)
 
 	s.checkHelpCommands(c, ctx, expectedNames)

--- a/cmd/juju/subnet/package_test.go
+++ b/cmd/juju/subnet/package_test.go
@@ -125,20 +125,20 @@ func (s *BaseSubnetSuite) TestHelp(c *gc.C) {
 		// Subcommands embed ModelCommandBase and have an extra
 		// "[options]" prepended before the args.
 		cmdInfo = s.command.Info()
-		expected = "(?sm).*^usage: juju subnet " +
+		expected = "(?sm).*^Usage: juju subnet " +
 			regexp.QuoteMeta(cmdInfo.Name) +
 			`( \[options\])? ` + regexp.QuoteMeta(cmdInfo.Args) + ".+"
 	} else {
-		expected = "(?sm).*^usage: juju subnet" +
+		expected = "(?sm).*^Usage: juju subnet" +
 			`( \[options\])? ` + regexp.QuoteMeta(cmdInfo.Args) + ".+"
 	}
 	c.Check(cmdInfo, gc.NotNil)
 	c.Check(stderr, gc.Matches, expected)
 
-	expected = "(?sm).*^purpose: " + regexp.QuoteMeta(cmdInfo.Purpose) + "$.*"
+	expected = "(?sm).*^Summary:\n" + regexp.QuoteMeta(cmdInfo.Purpose) + "$.*"
 	c.Check(stderr, gc.Matches, expected)
 
-	expected = "(?sm).*^" + regexp.QuoteMeta(cmdInfo.Doc) + "$.*"
+	expected = "(?sm).*^Details:\n" + regexp.QuoteMeta(cmdInfo.Doc) + "$.*"
 	c.Check(stderr, gc.Matches, expected)
 }
 

--- a/cmd/jujud/main_test.go
+++ b/cmd/jujud/main_test.go
@@ -131,13 +131,16 @@ type RemoteCommand struct {
 	msg string
 }
 
-var expectUsage = `usage: remote [options]
-purpose: test jujuc
+var expectUsage = `Usage: remote [options]
 
-options:
+Summary:
+test jujuc
+
+Options:
 --error (= "")
     if set, fail
 
+Details:
 here is some documentation
 `
 

--- a/cmd/plugins/juju-metadata/metadataplugin_test.go
+++ b/cmd/plugins/juju-metadata/metadataplugin_test.go
@@ -103,7 +103,7 @@ func (s *MetadataSuite) TestHelpCommands(c *gc.C) {
 }
 
 func (s *MetadataSuite) assertHelpOutput(c *gc.C, cmd string) {
-	expected := fmt.Sprintf("usage: juju metadata %s [options]", cmd)
+	expected := fmt.Sprintf("Usage: juju metadata %s [options]", cmd)
 	out := badrun(c, 0, cmd, "--help")
 	lines := strings.Split(out, "\n")
 	c.Assert(lines[0], gc.Equals, expected)

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -15,7 +15,7 @@ github.com/joyent/gosdc	git	2f11feadd2d9891e92296a1077c3e2e56939547d	2014-05-24T
 github.com/joyent/gosign	git	0da0d5f1342065321c97812b1f4ac0c2b0bab56c	2014-05-24T00:07:34Z
 github.com/juju/blobstore	git	06056004b3d7b54bbb7984d830c537bad00fec21	2015-07-29T11:18:58Z
 github.com/juju/bundlechanges	git	ad533f529b3b4a8bb2b76bf6213f1ef6b68df392	2016-01-06T16:13:59Z
-github.com/juju/cmd	git	33554d631f79b840d76673665b292215882ba90a	2015-10-28T03:05:29Z
+github.com/juju/cmd	git	fe220bad5ff6a2bb461b615da5e783762e97e49f	2016-03-08T16:06:58Z
 github.com/juju/errors	git	1b5e39b83d1835fa480e0c2ddefb040ee82d58b3	2015-09-16T12:56:42Z
 github.com/juju/go4	git	40d72ab9641a2a8c36a9c46a51e28367115c8e59	2016-02-22T16:32:58Z
 github.com/juju/gojsonpointer	git	afe8b77aa08f272b49e01b82de78510c11f61500	2015-02-04T19:46:29Z

--- a/payload/context/status-set_test.go
+++ b/payload/context/status-set_test.go
@@ -61,9 +61,12 @@ func (s *statusSetSuite) TestHelp(c *gc.C) {
 	c.Assert(code, gc.Equals, 0)
 
 	c.Check(s.ctx.Stdout.(*bytes.Buffer).String(), gc.Equals, `
-usage: payload-status-set <class> <id> <status>
-purpose: update the status of a payload
+Usage: payload-status-set <class> <id> <status>
 
+Summary:
+update the status of a payload
+
+Details:
 "payload-status-set" is used to update the current status of a registered payload.
 The <class> and <id> provided must match a payload that has been previously
 registered with juju using payload-register. The <status> must be one of the

--- a/payload/context/unregister_test.go
+++ b/payload/context/unregister_test.go
@@ -51,9 +51,12 @@ func (s *unregisterSuite) TestHelp(c *gc.C) {
 	c.Assert(code, gc.Equals, 0)
 
 	c.Check(s.ctx.Stdout.(*bytes.Buffer).String(), gc.Equals, `
-usage: payload-unregister <class> <id>
-purpose: stop tracking a payload
+Usage: payload-unregister <class> <id>
 
+Summary:
+stop tracking a payload
+
+Details:
 "payload-unregister" is used while a hook is running to let Juju know
 that a payload has been manually stopped. The <class> and <id> provided
 must match a payload that has been previously registered with juju using

--- a/worker/uniter/runner/jujuc/action-fail_test.go
+++ b/worker/uniter/runner/jujuc/action-fail_test.go
@@ -105,9 +105,12 @@ func (s *ActionFailSuite) TestHelp(c *gc.C) {
 	ctx := testing.Context(c)
 	code := cmd.Main(com, ctx, []string{"--help"})
 	c.Assert(code, gc.Equals, 0)
-	c.Assert(bufferString(ctx.Stdout), gc.Equals, `usage: action-fail ["<failure message>"]
-purpose: set action fail status with message
+	c.Assert(bufferString(ctx.Stdout), gc.Equals, `Usage: action-fail ["<failure message>"]
 
+Summary:
+set action fail status with message
+
+Details:
 action-fail sets the action's fail state with a given error message.  Using
 action-fail without a failure message will set a default message indicating a
 problem with the action.

--- a/worker/uniter/runner/jujuc/action-get_test.go
+++ b/worker/uniter/runner/jujuc/action-get_test.go
@@ -274,15 +274,18 @@ func (s *ActionGetSuite) TestHelp(c *gc.C) {
 	ctx := testing.Context(c)
 	code := cmd.Main(com, ctx, []string{"--help"})
 	c.Assert(code, gc.Equals, 0)
-	c.Assert(bufferString(ctx.Stdout), gc.Equals, `usage: action-get [options] [<key>[.<key>.<key>...]]
-purpose: get action parameters
+	c.Assert(bufferString(ctx.Stdout), gc.Equals, `Usage: action-get [options] [<key>[.<key>.<key>...]]
 
-options:
+Summary:
+get action parameters
+
+Options:
 --format  (= smart)
     specify output format (json|smart|yaml)
 -o, --output (= "")
     specify an output file
 
+Details:
 action-get will print the value of the parameter at the given key, serialized
 as YAML.  If multiple keys are passed, action-get will recurse into the param
 map as needed.

--- a/worker/uniter/runner/jujuc/action-set_test.go
+++ b/worker/uniter/runner/jujuc/action-set_test.go
@@ -143,9 +143,12 @@ func (s *ActionSetSuite) TestHelp(c *gc.C) {
 	ctx := testing.Context(c)
 	code := cmd.Main(com, ctx, []string{"--help"})
 	c.Assert(code, gc.Equals, 0)
-	c.Assert(bufferString(ctx.Stdout), gc.Equals, `usage: action-set <key>=<value> [<key>=<value> ...]
-purpose: set action results
+	c.Assert(bufferString(ctx.Stdout), gc.Equals, `Usage: action-set <key>=<value> [<key>=<value> ...]
 
+Summary:
+set action results
+
+Details:
 action-set adds the given values to the results map of the Action.  This map
 is returned to the user after the completion of the Action.  Keys must start
 and end with lowercase alphanumeric, and contain only lowercase alphanumeric,

--- a/worker/uniter/runner/jujuc/add-metric_test.go
+++ b/worker/uniter/runner/jujuc/add-metric_test.go
@@ -29,8 +29,10 @@ func (s *AddMetricSuite) TestHelp(c *gc.C) {
 	code := cmd.Main(com, ctx, []string{"--help"})
 	c.Assert(code, gc.Equals, 0)
 	c.Assert(bufferString(ctx.Stdout), gc.Equals, `
-usage: add-metric key1=value1 [key2=value2 ...]
-purpose: send metrics
+Usage: add-metric key1=value1 [key2=value2 ...]
+
+Summary:
+send metrics
 `[1:])
 	c.Assert(bufferString(ctx.Stderr), gc.Equals, "")
 }

--- a/worker/uniter/runner/jujuc/config-get_test.go
+++ b/worker/uniter/runner/jujuc/config-get_test.go
@@ -130,10 +130,12 @@ func (s *ConfigGetSuite) TestHelp(c *gc.C) {
 	ctx := testing.Context(c)
 	code := cmd.Main(com, ctx, []string{"--help"})
 	c.Assert(code, gc.Equals, 0)
-	c.Assert(bufferString(ctx.Stdout), gc.Equals, `usage: config-get [options] [<key>]
-purpose: print service configuration
+	c.Assert(bufferString(ctx.Stdout), gc.Equals, `Usage: config-get [options] [<key>]
 
-options:
+Summary:
+print service configuration
+
+Options:
 -a, --all  (= false)
     print all keys
 --format  (= smart)
@@ -141,6 +143,7 @@ options:
 -o, --output (= "")
     specify an output file
 
+Details:
 When no <key> is supplied, all keys with values or defaults are printed. If
 --all is set, all known keys are printed; those without defaults or values are
 reported as null. <key> and --all are mutually exclusive.

--- a/worker/uniter/runner/jujuc/network-get_test.go
+++ b/worker/uniter/runner/jujuc/network-get_test.go
@@ -101,10 +101,12 @@ func (s *NetworkGetSuite) TestNetworkGet(c *gc.C) {
 func (s *NetworkGetSuite) TestHelp(c *gc.C) {
 
 	var helpTemplate = `
-usage: network-get [options] --primary-address
-purpose: get network config
+Usage: network-get [options] --primary-address
 
-options:
+Summary:
+get network config
+
+Options:
 --format  (= smart)
     specify output format (json|smart|yaml)
 -o, --output (= "")
@@ -114,6 +116,7 @@ options:
 -r, --relation  (= %s)
     specify a relation by id
 
+Details:
 network-get returns the network config for a relation. The only supported
 flag for now is --primary-address, which is required and returns the IP
 address the local unit should advertise as its endpoint to its peers.

--- a/worker/uniter/runner/jujuc/opened-ports_test.go
+++ b/worker/uniter/runner/jujuc/opened-ports_test.go
@@ -72,9 +72,12 @@ func (s *OpenedPortsSuite) TestHelp(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	flags := testing.NewFlagSet()
 	c.Assert(string(openedPorts.Info().Help(flags)), gc.Equals, `
-usage: opened-ports
-purpose: lists all ports or ranges opened by the unit
+Usage: opened-ports
 
+Summary:
+lists all ports or ranges opened by the unit
+
+Details:
 Each list entry has format <port>/<protocol> (e.g. "80/tcp") or
 <from>-<to>/<protocol> (e.g. "8080-8088/udp").
 `[1:])

--- a/worker/uniter/runner/jujuc/ports_test.go
+++ b/worker/uniter/runner/jujuc/ports_test.go
@@ -119,17 +119,22 @@ func (s *PortsSuite) TestHelp(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	flags := testing.NewFlagSet()
 	c.Assert(string(open.Info().Help(flags)), gc.Equals, `
-usage: open-port <port>[/<protocol>] or <from>-<to>[/<protocol>]
-purpose: register a port or range to open
+Usage: open-port <port>[/<protocol>] or <from>-<to>[/<protocol>]
 
+Summary:
+register a port or range to open
+
+Details:
 The port range will only be open while the service is exposed.
 `[1:])
 
 	close, err := jujuc.NewCommand(hctx, cmdString("close-port"))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(close.Info().Help(flags)), gc.Equals, `
-usage: close-port <port>[/<protocol>] or <from>-<to>[/<protocol>]
-purpose: ensure a port or range is always closed
+Usage: close-port <port>[/<protocol>] or <from>-<to>[/<protocol>]
+
+Summary:
+ensure a port or range is always closed
 `[1:])
 }
 

--- a/worker/uniter/runner/jujuc/relation-get_test.go
+++ b/worker/uniter/runner/jujuc/relation-get_test.go
@@ -216,10 +216,12 @@ func (s *RelationGetSuite) TestRelationGetFormat(c *gc.C) {
 }
 
 var helpTemplate = `
-usage: %s
-purpose: get relation settings
+Usage: %s
 
-options:
+Summary:
+get relation settings
+
+Options:
 --format  (= smart)
     specify output format (json|smart|yaml)
 -o, --output (= "")
@@ -227,6 +229,7 @@ options:
 -r, --relation  (= %s)
     specify a relation by id
 
+Details:
 relation-get prints the value of a unit's relation setting, specified by key.
 If no key is given, or if the key is "-", all keys and values will be printed.
 %s`[1:]

--- a/worker/uniter/runner/jujuc/relation-ids_test.go
+++ b/worker/uniter/runner/jujuc/relation-ids_test.go
@@ -125,10 +125,12 @@ func (s *RelationIdsSuite) TestRelationIds(c *gc.C) {
 
 func (s *RelationIdsSuite) TestHelp(c *gc.C) {
 	template := `
-usage: %s
-purpose: list all relation ids with the given relation name
+Usage: %s
 
-options:
+Summary:
+list all relation ids with the given relation name
+
+Options:
 --format  (= smart)
     specify output format (json|smart|yaml)
 -o, --output (= "")
@@ -139,8 +141,8 @@ options:
 		usage, doc string
 	}{
 		-1: {"relation-ids [options] <name>", ""},
-		0:  {"relation-ids [options] [<name>]", "\nCurrent default relation name is \"x\".\n"},
-		3:  {"relation-ids [options] [<name>]", "\nCurrent default relation name is \"y\".\n"},
+		0:  {"relation-ids [options] [<name>]", "\nDetails:\nCurrent default relation name is \"x\".\n"},
+		3:  {"relation-ids [options] [<name>]", "\nDetails:\nCurrent default relation name is \"y\".\n"},
 	} {
 		c.Logf("relid %d", relid)
 		hctx, _ := s.newHookContext(relid, "")

--- a/worker/uniter/runner/jujuc/relation-list_test.go
+++ b/worker/uniter/runner/jujuc/relation-list_test.go
@@ -137,10 +137,12 @@ func (s *RelationListSuite) TestRelationList(c *gc.C) {
 
 func (s *RelationListSuite) TestRelationListHelp(c *gc.C) {
 	template := `
-usage: relation-list [options]
-purpose: list relation units
+Usage: relation-list [options]
 
-options:
+Summary:
+list relation units
+
+Options:
 --format  (= smart)
     specify output format (json|smart|yaml)
 -o, --output (= "")
@@ -152,7 +154,7 @@ options:
 	for relid, t := range map[int]struct {
 		usage, doc string
 	}{
-		-1: {"", "\n-r must be specified when not in a relation hook\n"},
+		-1: {"", "\nDetails:\n-r must be specified when not in a relation hook\n"},
 		0:  {"peer0:0", ""},
 	} {
 		c.Logf("test relid %d", relid)

--- a/worker/uniter/runner/jujuc/relation-set_test.go
+++ b/worker/uniter/runner/jujuc/relation-set_test.go
@@ -40,10 +40,12 @@ func (s *RelationSetSuite) TestHelp(c *gc.C) {
 		code := cmd.Main(com, ctx, []string{"--help"})
 		c.Assert(code, gc.Equals, 0)
 		c.Assert(bufferString(ctx.Stdout), gc.Equals, fmt.Sprintf(`
-usage: relation-set [options] key=value [key=value ...]
-purpose: set relation settings
+Usage: relation-set [options] key=value [key=value ...]
 
-options:
+Summary:
+set relation settings
+
+Options:
 --file  (= )
     file containing key-value pairs
 --format (= "")
@@ -51,6 +53,7 @@ options:
 -r, --relation  (= %s)
     specify a relation by id
 
+Details:
 "relation-set" writes the local unit's settings for some relation.
 If no relation is specified then the current relation is used. The
 setting values are not inspected and are stored as strings. Setting

--- a/worker/uniter/runner/jujuc/status-get_test.go
+++ b/worker/uniter/runner/jujuc/status-get_test.go
@@ -104,10 +104,12 @@ func (s *statusGetSuite) TestHelp(c *gc.C) {
 	code := cmd.Main(com, ctx, []string{"--help"})
 	c.Assert(code, gc.Equals, 0)
 	expectedHelp := "" +
-		"usage: status-get [options] [--include-data] [--service]\n" +
-		"purpose: print status information\n" +
+		"Usage: status-get [options] [--include-data] [--service]\n" +
 		"\n" +
-		"options:\n" +
+		"Summary:\n" +
+		"print status information\n" +
+		"\n" +
+		"Options:\n" +
 		"--format  (= smart)\n" +
 		"    specify output format (json|smart|yaml)\n" +
 		"--include-data  (= false)\n" +
@@ -117,6 +119,7 @@ func (s *statusGetSuite) TestHelp(c *gc.C) {
 		"--service  (= false)\n" +
 		"    print status for all units of this service if this unit is the leader\n" +
 		"\n" +
+		"Details:\n" +
 		"By default, only the status value is printed.\n" +
 		"If the --include-data flag is passed, the associated data are printed also.\n"
 

--- a/worker/uniter/runner/jujuc/status-set_test.go
+++ b/worker/uniter/runner/jujuc/status-set_test.go
@@ -52,13 +52,16 @@ func (s *statusSetSuite) TestHelp(c *gc.C) {
 	code := cmd.Main(com, ctx, []string{"--help"})
 	c.Assert(code, gc.Equals, 0)
 	expectedHelp := "" +
-		"usage: status-set [options] <maintenance | blocked | waiting | active> [message]\n" +
-		"purpose: set status information\n" +
+		"Usage: status-set [options] <maintenance | blocked | waiting | active> [message]\n" +
 		"\n" +
-		"options:\n" +
+		"Summary:\n" +
+		"set status information\n" +
+		"\n" +
+		"Options:\n" +
 		"--service  (= false)\n" +
 		"    set this status for the service to which the unit belongs if the unit is the leader\n" +
 		"\n" +
+		"Details:\n" +
 		"Sets the workload status of the charm. Message is optional.\n" +
 		"The \"last updated\" attribute of the status is set, even if the\n" +
 		"status and message are the same as what's already set.\n"

--- a/worker/uniter/runner/jujuc/storage-add.go
+++ b/worker/uniter/runner/jujuc/storage-add.go
@@ -30,7 +30,7 @@ and optional storage COUNT.
 
 COUNT is a positive integer indicating how many instances
 of the storage to create. If unspecified, COUNT defaults to 1.
-`
+`[1:]
 
 func (s *StorageAddCommand) Info() *cmd.Info {
 	return &cmd.Info{

--- a/worker/uniter/runner/jujuc/storage-add_test.go
+++ b/worker/uniter/runner/jujuc/storage-add_test.go
@@ -36,8 +36,12 @@ func (s *storageAddSuite) TestHelp(c *gc.C) {
 	code := cmd.Main(com, ctx, []string{"--help"})
 	c.Assert(code, gc.Equals, 0)
 	help := `
-usage: storage-add <charm storage name>[=count] ...
-purpose: add storage instances
+Usage: storage-add <charm storage name>[=count] ...
+
+Summary:
+add storage instances
+
+Details:
 `[1:] +
 		jujuc.StorageAddDoc
 	s.assertOutput(c, ctx, help, "")

--- a/worker/uniter/runner/jujuc/storage-get_test.go
+++ b/worker/uniter/runner/jujuc/storage-get_test.go
@@ -68,10 +68,12 @@ func (s *storageGetSuite) TestHelp(c *gc.C) {
 	ctx := testing.Context(c)
 	code := cmd.Main(com, ctx, []string{"--help"})
 	c.Assert(code, gc.Equals, 0)
-	c.Assert(bufferString(ctx.Stdout), gc.Equals, `usage: storage-get [options] [<key>]
-purpose: print information for storage instance with specified id
+	c.Assert(bufferString(ctx.Stdout), gc.Equals, `Usage: storage-get [options] [<key>]
 
-options:
+Summary:
+print information for storage instance with specified id
+
+Options:
 --format  (= smart)
     specify output format (json|smart|yaml)
 -o, --output (= "")
@@ -79,6 +81,7 @@ options:
 -s  (= data/0)
     specify a storage instance by id
 
+Details:
 When no <key> is supplied, all keys values are printed.
 `)
 	c.Assert(bufferString(ctx.Stderr), gc.Equals, "")

--- a/worker/uniter/runner/jujuc/storage-list_test.go
+++ b/worker/uniter/runner/jujuc/storage-list_test.go
@@ -105,15 +105,18 @@ func (s *storageListSuite) TestHelp(c *gc.C) {
 	ctx := testing.Context(c)
 	code := cmd.Main(com, ctx, []string{"--help"})
 	c.Assert(code, gc.Equals, 0)
-	c.Assert(bufferString(ctx.Stdout), gc.Equals, `usage: storage-list [options] [<storage-name>]
-purpose: list storage attached to the unit
+	c.Assert(bufferString(ctx.Stdout), gc.Equals, `Usage: storage-list [options] [<storage-name>]
 
-options:
+Summary:
+list storage attached to the unit
+
+Options:
 --format  (= smart)
     specify output format (json|smart|yaml)
 -o, --output (= "")
     specify an output file
 
+Details:
 storage-list will list the names of all storage instances
 attached to the unit. These names can be passed to storage-get
 via the "-s" flag to query the storage attributes.

--- a/worker/uniter/runner/jujuc/unit-get_test.go
+++ b/worker/uniter/runner/jujuc/unit-get_test.go
@@ -57,10 +57,12 @@ func (s *UnitGetSuite) TestHelp(c *gc.C) {
 	ctx := testing.Context(c)
 	code := cmd.Main(com, ctx, []string{"--help"})
 	c.Assert(code, gc.Equals, 0)
-	c.Assert(bufferString(ctx.Stdout), gc.Equals, `usage: unit-get [options] <setting>
-purpose: print public-address or private-address
+	c.Assert(bufferString(ctx.Stdout), gc.Equals, `Usage: unit-get [options] <setting>
 
-options:
+Summary:
+print public-address or private-address
+
+Options:
 --format  (= smart)
     specify output format (json|smart|yaml)
 -o, --output (= "")


### PR DESCRIPTION
Update dependencies.tsv to pull in updated juju/cmd to improve help text formatting.

This PR also updates any help text tests to use the new format.

(Review request: http://reviews.vapour.ws/r/4145/)