### PR TITLE
Store macaroons in mongo

### DIFF
--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -95,11 +95,12 @@ type state struct {
 	// access it safely.
 	loggedIn int32
 
-	// tag and password and nonce hold the cached login credentials.
-	// These are only valid if loggedIn is 1.
-	tag      string
-	password string
-	nonce    string
+	// tag, password, macaroons and nonce hold the cached login
+	// credentials. These are only valid if loggedIn is 1.
+	tag       string
+	password  string
+	macaroons []macaroon.Slice
+	nonce     string
 
 	// serverRootAddress holds the cached API server address and port used
 	// to login.
@@ -183,6 +184,7 @@ func open(
 		// state structure BEFORE login ?!?
 		tag:          tagToString(info.Tag),
 		password:     info.Password,
+		macaroons:    info.Macaroons,
 		nonce:        info.Nonce,
 		tlsConfig:    tlsConfig,
 		bakeryClient: bakeryClient,

--- a/api/http.go
+++ b/api/http.go
@@ -5,6 +5,7 @@ package api
 
 import (
 	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -13,6 +14,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/httprequest"
 	"gopkg.in/macaroon-bakery.v1/httpbakery"
+	"gopkg.in/macaroon.v1"
 
 	"github.com/juju/juju/apiserver/params"
 )
@@ -70,7 +72,18 @@ func (doer httpRequestDoer) DoWithBody(req *http.Request, body io.ReadSeeker) (*
 	// Add basic auth if appropriate
 	// Call doer.bakeryClient.DoWithBodyAndCustomError
 	if doer.st.tag != "" {
+		// Note that password may be empty here; we still
+		// want to pass the tag along. An empty password
+		// indicates that we're using macaroon authentication.
 		req.SetBasicAuth(doer.st.tag, doer.st.password)
+	}
+	// Add any explicitly-specified macaroons.
+	for _, ms := range doer.st.macaroons {
+		encoded, err := encodeMacaroonSlice(ms)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		req.Header.Add(httpbakery.MacaroonsHeader, encoded)
 	}
 	return doer.st.bakeryClient.DoWithBodyAndCustomError(req, body, func(resp *http.Response) error {
 		// At this point we are only interested in errors that
@@ -82,6 +95,15 @@ func (doer httpRequestDoer) DoWithBody(req *http.Request, body io.ReadSeeker) (*
 		}
 		return bakeryError(unmarshalHTTPErrorResponse(resp))
 	})
+}
+
+// encodeMacaroonSlice base64-JSON-encodes a slice of macaroons.
+func encodeMacaroonSlice(ms macaroon.Slice) (string, error) {
+	data, err := json.Marshal(ms)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	return base64.StdEncoding.EncodeToString(data), nil
 }
 
 // unmarshalHTTPErrorResponse unmarshals an error response from

--- a/api/state.go
+++ b/api/state.go
@@ -36,7 +36,6 @@ import (
 // This method is usually called automatically by Open. The machine nonce
 // should be empty unless logging in as a machine agent.
 func (st *state) Login(tag names.Tag, password, nonce string, ms []macaroon.Slice) error {
-	// TODO(axw) accept and pass on macaroons
 	err := st.loginV3(tag, password, nonce, ms)
 	return errors.Trace(err)
 }

--- a/api/state_test.go
+++ b/api/state_test.go
@@ -115,7 +115,7 @@ func (s *stateSuite) TestLoginMacaroonInvalidId(c *gc.C) {
 	mac, err := macaroon.New([]byte("root-key"), "id", "juju")
 	c.Assert(err, jc.ErrorIsNil)
 	err = apistate.Login(tag, "", "", []macaroon.Slice{{mac}})
-	c.Assert(err, gc.ErrorMatches, "verification failed: macaroon not found in storage")
+	c.Assert(err, gc.ErrorMatches, "invalid entity name or password \\(unauthorized access\\)")
 }
 
 func (s *stateSuite) TestLoginMacaroonInvalidUser(c *gc.C) {
@@ -125,7 +125,7 @@ func (s *stateSuite) TestLoginMacaroonInvalidUser(c *gc.C) {
 	mac, err := usermanager.NewClient(s.APIState).CreateLocalLoginMacaroon(tag.(names.UserTag))
 	c.Assert(err, jc.ErrorIsNil)
 	err = apistate.Login(names.NewUserTag("bob@local"), "", "", []macaroon.Slice{{mac}})
-	c.Assert(err, gc.ErrorMatches, `verification failed: caveat "declared username admin@local" not satisfied: got username="bob@local", expected "admin@local"`)
+	c.Assert(err, gc.ErrorMatches, "invalid entity name or password \\(unauthorized access\\)")
 }
 
 func (s *stateSuite) TestLoginTracksFacadeVersions(c *gc.C) {

--- a/apiserver/authentication/user_test.go
+++ b/apiserver/authentication/user_test.go
@@ -5,10 +5,12 @@ package authentication_test
 
 import (
 	"net/http"
+	"time"
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names"
+	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
@@ -23,6 +25,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/state"
+	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/testing/factory"
 )
 
@@ -138,6 +141,79 @@ func (s *userAuthenticatorSuite) TestInvalidRelationLogin(c *gc.C) {
 	})
 	c.Assert(err, gc.ErrorMatches, "invalid request")
 
+}
+
+func (s *userAuthenticatorSuite) TestValidMacaroonUserLogin(c *gc.C) {
+	user := s.Factory.MakeUser(c, &factory.UserParams{
+		Name: "bobbrown",
+	})
+	macaroons := []macaroon.Slice{{&macaroon.Macaroon{}}}
+	service := mockBakeryService{}
+
+	// User login
+	authenticator := &authentication.UserAuthenticator{Service: &service}
+	_, err := authenticator.Authenticate(s.State, user.Tag(), params.LoginRequest{
+		Credentials: "",
+		Nonce:       "",
+		Macaroons:   macaroons,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	service.CheckCallNames(c, "CheckAny")
+	call := service.Calls()[0]
+	c.Assert(call.Args, gc.HasLen, 3)
+	c.Assert(call.Args[0], jc.DeepEquals, macaroons)
+	c.Assert(call.Args[1], jc.DeepEquals, map[string]string{"username": "bobbrown@local"})
+	// no check for checker function, can't compare functions
+}
+
+func (s *userAuthenticatorSuite) TestCreateLocalLoginMacaroon(c *gc.C) {
+	service := mockBakeryService{}
+	clock := coretesting.NewClock(time.Time{})
+	authenticator := &authentication.UserAuthenticator{
+		Service: &service,
+		Clock:   clock,
+	}
+
+	_, err := authenticator.CreateLocalLoginMacaroon(names.NewUserTag("bobbrown"))
+	c.Assert(err, jc.ErrorIsNil)
+
+	service.CheckCallNames(c, "ExpireStorageAt", "NewMacaroon", "AddCaveat")
+	calls := service.Calls()
+	c.Assert(calls[0].Args, jc.DeepEquals, []interface{}{clock.Now().Add(24 * time.Hour)})
+	c.Assert(calls[1].Args, jc.DeepEquals, []interface{}{
+		"", []byte(nil), []checkers.Caveat{
+			checkers.DeclaredCaveat("username", "bobbrown@local"),
+		},
+	})
+	c.Assert(calls[2].Args, jc.DeepEquals, []interface{}{
+		&macaroon.Macaroon{},
+		checkers.TimeBeforeCaveat(clock.Now().Add(24 * time.Hour)),
+	})
+}
+
+type mockBakeryService struct {
+	testing.Stub
+}
+
+func (s *mockBakeryService) AddCaveat(m *macaroon.Macaroon, caveat checkers.Caveat) error {
+	s.MethodCall(s, "AddCaveat", m, caveat)
+	return s.NextErr()
+}
+
+func (s *mockBakeryService) CheckAny(ms []macaroon.Slice, assert map[string]string, checker checkers.Checker) (map[string]string, error) {
+	s.MethodCall(s, "CheckAny", ms, assert, checker)
+	return nil, s.NextErr()
+}
+
+func (s *mockBakeryService) NewMacaroon(id string, key []byte, caveats []checkers.Caveat) (*macaroon.Macaroon, error) {
+	s.MethodCall(s, "NewMacaroon", id, key, caveats)
+	return &macaroon.Macaroon{}, s.NextErr()
+}
+
+func (s *mockBakeryService) ExpireStorageAt(t time.Time) (authentication.ExpirableStorageBakeryService, error) {
+	s.MethodCall(s, "ExpireStorageAt", t)
+	return s, s.NextErr()
 }
 
 type macaroonAuthenticatorSuite struct {

--- a/apiserver/export_test.go
+++ b/apiserver/export_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-	"gopkg.in/macaroon-bakery.v1/bakery"
 	"gopkg.in/macaroon.v1"
 
 	"github.com/juju/juju/apiserver/authentication"
@@ -40,7 +39,7 @@ func ServerMacaroon(srv *Server) (*macaroon.Macaroon, error) {
 	return auth.(*authentication.ExternalMacaroonAuthenticator).Macaroon, nil
 }
 
-func ServerBakeryService(srv *Server) (*bakery.Service, error) {
+func ServerBakeryService(srv *Server) (authentication.BakeryService, error) {
 	auth, err := srv.authCtxt.macaroonAuth()
 	if err != nil {
 		return nil, err

--- a/apiserver/httpcontext.go
+++ b/apiserver/httpcontext.go
@@ -111,7 +111,7 @@ func (ctxt *httpContext) loginRequest(r *http.Request) (params.LoginRequest, err
 	authHeader := r.Header.Get("Authorization")
 	if authHeader == "" {
 		// No authorization header implies an attempt
-		// to login with macaroon authentication.
+		// to login with external user macaroon authentication.
 		return params.LoginRequest{
 			Macaroons: httpbakery.RequestMacaroons(r),
 		}, nil
@@ -139,6 +139,7 @@ func (ctxt *httpContext) loginRequest(r *http.Request) (params.LoginRequest, err
 	return params.LoginRequest{
 		AuthTag:     tagPass[0],
 		Credentials: tagPass[1],
+		Macaroons:   httpbakery.RequestMacaroons(r),
 		Nonce:       r.Header.Get(params.MachineNonceHeader),
 	}, nil
 }

--- a/apiserver/server_test.go
+++ b/apiserver/server_test.go
@@ -378,7 +378,7 @@ func (s *macaroonServerSuite) TestServerBakery(c *gc.C) {
 	ms, err := client.DischargeAll(m)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = bsvc.Check(ms, checkers.New())
+	err = bsvc.(*bakery.Service).Check(ms, checkers.New())
 	c.Assert(err, gc.IsNil)
 }
 

--- a/featuretests/bakerystorage_test.go
+++ b/featuretests/bakerystorage_test.go
@@ -1,0 +1,96 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package featuretests
+
+import (
+	"time"
+
+	"github.com/juju/juju/mongo"
+	"github.com/juju/juju/state/bakerystorage"
+	gitjujutesting "github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/clock"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/macaroon-bakery.v1/bakery"
+	"gopkg.in/macaroon.v1"
+	"gopkg.in/mgo.v2"
+)
+
+// This suite is not about a feature tests per se, but tests the integration
+// of the mongo-based bakery storage with the macaroon bakery service.
+type BakeryStorageSuite struct {
+	gitjujutesting.MgoSuite
+
+	store   bakery.Storage
+	service *bakery.Service
+	db      *mgo.Database
+	coll    *mgo.Collection
+}
+
+func (s *BakeryStorageSuite) SetUpTest(c *gc.C) {
+	s.MgoSuite.SetUpTest(c)
+
+	s.db = s.Session.DB("bakerydb")
+	s.coll = s.db.C("bakedgoods")
+
+	s.initService(c, time.Minute)
+}
+
+func (s *BakeryStorageSuite) initService(c *gc.C, expiryTime time.Duration) {
+	store, err := bakerystorage.New(bakerystorage.Config{
+		GetCollection: func(name string) (mongo.Collection, func()) {
+			return mongo.CollectionFromName(s.db, name)
+		},
+		Collection:  "bakedgoods",
+		Clock:       clock.WallClock,
+		ExpireAfter: expiryTime,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	s.store = store
+
+	service, err := bakery.NewService(bakery.NewServiceParams{
+		Location: "straya",
+		Store:    s.store,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	s.service = service
+}
+
+func (s *BakeryStorageSuite) ensureIndex(c *gc.C) {
+	err := s.coll.EnsureIndex(mgo.Index{
+		Key:         []string{"expire-at"},
+		ExpireAfter: time.Second,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *BakeryStorageSuite) TestCheckNewMacaroon(c *gc.C) {
+	mac, err := s.service.NewMacaroon("", nil, nil)
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = s.service.CheckAny([]macaroon.Slice{{mac}}, nil, nil)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *BakeryStorageSuite) TestExpiryTime(c *gc.C) {
+	// Reinitialise bakery service with storage that will expire
+	// items after 1 second.
+	s.initService(c, time.Second)
+	s.ensureIndex(c)
+
+	mac, err := s.service.NewMacaroon("", nil, nil)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// The background thread that removes records runs every 60s.
+	// Give a little bit of leeway for loaded systems.
+	for i := 0; i < 90; i++ {
+		_, err = s.service.CheckAny([]macaroon.Slice{{mac}}, nil, nil)
+		if err == nil {
+			time.Sleep(time.Second)
+			continue
+		}
+		c.Assert(err, gc.ErrorMatches, "verification failed: macaroon not found in storage")
+		return
+	}
+	c.Fatal("timed out waiting for storage expiry")
+}

--- a/featuretests/package_test.go
+++ b/featuretests/package_test.go
@@ -39,6 +39,7 @@ func init() {
 	gc.Suite(&upgradeSuite{})
 	gc.Suite(&cmdRegistrationSuite{})
 	gc.Suite(&cmdLoginSuite{})
+	gc.Suite(&BakeryStorageSuite{})
 }
 
 func TestPackage(t *stdtesting.T) {

--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -4,6 +4,8 @@
 package state
 
 import (
+	"time"
+
 	"gopkg.in/mgo.v2"
 )
 
@@ -157,6 +159,19 @@ func allCollections() collectionSchema {
 		// This collection was deprecated before multi-model support
 		// was implemented.
 		actionresultsC: {global: true},
+
+		// This collection holds storage items for a macaroon bakery.
+		bakeryStorageItemsC: {
+			global: true,
+			indexes: []mgo.Index{{
+				Key: []string{"expire-at"},
+				// We expire records when the clock time is one
+				// second older than the record's expire-at field
+				// value. It has to be at least one second, because
+				// mgo uses "omitempty" for this field.
+				ExpireAfter: time.Second,
+			}},
+		},
 
 		// -----------------
 
@@ -404,6 +419,7 @@ const (
 	actionsC                 = "actions"
 	annotationsC             = "annotations"
 	assignUnitC              = "assignUnits"
+	bakeryStorageItemsC      = "bakeryStorageItems"
 	blockDevicesC            = "blockdevices"
 	blocksC                  = "blocks"
 	charmsC                  = "charms"

--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -4,9 +4,9 @@
 package state
 
 import (
-	"time"
-
 	"gopkg.in/mgo.v2"
+
+	"github.com/juju/juju/state/bakerystorage"
 )
 
 // The capped collection used for transaction logs defaults to 10MB.
@@ -162,15 +162,8 @@ func allCollections() collectionSchema {
 
 		// This collection holds storage items for a macaroon bakery.
 		bakeryStorageItemsC: {
-			global: true,
-			indexes: []mgo.Index{{
-				Key: []string{"expire-at"},
-				// We expire records when the clock time is one
-				// second older than the record's expire-at field
-				// value. It has to be at least one second, because
-				// mgo uses "omitempty" for this field.
-				ExpireAfter: time.Second,
-			}},
+			global:  true,
+			indexes: bakerystorage.MongoIndexes(),
 		},
 
 		// -----------------

--- a/state/bakerystorage.go
+++ b/state/bakerystorage.go
@@ -4,21 +4,18 @@
 package state
 
 import (
-	"time"
-
+	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/state/bakerystorage"
-
-	"gopkg.in/macaroon-bakery.v1/bakery"
 )
 
-// NewBakeryStorage returns a new bakery.Storage that will remove any
-// entries after the "expiry" duration starting from when they are
-// added to storage.
-func (st *State) NewBakeryStorage(expiry time.Duration) (bakery.Storage, error) {
+// NewBakeryStorage returns a new bakery.Storage. By default, items
+// added to the store are retained until deleted explicitly. The
+// store's ExpireAt method can be called to derive a new store that
+// will expire items at the specified time.
+func (st *State) NewBakeryStorage() (bakerystorage.ExpirableStorage, error) {
 	return bakerystorage.New(bakerystorage.Config{
-		GetCollection: st.getCollection,
-		Collection:    bakeryStorageItemsC,
-		Clock:         GetClock(),
-		ExpireAfter:   expiry,
+		GetCollection: func() (mongo.Collection, func()) {
+			return st.getCollection(bakeryStorageItemsC)
+		},
 	})
 }

--- a/state/bakerystorage.go
+++ b/state/bakerystorage.go
@@ -1,0 +1,24 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"time"
+
+	"github.com/juju/juju/state/bakerystorage"
+
+	"gopkg.in/macaroon-bakery.v1/bakery"
+)
+
+// NewBakeryStorage returns a new bakery.Storage that will remove any
+// entries after the "expiry" duration starting from when they are
+// added to storage.
+func (st *State) NewBakeryStorage(expiry time.Duration) (bakery.Storage, error) {
+	return bakerystorage.New(bakerystorage.Config{
+		GetCollection: st.getCollection,
+		Collection:    bakeryStorageItemsC,
+		Clock:         GetClock(),
+		ExpireAfter:   expiry,
+	})
+}

--- a/state/bakerystorage/interface.go
+++ b/state/bakerystorage/interface.go
@@ -1,0 +1,65 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Package bakerystorage provides an implementation
+// of the bakery Storage interface that uses MongoDB
+// to store items.
+//
+// This is based on gopkg.in/macaroon-bakery.v1/bakery/mgostorage.
+package bakerystorage
+
+import (
+	"time"
+
+	"github.com/juju/errors"
+	"github.com/juju/utils/clock"
+	"gopkg.in/macaroon-bakery.v1/bakery"
+
+	"github.com/juju/juju/mongo"
+)
+
+// Config contains configuration for creating bakery storage with New.
+type Config struct {
+	// GetCollection returns a mongo.Collection, and a function that will close
+	// any associated resources, given a collection name.
+	GetCollection func(name string) (collection mongo.Collection, closer func())
+
+	// Collection is the name of the storage collection.
+	Collection string
+
+	// Clock is used to calculate the expiry time for storage items.
+	Clock clock.Clock
+
+	// ExpireAfter is the amount of time a storage item will remain in
+	// the collection. It is expected that there is an "expireAfterSeconds"
+	// index on the collection on the "expireAt" field, with a value of 1
+	// (not 0, which is impossible with mgo's EnsureIndex interface).
+	ExpireAfter time.Duration
+}
+
+// Validate validates the configuration.
+func (c Config) Validate() error {
+	if c.GetCollection == nil {
+		return errors.NotValidf("nil GetCollection")
+	}
+	if c.Collection == "" {
+		return errors.NotValidf("empty Collection")
+	}
+	if c.Clock == nil {
+		return errors.NotValidf("nil Clock")
+	}
+	if c.ExpireAfter == 0 {
+		return errors.NotValidf("unspecified ExpireAfter")
+	}
+	return nil
+}
+
+// New returns an implementation of bakery.Storage
+// that stores all items in MongoDB with an expiry
+// time.
+func New(config Config) (bakery.Storage, error) {
+	if err := config.Validate(); err != nil {
+		return nil, errors.Annotate(err, "validating config")
+	}
+	return &storage{config}, nil
+}

--- a/state/bakerystorage/package_test.go
+++ b/state/bakerystorage/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package bakerystorage
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/state/bakerystorage/storage.go
+++ b/state/bakerystorage/storage.go
@@ -1,0 +1,74 @@
+// Copyright 2014-2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package bakerystorage
+
+import (
+	"time"
+
+	"github.com/juju/errors"
+	"gopkg.in/macaroon-bakery.v1/bakery"
+	"gopkg.in/mgo.v2"
+)
+
+type storage struct {
+	config Config
+}
+
+type storageDoc struct {
+	Location string    `bson:"_id"`
+	Item     string    `bson:"item"`
+	ExpireAt time.Time `bson:"expire-at"`
+}
+
+// Put implements bakery.Storage.Put.
+func (s *storage) Put(location, item string) error {
+	coll, closer := s.config.GetCollection(s.config.Collection)
+	defer closer()
+
+	doc := storageDoc{
+		Location: location,
+		Item:     item,
+		// NOTE(axw) we subtract one second to the expiry time, because
+		// the expireAfterSeconds index we create is 1 and not 0 due to
+		// a limitation in the mgo EnsureIndex API.
+		ExpireAt: s.config.Clock.Now().Add(s.config.ExpireAfter - time.Second),
+	}
+	_, err := coll.Writeable().UpsertId(location, doc)
+	if err != nil {
+		return errors.Annotatef(err, "cannot store item for location %q", location)
+	}
+	return nil
+}
+
+// Get implements bakery.Storage.Get.
+func (s *storage) Get(location string) (string, error) {
+	coll, closer := s.config.GetCollection(s.config.Collection)
+	defer closer()
+
+	var i storageDoc
+	err := coll.FindId(location).One(&i)
+	if err != nil {
+		if err == mgo.ErrNotFound {
+			return "", bakery.ErrNotFound
+		}
+		return "", errors.Annotatef(err, "cannot get item for location %q", location)
+	}
+	return i.Item, nil
+}
+
+// Del implements bakery.Storage.Del.
+func (s *storage) Del(location string) error {
+	coll, closer := s.config.GetCollection(s.config.Collection)
+	defer closer()
+
+	err := coll.Writeable().RemoveId(location)
+	if err != nil {
+		if err == mgo.ErrNotFound {
+			// Not an error to remove an item that doesn't exist.
+			return nil
+		}
+		return errors.Annotatef(err, "cannot remove item for location %q", location)
+	}
+	return nil
+}

--- a/state/bakerystorage/storage_test.go
+++ b/state/bakerystorage/storage_test.go
@@ -1,0 +1,207 @@
+// Copyright 2014-2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package bakerystorage
+
+import (
+	"errors"
+	"time"
+
+	gitjujutesting "github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/macaroon-bakery.v1/bakery"
+	"gopkg.in/mgo.v2"
+
+	"github.com/juju/juju/mongo"
+	"github.com/juju/juju/testing"
+)
+
+type StorageSuite struct {
+	testing.BaseSuite
+	gitjujutesting.Stub
+	collection      mockCollection
+	closeCollection func()
+	clock           *testing.Clock
+	config          Config
+	store           bakery.Storage
+}
+
+var _ = gc.Suite(&StorageSuite{})
+
+func (s *StorageSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+	s.Stub.ResetCalls()
+	s.collection = mockCollection{Stub: &s.Stub}
+	s.closeCollection = func() {
+		s.AddCall("Close")
+		s.PopNoErr()
+	}
+	s.clock = testing.NewClock(time.Time{})
+	s.config = Config{
+		GetCollection: func(name string) (mongo.Collection, func()) {
+			s.AddCall("GetCollection", name)
+			s.PopNoErr()
+			return &s.collection, s.closeCollection
+		},
+		Collection:  "bakery-storage",
+		Clock:       s.clock,
+		ExpireAfter: time.Minute * 42,
+	}
+}
+
+func (s *StorageSuite) TestValidateConfigGetCollection(c *gc.C) {
+	s.config.GetCollection = nil
+	_, err := New(s.config)
+	c.Assert(err, gc.ErrorMatches, "validating config: nil GetCollection not valid")
+}
+
+func (s *StorageSuite) TestValidateConfigCollection(c *gc.C) {
+	s.config.Collection = ""
+	_, err := New(s.config)
+	c.Assert(err, gc.ErrorMatches, "validating config: empty Collection not valid")
+}
+
+func (s *StorageSuite) TestValidateConfigClock(c *gc.C) {
+	s.config.Clock = nil
+	_, err := New(s.config)
+	c.Assert(err, gc.ErrorMatches, "validating config: nil Clock not valid")
+}
+
+func (s *StorageSuite) TestValidateConfigExpireAfter(c *gc.C) {
+	s.config.ExpireAfter = 0
+	_, err := New(s.config)
+	c.Assert(err, gc.ErrorMatches, "validating config: unspecified ExpireAfter not valid")
+}
+
+func (s *StorageSuite) TestPut(c *gc.C) {
+	store, err := New(s.config)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = store.Put("foo", "bar")
+	c.Assert(err, jc.ErrorIsNil)
+	s.CheckCalls(c, []gitjujutesting.StubCall{
+		{"GetCollection", []interface{}{s.config.Collection}},
+		{"Writeable", nil},
+		{"UpsertId", []interface{}{"foo", storageDoc{
+			Location: "foo",
+			Item:     "bar",
+			ExpireAt: s.clock.Now().Add(s.config.ExpireAfter - time.Second),
+		}}},
+		{"Close", nil},
+	})
+}
+
+func (s *StorageSuite) TestPutError(c *gc.C) {
+	store, err := New(s.config)
+	c.Assert(err, jc.ErrorIsNil)
+	s.SetErrors(nil, nil, errors.New("failed to upsert"))
+	err = store.Put("foo", "bar")
+	c.Assert(err, gc.ErrorMatches, `cannot store item for location "foo": failed to upsert`)
+}
+
+func (s *StorageSuite) TestGet(c *gc.C) {
+	store, err := New(s.config)
+	c.Assert(err, jc.ErrorIsNil)
+	item, err := store.Get("foo")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(item, gc.Equals, "item-value")
+	s.CheckCalls(c, []gitjujutesting.StubCall{
+		{"GetCollection", []interface{}{s.config.Collection}},
+		{"FindId", []interface{}{"foo"}},
+		{"One", []interface{}{&storageDoc{
+			// Set by mock, not in input. Unimportant anyway.
+			Location: "foo",
+			Item:     "item-value",
+		}}},
+		{"Close", nil},
+	})
+}
+
+func (s *StorageSuite) TestGetNotFound(c *gc.C) {
+	store, err := New(s.config)
+	c.Assert(err, jc.ErrorIsNil)
+	s.SetErrors(nil, nil, mgo.ErrNotFound)
+	_, err = store.Get("foo")
+	c.Assert(err, gc.Equals, bakery.ErrNotFound)
+}
+
+func (s *StorageSuite) TestGetError(c *gc.C) {
+	store, err := New(s.config)
+	c.Assert(err, jc.ErrorIsNil)
+	s.SetErrors(nil, nil, errors.New("failed to read"))
+	_, err = store.Get("foo")
+	c.Assert(err, gc.ErrorMatches, `cannot get item for location "foo": failed to read`)
+}
+
+func (s *StorageSuite) TestDel(c *gc.C) {
+	store, err := New(s.config)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = store.Del("foo")
+	c.Assert(err, jc.ErrorIsNil)
+	s.CheckCalls(c, []gitjujutesting.StubCall{
+		{"GetCollection", []interface{}{s.config.Collection}},
+		{"Writeable", nil},
+		{"RemoveId", []interface{}{"foo"}},
+		{"Close", nil},
+	})
+}
+
+func (s *StorageSuite) TestDelNotFound(c *gc.C) {
+	store, err := New(s.config)
+	c.Assert(err, jc.ErrorIsNil)
+	s.SetErrors(nil, nil, mgo.ErrNotFound)
+	err = store.Del("foo")
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *StorageSuite) TestDelError(c *gc.C) {
+	store, err := New(s.config)
+	c.Assert(err, jc.ErrorIsNil)
+	s.SetErrors(nil, nil, errors.New("failed to remove"))
+	err = store.Del("foo")
+	c.Assert(err, gc.ErrorMatches, `cannot remove item for location "foo": failed to remove`)
+}
+
+type mockCollection struct {
+	mongo.WriteCollection
+	*gitjujutesting.Stub
+}
+
+func (c *mockCollection) FindId(id interface{}) mongo.Query {
+	c.MethodCall(c, "FindId", id)
+	c.PopNoErr()
+	return &mockQuery{Stub: c.Stub, id: id}
+}
+
+func (c *mockCollection) UpsertId(id, update interface{}) (*mgo.ChangeInfo, error) {
+	c.MethodCall(c, "UpsertId", id, update)
+	return &mgo.ChangeInfo{}, c.NextErr()
+}
+
+func (c *mockCollection) RemoveId(id interface{}) error {
+	c.MethodCall(c, "RemoveId", id)
+	return c.NextErr()
+}
+
+func (c *mockCollection) Writeable() mongo.WriteCollection {
+	c.MethodCall(c, "Writeable")
+	c.PopNoErr()
+	return c
+}
+
+type mockQuery struct {
+	mongo.Query
+	*gitjujutesting.Stub
+	id interface{}
+}
+
+func (q *mockQuery) One(result interface{}) error {
+	q.MethodCall(q, "One", result)
+	*result.(*storageDoc) = storageDoc{
+		Location: q.id.(string),
+		Item:     "item-value",
+	}
+	return q.NextErr()
+}

--- a/state/collection.go
+++ b/state/collection.go
@@ -66,14 +66,14 @@ func (c *modelStateCollection) Count() (int, error) {
 // "_id" field (e.g. using the $in operator) will not be modified. In
 // these cases it is up to the caller to add model UUID
 // prefixes when necessary.
-func (c *modelStateCollection) Find(query interface{}) *mgo.Query {
+func (c *modelStateCollection) Find(query interface{}) mongo.Query {
 	return c.WriteCollection.Find(c.mungeQuery(query))
 }
 
 // FindId looks up a single document by _id. If the id is a string the
 // relevant model UUID prefix will be added to it. Otherwise, the
 // query will be handled as per Find().
-func (c *modelStateCollection) FindId(id interface{}) *mgo.Query {
+func (c *modelStateCollection) FindId(id interface{}) mongo.Query {
 	if sid, ok := id.(string); ok {
 		return c.WriteCollection.FindId(ensureModelUUID(c.modelUUID, sid))
 	}

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -74,6 +74,10 @@ func (s *MigrationSuite) TestKnownCollections(c *gc.C) {
 		// Not exported, but the tools will possibly need to be either bundled
 		// with the representation or sent separately.
 		toolsmetadataC,
+		// Bakery storage items are non-critical. We store root keys for
+		// temporary credentials in there; after migration you'll just have
+		// to log back in.
+		bakeryStorageItemsC,
 		// Transaction stuff.
 		"txns",
 		"txns.log",

--- a/state/model.go
+++ b/state/model.go
@@ -16,6 +16,7 @@ import (
 	"gopkg.in/mgo.v2/txn"
 
 	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/mongo"
 	"github.com/juju/version"
 )
 
@@ -364,7 +365,7 @@ func (m *Model) Refresh() error {
 	return m.refresh(models.FindId(m.UUID()))
 }
 
-func (m *Model) refresh(query *mgo.Query) error {
+func (m *Model) refresh(query mongo.Query) error {
 	err := query.One(&m.doc)
 	if err == mgo.ErrNotFound {
 		return errors.NotFoundf("model")

--- a/state/mongo.go
+++ b/state/mongo.go
@@ -14,7 +14,7 @@ import (
 )
 
 // environMongo implements state/lease.Mongo to expose environ-filtered mongo
-// capabilities to the lease package.
+// capabilities to the sub-packages (e.g. lease, macaroonstorage).
 type environMongo struct {
 	state *State
 }


### PR DESCRIPTION
Store macaroons in mongo. We use a TTL index to
automatically garbage collect root keys after
the time-before caveat on the macaroon expires.

Also, send local-login macaroons with HTTP requests.
Fixes https://bugs.launchpad.net/bugs/1563762

(Review request: http://reviews.vapour.ws/r/4371/)