### PR TITLE
worker/migrationmaster: Various fixes following live testing

### DIFF
--- a/api/watcher/watcher_test.go
+++ b/api/watcher/watcher_test.go
@@ -348,6 +348,8 @@ func (s *migrationSuite) TestMigrationStatusWatcher(c *gc.C) {
 	// Now abort the migration, this should be reported too.
 	c.Assert(mig.SetPhase(migration.ABORT), jc.ErrorIsNil)
 	assertChange(migration.ABORT)
+	c.Assert(mig.SetPhase(migration.ABORTDONE), jc.ErrorIsNil)
+	assertChange(migration.ABORTDONE)
 
 	// Start a new migration, this should also trigger.
 	_, err = hostedState.CreateModelMigration(spec)

--- a/cmd/jujud/agent/util_test.go
+++ b/cmd/jujud/agent/util_test.go
@@ -32,9 +32,7 @@ var (
 		"storage-provisioner", "firewaller", "unit-assigner",
 		"service-scaler", "instance-poller", "charm-revision-updater",
 		"metric-worker", "state-cleaner", "status-history-pruner",
-		// Note absence of migration-master worker, which currently
-		// errors out repeatedly (when not migrating) and so never
-		// shows up.
+		"migration-master",
 	}
 	deadModelWorkers = []string{
 		"environ-tracker", "undertaker",

--- a/core/migration/phase.go
+++ b/core/migration/phase.go
@@ -21,6 +21,7 @@ const (
 	REAPFAILED
 	DONE
 	ABORT
+	ABORTDONE
 )
 
 var phaseNames = []string{
@@ -37,6 +38,7 @@ var phaseNames = []string{
 	"REAPFAILED",
 	"DONE",
 	"ABORT",
+	"ABORTDONE",
 }
 
 // String returns the name of an model migration phase constant.
@@ -87,6 +89,7 @@ var validTransitions = map[Phase][]Phase{
 	SUCCESS:     {LOGTRANSFER},
 	LOGTRANSFER: {REAP},
 	REAP:        {DONE, REAPFAILED},
+	ABORT:       {ABORTDONE},
 }
 
 var terminalPhases []Phase

--- a/core/migration/phase_test.go
+++ b/core/migration/phase_test.go
@@ -49,7 +49,8 @@ func (s *PhaseSuite) TestParseInvalid(c *gc.C) {
 func (s *PhaseSuite) TestIsTerminal(c *gc.C) {
 	c.Check(migration.QUIESCE.IsTerminal(), jc.IsFalse)
 	c.Check(migration.SUCCESS.IsTerminal(), jc.IsFalse)
-	c.Check(migration.ABORT.IsTerminal(), jc.IsTrue)
+	c.Check(migration.ABORT.IsTerminal(), jc.IsFalse)
+	c.Check(migration.ABORTDONE.IsTerminal(), jc.IsTrue)
 	c.Check(migration.REAPFAILED.IsTerminal(), jc.IsTrue)
 	c.Check(migration.DONE.IsTerminal(), jc.IsTrue)
 }

--- a/state/modelmigration_test.go
+++ b/state/modelmigration_test.go
@@ -99,6 +99,7 @@ func (s *ModelMigrationSuite) TestIdSequencesIncrement(c *gc.C) {
 		c.Assert(err, jc.ErrorIsNil)
 		checkIdAndAttempt(c, mig, attempt)
 		c.Check(mig.SetPhase(migration.ABORT), jc.ErrorIsNil)
+		c.Check(mig.SetPhase(migration.ABORTDONE), jc.ErrorIsNil)
 	}
 }
 
@@ -118,6 +119,7 @@ func (s *ModelMigrationSuite) TestIdSequencesIncrementOnlyWhenNecessary(c *gc.C)
 	// Now abort the migration and create another. The Id sequence
 	// should have only incremented by 1.
 	c.Assert(mig.SetPhase(migration.ABORT), jc.ErrorIsNil)
+	c.Assert(mig.SetPhase(migration.ABORTDONE), jc.ErrorIsNil)
 
 	mig, err = s.State2.CreateModelMigration(s.stdSpec)
 	c.Assert(err, jc.ErrorIsNil)
@@ -239,6 +241,7 @@ func (s *ModelMigrationSuite) TestGetsLatestAttempt(c *gc.C) {
 		c.Check(mig.Id(), gc.Equals, fmt.Sprintf("%s:%d", modelUUID, i))
 
 		c.Assert(mig.SetPhase(migration.ABORT), jc.ErrorIsNil)
+		c.Assert(mig.SetPhase(migration.ABORTDONE), jc.ErrorIsNil)
 	}
 }
 
@@ -323,6 +326,8 @@ func (s *ModelMigrationSuite) TestABORTCleanup(c *gc.C) {
 
 	s.clock.Advance(time.Millisecond)
 	c.Assert(mig.SetPhase(migration.ABORT), jc.ErrorIsNil)
+	s.clock.Advance(time.Millisecond)
+	c.Assert(mig.SetPhase(migration.ABORTDONE), jc.ErrorIsNil)
 
 	s.assertMigrationCleanedUp(c, mig)
 }
@@ -476,6 +481,8 @@ func (s *ModelMigrationSuite) TestWatchMigrationStatus(c *gc.C) {
 
 	// End it.
 	c.Assert(mig.SetPhase(migration.ABORT), jc.ErrorIsNil)
+	wc.AssertOneChange()
+	c.Assert(mig.SetPhase(migration.ABORTDONE), jc.ErrorIsNil)
 	wc.AssertOneChange()
 
 	// Start another.


### PR DESCRIPTION
Handle the initial watcher event where no migration may be present.

Use the new ABORTDONE phase. This allows distinguishing between
migrations that need aborting and those which have been aborted.

Don't attempt to reprocess previously completed/failed migrations.

Don't skip over the PRECHECK phase!

Don't use the NONE phase for signalling. Terminal phases no longer
have handler methods.

(Review request: http://reviews.vapour.ws/r/4431/)