### PR TITLE
Use the new boot-resources endpoint in MAAS 2 support

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -20,7 +20,7 @@ github.com/juju/go4	git	40d72ab9641a2a8c36a9c46a51e28367115c8e59	2016-02-22T16:3
 github.com/juju/gojsonpointer	git	afe8b77aa08f272b49e01b82de78510c11f61500	2015-02-04T19:46:29Z
 github.com/juju/gojsonreference	git	f0d24ac5ee330baa21721cdff56d45e4ee42628e	2015-02-04T19:46:33Z
 github.com/juju/gojsonschema	git	e1ad140384f254c82f89450d9a7c8dd38a632838	2015-03-12T17:00:16Z
-github.com/juju/gomaasapi       git     3888cd414c8d0ec07bc0867fd22ce130bd9bb7c7        2016-03-31T13:55:14Z
+github.com/juju/gomaasapi	git	3888cd414c8d0ec07bc0867fd22ce130bd9bb7c7	2016-03-31T13:55:14Z
 github.com/juju/govmomi	git	4354a88d4b34abe467215f77c2fc1cb9f78b66f7	2015-04-24T01:54:48Z
 github.com/juju/httpprof	git	14bf14c307672fd2456bdbf35d19cf0ccd3cf565	2014-12-17T16:00:36Z
 github.com/juju/httprequest	git	89d547093c45e293599088cc63e805c6f1205dc0	2016-03-02T10:09:58Z

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -379,7 +379,7 @@ func (env *maasEnviron) allArchitectures2() ([]string, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	architectures := make(set.Strings)
+	architectures := set.NewStrings()
 	for _, resource := range resources {
 		architectures.Add(strings.Split(resource.Architecture(), "/")[0])
 	}
@@ -409,7 +409,7 @@ func (env *maasEnviron) allArchitectures() ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	architectures := make(set.Strings)
+	architectures := set.NewStrings()
 	for _, nodegroup := range nodegroups {
 		bootImages, err := env.nodegroupBootImages(nodegroup)
 		if err != nil {

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -345,19 +345,15 @@ func (env *maasEnviron) SupportedArchitectures() ([]string, error) {
 		return env.supportedArchitectures, nil
 	}
 
+	fetchArchitectures := env.allArchitecturesWithFallback
 	if env.usingMAAS2() {
-		architectures, err := env.allArchitectures2()
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		env.supportedArchitectures = architectures
-	} else {
-		architectures, err := env.allArchitecturesWithFallback()
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		env.supportedArchitectures = architectures
+		fetchArchitectures = env.allArchitectures2
 	}
+	architectures, err := fetchArchitectures()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	env.supportedArchitectures = architectures
 	return env.supportedArchitectures, nil
 }
 
@@ -376,6 +372,8 @@ func (env *maasEnviron) SupportsAddressAllocation(_ network.Id) (bool, error) {
 	return true, nil
 }
 
+// allArchitectures2 uses the MAAS2 controller to get architectures from boot
+// resources.
 func (env *maasEnviron) allArchitectures2() ([]string, error) {
 	resources, err := env.maasController.BootResources()
 	if err != nil {
@@ -388,8 +386,8 @@ func (env *maasEnviron) allArchitectures2() ([]string, error) {
 	return architectures.SortedValues(), nil
 }
 
-// allArchitectures queries MAAS for all of the boot-images across all
-// registered nodegroups and collapses them down to unique
+// allArchitectureWithFallback queries MAAS for all of the boot-images
+// across all registered nodegroups and collapses them down to unique
 // architectures.
 func (env *maasEnviron) allArchitecturesWithFallback() ([]string, error) {
 	architectures, err := env.allArchitectures()

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -41,6 +41,9 @@ import (
 const (
 	// The string from the api indicating the dynamic range of a subnet.
 	dynamicRange = "dynamic-range"
+	// The version strings indicating the MAAS API version.
+	apiVersion1 = "1.0"
+	apiVersion2 = "2.0"
 )
 
 // A request may fail to due "eventual consistency" semantics, which
@@ -216,7 +219,7 @@ func NewEnviron(cfg *config.Config) (*maasEnviron, error) {
 }
 
 func (env *maasEnviron) usingMAAS2() bool {
-	return env.apiVersion == "2.0"
+	return env.apiVersion == apiVersion2
 }
 
 // Bootstrap is specified in the Environ interface.
@@ -308,12 +311,12 @@ func (env *maasEnviron) SetConfig(cfg *config.Config) error {
 	// We need to know the version of the server we're on. We support 1.9
 	// and 2.0. MAAS 1.9 uses the 1.0 api version and 2.0 uses the 2.0 api
 	// version.
-	apiVersion := "2.0"
+	apiVersion := apiVersion2
 	controller, err := GetMAAS2Controller(ecfg.maasServer(), ecfg.maasOAuth())
 	maasErr, ok := errors.Cause(err).(gomaasapi.ServerError)
 	if ok && maasErr.StatusCode == http.StatusNotFound {
-		apiVersion = "1.0"
-		authClient, err := gomaasapi.NewAuthenticatedClient(ecfg.maasServer(), ecfg.maasOAuth(), "1.0")
+		apiVersion = apiVersion1
+		authClient, err := gomaasapi.NewAuthenticatedClient(ecfg.maasServer(), ecfg.maasOAuth(), apiVersion1)
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/provider/maas/maas2_environ_whitebox_test.go
+++ b/provider/maas/maas2_environ_whitebox_test.go
@@ -43,7 +43,7 @@ func (r *fakeBootResource) Architecture() string {
 }
 
 type maas2EnvironSuite struct {
-	controllerSuite
+	baseProviderSuite
 }
 
 var _ = gc.Suite(&maas2EnvironSuite{})

--- a/provider/maas/maas2_environ_whitebox_test.go
+++ b/provider/maas/maas2_environ_whitebox_test.go
@@ -4,6 +4,10 @@
 package maas
 
 import (
+	"net/http"
+
+	"github.com/juju/errors"
+	"github.com/juju/gomaasapi"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -11,22 +15,62 @@ import (
 	coretesting "github.com/juju/juju/testing"
 )
 
+type fakeController struct {
+	gomaasapi.Controller
+}
+
+func (fakeController) BootResources() ([]gomaasapi.BootResource, error) {
+	return nil, errors.New("Something terrible!")
+}
+
 type maas2EnvironSuite struct {
 	controllerSuite
 }
 
 var _ = gc.Suite(&maas2EnvironSuite{})
 
-func (suite *maas2EnvironSuite) TestNewEnvironWithController(c *gc.C) {
+func makeEnviron(c *gc.C) *maasEnviron {
 	testAttrs := coretesting.Attrs{}
 	for k, v := range maasEnvAttrs {
 		testAttrs[k] = v
 	}
-	testAttrs["maas-server"] = suite.testServer.Server.URL
+	testAttrs["maas-server"] = "http://any-old-junk.invalid/"
 	attrs := coretesting.FakeConfig().Merge(testAttrs)
 	cfg, err := config.New(config.NoDefaults, attrs)
 	c.Assert(err, jc.ErrorIsNil)
 	env, err := NewEnviron(cfg)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(env, gc.NotNil)
+	return env
+}
+
+func (suite *maas2EnvironSuite) TestNewEnvironWithController(c *gc.C) {
+	testServer := gomaasapi.NewSimpleServer()
+	testServer.AddResponse("/api/2.0/version/", http.StatusOK, maas2VersionResponse)
+	testServer.Start()
+	defer testServer.Close()
+	testAttrs := coretesting.Attrs{}
+	for k, v := range maasEnvAttrs {
+		testAttrs[k] = v
+	}
+	testAttrs["maas-server"] = testServer.Server.URL
+	attrs := coretesting.FakeConfig().Merge(testAttrs)
+	cfg, err := config.New(config.NoDefaults, attrs)
+	c.Assert(err, jc.ErrorIsNil)
+	env, err := NewEnviron(cfg)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(env, gc.NotNil)
+}
+
+func (suite *maas2EnvironSuite) TestSupportedArchitectures(c *gc.C) {
+}
+
+func (suite *maas2EnvironSuite) TestSupportedArchitecturesError(c *gc.C) {
+	mockGetController := func(maasServer, apiKey string) (gomaasapi.Controller, error) {
+		return fakeController{}, nil
+	}
+	suite.PatchValue(&GetMAAS2Controller, mockGetController)
+	env := makeEnviron(c)
+	_, err := env.SupportedArchitectures()
+	c.Assert(err, gc.ErrorMatches, "Something terrible!")
 }

--- a/provider/maas/maas_test.go
+++ b/provider/maas/maas_test.go
@@ -79,18 +79,6 @@ func (s *baseProviderSuite) TearDownSuite(c *gc.C) {
 	s.FakeJujuXDGDataHomeSuite.TearDownSuite(c)
 }
 
-type controllerSuite struct {
-	baseProviderSuite
-}
-
-func (s *controllerSuite) SetUpTest(c *gc.C) {
-	s.baseProviderSuite.SetUpTest(c)
-}
-
-func (s *controllerSuite) TearDownTest(c *gc.C) {
-	s.baseProviderSuite.TearDownTest(c)
-}
-
 type providerSuite struct {
 	baseProviderSuite
 	testMAASObject *gomaasapi.TestMAASObject
@@ -109,8 +97,7 @@ const exampleAgentName = "dfb69555-0bc4-4d1f-85f2-4ee390974984"
 
 func (s *providerSuite) SetUpSuite(c *gc.C) {
 	s.baseProviderSuite.SetUpSuite(c)
-	TestMAASObject := gomaasapi.NewTestMAAS("1.0")
-	s.testMAASObject = TestMAASObject
+	s.testMAASObject = gomaasapi.NewTestMAAS("1.0")
 }
 
 func (s *providerSuite) SetUpTest(c *gc.C) {

--- a/provider/maas/maas_test.go
+++ b/provider/maas/maas_test.go
@@ -81,19 +81,14 @@ func (s *baseProviderSuite) TearDownSuite(c *gc.C) {
 
 type controllerSuite struct {
 	baseProviderSuite
-	testServer *gomaasapi.SimpleTestServer
 }
 
 func (s *controllerSuite) SetUpTest(c *gc.C) {
 	s.baseProviderSuite.SetUpTest(c)
-	s.testServer = gomaasapi.NewSimpleServer()
-	s.testServer.AddResponse("/api/2.0/version/", http.StatusOK, maas2VersionResponse)
-	s.testServer.Start()
 }
 
 func (s *controllerSuite) TearDownTest(c *gc.C) {
 	s.baseProviderSuite.TearDownTest(c)
-	s.testServer.Close()
 }
 
 type providerSuite struct {

--- a/provider/maas/maas_test.go
+++ b/provider/maas/maas_test.go
@@ -31,7 +31,7 @@ import (
 	jujuversion "github.com/juju/juju/version"
 )
 
-var maas2VersionResponse = `{"version": "unknown", "subversion": "", "capabilities": ["networks-management", "static-ipaddresses", "ipv6-deployment-ubuntu", "devices-management", "storage-deployment-ubuntu", "network-deployment-ubuntu"]}`
+const maas2VersionResponse = `{"version": "unknown", "subversion": "", "capabilities": ["networks-management", "static-ipaddresses", "ipv6-deployment-ubuntu", "devices-management", "storage-deployment-ubuntu", "network-deployment-ubuntu"]}`
 
 type baseProviderSuite struct {
 	coretesting.FakeJujuXDGDataHomeSuite


### PR DESCRIPTION
Change fetching boot images to use the new boot-resources endpoint for MAAS 2, with associated refactoring and test support.

(Review request: http://reviews.vapour.ws/r/4401/)