### PR TITLE
provider/manual: PrepareForCreateEnvironment

### DIFF
--- a/provider/manual/provider.go
+++ b/provider/manual/provider.go
@@ -47,8 +47,7 @@ func (p manualProvider) DetectRegions() ([]cloud.Region, error) {
 
 // PrepareForCreateEnvironment is specified in the EnvironProvider interface.
 func (p manualProvider) PrepareForCreateEnvironment(cfg *config.Config) (*config.Config, error) {
-	// Not even sure if this will ever make sense.
-	return nil, errors.NotImplementedf("PrepareForCreateEnvironment")
+	return cfg, nil
 }
 
 // BootstrapConfig is specified in the EnvironProvider interface.

--- a/provider/manual/provider_test.go
+++ b/provider/manual/provider_test.go
@@ -33,6 +33,14 @@ func (s *providerSuite) SetUpTest(c *gc.C) {
 	})
 }
 
+func (s *providerSuite) TestPrepareForCreateEnvironment(c *gc.C) {
+	testConfig, err := config.New(config.UseDefaults, manual.MinimalConfigValues())
+	c.Assert(err, jc.ErrorIsNil)
+	cfg, err := manual.ProviderInstance.PrepareForCreateEnvironment(testConfig)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cfg, gc.Equals, testConfig)
+}
+
 func (s *providerSuite) TestPrepareForBootstrapCloudEndpointAndRegion(c *gc.C) {
 	ctx, err := s.testPrepareForBootstrap(c, "endpoint", "region")
 	c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
Implement PrepareForCreateEnvironment for the manual provider.
The implementation just returns the input config, as there is
nothing to add.

Fixes https://bugs.launchpad.net/juju-core/+bug/1558678

(Review request: http://reviews.vapour.ws/r/4221/)