### PR TITLE
Fix ordering issue for unsupported constraints tests.

### DIFF
--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -766,7 +766,7 @@ func (t *localServerSuite) TestConstraintsValidatorUnsupported(c *gc.C) {
 	cons := constraints.MustParse("arch=amd64 tags=foo virt-type=kvm")
 	unsupported, err := validator.Validate(cons)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(unsupported, gc.DeepEquals, []string{"tags", "virt-type"})
+	c.Assert(unsupported, jc.SameContents, []string{"tags", "virt-type"})
 }
 
 func (t *localServerSuite) TestConstraintsValidatorVocab(c *gc.C) {

--- a/provider/lxd/environ_policy_test.go
+++ b/provider/lxd/environ_policy_test.go
@@ -6,7 +6,6 @@
 package lxd_test
 
 import (
-	"sort"
 	"strings"
 
 	jc "github.com/juju/testing/checkers"
@@ -132,8 +131,6 @@ func (s *environPolSuite) TestConstraintsValidatorUnsupported(c *gc.C) {
 		"cpu-power",
 		"virt-type",
 	}
-	sort.Strings(expected)
-	sort.Strings(unsupported)
 	c.Check(unsupported, jc.SameContents, expected)
 }
 


### PR DESCRIPTION
Trivial:
1. EC2 test: use SameContents check instead of DeepEquals;
2. LXD test: remove redundant sort as we are using SameContents for consistency with similar tests in other providers.

(Review request: http://reviews.vapour.ws/r/4253/)