### PR TITLE
Model agent integration

### DIFF
--- a/api/undertaker/undertaker.go
+++ b/api/undertaker/undertaker.go
@@ -5,88 +5,70 @@ package undertaker
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/names"
 
 	"github.com/juju/juju/api/base"
-	apiwatcher "github.com/juju/juju/api/watcher"
 	"github.com/juju/juju/apiserver/params"
-	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/watcher"
 )
 
+// NewWatcherFunc exists to let us test Watch properly.
+type NewWatcherFunc func(base.APICaller, params.NotifyWatchResult) watcher.NotifyWatcher
+
 // Client provides access to the undertaker API
 type Client struct {
-	base.ClientFacade
-	st     base.APICallCloser
-	facade base.FacadeCaller
-}
-
-// UndertakerClient defines the methods on the undertaker API end point.
-type UndertakerClient interface {
-	ModelInfo() (params.UndertakerModelInfoResult, error)
-	ProcessDyingModel() error
-	RemoveModel() error
-	WatchModelResources() (watcher.NotifyWatcher, error)
-	ModelConfig() (*config.Config, error)
+	modelTag   names.ModelTag
+	caller     base.FacadeCaller
+	newWatcher NewWatcherFunc
 }
 
 // NewClient creates a new client for accessing the undertaker API.
-func NewClient(st base.APICallCloser) *Client {
-	frontend, backend := base.NewClientFacade(st, "Undertaker")
-	return &Client{ClientFacade: frontend, st: st, facade: backend}
+func NewClient(caller base.APICaller, newWatcher NewWatcherFunc) (*Client, error) {
+	modelTag, err := caller.ModelTag()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return &Client{
+		modelTag:   modelTag,
+		caller:     base.NewFacadeCaller(caller, "Undertaker"),
+		newWatcher: newWatcher,
+	}, nil
 }
 
 // ModelInfo returns information on the model needed by the undertaker worker.
 func (c *Client) ModelInfo() (params.UndertakerModelInfoResult, error) {
 	result := params.UndertakerModelInfoResult{}
-	p, err := c.params()
-	if err != nil {
-		return params.UndertakerModelInfoResult{}, errors.Trace(err)
-	}
-	err = c.facade.FacadeCall("ModelInfo", p, &result)
+	err := c.facadeCall("ModelInfo", &result)
 	return result, errors.Trace(err)
 }
 
 // ProcessDyingModel checks if a dying model has any machines or services.
 // If there are none, the model's life is changed from dying to dead.
 func (c *Client) ProcessDyingModel() error {
-	p, err := c.params()
-	if err != nil {
-		return errors.Trace(err)
-	}
-
-	return c.facade.FacadeCall("ProcessDyingModel", p, nil)
+	return c.facadeCall("ProcessDyingModel", nil)
 }
 
 // RemoveModel removes any records of this model from Juju.
 func (c *Client) RemoveModel() error {
-	p, err := c.params()
-	if err != nil {
-		return errors.Trace(err)
-	}
-	return c.facade.FacadeCall("RemoveModel", p, nil)
+	return c.facadeCall("RemoveModel", nil)
 }
 
-func (c *Client) params() (params.Entities, error) {
-	modelTag, err := c.st.ModelTag()
-	if err != nil {
-		return params.Entities{}, errors.Trace(err)
+func (c *Client) facadeCall(name string, results interface{}) error {
+	args := params.Entities{
+		Entities: []params.Entity{{c.modelTag.String()}},
 	}
-	return params.Entities{Entities: []params.Entity{{modelTag.String()}}}, nil
+	return c.caller.FacadeCall(name, args, results)
 }
 
 // WatchModelResources starts a watcher for changes to the model's
 // machines and services.
 func (c *Client) WatchModelResources() (watcher.NotifyWatcher, error) {
 	var results params.NotifyWatchResults
-
-	p, err := c.params()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	err = c.facade.FacadeCall("WatchModelResources", p, &results)
+	err := c.facadeCall("WatchModelResources", &results)
 	if err != nil {
 		return nil, err
 	}
+
 	if len(results.Results) != 1 {
 		return nil, errors.Errorf("expected 1 result, got %d", len(results.Results))
 	}
@@ -94,25 +76,6 @@ func (c *Client) WatchModelResources() (watcher.NotifyWatcher, error) {
 	if result.Error != nil {
 		return nil, result.Error
 	}
-	w := apiwatcher.NewNotifyWatcher(c.facade.RawAPICaller(), result)
+	w := c.newWatcher(c.caller.RawAPICaller(), result)
 	return w, nil
-}
-
-// ModelConfig returns configuration information on the model needed
-// by the undertaker worker.
-func (c *Client) ModelConfig() (*config.Config, error) {
-	p, err := c.params()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	var result params.ModelConfigResult
-	err = c.facade.FacadeCall("ModelConfig", p, &result)
-	if err != nil {
-		return nil, err
-	}
-	conf, err := config.New(config.NoDefaults, result.Config)
-	if err != nil {
-		return nil, err
-	}
-	return conf, nil
 }

--- a/api/undertaker/undertaker_test.go
+++ b/api/undertaker/undertaker_test.go
@@ -4,20 +4,25 @@
 package undertaker_test
 
 import (
-	"time"
-
+	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/api/base"
 	basetesting "github.com/juju/juju/api/base/testing"
 	"github.com/juju/juju/api/undertaker"
 	"github.com/juju/juju/apiserver/params"
 	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/watcher"
 )
 
-var _ undertaker.UndertakerClient = (*undertaker.Client)(nil)
+type UndertakerSuite struct {
+	testing.IsolationSuite
+}
 
-func (s *undertakerSuite) TestEnvironInfo(c *gc.C) {
+var _ = gc.Suite(&UndertakerSuite{})
+
+func (s *UndertakerSuite) TestEnvironInfo(c *gc.C) {
 	var called bool
 	client := s.mockClient(c, "ModelInfo", func(response interface{}) {
 		called = true
@@ -31,7 +36,7 @@ func (s *undertakerSuite) TestEnvironInfo(c *gc.C) {
 	c.Assert(result, gc.Equals, params.UndertakerModelInfoResult{})
 }
 
-func (s *undertakerSuite) TestProcessDyingEnviron(c *gc.C) {
+func (s *UndertakerSuite) TestProcessDyingEnviron(c *gc.C) {
 	var called bool
 	client := s.mockClient(c, "ProcessDyingModel", func(response interface{}) {
 		called = true
@@ -42,7 +47,7 @@ func (s *undertakerSuite) TestProcessDyingEnviron(c *gc.C) {
 	c.Assert(called, jc.IsTrue)
 }
 
-func (s *undertakerSuite) TestRemoveModel(c *gc.C) {
+func (s *UndertakerSuite) TestRemoveModel(c *gc.C) {
 	var called bool
 	client := s.mockClient(c, "RemoveModel", func(response interface{}) {
 		called = true
@@ -54,72 +59,74 @@ func (s *undertakerSuite) TestRemoveModel(c *gc.C) {
 	c.Assert(called, jc.IsTrue)
 }
 
-func (s *undertakerSuite) mockClient(c *gc.C, expectedRequest string, callback func(response interface{})) *undertaker.Client {
-	apiCaller := basetesting.APICallerFunc(
-		func(objType string,
-			version int,
-			id, request string,
-			args, response interface{},
-		) error {
-			c.Check(objType, gc.Equals, "Undertaker")
-			c.Check(id, gc.Equals, "")
-			c.Check(request, gc.Equals, expectedRequest)
+func (s *UndertakerSuite) mockClient(c *gc.C, expectedRequest string, callback func(response interface{})) *undertaker.Client {
+	apiCaller := basetesting.APICallerFunc(func(
+		objType string,
+		version int,
+		id, request string,
+		args, response interface{},
+	) error {
+		c.Check(objType, gc.Equals, "Undertaker")
+		c.Check(id, gc.Equals, "")
+		c.Check(request, gc.Equals, expectedRequest)
 
-			a, ok := args.(params.Entities)
-			c.Check(ok, jc.IsTrue)
-			c.Check(a.Entities, gc.DeepEquals, []params.Entity{{Tag: coretesting.ModelTag.String()}})
+		a, ok := args.(params.Entities)
+		c.Check(ok, jc.IsTrue)
+		c.Check(a.Entities, gc.DeepEquals, []params.Entity{{Tag: coretesting.ModelTag.String()}})
 
-			callback(response)
-			return nil
-		})
-
-	return undertaker.NewClient(apiCaller)
+		callback(response)
+		return nil
+	})
+	client, err := undertaker.NewClient(apiCaller, nil)
+	c.Assert(err, jc.ErrorIsNil)
+	return client
 }
 
-func (s *undertakerSuite) TestWatchModelResourcesGetsChange(c *gc.C) {
-	apiCaller := basetesting.APICallerFunc(
-		func(objType string,
-			version int,
-			id, request string,
-			args, response interface{},
-		) error {
-			if resp, ok := response.(*params.NotifyWatchResults); ok {
-				c.Check(objType, gc.Equals, "Undertaker")
-				c.Check(id, gc.Equals, "")
-				c.Check(request, gc.Equals, "WatchModelResources")
+func (s *UndertakerSuite) TestWatchModelResourcesCreatesWatcher(c *gc.C) {
+	apiCaller := basetesting.APICallerFunc(func(
+		objType string,
+		version int,
+		id, request string,
+		args, response interface{},
+	) error {
+		c.Check(objType, gc.Equals, "Undertaker")
+		c.Check(id, gc.Equals, "")
+		c.Check(request, gc.Equals, "WatchModelResources")
 
-				a, ok := args.(params.Entities)
-				c.Check(ok, jc.IsTrue)
-				c.Check(a.Entities, gc.DeepEquals, []params.Entity{{Tag: coretesting.ModelTag.String()}})
+		a, ok := args.(params.Entities)
+		c.Check(ok, jc.IsTrue)
+		c.Check(a.Entities, gc.DeepEquals, []params.Entity{{Tag: coretesting.ModelTag.String()}})
 
-				resp.Results = []params.NotifyWatchResult{{NotifyWatcherId: "1"}}
-			} else {
-				c.Check(objType, gc.Equals, "NotifyWatcher")
-				c.Check(id, gc.Equals, "1")
-				c.Check(request, gc.Equals, "Next")
-			}
-			return nil
+		resp, ok := response.(*params.NotifyWatchResults)
+		c.Assert(ok, jc.IsTrue)
+		resp.Results = []params.NotifyWatchResult{{
+			NotifyWatcherId: "1001",
+		}}
+		return nil
+	})
+
+	expectWatcher := &fakeWatcher{}
+	newWatcher := func(apiCaller base.APICaller, result params.NotifyWatchResult) watcher.NotifyWatcher {
+		c.Check(apiCaller, gc.NotNil) // uncomparable
+		c.Check(result, gc.Equals, params.NotifyWatchResult{
+			NotifyWatcherId: "1001",
 		})
+		return expectWatcher
+	}
 
-	client := undertaker.NewClient(apiCaller)
+	client, err := undertaker.NewClient(apiCaller, newWatcher)
+	c.Assert(err, jc.ErrorIsNil)
 	w, err := client.WatchModelResources()
 	c.Assert(err, jc.ErrorIsNil)
-
-	select {
-	case <-w.Changes():
-	case <-time.After(coretesting.ShortWait):
-		c.Fatalf("timed out waiting for change")
-	}
+	c.Check(w, gc.Equals, expectWatcher)
 }
 
-func (s *undertakerSuite) TestWatchModelResourcesError(c *gc.C) {
+func (s *UndertakerSuite) TestWatchModelResourcesError(c *gc.C) {
 	var called bool
-
-	// The undertaker feature tests ensure WatchModelResources is connected
-	// correctly end to end. This test just ensures that the API calls work.
 	client := s.mockClient(c, "WatchModelResources", func(response interface{}) {
 		called = true
-		c.Check(response, gc.DeepEquals, &params.NotifyWatchResults{Results: []params.NotifyWatchResult(nil)})
+		_, ok := response.(*params.NotifyWatchResults)
+		c.Check(ok, jc.IsTrue)
 	})
 
 	w, err := client.WatchModelResources()
@@ -128,18 +135,6 @@ func (s *undertakerSuite) TestWatchModelResourcesError(c *gc.C) {
 	c.Assert(called, jc.IsTrue)
 }
 
-func (s *undertakerSuite) TestModelConfig(c *gc.C) {
-	var called bool
-
-	// The undertaker feature tests ensure ModelConfig is connected
-	// correctly end to end. This test just ensures that the API calls work.
-	client := s.mockClient(c, "ModelConfig", func(response interface{}) {
-		called = true
-		c.Check(response, gc.DeepEquals, &params.ModelConfigResult{Config: params.ModelConfig(nil)})
-	})
-
-	// We intentionally don't test the error here. We are only interested that
-	// the ModelConfig endpoint was called.
-	client.ModelConfig()
-	c.Assert(called, jc.IsTrue)
+type fakeWatcher struct {
+	watcher.NotifyWatcher
 }

--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -245,8 +245,9 @@ var globalCounter int64
 
 func newRequestNotifier(count *int32) *requestNotifier {
 	return &requestNotifier{
-		id:    atomic.AddInt64(&globalCounter, 1),
-		tag_:  "<unknown>",
+		id:   atomic.AddInt64(&globalCounter, 1),
+		tag_: "<unknown>",
+		// TODO(fwereade): 2016-03-17 lp:1558657
 		start: time.Now(),
 		count: count,
 	}
@@ -515,6 +516,7 @@ func (srv *Server) newAPIHandler(conn *rpc.Conn, reqNotifier *requestNotifier, m
 }
 
 func (srv *Server) mongoPinger() error {
+	// TODO(fwereade): 2016-03-17 lp:1558657
 	timer := time.NewTimer(0)
 	session := srv.state.MongoSession().Copy()
 	defer session.Close()

--- a/apiserver/authentication/user.go
+++ b/apiserver/authentication/user.go
@@ -62,6 +62,7 @@ func (m *MacaroonAuthenticator) newDischargeRequiredError(cause error) error {
 		return errors.Trace(cause)
 	}
 	mac := m.Macaroon.Clone()
+	// TODO(fwereade): 2016-03-17 lp:1558657
 	err := m.Service.AddCaveat(mac, checkers.TimeBeforeCaveat(time.Now().Add(time.Hour)))
 	if err != nil {
 		return errors.Annotatef(err, "cannot create macaroon")

--- a/apiserver/common/watch.go
+++ b/apiserver/common/watch.go
@@ -136,6 +136,7 @@ func (w *MultiNotifyWatcher) loop(in <-chan struct{}) {
 			return
 		case <-in:
 			if timer == nil {
+				// TODO(fwereade): 2016-03-17 lp:1558657
 				timer = time.After(10 * time.Millisecond)
 			}
 		case <-timer:

--- a/apiserver/metricsender/metricsender.go
+++ b/apiserver/metricsender/metricsender.go
@@ -93,6 +93,7 @@ func SendMetrics(st *state.State, sender MetricSender, batchSize int) error {
 		if response != nil {
 			// TODO (mattyw) We are currently ignoring errors during response handling.
 			handleResponse(metricsManager, st, *response)
+			// TODO(fwereade): 2016-03-17 lp:1558657
 			if err := metricsManager.SetLastSuccessfulSend(time.Now()); err != nil {
 				err = errors.Annotate(err, "failed to set successful send time")
 				logger.Warningf("%v", err)

--- a/apiserver/params/status.go
+++ b/apiserver/params/status.go
@@ -171,16 +171,6 @@ type UnitStatusHistory struct {
 	Statuses []AgentStatus
 }
 
-const (
-	// DefaultMaxLogsPerEntity is the default value for logs for each entity
-	// that should be kept at any given time.
-	DefaultMaxLogsPerEntity = 100
-
-	// DefaultPruneInterval is the default interval that should be waited
-	// between prune calls.
-	DefaultPruneInterval = 5 * time.Minute
-)
-
 // StatusHistoryPruneArgs holds arguments for status history
 // prunning process.
 type StatusHistoryPruneArgs struct {

--- a/apiserver/pinger.go
+++ b/apiserver/pinger.go
@@ -79,6 +79,7 @@ func (pt *pingTimeout) Stop() error {
 // loop waits for a reset signal, otherwise it performs
 // the initially passed action.
 func (pt *pingTimeout) loop() error {
+	// TODO(fwereade): 2016-03-17 lp:1558657
 	timer := time.NewTimer(pt.timeout)
 	defer timer.Stop()
 	for {

--- a/apiserver/provisioner/machineerror.go
+++ b/apiserver/provisioner/machineerror.go
@@ -70,6 +70,7 @@ func (w *machineErrorRetry) loop() error {
 		select {
 		case <-w.tomb.Dying():
 			return tomb.ErrDying
+		// TODO(fwereade): 2016-03-17 lp:1558657
 		case <-time.After(ErrorRetryWaitDelay):
 			out = w.out
 		case out <- struct{}{}:

--- a/cmd/juju/action/fetch.go
+++ b/cmd/juju/action/fetch.go
@@ -89,6 +89,7 @@ func (c *fetchCommand) Run(ctx *cmd.Context) error {
 	defer api.Close()
 
 	// tick every two seconds, to delay the loop timer.
+	// TODO(fwereade): 2016-03-17 lp:1558657
 	tick := time.NewTimer(2 * time.Second)
 	wait := time.NewTimer(0 * time.Second)
 

--- a/cmd/juju/metricsdebug/collectmetrics.go
+++ b/cmd/juju/metricsdebug/collectmetrics.go
@@ -153,6 +153,7 @@ func (c *collectMetricsCommand) Run(ctx *cmd.Context) error {
 	for _ = range runResults {
 		select {
 		case <-resultChannel:
+		// TODO(fwereade): 2016-03-17 lp:1558657
 		case <-time.After(3 * time.Second):
 			fmt.Fprintf(ctx.Stdout, "wait result timeout")
 			break

--- a/cmd/juju/service/bundle.go
+++ b/cmd/juju/service/bundle.go
@@ -609,6 +609,7 @@ func (h *bundleHandler) updateUnitStatus() error {
 			}
 		}
 	case <-time.After(updateUnitStatusPeriod):
+		// TODO(fwereade): 2016-03-17 lp:1558657
 		return errors.New("timeout while trying to get new changes from the watcher")
 	}
 	return nil

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -18,7 +18,6 @@ import (
 	"github.com/juju/errors"
 	apiagent "github.com/juju/juju/api/agent"
 	apimachiner "github.com/juju/juju/api/machiner"
-	apiundertaker "github.com/juju/juju/api/undertaker"
 	"github.com/juju/loggo"
 	"github.com/juju/names"
 	"github.com/juju/replicaset"
@@ -41,7 +40,6 @@ import (
 	"github.com/juju/juju/api/agenttools"
 	apideployer "github.com/juju/juju/api/deployer"
 	"github.com/juju/juju/api/metricsmanager"
-	"github.com/juju/juju/api/statushistory"
 	apistorageprovisioner "github.com/juju/juju/api/storageprovisioner"
 	"github.com/juju/juju/apiserver"
 	"github.com/juju/juju/apiserver/params"
@@ -55,7 +53,6 @@ import (
 	"github.com/juju/juju/container/lxc"
 	"github.com/juju/juju/container/lxc/lxcutils"
 	"github.com/juju/juju/environs"
-	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/simplestreams"
 	"github.com/juju/juju/instance"
 	jujunames "github.com/juju/juju/juju/names"
@@ -72,39 +69,25 @@ import (
 	"github.com/juju/juju/version"
 	"github.com/juju/juju/watcher"
 	"github.com/juju/juju/worker"
-	"github.com/juju/juju/worker/addresser"
 	"github.com/juju/juju/worker/apicaller"
 	"github.com/juju/juju/worker/certupdater"
-	"github.com/juju/juju/worker/charmrevision"
-	"github.com/juju/juju/worker/cleaner"
 	"github.com/juju/juju/worker/conv2state"
 	"github.com/juju/juju/worker/dblogpruner"
 	"github.com/juju/juju/worker/dependency"
 	"github.com/juju/juju/worker/deployer"
-	"github.com/juju/juju/worker/discoverspaces"
-	"github.com/juju/juju/worker/firewaller"
 	"github.com/juju/juju/worker/gate"
 	"github.com/juju/juju/worker/imagemetadataworker"
-	"github.com/juju/juju/worker/instancepoller"
 	"github.com/juju/juju/worker/logsender"
-	"github.com/juju/juju/worker/machiner"
-	"github.com/juju/juju/worker/metricworker"
-	"github.com/juju/juju/worker/minunitsworker"
 	"github.com/juju/juju/worker/modelworkermanager"
 	"github.com/juju/juju/worker/mongoupgrader"
 	"github.com/juju/juju/worker/peergrouper"
 	"github.com/juju/juju/worker/provisioner"
 	"github.com/juju/juju/worker/singular"
-	"github.com/juju/juju/worker/statushistorypruner"
 	"github.com/juju/juju/worker/storageprovisioner"
 	"github.com/juju/juju/worker/toolsversionchecker"
 	"github.com/juju/juju/worker/txnpruner"
-	"github.com/juju/juju/worker/undertaker"
-	"github.com/juju/juju/worker/unitassigner"
 	"github.com/juju/juju/worker/upgradesteps"
 )
-
-const bootstrapMachineId = "0"
 
 var (
 	logger       = loggo.GetLogger("juju.cmd.jujud")
@@ -117,21 +100,14 @@ var (
 	useMultipleCPUs          = utils.UseMultipleCPUs
 	maybeInitiateMongoServer = peergrouper.MaybeInitiateMongoServer
 	ensureMongoAdminUser     = mongo.EnsureAdminUser
+	modelManifolds           = model.Manifolds
 	newSingularRunner        = singular.New
 	peergrouperNew           = peergrouper.New
-	newMachiner              = machiner.NewMachiner
-	newDiscoverSpaces        = discoverspaces.NewWorker
-	newFirewaller            = firewaller.NewFirewaller
 	newStorageWorker         = storageprovisioner.NewStorageProvisioner
 	newCertificateUpdater    = certupdater.NewCertificateUpdater
-	newInstancePoller        = instancepoller.NewWorker
-	newCleaner               = cleaner.NewCleaner
-	newAddresser             = addresser.NewWorker
 	newMetadataUpdater       = imagemetadataworker.NewWorker
 	newUpgradeMongoWorker    = mongoupgrader.New
 	reportOpenedState        = func(io.Closer) {}
-	getMetricAPI             = metricAPI
-	getUndertakerAPI         = undertakerAPI
 )
 
 // Variable to override in tests, default is true
@@ -970,8 +946,6 @@ func (a *MachineAgent) StateWorker() (worker.Worker, error) {
 		return nil, errors.Trace(err)
 	}
 
-	// Take advantage of special knowledge here in that we will only ever want
-	// the storage provider on one machine, and that is the "bootstrap" node.
 	for _, job := range m.Jobs() {
 		switch job {
 		case state.JobHostUnits:
@@ -979,7 +953,15 @@ func (a *MachineAgent) StateWorker() (worker.Worker, error) {
 		case state.JobManageModel:
 			useMultipleCPUs()
 			a.startWorkerAfterUpgrade(runner, "model worker manager", func() (worker.Worker, error) {
-				return modelworkermanager.NewModelWorkerManager(st, a.startEnvWorkers, a.undertakerWorker, worker.RestartDelay), nil
+				w, err := modelworkermanager.New(modelworkermanager.Config{
+					Backend:    st,
+					NewWorker:  a.startModelWorkers,
+					ErrorDelay: worker.RestartDelay,
+				})
+				if err != nil {
+					return nil, errors.Annotate(err, "cannot start model worker manager")
+				}
+				return w, nil
 			})
 			a.startWorkerAfterUpgrade(runner, "peergrouper", func() (worker.Worker, error) {
 				w, err := peergrouperNew(st)
@@ -1063,293 +1045,41 @@ func (s stateWorkerCloser) Close() error {
 	return s.stateCloser.Close()
 }
 
-// startEnvWorkers starts controller workers that need to run per
-// environment.
-func (a *MachineAgent) startEnvWorkers(
-	ssSt modelworkermanager.InitialState,
-	st *state.State,
-) (_ worker.Worker, err error) {
-	modelUUID := st.ModelUUID()
-	defer errors.DeferredAnnotatef(&err, "failed to start workers for env %s", modelUUID)
-	logger.Infof("starting workers for env %s", modelUUID)
-
-	// Establish API connection for this model.
-	modelAgent, err := model.WrapAgent(a, st.ModelUUID())
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	conn, err := apicaller.OnlyConnect(modelAgent, apicaller.APIOpen)
+// startModelWorkers starts the set of workers that run for every model
+// in each controller.
+func (a *MachineAgent) startModelWorkers(uuid string) (worker.Worker, error) {
+	modelAgent, err := model.WrapAgent(a, uuid)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 
-	// Create a runner for workers specific to this model. Either
-	// the State or API connection failing will be considered fatal,
-	// killing the runner and all its workers.
-	runner := newConnRunner(st, conn)
-	defer func() {
-		if err != nil && runner != nil {
-			runner.Kill()
-			runner.Wait()
-		}
-	}()
-	// Close the API connection when the runner for this model dies.
-	go func() {
-		runner.Wait()
-		err := conn.Close()
-		if err != nil {
-			logger.Errorf("failed to close API connection for model %s: %v", modelUUID, err)
-		}
-	}()
-
-	// Create a singular runner for this environment.
-	machine, err := ssSt.Machine(a.machineId)
+	engine, err := dependency.NewEngine(dependency.EngineConfig{
+		IsFatal:     model.IsFatal,
+		WorstError:  model.WorstError,
+		Filter:      model.IgnoreErrRemoved,
+		ErrorDelay:  3 * time.Second,
+		BounceDelay: 10 * time.Millisecond,
+	})
 	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	singularRunner, err := newSingularStateRunner(runner, ssSt, machine)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	defer func() {
-		if err != nil && singularRunner != nil {
-			singularRunner.Kill()
-			singularRunner.Wait()
-		}
-	}()
-
-	// Start workers that depend on a *state.State.
-	// TODO(fwereade): 2015-04-21 THIS SHALL NOT PASS
-	// Seriously, these should all be using the API.
-	singularRunner.StartWorker("minunitsworker", func() (worker.Worker, error) {
-		return minunitsworker.NewMinUnitsWorker(st), nil
-	})
-
-	// Start workers that use an API connection.
-	singularRunner.StartWorker("environ-provisioner", func() (worker.Worker, error) {
-		w, err := provisioner.NewEnvironProvisioner(conn.Provisioner(), a.CurrentConfig())
-		if err != nil {
-			return nil, errors.Annotate(err, "cannot start environment compute provisioner worker")
-		}
-		return w, nil
-	})
-	singularRunner.StartWorker("environ-storageprovisioner", func() (worker.Worker, error) {
-		scope := st.ModelTag()
-		api, err := apistorageprovisioner.NewState(conn, scope)
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		w, err := newStorageWorker(storageprovisioner.Config{
-			Scope:       scope,
-			Volumes:     api,
-			Filesystems: api,
-			Life:        api,
-			Environ:     api,
-			Machines:    api,
-			Status:      api,
-			Clock:       clock.WallClock,
-		})
-		if err != nil {
-			return nil, errors.Annotate(err, "cannot start environment storage provisioner worker")
-		}
-		return w, nil
-	})
-	singularRunner.StartWorker("charm-revision-updater", func() (worker.Worker, error) {
-		w, err := charmrevision.NewWorker(charmrevision.Config{
-			RevisionUpdater: conn.CharmRevisionUpdater(),
-			Clock:           clock.WallClock,
-			Period:          24 * time.Hour,
-		})
-		if err != nil {
-			return nil, errors.Annotate(err, "cannot start charm revision updater worker")
-		}
-		return w, nil
-	})
-	runner.StartWorker("metricmanagerworker", func() (worker.Worker, error) {
-		client, err := getMetricAPI(conn)
-		if err != nil {
-			return nil, errors.Annotate(err, "cannot construct metrics api facade")
-		}
-		w, err := metricworker.NewMetricsManager(client)
-		if err != nil {
-			return nil, errors.Annotate(err, "cannot start metrics manager worker")
-		}
-		return w, nil
-	})
-	singularRunner.StartWorker("instancepoller", func() (worker.Worker, error) {
-		w, err := newInstancePoller(conn.InstancePoller())
-		if err != nil {
-			return nil, errors.Annotate(err, "cannot start instance poller worker")
-		}
-		return w, nil
-	})
-	singularRunner.StartWorker("cleaner", func() (worker.Worker, error) {
-		w, err := newCleaner(conn.Cleaner())
-		if err != nil {
-			return nil, errors.Annotate(err, "cannot start state cleaner worker")
-		}
-		return w, nil
-	})
-	singularRunner.StartWorker("addresserworker", func() (worker.Worker, error) {
-		w, err := newAddresser(conn.Addresser())
-		if err != nil {
-			return nil, errors.Annotate(err, "cannot start addresser worker")
-		}
-		return w, nil
-	})
-	singularRunner.StartWorker("discoverspaces", func() (worker.Worker, error) {
-		facade := conn.DiscoverSpaces()
-		envConfig, err := facade.ModelConfig()
-		if err != nil {
-			return nil, errors.Annotate(err, "cannot get model config")
-		}
-		environ, err := environs.New(envConfig)
-		if err != nil {
-			return nil, errors.Annotate(err, "cannot create environment")
-		}
-
-		config := discoverspaces.Config{
-			Facade:  facade,
-			Environ: environ,
-			NewName: discoverspaces.ConvertSpaceName,
-		}
-		w, err := newDiscoverSpaces(config)
-		if err != nil {
-			return nil, errors.Annotate(err, "cannot start space discovery worker")
-		}
-		return w, nil
-	})
-
-	if machine.IsManager() {
-		singularRunner.StartWorker("unitassigner", func() (worker.Worker, error) {
-			return unitassigner.New(conn.UnitAssigner())
-		})
+		return nil, err
 	}
 
-	// TODO(axw) 2013-09-24 bug #1229506
-	// Make another job to enable the firewaller. Not all
-	// environments are capable of managing ports
-	// centrally.
-	fwMode, err := getFirewallMode(conn)
-	if err != nil {
-		return nil, errors.Annotate(err, "cannot get firewall mode")
-	}
-	if fwMode != config.FwNone {
-		singularRunner.StartWorker("firewaller", func() (worker.Worker, error) {
-			w, err := newFirewaller(conn.Firewaller())
-			if err != nil {
-				return nil, errors.Annotate(err, "cannot start firewaller worker")
-			}
-			return w, nil
-		})
-	} else {
-		logger.Debugf("not starting firewaller worker - firewall-mode is %q", fwMode)
-	}
-
-	singularRunner.StartWorker("statushistorypruner", func() (worker.Worker, error) {
-		f := statushistory.NewFacade(conn)
-		conf := statushistorypruner.Config{
-			Facade:           f,
-			MaxLogsPerEntity: params.DefaultMaxLogsPerEntity,
-			PruneInterval:    params.DefaultPruneInterval,
-			NewTimer:         worker.NewTimer,
-		}
-		w, err := statushistorypruner.New(conf)
-		if err != nil {
-			return nil, errors.Annotate(err, "cannot start status history pruner worker")
-		}
-		return w, nil
+	manifolds := modelManifolds(model.ManifoldsConfig{
+		Agent:                       modelAgent,
+		Clock:                       clock.WallClock,
+		RunFlagDuration:             time.Minute,
+		CharmRevisionUpdateInterval: 24 * time.Hour,
+		EntityStatusHistoryCount:    100,
+		EntityStatusHistoryInterval: 5 * time.Minute,
+		ModelRemoveDelay:            24 * time.Hour,
 	})
-
-	return runner, nil
-}
-
-// undertakerWorker manages the controlled take-down of a dying environment.
-func (a *MachineAgent) undertakerWorker(
-	ssSt modelworkermanager.InitialState,
-	st *state.State,
-) (_ worker.Worker, err error) {
-	modelUUID := st.ModelUUID()
-	defer errors.DeferredAnnotatef(&err, "failed to start undertaker worker for model %s", modelUUID)
-	logger.Infof("starting undertaker worker for model %s", modelUUID)
-	singularRunner, runner, apiSt, err := a.newRunnersForAPIConn(ssSt, st)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	defer func() {
-		if err != nil && singularRunner != nil {
-			singularRunner.Kill()
-			singularRunner.Wait()
+	if err := dependency.Install(engine, manifolds); err != nil {
+		if err := worker.Stop(engine); err != nil {
+			logger.Errorf("while stopping engine with bad manifolds: %v", err)
 		}
-	}()
-
-	// Start the undertaker worker.
-	singularRunner.StartWorker("undertaker", func() (worker.Worker, error) {
-		return undertaker.NewUndertaker(getUndertakerAPI(apiSt), clock.WallClock)
-	})
-
-	return runner, nil
-}
-
-func (a *MachineAgent) newRunnersForAPIConn(
-	ssSt modelworkermanager.InitialState,
-	st *state.State,
-) (
-	worker.Runner,
-	worker.Runner,
-	api.Connection,
-	error,
-) {
-	// Establish API connection for this model.
-	modelAgent, err := model.WrapAgent(a, st.ModelUUID())
-	if err != nil {
-		return nil, nil, nil, errors.Trace(err)
+		return nil, err
 	}
-	conn, err := apicaller.OnlyConnect(modelAgent, apicaller.APIOpen)
-	if err != nil {
-		return nil, nil, nil, errors.Trace(err)
-	}
-
-	// Create a runner for workers specific to this model. Either
-	// the State or API connection failing will be considered fatal,
-	// killing the runner and all its workers.
-	runner := newConnRunner(st, conn)
-	defer func() {
-		if err != nil && runner != nil {
-			runner.Kill()
-			runner.Wait()
-		}
-	}()
-	// Close the API connection when the runner for this model dies.
-	go func() {
-		runner.Wait()
-		err := conn.Close()
-		if err != nil {
-			logger.Errorf("failed to close API connection for model %s: %v", st.ModelUUID(), err)
-		}
-	}()
-
-	// Create a singular runner for this model.
-	machine, err := ssSt.Machine(a.machineId)
-	if err != nil {
-		return nil, nil, nil, errors.Trace(err)
-	}
-	singularRunner, err := newSingularStateRunner(runner, ssSt, machine)
-	if err != nil {
-		return nil, nil, nil, errors.Trace(err)
-	}
-
-	return singularRunner, runner, conn, nil
-}
-
-var getFirewallMode = _getFirewallMode
-
-func _getFirewallMode(apiSt api.Connection) (string, error) {
-	modelConfig, err := apiagent.NewState(apiSt).ModelConfig()
-	if err != nil {
-		return "", errors.Annotate(err, "cannot read model config")
-	}
-	return modelConfig.FirewallMode(), nil
+	return engine, nil
 }
 
 // stateWorkerDialOpts is a mongo.DialOpts suitable
@@ -1957,10 +1687,6 @@ func metricAPI(st api.Connection) (metricsmanager.MetricsManagerClient, error) {
 		return nil, errors.Trace(err)
 	}
 	return client, nil
-}
-
-func undertakerAPI(st api.Connection) apiundertaker.UndertakerClient {
-	return apiundertaker.NewClient(st)
 }
 
 // newDeployContext gives the tests the opportunity to create a deployer.Context

--- a/cmd/jujud/agent/model/agent_test.go
+++ b/cmd/jujud/agent/model/agent_test.go
@@ -59,14 +59,14 @@ func (mock *mockAgent) CurrentConfig() agent.Config {
 type mockConfig struct{ agent.Config }
 
 func (mock *mockConfig) Model() names.ModelTag {
-	return names.NewModelTag("bad-wrong-no")
+	return names.NewModelTag("mock-model-uuid")
 }
 
 func (mock *mockConfig) APIInfo() (*api.Info, bool) {
 	return &api.Info{
 		Addrs:    []string{"here", "there"},
 		CACert:   "trust-me",
-		ModelTag: names.NewModelTag("bad-wrong-no"),
+		ModelTag: names.NewModelTag("mock-model-uuid"),
 		Tag:      names.NewMachineTag("123"),
 		Password: "12345",
 		Nonce:    "11111",

--- a/cmd/jujud/agent/model/errors.go
+++ b/cmd/jujud/agent/model/errors.go
@@ -1,0 +1,47 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package model
+
+import (
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/api/lifeflag"
+)
+
+// ErrRemoved may be returned by some worker started from Manifolds to
+// indicate that the model under management no longer exists.
+var ErrRemoved = errors.New("model removed")
+
+// lifeFilter is used with the lifeflag manifolds -- which do not depend
+// on runFlag -- to return an error that will be trapped by IsFatal.
+func lifeFilter(err error) error {
+	cause := errors.Cause(err)
+	if cause == lifeflag.ErrNotFound {
+		return ErrRemoved
+	}
+	return err
+}
+
+// IsFatal will probably be helpful when configuring a dependency.Engine
+// to run the result of Manifolds.
+func IsFatal(err error) bool {
+	return errors.Cause(err) == ErrRemoved
+}
+
+// WorstError will probably be helpful when configuring a dependency.Engine
+// to run the result of Manifolds.
+func WorstError(err, _ error) error {
+	// Doesn't matter if there's only one fatal error.
+	return err
+}
+
+// IgnoreErrRemoved returns nil if passed an error caused by ErrRemoved,
+// and otherwise returns the original error.
+func IgnoreErrRemoved(err error) error {
+	cause := errors.Cause(err)
+	if cause == ErrRemoved {
+		return nil
+	}
+	return err
+}

--- a/cmd/jujud/agent/model/manifolds.go
+++ b/cmd/jujud/agent/model/manifolds.go
@@ -1,0 +1,272 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package model
+
+import (
+	"time"
+
+	"github.com/juju/utils/clock"
+
+	coreagent "github.com/juju/juju/agent"
+	"github.com/juju/juju/core/life"
+	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/addresser"
+	"github.com/juju/juju/worker/agent"
+	"github.com/juju/juju/worker/apicaller"
+	"github.com/juju/juju/worker/charmrevision"
+	"github.com/juju/juju/worker/charmrevision/charmrevisionmanifold"
+	"github.com/juju/juju/worker/cleaner"
+	"github.com/juju/juju/worker/dependency"
+	"github.com/juju/juju/worker/discoverspaces"
+	"github.com/juju/juju/worker/environ"
+	"github.com/juju/juju/worker/firewaller"
+	"github.com/juju/juju/worker/instancepoller"
+	"github.com/juju/juju/worker/lifeflag"
+	"github.com/juju/juju/worker/metricworker"
+	"github.com/juju/juju/worker/provisioner"
+	"github.com/juju/juju/worker/servicescaler"
+	"github.com/juju/juju/worker/singular"
+	"github.com/juju/juju/worker/statushistorypruner"
+	"github.com/juju/juju/worker/storageprovisioner"
+	"github.com/juju/juju/worker/undertaker"
+	"github.com/juju/juju/worker/unitassigner"
+	"github.com/juju/juju/worker/util"
+)
+
+// ManifoldsConfig holds the dependencies and configuration options for a
+// model agent: that is, for the set of interdependent workers that observe
+// and manipulate a single model.
+type ManifoldsConfig struct {
+
+	// Agent identifies, and exposes configuration for, the controller
+	// machine running these manifolds and the model the manifolds
+	// should administer.
+	//
+	// You should almost certainly set this value to one created by
+	// model.WrapAgent.
+	Agent coreagent.Agent
+
+	// Clock supplies timing services to any manifolds that need them.
+	// Only a few workers have been converted to use them fo far.
+	Clock clock.Clock
+
+	// RunFlagDuration defines for how long this controller will ask
+	// for model administration rights; most of the workers controlled
+	// by this agent will only be started when the run flag is known
+	// to be held.
+	RunFlagDuration time.Duration
+
+	// CharmRevisionUpdateInterval determines how often the charm-
+	// revision worker will check for new revisions of known charms.
+	CharmRevisionUpdateInterval time.Duration
+
+	// EntityStatusHistory* values control status-history pruning
+	// behaviour per entity.
+	EntityStatusHistoryCount    uint
+	EntityStatusHistoryInterval time.Duration
+
+	// ModelRemoveDelay controls how long the model documents will be left
+	// lying around once the model has become dead.
+	ModelRemoveDelay time.Duration
+}
+
+// Manifolds returns a set of interdependent dependency manifolds that will
+// run together to administer a model, as configured.
+func Manifolds(config ManifoldsConfig) dependency.Manifolds {
+	modelTag := config.Agent.CurrentConfig().Model()
+	return dependency.Manifolds{
+
+		// The first group are foundational; the agent and clock
+		// which wrap those supplied in config, and the api-caller
+		// through everything else communicates with the apiserver.
+		agentName: agent.Manifold(config.Agent),
+		clockName: clockManifold(config.Clock),
+		apiCallerName: apicaller.Manifold(apicaller.ManifoldConfig{
+			AgentName:     agentName,
+			APIOpen:       apicaller.APIOpen,
+			NewConnection: apicaller.OnlyConnect,
+		}),
+
+		// All other manifolds should depend on at least one of these
+		// three, which handle all the tasks that are safe and sane
+		// to run in *all* controller machines.
+		notDeadFlagName: lifeflag.Manifold(lifeflag.ManifoldConfig{
+			APICallerName: apiCallerName,
+			Entity:        modelTag,
+			Result:        life.IsNotDead,
+			Filter:        lifeFilter,
+
+			NewFacade: lifeflag.NewFacade,
+			NewWorker: lifeflag.NewWorker,
+		}),
+		notAliveFlagName: lifeflag.Manifold(lifeflag.ManifoldConfig{
+			APICallerName: apiCallerName,
+			Entity:        modelTag,
+			Result:        life.IsNotAlive,
+			Filter:        lifeFilter,
+
+			NewFacade: lifeflag.NewFacade,
+			NewWorker: lifeflag.NewWorker,
+		}),
+		isResponsibleFlagName: singular.Manifold(singular.ManifoldConfig{
+			ClockName:     clockName,
+			AgentName:     agentName,
+			APICallerName: apiCallerName,
+			Duration:      config.RunFlagDuration,
+
+			NewFacade: singular.NewFacade,
+			NewWorker: singular.NewWorker,
+		}),
+
+		// Everything else should be wrapped in ifResponsible,
+		// ifNotAlive, or ifNotDead, to ensure that only a single
+		// controller is administering this model at a time.
+		//
+		// NOTE: not perfectly reliable at this stage? i.e. a worker
+		// that ignores its stop signal for "too long" might continue
+		// to take admin actions after the window of responsibility
+		// closes. This *is* a pre-existing problem, but demands some
+		// thought/care: e.g. should we make sure the apiserver also
+		// closes any connections that lose responsibility..? can we
+		// make sure all possible environ operations are either time-
+		// bounded or interruptible? etc
+		//
+		// On the other hand, all workers *should* be written in the
+		// expectation of dealing with a sucky infrastructure running
+		// things in parallel unexpectedly, just because the universe
+		// hates us and will engineer matters such that it happens
+		// sometimes, even when we try to avoid it.
+
+		// The environ tracker is currently only used by the space
+		// discovery worker and the undertaker, but could/should be
+		// used by several others (firewaller, provisioners, instance
+		// poller).
+		environTrackerName: ifResponsible(environ.Manifold(environ.ManifoldConfig{
+			APICallerName: apiCallerName,
+		})),
+
+		// The undertaker is currently the only ifNotAlive worker.
+		undertakerName: ifNotAlive(undertaker.Manifold(undertaker.ManifoldConfig{
+			APICallerName: apiCallerName,
+			EnvironName:   environTrackerName,
+			ClockName:     clockName,
+			RemoveDelay:   config.ModelRemoveDelay,
+
+			NewFacade: undertaker.NewFacade,
+			NewWorker: undertaker.NewWorker,
+		})),
+
+		// All the rest depend on ifNotDead.
+		spaceImporterName: ifNotDead(discoverspaces.Manifold(discoverspaces.ManifoldConfig{
+			EnvironName:   environTrackerName,
+			APICallerName: apiCallerName,
+			// No UnlockerName for now; might never be necessary
+			// in exactly this form (because we should probably
+			// just have a persistent flag set/read via the api).
+
+			NewFacade: discoverspaces.NewFacade,
+			NewWorker: discoverspaces.NewWorker,
+		})),
+		computeProvisionerName: ifNotDead(provisioner.Manifold(provisioner.ManifoldConfig{
+			AgentName:     agentName,
+			APICallerName: apiCallerName,
+		})),
+		storageProvisionerName: ifNotDead(storageprovisioner.Manifold(storageprovisioner.ManifoldConfig{
+			APICallerName: apiCallerName,
+			ClockName:     clockName,
+			Scope:         modelTag,
+		})),
+		firewallerName: ifNotDead(firewaller.Manifold(firewaller.ManifoldConfig{
+			APICallerName: apiCallerName,
+		})),
+		unitAssignerName: ifNotDead(unitassigner.Manifold(unitassigner.ManifoldConfig{
+			APICallerName: apiCallerName,
+		})),
+		serviceScalerName: ifNotDead(servicescaler.Manifold(servicescaler.ManifoldConfig{
+			APICallerName: apiCallerName,
+			NewFacade:     servicescaler.NewFacade,
+			NewWorker:     servicescaler.New,
+		})),
+		instancePollerName: ifNotDead(instancepoller.Manifold(instancepoller.ManifoldConfig{
+			APICallerName: apiCallerName,
+		})),
+		charmRevisionUpdaterName: ifNotDead(charmrevisionmanifold.Manifold(charmrevisionmanifold.ManifoldConfig{
+			APICallerName: apiCallerName,
+			ClockName:     clockName,
+			Period:        config.CharmRevisionUpdateInterval,
+
+			NewFacade: charmrevisionmanifold.NewAPIFacade,
+			NewWorker: charmrevision.NewWorker,
+		})),
+		metricWorkerName: ifNotDead(metricworker.Manifold(metricworker.ManifoldConfig{
+			APICallerName: apiCallerName,
+		})),
+		stateCleanerName: ifNotDead(cleaner.Manifold(cleaner.ManifoldConfig{
+			APICallerName: apiCallerName,
+		})),
+		addressCleanerName: ifNotDead(addresser.Manifold(addresser.ManifoldConfig{
+			APICallerName: apiCallerName,
+		})),
+		statusHistoryPrunerName: ifNotDead(statushistorypruner.Manifold(statushistorypruner.ManifoldConfig{
+			APICallerName:    apiCallerName,
+			MaxLogsPerEntity: config.EntityStatusHistoryCount,
+			PruneInterval:    config.EntityStatusHistoryInterval,
+			// TODO(fwereade): 2016-03-17 lp:1558657
+			NewTimer: worker.NewTimer,
+		})),
+	}
+}
+
+// ifResponsible wraps a manifold such that it only runs if the
+// responsibility flag is set.
+func ifResponsible(manifold dependency.Manifold) dependency.Manifold {
+	return dependency.WithFlag(manifold, isResponsibleFlagName)
+}
+
+// ifNotAlive wraps a manifold such that it only runs if the
+// responsibility flag is set and the model is Dying or Dead.
+func ifNotAlive(manifold dependency.Manifold) dependency.Manifold {
+	return ifResponsible(dependency.WithFlag(manifold, notAliveFlagName))
+}
+
+// ifNotDead wraps a manifold such that it only runs if the responsibility
+// flag is set and the model is Alive or Dying.
+func ifNotDead(manifold dependency.Manifold) dependency.Manifold {
+	return ifResponsible(dependency.WithFlag(manifold, notDeadFlagName))
+}
+
+// clockManifold expresses a Clock as a ValueWorker manifold.
+func clockManifold(clock clock.Clock) dependency.Manifold {
+	return dependency.Manifold{
+		Start: func(_ dependency.GetResourceFunc) (worker.Worker, error) {
+			return util.NewValueWorker(clock)
+		},
+		Output: util.ValueWorkerOutput,
+	}
+}
+
+const (
+	agentName     = "agent"
+	clockName     = "clock"
+	apiCallerName = "api-caller"
+
+	isResponsibleFlagName = "is-responsible-flag"
+	notDeadFlagName       = "not-dead-flag"
+	notAliveFlagName      = "not-alive-flag"
+
+	environTrackerName       = "environ-tracker"
+	undertakerName           = "undertaker"
+	spaceImporterName        = "space-importer"
+	computeProvisionerName   = "compute-provisioner"
+	storageProvisionerName   = "storage-provisioner"
+	firewallerName           = "firewaller"
+	unitAssignerName         = "unit-assigner"
+	serviceScalerName        = "service-scaler"
+	instancePollerName       = "instance-poller"
+	charmRevisionUpdaterName = "charm-revision-updater"
+	metricWorkerName         = "metric-worker"
+	stateCleanerName         = "state-cleaner"
+	addressCleanerName       = "address-cleaner"
+	statusHistoryPrunerName  = "status-history-pruner"
+)

--- a/cmd/jujud/agent/model/manifolds_test.go
+++ b/cmd/jujud/agent/model/manifolds_test.go
@@ -1,0 +1,82 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package model_test
+
+import (
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/clock"
+	"github.com/juju/utils/set"
+
+	"github.com/juju/juju/cmd/jujud/agent/model"
+	"github.com/juju/juju/worker/workertest"
+)
+
+type ManifoldsSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&ManifoldsSuite{})
+
+func (s *ManifoldsSuite) TestNames(c *gc.C) {
+	actual := set.NewStrings()
+	manifolds := model.Manifolds(model.ManifoldsConfig{
+		Agent: &mockAgent{},
+	})
+	for name := range manifolds {
+		actual.Add(name)
+	}
+	// NOTE: if this test failed, the cmd/jujud/agent tests will
+	// also fail. Search for 'ModelWorkers' to find affected vars.
+	c.Check(actual.Values(), jc.SameContents, []string{
+		"agent", "clock", "api-caller",
+		"is-responsible-flag", "not-dead-flag", "not-alive-flag",
+		"environ-tracker", "undertaker", "space-importer",
+		"storage-provisioner", "compute-provisioner",
+		"firewaller", "unit-assigner", "service-scaler",
+		"instance-poller", "charm-revision-updater",
+		"metric-worker", "state-cleaner", "address-cleaner",
+		"status-history-pruner",
+	})
+}
+
+func (s *ManifoldsSuite) TestResponsibleFlagDependencies(c *gc.C) {
+	exclusions := set.NewStrings(
+		"agent", "api-caller", "clock",
+		"is-responsible-flag", "not-dead-flag", "not-alive-flag",
+	)
+	manifolds := model.Manifolds(model.ManifoldsConfig{
+		Agent: &mockAgent{},
+	})
+	for name, manifold := range manifolds {
+		c.Logf("checking %s", name)
+		if exclusions.Contains(name) {
+			continue
+		}
+		inputs := set.NewStrings(manifold.Inputs...)
+		c.Check(inputs.Contains("is-responsible-flag"), jc.IsTrue)
+	}
+}
+
+func (s *ManifoldsSuite) TestClockWrapper(c *gc.C) {
+	expectClock := &fakeClock{}
+	manifolds := model.Manifolds(model.ManifoldsConfig{
+		Agent: &mockAgent{},
+		Clock: expectClock,
+	})
+	manifold, ok := manifolds["clock"]
+	c.Assert(ok, jc.IsTrue)
+	worker, err := manifold.Start(nil)
+	c.Assert(err, jc.ErrorIsNil)
+	defer workertest.CheckKill(c, worker)
+
+	var clock clock.Clock
+	err = manifold.Output(worker, &clock)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(clock, gc.Equals, expectClock)
+}
+
+type fakeClock struct{ clock.Clock }

--- a/cmd/jujud/agent/util_test.go
+++ b/cmd/jujud/agent/util_test.go
@@ -1,0 +1,137 @@
+// Copyright 2012-2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package agent
+
+import (
+	"sync"
+
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/set"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/cmd/jujud/agent/model"
+	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/dependency"
+)
+
+var (
+	// These vars hold the per-model workers we expect to run in
+	// various circumstances. Note the absence of dyingModelWorkers:
+	// it's not a stable state, because it's responsible for making
+	// the model Dead via the undertaker, so it can't be waited for
+	// reliably.
+	alwaysModelWorkers = []string{
+		"agent", "clock", "api-caller",
+		"is-responsible-flag", "not-alive-flag", "not-dead-flag",
+	}
+	aliveModelWorkers = []string{
+		"environ-tracker", "space-importer", "compute-provisioner",
+		"storage-provisioner", "firewaller", "unit-assigner",
+		"service-scaler", "instance-poller", "charm-revision-updater",
+		"metric-worker", "state-cleaner", "status-history-pruner",
+	}
+	deadModelWorkers = []string{
+		"environ-tracker", "undertaker",
+	}
+
+	// ReallyLongTimeout should be long enough for the model-tracker
+	// tests that depend on a hosted model; its backing state is not
+	// accessible for StartSyncs, so we generally have to wait for at
+	// least two 5s ticks to pass, and should expect rare circumstances
+	// to take even longer.
+	ReallyLongWait = coretesting.LongWait * 3
+)
+
+// modelMatchFunc returns a func that will return whether the current
+// set of workers running for the supplied model matches those supplied;
+// and will log what it saw in some detail.
+func modelMatchFunc(c *gc.C, tracker *modelTracker, workers []string) func(string) bool {
+	expect := set.NewStrings(workers...)
+	return func(uuid string) bool {
+		actual := tracker.Workers(uuid)
+		c.Logf("\n%s: has workers %v", uuid, actual.SortedValues())
+		extras := actual.Difference(expect)
+		missed := expect.Difference(actual)
+		if len(extras) == 0 && len(missed) == 0 {
+			return true
+		}
+		c.Logf("%s: waiting for %v", uuid, missed.SortedValues())
+		c.Logf("%s: unexpected %v", uuid, extras.SortedValues())
+		return false
+	}
+}
+
+// newModelTracker creates a type whose Manifolds method can
+// be patched over modelManifolds, and whose Workers method
+// will tell you what workers are currently running stably
+// within the requested model's dependency engine.
+func newModelTracker(c *gc.C) *modelTracker {
+	return &modelTracker{
+		c:       c,
+		current: make(map[string]set.Strings),
+	}
+}
+
+type modelTracker struct {
+	c       *gc.C
+	mu      sync.Mutex
+	current map[string]set.Strings
+}
+
+func (tracker *modelTracker) Workers(model string) set.Strings {
+	tracker.mu.Lock()
+	defer tracker.mu.Unlock()
+	return tracker.current[model]
+}
+
+func (tracker *modelTracker) Manifolds(config model.ManifoldsConfig) dependency.Manifolds {
+	const trackerName = "TEST-TRACKER"
+	raw := model.Manifolds(config)
+	uuid := config.Agent.CurrentConfig().Model().Id()
+
+	names := make([]string, 0, len(raw))
+	for name := range raw {
+		if name == trackerName {
+			tracker.c.Errorf("manifold tracker used repeatedly")
+			return raw
+		} else {
+			names = append(names, name)
+		}
+	}
+
+	tracker.mu.Lock()
+	defer tracker.mu.Unlock()
+	if _, exists := tracker.current[uuid]; exists {
+		tracker.c.Errorf("model %s started repeatedly", uuid)
+		return raw
+	}
+
+	raw[trackerName] = tracker.manifold(uuid, names)
+	return raw
+}
+
+func (tracker *modelTracker) manifold(uuid string, names []string) dependency.Manifold {
+	return dependency.Manifold{
+		Inputs: names,
+		Start: func(getResource dependency.GetResourceFunc) (worker.Worker, error) {
+			seen := set.NewStrings()
+			for _, name := range names {
+				err := getResource(name, nil)
+				if errors.Cause(err) == dependency.ErrMissing {
+					continue
+				}
+				if tracker.c.Check(err, jc.ErrorIsNil) {
+					seen.Add(name)
+				}
+			}
+			tracker.mu.Lock()
+			defer tracker.mu.Unlock()
+			tracker.current[uuid] = seen
+
+			return nil, dependency.ErrMissing
+		},
+	}
+}

--- a/cmd/jujud/reboot/reboot.go
+++ b/cmd/jujud/reboot/reboot.go
@@ -138,6 +138,7 @@ func (r *Reboot) waitForContainersOrTimeout() error {
 
 	select {
 	case <-time.After(timeout):
+		// TODO(fwereade): 2016-03-17 lp:1558657
 
 		// Containers are still up after timeout. C'est la vie
 		logger.Infof("Timeout reached waiting for containers to shutdown")

--- a/featuretests/api_undertaker_test.go
+++ b/featuretests/api_undertaker_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/undertaker"
+	apiwatcher "github.com/juju/juju/api/watcher"
 	"github.com/juju/juju/apiserver/params"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/rpc"
@@ -20,6 +21,9 @@ import (
 	"github.com/juju/juju/watcher/watchertest"
 )
 
+// TODO(fwereade) 2016-03-17 lp:1558668
+// this is not a feature test; much of it is redundant, and other
+// bits should be tested elsewhere.
 type undertakerSuite struct {
 	jujutesting.JujuConnSuite
 }
@@ -30,10 +34,11 @@ func (s *undertakerSuite) TestPermDenied(c *gc.C) {
 		nonManagerMachine,
 		s.APIState,
 	} {
-		undertakerClient := undertaker.NewClient(conn)
+		undertakerClient, err := undertaker.NewClient(conn, apiwatcher.NewNotifyWatcher)
+		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(undertakerClient, gc.NotNil)
 
-		_, err := undertakerClient.ModelInfo()
+		_, err = undertakerClient.ModelInfo()
 		c.Assert(errors.Cause(err), gc.DeepEquals, &rpc.RequestError{
 			Message: "permission denied",
 			Code:    "unauthorized access",
@@ -43,7 +48,8 @@ func (s *undertakerSuite) TestPermDenied(c *gc.C) {
 
 func (s *undertakerSuite) TestStateEnvironInfo(c *gc.C) {
 	st, _ := s.OpenAPIAsNewMachine(c, state.JobManageModel)
-	undertakerClient := undertaker.NewClient(st)
+	undertakerClient, err := undertaker.NewClient(st, apiwatcher.NewNotifyWatcher)
+	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(undertakerClient, gc.NotNil)
 
 	result, err := undertakerClient.ModelInfo()
@@ -61,10 +67,11 @@ func (s *undertakerSuite) TestStateEnvironInfo(c *gc.C) {
 
 func (s *undertakerSuite) TestStateProcessDyingEnviron(c *gc.C) {
 	st, _ := s.OpenAPIAsNewMachine(c, state.JobManageModel)
-	undertakerClient := undertaker.NewClient(st)
+	undertakerClient, err := undertaker.NewClient(st, apiwatcher.NewNotifyWatcher)
+	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(undertakerClient, gc.NotNil)
 
-	err := undertakerClient.ProcessDyingModel()
+	err = undertakerClient.ProcessDyingModel()
 	c.Assert(err, gc.ErrorMatches, "model is not dying")
 
 	env, err := s.State.Model()
@@ -79,7 +86,8 @@ func (s *undertakerSuite) TestStateProcessDyingEnviron(c *gc.C) {
 
 func (s *undertakerSuite) TestStateRemoveEnvironFails(c *gc.C) {
 	st, _ := s.OpenAPIAsNewMachine(c, state.JobManageModel)
-	undertakerClient := undertaker.NewClient(st)
+	undertakerClient, err := undertaker.NewClient(st, apiwatcher.NewNotifyWatcher)
+	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(undertakerClient, gc.NotNil)
 	c.Assert(undertakerClient.RemoveModel(), gc.ErrorMatches, "an error occurred, unable to remove model")
 }
@@ -161,17 +169,6 @@ func (s *undertakerSuite) TestHostedRemoveEnviron(c *gc.C) {
 	c.Assert(otherSt.EnsureModelRemoved(), jc.ErrorIsNil)
 }
 
-func (s *undertakerSuite) TestHostedModelConfig(c *gc.C) {
-	undertakerClient, otherSt := s.hostedAPI(c)
-	defer otherSt.Close()
-
-	cfg, err := undertakerClient.ModelConfig()
-	c.Assert(err, jc.ErrorIsNil)
-	uuid, ok := cfg.UUID()
-	c.Assert(ok, jc.IsTrue)
-	c.Assert(uuid, gc.Equals, otherSt.ModelUUID())
-}
-
 func (s *undertakerSuite) hostedAPI(c *gc.C) (*undertaker.Client, *state.State) {
 	otherState := s.Factory.MakeModel(c, &factory.ModelParams{Name: "hosted_env"})
 
@@ -194,7 +191,8 @@ func (s *undertakerSuite) hostedAPI(c *gc.C) (*undertaker.Client, *state.State) 
 	otherAPIState, err := api.Open(info, api.DefaultDialOpts())
 	c.Assert(err, jc.ErrorIsNil)
 
-	undertakerClient := undertaker.NewClient(otherAPIState)
+	undertakerClient, err := undertaker.NewClient(otherAPIState, apiwatcher.NewNotifyWatcher)
+	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(undertakerClient, gc.NotNil)
 
 	return undertakerClient, otherState

--- a/featuretests/cmd_juju_controller_test.go
+++ b/featuretests/cmd_juju_controller_test.go
@@ -16,9 +16,9 @@ import (
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/modelmanager"
-	undertakerapi "github.com/juju/juju/api/undertaker"
 	"github.com/juju/juju/cmd/juju/commands"
 	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/configstore"
 	"github.com/juju/juju/juju"
 	jujutesting "github.com/juju/juju/juju/testing"
@@ -26,7 +26,6 @@ import (
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/testing/factory"
-	"github.com/juju/juju/worker/undertaker"
 )
 
 type cmdControllerSuite struct {
@@ -188,22 +187,16 @@ func (s *cmdControllerSuite) TestSystemKillCallsEnvironDestroyOnHostedEnviron(c 
 	opc := make(chan dummy.Operation, 200)
 	dummy.Listen(opc)
 
-	conn, err := juju.NewAPIState(s.AdminUserTag(c), s.Environ, api.DialOpts{})
-	c.Assert(err, jc.ErrorIsNil)
-	s.AddCleanup(func(*gc.C) { conn.Close() })
-	client := undertakerapi.NewClient(conn)
-
-	startTime := time.Date(2015, time.September, 1, 17, 2, 1, 0, time.UTC)
-	mClock := testing.NewClock(startTime)
-	undertaker.NewUndertaker(client, mClock)
-
 	store, err := configstore.Default()
 	_, err = store.ReadInfo("dummymodel:dummymodel")
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.run(c, "kill-controller", "dummymodel", "-y")
 
-	// Ensure that Destroy was called on the hosted model ...
+	// Ensure that Destroy was called on the hosted environ ...
+	// TODO(fwereade): how do we know it's the hosted environ?
+	// what actual interactions made it ok to destroy any environ
+	// here? (there used to be an undertaker that didn't work...)
 	opRecvTimeout(c, st, opc, dummy.OpDestroy{})
 
 	// ... and that the configstore was removed.
@@ -228,4 +221,8 @@ func opRecvTimeout(c *gc.C, st *state.State, opc <-chan dummy.Operation, kinds .
 			c.Fatalf("time out wating for operation")
 		}
 	}
+}
+
+type fakeEnviron struct {
+	environs.Environ
 }

--- a/juju/api.go
+++ b/juju/api.go
@@ -243,6 +243,7 @@ func apiInfoConnect(info configstore.EnvironInfo, apiOpen api.OpenFunc, stop <-c
 func apiConfigConnect(cfg *config.Config, apiOpen api.OpenFunc, stop <-chan struct{}, delay time.Duration, user names.Tag) (api.Connection, error) {
 	select {
 	case <-time.After(delay):
+		// TODO(fwereade): 2016-03-17 lp:1558657
 	case <-stop:
 		return nil, errAborted
 	}

--- a/state/addmachine.go
+++ b/state/addmachine.go
@@ -488,7 +488,8 @@ func (st *State) insertNewMachineOps(mdoc *machineDoc, template MachineTemplate)
 	statusDoc := statusDoc{
 		Status:    StatusPending,
 		ModelUUID: st.ModelUUID(),
-		Updated:   time.Now().UnixNano(),
+		// TODO(fwereade): 2016-03-17 lp:1558657
+		Updated: time.Now().UnixNano(),
 	}
 	globalKey := machineGlobalKey(mdoc.Id)
 	prereqOps = []txn.Op{

--- a/state/allwatcher.go
+++ b/state/allwatcher.go
@@ -429,6 +429,7 @@ func (svc *backingService) updated(st *State, store *multiwatcherStore, id strin
 			// Not sure how status can even return NotFound as it is created
 			// with the service initially. For now, we'll log the error as per
 			// the above and return Unknown.
+			// TODO(fwereade): 2016-03-17 lp:1558657
 			now := time.Now()
 			info.Status = multiwatcher.StatusInfo{
 				Current: multiwatcher.Status(StatusUnknown),

--- a/state/backups/backups.go
+++ b/state/backups/backups.go
@@ -120,6 +120,7 @@ func NewBackups(stor filestorage.FileStorage) Backups {
 // Create creates and stores a new juju backup archive and updates the
 // provided metadata.
 func (b *backups) Create(meta *Metadata, paths *Paths, dbInfo *DBInfo) error {
+	// TODO(fwereade): 2016-03-17 lp:1558657
 	meta.Started = time.Now().UTC()
 
 	// The metadata file will not contain the ID or the "finished" data.

--- a/state/backups/metadata.go
+++ b/state/backups/metadata.go
@@ -69,7 +69,8 @@ type Metadata struct {
 func NewMetadata() *Metadata {
 	return &Metadata{
 		FileMetadata: filestorage.NewMetadata(),
-		Started:      time.Now().UTC(),
+		// TODO(fwereade): 2016-03-17 lp:1558657
+		Started: time.Now().UTC(),
 		Origin: Origin{
 			Version: version.Current,
 		},
@@ -105,6 +106,7 @@ func (m *Metadata) MarkComplete(size int64, checksum string) error {
 		return errors.New("missing checksum")
 	}
 	format := checksumFormat
+	// TODO(fwereade): 2016-03-17 lp:1558657
 	finished := time.Now().UTC()
 
 	if err := m.SetFileInfo(size, checksum, format); err != nil {

--- a/state/cloudimagemetadata/image.go
+++ b/state/cloudimagemetadata/image.go
@@ -242,9 +242,10 @@ func (s *storage) mongoDoc(m Metadata) imagesMetadataDoc {
 		VirtType:        m.VirtType,
 		RootStorageType: m.RootStorageType,
 		ImageId:         m.ImageId,
-		DateCreated:     time.Now().UnixNano(),
-		Source:          m.Source,
-		Priority:        m.Priority,
+		// TODO(fwereade): 2016-03-17 lp:1558657
+		DateCreated: time.Now().UnixNano(),
+		Source:      m.Source,
+		Priority:    m.Priority,
 	}
 	if m.RootStorageSize != nil {
 		r.RootStorageSize = *m.RootStorageSize

--- a/state/filesystem.go
+++ b/state/filesystem.go
@@ -754,7 +754,8 @@ func (st *State) addFilesystemOps(params FilesystemParams, machineId string) ([]
 
 	filesystemOps := []txn.Op{
 		createStatusOp(st, filesystemGlobalKey(filesystemId), statusDoc{
-			Status:  StatusPending,
+			Status: StatusPending,
+			// TODO(fwereade): 2016-03-17 lp:1558657
 			Updated: time.Now().UnixNano(),
 		}),
 		{

--- a/state/imagestorage/image.go
+++ b/state/imagestorage/image.go
@@ -105,7 +105,8 @@ func (s *imageStorage) AddImage(r io.Reader, metadata *Metadata) (resultErr erro
 		SHA256:    metadata.SHA256,
 		SourceURL: metadata.SourceURL,
 		Path:      path,
-		Created:   time.Now(),
+		// TODO(fwereade): 2016-03-17 lp:1558657
+		Created: time.Now(),
 	}
 
 	// Add or replace metadata. If replacing, record the

--- a/state/machine.go
+++ b/state/machine.go
@@ -945,6 +945,7 @@ func (m *Machine) WaitAgentPresence(timeout time.Duration) (err error) {
 				return nil
 			}
 		case <-time.After(timeout):
+			// TODO(fwereade): 2016-03-17 lp:1558657
 			return fmt.Errorf("still not alive after timeout")
 		case <-m.st.pwatcher.Dead():
 			return m.st.pwatcher.Err()

--- a/state/metrics.go
+++ b/state/metrics.go
@@ -230,6 +230,7 @@ func (st *State) MetricBatch(id string) (*MetricBatch, error) {
 // CleanupOldMetrics looks for metrics that are 24 hours old (or older)
 // and have been sent. Any metrics it finds are deleted.
 func (st *State) CleanupOldMetrics() error {
+	// TODO(fwereade): 2016-03-17 lp:1558657
 	now := time.Now()
 	metrics, closer := st.getCollection(metricsC)
 	defer closer()
@@ -369,6 +370,7 @@ func setSentOps(batchUUIDs []string, deleteTime time.Time) []txn.Op {
 
 // SetMetricBatchesSent sets sent on each MetricBatch corresponding to the uuids provided.
 func (st *State) SetMetricBatchesSent(batchUUIDs []string) error {
+	// TODO(fwereade): 2016-03-17 lp:1558657
 	deleteTime := time.Now().UTC().Add(CleanupAge)
 	ops := setSentOps(batchUUIDs, deleteTime)
 	if err := st.runTransaction(ops); err != nil {

--- a/state/metricsmanager.go
+++ b/state/metricsmanager.go
@@ -176,6 +176,7 @@ func (m *MetricsManager) IncrementConsecutiveErrors() error {
 }
 
 func (m *MetricsManager) gracePeriodExceeded() bool {
+	// TODO(fwereade): 2016-03-17 lp:1558657
 	now := time.Now()
 	t := m.LastSuccessfulSend().Add(m.GracePeriod())
 	return t.Before(now) || t.Equal(now)

--- a/state/service.go
+++ b/state/service.go
@@ -803,6 +803,7 @@ func (s *Service) addUnitOpsWithCons(args addUnitOpsArgs) (string, []txn.Op, err
 		Principal:              args.principalName,
 		StorageAttachmentCount: numStorageAttachments,
 	}
+	// TODO(fwereade): 2016-03-17 lp:1558657
 	now := time.Now()
 	agentStatusDoc := statusDoc{
 		Status:    StatusAllocating,

--- a/state/state.go
+++ b/state/state.go
@@ -1298,7 +1298,8 @@ func (st *State) AddService(args AddServiceArgs) (service *Service, err error) {
 		// behaviour.
 		Status:     StatusUnknown,
 		StatusInfo: MessageWaitForAgentInit,
-		Updated:    time.Now().UnixNano(),
+		// TODO(fwereade): 2016-03-17 lp:1558657
+		Updated: time.Now().UnixNano(),
 		// This exists to preserve questionable unit-aggregation behaviour
 		// while we work out how to switch to an implementation that makes
 		// sense. It is also set in AddMissingServiceStatuses.

--- a/state/status.go
+++ b/state/status.go
@@ -126,6 +126,7 @@ func setStatus(st *State, params setStatusParams) (err error) {
 	// status was *set*, not the time it happened to arrive in state.
 	// We should almost certainly be accepting StatusInfo in the exposed
 	// SetStatus methods, for symetry with the Status methods.
+	// TODO(fwereade): 2016-03-17 lp:1558657
 	now := time.Now().UnixNano()
 	doc := statusDoc{
 		Status:     params.status,

--- a/state/unit.go
+++ b/state/unit.go
@@ -1074,6 +1074,7 @@ func (u *Unit) WaitAgentPresence(timeout time.Duration) (err error) {
 				return nil
 			}
 		case <-time.After(timeout):
+			// TODO(fwereade): 2016-03-17 lp:1558657
 			return fmt.Errorf("still not alive after timeout")
 		case <-u.st.pwatcher.Dead():
 			return u.st.pwatcher.Err()

--- a/state/upgrade.go
+++ b/state/upgrade.go
@@ -263,10 +263,11 @@ func (st *State) EnsureUpgradeInfo(machineId string, previousVersion, targetVers
 	}
 
 	doc := upgradeInfoDoc{
-		Id:               currentUpgradeId,
-		PreviousVersion:  previousVersion,
-		TargetVersion:    targetVersion,
-		Status:           UpgradePending,
+		Id:              currentUpgradeId,
+		PreviousVersion: previousVersion,
+		TargetVersion:   targetVersion,
+		Status:          UpgradePending,
+		// TODO(fwereade): 2016-03-17 lp:1558657
 		Started:          time.Now().UTC(),
 		ControllersReady: []string{machineId},
 	}

--- a/state/user.go
+++ b/state/user.go
@@ -277,8 +277,7 @@ func (u *User) LastLogin() (time.Time, error) {
 // handle. When serializing time in and out of mongo, we lose enough
 // precision that it's misleading to store any more than precision to
 // the second.
-// TODO(jcw4) time dependencies should be injectable, not just internal
-// to package.
+// TODO(fwereade): 2016-03-17 lp:1558657
 var nowToTheSecond = func() time.Time { return time.Now().Round(time.Second).UTC() }
 
 // NeverLoggedInError is used to indicate that a user has never logged in.

--- a/state/volume.go
+++ b/state/volume.go
@@ -747,7 +747,8 @@ func (st *State) addVolumeOps(params VolumeParams, machineId string) ([]txn.Op, 
 	}
 	ops := []txn.Op{
 		createStatusOp(st, volumeGlobalKey(name), statusDoc{
-			Status:  StatusPending,
+			Status: StatusPending,
+			// TODO(fwereade): 2016-03-17 lp:1558657
 			Updated: time.Now().UnixNano(),
 		}),
 		{

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -125,6 +125,7 @@ func collect(one watcher.Change, more <-chan watcher.Change, stop <-chan struct{
 		result[ch.Id] = ch.Revno != -1
 	}
 	handle(one)
+	// TODO(fwereade): 2016-03-17 lp:1558657
 	timeout := time.After(10 * time.Millisecond)
 	for done := false; !done; {
 		select {

--- a/worker/dblogpruner/worker.go
+++ b/worker/dblogpruner/worker.go
@@ -57,6 +57,7 @@ func (w *pruneWorker) loop(stopCh <-chan struct{}) error {
 		case <-stopCh:
 			return tomb.ErrDying
 		case <-time.After(p.PruneInterval):
+			// TODO(fwereade): 2016-03-17 lp:1558657
 			minLogTime := time.Now().Add(-p.MaxLogAge)
 			err := state.PruneLogs(w.st, minLogTime, p.MaxCollectionMB)
 			if err != nil {

--- a/worker/dependency/engine.go
+++ b/worker/dependency/engine.go
@@ -398,6 +398,7 @@ func (engine *engine) runWorker(name string, delay time.Duration, start StartFun
 		defer resourceGetter.expire()
 		logger.Tracef("starting %q manifold worker in %s...", name, delay)
 		select {
+		// TODO(fwereade): 2016-03-17 lp:1558657
 		case <-time.After(delay):
 		case <-engine.tomb.Dying():
 			return nil, errAborted

--- a/worker/dependency/self_test.go
+++ b/worker/dependency/self_test.go
@@ -11,6 +11,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/worker/dependency"
+	"github.com/juju/juju/worker/workertest"
 )
 
 type SelfSuite struct {
@@ -99,6 +100,7 @@ func (s *SelfSuite) TestActuallyWorks(c *gc.C) {
 		// Give it a moment to screw up if it's going to
 		// (injudicious implementation could induce deadlock)
 		// then let the fixture worry about a clean kill.
+		workertest.CheckAlive(c, engine)
 	})
 }
 
@@ -114,5 +116,6 @@ func (s *SelfSuite) TestStress(c *gc.C) {
 		// Give it a moment to screw up if it's going to
 		// (injudicious implementation could induce deadlock)
 		// then let the fixture worry about a clean kill.
+		workertest.CheckAlive(c, engine)
 	})
 }

--- a/worker/discoverspaces/manifold.go
+++ b/worker/discoverspaces/manifold.go
@@ -7,6 +7,7 @@ import (
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/api/discoverspaces"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/dependency"
@@ -20,6 +21,10 @@ type ManifoldConfig struct {
 
 	NewFacade func(base.APICaller) (Facade, error)
 	NewWorker func(Config) (worker.Worker, error)
+}
+
+func NewFacade(apiCaller base.APICaller) (Facade, error) {
+	return discoverspaces.NewAPI(apiCaller), nil
 }
 
 func Manifold(config ManifoldConfig) dependency.Manifold {

--- a/worker/firewaller/firewaller.go
+++ b/worker/firewaller/firewaller.go
@@ -86,14 +86,16 @@ func (fw *Firewaller) setUp() error {
 		return errors.Trace(err)
 	}
 	switch fw.environ.Config().FirewallMode() {
+	case config.FwInstance:
 	case config.FwGlobal:
 		fw.globalMode = true
 		fw.globalPortRef = make(map[network.PortRange]int)
 	case config.FwNone:
-		logger.Warningf("stopping firewaller - firewall-mode is %q", config.FwNone)
-		// XXX(fwereade): shouldn't this be nil? Nothing wrong, nothing to do,
-		// now that we've logged there's no further reason to complain or retry.
-		return errors.Errorf("firewaller is disabled when firewall-mode is %q", config.FwNone)
+		logger.Infof("stopping firewaller (not required)")
+		fw.Kill()
+		return fw.catacomb.ErrDying()
+	default:
+		return errors.Errorf("unknown firewall-mode %q", config.FwNone)
 	}
 
 	fw.machinesWatcher, err = fw.st.WatchModelMachines()

--- a/worker/firewaller/firewaller_test.go
+++ b/worker/firewaller/firewaller_test.go
@@ -24,6 +24,7 @@ import (
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/firewaller"
+	"github.com/juju/juju/worker/workertest"
 )
 
 // firewallerBaseSuite implements common functionality for embedding
@@ -827,26 +828,9 @@ func (s *NoneModeSuite) SetUpTest(c *gc.C) {
 	s.firewallerBaseSuite.setUpTest(c, config.FwNone)
 }
 
-func (s *NoneModeSuite) TearDownTest(c *gc.C) {
-	s.firewallerBaseSuite.JujuConnSuite.TearDownTest(c)
-}
-
-func (s *NoneModeSuite) TestStopImmediatelyWhenModeNone(c *gc.C) {
+func (s *NoneModeSuite) TestStopImmediately(c *gc.C) {
 	fw, err := firewaller.NewFirewaller(s.firewaller)
 	c.Assert(err, jc.ErrorIsNil)
-	defer func() {
-		fw.Kill()
-		fw.Wait()
-	}()
-
-	wait := make(chan error)
-	go func() {
-		wait <- fw.Wait()
-	}()
-	select {
-	case err := <-wait:
-		c.Assert(err, gc.ErrorMatches, `firewaller is disabled when firewall-mode is "none"`)
-	case <-time.After(coretesting.LongWait):
-		c.Fatalf("timed out")
-	}
+	err = workertest.CheckKilled(c, fw)
+	c.Check(err, jc.ErrorIsNil)
 }

--- a/worker/instancepoller/aggregate.go
+++ b/worker/instancepoller/aggregate.go
@@ -64,6 +64,7 @@ func (a *aggregator) instanceInfo(id instance.Id) (instanceInfo, error) {
 var gatherTime = 3 * time.Second
 
 func (a *aggregator) loop() error {
+	// TODO(fwereade): 2016-03-17 lp:1558657
 	timer := time.NewTimer(0)
 	timer.Stop()
 	var reqs []instanceInfoReq

--- a/worker/instancepoller/updater.go
+++ b/worker/instancepoller/updater.go
@@ -211,6 +211,7 @@ func machineLoop(context machineContext, m machine, changed <-chan struct{}) err
 		case <-context.dying():
 			return context.errDying()
 		case <-time.After(pollInterval):
+			// TODO(fwereade): 2016-03-17 lp:1558657
 			pollInstance = true
 		case <-changed:
 			if err := m.Refresh(); err != nil {

--- a/worker/leadership/tracker.go
+++ b/worker/leadership/tracker.go
@@ -163,6 +163,7 @@ func (t *Tracker) loop() error {
 func (t *Tracker) refresh() error {
 	logger.Debugf("checking %s for %s leadership", t.unitName, t.serviceName)
 	leaseDuration := 2 * t.duration
+	// TODO(fwereade): 2016-03-17 lp:1558657
 	untilTime := time.Now().Add(leaseDuration)
 	err := t.claimer.ClaimLeadership(t.serviceName, t.unitName, leaseDuration)
 	switch {
@@ -181,6 +182,7 @@ func (t *Tracker) setLeader(untilTime time.Time) error {
 	logger.Infof("%s will renew %s leadership at %s", t.unitName, t.serviceName, renewTime)
 	t.isMinion = false
 	t.claimLease = nil
+	// TODO(fwereade): 2016-03-17 lp:1558657
 	t.renewLease = time.After(renewTime.Sub(time.Now()))
 
 	for len(t.waitingLeader) > 0 {

--- a/worker/meterstatus/context.go
+++ b/worker/meterstatus/context.go
@@ -26,6 +26,7 @@ type limitedContext struct {
 // NewLimitedContext creates a new context that implements just the bare minimum
 // of the jujuc.Context interface.
 func NewLimitedContext(unitName string) *limitedContext {
+	// TODO(fwereade): 2016-03-17 lp:1558657
 	id := fmt.Sprintf("%s-%s-%d", unitName, "meter-status", rand.New(rand.NewSource(time.Now().Unix())).Int63())
 	return &limitedContext{unitName: unitName, id: id}
 }

--- a/worker/metrics/collect/context.go
+++ b/worker/metrics/collect/context.go
@@ -24,6 +24,7 @@ type hookContext struct {
 }
 
 func newHookContext(unitName string, recorder spool.MetricRecorder) *hookContext {
+	// TODO(fwereade): 2016-03-17 lp:1558657
 	id := fmt.Sprintf("%s-%s-%d", unitName, "collect-metrics", rand.New(rand.NewSource(time.Now().Unix())).Int63())
 	return &hookContext{unitName: unitName, id: id, recorder: recorder}
 }
@@ -58,6 +59,7 @@ func (ctx *hookContext) AddMetric(key string, value string, created time.Time) e
 // is defined for this context.
 func (ctx *hookContext) addJujuUnitsMetric() error {
 	if ctx.recorder.IsDeclaredMetric("juju-units") {
+		// TODO(fwereade): 2016-03-17 lp:1558657
 		err := ctx.recorder.AddMetric("juju-units", "1", time.Now().UTC())
 		if err != nil {
 			return errors.Trace(err)

--- a/worker/metrics/collect/handler.go
+++ b/worker/metrics/collect/handler.go
@@ -43,6 +43,7 @@ func (l *handler) Handle(c net.Conn) (err error) {
 		}
 		c.Close()
 	}()
+	// TODO(fwereade): 2016-03-17 lp:1558657
 	err = c.SetDeadline(time.Now().Add(spool.DefaultTimeout))
 	if err != nil {
 		return errors.Annotate(err, "failed to set the deadline")

--- a/worker/metrics/sender/sender.go
+++ b/worker/metrics/sender/sender.go
@@ -86,6 +86,7 @@ func (s *sender) Handle(c net.Conn) (err error) {
 		}
 		c.Close()
 	}()
+	// TODO(fwereade): 2016-03-17 lp:1558657
 	err = c.SetDeadline(time.Now().Add(spool.DefaultTimeout))
 	if err != nil {
 		return errors.Annotate(err, "failed to set the deadline")

--- a/worker/metrics/spool/metrics.go
+++ b/worker/metrics/spool/metrics.go
@@ -137,9 +137,10 @@ func NewJSONMetricRecorder(config MetricRecorderConfig) (rec *JSONMetricRecorder
 	}
 
 	recorder := &JSONMetricRecorder{
-		spoolDir:     config.SpoolDir,
-		uuid:         mbUUID,
-		charmURL:     config.CharmURL,
+		spoolDir: config.SpoolDir,
+		uuid:     mbUUID,
+		charmURL: config.CharmURL,
+		// TODO(fwereade): 2016-03-17 lp:1558657
 		created:      time.Now().UTC(),
 		validMetrics: config.Metrics,
 		unitTag:      config.UnitTag,

--- a/worker/modelworkermanager/export_test.go
+++ b/worker/modelworkermanager/export_test.go
@@ -1,8 +1,0 @@
-// Copyright 2015 Canonical Ltd.
-// Licensed under the AGPLv3, see LICENCE file for details.
-
-package modelworkermanager
-
-func DyingModelWorkerId(uuid string) string {
-	return dyingModelWorkerId(uuid)
-}

--- a/worker/modelworkermanager/modelworkermanager.go
+++ b/worker/modelworkermanager/modelworkermanager.go
@@ -7,203 +7,143 @@ import (
 	"time"
 
 	"github.com/juju/errors"
-	"github.com/juju/loggo"
-	"github.com/juju/names"
-	"gopkg.in/mgo.v2"
-	"launchpad.net/tomb"
+	"github.com/juju/utils/set"
 
-	cmdutil "github.com/juju/juju/cmd/jujud/util"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/catacomb"
 )
 
-var logger = loggo.GetLogger("juju.worker.modelworkermanager")
-
-type modelWorkersCreator func(InitialState, *state.State) (worker.Worker, error)
-
-// NewModelWorkerManager returns a Worker which manages a worker which
-// needs to run on a per model basis. It takes a function which will
-// be called to start a worker for a new model. This worker
-// will be killed when an model goes away.
-func NewModelWorkerManager(
-	st InitialState,
-	startModelWorker modelWorkersCreator,
-	dyingModelWorker modelWorkersCreator,
-	delay time.Duration,
-) worker.Worker {
-	m := &modelWorkerManager{
-		st:               st,
-		startModelWorker: startModelWorker,
-		dyingModelWorker: dyingModelWorker,
-	}
-	m.runner = worker.NewRunner(cmdutil.IsFatal, cmdutil.MoreImportant, delay)
-	go func() {
-		defer m.tomb.Done()
-		m.tomb.Kill(m.loop())
-	}()
-	return m
+// Backend defines the State functionality used by the manager worker.
+type Backend interface {
+	WatchModels() state.StringsWatcher
 }
 
-// InitialState defines the State functionality used by
-// envWorkerManager and/or could be useful to startEnvWorker
-// funcs. It mainly exists to support testing.
-type InitialState interface {
-	WatchModels() state.StringsWatcher
-	ForModel(names.ModelTag) (*state.State, error)
-	GetModel(names.ModelTag) (*state.Model, error)
-	ModelUUID() string
-	Machine(string) (*state.Machine, error)
-	MongoSession() *mgo.Session
+// NewWorkerFunc should return a worker responsible for running
+// all a model's required workers; and for returning nil when
+// there's no more model to manage.
+type NewWorkerFunc func(modelUUID string) (worker.Worker, error)
+
+// Config holds the dependencies and configuration necessary to run
+// a model worker manager.
+type Config struct {
+	Backend    Backend
+	NewWorker  NewWorkerFunc
+	ErrorDelay time.Duration
+}
+
+// Validate returns an error if config cannot be expected to drive
+// a functional model worker manager.
+func (config Config) Validate() error {
+	if config.Backend == nil {
+		return errors.NotValidf("nil Backend")
+	}
+	if config.NewWorker == nil {
+		return errors.NotValidf("nil NewWorker")
+	}
+	if config.ErrorDelay <= 0 {
+		return errors.NotValidf("non-positive ErrorDelay")
+	}
+	return nil
+}
+
+func New(config Config) (worker.Worker, error) {
+	if err := config.Validate(); err != nil {
+		return nil, errors.Trace(err)
+	}
+	m := &modelWorkerManager{
+		config:  config,
+		started: set.NewStrings(),
+	}
+
+	err := catacomb.Invoke(catacomb.Plan{
+		Site: &m.catacomb,
+		Work: m.loop,
+	})
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return m, nil
 }
 
 type modelWorkerManager struct {
-	runner           worker.Runner
-	tomb             tomb.Tomb
-	st               InitialState
-	startModelWorker modelWorkersCreator
-	dyingModelWorker modelWorkersCreator
+	catacomb catacomb.Catacomb
+	config   Config
+	runner   worker.Runner
+	started  set.Strings
 }
 
 // Kill satisfies the Worker interface.
 func (m *modelWorkerManager) Kill() {
-	m.tomb.Kill(nil)
+	m.catacomb.Kill(nil)
 }
 
 // Wait satisfies the Worker interface.
 func (m *modelWorkerManager) Wait() error {
-	return m.tomb.Wait()
+	return m.catacomb.Wait()
 }
 
 func (m *modelWorkerManager) loop() error {
-	go func() {
-		// When the runner stops, make sure we stop the envWorker as well
-		m.tomb.Kill(m.runner.Wait())
-	}()
-	defer func() {
-		// When we return, make sure that we kill
-		// the runner and wait for it.
-		m.runner.Kill()
-		m.tomb.Kill(m.runner.Wait())
-	}()
-	w := m.st.WatchModels()
-	defer w.Stop()
+	m.runner = worker.NewRunner(
+		neverFatal, neverImportant, m.config.ErrorDelay,
+	)
+	if err := m.catacomb.Add(m.runner); err != nil {
+		return errors.Trace(err)
+	}
+	watcher := m.config.Backend.WatchModels()
+	if err := m.catacomb.Add(watcher); err != nil {
+		return errors.Trace(err)
+	}
+
 	for {
 		select {
-		case uuids := <-w.Changes():
-			// One or more models have changed.
+		case <-m.catacomb.Dying():
+			return m.catacomb.ErrDying()
+		case uuids, ok := <-watcher.Changes():
+			if !ok {
+				return errors.New("changes stopped")
+			}
 			for _, uuid := range uuids {
-				if err := m.modelHasChanged(uuid); err != nil {
+				if err := m.ensure(uuid); err != nil {
 					return errors.Trace(err)
 				}
 			}
-		case <-m.tomb.Dying():
-			return tomb.ErrDying
 		}
 	}
 }
 
-func (m *modelWorkerManager) modelHasChanged(uuid string) error {
-	modelTag := names.NewModelTag(uuid)
-	env, err := m.st.GetModel(modelTag)
-	if errors.IsNotFound(err) {
-		return m.modelNotFound(modelTag)
-	} else if err != nil {
-		return errors.Annotatef(err, "error loading model %s", modelTag.Id())
+func (m *modelWorkerManager) ensure(uuid string) error {
+	if m.started.Contains(uuid) {
+		// A second StartWorker for a given ID is mostly
+		// harmless -- it will probably be ignored, but
+		// might work if the previous worker has already
+		// stopped without error. Neither situation will
+		// hurt us directly, but we prefer to eliminate
+		// the messy uncertainty.
+		return nil
 	}
-
-	switch env.Life() {
-	case state.Alive:
-		err = m.envIsAlive(modelTag)
-	case state.Dying:
-		err = m.modelIsDying(modelTag)
-	case state.Dead:
-		err = m.envIsDead(modelTag)
-	}
-
-	return errors.Trace(err)
-}
-
-func (m *modelWorkerManager) envIsAlive(modelTag names.ModelTag) error {
-	return m.runner.StartWorker(modelTag.Id(), func() (worker.Worker, error) {
-		st, err := m.st.ForModel(modelTag)
-		if err != nil {
-			return nil, errors.Annotatef(err, "failed to open state for model %s", modelTag.Id())
-		}
-		closeState := func() {
-			err := st.Close()
-			if err != nil {
-				logger.Errorf("error closing state for model %s: %v", modelTag.Id(), err)
-			}
-		}
-
-		envRunner, err := m.startModelWorker(m.st, st)
-		if err != nil {
-			closeState()
-			return nil, errors.Trace(err)
-		}
-
-		// Close State when the runner for the model is done.
-		go func() {
-			envRunner.Wait()
-			closeState()
-		}()
-
-		return envRunner, nil
-	})
-}
-
-func dyingModelWorkerId(uuid string) string {
-	return "dying" + ":" + uuid
-}
-
-// envNotFound stops all workers for that model.
-func (m *modelWorkerManager) modelNotFound(modelTag names.ModelTag) error {
-	uuid := modelTag.Id()
-	if err := m.runner.StopWorker(uuid); err != nil {
+	starter := m.starter(uuid)
+	if err := m.runner.StartWorker(uuid, starter); err != nil {
 		return errors.Trace(err)
 	}
-	if err := m.runner.StopWorker(dyingModelWorkerId(uuid)); err != nil {
-		return errors.Trace(err)
-	}
+	m.started.Add(uuid)
 	return nil
 }
 
-func (m *modelWorkerManager) modelIsDying(modelTag names.ModelTag) error {
-	id := dyingModelWorkerId(modelTag.Id())
-	return m.runner.StartWorker(id, func() (worker.Worker, error) {
-		st, err := m.st.ForModel(modelTag)
+func (m *modelWorkerManager) starter(uuid string) func() (worker.Worker, error) {
+	return func() (worker.Worker, error) {
+		worker, err := m.config.NewWorker(uuid)
 		if err != nil {
-			return nil, errors.Annotatef(err, "failed to open state for model %s", modelTag.Id())
+			return nil, errors.Annotatef(err, "cannot manage model %q", uuid)
 		}
-		closeState := func() {
-			err := st.Close()
-			if err != nil {
-				logger.Errorf("error closing state for model %s: %v", modelTag.Id(), err)
-			}
-		}
-
-		dyingRunner, err := m.dyingModelWorker(m.st, st)
-		if err != nil {
-			closeState()
-			return nil, errors.Trace(err)
-		}
-
-		// Close State when the runner for the model is done.
-		go func() {
-			dyingRunner.Wait()
-			closeState()
-		}()
-
-		return dyingRunner, nil
-	})
+		return worker, nil
+	}
 }
 
-func (m *modelWorkerManager) envIsDead(modelTag names.ModelTag) error {
-	uuid := modelTag.Id()
-	err := m.runner.StopWorker(uuid)
-	if err != nil {
-		return errors.Trace(err)
-	}
+func neverFatal(error) bool {
+	return false
+}
 
-	return nil
+func neverImportant(error, error) bool {
+	return false
 }

--- a/worker/modelworkermanager/modelworkermanager_test.go
+++ b/worker/modelworkermanager/modelworkermanager_test.go
@@ -4,458 +4,253 @@
 package modelworkermanager_test
 
 import (
-	stdtesting "testing"
 	"time"
 
 	"github.com/juju/errors"
-	"github.com/juju/loggo"
-	"github.com/juju/names"
+	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"launchpad.net/tomb"
 
-	cmdutil "github.com/juju/juju/cmd/jujud/util"
 	"github.com/juju/juju/state"
-	statetesting "github.com/juju/juju/state/testing"
-	"github.com/juju/juju/testing"
-	"github.com/juju/juju/testing/factory"
+	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/modelworkermanager"
+	"github.com/juju/juju/worker/workertest"
 )
-
-func TestPackage(t *stdtesting.T) {
-	testing.MgoTestPackage(t)
-}
 
 var _ = gc.Suite(&suite{})
 
 type suite struct {
-	statetesting.StateSuite
-	factory  *factory.Factory
-	runnerC  chan *fakeRunner
-	startErr error
+	testing.IsolationSuite
+	workerC chan *mockWorker
 }
 
 func (s *suite) SetUpTest(c *gc.C) {
-	s.StateSuite.SetUpTest(c)
-	s.factory = factory.NewFactory(s.State)
-	s.runnerC = make(chan *fakeRunner, 1)
-	s.startErr = nil
+	s.IsolationSuite.SetUpTest(c)
+	s.workerC = make(chan *mockWorker, 100)
 }
 
-func (s *suite) TearDownTest(c *gc.C) {
-	close(s.runnerC)
-	s.StateSuite.TearDownTest(c)
+func (s *suite) TestStartEmpty(c *gc.C) {
+	s.runTest(c, func(_ worker.Worker, backend *mockBackend) {
+		backend.sendModelChange()
+
+		s.assertNoWorkers(c)
+	})
 }
 
-func (s *suite) MakeModel(c *gc.C) *state.State {
-	st := s.factory.MakeModel(c, nil)
-	s.AddCleanup(func(*gc.C) { st.Close() })
-	return st
+func (s *suite) TestStartsInitialWorker(c *gc.C) {
+	s.runTest(c, func(_ worker.Worker, backend *mockBackend) {
+		backend.sendModelChange("uuid")
+
+		s.assertStarts(c, "uuid")
+	})
 }
 
-func destroyEnvironment(c *gc.C, st *state.State) {
-	env, err := st.Model()
+func (s *suite) TestStartsLaterWorker(c *gc.C) {
+	s.runTest(c, func(_ worker.Worker, backend *mockBackend) {
+		backend.sendModelChange()
+		backend.sendModelChange("uuid")
+
+		s.assertStarts(c, "uuid")
+	})
+}
+
+func (s *suite) TestStartsMultiple(c *gc.C) {
+	s.runTest(c, func(_ worker.Worker, backend *mockBackend) {
+		backend.sendModelChange("uuid1")
+		backend.sendModelChange("uuid2", "uuid3")
+		backend.sendModelChange("uuid4")
+
+		s.assertStarts(c, "uuid1", "uuid2", "uuid3", "uuid4")
+	})
+}
+
+func (s *suite) TestIgnoresRepetition(c *gc.C) {
+	s.runTest(c, func(_ worker.Worker, backend *mockBackend) {
+		backend.sendModelChange("uuid")
+		backend.sendModelChange("uuid", "uuid")
+		backend.sendModelChange("uuid")
+
+		s.assertStarts(c, "uuid")
+	})
+}
+
+func (s *suite) TestRestartsErrorWorker(c *gc.C) {
+	s.runTest(c, func(w worker.Worker, backend *mockBackend) {
+		backend.sendModelChange("uuid")
+		workers := s.waitWorkers(c, 1)
+		workers[0].tomb.Kill(errors.New("blaf"))
+
+		s.assertStarts(c, "uuid")
+		workertest.CheckAlive(c, w)
+	})
+}
+
+func (s *suite) TestNeverRestartsFinishedWorker(c *gc.C) {
+	s.runTest(c, func(w worker.Worker, backend *mockBackend) {
+		backend.sendModelChange("uuid")
+		workers := s.waitWorkers(c, 1)
+		workers[0].tomb.Kill(nil)
+
+		// even when we get a change for it
+		backend.sendModelChange("uuid")
+		workertest.CheckAlive(c, w)
+		s.assertNoWorkers(c)
+	})
+}
+
+func (s *suite) TestKillsManagers(c *gc.C) {
+	s.runTest(c, func(w worker.Worker, backend *mockBackend) {
+		backend.sendModelChange("uuid1", "uuid2")
+		workers := s.waitWorkers(c, 2)
+
+		workertest.CleanKill(c, w)
+		for _, worker := range workers {
+			workertest.CheckKilled(c, worker)
+		}
+		s.assertNoWorkers(c)
+	})
+}
+
+func (s *suite) TestClosedChangesChannel(c *gc.C) {
+	s.runDirtyTest(c, func(w worker.Worker, backend *mockBackend) {
+		backend.sendModelChange("uuid1", "uuid2")
+		workers := s.waitWorkers(c, 2)
+
+		close(backend.envWatcher.changes)
+		err := workertest.CheckKilled(c, w)
+		c.Check(err, gc.ErrorMatches, "changes stopped")
+		for _, worker := range workers {
+			workertest.CheckKilled(c, worker)
+		}
+		s.assertNoWorkers(c)
+	})
+}
+
+type testFunc func(worker.Worker, *mockBackend)
+type killFunc func(*gc.C, worker.Worker)
+
+func (s *suite) runTest(c *gc.C, test testFunc) {
+	s.runKillTest(c, workertest.CleanKill, test)
+}
+
+func (s *suite) runDirtyTest(c *gc.C, test testFunc) {
+	s.runKillTest(c, workertest.DirtyKill, test)
+}
+
+func (s *suite) runKillTest(c *gc.C, kill killFunc, test testFunc) {
+	backend := newMockBackend()
+	config := modelworkermanager.Config{
+		Backend:    backend,
+		NewWorker:  s.startModelWorker,
+		ErrorDelay: time.Millisecond,
+	}
+	w, err := modelworkermanager.New(config)
 	c.Assert(err, jc.ErrorIsNil)
-	err = env.Destroy()
-	c.Assert(err, jc.ErrorIsNil)
+	defer kill(c, w)
+	test(w, backend)
 }
 
-func (s *suite) TestStartsWorkersForPreExistingEnvs(c *gc.C) {
-	moreState := s.MakeModel(c)
+func (s *suite) startModelWorker(uuid string) (worker.Worker, error) {
+	worker := newMockWorker(uuid)
+	s.workerC <- worker
+	return worker, nil
+}
 
-	var seenEnvs []string
-	m := modelworkermanager.NewModelWorkerManager(s.State, s.startEnvWorker, s.dyingEnvWorker, time.Millisecond)
-	defer m.Kill()
-	for _, r := range s.seeRunnersStart(c, 2) {
-		seenEnvs = append(seenEnvs, r.modelUUID)
+func (s *suite) assertStarts(c *gc.C, expect ...string) {
+	count := len(expect)
+	actual := make([]string, count)
+	workers := s.waitWorkers(c, count)
+	for i, worker := range workers {
+		actual[i] = worker.uuid
 	}
-
-	c.Assert(seenEnvs, jc.SameContents,
-		[]string{s.State.ModelUUID(), moreState.ModelUUID()},
-	)
-
-	destroyEnvironment(c, moreState)
-	dyingRunner := s.seeRunnersStart(c, 1)[0]
-	c.Assert(dyingRunner.modelUUID, gc.Equals, moreState.ModelUUID())
+	c.Assert(actual, jc.SameContents, expect)
 }
 
-func (s *suite) TestStartsWorkersForNewEnv(c *gc.C) {
-	m := modelworkermanager.NewModelWorkerManager(s.State, s.startEnvWorker, s.dyingEnvWorker, time.Millisecond)
-	defer m.Kill()
-	s.seeRunnersStart(c, 1) // Runner for controller env
-
-	// Create another environment and watch a runner be created for it.
-	st2 := s.MakeModel(c)
-	runner := s.seeRunnersStart(c, 1)[0]
-	c.Assert(runner.modelUUID, gc.Equals, st2.ModelUUID())
-}
-
-func (s *suite) TestStopsWorkersWhenEnvGoesAway(c *gc.C) {
-	m := modelworkermanager.NewModelWorkerManager(s.State, s.startEnvWorker, s.dyingEnvWorker, time.Millisecond)
-	defer m.Kill()
-	runner0 := s.seeRunnersStart(c, 1)[0]
-
-	// Create an environment and grab the runner for it.
-	otherState := s.MakeModel(c)
-	runner1 := s.seeRunnersStart(c, 1)[0]
-
-	// Set environment to dying.
-	destroyEnvironment(c, otherState)
-	s.seeRunnersStart(c, 1) // dying env runner
-
-	// Set environment to dead.
-	err := otherState.ProcessDyingModel()
-	c.Assert(err, jc.ErrorIsNil)
-
-	// See that the first runner is still running but the runner for
-	// the new environment is stopped.
-	s.State.StartSync()
-	select {
-	case <-runner0.tomb.Dead():
-		c.Fatal("first runner should not die here")
-	case <-runner1.tomb.Dead():
-		break
-	case <-time.After(testing.LongWait):
-		c.Fatal("timed out waiting for runner to die")
-	}
-
-	// Make sure the first runner doesn't get stopped.
-	s.State.StartSync()
-	select {
-	case <-runner0.tomb.Dead():
-		c.Fatal("first runner should not die here")
-	case <-time.After(testing.ShortWait):
-		break
-	}
-}
-
-func (s *suite) TestKillPropagates(c *gc.C) {
-	otherSt := s.MakeModel(c)
-
-	m := modelworkermanager.NewModelWorkerManager(s.State, s.startEnvWorker, s.dyingEnvWorker, time.Millisecond)
-	runners := s.seeRunnersStart(c, 2)
-	c.Assert(runners[0].killed, jc.IsFalse)
-	c.Assert(runners[1].killed, jc.IsFalse)
-
-	destroyEnvironment(c, otherSt)
-	dyingRunner := s.seeRunnersStart(c, 1)[0]
-	c.Assert(dyingRunner.killed, jc.IsFalse)
-
-	m.Kill()
-	err := waitOrFatal(c, m.Wait)
-	c.Assert(err, jc.ErrorIsNil)
-
-	c.Assert(runners[0].killed, jc.IsTrue)
-	c.Assert(runners[1].killed, jc.IsTrue)
-	c.Assert(dyingRunner.killed, jc.IsTrue)
-}
-
-// stateWithFailingGetEnvironment wraps a *state.State, overriding the
-// GetModel to generate an error.
-type stateWithFailingGetEnvironment struct {
-	*stateWithFakeWatcher
-	shouldFail bool
-}
-
-func newStateWithFailingGetEnvironment(realSt *state.State) *stateWithFailingGetEnvironment {
-	return &stateWithFailingGetEnvironment{
-		stateWithFakeWatcher: newStateWithFakeWatcher(realSt),
-		shouldFail:           false,
-	}
-}
-
-func (s *stateWithFailingGetEnvironment) GetModel(tag names.ModelTag) (*state.Model, error) {
-	if s.shouldFail {
-		return nil, errors.New("unable to GetModel")
-	}
-	return s.State.GetModel(tag)
-}
-
-func (s *suite) TestLoopExitKillsRunner(c *gc.C) {
-	// If something causes EnvWorkerManager.loop to exit that isn't Kill() then it should stop the runner.
-	// Currently the best way to cause this is to make
-	// m.st.GetModel(tag) fail with any error other than NotFound
-	otherSt := s.MakeModel(c)
-	st := newStateWithFailingGetEnvironment(s.State)
-	uuid := st.ModelUUID()
-	m := modelworkermanager.NewModelWorkerManager(st, s.startEnvWorker, s.dyingEnvWorker, time.Millisecond)
-	defer m.Kill()
-
-	// First time: runners started
-	st.sendEnvChange(uuid)
-	runners := s.seeRunnersStart(c, 1)
-	c.Assert(runners[0].killed, jc.IsFalse)
-
-	destroyEnvironment(c, otherSt)
-	st.sendEnvChange(otherSt.ModelUUID())
-	dyingRunner := s.seeRunnersStart(c, 1)[0]
-	c.Assert(dyingRunner.killed, jc.IsFalse)
-
-	// Now we start failing
-	st.shouldFail = true
-	st.sendEnvChange(uuid)
-
-	// This should kill the manager
-	err := waitOrFatal(c, m.Wait)
-	c.Assert(err, gc.ErrorMatches, "error loading model .*: unable to GetModel")
-
-	// And that should kill all the runners
-	c.Assert(runners[0].killed, jc.IsTrue)
-	c.Assert(dyingRunner.killed, jc.IsTrue)
-}
-
-func (s *suite) TestWorkerErrorIsPropagatedWhenKilled(c *gc.C) {
-	st := newStateWithFakeWatcher(s.State)
-	started := make(chan struct{}, 1)
-	m := modelworkermanager.NewModelWorkerManager(st, func(modelworkermanager.InitialState, *state.State) (worker.Worker, error) {
-		c.Logf("starting worker")
-		started <- struct{}{}
-		return &errorWhenKilledWorker{
-			err: &cmdutil.FatalError{"an error"},
-		}, nil
-	}, s.dyingEnvWorker, time.Millisecond)
-	st.sendEnvChange(st.ModelUUID())
-	s.State.StartSync()
-	<-started
-	m.Kill()
-	err := m.Wait()
-	c.Assert(err, gc.ErrorMatches, "an error")
-}
-
-type errorWhenKilledWorker struct {
-	tomb tomb.Tomb
-	err  error
-}
-
-var logger = loggo.GetLogger("juju.worker.modelworkermanager")
-
-func (w *errorWhenKilledWorker) Kill() {
-	w.tomb.Kill(w.err)
-	logger.Errorf("errorWhenKilledWorker dying with error %v", w.err)
-	w.tomb.Done()
-}
-
-func (w *errorWhenKilledWorker) Wait() error {
-	err := w.tomb.Wait()
-	logger.Errorf("errorWhenKilledWorker wait -> error %v", err)
-	return err
-}
-
-func (s *suite) TestNothingHappensWhenEnvIsSeenAgain(c *gc.C) {
-	// This could happen if there's a change to an environment doc but
-	// it's otherwise still alive (unlikely but possible).
-	st := newStateWithFakeWatcher(s.State)
-	uuid := st.ModelUUID()
-	otherSt := s.MakeModel(c)
-	otherUUID := otherSt.ModelUUID()
-
-	m := modelworkermanager.NewModelWorkerManager(st, s.startEnvWorker, s.dyingEnvWorker, time.Millisecond)
-	defer m.Kill()
-
-	// First time: runners started
-	st.sendEnvChange(uuid)
-	st.sendEnvChange(otherUUID)
-	s.seeRunnersStart(c, 2)
-
-	// Second time: no runners started
-	st.sendEnvChange(uuid)
-	s.checkNoRunnersStart(c)
-
-	destroyEnvironment(c, otherSt)
-	st.sendEnvChange(otherUUID)
-	s.seeRunnersStart(c, 1)
-
-	st.sendEnvChange(otherUUID)
-	s.checkNoRunnersStart(c)
-}
-
-func (s *suite) TestNothingHappensWhenUnknownEnvReported(c *gc.C) {
-	// This could perhaps happen when an environment is dying just as
-	// the EnvWorkerManager is coming up (unlikely but possible).
-	st := newStateWithFakeWatcher(s.State)
-
-	m := modelworkermanager.NewModelWorkerManager(st, s.startEnvWorker, s.dyingEnvWorker, time.Millisecond)
-	defer m.Kill()
-
-	st.sendEnvChange("unknown-model-uuid")
-	s.checkNoRunnersStart(c)
-
-	// Existing environment still works.
-	st.sendEnvChange(st.ModelUUID())
-	s.seeRunnersStart(c, 1)
-}
-
-func (s *suite) TestFatalErrorKillsEnvWorkerManager(c *gc.C) {
-	m := modelworkermanager.NewModelWorkerManager(s.State, s.startEnvWorker, s.dyingEnvWorker, time.Millisecond)
-	runner := s.seeRunnersStart(c, 1)[0]
-
-	runner.tomb.Kill(worker.ErrTerminateAgent)
-	runner.tomb.Done()
-
-	err := waitOrFatal(c, m.Wait)
-	c.Assert(errors.Cause(err), gc.Equals, worker.ErrTerminateAgent)
-}
-
-func (s *suite) TestNonFatalErrorCausesRunnerRestart(c *gc.C) {
-	m := modelworkermanager.NewModelWorkerManager(s.State, s.startEnvWorker, s.dyingEnvWorker, time.Millisecond)
-	defer m.Kill()
-	runner0 := s.seeRunnersStart(c, 1)[0]
-
-	runner0.tomb.Kill(errors.New("trivial"))
-	runner0.tomb.Done()
-
-	s.seeRunnersStart(c, 1)
-}
-
-func (s *suite) TestStateIsClosedIfStartEnvWorkersFails(c *gc.C) {
-	// If State is not closed when startEnvWorker errors, MgoSuite's
-	// dirty socket detection will pick up the leaked socket and
-	// panic.
-	s.startErr = worker.ErrTerminateAgent // This will make envWorkerManager exit.
-	m := modelworkermanager.NewModelWorkerManager(s.State, s.startEnvWorker, s.dyingEnvWorker, time.Millisecond)
-	waitOrFatal(c, m.Wait)
-}
-
-func (s *suite) TestdyingEnvWorkerId(c *gc.C) {
-	c.Assert(modelworkermanager.DyingModelWorkerId("uuid"), gc.Equals, "dying:uuid")
-}
-
-func (s *suite) seeRunnersStart(c *gc.C, expectedCount int) []*fakeRunner {
+func (s *suite) waitWorkers(c *gc.C, expectedCount int) []*mockWorker {
 	if expectedCount < 1 {
 		c.Fatal("expectedCount must be >= 1")
 	}
-	s.State.StartSync()
-	runners := make([]*fakeRunner, 0, expectedCount)
+	workers := make([]*mockWorker, 0, expectedCount)
 	for {
 		select {
-		case r := <-s.runnerC:
-			c.Assert(r.ssModelUUID, gc.Equals, s.State.ModelUUID())
-
-			runners = append(runners, r)
-			if len(runners) == expectedCount {
-				s.checkNoRunnersStart(c) // Check no more runners start
-				return runners
+		case worker := <-s.workerC:
+			workers = append(workers, worker)
+			if len(workers) == expectedCount {
+				s.assertNoWorkers(c)
+				return workers
 			}
-		case <-time.After(testing.LongWait):
-			c.Fatal("timed out waiting for runners to be started")
+		case <-time.After(coretesting.LongWait):
+			c.Fatal("timed out waiting for workers to be started")
 		}
 	}
 }
 
-func (s *suite) checkNoRunnersStart(c *gc.C) {
-	s.State.StartSync()
-	for {
-		select {
-		case <-s.runnerC:
-			c.Fatal("saw runner creation when expecting none")
-		case <-time.After(testing.ShortWait):
-			return
-		}
-	}
-}
-
-// startEnvWorker is passed to NewModelWorkerManager in these tests. It
-// creates fake Runner instances when envWorkerManager starts workers
-// for an alive environment.
-func (s *suite) startEnvWorker(ssSt modelworkermanager.InitialState, st *state.State) (worker.Worker, error) {
-	if s.startErr != nil {
-		return nil, s.startErr
-	}
-	runner := &fakeRunner{
-		ssModelUUID: ssSt.ModelUUID(),
-		modelUUID:   st.ModelUUID(),
-	}
-	s.runnerC <- runner
-	return runner, nil
-}
-
-// dyingEnvWorker is passed to NewModelWorkerManager in these tests. It
-// creates a fake Runner instance when envWorkerManager starts workers for a
-// dying or dead environment.
-func (s *suite) dyingEnvWorker(ssSt modelworkermanager.InitialState, st *state.State) (worker.Worker, error) {
-	if s.startErr != nil {
-		return nil, s.startErr
-	}
-	runner := &fakeRunner{
-		ssModelUUID: ssSt.ModelUUID(),
-		modelUUID:   st.ModelUUID(),
-	}
-	s.runnerC <- runner
-	return runner, nil
-}
-
-func waitOrFatal(c *gc.C, wait func() error) error {
-	errC := make(chan error)
-	go func() {
-		errC <- wait()
-	}()
-
+func (s *suite) assertNoWorkers(c *gc.C) {
 	select {
-	case err := <-errC:
-		return err
-	case <-time.After(testing.LongWait):
-		c.Fatal("waited too long")
+	case worker := <-s.workerC:
+		c.Fatalf("saw unexpected worker: %s", worker.uuid)
+	case <-time.After(coretesting.ShortWait):
 	}
-	return nil
 }
 
-// fakeRunner minimally implements the worker.Worker interface. It
-// doesn't actually run anything, recording some execution details for
-// testing.
-type fakeRunner struct {
-	tomb        tomb.Tomb
-	ssModelUUID string
-	modelUUID   string
-	killed      bool
+func newMockWorker(uuid string) *mockWorker {
+	w := &mockWorker{uuid: uuid}
+	go func() {
+		defer w.tomb.Done()
+		<-w.tomb.Dying()
+	}()
+	return w
 }
 
-func (r *fakeRunner) Kill() {
-	r.killed = true
-	r.tomb.Done()
+type mockWorker struct {
+	tomb tomb.Tomb
+	uuid string
 }
 
-func (r *fakeRunner) Wait() error {
-	return r.tomb.Wait()
+func (mock *mockWorker) Kill() {
+	mock.tomb.Kill(nil)
 }
 
-func newStateWithFakeWatcher(realSt *state.State) *stateWithFakeWatcher {
-	return &stateWithFakeWatcher{
-		State: realSt,
-		envWatcher: &fakeEnvWatcher{
+func (mock *mockWorker) Wait() error {
+	return mock.tomb.Wait()
+}
+
+func newMockBackend() *mockBackend {
+	return &mockBackend{
+		envWatcher: &mockEnvWatcher{
+			Worker:  workertest.NewErrorWorker(nil),
 			changes: make(chan []string),
 		},
 	}
 }
 
-// stateWithFakeWatcher wraps a *state.State, overriding the
-// WatchModels method to allow control over the reported
-// environment lifecycle events for testing.
-//
-// Use sendEnvChange to cause an environment event to be emitted by
-// the watcher returned by WatchModels.
-type stateWithFakeWatcher struct {
-	*state.State
-	envWatcher *fakeEnvWatcher
+type mockBackend struct {
+	envWatcher *mockEnvWatcher
 }
 
-func (s *stateWithFakeWatcher) WatchModels() state.StringsWatcher {
-	return s.envWatcher
+func (mock *mockBackend) WatchModels() state.StringsWatcher {
+	return mock.envWatcher
 }
 
-func (s *stateWithFakeWatcher) sendEnvChange(uuids ...string) {
-	s.envWatcher.changes <- uuids
+func (mock *mockBackend) sendModelChange(uuids ...string) {
+	mock.envWatcher.changes <- uuids
 }
 
-type fakeEnvWatcher struct {
-	state.StringsWatcher
+type mockEnvWatcher struct {
+	worker.Worker
 	changes chan []string
 }
 
-func (w *fakeEnvWatcher) Stop() error {
-	return nil
+func (w *mockEnvWatcher) Err() error {
+	panic("not used")
 }
 
-func (w *fakeEnvWatcher) Changes() <-chan []string {
+func (w *mockEnvWatcher) Stop() error {
+	return worker.Stop(w)
+}
+
+func (w *mockEnvWatcher) Changes() <-chan []string {
 	return w.changes
 }

--- a/worker/modelworkermanager/package_test.go
+++ b/worker/modelworkermanager/package_test.go
@@ -1,7 +1,7 @@
-// Copyright 2015 Canonical Ltd.
+// Copyright 2016 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package undertaker_test
+package modelworkermanager_test
 
 import (
 	"testing"
@@ -9,6 +9,6 @@ import (
 	gc "gopkg.in/check.v1"
 )
 
-func TestAll(t *testing.T) {
+func TestPackage(t *testing.T) {
 	gc.TestingT(t)
 }

--- a/worker/peergrouper/worker.go
+++ b/worker/peergrouper/worker.go
@@ -175,6 +175,7 @@ func (w *pgWorker) loop() error {
 				break
 			}
 			// Try to update the replica set immediately.
+			// TODO(fwereade): 2016-03-17 lp:1558657
 			updateChan = time.After(0)
 
 		case <-updateChan:
@@ -198,9 +199,11 @@ func (w *pgWorker) loop() error {
 				// Update the replica set members occasionally
 				// to keep them up to date with the current
 				// replica set member statuses.
+				// TODO(fwereade): 2016-03-17 lp:1558657
 				updateChan = time.After(pollInterval)
 				retryInterval = initialRetryInterval
 			} else {
+				// TODO(fwereade): 2016-03-17 lp:1558657
 				updateChan = time.After(retryInterval)
 				retryInterval *= 2
 				if retryInterval > maxRetryInterval {

--- a/worker/periodicworker.go
+++ b/worker/periodicworker.go
@@ -40,6 +40,7 @@ type PeriodicTimer interface {
 
 // NewTimerFunc is a constructor used to obtain the instance
 // of PeriodicTimer periodicWorker uses on its loop.
+// TODO(fwereade): 2016-03-17 lp:1558657
 type NewTimerFunc func(time.Duration) PeriodicTimer
 
 // Timer implements PeriodicTimer.

--- a/worker/resumer/resumer.go
+++ b/worker/resumer/resumer.go
@@ -61,6 +61,7 @@ func (rr *Resumer) loop() error {
 		case <-rr.tomb.Dying():
 			return tomb.ErrDying
 		case <-time.After(interval):
+			// TODO(fwereade): 2016-03-17 lp:1558657
 			if err := rr.tr.ResumeTransactions(); err != nil {
 				logger.Errorf("cannot resume transactions: %v", err)
 			}

--- a/worker/statushistorypruner/manifold.go
+++ b/worker/statushistorypruner/manifold.go
@@ -20,7 +20,8 @@ type ManifoldConfig struct {
 	APICallerName    string
 	MaxLogsPerEntity uint
 	PruneInterval    time.Duration
-	NewTimer         worker.NewTimerFunc
+	// TODO(fwereade): 2016-03-17 lp:1558657
+	NewTimer worker.NewTimerFunc
 }
 
 // Manifold returns a Manifold that encapsulates the statushistorypruner worker.

--- a/worker/statushistorypruner/worker.go
+++ b/worker/statushistorypruner/worker.go
@@ -28,7 +28,8 @@ type Config struct {
 	Facade           Facade
 	MaxLogsPerEntity uint
 	PruneInterval    time.Duration
-	NewTimer         worker.NewTimerFunc
+	// TODO(fwereade): 2016-03-17 lp:1558657
+	NewTimer worker.NewTimerFunc
 }
 
 // Validate will err unless basic requirements for a valid

--- a/worker/storageprovisioner/internal/schedule/schedule.go
+++ b/worker/storageprovisioner/internal/schedule/schedule.go
@@ -34,6 +34,7 @@ func NewSchedule(clock clock.Clock) *Schedule {
 // has been reached. If there are no scheduled items, nil is returned.
 func (s *Schedule) Next() <-chan time.Time {
 	if len(s.items) > 0 {
+		// TODO(fwereade): 2016-03-17 lp:1558657
 		return s.time.After(s.items[0].t.Sub(s.time.Now()))
 	}
 	return nil

--- a/worker/txnpruner/txnpruner.go
+++ b/worker/txnpruner/txnpruner.go
@@ -24,6 +24,7 @@ func New(tp TransactionPruner, interval time.Duration) worker.Worker {
 		// Use a timer rather than a ticker because pruning could
 		// sometimes take a while and we don't want pruning attempts
 		// to occur back-to-back.
+		// TODO(fwereade): 2016-03-17 lp:1558657
 		timer := time.NewTimer(interval)
 		defer timer.Stop()
 		for {

--- a/worker/undertaker/export_test.go
+++ b/worker/undertaker/export_test.go
@@ -1,8 +1,0 @@
-// Copyright 2015 Canonical Ltd.
-// Licensed under the AGPLv3, see LICENCE file for details.
-
-package undertaker
-
-const (
-	RIPTime = ripTime
-)

--- a/worker/undertaker/manifold.go
+++ b/worker/undertaker/manifold.go
@@ -1,0 +1,71 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package undertaker
+
+import (
+	"time"
+
+	"github.com/juju/errors"
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/dependency"
+	"github.com/juju/utils/clock"
+)
+
+// ManifoldConfig holds the names of the resources used by, and the
+// additional dependencies of, an undertaker worker.
+type ManifoldConfig struct {
+	APICallerName string
+	EnvironName   string
+	ClockName     string
+	RemoveDelay   time.Duration
+
+	NewFacade func(base.APICaller) (Facade, error)
+	NewWorker func(Config) (worker.Worker, error)
+}
+
+func (config ManifoldConfig) start(getResource dependency.GetResourceFunc) (worker.Worker, error) {
+
+	var apiCaller base.APICaller
+	if err := getResource(config.APICallerName, &apiCaller); err != nil {
+		return nil, errors.Trace(err)
+	}
+	var environ environs.Environ
+	if err := getResource(config.EnvironName, &environ); err != nil {
+		return nil, errors.Trace(err)
+	}
+	var clock clock.Clock
+	if err := getResource(config.ClockName, &clock); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	facade, err := config.NewFacade(apiCaller)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	worker, err := config.NewWorker(Config{
+		Facade:      facade,
+		Environ:     environ,
+		Clock:       clock,
+		RemoveDelay: config.RemoveDelay,
+	})
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return worker, nil
+}
+
+// Manifold returns a dependency.Manifold that runs a worker responsible
+// for shepherding a Dying model into Dead and ultimate removal.
+func Manifold(config ManifoldConfig) dependency.Manifold {
+	return dependency.Manifold{
+		Inputs: []string{
+			config.APICallerName,
+			config.EnvironName,
+			config.ClockName,
+		},
+		Start: config.start,
+	}
+}

--- a/worker/undertaker/manifold_test.go
+++ b/worker/undertaker/manifold_test.go
@@ -1,0 +1,159 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package undertaker_test
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/clock"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/dependency"
+	dt "github.com/juju/juju/worker/dependency/testing"
+	"github.com/juju/juju/worker/undertaker"
+)
+
+type ManifoldSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&ManifoldSuite{})
+
+func (*ManifoldSuite) TestInputs(c *gc.C) {
+	manifold := undertaker.Manifold(namesConfig())
+	c.Check(manifold.Inputs, jc.DeepEquals, []string{
+		"api-caller", "environ", "clock",
+	})
+}
+
+func (*ManifoldSuite) TestOutput(c *gc.C) {
+	manifold := undertaker.Manifold(namesConfig())
+	c.Check(manifold.Output, gc.IsNil)
+}
+
+func (*ManifoldSuite) TestAPICallerMissing(c *gc.C) {
+	resources := resourcesMissing("api-caller")
+	manifold := undertaker.Manifold(namesConfig())
+
+	worker, err := manifold.Start(dt.StubGetResource(resources))
+	c.Check(errors.Cause(err), gc.Equals, dependency.ErrMissing)
+	c.Check(worker, gc.IsNil)
+}
+
+func (*ManifoldSuite) TestEnvironMissing(c *gc.C) {
+	resources := resourcesMissing("environ")
+	manifold := undertaker.Manifold(namesConfig())
+
+	worker, err := manifold.Start(dt.StubGetResource(resources))
+	c.Check(errors.Cause(err), gc.Equals, dependency.ErrMissing)
+	c.Check(worker, gc.IsNil)
+}
+
+func (*ManifoldSuite) TestClockMissing(c *gc.C) {
+	resources := resourcesMissing("clock")
+	manifold := undertaker.Manifold(namesConfig())
+
+	worker, err := manifold.Start(dt.StubGetResource(resources))
+	c.Check(errors.Cause(err), gc.Equals, dependency.ErrMissing)
+	c.Check(worker, gc.IsNil)
+}
+
+func (*ManifoldSuite) TestNewFacadeError(c *gc.C) {
+	resources := resourcesMissing()
+	config := namesConfig()
+	config.NewFacade = func(apiCaller base.APICaller) (undertaker.Facade, error) {
+		checkResource(c, apiCaller, resources, "api-caller")
+		return nil, errors.New("blort")
+	}
+	manifold := undertaker.Manifold(config)
+
+	worker, err := manifold.Start(dt.StubGetResource(resources))
+	c.Check(err, gc.ErrorMatches, "blort")
+	c.Check(worker, gc.IsNil)
+}
+
+func (*ManifoldSuite) TestNewWorkerError(c *gc.C) {
+	resources := resourcesMissing()
+	expectFacade := &fakeFacade{}
+	config := namesConfig()
+	config.NewFacade = func(_ base.APICaller) (undertaker.Facade, error) {
+		return expectFacade, nil
+	}
+	config.NewWorker = func(cfg undertaker.Config) (worker.Worker, error) {
+		c.Check(cfg.Facade, gc.Equals, expectFacade)
+		checkResource(c, cfg.Environ, resources, "environ")
+		checkResource(c, cfg.Clock, resources, "clock")
+		return nil, errors.New("lhiis")
+	}
+	manifold := undertaker.Manifold(config)
+
+	worker, err := manifold.Start(dt.StubGetResource(resources))
+	c.Check(err, gc.ErrorMatches, "lhiis")
+	c.Check(worker, gc.IsNil)
+}
+
+func (*ManifoldSuite) TestNewWorkerSuccess(c *gc.C) {
+	expectWorker := &fakeWorker{}
+	config := namesConfig()
+	config.NewFacade = func(_ base.APICaller) (undertaker.Facade, error) {
+		return &fakeFacade{}, nil
+	}
+	config.NewWorker = func(_ undertaker.Config) (worker.Worker, error) {
+		return expectWorker, nil
+	}
+	manifold := undertaker.Manifold(config)
+	resources := resourcesMissing()
+
+	worker, err := manifold.Start(dt.StubGetResource(resources))
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(worker, gc.Equals, expectWorker)
+}
+
+func namesConfig() undertaker.ManifoldConfig {
+	return undertaker.ManifoldConfig{
+		APICallerName: "api-caller",
+		EnvironName:   "environ",
+		ClockName:     "clock",
+	}
+}
+
+func resourcesMissing(missing ...string) dt.StubResources {
+	resources := dt.StubResources{
+		"api-caller": dt.StubResource{Output: &fakeAPICaller{}},
+		"environ":    dt.StubResource{Output: &fakeEnviron{}},
+		"clock":      dt.StubResource{Output: &fakeClock{}},
+	}
+	for _, name := range missing {
+		resources[name] = dt.StubResource{Error: dependency.ErrMissing}
+	}
+	return resources
+}
+
+func checkResource(c *gc.C, actual interface{}, resources dt.StubResources, name string) {
+	c.Check(actual, gc.Equals, resources[name].Output)
+}
+
+type fakeAPICaller struct {
+	base.APICaller
+}
+
+type fakeEnviron struct {
+	environs.Environ
+}
+
+type fakeClock struct {
+	clock.Clock
+}
+
+type fakeFacade struct {
+	undertaker.Facade
+}
+
+type fakeWorker struct {
+	worker.Worker
+}

--- a/worker/undertaker/shim.go
+++ b/worker/undertaker/shim.go
@@ -1,0 +1,33 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package undertaker
+
+import (
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/api/undertaker"
+	"github.com/juju/juju/api/watcher"
+	"github.com/juju/juju/worker"
+)
+
+// NewFacade creates a Facade from a base.APICaller, by calling the
+// constructor in api/undertaker that returns a more specific type.
+func NewFacade(apiCaller base.APICaller) (Facade, error) {
+	facade, err := undertaker.NewClient(apiCaller, watcher.NewNotifyWatcher)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return facade, nil
+}
+
+// NewFacade creates a worker.Worker from a Config, by calling the
+// local constructor that returns a more specific type.
+func NewWorker(config Config) (worker.Worker, error) {
+	worker, err := NewUndertaker(config)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return worker, nil
+}

--- a/worker/undertaker/undertaker.go
+++ b/worker/undertaker/undertaker.go
@@ -1,4 +1,4 @@
-// Copyright 2015 Canonical Ltd.
+// Copyright 2015-2016 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 package undertaker
@@ -8,26 +8,59 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
-	uc "github.com/juju/utils/clock"
+	"github.com/juju/utils/clock"
 
-	apiundertaker "github.com/juju/juju/api/undertaker"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/environs"
-	"github.com/juju/juju/worker"
+	"github.com/juju/juju/watcher"
 	"github.com/juju/juju/worker/catacomb"
 )
 
 var logger = loggo.GetLogger("juju.worker.undertaker")
 
-// ripTime is the time to wait after an model has been set to
-// dead, before removing all model docs.
-const ripTime = 24 * time.Hour
+// Facade covers the parts of the api/undertaker.UndertakerClient that we
+// need for the worker. It's more than a little raw, but we'll survive.
+type Facade interface {
+	ModelInfo() (params.UndertakerModelInfoResult, error)
+	WatchModelResources() (watcher.NotifyWatcher, error)
+	ProcessDyingModel() error
+	RemoveModel() error
+}
+
+// Config holds the resources and configuration necessary to run an
+// undertaker worker.
+type Config struct {
+	Facade      Facade
+	Environ     environs.Environ
+	Clock       clock.Clock
+	RemoveDelay time.Duration
+}
+
+// Validate returns an error if the config cannot be expected to drive
+// a functional undertaker worker.
+func (config Config) Validate() error {
+	if config.Facade == nil {
+		return errors.NotValidf("nil Facade")
+	}
+	if config.Environ == nil {
+		return errors.NotValidf("nil Environ")
+	}
+	if config.Clock == nil {
+		return errors.NotValidf("nil Clock")
+	}
+	if config.RemoveDelay <= 0 {
+		return errors.NotValidf("non-positive RemoveDelay")
+	}
+	return nil
+}
 
 // NewUndertaker returns a worker which processes a dying model.
-func NewUndertaker(client apiundertaker.UndertakerClient, clock uc.Clock) (worker.Worker, error) {
-	u := &undertaker{
-		client: client,
-		clock:  clock,
+func NewUndertaker(config Config) (*Undertaker, error) {
+	if err := config.Validate(); err != nil {
+		return nil, errors.Trace(err)
+	}
+	u := &Undertaker{
+		config: config,
 	}
 	err := catacomb.Invoke(catacomb.Plan{
 		Site: &u.catacomb,
@@ -39,14 +72,23 @@ func NewUndertaker(client apiundertaker.UndertakerClient, clock uc.Clock) (worke
 	return u, nil
 }
 
-type undertaker struct {
+type Undertaker struct {
 	catacomb catacomb.Catacomb
-	client   apiundertaker.UndertakerClient
-	clock    uc.Clock
+	config   Config
 }
 
-func (u *undertaker) run() error {
-	result, err := u.client.ModelInfo()
+// Kill is part of the worker.Worker interface.
+func (u *Undertaker) Kill() {
+	u.catacomb.Kill(nil)
+}
+
+// Wait is part of the worker.Worker interface.
+func (u *Undertaker) Wait() error {
+	return u.catacomb.Wait()
+}
+
+func (u *Undertaker) run() error {
+	result, err := u.config.Facade.ModelInfo()
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -56,80 +98,74 @@ func (u *undertaker) run() error {
 	modelInfo := result.Result
 
 	if modelInfo.Life == params.Alive {
-		return errors.Errorf("undertaker worker should not be started for an alive model: %q", modelInfo.GlobalName)
+		return errors.Errorf("model still alive")
 	}
 
 	if modelInfo.Life == params.Dying {
 		// Process the dying model. This blocks until the model
-		// is dead.
-		u.processDyingModel()
+		// is dead or the worker is stopped.
+		if err := u.processDyingModel(); err != nil {
+			return errors.Trace(err)
+		}
 	}
 
-	// If model is not alive or dying, it must be dead.
-
+	// If we get this far, the model must be dead (or *have been*
+	// dead, but actually removed by something else since the call).
 	if modelInfo.IsSystem {
-		// Nothing to do. We don't remove model docs for a controller
-		// model.
+		// Nothing to do. We don't destroy environ resources or
+		// delete model docs for a controller model, because we're
+		// running inside that controller and can't safely clean up
+		// our own infrastructure. (That'll be the client's job in
+		// the end, once we've reported that we've tidied up what we
+		// can, by returning nil here, indicating that we've set it
+		// to Dead -- implied by processDyingModel succeeding.)
 		return nil
 	}
 
-	err = u.destroyProviderModel()
+	// Now the model is known to be hosted and dead, we can tidy up any
+	// provider resources it might have used.
+	err = u.destroyEnviron()
 	if err != nil {
 		return errors.Trace(err)
 	}
 
-	tod := u.clock.Now()
+	// Wait a reasonable amount of time before destroying model docs.
+	// Recorded time of death is assumed correct; if not recorded,
+	// assume we did it just now.
+	deadSince := u.config.Clock.Now()
 	if modelInfo.TimeOfDeath != nil {
-		// If TimeOfDeath is not nil, the model was already dead
-		// before the worker was started. So we use the recorded time of
-		// death. This may happen if the system is rebooted after an
-		// model is set to dead, but before the model docs are
-		// removed.
-		tod = *modelInfo.TimeOfDeath
+		deadSince = *modelInfo.TimeOfDeath
 	}
-
-	// Process the dead model
-	return u.processDeadModel(tod)
+	return u.processDeadModel(deadSince)
 }
 
-// Kill is part of the worker.Worker interface.
-func (u *undertaker) Kill() {
-	u.catacomb.Kill(nil)
-}
+func (u *Undertaker) processDyingModel() error {
 
-// Wait is part of the worker.Worker interface.
-func (u *undertaker) Wait() error {
-	return u.catacomb.Wait()
-}
-
-func (u *undertaker) processDyingModel() error {
-	// ProcessDyingModel will fail quite a few times before it succeeds as
-	// it is being woken up as every machine or service changes. We ignore the
-	// error here and rely on the logging inside the ProcessDyingModel.
-	if err := u.client.ProcessDyingModel(); err == nil {
-		return nil
-	}
-
-	watcher, err := u.client.WatchModelResources()
+	watcher, err := u.config.Facade.WatchModelResources()
 	if err != nil {
 		return errors.Trace(err)
 	}
-	defer watcher.Kill() // The watcher is not needed once this func returns.
 	if err := u.catacomb.Add(watcher); err != nil {
 		return errors.Trace(err)
 	}
+	defer watcher.Kill() // The watcher is not needed once this func returns.
 
 	for {
 		select {
 		case <-u.catacomb.Dying():
 			return u.catacomb.ErrDying()
-		case _, ok := <-watcher.Changes():
-			if !ok {
-				return errors.New("model resources watcher failed")
-			}
-			err := u.client.ProcessDyingModel()
+		case <-watcher.Changes():
+			// TODO(fwereade): this is wrong. If there's a time
+			// it's ok to ignore an error, it's when we know
+			// exactly what an error is/means. If there's a
+			// specific code for "not done yet", *that* is what
+			// we should be ignoring. But unknown errors are
+			// *unknown*, and we can't just assume that it's
+			// safe to continue.
+			err := u.config.Facade.ProcessDyingModel()
 			if err == nil {
-				// ProcessDyingModel succeeded. We're done.
+				// ProcessDyingModel succeeded. We're free to
+				// destroy any remaining environ resources.
 				return nil
 			}
 			// Yes, we ignore the error. See comment above.
@@ -137,31 +173,18 @@ func (u *undertaker) processDyingModel() error {
 	}
 }
 
-func (u *undertaker) destroyProviderModel() error {
-	cfg, err := u.client.ModelConfig()
-	if err != nil {
-		return errors.Trace(err)
-	}
-	env, err := environs.New(cfg)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	err = env.Destroy()
+func (u *Undertaker) destroyEnviron() error {
+	err := u.config.Environ.Destroy()
 	return errors.Trace(err)
 }
 
-func (u *undertaker) processDeadModel(timeOfDeath time.Time) error {
-	timeDead := u.clock.Now().Sub(timeOfDeath)
-	wait := ripTime - timeDead
-	if wait < 0 {
-		wait = 0
-	}
-
+func (u *Undertaker) processDeadModel(deadSince time.Time) error {
+	removeTime := deadSince.Add(u.config.RemoveDelay)
 	select {
 	case <-u.catacomb.Dying():
 		return u.catacomb.ErrDying()
-	case <-u.clock.After(wait):
-		err := u.client.RemoveModel()
-		return errors.Annotate(err, "could not remove all docs for dead model")
+	case <-clock.Alarm(u.config.Clock, removeTime):
+		err := u.config.Facade.RemoveModel()
+		return errors.Annotate(err, "cannot remove model")
 	}
 }

--- a/worker/undertaker/undertaker_test.go
+++ b/worker/undertaker/undertaker_test.go
@@ -4,278 +4,208 @@
 package undertaker_test
 
 import (
-	"sync"
-	"sync/atomic"
 	"time"
 
-	jc "github.com/juju/testing/checkers"
-	"github.com/juju/utils"
+	"github.com/juju/errors"
+	"github.com/juju/testing"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/cmd/modelcmd"
-	"github.com/juju/juju/environs"
-	"github.com/juju/juju/environs/config"
-	"github.com/juju/juju/environs/configstore"
-	"github.com/juju/juju/jujuclient/jujuclienttesting"
-	"github.com/juju/juju/provider/dummy"
-	"github.com/juju/juju/state"
-	"github.com/juju/juju/testing"
-	"github.com/juju/juju/worker/undertaker"
+	"github.com/juju/juju/apiserver/params"
+	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/workertest"
 )
 
-type undertakerSuite struct {
-	testing.BaseSuite
+const RIPTime = 18 * time.Hour
+
+// UndertakerSuite is *not* complete. But it's a lot more so
+// than it was before, and should be much easier to extend.
+type UndertakerSuite struct {
+	testing.IsolationSuite
+	fix fixture
 }
 
-var _ = gc.Suite(&undertakerSuite{})
+var _ = gc.Suite(&UndertakerSuite{})
 
-type clock struct {
-	// advanceDurationAfterNow is the duration to advance the clock after the
-	// next call to Now().
-	advanceDurationAfterNow int64
-
-	*testing.Clock
-}
-
-func (c *clock) Now() time.Time {
-	now := c.Clock.Now()
-	d := atomic.LoadInt64(&c.advanceDurationAfterNow)
-	if d != 0 {
-		c.Clock.Advance(time.Duration(d))
-		atomic.StoreInt64(&c.advanceDurationAfterNow, 0)
-	}
-
-	return now
-}
-
-func (c *clock) advanceAfterNextNow(d time.Duration) {
-	atomic.StoreInt64(&c.advanceDurationAfterNow, int64(d))
-}
-
-func (s *undertakerSuite) TestAPICalls(c *gc.C) {
-	cfg, uuid := dummyCfgAndUUID(c)
-	client := &mockClient{
-		calls: make(chan string),
-		mockModel: clientModel{
-			Life: state.Dying,
-			UUID: uuid,
-			HasMachinesAndServices: true,
-		},
-		cfg: cfg,
-		watcher: &mockModelResourceWatcher{
-			events: make(chan struct{}),
-		},
-	}
-
-	startTime := time.Date(2015, time.September, 1, 17, 2, 1, 0, time.UTC)
-	mClock := &clock{
-		Clock: testing.NewClock(startTime),
-	}
-
-	wg := sync.WaitGroup{}
-	wg.Add(1)
-
-	go func() {
-		defer wg.Done()
-		for _, test := range []struct {
-			call     string
-			callback func()
-		}{{
-			call: "ModelInfo",
-		}, {
-			call: "ProcessDyingModel",
-			callback: func() {
-				c.Check(client.mockModel.Life, gc.Equals, state.Dying)
-				c.Check(client.mockModel.TimeOfDeath, gc.IsNil)
-				client.mockModel.HasMachinesAndServices = false
-				client.watcher.(*mockModelResourceWatcher).events <- struct{}{}
-				mClock.advanceAfterNextNow(undertaker.RIPTime)
-			}}, {
-			call: "ProcessDyingModel",
-			callback: func() {
-				c.Check(client.mockModel.Life, gc.Equals, state.Dead)
-				c.Check(client.mockModel.TimeOfDeath, gc.NotNil)
-			}}, {
-			call: "RemoveModel",
-			callback: func() {
-				oneDayLater := startTime.Add(undertaker.RIPTime)
-				c.Check(mClock.Now().Equal(oneDayLater), jc.IsTrue)
-				c.Check(client.mockModel.Removed, gc.Equals, true)
-			}},
-		} {
-			select {
-			case call := <-client.calls:
-				c.Check(call, gc.Equals, test.call)
-				if test.callback != nil {
-					test.callback()
-				}
-			case <-time.After(testing.LongWait):
-				c.Fatalf("timed out waiting for API call: %q", test.call)
-			}
-		}
-	}()
-
-	worker, err := undertaker.NewUndertaker(client, mClock)
-	c.Assert(err, jc.ErrorIsNil)
-	defer worker.Kill()
-
-	wg.Wait()
-
-	assertNoMoreCalls(c, client)
-}
-
-func (s *undertakerSuite) TestRemoveModelDocsNotCalledForController(c *gc.C) {
-	mockWatcher := &mockModelResourceWatcher{
-		events: make(chan struct{}, 1),
-	}
-	uuid, err := utils.NewUUID()
-	c.Assert(err, jc.ErrorIsNil)
-	client := &mockClient{
-		calls: make(chan string, 1),
-		mockModel: clientModel{
-			Life:     state.Dying,
-			UUID:     uuid.String(),
-			IsSystem: true,
-		},
-		watcher: mockWatcher,
-	}
-	startTime := time.Date(2015, time.September, 1, 17, 2, 1, 0, time.UTC)
-	mClock := &clock{
-		Clock: testing.NewClock(startTime),
-	}
-
-	wg := sync.WaitGroup{}
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-
-		for _, test := range []struct {
-			call     string
-			callback func()
-		}{{
-			call: "ModelInfo",
-			callback: func() {
-				mockWatcher.events <- struct{}{}
-			},
-		}, {
-			call: "ProcessDyingModel",
-			callback: func() {
-				c.Assert(client.mockModel.Life, gc.Equals, state.Dead)
-				c.Assert(client.mockModel.TimeOfDeath, gc.NotNil)
-
-				mClock.advanceAfterNextNow(undertaker.RIPTime)
+func (s *UndertakerSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+	s.fix = fixture{
+		info: params.UndertakerModelInfoResult{
+			Result: params.UndertakerModelInfo{
+				Life: "dying",
 			},
 		},
-		} {
-			select {
-			case call := <-client.calls:
-				c.Assert(call, gc.Equals, test.call)
-				if test.callback != nil {
-					test.callback()
-				}
-			case <-time.After(testing.LongWait):
-				c.Fatalf("timed out waiting for API call: %q", test.call)
-			}
-		}
-	}()
-
-	worker, err := undertaker.NewUndertaker(client, mClock)
-	c.Assert(err, jc.ErrorIsNil)
-	defer worker.Kill()
-
-	wg.Wait()
-
-	assertNoMoreCalls(c, client)
-}
-
-func (s *undertakerSuite) TestRemoveModelOnRebootCalled(c *gc.C) {
-	startTime := time.Date(2015, time.September, 1, 17, 2, 1, 0, time.UTC)
-	mClock := testing.NewClock(startTime)
-	halfDayEarlier := mClock.Now().Add(-12 * time.Hour)
-
-	cfg, uuid := dummyCfgAndUUID(c)
-	client := &mockClient{
-		calls: make(chan string, 1),
-		// Mimic the situation where the worker is started after the
-		// model has been set to dead 12hrs ago.
-		mockModel: clientModel{
-			Life:        state.Dead,
-			UUID:        uuid,
-			TimeOfDeath: &halfDayEarlier,
-		},
-		cfg: cfg,
-	}
-
-	wg := sync.WaitGroup{}
-	wg.Add(1)
-
-	// We expect RemoveModel not to be called, as we have to wait another
-	// 12hrs.
-	go func() {
-		defer wg.Done()
-		for _, test := range []struct {
-			call     string
-			callback func()
-		}{{
-			call: "ModelInfo",
-			callback: func() {
-				// As model was set to dead 12hrs earlier, assert that the
-				// undertaker picks up where it left off and RemoveModel
-				// is called 12hrs later.
-				mClock.Advance(12 * time.Hour)
-			},
-		}, {
-			call: "RemoveModel",
-			callback: func() {
-				c.Assert(client.mockModel.Removed, gc.Equals, true)
-			}},
-		} {
-			select {
-			case call := <-client.calls:
-				c.Assert(call, gc.Equals, test.call)
-				if test.callback != nil {
-					test.callback()
-				}
-			case <-time.After(testing.LongWait):
-				c.Fatalf("timed out waiting for API call: %q", test.call)
-			}
-		}
-	}()
-
-	worker, err := undertaker.NewUndertaker(client, mClock)
-	c.Assert(err, jc.ErrorIsNil)
-	defer worker.Kill()
-
-	wg.Wait()
-
-	assertNoMoreCalls(c, client)
-}
-
-func assertNoMoreCalls(c *gc.C, client *mockClient) {
-	select {
-	case call := <-client.calls:
-		c.Fatalf("unexpected API call: %q", call)
-	case <-time.After(testing.ShortWait):
 	}
 }
 
-func dummyCfgAndUUID(c *gc.C) (*config.Config, string) {
-	cfg := testingEnvConfig(c)
-	uuid, ok := cfg.UUID()
-	c.Assert(ok, jc.IsTrue)
-	return cfg, uuid
+func (s *UndertakerSuite) TestAliveError(c *gc.C) {
+	s.fix.info.Result.Life = "alive"
+	s.fix.dirty = true
+	stub := s.fix.run(c, func(w worker.Worker, _ *coretesting.Clock) {
+		err := workertest.CheckKilled(c, w)
+		c.Check(err, gc.ErrorMatches, "model still alive")
+	})
+	stub.CheckCallNames(c, "ModelInfo")
 }
 
-// testingEnvConfig prepares an environment configuration using
-// the dummy provider.
-func testingEnvConfig(c *gc.C) *config.Config {
-	cfg, err := config.New(config.NoDefaults, dummy.SampleConfig())
-	c.Assert(err, jc.ErrorIsNil)
-	env, err := environs.Prepare(
-		modelcmd.BootstrapContext(testing.Context(c)), configstore.NewMem(),
-		jujuclienttesting.NewMemStore(),
-		"dummycontroller", environs.PrepareForBootstrapParams{Config: cfg},
+func (s *UndertakerSuite) TestAlreadyDeadTimeRecordedWaits(c *gc.C) {
+	halfTime := RIPTime / 2
+	diedAt := time.Now().Add(-halfTime)
+	s.fix.info.Result.Life = "dead"
+	s.fix.info.Result.TimeOfDeath = &diedAt
+	stub := s.fix.run(c, func(w worker.Worker, clock *coretesting.Clock) {
+		waitAlarm(c, clock)
+		clock.Advance(halfTime - time.Second)
+		workertest.CheckAlive(c, w)
+	})
+	stub.CheckCallNames(c, "ModelInfo", "Destroy")
+}
+
+func (s *UndertakerSuite) TestAlreadyDeadTimeRecordedFinishes(c *gc.C) {
+	halfTime := RIPTime / 2
+	diedAt := time.Now().Add(-halfTime)
+	s.fix.info.Result.Life = "dead"
+	s.fix.info.Result.TimeOfDeath = &diedAt
+	stub := s.fix.run(c, func(w worker.Worker, clock *coretesting.Clock) {
+		waitAlarm(c, clock)
+		clock.Advance(halfTime)
+		workertest.CheckKilled(c, w)
+	})
+	stub.CheckCallNames(c, "ModelInfo", "Destroy", "RemoveModel")
+}
+
+func (s *UndertakerSuite) TestAlreadyDeadTimeMissingWaits(c *gc.C) {
+	s.fix.info.Result.Life = "dead"
+	stub := s.fix.run(c, func(w worker.Worker, clock *coretesting.Clock) {
+		waitAlarm(c, clock)
+		clock.Advance(RIPTime - time.Second)
+		workertest.CheckAlive(c, w)
+	})
+	stub.CheckCallNames(c, "ModelInfo", "Destroy")
+}
+
+func (s *UndertakerSuite) TestAlreadyDeadTimeMissingFinishes(c *gc.C) {
+	s.fix.info.Result.Life = "dead"
+	stub := s.fix.run(c, func(w worker.Worker, clock *coretesting.Clock) {
+		waitAlarm(c, clock)
+		clock.Advance(RIPTime)
+		workertest.CheckKilled(c, w)
+	})
+	stub.CheckCallNames(c, "ModelInfo", "Destroy", "RemoveModel")
+}
+
+func (s *UndertakerSuite) TestImmediateSuccess(c *gc.C) {
+	stub := s.fix.run(c, func(w worker.Worker, clock *coretesting.Clock) {
+		waitAlarm(c, clock)
+		clock.Advance(RIPTime - time.Second)
+		workertest.CheckAlive(c, w)
+	})
+	stub.CheckCallNames(c,
+		"ModelInfo",
+		"WatchModelResources",
+		"ProcessDyingModel",
+		"Destroy",
 	)
-	c.Assert(err, jc.ErrorIsNil)
-	return env.Config()
+}
+
+func (s *UndertakerSuite) TestControllerStopsWhenModelDead(c *gc.C) {
+	s.fix.info.Result.IsSystem = true
+	stub := s.fix.run(c, func(w worker.Worker, clock *coretesting.Clock) {
+		workertest.CheckKilled(c, w)
+	})
+	stub.CheckCallNames(c,
+		"ModelInfo",
+		"WatchModelResources",
+		"ProcessDyingModel",
+	)
+}
+
+func (s *UndertakerSuite) TestFinalRemove(c *gc.C) {
+	stub := s.fix.run(c, func(w worker.Worker, clock *coretesting.Clock) {
+		waitAlarm(c, clock)
+		clock.Advance(RIPTime)
+		workertest.CheckKilled(c, w)
+	})
+	stub.CheckCallNames(c,
+		"ModelInfo",
+		"WatchModelResources",
+		"ProcessDyingModel",
+		"Destroy",
+		"RemoveModel",
+	)
+}
+
+func (s *UndertakerSuite) TestModelInfoErrorFatal(c *gc.C) {
+	s.fix.errors = []error{errors.New("pow")}
+	s.fix.dirty = true
+	stub := s.fix.run(c, func(w worker.Worker, clock *coretesting.Clock) {
+		err := workertest.CheckKilled(c, w)
+		c.Check(err, gc.ErrorMatches, "pow")
+	})
+	stub.CheckCallNames(c, "ModelInfo")
+}
+
+func (s *UndertakerSuite) TestWatchModelResourcesErrorFatal(c *gc.C) {
+	s.fix.errors = []error{nil, errors.New("pow")}
+	s.fix.dirty = true
+	stub := s.fix.run(c, func(w worker.Worker, clock *coretesting.Clock) {
+		err := workertest.CheckKilled(c, w)
+		c.Check(err, gc.ErrorMatches, "pow")
+	})
+	stub.CheckCallNames(c, "ModelInfo", "WatchModelResources")
+}
+
+func (s *UndertakerSuite) TestProcessDyingModelErrorRetried(c *gc.C) {
+	s.fix.errors = []error{
+		nil, // ModelInfo
+		nil, // WatchModelResources,
+		errors.New("meh, will retry"),  // ProcessDyingModel,
+		errors.New("will retry again"), // ProcessDyingModel,
+		nil, // ProcessDyingModel,
+		nil, // Destroy,
+	}
+	stub := s.fix.run(c, func(w worker.Worker, clock *coretesting.Clock) {
+		waitAlarm(c, clock)
+		workertest.CheckAlive(c, w)
+	})
+	stub.CheckCallNames(c,
+		"ModelInfo",
+		"WatchModelResources",
+		"ProcessDyingModel",
+		"ProcessDyingModel",
+		"ProcessDyingModel",
+		"Destroy",
+	)
+}
+
+func (s *UndertakerSuite) TestDestroyErrorFatal(c *gc.C) {
+	s.fix.errors = []error{nil, errors.New("pow")}
+	s.fix.info.Result.Life = "dead"
+	s.fix.dirty = true
+	stub := s.fix.run(c, func(w worker.Worker, clock *coretesting.Clock) {
+		err := workertest.CheckKilled(c, w)
+		c.Check(err, gc.ErrorMatches, "pow")
+	})
+	stub.CheckCallNames(c, "ModelInfo", "Destroy")
+}
+
+func (s *UndertakerSuite) TestRemoveModelErrorFatal(c *gc.C) {
+	s.fix.errors = []error{nil, nil, errors.New("pow")}
+	s.fix.info.Result.Life = "dead"
+	s.fix.dirty = true
+	stub := s.fix.run(c, func(w worker.Worker, clock *coretesting.Clock) {
+		waitAlarm(c, clock)
+		clock.Advance(RIPTime)
+		err := workertest.CheckKilled(c, w)
+		c.Check(err, gc.ErrorMatches, "cannot remove model: pow")
+	})
+	stub.CheckCallNames(c, "ModelInfo", "Destroy", "RemoveModel")
+}
+
+func waitAlarm(c *gc.C, clock *coretesting.Clock) {
+	select {
+	case <-clock.Alarms():
+	case <-time.After(coretesting.LongWait):
+		c.Fatalf("timed out waiting for SUT to use clock")
+	}
 }

--- a/worker/undertaker/validate_test.go
+++ b/worker/undertaker/validate_test.go
@@ -1,0 +1,73 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package undertaker_test
+
+import (
+	"time"
+
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/worker/undertaker"
+)
+
+type ValidateSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&ValidateSuite{})
+
+func (*ValidateSuite) TestNilFacade(c *gc.C) {
+	config := validConfig()
+	config.Facade = nil
+	checkInvalid(c, config, "nil Facade not valid")
+}
+
+func (*ValidateSuite) TestNilEnviron(c *gc.C) {
+	config := validConfig()
+	config.Environ = nil
+	checkInvalid(c, config, "nil Environ not valid")
+}
+
+func (*ValidateSuite) TestNilClock(c *gc.C) {
+	config := validConfig()
+	config.Clock = nil
+	checkInvalid(c, config, "nil Clock not valid")
+}
+
+func (*ValidateSuite) TestZeroDelay(c *gc.C) {
+	config := validConfig()
+	config.RemoveDelay = 0
+	checkInvalid(c, config, "non-positive RemoveDelay not valid")
+}
+
+func (*ValidateSuite) TestNegativeDelay(c *gc.C) {
+	config := validConfig()
+	config.RemoveDelay = -time.Second
+	checkInvalid(c, config, "non-positive RemoveDelay not valid")
+}
+
+func validConfig() undertaker.Config {
+	return undertaker.Config{
+		Facade:      &fakeFacade{},
+		Environ:     &fakeEnviron{},
+		Clock:       &fakeClock{},
+		RemoveDelay: time.Hour,
+	}
+}
+
+func checkInvalid(c *gc.C, config undertaker.Config, message string) {
+	check := func(err error) {
+		c.Check(err, jc.Satisfies, errors.IsNotValid)
+		c.Check(err, gc.ErrorMatches, message)
+	}
+	err := config.Validate()
+	check(err)
+
+	worker, err := undertaker.NewUndertaker(config)
+	c.Check(worker, gc.IsNil)
+	check(err)
+}

--- a/worker/unitassigner/manifold.go
+++ b/worker/unitassigner/manifold.go
@@ -1,0 +1,35 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package unitassigner
+
+import (
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/api/unitassigner"
+	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/dependency"
+	"github.com/juju/juju/worker/util"
+)
+
+// ManifoldConfig describes the resources used by a unitassigner worker.
+type ManifoldConfig util.ApiManifoldConfig
+
+// Manifold returns a Manifold that runs a unitassigner worker.
+func Manifold(config ManifoldConfig) dependency.Manifold {
+	return util.ApiManifold(
+		util.ApiManifoldConfig(config),
+		manifoldStart,
+	)
+}
+
+// manifoldStart returns a unitassigner worker using the supplied APICaller.
+func manifoldStart(apiCaller base.APICaller) (worker.Worker, error) {
+	facade := unitassigner.New(apiCaller)
+	worker, err := New(facade)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return worker, nil
+}

--- a/worker/uniter/charm/git_deployer.go
+++ b/worker/uniter/charm/git_deployer.go
@@ -228,5 +228,6 @@ func collectGitOrphans(dataPath string) {
 // assumes that the deployer will not need to create more than 10
 // directories in any given second.
 func (d *gitDeployer) newDir(prefix string) (string, error) {
+	// TODO(fwereade): 2016-03-17 lp:1558657
 	return ioutil.TempDir(d.dataPath, prefix+time.Now().Format("20060102-150405"))
 }

--- a/worker/uniter/runner/jujuc/add-metric.go
+++ b/worker/uniter/runner/jujuc/add-metric.go
@@ -43,6 +43,7 @@ func (c *AddMetricCommand) Info() *cmd.Info {
 
 // Init parses the command's parameters.
 func (c *AddMetricCommand) Init(args []string) error {
+	// TODO(fwereade): 2016-03-17 lp:1558657
 	now := time.Now()
 	if len(args) == 0 {
 		return fmt.Errorf("no metrics specified")

--- a/worker/uniter/timer.go
+++ b/worker/uniter/timer.go
@@ -14,6 +14,7 @@ const (
 
 // updateStatusSignal returns a time channel that fires after a given interval.
 func updateStatusSignal() <-chan time.Time {
+	// TODO(fwereade): 2016-03-17 lp:1558657
 	return time.After(statusPollInterval)
 }
 

--- a/worker/upgrader/upgrader.go
+++ b/worker/upgrader/upgrader.go
@@ -27,6 +27,7 @@ import (
 // retryAfter returns a channel that receives a value
 // when a failed download should be retried.
 var retryAfter = func() <-chan time.Time {
+	// TODO(fwereade): 2016-03-17 lp:1558657
 	return time.After(5 * time.Second)
 }
 
@@ -135,6 +136,7 @@ func (u *Upgrader) loop() error {
 		return errors.Trace(err)
 	}
 	logger.Infof("abort check blocked until version event received")
+	// TODO(fwereade): 2016-03-17 lp:1558657
 	mustProceed := time.After(time.Minute)
 	var dying <-chan struct{}
 	allowDying := func() {


### PR DESCRIPTION
This branch:

  * introduces the `cmd/jujud/agent/model package`, which defines the set of workers needed to manage a given model, including handling for the responsibilities once handled by:
          * a `singular.Runner` (see `is-responsible-flag`)
          * parts removed from `worker/modelworkermanager` (see `not-dead-flag`, `not-alive-flag`)
          * parts removed from `worker/undertaker` (see `environ-tracker`, whose use we should expand later)
  * replaces a significant `chunk of cmd/jujud/agent/machine.go` with an invocation of a `dependency.Engine` using `model.Manifolds`
  * drastically simplifies `worker/modelworkermanager` (which now only needs a `func(uuid string) ...` to start a model worker) ...and tests
  * slightly simplifies `worker/undertaker` (which no longer needs to watch its own environ) ...and tests
  * drops unwanted functionality from `api/undertaker`

It replaces PR4671, reviewed at length in RB4110.

(Review request: http://reviews.vapour.ws/r/4225/)