### PR TITLE
provider/lxd: destroy hosted model instances

### DIFF
--- a/apiserver/common/storagecommon/storage.go
+++ b/apiserver/common/storagecommon/storage.go
@@ -256,7 +256,11 @@ func storageTags(
 	storageInstance state.StorageInstance,
 	cfg *config.Config,
 ) (map[string]string, error) {
-	storageTags := tags.ResourceTags(names.NewModelTag(cfg.UUID()), cfg)
+	storageTags := tags.ResourceTags(
+		names.NewModelTag(cfg.UUID()),
+		names.NewModelTag(cfg.ControllerUUID()),
+		cfg,
+	)
 	if storageInstance != nil {
 		storageTags[tags.JujuStorageInstance] = storageInstance.Tag().Id()
 		storageTags[tags.JujuStorageOwner] = storageInstance.Owner().Id()

--- a/apiserver/common/storagecommon/volumes_test.go
+++ b/apiserver/common/storagecommon/volumes_test.go
@@ -49,9 +49,10 @@ func (*volumesSuite) testVolumeParams(c *gc.C, volumeParams *state.VolumeParams,
 		Provider:  "loop",
 		Size:      1024,
 		Tags: map[string]string{
-			tags.JujuModel: testing.ModelTag.Id(),
-			"a":            "b",
-			"c":            "",
+			tags.JujuController: testing.ModelTag.Id(),
+			tags.JujuModel:      testing.ModelTag.Id(),
+			"a":                 "b",
+			"c":                 "",
 		},
 	})
 }
@@ -74,6 +75,7 @@ func (*volumesSuite) TestVolumeParamsStorageTags(c *gc.C) {
 		Provider:  "loop",
 		Size:      1024,
 		Tags: map[string]string{
+			tags.JujuController:      testing.ModelTag.Id(),
 			tags.JujuModel:           testing.ModelTag.Id(),
 			tags.JujuStorageInstance: "mystore/0",
 			tags.JujuStorageOwner:    "mysql/123",

--- a/apiserver/provisioner/provisioninginfo_test.go
+++ b/apiserver/provisioner/provisioninginfo_test.go
@@ -57,7 +57,8 @@ func (s *withoutControllerSuite) TestProvisioningInfoWithStorage(c *gc.C) {
 				Networks: []string{},
 				Jobs:     []multiwatcher.MachineJob{multiwatcher.JobHostUnits},
 				Tags: map[string]string{
-					tags.JujuModel: coretesting.ModelTag.Id(),
+					tags.JujuController: coretesting.ModelTag.Id(),
+					tags.JujuModel:      coretesting.ModelTag.Id(),
 				},
 			}},
 			{Result: &params.ProvisioningInfo{
@@ -67,7 +68,8 @@ func (s *withoutControllerSuite) TestProvisioningInfoWithStorage(c *gc.C) {
 				Networks:    template.RequestedNetworks,
 				Jobs:        []multiwatcher.MachineJob{multiwatcher.JobHostUnits},
 				Tags: map[string]string{
-					tags.JujuModel: coretesting.ModelTag.Id(),
+					tags.JujuController: coretesting.ModelTag.Id(),
+					tags.JujuModel:      coretesting.ModelTag.Id(),
 				},
 				Volumes: []params.VolumeParams{{
 					VolumeTag:  "volume-0",
@@ -75,7 +77,8 @@ func (s *withoutControllerSuite) TestProvisioningInfoWithStorage(c *gc.C) {
 					Provider:   "static",
 					Attributes: map[string]interface{}{"foo": "bar"},
 					Tags: map[string]string{
-						tags.JujuModel: coretesting.ModelTag.Id(),
+						tags.JujuController: coretesting.ModelTag.Id(),
+						tags.JujuModel:      coretesting.ModelTag.Id(),
 					},
 					Attachment: &params.VolumeAttachmentParams{
 						MachineTag: placementMachine.Tag().String(),
@@ -88,7 +91,8 @@ func (s *withoutControllerSuite) TestProvisioningInfoWithStorage(c *gc.C) {
 					Provider:   "static",
 					Attributes: map[string]interface{}{"foo": "bar"},
 					Tags: map[string]string{
-						tags.JujuModel: coretesting.ModelTag.Id(),
+						tags.JujuController: coretesting.ModelTag.Id(),
+						tags.JujuModel:      coretesting.ModelTag.Id(),
 					},
 					Attachment: &params.VolumeAttachmentParams{
 						MachineTag: placementMachine.Tag().String(),
@@ -166,7 +170,8 @@ func (s *withoutControllerSuite) TestProvisioningInfoWithSingleNegativeAndPositi
 				Networks:    template.RequestedNetworks,
 				Jobs:        []multiwatcher.MachineJob{multiwatcher.JobHostUnits},
 				Tags: map[string]string{
-					tags.JujuModel: coretesting.ModelTag.Id(),
+					tags.JujuController: coretesting.ModelTag.Id(),
+					tags.JujuModel:      coretesting.ModelTag.Id(),
 				},
 				SubnetsToZones: map[string][]string{
 					"subnet-1": []string{"zone1"},
@@ -231,6 +236,7 @@ func (s *withoutControllerSuite) TestProvisioningInfoWithEndpointBindings(c *gc.
 				Series: "quantal",
 				Jobs:   []multiwatcher.MachineJob{multiwatcher.JobHostUnits},
 				Tags: map[string]string{
+					tags.JujuController:    coretesting.ModelTag.Id(),
 					tags.JujuModel:         coretesting.ModelTag.Id(),
 					tags.JujuUnitsDeployed: wordpressUnit.Name(),
 				},
@@ -317,7 +323,8 @@ func (s *withoutControllerSuite) TestStorageProviderFallbackToType(c *gc.C) {
 				Networks:    template.RequestedNetworks,
 				Jobs:        []multiwatcher.MachineJob{multiwatcher.JobHostUnits},
 				Tags: map[string]string{
-					tags.JujuModel: coretesting.ModelTag.Id(),
+					tags.JujuController: coretesting.ModelTag.Id(),
+					tags.JujuModel:      coretesting.ModelTag.Id(),
 				},
 				Volumes: []params.VolumeParams{{
 					VolumeTag:  "volume-1",
@@ -325,7 +332,8 @@ func (s *withoutControllerSuite) TestStorageProviderFallbackToType(c *gc.C) {
 					Provider:   "static",
 					Attributes: nil,
 					Tags: map[string]string{
-						tags.JujuModel: coretesting.ModelTag.Id(),
+						tags.JujuController: coretesting.ModelTag.Id(),
+						tags.JujuModel:      coretesting.ModelTag.Id(),
 					},
 					Attachment: &params.VolumeAttachmentParams{
 						MachineTag: placementMachine.Tag().String(),
@@ -364,7 +372,8 @@ func (s *withoutControllerSuite) TestProvisioningInfoPermissions(c *gc.C) {
 				Networks: []string{},
 				Jobs:     []multiwatcher.MachineJob{multiwatcher.JobHostUnits},
 				Tags: map[string]string{
-					tags.JujuModel: coretesting.ModelTag.Id(),
+					tags.JujuController: coretesting.ModelTag.Id(),
+					tags.JujuModel:      coretesting.ModelTag.Id(),
 				},
 			}},
 			{Error: apiservertesting.NotFoundError("machine 0/lxc/0")},

--- a/apiserver/storageprovisioner/storageprovisioner_test.go
+++ b/apiserver/storageprovisioner/storageprovisioner_test.go
@@ -368,7 +368,8 @@ func (s *provisionerSuite) TestVolumeParams(c *gc.C) {
 				Size:      1024,
 				Provider:  "machinescoped",
 				Tags: map[string]string{
-					tags.JujuModel: testing.ModelTag.Id(),
+					tags.JujuController: testing.ModelTag.Id(),
+					tags.JujuModel:      testing.ModelTag.Id(),
 				},
 				Attachment: &params.VolumeAttachmentParams{
 					MachineTag: "machine-0",
@@ -382,7 +383,8 @@ func (s *provisionerSuite) TestVolumeParams(c *gc.C) {
 				Size:      2048,
 				Provider:  "environscoped",
 				Tags: map[string]string{
-					tags.JujuModel: testing.ModelTag.Id(),
+					tags.JujuController: testing.ModelTag.Id(),
+					tags.JujuModel:      testing.ModelTag.Id(),
 				},
 				Attachment: &params.VolumeAttachmentParams{
 					MachineTag: "machine-0",
@@ -396,7 +398,8 @@ func (s *provisionerSuite) TestVolumeParams(c *gc.C) {
 				Size:      4096,
 				Provider:  "environscoped",
 				Tags: map[string]string{
-					tags.JujuModel: testing.ModelTag.Id(),
+					tags.JujuController: testing.ModelTag.Id(),
+					tags.JujuModel:      testing.ModelTag.Id(),
 				},
 				Attachment: &params.VolumeAttachmentParams{
 					MachineTag: "machine-0",
@@ -430,7 +433,8 @@ func (s *provisionerSuite) TestFilesystemParams(c *gc.C) {
 				Size:          1024,
 				Provider:      "machinescoped",
 				Tags: map[string]string{
-					tags.JujuModel: testing.ModelTag.Id(),
+					tags.JujuController: testing.ModelTag.Id(),
+					tags.JujuModel:      testing.ModelTag.Id(),
 				},
 			}},
 			{Result: params.FilesystemParams{
@@ -438,7 +442,8 @@ func (s *provisionerSuite) TestFilesystemParams(c *gc.C) {
 				Size:          2048,
 				Provider:      "environscoped",
 				Tags: map[string]string{
-					tags.JujuModel: testing.ModelTag.Id(),
+					tags.JujuController: testing.ModelTag.Id(),
+					tags.JujuModel:      testing.ModelTag.Id(),
 				},
 			}},
 			{Error: &params.Error{Message: "permission denied", Code: "unauthorized access"}},

--- a/cloudconfig/instancecfg/instancecfg.go
+++ b/cloudconfig/instancecfg/instancecfg.go
@@ -621,9 +621,13 @@ func FinishInstanceConfig(icfg *InstanceConfig, cfg *config.Config) (err error) 
 // InstanceTags returns the minimum set of tags that should be set on a
 // machine instance, if the provider supports them.
 func InstanceTags(cfg *config.Config, jobs []multiwatcher.MachineJob) map[string]string {
-	instanceTags := tags.ResourceTags(names.NewModelTag(cfg.UUID()), cfg)
+	instanceTags := tags.ResourceTags(
+		names.NewModelTag(cfg.UUID()),
+		names.NewModelTag(cfg.ControllerUUID()),
+		cfg,
+	)
 	if multiwatcher.AnyJobNeedsState(jobs...) {
-		instanceTags[tags.JujuController] = "true"
+		instanceTags[tags.JujuIsController] = "true"
 	}
 	return instanceTags
 }

--- a/cloudconfig/instancecfg/instancecfg_test.go
+++ b/cloudconfig/instancecfg/instancecfg_test.go
@@ -26,11 +26,13 @@ func (*instancecfgSuite) TestInstanceTagsController(c *gc.C) {
 	controllerJobs := []multiwatcher.MachineJob{multiwatcher.JobManageModel}
 	nonControllerJobs := []multiwatcher.MachineJob{multiwatcher.JobHostUnits}
 	testInstanceTags(c, cfg, controllerJobs, map[string]string{
-		"juju-model-uuid":    testing.ModelTag.Id(),
-		"juju-is-controller": "true",
+		"juju-model-uuid":      testing.ModelTag.Id(),
+		"juju-controller-uuid": testing.ModelTag.Id(),
+		"juju-is-controller":   "true",
 	})
 	testInstanceTags(c, cfg, nonControllerJobs, map[string]string{
-		"juju-model-uuid": testing.ModelTag.Id(),
+		"juju-model-uuid":      testing.ModelTag.Id(),
+		"juju-controller-uuid": testing.ModelTag.Id(),
 	})
 }
 
@@ -39,9 +41,10 @@ func (*instancecfgSuite) TestInstanceTagsUserSpecified(c *gc.C) {
 		"resource-tags": "a=b c=",
 	})
 	testInstanceTags(c, cfg, nil, map[string]string{
-		"juju-model-uuid": testing.ModelTag.Id(),
-		"a":               "b",
-		"c":               "",
+		"juju-model-uuid":      testing.ModelTag.Id(),
+		"juju-controller-uuid": testing.ModelTag.Id(),
+		"a": "b",
+		"c": "",
 	})
 }
 

--- a/environs/interface.go
+++ b/environs/interface.go
@@ -210,8 +210,13 @@ type Environ interface {
 	// very recently started instances may not be destroyed
 	// because they are not yet visible.
 	//
+	// If the Environ represents the controller model, then this
+	// method should also destroy any resources relating to hosted
+	// models. This ensures that "kill-controller" can clean up
+	// hosted models when the Juju controller process is unavailable.
+	//
 	// When Destroy has been called, any Environ referring to the
-	// same remote environment may become invalid
+	// same remote environment may become invalid.
 	Destroy() error
 
 	Firewaller

--- a/environs/tags/tags.go
+++ b/environs/tags/tags.go
@@ -13,7 +13,7 @@ const (
 	// Juju model a resource is part of.
 	JujuModel = JujuTagPrefix + "model-uuid"
 
-	// JujuModel is the tag name used for identifying the
+	// JujuController is the tag name used for identifying the
 	// Juju controller that manages a resource.
 	JujuController = JujuTagPrefix + "controller-uuid"
 

--- a/environs/tags/tags.go
+++ b/environs/tags/tags.go
@@ -13,9 +13,13 @@ const (
 	// Juju model a resource is part of.
 	JujuModel = JujuTagPrefix + "model-uuid"
 
-	// JujuController is the tag name used for determining
+	// JujuModel is the tag name used for identifying the
+	// Juju controller that manages a resource.
+	JujuController = JujuTagPrefix + "controller-uuid"
+
+	// JujuIsController is the tag name used for determining
 	// whether a machine instance is a controller or not.
-	JujuController = JujuTagPrefix + "is-controller"
+	JujuIsController = JujuTagPrefix + "is-controller"
 
 	// JujuUnitsDeployed is the tag name used for identifying
 	// the units deployed to a machine instance. The value is
@@ -43,7 +47,7 @@ type ResourceTagger interface {
 
 // ResourceTags returns tags to set on an infrastructure resource
 // for the specified Juju environment.
-func ResourceTags(e names.ModelTag, taggers ...ResourceTagger) map[string]string {
+func ResourceTags(modelTag, controllerTag names.ModelTag, taggers ...ResourceTagger) map[string]string {
 	allTags := make(map[string]string)
 	for _, tagger := range taggers {
 		tags, ok := tagger.ResourceTags()
@@ -54,6 +58,7 @@ func ResourceTags(e names.ModelTag, taggers ...ResourceTagger) map[string]string
 			allTags[k] = v
 		}
 	}
-	allTags[JujuModel] = e.Id()
+	allTags[JujuModel] = modelTag.Id()
+	allTags[JujuController] = controllerTag.Id()
 	return allTags
 }

--- a/environs/tags/tags_test.go
+++ b/environs/tags/tags_test.go
@@ -19,16 +19,18 @@ type tagsSuite struct {
 var _ = gc.Suite(&tagsSuite{})
 
 func (*tagsSuite) TestResourceTagsUUID(c *gc.C) {
-	testResourceTags(c, testing.ModelTag, nil, map[string]string{
-		"juju-model-uuid": testing.ModelTag.Id(),
+	testResourceTags(c, testing.ModelTag, names.NewModelTag(""), nil, map[string]string{
+		"juju-model-uuid":      testing.ModelTag.Id(),
+		"juju-controller-uuid": "",
 	})
-	testResourceTags(c, names.NewModelTag(""), nil, map[string]string{
-		"juju-model-uuid": "",
+	testResourceTags(c, names.NewModelTag(""), testing.ModelTag, nil, map[string]string{
+		"juju-model-uuid":      "",
+		"juju-controller-uuid": testing.ModelTag.Id(),
 	})
 }
 
 func (*tagsSuite) TestResourceTagsResourceTaggers(c *gc.C) {
-	testResourceTags(c, testing.ModelTag, []tags.ResourceTagger{
+	testResourceTags(c, testing.ModelTag, testing.ModelTag, []tags.ResourceTagger{
 		resourceTagger(func() (map[string]string, bool) {
 			return map[string]string{
 				"over":   "ridden",
@@ -51,15 +53,16 @@ func (*tagsSuite) TestResourceTagsResourceTaggers(c *gc.C) {
 			}, true
 		}),
 	}, map[string]string{
-		"juju-model-uuid": testing.ModelTag.Id(),
-		"froman":          "egg",
-		"over":            "easy",
-		"extra":           "play",
+		"juju-model-uuid":      testing.ModelTag.Id(),
+		"juju-controller-uuid": testing.ModelTag.Id(),
+		"froman":               "egg",
+		"over":                 "easy",
+		"extra":                "play",
 	})
 }
 
-func testResourceTags(c *gc.C, tag names.ModelTag, taggers []tags.ResourceTagger, expectTags map[string]string) {
-	tags := tags.ResourceTags(tag, taggers...)
+func testResourceTags(c *gc.C, model, controller names.ModelTag, taggers []tags.ResourceTagger, expectTags map[string]string) {
+	tags := tags.ResourceTags(model, controller, taggers...)
 	c.Assert(tags, jc.DeepEquals, expectTags)
 }
 

--- a/provider/azure/environ.go
+++ b/provider/azure/environ.go
@@ -233,7 +233,7 @@ func createStorageAccount(
 
 // ControllerInstances is specified in the Environ interface.
 func (env *azureEnviron) ControllerInstances() ([]instance.Id, error) {
-	// controllers are tagged with tags.JujuController, so just
+	// controllers are tagged with tags.JujuIsController, so just
 	// list the instances in the controller resource group and pick
 	// those ones out.
 	instances, err := env.allInstances(env.controllerResourceGroup, true)
@@ -243,7 +243,7 @@ func (env *azureEnviron) ControllerInstances() ([]instance.Id, error) {
 	var ids []instance.Id
 	for _, inst := range instances {
 		azureInstance := inst.(*azureInstance)
-		if toTags(azureInstance.Tags)[tags.JujuController] == "true" {
+		if toTags(azureInstance.Tags)[tags.JujuIsController] == "true" {
 			ids = append(ids, inst.Id())
 		}
 	}

--- a/provider/common/bootstrap_test.go
+++ b/provider/common/bootstrap_test.go
@@ -107,8 +107,9 @@ func (s *BootstrapSuite) TestCannotStartInstance(c *gc.C) {
 		expectedMcfg.EnableOSRefreshUpdate = env.Config().EnableOSRefreshUpdate()
 		expectedMcfg.EnableOSUpgrade = env.Config().EnableOSUpgrade()
 		expectedMcfg.Tags = map[string]string{
-			"juju-model-uuid":    coretesting.ModelTag.Id(),
-			"juju-is-controller": "true",
+			"juju-model-uuid":      coretesting.ModelTag.Id(),
+			"juju-controller-uuid": coretesting.ModelTag.Id(),
+			"juju-is-controller":   "true",
 		}
 
 		c.Assert(icfg, jc.DeepEquals, expectedMcfg)

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -1301,6 +1301,7 @@ func (t *localServerSuite) TestInstanceTags(c *gc.C) {
 	c.Assert(ec2Inst.Tags, jc.SameContents, []amzec2.Tag{
 		{"Name", "juju-sample-machine-0"},
 		{"juju-model-uuid", coretesting.ModelTag.Id()},
+		{"juju-controller-uuid", coretesting.ModelTag.Id()},
 		{"juju-is-controller", "true"},
 	})
 }
@@ -1330,6 +1331,7 @@ func (t *localServerSuite) TestRootDiskTags(c *gc.C) {
 	c.Assert(found.Tags, jc.SameContents, []amzec2.Tag{
 		{"Name", "juju-sample-machine-0-root"},
 		{"juju-model-uuid", coretesting.ModelTag.Id()},
+		{"juju-controller-uuid", coretesting.ModelTag.Id()},
 	})
 }
 

--- a/provider/joyent/environ.go
+++ b/provider/joyent/environ.go
@@ -131,7 +131,7 @@ func (env *joyentEnviron) ControllerInstances() ([]instance.Id, error) {
 	filter.Set(tagKey("group"), "juju")
 	filter.Set(tagKey("model"), env.Config().Name())
 	filter.Set(tagKey(tags.JujuModel), env.Config().UUID())
-	filter.Set(tagKey(tags.JujuController), "true")
+	filter.Set(tagKey(tags.JujuIsController), "true")
 
 	machines, err := env.compute.cloudapi.ListMachines(filter)
 	if err != nil || len(machines) == 0 {

--- a/provider/lxd/environ_broker.go
+++ b/provider/lxd/environ_broker.go
@@ -240,6 +240,9 @@ func getMetadata(args environs.StartInstanceParams) (map[string]string, error) {
 			// we cannot allow arbitrary tags to be passed
 			// in by the user. We currently only pass through
 			// Juju-defined tags.
+			//
+			// TODO(axw) 2016-04-11 #1568666
+			// We should reject non-juju tags in config validation.
 			logger.Debugf("ignoring non-juju tag: %s=%s", k, v)
 			continue
 		}

--- a/provider/lxd/environ_broker.go
+++ b/provider/lxd/environ_broker.go
@@ -16,6 +16,7 @@ import (
 	"github.com/juju/juju/cloudconfig/instancecfg"
 	"github.com/juju/juju/cloudconfig/providerinit"
 	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/tags"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/provider/common"
 	"github.com/juju/juju/state/multiwatcher"
@@ -230,14 +231,19 @@ func getMetadata(args environs.StartInstanceParams) (map[string]string, error) {
 	userdata := string(uncompressed)
 
 	metadata := map[string]string{
-		metadataKeyIsState: metadataValueFalse,
-		// We store a gz snapshop of information that is used by
-		// cloud-init and unpacked in to the /var/lib/cloud/instances folder
-		// for the instance.
+		// store the cloud-config userdata for cloud-init.
 		metadataKeyCloudInit: userdata,
 	}
-	if isController(args.InstanceConfig) {
-		metadata[metadataKeyIsState] = metadataValueTrue
+	for k, v := range args.InstanceConfig.Tags {
+		if !strings.HasPrefix(k, tags.JujuTagPrefix) {
+			// Since some metadata is interpreted by LXD,
+			// we cannot allow arbitrary tags to be passed
+			// in by the user. We currently only pass through
+			// Juju-defined tags.
+			logger.Debugf("ignoring non-juju tag: %s=%s", k, v)
+			continue
+		}
+		metadata[k] = v
 	}
 
 	return metadata, nil
@@ -270,8 +276,15 @@ func (env *environ) getHardwareCharacteristics(args environs.StartInstanceParams
 
 // AllInstances implements environs.InstanceBroker.
 func (env *environ) AllInstances() ([]instance.Instance, error) {
-	instances, err := getInstances(env)
-	return instances, errors.Trace(err)
+	environInstances, err := env.allInstances()
+	instances := make([]instance.Instance, len(environInstances))
+	for i, inst := range environInstances {
+		if inst == nil {
+			continue
+		}
+		instances[i] = inst
+	}
+	return instances, err
 }
 
 // StopInstances implements environs.InstanceBroker.

--- a/provider/lxd/environ_instance.go
+++ b/provider/lxd/environ_instance.go
@@ -9,14 +9,11 @@ import (
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/tags"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/provider/common"
 	"github.com/juju/juju/tools/lxdclient"
 )
-
-// instStatus is the list of statuses to accept when filtering
-// for "alive" instances.
-var instStatuses = lxdclient.AliveStatuses
 
 // Instances returns the available instances in the environment that
 // match the provided instance IDs. For IDs that did not match any
@@ -28,7 +25,7 @@ func (env *environ) Instances(ids []instance.Id) ([]instance.Instance, error) {
 		return nil, environs.ErrNoInstances
 	}
 
-	instances, err := getInstances(env)
+	instances, err := env.allInstances()
 	if err != nil {
 		// We don't return the error since we need to pack one instance
 		// for each ID into the result. If there is a problem then we
@@ -59,23 +56,32 @@ func (env *environ) Instances(ids []instance.Id) ([]instance.Instance, error) {
 	return results, err
 }
 
-var getInstances = func(env *environ) ([]instance.Instance, error) {
-	return env.instances()
+func findInst(id instance.Id, instances []*environInstance) instance.Instance {
+	for _, inst := range instances {
+		if id == inst.Id() {
+			return inst
+		}
+	}
+	return nil
 }
 
 // instances returns a list of all "alive" instances in the environment.
-// This means only instances where the IDs match
-// "juju-<env name>-machine-*". This is important because otherwise juju
-// will see they are not tracked in state, assume they're stale/rogue,
-// and shut them down.
-func (env *environ) instances() ([]instance.Instance, error) {
+// We match machine names to the pattern "juju-<model-UUID>-machine-*"
+// to ensure that only machines for the environment are returned. This
+// is necessary to isolate multiple models within the same LXD.
+func (env *environ) allInstances() ([]*environInstance, error) {
 	prefix := common.MachineFullName(env.Config().UUID(), "")
-	instances, err := env.raw.Instances(prefix, instStatuses...)
+	return env.prefixedInstances(prefix)
+}
+
+// prefixedInstances returns instances with the specified prefix.
+func (env *environ) prefixedInstances(prefix string) ([]*environInstance, error) {
+	instances, err := env.raw.Instances(prefix, lxdclient.AliveStatuses...)
 	err = errors.Trace(err)
 
 	// Turn lxdclient.Instance values into *environInstance values,
 	// whether or not we got an error.
-	var results []instance.Instance
+	var results []*environInstance
 	for _, base := range instances {
 		// If we don't make a copy then the same pointer is used for the
 		// base of all resulting instances.
@@ -83,7 +89,6 @@ func (env *environ) instances() ([]instance.Instance, error) {
 		inst := newInstance(&copied, env)
 		results = append(results, inst)
 	}
-
 	return results, err
 }
 
@@ -91,16 +96,14 @@ func (env *environ) instances() ([]instance.Instance, error) {
 // to juju controllers.
 func (env *environ) ControllerInstances() ([]instance.Id, error) {
 	prefix := common.MachineFullName(env.Config().ControllerUUID(), "")
-	instances, err := env.raw.Instances(prefix, instStatuses...)
+	instances, err := env.raw.Instances(prefix, lxdclient.AliveStatuses...)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 
 	var results []instance.Id
 	for _, inst := range instances {
-		metadata := inst.Metadata()
-		isState, ok := metadata[metadataKeyIsState]
-		if ok && isState == metadataValueTrue {
+		if inst.Metadata()[tags.JujuIsController] == "true" {
 			results = append(results, instance.Id(inst.Name))
 		}
 	}

--- a/provider/lxd/environ_instance_test.go
+++ b/provider/lxd/environ_instance_test.go
@@ -104,7 +104,7 @@ func (s *environInstSuite) TestControllerInstancesOkay(c *gc.C) {
 	s.BaseSuite.Client.CheckCall(
 		c, 0, "Instances",
 		"juju-"+s.Env.Config().ControllerUUID()+"-machine-",
-		[]string{"Starting", "Started", "Running"},
+		[]string{"Starting", "Started", "Running", "Stopping", "Stopped"},
 	)
 }
 

--- a/provider/lxd/instance.go
+++ b/provider/lxd/instance.go
@@ -60,15 +60,6 @@ func (inst *environInstance) Addresses() ([]network.Address, error) {
 	return inst.env.raw.Addresses(inst.raw.Name)
 }
 
-func findInst(id instance.Id, instances []instance.Instance) instance.Instance {
-	for _, inst := range instances {
-		if id == inst.Id() {
-			return inst
-		}
-	}
-	return nil
-}
-
 // firewall stuff
 
 // OpenPorts opens the given ports on the instance, which

--- a/provider/lxd/lxd.go
+++ b/provider/lxd/lxd.go
@@ -8,13 +8,11 @@ package lxd
 import (
 	"github.com/juju/loggo"
 
-	"github.com/juju/juju/environs/tags"
 	"github.com/juju/juju/tools/lxdclient"
 )
 
 // The metadata keys used when creating new instances.
 const (
-	metadataKeyIsState   = tags.JujuModel
 	metadataKeyCloudInit = lxdclient.UserdataKey
 )
 

--- a/provider/lxd/testing_test.go
+++ b/provider/lxd/testing_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/environs/tags"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/testing"
@@ -179,8 +180,10 @@ func (s *BaseSuiteUnpatched) initInst(c *gc.C) {
 	}
 
 	s.Metadata = map[string]string{ // userdata
-		metadataKeyIsState:   metadataValueTrue, // bootstrap
-		metadataKeyCloudInit: string(userData),
+		tags.JujuIsController: "true",
+		tags.JujuController:   s.Config.ControllerUUID(),
+		tags.JujuModel:        s.Config.UUID(),
+		metadataKeyCloudInit:  string(userData),
 	}
 	s.Addresses = []network.Address{{
 		Value: "10.0.0.1",
@@ -240,17 +243,21 @@ func (s *BaseSuiteUnpatched) UpdateConfig(c *gc.C, attrs map[string]interface{})
 }
 
 func (s *BaseSuiteUnpatched) NewRawInstance(c *gc.C, name string) *lxdclient.Instance {
+	metadata := make(map[string]string)
+	for k, v := range s.Metadata {
+		metadata[k] = v
+	}
 	summary := lxdclient.InstanceSummary{
 		Name:     name,
 		Status:   lxdclient.StatusRunning,
 		Hardware: *s.Hardware,
-		Metadata: s.Metadata,
+		Metadata: metadata,
 	}
 	instanceSpec := lxdclient.InstanceSpec{
 		Name:      name,
 		Profiles:  []string{},
 		Ephemeral: false,
-		Metadata:  s.Metadata,
+		Metadata:  metadata,
 	}
 	return lxdclient.NewInstance(summary, &instanceSpec)
 }

--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -1724,8 +1724,9 @@ func (t *localServerSuite) TestInstanceTags(c *gc.C) {
 		openstack.InstanceServerDetail(instances[0]).Metadata,
 		jc.DeepEquals,
 		map[string]string{
-			"juju-model-uuid":    coretesting.ModelTag.Id(),
-			"juju-is-controller": "true",
+			"juju-model-uuid":      coretesting.ModelTag.Id(),
+			"juju-controller-uuid": coretesting.ModelTag.Id(),
+			"juju-is-controller":   "true",
 		},
 	)
 }
@@ -1743,9 +1744,10 @@ func (t *localServerSuite) TestTagInstance(c *gc.C) {
 			openstack.InstanceServerDetail(instances[0]).Metadata,
 			jc.DeepEquals,
 			map[string]string{
-				"juju-model-uuid":    coretesting.ModelTag.Id(),
-				"juju-is-controller": "true",
-				extraKey:             extraValue,
+				"juju-model-uuid":      coretesting.ModelTag.Id(),
+				"juju-controller-uuid": coretesting.ModelTag.Id(),
+				"juju-is-controller":   "true",
+				extraKey:               extraValue,
 			},
 		)
 	}

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -575,7 +575,7 @@ func (e *Environ) Bootstrap(ctx environs.BootstrapContext, args environs.Bootstr
 }
 
 func (e *Environ) ControllerInstances() ([]instance.Id, error) {
-	// Find all instances tagged with tags.JujuController.
+	// Find all instances tagged with tags.JujuIsController.
 	instances, err := e.AllInstances()
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -583,7 +583,7 @@ func (e *Environ) ControllerInstances() ([]instance.Id, error) {
 	ids := make([]instance.Id, 0, 1)
 	for _, instance := range instances {
 		detail := instance.(*openstackInstance).getServerDetail()
-		if detail.Metadata[tags.JujuController] == "true" {
+		if detail.Metadata[tags.JujuIsController] == "true" {
 			ids = append(ids, instance.Id())
 		}
 	}

--- a/tools/lxdclient/instance.go
+++ b/tools/lxdclient/instance.go
@@ -48,6 +48,8 @@ var AliveStatuses = []string{
 	StatusStarting,
 	StatusStarted,
 	StatusRunning,
+	StatusStopping,
+	StatusStopped,
 }
 
 // InstanceSpec holds all the information needed to create a new LXD


### PR DESCRIPTION
The LXD provider has been updated so that its
Environ.Destroy method will, when called on
a controller model, destroy instances in hosted
models.

This is enabled by adding "juju-controller-uuid"
to resource tags, and adding all juju-originating
tags to the LXD container metadata.

Other providers are updated to tag also, but
have not yet been updated so that Destroy will
take down hosted models.

Partial fix for https://bugs.launchpad.net/juju-core/+bug/1566011

(Review request: http://reviews.vapour.ws/r/4463/)