### PR TITLE
provider/vsphere: remove incorrect getSnapshot pattern

### DIFF
--- a/provider/vsphere/environ.go
+++ b/provider/vsphere/environ.go
@@ -24,13 +24,13 @@ type environ struct {
 	common.SupportsUnitPlacementPolicy
 
 	name   string
-	ecfg   *environConfig
 	client *client
 
-	lock     sync.Mutex
-	archLock sync.Mutex
-
+	archLock               sync.Mutex // archLock protects access to the following fields.
 	supportedArchitectures []string
+
+	lock sync.Mutex // lock protects access the following fields.
+	ecfg *environConfig
 }
 
 func newEnviron(cfg *config.Config) (*environ, error) {

--- a/provider/vsphere/environ.go
+++ b/provider/vsphere/environ.go
@@ -77,17 +77,12 @@ func (env *environ) SetConfig(cfg *config.Config) error {
 	return nil
 }
 
-// getSnapshot returns a copy of the environment. This is useful for
-// ensuring the env you are using does not get changed by other code
-// while you are using it.
-func (env *environ) getSnapshot() *environ {
-	e := *env
-	return &e
-}
-
 // Config returns the configuration data with which the env was created.
 func (env *environ) Config() *config.Config {
-	return env.getSnapshot().ecfg.Config
+	env.lock.Lock()
+	cfg := env.ecfg.Config
+	env.lock.Unlock()
+	return cfg
 }
 
 //this variable is exported, because it has to be rewritten in external unit tests

--- a/provider/vsphere/environ_broker.go
+++ b/provider/vsphere/environ_broker.go
@@ -36,8 +36,6 @@ func (*environ) MaintainInstance(args environs.StartInstanceParams) error {
 
 // StartInstance implements environs.InstanceBroker.
 func (env *environ) StartInstance(args environs.StartInstanceParams) (*environs.StartInstanceResult, error) {
-	env = env.getSnapshot()
-
 	if args.InstanceConfig.HasNetworks() {
 		return nil, errors.New("starting instances with networks is not supported yet")
 	}
@@ -169,8 +167,6 @@ func (env *environ) AllInstances() ([]instance.Instance, error) {
 
 // StopInstances implements environs.InstanceBroker.
 func (env *environ) StopInstances(instances ...instance.Id) error {
-	env = env.getSnapshot()
-
 	var ids []string
 	for _, id := range instances {
 		ids = append(ids, string(id))

--- a/provider/vsphere/environ_instance.go
+++ b/provider/vsphere/environ_instance.go
@@ -62,8 +62,6 @@ func (env *environ) Instances(ids []instance.Id) ([]instance.Instance, error) {
 // will see they are not tracked in state, assume they're stale/rogue,
 // and shut them down.
 func (env *environ) instances() ([]instance.Instance, error) {
-	env = env.getSnapshot()
-
 	prefix := common.MachineFullName(env.Config().UUID(), "")
 	instances, err := env.client.Instances(prefix)
 	err = errors.Trace(err)
@@ -82,8 +80,6 @@ func (env *environ) instances() ([]instance.Instance, error) {
 // ControllerInstances returns the IDs of the instances corresponding
 // to juju controllers.
 func (env *environ) ControllerInstances() ([]instance.Id, error) {
-	env = env.getSnapshot()
-
 	prefix := common.MachineFullName(env.Config().ControllerUUID(), "")
 	instances, err := env.client.Instances(prefix)
 	if err != nil {


### PR DESCRIPTION
Updates LP 1563628

The `env = env.getSnapshot()` pattern was wrong. It provided the same guarentee as 

    func (e env) Method() { .. }

And was just as incorrect. This was spotted with a recent addition to `go vet`. 

(Review request: http://reviews.vapour.ws/r/4359/)