### PR TITLE
lp1561611: Use controller region for hosted models

### DIFF
--- a/controller/modelmanager/createmodel_test.go
+++ b/controller/modelmanager/createmodel_test.go
@@ -296,7 +296,7 @@ func (*RestrictedProviderFieldsSuite) TestRestrictedProviderFields(c *gc.C) {
 	}, {
 		provider: "joyent",
 		expected: []string{
-			"type", "ca-cert", "state-port", "api-port", "controller-uuid",
+			"type", "ca-cert", "state-port", "api-port", "controller-uuid", "sdc-url",
 		},
 	}, {
 		provider: "maas",

--- a/provider/joyent/provider.go
+++ b/provider/joyent/provider.go
@@ -30,7 +30,7 @@ var _ simplestreams.HasRegion = (*joyentEnviron)(nil)
 
 // RestrictedConfigAttributes is specified in the EnvironProvider interface.
 func (joyentProvider) RestrictedConfigAttributes() []string {
-	return nil
+	return []string{sdcUrl}
 }
 
 // PrepareForCreateEnvironment is specified in the EnvironProvider interface.


### PR DESCRIPTION
Hosted models in joyent were not using the same
region as the controller.  sdc-url should not be
overwritten / set to default for hosted models.

(Review request: http://reviews.vapour.ws/r/4340/)