### PR TITLE
Fixed a couple of issues found during CI

### DIFF
--- a/apiserver/machine/machiner.go
+++ b/apiserver/machine/machiner.go
@@ -169,7 +169,8 @@ func (api *MachinerAPI) SetObservedNetworkConfig(args params.SetMachineNetworkCo
 	}
 	netEnviron, err := networkingcommon.NetworkingEnvironFromModelConfig(api.st)
 	if errors.IsNotSupported(err) {
-		logger.Debugf("not merging observed and provider network config: %v", err)
+		logger.Infof("not merging observed and provider network config: %v", err)
+		return nil
 	} else if err != nil {
 		return errors.Annotate(err, "cannot get provider network config")
 	}


### PR DESCRIPTION
Don't panic on SetObservedNetworkConfig() with providers that do not
support networking features. Also fixed a related issue in apiserver/provisioner
that can cause PrepareContainerInterfaceInfo() to panic when trying to
call methods on an unknown subnet.

Testing: $ make check; live test on MAAS 1.9 with a bundle deployment

(Review request: http://reviews.vapour.ws/r/4226/)