### PR TITLE
cmd/juju/agent: Hard code loop manager

### DIFF
--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -257,7 +257,6 @@ func (a *machineAgentCmd) Info() *cmd.Info {
 func MachineAgentFactoryFn(
 	agentConfWriter AgentConfigWriter,
 	bufferedLogs logsender.LogRecordCh,
-	loopDeviceManager looputil.LoopDeviceManager,
 	rootDir string,
 ) func(string) *MachineAgent {
 	return func(machineId string) *MachineAgent {
@@ -266,7 +265,7 @@ func MachineAgentFactoryFn(
 			agentConfWriter,
 			bufferedLogs,
 			worker.NewRunner(cmdutil.IsFatal, cmdutil.MoreImportant, worker.RestartDelay),
-			loopDeviceManager,
+			looputil.NewLoopDeviceManager(),
 			rootDir,
 		)
 	}

--- a/cmd/jujud/main.go
+++ b/cmd/jujud/main.go
@@ -27,7 +27,6 @@ import (
 	"github.com/juju/juju/juju/sockets"
 	// Import the providers.
 	_ "github.com/juju/juju/provider/all"
-	"github.com/juju/juju/storage/looputil"
 	"github.com/juju/juju/worker/logsender"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
 )
@@ -152,9 +151,7 @@ func jujuDMain(args []string, ctx *cmd.Context) (code int, err error) {
 	// MachineAgent type has called out the separate concerns; the
 	// AgentConf should be split up to follow suit.
 	agentConf := agentcmd.NewAgentConf("")
-	machineAgentFactory := agentcmd.MachineAgentFactoryFn(
-		agentConf, logCh, looputil.NewLoopDeviceManager(), "",
-	)
+	machineAgentFactory := agentcmd.MachineAgentFactoryFn(agentConf, logCh, "")
 	jujud.Register(agentcmd.NewMachineAgentCmd(ctx, machineAgentFactory, agentConf, agentConf))
 
 	jujud.Register(agentcmd.NewUnitAgent(ctx, logCh))

--- a/featuretests/dblog_test.go
+++ b/featuretests/dblog_test.go
@@ -58,7 +58,7 @@ func (s *dblogSuite) runMachineAgentTest(c *gc.C) bool {
 	agentConf.ReadConfig(m.Tag().String())
 	logsCh, err := logsender.InstallBufferedLogWriter(1000)
 	c.Assert(err, jc.ErrorIsNil)
-	machineAgentFactory := agentcmd.MachineAgentFactoryFn(agentConf, logsCh, nil, c.MkDir())
+	machineAgentFactory := agentcmd.MachineAgentFactoryFn(agentConf, logsCh, c.MkDir())
 	a := machineAgentFactory(m.Id())
 
 	// Ensure there's no logs to begin with.

--- a/featuretests/upgrade_test.go
+++ b/featuretests/upgrade_test.go
@@ -217,7 +217,7 @@ func (s *upgradeSuite) TestDowngradeOnMasterWhenOtherControllerDoesntStartUpgrad
 func (s *upgradeSuite) newAgent(c *gc.C, m *state.Machine) *agentcmd.MachineAgent {
 	agentConf := agentcmd.NewAgentConf(s.DataDir())
 	agentConf.ReadConfig(m.Tag().String())
-	machineAgentFactory := agentcmd.MachineAgentFactoryFn(agentConf, nil, nil, c.MkDir())
+	machineAgentFactory := agentcmd.MachineAgentFactoryFn(agentConf, nil, c.MkDir())
 	return machineAgentFactory(m.Id())
 }
 


### PR DESCRIPTION
cmd/jujud/agent.MachineAgentFactoryFn only had one caller, who's
argument for the loop manager was hard coded. Push this down to the
jujud/agent method and add a variant of this function in test scope that
supplies a noop mock loop manager.

(Review request: http://reviews.vapour.ws/r/4147/)