### PR TITLE
container/kvm: use correct parent network device

### DIFF
--- a/container/kvm/kvm_test.go
+++ b/container/kvm/kvm_test.go
@@ -107,7 +107,10 @@ func (s *KVMSuite) TestWriteTemplate(c *gc.C) {
 		Hostname:      "foo-bar",
 		NetworkBridge: "br0",
 		Interfaces: []network.InterfaceInfo{
-			{MACAddress: "00:16:3e:20:b0:11"},
+			{
+				MACAddress:          "00:16:3e:20:b0:11",
+				ParentInterfaceName: "br-eth0.10",
+			},
 		},
 	}
 	tempDir := c.MkDir()
@@ -122,7 +125,7 @@ func (s *KVMSuite) TestWriteTemplate(c *gc.C) {
 
 	c.Assert(template, jc.Contains, "<name>foo-bar</name>")
 	c.Assert(template, jc.Contains, "<mac address='00:16:3e:20:b0:11'/>")
-	c.Assert(template, jc.Contains, "<source bridge='br0'/>")
+	c.Assert(template, jc.Contains, "<source bridge='br-eth0.10'/>")
 	c.Assert(strings.Count(string(template), "<interface type='bridge'>"), gc.Equals, 1)
 }
 

--- a/container/kvm/template.go
+++ b/container/kvm/template.go
@@ -48,7 +48,7 @@ var kvmTemplate = `
     <interface type='bridge'>
       <mac address='{{$nic.MACAddress}}'/>
       <model type='virtio'/>
-      <source bridge='{{$bridge}}'/>
+      <source bridge='{{$nic.ParentInterfaceName}}'/>
     </interface>
     {{end}}
   </devices>


### PR DESCRIPTION
When rendering the kvm-template.xml configuration the same parent device
was being used for all interfaces. This is incorrect now that we are
using spaces and is fixed by selecting `ParentInterfaceName' from the
modelled network.

Fixes [LP:#1563853](https://bugs.launchpad.net/juju-core/+bug/1563853)

(Review request: http://reviews.vapour.ws/r/4364/)