### PR TITLE
provider/gce: remove getSnapshot

### DIFF
--- a/provider/gce/environ_broker.go
+++ b/provider/gce/environ_broker.go
@@ -36,13 +36,7 @@ func (*environ) MaintainInstance(args environs.StartInstanceParams) error {
 
 // StartInstance implements environs.InstanceBroker.
 func (env *environ) StartInstance(args environs.StartInstanceParams) (*environs.StartInstanceResult, error) {
-	// Please note that in order to fulfil the demands made of Instances and
-	// AllInstances, it is imperative that some environment feature be used to
-	// keep track of which instances were actually started by juju.
-	env = env.getSnapshot()
-
 	// Start a new instance.
-
 	if args.InstanceConfig.HasNetworks() {
 		return nil, errors.New("starting instances with networks is not supported yet")
 	}
@@ -306,8 +300,6 @@ func (env *environ) AllInstances() ([]instance.Instance, error) {
 
 // StopInstances implements environs.InstanceBroker.
 func (env *environ) StopInstances(instances ...instance.Id) error {
-	env = env.getSnapshot()
-
 	var ids []string
 	for _, id := range instances {
 		ids = append(ids, string(id))

--- a/provider/gce/environ_instance.go
+++ b/provider/gce/environ_instance.go
@@ -74,8 +74,6 @@ var getInstances = func(env *environ) ([]instance.Instance, error) {
 // will see they are not tracked in state, assume they're stale/rogue,
 // and shut them down.
 func (env *environ) instances() ([]instance.Instance, error) {
-	env = env.getSnapshot()
-
 	prefix := common.MachineFullName(env.Config().UUID(), "")
 	instances, err := env.gce.Instances(prefix, instStatuses...)
 	err = errors.Trace(err)
@@ -97,8 +95,6 @@ func (env *environ) instances() ([]instance.Instance, error) {
 // ControllerInstances returns the IDs of the instances corresponding
 // to juju controllers.
 func (env *environ) ControllerInstances() ([]instance.Id, error) {
-	env = env.getSnapshot()
-
 	prefix := common.MachineFullName(env.Config().ControllerUUID(), "")
 	instances, err := env.gce.Instances(prefix, instStatuses...)
 	if err != nil {

--- a/provider/gce/instance.go
+++ b/provider/gce/instance.go
@@ -73,8 +73,7 @@ func findInst(id instance.Id, instances []instance.Instance) instance.Instance {
 func (inst *environInstance) OpenPorts(machineID string, ports []network.PortRange) error {
 	// TODO(ericsnow) Make sure machineId matches inst.Id()?
 	name := common.MachineFullName(inst.env.Config().UUID(), machineID)
-	env := inst.env.getSnapshot()
-	err := env.gce.OpenPorts(name, ports...)
+	err := inst.env.gce.OpenPorts(name, ports...)
 	return errors.Trace(err)
 }
 
@@ -82,8 +81,7 @@ func (inst *environInstance) OpenPorts(machineID string, ports []network.PortRan
 // should have been started with the given machine id.
 func (inst *environInstance) ClosePorts(machineID string, ports []network.PortRange) error {
 	name := common.MachineFullName(inst.env.Config().UUID(), machineID)
-	env := inst.env.getSnapshot()
-	err := env.gce.ClosePorts(name, ports...)
+	err := inst.env.gce.ClosePorts(name, ports...)
 	return errors.Trace(err)
 }
 
@@ -92,7 +90,6 @@ func (inst *environInstance) ClosePorts(machineID string, ports []network.PortRa
 // The ports are returned as sorted by SortPorts.
 func (inst *environInstance) Ports(machineID string) ([]network.PortRange, error) {
 	name := common.MachineFullName(inst.env.Config().UUID(), machineID)
-	env := inst.env.getSnapshot()
-	ports, err := env.gce.Ports(name)
+	ports, err := inst.env.gce.Ports(name)
 	return ports, errors.Trace(err)
 }


### PR DESCRIPTION
Updates LP 1563628

getSnapshot was being used incorrectly with the expectation that it was
creating an immutable copy of the environment at that point in time.

(Review request: http://reviews.vapour.ws/r/4367/)