### PR TITLE
Migration status watcher now always reports an initial event

### DIFF
--- a/api/watcher/watcher_test.go
+++ b/api/watcher/watcher_test.go
@@ -338,7 +338,7 @@ func (s *migrationSuite) TestMigrationMaster(c *gc.C) {
 	}
 }
 
-func (s *migrationSuite) TestMigrationminion(c *gc.C) {
+func (s *migrationSuite) TestMigrationStatusWatcher(c *gc.C) {
 	const nonce = "noncey"
 
 	// Create a model to migrate.
@@ -391,8 +391,8 @@ func (s *migrationSuite) TestMigrationminion(c *gc.C) {
 		assertNoChange()
 	}
 
-	// Should be no initial events.
-	assertNoChange()
+	// Initial event with no migration in progress.
+	assertChange(migration.NONE)
 
 	// Now create a migration, should trigger watcher.
 	spec := state.ModelMigrationSpec{

--- a/apiserver/watcher.go
+++ b/apiserver/watcher.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/common/storagecommon"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/migration"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
 )
@@ -500,7 +501,11 @@ func (w *srvMigrationStatusWatcher) Next() (params.MigrationStatus, error) {
 	}
 
 	mig, err := w.st.GetModelMigration()
-	if err != nil {
+	if errors.IsNotFound(err) {
+		return params.MigrationStatus{
+			Phase: migration.NONE,
+		}, nil
+	} else if err != nil {
 		return empty, errors.Annotate(err, "migration lookup")
 	}
 

--- a/core/migration/phase.go
+++ b/core/migration/phase.go
@@ -9,6 +9,7 @@ type Phase int
 // Enumerate all possible migration phases.
 const (
 	UNKNOWN Phase = iota
+	NONE
 	QUIESCE
 	READONLY
 	PRECHECK
@@ -23,7 +24,8 @@ const (
 )
 
 var phaseNames = []string{
-	"UNKNOWN",
+	"UNKNOWN", // To catch uninitialised fields.
+	"NONE",    // For watchers to indicate there's never been a migration attempt.
 	"QUIESCE",
 	"READONLY",
 	"PRECHECK",

--- a/core/migration/phase_internal_test.go
+++ b/core/migration/phase_internal_test.go
@@ -25,10 +25,15 @@ func (s *PhaseInternalSuite) TestForUnused(c *gc.C) {
 		}
 	}
 
-	allValidPhases := set.NewStrings(phaseNames...)
-	allValidPhases.Remove(UNKNOWN.String())
-	unused := allValidPhases.Difference(usedPhases)
-	c.Check(unused, gc.HasLen, 0)
+	specialPhases := set.NewStrings(
+		UNKNOWN.String(),
+		NONE.String(),
+	)
+	allValidPhases := set.NewStrings(phaseNames...).Difference(specialPhases)
+	c.Check(allValidPhases.Difference(usedPhases), gc.HasLen, 0)
+
+	// The special phases shouldn't appear in the transition map.
+	c.Check(usedPhases.Intersection(specialPhases), gc.HasLen, 0)
 }
 
 func (s *PhaseInternalSuite) TestForUnreachable(c *gc.C) {

--- a/state/modelmigration_test.go
+++ b/state/modelmigration_test.go
@@ -467,7 +467,7 @@ func (s *ModelMigrationSuite) createWatcher(c *gc.C, st *state.State) (
 
 func (s *ModelMigrationSuite) TestWatchMigrationStatus(c *gc.C) {
 	w, wc := s.createStatusWatcher(c, s.State2)
-	wc.AssertNoChange()
+	wc.AssertOneChange() // Initial event.
 
 	// Create a migration.
 	mig, err := s.State2.CreateModelMigration(s.stdSpec)
@@ -507,14 +507,14 @@ func (s *ModelMigrationSuite) TestWatchMigrationStatusPreexisting(c *gc.C) {
 
 func (s *ModelMigrationSuite) TestWatchMigrationStatusMultiModel(c *gc.C) {
 	_, wc2 := s.createStatusWatcher(c, s.State2)
-	wc2.AssertNoChange()
+	wc2.AssertOneChange()
 
 	// Create another hosted model to migrate and watch for
 	// migrations.
 	State3 := s.Factory.MakeModel(c, nil)
 	s.AddCleanup(func(*gc.C) { State3.Close() })
 	_, wc3 := s.createStatusWatcher(c, State3)
-	wc3.AssertNoChange()
+	wc3.AssertOneChange()
 
 	// Create a migration for 2.
 	mig, err := s.State2.CreateModelMigration(s.stdSpec)

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -2769,18 +2769,7 @@ func (w *migrationStatusWatcher) loop() error {
 	w.st.watcher.WatchCollectionWithFilter(w.collName, in, filter)
 	defer w.st.watcher.UnwatchCollection(w.collName, in)
 
-	var out chan<- struct{}
-
-	// If there is a migration record for the model - active or not -
-	// send an initial event.
-	if _, err := w.st.GetModelMigration(); errors.IsNotFound(err) {
-		// Nothing to report.
-	} else if err != nil {
-		return errors.Trace(err)
-	} else {
-		out = w.sink
-	}
-
+	out := w.sink // out set so that initial event is sent.
 	for {
 		select {
 		case <-w.tomb.Dying():


### PR DESCRIPTION
Previously the migration status watcher only reported an initial event when there had been a migration attempt for a model. An initial event (with a phase of NONE) is now reported. This brings the watcher's behaviour in line with Juju's other watchers.

This PR includes the addition of the NONE phase.

(Review request: http://reviews.vapour.ws/r/4332/)