### PR TITLE
Include ca cert and private key in backup metadata, refactor restore

### DIFF
--- a/api/backups/download_test.go
+++ b/api/backups/download_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state/backups"
+	"github.com/juju/juju/testing"
 )
 
 type downloadSuite struct {
@@ -28,6 +29,8 @@ func (s *downloadSuite) TestSuccessfulRequest(c *gc.C) {
 	r := strings.NewReader("<compressed archive data>")
 	meta, err := backups.NewMetadataState(s.State, "0")
 	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(meta.CACert, gc.Equals, testing.CACert)
+	c.Assert(meta.CAPrivateKey, gc.Equals, testing.CAKey)
 	// The Add method requires the length to be set
 	// otherwise the content is assumed to have length 0.
 	meta.Raw.Size = int64(r.Len())

--- a/api/backups/restore.go
+++ b/api/backups/restore.go
@@ -38,14 +38,14 @@ func isUpgradeInProgressErr(err error) bool {
 // ClientConnection type represents a function capable of spawning a new Client connection
 // it is used to pass around connection factories when necessary.
 // TODO(perrito666) This is a workaround for lp:1399722 .
-type ClientConnection func() (*Client, func() error, error)
+type ClientConnection func() (*Client, error)
 
 // closerfunc is a function that allows you to close a client connection.
 type closerFunc func() error
 
-func prepareAttempt(client *Client, closer closerFunc) (error, error) {
+func prepareAttempt(client *Client) (error, error) {
 	var remoteError error
-	defer closer()
+	defer client.Close()
 	err := client.facade.FacadeCall("PrepareRestore", nil, &remoteError)
 	return err, remoteError
 }
@@ -59,11 +59,11 @@ func prepareRestore(newClient ClientConnection) error {
 	// by restore.
 	for a := restoreStrategy.Start(); a.Next(); {
 		logger.Debugf("Will attempt to call 'PrepareRestore'")
-		client, clientCloser, clientErr := newClient()
+		client, clientErr := newClient()
 		if clientErr != nil {
 			return errors.Trace(clientErr)
 		}
-		err, remoteError = prepareAttempt(client, clientCloser)
+		err, remoteError = prepareAttempt(client)
 		if err == nil && remoteError == nil {
 			return nil
 		}
@@ -100,9 +100,9 @@ func (c *Client) Restore(backupId string, newClient ClientConnection) error {
 	return c.restore(backupId, newClient)
 }
 
-func restoreAttempt(client *Client, closer closerFunc, restoreArgs params.RestoreArgs) (error, error) {
+func restoreAttempt(client *Client, restoreArgs params.RestoreArgs) (error, error) {
 	var remoteError error
-	defer closer()
+	defer client.Close()
 	err := client.facade.FacadeCall("Restore", restoreArgs, &remoteError)
 	return err, remoteError
 }
@@ -125,13 +125,12 @@ func (c *Client) restore(backupId string, newClient ClientConnection) error {
 	for a := restoreStrategy.Start(); a.Next(); {
 		logger.Debugf("Attempting Restore of %q", backupId)
 		var restoreClient *Client
-		var restoreClientCloser func() error
-		restoreClient, restoreClientCloser, err = newClient()
+		restoreClient, err = newClient()
 		if err != nil {
 			return errors.Trace(err)
 		}
 
-		err, remoteError = restoreAttempt(restoreClient, restoreClientCloser, restoreArgs)
+		err, remoteError = restoreAttempt(restoreClient, restoreArgs)
 
 		// A ShutdownErr signals that Restore almost certainly finished and
 		// triggered Exit.
@@ -160,9 +159,9 @@ func (c *Client) restore(backupId string, newClient ClientConnection) error {
 	return nil
 }
 
-func finishAttempt(client *Client, closer closerFunc) (error, error) {
+func finishAttempt(client *Client) (error, error) {
 	var remoteError error
-	defer closer()
+	defer client.Close()
 	err := client.facade.FacadeCall("FinishRestore", nil, &remoteError)
 	return err, remoteError
 }
@@ -176,13 +175,12 @@ func finishRestore(newClient ClientConnection) error {
 	for a := restoreStrategy.Start(); a.Next(); {
 		logger.Debugf("Attempting finishRestore")
 		var finishClient *Client
-		var finishClientCloser func() error
-		finishClient, finishClientCloser, err = newClient()
+		finishClient, err = newClient()
 		if err != nil {
 			return errors.Trace(err)
 		}
 
-		err, remoteError = finishAttempt(finishClient, finishClientCloser)
+		err, remoteError = finishAttempt(finishClient)
 		if err == nil && remoteError == nil {
 			return nil
 		}

--- a/apiserver/backups/backups.go
+++ b/apiserver/backups/backups.go
@@ -111,8 +111,12 @@ func ResultFromMetadata(meta *backups.Metadata) params.BackupsMetadataResult {
 	result.Hostname = meta.Origin.Hostname
 	result.Version = meta.Origin.Version
 
-	// These are used by the restore CLI when re-bootstrapping.
-	// They are not used elsewhere.
+	// TODO(wallyworld) - remove these ASAP
+	// These are only used by the restore CLI when re-bootstrapping.
+	// We will use a better solution but the way restore currently
+	// works, we need them and they are no longer available via
+	// bootstrap config. We will need to ifx how re-bootstrap deals
+	// with these keys to address the issue.
 	result.CACert = meta.CACert
 	result.CAPrivateKey = meta.CAPrivateKey
 

--- a/apiserver/backups/backups.go
+++ b/apiserver/backups/backups.go
@@ -111,6 +111,11 @@ func ResultFromMetadata(meta *backups.Metadata) params.BackupsMetadataResult {
 	result.Hostname = meta.Origin.Hostname
 	result.Version = meta.Origin.Version
 
+	// These are used by the restore CLI when re-bootstrapping.
+	// They are not used elsewhere.
+	result.CACert = meta.CACert
+	result.CAPrivateKey = meta.CAPrivateKey
+
 	return result
 }
 

--- a/apiserver/params/backups.go
+++ b/apiserver/params/backups.go
@@ -66,6 +66,9 @@ type BackupsMetadataResult struct {
 	Machine  string
 	Hostname string
 	Version  version.Number
+
+	CACert       string
+	CAPrivateKey string
 }
 
 // RestoreArgs Holds the backup file or id

--- a/cmd/juju/backups/backups.go
+++ b/cmd/juju/backups/backups.go
@@ -114,12 +114,13 @@ func (c *CommandBase) dumpMetadata(ctx *cmd.Context, result *params.BackupsMetad
 	fmt.Fprintf(ctx.Stdout, "juju version:    %v\n", result.Version)
 }
 
-type readSeekCloser interface {
+// ArchiveReader can read a backup archive.
+type ArchiveReader interface {
 	io.ReadSeeker
 	io.Closer
 }
 
-func getArchive(filename string) (rc readSeekCloser, metaResult *params.BackupsMetadataResult, err error) {
+func getArchive(filename string) (rc ArchiveReader, metaResult *params.BackupsMetadataResult, err error) {
 	defer func() {
 		if err != nil && rc != nil {
 			rc.Close()

--- a/cmd/juju/backups/export_test.go
+++ b/cmd/juju/backups/export_test.go
@@ -68,16 +68,16 @@ func NewRemoveCommand() cmd.Command {
 func NewRestoreCommandForTest(
 	store jujuclient.ClientStore,
 	api RestoreAPI,
-	getArchiveFunc func(string) (ArchiveReader, *params.BackupsMetadataResult, error),
-	getEnvironFunc func(string, *params.BackupsMetadataResult) (environs.Environ, error),
+	getArchive func(string) (ArchiveReader, *params.BackupsMetadataResult, error),
+	getEnviron func(string, *params.BackupsMetadataResult) (environs.Environ, error),
 ) cmd.Command {
 	c := &restoreCommand{
-		getArchiveFunc: getArchiveFunc,
-		getEnvironFunc: getEnvironFunc,
+		getArchiveFunc: getArchive,
+		getEnvironFunc: getEnviron,
 		newAPIFunc: func() (RestoreAPI, error) {
 			return api, nil
 		}}
-	if getEnvironFunc == nil {
+	if getEnviron == nil {
 		c.getEnvironFunc = func(controllerNme string, meta *params.BackupsMetadataResult) (environs.Environ, error) {
 			return c.getEnviron(controllerNme, meta)
 		}

--- a/cmd/juju/backups/export_test.go
+++ b/cmd/juju/backups/export_test.go
@@ -74,7 +74,7 @@ func NewRestoreCommandForTest(
 	c := &restoreCommand{
 		getArchiveFunc: getArchive,
 		getEnvironFunc: getEnviron,
-		newAPIFunc: func() (RestoreAPI, error) {
+		newAPIClientFunc: func() (RestoreAPI, error) {
 			return api, nil
 		}}
 	if getEnviron == nil {

--- a/cmd/juju/backups/export_test.go
+++ b/cmd/juju/backups/export_test.go
@@ -6,8 +6,10 @@ package backups
 import (
 	"github.com/juju/cmd"
 
+	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/environs"
+	"github.com/juju/juju/jujuclient"
 )
 
 const (
@@ -63,8 +65,24 @@ func NewRemoveCommand() cmd.Command {
 	return modelcmd.Wrap(c)
 }
 
-func NewRestoreCommandForTest(getEnvironFunc func(string) (environs.Environ, error)) cmd.Command {
-	c := &restoreCommand{getEnvironFunc: getEnvironFunc}
+func NewRestoreCommandForTest(
+	store jujuclient.ClientStore,
+	api RestoreAPI,
+	getArchiveFunc func(string) (ArchiveReader, *params.BackupsMetadataResult, error),
+	getEnvironFunc func(string, *params.BackupsMetadataResult) (environs.Environ, error),
+) cmd.Command {
+	c := &restoreCommand{
+		getArchiveFunc: getArchiveFunc,
+		getEnvironFunc: getEnvironFunc,
+		newAPIFunc: func() (RestoreAPI, error) {
+			return api, nil
+		}}
+	if getEnvironFunc == nil {
+		c.getEnvironFunc = func(controllerNme string, meta *params.BackupsMetadataResult) (environs.Environ, error) {
+			return c.getEnviron(controllerNme, meta)
+		}
+	}
 	c.Log = &cmd.Log{}
+	c.SetClientStore(store)
 	return modelcmd.Wrap(c)
 }

--- a/cmd/juju/backups/restore.go
+++ b/cmd/juju/backups/restore.go
@@ -25,7 +25,7 @@ import (
 func newRestoreCommand() cmd.Command {
 	restoreCmd := &restoreCommand{}
 	restoreCmd.getEnvironFunc = restoreCmd.getEnviron
-	restoreCmd.newAPIFunc = func() (RestoreAPI, error) {
+	restoreCmd.newAPIClientFunc = func() (RestoreAPI, error) {
 		return restoreCmd.newClient()
 	}
 	restoreCmd.getArchiveFunc = getArchive
@@ -42,9 +42,9 @@ type restoreCommand struct {
 	bootstrap   bool
 	uploadTools bool
 
-	newAPIFunc     func() (RestoreAPI, error)
-	getEnvironFunc func(string, *params.BackupsMetadataResult) (environs.Environ, error)
-	getArchiveFunc func(string) (ArchiveReader, *params.BackupsMetadataResult, error)
+	newAPIClientFunc func() (RestoreAPI, error)
+	getEnvironFunc   func(string, *params.BackupsMetadataResult) (environs.Environ, error)
+	getArchiveFunc   func(string) (ArchiveReader, *params.BackupsMetadataResult, error)
 }
 
 // RestoreAPI is used to invoke various API calls.
@@ -196,13 +196,6 @@ func (c *restoreCommand) rebootstrap(ctx *cmd.Context, meta *params.BackupsMetad
 	return nil
 }
 
-func (c *restoreCommand) newAPIClient() (RestoreAPI, error) {
-	if c.newAPIFunc != nil {
-		return c.newAPIFunc()
-	}
-	return c.newClient()
-}
-
 func (c *restoreCommand) newClient() (*backups.Client, error) {
 	client, err := c.NewAPIClient()
 	if err != nil {
@@ -222,7 +215,7 @@ func (c *restoreCommand) Run(ctx *cmd.Context) error {
 			return err
 		}
 	}
-	client, err := c.newAPIClient()
+	client, err := c.newAPIClientFunc()
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/cmd/juju/backups/restore.go
+++ b/cmd/juju/backups/restore.go
@@ -4,7 +4,9 @@
 package backups
 
 import (
+	"crypto/rand"
 	"fmt"
+	"io"
 	"path/filepath"
 	"strings"
 
@@ -13,6 +15,7 @@ import (
 	"launchpad.net/gnuflag"
 
 	"github.com/juju/juju/api/backups"
+	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs"
@@ -21,9 +24,13 @@ import (
 
 func newRestoreCommand() cmd.Command {
 	restoreCmd := &restoreCommand{}
-	restoreCmd.getEnvironFunc = func(controllerNme string) (environs.Environ, error) {
-		return restoreCmd.getEnviron(controllerNme)
+	restoreCmd.getEnvironFunc = func(controllerNme string, meta *params.BackupsMetadataResult) (environs.Environ, error) {
+		return restoreCmd.getEnviron(controllerNme, meta)
 	}
+	restoreCmd.newAPIFunc = func() (RestoreAPI, error) {
+		return restoreCmd.newClient()
+	}
+	restoreCmd.getArchiveFunc = getArchive
 	return modelcmd.Wrap(restoreCmd)
 }
 
@@ -31,12 +38,21 @@ func newRestoreCommand() cmd.Command {
 // it is invoked with "juju restore-backup".
 type restoreCommand struct {
 	CommandBase
-	constraints    constraints.Value
-	filename       string
-	backupId       string
-	bootstrap      bool
-	uploadTools    bool
-	getEnvironFunc func(string) (environs.Environ, error)
+	constraints constraints.Value
+	filename    string
+	backupId    string
+	bootstrap   bool
+	uploadTools bool
+
+	newAPIFunc     func() (RestoreAPI, error)
+	getEnvironFunc func(string, *params.BackupsMetadataResult) (environs.Environ, error)
+	getArchiveFunc func(string) (ArchiveReader, *params.BackupsMetadataResult, error)
+}
+
+type RestoreAPI interface {
+	Close() error
+	Restore(backupId string, newClient backups.ClientConnection) error
+	RestoreReader(r io.ReadSeeker, meta *params.BackupsMetadataResult, newClient backups.ClientConnection) error
 }
 
 var restoreDoc = `
@@ -101,53 +117,45 @@ func (c *restoreCommand) Init(args []string) error {
 	return nil
 }
 
-// runRestore will implement the actual calls to the different Client parts
-// of restore.
-func (c *restoreCommand) runRestore(ctx *cmd.Context) error {
-	client, closer, err := c.newClient()
-	if err != nil {
-		return errors.Trace(err)
-	}
-	defer closer()
-	var target string
-	var rErr error
-	if c.filename != "" {
-		target = c.filename
-		archive, meta, err := getArchive(c.filename)
-		if err != nil {
-			return errors.Trace(err)
-		}
-		defer archive.Close()
-
-		rErr = client.RestoreReader(archive, meta, c.newClient)
-	} else {
-		target = c.backupId
-		rErr = client.Restore(c.backupId, c.newClient)
-	}
-	if rErr != nil {
-		return errors.Trace(rErr)
-	}
-
-	fmt.Fprintf(ctx.Stdout, "restore from %q completed\n", target)
-	return nil
-}
-
 // getEnviron returns the environ for the specified controller, or
 // mocked out environ for testing.
-func (c *restoreCommand) getEnviron(controllerName string) (environs.Environ, error) {
+func (c *restoreCommand) getEnviron(controllerName string, meta *params.BackupsMetadataResult) (environs.Environ, error) {
 	// TODO(axw) delete this and -b in 2.0-beta2. We will update bootstrap
 	// with a flag to specify a restore file. When we do that, we'll need
 	// to extract the CA cert from the backup, and we'll need to reset the
 	// password after restore so the admin user can login.
-	cfg, err := modelcmd.NewGetBootstrapConfigFunc(c.ClientStore())(controllerName)
+	// We also need to store things like the admin-secret, controller
+	// certificate etc with the backup.
+	store := c.ClientStore()
+	cfg, err := modelcmd.NewGetBootstrapConfigFunc(store)(controllerName)
 	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	// Get the local admin user so we can use the password as the admin secret.
+	var adminSecret string
+	account, err := store.AccountByName(controllerName, environs.AdminUser)
+	if err == nil {
+		adminSecret = account.Password
+	} else if errors.IsNotFound(err) {
+		// No relevant local admin user so generate a new secret.
+		buf := make([]byte, 16)
+		if _, err := io.ReadFull(rand.Reader, buf); err != nil {
+			return nil, errors.Annotate(err, "generating new admin secret")
+		}
+		adminSecret = fmt.Sprintf("%x", buf)
+	} else {
 		return nil, errors.Trace(err)
 	}
 
 	// Turn on safe mode so that the newly bootstrapped instance
 	// will not destroy all the instances it does not know about.
+	// Also set the admin secret and ca cert info.
 	cfg, err = cfg.Apply(map[string]interface{}{
 		"provisioner-safe-mode": true,
+		"admin-secret":          adminSecret,
+		"ca-private-key":        meta.CAPrivateKey,
+		"ca-cert":               meta.CACert,
 	})
 	if err != nil {
 		return nil, errors.Annotatef(err, "cannot enable provisioner-safe-mode")
@@ -157,13 +165,13 @@ func (c *restoreCommand) getEnviron(controllerName string) (environs.Environ, er
 
 // rebootstrap will bootstrap a new server in safe-mode (not killing any other agent)
 // if there is no current server available to restore to.
-func (c *restoreCommand) rebootstrap(ctx *cmd.Context) error {
-	env, err := c.getEnvironFunc(c.ControllerName())
+func (c *restoreCommand) rebootstrap(ctx *cmd.Context, meta *params.BackupsMetadataResult) error {
+	env, err := c.getEnvironFunc(c.ControllerName(), meta)
 	if err != nil {
 		return errors.Trace(err)
 	}
 	instanceIds, err := env.ControllerInstances()
-	if err != nil {
+	if err != nil && errors.Cause(err) != environs.ErrNotBootstrapped {
 		return errors.Annotatef(err, "cannot determine controller instances")
 	}
 	if len(instanceIds) > 0 {
@@ -184,16 +192,23 @@ func (c *restoreCommand) rebootstrap(ctx *cmd.Context) error {
 	return nil
 }
 
-func (c *restoreCommand) newClient() (*backups.Client, func() error, error) {
+func (c *restoreCommand) newAPIClient() (RestoreAPI, error) {
+	if c.newAPIFunc != nil {
+		return c.newAPIFunc()
+	}
+	return c.newClient()
+}
+
+func (c *restoreCommand) newClient() (*backups.Client, error) {
 	client, err := c.NewAPIClient()
 	if err != nil {
-		return nil, nil, errors.Trace(err)
+		return nil, errors.Trace(err)
 	}
 	backupsClient, ok := client.(*backups.Client)
 	if !ok {
-		return nil, nil, errors.Errorf("invalid client for backups")
+		return nil, errors.Errorf("invalid client for backups")
 	}
-	return backupsClient, client.Close, nil
+	return backupsClient, nil
 }
 
 // Run is the entry point for this command.
@@ -203,10 +218,33 @@ func (c *restoreCommand) Run(ctx *cmd.Context) error {
 			return err
 		}
 	}
-	if c.bootstrap {
-		if err := c.rebootstrap(ctx); err != nil {
+	client, err := c.newAPIClient()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	defer client.Close()
+
+	var target string
+	if c.filename != "" {
+		target = c.filename
+		archive, meta, err := c.getArchiveFunc(c.filename)
+		if err != nil {
 			return errors.Trace(err)
 		}
+		defer archive.Close()
+		if c.bootstrap {
+			if err := c.rebootstrap(ctx, meta); err != nil {
+				return errors.Trace(err)
+			}
+		}
+		err = client.RestoreReader(archive, meta, c.newClient)
+	} else {
+		target = c.backupId
+		err = client.Restore(c.backupId, c.newClient)
 	}
-	return c.runRestore(ctx)
+	if err != nil {
+		return nil
+	}
+	fmt.Fprintf(ctx.Stdout, "restore from %q completed\n", target)
+	return nil
 }

--- a/cmd/juju/backups/restore.go
+++ b/cmd/juju/backups/restore.go
@@ -24,9 +24,7 @@ import (
 
 func newRestoreCommand() cmd.Command {
 	restoreCmd := &restoreCommand{}
-	restoreCmd.getEnvironFunc = func(controllerNme string, meta *params.BackupsMetadataResult) (environs.Environ, error) {
-		return restoreCmd.getEnviron(controllerNme, meta)
-	}
+	restoreCmd.getEnvironFunc = restoreCmd.getEnviron
 	restoreCmd.newAPIFunc = func() (RestoreAPI, error) {
 		return restoreCmd.newClient()
 	}
@@ -49,9 +47,15 @@ type restoreCommand struct {
 	getArchiveFunc func(string) (ArchiveReader, *params.BackupsMetadataResult, error)
 }
 
+// RestoreAPI is used to invoke various API calls.
 type RestoreAPI interface {
+	// Close is taken from io.Closer.
 	Close() error
+
+	// Restore is taken from backups.Client.
 	Restore(backupId string, newClient backups.ClientConnection) error
+
+	// RestoreReader is taken from backups.Client.
 	RestoreReader(r io.ReadSeeker, meta *params.BackupsMetadataResult, newClient backups.ClientConnection) error
 }
 

--- a/cmd/juju/backups/restore_test.go
+++ b/cmd/juju/backups/restore_test.go
@@ -7,25 +7,71 @@ import (
 	"github.com/juju/errors"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/cmd/juju/backups"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/bootstrap"
 	"github.com/juju/juju/instance"
+	"github.com/juju/juju/jujuclient"
+	"github.com/juju/juju/jujuclient/jujuclienttesting"
+	_ "github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/testing"
 )
 
 type restoreSuite struct {
 	BaseBackupsSuite
+	store *jujuclienttesting.MemStore
 }
 
 var _ = gc.Suite(&restoreSuite{})
 
 func (s *restoreSuite) SetUpTest(c *gc.C) {
 	s.BaseBackupsSuite.SetUpTest(c)
+	s.store = jujuclienttesting.NewMemStore()
+	s.store.Controllers["testing"] = jujuclient.ControllerDetails{
+		ControllerUUID: testing.ModelTag.Id(),
+		CACert:         testing.CACert,
+	}
+	s.store.Models["testing"] = jujuclient.ControllerAccountModels{
+		AccountModels: map[string]*jujuclient.AccountModels{
+			"admin@local": {
+				Models: map[string]jujuclient.ModelDetails{
+					"test1": {"test1-uuid"},
+				},
+				CurrentModel: "test1",
+			},
+		},
+	}
+	s.store.Accounts["testing"] = &jujuclient.ControllerAccounts{
+		Accounts: map[string]jujuclient.AccountDetails{
+			"admin@local": {
+				User:     "current-user@local",
+				Password: "old-password",
+			},
+		},
+		CurrentAccount: "admin@local",
+	}
+	s.store.BootstrapConfig["testing"] = jujuclient.BootstrapConfig{
+		Cloud: "dummy",
+		//Credential: "me",
+		Config: map[string]interface{}{
+			"type": "dummy",
+			"name": "admin",
+		},
+	}
+	s.store.Credentials["dummy"] = cloud.CloudCredential{
+		AuthCredentials: map[string]cloud.Credential{
+			"me": cloud.NewCredential(cloud.UserPassAuthType, map[string]string{
+				"username": "user",
+				"password": "sekret",
+			}),
+		},
+	}
 }
 
 func (s *restoreSuite) TestRestoreArgs(c *gc.C) {
-	s.command = backups.NewRestoreCommandForTest(nil)
+	s.command = backups.NewRestoreCommandForTest(s.store, nil, nil, nil)
 	_, err := testing.RunCommand(c, s.command, "restore")
 	c.Assert(err, gc.ErrorMatches, "you must specify either a file or a backup id.")
 
@@ -36,25 +82,73 @@ func (s *restoreSuite) TestRestoreArgs(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "it is not possible to rebootstrap and restore from an id.")
 }
 
+// TODO(wallyworld) - add more api related unit tests
+type mockRestoreAPI struct {
+	backups.RestoreAPI
+}
+
+func (*mockRestoreAPI) Close() error {
+	return nil
+}
+
+type mockArchiveReader struct {
+	backups.ArchiveReader
+}
+
+func (*mockArchiveReader) Close() error {
+	return nil
+}
+
 func (s *restoreSuite) TestRestoreReboostrapControllerExists(c *gc.C) {
 	fakeEnv := fakeEnviron{controllerInstances: []instance.Id{"1"}}
-	s.command = backups.NewRestoreCommandForTest(func(string) (environs.Environ, error) {
-		return fakeEnv, nil
-	})
+	s.command = backups.NewRestoreCommandForTest(
+		s.store, &mockRestoreAPI{},
+		func(string) (backups.ArchiveReader, *params.BackupsMetadataResult, error) {
+			return &mockArchiveReader{}, &params.BackupsMetadataResult{}, nil
+		},
+		func(string, *params.BackupsMetadataResult) (environs.Environ, error) {
+			return fakeEnv, nil
+		})
 	_, err := testing.RunCommand(c, s.command, "restore", "--file", "afile", "-b")
 	c.Assert(err, gc.ErrorMatches, ".*still seems to exist.*")
 }
 
 func (s *restoreSuite) TestRestoreReboostrapNoControllers(c *gc.C) {
 	fakeEnv := fakeEnviron{}
-	s.command = backups.NewRestoreCommandForTest(func(string) (environs.Environ, error) {
-		return fakeEnv, nil
-	})
+	s.command = backups.NewRestoreCommandForTest(
+		s.store, &mockRestoreAPI{},
+		func(string) (backups.ArchiveReader, *params.BackupsMetadataResult, error) {
+			return &mockArchiveReader{}, &params.BackupsMetadataResult{}, nil
+		},
+		func(string, *params.BackupsMetadataResult) (environs.Environ, error) {
+			return fakeEnv, nil
+		})
 	s.PatchValue(&backups.BootstrapFunc, func(ctx environs.BootstrapContext, environ environs.Environ, args bootstrap.BootstrapParams) error {
 		return errors.New("failed to bootstrap new controller")
 	})
 
 	_, err := testing.RunCommand(c, s.command, "restore", "--file", "afile", "-b")
+	c.Assert(err, gc.ErrorMatches, ".*failed to bootstrap new controller")
+}
+
+func (s *restoreSuite) TestRestoreReboostrapReadsMetadata(c *gc.C) {
+	metadata := params.BackupsMetadataResult{
+		CACert:       testing.CACert,
+		CAPrivateKey: testing.CAKey,
+	}
+	s.command = backups.NewRestoreCommandForTest(
+		s.store, &mockRestoreAPI{},
+		func(string) (backups.ArchiveReader, *params.BackupsMetadataResult, error) {
+			return &mockArchiveReader{}, &metadata, nil
+		},
+		nil)
+	s.PatchValue(&backups.BootstrapFunc, func(ctx environs.BootstrapContext, environ environs.Environ, args bootstrap.BootstrapParams) error {
+		attr := environ.Config().AllAttrs()
+		c.Assert(attr["ca-cert"], gc.Equals, testing.CACert)
+		return errors.New("failed to bootstrap new controller")
+	})
+
+	_, err := testing.RunCommand(c, s.command, "restore", "-m", "testing:test1", "--file", "afile", "-b")
 	c.Assert(err, gc.ErrorMatches, ".*failed to bootstrap new controller")
 }
 

--- a/environs/open.go
+++ b/environs/open.go
@@ -21,7 +21,7 @@ import (
 const ControllerModelName = "admin"
 
 // adminUser is the initial admin user created for all controllers.
-const adminUser = "admin@local"
+const AdminUser = "admin@local"
 
 // New returns a new environment based on the provided configuration.
 func New(config *config.Config) (Environ, error) {
@@ -188,7 +188,7 @@ func prepare(
 
 	details.CACert = caCert
 	details.ControllerUUID = cfg.ControllerUUID()
-	details.User = adminUser
+	details.User = AdminUser
 	details.Password = adminSecret
 	details.ModelUUID = cfg.UUID()
 	details.CloudRegion = args.CloudRegion

--- a/state/backups/metadata.go
+++ b/state/backups/metadata.go
@@ -72,7 +72,7 @@ type Metadata struct {
 	// works, we need them and they are no longer available via
 	// bootstrap config. We will need to ifx how re-bootstrap deals
 	// with these keys to address the issue.
-	
+
 	// CACert is the controller CA certificate.
 	CACert string
 

--- a/state/backups/metadata.go
+++ b/state/backups/metadata.go
@@ -66,6 +66,13 @@ type Metadata struct {
 	// Notes is an optional user-supplied annotation.
 	Notes string
 
+	// TODO(wallyworld) - remove these ASAP
+	// These are only used by the restore CLI when re-bootstrapping.
+	// We will use a better solution but the way restore currently
+	// works, we need them and they are no longer available via
+	// bootstrap config. We will need to ifx how re-bootstrap deals
+	// with these keys to address the issue.
+	
 	// CACert is the controller CA certificate.
 	CACert string
 

--- a/state/backups/metadata_test.go
+++ b/state/backups/metadata_test.go
@@ -40,6 +40,9 @@ func (s *metadataSuite) TestAsJSONBuffer(c *gc.C) {
 	finished := meta.Started.Add(time.Minute)
 	meta.Finished = &finished
 
+	meta.CACert = "ca-cert"
+	meta.CAPrivateKey = "ca-private-key"
+
 	buf, err := meta.AsJSONBuffer()
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -55,7 +58,9 @@ func (s *metadataSuite) TestAsJSONBuffer(c *gc.C) {
 		`"Environment":"asdf-zxcv-qwe",`+
 		`"Machine":"0",`+
 		`"Hostname":"myhost",`+
-		`"Version":"1.21-alpha3"`+
+		`"Version":"1.21-alpha3",`+
+		`"CACert":"ca-cert",`+
+		`"CAPrivateKey":"ca-private-key"`+
 		`}`+"\n")
 }
 

--- a/state/backups/storage.go
+++ b/state/backups/storage.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	"github.com/juju/errors"
+	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/state"
 	"github.com/juju/names"
 	jujutxn "github.com/juju/txn"
 	"github.com/juju/utils/filestorage"
@@ -530,6 +532,12 @@ type DB interface {
 
 	// ModelTag is the concrete model tag for this database.
 	ModelTag() names.ModelTag
+
+	// ModelConfig is the config of the model being backedup.
+	ModelConfig() (*config.Config, error)
+
+	// StateServingInfo is the secrets of the controller.
+	StateServingInfo() (state.StateServingInfo, error)
 }
 
 // NewStorage returns a new FileStorage to use for storing backup


### PR DESCRIPTION
juju restore -b was failing because bootstrap config now only contains minimal information. It was missing:
- ca cert
- ca private key
- admin secret

We can read admin secret from accounts.yaml
(and also ca cert from controllers.yaml).
But there's no ca private key. And we would like to keep a backup archive as self contained as possible. The archive does contain the ca cert and private key, but these are buried deep in the archive, and there's no client code nor really clean way to read these values.

So as an interim solution, the backup metadata is augmented to have the ca cert and private key - there are existing mechanism to easily read this metadata, so we make use of that. This means that restore -b can now rebootstrap as it has all the info needed.

Part of the solution refactors the restore tests so allow better test coverage to be added later.

(Review request: http://reviews.vapour.ws/r/4287/)