### PR TITLE
Update help text for cloud related commands

### DIFF
--- a/cmd/juju/cloud/list.go
+++ b/cmd/juju/cloud/list.go
@@ -26,13 +26,24 @@ type listCloudsCommand struct {
 	out cmd.Output
 }
 
-var listCloudsDoc = `
-The list-clouds command lists the clouds on which Juju workloads can be deployed.
-The available clouds will be the publicly available clouds like AWS, Google, Azure,
-as well as any custom clouds make available by the add-cloud command.
+// listCloudsDoc is multi-line since we need to use ` to denote
+// commands for ease in markdown.
+var listCloudsDoc = "" +
+	"Provided information includes 'cloud' (as understood by Juju), cloud\n" +
+	"'type', and cloud 'regions'.\n" +
+	"The listing will consist of public clouds and any custom clouds made\n" +
+	"available through the `juju add-cloud` command. The former can be updated\n" +
+	"via the `juju update-cloud` command.\n" +
+	"By default, the tabular format is used.\n" + listCloudsDocExamples
 
-Example:
-   juju list-clouds
+var listCloudsDocExamples = `
+Examples:
+
+    juju list-clouds
+
+See also: show-cloud
+          update-clouds
+          add-cloud
 `
 
 // NewListCloudsCommand returns a command to list cloud information.
@@ -43,7 +54,7 @@ func NewListCloudsCommand() cmd.Command {
 func (c *listCloudsCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "list-clouds",
-		Purpose: "list clouds available to run Juju workloads",
+		Purpose: "Lists all clouds available to Juju.",
 		Doc:     listCloudsDoc,
 	}
 }

--- a/cmd/juju/cloud/show.go
+++ b/cmd/juju/cloud/show.go
@@ -20,10 +20,16 @@ type showCloudCommand struct {
 }
 
 var showCloudDoc = `
-The show-cloud command displays information about a specified cloud.
+Provided information includes 'defined' (public, built-in), 'type',
+'auth-type', 'regions', and 'endpoints'.
 
-Example:
-   juju show-cloud aws
+Examples:
+
+    juju show-cloud google
+    juju show-cloud azure-china --output ~/azure_cloud_details.txt
+
+See also: list-clouds
+          update-clouds
 `
 
 // NewShowCloudCommand returns a command to list cloud information.
@@ -51,8 +57,8 @@ func (c *showCloudCommand) Init(args []string) error {
 func (c *showCloudCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "show-cloud",
-		Args:    "<cloudname>",
-		Purpose: "show the details a specified cloud",
+		Args:    "<cloud name>",
+		Purpose: "Shows detailed information on a cloud.",
 		Doc:     showCloudDoc,
 	}
 }

--- a/cmd/juju/cloud/updateclouds.go
+++ b/cmd/juju/cloud/updateclouds.go
@@ -28,12 +28,15 @@ type updateCloudsCommand struct {
 }
 
 var updateCloudsDoc = `
-The update-clouds command updates the public cloud information available to Juju.
-If any new regions or updated endpoints are available, this command will ensure Juju
-knows about that information when bootstrapping a new controller.
+If any new information for public clouds (such as regions and connection
+endpoints) are available this command will update Juju accordingly. It is
+suggested to run this command periodically.
 
-Example:
-   juju update-clouds
+Examples:
+
+    juju update-clouds
+
+See also: list-clouds
 `
 
 // NewUpdateCloudsCommand returns a command to update cloud information.
@@ -47,7 +50,7 @@ func NewUpdateCloudsCommand() cmd.Command {
 func (c *updateCloudsCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "update-clouds",
-		Purpose: "update public cloud regions and endpoints",
+		Purpose: "Updates public cloud information available to Juju.",
 		Doc:     updateCloudsDoc,
 	}
 }


### PR DESCRIPTION
This patch updates the help text based on suggested
text from the docs team:

lp1560667 - list-clouds
lp1563958 - update-clouds
lp1560595 - show-cloud

This PR depends on PR #4953 landing first, or else
a command test will fail.

(Review request: http://reviews.vapour.ws/r/4408/)