### PR TITLE
all: prefer AddCleanup to TearDown

### DIFF
--- a/api/charmrevisionupdater/updater_test.go
+++ b/api/charmrevisionupdater/updater_test.go
@@ -29,11 +29,6 @@ func (s *versionUpdaterSuite) SetUpSuite(c *gc.C) {
 	s.CharmSuite.SetUpSuite(c, &s.JujuConnSuite)
 }
 
-func (s *versionUpdaterSuite) TearDownSuite(c *gc.C) {
-	s.CharmSuite.TearDownSuite(c)
-	s.JujuConnSuite.TearDownSuite(c)
-}
-
 func (s *versionUpdaterSuite) SetUpTest(c *gc.C) {
 	s.JujuConnSuite.SetUpTest(c)
 	s.CharmSuite.SetUpTest(c)

--- a/api/client_macaroon_test.go
+++ b/api/client_macaroon_test.go
@@ -37,11 +37,9 @@ func (s *clientMacaroonSuite) SetUpTest(c *gc.C) {
 	// the tests below to exercise the discharging logic
 	// so we clear the cookies.
 	s.cookieJar.Clear()
-}
-
-func (s *clientMacaroonSuite) TearDownTest(c *gc.C) {
-	s.client.Close()
-	s.MacaroonSuite.TearDownTest(c)
+	s.AddCleanup(func(*gc.C) {
+		s.client.Close()
+	})
 }
 
 func (s *clientMacaroonSuite) TestAddLocalCharmWithFailedDischarge(c *gc.C) {

--- a/api/firewaller/machine_test.go
+++ b/api/firewaller/machine_test.go
@@ -32,10 +32,6 @@ func (s *machineSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-func (s *machineSuite) TearDownTest(c *gc.C) {
-	s.firewallerSuite.TearDownTest(c)
-}
-
 func (s *machineSuite) TestMachine(c *gc.C) {
 	apiMachine42, err := s.firewaller.Machine(names.NewMachineTag("42"))
 	c.Assert(err, gc.ErrorMatches, "machine 42 not found")

--- a/api/firewaller/service_test.go
+++ b/api/firewaller/service_test.go
@@ -30,10 +30,6 @@ func (s *serviceSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-func (s *serviceSuite) TearDownTest(c *gc.C) {
-	s.firewallerSuite.TearDownTest(c)
-}
-
 func (s *serviceSuite) TestName(c *gc.C) {
 	c.Assert(s.apiService.Name(), gc.Equals, s.service.Name())
 }

--- a/api/firewaller/state_test.go
+++ b/api/firewaller/state_test.go
@@ -25,10 +25,6 @@ func (s *stateSuite) SetUpTest(c *gc.C) {
 	s.ModelWatcherTests = apitesting.NewModelWatcherTests(s.firewaller, s.BackingState, true)
 }
 
-func (s *stateSuite) TearDownTest(c *gc.C) {
-	s.firewallerSuite.TearDownTest(c)
-}
-
 func (s *stateSuite) TestWatchModelMachines(c *gc.C) {
 	w, err := s.firewaller.WatchModelMachines()
 	c.Assert(err, jc.ErrorIsNil)

--- a/api/firewaller/unit_test.go
+++ b/api/firewaller/unit_test.go
@@ -28,10 +28,6 @@ func (s *unitSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-func (s *unitSuite) TearDownTest(c *gc.C) {
-	s.firewallerSuite.TearDownTest(c)
-}
-
 func (s *unitSuite) TestUnit(c *gc.C) {
 	apiUnitFoo, err := s.firewaller.Unit(names.NewUnitTag("foo/42"))
 	c.Assert(err, gc.ErrorMatches, `unit "foo/42" not found`)

--- a/apiserver/charmrevisionupdater/testing/suite.go
+++ b/apiserver/charmrevisionupdater/testing/suite.go
@@ -38,8 +38,6 @@ func (s *CharmSuite) SetUpSuite(c *gc.C, jcSuite *jujutesting.JujuConnSuite) {
 	s.jcSuite = jcSuite
 }
 
-func (s *CharmSuite) TearDownSuite(c *gc.C) {}
-
 func (s *CharmSuite) SetUpTest(c *gc.C) {
 	db := s.jcSuite.Session.DB("juju-testing")
 	params := charmstore.ServerParams{

--- a/apiserver/charmrevisionupdater/updater_test.go
+++ b/apiserver/charmrevisionupdater/updater_test.go
@@ -39,11 +39,6 @@ func (s *charmVersionSuite) SetUpSuite(c *gc.C) {
 	s.CharmSuite.SetUpSuite(c, &s.JujuConnSuite)
 }
 
-func (s *charmVersionSuite) TearDownSuite(c *gc.C) {
-	s.CharmSuite.TearDownSuite(c)
-	s.JujuConnSuite.TearDownSuite(c)
-}
-
 func (s *charmVersionSuite) SetUpTest(c *gc.C) {
 	s.JujuConnSuite.SetUpTest(c)
 	s.CharmSuite.SetUpTest(c)

--- a/apiserver/client/status_test.go
+++ b/apiserver/client/status_test.go
@@ -169,11 +169,6 @@ func (s *statusUpgradeUnitSuite) SetUpSuite(c *gc.C) {
 	s.CharmSuite.SetUpSuite(c, &s.JujuConnSuite)
 }
 
-func (s *statusUpgradeUnitSuite) TearDownSuite(c *gc.C) {
-	s.CharmSuite.TearDownSuite(c)
-	s.JujuConnSuite.TearDownSuite(c)
-}
-
 func (s *statusUpgradeUnitSuite) SetUpTest(c *gc.C) {
 	s.JujuConnSuite.SetUpTest(c)
 	s.CharmSuite.SetUpTest(c)

--- a/cmd/juju/commands/plugin_test.go
+++ b/cmd/juju/commands/plugin_test.go
@@ -24,7 +24,6 @@ import (
 
 type PluginSuite struct {
 	testing.FakeJujuXDGDataHomeSuite
-	oldPath string
 }
 
 var _ = gc.Suite(&PluginSuite{})
@@ -35,13 +34,11 @@ func (suite *PluginSuite) SetUpTest(c *gc.C) {
 		c.Skip("bug 1403084: tests use bash scrips, will be rewritten for windows")
 	}
 	suite.FakeJujuXDGDataHomeSuite.SetUpTest(c)
-	suite.oldPath = os.Getenv("PATH")
+	oldPath := os.Getenv("PATH")
 	os.Setenv("PATH", "/bin:"+gitjujutesting.HomePath())
-}
-
-func (suite *PluginSuite) TearDownTest(c *gc.C) {
-	os.Setenv("PATH", suite.oldPath)
-	suite.FakeJujuXDGDataHomeSuite.TearDownTest(c)
+	suite.AddCleanup(func(*gc.C) {
+		os.Setenv("PATH", oldPath)
+	})
 }
 
 func (*PluginSuite) TestFindPlugins(c *gc.C) {

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -1697,11 +1697,6 @@ func (s *MachineWithCharmsSuite) SetUpSuite(c *gc.C) {
 	s.CharmSuite.SetUpSuite(c, &s.commonMachineSuite.JujuConnSuite)
 }
 
-func (s *MachineWithCharmsSuite) TearDownSuite(c *gc.C) {
-	s.CharmSuite.TearDownSuite(c)
-	s.commonMachineSuite.TearDownSuite(c)
-}
-
 func (s *MachineWithCharmsSuite) SetUpTest(c *gc.C) {
 	s.commonMachineSuite.SetUpTest(c)
 	s.CharmSuite.SetUpTest(c)

--- a/environs/imagemetadata_test.go
+++ b/environs/imagemetadata_test.go
@@ -26,9 +26,9 @@ type ImageMetadataSuite struct {
 
 var _ = gc.Suite(&ImageMetadataSuite{})
 
-func (s *ImageMetadataSuite) TearDownTest(c *gc.C) {
-	dummy.Reset(c)
-	s.BaseSuite.TearDownTest(c)
+func (s *ImageMetadataSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+	s.AddCleanup(dummy.Reset)
 }
 
 func (s *ImageMetadataSuite) env(c *gc.C, imageMetadataURL, stream string) environs.Environ {

--- a/environs/jujutest/tests.go
+++ b/environs/jujutest/tests.go
@@ -108,10 +108,6 @@ func (t *Tests) SetUpTest(c *gc.C) {
 	t.ControllerStore = jujuclienttesting.NewMemStore()
 }
 
-func (t *Tests) TearDownTest(c *gc.C) {
-	t.ToolsFixture.TearDownTest(c)
-}
-
 func (t *Tests) TestStartStop(c *gc.C) {
 	e := t.Prepare(c)
 	cfg, err := e.Config().Apply(map[string]interface{}{

--- a/environs/open_test.go
+++ b/environs/open_test.go
@@ -36,10 +36,10 @@ func (s *OpenSuite) SetUpTest(c *gc.C) {
 	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
 	s.ToolsFixture.SetUpTest(c)
 	s.PatchValue(&juju.JujuPublicKey, sstesting.SignedMetadataPublicKey)
+	s.AddCleanup(dummy.Reset)
 }
 
 func (s *OpenSuite) TearDownTest(c *gc.C) {
-	dummy.Reset(c)
 	s.ToolsFixture.TearDownTest(c)
 	s.FakeJujuXDGDataHomeSuite.TearDownTest(c)
 }

--- a/environs/simplestreams/datasource_test.go
+++ b/environs/simplestreams/datasource_test.go
@@ -58,10 +58,7 @@ func (s *datasourceHTTPSSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *datasourceHTTPSSuite) TearDownTest(c *gc.C) {
-	if s.Server != nil {
-		s.Server.Close()
-		s.Server = nil
-	}
+	s.Server.Close()
 }
 
 func (s *datasourceHTTPSSuite) TestNormalClientFails(c *gc.C) {

--- a/environs/tools/build_test.go
+++ b/environs/tools/build_test.go
@@ -25,7 +25,6 @@ import (
 
 type buildSuite struct {
 	testing.BaseSuite
-	restore  func()
 	cwd      string
 	filePath string
 	exttest.PatchExecHelper
@@ -65,15 +64,10 @@ func (b *buildSuite) SetUpTest(c *gc.C) {
 	err = os.Chdir(b.cwd)
 	c.Assert(err, jc.ErrorIsNil)
 
-	b.restore = func() {
+	b.AddCleanup(func(*gc.C) {
 		os.Setenv("PATH", path)
 		os.Chdir(cwd)
-	}
-}
-
-func (b *buildSuite) TearDownTest(c *gc.C) {
-	b.restore()
-	b.BaseSuite.TearDownTest(c)
+	})
 }
 
 func (b *buildSuite) TestFindExecutable(c *gc.C) {

--- a/provider/cloudsigma/client_test.go
+++ b/provider/cloudsigma/client_test.go
@@ -50,10 +50,6 @@ func (s *clientSuite) SetUpTest(c *gc.C) {
 	mock.Reset()
 }
 
-func (s *clientSuite) TearDownTest(c *gc.C) {
-	s.BaseSuite.TearDownTest(c)
-}
-
 func testNewClient(c *gc.C, endpoint, username, password string) (*environClient, error) {
 	ecfg := &environConfig{
 		Config: newConfig(c, testing.Attrs{"name": "client-test", "uuid": "f54aac3a-9dcd-4a0c-86b5-24091478478c"}),

--- a/provider/cloudsigma/environ_test.go
+++ b/provider/cloudsigma/environ_test.go
@@ -24,22 +24,6 @@ type environSuite struct {
 
 var _ = gc.Suite(&environSuite{})
 
-func (s *environSuite) SetUpSuite(c *gc.C) {
-	s.BaseSuite.SetUpSuite(c)
-}
-
-func (s *environSuite) TearDownSuite(c *gc.C) {
-	s.BaseSuite.TearDownSuite(c)
-}
-
-func (s *environSuite) SetUpTest(c *gc.C) {
-	s.BaseSuite.SetUpTest(c)
-}
-
-func (s *environSuite) TearDownTest(c *gc.C) {
-	s.BaseSuite.TearDownTest(c)
-}
-
 func (s *environSuite) TestBase(c *gc.C) {
 	s.PatchValue(&newClient, func(*environConfig) (*environClient, error) {
 		return nil, nil

--- a/provider/cloudsigma/environinstance_test.go
+++ b/provider/cloudsigma/environinstance_test.go
@@ -43,11 +43,10 @@ func (s *environInstanceSuite) SetUpSuite(c *gc.C) {
 		"password": mock.TestPassword,
 	}
 	s.baseConfig = newConfig(c, validAttrs().Merge(attrs))
-}
+	s.AddCleanup(func(*gc.C) {
+		mock.Stop()
+	})
 
-func (s *environInstanceSuite) TearDownSuite(c *gc.C) {
-	mock.Stop()
-	s.BaseSuite.TearDownSuite(c)
 }
 
 func (s *environInstanceSuite) SetUpTest(c *gc.C) {
@@ -56,13 +55,7 @@ func (s *environInstanceSuite) SetUpTest(c *gc.C) {
 	ll := logger.LogLevel()
 	logger.SetLogLevel(loggo.TRACE)
 	s.AddCleanup(func(*gc.C) { logger.SetLogLevel(ll) })
-
 	mock.Reset()
-}
-
-func (s *environInstanceSuite) TearDownTest(c *gc.C) {
-	mock.Reset()
-	s.BaseSuite.TearDownTest(c)
 }
 
 func (s *environInstanceSuite) createEnviron(c *gc.C, cfg *config.Config) environs.Environ {

--- a/provider/cloudsigma/instance_test.go
+++ b/provider/cloudsigma/instance_test.go
@@ -27,11 +27,9 @@ var _ = gc.Suite(&instanceSuite{})
 func (s *instanceSuite) SetUpSuite(c *gc.C) {
 	s.BaseSuite.SetUpSuite(c)
 	mock.Start()
-}
-
-func (s *instanceSuite) TearDownSuite(c *gc.C) {
-	mock.Stop()
-	s.BaseSuite.TearDownSuite(c)
+	s.AddCleanup(func(*gc.C) {
+		mock.Stop()
+	})
 }
 
 func (s *instanceSuite) SetUpTest(c *gc.C) {
@@ -59,11 +57,6 @@ func (s *instanceSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 	c.Assert(server, gc.NotNil)
 	s.instWithoutIP = &sigmaInstance{server}
-}
-
-func (s *instanceSuite) TearDownTest(c *gc.C) {
-	mock.ResetServers()
-	s.BaseSuite.TearDownTest(c)
 }
 
 func (s *instanceSuite) TestInstanceId(c *gc.C) {

--- a/provider/dummy/config_test.go
+++ b/provider/dummy/config_test.go
@@ -21,9 +21,9 @@ type ConfigSuite struct {
 	testing.BaseSuite
 }
 
-func (s *ConfigSuite) TearDownTest(c *gc.C) {
-	s.BaseSuite.TearDownTest(c)
-	dummy.Reset(c)
+func (s *ConfigSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+	s.AddCleanup(dummy.Reset)
 }
 
 func (*ConfigSuite) TestSecretAttrs(c *gc.C) {

--- a/provider/dummy/environs_test.go
+++ b/provider/dummy/environs_test.go
@@ -105,12 +105,12 @@ func (s *suite) SetUpTest(c *gc.C) {
 	s.MgoSuite.SetUpTest(c)
 	s.Tests.SetUpTest(c)
 	s.PatchValue(&dummy.LogDir, c.MkDir())
+	s.AddCleanup(dummy.Reset)
 }
 
 func (s *suite) TearDownTest(c *gc.C) {
 	s.Tests.TearDownTest(c)
 	s.MgoSuite.TearDownTest(c)
-	dummy.Reset(c)
 	s.BaseSuite.TearDownTest(c)
 }
 

--- a/state/backups/storage_test.go
+++ b/state/backups/storage_test.go
@@ -43,7 +43,8 @@ func (s *storageSuite) SetUpTest(c *gc.C) {
 
 func (s *storageSuite) TearDownTest(c *gc.C) {
 	if s.State != nil {
-		// If setup fails, we don't have a State yet
+		// must execute before MgoSuite.TearDownTest as the latter
+		// expects there to be no remaining state connections.
 		s.State.Close()
 	}
 	s.MgoSuite.TearDownTest(c)

--- a/state/binarystorage/binarystorage_test.go
+++ b/state/binarystorage/binarystorage_test.go
@@ -61,12 +61,6 @@ func (s *binaryStorageSuite) SetUpTest(c *gc.C) {
 	s.storage = binarystorage.New("my-uuid", s.managedStorage, s.metadataCollection, s.txnRunner)
 }
 
-func (s *binaryStorageSuite) TearDownTest(c *gc.C) {
-	s.session.Close()
-	s.mongo.DestroyWithLog()
-	s.BaseSuite.TearDownTest(c)
-}
-
 func (s *binaryStorageSuite) TestAdd(c *gc.C) {
 	s.testAdd(c, "some-binary")
 }

--- a/state/imagestorage/image_test.go
+++ b/state/imagestorage/image_test.go
@@ -48,17 +48,16 @@ func (s *ImageSuite) SetUpTest(c *gc.C) {
 	var err error
 	s.session, err = s.mongo.Dial()
 	c.Assert(err, gc.IsNil)
+	s.AddCleanup(func(*gc.C) {
+		s.session.Close()
+		s.mongo.DestroyWithLog()
+	})
 	s.storage = imagestorage.NewStorage(s.session, "my-uuid")
 	s.metadataCollection = imagestorage.MetadataCollection(s.storage)
 	s.txnRunner = jujutxn.NewRunner(jujutxn.RunnerParams{Database: s.metadataCollection.Database})
 	s.patchTransactionRunner()
 }
 
-func (s *ImageSuite) TearDownTest(c *gc.C) {
-	s.session.Close()
-	s.mongo.DestroyWithLog()
-	s.BaseSuite.TearDownTest(c)
-}
 func (s *ImageSuite) patchTransactionRunner() {
 	s.PatchValue(imagestorage.TxnRunner, func(db *mgo.Database) txn.Runner {
 		return s.txnRunner

--- a/state/initialize_test.go
+++ b/state/initialize_test.go
@@ -49,13 +49,13 @@ func (s *InitializeSuite) openState(c *gc.C, modelTag names.ModelTag) {
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	s.State = st
+	s.AddCleanup(func(*gc.C) {
+		err := s.State.Close()
+		c.Check(err, jc.ErrorIsNil)
+	})
 }
 
 func (s *InitializeSuite) TearDownTest(c *gc.C) {
-	if s.State != nil {
-		err := s.State.Close()
-		c.Check(err, jc.ErrorIsNil)
-	}
 	s.MgoSuite.TearDownTest(c)
 	s.BaseSuite.TearDownTest(c)
 }

--- a/worker/cleaner/cleaner.go
+++ b/worker/cleaner/cleaner.go
@@ -29,10 +29,7 @@ func NewCleaner(st StateCleaner) (worker.Worker, error) {
 	w, err := watcher.NewNotifyWorker(watcher.NotifyConfig{
 		Handler: &Cleaner{st: st},
 	})
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	return w, nil
+	return w, errors.Trace(err)
 }
 
 func (c *Cleaner) SetUp() (watcher.NotifyWatcher, error) {

--- a/worker/deployer/simple_test.go
+++ b/worker/deployer/simple_test.go
@@ -50,10 +50,6 @@ func (s *SimpleContextSuite) SetUpTest(c *gc.C) {
 	s.SimpleToolsFixture.SetUp(c, c.MkDir())
 }
 
-func (s *SimpleContextSuite) TearDownTest(c *gc.C) {
-	s.SimpleToolsFixture.TearDown(c)
-}
-
 func (s *SimpleContextSuite) TestDeployRecall(c *gc.C) {
 	mgr0 := s.getContext(c)
 	units, err := mgr0.DeployedUnits()

--- a/worker/discoverspaces/worker_test.go
+++ b/worker/discoverspaces/worker_test.go
@@ -68,6 +68,9 @@ func (s *WorkerSuite) SetUpTest(c *gc.C) {
 	s.AssertConfigParameterUpdated(c, "broken", "")
 
 	s.APIConnection, _ = s.OpenAPIAsNewMachine(c, state.JobManageModel)
+	s.AddCleanup(func(*gc.C) {
+		c.Check(s.APIConnection.Close(), jc.ErrorIsNil)
+	})
 
 	realAPI := s.APIConnection.DiscoverSpaces()
 	s.API = &checkingFacade{
@@ -79,13 +82,6 @@ func (s *WorkerSuite) SetUpTest(c *gc.C) {
 			atomic.AddUint32(&s.numAddSubnetsCalls, 1)
 		},
 	}
-}
-
-func (s *WorkerSuite) TearDownTest(c *gc.C) {
-	if s.APIConnection != nil {
-		c.Check(s.APIConnection.Close(), jc.ErrorIsNil)
-	}
-	s.JujuConnSuite.TearDownTest(c)
 }
 
 func (s *WorkerSuite) TestSupportsSpaceDiscoveryBroken(c *gc.C) {


### PR DESCRIPTION
A common failure mode of our tests is when an issue occurs during
the SetUp phase of the suite or test, not only does the test fail, but
the Tear down phase blows up because it is rarely written to handle the
case where the setup phase did not complete.

(Review request: http://reviews.vapour.ws/r/4467/)