### PR TITLE
apiserver: Add the MigrationMinion and MigrationStatusWatcher facades

### DIFF
--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -37,6 +37,7 @@ import (
 	_ "github.com/juju/juju/apiserver/metricsdebug"
 	_ "github.com/juju/juju/apiserver/metricsmanager"
 	_ "github.com/juju/juju/apiserver/migrationmaster"
+	_ "github.com/juju/juju/apiserver/migrationminion"
 	_ "github.com/juju/juju/apiserver/migrationtarget"
 	_ "github.com/juju/juju/apiserver/modelmanager"
 	_ "github.com/juju/juju/apiserver/provisioner"

--- a/apiserver/export_test.go
+++ b/apiserver/export_test.go
@@ -189,11 +189,19 @@ func (srv *Server) Addr() *net.TCPAddr {
 	return srv.lis.Addr().(*net.TCPAddr) // cannot fail
 }
 
-// PatchMigrationGetter overrides the migrationGetter function to
-// support testing.
-func PatchMigrationGetter(p Patcher, st modelMigrationGetter) {
-	p.PatchValue(&migrationGetter, func(*state.State) modelMigrationGetter {
+// PatchGetMigrationBackend overrides the getMigrationBackend function
+// to support testing.
+func PatchGetMigrationBackend(p Patcher, st migrationBackend) {
+	p.PatchValue(&getMigrationBackend, func(*state.State) migrationBackend {
 		return st
+	})
+}
+
+// PatchGetControllerCACert overrides the getControllerCACert function
+// to support testing.
+func PatchGetControllerCACert(p Patcher, caCert string) {
+	p.PatchValue(&getControllerCACert, func(migrationBackend) (string, error) {
+		return caCert, nil
 	})
 }
 

--- a/apiserver/migrationminion/doc.go
+++ b/apiserver/migrationminion/doc.go
@@ -1,0 +1,9 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Package migrationminion defines the API facade for use by the
+// migration minion worker to monitor the progress of, and interact
+// with, model migrations.
+//
+// The migration minion runs inside every non-controller agent.
+package migrationminion

--- a/apiserver/migrationminion/export_test.go
+++ b/apiserver/migrationminion/export_test.go
@@ -1,0 +1,16 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package migrationminion
+
+import "github.com/juju/juju/state"
+
+func PatchState(p Patcher, st Backend) {
+	p.PatchValue(&getBackend, func(*state.State) Backend {
+		return st
+	})
+}
+
+type Patcher interface {
+	PatchValue(ptr, value interface{})
+}

--- a/apiserver/migrationminion/migrationslave.go
+++ b/apiserver/migrationminion/migrationslave.go
@@ -1,0 +1,58 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package migrationminion
+
+import (
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/state"
+)
+
+func init() {
+	common.RegisterStandardFacade("MigrationMinion", 1, NewAPI)
+}
+
+// API implements the API required for the model migration
+// master worker.
+type API struct {
+	backend    Backend
+	authorizer common.Authorizer
+	resources  *common.Resources
+}
+
+// NewAPI creates a new API server endpoint for the model migration
+// master worker.
+func NewAPI(
+	st *state.State,
+	resources *common.Resources,
+	authorizer common.Authorizer,
+) (*API, error) {
+	if !(authorizer.AuthMachineAgent() || authorizer.AuthUnitAgent()) {
+		return nil, common.ErrPerm
+	}
+	return &API{
+		backend:    getBackend(st),
+		authorizer: authorizer,
+		resources:  resources,
+	}, nil
+}
+
+// Watch starts watching for status updates for a migration attempt
+// for the model. It will report when a migration starts and when its
+// status changes (including when it finishes). An initial event will
+// be fired if there has ever been a migration attempt for the model.
+//
+// The MigrationStatusWatcher facade must be used to receive events
+// from the watcher.
+func (api *API) Watch() (params.NotifyWatchResult, error) {
+	w, err := api.backend.WatchMigrationStatus()
+	if err != nil {
+		return params.NotifyWatchResult{}, errors.Trace(err)
+	}
+	return params.NotifyWatchResult{
+		NotifyWatcherId: api.resources.Register(w),
+	}, nil
+}

--- a/apiserver/migrationminion/migrationslave_test.go
+++ b/apiserver/migrationminion/migrationslave_test.go
@@ -1,0 +1,97 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package migrationminion_test
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/names"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/migrationminion"
+	apiservertesting "github.com/juju/juju/apiserver/testing"
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/testing"
+)
+
+// Ensure that Backend remains compatible with *state.State
+var _ migrationminion.Backend = (*state.State)(nil)
+
+type Suite struct {
+	testing.BaseSuite
+
+	backend    *stubBackend
+	resources  *common.Resources
+	authorizer apiservertesting.FakeAuthorizer
+}
+
+var _ = gc.Suite(&Suite{})
+
+func (s *Suite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+
+	s.backend = &stubBackend{}
+	migrationminion.PatchState(s, s.backend)
+
+	s.resources = common.NewResources()
+	s.AddCleanup(func(*gc.C) { s.resources.StopAll() })
+
+	s.authorizer = apiservertesting.FakeAuthorizer{
+		Tag: names.NewMachineTag("99"),
+	}
+}
+
+func (s *Suite) TestAuthMachineAgent(c *gc.C) {
+	s.authorizer.Tag = names.NewMachineTag("42")
+	s.mustMakeAPI(c)
+}
+
+func (s *Suite) TestAuthUnitAgent(c *gc.C) {
+	s.authorizer.Tag = names.NewUnitTag("foo/0")
+	s.mustMakeAPI(c)
+}
+
+func (s *Suite) TestAuthNotAgent(c *gc.C) {
+	s.authorizer.Tag = names.NewUserTag("dorothy")
+	_, err := s.makeAPI()
+	c.Assert(err, gc.Equals, common.ErrPerm)
+}
+
+func (s *Suite) TestWatchError(c *gc.C) {
+	s.backend.watchError = errors.New("boom")
+	api := s.mustMakeAPI(c)
+	_, err := api.Watch()
+	c.Assert(err, gc.ErrorMatches, "boom")
+	c.Assert(s.resources.Count(), gc.Equals, 0)
+}
+
+func (s *Suite) TestWatch(c *gc.C) {
+	api := s.mustMakeAPI(c)
+	result, err := api.Watch()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s.resources.Get(result.NotifyWatcherId), gc.NotNil)
+}
+
+func (s *Suite) makeAPI() (*migrationminion.API, error) {
+	return migrationminion.NewAPI(nil, s.resources, s.authorizer)
+}
+
+func (s *Suite) mustMakeAPI(c *gc.C) *migrationminion.API {
+	api, err := migrationminion.NewAPI(nil, s.resources, s.authorizer)
+	c.Assert(err, jc.ErrorIsNil)
+	return api
+}
+
+type stubBackend struct {
+	migrationminion.Backend
+	watchError error
+}
+
+func (b *stubBackend) WatchMigrationStatus() (state.NotifyWatcher, error) {
+	if b.watchError != nil {
+		return nil, b.watchError
+	}
+	return apiservertesting.NewFakeNotifyWatcher(), nil
+}

--- a/apiserver/migrationminion/package_test.go
+++ b/apiserver/migrationminion/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package migrationminion_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/apiserver/migrationminion/state.go
+++ b/apiserver/migrationminion/state.go
@@ -1,0 +1,16 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package migrationminion
+
+import "github.com/juju/juju/state"
+
+// Backend defines the state functionality required by the
+// MigrationMinion facade.
+type Backend interface {
+	WatchMigrationStatus() (state.NotifyWatcher, error)
+}
+
+var getBackend = func(st *state.State) Backend {
+	return st
+}

--- a/apiserver/params/migration.go
+++ b/apiserver/params/migration.go
@@ -3,6 +3,8 @@
 
 package params
 
+import "github.com/juju/juju/core/migration"
+
 // SetMigrationPhaseArgs provides a migration phase to the
 // migrationmaster.SetPhase API method.
 type SetMigrationPhaseArgs struct {
@@ -12,4 +14,14 @@ type SetMigrationPhaseArgs struct {
 // SerializedModel wraps a buffer contain a serialised Juju model.
 type SerializedModel struct {
 	Bytes []byte `json:"bytes"`
+}
+
+// MigrationStatus reports the current status of a model migration.
+type MigrationStatus struct {
+	Attempt        int             `json:"attempt"`
+	Phase          migration.Phase `json:"phase"`
+	SourceAPIAddrs []string        `json:"source-api-addrs"`
+	SourceCACert   string          `json:"source-ca-cert"`
+	TargetAPIAddrs []string        `json:"target-api-addrs"`
+	TargetCACert   string          `json:"target-ca-cert"`
 }

--- a/apiserver/watcher.go
+++ b/apiserver/watcher.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/common/storagecommon"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
 )
 
@@ -54,6 +55,10 @@ func init() {
 	common.RegisterFacade(
 		"MigrationMasterWatcher", 1, newMigrationMasterWatcher,
 		reflect.TypeOf((*srvMigrationMasterWatcher)(nil)),
+	)
+	common.RegisterFacade(
+		"MigrationStatusWatcher", 1, newMigrationStatusWatcher,
+		reflect.TypeOf((*srvMigrationStatusWatcher)(nil)),
 	)
 }
 
@@ -393,7 +398,7 @@ func newMigrationMasterWatcher(
 		watcher:   w,
 		id:        id,
 		resources: resources,
-		st:        migrationGetter(st),
+		st:        getMigrationBackend(st),
 	}, nil
 }
 
@@ -401,15 +406,19 @@ type srvMigrationMasterWatcher struct {
 	watcher   state.NotifyWatcher
 	id        string
 	resources *common.Resources
-	st        modelMigrationGetter
+	st        migrationBackend
 }
 
-var migrationGetter = func(st *state.State) modelMigrationGetter {
+var getMigrationBackend = func(st *state.State) migrationBackend {
 	return st
 }
 
-type modelMigrationGetter interface {
+// migrationBackend defines State functionality required by the
+// migration watchers.
+type migrationBackend interface {
 	GetModelMigration() (state.ModelMigration, error)
+	APIHostPorts() ([][]network.HostPort, error)
+	ControllerModel() (*state.Model, error)
 }
 
 // Next returns when a model migration is active for the associated
@@ -446,4 +455,125 @@ func (w *srvMigrationMasterWatcher) Next() (params.ModelMigrationTargetInfo, err
 // Stop stops the watcher.
 func (w *srvMigrationMasterWatcher) Stop() error {
 	return w.resources.Stop(w.id)
+}
+
+func newMigrationStatusWatcher(
+	st *state.State,
+	resources *common.Resources,
+	auth common.Authorizer,
+	id string,
+) (interface{}, error) {
+	if !(auth.AuthMachineAgent() || auth.AuthUnitAgent()) {
+		return nil, common.ErrPerm
+	}
+	w, ok := resources.Get(id).(state.NotifyWatcher)
+	if !ok {
+		return nil, common.ErrUnknownWatcher
+	}
+	return &srvMigrationStatusWatcher{
+		watcher:   w,
+		id:        id,
+		resources: resources,
+		st:        getMigrationBackend(st),
+	}, nil
+}
+
+type srvMigrationStatusWatcher struct {
+	watcher   state.NotifyWatcher
+	id        string
+	resources *common.Resources
+	st        migrationBackend
+}
+
+// Next returns when the status for a model migration for the
+// associated model changes. The current details for the active
+// migration are returned.
+func (w *srvMigrationStatusWatcher) Next() (params.MigrationStatus, error) {
+	empty := params.MigrationStatus{}
+
+	if _, ok := <-w.watcher.Changes(); !ok {
+		err := w.watcher.Err()
+		if err == nil {
+			err = common.ErrStoppedWatcher
+		}
+		return empty, err
+	}
+
+	mig, err := w.st.GetModelMigration()
+	if err != nil {
+		return empty, errors.Annotate(err, "migration lookup")
+	}
+
+	attempt, err := mig.Attempt()
+	if err != nil {
+		return empty, errors.Annotate(err, "retrieving migration attempt")
+	}
+
+	phase, err := mig.Phase()
+	if err != nil {
+		return empty, errors.Annotate(err, "retrieving migration phase")
+	}
+
+	sourceAddrs, err := w.getLocalHostPorts()
+	if err != nil {
+		return empty, errors.Annotate(err, "retrieving source addresses")
+	}
+
+	sourceCACert, err := getControllerCACert(w.st)
+	if err != nil {
+		return empty, errors.Annotate(err, "retrieving source CA cert")
+	}
+
+	target, err := mig.TargetInfo()
+	if err != nil {
+		return empty, errors.Annotate(err, "retrieving target info")
+	}
+
+	return params.MigrationStatus{
+		Attempt:        attempt,
+		Phase:          phase,
+		SourceAPIAddrs: sourceAddrs,
+		SourceCACert:   sourceCACert,
+		TargetAPIAddrs: target.Addrs,
+		TargetCACert:   target.CACert,
+	}, nil
+}
+
+func (w *srvMigrationStatusWatcher) getLocalHostPorts() ([]string, error) {
+	hostports, err := w.st.APIHostPorts()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	var out []string
+	for _, section := range hostports {
+		for _, hostport := range section {
+			out = append(out, hostport.String())
+		}
+	}
+	return out, nil
+}
+
+// Stop stops the watcher.
+func (w *srvMigrationStatusWatcher) Stop() error {
+	return w.resources.Stop(w.id)
+}
+
+// This is a shim to avoid the need to use a working State into the
+// unit tests. It is tested as part of the client side API tests.
+var getControllerCACert = func(st migrationBackend) (string, error) {
+	model, err := st.ControllerModel()
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+
+	config, err := model.Config()
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+
+	cacert, ok := config.CACert()
+	if !ok {
+		return "", errors.New("missing CA cert for controller model")
+	}
+	return cacert, nil
 }

--- a/state/modelmigration.go
+++ b/state/modelmigration.go
@@ -5,6 +5,7 @@ package state
 
 import (
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/juju/errors"
@@ -27,6 +28,10 @@ type ModelMigration interface {
 
 	// ModelUUID returns the UUID for the model being migrated.
 	ModelUUID() string
+
+	// Attempt returns the migration attempt identifier. This
+	// increments for each migration attempt for the model.
+	Attempt() (int, error)
 
 	// StartTime returns the time when the migration was started.
 	StartTime() time.Time
@@ -158,6 +163,16 @@ func (mig *modelMigration) Id() string {
 // ModelUUID implements ModelMigration.
 func (mig *modelMigration) ModelUUID() string {
 	return mig.doc.ModelUUID
+}
+
+// Attempt implements ModelMigration.
+func (mig *modelMigration) Attempt() (int, error) {
+	attempt, err := strconv.Atoi(mig.st.localID(mig.doc.Id))
+	if err != nil {
+		// This really shouldn't happen.
+		return -1, errors.Errorf("invalid migration id: %v", mig.doc.Id)
+	}
+	return attempt, nil
 }
 
 // StartTime implements ModelMigration.

--- a/state/modelmigration_test.go
+++ b/state/modelmigration_test.go
@@ -471,6 +471,85 @@ func (s *ModelMigrationSuite) createWatcher(c *gc.C, st *state.State) (
 	return w, statetesting.NewNotifyWatcherC(c, st, w)
 }
 
+func (s *ModelMigrationSuite) TestWatchMigrationStatus(c *gc.C) {
+	w, wc := s.createStatusWatcher(c, s.State2)
+	wc.AssertNoChange()
+
+	// Create a migration.
+	mig, err := s.State2.CreateModelMigration(s.stdSpec)
+	c.Assert(err, jc.ErrorIsNil)
+	wc.AssertOneChange()
+
+	// End it.
+	c.Assert(mig.SetPhase(migration.ABORT), jc.ErrorIsNil)
+	wc.AssertOneChange()
+
+	// Start another.
+	mig2, err := s.State2.CreateModelMigration(s.stdSpec)
+	c.Assert(err, jc.ErrorIsNil)
+	wc.AssertOneChange()
+
+	// Change phase.
+	c.Assert(mig2.SetPhase(migration.READONLY), jc.ErrorIsNil)
+	wc.AssertOneChange()
+
+	// End it.
+	c.Assert(mig2.SetPhase(migration.ABORT), jc.ErrorIsNil)
+	wc.AssertOneChange()
+
+	statetesting.AssertStop(c, w)
+	wc.AssertClosed()
+}
+
+func (s *ModelMigrationSuite) TestWatchMigrationStatusPreexisting(c *gc.C) {
+	// Create an aborted migration.
+	mig, err := s.State2.CreateModelMigration(s.stdSpec)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(mig.SetPhase(migration.ABORT), jc.ErrorIsNil)
+
+	_, wc := s.createStatusWatcher(c, s.State2)
+	wc.AssertOneChange()
+}
+
+func (s *ModelMigrationSuite) TestWatchMigrationStatusMultiModel(c *gc.C) {
+	_, wc2 := s.createStatusWatcher(c, s.State2)
+	wc2.AssertNoChange()
+
+	// Create another hosted model to migrate and watch for
+	// migrations.
+	State3 := s.Factory.MakeModel(c, nil)
+	s.AddCleanup(func(*gc.C) { State3.Close() })
+	_, wc3 := s.createStatusWatcher(c, State3)
+	wc3.AssertNoChange()
+
+	// Create a migration for 2.
+	mig, err := s.State2.CreateModelMigration(s.stdSpec)
+	c.Assert(err, jc.ErrorIsNil)
+	wc2.AssertOneChange()
+	wc3.AssertNoChange()
+
+	// Create a migration for 3.
+	_, err = State3.CreateModelMigration(s.stdSpec)
+	c.Assert(err, jc.ErrorIsNil)
+	wc2.AssertNoChange()
+	wc3.AssertOneChange()
+
+	// Update the migration for 2.
+	err = mig.SetPhase(migration.ABORT)
+	c.Assert(err, jc.ErrorIsNil)
+	wc2.AssertOneChange()
+	wc3.AssertNoChange()
+}
+
+func (s *ModelMigrationSuite) createStatusWatcher(c *gc.C, st *state.State) (
+	state.NotifyWatcher, statetesting.NotifyWatcherC,
+) {
+	w, err := st.WatchMigrationStatus()
+	c.Assert(err, jc.ErrorIsNil)
+	s.AddCleanup(func(c *gc.C) { statetesting.AssertStop(c, w) })
+	return w, statetesting.NewNotifyWatcherC(c, st, w)
+}
+
 func assertPhase(c *gc.C, mig state.ModelMigration, phase migration.Phase) {
 	actualPhase, err := mig.Phase()
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -2637,21 +2637,21 @@ func (w *blockDevicesWatcher) loop() error {
 	}
 }
 
-// WatchForModelMigration returns a notify watcher which which report
-// when a migration is in progress for the model associated with the
+// WatchForModelMigration returns a notify watcher which reports when
+// a migration is in progress for the model associated with the
 // State. Only in-progress and newly created migrations are reported.
 func (st *State) WatchForModelMigration() (NotifyWatcher, error) {
-	return newModelMigrationWatcher(st), nil
+	return newMigrationActiveWatcher(st), nil
 }
 
-type modelMigrationWatcher struct {
+type migrationActiveWatcher struct {
 	commonWatcher
 	collName string
 	sink     chan struct{}
 }
 
-func newModelMigrationWatcher(st *State) NotifyWatcher {
-	w := &modelMigrationWatcher{
+func newMigrationActiveWatcher(st *State) NotifyWatcher {
+	w := &migrationActiveWatcher{
 		commonWatcher: commonWatcher{st: st},
 		collName:      modelMigrationsActiveC,
 		sink:          make(chan struct{}),
@@ -2665,11 +2665,11 @@ func newModelMigrationWatcher(st *State) NotifyWatcher {
 }
 
 // Changes returns the event channel for this watcher.
-func (w *modelMigrationWatcher) Changes() <-chan struct{} {
+func (w *migrationActiveWatcher) Changes() <-chan struct{} {
 	return w.sink
 }
 
-func (w *modelMigrationWatcher) loop() error {
+func (w *migrationActiveWatcher) loop() error {
 	in := make(chan watcher.Change)
 	filter := func(id interface{}) bool {
 		// Only report migrations for the requested model.
@@ -2702,6 +2702,95 @@ func (w *modelMigrationWatcher) loop() error {
 				continue
 			}
 
+			if _, ok := collect(change, in, w.tomb.Dying()); !ok {
+				return tomb.ErrDying
+			}
+			out = w.sink
+		case out <- struct{}{}:
+			out = nil
+		}
+	}
+}
+
+// WatchMigrationStatus returns a NotifyWatcher which triggers
+// whenever the status of latest migration for the State's model
+// changes. One instance can be used across migrations. The watcher
+// will report changes when one migration finishes and another one
+// begins.
+//
+// Note that this watcher does not produce an initial event if there's
+// never been a migration attempt for the model.
+func (st *State) WatchMigrationStatus() (NotifyWatcher, error) {
+	return newMigrationStatusWatcher(st), nil
+}
+
+type migrationStatusWatcher struct {
+	commonWatcher
+	collName string
+	sink     chan struct{}
+}
+
+func newMigrationStatusWatcher(st *State) NotifyWatcher {
+	w := &migrationStatusWatcher{
+		commonWatcher: commonWatcher{st: st},
+		collName:      modelMigrationStatusC,
+		sink:          make(chan struct{}),
+	}
+	go func() {
+		defer w.tomb.Done()
+		defer close(w.sink)
+		w.tomb.Kill(w.loop())
+	}()
+	return w
+}
+
+// Changes returns the event channel for this watcher.
+func (w *migrationStatusWatcher) Changes() <-chan struct{} {
+	return w.sink
+}
+
+func (w *migrationStatusWatcher) loop() error {
+	in := make(chan watcher.Change)
+
+	// Watch the entire modelMigrationStatusC collection for migration
+	// status updates related to the State's model. This is more
+	// efficient and simpler than tracking the current active
+	// migration (and changing watchers when one migration finishes
+	// and another starts.
+	//
+	// This approach is safe because there are strong guarantees that
+	// there will only be one active migration per model. The watcher
+	// will only see changes for one migration status document at a
+	// time for the model.
+	filter := func(id interface{}) bool {
+		_, err := w.st.strictLocalID(id.(string))
+		return err == nil
+	}
+	w.st.watcher.WatchCollectionWithFilter(w.collName, in, filter)
+	defer w.st.watcher.UnwatchCollection(w.collName, in)
+
+	var out chan<- struct{}
+
+	// If there is a migration record for the model - active or not -
+	// send an initial event.
+	if _, err := w.st.GetModelMigration(); errors.IsNotFound(err) {
+		// Nothing to report.
+	} else if err != nil {
+		return errors.Trace(err)
+	} else {
+		out = w.sink
+	}
+
+	for {
+		select {
+		case <-w.tomb.Dying():
+			return tomb.ErrDying
+		case <-w.st.watcher.Dead():
+			return stateWatcherDeadError(w.st.watcher.Err())
+		case change := <-in:
+			if change.Revno == -1 {
+				return errors.New("model migration status disappeared (shouldn't happen)")
+			}
 			if _, ok := collect(change, in, w.tomb.Dying()); !ok {
 				return tomb.ErrDying
 			}


### PR DESCRIPTION
These are to be used by the migration minion worker to monitor and react to the progression of a model migration. 

This PR also includes the state.WatchMigrationStatus work. This has already been merged into master but is needed for this PR to function.

(Review request: http://reviews.vapour.ws/r/4281/)