### PR TITLE
Do a better job of restoring current controller/model/account info on failed bootstrap

### DIFF
--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -382,7 +382,7 @@ func (c *bootstrapCommand) Run(ctx *cmd.Context) (resultErr error) {
 		}
 		if err := store.RemoveController(c.controllerName); err != nil {
 			logger.Warningf(
-				"cannot destroy newly created controller details %q info: %v",
+				"cannot destroy newly created controller %q details: %v",
 				c.controllerName, err,
 			)
 		}

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -382,7 +382,7 @@ func (c *bootstrapCommand) Run(ctx *cmd.Context) (resultErr error) {
 		}
 		if err := store.RemoveController(c.controllerName); err != nil {
 			logger.Warningf(
-				"cannot destroy newly created controller metadata info %q info: %v",
+				"cannot destroy newly created controller details %q info: %v",
 				c.controllerName, err,
 			)
 		}

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -364,7 +364,7 @@ func (c *bootstrapCommand) Run(ctx *cmd.Context) (resultErr error) {
 	// Read existing current controller, account, model so we can clean up on error.
 	var oldCurrentController, oldCurrentAccount, oldCurrentModel string
 	oldCurrentController, err = modelcmd.ReadCurrentController()
-	if err != nil && !errors.IsNotFound(err) {
+	if err != nil {
 		return errors.Annotate(err, "error reading current controller")
 	}
 	if oldCurrentController != "" {
@@ -381,7 +381,7 @@ func (c *bootstrapCommand) Run(ctx *cmd.Context) (resultErr error) {
 	}
 
 	defer func() {
-		if resultErr == nil {
+		if resultErr == nil || errors.IsAlreadyExists(resultErr) {
 			return
 		}
 		if err := store.RemoveController(c.controllerName); err != nil {
@@ -393,7 +393,7 @@ func (c *bootstrapCommand) Run(ctx *cmd.Context) (resultErr error) {
 		if oldCurrentModel != "" {
 			if err := store.SetCurrentModel(oldCurrentController, oldCurrentAccount, oldCurrentModel); err != nil {
 				logger.Warningf(
-					"cannot restore old controller model metadata %q: %v",
+					"cannot reset current model to %q: %v",
 					oldCurrentModel, err,
 				)
 			}
@@ -401,7 +401,7 @@ func (c *bootstrapCommand) Run(ctx *cmd.Context) (resultErr error) {
 		if oldCurrentAccount != "" {
 			if err := store.SetCurrentAccount(oldCurrentController, oldCurrentAccount); err != nil {
 				logger.Warningf(
-					"cannot restore old controller account metadata %q: %v",
+					"cannot reset current account to %q: %v",
 					oldCurrentAccount, err,
 				)
 			}
@@ -409,7 +409,7 @@ func (c *bootstrapCommand) Run(ctx *cmd.Context) (resultErr error) {
 		if oldCurrentController != "" {
 			if err := modelcmd.WriteCurrentController(oldCurrentController); err != nil {
 				logger.Warningf(
-					"cannot restore old controller metadata %q: %v",
+					"cannot reset current controller to %q: %v",
 					oldCurrentController, err,
 				)
 			}


### PR DESCRIPTION
Move the deferred cleanup function to before the environs.Prepare call.
We also restore any previous current controller, account, and model names.

It's not perfect - the saving and restore of current controller/model/account is not atomic, and neither is the restore. But it covers cases where a bootstrap fails and we may be left with invalid info.

(Review request: http://reviews.vapour.ws/r/4262/)