### PR TITLE
Fix parsing of novarc files

### DIFF
--- a/provider/openstack/credentials.go
+++ b/provider/openstack/credentials.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 
 	"github.com/juju/errors"
 	"github.com/juju/utils"
@@ -67,9 +68,11 @@ func (c OpenstackCredentials) DetectCredentials() (*cloud.CloudCredential, error
 	if err != nil {
 		return nil, errors.Annotate(err, "loading novarc file")
 	}
+	stripExport := regexp.MustCompile(`(?i)^\s*export\s*`)
 	keyValues := novaInfo.Section(ini.DEFAULT_SECTION).KeysHash()
 	if len(keyValues) > 0 {
 		for k, v := range keyValues {
+			k = stripExport.ReplaceAllString(k, "")
 			os.Setenv(k, v)
 		}
 		creds, user, region, err := c.detectCredential()

--- a/provider/openstack/credentials_test.go
+++ b/provider/openstack/credentials_test.go
@@ -123,16 +123,17 @@ func (s *credentialsSuite) TestDetectCredentialsNovarc(c *gc.C) {
 
 	content := `
 # Some secrets
-OS_TENANT_NAME=gary
-OS_USERNAME=bob
-OS_PASSWORD=dobbs
+export OS_TENANT_NAME=gary
+EXPORT OS_USERNAME=bob
+  export  OS_PASSWORD = dobbs
+OS_REGION_NAME=region  
 `[1:]
 	novarc := filepath.Join(dir, ".novarc")
 	err := ioutil.WriteFile(novarc, []byte(content), 0600)
 
 	credentials, err := s.provider.DetectCredentials()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(credentials.DefaultRegion, gc.Equals, "")
+	c.Assert(credentials.DefaultRegion, gc.Equals, "region")
 	expected := cloud.NewCredential(
 		cloud.UserPassAuthType, map[string]string{
 			"username":    "bob",
@@ -140,6 +141,6 @@ OS_PASSWORD=dobbs
 			"tenant-name": "gary",
 		},
 	)
-	expected.Label = `openstack region "<unspecified>" project "gary" user "bob"`
+	expected.Label = `openstack region "region" project "gary" user "bob"`
 	c.Assert(credentials.AuthCredentials["bob"], jc.DeepEquals, expected)
 }


### PR DESCRIPTION
The parsing of novarc files was not stripping out the export keyword on each line.

(Review request: http://reviews.vapour.ws/r/4208/)