### PR TITLE
Implement the upgrade-gui command.

### DIFF
--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -275,6 +275,7 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 
 	// Juju GUI commands.
 	r.Register(gui.NewGUICommand())
+	r.Register(gui.NewUpgradeGUICommand())
 
 	// Commands registered elsewhere.
 	for _, newCommand := range registeredCommands {

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -323,6 +323,7 @@ var commandNames = []string{
 	"unset-model-config",
 	"update-clouds",
 	"upgrade-charm",
+	"upgrade-gui",
 	"upgrade-juju",
 	"version",
 }

--- a/cmd/juju/gui/export_test.go
+++ b/cmd/juju/gui/export_test.go
@@ -6,4 +6,8 @@ package gui
 var (
 	ClientGet      = &clientGet
 	WebbrowserOpen = &webbrowserOpen
+
+	ClientGUIArchives      = &clientGUIArchives
+	ClientSelectGUIVersion = &clientSelectGUIVersion
+	ClientUploadGUIArchive = &clientUploadGUIArchive
 )

--- a/cmd/juju/gui/gui.go
+++ b/cmd/juju/gui/gui.go
@@ -46,6 +46,7 @@ Do not open the browser, just output the GUI URL:
 An error is returned if the Juju GUI is not available in the controller.
 `
 
+// Info implements the cmd.Command interface.
 func (c *guiCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "gui",
@@ -54,11 +55,13 @@ func (c *guiCommand) Info() *cmd.Info {
 	}
 }
 
+// SetFlags implements the cmd.Command interface.
 func (c *guiCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.BoolVar(&c.showCreds, "show-credentials", false, "show admin credentials to use for logging into the Juju GUI")
 	f.BoolVar(&c.noBrowser, "no-browser", false, "do not try to open the web browser, just print the Juju GUI URL")
 }
 
+// Run implements the cmd.Command interface.
 func (c *guiCommand) Run(ctx *cmd.Context) error {
 	// Retrieve model details.
 	conn, err := c.NewAPIRoot()

--- a/cmd/juju/gui/gui.go
+++ b/cmd/juju/gui/gui.go
@@ -17,6 +17,7 @@ import (
 	"github.com/juju/juju/cmd/modelcmd"
 )
 
+// NewGUICommand creates and returns a new gui command.
 func NewGUICommand() cmd.Command {
 	return modelcmd.Wrap(&guiCommand{})
 }

--- a/cmd/juju/gui/gui_test.go
+++ b/cmd/juju/gui/gui_test.go
@@ -25,6 +25,7 @@ type guiSuite struct {
 
 var _ = gc.Suite(&guiSuite{})
 
+// run executes the gui command passing the given args.
 func (s *guiSuite) run(c *gc.C, args ...string) (string, error) {
 	ctx, err := coretesting.RunCommand(c, gui.NewGUICommand(), args...)
 	return strings.Trim(coretesting.Stderr(ctx), "\n"), err

--- a/cmd/juju/gui/upgradegui.go
+++ b/cmd/juju/gui/upgradegui.go
@@ -1,0 +1,223 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package gui
+
+import (
+	"archive/tar"
+	"compress/bzip2"
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+	"github.com/juju/version"
+
+	"github.com/juju/juju/api"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/modelcmd"
+)
+
+// NewUpgradeGUICommand creates and returns a new upgrade-gui command.
+func NewUpgradeGUICommand() cmd.Command {
+	return modelcmd.Wrap(&upgradeGUICommand{})
+}
+
+// upgradeGUICommand upgrades to a new Juju GUI version in the controller.
+type upgradeGUICommand struct {
+	modelcmd.ModelCommandBase
+
+	versOrPath string
+}
+
+const upgradeGUIDoc = `
+Upgrade to the latest Juju GUI released version:
+
+	juju upgrade-gui
+
+Upgrade to a specific Juju GUI released version:
+
+	juju upgrade-gui 2.2.0
+
+Upgrade to a Juju GUI version present in a local tar.bz2 GUI release file.
+
+	juju upgrade-gui /path/to/jujugui-2.2.0.tar.bz2
+`
+
+func (c *upgradeGUICommand) Info() *cmd.Info {
+	return &cmd.Info{
+		Name:    "upgrade-gui",
+		Purpose: "upgrade to a new Juju GUI version",
+		Doc:     upgradeGUIDoc,
+	}
+}
+
+func (c *upgradeGUICommand) Init(args []string) error {
+	if len(args) == 1 {
+		c.versOrPath, args = args[0], args[1:]
+	}
+	return cmd.CheckEmpty(args)
+}
+
+func (c *upgradeGUICommand) Run(ctx *cmd.Context) error {
+	// Retrieve the GUI archive and its related info.
+	r, hash, size, vers, err := openArchive(c.versOrPath)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	defer r.Close()
+
+	// Open the Juju API client.
+	client, err := c.NewAPIClient()
+	if err != nil {
+		return errors.Annotate(err, "cannot establish API connection")
+	}
+	defer client.Close()
+
+	// Check currently uploaded GUI version.
+	existingHash, isCurrent, err := existingVersionInfo(client, vers)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	// Upload the release file if required.
+	if hash != existingHash {
+		isCurrent, err = clientUploadGUIArchive(client, r, hash, size, vers)
+		if err != nil {
+			return errors.Annotate(err, "cannot upload Juju GUI")
+		}
+		ctx.Infof("Juju GUI version %s uploaded", vers)
+	}
+	// Switch to the new version if not already at the desired one.
+	if isCurrent {
+		ctx.Infof("Juju GUI already at version %s", vers)
+		return nil
+	}
+	if err = clientSelectGUIVersion(client, vers); err != nil {
+		return errors.Annotate(err, "cannot switch to new Juju GUI version")
+	}
+	ctx.Infof("Juju GUI switched to version %s", vers)
+	return nil
+}
+
+// openArchive opens a Juju GUI archive from the given version or file path.
+// The returned readSeekCloser must be closed by callers.
+func openArchive(versOrPath string) (r readSeekCloser, hash string, size int64, vers version.Number, err error) {
+	if versOrPath == "" {
+		// TODO frankban: implement retrieving the latest GUI archive from
+		// simplestreams.
+		return nil, "", 0, vers, errors.New("upgrading to latest released version not implemented")
+	}
+	f, err := os.Open(versOrPath)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return nil, "", 0, vers, errors.Annotate(err, "cannot open GUI archive")
+		}
+		vers, err = version.Parse(versOrPath)
+		if err != nil {
+			return nil, "", 0, vers, errors.Errorf("invalid GUI release version or local path %q", versOrPath)
+		}
+		// TODO frankban: implement upgrading to a released version.
+		return nil, "", 0, vers, errors.Errorf("upgrading to a released version (%s) not implemented", vers)
+	}
+	defer func() {
+		if err != nil {
+			f.Close()
+		}
+	}()
+	vers, err = archiveVersion(f)
+	if err != nil {
+		return nil, "", 0, vers, errors.Annotatef(err, "cannot upgrade Juju GUI using %q", versOrPath)
+	}
+	hash, size, err = hashAndSize(f)
+	if err != nil {
+		return nil, "", 0, vers, errors.Annotatef(err, "cannot upgrade Juju GUI using %q", versOrPath)
+	}
+	return f, hash, size, vers, nil
+}
+
+// readSeekCloser combines the io read, seek and close methods.
+type readSeekCloser interface {
+	io.ReadCloser
+	io.Seeker
+}
+
+// archiveVersion retrieves the GUI version from the juju-gui-* directory
+// included in the given tar.bz2 archive reader.
+func archiveVersion(r io.ReadSeeker) (version.Number, error) {
+	var vers version.Number
+	prefix := "jujugui-"
+	tr := tar.NewReader(bzip2.NewReader(r))
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return vers, errors.New("cannot read Juju GUI archive")
+		}
+		info := hdr.FileInfo()
+		if !info.IsDir() || !strings.HasPrefix(hdr.Name, prefix) {
+			continue
+		}
+		n := filepath.Dir(hdr.Name)[len(prefix):]
+		vers, err = version.Parse(n)
+		if err != nil {
+			return vers, errors.Errorf("invalid version %q in archive", n)
+		}
+		if _, err := r.Seek(0, 0); err != nil {
+			return vers, errors.Annotate(err, "cannot seek archive")
+		}
+		return vers, nil
+	}
+	return vers, errors.New("cannot find Juju GUI version in archive")
+}
+
+// hashAndSize returns the SHA256 hash and size of the data included in r.
+func hashAndSize(r io.ReadSeeker) (hash string, size int64, err error) {
+	h := sha256.New()
+	size, err = io.Copy(h, r)
+	if err != nil {
+		return "", 0, errors.Annotate(err, "cannot calculate archive hash")
+	}
+	if _, err := r.Seek(0, 0); err != nil {
+		return "", 0, errors.Annotate(err, "cannot seek archive")
+	}
+	return fmt.Sprintf("%x", h.Sum(nil)), size, nil
+}
+
+// existingVersionInfo returns the hash of the existing GUI archive at the
+// given version and reports whether that's the current version served by the
+// controller. If the given version is not present in the server, an empty
+// hash is returned.
+func existingVersionInfo(client *api.Client, vers version.Number) (hash string, current bool, err error) {
+	versions, err := clientGUIArchives(client)
+	if err != nil {
+		return "", false, errors.Annotate(err, "cannot retrieve GUI versions from the controller")
+	}
+	for _, v := range versions {
+		if v.Version == vers {
+			return v.SHA256, v.Current, nil
+		}
+	}
+	return "", false, nil
+}
+
+// clientGUIArchives is defined for testing purposes.
+var clientGUIArchives = func(client *api.Client) ([]params.GUIArchiveVersion, error) {
+	return client.GUIArchives()
+}
+
+// clientSelectGUIVersion is defined for testing purposes.
+var clientSelectGUIVersion = func(client *api.Client, vers version.Number) error {
+	return client.SelectGUIVersion(vers)
+}
+
+// clientUploadGUIArchive is defined for testing purposes.
+var clientUploadGUIArchive = func(client *api.Client, r io.ReadSeeker, hash string, size int64, vers version.Number) (bool, error) {
+	return client.UploadGUIArchive(r, hash, size, vers)
+}

--- a/cmd/juju/gui/upgradegui.go
+++ b/cmd/juju/gui/upgradegui.go
@@ -48,6 +48,7 @@ Upgrade to a Juju GUI version present in a local tar.bz2 GUI release file.
 	juju upgrade-gui /path/to/jujugui-2.2.0.tar.bz2
 `
 
+// Info implements the cmd.Command interface.
 func (c *upgradeGUICommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "upgrade-gui",
@@ -56,6 +57,7 @@ func (c *upgradeGUICommand) Info() *cmd.Info {
 	}
 }
 
+// Init implements the cmd.Command interface.
 func (c *upgradeGUICommand) Init(args []string) error {
 	if len(args) == 1 {
 		c.versOrPath = args[0]
@@ -64,6 +66,7 @@ func (c *upgradeGUICommand) Init(args []string) error {
 	return cmd.CheckEmpty(args)
 }
 
+// Run implements the cmd.Command interface.
 func (c *upgradeGUICommand) Run(ctx *cmd.Context) error {
 	// Retrieve the GUI archive and its related info.
 	r, hash, size, vers, err := openArchive(c.versOrPath)

--- a/cmd/juju/gui/upgradegui_test.go
+++ b/cmd/juju/gui/upgradegui_test.go
@@ -328,7 +328,7 @@ func (s *upgradeGUISuite) TestUpgradeGUIIntegration(c *gc.C) {
 	// Check that the uploaded version has been set as the current one.
 	vers, err := s.State.GUIVersion()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(vers.String(), gc.Equals, "2.42.2")
+	c.Assert(vers.String(), gc.Equals, "2.42.0")
 }
 
 // makeGUIArchive creates a Juju GUI tar.bz2 archive in memory, and returns a

--- a/cmd/juju/gui/upgradegui_test.go
+++ b/cmd/juju/gui/upgradegui_test.go
@@ -1,0 +1,361 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package gui_test
+
+import (
+	"archive/tar"
+	"bytes"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/version"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/api"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/juju/gui"
+	jujutesting "github.com/juju/juju/juju/testing"
+	coretesting "github.com/juju/juju/testing"
+)
+
+type upgradeGUISuite struct {
+	jujutesting.JujuConnSuite
+}
+
+var _ = gc.Suite(&upgradeGUISuite{})
+
+// run executes the upgrade-gui command passing the given args.
+func (s *upgradeGUISuite) run(c *gc.C, args ...string) (string, error) {
+	ctx, err := coretesting.RunCommand(c, gui.NewUpgradeGUICommand(), args...)
+	return strings.Trim(coretesting.Stderr(ctx), "\n"), err
+}
+
+// calledFunc is returned by the patch* methods below, and when called reports
+// whether the corresponding patched function has been called.
+type calledFunc func() bool
+
+func (s *upgradeGUISuite) patchClientGUIArchives(c *gc.C, returnedVersions []params.GUIArchiveVersion, returnedErr error) calledFunc {
+	var called bool
+	f := func(client *api.Client) ([]params.GUIArchiveVersion, error) {
+		called = true
+		return returnedVersions, returnedErr
+	}
+	s.PatchValue(gui.ClientGUIArchives, f)
+	return func() bool {
+		return called
+	}
+}
+
+func (s *upgradeGUISuite) patchClientSelectGUIVersion(c *gc.C, expectedVers string, returnedErr error) calledFunc {
+	var called bool
+	f := func(client *api.Client, vers version.Number) error {
+		called = true
+		c.Assert(vers.String(), gc.Equals, expectedVers)
+		return returnedErr
+	}
+	s.PatchValue(gui.ClientSelectGUIVersion, f)
+	return func() bool {
+		return called
+	}
+}
+
+func (s *upgradeGUISuite) patchClientUploadGUIArchive(c *gc.C, expectedHash string, expectedSize int64, expectedVers string, returnedIsCurrent bool, returnedErr error) calledFunc {
+	var called bool
+	f := func(client *api.Client, r io.ReadSeeker, hash string, size int64, vers version.Number) (bool, error) {
+		called = true
+		c.Assert(hash, gc.Equals, expectedHash)
+		c.Assert(size, gc.Equals, expectedSize)
+		c.Assert(vers.String(), gc.Equals, expectedVers)
+		return returnedIsCurrent, returnedErr
+	}
+	s.PatchValue(gui.ClientUploadGUIArchive, f)
+	return func() bool {
+		return called
+	}
+}
+
+var upgradeGUIInputErrorsTests = []struct {
+	about         string
+	args          []string
+	expectedError string
+}{{
+	about:         "too many arguments",
+	args:          []string{"bad", "wolf"},
+	expectedError: `unrecognized args: \["bad" "wolf"\]`,
+}, {
+	// TODO frankban: remove this case when we have GUI from simplestreams.
+	about:         "upgrading to latest simplestreams version not implemented",
+	expectedError: "upgrading to latest released version not implemented",
+}, {
+	// TODO frankban: remove this case when we have GUI from simplestreams.
+	about:         "upgrading to simplestreams version not implemented",
+	args:          []string{"2.1.41"},
+	expectedError: `upgrading to a released version \(2.1.41\) not implemented`,
+}, {
+	about:         "archive path not found",
+	args:          []string{"no-such-file"},
+	expectedError: `invalid GUI release version or local path "no-such-file"`,
+}}
+
+func (s *upgradeGUISuite) TestUpgradeGUIInputErrors(c *gc.C) {
+	for i, test := range upgradeGUIInputErrorsTests {
+		c.Logf("\n%d: %s", i, test.about)
+		_, err := s.run(c, test.args...)
+		c.Assert(err, gc.ErrorMatches, test.expectedError)
+	}
+}
+
+func (s *upgradeGUISuite) TestUpgradeGUIFileError(c *gc.C) {
+	path, _, _ := saveGUIArchive(c, "2.0.0")
+	err := os.Chmod(path, 0000)
+	c.Assert(err, jc.ErrorIsNil)
+	defer os.Chmod(path, 0600)
+	out, err := s.run(c, path)
+	c.Assert(err, gc.ErrorMatches, "cannot open GUI archive: .*")
+	c.Assert(out, gc.Equals, "")
+}
+
+func (s *upgradeGUISuite) TestUpgradeGUIArchiveVersionNotValid(c *gc.C) {
+	path, _, _ := saveGUIArchive(c, "bad-wolf")
+	out, err := s.run(c, path)
+	c.Assert(err, gc.ErrorMatches, `cannot upgrade Juju GUI using ".*": invalid version "bad-wolf" in archive`)
+	c.Assert(out, gc.Equals, "")
+}
+
+func (s *upgradeGUISuite) TestUpgradeGUIArchiveVersionNotFound(c *gc.C) {
+	path, _, _ := saveGUIArchive(c, "")
+	out, err := s.run(c, path)
+	c.Assert(err, gc.ErrorMatches, `cannot upgrade Juju GUI using ".*": cannot find Juju GUI version in archive`)
+	c.Assert(out, gc.Equals, "")
+}
+
+func (s *upgradeGUISuite) TestUpgradeGUIGUIArchivesError(c *gc.C) {
+	path, _, _ := saveGUIArchive(c, "2.1.0")
+	s.patchClientGUIArchives(c, nil, errors.New("bad wolf"))
+	out, err := s.run(c, path)
+	c.Assert(err, gc.ErrorMatches, "cannot retrieve GUI versions from the controller: bad wolf")
+	c.Assert(out, gc.Equals, "")
+}
+
+func (s *upgradeGUISuite) TestUpgradeGUIUploadGUIArchiveError(c *gc.C) {
+	path, hash, size := saveGUIArchive(c, "2.2.0")
+	s.patchClientGUIArchives(c, nil, nil)
+	s.patchClientUploadGUIArchive(c, hash, size, "2.2.0", false, errors.New("bad wolf"))
+	out, err := s.run(c, path)
+	c.Assert(err, gc.ErrorMatches, "cannot upload Juju GUI: bad wolf")
+	c.Assert(out, gc.Equals, "")
+}
+
+func (s *upgradeGUISuite) TestUpgradeGUISelectGUIVersionError(c *gc.C) {
+	path, hash, size := saveGUIArchive(c, "2.3.0")
+	s.patchClientGUIArchives(c, nil, nil)
+	s.patchClientUploadGUIArchive(c, hash, size, "2.3.0", false, nil)
+	s.patchClientSelectGUIVersion(c, "2.3.0", errors.New("bad wolf"))
+	out, err := s.run(c, path)
+	c.Assert(err, gc.ErrorMatches, "cannot switch to new Juju GUI version: bad wolf")
+	c.Assert(out, gc.Equals, "Juju GUI version 2.3.0 uploaded")
+}
+
+var upgradeGUISuccessTests = []struct {
+	// about describes the test.
+	about string
+	// archiveVersion is the version of the archive to be uploaded.
+	archiveVersion string
+	// existingVersions is a function returning a list of GUI archive versions
+	// already included in the controller.
+	existingVersions func(hash string) []params.GUIArchiveVersion
+	// uploaded holds whether the archive has been actually uploaded. If an
+	// archive with the same hash and version is already present in the
+	// controller, the upload is not performed again.
+	uploaded bool
+	// selected holds whether a new GUI version must be selected. If the upload
+	// upgraded the currently served version there is no need to perform
+	// the API call to switch GUI version.
+	selected bool
+	// expectedOutput holds the expected upgrade-gui command output.
+	expectedOutput string
+}{{
+	about:          "archive: first archive",
+	archiveVersion: "2.0.0",
+	expectedOutput: "Juju GUI version 2.0.0 uploaded\nJuju GUI switched to version 2.0.0",
+	uploaded:       true,
+	selected:       true,
+}, {
+	about:          "archive: new archive",
+	archiveVersion: "2.1.0",
+	existingVersions: func(hash string) []params.GUIArchiveVersion {
+		return []params.GUIArchiveVersion{{
+			Version: version.MustParse("1.0.0"),
+			SHA256:  "hash-1",
+			Current: true,
+		}}
+	},
+	uploaded:       true,
+	selected:       true,
+	expectedOutput: "Juju GUI version 2.1.0 uploaded\nJuju GUI switched to version 2.1.0",
+}, {
+	about:          "archive: new archive, existing non-current version",
+	archiveVersion: "2.0.42",
+	existingVersions: func(hash string) []params.GUIArchiveVersion {
+		return []params.GUIArchiveVersion{{
+			Version: version.MustParse("2.0.42"),
+			SHA256:  "hash-42",
+			Current: false,
+		}, {
+			Version: version.MustParse("2.0.47"),
+			SHA256:  "hash-47",
+			Current: true,
+		}}
+	},
+	uploaded:       true,
+	selected:       true,
+	expectedOutput: "Juju GUI version 2.0.42 uploaded\nJuju GUI switched to version 2.0.42",
+}, {
+	about:          "archive: new archive, existing current version",
+	archiveVersion: "2.0.47",
+	existingVersions: func(hash string) []params.GUIArchiveVersion {
+		return []params.GUIArchiveVersion{{
+			Version: version.MustParse("2.0.47"),
+			SHA256:  "hash-47",
+			Current: true,
+		}}
+	},
+	uploaded:       true,
+	expectedOutput: "Juju GUI version 2.0.47 uploaded\nJuju GUI already at version 2.0.47",
+}, {
+	about:          "archive: existing archive, existing non-current version",
+	archiveVersion: "2.0.42",
+	existingVersions: func(hash string) []params.GUIArchiveVersion {
+		return []params.GUIArchiveVersion{{
+			Version: version.MustParse("2.0.42"),
+			SHA256:  hash,
+			Current: false,
+		}, {
+			Version: version.MustParse("2.0.47"),
+			SHA256:  "hash-47",
+			Current: true,
+		}}
+	},
+	selected:       true,
+	expectedOutput: "Juju GUI switched to version 2.0.42",
+}, {
+	about:          "archive: existing archive, existing current version",
+	archiveVersion: "1.47.0",
+	existingVersions: func(hash string) []params.GUIArchiveVersion {
+		return []params.GUIArchiveVersion{{
+			Version: version.MustParse("1.47.0"),
+			SHA256:  hash,
+			Current: true,
+		}}
+	},
+	expectedOutput: "Juju GUI already at version 1.47.0",
+}, {
+	about:          "archive: existing archive, different existing version",
+	archiveVersion: "2.0.42",
+	existingVersions: func(hash string) []params.GUIArchiveVersion {
+		return []params.GUIArchiveVersion{{
+			Version: version.MustParse("2.0.42"),
+			SHA256:  "hash-42",
+			Current: false,
+		}, {
+			Version: version.MustParse("2.0.47"),
+			SHA256:  hash,
+			Current: true,
+		}}
+	},
+	uploaded:       true,
+	selected:       true,
+	expectedOutput: "Juju GUI version 2.0.42 uploaded\nJuju GUI switched to version 2.0.42",
+	// TODO frankban: add simplestreams cases when the feature is implemented.
+}}
+
+func (s *upgradeGUISuite) TestUpgradeGUISuccess(c *gc.C) {
+	for i, test := range upgradeGUISuccessTests {
+		c.Logf("\n%d: %s", i, test.about)
+
+		// Create an fake Juju GUI archive.
+		path, hash, size := saveGUIArchive(c, test.archiveVersion)
+
+		// Patch the call to get existing archive versions.
+		var existingVersions []params.GUIArchiveVersion
+		if test.existingVersions != nil {
+			existingVersions = test.existingVersions(hash)
+		}
+		guiArchivesCalled := s.patchClientGUIArchives(c, existingVersions, nil)
+
+		// Patch the other calls to the controller.
+		uploadGUIArchiveCalled := s.patchClientUploadGUIArchive(c, hash, size, test.archiveVersion, !test.selected, nil)
+		selectGUIVersionCalled := s.patchClientSelectGUIVersion(c, test.archiveVersion, nil)
+
+		// Run the command.
+		out, err := s.run(c, path)
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(out, gc.Equals, test.expectedOutput)
+		c.Assert(guiArchivesCalled(), jc.IsTrue)
+		c.Assert(uploadGUIArchiveCalled(), gc.Equals, test.uploaded)
+		c.Assert(selectGUIVersionCalled(), gc.Equals, test.selected)
+	}
+}
+
+// makeGUIArchive creates a Juju GUI tar.bz2 archive in memory, and returns a
+// reader for the archive, its SHA256 hash and size.
+func makeGUIArchive(c *gc.C, vers string) (r io.Reader, hash string, size int64) {
+	if runtime.GOOS == "windows" {
+		c.Skip("bzip2 command not available")
+	}
+	cmd := exec.Command("bzip2", "--compress", "--stdout", "--fast")
+
+	stdin, err := cmd.StdinPipe()
+	c.Assert(err, jc.ErrorIsNil)
+	stdout, err := cmd.StdoutPipe()
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = cmd.Start()
+	c.Assert(err, jc.ErrorIsNil)
+
+	tw := tar.NewWriter(stdin)
+	if vers != "" {
+		err = tw.WriteHeader(&tar.Header{
+			Name:     filepath.Join("jujugui-"+vers, "jujugui"),
+			Mode:     0700,
+			Typeflag: tar.TypeDir,
+		})
+		c.Assert(err, jc.ErrorIsNil)
+	}
+	err = tw.Close()
+	c.Assert(err, jc.ErrorIsNil)
+	err = stdin.Close()
+	c.Assert(err, jc.ErrorIsNil)
+
+	h := sha256.New()
+	r = io.TeeReader(stdout, h)
+	b, err := ioutil.ReadAll(r)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = cmd.Wait()
+	c.Assert(err, jc.ErrorIsNil)
+
+	return bytes.NewReader(b), fmt.Sprintf("%x", h.Sum(nil)), int64(len(b))
+}
+
+// saveGUIArchive creates a Juju GUI tar.bz2 archive with the given version on
+// disk, and return its path, SHA256 hash and size.
+func saveGUIArchive(c *gc.C, vers string) (path, hash string, size int64) {
+	r, hash, size := makeGUIArchive(c, vers)
+	path = filepath.Join(c.MkDir(), "gui.tar.bz2")
+	data, err := ioutil.ReadAll(r)
+	c.Assert(err, jc.ErrorIsNil)
+	err = ioutil.WriteFile(path, data, 0600)
+	c.Assert(err, jc.ErrorIsNil)
+	return path, hash, size
+}


### PR DESCRIPTION
It is used to upload and switch to different Juju GUI versions.

(Review request: http://reviews.vapour.ws/r/4319/)