### PR TITLE
rpc: introduce ClientConn and ServerConn interfaces

### DIFF
--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -147,7 +147,7 @@ func open(
 		return nil, errors.Trace(err)
 	}
 
-	client := rpc.NewConn(jsoncodec.NewWebsocket(conn), nil)
+	client := rpc.NewClientConn(jsoncodec.NewWebsocket(conn), nil)
 	client.Start()
 
 	bakeryClient := opts.BakeryClient

--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -147,8 +147,7 @@ func open(
 		return nil, errors.Trace(err)
 	}
 
-	client := rpc.NewClientConn(jsoncodec.NewWebsocket(conn), nil)
-	client.Start()
+	client := rpc.NewClientConn(jsoncodec.NewWebsocket(conn))
 
 	bakeryClient := opts.BakeryClient
 	if bakeryClient == nil {

--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -571,13 +571,6 @@ func (s *state) Broken() <-chan struct{} {
 	return s.broken
 }
 
-// RPCClient returns the RPC client for the state, so that testing
-// functions can tickle parts of the API that the conventional entry
-// points don't reach. This is exported for testing purposes only.
-func (s *state) RPCClient() rpc.ClientConn {
-	return s.client
-}
-
 // Addr returns the address used to connect to the API server.
 func (s *state) Addr() string {
 	return s.addr

--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -49,7 +49,7 @@ var (
 
 // state is the internal implementation of the Connection interface.
 type state struct {
-	client *rpc.Conn
+	client rpc.ClientConn
 	conn   *websocket.Conn
 
 	// addr is the address used to connect to the API server.
@@ -575,7 +575,7 @@ func (s *state) Broken() <-chan struct{} {
 // RPCClient returns the RPC client for the state, so that testing
 // functions can tickle parts of the API that the conventional entry
 // points don't reach. This is exported for testing purposes only.
-func (s *state) RPCClient() *rpc.Conn {
+func (s *state) RPCClient() rpc.ClientConn {
 	return s.client
 }
 

--- a/api/interface.go
+++ b/api/interface.go
@@ -177,7 +177,7 @@ type Connection interface {
 
 	// RPCClient is apparently exported for testing purposes only, but this
 	// seems to indicate *some* sort of layering confusion.
-	RPCClient() *rpc.Conn
+	RPCClient() rpc.ClientConn
 
 	// I think this is actually dead code. It's tested, at least, so I'm
 	// keeping it for now, but it's not apparently used anywhere else.

--- a/api/interface.go
+++ b/api/interface.go
@@ -29,7 +29,6 @@ import (
 	"github.com/juju/juju/api/uniter"
 	"github.com/juju/juju/api/upgrader"
 	"github.com/juju/juju/network"
-	"github.com/juju/juju/rpc"
 )
 
 // Info encapsulates information about a server holding juju state and
@@ -174,10 +173,6 @@ type Connection interface {
 	// inside it as well. We should figure this out sometime -- we should
 	// either expose Ping() or Broken() but not both.
 	Ping() error
-
-	// RPCClient is apparently exported for testing purposes only, but this
-	// seems to indicate *some* sort of layering confusion.
-	RPCClient() rpc.ClientConn
 
 	// I think this is actually dead code. It's tested, at least, so I'm
 	// keeping it for now, but it's not apparently used anywhere else.

--- a/apiserver/admin.go
+++ b/apiserver/admin.go
@@ -200,7 +200,7 @@ func (a *admin) doLogin(req params.LoginRequest, loginVersion int) (params.Login
 		authedApi = newClientAuthRoot(authedApi, envUser)
 	}
 
-	a.root.rpcConn.ServeFinder(authedApi, serverError)
+	a.root.conn.ServeFinder(authedApi, serverError)
 
 	return loginResult, nil
 }
@@ -444,7 +444,7 @@ func startPingerIfAgent(root *apiHandler, entity state.Entity) error {
 
 	root.getResources().Register(&machinePinger{pinger, root.mongoUnavailable})
 	action := func() {
-		if err := root.getRpcConn().Close(); err != nil {
+		if err := root.conn.Close(); err != nil {
 			logger.Errorf("error closing the RPC connection: %v", err)
 		}
 	}

--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -518,7 +518,7 @@ func (srv *Server) serveConn(wsConn *websocket.Conn, reqNotifier *requestNotifie
 	return conn.Close()
 }
 
-func (srv *Server) newAPIHandler(conn *rpc.Conn, reqNotifier *requestNotifier, modelUUID string) (*apiHandler, error) {
+func (srv *Server) newAPIHandler(conn rpc.ServerConn, reqNotifier *requestNotifier, modelUUID string) (*apiHandler, error) {
 	// Note that we don't overwrite modelUUID here because
 	// newAPIHandler treats an empty modelUUID as signifying
 	// the API version used.

--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -498,7 +498,7 @@ func (srv *Server) serveConn(wsConn *websocket.Conn, reqNotifier *requestNotifie
 		// know we'll need it.
 		notifier = reqNotifier
 	}
-	conn := rpc.NewConn(codec, notifier)
+	conn := rpc.NewServerConn(codec, notifier)
 
 	h, err := srv.newAPIHandler(conn, reqNotifier, modelUUID)
 	if err != nil {

--- a/apiserver/root.go
+++ b/apiserver/root.go
@@ -43,7 +43,7 @@ type objectKey struct {
 // uses to dispatch Api calls appropriately.
 type apiHandler struct {
 	state            *state.State
-	rpcConn          *rpc.Conn
+	conn             rpc.ServerConn
 	resources        *common.Resources
 	entity           state.Entity
 	mongoUnavailable *uint32
@@ -54,14 +54,13 @@ type apiHandler struct {
 	modelUUID string
 }
 
-var _ = (*apiHandler)(nil)
-
 // newApiHandler returns a new apiHandler.
-func newApiHandler(srv *Server, st *state.State, rpcConn *rpc.Conn, reqNotifier *requestNotifier, modelUUID string) (*apiHandler, error) {
+// TODO(dfc) rename to newAPIHandler
+func newApiHandler(srv *Server, st *state.State, conn rpc.ServerConn, reqNotifier *requestNotifier, modelUUID string) (*apiHandler, error) {
 	r := &apiHandler{
 		state:            st,
 		resources:        common.NewResources(),
-		rpcConn:          rpcConn,
+		conn:             conn,
 		modelUUID:        modelUUID,
 		mongoUnavailable: &srv.mongoUnavailable,
 	}
@@ -84,10 +83,6 @@ func newApiHandler(srv *Server, st *state.State, rpcConn *rpc.Conn, reqNotifier 
 
 func (r *apiHandler) getResources() *common.Resources {
 	return r.resources
-}
-
-func (r *apiHandler) getRpcConn() *rpc.Conn {
-	return r.rpcConn
 }
 
 // Kill implements rpc.Killer, cleaning up any resources that need

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -5,6 +5,7 @@ package rpc
 
 import (
 	"strings"
+	"sync/atomic"
 
 	"github.com/juju/errors"
 )
@@ -77,8 +78,7 @@ func (conn *Conn) send(call *Call) {
 		call.done()
 		return
 	}
-	conn.reqId++
-	reqId := conn.reqId
+	reqId := atomic.AddUint64(&conn.reqId, 1)
 	conn.clientPending[reqId] = call
 	conn.mutex.Unlock()
 

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -43,10 +43,6 @@ func (e *RequestError) ErrorCode() string {
 
 // ClientConn represents a RPC client connection.
 type ClientConn interface {
-
-	// Start starts something
-	Start()
-
 	// Call invokes the named action on the object of the given type with the given
 	// id. The returned values will be stored in response, which should be a pointer.
 	// If the action fails remotely, the error will have a cause of type RequestError.
@@ -59,8 +55,11 @@ type ClientConn interface {
 }
 
 // NewClientConn returns a ClientConn for the underlying codec.
-func NewClientConn(codec Codec, notifier RequestNotifier) ClientConn {
-	return newConn(codec, notifier)
+func NewClientConn(codec Codec) ClientConn {
+	var notifier dummyNotifier
+	client := newConn(codec, &notifier)
+	client.Start()
+	return client
 }
 
 func (conn *Conn) send(call *Call) {

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -41,6 +41,28 @@ func (e *RequestError) ErrorCode() string {
 	return e.Code
 }
 
+// ClientConn represents a RPC client connection.
+type ClientConn interface {
+
+	// Start starts something
+	Start()
+
+	// Call invokes the named action on the object of the given type with the given
+	// id. The returned values will be stored in response, which should be a pointer.
+	// If the action fails remotely, the error will have a cause of type RequestError.
+	// The params value may be nil if no parameters are provided; the response value
+	// may be nil to indicate that any result should be discarded.
+	Call(req Request, params, response interface{}) error
+
+	// Close closes the connection.
+	Close() error
+}
+
+// NewClientConn returns a ClientConn for the underlying codec.
+func NewClientConn(codec Codec, notifier RequestNotifier) ClientConn {
+	return newConn(codec, notifier)
+}
+
 func (conn *Conn) send(call *Call) {
 	conn.sending.Lock()
 	defer conn.sending.Unlock()

--- a/rpc/dispatch_test.go
+++ b/rpc/dispatch_test.go
@@ -27,7 +27,7 @@ var _ = gc.Suite(&dispatchSuite{})
 func (s *dispatchSuite) SetUpSuite(c *gc.C) {
 	rpcServer := func(ws *websocket.Conn) {
 		codec := jsoncodec.NewWebsocket(ws)
-		conn := rpc.NewConn(codec, nil)
+		conn := rpc.NewServerConn(codec, nil)
 
 		conn.Serve(&DispatchRoot{}, nil)
 		conn.Start()

--- a/rpc/rpc_test.go
+++ b/rpc/rpc_test.go
@@ -1205,7 +1205,7 @@ func newRPCClientServer(c *gc.C, root interface{}, tfErr func(error) error, bidi
 		if bidir {
 			role = roleBoth
 		}
-		rpcConn := rpc.NewConn(NewJSONCodec(conn, role), serverNotifier)
+		rpcConn := rpc.NewServerConn(NewJSONCodec(conn, role), serverNotifier)
 		if custroot, ok := root.(*CustomMethodFinder); ok {
 			rpcConn.ServeFinder(custroot, tfErr)
 			custroot.root.conn = rpcConn
@@ -1225,7 +1225,7 @@ func newRPCClientServer(c *gc.C, root interface{}, tfErr func(error) error, bidi
 	if bidir {
 		role = roleBoth
 	}
-	client = rpc.NewConn(NewJSONCodec(conn, role), clientNotifier)
+	client = rpc.NewClientConn(NewJSONCodec(conn, role), clientNotifier)
 	client.Start()
 	return client, srvDone, clientNotifier, serverNotifier
 }

--- a/rpc/rpc_test.go
+++ b/rpc/rpc_test.go
@@ -234,8 +234,9 @@ func (a *CallbackMethods) Factorial(x int64val) (int64val, error) {
 	if x.I <= 1 {
 		return int64val{1}, nil
 	}
+	client := a.root.conn.(rpc.ClientConn)
 	var r int64val
-	err := a.root.conn.(rpc.ClientConn).Call(rpc.Request{"CallbackMethods", 0, "", "Factorial"}, int64val{x.I - 1}, &r)
+	err := client.Call(rpc.Request{"CallbackMethods", 0, "", "Factorial"}, int64val{x.I - 1}, &r)
 	if err != nil {
 		return int64val{}, err
 	}

--- a/rpc/rpc_test.go
+++ b/rpc/rpc_test.go
@@ -1226,7 +1226,7 @@ func newRPCClientServer(c *gc.C, root interface{}, tfErr func(error) error, bidi
 	if bidir {
 		role = roleBoth
 	}
-	client := rpc.NewClientConn(NewJSONCodec(conn, role), clientNotifier)
+	client := rpc.NewServerConn(NewJSONCodec(conn, role), clientNotifier)
 	client.Start()
 	return client, srvDone, clientNotifier, serverNotifier
 }

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -186,10 +186,6 @@ type RequestNotifier interface {
 	ClientReply(req Request, hdr *Header, body interface{})
 }
 
-func NewClientConn(codec Codec, notifier RequestNotifier) *Conn {
-	return newConn(codec, notifier)
-}
-
 func NewServerConn(codec Codec, notifier RequestNotifier) *Conn {
 	return newConn(codec, notifier)
 }

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -107,6 +107,9 @@ type Conn struct {
 	// It also guards shutdown.
 	sending sync.Mutex
 
+	// reqId holds the latest client request id.
+	reqId uint64
+
 	// mutex guards the following values.
 	mutex sync.Mutex
 
@@ -123,9 +126,6 @@ type Conn struct {
 
 	// transformErrors is used to transform returned errors.
 	transformErrors func(error) error
-
-	// reqId holds the latest client request id.
-	reqId uint64
 
 	// clientPending holds all pending client requests.
 	clientPending map[uint64]*Call

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -186,11 +186,19 @@ type RequestNotifier interface {
 	ClientReply(req Request, hdr *Header, body interface{})
 }
 
-// NewConn creates a new connection that uses the given codec for
+func NewClientConn(codec Codec, notifier RequestNotifier) *Conn {
+	return newConn(codec, notifier)
+}
+
+func NewServerConn(codec Codec, notifier RequestNotifier) *Conn {
+	return newConn(codec, notifier)
+}
+
+// newConn creates a new connection that uses the given codec for
 // transport, but it does not start it. Conn.Start must be called before
 // any requests are sent or received. If notifier is non-nil, the
 // appropriate method will be called for every RPC request.
-func NewConn(codec Codec, notifier RequestNotifier) *Conn {
+func newConn(codec Codec, notifier RequestNotifier) *Conn {
 	if notifier == nil {
 		notifier = new(dummyNotifier)
 	}


### PR DESCRIPTION
This PR is in preparation for adding tests for retrying temporary RPC errors.

It introduces two new interface types, `rpc.ClientConn` and `rpc.ServerConn` whose purposes are self explanatory. Also provide constructor functions for these new interface types as `NewConn` has been unexported.

Remove the ability to provide a RequestNotifier when requesting a ClientConn, this was never used by any non test caller and is only part of the bidirectional code for the rpc package, which is also unused by juju.

Adjust the callers in the `api` and `apiserver` packages to these new interfaces, very few changes were needed apart from adjusting the types in various wrapper types.

The bidirection nature of the rpc package remains, but if needed the caller must assert their ServerConn value to a ClientConn, or vice versa. No code in Juju does this, but the rpc tests assert this behaviour

Finally, unexport `rpc.Conn`.