### PR TITLE
lp1538303: Retry with EOF error from API Open

### DIFF
--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -602,7 +602,10 @@ func (c *bootstrapCommand) tryAPI() error {
 	client, err := blockAPI(&c.ModelCommandBase)
 	if err == nil {
 		_, err = client.List()
-		client.Close()
+		closeErr := client.Close()
+		if closeErr != nil {
+			logger.Debugf("Error closing client: %v", closeErr)
+		}
 	}
 	return err
 }


### PR DESCRIPTION
During bootstrap, we may get EOF or upgrade in
progress errors while juju is still coming up.
We would retry when we got those errors from
the blocks.List call, but it is also possible
to get an EOF error from the Login (apiOpen).

Those should be retried as well.

This is a forward port of:
https://github.com/juju/juju/pull/4247

(Review request: http://reviews.vapour.ws/r/4407/)