### PR TITLE
provider/manual: drop use-sshstorage

### DIFF
--- a/provider/manual/config.go
+++ b/provider/manual/config.go
@@ -13,14 +13,9 @@ var (
 	configFields = schema.Fields{
 		"bootstrap-host": schema.String(),
 		"bootstrap-user": schema.String(),
-		// NOTE(axw) use-sshstorage, despite its name, is now used
-		// just for determining whether the code is running inside
-		// or outside the Juju environment.
-		"use-sshstorage": schema.Bool(),
 	}
 	configDefaults = schema.Defaults{
 		"bootstrap-user": "",
-		"use-sshstorage": true,
 	}
 )
 
@@ -31,14 +26,6 @@ type environConfig struct {
 
 func newModelConfig(config *config.Config, attrs map[string]interface{}) *environConfig {
 	return &environConfig{Config: config, attrs: attrs}
-}
-
-func (c *environConfig) useSSHStorage() bool {
-	// Prior to 1.17.3, the use-sshstorage attribute
-	// did not exist. We take non-existence to be
-	// equivalent to false.
-	useSSHStorage, _ := c.attrs["use-sshstorage"].(bool)
-	return useSSHStorage
 }
 
 func (c *environConfig) bootstrapHost() string {

--- a/provider/manual/config_test.go
+++ b/provider/manual/config_test.go
@@ -28,9 +28,6 @@ func MinimalConfigValues() map[string]interface{} {
 		"controller-uuid": coretesting.ModelTag.Id(),
 		"bootstrap-host":  "hostname",
 		"bootstrap-user":  "",
-		// Not strictly necessary, but simplifies testing by disabling
-		// ssh storage by default.
-		"use-sshstorage": false,
 		// While the ca-cert bits aren't entirely minimal, they avoid the need
 		// to set up a fake home.
 		"ca-cert":        coretesting.CACert,
@@ -106,17 +103,4 @@ func (s *configSuite) TestBootstrapHostUser(c *gc.C) {
 	testConfig = getModelConfig(c, values)
 	c.Assert(testConfig.bootstrapHost(), gc.Equals, "127.0.0.1")
 	c.Assert(testConfig.bootstrapUser(), gc.Equals, "ubuntu")
-}
-
-func (s *configSuite) TestStorageCompat(c *gc.C) {
-	// Older environment configurations will not have the
-	// use-sshstorage attribute. We treat them as if they
-	// have use-sshstorage=false.
-	values := MinimalConfigValues()
-	delete(values, "use-sshstorage")
-	cfg, err := config.New(config.UseDefaults, values)
-	c.Assert(err, jc.ErrorIsNil)
-	envConfig := newModelConfig(cfg, values)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(envConfig.useSSHStorage(), jc.IsFalse)
 }

--- a/provider/manual/environ.go
+++ b/provider/manual/environ.go
@@ -6,7 +6,9 @@ package manual
 import (
 	"bytes"
 	"fmt"
+	"os"
 	"path"
+	"path/filepath"
 	"strings"
 	"sync"
 
@@ -23,6 +25,7 @@ import (
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/manual"
 	"github.com/juju/juju/instance"
+	"github.com/juju/juju/juju/names"
 	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/provider/common"
@@ -86,17 +89,9 @@ func (e *manualEnviron) SupportedArchitectures() ([]string, error) {
 	return arch.AllSupportedArches, nil
 }
 
+// Bootstrap is specified on the Environ interface.
 func (e *manualEnviron) Bootstrap(ctx environs.BootstrapContext, args environs.BootstrapParams) (*environs.BootstrapResult, error) {
-	// Set "use-sshstorage" to false, so agents know not to use sshstorage.
-	cfg, err := e.Config().Apply(map[string]interface{}{"use-sshstorage": false})
-	if err != nil {
-		return nil, err
-	}
-	if err := e.SetConfig(cfg); err != nil {
-		return nil, err
-	}
 	envConfig := e.envConfig()
-	// TODO(axw) consider how we can use placement to override bootstrap-host.
 	host := envConfig.bootstrapHost()
 	provisioned, err := manualCheckProvisioned(host)
 	if err != nil {
@@ -128,10 +123,10 @@ func (e *manualEnviron) Bootstrap(ctx environs.BootstrapContext, args environs.B
 
 // ControllerInstances is specified in the Environ interface.
 func (e *manualEnviron) ControllerInstances() ([]instance.Id, error) {
-	// If we're running from the bootstrap host, then
-	// useSSHStorage will be false; in that case, we
-	// do not need or want to verify the bootstrap host.
-	if e.envConfig().useSSHStorage() {
+	arg0 := filepath.Base(os.Args[0])
+	if arg0 != names.Jujud {
+		// Not running inside the controller, so we must
+		// verify the host.
 		if err := e.verifyBootstrapHost(); err != nil {
 			return nil, err
 		}

--- a/provider/manual/environ_test.go
+++ b/provider/manual/environ_test.go
@@ -4,6 +4,8 @@
 package manual
 
 import (
+	"os"
+
 	"github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -12,7 +14,6 @@ import (
 
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs"
-	envtesting "github.com/juju/juju/environs/testing"
 	"github.com/juju/juju/instance"
 	coretesting "github.com/juju/juju/testing"
 )
@@ -147,40 +148,9 @@ var _ = gc.Suite(&bootstrapSuite{})
 
 func (s *bootstrapSuite) SetUpTest(c *gc.C) {
 	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
-
-	// ensure use-sshstorage=true to mimic what happens
-	// in the real client: the environment is Prepared,
-	// at which point use-sshstorage=true.
-	cfg := MinimalConfig(c)
-	cfg, err := cfg.Apply(map[string]interface{}{
-		"use-sshstorage": true,
-	})
-	c.Assert(err, jc.ErrorIsNil)
-
-	env, err := manualProvider{}.Open(cfg)
+	env, err := manualProvider{}.Open(MinimalConfig(c))
 	c.Assert(err, jc.ErrorIsNil)
 	s.env = env.(*manualEnviron)
-}
-
-func (s *bootstrapSuite) TestBootstrapClearsUseSSHStorage(c *gc.C) {
-	s.PatchValue(&manualDetectSeriesAndHardwareCharacteristics, func(string) (instance.HardwareCharacteristics, string, error) {
-		arch := arch.HostArch()
-		return instance.HardwareCharacteristics{Arch: &arch}, "precise", nil
-	})
-	s.PatchValue(&manualCheckProvisioned, func(string) (bool, error) {
-		return false, nil
-	})
-
-	// use-sshstorage is initially true.
-	cfg := s.env.Config()
-	c.Assert(cfg.UnknownAttrs()["use-sshstorage"], jc.IsTrue)
-
-	_, err := s.env.Bootstrap(envtesting.BootstrapContext(c), environs.BootstrapParams{})
-	c.Assert(err, jc.ErrorIsNil)
-
-	// Bootstrap must set use-sshstorage to false within the environment.
-	cfg = s.env.Config()
-	c.Assert(cfg.UnknownAttrs()["use-sshstorage"], jc.IsFalse)
 }
 
 type controllerInstancesSuite struct {
@@ -192,15 +162,7 @@ var _ = gc.Suite(&controllerInstancesSuite{})
 
 func (s *controllerInstancesSuite) SetUpTest(c *gc.C) {
 	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
-	// ensure use-sshstorage=true, or bootstrap-host
-	// verification won't happen in ControllerInstances.
-	cfg := MinimalConfig(c)
-	cfg, err := cfg.Apply(map[string]interface{}{
-		"use-sshstorage": true,
-	})
-	c.Assert(err, jc.ErrorIsNil)
-
-	env, err := manualProvider{}.Open(cfg)
+	env, err := manualProvider{}.Open(MinimalConfig(c))
 	c.Assert(err, jc.ErrorIsNil)
 	s.env = env.(*manualEnviron)
 }
@@ -261,13 +223,12 @@ func (s *controllerInstancesSuite) TestControllerInstancesError(c *gc.C) {
 }
 
 func (s *controllerInstancesSuite) TestControllerInstancesInternal(c *gc.C) {
-	// If use-sshstorage=false, then we're on the bootstrap host;
-	// verification is elided.
-	env, err := manualProvider{}.Open(MinimalConfig(c))
-	c.Assert(err, jc.ErrorIsNil)
-
+	// Patch os.Args so it appears that we're running in "jujud".
+	s.PatchValue(&os.Args, []string{"/some/where/containing/jujud", "whatever"})
+	// Patch the ssh executable so that it would cause an error if we
+	// were to call it.
 	testing.PatchExecutable(c, s, "ssh", "#!/bin/sh\nhead -n1 > /dev/null; echo abc >&2; exit 1")
-	instances, err := env.ControllerInstances()
+	instances, err := s.env.ControllerInstances()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(instances, gc.DeepEquals, []instance.Id{BootstrapInstanceId})
 }

--- a/provider/manual/export_test.go
+++ b/provider/manual/export_test.go
@@ -3,19 +3,7 @@
 
 package manual
 
-import (
-	"github.com/juju/juju/environs"
-)
-
 var (
 	ProviderInstance = manualProvider{}
 	InitUbuntuUser   = &initUbuntuUser
 )
-
-func EnvironUseSSHStorage(env environs.Environ) bool {
-	e, ok := env.(*manualEnviron)
-	if !ok {
-		return false
-	}
-	return e.cfg.useSSHStorage()
-}

--- a/provider/manual/provider.go
+++ b/provider/manual/provider.go
@@ -76,9 +76,6 @@ func (p manualProvider) BootstrapConfig(args environs.BootstrapConfigParams) (*c
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	if use, ok := cfg.UnknownAttrs()["use-sshstorage"].(bool); ok && !use {
-		return nil, fmt.Errorf("use-sshstorage must not be specified")
-	}
 	envConfig, err := p.validate(cfg, nil)
 	if err != nil {
 		return nil, err
@@ -152,10 +149,6 @@ func (p manualProvider) validate(cfg, old *config.Config) (*environConfig, error
 			if err = checkImmutableString(envConfig, oldEnvConfig, key); err != nil {
 				return nil, err
 			}
-		}
-		oldUseSSHStorage, newUseSSHStorage := oldEnvConfig.useSSHStorage(), envConfig.useSSHStorage()
-		if oldUseSSHStorage != newUseSSHStorage && newUseSSHStorage == true {
-			return nil, fmt.Errorf("cannot change use-sshstorage from %v to %v", oldUseSSHStorage, newUseSSHStorage)
 		}
 	}
 

--- a/provider/manual/provider_test.go
+++ b/provider/manual/provider_test.go
@@ -61,7 +61,6 @@ func (s *providerSuite) TestPrepareForBootstrapNoCloudEndpointOrRegion(c *gc.C) 
 
 func (s *providerSuite) testPrepareForBootstrap(c *gc.C, endpoint, region string) (environs.BootstrapContext, error) {
 	minimal := manual.MinimalConfigValues()
-	minimal["use-sshstorage"] = true
 	testConfig, err := config.New(config.UseDefaults, minimal)
 	c.Assert(err, jc.ErrorIsNil)
 	testConfig, err = manual.ProviderInstance.BootstrapConfig(environs.BootstrapConfigParams{
@@ -75,57 +74,6 @@ func (s *providerSuite) testPrepareForBootstrap(c *gc.C, endpoint, region string
 	ctx := envtesting.BootstrapContext(c)
 	_, err = manual.ProviderInstance.PrepareForBootstrap(ctx, testConfig)
 	return ctx, err
-}
-
-func (s *providerSuite) TestBootstrapConfigUseSSHStorage(c *gc.C) {
-	minimal := manual.MinimalConfigValues()
-	minimal["use-sshstorage"] = false
-	testConfig, err := config.New(config.UseDefaults, minimal)
-	c.Assert(err, jc.ErrorIsNil)
-	_, err = manual.ProviderInstance.BootstrapConfig(environs.BootstrapConfigParams{
-		Config:        testConfig,
-		CloudEndpoint: "hostname",
-	})
-	c.Assert(err, gc.ErrorMatches, "use-sshstorage must not be specified")
-
-	minimal["use-sshstorage"] = true
-	testConfig, err = config.New(config.UseDefaults, minimal)
-	c.Assert(err, jc.ErrorIsNil)
-	_, err = manual.ProviderInstance.BootstrapConfig(environs.BootstrapConfigParams{
-		Config:        testConfig,
-		CloudEndpoint: "hostname",
-	})
-	c.Assert(err, jc.ErrorIsNil)
-}
-
-func (s *providerSuite) TestBootstrapConfigSetsUseSSHStorage(c *gc.C) {
-	attrs := manual.MinimalConfigValues()
-	delete(attrs, "use-sshstorage")
-	testConfig, err := config.New(config.UseDefaults, attrs)
-	c.Assert(err, jc.ErrorIsNil)
-
-	testConfig, err = manual.ProviderInstance.BootstrapConfig(environs.BootstrapConfigParams{
-		Config:        testConfig,
-		CloudEndpoint: "hostname",
-	})
-	c.Assert(err, jc.ErrorIsNil)
-	value := testConfig.AllAttrs()["use-sshstorage"]
-	c.Assert(value, jc.IsTrue)
-}
-
-func (s *providerSuite) TestOpenDoesntSetUseSSHStorage(c *gc.C) {
-	attrs := manual.MinimalConfigValues()
-	delete(attrs, "use-sshstorage")
-	testConfig, err := config.New(config.UseDefaults, attrs)
-	c.Assert(err, jc.ErrorIsNil)
-
-	env, err := manual.ProviderInstance.Open(testConfig)
-	c.Assert(err, jc.ErrorIsNil)
-	cfg := env.Config()
-	_, ok := cfg.AllAttrs()["use-sshstorage"]
-	c.Assert(ok, jc.IsFalse)
-	ok = manual.EnvironUseSSHStorage(env)
-	c.Assert(ok, jc.IsFalse)
 }
 
 func (s *providerSuite) TestNullAlias(c *gc.C) {


### PR DESCRIPTION
We were using use-sshstorage in one place:
to decide whether ControllerInstances should
perform a host validity check or not. Instead
of doing that, we can just check if we're
running inside "jujud". With that in place,
drop use-sshstorage from config.

(Review request: http://reviews.vapour.ws/r/4259/)