### PR TITLE
provider/maas: don't bridge all interfaces

### DIFF
--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -1188,7 +1188,7 @@ if [ ! -z "${juju_networking_preferred_python_binary:-}" ]; then
 # For the moment we want master and 1.25 to not bridge all interfaces.
 # This setting allows us to easily switch the behaviour when merging
 # the code between those various branches.
-        juju_bridge_all_interfaces=1
+        juju_bridge_all_interfaces=0
         if [ $juju_bridge_all_interfaces -eq 1 ]; then
             $juju_networking_preferred_python_binary %[1]q --bridge-prefix=%[2]q --one-time-backup --activate %[4]q
         else


### PR DESCRIPTION
To ensure that we get a blessed CI biuld we need to disable bridging
all interfaces as we did on master.

(Review request: http://reviews.vapour.ws/r/4172/)