### PR TITLE
cmd/juju/model: add "show-model" command

### DIFF
--- a/api/modelmanager/modelinfo_test.go
+++ b/api/modelmanager/modelinfo_test.go
@@ -1,0 +1,85 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package modelmanager_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	basetesting "github.com/juju/juju/api/base/testing"
+	"github.com/juju/juju/api/modelmanager"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/testing"
+	"github.com/juju/names"
+)
+
+type modelInfoSuite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&modelInfoSuite{})
+
+/*
+const (
+	someModelUUID = "63f5e78f-2d21-4d0c-a5c1-73463f3443bf"
+	someModelTag  = "model-" + someModelUUID
+)
+
+func (s *modelInfoSuite) TestGrantModelReadOnlyUser(c *gc.C) {
+	s.readOnlyUser(c, params.GrantModelAccess)
+}
+
+func (s *modelInfoSuite) TestRevokeModelReadOnlyUser(c *gc.C) {
+	s.readOnlyUser(c, params.RevokeModelAccess)
+}
+*/
+
+func (s *modelInfoSuite) checkCall(c *gc.C, objType string, id, request string) {
+	c.Check(objType, gc.Equals, "ModelManager")
+	c.Check(id, gc.Equals, "")
+	c.Check(request, gc.Equals, "ModelInfo")
+}
+
+func (s *modelInfoSuite) assertResponse(c *gc.C, result interface{}) *params.ModelInfoResults {
+	c.Assert(result, gc.FitsTypeOf, &params.ModelInfoResults{})
+	return result.(*params.ModelInfoResults)
+}
+
+func (s *modelInfoSuite) TestModelInfo(c *gc.C) {
+	results := params.ModelInfoResults{
+		Results: []params.ModelInfoResult{{
+			Result: &params.ModelInfo{Name: "name", UUID: "etc."},
+		}, {
+			Error: &params.Error{Message: "woop"},
+		}},
+	}
+	apiCaller := basetesting.APICallerFunc(
+		func(objType string, version int, id, request string, a, result interface{}) error {
+			s.checkCall(c, objType, id, request)
+			resp := s.assertResponse(c, result)
+			*resp = results
+			return nil
+		})
+	client := modelmanager.NewClient(apiCaller)
+	info, err := client.ModelInfo([]names.ModelTag{testing.ModelTag, testing.ModelTag})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(info, jc.DeepEquals, results.Results)
+}
+
+func (s *modelInfoSuite) TestInvalidResultCount(c *gc.C) {
+	apiCaller := basetesting.APICallerFunc(
+		func(objType string, version int, id, request string, a, result interface{}) error {
+			s.checkCall(c, objType, id, request)
+			c.Assert(a, jc.DeepEquals, params.Entities{
+				Entities: []params.Entity{{testing.ModelTag.String()}, {testing.ModelTag.String()}},
+			})
+			resp := s.assertResponse(c, result)
+			*resp = params.ModelInfoResults{Results: []params.ModelInfoResult{{}}}
+			return nil
+		},
+	)
+	client := modelmanager.NewClient(apiCaller)
+	_, err := client.ModelInfo([]names.ModelTag{testing.ModelTag, testing.ModelTag})
+	c.Assert(err, gc.ErrorMatches, "expected 2 result\\(s\\), got 1")
+}

--- a/api/modelmanager/modelinfo_test.go
+++ b/api/modelmanager/modelinfo_test.go
@@ -4,6 +4,7 @@
 package modelmanager_test
 
 import (
+	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -11,7 +12,6 @@ import (
 	"github.com/juju/juju/api/modelmanager"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/testing"
-	"github.com/juju/names"
 )
 
 type modelInfoSuite struct {
@@ -19,21 +19,6 @@ type modelInfoSuite struct {
 }
 
 var _ = gc.Suite(&modelInfoSuite{})
-
-/*
-const (
-	someModelUUID = "63f5e78f-2d21-4d0c-a5c1-73463f3443bf"
-	someModelTag  = "model-" + someModelUUID
-)
-
-func (s *modelInfoSuite) TestGrantModelReadOnlyUser(c *gc.C) {
-	s.readOnlyUser(c, params.GrantModelAccess)
-}
-
-func (s *modelInfoSuite) TestRevokeModelReadOnlyUser(c *gc.C) {
-	s.readOnlyUser(c, params.RevokeModelAccess)
-}
-*/
 
 func (s *modelInfoSuite) checkCall(c *gc.C, objType string, id, request string) {
 	c.Check(objType, gc.Equals, "ModelManager")

--- a/api/modelmanager/modelmanager.go
+++ b/api/modelmanager/modelmanager.go
@@ -102,6 +102,24 @@ func (c *Client) ListModels(user string) ([]base.UserModel, error) {
 	return result, nil
 }
 
+func (c *Client) ModelInfo(tags []names.ModelTag) ([]params.ModelInfoResult, error) {
+	entities := params.Entities{
+		Entities: make([]params.Entity, len(tags)),
+	}
+	for i, tag := range tags {
+		entities.Entities[i].Tag = tag.String()
+	}
+	var results params.ModelInfoResults
+	err := c.facade.FacadeCall("ModelInfo", entities, &results)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if len(results.Results) != len(tags) {
+		return nil, errors.Errorf("expected %d result(s), got %d", len(tags), len(results.Results))
+	}
+	return results.Results, nil
+}
+
 // ParseModelAccess parses an access permission argument into
 // a type suitable for making an API facade call.
 func ParseModelAccess(access string) (params.ModelAccessPermission, error) {

--- a/apiserver/client/client.go
+++ b/apiserver/client/client.go
@@ -5,7 +5,6 @@ package client
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
@@ -374,24 +373,14 @@ func (c *Client) ModelUserInfo() (params.ModelUserInfoResults, error) {
 	}
 
 	for _, user := range users {
-		var lastConn *time.Time
-		userLastConn, err := user.LastConnection()
+		var result params.ModelUserInfoResult
+		userInfo, err := common.ModelUserInfo(user)
 		if err != nil {
-			if !state.IsNeverConnectedError(err) {
-				return results, errors.Trace(err)
-			}
+			result.Error = common.ServerError(err)
 		} else {
-			lastConn = &userLastConn
+			result.Result = &userInfo
 		}
-		results.Results = append(results.Results, params.ModelUserInfoResult{
-			Result: &params.ModelUserInfo{
-				UserName:       user.UserName(),
-				DisplayName:    user.DisplayName(),
-				CreatedBy:      user.CreatedBy(),
-				DateCreated:    user.DateCreated(),
-				LastConnection: lastConn,
-			},
-		})
+		results.Results = append(results.Results, result)
 	}
 	return results, nil
 }

--- a/apiserver/client/client_test.go
+++ b/apiserver/client/client_test.go
@@ -96,35 +96,38 @@ func (s *serverSuite) TestModelUsersInfo(c *gc.C) {
 			&params.ModelUserInfo{
 				UserName:    owner.UserName(),
 				DisplayName: owner.DisplayName(),
+				Access:      "write",
 			},
 		}, {
 			localUser1,
 			&params.ModelUserInfo{
 				UserName:    "ralphdoe@local",
 				DisplayName: "Ralph Doe",
+				Access:      "write",
 			},
 		}, {
 			localUser2,
 			&params.ModelUserInfo{
 				UserName:    "samsmith@local",
 				DisplayName: "Sam Smith",
+				Access:      "write",
 			},
 		}, {
 			remoteUser1,
 			&params.ModelUserInfo{
 				UserName:    "bobjohns@ubuntuone",
 				DisplayName: "Bob Johns",
+				Access:      "write",
 			},
 		}, {
 			remoteUser2,
 			&params.ModelUserInfo{
 				UserName:    "nicshaw@idprovider",
 				DisplayName: "Nic Shaw",
+				Access:      "write",
 			},
 		},
 	} {
-		r.info.CreatedBy = owner.UserName()
-		r.info.DateCreated = r.user.DateCreated()
 		r.info.LastConnection = lastConnPointer(c, r.user)
 		expected.Results = append(expected.Results, params.ModelUserInfoResult{Result: r.info})
 	}

--- a/apiserver/common/modeluser.go
+++ b/apiserver/common/modeluser.go
@@ -1,0 +1,59 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package common
+
+import (
+	"time"
+
+	"github.com/juju/errors"
+	"github.com/juju/names"
+
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/state"
+)
+
+// ModelUser defines a subset of the state.ModelUser type
+// that we require to convert to a params.ModelUserInfo.
+type ModelUser interface {
+	Access() state.ModelAccess
+	DisplayName() string
+	LastConnection() (time.Time, error)
+	UserName() string
+	UserTag() names.UserTag
+}
+
+// ModelUserInfo converts *state.ModelUser to params.ModelUserInfo.
+func ModelUserInfo(user ModelUser) (params.ModelUserInfo, error) {
+	access, err := StateToParamsModelAccess(user.Access())
+	if err != nil {
+		return params.ModelUserInfo{}, errors.Trace(err)
+	}
+
+	var lastConn *time.Time
+	userLastConn, err := user.LastConnection()
+	if err == nil {
+		lastConn = &userLastConn
+	} else if !state.IsNeverConnectedError(err) {
+		return params.ModelUserInfo{}, errors.Trace(err)
+	}
+
+	userInfo := params.ModelUserInfo{
+		UserName:       user.UserName(),
+		DisplayName:    user.DisplayName(),
+		LastConnection: lastConn,
+		Access:         access,
+	}
+	return userInfo, nil
+}
+
+// StateToParamsModelAccess converts state.ModelAccess to params.ModelAccessPermission.
+func StateToParamsModelAccess(stateAccess state.ModelAccess) (params.ModelAccessPermission, error) {
+	switch stateAccess {
+	case state.ModelReadAccess:
+		return params.ModelReadAccess, nil
+	case state.ModelAdminAccess:
+		return params.ModelWriteAccess, nil
+	}
+	return "", errors.Errorf("invalid model access permission %q", stateAccess)
+}

--- a/apiserver/common/modeluser.go
+++ b/apiserver/common/modeluser.go
@@ -13,7 +13,7 @@ import (
 	"github.com/juju/juju/state"
 )
 
-// ModelUser defines a subset of the state.ModelUser type
+// ModelUser defines the subset of the state.ModelUser type
 // that we require to convert to a params.ModelUserInfo.
 type ModelUser interface {
 	Access() state.ModelAccess

--- a/apiserver/modelmanager/export_test.go
+++ b/apiserver/modelmanager/export_test.go
@@ -6,10 +6,19 @@ package modelmanager
 import (
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/names"
 )
 
 func AuthCheck(c *gc.C, mm *ModelManagerAPI, user names.UserTag) bool {
 	mm.authCheck(user)
 	return mm.isAdmin
+}
+
+func NewModelManagerAPIForTest(
+	st stateInterface,
+	authorizer common.Authorizer,
+	toolsFinder *common.ToolsFinder,
+) *ModelManagerAPI {
+	return &ModelManagerAPI{st, authorizer, toolsFinder, false}
 }

--- a/apiserver/modelmanager/modelinfo_test.go
+++ b/apiserver/modelmanager/modelinfo_test.go
@@ -1,0 +1,264 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package modelmanager_test
+
+import (
+	"time"
+
+	"github.com/juju/errors"
+	"github.com/juju/names"
+	gitjujutesting "github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/modelmanager"
+	"github.com/juju/juju/apiserver/params"
+	apiservertesting "github.com/juju/juju/apiserver/testing"
+	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/state"
+	coretesting "github.com/juju/juju/testing"
+)
+
+type modelInfoSuite struct {
+	coretesting.BaseSuite
+	authorizer   apiservertesting.FakeAuthorizer
+	st           *mockState
+	modelmanager *modelmanager.ModelManagerAPI
+}
+
+var _ = gc.Suite(&modelInfoSuite{})
+
+func (s *modelInfoSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+	s.authorizer = apiservertesting.FakeAuthorizer{
+		Tag: names.NewUserTag("admin@local"),
+	}
+	s.st = &mockState{}
+	s.st.model = &mockModel{
+		owner: names.NewUserTag("bob@local"),
+		cfg:   coretesting.ModelConfig(c),
+		users: []*mockModelUser{{
+			userName: "admin",
+			access:   state.ModelAdminAccess,
+		}, {
+			userName:    "bob@local",
+			displayName: "Bob",
+			access:      state.ModelReadAccess,
+		}, {
+			userName:    "charlotte@local",
+			displayName: "Charlotte",
+			access:      state.ModelReadAccess,
+		}},
+	}
+	s.modelmanager = modelmanager.NewModelManagerAPIForTest(s.st, &s.authorizer, nil)
+}
+
+func (s *modelInfoSuite) TestModelInfo(c *gc.C) {
+	s.st.model.users[1].SetErrors(
+		nil, state.NeverConnectedError("never connected"),
+	)
+	info := s.getModelInfo(c)
+	c.Assert(info, jc.DeepEquals, params.ModelInfo{
+		Name:           "testenv",
+		UUID:           s.st.model.cfg.UUID(),
+		ControllerUUID: coretesting.ModelTag.Id(),
+		OwnerTag:       "user-bob@local",
+		ProviderType:   "someprovider",
+		DefaultSeries:  coretesting.FakeDefaultSeries,
+		Users: []params.ModelUserInfo{{
+			UserName:       "admin",
+			LastConnection: &time.Time{},
+			Access:         params.ModelWriteAccess,
+		}, {
+			UserName:       "bob@local",
+			DisplayName:    "Bob",
+			LastConnection: nil, // never connected
+			Access:         params.ModelReadAccess,
+		}, {
+			UserName:       "charlotte@local",
+			DisplayName:    "Charlotte",
+			LastConnection: &time.Time{},
+			Access:         params.ModelReadAccess,
+		}},
+	})
+	s.st.CheckCalls(c, []gitjujutesting.StubCall{
+		{"GetModel", []interface{}{names.NewModelTag(s.st.model.cfg.UUID())}},
+		{"IsControllerAdministrator", []interface{}{names.NewUserTag("admin@local")}},
+	})
+	s.st.model.CheckCalls(c, []gitjujutesting.StubCall{
+		{"Config", nil},
+		{"Users", nil},
+		{"Owner", nil},
+	})
+}
+
+func (s *modelInfoSuite) TestModelInfoOwner(c *gc.C) {
+	s.authorizer.Tag = names.NewUserTag("bob@local")
+	info := s.getModelInfo(c)
+	c.Assert(info.Users, gc.HasLen, 3)
+}
+
+func (s *modelInfoSuite) TestModelInfoNonOwner(c *gc.C) {
+	s.authorizer.Tag = names.NewUserTag("charlotte@local")
+	info := s.getModelInfo(c)
+	c.Assert(info.Users, gc.HasLen, 1)
+	c.Assert(info.Users[0].UserName, gc.Equals, "charlotte@local")
+}
+
+func (s *modelInfoSuite) getModelInfo(c *gc.C) params.ModelInfo {
+	results, err := s.modelmanager.ModelInfo(params.Entities{
+		Entities: []params.Entity{{
+			names.NewModelTag(s.st.model.cfg.UUID()).String(),
+		}},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results.Results, gc.HasLen, 1)
+	c.Assert(results.Results[0].Result, gc.NotNil)
+	c.Assert(results.Results[0].Error, gc.IsNil)
+	return *results.Results[0].Result
+}
+
+func (s *modelInfoSuite) TestModelInfoErrorInvalidTag(c *gc.C) {
+	s.testModelInfoError(c, "user-bob", `"user-bob" is not a valid model tag`)
+}
+
+func (s *modelInfoSuite) TestModelInfoErrorGetModelNotFound(c *gc.C) {
+	s.st.SetErrors(errors.NotFoundf("model"))
+	s.testModelInfoError(c, coretesting.ModelTag.String(), `permission denied`)
+}
+
+func (s *modelInfoSuite) TestModelInfoErrorModelConfig(c *gc.C) {
+	s.st.model.SetErrors(errors.Errorf("no config for you"))
+	s.testModelInfoError(c, coretesting.ModelTag.String(), `no config for you`)
+}
+
+func (s *modelInfoSuite) TestModelInfoErrorModelUsers(c *gc.C) {
+	s.st.model.SetErrors(errors.Errorf("no users for you"))
+	s.testModelInfoError(c, coretesting.ModelTag.String(), `no users for you`)
+}
+
+func (s *modelInfoSuite) TestModelInfoErrorNoModelUsers(c *gc.C) {
+	s.st.model.users = nil
+	s.testModelInfoError(c, coretesting.ModelTag.String(), `permission denied`)
+}
+
+func (s *modelInfoSuite) TestModelInfoErrorNoAccess(c *gc.C) {
+	s.authorizer.Tag = names.NewUserTag("nemo@local")
+	s.testModelInfoError(c, coretesting.ModelTag.String(), `permission denied`)
+}
+
+func (s *modelInfoSuite) testModelInfoError(c *gc.C, modelTag, expectedErr string) {
+	results, err := s.modelmanager.ModelInfo(params.Entities{
+		Entities: []params.Entity{{modelTag}},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results.Results, gc.HasLen, 1)
+	c.Assert(results.Results[0].Result, gc.IsNil)
+	c.Assert(results.Results[0].Error, gc.ErrorMatches, expectedErr)
+}
+
+type mockState struct {
+	gitjujutesting.Stub
+	model *mockModel
+	owner names.UserTag
+	users []*state.ModelUser
+}
+
+func (st *mockState) ModelsForUser(user names.UserTag) ([]*state.UserModel, error) {
+	st.MethodCall(st, "ModelsForUser", user)
+	return nil, st.NextErr()
+}
+
+func (st *mockState) IsControllerAdministrator(user names.UserTag) (bool, error) {
+	st.MethodCall(st, "IsControllerAdministrator", user)
+	return user.Canonical() == "admin@local", st.NextErr()
+}
+
+func (st *mockState) NewModel(cfg *config.Config, owner names.UserTag) (*state.Model, *state.State, error) {
+	st.MethodCall(st, "NewModel", cfg, owner)
+	return nil, nil, st.NextErr()
+}
+
+func (st *mockState) ControllerModel() (*state.Model, error) {
+	st.MethodCall(st, "ControllerModel")
+	return nil, st.NextErr()
+}
+
+func (st *mockState) ForModel(tag names.ModelTag) (*state.State, error) {
+	st.MethodCall(st, "ForModel", tag)
+	return nil, st.NextErr()
+}
+
+func (st *mockState) GetModel(tag names.ModelTag) (modelmanager.Model, error) {
+	st.MethodCall(st, "GetModel", tag)
+	return st.model, st.NextErr()
+}
+
+type mockModel struct {
+	gitjujutesting.Stub
+	owner names.UserTag
+	cfg   *config.Config
+	users []*mockModelUser
+}
+
+func (m *mockModel) Config() (*config.Config, error) {
+	m.MethodCall(m, "Config")
+	return m.cfg, m.NextErr()
+}
+
+func (m *mockModel) Owner() names.UserTag {
+	m.MethodCall(m, "Owner")
+	m.PopNoErr()
+	return m.owner
+}
+
+func (m *mockModel) Users() ([]common.ModelUser, error) {
+	m.MethodCall(m, "Users")
+	if err := m.NextErr(); err != nil {
+		return nil, err
+	}
+	users := make([]common.ModelUser, len(m.users))
+	for i, user := range m.users {
+		users[i] = user
+	}
+	return users, nil
+}
+
+type mockModelUser struct {
+	gitjujutesting.Stub
+	userName       string
+	displayName    string
+	access         state.ModelAccess
+	lastConnection time.Time
+}
+
+func (u *mockModelUser) Access() state.ModelAccess {
+	u.MethodCall(u, "Access")
+	u.PopNoErr()
+	return u.access
+}
+
+func (u *mockModelUser) DisplayName() string {
+	u.MethodCall(u, "DisplayName")
+	u.PopNoErr()
+	return u.displayName
+}
+
+func (u *mockModelUser) LastConnection() (time.Time, error) {
+	u.MethodCall(u, "LastConnection")
+	return u.lastConnection, u.NextErr()
+}
+
+func (u *mockModelUser) UserName() string {
+	u.MethodCall(u, "UserName")
+	u.PopNoErr()
+	return u.userName
+}
+
+func (u *mockModelUser) UserTag() names.UserTag {
+	u.MethodCall(u, "UserTag")
+	u.PopNoErr()
+	return names.NewUserTag(u.userName)
+}

--- a/apiserver/modelmanager/state.go
+++ b/apiserver/modelmanager/state.go
@@ -47,7 +47,7 @@ type modelShim struct {
 }
 
 func (m modelShim) Users() ([]common.ModelUser, error) {
-	stateUsers, err := m.Users()
+	stateUsers, err := m.Model.Users()
 	if err != nil {
 		return nil, err
 	}

--- a/apiserver/modelmanager/state.go
+++ b/apiserver/modelmanager/state.go
@@ -6,6 +6,7 @@ package modelmanager
 import (
 	"github.com/juju/names"
 
+	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/state"
 )
@@ -20,8 +21,39 @@ type stateInterface interface {
 	NewModel(*config.Config, names.UserTag) (*state.Model, *state.State, error)
 	ControllerModel() (*state.Model, error)
 	ForModel(tag names.ModelTag) (*state.State, error)
+	GetModel(names.ModelTag) (Model, error)
+}
+
+type Model interface {
+	Config() (*config.Config, error)
+	Owner() names.UserTag
+	Users() ([]common.ModelUser, error)
 }
 
 type stateShim struct {
 	*state.State
+}
+
+func (st stateShim) GetModel(tag names.ModelTag) (Model, error) {
+	m, err := st.State.GetModel(tag)
+	if err != nil {
+		return nil, err
+	}
+	return modelShim{m}, nil
+}
+
+type modelShim struct {
+	*state.Model
+}
+
+func (m modelShim) Users() ([]common.ModelUser, error) {
+	stateUsers, err := m.Users()
+	if err != nil {
+		return nil, err
+	}
+	users := make([]common.ModelUser, len(stateUsers))
+	for i, user := range stateUsers {
+		users[i] = user
+	}
+	return users, nil
 }

--- a/apiserver/params/model.go
+++ b/apiserver/params/model.go
@@ -33,13 +33,44 @@ type SetModelAgentVersion struct {
 	Version version.Number
 }
 
-// ModelUserInfo holds information on a user.
+// ModelInfo holds information about the Juju model.
+type ModelInfo struct {
+	// The json names for the fields below are as per the older
+	// field names for backward compatability.
+	Name           string `json:"Name"`
+	UUID           string `json:"UUID"`
+	ControllerUUID string `json:"ServerUUID"`
+	ProviderType   string `json:"ProviderType"`
+	DefaultSeries  string `json:"DefaultSeries"`
+
+	// OwnerTag is the tag of the user that owns the model.
+	OwnerTag string `json:"owner-tag"`
+
+	// Users contains information about the users that have access
+	// to the model. Owners and administrators can see all users
+	// that have access; other users can only see their own details.
+	Users []ModelUserInfo
+}
+
+// ModelInfoResult holds the result of a ModelInfo call.
+type ModelInfoResult struct {
+	Result *ModelInfo `json:"result,omitempty"`
+	Error  *Error     `json:"error,omitempty"`
+}
+
+// ModelInfoResult holds the result of a bulk ModelInfo call.
+type ModelInfoResults struct {
+	Results []ModelInfoResult `json:"results"`
+}
+
+// ModelUserInfo holds information on a user who has access to a
+// model. Owners of a model can see this information for all users
+// who have access, so it should not include sensitive information.
 type ModelUserInfo struct {
-	UserName       string     `json:"user"`
-	DisplayName    string     `json:"displayname"`
-	CreatedBy      string     `json:"createdby"`
-	DateCreated    time.Time  `json:"datecreated"`
-	LastConnection *time.Time `json:"lastconnection"`
+	UserName       string                `json:"user"`
+	DisplayName    string                `json:"displayname"`
+	LastConnection *time.Time            `json:"lastconnection"`
+	Access         ModelAccessPermission `json:"access"`
 }
 
 // ModelUserInfoResult holds the result of an ModelUserInfo call.

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -810,18 +810,6 @@ type ResumeReplicationParams struct {
 	Members []replicaset.Member
 }
 
-// ModelInfo holds information about the Juju model.
-type ModelInfo struct {
-	DefaultSeries string `json:"DefaultSeries"`
-	ProviderType  string `json:"ProviderType"`
-	Name          string `json:"Name"`
-	UUID          string `json:"UUID"`
-	// The json name here is as per the older field name and is required
-	// for backward compatability. The other fields also have explicit
-	// matching serialization directives for the benefit of being explicit.
-	ControllerUUID string `json:"ServerUUID"`
-}
-
 // MeterStatusParam holds meter status information to be set for the specified tag.
 type MeterStatusParam struct {
 	Tag  string `json:"tag"`

--- a/apiserver/read_only_calls.go
+++ b/apiserver/read_only_calls.go
@@ -45,6 +45,7 @@ var readOnlyCalls = set.NewStrings(
 	"Client.WatchAll",
 	// TODO: add controller work.
 	"KeyManager.ListKeys",
+	"ModelManager.ModelInfo",
 	"Service.GetConstraints",
 	"Service.CharmRelations",
 	"Service.Get",

--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -202,6 +202,7 @@ func registerCommands(r commandRegistry, ctx *cmd.Context) {
 	r.Register(model.NewUsersCommand())
 	r.Register(model.NewGrantCommand())
 	r.Register(model.NewRevokeCommand())
+	r.Register(model.NewShowCommand())
 
 	if featureflag.Enabled(feature.Migration) {
 		r.Register(newMigrateCommand())

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -306,6 +306,7 @@ var commandNames = []string{
 	"show-controllers",
 	"show-machine",
 	"show-machines",
+	"show-model",
 	"show-status",
 	"show-storage",
 	"show-user",

--- a/cmd/juju/model/export_test.go
+++ b/cmd/juju/model/export_test.go
@@ -49,6 +49,13 @@ func NewUsersCommandForTest(api UsersAPI, store jujuclient.ClientStore) cmd.Comm
 	return modelcmd.Wrap(cmd)
 }
 
+// NewShowCommandForTest returns a ShowCommand with the api provided as specified.
+func NewShowCommandForTest(api ShowModelAPI, store jujuclient.ClientStore) cmd.Command {
+	cmd := &showModelCommand{api: api}
+	cmd.SetClientStore(store)
+	return modelcmd.Wrap(cmd)
+}
+
 // NewDestroyCommandForTest returns a DestroyCommand with the api provided as specified.
 func NewDestroyCommandForTest(api DestroyEnvironmentAPI, store jujuclient.ClientStore) cmd.Command {
 	cmd := &destroyCommand{

--- a/cmd/juju/model/show.go
+++ b/cmd/juju/model/show.go
@@ -1,0 +1,123 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for infos.
+
+package model
+
+import (
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+	"github.com/juju/names"
+	"launchpad.net/gnuflag"
+
+	"github.com/juju/juju/api/modelmanager"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/modelcmd"
+)
+
+const showModelCommandDoc = `Show information about the current or specified model`
+
+func NewShowCommand() cmd.Command {
+	return modelcmd.Wrap(&showModelCommand{})
+}
+
+// showModelCommand shows all the users with access to the current model.
+type showModelCommand struct {
+	modelcmd.ModelCommandBase
+	out cmd.Output
+	api ShowModelAPI
+}
+
+// ModelInfo contains information about a model.
+type ModelInfo struct {
+	UUID           string              `json:"model-uuid" yaml:"model-uuid"`
+	ControllerUUID string              `json:"controller-uuid" yaml:"controller-uuid"`
+	Owner          string              `json:"owner" yaml:"owner"`
+	ProviderType   string              `json:"type" yaml:"type"`
+	Users          map[string]UserInfo `json:"users" yaml:"users"`
+}
+
+// ShowModelAPI defines the methods on the client API that the
+// users command calls.
+type ShowModelAPI interface {
+	Close() error
+	ModelInfo([]names.ModelTag) ([]params.ModelInfoResult, error)
+}
+
+func (c *showModelCommand) getAPI() (ShowModelAPI, error) {
+	if c.api != nil {
+		return c.api, nil
+	}
+	api, err := c.NewAPIRoot()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return modelmanager.NewClient(api), nil
+}
+
+// Info implements Command.Info.
+func (c *showModelCommand) Info() *cmd.Info {
+	return &cmd.Info{
+		Name:    "show-model",
+		Purpose: "shows information about the current or specified model",
+		Doc:     showModelCommandDoc,
+	}
+}
+
+// SetFlags implements Command.SetFlags.
+func (c *showModelCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.out.AddFlags(f, "yaml", map[string]cmd.Formatter{
+		"yaml": cmd.FormatYaml,
+		"json": cmd.FormatJson,
+	})
+}
+
+// Run implements Command.Run.
+func (c *showModelCommand) Run(ctx *cmd.Context) (err error) {
+	api, err := c.getAPI()
+	if err != nil {
+		return err
+	}
+	defer api.Close()
+
+	store := c.ClientStore()
+	modelDetails, err := store.ModelByName(
+		c.ControllerName(),
+		c.AccountName(),
+		c.ModelName(),
+	)
+	if err != nil {
+		return errors.Annotate(err, "getting model details")
+	}
+
+	modelTag := names.NewModelTag(modelDetails.ModelUUID)
+	results, err := api.ModelInfo([]names.ModelTag{modelTag})
+	if err != nil {
+		return err
+	}
+	if results[0].Error != nil {
+		return results[0].Error
+	}
+	infoMap, err := c.apiModelInfoToModelInfoMap([]params.ModelInfo{*results[0].Result})
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return c.out.Write(ctx, infoMap)
+}
+
+func (c *showModelCommand) apiModelInfoToModelInfoMap(modelInfo []params.ModelInfo) (map[string]ModelInfo, error) {
+	output := make(map[string]ModelInfo)
+	for _, info := range modelInfo {
+		tag, err := names.ParseUserTag(info.OwnerTag)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		output[info.Name] = ModelInfo{
+			UUID:           info.UUID,
+			ControllerUUID: info.ControllerUUID,
+			Owner:          tag.Id(),
+			ProviderType:   info.ProviderType,
+			Users:          apiUsersToUserInfoMap(info.Users),
+		}
+	}
+	return output, nil
+}

--- a/cmd/juju/model/show_test.go
+++ b/cmd/juju/model/show_test.go
@@ -1,0 +1,136 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for info.
+
+package model_test
+
+import (
+	"time"
+
+	"github.com/juju/errors"
+	"github.com/juju/names"
+	gitjujutesting "github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/juju/model"
+	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/jujuclient"
+	"github.com/juju/juju/jujuclient/jujuclienttesting"
+	"github.com/juju/juju/testing"
+)
+
+type ShowCommandSuite struct {
+	testing.FakeJujuXDGDataHomeSuite
+	fake  fakeModelShowClient
+	store *jujuclienttesting.MemStore
+}
+
+var _ = gc.Suite(&ShowCommandSuite{})
+
+type fakeModelShowClient struct {
+	gitjujutesting.Stub
+	info params.ModelInfo
+	err  *params.Error
+}
+
+func (f *fakeModelShowClient) Close() error {
+	f.MethodCall(f, "Close")
+	return f.NextErr()
+}
+
+func (f *fakeModelShowClient) ModelInfo(tags []names.ModelTag) ([]params.ModelInfoResult, error) {
+	f.MethodCall(f, "ModelInfo", tags)
+	if len(tags) != 1 {
+		return nil, errors.Errorf("expected 1 tag, got %d", len(tags))
+	}
+	if tags[0] != testing.ModelTag {
+		return nil, errors.Errorf("expected %s, got %s", testing.ModelTag.Id(), tags[0].Id())
+	}
+	return []params.ModelInfoResult{{Result: &f.info, Error: f.err}}, f.NextErr()
+}
+
+func (s *ShowCommandSuite) SetUpTest(c *gc.C) {
+	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
+	last1 := time.Date(2015, 3, 20, 0, 0, 0, 0, time.UTC)
+
+	users := []params.ModelUserInfo{{
+		UserName:       "admin@local",
+		LastConnection: &last1,
+		Access:         "write",
+	}, {
+		UserName:    "bob@local",
+		DisplayName: "Bob",
+		Access:      "read",
+	}}
+
+	s.fake.ResetCalls()
+	s.fake.err = nil
+	s.fake.info = params.ModelInfo{
+		Name:           "mymodel",
+		UUID:           testing.ModelTag.Id(),
+		ControllerUUID: "1ca2293b-fdb9-4299-97d6-55583bb39364",
+		OwnerTag:       "user-admin@local",
+		ProviderType:   "openstack",
+		Users:          users,
+	}
+
+	err := modelcmd.WriteCurrentController("testing")
+	c.Assert(err, jc.ErrorIsNil)
+	s.store = jujuclienttesting.NewMemStore()
+	s.store.Controllers["testing"] = jujuclient.ControllerDetails{}
+	s.store.Accounts["testing"] = &jujuclient.ControllerAccounts{
+		CurrentAccount: "admin@local",
+	}
+	err = s.store.UpdateModel("testing", "admin@local", "mymodel", jujuclient.ModelDetails{
+		testing.ModelTag.Id(),
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	s.store.Models["testing"].AccountModels["admin@local"].CurrentModel = "mymodel"
+}
+
+func (s *ShowCommandSuite) TestShow(c *gc.C) {
+	_, err := testing.RunCommand(c, model.NewShowCommandForTest(&s.fake, s.store))
+	c.Assert(err, jc.ErrorIsNil)
+	s.fake.CheckCalls(c, []gitjujutesting.StubCall{
+		{"ModelInfo", []interface{}{[]names.ModelTag{testing.ModelTag}}},
+		{"Close", nil},
+	})
+}
+
+func (s *ShowCommandSuite) TestShowFormatYaml(c *gc.C) {
+	ctx, err := testing.RunCommand(c, model.NewShowCommandForTest(&s.fake, s.store), "--format", "yaml")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(testing.Stdout(ctx), gc.Equals, `
+mymodel:
+  model-uuid: deadbeef-0bad-400d-8000-4b1d0d06f00d
+  controller-uuid: 1ca2293b-fdb9-4299-97d6-55583bb39364
+  owner: admin@local
+  type: openstack
+  users:
+    admin@local:
+      access: write
+      last-connection: 2015-03-20
+    bob@local:
+      display-name: Bob
+      access: read
+      last-connection: never connected
+`[1:])
+}
+
+func (s *ShowCommandSuite) TestShowFormatJson(c *gc.C) {
+	ctx, err := testing.RunCommand(c, model.NewShowCommandForTest(&s.fake, s.store), "--format", "json")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(testing.Stdout(ctx), gc.Equals, ""+
+		`{"mymodel":{"model-uuid":"deadbeef-0bad-400d-8000-4b1d0d06f00d",`+
+		`"controller-uuid":"1ca2293b-fdb9-4299-97d6-55583bb39364",`+
+		`"owner":"admin@local","type":"openstack",`+
+		`"users":{"admin@local":{"access":"write","last-connection":"2015-03-20"},`+
+		`"bob@local":{"display-name":"Bob","access":"read","last-connection":"never connected"}}}}
+`)
+}
+
+func (s *ShowCommandSuite) TestUnrecognizedArg(c *gc.C) {
+	_, err := testing.RunCommand(c, model.NewShowCommandForTest(&s.fake, s.store), "-m", "admin", "whoops")
+	c.Assert(err, gc.ErrorMatches, `unrecognized args: \["whoops"\]`)
+}

--- a/cmd/juju/model/users.go
+++ b/cmd/juju/model/users.go
@@ -108,7 +108,7 @@ func formatTabularUserInfo(users map[string]UserInfo, out *bytes.Buffer) error {
 		padchar  = ' '
 		flags    = 0
 	)
-	names := make(set.Strings)
+	names := set.NewStrings()
 	for name := range users {
 		names.Add(name)
 	}

--- a/cmd/juju/model/users.go
+++ b/cmd/juju/model/users.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
+	"github.com/juju/utils/set"
 	"launchpad.net/gnuflag"
 
 	"github.com/juju/juju/apiserver/params"
@@ -33,8 +34,8 @@ type usersCommand struct {
 
 // UserInfo defines the serialization behaviour of the user information.
 type UserInfo struct {
-	Username       string `yaml:"user-name" json:"user-name"`
-	DateCreated    string `yaml:"date-created" json:"date-created"`
+	DisplayName    string `yaml:"display-name,omitempty" json:"display-name,omitempty"`
+	Access         string `yaml:"access" json:"access"`
 	LastConnection string `yaml:"last-connection" json:"last-connection"`
 }
 
@@ -82,17 +83,23 @@ func (c *usersCommand) Run(ctx *cmd.Context) (err error) {
 	if err != nil {
 		return err
 	}
-
-	return c.out.Write(ctx, c.apiUsersToUserInfoSlice(result))
+	return c.out.Write(ctx, apiUsersToUserInfoMap(result))
 }
 
 // formatTabular takes an interface{} to adhere to the cmd.Formatter interface
 func (c *usersCommand) formatTabular(value interface{}) ([]byte, error) {
-	users, ok := value.([]UserInfo)
+	users, ok := value.(map[string]UserInfo)
 	if !ok {
 		return nil, errors.Errorf("expected value of type %T, got %T", users, value)
 	}
 	var out bytes.Buffer
+	if err := formatTabularUserInfo(users, &out); err != nil {
+		return nil, errors.Trace(err)
+	}
+	return out.Bytes(), nil
+}
+
+func formatTabularUserInfo(users map[string]UserInfo, out *bytes.Buffer) error {
 	const (
 		// To format things into columns.
 		minwidth = 0
@@ -101,28 +108,37 @@ func (c *usersCommand) formatTabular(value interface{}) ([]byte, error) {
 		padchar  = ' '
 		flags    = 0
 	)
-	tw := tabwriter.NewWriter(&out, minwidth, tabwidth, padding, padchar, flags)
-	fmt.Fprintf(tw, "NAME\tDATE CREATED\tLAST CONNECTION\n")
-	for _, user := range users {
-		fmt.Fprintf(tw, "%s\t%s\t%s\n", user.Username, user.DateCreated, user.LastConnection)
+	names := make(set.Strings)
+	for name := range users {
+		names.Add(name)
+	}
+	tw := tabwriter.NewWriter(out, minwidth, tabwidth, padding, padchar, flags)
+	fmt.Fprintf(tw, "NAME\tACCESS\tLAST CONNECTION\n")
+	for _, name := range names.SortedValues() {
+		user := users[name]
+		displayName := name
+		if user.DisplayName != "" {
+			displayName = fmt.Sprintf("%s (%s)", name, user.DisplayName)
+		}
+		fmt.Fprintf(tw, "%s\t%s\t%s\n", displayName, user.Access, user.LastConnection)
 	}
 	tw.Flush()
-	return out.Bytes(), nil
+	return nil
 }
 
-func (c *usersCommand) apiUsersToUserInfoSlice(users []params.ModelUserInfo) []UserInfo {
-	var output []UserInfo
+func apiUsersToUserInfoMap(users []params.ModelUserInfo) map[string]UserInfo {
+	output := make(map[string]UserInfo)
 	for _, info := range users {
-		outInfo := UserInfo{Username: info.UserName}
-		outInfo.DateCreated = user.UserFriendlyDuration(info.DateCreated, time.Now())
+		outInfo := UserInfo{
+			DisplayName: info.DisplayName,
+			Access:      string(info.Access),
+		}
 		if info.LastConnection != nil {
 			outInfo.LastConnection = user.UserFriendlyDuration(*info.LastConnection, time.Now())
 		} else {
 			outInfo.LastConnection = "never connected"
 		}
-
-		output = append(output, outInfo)
+		output[info.UserName] = outInfo
 	}
-
 	return output
 }

--- a/cmd/juju/model/users_test.go
+++ b/cmd/juju/model/users_test.go
@@ -45,21 +45,17 @@ func (s *UsersCommandSuite) SetUpTest(c *gc.C) {
 	userlist := []params.ModelUserInfo{
 		{
 			UserName:       "admin@local",
-			DisplayName:    "admin",
-			CreatedBy:      "admin@local",
-			DateCreated:    time.Date(2014, 7, 20, 9, 0, 0, 0, time.UTC),
 			LastConnection: &last1,
+			Access:         "write",
 		}, {
 			UserName:       "bob@local",
 			DisplayName:    "Bob",
-			CreatedBy:      "admin@local",
-			DateCreated:    time.Date(2015, 2, 15, 9, 0, 0, 0, time.UTC),
 			LastConnection: &last2,
+			Access:         "read",
 		}, {
 			UserName:    "charlie@ubuntu.com",
 			DisplayName: "Charlie",
-			CreatedBy:   "admin@local",
-			DateCreated: time.Date(2015, 2, 15, 9, 0, 0, 0, time.UTC),
+			Access:      "read",
 		},
 	}
 
@@ -78,35 +74,37 @@ func (s *UsersCommandSuite) TestModelUsers(c *gc.C) {
 	context, err := testing.RunCommand(c, model.NewUsersCommandForTest(s.fake, s.store), "-m", "admin")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(testing.Stdout(context), gc.Equals, ""+
-		"NAME                DATE CREATED  LAST CONNECTION\n"+
-		"admin@local         2014-07-20    2015-03-20\n"+
-		"bob@local           2015-02-15    2015-03-01\n"+
-		"charlie@ubuntu.com  2015-02-15    never connected\n"+
+		"NAME                          ACCESS  LAST CONNECTION\n"+
+		"admin@local                   write   2015-03-20\n"+
+		"bob@local (Bob)               read    2015-03-01\n"+
+		"charlie@ubuntu.com (Charlie)  read    never connected\n"+
 		"\n")
 }
 
 func (s *UsersCommandSuite) TestModelUsersFormatJson(c *gc.C) {
 	context, err := testing.RunCommand(c, model.NewUsersCommandForTest(s.fake, s.store), "-m", "admin", "--format", "json")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(testing.Stdout(context), gc.Equals, "["+
-		`{"user-name":"admin@local","date-created":"2014-07-20","last-connection":"2015-03-20"},`+
-		`{"user-name":"bob@local","date-created":"2015-02-15","last-connection":"2015-03-01"},`+
-		`{"user-name":"charlie@ubuntu.com","date-created":"2015-02-15","last-connection":"never connected"}`+
-		"]\n")
+	c.Assert(testing.Stdout(context), gc.Equals, "{"+
+		`"admin@local":{"access":"write","last-connection":"2015-03-20"},`+
+		`"bob@local":{"display-name":"Bob","access":"read","last-connection":"2015-03-01"},`+
+		`"charlie@ubuntu.com":{"display-name":"Charlie","access":"read","last-connection":"never connected"}`+
+		"}\n")
 }
 
 func (s *UsersCommandSuite) TestUserInfoFormatYaml(c *gc.C) {
 	context, err := testing.RunCommand(c, model.NewUsersCommandForTest(s.fake, s.store), "-m", "admin", "--format", "yaml")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(testing.Stdout(context), gc.Equals, ""+
-		"- user-name: admin@local\n"+
-		"  date-created: 2014-07-20\n"+
+		"admin@local:\n"+
+		"  access: write\n"+
 		"  last-connection: 2015-03-20\n"+
-		"- user-name: bob@local\n"+
-		"  date-created: 2015-02-15\n"+
+		"bob@local:\n"+
+		"  display-name: Bob\n"+
+		"  access: read\n"+
 		"  last-connection: 2015-03-01\n"+
-		"- user-name: charlie@ubuntu.com\n"+
-		"  date-created: 2015-02-15\n"+
+		"charlie@ubuntu.com:\n"+
+		"  display-name: Charlie\n"+
+		"  access: read\n"+
 		"  last-connection: never connected\n")
 }
 

--- a/featuretests/api_model_test.go
+++ b/featuretests/api_model_test.go
@@ -53,7 +53,6 @@ func (s *apiEnvironmentSuite) TestGrantModel(c *gc.C) {
 	modelUser, err := s.State.ModelUser(user)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(modelUser.UserName(), gc.Equals, user.Canonical())
-	c.Assert(modelUser.CreatedBy(), gc.Equals, s.AdminUserTag(c).Canonical())
 	lastConn, err := modelUser.LastConnection()
 	c.Assert(err, jc.Satisfies, state.IsNeverConnectedError)
 	c.Assert(lastConn.IsZero(), jc.IsTrue)
@@ -92,14 +91,12 @@ func (s *apiEnvironmentSuite) TestEnvironmentUserInfo(c *gc.C) {
 		{
 			UserName:       owner.UserName(),
 			DisplayName:    owner.DisplayName(),
-			CreatedBy:      owner.UserName(),
-			DateCreated:    owner.DateCreated(),
+			Access:         "write",
 			LastConnection: lastConnPointer(c, owner),
 		}, {
 			UserName:       "bobjohns@ubuntuone",
 			DisplayName:    "Bob Johns",
-			CreatedBy:      owner.UserName(),
-			DateCreated:    modelUser.DateCreated(),
+			Access:         "write",
 			LastConnection: lastConnPointer(c, modelUser),
 		},
 	})

--- a/featuretests/cmd_juju_model_test.go
+++ b/featuretests/cmd_juju_model_test.go
@@ -95,9 +95,9 @@ func (s *cmdModelSuite) TestModelUsersCmd(c *gc.C) {
 	context = s.run(c, "list-shares")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(testing.Stdout(context), gc.Equals, ""+
-		"NAME           DATE CREATED  LAST CONNECTION\n"+
-		"admin@local    just now      just now\n"+
-		"bar@ubuntuone  just now      never connected\n"+
+		"NAME                 ACCESS  LAST CONNECTION\n"+
+		"admin@local (admin)  write   just now\n"+
+		"bar@ubuntuone        read    never connected\n"+
 		"\n")
 
 }


### PR DESCRIPTION
We add the "show-model" command which shows
summary information about the current model.
This includes the name, UUID, provider type,
owner, and users with access.

If you are an administrator or owner of the
model, you will see all users with access to
the model. Otherwise, you will see only your
own user details.

(Review request: http://reviews.vapour.ws/r/4398/)