### PR TITLE
Fixed #1564395: newly created LXD container has zero network devices

### DIFF
--- a/apiserver/common/networkingcommon/types.go
+++ b/apiserver/common/networkingcommon/types.go
@@ -492,7 +492,7 @@ func MergeProviderAndObservedNetworkConfigs(providerConfigs, observedConfigs []p
 	if err != nil {
 		logger.Warningf("cannot serialize provider config %#v as JSON: %v", sortedProviderConfigs, err)
 	} else {
-		logger.Infof("provider network config of machine:\n%s", jsonProviderConfig)
+		logger.Debugf("provider network config of machine:\n%s", jsonProviderConfig)
 	}
 
 	sortedObservedConfigs := SortNetworkConfigsByParents(observedConfigs)
@@ -501,7 +501,7 @@ func MergeProviderAndObservedNetworkConfigs(providerConfigs, observedConfigs []p
 	if err != nil {
 		logger.Warningf("cannot serialize observed config %#v as JSON: %v", sortedObservedConfigs, err)
 	} else {
-		logger.Infof("observed network config of machine:\n%s", jsonObservedConfig)
+		logger.Debugf("observed network config of machine:\n%s", jsonObservedConfig)
 	}
 
 	var mergedConfigs []params.NetworkConfig
@@ -587,13 +587,13 @@ func MergeProviderAndObservedNetworkConfigs(providerConfigs, observedConfigs []p
 		}
 	}
 
-	// No need to re-sort the result as both inputs were sorted and processed in
-	// order.
-	jsonMergedConfig, err := NetworkConfigsToIndentedJSON(mergedConfigs)
+	sortedMergedConfigs := SortNetworkConfigsByParents(mergedConfigs)
+
+	jsonMergedConfig, err := NetworkConfigsToIndentedJSON(sortedMergedConfigs)
 	if err != nil {
-		logger.Warningf("cannot serialize merged config %#v as JSON: %v", mergedConfigs, err)
+		logger.Warningf("cannot serialize merged config %#v as JSON: %v", sortedMergedConfigs, err)
 	} else {
-		logger.Infof("combined machine network config:\n%s", jsonMergedConfig)
+		logger.Debugf("combined machine network config:\n%s", jsonMergedConfig)
 	}
 
 	return mergedConfigs

--- a/apiserver/provisioner/provisioner.go
+++ b/apiserver/provisioner/provisioner.go
@@ -813,7 +813,7 @@ func (p *ProvisionerAPI) prepareOrGetContainerInterfaceInfo(args params.Entities
 				VLANTag:             parentDeviceSubnet.VLANTag(),
 				ParentInterfaceName: parentDevice.Name(),
 			}
-			logger.Debugf("prepared info for container interface %q: %+v", info.InterfaceName, info)
+			logger.Tracef("prepared info for container interface %q: %+v", info.InterfaceName, info)
 			preparedOK = true
 			preparedInfo[j] = info
 		}
@@ -832,7 +832,7 @@ func (p *ProvisionerAPI) prepareOrGetContainerInterfaceInfo(args params.Entities
 
 		allocatedConfig := networkingcommon.NetworkConfigFromInterfaceInfo(allocatedInfo)
 		sortedAllocatedConfig := networkingcommon.SortNetworkConfigsByInterfaceName(allocatedConfig)
-		logger.Debugf("allocated sorted network config: %+v", sortedAllocatedConfig)
+		logger.Tracef("allocated sorted network config: %+v", sortedAllocatedConfig)
 		result.Results[i].Config = sortedAllocatedConfig
 	}
 	return result, nil

--- a/cloudconfig/containerinit/container_userdata.go
+++ b/cloudconfig/containerinit/container_userdata.go
@@ -101,7 +101,7 @@ iface {{.InterfaceName}} inet manual{{if .DNSServers}}
   down ip route del default via {{.GatewayAddress.Value}} || true{{end}}
 {{end}}`
 
-var networkInterfacesFile = "/etc/network/interfaces"
+var networkInterfacesFile = "/etc/network/interfaces.d/00-juju.cfg"
 
 // GenerateNetworkConfig renders a network config for one or more
 // network interfaces, using the given non-nil networkConfig

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -444,7 +444,7 @@ func (a *MachineAgent) makeEngineCreator(previousAgentVersion version.Number) fu
 		}
 		manifolds := machine.Manifolds(machine.ManifoldsConfig{
 			PreviousAgentVersion: previousAgentVersion,
-			Agent:                agent.APIHostPortsSetter{a},
+			Agent:                agent.APIHostPortsSetter{Agent: a},
 			AgentConfigChanged:   a.configChangedVal,
 			UpgradeStepsLock:     a.upgradeComplete,
 			UpgradeCheckLock:     a.initialUpgradeCheckComplete,
@@ -998,6 +998,7 @@ func (a *MachineAgent) startModelWorkers(uuid string) (worker.Worker, error) {
 		EntityStatusHistoryCount:    100,
 		EntityStatusHistoryInterval: 5 * time.Minute,
 		ModelRemoveDelay:            24 * time.Hour,
+		DiscoverSpacesCheckLock:     a.discoverSpacesComplete,
 	})
 	if err := dependency.Install(engine, manifolds); err != nil {
 		if err := worker.Stop(engine); err != nil {

--- a/cmd/jujud/agent/model/manifolds_test.go
+++ b/cmd/jujud/agent/model/manifolds_test.go
@@ -32,9 +32,9 @@ func (s *ManifoldsSuite) TestNames(c *gc.C) {
 	// NOTE: if this test failed, the cmd/jujud/agent tests will
 	// also fail. Search for 'ModelWorkers' to find affected vars.
 	c.Check(actual.Values(), jc.SameContents, []string{
-		"agent", "clock", "api-caller",
+		"agent", "clock", "api-caller", "discover-spaces-check-gate",
 		"is-responsible-flag", "not-dead-flag", "not-alive-flag",
-		"environ-tracker", "undertaker", "space-importer",
+		"environ-tracker", "undertaker", "discover-spaces",
 		"storage-provisioner", "compute-provisioner",
 		"firewaller", "unit-assigner", "service-scaler",
 		"instance-poller", "charm-revision-updater",
@@ -45,7 +45,7 @@ func (s *ManifoldsSuite) TestNames(c *gc.C) {
 
 func (s *ManifoldsSuite) TestResponsibleFlagDependencies(c *gc.C) {
 	exclusions := set.NewStrings(
-		"agent", "api-caller", "clock",
+		"agent", "api-caller", "clock", "discover-spaces-check-gate",
 		"is-responsible-flag", "not-dead-flag", "not-alive-flag",
 	)
 	manifolds := model.Manifolds(model.ManifoldsConfig{

--- a/cmd/jujud/agent/util_test.go
+++ b/cmd/jujud/agent/util_test.go
@@ -24,11 +24,11 @@ var (
 	// the model Dead via the undertaker, so it can't be waited for
 	// reliably.
 	alwaysModelWorkers = []string{
-		"agent", "clock", "api-caller",
+		"agent", "clock", "api-caller", "discover-spaces-check-gate",
 		"is-responsible-flag", "not-alive-flag", "not-dead-flag",
 	}
 	aliveModelWorkers = []string{
-		"environ-tracker", "space-importer", "compute-provisioner",
+		"environ-tracker", "discover-spaces", "compute-provisioner",
 		"storage-provisioner", "firewaller", "unit-assigner",
 		"service-scaler", "instance-poller", "charm-revision-updater",
 		"metric-worker", "state-cleaner", "status-history-pruner",

--- a/worker/machiner/machiner.go
+++ b/worker/machiner/machiner.go
@@ -50,9 +50,8 @@ func (cfg *Config) Validate() error {
 
 // Machiner is responsible for a machine agent's lifecycle.
 type Machiner struct {
-	config            Config
-	machine           Machine
-	observedConfigSet bool
+	config  Config
+	machine Machine
 }
 
 // NewMachiner returns a Worker that will wait for the identified machine
@@ -158,11 +157,6 @@ func (mr *Machiner) Handle(_ <-chan struct{}) error {
 
 	life := mr.machine.Life()
 	if life == params.Alive {
-		if mr.observedConfigSet {
-			logger.Infof("observed network config already updated")
-			return nil
-		}
-
 		observedConfig, err := getObservedNetworkConfig()
 		if err != nil {
 			return errors.Annotate(err, "cannot discover observed network config")
@@ -174,8 +168,7 @@ func (mr *Machiner) Handle(_ <-chan struct{}) error {
 				return errors.Annotate(err, "cannot update observed network config")
 			}
 		}
-		logger.Infof("observed network config updated")
-		mr.observedConfigSet = true
+		logger.Debugf("observed network config updated")
 
 		return nil
 	}


### PR DESCRIPTION
tl;dr Fixes http://pad.lv/1564395 to unblock multi-NIC containers provisioning.

Machiner now always tries to call SetObservedNetworkConfig() initially, rather than only
once. This fixes the underlying issue - containers do not get multi-NIC config unless the
MA is bounced after bootstrap. Because of how the network config MA can observe
is merged with the provider's NetworkInterfaces() results, there is a contention between
spaces discovery still going (or not yet started) and trying to update the controller's
network config post-bootstrap (or post-create-model), which includes addresses coming
from subnets yet-to-be-discovered for the current model. In this case we don't store the
SubnetID of the link-layer device address, which later causes PrepareContainerInterfaceInfo()
provisioner API call to fail. This PR fixes the symptom of the issue, but later the process of
provisioning machines/containers and updating their network config will be improved
(using separate workers, rather than the machiner and provisioner).

Additionally, a new DiscoverSpacesCheckGate is added to the modelworker manifold,
but it's not utilized yet (in a follow-up).

Live tested on MAAS 1.9.0 / xenial.

(Review request: http://reviews.vapour.ws/r/4488/)