### PR TITLE
provider/azure: fix create-model

### DIFF
--- a/controller/modelmanager/createmodel_test.go
+++ b/controller/modelmanager/createmodel_test.go
@@ -272,8 +272,7 @@ func (*RestrictedProviderFieldsSuite) TestRestrictedProviderFields(c *gc.C) {
 		provider: "azure",
 		expected: []string{
 			"type", "ca-cert", "state-port", "api-port", "controller-uuid",
-			"subscription-id", "tenant-id", "application-id", "application-password",
-			"location", "controller-resource-group", "storage-account-type",
+			"location", "endpoint", "storage-endpoint", "controller-resource-group",
 		},
 	}, {
 		provider: "dummy",

--- a/provider/azure/environprovider.go
+++ b/provider/azure/environprovider.go
@@ -78,13 +78,10 @@ func (prov *azureEnvironProvider) Open(cfg *config.Config) (environs.Environ, er
 // will be copied across to a hosted environment's initial configuration.
 func (prov *azureEnvironProvider) RestrictedConfigAttributes() []string {
 	return []string{
-		configAttrSubscriptionId,
-		configAttrTenantId,
-		configAttrAppId,
-		configAttrAppPassword,
 		configAttrLocation,
+		configAttrEndpoint,
 		configAttrControllerResourceGroup,
-		configAttrStorageAccountType,
+		configAttrStorageEndpoint,
 	}
 }
 


### PR DESCRIPTION
Add endpoint and storage-endpoint to,
and remove credentials and storage
account type from, restricted config
attributes.

Fixes https://bugs.launchpad.net/juju-core/+bug/1558769

(Review request: http://reviews.vapour.ws/r/4250/)