### PR TITLE
lxd provider: use right bind address for LXD

### DIFF
--- a/container/lxd/lxd.go
+++ b/container/lxd/lxd.go
@@ -7,7 +7,6 @@ package lxd
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
@@ -267,19 +266,4 @@ func (manager *containerManager) createNetworkProfile(profile string, networkCon
 	}
 
 	return nil
-}
-
-// GetDefaultBridgeName returns the name of the default bridge for lxd.
-func GetDefaultBridgeName() (string, error) {
-	_, err := os.Lstat("/sys/class/net/lxdbr0/bridge")
-	if err == nil {
-		return "lxdbr0", nil
-	}
-
-	/* if it was some unknown error, return that */
-	if !os.IsNotExist(err) {
-		return "", err
-	}
-
-	return "lxcbr0", nil
 }

--- a/tools/lxdclient/remote.go
+++ b/tools/lxdclient/remote.go
@@ -9,8 +9,6 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/utils"
 	lxdshared "github.com/lxc/lxd/shared"
-
-	"github.com/juju/juju/container/lxc"
 )
 
 const (
@@ -192,7 +190,10 @@ func (r Remote) UsingTCP() (Remote, error) {
 	// TODO: jam 2016-02-25 This should be updated for systems that are
 	// 	 space aware, as we may not be just using the default LXC
 	// 	 bridge.
-	netIF := lxc.DefaultLxcBridge
+	netIF, err := GetDefaultBridgeName()
+	if err != nil {
+		return r, errors.Trace(err)
+	}
 	addr, err := utils.GetAddressForInterface(netIF)
 	if err != nil {
 		return r, errors.Trace(err)

--- a/tools/lxdclient/utils.go
+++ b/tools/lxdclient/utils.go
@@ -7,6 +7,7 @@ package lxdclient
 
 import (
 	"bytes"
+	"os"
 
 	"github.com/juju/errors"
 	"github.com/juju/utils/series"
@@ -59,4 +60,19 @@ func IsRunningLocally() (bool, error) {
 	}
 
 	return running, nil
+}
+
+// GetDefaultBridgeName returns the name of the default bridge for lxd.
+func GetDefaultBridgeName() (string, error) {
+	_, err := os.Lstat("/sys/class/net/lxdbr0/bridge")
+	if err == nil {
+		return "lxdbr0", nil
+	}
+
+	/* if it was some unknown error, return that */
+	if !os.IsNotExist(err) {
+		return "", err
+	}
+
+	return "lxcbr0", nil
 }

--- a/tools/lxdclient/utils_go12.go
+++ b/tools/lxdclient/utils_go12.go
@@ -1,0 +1,11 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// +build !go1.3
+
+package lxdclient
+
+func GetDefaultBridgeName() (string, error) {
+	/* lxd not supported in go1.2 */
+	return "lxcbr0", nil
+}

--- a/worker/provisioner/lxd-broker.go
+++ b/worker/provisioner/lxd-broker.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/juju/container/lxd"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/instance"
+	"github.com/juju/juju/tools/lxdclient"
 )
 
 var lxdLogger = loggo.GetLogger("juju.provisioner.lxd")
@@ -56,7 +57,7 @@ func (broker *lxdBroker) StartInstance(args environs.StartInstanceParams) (*envi
 	bridgeDevice := broker.agentConfig.Value(agent.LxcBridge)
 	if bridgeDevice == "" {
 		var err error
-		bridgeDevice, err = lxd.GetDefaultBridgeName()
+		bridgeDevice, err = lxdclient.GetDefaultBridgeName()
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -150,7 +151,7 @@ func (broker *lxdBroker) MaintainInstance(args environs.StartInstanceParams) err
 	bridgeDevice := broker.agentConfig.Value(agent.LxdBridge)
 	if bridgeDevice == "" {
 		var err error
-		bridgeDevice, err = lxd.GetDefaultBridgeName()
+		bridgeDevice, err = lxdclient.GetDefaultBridgeName()
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Prevents:

ERROR cannot find network interface "lxcbr0": route ip+net: no such network interface
ERROR invalid config: route ip+net: no such network interface

when the user doesn't have a lxcbr0 (i.e. doesn't have lxc1 installed).

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>

(Review request: http://reviews.vapour.ws/r/4446/)