### PR TITLE
Fixes bug 1537620: delete ec2 security group with exponential delay btw retries.

### DIFF
--- a/provider/ec2/export_test.go
+++ b/provider/ec2/export_test.go
@@ -95,10 +95,10 @@ func UseTestInstanceTypeData(content instanceTypeCost) {
 }
 
 var (
-	ShortAttempt         = &shortAttempt
-	StorageAttempt       = &storageAttempt
-	DestroyVolumeAttempt = &destroyVolumeAttempt
-	LongAttempt          = &longAttempt
+	ShortAttempt                   = &shortAttempt
+	StorageAttempt                 = &storageAttempt
+	DestroyVolumeAttempt           = &destroyVolumeAttempt
+	DeleteSecurityGroupInsistently = &deleteSecurityGroupInsistently
 )
 
 func EC2ErrCode(err error) string {

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -97,14 +97,8 @@ func (t *localLiveSuite) SetUpSuite(c *gc.C) {
 	t.TestConfig = localConfigAttrs
 	t.restoreEC2Patching = patchEC2ForTesting(c)
 	imagetesting.PatchOfficialDataSources(&t.BaseSuite.CleanupSuite, "test:")
-
-	// with an exponential retry for deleting security groups,
-	// we never return from local live tests.
-	t.BaseSuite.PatchValue(ec2.DeleteSecurityGroupInsistently, func(inst ec2.SecurityGroupCleaner, group amzec2.SecurityGroup) error {
-		return nil
-	})
-
 	t.BaseSuite.PatchValue(&imagemetadata.SimplestreamsImagesPublicKey, sstesting.SignedMetadataPublicKey)
+	t.BaseSuite.PatchValue(ec2.DeleteSecurityGroupInsistently, deleteSecurityGroupForTestFunc)
 	t.srv.createRootDisks = true
 	t.srv.startServer(c)
 }
@@ -217,6 +211,7 @@ func (t *localServerSuite) SetUpSuite(c *gc.C) {
 	t.BaseSuite.PatchValue(&jujuversion.Current, coretesting.FakeVersionNumber)
 	t.BaseSuite.PatchValue(&arch.HostArch, func() string { return arch.AMD64 })
 	t.BaseSuite.PatchValue(&series.HostSeries, func() string { return coretesting.FakeDefaultSeries })
+	t.BaseSuite.PatchValue(ec2.DeleteSecurityGroupInsistently, deleteSecurityGroupForTestFunc)
 	t.srv.createRootDisks = true
 	t.srv.startServer(c)
 	// TODO(jam) I don't understand why we shouldn't do this.
@@ -329,6 +324,24 @@ func (t *localServerSuite) TestBootstrapInstanceUserDataAndState(c *gc.C) {
 
 	_, err = env.ControllerInstances()
 	c.Assert(err, gc.Equals, environs.ErrNotBootstrapped)
+}
+
+func (t *localServerSuite) TestDestroySecurityGroupInsistentlyError(c *gc.C) {
+	env := t.Prepare(c)
+	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{})
+	c.Assert(err, jc.ErrorIsNil)
+
+	called := false
+	msg := "destroy security group error"
+	t.BaseSuite.PatchValue(ec2.DeleteSecurityGroupInsistently, func(inst ec2.SecurityGroupCleaner, group amzec2.SecurityGroup) error {
+		called = true
+		return errors.New(msg)
+	})
+
+	err = env.Destroy()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(called, jc.IsTrue)
+	c.Assert(c.GetTestLog(), jc.Contains, "WARNING juju.provider.ec2 provider failure: destroy security group error")
 }
 
 // splitAuthKeys splits the given authorized keys
@@ -1258,6 +1271,7 @@ func (t *localNonUSEastSuite) SetUpSuite(c *gc.C) {
 	t.PatchValue(&juju.JujuPublicKey, sstesting.SignedMetadataPublicKey)
 
 	t.restoreEC2Patching = patchEC2ForTesting(c)
+	t.BaseSuite.PatchValue(ec2.DeleteSecurityGroupInsistently, deleteSecurityGroupForTestFunc)
 }
 
 func (t *localNonUSEastSuite) TearDownSuite(c *gc.C) {

--- a/provider/ec2/package_test.go
+++ b/provider/ec2/package_test.go
@@ -8,7 +8,6 @@ import (
 	stdtesting "testing"
 
 	"github.com/juju/testing"
-
 	gc "gopkg.in/check.v1"
 )
 

--- a/provider/ec2/securitygroups_test.go
+++ b/provider/ec2/securitygroups_test.go
@@ -1,0 +1,115 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package ec2_test
+
+import (
+	"fmt"
+	"math"
+	"regexp"
+	"time"
+
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	amzec2 "gopkg.in/amz.v3/ec2"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/provider/ec2"
+	coretesting "github.com/juju/juju/testing"
+)
+
+type SecurityGroupSuite struct {
+	coretesting.BaseSuite
+
+	instanceStub *stubInstance
+	deleteFunc   func(inst ec2.SecurityGroupCleaner, group amzec2.SecurityGroup) error
+}
+
+var _ = gc.Suite(&SecurityGroupSuite{})
+
+func (s *SecurityGroupSuite) SetUpSuite(c *gc.C) {
+	s.BaseSuite.SetUpSuite(c)
+	s.deleteFunc = *ec2.DeleteSecurityGroupInsistently
+}
+
+func (s *SecurityGroupSuite) TearDownSuite(c *gc.C) {
+	s.BaseSuite.TearDownSuite(c)
+}
+
+func (s *SecurityGroupSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+	s.instanceStub = &stubInstance{
+		Stub: &testing.Stub{},
+		deleteSecurityGroup: func(group amzec2.SecurityGroup) (resp *amzec2.SimpleResp, err error) {
+			return nil, nil
+		},
+	}
+}
+
+func (s *SecurityGroupSuite) TearDownTest(c *gc.C) {
+	s.BaseSuite.TearDownTest(c)
+}
+
+func (s *SecurityGroupSuite) TestDeleteSecurityGroupSuccess(c *gc.C) {
+	err := s.deleteFunc(s.instanceStub, amzec2.SecurityGroup{})
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *SecurityGroupSuite) TestDeleteSecurityGroupRequestExceedsRate(c *gc.C) {
+	callCount := 0
+	errMsg := "my message"
+	s.instanceStub.deleteSecurityGroup = func(group amzec2.SecurityGroup) (resp *amzec2.SimpleResp, err error) {
+		if callCount == 0 {
+			callCount++
+			return nil, &amzec2.Error{Code: errMsg}
+		}
+		return nil, &amzec2.Error{Code: "RequestLimitExceeded"}
+	}
+	err := s.deleteFunc(s.instanceStub, amzec2.SecurityGroup{})
+	c.Assert(err, gc.ErrorMatches, ec2LikeErrorString(errMsg))
+}
+
+func (s *SecurityGroupSuite) TestDeleteSecurityGroupExponentialRetry(c *gc.C) {
+	callCount := 0
+	maxCalls := 5
+	differencesCount := maxCalls - 1
+	errMsg := "my message"
+
+	timestamps := make([]time.Time, maxCalls)
+	s.instanceStub.deleteSecurityGroup = func(group amzec2.SecurityGroup) (resp *amzec2.SimpleResp, err error) {
+		if callCount < maxCalls {
+			timestamps[callCount] = time.Now()
+			callCount++
+			return nil, &amzec2.Error{Code: errMsg}
+		}
+		return nil, nil
+	}
+	err := s.deleteFunc(s.instanceStub, amzec2.SecurityGroup{})
+	c.Assert(err, jc.ErrorIsNil)
+
+	// difference between calls should double
+	differences := make([]time.Duration, differencesCount)
+	for i := 0; i < differencesCount; i++ {
+		differences[i] = timestamps[i+1].Sub(timestamps[i])
+	}
+
+	// Since retries are measured in seconds,
+	// we expect each consequent delay double in duration
+	for i := 0; i < differencesCount-1; i++ {
+		c.Assert(math.Trunc(differences[i+1].Seconds()), gc.Equals, math.Trunc(differences[i].Seconds())*2)
+	}
+}
+
+func ec2LikeErrorString(msg string) string {
+	return regexp.QuoteMeta(fmt.Sprintf(" (%s)", msg))
+}
+
+type stubInstance struct {
+	*testing.Stub
+	deleteSecurityGroup func(group amzec2.SecurityGroup) (resp *amzec2.SimpleResp, err error)
+}
+
+func (s *stubInstance) DeleteSecurityGroup(group amzec2.SecurityGroup) (resp *amzec2.SimpleResp, err error) {
+	s.MethodCall(s, "DeleteSecurityGroup", group)
+	return s.deleteSecurityGroup(group)
+}

--- a/provider/ec2/securitygroups_test.go
+++ b/provider/ec2/securitygroups_test.go
@@ -55,23 +55,17 @@ func (s *SecurityGroupSuite) TestDeleteSecurityGroupSuccess(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-func (s *SecurityGroupSuite) TestDeleteSecurityGroupRequestExceedsRate(c *gc.C) {
-	callCount := 0
-	errMsg := "my message"
+func (s *SecurityGroupSuite) TestDeleteSecurityGroupInvalidGroupNotFound(c *gc.C) {
 	s.instanceStub.deleteSecurityGroup = func(group amzec2.SecurityGroup) (resp *amzec2.SimpleResp, err error) {
-		if callCount == 0 {
-			callCount++
-			return nil, &amzec2.Error{Code: errMsg}
-		}
-		return nil, &amzec2.Error{Code: "RequestLimitExceeded"}
+		return nil, &amzec2.Error{Code: "InvalidGroup.NotFound"}
 	}
 	err := s.deleteFunc(s.instanceStub, amzec2.SecurityGroup{})
-	c.Assert(err, gc.ErrorMatches, ec2LikeErrorString(errMsg))
+	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *SecurityGroupSuite) TestDeleteSecurityGroupExponentialRetry(c *gc.C) {
 	callCount := 0
-	maxCalls := 5
+	maxCalls := 3
 	differencesCount := maxCalls - 1
 	errMsg := "my message"
 


### PR DESCRIPTION
Added retry for security group delete with exponential delays plus tests.

Also tested manually.

(Review request: http://reviews.vapour.ws/r/4456/)