### PR TITLE
Fixes bug 1556293: gce invalid volume ID.

### DIFF
--- a/provider/gce/disks_test.go
+++ b/provider/gce/disks_test.go
@@ -197,6 +197,54 @@ func (s *volumeSourceSuite) TestListVolumes(c *gc.C) {
 	c.Assert(call[0].ZoneName, gc.Equals, "home-zone")
 }
 
+func (s *volumeSourceSuite) TestListVolumesOnlyListsCurrentEnvUUID(c *gc.C) {
+	otherDisk := &google.Disk{
+		Id:          1234568,
+		Name:        "home-zone--566fe7b2-c026-4a86-a2cc-84cb7f9a4868",
+		Zone:        "home-zone",
+		Status:      google.StatusReady,
+		Size:        1024,
+		Description: "a-different-model-uuid",
+	}
+	s.FakeConn.GoogleDisks = []*google.Disk{s.BaseDisk, otherDisk}
+	s.FakeConn.Zones = []google.AvailabilityZone{google.NewZone("home-zone", "Ready", "", "")}
+	vols, err := s.source.ListVolumes()
+	c.Check(err, jc.ErrorIsNil)
+	c.Assert(vols, gc.HasLen, 1)
+}
+
+func (s *volumeSourceSuite) TestListVolumesListsEmptyUUIDVolumes(c *gc.C) {
+	otherDisk := &google.Disk{
+		Id:          1234568,
+		Name:        "home-zone--566fe7b2-c026-4a86-a2cc-84cb7f9a4868",
+		Zone:        "home-zone",
+		Status:      google.StatusReady,
+		Size:        1024,
+		Description: "",
+	}
+	s.FakeConn.GoogleDisks = []*google.Disk{s.BaseDisk, otherDisk}
+	s.FakeConn.Zones = []google.AvailabilityZone{google.NewZone("home-zone", "Ready", "", "")}
+	vols, err := s.source.ListVolumes()
+	c.Check(err, jc.ErrorIsNil)
+	c.Assert(vols, gc.HasLen, 2)
+}
+
+func (s *volumeSourceSuite) TestListVolumesIgnoresNamesFormattedDifferently(c *gc.C) {
+	otherDisk := &google.Disk{
+		Id:          1234568,
+		Name:        "juju-566fe7b2-c026-4a86-a2cc-84cb7f9a4868",
+		Zone:        "home-zone",
+		Status:      google.StatusReady,
+		Size:        1024,
+		Description: "",
+	}
+	s.FakeConn.GoogleDisks = []*google.Disk{s.BaseDisk, otherDisk}
+	s.FakeConn.Zones = []google.AvailabilityZone{google.NewZone("home-zone", "Ready", "", "")}
+	vols, err := s.source.ListVolumes()
+	c.Check(err, jc.ErrorIsNil)
+	c.Assert(vols, gc.HasLen, 1)
+}
+
 func (s *volumeSourceSuite) TestDescribeVolumes(c *gc.C) {
 	s.FakeConn.GoogleDisk = s.BaseDisk
 	volName := "home-zone--c930380d-8337-4bf5-b07a-9dbb5ae771e4"

--- a/provider/gce/google/disk_test.go
+++ b/provider/gce/google/disk_test.go
@@ -36,8 +36,24 @@ func (s *diskSuite) TestDiskSpecSizeGB(c *gc.C) {
 	c.Check(size, gc.Equals, uint64(15))
 }
 
-func (s *diskSuite) TestDiskSpecSizeGBMin(c *gc.C) {
+func (s *diskSuite) TestDiskSpecSizeGBMinUbuntu(c *gc.C) {
 	s.DiskSpec.SizeHintGB = 0
+	size := s.DiskSpec.SizeGB()
+
+	c.Check(size, gc.Equals, uint64(10))
+}
+
+func (s *diskSuite) TestDiskSpecSizeGBMinWindows(c *gc.C) {
+	s.DiskSpec.SizeHintGB = 0
+	s.DiskSpec.Series = "win2012r2"
+	size := s.DiskSpec.SizeGB()
+
+	c.Check(size, gc.Equals, uint64(50))
+}
+
+func (s *diskSuite) TestDiskSpecSizeGBMinUnknown(c *gc.C) {
+	s.DiskSpec.SizeHintGB = 0
+	s.DiskSpec.Series = "arch"
 	size := s.DiskSpec.SizeGB()
 
 	c.Check(size, gc.Equals, uint64(10))


### PR DESCRIPTION
Ensure volumes are easily distinguished by env uuid.
Added os-specific size check.
Fixed volume listing.

(Review request: http://reviews.vapour.ws/r/4372/)