### PR TITLE
Remove imported model when migration aborts

### DIFF
--- a/api/migrationtarget/client.go
+++ b/api/migrationtarget/client.go
@@ -17,9 +17,13 @@ type Client interface {
 	// Import takes a serialized model and imports it into the target
 	// controller.
 	Import([]byte) error
-	// XXX these should take UUIDs not tags
-	Abort(names.ModelTag) error
-	Activate(names.ModelTag) error
+
+	// Abort removes all data relating to a previously imported
+	// model.
+	Abort(string) error
+
+	// Activate marks a migrated model as being ready to use.
+	Activate(string) error
 }
 
 // NewClient returns a new Client based on an existing API connection.
@@ -39,13 +43,13 @@ func (c *client) Import(bytes []byte) error {
 }
 
 // Abort implements Client.
-func (c *client) Abort(tag names.ModelTag) error {
-	args := params.ModelArgs{ModelTag: tag.String()}
+func (c *client) Abort(modelUUID string) error {
+	args := params.ModelArgs{ModelTag: names.NewModelTag(modelUUID).String()}
 	return c.caller.FacadeCall("Abort", args, nil)
 }
 
 // Activate implements Client.
-func (c *client) Activate(tag names.ModelTag) error {
-	args := params.ModelArgs{ModelTag: tag.String()}
+func (c *client) Activate(modelUUID string) error {
+	args := params.ModelArgs{ModelTag: names.NewModelTag(modelUUID).String()}
 	return c.caller.FacadeCall("Activate", args, nil)
 }

--- a/api/migrationtarget/client.go
+++ b/api/migrationtarget/client.go
@@ -17,6 +17,7 @@ type Client interface {
 	// Import takes a serialized model and imports it into the target
 	// controller.
 	Import([]byte) error
+	// XXX these should take UUIDs not tags
 	Abort(names.ModelTag) error
 	Activate(names.ModelTag) error
 }

--- a/api/migrationtarget/client_test.go
+++ b/api/migrationtarget/client_test.go
@@ -45,17 +45,17 @@ func (s *ClientSuite) TestImport(c *gc.C) {
 func (s *ClientSuite) TestAbort(c *gc.C) {
 	client, stub := s.getClientAndStub(c)
 
-	tag := names.NewModelTag("fake-uuid")
-	err := client.Abort(tag)
-	s.AssertModelCall(c, stub, tag, "Abort", err)
+	uuid := "fake"
+	err := client.Abort(uuid)
+	s.AssertModelCall(c, stub, names.NewModelTag(uuid), "Abort", err)
 }
 
 func (s *ClientSuite) TestActivate(c *gc.C) {
 	client, stub := s.getClientAndStub(c)
 
-	tag := names.NewModelTag("fake-uuid")
-	err := client.Activate(tag)
-	s.AssertModelCall(c, stub, tag, "Activate", err)
+	uuid := "fake"
+	err := client.Activate(uuid)
+	s.AssertModelCall(c, stub, names.NewModelTag(uuid), "Activate", err)
 }
 
 func (s *ClientSuite) AssertModelCall(c *gc.C, stub *jujutesting.Stub, tag names.ModelTag, call string, err error) {

--- a/worker/migrationmaster/worker.go
+++ b/worker/migrationmaster/worker.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
-	"github.com/juju/names"
 	"launchpad.net/tomb"
 
 	"github.com/juju/juju/api"
@@ -213,7 +212,7 @@ func removeImportedModel(targetInfo migration.TargetInfo, modelUUID string) erro
 	defer conn.Close()
 
 	targetClient := migrationtarget.NewClient(conn)
-	err = targetClient.Abort(names.NewModelTag(modelUUID))
+	err = targetClient.Abort(modelUUID)
 	return errors.Trace(err)
 }
 

--- a/worker/migrationmaster/worker.go
+++ b/worker/migrationmaster/worker.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
+	"github.com/juju/names"
 	"launchpad.net/tomb"
 
 	"github.com/juju/juju/api"
@@ -89,7 +90,7 @@ func (w *migrationMaster) run() error {
 		case migration.REAPFAILED:
 			phase, err = w.doREAPFAILED()
 		case migration.ABORT:
-			phase, err = w.doABORT(status.TargetInfo)
+			phase, err = w.doABORT(status.TargetInfo, status.ModelUUID)
 		default:
 			return errors.Errorf("unknown phase: %v [%d]", phase.String(), phase)
 		}
@@ -195,34 +196,25 @@ func (w *migrationMaster) doREAPFAILED() (migration.Phase, error) {
 	return migration.NONE, nil
 }
 
-func (w *migrationMaster) doABORT(targetInfo migration.TargetInfo) (migration.Phase, error) {
-	if err := removeImportedModel(targetInfo); err != nil {
-		// This is fatal. Removing the imported model is a best
+func (w *migrationMaster) doABORT(targetInfo migration.TargetInfo, modelUUID string) (migration.Phase, error) {
+	if err := removeImportedModel(targetInfo, modelUUID); err != nil {
+		// This isn't fatal. Removing the imported model is a best
 		// efforts attempt.
 		logger.Errorf("failed to reverse model import: %v", err)
 	}
-
-	// TODO(mjs) - turn off the "migrating" status on the model
 	return migration.NONE, nil
 }
 
-func removeImportedModel(targetInfo migration.TargetInfo) error {
-	/* TODO(mjs) - Can't call Abort API without the model UUID!
-	   migrationmaster facade needs work.
+func removeImportedModel(targetInfo migration.TargetInfo, modelUUID string) error {
 	conn, err := openAPIConn(targetInfo)
 	if err != nil {
-		return
+		return errors.Trace(err)
 	}
 	defer conn.Close()
 
 	targetClient := migrationtarget.NewClient(conn)
-	err = targetClient.Abort(uuid)
-	if err != nil {
-		logger.Errorf("failed to reverse model import: %v", err)
-		return migration.ABORT, nil
-	}
-	*/
-	return nil
+	err = targetClient.Abort(names.NewModelTag(modelUUID))
+	return errors.Trace(err)
 }
 
 func (w *migrationMaster) waitForActiveMigration() error {

--- a/worker/migrationmaster/worker_test.go
+++ b/worker/migrationmaster/worker_test.go
@@ -135,6 +135,15 @@ func (s *Suite) TestExportFailure(c *gc.C) {
 		{"masterClient.SetPhase", []interface{}{migration.IMPORT}},
 		{"masterClient.Export", nil},
 		{"masterClient.SetPhase", []interface{}{migration.ABORT}},
+		{"apiOpen", []interface{}{&api.Info{
+			Addrs:    []string{"1.2.3.4:5"},
+			CACert:   "cert",
+			Tag:      names.NewUserTag("admin"),
+			Password: "secret",
+		}, api.DialOpts{}}},
+		{"APICall:MigrationTarget.Abort",
+			[]interface{}{params.ModelArgs{ModelTag: "model-model-uuid"}}},
+		{"Connection.Close", nil},
 	})
 }
 
@@ -160,6 +169,12 @@ func (s *Suite) TestAPIOpenFailure(c *gc.C) {
 			Password: "secret",
 		}, api.DialOpts{}}},
 		{"masterClient.SetPhase", []interface{}{migration.ABORT}},
+		{"apiOpen", []interface{}{&api.Info{
+			Addrs:    []string{"1.2.3.4:5"},
+			CACert:   "cert",
+			Tag:      names.NewUserTag("admin"),
+			Password: "secret",
+		}, api.DialOpts{}}},
 	})
 }
 
@@ -189,6 +204,15 @@ func (s *Suite) TestImportFailure(c *gc.C) {
 
 		{"Connection.Close", nil},
 		{"masterClient.SetPhase", []interface{}{migration.ABORT}},
+		{"apiOpen", []interface{}{&api.Info{
+			Addrs:    []string{"1.2.3.4:5"},
+			CACert:   "cert",
+			Tag:      names.NewUserTag("admin"),
+			Password: "secret",
+		}, api.DialOpts{}}},
+		{"APICall:MigrationTarget.Abort",
+			[]interface{}{params.ModelArgs{ModelTag: "model-model-uuid"}}},
+		{"Connection.Close", nil},
 	})
 }
 

--- a/worker/migrationmaster/worker_test.go
+++ b/worker/migrationmaster/worker_test.go
@@ -31,7 +31,36 @@ type Suite struct {
 
 var _ = gc.Suite(&Suite{})
 
-var fakeSerializedModel = []byte("model")
+var (
+	fakeSerializedModel = []byte("model")
+
+	// Define stub calls that commonly appear in tests here to allow reuse.
+	apiOpenCall = jujutesting.StubCall{
+		"apiOpen",
+		[]interface{}{
+			&api.Info{
+				Addrs:    []string{"1.2.3.4:5"},
+				CACert:   "cert",
+				Tag:      names.NewUserTag("admin"),
+				Password: "secret",
+			},
+			api.DialOpts{},
+		},
+	}
+	importCall = jujutesting.StubCall{
+		"APICall:MigrationTarget.Import",
+		[]interface{}{
+			params.SerializedModel{Bytes: fakeSerializedModel},
+		},
+	}
+	connCloseCall = jujutesting.StubCall{"Connection.Close", nil}
+	abortCall     = jujutesting.StubCall{
+		"APICall:MigrationTarget.Abort",
+		[]interface{}{
+			params.ModelArgs{ModelTag: names.NewModelTag("model-uuid").String()},
+		},
+	}
+)
 
 func (s *Suite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
@@ -72,16 +101,9 @@ func (s *Suite) TestSuccessfulMigration(c *gc.C) {
 		{"masterClient.SetPhase", []interface{}{migration.READONLY}},
 		{"masterClient.SetPhase", []interface{}{migration.IMPORT}},
 		{"masterClient.Export", nil},
-		{"apiOpen", []interface{}{&api.Info{
-			Addrs:    []string{"1.2.3.4:5"},
-			CACert:   "cert",
-			Tag:      names.NewUserTag("admin"),
-			Password: "secret",
-		}, api.DialOpts{}}},
-		{"APICall:MigrationTarget.Import",
-			[]interface{}{params.SerializedModel{Bytes: fakeSerializedModel}}},
-
-		{"Connection.Close", nil},
+		apiOpenCall,
+		importCall,
+		connCloseCall,
 		{"masterClient.SetPhase", []interface{}{migration.VALIDATION}},
 		{"masterClient.SetPhase", []interface{}{migration.SUCCESS}},
 		{"masterClient.SetPhase", []interface{}{migration.LOGTRANSFER}},
@@ -135,15 +157,9 @@ func (s *Suite) TestExportFailure(c *gc.C) {
 		{"masterClient.SetPhase", []interface{}{migration.IMPORT}},
 		{"masterClient.Export", nil},
 		{"masterClient.SetPhase", []interface{}{migration.ABORT}},
-		{"apiOpen", []interface{}{&api.Info{
-			Addrs:    []string{"1.2.3.4:5"},
-			CACert:   "cert",
-			Tag:      names.NewUserTag("admin"),
-			Password: "secret",
-		}, api.DialOpts{}}},
-		{"APICall:MigrationTarget.Abort",
-			[]interface{}{params.ModelArgs{ModelTag: "model-model-uuid"}}},
-		{"Connection.Close", nil},
+		apiOpenCall,
+		abortCall,
+		connCloseCall,
 	})
 }
 
@@ -162,19 +178,9 @@ func (s *Suite) TestAPIOpenFailure(c *gc.C) {
 		{"masterClient.SetPhase", []interface{}{migration.READONLY}},
 		{"masterClient.SetPhase", []interface{}{migration.IMPORT}},
 		{"masterClient.Export", nil},
-		{"apiOpen", []interface{}{&api.Info{
-			Addrs:    []string{"1.2.3.4:5"},
-			CACert:   "cert",
-			Tag:      names.NewUserTag("admin"),
-			Password: "secret",
-		}, api.DialOpts{}}},
+		apiOpenCall,
 		{"masterClient.SetPhase", []interface{}{migration.ABORT}},
-		{"apiOpen", []interface{}{&api.Info{
-			Addrs:    []string{"1.2.3.4:5"},
-			CACert:   "cert",
-			Tag:      names.NewUserTag("admin"),
-			Password: "secret",
-		}, api.DialOpts{}}},
+		apiOpenCall,
 	})
 }
 
@@ -193,26 +199,13 @@ func (s *Suite) TestImportFailure(c *gc.C) {
 		{"masterClient.SetPhase", []interface{}{migration.READONLY}},
 		{"masterClient.SetPhase", []interface{}{migration.IMPORT}},
 		{"masterClient.Export", nil},
-		{"apiOpen", []interface{}{&api.Info{
-			Addrs:    []string{"1.2.3.4:5"},
-			CACert:   "cert",
-			Tag:      names.NewUserTag("admin"),
-			Password: "secret",
-		}, api.DialOpts{}}},
-		{"APICall:MigrationTarget.Import",
-			[]interface{}{params.SerializedModel{Bytes: fakeSerializedModel}}},
-
-		{"Connection.Close", nil},
+		apiOpenCall,
+		importCall,
+		connCloseCall,
 		{"masterClient.SetPhase", []interface{}{migration.ABORT}},
-		{"apiOpen", []interface{}{&api.Info{
-			Addrs:    []string{"1.2.3.4:5"},
-			CACert:   "cert",
-			Tag:      names.NewUserTag("admin"),
-			Password: "secret",
-		}, api.DialOpts{}}},
-		{"APICall:MigrationTarget.Abort",
-			[]interface{}{params.ModelArgs{ModelTag: "model-model-uuid"}}},
-		{"Connection.Close", nil},
+		apiOpenCall,
+		abortCall,
+		connCloseCall,
 	})
 }
 


### PR DESCRIPTION
worker/migrationmaster: Remove imported model when migration aborts

...using the MigrationTarget.Abort API.

---

api/migrationtarget: take strings not tags

Client side APIs shouldn't generally be involve tags, and not using tags simplifies use in this case.

---

worker/migrationmaster: Define commonly used stub calls once

This makes the tests a bit more readable and maintainable.


(Review request: http://reviews.vapour.ws/r/4419/)