### PR TITLE
Implement local macaroon logins

### DIFF
--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -24,6 +24,7 @@ import (
 	"github.com/juju/version"
 	"golang.org/x/net/websocket"
 	"gopkg.in/macaroon-bakery.v1/httpbakery"
+	"gopkg.in/macaroon.v1"
 
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/apiserver/params"
@@ -132,11 +133,14 @@ func Open(info *Info, opts DialOpts) (Connection, error) {
 // This unexported open method is used both directly above in the Open
 // function, and also the OpenWithVersion function below to explicitly cause
 // the API server to think that the client is older than it really is.
-func open(info *Info, opts DialOpts, loginFunc func(st *state, tag names.Tag, pwd, nonce string) error) (Connection, error) {
-	if info.UseMacaroons {
-		if info.Tag != nil || info.Password != "" {
-			return nil, errors.New("open should specifiy UseMacaroons or a username & password. Not both")
-		}
+func open(
+	info *Info,
+	opts DialOpts,
+	loginFunc func(st *state, tag names.Tag, pwd, nonce string, ms []macaroon.Slice) error,
+) (Connection, error) {
+
+	if err := info.Validate(); err != nil {
+		return nil, errors.Annotate(err, "validating info for opening an API connection")
 	}
 	conn, tlsConfig, err := connectWebsocket(info, opts)
 	if err != nil {
@@ -183,8 +187,8 @@ func open(info *Info, opts DialOpts, loginFunc func(st *state, tag names.Tag, pw
 		tlsConfig:    tlsConfig,
 		bakeryClient: bakeryClient,
 	}
-	if info.Tag != nil || info.Password != "" || info.UseMacaroons {
-		if err := loginFunc(st, info.Tag, info.Password, info.Nonce); err != nil {
+	if !info.SkipLogin {
+		if err := loginFunc(st, info.Tag, info.Password, info.Nonce, info.Macaroons); err != nil {
 			conn.Close()
 			return nil, err
 		}
@@ -219,7 +223,7 @@ func (t *hostSwitchingTransport) RoundTrip(req *http.Request) (*http.Response, e
 // on. This allows the caller to pretend to be an older client, and is used
 // only in testing.
 func OpenWithVersion(info *Info, opts DialOpts, loginVersion int) (Connection, error) {
-	var loginFunc func(st *state, tag names.Tag, pwd, nonce string) error
+	var loginFunc func(st *state, tag names.Tag, pwd, nonce string, ms []macaroon.Slice) error
 	switch loginVersion {
 	case 2:
 		loginFunc = (*state).loginV2
@@ -241,11 +245,19 @@ func connectWebsocket(info *Info, opts DialOpts) (*websocket.Conn, *tls.Config, 
 	if len(info.Addrs) == 0 {
 		return nil, nil, errors.New("no API addresses to connect to")
 	}
-	tlsConfig, err := tlsConfigForCACert(info.CACert)
-	if err != nil {
-		return nil, nil, errors.Annotatef(err, "cannot make TLS configuration")
+	tlsConfig := &tls.Config{
+		// We want to be specific here (rather than just using "anything".
+		// See commit 7fc118f015d8480dfad7831788e4b8c0432205e8 (PR 899).
+		ServerName:         "juju-apiserver",
+		InsecureSkipVerify: opts.InsecureSkipVerify,
 	}
-	tlsConfig.InsecureSkipVerify = opts.InsecureSkipVerify
+	if !tlsConfig.InsecureSkipVerify {
+		certPool, err := CreateCertPool(info.CACert)
+		if err != nil {
+			return nil, nil, errors.Annotate(err, "cert pool creation failed")
+		}
+		tlsConfig.RootCAs = certPool
+	}
 	path := "/"
 	if info.ModelTag.Id() != "" {
 		path = apiPath(info.ModelTag, "/api")
@@ -256,19 +268,6 @@ func connectWebsocket(info *Info, opts DialOpts) (*websocket.Conn, *tls.Config, 
 	}
 	logger.Infof("connection established to %q", conn.RemoteAddr())
 	return conn, tlsConfig, nil
-}
-
-func tlsConfigForCACert(caCert string) (*tls.Config, error) {
-	certPool, err := CreateCertPool(caCert)
-	if err != nil {
-		return nil, errors.Annotate(err, "cert pool creation failed")
-	}
-	return &tls.Config{
-		RootCAs: certPool,
-		// We want to be specific here (rather than just using "anything".
-		// See commit 7fc118f015d8480dfad7831788e4b8c0432205e8 (PR 899).
-		ServerName: "juju-apiserver",
-	}, nil
 }
 
 // dialWebSocket dials a websocket with one of the provided addresses, the

--- a/api/apiclient_test.go
+++ b/api/apiclient_test.go
@@ -28,14 +28,6 @@ type apiclientSuite struct {
 
 var _ = gc.Suite(&apiclientSuite{})
 
-func (s *apiclientSuite) TestOpenFailsIfUsernameAndUseMacaroon(c *gc.C) {
-	info := s.APIInfo(c)
-	info.Tag = names.NewUserTag("foobar")
-	info.UseMacaroons = true
-	_, err := api.Open(info, api.DialOpts{})
-	c.Assert(err, gc.ErrorMatches, "open should specifiy UseMacaroons or a username & password. Not both")
-}
-
 func (s *apiclientSuite) TestConnectWebsocketToEnv(c *gc.C) {
 	info := s.APIInfo(c)
 	conn, _, err := api.ConnectWebsocket(info, api.DialOpts{})

--- a/api/interface.go
+++ b/api/interface.go
@@ -6,9 +6,11 @@ package api
 import (
 	"time"
 
+	"github.com/juju/errors"
 	"github.com/juju/names"
 	"github.com/juju/version"
 	"gopkg.in/macaroon-bakery.v1/httpbakery"
+	"gopkg.in/macaroon.v1"
 
 	"github.com/juju/juju/api/addresser"
 	"github.com/juju/juju/api/agent"
@@ -50,9 +52,9 @@ type Info struct {
 	// ...but this block of fields is all about the authentication mechanism
 	// to use after connecting -- if any -- and should probably be extracted.
 
-	// UseMacaroons, when true, enables macaroon-based login and ignores
-	// the provided username and password.
-	UseMacaroons bool `yaml:"use-macaroons,omitempty"`
+	// SkipLogin, if true, skips the Login call on connection. It is an
+	// error to set Tag, Password, or Macaroons if SkipLogin is true.
+	SkipLogin bool `yaml:"-"`
 
 	// Tag holds the name of the entity that is connecting.
 	// If this is nil, and the password is empty, no login attempt will be made.
@@ -63,9 +65,35 @@ type Info struct {
 	// Password holds the password for the administrator or connecting entity.
 	Password string
 
+	// Macaroons holds a slice of macaroon.Slice that may be used to
+	// authenticate with the API server.
+	Macaroons []macaroon.Slice `yaml:",omitempty"`
+
 	// Nonce holds the nonce used when provisioning the machine. Used
 	// only by the machine agent.
 	Nonce string `yaml:",omitempty"`
+}
+
+// Validate validates the API info.
+func (info *Info) Validate() error {
+	if len(info.Addrs) == 0 {
+		return errors.NotValidf("missing addresses")
+	}
+	if info.CACert == "" {
+		return errors.NotValidf("missing CA certificate")
+	}
+	if info.SkipLogin {
+		if info.Tag != nil {
+			return errors.NotValidf("specifying Tag and SkipLogin")
+		}
+		if info.Password != "" {
+			return errors.NotValidf("specifying Password and SkipLogin")
+		}
+		if len(info.Macaroons) > 0 {
+			return errors.NotValidf("specifying Macaroons and SkipLogin")
+		}
+	}
+	return nil
 }
 
 // DialOpts holds configuration parameters that control the
@@ -125,7 +153,7 @@ type Connection interface {
 
 	// These are a bit off -- ServerVersion is apparently not known until after
 	// Login()? Maybe evidence of need for a separate AuthenticatedConnection..?
-	Login(name names.Tag, password, nonce string) error
+	Login(name names.Tag, password, nonce string, ms []macaroon.Slice) error
 	ServerVersion() (version.Number, bool)
 
 	// APICaller provides the facility to make API calls directly.

--- a/api/state.go
+++ b/api/state.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/names"
 	"github.com/juju/version"
 	"gopkg.in/macaroon-bakery.v1/httpbakery"
+	"gopkg.in/macaroon.v1"
 
 	"github.com/juju/juju/api/addresser"
 	"github.com/juju/juju/api/agent"
@@ -33,34 +34,39 @@ import (
 	"github.com/juju/juju/network"
 )
 
-// Login authenticates as the entity with the given name and password.
-// Subsequent requests on the state will act as that entity.  This
-// method is usually called automatically by Open. The machine nonce
+// Login authenticates as the entity with the given name and password
+// or macaroons. Subsequent requests on the state will act as that entity.
+// This method is usually called automatically by Open. The machine nonce
 // should be empty unless logging in as a machine agent.
-func (st *state) Login(tag names.Tag, password, nonce string) error {
-	err := st.loginV3(tag, password, nonce)
+func (st *state) Login(tag names.Tag, password, nonce string, ms []macaroon.Slice) error {
+	// TODO(axw) accept and pass on macaroons
+	err := st.loginV3(tag, password, nonce, ms)
 	return errors.Trace(err)
 }
 
 // loginV2 is retained for testing logins from older clients.
-func (st *state) loginV2(tag names.Tag, password, nonce string) error {
-	return st.loginForVersion(tag, password, nonce, 2)
+func (st *state) loginV2(tag names.Tag, password, nonce string, ms []macaroon.Slice) error {
+	return st.loginForVersion(tag, password, nonce, ms, 2)
 }
 
-func (st *state) loginV3(tag names.Tag, password, nonce string) error {
-	return st.loginForVersion(tag, password, nonce, 3)
+func (st *state) loginV3(tag names.Tag, password, nonce string, ms []macaroon.Slice) error {
+	return st.loginForVersion(tag, password, nonce, ms, 3)
 }
 
-func (st *state) loginForVersion(tag names.Tag, password, nonce string, vers int) error {
+func (st *state) loginForVersion(tag names.Tag, password, nonce string, macaroons []macaroon.Slice, vers int) error {
 	var result params.LoginResultV1
 	request := &params.LoginRequest{
 		AuthTag:     tagToString(tag),
 		Credentials: password,
 		Nonce:       nonce,
+		Macaroons:   macaroons,
 	}
 	if tag == nil {
-		// Add any macaroons that might work for authenticating the login request.
-		request.Macaroons = httpbakery.MacaroonsForURL(st.bakeryClient.Client.Jar, st.cookieURL)
+		// Add any macaroons from the cookie jar that might work for
+		// authenticating the login request.
+		request.Macaroons = append(request.Macaroons,
+			httpbakery.MacaroonsForURL(st.bakeryClient.Client.Jar, st.cookieURL)...,
+		)
 	}
 	err := st.APICall("Admin", vers, "", "Login", request, &result)
 	if err != nil {

--- a/api/state_macaroon_test.go
+++ b/api/state_macaroon_test.go
@@ -28,8 +28,7 @@ func (s *macaroonLoginSuite) SetUpTest(c *gc.C) {
 	s.MacaroonSuite.SetUpTest(c)
 	s.AddModelUser(c, testUserName)
 	info := s.APIInfo(c)
-	// Don't log in.
-	info.UseMacaroons = false
+	info.SkipLogin = true
 	s.client = s.OpenAPI(c, info, nil)
 }
 
@@ -40,12 +39,12 @@ func (s *macaroonLoginSuite) TearDownTest(c *gc.C) {
 
 func (s *macaroonLoginSuite) TestSuccessfulLogin(c *gc.C) {
 	s.DischargerLogin = func() string { return testUserName }
-	err := s.client.Login(nil, "", "")
+	err := s.client.Login(nil, "", "", nil)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *macaroonLoginSuite) TestFailedToObtainDischargeLogin(c *gc.C) {
-	err := s.client.Login(nil, "", "")
+	err := s.client.Login(nil, "", "", nil)
 	c.Assert(err, gc.ErrorMatches, `cannot get discharge from "https://.*": third party refused discharge: cannot discharge: login denied by discharger`)
 }
 
@@ -53,7 +52,7 @@ func (s *macaroonLoginSuite) TestUnknownUserLogin(c *gc.C) {
 	s.DischargerLogin = func() string {
 		return "testUnknown"
 	}
-	err := s.client.Login(nil, "", "")
+	err := s.client.Login(nil, "", "", nil)
 	c.Assert(errors.Cause(err), gc.DeepEquals, &rpc.RequestError{
 		Message: "invalid entity name or password",
 		Code:    "unauthorized access",
@@ -69,7 +68,7 @@ func (s *macaroonLoginSuite) TestConnectStream(c *gc.C) {
 		return testUserName
 	}
 	// First log into the regular API.
-	err := s.client.Login(nil, "", "")
+	err := s.client.Login(nil, "", "", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(dischargeCount, gc.Equals, 1)
 

--- a/api/state_test.go
+++ b/api/state_test.go
@@ -118,14 +118,14 @@ func (s *stateSuite) TestLoginMacaroonInvalidId(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "verification failed: macaroon not found in storage")
 }
 
-func (s *stateSuite) TestLoginInvalidUser(c *gc.C) {
+func (s *stateSuite) TestLoginMacaroonInvalidUser(c *gc.C) {
 	apistate, tag, _ := s.OpenAPIWithoutLogin(c)
 	defer apistate.Close()
 	// Use s.APIState, because we can't get at UserManager without logging in.
 	mac, err := usermanager.NewClient(s.APIState).CreateLocalLoginMacaroon(tag.(names.UserTag))
 	c.Assert(err, jc.ErrorIsNil)
 	err = apistate.Login(names.NewUserTag("bob@local"), "", "", []macaroon.Slice{{mac}})
-	c.Assert(err, gc.ErrorMatches, "verification failed: macaroon not found in storage")
+	c.Assert(err, gc.ErrorMatches, `verification failed: caveat "declared username admin@local" not satisfied: got username="bob@local", expected "admin@local"`)
 }
 
 func (s *stateSuite) TestLoginTracksFacadeVersions(c *gc.C) {

--- a/api/state_test.go
+++ b/api/state_test.go
@@ -47,6 +47,8 @@ func (s *stateSuite) OpenAPIWithoutLogin(c *gc.C) (api.Connection, names.Tag, st
 	password := info.Password
 	info.Tag = nil
 	info.Password = ""
+	info.Macaroons = nil
+	info.SkipLogin = true
 	apistate, err := api.Open(info, api.DialOpts{})
 	c.Assert(err, jc.ErrorIsNil)
 	return apistate, tag, password
@@ -82,7 +84,7 @@ func (s *stateSuite) TestLoginSetsModelTag(c *gc.C) {
 	modelTag, err := apistate.ModelTag()
 	c.Check(err, gc.ErrorMatches, `"" is not a valid tag`)
 	c.Check(modelTag, gc.Equals, names.ModelTag{})
-	err = apistate.Login(tag, password, "")
+	err = apistate.Login(tag, password, "", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	// Now that we've logged in, ModelTag should be updated correctly.
 	modelTag, err = apistate.ModelTag()
@@ -100,7 +102,7 @@ func (s *stateSuite) TestLoginTracksFacadeVersions(c *gc.C) {
 	defer apistate.Close()
 	// We haven't called Login yet, so the Facade Versions should be empty
 	c.Check(apistate.AllFacadeVersions(), gc.HasLen, 0)
-	err := apistate.Login(tag, password, "")
+	err := apistate.Login(tag, password, "", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	// Now that we've logged in, AllFacadeVersions should be updated.
 	allVersions := apistate.AllFacadeVersions()

--- a/api/testing/macaroonsuite.go
+++ b/api/testing/macaroonsuite.go
@@ -100,7 +100,6 @@ func (s *MacaroonSuite) APIInfo(c *gc.C) *api.Info {
 	info := s.JujuConnSuite.APIInfo(c)
 	info.Tag = nil
 	info.Password = ""
-	info.UseMacaroons = true
 	return info
 }
 

--- a/apiserver/admin_test.go
+++ b/apiserver/admin_test.go
@@ -79,8 +79,8 @@ func (s *loginSuite) TestLoginWithInvalidTag(c *gc.C) {
 	info := s.APIInfo(c)
 	info.Tag = nil
 	info.Password = ""
-	st, err := api.Open(info, api.DialOpts{})
-	c.Assert(err, jc.ErrorIsNil)
+	st := s.openAPIWithoutLogin(c, info)
+	defer st.Close()
 
 	request := &params.LoginRequest{
 		AuthTag:     "bar",
@@ -88,7 +88,7 @@ func (s *loginSuite) TestLoginWithInvalidTag(c *gc.C) {
 	}
 
 	var response params.LoginResult
-	err = st.APICall("Admin", 3, "", "Login", request, &response)
+	err := st.APICall("Admin", 3, "", "Login", request, &response)
 	c.Assert(err, gc.ErrorMatches, `.*"bar" is not a valid tag.*`)
 }
 
@@ -124,25 +124,20 @@ func (s *loginSuite) TestBadLogin(c *gc.C) {
 		code: params.CodeUnauthorized,
 	}} {
 		c.Logf("test %d; entity %q; password %q", i, t.tag, t.password)
-		// Note that Open does not log in if the tag and password
-		// are empty. This allows us to test operations on the connection
-		// before calling Login, which we could not do if Open
-		// always logged in.
-		info.Tag = nil
-		info.Password = ""
 		func() {
-			st, err := api.Open(info, fastDialOpts)
-			c.Assert(err, jc.ErrorIsNil)
+			// Open the API without logging in, so we can perform
+			// operations on the connection before calling Login.
+			st := s.openAPIWithoutLogin(c, info)
 			defer st.Close()
 
-			_, err = st.Machiner().Machine(names.NewMachineTag("0"))
+			_, err := st.Machiner().Machine(names.NewMachineTag("0"))
 			c.Assert(errors.Cause(err), gc.DeepEquals, &rpc.RequestError{
 				Message: `unknown object type "Machiner"`,
 				Code:    "not implemented",
 			})
 
 			// Since these are user login tests, the nonce is empty.
-			err = st.Login(t.tag, t.password, "")
+			err = st.Login(t.tag, t.password, "", nil)
 			c.Assert(errors.Cause(err), gc.DeepEquals, t.err)
 			c.Assert(params.ErrCode(err), gc.Equals, t.code)
 
@@ -159,22 +154,19 @@ func (s *loginSuite) TestLoginAsDeactivatedUser(c *gc.C) {
 	info, cleanup := s.setupServerWithValidator(c, nil)
 	defer cleanup()
 
-	info.Tag = nil
-	info.Password = ""
-	st, err := api.Open(info, fastDialOpts)
-	c.Assert(err, jc.ErrorIsNil)
+	st := s.openAPIWithoutLogin(c, info)
 	defer st.Close()
 	password := "password"
 	u := s.Factory.MakeUser(c, &factory.UserParams{Password: password, Disabled: true})
 
-	_, err = st.Client().Status([]string{})
+	_, err := st.Client().Status([]string{})
 	c.Assert(errors.Cause(err), gc.DeepEquals, &rpc.RequestError{
 		Message: `unknown object type "Client"`,
 		Code:    "not implemented",
 	})
 
 	// Since these are user login tests, the nonce is empty.
-	err = st.Login(u.Tag(), password, "")
+	err = st.Login(u.Tag(), password, "", nil)
 	c.Assert(errors.Cause(err), gc.DeepEquals, &rpc.RequestError{
 		Message: "invalid entity name or password",
 		Code:    "unauthorized access",
@@ -542,7 +534,7 @@ func (s *loginSuite) TestFailedLoginDuringMaintenance(c *gc.C) {
 	checkLogin := func(tag names.Tag) {
 		st := s.openAPIWithoutLogin(c, info)
 		defer st.Close()
-		err := st.Login(tag, "dummy-secret", "nonce")
+		err := st.Login(tag, "dummy-secret", "nonce", nil)
 		c.Assert(err, gc.ErrorMatches, "something")
 	}
 	checkLogin(names.NewUserTag("definitelywontexist"))
@@ -567,7 +559,7 @@ func (s *baseLoginSuite) checkLoginWithValidator(c *gc.C, validator apiserver.Lo
 
 	adminUser := s.AdminUserTag(c)
 	// Since these are user login tests, the nonce is empty.
-	err = st.Login(adminUser, "dummy-secret", "")
+	err = st.Login(adminUser, "dummy-secret", "", nil)
 
 	checker(c, err, st)
 }
@@ -611,6 +603,7 @@ func (s *baseLoginSuite) setupServerForEnvironmentWithValidator(c *gc.C, modelTa
 func (s *baseLoginSuite) openAPIWithoutLogin(c *gc.C, info *api.Info) api.Connection {
 	info.Tag = nil
 	info.Password = ""
+	info.SkipLogin = true
 	st, err := api.Open(info, fastDialOpts)
 	c.Assert(err, jc.ErrorIsNil)
 	return st
@@ -621,12 +614,11 @@ func (s *loginSuite) TestControllerModel(c *gc.C) {
 	defer cleanup()
 
 	c.Assert(info.ModelTag, gc.Equals, s.State.ModelTag())
-	st, err := api.Open(info, fastDialOpts)
-	c.Assert(err, jc.ErrorIsNil)
+	st := s.openAPIWithoutLogin(c, info)
 	defer st.Close()
 
 	adminUser := s.AdminUserTag(c)
-	err = st.Login(adminUser, "dummy-secret", "")
+	err := st.Login(adminUser, "dummy-secret", "", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.assertRemoteEnvironment(c, st, s.State.ModelTag())
@@ -637,12 +629,11 @@ func (s *loginSuite) TestControllerModelBadCreds(c *gc.C) {
 	defer cleanup()
 
 	c.Assert(info.ModelTag, gc.Equals, s.State.ModelTag())
-	st, err := api.Open(info, fastDialOpts)
-	c.Assert(err, jc.ErrorIsNil)
+	st := s.openAPIWithoutLogin(c, info)
 	defer st.Close()
 
 	adminUser := s.AdminUserTag(c)
-	err = st.Login(adminUser, "bad-password", "")
+	err := st.Login(adminUser, "bad-password", "", nil)
 	c.Assert(errors.Cause(err), gc.DeepEquals, &rpc.RequestError{
 		Message: `invalid entity name or password`,
 		Code:    "unauthorized access",
@@ -656,12 +647,11 @@ func (s *loginSuite) TestNonExistentEnvironment(c *gc.C) {
 	uuid, err := utils.NewUUID()
 	c.Assert(err, jc.ErrorIsNil)
 	info.ModelTag = names.NewModelTag(uuid.String())
-	st, err := api.Open(info, fastDialOpts)
-	c.Assert(err, jc.ErrorIsNil)
+	st := s.openAPIWithoutLogin(c, info)
 	defer st.Close()
 
 	adminUser := s.AdminUserTag(c)
-	err = st.Login(adminUser, "dummy-secret", "")
+	err = st.Login(adminUser, "dummy-secret", "", nil)
 	c.Assert(errors.Cause(err), gc.DeepEquals, &rpc.RequestError{
 		Message: fmt.Sprintf("unknown model: %q", uuid),
 		Code:    "not found",
@@ -673,12 +663,11 @@ func (s *loginSuite) TestInvalidEnvironment(c *gc.C) {
 	defer cleanup()
 
 	info.ModelTag = names.NewModelTag("rubbish")
-	st, err := api.Open(info, fastDialOpts)
-	c.Assert(err, jc.ErrorIsNil)
+	st := s.openAPIWithoutLogin(c, info)
 	defer st.Close()
 
 	adminUser := s.AdminUserTag(c)
-	err = st.Login(adminUser, "dummy-secret", "")
+	err := st.Login(adminUser, "dummy-secret", "", nil)
 	c.Assert(errors.Cause(err), gc.DeepEquals, &rpc.RequestError{
 		Message: `unknown model: "rubbish"`,
 		Code:    "not found",
@@ -695,11 +684,10 @@ func (s *loginSuite) TestOtherEnvironment(c *gc.C) {
 	})
 	defer envState.Close()
 	info.ModelTag = envState.ModelTag()
-	st, err := api.Open(info, fastDialOpts)
-	c.Assert(err, jc.ErrorIsNil)
+	st := s.openAPIWithoutLogin(c, info)
 	defer st.Close()
 
-	err = st.Login(envOwner.UserTag(), "password", "")
+	err := st.Login(envOwner.UserTag(), "password", "", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertRemoteEnvironment(c, st, envState.ModelTag())
 }
@@ -727,11 +715,10 @@ func (s *loginSuite) TestMachineLoginOtherEnvironment(c *gc.C) {
 	})
 
 	info.ModelTag = envState.ModelTag()
-	st, err := api.Open(info, fastDialOpts)
-	c.Assert(err, jc.ErrorIsNil)
+	st := s.openAPIWithoutLogin(c, info)
 	defer st.Close()
 
-	err = st.Login(machine.Tag(), password, "nonce")
+	err := st.Login(machine.Tag(), password, "nonce", nil)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -746,11 +733,10 @@ func (s *loginSuite) TestOtherEnvironmentFromController(c *gc.C) {
 	envState := s.Factory.MakeModel(c, nil)
 	defer envState.Close()
 	info.ModelTag = envState.ModelTag()
-	st, err := api.Open(info, fastDialOpts)
-	c.Assert(err, jc.ErrorIsNil)
+	st := s.openAPIWithoutLogin(c, info)
 	defer st.Close()
 
-	err = st.Login(machine.Tag(), password, "nonce")
+	err := st.Login(machine.Tag(), password, "nonce", nil)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -763,11 +749,10 @@ func (s *loginSuite) TestOtherEnvironmentWhenNotController(c *gc.C) {
 	envState := s.Factory.MakeModel(c, nil)
 	defer envState.Close()
 	info.ModelTag = envState.ModelTag()
-	st, err := api.Open(info, fastDialOpts)
-	c.Assert(err, jc.ErrorIsNil)
+	st := s.openAPIWithoutLogin(c, info)
 	defer st.Close()
 
-	err = st.Login(machine.Tag(), password, "nonce")
+	err := st.Login(machine.Tag(), password, "nonce", nil)
 	c.Assert(errors.Cause(err), gc.DeepEquals, &rpc.RequestError{
 		Message: "invalid entity name or password",
 		Code:    "unauthorized access",

--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -201,7 +201,10 @@ func newServer(s *state.State, lis *net.TCPListener, cfg ServerConfig) (_ *Serve
 			3: newAdminApiV3,
 		},
 	}
-	srv.authCtxt = newAuthContext(srv)
+	srv.authCtxt, err = newAuthContext(s)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	go srv.run()
 	return srv, nil
 }

--- a/apiserver/authcontext.go
+++ b/apiserver/authcontext.go
@@ -97,7 +97,8 @@ func (ctxt *authContext) macaroonAuth() (authentication.EntityAuthenticator, err
 var errMacaroonAuthNotConfigured = errors.New("macaroon authentication is not configured")
 
 // newExternalMacaroonAuth returns an authenticator that can authenticate
-// macaroon-based logins. This is just a helper function for authCtxt.macaroonAuth.
+// macaroon-based logins for external users. This is just a helper function
+// for authCtxt.macaroonAuth.
 func newExternalMacaroonAuth(st *state.State) (*authentication.ExternalMacaroonAuthenticator, error) {
 	envCfg, err := st.ModelConfig()
 	if err != nil {

--- a/apiserver/authentication/user.go
+++ b/apiserver/authentication/user.go
@@ -17,29 +17,101 @@ import (
 	"github.com/juju/juju/state"
 )
 
-// UserAuthenticator performs password based authentication for users.
+// UserAuthenticator performs authentication for local users. If a password
 type UserAuthenticator struct {
 	AgentAuthenticator
+
+	// Service holds the service that is used to mint and verify macaroons.
+	Service *bakery.Service
 }
 
-const usernameKey = "username"
+const (
+	usernameKey = "username"
+
+	// TODO(axw) make this configurable via model config.
+	localLoginExpiryTime = 24 * time.Hour
+
+	// TODO(axw) check with cmars about this time limit. Seems a bit
+	// too low. Are we prompting the user every hour, or just refreshing
+	// the token every hour until the external IdM requires prompting
+	// the user?
+	externalLoginExpiryTime = 1 * time.Hour
+)
 
 var _ EntityAuthenticator = (*UserAuthenticator)(nil)
 
-// Authenticate authenticates the provided entity and returns an error on authentication failure.
-func (u *UserAuthenticator) Authenticate(entityFinder EntityFinder, tag names.Tag, req params.LoginRequest) (state.Entity, error) {
-	if tag.Kind() != names.UserTagKind {
+// Authenticate authenticates the entity with the specified tag, and returns an
+// error on authentication failure.
+//
+// If and only if no password is supplied, then Authenticate will check for any
+// valid macaroons. Otherwise, password authentication will be performed.
+func (u *UserAuthenticator) Authenticate(
+	entityFinder EntityFinder, tag names.Tag, req params.LoginRequest,
+) (state.Entity, error) {
+	userTag, ok := tag.(names.UserTag)
+	if !ok {
 		return nil, errors.Errorf("invalid request")
+	}
+	if req.Credentials == "" && userTag.IsLocal() {
+		return u.authenticateMacaroons(entityFinder, userTag, req)
 	}
 	return u.AgentAuthenticator.Authenticate(entityFinder, tag, req)
 }
 
-// MacaroonAuthenticator performs authentication for users using macaroons.
-// If the authentication fails because provided macaroons are invalid,
-// and macaroon authentiction is enabled, it will return a
-// *common.DischargeRequiredError holding a macaroon to be
-// discharged.
-type MacaroonAuthenticator struct {
+// CreateLocalLoginMacaroon creates a time-limited macaroon for a local user
+// to log into the controller with. The macaroon will be valid for use with
+// UserAuthenticator.Authenticate until the time limit expires, or the Juju
+// controller agent restarts.
+//
+// NOTE(axw) this method will generate a key for a previously unseen user,
+// and store it in the bakery.Service's storage, which is currently in-memory.
+// Callers should first ensure the user is valid before calling this, to avoid
+// filling memory with keys for invalid users.
+func (u *UserAuthenticator) CreateLocalLoginMacaroon(tag names.UserTag) (*macaroon.Macaroon, error) {
+	// We create the macaroon with a random ID and random root key, which
+	// enables multiple clients to login as the same user and obtain separate
+	// macaroons without having them use the same root key.
+	//
+	// TODO(axw) check with rogpeppe about this. bakery.Service doesn't
+	// currently garbage collect, so this will grow until the controller
+	// agent restarts.
+	m, err := u.Service.NewMacaroon("", nil, []checkers.Caveat{
+		// The macaroon may only be used to log in as the user
+		// specified by the tag passed to CreateLocalUserMacaroon.
+		checkers.DeclaredCaveat(usernameKey, tag.Canonical()),
+	})
+	if err != nil {
+		return nil, errors.Annotate(err, "cannot create macaroon")
+	}
+	if err := addMacaroonTimeBeforeCaveat(u.Service, m, localLoginExpiryTime); err != nil {
+		return nil, errors.Trace(err)
+	}
+	return m, nil
+}
+
+func (u *UserAuthenticator) authenticateMacaroons(
+	entityFinder EntityFinder, tag names.UserTag, req params.LoginRequest,
+) (state.Entity, error) {
+	// Check for a valid request macaroon.
+	assert := map[string]string{usernameKey: tag.Canonical()}
+	_, err := u.Service.CheckAny(req.Macaroons, assert, checkers.New(checkers.TimeBefore))
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	entity, err := entityFinder.FindEntity(tag)
+	if errors.IsNotFound(err) {
+		return nil, errors.Trace(common.ErrBadCreds)
+	} else if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return entity, nil
+}
+
+// ExternalMacaroonAuthenticator performs authentication for external users using
+// macaroons. If the authentication fails because provided macaroons are invalid,
+// and macaroon authentiction is enabled, it will return a *common.DischargeRequiredError
+// holding a macaroon to be discharged.
+type ExternalMacaroonAuthenticator struct {
 	// Service holds the service that is
 	// used to verify macaroon authorization.
 	Service *bakery.Service
@@ -55,18 +127,17 @@ type MacaroonAuthenticator struct {
 	IdentityLocation string
 }
 
-var _ EntityAuthenticator = (*MacaroonAuthenticator)(nil)
+var _ EntityAuthenticator = (*ExternalMacaroonAuthenticator)(nil)
 
-func (m *MacaroonAuthenticator) newDischargeRequiredError(cause error) error {
+func (m *ExternalMacaroonAuthenticator) newDischargeRequiredError(cause error) error {
 	if m.Service == nil || m.Macaroon == nil {
 		return errors.Trace(cause)
 	}
 	mac := m.Macaroon.Clone()
-	err := m.Service.AddCaveat(mac, checkers.TimeBeforeCaveat(time.Now().Add(time.Hour)))
-	if err != nil {
+	if err := addMacaroonTimeBeforeCaveat(m.Service, mac, externalLoginExpiryTime); err != nil {
 		return errors.Annotatef(err, "cannot create macaroon")
 	}
-	err = m.Service.AddCaveat(mac, checkers.NeedDeclaredCaveat(
+	err := m.Service.AddCaveat(mac, checkers.NeedDeclaredCaveat(
 		checkers.Caveat{
 			Location:  m.IdentityLocation,
 			Condition: "is-authenticated-user",
@@ -84,7 +155,7 @@ func (m *MacaroonAuthenticator) newDischargeRequiredError(cause error) error {
 
 // Authenticate authenticates the provided entity. If there is no macaroon provided, it will
 // return a *DischargeRequiredError containing a macaroon that can be used to grant access.
-func (m *MacaroonAuthenticator) Authenticate(entityFinder EntityFinder, _ names.Tag, req params.LoginRequest) (state.Entity, error) {
+func (m *ExternalMacaroonAuthenticator) Authenticate(entityFinder EntityFinder, _ names.Tag, req params.LoginRequest) (state.Entity, error) {
 	declared, err := m.Service.CheckAny(req.Macaroons, nil, checkers.New(checkers.TimeBefore))
 	if _, ok := errors.Cause(err).(*bakery.VerificationError); ok {
 		return nil, m.newDischargeRequiredError(err)
@@ -120,4 +191,8 @@ func (m *MacaroonAuthenticator) Authenticate(entityFinder EntityFinder, _ names.
 		return nil, errors.Trace(err)
 	}
 	return entity, nil
+}
+
+func addMacaroonTimeBeforeCaveat(svc *bakery.Service, m *macaroon.Macaroon, d time.Duration) error {
+	return svc.AddCaveat(m, checkers.TimeBeforeCaveat(time.Now().Add(d)))
 }

--- a/apiserver/authentication/user_test.go
+++ b/apiserver/authentication/user_test.go
@@ -217,7 +217,7 @@ func (s *macaroonAuthenticatorSuite) TestMacaroonAuthentication(c *gc.C) {
 		c.Assert(err, jc.ErrorIsNil)
 		mac, err := svc.NewMacaroon("", nil, nil)
 		c.Assert(err, jc.ErrorIsNil)
-		authenticator := &authentication.MacaroonAuthenticator{
+		authenticator := &authentication.ExternalMacaroonAuthenticator{
 			Service:          svc,
 			IdentityLocation: s.discharger.Location(),
 			Macaroon:         mac,

--- a/apiserver/common/resource.go
+++ b/apiserver/common/resource.go
@@ -141,3 +141,13 @@ func (StringResource) Stop() error {
 func (s StringResource) String() string {
 	return string(s)
 }
+
+// ValueResource is a Resource with a no-op Stop method, containing an
+// interface{} value.
+type ValueResource struct {
+	Value interface{}
+}
+
+func (r ValueResource) Stop() error {
+	return nil
+}

--- a/apiserver/export_test.go
+++ b/apiserver/export_test.go
@@ -36,7 +36,7 @@ func ServerMacaroon(srv *Server) (*macaroon.Macaroon, error) {
 	if err != nil {
 		return nil, err
 	}
-	return auth.(*authentication.MacaroonAuthenticator).Macaroon, nil
+	return auth.(*authentication.ExternalMacaroonAuthenticator).Macaroon, nil
 }
 
 func ServerBakeryService(srv *Server) (*bakery.Service, error) {
@@ -44,7 +44,7 @@ func ServerBakeryService(srv *Server) (*bakery.Service, error) {
 	if err != nil {
 		return nil, err
 	}
-	return auth.(*authentication.MacaroonAuthenticator).Service, nil
+	return auth.(*authentication.ExternalMacaroonAuthenticator).Service, nil
 }
 
 // ServerAuthenticatorForTag calls the authenticatorForTag method
@@ -91,9 +91,12 @@ func TestingApiRoot(st *state.State) rpc.MethodFinder {
 // TestingApiHandler gives you an ApiHandler that isn't connected to
 // anything real. It's enough to let test some basic functionality though.
 func TestingApiHandler(c *gc.C, srvSt, st *state.State) (*apiHandler, *common.Resources) {
+	authCtxt, err := newAuthContext(srvSt)
+	c.Assert(err, jc.ErrorIsNil)
 	srv := &Server{
-		state: srvSt,
-		tag:   names.NewMachineTag("0"),
+		authCtxt: authCtxt,
+		state:    srvSt,
+		tag:      names.NewMachineTag("0"),
 	}
 	h, err := newApiHandler(srv, st, nil, nil, st.ModelUUID())
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -833,3 +833,14 @@ type MeterStatusParam struct {
 type MeterStatusParams struct {
 	Statuses []MeterStatusParam `json:"statues"`
 }
+
+// MacaroonResults contains a set of MacaroonResults.
+type MacaroonResults struct {
+	Results []MacaroonResult `json:"results"`
+}
+
+// MacaroonResult contains a macaroon or an error.
+type MacaroonResult struct {
+	Result *macaroon.Macaroon `json:"result,omitempty"`
+	Error  *Error             `json:"error,omitempty"`
+}

--- a/apiserver/root.go
+++ b/apiserver/root.go
@@ -74,6 +74,11 @@ func newApiHandler(srv *Server, st *state.State, rpcConn *rpc.Conn, reqNotifier 
 	if err := r.resources.RegisterNamed("logDir", common.StringResource(srv.logDir)); err != nil {
 		return nil, errors.Trace(err)
 	}
+	if err := r.resources.RegisterNamed("createLocalLoginMacaroon", common.ValueResource{
+		srv.authCtxt.userAuth.CreateLocalLoginMacaroon,
+	}); err != nil {
+		return nil, errors.Trace(err)
+	}
 	return r, nil
 }
 

--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -183,6 +183,7 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 	r.Register(user.NewEnableCommand())
 	r.Register(user.NewDisableCommand())
 	r.Register(user.NewSwitchUserCommand())
+	r.Register(user.NewLoginCommand())
 
 	// Manage cached images
 	r.Register(cachedimages.NewSuperCommand())

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -264,6 +264,7 @@ var commandNames = []string{
 	"list-storage",
 	"list-storage-pools",
 	"list-users",
+	"login",
 	"machine",
 	"machines",
 	"publish",

--- a/cmd/juju/controller/register.go
+++ b/cmd/juju/controller/register.go
@@ -250,13 +250,21 @@ func (c *registerCommand) secretKeyLogin(addrs []string, request params.SecretKe
 	r := bytes.NewReader(buf)
 
 	// Determine which address to use by attempting to open an API
-	// connection with each of the addresses. Note that we don't
-	// set a username/password, so no login will be attempted; and
-	// we skip verification, because we don't know the CA certificate
-	// and we do not send anything sensitive.
+	// connection with each of the addresses. Note that we do not
+	// know the CA certificate yet, so we do not want to send any
+	// sensitive information. We make no attempt to log in until
+	// we can verify the server's identity.
 	opts := api.DefaultDialOpts()
 	opts.InsecureSkipVerify = true
-	conn, err := c.apiOpen(&api.Info{Addrs: addrs}, opts)
+	conn, err := c.apiOpen(&api.Info{
+		Addrs:     addrs,
+		SkipLogin: true,
+		// NOTE(axw) CACert is required, but ignored if
+		// InsecureSkipVerify is set. We should try to
+		// bring together CACert and InsecureSkipVerify
+		// so they can be validated together.
+		CACert: "ignored",
+	}, opts)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/cmd/juju/user/change_password.go
+++ b/cmd/juju/user/change_password.go
@@ -171,6 +171,8 @@ func readAndConfirmPassword(ctx *cmd.Context) (string, error) {
 	// Don't add the carriage returns before readPassword, but add
 	// them directly after the readPassword so any errors are output
 	// on their own lines.
+	//
+	// TODO(axw) retry/loop on failure
 	fmt.Fprint(ctx.Stderr, "password: ")
 	password, err := readPassword(ctx.Stdin)
 	fmt.Fprint(ctx.Stderr, "\n")

--- a/cmd/juju/user/export_test.go
+++ b/cmd/juju/user/export_test.go
@@ -13,7 +13,6 @@ import (
 
 var (
 	RandomPasswordNotify = &randomPasswordNotify
-	ReadPassword         = &readPassword
 )
 
 type AddCommand struct {

--- a/cmd/juju/user/export_test.go
+++ b/cmd/juju/user/export_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/juju/cmd"
 
 	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/juju"
 	"github.com/juju/juju/jujuclient"
 )
 
@@ -21,6 +22,10 @@ type AddCommand struct {
 
 type ChangePasswordCommand struct {
 	*changePasswordCommand
+}
+
+type LoginCommand struct {
+	*loginCommand
 }
 
 type DisenableUserBase struct {
@@ -50,6 +55,17 @@ func NewChangePasswordCommandForTest(api ChangePasswordAPI, store jujuclient.Cli
 	c := &changePasswordCommand{api: api}
 	c.SetClientStore(store)
 	return modelcmd.WrapController(c), &ChangePasswordCommand{c}
+}
+
+// NewLoginCommand returns a LoginCommand with the api
+// and writer provided as specified.
+func NewLoginCommandForTest(
+	newLoginAPI func(juju.NewAPIConnectionParams) (LoginAPI, error),
+	store jujuclient.ClientStore,
+) (cmd.Command, *LoginCommand) {
+	c := &loginCommand{newLoginAPI: newLoginAPI}
+	c.SetClientStore(store)
+	return modelcmd.WrapController(c), &LoginCommand{c}
 }
 
 // NewSwitchUserCommand returns a SwitchUserCommand using the

--- a/cmd/juju/user/login.go
+++ b/cmd/juju/user/login.go
@@ -1,0 +1,148 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package user
+
+import (
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+	"github.com/juju/names"
+	"gopkg.in/macaroon.v1"
+
+	"github.com/juju/juju/api/usermanager"
+	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/juju"
+	"github.com/juju/juju/jujuclient"
+)
+
+const loginDoc = `
+Log in to the controller.
+
+After logging in successfully, the client system will
+be updated such that any previously recorded password
+will be removed from disk, and a temporary, time-limited
+credential written in its place. Once the credential
+expires, you will be prompted to run "juju login" again.
+
+Examples:
+  # Log in as the current user for the controller.
+  juju login
+
+  # Log in as the user "bob".
+  juju login bob
+
+`
+
+func NewLoginCommand() cmd.Command {
+	return modelcmd.WrapController(&loginCommand{
+		newLoginAPI: func(args juju.NewAPIConnectionParams) (LoginAPI, error) {
+			api, err := juju.NewAPIConnection(args)
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			return usermanager.NewClient(api), nil
+		},
+	})
+}
+
+// loginCommand changes the password for a user.
+type loginCommand struct {
+	modelcmd.ControllerCommandBase
+	newLoginAPI func(juju.NewAPIConnectionParams) (LoginAPI, error)
+	User        string
+}
+
+// Info implements Command.Info.
+func (c *loginCommand) Info() *cmd.Info {
+	return &cmd.Info{
+		Name:    "login",
+		Args:    "[username]",
+		Purpose: "logs in to the controller",
+		Doc:     loginDoc,
+	}
+}
+
+// Init implements Command.Init.
+func (c *loginCommand) Init(args []string) error {
+	var err error
+	c.User, err = cmd.ZeroOrOneArgs(args)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return nil
+}
+
+// LoginAPI provides the API methods that the login command uses.
+type LoginAPI interface {
+	CreateLocalLoginMacaroon(names.UserTag) (*macaroon.Macaroon, error)
+	Close() error
+}
+
+// Run implements Command.Run.
+func (c *loginCommand) Run(ctx *cmd.Context) error {
+	var accountName string
+	var userTag names.UserTag
+	controllerName := c.ControllerName()
+	store := c.ClientStore()
+	if c.User != "" {
+		if !names.IsValidUserName(c.User) {
+			return errors.NotValidf("user name %q", c.User)
+		}
+		userTag = names.NewUserTag(c.User)
+		accountName = userTag.Canonical()
+	} else {
+		var err error
+		accountName, err = store.CurrentAccount(controllerName)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		userTag = names.NewUserTag(accountName)
+	}
+	accountDetails, err := store.AccountByName(controllerName, accountName)
+	if err != nil && !errors.IsNotFound(err) {
+		return errors.Trace(err)
+	}
+
+	// Read password from the terminal, and attempt to log in using that.
+	password, err := readAndConfirmPassword(ctx)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	params, err := c.NewAPIConnectionParams(store, controllerName, "", "")
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if accountDetails != nil {
+		accountDetails.Password = password
+	} else {
+		accountDetails = &jujuclient.AccountDetails{
+			User:     accountName,
+			Password: password,
+		}
+	}
+	params.AccountDetails = accountDetails
+	api, err := c.newLoginAPI(params)
+	if err != nil {
+		return errors.Annotate(err, "creating API connection")
+	}
+	defer api.Close()
+
+	// Create a new local login macaroon, and update the account details
+	// in the client store, removing the recorded password (if any) and
+	// storing the macaroon.
+	macaroon, err := api.CreateLocalLoginMacaroon(userTag)
+	if err != nil {
+		return errors.Annotate(err, "failed to create a temporary credential")
+	}
+	macaroonJSON, err := macaroon.MarshalJSON()
+	if err != nil {
+		return errors.Annotate(err, "marshalling temporary credential to JSON")
+	}
+	accountDetails.Password = ""
+	accountDetails.Macaroon = string(macaroonJSON)
+	if err := store.UpdateAccount(controllerName, accountName, *accountDetails); err != nil {
+		return errors.Annotate(err, "failed to record temporary credential")
+	}
+	ctx.Infof("You are now logged in to %q as %q.", controllerName, accountName)
+	return nil
+}

--- a/cmd/juju/user/login.go
+++ b/cmd/juju/user/login.go
@@ -33,6 +33,7 @@ Examples:
 
 `
 
+// NewLoginCommand returns a new cmd.Command to handle "juju login".
 func NewLoginCommand() cmd.Command {
 	return modelcmd.WrapController(&loginCommand{
 		newLoginAPI: func(args juju.NewAPIConnectionParams) (LoginAPI, error) {

--- a/cmd/juju/user/login_test.go
+++ b/cmd/juju/user/login_test.go
@@ -1,0 +1,149 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package user_test
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/juju/cmd"
+	"github.com/juju/names"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/macaroon.v1"
+
+	"github.com/juju/juju/cmd/juju/user"
+	"github.com/juju/juju/juju"
+	"github.com/juju/juju/jujuclient"
+	coretesting "github.com/juju/juju/testing"
+)
+
+type LoginCommandSuite struct {
+	BaseSuite
+	mockAPI *mockLoginAPI
+}
+
+var _ = gc.Suite(&LoginCommandSuite{})
+
+func (s *LoginCommandSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+	s.mockAPI = &mockLoginAPI{}
+}
+
+func (s *LoginCommandSuite) run(c *gc.C, args ...string) (*cmd.Context, juju.NewAPIConnectionParams, error) {
+	var argsOut juju.NewAPIConnectionParams
+	cmd, _ := user.NewLoginCommandForTest(func(args juju.NewAPIConnectionParams) (user.LoginAPI, error) {
+		argsOut = args
+		// The account details are modified in place, so take a copy.
+		accountDetails := *argsOut.AccountDetails
+		argsOut.AccountDetails = &accountDetails
+		return s.mockAPI, nil
+	}, s.store)
+	ctx := coretesting.Context(c)
+	ctx.Stdin = strings.NewReader("sekrit\nsekrit\n")
+	err := coretesting.InitCommand(cmd, args)
+	if err != nil {
+		return nil, argsOut, err
+	}
+	err = cmd.Run(ctx)
+	return ctx, argsOut, err
+}
+
+func (s *LoginCommandSuite) TestInit(c *gc.C) {
+	for i, test := range []struct {
+		args        []string
+		user        string
+		generate    bool
+		errorString string
+	}{
+		{
+		// no args is fine
+		}, {
+			args:     []string{"foobar"},
+			user:     "foobar",
+			generate: true,
+		}, {
+			args:        []string{"--foobar"},
+			errorString: "flag provided but not defined: --foobar",
+		}, {
+			args:        []string{"foobar", "extra"},
+			errorString: `unrecognized args: \["extra"\]`,
+		},
+	} {
+		c.Logf("test %d", i)
+		wrappedCommand, command := user.NewLoginCommandForTest(nil, s.store)
+		err := coretesting.InitCommand(wrappedCommand, test.args)
+		if test.errorString == "" {
+			c.Check(command.User, gc.Equals, test.user)
+		} else {
+			c.Check(err, gc.ErrorMatches, test.errorString)
+		}
+	}
+}
+
+func (s *LoginCommandSuite) assertStorePassword(c *gc.C, user, pass string) {
+	details, err := s.store.AccountByName("testing", user)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(details.Password, gc.Equals, pass)
+}
+
+func (s *LoginCommandSuite) assertStoreMacaroon(c *gc.C, user string, mac *macaroon.Macaroon) {
+	details, err := s.store.AccountByName("testing", user)
+	c.Assert(err, jc.ErrorIsNil)
+	if mac == nil {
+		c.Assert(details.Macaroon, gc.Equals, "")
+		return
+	}
+	macaroonJSON, err := mac.MarshalJSON()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(details.Macaroon, gc.Equals, string(macaroonJSON))
+}
+
+func (s *LoginCommandSuite) TestLogin(c *gc.C) {
+	context, args, err := s.run(c)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(coretesting.Stdout(context), gc.Equals, "")
+	c.Assert(coretesting.Stderr(context), gc.Equals, `
+password: 
+type password again: 
+You are now logged in to "testing" as "current-user@local".
+`[1:],
+	)
+	s.assertStorePassword(c, "current-user@local", "")
+	s.assertStoreMacaroon(c, "current-user@local", fakeLocalLoginMacaroon(names.NewUserTag("current-user@local")))
+	c.Assert(args.AccountDetails, jc.DeepEquals, &jujuclient.AccountDetails{
+		User:     "current-user@local",
+		Password: "sekrit",
+	})
+}
+
+func (s *LoginCommandSuite) TestLoginNewUser(c *gc.C) {
+	context, args, err := s.run(c, "new-user")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(coretesting.Stdout(context), gc.Equals, "")
+	c.Assert(coretesting.Stderr(context), gc.Equals, `
+password: 
+type password again: 
+You are now logged in to "testing" as "new-user@local".
+`[1:],
+	)
+	s.assertStorePassword(c, "new-user@local", "")
+	s.assertStoreMacaroon(c, "new-user@local", fakeLocalLoginMacaroon(names.NewUserTag("new-user@local")))
+	c.Assert(args.AccountDetails, jc.DeepEquals, &jujuclient.AccountDetails{
+		User:     "new-user@local",
+		Password: "sekrit",
+	})
+}
+
+func (s *LoginCommandSuite) TestLoginFail(c *gc.C) {
+	s.mockAPI.SetErrors(errors.New("failed to do something"))
+	_, _, err := s.run(c)
+	c.Assert(err, gc.ErrorMatches, "failed to create a temporary credential: failed to do something")
+	s.assertStorePassword(c, "current-user@local", "old-password")
+	s.assertStoreMacaroon(c, "current-user@local", nil)
+}
+
+type mockLoginAPI struct {
+	mockChangePasswordAPI
+}

--- a/cmd/juju/user/user_test.go
+++ b/cmd/juju/user/user_test.go
@@ -7,7 +7,6 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/cmd/juju/user"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/jujuclient/jujuclienttesting"
@@ -21,9 +20,6 @@ type BaseSuite struct {
 
 func (s *BaseSuite) SetUpTest(c *gc.C) {
 	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
-	s.PatchValue(user.ReadPassword, func() (string, error) {
-		return "sekrit", nil
-	})
 	err := modelcmd.WriteCurrentController("testing")
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/cmd/modelcmd/modelcommand_test.go
+++ b/cmd/modelcmd/modelcommand_test.go
@@ -251,7 +251,7 @@ func (s *macaroonLoginSuite) TestsFailToObtainDischargeLogin(c *gc.C) {
 
 	cmd := modelcmd.NewModelCommandBase(s.store, s.controllerName, s.accountName, s.modelName)
 	_, err := cmd.NewAPIRoot()
-	c.Assert(err, gc.ErrorMatches, "cannot get discharge.*")
+	c.Assert(err, gc.ErrorMatches, "connecting with cached addresses: cannot get discharge.*")
 }
 
 func (s *macaroonLoginSuite) TestsUnknownUserLogin(c *gc.C) {
@@ -261,5 +261,5 @@ func (s *macaroonLoginSuite) TestsUnknownUserLogin(c *gc.C) {
 
 	cmd := modelcmd.NewModelCommandBase(s.store, s.controllerName, s.accountName, s.modelName)
 	_, err := cmd.NewAPIRoot()
-	c.Assert(err, gc.ErrorMatches, "invalid entity name or password \\(unauthorized access\\)")
+	c.Assert(err, gc.ErrorMatches, "connecting with cached addresses: invalid entity name or password \\(unauthorized access\\)")
 }

--- a/featuretests/cmd_juju_controller_test.go
+++ b/featuretests/cmd_juju_controller_test.go
@@ -15,6 +15,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/modelmanager"
 	undertakerapi "github.com/juju/juju/api/undertaker"
 	"github.com/juju/juju/cmd/juju/commands"
@@ -101,7 +102,18 @@ func (s *cmdControllerSuite) TestCreateModel(c *gc.C) {
 
 	// Make sure that the saved server details are sufficient to connect
 	// to the api server.
-	api, err := juju.NewAPIConnection(s.ControllerStore, "kontroll", "admin@local", "new-model", nil, noBootstrapConfig)
+	accountDetails, err := s.ControllerStore.AccountByName("kontroll", "admin@local")
+	c.Assert(err, jc.ErrorIsNil)
+	modelDetails, err := s.ControllerStore.ModelByName("kontroll", "admin@local", "new-model")
+	c.Assert(err, jc.ErrorIsNil)
+	api, err := juju.NewAPIConnection(juju.NewAPIConnectionParams{
+		Store:           s.ControllerStore,
+		ControllerName:  "kontroll",
+		AccountDetails:  accountDetails,
+		ModelUUID:       modelDetails.ModelUUID,
+		BootstrapConfig: noBootstrapConfig,
+		DialOpts:        api.DefaultDialOpts(),
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	api.Close()
 }

--- a/featuretests/cmd_juju_login_test.go
+++ b/featuretests/cmd_juju_login_test.go
@@ -1,0 +1,62 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package featuretests
+
+import (
+	"io"
+	"strings"
+
+	"github.com/juju/cmd"
+	"github.com/juju/loggo"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/cmd/juju/commands"
+	jujutesting "github.com/juju/juju/juju/testing"
+	"github.com/juju/juju/jujuclient"
+	"github.com/juju/juju/testing"
+)
+
+type cmdLoginSuite struct {
+	jujutesting.JujuConnSuite
+}
+
+func (s *cmdLoginSuite) run(c *gc.C, stdin io.Reader, args ...string) *cmd.Context {
+	context := testing.Context(c)
+	if stdin != nil {
+		context.Stdin = stdin
+	}
+	command := commands.NewJujuCommand(context)
+	c.Assert(testing.InitCommand(command, args), jc.ErrorIsNil)
+	c.Assert(command.Run(context), jc.ErrorIsNil)
+	loggo.RemoveWriter("warning") // remove logger added by main command
+	return context
+}
+
+func (s *cmdLoginSuite) createTestUser(c *gc.C) {
+	s.run(c, nil, "add-user", "test", "--models", "admin")
+	s.run(c, strings.NewReader("hunter2\nhunter2\n"), "change-user-password", "test")
+}
+
+func (s *cmdLoginSuite) TestLoginCommand(c *gc.C) {
+	s.createTestUser(c)
+
+	context := s.run(c, strings.NewReader("hunter2\nhunter2\n"), "login", "test")
+	c.Assert(testing.Stdout(context), gc.Equals, "")
+	c.Assert(testing.Stderr(context), gc.Equals, `
+password: 
+type password again: 
+You are now logged in to "kontroll" as "test@local".
+`[1:])
+
+	// We should have a macaroon, but no password, in the client store.
+	store := jujuclient.NewFileClientStore()
+	accountDetails, err := store.AccountByName("kontroll", "test@local")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(accountDetails.Password, gc.Equals, "")
+	c.Assert(accountDetails.Macaroon, gc.Not(gc.Equals), "")
+
+	// We should be able to login with the macaroon.
+	s.run(c, nil, "status")
+}

--- a/featuretests/cmd_juju_register_test.go
+++ b/featuretests/cmd_juju_register_test.go
@@ -12,6 +12,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/api"
 	"github.com/juju/juju/cmd/juju/commands"
 	"github.com/juju/juju/juju"
 	jujutesting "github.com/juju/juju/juju/testing"
@@ -66,7 +67,15 @@ Welcome, bob. You are now logged into "bob-controller".
 
 	// Make sure that the saved server details are sufficient to connect
 	// to the api server.
-	api, err := juju.NewAPIConnection(s.ControllerStore, "bob-controller", "bob@local", "", nil, noBootstrapConfig)
+	accountDetails, err := s.ControllerStore.AccountByName("bob-controller", "bob@local")
+	c.Assert(err, jc.ErrorIsNil)
+	api, err := juju.NewAPIConnection(juju.NewAPIConnectionParams{
+		Store:           s.ControllerStore,
+		ControllerName:  "bob-controller",
+		AccountDetails:  accountDetails,
+		BootstrapConfig: noBootstrapConfig,
+		DialOpts:        api.DefaultDialOpts(),
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(api.Close(), jc.ErrorIsNil)
 }

--- a/featuretests/package_test.go
+++ b/featuretests/package_test.go
@@ -38,6 +38,7 @@ func init() {
 	gc.Suite(&dumpLogsCommandSuite{})
 	gc.Suite(&upgradeSuite{})
 	gc.Suite(&cmdRegistrationSuite{})
+	gc.Suite(&cmdLoginSuite{})
 }
 
 func TestPackage(t *stdtesting.T) {

--- a/juju/export_test.go
+++ b/juju/export_test.go
@@ -1,10 +1,6 @@
 package juju
 
-import (
-	"github.com/juju/juju/api"
-	"github.com/juju/juju/environs/config"
-	"github.com/juju/juju/jujuclient"
-)
+import "github.com/juju/juju/api"
 
 var (
 	ProviderConnectDelay   = &providerConnectDelay
@@ -12,11 +8,6 @@ var (
 	ServerAddress          = &serverAddress
 )
 
-func NewAPIFromStore(
-	controllerName, accountName, modelName string,
-	store jujuclient.ClientStore,
-	open api.OpenFunc,
-	getBootstrapConfig func(controllerName string) (*config.Config, error),
-) (api.Connection, error) {
-	return newAPIFromStore(controllerName, accountName, modelName, store, open, nil, getBootstrapConfig)
+func NewAPIFromStore(args NewAPIConnectionParams, open api.OpenFunc) (api.Connection, error) {
+	return newAPIFromStore(args, open)
 }

--- a/jujuclient/interface.go
+++ b/jujuclient/interface.go
@@ -34,6 +34,11 @@ type AccountDetails struct {
 
 	// Password is the password for the account.
 	Password string `yaml:"password,omitempty"`
+
+	// Macaroon is a time-limited macaroon that may be
+	// used to log in. This string is the JSON-encoding
+	// of a gopkg.in/macaroon.v1.Macaroon.
+	Macaroon string `yaml:"macaroon,omitempty"`
 }
 
 // BootstrapConfig holds the configuration used to bootstrap a controller.

--- a/jujuclient/validation.go
+++ b/jujuclient/validation.go
@@ -34,6 +34,9 @@ func ValidateAccountDetails(details AccountDetails) error {
 	}
 	// It is valid for a password to be blank, because the client
 	// may use macaroons instead.
+	//
+	// TODO(axw) expand validation rules to check that at least
+	// one of Password or Macaroon is non-empty.
 	return nil
 }
 


### PR DESCRIPTION
Reintroduce the "login" command, with a new approach
using macaroons. This is in addition to the existing
external-IdM macaroon support.

We now support macaroon logins for local users: if a
local user tag is specified in login, a macaroon may
be provided instead of a password.

We can now record a macaroon in accounts.yaml instead
of a password. When you run "juju login", you will be
prompted for your password, which will be used for the
login; a macaroon is requested from the server, which
is then written to disk and any existing password
wiped from accounts.yaml.

The change-user-password command is similarly updated
to manage macaroons.

TODO:
 - update "juju register" to generate and record macaroons
 - update juju/api.go code to prompt user to run "juju login"
   if the macaroon is expired
 - persist root keys in mongo, so logins work across
   controller machines
 - garbage collect root keys after macaroon expiry

(Review request: http://reviews.vapour.ws/r/4265/)