### PR TITLE
Implementing maasEnviron.AllInstances for MAAS 2

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -20,7 +20,7 @@ github.com/juju/go4	git	40d72ab9641a2a8c36a9c46a51e28367115c8e59	2016-02-22T16:3
 github.com/juju/gojsonpointer	git	afe8b77aa08f272b49e01b82de78510c11f61500	2015-02-04T19:46:29Z
 github.com/juju/gojsonreference	git	f0d24ac5ee330baa21721cdff56d45e4ee42628e	2015-02-04T19:46:33Z
 github.com/juju/gojsonschema	git	e1ad140384f254c82f89450d9a7c8dd38a632838	2015-03-12T17:00:16Z
-github.com/juju/gomaasapi	git	3888cd414c8d0ec07bc0867fd22ce130bd9bb7c7	2016-03-31T13:55:14Z
+github.com/juju/gomaasapi	git	e7bc20c748a7194f20cdf0b6578e4797b3765faf	2016-04-04T03:37:13Z
 github.com/juju/govmomi	git	4354a88d4b34abe467215f77c2fc1cb9f78b66f7	2015-04-24T01:54:48Z
 github.com/juju/httpprof	git	14bf14c307672fd2456bdbf35d19cf0ccd3cf565	2014-12-17T16:00:36Z
 github.com/juju/httprequest	git	89d547093c45e293599088cc63e805c6f1205dc0	2016-03-02T10:09:58Z

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -2118,7 +2118,7 @@ func (environ *maasEnviron) allInstances2() ([]instance.Instance, error) {
 	}
 	instances := make([]instance.Instance, len(machines))
 	for i, machine := range machines {
-		instances[i] = &maas2Instance{machine, environ.maasController}
+		instances[i] = &maas2Instance{machine}
 	}
 	return instances, nil
 }

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -1364,21 +1364,9 @@ func (environ *maasEnviron) Instances(ids []instance.Id) ([]instance.Instance, e
 		// if no instances were found.
 		return nil, environs.ErrNoInstances
 	}
-	var instances []instance.Instance
-	if environ.usingMAAS2() {
-		// XXX we need to be able to filter by id in
-		// Controller.Machines.
-		var err error
-		instances, err = environ.AllInstances()
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-	} else {
-		var err error
-		instances, err = environ.acquiredInstances(ids)
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
+	instances, err := environ.acquiredInstances(ids)
+	if err != nil {
+		return nil, errors.Trace(err)
 	}
 	if len(instances) == 0 {
 		return nil, environs.ErrNoInstances

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -345,19 +345,15 @@ func (env *maasEnviron) SupportedArchitectures() ([]string, error) {
 		return env.supportedArchitectures, nil
 	}
 
+	fetchArchitectures := env.allArchitecturesWithFallback
 	if env.usingMAAS2() {
-		architectures, err := env.allArchitectures2()
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		env.supportedArchitectures = architectures
-	} else {
-		architectures, err := env.allArchitecturesWithFallback()
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		env.supportedArchitectures = architectures
+		fetchArchitectures = env.allArchitectures2
 	}
+	architectures, err := fetchArchitectures()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	env.supportedArchitectures = architectures
 	return env.supportedArchitectures, nil
 }
 
@@ -376,6 +372,8 @@ func (env *maasEnviron) SupportsAddressAllocation(_ network.Id) (bool, error) {
 	return true, nil
 }
 
+// allArchitectures2 uses the MAAS2 controller to get architectures from boot
+// resources.
 func (env *maasEnviron) allArchitectures2() ([]string, error) {
 	resources, err := env.maasController.BootResources()
 	if err != nil {
@@ -388,8 +386,8 @@ func (env *maasEnviron) allArchitectures2() ([]string, error) {
 	return architectures.SortedValues(), nil
 }
 
-// allArchitectures queries MAAS for all of the boot-images across all
-// registered nodegroups and collapses them down to unique
+// allArchitectureWithFallback queries MAAS for all of the boot-images
+// across all registered nodegroups and collapses them down to unique
 // architectures.
 func (env *maasEnviron) allArchitecturesWithFallback() ([]string, error) {
 	architectures, err := env.allArchitectures()

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -506,7 +506,7 @@ func (env *maasEnviron) nodeArchitectures() ([]string, error) {
 	}
 	architectures := make(set.Strings)
 	for _, inst := range allInstances {
-		inst := inst.(*maasInstance)
+		inst := inst.(*maas1Instance)
 		arch, _, err := inst.architecture()
 		if err != nil {
 			return nil, err
@@ -579,7 +579,7 @@ func (e *maasEnviron) InstanceAvailabilityZoneNames(ids []instance.Id) ([]string
 		if inst == nil {
 			continue
 		}
-		zones[i] = inst.(maasInstanceInterface).zone()
+		zones[i] = inst.(maasInstance).zone()
 	}
 	return zones, nil
 }
@@ -903,7 +903,7 @@ func (environ *maasEnviron) StartInstance(args environs.StartInstanceParams) (
 		return nil, errors.Errorf("cannot run instances: %v", err)
 	}
 
-	inst := &maasInstance{
+	inst := &maas1Instance{
 		maasObject:   selectedNode,
 		environ:      environ,
 		statusGetter: environ.deploymentStatusOne,
@@ -1345,7 +1345,7 @@ func (environ *maasEnviron) instances(filter url.Values) ([]instance.Instance, e
 		if err != nil {
 			return nil, err
 		}
-		instances[index] = &maasInstance{
+		instances[index] = &maas1Instance{
 			maasObject:   &node,
 			environ:      environ,
 			statusGetter: environ.deploymentStatusOne,
@@ -2165,7 +2165,7 @@ func (*maasEnviron) Provider() environs.EnvironProvider {
 }
 
 func (environ *maasEnviron) nodeIdFromInstance(inst instance.Instance) (string, error) {
-	maasInst := inst.(*maasInstance)
+	maasInst := inst.(*maas1Instance)
 	maasObj := maasInst.maasObject
 	nodeId, err := maasObj.GetField("system_id")
 	if err != nil {

--- a/provider/maas/environ_whitebox_test.go
+++ b/provider/maas/environ_whitebox_test.go
@@ -261,14 +261,14 @@ var testNetworkValues = []struct {
 	},
 }
 
-func (suite *environSuite) getInstance(systemId string) *maasInstance {
+func (suite *environSuite) getInstance(systemId string) *maas1Instance {
 	input := fmt.Sprintf(`{"system_id": %q}`, systemId)
 	node := suite.testMAASObject.TestServer.NewNode(input)
 	statusGetter := func(instance.Id) (string, string) {
 		return "unknown", "FAKE"
 	}
 
-	return &maasInstance{&node, nil, statusGetter}
+	return &maas1Instance{&node, nil, statusGetter}
 }
 
 func (suite *environSuite) newNetwork(name string, id int, vlanTag int, defaultGateway string) *gomaasapi.MAASObject {
@@ -1122,7 +1122,7 @@ func (s *environSuite) TestStartInstanceAvailZone(c *gc.C) {
 	s.testMAASObject.TestServer.AddZone("test-available", "description")
 	inst, err := s.testStartInstanceAvailZone(c, "test-available")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(inst.(*maasInstance).zone(), gc.Equals, "test-available")
+	c.Assert(inst.(*maas1Instance).zone(), gc.Equals, "test-available")
 }
 
 func (s *environSuite) TestStartInstanceAvailZoneUnknown(c *gc.C) {
@@ -1388,7 +1388,7 @@ func (s *environSuite) TestStartInstanceDistribution(c *gc.C) {
 	s.newNode(c, "node1", "host1", map[string]interface{}{"zone": "test-available"})
 	s.addSubnet(c, 1, 1, "node1")
 	inst, _ := testing.AssertStartInstance(c, env, "1")
-	c.Assert(inst.(*maasInstance).zone(), gc.Equals, "test-available")
+	c.Assert(inst.(*maas1Instance).zone(), gc.Equals, "test-available")
 }
 
 func (s *environSuite) TestStartInstanceDistributionAZNotImplemented(c *gc.C) {
@@ -1401,7 +1401,7 @@ func (s *environSuite) TestStartInstanceDistributionAZNotImplemented(c *gc.C) {
 	s.newNode(c, "node1", "host1", nil)
 	s.addSubnet(c, 1, 1, "node1")
 	inst, _ := testing.AssertStartInstance(c, env, "1")
-	c.Assert(inst.(*maasInstance).zone(), gc.Equals, "")
+	c.Assert(inst.(*maas1Instance).zone(), gc.Equals, "")
 }
 
 func (s *environSuite) TestStartInstanceDistributionFailover(c *gc.C) {
@@ -1422,7 +1422,7 @@ func (s *environSuite) TestStartInstanceDistributionFailover(c *gc.C) {
 
 	env := s.bootstrap(c)
 	inst, _ := testing.AssertStartInstance(c, env, "1")
-	c.Assert(inst.(*maasInstance).zone(), gc.Equals, "zone2")
+	c.Assert(inst.(*maas1Instance).zone(), gc.Equals, "zone2")
 	c.Assert(s.testMAASObject.TestServer.NodesOperations(), gc.DeepEquals, []string{
 		// one acquire for the bootstrap, three for StartInstance (with zone failover)
 		"acquire", "acquire", "acquire", "acquire",

--- a/provider/maas/instance.go
+++ b/provider/maas/instance.go
@@ -46,11 +46,8 @@ func maasObjectId(maasObject *gomaasapi.MAASObject) instance.Id {
 	return instance.Id(maasObject.URI().String())
 }
 
-// Status returns a juju status based on the maas instance returned
-// status message.
-func (mi *maasInstance) Status() instance.InstanceStatus {
+func instanceStatusConverter(statusMsg, substatus string) instance.InstanceStatus {
 	maasInstanceStatus := status.StatusEmpty
-	statusMsg, substatus := mi.statusGetter(mi.Id())
 	switch statusMsg {
 	case "":
 		logger.Debugf("unable to obtain status of instance %s", mi.Id())
@@ -71,11 +68,17 @@ func (mi *maasInstance) Status() instance.InstanceStatus {
 		maasInstanceStatus = status.StatusEmpty
 		statusMsg = fmt.Sprintf("%s: %s", statusMsg, substatus)
 	}
-
 	return instance.InstanceStatus{
 		Status:  maasInstanceStatus,
 		Message: statusMsg,
 	}
+}
+
+// Status returns a juju status based on the maas instance returned
+// status message.
+func (mi *maasInstance) Status() instance.InstanceStatus {
+	statusMsg, substatus := mi.statusGetter(mi.Id())
+	return instanceStatusConverter(statusMsg, substatus)
 }
 
 func (mi *maasInstance) Addresses() ([]network.Address, error) {

--- a/provider/maas/instance.go
+++ b/provider/maas/instance.go
@@ -52,29 +52,29 @@ func maasObjectId(maasObject *gomaasapi.MAASObject) instance.Id {
 }
 
 func convertInstanceStatus(statusMsg, substatus string, id instance.Id) instance.InstanceStatus {
-	maas1InstanceStatus := status.StatusEmpty
+	maasInstanceStatus := status.StatusEmpty
 	switch statusMsg {
 	case "":
 		logger.Debugf("unable to obtain status of instance %s", id)
 		statusMsg = "error in getting status"
 	case "Deployed":
-		maas1InstanceStatus = status.StatusRunning
+		maasInstanceStatus = status.StatusRunning
 	case "Deploying":
-		maas1InstanceStatus = status.StatusAllocating
+		maasInstanceStatus = status.StatusAllocating
 		if substatus != "" {
 			statusMsg = fmt.Sprintf("%s: %s", statusMsg, substatus)
 		}
 	case "Failed Deployment":
-		maas1InstanceStatus = status.StatusProvisioningError
+		maasInstanceStatus = status.StatusProvisioningError
 		if substatus != "" {
 			statusMsg = fmt.Sprintf("%s: %s", statusMsg, substatus)
 		}
 	default:
-		maas1InstanceStatus = status.StatusEmpty
+		maasInstanceStatus = status.StatusEmpty
 		statusMsg = fmt.Sprintf("%s: %s", statusMsg, substatus)
 	}
 	return instance.InstanceStatus{
-		Status:  maas1InstanceStatus,
+		Status:  maasInstanceStatus,
 		Message: statusMsg,
 	}
 }

--- a/provider/maas/instance.go
+++ b/provider/maas/instance.go
@@ -46,11 +46,11 @@ func maasObjectId(maasObject *gomaasapi.MAASObject) instance.Id {
 	return instance.Id(maasObject.URI().String())
 }
 
-func instanceStatusConverter(statusMsg, substatus string) instance.InstanceStatus {
+func convertInstanceStatus(statusMsg, substatus string, id instance.Id) instance.InstanceStatus {
 	maasInstanceStatus := status.StatusEmpty
 	switch statusMsg {
 	case "":
-		logger.Debugf("unable to obtain status of instance %s", mi.Id())
+		logger.Debugf("unable to obtain status of instance %s", id)
 		statusMsg = "error in getting status"
 	case "Deployed":
 		maasInstanceStatus = status.StatusRunning
@@ -78,7 +78,7 @@ func instanceStatusConverter(statusMsg, substatus string) instance.InstanceStatu
 // status message.
 func (mi *maasInstance) Status() instance.InstanceStatus {
 	statusMsg, substatus := mi.statusGetter(mi.Id())
-	return instanceStatusConverter(statusMsg, substatus)
+	return convertInstanceStatus(statusMsg, substatus, mi.Id())
 }
 
 func (mi *maasInstance) Addresses() ([]network.Address, error) {

--- a/provider/maas/instance.go
+++ b/provider/maas/instance.go
@@ -15,13 +15,18 @@ import (
 	"github.com/juju/juju/status"
 )
 
+type maasInstanceInterface interface {
+	instance.Instance
+	zone() string
+}
+
 type maasInstance struct {
 	maasObject   *gomaasapi.MAASObject
 	environ      *maasEnviron
 	statusGetter func(instance.Id) (string, string)
 }
 
-var _ instance.Instance = (*maasInstance)(nil)
+var _ maasInstanceInterface = (*maasInstance)(nil)
 
 // Override for testing.
 var resolveHostnames = func(addrs []network.Address) []network.Address {

--- a/provider/maas/instance_test.go
+++ b/provider/maas/instance_test.go
@@ -68,7 +68,7 @@ func (s *instanceTest) TestId(c *gc.C) {
 	statusGetter := func(instance.Id) (string, string) {
 		return "unknown", "FAKE"
 	}
-	instance := maasInstance{&obj, nil, statusGetter}
+	instance := maas1Instance{&obj, nil, statusGetter}
 
 	c.Check(string(instance.Id()), gc.Equals, resourceURI)
 }
@@ -80,7 +80,7 @@ func (s *instanceTest) TestString(c *gc.C) {
 		return "unknown", "FAKE"
 	}
 
-	instance := &maasInstance{&obj, nil, statusGetter}
+	instance := &maas1Instance{&obj, nil, statusGetter}
 	hostname, err := instance.hostname()
 	c.Assert(err, jc.ErrorIsNil)
 	expected := hostname + ":" + string(instance.Id())
@@ -95,7 +95,7 @@ func (s *instanceTest) TestStringWithoutHostname(c *gc.C) {
 		return "unknown", "FAKE"
 	}
 
-	instance := &maasInstance{&obj, nil, statusGetter}
+	instance := &maas1Instance{&obj, nil, statusGetter}
 	_, err := instance.hostname()
 	c.Assert(err, gc.NotNil)
 	expected := fmt.Sprintf("<DNSName failed: %q>", err) + ":" + string(instance.Id())
@@ -116,7 +116,7 @@ func (s *instanceTest) TestAddressesLegacy(c *gc.C) {
 		return "unknown", "FAKE"
 	}
 
-	inst := maasInstance{&obj, s.makeEnviron(), statusGetter}
+	inst := maas1Instance{&obj, s.makeEnviron(), statusGetter}
 
 	expected := []network.Address{
 		network.NewScopedAddress("testing.invalid", network.ScopePublic),
@@ -169,7 +169,7 @@ func (s *instanceTest) TestAddressesViaInterfaces(c *gc.C) {
 	server.NewSubnet(s.newSubnet("8.7.6.0/24", "bar", 2))
 	server.NewSubnet(s.newSubnet("10.0.1.1/24", "storage", 3))
 	server.NewSubnet(s.newSubnet("fc00::/64", "db", 4))
-	inst := maasInstance{&obj, s.makeEnviron(), statusGetter}
+	inst := maas1Instance{&obj, s.makeEnviron(), statusGetter}
 
 	// Since gomaasapi treats "interface_set" specially and the only way to
 	// change it is via SetNodeNetworkLink(), which in turn does not allow you
@@ -207,7 +207,7 @@ func (s *instanceTest) TestAddressesMissing(c *gc.C) {
 		return "unknown", "FAKE"
 	}
 
-	inst := maasInstance{&obj, s.makeEnviron(), statusGetter}
+	inst := maas1Instance{&obj, s.makeEnviron(), statusGetter}
 
 	addr, err := inst.Addresses()
 	c.Assert(err, jc.ErrorIsNil)
@@ -228,7 +228,7 @@ func (s *instanceTest) TestAddressesInvalid(c *gc.C) {
 		return "unknown", "FAKE"
 	}
 
-	inst := maasInstance{&obj, s.makeEnviron(), statusGetter}
+	inst := maas1Instance{&obj, s.makeEnviron(), statusGetter}
 
 	_, err := inst.Addresses()
 	c.Assert(err, gc.NotNil)
@@ -245,7 +245,7 @@ func (s *instanceTest) TestAddressesInvalidContents(c *gc.C) {
 		return "unknown", "FAKE"
 	}
 
-	inst := maasInstance{&obj, s.makeEnviron(), statusGetter}
+	inst := maas1Instance{&obj, s.makeEnviron(), statusGetter}
 
 	_, err := inst.Addresses()
 	c.Assert(err, gc.NotNil)
@@ -263,7 +263,7 @@ func (s *instanceTest) TestHardwareCharacteristics(c *gc.C) {
 		return "unknown", "FAKE"
 	}
 
-	inst := maasInstance{&obj, nil, statusGetter}
+	inst := maas1Instance{&obj, nil, statusGetter}
 	hc, err := inst.hardwareCharacteristics()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(hc, gc.NotNil)
@@ -283,7 +283,7 @@ func (s *instanceTest) TestHardwareCharacteristicsWithTags(c *gc.C) {
 		return "unknown", "FAKE"
 	}
 
-	inst := maasInstance{&obj, nil, statusGetter}
+	inst := maas1Instance{&obj, nil, statusGetter}
 	hc, err := inst.hardwareCharacteristics()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(hc, gc.NotNil)
@@ -307,7 +307,7 @@ func (s *instanceTest) testHardwareCharacteristicsMissing(c *gc.C, json, expect 
 		return "unknown", "FAKE"
 	}
 
-	inst := maasInstance{&obj, nil, statusGetter}
+	inst := maas1Instance{&obj, nil, statusGetter}
 	_, err := inst.hardwareCharacteristics()
 	c.Assert(err, gc.ErrorMatches, expect)
 }

--- a/provider/maas/interfaces.go
+++ b/provider/maas/interfaces.go
@@ -229,6 +229,6 @@ func (environ *maasEnviron) NetworkInterfaces(instId instance.Id) ([]network.Int
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	mi := inst.(*maasInstance)
+	mi := inst.(*maas1Instance)
 	return maasObjectNetworkInterfaces(mi.maasObject, subnetsMap)
 }

--- a/provider/maas/maas2_environ_whitebox_test.go
+++ b/provider/maas/maas2_environ_whitebox_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/gomaasapi"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/set"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/environs/config"
@@ -80,5 +81,37 @@ func (suite *maas2EnvironSuite) TestSupportedArchitecturesError(c *gc.C) {
 	suite.PatchValue(&GetMAAS2Controller, mockGetController)
 	env := makeEnviron(c)
 	_, err := env.SupportedArchitectures()
+	c.Assert(err, gc.ErrorMatches, "Something terrible!")
+}
+
+func (suite *maas2EnvironSuite) TestAllInstances(c *gc.C) {
+	mockGetController := func(maasServer, apiKey string) (gomaasapi.Controller, error) {
+		return &fakeController{
+			machines: []gomaasapi.Machine{
+				&fakeMachine{systemID: "tuco"},
+				&fakeMachine{systemID: "tio"},
+				&fakeMachine{systemID: "gus"},
+			},
+		}, nil
+	}
+	suite.PatchValue(&GetMAAS2Controller, mockGetController)
+	env := makeEnviron(c)
+	result, err := env.AllInstances()
+	c.Assert(err, jc.ErrorIsNil)
+	expectedMachines := set.NewStrings("tuco", "tio", "gus")
+	actualMachines := set.NewStrings()
+	for _, instance := range result {
+		actualMachines.Add(string(instance.Id()))
+	}
+	c.Assert(actualMachines, jc.DeepEquals, expectedMachines)
+}
+
+func (suite *maas2EnvironSuite) TestAllInstancesError(c *gc.C) {
+	mockGetController := func(maasServer, apiKey string) (gomaasapi.Controller, error) {
+		return &fakeController{machinesError: errors.New("Something terrible!")}, nil
+	}
+	suite.PatchValue(&GetMAAS2Controller, mockGetController)
+	env := makeEnviron(c)
+	_, err := env.AllInstances()
 	c.Assert(err, gc.ErrorMatches, "Something terrible!")
 }

--- a/provider/maas/maas2_environ_whitebox_test.go
+++ b/provider/maas/maas2_environ_whitebox_test.go
@@ -15,33 +15,6 @@ import (
 	coretesting "github.com/juju/juju/testing"
 )
 
-type fakeController struct {
-	gomaasapi.Controller
-	bootResources      []gomaasapi.BootResource
-	bootResourcesError error
-}
-
-func (c *fakeController) BootResources() ([]gomaasapi.BootResource, error) {
-	if c.bootResourcesError != nil {
-		return nil, c.bootResourcesError
-	}
-	return c.bootResources, nil
-}
-
-type fakeBootResource struct {
-	gomaasapi.BootResource
-	name         string
-	architecture string
-}
-
-func (r *fakeBootResource) Name() string {
-	return r.name
-}
-
-func (r *fakeBootResource) Architecture() string {
-	return r.architecture
-}
-
 type maas2EnvironSuite struct {
 	baseProviderSuite
 }

--- a/provider/maas/maas2_test.go
+++ b/provider/maas/maas2_test.go
@@ -51,3 +51,20 @@ func (m *fakeMachine) SystemID() string {
 func (m *fakeMachine) Hostname() string {
 	return m.hostname
 }
+
+func (m *fakeMachine) IPAddresses() []string {
+	return m.ipAddresses
+}
+
+func (m *fakeMachine) Zone() gomaasapi.Zone {
+	return fakeZone{name: m.zoneName}
+}
+
+type fakeZone struct {
+	gomaasapi.Zone
+	name string
+}
+
+func (z fakeZone) Name() string {
+	return z.name
+}

--- a/provider/maas/maas2_test.go
+++ b/provider/maas/maas2_test.go
@@ -1,0 +1,46 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package maas
+
+import (
+	"github.com/juju/gomaasapi"
+	"github.com/juju/juju/network"
+)
+
+type fakeController struct {
+	gomaasapi.Controller
+	bootResources      []gomaasapi.BootResource
+	bootResourcesError error
+}
+
+func (c *fakeController) BootResources() ([]gomaasapi.BootResource, error) {
+	if c.bootResourcesError != nil {
+		return nil, c.bootResourcesError
+	}
+	return c.bootResources, nil
+}
+
+type fakeBootResource struct {
+	gomaasapi.BootResource
+	name         string
+	architecture string
+}
+
+func (r *fakeBootResource) Name() string {
+	return r.name
+}
+
+func (r *fakeBootResource) Architecture() string {
+	return r.architecture
+}
+
+type fakeMachine struct {
+	gomaasapi.Machine
+	zoneName      string
+	hostname      string
+	systemId      string
+	ipAddresses   []string
+	statusName    string
+	statusMessage string
+}

--- a/provider/maas/maas2_test.go
+++ b/provider/maas/maas2_test.go
@@ -5,7 +5,6 @@ package maas
 
 import (
 	"github.com/juju/gomaasapi"
-	"github.com/juju/juju/network"
 )
 
 type fakeController struct {
@@ -39,8 +38,16 @@ type fakeMachine struct {
 	gomaasapi.Machine
 	zoneName      string
 	hostname      string
-	systemId      string
+	systemID      string
 	ipAddresses   []string
 	statusName    string
 	statusMessage string
+}
+
+func (m *fakeMachine) SystemID() string {
+	return m.systemID
+}
+
+func (m *fakeMachine) Hostname() string {
+	return m.hostname
 }

--- a/provider/maas/maas2_test.go
+++ b/provider/maas/maas2_test.go
@@ -11,6 +11,15 @@ type fakeController struct {
 	gomaasapi.Controller
 	bootResources      []gomaasapi.BootResource
 	bootResourcesError error
+	machines           []gomaasapi.Machine
+	machinesError      error
+}
+
+func (c *fakeController) Machines(args gomaasapi.MachinesArgs) ([]gomaasapi.Machine, error) {
+	if c.machinesError != nil {
+		return nil, c.machinesError
+	}
+	return c.machines, nil
 }
 
 func (c *fakeController) BootResources() ([]gomaasapi.BootResource, error) {

--- a/provider/maas/maas2_test.go
+++ b/provider/maas/maas2_test.go
@@ -56,6 +56,14 @@ func (m *fakeMachine) IPAddresses() []string {
 	return m.ipAddresses
 }
 
+func (m *fakeMachine) StatusName() string {
+	return m.statusName
+}
+
+func (m *fakeMachine) StatusMessage() string {
+	return m.statusMessage
+}
+
 func (m *fakeMachine) Zone() gomaasapi.Zone {
 	return fakeZone{name: m.zoneName}
 }

--- a/provider/maas/maas2instance.go
+++ b/provider/maas/maas2instance.go
@@ -15,7 +15,11 @@ type maas2Instance struct {
 	controller gomaasapi.Controller
 }
 
-var _ instance.Instance = (*maas2Instance)(nil)
+var _ maasInstanceInterface = (*maas2Instance)(nil)
+
+func (mi *maas2Instance) zone() string {
+	return mi.machine.Zone().Name()
+}
 
 func (mi *maas2Instance) String() string {
 	return mi.machine.Hostname()

--- a/provider/maas/maas2instance.go
+++ b/provider/maas/maas2instance.go
@@ -11,8 +11,7 @@ import (
 )
 
 type maas2Instance struct {
-	machine    gomaasapi.Machine
-	controller gomaasapi.Controller
+	machine gomaasapi.Machine
 }
 
 var _ maasInstanceInterface = (*maas2Instance)(nil)

--- a/provider/maas/maas2instance.go
+++ b/provider/maas/maas2instance.go
@@ -4,6 +4,8 @@
 package maas
 
 import (
+	"fmt"
+
 	"github.com/juju/gomaasapi"
 
 	"github.com/juju/juju/instance"
@@ -21,13 +23,11 @@ func (mi *maas2Instance) zone() string {
 }
 
 func (mi *maas2Instance) String() string {
-	return mi.machine.Hostname()
+	return fmt.Sprintf("%s:%s", mi.machine.Hostname(), mi.machine.SystemID())
 }
 
 func (mi *maas2Instance) Id() instance.Id {
-	// TODO (mfoord): this should be machine.URI() but that isn't implemented
-	// yet.
-	return instance.Id(mi.machine.SystemId())
+	return instance.Id(mi.machine.SystemID())
 }
 
 func (mi *maas2Instance) Addresses() ([]network.Address, error) {

--- a/provider/maas/maas2instance.go
+++ b/provider/maas/maas2instance.go
@@ -42,25 +42,10 @@ func (mi *maas2Instance) Addresses() ([]network.Address, error) {
 // Status returns a juju status based on the maas instance returned
 // status message.
 func (mi *maas2Instance) Status() instance.InstanceStatus {
-	var statusMsg, statusName string
-	err := mi.refresh()
-	if err != nil {
-		// The instanceStatusConverter will turn these into an appropriate
-		// error status.
-		statusMsg = ""
-		statusName = ""
-
-	} else {
-		statusName = mi.machine.StatusName()
-		statusMsg = mi.machine.StatusMessage()
-	}
+	// TODO (babbageclunk): this should rerequest to get live status.
+	statusName := mi.machine.StatusName()
+	statusMsg := mi.machine.StatusMessage()
 	return convertInstanceStatus(statusMsg, statusName, mi.Id())
-}
-
-func (mi *maas2Instance) refresh() error {
-	// XXXX refresh the machine, that requires being able to fetch a machine by
-	// id from the controller which isn't yet implemented.
-	return nil
 }
 
 // MAAS does not do firewalling so these port methods do nothing.

--- a/provider/maas/maas2instance.go
+++ b/provider/maas/maas2instance.go
@@ -1,0 +1,73 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package maas
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/juju/errors"
+	"github.com/juju/gomaasapi"
+
+	"github.com/juju/juju/instance"
+	"github.com/juju/juju/network"
+	"github.com/juju/juju/status"
+)
+
+type maas2Instance struct {
+	machine    gomaasapi.Machine
+	controller gomaasapi.Controller
+}
+
+var _ instance.Instance = (*maas2Instance)(nil)
+
+func (mi *maas2Instance) String() string {
+	return mi.machine.Hostname()
+}
+
+func (mi *maas2Instance) Id() instance.Id {
+	// TODO (mfoord): this should be machine.URI() but that isn't implemented
+	// yet.
+	return mi.machine.SystemId()
+}
+
+// Status returns a juju status based on the maas instance returned
+// status message.
+func (mi *maas2Instance) Status() instance.InstanceStatus {
+	var statusMsg, statusName string
+	err := mi.refresh()
+	if err != nil {
+		// The instanceStatusConverter will turn these into an appropriate
+		// error status.
+		statusMsg = ""
+		statusName = ""
+
+	} else {
+		statusName = mi.machine.StatusName()
+		statusMsg = mi.machine.StatusMessage()
+	}
+	return instanceStatusConverter(statusMsg, statusName)
+}
+
+func (mi *maas2Instance) refresh() error {
+	// XXXX refresh the machine, that requires being able to fetch a machine by
+	// id from the controller which isn't yet implemented.
+	return nil
+}
+
+// MAAS does not do firewalling so these port methods do nothing.
+func (mi *maas2Instance) OpenPorts(machineId string, ports []network.PortRange) error {
+	logger.Debugf("unimplemented OpenPorts() called")
+	return nil
+}
+
+func (mi *maas2Instance) ClosePorts(machineId string, ports []network.PortRange) error {
+	logger.Debugf("unimplemented ClosePorts() called")
+	return nil
+}
+
+func (mi *maas2Instance) Ports(machineId string) ([]network.PortRange, error) {
+	logger.Debugf("unimplemented Ports() called")
+	return nil, nil
+}

--- a/provider/maas/maas2instance.go
+++ b/provider/maas/maas2instance.go
@@ -14,7 +14,7 @@ type maas2Instance struct {
 	machine gomaasapi.Machine
 }
 
-var _ maasInstanceInterface = (*maas2Instance)(nil)
+var _ maasInstance = (*maas2Instance)(nil)
 
 func (mi *maas2Instance) zone() string {
 	return mi.machine.Zone().Name()

--- a/provider/maas/maas2instance.go
+++ b/provider/maas/maas2instance.go
@@ -4,7 +4,6 @@
 package maas
 
 import (
-	"github.com/juju/errors"
 	"github.com/juju/gomaasapi"
 
 	"github.com/juju/juju/instance"
@@ -29,7 +28,12 @@ func (mi *maas2Instance) Id() instance.Id {
 }
 
 func (mi *maas2Instance) Addresses() ([]network.Address, error) {
-	return nil, errors.New("write me or bite me")
+	machineAddresses := mi.machine.IPAddresses()
+	addresses := make([]network.Address, len(machineAddresses))
+	for i, address := range machineAddresses {
+		addresses[i] = network.NewAddress(address)
+	}
+	return addresses, nil
 }
 
 // Status returns a juju status based on the maas instance returned

--- a/provider/maas/maas2instance.go
+++ b/provider/maas/maas2instance.go
@@ -4,15 +4,11 @@
 package maas
 
 import (
-	"fmt"
-	"strings"
-
 	"github.com/juju/errors"
 	"github.com/juju/gomaasapi"
 
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/network"
-	"github.com/juju/juju/status"
 )
 
 type maas2Instance struct {
@@ -29,7 +25,11 @@ func (mi *maas2Instance) String() string {
 func (mi *maas2Instance) Id() instance.Id {
 	// TODO (mfoord): this should be machine.URI() but that isn't implemented
 	// yet.
-	return mi.machine.SystemId()
+	return instance.Id(mi.machine.SystemId())
+}
+
+func (mi *maas2Instance) Addresses() ([]network.Address, error) {
+	return nil, errors.New("write me or bite me")
 }
 
 // Status returns a juju status based on the maas instance returned
@@ -47,7 +47,7 @@ func (mi *maas2Instance) Status() instance.InstanceStatus {
 		statusName = mi.machine.StatusName()
 		statusMsg = mi.machine.StatusMessage()
 	}
-	return instanceStatusConverter(statusMsg, statusName)
+	return convertInstanceStatus(statusMsg, statusName, mi.Id())
 }
 
 func (mi *maas2Instance) refresh() error {

--- a/provider/maas/maas2instance_test.go
+++ b/provider/maas/maas2instance_test.go
@@ -4,7 +4,11 @@
 package maas
 
 import (
+	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/instance"
+	"github.com/juju/juju/network"
 )
 
 type maas2InstanceSuite struct {
@@ -16,4 +20,30 @@ var _ = gc.Suite(&maas2InstanceSuite{})
 func (s *maas2InstanceSuite) TestString(c *gc.C) {
 	instance := &maas2Instance{&fakeMachine{hostname: "peewee", systemID: "herman"}}
 	c.Assert(instance.String(), gc.Equals, "peewee:herman")
+}
+
+func (s *maas2InstanceSuite) TestID(c *gc.C) {
+	thing := &maas2Instance{&fakeMachine{systemID: "herman"}}
+	c.Assert(thing.Id(), gc.Equals, instance.Id("herman"))
+}
+
+func (s *maas2InstanceSuite) TestAddresses(c *gc.C) {
+	instance := &maas2Instance{&fakeMachine{ipAddresses: []string{
+		"0.0.0.0",
+		"1.2.3.4",
+		"127.0.0.1",
+	}}}
+	expectedAddresses := []network.Address{
+		network.NewAddress("0.0.0.0"),
+		network.NewAddress("1.2.3.4"),
+		network.NewAddress("127.0.0.1"),
+	}
+	addresses, err := instance.Addresses()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(addresses, jc.SameContents, expectedAddresses)
+}
+
+func (s *maas2InstanceSuite) TestZone(c *gc.C) {
+	instance := &maas2Instance{&fakeMachine{zoneName: "inflatable"}}
+	c.Assert(instance.zone(), gc.Equals, "inflatable")
 }

--- a/provider/maas/maas2instance_test.go
+++ b/provider/maas/maas2instance_test.go
@@ -1,0 +1,23 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package maas
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/gomaasapi"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	coretesting "github.com/juju/juju/testing"
+)
+
+type maas2InstanceSuite struct {
+	baseProviderSuite
+}
+
+var _ = gc.Suite(&maas2InstanceSuite{})
+
+func (s *maas2InstanceSuite) TestString(c *gc.C) {
+	instance := maas2Instance{fakeMachine{}}
+}

--- a/provider/maas/maas2instance_test.go
+++ b/provider/maas/maas2instance_test.go
@@ -4,12 +4,7 @@
 package maas
 
 import (
-	"github.com/juju/errors"
-	"github.com/juju/gomaasapi"
-	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-
-	coretesting "github.com/juju/juju/testing"
 )
 
 type maas2InstanceSuite struct {
@@ -19,5 +14,6 @@ type maas2InstanceSuite struct {
 var _ = gc.Suite(&maas2InstanceSuite{})
 
 func (s *maas2InstanceSuite) TestString(c *gc.C) {
-	instance := maas2Instance{fakeMachine{}}
+	instance := &maas2Instance{&fakeMachine{hostname: "peewee", systemID: "herman"}}
+	c.Assert(instance.String(), gc.Equals, "peewee:herman")
 }

--- a/provider/maas/maas2instance_test.go
+++ b/provider/maas/maas2instance_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/network"
+	"github.com/juju/juju/status"
 )
 
 type maas2InstanceSuite struct {
@@ -46,4 +47,16 @@ func (s *maas2InstanceSuite) TestAddresses(c *gc.C) {
 func (s *maas2InstanceSuite) TestZone(c *gc.C) {
 	instance := &maas2Instance{&fakeMachine{zoneName: "inflatable"}}
 	c.Assert(instance.zone(), gc.Equals, "inflatable")
+}
+
+func (s *maas2InstanceSuite) TestStatusSuccess(c *gc.C) {
+	thing := &maas2Instance{&fakeMachine{statusMessage: "Deploying", statusName: "Wexler"}}
+	result := thing.Status()
+	c.Assert(result, jc.DeepEquals, instance.InstanceStatus{status.StatusAllocating, "Deploying: Wexler"})
+}
+
+func (s *maas2InstanceSuite) TestStatusError(c *gc.C) {
+	thing := &maas2Instance{&fakeMachine{statusMessage: "", statusName: ""}}
+	result := thing.Status()
+	c.Assert(result, jc.DeepEquals, instance.InstanceStatus{"", "error in getting status"})
 }

--- a/provider/maas/maas_test.go
+++ b/provider/maas/maas_test.go
@@ -55,9 +55,6 @@ func (s *baseProviderSuite) SetUpSuite(c *gc.C) {
 	s.PatchValue(&nodeDeploymentTimeout, func(*maasEnviron) time.Duration {
 		return coretesting.ShortWait
 	})
-	s.PatchValue(&resolveHostnames, func(addrs []network.Address) []network.Address {
-		return addrs
-	})
 }
 
 func (s *baseProviderSuite) SetUpTest(c *gc.C) {

--- a/provider/maas/maas_test.go
+++ b/provider/maas/maas_test.go
@@ -156,13 +156,13 @@ func (suite *providerSuite) addNode(jsonText string) instance.Id {
 	return instance.Id(resourceURI)
 }
 
-func (suite *providerSuite) getInstance(systemId string) *maasInstance {
+func (suite *providerSuite) getInstance(systemId string) *maas1Instance {
 	input := fmt.Sprintf(`{"system_id": %q}`, systemId)
 	node := suite.testMAASObject.TestServer.NewNode(input)
 	statusGetter := func(instance.Id) (string, string) {
 		return "unknown", "FAKE"
 	}
-	return &maasInstance{&node, nil, statusGetter}
+	return &maas1Instance{&node, nil, statusGetter}
 }
 
 func (suite *providerSuite) getNetwork(name string, id int, vlanTag int) *gomaasapi.MAASObject {

--- a/provider/maas/volumes.go
+++ b/provider/maas/volumes.go
@@ -154,7 +154,7 @@ func buildMAASVolumeParameters(args []storage.VolumeParams, cons constraints.Val
 
 // volumes creates the storage volumes and attachments
 // corresponding to the volume info associated with a MAAS node.
-func (mi *maasInstance) volumes(
+func (mi *maas1Instance) volumes(
 	mTag names.MachineTag, requestedVolumes []names.VolumeTag,
 ) (
 	[]storage.Volume, []storage.VolumeAttachment, error,

--- a/provider/maas/volumes_test.go
+++ b/provider/maas/volumes_test.go
@@ -79,7 +79,7 @@ func (s *volumeSuite) TestInstanceVolumes(c *gc.C) {
 		return "unknown", "FAKE"
 	}
 
-	instance := maasInstance{&obj, nil, statusGetter}
+	instance := maas1Instance{&obj, nil, statusGetter}
 	mTag := names.NewMachineTag("1")
 	volumes, attachments, err := instance.volumes(mTag, []names.VolumeTag{
 		names.NewVolumeTag("1"),
@@ -138,7 +138,7 @@ func (s *volumeSuite) TestInstanceVolumesOldMass(c *gc.C) {
 		return "provisioning", "substatus"
 	}
 
-	instance := maasInstance{&obj, nil, statusGetter}
+	instance := maas1Instance{&obj, nil, statusGetter}
 	volumes, attachments, err := instance.volumes(names.NewMachineTag("1"), []names.VolumeTag{
 		names.NewVolumeTag("1"),
 		names.NewVolumeTag("2"),


### PR DESCRIPTION
It now returns maas2Instances if we're talking to a MAAS 2 API.

Created a maasInstance interface with maas1- and maas2- implementations. Private methods that lived on the concrete maasInstance (now maas1Instance) will be added to the interface as they're needed.

(Review request: http://reviews.vapour.ws/r/4425/)