### PR TITLE
cmd/modelcmd: Registering cmd.Context in the wrong place meant wrong login logic was being used

### DIFF
--- a/cmd/modelcmd/base.go
+++ b/cmd/modelcmd/base.go
@@ -190,6 +190,7 @@ type baseCommandWrapper struct {
 // Run implements Command.Run.
 func (w *baseCommandWrapper) Run(ctx *cmd.Context) error {
 	defer w.closeContext()
+	w.setCmdContext(ctx)
 	return w.CommandBase.Run(ctx)
 }
 

--- a/cmd/modelcmd/modelcommand.go
+++ b/cmd/modelcmd/modelcommand.go
@@ -309,7 +309,6 @@ type modelCommandWrapper struct {
 }
 
 func (w *modelCommandWrapper) Run(ctx *cmd.Context) error {
-	w.ModelCommand.setCmdContext(ctx)
 	return w.ModelCommand.Run(ctx)
 }
 


### PR DESCRIPTION


(Review request: http://reviews.vapour.ws/r/4316/)