### PR TITLE
jujuclient: remove controllers with same UUID

### DIFF
--- a/jujuclient/accounts_test.go
+++ b/jujuclient/accounts_test.go
@@ -169,7 +169,12 @@ func (s *AccountsSuite) TestRemoveAccount(c *gc.C) {
 
 func (s *AccountsSuite) TestRemoveControllerRemovesaccounts(c *gc.C) {
 	store := jujuclient.NewFileClientStore()
-	err := store.RemoveController("kontroll")
+	err := store.UpdateController("kontroll", jujuclient.ControllerDetails{
+		ControllerUUID: "abc",
+		CACert:         "woop",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	err = store.RemoveController("kontroll")
 	c.Assert(err, jc.ErrorIsNil)
 
 	accounts, err := jujuclient.ReadAccountsFile(jujuclient.JujuAccountsPath())

--- a/jujuclient/controllers_test.go
+++ b/jujuclient/controllers_test.go
@@ -102,6 +102,23 @@ func (s *ControllersSuite) TestRemoveController(c *gc.C) {
 	c.Assert(found, gc.IsNil)
 }
 
+func (s *ControllersSuite) TestRemoveControllerRemovesIdenticalControllers(c *gc.C) {
+	name := firstTestControllerName(c)
+	details, err := s.store.ControllerByName(name)
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.store.UpdateController(name+"-copy", *details)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = s.store.RemoveController(name)
+	c.Assert(err, jc.ErrorIsNil)
+
+	for _, name := range []string{name, name + "-copy"} {
+		found, err := s.store.ControllerByName(name)
+		c.Assert(err, gc.ErrorMatches, fmt.Sprintf("controller %v not found", name))
+		c.Assert(found, gc.IsNil)
+	}
+}
+
 func (s *ControllersSuite) assertWriteFails(c *gc.C, failureMessage string) {
 	err := s.store.UpdateController(s.controllerName, s.controller)
 	c.Assert(err, gc.ErrorMatches, failureMessage)

--- a/jujuclient/interface.go
+++ b/jujuclient/interface.go
@@ -92,10 +92,11 @@ type ControllerUpdater interface {
 // ControllerRemover removes controllers.
 type ControllerRemover interface {
 	// RemoveController removes the controller with the given name from the
-	// controllers collection.
+	// controllers collection. Any other controllers with matching UUIDs
+	// will also be removed.
 	//
-	// Removing a controller will remove all information related to that
-	// controller (models, accounts, bootstrap config.)
+	// Removing controllers will remove all information related to those
+	// controllers (models, accounts, bootstrap config.)
 	RemoveController(controllerName string) error
 }
 

--- a/jujuclient/jujuclienttesting/mem.go
+++ b/jujuclient/jujuclienttesting/mem.go
@@ -5,6 +5,7 @@ package jujuclienttesting
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/utils/set"
 
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/jujuclient"
@@ -63,8 +64,20 @@ func (c *MemStore) RemoveController(name string) error {
 	if err := jujuclient.ValidateControllerName(name); err != nil {
 		return err
 	}
-	delete(c.BootstrapConfig, name)
-	delete(c.Controllers, name)
+	names := set.NewStrings(name)
+	if namedControllerDetails, ok := c.Controllers[name]; ok {
+		for name, details := range c.Controllers {
+			if details.ControllerUUID == namedControllerDetails.ControllerUUID {
+				names.Add(name)
+			}
+		}
+	}
+	for _, name := range names.Values() {
+		delete(c.Models, name)
+		delete(c.Accounts, name)
+		delete(c.BootstrapConfig, name)
+		delete(c.Controllers, name)
+	}
 	return nil
 }
 

--- a/jujuclient/models_test.go
+++ b/jujuclient/models_test.go
@@ -186,7 +186,12 @@ func (s *ModelsSuite) TestRemoveModel(c *gc.C) {
 
 func (s *ModelsSuite) TestRemoveControllerRemovesModels(c *gc.C) {
 	store := jujuclient.NewFileClientStore()
-	err := store.RemoveController("kontroll")
+	err := store.UpdateController("kontroll", jujuclient.ControllerDetails{
+		ControllerUUID: "abc",
+		CACert:         "woop",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	err = store.RemoveController("kontroll")
 	c.Assert(err, jc.ErrorIsNil)
 
 	models, err := jujuclient.ReadModelsFile(jujuclient.JujuModelsPath())


### PR DESCRIPTION
RemoveController has been updated to remove all
controllers with the same UUID as the named
controller. Thus, if you "juju add-user" and
"juju register" on the same machine, such that
you have two entries with the same UUID, removing
one of them will remove the other.

(Review request: http://reviews.vapour.ws/r/4315/)