### PR TITLE
Fixes 1524297: Openstack support for virt-type constraint. 

### DIFF
--- a/provider/openstack/image.go
+++ b/provider/openstack/image.go
@@ -15,12 +15,16 @@ func findInstanceSpec(
 	ic *instances.InstanceConstraint,
 	imageMetadata []*imagemetadata.ImageMetadata,
 ) (*instances.InstanceSpec, error) {
-	// first construct all available instance types from the supported flavors.
+	// First construct all available instance types from the supported flavors.
 	nova := e.nova()
 	flavors, err := nova.ListFlavorsDetail()
 	if err != nil {
 		return nil, err
 	}
+	// Not all needed information is available in flavors,
+	// for e.g. architectures or virtualisation types.
+	// For these properties, we assume that all instance types support
+	// all values.
 	allInstanceTypes := []instances.InstanceType{}
 	for _, flavor := range flavors {
 		instanceType := instances.InstanceType{
@@ -46,7 +50,7 @@ func findInstanceSpec(
 		return nil, err
 	}
 
-	// If image constraints did not have a virtualisation type,
+	// If instance constraints did not have a virtualisation type,
 	// but image metadata did, we will have an instance type
 	// with virtualisation type of an image.
 	if !ic.Constraints.HasVirtType() && spec.Image.VirtType != "" {

--- a/provider/openstack/image.go
+++ b/provider/openstack/image.go
@@ -32,6 +32,11 @@ func findInstanceSpec(
 			RootDisk: uint64(flavor.Disk * 1024),
 			// tags not currently supported on openstack
 		}
+		if ic.Constraints.HasVirtType() {
+			// Instance Type virtual type depends on the virtual type of the selected image, i.e.
+			// picking an image with a virt type gives a machine with this virt type.
+			instanceType.VirtType = ic.Constraints.VirtType
+		}
 		allInstanceTypes = append(allInstanceTypes, instanceType)
 	}
 
@@ -39,6 +44,13 @@ func findInstanceSpec(
 	spec, err := instances.FindInstanceSpec(images, ic, allInstanceTypes)
 	if err != nil {
 		return nil, err
+	}
+
+	// If image constraints did not have a virtualisation type,
+	// but image metadata did, we will have an instance type
+	// with virtualisation type of an image.
+	if !ic.Constraints.HasVirtType() && spec.Image.VirtType != "" {
+		spec.InstanceType.VirtType = &spec.Image.VirtType
 	}
 	return spec, nil
 }

--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	jujuerrors "github.com/juju/errors"
@@ -954,10 +955,10 @@ func (s *localServerSuite) TestConstraintsValidator(c *gc.C) {
 	env := s.Open(c)
 	validator, err := env.ConstraintsValidator()
 	c.Assert(err, jc.ErrorIsNil)
-	cons := constraints.MustParse("arch=amd64 cpu-power=10 virt-type=kvm")
+	cons := constraints.MustParse("arch=amd64 cpu-power=10 virt-type=lxd")
 	unsupported, err := validator.Validate(cons)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(unsupported, jc.SameContents, []string{"cpu-power", "virt-type"})
+	c.Assert(unsupported, jc.SameContents, []string{"cpu-power"})
 }
 
 func (s *localServerSuite) TestConstraintsValidatorVocab(c *gc.C) {
@@ -970,6 +971,10 @@ func (s *localServerSuite) TestConstraintsValidatorVocab(c *gc.C) {
 	cons = constraints.MustParse("instance-type=foo")
 	_, err = validator.Validate(cons)
 	c.Assert(err, gc.ErrorMatches, "invalid constraint value: instance-type=foo\nvalid values are:.*")
+
+	cons = constraints.MustParse("virt-type=foo")
+	_, err = validator.Validate(cons)
+	c.Assert(err, gc.ErrorMatches, regexp.QuoteMeta("invalid constraint value: virt-type=foo\nvalid values are: [lxd qemu]"))
 }
 
 func (s *localServerSuite) TestConstraintsMerge(c *gc.C) {
@@ -996,6 +1001,60 @@ func (s *localServerSuite) TestFindImageInstanceConstraint(c *gc.C) {
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(spec.InstanceType.Name, gc.Equals, "m1.tiny")
+}
+
+func (s *localServerSuite) TestFindInstanceImageConstraintHypervisor(c *gc.C) {
+	testVirtType := "qemu"
+	env := s.Open(c)
+	imageMetadata := []*imagemetadata.ImageMetadata{{
+		Id:       "image-id",
+		Arch:     "amd64",
+		VirtType: testVirtType,
+	}}
+
+	spec, err := openstack.FindInstanceSpec(
+		env, coretesting.FakeDefaultSeries, "amd64", "virt-type="+testVirtType,
+		imageMetadata,
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(spec.InstanceType.VirtType, gc.NotNil)
+	c.Assert(*spec.InstanceType.VirtType, gc.Equals, testVirtType)
+	c.Assert(spec.InstanceType.Name, gc.Equals, "m1.small")
+}
+
+func (s *localServerSuite) TestFindInstanceImageWithHypervisorNoConstraint(c *gc.C) {
+	testVirtType := "qemu"
+	env := s.Open(c)
+	imageMetadata := []*imagemetadata.ImageMetadata{{
+		Id:       "image-id",
+		Arch:     "amd64",
+		VirtType: testVirtType,
+	}}
+
+	spec, err := openstack.FindInstanceSpec(
+		env, coretesting.FakeDefaultSeries, "amd64", "",
+		imageMetadata,
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(spec.InstanceType.VirtType, gc.NotNil)
+	c.Assert(*spec.InstanceType.VirtType, gc.Equals, testVirtType)
+	c.Assert(spec.InstanceType.Name, gc.Equals, "m1.small")
+}
+
+func (s *localServerSuite) TestFindInstanceNoConstraint(c *gc.C) {
+	env := s.Open(c)
+	imageMetadata := []*imagemetadata.ImageMetadata{{
+		Id:   "image-id",
+		Arch: "amd64",
+	}}
+
+	spec, err := openstack.FindInstanceSpec(
+		env, coretesting.FakeDefaultSeries, "amd64", "",
+		imageMetadata,
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(spec.InstanceType.VirtType, gc.IsNil)
+	c.Assert(spec.InstanceType.Name, gc.Equals, "m1.small")
 }
 
 func (s *localServerSuite) TestFindImageInvalidInstanceConstraint(c *gc.C) {

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -425,9 +425,6 @@ func (e *Environ) SupportedArchitectures() ([]string, error) {
 var unsupportedConstraints = []string{
 	constraints.Tags,
 	constraints.CpuPower,
-	// TODO(anastasiamac 2016-03-16) LP#1524297
-	// use virt-type in StartInstances
-	constraints.VirtType,
 }
 
 // ConstraintsValidator is defined on the Environs interface.
@@ -452,6 +449,7 @@ func (e *Environ) ConstraintsValidator() (constraints.Validator, error) {
 		instTypeNames[i] = flavor.Name
 	}
 	validator.RegisterVocabulary(constraints.InstanceType, instTypeNames)
+	validator.RegisterVocabulary(constraints.VirtType, []string{"lxd", "qemu"})
 	return validator, nil
 }
 


### PR DESCRIPTION
Openstack provider supports virt-type constraint. 

For openstack clouds seeded with images where virtualisation type is defined, this PR allows to specify "--constraints="virt-type=...".  Currently supported types are lxd and qemu.

For deployments with no constraints specified, where an image with virtualisation type is used, instance type virtualisation type will reflect it.

(Review request: http://reviews.vapour.ws/r/4276/)