### PR TITLE
Fixes lp:1560201: Correctly handle an empty model in Multiwatcher.

### DIFF
--- a/apiserver/client/client_test.go
+++ b/apiserver/client/client_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/api"
+	"github.com/juju/juju/apiserver"
 	"github.com/juju/juju/apiserver/client"
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
@@ -46,7 +47,9 @@ type Killer interface {
 
 type serverSuite struct {
 	baseSuite
-	client *client.Client
+	resources *common.Resources
+	auth      common.Authorizer
+	client    *client.Client
 }
 
 var _ = gc.Suite(&serverSuite{})
@@ -54,12 +57,13 @@ var _ = gc.Suite(&serverSuite{})
 func (s *serverSuite) SetUpTest(c *gc.C) {
 	s.baseSuite.SetUpTest(c)
 
-	var err error
-	auth := testing.FakeAuthorizer{
+	s.resources = common.NewResources()
+	s.auth = testing.FakeAuthorizer{
 		Tag:            s.AdminUserTag(c),
 		EnvironManager: true,
 	}
-	s.client, err = client.NewClient(s.State, common.NewResources(), auth)
+	var err error
+	s.client, err = client.NewClient(s.State, s.resources, s.auth)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -72,6 +76,36 @@ func (s *serverSuite) setAgentPresence(c *gc.C, machineId string) *presence.Ping
 	err = m.WaitAgentPresence(coretesting.LongWait)
 	c.Assert(err, jc.ErrorIsNil)
 	return pinger
+}
+
+func (s *serverSuite) TestWatchAllNewModel(c *gc.C) {
+	idRes, err := s.client.WatchAll()
+	c.Assert(err, jc.ErrorIsNil)
+
+	// At this point the watcher has been registered in state and the
+	// initial "change" should be waiting. The first call to Next() will
+	// get that one, which should come back empty since the model is
+	// empty. Subsequent changes will be provided through subsequent
+	// calls to Next(). We use these conditions to verify that the
+	// initial "change" was empty.
+	m, err := s.State.AddMachine("quantal", state.JobManageModel)
+	c.Assert(err, jc.ErrorIsNil)
+	err = m.SetProvisioned("i-0", agent.BootstrapNonce, nil)
+	c.Assert(err, jc.ErrorIsNil)
+
+	raw, err := apiserver.NewAllWatcher(s.State, s.resources, s.auth, idRes.AllWatcherId)
+	c.Assert(err, jc.ErrorIsNil)
+	watcher := raw.(*apiserver.SrvAllWatcher)
+	defer func() {
+		err := watcher.Stop()
+		c.Assert(err, jc.ErrorIsNil)
+	}()
+	deltasRes, err := watcher.Next()
+	c.Assert(err, jc.ErrorIsNil)
+
+	// This verifies that the initial "change" does not include the
+	// machine we added.
+	c.Check(deltasRes.Deltas, gc.HasLen, 0)
 }
 
 func (s *serverSuite) TestModelUsersInfo(c *gc.C) {
@@ -614,7 +648,7 @@ func (s *clientRepoSuite) TearDownTest(c *gc.C) {
 	s.baseSuite.TearDownTest(c)
 }
 
-func (s *clientSuite) TestClientWatchAll(c *gc.C) {
+func (s *clientSuite) TestClientWatchAllNotEmpty(c *gc.C) {
 	// A very simple end-to-end test, because
 	// all the logic is tested elsewhere.
 	m, err := s.State.AddMachine("quantal", state.JobManageModel)

--- a/apiserver/watcher.go
+++ b/apiserver/watcher.go
@@ -57,7 +57,7 @@ func init() {
 	)
 }
 
-// NewAllModelWatcher returns a new API server endpoint for interacting
+// NewAllWatcher returns a new API server endpoint for interacting
 // with a watcher created by the WatchAll and WatchAllModels API calls.
 func NewAllWatcher(st *state.State, resources *common.Resources, auth common.Authorizer, id string) (interface{}, error) {
 	if !auth.AuthClient() {

--- a/state/allwatcher_internal_test.go
+++ b/state/allwatcher_internal_test.go
@@ -1059,6 +1059,9 @@ func (s *allWatcherStateSuite) TestStateWatcherTwoModels(c *gc.C) {
 			w2 := newTestAllWatcher(otherState, c)
 			defer w2.Stop()
 
+			// The first set of deltas is empty, reflecting an empty model.
+			w1.AssertNoChange()
+			w2.AssertNoChange()
 			checkIsolationForEnv(s.state, w1, w2)
 			checkIsolationForEnv(otherState, w2, w1)
 		}()
@@ -3011,11 +3014,11 @@ func (tw *testWatcher) NumDeltas() int {
 		// TODO(mjs) - this is somewhat fragile. There are no
 		// guarentees that the watcher will be able to return deltas
 		// in ShortWait time.
-		deltas := len(tw.Next(testing.ShortWait))
-		if deltas == 0 {
+		deltas := tw.Next(testing.ShortWait)
+		if len(deltas) == 0 {
 			break
 		}
-		count += deltas
+		count += len(deltas)
 	}
 	return count
 }

--- a/state/multiwatcher.go
+++ b/state/multiwatcher.go
@@ -86,6 +86,10 @@ func (w *Multiwatcher) Next() ([]multiwatcher.Delta, error) {
 		return nil, err
 	}
 
+	// TODO(ericsnow) Clean up Multiwatcher/storeManager interaction.
+	// Relying on req.reply and req.noChanges here is not an ideal
+	// solution. It reflects the level of coupling we have between
+	// the Multiwatcher, request, and storeManager types.
 	select {
 	case ok := <-req.reply:
 		if !ok {

--- a/state/multiwatcher.go
+++ b/state/multiwatcher.go
@@ -93,6 +93,12 @@ func (w *Multiwatcher) Next() ([]multiwatcher.Delta, error) {
 		}
 	case <-req.noChanges:
 		return []multiwatcher.Delta{}, nil
+	case <-w.all.tomb.Dying():
+		err := w.all.tomb.Err()
+		if err == nil {
+			err = errors.Errorf("shared state watcher was stopped")
+		}
+		return nil, err
 	}
 	return req.changes, nil
 }

--- a/state/multiwatcher.go
+++ b/state/multiwatcher.go
@@ -31,9 +31,18 @@ type Multiwatcher struct {
 // NewMultiwatcher creates a new watcher that can observe
 // changes to an underlying store manager.
 func NewMultiwatcher(all *storeManager) *Multiwatcher {
+	// Note that we want to be clear about the defaults. So we set zero
+	// values explicitly.
+	//  used:    false means that the watcher has not been used yet
+	//  revno:   0 means that *all* transactions prior to the first
+	//           Next() call will be reflected in the deltas.
+	//  stopped: false means that the watcher immediately starts off
+	//           handling changes.
 	return &Multiwatcher{
-		all:  all,
-		used: false,
+		all:     all,
+		used:    false,
+		revno:   0,
+		stopped: false,
 	}
 }
 

--- a/state/multiwatcher.go
+++ b/state/multiwatcher.go
@@ -47,6 +47,10 @@ var ErrStopped = stderrors.New("watcher was stopped")
 
 // Next retrieves all changes that have happened since the last
 // time it was called, blocking until there are some changes available.
+//
+// The initial call to Next() will always return without waiting for new
+// changes in the model. That first call returns the deltas that
+// represent the model's current state, even when the model is empty.
 func (w *Multiwatcher) Next() ([]multiwatcher.Delta, error) {
 	req := &request{
 		w:     w,

--- a/state/multiwatcher.go
+++ b/state/multiwatcher.go
@@ -78,7 +78,7 @@ func (w *Multiwatcher) Next() ([]multiwatcher.Delta, error) {
 
 	select {
 	case w.all.request <- req:
-	case <-w.all.tomb.Dead():
+	case <-w.all.tomb.Dying():
 		err := w.all.tomb.Err()
 		if err == nil {
 			err = errors.Errorf("shared state watcher was stopped")

--- a/state/multiwatcher.go
+++ b/state/multiwatcher.go
@@ -19,7 +19,7 @@ import (
 type Multiwatcher struct {
 	all *storeManager
 
-	// used indicates that the watcher was used (e.g. Next() called).
+	// used indicates that the watcher was used (i.e. Next() called).
 	used bool
 
 	// The following fields are maintained by the storeManager
@@ -65,7 +65,8 @@ var ErrStopped = stderrors.New("watcher was stopped")
 // subsequent calls. The latter will reflect changes that have happened
 // since the last Next() call. In contrast, the initial Next() call will
 // return the deltas that represent the model's complete state at that
-// moment, even when the model is empty.
+// moment, even when the model is empty. In that empty model case an
+// empty set of deltas is returned.
 func (w *Multiwatcher) Next() ([]multiwatcher.Delta, error) {
 	req := &request{
 		w:     w,

--- a/state/multiwatcher.go
+++ b/state/multiwatcher.go
@@ -61,9 +61,11 @@ var ErrStopped = stderrors.New("watcher was stopped")
 // Next retrieves all changes that have happened since the last
 // time it was called, blocking until there are some changes available.
 //
-// The initial call to Next() will always return without waiting for new
-// changes in the model. That first call returns the deltas that
-// represent the model's current state, even when the model is empty.
+// The result from the initial call to Next() is different from
+// subsequent calls. The latter will reflect changes that have happened
+// since the last Next() call. In contrast, the initial Next() call will
+// return the deltas that represent the model's complete state at that
+// moment, even when the model is empty.
 func (w *Multiwatcher) Next() ([]multiwatcher.Delta, error) {
 	req := &request{
 		w:     w,

--- a/state/multiwatcher.go
+++ b/state/multiwatcher.go
@@ -81,6 +81,7 @@ func (w *Multiwatcher) Next() ([]multiwatcher.Delta, error) {
 			return nil, errors.Trace(ErrStopped)
 		}
 	case <-req.noChanges:
+		return []multiwatcher.Delta{}, nil
 	}
 	return req.changes, nil
 }

--- a/state/multiwatcher_internal_test.go
+++ b/state/multiwatcher_internal_test.go
@@ -647,6 +647,16 @@ func (*storeManagerSuite) TestRun(c *gc.C) {
 	}, "")
 }
 
+func (*storeManagerSuite) TestEmptyModel(c *gc.C) {
+	b := newTestBacking(nil)
+	sm := newStoreManager(b)
+	defer func() {
+		c.Check(sm.Stop(), gc.IsNil)
+	}()
+	w := &Multiwatcher{all: sm}
+	checkNext(c, w, nil, "")
+}
+
 func (*storeManagerSuite) TestMultipleEnvironments(c *gc.C) {
 	b := newTestBacking([]multiwatcher.EntityInfo{
 		&multiwatcher.MachineInfo{ModelUUID: "uuid0", Id: "0"},

--- a/state/multiwatcher_internal_test.go
+++ b/state/multiwatcher_internal_test.go
@@ -725,7 +725,7 @@ func (*storeManagerSuite) TestMultiwatcherStopBecauseStoreManagerError(c *gc.C) 
 	b.setFetchError(errors.New("some error"))
 	c.Logf("updating entity")
 	b.updateEntity(&multiwatcher.MachineInfo{Id: "1"})
-	checkNext(c, w, nil, "some error")
+	checkNext(c, w, nil, `shared state watcher was stopped`)
 }
 
 func StoreIncRef(a *multiwatcherStore, id interface{}) {

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -188,6 +188,16 @@ func (s *StateSuite) TestWatch(c *gc.C) {
 	w := s.State.Watch()
 	defer w.Stop()
 	deltasC := makeMultiwatcherOutput(w)
+	s.State.StartSync()
+
+	select {
+	case deltas := <-deltasC:
+		// The Watch() call results in an empty "change" reflecting
+		// the initially empty model.
+		c.Assert(deltas, gc.HasLen, 0)
+	case <-time.After(testing.LongWait):
+		c.Fatal("timed out")
+	}
 
 	m := s.Factory.MakeMachine(c, nil) // Generate event
 	s.State.StartSync()


### PR DESCRIPTION
(see https://bugs.launchpad.net/juju-core/+bug/1560201)

The initial "change" for an empty model should be an empty slice of deltas.  Instead we were skipping the initial state, which breaks an invariant of the watcher API and a number of watchers.  This patch fixes that by special-casing the first change given to Multiwatcher.

(Review request: http://reviews.vapour.ws/r/4406/)