### PR TITLE
Fix series OS checks

### DIFF
--- a/state/export_test.go
+++ b/state/export_test.go
@@ -186,7 +186,12 @@ func AddCustomCharm(c *gc.C, st *State, name, filename, content, series string, 
 
 func addCharm(c *gc.C, st *State, series string, ch charm.Charm) *Charm {
 	ident := fmt.Sprintf("%s-%s-%d", series, ch.Meta().Name, ch.Revision())
-	curl := charm.MustParseURL("local:" + series + "/" + ident)
+	url := "local:" + series + "/" + ident
+	if series == "" {
+		ident = fmt.Sprintf("%s-%d", ch.Meta().Name, ch.Revision())
+		url = "local:" + ident
+	}
+	curl := charm.MustParseURL(url)
 	sch, err := st.AddCharm(ch, curl, "dummy-path", ident+"-sha256")
 	c.Assert(err, jc.ErrorIsNil)
 	return sch

--- a/state/service.go
+++ b/state/service.go
@@ -698,7 +698,8 @@ func (s *Service) SetCharm(cfg SetCharmConfig) error {
 		}
 	} else {
 		// Even with forceSeries=true, we do not allow a charm to be used which is for
-		// a different OS.
+		// a different OS. This assumes the charm declares it has supported series which
+		// we can check for OS compatibility. Otherwise, we just accept the series supplied.
 		currentOS, err := series.GetOSFromSeries(s.doc.Series)
 		if err != nil {
 			// We don't expect an error here but there's not much we can

--- a/state/service.go
+++ b/state/service.go
@@ -706,7 +706,8 @@ func (s *Service) SetCharm(cfg SetCharmConfig) error {
 			return err
 		}
 		supportedOS := false
-		for _, chSeries := range cfg.Charm.Meta().Series {
+		supportedSeries := cfg.Charm.Meta().Series
+		for _, chSeries := range supportedSeries {
 			charmSeriesOS, err := series.GetOSFromSeries(chSeries)
 			if err != nil {
 				return nil
@@ -716,7 +717,7 @@ func (s *Service) SetCharm(cfg SetCharmConfig) error {
 				break
 			}
 		}
-		if !supportedOS {
+		if !supportedOS && len(supportedSeries) > 0 {
 			return errors.Errorf("cannot upgrade charm, OS %q not supported by charm", currentOS)
 		}
 	}

--- a/state/state.go
+++ b/state/state.go
@@ -1245,23 +1245,25 @@ func (st *State) AddService(args AddServiceArgs) (service *Service, err error) {
 		} else {
 			supportedSeries = args.Charm.Meta().Series
 		}
-		seriesOS, err := series.GetOSFromSeries(args.Series)
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		supportedOperatingSystems := make(map[os.OSType]bool)
-		for _, supportedSeries := range supportedSeries {
-			os, err := series.GetOSFromSeries(supportedSeries)
+		if len(supportedSeries) > 0 {
+			seriesOS, err := series.GetOSFromSeries(args.Series)
 			if err != nil {
 				return nil, errors.Trace(err)
 			}
-			supportedOperatingSystems[os] = true
-		}
-		if !supportedOperatingSystems[seriesOS] {
-			return nil, errors.NewNotSupported(errors.Errorf(
-				"series %q (OS %q) not supported by charm",
-				args.Series, seriesOS,
-			), "")
+			supportedOperatingSystems := make(map[os.OSType]bool)
+			for _, supportedSeries := range supportedSeries {
+				os, err := series.GetOSFromSeries(supportedSeries)
+				if err != nil {
+					return nil, errors.Trace(err)
+				}
+				supportedOperatingSystems[os] = true
+			}
+			if !supportedOperatingSystems[seriesOS] {
+				return nil, errors.NewNotSupported(errors.Errorf(
+					"series %q (OS %q) not supported by charm, supported series are %q",
+					args.Series, seriesOS, strings.Join(supportedSeries, ", "),
+				), "")
+			}
 		}
 	}
 

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -2039,7 +2039,7 @@ func (s *StateSuite) TestAddServiceIncompatibleOSWithSeriesInURL(c *gc.C) {
 		Name: "wordpress", Owner: s.Owner.String(), Charm: charm,
 		Series: "centos7",
 	})
-	c.Assert(err, gc.ErrorMatches, "cannot add service \"wordpress\": series \"centos7\" \\(OS \"CentOS\"\\) not supported by charm")
+	c.Assert(err, gc.ErrorMatches, `cannot add service "wordpress": series "centos7" \(OS \"CentOS"\) not supported by charm, supported series are "quantal"`)
 }
 
 func (s *StateSuite) TestAddServiceCompatibleOSWithSeriesInURL(c *gc.C) {
@@ -2053,6 +2053,16 @@ func (s *StateSuite) TestAddServiceCompatibleOSWithSeriesInURL(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
+func (s *StateSuite) TestAddServiceCompatibleOSWithNoExplicitSupportedSeries(c *gc.C) {
+	// If a charm doesn't declare any series, we can add it with any series we choose.
+	charm := s.AddSeriesCharm(c, "dummy", "")
+	_, err := s.State.AddService(state.AddServiceArgs{
+		Name: "wordpress", Owner: s.Owner.String(), Charm: charm,
+		Series: "quantal",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+}
+
 func (s *StateSuite) TestAddServiceOSIncompatibleWithSupportedSeries(c *gc.C) {
 	charm := state.AddTestingCharmMultiSeries(c, s.State, "multi-series")
 	// A charm with supported series can only be force-deployed to series
@@ -2061,7 +2071,7 @@ func (s *StateSuite) TestAddServiceOSIncompatibleWithSupportedSeries(c *gc.C) {
 		Name: "wordpress", Owner: s.Owner.String(), Charm: charm,
 		Series: "centos7",
 	})
-	c.Assert(err, gc.ErrorMatches, "cannot add service \"wordpress\": series \"centos7\" \\(OS \"CentOS\"\\) not supported by charm")
+	c.Assert(err, gc.ErrorMatches, `cannot add service "wordpress": series "centos7" \(OS "CentOS"\) not supported by charm, supported series are "precise, trusty"`)
 }
 
 func (s *StateSuite) TestAllServices(c *gc.C) {


### PR DESCRIPTION
Fixes this issue. Cannot deploy a charm which has no supported series defined.

The case below appears to show that the charm store is claiming the charm has supported series when there's none in metadata. Nonetheless, even for local charms, we should allow the case:

$ juju deploy ~/mycharm --series "trusty"

even if mycharm declares no series

$ juju deploy cs:~uros-jovanovic/wpnew --channel development
Added charm "cs:~uros-jovanovic/wpnew-1" to the model.
Deploying charm "cs:~uros-jovanovic/wpnew-1" with the default charm metadata series "trusty".
ERROR cannot add service "wordpress": series "trusty" (OS "Ubuntu") not supported by charm

(Review request: http://reviews.vapour.ws/r/4308/)