### PR TITLE
Fix issue creating hosted model config

### DIFF
--- a/agent/agentbootstrap/bootstrap.go
+++ b/agent/agentbootstrap/bootstrap.go
@@ -24,8 +24,6 @@ import (
 
 var logger = loggo.GetLogger("juju.agent.agentbootstrap")
 
-const AdminModelName = "admin"
-
 // BootstrapMachineConfig holds configuration information
 // to attach to the bootstrap machine.
 type BootstrapMachineConfig struct {
@@ -125,7 +123,7 @@ func InitializeState(
 
 	// Create the initial hosted model, with the model config passed to
 	// bootstrap, which contains the UUID and name for the hosted model.
-	attrs := cfg.AllAttrs()
+	attrs := make(map[string]interface{})
 	for k, v := range hostedModelConfigAttrs {
 		attrs[k] = v
 	}

--- a/agent/agentbootstrap/bootstrap.go
+++ b/agent/agentbootstrap/bootstrap.go
@@ -122,7 +122,8 @@ func InitializeState(
 	}
 
 	// Create the initial hosted model, with the model config passed to
-	// bootstrap, which contains the UUID and name for the hosted model.
+	// bootstrap, which contains the UUID, name for the hosted model,
+	// and any user supplied config.
 	attrs := make(map[string]interface{})
 	for k, v := range hostedModelConfigAttrs {
 		attrs[k] = v

--- a/agent/agentbootstrap/bootstrap_test.go
+++ b/agent/agentbootstrap/bootstrap_test.go
@@ -127,7 +127,8 @@ LXC_BRIDGE="ignored"`[1:])
 	provider, err := environs.Provider("dummy")
 	c.Assert(err, jc.ErrorIsNil)
 	envAttrs := dummy.SampleConfig().Delete("admin-secret").Merge(testing.Attrs{
-		"agent-version": version.Current.String(),
+		"agent-version":  version.Current.String(),
+		"not-for-hosted": "foo",
 	})
 	envCfg, err := config.New(config.NoDefaults, envAttrs)
 	c.Assert(err, jc.ErrorIsNil)
@@ -184,6 +185,10 @@ LXC_BRIDGE="ignored"`[1:])
 	hostedModel, err := hostedModelSt.Model()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(hostedModel.Name(), gc.Equals, "hosted")
+	hostedCfg, err := hostedModelSt.ModelConfig()
+	c.Assert(err, jc.ErrorIsNil)
+	_, hasUnexpected := hostedCfg.AllAttrs()["not-for-hosted"]
+	c.Assert(hasUnexpected, jc.IsFalse)
 
 	// Check that the bootstrap machine looks correct.
 	c.Assert(m.Id(), gc.Equals, "0")

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -467,6 +467,13 @@ to clean up the model.`[1:])
 	}
 	logger.Infof("combined bootstrap constraints: %v", bootstrapConstraints)
 
+	hostedModelConfig := map[string]interface{}{
+		"name":         c.hostedModelName,
+		config.UUIDKey: hostedModelUUID.String(),
+	}
+	for k, v := range userConfigAttrs {
+		hostedModelConfig[k] = v
+	}
 	err = bootstrapFuncs.Bootstrap(modelcmd.BootstrapContext(ctx), environ, bootstrap.BootstrapParams{
 		ModelConstraints:     c.Constraints,
 		BootstrapConstraints: bootstrapConstraints,
@@ -476,10 +483,7 @@ to clean up the model.`[1:])
 		UploadTools:          c.UploadTools,
 		AgentVersion:         c.AgentVersion,
 		MetadataDir:          metadataDir,
-		HostedModelConfig: map[string]interface{}{
-			"name":         c.hostedModelName,
-			config.UUIDKey: hostedModelUUID.String(),
-		},
+		HostedModelConfig:    hostedModelConfig,
 	})
 	if err != nil {
 		return errors.Annotate(err, "failed to bootstrap model")

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -493,8 +493,10 @@ func (s *BootstrapSuite) TestBootstrapDefaultModel(c *gc.C) {
 		"devcontroller", "dummy",
 		"--auto-upgrade",
 		"--default-model", "mymodel",
+		"--config", "foo=bar",
 	)
 	c.Assert(bootstrap.args.HostedModelConfig["name"], gc.Equals, "mymodel")
+	c.Assert(bootstrap.args.HostedModelConfig["foo"], gc.Equals, "bar")
 }
 
 type mockBootstrapInstance struct {


### PR DESCRIPTION
When creating the hosted model config, we were copying across the entire admin model config by mistake.

(Review request: http://reviews.vapour.ws/r/4222/)