### PR TITLE
Update MAAS2 branch with latest gomaasapi changes

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -20,7 +20,7 @@ github.com/juju/go4	git	40d72ab9641a2a8c36a9c46a51e28367115c8e59	2016-02-22T16:3
 github.com/juju/gojsonpointer	git	afe8b77aa08f272b49e01b82de78510c11f61500	2015-02-04T19:46:29Z
 github.com/juju/gojsonreference	git	f0d24ac5ee330baa21721cdff56d45e4ee42628e	2015-02-04T19:46:33Z
 github.com/juju/gojsonschema	git	e1ad140384f254c82f89450d9a7c8dd38a632838	2015-03-12T17:00:16Z
-github.com/juju/gomaasapi	git	3888cd414c8d0ec07bc0867fd22ce130bd9bb7c7	2016-03-31T13:55:14Z
+github.com/juju/gomaasapi	git	e7bc20c748a7194f20cdf0b6578e4797b3765faf	2016-04-04T03:37:13Z
 github.com/juju/govmomi	git	4354a88d4b34abe467215f77c2fc1cb9f78b66f7	2015-04-24T01:54:48Z
 github.com/juju/httpprof	git	14bf14c307672fd2456bdbf35d19cf0ccd3cf565	2014-12-17T16:00:36Z
 github.com/juju/httprequest	git	89d547093c45e293599088cc63e805c6f1205dc0	2016-03-02T10:09:58Z

--- a/provider/maas/config_test.go
+++ b/provider/maas/config_test.go
@@ -4,8 +4,6 @@
 package maas
 
 import (
-	"net/http"
-
 	"github.com/juju/gomaasapi"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
@@ -56,7 +54,7 @@ func (s *configSuite) SetUpTest(c *gc.C) {
 	}
 	s.PatchValue(&GetCapabilities, mockCapabilities)
 	mockGetController := func(maasServer, apiKey string) (gomaasapi.Controller, error) {
-		return nil, gomaasapi.ServerError{StatusCode: http.StatusNotFound}
+		return nil, gomaasapi.NewUnsupportedVersionError("oops")
 	}
 	s.PatchValue(&GetMAAS2Controller, mockGetController)
 }

--- a/provider/maas/constraints_test.go
+++ b/provider/maas/constraints_test.go
@@ -169,7 +169,7 @@ func (suite *environSuite) TestSelectNodeInvalidZone(c *gc.C) {
 
 	_, err := env.selectNode(snArgs)
 	c.Assert(err, gc.NotNil)
-	c.Assert(err, gc.ErrorMatches, "cannot run instances: ServerError: 409 Conflict \\(\\)")
+	c.Assert(err, gc.ErrorMatches, `cannot run instances: ServerError: 409 Conflict \(\)`)
 }
 
 func (suite *environSuite) TestAcquireNode(c *gc.C) {

--- a/provider/maas/constraints_test.go
+++ b/provider/maas/constraints_test.go
@@ -4,7 +4,6 @@
 package maas
 
 import (
-	"fmt"
 	"net/url"
 
 	"github.com/juju/errors"
@@ -170,7 +169,7 @@ func (suite *environSuite) TestSelectNodeInvalidZone(c *gc.C) {
 
 	_, err := env.selectNode(snArgs)
 	c.Assert(err, gc.NotNil)
-	c.Assert(fmt.Sprintf("%s", err), gc.Equals, "cannot run instances: gomaasapi: got error back from server: 409 Conflict ()")
+	c.Assert(err, gc.ErrorMatches, "cannot run instances: ServerError: 409 Conflict \\(\\)")
 }
 
 func (suite *environSuite) TestAcquireNode(c *gc.C) {

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -539,7 +539,7 @@ func (e *maasEnviron) AvailabilityZones() ([]common.AvailabilityZone, error) {
 	if e.availabilityZones == nil {
 		zonesObject := e.getMAASClient().GetSubObject("zones")
 		result, err := zonesObject.CallGet("", nil)
-		if err, ok := err.(gomaasapi.ServerError); ok && err.StatusCode == http.StatusNotFound {
+		if err, ok := errors.Cause(err).(gomaasapi.ServerError); ok && err.StatusCode == http.StatusNotFound {
 			return nil, errors.NewNotImplemented(nil, "the MAAS server does not support zones")
 		}
 		if err != nil {
@@ -635,7 +635,7 @@ func getCapabilities(client *gomaasapi.MAASObject) (set.Strings, error) {
 		version := client.GetSubObject("version/")
 		result, err = version.CallGet("", nil)
 		if err != nil {
-			if err, ok := err.(gomaasapi.ServerError); ok && err.StatusCode == 404 {
+			if err, ok := errors.Cause(err).(gomaasapi.ServerError); ok && err.StatusCode == 404 {
 				return caps, errors.NotSupportedf("MAAS version 1.9 or more recent is required")
 			}
 		} else {
@@ -1091,7 +1091,7 @@ func (environ *maasEnviron) deploymentStatus(ids ...instance.Id) (map[string]str
 	nodesAPI := environ.getMAASClient().GetSubObject("nodes")
 	result, err := DeploymentStatusCall(nodesAPI, ids...)
 	if err != nil {
-		if err, ok := err.(gomaasapi.ServerError); ok && err.StatusCode == http.StatusBadRequest {
+		if err, ok := errors.Cause(err).(gomaasapi.ServerError); ok && err.StatusCode == http.StatusBadRequest {
 			return nil, errors.NewNotImplemented(err, "deployment status")
 		}
 		return nil, errors.Trace(err)
@@ -1137,7 +1137,7 @@ func (environ *maasEnviron) selectNode(args selectNodeArgs) (*gomaasapi.MAASObje
 			args.Volumes,
 		)
 
-		if err, ok := err.(gomaasapi.ServerError); ok && err.StatusCode == http.StatusConflict {
+		if err, ok := errors.Cause(err).(gomaasapi.ServerError); ok && err.StatusCode == http.StatusConflict {
 			if i+1 < len(args.AvailabilityZones) {
 				logger.Infof("could not acquire a node in zone %q, trying another zone", zoneName)
 				continue
@@ -1259,7 +1259,7 @@ func (environ *maasEnviron) releaseNodes(nodes gomaasapi.MAASObject, ids url.Val
 	if err == nil {
 		return nil
 	}
-	maasErr, ok := err.(gomaasapi.ServerError)
+	maasErr, ok := errors.Cause(err).(gomaasapi.ServerError)
 	if !ok {
 		return errors.Annotate(err, "cannot release nodes")
 	}
@@ -1596,7 +1596,7 @@ func (environ *maasEnviron) AllocateAddress(instId instance.Id, subnetId network
 		return nil
 	}
 
-	maasErr, ok := err.(gomaasapi.ServerError)
+	maasErr, ok := errors.Cause(err).(gomaasapi.ServerError)
 	if !ok {
 		return errors.Trace(err)
 	}
@@ -1705,7 +1705,7 @@ func (environ *maasEnviron) subnetsFromNode(nodeId string) ([]gomaasapi.JSONObje
 	client := environ.getMAASClient().GetSubObject("nodes").GetSubObject(nodeId)
 	json, err := client.CallGet("", nil)
 	if err != nil {
-		if maasErr, ok := err.(gomaasapi.ServerError); ok && maasErr.StatusCode == http.StatusNotFound {
+		if maasErr, ok := errors.Cause(err).(gomaasapi.ServerError); ok && maasErr.StatusCode == http.StatusNotFound {
 			return nil, errors.NotFoundf("intance %q", nodeId)
 		}
 		return nil, errors.Trace(err)
@@ -1981,7 +1981,7 @@ func (environ *maasEnviron) filteredSubnets(nodeId string, subnetIds []network.I
 func (environ *maasEnviron) getInstance(instId instance.Id) (instance.Instance, error) {
 	instances, err := environ.acquiredInstances([]instance.Id{instId})
 	if err != nil {
-		if maasErr, ok := err.(gomaasapi.ServerError); ok && maasErr.StatusCode == http.StatusNotFound {
+		if maasErr, ok := errors.Cause(err).(gomaasapi.ServerError); ok && maasErr.StatusCode == http.StatusNotFound {
 			return nil, errors.NotFoundf("instance %q", instId)
 		}
 		return nil, errors.Annotatef(err, "getting instance %q", instId)

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -313,8 +313,7 @@ func (env *maasEnviron) SetConfig(cfg *config.Config) error {
 	// version.
 	apiVersion := apiVersion2
 	controller, err := GetMAAS2Controller(ecfg.maasServer(), ecfg.maasOAuth())
-	maasErr, ok := errors.Cause(err).(gomaasapi.ServerError)
-	if ok && maasErr.StatusCode == http.StatusNotFound {
+	if err != nil && gomaasapi.IsUnsupportedVersionError(err) {
 		apiVersion = apiVersion1
 		authClient, err := gomaasapi.NewAuthenticatedClient(ecfg.maasServer(), ecfg.maasOAuth(), apiVersion1)
 		if err != nil {

--- a/provider/maas/environ_test.go
+++ b/provider/maas/environ_test.go
@@ -4,7 +4,6 @@
 package maas_test
 
 import (
-	"net/http"
 	stdtesting "testing"
 
 	"github.com/juju/gomaasapi"
@@ -51,7 +50,7 @@ func (s *environSuite) SetUpTest(c *gc.C) {
 		return set.NewStrings("network-deployment-ubuntu"), nil
 	}
 	mockGetController := func(maasServer, apiKey string) (gomaasapi.Controller, error) {
-		return nil, gomaasapi.ServerError{StatusCode: http.StatusNotFound}
+		return nil, gomaasapi.NewUnsupportedVersionError("oops")
 	}
 	s.PatchValue(&maas.GetCapabilities, mockCapabilities)
 	s.PatchValue(&maas.GetMAAS2Controller, mockGetController)

--- a/provider/maas/environprovider.go
+++ b/provider/maas/environprovider.go
@@ -104,16 +104,12 @@ func (p maasEnvironProvider) PrepareForBootstrap(ctx environs.BootstrapContext, 
 }
 
 func verifyCredentials(env *maasEnviron) error {
-	var err error
 	// Verify we can connect to the server and authenticate.
 	if env.usingMAAS2() {
-		// TODO (mfoord): use a lighterweight endpoint than machines.
-		// Could implement /api/2.0/maas/ op=get_config in new API
-		// layer.
-		_, err = env.maasController.Machines(gomaasapi.MachinesArgs{})
-	} else {
-		_, err = env.getMAASClient().GetSubObject("maas").CallGet("get_config", nil)
+		// The maas2 controller verifies credentials at creation time.
+		return nil
 	}
+	_, err := env.getMAASClient().GetSubObject("maas").CallGet("get_config", nil)
 	if err, ok := errors.Cause(err).(gomaasapi.ServerError); ok && err.StatusCode == http.StatusUnauthorized {
 		logger.Debugf("authentication failed: %v", err)
 		return errors.New(`authentication failed.

--- a/provider/maas/maas2_environ_whitebox_test.go
+++ b/provider/maas/maas2_environ_whitebox_test.go
@@ -66,6 +66,7 @@ func makeEnviron(c *gc.C) *maasEnviron {
 func (suite *maas2EnvironSuite) TestNewEnvironWithController(c *gc.C) {
 	testServer := gomaasapi.NewSimpleServer()
 	testServer.AddGetResponse("/api/2.0/version/", http.StatusOK, maas2VersionResponse)
+	testServer.AddGetResponse("/api/2.0/users/?op=whoami", http.StatusOK, "{}")
 	testServer.Start()
 	defer testServer.Close()
 	testAttrs := coretesting.Attrs{}

--- a/provider/maas/maas2_environ_whitebox_test.go
+++ b/provider/maas/maas2_environ_whitebox_test.go
@@ -65,7 +65,7 @@ func makeEnviron(c *gc.C) *maasEnviron {
 
 func (suite *maas2EnvironSuite) TestNewEnvironWithController(c *gc.C) {
 	testServer := gomaasapi.NewSimpleServer()
-	testServer.AddResponse("/api/2.0/version/", http.StatusOK, maas2VersionResponse)
+	testServer.AddGetResponse("/api/2.0/version/", http.StatusOK, maas2VersionResponse)
 	testServer.Start()
 	defer testServer.Close()
 	testAttrs := coretesting.Attrs{}

--- a/provider/maas/maas_test.go
+++ b/provider/maas/maas_test.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
-	"net/http"
 	"strconv"
 	"time"
 
@@ -106,7 +105,7 @@ func (s *providerSuite) SetUpTest(c *gc.C) {
 		return set.NewStrings("network-deployment-ubuntu"), nil
 	}
 	mockGetController := func(maasServer, apiKey string) (gomaasapi.Controller, error) {
-		return nil, gomaasapi.ServerError{StatusCode: http.StatusNotFound}
+		return nil, gomaasapi.NewUnsupportedVersionError("oops")
 	}
 	s.PatchValue(&GetCapabilities, mockCapabilities)
 	s.PatchValue(&GetMAAS2Controller, mockGetController)

--- a/provider/maas/storage.go
+++ b/provider/maas/storage.go
@@ -83,7 +83,7 @@ func (stor *maasStorage) retrieveFileObject(name string) (gomaasapi.MAASObject, 
 	obj, err := stor.addressFileObject(name).Get()
 	if err != nil {
 		noObj := gomaasapi.MAASObject{}
-		serverErr, ok := err.(gomaasapi.ServerError)
+		serverErr, ok := errors.Cause(err).(gomaasapi.ServerError)
 		if ok && serverErr.StatusCode == 404 {
 			return noObj, errors.NotFoundf("file '%s' not found", name)
 		}


### PR DESCRIPTION
We no longer call /machines to verify credentials, gomaasapi does a /users?op=whoami call on controller construction.

Use the more specific errors defined in gomaasapi, rather than net/http status codes.

(Review request: http://reviews.vapour.ws/r/4422/)