### PR TITLE
worker/apiconfigwatcher: Add dependency for API address changes

### DIFF
--- a/worker/apiconfigwatcher/manifold.go
+++ b/worker/apiconfigwatcher/manifold.go
@@ -1,0 +1,151 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package apiconfigwatcher
+
+import (
+	"sort"
+
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	"github.com/juju/utils/voyeur"
+	"launchpad.net/tomb"
+
+	"github.com/juju/juju/agent"
+	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/dependency"
+)
+
+var logger = loggo.GetLogger("juju.worker.apiconfigwatcher")
+
+type ManifoldConfig struct {
+	AgentName          string
+	AgentConfigChanged *voyeur.Value
+}
+
+// Manifold returns a dependency.Manifold which wraps an agent's
+// voyeur.Value which is set whenever the agent config is
+// changed. When the API server addresses in the config change the
+// manifold will bounce itself.
+//
+// The manifold is intended to be a dependency for the api-caller
+// manifold and is required to support model migrations.
+func Manifold(config ManifoldConfig) dependency.Manifold {
+	return dependency.Manifold{
+		Inputs: []string{config.AgentName},
+		Start: func(getResource dependency.GetResourceFunc) (worker.Worker, error) {
+			if config.AgentConfigChanged == nil {
+				return nil, errors.NotValidf("nil AgentConfigChanged")
+			}
+
+			var a agent.Agent
+			if err := getResource(config.AgentName, &a); err != nil {
+				return nil, err
+			}
+
+			w := &apiconfigwatcher{
+				agent:              a,
+				agentConfigChanged: config.AgentConfigChanged,
+				addrs:              getAPIAddresses(a),
+			}
+			go func() {
+				defer w.tomb.Done()
+				w.tomb.Kill(w.loop())
+			}()
+			return w, nil
+		},
+	}
+}
+
+type apiconfigwatcher struct {
+	tomb               tomb.Tomb
+	agent              agent.Agent
+	agentConfigChanged *voyeur.Value
+	addrs              []string
+}
+
+func (w *apiconfigwatcher) loop() error {
+	watch := w.agentConfigChanged.Watch()
+	defer watch.Close()
+
+	// TODO(mjs) - this is pretty awful. There should be a
+	// NotifyWatcher for voyeur.Value. Note also that this code is
+	// repeated elsewhere.
+	watchCh := make(chan bool)
+	go func() {
+		for {
+			if watch.Next() {
+				select {
+				case <-w.tomb.Dying():
+					return
+				case watchCh <- true:
+				}
+			} else {
+				// watcher or voyeur.Value closed.
+				close(watchCh)
+				return
+			}
+		}
+	}()
+
+	for {
+		// Always unconditionally check for a change in API addresses
+		// first, in case there was a change between the start func
+		// and the call to Watch.
+		if !stringSliceEq(w.addrs, getAPIAddresses(w.agent)) {
+			logger.Debugf("API addresses changed in agent config")
+			return dependency.ErrBounce
+		}
+
+		select {
+		case <-w.tomb.Dying():
+			return tomb.ErrDying
+		case _, ok := <-watchCh:
+			if !ok {
+				return errors.New("config changed value closed")
+			}
+		}
+	}
+}
+
+// Kill implements worker.Worker.
+func (w *apiconfigwatcher) Kill() {
+	w.tomb.Kill(nil)
+}
+
+// Wait implements worker.Worker.
+func (w *apiconfigwatcher) Wait() error {
+	return w.tomb.Wait()
+}
+
+func getAPIAddresses(a agent.Agent) []string {
+	config := a.CurrentConfig()
+	addrs, err := config.APIAddresses()
+	if err != nil {
+		logger.Errorf("retrieving API addresses: %s", err)
+		addrs = nil
+	}
+	sort.Strings(addrs)
+	return addrs
+}
+
+func stringSliceEq(a, b []string) bool {
+	if a == nil && b == nil {
+		return true
+	}
+
+	if a == nil || b == nil {
+		return false
+	}
+
+	if len(a) != len(b) {
+		return false
+	}
+
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/worker/apiconfigwatcher/manifold_test.go
+++ b/worker/apiconfigwatcher/manifold_test.go
@@ -1,0 +1,152 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package apiconfigwatcher_test
+
+import (
+	"sync"
+
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/voyeur"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/agent"
+	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/apiconfigwatcher"
+	"github.com/juju/juju/worker/dependency"
+	dt "github.com/juju/juju/worker/dependency/testing"
+	"github.com/juju/juju/worker/workertest"
+)
+
+type ManifoldSuite struct {
+	testing.IsolationSuite
+
+	manifold           dependency.Manifold
+	getResource        dependency.GetResourceFunc
+	agent              *mockAgent
+	agentConfigChanged *voyeur.Value
+}
+
+var _ = gc.Suite(&ManifoldSuite{})
+
+func (s *ManifoldSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+
+	s.agent = new(mockAgent)
+	s.getResource = dt.StubGetResource(dt.StubResources{
+		"agent": dt.StubResource{Output: s.agent},
+	})
+	s.agentConfigChanged = voyeur.NewValue(0)
+	s.manifold = apiconfigwatcher.Manifold(apiconfigwatcher.ManifoldConfig{
+		AgentName:          "agent",
+		AgentConfigChanged: s.agentConfigChanged,
+	})
+}
+
+func (s *ManifoldSuite) TestInputs(c *gc.C) {
+	c.Assert(s.manifold.Inputs, jc.SameContents, []string{"agent"})
+}
+
+func (s *ManifoldSuite) TestNilAgentConfigChanged(c *gc.C) {
+	manifold := apiconfigwatcher.Manifold(apiconfigwatcher.ManifoldConfig{
+		AgentName: "agent",
+	})
+	_, err := manifold.Start(s.getResource)
+	c.Assert(err, gc.ErrorMatches, "nil AgentConfigChanged .+")
+}
+
+func (s *ManifoldSuite) TestNoAgent(c *gc.C) {
+	getResource := dt.StubGetResource(dt.StubResources{
+		"agent": dt.StubResource{Error: dependency.ErrMissing},
+	})
+	_, err := s.manifold.Start(getResource)
+	c.Assert(err, gc.Equals, dependency.ErrMissing)
+}
+
+func (s *ManifoldSuite) TestStart(c *gc.C) {
+	w := s.startWorkerClean(c)
+	workertest.CleanKill(c, w)
+}
+
+func (s *ManifoldSuite) TestBounceOnChange(c *gc.C) {
+	s.agent.conf.setAddresses("1.1.1.1:1")
+	w := s.startWorkerClean(c)
+
+	// Change API addresses - worker should bounce.
+	s.agent.conf.setAddresses("2.2.2.2:2")
+	s.agentConfigChanged.Set(0)
+	err := workertest.CheckKilled(c, w)
+	c.Assert(err, gc.Equals, dependency.ErrBounce)
+
+	// Restart the worker - worker should stay up.
+	w = s.startWorkerClean(c)
+
+	// Change API addresses again - worker should bounce again.
+	s.agent.conf.setAddresses("2.2.2.2:2", "3.3.3.3:3")
+	s.agentConfigChanged.Set(0)
+	err = workertest.CheckKilled(c, w)
+	c.Assert(err, gc.Equals, dependency.ErrBounce)
+}
+
+func (s *ManifoldSuite) TestConfigChangeWithNoAddrChange(c *gc.C) {
+	s.agent.conf.setAddresses("1.1.1.1:1")
+	w := s.startWorkerClean(c)
+
+	// Signal config change without changing API addresses - worker
+	// should continue running.
+	s.agentConfigChanged.Set(0)
+	workertest.CheckAlive(c, w)
+}
+
+func (s *ManifoldSuite) TestConfigChangeWithAddrReordering(c *gc.C) {
+	s.agent.conf.setAddresses("1.1.1.1:1", "2.2.2.2:2")
+	w := s.startWorkerClean(c)
+
+	// Change API address ordering - worker should stay up.
+	s.agent.conf.setAddresses("2.2.2.2:2", "1.1.1.1:1")
+	s.agentConfigChanged.Set(0)
+	workertest.CheckAlive(c, w)
+}
+
+func (s *ManifoldSuite) TestClosedVoyeur(c *gc.C) {
+	w := s.startWorkerClean(c)
+	s.agentConfigChanged.Close()
+	err := workertest.CheckKilled(c, w)
+	c.Assert(err, gc.ErrorMatches, "config changed value closed")
+}
+
+func (s *ManifoldSuite) startWorkerClean(c *gc.C) worker.Worker {
+	w, err := s.manifold.Start(s.getResource)
+	c.Assert(err, jc.ErrorIsNil)
+	workertest.CheckAlive(c, w)
+	return w
+}
+
+type mockAgent struct {
+	agent.Agent
+	conf mockConfig
+}
+
+func (ma *mockAgent) CurrentConfig() agent.Config {
+	return &ma.conf
+}
+
+type mockConfig struct {
+	agent.Config
+
+	mu    sync.Mutex
+	addrs []string
+}
+
+func (mc *mockConfig) setAddresses(addrs ...string) {
+	mc.mu.Lock()
+	defer mc.mu.Unlock()
+	mc.addrs = append([]string(nil), addrs...)
+}
+
+func (mc *mockConfig) APIAddresses() ([]string, error) {
+	mc.mu.Lock()
+	defer mc.mu.Unlock()
+	return mc.addrs, nil
+}

--- a/worker/apiconfigwatcher/package_test.go
+++ b/worker/apiconfigwatcher/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package apiconfigwatcher_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}


### PR DESCRIPTION
The apiconfigwatcher manifold monitors the agent configuration for changes to the API addresses. For any material change the manifold worker will restart itself.

It is intended for use as a dependency for the api-caller worker. The apiconfigwatcher will cause the api-caller to restart whenever the migration minion updates the API server addresses in the agent
configuration.