### PR TITLE
(WIP): buildable sketch of fortress-mediated migration sync

### DIFF
--- a/api/migrationmaster/client.go
+++ b/api/migrationmaster/client.go
@@ -14,28 +14,11 @@ import (
 	"github.com/juju/juju/watcher"
 )
 
-// Client describes the client side API for the MigrationMaster facade
-// (used by the migration master worker).
-type Client interface {
-	// Watch returns a watcher which reports when a migration is
-	// active for the model associated with the API connection.
-	Watch() (watcher.NotifyWatcher, error)
-
-	// GetMigrationStatus returns the details and progress of the
-	// latest model migration.
-	GetMigrationStatus() (MigrationStatus, error)
-
-	// SetPhase updates the phase of the currently active model
-	// migration.
-	SetPhase(migration.Phase) error
-
-	// Export returns a serialized representation of the model
-	// associated with the API connection.
-	Export() ([]byte, error)
-}
-
 // MigrationStatus returns the details for a migration as needed by
 // the migration master worker.
+// XXX(fwereade): I see why it's not in core/migration, but it doesn't
+// quite feel like it belongs here either; or, for that matter, in any
+// other package that currently exists. Thoughts?
 type MigrationStatus struct {
 	ModelUUID  string
 	Attempt    int
@@ -44,17 +27,17 @@ type MigrationStatus struct {
 }
 
 // NewClient returns a new Client based on an existing API connection.
-func NewClient(caller base.APICaller) Client {
-	return &client{base.NewFacadeCaller(caller, "MigrationMaster")}
+func NewClient(caller base.APICaller) *Client {
+	return &Client{base.NewFacadeCaller(caller, "MigrationMaster")}
 }
 
-// client implements Client.
-type client struct {
+type Client struct {
 	caller base.FacadeCaller
 }
 
-// Watch implements Client.
-func (c *client) Watch() (watcher.NotifyWatcher, error) {
+// Watch returns a watcher which reports when a migration is active for
+// the model associated with the API connection.
+func (c *Client) Watch() (watcher.NotifyWatcher, error) {
 	var result params.NotifyWatchResult
 	err := c.caller.FacadeCall("Watch", nil, &result)
 	if err != nil {
@@ -67,8 +50,9 @@ func (c *client) Watch() (watcher.NotifyWatcher, error) {
 	return w, nil
 }
 
-// GetMigrationStatus implements Client.
-func (c *client) GetMigrationStatus() (MigrationStatus, error) {
+// GetMigrationStatus returns the details and progress of the latest
+// model migration.
+func (c *Client) GetMigrationStatus() (MigrationStatus, error) {
 	var empty MigrationStatus
 	var status params.FullMigrationStatus
 	err := c.caller.FacadeCall("GetMigrationStatus", nil, &status)
@@ -111,16 +95,17 @@ func (c *client) GetMigrationStatus() (MigrationStatus, error) {
 	}, nil
 }
 
-// SetPhase implements Client.
-func (c *client) SetPhase(phase migration.Phase) error {
+// SetPhase updates the phase of the currently active model migration.
+func (c *Client) SetPhase(phase migration.Phase) error {
 	args := params.SetMigrationPhaseArgs{
 		Phase: phase.String(),
 	}
 	return c.caller.FacadeCall("SetPhase", args, nil)
 }
 
-// Export implements Client.
-func (c *client) Export() ([]byte, error) {
+// Export returns a serialized representation of the model associated
+// with the API connection.
+func (c *Client) Export() ([]byte, error) {
 	var serialized params.SerializedModel
 	err := c.caller.FacadeCall("Export", nil, &serialized)
 	if err != nil {

--- a/api/migrationminion/client.go
+++ b/api/migrationminion/client.go
@@ -12,27 +12,18 @@ import (
 	"github.com/juju/juju/watcher"
 )
 
-// Client describes the client side API for the MigrationMinion facade
-// (used by the migration minion worker).
-type Client interface {
-	// Watch returns a watcher which reports when the status changes
-	// for the migration for the model associated with the API
-	// connection.
-	Watch() (watcher.MigrationStatusWatcher, error)
-}
-
 // NewClient returns a new Client based on an existing API connection.
-func NewClient(caller base.APICaller) Client {
-	return &client{base.NewFacadeCaller(caller, "MigrationMinion")}
+func NewClient(caller base.APICaller) *Client {
+	return &Client{base.NewFacadeCaller(caller, "MigrationMinion")}
 }
 
-// client implements Client.
-type client struct {
+// Client exposes migration status for an API connection's model.
+type Client struct {
 	caller base.FacadeCaller
 }
 
-// Watch implements Client.
-func (c *client) Watch() (watcher.MigrationStatusWatcher, error) {
+// Watch returns a watcher that sends migration status updates.
+func (c *Client) Watch() (watcher.MigrationStatusWatcher, error) {
 	var result params.NotifyWatchResult
 	err := c.caller.FacadeCall("Watch", nil, &result)
 	if err != nil {

--- a/cmd/jujud/agent/common/migration.go
+++ b/cmd/jujud/agent/common/migration.go
@@ -1,0 +1,99 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package common
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/dependency"
+	"github.com/juju/juju/worker/fortress"
+)
+
+// Spec expresses a convenient set of tweaks to a dependency.Manifold.
+// It has a single Decorate method, which returns a new Manifold with
+// the following modifications:
+type Spec struct {
+
+	// Occupy, if empty, is ignored. Otherwise it's added to Inputs,
+	// if not already present, and the Start func is wrapped to
+	// invoke the worker only if Occupy points to a fortress.Guest;
+	// and both to ensure that the worker can only run while that
+	// fortress is unlocked, and that the fortress cannot be locked
+	// down while the worker is running.
+	//
+	// NOTE: this effectively involves acquiring a lock, and demands
+	// exactly as much care and attention as any other locking
+	// operation. Lock acquisition will be a decorated manifold's
+	// last act before starting its worker -- we will make a good
+	// faith attempt to minimise the time it's held for -- but if
+	// you start chaining Specs that Occupy, you are inviting
+	// deadlock vampires into the house and it is guaranteed to end
+	// badly.
+	Occupy string
+
+	// Flags are each added to Inputs, if not already present, and
+	// the Start func is wrapped to only run if each name points to
+	// a dependency.Flag() whose Check() succeeds.
+	Flags []string
+
+	// Filter unconditionally sets a single error filter for the
+	// manifold. They could plausibly be chained instead, but use
+	// of multiple filters is likely to signify that you're doing
+	// something wrong anyway: the hosting Engine has an overly-
+	// enthusiastic IsFatal, and/or the responsibility for stopping
+	// the Engine is too widely distributed across its manifolds.
+	Filter dependency.FilterFunc
+}
+
+// Decorate returns a copy of base with changes made according to spec.
+func (spec Spec) Decorate(base dependency.Manifold) dependency.Manifold {
+	manifold := base
+	if spec.Occupy != "" {
+		manifold.Inputs = maybeAdd(manifold.Inputs, spec.Occupy)
+		manifold.Start = occupyStart(manifold.Start, spec.Occupy)
+	}
+	for _, name := range spec.Flags {
+		manifold.Inputs = maybeAdd(manifold.Inputs, name)
+		manifold.Start = flagStart(manifold.Start, name)
+	}
+	manifold.Filter = spec.Filter
+	return manifold
+}
+
+func maybeAdd(inputs []string, add string) []string {
+	for _, input := range inputs {
+		if input == add {
+			return inputs
+		}
+	}
+	result := make([]string, len(inputs)+1)
+	copy(result, inputs)
+	return append(result, add)
+}
+
+func flagStart(inner dependency.StartFunc, name string) dependency.StartFunc {
+	return func(context dependency.Context) (worker.Worker, error) {
+		var flag dependency.Flag
+		if err := context.Get(name, &flag); err != nil {
+			return nil, errors.Trace(err)
+		}
+		if !flag.Check() {
+			return nil, dependency.ErrMissing
+		}
+		return inner(context)
+	}
+}
+
+func occupyStart(inner dependency.StartFunc, name string) dependency.StartFunc {
+	return func(context dependency.Context) (worker.Worker, error) {
+		var guest fortress.Guest
+		if err := context.Get(name, &guest); err != nil {
+			return nil, errors.Trace(err)
+		}
+		start := func() (worker.Worker, error) {
+			return inner(context)
+		}
+		return fortress.Occupy(guest, start, context.Abort())
+	}
+}

--- a/cmd/jujud/agent/unit/manifolds.go
+++ b/cmd/jujud/agent/unit/manifolds.go
@@ -11,6 +11,7 @@ import (
 
 	coreagent "github.com/juju/juju/agent"
 	msapi "github.com/juju/juju/api/meterstatus"
+	"github.com/juju/juju/cmd/jujud/agent/common"
 	"github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/agent"
 	"github.com/juju/juju/worker/apiaddressupdater"
@@ -26,6 +27,7 @@ import (
 	"github.com/juju/juju/worker/metrics/collect"
 	"github.com/juju/juju/worker/metrics/sender"
 	"github.com/juju/juju/worker/metrics/spool"
+	"github.com/juju/juju/worker/migrationflag"
 	"github.com/juju/juju/worker/migrationminion"
 	"github.com/juju/juju/worker/proxyupdater"
 	"github.com/juju/juju/worker/retrystrategy"
@@ -77,20 +79,20 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 		// The agent manifold references the enclosing agent, and is the
 		// foundation stone on which most other manifolds ultimately depend.
 		// (Currently, that is "all manifolds", but consider a shared clock.)
-		AgentName: agent.Manifold(config.Agent),
+		agentName: agent.Manifold(config.Agent),
 
 		// The machine lock manifold is a thin concurrent wrapper around an
 		// FSLock in an agreed location. We expect it to be replaced with an
 		// in-memory lock when the unit agent moves into the machine agent.
-		MachineLockName: machinelock.Manifold(machinelock.ManifoldConfig{
-			AgentName: AgentName,
+		machineLockName: machinelock.Manifold(machinelock.ManifoldConfig{
+			AgentName: agentName,
 		}),
 
 		// The api-config-watcher manifold monitors the API server
 		// addresses in the agent config and bounces when they
 		// change. It's required as part of model migrations.
-		APIConfigWatcherName: apiconfigwatcher.Manifold(apiconfigwatcher.ManifoldConfig{
-			AgentName:          AgentName,
+		apiConfigWatcherName: apiconfigwatcher.Manifold(apiconfigwatcher.ManifoldConfig{
+			AgentName:          agentName,
 			AgentConfigChanged: config.AgentConfigChanged,
 		}),
 
@@ -99,9 +101,9 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 		// select their own desired facades. It will be interesting to see
 		// how this works when we consolidate the agents; might be best to
 		// handle the auth changes server-side..?
-		APICallerName: apicaller.Manifold(apicaller.ManifoldConfig{
-			AgentName:            AgentName,
-			APIConfigWatcherName: APIConfigWatcherName,
+		apiCallerName: apicaller.Manifold(apicaller.ManifoldConfig{
+			AgentName:            agentName,
+			APIConfigWatcherName: apiConfigWatcherName,
 			APIOpen:              apicaller.APIOpen,
 			NewConnection:        apicaller.ScaryConnect,
 			Filter:               connectFilter,
@@ -110,36 +112,9 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 		// The log sender is a leaf worker that sends log messages to some
 		// API server, when configured so to do. We should only need one of
 		// these in a consolidated agent.
-		LogSenderName: logsender.Manifold(logsender.ManifoldConfig{
-			APICallerName: APICallerName,
+		logSenderName: logsender.Manifold(logsender.ManifoldConfig{
+			APICallerName: apiCallerName,
 			LogSource:     config.LogSource,
-		}),
-
-		// The logging config updater is a leaf worker that indirectly
-		// controls the messages sent via the log sender or rsyslog,
-		// according to changes in environment config. We should only need
-		// one of these in a consolidated agent.
-		LoggingConfigUpdaterName: logger.Manifold(logger.ManifoldConfig{
-			AgentName:     AgentName,
-			APICallerName: APICallerName,
-		}),
-
-		// The api address updater is a leaf worker that rewrites agent config
-		// as the controller addresses change. We should only need one of
-		// these in a consolidated agent.
-		APIAddressUpdaterName: apiaddressupdater.Manifold(apiaddressupdater.ManifoldConfig{
-			AgentName:     AgentName,
-			APICallerName: APICallerName,
-		}),
-
-		// The proxy config updater is a leaf worker that sets http/https/apt/etc
-		// proxy settings.
-		// TODO(fwereade): timing of this is suspicious. There was superstitious
-		// code trying to run this early; if that ever helped, it was only by
-		// coincidence. Probably we ought to be making components that might
-		// need proxy config into explicit dependencies of the proxy updater...
-		ProxyConfigUpdaterName: proxyupdater.Manifold(proxyupdater.ManifoldConfig{
-			APICallerName: APICallerName,
 		}),
 
 		// The upgrader is a leaf worker that returns a specific error type
@@ -148,106 +123,164 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 		// need one of these in a consolidated agent, but we'll need to be
 		// careful about behavioural differences, and interactions with the
 		// upgradesteps worker.
-		UpgraderName: upgrader.Manifold(upgrader.ManifoldConfig{
-			AgentName:     AgentName,
-			APICallerName: APICallerName,
+		upgraderName: upgrader.Manifold(upgrader.ManifoldConfig{
+			AgentName:     agentName,
+			APICallerName: apiCallerName,
 		}),
 
-		// The migration minion handles the agent side aspects of model migrations.
-		MigrationMinionName: migrationminion.Manifold(migrationminion.ManifoldConfig{
-			AgentName:     AgentName,
-			APICallerName: APICallerName,
+		// The migration fortress synchronises the migration
+		// minion worker (as a Guard) with all workers that
+		// might interfere with migration (basically, all other
+		// workers).
+		migrationFortressName: fortress.Manifold(),
+
+		// The migration minion handles the agent-side aspects
+		// of model migrations.
+		migrationMinionName: migrationminion.Manifold(migrationminion.ManifoldConfig{
+			AgentName:     agentName,
+			APICallerName: apiCallerName,
+			FortressName:  migrationFortressName,
 		}),
+
+		// The migration-inactive flag is used to signal to the
+		// bulk of manifolds that they are allowed to run and
+		// should attempt to do so.
+		migrationInactiveFlagName: migrationflag.Manifold(migrationflag.ManifoldConfig{
+			APICallerName: apiCallerName,
+			Check:         migrationflag.IsNone,
+			NewFacade:     migrationflag.NewFacade,
+			NewWorker:     migrationflag.NewWorker,
+		}),
+
+		// The logging config updater is a leaf worker that indirectly
+		// controls the messages sent via the log sender or rsyslog,
+		// according to changes in environment config. We should only need
+		// one of these in a consolidated agent.
+		loggingConfigUpdaterName: ifNotMigrating(logger.Manifold(logger.ManifoldConfig{
+			AgentName:     agentName,
+			APICallerName: apiCallerName,
+		})),
+
+		// The api address updater is a leaf worker that rewrites agent config
+		// as the controller addresses change. We should only need one of
+		// these in a consolidated agent.
+		apiAddressUpdaterName: ifNotMigrating(apiaddressupdater.Manifold(apiaddressupdater.ManifoldConfig{
+			AgentName:     agentName,
+			APICallerName: apiCallerName,
+		})),
+
+		// The proxy config updater is a leaf worker that sets http/https/apt/etc
+		// proxy settings.
+		// TODO(fwereade): timing of this is suspicious. There was superstitious
+		// code trying to run this early; if that ever helped, it was only by
+		// coincidence. Probably we ought to be making components that might
+		// need proxy config into explicit dependencies of the proxy updater...
+		proxyConfigUpdaterName: ifNotMigrating(proxyupdater.Manifold(proxyupdater.ManifoldConfig{
+			APICallerName: apiCallerName,
+		})),
+
+		// The charmdir resource coordinates whether the charm directory is
+		// available or not; after 'start' hook and before 'stop' hook
+		// executes, and not during upgrades.
+		charmDirName: fortress.Manifold(),
 
 		// The leadership tracker attempts to secure and retain leadership of
 		// the unit's service, and is consulted on such matters by the
 		// uniter. As it stannds today, we'll need one per unit in a
 		// consolidated agent.
-		LeadershipTrackerName: leadership.Manifold(leadership.ManifoldConfig{
-			AgentName:           AgentName,
-			APICallerName:       APICallerName,
+		leadershipTrackerName: ifNotMigrating(leadership.Manifold(leadership.ManifoldConfig{
+			AgentName:           agentName,
+			APICallerName:       apiCallerName,
 			LeadershipGuarantee: config.LeadershipGuarantee,
-		}),
+		})),
 
 		// HookRetryStrategy uses a retrystrategy worker to get a
 		// retry strategy that will be used by the uniter to run its hooks.
-		HookRetryStrategyName: retrystrategy.Manifold(retrystrategy.ManifoldConfig{
-			AgentName:     AgentName,
-			APICallerName: APICallerName,
+		hookRetryStrategyName: ifNotMigrating(retrystrategy.Manifold(retrystrategy.ManifoldConfig{
+			AgentName:     agentName,
+			APICallerName: apiCallerName,
 			NewFacade:     retrystrategy.NewFacade,
 			NewWorker:     retrystrategy.NewRetryStrategyWorker,
-		}),
+		})),
 
 		// The uniter installs charms; manages the unit's presence in its
 		// relations; creates suboordinate units; runs all the hooks; sends
 		// metrics; etc etc etc. We expect to break it up further in the
 		// coming weeks, and to need one per unit in a consolidated agent
 		// (and probably one for each component broken out).
-		UniterName: uniter.Manifold(uniter.ManifoldConfig{
-			AgentName:             AgentName,
-			APICallerName:         APICallerName,
-			LeadershipTrackerName: LeadershipTrackerName,
-			MachineLockName:       MachineLockName,
-			CharmDirName:          CharmDirName,
-			HookRetryStrategyName: HookRetryStrategyName,
-		}),
+		uniterName: ifNotMigrating(uniter.Manifold(uniter.ManifoldConfig{
+			AgentName:             agentName,
+			APICallerName:         apiCallerName,
+			LeadershipTrackerName: leadershipTrackerName,
+			MachineLockName:       machineLockName,
+			CharmDirName:          charmDirName,
+			HookRetryStrategyName: hookRetryStrategyName,
+		})),
 
 		// TODO (mattyw) should be added to machine agent.
-		MetricSpoolName: spool.Manifold(spool.ManifoldConfig{
-			AgentName: AgentName,
-		}),
-
-		// The charmdir resource coordinates whether the charm directory is
-		// available or not; after 'start' hook and before 'stop' hook
-		// executes, and not during upgrades.
-		CharmDirName: fortress.Manifold(),
+		metricSpoolName: ifNotMigrating(spool.Manifold(spool.ManifoldConfig{
+			AgentName: agentName,
+		})),
 
 		// The metric collect worker executes the collect-metrics hook in a
 		// restricted context that can safely run concurrently with other hooks.
-		MetricCollectName: collect.Manifold(collect.ManifoldConfig{
-			AgentName:       AgentName,
-			MetricSpoolName: MetricSpoolName,
-			CharmDirName:    CharmDirName,
-		}),
+		metricCollectName: ifNotMigrating(collect.Manifold(collect.ManifoldConfig{
+			AgentName:       agentName,
+			MetricSpoolName: metricSpoolName,
+			CharmDirName:    charmDirName,
+		})),
 
 		// The meter status worker executes the meter-status-changed hook when it detects
 		// that the meter status has changed.
-		MeterStatusName: meterstatus.Manifold(meterstatus.ManifoldConfig{
-			AgentName:                AgentName,
-			APICallerName:            APICallerName,
-			MachineLockName:          MachineLockName,
+		meterStatusName: ifNotMigrating(meterstatus.Manifold(meterstatus.ManifoldConfig{
+			AgentName:                agentName,
+			APICallerName:            apiCallerName,
+			MachineLockName:          machineLockName,
 			NewHookRunner:            meterstatus.NewHookRunner,
 			NewMeterStatusAPIClient:  msapi.NewClient,
 			NewConnectedStatusWorker: meterstatus.NewConnectedStatusWorker,
 			NewIsolatedStatusWorker:  meterstatus.NewIsolatedStatusWorker,
-		}),
+		})),
 
 		// The metric sender worker periodically sends accumulated metrics to the controller.
-		MetricSenderName: sender.Manifold(sender.ManifoldConfig{
-			AgentName:       AgentName,
-			APICallerName:   APICallerName,
-			MetricSpoolName: MetricSpoolName,
-		}),
+		metricSenderName: ifNotMigrating(sender.Manifold(sender.ManifoldConfig{
+			AgentName:       agentName,
+			APICallerName:   apiCallerName,
+			MetricSpoolName: metricSpoolName,
+		})),
 	}
 }
 
+var ifNotMigrating = common.Spec{
+	Flags: []string{
+		migrationInactiveFlagName,
+	},
+	Occupy: migrationFortressName,
+}.Decorate
+
 const (
-	AgentName                = "agent"
-	APIAddressUpdaterName    = "api-address-updater"
-	APICallerName            = "api-caller"
-	LeadershipTrackerName    = "leadership-tracker"
-	LoggingConfigUpdaterName = "logging-config-updater"
-	LogSenderName            = "log-sender"
-	MachineLockName          = "machine-lock"
-	ProxyConfigUpdaterName   = "proxy-config-updater"
-	UniterName               = "uniter"
-	UpgraderName             = "upgrader"
-	MetricSpoolName          = "metric-spool"
-	CharmDirName             = "charm-dir"
-	MeterStatusName          = "meter-status"
-	MetricCollectName        = "metric-collect"
-	MetricSenderName         = "metric-sender"
-	APIConfigWatcherName     = "api-config-watcher"
-	MigrationMinionName      = "migration-minion"
-	HookRetryStrategyName    = "hook-retry-strategy"
+	agentName            = "agent"
+	machineLockName      = "machine-lock"
+	apiConfigWatcherName = "api-config-watcher"
+	apiCallerName        = "api-caller"
+	logSenderName        = "log-sender"
+	upgraderName         = "upgrader"
+
+	migrationFortressName     = "migration-fortress"
+	migrationMinionName       = "migration-minion"
+	migrationInactiveFlagName = "migration-inactive-flag"
+
+	apiAddressUpdaterName    = "api-address-updater"
+	loggingConfigUpdaterName = "logging-config-updater"
+	proxyConfigUpdaterName   = "proxy-config-updater"
+
+	charmDirName          = "charm-dir"
+	hookRetryStrategyName = "hook-retry-strategy"
+	leadershipTrackerName = "leadership-tracker"
+	uniterName            = "uniter"
+
+	metricSpoolName   = "metric-spool"
+	meterStatusName   = "meter-status"
+	metricCollectName = "metric-collect"
+	metricSenderName  = "metric-sender"
 )

--- a/worker/migrationflag/shim.go
+++ b/worker/migrationflag/shim.go
@@ -1,0 +1,26 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package migrationflag
+
+import (
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/api/migrationflag"
+	"github.com/juju/juju/api/watcher"
+	"github.com/juju/juju/worker"
+)
+
+func NewFacade(apiCaller base.APICaller) (Facade, error) {
+	facade := migrationflag.NewFacade(apiCaller, watcher.NewNotifyWatcher)
+	return facade, nil
+}
+
+func NewWorker(config Config) (worker.Worker, error) {
+	worker, err := New(config)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return worker, nil
+}

--- a/worker/migrationflag/worker.go
+++ b/worker/migrationflag/worker.go
@@ -12,6 +12,19 @@ import (
 	"github.com/juju/juju/worker/catacomb"
 )
 
+// Predicate defines a predicate.
+type Predicate func(migration.Phase) bool
+
+// IsNone is a predicate.
+func IsNone(phase migration.Phase) bool {
+	return phase == migration.NONE
+}
+
+// IsNotNone is a predicate.
+func IsNotNone(phase migration.Phase) bool {
+	return phase != migration.NONE
+}
+
 // ErrChanged indicates that a Worker has stopped because its
 // Check result is no longer valid.
 var ErrChanged = errors.New("migration flag value changed")
@@ -26,7 +39,7 @@ type Facade interface {
 type Config struct {
 	Facade Facade
 	Model  string
-	Check  func(migration.Phase) bool
+	Check  Predicate
 }
 
 // Validate returns an error if the config cannot be expected to

--- a/worker/migrationmaster/shim.go
+++ b/worker/migrationmaster/shim.go
@@ -1,0 +1,24 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package migrationmaster
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/api/migrationmaster"
+	"github.com/juju/juju/worker"
+)
+
+func NewFacade(apiCaller base.APICaller) (Facade, error) {
+	facade := migrationmaster.NewClient(apiCaller)
+	return facade, nil
+}
+
+func NewWorker(config Config) (worker.Worker, error) {
+	worker, err := New(config)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return worker, nil
+}

--- a/worker/migrationminion/manifold.go
+++ b/worker/migrationminion/manifold.go
@@ -4,27 +4,63 @@
 package migrationminion
 
 import (
+	"github.com/juju/errors"
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/api/base"
-	minionapi "github.com/juju/juju/api/migrationminion"
 	"github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/dependency"
-	"github.com/juju/juju/worker/util"
+	"github.com/juju/juju/worker/fortress"
 )
 
 // ManifoldConfig defines the names of the manifolds on which a
 // Manifold will depend.
-type ManifoldConfig util.AgentApiManifoldConfig
+type ManifoldConfig struct {
+	AgentName     string
+	APICallerName string
+	FortressName  string
+
+	NewFacade func(base.APICaller) (Facade, error)
+	NewWorker func(Config) (worker.Worker, error)
+}
+
+func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, error) {
+	var agent agent.Agent
+	if err := context.Get(config.AgentName, &agent); err != nil {
+		return nil, errors.Trace(err)
+	}
+	var apiCaller base.APICaller
+	if err := context.Get(config.APICallerName, &apiCaller); err != nil {
+		return nil, errors.Trace(err)
+	}
+	var guard fortress.Guard
+	if err := context.Get(config.FortressName, &guard); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	facade, err := config.NewFacade(apiCaller)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	worker, err := config.NewWorker(Config{
+		Agent:  agent,
+		Facade: facade,
+		Guard:  guard,
+	})
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return worker, nil
+}
 
 // Manifold returns a dependency manifold that runs the migration
 // worker.
 func Manifold(config ManifoldConfig) dependency.Manifold {
-	typedConfig := util.AgentApiManifoldConfig(config)
-	return util.AgentApiManifold(typedConfig, newWorker)
-}
-
-// newWorker is a shim to allow New to work with AgentApiManifold.
-func newWorker(a agent.Agent, apiCaller base.APICaller) (worker.Worker, error) {
-	client := minionapi.NewClient(apiCaller)
-	return New(client, a)
+	return dependency.Manifold{
+		Inputs: []string{
+			config.AgentName,
+			config.APICallerName,
+			config.FortressName,
+		},
+		Start: config.start,
+	}
 }

--- a/worker/migrationminion/shim.go
+++ b/worker/migrationminion/shim.go
@@ -1,0 +1,25 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package migrationminion
+
+import (
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/api/migrationminion"
+	"github.com/juju/juju/worker"
+)
+
+func NewFacade(apiCaller base.APICaller) (Facade, error) {
+	facade := migrationminion.NewClient(apiCaller)
+	return facade, nil
+}
+
+func NewWorker(config Config) (worker.Worker, error) {
+	worker, err := New(config)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return worker, nil
+}

--- a/worker/migrationminion/worker.go
+++ b/worker/migrationminion/worker.go
@@ -8,21 +8,49 @@ import (
 	"github.com/juju/loggo"
 
 	"github.com/juju/juju/agent"
-	minionapi "github.com/juju/juju/api/migrationminion"
 	"github.com/juju/juju/core/migration"
 	"github.com/juju/juju/network"
-	"github.com/juju/juju/worker"
+	"github.com/juju/juju/watcher"
 	"github.com/juju/juju/worker/catacomb"
+	"github.com/juju/juju/worker/fortress"
 )
 
 var logger = loggo.GetLogger("juju.worker.migrationminion")
 
+type Facade interface {
+	// Watch returns a watcher which reports when the status changes
+	// for the migration for the model associated with the API
+	// connection.
+	Watch() (watcher.MigrationStatusWatcher, error)
+}
+
+type Config struct {
+	Agent  agent.Agent
+	Facade Facade
+	Guard  fortress.Guard
+}
+
+func (config Config) Validate() error {
+	if config.Agent == nil {
+		return errors.NotValidf("nil Agent")
+	}
+	if config.Facade == nil {
+		return errors.NotValidf("nil Facade")
+	}
+	if config.Guard == nil {
+		return errors.NotValidf("nil Guard")
+	}
+	return nil
+}
+
 // New starts a migration minion worker using the supplied migration
 // minion API facade.
-func New(client minionapi.Client, a agent.Agent) (worker.Worker, error) {
-	w := &migrationMinion{
-		client: client,
-		agent:  a,
+func New(config Config) (*Minion, error) {
+	if err := config.Validate(); err != nil {
+		return nil, errors.Trace(err)
+	}
+	w := &Minion{
+		config: config,
 	}
 	err := catacomb.Invoke(catacomb.Plan{
 		Site: &w.catacomb,
@@ -34,31 +62,29 @@ func New(client minionapi.Client, a agent.Agent) (worker.Worker, error) {
 	return w, nil
 }
 
-type migrationMinion struct {
+type Minion struct {
 	catacomb catacomb.Catacomb
-	client   minionapi.Client
-	agent    agent.Agent
+	config   Config
 }
 
 // Kill implements worker.Worker.
-func (w *migrationMinion) Kill() {
+func (w *Minion) Kill() {
 	w.catacomb.Kill(nil)
 }
 
 // Wait implements worker.Worker.
-func (w *migrationMinion) Wait() error {
+func (w *Minion) Wait() error {
 	return w.catacomb.Wait()
 }
 
-func (w *migrationMinion) loop() error {
-	watcher, err := w.client.Watch()
+func (w *Minion) loop() error {
+	watcher, err := w.config.Facade.Watch()
 	if err != nil {
 		return errors.Annotate(err, "setting up watcher")
 	}
 	if err := w.catacomb.Add(watcher); err != nil {
 		return errors.Trace(err)
 	}
-
 	for {
 		select {
 		case <-w.catacomb.Dying():
@@ -67,41 +93,70 @@ func (w *migrationMinion) loop() error {
 			if !ok {
 				return errors.New("watcher channel closed")
 			}
-
-			logger.Infof("migration phase is now: %s", status.Phase)
-			switch status.Phase {
-			case migration.QUIESCE:
-				// TODO(mjs) - once Will's stable mode work comes
-				// together this worker will only start up when a
-				// migration is active. Here the minion should report
-				// to the controller that it is running so that the
-				// migration can progress to READONLY.
-			case migration.VALIDATION:
-				// TODO(mjs) - check connection to the target
-				// controller here and report success/failure.
-			case migration.SUCCESS:
-				err := w.doSUCCESS(status.TargetAPIAddrs, status.TargetCACert)
-				if err != nil {
-					return errors.Trace(err)
-				}
-			case migration.ABORT:
-				// TODO(mjs) - exit here once Will's stable mode work
-				// comes together. The minion is done if these phases
-				// are reached.
-			default:
-				// The minion doesn't need to do anything for other
-				// migration phases.
+			if err := w.handle(status); err != nil {
+				return errors.Trace(err)
 			}
 		}
 	}
 }
 
-func (w *migrationMinion) doSUCCESS(targetAddrs []string, caCert string) error {
+func (w *Minion) handle(status watcher.MigrationStatus) error {
+	logger.Infof("migration phase is now: %s", status.Phase)
+	if status.Phase == migration.NONE {
+		return w.config.Guard.Unlock()
+	}
+
+	logger.Debugf("waiting for fortress...")
+	err := w.config.Guard.Lockdown(w.catacomb.Dying())
+	if errors.Cause(err) == fortress.ErrAborted {
+		return w.catacomb.ErrDying()
+	} else if err != nil {
+		return errors.Trace(err)
+	}
+
+	// If we get here, we know that a migration is active *and* that
+	// none of the workers that use the migration fortress can be
+	// running.
+	//
+	// XXX(fwereade) We should be a little bit concerned that the
+	// status may now potentially be minutes out of date, though.
+	// AFAICT it won't cause specific problems as currently
+	// designed, but it seems this is maybe another reason to prefer
+	// separation of notification and data? A single Phase() call at
+	// the start of the func, and a more-detailed Status() call when
+	// we know the phase is interesting *and* have waited long
+	// enough to grab exclusivity, feels a bit cleaner. Thoughts?
+	logger.Debugf("fortress locked down")
+	switch status.Phase {
+	case migration.QUIESCE:
+		// TODO(mjs) - Here the minion should report to the
+		// controller that it is running so that the migration
+		// can progress to READONLY.
+	case migration.VALIDATION:
+		// TODO(mjs) - check connection to the target
+		// controller here and report success/failure.
+	case migration.SUCCESS:
+		err := w.doSUCCESS(status.TargetAPIAddrs, status.TargetCACert)
+		if err != nil {
+			return errors.Trace(err)
+		}
+	case migration.ABORT:
+		// TODO(mjs) - exit here once Will's stable mode work
+		// comes together. The minion is done if these phases
+		// are reached.
+	default:
+		// The minion doesn't need to do anything for other
+		// migration phases.
+	}
+	return nil
+}
+
+func (w *Minion) doSUCCESS(targetAddrs []string, caCert string) error {
 	hps, err := apiAddrsToHostPorts(targetAddrs)
 	if err != nil {
 		return errors.Annotate(err, "converting API addresses")
 	}
-	err = w.agent.ChangeConfig(func(conf agent.ConfigSetter) error {
+	err = w.config.Agent.ChangeConfig(func(conf agent.ConfigSetter) error {
 		conf.SetAPIHostPorts(hps)
 		conf.SetCACert(caCert)
 		return nil


### PR DESCRIPTION
entirely untested; lightly documented; has a number of XXX comments; still worth discussing.

changes were driven by those in cmd/jujud/agent/* packages; each Manifolds now runs a set of [migration-fortress, migration-<worker>, migration-inactive-flag], in which:

  * migration-fortress starts out locked, as usual
  * migration-<worker> runs constantly, doing nothing until it sees a non-NONE phase, and then locking down migration-fortress
  * migration-inactive-flag is a dependency for migration-inconvenient workers (for easy Kill()ing)
  * the aforementioned workers are run by Occupy()ing migration-fortress (for synchronisation)

...such that, all in all, migration-<worker> effectively gets to inspect the world before anyone else does, and will only unlock the fortress once it knows no migration is active. That's the idea, anyway; I'm sure that it's possible for migration-<worker> and migration-inactive-flag to be out of sync at times, but I'm *pretty* sure that doesn't have any ill effects.

This involved a couple of ham-fisted changes to the migration-<worker> implementations; would particularly appreciate thoughts on issues raised therein.

several packages had their main types exported, and their declared interfaces dropped or moved; a few workers grew Config structs; and the unit/ package had a bunch of consts unexported; sorry for the noise.

(Review request: http://reviews.vapour.ws/r/4437/)