### PR TITLE
provider/{lxd,gce,vsphere} fix ControllerInstances

### DIFF
--- a/provider/common/util.go
+++ b/provider/common/util.go
@@ -5,22 +5,22 @@ package common
 
 import "fmt"
 
-// ModelFullName returns a string based on the provided model
+// EnvFullName returns a string based on the provided model
 // UUID that is suitable for identifying the env on a provider.
 //
 // The resulting string clearly associates the value with juju,
 // whereas the model's UUID alone isn't very distinctive for humans.
 // This benefits users by helping them quickly identify in their
 // hosting management tools which instances are juju related.
-func ModelFullName(modelUUID string) string {
+func EnvFullName(modelUUID string) string {
 	return fmt.Sprintf("juju-%s", modelUUID)
 }
 
 // MachineFullName returns a string based on the provided model
 // UUID and machine ID that is suitable for identifying instances
-// on a provider. See ModelFullName for an explanation on how this
+// on a provider. See EnvFullName for an explanation on how this
 // function helps juju users.
 func MachineFullName(modelUUID, machineID string) string {
-	modelstr := ModelFullName(modelUUID)
+	modelstr := EnvFullName(modelUUID)
 	return fmt.Sprintf("%s-machine-%s", modelstr, machineID)
 }

--- a/provider/common/util.go
+++ b/provider/common/util.go
@@ -3,28 +3,24 @@
 
 package common
 
-import (
-	"fmt"
+import "fmt"
 
-	"github.com/juju/juju/environs"
-)
-
-// EnvFullName returns a string based on the provided environment
-// that is suitable for identifying the env on a provider. The resulting
-// string clearly associates the value with juju, whereas the
-// environment's UUID alone isn't very distinctive for humans. This
-// benefits users by helping them quickly identify in their hosting
-// management tools which instances are juju related.
-func EnvFullName(env environs.Environ) string {
-	modelUUID := env.Config().UUID()
+// ModelFullName returns a string based on the provided model
+// UUID that is suitable for identifying the env on a provider.
+//
+// The resulting string clearly associates the value with juju,
+// whereas the model's UUID alone isn't very distinctive for humans.
+// This benefits users by helping them quickly identify in their
+// hosting management tools which instances are juju related.
+func ModelFullName(modelUUID string) string {
 	return fmt.Sprintf("juju-%s", modelUUID)
 }
 
-// MachineFullName returns a string based on the provided environment
-// and machine ID that is suitable for identifying instances on a
-// provider. See EnvFullName for an explanation on how this function
-// helps juju users.
-func MachineFullName(env environs.Environ, machineID string) string {
-	envstr := EnvFullName(env)
-	return fmt.Sprintf("%s-machine-%s", envstr, machineID)
+// MachineFullName returns a string based on the provided model
+// UUID and machine ID that is suitable for identifying instances
+// on a provider. See ModelFullName for an explanation on how this
+// function helps juju users.
+func MachineFullName(modelUUID, machineID string) string {
+	modelstr := ModelFullName(modelUUID)
+	return fmt.Sprintf("%s-machine-%s", modelstr, machineID)
 }

--- a/provider/gce/environ_broker.go
+++ b/provider/gce/environ_broker.go
@@ -152,7 +152,7 @@ func (env *environ) findInstanceSpec(
 // provisioned, relative to the provided args and spec. Info for that
 // low-level instance is returned.
 func (env *environ) newRawInstance(args environs.StartInstanceParams, spec *instances.InstanceSpec) (*google.Instance, error) {
-	machineID := common.MachineFullName(env, args.InstanceConfig.MachineId)
+	machineID := common.MachineFullName(env.Config().UUID(), args.InstanceConfig.MachineId)
 
 	os, err := series.GetOSFromSeries(args.InstanceConfig.Series)
 	if err != nil {
@@ -313,7 +313,7 @@ func (env *environ) StopInstances(instances ...instance.Id) error {
 		ids = append(ids, string(id))
 	}
 
-	prefix := common.MachineFullName(env, "")
+	prefix := common.MachineFullName(env.Config().UUID(), "")
 	err := env.gce.RemoveInstances(prefix, ids...)
 	return errors.Trace(err)
 }

--- a/provider/gce/environ_instance.go
+++ b/provider/gce/environ_instance.go
@@ -76,7 +76,7 @@ var getInstances = func(env *environ) ([]instance.Instance, error) {
 func (env *environ) instances() ([]instance.Instance, error) {
 	env = env.getSnapshot()
 
-	prefix := common.MachineFullName(env, "")
+	prefix := common.MachineFullName(env.Config().UUID(), "")
 	instances, err := env.gce.Instances(prefix, instStatuses...)
 	err = errors.Trace(err)
 
@@ -99,7 +99,7 @@ func (env *environ) instances() ([]instance.Instance, error) {
 func (env *environ) ControllerInstances() ([]instance.Id, error) {
 	env = env.getSnapshot()
 
-	prefix := common.MachineFullName(env, "")
+	prefix := common.MachineFullName(env.Config().ControllerUUID(), "")
 	instances, err := env.gce.Instances(prefix, instStatuses...)
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/provider/gce/environ_instance_test.go
+++ b/provider/gce/environ_instance_test.go
@@ -116,7 +116,7 @@ func (s *environInstSuite) TestControllerInstancesAPI(c *gc.C) {
 
 	c.Check(s.FakeConn.Calls, gc.HasLen, 1)
 	c.Check(s.FakeConn.Calls[0].FuncName, gc.Equals, "Instances")
-	c.Check(s.FakeConn.Calls[0].Prefix, gc.Equals, s.Prefix+"machine-")
+	c.Check(s.FakeConn.Calls[0].Prefix, gc.Equals, "juju-"+s.Env.Config().ControllerUUID()+"-machine-")
 	c.Check(s.FakeConn.Calls[0].Statuses, jc.DeepEquals, []string{google.StatusPending, google.StatusStaging, google.StatusRunning})
 }
 

--- a/provider/gce/environ_network.go
+++ b/provider/gce/environ_network.go
@@ -12,7 +12,7 @@ import (
 
 // globalFirewallName returns the name to use for the global firewall.
 func (env *environ) globalFirewallName() string {
-	return common.EnvFullName(env)
+	return common.ModelFullName(env.uuid)
 }
 
 // OpenPorts opens the given port ranges for the whole environment.

--- a/provider/gce/environ_network.go
+++ b/provider/gce/environ_network.go
@@ -12,7 +12,7 @@ import (
 
 // globalFirewallName returns the name to use for the global firewall.
 func (env *environ) globalFirewallName() string {
-	return common.ModelFullName(env.uuid)
+	return common.EnvFullName(env.uuid)
 }
 
 // OpenPorts opens the given port ranges for the whole environment.

--- a/provider/gce/instance.go
+++ b/provider/gce/instance.go
@@ -72,7 +72,7 @@ func findInst(id instance.Id, instances []instance.Instance) instance.Instance {
 // should have been started with the given machine id.
 func (inst *environInstance) OpenPorts(machineID string, ports []network.PortRange) error {
 	// TODO(ericsnow) Make sure machineId matches inst.Id()?
-	name := common.MachineFullName(inst.env, machineID)
+	name := common.MachineFullName(inst.env.Config().UUID(), machineID)
 	env := inst.env.getSnapshot()
 	err := env.gce.OpenPorts(name, ports...)
 	return errors.Trace(err)
@@ -81,7 +81,7 @@ func (inst *environInstance) OpenPorts(machineID string, ports []network.PortRan
 // ClosePorts closes the given ports on the instance, which
 // should have been started with the given machine id.
 func (inst *environInstance) ClosePorts(machineID string, ports []network.PortRange) error {
-	name := common.MachineFullName(inst.env, machineID)
+	name := common.MachineFullName(inst.env.Config().UUID(), machineID)
 	env := inst.env.getSnapshot()
 	err := env.gce.ClosePorts(name, ports...)
 	return errors.Trace(err)
@@ -91,7 +91,7 @@ func (inst *environInstance) ClosePorts(machineID string, ports []network.PortRa
 // should have been started with the given machine id.
 // The ports are returned as sorted by SortPorts.
 func (inst *environInstance) Ports(machineID string) ([]network.PortRange, error) {
-	name := common.MachineFullName(inst.env, machineID)
+	name := common.MachineFullName(inst.env.Config().UUID(), machineID)
 	env := inst.env.getSnapshot()
 	ports, err := env.gce.Ports(name)
 	return ports, errors.Trace(err)

--- a/provider/gce/testing_test.go
+++ b/provider/gce/testing_test.go
@@ -64,14 +64,15 @@ var (
 }`, strings.Replace(PrivateKey, "\n", "\\n", -1), ClientEmail, ClientID)
 
 	ConfigAttrs = testing.FakeConfig().Merge(testing.Attrs{
-		"type":           "gce",
-		"private-key":    PrivateKey,
-		"client-id":      ClientID,
-		"client-email":   ClientEmail,
-		"region":         "home",
-		"project-id":     "my-juju",
-		"image-endpoint": "https://www.googleapis.com",
-		"uuid":           "2d02eeac-9dbb-11e4-89d3-123b93f75cba",
+		"type":            "gce",
+		"private-key":     PrivateKey,
+		"client-id":       ClientID,
+		"client-email":    ClientEmail,
+		"region":          "home",
+		"project-id":      "my-juju",
+		"image-endpoint":  "https://www.googleapis.com",
+		"uuid":            "2d02eeac-9dbb-11e4-89d3-123b93f75cba",
+		"controller-uuid": "bfef02f1-932a-425a-a102-62175dcabd1d",
 	})
 )
 

--- a/provider/lxd/environ_broker.go
+++ b/provider/lxd/environ_broker.go
@@ -94,7 +94,7 @@ func (env *environ) finishInstanceConfig(args environs.StartInstanceParams) erro
 // provisioned, relative to the provided args and spec. Info for that
 // low-level instance is returned.
 func (env *environ) newRawInstance(args environs.StartInstanceParams) (*lxdclient.Instance, error) {
-	machineID := common.MachineFullName(env, args.InstanceConfig.MachineId)
+	machineID := common.MachineFullName(env.Config().UUID(), args.InstanceConfig.MachineId)
 
 	series := args.Tools.OneSeries()
 	image := "ubuntu-" + series
@@ -220,7 +220,7 @@ func (env *environ) StopInstances(instances ...instance.Id) error {
 		ids = append(ids, string(id))
 	}
 
-	prefix := common.MachineFullName(env, "")
+	prefix := common.MachineFullName(env.Config().UUID(), "")
 	err := env.raw.RemoveInstances(prefix, ids...)
 	return errors.Trace(err)
 }

--- a/provider/lxd/environ_instance.go
+++ b/provider/lxd/environ_instance.go
@@ -71,7 +71,7 @@ var getInstances = func(env *environ) ([]instance.Instance, error) {
 func (env *environ) instances() ([]instance.Instance, error) {
 	env = env.getSnapshot()
 
-	prefix := common.MachineFullName(env, "")
+	prefix := common.MachineFullName(env.Config().UUID(), "")
 	instances, err := env.raw.Instances(prefix, instStatuses...)
 	err = errors.Trace(err)
 
@@ -94,7 +94,7 @@ func (env *environ) instances() ([]instance.Instance, error) {
 func (env *environ) ControllerInstances() ([]instance.Id, error) {
 	env = env.getSnapshot()
 
-	prefix := common.MachineFullName(env, "")
+	prefix := common.MachineFullName(env.Config().ControllerUUID(), "")
 	instances, err := env.raw.Instances(prefix, instStatuses...)
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/provider/lxd/environ_instance_test.go
+++ b/provider/lxd/environ_instance_test.go
@@ -100,6 +100,12 @@ func (s *environInstSuite) TestControllerInstancesOkay(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(ids, jc.DeepEquals, []instance.Id{"spam"})
+	s.BaseSuite.Client.CheckCallNames(c, "Instances")
+	s.BaseSuite.Client.CheckCall(
+		c, 0, "Instances",
+		"juju-"+s.Env.Config().ControllerUUID()+"-machine-",
+		[]string{"Starting", "Started", "Running"},
+	)
 }
 
 func (s *environInstSuite) TestControllerInstancesNotBootstrapped(c *gc.C) {

--- a/provider/lxd/environ_network.go
+++ b/provider/lxd/environ_network.go
@@ -14,7 +14,7 @@ import (
 
 // globalFirewallName returns the name to use for the global firewall.
 func (env *environ) globalFirewallName() string {
-	return common.ModelFullName(env.uuid)
+	return common.EnvFullName(env.uuid)
 }
 
 // OpenPorts opens the given port ranges for the whole environment.

--- a/provider/lxd/environ_network.go
+++ b/provider/lxd/environ_network.go
@@ -14,7 +14,7 @@ import (
 
 // globalFirewallName returns the name to use for the global firewall.
 func (env *environ) globalFirewallName() string {
-	return common.EnvFullName(env)
+	return common.ModelFullName(env.uuid)
 }
 
 // OpenPorts opens the given port ranges for the whole environment.

--- a/provider/lxd/instance.go
+++ b/provider/lxd/instance.go
@@ -75,7 +75,7 @@ func findInst(id instance.Id, instances []instance.Instance) instance.Instance {
 // should have been started with the given machine id.
 func (inst *environInstance) OpenPorts(machineID string, ports []network.PortRange) error {
 	// TODO(ericsnow) Make sure machineId matches inst.Id()?
-	name := common.MachineFullName(inst.env, machineID)
+	name := common.MachineFullName(inst.env.Config().UUID(), machineID)
 	env := inst.env.getSnapshot()
 	err := env.raw.OpenPorts(name, ports...)
 	if errors.IsNotImplemented(err) {
@@ -88,7 +88,7 @@ func (inst *environInstance) OpenPorts(machineID string, ports []network.PortRan
 // ClosePorts closes the given ports on the instance, which
 // should have been started with the given machine id.
 func (inst *environInstance) ClosePorts(machineID string, ports []network.PortRange) error {
-	name := common.MachineFullName(inst.env, machineID)
+	name := common.MachineFullName(inst.env.Config().UUID(), machineID)
 	env := inst.env.getSnapshot()
 	err := env.raw.ClosePorts(name, ports...)
 	if errors.IsNotImplemented(err) {
@@ -102,7 +102,7 @@ func (inst *environInstance) ClosePorts(machineID string, ports []network.PortRa
 // should have been started with the given machine id.
 // The ports are returned as sorted by SortPorts.
 func (inst *environInstance) Ports(machineID string) ([]network.PortRange, error) {
-	name := common.MachineFullName(inst.env, machineID)
+	name := common.MachineFullName(inst.env.Config().UUID(), machineID)
 	env := inst.env.getSnapshot()
 	ports, err := env.raw.Ports(name)
 	if errors.IsNotImplemented(err) {

--- a/provider/lxd/testing_test.go
+++ b/provider/lxd/testing_test.go
@@ -70,13 +70,14 @@ const (
 // These are stub config values for use in tests.
 var (
 	ConfigAttrs = testing.FakeConfig().Merge(testing.Attrs{
-		"type":        "lxd",
-		"namespace":   "",
-		"remote-url":  "",
-		"client-cert": "",
-		"client-key":  "",
-		"server-cert": "",
-		"uuid":        "2d02eeac-9dbb-11e4-89d3-123b93f75cba",
+		"type":            "lxd",
+		"namespace":       "",
+		"remote-url":      "",
+		"client-cert":     "",
+		"client-key":      "",
+		"server-cert":     "",
+		"uuid":            "2d02eeac-9dbb-11e4-89d3-123b93f75cba",
+		"controller-uuid": "bfef02f1-932a-425a-a102-62175dcabd1d",
 	})
 )
 
@@ -266,7 +267,7 @@ type BaseSuite struct {
 	BaseSuiteUnpatched
 
 	Stub       *gitjujutesting.Stub
-	Client     *stubClient
+	Client     *StubClient
 	Firewaller *stubFirewaller
 	Common     *stubCommon
 	Policy     *stubPolicy
@@ -279,7 +280,7 @@ func (s *BaseSuite) SetUpTest(c *gc.C) {
 	s.BaseSuiteUnpatched.SetUpTest(c)
 
 	s.Stub = &gitjujutesting.Stub{}
-	s.Client = &stubClient{stub: s.Stub}
+	s.Client = &StubClient{Stub: s.Stub}
 	s.Firewaller = &stubFirewaller{stub: s.Stub}
 	s.Common = &stubCommon{stub: s.Stub}
 	s.Policy = &stubPolicy{stub: s.Stub}
@@ -470,52 +471,52 @@ func (s *stubPolicy) SupportedArchitectures() ([]string, error) {
 	return s.Arches, nil
 }
 
-type stubClient struct {
-	stub *gitjujutesting.Stub
+type StubClient struct {
+	*gitjujutesting.Stub
 
 	Insts []lxdclient.Instance
 	Inst  *lxdclient.Instance
 }
 
-func (conn *stubClient) Instances(prefix string, statuses ...string) ([]lxdclient.Instance, error) {
-	conn.stub.AddCall("Instances", prefix, statuses)
-	if err := conn.stub.NextErr(); err != nil {
+func (conn *StubClient) Instances(prefix string, statuses ...string) ([]lxdclient.Instance, error) {
+	conn.AddCall("Instances", prefix, statuses)
+	if err := conn.NextErr(); err != nil {
 		return nil, errors.Trace(err)
 	}
 
 	return conn.Insts, nil
 }
 
-func (conn *stubClient) AddInstance(spec lxdclient.InstanceSpec) (*lxdclient.Instance, error) {
-	conn.stub.AddCall("AddInstance", spec)
-	if err := conn.stub.NextErr(); err != nil {
+func (conn *StubClient) AddInstance(spec lxdclient.InstanceSpec) (*lxdclient.Instance, error) {
+	conn.AddCall("AddInstance", spec)
+	if err := conn.NextErr(); err != nil {
 		return nil, errors.Trace(err)
 	}
 
 	return conn.Inst, nil
 }
 
-func (conn *stubClient) RemoveInstances(prefix string, ids ...string) error {
-	conn.stub.AddCall("RemoveInstances", prefix, ids)
-	if err := conn.stub.NextErr(); err != nil {
+func (conn *StubClient) RemoveInstances(prefix string, ids ...string) error {
+	conn.AddCall("RemoveInstances", prefix, ids)
+	if err := conn.NextErr(); err != nil {
 		return errors.Trace(err)
 	}
 
 	return nil
 }
 
-func (conn *stubClient) EnsureImageExists(series string, _ func(string)) error {
-	conn.stub.AddCall("EnsureImageExists", series)
-	if err := conn.stub.NextErr(); err != nil {
+func (conn *StubClient) EnsureImageExists(series string, _ func(string)) error {
+	conn.AddCall("EnsureImageExists", series)
+	if err := conn.NextErr(); err != nil {
 		return errors.Trace(err)
 	}
 
 	return nil
 }
 
-func (conn *stubClient) Addresses(name string) ([]network.Address, error) {
-	conn.stub.AddCall("Addresses", name)
-	if err := conn.stub.NextErr(); err != nil {
+func (conn *StubClient) Addresses(name string) ([]network.Address, error) {
+	conn.AddCall("Addresses", name)
+	if err := conn.NextErr(); err != nil {
 		return nil, errors.Trace(err)
 	}
 

--- a/provider/vsphere/environ_availzones_test.go
+++ b/provider/vsphere/environ_availzones_test.go
@@ -38,7 +38,7 @@ func (s *environAvailzonesSuite) TestAvailabilityZones(c *gc.C) {
 func (s *environAvailzonesSuite) TestInstanceAvailabilityZoneNames(c *gc.C) {
 	client := vsphere.ExposeEnvFakeClient(s.Env)
 	client.SetPropertyProxyHandler("FakeDatacenter", vsphere.RetrieveDatacenterProperties)
-	vmName := common.MachineFullName(s.Env, "1")
+	vmName := common.MachineFullName(s.Env.Config().UUID(), "1")
 	s.FakeInstancesWithResourcePool(client, vsphere.InstRp{Inst: vmName, Rp: "rp1"})
 	s.FakeAvailabilityZonesWithResourcePool(client, vsphere.ZoneRp{Zone: "z1", Rp: "rp1"}, vsphere.ZoneRp{Zone: "z2", Rp: "rp2"})
 

--- a/provider/vsphere/environ_broker.go
+++ b/provider/vsphere/environ_broker.go
@@ -84,7 +84,7 @@ func (env *environ) finishMachineConfig(args environs.StartInstanceParams, img *
 // provisioned, relative to the provided args and spec. Info for that
 // low-level instance is returned.
 func (env *environ) newRawInstance(args environs.StartInstanceParams, img *OvaFileMetadata) (*mo.VirtualMachine, *instance.HardwareCharacteristics, error) {
-	machineID := common.MachineFullName(env, args.InstanceConfig.MachineId)
+	machineID := common.MachineFullName(env.Config().UUID(), args.InstanceConfig.MachineId)
 
 	cloudcfg, err := cloudinit.New(args.Tools.OneSeries())
 	if err != nil {

--- a/provider/vsphere/environ_instance.go
+++ b/provider/vsphere/environ_instance.go
@@ -64,7 +64,7 @@ func (env *environ) Instances(ids []instance.Id) ([]instance.Instance, error) {
 func (env *environ) instances() ([]instance.Instance, error) {
 	env = env.getSnapshot()
 
-	prefix := common.MachineFullName(env, "")
+	prefix := common.MachineFullName(env.Config().UUID(), "")
 	instances, err := env.client.Instances(prefix)
 	err = errors.Trace(err)
 
@@ -84,7 +84,7 @@ func (env *environ) instances() ([]instance.Instance, error) {
 func (env *environ) ControllerInstances() ([]instance.Id, error) {
 	env = env.getSnapshot()
 
-	prefix := common.MachineFullName(env, "")
+	prefix := common.MachineFullName(env.Config().ControllerUUID(), "")
 	instances, err := env.client.Instances(prefix)
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/provider/vsphere/environ_instance_test.go
+++ b/provider/vsphere/environ_instance_test.go
@@ -28,8 +28,8 @@ func (s *environInstanceSuite) SetUpTest(c *gc.C) {
 func (s *environAvailzonesSuite) TestInstances(c *gc.C) {
 	client := vsphere.ExposeEnvFakeClient(s.Env)
 	client.SetPropertyProxyHandler("FakeDatacenter", vsphere.RetrieveDatacenterProperties)
-	vmName1 := common.MachineFullName(s.Env, "1")
-	vmName2 := common.MachineFullName(s.Env, "2")
+	vmName1 := common.MachineFullName(s.Env.Config().UUID(), "1")
+	vmName2 := common.MachineFullName(s.Env.Config().UUID(), "2")
 	s.FakeInstancesWithResourcePool(client, vsphere.InstRp{Inst: vmName1, Rp: "rp1"}, vsphere.InstRp{Inst: vmName2, Rp: "rp2"})
 
 	instances, err := s.Env.Instances([]instance.Id{instance.Id(vmName1), instance.Id(vmName2)})
@@ -53,8 +53,8 @@ func (s *environAvailzonesSuite) TestInstancesReturnNoInstances(c *gc.C) {
 func (s *environAvailzonesSuite) TestInstancesReturnPartialInstances(c *gc.C) {
 	client := vsphere.ExposeEnvFakeClient(s.Env)
 	client.SetPropertyProxyHandler("FakeDatacenter", vsphere.RetrieveDatacenterProperties)
-	vmName1 := common.MachineFullName(s.Env, "1")
-	vmName2 := common.MachineFullName(s.Env, "2")
+	vmName1 := common.MachineFullName(s.Env.Config().UUID(), "1")
+	vmName2 := common.MachineFullName(s.Env.Config().UUID(), "2")
 	s.FakeInstancesWithResourcePool(client, vsphere.InstRp{Inst: vmName1, Rp: "rp1"}, vsphere.InstRp{Inst: "Some inst", Rp: "rp2"})
 
 	_, err := s.Env.Instances([]instance.Id{instance.Id(vmName1), instance.Id(vmName2)})


### PR DESCRIPTION
In ControllerInstances, use controller-uuid rather than
uuid to filter machines. Controllers are always created
with uuid==controller-uuid, but ControllerInstances may
be called on an Environ with uuid!=controller-uuid.

(Review request: http://reviews.vapour.ws/r/4261/)