### PR TITLE
1.25: fixes Bug#1558158

### DIFF
--- a/cmd/juju/backups/export_test.go
+++ b/cmd/juju/backups/export_test.go
@@ -3,6 +3,13 @@
 
 package backups
 
+import (
+	"github.com/juju/cmd"
+
+	"github.com/juju/juju/cmd/envcmd"
+	"github.com/juju/juju/environs"
+)
+
 const (
 	NotSet          = notset
 	DownloadWarning = downloadWarning
@@ -11,3 +18,8 @@ const (
 var (
 	NewAPIClient = &newAPIClient
 )
+
+func RestoreCommandForTest(environTestFunc func() (environs.Environ, error)) cmd.Command {
+	c := &RestoreCommand{environFunc: environTestFunc}
+	return envcmd.Wrap(c)
+}

--- a/cmd/juju/backups/restore_test.go
+++ b/cmd/juju/backups/restore_test.go
@@ -4,26 +4,31 @@
 package backups_test
 
 import (
-	//jc "github.com/juju/testing/checkers"
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cmd/juju/backups"
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/bootstrap"
+	"github.com/juju/juju/instance"
 	"github.com/juju/juju/testing"
 )
 
 type restoreSuite struct {
 	BaseBackupsSuite
-	subcommand *backups.RestoreCommand
+
+	restoreCommand cmd.Command
 }
 
 var _ = gc.Suite(&restoreSuite{})
 
 func (s *restoreSuite) SetUpTest(c *gc.C) {
 	s.BaseBackupsSuite.SetUpTest(c)
-	s.subcommand = &backups.RestoreCommand{}
 }
 
 func (s *restoreSuite) TestRestoreArgs(c *gc.C) {
+	s.restoreCommand = backups.RestoreCommandForTest(nil)
 	_, err := testing.RunCommand(c, s.command, "restore")
 	c.Assert(err, gc.ErrorMatches, "you must specify either a file or a backup id.")
 
@@ -32,4 +37,44 @@ func (s *restoreSuite) TestRestoreArgs(c *gc.C) {
 
 	_, err = testing.RunCommand(c, s.command, "restore", "--id", "anid", "-b")
 	c.Assert(err, gc.ErrorMatches, "it is not possible to rebootstrap and restore from an id.")
+}
+
+func (s *restoreSuite) TestRestoreReboostrapControllerExists(c *gc.C) {
+	fakeEnv := fakeEnviron{controllerInstances: []instance.Id{"1"}}
+	s.restoreCommand = backups.RestoreCommandForTest(func() (environs.Environ, error) {
+		return fakeEnv, nil
+	})
+	_, err := testing.RunCommand(c, s.restoreCommand, "restore", "--file", "afile", "-b")
+	c.Assert(err, gc.ErrorMatches, ".*still seems to exist.*")
+}
+
+func (s *restoreSuite) TestRestoreReboostrapNoControllers(c *gc.C) {
+	fakeEnv := fakeEnviron{}
+	s.restoreCommand = backups.RestoreCommandForTest(func() (environs.Environ, error) {
+		return fakeEnv, nil
+	})
+	s.PatchValue(&backups.BootstrapFunc, func(ctx environs.BootstrapContext, environ environs.Environ, args bootstrap.BootstrapParams) error {
+		return errors.New("failed to bootstrap new controller")
+	})
+
+	_, err := testing.RunCommand(c, s.restoreCommand, "restore", "--file", "afile", "-b")
+	c.Assert(err, gc.ErrorMatches, ".*failed to bootstrap new controller")
+}
+
+type fakeInstance struct {
+	instance.Instance
+	id instance.Id
+}
+
+type fakeEnviron struct {
+	environs.Environ
+	controllerInstances []instance.Id
+}
+
+func (f fakeEnviron) StateServerInstances() ([]instance.Id, error) {
+	return f.controllerInstances, nil
+}
+
+func (f fakeEnviron) Instances(ids []instance.Id) ([]instance.Instance, error) {
+	return []instance.Instance{fakeInstance{id: "1"}}, nil
 }


### PR DESCRIPTION
This is almost a cherry-picked backport.

Major differences are the renames of env vs model and state server vs controller.

Manual testing is different too since, in 1.25, only ec2 and openstack providers use cleaner tagging strategy to keep track of instances.


(Review request: http://reviews.vapour.ws/r/4293/)