### PR TITLE
Support hostname and hardwareCharacteristics on maas2Instance

### DIFF
--- a/provider/maas/instance.go
+++ b/provider/maas/instance.go
@@ -18,6 +18,8 @@ import (
 type maasInstance interface {
 	instance.Instance
 	zone() string
+	hostname() (string, error)
+	hardwareCharacteristics() (*instance.HardwareCharacteristics, error)
 }
 
 type maas1Instance struct {

--- a/provider/maas/maas2_test.go
+++ b/provider/maas/maas2_test.go
@@ -73,6 +73,21 @@ type fakeMachine struct {
 	ipAddresses   []string
 	statusName    string
 	statusMessage string
+	cpuCount      int
+	memory        int
+	architecture  string
+}
+
+func (m *fakeMachine) CPUCount() int {
+	return m.cpuCount
+}
+
+func (m *fakeMachine) Memory() int {
+	return m.memory
+}
+
+func (m *fakeMachine) Architecture() string {
+	return m.architecture
 }
 
 func (m *fakeMachine) SystemID() string {

--- a/provider/maas/maas2instance.go
+++ b/provider/maas/maas2instance.go
@@ -5,6 +5,7 @@ package maas
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/juju/gomaasapi"
 
@@ -27,8 +28,7 @@ func (mi *maas2Instance) hostname() (string, error) {
 }
 
 func (mi *maas2Instance) hardwareCharacteristics() (*instance.HardwareCharacteristics, error) {
-	// XXX strip off kernel version from architecture
-	nodeArch := mi.machine.Architecture()
+	nodeArch := strings.Split(mi.machine.Architecture(), "/")[0]
 	nodeCpuCount := uint64(mi.machine.CPUCount())
 	nodeMemoryMB := uint64(mi.machine.Memory())
 	zone := mi.zone()
@@ -38,7 +38,7 @@ func (mi *maas2Instance) hardwareCharacteristics() (*instance.HardwareCharacteri
 		Mem:              &nodeMemoryMB,
 		AvailabilityZone: &zone,
 	}
-	// TODO: also need hardware tags
+	// TODO (mfoord): also need machine tags
 	return hc, nil
 }
 

--- a/provider/maas/maas2instance.go
+++ b/provider/maas/maas2instance.go
@@ -22,6 +22,26 @@ func (mi *maas2Instance) zone() string {
 	return mi.machine.Zone().Name()
 }
 
+func (mi *maas2Instance) hostname() (string, error) {
+	return mi.machine.Hostname(), nil
+}
+
+func (mi *maas2Instance) hardwareCharacteristics() (*instance.HardwareCharacteristics, error) {
+	// XXX strip off kernel version from architecture
+	nodeArch := mi.machine.Architecture()
+	nodeCpuCount := uint64(mi.machine.CPUCount())
+	nodeMemoryMB := uint64(mi.machine.Memory())
+	zone := mi.zone()
+	hc := &instance.HardwareCharacteristics{
+		Arch:             &nodeArch,
+		CpuCores:         &nodeCpuCount,
+		Mem:              &nodeMemoryMB,
+		AvailabilityZone: &zone,
+	}
+	// TODO: also need hardware tags
+	return hc, nil
+}
+
 func (mi *maas2Instance) String() string {
 	return fmt.Sprintf("%s:%s", mi.machine.Hostname(), mi.machine.SystemID())
 }

--- a/provider/maas/maas2instance_test.go
+++ b/provider/maas/maas2instance_test.go
@@ -60,3 +60,28 @@ func (s *maas2InstanceSuite) TestStatusError(c *gc.C) {
 	result := thing.Status()
 	c.Assert(result, jc.DeepEquals, instance.InstanceStatus{"", "error in getting status"})
 }
+
+func (s *maas2InstanceSuite) TestHostname(c *gc.C) {
+	thing := &maas2Instance{&fakeMachine{hostname: "saul-goodman"}}
+	result, err := thing.hostname()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, gc.Equals, "saul-goodman")
+}
+
+func (s *maas2InstanceSuite) TestHardwareCharacteristics(c *gc.C) {
+	machine := &fakeMachine{cpuCount: 3, memory: 4, architecture: "foo/bam", zoneName: "bar"}
+	thing := &maas2Instance{machine}
+	arch := "foo"
+	cpu := uint64(3)
+	mem := uint64(4)
+	zone := "bar"
+	expected := &instance.HardwareCharacteristics{
+		Arch:             &arch,
+		CpuCores:         &cpu,
+		Mem:              &mem,
+		AvailabilityZone: &zone,
+	}
+	result, err := thing.hardwareCharacteristics()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, jc.DeepEquals, expected)
+}


### PR DESCRIPTION
Starting a node needs the hostname and hardwareCharacteristics available on the maasInstance interface and the maas2Instance implementation.

(Review request: http://reviews.vapour.ws/r/4458/)