### PR TITLE
HTTPS endpoints for managing Juju GUI archives.

### DIFF
--- a/api/gui.go
+++ b/api/gui.go
@@ -1,0 +1,37 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package api
+
+import (
+	"io"
+	"net/http"
+	"net/url"
+
+	"github.com/juju/errors"
+	"github.com/juju/version"
+)
+
+// UploadGUIArchive uploads a GUI archive to the controller over HTTPS.
+func (c *Client) UploadGUIArchive(r io.ReadSeeker, hash string, size int64, vers version.Number) error {
+	// Prepare the request.
+	v := url.Values{}
+	v.Set("version", vers.String())
+	v.Set("hash", hash)
+	req, err := http.NewRequest("POST", "/gui-archive?"+v.Encode(), nil)
+	if err != nil {
+		return errors.Annotate(err, "cannot create upload request")
+	}
+	req.Header.Set("Content-Type", "application/x-tar-bzip2")
+	req.ContentLength = size
+
+	// Retrieve a client and send the request.
+	httpClient, err := c.st.RootHTTPClient()
+	if err != nil {
+		return errors.Annotate(err, "cannot retrieve HTTP client")
+	}
+	if err = httpClient.Do(req, r, nil); err != nil {
+		return errors.Annotate(err, "cannot upload the GUI archive")
+	}
+	return nil
+}

--- a/api/gui_test.go
+++ b/api/gui_test.go
@@ -41,6 +41,7 @@ func (s *clientSuite) TestUploadGUIArchive(c *gc.C) {
 	).Close()
 
 	// Check that the API client POSTs the GUI archive to the correct endpoint.
-	client.UploadGUIArchive(bytes.NewReader(archive), hash, size, vers)
+	err := client.UploadGUIArchive(bytes.NewReader(archive), hash, size, vers)
+	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(called, jc.IsTrue)
 }

--- a/api/gui_test.go
+++ b/api/gui_test.go
@@ -1,0 +1,46 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package api_test
+
+import (
+	"bytes"
+	"io/ioutil"
+	"net/http"
+
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/version"
+	gc "gopkg.in/check.v1"
+)
+
+func (s *clientSuite) TestUploadGUIArchive(c *gc.C) {
+	otherSt, otherAPISt := s.otherEnviron(c)
+	defer otherSt.Close()
+	defer otherAPISt.Close()
+	client := otherAPISt.Client()
+
+	// Prepare a GUI archive.
+	archive := []byte("archive content")
+	hash, size, vers := "archive-hash", int64(len(archive)), version.MustParse("2.1.0")
+	called := false
+
+	// Set up a fake endpoint for tests.
+	defer fakeAPIEndpoint(c, client, "/gui-archive", "POST",
+		func(w http.ResponseWriter, req *http.Request) {
+			defer req.Body.Close()
+			called = true
+			err := req.ParseForm()
+			c.Assert(err, jc.ErrorIsNil)
+			c.Assert(req.Form.Get("hash"), gc.Equals, hash)
+			c.Assert(req.Form.Get("version"), gc.Equals, vers.String())
+			c.Assert(req.ContentLength, gc.Equals, size)
+			obtainedArchive, err := ioutil.ReadAll(req.Body)
+			c.Assert(err, jc.ErrorIsNil)
+			c.Assert(obtainedArchive, gc.DeepEquals, archive)
+		},
+	).Close()
+
+	// Check that the API client POSTs the GUI archive to the correct endpoint.
+	client.UploadGUIArchive(bytes.NewReader(archive), hash, size, vers)
+	c.Assert(called, jc.IsTrue)
+}

--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -428,6 +428,9 @@ func (srv *Server) run() {
 	)
 
 	handleGUI(mux, "/gui/:modeluuid/", srv.dataDir, httpCtxt)
+	handleAll(mux, "/gui-archive", &guiArchiveHandler{
+		ctxt: httpCtxt,
+	})
 
 	// For backwards compatibility we register all the old paths
 	handleAll(mux, "/log", debugLogHandler)

--- a/apiserver/export_test.go
+++ b/apiserver/export_test.go
@@ -27,6 +27,7 @@ var (
 	MongoPingInterval            = &mongoPingInterval
 	NewBackups                   = &newBackups
 	AllowedMethodsDuringUpgrades = allowedMethodsDuringUpgrades
+	BZMimeType                   = bzMimeType
 	JSMimeType                   = jsMimeType
 	SpritePath                   = spritePath
 )

--- a/apiserver/gui.go
+++ b/apiserver/gui.go
@@ -29,8 +29,11 @@ import (
 	jujuversion "github.com/juju/juju/version"
 )
 
-var (
+const (
 	bzMimeType = "application/x-tar-bzip2"
+)
+
+var (
 	jsMimeType = mime.TypeByExtension(".js")
 	spritePath = filepath.FromSlash("static/gui/build/app/assets/stack/svg/sprite.css.svg")
 )
@@ -446,12 +449,12 @@ func (h *guiArchiveHandler) handlePost(w http.ResponseWriter, req *http.Request)
 
 	// Read and validate the archive data.
 	data, hash, err := readAndHash(req.Body)
-	if hash != hashParam {
-		return errors.BadRequestf("archive does not match provided hash")
-	}
 	size := int64(len(data))
 	if size != req.ContentLength {
 		return errors.BadRequestf("archive does not match provided content length")
+	}
+	if hash != hashParam {
+		return errors.BadRequestf("archive does not match provided hash")
 	}
 
 	// Add the archive to the GUI storage.
@@ -463,8 +466,6 @@ func (h *guiArchiveHandler) handlePost(w http.ResponseWriter, req *http.Request)
 	if err := storage.Add(bytes.NewReader(data), metadata); err != nil {
 		return errors.Annotate(err, "cannot add GUI archive to storage")
 	}
-
-	// TODO frankban: set this version as current somewhere in state.
 
 	// Return the response with current version.
 	sendStatusAndJSON(w, http.StatusOK, params.GUIArchiveVersion{

--- a/apiserver/gui.go
+++ b/apiserver/gui.go
@@ -5,6 +5,7 @@ package apiserver
 
 import (
 	"archive/tar"
+	"bytes"
 	"compress/bzip2"
 	"fmt"
 	"io"
@@ -20,13 +21,16 @@ import (
 
 	"github.com/bmizerany/pat"
 	"github.com/juju/errors"
+	"github.com/juju/version"
 
 	agenttools "github.com/juju/juju/agent/tools"
+	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state/binarystorage"
-	"github.com/juju/juju/version"
+	jujuversion "github.com/juju/juju/version"
 )
 
 var (
+	bzMimeType = "application/x-tar-bzip2"
 	jsMimeType = mime.TypeByExtension(".js")
 	spritePath = filepath.FromSlash("static/gui/build/app/assets/stack/svg/sprite.css.svg")
 )
@@ -320,7 +324,7 @@ func (h *guiHandler) serveConfig(w http.ResponseWriter, req *http.Request) {
 		"host":    req.Host,
 		"socket":  "/model/$uuid/api",
 		"uuid":    h.uuid,
-		"version": version.Current.String(),
+		"version": jujuversion.Current.String(),
 	})
 }
 
@@ -340,4 +344,133 @@ func renderGUITemplate(w http.ResponseWriter, tmpl string, ctx map[string]interf
 	if err := t.Execute(w, ctx); err != nil {
 		sendError(w, errors.Annotate(err, "cannot render template"))
 	}
+}
+
+// guiArchiveHandler serves the Juju GUI archive endpoints, used for uploading
+// and retrieving information about GUI archives.
+type guiArchiveHandler struct {
+	ctxt httpContext
+}
+
+// ServeHTTP implements http.Handler.
+func (h *guiArchiveHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	var handler func(http.ResponseWriter, *http.Request) error
+	switch req.Method {
+	case "GET":
+		handler = h.handleGet
+	case "POST":
+		handler = h.handlePost
+	default:
+		sendError(w, errors.MethodNotAllowedf("unsupported method: %q", req.Method))
+		return
+	}
+	if err := handler(w, req); err != nil {
+		sendError(w, errors.Trace(err))
+	}
+}
+
+// handleGet returns information on Juju GUI archives in the controller.
+func (h *guiArchiveHandler) handleGet(w http.ResponseWriter, req *http.Request) error {
+	// Open the GUI archive storage.
+	st, err := h.ctxt.stateForRequestUnauthenticated(req)
+	if err != nil {
+		return errors.Annotate(err, "cannot open state")
+	}
+	storage, err := st.GUIStorage()
+	if err != nil {
+		return errors.Annotate(err, "cannot open GUI storage")
+	}
+	defer storage.Close()
+
+	// Retrieve metadata information.
+	allMeta, err := storage.AllMetadata()
+	if err != nil {
+		return errors.Annotate(err, "cannot retrieve GUI metadata")
+	}
+
+	// Prepare and send the response.
+	versions := make([]params.GUIArchiveVersion, len(allMeta))
+	for i, m := range allMeta {
+		vers, err := version.Parse(m.Version)
+		if err != nil {
+			return errors.Annotate(err, "cannot parse GUI version")
+		}
+		versions[i] = params.GUIArchiveVersion{
+			Version: vers,
+			SHA256:  m.SHA256,
+			// TODO frankban: check that this is the current version.
+			Current: true,
+		}
+	}
+	sendStatusAndJSON(w, http.StatusOK, params.GUIArchiveResponse{
+		Versions: versions,
+	})
+	return nil
+}
+
+// handlePost is used to upload new Juju GUI archives to the controller.
+func (h *guiArchiveHandler) handlePost(w http.ResponseWriter, req *http.Request) error {
+	// Validate the request.
+	if ctype := req.Header.Get("Content-Type"); ctype != bzMimeType {
+		return errors.BadRequestf("invalid content type %q: expected %q", ctype, bzMimeType)
+	}
+	if err := req.ParseForm(); err != nil {
+		return errors.Annotate(err, "cannot parse form")
+	}
+	versParam := req.Form.Get("version")
+	if versParam == "" {
+		return errors.BadRequestf("version parameter not provided")
+	}
+	vers, err := version.Parse(versParam)
+	if err != nil {
+		return errors.BadRequestf("invalid version parameter %q", versParam)
+	}
+	hashParam := req.Form.Get("hash")
+	if hashParam == "" {
+		return errors.BadRequestf("hash parameter not provided")
+	}
+	if req.ContentLength == -1 {
+		return errors.BadRequestf("content length not provided")
+	}
+
+	// Open the GUI archive storage.
+	st, _, err := h.ctxt.stateForRequestAuthenticatedUser(req)
+	if err != nil {
+		return errors.Annotate(err, "cannot open state")
+	}
+	storage, err := st.GUIStorage()
+	if err != nil {
+		return errors.Annotate(err, "cannot open GUI storage")
+	}
+	defer storage.Close()
+
+	// Read and validate the archive data.
+	data, hash, err := readAndHash(req.Body)
+	if hash != hashParam {
+		return errors.BadRequestf("archive does not match provided hash")
+	}
+	size := int64(len(data))
+	if size != req.ContentLength {
+		return errors.BadRequestf("archive does not match provided content length")
+	}
+
+	// Add the archive to the GUI storage.
+	metadata := binarystorage.Metadata{
+		Version: vers.String(),
+		Size:    size,
+		SHA256:  hash,
+	}
+	if err := storage.Add(bytes.NewReader(data), metadata); err != nil {
+		return errors.Annotate(err, "cannot add GUI archive to storage")
+	}
+
+	// TODO frankban: set this version as current somewhere in state.
+
+	// Return the response with current version.
+	sendStatusAndJSON(w, http.StatusOK, params.GUIArchiveVersion{
+		Version: vers,
+		SHA256:  hash,
+		Current: true,
+	})
+	return nil
 }

--- a/apiserver/gui_test.go
+++ b/apiserver/gui_test.go
@@ -553,18 +553,18 @@ var guiArchivePostErrorsTests = []struct {
 	expectedStatus: http.StatusBadRequest,
 	expectedError:  `invalid version parameter "bad-wolf"`,
 }, {
-	about:          "no hash provided",
-	contentType:    apiserver.BZMimeType,
-	query:          "?version=2.0.42",
-	expectedStatus: http.StatusBadRequest,
-	expectedError:  "hash parameter not provided",
-}, {
 	about:           "no content length provided",
 	contentType:     apiserver.BZMimeType,
 	query:           "?version=2.0.42&hash=sha",
 	noContentLength: true,
 	expectedStatus:  http.StatusBadRequest,
 	expectedError:   "content length not provided",
+}, {
+	about:          "no hash provided",
+	contentType:    apiserver.BZMimeType,
+	query:          "?version=2.0.42",
+	expectedStatus: http.StatusBadRequest,
+	expectedError:  "hash parameter not provided",
 }, {
 	about:          "content hash mismatch",
 	contentType:    apiserver.BZMimeType,

--- a/apiserver/params/internal.go
+++ b/apiserver/params/internal.go
@@ -645,3 +645,19 @@ type SingularClaim struct {
 type SingularClaims struct {
 	Claims []SingularClaim `json:"Claims"`
 }
+
+// GUIArchiveVersion holds information on a specific GUI archive version.
+type GUIArchiveVersion struct {
+	// Version holds the Juju GUI version number.
+	Version version.Number `json:"version"`
+	// SHA256 holds the SHA256 hash of the GUI tar.bz2 archive.
+	SHA256 string `json:"sha256"`
+	// Current holds whether this specific version is the current one served
+	// by the controller.
+	Current bool `json:"current"`
+}
+
+// GUIArchiveResponse holds the response to /gui-archive GET requests.
+type GUIArchiveResponse struct {
+	Versions []GUIArchiveVersion `json:"versions"`
+}


### PR DESCRIPTION
Implement client and server API endpoints for
uploading new Juju GUI archives to the controller
and for obtaining information on currently
uploaded archives.

Note that thsi is proposed against the embedded-gui
feature branch.

(Review request: http://reviews.vapour.ws/r/4227/)