### PR TITLE
rpc: retry conn.Call on temporary error

### DIFF
--- a/provider/lxd/environ.go
+++ b/provider/lxd/environ.go
@@ -120,17 +120,12 @@ func (env *environ) SetConfig(cfg *config.Config) error {
 	return nil
 }
 
-// getSnapshot returns a copy of the environment. This is useful for
-// ensuring the env you are using does not get changed by other code
-// while you are using it.
-func (env *environ) getSnapshot() *environ {
-	e := *env
-	return &e
-}
-
 // Config returns the configuration data with which the env was created.
 func (env *environ) Config() *config.Config {
-	return env.getSnapshot().ecfg.Config
+	env.lock.Lock()
+	cfg := env.ecfg.Config
+	env.lock.Unlock()
+	return cfg
 }
 
 // Bootstrap creates a new instance, chosing the series and arch out of

--- a/provider/lxd/environ_broker.go
+++ b/provider/lxd/environ_broker.go
@@ -34,11 +34,6 @@ func (*environ) MaintainInstance(args environs.StartInstanceParams) error {
 
 // StartInstance implements environs.InstanceBroker.
 func (env *environ) StartInstance(args environs.StartInstanceParams) (*environs.StartInstanceResult, error) {
-	// Please note that in order to fulfil the demands made of Instances and
-	// AllInstances, it is imperative that some environment feature be used to
-	// keep track of which instances were actually started by juju.
-	env = env.getSnapshot()
-
 	// Start a new instance.
 
 	if args.InstanceConfig.HasNetworks() {
@@ -270,8 +265,6 @@ func (env *environ) AllInstances() ([]instance.Instance, error) {
 
 // StopInstances implements environs.InstanceBroker.
 func (env *environ) StopInstances(instances ...instance.Id) error {
-	env = env.getSnapshot()
-
 	var ids []string
 	for _, id := range instances {
 		ids = append(ids, string(id))

--- a/provider/lxd/environ_instance.go
+++ b/provider/lxd/environ_instance.go
@@ -69,8 +69,6 @@ var getInstances = func(env *environ) ([]instance.Instance, error) {
 // will see they are not tracked in state, assume they're stale/rogue,
 // and shut them down.
 func (env *environ) instances() ([]instance.Instance, error) {
-	env = env.getSnapshot()
-
 	prefix := common.MachineFullName(env.Config().UUID(), "")
 	instances, err := env.raw.Instances(prefix, instStatuses...)
 	err = errors.Trace(err)
@@ -92,8 +90,6 @@ func (env *environ) instances() ([]instance.Instance, error) {
 // ControllerInstances returns the IDs of the instances corresponding
 // to juju controllers.
 func (env *environ) ControllerInstances() ([]instance.Id, error) {
-	env = env.getSnapshot()
-
 	prefix := common.MachineFullName(env.Config().ControllerUUID(), "")
 	instances, err := env.raw.Instances(prefix, instStatuses...)
 	if err != nil {

--- a/provider/lxd/instance.go
+++ b/provider/lxd/instance.go
@@ -76,8 +76,7 @@ func findInst(id instance.Id, instances []instance.Instance) instance.Instance {
 func (inst *environInstance) OpenPorts(machineID string, ports []network.PortRange) error {
 	// TODO(ericsnow) Make sure machineId matches inst.Id()?
 	name := common.MachineFullName(inst.env.Config().UUID(), machineID)
-	env := inst.env.getSnapshot()
-	err := env.raw.OpenPorts(name, ports...)
+	err := inst.env.raw.OpenPorts(name, ports...)
 	if errors.IsNotImplemented(err) {
 		// TODO(ericsnow) for now...
 		return nil
@@ -89,8 +88,7 @@ func (inst *environInstance) OpenPorts(machineID string, ports []network.PortRan
 // should have been started with the given machine id.
 func (inst *environInstance) ClosePorts(machineID string, ports []network.PortRange) error {
 	name := common.MachineFullName(inst.env.Config().UUID(), machineID)
-	env := inst.env.getSnapshot()
-	err := env.raw.ClosePorts(name, ports...)
+	err := inst.env.raw.ClosePorts(name, ports...)
 	if errors.IsNotImplemented(err) {
 		// TODO(ericsnow) for now...
 		return nil
@@ -103,8 +101,7 @@ func (inst *environInstance) ClosePorts(machineID string, ports []network.PortRa
 // The ports are returned as sorted by SortPorts.
 func (inst *environInstance) Ports(machineID string) ([]network.PortRange, error) {
 	name := common.MachineFullName(inst.env.Config().UUID(), machineID)
-	env := inst.env.getSnapshot()
-	ports, err := env.raw.Ports(name)
+	ports, err := inst.env.raw.Ports(name)
 	if errors.IsNotImplemented(err) {
 		// TODO(ericsnow) for now...
 		return nil, nil

--- a/worker/metrics/sender/sender_test.go
+++ b/worker/metrics/sender/sender_test.go
@@ -283,7 +283,7 @@ func (c *mockConnection) Close() error {
 	return nil
 }
 
-func (c mockConnection) eof() bool {
+func (c *mockConnection) eof() bool {
 	return len(c.data) == 0
 }
 


### PR DESCRIPTION
This PR adds support for retrying rpc operations on temporary errors.

The current logic is a noop -- a zero valued retry strategy only
executes one time.

Followup PR's will expose the retry strategy to the callers of
rpc.NewConn so we can plub the correct production and testing values to
them.

(Review request: http://reviews.vapour.ws/r/4334/)