### PR TITLE
state: Fix machine principals during import

### DIFF
--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/loggo"
 	"github.com/juju/version"
 	"gopkg.in/juju/charm.v6-unstable"
+	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
 
 	"github.com/juju/juju/constraints"
@@ -400,7 +401,7 @@ func (i *importer) makeMachineDoc(m description.Machine) (*machineDoc, error) {
 		Nonce:                    m.Nonce(),
 		Series:                   m.Series(),
 		ContainerType:            m.ContainerType(),
-		Principals:               nil, // TODO
+		Principals:               nil, // Set during unit import.
 		Life:                     Alive,
 		Tools:                    i.makeTools(m.Tools()),
 		Jobs:                     jobs,
@@ -609,6 +610,17 @@ func (i *importer) unit(s description.Service, u description.Unit) error {
 			Info: u.MeterStatusInfo(),
 		},
 	})
+
+	// If the unit is a principal, add it to its machine.
+	if u.Principal().Id() == "" {
+		ops = append(ops, txn.Op{
+			C:      machinesC,
+			Id:     u.Machine().Id(),
+			Assert: txn.DocExists,
+			Update: bson.M{"$addToSet": bson.M{"principals": u.Name()}},
+		})
+	}
+
 	// We should only have constraints for principal agents.
 	// We don't encode that business logic here, if there are constraints
 	// in the imported model, we put them in the database.

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -380,6 +380,14 @@ func (s *MigrationImportSuite) TestUnits(c *gc.C) {
 	importedMachineId, err := imported.AssignedMachineId()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(importedMachineId, gc.Equals, exportedMachineId)
+
+	// Confirm machine Principals are set.
+	exportedMachine, err := s.State.Machine(exportedMachineId)
+	c.Assert(err, jc.ErrorIsNil)
+	importedMachine, err := newSt.Machine(importedMachineId)
+	c.Assert(err, jc.ErrorIsNil)
+	s.AssertMachineEqual(c, importedMachine, exportedMachine)
+
 	meterStatus, err := imported.GetMeterStatus()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(meterStatus, gc.Equals, state.MeterStatus{state.MeterGreen, "some info"})


### PR DESCRIPTION
The model migration unit import code wasn't assigning princpal units to machine docs. This was causing units to be killed by the deployer post migration.

(Review request: http://reviews.vapour.ws/r/4451/)