### PR TITLE
cmd/juju/commands: refactor bootstrap retry logic

### DIFF
--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -192,7 +192,7 @@ func (s *BootstrapSuite) TestBootstrapAPIReadyRetries(c *gc.C) {
 			c, s.newBootstrapCommand(),
 			"devcontroller", "dummy", "--auto-upgrade",
 		)
-		c.Check(err, gc.DeepEquals, t.err)
+		c.Check(errors.Cause(err), gc.DeepEquals, t.err)
 		expectedRetries := t.numRetries
 		if t.numRetries <= 0 {
 			expectedRetries = 1


### PR DESCRIPTION
Refactor bootstrap retry logic in preparation for making it a general
function of any API call.

This refactor is made a little more complex by the contract for
bootstrap that says the method will return the last error in the retry
loop -- but at least we wrap it with an explanation of what caused the
error.

Tested with various manual boostrap scenarios including terminating the
machine during bootstrap.

(Review request: http://reviews.vapour.ws/r/4254/)