### PR TITLE
apiserver/client: InstanceConfig: use cached addrs

### DIFF
--- a/apiserver/client/instanceconfig_test.go
+++ b/apiserver/client/instanceconfig_test.go
@@ -116,5 +116,5 @@ func (s *machineConfigSuite) TestMachineConfigNoTools(c *gc.C) {
 	machines, err := s.APIState.Client().AddMachines([]params.AddMachineParams{apiParams})
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = client.InstanceConfig(s.State, machines[0].Machine, apiParams.Nonce, "")
-	c.Assert(err, gc.ErrorMatches, coretools.ErrNoMatches.Error())
+	c.Assert(err, gc.ErrorMatches, "finding tools: "+coretools.ErrNoMatches.Error())
 }


### PR DESCRIPTION
The ProvisioningScript client method calls InstanceConfig,
which was constructing an Environ to get the Juju API
addresses. We already store those addresses in state, so
just fetch them from state.

Fixes https://bugs.launchpad.net/juju-core/+bug/1559299

(Review request: http://reviews.vapour.ws/r/4258/)