### PR TITLE
Remove fancycheck usage

### DIFF
--- a/container/lxc/lxc_test.go
+++ b/container/lxc/lxc_test.go
@@ -13,7 +13,6 @@ import (
 	stdtesting "testing"
 	"time"
 
-	"github.com/axw/fancycheck"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	jc "github.com/juju/testing/checkers"
@@ -398,7 +397,7 @@ lxc.rootfs = /bar/foo
 	c.Assert(err, jc.ErrorIsNil)
 	lxcConfContents, err = ioutil.ReadFile(configPath)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(string(lxcConfContents), fancycheck.StringEquals, updatedConfig)
+	c.Assert(string(lxcConfContents), gc.Equals, updatedConfig)
 
 	// Now test the example in updateContainerConfig's doc string.
 	oldConfig := `


### PR DESCRIPTION
Makes a lot of CI tests fail.

(Review request: http://reviews.vapour.ws/r/4241/)