### PR TITLE
Use gomaasapi MAAS 2 controller

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -20,7 +20,7 @@ github.com/juju/go4	git	40d72ab9641a2a8c36a9c46a51e28367115c8e59	2016-02-22T16:3
 github.com/juju/gojsonpointer	git	afe8b77aa08f272b49e01b82de78510c11f61500	2015-02-04T19:46:29Z
 github.com/juju/gojsonreference	git	f0d24ac5ee330baa21721cdff56d45e4ee42628e	2015-02-04T19:46:33Z
 github.com/juju/gojsonschema	git	e1ad140384f254c82f89450d9a7c8dd38a632838	2015-03-12T17:00:16Z
-github.com/juju/gomaasapi       git     3888cd414c8d0ec07bc0867fd22ce130bd9bb7c7        2016-03-31T13:55:14Z
+github.com/juju/gomaasapi	git	3888cd414c8d0ec07bc0867fd22ce130bd9bb7c7	2016-03-31T13:55:14Z
 github.com/juju/govmomi	git	4354a88d4b34abe467215f77c2fc1cb9f78b66f7	2015-04-24T01:54:48Z
 github.com/juju/httpprof	git	14bf14c307672fd2456bdbf35d19cf0ccd3cf565	2014-12-17T16:00:36Z
 github.com/juju/httprequest	git	89d547093c45e293599088cc63e805c6f1205dc0	2016-03-02T10:09:58Z

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -20,7 +20,7 @@ github.com/juju/go4	git	40d72ab9641a2a8c36a9c46a51e28367115c8e59	2016-02-22T16:3
 github.com/juju/gojsonpointer	git	afe8b77aa08f272b49e01b82de78510c11f61500	2015-02-04T19:46:29Z
 github.com/juju/gojsonreference	git	f0d24ac5ee330baa21721cdff56d45e4ee42628e	2015-02-04T19:46:33Z
 github.com/juju/gojsonschema	git	e1ad140384f254c82f89450d9a7c8dd38a632838	2015-03-12T17:00:16Z
-github.com/juju/gomaasapi	git	29f9675f72711e0b40a577fd2636ab68b5608655	2016-03-17T18:40:24Z
+github.com/juju/gomaasapi       git     3888cd414c8d0ec07bc0867fd22ce130bd9bb7c7        2016-03-31T13:55:14Z
 github.com/juju/govmomi	git	4354a88d4b34abe467215f77c2fc1cb9f78b66f7	2015-04-24T01:54:48Z
 github.com/juju/httpprof	git	14bf14c307672fd2456bdbf35d19cf0ccd3cf565	2014-12-17T16:00:36Z
 github.com/juju/httprequest	git	89d547093c45e293599088cc63e805c6f1205dc0	2016-03-02T10:09:58Z

--- a/provider/maas/config_test.go
+++ b/provider/maas/config_test.go
@@ -4,6 +4,8 @@
 package maas
 
 import (
+	"net/http"
+
 	"github.com/juju/gomaasapi"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
@@ -53,6 +55,10 @@ func (s *configSuite) SetUpTest(c *gc.C) {
 		return set.NewStrings("network-deployment-ubuntu"), nil
 	}
 	s.PatchValue(&GetCapabilities, mockCapabilities)
+	mockGetController := func(maasServer, apiKey string) (gomaasapi.Controller, error) {
+		return nil, gomaasapi.ServerError{StatusCode: http.StatusNotFound}
+	}
+	s.PatchValue(&GetMAAS2Controller, mockGetController)
 }
 
 func (*configSuite) TestParsesMAASSettings(c *gc.C) {

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -1,5 +1,5 @@
 // Copyright 2013 Canonical Ltd.
-// Licensed under the AGPLv4, see LICENCE file for details.
+// Licensed under the AGPLv3, see LICENCE file for details.
 
 package maas
 

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -1,5 +1,5 @@
 // Copyright 2013 Canonical Ltd.
-// Licensed under the AGPLv3, see LICENCE file for details.
+// Licensed under the AGPLv4, see LICENCE file for details.
 
 package maas
 
@@ -208,6 +208,10 @@ func NewEnviron(cfg *config.Config) (*maasEnviron, error) {
 	env.storageUnlocked = NewStorage(env)
 
 	return env, nil
+}
+
+func (env *maasEnviron) usingMAAS2() bool {
+	return env.apiVersion == "2.0"
 }
 
 // Bootstrap is specified in the Environ interface.

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -302,6 +302,8 @@ func (env *maasEnviron) SetConfig(cfg *config.Config) error {
 	apiVersion := "2.0"
 	controller, err := gomaasapi.NewController(gomaasapi.ControllerArgs{
 		ecfg.maasServer(), ecfg.maasOAuth()})
+	// TODO (mfoord): we should probably be checking specifically for a 404
+	// error here.
 	if err != nil {
 		apiVersion = "1.0"
 		authClient, err := gomaasapi.NewAuthenticatedClient(ecfg.maasServer(), ecfg.maasOAuth(), "1.0")

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -41,6 +41,9 @@ import (
 const (
 	// The string from the api indicating the dynamic range of a subnet.
 	dynamicRange = "dynamic-range"
+	// The version strings indicating the MAAS API version.
+	apiVersion1 = "1.0"
+	apiVersion2 = "2.0"
 )
 
 // A request may fail to due "eventual consistency" semantics, which
@@ -216,7 +219,7 @@ func NewEnviron(cfg *config.Config) (*maasEnviron, error) {
 }
 
 func (env *maasEnviron) usingMAAS2() bool {
-	return env.apiVersion == "2.0"
+	return env.apiVersion == apiVersion2
 }
 
 // Bootstrap is specified in the Environ interface.
@@ -308,12 +311,12 @@ func (env *maasEnviron) SetConfig(cfg *config.Config) error {
 	// We need to know the version of the server we're on. We support 1.9
 	// and 2.0. MAAS 1.9 uses the 1.0 api version and 2.0 uses the 2.0 api
 	// version.
-	apiVersion := "2.0"
+	apiVersion := apiVersion2
 	controller, err := GetMAAS2Controller(ecfg.maasServer(), ecfg.maasOAuth())
 	maasErr, ok := errors.Cause(err).(gomaasapi.ServerError)
 	if ok && maasErr.StatusCode == http.StatusNotFound {
-		apiVersion = "1.0"
-		authClient, err := gomaasapi.NewAuthenticatedClient(ecfg.maasServer(), ecfg.maasOAuth(), "1.0")
+		apiVersion = apiVersion1
+		authClient, err := gomaasapi.NewAuthenticatedClient(ecfg.maasServer(), ecfg.maasOAuth(), apiVersion1)
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/provider/maas/environ_test.go
+++ b/provider/maas/environ_test.go
@@ -4,6 +4,7 @@
 package maas_test
 
 import (
+	"net/http"
 	stdtesting "testing"
 
 	"github.com/juju/gomaasapi"
@@ -49,7 +50,11 @@ func (s *environSuite) SetUpTest(c *gc.C) {
 	mockCapabilities := func(client *gomaasapi.MAASObject) (set.Strings, error) {
 		return set.NewStrings("network-deployment-ubuntu"), nil
 	}
+	mockGetController := func(maasServer, apiKey string) (gomaasapi.Controller, error) {
+		return nil, gomaasapi.ServerError{StatusCode: http.StatusNotFound}
+	}
 	s.PatchValue(&maas.GetCapabilities, mockCapabilities)
+	s.PatchValue(&maas.GetMAAS2Controller, mockGetController)
 }
 
 func (s *environSuite) TearDownTest(c *gc.C) {

--- a/provider/maas/environ_whitebox_test.go
+++ b/provider/maas/environ_whitebox_test.go
@@ -28,12 +28,10 @@ import (
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/bootstrap"
 	"github.com/juju/juju/environs/config"
-	sstesting "github.com/juju/juju/environs/simplestreams/testing"
 	envstorage "github.com/juju/juju/environs/storage"
 	envtesting "github.com/juju/juju/environs/testing"
 	envtools "github.com/juju/juju/environs/tools"
 	"github.com/juju/juju/instance"
-	"github.com/juju/juju/juju"
 	"github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/provider/common"
@@ -72,13 +70,6 @@ func getTestConfig(name, server, oauth, secret string) *config.Config {
 		panic(err)
 	}
 	return ecfg.Config
-}
-
-func (suite *environSuite) setupFakeTools(c *gc.C) {
-	suite.PatchValue(&juju.JujuPublicKey, sstesting.SignedMetadataPublicKey)
-	storageDir := c.MkDir()
-	suite.PatchValue(&envtools.DefaultBaseURL, "file://"+storageDir+"/tools")
-	suite.UploadFakeToolsToDirectory(c, storageDir, "released", "released")
 }
 
 func (suite *environSuite) addNode(jsonText string) instance.Id {

--- a/provider/maas/environprovider.go
+++ b/provider/maas/environprovider.go
@@ -104,6 +104,12 @@ func (p maasEnvironProvider) PrepareForBootstrap(ctx environs.BootstrapContext, 
 }
 
 func verifyCredentials(env *maasEnviron) error {
+	// TODO (mfoord): horrible hardcoded version check.
+	// If we're using the 2.0 API we've already made a succesful authenticated
+	// call.
+	if env.apiVersion == "2.0" {
+		return nil
+	}
 	// Verify we can connect to the server and authenticate.
 	_, err := env.getMAASClient().GetSubObject("maas").CallGet("get_config", nil)
 	if err, ok := err.(gomaasapi.ServerError); ok && err.StatusCode == http.StatusUnauthorized {

--- a/provider/maas/environprovider.go
+++ b/provider/maas/environprovider.go
@@ -106,8 +106,7 @@ func (p maasEnvironProvider) PrepareForBootstrap(ctx environs.BootstrapContext, 
 func verifyCredentials(env *maasEnviron) error {
 	var err error
 	// Verify we can connect to the server and authenticate.
-	// TODO (mfoord): horrible hardcoded version check.
-	if env.apiVersion == "2.0" {
+	if env.usingMAAS2() {
 		// TODO (mfoord): use a lighterweight endpoint than machines.
 		// Could implement /api/2.0/maas/ op=get_config in new API
 		// layer.

--- a/provider/maas/environprovider.go
+++ b/provider/maas/environprovider.go
@@ -111,7 +111,7 @@ func verifyCredentials(env *maasEnviron) error {
 		// TODO (mfoord): use a lighterweight endpoint than machines.
 		// Could implement /api/2.0/maas/ op=get_config in new API
 		// layer.
-		_, err = env.maasController.Machines(gomaasapi.MachinesParams{})
+		_, err = env.maasController.Machines(gomaasapi.MachinesArgs{})
 	} else {
 		_, err = env.getMAASClient().GetSubObject("maas").CallGet("get_config", nil)
 	}

--- a/provider/maas/environprovider.go
+++ b/provider/maas/environprovider.go
@@ -109,6 +109,8 @@ func verifyCredentials(env *maasEnviron) error {
 	// TODO (mfoord): horrible hardcoded version check.
 	if env.apiVersion == "2.0" {
 		// TODO (mfoord): use a lighterweight endpoint than machines.
+		// Could implement /api/2.0/maas/ op=get_config in new API
+		// layer.
 		_, err = env.maasController.Machines(gomaasapi.MachinesParams{})
 	} else {
 		_, err = env.getMAASClient().GetSubObject("maas").CallGet("get_config", nil)

--- a/provider/maas/maas2_environ_whitebox_test.go
+++ b/provider/maas/maas2_environ_whitebox_test.go
@@ -1,0 +1,32 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package maas
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/environs/config"
+	coretesting "github.com/juju/juju/testing"
+)
+
+type maas2EnvironSuite struct {
+	controllerSuite
+}
+
+var _ = gc.Suite(&maas2EnvironSuite{})
+
+func (suite *maas2EnvironSuite) TestNewEnvironWithController(c *gc.C) {
+	testAttrs := coretesting.Attrs{}
+	for k, v := range maasEnvAttrs {
+		testAttrs[k] = v
+	}
+	testAttrs["maas-server"] = suite.testServer.Server.URL
+	attrs := coretesting.FakeConfig().Merge(testAttrs)
+	cfg, err := config.New(config.NoDefaults, attrs)
+	c.Assert(err, jc.ErrorIsNil)
+	env, err := NewEnviron(cfg)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(env, gc.NotNil)
+}

--- a/provider/maas/maas2_environ_whitebox_test.go
+++ b/provider/maas/maas2_environ_whitebox_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 type maas2EnvironSuite struct {
-	baseProviderSuite
+	controllerSuite
 }
 
 var _ = gc.Suite(&maas2EnvironSuite{})

--- a/provider/maas/maas2_environ_whitebox_test.go
+++ b/provider/maas/maas2_environ_whitebox_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 type maas2EnvironSuite struct {
-	controllerSuite
+	baseProviderSuite
 }
 
 var _ = gc.Suite(&maas2EnvironSuite{})

--- a/provider/maas/maas_test.go
+++ b/provider/maas/maas_test.go
@@ -114,8 +114,7 @@ const exampleAgentName = "dfb69555-0bc4-4d1f-85f2-4ee390974984"
 
 func (s *providerSuite) SetUpSuite(c *gc.C) {
 	s.baseProviderSuite.SetUpSuite(c)
-	TestMAASObject := gomaasapi.NewTestMAAS("1.0")
-	s.testMAASObject = TestMAASObject
+	s.testMAASObject = gomaasapi.NewTestMAAS("1.0")
 }
 
 func (s *providerSuite) SetUpTest(c *gc.C) {

--- a/provider/maas/maas_test.go
+++ b/provider/maas/maas_test.go
@@ -79,6 +79,23 @@ func (s *baseProviderSuite) TearDownSuite(c *gc.C) {
 	s.FakeJujuXDGDataHomeSuite.TearDownSuite(c)
 }
 
+type controllerSuite struct {
+	baseProviderSuite
+	testServer *gomaasapi.SimpleTestServer
+}
+
+func (s *controllerSuite) SetUpTest(c *gc.C) {
+	s.baseProviderSuite.SetUpTest(c)
+	s.testServer = gomaasapi.NewSimpleServer()
+	s.testServer.AddResponse("/api/2.0/version/", http.StatusOK, maas2VersionResponse)
+	s.testServer.Start()
+}
+
+func (s *controllerSuite) TearDownTest(c *gc.C) {
+	s.baseProviderSuite.TearDownTest(c)
+	s.testServer.Close()
+}
+
 type providerSuite struct {
 	baseProviderSuite
 	testMAASObject *gomaasapi.TestMAASObject
@@ -97,7 +114,8 @@ const exampleAgentName = "dfb69555-0bc4-4d1f-85f2-4ee390974984"
 
 func (s *providerSuite) SetUpSuite(c *gc.C) {
 	s.baseProviderSuite.SetUpSuite(c)
-	s.testMAASObject = gomaasapi.NewTestMAAS("1.0")
+	TestMAASObject := gomaasapi.NewTestMAAS("1.0")
+	s.testMAASObject = TestMAASObject
 }
 
 func (s *providerSuite) SetUpTest(c *gc.C) {

--- a/provider/maas/maas_test.go
+++ b/provider/maas/maas_test.go
@@ -123,7 +123,11 @@ func (s *providerSuite) SetUpTest(c *gc.C) {
 	mockCapabilities := func(client *gomaasapi.MAASObject) (set.Strings, error) {
 		return set.NewStrings("network-deployment-ubuntu"), nil
 	}
+	mockGetController := func(maasServer, apiKey string) (gomaasapi.Controller, error) {
+		return nil, gomaasapi.ServerError{StatusCode: http.StatusNotFound}
+	}
 	s.PatchValue(&GetCapabilities, mockCapabilities)
+	s.PatchValue(&GetMAAS2Controller, mockGetController)
 	// Creating a space ensures that the spaces endpoint won't 404.
 	s.testMAASObject.TestServer.NewSpace(spaceJSON(gomaasapi.CreateSpace{Name: "space-0"}))
 }

--- a/provider/maas/maas_test.go
+++ b/provider/maas/maas_test.go
@@ -79,23 +79,6 @@ func (s *baseProviderSuite) TearDownSuite(c *gc.C) {
 	s.FakeJujuXDGDataHomeSuite.TearDownSuite(c)
 }
 
-type controllerSuite struct {
-	baseProviderSuite
-	testServer *gomaasapi.SimpleTestServer
-}
-
-func (s *controllerSuite) SetUpTest(c *gc.C) {
-	s.baseProviderSuite.SetUpTest(c)
-	s.testServer = gomaasapi.NewSimpleServer()
-	s.testServer.AddResponse("/api/2.0/version/", http.StatusOK, maas2VersionResponse)
-	s.testServer.Start()
-}
-
-func (s *controllerSuite) TearDownTest(c *gc.C) {
-	s.baseProviderSuite.TearDownTest(c)
-	s.testServer.Close()
-}
-
 type providerSuite struct {
 	baseProviderSuite
 	testMAASObject *gomaasapi.TestMAASObject
@@ -114,8 +97,7 @@ const exampleAgentName = "dfb69555-0bc4-4d1f-85f2-4ee390974984"
 
 func (s *providerSuite) SetUpSuite(c *gc.C) {
 	s.baseProviderSuite.SetUpSuite(c)
-	TestMAASObject := gomaasapi.NewTestMAAS("1.0")
-	s.testMAASObject = TestMAASObject
+	s.testMAASObject = gomaasapi.NewTestMAAS("1.0")
 }
 
 func (s *providerSuite) SetUpTest(c *gc.C) {

--- a/provider/maas/maas_test.go
+++ b/provider/maas/maas_test.go
@@ -31,7 +31,7 @@ import (
 	jujuversion "github.com/juju/juju/version"
 )
 
-var maas2VersionResponse = `{"version": "unknown", "subversion": "", "capabilities": ["networks-management", "static-ipaddresses", "ipv6-deployment-ubuntu", "devices-management", "storage-deployment-ubuntu", "network-deployment-ubuntu"]}`
+const maas2VersionResponse = `{"version": "unknown", "subversion": "", "capabilities": ["networks-management", "static-ipaddresses", "ipv6-deployment-ubuntu", "devices-management", "storage-deployment-ubuntu", "network-deployment-ubuntu"]}`
 
 type baseProviderSuite struct {
 	coretesting.FakeJujuXDGDataHomeSuite

--- a/provider/maas/storage.go
+++ b/provider/maas/storage.go
@@ -37,8 +37,8 @@ var _ storage.Storage = (*maasStorage)(nil)
 func NewStorage(env *maasEnviron) storage.Storage {
 	stor := new(maasStorage)
 	stor.environUnlocked = env
-	// TODO (mfoord): horrible, horrible
-	if env.apiVersion == "1.0" {
+	// TODO (babbageclunk): needs MAAS 2.0 support
+	if !env.usingMAAS2() {
 		stor.maasClientUnlocked = env.getMAASClient().GetSubObject("files")
 	}
 	return stor

--- a/provider/maas/storage.go
+++ b/provider/maas/storage.go
@@ -37,7 +37,10 @@ var _ storage.Storage = (*maasStorage)(nil)
 func NewStorage(env *maasEnviron) storage.Storage {
 	stor := new(maasStorage)
 	stor.environUnlocked = env
-	stor.maasClientUnlocked = env.getMAASClient().GetSubObject("files")
+	// TODO (mfoord): horrible, horrible
+	if env.apiVersion == "1.0" {
+		stor.maasClientUnlocked = env.getMAASClient().GetSubObject("files")
+	}
 	return stor
 }
 


### PR DESCRIPTION
Update the MAAS provider to start using the new 2.0 API Controller from gomaasapi.

The provider will now use the Controller when working with MAAS 2.0. 
Test infrastructure support for MAAS 2 tests.
Update dependencies.tsv to use the new gomaasapi.
A new method to tell if we're using MAAS 2, plus using it in a couple of places to get us slightly further on in bootstrap.

(Review request: http://reviews.vapour.ws/r/4380/)