### PR TITLE
Certificates need unique metadata on each creation

### DIFF
--- a/api/certpool_test.go
+++ b/api/certpool_test.go
@@ -127,7 +127,7 @@ func (s *certPoolSuite) TestCreateCertPoolLogsBadCerts(c *gc.C) {
 
 func (s *certPoolSuite) addCert(c *gc.C, filename string) {
 	expiry := time.Now().UTC().AddDate(10, 0, 0)
-	pem, _, err := cert.NewCA("random env name", expiry)
+	pem, _, err := cert.NewCA("random env name", "1", expiry)
 	c.Assert(err, jc.ErrorIsNil)
 	err = ioutil.WriteFile(filename, []byte(pem), 0644)
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/metricsender/sender_test.go
+++ b/apiserver/metricsender/sender_test.go
@@ -32,7 +32,7 @@ type SenderSuite struct {
 var _ = gc.Suite(&SenderSuite{})
 
 func createCerts(c *gc.C, serverName string) (*x509.CertPool, tls.Certificate) {
-	certCaPem, keyCaPem, err := cert.NewCA("sender-test", time.Now().Add(time.Minute))
+	certCaPem, keyCaPem, err := cert.NewCA("sender-test", "1", time.Now().Add(time.Minute))
 	c.Assert(err, jc.ErrorIsNil)
 	certPem, keyPem, err := cert.NewServer(certCaPem, keyCaPem, time.Now().Add(time.Minute), []string{serverName})
 	c.Assert(err, jc.ErrorIsNil)

--- a/cert/cert.go
+++ b/cert/cert.go
@@ -88,8 +88,16 @@ func NewCA(envName, UUID string, expiry time.Time) (certPEM, keyPEM string, err 
 		return "", "", err
 	}
 	now := time.Now()
+
+	// A serial number can be up to 20 octets in size.
+	// https://tools.ietf.org/html/rfc5280#section-4.1.2.2
+	serialNumber, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 8*20))
+	if err != nil {
+		return "", "", fmt.Errorf("failed to generate serial number: %s", err)
+	}
+
 	template := &x509.Certificate{
-		SerialNumber: new(big.Int),
+		SerialNumber: serialNumber,
 		Subject: pkix.Name{
 			CommonName:   fmt.Sprintf("juju-generated CA for model %q", envName),
 			Organization: []string{"juju"},

--- a/cert/cert.go
+++ b/cert/cert.go
@@ -82,7 +82,7 @@ func Verify(srvCertPEM, caCertPEM string, when time.Time) error {
 
 // NewCA generates a CA certificate/key pair suitable for signing server
 // keys for an environment with the given name.
-func NewCA(envName string, expiry time.Time) (certPEM, keyPEM string, err error) {
+func NewCA(envName, UUID string, expiry time.Time) (certPEM, keyPEM string, err error) {
 	key, err := rsa.GenerateKey(rand.Reader, KeyBits)
 	if err != nil {
 		return "", "", err
@@ -93,6 +93,7 @@ func NewCA(envName string, expiry time.Time) (certPEM, keyPEM string, err error)
 		Subject: pkix.Name{
 			CommonName:   fmt.Sprintf("juju-generated CA for model %q", envName),
 			Organization: []string{"juju"},
+			SerialNumber: UUID,
 		},
 		NotBefore:             now.UTC().AddDate(0, 0, -7),
 		NotAfter:              expiry.UTC(),

--- a/cert/cert_test.go
+++ b/cert/cert_test.go
@@ -68,7 +68,7 @@ func (certSuite) TestParseCertAndKey(c *gc.C) {
 func (certSuite) TestNewCA(c *gc.C) {
 	now := time.Now()
 	expiry := roundTime(now.AddDate(0, 0, 1))
-	caCertPEM, caKeyPEM, err := cert.NewCA("foo", expiry)
+	caCertPEM, caKeyPEM, err := cert.NewCA("foo", "1", expiry)
 	c.Assert(err, jc.ErrorIsNil)
 
 	caCert, caKey, err := cert.ParseCertAndKey(caCertPEM, caKeyPEM)
@@ -86,7 +86,7 @@ func (certSuite) TestNewCA(c *gc.C) {
 func (certSuite) TestNewServer(c *gc.C) {
 	now := time.Now()
 	expiry := roundTime(now.AddDate(1, 0, 0))
-	caCertPEM, caKeyPEM, err := cert.NewCA("foo", expiry)
+	caCertPEM, caKeyPEM, err := cert.NewCA("foo", "1", expiry)
 	c.Assert(err, jc.ErrorIsNil)
 
 	caCert, _, err := cert.ParseCertAndKey(caCertPEM, caKeyPEM)
@@ -100,7 +100,7 @@ func (certSuite) TestNewServer(c *gc.C) {
 func (certSuite) TestNewDefaultServer(c *gc.C) {
 	now := time.Now()
 	expiry := roundTime(now.AddDate(1, 0, 0))
-	caCertPEM, caKeyPEM, err := cert.NewCA("foo", expiry)
+	caCertPEM, caKeyPEM, err := cert.NewCA("foo", "1", expiry)
 	c.Assert(err, jc.ErrorIsNil)
 
 	caCert, _, err := cert.ParseCertAndKey(caCertPEM, caKeyPEM)
@@ -163,7 +163,7 @@ func (certSuite) TestNewServerHostnames(c *gc.C) {
 func (certSuite) TestWithNonUTCExpiry(c *gc.C) {
 	expiry, err := time.Parse("2006-01-02 15:04:05.999999999 -0700 MST", "2012-11-28 15:53:57 +0100 CET")
 	c.Assert(err, jc.ErrorIsNil)
-	certPEM, keyPEM, err := cert.NewCA("foo", expiry)
+	certPEM, keyPEM, err := cert.NewCA("foo", "1", expiry)
 	xcert, err := cert.ParseCert(certPEM)
 	c.Assert(err, jc.ErrorIsNil)
 	checkNotAfter(c, xcert, expiry)
@@ -185,7 +185,7 @@ func (certSuite) TestNewServerWithInvalidCert(c *gc.C) {
 
 func (certSuite) TestVerify(c *gc.C) {
 	now := time.Now()
-	caCert, caKey, err := cert.NewCA("foo", now.Add(1*time.Minute))
+	caCert, caKey, err := cert.NewCA("foo", "1", now.Add(1*time.Minute))
 	c.Assert(err, jc.ErrorIsNil)
 
 	var noHostnames []string
@@ -204,7 +204,7 @@ func (certSuite) TestVerify(c *gc.C) {
 	err = cert.Verify(srvCert, caCert, now.Add(2*time.Minute))
 	c.Check(err, gc.ErrorMatches, "x509: certificate has expired or is not yet valid")
 
-	caCert2, caKey2, err := cert.NewCA("bar", now.Add(1*time.Minute))
+	caCert2, caKey2, err := cert.NewCA("bar", "1", now.Add(1*time.Minute))
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Check original server certificate against wrong CA.

--- a/environs/open.go
+++ b/environs/open.go
@@ -238,7 +238,7 @@ func ensureCertificate(cfg *config.Config) (*config.Config, string, error) {
 		return nil, "", errors.Errorf("controller configuration with a certificate but no CA private key")
 	}
 
-	caCert, caKey, err := cert.NewCA(cfg.Name(), time.Now().UTC().AddDate(10, 0, 0))
+	caCert, caKey, err := cert.NewCA(cfg.Name(), cfg.UUID(), time.Now().UTC().AddDate(10, 0, 0))
 	if err != nil {
 		return nil, "", errors.Trace(err)
 	}

--- a/testing/cert.go
+++ b/testing/cert.go
@@ -53,7 +53,7 @@ func verifyCertificates() error {
 
 func mustNewCA() (string, string) {
 	cert.KeyBits = 512
-	caCert, caKey, err := cert.NewCA("juju testing", time.Now().AddDate(10, 0, 0))
+	caCert, caKey, err := cert.NewCA("juju testing", "1234-ABCD-IS-NOT-A-REAL-UUID", time.Now().AddDate(10, 0, 0))
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Certificates weren't unique enough on each creation. This resulted in browsers attaching to the embedded GUI to complain about old/invalid certificates. We now store the model UUID in the x.509 Subject.SerialNumber field to fix this.

Live tested in Chrome and Firefox.

(Review request: http://reviews.vapour.ws/r/4404/)