### PR TITLE
Update upgrade-gui command to support switching simplestreams releases.

### DIFF
--- a/cmd/juju/gui/export_test.go
+++ b/cmd/juju/gui/export_test.go
@@ -10,4 +10,5 @@ var (
 	ClientGUIArchives      = &clientGUIArchives
 	ClientSelectGUIVersion = &clientSelectGUIVersion
 	ClientUploadGUIArchive = &clientUploadGUIArchive
+	GUIFetchMetadata       = &guiFetchMetadata
 )

--- a/cmd/juju/gui/upgradegui.go
+++ b/cmd/juju/gui/upgradegui.go
@@ -9,6 +9,7 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -16,10 +17,12 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/version"
+	"launchpad.net/gnuflag"
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/environs/gui"
 )
 
 // NewUpgradeGUICommand creates and returns a new upgrade-gui command.
@@ -32,6 +35,7 @@ type upgradeGUICommand struct {
 	modelcmd.ModelCommandBase
 
 	versOrPath string
+	list       bool
 }
 
 const upgradeGUIDoc = `
@@ -43,9 +47,13 @@ Upgrade to a specific Juju GUI released version:
 
 	juju upgrade-gui 2.2.0
 
-Upgrade to a Juju GUI version present in a local tar.bz2 GUI release file.
+Upgrade to a Juju GUI version present in a local tar.bz2 GUI release file:
 
 	juju upgrade-gui /path/to/jujugui-2.2.0.tar.bz2
+
+List available Juju GUI releases without upgrading:
+
+	juju upgrade-gui --list
 `
 
 // Info implements the cmd.Command interface.
@@ -57,9 +65,17 @@ func (c *upgradeGUICommand) Info() *cmd.Info {
 	}
 }
 
+// SetFlags implements the cmd.Command interface.
+func (c *upgradeGUICommand) SetFlags(f *gnuflag.FlagSet) {
+	f.BoolVar(&c.list, "list", false, "list available Juju GUI release versions without upgrading")
+}
+
 // Init implements the cmd.Command interface.
 func (c *upgradeGUICommand) Init(args []string) error {
 	if len(args) == 1 {
+		if c.list {
+			return errors.New("cannot provide arguments if --list is provided")
+		}
 		c.versOrPath = args[0]
 		return nil
 	}
@@ -68,6 +84,17 @@ func (c *upgradeGUICommand) Init(args []string) error {
 
 // Run implements the cmd.Command interface.
 func (c *upgradeGUICommand) Run(ctx *cmd.Context) error {
+	if c.list {
+		// List available Juju GUI archive versions.
+		allMeta, err := remoteArchiveMetadata()
+		if err != nil {
+			return errors.Annotate(err, "cannot list Juju GUI release versions")
+		}
+		for _, metadata := range allMeta {
+			ctx.Infof(metadata.Version.String())
+		}
+		return nil
+	}
 	// Retrieve the GUI archive and its related info.
 	r, hash, size, vers, err := openArchive(c.versOrPath)
 	if err != nil {
@@ -90,8 +117,14 @@ func (c *upgradeGUICommand) Run(ctx *cmd.Context) error {
 
 	// Upload the release file if required.
 	if hash != existingHash {
+		ctx.Infof("fetching Juju GUI archive")
+		f, err := storeArchive(r)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		defer f.Close()
 		ctx.Infof("uploading Juju GUI %s", vers)
-		isCurrent, err = clientUploadGUIArchive(client, r, hash, size, vers)
+		isCurrent, err = clientUploadGUIArchive(client, f, hash, size, vers)
 		if err != nil {
 			return errors.Annotate(err, "cannot upload Juju GUI")
 		}
@@ -111,11 +144,20 @@ func (c *upgradeGUICommand) Run(ctx *cmd.Context) error {
 
 // openArchive opens a Juju GUI archive from the given version or file path.
 // The returned readSeekCloser must be closed by callers.
-func openArchive(versOrPath string) (r readSeekCloser, hash string, size int64, vers version.Number, err error) {
+func openArchive(versOrPath string) (r io.ReadCloser, hash string, size int64, vers version.Number, err error) {
 	if versOrPath == "" {
-		// TODO frankban: implement retrieving the latest GUI archive from
-		// simplestreams.
-		return nil, "", 0, vers, errors.New("upgrading to latest released version not implemented")
+		// Return the most recent Juju GUI from simplestreams.
+		allMeta, err := remoteArchiveMetadata()
+		if err != nil {
+			return nil, "", 0, vers, errors.Annotate(err, "cannot upgrade to most recent release")
+		}
+		// The most recent Juju GUI release is the first on the list.
+		metadata := allMeta[0]
+		r, _, err := metadata.Source.Fetch(metadata.Path)
+		if err != nil {
+			return nil, "", 0, vers, errors.Annotatef(err, "cannot open Juju GUI archive at %q", metadata.FullPath)
+		}
+		return r, metadata.SHA256, metadata.Size, metadata.Version, nil
 	}
 	f, err := os.Open(versOrPath)
 	if err != nil {
@@ -126,9 +168,22 @@ func openArchive(versOrPath string) (r readSeekCloser, hash string, size int64, 
 		if err != nil {
 			return nil, "", 0, vers, errors.Errorf("invalid GUI release version or local path %q", versOrPath)
 		}
-		// TODO frankban: implement upgrading to a released version.
-		return nil, "", 0, vers, errors.Errorf("upgrading to a released version (%s) not implemented", vers)
+		// Return a specific release version from simplestreams.
+		allMeta, err := remoteArchiveMetadata()
+		if err != nil {
+			return nil, "", 0, vers, errors.Annotatef(err, "cannot upgrade to release %s", vers)
+		}
+		metadata, err := findMetadataVersion(allMeta, vers)
+		if err != nil {
+			return nil, "", 0, vers, errors.Trace(err)
+		}
+		r, _, err := metadata.Source.Fetch(metadata.Path)
+		if err != nil {
+			return nil, "", 0, vers, errors.Annotatef(err, "cannot open Juju GUI archive at %q", metadata.FullPath)
+		}
+		return r, metadata.SHA256, metadata.Size, metadata.Version, nil
 	}
+	// This is a local Juju GUI release.
 	defer func() {
 		if err != nil {
 			f.Close()
@@ -151,10 +206,27 @@ func openArchive(versOrPath string) (r readSeekCloser, hash string, size int64, 
 	return f, hash, size, vers, nil
 }
 
-// readSeekCloser combines the io read, seek and close methods.
-type readSeekCloser interface {
-	io.ReadCloser
-	io.Seeker
+// remoteArchiveMetadata returns Juju GUI archive metadata from simplestreams.
+func remoteArchiveMetadata() ([]*gui.Metadata, error) {
+	source := gui.NewDataSource(gui.DefaultBaseURL)
+	allMeta, err := guiFetchMetadata(gui.ReleasedStream, source)
+	if err != nil {
+		return nil, errors.Annotate(err, "cannot retrieve Juju GUI archive info")
+	}
+	if len(allMeta) == 0 {
+		return nil, errors.New("no available Juju GUI archives found")
+	}
+	return allMeta, nil
+}
+
+// findMetadataVersion returns the metadata in allMeta with the given version.
+func findMetadataVersion(allMeta []*gui.Metadata, vers version.Number) (*gui.Metadata, error) {
+	for _, metadata := range allMeta {
+		if metadata.Version == vers {
+			return metadata, nil
+		}
+	}
+	return nil, errors.NotFoundf("Juju GUI release version %s", vers)
 }
 
 // archiveVersion retrieves the GUI version from the juju-gui-* directory
@@ -212,6 +284,40 @@ func existingVersionInfo(client *api.Client, vers version.Number) (hash string, 
 	return "", false, nil
 }
 
+// storeArchive saves the Juju GUI archive in the given reader in a temporary
+// file. The resulting returned readSeekCloser is deleted when closed.
+func storeArchive(r io.Reader) (readSeekCloser, error) {
+	f, err := ioutil.TempFile("", "gui-archive")
+	if err != nil {
+		return nil, errors.Annotate(err, "cannot create a temporary file to save the Juju GUI archive")
+	}
+	if _, err = io.Copy(f, r); err != nil {
+		return nil, errors.Annotate(err, "cannot retrieve Juju GUI archive")
+	}
+	if _, err = f.Seek(0, 0); err != nil {
+		return nil, errors.Annotate(err, "cannot seek temporary archive file")
+	}
+	return deleteOnCloseFile{f}, nil
+}
+
+// readSeekCloser combines the io read, seek and close methods.
+type readSeekCloser interface {
+	io.ReadCloser
+	io.Seeker
+}
+
+// deleteOnCloseFile is a file that gets deleted when closed.
+type deleteOnCloseFile struct {
+	*os.File
+}
+
+// Close closes the file.
+func (f deleteOnCloseFile) Close() error {
+	f.File.Close()
+	os.Remove(f.Name())
+	return nil
+}
+
 // clientGUIArchives is defined for testing purposes.
 var clientGUIArchives = func(client *api.Client) ([]params.GUIArchiveVersion, error) {
 	return client.GUIArchives()
@@ -226,3 +332,6 @@ var clientSelectGUIVersion = func(client *api.Client, vers version.Number) error
 var clientUploadGUIArchive = func(client *api.Client, r io.ReadSeeker, hash string, size int64, vers version.Number) (bool, error) {
 	return client.UploadGUIArchive(r, hash, size, vers)
 }
+
+// guiFetchMetadata is defined for testing purposes.
+var guiFetchMetadata = gui.FetchMetadata

--- a/cmd/juju/gui/upgradegui_test.go
+++ b/cmd/juju/gui/upgradegui_test.go
@@ -134,9 +134,17 @@ func (s *upgradeGUISuite) TestUpgradeGUIListSuccess(c *gc.C) {
 	}, {
 		Version: version.MustParse("2.1.0"),
 	}}, nil)
+	uploadCalled := s.patchClientUploadGUIArchive(c, "", 0, "", false, nil)
+	selectCalled := s.patchClientSelectGUIVersion(c, "", nil)
+
+	// Run the command to list available Juju GUI archive versions.
 	out, err := s.run(c, "--list")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(out, gc.Equals, "2.2.0\n2.1.1\n2.1.0")
+
+	// No uploads or switches are preformed.
+	c.Assert(uploadCalled(), jc.IsFalse)
+	c.Assert(selectCalled(), jc.IsFalse)
 }
 
 func (s *upgradeGUISuite) TestUpgradeGUIListNoReleases(c *gc.C) {

--- a/cmd/jujud/bootstrap_test.go
+++ b/cmd/jujud/bootstrap_test.go
@@ -11,6 +11,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"runtime"
 	"time"
 
 	"github.com/juju/cmd"
@@ -190,6 +191,12 @@ func (s *BootstrapSuite) TestGUIArchiveInfoNotFound(c *gc.C) {
 }
 
 func (s *BootstrapSuite) TestGUIArchiveInfoError(c *gc.C) {
+	if runtime.GOOS == "windows" {
+		// TODO frankban: skipping for now due to chmod problems with mode 0000
+		// on Windows. We will re-enable this test after further investigation:
+		// "jujud bootstrap" is never run on Windows anyway.
+		c.Skip("needs chmod investigation")
+	}
 	dir := filepath.FromSlash(agenttools.SharedGUIDir(s.dataDir))
 	info := filepath.Join(dir, "downloaded-gui.txt")
 	err := os.Chmod(info, 0000)


### PR DESCRIPTION
Also add the --list flag to upgrade-gui.
Also disable a jujud bootstrap test failing on Windows.

(Review request: http://reviews.vapour.ws/r/4471/)