### PR TITLE
Fix invalid filepath windows

### DIFF
--- a/cloud/credentials_test.go
+++ b/cloud/credentials_test.go
@@ -603,12 +603,10 @@ func (s *credentialsSuite) TestFinalizeCredentialFilePath(c *gc.C) {
 }
 
 func (s *credentialsSuite) TestFinalizeCredentialInvalidFilePath(c *gc.C) {
-	dir, err := ioutil.TempDir(c.MkDir(), "testinvalid")
-	c.Assert(err, jc.ErrorIsNil)
 	cred := cloud.NewCredential(
 		cloud.JSONFileAuthType,
 		map[string]string{
-			"file": filepath.Join(dir, "somefile"),
+			"file": filepath.Join(c.MkDir(), "somefile"),
 		},
 	)
 	schema := cloud.CredentialSchema{
@@ -616,7 +614,7 @@ func (s *credentialsSuite) TestFinalizeCredentialInvalidFilePath(c *gc.C) {
 			"file", cloud.CredentialAttr{FilePath: true},
 		},
 	}
-	_, err = cloud.FinalizeCredential(cred, map[cloud.AuthType]cloud.CredentialSchema{
+	_, err := cloud.FinalizeCredential(cred, map[cloud.AuthType]cloud.CredentialSchema{
 		cloud.JSONFileAuthType: schema,
 	}, nil)
 	c.Assert(err, gc.ErrorMatches, "invalid file path: .*")

--- a/cloud/credentials_test.go
+++ b/cloud/credentials_test.go
@@ -603,10 +603,13 @@ func (s *credentialsSuite) TestFinalizeCredentialFilePath(c *gc.C) {
 }
 
 func (s *credentialsSuite) TestFinalizeCredentialInvalidFilePath(c *gc.C) {
+	dir, err := ioutil.TempDir(c.MkDir(), "testinvalid")
+	c.Assert(err, jc.ErrorIsNil)
+	invalidPath := filepath.Join(dir, "somefile")
 	cred := cloud.NewCredential(
 		cloud.JSONFileAuthType,
 		map[string]string{
-			"file": "/some/file",
+			"file": invalidPath,
 		},
 	)
 	schema := cloud.CredentialSchema{
@@ -614,10 +617,10 @@ func (s *credentialsSuite) TestFinalizeCredentialInvalidFilePath(c *gc.C) {
 			"file", cloud.CredentialAttr{FilePath: true},
 		},
 	}
-	_, err := cloud.FinalizeCredential(cred, map[cloud.AuthType]cloud.CredentialSchema{
+	_, err = cloud.FinalizeCredential(cred, map[cloud.AuthType]cloud.CredentialSchema{
 		cloud.JSONFileAuthType: schema,
 	}, nil)
-	c.Assert(err, gc.ErrorMatches, "invalid file path: /some/file")
+	c.Assert(err, gc.ErrorMatches, "invalid file path: .*")
 }
 
 func (s *credentialsSuite) TestFinalizeCredentialRelativeFilePath(c *gc.C) {

--- a/cloud/credentials_test.go
+++ b/cloud/credentials_test.go
@@ -605,11 +605,10 @@ func (s *credentialsSuite) TestFinalizeCredentialFilePath(c *gc.C) {
 func (s *credentialsSuite) TestFinalizeCredentialInvalidFilePath(c *gc.C) {
 	dir, err := ioutil.TempDir(c.MkDir(), "testinvalid")
 	c.Assert(err, jc.ErrorIsNil)
-	invalidPath := filepath.Join(dir, "somefile")
 	cred := cloud.NewCredential(
 		cloud.JSONFileAuthType,
 		map[string]string{
-			"file": invalidPath,
+			"file": filepath.Join(dir, "somefile"),
 		},
 	)
 	schema := cloud.CredentialSchema{


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/juju-core/+bug/1559706
Ensure a test using an absolute filepath works on windows.

(Review request: http://reviews.vapour.ws/r/4251/)