### PR TITLE
Removed fancycheck from a few tests

### DIFF
--- a/apiserver/common/networkingcommon/types_test.go
+++ b/apiserver/common/networkingcommon/types_test.go
@@ -8,7 +8,6 @@ import (
 	"math/rand"
 	"net"
 
-	"github.com/axw/fancycheck"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -892,7 +891,7 @@ func (s *TypesSuite) checkSortNetworkConfigsByParentsWithAllInputPremutationsMat
 		result := networkingcommon.SortNetworkConfigsByParents(shuffledInput)
 		c.Assert(result, gc.HasLen, expectedLength)
 		jsonResult := s.networkConfigsAsJSON(c, result)
-		c.Check(jsonResult, fancycheck.StringEquals, jsonExpected)
+		c.Check(jsonResult, gc.Equals, jsonExpected)
 	}
 }
 
@@ -928,7 +927,7 @@ func (s *TypesSuite) TestSortNetworkConfigsByInterfaceName(c *gc.C) {
 		result := networkingcommon.SortNetworkConfigsByInterfaceName(shuffledInput)
 		c.Assert(result, gc.HasLen, expectedLength)
 		jsonResult := s.networkConfigsAsJSON(c, result)
-		c.Check(jsonResult, fancycheck.StringEquals, jsonExpected)
+		c.Check(jsonResult, gc.Equals, jsonExpected)
 	}
 }
 
@@ -943,7 +942,7 @@ func (s *TypesSuite) TestMergeProviderAndObservedNetworkConfigs(c *gc.C) {
 
 			mergedConfigs := networkingcommon.MergeProviderAndObservedNetworkConfigs(shuffledProviderConfigs, shuffledObservedConfigs)
 			jsonResult := s.networkConfigsAsJSON(c, mergedConfigs)
-			c.Check(jsonResult, fancycheck.StringEquals, jsonExpected)
+			c.Check(jsonResult, gc.Equals, jsonExpected)
 		}
 	}
 }
@@ -964,12 +963,12 @@ func (s *TypesSuite) TestGetObservedNetworkConfig(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	jsonResult := s.networkConfigsAsJSON(c, observedConfig)
 	jsonExpected := s.networkConfigsAsJSON(c, expectedSortedObservedNetworkConfigs)
-	c.Check(jsonResult, fancycheck.StringEquals, jsonExpected)
+	c.Check(jsonResult, gc.Equals, jsonExpected)
 }
 
 func (s *TypesSuite) TestNetworkConfigsToStateArgs(c *gc.C) {
 	devicesArgs, devicesAddrs := networkingcommon.NetworkConfigsToStateArgs(expectedSortedMergedNetworkConfigs)
 
-	c.Check(devicesArgs, fancycheck.StringEquals, expectedLinkLayerDeviceArgsWithMergedNetworkConfig)
-	c.Check(devicesAddrs, fancycheck.StringEquals, expectedLinkLayerDeviceAdressesWithMergedNetworkConfig)
+	c.Check(devicesArgs, jc.DeepEquals, expectedLinkLayerDeviceArgsWithMergedNetworkConfig)
+	c.Check(devicesAddrs, jc.DeepEquals, expectedLinkLayerDeviceAdressesWithMergedNetworkConfig)
 }

--- a/cloudconfig/containerinit/container_userdata_test.go
+++ b/cloudconfig/containerinit/container_userdata_test.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	stdtesting "testing"
 
-	"github.com/axw/fancycheck"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/yaml.v2"
@@ -160,7 +159,7 @@ func (s *UserDataSuite) TestCloudInitUserData(c *gc.C) {
 func assertUserData(c *gc.C, cloudConf cloudinit.CloudConfig, expected string) {
 	data, err := cloudConf.RenderYAML()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(string(data), fancycheck.StringEquals, expected)
+	c.Assert(string(data), gc.Equals, expected)
 	// Make sure it's valid YAML as well.
 	out := make(map[string]interface{})
 	err = yaml.Unmarshal(data, &out)


### PR DESCRIPTION
It was meant to be used only temporary for a few tests, not needed
anymore.

(Review request: http://reviews.vapour.ws/r/4210/)