### PR TITLE
Migrate target abort and activate

### DIFF
--- a/api/migrationtarget/client.go
+++ b/api/migrationtarget/client.go
@@ -4,6 +4,8 @@
 package migrationtarget
 
 import (
+	"github.com/juju/names"
+
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/apiserver/params"
 )
@@ -15,6 +17,8 @@ type Client interface {
 	// Import takes a serialized model and imports it into the target
 	// controller.
 	Import([]byte) error
+	Abort(names.ModelTag) error
+	Activate(names.ModelTag) error
 }
 
 // NewClient returns a new Client based on an existing API connection.
@@ -31,4 +35,16 @@ type client struct {
 func (c *client) Import(bytes []byte) error {
 	serialized := params.SerializedModel{Bytes: bytes}
 	return c.caller.FacadeCall("Import", serialized, nil)
+}
+
+// Abort implements Client.
+func (c *client) Abort(tag names.ModelTag) error {
+	args := params.ModelArgs{ModelTag: tag.String()}
+	return c.caller.FacadeCall("Abort", args, nil)
+}
+
+// Activate implements Client.
+func (c *client) Activate(tag names.ModelTag) error {
+	args := params.ModelArgs{ModelTag: tag.String()}
+	return c.caller.FacadeCall("Activate", args, nil)
 }

--- a/api/migrationtarget/client_test.go
+++ b/api/migrationtarget/client_test.go
@@ -5,6 +5,7 @@ package migrationtarget_test
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/names"
 	jujutesting "github.com/juju/testing"
 	gc "gopkg.in/check.v1"
 
@@ -19,19 +20,50 @@ type ClientSuite struct {
 
 var _ = gc.Suite(&ClientSuite{})
 
-func (s *ClientSuite) TestImport(c *gc.C) {
+func (s *ClientSuite) getClientAndStub(c *gc.C) (migrationtarget.Client, *jujutesting.Stub) {
 	var stub jujutesting.Stub
 	apiCaller := apitesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		stub.AddCall(objType+"."+request, id, arg)
 		return errors.New("boom")
 	})
 	client := migrationtarget.NewClient(apiCaller)
+	return client, &stub
+}
+
+func (s *ClientSuite) TestImport(c *gc.C) {
+	client, stub := s.getClientAndStub(c)
 
 	err := client.Import([]byte("foo"))
 
 	expectedArg := params.SerializedModel{Bytes: []byte("foo")}
 	stub.CheckCalls(c, []jujutesting.StubCall{
 		{"MigrationTarget.Import", []interface{}{"", expectedArg}},
+	})
+	c.Assert(err, gc.ErrorMatches, "boom")
+}
+
+func (s *ClientSuite) TestAbort(c *gc.C) {
+	client, stub := s.getClientAndStub(c)
+
+	tag := names.NewModelTag("fake-uuid")
+	err := client.Abort(tag)
+
+	expectedArg := params.ModelArgs{ModelTag: tag.String()}
+	stub.CheckCalls(c, []jujutesting.StubCall{
+		{"MigrationTarget.Abort", []interface{}{"", expectedArg}},
+	})
+	c.Assert(err, gc.ErrorMatches, "boom")
+}
+
+func (s *ClientSuite) TestActivate(c *gc.C) {
+	client, stub := s.getClientAndStub(c)
+
+	tag := names.NewModelTag("fake-uuid")
+	err := client.Activate(tag)
+
+	expectedArg := params.ModelArgs{ModelTag: tag.String()}
+	stub.CheckCalls(c, []jujutesting.StubCall{
+		{"MigrationTarget.Activate", []interface{}{"", expectedArg}},
 	})
 	c.Assert(err, gc.ErrorMatches, "boom")
 }

--- a/api/migrationtarget/client_test.go
+++ b/api/migrationtarget/client_test.go
@@ -47,7 +47,7 @@ func (s *ClientSuite) TestAbort(c *gc.C) {
 
 	tag := names.NewModelTag("fake-uuid")
 	err := client.Abort(tag)
-	s.AssertModelCall(c, tag, "Abort", err)
+	s.AssertModelCall(c, stub, tag, "Abort", err)
 }
 
 func (s *ClientSuite) TestActivate(c *gc.C) {
@@ -55,13 +55,13 @@ func (s *ClientSuite) TestActivate(c *gc.C) {
 
 	tag := names.NewModelTag("fake-uuid")
 	err := client.Activate(tag)
-	s.AssertModelCall(c, tag, "Activate", err)
+	s.AssertModelCall(c, stub, tag, "Activate", err)
 }
 
-func (s *ClientSuite) AssertModelCall(c *gc.C, tag names.ModelTag, call string, err error) {
+func (s *ClientSuite) AssertModelCall(c *gc.C, stub *jujutesting.Stub, tag names.ModelTag, call string, err error) {
 	expectedArg := params.ModelArgs{ModelTag: tag.String()}
 	stub.CheckCalls(c, []jujutesting.StubCall{
-		{"MigrationTarget."+call, []interface{}{"", expectedArg}},
+		{"MigrationTarget." + call, []interface{}{"", expectedArg}},
 	})
 	c.Assert(err, gc.ErrorMatches, "boom")
-}}
+}

--- a/api/migrationtarget/client_test.go
+++ b/api/migrationtarget/client_test.go
@@ -47,12 +47,7 @@ func (s *ClientSuite) TestAbort(c *gc.C) {
 
 	tag := names.NewModelTag("fake-uuid")
 	err := client.Abort(tag)
-
-	expectedArg := params.ModelArgs{ModelTag: tag.String()}
-	stub.CheckCalls(c, []jujutesting.StubCall{
-		{"MigrationTarget.Abort", []interface{}{"", expectedArg}},
-	})
-	c.Assert(err, gc.ErrorMatches, "boom")
+	s.AssertModelCall(c, tag, "Abort", err)
 }
 
 func (s *ClientSuite) TestActivate(c *gc.C) {
@@ -60,10 +55,13 @@ func (s *ClientSuite) TestActivate(c *gc.C) {
 
 	tag := names.NewModelTag("fake-uuid")
 	err := client.Activate(tag)
+	s.AssertModelCall(c, tag, "Activate", err)
+}
 
+func (s *ClientSuite) AssertModelCall(c *gc.C, tag names.ModelTag, call string, err error) {
 	expectedArg := params.ModelArgs{ModelTag: tag.String()}
 	stub.CheckCalls(c, []jujutesting.StubCall{
-		{"MigrationTarget.Activate", []interface{}{"", expectedArg}},
+		{"MigrationTarget."+call, []interface{}{"", expectedArg}},
 	})
 	c.Assert(err, gc.ErrorMatches, "boom")
-}
+}}

--- a/api/migrationtarget/doc.go
+++ b/api/migrationtarget/doc.go
@@ -1,7 +1,7 @@
 // Copyright 2016 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-// This package defines the client side API facade for use by the
+// Package migrationtarget defines the client side API facade for use by the
 // migration master worker when communicating with the target
 // controller.
 package migrationtarget

--- a/apiserver/params/migration.go
+++ b/apiserver/params/migration.go
@@ -13,3 +13,8 @@ type SetMigrationPhaseArgs struct {
 type SerializedModel struct {
 	Bytes []byte `json:"bytes"`
 }
+
+// ModelArgs wraps a simple model tag.
+type ModelArgs struct {
+	ModelTag string `json:"model-tag"`
+}

--- a/state/state.go
+++ b/state/state.go
@@ -124,6 +124,17 @@ func (st *State) IsController() bool {
 // this method. Otherwise, there is a race condition in which collections
 // could be added to during or after the running of this method.
 func (st *State) RemoveAllModelDocs() error {
+	return st.removeAllModelDocs(bson.D{{"life", Dead}})
+}
+
+// RemoveImportingModelDocs removes all documents from multi-model collections
+// for the current model. This method asserts that the model's migration mode
+// is "importing".
+func (st *State) RemoveImportingModelDocs() error {
+	return st.removeAllModelDocs(bson.D{{"migration-mode", MigrationModeImporting}})
+}
+
+func (st *State) removeAllModelDocs(modelAssertion bson.D) error {
 	env, err := st.Model()
 	if err != nil {
 		return errors.Trace(err)
@@ -137,7 +148,7 @@ func (st *State) RemoveAllModelDocs() error {
 	}, {
 		C:      modelsC,
 		Id:     st.ModelUUID(),
-		Assert: bson.D{{"life", Dead}},
+		Assert: modelAssertion,
 		Remove: true,
 	}}
 

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -2881,10 +2881,7 @@ func (s *StateSuite) TestAdditionalValidation(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-func (s *StateSuite) TestRemoveAllEnvironDocs(c *gc.C) {
-	st := s.Factory.MakeModel(c, nil)
-	defer st.Close()
-
+func (s *StateSuite) insertFakeModelDocs(c *gc.C, st *state.State) string {
 	// insert one doc for each multiEnvCollection
 	var ops []mgotxn.Op
 	for _, collName := range state.MultiEnvCollections() {
@@ -2921,26 +2918,33 @@ func (s *StateSuite) TestRemoveAllEnvironDocs(c *gc.C) {
 		c.Assert(n, gc.Not(gc.Equals), 0)
 	}
 
-	// test that we can find the user:envName unique index
-	env, err := st.Model()
+	model, err := st.Model()
 	c.Assert(err, jc.ErrorIsNil)
-	indexColl, closer := state.GetCollection(st, "usermodelname")
+	return state.UserModelNameIndex(model.Owner().Canonical(), model.Name())
+}
+
+type checkUserModelNameArgs struct {
+	st     *state.State
+	id     string
+	exists bool
+}
+
+func (s *StateSuite) checkUserModelNameExists(c *gc.C, args checkUserModelNameArgs) {
+	indexColl, closer := state.GetCollection(args.st, "usermodelname")
 	defer closer()
-	id := state.UserModelNameIndex(env.Owner().Canonical(), env.Name())
-	n, err := indexColl.FindId(id).Count()
+	n, err := indexColl.FindId(args.id).Count()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(n, gc.Equals, 1)
+	if args.exists {
+		c.Assert(n, gc.Equals, 1)
+	} else {
+		c.Assert(n, gc.Equals, 0)
+	}
+}
 
-	err = state.SetModelLifeDead(st, st.ModelUUID())
-	c.Assert(err, jc.ErrorIsNil)
-
-	err = st.RemoveAllModelDocs()
-	c.Assert(err, jc.ErrorIsNil)
-
-	// test that we can not find the user:envName unique index
-	n, err = indexColl.FindId(id).Count()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(n, gc.Equals, 0)
+func (s *StateSuite) AssertModelDeleted(c *gc.C, st *state.State) {
+	// check to see if the model itself is gone
+	_, err := st.Model()
+	c.Assert(err, gc.ErrorMatches, `model not found`)
 
 	// ensure all docs for all multiEnvCollections are removed
 	for _, collName := range state.MultiEnvCollections() {
@@ -2952,12 +2956,68 @@ func (s *StateSuite) TestRemoveAllEnvironDocs(c *gc.C) {
 	}
 }
 
+func (s *StateSuite) TestRemoveAllEnvironDocs(c *gc.C) {
+	st := s.Factory.MakeModel(c, nil)
+	defer st.Close()
+
+	userModelKey := s.insertFakeModelDocs(c, st)
+	s.checkUserModelNameExists(c, checkUserModelNameArgs{st: st, id: userModelKey, exists: true})
+
+	err := state.SetModelLifeDead(st, st.ModelUUID())
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = st.RemoveAllModelDocs()
+	c.Assert(err, jc.ErrorIsNil)
+
+	// test that we can not find the user:envName unique index
+	s.checkUserModelNameExists(c, checkUserModelNameArgs{st: st, id: userModelKey, exists: false})
+	s.AssertModelDeleted(c, st)
+}
+
 func (s *StateSuite) TestRemoveAllEnvironDocsAliveEnvFails(c *gc.C) {
 	st := s.Factory.MakeModel(c, nil)
 	defer st.Close()
 
 	err := st.RemoveAllModelDocs()
 	c.Assert(err, gc.ErrorMatches, "transaction aborted")
+}
+
+func (s *StateSuite) TestRemoveImportingModelDocsFailsActive(c *gc.C) {
+	st := s.Factory.MakeModel(c, nil)
+	defer st.Close()
+
+	err := st.RemoveImportingModelDocs()
+	c.Assert(err, gc.ErrorMatches, "transaction aborted")
+}
+
+func (s *StateSuite) TestRemoveImportingModelDocsFailsExporting(c *gc.C) {
+	st := s.Factory.MakeModel(c, nil)
+	defer st.Close()
+	model, err := st.Model()
+	c.Assert(err, jc.ErrorIsNil)
+	err = model.SetMigrationMode(state.MigrationModeExporting)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = st.RemoveImportingModelDocs()
+	c.Assert(err, gc.ErrorMatches, "transaction aborted")
+}
+
+func (s *StateSuite) TestRemoveImportingModelDocsImporting(c *gc.C) {
+	st := s.Factory.MakeModel(c, nil)
+	defer st.Close()
+	userModelKey := s.insertFakeModelDocs(c, st)
+
+	model, err := st.Model()
+	c.Assert(err, jc.ErrorIsNil)
+	err = model.SetMigrationMode(state.MigrationModeImporting)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = st.RemoveImportingModelDocs()
+	c.Assert(err, jc.ErrorIsNil)
+
+	// test that we can not find the user:envName unique index
+	s.checkUserModelNameExists(c, checkUserModelNameArgs{st: st, id: userModelKey, exists: false})
+	s.AssertModelDeleted(c, st)
 }
 
 type attrs map[string]interface{}


### PR DESCRIPTION
Adds Abort and Activate to the MigrationTarget API façade and client.