### PR TITLE
1538735: Pass BootstrapSeries to provider bootstrap

### DIFF
--- a/environs/bootstrap.go
+++ b/environs/bootstrap.go
@@ -25,6 +25,10 @@ type BootstrapParams struct {
 	// will not be stored in state for the environment.
 	BootstrapConstraints constraints.Value
 
+	// BootstrapSeries, if specified, is the series to use for the
+	// initial bootstrap machine.
+	BootstrapSeries string
+
 	// Placement, if non-empty, holds an environment-specific placement
 	// directive used to choose the initial instance.
 	Placement string

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -156,6 +156,7 @@ func Bootstrap(ctx environs.BootstrapContext, environ environs.Environ, args Boo
 	} else if err != nil {
 		return err
 	}
+
 	if lxcMTU, ok := cfg.LXCDefaultMTU(); ok {
 		logger.Debugf("using MTU %v for all created LXC containers' network interfaces", lxcMTU)
 	}
@@ -191,6 +192,7 @@ func Bootstrap(ctx environs.BootstrapContext, environ environs.Environ, args Boo
 	result, err := environ.Bootstrap(ctx, environs.BootstrapParams{
 		ModelConstraints:     args.ModelConstraints,
 		BootstrapConstraints: args.BootstrapConstraints,
+		BootstrapSeries:      args.BootstrapSeries,
 		Placement:            args.Placement,
 		AvailableTools:       availableTools,
 		ImageMetadata:        imageMetadata,

--- a/environs/bootstrap/bootstrap_test.go
+++ b/environs/bootstrap/bootstrap_test.go
@@ -122,6 +122,24 @@ func (s *bootstrapSuite) TestBootstrapSpecifiedConstraints(c *gc.C) {
 	c.Assert(env.args.ModelConstraints, gc.DeepEquals, modelCons)
 }
 
+func (s *bootstrapSuite) TestBootstrapSpecifiedBootstrapSeries(c *gc.C) {
+	env := newEnviron("foo", useDefaultKeys, nil)
+	s.setDummyStorage(c, env)
+	cfg, err := env.Config().Apply(map[string]interface{}{
+		"default-series": "wily",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	env.cfg = cfg
+
+	err = bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{
+		BootstrapSeries: "trusty",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(env.bootstrapCount, gc.Equals, 1)
+	c.Assert(env.args.BootstrapSeries, gc.Equals, "trusty")
+	c.Assert(env.args.AvailableTools.AllSeries(), jc.SameContents, []string{"trusty"})
+}
+
 func (s *bootstrapSuite) TestBootstrapSpecifiedPlacement(c *gc.C) {
 	env := newEnviron("foo", useDefaultKeys, nil)
 	s.setDummyStorage(c, env)
@@ -565,7 +583,11 @@ func (e *bootstrapEnviron) Bootstrap(ctx environs.BootstrapContext, args environ
 		e.instanceConfig = icfg
 		return nil
 	}
-	return &environs.BootstrapResult{Arch: arch.HostArch(), Series: series.HostSeries(), Finalize: finalizer}, nil
+	series := series.HostSeries()
+	if args.BootstrapSeries != "" {
+		series = args.BootstrapSeries
+	}
+	return &environs.BootstrapResult{Arch: arch.HostArch(), Series: series, Finalize: finalizer}, nil
 }
 
 func (e *bootstrapEnviron) Config() *config.Config {

--- a/environs/bootstrap/bootstrap_test.go
+++ b/environs/bootstrap/bootstrap_test.go
@@ -135,9 +135,9 @@ func (s *bootstrapSuite) TestBootstrapSpecifiedBootstrapSeries(c *gc.C) {
 		BootstrapSeries: "trusty",
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(env.bootstrapCount, gc.Equals, 1)
-	c.Assert(env.args.BootstrapSeries, gc.Equals, "trusty")
-	c.Assert(env.args.AvailableTools.AllSeries(), jc.SameContents, []string{"trusty"})
+	c.Check(env.bootstrapCount, gc.Equals, 1)
+	c.Check(env.args.BootstrapSeries, gc.Equals, "trusty")
+	c.Check(env.args.AvailableTools.AllSeries(), jc.SameContents, []string{"trusty"})
 }
 
 func (s *bootstrapSuite) TestBootstrapSpecifiedPlacement(c *gc.C) {

--- a/provider/common/bootstrap.go
+++ b/provider/common/bootstrap.go
@@ -69,7 +69,11 @@ func BootstrapInstance(ctx environs.BootstrapContext, env environs.Environ, args
 	// no way to make sure that only one succeeds.
 
 	// First thing, ensure we have tools otherwise there's no point.
-	selectedSeries = config.PreferredSeries(env.Config())
+	if args.BootstrapSeries != "" {
+		selectedSeries = args.BootstrapSeries
+	} else {
+		selectedSeries = config.PreferredSeries(env.Config())
+	}
 	availableTools, err := args.AvailableTools.Match(coretools.Filter{
 		Series: selectedSeries,
 	})

--- a/provider/common/bootstrap_test.go
+++ b/provider/common/bootstrap_test.go
@@ -135,6 +135,55 @@ func (s *BootstrapSuite) TestCannotStartInstance(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "cannot start bootstrap instance: meh, not started")
 }
 
+func (s *BootstrapSuite) TestBootstrapSeries(c *gc.C) {
+	s.PatchValue(&jujuversion.Current, coretesting.FakeVersionNumber)
+	s.PatchValue(&series.HostSeries, func() string { return "precise" })
+	stor := newStorage(s, c)
+	checkInstanceId := "i-success"
+	checkHardware := instance.MustParseHardware("arch=ppc64el mem=2T")
+
+	startInstance := func(
+		_ string, _ constraints.Value, _ []string, _ tools.List, icfg *instancecfg.InstanceConfig,
+	) (
+		instance.Instance, *instance.HardwareCharacteristics, []network.InterfaceInfo, error,
+	) {
+		return &mockInstance{id: checkInstanceId}, &checkHardware, nil, nil
+	}
+	var mocksConfig = minimalConfig(c)
+	var getConfigCalled int
+	getConfig := func() *config.Config {
+		getConfigCalled++
+		return mocksConfig
+	}
+	setConfig := func(c *config.Config) error {
+		mocksConfig = c
+		return nil
+	}
+
+	env := &mockEnviron{
+		storage:       stor,
+		startInstance: startInstance,
+		config:        getConfig,
+		setConfig:     setConfig,
+	}
+	ctx := envtesting.BootstrapContext(c)
+	bootstrapSeries := "xenial"
+	result, err := common.Bootstrap(ctx, env, environs.BootstrapParams{
+		BootstrapSeries: bootstrapSeries,
+		AvailableTools: tools.List{
+			&tools.Tools{
+				Version: version.Binary{
+					Number: jujuversion.Current,
+					Arch:   arch.HostArch(),
+					Series: bootstrapSeries,
+				},
+			},
+		}})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.Arch, gc.Equals, "ppc64el") // based on hardware characteristics
+	c.Assert(result.Series, gc.Equals, bootstrapSeries)
+}
+
 func (s *BootstrapSuite) TestSuccess(c *gc.C) {
 	s.PatchValue(&jujuversion.Current, coretesting.FakeVersionNumber)
 	stor := newStorage(s, c)

--- a/provider/common/bootstrap_test.go
+++ b/provider/common/bootstrap_test.go
@@ -167,7 +167,7 @@ func (s *BootstrapSuite) TestBootstrapSeries(c *gc.C) {
 		setConfig:     setConfig,
 	}
 	ctx := envtesting.BootstrapContext(c)
-	bootstrapSeries := "xenial"
+	bootstrapSeries := "utopic"
 	result, err := common.Bootstrap(ctx, env, environs.BootstrapParams{
 		BootstrapSeries: bootstrapSeries,
 		AvailableTools: tools.List{

--- a/provider/common/bootstrap_test.go
+++ b/provider/common/bootstrap_test.go
@@ -142,17 +142,14 @@ func (s *BootstrapSuite) TestBootstrapSeries(c *gc.C) {
 	checkInstanceId := "i-success"
 	checkHardware := instance.MustParseHardware("arch=ppc64el mem=2T")
 
-	startInstance := func(
-		_ string, _ constraints.Value, _ []string, _ tools.List, icfg *instancecfg.InstanceConfig,
-	) (
-		instance.Instance, *instance.HardwareCharacteristics, []network.InterfaceInfo, error,
-	) {
+	startInstance := func(_ string, _ constraints.Value, _ []string, _ tools.List, icfg *instancecfg.InstanceConfig) (instance.Instance,
+		*instance.HardwareCharacteristics, []network.InterfaceInfo, error) {
 		return &mockInstance{id: checkInstanceId}, &checkHardware, nil, nil
 	}
 	var mocksConfig = minimalConfig(c)
-	var getConfigCalled int
+	var numGetConfigCalled int
 	getConfig := func() *config.Config {
-		getConfigCalled++
+		numGetConfigCalled++
 		return mocksConfig
 	}
 	setConfig := func(c *config.Config) error {
@@ -180,8 +177,8 @@ func (s *BootstrapSuite) TestBootstrapSeries(c *gc.C) {
 			},
 		}})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(result.Arch, gc.Equals, "ppc64el") // based on hardware characteristics
-	c.Assert(result.Series, gc.Equals, bootstrapSeries)
+	c.Check(result.Arch, gc.Equals, "ppc64el") // based on hardware characteristics
+	c.Check(result.Series, gc.Equals, bootstrapSeries)
 }
 
 func (s *BootstrapSuite) TestSuccess(c *gc.C) {


### PR DESCRIPTION
--bootstrap-series is used to filter tools before
calling the provider bootstrap method, but then the
bootstrap-series is not passed into the provider when
calling bootstrap.

The provider then used either the specified
default-series, or the default default-series to choose
tools.  This led to a "no matching tools available"
error if the bootstrap series differed from the default
series used.

In this patch, I update the BootstrapParams to include
the bootstrap series and have the provider use that
to check for tools.

Unit tests reference unsupported "utopic" as support
for xenial and wily has yet to land for non-ubuntu 
clients:  https://github.com/juju/utils/pull/201