### PR TITLE
Auth for unit agent allowed for proxyupdater

### DIFF
--- a/apiserver/proxyupdater/proxyupdater.go
+++ b/apiserver/proxyupdater/proxyupdater.go
@@ -47,7 +47,7 @@ func NewAPI(st *state.State, res *common.Resources, auth common.Authorizer) (API
 
 // newAPIWithBacking creates a new server-side API facade with the given Backing.
 func newAPIWithBacking(st Backend, resources *common.Resources, authorizer common.Authorizer) (API, error) {
-	if !authorizer.AuthMachineAgent() {
+	if !(authorizer.AuthMachineAgent() || authorizer.AuthUnitAgent()) {
 		return nil, common.ErrPerm
 	}
 	return &proxyUpdaterAPI{


### PR DESCRIPTION
...because that is what we get when we are launched by the dep engine.

(Review request: http://reviews.vapour.ws/r/4400/)