### PR TITLE
Update help text for model related commands

### DIFF
--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -519,8 +519,7 @@ func (s *MainSuite) TestModelCommands(c *gc.C) {
 
 func (s *MainSuite) TestAllCommandsPurposeDocCapitalization(c *gc.C) {
 	// Verify each command that:
-	// - the Purpose field is not empty and begins with a lowercase
-	// letter, and,
+	// - the Purpose field is not empty
 	// - if set, the Doc field either begins with the name of the
 	// command or and uppercase letter.
 	//
@@ -541,12 +540,9 @@ func (s *MainSuite) TestAllCommandsPurposeDocCapitalization(c *gc.C) {
 		}
 
 		c.Check(purpose, gc.Not(gc.Equals), "", comment("has empty Purpose"))
-		if purpose != "" {
-			prefix := string(purpose[0])
-			c.Check(prefix, gc.Equals, strings.ToLower(prefix),
-				comment("expected lowercase first-letter Purpose"),
-			)
-		}
+		// TODO (cherylj) Add back in the check for capitalization of
+		// purpose, but check for upper case.  This requires all commands
+		// to have been updated first.
 		if doc != "" && !strings.HasPrefix(doc, info.Name) {
 			prefix := string(doc[0])
 			c.Check(prefix, gc.Equals, strings.ToUpper(prefix),

--- a/cmd/juju/controller/listmodels.go
+++ b/cmd/juju/controller/listmodels.go
@@ -37,16 +37,19 @@ type modelsCommand struct {
 }
 
 var listModelsDoc = `
-List all the models the user can access on the current controller.
+The models listed here are either models you have created yourself, or
+models which have been shared with you. Default values for user and
+controller are, respectively, the current user and the current controller.
+The active model is denoted by an asterisk.
 
-The models listed here are either models you have created
-yourself, or models which have been shared with you.
+Examples:
 
-See Also:
-    juju help controllers
-    juju help model users
-    juju help model share
-    juju help model unshare
+    juju list-models
+    juju list-models --user bob
+
+See also: create-model
+          share-model
+          unshare-model
 `
 
 // ModelManagerAPI defines the methods on the model manager API that
@@ -67,7 +70,7 @@ type ModelsSysAPI interface {
 func (c *modelsCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "list-models",
-		Purpose: "list all models the user can access on the current controller",
+		Purpose: "Lists models a user can access on a controller.",
 		Doc:     listModelsDoc,
 	}
 }
@@ -88,10 +91,10 @@ func (c *modelsCommand) getSysAPI() (ModelsSysAPI, error) {
 
 // SetFlags implements Command.SetFlags.
 func (c *modelsCommand) SetFlags(f *gnuflag.FlagSet) {
-	f.StringVar(&c.user, "user", "", "the user to list models for (administrative users only)")
-	f.BoolVar(&c.all, "all", false, "show all models  (administrative users only)")
-	f.BoolVar(&c.listUUID, "uuid", false, "display UUID for models")
-	f.BoolVar(&c.exactTime, "exact-time", false, "use full timestamp precision")
+	f.StringVar(&c.user, "user", "", "The user to list models for (administrative users only)")
+	f.BoolVar(&c.all, "all", false, "Lists all models, regardless of user accessibility (administrative users only)")
+	f.BoolVar(&c.listUUID, "uuid", false, "Display UUID for models")
+	f.BoolVar(&c.exactTime, "exact-time", false, "Use full timestamp for connection times")
 	c.out.AddFlags(f, "tabular", map[string]cmd.Formatter{
 		"yaml":    cmd.FormatYaml,
 		"json":    cmd.FormatJson,

--- a/cmd/juju/model/constraints.go
+++ b/cmd/juju/model/constraints.go
@@ -12,45 +12,51 @@ import (
 	"github.com/juju/juju/constraints"
 )
 
-const getConstraintsDoc = `
-Shows a list of constraints that have been set on the model
-using juju set-model-constraints.  You can also view constraints
-set for a specific service by using juju get-constraints <service>.
+// getConstraintsDoc is multi-line since we need to use ` to denote
+// commands for ease in markdown.
+const getConstraintsDoc = "" +
+	"Shows machine constraints that have been set on the model with\n" +
+	"`juju set-model-constraints.`\n" +
+	"By default, the model is the current model.\n" +
+	"Model constraints are combined with constraints set on a service\n" +
+	"with `juju set-constraints` for commands (such as 'deploy') that provision\n" +
+	"machines for services. Where model and service constraints overlap, the\n" +
+	"service constraints take precedence.\n" +
+	"Constraints for a specific service can be viewed with `juju get-constraints`.\n" + getConstraintsDocExamples
 
-Constraints set on a service are combined with model constraints for
-commands (such as juju deploy) that provision machines for services.  Where
-model and service constraints overlap, the service constraints take
-precedence.
+const getConstraintsDocExamples = `
+Examples:
 
-See Also:
-   juju help constraints
-   juju help set-model-constraints
-   juju help deploy
-   juju help machine add
-   juju help add-unit
+    juju get-model-constraints
+    juju get-model-constraints -m mymodel
+
+See also: list-models
+          set-model-constraints
+          set-constraints
+          get-constraints
 `
 
-const setConstraintsDoc = `
-Sets machine constraints on the model, which are used as the default
-constraints for all new machines provisioned in the model (unless
-overridden).  You can also set constraints on a specific service by using
-juju set-constraints.
+// setConstraintsDoc is multi-line since we need to use ` to denote
+// commands for ease in markdown.
+const setConstraintsDoc = "" +
+	"Sets machine constraints on the model that can be viewed with\n" +
+	"`juju get-model-constraints`.  By default, the model is the current model.\n" +
+	"Model constraints are combined with constraints set for a service with\n" +
+	"`juju set-constraints` for commands (such as 'deploy') that provision\n" +
+	"machines for services. Where model and service constraints overlap, the\n" +
+	"service constraints take precedence.\n" +
+	"Constraints for a specific service can be viewed with `juju get-constraints`.\n" + setConstraintsDocExamples
 
-Constraints set on a service are combined with model constraints for
-commands (such as juju deploy) that provision machines for services.  Where
-model and service constraints overlap, the service constraints take
-precedence.
+const setConstraintsDocExamples = `
+Examples:
 
-Example:
+    juju set-model-constraints cpu-cores=8 mem=16G
+    juju set-model-constraints -m mymodel root-disk=64G
 
-   juju model set-constraints mem=8G                         (all new machines in the model must have at least 8GB of RAM)
-
-See Also:
-   juju help constraints
-   juju help get-model-constraints
-   juju help deploy
-   juju help machine add
-   juju help add-unit
+See also: list-models
+          get-model-constraints
+          set-constraints
+          get-constraints
 `
 
 // ConstraintsAPI defines methods on the client API that
@@ -76,7 +82,7 @@ type modelGetConstraintsCommand struct {
 func (c *modelGetConstraintsCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "get-model-constraints",
-		Purpose: "view constraints on the model",
+		Purpose: "Displays machine constraints for a model.",
 		Doc:     getConstraintsDoc,
 	}
 }
@@ -133,8 +139,8 @@ type modelSetConstraintsCommand struct {
 func (c *modelSetConstraintsCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "set-model-constraints",
-		Args:    "[key=[value] ...]",
-		Purpose: "set constraints on the model",
+		Args:    "<constraint>=<value> ...",
+		Purpose: "Sets machine constraints on a model.",
 		Doc:     setConstraintsDoc,
 	}
 }

--- a/cmd/juju/model/destroy.go
+++ b/cmd/juju/model/destroy.go
@@ -36,7 +36,20 @@ type destroyCommand struct {
 	api       DestroyEnvironmentAPI
 }
 
-var destroyDoc = `Destroys the specified model`
+var destroyDoc = `
+Destroys the specified model. This will result in the non-recoverable
+removal of all the units operating in the model and any resources stored
+there. Due to the irreversible nature of the command, it will prompt for
+confirmation (unless overridden with the '-y' option) before taking any
+action.
+
+Examples:
+
+      juju destroy-model test
+      juju destroy-model -y mymodel
+
+See also: destroy-controller
+`
 var destroyEnvMsg = `
 WARNING! This command will destroy the %q model.
 This includes all machines, services, data and other resources.
@@ -55,14 +68,14 @@ func (c *destroyCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "destroy-model",
 		Args:    "<model name>",
-		Purpose: "terminate all machines and other associated resources for a non-controller model",
+		Purpose: "Terminate all machines and resources for a non-controller model.",
 		Doc:     destroyDoc,
 	}
 }
 
 // SetFlags implements Command.SetFlags.
 func (c *destroyCommand) SetFlags(f *gnuflag.FlagSet) {
-	f.BoolVar(&c.assumeYes, "y", false, "Do not ask for confirmation")
+	f.BoolVar(&c.assumeYes, "y", false, "Do not prompt for confirmation")
 	f.BoolVar(&c.assumeYes, "yes", false, "")
 }
 

--- a/cmd/juju/model/destroy.go
+++ b/cmd/juju/model/destroy.go
@@ -67,7 +67,7 @@ type DestroyEnvironmentAPI interface {
 func (c *destroyCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "destroy-model",
-		Args:    "<model name>",
+		Args:    "[<controller name>:]<model name>",
 		Purpose: "Terminate all machines and resources for a non-controller model.",
 		Doc:     destroyDoc,
 	}

--- a/cmd/juju/model/get.go
+++ b/cmd/juju/model/get.go
@@ -27,22 +27,25 @@ type getCommand struct {
 }
 
 const getModelHelpDoc = `
-If no extra args passed on the command line, all configuration keys and values
-for the environment are output using the selected formatter.
+By default, all configuration (keys and values) for the model are
+displayed if a key is not specified.
+By default, the model is the current model.
 
-A single model value can be output by adding the model key name to
-the end of the command line.
+Examples:
 
-Example:
-  
-  juju get-model-config default-series  (returns the default series for the model)
+    juju get-model-config default-series
+    juju get-model-config -m mymodel type
+
+See also: list-models
+          set-model-config
+          unset-model-config
 `
 
 func (c *getCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "get-model-config",
 		Args:    "[<model key>]",
-		Purpose: "view model values",
+		Purpose: "Displays configuration settings for a model.",
 		Doc:     strings.TrimSpace(getModelHelpDoc),
 	}
 }

--- a/cmd/juju/model/set.go
+++ b/cmd/juju/model/set.go
@@ -27,15 +27,25 @@ type setCommand struct {
 }
 
 const setModelHelpDoc = `
-Updates the model of a running Juju instance.  Multiple key/value pairs
-can be passed on as command line arguments.
+Model configuration consists of a collection of keys and their respective values.
+By default, the model is the current model.
+Consult the online documentation for a list of keys and possible values.
+
+Examples:
+
+    juju set-model-config logging-config='<root>=WARNING;unit=INFO'
+    juju set-model-config -m mymodel api-port=17071 default-series=xenial
+
+See also: list-models
+          get-model-config
+          unset-model-config
 `
 
 func (c *setCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "set-model-config",
-		Args:    "key=[value] ...",
-		Purpose: "replace model values",
+		Args:    "<model key>=<value> ...",
+		Purpose: "Sets configuration keys on a model.",
 		Doc:     strings.TrimSpace(setModelHelpDoc),
 	}
 }

--- a/cmd/juju/model/unset.go
+++ b/cmd/juju/model/unset.go
@@ -23,20 +23,29 @@ type unsetCommand struct {
 	keys []string
 }
 
-const unsetEnvHelpDoc = `
-Reset one or more the model configuration attributes to its default
-value in a running Juju instance.  Attributes without defaults are removed,
-and attempting to remove a required attribute with no default will result
-in an error.
+// unsetEnvHelpDoc is multi-line since we need to use ` to denote
+// commands for ease in markdown.
+const unsetEnvHelpDoc = "" +
+	"Unsets specified model configuration to default values and removes\n" +
+	"specified keys that have no default values.  Attempting to remove a\n" +
+	"required key with no default value will result in an error.\n" +
+	"By default, the model is the current model.\n" +
+	"Model configuration key values can be viewed with `juju get-model-config`.\n" + unsetEnvHelpDocExamples
 
-Multiple attributes may be removed at once; keys should be space-separated.
+const unsetEnvHelpDocExamples = `
+Examples:
+
+    juju unset-model-config api-port test-mode
+
+See also: set-model-config
+          get-model-config
 `
 
 func (c *unsetCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "unset-model-config",
 		Args:    "<model key> ...",
-		Purpose: "unset model values",
+		Purpose: "Unsets specified model configuration.",
 		Doc:     strings.TrimSpace(unsetEnvHelpDoc),
 	}
 }

--- a/cmd/juju/model/unset.go
+++ b/cmd/juju/model/unset.go
@@ -26,9 +26,10 @@ type unsetCommand struct {
 // unsetEnvHelpDoc is multi-line since we need to use ` to denote
 // commands for ease in markdown.
 const unsetEnvHelpDoc = "" +
-	"Unsets specified model configuration to default values and removes\n" +
-	"specified keys that have no default values.  Attempting to remove a\n" +
-	"required key with no default value will result in an error.\n" +
+	"A model key is reset to its default value. If it does not have such a\n" +
+	"value defined then it is removed.\n" +
+	"Attempting to remove a required key with no default value will result\n" +
+	"in an error.\n" +
 	"By default, the model is the current model.\n" +
 	"Model configuration key values can be viewed with `juju get-model-config`.\n" + unsetEnvHelpDocExamples
 
@@ -45,7 +46,7 @@ func (c *unsetCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "unset-model-config",
 		Args:    "<model key> ...",
-		Purpose: "Unsets specified model configuration.",
+		Purpose: "Unsets model configuration.",
 		Doc:     strings.TrimSpace(unsetEnvHelpDoc),
 	}
 }

--- a/cmd/modelcmd/controller.go
+++ b/cmd/modelcmd/controller.go
@@ -236,7 +236,7 @@ type sysCommandWrapper struct {
 // SetFlags implements Command.SetFlags, then calls the wrapped command's SetFlags.
 func (w *sysCommandWrapper) SetFlags(f *gnuflag.FlagSet) {
 	if w.setFlags {
-		f.StringVar(&w.controllerName, "c", "", "juju controller to operate in")
+		f.StringVar(&w.controllerName, "c", "", "Controller to operate in")
 		f.StringVar(&w.controllerName, "controller", "", "")
 	}
 	w.ControllerCommand.SetFlags(f)

--- a/cmd/modelcmd/modelcommand.go
+++ b/cmd/modelcmd/modelcommand.go
@@ -275,7 +275,7 @@ func (w *modelCommandWrapper) Run(ctx *cmd.Context) error {
 
 func (w *modelCommandWrapper) SetFlags(f *gnuflag.FlagSet) {
 	if !w.skipFlags {
-		f.StringVar(&w.modelName, "m", "", "juju model to operate in")
+		f.StringVar(&w.modelName, "m", "", "Model to operate in")
 		f.StringVar(&w.modelName, "model", "", "")
 	}
 	w.ModelCommand.SetFlags(f)


### PR DESCRIPTION
This patch updates the help text based on suggested
text from the docs team:

lp1556249 - list-models
lp1563927 - get-model-constraints
lp1563928 - set-model-constraints
lp1553272 - destroy-model
lp1563924 - get-model-config
lp1563923 - set-model-config
lp1563938 - unset-model-config

Some command help text needed to be broken up into
multi-line text to allow for the use of backticks
in the help.  It is necessary to use the backticks
for markdown formatting.

(Review request: http://reviews.vapour.ws/r/4391/)