### PR TITLE
Fixes bug LP: #1319890

### DIFF
--- a/apiserver/client/status.go
+++ b/apiserver/client/status.go
@@ -326,7 +326,7 @@ type statusContext struct {
 	relations    map[string][]*state.Relation
 	units        map[string]map[string]*state.Unit
 	networks     map[string]*state.Network
-	latestCharms map[charm.URL]string
+	latestCharms map[charm.URL]*state.Charm
 }
 
 // fetchMachines returns a map from top level machine id to machines, where machines[0] is the host
@@ -366,11 +366,11 @@ func fetchMachines(st stateInterface, machineIds set.Strings) (map[string][]*sta
 func fetchAllServicesAndUnits(
 	st stateInterface,
 	matchAny bool,
-) (map[string]*state.Service, map[string]map[string]*state.Unit, map[charm.URL]string, error) {
+) (map[string]*state.Service, map[string]map[string]*state.Unit, map[charm.URL]*state.Charm, error) {
 
 	svcMap := make(map[string]*state.Service)
 	unitMap := make(map[string]map[string]*state.Unit)
-	latestCharms := make(map[charm.URL]string)
+	latestCharms := make(map[charm.URL]*state.Charm)
 	services, err := st.AllServices()
 	if err != nil {
 		return nil, nil, nil, err
@@ -391,7 +391,7 @@ func fetchAllServicesAndUnits(
 			// the latest store revision can be looked up.
 			charmURL, _ := s.CharmURL()
 			if charmURL.Schema == "cs" {
-				latestCharms[*charmURL.WithRevision(-1)] = ""
+				latestCharms[*charmURL.WithRevision(-1)] = nil
 			}
 		}
 	}
@@ -403,8 +403,9 @@ func fetchAllServicesAndUnits(
 		if err != nil {
 			return nil, nil, nil, err
 		}
-		latestCharms[baseURL] = ch.String()
+		latestCharms[baseURL] = ch
 	}
+
 	return svcMap, unitMap, latestCharms, nil
 }
 
@@ -620,10 +621,12 @@ func (context *statusContext) processService(service *state.Service) (processedS
 	processedStatus.Exposed = service.IsExposed()
 	processedStatus.Life = processLife(service)
 
-	latestCharm, ok := context.latestCharms[*serviceCharmURL.WithRevision(-1)]
-	if ok && latestCharm != serviceCharmURL.String() {
-		processedStatus.CanUpgradeTo = latestCharm
+	if latestCharm, ok := context.latestCharms[*serviceCharmURL.WithRevision(-1)]; ok && latestCharm != nil {
+		if latestCharm.Revision() > serviceCharmURL.Revision {
+			processedStatus.CanUpgradeTo = latestCharm.String()
+		}
 	}
+
 	var err error
 	processedStatus.Relations, processedStatus.SubordinateTo, err = context.processServiceRelations(service)
 	if err != nil {


### PR DESCRIPTION
This change validates that the latest available
revision is greater than the current, in that case
it sets the CanUpgradeTo field to the latest URL.

I also added unit tests for validating the change.

Signed-off-by: Jorge Niedbalski <jorge.niedbalski@canonical.com>

(Review request: http://reviews.vapour.ws/r/4216/)