### PR TITLE
lxd provider: better errors when bootstrap failed

### DIFF
--- a/tools/lxdclient/client.go
+++ b/tools/lxdclient/client.go
@@ -228,7 +228,6 @@ func hoistLocalConnectErr(err error) error {
 
 	configureText := `
 Please configure LXD by running:
-	$ sudo dpkg-reconfigure -p medium lxd
 	$ newgrp lxd
 	$ lxd init
 `
@@ -236,7 +235,6 @@ Please configure LXD by running:
 	installText := `
 Please install LXD by running:
 	$ sudo apt-get install lxd
-	$ sudo dpkg-reconfigure -p medium lxd
 and then configure it with:
 	$ newgrp lxd
 	$ lxd init

--- a/tools/lxdclient/client.go
+++ b/tools/lxdclient/client.go
@@ -7,9 +7,11 @@ package lxdclient
 
 import (
 	"fmt"
+	"io/ioutil"
 	"net"
 	"net/url"
 	"os"
+	"strconv"
 	"strings"
 	"syscall"
 
@@ -21,6 +23,8 @@ import (
 )
 
 var logger = loggo.GetLogger("juju.tools.lxdclient")
+
+const LXDBridgeFile = "/etc/default/lxd-bridge"
 
 // Client is a high-level wrapper around the LXD API client.
 type Client struct {
@@ -114,7 +118,86 @@ func newRawClient(remote Remote) (*lxd.Client, error) {
 		}
 		return nil, errors.Trace(err)
 	}
+
+	/* If this is the LXD provider on the localhost, let's do an extra
+	 * check to make sure that lxdbr0 is configured.
+	 */
+	if remote.ID() == remoteIDForLocal {
+		profile, err := client.ProfileConfig("default")
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+
+		/* If the default profile doesn't have eth0 in it, then the
+		 * user has messed with it, so let's just use whatever they set up.
+		 *
+		 * Otherwise, if it looks like it's pointing at our lxdbr0,
+		 * let's check and make sure that is configured.
+		 */
+		eth0, ok := profile.Devices["eth0"]
+		if ok && eth0["type"] == "nic" && eth0["nictype"] == "bridged" && eth0["parent"] == "lxdbr0" {
+			conf, err := ioutil.ReadFile(LXDBridgeFile)
+			if err != nil {
+				if !os.IsNotExist(err) {
+					return nil, errors.Trace(err)
+				} else {
+					return nil, bridgeConfigError("lxdbr0 configured but no config file found at " + LXDBridgeFile)
+				}
+			}
+
+			if err = checkLXDBridgeConfiguration(string(conf)); err != nil {
+				return nil, errors.Trace(err)
+			}
+		}
+	}
+
 	return client, nil
+}
+
+func bridgeConfigError(err string) error {
+	return errors.Errorf(`%s
+It looks like your lxdbr0 has not yet been configured. Please configure it via:
+
+	sudo dpkg-reconfigure -p medium lxd
+
+and then bootstrap again.`, err)
+}
+
+func checkLXDBridgeConfiguration(conf string) error {
+	foundSubnetConfig := false
+	for _, line := range strings.Split(conf, "\n") {
+		if strings.HasPrefix(line, "USE_LXD_BRIDGE=") {
+			b, err := strconv.ParseBool(strings.Trim(line[len("USE_LXD_BRIDGE="):], " \""))
+			if err != nil {
+				logger.Warningf("couldn't parse bool, skipping USE_LXD_BRIDGE check: %s", err)
+				continue
+			}
+
+			if !b {
+				return bridgeConfigError("lxdbr0 not enabled but required")
+			}
+		} else if strings.HasPrefix(line, "LXD_BRIDGE=") {
+			name := strings.Trim(line[len("LXD_BRIDGE="):], " \"")
+			/* If we're here, we want lxdbr0 to be configured
+			 * because the default profile that juju will use says
+			 * lxdbr0. So let's fail if it doesn't.
+			 */
+			if name != "lxdbr0" {
+				return bridgeConfigError(fmt.Sprintf(LXDBridgeFile+" has a bridge named %s, not lxdbr0", name))
+			}
+		} else if strings.HasPrefix(line, "LXD_IPV4_ADDR=") || strings.HasPrefix(line, "LXD_IPV6_ADDR=") {
+			contents := strings.Trim(line[len("LXD_IPVN_ADDR="):], " \"")
+			if len(contents) > 0 {
+				foundSubnetConfig = true
+			}
+		}
+	}
+
+	if !foundSubnetConfig {
+		return bridgeConfigError("lxdbr0 has no ipv4 or ipv6 subnet enabled")
+	}
+
+	return nil
 }
 
 func hoistLocalConnectErr(err error) error {
@@ -145,6 +228,7 @@ func hoistLocalConnectErr(err error) error {
 
 	configureText := `
 Please configure LXD by running:
+	$ sudo dpkg-reconfigure -p medium lxd
 	$ newgrp lxd
 	$ lxd init
 `
@@ -152,6 +236,7 @@ Please configure LXD by running:
 	installText := `
 Please install LXD by running:
 	$ sudo apt-get install lxd
+	$ sudo dpkg-reconfigure -p medium lxd
 and then configure it with:
 	$ newgrp lxd
 	$ lxd init

--- a/tools/lxdclient/client.go
+++ b/tools/lxdclient/client.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"net/url"
 	"os"
+	"strings"
 	"syscall"
 
 	"github.com/lxc/lxd"
@@ -67,9 +68,9 @@ func newRawClient(remote Remote) (*lxd.Client, error) {
 	host := remote.Host
 	logger.Debugf("connecting to LXD remote %q: %q", remote.ID(), host)
 
-	if remote.ID() == remoteIDForLocal || host == "" {
+	if remote.ID() == remoteIDForLocal && host == "" {
 		host = "unix://" + lxdshared.VarPath("unix.socket")
-	} else {
+	} else if !strings.HasPrefix(host, "unix://") {
 		_, _, err := net.SplitHostPort(host)
 		if err != nil {
 			// There is no port here

--- a/tools/lxdclient/client_test.go
+++ b/tools/lxdclient/client_test.go
@@ -42,7 +42,6 @@ func (cs *ConnectSuite) TestLocalConnectError(c *gc.C) {
 	c.Assert(err.Error(), gc.Equals, `can't connect to the local LXD server: LXD refused connections; is LXD running?
 
 Please configure LXD by running:
-	$ sudo dpkg-reconfigure -p medium lxd
 	$ newgrp lxd
 	$ lxd init
 `)
@@ -53,7 +52,6 @@ Please configure LXD by running:
 	c.Assert(err.Error(), gc.Equals, `can't connect to the local LXD server: Permisson denied, are you in the lxd group?
 
 Please configure LXD by running:
-	$ sudo dpkg-reconfigure -p medium lxd
 	$ newgrp lxd
 	$ lxd init
 `)
@@ -65,7 +63,6 @@ Please configure LXD by running:
 
 Please install LXD by running:
 	$ sudo apt-get install lxd
-	$ sudo dpkg-reconfigure -p medium lxd
 and then configure it with:
 	$ newgrp lxd
 	$ lxd init
@@ -79,7 +76,6 @@ and then configure it with:
 
 Please install LXD by running:
 	$ sudo apt-get install lxd
-	$ sudo dpkg-reconfigure -p medium lxd
 and then configure it with:
 	$ newgrp lxd
 	$ lxd init

--- a/tools/lxdclient/client_test.go
+++ b/tools/lxdclient/client_test.go
@@ -30,7 +30,14 @@ func (cs *ConnectSuite) TestLocalConnectError(c *gc.C) {
 
 	// Yes, the error message actually matters here... this is being displayed
 	// to the user.
-	c.Assert(err, gc.ErrorMatches, "can't connect to the local LXD server.*")
+	c.Assert(err.Error(), gc.Equals, `can't connect to the local LXD server: boo!
+
+Please install LXD by running:
+	$ sudo apt-get install lxd
+and then configure it with:
+	$ newgrp lxd
+	$ lxd init
+`)
 }
 
 func (cs *ConnectSuite) TestRemoteConnectError(c *gc.C) {

--- a/tools/lxdclient/client_test.go
+++ b/tools/lxdclient/client_test.go
@@ -42,6 +42,7 @@ func (cs *ConnectSuite) TestLocalConnectError(c *gc.C) {
 	c.Assert(err.Error(), gc.Equals, `can't connect to the local LXD server: LXD refused connections; is LXD running?
 
 Please configure LXD by running:
+	$ sudo dpkg-reconfigure -p medium lxd
 	$ newgrp lxd
 	$ lxd init
 `)
@@ -52,6 +53,7 @@ Please configure LXD by running:
 	c.Assert(err.Error(), gc.Equals, `can't connect to the local LXD server: Permisson denied, are you in the lxd group?
 
 Please configure LXD by running:
+	$ sudo dpkg-reconfigure -p medium lxd
 	$ newgrp lxd
 	$ lxd init
 `)
@@ -63,6 +65,7 @@ Please configure LXD by running:
 
 Please install LXD by running:
 	$ sudo apt-get install lxd
+	$ sudo dpkg-reconfigure -p medium lxd
 and then configure it with:
 	$ newgrp lxd
 	$ lxd init
@@ -76,10 +79,97 @@ and then configure it with:
 
 Please install LXD by running:
 	$ sudo apt-get install lxd
+	$ sudo dpkg-reconfigure -p medium lxd
 and then configure it with:
 	$ newgrp lxd
 	$ lxd init
 `)
+}
+
+func (cs *ConnectSuite) TestCheckLXDBridgeConfiguration(c *gc.C) {
+	var err error
+
+	valid := `
+# Whether to setup a new bridge or use an existing one
+USE_LXD_BRIDGE="true"
+
+# Bridge name
+# This is still used even if USE_LXD_BRIDGE is set to false
+# set to an empty value to fully disable
+LXD_BRIDGE="lxdbr0"
+
+# Path to an extra dnsmasq configuration file
+LXD_CONFILE=""
+
+# DNS domain for the bridge
+LXD_DOMAIN="lxd"
+
+# IPv4
+## IPv4 address (e.g. 10.0.4.1)
+LXD_IPV4_ADDR="10.0.4.1"
+
+## IPv4 netmask (e.g. 255.255.255.0)
+LXD_IPV4_NETMASK="255.255.255.0"
+
+## IPv4 network (e.g. 10.0.4.0/24)
+LXD_IPV4_NETWORK="10.0.4.1/24"
+
+## IPv4 DHCP range (e.g. 10.0.4.2,10.0.4.254)
+LXD_IPV4_DHCP_RANGE="10.0.4.2,10.0.4.254"
+
+## IPv4 DHCP number of hosts (e.g. 250)
+LXD_IPV4_DHCP_MAX="253"
+
+## NAT IPv4 traffic
+LXD_IPV4_NAT="true"
+
+# IPv6
+## IPv6 address (e.g. 2001:470:b368:4242::1)
+LXD_IPV6_ADDR=""
+
+## IPv6 CIDR mask (e.g. 64)
+LXD_IPV6_MASK=""
+LXD_IPV6_NETWORK=""
+`
+
+	err = checkLXDBridgeConfiguration(valid)
+	c.Assert(err, jc.ErrorIsNil)
+
+	noBridge := `
+USE_LXD_BRIDGE="false"
+`
+	err = checkLXDBridgeConfiguration(noBridge)
+	c.Assert(err.Error(), gc.Equals, `lxdbr0 not enabled but required
+It looks like your lxdbr0 has not yet been configured. Please configure it via:
+
+	sudo dpkg-reconfigure -p medium lxd
+
+and then bootstrap again.`)
+
+	badName := `
+USE_LXD_BRIDGE="true"
+LXD_BRIDGE="meshuggahrocks"
+`
+	err = checkLXDBridgeConfiguration(badName)
+	c.Assert(err.Error(), gc.Equals, LXDBridgeFile+` has a bridge named meshuggahrocks, not lxdbr0
+It looks like your lxdbr0 has not yet been configured. Please configure it via:
+
+	sudo dpkg-reconfigure -p medium lxd
+
+and then bootstrap again.`)
+
+	noSubnets := `
+USE_LXD_BRIDGE="true"
+LXD_BRIDGE="lxdbr0"
+`
+	err = checkLXDBridgeConfiguration(noSubnets)
+	c.Assert(err.Error(), gc.Equals, `lxdbr0 has no ipv4 or ipv6 subnet enabled
+It looks like your lxdbr0 has not yet been configured. Please configure it via:
+
+	sudo dpkg-reconfigure -p medium lxd
+
+and then bootstrap again.`)
+
 }
 
 func (cs *ConnectSuite) TestRemoteConnectError(c *gc.C) {


### PR DESCRIPTION
When LXD isn't installed:

$ juju bootstrap bob lxd
ERROR invalid config: can't connect to the local LXD server: LXD socket not found; is LXD installed & running?

Please install LXD by running:
  $ sudo apt-get install lxd
and then configure it with:
  $ newgrp lxd
  $ lxd init

When the user doesn't have permissions:

$ juju bootstrap bob lxd
ERROR invalid config: can't connect to the local LXD server: Permisson denied, are you in the lxd group?

Please configure LXD by running:
  $ newgrp lxd
  $ lxd init

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>

(Review request: http://reviews.vapour.ws/r/4424/)