### PR TITLE
Backport of fix-1319890

### DIFF
--- a/apiserver/client/status_test.go
+++ b/apiserver/client/status_test.go
@@ -4,6 +4,11 @@
 package client_test
 
 import (
+	"github.com/juju/juju/apiserver/charmrevisionupdater"
+	"github.com/juju/juju/apiserver/charmrevisionupdater/testing"
+	"github.com/juju/juju/apiserver/common"
+	apiservertesting "github.com/juju/juju/apiserver/testing"
+	jujutesting "github.com/juju/juju/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -163,4 +168,65 @@ func (s *statusUnitTestSuite) TestMeterStatus(c *gc.C) {
 			c.Assert(ok, gc.Equals, false)
 		}
 	}
+}
+
+type statusUpgradeUnitSuite struct {
+	testing.CharmSuite
+	jujutesting.JujuConnSuite
+
+	charmrevisionupdater *charmrevisionupdater.CharmRevisionUpdaterAPI
+	resources            *common.Resources
+	authoriser           apiservertesting.FakeAuthorizer
+}
+
+var _ = gc.Suite(&statusUpgradeUnitSuite{})
+
+func (s *statusUpgradeUnitSuite) SetUpSuite(c *gc.C) {
+	s.JujuConnSuite.SetUpSuite(c)
+	s.CharmSuite.SetUpSuite(c, &s.JujuConnSuite)
+}
+
+func (s *statusUpgradeUnitSuite) TearDownSuite(c *gc.C) {
+	s.CharmSuite.TearDownSuite(c)
+	s.JujuConnSuite.TearDownSuite(c)
+}
+
+func (s *statusUpgradeUnitSuite) SetUpTest(c *gc.C) {
+	s.JujuConnSuite.SetUpTest(c)
+	s.CharmSuite.SetUpTest(c)
+	s.resources = common.NewResources()
+	s.AddCleanup(func(_ *gc.C) { s.resources.StopAll() })
+	s.authoriser = apiservertesting.FakeAuthorizer{
+		EnvironManager: true,
+	}
+	var err error
+	s.charmrevisionupdater, err = charmrevisionupdater.NewCharmRevisionUpdaterAPI(s.State, s.resources, s.authoriser)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *statusUpgradeUnitSuite) TearDownTest(c *gc.C) {
+	s.CharmSuite.TearDownTest(c)
+	s.JujuConnSuite.TearDownTest(c)
+}
+
+func (s *statusUpgradeUnitSuite) TestUpdateRevisions(c *gc.C) {
+	s.AddMachine(c, "0", 2)
+	s.SetupScenario(c)
+	client := s.APIState.Client()
+	status, _ := client.Status(nil)
+
+	serviceStatus, ok := status.Services["mysql"]
+	c.Assert(ok, gc.Equals, true)
+	c.Assert(serviceStatus.CanUpgradeTo, gc.Equals, "")
+
+	// Update to the latest available charm revision.
+	result, err := s.charmrevisionupdater.UpdateLatestRevisions()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.Error, gc.IsNil)
+
+	// Check if CanUpgradeTo suggest the latest revision.
+	status, _ = client.Status(nil)
+	serviceStatus, ok = status.Services["mysql"]
+	c.Assert(ok, gc.Equals, true)
+	c.Assert(serviceStatus.CanUpgradeTo, gc.Equals, "cs:quantal/mysql-23")
 }


### PR DESCRIPTION
Cherry pick of previously reviewed commit: https://github.com/juju/juju/commit/742513cee35ecfba09e1b9c3bf7686c4fc8b1c57

Backport of fix-1319890.

This change validates that the latest available
revision is greater than the current, in that case
it sets the CanUpgradeTo field to the latest URL.

I also added unit tests for validating the change.

Closes-Bug: 1319890
Signed-off-by: Jorge Niedbalski <jorge.niedbalski@canonical.com>

(Review request: http://reviews.vapour.ws/r/4270/)