### PR TITLE
Implement API for switching GUI versions.

### DIFF
--- a/api/client_test.go
+++ b/api/client_test.go
@@ -238,13 +238,14 @@ func fakeAPIEndpoint(c *gc.C, client *api.Client, address, method string, handle
 	lis, err := net.Listen("tcp", "127.0.0.1:0")
 	c.Assert(err, jc.ErrorIsNil)
 
-	http.HandleFunc(address, func(w http.ResponseWriter, r *http.Request) {
+	mux := http.NewServeMux()
+	mux.HandleFunc(address, func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == method {
 			handle(w, r)
 		}
 	})
 	go func() {
-		http.Serve(lis, nil)
+		http.Serve(lis, mux)
 	}()
 	api.SetServerAddress(client, "http", lis.Addr().String())
 	return lis

--- a/api/gui.go
+++ b/api/gui.go
@@ -4,23 +4,47 @@
 package api
 
 import (
+	"bytes"
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/url"
 
 	"github.com/juju/errors"
 	"github.com/juju/version"
+
+	"github.com/juju/juju/apiserver/params"
 )
 
-// UploadGUIArchive uploads a GUI archive to the controller over HTTPS.
-func (c *Client) UploadGUIArchive(r io.ReadSeeker, hash string, size int64, vers version.Number) error {
+const (
+	guiArchivePath = "/gui-archive"
+	guiVersionPath = "/gui-version"
+)
+
+// GUIArchives retrieves information about Juju GUI archives currently present
+// in the Juju controller.
+func (c *Client) GUIArchives() ([]params.GUIArchiveVersion, error) {
+	httpClient, err := c.st.RootHTTPClient()
+	if err != nil {
+		return nil, errors.Annotate(err, "cannot retrieve HTTP client")
+	}
+	var resp params.GUIArchiveResponse
+	if err = httpClient.Get(guiArchivePath, &resp); err != nil {
+		return nil, errors.Annotate(err, "cannot retrieve GUI archives info")
+	}
+	return resp.Versions, nil
+}
+
+// UploadGUIArchive uploads a GUI archive to the controller over HTTPS, and
+// reports about whether the upload updated the current GUI served by Juju.
+func (c *Client) UploadGUIArchive(r io.ReadSeeker, hash string, size int64, vers version.Number) (current bool, err error) {
 	// Prepare the request.
 	v := url.Values{}
 	v.Set("version", vers.String())
 	v.Set("hash", hash)
-	req, err := http.NewRequest("POST", "/gui-archive?"+v.Encode(), nil)
+	req, err := http.NewRequest("POST", guiArchivePath+"?"+v.Encode(), nil)
 	if err != nil {
-		return errors.Annotate(err, "cannot create upload request")
+		return false, errors.Annotate(err, "cannot create upload request")
 	}
 	req.Header.Set("Content-Type", "application/x-tar-bzip2")
 	req.ContentLength = size
@@ -28,10 +52,38 @@ func (c *Client) UploadGUIArchive(r io.ReadSeeker, hash string, size int64, vers
 	// Retrieve a client and send the request.
 	httpClient, err := c.st.RootHTTPClient()
 	if err != nil {
+		return false, errors.Annotate(err, "cannot retrieve HTTP client")
+	}
+	var resp params.GUIArchiveVersion
+	if err = httpClient.Do(req, r, &resp); err != nil {
+		return false, errors.Annotate(err, "cannot upload the GUI archive")
+	}
+	return resp.Current, nil
+}
+
+// SelectGUIVersion selects which version of the Juju GUI is served by the
+// controller.
+func (c *Client) SelectGUIVersion(vers version.Number) error {
+	// Prepare the request.
+	req, err := http.NewRequest("PUT", guiVersionPath, nil)
+	if err != nil {
+		return errors.Annotate(err, "cannot create PUT request")
+	}
+	req.Header.Set("Content-Type", params.ContentTypeJSON)
+	content, err := json.Marshal(params.GUIVersionRequest{
+		Version: vers,
+	})
+	if err != nil {
+		errors.Annotate(err, "cannot marshal request body")
+	}
+
+	// Retrieve a client and send the request.
+	httpClient, err := c.st.RootHTTPClient()
+	if err != nil {
 		return errors.Annotate(err, "cannot retrieve HTTP client")
 	}
-	if err = httpClient.Do(req, r, nil); err != nil {
-		return errors.Annotate(err, "cannot upload the GUI archive")
+	if err = httpClient.Do(req, bytes.NewReader(content), nil); err != nil {
+		return errors.Annotate(err, "cannot select GUI version")
 	}
 	return nil
 }

--- a/api/gui_test.go
+++ b/api/gui_test.go
@@ -5,24 +5,77 @@ package api_test
 
 import (
 	"bytes"
+	"encoding/json"
 	"io/ioutil"
 	"net/http"
 
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/version"
 	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/params"
 )
 
-func (s *clientSuite) TestUploadGUIArchiveSuccess(c *gc.C) {
-	otherSt, otherAPISt := s.otherEnviron(c)
-	defer otherSt.Close()
-	defer otherAPISt.Close()
-	client := otherAPISt.Client()
+// sendJSONResponse encodes the given content as JSON and writes it to the
+// given response writer.
+func sendJSONResponse(c *gc.C, w http.ResponseWriter, content interface{}) {
+	w.Header().Set("Content-Type", params.ContentTypeJSON)
+	encoder := json.NewEncoder(w)
+	err := encoder.Encode(content)
+	c.Assert(err, jc.ErrorIsNil)
+}
 
-	// Prepare a GUI archive.
+func (s *clientSuite) TestGUIArchives(c *gc.C) {
+	client := s.APIState.Client()
+	called := false
+	response := params.GUIArchiveResponse{
+		Versions: []params.GUIArchiveVersion{{
+			Version: version.MustParse("1.0.0"),
+			SHA256:  "hash1",
+			Current: false,
+		}, {
+			Version: version.MustParse("2.0.0"),
+			SHA256:  "hash2",
+			Current: true,
+		}},
+	}
+
+	// Set up a fake endpoint for tests.
+	defer fakeAPIEndpoint(c, client, "/gui-archive", "GET",
+		func(w http.ResponseWriter, req *http.Request) {
+			defer req.Body.Close()
+			called = true
+			sendJSONResponse(c, w, response)
+		},
+	).Close()
+
+	versions, err := client.GUIArchives()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(versions, jc.DeepEquals, response.Versions)
+	c.Assert(called, jc.IsTrue)
+}
+
+func (s *clientSuite) TestGUIArchivesError(c *gc.C) {
+	client := s.APIState.Client()
+
+	// Set up a fake endpoint for tests.
+	defer fakeAPIEndpoint(c, client, "/gui-archive", "GET",
+		func(w http.ResponseWriter, req *http.Request) {
+			defer req.Body.Close()
+			w.WriteHeader(http.StatusBadRequest)
+		},
+	).Close()
+
+	versions, err := client.GUIArchives()
+	c.Assert(err, gc.ErrorMatches, "cannot retrieve GUI archives info: .*")
+	c.Assert(versions, gc.IsNil)
+}
+
+func (s *clientSuite) TestUploadGUIArchive(c *gc.C) {
+	client := s.APIState.Client()
+	called := false
 	archive := []byte("archive content")
 	hash, size, vers := "archive-hash", int64(len(archive)), version.MustParse("2.1.0")
-	called := false
 
 	// Set up a fake endpoint for tests.
 	defer fakeAPIEndpoint(c, client, "/gui-archive", "POST",
@@ -38,22 +91,76 @@ func (s *clientSuite) TestUploadGUIArchiveSuccess(c *gc.C) {
 			obtainedArchive, err := ioutil.ReadAll(req.Body)
 			c.Assert(err, jc.ErrorIsNil)
 			c.Assert(obtainedArchive, gc.DeepEquals, archive)
-			// Check hash, and fail if hash is empty.
+			// Check hash.
 			h := req.Form.Get("hash")
-			if h == "" {
-				w.WriteHeader(http.StatusBadRequest)
-			} else {
-				c.Assert(h, gc.Equals, hash)
-			}
+			c.Assert(h, gc.Equals, hash)
+			// Send the response.
+			sendJSONResponse(c, w, params.GUIArchiveVersion{
+				Current: true,
+			})
 		},
 	).Close()
 
-	// Check that the API client POSTs the GUI archive to the correct endpoint.
-	err := client.UploadGUIArchive(bytes.NewReader(archive), hash, size, vers)
+	current, err := client.UploadGUIArchive(bytes.NewReader(archive), hash, size, vers)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(current, jc.IsTrue)
+	c.Assert(called, jc.IsTrue)
+}
+
+func (s *clientSuite) TestUploadGUIArchiveError(c *gc.C) {
+	client := s.APIState.Client()
+	archive := []byte("archive content")
+	hash, size, vers := "archive-hash", int64(len(archive)), version.MustParse("2.1.0")
+
+	// Set up a fake endpoint for tests.
+	defer fakeAPIEndpoint(c, client, "/gui-archive", "POST",
+		func(w http.ResponseWriter, req *http.Request) {
+			defer req.Body.Close()
+			w.WriteHeader(http.StatusBadRequest)
+		},
+	).Close()
+
+	current, err := client.UploadGUIArchive(bytes.NewReader(archive), hash, size, vers)
+	c.Assert(err, gc.ErrorMatches, "cannot upload the GUI archive: .*")
+	c.Assert(current, jc.IsFalse)
+}
+
+func (s *clientSuite) TestSelectGUIVersion(c *gc.C) {
+	client := s.APIState.Client()
+	called := false
+	vers := version.MustParse("2.0.42")
+
+	// Set up a fake endpoint for tests.
+	defer fakeAPIEndpoint(c, client, "/gui-version", "PUT",
+		func(w http.ResponseWriter, req *http.Request) {
+			defer req.Body.Close()
+			called = true
+			// Check request body.
+			var request params.GUIVersionRequest
+			decoder := json.NewDecoder(req.Body)
+			err := decoder.Decode(&request)
+			c.Assert(err, jc.ErrorIsNil)
+			c.Assert(request.Version, gc.Equals, vers)
+		},
+	).Close()
+
+	err := client.SelectGUIVersion(vers)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(called, jc.IsTrue)
+}
 
-	// Fail by passing an empty hash.
-	err = client.UploadGUIArchive(bytes.NewReader(archive), "", size, vers)
-	c.Assert(err, gc.ErrorMatches, "cannot upload the GUI archive: .*")
+func (s *clientSuite) TestSelectGUIVersionError(c *gc.C) {
+	client := s.APIState.Client()
+	vers := version.MustParse("2.0.42")
+
+	// Set up a fake endpoint for tests.
+	defer fakeAPIEndpoint(c, client, "/gui-version", "PUT",
+		func(w http.ResponseWriter, req *http.Request) {
+			defer req.Body.Close()
+			w.WriteHeader(http.StatusBadRequest)
+		},
+	).Close()
+
+	err := client.SelectGUIVersion(vers)
+	c.Assert(err, gc.ErrorMatches, "cannot select GUI version: .*")
 }

--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -431,6 +431,9 @@ func (srv *Server) run() {
 	handleAll(mux, "/gui-archive", &guiArchiveHandler{
 		ctxt: httpCtxt,
 	})
+	handleAll(mux, "/gui-version", &guiVersionHandler{
+		ctxt: httpCtxt,
+	})
 
 	// For backwards compatibility we register all the old paths
 	handleAll(mux, "/log", debugLogHandler)

--- a/apiserver/gui.go
+++ b/apiserver/gui.go
@@ -7,6 +7,7 @@ import (
 	"archive/tar"
 	"bytes"
 	"compress/bzip2"
+	"encoding/json"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -25,6 +26,7 @@ import (
 
 	agenttools "github.com/juju/juju/agent/tools"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/binarystorage"
 	jujuversion "github.com/juju/juju/version"
 )
@@ -128,7 +130,7 @@ func (gr *guiRouter) ensureFiles(req *http.Request) (rootDir string, hash string
 		return "", "", errors.Annotate(err, "cannot open GUI storage")
 	}
 	defer storage.Close()
-	vers, hash, err := guiVersionAndHash(storage)
+	vers, hash, err := guiVersionAndHash(st, storage)
 	if err != nil {
 		return "", "", errors.Trace(err)
 	}
@@ -169,17 +171,19 @@ func (gr *guiRouter) ensureFiles(req *http.Request) (rootDir string, hash string
 
 // guiVersionAndHash returns the version and the SHA256 hash of the current
 // Juju GUI archive.
-func guiVersionAndHash(storage binarystorage.Storage) (vers, hash string, err error) {
-	// TODO frankban: retrieve current GUI version from somewhere.
-	// For now, just return an arbitrary version from the storage.
-	allMeta, err := storage.AllMetadata()
+func guiVersionAndHash(st *state.State, storage binarystorage.Storage) (vers, hash string, err error) {
+	currentVers, err := st.GUIVersion()
+	if errors.IsNotFound(err) {
+		return "", "", errors.NotFoundf("Juju GUI")
+	}
+	if err != nil {
+		return "", "", errors.Annotate(err, "cannot retrieve current GUI version")
+	}
+	metadata, err := storage.Metadata(currentVers.String())
 	if err != nil {
 		return "", "", errors.Annotate(err, "cannot retrieve GUI metadata")
 	}
-	if len(allMeta) == 0 {
-		return "", "", errors.NotFoundf("Juju GUI")
-	}
-	return allMeta[0].Version, allMeta[0].SHA256, nil
+	return metadata.Version, metadata.SHA256, nil
 }
 
 // uncompressGUI uncompresses the tar.bz2 Juju GUI archive provided in r.
@@ -392,6 +396,13 @@ func (h *guiArchiveHandler) handleGet(w http.ResponseWriter, req *http.Request) 
 	}
 
 	// Prepare and send the response.
+	var currentVersion string
+	vers, err := st.GUIVersion()
+	if err == nil {
+		currentVersion = vers.String()
+	} else if !errors.IsNotFound(err) {
+		return errors.Annotate(err, "cannot retrieve current GUI version")
+	}
 	versions := make([]params.GUIArchiveVersion, len(allMeta))
 	for i, m := range allMeta {
 		vers, err := version.Parse(m.Version)
@@ -401,8 +412,7 @@ func (h *guiArchiveHandler) handleGet(w http.ResponseWriter, req *http.Request) 
 		versions[i] = params.GUIArchiveVersion{
 			Version: vers,
 			SHA256:  m.SHA256,
-			// TODO frankban: check that this is the current version.
-			Current: true,
+			Current: m.Version == currentVersion,
 		}
 	}
 	sendStatusAndJSON(w, http.StatusOK, params.GUIArchiveResponse{
@@ -467,11 +477,61 @@ func (h *guiArchiveHandler) handlePost(w http.ResponseWriter, req *http.Request)
 		return errors.Annotate(err, "cannot add GUI archive to storage")
 	}
 
-	// Return the response with current version.
-	sendStatusAndJSON(w, http.StatusOK, params.GUIArchiveVersion{
+	// Prepare and return the response.
+	resp := params.GUIArchiveVersion{
 		Version: vers,
 		SHA256:  hash,
-		Current: true,
-	})
+	}
+	if currentVers, err := st.GUIVersion(); err == nil {
+		if currentVers == vers {
+			resp.Current = true
+		}
+	} else if !errors.IsNotFound(err) {
+		return errors.Annotate(err, "cannot retrieve current GUI version")
+	}
+	sendStatusAndJSON(w, http.StatusOK, resp)
+	return nil
+}
+
+// guiVersionHandler is used to select the Juju GUI version served by the
+// controller. The specified version must be available in the controller.
+type guiVersionHandler struct {
+	ctxt httpContext
+}
+
+// ServeHTTP implements http.Handler.
+func (h *guiVersionHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	if req.Method != "PUT" {
+		sendError(w, errors.MethodNotAllowedf("unsupported method: %q", req.Method))
+		return
+	}
+	if err := h.handlePut(w, req); err != nil {
+		sendError(w, errors.Trace(err))
+	}
+}
+
+// handlePost is used to switch to a specific Juju GUI version.
+func (h *guiVersionHandler) handlePut(w http.ResponseWriter, req *http.Request) error {
+	// Validate the request.
+	if ctype := req.Header.Get("Content-Type"); ctype != params.ContentTypeJSON {
+		return errors.BadRequestf("invalid content type %q: expected %q", ctype, params.ContentTypeJSON)
+	}
+
+	// Authenticate the request and retrieve the Juju state.
+	st, _, err := h.ctxt.stateForRequestAuthenticatedUser(req)
+	if err != nil {
+		return errors.Annotate(err, "cannot open state")
+	}
+
+	var selected params.GUIVersionRequest
+	decoder := json.NewDecoder(req.Body)
+	if err := decoder.Decode(&selected); err != nil {
+		return errors.NewBadRequest(err, "invalid request body")
+	}
+
+	// Switch to the provided GUI version.
+	if err = st.GUISetVersion(selected.Version); err != nil {
+		return errors.Trace(err)
+	}
 	return nil
 }

--- a/apiserver/gui.go
+++ b/apiserver/gui.go
@@ -510,7 +510,7 @@ func (h *guiVersionHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) 
 	}
 }
 
-// handlePost is used to switch to a specific Juju GUI version.
+// handlePut is used to switch to a specific Juju GUI version.
 func (h *guiVersionHandler) handlePut(w http.ResponseWriter, req *http.Request) error {
 	// Validate the request.
 	if ctype := req.Header.Get("Content-Type"); ctype != params.ContentTypeJSON {

--- a/apiserver/gui_test.go
+++ b/apiserver/gui_test.go
@@ -67,6 +67,9 @@ var guiHandlerTests = []struct {
 	// Optionally it can return a GUI archive hash which is used by the test
 	// to build the URL path for the HTTP request.
 	setup guiSetupFunc
+	// currentVersion optionally holds the GUI version that must be set as
+	// current right after setup is called and before the test is run.
+	currentVersion string
 	// pathAndquery holds the optional path and query for the request, for
 	// instance "/combo?file". If not provided, the "/" path is used.
 	pathAndquery string
@@ -89,7 +92,8 @@ var guiHandlerTests = []struct {
 	about: "GUI directory is a file",
 	setup: func(c *gc.C, baseDir string, storage binarystorage.Storage) string {
 		err := storage.Add(strings.NewReader(""), binarystorage.Metadata{
-			SHA256: "fake-hash",
+			SHA256:  "fake-hash",
+			Version: "2.1.0",
 		})
 		c.Assert(err, jc.ErrorIsNil)
 		err = os.MkdirAll(baseDir, 0755)
@@ -99,23 +103,39 @@ var guiHandlerTests = []struct {
 		c.Assert(err, jc.ErrorIsNil)
 		return ""
 	},
+	currentVersion: "2.1.0",
 	expectedStatus: http.StatusInternalServerError,
 	expectedError:  "cannot use Juju GUI root directory .*",
 }, {
 	about: "GUI directory is unaccessible",
 	setup: func(c *gc.C, baseDir string, storage binarystorage.Storage) string {
 		err := storage.Add(strings.NewReader(""), binarystorage.Metadata{
-			SHA256: "fake-hash",
+			SHA256:  "fake-hash",
+			Version: "2.2.0",
 		})
 		c.Assert(err, jc.ErrorIsNil)
 		err = os.MkdirAll(baseDir, 0000)
 		c.Assert(err, jc.ErrorIsNil)
 		return ""
 	},
+	currentVersion: "2.2.0",
 	expectedStatus: http.StatusInternalServerError,
 	expectedError:  "cannot stat Juju GUI root directory: .*",
 }, {
 	about: "invalid GUI archive",
+	setup: func(c *gc.C, baseDir string, storage binarystorage.Storage) string {
+		err := storage.Add(strings.NewReader(""), binarystorage.Metadata{
+			SHA256:  "fake-hash",
+			Version: "2.3.0",
+		})
+		c.Assert(err, jc.ErrorIsNil)
+		return ""
+	},
+	currentVersion: "2.3.0",
+	expectedStatus: http.StatusInternalServerError,
+	expectedError:  "cannot uncompress Juju GUI archive: cannot parse archive: .*",
+}, {
+	about: "GUI current version not set",
 	setup: func(c *gc.C, baseDir string, storage binarystorage.Storage) string {
 		err := storage.Add(strings.NewReader(""), binarystorage.Metadata{
 			SHA256: "fake-hash",
@@ -123,14 +143,15 @@ var guiHandlerTests = []struct {
 		c.Assert(err, jc.ErrorIsNil)
 		return ""
 	},
-	expectedStatus: http.StatusInternalServerError,
-	expectedError:  "cannot uncompress Juju GUI archive: cannot parse archive: .*",
+	expectedStatus: http.StatusNotFound,
+	expectedError:  "Juju GUI not found",
 }, {
 	about: "index: sprite file not found",
 	setup: func(c *gc.C, baseDir string, storage binarystorage.Storage) string {
 		setupGUIArchive(c, storage, "2.0.42", nil)
 		return ""
 	},
+	currentVersion: "2.0.42",
 	expectedStatus: http.StatusInternalServerError,
 	expectedError:  "cannot read sprite file: .*",
 }, {
@@ -141,6 +162,7 @@ var guiHandlerTests = []struct {
 		})
 		return ""
 	},
+	currentVersion: "2.0.42",
 	expectedStatus: http.StatusInternalServerError,
 	expectedError:  "cannot parse template: .*: no such file or directory",
 }, {
@@ -152,6 +174,7 @@ var guiHandlerTests = []struct {
 		})
 		return ""
 	},
+	currentVersion: "2.0.47",
 	expectedStatus: http.StatusInternalServerError,
 	expectedError:  `cannot parse template: template: index.html.go:1: unexpected ".47" .*`,
 }, {
@@ -163,6 +186,7 @@ var guiHandlerTests = []struct {
 		})
 		return ""
 	},
+	currentVersion: "2.0.47",
 	expectedStatus: http.StatusInternalServerError,
 	expectedError:  `cannot render template: template: .*: range can't iterate over .*`,
 }, {
@@ -170,6 +194,7 @@ var guiHandlerTests = []struct {
 	setup: func(c *gc.C, baseDir string, storage binarystorage.Storage) string {
 		return setupGUIArchive(c, storage, "2.0.42", nil)
 	},
+	currentVersion: "2.0.42",
 	pathAndquery:   "/config.js",
 	expectedStatus: http.StatusInternalServerError,
 	expectedError:  "cannot parse template: .*: no such file or directory",
@@ -180,6 +205,7 @@ var guiHandlerTests = []struct {
 			guiConfigPath: "{{.BadWolf.47}}",
 		})
 	},
+	currentVersion: "2.0.47",
 	pathAndquery:   "/config.js",
 	expectedStatus: http.StatusInternalServerError,
 	expectedError:  `cannot parse template: template: config.js.go:1: unexpected ".47" .*`,
@@ -189,6 +215,7 @@ var guiHandlerTests = []struct {
 		setupGUIArchive(c, storage, "2.0.47", nil)
 		return "invalid"
 	},
+	currentVersion: "2.0.47",
 	pathAndquery:   "/config.js",
 	expectedStatus: http.StatusNotFound,
 	expectedError:  `resource with "invalid" hash not found`,
@@ -197,6 +224,7 @@ var guiHandlerTests = []struct {
 	setup: func(c *gc.C, baseDir string, storage binarystorage.Storage) string {
 		return setupGUIArchive(c, storage, "1.0.0", nil)
 	},
+	currentVersion: "1.0.0",
 	pathAndquery:   "/combo?foo&%%",
 	expectedStatus: http.StatusBadRequest,
 	expectedError:  `cannot combine files: invalid file name "%": invalid URL escape "%%"`,
@@ -205,6 +233,7 @@ var guiHandlerTests = []struct {
 	setup: func(c *gc.C, baseDir string, storage binarystorage.Storage) string {
 		return setupGUIArchive(c, storage, "1.0.0", nil)
 	},
+	currentVersion: "1.0.0",
 	pathAndquery:   "/combo?../../../../../../etc/passwd",
 	expectedStatus: http.StatusBadRequest,
 	expectedError:  `cannot combine files: forbidden file path "../../../../../../etc/passwd"`,
@@ -214,6 +243,7 @@ var guiHandlerTests = []struct {
 		setupGUIArchive(c, storage, "2.0.47", nil)
 		return "invalid"
 	},
+	currentVersion: "2.0.47",
 	pathAndquery:   "/combo?foo",
 	expectedStatus: http.StatusNotFound,
 	expectedError:  `resource with "invalid" hash not found`,
@@ -227,6 +257,7 @@ var guiHandlerTests = []struct {
 			"static/gui/build/borg.js":        "cube",
 		})
 	},
+	currentVersion:      "1.0.0",
 	pathAndquery:        "/combo?voy/janeway.js&tng/picard.js&borg.js&ds9/sisko.js",
 	expectedStatus:      http.StatusOK,
 	expectedContentType: apiserver.JSMimeType,
@@ -246,6 +277,7 @@ deep space nine
 			"static/gui/build/foo.css": "my-style",
 		})
 	},
+	currentVersion:      "1.0.0",
 	pathAndquery:        "/combo?no-such.css&foo.css&bad-wolf.css",
 	expectedStatus:      http.StatusOK,
 	expectedContentType: "text/css; charset=utf-8",
@@ -259,6 +291,7 @@ deep space nine
 			"static/file.js": "static file content",
 		})
 	},
+	currentVersion:      "1.0.0",
 	pathAndquery:        "/static/file.js",
 	expectedStatus:      http.StatusOK,
 	expectedContentType: apiserver.JSMimeType,
@@ -269,9 +302,24 @@ deep space nine
 		setupGUIArchive(c, storage, "2.0.47", nil)
 		return "bad-wolf"
 	},
+	currentVersion: "2.0.47",
 	pathAndquery:   "/static/file.js",
 	expectedStatus: http.StatusNotFound,
 	expectedError:  `resource with "bad-wolf" hash not found`,
+}, {
+	about: "static files: old version hash",
+	setup: func(c *gc.C, baseDir string, storage binarystorage.Storage) string {
+		setupGUIArchive(c, storage, "2.1.1", map[string]string{
+			"static/file.js": "static file version 2.1.1",
+		})
+		return setupGUIArchive(c, storage, "2.1.2", map[string]string{
+			"static/file.js": "static file version 2.1.2",
+		})
+	},
+	currentVersion: "2.1.1",
+	pathAndquery:   "/static/file.js",
+	expectedStatus: http.StatusNotFound,
+	expectedError:  `resource with ".*" hash not found`,
 }}
 
 func (s *guiSuite) TestGUIHandler(c *gc.C) {
@@ -280,7 +328,7 @@ func (s *guiSuite) TestGUIHandler(c *gc.C) {
 		// only served from Linux machines.
 		c.Skip("bzip2 command not available")
 	}
-	sendRequest := func(setup guiSetupFunc, pathAndquery string) *http.Response {
+	sendRequest := func(setup guiSetupFunc, currentVersion, pathAndquery string) *http.Response {
 		// Set up the GUI base directory.
 		datadir := filepath.ToSlash(s.DataDir())
 		baseDir := filepath.FromSlash(agenttools.SharedGUIDir(datadir))
@@ -304,6 +352,12 @@ func (s *guiSuite) TestGUIHandler(c *gc.C) {
 			hash = setup(c, baseDir, storage)
 		}
 
+		// Set the current GUI version if required.
+		if currentVersion != "" {
+			err := s.State.GUISetVersion(version.MustParse(currentVersion))
+			c.Assert(err, jc.ErrorIsNil)
+		}
+
 		// Send a request to the test path.
 		if pathAndquery == "" {
 			pathAndquery = "/"
@@ -320,7 +374,7 @@ func (s *guiSuite) TestGUIHandler(c *gc.C) {
 		s.Reset(c)
 
 		// Perform the request.
-		resp := sendRequest(test.setup, test.pathAndquery)
+		resp := sendRequest(test.setup, test.currentVersion, test.pathAndquery)
 
 		// Check the response.
 		if test.expectedStatus == 0 {
@@ -357,10 +411,14 @@ func (s *guiSuite) TestGUIIndex(c *gc.C) {
     spriteContent: {{.spriteContent}}
 </body>
 </html>`
-	hash := setupGUIArchive(c, storage, "2.0.0", map[string]string{
+	vers := version.MustParse("2.0.0")
+	hash := setupGUIArchive(c, storage, vers.String(), map[string]string{
 		guiIndexPath:         indexContent,
 		apiserver.SpritePath: "sprite content",
 	})
+	err = s.State.GUISetVersion(vers)
+	c.Assert(err, jc.ErrorIsNil)
+
 	expectedIndexContent := fmt.Sprintf(`
 <!DOCTYPE html>
 <html>
@@ -386,6 +444,45 @@ func (s *guiSuite) TestGUIIndex(c *gc.C) {
 	c.Assert(string(body), gc.Equals, expectedIndexContent)
 }
 
+func (s *guiSuite) TestGUIIndexVersions(c *gc.C) {
+	storage, err := s.State.GUIStorage()
+	c.Assert(err, jc.ErrorIsNil)
+	defer storage.Close()
+
+	// Create Juju GUI archives and save it into the storage.
+	setupGUIArchive(c, storage, "1.0.0", map[string]string{
+		guiIndexPath:         "index version 1.0.0",
+		apiserver.SpritePath: "sprite content",
+	})
+	vers2 := version.MustParse("2.0.0")
+	setupGUIArchive(c, storage, vers2.String(), map[string]string{
+		guiIndexPath:         "index version 2.0.0",
+		apiserver.SpritePath: "sprite content",
+	})
+	vers3 := version.MustParse("3.0.0")
+	setupGUIArchive(c, storage, vers3.String(), map[string]string{
+		guiIndexPath:         "index version 3.0.0",
+		apiserver.SpritePath: "sprite content",
+	})
+
+	// Check that the correct index version is served.
+	err = s.State.GUISetVersion(vers2)
+	c.Assert(err, jc.ErrorIsNil)
+	resp := s.sendRequest(c, httpRequestParams{
+		url: s.guiURL(c, "", "/"),
+	})
+	body := assertResponse(c, resp, http.StatusOK, "text/plain; charset=utf-8")
+	c.Assert(string(body), gc.Equals, "index version 2.0.0")
+
+	err = s.State.GUISetVersion(vers3)
+	c.Assert(err, jc.ErrorIsNil)
+	resp = s.sendRequest(c, httpRequestParams{
+		url: s.guiURL(c, "", "/"),
+	})
+	body = assertResponse(c, resp, http.StatusOK, "text/plain; charset=utf-8")
+	c.Assert(string(body), gc.Equals, "index version 3.0.0")
+}
+
 func (s *guiSuite) TestGUIConfig(c *gc.C) {
 	storage, err := s.State.GUIStorage()
 	c.Assert(err, jc.ErrorIsNil)
@@ -401,9 +498,13 @@ var config = {
     uuid: '{{.uuid}}',
     version: '{{.version}}'
 };`
-	hash := setupGUIArchive(c, storage, "2.0.0", map[string]string{
+	vers := version.MustParse("2.0.0")
+	hash := setupGUIArchive(c, storage, vers.String(), map[string]string{
 		guiConfigPath: configContent,
 	})
+	err = s.State.GUISetVersion(vers)
+	c.Assert(err, jc.ErrorIsNil)
+
 	expectedConfigContent := fmt.Sprintf(`
 var config = {
     // This is just an example and does not reflect the real Juju GUI config.
@@ -429,10 +530,13 @@ func (s *guiSuite) TestGUIDirectory(c *gc.C) {
 
 	// Create a Juju GUI archive and save it into the storage.
 	indexContent := "<!DOCTYPE html><html><body>Exterminate!</body></html>"
-	hash := setupGUIArchive(c, storage, "2.0.0", map[string]string{
+	vers := version.MustParse("2.0.0")
+	hash := setupGUIArchive(c, storage, vers.String(), map[string]string{
 		guiIndexPath:         indexContent,
 		apiserver.SpritePath: "",
 	})
+	err = s.State.GUISetVersion(vers)
+	c.Assert(err, jc.ErrorIsNil)
 
 	// Initially the GUI directory on the server is empty.
 	baseDir := agenttools.SharedGUIDir(s.DataDir())
@@ -467,24 +571,45 @@ func (s *guiArchiveSuite) guiURL(c *gc.C) string {
 	return u.String()
 }
 
+func (s *guiArchiveSuite) TestGUIArchiveMethodNotAllowed(c *gc.C) {
+	resp := s.authRequest(c, httpRequestParams{
+		method: "PUT",
+		url:    s.guiURL(c),
+	})
+	body := assertResponse(c, resp, http.StatusMethodNotAllowed, params.ContentTypeJSON)
+	var jsonResp params.ErrorResult
+	err := json.Unmarshal(body, &jsonResp)
+	c.Assert(err, jc.ErrorIsNil, gc.Commentf("body: %s", body))
+	c.Assert(jsonResp.Error.Message, gc.Matches, `unsupported method: "PUT"`)
+}
+
 var guiArchiveGetTests = []struct {
 	about    string
 	versions []string
+	current  string
 }{{
 	about: "empty storage",
 }, {
 	about:    "one version",
 	versions: []string{"2.42.0"},
 }, {
+	about:    "one version (current)",
+	versions: []string{"2.42.0"},
+	current:  "2.42.0",
+}, {
 	about:    "multiple versions",
 	versions: []string{"2.42.0", "3.0.0", "2.47.1"},
+}, {
+	about:    "multiple versions (current)",
+	versions: []string{"2.42.0", "3.0.0", "2.47.1"},
+	current:  "3.0.0",
 }}
 
 func (s *guiArchiveSuite) TestGUIArchiveGet(c *gc.C) {
 	for i, test := range guiArchiveGetTests {
 		c.Logf("\n%d: %s", i, test.about)
 
-		uploadVersions := func(versions []string) params.GUIArchiveResponse {
+		uploadVersions := func(versions []string, current string) params.GUIArchiveResponse {
 			// Open the GUI storage.
 			storage, err := s.State.GUIStorage()
 			c.Assert(err, jc.ErrorIsNil)
@@ -494,12 +619,16 @@ func (s *guiArchiveSuite) TestGUIArchiveGet(c *gc.C) {
 			expectedVersions := make([]params.GUIArchiveVersion, len(versions))
 			for i, vers := range versions {
 				files := map[string]string{"file": fmt.Sprintf("content %d", i)}
+				v := version.MustParse(vers)
 				hash := setupGUIArchive(c, storage, vers, files)
 				expectedVersions[i] = params.GUIArchiveVersion{
-					Version: version.MustParse(vers),
+					Version: v,
 					SHA256:  hash,
-					// TODO frankban: use real current one.
-					Current: true,
+				}
+				if vers == current {
+					err := s.State.GUISetVersion(v)
+					c.Assert(err, jc.ErrorIsNil)
+					expectedVersions[i].Current = true
 				}
 			}
 			return params.GUIArchiveResponse{
@@ -511,7 +640,7 @@ func (s *guiArchiveSuite) TestGUIArchiveGet(c *gc.C) {
 		s.Reset(c)
 
 		// Send the request to retrieve GUI version information.
-		expectedResponse := uploadVersions(test.versions)
+		expectedResponse := uploadVersions(test.versions, test.current)
 		resp := s.sendRequest(c, httpRequestParams{
 			url: s.guiURL(c),
 		})
@@ -641,7 +770,7 @@ func (s *guiArchiveSuite) TestGUIArchivePostSuccess(c *gc.C) {
 	c.Assert(jsonResponse, jc.DeepEquals, params.GUIArchiveVersion{
 		Version: version.MustParse(vers),
 		SHA256:  hash,
-		Current: true,
+		Current: false,
 	})
 
 	// Check that the new archive is actually present in the GUI storage.
@@ -653,6 +782,169 @@ func (s *guiArchiveSuite) TestGUIArchivePostSuccess(c *gc.C) {
 	c.Assert(allMeta, gc.HasLen, 1)
 	c.Assert(allMeta[0].SHA256, gc.Equals, hash)
 	c.Assert(allMeta[0].Size, gc.Equals, size)
+}
+
+func (s *guiArchiveSuite) TestGUIArchivePostCurrent(c *gc.C) {
+	// Add an existing GUI archive and set it as the current one.
+	storage, err := s.State.GUIStorage()
+	c.Assert(err, jc.ErrorIsNil)
+	defer storage.Close()
+	vers := version.MustParse("2.0.47")
+	setupGUIArchive(c, storage, vers.String(), nil)
+	err = s.State.GUISetVersion(vers)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Create a GUI archive to be uploaded.
+	r, hash, _ := makeGUIArchive(c, vers.String(), map[string]string{"filename": "content"})
+
+	// Prepare and send the request to upload a new GUI archive.
+	v := url.Values{}
+	v.Set("version", vers.String())
+	v.Set("hash", hash)
+	resp := s.authRequest(c, httpRequestParams{
+		method:      "POST",
+		url:         s.guiURL(c) + "?" + v.Encode(),
+		contentType: apiserver.BZMimeType,
+		body:        r,
+	})
+
+	// Check that the response reflects a successful upload.
+	body := assertResponse(c, resp, http.StatusOK, params.ContentTypeJSON)
+	var jsonResponse params.GUIArchiveVersion
+	err = json.Unmarshal(body, &jsonResponse)
+	c.Assert(err, jc.ErrorIsNil, gc.Commentf("body: %s", body))
+	c.Assert(jsonResponse, jc.DeepEquals, params.GUIArchiveVersion{
+		Version: vers,
+		SHA256:  hash,
+		Current: true,
+	})
+}
+
+type guiVersionSuite struct {
+	authHttpSuite
+}
+
+var _ = gc.Suite(&guiVersionSuite{})
+
+// guiURL returns the URL used to select the Juju GUI archive version.
+func (s *guiVersionSuite) guiURL(c *gc.C) string {
+	u := s.baseURL(c)
+	u.Path = "/gui-version"
+	return u.String()
+}
+
+func (s *guiVersionSuite) TestGUIVersionMethodNotAllowed(c *gc.C) {
+	resp := s.authRequest(c, httpRequestParams{
+		method: "GET",
+		url:    s.guiURL(c),
+	})
+	body := assertResponse(c, resp, http.StatusMethodNotAllowed, params.ContentTypeJSON)
+	var jsonResp params.ErrorResult
+	err := json.Unmarshal(body, &jsonResp)
+	c.Assert(err, jc.ErrorIsNil, gc.Commentf("body: %s", body))
+	c.Assert(jsonResp.Error.Message, gc.Matches, `unsupported method: "GET"`)
+}
+
+var guiVersionPutTests = []struct {
+	about           string
+	contentType     string
+	body            interface{}
+	expectedStatus  int
+	expectedVersion string
+	expectedError   string
+}{{
+	about:          "no content type",
+	expectedStatus: http.StatusBadRequest,
+	expectedError:  fmt.Sprintf(`invalid content type "": expected %q`, params.ContentTypeJSON),
+}, {
+	about:          "invalid content type",
+	contentType:    "text/html",
+	expectedStatus: http.StatusBadRequest,
+	expectedError:  fmt.Sprintf(`invalid content type "text/html": expected %q`, params.ContentTypeJSON),
+}, {
+	about:          "invalid body",
+	contentType:    params.ContentTypeJSON,
+	body:           "bad wolf",
+	expectedStatus: http.StatusBadRequest,
+	expectedError:  "invalid request body: json: .*",
+}, {
+	about:       "non existing version",
+	contentType: params.ContentTypeJSON,
+	body: params.GUIVersionRequest{
+		Version: version.MustParse("2.0.1"),
+	},
+	expectedStatus: http.StatusNotFound,
+	expectedError:  `cannot find "2.0.1" GUI version in the storage: 2.0.1 binary metadata not found`,
+}, {
+	about:       "success: switch to new version",
+	contentType: params.ContentTypeJSON,
+	body: params.GUIVersionRequest{
+		Version: version.MustParse("2.47.0"),
+	},
+	expectedStatus:  http.StatusOK,
+	expectedVersion: "2.47.0",
+}, {
+	about:       "success: same version",
+	contentType: params.ContentTypeJSON,
+	body: params.GUIVersionRequest{
+		Version: version.MustParse("2.42.0"),
+	},
+	expectedStatus:  http.StatusOK,
+	expectedVersion: "2.42.0",
+}}
+
+func (s *guiVersionSuite) TestGUIVersionPut(c *gc.C) {
+	// Prepare the initial Juju state.
+	storage, err := s.State.GUIStorage()
+	c.Assert(err, jc.ErrorIsNil)
+	defer storage.Close()
+	setupGUIArchive(c, storage, "2.42.0", nil)
+	setupGUIArchive(c, storage, "2.47.0", nil)
+	err = s.State.GUISetVersion(version.MustParse("2.42.0"))
+	c.Assert(err, jc.ErrorIsNil)
+
+	for i, test := range guiVersionPutTests {
+		c.Logf("\n%d: %s", i, test.about)
+
+		// Prepare the request.
+		content, err := json.Marshal(test.body)
+		c.Assert(err, jc.ErrorIsNil)
+
+		// Send the request and retrieve the response.
+		resp := s.authRequest(c, httpRequestParams{
+			method:      "PUT",
+			url:         s.guiURL(c),
+			contentType: test.contentType,
+			body:        bytes.NewReader(content),
+		})
+		var body []byte
+		if test.expectedError != "" {
+			body = assertResponse(c, resp, test.expectedStatus, params.ContentTypeJSON)
+			var jsonResp params.ErrorResult
+			err := json.Unmarshal(body, &jsonResp)
+			c.Assert(err, jc.ErrorIsNil, gc.Commentf("body: %s", body))
+			c.Assert(jsonResp.Error.Message, gc.Matches, test.expectedError)
+		} else {
+			body = assertResponse(c, resp, test.expectedStatus, "text/plain; charset=utf-8")
+			c.Assert(body, gc.HasLen, 0)
+			vers, err := s.State.GUIVersion()
+			c.Assert(err, jc.ErrorIsNil)
+			c.Assert(vers.String(), gc.Equals, test.expectedVersion)
+		}
+	}
+}
+
+func (s *guiVersionSuite) TestGUIVersionPutErrorUnauthorized(c *gc.C) {
+	resp := s.sendRequest(c, httpRequestParams{
+		method:      "PUT",
+		url:         s.guiURL(c),
+		contentType: params.ContentTypeJSON,
+	})
+	body := assertResponse(c, resp, http.StatusUnauthorized, params.ContentTypeJSON)
+	var jsonResp params.ErrorResult
+	err := json.Unmarshal(body, &jsonResp)
+	c.Assert(err, jc.ErrorIsNil, gc.Commentf("body: %s", body))
+	c.Assert(jsonResp.Error.Message, gc.Matches, "cannot open state: no credentials provided")
 }
 
 // makeGUIArchive creates a Juju GUI tar.bz2 archive with the given files.

--- a/apiserver/params/internal.go
+++ b/apiserver/params/internal.go
@@ -661,3 +661,9 @@ type GUIArchiveVersion struct {
 type GUIArchiveResponse struct {
 	Versions []GUIArchiveVersion `json:"versions"`
 }
+
+// GUIVersionRequest holds the body for /gui-version PUT requests.
+type GUIVersionRequest struct {
+	// Version holds the Juju GUI version number.
+	Version version.Number `json:"version"`
+}

--- a/cmd/jujud/bootstrap.go
+++ b/cmd/jujud/bootstrap.go
@@ -439,8 +439,8 @@ func (c *BootstrapCommand) populateTools(st *state.State, env environs.Environ) 
 	return nil
 }
 
-// populateGUIArchive stores uploaded Juju GUI archive in provider storage
-// and updates the GUI metadata.
+// populateGUIArchive stores uploaded Juju GUI archive in provider storage,
+// updates the GUI metadata and set the current Juju GUI version.
 func (c *BootstrapCommand) populateGUIArchive(st *state.State, env environs.Environ) error {
 	agentConfig := c.CurrentConfig()
 	dataDir := agentConfig.DataDir()
@@ -467,6 +467,9 @@ func (c *BootstrapCommand) populateGUIArchive(st *state.State, env environs.Envi
 		SHA256:  gui.SHA256,
 	}); err != nil {
 		return errors.Annotate(err, "cannot store GUI archive")
+	}
+	if err = st.GUISetVersion(gui.Version); err != nil {
+		return errors.Annotate(err, "cannot set current GUI version")
 	}
 	return nil
 }

--- a/cmd/jujud/bootstrap_test.go
+++ b/cmd/jujud/bootstrap_test.go
@@ -211,6 +211,11 @@ func (s *BootstrapSuite) TestGUIArchiveSuccess(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(allMeta, gc.HasLen, 1)
 	c.Assert(allMeta[0].Version, gc.Equals, "2.0.42")
+
+	// The current GUI version has been set.
+	vers, err := st.GUIVersion()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(vers.String(), gc.Equals, "2.0.42")
 }
 
 var testPassword = "my-admin-secret"

--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -91,6 +91,9 @@ func allCollections() collectionSchema {
 		// the simplestreams data source pointing to Juju GUI archives.
 		guimetadataC: {global: true},
 
+		// This collection holds Juju GUI current version and other settings.
+		guisettingsC: {global: true},
+
 		// This collection holds model information; in particular its
 		// Life and its UUID.
 		modelsC: {global: true},
@@ -407,6 +410,7 @@ const (
 	filesystemAttachmentsC   = "filesystemAttachments"
 	filesystemsC             = "filesystems"
 	guimetadataC             = "guimetadata"
+	guisettingsC             = "guisettings"
 	instanceDataC            = "instanceData"
 	legacyipaddressesC       = "ipaddresses"
 	leaseC                   = "lease"

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -38,6 +38,7 @@ const (
 	BlockDevicesC      = blockDevicesC
 	StorageInstancesC  = storageInstancesC
 	StatusesHistoryC   = statusesHistoryC
+	GUISettingsC       = guisettingsC
 )
 
 var (

--- a/state/gui.go
+++ b/state/gui.go
@@ -1,4 +1,4 @@
-// Copyright 2-16 Canonical Ltd.
+// Copyright 2016 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 package state

--- a/state/gui.go
+++ b/state/gui.go
@@ -1,0 +1,56 @@
+// Copyright 2-16 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/version"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
+)
+
+// guiSettingsDoc represents the Juju GUI settings in MongoDB.
+type guiSettingsDoc struct {
+	// CurrentVersion is the version of the Juju GUI currently served by
+	// the controller when requesting the GUI via HTTP.
+	CurrentVersion version.Number `bson:"current-version"`
+}
+
+// GUISetVersion sets the Juju GUI version that the controller must serve.
+func (st *State) GUISetVersion(vers version.Number) error {
+	// Check that the provided version is actually present in the GUI storage.
+	storage, err := st.GUIStorage()
+	if err != nil {
+		return errors.Annotate(err, "cannot open GUI storage")
+	}
+	defer storage.Close()
+	if _, err = storage.Metadata(vers.String()); err != nil {
+		return errors.Annotatef(err, "cannot find %q GUI version in the storage", vers)
+	}
+
+	// Set the current version.
+	settings, closer := st.getCollection(guisettingsC)
+	defer closer()
+	if _, err = settings.Writeable().Upsert(nil, bson.D{{"current-version", vers}}); err != nil {
+		return errors.Annotate(err, "cannot set current GUI version")
+	}
+	return nil
+}
+
+// GUIVersion returns the Juju GUI version currently served by the controller.
+func (st *State) GUIVersion() (vers version.Number, err error) {
+	settings, closer := st.getCollection(guisettingsC)
+	defer closer()
+
+	// Retrieve the settings document.
+	var doc guiSettingsDoc
+	err = settings.Find(nil).Select(bson.D{{"current-version", 1}}).One(&doc)
+	if err == nil {
+		return doc.CurrentVersion, nil
+	}
+	if err == mgo.ErrNotFound {
+		return vers, errors.NotFoundf("Juju GUI version")
+	}
+	return vers, errors.Trace(err)
+}

--- a/state/gui_test.go
+++ b/state/gui_test.go
@@ -1,0 +1,83 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state_test
+
+import (
+	"bytes"
+
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/version"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/state/binarystorage"
+)
+
+type guiVersionSuite struct {
+	ConnSuite
+}
+
+var _ = gc.Suite(&guiVersionSuite{})
+
+func (s *guiVersionSuite) TestGUISetVersionNotFoundError(c *gc.C) {
+	err := s.State.GUISetVersion(version.MustParse("2.0.1"))
+	c.Assert(err, gc.ErrorMatches, `cannot find "2.0.1" GUI version in the storage: 2.0.1 binary metadata not found`)
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+}
+
+func (s *guiVersionSuite) TestGUIVersionNotFoundError(c *gc.C) {
+	_, err := s.State.GUIVersion()
+	c.Assert(err, gc.ErrorMatches, "Juju GUI version not found")
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+}
+
+func (s *guiVersionSuite) TestGUISetVersion(c *gc.C) {
+	vers := s.addArchive(c, "2.1.0")
+	err := s.State.GUISetVersion(vers)
+	c.Assert(err, jc.ErrorIsNil)
+	obtainedVers, err := s.State.GUIVersion()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(obtainedVers, gc.Equals, vers)
+}
+
+func (s *guiVersionSuite) TestGUISwitchVersion(c *gc.C) {
+	err := s.State.GUISetVersion(s.addArchive(c, "2.47.0"))
+	c.Assert(err, jc.ErrorIsNil)
+
+	vers := s.addArchive(c, "2.42.0")
+	err = s.State.GUISetVersion(vers)
+	c.Assert(err, jc.ErrorIsNil)
+
+	obtainedVers, err := s.State.GUIVersion()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(obtainedVers, gc.Equals, vers)
+
+	// The collection still only includes one document.
+	s.checkCount(c)
+}
+
+// addArchive adds a fake Juju GUI archive to the binary storage.
+func (s *guiVersionSuite) addArchive(c *gc.C, vers string) version.Number {
+	storage, err := s.State.GUIStorage()
+	c.Assert(err, jc.ErrorIsNil)
+	defer storage.Close()
+	content := "content " + vers
+	err = storage.Add(bytes.NewReader([]byte(content)), binarystorage.Metadata{
+		SHA256:  "hash",
+		Size:    int64(len(content)),
+		Version: vers,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	return version.MustParse(vers)
+}
+
+// checkCount ensures that there is only one document in the GUI settings
+// mongo collection.
+func (s *guiVersionSuite) checkCount(c *gc.C) {
+	settings := s.State.MongoSession().DB("juju").C(state.GUISettingsC)
+	count, err := settings.Find(nil).Count()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(count, gc.Equals, 1)
+}


### PR DESCRIPTION
Both server and client sides are implemented.
This will unblock work on the upgrade-gui command.

(Review request: http://reviews.vapour.ws/r/4298/)