### PR TITLE
Enable multi-NIC LXD containers on MAAS

### DIFF
--- a/cloudconfig/containerinit/container_userdata.go
+++ b/cloudconfig/containerinit/container_userdata.go
@@ -158,6 +158,7 @@ func newCloudInitConfigWithNetworks(series string, networkConfig *container.Netw
 	}
 
 	cloudConfig.AddBootTextFile(networkInterfacesFile, config, 0644)
+	cloudConfig.AddRunCmd("ifup -a || true")
 	return cloudConfig, nil
 }
 

--- a/cloudconfig/containerinit/container_userdata_test.go
+++ b/cloudconfig/containerinit/container_userdata_test.go
@@ -133,6 +133,8 @@ bootcmd:
 - |-
   printf '%s\n' '` + indentedNetConfig + `
   ' > '` + s.networkInterfacesFile + `'
+runcmd:
+- ifup -a || true
 `
 	assertUserData(c, cloudConf, expected)
 }

--- a/container/lxd/lxd.go
+++ b/container/lxd/lxd.go
@@ -215,6 +215,8 @@ func (manager *containerManager) createNetworkProfile(profile string, networkCon
 		return err
 	}
 
+	logger.Infof("created new network profile %q", profile)
+
 	for _, v := range networkConfig.Interfaces {
 		if v.InterfaceType == network.LoopbackInterface {
 			continue
@@ -236,6 +238,9 @@ func (manager *containerManager) createNetworkProfile(profile string, networkCon
 		if v.MTU > 0 {
 			props = append(props, fmt.Sprintf("mtu=%v", v.MTU))
 		}
+
+		logger.Infof("adding nic device %q with properties %+v to profile %q",
+			v.InterfaceName, props, profile)
 
 		_, err := manager.client.ProfileDeviceAdd(profile, v.InterfaceName, "nic", props)
 

--- a/tools/lxdclient/client_profile.go
+++ b/tools/lxdclient/client_profile.go
@@ -7,16 +7,39 @@ package lxdclient
 
 import (
 	"github.com/juju/errors"
+	"github.com/lxc/lxd"
 )
 
 type rawProfileClient interface {
 	ProfileCreate(name string) error
 	ListProfiles() ([]string, error)
 	SetProfileConfigItem(name, key, value string) error
+	ProfileDelete(profile string) error
+	ProfileDeviceAdd(profile, devname, devtype string, props []string) (*lxd.Response, error)
 }
 
 type profileClient struct {
 	raw rawProfileClient
+}
+
+// ProfileDelete deletes an existing profile. No check is made to
+// verify the profile exists.
+func (p profileClient) ProfileDelete(profile string) error {
+	if err := p.raw.ProfileDelete(profile); err != nil {
+		return errors.Trace(err)
+	}
+	return nil
+}
+
+// ProfileDeviceAdd adds a profile device, such as a disk or a nic, to
+// the specified profile. No check is made to verify the profile
+// exists.
+func (p profileClient) ProfileDeviceAdd(profile, devname, devtype string, props []string) (*lxd.Response, error) {
+	resp, err := p.raw.ProfileDeviceAdd(profile, devname, devtype, props)
+	if err != nil {
+		return resp, errors.Trace(err)
+	}
+	return resp, err
 }
 
 // CreateProfile attempts to create a new lxc profile and set the given config.


### PR DESCRIPTION
This is essentially https://github.com/juju/juju/pull/4789 with an minor
fix for cloudconfig/containerinit tests. Enables multi-NIC LXD container
provisioning on MAAS, using the same approach previously tested with
LXC.

Live tested on MAAS 1.9 with a mediawiki bundle deployment including
placement to both LXC and LXD containers: http://paste.ubuntu.com/15426062/
on both trusty and xenial.

(Review request: http://reviews.vapour.ws/r/4244/)