### PR TITLE
Add MigrationMaster.Export API

### DIFF
--- a/api/migrationmaster/client.go
+++ b/api/migrationmaster/client.go
@@ -4,6 +4,8 @@
 package migrationmaster
 
 import (
+	"github.com/juju/errors"
+
 	"github.com/juju/juju/api/base"
 	apiwatcher "github.com/juju/juju/api/watcher"
 	"github.com/juju/juju/apiserver/params"
@@ -42,7 +44,7 @@ func (c *client) Watch() (watcher.MigrationMasterWatcher, error) {
 	var result params.NotifyWatchResult
 	err := c.caller.FacadeCall("Watch", nil, &result)
 	if err != nil {
-		return nil, err
+		return nil, errors.Trace(err)
 	}
 	if result.Error != nil {
 		return nil, result.Error

--- a/api/migrationmaster/client.go
+++ b/api/migrationmaster/client.go
@@ -21,6 +21,10 @@ type Client interface {
 	// SetPhase updates the phase of the currently active model
 	// migration.
 	SetPhase(migration.Phase) error
+
+	// Export returns a serialized representation of the model
+	// associated with the API connection.
+	Export() ([]byte, error)
 }
 
 // NewClient returns a new Client based on an existing API connection.
@@ -53,4 +57,14 @@ func (c *client) SetPhase(phase migration.Phase) error {
 		Phase: phase.String(),
 	}
 	return c.caller.FacadeCall("SetPhase", args, nil)
+}
+
+// Export implements Client.
+func (c *client) Export() ([]byte, error) {
+	var serialized params.SerializedModel
+	err := c.caller.FacadeCall("Export", nil, &serialized)
+	if err != nil {
+		return nil, err
+	}
+	return serialized.Bytes, nil
 }

--- a/api/migrationmaster/client_test.go
+++ b/api/migrationmaster/client_test.go
@@ -68,8 +68,7 @@ func (s *ClientSuite) TestWatch(c *gc.C) {
 				return
 			}
 		}
-
-		c.Assert(stub.Calls(), jc.DeepEquals, expectedCalls)
+		stub.CheckCalls(c, expectedCalls)
 	case <-time.After(coretesting.LongWait):
 		c.Fatal("timed out waiting for watcher to die")
 	}
@@ -79,7 +78,6 @@ func (s *ClientSuite) TestWatchErr(c *gc.C) {
 	apiCaller := apitesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		return errors.New("boom")
 	})
-
 	client := migrationmaster.NewClient(apiCaller)
 	_, err := client.Watch()
 	c.Assert(err, gc.ErrorMatches, "boom")
@@ -92,9 +90,7 @@ func (s *ClientSuite) TestSetPhase(c *gc.C) {
 		return nil
 	})
 	client := migrationmaster.NewClient(apiCaller)
-
 	err := client.SetPhase(migration.QUIESCE)
-
 	c.Assert(err, jc.ErrorIsNil)
 	expectedArg := params.SetMigrationPhaseArgs{Phase: "QUIESCE"}
 	stub.CheckCalls(c, []jujutesting.StubCall{
@@ -107,7 +103,6 @@ func (s *ClientSuite) TestSetPhaseError(c *gc.C) {
 		return errors.New("boom")
 	})
 	client := migrationmaster.NewClient(apiCaller)
-
 	err := client.SetPhase(migration.QUIESCE)
 	c.Assert(err, gc.ErrorMatches, "boom")
 }
@@ -121,9 +116,7 @@ func (s *ClientSuite) TestExport(c *gc.C) {
 		return nil
 	})
 	client := migrationmaster.NewClient(apiCaller)
-
 	bytes, err := client.Export()
-
 	c.Assert(err, jc.ErrorIsNil)
 	stub.CheckCalls(c, []jujutesting.StubCall{
 		{"MigrationMaster.Export", []interface{}{"", nil}},
@@ -136,9 +129,6 @@ func (s *ClientSuite) TestExportError(c *gc.C) {
 		return errors.New("blam")
 	})
 	client := migrationmaster.NewClient(apiCaller)
-
-	bytes, err := client.Export()
-
+	_, err := client.Export()
 	c.Assert(err, gc.ErrorMatches, "blam")
-	c.Assert(bytes, gc.IsNil)
 }

--- a/apiserver/migrationmaster/doc.go
+++ b/apiserver/migrationmaster/doc.go
@@ -2,5 +2,5 @@
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 // This package defines the API facade for use by the migration master
-// worker.
+// worker when communicating to it's own controller.
 package migrationmaster

--- a/apiserver/migrationmaster/export_test.go
+++ b/apiserver/migrationmaster/export_test.go
@@ -3,7 +3,10 @@
 
 package migrationmaster
 
-import "github.com/juju/juju/state"
+import (
+	"github.com/juju/juju/migration"
+	"github.com/juju/juju/state"
+)
 
 func PatchState(p Patcher, st Backend) {
 	p.PatchValue(&getBackend, func(*state.State) Backend {
@@ -11,7 +14,7 @@ func PatchState(p Patcher, st Backend) {
 	})
 }
 
-func PatchExportModel(p Patcher, f func(Backend) ([]byte, error)) {
+func PatchExportModel(p Patcher, f func(migration.StateExporter) ([]byte, error)) {
 	p.PatchValue(&exportModel, f)
 }
 

--- a/apiserver/migrationmaster/export_test.go
+++ b/apiserver/migrationmaster/export_test.go
@@ -11,6 +11,10 @@ func PatchState(p Patcher, st Backend) {
 	})
 }
 
+func PatchExportModel(p Patcher, f func(Backend) ([]byte, error)) {
+	p.PatchValue(&exportModel, f)
+}
+
 type Patcher interface {
 	PatchValue(ptr, value interface{})
 }

--- a/apiserver/migrationmaster/migrationmaster.go
+++ b/apiserver/migrationmaster/migrationmaster.go
@@ -9,6 +9,7 @@ import (
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
 	coremigration "github.com/juju/juju/core/migration"
+	"github.com/juju/juju/migration"
 	"github.com/juju/juju/state"
 )
 
@@ -69,11 +70,10 @@ func (api *API) SetPhase(args params.SetMigrationPhaseArgs) error {
 	}
 
 	err = mig.SetPhase(phase)
-	if err != nil {
-		return errors.Annotate(err, "failed to set phase")
-	}
-	return nil
+	return errors.Annotate(err, "failed to set phase")
 }
+
+var exportModel = migration.ExportModel
 
 // Export serializes the model associated with the API connection.
 func (api *API) Export() (params.SerializedModel, error) {

--- a/apiserver/migrationmaster/migrationmaster_test.go
+++ b/apiserver/migrationmaster/migrationmaster_test.go
@@ -103,6 +103,21 @@ func (s *Suite) TestSetPhaseError(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "failed to set phase: blam")
 }
 
+func (s *Suite) TestExport(c *gc.C) {
+	exportModel := func(migrationmaster.Backend) ([]byte, error) {
+		return []byte("foo"), nil
+	}
+	migrationmaster.PatchExportModel(s, exportModel)
+	api := s.mustMakeAPI(c)
+
+	serialized, err := api.Export()
+
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(serialized, gc.DeepEquals, params.SerializedModel{
+		Bytes: []byte("foo"),
+	})
+}
+
 func (s *Suite) makeAPI() (*migrationmaster.API, error) {
 	return migrationmaster.NewAPI(nil, s.resources, s.authorizer)
 }

--- a/apiserver/migrationmaster/migrationmaster_test.go
+++ b/apiserver/migrationmaster/migrationmaster_test.go
@@ -12,7 +12,8 @@ import (
 	"github.com/juju/juju/apiserver/migrationmaster"
 	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
-	"github.com/juju/juju/core/migration"
+	coremigration "github.com/juju/juju/core/migration"
+	"github.com/juju/juju/migration"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/testing"
 )
@@ -77,7 +78,7 @@ func (s *Suite) TestSetPhase(c *gc.C) {
 	err := api.SetPhase(params.SetMigrationPhaseArgs{Phase: "ABORT"})
 	c.Assert(err, jc.ErrorIsNil)
 
-	c.Assert(s.backend.migration.phaseSet, gc.Equals, migration.ABORT)
+	c.Assert(s.backend.migration.phaseSet, gc.Equals, coremigration.ABORT)
 }
 
 func (s *Suite) TestSetPhaseNoMigration(c *gc.C) {
@@ -104,7 +105,7 @@ func (s *Suite) TestSetPhaseError(c *gc.C) {
 }
 
 func (s *Suite) TestExport(c *gc.C) {
-	exportModel := func(migrationmaster.Backend) ([]byte, error) {
+	exportModel := func(migration.StateExporter) ([]byte, error) {
 		return []byte("foo"), nil
 	}
 	migrationmaster.PatchExportModel(s, exportModel)
@@ -129,6 +130,8 @@ func (s *Suite) mustMakeAPI(c *gc.C) *migrationmaster.API {
 }
 
 type stubBackend struct {
+	migrationmaster.Backend
+
 	watchError error
 	getErr     error
 	migration  *stubMigration
@@ -151,10 +154,10 @@ func (b *stubBackend) GetModelMigration() (state.ModelMigration, error) {
 type stubMigration struct {
 	state.ModelMigration
 	setPhaseErr error
-	phaseSet    migration.Phase
+	phaseSet    coremigration.Phase
 }
 
-func (m *stubMigration) SetPhase(phase migration.Phase) error {
+func (m *stubMigration) SetPhase(phase coremigration.Phase) error {
 	if m.setPhaseErr != nil {
 		return m.setPhaseErr
 	}

--- a/apiserver/migrationmaster/state.go
+++ b/apiserver/migrationmaster/state.go
@@ -4,7 +4,6 @@
 package migrationmaster
 
 import (
-	"errors"
 	"github.com/juju/juju/migration"
 	"github.com/juju/juju/state"
 )
@@ -12,20 +11,12 @@ import (
 // Backend defines the state functionality required by the
 // migrationmaster facade.
 type Backend interface {
+	migration.StateExporter
+
 	WatchForModelMigration() (state.NotifyWatcher, error)
 	GetModelMigration() (state.ModelMigration, error)
 }
 
 var getBackend = func(st *state.State) Backend {
 	return st
-}
-
-// exportModel is a shim that allows testing of the export
-// functionality without requiring a real *state.State in tests.
-var exportModel = func(backend Backend) ([]byte, error) {
-	st, ok := backend.(*state.State)
-	if !ok {
-		return nil, errors.New("backend is not the expected type")
-	}
-	return migration.ExportModel(st)
 }

--- a/apiserver/migrationmaster/state.go
+++ b/apiserver/migrationmaster/state.go
@@ -3,15 +3,29 @@
 
 package migrationmaster
 
-import "github.com/juju/juju/state"
-
-var getBackend = func(st *state.State) Backend {
-	return st
-}
+import (
+	"errors"
+	"github.com/juju/juju/migration"
+	"github.com/juju/juju/state"
+)
 
 // Backend defines the state functionality required by the
 // migrationmaster facade.
 type Backend interface {
 	WatchForModelMigration() (state.NotifyWatcher, error)
 	GetModelMigration() (state.ModelMigration, error)
+}
+
+var getBackend = func(st *state.State) Backend {
+	return st
+}
+
+// exportModel is a shim that allows testing of the export
+// functionality without requiring a real *state.State in tests.
+var exportModel = func(backend Backend) ([]byte, error) {
+	st, ok := backend.(*state.State)
+	if !ok {
+		return nil, errors.New("backend is not the expected type")
+	}
+	return migration.ExportModel(st)
 }

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -27,10 +27,18 @@ import (
 
 var logger = loggo.GetLogger("juju.migration")
 
-// ExportModel creates a description.Model representation of the active model
-// for the state instance, and returns the serialized version. Primarily here
-// as a symetric method for ImportModel.
-func ExportModel(st *state.State) ([]byte, error) {
+// StateExporter describes interface on state required to export a
+// model.
+type StateExporter interface {
+	// Export generates an abstract representation of a model.
+	Export() (description.Model, error)
+}
+
+// ExportModel creates a description.Model representation of the
+// active model for StateExporter (typically a *state.State), and
+// returns the serialized version. It provides the symmetric
+// functionality to ImportModel.
+func ExportModel(st StateExporter) ([]byte, error) {
 	model, err := st.Export()
 	if err != nil {
 		return nil, errors.Trace(err)


### PR DESCRIPTION
This contains the apiserver and api implementation for the model export API.

(Review request: http://reviews.vapour.ws/r/4185/)