### PR TITLE
Tweak adding of attributes from files

### DIFF
--- a/cmd/juju/cloud/addcredential.go
+++ b/cmd/juju/cloud/addcredential.go
@@ -283,11 +283,16 @@ func (c *addCredentialCommand) promptCredentialAttributes(
 		value := ""
 		for {
 			var err error
-			value, err = c.promptFieldValue(out, in, currentAttr)
-			if err != nil {
-				return nil, err
+			// Interactive add does not support adding multi-line values, which
+			// is what we typically get when the attribute can come from a file.
+			// For now we'll skip, and just get the user to enter the file path.
+			// TODO(wallyworld) - add support for multi-line entry
+			if currentAttr.FileAttr == "" {
+				value, err = c.promptFieldValue(out, in, currentAttr)
+				if err != nil {
+					return nil, err
+				}
 			}
-
 			// Validate the entered value matches any options.
 			// If the user just hits Enter, the first option is used.
 			if len(currentAttr.Options) > 0 {

--- a/cmd/juju/cloud/addcredential_test.go
+++ b/cmd/juju/cloud/addcredential_test.go
@@ -285,7 +285,7 @@ func (s *addCredentialSuite) TestAddCredentialWithFileAttr(c *gc.C) {
 		},
 	}
 	// Input includes invalid file info.
-	s.assertAddFileCredential(c, "fred\n\nbadfile\n.\n%s\n", "key-file")
+	s.assertAddFileCredential(c, "fred\nbadfile\n.\n%s\n", "key-file")
 }
 
 func (s *addCredentialSuite) assertAddCredentialWithOptions(c *gc.C, input string) {


### PR DESCRIPTION
We'll skip direct entry of attributes from files and just prompt for the file name.

(Review request: http://reviews.vapour.ws/r/4305/)