### PR TITLE
Fixes 1560625: image metadata not found.

### DIFF
--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -358,7 +358,7 @@ func bootstrapImageMetadata(
 	for _, source := range sources {
 		sourceMetadata, _, err := imagemetadata.Fetch([]simplestreams.DataSource{source}, imageConstraint)
 		if err != nil {
-			logger.Debugf("ignoring image metadata in %s because %v", source.Description(), err)
+			logger.Debugf("ignoring image metadata in %s: %v", source.Description(), err)
 			// Just keep looking...
 			continue
 		}
@@ -366,7 +366,7 @@ func bootstrapImageMetadata(
 		publicImageMetadata = append(publicImageMetadata, sourceMetadata...)
 	}
 
-	logger.Debugf("found %d image metadata from all obtined image data sources", len(publicImageMetadata))
+	logger.Debugf("found %d image metadata from all image data sources", len(publicImageMetadata))
 	if len(publicImageMetadata) == 0 {
 		return nil, errors.New("no image metadata found")
 	}

--- a/environs/bootstrap/bootstrap_test.go
+++ b/environs/bootstrap/bootstrap_test.go
@@ -192,6 +192,48 @@ func (s *bootstrapSuite) TestBootstrapImage(c *gc.C) {
 	c.Assert(env.instanceConfig.Constraints, jc.DeepEquals, bootstrapCons)
 }
 
+// TestBootstrapImageMetadataFromAllSources tests that we are looking for
+// image metadata in all data sources available to environment.
+// Abandoning look up too soon led to misleading bootstrap failures:
+// Juju reported no images available for a particular configuration,
+// despite image metadata in other data sources compatible with the same configuration as well.
+// Related to bug#1560625.
+func (s *bootstrapSuite) TestBootstrapImageMetadataFromAllSources(c *gc.C) {
+	s.PatchValue(&series.HostSeries, func() string { return "raring" })
+	s.PatchValue(&arch.HostArch, func() string { return arch.AMD64 })
+
+	// Ensure that we can find at least one image metadata
+	// early on in the image metadata lookup.
+	// We should continue looking despite it.
+	metadataDir, _ := createImageMetadata(c)
+	stor, err := filestorage.NewFileStorageWriter(metadataDir)
+	c.Assert(err, jc.ErrorIsNil)
+	envtesting.UploadFakeTools(c, stor, "released", "released")
+
+	env := bootstrapEnvironWithRegion{
+		newEnviron("foo", useDefaultKeys, nil),
+		simplestreams.CloudSpec{
+			Region:   "region",
+			Endpoint: "endpoint",
+		},
+	}
+	s.setDummyStorage(c, env.bootstrapEnviron)
+
+	bootstrapCons := constraints.MustParse("arch=amd64")
+	err = bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{
+		BootstrapConstraints: bootstrapCons,
+		MetadataDir:          metadataDir,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	datasources, err := environs.ImageMetadataSources(env)
+	c.Assert(err, jc.ErrorIsNil)
+	for _, source := range datasources {
+		// make sure we looked in each and all...
+		c.Assert(c.GetTestLog(), jc.Contains, fmt.Sprintf("image metadata in %s", source.Description()))
+	}
+}
+
 func (s *bootstrapSuite) TestBootstrapNoToolsNonReleaseStream(c *gc.C) {
 	if runtime.GOOS == "windows" {
 		c.Skip("issue 1403084: Currently does not work because of jujud problems")

--- a/environs/imagemetadata.go
+++ b/environs/imagemetadata.go
@@ -109,7 +109,7 @@ func ImageMetadataSources(env Environ) ([]simplestreams.DataSource, error) {
 		sources = append(sources, source)
 	}
 	for _, ds := range sources {
-		logger.Debugf("using image datasource %q", ds.Description())
+		logger.Debugf("obtained image datasource %q", ds.Description())
 	}
 	return sources, nil
 }

--- a/environs/instances/image.go
+++ b/environs/instances/image.go
@@ -66,6 +66,8 @@ func FindInstanceSpec(possibleImages []Image, ic *InstanceConstraint, allInstanc
 			ic.Series, ic.Region, ic.Arches)
 	}
 
+	logger.Debugf("matching constraints %v", ic)
+	logger.Debugf("against possible image metadata %+v", possibleImages)
 	matchingTypes, err := MatchingInstanceTypes(allInstanceTypes, ic.Region, ic.Constraints)
 	if err != nil {
 		return nil, err

--- a/environs/instances/image.go
+++ b/environs/instances/image.go
@@ -66,8 +66,7 @@ func FindInstanceSpec(possibleImages []Image, ic *InstanceConstraint, allInstanc
 			ic.Series, ic.Region, ic.Arches)
 	}
 
-	logger.Debugf("matching constraints %v", ic)
-	logger.Debugf("against possible image metadata %+v", possibleImages)
+	logger.Debugf("matching constraints %v against possible image metadata %+v", ic, possibleImages)
 	matchingTypes, err := MatchingInstanceTypes(allInstanceTypes, ic.Region, ic.Constraints)
 	if err != nil {
 		return nil, err

--- a/environs/simplestreams/simplestreams.go
+++ b/environs/simplestreams/simplestreams.go
@@ -430,7 +430,7 @@ func getMaybeSignedMetadata(source DataSource, params GetMetadataParams, signed 
 		}
 		return nil, resolveInfo, err
 	}
-	logger.Debugf("read metadata index at %q", indexURL)
+	logger.Tracef("read metadata index at %q", indexURL)
 	items, err := indexRef.getLatestMetadataWithFormat(cons, ProductFormat, signed)
 	if err != nil {
 		if errors.IsNotFound(err) {
@@ -969,7 +969,7 @@ func (indexRef *IndexReference) getLatestMetadataWithFormat(cons LookupConstrain
 	if err != nil {
 		return nil, err
 	}
-	logger.Debugf("metadata: %v", metadata)
+	logger.Tracef("metadata: %v", metadata)
 	matches, err := GetLatestMetadata(metadata, cons, indexRef.Source, indexRef.valueParams.FilterFunc)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Prior to this proposal, at bootstrap, we'd look into all data sources available to us to get an image metadata that can be used. However, we would stop looking at the first match for our desired product - stream and series combination. This does not work very well if the retrieved metadata does not satisfy further filtering: some constraints are checked later at provider level.

This proposal ensures that we look and combine metadata from all data sources relevant to the environment. 

bug: https://bugs.launchpad.net/juju-core/+bug/1560625