### PR TITLE
add fortress.Occupy

### DIFF
--- a/worker/fortress/occupy.go
+++ b/worker/fortress/occupy.go
@@ -1,0 +1,69 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package fortress
+
+import (
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/worker"
+)
+
+// StartFunc starts a worker.Worker.
+type StartFunc func() (worker.Worker, error)
+
+// Occupy launches a Visit to fortress that creates a worker and holds the
+// visit open until the worker completes. Like most funcs that return any
+// Worker, the caller takes responsibility for its lifetime; be aware that
+// the responsibility is especially heavy here, because failure to clean up
+// the worker will block cleanup of the fortress.
+//
+// This may sound scary, but the alternative is to have multiple components
+// "responsible for" a single worker's lifetime -- and Fortress itself would
+// have to grow new concerns, of understanding and managing worker.Workers --
+// and that scenario ends up much worse.
+func Occupy(fortress Guest, start StartFunc, abort Abort) (worker.Worker, error) {
+
+	// Create two channels to communicate success and failure of worker
+	// creation; and a worker-running func that sends on exactly one
+	// of them, and returns only when (1) a value has been sent and (2)
+	// no worker is running. Note especially that it always returns nil.
+	started := make(chan worker.Worker, 1)
+	failed := make(chan error, 1)
+	task := func() error {
+		worker, err := start()
+		if err != nil {
+			failed <- err
+		} else {
+			started <- worker
+			worker.Wait() // ignore error: worker is SEP now.
+		}
+		return nil
+	}
+
+	// Start a goroutine to run the task func inside the fortress. If
+	// this operation succeeds, we must inspect started and failed to
+	// determine what actually happened; but if it fails, we can be
+	// confident that the task (which never fails) did not run, and can
+	// therefore return the failure without waiting further.
+	finished := make(chan error, 1)
+	go func() {
+		finished <- fortress.Visit(task, abort)
+	}()
+
+	// Watch all these channels to figure out what happened and inform
+	// the client. A nil error from finished indicates that there will
+	// be some value waiting on one of the other channels.
+	for {
+		select {
+		case err := <-finished:
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+		case err := <-failed:
+			return nil, errors.Trace(err)
+		case worker := <-started:
+			return worker, nil
+		}
+	}
+}

--- a/worker/fortress/occupy_test.go
+++ b/worker/fortress/occupy_test.go
@@ -1,0 +1,112 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package fortress_test
+
+import (
+	"time"
+
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/fortress"
+	"github.com/juju/juju/worker/workertest"
+)
+
+type OccupySuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&OccupySuite{})
+
+func (*OccupySuite) TestAbort(c *gc.C) {
+	fix := newFixture(c)
+	defer fix.TearDown(c)
+
+	// Try to occupy an unlocked fortress.
+	run := func() (worker.Worker, error) {
+		panic("shouldn't happen")
+	}
+	abort := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		worker, err := fortress.Occupy(fix.Guest(c), run, abort)
+		c.Check(worker, gc.IsNil)
+		c.Check(errors.Cause(err), gc.Equals, fortress.ErrAborted)
+	}()
+
+	// Observe that nothing happens.
+	select {
+	case <-done:
+		c.Fatalf("started early")
+	case <-time.After(coretesting.ShortWait):
+	}
+
+	// Abort and wait for completion.
+	close(abort)
+	select {
+	case <-done:
+	case <-time.After(coretesting.LongWait):
+		c.Fatalf("never cancelled")
+	}
+}
+
+func (*OccupySuite) TestStartError(c *gc.C) {
+	fix := newFixture(c)
+	defer fix.TearDown(c)
+	c.Check(fix.Guard(c).Unlock(), jc.ErrorIsNil)
+
+	// Error just passes straight through.
+	run := func() (worker.Worker, error) {
+		return nil, errors.New("splosh")
+	}
+	worker, err := fortress.Occupy(fix.Guest(c), run, nil)
+	c.Check(worker, gc.IsNil)
+	c.Check(err, gc.ErrorMatches, "splosh")
+
+	// Guard can lock fortress immediately.
+	err = fix.Guard(c).Lockdown(nil)
+	c.Check(err, jc.ErrorIsNil)
+	AssertLocked(c, fix.Guest(c))
+}
+
+func (*OccupySuite) TestStartSuccess(c *gc.C) {
+	fix := newFixture(c)
+	defer fix.TearDown(c)
+	c.Check(fix.Guard(c).Unlock(), jc.ErrorIsNil)
+
+	// Start a worker...
+	expect := workertest.NewErrorWorker(nil)
+	defer workertest.CleanKill(c, expect)
+	run := func() (worker.Worker, error) {
+		return expect, nil
+	}
+	worker, err := fortress.Occupy(fix.Guest(c), run, nil)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(worker, gc.Equals, expect)
+
+	// ...and check we can't lockdown again...
+	locked := make(chan error, 1)
+	go func() {
+		locked <- fix.Guard(c).Lockdown(nil)
+	}()
+	select {
+	case err := <-locked:
+		c.Fatalf("unexpected Lockdown result: %v", err)
+	case <-time.After(coretesting.ShortWait):
+	}
+
+	// ...until the worker completes.
+	workertest.CleanKill(c, worker)
+	select {
+	case err := <-locked:
+		c.Check(err, jc.ErrorIsNil)
+	case <-time.After(coretesting.LongWait):
+		c.Fatalf("visit never completed")
+	}
+}


### PR DESCRIPTION
introduce a mechanism for running workers as fortress Guests; but handing the workers over to external management; such that we can run migration tasks as an associated fortress Guard, and be able to guarantee exclusivity.

(Review request: http://reviews.vapour.ws/r/4430/)