### PR TITLE
1543223: Ignore NotFound err when destroying volume

### DIFF
--- a/provider/ec2/ebs.go
+++ b/provider/ec2/ebs.go
@@ -5,7 +5,6 @@ package ec2
 
 import (
 	"regexp"
-	"strings"
 	"sync"
 	"time"
 
@@ -432,8 +431,7 @@ var destroyVolumeAttempt = utils.AttemptStrategy{
 func (v *ebsVolumeSource) destroyVolume(volumeId string) (err error) {
 	defer func() {
 		if err != nil {
-			errMessage := errors.Cause(err).Error()
-			if strings.Contains(errMessage, volumeNotFound) {
+			if ec2ErrCode(err) == volumeNotFound || errors.IsNotFound(err) {
 				// Either the volume isn't found, or we queried the
 				// instance corresponding to a DeleteOnTermination
 				// attachment; in either case, the volume is or will

--- a/provider/ec2/ebs.go
+++ b/provider/ec2/ebs.go
@@ -5,6 +5,7 @@ package ec2
 
 import (
 	"regexp"
+	"strings"
 	"sync"
 	"time"
 
@@ -54,6 +55,7 @@ const (
 const (
 	deviceInUse        = "InvalidDevice.InUse"
 	attachmentNotFound = "InvalidAttachment.NotFound"
+	volumeNotFound     = "InvalidVolume.NotFound"
 )
 
 const (
@@ -427,7 +429,21 @@ var destroyVolumeAttempt = utils.AttemptStrategy{
 	Delay: 5 * time.Second,
 }
 
-func (v *ebsVolumeSource) destroyVolume(volumeId string) error {
+func (v *ebsVolumeSource) destroyVolume(volumeId string) (err error) {
+	defer func() {
+		if err != nil {
+			errMessage := errors.Cause(err).Error()
+			if strings.Contains(errMessage, volumeNotFound) {
+				// Either the volume isn't found, or we queried the
+				// instance corresponding to a DeleteOnTermination
+				// attachment; in either case, the volume is or will
+				// be destroyed.
+				logger.Tracef("Ignoring error destroying volume %q: %v", volumeId, err)
+				err = nil
+			}
+		}
+	}()
+
 	logger.Debugf("destroying %q", volumeId)
 	// Volumes must not be in-use when destroying. A volume may
 	// still be in-use when the instance it is attached to is
@@ -505,13 +521,7 @@ func (v *ebsVolumeSource) destroyVolume(volumeId string) error {
 		return false, nil
 	})
 	if err != nil {
-		if errors.IsNotFound(err) {
-			// Either the volume isn't found, or we queried the
-			// instance corresponding to a DeleteOnTermination
-			// attachment; in either case, the volume is or will
-			// be destroyed.
-			return nil
-		} else if err == errWaitVolumeTimeout {
+		if err == errWaitVolumeTimeout {
 			return errors.Errorf("timed out waiting for volume %v to not be in-use", volumeId)
 		}
 		return errors.Trace(err)

--- a/provider/ec2/ebs_test.go
+++ b/provider/ec2/ebs_test.go
@@ -336,6 +336,14 @@ func (s *ebsVolumeSuite) TestVolumeTypeAliases(c *gc.C) {
 	}
 }
 
+func (s *ebsVolumeSuite) TestDestroyVolumesNotFoundReturnsNil(c *gc.C) {
+	vs := s.volumeSource(c, nil)
+	results, err := vs.DestroyVolumes([]string{"vol-42"})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, gc.HasLen, 1)
+	c.Assert(results[0], jc.ErrorIsNil)
+}
+
 func (s *ebsVolumeSuite) TestDestroyVolumes(c *gc.C) {
 	vs := s.volumeSource(c, nil)
 	params := s.setupAttachVolumesTest(c, vs, ec2test.Running)

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -1695,7 +1695,7 @@ func isSubnetConstrainedError(err error) bool {
 // If the err is of type *ec2.Error, ec2ErrCode returns
 // its code, otherwise it returns the empty string.
 func ec2ErrCode(err error) string {
-	ec2err, _ := err.(*ec2.Error)
+	ec2err, _ := errors.Cause(err).(*ec2.Error)
 	if ec2err == nil {
 		return ""
 	}


### PR DESCRIPTION
Both querying and destroying a volume can return
a InvalidVolume.NotFound error.  Fix the check for
the NotFound error, and also catch this error when
it comes from the actual destroy call.

Live tested to make sure this worked in:
1 - The non error case
2 - The error querying volume case, and
3 - The error destroying volume case

(Review request: http://reviews.vapour.ws/r/4389/)