### PR TITLE
Send phase as a string instead of an int

### DIFF
--- a/apiserver/params/migration.go
+++ b/apiserver/params/migration.go
@@ -3,8 +3,6 @@
 
 package params
 
-import "github.com/juju/juju/core/migration"
-
 // InitiateModelMigrationArgs holds the details required to start one
 // or more model migrations.
 type InitiateModelMigrationArgs struct {
@@ -60,9 +58,8 @@ type ModelArgs struct {
 
 // MigrationStatus reports the current status of a model migration.
 type MigrationStatus struct {
-	Attempt int `json:"attempt"`
-	// TODO(fwereade): shouldn't Phase be a string?
-	Phase migration.Phase `json:"phase"`
+	Attempt int    `json:"attempt"`
+	Phase   string `json:"phase"`
 
 	// TODO(mjs): I'm not convinced these Source fields will get used.
 	SourceAPIAddrs []string `json:"source-api-addrs"`

--- a/apiserver/watcher.go
+++ b/apiserver/watcher.go
@@ -435,7 +435,7 @@ func (w *srvMigrationStatusWatcher) Next() (params.MigrationStatus, error) {
 	mig, err := w.st.GetModelMigration()
 	if errors.IsNotFound(err) {
 		return params.MigrationStatus{
-			Phase: migration.NONE,
+			Phase: migration.NONE.String(),
 		}, nil
 	} else if err != nil {
 		return empty, errors.Annotate(err, "migration lookup")
@@ -468,7 +468,7 @@ func (w *srvMigrationStatusWatcher) Next() (params.MigrationStatus, error) {
 
 	return params.MigrationStatus{
 		Attempt:        attempt,
-		Phase:          phase,
+		Phase:          phase.String(),
 		SourceAPIAddrs: sourceAddrs,
 		SourceCACert:   sourceCACert,
 		TargetAPIAddrs: target.Addrs,

--- a/apiserver/watcher_test.go
+++ b/apiserver/watcher_test.go
@@ -93,7 +93,7 @@ func (s *watcherSuite) TestMigrationStatusWatcher(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, params.MigrationStatus{
 		Attempt:        2,
-		Phase:          migration.READONLY,
+		Phase:          "READONLY",
 		SourceAPIAddrs: []string{"1.2.3.4:5", "2.3.4.5:6", "3.4.5.6:7"},
 		SourceCACert:   "no worries",
 		TargetAPIAddrs: []string{"1.2.3.4:5555"},
@@ -113,7 +113,7 @@ func (s *watcherSuite) TestMigrationStatusWatcherNoMigration(c *gc.C) {
 	result, err := facade.Next()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, params.MigrationStatus{
-		Phase: migration.NONE,
+		Phase: "NONE",
 	})
 }
 

--- a/watcher/migrationstatus.go
+++ b/watcher/migrationstatus.go
@@ -3,11 +3,22 @@
 
 package watcher
 
-import "github.com/juju/juju/apiserver/params"
+import "github.com/juju/juju/core/migration"
+
+// MigrationStatus is the client side version of
+// params.MigrationStatus.
+type MigrationStatus struct {
+	Attempt        int
+	Phase          migration.Phase
+	SourceAPIAddrs []string
+	SourceCACert   string
+	TargetAPIAddrs []string
+	TargetCACert   string
+}
 
 // MigrationStatusWatcher describes a watcher that reports the latest
 // status of a migration for a model.
 type MigrationStatusWatcher interface {
 	CoreWatcher
-	Changes() <-chan params.MigrationStatus
+	Changes() <-chan MigrationStatus
 }

--- a/worker/migrationminion/worker_test.go
+++ b/worker/migrationminion/worker_test.go
@@ -13,7 +13,6 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/agent"
-	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/migration"
 	"github.com/juju/juju/network"
 	coretesting "github.com/juju/juju/testing"
@@ -64,7 +63,7 @@ func (s *Suite) TestClosedWatcherChannel(c *gc.C) {
 
 func (s *Suite) TestSUCCESS(c *gc.C) {
 	addrs := []string{"1.1.1.1:1", "9.9.9.9:9"}
-	s.client.watcher.changes <- params.MigrationStatus{
+	s.client.watcher.changes <- watcher.MigrationStatus{
 		Phase:          migration.SUCCESS,
 		TargetAPIAddrs: addrs,
 		TargetCACert:   "top secret",
@@ -106,16 +105,16 @@ func (c *stubMinionClient) Watch() (watcher.MigrationStatusWatcher, error) {
 func newStubWatcher() *stubWatcher {
 	return &stubWatcher{
 		Worker:  workertest.NewErrorWorker(nil),
-		changes: make(chan params.MigrationStatus, 1),
+		changes: make(chan watcher.MigrationStatus, 1),
 	}
 }
 
 type stubWatcher struct {
 	worker.Worker
-	changes chan params.MigrationStatus
+	changes chan watcher.MigrationStatus
 }
 
-func (w *stubWatcher) Changes() <-chan params.MigrationStatus {
+func (w *stubWatcher) Changes() <-chan watcher.MigrationStatus {
 	return w.changes
 }
 


### PR DESCRIPTION
Due to an oversight, the migration status watcher API was sending the migration phase as an int instead of serializing to a string.

(Review request: http://reviews.vapour.ws/r/4415/)