### PR TITLE
Update help text for ssh related commands

### DIFF
--- a/cmd/juju/commands/add_sshkeys.go
+++ b/cmd/juju/commands/add_sshkeys.go
@@ -19,7 +19,32 @@ func NewAddKeysCommand() cmd.Command {
 }
 
 var addKeysDoc = `
-Add new authorized ssh keys to allow the holder of those keys to log on to Juju nodes or machines.
+Juju maintains a per-model cache of public SSH keys which it copies to
+each unit (including units already deployed). By default this includes the
+key of the user who created the model (assuming it is stored in the
+default location ~/.ssh/). Additional keys may be added with this command,
+quoting the entire public key as an argument.
+
+Examples:
+
+    juju add-ssh-key "ssh-rsa qYfS5LieM79HIOr535ret6xy
+    AAAAB3NzaC1yc2EAAAADAQA6fgBAAABAQCygc6Rc9XgHdhQqTJ
+    Wsoj+I3xGrOtk21xYtKijnhkGqItAHmrE5+VH6PY1rVIUXhpTg
+    pSkJsHLmhE29OhIpt6yr8vQSOChqYfS5LieM79HIOJEgJEzIqC
+    52rCYXLvr/BVkd6yr4IoM1vpb/n6u9o8v1a0VUGfc/J6tQAcPR
+    ExzjZUVsfjj8HdLtcFq4JLYC41miiJtHw4b3qYu7qm3vh4eCiK
+    1LqLncXnBCJfjj0pADXaL5OQ9dmD3aCbi8KFyOEs3UumPosgmh
+    VCAfjjHObWHwNQ/ZU2KrX1/lv/+lBChx2tJliqQpyYMiA3nrtS
+    jfqQgZfjVF5vz8LESQbGc6+vLcXZ9KQpuYDt joe@ubuntu"
+
+For ease of use, on Ubuntu/CentOS/MacOSX it is possible to use shell
+substitution to pass the key to the command:
+
+    juju add-ssh-key $(cat ~/mykey.pub)
+
+See also: list-ssh-key
+          remove-ssh-key
+          import-ssh-key
 `
 
 // addKeysCommand is used to add a new authorized ssh key for a user.
@@ -33,9 +58,9 @@ type addKeysCommand struct {
 func (c *addKeysCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "add-ssh-key",
-		Args:    "<ssh key> ...",
+		Args:    "<ssh-key> ...",
 		Doc:     addKeysDoc,
-		Purpose: "add new authorized ssh key to a Juju model",
+		Purpose: "Adds a public SSH key (or keys) to a model.",
 		Aliases: []string{"add-ssh-keys"},
 	}
 }

--- a/cmd/juju/commands/add_sshkeys.go
+++ b/cmd/juju/commands/add_sshkeys.go
@@ -37,10 +37,10 @@ Examples:
     VCAfjjHObWHwNQ/ZU2KrX1/lv/+lBChx2tJliqQpyYMiA3nrtS
     jfqQgZfjVF5vz8LESQbGc6+vLcXZ9KQpuYDt joe@ubuntu"
 
-For ease of use, on Ubuntu/CentOS/MacOSX it is possible to use shell
-substitution to pass the key to the command:
+For ease of use, on it is possible to use shell substitution to pass
+the key to the command:
 
-    juju add-ssh-key $(cat ~/mykey.pub)
+    juju add-ssh-key $(cat mykey.pub)
 
 See also: list-ssh-key
           remove-ssh-key

--- a/cmd/juju/commands/import_sshkeys.go
+++ b/cmd/juju/commands/import_sshkeys.go
@@ -18,9 +18,35 @@ func NewImportKeysCommand() cmd.Command {
 	return modelcmd.Wrap(&importKeysCommand{})
 }
 
-var importKeysDoc = `
-Import new authorised ssh keys to allow the holder of those keys to log on to Juju nodes or machines.
-The keys are imported using ssh-import-id.
+// importKeysDoc is multi-line since we need to use ` to denote
+// commands for ease in markdown.
+var importKeysDoc = "" +
+	"Juju can add SSH keys to its cache from reliable public sources (currently\n" +
+	"Launchpad and Github), allowing those users SSH access to Juju machines.\n" +
+	"The user identity supplied should be the username on the respective\n" +
+	"service, preferably prefixed by 'lp:' or 'gh:' to avoid confusion/\n" +
+	"conflicts.\n" +
+	"Note that if the user has multiple keys on the service, all the associated\n" +
+	"keys will be added.\n" +
+	"Once the keys are added, they can be viewed as normal with the\n" +
+	"`juju list-ssh-keys` command, where comments will indicate which ones were\n" +
+	"imported this way.\n" + importKeysDocExamples
+
+var importKeysDocExamples = `
+Examples:
+
+    juju import-ssh-key lazypower
+
+To specify the service, use a 'gh:' or 'lp:' prefix:
+
+    juju import-ssh-key gh:cherylj
+
+Multiple identities may be specified in a space delimited list:
+
+    juju import-ssh-key rheinlein lp:iasmiov gh:hharrison
+
+See also: add-ssh-key
+          list-ssh-keys
 `
 
 // importKeysCommand is used to import authorized ssh keys to a model.
@@ -34,9 +60,9 @@ type importKeysCommand struct {
 func (c *importKeysCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "import-ssh-key",
-		Args:    "<ssh key id> ...",
+		Args:    "<user identity> ...",
 		Doc:     importKeysDoc,
-		Purpose: "using ssh-import-id, import new authorized ssh keys to a Juju model",
+		Purpose: "Imports an SSH key from a trusted identity source (Launchpad, Github).",
 		Aliases: []string{"import-ssh-keys"},
 	}
 }

--- a/cmd/juju/commands/import_sshkeys.go
+++ b/cmd/juju/commands/import_sshkeys.go
@@ -60,7 +60,7 @@ type importKeysCommand struct {
 func (c *importKeysCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "import-ssh-key",
-		Args:    "<user identity> ...",
+		Args:    "<user-identity> ...",
 		Doc:     importKeysDoc,
 		Purpose: "Imports an SSH key from a trusted identity source (Launchpad, Github).",
 		Aliases: []string{"import-ssh-keys"},

--- a/cmd/juju/commands/list_sshkeys.go
+++ b/cmd/juju/commands/list_sshkeys.go
@@ -25,15 +25,12 @@ created unit.
 This command will display a list of all the keys currently used by Juju in
 the current model (or the model specified, if the '-m' option is used).
 By default a minimal list is returned, showing only the fingerprint of
-each key and its text identifier. By using the '-full' option, the entire
+each key and its text identifier. By using the '--full' option, the entire
 key may be displayed.
 
 Examples:
 
     juju list-ssh-keys
-
-To examine the full key, use the '--full' option:
-
     juju list-keys -m jujutest --full
 `
 

--- a/cmd/juju/commands/list_sshkeys.go
+++ b/cmd/juju/commands/list_sshkeys.go
@@ -20,9 +20,21 @@ func NewListKeysCommand() cmd.Command {
 }
 
 var listKeysDoc = `
-List the authorized ssh keys in the model, allowing the holders of those keys to log on to Juju nodes.
-By default, just the key fingerprint is printed. Use --full to display the entire key.
+Juju maintains a per-model cache of SSH keys which it copies to each newly
+created unit.
+This command will display a list of all the keys currently used by Juju in
+the current model (or the model specified, if the '-m' option is used).
+By default a minimal list is returned, showing only the fingerprint of
+each key and its text identifier. By using the '-full' option, the entire
+key may be displayed.
 
+Examples:
+
+    juju list-ssh-keys
+
+To examine the full key, use the '--full' option:
+
+    juju list-keys -m jujutest --full
 `
 
 // listKeysCommand is used to list the authorized ssh keys.
@@ -37,14 +49,14 @@ func (c *listKeysCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "list-ssh-keys",
 		Doc:     listKeysDoc,
-		Purpose: "list authorised ssh keys in a model",
+		Purpose: "Lists the currently known SSH keys for the current (or specified) model.",
 		Aliases: []string{"ssh-key", "ssh-keys", "list-ssh-key"},
 	}
 }
 
 // SetFlags implements Command.SetFlags.
 func (c *listKeysCommand) SetFlags(f *gnuflag.FlagSet) {
-	f.BoolVar(&c.showFullKey, "full", false, "show full key instead of just the key fingerprint")
+	f.BoolVar(&c.showFullKey, "full", false, "Show full key instead of just the fingerprint")
 }
 
 // Run implements Command.Run.

--- a/cmd/juju/commands/remove_sshkeys.go
+++ b/cmd/juju/commands/remove_sshkeys.go
@@ -19,9 +19,21 @@ func NewRemoveKeysCommand() cmd.Command {
 }
 
 var removeKeysDoc = `
-Remove existing authorized ssh keys to remove ssh access for the holder of those keys.
-The keys to delete are found by specifying either the "comment" portion of the ssh key,
-typically something like "user@host", or the key fingerprint.
+Juju maintains a per-model cache of public SSH keys which it copies to
+each unit. This command will remove a specified key (or space separated
+list of keys) from the model cache and all current units deployed in that
+model. The keys to be removed may be specified by the key's fingerprint,
+or by the text label associated with them.
+
+Examples:
+
+    juju remove-ssh-key ubuntu@ubuntu
+    juju remove-ssh-key 45:7f:33:2c:10:4e:6c:14:e3:a1:a4:c8:b2:e1:34:b4
+    juju remove-ssh-key bob@ubuntu carol@ubuntu
+
+See also: list-ssh-key
+          add-ssh-key
+          import-ssh-key
 `
 
 // removeKeysCommand is used to delete authorised ssh keys for a user.
@@ -35,9 +47,9 @@ type removeKeysCommand struct {
 func (c *removeKeysCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "remove-ssh-key",
-		Args:    "<ssh key id> ...",
+		Args:    "<ssh-key-id> ...",
 		Doc:     removeKeysDoc,
-		Purpose: "remove authorized ssh keys from a Juju model",
+		Purpose: "Removes a public SSH key (or keys) from a model.",
 		Aliases: []string{"remove-ssh-keys"},
 	}
 }

--- a/cmd/juju/commands/sshkeys_test.go
+++ b/cmd/juju/commands/sshkeys_test.go
@@ -40,15 +40,15 @@ func (s *SSHKeysSuite) TestHelpList(c *gc.C) {
 }
 
 func (s *SSHKeysSuite) TestHelpAdd(c *gc.C) {
-	s.assertHelpOutput(c, "add-ssh-key", "<ssh key> ...")
+	s.assertHelpOutput(c, "add-ssh-key", "<ssh-key> ...")
 }
 
 func (s *SSHKeysSuite) TestHelpRemove(c *gc.C) {
-	s.assertHelpOutput(c, "remove-ssh-key", "<ssh key id> ...")
+	s.assertHelpOutput(c, "remove-ssh-key", "<ssh-key-id> ...")
 }
 
 func (s *SSHKeysSuite) TestHelpImport(c *gc.C) {
-	s.assertHelpOutput(c, "import-ssh-key", "<ssh key id> ...")
+	s.assertHelpOutput(c, "import-ssh-key", "<user identity> ...")
 }
 
 type keySuiteBase struct {

--- a/cmd/juju/commands/sshkeys_test.go
+++ b/cmd/juju/commands/sshkeys_test.go
@@ -48,7 +48,7 @@ func (s *SSHKeysSuite) TestHelpRemove(c *gc.C) {
 }
 
 func (s *SSHKeysSuite) TestHelpImport(c *gc.C) {
-	s.assertHelpOutput(c, "import-ssh-key", "<user identity> ...")
+	s.assertHelpOutput(c, "import-ssh-key", "<user-identity> ...")
 }
 
 type keySuiteBase struct {


### PR DESCRIPTION
This patch updates the help text based on suggested
text from the docs team:

lp1554700 - import-ssh-key
lp1554705 - list-ssh-keys
lp1557380 - add-ssh-key
lp1558078 - remove-ssh-key

This PR depends on PR #4953 landing first, or else
a command test will fail.

(Review request: http://reviews.vapour.ws/r/4409/)