### PR TITLE
Add a migration mode to the model doc.

### DIFF
--- a/apiserver/modelmanager/modelmanager.go
+++ b/apiserver/modelmanager/modelmanager.go
@@ -318,7 +318,7 @@ func (em *ModelManagerAPI) CreateModel(args params.ModelCreateArgs) (params.Mode
 	// NOTE: check the agent-version of the config, and if it is > the current
 	// version, it is not supported, also check existing tools, and if we don't
 	// have tools for that version, also die.
-	model, st, err := em.state.NewModel(newConfig, ownerTag)
+	model, st, err := em.state.NewModel(state.ModelArgs{Config: newConfig, Owner: ownerTag})
 	if err != nil {
 		return result, errors.Annotate(err, "failed to create new model")
 	}

--- a/apiserver/modelmanager/state.go
+++ b/apiserver/modelmanager/state.go
@@ -6,7 +6,6 @@ package modelmanager
 import (
 	"github.com/juju/names"
 
-	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/state"
 )
 
@@ -17,7 +16,7 @@ var getState = func(st *state.State) stateInterface {
 type stateInterface interface {
 	ModelsForUser(names.UserTag) ([]*state.UserModel, error)
 	IsControllerAdministrator(user names.UserTag) (bool, error)
-	NewModel(*config.Config, names.UserTag) (*state.Model, *state.State, error)
+	NewModel(state.ModelArgs) (*state.Model, *state.State, error)
 	ControllerModel() (*state.Model, error)
 }
 

--- a/state/allwatcher_internal_test.go
+++ b/state/allwatcher_internal_test.go
@@ -55,7 +55,7 @@ func (s *allWatcherBaseSuite) newState(c *gc.C) *State {
 		"name": fmt.Sprintf("testenv%d", s.envCount),
 		"uuid": utils.MustNewUUID().String(),
 	})
-	_, st, err := s.state.NewModel(cfg, s.owner)
+	_, st, err := s.state.NewModel(ModelArgs{Config: cfg, Owner: s.owner})
 	c.Assert(err, jc.ErrorIsNil)
 	s.AddCleanup(func(*gc.C) { st.Close() })
 	return st

--- a/state/annotations_test.go
+++ b/state/annotations_test.go
@@ -179,7 +179,7 @@ func (s *AnnotationsEnvSuite) createTestEnv(c *gc.C) (*state.Model, *state.State
 		"uuid": uuid.String(),
 	})
 	owner := names.NewUserTag("test@remote")
-	env, st, err := s.State.NewModel(cfg, owner)
+	env, st, err := s.State.NewModel(state.ModelArgs{Config: cfg, Owner: owner})
 	c.Assert(err, jc.ErrorIsNil)
 	return env, st
 }

--- a/state/block_test.go
+++ b/state/block_test.go
@@ -194,7 +194,7 @@ func (s *blockSuite) createTestEnv(c *gc.C) (*state.Model, *state.State) {
 		"uuid": uuid.String(),
 	})
 	owner := names.NewUserTag("test@remote")
-	env, st, err := s.State.NewModel(cfg, owner)
+	env, st, err := s.State.NewModel(state.ModelArgs{Config: cfg, Owner: owner})
 	c.Assert(err, jc.ErrorIsNil)
 	return env, st
 }

--- a/state/conn_test.go
+++ b/state/conn_test.go
@@ -111,7 +111,7 @@ func (s *ConnSuite) NewStateForModelNamed(c *gc.C, modelName string) *state.Stat
 		"uuid": utils.MustNewUUID().String(),
 	})
 	otherOwner := names.NewLocalUserTag("test-admin")
-	_, otherState, err := s.State.NewModel(cfg, otherOwner)
+	_, otherState, err := s.State.NewModel(state.ModelArgs{Config: cfg, Owner: otherOwner})
 
 	c.Assert(err, jc.ErrorIsNil)
 	s.AddCleanup(func(*gc.C) { otherState.Close() })

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -47,7 +47,11 @@ func (st *State) Import(model description.Model) (_ *Model, _ *State, err error)
 	if err != nil {
 		return nil, nil, errors.Trace(err)
 	}
-	dbModel, newSt, err := st.NewModel(cfg, model.Owner())
+	dbModel, newSt, err := st.NewModel(ModelArgs{
+		Config:        cfg,
+		Owner:         model.Owner(),
+		MigrationMode: MigrationModeImporting,
+	})
 	if err != nil {
 		return nil, nil, errors.Trace(err)
 	}

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -93,6 +93,7 @@ func (s *MigrationImportSuite) TestNewModel(c *gc.C) {
 
 	c.Assert(newModel.Owner(), gc.Equals, original.Owner())
 	c.Assert(newModel.LatestToolsVersion(), gc.Equals, latestTools)
+	c.Assert(newModel.MigrationMode(), gc.Equals, state.MigrationModeImporting)
 	s.assertAnnotations(c, newSt, newModel)
 
 	originalConfig, err := original.Config()

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -149,14 +149,12 @@ func (s *MigrationSuite) TestKnownCollections(c *gc.C) {
 }
 
 func (s *MigrationSuite) TestModelDocFields(c *gc.C) {
-	fields := set.NewStrings(
+	ignored := set.NewStrings(
 		// UUID and Mame are constructed from the model config.
 		"UUID",
 		"Name",
 		// Life will always be alive, or we won't be migrating.
 		"Life",
-		"Owner",
-		"LatestAvailableTools",
 		// ServerUUID is recreated when the new model is created in the
 		// new controller (yay name changes).
 		"ServerUUID",
@@ -164,8 +162,13 @@ func (s *MigrationSuite) TestModelDocFields(c *gc.C) {
 		// is alive.
 		"TimeOfDying",
 		"TimeOfDeath",
+		"MigrationMode",
 	)
-	s.AssertExportedFields(c, modelDoc{}, fields)
+	migrated := set.NewStrings(
+		"Owner",
+		"LatestAvailableTools",
+	)
+	s.AssertExportedFields(c, modelDoc{}, migrated.Union(ignored))
 }
 
 func (s *MigrationSuite) TestEnvUserDocFields(c *gc.C) {

--- a/state/modeluser_test.go
+++ b/state/modeluser_test.go
@@ -263,7 +263,7 @@ func (s *ModelUserSuite) newEnvWithOwner(c *gc.C, name string, owner names.UserT
 		"name": name,
 		"uuid": uuid.String(),
 	})
-	model, st, err := s.State.NewModel(cfg, owner)
+	model, st, err := s.State.NewModel(state.ModelArgs{Config: cfg, Owner: owner})
 	c.Assert(err, jc.ErrorIsNil)
 	defer st.Close()
 	return model

--- a/testing/factory/factory.go
+++ b/testing/factory/factory.go
@@ -562,7 +562,10 @@ func (factory *Factory) MakeModel(c *gc.C, params *ModelParams) *state.State {
 		"state-port": currentCfg.StatePort(),
 		"api-port":   currentCfg.APIPort(),
 	}.Merge(params.ConfigAttrs))
-	_, st, err := factory.st.NewModel(cfg, params.Owner.(names.UserTag))
+	_, st, err := factory.st.NewModel(state.ModelArgs{
+		Config: cfg,
+		Owner:  params.Owner.(names.UserTag),
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	if params.Prepare {
 		if params.Credential == nil {


### PR DESCRIPTION
When importing a model, it now sets the migration mode to "importing".

(Review request: http://reviews.vapour.ws/r/4257/)