### PR TITLE
Backslashes on windows are still wrong for a regex.

### DIFF
--- a/cmd/juju/service/deploy_test.go
+++ b/cmd/juju/service/deploy_test.go
@@ -126,8 +126,7 @@ func (s *DeploySuite) TestInvalidFileFormat(c *gc.C) {
 	err := ioutil.WriteFile(path, []byte(":"), 0600)
 	c.Assert(err, jc.ErrorIsNil)
 	err = runDeploy(c, path)
-	c.Assert(err, gc.ErrorMatches,
-		`invalid charm or bundle provided at ".*`+filepath.FromSlash("/bundle.yaml")+`"`)
+	c.Assert(err, gc.ErrorMatches, `invalid charm or bundle provided at ".*bundle.yaml"`)
 }
 
 func (s *DeploySuite) TestPathWithNoCharm(c *gc.C) {


### PR DESCRIPTION
Removed path separators from error regex altogether, as I should have
done originally.

(Review request: http://reviews.vapour.ws/r/4196/)