### PR TITLE
state: Added WatchMigrationStatus

### DIFF
--- a/state/modelmigration_test.go
+++ b/state/modelmigration_test.go
@@ -471,6 +471,85 @@ func (s *ModelMigrationSuite) createWatcher(c *gc.C, st *state.State) (
 	return w, statetesting.NewNotifyWatcherC(c, st, w)
 }
 
+func (s *ModelMigrationSuite) TestWatchMigrationStatus(c *gc.C) {
+	w, wc := s.createStatusWatcher(c, s.State2)
+	wc.AssertNoChange()
+
+	// Create a migration.
+	mig, err := s.State2.CreateModelMigration(s.stdSpec)
+	c.Assert(err, jc.ErrorIsNil)
+	wc.AssertOneChange()
+
+	// End it.
+	c.Assert(mig.SetPhase(migration.ABORT), jc.ErrorIsNil)
+	wc.AssertOneChange()
+
+	// Start another.
+	mig2, err := s.State2.CreateModelMigration(s.stdSpec)
+	c.Assert(err, jc.ErrorIsNil)
+	wc.AssertOneChange()
+
+	// Change phase.
+	c.Assert(mig2.SetPhase(migration.READONLY), jc.ErrorIsNil)
+	wc.AssertOneChange()
+
+	// End it.
+	c.Assert(mig2.SetPhase(migration.ABORT), jc.ErrorIsNil)
+	wc.AssertOneChange()
+
+	statetesting.AssertStop(c, w)
+	wc.AssertClosed()
+}
+
+func (s *ModelMigrationSuite) TestWatchMigrationStatusPreexisting(c *gc.C) {
+	// Create an aborted migration.
+	mig, err := s.State2.CreateModelMigration(s.stdSpec)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(mig.SetPhase(migration.ABORT), jc.ErrorIsNil)
+
+	_, wc := s.createStatusWatcher(c, s.State2)
+	wc.AssertOneChange()
+}
+
+func (s *ModelMigrationSuite) TestWatchMigrationStatusMultiModel(c *gc.C) {
+	_, wc2 := s.createStatusWatcher(c, s.State2)
+	wc2.AssertNoChange()
+
+	// Create another hosted model to migrate and watch for
+	// migrations.
+	State3 := s.Factory.MakeModel(c, nil)
+	s.AddCleanup(func(*gc.C) { State3.Close() })
+	_, wc3 := s.createStatusWatcher(c, State3)
+	wc3.AssertNoChange()
+
+	// Create a migration for 2.
+	mig, err := s.State2.CreateModelMigration(s.stdSpec)
+	c.Assert(err, jc.ErrorIsNil)
+	wc2.AssertOneChange()
+	wc3.AssertNoChange()
+
+	// Create a migration for 3.
+	_, err = State3.CreateModelMigration(s.stdSpec)
+	c.Assert(err, jc.ErrorIsNil)
+	wc2.AssertNoChange()
+	wc3.AssertOneChange()
+
+	// Update the migration for 2.
+	err = mig.SetPhase(migration.ABORT)
+	c.Assert(err, jc.ErrorIsNil)
+	wc2.AssertOneChange()
+	wc3.AssertNoChange()
+}
+
+func (s *ModelMigrationSuite) createStatusWatcher(c *gc.C, st *state.State) (
+	state.NotifyWatcher, statetesting.NotifyWatcherC,
+) {
+	w, err := st.WatchMigrationStatus()
+	c.Assert(err, jc.ErrorIsNil)
+	s.AddCleanup(func(c *gc.C) { statetesting.AssertStop(c, w) })
+	return w, statetesting.NewNotifyWatcherC(c, st, w)
+}
+
 func assertPhase(c *gc.C, mig state.ModelMigration, phase migration.Phase) {
 	actualPhase, err := mig.Phase()
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -2637,21 +2637,21 @@ func (w *blockDevicesWatcher) loop() error {
 	}
 }
 
-// WatchForModelMigration returns a notify watcher which which report
-// when a migration is in progress for the model associated with the
+// WatchForModelMigration returns a notify watcher which reports when
+// a migration is in progress for the model associated with the
 // State. Only in-progress and newly created migrations are reported.
 func (st *State) WatchForModelMigration() (NotifyWatcher, error) {
-	return newModelMigrationWatcher(st), nil
+	return newMigrationActiveWatcher(st), nil
 }
 
-type modelMigrationWatcher struct {
+type migrationActiveWatcher struct {
 	commonWatcher
 	collName string
 	sink     chan struct{}
 }
 
-func newModelMigrationWatcher(st *State) NotifyWatcher {
-	w := &modelMigrationWatcher{
+func newMigrationActiveWatcher(st *State) NotifyWatcher {
+	w := &migrationActiveWatcher{
 		commonWatcher: commonWatcher{st: st},
 		collName:      modelMigrationsActiveC,
 		sink:          make(chan struct{}),
@@ -2665,11 +2665,11 @@ func newModelMigrationWatcher(st *State) NotifyWatcher {
 }
 
 // Changes returns the event channel for this watcher.
-func (w *modelMigrationWatcher) Changes() <-chan struct{} {
+func (w *migrationActiveWatcher) Changes() <-chan struct{} {
 	return w.sink
 }
 
-func (w *modelMigrationWatcher) loop() error {
+func (w *migrationActiveWatcher) loop() error {
 	in := make(chan watcher.Change)
 	filter := func(id interface{}) bool {
 		// Only report migrations for the requested model.
@@ -2702,6 +2702,95 @@ func (w *modelMigrationWatcher) loop() error {
 				continue
 			}
 
+			if _, ok := collect(change, in, w.tomb.Dying()); !ok {
+				return tomb.ErrDying
+			}
+			out = w.sink
+		case out <- struct{}{}:
+			out = nil
+		}
+	}
+}
+
+// WatchMigrationStatus returns a NotifyWatcher which triggers
+// whenever the status of latest migration for the State's model
+// changes. One instance can be used across migrations. The watcher
+// will report changes when one migration finishes and another one
+// begins.
+//
+// Note that this watcher does not produce an initial event if there's
+// never been a migration attempt for the model.
+func (st *State) WatchMigrationStatus() (NotifyWatcher, error) {
+	return newMigrationStatusWatcher(st), nil
+}
+
+type migrationStatusWatcher struct {
+	commonWatcher
+	collName string
+	sink     chan struct{}
+}
+
+func newMigrationStatusWatcher(st *State) NotifyWatcher {
+	w := &migrationStatusWatcher{
+		commonWatcher: commonWatcher{st: st},
+		collName:      modelMigrationStatusC,
+		sink:          make(chan struct{}),
+	}
+	go func() {
+		defer w.tomb.Done()
+		defer close(w.sink)
+		w.tomb.Kill(w.loop())
+	}()
+	return w
+}
+
+// Changes returns the event channel for this watcher.
+func (w *migrationStatusWatcher) Changes() <-chan struct{} {
+	return w.sink
+}
+
+func (w *migrationStatusWatcher) loop() error {
+	in := make(chan watcher.Change)
+
+	// Watch the entire modelMigrationStatusC collection for migration
+	// status updates related to the State's model. This is more
+	// efficient and simpler than tracking the current active
+	// migration (and changing watchers when one migration finishes
+	// and another starts.
+	//
+	// This approach is safe because there are strong guarantees that
+	// there will only be one active migration per model. The watcher
+	// will only see changes for one migration status document at a
+	// time for the model.
+	filter := func(id interface{}) bool {
+		_, err := w.st.strictLocalID(id.(string))
+		return err == nil
+	}
+	w.st.watcher.WatchCollectionWithFilter(w.collName, in, filter)
+	defer w.st.watcher.UnwatchCollection(w.collName, in)
+
+	var out chan<- struct{}
+
+	// If there is a migration record for the model - active or not -
+	// send an initial event.
+	if _, err := w.st.GetModelMigration(); errors.IsNotFound(err) {
+		// Nothing to report.
+	} else if err != nil {
+		return errors.Trace(err)
+	} else {
+		out = w.sink
+	}
+
+	for {
+		select {
+		case <-w.tomb.Dying():
+			return tomb.ErrDying
+		case <-w.st.watcher.Dead():
+			return stateWatcherDeadError(w.st.watcher.Err())
+		case change := <-in:
+			if change.Revno == -1 {
+				return errors.New("model migration status disappeared (shouldn't happen)")
+			}
 			if _, ok := collect(change, in, w.tomb.Dying()); !ok {
 				return tomb.ErrDying
 			}


### PR DESCRIPTION
This watcher triggers whenever there's a status change for a model's migration. It works across multiple migration attempts for a model.

Already reviewed here (different branch): http://reviews.vapour.ws/r/4223/

(Review request: http://reviews.vapour.ws/r/4273/)