### PR TITLE
lxd container type: skip local subnet test if no `ip` tool present

### DIFF
--- a/container/lxd/initialisation_test.go
+++ b/container/lxd/initialisation_test.go
@@ -213,6 +213,11 @@ func (s *InitialiserSuite) TestDetectSubnet(c *gc.C) {
 }
 
 func (s *InitialiserSuite) TestDetectSubnetLocal(c *gc.C) {
+	_, err := exec.LookPath("ip")
+	if err != nil {
+		c.Skip("skipping local detect subnet test, ip tool not found")
+	}
+
 	output, err := exec.Command("ip", "addr", "show").CombinedOutput()
 	c.Assert(err, jc.ErrorIsNil)
 


### PR DESCRIPTION
centos doesn't have `ip` by default, so we can't test against the local
network configuration since we can't query it.

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>

(Review request: http://reviews.vapour.ws/r/4469/)