### PR TITLE
Download Juju GUI from simplestreams.

### DIFF
--- a/agent/tools/tools_test.go
+++ b/agent/tools/tools_test.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"sort"
 
+	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/version"
 	gc "gopkg.in/check.v1"
@@ -167,7 +168,8 @@ func (t *ToolsSuite) TestReadToolsErrors(c *gc.C) {
 
 func (t *ToolsSuite) TestReadGUIArchiveErrorNotFound(c *gc.C) {
 	gui, err := agenttools.ReadGUIArchive(t.dataDir)
-	c.Assert(err, gc.ErrorMatches, "cannot read GUI metadata in tools directory: .*")
+	c.Assert(err, gc.ErrorMatches, "GUI metadata not found")
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 	c.Assert(gui, gc.IsNil)
 }
 

--- a/agent/tools/toolsdir.go
+++ b/agent/tools/toolsdir.go
@@ -187,6 +187,9 @@ func ReadGUIArchive(dataDir string) (*coretools.GUIArchive, error) {
 	dir := SharedGUIDir(dataDir)
 	toolsData, err := ioutil.ReadFile(path.Join(dir, guiArchiveFile))
 	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, errors.NotFoundf("GUI metadata")
+		}
 		return nil, fmt.Errorf("cannot read GUI metadata in tools directory: %v", err)
 	}
 	var gui coretools.GUIArchive

--- a/cloudconfig/userdatacfg_test.go
+++ b/cloudconfig/userdatacfg_test.go
@@ -403,7 +403,7 @@ printf '%s\\n' 'FAKE_NONCE' > '/var/lib/juju/nonce.txt'
 
 	// non controller with GUI (the GUI is not installed)
 	{
-		cfg: makeNormalConfig("quantal").setGUI("file://" + filepath.ToSlash("/path/to/gui.tar.bz2")),
+		cfg: makeNormalConfig("quantal").setGUI("file:///path/to/gui.tar.bz2"),
 		expectScripts: `
 set -xe
 install -D -m 644 /dev/null '/etc/init/juju-clean-shutdown\.conf'

--- a/cloudconfig/userdatacfg_test.go
+++ b/cloudconfig/userdatacfg_test.go
@@ -163,9 +163,9 @@ func (cfg *testInstanceConfig) setMachineID(id string) *testInstanceConfig {
 }
 
 // setGUI populates the configuration with the Juju GUI tools.
-func (cfg *testInstanceConfig) setGUI(path string) *testInstanceConfig {
+func (cfg *testInstanceConfig) setGUI(url string) *testInstanceConfig {
 	cfg.GUI = &tools.GUIArchive{
-		URL:     "file://" + filepath.ToSlash(path),
+		URL:     url,
 		Version: version.MustParse("1.2.3"),
 		Size:    42,
 		SHA256:  "1234",
@@ -403,7 +403,7 @@ printf '%s\\n' 'FAKE_NONCE' > '/var/lib/juju/nonce.txt'
 
 	// non controller with GUI (the GUI is not installed)
 	{
-		cfg: makeNormalConfig("quantal").setGUI("/path/to/gui.tar.bz2"),
+		cfg: makeNormalConfig("quantal").setGUI("file://" + filepath.ToSlash("/path/to/gui.tar.bz2")),
 		expectScripts: `
 set -xe
 install -D -m 644 /dev/null '/etc/init/juju-clean-shutdown\.conf'
@@ -644,10 +644,53 @@ func (*cloudinitSuite) TestCloudInit(c *gc.C) {
 	}
 }
 
-func (*cloudinitSuite) TestCloudInitWithGUI(c *gc.C) {
+func (*cloudinitSuite) TestCloudInitWithLocalGUI(c *gc.C) {
 	guiPath := path.Join(c.MkDir(), "gui.tar.bz2")
-	err := ioutil.WriteFile(guiPath, []byte("content"), 0644)
-	cfg := makeBootstrapConfig("precise").setGUI(guiPath)
+	content := []byte("content")
+	err := ioutil.WriteFile(guiPath, content, 0644)
+	c.Assert(err, jc.ErrorIsNil)
+	cfg := makeBootstrapConfig("precise").setGUI("file://" + filepath.ToSlash(guiPath))
+	guiJson, err := json.Marshal(cfg.GUI)
+	c.Assert(err, jc.ErrorIsNil)
+	base64Content := base64.StdEncoding.EncodeToString(content)
+	expectedScripts := regexp.QuoteMeta(fmt.Sprintf(`gui='/var/lib/juju/gui'
+mkdir -p $gui
+install -D -m 644 /dev/null '/var/lib/juju/gui/gui.tar.bz2'
+printf %%s %s | base64 -d > '/var/lib/juju/gui/gui.tar.bz2'
+[ -f $gui/gui.tar.bz2 ] && sha256sum $gui/gui.tar.bz2 > $gui/jujugui.sha256
+[ -f $gui/jujugui.sha256 ] && (grep '1234' $gui/jujugui.sha256 && printf %%s '%s' > $gui/downloaded-gui.txt || echo Juju GUI checksum mismatch)
+rm -f $gui/gui.tar.bz2 $gui/jujugui.sha256 $gui/downloaded-gui.txt
+`, base64Content, guiJson))
+	checkCloudInitWithGUI(c, cfg, expectedScripts, "")
+}
+
+func (*cloudinitSuite) TestCloudInitWithRemoteGUI(c *gc.C) {
+	cfg := makeBootstrapConfig("precise").setGUI("https://1.2.3.4/gui.tar.bz2")
+	guiJson, err := json.Marshal(cfg.GUI)
+	c.Assert(err, jc.ErrorIsNil)
+	expectedScripts := regexp.QuoteMeta(fmt.Sprintf(`gui='/var/lib/juju/gui'
+mkdir -p $gui
+curl -sSf -o $gui/gui.tar.bz2 --retry 10 'https://1.2.3.4/gui.tar.bz2' || echo Unable to retrieve Juju GUI
+[ -f $gui/gui.tar.bz2 ] && sha256sum $gui/gui.tar.bz2 > $gui/jujugui.sha256
+[ -f $gui/jujugui.sha256 ] && (grep '1234' $gui/jujugui.sha256 && printf %%s '%s' > $gui/downloaded-gui.txt || echo Juju GUI checksum mismatch)
+rm -f $gui/gui.tar.bz2 $gui/jujugui.sha256 $gui/downloaded-gui.txt
+`, guiJson))
+	checkCloudInitWithGUI(c, cfg, expectedScripts, "")
+}
+
+func (*cloudinitSuite) TestCloudInitWithGUIReadError(c *gc.C) {
+	cfg := makeBootstrapConfig("precise").setGUI("file://" + filepath.ToSlash("/no/such/gui.tar.bz2"))
+	expectedError := "cannot set up Juju GUI: cannot read Juju GUI archive: .*"
+	checkCloudInitWithGUI(c, cfg, "", expectedError)
+}
+
+func (*cloudinitSuite) TestCloudInitWithGUIURLError(c *gc.C) {
+	cfg := makeBootstrapConfig("precise").setGUI(":")
+	expectedError := "cannot set up Juju GUI: cannot parse Juju GUI URL: .*"
+	checkCloudInitWithGUI(c, cfg, "", expectedError)
+}
+
+func checkCloudInitWithGUI(c *gc.C, cfg *testInstanceConfig, expectedScripts string, expectedError string) {
 	envConfig := minimalModelConfig(c)
 	testConfig := cfg.maybeSetModelConfig(envConfig).render()
 	ci, err := cloudinit.New(testConfig.Series)
@@ -655,6 +698,10 @@ func (*cloudinitSuite) TestCloudInitWithGUI(c *gc.C) {
 	udata, err := cloudconfig.NewUserdataConfig(&testConfig, ci)
 	c.Assert(err, jc.ErrorIsNil)
 	err = udata.Configure()
+	if expectedError != "" {
+		c.Assert(err, gc.ErrorMatches, expectedError)
+		return
+	}
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(ci, gc.NotNil)
 	data, err := ci.RenderYAML()
@@ -664,28 +711,8 @@ func (*cloudinitSuite) TestCloudInitWithGUI(c *gc.C) {
 	err = goyaml.Unmarshal(data, &configKeyValues)
 	c.Assert(err, jc.ErrorIsNil)
 
-	guiJson, err := json.Marshal(cfg.GUI)
-	c.Assert(err, jc.ErrorIsNil)
-
 	scripts := getScripts(configKeyValues)
-	expectedScripts := regexp.QuoteMeta(fmt.Sprintf(`sha256sum $gui/gui.tar.bz2 > $gui/jujugui.sha256
-grep '1234' $gui/jujugui.sha256 || (echo Juju GUI checksum mismatch; exit 1)
-printf %%s '%s' > $gui/downloaded-gui.txt
-rm $gui/gui.tar.bz2 $gui/jujugui.sha256 $gui/downloaded-gui.txt
-`, guiJson))
 	assertScriptMatch(c, scripts, expectedScripts, false)
-}
-
-func (*cloudinitSuite) TestCloudInitWithGUIError(c *gc.C) {
-	cfg := makeBootstrapConfig("precise").setGUI("/path/to/gui.tar.bz2")
-	envConfig := minimalModelConfig(c)
-	testConfig := cfg.maybeSetModelConfig(envConfig).render()
-	ci, err := cloudinit.New(testConfig.Series)
-	c.Assert(err, jc.ErrorIsNil)
-	udata, err := cloudconfig.NewUserdataConfig(&testConfig, ci)
-	c.Assert(err, jc.ErrorIsNil)
-	err = udata.Configure()
-	c.Assert(err, gc.ErrorMatches, "cannot fetch Juju GUI: cannot read Juju GUI archive: .*")
 }
 
 func (*cloudinitSuite) TestCloudInitConfigure(c *gc.C) {

--- a/cloudconfig/userdatacfg_test.go
+++ b/cloudconfig/userdatacfg_test.go
@@ -679,7 +679,7 @@ rm -f $gui/gui.tar.bz2 $gui/jujugui.sha256 $gui/downloaded-gui.txt
 }
 
 func (*cloudinitSuite) TestCloudInitWithGUIReadError(c *gc.C) {
-	cfg := makeBootstrapConfig("precise").setGUI("file://" + filepath.ToSlash("/no/such/gui.tar.bz2"))
+	cfg := makeBootstrapConfig("precise").setGUI("file:///no/such/gui.tar.bz2")
 	expectedError := "cannot set up Juju GUI: cannot read Juju GUI archive: .*"
 	checkCloudInitWithGUI(c, cfg, "", expectedError)
 }

--- a/cloudconfig/userdatacfg_unix.go
+++ b/cloudconfig/userdatacfg_unix.go
@@ -397,7 +397,7 @@ func (w *unixConfigure) setUpGUI() (func(), error) {
 		}
 		w.conf.AddRunBinaryFile(path.Join(guiDir, "gui.tar.bz2"), guiData, 0644)
 	} else {
-		// Upload the GUI from simplestreams.
+		// Download the GUI from simplestreams.
 		command := "curl -sSf -o $gui/gui.tar.bz2 --retry 10"
 		if w.icfg.DisableSSLHostnameVerification {
 			command += " --insecure"

--- a/cmd/jujud/bootstrap.go
+++ b/cmd/jujud/bootstrap.go
@@ -305,7 +305,10 @@ func (c *BootstrapCommand) Run(_ *cmd.Context) error {
 
 	// Populate the GUI archive catalogue.
 	if err := c.populateGUIArchive(st, env); err != nil {
-		return err
+		// Do not stop the bootstrapping process for Juju GUI archive errors.
+		logger.Warningf("cannot set up Juju GUI: %s", err)
+	} else {
+		logger.Debugf("Juju GUI successfully set up")
 	}
 
 	// Add custom image metadata to environment storage.
@@ -457,11 +460,6 @@ func (c *BootstrapCommand) populateGUIArchive(st *state.State, env environs.Envi
 	defer guistorage.Close()
 	gui, err := agenttools.ReadGUIArchive(dataDir)
 	if err != nil {
-		if errors.IsNotFound(err) {
-			// Do not fail just because there were errors while downloading
-			// the GUI archive from simplestreams.
-			return nil
-		}
 		return errors.Annotate(err, "cannot fetch GUI info")
 	}
 	f, err := os.Open(filepath.Join(agenttools.SharedGUIDir(dataDir), "gui.tar.bz2"))

--- a/cmd/jujud/bootstrap_test.go
+++ b/cmd/jujud/bootstrap_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	"github.com/juju/names"
 	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -175,8 +176,17 @@ func (s *BootstrapSuite) TestGUIArchiveInfoNotFound(c *gc.C) {
 		"--hosted-model-config", s.b64yamlHostedModelConfig,
 		"--instance-id", string(s.instanceId))
 	c.Assert(err, jc.ErrorIsNil)
-	err = cmd.Run(nil)
+
+	var tw loggo.TestWriter
+	err = loggo.RegisterWriter("bootstrap-test", &tw, loggo.DEBUG)
 	c.Assert(err, jc.ErrorIsNil)
+	defer loggo.RemoveWriter("bootstrap-test")
+
+	err = cmd.Run(nil)
+	c.Assert(tw.Log(), jc.LogMatches, jc.SimpleMessages{{
+		loggo.WARNING,
+		`cannot set up Juju GUI: cannot fetch GUI info: GUI metadata not found`,
+	}})
 }
 
 func (s *BootstrapSuite) TestGUIArchiveInfoError(c *gc.C) {
@@ -190,8 +200,18 @@ func (s *BootstrapSuite) TestGUIArchiveInfoError(c *gc.C) {
 		"--hosted-model-config", s.b64yamlHostedModelConfig,
 		"--instance-id", string(s.instanceId))
 	c.Assert(err, jc.ErrorIsNil)
+
+	var tw loggo.TestWriter
+	err = loggo.RegisterWriter("bootstrap-test", &tw, loggo.DEBUG)
+	c.Assert(err, jc.ErrorIsNil)
+	defer loggo.RemoveWriter("bootstrap-test")
+
 	err = cmd.Run(nil)
-	c.Assert(err, gc.ErrorMatches, "cannot fetch GUI info: cannot read GUI metadata in tools directory: .*")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(tw.Log(), jc.LogMatches, jc.SimpleMessages{{
+		loggo.WARNING,
+		`cannot set up Juju GUI: cannot fetch GUI info: cannot read GUI metadata in tools directory: .*`,
+	}})
 }
 
 func (s *BootstrapSuite) TestGUIArchiveError(c *gc.C) {
@@ -204,8 +224,17 @@ func (s *BootstrapSuite) TestGUIArchiveError(c *gc.C) {
 		"--hosted-model-config", s.b64yamlHostedModelConfig,
 		"--instance-id", string(s.instanceId))
 	c.Assert(err, jc.ErrorIsNil)
+
+	var tw loggo.TestWriter
+	err = loggo.RegisterWriter("bootstrap-test", &tw, loggo.DEBUG)
+	c.Assert(err, jc.ErrorIsNil)
+	defer loggo.RemoveWriter("bootstrap-test")
+
 	err = cmd.Run(nil)
-	c.Assert(err, gc.ErrorMatches, "cannot read GUI archive: .*")
+	c.Assert(tw.Log(), jc.LogMatches, jc.SimpleMessages{{
+		loggo.WARNING,
+		`cannot set up Juju GUI: cannot read GUI archive: .*`,
+	}})
 }
 
 func (s *BootstrapSuite) TestGUIArchiveSuccess(c *gc.C) {
@@ -214,8 +243,18 @@ func (s *BootstrapSuite) TestGUIArchiveSuccess(c *gc.C) {
 		"--hosted-model-config", s.b64yamlHostedModelConfig,
 		"--instance-id", string(s.instanceId))
 	c.Assert(err, jc.ErrorIsNil)
+
+	var tw loggo.TestWriter
+	err = loggo.RegisterWriter("bootstrap-test", &tw, loggo.DEBUG)
+	c.Assert(err, jc.ErrorIsNil)
+	defer loggo.RemoveWriter("bootstrap-test")
+
 	err = cmd.Run(nil)
 	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(tw.Log(), jc.LogMatches, jc.SimpleMessages{{
+		loggo.DEBUG,
+		`Juju GUI successfully set up`,
+	}})
 
 	// Retrieve the state so that it is possible to access the GUI storage.
 	st, err := state.Open(testing.ModelTag, &mongo.MongoInfo{

--- a/cmd/jujud/bootstrap_test.go
+++ b/cmd/jujud/bootstrap_test.go
@@ -165,7 +165,7 @@ func (s *BootstrapSuite) writeDownloadedGUI(c *gc.C, gui *tools.GUIArchive) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-func (s *BootstrapSuite) TestGUIArchiveInfoError(c *gc.C) {
+func (s *BootstrapSuite) TestGUIArchiveInfoNotFound(c *gc.C) {
 	dir := filepath.FromSlash(agenttools.SharedGUIDir(s.dataDir))
 	info := filepath.Join(dir, "downloaded-gui.txt")
 	err := os.Remove(info)
@@ -175,10 +175,23 @@ func (s *BootstrapSuite) TestGUIArchiveInfoError(c *gc.C) {
 		"--hosted-model-config", s.b64yamlHostedModelConfig,
 		"--instance-id", string(s.instanceId))
 	c.Assert(err, jc.ErrorIsNil)
-	// TODO frankban: this must return an error before the feature branch is
-	// merged into master.
 	err = cmd.Run(nil)
 	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *BootstrapSuite) TestGUIArchiveInfoError(c *gc.C) {
+	dir := filepath.FromSlash(agenttools.SharedGUIDir(s.dataDir))
+	info := filepath.Join(dir, "downloaded-gui.txt")
+	err := os.Chmod(info, 0000)
+	c.Assert(err, jc.ErrorIsNil)
+	defer os.Chmod(info, 0600)
+	_, cmd, err := s.initBootstrapCommand(
+		c, nil, "--model-config", s.b64yamlControllerModelConfig,
+		"--hosted-model-config", s.b64yamlHostedModelConfig,
+		"--instance-id", string(s.instanceId))
+	c.Assert(err, jc.ErrorIsNil)
+	err = cmd.Run(nil)
+	c.Assert(err, gc.ErrorMatches, "cannot fetch GUI info: cannot read GUI metadata in tools directory: .*")
 }
 
 func (s *BootstrapSuite) TestGUIArchiveError(c *gc.C) {

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -485,22 +485,27 @@ func guiArchive(output func(string, ...interface{})) *coretools.GUIArchive {
 		}
 	}
 	// Fetch GUI archives info from simplestreams.
-	archives, err := fetchGUIArchives(gui.ReleasedStream, gui.NewDataSource(gui.DefaultBaseURL))
+	allMeta, err := guiFetchMetadata(gui.ReleasedStream, gui.NewDataSource(gui.DefaultBaseURL))
 	if err != nil {
 		output("Unable to fetch Juju GUI info: %s", err)
 		return nil
 	}
-	if len(archives) == 0 {
+	if len(allMeta) == 0 {
 		output("No available Juju GUI archives found")
 		return nil
 	}
-	output("Preparing for Juju GUI %s release installation", archives[0].Version)
-	// Archives are returned in descending version order.
-	return archives[0]
+	// Metadata info are returned in descending version order.
+	output("Preparing for Juju GUI %s release installation", allMeta[0].Version)
+	return &coretools.GUIArchive{
+		Version: allMeta[0].Version,
+		URL:     allMeta[0].FullPath,
+		SHA256:  allMeta[0].SHA256,
+		Size:    allMeta[0].Size,
+	}
 }
 
-// fetchGUIArchives is defined for testing purposes.
-var fetchGUIArchives = gui.FetchGUIArchives
+// guiFetchMetadata is defined for testing purposes.
+var guiFetchMetadata = gui.FetchMetadata
 
 // guiVersion retrieves the GUI version from the juju-gui-* directory included
 // in the bz2 archive at the given path.

--- a/environs/bootstrap/bootstrap_test.go
+++ b/environs/bootstrap/bootstrap_test.go
@@ -67,7 +67,7 @@ func (s *bootstrapSuite) SetUpTest(c *gc.C) {
 	envtesting.UploadFakeTools(c, stor, "released", "released")
 
 	// Patch the function used to retrieve GUI archive info from simplestreams.
-	s.PatchValue(bootstrap.FetchGUIArchives, func(string, ...simplestreams.DataSource) ([]*tools.GUIArchive, error) {
+	s.PatchValue(bootstrap.GUIFetchMetadata, func(string, ...simplestreams.DataSource) ([]*gui.Metadata, error) {
 		return nil, nil
 	})
 }
@@ -291,20 +291,20 @@ func (s *bootstrapSuite) TestSetBootstrapTools(c *gc.C) {
 }
 
 func (s *bootstrapSuite) TestBootstrapGUISuccessRemote(c *gc.C) {
-	s.PatchValue(bootstrap.FetchGUIArchives, func(stream string, sources ...simplestreams.DataSource) ([]*tools.GUIArchive, error) {
+	s.PatchValue(bootstrap.GUIFetchMetadata, func(stream string, sources ...simplestreams.DataSource) ([]*gui.Metadata, error) {
 		c.Assert(stream, gc.Equals, gui.ReleasedStream)
 		c.Assert(sources[0].Description(), gc.Equals, "gui simplestreams")
 		c.Assert(sources[0].RequireSigned(), jc.IsTrue)
-		return []*tools.GUIArchive{{
-			Version: version.MustParse("2.0.42"),
-			URL:     "https://1.2.3.4/juju-gui-2.0.42.tar.bz2",
-			SHA256:  "hash-2.0.42",
-			Size:    42,
+		return []*gui.Metadata{{
+			Version:  version.MustParse("2.0.42"),
+			FullPath: "https://1.2.3.4/juju-gui-2.0.42.tar.bz2",
+			SHA256:   "hash-2.0.42",
+			Size:     42,
 		}, {
-			Version: version.MustParse("2.0.47"),
-			URL:     "https://1.2.3.4/juju-gui-2.0.47.tar.bz2",
-			SHA256:  "hash-2.0.47",
-			Size:    47,
+			Version:  version.MustParse("2.0.47"),
+			FullPath: "https://1.2.3.4/juju-gui-2.0.47.tar.bz2",
+			SHA256:   "hash-2.0.47",
+			Size:     47,
 		}}, nil
 	})
 	env := newEnviron("foo", useDefaultKeys, nil)
@@ -349,7 +349,7 @@ func (s *bootstrapSuite) TestBootstrapGUISuccessLocal(c *gc.C) {
 }
 
 func (s *bootstrapSuite) TestBootstrapGUINoStreams(c *gc.C) {
-	s.PatchValue(bootstrap.FetchGUIArchives, func(string, ...simplestreams.DataSource) ([]*tools.GUIArchive, error) {
+	s.PatchValue(bootstrap.GUIFetchMetadata, func(string, ...simplestreams.DataSource) ([]*gui.Metadata, error) {
 		return nil, nil
 	})
 	env := newEnviron("foo", useDefaultKeys, nil)
@@ -361,7 +361,7 @@ func (s *bootstrapSuite) TestBootstrapGUINoStreams(c *gc.C) {
 }
 
 func (s *bootstrapSuite) TestBootstrapGUIStreamsFailure(c *gc.C) {
-	s.PatchValue(bootstrap.FetchGUIArchives, func(string, ...simplestreams.DataSource) ([]*tools.GUIArchive, error) {
+	s.PatchValue(bootstrap.GUIFetchMetadata, func(string, ...simplestreams.DataSource) ([]*gui.Metadata, error) {
 		return nil, errors.New("bad wolf")
 	})
 	env := newEnviron("foo", useDefaultKeys, nil)

--- a/environs/bootstrap/export_test.go
+++ b/environs/bootstrap/export_test.go
@@ -9,5 +9,5 @@ var (
 	FindTools             = &findTools
 	FindBootstrapTools    = findBootstrapTools
 	FindAvailableTools    = findAvailableTools
-	FetchGUIArchives      = &fetchGUIArchives
+	GUIFetchMetadata      = &guiFetchMetadata
 )

--- a/environs/bootstrap/export_test.go
+++ b/environs/bootstrap/export_test.go
@@ -9,4 +9,5 @@ var (
 	FindTools             = &findTools
 	FindBootstrapTools    = findBootstrapTools
 	FindAvailableTools    = findAvailableTools
+	FetchGUIArchives      = &fetchGUIArchives
 )

--- a/environs/gui/export_test.go
+++ b/environs/gui/export_test.go
@@ -1,0 +1,20 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package gui
+
+import (
+	"github.com/juju/juju/environs/simplestreams"
+)
+
+var (
+	StreamsVersion = streamsVersion
+	DownloadType   = downloadType
+)
+
+func NewConstraint(stream string, majorVersion int) *constraint {
+	return &constraint{
+		LookupParams: simplestreams.LookupParams{Stream: stream},
+		majorVersion: majorVersion,
+	}
+}

--- a/environs/gui/package_test.go
+++ b/environs/gui/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package gui_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/environs/gui/simplestreams.go
+++ b/environs/gui/simplestreams.go
@@ -75,8 +75,13 @@ func FetchGUIArchives(stream string, sources ...simplestreams.DataSource) ([]*to
 // byVersion is used to sort GUI archives by version, most recent first.
 type byVersion []*tools.GUIArchive
 
-func (b byVersion) Len() int           { return len(b) }
-func (b byVersion) Swap(i, j int)      { b[i], b[j] = b[j], b[i] }
+// Len implements sort.Interface.
+func (b byVersion) Len() int { return len(b) }
+
+// Swap implements sort.Interface.
+func (b byVersion) Swap(i, j int) { b[i], b[j] = b[j], b[i] }
+
+// Less implements sort.Interface.
 func (b byVersion) Less(i, j int) bool { return b[i].Version.Compare(b[j].Version) > 0 }
 
 // fetch fetches Juju GUI metadata from simplestreams.

--- a/environs/gui/simplestreams.go
+++ b/environs/gui/simplestreams.go
@@ -1,0 +1,168 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package gui
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/juju/errors"
+	"github.com/juju/utils"
+	"github.com/juju/version"
+
+	"github.com/juju/juju/environs/simplestreams"
+	"github.com/juju/juju/juju"
+	"github.com/juju/juju/tools"
+	jujuversion "github.com/juju/juju/version"
+)
+
+const (
+	// DefaultBaseURL holds the default simplestreams data source URL from
+	// where to retrieve Juju GUI archives.
+	DefaultBaseURL = "https://streams.canonical.com/juju/gui"
+	// ReleasedStream and DevelStreams hold stream names to use when fetching
+	// Juju GUI archives.
+	ReleasedStream = "released"
+	DevelStream    = "devel"
+
+	downloadType      = "content-download"
+	sourceDescription = "gui simplestreams"
+	streamsVersion    = "v1"
+)
+
+func init() {
+	simplestreams.RegisterStructTags(metadata{})
+}
+
+// DataSource creates and returns a new simplestreams signed data source for
+// fetching Juju GUI archives, at the given URL.
+func NewDataSource(baseURL string) simplestreams.DataSource {
+	requireSigned := true
+	return simplestreams.NewURLSignedDataSource(
+		sourceDescription,
+		baseURL,
+		juju.JujuPublicKey,
+		utils.VerifySSLHostnames,
+		simplestreams.DEFAULT_CLOUD_DATA,
+		requireSigned)
+}
+
+// FetchGUIArchives fetches all Juju GUI metadata from simplestreams and
+// returns a list of corresponding GUI archives, sorted by version descending.
+func FetchGUIArchives(stream string, sources ...simplestreams.DataSource) ([]*tools.GUIArchive, error) {
+	allMeta, err := fetch(sources, stream)
+	if err != nil {
+		return nil, errors.Annotate(err, "error fetching simplestreams metadata")
+	}
+	guiArchives := make([]*tools.GUIArchive, len(allMeta))
+	for i, meta := range allMeta {
+		vers, err := version.Parse(meta.Version)
+		if err != nil {
+			return nil, errors.Annotatef(err, "error parsing version %q", meta.Version)
+		}
+		guiArchives[i] = &tools.GUIArchive{
+			Version: vers,
+			URL:     meta.FullPath,
+			Size:    meta.Size,
+			SHA256:  meta.SHA256,
+		}
+	}
+	sort.Sort(byVersion(guiArchives))
+	return guiArchives, nil
+}
+
+// byVersion is used to sort GUI archives by version, most recent first.
+type byVersion []*tools.GUIArchive
+
+func (b byVersion) Len() int           { return len(b) }
+func (b byVersion) Swap(i, j int)      { b[i], b[j] = b[j], b[i] }
+func (b byVersion) Less(i, j int) bool { return b[i].Version.Compare(b[j].Version) > 0 }
+
+// fetch fetches Juju GUI metadata from simplestreams.
+func fetch(sources []simplestreams.DataSource, stream string) ([]*metadata, error) {
+	params := simplestreams.GetMetadataParams{
+		StreamsVersion: streamsVersion,
+		LookupConstraint: &constraint{
+			LookupParams: simplestreams.LookupParams{Stream: stream},
+			majorVersion: jujuversion.Current.Major,
+		},
+		ValueParams: simplestreams.ValueParams{
+			DataType:        downloadType,
+			MirrorContentId: contentId(stream),
+			FilterFunc:      appendArchives,
+			ValueTemplate:   metadata{},
+		},
+	}
+	items, _, err := simplestreams.GetMetadata(sources, params)
+	if err != nil {
+		return nil, err
+	}
+	allMeta := make([]*metadata, len(items))
+	for i, item := range items {
+		allMeta[i] = item.(*metadata)
+	}
+	return allMeta, nil
+}
+
+// constraint is used as simplestreams.LookupConstraint when retrieving Juju
+// GUI metadata information.
+type constraint struct {
+	simplestreams.LookupParams
+	majorVersion int
+}
+
+// IndexIds generates a string array representing index ids formed similarly to
+// an ISCSI qualified name (IQN).
+func (c *constraint) IndexIds() []string {
+	return []string{contentId(c.Stream)}
+}
+
+// ProductIds generates a string array representing product ids formed
+// similarly to an ISCSI qualified name (IQN).
+func (c *constraint) ProductIds() ([]string, error) {
+	return []string{"com.canonical.streams:gui"}, nil
+}
+
+// contentId returns the GUI content id in simplestreams for the given stream.
+func contentId(stream string) string {
+	return fmt.Sprintf("com.canonical.streams:%s:gui", stream)
+}
+
+// appendArchives collects all matching Juju GUI archive metadata information.
+func appendArchives(
+	source simplestreams.DataSource,
+	matchingItems []interface{},
+	items map[string]interface{},
+	cons simplestreams.LookupConstraint,
+) ([]interface{}, error) {
+	var majorVersion int
+	if guiConstraint, ok := cons.(*constraint); ok {
+		majorVersion = guiConstraint.majorVersion
+	}
+	for _, item := range items {
+		meta := item.(*metadata)
+		if majorVersion != 0 && majorVersion != meta.JujuVersion {
+			continue
+		}
+		fullPath, err := source.URL(meta.Path)
+		if err != nil {
+			return nil, err
+		}
+		meta.FullPath = fullPath
+		matchingItems = append(matchingItems, meta)
+	}
+	return matchingItems, nil
+}
+
+// metadata is the type used to retrieve GUI archive metadata information from
+// simplestream. Tags for this structure are registered in init().
+type metadata struct {
+	JujuVersion int    `json:"juju-version"`
+	Version     string `json:"version"`
+	Size        int64  `json:"size"`
+	SHA256      string `json:"sha256"`
+	Path        string `json:"path"`
+
+	FullPath string `json:"-"`
+}

--- a/environs/gui/simplestreams_test.go
+++ b/environs/gui/simplestreams_test.go
@@ -1,0 +1,330 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package gui_test
+
+import (
+	"net/http"
+
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils"
+	"github.com/juju/version"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/environs/gui"
+	"github.com/juju/juju/environs/simplestreams"
+	sstesting "github.com/juju/juju/environs/simplestreams/testing"
+	"github.com/juju/juju/juju"
+	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/tools"
+	jujuversion "github.com/juju/juju/version"
+)
+
+type simplestreamsSuite struct {
+	sstesting.LocalLiveSimplestreamsSuite
+}
+
+var _ = gc.Suite(&simplestreamsSuite{
+	LocalLiveSimplestreamsSuite: sstesting.LocalLiveSimplestreamsSuite{
+		Source:          simplestreams.NewURLDataSource("test", "test:", utils.VerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA, false),
+		RequireSigned:   false,
+		DataType:        gui.DownloadType,
+		StreamsVersion:  gui.StreamsVersion,
+		ValidConstraint: gui.NewConstraint(gui.ReleasedStream, 2),
+	},
+})
+
+func (s *simplestreamsSuite) SetUpSuite(c *gc.C) {
+	s.LocalLiveSimplestreamsSuite.SetUpSuite(c)
+	sstesting.TestRoundTripper.Sub = coretesting.NewCannedRoundTripper(
+		guiData, map[string]int{"test://unauth": http.StatusUnauthorized})
+}
+
+func (s *simplestreamsSuite) TearDownSuite(c *gc.C) {
+	sstesting.TestRoundTripper.Sub = nil
+	s.LocalLiveSimplestreamsSuite.TearDownSuite(c)
+}
+
+func (s *simplestreamsSuite) TestNewDataSource(c *gc.C) {
+	source := gui.NewDataSource("https://1.2.3.4/streams")
+	c.Assert(source.Description(), gc.Equals, "gui simplestreams")
+
+	url, err := source.URL("/my/path")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(url, gc.Equals, "https://1.2.3.4/streams//my/path")
+
+	c.Assert(source.RequireSigned(), jc.IsTrue)
+	c.Assert(source.PublicSigningKey(), gc.Equals, juju.JujuPublicKey)
+}
+
+var fetchGUIArchiveTests = []struct {
+	about            string
+	stream           string
+	jujuVersion      string
+	expectedArchives []*tools.GUIArchive
+	expectedError    string
+}{{
+	about:       "released version 2",
+	stream:      gui.ReleasedStream,
+	jujuVersion: "2.0.0",
+	expectedArchives: []*tools.GUIArchive{{
+		Version: version.MustParse("2.1.1"),
+		URL:     "test:/gui/2.1.1/jujugui-2.1.1.tar.bz2",
+		Size:    6140774,
+		SHA256:  "5236f1b694a9a66dc4f86b740371408bf4ddf2354ebc6e5410587843a1e55743",
+	}, {
+		Version: version.MustParse("2.1.0"),
+		URL:     "test:/gui/2.1.0/jujugui-2.1.0.tar.bz2",
+		Size:    6098111,
+		SHA256:  "6cec58b36969590d3ff56279a2c63b4f5faf277b0dbeefe1106f666582575894",
+	}},
+}, {
+	about:       "released version 2 beta",
+	stream:      gui.ReleasedStream,
+	jujuVersion: "2.0-beta1",
+	expectedArchives: []*tools.GUIArchive{{
+		Version: version.MustParse("2.1.1"),
+		URL:     "test:/gui/2.1.1/jujugui-2.1.1.tar.bz2",
+		Size:    6140774,
+		SHA256:  "5236f1b694a9a66dc4f86b740371408bf4ddf2354ebc6e5410587843a1e55743",
+	}, {
+		Version: version.MustParse("2.1.0"),
+		URL:     "test:/gui/2.1.0/jujugui-2.1.0.tar.bz2",
+		Size:    6098111,
+		SHA256:  "6cec58b36969590d3ff56279a2c63b4f5faf277b0dbeefe1106f666582575894",
+	}},
+}, {
+	about:       "released version 2.42",
+	stream:      gui.ReleasedStream,
+	jujuVersion: "2.42.0",
+	expectedArchives: []*tools.GUIArchive{{
+		Version: version.MustParse("2.1.1"),
+		URL:     "test:/gui/2.1.1/jujugui-2.1.1.tar.bz2",
+		Size:    6140774,
+		SHA256:  "5236f1b694a9a66dc4f86b740371408bf4ddf2354ebc6e5410587843a1e55743",
+	}, {
+		Version: version.MustParse("2.1.0"),
+		URL:     "test:/gui/2.1.0/jujugui-2.1.0.tar.bz2",
+		Size:    6098111,
+		SHA256:  "6cec58b36969590d3ff56279a2c63b4f5faf277b0dbeefe1106f666582575894",
+	}},
+}, {
+	about:       "released version 3",
+	stream:      gui.ReleasedStream,
+	jujuVersion: "3.0.0",
+	expectedArchives: []*tools.GUIArchive{{
+		Version: version.MustParse("3.0.0"),
+		URL:     "test:/gui/3.0.0/jujugui-3.0.0.tar.bz2",
+		Size:    42424242,
+		SHA256:  "5236f1b694a9a66dc4f86b740371408bf4ddf2354ebc6e5410587843a1e55743",
+	}},
+}, {
+	about:       "released version 47",
+	stream:      gui.ReleasedStream,
+	jujuVersion: "47.0.0",
+}, {
+	about:       "devel version 2",
+	stream:      gui.DevelStream,
+	jujuVersion: "2.0.0",
+	expectedArchives: []*tools.GUIArchive{{
+		Version: version.MustParse("2.4.0"),
+		URL:     "test:/gui/2.4.0/jujugui-2.4.0.tar.bz2",
+		Size:    6098111,
+		SHA256:  "6cec58b36969590d3ff56279a2c63b4f5faf277b0dbeefe1106f666582575894",
+	}, {
+		Version: version.MustParse("2.1.1"),
+		URL:     "test:/gui/2.1.1/jujugui-2.1.1.tar.bz2",
+		Size:    474747,
+		SHA256:  "5236f1b694a9a66dc4f86b740371408bf4ddf2354ebc6e5410587843a1e55743",
+	}},
+}, {
+	about:       "devel version 42",
+	stream:      gui.DevelStream,
+	jujuVersion: "42.0.0",
+}, {
+	about:         "error: invalid stream",
+	stream:        "invalid",
+	jujuVersion:   "2.0.0",
+	expectedError: `error fetching simplestreams metadata: cannot unmarshal JSON metadata at URL "test:/streams/v1/com.canonical.streams-invalid-gui.json": .*`,
+}, {
+	about:         "error: stream not found",
+	stream:        "no-stream",
+	jujuVersion:   "2.0.0",
+	expectedError: `error fetching simplestreams metadata: "content-download" data not found`,
+}, {
+	about:         "error: stream file not found",
+	stream:        "no-such",
+	jujuVersion:   "2.0.0",
+	expectedError: `error fetching simplestreams metadata: cannot read product data, invalid URL "test:/streams/v1/com.canonical.streams-no-such-gui.json" not found`,
+}}
+
+func (s *simplestreamsSuite) TestFetchGUIArchives(c *gc.C) {
+	for i, test := range fetchGUIArchiveTests {
+		c.Logf("\ntest %d: %s", i, test.about)
+
+		// Patch the current Juju version.
+		s.PatchValue(&jujuversion.Current, version.MustParse(test.jujuVersion))
+
+		// Add invalid datasource and check later that resolveInfo is correct.
+		invalidSource := simplestreams.NewURLDataSource(
+			"invalid", "file://invalid", utils.VerifySSLHostnames, simplestreams.DEFAULT_CLOUD_DATA, s.RequireSigned)
+
+		// Fetch the Juju GUI archives.
+		archives, err := gui.FetchGUIArchives(test.stream, invalidSource, s.Source)
+		for i, archive := range archives {
+			c.Logf("archive %d:\n%#v", i, archive)
+		}
+		if test.expectedError != "" {
+			c.Assert(err, gc.ErrorMatches, test.expectedError)
+			c.Assert(archives, gc.IsNil)
+			continue
+		}
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(archives, jc.DeepEquals, test.expectedArchives)
+	}
+}
+
+func (s *simplestreamsSuite) TestConstraint(c *gc.C) {
+	constraint := gui.NewConstraint("test-stream", 42)
+	c.Assert(constraint.IndexIds(), jc.DeepEquals, []string{"com.canonical.streams:test-stream:gui"})
+
+	ids, err := constraint.ProductIds()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ids, jc.DeepEquals, []string{"com.canonical.streams:gui"})
+
+	c.Assert(constraint.Arches, jc.DeepEquals, []string{})
+	c.Assert(constraint.Series, jc.DeepEquals, []string{})
+
+	c.Assert(constraint.Endpoint, gc.Equals, "")
+	c.Assert(constraint.Region, gc.Equals, "")
+	c.Assert(constraint.Stream, gc.Equals, "test-stream")
+}
+
+var guiData = map[string]string{
+	"/streams/v1/index.json": `{
+        "format": "index:1.0",
+        "index": {
+            "com.canonical.streams:devel:gui": {
+                "datatype": "content-download",
+                "format": "products:1.0",
+                "path": "streams/v1/com.canonical.streams-devel-gui.json",
+                "products": [
+                    "com.canonical.streams:gui"
+                ],
+                "updated": "Tue, 05 Apr 2016 16:19:03 +0000"
+            },
+            "com.canonical.streams:released:gui": {
+                "datatype": "content-download",
+                "format": "products:1.0",
+                "path": "streams/v1/com.canonical.streams-released-gui.json",
+                "products": [
+                    "com.canonical.streams:gui"
+                ],
+                "updated": "Fri, 01 Apr 2016 15:47:41 +0000"
+            },
+            "com.canonical.streams:invalid:gui": {
+                "datatype": "content-download",
+                "format": "products:1.0",
+                "path": "streams/v1/com.canonical.streams-invalid-gui.json",
+                "products": [
+                    "com.canonical.streams:gui"
+                ],
+                "updated": "Fri, 01 Apr 2016 15:47:41 +0000"
+            },
+            "com.canonical.streams:no-such:gui": {
+                "datatype": "content-download",
+                "format": "products:1.0",
+                "path": "streams/v1/com.canonical.streams-no-such-gui.json",
+                "products": [
+                    "com.canonical.streams:gui"
+                ],
+                "updated": "Fri, 01 Apr 2016 15:47:41 +0000"
+            }
+        },
+    "updated": "Fri, 01 Apr 2016 15:47:41 +0000"
+    }`,
+	"/streams/v1/com.canonical.streams-devel-gui.json": `{
+        "content_id": "com.canonical.streams:devel:gui",
+        "datatype": "content-download",
+        "format": "products:1.0",
+        "products": {
+            "com.canonical.streams:gui": {
+                "format": "products:1.0",
+                "ftype": "tar.bz2",
+                "versions": {
+                    "20160404": {
+                        "items": {
+                            "2.4.0": {
+                                "juju-version": 2,
+                                "md5": "5af3cb9f2625afbaff904cbd5c65772f",
+                                "path": "gui/2.4.0/jujugui-2.4.0.tar.bz2",
+                                "sha1": "b364a4236a132c75241a75d6ab1c96788c6f38b0",
+                                "sha256": "6cec58b36969590d3ff56279a2c63b4f5faf277b0dbeefe1106f666582575894",
+                                "size": 6098111,
+                                "version": "2.4.0"
+                            },
+                            "2.1.1": {
+                                "juju-version": 2,
+                                "md5": "c49f1707078347cab31b0ff98bfb8dca",
+                                "path": "gui/2.1.1/jujugui-2.1.1.tar.bz2",
+                                "sha1": "1300d555f79b3de3bf334702d027701f69563849",
+                                "sha256": "5236f1b694a9a66dc4f86b740371408bf4ddf2354ebc6e5410587843a1e55743",
+                                "size": 474747,
+                                "version": "2.1.1"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "updated": "Mon, 04 Apr 2016 17:14:58 +0000"
+    }`,
+	"/streams/v1/com.canonical.streams-released-gui.json": `{
+        "content_id": "com.canonical.streams:released:gui",
+        "datatype": "content-download",
+        "format": "products:1.0",
+        "products": {
+            "com.canonical.streams:gui": {
+                "format": "products:1.0",
+                "ftype": "tar.bz2",
+                "versions": {
+                    "20160404": {
+                        "items": {
+                            "2.1.0": {
+                                "juju-version": 2,
+                                "md5": "5af3cb9f2625afbaff904cbd5c65772f",
+                                "path": "gui/2.1.0/jujugui-2.1.0.tar.bz2",
+                                "sha1": "b364a4236a132c75241a75d6ab1c96788c6f38b0",
+                                "sha256": "6cec58b36969590d3ff56279a2c63b4f5faf277b0dbeefe1106f666582575894",
+                                "size": 6098111,
+                                "version": "2.1.0"
+                            },
+                            "2.1.1": {
+                                "juju-version": 2,
+                                "md5": "c49f1707078347cab31b0ff98bfb8dca",
+                                "path": "gui/2.1.1/jujugui-2.1.1.tar.bz2",
+                                "sha1": "1300d555f79b3de3bf334702d027701f69563849",
+                                "sha256": "5236f1b694a9a66dc4f86b740371408bf4ddf2354ebc6e5410587843a1e55743",
+                                "size": 6140774,
+                                "version": "2.1.1"
+                            },
+                            "3.0.0": {
+                                "juju-version": 3,
+                                "md5": "c49f1707078347cab31b0ff98bfb8dca",
+                                "path": "gui/3.0.0/jujugui-3.0.0.tar.bz2",
+                                "sha1": "1300d555f79b3de3bf334702d027701f69563849",
+                                "sha256": "5236f1b694a9a66dc4f86b740371408bf4ddf2354ebc6e5410587843a1e55743",
+                                "size": 42424242,
+                                "version": "3.0.0"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "updated": "Mon, 04 Apr 2016 17:14:58 +0000"
+    }`,
+	"/streams/v1/com.canonical.streams-invalid-gui.json": `
+        bad: wolf
+    `,
+}

--- a/environs/gui/simplestreams_test.go
+++ b/environs/gui/simplestreams_test.go
@@ -154,6 +154,11 @@ var fetchMetadataTests = []struct {
 	jujuVersion:   "2.0.0",
 	expectedError: `error fetching simplestreams metadata: cannot unmarshal JSON metadata at URL "test:/streams/v1/com.canonical.streams-invalid-gui.json": .*`,
 }, {
+	about:         "error: invalid metadata",
+	stream:        "errors",
+	jujuVersion:   "2.0.0",
+	expectedError: `error fetching simplestreams metadata: cannot parse metadata version: invalid version "bad-wolf"`,
+}, {
 	about:         "error: stream not found",
 	stream:        "no-stream",
 	jujuVersion:   "2.0.0",
@@ -242,6 +247,15 @@ var guiData = map[string]string{
                 "datatype": "content-download",
                 "format": "products:1.0",
                 "path": "streams/v1/com.canonical.streams-invalid-gui.json",
+                "products": [
+                    "com.canonical.streams:gui"
+                ],
+                "updated": "Fri, 01 Apr 2016 15:47:41 +0000"
+            },
+            "com.canonical.streams:errors:gui": {
+                "datatype": "content-download",
+                "format": "products:1.0",
+                "path": "streams/v1/com.canonical.streams-errors-gui.json",
                 "products": [
                     "com.canonical.streams:gui"
                 ],
@@ -343,4 +357,31 @@ var guiData = map[string]string{
 	"/streams/v1/com.canonical.streams-invalid-gui.json": `
         bad: wolf
     `,
+	"/streams/v1/com.canonical.streams-errors-gui.json": `{
+        "content_id": "com.canonical.streams:devel:gui",
+        "datatype": "content-download",
+        "format": "products:1.0",
+        "products": {
+            "com.canonical.streams:gui": {
+                "format": "products:1.0",
+                "ftype": "tar.bz2",
+                "versions": {
+                    "20160404": {
+                        "items": {
+                            "2.0.0": {
+                                "juju-version": 2,
+                                "md5": "5af3cb9f2625afbaff904cbd5c65772f",
+                                "path": "gui/2.0.0/jujugui-2.0.0.tar.bz2",
+                                "sha1": "b364a4236a132c75241a75d6ab1c96788c6f38b0",
+                                "sha256": "6cec58b36969590d3ff56279a2c63b4f5faf277b0dbeefe1106f666582575894",
+                                "size": 6098111,
+                                "version": "bad-wolf"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "updated": "Mon, 04 Apr 2016 17:14:58 +0000"
+    }`,
 }


### PR DESCRIPTION
When bootstrapping a Juju model, download the most recent GUI archive
from simplestreams. A failure in getting the GUI from simplestreams
never prevents the model from being bootstrapped.

(Review request: http://reviews.vapour.ws/r/4453/)