### PR TITLE
cmd/juju: add bootstrap config to show-controller

### DIFF
--- a/cmd/juju/controller/package_test.go
+++ b/cmd/juju/controller/package_test.go
@@ -37,7 +37,7 @@ func (s *baseControllerSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-func (s *baseControllerSuite) createTestClientStore(c *gc.C) {
+func (s *baseControllerSuite) createTestClientStore(c *gc.C) *jujuclienttesting.MemStore {
 	controllers, err := jujuclient.ParseControllers([]byte(s.controllersYaml))
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -47,11 +47,12 @@ func (s *baseControllerSuite) createTestClientStore(c *gc.C) {
 	accounts, err := jujuclient.ParseAccounts([]byte(s.accountsYaml))
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.store = &jujuclienttesting.MemStore{
-		Controllers: controllers,
-		Models:      models,
-		Accounts:    accounts,
-	}
+	store := jujuclienttesting.NewMemStore()
+	store.Controllers = controllers
+	store.Models = models
+	store.Accounts = accounts
+	s.store = store
+	return store
 }
 
 const testControllersYaml = `

--- a/cmd/juju/controller/showcontroller_test.go
+++ b/cmd/juju/controller/showcontroller_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/juju/juju/cmd/juju/controller"
 	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	"github.com/juju/juju/testing"
 )
@@ -95,6 +96,60 @@ local.mallards:
 `[1:]
 
 	s.assertShowController(c, "local.mallards", "--show-passwords")
+}
+
+func (s *ShowControllerSuite) TestShowControllerWithBootstrapConfig(c *gc.C) {
+	s.controllersYaml = `controllers:
+  local.mallards:
+    servers: [maas-1-05.cluster.mallards]
+    uuid: this-is-another-uuid
+    api-endpoints: [this-is-another-of-many-api-endpoints, this-is-one-more-of-many-api-endpoints]
+    ca-cert: this-is-another-ca-cert
+`
+	store := s.createTestClientStore(c)
+	store.BootstrapConfig["local.mallards"] = jujuclient.BootstrapConfig{
+		Config: map[string]interface{}{
+			"name": "admin",
+			"type": "maas",
+		},
+		Credential:    "my-credential",
+		Cloud:         "mallards",
+		CloudRegion:   "mallards1",
+		CloudEndpoint: "http://mallards.local/MAAS",
+	}
+
+	s.expectedOutput = `
+local.mallards:
+  details:
+    servers: [maas-1-05.cluster.mallards]
+    uuid: this-is-another-uuid
+    api-endpoints: [this-is-another-of-many-api-endpoints, this-is-one-more-of-many-api-endpoints]
+    ca-cert: this-is-another-ca-cert
+  accounts:
+    admin@local:
+      user: admin@local
+      models:
+        admin:
+          uuid: abc
+        my-model:
+          uuid: def
+      current-model: my-model
+    bob@local:
+      user: bob@local
+    bob@remote:
+      user: bob@remote
+  current-account: admin@local
+  bootstrap-config:
+    config:
+      name: admin
+      type: maas
+    cloud: mallards
+    region: mallards1
+    endpoint: http://mallards.local/MAAS
+    credential: my-credential
+`[1:]
+
+	s.assertShowController(c, "local.mallards")
 }
 
 func (s *ShowControllerSuite) TestShowOneControllerManyInStore(c *gc.C) {

--- a/cmd/juju/controller/showcontroller_test.go
+++ b/cmd/juju/controller/showcontroller_test.go
@@ -109,8 +109,9 @@ func (s *ShowControllerSuite) TestShowControllerWithBootstrapConfig(c *gc.C) {
 	store := s.createTestClientStore(c)
 	store.BootstrapConfig["local.mallards"] = jujuclient.BootstrapConfig{
 		Config: map[string]interface{}{
-			"name": "admin",
-			"type": "maas",
+			"name":  "admin",
+			"type":  "maas",
+			"extra": "value",
 		},
 		Credential:    "my-credential",
 		Cloud:         "mallards",
@@ -141,9 +142,9 @@ local.mallards:
   current-account: admin@local
   bootstrap-config:
     config:
-      name: admin
-      type: maas
+      extra: value
     cloud: mallards
+    cloud-type: maas
     region: mallards1
     endpoint: http://mallards.local/MAAS
     credential: my-credential

--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -103,6 +103,12 @@ const (
 	// Settings Attributes
 	//
 
+	// NameKey is the key for the model's name.
+	NameKey = "name"
+
+	// TypeKey is the key for the model's cloud type.
+	TypeKey = "type"
+
 	// AgentVersionKey is the key for the model's Juju agent version.
 	AgentVersionKey = "agent-version"
 
@@ -457,7 +463,7 @@ func (c *Config) fillInDefaults() error {
 
 	// Don't use c.Name() because the name hasn't
 	// been verified yet.
-	name := c.asString("name")
+	name := c.asString(NameKey)
 	if name == "" {
 		return fmt.Errorf("empty name in model configuration")
 	}
@@ -509,8 +515,8 @@ func ProcessDeprecatedAttributes(attrs map[string]interface{}) map[string]interf
 	}
 
 	// Update the provider type from null to manual.
-	if attrs["type"] == "null" {
-		processedAttrs["type"] = "manual"
+	if attrs[TypeKey] == "null" {
+		processedAttrs[TypeKey] = "manual"
 	}
 
 	if _, ok := attrs[ProvisionerHarvestModeKey]; !ok {
@@ -596,7 +602,7 @@ func Validate(cfg, old *Config) error {
 		}
 	}
 
-	if strings.ContainsAny(cfg.mustString("name"), "/\\") {
+	if strings.ContainsAny(cfg.mustString(NameKey), "/\\") {
 		return fmt.Errorf("model name contains unsafe characters")
 	}
 
@@ -776,12 +782,12 @@ func (c *Config) mustInt(name string) int {
 
 // Type returns the model's cloud provider type.
 func (c *Config) Type() string {
-	return c.mustString("type")
+	return c.mustString(TypeKey)
 }
 
 // Name returns the model name.
 func (c *Config) Name() string {
-	return c.mustString("name")
+	return c.mustString(NameKey)
 }
 
 // UUID returns the uuid for the model.
@@ -1420,8 +1426,8 @@ var mandatoryWithoutDefaults = []string{
 // which are not allowed to change in the lifetime
 // of an environment.
 var immutableAttributes = []string{
-	"name",
-	"type",
+	NameKey,
+	TypeKey,
 	UUIDKey,
 	ControllerUUIDKey,
 	"firewall-mode",
@@ -1793,7 +1799,7 @@ global or per instance security groups.`,
 		Description: `Whether the LXC provisioner should create a template and use cloning to speed up container provisioning. (deprecated by lxc-clone)`,
 		Type:        environschema.Tbool,
 	},
-	"name": {
+	NameKey: {
 		Description: "The name of the current model",
 		Type:        environschema.Tstring,
 		Mandatory:   true,
@@ -1882,7 +1888,7 @@ data of the store. (default false)`,
 		Type:        environschema.Tstring,
 		Group:       environschema.EnvironGroup,
 	},
-	"type": {
+	TypeKey: {
 		Description: "Type of model, e.g. local, ec2",
 		Type:        environschema.Tstring,
 		Mandatory:   true,

--- a/jujuclient/interface.go
+++ b/jujuclient/interface.go
@@ -28,7 +28,7 @@ type ControllerDetails struct {
 
 // ModelDetails holds details of a model.
 type ModelDetails struct {
-	// ModelUUID holds the details of a model.
+	// ModelUUID is the unique ID for the model.
 	ModelUUID string `yaml:"uuid"`
 }
 


### PR DESCRIPTION
Add bootstrap config to the output of "show-controller".
This provides a more extended description of a controller,
on the client that bootstrapped it only. This includes
information about the cloud, and the credential used to
bootstrap.

Generally speaking, one should use "get-model-config"
to inspect model properties. This change is made available
only to provide details on the controller itself, and not
any models within it. It is not safe to assume that all
models within a controller have the same cloud type, as
we may in the future support heterogenous environments.

Possible fix for https://bugs.launchpad.net/juju-core/+bug/1554721

(Review request: http://reviews.vapour.ws/r/4311/)