### PR TITLE
1560391 - Use apt-mirror for containers

### DIFF
--- a/apiserver/provisioner/provisioner.go
+++ b/apiserver/provisioner/provisioner.go
@@ -306,6 +306,7 @@ func (p *ProvisionerAPI) ContainerConfig() (params.ContainerConfig, error) {
 	result.SSLHostnameVerification = config.SSLHostnameVerification()
 	result.Proxy = config.ProxySettings()
 	result.AptProxy = config.AptProxySettings()
+	result.AptMirror = config.AptMirror()
 	result.PreferIPv6 = config.PreferIPv6()
 	result.AllowLXCLoopMounts, _ = config.AllowLXCLoopMounts()
 

--- a/apiserver/provisioner/provisioner_test.go
+++ b/apiserver/provisioner/provisioner_test.go
@@ -1425,6 +1425,7 @@ func (s *withoutStateServerSuite) TestContainerConfig(c *gc.C) {
 	attrs := map[string]interface{}{
 		"http-proxy":            "http://proxy.example.com:9000",
 		"allow-lxc-loop-mounts": true,
+		"apt-mirror":            "http://example.mirror.com",
 	}
 	err := s.State.UpdateEnvironConfig(attrs, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1440,6 +1441,7 @@ func (s *withoutStateServerSuite) TestContainerConfig(c *gc.C) {
 	c.Check(results.SSLHostnameVerification, jc.IsTrue)
 	c.Check(results.Proxy, gc.DeepEquals, expectedProxy)
 	c.Check(results.AptProxy, gc.DeepEquals, expectedProxy)
+	c.Check(results.AptMirror, gc.DeepEquals, "http://example.mirror.com")
 	c.Check(results.PreferIPv6, jc.IsTrue)
 	c.Check(results.AllowLXCLoopMounts, jc.IsTrue)
 }


### PR DESCRIPTION
The apt-mirror config was not used when creating
containers.  Added it to the ContainerConfig.

(Review request: http://reviews.vapour.ws/r/4384/)