### PR TITLE
Add remove-credential command

### DIFF
--- a/cmd/juju/cloud/addcredential.go
+++ b/cmd/juju/cloud/addcredential.go
@@ -55,6 +55,7 @@ Example:
 
 See Also:
    juju list-credentials
+   juju remove-credential
 `
 
 // NewAddCredentialCommand returns a command to add credential information.

--- a/cmd/juju/cloud/defaultregion_test.go
+++ b/cmd/juju/cloud/defaultregion_test.go
@@ -59,13 +59,13 @@ func (s *defaultRegionSuite) assertSetDefaultRegion(c *gc.C, cmd cmd.Command, st
 
 func (s *defaultRegionSuite) TestSetDefaultRegion(c *gc.C) {
 	store := jujuclienttesting.NewMemStore()
-	cmd := cloud.NewsetDefaultRegionCommandForTest(store)
+	cmd := cloud.NewSetDefaultRegionCommandForTest(store)
 	s.assertSetDefaultRegion(c, cmd, store)
 }
 
 func (s *defaultRegionSuite) TestOverwriteDefaultRegion(c *gc.C) {
 	store := jujuclienttesting.NewMemStore()
 	store.Credentials["aws"] = jujucloud.CloudCredential{DefaultRegion: "us-east-1"}
-	cmd := cloud.NewsetDefaultRegionCommandForTest(store)
+	cmd := cloud.NewSetDefaultRegionCommandForTest(store)
 	s.assertSetDefaultRegion(c, cmd, store)
 }

--- a/cmd/juju/cloud/export_test.go
+++ b/cmd/juju/cloud/export_test.go
@@ -53,14 +53,20 @@ func NewAddCredentialCommandForTest(
 	}
 }
 
-func NewsetDefaultRegionCommandForTest(testStore jujuclient.CredentialStore) *setDefaultRegionCommand {
-	return &setDefaultRegionCommand{
+func NewRemoveCredentialCommandForTest(testStore jujuclient.CredentialStore) *removeCredentialCommand {
+	return &removeCredentialCommand{
 		store: testStore,
 	}
 }
 
 func NewSetDefaultCredentialCommandForTest(testStore jujuclient.CredentialStore) *setDefaultCredentialCommand {
 	return &setDefaultCredentialCommand{
+		store: testStore,
+	}
+}
+
+func NewSetDefaultRegionCommandForTest(testStore jujuclient.CredentialStore) *setDefaultRegionCommand {
+	return &setDefaultRegionCommand{
 		store: testStore,
 	}
 }

--- a/cmd/juju/cloud/listcredentials.go
+++ b/cmd/juju/cloud/listcredentials.go
@@ -43,6 +43,10 @@ Example:
    
    # List detailed credential information including passwords.
    juju list-credentials --format yaml --show-secrets
+   
+See Also:
+   juju add-credential
+   juju remove-credential   
 `
 
 type credentialsMap struct {

--- a/cmd/juju/cloud/removecredential.go
+++ b/cmd/juju/cloud/removecredential.go
@@ -1,0 +1,75 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cloud
+
+import (
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/jujuclient"
+)
+
+type removeCredentialCommand struct {
+	cmd.CommandBase
+
+	store      jujuclient.CredentialStore
+	cloud      string
+	credential string
+}
+
+var removeCredentialDoc = `
+The remove-credential command removes a named credential for the specified cloud.
+
+Example:
+   juju remove-credential aws my-credential
+
+See Also:
+   juju list-credentials
+   juju add-credential   
+`
+
+// NewremoveCredentialCommand returns a command to remove a named credential for a cloud.
+func NewRemoveCredentialCommand() cmd.Command {
+	return &removeCredentialCommand{
+		store: jujuclient.NewFileCredentialStore(),
+	}
+}
+
+func (c *removeCredentialCommand) Info() *cmd.Info {
+	return &cmd.Info{
+		Name:    "remove-credential",
+		Purpose: "removes a credential for a cloud",
+		Doc:     removeCredentialDoc,
+		Args:    "<cloud> <credential-name>",
+	}
+}
+
+func (c *removeCredentialCommand) Init(args []string) (err error) {
+	if len(args) < 2 {
+		return errors.New("Usage: juju remove-credential <cloud-name> <credential-name>")
+	}
+	c.cloud = args[0]
+	c.credential = args[1]
+	return cmd.CheckEmpty(args[2:])
+}
+
+func (c *removeCredentialCommand) Run(ctxt *cmd.Context) error {
+	cred, err := c.store.CredentialForCloud(c.cloud)
+	if errors.IsNotFound(err) {
+		ctxt.Infof("No credentials exist for cloud %q", c.cloud)
+		return nil
+	} else if err != nil {
+		return err
+	}
+	if _, ok := cred.AuthCredentials[c.credential]; !ok {
+		ctxt.Infof("No credential called %q exists for cloud %q", c.credential, c.cloud)
+		return nil
+	}
+	delete(cred.AuthCredentials, c.credential)
+	if err := c.store.UpdateCredential(c.cloud, *cred); err != nil {
+		return err
+	}
+	ctxt.Infof("Credential %q for cloud %q has been deleted.", c.credential, c.credential)
+	return nil
+}

--- a/cmd/juju/cloud/removecredential_test.go
+++ b/cmd/juju/cloud/removecredential_test.go
@@ -1,0 +1,79 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cloud_test
+
+import (
+	"strings"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	jujucloud "github.com/juju/juju/cloud"
+	"github.com/juju/juju/cmd/juju/cloud"
+	"github.com/juju/juju/jujuclient/jujuclienttesting"
+	"github.com/juju/juju/testing"
+)
+
+type removeCredentialSuite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&removeCredentialSuite{})
+
+func (s *removeCredentialSuite) TestBadArgs(c *gc.C) {
+	cmd := cloud.NewRemoveCredentialCommand()
+	_, err := testing.RunCommand(c, cmd)
+	c.Assert(err, gc.ErrorMatches, "Usage: juju remove-credential <cloud-name> <credential-name>")
+	_, err = testing.RunCommand(c, cmd, "cloud", "credential", "extra")
+	c.Assert(err, gc.ErrorMatches, `unrecognized args: \["extra"\]`)
+}
+
+func (s *removeCredentialSuite) TestMissingCredential(c *gc.C) {
+	store := &jujuclienttesting.MemStore{
+		Credentials: map[string]jujucloud.CloudCredential{
+			"aws": {
+				AuthCredentials: map[string]jujucloud.Credential{
+					"my-credential": jujucloud.NewCredential(jujucloud.AccessKeyAuthType, nil),
+				},
+			},
+		},
+	}
+	cmd := cloud.NewRemoveCredentialCommandForTest(store)
+	ctx, err := testing.RunCommand(c, cmd, "aws", "foo")
+	c.Assert(err, jc.ErrorIsNil)
+	output := testing.Stderr(ctx)
+	output = strings.Replace(output, "\n", "", -1)
+	c.Assert(output, gc.Equals, `No credential called "foo" exists for cloud "aws"`)
+}
+
+func (s *removeCredentialSuite) TestBadCloudName(c *gc.C) {
+	cmd := cloud.NewRemoveCredentialCommandForTest(jujuclienttesting.NewMemStore())
+	ctx, err := testing.RunCommand(c, cmd, "somecloud", "foo")
+	c.Assert(err, jc.ErrorIsNil)
+	output := testing.Stderr(ctx)
+	output = strings.Replace(output, "\n", "", -1)
+	c.Assert(output, gc.Equals, `No credentials exist for cloud "somecloud"`)
+}
+
+func (s *removeCredentialSuite) TestRemove(c *gc.C) {
+	store := &jujuclienttesting.MemStore{
+		Credentials: map[string]jujucloud.CloudCredential{
+			"aws": {
+				AuthCredentials: map[string]jujucloud.Credential{
+					"my-credential":      jujucloud.NewCredential(jujucloud.AccessKeyAuthType, nil),
+					"another-credential": jujucloud.NewCredential(jujucloud.AccessKeyAuthType, nil),
+				},
+			},
+		},
+	}
+	cmd := cloud.NewRemoveCredentialCommandForTest(store)
+	ctx, err := testing.RunCommand(c, cmd, "aws", "my-credential")
+	c.Assert(err, jc.ErrorIsNil)
+	output := testing.Stderr(ctx)
+	output = strings.Replace(output, "\n", "", -1)
+	c.Assert(output, gc.Equals, `Credential "my-credential" for cloud "my-credential" has been deleted.`)
+	_, stillThere := store.Credentials["aws"].AuthCredentials["my-credential"]
+	c.Assert(stillThere, jc.IsFalse)
+	c.Assert(store.Credentials["aws"].AuthCredentials, gc.HasLen, 1)
+}

--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -268,6 +268,7 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 	r.Register(cloud.NewSetDefaultRegionCommand())
 	r.Register(cloud.NewSetDefaultCredentialCommand())
 	r.Register(cloud.NewAddCredentialCommand())
+	r.Register(cloud.NewRemoveCredentialCommand())
 
 	// Juju GUI commands.
 	r.Register(gui.NewGUICommand())

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -268,6 +268,7 @@ var commandNames = []string{
 	"publish",
 	"register",
 	"remove-all-blocks",
+	"remove-credential",
 	"remove-machine",
 	"remove-machines",
 	"remove-relation", // alias for destroy-relation

--- a/jujuclient/file.go
+++ b/jujuclient/file.go
@@ -664,6 +664,20 @@ func (s *store) UpdateCredential(cloudName string, details cloud.CloudCredential
 		all = make(map[string]cloud.CloudCredential)
 	}
 
+	// Clear the default credential if we are removing that one.
+	if existing, ok := all[cloudName]; ok && existing.DefaultCredential != "" {
+		stillHaveDefault := false
+		for name := range details.AuthCredentials {
+			if name == existing.DefaultCredential {
+				stillHaveDefault = true
+				break
+			}
+		}
+		if !stillHaveDefault {
+			details.DefaultCredential = ""
+		}
+	}
+
 	all[cloudName] = details
 	return WriteCredentialsFile(all)
 }


### PR DESCRIPTION
What it says on the box.

Specifying to remove a non-existent credential is not treated as an error, but a no-op.

(Review request: http://reviews.vapour.ws/r/4205/)