### PR TITLE
Implement the MigrationAgent facade

### DIFF
--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -36,6 +36,7 @@ import (
 	_ "github.com/juju/juju/apiserver/metricsadder"
 	_ "github.com/juju/juju/apiserver/metricsdebug"
 	_ "github.com/juju/juju/apiserver/metricsmanager"
+	_ "github.com/juju/juju/apiserver/migrationagent"
 	_ "github.com/juju/juju/apiserver/migrationmaster"
 	_ "github.com/juju/juju/apiserver/migrationtarget"
 	_ "github.com/juju/juju/apiserver/modelmanager"

--- a/apiserver/export_test.go
+++ b/apiserver/export_test.go
@@ -187,10 +187,10 @@ func (srv *Server) Addr() *net.TCPAddr {
 	return srv.lis.Addr().(*net.TCPAddr) // cannot fail
 }
 
-// PatchMigrationGetter overrides the migrationGetter function to
-// support testing.
-func PatchMigrationGetter(p Patcher, st modelMigrationGetter) {
-	p.PatchValue(&migrationGetter, func(*state.State) modelMigrationGetter {
+// PatchGetMigrationBackend overrides the getMigrationBackend function
+// to support testing.
+func PatchGetMigrationBackend(p Patcher, st migrationBackend) {
+	p.PatchValue(&getMigrationBackend, func(*state.State) migrationBackend {
 		return st
 	})
 }

--- a/apiserver/migrationagent/doc.go
+++ b/apiserver/migrationagent/doc.go
@@ -1,0 +1,8 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// This package defines the API facade for use by the migration worker
+// to monitor the progress of, and interact with, model migrations.
+//
+// The migration worker runs inside every non-controller agent.
+package migrationagent

--- a/apiserver/migrationagent/export_test.go
+++ b/apiserver/migrationagent/export_test.go
@@ -1,0 +1,16 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package migrationagent
+
+import "github.com/juju/juju/state"
+
+func PatchState(p Patcher, st Backend) {
+	p.PatchValue(&getBackend, func(*state.State) Backend {
+		return st
+	})
+}
+
+type Patcher interface {
+	PatchValue(ptr, value interface{})
+}

--- a/apiserver/migrationagent/migrationagent.go
+++ b/apiserver/migrationagent/migrationagent.go
@@ -1,0 +1,58 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package migrationagent
+
+import (
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/state"
+)
+
+func init() {
+	common.RegisterStandardFacade("MigrationAgent", 1, NewAPI)
+}
+
+// API implements the API required for the model migration
+// master worker.
+type API struct {
+	backend    Backend
+	authorizer common.Authorizer
+	resources  *common.Resources
+}
+
+// NewAPI creates a new API server endpoint for the model migration
+// master worker.
+func NewAPI(
+	st *state.State,
+	resources *common.Resources,
+	authorizer common.Authorizer,
+) (*API, error) {
+	if !(authorizer.AuthMachineAgent() || authorizer.AuthUnitAgent()) {
+		return nil, common.ErrPerm
+	}
+	return &API{
+		backend:    getBackend(st),
+		authorizer: authorizer,
+		resources:  resources,
+	}, nil
+}
+
+// Watch starts watching for status updates for a migration attempt
+// for the model. It will report when a migration starts and when its
+// status changes (including when it finishes). An initial event will
+// be fired if there has ever been a migration attempt for the model.
+//
+// The MigrationAgentWatcher facade must be used to receive events
+// from the watcher.
+func (api *API) Watch() (params.NotifyWatchResult, error) {
+	w, err := api.backend.WatchMigrationStatus()
+	if err != nil {
+		return params.NotifyWatchResult{}, errors.Trace(err)
+	}
+	return params.NotifyWatchResult{
+		NotifyWatcherId: api.resources.Register(w),
+	}, nil
+}

--- a/apiserver/migrationagent/migrationagent_test.go
+++ b/apiserver/migrationagent/migrationagent_test.go
@@ -1,0 +1,97 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package migrationagent_test
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/names"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/migrationagent"
+	apiservertesting "github.com/juju/juju/apiserver/testing"
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/testing"
+)
+
+// Ensure that Backend remains compatible with *state.State
+var _ migrationagent.Backend = (*state.State)(nil)
+
+type Suite struct {
+	testing.BaseSuite
+
+	backend    *stubBackend
+	resources  *common.Resources
+	authorizer apiservertesting.FakeAuthorizer
+}
+
+var _ = gc.Suite(&Suite{})
+
+func (s *Suite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+
+	s.backend = &stubBackend{}
+	migrationagent.PatchState(s, s.backend)
+
+	s.resources = common.NewResources()
+	s.AddCleanup(func(*gc.C) { s.resources.StopAll() })
+
+	s.authorizer = apiservertesting.FakeAuthorizer{
+		Tag: names.NewMachineTag("99"),
+	}
+}
+
+func (s *Suite) TestAuthMachineAgent(c *gc.C) {
+	s.authorizer.Tag = names.NewMachineTag("42")
+	s.mustMakeAPI(c)
+}
+
+func (s *Suite) TestAuthUnitAgent(c *gc.C) {
+	s.authorizer.Tag = names.NewUnitTag("foo/0")
+	s.mustMakeAPI(c)
+}
+
+func (s *Suite) TestAuthNotAgent(c *gc.C) {
+	s.authorizer.Tag = names.NewUserTag("dorothy")
+	_, err := s.makeAPI()
+	c.Assert(err, gc.Equals, common.ErrPerm)
+}
+
+func (s *Suite) TestWatchError(c *gc.C) {
+	s.backend.watchError = errors.New("boom")
+	api := s.mustMakeAPI(c)
+	_, err := api.Watch()
+	c.Assert(err, gc.ErrorMatches, "boom")
+	c.Assert(s.resources.Count(), gc.Equals, 0)
+}
+
+func (s *Suite) TestWatch(c *gc.C) {
+	api := s.mustMakeAPI(c)
+	result, err := api.Watch()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s.resources.Get(result.NotifyWatcherId), gc.NotNil)
+}
+
+func (s *Suite) makeAPI() (*migrationagent.API, error) {
+	return migrationagent.NewAPI(nil, s.resources, s.authorizer)
+}
+
+func (s *Suite) mustMakeAPI(c *gc.C) *migrationagent.API {
+	api, err := migrationagent.NewAPI(nil, s.resources, s.authorizer)
+	c.Assert(err, jc.ErrorIsNil)
+	return api
+}
+
+type stubBackend struct {
+	migrationagent.Backend
+	watchError error
+}
+
+func (b *stubBackend) WatchMigrationStatus() (state.NotifyWatcher, error) {
+	if b.watchError != nil {
+		return nil, b.watchError
+	}
+	return apiservertesting.NewFakeNotifyWatcher(), nil
+}

--- a/apiserver/migrationagent/package_test.go
+++ b/apiserver/migrationagent/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package migrationagent_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/apiserver/migrationagent/state.go
+++ b/apiserver/migrationagent/state.go
@@ -1,0 +1,16 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package migrationagent
+
+import "github.com/juju/juju/state"
+
+// Backend defines the state functionality required by the
+// MigrationTarget facade.
+type Backend interface {
+	WatchMigrationStatus() (state.NotifyWatcher, error)
+}
+
+var getBackend = func(st *state.State) Backend {
+	return st
+}

--- a/apiserver/params/migration.go
+++ b/apiserver/params/migration.go
@@ -3,6 +3,8 @@
 
 package params
 
+import "github.com/juju/juju/core/migration"
+
 // SetMigrationPhaseArgs provides a migration phase to the
 // migrationmaster.SetPhase API method.
 type SetMigrationPhaseArgs struct {
@@ -12,4 +14,12 @@ type SetMigrationPhaseArgs struct {
 // SerializedModel wraps a buffer contain a serialised Juju model.
 type SerializedModel struct {
 	Bytes []byte `json:"bytes"`
+}
+
+// MigrationStatus reports the current status of a model migration.
+type MigrationStatus struct {
+	Attempt        int             `json:"attempt"`
+	Phase          migration.Phase `json:"phase"`
+	SourceAPIAddrs []string        `json:"source-api-addrs"`
+	TargetAPIAddrs []string        `json:"target-api-addrs"`
 }

--- a/apiserver/watcher_test.go
+++ b/apiserver/watcher_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/core/migration"
+	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/testing"
 )
@@ -81,13 +82,13 @@ func (s *watcherSuite) TestMigrationMasterWatcher(c *gc.C) {
 	w := apiservertesting.NewFakeNotifyWatcher()
 	id := s.resources.Register(w)
 	s.authorizer.EnvironManager = true
-	apiserver.PatchMigrationGetter(s, new(fakeModelMigrationGetter))
+	apiserver.PatchGetMigrationBackend(s, new(fakeMigrationBackend))
 
 	w.C <- struct{}{}
 	facade := s.getFacade(c, "MigrationMasterWatcher", 1, id).(migrationMasterWatcher)
+	defer c.Check(facade.Stop(), jc.ErrorIsNil)
 	result, err := facade.Next()
 	c.Assert(err, jc.ErrorIsNil)
-	defer c.Check(facade.Stop(), jc.ErrorIsNil)
 
 	c.Assert(result, jc.DeepEquals, params.ModelMigrationTargetInfo{
 		ControllerTag: "model-uuid",
@@ -98,11 +99,40 @@ func (s *watcherSuite) TestMigrationMasterWatcher(c *gc.C) {
 	})
 }
 
-func (s *watcherSuite) TestMigrationNotModelManager(c *gc.C) {
+func (s *watcherSuite) TestMigrationMasterNotModelManager(c *gc.C) {
 	id := s.resources.Register(apiservertesting.NewFakeNotifyWatcher())
 	s.authorizer.EnvironManager = false
 
 	factory, err := common.Facades.GetFactory("MigrationMasterWatcher", 1)
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = factory(s.st, s.resources, s.authorizer, id)
+	c.Assert(err, gc.Equals, common.ErrPerm)
+}
+
+func (s *watcherSuite) TestMigrationAgentWatcher(c *gc.C) {
+	w := apiservertesting.NewFakeNotifyWatcher()
+	id := s.resources.Register(w)
+	s.authorizer.Tag = names.NewMachineTag("12")
+	apiserver.PatchGetMigrationBackend(s, new(fakeMigrationBackend))
+
+	w.C <- struct{}{}
+	facade := s.getFacade(c, "MigrationAgentWatcher", 1, id).(migrationAgentWatcher)
+	defer c.Check(facade.Stop(), jc.ErrorIsNil)
+	result, err := facade.Next()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, jc.DeepEquals, params.MigrationStatus{
+		Attempt:        2,
+		Phase:          migration.READONLY,
+		SourceAPIAddrs: []string{"1.2.3.4:5", "2.3.4.5:6", "3.4.5.6:7"},
+		TargetAPIAddrs: []string{"1.2.3.4:5555"},
+	})
+}
+
+func (s *watcherSuite) TestMigrationAgentNotAgent(c *gc.C) {
+	id := s.resources.Register(apiservertesting.NewFakeNotifyWatcher())
+	s.authorizer.Tag = names.NewUserTag("frogdog")
+
+	factory, err := common.Facades.GetFactory("MigrationAgentWatcher", 1)
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = factory(s.st, s.resources, s.authorizer, id)
 	c.Assert(err, gc.Equals, common.ErrPerm)
@@ -121,14 +151,37 @@ func (w *fakeStringsWatcher) Changes() <-chan []string {
 	return w.ch
 }
 
-type fakeModelMigrationGetter struct{}
+type fakeMigrationBackend struct{}
 
-func (g *fakeModelMigrationGetter) GetModelMigration() (state.ModelMigration, error) {
+func (b *fakeMigrationBackend) GetModelMigration() (state.ModelMigration, error) {
 	return new(fakeModelMigration), nil
+}
+
+func (b *fakeMigrationBackend) APIHostPorts() ([][]network.HostPort, error) {
+	return [][]network.HostPort{
+		MustParseHostPorts("1.2.3.4:5", "2.3.4.5:6"),
+		MustParseHostPorts("3.4.5.6:7"),
+	}, nil
+}
+
+func MustParseHostPorts(hostports ...string) []network.HostPort {
+	out, err := network.ParseHostPorts(hostports...)
+	if err != nil {
+		panic(err)
+	}
+	return out
 }
 
 type fakeModelMigration struct {
 	state.ModelMigration
+}
+
+func (m *fakeModelMigration) Attempt() (int, error) {
+	return 2, nil
+}
+
+func (m *fakeModelMigration) Phase() (migration.Phase, error) {
+	return migration.READONLY, nil
 }
 
 func (m *fakeModelMigration) TargetInfo() (*migration.TargetInfo, error) {
@@ -143,5 +196,10 @@ func (m *fakeModelMigration) TargetInfo() (*migration.TargetInfo, error) {
 
 type migrationMasterWatcher interface {
 	Next() (params.ModelMigrationTargetInfo, error)
+	Stop() error
+}
+
+type migrationAgentWatcher interface {
+	Next() (params.MigrationStatus, error)
 	Stop() error
 }

--- a/state/modelmigration.go
+++ b/state/modelmigration.go
@@ -5,6 +5,7 @@ package state
 
 import (
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/juju/errors"
@@ -27,6 +28,10 @@ type ModelMigration interface {
 
 	// ModelUUID returns the UUID for the model being migrated.
 	ModelUUID() string
+
+	// Attempt returns the migration attempt identifier. This
+	// increments for each migration attempt for the model.
+	Attempt() (int, error)
 
 	// StartTime returns the time when the migration was started.
 	StartTime() time.Time
@@ -158,6 +163,16 @@ func (mig *modelMigration) Id() string {
 // ModelUUID implements ModelMigration.
 func (mig *modelMigration) ModelUUID() string {
 	return mig.doc.ModelUUID
+}
+
+// Attempt implements ModelMigration.
+func (mig *modelMigration) Attempt() (int, error) {
+	attempt, err := strconv.Atoi(mig.st.localID(mig.doc.Id))
+	if err != nil {
+		// This really shouldn't happen.
+		return -1, errors.Errorf("invalid migration id: %v", mig.doc.Id)
+	}
+	return attempt, nil
 }
 
 // StartTime implements ModelMigration.

--- a/state/modelmigration_test.go
+++ b/state/modelmigration_test.go
@@ -61,7 +61,7 @@ func (s *ModelMigrationSuite) TestCreate(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(mig.ModelUUID(), gc.Equals, s.State2.ModelUUID())
-	c.Check(mig.Id(), gc.Equals, mig.ModelUUID()+":0")
+	checkIdAndAttempt(c, mig, 0)
 
 	c.Check(mig.StartTime(), gc.Equals, s.clock.Now())
 
@@ -87,35 +87,29 @@ func (s *ModelMigrationSuite) TestIdSequencesAreIndependent(c *gc.C) {
 
 	mig2, err := st2.CreateModelMigration(s.stdSpec)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Check(mig2.Id(), gc.Equals, st2.ModelUUID()+":0")
+	checkIdAndAttempt(c, mig2, 0)
 
 	mig3, err := st3.CreateModelMigration(s.stdSpec)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Check(mig3.Id(), gc.Equals, st3.ModelUUID()+":0")
+	checkIdAndAttempt(c, mig3, 0)
 }
 
 func (s *ModelMigrationSuite) TestIdSequencesIncrement(c *gc.C) {
-	createAndAbort := func() string {
+	for attempt := 0; attempt < 3; attempt++ {
 		mig, err := s.State2.CreateModelMigration(s.stdSpec)
 		c.Assert(err, jc.ErrorIsNil)
+		checkIdAndAttempt(c, mig, attempt)
 		c.Check(mig.SetPhase(migration.ABORT), jc.ErrorIsNil)
-		return mig.Id()
 	}
-
-	modelUUID := s.State2.ModelUUID()
-	c.Check(createAndAbort(), gc.Equals, modelUUID+":0")
-	c.Check(createAndAbort(), gc.Equals, modelUUID+":1")
-	c.Check(createAndAbort(), gc.Equals, modelUUID+":2")
 }
 
 func (s *ModelMigrationSuite) TestIdSequencesIncrementOnlyWhenNecessary(c *gc.C) {
 	// Ensure that sequence numbers aren't "used up" unnecessarily
 	// when the create txn is going to fail.
-	modelUUID := s.State2.ModelUUID()
 
 	mig, err := s.State2.CreateModelMigration(s.stdSpec)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Check(mig.Id(), gc.Equals, modelUUID+":0")
+	checkIdAndAttempt(c, mig, 0)
 
 	// This attempt will fail because a migration is already in
 	// progress.
@@ -128,7 +122,7 @@ func (s *ModelMigrationSuite) TestIdSequencesIncrementOnlyWhenNecessary(c *gc.C)
 
 	mig, err = s.State2.CreateModelMigration(s.stdSpec)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Check(mig.Id(), gc.Equals, modelUUID+":1")
+	checkIdAndAttempt(c, mig, 1)
 }
 
 func (s *ModelMigrationSuite) TestSpecValidation(c *gc.C) {
@@ -569,4 +563,11 @@ func isMigrationActive(c *gc.C, st *state.State) bool {
 	isActive, err := st.IsModelMigrationActive()
 	c.Assert(err, jc.ErrorIsNil)
 	return isActive
+}
+
+func checkIdAndAttempt(c *gc.C, mig state.ModelMigration, expected int) {
+	c.Check(mig.Id(), gc.Equals, fmt.Sprintf("%s:%d", mig.ModelUUID(), expected))
+	attempt, err := mig.Attempt()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(attempt, gc.Equals, expected)
 }

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -2647,21 +2647,21 @@ func (w *blockDevicesWatcher) loop() error {
 	}
 }
 
-// WatchForModelMigration returns a notify watcher which which report
-// when a migration is in progress for the model associated with the
+// WatchForModelMigration returns a notify watcher which reports when
+// a migration is in progress for the model associated with the
 // State. Only in-progress and newly created migrations are reported.
 func (st *State) WatchForModelMigration() (NotifyWatcher, error) {
-	return newModelMigrationWatcher(st), nil
+	return newMigrationActiveWatcher(st), nil
 }
 
-type modelMigrationWatcher struct {
+type migrationActiveWatcher struct {
 	commonWatcher
 	collName string
 	sink     chan struct{}
 }
 
-func newModelMigrationWatcher(st *State) NotifyWatcher {
-	w := &modelMigrationWatcher{
+func newMigrationActiveWatcher(st *State) NotifyWatcher {
+	w := &migrationActiveWatcher{
 		commonWatcher: commonWatcher{st: st},
 		collName:      modelMigrationsActiveC,
 		sink:          make(chan struct{}),
@@ -2675,11 +2675,11 @@ func newModelMigrationWatcher(st *State) NotifyWatcher {
 }
 
 // Changes returns the event channel for this watcher.
-func (w *modelMigrationWatcher) Changes() <-chan struct{} {
+func (w *migrationActiveWatcher) Changes() <-chan struct{} {
 	return w.sink
 }
 
-func (w *modelMigrationWatcher) loop() error {
+func (w *migrationActiveWatcher) loop() error {
 	in := make(chan watcher.Change)
 	filter := func(id interface{}) bool {
 		// Only report migrations for the requested model.
@@ -2712,6 +2712,95 @@ func (w *modelMigrationWatcher) loop() error {
 				continue
 			}
 
+			if _, ok := collect(change, in, w.tomb.Dying()); !ok {
+				return tomb.ErrDying
+			}
+			out = w.sink
+		case out <- struct{}{}:
+			out = nil
+		}
+	}
+}
+
+// WatchMigrationStatus returns a NotifyWatcher which triggers
+// whenever the status of latest migration for the State's model
+// changes. One instance can be used across migrations. The watcher
+// will report changes when one migration finishes and another one
+// begins.
+//
+// Note that this watcher does not produce an initial event if there's
+// never been a migration attempt for the model.
+func (st *State) WatchMigrationStatus() (NotifyWatcher, error) {
+	return newMigrationStatusWatcher(st), nil
+}
+
+type migrationStatusWatcher struct {
+	commonWatcher
+	collName string
+	sink     chan struct{}
+}
+
+func newMigrationStatusWatcher(st *State) NotifyWatcher {
+	w := &migrationStatusWatcher{
+		commonWatcher: commonWatcher{st: st},
+		collName:      modelMigrationStatusC,
+		sink:          make(chan struct{}),
+	}
+	go func() {
+		defer w.tomb.Done()
+		defer close(w.sink)
+		w.tomb.Kill(w.loop())
+	}()
+	return w
+}
+
+// Changes returns the event channel for this watcher.
+func (w *migrationStatusWatcher) Changes() <-chan struct{} {
+	return w.sink
+}
+
+func (w *migrationStatusWatcher) loop() error {
+	in := make(chan watcher.Change)
+
+	// Watch the entire modelMigrationStatusC collection for migration
+	// status updates related to the State's model. This is more
+	// efficient and simpler than tracking the current active
+	// migration (and changing watchers when one migration finishes
+	// and another starts.
+	//
+	// This approach is safe because there are strong guarantees that
+	// there will only be one active migration per model. The watcher
+	// will only see changes for one migration status document at a
+	// time for the model.
+	filter := func(id interface{}) bool {
+		_, err := w.st.strictLocalID(id.(string))
+		return err == nil
+	}
+	w.st.watcher.WatchCollectionWithFilter(w.collName, in, filter)
+	defer w.st.watcher.UnwatchCollection(w.collName, in)
+
+	var out chan<- struct{}
+
+	// If there is a migration record for the model - active or not -
+	// send an initial event.
+	if _, err := w.st.GetModelMigration(); errors.IsNotFound(err) {
+		// Nothing to report.
+	} else if err != nil {
+		return errors.Trace(err)
+	} else {
+		out = w.sink
+	}
+
+	for {
+		select {
+		case <-w.tomb.Dying():
+			return tomb.ErrDying
+		case <-w.st.watcher.Dead():
+			return stateWatcherDeadError(w.st.watcher.Err())
+		case change := <-in:
+			if change.Revno == -1 {
+				return errors.New("model migration status disappeared (shouldn't happen)")
+			}
 			if _, ok := collect(change, in, w.tomb.Dying()); !ok {
 				return tomb.ErrDying
 			}


### PR DESCRIPTION
(This will get landed against master, once the model-migration branch lands)

apiserver: Add MigrationAgent facade

This currently has a single API method for the migration worker to use to monitor the progress of model migrations.

---

state: Expose a migration's attempt number

---

apiserver: Add MigrationAgentWatcher facade.

This supports receiving of events from the watcher created using the MigrationAgent.Watch API.


(Review request: http://reviews.vapour.ws/r/4255/)