### PR TITLE
EC2: have correct instance ids collection on successful instance(s) termination. 

### DIFF
--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -1460,6 +1460,7 @@ func (e *environ) terminateInstances(ids []instance.Id) error {
 	for a := shortAttempt.Start(); a.Next(); {
 		_, err = ec2inst.TerminateInstances(strs)
 		if err == nil || ec2ErrCode(err) != "InvalidInstanceID.NotFound" {
+			terminatedInstances = ids
 			return err
 		}
 	}

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -1417,11 +1417,8 @@ func (e *environ) terminateInstances(ids []instance.Id) error {
 	}
 	ec2inst := e.ec2()
 
-	// Hold the IDs of successfully terminated instances.
-	terminatedInstances := []instance.Id{}
-
 	defer func() {
-		securityGroups, err := e.instanceSecurityGroups(terminatedInstances)
+		securityGroups, err := e.instanceSecurityGroups(ids)
 		if err != nil {
 			logger.Warningf("cannot determine security groups to delete: %v", err)
 		}
@@ -1460,7 +1457,6 @@ func (e *environ) terminateInstances(ids []instance.Id) error {
 	for a := shortAttempt.Start(); a.Next(); {
 		_, err = ec2inst.TerminateInstances(strs)
 		if err == nil || ec2ErrCode(err) != "InvalidInstanceID.NotFound" {
-			terminatedInstances = ids
 			return err
 		}
 	}
@@ -1475,7 +1471,6 @@ func (e *environ) terminateInstances(ids []instance.Id) error {
 		_, err = ec2inst.TerminateInstances([]string{string(id)})
 		if ec2ErrCode(err) == "InvalidInstanceID.NotFound" {
 			err = nil
-			terminatedInstances = append(terminatedInstances, id)
 		}
 		if err != nil && firstErr == nil {
 			firstErr = err


### PR DESCRIPTION
An oversight: if all instances are terminated successfully, we can try to delete security groups for all of them.

(Review request: http://reviews.vapour.ws/r/4484/)