### PR TITLE
Replace JujuConnSuite with BaseSuite for modelmanager access tests.

### DIFF
--- a/api/modelmanager/access_test.go
+++ b/api/modelmanager/access_test.go
@@ -8,15 +8,14 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	basetesting "github.com/juju/juju/api/base/testing"
 	"github.com/juju/juju/api/modelmanager"
 	"github.com/juju/juju/apiserver/params"
-	jujutesting "github.com/juju/juju/juju/testing"
+	"github.com/juju/juju/testing"
 )
 
 type accessSuite struct {
-	jujutesting.JujuConnSuite
-
-	modelmanager *modelmanager.Client
+	testing.BaseSuite
 }
 
 type accessFunc func(string, string, ...string) error
@@ -28,18 +27,12 @@ const (
 	someModelTag  = "model-" + someModelUUID
 )
 
-func (s *accessSuite) SetUpTest(c *gc.C) {
-	s.JujuConnSuite.SetUpTest(c)
-	s.modelmanager = modelmanager.NewClient(s.APIState)
-	c.Assert(s.modelmanager, gc.NotNil)
-}
-
-func (s *accessSuite) accessFunc(action params.ModelAction) accessFunc {
+func accessCall(client *modelmanager.Client, action params.ModelAction, user, access string, modelUUIDs ...string) error {
 	switch action {
 	case params.GrantModelAccess:
-		return s.modelmanager.GrantModel
+		return client.GrantModel(user, access, modelUUIDs...)
 	case params.RevokeModelAccess:
-		return s.modelmanager.RevokeModel
+		return client.RevokeModel(user, access, modelUUIDs...)
 	default:
 		panic(action)
 	}
@@ -53,26 +46,42 @@ func (s *accessSuite) TestRevokeModelReadOnlyUser(c *gc.C) {
 	s.readOnlyUser(c, params.RevokeModelAccess)
 }
 
+func checkCall(c *gc.C, objType string, id, request string) {
+	c.Check(objType, gc.Equals, "ModelManager")
+	c.Check(id, gc.Equals, "")
+	c.Check(request, gc.Equals, "ModifyModelAccess")
+}
+
+func assertRequest(c *gc.C, a interface{}) params.ModifyModelAccessRequest {
+	req, ok := a.(params.ModifyModelAccessRequest)
+	c.Assert(ok, jc.IsTrue, gc.Commentf("wrong request type"))
+	return req
+}
+
+func assertResponse(c *gc.C, result interface{}) *params.ErrorResults {
+	resp, ok := result.(*params.ErrorResults)
+	c.Assert(ok, jc.IsTrue, gc.Commentf("wrong response type"))
+	return resp
+}
+
 func (s *accessSuite) readOnlyUser(c *gc.C, action params.ModelAction) {
-	modelmanager.PatchFacadeCall(s, s.modelmanager, func(request string, paramsIn interface{}, response interface{}) error {
-		if req, ok := paramsIn.(params.ModifyModelAccessRequest); ok {
+	apiCaller := basetesting.APICallerFunc(
+		func(objType string, version int, id, request string, a, result interface{}) error {
+			checkCall(c, objType, id, request)
+
+			req := assertRequest(c, a)
 			c.Assert(req.Changes, gc.HasLen, 1)
 			c.Assert(string(req.Changes[0].Action), gc.Equals, string(action))
 			c.Assert(string(req.Changes[0].Access), gc.Equals, string(params.ModelReadAccess))
 			c.Assert(req.Changes[0].ModelTag, gc.Equals, someModelTag)
-		} else {
-			c.Fatalf("wrong input structure")
-		}
-		if result, ok := response.(*params.ErrorResults); ok {
-			*result = params.ErrorResults{Results: []params.ErrorResult{{Error: nil}}}
-		} else {
-			c.Fatalf("wrong input structure")
-		}
-		return nil
-	})
 
-	fn := s.accessFunc(action)
-	err := fn("bob", "read", someModelUUID)
+			resp := assertResponse(c, result)
+			*resp = params.ErrorResults{Results: []params.ErrorResult{{Error: nil}}}
+
+			return nil
+		})
+	client := modelmanager.NewClient(apiCaller)
+	err := accessCall(client, action, "bob", "read", someModelUUID)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -85,25 +94,23 @@ func (s *accessSuite) TestRevokeModelAdminUser(c *gc.C) {
 }
 
 func (s *accessSuite) adminUser(c *gc.C, action params.ModelAction) {
-	modelmanager.PatchFacadeCall(s, s.modelmanager, func(request string, paramsIn interface{}, response interface{}) error {
-		if req, ok := paramsIn.(params.ModifyModelAccessRequest); ok {
+	apiCaller := basetesting.APICallerFunc(
+		func(objType string, version int, id, request string, a, result interface{}) error {
+			checkCall(c, objType, id, request)
+
+			req := assertRequest(c, a)
 			c.Assert(req.Changes, gc.HasLen, 1)
 			c.Assert(string(req.Changes[0].Action), gc.Equals, string(action))
 			c.Assert(string(req.Changes[0].Access), gc.Equals, string(params.ModelWriteAccess))
 			c.Assert(req.Changes[0].ModelTag, gc.Equals, someModelTag)
-		} else {
-			c.Fatalf("wrong input structure")
-		}
-		if result, ok := response.(*params.ErrorResults); ok {
-			*result = params.ErrorResults{Results: []params.ErrorResult{{Error: nil}}}
-		} else {
-			c.Fatalf("wrong input structure")
-		}
-		return nil
-	})
 
-	fn := s.accessFunc(action)
-	err := fn(s.Factory.MakeModelUser(c, nil).UserTag().Name(), "write", someModelUUID)
+			resp := assertResponse(c, result)
+			*resp = params.ErrorResults{Results: []params.ErrorResult{{Error: nil}}}
+
+			return nil
+		})
+	client := modelmanager.NewClient(apiCaller)
+	err := accessCall(client, action, "bob", "write", someModelUUID)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -116,30 +123,25 @@ func (s *accessSuite) TestRevokeThreeModels(c *gc.C) {
 }
 
 func (s *accessSuite) threeModels(c *gc.C, action params.ModelAction) {
-	modelmanager.PatchFacadeCall(s, s.modelmanager, func(request string, paramsIn interface{}, response interface{}) error {
-		if req, ok := paramsIn.(params.ModifyModelAccessRequest); ok {
+	apiCaller := basetesting.APICallerFunc(
+		func(objType string, version int, id, request string, a, result interface{}) error {
+			checkCall(c, objType, id, request)
+
+			req := assertRequest(c, a)
 			c.Assert(req.Changes, gc.HasLen, 3)
 			for i := range req.Changes {
 				c.Assert(string(req.Changes[i].Action), gc.Equals, string(action))
 				c.Assert(string(req.Changes[i].Access), gc.Equals, string(params.ModelReadAccess))
 				c.Assert(req.Changes[i].ModelTag, gc.Equals, someModelTag)
 			}
-		} else {
-			c.Log("wrong input structure")
-			c.Fail()
-		}
-		if result, ok := response.(*params.ErrorResults); ok {
-			*result = params.ErrorResults{Results: []params.ErrorResult{{Error: nil}, {Error: nil}, {Error: nil}}}
-		} else {
-			c.Log("wrong output structure")
-			c.Fail()
-		}
-		return nil
-	})
 
-	fn := s.accessFunc(action)
-	err := fn(s.Factory.MakeModelUser(c, nil).UserTag().Name(), "read",
-		someModelUUID, someModelUUID, someModelUUID)
+			resp := assertResponse(c, result)
+			*resp = params.ErrorResults{Results: []params.ErrorResult{{Error: nil}, {Error: nil}, {Error: nil}}}
+
+			return nil
+		})
+	client := modelmanager.NewClient(apiCaller)
+	err := accessCall(client, action, "carol", "read", someModelUUID, someModelUUID, someModelUUID)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -152,41 +154,39 @@ func (s *accessSuite) TestRevokeErrorResult(c *gc.C) {
 }
 
 func (s *accessSuite) errorResult(c *gc.C, action params.ModelAction) {
-	modelmanager.PatchFacadeCall(s, s.modelmanager, func(request string, paramsIn interface{}, response interface{}) error {
-		if req, ok := paramsIn.(params.ModifyModelAccessRequest); ok {
+	apiCaller := basetesting.APICallerFunc(
+		func(objType string, version int, id, request string, a, result interface{}) error {
+			checkCall(c, objType, id, request)
+
+			req := assertRequest(c, a)
 			c.Assert(req.Changes, gc.HasLen, 1)
 			c.Assert(string(req.Changes[0].Action), gc.Equals, string(action))
 			c.Assert(req.Changes[0].UserTag, gc.Equals, names.NewUserTag("aaa").String())
 			c.Assert(req.Changes[0].ModelTag, gc.Equals, someModelTag)
-		} else {
-			c.Log("wrong input structure")
-			c.Fail()
-		}
-		if result, ok := response.(*params.ErrorResults); ok {
-			err := &params.Error{Message: "unfortunate mishap"}
-			*result = params.ErrorResults{Results: []params.ErrorResult{{Error: err}}}
-		} else {
-			c.Log("wrong output structure")
-			c.Fail()
-		}
-		return nil
-	})
 
-	fn := s.accessFunc(action)
-	err := fn("aaa", "write", someModelUUID)
+			resp := assertResponse(c, result)
+			err := &params.Error{Message: "unfortunate mishap"}
+			*resp = params.ErrorResults{Results: []params.ErrorResult{{Error: err}}}
+
+			return nil
+		})
+	client := modelmanager.NewClient(apiCaller)
+	err := accessCall(client, action, "aaa", "write", someModelUUID)
 	c.Assert(err, gc.ErrorMatches, "unfortunate mishap")
 }
 
 func (s *accessSuite) TestInvalidResultCount(c *gc.C) {
-	modelmanager.PatchFacadeCall(s, s.modelmanager, func(request string, paramsIn interface{}, response interface{}) error {
-		if result, ok := response.(*params.ErrorResults); ok {
-			*result = params.ErrorResults{Results: nil}
-		} else {
-			c.Fatalf("wrong input structure")
-		}
-		return nil
-	})
+	apiCaller := basetesting.APICallerFunc(
+		func(objType string, version int, id, request string, a, result interface{}) error {
+			checkCall(c, objType, id, request)
+			assertRequest(c, a)
 
-	err := s.modelmanager.GrantModel("bob", "write", someModelUUID, someModelUUID)
+			resp := assertResponse(c, result)
+			*resp = params.ErrorResults{Results: nil}
+
+			return nil
+		})
+	client := modelmanager.NewClient(apiCaller)
+	err := client.GrantModel("bob", "write", someModelUUID, someModelUUID)
 	c.Assert(err, gc.ErrorMatches, "expected 2 results, got 0")
 }


### PR DESCRIPTION
API client tests in this suite were migrated over from "ShareModel" and
"UnshareModel" tests that used JujuConnSuite.

This patch provides equivalent test coverage of the modelmanager API
client with a mock API server.

(Review request: http://reviews.vapour.ws/r/4177/)