### PR TITLE
provider/maas: no need to lock an immutable value

### DIFF
--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -298,8 +298,9 @@ func (env *maasEnviron) ControllerInstances() ([]instance.Id, error) {
 // mutex.
 func (env *maasEnviron) ecfg() *maasModelConfig {
 	env.ecfgMutex.Lock()
-	defer env.ecfgMutex.Unlock()
-	return env.ecfgUnlocked
+	cfg := *env.ecfgUnlocked
+	env.ecfgMutex.Unlock()
+	return &cfg
 }
 
 // Config is specified in the Environ interface.

--- a/provider/maas/environ_whitebox_test.go
+++ b/provider/maas/environ_whitebox_test.go
@@ -147,7 +147,7 @@ func (suite *environSuite) TestStorageReturnsStorage(c *gc.C) {
 	// The Storage object is really a maasStorage.
 	specificStorage := stor.(*maasStorage)
 	// Its environment pointer refers back to its environment.
-	c.Check(specificStorage.environUnlocked, gc.Equals, env)
+	c.Check(specificStorage.environ, gc.Equals, env)
 }
 
 func decodeUserData(userData string) ([]byte, error) {

--- a/provider/maas/storage_test.go
+++ b/provider/maas/storage_test.go
@@ -10,7 +10,6 @@ import (
 	"math/rand"
 	"net/http"
 	"net/url"
-	"sync"
 
 	"github.com/juju/errors"
 	"github.com/juju/gomaasapi"
@@ -19,6 +18,8 @@ import (
 
 	"github.com/juju/juju/environs/storage"
 )
+
+var _ storage.Storage = (*maasStorage)(nil)
 
 type storageSuite struct {
 	providerSuite
@@ -56,18 +57,6 @@ func (s *storageSuite) fakeStoredFile(stor storage.Storage, name string) gomaasa
 	// bypassing the Put() method that would normally do that.
 	prefixFilename := stor.(*maasStorage).prefixWithPrivateNamespace("") + name
 	return s.testMAASObject.TestServer.NewFile(prefixFilename, data)
-}
-
-func (s *storageSuite) TestGetSnapshotCreatesClone(c *gc.C) {
-	original := s.makeStorage("storage-name")
-	snapshot := original.getSnapshot()
-	c.Check(snapshot.environUnlocked, gc.Equals, original.environUnlocked)
-	c.Check(snapshot.maasClientUnlocked.URL().String(), gc.Equals, original.maasClientUnlocked.URL().String())
-	// Snapshotting locks the original internally, but does not leave
-	// either the original or the snapshot locked.
-	unlockedMutexValue := sync.Mutex{}
-	c.Check(original.Mutex, gc.Equals, unlockedMutexValue)
-	c.Check(snapshot.Mutex, gc.Equals, unlockedMutexValue)
 }
 
 func (s *storageSuite) TestGetRetrievesFile(c *gc.C) {
@@ -249,7 +238,7 @@ func (s *storageSuite) TestURLReturnsURLCorrespondingToFile(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	parsedURI, err := url.Parse(anonURI)
 	c.Assert(err, jc.ErrorIsNil)
-	anonURL := stor.maasClientUnlocked.URL().ResolveReference(parsedURI)
+	anonURL := stor.maasClient.URL().ResolveReference(parsedURI)
 	c.Assert(err, jc.ErrorIsNil)
 
 	fileURL, err := stor.URL(filename)
@@ -401,7 +390,7 @@ func (s *storageSuite) TestRemoveAllDeletesAllFiles(c *gc.C) {
 func (s *storageSuite) TestprefixWithPrivateNamespacePrefixesWithAgentName(c *gc.C) {
 	sstor := NewStorage(s.makeEnviron())
 	stor := sstor.(*maasStorage)
-	agentName := stor.environUnlocked.ecfg().maasAgentName()
+	agentName := stor.environ.ecfg().maasAgentName()
 	c.Assert(agentName, gc.Not(gc.Equals), "")
 	expectedPrefix := agentName + "-"
 	const name = "myname"
@@ -412,7 +401,7 @@ func (s *storageSuite) TestprefixWithPrivateNamespacePrefixesWithAgentName(c *gc
 func (s *storageSuite) TesttprefixWithPrivateNamespaceIgnoresAgentName(c *gc.C) {
 	sstor := NewStorage(s.makeEnviron())
 	stor := sstor.(*maasStorage)
-	ecfg := stor.environUnlocked.ecfg()
+	ecfg := stor.environ.ecfg()
 	ecfg.attrs["maas-agent-name"] = ""
 
 	const name = "myname"


### PR DESCRIPTION
Updates LP 1563628

The maas storage type is immutable, its consituent fields cannot be
changed after construction so there is no need to ensure they are safely
mutated behind a mutex.

(Review request: http://reviews.vapour.ws/r/4361/)