### PR TITLE
Fix DeploySuite.TestInvalidFileFormat on windows.

### DIFF
--- a/cmd/juju/service/deploy_test.go
+++ b/cmd/juju/service/deploy_test.go
@@ -126,7 +126,8 @@ func (s *DeploySuite) TestInvalidFileFormat(c *gc.C) {
 	err := ioutil.WriteFile(path, []byte(":"), 0600)
 	c.Assert(err, jc.ErrorIsNil)
 	err = runDeploy(c, path)
-	c.Assert(err, gc.ErrorMatches, `invalid charm or bundle provided at ".*/bundle.yaml"`)
+	c.Assert(err, gc.ErrorMatches,
+		`invalid charm or bundle provided at ".*`+filepath.FromSlash("/bundle.yaml")+`"`)
 }
 
 func (s *DeploySuite) TestPathWithNoCharm(c *gc.C) {


### PR DESCRIPTION
Found in CI: http://data.vapour.ws/juju-ci/products/version-3760/run-unit-tests-win2012-amd64/build-2077/consoleText

(Review request: http://reviews.vapour.ws/r/4184/)