### PR TITLE
Give progress indication while copying images

### DIFF
--- a/container/lxc/lxc.go
+++ b/container/lxc/lxc.go
@@ -181,7 +181,7 @@ func (manager *containerManager) CreateContainer(
 	} else if storageConfig == nil {
 		panic("storageConfig is nil")
 	} else if callback == nil {
-		panic("storageConfig is nil")
+		panic("status callback is nil")
 	}
 
 	// Log how long the start took

--- a/container/lxd/lxd.go
+++ b/container/lxd/lxd.go
@@ -91,7 +91,9 @@ func (manager *containerManager) CreateContainer(
 		}
 	}
 
-	err = manager.client.EnsureImageExists(series)
+	err = manager.client.EnsureImageExists(series, func(progress string) {
+		callback(status.StatusAllocating, progress, nil)
+	})
 	if err != nil {
 		return
 	}

--- a/provider/common/bootstrap.go
+++ b/provider/common/bootstrap.go
@@ -31,6 +31,7 @@ import (
 	"github.com/juju/juju/environs/simplestreams"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/network"
+	"github.com/juju/juju/status"
 	coretools "github.com/juju/juju/tools"
 )
 
@@ -126,12 +127,17 @@ func BootstrapInstance(ctx environs.BootstrapContext, env environs.Environ, args
 	maybeSetBridge(instanceConfig)
 
 	fmt.Fprintln(ctx.GetStderr(), "Launching instance")
+	instanceStatus := func(settableStatus status.Status, info string, data map[string]interface{}) error {
+		fmt.Fprintf(ctx.GetStderr(), "%s      \r", info)
+		return nil
+	}
 	result, err := env.StartInstance(environs.StartInstanceParams{
 		Constraints:    args.BootstrapConstraints,
 		Tools:          availableTools,
 		InstanceConfig: instanceConfig,
 		Placement:      args.Placement,
 		ImageMetadata:  imageMetadata,
+		StatusCallback: instanceStatus,
 	})
 	if err != nil {
 		return nil, "", nil, errors.Annotate(err, "cannot start bootstrap instance")

--- a/provider/lxd/environ_raw.go
+++ b/provider/lxd/environ_raw.go
@@ -34,7 +34,7 @@ type lxdProfiles interface {
 }
 
 type lxdImages interface {
-	EnsureImageExists(series string) error
+	EnsureImageExists(series string, copyProgressHandler func(string)) error
 }
 
 func newRawProvider(ecfg *environConfig) (*rawProvider, error) {

--- a/provider/lxd/testing_test.go
+++ b/provider/lxd/testing_test.go
@@ -504,7 +504,7 @@ func (conn *stubClient) RemoveInstances(prefix string, ids ...string) error {
 	return nil
 }
 
-func (conn *stubClient) EnsureImageExists(series string) error {
+func (conn *stubClient) EnsureImageExists(series string, _ func(string)) error {
 	conn.stub.AddCall("EnsureImageExists", series)
 	if err := conn.stub.NextErr(); err != nil {
 		return errors.Trace(err)

--- a/tools/lxdclient/client_image.go
+++ b/tools/lxdclient/client_image.go
@@ -71,7 +71,7 @@ func (i *imageClient) EnsureImageExists(series string, copyProgressHandler func(
 	adapter := &progressContext{
 		logger:  logger,
 		level:   loggo.INFO,
-		context: fmt.Sprintf("copying image for %s from %s: %%s", series, ubuntu.BaseURL),
+		context: fmt.Sprintf("copying image for %s from %s: %%s", name, ubuntu.BaseURL),
 		forward: copyProgressHandler,
 	}
 	target := ubuntu.GetAlias(series)

--- a/tools/lxdclient/client_image.go
+++ b/tools/lxdclient/client_image.go
@@ -6,10 +6,12 @@
 package lxdclient
 
 import (
-	"github.com/lxc/lxd"
-	"github.com/lxc/lxd/shared"
+	"fmt"
 
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	"github.com/lxc/lxd"
+	"github.com/lxc/lxd/shared"
 )
 
 type rawImageClient interface {
@@ -21,7 +23,27 @@ type imageClient struct {
 	config Config
 }
 
-func (i *imageClient) EnsureImageExists(series string) error {
+// progressContext takes progress messages from LXD and just writes them to
+// the associated logger at the given log level.
+type progressContext struct {
+	logger  loggo.Logger
+	level   loggo.Level
+	context string       // a format string that should take a single %s parameter
+	forward func(string) // pass messages onward
+}
+
+func (p *progressContext) copyProgress(progress string) {
+	msg := fmt.Sprintf(p.context, progress)
+	p.logger.Logf(p.level, msg)
+	if p.forward != nil {
+		p.forward(msg)
+	}
+}
+
+func (i *imageClient) EnsureImageExists(series string, copyProgressHandler func(string)) error {
+	// TODO(jam) We should add Architecture in this information as well
+	// TODO(jam) We should also update this for multiple locations to copy
+	// from
 	name := i.ImageNameForSeries(series)
 
 	aliases, err := i.raw.ListAliases()
@@ -31,6 +53,8 @@ func (i *imageClient) EnsureImageExists(series string) error {
 
 	for _, alias := range aliases {
 		if alias.Description == name {
+			logger.Infof("found cached image %q = %s",
+				alias.Description, alias.Target)
 			return nil
 		}
 	}
@@ -44,8 +68,18 @@ func (i *imageClient) EnsureImageExists(series string) error {
 	if !ok {
 		return errors.Errorf("can't use a fake client as target")
 	}
-
-	return ubuntu.CopyImage(series, client, false, []string{name}, false, true, nil)
+	adapter := &progressContext{
+		logger:  logger,
+		level:   loggo.INFO,
+		context: fmt.Sprintf("copying image for %s from %s: %%s", series, ubuntu.BaseURL),
+		forward: copyProgressHandler,
+	}
+	target := ubuntu.GetAlias(series)
+	logger.Infof("found image from %s for %s = %s",
+		ubuntu.BaseURL, series, target)
+	return ubuntu.CopyImage(
+		target, client, false, []string{name}, false,
+		true, adapter.copyProgress)
 }
 
 // A common place to compute image names (alises) based on the series

--- a/tools/lxdclient/client_image.go
+++ b/tools/lxdclient/client_image.go
@@ -44,6 +44,9 @@ func (i *imageClient) EnsureImageExists(series string, copyProgressHandler func(
 	// TODO(jam) We should add Architecture in this information as well
 	// TODO(jam) We should also update this for multiple locations to copy
 	// from
+	// TODO(jam) Find a way to test this, even though lxd.Client can't
+	// really be stubbed out because CopyImage takes one directly and pokes
+	// at private methods so we can't easily tweak it.
 	name := i.ImageNameForSeries(series)
 
 	aliases, err := i.raw.ListAliases()

--- a/tools/lxdclient/config.go
+++ b/tools/lxdclient/config.go
@@ -28,8 +28,6 @@ type Config struct {
 	// ImageStream can be either blank (""), "released", or "daily".
 	// This decides what Ubuntu stream we will use for LXD images.
 	ImageStream ImageStream
-	// // ImageSourceURLs are locations where we will look for
-	// ImageSourceURLs []string
 
 	// Remote identifies the remote server to which the client should
 	// connect. For the default "remote" use Local.

--- a/tools/lxdclient/config.go
+++ b/tools/lxdclient/config.go
@@ -28,6 +28,8 @@ type Config struct {
 	// ImageStream can be either blank (""), "released", or "daily".
 	// This decides what Ubuntu stream we will use for LXD images.
 	ImageStream ImageStream
+	// // ImageSourceURLs are locations where we will look for
+	// ImageSourceURLs []string
 
 	// Remote identifies the remote server to which the client should
 	// connect. For the default "remote" use Local.


### PR DESCRIPTION
This probably needs more tests, but does 3 key things:

1) Updates "juju bootstrap" and the common/provider/bootstrap.go to pass in a StatusCallback function, which maps the status messages to being printed on StdErr along with the other messages
2) Updates the LXD client code to wire up the LXD CopyImage progress function into passing messages to StatusCallback.
3) Log the progress messages at Info level. Will need some 

The really nice thing is that now "juju bootstrap test-lxd lxd" now gives a very nice:
copying image "ubuntu-trusty" from http://cloud-images.ubuntu.com/releases 22%
progress indicator when you didn't have the LXD image already installed.

To test this, you can 
  $ lxc image delete ubuntu-trusty
  $ juju bootstrap test-lxd lxd


(Review request: http://reviews.vapour.ws/r/4182/)