### PR TITLE
container/lxc: hard code loop device manager

### DIFF
--- a/container/factory/factory.go
+++ b/container/factory/factory.go
@@ -13,7 +13,6 @@ import (
 	"github.com/juju/juju/container/lxc"
 	"github.com/juju/juju/container/lxd"
 	"github.com/juju/juju/instance"
-	"github.com/juju/juju/storage/looputil"
 )
 
 // NewContainerManager creates the appropriate container.Manager for the
@@ -21,7 +20,7 @@ import (
 func NewContainerManager(forType instance.ContainerType, conf container.ManagerConfig, imageURLGetter container.ImageURLGetter) (container.Manager, error) {
 	switch forType {
 	case instance.LXC:
-		return lxc.NewContainerManager(conf, imageURLGetter, looputil.NewLoopDeviceManager())
+		return lxc.NewContainerManager(conf, imageURLGetter)
 	case instance.LXD:
 		return lxd.NewContainerManager(conf)
 	case instance.KVM:

--- a/container/lxc/export_test.go
+++ b/container/lxc/export_test.go
@@ -8,17 +8,18 @@ import (
 )
 
 var (
-	ContainerConfigFilename = containerConfigFilename
-	ContainerDirFilesystem  = containerDirFilesystem
-	GenerateNetworkConfig   = generateNetworkConfig
-	ParseConfigLine         = parseConfigLine
-	UpdateContainerConfig   = updateContainerConfig
-	ReorderNetworkConfig    = reorderNetworkConfig
-	NetworkConfigTemplate   = networkConfigTemplate
-	RestartSymlink          = restartSymlink
-	ReleaseVersion          = &releaseVersion
-	PreferFastLXC           = preferFastLXC
-	WriteWgetTmpFile        = &writeWgetTmpFile
+	ContainerConfigFilename    = containerConfigFilename
+	ContainerDirFilesystem     = containerDirFilesystem
+	GenerateNetworkConfig      = generateNetworkConfig
+	ParseConfigLine            = parseConfigLine
+	UpdateContainerConfig      = updateContainerConfig
+	ReorderNetworkConfig       = reorderNetworkConfig
+	NetworkConfigTemplate      = networkConfigTemplate
+	RestartSymlink             = restartSymlink
+	ReleaseVersion             = &releaseVersion
+	PreferFastLXC              = preferFastLXC
+	WriteWgetTmpFile           = &writeWgetTmpFile
+	NewContainerManagerForTest = newContainerManager
 )
 
 func GetCreateWithCloneValue(mgr container.Manager) bool {

--- a/container/lxc/lxc.go
+++ b/container/lxc/lxc.go
@@ -91,13 +91,14 @@ type containerManager struct {
 	loopDeviceManager looputil.LoopDeviceManager
 }
 
-// containerManager implements container.Manager.
-var _ container.Manager = (*containerManager)(nil)
-
 // NewContainerManager returns a manager object that can start and
 // stop lxc containers. The containers that are created are namespaced
 // by the name parameter inside the given ManagerConfig.
-func NewContainerManager(
+func NewContainerManager(conf container.ManagerConfig, imageURLGetter container.ImageURLGetter) (container.Manager, error) {
+	return newContainerManager(conf, imageURLGetter, looputil.NewLoopDeviceManager())
+}
+
+func newContainerManager(
 	conf container.ManagerConfig,
 	imageURLGetter container.ImageURLGetter,
 	loopDeviceManager looputil.LoopDeviceManager,

--- a/container/lxc/lxc_test.go
+++ b/container/lxc/lxc_test.go
@@ -159,7 +159,7 @@ func (s *LxcSuite) TestContainerManagerLXCClone(c *gc.C) {
 		mgr, err := lxc.NewContainerManager(container.ManagerConfig{
 			container.ConfigName: "juju",
 			"use-clone":          test.useClone,
-		}, &containertesting.MockURLGetter{}, nil)
+		}, &containertesting.MockURLGetter{})
 		c.Assert(err, jc.ErrorIsNil)
 		c.Check(lxc.GetCreateWithCloneValue(mgr), gc.Equals, test.expectClone)
 	}
@@ -600,7 +600,7 @@ func (s *LxcSuite) makeManager(c *gc.C, name string) container.Manager {
 	if s.useAUFS {
 		params["use-aufs"] = "true"
 	}
-	manager, err := lxc.NewContainerManager(
+	manager, err := lxc.NewContainerManagerForTest(
 		params, &containertesting.MockURLGetter{},
 		&s.loopDeviceManager,
 	)
@@ -612,7 +612,7 @@ func (*LxcSuite) TestManagerWarnsAboutUnknownOption(c *gc.C) {
 	_, err := lxc.NewContainerManager(container.ManagerConfig{
 		container.ConfigName: "BillyBatson",
 		"shazam":             "Captain Marvel",
-	}, &containertesting.MockURLGetter{}, nil)
+	}, &containertesting.MockURLGetter{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(c.GetTestLog(), jc.Contains, `WARNING juju.container unused config option: "shazam" -> "Captain Marvel"`)
 }

--- a/provider/ec2/credentials_test.go
+++ b/provider/ec2/credentials_test.go
@@ -4,6 +4,7 @@
 package ec2_test
 
 import (
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -17,7 +18,6 @@ import (
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs"
 	envtesting "github.com/juju/juju/environs/testing"
-	"io/ioutil"
 )
 
 type credentialsSuite struct {

--- a/worker/provisioner/lxc-broker.go
+++ b/worker/provisioner/lxc-broker.go
@@ -28,7 +28,6 @@ import (
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/network"
-	"github.com/juju/juju/storage/looputil"
 	"github.com/juju/juju/tools"
 	"github.com/juju/juju/version"
 )
@@ -49,8 +48,7 @@ var _ APICalls = (*apiprovisioner.State)(nil)
 // Override for testing.
 var NewLxcBroker = newLxcBroker
 
-func newLxcBroker(
-	api APICalls,
+func newLxcBroker(api APICalls,
 	agentConfig agent.Config,
 	managerConfig container.ManagerConfig,
 	imageURLGetter container.ImageURLGetter,
@@ -58,11 +56,9 @@ func newLxcBroker(
 	defaultMTU int,
 ) (environs.InstanceBroker, error) {
 	namespace := maybeGetManagerConfigNamespaces(managerConfig)
-	manager, err := lxc.NewContainerManager(
-		managerConfig, imageURLGetter, looputil.NewLoopDeviceManager(),
-	)
+	manager, err := lxc.NewContainerManager(managerConfig, imageURLGetter)
 	if err != nil {
-		return nil, err
+		return nil, errors.Trace(err)
 	}
 	return &lxcBroker{
 		manager:     manager,


### PR DESCRIPTION
lxx.NewContainerManager requires a loop device manager. This parameter
is not documented, and there is no check to ensure that it is not nil.
There is only one caller of this method, inside container/factory which
always passes a valid value. This parameter tf. is only used for testing.

This change hard codes the parameter unconditionally passed in via the
the container factory and adds a new test scoped method to alter the
loopback manager for testing.

(Review request: http://reviews.vapour.ws/r/4146/)