### PR TITLE
lxd container type: don't try to change settings while running tests

### DIFF
--- a/container/lxd/initialisation.go
+++ b/container/lxd/initialisation.go
@@ -76,7 +76,7 @@ func getPackagingConfigurer(series string) (config.PackagingConfigurer, error) {
 	return config.NewPackagingConfigurer(series)
 }
 
-func configureZFS() {
+var configureZFS = func() {
 	/* create a 100 GB pool by default (sparse, so it won't actually fill
 	 * that immediately)
 	 */
@@ -94,7 +94,7 @@ func configureZFS() {
 	}
 }
 
-func configureLXDBridge() error {
+var configureLXDBridge = func() error {
 	f, err := os.OpenFile(lxdBridgeFile, os.O_RDWR, 0777)
 	if err != nil {
 		/* We're using an old version of LXD which doesn't have

--- a/container/lxd/initialisation_test.go
+++ b/container/lxd/initialisation_test.go
@@ -40,6 +40,8 @@ func (s *InitialiserSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 	s.calledCmds = []string{}
 	s.PatchValue(&manager.RunCommandWithRetry, getMockRunCommandWithRetry(&s.calledCmds))
+	s.PatchValue(&configureZFS, func() {})
+	s.PatchValue(&configureLXDBridge, func() error { return nil })
 }
 
 func (s *InitialiserSuite) TestLTSSeriesPackages(c *gc.C) {


### PR DESCRIPTION
avoids failures like:

----------------------------------------------------------------------
FAIL: initialisation_test.go:45: InitialiserSuite.TestLTSSeriesPackages

[LOG] 0:00.000 INFO juju.network setting prefer-ipv6 to false
initialisation_test.go:55:
    c.Assert(err, jc.ErrorIsNil)
... value *errors.Err = &errors.Err{message:"", cause:(*os.PathError)(0xc820448b10), previous:(*os.PathError)(0xc820448b10), file:"github.com/juju/juju/container/lxd/initialisation.go", line:107} ("open /etc/default/lxd-bridge: permission denied")
... error stack:
  open /etc/default/lxd-bridge: permission denied
  github.com/juju/juju/container/lxd/initialisation.go:107:

----------------------------------------------------------------------
FAIL: initialisation_test.go:62: InitialiserSuite.TestNoSeriesPackages

[LOG] 0:00.000 INFO juju.network setting prefer-ipv6 to false
initialisation_test.go:72:
    c.Assert(err, jc.ErrorIsNil)
... value *errors.Err = &errors.Err{message:"", cause:(*os.PathError)(0xc820449e00), previous:(*os.PathError)(0xc820449e00), file:"github.com/juju/juju/container/lxd/initialisation.go", line:107} ("open /etc/default/lxd-bridge: permission denied")
... error stack:
  open /etc/default/lxd-bridge: permission denied
  github.com/juju/juju/container/lxd/initialisation.go:107:

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>

(Review request: http://reviews.vapour.ws/r/4442/)