### PR TITLE
Add back github.com/gabriel-samfira/sys dep

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -4,6 +4,7 @@ github.com/altoros/gosigma	git	31228935eec685587914528585da4eb9b073c76d	2015-04-
 github.com/bmizerany/pat	git	48be7df2c27e1cec821a3284a683ce6ef90d9052	2014-04-29T04:34:05Z
 github.com/coreos/go-systemd	git	2d21675230a81a503f4363f4aa3490af06d52bb8	2015-01-26T19:09:17Z
 github.com/dustin/go-humanize	git	145fabdb1ab757076a70a886d092a3af27f66f4c	2014-12-28T07:11:48Z
+github.com/gabriel-samfira/sys	git	9ddc60d56b511544223adecea68da1e4f2153beb	2015-06-08T13:21:19Z
 github.com/godbus/dbus	git	88765d85c0fdadcd98a54e30694fa4e4f5b51133	2015-01-22T18:02:51Z
 github.com/gorilla/websocket	git	13e4d0621caa4d77fd9aa470ef6d7ab63d1a5e41	2015-09-23T22:29:30Z
 github.com/gosuri/uitable	git	cacfc559e8712a81692496c5147c80aced020e51	2015-12-16T01:20:41Z


### PR DESCRIPTION
PR #4807 removed github.com/gabriel-samfira/sys from
dependencies.tsv, causing build failures on master.

Re-adding it back in.

(Review request: http://reviews.vapour.ws/r/4299/)