### PR TITLE
Adding virttype to constraints.

### DIFF
--- a/constraints/constraints.go
+++ b/constraints/constraints.go
@@ -652,8 +652,6 @@ func (v *Value) setVirtType(str string) error {
 	if v.VirtType != nil {
 		return errors.Errorf("already set")
 	}
-	// TODO (anastasiamac 2016-03-15)
-	// Do I need to validate that this is a supported virt type?
 	v.VirtType = &str
 	return nil
 }

--- a/constraints/constraints_test.go
+++ b/constraints/constraints_test.go
@@ -310,18 +310,39 @@ var parseConstraintsTests = []struct {
 		args:    []string{"instance-type="},
 	},
 
+	// "virt-type" in detail.
+	{
+		summary: "set virt-type empty",
+		args:    []string{"virt-type="},
+	}, {
+		summary: "set virt-type kvm",
+		args:    []string{"virt-type=kvm"},
+	}, {
+		summary: "set virt-type lxd",
+		args:    []string{"virt-type=lxd"},
+	}, {
+		summary: "double set virt-type together",
+		args:    []string{"virt-type=kvm virt-type=kvm"},
+		err:     `bad "virt-type" constraint: already set`,
+	}, {
+		summary: "double set virt-type separately",
+		args:    []string{"virt-type=kvm", "virt-type="},
+		err:     `bad "virt-type" constraint: already set`,
+	},
+
 	// Everything at once.
 	{
 		summary: "kitchen sink together",
 		args: []string{
 			"root-disk=8G mem=2T  arch=i386  cpu-cores=4096 cpu-power=9001 container=lxc " +
-				"tags=foo,bar spaces=space1,^space2 networks=net,^net2 instance-type=foo"},
+				"tags=foo,bar spaces=space1,^space2 networks=net,^net2 instance-type=foo",
+			"virt-type=kvm"},
 	}, {
 		summary: "kitchen sink separately",
 		args: []string{
 			"root-disk=8G", "mem=2T", "cpu-cores=4096", "cpu-power=9001", "arch=armhf",
 			"container=lxc", "tags=foo,bar", "spaces=space1,^space2", "networks=net1,^net2",
-			"instance-type=foo"},
+			"instance-type=foo", "virt-type=kvm"},
 	},
 }
 

--- a/constraints/validation_test.go
+++ b/constraints/validation_test.go
@@ -113,6 +113,10 @@ var validationTests = []struct {
 			"instance-type": {"foo", "bar"},
 			"arch":          {"amd64", "i386"}},
 	},
+	{
+		cons:  "virt-type=bar",
+		vocab: map[string][]interface{}{"virt-type": {"bar"}},
+	},
 }
 
 func (s *validationSuite) TestValidation(c *gc.C) {

--- a/environs/instances/instancetype.go
+++ b/environs/instances/instancetype.go
@@ -62,6 +62,9 @@ func (itype InstanceType) match(cons constraints.Value) (InstanceType, bool) {
 	if cons.Tags != nil && len(*cons.Tags) > 0 && !tagsMatch(*cons.Tags, itype.Tags) {
 		return nothing, false
 	}
+	if cons.HasVirtType() && (itype.VirtType == nil || *itype.VirtType != *cons.VirtType) {
+		return nothing, false
+	}
 	return itype, true
 }
 

--- a/environs/instances/instancetype_test.go
+++ b/environs/instances/instancetype_test.go
@@ -217,6 +217,11 @@ var getInstanceTypesTest = []struct {
 		},
 		expectedItypes: []string{"it-2"},
 	}, {
+		about:          "virt-type filtered by constraint",
+		cons:           "virt-type=hvm",
+		expectedItypes: []string{"cc1.4xlarge", "cc2.8xlarge"},
+		itypesToUse:    nil,
+	}, {
 		about:          "deprecated image type requested by name",
 		cons:           "instance-type=dep.small",
 		expectedItypes: []string{"dep.small"},


### PR DESCRIPTION
This is a first step in enabling selection of images based on virt-type filtering. 

Needed for clouds with multi-hypervisor support.

Related to bug # 1524297.

(Review request: http://reviews.vapour.ws/r/4189/)