### PR TITLE
cloudconfig: change windows untar implementation from C# to powershell

### DIFF
--- a/cloudconfig/powershell_helpers.go
+++ b/cloudconfig/powershell_helpers.go
@@ -451,371 +451,150 @@ function SetUserLogonAsServiceRights($UserName)
 	}
 }
 
-$Source = @"
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
-using System.Net;
-using System.Text;
-
-namespace Tarer
-{
-	public enum EntryType : byte
-	{
-		File = 0,
-		FileObsolete = 0x30,
-		HardLink = 0x31,
-		SymLink = 0x32,
-		CharDevice = 0x33,
-		BlockDevice = 0x34,
-		Directory = 0x35,
-		Fifo = 0x36,
-	}
-
-	public interface ITarHeader
-	{
-		string FileName { get; set; }
-		long SizeInBytes { get; set; }
-		DateTime LastModification { get; set; }
-		int HeaderSize { get; }
-		EntryType EntryType { get; set; }
-	}
-
-	public class Tar
-	{
-		private byte[] dataBuffer = new byte[512];
-		private UsTarHeader header;
-		private Stream inStream;
-		private long remainingBytesInFile;
-
-		public Tar(Stream tarredData) {
-			inStream = tarredData;
-			header = new UsTarHeader();
-		}
-
-		public ITarHeader FileInfo
-		{
-			get { return header; }
-		}
-
-		public void ReadToEnd(string destDirectory)
-		{
-			while (MoveNext())
-			{
-				string fileNameFromArchive = FileInfo.FileName;
-				string totalPath = destDirectory + Path.DirectorySeparatorChar + fileNameFromArchive;
-				if(UsTarHeader.IsPathSeparator(fileNameFromArchive[fileNameFromArchive.Length -1]) || FileInfo.EntryType == EntryType.Directory)
-				{
-					Directory.CreateDirectory(totalPath);
-					continue;
-				}
-				string fileName = Path.GetFileName(totalPath);
-				string directory = totalPath.Remove(totalPath.Length - fileName.Length);
-				Directory.CreateDirectory(directory);
-				using (FileStream file = File.Create(totalPath))
-				{
-					Read(file);
-				}
-			}
-		}
-
-		public void Read(Stream dataDestination)
-		{
-			int readBytes;
-			byte[] read;
-			while ((readBytes = Read(out read)) != -1)
-			{
-				dataDestination.Write(read, 0, readBytes);
-			}
-		}
-
-		protected int Read(out byte[] buffer)
-		{
-			if(remainingBytesInFile == 0)
-			{
-				buffer = null;
-				return -1;
-			}
-			int align512 = -1;
-			long toRead = remainingBytesInFile - 512;
-
-			if (toRead > 0)
-			{
-				toRead = 512;
-			}
-			else
-			{
-				align512 = 512 - (int)remainingBytesInFile;
-				toRead = remainingBytesInFile;
-			}
-
-			int bytesRead = 0;
-			long bytesRemainingToRead = toRead;
-			while (bytesRead < toRead && bytesRemainingToRead > 0)
-			{
-				bytesRead = inStream.Read(dataBuffer, (int)(toRead-bytesRemainingToRead), (int)bytesRemainingToRead);
-				bytesRemainingToRead -= bytesRead;
-				remainingBytesInFile -= bytesRead;
-			}
-
-			if(inStream.CanSeek && align512 > 0)
-			{
-				inStream.Seek(align512, SeekOrigin.Current);
-			}
-			else
-			{
-				while(align512 > 0)
-				{
-					inStream.ReadByte();
-					--align512;
-				}
-			}
-
-			buffer = dataBuffer;
-			return bytesRead;
-		}
-
-		private static bool IsEmpty(IEnumerable<byte> buffer)
-		{
-			foreach(byte b in buffer)
-			{
-				if (b != 0)
-				{
-					return false;
-				}
-			}
-			return true;
-		}
-
-		public bool MoveNext()
-		{
-			byte[] bytes = header.GetBytes();
-			int headerRead;
-			int bytesRemaining = header.HeaderSize;
-			while (bytesRemaining > 0)
-			{
-				headerRead = inStream.Read(bytes, header.HeaderSize - bytesRemaining, bytesRemaining);
-				bytesRemaining -= headerRead;
-				if (headerRead <= 0 && bytesRemaining > 0)
-				{
-					throw new Exception("Error reading tar header. Header size invalid");
-				}
-			}
-
-			if(IsEmpty(bytes))
-			{
-				bytesRemaining = header.HeaderSize;
-				while (bytesRemaining > 0)
-				{
-					headerRead = inStream.Read(bytes, header.HeaderSize - bytesRemaining, bytesRemaining);
-					bytesRemaining -= headerRead;
-					if (headerRead <= 0 && bytesRemaining > 0)
-					{
-						throw new Exception("Broken archive");
-					}
-				}
-				if (bytesRemaining == 0 && IsEmpty(bytes))
-				{
-					return false;
-				}
-				throw new Exception("Error occured: expected end of archive");
-			}
-
-			if (!header.UpdateHeaderFromBytes())
-			{
-				throw new Exception("Checksum check failed");
-			}
-
-			remainingBytesInFile = header.SizeInBytes;
-			return true;
-		}
-	}
-
-	internal class TarHeader : ITarHeader
-	{
-		private byte[] buffer = new byte[512];
-		private long headerChecksum;
-
-		private string fileName;
-		protected DateTime dateTime1970 = new DateTime(1970, 1, 1, 0, 0, 0);
-		private Tarer.EntryType _entryType;
-		public EntryType EntryType
-		{
-			get { return _entryType; }
-			set { _entryType = value; }
-		}
-		private static byte[] spaces = Encoding.ASCII.GetBytes("        ");
-
-		public virtual string FileName
-		{
-			get { return fileName.Replace("\0",string.Empty); }
-			set { fileName = value; }
-		}
-
-		private long _sizeInBytes;
-		public long SizeInBytes {
-			get{ return _sizeInBytes; }
-			set{ _sizeInBytes = value; }
-		}
-
-		public string SizeString { get { return Convert.ToString(SizeInBytes, 8).PadLeft(11, '0'); } }
-
-		private DateTime _lastModified;
-		public DateTime LastModification {
-			get{return _lastModified;}
-			set{_lastModified = value;}
-		}
-
-		public virtual int HeaderSize { get { return 512; } }
-
-		public byte[] GetBytes()
-		{
-			return buffer;
-		}
-
-		public virtual bool UpdateHeaderFromBytes()
-		{
-			FileName = Encoding.UTF8.GetString(buffer, 0, 100);
-
-			EntryType = (EntryType)buffer[156];
-
-			if((buffer[124] & 0x80) == 0x80) // if size in binary
-			{
-				long sizeBigEndian = BitConverter.ToInt64(buffer,0x80);
-				SizeInBytes = IPAddress.NetworkToHostOrder(sizeBigEndian);
-			}
-			else
-			{
-				SizeInBytes = Convert.ToInt64(Encoding.ASCII.GetString(buffer, 124, 11).Trim(), 8);
-			}
-			long unixTimeStamp = Convert.ToInt64(Encoding.ASCII.GetString(buffer,136,11).Trim(),8);
-			LastModification = dateTime1970.AddSeconds(unixTimeStamp);
-
-			long storedChecksum = Convert.ToInt64(Encoding.ASCII.GetString(buffer,148,6).Trim(), 8);
-			RecalculateChecksum(buffer);
-			if (storedChecksum == headerChecksum)
-			{
-				return true;
-			}
-
-			RecalculateAltChecksum(buffer);
-			return storedChecksum == headerChecksum;
-		}
-
-		private void RecalculateAltChecksum(byte[] buf)
-		{
-			spaces.CopyTo(buf, 148);
-			headerChecksum = 0;
-			foreach(byte b in buf)
-			{
-				if((b & 0x80) == 0x80)
-				{
-					headerChecksum -= b ^ 0x80;
-				}
-				else
-				{
-					headerChecksum += b;
-				}
-			}
-		}
-
-		protected virtual void RecalculateChecksum(byte[] buf)
-		{
-			// Set default value for checksum. That is 8 spaces.
-			spaces.CopyTo(buf, 148);
-			// Calculate checksum
-			headerChecksum = 0;
-			foreach (byte b in buf)
-			{
-				headerChecksum += b;
-			}
-		}
-	}
-	internal class UsTarHeader : TarHeader
-	{
-		private const string magic = "ustar";
-		private const string version = "  ";
-
-		private string namePrefix = string.Empty;
-
-		public override string FileName
-		{
-			get { return namePrefix.Replace("\0", string.Empty) + base.FileName.Replace("\0", string.Empty); }
-			set
-			{
-				if (value.Length > 255)
-				{
-					throw new Exception("UsTar fileName can not be longer than 255 chars");
-				}
-				if (value.Length > 100)
-				{
-				int position = value.Length - 100;
-				while (!IsPathSeparator(value[position]))
-				{
-					++position;
-					if (position == value.Length)
-					{
-						break;
-					}
-				}
-				if (position == value.Length)
-				{
-					position = value.Length - 100;
-				}
-				namePrefix = value.Substring(0, position);
-				base.FileName = value.Substring(position, value.Length - position);
-				}
-				else
-				{
-					base.FileName = value;
-				}
-			}
-		}
-
-		public override bool UpdateHeaderFromBytes()
-		{
-			byte[] bytes = GetBytes();
-			namePrefix = Encoding.UTF8.GetString(bytes, 347, 157);
-			return base.UpdateHeaderFromBytes();
-		}
-
-		internal static bool IsPathSeparator(char ch)
-		{
-			return (ch == '\\' || ch == '/' || ch == '|');
-		}
-	}
-}
-"@
-
-Add-Type -TypeDefinition $Source -Language CSharp
-
 Function GUnZip-File{
-	Param(
-		$infile,
-		$outdir
-		)
+    Param(
+        $infile,
+        $outdir
+        )
 
-	$input = New-Object System.IO.FileStream $inFile, ([IO.FileMode]::Open), ([IO.FileAccess]::Read), ([IO.FileShare]::Read)
-	$tempFile = "$env:TEMP\jujud.tar"
-	$tempOut = New-Object System.IO.FileStream $tempFile, ([IO.FileMode]::Create), ([IO.FileAccess]::Write), ([IO.FileShare]::None)
-	$gzipStream = New-Object System.IO.Compression.GzipStream $input, ([IO.Compression.CompressionMode]::Decompress)
+    $input = New-Object System.IO.FileStream $inFile, ([IO.FileMode]::Open), ([IO.FileAccess]::Read), ([IO.FileShare]::Read)
+    $tempFile = "$env:TEMP\jujud.tar"
+    $tempOut = New-Object System.IO.FileStream $tempFile, ([IO.FileMode]::Create), ([IO.FileAccess]::Write), ([IO.FileShare]::None)
+    $gzipStream = New-Object System.IO.Compression.GzipStream $input, ([IO.Compression.CompressionMode]::Decompress)
 
-	$buffer = New-Object byte[](1024)
-	while($true){
-		$read = $gzipstream.Read($buffer, 0, 1024)
-		if ($read -le 0){break}
-		$tempOut.Write($buffer, 0, $read)
-	}
-	$gzipStream.Close()
-	$tempOut.Close()
-	$input.Close()
+    $buffer = New-Object byte[](1024)
+    while($true){
+        $read = $gzipstream.Read($buffer, 0, 1024)
+        if ($read -le 0){break}
+        $tempOut.Write($buffer, 0, $read)
+    }
+    $gzipStream.Close()
+    $tempOut.Close()
+    $input.Close()
 
-	$in = New-Object System.IO.FileStream $tempFile, ([IO.FileMode]::Open), ([IO.FileAccess]::Read), ([IO.FileShare]::Read)
-	$tar = New-Object Tarer.Tar($in)
-	$tar.ReadToEnd($outdir)
-	$in.Close()
-	rm $tempFile
+    $in = New-Object System.IO.FileStream $tempFile, ([IO.FileMode]::Open), ([IO.FileAccess]::Read), ([IO.FileShare]::Read)
+    Untar-File $in $outdir
+    $in.Close()
+    rm $tempFile
+}
+
+$HEADERSIZE = 512
+
+Function Untar-File {
+    Param(
+        $inStream,
+        $outdir
+        )
+	$DirectoryEntryType = 0x35
+    $headerBytes = New-Object byte[]($HEADERSIZE)
+
+    # $headerBytes is written inside, function returns whether we've reached the end
+    while(GetHeaderBytes $inStream $headerBytes) {
+        $fileName, $entryType, $sizeInBytes = GetFileInfoFromHeader $headerBytes
+
+        $totalPath = Join-Path $outDir $fileName
+        if ($entryType -eq $DirectoryEntryType) {
+            [System.IO.Directory]::CreateDirectory($totalPath)
+            continue;
+        }
+
+        $fName = [System.IO.Path]::GetFileName($totalPath)
+        $dirName = [System.IO.Path]::GetDirectoryName($totalPath)
+        [System.IO.Directory]::CreateDirectory($dirName)
+        $file = [System.IO.File]::Create($totalPath)
+        WriteTarEntryToFile $inStream $file $sizeInBytes
+        $file.Close()
+    }
+}
+
+Function WriteTarEntryToFile {
+    Param(
+        $inStream,
+        $outFile,
+        $sizeInBytes
+        )
+        $moveToAlign512 = 0
+        $toRead = 0
+        $buf = New-Object byte[](512)
+
+        $remainingBytesInFile = $sizeInBytes
+        while ($remainingBytesInFile -ne 0) {
+            if ($remainingBytesInFile - 512 -lt 0) {
+                $moveToAlign512 = 512 - $remainingBytesInFile
+                $toRead = $remainingBytesInFile
+            } else {
+                $toRead = 512
+            }
+
+            $bytesRead = 0
+            $bytesRemainingToRead = $toRead
+            while ($bytesRead -lt $toRead -and $bytesRemainingToRead -gt 0) {
+                $bytesRead = $inStream.Read($buf, $toRead - $bytesRemainingToRead, $bytesRemainingToRead)
+                $bytesRemainingToRead = $bytesRemainingToRead - $bytesRead
+                $remainingBytesInFile = $remainingBytesInFile - $bytesRead
+                $outFile.Write($buf, 0, $bytesRead)
+            }
+
+            if ($moveToAlign512 -ne 0) {
+                $inStream.Seek($moveToAlign512, [System.IO.SeekOrigin]::Current)
+            }
+        }
+}
+
+Function GetHeaderBytes {
+    Param($inStream, $headerBytes)
+
+    $headerRead = 0
+    $bytesRemaining = $HEADERSIZE
+	while ($bytesRemaining -gt 0)
+    {
+        $headerRead = $inStream.Read($headerBytes, $HEADERSIZE - $bytesRemaining, $bytesRemaining)
+        $bytesRemaining -= $headerRead
+        if ($headerRead -le 0 -and $bytesRemaining -gt 0)
+        {
+            throw "Error reading tar header. Header size invalid"
+        }
+    }
+
+    # Proper end of archive is 2 empty headers
+    if (IsEmptyByteArray $headerBytes) {
+        $bytesRemaining = $HEADERSIZE
+	    while ($bytesRemaining -gt 0)
+        {
+            $headerRead = $inStream.Read($headerBytes, $HEADERSIZE - $bytesRemaining, $bytesRemaining)
+            $bytesRemaining -= $headerRead
+            if ($headerRead -le 0 -and $bytesRemaining -gt 0)
+            {
+                throw "Broken end archive"
+            }
+        }
+        if ($bytesRemaining -eq 0 -and (IsEmptyByteArray($headerBytes)))
+        {
+            return $false
+        }
+        throw "Error occured: expected end of archive"
+    }
+
+    return $true
+}
+
+Function GetFileInfoFromHeader {
+    Param($headerBytes)
+
+    $FileName = [System.Text.Encoding]::UTF8.GetString($headerBytes, 0, 100);
+    $EntryType = $headerBytes[156];
+    $SizeInBytes = [Convert]::ToInt64([System.Text.Encoding]::ASCII.GetString($headerBytes, 124, 11).Trim(), 8);
+    Return $FileName.replace("` + "`" + `0", [String].Empty), $EntryType, $SizeInBytes
+}
+
+Function IsEmptyByteArray {
+    Param ($bytes)
+    foreach($b in $bytes) {
+        if ($b -ne 0) {
+            return $false
+        }
+    }
+    return $true
 }
 
 Function Get-FileSHA256{

--- a/cloudconfig/powershell_helpers.go
+++ b/cloudconfig/powershell_helpers.go
@@ -463,7 +463,7 @@ Function GUnZip-File{
     $gzipStream = New-Object System.IO.Compression.GzipStream $input, ([IO.Compression.CompressionMode]::Decompress)
 
     $buffer = New-Object byte[](1024)
-    while($true){
+    while($true) {
         $read = $gzipstream.Read($buffer, 0, 1024)
         if ($read -le 0){break}
         $tempOut.Write($buffer, 0, $read)
@@ -485,7 +485,7 @@ Function Untar-File {
         $inStream,
         $outdir
         )
-	$DirectoryEntryType = 0x35
+    $DirectoryEntryType = 0x35
     $headerBytes = New-Object byte[]($HEADERSIZE)
 
     # $headerBytes is written inside, function returns whether we've reached the end
@@ -513,32 +513,32 @@ Function WriteTarEntryToFile {
         $outFile,
         $sizeInBytes
         )
-        $moveToAlign512 = 0
-        $toRead = 0
-        $buf = New-Object byte[](512)
+    $moveToAlign512 = 0
+    $toRead = 0
+    $buf = New-Object byte[](512)
 
-        $remainingBytesInFile = $sizeInBytes
-        while ($remainingBytesInFile -ne 0) {
-            if ($remainingBytesInFile - 512 -lt 0) {
-                $moveToAlign512 = 512 - $remainingBytesInFile
-                $toRead = $remainingBytesInFile
-            } else {
-                $toRead = 512
-            }
-
-            $bytesRead = 0
-            $bytesRemainingToRead = $toRead
-            while ($bytesRead -lt $toRead -and $bytesRemainingToRead -gt 0) {
-                $bytesRead = $inStream.Read($buf, $toRead - $bytesRemainingToRead, $bytesRemainingToRead)
-                $bytesRemainingToRead = $bytesRemainingToRead - $bytesRead
-                $remainingBytesInFile = $remainingBytesInFile - $bytesRead
-                $outFile.Write($buf, 0, $bytesRead)
-            }
-
-            if ($moveToAlign512 -ne 0) {
-                $inStream.Seek($moveToAlign512, [System.IO.SeekOrigin]::Current)
-            }
+    $remainingBytesInFile = $sizeInBytes
+    while ($remainingBytesInFile -ne 0) {
+        if ($remainingBytesInFile - 512 -lt 0) {
+            $moveToAlign512 = 512 - $remainingBytesInFile
+            $toRead = $remainingBytesInFile
+        } else {
+            $toRead = 512
         }
+
+        $bytesRead = 0
+        $bytesRemainingToRead = $toRead
+        while ($bytesRead -lt $toRead -and $bytesRemainingToRead -gt 0) {
+            $bytesRead = $inStream.Read($buf, $toRead - $bytesRemainingToRead, $bytesRemainingToRead)
+            $bytesRemainingToRead = $bytesRemainingToRead - $bytesRead
+            $remainingBytesInFile = $remainingBytesInFile - $bytesRead
+            $outFile.Write($buf, 0, $bytesRead)
+        }
+
+        if ($moveToAlign512 -ne 0) {
+            $inStream.Seek($moveToAlign512, [System.IO.SeekOrigin]::Current)
+        }
+    }
 }
 
 Function GetHeaderBytes {
@@ -546,12 +546,10 @@ Function GetHeaderBytes {
 
     $headerRead = 0
     $bytesRemaining = $HEADERSIZE
-	while ($bytesRemaining -gt 0)
-    {
+    while ($bytesRemaining -gt 0) {
         $headerRead = $inStream.Read($headerBytes, $HEADERSIZE - $bytesRemaining, $bytesRemaining)
         $bytesRemaining -= $headerRead
-        if ($headerRead -le 0 -and $bytesRemaining -gt 0)
-        {
+        if ($headerRead -le 0 -and $bytesRemaining -gt 0) {
             throw "Error reading tar header. Header size invalid"
         }
     }
@@ -559,20 +557,17 @@ Function GetHeaderBytes {
     # Proper end of archive is 2 empty headers
     if (IsEmptyByteArray $headerBytes) {
         $bytesRemaining = $HEADERSIZE
-	    while ($bytesRemaining -gt 0)
-        {
+        while ($bytesRemaining -gt 0) {
             $headerRead = $inStream.Read($headerBytes, $HEADERSIZE - $bytesRemaining, $bytesRemaining)
             $bytesRemaining -= $headerRead
-            if ($headerRead -le 0 -and $bytesRemaining -gt 0)
-            {
+            if ($headerRead -le 0 -and $bytesRemaining -gt 0) {
                 throw "Broken end archive"
             }
         }
-        if ($bytesRemaining -eq 0 -and (IsEmptyByteArray($headerBytes)))
-        {
+        if ($bytesRemaining -eq 0 -and (IsEmptyByteArray($headerBytes))) {
             return $false
         }
-        throw "Error occured: expected end of archive"
+        throw "Error occurred: expected end of archive"
     }
 
     return $true

--- a/cloudconfig/windows_userdata_test.go
+++ b/cloudconfig/windows_userdata_test.go
@@ -456,7 +456,7 @@ Function GUnZip-File{
     $gzipStream = New-Object System.IO.Compression.GzipStream $input, ([IO.Compression.CompressionMode]::Decompress)
 
     $buffer = New-Object byte[](1024)
-    while($true){
+    while($true) {
         $read = $gzipstream.Read($buffer, 0, 1024)
         if ($read -le 0){break}
         $tempOut.Write($buffer, 0, $read)
@@ -478,7 +478,7 @@ Function Untar-File {
         $inStream,
         $outdir
         )
-	$DirectoryEntryType = 0x35
+    $DirectoryEntryType = 0x35
     $headerBytes = New-Object byte[]($HEADERSIZE)
 
     # $headerBytes is written inside, function returns whether we've reached the end
@@ -506,32 +506,32 @@ Function WriteTarEntryToFile {
         $outFile,
         $sizeInBytes
         )
-        $moveToAlign512 = 0
-        $toRead = 0
-        $buf = New-Object byte[](512)
+    $moveToAlign512 = 0
+    $toRead = 0
+    $buf = New-Object byte[](512)
 
-        $remainingBytesInFile = $sizeInBytes
-        while ($remainingBytesInFile -ne 0) {
-            if ($remainingBytesInFile - 512 -lt 0) {
-                $moveToAlign512 = 512 - $remainingBytesInFile
-                $toRead = $remainingBytesInFile
-            } else {
-                $toRead = 512
-            }
-
-            $bytesRead = 0
-            $bytesRemainingToRead = $toRead
-            while ($bytesRead -lt $toRead -and $bytesRemainingToRead -gt 0) {
-                $bytesRead = $inStream.Read($buf, $toRead - $bytesRemainingToRead, $bytesRemainingToRead)
-                $bytesRemainingToRead = $bytesRemainingToRead - $bytesRead
-                $remainingBytesInFile = $remainingBytesInFile - $bytesRead
-                $outFile.Write($buf, 0, $bytesRead)
-            }
-
-            if ($moveToAlign512 -ne 0) {
-                $inStream.Seek($moveToAlign512, [System.IO.SeekOrigin]::Current)
-            }
+    $remainingBytesInFile = $sizeInBytes
+    while ($remainingBytesInFile -ne 0) {
+        if ($remainingBytesInFile - 512 -lt 0) {
+            $moveToAlign512 = 512 - $remainingBytesInFile
+            $toRead = $remainingBytesInFile
+        } else {
+            $toRead = 512
         }
+
+        $bytesRead = 0
+        $bytesRemainingToRead = $toRead
+        while ($bytesRead -lt $toRead -and $bytesRemainingToRead -gt 0) {
+            $bytesRead = $inStream.Read($buf, $toRead - $bytesRemainingToRead, $bytesRemainingToRead)
+            $bytesRemainingToRead = $bytesRemainingToRead - $bytesRead
+            $remainingBytesInFile = $remainingBytesInFile - $bytesRead
+            $outFile.Write($buf, 0, $bytesRead)
+        }
+
+        if ($moveToAlign512 -ne 0) {
+            $inStream.Seek($moveToAlign512, [System.IO.SeekOrigin]::Current)
+        }
+    }
 }
 
 Function GetHeaderBytes {
@@ -539,12 +539,10 @@ Function GetHeaderBytes {
 
     $headerRead = 0
     $bytesRemaining = $HEADERSIZE
-	while ($bytesRemaining -gt 0)
-    {
+    while ($bytesRemaining -gt 0) {
         $headerRead = $inStream.Read($headerBytes, $HEADERSIZE - $bytesRemaining, $bytesRemaining)
         $bytesRemaining -= $headerRead
-        if ($headerRead -le 0 -and $bytesRemaining -gt 0)
-        {
+        if ($headerRead -le 0 -and $bytesRemaining -gt 0) {
             throw "Error reading tar header. Header size invalid"
         }
     }
@@ -552,20 +550,17 @@ Function GetHeaderBytes {
     # Proper end of archive is 2 empty headers
     if (IsEmptyByteArray $headerBytes) {
         $bytesRemaining = $HEADERSIZE
-	    while ($bytesRemaining -gt 0)
-        {
+        while ($bytesRemaining -gt 0) {
             $headerRead = $inStream.Read($headerBytes, $HEADERSIZE - $bytesRemaining, $bytesRemaining)
             $bytesRemaining -= $headerRead
-            if ($headerRead -le 0 -and $bytesRemaining -gt 0)
-            {
+            if ($headerRead -le 0 -and $bytesRemaining -gt 0) {
                 throw "Broken end archive"
             }
         }
-        if ($bytesRemaining -eq 0 -and (IsEmptyByteArray($headerBytes)))
-        {
+        if ($bytesRemaining -eq 0 -and (IsEmptyByteArray($headerBytes))) {
             return $false
         }
-        throw "Error occured: expected end of archive"
+        throw "Error occurred: expected end of archive"
     }
 
     return $true

--- a/cloudconfig/windows_userdata_test.go
+++ b/cloudconfig/windows_userdata_test.go
@@ -444,371 +444,150 @@ function SetUserLogonAsServiceRights($UserName)
 	}
 }
 
-$Source = @"
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
-using System.Net;
-using System.Text;
-
-namespace Tarer
-{
-	public enum EntryType : byte
-	{
-		File = 0,
-		FileObsolete = 0x30,
-		HardLink = 0x31,
-		SymLink = 0x32,
-		CharDevice = 0x33,
-		BlockDevice = 0x34,
-		Directory = 0x35,
-		Fifo = 0x36,
-	}
-
-	public interface ITarHeader
-	{
-		string FileName { get; set; }
-		long SizeInBytes { get; set; }
-		DateTime LastModification { get; set; }
-		int HeaderSize { get; }
-		EntryType EntryType { get; set; }
-	}
-
-	public class Tar
-	{
-		private byte[] dataBuffer = new byte[512];
-		private UsTarHeader header;
-		private Stream inStream;
-		private long remainingBytesInFile;
-
-		public Tar(Stream tarredData) {
-			inStream = tarredData;
-			header = new UsTarHeader();
-		}
-
-		public ITarHeader FileInfo
-		{
-			get { return header; }
-		}
-
-		public void ReadToEnd(string destDirectory)
-		{
-			while (MoveNext())
-			{
-				string fileNameFromArchive = FileInfo.FileName;
-				string totalPath = destDirectory + Path.DirectorySeparatorChar + fileNameFromArchive;
-				if(UsTarHeader.IsPathSeparator(fileNameFromArchive[fileNameFromArchive.Length -1]) || FileInfo.EntryType == EntryType.Directory)
-				{
-					Directory.CreateDirectory(totalPath);
-					continue;
-				}
-				string fileName = Path.GetFileName(totalPath);
-				string directory = totalPath.Remove(totalPath.Length - fileName.Length);
-				Directory.CreateDirectory(directory);
-				using (FileStream file = File.Create(totalPath))
-				{
-					Read(file);
-				}
-			}
-		}
-
-		public void Read(Stream dataDestination)
-		{
-			int readBytes;
-			byte[] read;
-			while ((readBytes = Read(out read)) != -1)
-			{
-				dataDestination.Write(read, 0, readBytes);
-			}
-		}
-
-		protected int Read(out byte[] buffer)
-		{
-			if(remainingBytesInFile == 0)
-			{
-				buffer = null;
-				return -1;
-			}
-			int align512 = -1;
-			long toRead = remainingBytesInFile - 512;
-
-			if (toRead > 0)
-			{
-				toRead = 512;
-			}
-			else
-			{
-				align512 = 512 - (int)remainingBytesInFile;
-				toRead = remainingBytesInFile;
-			}
-
-			int bytesRead = 0;
-			long bytesRemainingToRead = toRead;
-			while (bytesRead < toRead && bytesRemainingToRead > 0)
-			{
-				bytesRead = inStream.Read(dataBuffer, (int)(toRead-bytesRemainingToRead), (int)bytesRemainingToRead);
-				bytesRemainingToRead -= bytesRead;
-				remainingBytesInFile -= bytesRead;
-			}
-
-			if(inStream.CanSeek && align512 > 0)
-			{
-				inStream.Seek(align512, SeekOrigin.Current);
-			}
-			else
-			{
-				while(align512 > 0)
-				{
-					inStream.ReadByte();
-					--align512;
-				}
-			}
-
-			buffer = dataBuffer;
-			return bytesRead;
-		}
-
-		private static bool IsEmpty(IEnumerable<byte> buffer)
-		{
-			foreach(byte b in buffer)
-			{
-				if (b != 0)
-				{
-					return false;
-				}
-			}
-			return true;
-		}
-
-		public bool MoveNext()
-		{
-			byte[] bytes = header.GetBytes();
-			int headerRead;
-			int bytesRemaining = header.HeaderSize;
-			while (bytesRemaining > 0)
-			{
-				headerRead = inStream.Read(bytes, header.HeaderSize - bytesRemaining, bytesRemaining);
-				bytesRemaining -= headerRead;
-				if (headerRead <= 0 && bytesRemaining > 0)
-				{
-					throw new Exception("Error reading tar header. Header size invalid");
-				}
-			}
-
-			if(IsEmpty(bytes))
-			{
-				bytesRemaining = header.HeaderSize;
-				while (bytesRemaining > 0)
-				{
-					headerRead = inStream.Read(bytes, header.HeaderSize - bytesRemaining, bytesRemaining);
-					bytesRemaining -= headerRead;
-					if (headerRead <= 0 && bytesRemaining > 0)
-					{
-						throw new Exception("Broken archive");
-					}
-				}
-				if (bytesRemaining == 0 && IsEmpty(bytes))
-				{
-					return false;
-				}
-				throw new Exception("Error occured: expected end of archive");
-			}
-
-			if (!header.UpdateHeaderFromBytes())
-			{
-				throw new Exception("Checksum check failed");
-			}
-
-			remainingBytesInFile = header.SizeInBytes;
-			return true;
-		}
-	}
-
-	internal class TarHeader : ITarHeader
-	{
-		private byte[] buffer = new byte[512];
-		private long headerChecksum;
-
-		private string fileName;
-		protected DateTime dateTime1970 = new DateTime(1970, 1, 1, 0, 0, 0);
-		private Tarer.EntryType _entryType;
-		public EntryType EntryType
-		{
-			get { return _entryType; }
-			set { _entryType = value; }
-		}
-		private static byte[] spaces = Encoding.ASCII.GetBytes("        ");
-
-		public virtual string FileName
-		{
-			get { return fileName.Replace("\0",string.Empty); }
-			set { fileName = value; }
-		}
-
-		private long _sizeInBytes;
-		public long SizeInBytes {
-			get{ return _sizeInBytes; }
-			set{ _sizeInBytes = value; }
-		}
-
-		public string SizeString { get { return Convert.ToString(SizeInBytes, 8).PadLeft(11, '0'); } }
-
-		private DateTime _lastModified;
-		public DateTime LastModification {
-			get{return _lastModified;}
-			set{_lastModified = value;}
-		}
-
-		public virtual int HeaderSize { get { return 512; } }
-
-		public byte[] GetBytes()
-		{
-			return buffer;
-		}
-
-		public virtual bool UpdateHeaderFromBytes()
-		{
-			FileName = Encoding.UTF8.GetString(buffer, 0, 100);
-
-			EntryType = (EntryType)buffer[156];
-
-			if((buffer[124] & 0x80) == 0x80) // if size in binary
-			{
-				long sizeBigEndian = BitConverter.ToInt64(buffer,0x80);
-				SizeInBytes = IPAddress.NetworkToHostOrder(sizeBigEndian);
-			}
-			else
-			{
-				SizeInBytes = Convert.ToInt64(Encoding.ASCII.GetString(buffer, 124, 11).Trim(), 8);
-			}
-			long unixTimeStamp = Convert.ToInt64(Encoding.ASCII.GetString(buffer,136,11).Trim(),8);
-			LastModification = dateTime1970.AddSeconds(unixTimeStamp);
-
-			long storedChecksum = Convert.ToInt64(Encoding.ASCII.GetString(buffer,148,6).Trim(), 8);
-			RecalculateChecksum(buffer);
-			if (storedChecksum == headerChecksum)
-			{
-				return true;
-			}
-
-			RecalculateAltChecksum(buffer);
-			return storedChecksum == headerChecksum;
-		}
-
-		private void RecalculateAltChecksum(byte[] buf)
-		{
-			spaces.CopyTo(buf, 148);
-			headerChecksum = 0;
-			foreach(byte b in buf)
-			{
-				if((b & 0x80) == 0x80)
-				{
-					headerChecksum -= b ^ 0x80;
-				}
-				else
-				{
-					headerChecksum += b;
-				}
-			}
-		}
-
-		protected virtual void RecalculateChecksum(byte[] buf)
-		{
-			// Set default value for checksum. That is 8 spaces.
-			spaces.CopyTo(buf, 148);
-			// Calculate checksum
-			headerChecksum = 0;
-			foreach (byte b in buf)
-			{
-				headerChecksum += b;
-			}
-		}
-	}
-	internal class UsTarHeader : TarHeader
-	{
-		private const string magic = "ustar";
-		private const string version = "  ";
-
-		private string namePrefix = string.Empty;
-
-		public override string FileName
-		{
-			get { return namePrefix.Replace("\0", string.Empty) + base.FileName.Replace("\0", string.Empty); }
-			set
-			{
-				if (value.Length > 255)
-				{
-					throw new Exception("UsTar fileName can not be longer than 255 chars");
-				}
-				if (value.Length > 100)
-				{
-				int position = value.Length - 100;
-				while (!IsPathSeparator(value[position]))
-				{
-					++position;
-					if (position == value.Length)
-					{
-						break;
-					}
-				}
-				if (position == value.Length)
-				{
-					position = value.Length - 100;
-				}
-				namePrefix = value.Substring(0, position);
-				base.FileName = value.Substring(position, value.Length - position);
-				}
-				else
-				{
-					base.FileName = value;
-				}
-			}
-		}
-
-		public override bool UpdateHeaderFromBytes()
-		{
-			byte[] bytes = GetBytes();
-			namePrefix = Encoding.UTF8.GetString(bytes, 347, 157);
-			return base.UpdateHeaderFromBytes();
-		}
-
-		internal static bool IsPathSeparator(char ch)
-		{
-			return (ch == '\\' || ch == '/' || ch == '|');
-		}
-	}
-}
-"@
-
-Add-Type -TypeDefinition $Source -Language CSharp
-
 Function GUnZip-File{
-	Param(
-		$infile,
-		$outdir
-		)
+    Param(
+        $infile,
+        $outdir
+        )
 
-	$input = New-Object System.IO.FileStream $inFile, ([IO.FileMode]::Open), ([IO.FileAccess]::Read), ([IO.FileShare]::Read)
-	$tempFile = "$env:TEMP\jujud.tar"
-	$tempOut = New-Object System.IO.FileStream $tempFile, ([IO.FileMode]::Create), ([IO.FileAccess]::Write), ([IO.FileShare]::None)
-	$gzipStream = New-Object System.IO.Compression.GzipStream $input, ([IO.Compression.CompressionMode]::Decompress)
+    $input = New-Object System.IO.FileStream $inFile, ([IO.FileMode]::Open), ([IO.FileAccess]::Read), ([IO.FileShare]::Read)
+    $tempFile = "$env:TEMP\jujud.tar"
+    $tempOut = New-Object System.IO.FileStream $tempFile, ([IO.FileMode]::Create), ([IO.FileAccess]::Write), ([IO.FileShare]::None)
+    $gzipStream = New-Object System.IO.Compression.GzipStream $input, ([IO.Compression.CompressionMode]::Decompress)
 
-	$buffer = New-Object byte[](1024)
-	while($true){
-		$read = $gzipstream.Read($buffer, 0, 1024)
-		if ($read -le 0){break}
-		$tempOut.Write($buffer, 0, $read)
-	}
-	$gzipStream.Close()
-	$tempOut.Close()
-	$input.Close()
+    $buffer = New-Object byte[](1024)
+    while($true){
+        $read = $gzipstream.Read($buffer, 0, 1024)
+        if ($read -le 0){break}
+        $tempOut.Write($buffer, 0, $read)
+    }
+    $gzipStream.Close()
+    $tempOut.Close()
+    $input.Close()
 
-	$in = New-Object System.IO.FileStream $tempFile, ([IO.FileMode]::Open), ([IO.FileAccess]::Read), ([IO.FileShare]::Read)
-	$tar = New-Object Tarer.Tar($in)
-	$tar.ReadToEnd($outdir)
-	$in.Close()
-	rm $tempFile
+    $in = New-Object System.IO.FileStream $tempFile, ([IO.FileMode]::Open), ([IO.FileAccess]::Read), ([IO.FileShare]::Read)
+    Untar-File $in $outdir
+    $in.Close()
+    rm $tempFile
+}
+
+$HEADERSIZE = 512
+
+Function Untar-File {
+    Param(
+        $inStream,
+        $outdir
+        )
+	$DirectoryEntryType = 0x35
+    $headerBytes = New-Object byte[]($HEADERSIZE)
+
+    # $headerBytes is written inside, function returns whether we've reached the end
+    while(GetHeaderBytes $inStream $headerBytes) {
+        $fileName, $entryType, $sizeInBytes = GetFileInfoFromHeader $headerBytes
+
+        $totalPath = Join-Path $outDir $fileName
+        if ($entryType -eq $DirectoryEntryType) {
+            [System.IO.Directory]::CreateDirectory($totalPath)
+            continue;
+        }
+
+        $fName = [System.IO.Path]::GetFileName($totalPath)
+        $dirName = [System.IO.Path]::GetDirectoryName($totalPath)
+        [System.IO.Directory]::CreateDirectory($dirName)
+        $file = [System.IO.File]::Create($totalPath)
+        WriteTarEntryToFile $inStream $file $sizeInBytes
+        $file.Close()
+    }
+}
+
+Function WriteTarEntryToFile {
+    Param(
+        $inStream,
+        $outFile,
+        $sizeInBytes
+        )
+        $moveToAlign512 = 0
+        $toRead = 0
+        $buf = New-Object byte[](512)
+
+        $remainingBytesInFile = $sizeInBytes
+        while ($remainingBytesInFile -ne 0) {
+            if ($remainingBytesInFile - 512 -lt 0) {
+                $moveToAlign512 = 512 - $remainingBytesInFile
+                $toRead = $remainingBytesInFile
+            } else {
+                $toRead = 512
+            }
+
+            $bytesRead = 0
+            $bytesRemainingToRead = $toRead
+            while ($bytesRead -lt $toRead -and $bytesRemainingToRead -gt 0) {
+                $bytesRead = $inStream.Read($buf, $toRead - $bytesRemainingToRead, $bytesRemainingToRead)
+                $bytesRemainingToRead = $bytesRemainingToRead - $bytesRead
+                $remainingBytesInFile = $remainingBytesInFile - $bytesRead
+                $outFile.Write($buf, 0, $bytesRead)
+            }
+
+            if ($moveToAlign512 -ne 0) {
+                $inStream.Seek($moveToAlign512, [System.IO.SeekOrigin]::Current)
+            }
+        }
+}
+
+Function GetHeaderBytes {
+    Param($inStream, $headerBytes)
+
+    $headerRead = 0
+    $bytesRemaining = $HEADERSIZE
+	while ($bytesRemaining -gt 0)
+    {
+        $headerRead = $inStream.Read($headerBytes, $HEADERSIZE - $bytesRemaining, $bytesRemaining)
+        $bytesRemaining -= $headerRead
+        if ($headerRead -le 0 -and $bytesRemaining -gt 0)
+        {
+            throw "Error reading tar header. Header size invalid"
+        }
+    }
+
+    # Proper end of archive is 2 empty headers
+    if (IsEmptyByteArray $headerBytes) {
+        $bytesRemaining = $HEADERSIZE
+	    while ($bytesRemaining -gt 0)
+        {
+            $headerRead = $inStream.Read($headerBytes, $HEADERSIZE - $bytesRemaining, $bytesRemaining)
+            $bytesRemaining -= $headerRead
+            if ($headerRead -le 0 -and $bytesRemaining -gt 0)
+            {
+                throw "Broken end archive"
+            }
+        }
+        if ($bytesRemaining -eq 0 -and (IsEmptyByteArray($headerBytes)))
+        {
+            return $false
+        }
+        throw "Error occured: expected end of archive"
+    }
+
+    return $true
+}
+
+Function GetFileInfoFromHeader {
+    Param($headerBytes)
+
+    $FileName = [System.Text.Encoding]::UTF8.GetString($headerBytes, 0, 100);
+    $EntryType = $headerBytes[156];
+    $SizeInBytes = [Convert]::ToInt64([System.Text.Encoding]::ASCII.GetString($headerBytes, 124, 11).Trim(), 8);
+    Return $FileName.replace("` + "`" + `0", [String].Empty), $EntryType, $SizeInBytes
+}
+
+Function IsEmptyByteArray {
+    Param ($bytes)
+    foreach($b in $bytes) {
+        if ($b -ne 0) {
+            return $false
+        }
+    }
+    return $true
 }
 
 Function Get-FileSHA256{


### PR DESCRIPTION
For the upcoming Nano server we cannot use Add-Type to compile C# code and run it from within powershell. So we had to rewrite the untar code in powershell. It's *mostly* the same, more bits were thrown out this time compared to when the code was pulled from bitbucket. Most of it was simply not used at all, the most notable drop being checksum checking. Since we 1) already do it before untar-ing anyway and 2) we want to keep this as small as possible, it was skipped. 

For the rest of the Add-Type code we have a different upcoming solution, we will probably end up not using it at all on Nano.

(Review request: http://reviews.vapour.ws/r/4278/)