### PR TITLE
state: Shorten the names of model migration collections

### DIFF
--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -99,7 +99,7 @@ func allCollections() collectionSchema {
 		modelsC: {global: true},
 
 		// This collection is holds the parameters for model migrations.
-		modelMigrationsC: {
+		migrationsC: {
 			global: true,
 			indexes: []mgo.Index{{
 				Key: []string{"model-uuid"},
@@ -107,12 +107,12 @@ func allCollections() collectionSchema {
 		},
 
 		// This collection tracks the progress of model migrations.
-		modelMigrationStatusC: {global: true},
+		migrationsStatusC: {global: true},
 
 		// This collection records the model migrations which
 		// are currently in progress. It is used to ensure that only
 		// one model migration document exists per environment.
-		modelMigrationsActiveC: {global: true},
+		migrationsActiveC: {global: true},
 
 		// This collection holds user information that's not specific to any
 		// one model.
@@ -420,9 +420,9 @@ const (
 	metricsC                 = "metrics"
 	metricsManagerC          = "metricsmanager"
 	minUnitsC                = "minunits"
-	modelMigrationStatusC    = "modelmigrations.status"
-	modelMigrationsActiveC   = "modelmigrations.active"
-	modelMigrationsC         = "modelmigrations"
+	migrationsStatusC        = "migrations.status"
+	migrationsActiveC        = "migrations.active"
+	migrationsC              = "migrations"
 	modelUserLastConnectionC = "modelUserLastConnection"
 	modelUsersC              = "modelusers"
 	modelsC                  = "models"

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -79,9 +79,9 @@ func (s *MigrationSuite) TestKnownCollections(c *gc.C) {
 		"txns.log",
 
 		// We don't import any of the migration collections.
-		modelMigrationsC,
-		modelMigrationStatusC,
-		modelMigrationsActiveC,
+		migrationsC,
+		migrationsStatusC,
+		migrationsActiveC,
 
 		// The container ref document is primarily there to keep track
 		// of a particular machine's containers. The migration format

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -2654,7 +2654,7 @@ type migrationActiveWatcher struct {
 func newMigrationActiveWatcher(st *State) NotifyWatcher {
 	w := &migrationActiveWatcher{
 		commonWatcher: commonWatcher{st: st},
-		collName:      modelMigrationsActiveC,
+		collName:      migrationsActiveC,
 		sink:          make(chan struct{}),
 	}
 	go func() {
@@ -2734,7 +2734,7 @@ type migrationStatusWatcher struct {
 func newMigrationStatusWatcher(st *State) NotifyWatcher {
 	w := &migrationStatusWatcher{
 		commonWatcher: commonWatcher{st: st},
-		collName:      modelMigrationStatusC,
+		collName:      migrationsStatusC,
 		sink:          make(chan struct{}),
 	}
 	go func() {
@@ -2753,7 +2753,7 @@ func (w *migrationStatusWatcher) Changes() <-chan struct{} {
 func (w *migrationStatusWatcher) loop() error {
 	in := make(chan watcher.Change)
 
-	// Watch the entire modelMigrationStatusC collection for migration
+	// Watch the entire migrationsStatusC collection for migration
 	// status updates related to the State's model. This is more
 	// efficient and simpler than tracking the current active
 	// migration (and changing watchers when one migration finishes


### PR DESCRIPTION
They were a bit unwieldy.

(Review request: http://reviews.vapour.ws/r/4466/)