### PR TITLE
cmd/...: juju errors for humans

### DIFF
--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -321,7 +321,7 @@ func (s *BootstrapSuite) run(c *gc.C, test bootstrapTest) testing.Restorer {
 	controller, err := s.store.ControllerByName(expectedBootstrappedControllerName)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(controller.CACert, gc.Not(gc.Equals), "")
-	c.Assert(controller.Servers, gc.DeepEquals, addrConnectedTo)
+	c.Assert(controller.UnresolvedAPIEndpoints, gc.DeepEquals, addrConnectedTo)
 	c.Assert(controller.APIEndpoints, gc.DeepEquals, addrConnectedTo)
 	c.Assert(utils.IsValidUUIDString(controller.ControllerUUID), jc.IsTrue)
 

--- a/cmd/juju/commands/switch.go
+++ b/cmd/juju/commands/switch.go
@@ -38,10 +38,13 @@ type switchCommand struct {
 var switchDoc = `
 Switch to the specified model or controller.
 
-If the name identifies controller, the client will switch to the
+If the name identifies a controller, the client will switch to the
 active model for that controller. Otherwise, the name must specify
 either the name of a model within the active controller, or a
 fully-qualified model with the format "controller:model".
+
+To list the available controllers or models, you can use the
+list-controllers and list-models commands respectively.
 `
 
 func (c *switchCommand) Info() *cmd.Info {

--- a/cmd/juju/controller/export_test.go
+++ b/cmd/juju/controller/export_test.go
@@ -60,8 +60,8 @@ func NewListModelsCommandForTest(modelAPI ModelManagerAPI, sysAPI ModelsSysAPI, 
 
 // NewRegisterCommandForTest returns a RegisterCommand with the function used
 // to open the API connection mocked out.
-func NewRegisterCommandForTest(apiOpen api.OpenFunc, newAPIRoot modelcmd.OpenFunc, store jujuclient.ClientStore) *registerCommand {
-	return &registerCommand{apiOpen: apiOpen, newAPIRoot: newAPIRoot, store: store}
+func NewRegisterCommandForTest(apiOpen api.OpenFunc, refreshModels func(jujuclient.ClientStore, string, string) error, store jujuclient.ClientStore) *registerCommand {
+	return &registerCommand{apiOpen: apiOpen, refreshModels: refreshModels, store: store}
 }
 
 // NewRemoveBlocksCommandForTest returns a RemoveBlocksCommand with the

--- a/cmd/juju/controller/listcontrollers_test.go
+++ b/cmd/juju/controller/listcontrollers_test.go
@@ -36,9 +36,9 @@ CONTROLLER  MODEL  USER  SERVER
 func (s *ListControllersSuite) TestListControllers(c *gc.C) {
 	s.expectedOutput = `
 CONTROLLER                 MODEL     USER         SERVER
-local.aws-test             -         -            instance-1-2-4.useast.aws.com
-local.mallards*            my-model  admin@local  maas-1-05.cluster.mallards
-local.mark-test-prodstack  -         -            vm-23532.prodstack.canonical.com
+local.aws-test             -         -            this-is-aws-test-of-many-api-endpoints
+local.mallards*            my-model  admin@local  this-is-another-of-many-api-endpoints
+local.mark-test-prodstack  -         -            this-is-one-of-many-api-endpoints
 
 `[1:]
 
@@ -50,22 +50,19 @@ func (s *ListControllersSuite) TestListControllersYaml(c *gc.C) {
 	s.expectedOutput = `
 controllers:
   local.aws-test:
-    recent-server: instance-1-2-4.useast.aws.com
-    servers: [instance-1-2-4.useast.aws.com]
+    recent-server: this-is-aws-test-of-many-api-endpoints
     uuid: this-is-the-aws-test-uuid
     api-endpoints: [this-is-aws-test-of-many-api-endpoints]
     ca-cert: this-is-aws-test-ca-cert
   local.mallards:
     current-model: my-model
     user: admin@local
-    recent-server: maas-1-05.cluster.mallards
-    servers: [maas-1-05.cluster.mallards]
+    recent-server: this-is-another-of-many-api-endpoints
     uuid: this-is-another-uuid
     api-endpoints: [this-is-another-of-many-api-endpoints, this-is-one-more-of-many-api-endpoints]
     ca-cert: this-is-another-ca-cert
   local.mark-test-prodstack:
-    recent-server: vm-23532.prodstack.canonical.com
-    servers: [vm-23532.prodstack.canonical.com, great.test.server.hostname.co.nz]
+    recent-server: this-is-one-of-many-api-endpoints
     uuid: this-is-a-uuid
     api-endpoints: [this-is-one-of-many-api-endpoints]
     ca-cert: this-is-a-ca-cert
@@ -87,8 +84,7 @@ func (s *ListControllersSuite) TestListControllersJson(c *gc.C) {
 		Controllers: map[string]controller.ControllerItem{
 			"local.aws-test": {
 				ControllerUUID: "this-is-the-aws-test-uuid",
-				Server:         "instance-1-2-4.useast.aws.com",
-				Servers:        []string{"instance-1-2-4.useast.aws.com"},
+				Server:         "this-is-aws-test-of-many-api-endpoints",
 				APIEndpoints:   []string{"this-is-aws-test-of-many-api-endpoints"},
 				CACert:         "this-is-aws-test-ca-cert",
 			},
@@ -96,15 +92,13 @@ func (s *ListControllersSuite) TestListControllersJson(c *gc.C) {
 				ControllerUUID: "this-is-another-uuid",
 				ModelName:      "my-model",
 				User:           "admin@local",
-				Server:         "maas-1-05.cluster.mallards",
-				Servers:        []string{"maas-1-05.cluster.mallards"},
+				Server:         "this-is-another-of-many-api-endpoints",
 				APIEndpoints:   []string{"this-is-another-of-many-api-endpoints", "this-is-one-more-of-many-api-endpoints"},
 				CACert:         "this-is-another-ca-cert",
 			},
 			"local.mark-test-prodstack": {
 				ControllerUUID: "this-is-a-uuid",
-				Server:         "vm-23532.prodstack.canonical.com",
-				Servers:        []string{"vm-23532.prodstack.canonical.com", "great.test.server.hostname.co.nz"},
+				Server:         "this-is-one-of-many-api-endpoints",
 				APIEndpoints:   []string{"this-is-one-of-many-api-endpoints"},
 				CACert:         "this-is-a-ca-cert",
 			},

--- a/cmd/juju/controller/listcontrollersconverters.go
+++ b/cmd/juju/controller/listcontrollersconverters.go
@@ -23,7 +23,6 @@ type ControllerItem struct {
 	ModelName      string   `yaml:"current-model,omitempty" json:"current-model,omitempty"`
 	User           string   `yaml:"user,omitempty" json:"user,omitempty"`
 	Server         string   `yaml:"recent-server,omitempty" json:"recent-server,omitempty"`
-	Servers        []string `yaml:"servers,flow" json:"servers"`
 	ControllerUUID string   `yaml:"uuid" json:"uuid"`
 	APIEndpoints   []string `yaml:"api-endpoints,flow" json:"api-endpoints"`
 	CACert         string   `yaml:"ca-cert" json:"ca-cert"`
@@ -46,10 +45,10 @@ func (c *listControllersCommand) convertControllerDetails(storeControllers map[s
 	controllers := map[string]ControllerItem{}
 	for controllerName, details := range storeControllers {
 		serverName := ""
-		// The most recently connected-to host name
+		// The most recently connected-to address
 		// is the first in the list.
-		if len(details.Servers) > 0 {
-			serverName = details.Servers[0]
+		if len(details.APIEndpoints) > 0 {
+			serverName = details.APIEndpoints[0]
 		}
 
 		var userName, modelName string
@@ -81,7 +80,6 @@ func (c *listControllersCommand) convertControllerDetails(storeControllers map[s
 			ModelName:      modelName,
 			User:           userName,
 			Server:         serverName,
-			Servers:        details.Servers,
 			APIEndpoints:   details.APIEndpoints,
 			ControllerUUID: details.ControllerUUID,
 			CACert:         details.CACert,

--- a/cmd/juju/controller/listmodels.go
+++ b/cmd/juju/controller/listmodels.go
@@ -155,7 +155,17 @@ func (c *modelsCommand) Run(ctx *cmd.Context) error {
 		return err
 	}
 	modelSet.CurrentModel = current
-	return c.out.Write(ctx, modelSet)
+	if err := c.out.Write(ctx, modelSet); err != nil {
+		return err
+	}
+
+	if len(models) == 0 && c.out.Name() == "tabular" {
+		// When the output is tabular, we inform the user when there
+		// are no models available, and tell them how to go about
+		// creating or granting access to them.
+		fmt.Fprintf(ctx.Stderr, "\n%s\n\n", errNoModels.Error())
+	}
+	return nil
 }
 
 func (c *modelsCommand) getAllModels() ([]base.UserModel, error) {

--- a/cmd/juju/controller/package_test.go
+++ b/cmd/juju/controller/package_test.go
@@ -58,17 +58,14 @@ func (s *baseControllerSuite) createTestClientStore(c *gc.C) *jujuclienttesting.
 const testControllersYaml = `
 controllers:
   local.aws-test:
-    servers: [instance-1-2-4.useast.aws.com]
     uuid: this-is-the-aws-test-uuid
     api-endpoints: [this-is-aws-test-of-many-api-endpoints]
     ca-cert: this-is-aws-test-ca-cert
   local.mallards:
-    servers: [maas-1-05.cluster.mallards]
     uuid: this-is-another-uuid
     api-endpoints: [this-is-another-of-many-api-endpoints, this-is-one-more-of-many-api-endpoints]
     ca-cert: this-is-another-ca-cert
   local.mark-test-prodstack:
-    servers: [vm-23532.prodstack.canonical.com, great.test.server.hostname.co.nz]
     uuid: this-is-a-uuid
     api-endpoints: [this-is-one-of-many-api-endpoints]
     ca-cert: this-is-a-ca-cert

--- a/cmd/juju/controller/showcontroller.go
+++ b/cmd/juju/controller/showcontroller.go
@@ -97,9 +97,6 @@ type ShowControllerDetails struct {
 
 // ControllerDetails holds details of a controller to show.
 type ControllerDetails struct {
-	// Servers contains the addresses of hosts that form this controller's cluster.
-	Servers []string `yaml:"servers,flow" json:"servers"`
-
 	// ControllerUUID is the unique ID for the controller.
 	ControllerUUID string `yaml:"uuid" json:"uuid"`
 
@@ -145,7 +142,6 @@ type BootstrapConfig struct {
 func (c *showControllerCommand) convertControllerForShow(controllerName string, details *jujuclient.ControllerDetails) ShowControllerDetails {
 	controller := ShowControllerDetails{
 		Details: ControllerDetails{
-			Servers:        details.Servers,
 			ControllerUUID: details.ControllerUUID,
 			APIEndpoints:   details.APIEndpoints,
 			CACert:         details.CACert,

--- a/cmd/juju/controller/showcontroller_test.go
+++ b/cmd/juju/controller/showcontroller_test.go
@@ -27,7 +27,6 @@ var _ = gc.Suite(&ShowControllerSuite{})
 func (s *ShowControllerSuite) TestShowOneControllerOneInStore(c *gc.C) {
 	s.controllersYaml = `controllers:
   local.mallards:
-    servers: [maas-1-05.cluster.mallards]
     uuid: this-is-another-uuid
     api-endpoints: [this-is-another-of-many-api-endpoints, this-is-one-more-of-many-api-endpoints]
     ca-cert: this-is-another-ca-cert
@@ -37,7 +36,6 @@ func (s *ShowControllerSuite) TestShowOneControllerOneInStore(c *gc.C) {
 	s.expectedOutput = `
 local.mallards:
   details:
-    servers: [maas-1-05.cluster.mallards]
     uuid: this-is-another-uuid
     api-endpoints: [this-is-another-of-many-api-endpoints, this-is-one-more-of-many-api-endpoints]
     ca-cert: this-is-another-ca-cert
@@ -63,7 +61,6 @@ local.mallards:
 func (s *ShowControllerSuite) TestShowControllerWithPasswords(c *gc.C) {
 	s.controllersYaml = `controllers:
   local.mallards:
-    servers: [maas-1-05.cluster.mallards]
     uuid: this-is-another-uuid
     api-endpoints: [this-is-another-of-many-api-endpoints, this-is-one-more-of-many-api-endpoints]
     ca-cert: this-is-another-ca-cert
@@ -73,7 +70,6 @@ func (s *ShowControllerSuite) TestShowControllerWithPasswords(c *gc.C) {
 	s.expectedOutput = `
 local.mallards:
   details:
-    servers: [maas-1-05.cluster.mallards]
     uuid: this-is-another-uuid
     api-endpoints: [this-is-another-of-many-api-endpoints, this-is-one-more-of-many-api-endpoints]
     ca-cert: this-is-another-ca-cert
@@ -101,7 +97,6 @@ local.mallards:
 func (s *ShowControllerSuite) TestShowControllerWithBootstrapConfig(c *gc.C) {
 	s.controllersYaml = `controllers:
   local.mallards:
-    servers: [maas-1-05.cluster.mallards]
     uuid: this-is-another-uuid
     api-endpoints: [this-is-another-of-many-api-endpoints, this-is-one-more-of-many-api-endpoints]
     ca-cert: this-is-another-ca-cert
@@ -122,7 +117,6 @@ func (s *ShowControllerSuite) TestShowControllerWithBootstrapConfig(c *gc.C) {
 	s.expectedOutput = `
 local.mallards:
   details:
-    servers: [maas-1-05.cluster.mallards]
     uuid: this-is-another-uuid
     api-endpoints: [this-is-another-of-many-api-endpoints, this-is-one-more-of-many-api-endpoints]
     ca-cert: this-is-another-ca-cert
@@ -159,7 +153,6 @@ func (s *ShowControllerSuite) TestShowOneControllerManyInStore(c *gc.C) {
 	s.expectedOutput = `
 local.aws-test:
   details:
-    servers: [instance-1-2-4.useast.aws.com]
     uuid: this-is-the-aws-test-uuid
     api-endpoints: [this-is-aws-test-of-many-api-endpoints]
     ca-cert: this-is-aws-test-ca-cert
@@ -179,7 +172,6 @@ func (s *ShowControllerSuite) TestShowSomeControllerMoreInStore(c *gc.C) {
 	s.expectedOutput = `
 local.aws-test:
   details:
-    servers: [instance-1-2-4.useast.aws.com]
     uuid: this-is-the-aws-test-uuid
     api-endpoints: [this-is-aws-test-of-many-api-endpoints]
     ca-cert: this-is-aws-test-ca-cert
@@ -192,7 +184,6 @@ local.aws-test:
       current-model: admin
 local.mark-test-prodstack:
   details:
-    servers: [vm-23532.prodstack.canonical.com, great.test.server.hostname.co.nz]
     uuid: this-is-a-uuid
     api-endpoints: [this-is-one-of-many-api-endpoints]
     ca-cert: this-is-a-ca-cert
@@ -208,7 +199,7 @@ func (s *ShowControllerSuite) TestShowControllerJsonOne(c *gc.C) {
 	s.createTestClientStore(c)
 
 	s.expectedOutput = `
-{"local.aws-test":{"details":{"servers":["instance-1-2-4.useast.aws.com"],"uuid":"this-is-the-aws-test-uuid","api-endpoints":["this-is-aws-test-of-many-api-endpoints"],"ca-cert":"this-is-aws-test-ca-cert"},"accounts":{"admin@local":{"user":"admin@local","models":{"admin":{"uuid":"ghi"}},"current-model":"admin"}}}}
+{"local.aws-test":{"details":{"uuid":"this-is-the-aws-test-uuid","api-endpoints":["this-is-aws-test-of-many-api-endpoints"],"ca-cert":"this-is-aws-test-ca-cert"},"accounts":{"admin@local":{"user":"admin@local","models":{"admin":{"uuid":"ghi"}},"current-model":"admin"}}}}
 `[1:]
 
 	s.assertShowController(c, "--format", "json", "local.aws-test")
@@ -217,7 +208,7 @@ func (s *ShowControllerSuite) TestShowControllerJsonOne(c *gc.C) {
 func (s *ShowControllerSuite) TestShowControllerJsonMany(c *gc.C) {
 	s.createTestClientStore(c)
 	s.expectedOutput = `
-{"local.aws-test":{"details":{"servers":["instance-1-2-4.useast.aws.com"],"uuid":"this-is-the-aws-test-uuid","api-endpoints":["this-is-aws-test-of-many-api-endpoints"],"ca-cert":"this-is-aws-test-ca-cert"},"accounts":{"admin@local":{"user":"admin@local","models":{"admin":{"uuid":"ghi"}},"current-model":"admin"}}},"local.mark-test-prodstack":{"details":{"servers":["vm-23532.prodstack.canonical.com","great.test.server.hostname.co.nz"],"uuid":"this-is-a-uuid","api-endpoints":["this-is-one-of-many-api-endpoints"],"ca-cert":"this-is-a-ca-cert"},"accounts":{"admin@local":{"user":"admin@local"}}}}
+{"local.aws-test":{"details":{"uuid":"this-is-the-aws-test-uuid","api-endpoints":["this-is-aws-test-of-many-api-endpoints"],"ca-cert":"this-is-aws-test-ca-cert"},"accounts":{"admin@local":{"user":"admin@local","models":{"admin":{"uuid":"ghi"}},"current-model":"admin"}}},"local.mark-test-prodstack":{"details":{"uuid":"this-is-a-uuid","api-endpoints":["this-is-one-of-many-api-endpoints"],"ca-cert":"this-is-a-ca-cert"},"accounts":{"admin@local":{"user":"admin@local"}}}}
 `[1:]
 	s.assertShowController(c, "--format", "json", "local.aws-test", "local.mark-test-prodstack")
 }
@@ -239,7 +230,7 @@ func (s *ShowControllerSuite) TestShowControllerNoArgs(c *gc.C) {
 	s.createTestClientStore(c)
 
 	s.expectedOutput = `
-{"local.aws-test":{"details":{"servers":["instance-1-2-4.useast.aws.com"],"uuid":"this-is-the-aws-test-uuid","api-endpoints":["this-is-aws-test-of-many-api-endpoints"],"ca-cert":"this-is-aws-test-ca-cert"},"accounts":{"admin@local":{"user":"admin@local","models":{"admin":{"uuid":"ghi"}},"current-model":"admin"}}}}
+{"local.aws-test":{"details":{"uuid":"this-is-the-aws-test-uuid","api-endpoints":["this-is-aws-test-of-many-api-endpoints"],"ca-cert":"this-is-aws-test-ca-cert"},"accounts":{"admin@local":{"user":"admin@local","models":{"admin":{"uuid":"ghi"}},"current-model":"admin"}}}}
 `[1:]
 	err := modelcmd.WriteCurrentController("local.aws-test")
 	c.Assert(err, jc.ErrorIsNil)

--- a/cmd/juju/machine/base.go
+++ b/cmd/juju/machine/base.go
@@ -41,12 +41,6 @@ func (c *baselistMachinesCommand) SetFlags(f *gnuflag.FlagSet) {
 	})
 }
 
-var connectionError = `Unable to connect to model %q.
-Please check your credentials or use 'juju bootstrap' to create a new model.
-
-Error details:
-%v
-`
 var newAPIClientForMachines = func(c *baselistMachinesCommand) (statusAPI, error) {
 	if c.api != nil {
 		return c.api, nil
@@ -58,7 +52,7 @@ var newAPIClientForMachines = func(c *baselistMachinesCommand) (statusAPI, error
 func (c *baselistMachinesCommand) Run(ctx *cmd.Context) error {
 	apiclient, err := newAPIClientForMachines(c)
 	if err != nil {
-		return errors.Errorf(connectionError, c.ConnectionName(), err)
+		return errors.Trace(err)
 	}
 	defer apiclient.Close()
 

--- a/cmd/juju/status/history.go
+++ b/cmd/juju/status/history.go
@@ -97,7 +97,7 @@ func (c *statusHistoryCommand) Init(args []string) error {
 func (c *statusHistoryCommand) Run(ctx *cmd.Context) error {
 	apiclient, err := c.NewAPIClient()
 	if err != nil {
-		return fmt.Errorf(connectionError, c.ConnectionName(), err)
+		return errors.Trace(err)
 	}
 	defer apiclient.Close()
 	var statuses *params.StatusHistoryResults

--- a/cmd/juju/status/status.go
+++ b/cmd/juju/status/status.go
@@ -114,13 +114,6 @@ func (c *statusCommand) Init(args []string) error {
 	return nil
 }
 
-var connectionError = `Unable to connect to model %q.
-Please check your credentials or use 'juju bootstrap' to create a new model.
-
-Error details:
-%v
-`
-
 var newApiClientForStatus = func(c *statusCommand) (statusAPI, error) {
 	return c.NewAPIClient()
 }
@@ -128,7 +121,7 @@ var newApiClientForStatus = func(c *statusCommand) (statusAPI, error) {
 func (c *statusCommand) Run(ctx *cmd.Context) error {
 	apiclient, err := newApiClientForStatus(c)
 	if err != nil {
-		return errors.Errorf(connectionError, c.ConnectionName(), err)
+		return errors.Trace(err)
 	}
 	defer apiclient.Close()
 

--- a/cmd/juju/user/add.go
+++ b/cmd/juju/user/add.go
@@ -177,6 +177,11 @@ func (c *addCommand) Run(ctx *cmd.Context) error {
 	fmt.Fprintf(ctx.Stdout, "    juju register %s\n",
 		base64RegistrationData,
 	)
+	if len(modelNames) == 0 {
+		fmt.Fprintf(ctx.Stdout, `
+%q has not been granted access to any models. You can use "juju grant" to grant access.
+`, displayName)
+	}
 
 	return nil
 }

--- a/cmd/juju/user/add_test.go
+++ b/cmd/juju/user/add_test.go
@@ -100,6 +100,8 @@ func (s *UserAddCommandSuite) TestAddUserWithUsername(c *gc.C) {
 User "foobar" added
 Please send this command to foobar:
     juju register MD0TBmZvb2JhcjAREw8xMjcuMC4wLjE6MTIzNDUEIFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhY
+
+"foobar" has not been granted access to any models. You can use "juju grant" to grant access.
 `[1:]
 	c.Assert(testing.Stdout(context), gc.Equals, expected)
 	c.Assert(testing.Stderr(context), gc.Equals, "")
@@ -116,6 +118,8 @@ func (s *UserAddCommandSuite) TestAddUserWithUsernameAndACL(c *gc.C) {
 User "foobar" added
 Please send this command to foobar:
     juju register MD0TBmZvb2JhcjAREw8xMjcuMC4wLjE6MTIzNDUEIFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhY
+
+"foobar" has not been granted access to any models. You can use "juju grant" to grant access.
 `[1:]
 	c.Assert(testing.Stdout(context), gc.Equals, expected)
 	c.Assert(testing.Stderr(context), gc.Equals, "")
@@ -132,6 +136,8 @@ func (s *UserAddCommandSuite) TestAddUserWithUsernameAndDisplayname(c *gc.C) {
 User "Foo Bar (foobar)" added
 Please send this command to foobar:
     juju register MD0TBmZvb2JhcjAREw8xMjcuMC4wLjE6MTIzNDUEIFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhY
+
+"Foo Bar (foobar)" has not been granted access to any models. You can use "juju grant" to grant access.
 `[1:]
 	c.Assert(testing.Stdout(context), gc.Equals, expected)
 	c.Assert(testing.Stderr(context), gc.Equals, "")

--- a/cmd/modelcmd/controller.go
+++ b/cmd/modelcmd/controller.go
@@ -19,7 +19,12 @@ var (
 	// ErrNoControllerSpecified is returned by commands that operate on
 	// a controller if there is no current controller, no controller has been
 	// explicitly specified, and there is no default controller.
-	ErrNoControllerSpecified = errors.New("no controller specified")
+	ErrNoControllerSpecified = errors.New(`no controller specified
+
+There is no current controller. Please use "juju switch" to
+set the current controller/model, or create a new controller
+using "juju bootstrap".
+`)
 
 	// ErrNoAccountSpecified is returned by commands that operate on a
 	// controller if there is no current account associated with the

--- a/cmd/modelcmd/controller_test.go
+++ b/cmd/modelcmd/controller_test.go
@@ -24,7 +24,7 @@ var _ = gc.Suite(&ControllerCommandSuite{})
 
 func (s *ControllerCommandSuite) TestControllerCommandNoneSpecified(c *gc.C) {
 	_, err := initTestControllerCommand(c, nil)
-	c.Assert(err, gc.ErrorMatches, "no controller specified")
+	c.Assert(err, gc.ErrorMatches, "no controller specified(.|\n)*")
 }
 
 func (s *ControllerCommandSuite) TestControllerCommandInitSystemFile(c *gc.C) {

--- a/cmd/modelcmd/modelcommand.go
+++ b/cmd/modelcmd/modelcommand.go
@@ -24,7 +24,13 @@ var logger = loggo.GetLogger("juju.cmd.modelcmd")
 // ErrNoModelSpecified is returned by commands that operate on
 // an environment if there is no current model, no model
 // has been explicitly specified, and there is no default model.
-var ErrNoModelSpecified = errors.New("no model specified")
+var ErrNoModelSpecified = errors.New(`no model specified
+
+There is no current model specified for the current controller,
+and none specified on the command line. Please use "juju switch"
+to set the current model, or specify a model on the command line
+using the "-m" flag.
+`)
 
 // GetCurrentModel returns the name of the current Juju model.
 //
@@ -189,6 +195,9 @@ func (c *ModelCommandBase) NewAPIRoot() (api.Connection, error) {
 	// This is work in progress as we remove the ModelName from downstream code.
 	// We want to be able to specify the environment in a number of ways, one of
 	// which is the connection name on the client machine.
+	if c.controllerName == "" {
+		return nil, errors.Trace(ErrNoControllerSpecified)
+	}
 	if c.modelName == "" {
 		return nil, errors.Trace(ErrNoModelSpecified)
 	}

--- a/cmd/modelcmd/modelcommand_test.go
+++ b/cmd/modelcmd/modelcommand_test.go
@@ -211,7 +211,6 @@ func (s *macaroonLoginSuite) SetUpTest(c *gc.C) {
 
 	s.store = jujuclienttesting.NewMemStore()
 	s.store.Controllers[s.controllerName] = jujuclient.ControllerDetails{
-		Servers:        []string{"0.1.2.3"},
 		APIEndpoints:   apiInfo.Addrs,
 		ControllerUUID: apiInfo.ModelTag.Id(),
 		CACert:         apiInfo.CACert,

--- a/featuretests/cmd_juju_controller_test.go
+++ b/featuretests/cmd_juju_controller_test.go
@@ -64,11 +64,11 @@ func (s *cmdControllerSuite) createModelNormalUser(c *gc.C, modelname string, is
 
 func (s *cmdControllerSuite) TestControllerListCommand(c *gc.C) {
 	context := s.run(c, "list-controllers")
-	expectedOutput := `
+	expectedOutput := fmt.Sprintf(`
 CONTROLLER  MODEL  USER         SERVER
-kontroll*   admin  admin@local  
+kontroll*   admin  admin@local  %s
 
-`[1:]
+`[1:], s.APIState.Addr())
 	c.Assert(testing.Stdout(context), gc.Equals, expectedOutput)
 }
 

--- a/featuretests/cmd_juju_register_test.go
+++ b/featuretests/cmd_juju_register_test.go
@@ -45,9 +45,11 @@ func (s *cmdRegistrationSuite) TestAddUserAndRegister(c *gc.C) {
 User "Bob Dobbs \(bob\)" added
 Please send this command to bob:
     juju register .*
+
+"Bob Dobbs \(bob\)" has not been granted access to any models(.|\n)*
 `[1:])
 	jujuRegisterCommand := strings.Fields(strings.TrimSpace(
-		stdout[strings.Index(stdout, "juju register"):],
+		strings.SplitN(stdout[strings.Index(stdout, "juju register"):], "\n", 2)[0],
 	))
 	c.Logf("%q", jujuRegisterCommand)
 
@@ -63,6 +65,11 @@ Enter password:
 Confirm password: 
 
 Welcome, bob. You are now logged into "bob-controller".
+
+There are no models available. You can create models with
+"juju create-model", or you can ask an administrator or owner
+of a model to grant access to that model with "juju grant".
+
 `[1:])
 
 	// Make sure that the saved server details are sufficient to connect

--- a/juju/api.go
+++ b/juju/api.go
@@ -343,11 +343,11 @@ func PrepareEndpointsForCaching(
 	needResolving := false
 
 	// Verify if the unresolved addresses have changed.
-	if len(apiHosts) > 0 && len(controllerDetails.Servers) > 0 {
-		if addrsChanged(hostsStrings, controllerDetails.Servers) {
+	if len(apiHosts) > 0 && len(controllerDetails.UnresolvedAPIEndpoints) > 0 {
+		if addrsChanged(hostsStrings, controllerDetails.UnresolvedAPIEndpoints) {
 			logger.Debugf(
 				"API hostnames changed from %v to %v - resolving hostnames",
-				controllerDetails.Servers, hostsStrings,
+				controllerDetails.UnresolvedAPIEndpoints, hostsStrings,
 			)
 			needResolving = true
 		}
@@ -425,7 +425,7 @@ func updateControllerAddresses(
 	}
 
 	// Write the new controller data.
-	controllerDetails.Servers = hosts
+	controllerDetails.UnresolvedAPIEndpoints = hosts
 	controllerDetails.APIEndpoints = addrs
 	err := store.UpdateController(controllerName, *controllerDetails)
 	return errors.Trace(err)

--- a/juju/api_test.go
+++ b/juju/api_test.go
@@ -293,7 +293,7 @@ func setEndpointAddressAndHostname(c *gc.C, store jujuclient.ControllerStore, ad
 	details, err := store.ControllerByName("local.my-controller")
 	c.Assert(err, jc.ErrorIsNil)
 	details.APIEndpoints = []string{addr}
-	details.Servers = []string{host}
+	details.UnresolvedAPIEndpoints = []string{host}
 	err = store.UpdateController("local.my-controller", *details)
 	c.Assert(err, jc.ErrorIsNil)
 }
@@ -491,7 +491,7 @@ func (s *CacheAPIEndpointsSuite) assertCreateController(c *gc.C, name string) ju
 func (s *CacheAPIEndpointsSuite) assertControllerDetailsUpdated(c *gc.C, name string, check gc.Checker) {
 	found, err := s.ControllerStore.ControllerByName(name)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(found.Servers, check, 0)
+	c.Assert(found.UnresolvedAPIEndpoints, check, 0)
 	c.Assert(found.APIEndpoints, check, 0)
 }
 
@@ -523,9 +523,9 @@ func (s *CacheAPIEndpointsSuite) TestResolveSkippedWhenHostnamesUnchanged(c *gc.
 		"10.0.0.1",
 	)
 	controllerDetails := jujuclient.ControllerDetails{
-		ControllerUUID: fakeUUID,
-		CACert:         "certificate",
-		Servers:        network.HostPortsToStrings(hps),
+		ControllerUUID:         fakeUUID,
+		CACert:                 "certificate",
+		UnresolvedAPIEndpoints: network.HostPortsToStrings(hps),
 	}
 	err := s.ControllerStore.UpdateController("controller-name", controllerDetails)
 	c.Assert(err, jc.ErrorIsNil)
@@ -572,9 +572,9 @@ func (s *CacheAPIEndpointsSuite) TestResolveCalledWithChangedHostnames(c *gc.C) 
 	)
 	strResolved := network.HostPortsToStrings(resolvedHPs)
 	controllerDetails := jujuclient.ControllerDetails{
-		ControllerUUID: fakeUUID,
-		CACert:         "certificate",
-		Servers:        strUnsorted,
+		ControllerUUID:         fakeUUID,
+		CACert:                 "certificate",
+		UnresolvedAPIEndpoints: strUnsorted,
 	}
 	err := s.ControllerStore.UpdateController("controller-name", controllerDetails)
 	c.Assert(err, jc.ErrorIsNil)
@@ -621,10 +621,10 @@ func (s *CacheAPIEndpointsSuite) TestAfterResolvingUnchangedAddressesNotCached(c
 	)
 	strResolved := network.HostPortsToStrings(resolvedHPs)
 	controllerDetails := jujuclient.ControllerDetails{
-		ControllerUUID: fakeUUID,
-		CACert:         "certificate",
-		Servers:        strUnsorted,
-		APIEndpoints:   strResolved,
+		ControllerUUID:         fakeUUID,
+		CACert:                 "certificate",
+		UnresolvedAPIEndpoints: strUnsorted,
+		APIEndpoints:           strResolved,
 	}
 	err := s.ControllerStore.UpdateController("controller-name", controllerDetails)
 	c.Assert(err, jc.ErrorIsNil)
@@ -717,7 +717,7 @@ func (s *CacheAPIEndpointsSuite) assertEndpoints(c *gc.C, controllerDetails *juj
 		"[fc00::9]:1234", // From ipv6+6.example.com
 	})
 	// Check Hostnames before resolving
-	c.Check(controllerDetails.Servers, jc.DeepEquals, []string{
+	c.Check(controllerDetails.UnresolvedAPIEndpoints, jc.DeepEquals, []string{
 		s.apiHostPort.NetAddr(), // Last endpoint successfully connected to is always on top.
 		"1.0.0.1:1234",
 		"1.0.0.2:1235",

--- a/jujuclient/controllersfile_test.go
+++ b/jujuclient/controllersfile_test.go
@@ -23,17 +23,17 @@ var _ = gc.Suite(&ControllersFileSuite{})
 const testControllersYAML = `
 controllers:
   local.aws-test:
-    servers: [instance-1-2-4.useast.aws.com]
+    unresolved-api-endpoints: [instance-1-2-4.useast.aws.com]
     uuid: this-is-the-aws-test-uuid
     api-endpoints: [this-is-aws-test-of-many-api-endpoints]
     ca-cert: this-is-aws-test-ca-cert
   local.mallards:
-    servers: [maas-1-05.cluster.mallards]
+    unresolved-api-endpoints: [maas-1-05.cluster.mallards]
     uuid: this-is-another-uuid
     api-endpoints: [this-is-another-of-many-api-endpoints, this-is-one-more-of-many-api-endpoints]
     ca-cert: this-is-another-ca-cert
   local.mark-test-prodstack:
-    servers: [vm-23532.prodstack.canonical.com, great.test.server.hostname.co.nz]
+    unresolved-api-endpoints: [vm-23532.prodstack.canonical.com, great.test.server.hostname.co.nz]
     uuid: this-is-a-uuid
     api-endpoints: [this-is-one-of-many-api-endpoints]
     ca-cert: this-is-a-ca-cert
@@ -67,7 +67,7 @@ func parseControllers(c *gc.C) map[string]jujuclient.ControllerDetails {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// ensure that multiple server hostnames and eapi endpoints are parsed correctly
-	c.Assert(controllers["local.mark-test-prodstack"].Servers, gc.HasLen, 2)
+	c.Assert(controllers["local.mark-test-prodstack"].UnresolvedAPIEndpoints, gc.HasLen, 2)
 	c.Assert(controllers["local.mallards"].APIEndpoints, gc.HasLen, 2)
 	return controllers
 }

--- a/jujuclient/interface.go
+++ b/jujuclient/interface.go
@@ -7,12 +7,12 @@ import "github.com/juju/juju/cloud"
 
 // ControllerDetails holds the details needed to connect to a controller.
 type ControllerDetails struct {
-	// Servers holds a list of API addresses which may contain
-	// unresolved hostnames. It's used to compare more recent API
-	// addresses before resolving hostnames to determine if the cached
-	// addresses have changed and therefore perform (a possibly slow)
-	// local DNS resolution before comparing them against Addresses.
-	Servers []string `yaml:"servers,flow"`
+	// UnresolvedAPIEndpoints holds a list of API addresses which may
+	// contain unresolved hostnames. It's used to compare more recent
+	// API addresses before resolving hostnames to determine if the
+	// cached addresses have changed and therefore perform (a possibly
+	// slow) local DNS resolution before comparing them against Addresses.
+	UnresolvedAPIEndpoints []string `yaml:"unresolved-api-endpoints,flow"`
 
 	// ControllerUUID is the unique ID for the controller.
 	ControllerUUID string `yaml:"uuid"`

--- a/payload/status/list.go
+++ b/payload/status/list.go
@@ -80,18 +80,10 @@ func (c *ListCommand) Init(args []string) error {
 	return nil
 }
 
-// TODO(ericsnow) Move this to a common place, like cmd/modelcmd?
-const connectionError = `Unable to connect to model %q.
-Please check your credentials or use 'juju bootstrap' to create a new model.
-
-Error details:
-%v
-`
-
 func (c *ListCommand) Run(ctx *cmd.Context) error {
 	apiclient, err := c.newAPIClient(c)
 	if err != nil {
-		return fmt.Errorf(connectionError, c.ConnectionName(), err)
+		return errors.Trace(err)
 	}
 	defer apiclient.Close()
 


### PR DESCRIPTION
Update the error messages that are printed out
whenever a current controller or model is not set,
and not specified. Give advice on what commands
and flags to use to rectify the situation. Give
a bit more feedback in "juju add-user" and
"juju register", and set the current model in
"juju register" if there is only one model
available.

(Review request: http://reviews.vapour.ws/r/4333/)