### PR TITLE
Improve "juju deploy" error messages.

### DIFF
--- a/cmd/juju/service/bundle.go
+++ b/cmd/juju/service/bundle.go
@@ -60,6 +60,13 @@ func deployBundle(
 		return err
 	}
 	if err := data.Verify(verifyConstraints, verifyStorage); err != nil {
+		if verr, ok := err.(*charm.VerificationError); ok {
+			errs := make([]string, len(verr.Errors))
+			for i, err := range verr.Errors {
+				errs[i] = err.Error()
+			}
+			return errors.New("the provided bundle has the following errors:\n" + strings.Join(errs, "\n"))
+		}
 		return errors.Annotate(err, "cannot deploy bundle")
 	}
 

--- a/cmd/juju/service/bundle_test.go
+++ b/cmd/juju/service/bundle_test.go
@@ -363,7 +363,8 @@ var deployBundleErrorsTests = []struct {
                 charm: mysql
                 num_units: -1
     `,
-	err: `cannot deploy bundle: negative number of units specified on service "mysql"`,
+	err: `the provided bundle has the following errors:
+negative number of units specified on service "mysql"`,
 }, {
 	about: "invalid constraints",
 	content: `
@@ -373,7 +374,20 @@ var deployBundleErrorsTests = []struct {
                 num_units: 1
                 constraints: bad-wolf
     `,
-	err: `cannot deploy bundle: invalid constraints "bad-wolf" in service "mysql": malformed constraint "bad-wolf"`,
+	err: `the provided bundle has the following errors:
+invalid constraints "bad-wolf" in service "mysql": malformed constraint "bad-wolf"`,
+}, {
+	about: "multiple bundle verification errors",
+	content: `
+        services:
+            mysql:
+                charm: mysql
+                num_units: -1
+                constraints: bad-wolf
+    `,
+	err: `the provided bundle has the following errors:
+invalid constraints "bad-wolf" in service "mysql": malformed constraint "bad-wolf"
+negative number of units specified on service "mysql"`,
 }, {
 	about: "bundle inception",
 	content: `
@@ -503,6 +517,24 @@ deployment of bundle "local:bundle/example-0" completed`
 		"mysql/1":     "1",
 		"wordpress/0": "2",
 	})
+}
+
+func (s *deployRepoCharmStoreSuite) TestDeployBundleFromBundlePath(c *gc.C) {
+	testcharms.Repo.ClonedDirPath(s.SeriesPath, "wordpress")
+	bundlePath := filepath.Join(c.MkDir(), "example")
+	err := os.Mkdir(bundlePath, 0777)
+	c.Assert(err, jc.ErrorIsNil)
+	err = ioutil.WriteFile(filepath.Join(bundlePath, "bundle.yaml"), []byte(`
+        services:
+            wordpress:
+                charm: local:wordpress
+                num_units: 1
+    `), 0644)
+	c.Assert(err, jc.ErrorIsNil)
+	err = ioutil.WriteFile(filepath.Join(bundlePath, "README.md"), []byte("README"), 0644)
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = runDeployCommand(c, bundlePath)
+	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *deployRepoCharmStoreSuite) TestDeployBundleLocalAndCharmStoreCharms(c *gc.C) {

--- a/cmd/juju/service/deploy_test.go
+++ b/cmd/juju/service/deploy_test.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"os"
 	"path"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -117,6 +118,14 @@ func (s *DeploySuite) TestBlockDeploy(c *gc.C) {
 func (s *DeploySuite) TestInvalidPath(c *gc.C) {
 	err := runDeploy(c, "/home/nowhere")
 	c.Assert(err, gc.ErrorMatches, `charm or bundle URL has invalid form: "/home/nowhere"`)
+}
+
+func (s *DeploySuite) TestInvalidFileFormat(c *gc.C) {
+	path := filepath.Join(c.MkDir(), "bundle.yaml")
+	err := ioutil.WriteFile(path, []byte(":"), 0600)
+	c.Assert(err, jc.ErrorIsNil)
+	err = runDeploy(c, path)
+	c.Assert(err, gc.ErrorMatches, `invalid charm or bundle provided at ".*/bundle.yaml"`)
 }
 
 func (s *DeploySuite) TestPathWithNoCharm(c *gc.C) {


### PR DESCRIPTION
Print all bundle verification errors.
Improve the error printed in a case a provide file is
not a bundle or a charm archive.

Also fix a bug preventing deploying bundle
directories.

(Review request: http://reviews.vapour.ws/r/4154/)