### PR TITLE
Pass channels through the API.

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -373,16 +373,15 @@ func (c *Client) validateCharmVersion(ch charm.Charm) error {
 // If the AddCharm API call fails because of an authorization error
 // when retrieving the charm from the charm store, an error
 // satisfying params.IsCodeUnauthorized will be returned.
-func (c *Client) AddCharm(curl *charm.URL, channel csparams.Channel) (csparams.Channel, error) {
+func (c *Client) AddCharm(curl *charm.URL, channel csparams.Channel) error {
 	args := params.AddCharm{
 		URL:     curl.String(),
 		Channel: string(channel),
 	}
 	if err := c.facade.FacadeCall("AddCharm", args, nil); err != nil {
-		return channel, errors.Trace(err)
+		return errors.Trace(err)
 	}
-	// TODO(ericsnow) Get the actual channel used.
-	return channel, nil
+	return nil
 }
 
 // AddCharmWithAuthorization is like AddCharm except it also provides
@@ -394,17 +393,16 @@ func (c *Client) AddCharm(curl *charm.URL, channel csparams.Channel) (csparams.C
 // If the AddCharmWithAuthorization API call fails because of an
 // authorization error when retrieving the charm from the charm store,
 // an error satisfying params.IsCodeUnauthorized will be returned.
-func (c *Client) AddCharmWithAuthorization(curl *charm.URL, channel csparams.Channel, csMac *macaroon.Macaroon) (csparams.Channel, error) {
+func (c *Client) AddCharmWithAuthorization(curl *charm.URL, channel csparams.Channel, csMac *macaroon.Macaroon) error {
 	args := params.AddCharmWithAuthorization{
 		URL:                curl.String(),
 		Channel:            string(channel),
 		CharmStoreMacaroon: csMac,
 	}
 	if err := c.facade.FacadeCall("AddCharmWithAuthorization", args, nil); err != nil {
-		return channel, errors.Trace(err)
+		return errors.Trace(err)
 	}
-	// TODO(ericsnow) Get the actual channel used.
-	return channel, nil
+	return nil
 }
 
 // ResolveCharm resolves the best available charm URLs with series, for charm

--- a/api/client.go
+++ b/api/client.go
@@ -18,6 +18,7 @@ import (
 	"github.com/juju/version"
 	"golang.org/x/net/websocket"
 	"gopkg.in/juju/charm.v6-unstable"
+	csparams "gopkg.in/juju/charmrepo.v2-unstable/csclient/params"
 	"gopkg.in/macaroon.v1"
 
 	"github.com/juju/juju/api/base"
@@ -372,11 +373,16 @@ func (c *Client) validateCharmVersion(ch charm.Charm) error {
 // If the AddCharm API call fails because of an authorization error
 // when retrieving the charm from the charm store, an error
 // satisfying params.IsCodeUnauthorized will be returned.
-func (c *Client) AddCharm(curl *charm.URL) error {
-	args := params.CharmURL{
-		URL: curl.String(),
+func (c *Client) AddCharm(curl *charm.URL, channel csparams.Channel) (csparams.Channel, error) {
+	args := params.AddCharm{
+		URL:     curl.String(),
+		Channel: string(channel),
 	}
-	return c.facade.FacadeCall("AddCharm", args, nil)
+	if err := c.facade.FacadeCall("AddCharm", args, nil); err != nil {
+		return channel, errors.Trace(err)
+	}
+	// TODO(ericsnow) Get the actual channel used.
+	return channel, nil
 }
 
 // AddCharmWithAuthorization is like AddCharm except it also provides
@@ -388,12 +394,17 @@ func (c *Client) AddCharm(curl *charm.URL) error {
 // If the AddCharmWithAuthorization API call fails because of an
 // authorization error when retrieving the charm from the charm store,
 // an error satisfying params.IsCodeUnauthorized will be returned.
-func (c *Client) AddCharmWithAuthorization(curl *charm.URL, csMac *macaroon.Macaroon) error {
+func (c *Client) AddCharmWithAuthorization(curl *charm.URL, channel csparams.Channel, csMac *macaroon.Macaroon) (csparams.Channel, error) {
 	args := params.AddCharmWithAuthorization{
 		URL:                curl.String(),
+		Channel:            string(channel),
 		CharmStoreMacaroon: csMac,
 	}
-	return c.facade.FacadeCall("AddCharmWithAuthorization", args, nil)
+	if err := c.facade.FacadeCall("AddCharmWithAuthorization", args, nil); err != nil {
+		return channel, errors.Trace(err)
+	}
+	// TODO(ericsnow) Get the actual channel used.
+	return channel, nil
 }
 
 // ResolveCharm resolves the best available charm URLs with series, for charm

--- a/api/service/client.go
+++ b/api/service/client.go
@@ -146,6 +146,8 @@ type SetCharmConfig struct {
 	ServiceName string
 	// CharmUrl is the url for the charm.
 	CharmUrl string
+	// Channel is the charm store channel from which the charm came.
+	Channel csparams.Channel
 	// ForceSeries forces the use of the charm even if it doesn't match the
 	// series of the unit.
 	ForceSeries bool
@@ -161,6 +163,7 @@ func (c *Client) SetCharm(cfg SetCharmConfig) error {
 	args := params.ServiceSetCharm{
 		ServiceName: cfg.ServiceName,
 		CharmUrl:    cfg.CharmUrl,
+		Channel:     string(cfg.Channel),
 		ForceSeries: cfg.ForceSeries,
 		ForceUnits:  cfg.ForceUnits,
 		ResourceIDs: cfg.ResourceIDs,

--- a/api/service/client.go
+++ b/api/service/client.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"gopkg.in/juju/charm.v6-unstable"
+	csparams "gopkg.in/juju/charmrepo.v2-unstable/csclient/params"
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/base"
@@ -63,6 +64,8 @@ func (c *Client) ModelUUID() string {
 type DeployArgs struct {
 	// CharmURL is the URL of the charm to deploy.
 	CharmURL string
+	// Channel is the charm store channel from which the charm came.
+	Channel csparams.Channel
 	// ServiceName is the name to give the service.
 	ServiceName string
 	// Series to be used for the machine.
@@ -101,6 +104,7 @@ func (c *Client) Deploy(args DeployArgs) error {
 			ServiceName:      args.ServiceName,
 			Series:           args.Series,
 			CharmUrl:         args.CharmURL,
+			Channel:          string(args.Channel),
 			NumUnits:         args.NumUnits,
 			ConfigYAML:       args.ConfigYAML,
 			Constraints:      args.Cons,

--- a/apiserver/client/client.go
+++ b/apiserver/client/client.go
@@ -482,9 +482,10 @@ func (c *Client) FindTools(args params.FindToolsParams) (params.FindToolsResult,
 	return c.api.toolsFinder.FindTools(args)
 }
 
-func (c *Client) AddCharm(args params.CharmURL) error {
+func (c *Client) AddCharm(args params.AddCharm) error {
 	return service.AddCharmWithAuthorization(c.api.state(), params.AddCharmWithAuthorization{
-		URL: args.URL,
+		URL:     args.URL,
+		Channel: args.Channel,
 	})
 }
 

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -229,6 +229,8 @@ type ServiceSetCharm struct {
 	ServiceName string `json:"servicename"`
 	// CharmUrl is the new url for the charm.
 	CharmUrl string `json:"charmurl"`
+	// Channel is the charm store channel from which the charm came.
+	Channel string `json:"cs-channel"`
 	// ForceUnits forces the upgrade on units in an error state.
 	ForceUnits bool `json:"forceunits"`
 	// ForceSeries forces the use of the charm even if it doesn't match the

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -119,9 +119,16 @@ type DestroyRelation struct {
 	Endpoints []string
 }
 
+// AddCharm holds the arguments for making an AddCharm API call.
+type AddCharm struct {
+	URL     string
+	Channel string
+}
+
 // AddCharmWithAuthorization holds the arguments for making an AddCharmWithAuthorization API call.
 type AddCharmWithAuthorization struct {
 	URL                string
+	Channel            string
 	CharmStoreMacaroon *macaroon.Macaroon
 }
 

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -199,6 +199,7 @@ type ServiceDeploy struct {
 	ServiceName      string
 	Series           string
 	CharmUrl         string
+	Channel          string
 	NumUnits         int
 	Config           map[string]string
 	ConfigYAML       string // Takes precedence over config if both are present.

--- a/apiserver/service/charmstore.go
+++ b/apiserver/service/charmstore.go
@@ -146,6 +146,10 @@ func openCSClient(args params.AddCharmWithAuthorization) (*csclient.Client, erro
 		httpbakery.SetCookie(csParams.HTTPClient.Jar, csURL, ms)
 	}
 	csClient := csclient.New(csParams)
+	channel := csparams.Channel(args.Channel)
+	if channel != csparams.NoChannel {
+		csClient = csClient.WithChannel(channel)
+	}
 	return csClient, nil
 }
 

--- a/apiserver/service/service.go
+++ b/apiserver/service/service.go
@@ -301,8 +301,7 @@ func (api *API) SetCharm(args params.ServiceSetCharm) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	// TODO(ericsnow) Use args.Channel once params.ServiceSetCharm has the field.
-	channel := csparams.StableChannel
+	channel := csparams.Channel(args.Channel)
 	return api.serviceSetCharm(service, args.CharmUrl, channel, args.ForceSeries, args.ForceUnits, args.ResourceIDs)
 }
 

--- a/apiserver/service/service.go
+++ b/apiserver/service/service.go
@@ -162,8 +162,7 @@ func deployService(st *state.State, owner string, args params.ServiceDeploy) err
 		return errors.Trace(err)
 	}
 
-	// TODO(ericsnow) Use args.Channel once params.ServiceDeploy has the field.
-	channel := csparams.StableChannel
+	channel := csparams.Channel(args.Channel)
 
 	_, err = jjj.DeployService(st,
 		jjj.DeployServiceParams{

--- a/apiserver/service/service_test.go
+++ b/apiserver/service/service_test.go
@@ -963,9 +963,9 @@ func (s *testModeCharmRepo) WithTestMode() charmrepo.Interface {
 func (s *serviceSuite) TestSpecializeStoreOnDeployServiceSetCharmAndAddCharm(c *gc.C) {
 	repo := &testModeCharmRepo{}
 	s.PatchValue(&csclient.ServerURL, s.Srv.URL)
-	newCharmStore := service.NewCharmStore
-	s.PatchValue(&service.NewCharmStore, func(p charmrepo.NewCharmStoreParams) charmrepo.Interface {
-		repo.CharmStore = newCharmStore(p)
+	newCharmStoreRepo := service.NewCharmStoreRepo
+	s.PatchValue(&service.NewCharmStoreRepo, func(c *csclient.Client) charmrepo.Interface {
+		repo.CharmStore = newCharmStoreRepo(c).(*charmrepo.CharmStore)
 		return repo
 	})
 	attrs := map[string]interface{}{"test-mode": true}

--- a/apiserver/service/service_test.go
+++ b/apiserver/service/service_test.go
@@ -199,7 +199,9 @@ func setupStoragePool(c *gc.C, st *state.State) {
 func (s *serviceSuite) TestServiceDeployWithStorage(c *gc.C) {
 	setupStoragePool(c, s.State)
 	curl, ch := s.UploadCharm(c, "utopic/storage-block-10", "storage-block")
-	err := service.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{URL: curl.String()})
+	err := service.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{
+		URL: curl.String(),
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	storageConstraints := map[string]storage.Constraints{
 		"data": {
@@ -243,7 +245,9 @@ func (s *serviceSuite) TestServiceDeployWithStorage(c *gc.C) {
 
 func (s *serviceSuite) TestMinJujuVersionTooHigh(c *gc.C) {
 	curl, _ := s.UploadCharm(c, "quantal/minjujuversion-0", "minjujuversion")
-	err := service.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{URL: curl.String()})
+	err := service.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{
+		URL: curl.String(),
+	})
 	match := fmt.Sprintf(`charm's min version (999.999.999) is higher than this juju environment's version (%s)`, jujuversion.Current)
 	c.Assert(err, gc.ErrorMatches, regexp.QuoteMeta(match))
 }
@@ -251,7 +255,9 @@ func (s *serviceSuite) TestMinJujuVersionTooHigh(c *gc.C) {
 func (s *serviceSuite) TestServiceDeployWithInvalidStoragePool(c *gc.C) {
 	setupStoragePool(c, s.State)
 	curl, _ := s.UploadCharm(c, "utopic/storage-block-0", "storage-block")
-	err := service.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{URL: curl.String()})
+	err := service.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{
+		URL: curl.String(),
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	storageConstraints := map[string]storage.Constraints{
 		"data": storage.Constraints{
@@ -284,7 +290,9 @@ func (s *serviceSuite) TestServiceDeployWithUnsupportedStoragePool(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	curl, _ := s.UploadCharm(c, "utopic/storage-block-0", "storage-block")
-	err = service.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{URL: curl.String()})
+	err = service.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{
+		URL: curl.String(),
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	storageConstraints := map[string]storage.Constraints{
 		"data": storage.Constraints{
@@ -314,7 +322,9 @@ func (s *serviceSuite) TestServiceDeployWithUnsupportedStoragePool(c *gc.C) {
 func (s *serviceSuite) TestServiceDeployDefaultFilesystemStorage(c *gc.C) {
 	setupStoragePool(c, s.State)
 	curl, ch := s.UploadCharm(c, "trusty/storage-filesystem-1", "storage-filesystem")
-	err := service.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{URL: curl.String()})
+	err := service.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{
+		URL: curl.String(),
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	var cons constraints.Value
 	args := params.ServiceDeploy{
@@ -344,7 +354,9 @@ func (s *serviceSuite) TestServiceDeployDefaultFilesystemStorage(c *gc.C) {
 
 func (s *serviceSuite) TestServiceDeploy(c *gc.C) {
 	curl, ch := s.UploadCharm(c, "precise/dummy-42", "dummy")
-	err := service.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{URL: curl.String()})
+	err := service.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{
+		URL: curl.String(),
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	var cons constraints.Value
 	args := params.ServiceDeploy{
@@ -371,7 +383,9 @@ func (s *serviceSuite) TestServiceDeploy(c *gc.C) {
 
 func (s *serviceSuite) TestServiceDeployWithInvalidPlacement(c *gc.C) {
 	curl, _ := s.UploadCharm(c, "precise/dummy-42", "dummy")
-	err := service.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{URL: curl.String()})
+	err := service.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{
+		URL: curl.String(),
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	var cons constraints.Value
 	args := params.ServiceDeploy{
@@ -394,7 +408,9 @@ func (s *serviceSuite) TestServiceDeployWithInvalidPlacement(c *gc.C) {
 
 func (s *serviceSuite) testClientServicesDeployWithBindings(c *gc.C, endpointBindings, expected map[string]string) {
 	curl, _ := s.UploadCharm(c, "utopic/riak-42", "riak")
-	err := service.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{URL: curl.String()})
+	err := service.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{
+		URL: curl.String(),
+	})
 	c.Assert(err, jc.ErrorIsNil)
 
 	var cons constraints.Value
@@ -631,7 +647,9 @@ func (s *serviceSuite) TestServiceGetCharmURL(c *gc.C) {
 
 func (s *serviceSuite) TestServiceSetCharm(c *gc.C) {
 	curl, _ := s.UploadCharm(c, "precise/dummy-0", "dummy")
-	err := service.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{URL: curl.String()})
+	err := service.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{
+		URL: curl.String(),
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	results, err := s.serviceApi.Deploy(params.ServicesDeploy{
 		Services: []params.ServiceDeploy{{
@@ -643,7 +661,9 @@ func (s *serviceSuite) TestServiceSetCharm(c *gc.C) {
 	c.Assert(results.Results, gc.HasLen, 1)
 	c.Assert(results.Results[0].Error, gc.IsNil)
 	curl, _ = s.UploadCharm(c, "precise/wordpress-3", "wordpress")
-	err = service.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{URL: curl.String()})
+	err = service.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{
+		URL: curl.String(),
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.serviceApi.SetCharm(params.ServiceSetCharm{
 		ServiceName: "service",
@@ -662,7 +682,9 @@ func (s *serviceSuite) TestServiceSetCharm(c *gc.C) {
 
 func (s *serviceSuite) setupServiceSetCharm(c *gc.C) {
 	curl, _ := s.UploadCharm(c, "precise/dummy-0", "dummy")
-	err := service.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{URL: curl.String()})
+	err := service.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{
+		URL: curl.String(),
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	results, err := s.serviceApi.Deploy(params.ServicesDeploy{
 		Services: []params.ServiceDeploy{{
@@ -674,7 +696,9 @@ func (s *serviceSuite) setupServiceSetCharm(c *gc.C) {
 	c.Assert(results.Results, gc.HasLen, 1)
 	c.Assert(results.Results[0].Error, gc.IsNil)
 	curl, _ = s.UploadCharm(c, "precise/wordpress-3", "wordpress")
-	err = service.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{URL: curl.String()})
+	err = service.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{
+		URL: curl.String(),
+	})
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -721,7 +745,9 @@ func (s *serviceSuite) TestBlockChangesServiceSetCharm(c *gc.C) {
 
 func (s *serviceSuite) TestServiceSetCharmForceUnits(c *gc.C) {
 	curl, _ := s.UploadCharm(c, "precise/dummy-0", "dummy")
-	err := service.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{URL: curl.String()})
+	err := service.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{
+		URL: curl.String(),
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	results, err := s.serviceApi.Deploy(params.ServicesDeploy{
 		Services: []params.ServiceDeploy{{
@@ -733,7 +759,9 @@ func (s *serviceSuite) TestServiceSetCharmForceUnits(c *gc.C) {
 	c.Assert(results.Results, gc.HasLen, 1)
 	c.Assert(results.Results[0].Error, gc.IsNil)
 	curl, _ = s.UploadCharm(c, "precise/wordpress-3", "wordpress")
-	err = service.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{URL: curl.String()})
+	err = service.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{
+		URL: curl.String(),
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.serviceApi.SetCharm(params.ServiceSetCharm{
 		ServiceName: "service",
@@ -789,7 +817,9 @@ func (s *serviceSuite) TestServiceAddCharmErrors(c *gc.C) {
 
 func (s *serviceSuite) TestServiceSetCharmLegacy(c *gc.C) {
 	curl, _ := s.UploadCharm(c, "precise/dummy-0", "dummy")
-	err := service.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{URL: curl.String()})
+	err := service.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{
+		URL: curl.String(),
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	results, err := s.serviceApi.Deploy(params.ServicesDeploy{
 		Services: []params.ServiceDeploy{{
@@ -800,7 +830,9 @@ func (s *serviceSuite) TestServiceSetCharmLegacy(c *gc.C) {
 	c.Assert(results.Results, gc.HasLen, 1)
 	c.Assert(results.Results[0].Error, gc.IsNil)
 	curl, _ = s.UploadCharm(c, "trusty/dummy-1", "dummy")
-	err = service.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{URL: curl.String()})
+	err = service.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{
+		URL: curl.String(),
+	})
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Even with forceSeries = true, we can't change a charm where
@@ -815,7 +847,9 @@ func (s *serviceSuite) TestServiceSetCharmLegacy(c *gc.C) {
 
 func (s *serviceSuite) TestServiceSetCharmUnsupportedSeries(c *gc.C) {
 	curl, _ := s.UploadCharmMultiSeries(c, "~who/multi-series", "multi-series")
-	err := service.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{URL: curl.String()})
+	err := service.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{
+		URL: curl.String(),
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	results, err := s.serviceApi.Deploy(params.ServicesDeploy{
 		Services: []params.ServiceDeploy{{
@@ -827,7 +861,9 @@ func (s *serviceSuite) TestServiceSetCharmUnsupportedSeries(c *gc.C) {
 	c.Assert(results.Results, gc.HasLen, 1)
 	c.Assert(results.Results[0].Error, gc.IsNil)
 	curl, _ = s.UploadCharmMultiSeries(c, "~who/multi-series", "multi-series2")
-	err = service.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{URL: curl.String()})
+	err = service.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{
+		URL: curl.String(),
+	})
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = s.serviceApi.SetCharm(params.ServiceSetCharm{
@@ -839,7 +875,9 @@ func (s *serviceSuite) TestServiceSetCharmUnsupportedSeries(c *gc.C) {
 
 func (s *serviceSuite) assertServiceSetCharmSeries(c *gc.C, upgradeCharm, series string) {
 	curl, _ := s.UploadCharmMultiSeries(c, "~who/multi-series", "multi-series")
-	err := service.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{URL: curl.String()})
+	err := service.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{
+		URL: curl.String(),
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	results, err := s.serviceApi.Deploy(params.ServicesDeploy{
 		Services: []params.ServiceDeploy{{
@@ -856,7 +894,9 @@ func (s *serviceSuite) assertServiceSetCharmSeries(c *gc.C, upgradeCharm, series
 		url = series + "/" + upgradeCharm
 	}
 	curl, _ = s.UploadCharmMultiSeries(c, "~who/"+url, upgradeCharm)
-	err = service.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{URL: curl.String()})
+	err = service.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{
+		URL: curl.String(),
+	})
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = s.serviceApi.SetCharm(params.ServiceSetCharm{
@@ -882,7 +922,9 @@ func (s *serviceSuite) TestServiceSetCharmNoExplicitSupportedSeries(c *gc.C) {
 
 func (s *serviceSuite) TestServiceSetCharmWrongOS(c *gc.C) {
 	curl, _ := s.UploadCharmMultiSeries(c, "~who/multi-series", "multi-series")
-	err := service.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{URL: curl.String()})
+	err := service.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{
+		URL: curl.String(),
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	results, err := s.serviceApi.Deploy(params.ServicesDeploy{
 		Services: []params.ServiceDeploy{{
@@ -894,7 +936,9 @@ func (s *serviceSuite) TestServiceSetCharmWrongOS(c *gc.C) {
 	c.Assert(results.Results, gc.HasLen, 1)
 	c.Assert(results.Results[0].Error, gc.IsNil)
 	curl, _ = s.UploadCharmMultiSeries(c, "~who/multi-series-windows", "multi-series-windows")
-	err = service.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{URL: curl.String()})
+	err = service.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{
+		URL: curl.String(),
+	})
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = s.serviceApi.SetCharm(params.ServiceSetCharm{
@@ -929,7 +973,9 @@ func (s *serviceSuite) TestSpecializeStoreOnDeployServiceSetCharmAndAddCharm(c *
 
 	// Check that the store's test mode is enabled when calling service Deploy.
 	curl, _ := s.UploadCharm(c, "trusty/dummy-1", "dummy")
-	err = service.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{URL: curl.String()})
+	err = service.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{
+		URL: curl.String(),
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	results, err := s.serviceApi.Deploy(params.ServicesDeploy{
 		Services: []params.ServiceDeploy{{
@@ -959,7 +1005,9 @@ func (s *serviceSuite) TestSpecializeStoreOnDeployServiceSetCharmAndAddCharm(c *
 
 func (s *serviceSuite) setupServiceDeploy(c *gc.C, args string) (*charm.URL, charm.Charm, constraints.Value) {
 	curl, ch := s.UploadCharm(c, "precise/dummy-42", "dummy")
-	err := service.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{URL: curl.String()})
+	err := service.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{
+		URL: curl.String(),
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	cons := constraints.MustParse(args)
 	return curl, ch, cons
@@ -1010,7 +1058,9 @@ func (s *serviceSuite) TestBlockChangesServiceDeployPrincipal(c *gc.C) {
 
 func (s *serviceSuite) TestServiceDeploySubordinate(c *gc.C) {
 	curl, ch := s.UploadCharm(c, "utopic/logging-47", "logging")
-	err := service.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{URL: curl.String()})
+	err := service.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{
+		URL: curl.String(),
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	results, err := s.serviceApi.Deploy(params.ServicesDeploy{
 		Services: []params.ServiceDeploy{{
@@ -1037,7 +1087,9 @@ func (s *serviceSuite) TestServiceDeploySubordinate(c *gc.C) {
 
 func (s *serviceSuite) TestServiceDeployConfig(c *gc.C) {
 	curl, _ := s.UploadCharm(c, "precise/dummy-0", "dummy")
-	err := service.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{URL: curl.String()})
+	err := service.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{
+		URL: curl.String(),
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	results, err := s.serviceApi.Deploy(params.ServicesDeploy{
 		Services: []params.ServiceDeploy{{
@@ -1061,7 +1113,9 @@ func (s *serviceSuite) TestServiceDeployConfigError(c *gc.C) {
 	// TODO(fwereade): test Config/ConfigYAML handling directly on srvClient.
 	// Can't be done cleanly until it's extracted similarly to Machiner.
 	curl, _ := s.UploadCharm(c, "precise/dummy-0", "dummy")
-	err := service.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{URL: curl.String()})
+	err := service.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{
+		URL: curl.String(),
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	results, err := s.serviceApi.Deploy(params.ServicesDeploy{
 		Services: []params.ServiceDeploy{{
@@ -1079,7 +1133,9 @@ func (s *serviceSuite) TestServiceDeployConfigError(c *gc.C) {
 
 func (s *serviceSuite) TestServiceDeployToMachine(c *gc.C) {
 	curl, ch := s.UploadCharm(c, "precise/dummy-0", "dummy")
-	err := service.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{URL: curl.String()})
+	err := service.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{
+		URL: curl.String(),
+	})
 	c.Assert(err, jc.ErrorIsNil)
 
 	machine, err := s.State.AddMachine("precise", state.JobHostUnits)
@@ -1135,7 +1191,9 @@ func (s *serviceSuite) TestServiceDeployToMachineNotFound(c *gc.C) {
 
 func (s *serviceSuite) TestServiceDeployServiceOwner(c *gc.C) {
 	curl, _ := s.UploadCharm(c, "precise/dummy-0", "dummy")
-	err := service.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{URL: curl.String()})
+	err := service.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{
+		URL: curl.String(),
+	})
 	c.Assert(err, jc.ErrorIsNil)
 
 	results, err := s.serviceApi.Deploy(params.ServicesDeploy{
@@ -1155,7 +1213,9 @@ func (s *serviceSuite) TestServiceDeployServiceOwner(c *gc.C) {
 
 func (s *serviceSuite) deployServiceForUpdateTests(c *gc.C) {
 	curl, _ := s.UploadCharm(c, "precise/dummy-1", "dummy")
-	err := service.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{URL: curl.String()})
+	err := service.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{
+		URL: curl.String(),
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	results, err := s.serviceApi.Deploy(params.ServicesDeploy{
 		Services: []params.ServiceDeploy{{
@@ -1171,7 +1231,9 @@ func (s *serviceSuite) deployServiceForUpdateTests(c *gc.C) {
 func (s *serviceSuite) checkClientServiceUpdateSetCharm(c *gc.C, forceCharmUrl bool) {
 	s.deployServiceForUpdateTests(c)
 	curl, _ := s.UploadCharm(c, "precise/wordpress-3", "wordpress")
-	err := service.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{URL: curl.String()})
+	err := service.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{
+		URL: curl.String(),
+	})
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Update the charm for the service.
@@ -1209,7 +1271,9 @@ func (s *serviceSuite) TestBlockRemoveServiceUpdate(c *gc.C) {
 func (s *serviceSuite) setupServiceUpdate(c *gc.C) string {
 	s.deployServiceForUpdateTests(c)
 	curl, _ := s.UploadCharm(c, "precise/wordpress-3", "wordpress")
-	err := service.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{URL: curl.String()})
+	err := service.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{
+		URL: curl.String(),
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	return curl.String()
 }
@@ -1378,7 +1442,9 @@ func (s *serviceSuite) TestServiceUpdateSetConstraints(c *gc.C) {
 func (s *serviceSuite) TestServiceUpdateAllParams(c *gc.C) {
 	s.deployServiceForUpdateTests(c)
 	curl, _ := s.UploadCharm(c, "precise/wordpress-3", "wordpress")
-	err := service.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{URL: curl.String()})
+	err := service.AddCharmWithAuthorization(s.State, params.AddCharmWithAuthorization{
+		URL: curl.String(),
+	})
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Update all the service attributes.

--- a/apiserver/service/service_test.go
+++ b/apiserver/service/service_test.go
@@ -962,9 +962,10 @@ func (s *testModeCharmRepo) WithTestMode() charmrepo.Interface {
 
 func (s *serviceSuite) TestSpecializeStoreOnDeployServiceSetCharmAndAddCharm(c *gc.C) {
 	repo := &testModeCharmRepo{}
+	s.PatchValue(&csclient.ServerURL, s.Srv.URL)
+	newCharmStore := service.NewCharmStore
 	s.PatchValue(&service.NewCharmStore, func(p charmrepo.NewCharmStoreParams) charmrepo.Interface {
-		p.URL = s.Srv.URL
-		repo.CharmStore = charmrepo.NewCharmStore(p)
+		repo.CharmStore = newCharmStore(p)
 		return repo
 	})
 	attrs := map[string]interface{}{"test-mode": true}

--- a/apiserver/testing/fakecharmstore.go
+++ b/apiserver/testing/fakecharmstore.go
@@ -19,7 +19,6 @@ import (
 	"gopkg.in/macaroon-bakery.v1/bakerytest"
 	"gopkg.in/mgo.v2"
 
-	"github.com/juju/juju/apiserver/service"
 	"github.com/juju/juju/testcharms"
 )
 
@@ -67,10 +66,7 @@ func (s *CharmStoreSuite) SetUpTest(c *gc.C) {
 	})
 
 	s.PatchValue(&charmrepo.CacheDir, c.MkDir())
-	s.PatchValue(&service.NewCharmStore, func(p charmrepo.NewCharmStoreParams) charmrepo.Interface {
-		p.URL = s.Srv.URL
-		return charmrepo.NewCharmStore(p)
-	})
+	s.PatchValue(&csclient.ServerURL, s.Srv.URL)
 }
 
 func (s *CharmStoreSuite) TearDownTest(c *gc.C) {

--- a/charmstore/charmid.go
+++ b/charmstore/charmid.go
@@ -1,6 +1,9 @@
 package charmstore
 
-import "gopkg.in/juju/charm.v6-unstable"
+import (
+	"gopkg.in/juju/charm.v6-unstable"
+	csparams "gopkg.in/juju/charmrepo.v2-unstable/csclient/params"
+)
 
 // CharmID is a type that encapsulates all the data required to interact with a
 // unique charm from the charmstore.
@@ -9,5 +12,5 @@ type CharmID struct {
 	URL *charm.URL
 
 	// Channel is the channel in which the charm was published.
-	Channel charm.Channel
+	Channel csparams.Channel
 }

--- a/charmstore/client_internal_test.go
+++ b/charmstore/client_internal_test.go
@@ -40,7 +40,7 @@ func (s *InternalClientSuite) TestCollate(c *gc.C) {
 		{URL: bat, Channel: "stable"},
 	}
 	output := collate(input)
-	c.Assert(output, gc.DeepEquals, map[charm.Channel]charmRequest{
+	c.Assert(output, gc.DeepEquals, map[params.Channel]charmRequest{
 		"stable": charmRequest{
 			ids:     []*charm.URL{foo, bat},
 			indices: []int{0, 3},
@@ -75,8 +75,8 @@ func (s *InternalClientSuite) TestLatestRevisions(c *gc.C) {
 	}}, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ret, gc.DeepEquals, append(s.lowLevel.ReturnLatestStable, s.lowLevel.ReturnLatestDev...))
-	s.lowLevel.stableStub.CheckCall(c, 0, "Latest", charm.Channel("stable"), []*charm.URL{foo}, map[string]string(nil))
-	s.lowLevel.devStub.CheckCall(c, 0, "Latest", charm.Channel("development"), []*charm.URL{bar}, map[string]string(nil))
+	s.lowLevel.stableStub.CheckCall(c, 0, "Latest", params.StableChannel, []*charm.URL{foo}, map[string]string(nil))
+	s.lowLevel.devStub.CheckCall(c, 0, "Latest", params.DevelopmentChannel, []*charm.URL{bar}, map[string]string(nil))
 }
 
 func (s *InternalClientSuite) TestListResources(c *gc.C) {
@@ -133,6 +133,6 @@ func (s *InternalClientSuite) TestListResources(c *gc.C) {
 		{stableOut},
 		{devOut},
 	})
-	s.lowLevel.stableStub.CheckCall(c, 0, "ListResources", charm.Channel("stable"), []*charm.URL{foo})
-	s.lowLevel.devStub.CheckCall(c, 0, "ListResources", charm.Channel("development"), []*charm.URL{bar})
+	s.lowLevel.stableStub.CheckCall(c, 0, "ListResources", params.StableChannel, []*charm.URL{foo})
+	s.lowLevel.devStub.CheckCall(c, 0, "ListResources", params.DevelopmentChannel, []*charm.URL{bar})
 }

--- a/charmstore/latest_test.go
+++ b/charmstore/latest_test.go
@@ -63,8 +63,8 @@ func (s *LatestCharmInfoSuite) TestSuccess(c *gc.C) {
 	expectedIds := []*charm.URL{spam, eggs, ham}
 
 	s.lowLevel.stableStub.CheckCallNames(c, "Latest", "ListResources")
-	s.lowLevel.stableStub.CheckCall(c, 0, "Latest", charm.Channel("stable"), expectedIds, map[string]string{"environment_uuid": uuid})
-	s.lowLevel.stableStub.CheckCall(c, 1, "ListResources", charm.Channel("stable"), expectedIds)
+	s.lowLevel.stableStub.CheckCall(c, 0, "Latest", params.StableChannel, expectedIds, map[string]string{"environment_uuid": uuid})
+	s.lowLevel.stableStub.CheckCall(c, 1, "ListResources", params.StableChannel, expectedIds)
 
 	expectedRes, err := params.API2Resource(fakeRes)
 	c.Assert(err, jc.ErrorIsNil)

--- a/charmstore/stub_test.go
+++ b/charmstore/stub_test.go
@@ -34,7 +34,7 @@ type fakeWrapper struct {
 	ReturnResourceInfo params.Resource
 }
 
-func (f *fakeWrapper) Latest(channel charm.Channel, ids []*charm.URL, headers map[string]string) ([]charmrepo.CharmRevision, error) {
+func (f *fakeWrapper) Latest(channel params.Channel, ids []*charm.URL, headers map[string]string) ([]charmrepo.CharmRevision, error) {
 	if channel == "stable" {
 		f.stableStub.AddCall("Latest", channel, ids, headers)
 		return f.ReturnLatestStable, nil
@@ -43,7 +43,7 @@ func (f *fakeWrapper) Latest(channel charm.Channel, ids []*charm.URL, headers ma
 	return f.ReturnLatestDev, nil
 }
 
-func (f *fakeWrapper) ListResources(channel charm.Channel, ids []*charm.URL) (map[string][]params.Resource, error) {
+func (f *fakeWrapper) ListResources(channel params.Channel, ids []*charm.URL) (map[string][]params.Resource, error) {
 	if channel == "stable" {
 		f.stableStub.AddCall("ListResources", channel, ids)
 		return f.ReturnListResourcesStable, nil

--- a/cmd/juju/service/bundle.go
+++ b/cmd/juju/service/bundle.go
@@ -234,8 +234,7 @@ type bundleHandler struct {
 
 // addCharm adds a charm to the environment.
 func (h *bundleHandler) addCharm(id string, p bundlechanges.AddCharmParams) (*charm.URL, csparams.Channel, *macaroon.Macaroon, error) {
-	var channel csparams.Channel
-	url, _, repo, err := h.resolver.resolve(p.Charm)
+	url, channel, _, repo, err := h.resolver.resolve(p.Charm)
 	if err != nil {
 		return nil, channel, nil, errors.Annotatef(err, "cannot resolve URL %q", p.Charm)
 	}
@@ -243,7 +242,7 @@ func (h *bundleHandler) addCharm(id string, p bundlechanges.AddCharmParams) (*ch
 		return nil, channel, nil, errors.Errorf("expected charm URL, got bundle URL %q", p.Charm)
 	}
 	var csMac *macaroon.Macaroon
-	url, channel, csMac, err = addCharmFromURL(h.client, url, h.channel, repo)
+	url, csMac, err = addCharmFromURL(h.client, url, channel, repo)
 	if err != nil {
 		return nil, channel, nil, errors.Annotatef(err, "cannot add charm %q", p.Charm)
 	}

--- a/cmd/juju/service/bundle.go
+++ b/cmd/juju/service/bundle.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/names"
 	"gopkg.in/juju/charm.v6-unstable"
+	csparams "gopkg.in/juju/charmrepo.v2-unstable/csclient/params"
 	"gopkg.in/macaroon.v1"
 	"gopkg.in/yaml.v1"
 
@@ -48,6 +49,7 @@ type deploymentLogger interface {
 // notified using the given deployment logger.
 func deployBundle(
 	data *charm.BundleData,
+	channel csparams.Channel,
 	client *api.Client,
 	serviceDeployer *serviceDeployer,
 	resolver *charmURLResolver,
@@ -110,6 +112,7 @@ func deployBundle(
 	h := &bundleHandler{
 		changes:           changes,
 		results:           make(map[string]string, numChanges),
+		channel:           channel,
 		client:            client,
 		serviceClient:     serviceClient,
 		annotationsClient: annotationsClient,
@@ -126,12 +129,14 @@ func deployBundle(
 
 	// Deploy the bundle.
 	csMacs := make(map[*charm.URL]*macaroon.Macaroon)
+	channels := make(map[*charm.URL]csparams.Channel)
 	for _, change := range changes {
 		switch change := change.(type) {
 		case *bundlechanges.AddCharmChange:
-			cURL, csMac, err2 := h.addCharm(change.Id(), change.Params)
+			cURL, channel, csMac, err2 := h.addCharm(change.Id(), change.Params)
 			if err2 == nil {
 				csMacs[cURL] = csMac
+				channels[cURL] = channel
 			}
 			err = err2
 		case *bundlechanges.AddMachineChange:
@@ -143,7 +148,8 @@ func deployBundle(
 			cURL, err = charm.ParseURL(resolve(change.Params.Charm, h.results))
 			if err == nil {
 				csMac := csMacs[cURL]
-				err = h.addService(change.Id(), change.Params, cURL, csMac)
+				channel := channels[cURL]
+				err = h.addService(change.Id(), change.Params, cURL, channel, csMac)
 			}
 		case *bundlechanges.AddUnitChange:
 			err = h.addUnit(change.Id(), change.Params)
@@ -178,6 +184,9 @@ type bundleHandler struct {
 	//   the unit name can be stored. The latter happens when a machine is
 	//   implicitly created by adding a unit without a machine spec.
 	results map[string]string
+
+	// channel identifies the default channel to use for the bundle.
+	channel csparams.Channel
 
 	// client is used to interact with the environment.
 	client *api.Client
@@ -224,27 +233,28 @@ type bundleHandler struct {
 }
 
 // addCharm adds a charm to the environment.
-func (h *bundleHandler) addCharm(id string, p bundlechanges.AddCharmParams) (*charm.URL, *macaroon.Macaroon, error) {
+func (h *bundleHandler) addCharm(id string, p bundlechanges.AddCharmParams) (*charm.URL, csparams.Channel, *macaroon.Macaroon, error) {
+	var channel csparams.Channel
 	url, _, repo, err := h.resolver.resolve(p.Charm)
 	if err != nil {
-		return nil, nil, errors.Annotatef(err, "cannot resolve URL %q", p.Charm)
+		return nil, channel, nil, errors.Annotatef(err, "cannot resolve URL %q", p.Charm)
 	}
 	if url.Series == "bundle" {
-		return nil, nil, errors.Errorf("expected charm URL, got bundle URL %q", p.Charm)
+		return nil, channel, nil, errors.Errorf("expected charm URL, got bundle URL %q", p.Charm)
 	}
 	var csMac *macaroon.Macaroon
-	url, csMac, err = addCharmFromURL(h.client, url, repo)
+	url, channel, csMac, err = addCharmFromURL(h.client, url, h.channel, repo)
 	if err != nil {
-		return nil, nil, errors.Annotatef(err, "cannot add charm %q", p.Charm)
+		return nil, channel, nil, errors.Annotatef(err, "cannot add charm %q", p.Charm)
 	}
 	h.log.Infof("added charm %s", url)
 	h.results[id] = url.String()
-	return url, csMac, nil
+	return url, channel, csMac, nil
 }
 
 // addService deploys or update a service with no units. Service options are
 // also set or updated.
-func (h *bundleHandler) addService(id string, p bundlechanges.AddServiceParams, cURL *charm.URL, csMac *macaroon.Macaroon) error {
+func (h *bundleHandler) addService(id string, p bundlechanges.AddServiceParams, cURL *charm.URL, channel csparams.Channel, csMac *macaroon.Macaroon) error {
 	h.results[id] = p.Service
 	ch := cURL.String()
 	// Handle service configuration.
@@ -288,13 +298,14 @@ func (h *bundleHandler) addService(id string, p bundlechanges.AddServiceParams, 
 	if err != nil {
 		return err
 	}
-	resNames2IDs, err := handleResources(h.serviceDeployer.api, resources, p.Service, cURL, csMac, charmInfo.Meta.Resources)
+	resNames2IDs, err := handleResources(h.serviceDeployer.api, resources, p.Service, cURL, channel, csMac, charmInfo.Meta.Resources)
 	if err != nil {
 		return errors.Trace(err)
 	}
 	// Deploy the service.
 	if err := h.serviceDeployer.serviceDeploy(serviceDeployParams{
 		charmURL:      ch,
+		channel:       channel,
 		serviceName:   p.Service,
 		configYAML:    configYAML,
 		constraints:   cons,
@@ -314,7 +325,7 @@ func (h *bundleHandler) addService(id string, p bundlechanges.AddServiceParams, 
 	// charm is compatible with the one declared in the bundle. If it is,
 	// reuse the existing service or upgrade to a specified revision.
 	// Exit with an error otherwise.
-	if err := h.upgradeCharm(p.Service, cURL, csMac, resources); err != nil {
+	if err := h.upgradeCharm(p.Service, cURL, channel, csMac, resources); err != nil {
 		return errors.Annotatef(err, "cannot upgrade service %q", p.Service)
 	}
 	// Update service configuration.
@@ -714,7 +725,7 @@ func resolve(placeholder string, results map[string]string) string {
 // If the service is already deployed using the given charm id, do nothing.
 // This function returns an error if the existing charm and the target one are
 // incompatible, meaning an upgrade from one to the other is not allowed.
-func (h *bundleHandler) upgradeCharm(service string, cURL *charm.URL, csMac *macaroon.Macaroon, resources map[string]string) error {
+func (h *bundleHandler) upgradeCharm(service string, cURL *charm.URL, channel csparams.Channel, csMac *macaroon.Macaroon, resources map[string]string) error {
 	id := cURL.String()
 	existing, err := h.serviceClient.GetCharmURL(service)
 	if err != nil {
@@ -737,7 +748,7 @@ func (h *bundleHandler) upgradeCharm(service string, cURL *charm.URL, csMac *mac
 	}
 	var resNames2IDs map[string]string
 	if len(filtered) != 0 {
-		resNames2IDs, err = handleResources(h.serviceDeployer.api, resources, service, url, csMac, filtered)
+		resNames2IDs, err = handleResources(h.serviceDeployer.api, resources, service, url, channel, csMac, filtered)
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/cmd/juju/service/deploy.go
+++ b/cmd/juju/service/deploy.go
@@ -376,7 +376,7 @@ func (c *DeployCommand) deployCharmOrBundle(ctx *cmd.Context, client *api.Client
 	// If we don't already have a bundle loaded, we try the charm store for a charm or bundle.
 	if bundleData == nil {
 		// Charm or bundle has been supplied as a URL so we resolve and deploy using the store.
-		charmOrBundleURL, supportedSeries, repo, err = resolver.resolve(c.CharmOrBundle)
+		charmOrBundleURL, c.Channel, supportedSeries, repo, err = resolver.resolve(c.CharmOrBundle)
 		if charm.IsUnsupportedSeriesError(err) {
 			return errors.Errorf("%v. Use --force to deploy the charm anyway.", err)
 		}
@@ -417,7 +417,7 @@ func (c *DeployCommand) deployCharmOrBundle(ctx *cmd.Context, client *api.Client
 		return errors.Errorf("%v. Use --force to deploy the charm anyway.", err)
 	}
 	// Store the charm in state.
-	curl, channel, csMac, err := addCharmFromURL(client, charmOrBundleURL, c.Channel, repo)
+	curl, csMac, err := addCharmFromURL(client, charmOrBundleURL, c.Channel, repo)
 	if err != nil {
 		if err1, ok := errors.Cause(err).(*termsRequiredError); ok {
 			terms := strings.Join(err1.Terms, " ")
@@ -427,7 +427,7 @@ func (c *DeployCommand) deployCharmOrBundle(ctx *cmd.Context, client *api.Client
 	}
 	ctx.Infof("Added charm %q to the model.", curl)
 	ctx.Infof("Deploying charm %q %v.", curl, fmt.Sprintf(message, series))
-	return c.deployCharm(curl, channel, csMac, series, ctx, client, &deployer)
+	return c.deployCharm(curl, c.Channel, csMac, series, ctx, client, &deployer)
 }
 
 const (

--- a/cmd/juju/service/deploy.go
+++ b/cmd/juju/service/deploy.go
@@ -569,6 +569,7 @@ func (c *DeployCommand) deployCharm(
 
 	params := serviceDeployParams{
 		charmURL:      curl.String(),
+		channel:       c.Channel,
 		serviceName:   serviceName,
 		series:        series,
 		numUnits:      numUnits,
@@ -652,6 +653,7 @@ func (c *DeployCommand) parseBind() error {
 
 type serviceDeployParams struct {
 	charmURL      string
+	channel       csclientparams.Channel
 	serviceName   string
 	series        string
 	numUnits      int
@@ -705,17 +707,18 @@ func (c *serviceDeployer) serviceDeploy(args serviceDeployParams) error {
 	}
 
 	clientArgs := apiservice.DeployArgs{
-		args.charmURL,
-		args.serviceName,
-		args.series,
-		args.numUnits,
-		args.configYAML,
-		args.constraints,
-		args.placement,
-		[]string{},
-		args.storage,
-		args.spaceBindings,
-		args.resources,
+		CharmURL:         args.charmURL,
+		Channel:          args.channel,
+		ServiceName:      args.serviceName,
+		Series:           args.series,
+		NumUnits:         args.numUnits,
+		ConfigYAML:       args.configYAML,
+		Cons:             args.constraints,
+		Placement:        args.placement,
+		Networks:         []string{},
+		Storage:          args.storage,
+		EndpointBindings: args.spaceBindings,
+		Resources:        args.resources,
 	}
 
 	return serviceClient.Deploy(clientArgs)

--- a/cmd/juju/service/deploy_test.go
+++ b/cmd/juju/service/deploy_test.go
@@ -637,13 +637,13 @@ Deploying charm "cs:~bob/trusty/wordpress4-10" with the charm series "trusty".`,
 	uploadURL:    "cs:~bob/trusty/wordpress5-10",
 	deployURL:    "cs:~bob/trusty/wordpress5",
 	readPermUser: "bob",
-	expectError:  `cannot resolve (charm )?URL "cs:~bob/trusty/wordpress5": cannot get "/~bob/trusty/wordpress5/meta/any\?include=id&include=supported-series": unauthorized: access denied for user "client-username"`,
+	expectError:  `cannot resolve (charm )?URL "cs:~bob/trusty/wordpress5": cannot get "/~bob/trusty/wordpress5/meta/any\?include=id&include=supported-series&include=published": unauthorized: access denied for user "client-username"`,
 }, {
 	about:        "non-public charm, fully resolved, access denied",
 	uploadURL:    "cs:~bob/trusty/wordpress6-47",
 	deployURL:    "cs:~bob/trusty/wordpress6-47",
 	readPermUser: "bob",
-	expectError:  `cannot resolve charm URL "cs:~bob/trusty/wordpress6-47": cannot get "/~bob/trusty/wordpress6-47/meta/any\?include=id&include=supported-series": unauthorized: access denied for user "client-username"`,
+	expectError:  `cannot resolve charm URL "cs:~bob/trusty/wordpress6-47": cannot get "/~bob/trusty/wordpress6-47/meta/any\?include=id&include=supported-series&include=published": unauthorized: access denied for user "client-username"`,
 }, {
 	about:     "public bundle, success",
 	uploadURL: "cs:~bob/bundle/wordpress-simple1-42",
@@ -676,7 +676,7 @@ deployment of bundle "cs:~bob/bundle/wordpress-simple2-0" completed`,
 	uploadURL:    "cs:~bob/bundle/wordpress-simple3-47",
 	deployURL:    "cs:~bob/bundle/wordpress-simple3",
 	readPermUser: "bob",
-	expectError:  `cannot resolve charm URL "cs:~bob/bundle/wordpress-simple3": cannot get "/~bob/bundle/wordpress-simple3/meta/any\?include=id&include=supported-series": unauthorized: access denied for user "client-username"`,
+	expectError:  `cannot resolve charm URL "cs:~bob/bundle/wordpress-simple3": cannot get "/~bob/bundle/wordpress-simple3/meta/any\?include=id&include=supported-series&include=published": unauthorized: access denied for user "client-username"`,
 }}
 
 func (s *DeployCharmStoreSuite) TestDeployAuthorization(c *gc.C) {

--- a/cmd/juju/service/upgradecharm.go
+++ b/cmd/juju/service/upgradecharm.go
@@ -353,7 +353,7 @@ func (c *upgradeCharmCommand) addCharm(
 	}
 
 	// Charm has been supplied as a URL so we resolve and deploy using the store.
-	newURL, supportedSeries, repo, err := resolver.resolve(charmRef)
+	newURL, channel, supportedSeries, repo, err := resolver.resolve(charmRef)
 	if err != nil {
 		return nil, noChannel, nil, errors.Trace(err)
 	}
@@ -382,5 +382,9 @@ func (c *upgradeCharmCommand) addCharm(
 		}
 	}
 
-	return addCharmFromURL(client, newURL, c.Channel, repo)
+	curl, csMac, err := addCharmFromURL(client, newURL, channel, repo)
+	if err != nil {
+		return nil, noChannel, nil, errors.Trace(err)
+	}
+	return curl, channel, csMac, nil
 }

--- a/cmd/juju/service/upgradecharm.go
+++ b/cmd/juju/service/upgradecharm.go
@@ -220,6 +220,7 @@ func (c *upgradeCharmCommand) Run(ctx *cmd.Context) error {
 	cfg := apiservice.SetCharmConfig{
 		ServiceName: c.ServiceName,
 		CharmUrl:    addedURL.String(),
+		Channel:     c.Channel,
 		ForceSeries: c.ForceSeries,
 		ForceUnits:  c.ForceUnits,
 		ResourceIDs: ids,

--- a/cmd/juju/service/upgradecharm_test.go
+++ b/cmd/juju/service/upgradecharm_test.go
@@ -424,13 +424,13 @@ var upgradeCharmAuthorizationTests = []struct {
 	uploadURL:    "cs:~bob/trusty/wordpress5-10",
 	switchURL:    "cs:~bob/trusty/wordpress5",
 	readPermUser: "bob",
-	expectError:  `cannot resolve charm URL "cs:~bob/trusty/wordpress5": cannot get "/~bob/trusty/wordpress5/meta/any\?include=id&include=supported-series": unauthorized: access denied for user "client-username"`,
+	expectError:  `cannot resolve charm URL "cs:~bob/trusty/wordpress5": cannot get "/~bob/trusty/wordpress5/meta/any\?include=id&include=supported-series&include=published": unauthorized: access denied for user "client-username"`,
 }, {
 	about:        "non-public charm, fully resolved, access denied",
 	uploadURL:    "cs:~bob/trusty/wordpress6-47",
 	switchURL:    "cs:~bob/trusty/wordpress6-47",
 	readPermUser: "bob",
-	expectError:  `cannot resolve charm URL "cs:~bob/trusty/wordpress6-47": cannot get "/~bob/trusty/wordpress6-47/meta/any\?include=id&include=supported-series": unauthorized: access denied for user "client-username"`,
+	expectError:  `cannot resolve charm URL "cs:~bob/trusty/wordpress6-47": cannot get "/~bob/trusty/wordpress6-47/meta/any\?include=id&include=supported-series&include=published": unauthorized: access denied for user "client-username"`,
 }}
 
 func (s *UpgradeCharmCharmStoreSuite) TestUpgradeCharmAuthorization(c *gc.C) {

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -57,7 +57,7 @@ gopkg.in/goose.v1	git	495e6fa2ab89bc5ed2c8e1bbcbc4c9e4a3c97d37	2016-03-17T17:25:
 gopkg.in/ini.v1	git	776aa739ce9373377cd16f526cdf06cb4c89b40f	2016-02-22T23:24:41Z
 gopkg.in/juju/blobstore.v2	git	51fa6e26128d74e445c72d3a91af555151cc3654	2016-01-25T02:37:03Z
 gopkg.in/juju/charm.v6-unstable	git	728a5ea3ff1c1ae8b4c3ac4779c0027f693d1ca5	2016-04-08T11:12:17Z
-gopkg.in/juju/charmrepo.v2-unstable	git	64555d419cf90c85525313e98102158c5e8074f4	2016-04-08T12:19:14Z
+gopkg.in/juju/charmrepo.v2-unstable	git	9a33b60d66041321e8e0d0210fe33f972b17b7b9	2016-04-08T20:03:22Z
 gopkg.in/juju/charmstore.v5-unstable	git	dab0340f56958cb5f5ca007e9d15d4f3b1b1b3cb	2016-03-23T15:22:24Z
 gopkg.in/juju/environschema.v1	git	7bea6a9a531586600a7741e9bdd5e3c978ffda15	2015-10-20T16:12:31Z
 gopkg.in/juju/jujusvg.v1	git	a60359df348ef2ca40ec3bcd58a01de54f05658e	2016-02-11T10:02:50Z

--- a/resource/api/client/client.go
+++ b/resource/api/client/client.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/errors"
 	"gopkg.in/juju/charm.v6-unstable"
 	charmresource "gopkg.in/juju/charm.v6-unstable/resource"
+	csparams "gopkg.in/juju/charmrepo.v2-unstable/csclient/params"
 	"gopkg.in/macaroon.v1"
 
 	"github.com/juju/juju/apiserver/common"
@@ -110,6 +111,9 @@ type AddPendingResourcesArgs struct {
 	// CharmURL identifies the service's charm.
 	CharmURL *charm.URL
 
+	// Channel identifies the channel from which the charm will come.
+	Channel csparams.Channel
+
 	// CharmStoreMacaroon is the macaroon to use for the charm when
 	// interacting with the charm store.
 	CharmStoreMacaroon *macaroon.Macaroon
@@ -122,7 +126,7 @@ type AddPendingResourcesArgs struct {
 // AddPendingResources sends the provided resource info up to Juju
 // without making it available yet.
 func (c Client) AddPendingResources(args AddPendingResourcesArgs) (pendingIDs []string, err error) {
-	apiArgs, err := api.NewAddPendingResourcesArgs(args.ServiceID, args.CharmURL, args.CharmStoreMacaroon, args.Resources)
+	apiArgs, err := api.NewAddPendingResourcesArgs(args.ServiceID, args.CharmURL, args.Channel, args.CharmStoreMacaroon, args.Resources)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/resource/api/data.go
+++ b/resource/api/data.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/names"
 	"gopkg.in/juju/charm.v6-unstable"
 	charmresource "gopkg.in/juju/charm.v6-unstable/resource"
+	csparams "gopkg.in/juju/charmrepo.v2-unstable/csclient/params"
 	"gopkg.in/macaroon.v1"
 
 	"github.com/juju/juju/apiserver/params"
@@ -53,7 +54,7 @@ type AddPendingResourcesArgs struct {
 
 // NewAddPendingResourcesArgs returns the arguments for the
 // AddPendingResources API endpoint.
-func NewAddPendingResourcesArgs(serviceID string, cURL *charm.URL, csMac *macaroon.Macaroon, resources []charmresource.Resource) (AddPendingResourcesArgs, error) {
+func NewAddPendingResourcesArgs(serviceID string, cURL *charm.URL, channel csparams.Channel, csMac *macaroon.Macaroon, resources []charmresource.Resource) (AddPendingResourcesArgs, error) {
 	var args AddPendingResourcesArgs
 
 	if !names.IsValidService(serviceID) {
@@ -73,6 +74,7 @@ func NewAddPendingResourcesArgs(serviceID string, cURL *charm.URL, csMac *macaro
 	args.Resources = apiResources
 	if cURL != nil {
 		args.URL = cURL.String()
+		args.Channel = string(channel)
 		args.CharmStoreMacaroon = csMac
 	}
 	return args, nil

--- a/resource/cmd/deploy_test.go
+++ b/resource/cmd/deploy_test.go
@@ -14,6 +14,7 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v6-unstable"
 	charmresource "gopkg.in/juju/charm.v6-unstable/resource"
+	csparams "gopkg.in/juju/charmrepo.v2-unstable/csclient/params"
 	"gopkg.in/macaroon.v1"
 )
 
@@ -313,7 +314,7 @@ type uploadDeps struct {
 	ReadSeekCloser ReadSeekCloser
 }
 
-func (s uploadDeps) AddPendingResources(serviceID string, cURL *charm.URL, csMac *macaroon.Macaroon, resources []charmresource.Resource) (ids []string, err error) {
+func (s uploadDeps) AddPendingResources(serviceID string, cURL *charm.URL, channel csparams.Channel, csMac *macaroon.Macaroon, resources []charmresource.Resource) (ids []string, err error) {
 	charmresource.Sort(resources)
 	s.stub.AddCall("AddPendingResources", serviceID, cURL, csMac, resources)
 	if err := s.stub.NextErr(); err != nil {

--- a/resource/cmd/list_charm_resources.go
+++ b/resource/cmd/list_charm_resources.go
@@ -8,6 +8,7 @@ import (
 	"github.com/juju/errors"
 	"gopkg.in/juju/charm.v6-unstable"
 	charmresource "gopkg.in/juju/charm.v6-unstable/resource"
+	csparams "gopkg.in/juju/charmrepo.v2-unstable/csclient/params"
 	"launchpad.net/gnuflag"
 
 	"github.com/juju/juju/charmstore"
@@ -121,7 +122,7 @@ func (c *ListCharmResourcesCommand) Run(ctx *cmd.Context) error {
 
 	charms := make([]charmstore.CharmID, len(charmURLs))
 	for i, id := range charmURLs {
-		charms[i] = charmstore.CharmID{URL: id, Channel: charm.Channel(c.channel)}
+		charms[i] = charmstore.CharmID{URL: id, Channel: csparams.Channel(c.channel)}
 	}
 
 	resources, err := apiclient.ListResources(charms)

--- a/resource/resourceadapters/deploy.go
+++ b/resource/resourceadapters/deploy.go
@@ -37,10 +37,10 @@ func DeployResources(serviceID string, cURL *charm.URL, channel csparams.Channel
 		}
 	}
 
-	// TODO(ericsnow) Pass the channel here.
 	ids, err = cmd.DeployResources(cmd.DeployResourcesArgs{
 		ServiceID:          serviceID,
 		CharmURL:           cURL,
+		Channel:            channel,
 		CharmStoreMacaroon: csMac,
 		Filenames:          filenames,
 		Revisions:          revisions,
@@ -58,10 +58,11 @@ type deployClient struct {
 }
 
 // AddPendingResources adds pending metadata for store-based resources.
-func (cl *deployClient) AddPendingResources(serviceID string, cURL *charm.URL, csMac *macaroon.Macaroon, resources []charmresource.Resource) ([]string, error) {
+func (cl *deployClient) AddPendingResources(serviceID string, cURL *charm.URL, channel csparams.Channel, csMac *macaroon.Macaroon, resources []charmresource.Resource) ([]string, error) {
 	return cl.Client.AddPendingResources(client.AddPendingResourcesArgs{
 		ServiceID:          serviceID,
 		CharmURL:           cURL,
+		Channel:            channel,
 		CharmStoreMacaroon: csMac,
 		Resources:          resources,
 	})

--- a/resource/resourceadapters/deploy.go
+++ b/resource/resourceadapters/deploy.go
@@ -9,6 +9,7 @@ import (
 	"github.com/juju/errors"
 	"gopkg.in/juju/charm.v6-unstable"
 	charmresource "gopkg.in/juju/charm.v6-unstable/resource"
+	csparams "gopkg.in/juju/charmrepo.v2-unstable/csclient/params"
 	"gopkg.in/macaroon.v1"
 
 	"github.com/juju/juju/api"
@@ -19,7 +20,7 @@ import (
 // DeployResources uploads the bytes for the given files to the server and
 // creates pending resource metadata for the all resource mentioned in the
 // metadata. It returns a map of resource name to pending resource IDs.
-func DeployResources(serviceID string, cURL *charm.URL, csMac *macaroon.Macaroon, filesAndRevisions map[string]string, resources map[string]charmresource.Meta, conn api.Connection) (ids map[string]string, err error) {
+func DeployResources(serviceID string, cURL *charm.URL, channel csparams.Channel, csMac *macaroon.Macaroon, filesAndRevisions map[string]string, resources map[string]charmresource.Meta, conn api.Connection) (ids map[string]string, err error) {
 	client, err := newAPIClient(conn)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -36,6 +37,7 @@ func DeployResources(serviceID string, cURL *charm.URL, csMac *macaroon.Macaroon
 		}
 	}
 
+	// TODO(ericsnow) Pass the channel here.
 	ids, err = cmd.DeployResources(cmd.DeployResourcesArgs{
 		ServiceID:          serviceID,
 		CharmURL:           cURL,


### PR DESCRIPTION
We currently have the channels in the deploy and upgrade-charm commands.  However, we need to store them in the DB for later use.  This patch does so.

(Review request: http://reviews.vapour.ws/r/4443/)