### PR TITLE
Handle builtin providers for set default region/credential

### DIFF
--- a/cmd/juju/cloud/defaultcredential.go
+++ b/cmd/juju/cloud/defaultcredential.go
@@ -61,12 +61,10 @@ func hasCredential(credential string, credentials map[string]jujucloud.Credentia
 }
 
 func (c *setDefaultCredentialCommand) Run(ctxt *cmd.Context) error {
-	_, err := jujucloud.CloudByName(c.cloud)
-	if err != nil {
+	if _, err := cloudOrProvider(c.cloud, jujucloud.CloudByName); err != nil {
 		return err
 	}
-	var cred *jujucloud.CloudCredential
-	cred, err = c.store.CredentialForCloud(c.cloud)
+	cred, err := c.store.CredentialForCloud(c.cloud)
 	if errors.IsNotFound(err) {
 		cred = &jujucloud.CloudCredential{}
 	} else if err != nil {

--- a/cmd/juju/cloud/defaultregion.go
+++ b/cmd/juju/cloud/defaultregion.go
@@ -61,7 +61,7 @@ func hasRegion(region string, regions []jujucloud.Region) bool {
 }
 
 func (c *setDefaultRegionCommand) Run(ctxt *cmd.Context) error {
-	cloudDetails, err := jujucloud.CloudByName(c.cloud)
+	cloudDetails, err := cloudOrProvider(c.cloud, jujucloud.CloudByName)
 	if err != nil {
 		return err
 	}

--- a/cmd/juju/cloud/defaultregion.go
+++ b/cmd/juju/cloud/defaultregion.go
@@ -7,8 +7,10 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 
+	"fmt"
 	jujucloud "github.com/juju/juju/cloud"
 	"github.com/juju/juju/jujuclient"
+	"strings"
 )
 
 type setDefaultRegionCommand struct {
@@ -65,8 +67,18 @@ func (c *setDefaultRegionCommand) Run(ctxt *cmd.Context) error {
 	if err != nil {
 		return err
 	}
+	if len(cloudDetails.Regions) == 0 {
+		return errors.Errorf("cloud %s has no regions", c.cloud)
+	}
 	if !hasRegion(c.region, cloudDetails.Regions) {
-		return errors.NotValidf("region %q for cloud %s", c.region, c.cloud)
+		var regionNames []string
+		for _, r := range cloudDetails.Regions {
+			regionNames = append(regionNames, r.Name)
+		}
+		return errors.NewNotValid(
+			nil,
+			fmt.Sprintf("region %q for cloud %s not valid, valid regions are %s",
+				c.region, c.cloud, strings.Join(regionNames, ", ")))
 	}
 	var cred *jujucloud.CloudCredential
 	cred, err = c.store.CredentialForCloud(c.cloud)

--- a/cmd/juju/cloud/defaultregion_test.go
+++ b/cmd/juju/cloud/defaultregion_test.go
@@ -40,7 +40,7 @@ func (s *defaultRegionSuite) TestBadArgs(c *gc.C) {
 func (s *defaultRegionSuite) TestBadRegion(c *gc.C) {
 	cmd := cloud.NewSetDefaultRegionCommand()
 	_, err := testing.RunCommand(c, cmd, "aws", "foo")
-	c.Assert(err, gc.ErrorMatches, `region "foo" for cloud aws not valid`)
+	c.Assert(err, gc.ErrorMatches, `region "foo" for cloud aws not valid, valid regions are .*`)
 }
 
 func (s *defaultRegionSuite) TestBadCloudName(c *gc.C) {
@@ -74,7 +74,7 @@ func (s *defaultRegionSuite) TestSetDefaultRegionBuiltIn(c *gc.C) {
 	store := jujuclienttesting.NewMemStore()
 	cmd := cloud.NewSetDefaultRegionCommandForTest(store)
 	// maas has no regions
-	s.assertSetDefaultRegion(c, cmd, store, "maas", `region "us-west-1" for cloud maas not valid`)
+	s.assertSetDefaultRegion(c, cmd, store, "maas", `cloud maas has no regions`)
 }
 
 func (s *defaultRegionSuite) TestOverwriteDefaultRegion(c *gc.C) {

--- a/cmd/juju/cloud/defaultregion_test.go
+++ b/cmd/juju/cloud/defaultregion_test.go
@@ -4,6 +4,7 @@
 package cloud_test
 
 import (
+	"fmt"
 	"strings"
 
 	jc "github.com/juju/testing/checkers"
@@ -45,27 +46,40 @@ func (s *defaultRegionSuite) TestBadRegion(c *gc.C) {
 func (s *defaultRegionSuite) TestBadCloudName(c *gc.C) {
 	cmd := cloud.NewSetDefaultRegionCommand()
 	_, err := testing.RunCommand(c, cmd, "somecloud", "us-west-1")
-	c.Assert(err, gc.ErrorMatches, `cloud somecloud not found`)
+	c.Assert(err, gc.ErrorMatches, `cloud somecloud not valid`)
 }
 
-func (s *defaultRegionSuite) assertSetDefaultRegion(c *gc.C, cmd cmd.Command, store *jujuclienttesting.MemStore) {
-	ctx, err := testing.RunCommand(c, cmd, "aws", "us-west-1")
-	c.Assert(err, jc.ErrorIsNil)
+func (s *defaultRegionSuite) assertSetDefaultRegion(c *gc.C, cmd cmd.Command, store *jujuclienttesting.MemStore, cloud, errStr string) {
+	ctx, err := testing.RunCommand(c, cmd, cloud, "us-west-1")
 	output := testing.Stderr(ctx)
 	output = strings.Replace(output, "\n", "", -1)
-	c.Assert(output, gc.Equals, `Default region in aws set to "us-west-1".`)
-	c.Assert(store.Credentials["aws"].DefaultRegion, gc.Equals, "us-west-1")
+	if errStr != "" {
+		c.Assert(err, gc.ErrorMatches, errStr)
+		c.Assert(output, gc.Equals, "")
+		c.Assert(store.Credentials[cloud].DefaultRegion, gc.Equals, "")
+		return
+	}
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(output, gc.Equals, fmt.Sprintf(`Default region in %s set to "us-west-1".`, cloud))
+	c.Assert(store.Credentials[cloud].DefaultRegion, gc.Equals, "us-west-1")
 }
 
 func (s *defaultRegionSuite) TestSetDefaultRegion(c *gc.C) {
 	store := jujuclienttesting.NewMemStore()
 	cmd := cloud.NewSetDefaultRegionCommandForTest(store)
-	s.assertSetDefaultRegion(c, cmd, store)
+	s.assertSetDefaultRegion(c, cmd, store, "aws", "")
+}
+
+func (s *defaultRegionSuite) TestSetDefaultRegionBuiltIn(c *gc.C) {
+	store := jujuclienttesting.NewMemStore()
+	cmd := cloud.NewSetDefaultRegionCommandForTest(store)
+	// maas has no regions
+	s.assertSetDefaultRegion(c, cmd, store, "maas", `region "us-west-1" for cloud maas not valid`)
 }
 
 func (s *defaultRegionSuite) TestOverwriteDefaultRegion(c *gc.C) {
 	store := jujuclienttesting.NewMemStore()
 	store.Credentials["aws"] = jujucloud.CloudCredential{DefaultRegion: "us-east-1"}
 	cmd := cloud.NewSetDefaultRegionCommandForTest(store)
-	s.assertSetDefaultRegion(c, cmd, store)
+	s.assertSetDefaultRegion(c, cmd, store, "aws", "")
 }

--- a/cmd/juju/cloud/removecredential.go
+++ b/cmd/juju/cloud/removecredential.go
@@ -70,6 +70,6 @@ func (c *removeCredentialCommand) Run(ctxt *cmd.Context) error {
 	if err := c.store.UpdateCredential(c.cloud, *cred); err != nil {
 		return err
 	}
-	ctxt.Infof("Credential %q for cloud %q has been deleted.", c.credential, c.credential)
+	ctxt.Infof("Credential %q for cloud %q has been deleted.", c.credential, c.cloud)
 	return nil
 }

--- a/cmd/juju/cloud/removecredential_test.go
+++ b/cmd/juju/cloud/removecredential_test.go
@@ -72,7 +72,7 @@ func (s *removeCredentialSuite) TestRemove(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	output := testing.Stderr(ctx)
 	output = strings.Replace(output, "\n", "", -1)
-	c.Assert(output, gc.Equals, `Credential "my-credential" for cloud "my-credential" has been deleted.`)
+	c.Assert(output, gc.Equals, `Credential "my-credential" for cloud "aws" has been deleted.`)
 	_, stillThere := store.Credentials["aws"].AuthCredentials["my-credential"]
 	c.Assert(stillThere, jc.IsFalse)
 	c.Assert(store.Credentials["aws"].AuthCredentials, gc.HasLen, 1)


### PR DESCRIPTION
juju set-default region and set-default-credential now accept builtin providers as arguments
Also a couple of other fixes.

(Review request: http://reviews.vapour.ws/r/4314/)