### PR TITLE
testing: refactor registry setup/tear down code

### DIFF
--- a/testing/base_windows.go
+++ b/testing/base_windows.go
@@ -20,31 +20,35 @@ import (
 // also sets up the registry key on windows because some functions are
 // trying to look in there.
 func (s *JujuOSEnvSuite) setUpFeatureFlags(c *gc.C) {
-	regKey := osenv.JujuRegistryKey[len(`HKLM:\`):]
-	k, existed, err := registry.CreateKey(registry.LOCAL_MACHINE, regKey, registry.ALL_ACCESS)
-	s.regKeyExisted = existed
-	c.Assert(err, jc.ErrorIsNil)
+	const len = len(`HKLM:\`)
+	regKey := osenv.JujuRegistryKey[len:]
+
+	k, exists := createKey(c, regKey)
+	defer closeKey(c, k)
+
+	s.regKeyExisted = exists
+	s.regEntryExisted = false
+
 	val, _, err := k.GetStringValue(osenv.JujuFeatureFlagEnvKey)
-	if errors.Cause(err) == registry.ErrNotExist {
-		s.regEntryExisted = false
-	} else {
+	if errors.Cause(err) != registry.ErrNotExist {
 		c.Assert(err, jc.ErrorIsNil)
 		s.oldRegEntryValue = val
 		s.regEntryExisted = true
 	}
+
 	err = k.SetStringValue(osenv.JujuFeatureFlagEnvKey, s.initialFeatureFlags)
 	c.Assert(err, jc.ErrorIsNil)
 	featureflag.SetFlagsFromRegistry(osenv.JujuRegistryKey, osenv.JujuFeatureFlagEnvKey)
-	err = k.Close()
-	c.Assert(err, jc.ErrorIsNil)
-
 }
 
 // tearDownFeatureFlags restores the old registry values
 func (s *JujuOSEnvSuite) tearDownFeatureFlags(c *gc.C) {
-	regKey := osenv.JujuRegistryKey[len(`HKLM:\`):]
+	const len = len(`HKLM:\`)
+	regKey := osenv.JujuRegistryKey[len:]
+
 	if s.regKeyExisted {
-		k, err := registry.OpenKey(registry.LOCAL_MACHINE, regKey, registry.ALL_ACCESS)
+		k := openKey(c, regKey)
+		defer closeKey(c, k)
 		if s.regEntryExisted {
 			err := k.SetStringValue(osenv.JujuFeatureFlagEnvKey, s.oldRegEntryValue)
 			c.Assert(err, jc.ErrorIsNil)
@@ -52,11 +56,29 @@ func (s *JujuOSEnvSuite) tearDownFeatureFlags(c *gc.C) {
 			err := k.DeleteValue(osenv.JujuFeatureFlagEnvKey)
 			c.Assert(err, jc.ErrorIsNil)
 		}
-		err = k.Close()
-		c.Assert(err, jc.ErrorIsNil)
 	} else {
-		err := registry.DeleteKey(registry.LOCAL_MACHINE, regKey)
-		c.Assert(err, jc.ErrorIsNil)
+		deleteKey(c, regKey)
 	}
+}
 
+func createKey(c *gc.C, regKey string) (registry.Key, bool) {
+	k, exists, err := registry.CreateKey(registry.LOCAL_MACHINE, regKey, registry.ALL_ACCESS)
+	c.Assert(err, jc.ErrorIsNil)
+	return k, exists
+}
+
+func openKey(c *gc.C, regKey string) registry.Key {
+	k, err := registry.OpenKey(registry.LOCAL_MACHINE, regKey, registry.ALL_ACCESS)
+	c.Assert(err, jc.ErrorIsNil)
+	return k
+}
+
+func closeKey(c *gc.C, k registry.Key) {
+	err := k.Close()
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func deleteKey(c *gc.C, regKey string) {
+	err := registry.DeleteKey(registry.LOCAL_MACHINE, regKey)
+	c.Assert(err, jc.ErrorIsNil)
 }


### PR DESCRIPTION
Fixes LP #1566303

The old code was missing an error check opening the registry to modify
it. Refactor the code to always check error codes and adopt a more
robust defer cleanup pattern.

At least when it fails now, we'll know the _real_ reason why.

(Review request: http://reviews.vapour.ws/r/4486/)