### PR TITLE
provider/rackspace: lower-case region names

### DIFF
--- a/cloud/clouds_test.go
+++ b/cloud/clouds_test.go
@@ -49,13 +49,13 @@ func (s *cloudSuite) TestParseCloudsEndpointDenormalisation(c *gc.C) {
 	var regionNames []string
 	for _, region := range rackspace.Regions {
 		regionNames = append(regionNames, region.Name)
-		if region.Name == "LON" {
+		if region.Name == "lon" {
 			c.Assert(region.Endpoint, gc.Equals, "https://lon.identity.api.rackspacecloud.com/v2.0")
 		} else {
 			c.Assert(region.Endpoint, gc.Equals, "https://identity.api.rackspacecloud.com/v2.0")
 		}
 	}
-	c.Assert(regionNames, jc.SameContents, []string{"DFW", "ORD", "IAD", "LON", "SYD", "HKG"})
+	c.Assert(regionNames, jc.SameContents, []string{"dfw", "ord", "iad", "lon", "syd", "hkg"})
 }
 
 func (s *cloudSuite) TestParseCloudsAuthTypes(c *gc.C) {

--- a/cloud/fallback-public-cloud.yaml
+++ b/cloud/fallback-public-cloud.yaml
@@ -121,17 +121,17 @@ clouds:
     auth-types: [ access-key, userpass ]
     endpoint: https://identity.api.rackspacecloud.com/v2.0
     regions:
-      DFW:
+      dfw:
         endpoint: https://identity.api.rackspacecloud.com/v2.0
-      ORD:
+      ord:
         endpoint: https://identity.api.rackspacecloud.com/v2.0
-      IAD:
+      iad:
         endpoint: https://identity.api.rackspacecloud.com/v2.0
-      LON:
+      lon:
         endpoint: https://lon.identity.api.rackspacecloud.com/v2.0
-      SYD:
+      syd:
         endpoint: https://identity.api.rackspacecloud.com/v2.0
-      HKG:
+      hkg:
         endpoint: https://identity.api.rackspacecloud.com/v2.0
   joyent:
     type: joyent

--- a/cloud/fallback_public_cloud.go
+++ b/cloud/fallback_public_cloud.go
@@ -129,17 +129,17 @@ clouds:
     auth-types: [ access-key, userpass ]
     endpoint: https://identity.api.rackspacecloud.com/v2.0
     regions:
-      DFW:
+      dfw:
         endpoint: https://identity.api.rackspacecloud.com/v2.0
-      ORD:
+      ord:
         endpoint: https://identity.api.rackspacecloud.com/v2.0
-      IAD:
+      iad:
         endpoint: https://identity.api.rackspacecloud.com/v2.0
-      LON:
+      lon:
         endpoint: https://lon.identity.api.rackspacecloud.com/v2.0
-      SYD:
+      syd:
         endpoint: https://identity.api.rackspacecloud.com/v2.0
-      HKG:
+      hkg:
         endpoint: https://identity.api.rackspacecloud.com/v2.0
   joyent:
     type: joyent

--- a/provider/rackspace/export_test.go
+++ b/provider/rackspace/export_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func NewProvider(innerProvider environs.EnvironProvider) environs.EnvironProvider {
-	return environProvider{innerProvider}
+	return &environProvider{innerProvider}
 }
 
 func NewEnviron(innerEnviron environs.Environ) environs.Environ {

--- a/provider/rackspace/provider.go
+++ b/provider/rackspace/provider.go
@@ -4,7 +4,10 @@
 package rackspace
 
 import (
+	"strings"
+
 	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/config"
 )
 
 type environProvider struct {
@@ -12,3 +15,12 @@ type environProvider struct {
 }
 
 var providerInstance *environProvider
+
+// BootstrapConfig is specified in the EnvironProvider interface.
+func (p *environProvider) BootstrapConfig(args environs.BootstrapConfigParams) (*config.Config, error) {
+	// Rackspace regions are expected to be uppercase, but Juju
+	// stores and displays them in lowercase in the CLI. Ensure
+	// they're uppercase when they get to the Rackspace API.
+	args.CloudRegion = strings.ToUpper(args.CloudRegion)
+	return p.EnvironProvider.BootstrapConfig(args)
+}

--- a/provider/rackspace/provider_test.go
+++ b/provider/rackspace/provider_test.go
@@ -4,6 +4,7 @@
 package rackspace_test
 
 import (
+	"github.com/juju/testing"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/errors"
@@ -12,7 +13,6 @@ import (
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/provider/rackspace"
 	coretesting "github.com/juju/juju/testing"
-	"github.com/juju/testing"
 )
 
 type providerSuite struct {

--- a/provider/rackspace/provider_test.go
+++ b/provider/rackspace/provider_test.go
@@ -11,7 +11,8 @@ import (
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/provider/rackspace"
-	"github.com/juju/juju/testing"
+	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/testing"
 )
 
 type providerSuite struct {
@@ -30,71 +31,72 @@ func (s *providerSuite) TestValidate(c *gc.C) {
 	cfg, err := config.New(config.UseDefaults, map[string]interface{}{
 		"name":            "some-name",
 		"type":            "some-type",
-		"uuid":            testing.ModelTag.Id(),
-		"controller-uuid": testing.ModelTag.Id(),
+		"uuid":            coretesting.ModelTag.Id(),
+		"controller-uuid": coretesting.ModelTag.Id(),
 		"authorized-keys": "key",
 	})
 	c.Check(err, gc.IsNil)
 	_, err = s.provider.Validate(cfg, nil)
 	c.Check(err, gc.IsNil)
-	c.Check(s.innerProvider.Pop().name, gc.Equals, "Validate")
+	s.innerProvider.CheckCallNames(c, "Validate")
+}
+
+func (s *providerSuite) TestBootstrapConfig(c *gc.C) {
+	args := environs.BootstrapConfigParams{CloudRegion: "dfw"}
+	s.provider.BootstrapConfig(args)
+
+	expect := args
+	expect.CloudRegion = "DFW"
+	s.innerProvider.CheckCalls(c, []testing.StubCall{
+		{"BootstrapConfig", []interface{}{expect}},
+	})
 }
 
 type fakeProvider struct {
-	methodCalls []methodCall
-}
-
-func (p *fakeProvider) Push(name string, params ...interface{}) {
-	p.methodCalls = append(p.methodCalls, methodCall{name, params})
-}
-
-func (p *fakeProvider) Pop() methodCall {
-	m := p.methodCalls[0]
-	p.methodCalls = p.methodCalls[1:]
-	return m
+	testing.Stub
 }
 
 func (p *fakeProvider) Open(cfg *config.Config) (environs.Environ, error) {
-	p.Push("Open", cfg)
+	p.MethodCall(p, "Open", cfg)
 	return nil, nil
 }
 
 func (p *fakeProvider) RestrictedConfigAttributes() []string {
-	p.Push("RestrictedConfigAttributes")
+	p.MethodCall(p, "RestrictedConfigAttributes")
 	return nil
 }
 
 func (p *fakeProvider) PrepareForCreateEnvironment(cfg *config.Config) (*config.Config, error) {
-	p.Push("PrepareForCreateEnvironment", cfg)
+	p.MethodCall(p, "PrepareForCreateEnvironment", cfg)
 	return nil, nil
 }
 
 func (p *fakeProvider) BootstrapConfig(args environs.BootstrapConfigParams) (*config.Config, error) {
-	p.Push("BootstrapConfig", args)
+	p.MethodCall(p, "BootstrapConfig", args)
 	return nil, nil
 }
 
 func (p *fakeProvider) PrepareForBootstrap(ctx environs.BootstrapContext, cfg *config.Config) (environs.Environ, error) {
-	p.Push("PrepareForBootstrap", ctx, cfg)
+	p.MethodCall(p, "PrepareForBootstrap", ctx, cfg)
 	return nil, nil
 }
 
 func (p *fakeProvider) Validate(cfg, old *config.Config) (valid *config.Config, err error) {
-	p.Push("Validate", cfg, old)
+	p.MethodCall(p, "Validate", cfg, old)
 	return cfg, nil
 }
 
 func (p *fakeProvider) SecretAttrs(cfg *config.Config) (map[string]string, error) {
-	p.Push("SecretAttrs", cfg)
+	p.MethodCall(p, "SecretAttrs", cfg)
 	return nil, nil
 }
 
 func (p *fakeProvider) CredentialSchemas() map[cloud.AuthType]cloud.CredentialSchema {
-	p.Push("CredentialSchemas")
+	p.MethodCall(p, "CredentialSchemas")
 	return nil
 }
 
 func (p *fakeProvider) DetectCredentials() (*cloud.CloudCredential, error) {
-	p.Push("DetectCredentials")
+	p.MethodCall(p, "DetectCredentials")
 	return nil, errors.NotFoundf("credentials")
 }


### PR DESCRIPTION
Lower-case the region names in list-clouds and co.,
for consistency with other clouds. Due to exact-matching
in various bits of code, we upper-case the region again
when it gets to the rackspace provider code.

Fixes https://bugs.launchpad.net/juju-core/+bug/1563845

(Review request: http://reviews.vapour.ws/r/4434/)