### PR TITLE
Store the charm channel in the DB.

### DIFF
--- a/apiserver/service/service.go
+++ b/apiserver/service/service.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/loggo"
 	"github.com/juju/names"
 	"gopkg.in/juju/charm.v6-unstable"
+	csparams "gopkg.in/juju/charmrepo.v2-unstable/csclient/params"
 	goyaml "gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/apiserver/common"
@@ -161,6 +162,9 @@ func deployService(st *state.State, owner string, args params.ServiceDeploy) err
 		return errors.Trace(err)
 	}
 
+	// TODO(ericsnow) Use args.Channel once params.ServiceDeploy has the field.
+	channel := csparams.StableChannel
+
 	_, err = jjj.DeployService(st,
 		jjj.DeployServiceParams{
 			ServiceName: args.ServiceName,
@@ -168,6 +172,7 @@ func deployService(st *state.State, owner string, args params.ServiceDeploy) err
 			// TODO(dfc) ServiceOwner should be a tag
 			ServiceOwner:     owner,
 			Charm:            ch,
+			Channel:          channel,
 			NumUnits:         args.NumUnits,
 			ConfigSettings:   settings,
 			Constraints:      args.Constraints,

--- a/core/description/interfaces.go
+++ b/core/description/interfaces.go
@@ -215,6 +215,7 @@ type Service interface {
 	Series() string
 	Subordinate() bool
 	CharmURL() string
+	Channel() string
 	CharmModifiedVersion() int
 	ForceCharm() bool
 	Exposed() bool

--- a/core/description/service.go
+++ b/core/description/service.go
@@ -23,6 +23,7 @@ type service struct {
 	Series_               string `yaml:"series"`
 	Subordinate_          bool   `yaml:"subordinate,omitempty"`
 	CharmURL_             string `yaml:"charm-url"`
+	Channel_              string `yaml:"cs-channel"`
 	CharmModifiedVersion_ int    `yaml:"charm-mod-version"`
 
 	// ForceCharm is true if an upgrade charm is forced.
@@ -59,6 +60,7 @@ type ServiceArgs struct {
 	Series               string
 	Subordinate          bool
 	CharmURL             string
+	Channel              string
 	CharmModifiedVersion int
 	ForceCharm           bool
 	Exposed              bool
@@ -77,6 +79,7 @@ func newService(args ServiceArgs) *service {
 		Series_:               args.Series,
 		Subordinate_:          args.Subordinate,
 		CharmURL_:             args.CharmURL,
+		Channel_:              args.Channel,
 		CharmModifiedVersion_: args.CharmModifiedVersion,
 		ForceCharm_:           args.ForceCharm,
 		Exposed_:              args.Exposed,
@@ -115,6 +118,11 @@ func (s *service) Subordinate() bool {
 // CharmURL implements Service.
 func (s *service) CharmURL() string {
 	return s.CharmURL_
+}
+
+// Channel implements Service.
+func (s *service) Channel() string {
+	return s.Channel_
 }
 
 // CharmModifiedVersion implements Service.
@@ -296,6 +304,7 @@ func importServiceV1(source map[string]interface{}) (*service, error) {
 		"series":              schema.String(),
 		"subordinate":         schema.Bool(),
 		"charm-url":           schema.String(),
+		"cs-channel":          schema.String(),
 		"charm-mod-version":   schema.Int(),
 		"force-charm":         schema.Bool(),
 		"exposed":             schema.Bool(),
@@ -334,6 +343,7 @@ func importServiceV1(source map[string]interface{}) (*service, error) {
 		Series_:               valid["series"].(string),
 		Subordinate_:          valid["subordinate"].(bool),
 		CharmURL_:             valid["charm-url"].(string),
+		Channel_:              valid["cs-channel"].(string),
 		CharmModifiedVersion_: int(valid["charm-mod-version"].(int64)),
 		ForceCharm_:           valid["force-charm"].(bool),
 		Exposed_:              valid["exposed"].(bool),

--- a/core/description/service_test.go
+++ b/core/description/service_test.go
@@ -40,6 +40,7 @@ func minimalServiceMap() map[interface{}]interface{} {
 		"name":              "ubuntu",
 		"series":            "trusty",
 		"charm-url":         "cs:trusty/ubuntu",
+		"cs-channel":        "stable",
 		"charm-mod-version": 1,
 		"status":            minimalStatusMap(),
 		"status-history":    emptyStatusHistoryMap(),
@@ -85,6 +86,7 @@ func minimalServiceArgs() ServiceArgs {
 		Tag:                  names.NewServiceTag("ubuntu"),
 		Series:               "trusty",
 		CharmURL:             "cs:trusty/ubuntu",
+		Channel:              "stable",
 		CharmModifiedVersion: 1,
 		Settings: map[string]interface{}{
 			"key": "value",
@@ -104,6 +106,7 @@ func (s *ServiceSerializationSuite) TestNewService(c *gc.C) {
 		Series:               "zesty",
 		Subordinate:          true,
 		CharmURL:             "cs:zesty/magic",
+		Channel:              "stable",
 		CharmModifiedVersion: 1,
 		ForceCharm:           true,
 		Exposed:              true,
@@ -125,6 +128,7 @@ func (s *ServiceSerializationSuite) TestNewService(c *gc.C) {
 	c.Assert(service.Series(), gc.Equals, "zesty")
 	c.Assert(service.Subordinate(), jc.IsTrue)
 	c.Assert(service.CharmURL(), gc.Equals, "cs:zesty/magic")
+	c.Assert(service.Channel(), gc.Equals, "stable")
 	c.Assert(service.CharmModifiedVersion(), gc.Equals, 1)
 	c.Assert(service.ForceCharm(), jc.IsTrue)
 	c.Assert(service.Exposed(), jc.IsTrue)

--- a/juju/deploy.go
+++ b/juju/deploy.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/juju/errors"
 	"gopkg.in/juju/charm.v6-unstable"
+	csparams "gopkg.in/juju/charmrepo.v2-unstable/csclient/params"
 
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/instance"
@@ -22,6 +23,7 @@ type DeployServiceParams struct {
 	Series         string
 	ServiceOwner   string
 	Charm          *state.Charm
+	Channel        csparams.Channel
 	ConfigSettings charm.Settings
 	Constraints    constraints.Value
 	NumUnits       int
@@ -77,6 +79,7 @@ func DeployService(st ServiceDeployer, args DeployServiceParams) (*state.Service
 		Series:           args.Series,
 		Owner:            args.ServiceOwner,
 		Charm:            args.Charm,
+		Channel:          args.Channel,
 		Networks:         args.Networks,
 		Storage:          stateStorageConstraints(args.Storage),
 		Settings:         settings,

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -439,6 +439,7 @@ func (e *exporter) addService(service *Service, refcounts map[string]int, units 
 		Series:               service.doc.Series,
 		Subordinate:          service.doc.Subordinate,
 		CharmURL:             service.doc.CharmURL.String(),
+		Channel:              service.doc.Channel,
 		CharmModifiedVersion: service.doc.CharmModifiedVersion,
 		ForceCharm:           service.doc.ForceCharm,
 		Exposed:              service.doc.Exposed,

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -644,6 +644,7 @@ func (i *importer) makeServiceDoc(s description.Service) (*serviceDoc, error) {
 		Series:               s.Series(),
 		Subordinate:          s.Subordinate(),
 		CharmURL:             charmUrl,
+		Channel:              s.Channel(),
 		CharmModifiedVersion: s.CharmModifiedVersion(),
 		ForceCharm:           s.ForceCharm(),
 		Life:                 Alive,

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -693,7 +693,6 @@ func (i *importer) makeUnitDoc(s description.Service, u description.Unit) (*unit
 		Service:      s.Name(),
 		Series:       s.Series(),
 		CharmURL:     charmUrl,
-		Channel:      s.Channel(),
 		Principal:    u.Principal().Id(),
 		Subordinates: subordinates,
 		// StorageAttachmentCount int `bson:"storageattachmentcount"`

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -693,6 +693,7 @@ func (i *importer) makeUnitDoc(s description.Service, u description.Unit) (*unit
 		Service:      s.Name(),
 		Series:       s.Series(),
 		CharmURL:     charmUrl,
+		Channel:      s.Channel(),
 		Principal:    u.Principal().Id(),
 		Subordinates: subordinates,
 		// StorageAttachmentCount int `bson:"storageattachmentcount"`

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -328,9 +328,10 @@ func (s *MigrationSuite) TestUnitDocFields(c *gc.C) {
 		"ModelUUID",
 		// Service is implicit in the migration structure through containment.
 		"Service",
-		// Series and CharmURL also come from the service.
+		// Series, CharmURL, and Channel also come from the service.
 		"Series",
 		"CharmURL",
+		"Channel",
 		"Principal",
 		"Subordinates",
 		"MachineId",

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -331,7 +331,6 @@ func (s *MigrationSuite) TestUnitDocFields(c *gc.C) {
 		// Series, CharmURL, and Channel also come from the service.
 		"Series",
 		"CharmURL",
-		"Channel",
 		"Principal",
 		"Subordinates",
 		"MachineId",

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -297,6 +297,7 @@ func (s *MigrationSuite) TestServiceDocFields(c *gc.C) {
 		"Series",
 		"Subordinate",
 		"CharmURL",
+		"Channel",
 		"CharmModifiedVersion",
 		"ForceCharm",
 		"Exposed",

--- a/state/service.go
+++ b/state/service.go
@@ -16,6 +16,7 @@ import (
 	jujutxn "github.com/juju/txn"
 	"github.com/juju/utils/series"
 	"gopkg.in/juju/charm.v6-unstable"
+	csparams "gopkg.in/juju/charmrepo.v2-unstable/csclient/params"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
@@ -332,6 +333,12 @@ func (s *Service) CharmModifiedVersion() int {
 // to the charm with that URL even if they are in an error state.
 func (s *Service) CharmURL() (curl *charm.URL, force bool) {
 	return s.doc.CharmURL, s.doc.ForceCharm
+}
+
+// Channel identifies the charm store channel from which the service's
+// charm was deployed.
+func (s *Service) Channel() csparams.Channel {
+	return csparams.Channel(s.doc.Channel)
 }
 
 // Endpoints returns the service's currently available relation endpoints.

--- a/state/service.go
+++ b/state/service.go
@@ -310,6 +310,8 @@ func (s *Service) setExposed(exposed bool) (err error) {
 // Charm returns the service's charm and whether units should upgrade to that
 // charm even if they are in an error state.
 func (s *Service) Charm() (ch *Charm, force bool, err error) {
+	// We don't worry about the channel since we aren't interacting
+	// with the charm store here.
 	ch, err = s.st.Charm(s.doc.CharmURL)
 	if err != nil {
 		return nil, false, err
@@ -336,7 +338,8 @@ func (s *Service) CharmURL() (curl *charm.URL, force bool) {
 }
 
 // Channel identifies the charm store channel from which the service's
-// charm was deployed.
+// charm was deployed. It is only needed when interacting with the charm
+// store.
 func (s *Service) Channel() csparams.Channel {
 	return csparams.Channel(s.doc.Channel)
 }

--- a/state/service.go
+++ b/state/service.go
@@ -40,6 +40,7 @@ type serviceDoc struct {
 	Series               string     `bson:"series"`
 	Subordinate          bool       `bson:"subordinate"`
 	CharmURL             *charm.URL `bson:"charmurl"`
+	Channel              string     `bson:"cs-channel"`
 	CharmModifiedVersion int        `bson:"charmmodifiedversion"`
 	ForceCharm           bool       `bson:"forcecharm"`
 	Life                 Life       `bson:"life"`

--- a/state/state.go
+++ b/state/state.go
@@ -26,6 +26,7 @@ import (
 	"github.com/juju/utils/set"
 	"github.com/juju/version"
 	"gopkg.in/juju/charm.v6-unstable"
+	csparams "gopkg.in/juju/charmrepo.v2-unstable/csclient/params"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
@@ -1166,6 +1167,7 @@ type AddServiceArgs struct {
 	Series           string
 	Owner            string
 	Charm            *Charm
+	Channel          csparams.Channel
 	Networks         []string
 	Storage          map[string]StorageConstraints
 	EndpointBindings map[string]string
@@ -1310,6 +1312,7 @@ func (st *State) AddService(args AddServiceArgs) (service *Service, err error) {
 		Series:        args.Series,
 		Subordinate:   args.Charm.Meta().Subordinate,
 		CharmURL:      args.Charm.URL(),
+		Channel:       string(args.Channel),
 		RelationCount: len(peers),
 		Life:          Alive,
 		OwnerTag:      args.Owner,

--- a/state/unit.go
+++ b/state/unit.go
@@ -15,7 +15,6 @@ import (
 	"github.com/juju/utils/set"
 	"github.com/juju/version"
 	"gopkg.in/juju/charm.v6-unstable"
-	csparams "gopkg.in/juju/charmrepo.v2-unstable/csclient/params"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
@@ -82,7 +81,6 @@ type unitDoc struct {
 	Service                string
 	Series                 string
 	CharmURL               *charm.URL
-	Channel                string `bson:"cs-channel"`
 	Principal              string
 	Subordinates           []string
 	StorageAttachmentCount int `bson:"storageattachmentcount"`
@@ -930,13 +928,6 @@ func (u *Unit) CharmURL() (*charm.URL, bool) {
 		return nil, false
 	}
 	return u.doc.CharmURL, true
-}
-
-// Channel identifies the charm store channel from which the service's
-// charm was deployed. It is only needed when interacting with the charm
-// store.
-func (u *Unit) Channel() csparams.Channel {
-	return csparams.Channel(u.doc.Channel)
 }
 
 // SetCharmURL marks the unit as currently using the supplied charm URL.

--- a/state/unit.go
+++ b/state/unit.go
@@ -933,7 +933,8 @@ func (u *Unit) CharmURL() (*charm.URL, bool) {
 }
 
 // Channel identifies the charm store channel from which the service's
-// charm was deployed.
+// charm was deployed. It is only needed when interacting with the charm
+// store.
 func (u *Unit) Channel() csparams.Channel {
 	return csparams.Channel(u.doc.Channel)
 }

--- a/state/unit.go
+++ b/state/unit.go
@@ -81,6 +81,7 @@ type unitDoc struct {
 	Service                string
 	Series                 string
 	CharmURL               *charm.URL
+	Channel                string `bson:"cs-channel"`
 	Principal              string
 	Subordinates           []string
 	StorageAttachmentCount int `bson:"storageattachmentcount"`

--- a/state/unit.go
+++ b/state/unit.go
@@ -15,6 +15,7 @@ import (
 	"github.com/juju/utils/set"
 	"github.com/juju/version"
 	"gopkg.in/juju/charm.v6-unstable"
+	csparams "gopkg.in/juju/charmrepo.v2-unstable/csclient/params"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
@@ -929,6 +930,12 @@ func (u *Unit) CharmURL() (*charm.URL, bool) {
 		return nil, false
 	}
 	return u.doc.CharmURL, true
+}
+
+// Channel identifies the charm store channel from which the service's
+// charm was deployed.
+func (u *Unit) Channel() csparams.Channel {
+	return csparams.Channel(u.doc.Channel)
 }
 
 // SetCharmURL marks the unit as currently using the supplied charm URL.


### PR DESCRIPTION
We need to persist the channel used at deploy-/upgrade-charm-time in order to use it later when interacting with the charm store on the controller.

(Review request: http://reviews.vapour.ws/r/4441/)