### PR TITLE
Juju uses mongo 3.2 on xenial; fix upgrade mongo tests

### DIFF
--- a/cmd/jujud/bootstrap.go
+++ b/cmd/jujud/bootstrap.go
@@ -219,10 +219,10 @@ func (c *BootstrapCommand) Run(_ *cmd.Context) error {
 	}
 
 	err = c.ChangeConfig(func(config agent.ConfigSetter) error {
-		// We cannot set wired tiger as the storage because mongo
-		// shipped with ubuntu lacks js.
-		if mongo.BinariesAvailable(mongo.Mongo30wt) {
-			config.SetMongoVersion(mongo.Mongo30wt)
+		// We'll try for mongo 3.2 first and fallback to
+		// mongo 2.4 if the newer binaries are not available.
+		if mongo.BinariesAvailable(mongo.Mongo32wt) {
+			config.SetMongoVersion(mongo.Mongo32wt)
 		} else {
 			config.SetMongoVersion(mongo.Mongo24)
 		}

--- a/cmd/jujud/upgrade_mongo.go
+++ b/cmd/jujud/upgrade_mongo.go
@@ -8,33 +8,42 @@ import (
 	"io/ioutil"
 	"net"
 	"os"
-	"path"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
+	"github.com/juju/names"
+	"github.com/juju/replicaset"
+	"github.com/juju/retry"
+	"github.com/juju/utils"
+	"github.com/juju/utils/clock"
+	"github.com/juju/utils/fs"
+	"github.com/juju/utils/packaging/manager"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
+	"launchpad.net/gnuflag"
+
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/juju/paths"
 	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/service"
 	"github.com/juju/juju/service/common"
 	"github.com/juju/juju/worker/peergrouper"
-	"github.com/juju/names"
-	"github.com/juju/replicaset"
-	"github.com/juju/utils"
-	"github.com/juju/utils/fs"
-	"github.com/juju/utils/packaging/manager"
-	"gopkg.in/mgo.v2"
-	"gopkg.in/mgo.v2/bson"
-	"launchpad.net/gnuflag"
 )
 
 const KeyUpgradeBackup = "mongo-upgrade-backup"
 
 func createTempDir() (string, error) {
 	return ioutil.TempDir("", "")
+}
+
+var defaultCallArgs = retry.CallArgs{
+	Attempts: 60,
+	Delay:    time.Second,
+	Clock:    clock.WallClock,
 }
 
 // NewUpgradeMongoCommand returns a new UpgradeMongo command initialized with
@@ -52,6 +61,7 @@ func NewUpgradeMongoCommand() *UpgradeMongoCommand {
 		fsCopy:               fs.Copy,
 		osGetenv:             os.Getenv,
 
+		callArgs:                    defaultCallArgs,
 		mongoStart:                  mongo.StartService,
 		mongoStop:                   mongo.StopService,
 		mongoRestart:                mongo.ReStartService,
@@ -81,7 +91,7 @@ type mgoDb interface {
 	Run(interface{}, interface{}) error
 }
 
-type dialAndLogger func(*mongo.MongoInfo) (mgoSession, mgoDb, error)
+type dialAndLogger func(*mongo.MongoInfo, retry.CallArgs) (mgoSession, mgoDb, error)
 
 type requisitesSatisfier func(string) error
 
@@ -105,10 +115,10 @@ type UpgradeMongoCommand struct {
 	backupPath     string
 	rollback       bool
 	slave          bool
-	wiredTiger     bool
 	members        string
 
 	// utils used by this struct.
+	callArgs             retry.CallArgs
 	stat                 statFunc
 	remove               removeFunc
 	mkdir                mkdirFunc
@@ -147,7 +157,6 @@ func (u *UpgradeMongoCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.StringVar(&u.members, "members", "", "a comma separated list of replicaset member ips")
 	f.BoolVar(&u.rollback, "rollback", false, "rollback a previous attempt at upgrading that was cut in the process")
 	f.BoolVar(&u.slave, "slave", false, "this is a slave machine in a replicaset")
-	f.BoolVar(&u.wiredTiger, "wiredTiger", false, "use wired tiger storage, requires a mongo 3 with js enabled")
 }
 
 // Init initializes the command for running.
@@ -242,8 +251,8 @@ func (u *UpgradeMongoCommand) run() (err error) {
 		}
 		current = mongo.Mongo26
 	}
-	if current == mongo.Mongo26 || current == mongo.Mongo30 {
-		if err := u.maybeUpgrade26to31(dataDir); err != nil {
+	if current == mongo.Mongo26 || current.StorageEngine != mongo.WiredTiger {
+		if err := u.maybeUpgrade26to3x(dataDir); err != nil {
 			defer func() {
 				if u.backupPath == "" {
 					return
@@ -276,16 +285,7 @@ func (u *UpgradeMongoCommand) replicaRemove() error {
 		return errors.New("cannot get mongo info from agent config to resume HA")
 	}
 
-	var session mgoSession
-	var err error
-	for attempt := connectAfterRestartRetryAttempts.Start(); attempt.Next(); {
-		// Try to connect, retry a few times until the db comes up.
-		session, _, err = u.dialAndLogin(info)
-		if err == nil {
-			break
-		}
-		logger.Errorf("cannot open mongo connection to resume HA auth schema: %v", err)
-	}
+	session, _, err := u.dialAndLogin(info, u.callArgs)
 	if err != nil {
 		return errors.Annotate(err, "error dialing mongo to resume HA")
 	}
@@ -315,16 +315,7 @@ func (u *UpgradeMongoCommand) replicaAdd() error {
 		return errors.New("cannot get mongo info from agent config to resume HA")
 	}
 
-	var session mgoSession
-	var err error
-	for attempt := connectAfterRestartRetryAttempts.Start(); attempt.Next(); {
-		// Try to connect, retry a few times until the db comes up.
-		session, _, err = u.dialAndLogin(info)
-		if err == nil {
-			break
-		}
-		logger.Errorf("cannot open mongo connection to resume HA auth schema: %v", err)
-	}
+	session, _, err := u.dialAndLogin(info, u.callArgs)
 	if err != nil {
 		return errors.Annotate(err, "error dialing mongo to resume HA")
 	}
@@ -406,16 +397,7 @@ func (u *UpgradeMongoCommand) maybeUpgrade24to26(dataDir string) error {
 		return errors.New("cannot get mongo info from agent config")
 	}
 
-	var session mgoSession
-	var db mgoDb
-	for attempt := connectAfterRestartRetryAttempts.Start(); attempt.Next(); {
-		// Try to connect, retry a few times until the db comes up.
-		session, db, err = u.dialAndLogin(info)
-		if err == nil {
-			break
-		}
-		logger.Errorf("cannot open mongo connection to upgrade auth schema: %v", err)
-	}
+	session, db, err := u.dialAndLogin(info, u.callArgs)
 	if err != nil {
 		return errors.Annotate(err, "error dialing mongo to upgrade auth schema")
 	}
@@ -438,8 +420,8 @@ func (u *UpgradeMongoCommand) maybeUpgrade24to26(dataDir string) error {
 	return nil
 }
 
-func (u *UpgradeMongoCommand) maybeUpgrade26to31(dataDir string) error {
-	jujuMongoPath := path.Dir(mongo.JujuMongod26Path)
+func (u *UpgradeMongoCommand) maybeUpgrade26to3x(dataDir string) error {
+	jujuMongoPath := filepath.Dir(mongo.JujuMongodPath(mongo.Mongo26))
 	password := u.agentConfig.OldPassword()
 	ssi, _ := u.agentConfig.StateServingInfo()
 	port := ssi.StatePort
@@ -458,12 +440,14 @@ func (u *UpgradeMongoCommand) maybeUpgrade26to31(dataDir string) error {
 		}
 		logger.Infof("mongo stopped")
 
-		// Mongo 3, no wired tiger
-		u.agentConfig.SetMongoVersion(mongo.Mongo30)
+		// Initially, mongo 3, no wired tiger so we can do a pre-migration dump.
+		mongoNoWiredTiger := mongo.Mongo32wt
+		mongoNoWiredTiger.StorageEngine = mongo.MMAPV1
+		u.agentConfig.SetMongoVersion(mongoNoWiredTiger)
 		if err := u.agentConfig.Write(); err != nil {
 			return errors.Annotate(err, "could not update mongo version in agent.config")
 		}
-		logger.Infof(fmt.Sprintf("new mongo version set-up to %q", mongo.Mongo30.String()))
+		logger.Infof(fmt.Sprintf("new mongo version set-up to %q", mongoNoWiredTiger.String()))
 
 		if err := u.UpdateService(true); err != nil {
 			return errors.Annotate(err, "cannot update service script")
@@ -474,11 +458,11 @@ func (u *UpgradeMongoCommand) maybeUpgrade26to31(dataDir string) error {
 			return errors.Annotate(err, "cannot start mongo 3 to do a pre-tiger migration dump")
 		}
 		logger.Infof("started mongo")
-		current = mongo.Mongo30
+		current = mongo.Mongo32wt
 	}
 
-	if current == mongo.Mongo30 && u.wiredTiger {
-		jujuMongoPath = path.Dir(mongo.JujuMongod30Path)
+	if current.Major > 2 {
+		jujuMongoPath = filepath.Dir(mongo.JujuMongodPath(current))
 		_, err := u.mongoDump(jujuMongoPath, password, "Tiger", port)
 		if err != nil {
 			return errors.Annotate(err, "could not do the tiger migration export")
@@ -494,8 +478,8 @@ func (u *UpgradeMongoCommand) maybeUpgrade26to31(dataDir string) error {
 		}
 		logger.Infof("old db files removed")
 
-		// Mongo 3, with wired tiger
-		u.agentConfig.SetMongoVersion(mongo.Mongo30wt)
+		// Mongo, with wired tiger
+		u.agentConfig.SetMongoVersion(mongo.Mongo32wt)
 		if err := u.agentConfig.Write(); err != nil {
 			return errors.Annotate(err, "could not update mongo version in agent.config")
 		}
@@ -558,29 +542,23 @@ func (u *UpgradeMongoCommand) maybeUpgrade26to31(dataDir string) error {
 	return nil
 }
 
-// connectAfterRestartRetryAttempts defines how many retries
-// will there be when trying to connect to mongo after starting it.
-var connectAfterRestartRetryAttempts = utils.AttemptStrategy{
-	Total: 1 * time.Minute,
-	Delay: 1 * time.Second,
-}
-
 // dialAndLogin returns a mongo session logged in as a user with administrative
 // privileges
-func dialAndLogin(mongoInfo *mongo.MongoInfo) (mgoSession, mgoDb, error) {
+func dialAndLogin(mongoInfo *mongo.MongoInfo, callArgs retry.CallArgs) (mgoSession, mgoDb, error) {
 	var session *mgo.Session
-	var err error
 	opts := mongo.DefaultDialOpts()
-	for attempt := connectAfterRestartRetryAttempts.Start(); attempt.Next(); {
+	callArgs.Func = func() error {
 		// Try to connect, retry a few times until the db comes up.
+		var err error
 		session, err = mongo.DialWithInfo(mongoInfo.Info, opts)
 		if err == nil {
-			break
+			return nil
 		}
-		logger.Errorf("cannot open mongo connection to upgrade auth schema: %v", err)
+		logger.Errorf("cannot open mongo connection to resume HA auth schema: %v", err)
+		return err
 	}
-	if err != nil {
-		return nil, nil, errors.Annotate(err, "timed out trying to dial mongo")
+	if err := retry.Call(callArgs); err != nil {
+		return nil, nil, errors.Annotate(err, "error dialing mongo to resume HA")
 	}
 	admin := session.DB("admin")
 	if mongoInfo.Tag != nil {
@@ -597,7 +575,7 @@ func dialAndLogin(mongoInfo *mongo.MongoInfo) (mgoSession, mgoDb, error) {
 
 func mongo26UpgradeStepCall(runCommand utilsRun, dataDir string) error {
 	updateArgs := []string{"--dbpath", mongo.DbDir(dataDir), "--replSet", "juju", "--upgrade"}
-	out, err := runCommand(mongo.JujuMongodPath, updateArgs...)
+	out, err := runCommand(mongo.JujuMongod24Path, updateArgs...)
 	logger.Infof(out)
 	if err != nil {
 		return errors.Annotate(err, "cannot upgrade mongo 2.4 data")
@@ -610,7 +588,7 @@ func (u *UpgradeMongoCommand) mongo26UpgradeStep(dataDir string) error {
 }
 
 func removeOldDbCall(dataDir string, stat statFunc, remove removeFunc, mkdir mkdirFunc) error {
-	dbPath := path.Join(dataDir, "db")
+	dbPath := filepath.Join(dataDir, "db")
 
 	fi, err := stat(dbPath)
 	if err != nil {
@@ -648,32 +626,36 @@ func satisfyPrerequisites(operatingsystem string) error {
 	if err := pacman.Install("juju-mongodb2.6"); err != nil {
 		return errors.Annotate(err, "cannot install juju-mongodb2.6")
 	}
-	if err := pacman.Install("juju-mongodb3"); err != nil {
-		return errors.Annotate(err, "cannot install juju-mongodb3")
+	if err := pacman.Install(mongo.JujuMongoPackage); err != nil {
+		return errors.Annotatef(err, "cannot install %v", mongo.JujuMongoPackage)
 	}
 	return nil
 }
 
-func mongoDumpCall(runCommand utilsRun, tmpDir, mongoPath, adminPassword, migrationName string, statePort int) (string, error) {
-	mongodump := path.Join(mongoPath, "mongodump")
+func mongoDumpCall(
+	runCommand utilsRun, tmpDir, mongoPath, adminPassword, migrationName string,
+	statePort int, callArgs retry.CallArgs,
+) (string, error) {
+	mongodump := filepath.Join(mongoPath, "mongodump")
 	dumpParams := []string{
 		"--ssl",
 		"-u", "admin",
 		"-p", adminPassword,
 		"--port", strconv.Itoa(statePort),
 		"--host", "localhost",
-		"--out", path.Join(tmpDir, fmt.Sprintf("migrateTo%sdump", migrationName)),
+		"--out", filepath.Join(tmpDir, fmt.Sprintf("migrateTo%sdump", migrationName)),
 	}
 	var out string
-	var err error
-	for attempt := connectAfterRestartRetryAttempts.Start(); attempt.Next(); {
+	callArgs.Func = func() error {
+		var err error
 		out, err = runCommand(mongodump, dumpParams...)
 		if err == nil {
-			break
+			return nil
 		}
-		logger.Errorf(out)
+		logger.Errorf("cannot dump db %v: %s", err, out)
+		return err
 	}
-	if err != nil {
+	if err := retry.Call(callArgs); err != nil {
 		logger.Errorf(out)
 		return out, errors.Annotate(err, "cannot dump mongo db")
 	}
@@ -681,12 +663,12 @@ func mongoDumpCall(runCommand utilsRun, tmpDir, mongoPath, adminPassword, migrat
 }
 
 func (u *UpgradeMongoCommand) mongoDump(mongoPath, adminPassword, migrationName string, statePort int) (string, error) {
-	return mongoDumpCall(u.runCommand, u.tmpDir, mongoPath, adminPassword, migrationName, statePort)
+	return mongoDumpCall(u.runCommand, u.tmpDir, mongoPath, adminPassword, migrationName, statePort, u.callArgs)
 }
 
 func mongoRestoreCall(runCommand utilsRun, tmpDir, mongoPath, adminPassword, migrationName string,
-	dbs []string, statePort int, invalidSSL bool, batchSize int) error {
-	mongorestore := path.Join(mongoPath, "mongorestore")
+	dbs []string, statePort int, invalidSSL bool, batchSize int, callArgs retry.CallArgs) error {
+	mongorestore := filepath.Join(mongoPath, "mongorestore")
 	restoreParams := []string{
 		"--ssl",
 		"--port", strconv.Itoa(statePort),
@@ -703,31 +685,38 @@ func mongoRestoreCall(runCommand utilsRun, tmpDir, mongoPath, adminPassword, mig
 		restoreParams = append(restoreParams, "-u", "admin", "-p", adminPassword)
 	}
 	var out string
-	var err error
 	if len(dbs) == 0 || dbs == nil {
-		restoreParams = append(restoreParams, path.Join(tmpDir, fmt.Sprintf("migrateTo%sdump", migrationName)))
-		for attempt := connectAfterRestartRetryAttempts.Start(); attempt.Next(); {
+		restoreParams = append(restoreParams, filepath.Join(tmpDir, fmt.Sprintf("migrateTo%sdump", migrationName)))
+		restoreCallArgs := callArgs
+		restoreCallArgs.Func = func() error {
+			var err error
 			out, err = runCommand(mongorestore, restoreParams...)
 			if err == nil {
-				break
+				return nil
 			}
 			logger.Errorf("cannot restore %v: %s", err, out)
+			return err
 		}
-		// if err is nil, Annotate returns nil
-		return errors.Annotatef(err, "cannot restore dbs got: %s", out)
+		if err := retry.Call(restoreCallArgs); err != nil {
+			logger.Errorf(out)
+			return errors.Annotatef(err, "cannot restore dbs got: %s", out)
+		}
 	}
 	for i := range dbs {
 		restoreDbParams := append(restoreParams,
 			fmt.Sprintf("--db=%s", dbs[i]),
-			path.Join(tmpDir, fmt.Sprintf("migrateTo%sdump/%s", migrationName, dbs[i])))
-		for attempt := connectAfterRestartRetryAttempts.Start(); attempt.Next(); {
+			filepath.Join(tmpDir, fmt.Sprintf("migrateTo%sdump/%s", migrationName, dbs[i])))
+		restoreCallArgs := callArgs
+		restoreCallArgs.Func = func() error {
+			var err error
 			out, err = runCommand(mongorestore, restoreDbParams...)
 			if err == nil {
-				break
+				return nil
 			}
 			logger.Errorf("cannot restore db %q: %v: got %s", dbs[i], err, out)
+			return err
 		}
-		if err != nil {
+		if err := retry.Call(restoreCallArgs); err != nil {
 			return errors.Annotatef(err, "cannot restore db %q got: %s", dbs[i], out)
 		}
 		logger.Infof("Succesfully restored db %q", dbs[i])
@@ -736,7 +725,10 @@ func mongoRestoreCall(runCommand utilsRun, tmpDir, mongoPath, adminPassword, mig
 }
 
 func (u *UpgradeMongoCommand) mongoRestore(mongoPath, adminPassword, migrationName string, dbs []string, statePort int, invalidSSL bool, batchSize int) error {
-	return mongoRestoreCall(u.runCommand, u.tmpDir, mongoPath, adminPassword, migrationName, dbs, statePort, invalidSSL, batchSize)
+	return mongoRestoreCall(
+		u.runCommand, u.tmpDir, mongoPath, adminPassword, migrationName, dbs,
+		statePort, invalidSSL, batchSize, u.callArgs,
+	)
 }
 
 // copyBackupMongo will make a copy of mongo db by copying the db
@@ -751,14 +743,14 @@ func (u *UpgradeMongoCommand) copyBackupMongo(targetVersion, dataDir string) (st
 	}
 	defer u.mongoStart()
 
-	dbPath := path.Join(dataDir, "db")
+	dbPath := filepath.Join(dataDir, "db")
 	fi, err := u.stat(dbPath)
 
-	target := path.Join(tmpDir, targetVersion)
+	target := filepath.Join(tmpDir, targetVersion)
 	if err := u.mkdir(target, fi.Mode()); err != nil {
 		return "", errors.Annotate(err, "cannot create target folder for backup")
 	}
-	targetDb := path.Join(target, "db")
+	targetDb := filepath.Join(target, "db")
 
 	u.agentConfig.SetValue(KeyUpgradeBackup, targetDb)
 	if err := u.agentConfig.Write(); err != nil {
@@ -778,7 +770,7 @@ func (u *UpgradeMongoCommand) rollbackCopyBackup(dataDir, origin string) error {
 	}
 	defer u.mongoStart()
 
-	dbDir := path.Join(dataDir, "db")
+	dbDir := filepath.Join(dataDir, "db")
 	if err := u.remove(dbDir); err != nil {
 		return errors.Annotate(err, "could not remove the existing folder to rollback")
 	}
@@ -799,10 +791,6 @@ func (u *UpgradeMongoCommand) rollbackAgentConfig() error {
 	return errors.Annotate(u.agentConfig.Write(), "could not rollback mongo version in agent.config")
 }
 
-func enoughFreeSpace() bool {
-	return true
-}
-
 func (u *UpgradeMongoCommand) upgradeSlave(dataDir string) error {
 	if err := u.satisfyPrerequisites(u.series); err != nil {
 		return errors.Annotate(err, "cannot satisfy pre-requisites for the migration")
@@ -815,7 +803,7 @@ func (u *UpgradeMongoCommand) upgradeSlave(dataDir string) error {
 		return errors.Annotate(err, "cannot remove existing slave db")
 	}
 	// Mongo 3, with wired tiger
-	u.agentConfig.SetMongoVersion(mongo.Mongo30wt)
+	u.agentConfig.SetMongoVersion(mongo.Mongo32wt)
 	if err := u.agentConfig.Write(); err != nil {
 		return errors.Annotate(err, "could not update mongo version in agent.config")
 	}

--- a/cmd/jujud/upgrade_mongo_test.go
+++ b/cmd/jujud/upgrade_mongo_test.go
@@ -8,10 +8,20 @@ package main
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strconv"
 	"time"
 
 	"github.com/juju/errors"
+	"github.com/juju/names"
+	"github.com/juju/replicaset"
+	"github.com/juju/retry"
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/clock"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
+
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/mongo"
@@ -20,16 +30,42 @@ import (
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/version"
 	"github.com/juju/juju/worker/peergrouper"
-	"github.com/juju/names"
-	"github.com/juju/replicaset"
-	jc "github.com/juju/testing/checkers"
-	gc "gopkg.in/check.v1"
-	"gopkg.in/mgo.v2"
-	"gopkg.in/mgo.v2/bson"
 )
 
-type UpgradeMongoSuite struct{}
-type UpgradeMongoCommandSuite struct{}
+type UpgradeMongoSuite struct {
+	testing.BaseSuite
+}
+
+type UpgradeMongoCommandSuite struct {
+	testing.BaseSuite
+}
+
+// TODO(wallyworld) - create a common mock clock in juju/utils/clock
+type mockClock struct {
+	now time.Time
+}
+
+func (mock *mockClock) Now() time.Time {
+	return mock.now
+}
+
+func (mock *mockClock) After(wait time.Duration) <-chan time.Time {
+	mock.now = mock.now.Add(wait)
+	return time.After(time.Microsecond)
+}
+
+func (c *mockClock) AfterFunc(d time.Duration, f func()) clock.Timer {
+	if d > 0 {
+		c.now = c.now.Add(d)
+	}
+	return time.AfterFunc(0, f)
+}
+
+func retryCallArgs() retry.CallArgs {
+	args := defaultCallArgs
+	args.Clock = &mockClock{}
+	return args
+}
 
 var _ = gc.Suite(&UpgradeMongoSuite{})
 var _ = gc.Suite(&UpgradeMongoCommandSuite{})
@@ -114,7 +150,8 @@ func (s *UpgradeMongoSuite) TestRemoveOldDb(c *gc.C) {
 
 func (s *UpgradeMongoSuite) TestMongoDump(c *gc.C) {
 	command := fakeRunCommand{}
-	out, err := mongoDumpCall(command.runCommand, "/fake/tmp/dir", "/fake/mongo/path", "adminpass", "aMigrationName", 1234)
+	callArgs := retryCallArgs()
+	out, err := mongoDumpCall(command.runCommand, "/fake/tmp/dir", "/fake/mongo/path", "adminpass", "aMigrationName", 1234, callArgs)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(out, gc.Equals, "")
 	c.Assert(command.ranCommands, gc.HasLen, 1)
@@ -123,8 +160,9 @@ func (s *UpgradeMongoSuite) TestMongoDump(c *gc.C) {
 
 func (s *UpgradeMongoSuite) TestMongoDumpRetries(c *gc.C) {
 	command := fakeRunCommand{}
-	out, err := mongoDumpCall(command.runCommandFail, "/fake/tmp/dir", "/fake/mongo/path", "", "aMigrationName", 1234)
-	c.Assert(err, gc.ErrorMatches, "cannot dump mongo db: a generic error")
+	callArgs := retryCallArgs()
+	out, err := mongoDumpCall(command.runCommandFail, "/fake/tmp/dir", "/fake/mongo/path", "", "aMigrationName", 1234, callArgs)
+	c.Assert(err, gc.ErrorMatches, "cannot dump mongo db: attempt count exceeded: a generic error")
 	c.Assert(out, gc.Equals, "this failed")
 	c.Assert(command.ranCommands, gc.HasLen, 60)
 	for i := range command.ranCommands {
@@ -135,7 +173,8 @@ func (s *UpgradeMongoSuite) TestMongoDumpRetries(c *gc.C) {
 
 func (s *UpgradeMongoSuite) TestMongoRestore(c *gc.C) {
 	command := fakeRunCommand{}
-	err := mongoRestoreCall(command.runCommand, "/fake/tmp/dir", "/fake/mongo/path", "adminpass", "aMigrationName", []string{}, 1234, true, 100)
+	callArgs := retryCallArgs()
+	err := mongoRestoreCall(command.runCommand, "/fake/tmp/dir", "/fake/mongo/path", "adminpass", "aMigrationName", []string{}, 1234, true, 100, callArgs)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(command.ranCommands, gc.HasLen, 1)
 	c.Assert(command.ranCommands[0], gc.DeepEquals, []string{"/fake/mongo/path/mongorestore", "--ssl", "--port", "1234", "--host", "localhost", "--sslAllowInvalidCertificates", "--batchSize", "100", "-u", "admin", "-p", "adminpass", "/fake/tmp/dir/migrateToaMigrationNamedump"})
@@ -143,7 +182,8 @@ func (s *UpgradeMongoSuite) TestMongoRestore(c *gc.C) {
 
 func (s *UpgradeMongoSuite) TestMongoRestoreWithoutAdmin(c *gc.C) {
 	command := fakeRunCommand{}
-	err := mongoRestoreCall(command.runCommand, "/fake/tmp/dir", "/fake/mongo/path", "", "aMigrationName", []string{}, 1234, false, 0)
+	callArgs := retryCallArgs()
+	err := mongoRestoreCall(command.runCommand, "/fake/tmp/dir", "/fake/mongo/path", "", "aMigrationName", []string{}, 1234, false, 0, callArgs)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(command.ranCommands, gc.HasLen, 1)
 	c.Assert(command.ranCommands[0], gc.DeepEquals, []string{"/fake/mongo/path/mongorestore", "--ssl", "--port", "1234", "--host", "localhost", "/fake/tmp/dir/migrateToaMigrationNamedump"})
@@ -151,7 +191,8 @@ func (s *UpgradeMongoSuite) TestMongoRestoreWithoutAdmin(c *gc.C) {
 
 func (s *UpgradeMongoSuite) TestMongoRestoreWithDBs(c *gc.C) {
 	command := fakeRunCommand{}
-	err := mongoRestoreCall(command.runCommand, "/fake/tmp/dir", "/fake/mongo/path", "adminpass", "aMigrationName", []string{"onedb", "twodb"}, 1234, false, 0)
+	callArgs := retryCallArgs()
+	err := mongoRestoreCall(command.runCommand, "/fake/tmp/dir", "/fake/mongo/path", "adminpass", "aMigrationName", []string{"onedb", "twodb"}, 1234, false, 0, callArgs)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(command.ranCommands, gc.HasLen, 2)
 	c.Assert(command.ranCommands[0], gc.DeepEquals, []string{"/fake/mongo/path/mongorestore", "--ssl", "--port", "1234", "--host", "localhost", "-u", "admin", "-p", "adminpass", "--db=onedb", "/fake/tmp/dir/migrateToaMigrationNamedump/onedb"})
@@ -160,8 +201,9 @@ func (s *UpgradeMongoSuite) TestMongoRestoreWithDBs(c *gc.C) {
 
 func (s *UpgradeMongoSuite) TestMongoRestoreRetries(c *gc.C) {
 	command := fakeRunCommand{}
-	err := mongoRestoreCall(command.runCommandFail, "/fake/tmp/dir", "/fake/mongo/path", "", "aMigrationName", []string{}, 1234, false, 0)
-	c.Assert(err, gc.ErrorMatches, "cannot restore dbs got: this failed: a generic error")
+	callArgs := retryCallArgs()
+	err := mongoRestoreCall(command.runCommandFail, "/fake/tmp/dir", "/fake/mongo/path", "", "aMigrationName", []string{}, 1234, false, 0, callArgs)
+	c.Assert(err, gc.ErrorMatches, "cannot restore dbs got: this failed: attempt count exceeded: a generic error")
 	c.Assert(command.ranCommands, gc.HasLen, 60)
 	for i := range command.ranCommands {
 		c.Log(fmt.Sprintf("Checking attempt %d", i))
@@ -188,7 +230,7 @@ func (f *fakeMgoDb) Run(action interface{}, res interface{}) error {
 	return nil
 }
 
-func (f *fakeRunCommand) dialAndLogin(*mongo.MongoInfo) (mgoSession, mgoDb, error) {
+func (f *fakeRunCommand) dialAndLogin(*mongo.MongoInfo, retry.CallArgs) (mgoSession, mgoDb, error) {
 	f.ranCommands = append(f.ranCommands, []string{"DialAndlogin"})
 	return f.mgoSession, f.mgoDb, nil
 }
@@ -370,11 +412,13 @@ func (s *UpgradeMongoCommandSuite) TestRun(c *gc.C) {
 	testAgentConfig := agent.ConfigPath(testDir, names.NewMachineTag("0"))
 	s.createFakeAgentConf(c, testDir, mongo.Mongo24)
 
+	callArgs := retryCallArgs()
 	upgradeMongoCommand := &UpgradeMongoCommand{
 		machineTag:     "0",
 		series:         "vivid",
 		configFilePath: testAgentConfig,
 		tmpDir:         "/fake/temp/dir",
+		callArgs:       callArgs,
 
 		stat:                 command.stat,
 		remove:               command.remove,
@@ -400,6 +444,7 @@ func (s *UpgradeMongoCommandSuite) TestRun(c *gc.C) {
 	err := upgradeMongoCommand.run()
 	c.Assert(err, jc.ErrorIsNil)
 
+	dbDir := filepath.Join(testDir, "db")
 	expectedCommands := [][]string{
 		[]string{"getenv", "UPSTART_JOB"},
 		[]string{"service.DiscoverService", "bogus_daemon"},
@@ -419,13 +464,25 @@ func (s *UpgradeMongoCommandSuite) TestRun(c *gc.C) {
 		[]string{"mongo.ReStartService"},
 		[]string{"/usr/lib/juju/mongo2.6/bin/mongodump", "--ssl", "-u", "admin", "-p", "sekrit", "--port", "69", "--host", "localhost", "--out", "/fake/temp/dir/migrateTo30dump"},
 		[]string{"mongo.StopService"},
-		[]string{"mongo.EnsureServiceInstalled", testDir, "69", "0", "false", "3.0/mmapv1", "true"},
+		[]string{"mongo.EnsureServiceInstalled", testDir, "69", "0", "false", "3.2/mmapv1", "true"},
 		[]string{"mongo.StartService"},
+		[]string{"/usr/lib/juju/mongo3.2/bin/mongodump", "--ssl", "-u", "admin", "-p", "sekrit", "--port", "69", "--host", "localhost", "--out", "/fake/temp/dir/migrateToTigerdump"},
+		[]string{"mongo.StopService"},
+		[]string{"stat", dbDir},
+		[]string{"remove", dbDir},
+		[]string{"mkdir", dbDir},
+		[]string{"mongo.EnsureServiceInstalled", testDir, "69", "0", "false", "3.2/wiredTiger", "false"},
+		[]string{"mongo.DialInfo"},
+		[]string{"mongo.StartService"},
+		[]string{"peergrouper.InitiateMongoServer"},
+		[]string{"/usr/lib/juju/mongo3.2/bin/mongorestore", "--ssl", "--port", "69", "--host", "localhost", "--sslAllowInvalidCertificates", "--batchSize", "100", "/fake/temp/dir/migrateToTigerdump"},
+		[]string{"mongo.EnsureServiceInstalled", testDir, "69", "0", "false", "3.2/wiredTiger", "true"},
+		[]string{"mongo.ReStartService"},
 	}
-	c.Assert(command.ranCommands, gc.DeepEquals, expectedCommands)
+	c.Assert(command.ranCommands, jc.DeepEquals, expectedCommands)
 	c.Assert(session.ranClose, gc.Equals, 2)
 	c.Assert(db.ranAction, gc.Equals, "authSchemaUpgrade")
-	c.Assert(service.ranCommands, gc.DeepEquals, []string{"Stop", "Start"})
+	c.Assert(service.ranCommands, jc.DeepEquals, []string{"Stop", "Start"})
 }
 
 func (s *UpgradeMongoCommandSuite) TestRunRollback(c *gc.C) {
@@ -442,11 +499,13 @@ func (s *UpgradeMongoCommandSuite) TestRunRollback(c *gc.C) {
 	testAgentConfig := agent.ConfigPath(tempDir, names.NewMachineTag("0"))
 	s.createFakeAgentConf(c, tempDir, mongo.Mongo24)
 
+	callArgs := retryCallArgs()
 	upgradeMongoCommand := &UpgradeMongoCommand{
 		machineTag:     "0",
 		series:         "vivid",
 		configFilePath: testAgentConfig,
 		tmpDir:         "/fake/temp/dir",
+		callArgs:       callArgs,
 
 		stat:                 command.stat,
 		remove:               command.remove,
@@ -495,10 +554,10 @@ func (s *UpgradeMongoCommandSuite) TestRunRollback(c *gc.C) {
 		[]string{"mongo.StartService"},
 	}
 
-	c.Assert(command.ranCommands, gc.DeepEquals, expectedCommands)
+	c.Assert(command.ranCommands, jc.DeepEquals, expectedCommands)
 	c.Assert(session.ranClose, gc.Equals, 2)
 	c.Assert(db.ranAction, gc.Equals, "authSchemaUpgrade")
-	c.Assert(service.ranCommands, gc.DeepEquals, []string{"Stop", "Start"})
+	c.Assert(service.ranCommands, jc.DeepEquals, []string{"Stop", "Start"})
 }
 
 func (s *UpgradeMongoCommandSuite) TestRunContinuesWhereLeft(c *gc.C) {
@@ -516,11 +575,13 @@ func (s *UpgradeMongoCommandSuite) TestRunContinuesWhereLeft(c *gc.C) {
 	testAgentConfig := agent.ConfigPath(testDir, names.NewMachineTag("0"))
 	s.createFakeAgentConf(c, testDir, mongo.Mongo26)
 
+	callArgs := retryCallArgs()
 	upgradeMongoCommand := &UpgradeMongoCommand{
 		machineTag:     "0",
 		series:         "vivid",
 		configFilePath: testAgentConfig,
 		tmpDir:         "/fake/temp/dir",
+		callArgs:       callArgs,
 
 		stat:                 command.stat,
 		remove:               command.remove,
@@ -545,6 +606,7 @@ func (s *UpgradeMongoCommandSuite) TestRunContinuesWhereLeft(c *gc.C) {
 
 	err := upgradeMongoCommand.run()
 	c.Assert(err, jc.ErrorIsNil)
+	dbDir := filepath.Join(testDir, "db")
 	expectedCommands := [][]string{
 		[]string{"getenv", "UPSTART_JOB"},
 		[]string{"service.DiscoverService", "bogus_daemon"},
@@ -552,8 +614,20 @@ func (s *UpgradeMongoCommandSuite) TestRunContinuesWhereLeft(c *gc.C) {
 		[]string{"SatisfyPrerequisites"},
 		[]string{"/usr/lib/juju/mongo2.6/bin/mongodump", "--ssl", "-u", "admin", "-p", "sekrit", "--port", "69", "--host", "localhost", "--out", "/fake/temp/dir/migrateTo30dump"},
 		[]string{"mongo.StopService"},
-		[]string{"mongo.EnsureServiceInstalled", testDir, "69", "0", "false", "3.0/mmapv1", "true"},
+		[]string{"mongo.EnsureServiceInstalled", testDir, "69", "0", "false", "3.2/mmapv1", "true"},
 		[]string{"mongo.StartService"},
+		[]string{"/usr/lib/juju/mongo3.2/bin/mongodump", "--ssl", "-u", "admin", "-p", "sekrit", "--port", "69", "--host", "localhost", "--out", "/fake/temp/dir/migrateToTigerdump"},
+		[]string{"mongo.StopService"},
+		[]string{"stat", dbDir},
+		[]string{"remove", dbDir},
+		[]string{"mkdir", dbDir},
+		[]string{"mongo.EnsureServiceInstalled", testDir, "69", "0", "false", "3.2/wiredTiger", "false"},
+		[]string{"mongo.DialInfo"},
+		[]string{"mongo.StartService"},
+		[]string{"peergrouper.InitiateMongoServer"},
+		[]string{"/usr/lib/juju/mongo3.2/bin/mongorestore", "--ssl", "--port", "69", "--host", "localhost", "--sslAllowInvalidCertificates", "--batchSize", "100", "/fake/temp/dir/migrateToTigerdump"},
+		[]string{"mongo.EnsureServiceInstalled", testDir, "69", "0", "false", "3.2/wiredTiger", "true"},
+		[]string{"mongo.ReStartService"},
 	}
 	c.Assert(command.ranCommands, gc.DeepEquals, expectedCommands)
 }

--- a/cmd/plugins/juju-upgrade-mongo/upgrade.go
+++ b/cmd/plugins/juju-upgrade-mongo/upgrade.go
@@ -243,7 +243,7 @@ func (c *upgradeMongoCommand) migratableMachines() (upgradeMongoParams, error) {
 	}
 
 	defer haClient.Close()
-	results, err := haClient.MongoUpgradeMode(mongo.Mongo30wt)
+	results, err := haClient.MongoUpgradeMode(mongo.Mongo32wt)
 	if err != nil {
 		return upgradeMongoParams{}, errors.Annotate(err, "cannot enter mongo upgrade mode")
 	}

--- a/mongo/admin_test.go
+++ b/mongo/admin_test.go
@@ -46,7 +46,7 @@ func (s *adminSuite) TestEnsureAdminUser(c *gc.C) {
 	// do anything nasty. Also mock out the Signal method.
 	gitjujutesting.PatchExecutableAsEchoArgs(c, s, "mongod")
 	mongodDir := filepath.SplitList(os.Getenv("PATH"))[0]
-	s.PatchValue(&mongo.JujuMongodPath, filepath.Join(mongodDir, "mongod"))
+	s.PatchValue(&mongo.JujuMongod24Path, filepath.Join(mongodDir, "mongod"))
 	s.PatchValue(mongo.ProcessSignal, func(*os.Process, os.Signal) error {
 		return nil
 	})

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -33,14 +33,9 @@ var (
 	logger          = loggo.GetLogger("juju.mongo")
 	mongoConfigPath = "/etc/default/mongodb"
 
-	// JujuMongodPath holds the default path to the juju-specific
+	// JujuMongod24Path holds the default path to the legacy Juju
 	// mongod.
-	JujuMongodPath = "/usr/lib/juju/bin/mongod"
-	// JujuMongod26Path holds the default path for the transitional
-	// mongo 2.6 to be installed to upgrade to 3.
-	JujuMongod26Path = "/usr/lib/juju/mongo2.6/bin/mongod"
-	// JujuMongod30Path holds the default path for mongo 3.
-	JujuMongod30Path = "/usr/lib/juju/mongo3/bin/mongod"
+	JujuMongod24Path = "/usr/lib/juju/bin/mongod"
 
 	// This is NUMACTL package name for apt-get
 	numaCtlPkg = "numactl"
@@ -50,10 +45,16 @@ var (
 type StorageEngine string
 
 const (
+	// JujuMongoPackage is the mongo package Juju uses when
+	// installing mongo.
+	JujuMongoPackage = "juju-mongodb3.2"
+	
 	// MMAPV2 is the default storage engine in mongo db up to 3.x
 	MMAPV1 StorageEngine = "mmapv1"
+	
 	// WiredTiger is a storage type introduced in 3
 	WiredTiger StorageEngine = "wiredTiger"
+	
 	// Upgrading is a special case where mongo is being upgraded.
 	Upgrading StorageEngine = "Upgrading"
 )
@@ -104,10 +105,12 @@ func NewVersion(v string) (Version, error) {
 	}
 
 	parts := strings.SplitN(v, "/", 2)
-	if len(parts) == 0 {
+	switch len(parts) {
+	case 0:
 		return Version{}, errors.New("invalid version string")
-	}
-	if len(parts) == 2 {
+	case 1:
+		version.StorageEngine = MMAPV1
+	case 2:
 		switch StorageEngine(parts[1]) {
 		case MMAPV1:
 			version.StorageEngine = MMAPV1
@@ -151,6 +154,12 @@ func (v Version) String() string {
 	return s
 }
 
+// JujuMongodPath returns the path for the mongod binary
+// with the specified version.
+func JujuMongodPath(v Version) string {
+	return fmt.Sprintf("/usr/lib/juju/mongo%d.%d/bin/mongod", v.Major, v.Minor)
+}
+
 var (
 	// Mongo24 represents juju-mongodb 2.4.x
 	Mongo24 = Version{Major: 2,
@@ -164,15 +173,9 @@ var (
 		Patch:         "",
 		StorageEngine: MMAPV1,
 	}
-	// Mongo30 represents juju-mongodb3 3.x.x
-	Mongo30 = Version{Major: 3,
-		Minor:         0,
-		Patch:         "",
-		StorageEngine: MMAPV1,
-	}
-	// Mongo30wt represents juju-mongodb3 3.x.x with wiredTiger storage.
-	Mongo30wt = Version{Major: 3,
-		Minor:         0,
+	// Mongo32wt represents juju-mongodb3 3.2.x with wiredTiger storage.
+	Mongo32wt = Version{Major: 3,
+		Minor:         2,
 		Patch:         "",
 		StorageEngine: WiredTiger,
 	}
@@ -191,14 +194,10 @@ func BinariesAvailable(v Version) bool {
 	var path string
 	switch v {
 	case Mongo24:
-		path = JujuMongodPath
-
-	case Mongo26:
-		path = JujuMongod26Path
-	case Mongo30, Mongo30wt:
-		path = JujuMongod30Path
+		// 2.4 has a fixed path.
+		path = JujuMongod24Path
 	default:
-		return false
+		path = JujuMongodPath(v)
 	}
 	if _, err := os.Stat(path); err == nil {
 		return true
@@ -281,32 +280,23 @@ func Path(version Version) (string, error) {
 	noVersion := Version{}
 	switch version {
 	case Mongo24, noVersion:
-		if _, err := os.Stat(JujuMongodPath); err == nil {
-			return JujuMongodPath, nil
+		if _, err := os.Stat(JujuMongod24Path); err == nil {
+			return JujuMongod24Path, nil
 		}
 
 		path, err := exec.LookPath("mongod")
 		if err != nil {
-			logger.Infof("could not find %v or mongod in $PATH", JujuMongodPath)
+			logger.Infof("could not find %v or mongod in $PATH", JujuMongod24Path)
 			return "", err
 		}
 		return path, nil
 
-	case Mongo26:
+	default:
+		path := JujuMongodPath(version)
 		var err error
-		if _, err = os.Stat(JujuMongod26Path); err == nil {
-			return JujuMongod26Path, nil
+		if _, err = os.Stat(path); err == nil {
+			return path, nil
 		}
-		logger.Infof("could not find %q ", JujuMongod26Path)
-		return "", err
-
-	case Mongo30, Mongo30wt:
-		var err error
-		if _, err = os.Stat(JujuMongod30Path); err == nil {
-			return JujuMongod30Path, nil
-		}
-		logger.Infof("could not find %q", JujuMongod30Path)
-		return "", err
 	}
 
 	logger.Infof("could not find a suitable binary for %q", version)
@@ -545,17 +535,6 @@ func installMongod(operatingsystem string, numaCtl bool) error {
 			return err
 		}
 	}
-	optionals := optionalPackagesForSeries(operatingsystem)
-	for i := range optionals {
-		// apply release targeting if needed.
-		if pacconfer.IsCloudArchivePackage(optionals[i]) {
-			optionals[i] = strings.Join(pacconfer.ApplyCloudArchiveTarget(optionals[i]), " ")
-		}
-
-		if err := pacman.Install(optionals[i]); err != nil {
-			logger.Errorf("could not install package %q: %v", optionals[i], err)
-		}
-	}
 
 	// Work around SELinux on centos7
 	if operatingsystem == "centos7" {
@@ -587,20 +566,12 @@ func packagesForSeries(series string) []string {
 	switch series {
 	case "precise", "quantal", "raring", "saucy", "centos7":
 		return []string{"mongodb-server"}
-	default:
-		// trusty and onwards
+	// TODO(wallyworld) - remove this fallback when mongo3.2 is in trusty
+	case "trusty":
 		return []string{"juju-mongodb"}
-	}
-}
-
-func optionalPackagesForSeries(series string) []string {
-	switch series {
-	case "precise", "quantal", "raring", "saucy", "centos7":
-		return []string{}
 	default:
-		// TODO(perrito666) when the packages are ready, this should be
-		// "juju-mongodb2.6", "juju-mongodb3"
-		return []string{}
+		// xenial and onwards
+		return []string{JujuMongoPackage}
 	}
 }
 
@@ -632,31 +603,16 @@ func noauthCommand(dataDir string, port int, version Version) (*exec.Cmd, error)
 		"--journal",
 		"--quiet",
 	}
-	if version == Mongo30wt {
+	if version.StorageEngine == WiredTiger {
 		args = append(args, "--storageEngine", "wiredTiger")
 
 	} else {
 		args = append(args, "--noprealloc", "--smallfiles")
-	}
-	if version == Mongo30 {
-		args = append(args, "--storageEngine", "mmapv1")
+		if version.Major > 2 {
+			args = append(args, "--storageEngine", "mmapv1")
+		}
 	}
 
 	cmd := exec.Command(mongoPath, args...)
-
 	return cmd, nil
-}
-
-// ReplicaSetInformation holds information about replicaset
-// components.
-type ReplicaSetInformation struct {
-	Master  replicaset.Member
-	Members []replicaset.Member
-	Config  replicaset.Config
-}
-
-// ReplicaSetInfo returns information describing the replicaset members
-// and configuration
-func ReplicaSetInfo(session *mgo.Session) (ReplicaSetInformation, error) {
-	return ReplicaSetInformation{}, nil
 }

--- a/mongo/mongo_test.go
+++ b/mongo/mongo_test.go
@@ -118,7 +118,7 @@ func (s *MongoSuite) SetUpTest(c *gc.C) {
 	jujuMongodPath, err := exec.LookPath("mongod")
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.PatchValue(&mongo.JujuMongodPath, jujuMongodPath)
+	s.PatchValue(&mongo.JujuMongod24Path, jujuMongodPath)
 	s.mongodPath = jujuMongodPath
 
 	// Patch "df" such that it always reports there's 1MB free.
@@ -154,7 +154,7 @@ func (s *MongoSuite) TestJujuMongodPath(c *gc.C) {
 }
 
 func (s *MongoSuite) TestDefaultMongodPath(c *gc.C) {
-	s.PatchValue(&mongo.JujuMongodPath, "/not/going/to/exist/mongod")
+	s.PatchValue(&mongo.JujuMongod24Path, "/not/going/to/exist/mongod")
 	s.PatchEnvPathPrepend(filepath.Dir(s.mongodPath))
 
 	c.Logf("mongo version is %q", s.mongodVersion)
@@ -335,7 +335,7 @@ func (s *MongoSuite) TestInstallMongod(c *gc.C) {
 		{"raring", [][]string{{"--target-release", "mongodb-server"}}},
 		{"saucy", [][]string{{"--target-release", "mongodb-server"}}},
 		{"trusty", [][]string{{"juju-mongodb"}}},
-		{"u-series", [][]string{{"juju-mongodb"}}},
+		{"xenial", [][]string{{"juju-mongodb3.2"}}},
 	}
 
 	testing.PatchExecutableAsEchoArgs(c, s, "add-apt-repository")
@@ -520,28 +520,28 @@ func (s *MongoSuite) TestInstallMongodServiceExists(c *gc.C) {
 func (s *MongoSuite) TestNewServiceWithReplSet(c *gc.C) {
 	dataDir := c.MkDir()
 
-	conf := mongo.NewConf(dataDir, dataDir, mongo.JujuMongodPath, 1234, 1024, false, s.mongodVersion, true)
+	conf := mongo.NewConf(dataDir, dataDir, mongo.JujuMongod24Path, 1234, 1024, false, s.mongodVersion, true)
 	c.Assert(strings.Contains(conf.ExecStart, "--replSet"), jc.IsTrue)
 }
 
 func (s *MongoSuite) TestNewServiceWithNumCtl(c *gc.C) {
 	dataDir := c.MkDir()
 
-	conf := mongo.NewConf(dataDir, dataDir, mongo.JujuMongodPath, 1234, 1024, true, s.mongodVersion, true)
+	conf := mongo.NewConf(dataDir, dataDir, mongo.JujuMongod24Path, 1234, 1024, true, s.mongodVersion, true)
 	c.Assert(conf.ExtraScript, gc.Not(gc.Matches), "")
 }
 
 func (s *MongoSuite) TestNewServiceIPv6(c *gc.C) {
 	dataDir := c.MkDir()
 
-	conf := mongo.NewConf(dataDir, dataDir, mongo.JujuMongodPath, 1234, 1024, false, s.mongodVersion, true)
+	conf := mongo.NewConf(dataDir, dataDir, mongo.JujuMongod24Path, 1234, 1024, false, s.mongodVersion, true)
 	c.Assert(strings.Contains(conf.ExecStart, "--ipv6"), jc.IsTrue)
 }
 
 func (s *MongoSuite) TestNewServiceWithJournal(c *gc.C) {
 	dataDir := c.MkDir()
 
-	conf := mongo.NewConf(dataDir, dataDir, mongo.JujuMongodPath, 1234, 1024, false, s.mongodVersion, true)
+	conf := mongo.NewConf(dataDir, dataDir, mongo.JujuMongod24Path, 1234, 1024, false, s.mongodVersion, true)
 	c.Assert(conf.ExecStart, gc.Matches, `.* --journal.*`)
 }
 

--- a/mongo/service.go
+++ b/mongo/service.go
@@ -160,9 +160,7 @@ func newConf(dataDir, dbDir, mongoPath string, port, oplogSizeMB int, wantNumaCt
 		mongoCmd = mongoCmd +
 			" --noauth"
 	}
-	// TODO(perrito666) implement a proper version comparision with <>
-	// also make sure storageEngine is explicit every time it is possible.
-	if version != Mongo30wt {
+	if version.StorageEngine != WiredTiger {
 		mongoCmd = mongoCmd +
 			" --noprealloc" +
 			" --smallfiles"


### PR DESCRIPTION
On xenial juju will attempt to install mongo 3.2 and use that. Previously 3.0 was used. Wired tiger is used on all architectures by default so some tests needed changing to match.
Part of the implementation cleaned up a bit how the mongo paths are managed.

This work will land once mongo3.2 is packaged for xenial.

Once mongo3.2 is backported to trusty, juju will need to be updated again to use mongo3.2 on trusty.

It was discovered that the upgrade mongo tests were, um, "not optimally implemented". They used a hard coded retry strategy that caused some tests to take 60s to run. The tests are re-written to use the retry package and sensible test defaults. The tests are now *fast*. 

(Review request: http://reviews.vapour.ws/r/4153/)