### PR TITLE
Migration flag apiserver/api/worker

### DIFF
--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -49,6 +49,7 @@ var facadeVersions = map[string]int{
 	"MetricsAdder":                 2,
 	"MetricsDebug":                 1,
 	"MetricsManager":               1,
+	"MigrationFlag":                1,
 	"MigrationMaster":              1,
 	"MigrationMasterWatcher":       1,
 	"MigrationMinion":              1,

--- a/api/migrationflag/facade.go
+++ b/api/migrationflag/facade.go
@@ -1,0 +1,88 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package migrationflag
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/names"
+
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/migration"
+	"github.com/juju/juju/watcher"
+)
+
+// NewWatcherFunc exists to let us unit test Facade without patching.
+type NewWatcherFunc func(base.APICaller, params.NotifyWatchResult) watcher.NotifyWatcher
+
+// NewFacade returns a Facade backed by the supplied api caller.
+func NewFacade(apiCaller base.APICaller, newWatcher NewWatcherFunc) *Facade {
+	facadeCaller := base.NewFacadeCaller(apiCaller, "MigrationFlag")
+	return &Facade{
+		caller:     facadeCaller,
+		newWatcher: newWatcher,
+	}
+}
+
+// Facade lets a client watch and query a model's migration phase.
+type Facade struct {
+	caller     base.FacadeCaller
+	newWatcher NewWatcherFunc
+}
+
+// Phase returns the current migration.Phase for the supplied model UUID.
+func (facade *Facade) Phase(uuid string) (migration.Phase, error) {
+	results := params.PhaseResults{}
+	err := facade.call("Phase", uuid, &results)
+	if err != nil {
+		return migration.UNKNOWN, errors.Trace(err)
+	}
+	if count := len(results.Results); count != 1 {
+		return migration.UNKNOWN, countError(count)
+	}
+	result := results.Results[0]
+	if result.Error != nil {
+		return migration.UNKNOWN, errors.Trace(result.Error)
+	}
+	phase, ok := migration.ParsePhase(result.Phase)
+	if !ok {
+		err := errors.Errorf("unknown phase %q", result.Phase)
+		return migration.UNKNOWN, err
+	}
+	return phase, nil
+}
+
+// Watch returns a NotifyWatcher that will inform of potential changes
+// to the result of Phase for the supplied model UUID.
+func (facade *Facade) Watch(uuid string) (watcher.NotifyWatcher, error) {
+	results := params.NotifyWatchResults{}
+	err := facade.call("Watch", uuid, &results)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if count := len(results.Results); count != 1 {
+		return nil, countError(count)
+	}
+	result := results.Results[0]
+	if result.Error != nil {
+		return nil, errors.Trace(result.Error)
+	}
+	apiCaller := facade.caller.RawAPICaller()
+	watcher := facade.newWatcher(apiCaller, result)
+	return watcher, nil
+}
+
+// call converts the supplied model uuid into a params.Entities and
+// invokes the facade caller.
+func (facade *Facade) call(name, uuid string, results interface{}) error {
+	model := names.NewModelTag(uuid).String()
+	args := params.Entities{[]params.Entity{{model}}}
+	err := facade.caller.FacadeCall(name, args, results)
+	return errors.Trace(err)
+}
+
+// countError complains about malformed results.
+func countError(count int) error {
+	return errors.Errorf("expected 1 result, got %d", count)
+}

--- a/api/migrationflag/facade_test.go
+++ b/api/migrationflag/facade_test.go
@@ -1,0 +1,236 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package migrationflag_test
+
+import (
+	"errors"
+
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/api/base"
+	basetesting "github.com/juju/juju/api/base/testing"
+	"github.com/juju/juju/api/migrationflag"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/migration"
+	"github.com/juju/juju/watcher"
+)
+
+type FacadeSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&FacadeSuite{})
+
+func (*FacadeSuite) TestPhaseCallError(c *gc.C) {
+	stub := &testing.Stub{}
+	apiCaller := apiCaller(c, stub, func(interface{}) error {
+		return errors.New("bork")
+	})
+	facade := migrationflag.NewFacade(apiCaller, nil)
+
+	phase, err := facade.Phase(someUUID)
+	c.Check(err, gc.ErrorMatches, "bork")
+	c.Check(phase, gc.Equals, migration.UNKNOWN)
+	checkCalls(c, stub, "Phase")
+}
+
+func (*FacadeSuite) TestPhaseNoResults(c *gc.C) {
+	stub := &testing.Stub{}
+	apiCaller := apiCaller(c, stub, func(interface{}) error {
+		return nil
+	})
+	facade := migrationflag.NewFacade(apiCaller, nil)
+
+	phase, err := facade.Phase(someUUID)
+	c.Check(err, gc.ErrorMatches, "expected 1 result, got 0")
+	c.Check(phase, gc.Equals, migration.UNKNOWN)
+	checkCalls(c, stub, "Phase")
+}
+
+func (*FacadeSuite) TestPhaseExtraResults(c *gc.C) {
+	stub := &testing.Stub{}
+	apiCaller := apiCaller(c, stub, func(response interface{}) error {
+		outPtr, ok := response.(*params.PhaseResults)
+		c.Assert(ok, jc.IsTrue)
+		outPtr.Results = []params.PhaseResult{
+			{Phase: "ABORT"},
+			{Phase: "DONE"},
+		}
+		return nil
+	})
+	facade := migrationflag.NewFacade(apiCaller, nil)
+
+	phase, err := facade.Phase(someUUID)
+	c.Check(err, gc.ErrorMatches, "expected 1 result, got 2")
+	c.Check(phase, gc.Equals, migration.UNKNOWN)
+	checkCalls(c, stub, "Phase")
+}
+
+func (*FacadeSuite) TestPhaseError(c *gc.C) {
+	stub := &testing.Stub{}
+	apiCaller := apiCaller(c, stub, func(response interface{}) error {
+		outPtr, ok := response.(*params.PhaseResults)
+		c.Assert(ok, jc.IsTrue)
+		outPtr.Results = []params.PhaseResult{
+			{Error: &params.Error{Message: "mneh"}},
+		}
+		return nil
+	})
+	facade := migrationflag.NewFacade(apiCaller, nil)
+
+	phase, err := facade.Phase(someUUID)
+	c.Check(err, gc.ErrorMatches, "mneh")
+	c.Check(phase, gc.Equals, migration.UNKNOWN)
+	checkCalls(c, stub, "Phase")
+}
+
+func (*FacadeSuite) TestPhaseInvalid(c *gc.C) {
+	stub := &testing.Stub{}
+	apiCaller := apiCaller(c, stub, func(response interface{}) error {
+		outPtr, ok := response.(*params.PhaseResults)
+		c.Assert(ok, jc.IsTrue)
+		outPtr.Results = []params.PhaseResult{{Phase: "COLLABORATE"}}
+		return nil
+	})
+	facade := migrationflag.NewFacade(apiCaller, nil)
+
+	phase, err := facade.Phase(someUUID)
+	c.Check(err, gc.ErrorMatches, `unknown phase "COLLABORATE"`)
+	c.Check(phase, gc.Equals, migration.UNKNOWN)
+	checkCalls(c, stub, "Phase")
+}
+
+func (*FacadeSuite) TestPhaseSuccess(c *gc.C) {
+	stub := &testing.Stub{}
+	apiCaller := apiCaller(c, stub, func(response interface{}) error {
+		outPtr, ok := response.(*params.PhaseResults)
+		c.Assert(ok, jc.IsTrue)
+		outPtr.Results = []params.PhaseResult{{Phase: "ABORT"}}
+		return nil
+	})
+	facade := migrationflag.NewFacade(apiCaller, nil)
+
+	phase, err := facade.Phase(someUUID)
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(phase, gc.Equals, migration.ABORT)
+	checkCalls(c, stub, "Phase")
+}
+
+func (*FacadeSuite) TestWatchCallError(c *gc.C) {
+	stub := &testing.Stub{}
+	apiCaller := apiCaller(c, stub, func(interface{}) error {
+		return errors.New("bork")
+	})
+	facade := migrationflag.NewFacade(apiCaller, nil)
+
+	watch, err := facade.Watch(someUUID)
+	c.Check(err, gc.ErrorMatches, "bork")
+	c.Check(watch, gc.IsNil)
+	checkCalls(c, stub, "Watch")
+}
+
+func (*FacadeSuite) TestWatchNoResults(c *gc.C) {
+	stub := &testing.Stub{}
+	apiCaller := apiCaller(c, stub, func(interface{}) error {
+		return nil
+	})
+	facade := migrationflag.NewFacade(apiCaller, nil)
+
+	watch, err := facade.Watch(someUUID)
+	c.Check(err, gc.ErrorMatches, "expected 1 result, got 0")
+	c.Check(watch, gc.IsNil)
+	checkCalls(c, stub, "Watch")
+}
+
+func (*FacadeSuite) TestWatchExtraResults(c *gc.C) {
+	stub := &testing.Stub{}
+	apiCaller := apiCaller(c, stub, func(response interface{}) error {
+		outPtr, ok := response.(*params.NotifyWatchResults)
+		c.Assert(ok, jc.IsTrue)
+		outPtr.Results = []params.NotifyWatchResult{
+			{NotifyWatcherId: "123"},
+			{NotifyWatcherId: "456"},
+		}
+		return nil
+	})
+	facade := migrationflag.NewFacade(apiCaller, nil)
+
+	watch, err := facade.Watch(someUUID)
+	c.Check(err, gc.ErrorMatches, "expected 1 result, got 2")
+	c.Check(watch, gc.IsNil)
+	checkCalls(c, stub, "Watch")
+}
+
+func (*FacadeSuite) TestWatchError(c *gc.C) {
+	stub := &testing.Stub{}
+	apiCaller := apiCaller(c, stub, func(response interface{}) error {
+		outPtr, ok := response.(*params.NotifyWatchResults)
+		c.Assert(ok, jc.IsTrue)
+		outPtr.Results = []params.NotifyWatchResult{
+			{Error: &params.Error{Message: "snfl"}},
+		}
+		return nil
+	})
+	facade := migrationflag.NewFacade(apiCaller, nil)
+
+	watch, err := facade.Watch(someUUID)
+	c.Check(err, gc.ErrorMatches, "snfl")
+	c.Check(watch, gc.IsNil)
+	checkCalls(c, stub, "Watch")
+}
+
+func (*FacadeSuite) TestWatchSuccess(c *gc.C) {
+	stub := &testing.Stub{}
+	apiCaller := apiCaller(c, stub, func(response interface{}) error {
+		outPtr, ok := response.(*params.NotifyWatchResults)
+		c.Assert(ok, jc.IsTrue)
+		outPtr.Results = []params.NotifyWatchResult{
+			{NotifyWatcherId: "789"},
+		}
+		return nil
+	})
+	expectWatch := &struct{ watcher.NotifyWatcher }{}
+	newWatcher := func(gotCaller base.APICaller, result params.NotifyWatchResult) watcher.NotifyWatcher {
+		c.Check(gotCaller, gc.NotNil) // uncomparable
+		c.Check(result, jc.DeepEquals, params.NotifyWatchResult{
+			NotifyWatcherId: "789",
+		})
+		return expectWatch
+	}
+	facade := migrationflag.NewFacade(apiCaller, newWatcher)
+
+	watch, err := facade.Watch(someUUID)
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(watch, gc.Equals, expectWatch)
+	checkCalls(c, stub, "Watch")
+}
+
+func apiCaller(c *gc.C, stub *testing.Stub, set func(interface{}) error) base.APICaller {
+	return basetesting.APICallerFunc(func(
+		objType string, version int,
+		id, request string,
+		args, response interface{},
+	) error {
+		c.Check(objType, gc.Equals, "MigrationFlag")
+		c.Check(version, gc.Equals, 0)
+		c.Check(id, gc.Equals, "")
+		stub.AddCall(request, args)
+		return set(response)
+	})
+}
+
+func checkCalls(c *gc.C, stub *testing.Stub, names ...string) {
+	stub.CheckCallNames(c, names...)
+	for _, call := range stub.Calls() {
+		c.Check(call.Args, jc.DeepEquals, []interface{}{
+			params.Entities{
+				[]params.Entity{{"model-some-uuid"}},
+			},
+		})
+	}
+}
+
+const someUUID = "some-uuid"

--- a/api/migrationflag/package_test.go
+++ b/api/migrationflag/package_test.go
@@ -1,7 +1,7 @@
 // Copyright 2016 Canonical Ltd.
 // Licensed under the LGPLv3, see LICENCE file for details.
 
-package migrationmaster_test
+package migrationflag_test
 
 import (
 	stdtesting "testing"

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -36,6 +36,7 @@ import (
 	_ "github.com/juju/juju/apiserver/metricsadder"
 	_ "github.com/juju/juju/apiserver/metricsdebug"
 	_ "github.com/juju/juju/apiserver/metricsmanager"
+	_ "github.com/juju/juju/apiserver/migrationflag"
 	_ "github.com/juju/juju/apiserver/migrationmaster"
 	_ "github.com/juju/juju/apiserver/migrationminion"
 	_ "github.com/juju/juju/apiserver/migrationtarget"

--- a/apiserver/migrationflag/facade.go
+++ b/apiserver/migrationflag/facade.go
@@ -1,0 +1,97 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package migrationflag
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/migration"
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/state/watcher"
+	"github.com/juju/names"
+)
+
+type Backend interface {
+	ModelUUID() string
+	MigrationPhase() (migration.Phase, error)
+	WatchMigrationPhase() (state.NotifyWatcher, error)
+}
+
+type Facade struct {
+	backend   Backend
+	resources *common.Resources
+}
+
+func New(backend Backend, auth common.Authorizer, resources *common.Resources) (*Facade, error) {
+	if !auth.AuthMachineAgent() && !auth.AuthUnitAgent() {
+		return nil, common.ErrPerm
+	}
+	return &Facade{
+		backend:   backend,
+		resources: resources,
+	}, nil
+}
+
+func (facade *Facade) auth(tagString string) error {
+	tag, err := names.ParseModelTag(tagString)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if tag.Id() != facade.backend.ModelUUID() {
+		return common.ErrPerm
+	}
+	return nil
+}
+
+func (facade *Facade) Phase(entities params.Entities) params.PhaseResults {
+	count := len(entities.Entities)
+	results := params.PhaseResults{
+		Results: make([]params.PhaseResult, count),
+	}
+	for i, entity := range entities.Entities {
+		phase, err := facade.onePhase(entity.Tag)
+		results.Results[i].Phase = phase
+		results.Results[i].Error = common.ServerError(err)
+	}
+	return results
+}
+
+func (facade *Facade) onePhase(tagString string) (string, error) {
+	if err := facade.auth(tagString); err != nil {
+		return "", errors.Trace(err)
+	}
+	phase, err := facade.backend.MigrationPhase()
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	return phase.String(), nil
+}
+
+func (facade *Facade) Watch(entities params.Entities) params.NotifyWatchResults {
+	count := len(entities.Entities)
+	results := params.NotifyWatchResults{
+		Results: make([]params.NotifyWatchResult, count),
+	}
+	for i, entity := range entities.Entities {
+		id, err := facade.oneWatch(entity.Tag)
+		results.Results[i].NotifyWatcherId = id
+		results.Results[i].Error = common.ServerError(err)
+	}
+	return results
+}
+
+func (facade *Facade) oneWatch(tagString string) (string, error) {
+	if err := facade.auth(tagString); err != nil {
+		return "", errors.Trace(err)
+	}
+	watch, err := facade.backend.WatchMigrationPhase()
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	if _, ok := <-watch.Changes(); ok {
+		return facade.resources.Register(watch), nil
+	}
+	return "", watcher.EnsureErr(watch)
+}

--- a/apiserver/migrationflag/facade.go
+++ b/apiserver/migrationflag/facade.go
@@ -24,7 +24,7 @@ type Facade struct {
 	resources *common.Resources
 }
 
-func New(backend Backend, auth common.Authorizer, resources *common.Resources) (*Facade, error) {
+func New(backend Backend, resources *common.Resources, auth common.Authorizer) (*Facade, error) {
 	if !auth.AuthMachineAgent() && !auth.AuthUnitAgent() {
 		return nil, common.ErrPerm
 	}

--- a/apiserver/migrationflag/facade.go
+++ b/apiserver/migrationflag/facade.go
@@ -5,12 +5,13 @@ package migrationflag
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/names"
+
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/migration"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/watcher"
-	"github.com/juju/names"
 )
 
 // Backend exposes information about any current model migrations.

--- a/apiserver/migrationflag/facade_test.go
+++ b/apiserver/migrationflag/facade_test.go
@@ -22,19 +22,19 @@ type FacadeSuite struct {
 var _ = gc.Suite(&FacadeSuite{})
 
 func (*FacadeSuite) TestAcceptsMachineAgent(c *gc.C) {
-	facade, err := migrationflag.New(nil, agentAuth{machine: true}, nil)
+	facade, err := migrationflag.New(nil, nil, agentAuth{machine: true})
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(facade, gc.NotNil)
 }
 
 func (*FacadeSuite) TestAcceptsUnitAgent(c *gc.C) {
-	facade, err := migrationflag.New(nil, agentAuth{machine: true}, nil)
+	facade, err := migrationflag.New(nil, nil, agentAuth{machine: true})
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(facade, gc.NotNil)
 }
 
 func (*FacadeSuite) TestRejectsNonAgent(c *gc.C) {
-	facade, err := migrationflag.New(nil, agentAuth{}, nil)
+	facade, err := migrationflag.New(nil, nil, agentAuth{})
 	c.Check(err, gc.Equals, common.ErrPerm)
 	c.Check(facade, gc.IsNil)
 }
@@ -42,7 +42,7 @@ func (*FacadeSuite) TestRejectsNonAgent(c *gc.C) {
 func (*FacadeSuite) TestPhaseSuccess(c *gc.C) {
 	stub := &testing.Stub{}
 	backend := newMockBackend(stub)
-	facade, err := migrationflag.New(backend, authOK, nil)
+	facade, err := migrationflag.New(backend, nil, authOK)
 	c.Assert(err, jc.ErrorIsNil)
 
 	results := facade.Phase(entities(
@@ -62,7 +62,7 @@ func (*FacadeSuite) TestPhaseErrors(c *gc.C) {
 	stub := &testing.Stub{}
 	stub.SetErrors(errors.New("ouch"))
 	backend := newMockBackend(stub)
-	facade, err := migrationflag.New(backend, authOK, nil)
+	facade, err := migrationflag.New(backend, nil, authOK)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// 3 entities: unparseable, unauthorized, call error.
@@ -92,7 +92,7 @@ func (*FacadeSuite) TestWatchSuccess(c *gc.C) {
 	stub := &testing.Stub{}
 	backend := newMockBackend(stub)
 	resources := common.NewResources()
-	facade, err := migrationflag.New(backend, authOK, resources)
+	facade, err := migrationflag.New(backend, resources, authOK)
 	c.Assert(err, jc.ErrorIsNil)
 
 	results := facade.Watch(entities(
@@ -119,7 +119,7 @@ func (*FacadeSuite) TestWatchErrors(c *gc.C) {
 	stub.SetErrors(errors.New("blort"), nil, errors.New("squish"))
 	backend := newMockBackend(stub)
 	resources := common.NewResources()
-	facade, err := migrationflag.New(backend, authOK, resources)
+	facade, err := migrationflag.New(backend, resources, authOK)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// 4 entities: unparseable, unauthorized, watch error, closed chan.

--- a/apiserver/migrationflag/facade_test.go
+++ b/apiserver/migrationflag/facade_test.go
@@ -1,0 +1,151 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package migrationflag_test
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/migrationflag"
+	"github.com/juju/juju/apiserver/params"
+	coretesting "github.com/juju/juju/testing"
+)
+
+type FacadeSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&FacadeSuite{})
+
+func (*FacadeSuite) TestAcceptsMachineAgent(c *gc.C) {
+	facade, err := migrationflag.New(nil, agentAuth{machine: true}, nil)
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(facade, gc.NotNil)
+}
+
+func (*FacadeSuite) TestAcceptsUnitAgent(c *gc.C) {
+	facade, err := migrationflag.New(nil, agentAuth{machine: true}, nil)
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(facade, gc.NotNil)
+}
+
+func (*FacadeSuite) TestRejectsNonAgent(c *gc.C) {
+	facade, err := migrationflag.New(nil, agentAuth{}, nil)
+	c.Check(err, gc.Equals, common.ErrPerm)
+	c.Check(facade, gc.IsNil)
+}
+
+func (*FacadeSuite) TestPhaseSuccess(c *gc.C) {
+	stub := &testing.Stub{}
+	backend := newMockBackend(stub)
+	facade, err := migrationflag.New(backend, authOK, nil)
+	c.Assert(err, jc.ErrorIsNil)
+
+	results := facade.Phase(entities(
+		coretesting.ModelTag.String(),
+		coretesting.ModelTag.String(),
+	))
+	c.Assert(results.Results, gc.HasLen, 2)
+	stub.CheckCallNames(c, "MigrationPhase", "MigrationPhase")
+
+	for _, result := range results.Results {
+		c.Check(result.Error, gc.IsNil)
+		c.Check(result.Phase, gc.Equals, "REAP")
+	}
+}
+
+func (*FacadeSuite) TestPhaseErrors(c *gc.C) {
+	stub := &testing.Stub{}
+	stub.SetErrors(errors.New("ouch"))
+	backend := newMockBackend(stub)
+	facade, err := migrationflag.New(backend, authOK, nil)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// 3 entities: unparseable, unauthorized, call error.
+	results := facade.Phase(entities(
+		"urgle",
+		unknownModel,
+		coretesting.ModelTag.String(),
+	))
+	c.Assert(results.Results, gc.HasLen, 3)
+	stub.CheckCallNames(c, "MigrationPhase")
+
+	c.Check(results.Results, jc.DeepEquals, []params.PhaseResult{{
+		Error: &params.Error{
+			Message: `"urgle" is not a valid tag`,
+		}}, {
+		Error: &params.Error{
+			Message: "permission denied",
+			Code:    "unauthorized access",
+		}}, {
+		Error: &params.Error{
+			Message: "ouch",
+		},
+	}})
+}
+
+func (*FacadeSuite) TestWatchSuccess(c *gc.C) {
+	stub := &testing.Stub{}
+	backend := newMockBackend(stub)
+	resources := common.NewResources()
+	facade, err := migrationflag.New(backend, authOK, resources)
+	c.Assert(err, jc.ErrorIsNil)
+
+	results := facade.Watch(entities(
+		coretesting.ModelTag.String(),
+		coretesting.ModelTag.String(),
+	))
+	c.Assert(results.Results, gc.HasLen, 2)
+	stub.CheckCallNames(c, "WatchMigrationPhase", "WatchMigrationPhase")
+
+	check := func(result params.NotifyWatchResult) {
+		c.Check(result.Error, gc.IsNil)
+		resource := resources.Get(result.NotifyWatcherId)
+		c.Check(resource, gc.NotNil)
+	}
+	first := results.Results[0]
+	second := results.Results[1]
+	check(first)
+	check(second)
+	c.Check(first.NotifyWatcherId, gc.Not(gc.Equals), second.NotifyWatcherId)
+}
+
+func (*FacadeSuite) TestWatchErrors(c *gc.C) {
+	stub := &testing.Stub{}
+	stub.SetErrors(errors.New("blort"), nil, errors.New("squish"))
+	backend := newMockBackend(stub)
+	resources := common.NewResources()
+	facade, err := migrationflag.New(backend, authOK, resources)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// 4 entities: unparseable, unauthorized, watch error, closed chan.
+	results := facade.Watch(entities(
+		"urgle",
+		unknownModel,
+		coretesting.ModelTag.String(),
+		coretesting.ModelTag.String(),
+	))
+	c.Assert(results.Results, gc.HasLen, 4)
+	stub.CheckCallNames(c, "WatchMigrationPhase", "WatchMigrationPhase")
+
+	c.Check(results.Results, jc.DeepEquals, []params.NotifyWatchResult{{
+		Error: &params.Error{
+			Message: `"urgle" is not a valid tag`,
+		}}, {
+		Error: &params.Error{
+			Message: "permission denied",
+			Code:    "unauthorized access",
+		}}, {
+		Error: &params.Error{
+			Message: "blort",
+		}}, {
+		Error: &params.Error{
+			Message: "squish",
+		},
+	}})
+	c.Check(resources.Count(), gc.Equals, 0)
+}

--- a/apiserver/migrationflag/package_test.go
+++ b/apiserver/migrationflag/package_test.go
@@ -1,7 +1,7 @@
 // Copyright 2016 Canonical Ltd.
 // Licensed under the LGPLv3, see LICENCE file for details.
 
-package migrationmaster_test
+package migrationflag_test
 
 import (
 	stdtesting "testing"

--- a/apiserver/migrationflag/shim.go
+++ b/apiserver/migrationflag/shim.go
@@ -1,0 +1,54 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package migrationflag
+
+import (
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/core/migration"
+	"github.com/juju/juju/state"
+)
+
+func init() {
+	common.RegisterStandardFacade("MigrationFlag", 1, newFacade)
+}
+
+func newFacade(st *state.State, resources *common.Resources, auth common.Authorizer) (*Facade, error) {
+	facade, err := New(&backend{st}, resources, auth)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return facade, nil
+}
+
+type backend struct {
+	st *state.State
+}
+
+func (shim *backend) ModelUUID() string {
+	return shim.st.ModelUUID()
+}
+
+func (shim *backend) WatchMigrationPhase() (state.NotifyWatcher, error) {
+	watcher, err := shim.st.WatchMigrationStatus()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return watcher, nil
+}
+
+func (shim *backend) MigrationPhase() (migration.Phase, error) {
+	mig, err := shim.st.GetModelMigration()
+	if errors.IsNotFound(err) {
+		return migration.NONE, nil
+	} else if err != nil {
+		return migration.UNKNOWN, errors.Trace(err)
+	}
+	phase, err := mig.Phase()
+	if err != nil {
+		return migration.UNKNOWN, errors.Trace(err)
+	}
+	return phase, nil
+}

--- a/apiserver/migrationflag/shim.go
+++ b/apiserver/migrationflag/shim.go
@@ -15,6 +15,7 @@ func init() {
 	common.RegisterStandardFacade("MigrationFlag", 1, newFacade)
 }
 
+// newFacade wraps New to express the supplied *state.State as a Backend.
 func newFacade(st *state.State, resources *common.Resources, auth common.Authorizer) (*Facade, error) {
 	facade, err := New(&backend{st}, resources, auth)
 	if err != nil {
@@ -23,14 +24,17 @@ func newFacade(st *state.State, resources *common.Resources, auth common.Authori
 	return facade, nil
 }
 
+// backend implements Backend by wrapping a *state.State.
 type backend struct {
 	st *state.State
 }
 
+// ModelUUID is part of the Backend interface.
 func (shim *backend) ModelUUID() string {
 	return shim.st.ModelUUID()
 }
 
+// WatchMigrationPhase is part of the Backend interface.
 func (shim *backend) WatchMigrationPhase() (state.NotifyWatcher, error) {
 	watcher, err := shim.st.WatchMigrationStatus()
 	if err != nil {
@@ -39,6 +43,7 @@ func (shim *backend) WatchMigrationPhase() (state.NotifyWatcher, error) {
 	return watcher, nil
 }
 
+// MigrationPhase is part of the Backend interface.
 func (shim *backend) MigrationPhase() (migration.Phase, error) {
 	mig, err := shim.st.GetModelMigration()
 	if errors.IsNotFound(err) {

--- a/apiserver/migrationflag/util_test.go
+++ b/apiserver/migrationflag/util_test.go
@@ -1,0 +1,100 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package migrationflag_test
+
+import (
+	"github.com/juju/testing"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/migration"
+	"github.com/juju/juju/state"
+	coretesting "github.com/juju/juju/testing"
+)
+
+type agentAuth struct {
+	common.Authorizer
+	machine bool
+	unit    bool
+}
+
+var authOK = agentAuth{machine: true}
+
+func (auth agentAuth) AuthMachineAgent() bool {
+	return auth.machine
+}
+
+func (auth agentAuth) AuthUnitAgent() bool {
+	return auth.unit
+}
+
+func newMockBackend(stub *testing.Stub) *mockBackend {
+	return &mockBackend{
+		stub: stub,
+	}
+}
+
+type mockBackend struct {
+	stub *testing.Stub
+}
+
+func (mock *mockBackend) ModelUUID() string {
+	return coretesting.ModelTag.Id()
+}
+
+func (mock *mockBackend) MigrationPhase() (migration.Phase, error) {
+	mock.stub.AddCall("MigrationPhase")
+	if err := mock.stub.NextErr(); err != nil {
+		return migration.UNKNOWN, err
+	}
+	return migration.REAP, nil
+}
+
+func (mock *mockBackend) WatchMigrationPhase() (state.NotifyWatcher, error) {
+	mock.stub.AddCall("WatchMigrationPhase")
+	if err := mock.stub.NextErr(); err != nil {
+		return nil, err
+	}
+	return newMockWatcher(mock.stub), nil
+}
+
+func newMockWatcher(stub *testing.Stub) *mockWatcher {
+	changes := make(chan struct{}, 1)
+	err := stub.NextErr()
+	if err == nil {
+		changes <- struct{}{}
+	} else {
+		close(changes)
+	}
+	return &mockWatcher{
+		err:     err,
+		changes: changes,
+	}
+}
+
+type mockWatcher struct {
+	state.NotifyWatcher
+	changes chan struct{}
+	err     error
+}
+
+func (mock *mockWatcher) Changes() <-chan struct{} {
+	return mock.changes
+}
+
+func (mock *mockWatcher) Err() error {
+	return mock.err
+}
+
+const unknownModel = "model-01234567-89ab-cdef-0123-456789abcdef"
+
+func entities(tags ...string) params.Entities {
+	entities := params.Entities{
+		Entities: make([]params.Entity, len(tags)),
+	}
+	for i, tag := range tags {
+		entities.Entities[i].Tag = tag
+	}
+	return entities
+}

--- a/apiserver/migrationflag/util_test.go
+++ b/apiserver/migrationflag/util_test.go
@@ -13,36 +13,43 @@ import (
 	coretesting "github.com/juju/juju/testing"
 )
 
+// agentAuth implements common.Authorizer for use in the tests.
 type agentAuth struct {
 	common.Authorizer
 	machine bool
 	unit    bool
 }
 
-var authOK = agentAuth{machine: true}
-
+// AuthMachineAgent is part of the common.Authorizer interface.
 func (auth agentAuth) AuthMachineAgent() bool {
 	return auth.machine
 }
 
+// AuthUnitAgent is part of the common.Authorizer interface.
 func (auth agentAuth) AuthUnitAgent() bool {
 	return auth.unit
 }
 
+// newMockBackend returns a mock Backend that will add calls to the
+// supplied testing.Stub, and return errors in the sequence it
+// specifies.
 func newMockBackend(stub *testing.Stub) *mockBackend {
 	return &mockBackend{
 		stub: stub,
 	}
 }
 
+// mockBackend implements migrationflag.Backend for use in the tests.
 type mockBackend struct {
 	stub *testing.Stub
 }
 
+// ModelUUID is part of the migrationflag.Backend interface.
 func (mock *mockBackend) ModelUUID() string {
 	return coretesting.ModelTag.Id()
 }
 
+// MigrationPhase is part of the migrationflag.Backend interface.
 func (mock *mockBackend) MigrationPhase() (migration.Phase, error) {
 	mock.stub.AddCall("MigrationPhase")
 	if err := mock.stub.NextErr(); err != nil {
@@ -51,6 +58,7 @@ func (mock *mockBackend) MigrationPhase() (migration.Phase, error) {
 	return migration.REAP, nil
 }
 
+// WatchMigrationPhase is part of the migrationflag.Backend interface.
 func (mock *mockBackend) WatchMigrationPhase() (state.NotifyWatcher, error) {
 	mock.stub.AddCall("WatchMigrationPhase")
 	if err := mock.stub.NextErr(); err != nil {
@@ -59,6 +67,9 @@ func (mock *mockBackend) WatchMigrationPhase() (state.NotifyWatcher, error) {
 	return newMockWatcher(mock.stub), nil
 }
 
+// newMockWatcher consumes an error from the supplied testing.Stub, and
+// returns a state.NotifyWatcher that either works or doesn't depending
+// on whether the error was nil.
 func newMockWatcher(stub *testing.Stub) *mockWatcher {
 	changes := make(chan struct{}, 1)
 	err := stub.NextErr()
@@ -73,22 +84,24 @@ func newMockWatcher(stub *testing.Stub) *mockWatcher {
 	}
 }
 
+// mockWatcher implements state.NotifyWatcher for use in the tests.
 type mockWatcher struct {
 	state.NotifyWatcher
 	changes chan struct{}
 	err     error
 }
 
+// Changes is part of the state.NotifyWatcher interface.
 func (mock *mockWatcher) Changes() <-chan struct{} {
 	return mock.changes
 }
 
+// Err is part of the state.NotifyWatcher interface.
 func (mock *mockWatcher) Err() error {
 	return mock.err
 }
 
-const unknownModel = "model-01234567-89ab-cdef-0123-456789abcdef"
-
+// entities is a convenience constructor for params.Entities.
 func entities(tags ...string) params.Entities {
 	entities := params.Entities{
 		Entities: make([]params.Entity, len(tags)),
@@ -98,3 +111,9 @@ func entities(tags ...string) params.Entities {
 	}
 	return entities
 }
+
+// authOK will always authenticate successfully.
+var authOK = agentAuth{machine: true}
+
+// unknownModel is expected to induce a permissions error.
+const unknownModel = "model-01234567-89ab-cdef-0123-456789abcdef"

--- a/apiserver/params/migration.go
+++ b/apiserver/params/migration.go
@@ -23,10 +23,20 @@ type ModelArgs struct {
 
 // MigrationStatus reports the current status of a model migration.
 type MigrationStatus struct {
-	Attempt        int             `json:"attempt"`
+	Attempt int `json:"attempt"`
+	// TODO(fwereade): shouldn't Phase be a string?
 	Phase          migration.Phase `json:"phase"`
 	SourceAPIAddrs []string        `json:"source-api-addrs"`
 	SourceCACert   string          `json:"source-ca-cert"`
 	TargetAPIAddrs []string        `json:"target-api-addrs"`
 	TargetCACert   string          `json:"target-ca-cert"`
+}
+
+type PhaseResult struct {
+	Phase string `json:"phase"`
+	Error *Error
+}
+
+type PhaseResults struct {
+	Results []PhaseResult `json:"Results"`
 }

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -2720,34 +2720,21 @@ func (w *migrationActiveWatcher) loop() error {
 //
 // Note that this watcher does not produce an initial event if there's
 // never been a migration attempt for the model.
-//
-// TODO(fwereade): this is hard to justify. Presumably it's so that we
-// don't have to write a MigrationStatus type that can express that no
-// migration is in progress? I really don't think it's worth the costs.
 func (st *State) WatchMigrationStatus() (NotifyWatcher, error) {
-	return newMigrationStatusWatcher(st, true), nil
-}
-
-// WatchMigrationPhase is like WatchMigrationStatus but it returns a
-// watcher that really behaves like a Watcher, rather than just some
-// type with a Changes channel.
-func (st *State) WatchMigrationPhase() (NotifyWatcher, error) {
-	return newMigrationStatusWatcher(st, false), nil
+	return newMigrationStatusWatcher(st), nil
 }
 
 type migrationStatusWatcher struct {
 	commonWatcher
 	collName string
 	sink     chan struct{}
-	insane   bool
 }
 
-func newMigrationStatusWatcher(st *State, insane bool) NotifyWatcher {
+func newMigrationStatusWatcher(st *State) NotifyWatcher {
 	w := &migrationStatusWatcher{
 		commonWatcher: commonWatcher{st: st},
 		collName:      modelMigrationStatusC,
 		sink:          make(chan struct{}),
-		insane:        insane,
 	}
 	go func() {
 		defer w.tomb.Done()
@@ -2782,19 +2769,7 @@ func (w *migrationStatusWatcher) loop() error {
 	w.st.watcher.WatchCollectionWithFilter(w.collName, in, filter)
 	defer w.st.watcher.UnwatchCollection(w.collName, in)
 
-	var out chan<- struct{}
-
-	// If we want to break the watcher model, suppress initial events.
-	if w.insane {
-		if _, err := w.st.GetModelMigration(); errors.IsNotFound(err) {
-			// Nothing to report.
-		} else if err != nil {
-			return errors.Trace(err)
-		}
-	} else {
-		out = w.sink
-	}
-
+	out := w.sink // out set so that initial event is sent.
 	for {
 		select {
 		case <-w.tomb.Dying():
@@ -2802,12 +2777,6 @@ func (w *migrationStatusWatcher) loop() error {
 		case <-w.st.watcher.Dead():
 			return stateWatcherDeadError(w.st.watcher.Err())
 		case change := <-in:
-			// TODO(fwereade): why do we have a watcher that acts
-			// so very differently from all the other watchers?
-			// If a migration appears or disappears, that is a
-			// change, and should be reported. It's up to the
-			// client to understand the new state and respond as
-			// appropriate.
 			if change.Revno == -1 {
 				return errors.New("model migration status disappeared (shouldn't happen)")
 			}

--- a/worker/migrationflag/package_test.go
+++ b/worker/migrationflag/package_test.go
@@ -1,7 +1,7 @@
 // Copyright 2016 Canonical Ltd.
 // Licensed under the LGPLv3, see LICENCE file for details.
 
-package migrationmaster_test
+package migrationflag_test
 
 import (
 	stdtesting "testing"

--- a/worker/migrationflag/util_test.go
+++ b/worker/migrationflag/util_test.go
@@ -1,0 +1,110 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package migrationflag_test
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/core/migration"
+	"github.com/juju/juju/watcher"
+	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/migrationflag"
+	"github.com/juju/juju/worker/workertest"
+)
+
+func newMockFacade(stub *testing.Stub, phases ...migration.Phase) *mockFacade {
+	return &mockFacade{
+		stub:   stub,
+		phases: phases,
+	}
+}
+
+type mockFacade struct {
+	stub   *testing.Stub
+	phases []migration.Phase
+}
+
+// Phase is part of the migrationflag.Facade interface.
+func (mock *mockFacade) Phase(uuid string) (migration.Phase, error) {
+	mock.stub.AddCall("Phase", uuid)
+	if err := mock.stub.NextErr(); err != nil {
+		return 0, err
+	}
+	return mock.nextPhase(), nil
+}
+
+func (mock *mockFacade) nextPhase() migration.Phase {
+	phase := mock.phases[0]
+	mock.phases = mock.phases[1:]
+	return phase
+}
+
+// Watch is part of the migrationflag.Facade interface.
+func (mock *mockFacade) Watch(uuid string) (watcher.NotifyWatcher, error) {
+	mock.stub.AddCall("Watch", uuid)
+	if err := mock.stub.NextErr(); err != nil {
+		return nil, err
+	}
+	return newMockWatcher(), nil
+}
+
+func newMockWatcher() *mockWatcher {
+	const count = 3
+	changes := make(chan struct{}, count)
+	for i := 0; i < count; i++ {
+		changes <- struct{}{}
+	}
+	return &mockWatcher{
+		Worker:  workertest.NewErrorWorker(nil),
+		changes: changes,
+	}
+}
+
+type mockWatcher struct {
+	worker.Worker
+	changes chan struct{}
+}
+
+// Changes is part of the watcher.NotifyWatcher interface.
+func (mock *mockWatcher) Changes() watcher.NotifyChannel {
+	return mock.changes
+}
+
+func checkCalls(c *gc.C, stub *testing.Stub, names ...string) {
+	stub.CheckCallNames(c, names...)
+	for _, call := range stub.Calls() {
+		c.Check(call.Args, jc.DeepEquals, []interface{}{validUUID})
+	}
+}
+
+var validUUID = "01234567-89ab-cdef-0123-456789abcdef"
+
+func panicCheck(migration.Phase) bool  { panic("unexpected") }
+func neverCheck(migration.Phase) bool  { return false }
+func isQuiesce(p migration.Phase) bool { return p == migration.QUIESCE }
+
+func validConfig() migrationflag.Config {
+	return migrationflag.Config{
+		Facade: struct{ migrationflag.Facade }{},
+		Model:  validUUID,
+		Check:  panicCheck,
+	}
+}
+
+func checkNotValid(c *gc.C, config migrationflag.Config, expect string) {
+	check := func(err error) {
+		c.Check(err, gc.ErrorMatches, expect)
+		c.Check(err, jc.Satisfies, errors.IsNotValid)
+	}
+
+	err := config.Validate()
+	check(err)
+
+	worker, err := migrationflag.New(config)
+	c.Check(worker, gc.IsNil)
+	check(err)
+}

--- a/worker/migrationflag/util_test.go
+++ b/worker/migrationflag/util_test.go
@@ -16,6 +16,11 @@ import (
 	"github.com/juju/juju/worker/workertest"
 )
 
+// newMockFacade returns a mock Facade that will add calls to the
+// supplied testing.Stub, and return errors in the sequences it
+// specifies; if any Phase call does not return an error, it will
+// return a phase consumed from the head of the supplied list (or
+// panic if it's empty).
 func newMockFacade(stub *testing.Stub, phases ...migration.Phase) *mockFacade {
 	return &mockFacade{
 		stub:   stub,
@@ -23,6 +28,7 @@ func newMockFacade(stub *testing.Stub, phases ...migration.Phase) *mockFacade {
 	}
 }
 
+// mockFacade implements migrationflag.Facade for use in the tests.
 type mockFacade struct {
 	stub   *testing.Stub
 	phases []migration.Phase
@@ -37,6 +43,7 @@ func (mock *mockFacade) Phase(uuid string) (migration.Phase, error) {
 	return mock.nextPhase(), nil
 }
 
+// nextPhase consumes a phase and returns it, or panics.
 func (mock *mockFacade) nextPhase() migration.Phase {
 	phase := mock.phases[0]
 	mock.phases = mock.phases[1:]
@@ -52,6 +59,8 @@ func (mock *mockFacade) Watch(uuid string) (watcher.NotifyWatcher, error) {
 	return newMockWatcher(), nil
 }
 
+// newMockWatcher returns a watcher.NotifyWatcher that always
+// sends 3 changes and then sits quietly until killed.
 func newMockWatcher() *mockWatcher {
 	const count = 3
 	changes := make(chan struct{}, count)
@@ -64,6 +73,7 @@ func newMockWatcher() *mockWatcher {
 	}
 }
 
+// mockWatcher implements watcher.NotifyWatcher for use in the tests.
 type mockWatcher struct {
 	worker.Worker
 	changes chan struct{}
@@ -74,6 +84,8 @@ func (mock *mockWatcher) Changes() watcher.NotifyChannel {
 	return mock.changes
 }
 
+// checkCalls checks that all the supplied call names were invoked
+// in the supplied order, and that every one was passed [validUUID].
 func checkCalls(c *gc.C, stub *testing.Stub, names ...string) {
 	stub.CheckCallNames(c, names...)
 	for _, call := range stub.Calls() {
@@ -81,12 +93,20 @@ func checkCalls(c *gc.C, stub *testing.Stub, names ...string) {
 	}
 }
 
+// validUUID is the model UUID we're using in the tests.
 var validUUID = "01234567-89ab-cdef-0123-456789abcdef"
 
-func panicCheck(migration.Phase) bool  { panic("unexpected") }
-func neverCheck(migration.Phase) bool  { return false }
+// panicCheck is a Config.Check value that should not be called.
+func panicCheck(migration.Phase) bool { panic("unexpected") }
+
+// neverCheck is a Config.Check value that always returns false.
+func neverCheck(migration.Phase) bool { return false }
+
+// isQuiesce is a Config.Check value that returns whether the phase is QUIESCE.
 func isQuiesce(p migration.Phase) bool { return p == migration.QUIESCE }
 
+// validConfig returns a minimal config stuffed with dummy objects that
+// will expose when used.
 func validConfig() migrationflag.Config {
 	return migrationflag.Config{
 		Facade: struct{ migrationflag.Facade }{},
@@ -95,6 +115,8 @@ func validConfig() migrationflag.Config {
 	}
 }
 
+// checkNotValid checks that the supplied migrationflag.Config fails to
+// Validate, and cannot be used to construct a migrationflag.Worker.
 func checkNotValid(c *gc.C, config migrationflag.Config, expect string) {
 	check := func(err error) {
 		c.Check(err, gc.ErrorMatches, expect)

--- a/worker/migrationflag/validate_test.go
+++ b/worker/migrationflag/validate_test.go
@@ -1,0 +1,40 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package migrationflag_test
+
+import (
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+)
+
+type ValidateSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&ValidateSuite{})
+
+func (*ValidateSuite) TestValid(c *gc.C) {
+	config := validConfig()
+	err := config.Validate()
+	c.Check(err, jc.ErrorIsNil)
+}
+
+func (*ValidateSuite) TestNilFacade(c *gc.C) {
+	config := validConfig()
+	config.Facade = nil
+	checkNotValid(c, config, "nil Facade not valid")
+}
+
+func (*ValidateSuite) TestInvalidModel(c *gc.C) {
+	config := validConfig()
+	config.Model = "abcd-1234"
+	checkNotValid(c, config, `Model "abcd-1234" not valid`)
+}
+
+func (*ValidateSuite) TestNilCheck(c *gc.C) {
+	config := validConfig()
+	config.Check = nil
+	checkNotValid(c, config, "nil Check not valid")
+}

--- a/worker/migrationflag/worker.go
+++ b/worker/migrationflag/worker.go
@@ -1,0 +1,120 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package migrationflag
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/utils"
+
+	"github.com/juju/juju/core/migration"
+	"github.com/juju/juju/watcher"
+	"github.com/juju/juju/worker/catacomb"
+)
+
+// ErrChanged indicates that a Worker has stopped because its
+// Check result is no longer valid.
+var ErrChanged = errors.New("migration flag value changed")
+
+// Facade exposes controller functionality required by a Worker.
+type Facade interface {
+	Watch(uuid string) (watcher.NotifyWatcher, error)
+	Phase(uuid string) (migration.Phase, error)
+}
+
+// Config holds the dependencies and configuration for a Worker.
+type Config struct {
+	Facade Facade
+	Model  string
+	Check  func(migration.Phase) bool
+}
+
+// Validate returns an error if the config cannot be expected to
+// drive a functional Worker.
+func (config Config) Validate() error {
+	if config.Facade == nil {
+		return errors.NotValidf("nil Facade")
+	}
+	if !utils.IsValidUUIDString(config.Model) {
+		return errors.NotValidf("Model %q", config.Model)
+	}
+	if config.Check == nil {
+		return errors.NotValidf("nil Check")
+	}
+	return nil
+}
+
+// New returns a Worker that tracks the result of the configured
+// Check on the Model's migration phase, as exposed by the Facade.
+func New(config Config) (*Worker, error) {
+	if err := config.Validate(); err != nil {
+		return nil, errors.Trace(err)
+	}
+	phase, err := config.Facade.Phase(config.Model)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	w := &Worker{
+		config: config,
+		phase:  phase,
+	}
+	err = catacomb.Invoke(catacomb.Plan{
+		Site: &w.catacomb,
+		Work: w.loop,
+	})
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return w, nil
+}
+
+// Worker implements worker.Worker and dependency.Flag, and exits
+// with ErrChanged whenever the result of its configured Check of
+// the Model's migration phase changes.
+type Worker struct {
+	catacomb catacomb.Catacomb
+	config   Config
+	phase    migration.Phase
+}
+
+// Kill is part of the worker.Worker interface.
+func (w *Worker) Kill() {
+	w.catacomb.Kill(nil)
+}
+
+// Wait is part of the worker.Worker interface.
+func (w *Worker) Wait() error {
+	return w.catacomb.Wait()
+}
+
+// Check is part of the dependency.Flag interface.
+func (w *Worker) Check() bool {
+	return w.config.Check(w.phase)
+}
+
+func (w *Worker) loop() error {
+	model := w.config.Model
+	facade := w.config.Facade
+	watcher, err := facade.Watch(model)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if err := w.catacomb.Add(watcher); err != nil {
+		return errors.Trace(err)
+	}
+	for {
+		select {
+		case <-w.catacomb.Dying():
+			return w.catacomb.ErrDying()
+		case <-watcher.Changes():
+			phase, err := facade.Phase(model)
+			if err != nil {
+				return errors.Trace(err)
+			}
+			if w.Check() != w.config.Check(phase) {
+				return ErrChanged
+			}
+		}
+	}
+}

--- a/worker/migrationflag/worker_test.go
+++ b/worker/migrationflag/worker_test.go
@@ -1,0 +1,132 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package migrationflag_test
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/core/migration"
+	"github.com/juju/juju/worker/migrationflag"
+	"github.com/juju/juju/worker/workertest"
+)
+
+type WorkerSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&WorkerSuite{})
+
+func (*WorkerSuite) TestPhaseErrorOnStartup(c *gc.C) {
+	stub := &testing.Stub{}
+	stub.SetErrors(errors.New("gaah"))
+	facade := newMockFacade(stub)
+	config := migrationflag.Config{
+		Facade: facade,
+		Model:  validUUID,
+		Check:  panicCheck,
+	}
+	worker, err := migrationflag.New(config)
+	c.Check(worker, gc.IsNil)
+	c.Check(err, gc.ErrorMatches, "gaah")
+	checkCalls(c, stub, "Phase")
+}
+
+func (*WorkerSuite) TestWatchError(c *gc.C) {
+	stub := &testing.Stub{}
+	stub.SetErrors(nil, errors.New("boff"))
+	facade := newMockFacade(stub, migration.REAP)
+	config := migrationflag.Config{
+		Facade: facade,
+		Model:  validUUID,
+		Check:  neverCheck,
+	}
+	worker, err := migrationflag.New(config)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(worker.Check(), jc.IsFalse)
+
+	err = workertest.CheckKilled(c, worker)
+	c.Check(err, gc.ErrorMatches, "boff")
+	checkCalls(c, stub, "Phase", "Watch")
+}
+
+func (*WorkerSuite) TestPhaseErrorWhileRunning(c *gc.C) {
+	stub := &testing.Stub{}
+	stub.SetErrors(nil, nil, errors.New("glug"))
+	facade := newMockFacade(stub, migration.QUIESCE)
+	config := migrationflag.Config{
+		Facade: facade,
+		Model:  validUUID,
+		Check:  neverCheck,
+	}
+	worker, err := migrationflag.New(config)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(worker.Check(), jc.IsFalse)
+
+	err = workertest.CheckKilled(c, worker)
+	c.Check(err, gc.ErrorMatches, "glug")
+	checkCalls(c, stub, "Phase", "Watch", "Phase")
+}
+
+func (*WorkerSuite) TestImmediatePhaseChange(c *gc.C) {
+	stub := &testing.Stub{}
+	facade := newMockFacade(stub,
+		migration.QUIESCE, migration.REAP,
+	)
+	config := migrationflag.Config{
+		Facade: facade,
+		Model:  validUUID,
+		Check:  isQuiesce,
+	}
+	worker, err := migrationflag.New(config)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(worker.Check(), jc.IsTrue)
+
+	err = workertest.CheckKilled(c, worker)
+	c.Check(err, gc.Equals, migrationflag.ErrChanged)
+	checkCalls(c, stub, "Phase", "Watch", "Phase")
+}
+
+func (*WorkerSuite) TestSubsequentPhaseChange(c *gc.C) {
+	stub := &testing.Stub{}
+	facade := newMockFacade(stub,
+		migration.ABORT, migration.REAP, migration.QUIESCE,
+	)
+	config := migrationflag.Config{
+		Facade: facade,
+		Model:  validUUID,
+		Check:  isQuiesce,
+	}
+	worker, err := migrationflag.New(config)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(worker.Check(), jc.IsFalse)
+
+	err = workertest.CheckKilled(c, worker)
+	c.Check(err, gc.Equals, migrationflag.ErrChanged)
+	checkCalls(c, stub, "Phase", "Watch", "Phase", "Phase")
+}
+
+func (*WorkerSuite) TestNoRelevantPhaseChange(c *gc.C) {
+	stub := &testing.Stub{}
+	facade := newMockFacade(stub,
+		migration.REAPFAILED,
+		migration.DONE,
+		migration.ABORT,
+		migration.IMPORT,
+	)
+	config := migrationflag.Config{
+		Facade: facade,
+		Model:  validUUID,
+		Check:  isQuiesce,
+	}
+	worker, err := migrationflag.New(config)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(worker.Check(), jc.IsFalse)
+
+	workertest.CheckAlive(c, worker)
+	workertest.CleanKill(c, worker)
+	checkCalls(c, stub, "Phase", "Watch", "Phase", "Phase", "Phase")
+}


### PR DESCRIPTION
*Very* similar to lifeflag stack in MADE-model-workers. No manifolds yet.

(Review request: http://reviews.vapour.ws/r/4342/)