### PR TITLE
Ensure authorised keys are properly processed on bootstrap

### DIFF
--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -13,7 +13,6 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/utils"
 	"github.com/juju/utils/featureflag"
-	"github.com/juju/utils/set"
 	"github.com/juju/version"
 	"gopkg.in/juju/charm.v6-unstable"
 	"launchpad.net/gnuflag"
@@ -477,12 +476,9 @@ to clean up the model.`[1:])
 	// We copy across any user supplied attributes to the hosted model config.
 	// But only if the attributes have not been removed from the controller
 	// model config as part of preparing the controller model.
-	controllerCfgAttrs := set.NewStrings()
-	for attr := range environ.Config().AllAttrs() {
-		controllerCfgAttrs.Add(attr)
-	}
+	controllerConfigAttrs := environ.Config().AllAttrs()
 	for k, v := range userConfigAttrs {
-		if controllerCfgAttrs.Contains(k) {
+		if _, ok := controllerConfigAttrs[k]; ok {
 			hostedModelConfig[k] = v
 		}
 	}

--- a/controller/modelmanager/createmodel.go
+++ b/controller/modelmanager/createmodel.go
@@ -253,9 +253,9 @@ func maybeCopyControllerSecrets(provider environs.ProviderCredentials, controlle
 		}
 	}
 
-	// No user supplied credentials so use the ones from the controller.
+	// Ensure any required attributes which are empty are copied from the controller config.
 	for _, attrName := range requiredControllerAttrNames {
-		if _, ok := attrs[attrName]; !ok {
+		if val, ok := attrs[attrName]; !ok || val == "" {
 			attrs[attrName] = controllerAttrs[attrName]
 		}
 	}

--- a/controller/modelmanager/createmodel.go
+++ b/controller/modelmanager/createmodel.go
@@ -255,7 +255,7 @@ func maybeCopyControllerSecrets(provider environs.ProviderCredentials, controlle
 
 	// Ensure any required attributes which are empty are copied from the controller config.
 	for _, attrName := range requiredControllerAttrNames {
-		if val, ok := attrs[attrName]; !ok || val == "" {
+		if _, ok := attrs[attrName]; !ok {
 			attrs[attrName] = controllerAttrs[attrName]
 		}
 	}

--- a/controller/modelmanager/createmodel_test.go
+++ b/controller/modelmanager/createmodel_test.go
@@ -120,6 +120,21 @@ func (s *ModelConfigCreatorSuite) TestCreateModelForAdminUserCopiesSecrets(c *gc
 	c.Assert(validateCall.Args[1], gc.IsNil)
 }
 
+func (s *ModelConfigCreatorSuite) TestCreateModelEnsuresRequiredFields(c *gc.C) {
+	var err error
+	s.baseConfig, err = s.baseConfig.Apply(coretesting.Attrs{
+		"authorized-keys": "ssh-key",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	newAttrs := coretesting.Attrs{
+		"name":            "new-model",
+		"authorized-keys": "",
+	}
+	_, err = s.newModelConfigAdmin(newAttrs)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(newAttrs["authorized-keys"], gc.Equals, "ssh-key")
+}
+
 func (s *ModelConfigCreatorSuite) TestCreateModelForAdminUserPrefersUserSecrets(c *gc.C) {
 	var err error
 	s.baseConfig, err = s.baseConfig.Apply(coretesting.Attrs{

--- a/controller/modelmanager/createmodel_test.go
+++ b/controller/modelmanager/createmodel_test.go
@@ -127,8 +127,7 @@ func (s *ModelConfigCreatorSuite) TestCreateModelEnsuresRequiredFields(c *gc.C) 
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	newAttrs := coretesting.Attrs{
-		"name":            "new-model",
-		"authorized-keys": "",
+		"name": "new-model",
 	}
 	_, err = s.newModelConfigAdmin(newAttrs)
 	c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
The hosted model config was not correctly processing authorised keys config.
If the authorised keys path was specified at bootstrap, we need to ensure this config value is not copied across to the hosted model config.

(Review request: http://reviews.vapour.ws/r/4252/)