### PR TITLE
Add meter status to juju status tabular format.

### DIFF
--- a/cmd/juju/status/output_tabular.go
+++ b/cmd/juju/status/output_tabular.go
@@ -104,6 +104,7 @@ func FormatTabular(value interface{}) ([]byte, error) {
 	}
 
 	units := make(map[string]unitStatus)
+	metering := false
 	relations := newRelationFormatter()
 	p("[Services]")
 	p("NAME\tSTATUS\tEXPOSED\tCHARM")
@@ -111,6 +112,9 @@ func FormatTabular(value interface{}) ([]byte, error) {
 		svc := fs.Services[svcName]
 		for un, u := range svc.Units {
 			units[un] = u
+			if u.MeterStatus != nil {
+				metering = true
+			}
 		}
 
 		subs := set.NewStrings(svc.SubordinateTo...)
@@ -164,6 +168,17 @@ func FormatTabular(value interface{}) ([]byte, error) {
 		recurseUnits(u, indentationLevel, pUnit)
 	}
 	tw.Flush()
+
+	if metering {
+		p("\n[Metering]")
+		p("ID\tSTATUS\tMESSAGE")
+		for _, name := range common.SortStringsNaturally(stringKeysFromMap(units)) {
+			u := units[name]
+			if u.MeterStatus != nil {
+				p(name, u.MeterStatus.Color, u.MeterStatus.Message)
+			}
+		}
+	}
 
 	p("\n[Machines]")
 	p("ID\tSTATE\tDNS\tINS-ID\tSERIES\tAZ")

--- a/cmd/juju/status/status_test.go
+++ b/cmd/juju/status/status_test.go
@@ -3282,6 +3282,49 @@ func (s *StatusSuite) TestStatusWithNilStatusApi(c *gc.C) {
 	c.Check(string(stderr), gc.Equals, "error: unable to obtain the current status\n")
 }
 
+func (s *StatusSuite) TestFormatTabularMetering(c *gc.C) {
+	status := formattedStatus{
+		Services: map[string]serviceStatus{
+			"foo": serviceStatus{
+				Units: map[string]unitStatus{
+					"foo/0": unitStatus{
+						MeterStatus: &meterStatus{
+							Color:   "strange",
+							Message: "warning: stable strangelets",
+						},
+					},
+					"foo/1": unitStatus{
+						MeterStatus: &meterStatus{
+							Color:   "up",
+							Message: "things are looking up",
+						},
+					},
+				},
+			},
+		},
+	}
+	out, err := FormatTabular(status)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(string(out), gc.Equals, `
+[Services] 
+NAME       STATUS EXPOSED CHARM 
+foo               false         
+
+[Units] 
+ID      WORKLOAD-STATUS JUJU-STATUS VERSION MACHINE PORTS PUBLIC-ADDRESS MESSAGE 
+foo/0                                                                            
+foo/1                                                                            
+
+[Metering] 
+ID         STATUS  MESSAGE                     
+foo/0      strange warning: stable strangelets 
+foo/1      up      things are looking up       
+
+[Machines] 
+ID         STATE DNS INS-ID SERIES AZ 
+`[1:])
+}
+
 //
 // Filtering Feature
 //


### PR DESCRIPTION
Only show the section if meter status is set on one or more workloads.

(Review request: http://reviews.vapour.ws/r/4426/)