### PR TITLE
core/description: Work around go-yaml limitation under Go 1.6

### DIFF
--- a/core/description/annotations.go
+++ b/core/description/annotations.go
@@ -8,15 +8,21 @@ import (
 )
 
 // Instead of copy / pasting the Annotations, SetAnnotations, and the import
-// three lines into every entity that has annotations, we provide a helper
-// struct used in composition. This allows the accessor and setter methods to
-// work. This type is composed without a name so the methods get promoted so
-// they satisfy the HasAnnotations interface, but it does require that the
-// name is serialized as "annotations".
-type annotations map[string]string
+// three lines into every entity that has annotations, the Annotations_ helper
+// type is provided for use in composition. This type is composed without a
+// name so the methods get promoted so they satisfy the HasAnnotations
+// interface.
+//
+// NOTE(mjs) - The type is exported due to a limitation with go-yaml under
+// 1.6. Once that's fixed it should be possible to make it private again.
+//
+// NOTE(mjs) - The trailing underscore on the type name is to avoid collisions
+// between the type name and the Annotations method. The underscore can go once
+// the type becomes private again (revert to "annotations").
+type Annotations_ map[string]string
 
 // Annotations implements HasAnnotations.
-func (a *annotations) Annotations() map[string]string {
+func (a *Annotations_) Annotations() map[string]string {
 	if a == nil {
 		return nil
 	}
@@ -24,11 +30,11 @@ func (a *annotations) Annotations() map[string]string {
 }
 
 // SetAnnotations implements HasAnnotations.
-func (a *annotations) SetAnnotations(annotations map[string]string) {
+func (a *Annotations_) SetAnnotations(annotations map[string]string) {
 	*a = annotations
 }
 
-func (a *annotations) importAnnotations(valid map[string]interface{}) {
+func (a *Annotations_) importAnnotations(valid map[string]interface{}) {
 	if annotations := convertToStringMap(valid["annotations"]); annotations != nil {
 		a.SetAnnotations(annotations)
 	}

--- a/core/description/machine.go
+++ b/core/description/machine.go
@@ -25,8 +25,8 @@ type machine struct {
 	Series_        string         `yaml:"series"`
 	ContainerType_ string         `yaml:"container-type,omitempty"`
 
-	Status_       *status `yaml:"status"`
-	statusHistory `yaml:"status-history"`
+	Status_        *status `yaml:"status"`
+	StatusHistory_ `yaml:"status-history"`
 
 	ProviderAddresses_ []*address `yaml:"provider-addresses,omitempty"`
 	MachineAddresses_  []*address `yaml:"machine-addresses,omitempty"`
@@ -43,8 +43,7 @@ type machine struct {
 
 	NetworkPorts_ *versionedNetworkPorts `yaml:"network-ports,omitempty"`
 
-	// annotations is exported as it is a composed type, even if private.
-	annotations `yaml:"annotations,omitempty"`
+	Annotations_ `yaml:"annotations,omitempty"`
 
 	Constraints_ *constraints `yaml:"constraints,omitempty"`
 }
@@ -77,7 +76,7 @@ func newMachine(args MachineArgs) *machine {
 		Series_:        args.Series,
 		ContainerType_: args.ContainerType,
 		Jobs_:          jobs,
-		statusHistory:  newStatusHistory(),
+		StatusHistory_: newStatusHistory(),
 	}
 	if args.SupportedContainers != nil {
 		supported := make([]string, len(*args.SupportedContainers))
@@ -415,7 +414,7 @@ func importMachineV1(source map[string]interface{}) (*machine, error) {
 		Placement_:     valid["placement"].(string),
 		Series_:        valid["series"].(string),
 		ContainerType_: valid["container-type"].(string),
-		statusHistory:  newStatusHistory(),
+		StatusHistory_: newStatusHistory(),
 	}
 	result.importAnnotations(valid)
 	if err := result.importStatusHistory(valid); err != nil {

--- a/core/description/model.go
+++ b/core/description/model.go
@@ -83,8 +83,7 @@ type model struct {
 
 	Sequences_ map[string]int `yaml:"sequences"`
 
-	// annotations is exported as it is a composed type, even if private.
-	annotations `yaml:"annotations,omitempty"`
+	Annotations_ `yaml:"annotations,omitempty"`
 
 	Constraints_ *constraints `yaml:"constraints,omitempty"`
 

--- a/core/description/service.go
+++ b/core/description/service.go
@@ -5,6 +5,7 @@ package description
 
 import (
 	"encoding/base64"
+
 	"github.com/juju/utils/set"
 
 	"github.com/juju/errors"
@@ -30,8 +31,8 @@ type service struct {
 	Exposed_    bool `yaml:"exposed,omitempty"`
 	MinUnits_   int  `yaml:"min-units,omitempty"`
 
-	Status_       *status `yaml:"status"`
-	statusHistory `yaml:"status-history"`
+	Status_        *status `yaml:"status"`
+	StatusHistory_ `yaml:"status-history"`
 
 	Settings_         map[string]interface{} `yaml:"settings"`
 	SettingsRefCount_ int                    `yaml:"settings-refcount"`
@@ -44,8 +45,7 @@ type service struct {
 	// unit count will be assumed by the number of units associated.
 	Units_ units `yaml:"units"`
 
-	// annotations is exported as it is a composed type, even if private.
-	annotations `yaml:"annotations,omitempty"`
+	Annotations_ `yaml:"annotations,omitempty"`
 
 	Constraints_ *constraints `yaml:"constraints,omitempty"`
 
@@ -86,7 +86,7 @@ func newService(args ServiceArgs) *service {
 		Leader_:               args.Leader,
 		LeadershipSettings_:   args.LeadershipSettings,
 		MetricsCredentials_:   creds,
-		statusHistory:         newStatusHistory(),
+		StatusHistory_:        newStatusHistory(),
 	}
 	svc.setUnits(nil)
 	return svc
@@ -342,7 +342,7 @@ func importServiceV1(source map[string]interface{}) (*service, error) {
 		SettingsRefCount_:     int(valid["settings-refcount"].(int64)),
 		Leader_:               valid["leader"].(string),
 		LeadershipSettings_:   valid["leadership-settings"].(map[string]interface{}),
-		statusHistory:         newStatusHistory(),
+		StatusHistory_:        newStatusHistory(),
 	}
 	result.importAnnotations(valid)
 	if err := result.importStatusHistory(valid); err != nil {

--- a/core/description/status.go
+++ b/core/description/status.go
@@ -22,7 +22,7 @@ type StatusArgs struct {
 func newStatus(args StatusArgs) *status {
 	return &status{
 		Version: 1,
-		statusPoint: statusPoint{
+		StatusPoint_: StatusPoint_{
 			Value_:   args.Value,
 			Message_: args.Message,
 			Data_:    args.Data,
@@ -31,16 +31,16 @@ func newStatus(args StatusArgs) *status {
 	}
 }
 
-func newStatusHistory() statusHistory {
-	return statusHistory{
+func newStatusHistory() StatusHistory_ {
+	return StatusHistory_{
 		Version: 1,
 	}
 }
 
-// statusPoint implements Status, and represents the status
+// StatusPoint_ implements Status, and represents the status
 // of an entity at a point in time. Used in the serialization of
-// both status and statusHistory.
-type statusPoint struct {
+// both status and StatusHistory_.
+type StatusPoint_ struct {
 	Value_   string                 `yaml:"value"`
 	Message_ string                 `yaml:"message,omitempty"`
 	Data_    map[string]interface{} `yaml:"data,omitempty"`
@@ -48,32 +48,32 @@ type statusPoint struct {
 }
 
 type status struct {
-	Version     int `yaml:"version"`
-	statusPoint `yaml:"status"`
+	Version      int `yaml:"version"`
+	StatusPoint_ `yaml:"status"`
 }
 
-type statusHistory struct {
-	Version int            `yaml:"version"`
-	History []*statusPoint `yaml:"history"`
+type StatusHistory_ struct {
+	Version int             `yaml:"version"`
+	History []*StatusPoint_ `yaml:"history"`
 }
 
 // Value implements Status.
-func (a *statusPoint) Value() string {
+func (a *StatusPoint_) Value() string {
 	return a.Value_
 }
 
 // Message implements Status.
-func (a *statusPoint) Message() string {
+func (a *StatusPoint_) Message() string {
 	return a.Message_
 }
 
 // Data implements Status.
-func (a *statusPoint) Data() map[string]interface{} {
+func (a *StatusPoint_) Data() map[string]interface{} {
 	return a.Data_
 }
 
 // Updated implements Status.
-func (a *statusPoint) Updated() time.Time {
+func (a *StatusPoint_) Updated() time.Time {
 	return a.Updated_
 }
 
@@ -97,12 +97,12 @@ func importStatus(source map[string]interface{}) (*status, error) {
 		return nil, errors.Trace(err)
 	}
 	return &status{
-		Version:     1,
-		statusPoint: point,
+		Version:      1,
+		StatusPoint_: point,
 	}, nil
 }
 
-func importStatusHistory(history *statusHistory, source map[string]interface{}) error {
+func importStatusHistory(history *StatusHistory_, source map[string]interface{}) error {
 	checker := versionedChecker("history")
 	coerced, err := checker.Coerce(source, nil)
 	if err != nil {
@@ -125,8 +125,8 @@ func importStatusHistory(history *statusHistory, source map[string]interface{}) 
 	return nil
 }
 
-func importStatusList(sourceList []interface{}, importFunc statusDeserializationFunc) ([]*statusPoint, error) {
-	result := make([]*statusPoint, 0, len(sourceList))
+func importStatusList(sourceList []interface{}, importFunc statusDeserializationFunc) ([]*StatusPoint_, error) {
+	result := make([]*StatusPoint_, 0, len(sourceList))
 	for i, value := range sourceList {
 		source, ok := value.(map[string]interface{})
 		if !ok {
@@ -141,13 +141,13 @@ func importStatusList(sourceList []interface{}, importFunc statusDeserialization
 	return result, nil
 }
 
-type statusDeserializationFunc func(map[string]interface{}) (statusPoint, error)
+type statusDeserializationFunc func(map[string]interface{}) (StatusPoint_, error)
 
 var statusDeserializationFuncs = map[int]statusDeserializationFunc{
 	1: importStatusV1,
 }
 
-func importStatusV1(source map[string]interface{}) (statusPoint, error) {
+func importStatusV1(source map[string]interface{}) (StatusPoint_, error) {
 	fields := schema.Fields{
 		"value":   schema.String(),
 		"message": schema.String(),
@@ -163,7 +163,7 @@ func importStatusV1(source map[string]interface{}) (statusPoint, error) {
 
 	coerced, err := checker.Coerce(source, nil)
 	if err != nil {
-		return statusPoint{}, errors.Annotatef(err, "status v1 schema check failed")
+		return StatusPoint_{}, errors.Annotatef(err, "status v1 schema check failed")
 	}
 	valid := coerced.(map[string]interface{})
 	// From here we know that the map returned from the schema coercion
@@ -173,7 +173,7 @@ func importStatusV1(source map[string]interface{}) (statusPoint, error) {
 	if sourceData, set := valid["data"]; set {
 		data = sourceData.(map[string]interface{})
 	}
-	return statusPoint{
+	return StatusPoint_{
 		Value_:   valid["value"].(string),
 		Message_: valid["message"].(string),
 		Data_:    data,
@@ -182,7 +182,7 @@ func importStatusV1(source map[string]interface{}) (statusPoint, error) {
 }
 
 // StatusHistory implements HasStatusHistory.
-func (s *statusHistory) StatusHistory() []Status {
+func (s *StatusHistory_) StatusHistory() []Status {
 	var result []Status
 	if count := len(s.History); count > 0 {
 		result = make([]Status, count)
@@ -194,10 +194,10 @@ func (s *statusHistory) StatusHistory() []Status {
 }
 
 // SetStatusHistory implements HasStatusHistory.
-func (s *statusHistory) SetStatusHistory(args []StatusArgs) {
-	points := make([]*statusPoint, len(args))
+func (s *StatusHistory_) SetStatusHistory(args []StatusArgs) {
+	points := make([]*StatusPoint_, len(args))
 	for i, arg := range args {
-		points[i] = &statusPoint{
+		points[i] = &StatusPoint_{
 			Value_:   arg.Value,
 			Message_: arg.Message,
 			Data_:    arg.Data,
@@ -211,6 +211,6 @@ func addStatusHistorySchema(fields schema.Fields) {
 	fields["status-history"] = schema.StringMap(schema.Any())
 }
 
-func (s *statusHistory) importStatusHistory(valid map[string]interface{}) error {
+func (s *StatusHistory_) importStatusHistory(valid map[string]interface{}) error {
 	return importStatusHistory(s, valid["status-history"].(map[string]interface{}))
 }

--- a/core/description/status_test.go
+++ b/core/description/status_test.go
@@ -191,7 +191,7 @@ func (s *StatusHistorySerializationSuite) TestSetStatusHistory(c *gc.C) {
 	}
 }
 
-func (s *StatusHistorySerializationSuite) exportImport(c *gc.C, status_ statusHistory) statusHistory {
+func (s *StatusHistorySerializationSuite) exportImport(c *gc.C, status_ StatusHistory_) StatusHistory_ {
 	bytes, err := yaml.Marshal(status_)
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/core/description/unit.go
+++ b/core/description/unit.go
@@ -19,11 +19,11 @@ type unit struct {
 
 	Machine_ string `yaml:"machine"`
 
-	AgentStatus_        *status       `yaml:"agent-status"`
-	AgentStatusHistory_ statusHistory `yaml:"agent-status-history"`
+	AgentStatus_        *status        `yaml:"agent-status"`
+	AgentStatusHistory_ StatusHistory_ `yaml:"agent-status-history"`
 
-	WorkloadStatus_        *status       `yaml:"workload-status"`
-	WorkloadStatusHistory_ statusHistory `yaml:"workload-status-history"`
+	WorkloadStatus_        *status        `yaml:"workload-status"`
+	WorkloadStatusHistory_ StatusHistory_ `yaml:"workload-status-history"`
 
 	Principal_    string   `yaml:"principal,omitempty"`
 	Subordinates_ []string `yaml:"subordinates,omitempty"`
@@ -38,8 +38,7 @@ type unit struct {
 	MeterStatusCode_ string `yaml:"meter-status-code,omitempty"`
 	MeterStatusInfo_ string `yaml:"meter-status-info,omitempty"`
 
-	// annotations is exported as it is a composed type, even if private.
-	annotations `yaml:"annotations,omitempty"`
+	Annotations_ `yaml:"annotations,omitempty"`
 
 	Constraints_ *constraints `yaml:"constraints,omitempty"`
 }


### PR DESCRIPTION
Under Go 1.6, go-yaml panics when it encounters private embedded
types. This is fine in older Go versions and is even fine on Go 1.6
with encoding/json's serialization. go-yaml needs changing and I have
some idea of the changes required but I don't have the time to make
the changes nor them merged upstream. The YAML format produced is
unaffected by this change.

For now, various private embedded types have been made public. This
can be reversed at some point in the future.

This issue is a non-obvious side-effect of
https://golang.org/doc/go1.6#reflect.

(Review request: http://reviews.vapour.ws/r/4206/)