### PR TITLE
concurrent calls to State.RestoreInfoSetter are now safe

### DIFF
--- a/state/restore_test.go
+++ b/state/restore_test.go
@@ -35,7 +35,6 @@ func (s *RestoreInfoSuite) TestGetSetter(c *gc.C) {
 }
 
 func (s *RestoreInfoSuite) TestGetSetterRace(c *gc.C) {
-	timeout := time.After(coretesting.LongWait)
 	trigger := make(chan struct{})
 	test := func() {
 		select {
@@ -44,7 +43,7 @@ func (s *RestoreInfoSuite) TestGetSetterRace(c *gc.C) {
 			if c.Check(err, jc.ErrorIsNil) {
 				checkStatus(c, setter, state.UnknownRestoreStatus)
 			}
-		case <-timeout:
+		case <-time.After(coretesting.LongWait):
 			c.Errorf("test invoked but not triggered")
 		}
 	}

--- a/state/restore_test.go
+++ b/state/restore_test.go
@@ -11,6 +11,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/state"
+	statetesting "github.com/juju/juju/state/testing"
 	coretesting "github.com/juju/juju/testing"
 )
 
@@ -23,7 +24,7 @@ import (
 // None of the other functionality is tested, and little of it is reliable or
 // consistent with the other state code, but that's not for today.
 type RestoreInfoSuite struct {
-	StateSuite
+	statetesting.StateSuite
 }
 
 var _ = gc.Suite(&RestoreInfoSuite{})

--- a/state/restore_test.go
+++ b/state/restore_test.go
@@ -1,0 +1,70 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state_test
+
+import (
+	"sync"
+	"time"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/state"
+	coretesting "github.com/juju/juju/testing"
+)
+
+// RestoreInfoSuite is *tremendously* incomplete: this test exists purely to
+// verify that independent RestoreInfoSetters can be created concurrently.
+// This says nothing about whether that's a good idea (it's *not*) but it's
+// what we currently do and we need it to not just arbitrarily fail.
+//
+// TODO(fwereade): 2016-03-23 lp:1560920
+// None of the other functionality is tested, and little of it is reliable or
+// consistent with the other state code, but that's not for today.
+type RestoreInfoSuite struct {
+	ConnSuite
+}
+
+var _ = gc.Suite(&RestoreInfoSuite{})
+
+func (s *RestoreInfoSuite) TestGetSetter(c *gc.C) {
+	setter, err := s.State.RestoreInfoSetter()
+	c.Assert(err, jc.ErrorIsNil)
+	checkStatus(c, setter, state.UnknownRestoreStatus)
+}
+
+func (s *RestoreInfoSuite) TestGetSetterRace(c *gc.C) {
+	timeout := time.After(coretesting.LongWait)
+	trigger := make(chan struct{})
+	test := func() {
+		select {
+		case <-trigger:
+			setter, err := s.State.RestoreInfoSetter()
+			if c.Check(err, jc.ErrorIsNil) {
+				checkStatus(c, setter, state.UnknownRestoreStatus)
+			}
+		case <-timeout:
+			c.Errorf("test invoked but not triggered")
+		}
+	}
+
+	const count = 100
+	wg := sync.WaitGroup{}
+	wg.Add(count)
+	defer wg.Wait()
+	for i := 0; i < count; i++ {
+		go func() {
+			defer wg.Done()
+			test()
+		}()
+	}
+
+	close(trigger)
+}
+
+func checkStatus(c *gc.C, setter *state.RestoreInfo, status state.RestoreStatus) {
+	if c.Check(setter, gc.NotNil) {
+		c.Check(setter.Status(), gc.Equals, status)
+	}
+}

--- a/state/restore_test.go
+++ b/state/restore_test.go
@@ -23,7 +23,7 @@ import (
 // None of the other functionality is tested, and little of it is reliable or
 // consistent with the other state code, but that's not for today.
 type RestoreInfoSuite struct {
-	ConnSuite
+	StateSuite
 }
 
 var _ = gc.Suite(&RestoreInfoSuite{})
@@ -51,15 +51,14 @@ func (s *RestoreInfoSuite) TestGetSetterRace(c *gc.C) {
 	const count = 100
 	wg := sync.WaitGroup{}
 	wg.Add(count)
-	defer wg.Wait()
 	for i := 0; i < count; i++ {
 		go func() {
 			defer wg.Done()
 			test()
 		}()
 	}
-
 	close(trigger)
+	wg.Wait()
 }
 
 func checkStatus(c *gc.C, setter *state.RestoreInfo, status state.RestoreStatus) {


### PR DESCRIPTION
They're still a bad idea, but I don't think it's reasonable to try to fix all of restore :-/.

(Review request: http://reviews.vapour.ws/r/4320/)