### PR TITLE
Sync on writes/reads on mockConnection.

### DIFF
--- a/worker/metrics/collect/handler_test.go
+++ b/worker/metrics/collect/handler_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/juju/names"
@@ -127,7 +128,8 @@ func (s *handlerSuite) TestJujuUnitsBuiltinMetric(c *gc.C) {
 	c.Assert(conn.Calls(), gc.HasLen, 3)
 	conn.CheckCall(c, 2, "Close")
 
-	responseString := strings.Trim(string(conn.data), " \n\t")
+	data := conn.readData()
+	responseString := strings.Trim(string(data), " \n\t")
 	c.Assert(responseString, gc.Equals, "ok")
 	c.Assert(s.recorder.batches, gc.HasLen, 1)
 
@@ -151,7 +153,8 @@ func (s *handlerSuite) TestHandlerError(c *gc.C) {
 	c.Assert(conn.Calls(), gc.HasLen, 3)
 	conn.CheckCall(c, 2, "Close")
 
-	responseString := strings.Trim(string(conn.data), " \n\t")
+	data := conn.readData()
+	responseString := strings.Trim(string(data), " \n\t")
 	c.Assert(responseString, gc.Matches, ".*well, this is embarassing")
 	c.Assert(s.recorder.batches, gc.HasLen, 0)
 
@@ -186,6 +189,7 @@ func (l *mockListener) SetHandler(handler spool.ConnectionHandler) {
 
 type mockConnection struct {
 	net.Conn
+	sync.Mutex
 	testing.Stub
 	data []byte
 }
@@ -198,9 +202,19 @@ func (c *mockConnection) SetDeadline(t time.Time) error {
 
 // Write implements the net.Conn interface.
 func (c *mockConnection) Write(data []byte) (int, error) {
+	c.Lock()
+	defer c.Unlock()
 	c.AddCall("Write", data)
 	c.data = data
 	return len(data), nil
+}
+
+func (c *mockConnection) readData() []byte {
+	c.Lock()
+	defer c.Unlock()
+	ret := make([]byte, len(c.data))
+	copy(ret, c.data)
+	return ret
 }
 
 // Close implements the net.Conn interface.


### PR DESCRIPTION
This fixes a potential race condition in tests.

(Review request: http://reviews.vapour.ws/r/4170/)