### PR TITLE
Filter LXD addresses from State servers

### DIFF
--- a/agent/agentbootstrap/bootstrap.go
+++ b/agent/agentbootstrap/bootstrap.go
@@ -116,8 +116,8 @@ func InitializeState(
 	servingInfo.SharedSecret = args.SharedSecret
 	c.SetStateServingInfo(servingInfo)
 
-	// Filter out any LXC bridge addresses from the machine addresses.
-	args.BootstrapMachineAddresses = network.FilterLXCAddresses(args.BootstrapMachineAddresses)
+	// Filter out any LXC or LXD bridge addresses from the machine addresses.
+	args.BootstrapMachineAddresses = network.FilterBridgeAddresses(args.BootstrapMachineAddresses)
 
 	if err = initAPIHostPorts(c, st, args.BootstrapMachineAddresses, servingInfo.APIPort); err != nil {
 		return nil, nil, err

--- a/agent/agentbootstrap/bootstrap_test.go
+++ b/agent/agentbootstrap/bootstrap_test.go
@@ -69,7 +69,6 @@ anything else ignored
 LXC_BRIDGE="ignored"`[1:])
 	err := ioutil.WriteFile(lxcFakeNetConfig, netConf, 0644)
 	c.Assert(err, jc.ErrorIsNil)
-	lxdbridge, err := network.GetDefaultLXDBridgeName()
 	c.Assert(err, jc.ErrorIsNil)
 	s.PatchValue(&network.InterfaceByNameAddrs, func(name string) ([]net.Addr, error) {
 		if name == "foobar" {
@@ -78,7 +77,7 @@ LXC_BRIDGE="ignored"`[1:])
 				&net.IPAddr{IP: net.IPv4(10, 0, 3, 1)},
 				&net.IPAddr{IP: net.IPv4(10, 0, 3, 4)},
 			}, nil
-		} else if name == lxdbridge {
+		} else if name == network.DefaultLXDBridge {
 			// The addresses on the LXD bridge
 			return []net.Addr{
 				&net.IPAddr{IP: net.IPv4(10, 0, 4, 1)},

--- a/agent/agentbootstrap/bootstrap_test.go
+++ b/agent/agentbootstrap/bootstrap_test.go
@@ -69,12 +69,24 @@ anything else ignored
 LXC_BRIDGE="ignored"`[1:])
 	err := ioutil.WriteFile(lxcFakeNetConfig, netConf, 0644)
 	c.Assert(err, jc.ErrorIsNil)
+	lxdbridge, err := network.GetDefaultLXDBridgeName()
+	c.Assert(err, jc.ErrorIsNil)
 	s.PatchValue(&network.InterfaceByNameAddrs, func(name string) ([]net.Addr, error) {
-		c.Assert(name, gc.Equals, "foobar")
-		return []net.Addr{
-			&net.IPAddr{IP: net.IPv4(10, 0, 3, 1)},
-			&net.IPAddr{IP: net.IPv4(10, 0, 3, 4)},
-		}, nil
+		if name == "foobar" {
+			// The addresses on the LXC bridge
+			return []net.Addr{
+				&net.IPAddr{IP: net.IPv4(10, 0, 3, 1)},
+				&net.IPAddr{IP: net.IPv4(10, 0, 3, 4)},
+			}, nil
+		} else if name == lxdbridge {
+			// The addresses on the LXD bridge
+			return []net.Addr{
+				&net.IPAddr{IP: net.IPv4(10, 0, 4, 1)},
+				&net.IPAddr{IP: net.IPv4(10, 0, 4, 4)},
+			}, nil
+		}
+		c.Fatalf("unknown bridge in testing: %v", name)
+		return nil, nil
 	})
 	s.PatchValue(&network.LXCNetDefaultConfig, lxcFakeNetConfig)
 
@@ -110,11 +122,15 @@ LXC_BRIDGE="ignored"`[1:])
 		"10.0.3.1", // lxc bridge address filtered.
 		"10.0.3.4", // lxc bridge address filtered (-"-).
 		"10.0.3.3", // not a lxc bridge address
+		"10.0.4.1", // lxd bridge address filtered.
+		"10.0.4.4", // lxd bridge address filtered.
+		"10.0.4.5", // not an lxd bridge address
 	)
 	filteredAddrs := network.NewAddresses(
 		"zeroonetwothree",
 		"0.1.2.3",
 		"10.0.3.3",
+		"10.0.4.5",
 	)
 
 	// Prepare bootstrap config, so we can use it in the state policy.

--- a/apiserver/client/client_test.go
+++ b/apiserver/client/client_test.go
@@ -1121,7 +1121,7 @@ func (s *clientSuite) TestClientAddMachinesSomeErrors(c *gc.C) {
 	// Create a machine to host the requested containers.
 	host, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
-	// The host only supports ldc containers.
+	// The host only supports lxd containers.
 	err = host.SetSupportedContainers([]instance.ContainerType{instance.LXD})
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/container/lxd/lxd_go12.go
+++ b/container/lxd/lxd_go12.go
@@ -16,10 +16,6 @@ var (
 	logger = loggo.GetLogger("juju.container.lxd")
 )
 
-func GetDefaultBridgeName() (string, error) {
-	return "", errors.Errorf("LXD not supported in go 1.2")
-}
-
 func NewContainerManager(conf container.ManagerConfig) (container.Manager, error) {
 	return nil, errors.Errorf("LXD containers not supported in go 1.2")
 }

--- a/network/network.go
+++ b/network/network.go
@@ -55,6 +55,9 @@ const AnySubnet Id = ""
 // UnknownId can be used whenever an Id is needed but not known.
 const UnknownId = ""
 
+// DefaultLXDBridge is the bridge that gets used for LXD containers
+const DefaultLXDBridge = "lxdbr0"
+
 var dashPrefix = regexp.MustCompile("^-*")
 var dashSuffix = regexp.MustCompile("-*$")
 var multipleDashes = regexp.MustCompile("--+")
@@ -314,12 +317,68 @@ var InterfaceByNameAddrs = func(name string) ([]net.Addr, error) {
 	return iface.Addrs()
 }
 
-// FilterLXCAddresses tries to discover the default lxc bridge name
+// filterAddrs looks at all of the addresses in allAddresses and removes ones
+// that line up with removeAddresses. Note that net.Addr may be just an IP or
+// may be a CIDR.
+func filterAddrs(bridgeName string, allAddresses []Address, removeAddresses []net.Addr) []Address {
+	filtered := make([]Address, 0, len(allAddresses))
+	// TODO(jam) ips could be turned into a map[string]bool rather than
+	// iterating over all of them, as we only compare against ip.String()
+	ips := make([]net.IP, 0, len(removeAddresses))
+	ipNets := make([]*net.IPNet, 0, len(removeAddresses))
+	for _, ifaceAddr := range removeAddresses {
+		// First check if this is a CIDR, as
+		// net.InterfaceAddrs might return this instead of
+		// a plain IP.
+		ip, ipNet, err := net.ParseCIDR(ifaceAddr.String())
+		if err != nil {
+			// It's not a CIDR, try parsing as IP.
+			ip = net.ParseIP(ifaceAddr.String())
+		}
+		if ip == nil {
+			logger.Debugf("cannot parse %q as IP, ignoring", ifaceAddr)
+			continue
+		}
+		ips = append(ips, ip)
+		if ipNet != nil {
+			ipNets = append(ipNets, ipNet)
+		}
+	}
+	for _, addr := range allAddresses {
+		found := false
+		// Filter all known IPs
+		for _, ip := range ips {
+			if ip.String() == addr.Value {
+				found = true
+				break
+			}
+		}
+		if !found {
+			// Then check if it is in one of the CIDRs
+			for _, ipNet := range ipNets {
+				if ipNet.Contains(net.ParseIP(addr.Value)) {
+					found = true
+					break
+				}
+			}
+		}
+		if found {
+			logger.Debugf("filtering %q address %s for machine", bridgeName, addr.String())
+		} else {
+			logger.Debugf("not filtering address %s for machine", addr)
+			filtered = append(filtered, addr)
+		}
+	}
+	logger.Debugf("addresses after filtering: %v", filtered)
+	return filtered
+}
+
+// filterLXCAddresses tries to discover the default lxc bridge name
 // and all of its addresses, then filters those addresses out of the
 // given ones and returns the result. Any errors encountered during
 // this process are logged, but not considered fatal. See LP bug
 // #1416928.
-func FilterLXCAddresses(addresses []Address) []Address {
+func filterLXCAddresses(addresses []Address) []Address {
 	file, err := os.Open(LXCNetDefaultConfig)
 	if os.IsNotExist(err) {
 		// No lxc-net config found, nothing to do.
@@ -331,40 +390,6 @@ func FilterLXCAddresses(addresses []Address) []Address {
 		return addresses
 	}
 	defer file.Close()
-
-	filterAddrs := func(bridgeName string, addrs []net.Addr) []Address {
-		// Filter out any bridge addresses.
-		filtered := make([]Address, 0, len(addresses))
-		for _, addr := range addresses {
-			found := false
-			for _, ifaceAddr := range addrs {
-				// First check if this is a CIDR, as
-				// net.InterfaceAddrs might return this instead of
-				// a plain IP.
-				ip, ipNet, err := net.ParseCIDR(ifaceAddr.String())
-				if err != nil {
-					// It's not a CIDR, try parsing as IP.
-					ip = net.ParseIP(ifaceAddr.String())
-				}
-				if ip == nil {
-					logger.Debugf("cannot parse %q as IP, ignoring", ifaceAddr)
-					continue
-				}
-				// Filter by CIDR if known or single IP otherwise.
-				if ipNet != nil && ipNet.Contains(net.ParseIP(addr.Value)) ||
-					ip.String() == addr.Value {
-					found = true
-					logger.Debugf("filtering %q address %s for machine", bridgeName, ifaceAddr.String())
-				}
-			}
-			if !found {
-				logger.Debugf("not filtering address %s for machine", addr)
-				filtered = append(filtered, addr)
-			}
-		}
-		logger.Debugf("addresses after filtering: %v", filtered)
-		return filtered
-	}
 
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {
@@ -387,11 +412,34 @@ func FilterLXCAddresses(addresses []Address) []Address {
 				continue
 			}
 			logger.Debugf("%q has addresses %v", bridgeName, addrs)
-			return filterAddrs(bridgeName, addrs)
+			return filterAddrs(bridgeName, addresses, addrs)
 		}
 	}
 	if err := scanner.Err(); err != nil {
 		logger.Debugf("failed to read %q: %v (ignoring)", LXCNetDefaultConfig, err)
 	}
+	return addresses
+}
+
+// filterLXDAddresses removes addresses on the LXD bridge from the list to be
+// considered.
+func filterLXDAddresses(addresses []Address) []Address {
+	// Should we be getting this from LXD instead?
+	addrs, err := InterfaceByNameAddrs(DefaultLXDBridge)
+	if err != nil {
+		logger.Warningf("cannot get %q addresses: %v (ignoring)", DefaultLXDBridge, err)
+		return addresses
+	}
+	logger.Debugf("%q has addresses %v", DefaultLXDBridge, addrs)
+	return filterAddrs(DefaultLXDBridge, addresses, addrs)
+
+}
+
+// FilterBridgeAddresses removes addresses seen as a Bridge address (the IP
+// address used only to connect to local containers), rather than a remote
+// accessible address.
+func FilterBridgeAddresses(addresses []Address) []Address {
+	addresses = filterLXCAddresses(addresses)
+	addresses = filterLXDAddresses(addresses)
 	return addresses
 }

--- a/tools/lxdclient/lxd_client.go
+++ b/tools/lxdclient/lxd_client.go
@@ -27,8 +27,6 @@ const (
 	StatusCancelled        = "Canceled"
 	StatusSuccess          = "Success"
 	StatusFailure          = "Failure"
-
-	DefaultLXDBridge = "lxdbr0"
 )
 
 var allStatuses = map[string]shared.StatusCode{

--- a/tools/lxdclient/lxd_go12.go
+++ b/tools/lxdclient/lxd_go12.go
@@ -1,8 +1,0 @@
-// Copyright 2016 Canonical Ltd.
-// Licensed under the AGPLv3, see LICENCE file for details.
-
-// +build !go1.3
-
-package lxdclient
-
-const DefaultLXDBridge = "INVALIDLXDBRIDGEGO12"

--- a/tools/lxdclient/remote.go
+++ b/tools/lxdclient/remote.go
@@ -9,6 +9,8 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/utils"
 	lxdshared "github.com/lxc/lxd/shared"
+
+	"github.com/juju/juju/network"
 )
 
 const (
@@ -191,7 +193,7 @@ func (r Remote) UsingTCP() (Remote, error) {
 	// TODO: jam 2016-02-25 This should be updated for systems that are
 	// 	 space aware, as we may not be just using the default LXC
 	// 	 bridge.
-	addr, err := utils.GetAddressForInterface(DefaultLXDBridge)
+	addr, err := utils.GetAddressForInterface(network.DefaultLXDBridge)
 	if err != nil {
 		return r, errors.Trace(err)
 	}
@@ -206,9 +208,3 @@ func (r Remote) UsingTCP() (Remote, error) {
 
 	return r, nil
 }
-
-// TODO(ericsnow) Add a "Connect(Config)" method that connects
-// to the remote and returns the corresponding Client.
-
-// TODO(ericsnow) Add a "Register" method to Client that adds the remote
-// to the client's remote?

--- a/tools/lxdclient/remote_test.go
+++ b/tools/lxdclient/remote_test.go
@@ -6,12 +6,15 @@
 package lxdclient_test
 
 import (
+	"fmt"
 	"net"
 
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/network"
 	"github.com/juju/juju/tools/lxdclient"
 )
 
@@ -406,11 +409,6 @@ func (s *remoteSuite) TestIDLocal(c *gc.C) {
 	c.Check(id, gc.Equals, "local")
 }
 
-func (s *remoteSuite) TestUsingTCPOkay(c *gc.C) {
-	c.Skip("not implemented yet")
-	// TODO(ericsnow) Finish this!
-}
-
 func (s *remoteSuite) TestUsingTCPNoop(c *gc.C) {
 	remote := lxdclient.Remote{
 		Name:     "my-remote",
@@ -429,8 +427,11 @@ type remoteFunctionalSuite struct {
 }
 
 func (s *remoteFunctionalSuite) TestUsingTCP(c *gc.C) {
-	if _, err := net.InterfaceByName(lxdclient.DefaultLXDBridge); err != nil {
+	if _, err := net.InterfaceByName(network.DefaultLXDBridge); err != nil {
 		c.Skip("network bridge interface not found")
+	}
+	if _, err := utils.GetAddressForInterface(network.DefaultLXDBridge); err != nil {
+		c.Skip(fmt.Sprintf("no IPv4 address available for %s", network.DefaultLXDBridge))
 	}
 	lxdclient.PatchGenerateCertificate(&s.CleanupSuite, testingCert, testingKey)
 

--- a/worker/apiaddressupdater/apiaddressupdater.go
+++ b/worker/apiaddressupdater/apiaddressupdater.go
@@ -67,11 +67,12 @@ func (c *APIAddressUpdater) Handle(_ <-chan struct{}) error {
 		return fmt.Errorf("error getting addresses: %v", err)
 	}
 
-	// Filter out any LXC bridge addresses. See LP bug #1416928.
+	// Filter out any LXC or LXD bridge addresses. See LP bug #1416928. and
+	// bug #1567683
 	hpsToSet := make([][]network.HostPort, 0, len(addresses))
 	for _, hostPorts := range addresses {
 		// Strip ports, filter, then add ports again.
-		filtered := network.FilterLXCAddresses(network.HostsWithoutPort(hostPorts))
+		filtered := network.FilterBridgeAddresses(network.HostsWithoutPort(hostPorts))
 		hps := make([]network.HostPort, 0, len(filtered))
 		for _, hostPort := range hostPorts {
 			for _, addr := range filtered {

--- a/worker/machiner/machiner.go
+++ b/worker/machiner/machiner.go
@@ -137,8 +137,8 @@ func setMachineAddresses(tag names.MachineTag, m Machine) error {
 	if len(hostAddresses) == 0 {
 		return nil
 	}
-	// Filter out any LXC bridge addresses.
-	hostAddresses = network.FilterLXCAddresses(hostAddresses)
+	// Filter out any LXC or LXD bridge addresses.
+	hostAddresses = network.FilterBridgeAddresses(hostAddresses)
 	logger.Infof("setting addresses for %v to %q", tag, hostAddresses)
 	return m.SetMachineAddresses(hostAddresses)
 }

--- a/worker/machiner/machiner_test.go
+++ b/worker/machiner/machiner_test.go
@@ -456,12 +456,21 @@ LXC_BRIDGE="ignored"`[1:])
 		return addrs, nil
 	})
 	s.PatchValue(&network.InterfaceByNameAddrs, func(name string) ([]net.Addr, error) {
-		// XXX: handle lxdbr0
-		c.Assert(name, gc.Equals, "foobar")
-		return []net.Addr{
-			&net.IPAddr{IP: net.IPv4(10, 0, 3, 1)},
-			&net.IPAddr{IP: net.IPv4(10, 0, 3, 4)},
-		}, nil
+		if name == "foobar" {
+			// The addresses on the LXC bridge
+			return []net.Addr{
+				&net.IPAddr{IP: net.IPv4(10, 0, 3, 1)},
+				&net.IPAddr{IP: net.IPv4(10, 0, 3, 4)},
+			}, nil
+		} else if name == network.DefaultLXDBridge {
+			// The addresses on the LXD bridge
+			return []net.Addr{
+				&net.IPAddr{IP: net.IPv4(10, 0, 4, 1)},
+				&net.IPAddr{IP: net.IPv4(10, 0, 4, 4)},
+			}, nil
+		}
+		c.Fatalf("unknown bridge in testing: %v", name)
+		return nil, nil
 	})
 	s.PatchValue(&network.LXCNetDefaultConfig, lxcFakeNetConfig)
 

--- a/worker/machiner/machiner_test.go
+++ b/worker/machiner/machiner_test.go
@@ -456,6 +456,7 @@ LXC_BRIDGE="ignored"`[1:])
 		return addrs, nil
 	})
 	s.PatchValue(&network.InterfaceByNameAddrs, func(name string) ([]net.Addr, error) {
+		// XXX: handle lxdbr0
 		c.Assert(name, gc.Equals, "foobar")
 		return []net.Addr{
 			&net.IPAddr{IP: net.IPv4(10, 0, 3, 1)},

--- a/worker/provisioner/lxd-broker.go
+++ b/worker/provisioner/lxd-broker.go
@@ -12,7 +12,7 @@ import (
 	"github.com/juju/juju/container"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/instance"
-	"github.com/juju/juju/tools/lxdclient"
+	"github.com/juju/juju/network"
 )
 
 var lxdLogger = loggo.GetLogger("juju.provisioner.lxd")
@@ -39,7 +39,7 @@ func (broker *lxdBroker) StartInstance(args environs.StartInstanceParams) (*envi
 	machineId := args.InstanceConfig.MachineId
 	bridgeDevice := broker.agentConfig.Value(agent.LxdBridge)
 	if bridgeDevice == "" {
-		bridgeDevice = lxdclient.DefaultLXDBridge
+		bridgeDevice = network.DefaultLXDBridge
 	}
 
 	config, err := broker.api.ContainerConfig()
@@ -144,7 +144,7 @@ func (broker *lxdBroker) MaintainInstance(args environs.StartInstanceParams) err
 	// Default to using the host network until we can configure.
 	bridgeDevice := broker.agentConfig.Value(agent.LxdBridge)
 	if bridgeDevice == "" {
-		bridgeDevice = lxdclient.DefaultLXDBridge
+		bridgeDevice = network.DefaultLXDBridge
 	}
 
 	// There's no InterfaceInfo we expect to get below.


### PR DESCRIPTION
We already had code to filter the agent's addresses that were on the LXC bridge. However, now that LXD has its own bridge, we need to start filtering those as well.

This patch also includes a few changes of renaming LXC => LXD in tests and in the documentation. I can trim some of that stuff out, but it is all useful as we move into next steps.


(Review request: http://reviews.vapour.ws/r/4478/)