### PR TITLE
provider/dummy: remove call to dummy.Reset in init()

### DIFF
--- a/agent/agentbootstrap/bootstrap_test.go
+++ b/agent/agentbootstrap/bootstrap_test.go
@@ -133,7 +133,7 @@ LXC_BRIDGE="ignored"`[1:])
 	c.Assert(err, jc.ErrorIsNil)
 	envCfg, err = provider.BootstrapConfig(environs.BootstrapConfigParams{Config: envCfg})
 	c.Assert(err, jc.ErrorIsNil)
-	defer dummy.Reset()
+	defer dummy.Reset(c)
 
 	hostedModelUUID := utils.MustNewUUID().String()
 	hostedModelConfigAttrs := map[string]interface{}{

--- a/apiserver/addresser/addresser_test.go
+++ b/apiserver/addresser/addresser_test.go
@@ -61,7 +61,7 @@ func (s *AddresserSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *AddresserSuite) TearDownTest(c *gc.C) {
-	dummy.Reset()
+	dummy.Reset(c)
 	s.BaseSuite.TearDownTest(c)
 }
 

--- a/apiserver/common/modelwatcher_test.go
+++ b/apiserver/common/modelwatcher_test.go
@@ -50,7 +50,7 @@ func (f *fakeModelAccessor) ModelConfig() (*config.Config, error) {
 }
 
 func (s *environWatcherSuite) TearDownTest(c *gc.C) {
-	dummy.Reset()
+	dummy.Reset(c)
 	s.BaseSuite.TearDownTest(c)
 }
 

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -121,7 +121,7 @@ func (s *BootstrapSuite) TearDownTest(c *gc.C) {
 	s.ToolsFixture.TearDownTest(c)
 	s.MgoSuite.TearDownTest(c)
 	s.FakeJujuXDGDataHomeSuite.TearDownTest(c)
-	dummy.Reset()
+	dummy.Reset(c)
 }
 
 func (s *BootstrapSuite) newBootstrapCommand() cmd.Command {
@@ -178,7 +178,7 @@ func (s *BootstrapSuite) TestBootstrapAPIReadyRetries(c *gc.C) {
 		{-1, errOther}, // another error is returned
 	} {
 		resetJujuXDGDataHome(c)
-		dummy.Reset()
+		dummy.Reset(c)
 		s.store = jujuclienttesting.NewMemStore()
 
 		s.mockBlockClient.numRetries = t.numRetries
@@ -259,7 +259,7 @@ func (s *BootstrapSuite) run(c *gc.C, test bootstrapTest) testing.Restorer {
 	// Create home with dummy provider and remove all
 	// of its envtools.
 	resetJujuXDGDataHome(c)
-	dummy.Reset()
+	dummy.Reset(c)
 
 	var restore testing.Restorer = func() {
 		s.store = jujuclienttesting.NewMemStore()

--- a/cmd/jujud/bootstrap_test.go
+++ b/cmd/jujud/bootstrap_test.go
@@ -100,7 +100,7 @@ func (s *BootstrapSuite) SetUpSuite(c *gc.C) {
 func (s *BootstrapSuite) TearDownSuite(c *gc.C) {
 	s.MgoSuite.TearDownSuite(c)
 	s.BaseSuite.TearDownSuite(c)
-	dummy.Reset()
+	dummy.Reset(c)
 }
 
 func (s *BootstrapSuite) SetUpTest(c *gc.C) {

--- a/cmd/plugins/juju-metadata/imagemetadata_test.go
+++ b/cmd/plugins/juju-metadata/imagemetadata_test.go
@@ -248,6 +248,6 @@ func (s *ImageMetadataSuite) TestImageMetadataBadArgs(c *gc.C) {
 		c.Logf("test: %d", i)
 		_, err := runImageMetadata(c, s.store, t.args...)
 		c.Check(err, gc.NotNil, gc.Commentf("test %d: %s", i, t.args))
-		dummy.Reset()
+		dummy.Reset(c)
 	}
 }

--- a/cmd/plugins/juju-metadata/toolsmetadata_test.go
+++ b/cmd/plugins/juju-metadata/toolsmetadata_test.go
@@ -41,8 +41,8 @@ var _ = gc.Suite(&ToolsMetadataSuite{})
 
 func (s *ToolsMetadataSuite) SetUpTest(c *gc.C) {
 	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
+	s.AddCleanup(dummy.Reset)
 	s.AddCleanup(func(*gc.C) {
-		dummy.Reset()
 		loggo.ResetLoggers()
 	})
 	cfg, err := config.New(config.UseDefaults, map[string]interface{}{

--- a/environs/config_test.go
+++ b/environs/config_test.go
@@ -21,7 +21,7 @@ type suite struct {
 var _ = gc.Suite(&suite{})
 
 func (s *suite) TearDownTest(c *gc.C) {
-	dummy.Reset()
+	dummy.Reset(c)
 	s.FakeJujuXDGDataHomeSuite.TearDownTest(c)
 }
 

--- a/environs/imagemetadata_test.go
+++ b/environs/imagemetadata_test.go
@@ -27,7 +27,7 @@ type ImageMetadataSuite struct {
 var _ = gc.Suite(&ImageMetadataSuite{})
 
 func (s *ImageMetadataSuite) TearDownTest(c *gc.C) {
-	dummy.Reset()
+	dummy.Reset(c)
 	s.BaseSuite.TearDownTest(c)
 }
 

--- a/environs/open_test.go
+++ b/environs/open_test.go
@@ -39,7 +39,7 @@ func (s *OpenSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *OpenSuite) TearDownTest(c *gc.C) {
-	dummy.Reset()
+	dummy.Reset(c)
 	s.ToolsFixture.TearDownTest(c)
 	s.FakeJujuXDGDataHomeSuite.TearDownTest(c)
 }

--- a/environs/tools/tools_test.go
+++ b/environs/tools/tools_test.go
@@ -57,7 +57,7 @@ func (s *SimpleStreamsToolsSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *SimpleStreamsToolsSuite) TearDownTest(c *gc.C) {
-	dummy.Reset()
+	dummy.Reset(c)
 	jujuversion.Current = s.origCurrentVersion
 	s.ToolsFixture.TearDownTest(c)
 	s.BaseSuite.TearDownTest(c)
@@ -95,7 +95,7 @@ func (s *SimpleStreamsToolsSuite) uploadPublic(c *gc.C, verses ...version.Binary
 
 func (s *SimpleStreamsToolsSuite) resetEnv(c *gc.C, attrs map[string]interface{}) {
 	jujuversion.Current = s.origCurrentVersion
-	dummy.Reset()
+	dummy.Reset(c)
 	attrs = dummy.SampleConfig().Merge(attrs)
 	env, err := environs.Prepare(envtesting.BootstrapContext(c),
 		jujuclienttesting.NewMemStore(),

--- a/environs/tools/urls_test.go
+++ b/environs/tools/urls_test.go
@@ -31,7 +31,7 @@ type URLsSuite struct {
 var _ = gc.Suite(&URLsSuite{})
 
 func (s *URLsSuite) TearDownTest(c *gc.C) {
-	dummy.Reset()
+	dummy.Reset(c)
 
 	s.BaseSuite.TearDownTest(c)
 }

--- a/juju/api_test.go
+++ b/juju/api_test.go
@@ -76,7 +76,7 @@ func (cs *NewAPIClientSuite) SetUpTest(c *gc.C) {
 }
 
 func (cs *NewAPIClientSuite) TearDownTest(c *gc.C) {
-	dummy.Reset()
+	dummy.Reset(c)
 	cs.ToolsFixture.TearDownTest(c)
 	cs.MgoSuite.TearDownTest(c)
 	cs.FakeJujuXDGDataHomeSuite.TearDownTest(c)

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -552,8 +552,7 @@ func (s *JujuConnSuite) tearDownConn(c *gc.C) {
 		s.State = nil
 	}
 
-	err := dummy.Reset()
-	c.Assert(err, jc.ErrorIsNil)
+	dummy.Reset(c)
 	utils.SetHome(s.oldHome)
 	osenv.SetJujuXDGDataHome(s.oldJujuXDGDataHome)
 	s.oldHome = ""

--- a/provider/dummy/config_test.go
+++ b/provider/dummy/config_test.go
@@ -23,7 +23,7 @@ type ConfigSuite struct {
 
 func (s *ConfigSuite) TearDownTest(c *gc.C) {
 	s.BaseSuite.TearDownTest(c)
-	dummy.Reset()
+	dummy.Reset(c)
 }
 
 func (*ConfigSuite) TestSecretAttrs(c *gc.C) {

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -36,7 +36,9 @@ import (
 	"github.com/juju/names"
 	"github.com/juju/schema"
 	gitjujutesting "github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/arch"
+	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/environschema.v1"
 
 	"github.com/juju/juju/agent"
@@ -291,9 +293,9 @@ var dummy = environProvider{
 }
 
 // Reset resets the entire dummy environment and forgets any registered
-// operation listener.  All opened environments after Reset will share
+// operation listener. All opened environments after Reset will share
 // the same underlying state.
-func Reset() error {
+func Reset(c *gc.C) {
 	logger.Infof("reset model")
 	dummy.mu.Lock()
 	defer dummy.mu.Unlock()
@@ -306,14 +308,12 @@ func Reset() error {
 	}
 	dummy.state = make(map[string]*environState)
 	if mongoAlive() {
-		if err := gitjujutesting.MgoServer.Reset(); err != nil {
-			return errors.Trace(err)
-		}
+		err := gitjujutesting.MgoServer.Reset()
+		c.Assert(err, jc.ErrorIsNil)
 	}
 	dummy.statePolicy = environs.NewStatePolicy()
 	dummy.supportsSpaces = true
 	dummy.supportsSpaceDiscovery = false
-	return nil
 }
 
 func (state *environState) destroy() {

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -273,14 +273,10 @@ func init() {
 
 	// Prime the first ops channel, so that naive clients can use
 	// the testing environment by simply importing it.
-	c := discardOperations
 	go func() {
-		for _ = range c {
+		for _ = range discardOperations {
 		}
 	}()
-
-	// parse errors are ignored
-	providerDelay, _ = time.ParseDuration(os.Getenv("JUJU_DUMMY_DELAY"))
 }
 
 // dummy is the dummy environmentProvider singleton.
@@ -1652,7 +1648,7 @@ func (inst *dummyInstance) Ports(machineId string) (ports []network.PortRange, e
 // providerDelay controls the delay before dummy responds.
 // non empty values in JUJU_DUMMY_DELAY will be parsed as
 // time.Durations into this value.
-var providerDelay time.Duration
+var providerDelay, _ = time.ParseDuration(os.Getenv("JUJU_DUMMY_DELAY")) // parse errors are ignored
 
 // pause execution to simulate the latency of a real provider
 func delay() {

--- a/provider/dummy/environs_test.go
+++ b/provider/dummy/environs_test.go
@@ -110,7 +110,7 @@ func (s *suite) SetUpTest(c *gc.C) {
 func (s *suite) TearDownTest(c *gc.C) {
 	s.Tests.TearDownTest(c)
 	s.MgoSuite.TearDownTest(c)
-	dummy.Reset()
+	dummy.Reset(c)
 	s.BaseSuite.TearDownTest(c)
 }
 


### PR DESCRIPTION
Remove the call to dummy.Reset in the package's init() function. With
this call removed, we can change the signature of Reset to always take a
gc.C.

Make dummy.Reset take a *gc.C and use that rather than returning an
error (which is frequently ignored).

This also makes the signature of dummy.Reset compatible with
CleanupSuite.AddCleanup.

(Review request: http://reviews.vapour.ws/r/4447/)