### PR TITLE
Black list virt-type.

### DIFF
--- a/provider/azure/environ.go
+++ b/provider/azure/environ.go
@@ -343,6 +343,7 @@ func (env *azureEnviron) ConstraintsValidator() (constraints.Validator, error) {
 	validator.RegisterUnsupported([]string{
 		constraints.CpuPower,
 		constraints.Tags,
+		constraints.VirtType,
 	})
 	validator.RegisterVocabulary(
 		constraints.Arch,

--- a/provider/azure/environ_test.go
+++ b/provider/azure/environ_test.go
@@ -716,10 +716,10 @@ func (s *environSuite) TestStopInstances(c *gc.C) {
 func (s *environSuite) TestConstraintsValidatorUnsupported(c *gc.C) {
 	validator := s.constraintsValidator(c)
 	unsupported, err := validator.Validate(constraints.MustParse(
-		"arch=amd64 tags=foo cpu-power=100",
+		"arch=amd64 tags=foo cpu-power=100 virt-type=kvm",
 	))
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(unsupported, jc.SameContents, []string{"tags", "cpu-power"})
+	c.Assert(unsupported, jc.SameContents, []string{"tags", "cpu-power", "virt-type"})
 }
 
 func (s *environSuite) TestConstraintsValidatorVocabulary(c *gc.C) {

--- a/provider/cloudsigma/environcaps.go
+++ b/provider/cloudsigma/environcaps.go
@@ -36,6 +36,7 @@ var unsupportedConstraints = []string{
 	constraints.Container,
 	constraints.InstanceType,
 	constraints.Tags,
+	constraints.VirtType,
 }
 
 // ConstraintsValidator returns a Validator instance which

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -858,7 +858,7 @@ func (e *environ) Destroy() (res error) {
 // ConstraintsValidator is defined on the Environs interface.
 func (e *environ) ConstraintsValidator() (constraints.Validator, error) {
 	validator := constraints.NewValidator()
-	validator.RegisterUnsupported([]string{constraints.CpuPower})
+	validator.RegisterUnsupported([]string{constraints.CpuPower, constraints.VirtType})
 	validator.RegisterConflicts([]string{constraints.InstanceType}, []string{constraints.Mem})
 	return validator, nil
 }

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -274,6 +274,12 @@ func (e *environ) SupportsAddressAllocation(_ network.Id) (bool, error) {
 
 var unsupportedConstraints = []string{
 	constraints.Tags,
+	// TODO (anastasiamac 2016-03-16)
+	// virt-type for ec2 exists
+	// but because we sort alphabetically and
+	// up until recently not filtered on virt-type,
+	// does it make sense here?
+	constraints.VirtType,
 }
 
 // ConstraintsValidator is defined on the Environs interface.

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -274,6 +274,8 @@ func (e *environ) SupportsAddressAllocation(_ network.Id) (bool, error) {
 
 var unsupportedConstraints = []string{
 	constraints.Tags,
+	// TODO(anastasiamac 2016-03-16) LP#1557874
+	// use virt-type in StartInstances
 	constraints.VirtType,
 }
 

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -274,11 +274,6 @@ func (e *environ) SupportsAddressAllocation(_ network.Id) (bool, error) {
 
 var unsupportedConstraints = []string{
 	constraints.Tags,
-	// TODO (anastasiamac 2016-03-16)
-	// virt-type for ec2 exists
-	// but because we sort alphabetically and
-	// up until recently not filtered on virt-type,
-	// does it make sense here?
 	constraints.VirtType,
 }
 

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -763,10 +763,10 @@ func (t *localServerSuite) TestConstraintsValidatorUnsupported(c *gc.C) {
 	env := t.Prepare(c)
 	validator, err := env.ConstraintsValidator()
 	c.Assert(err, jc.ErrorIsNil)
-	cons := constraints.MustParse("arch=amd64 tags=foo")
+	cons := constraints.MustParse("arch=amd64 tags=foo virt-type=kvm")
 	unsupported, err := validator.Validate(cons)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(unsupported, gc.DeepEquals, []string{"tags"})
+	c.Assert(unsupported, gc.DeepEquals, []string{"tags", "virt-type"})
 }
 
 func (t *localServerSuite) TestConstraintsValidatorVocab(c *gc.C) {

--- a/provider/gce/environ_policy.go
+++ b/provider/gce/environ_policy.go
@@ -68,6 +68,7 @@ var unsupportedConstraints = []string{
 	constraints.Tags,
 	// TODO(dimitern: Replace Networks with Spaces in a follow-up.
 	constraints.Networks,
+	constraints.VirtType,
 }
 
 // instanceTypeConstraints defines the fields defined on each of the

--- a/provider/gce/environ_policy_test.go
+++ b/provider/gce/environ_policy_test.go
@@ -163,11 +163,11 @@ func (s *environPolSuite) TestConstraintsValidatorUnsupported(c *gc.C) {
 	validator, err := s.Env.ConstraintsValidator()
 	c.Assert(err, jc.ErrorIsNil)
 
-	cons := constraints.MustParse("arch=amd64 tags=foo")
+	cons := constraints.MustParse("arch=amd64 tags=foo virt-type=kvm")
 	unsupported, err := validator.Validate(cons)
 	c.Assert(err, jc.ErrorIsNil)
 
-	c.Check(unsupported, jc.DeepEquals, []string{"tags"})
+	c.Check(unsupported, jc.DeepEquals, []string{"tags", "virt-type"})
 }
 
 func (s *environPolSuite) TestConstraintsValidatorVocabArch(c *gc.C) {

--- a/provider/joyent/environ_instance.go
+++ b/provider/joyent/environ_instance.go
@@ -57,6 +57,7 @@ func (env *joyentEnviron) machineFullName(machineId string) string {
 var unsupportedConstraints = []string{
 	constraints.CpuPower,
 	constraints.Tags,
+	constraints.VirtType,
 }
 
 // ConstraintsValidator is defined on the Environs interface.

--- a/provider/joyent/local_test.go
+++ b/provider/joyent/local_test.go
@@ -394,10 +394,10 @@ func (s *localServerSuite) TestConstraintsValidator(c *gc.C) {
 	env := s.Prepare(c)
 	validator, err := env.ConstraintsValidator()
 	c.Assert(err, jc.ErrorIsNil)
-	cons := constraints.MustParse("arch=amd64 tags=bar cpu-power=10")
+	cons := constraints.MustParse("arch=amd64 tags=bar cpu-power=10 virt-type=kvm")
 	unsupported, err := validator.Validate(cons)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(unsupported, jc.SameContents, []string{"cpu-power", "tags"})
+	c.Assert(unsupported, jc.SameContents, []string{"cpu-power", "tags", "virt-type"})
 }
 
 func (s *localServerSuite) TestConstraintsValidatorVocab(c *gc.C) {

--- a/provider/lxd/environ_policy.go
+++ b/provider/lxd/environ_policy.go
@@ -61,6 +61,7 @@ var unsupportedConstraints = []string{
 	//TODO(ericsnow) Add constraints.Mem as unsupported?
 	constraints.InstanceType,
 	constraints.Tags,
+	constraints.VirtType,
 }
 
 // ConstraintsValidator returns a Validator value which is used to

--- a/provider/lxd/environ_policy_test.go
+++ b/provider/lxd/environ_policy_test.go
@@ -120,6 +120,7 @@ func (s *environPolSuite) TestConstraintsValidatorUnsupported(c *gc.C) {
 		"instance-type=some-type",
 		"cpu-cores=2",
 		"cpu-power=250",
+		"virt-type=kvm",
 	}, " "))
 	unsupported, err := validator.Validate(cons)
 	c.Assert(err, jc.ErrorIsNil)
@@ -129,6 +130,7 @@ func (s *environPolSuite) TestConstraintsValidatorUnsupported(c *gc.C) {
 		"instance-type",
 		"cpu-cores",
 		"cpu-power",
+		"virt-type",
 	}
 	sort.Strings(expected)
 	sort.Strings(unsupported)

--- a/provider/maas/constraints.go
+++ b/provider/maas/constraints.go
@@ -17,6 +17,7 @@ import (
 var unsupportedConstraints = []string{
 	constraints.CpuPower,
 	constraints.InstanceType,
+	constraints.VirtType,
 }
 
 // ConstraintsValidator is defined on the Environs interface.

--- a/provider/maas/environ_whitebox_test.go
+++ b/provider/maas/environ_whitebox_test.go
@@ -532,10 +532,10 @@ func (suite *environSuite) TestConstraintsValidator(c *gc.C) {
 	env := suite.makeEnviron()
 	validator, err := env.ConstraintsValidator()
 	c.Assert(err, jc.ErrorIsNil)
-	cons := constraints.MustParse("arch=amd64 cpu-power=10 instance-type=foo")
+	cons := constraints.MustParse("arch=amd64 cpu-power=10 instance-type=foo virt-type=kvm")
 	unsupported, err := validator.Validate(cons)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(unsupported, jc.SameContents, []string{"cpu-power", "instance-type"})
+	c.Assert(unsupported, jc.SameContents, []string{"cpu-power", "instance-type", "virt-type"})
 }
 
 func (suite *environSuite) TestConstraintsValidatorVocab(c *gc.C) {

--- a/provider/manual/environ.go
+++ b/provider/manual/environ.go
@@ -255,6 +255,7 @@ var unsupportedConstraints = []string{
 	constraints.CpuPower,
 	constraints.InstanceType,
 	constraints.Tags,
+	constraints.VirtType,
 }
 
 // ConstraintsValidator is defined on the Environs interface.

--- a/provider/manual/environ_test.go
+++ b/provider/manual/environ_test.go
@@ -132,10 +132,10 @@ func (s *environSuite) TestSupportsNetworking(c *gc.C) {
 func (s *environSuite) TestConstraintsValidator(c *gc.C) {
 	validator, err := s.env.ConstraintsValidator()
 	c.Assert(err, jc.ErrorIsNil)
-	cons := constraints.MustParse("arch=amd64 instance-type=foo tags=bar cpu-power=10 cpu-cores=2 mem=1G")
+	cons := constraints.MustParse("arch=amd64 instance-type=foo tags=bar cpu-power=10 cpu-cores=2 mem=1G virt-type=kvm")
 	unsupported, err := validator.Validate(cons)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(unsupported, jc.SameContents, []string{"cpu-power", "instance-type", "tags"})
+	c.Assert(unsupported, jc.SameContents, []string{"cpu-power", "instance-type", "tags", "virt-type"})
 }
 
 type bootstrapSuite struct {

--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -953,10 +953,10 @@ func (s *localServerSuite) TestConstraintsValidator(c *gc.C) {
 	env := s.Open(c)
 	validator, err := env.ConstraintsValidator()
 	c.Assert(err, jc.ErrorIsNil)
-	cons := constraints.MustParse("arch=amd64 cpu-power=10")
+	cons := constraints.MustParse("arch=amd64 cpu-power=10 virt-type=kvm")
 	unsupported, err := validator.Validate(cons)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(unsupported, jc.SameContents, []string{"cpu-power"})
+	c.Assert(unsupported, jc.SameContents, []string{"cpu-power", "virt-type"})
 }
 
 func (s *localServerSuite) TestConstraintsValidatorVocab(c *gc.C) {

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -423,6 +423,8 @@ func (e *Environ) SupportedArchitectures() ([]string, error) {
 var unsupportedConstraints = []string{
 	constraints.Tags,
 	constraints.CpuPower,
+	// TODO(anastasiamac 2016-03-16) LP#1524297
+	// use virt-type in StartInstances
 	constraints.VirtType,
 }
 

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -423,6 +423,7 @@ func (e *Environ) SupportedArchitectures() ([]string, error) {
 var unsupportedConstraints = []string{
 	constraints.Tags,
 	constraints.CpuPower,
+	constraints.VirtType,
 }
 
 // ConstraintsValidator is defined on the Environs interface.

--- a/provider/vsphere/environ_policy.go
+++ b/provider/vsphere/environ_policy.go
@@ -71,6 +71,7 @@ func (env *environ) lookupArchitectures() ([]string, error) {
 var unsupportedConstraints = []string{
 	constraints.Tags,
 	constraints.Networks,
+	constraints.VirtType,
 }
 
 // ConstraintsValidator returns a Validator value which is used to

--- a/provider/vsphere/environ_policy_test.go
+++ b/provider/vsphere/environ_policy_test.go
@@ -52,11 +52,11 @@ func (s *environPolSuite) TestConstraintsValidatorUnsupported(c *gc.C) {
 	validator, err := s.Env.ConstraintsValidator()
 	c.Assert(err, jc.ErrorIsNil)
 
-	cons := constraints.MustParse("arch=amd64 tags=foo")
+	cons := constraints.MustParse("arch=amd64 tags=foo virt-type=kvm")
 	unsupported, err := validator.Validate(cons)
 	c.Assert(err, jc.ErrorIsNil)
 
-	c.Check(unsupported, jc.DeepEquals, []string{"tags"})
+	c.Check(unsupported, jc.SameContents, []string{"tags", "virt-type"})
 }
 
 func (s *environPolSuite) TestConstraintsValidatorVocabArch(c *gc.C) {


### PR DESCRIPTION
Providers currently do not support virt-type as a constraint. 

(Review request: http://reviews.vapour.ws/r/4192/)