### PR TITLE
apiserver/provisioner: Use legacyPrepareContainerInterfaceInfo if address-allocation is enabled

### DIFF
--- a/apiserver/provisioner/provisioner.go
+++ b/apiserver/provisioner/provisioner.go
@@ -662,6 +662,10 @@ func (p *ProvisionerAPI) ReleaseContainerAddresses(args params.Entities) (params
 // is not enabled, it returns a NotSupported error.
 func (p *ProvisionerAPI) PrepareContainerInterfaceInfo(args params.Entities) (
 	params.MachineNetworkConfigResults, error) {
+	if environs.AddressAllocationEnabled() {
+		logger.Warningf("address allocation enabled - using legacyPrepareOrGetContainerInterfaceInfo(true)")
+		return p.legacyPrepareOrGetContainerInterfaceInfo(args, true)
+	}
 	return p.prepareOrGetContainerInterfaceInfo(args, true)
 }
 
@@ -670,6 +674,10 @@ func (p *ProvisionerAPI) PrepareContainerInterfaceInfo(args params.Entities) (
 // allocation feature flag is not enabled, it returns a NotSupported error.
 func (p *ProvisionerAPI) GetContainerInterfaceInfo(args params.Entities) (
 	params.MachineNetworkConfigResults, error) {
+	if environs.AddressAllocationEnabled() {
+		logger.Warningf("address allocation enabled - using legacyPrepareOrGetContainerInterfaceInfo(false)")
+		return p.legacyPrepareOrGetContainerInterfaceInfo(args, false)
+	}
 	return p.prepareOrGetContainerInterfaceInfo(args, false)
 }
 


### PR DESCRIPTION
Even though the address-allocation feature flag is considered deprecated
and will be removed soon, there is still one CI job that tests this
feature on EC2:
http://reports.vapour.ws/releases/3783/job/functional-container-networking/attempt/345

This PR makes Prepare|GetContainerInterfaceInfo in apiserver/provisioner
to switch to the legacy implementation with single-NIC allocation for
containers when the address-allocation feature flag is enabled.

(Review request: http://reviews.vapour.ws/r/4243/)