### PR TITLE
provider/azure: validate model name length

### DIFF
--- a/provider/azure/config.go
+++ b/provider/azure/config.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/Godeps/_workspace/src/github.com/Azure/go-autorest/autorest/azure"
 	"github.com/Azure/azure-sdk-for-go/arm/storage"
 	"github.com/juju/errors"
+	"github.com/juju/names"
 	"github.com/juju/schema"
 
 	"github.com/juju/juju/environs/config"
@@ -43,6 +44,10 @@ const (
 	// to know this because some resources are shared, and live in the
 	// controller environment's resource group.
 	configAttrControllerResourceGroup = "controller-resource-group"
+
+	// resourceNameLengthMax is the maximum length of resource
+	// names in Azure.
+	resourceNameLengthMax = 80
 )
 
 var configFields = schema.Fields{
@@ -159,6 +164,21 @@ func validateConfig(newCfg, oldCfg *config.Config) (*azureModelConfig, error) {
 		}
 		// TODO(axw) figure out how we intend to handle changing
 		// secrets, such as application key
+	}
+
+	// Resource group names must not exceed 80 characters. Resource group
+	// names are based on the model UUID and model name, the latter of
+	// which the model creator controls.
+	modelTag := names.NewModelTag(newCfg.UUID())
+	resourceGroup := resourceGroupName(modelTag, newCfg.Name())
+	if n := len(resourceGroup); n > resourceNameLengthMax {
+		smallestResourceGroup := resourceGroupName(modelTag, "")
+		return nil, errors.Errorf(`resource group name %q is too long
+
+Please choose a model name of no more than %d characters.`,
+			resourceGroup,
+			resourceNameLengthMax-len(smallestResourceGroup),
+		)
 	}
 
 	location := canonicalLocation(validated[configAttrLocation].(string))

--- a/provider/azure/config_test.go
+++ b/provider/azure/config_test.go
@@ -62,6 +62,14 @@ func (s *configSuite) TestValidateLocation(c *gc.C) {
 	s.assertConfigValid(c, testing.Attrs{"location": "eurasia"})
 }
 
+func (s *configSuite) TestValidateModelNameLength(c *gc.C) {
+	s.assertConfigInvalid(
+		c, testing.Attrs{"name": "someextremelyoverlylongishmodelname"},
+		`resource group name "juju-someextremelyoverlylongishmodelname-model-deadbeef-0bad-400d-8000-4b1d0d06f00d" is too long
+
+Please choose a model name of no more than 32 characters.`)
+}
+
 func (s *configSuite) TestValidateInvalidCredentials(c *gc.C) {
 	s.assertConfigInvalid(c, testing.Attrs{"application-id": ""}, `"application-id" config not specified`)
 	s.assertConfigInvalid(c, testing.Attrs{"application-password": ""}, `"application-password" config not specified`)

--- a/provider/azure/environ.go
+++ b/provider/azure/environ.go
@@ -82,7 +82,8 @@ func newEnviron(provider *azureEnvironProvider, cfg *config.Config) (*azureEnvir
 	if err != nil {
 		return nil, err
 	}
-	env.resourceGroup = resourceGroupName(cfg)
+	modelTag := names.NewModelTag(cfg.UUID())
+	env.resourceGroup = resourceGroupName(modelTag, cfg.Name())
 	env.controllerResourceGroup = env.config.controllerResourceGroup
 	env.envName = cfg.Name()
 	return &env, nil
@@ -1097,12 +1098,8 @@ func (env *azureEnviron) Provider() environs.EnvironProvider {
 }
 
 // resourceGroupName returns the name of the environment's resource group.
-func resourceGroupName(cfg *config.Config) string {
-	modelTag := names.NewModelTag(cfg.UUID())
-	return fmt.Sprintf(
-		"juju-%s-%s", cfg.Name(),
-		resourceName(modelTag),
-	)
+func resourceGroupName(modelTag names.ModelTag, modelName string) string {
+	return fmt.Sprintf("juju-%s-%s", modelName, resourceName(modelTag))
 }
 
 // resourceName returns the string to use for a resource's Name tag,

--- a/provider/azure/environprovider.go
+++ b/provider/azure/environprovider.go
@@ -7,6 +7,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/Godeps/_workspace/src/github.com/Azure/go-autorest/autorest"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
+	"github.com/juju/names"
 
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs"
@@ -113,7 +114,10 @@ func (prov *azureEnvironProvider) BootstrapConfig(args environs.BootstrapConfigP
 
 		// Record the UUID that will be used for the controller
 		// model, which contains shared resources.
-		configAttrControllerResourceGroup: resourceGroupName(args.Config),
+		configAttrControllerResourceGroup: resourceGroupName(
+			names.NewModelTag(args.Config.UUID()),
+			args.Config.Name(),
+		),
 	}
 	switch authType := args.Credentials.AuthType(); authType {
 	case cloud.UserPassAuthType:


### PR DESCRIPTION
Azure complains when you use a resource name
that is greater than 80 characters long. The
limit is not checked consistently by Azure,
and only shows up when trying to create some
resources, e.g. subnets and availability sets.

We reject model names that will tip the resource
group name over the limit. This means you can
only use model names of at most 32 characters
in Azure.

Fixes https://bugs.launchpad.net/juju-core/+bug/1524077

(Review request: http://reviews.vapour.ws/r/4362/)