### PR TITLE
worker/metrics/sender: fix mutex copy bug in test

### DIFF
--- a/worker/metrics/sender/sender_test.go
+++ b/worker/metrics/sender/sender_test.go
@@ -283,7 +283,7 @@ func (c *mockConnection) Close() error {
 	return nil
 }
 
-func (c mockConnection) eof() bool {
+func (c *mockConnection) eof() bool {
 	return len(c.data) == 0
 }
 


### PR DESCRIPTION
Fixes 1563628

Fixed accidental copy of a mutex in test.

Fixes LP 1563628 when #4938, #4937 and #4931 are comitted.

(Review request: http://reviews.vapour.ws/r/4376/)