### PR TITLE
rework the code a little to make it more clear, and clean up a couple tests.

### DIFF
--- a/tools/lxdclient/client_image.go
+++ b/tools/lxdclient/client_image.go
@@ -95,7 +95,7 @@ func (i *imageClient) EnsureImageExists(series string, sources []Remote, copyPro
 		}
 		logger.Infof("found image from %s for %s = %s",
 			source.BaseURL, series, target)
-		forwarder := stringforwarder.NewStringForwarder(copyProgressHandler)
+		forwarder := stringforwarder.New(copyProgressHandler)
 		defer func() {
 			dropCount := forwarder.Stop()
 			logger.Debugf("dropped %d progress messages", dropCount)
@@ -104,7 +104,7 @@ func (i *imageClient) EnsureImageExists(series string, sources []Remote, copyPro
 			logger:  logger,
 			level:   loggo.INFO,
 			context: fmt.Sprintf("copying image for %s from %s: %%s", name, source.BaseURL),
-			forward: forwarder.Receive,
+			forward: forwarder.Forward,
 		}
 		err = source.CopyImage(
 			target, client, false, []string{name}, false,

--- a/utils/stringforwarder/package_test.go
+++ b/utils/stringforwarder/package_test.go
@@ -1,7 +1,7 @@
 // Copyright 2016 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package stringforwarder_test
+package stringforwarder
 
 import (
 	"testing"

--- a/utils/stringforwarder/stringforwarder.go
+++ b/utils/stringforwarder/stringforwarder.go
@@ -4,62 +4,81 @@
 package stringforwarder
 
 import (
+	"sync"
 	"sync/atomic"
 )
 
-// stringForwarder will take messages on a receive() method and forward them to
-// callback, but will drop them if callback() has not finished processing the
-// last message. We will track how many messages we have discarded.
-type stringForwarder struct {
-	callback     func(string)
-	buffer       chan string
-	stopch       chan struct{}
-	started      chan struct{}
+// StringForwarder is a goroutine-safe type that pipes messages from the
+// its Forward() method, sending them to callback.  The send is non-blocking and
+// will discard messages if the last message has not finished processing.
+// The number of discarded messages is tracked and returned when the forwarder
+// is stopped.
+type StringForwarder struct {
+	messages     chan string
+	done         chan struct{}
 	discardCount uint64
+	mu           *sync.Mutex
 }
 
-func NewStringForwarder(callback func(string)) *stringForwarder {
+// New returns a new StringForwarder that sends messages to the callback,
+// function, dropping messages if the receiver is not ready.
+func New(callback func(string)) *StringForwarder {
 	if callback == nil {
 		// Nothing to forward to, so no need to start the loop(). We'll
 		// just count the discardCount.
-		return &stringForwarder{}
+		return &StringForwarder{mu: &sync.Mutex{}}
 	}
-	forwarder := &stringForwarder{
-		callback:     callback,
-		buffer:       make(chan string),
-		stopch:       make(chan struct{}),
+
+	messages := make(chan string)
+	done := make(chan struct{})
+	forwarder := &StringForwarder{
+		messages:     messages,
+		done:         done,
+		mu:           &sync.Mutex{},
 		discardCount: 0,
 	}
 	started := make(chan struct{})
-	go forwarder.loop(started)
+	go forwarder.loop(started, callback)
 	<-started
 	return forwarder
 }
 
-func (f *stringForwarder) Receive(msg string) {
+// Forward makes a non-blocking send of the message to the callback function.
+// If the message is not received, it will increment the count of discarded
+// messages. Forward is safe to call from multiple goroutines at once.
+// Note that if this StringForwarder was created with a nil callback, all
+// messages will be discarded.
+func (f *StringForwarder) Forward(msg string) {
 	select {
-	case f.buffer <- msg:
+	case f.messages <- msg:
 	default:
 		atomic.AddUint64(&f.discardCount, 1)
 	}
 }
 
-func (f *stringForwarder) Stop() uint64 {
-	if f.stopch != nil {
-		close(f.stopch)
-		f.stopch = nil
+// Stop cleans up the goroutine running behind StringForwarder and returns the
+// count of discarded messages. Stop is thread-safe and may be called multiple
+// times - after the first time, it simply returns the current discard count.
+func (f *StringForwarder) Stop() uint64 {
+	f.mu.Lock()
+	if f.done != nil {
+		close(f.done)
+		f.done = nil
 	}
+	f.mu.Unlock()
 	return atomic.LoadUint64(&f.discardCount)
 }
 
-func (f *stringForwarder) loop(started chan struct{}) {
-	stopch := f.stopch
+// loop pipes messages from the messages channel into the callback function. It
+// closes started to signal that it has begun, and will clean itself up when
+// done is closed.
+func (f *StringForwarder) loop(started chan struct{}, callback func(string)) {
 	close(started)
 	for {
 		select {
-		case msg := <-f.buffer:
-			f.callback(msg)
-		case <-stopch:
+		case msg := <-f.messages:
+			callback(msg)
+		case <-f.done:
 			return
 		}
 	}


### PR DESCRIPTION
Fix for bug https://bugs.launchpad.net/juju-core/+bug/1560203

So, honestly, the fix for this bug was "don't do that".  The test was not failing because it found a race condition, it was failing because one goroutine was going a lot faster than another goroutine.  This is probably just a difference in the scheduler on gccgo and/or the load on the machine.  There doesn't seem to be any need to test that stop actually stops the goroutines in some amount of time... that's not what the test is for, so I just removed that error and made the loops in the goroutine run forever.  To make it a little more stressful, I created 4 goroutines sending messages, and added code to wait for the goroutines to start up.  In theory the time.sleep(1ms) should do that, but it's not guaranteed, so I used a waitgroup to ensure that they're actually going.

I cleaned up the production code some... it was an unexported type being returned from an exported function, which is a no-no.  I also removed some extraneous fields from StringForwarder that aren't actually needed by the type itself.  I renamed Receive to Forward, since it's a forwarder, not a receiver, and that value was being assigned to a field named forward anyway.

Finally, I removed the re-entrant code on Stop, since it would be easy to think that Stop was now able to be called from multiple goroutines, which it is not (unless we added mutexes to it).  Being able to call Stop multiple times is not something we need to do, and so there's no reason to allow it.  if we later need a way to get the count after stopping, it's easy enough to add a Count() method, but for now, we don't need it.