### PR TITLE
destroy-controller: short-circuit empty models

### DIFF
--- a/api/controller/controller_test.go
+++ b/api/controller/controller_test.go
@@ -71,7 +71,9 @@ func (s *controllerSuite) TestModelConfig(c *gc.C) {
 }
 
 func (s *controllerSuite) TestDestroyController(c *gc.C) {
-	s.Factory.MakeModel(c, &factory.ModelParams{Name: "foo"}).Close()
+	st := s.Factory.MakeModel(c, &factory.ModelParams{Name: "foo"})
+	factory.NewFactory(st).MakeMachine(c, nil) // make it non-empty
+	st.Close()
 
 	sysManager := s.OpenAPI(c)
 	err := sysManager.DestroyController(false)

--- a/apiserver/common/errors.go
+++ b/apiserver/common/errors.go
@@ -205,6 +205,8 @@ func ServerError(err error) *params.Error {
 		code = params.CodeNotAssigned
 	case state.IsHasAssignedUnitsError(err):
 		code = params.CodeHasAssignedUnits
+	case state.IsHasHostedModelsError(err):
+		code = params.CodeHasHostedModels
 	case isNoAddressSetError(err):
 		code = params.CodeNoAddressSet
 	case errors.IsNotProvisioned(err):
@@ -287,6 +289,8 @@ func RestoreError(err error) error {
 	case params.IsCodeHasAssignedUnits(err):
 		// TODO(ericsnow) Handle state.HasAssignedUnitsError here.
 		// ...by parsing msg?
+		return err
+	case params.IsCodeHasHostedModels(err):
 		return err
 	case params.IsCodeNoAddressSet(err):
 		// TODO(ericsnow) Handle isNoAddressSetError here.

--- a/apiserver/common/modeldestroy_test.go
+++ b/apiserver/common/modeldestroy_test.go
@@ -331,14 +331,19 @@ func (s *destroyTwoModelsSuite) TestDestroyControllerAfterNonControllerIsDestroy
 	err = common.DestroyModel(s.State, s.otherState.ModelTag())
 	c.Assert(err, jc.ErrorIsNil)
 
+	// The hosted model is Dying, not Dead; we cannot destroy
+	// the controller model until all hosted models are Dead.
 	err = common.DestroyModel(s.State, s.State.ModelTag())
-	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(err, gc.ErrorMatches, "failed to destroy model: hosting 1 other models")
 
-	// Make sure we can continue to take the hosted model down while the
-	// controller environ is dying.
+	// Continue to take the hosted model down so we can
+	// destroy the controller model.
 	runAllCleanups(c, s.otherState)
 	assertAllMachinesDeadAndRemove(c, s.otherState)
 	c.Assert(s.otherState.ProcessDyingModel(), jc.ErrorIsNil)
+
+	err = common.DestroyModel(s.State, s.State.ModelTag())
+	c.Assert(err, jc.ErrorIsNil)
 
 	otherEnv, err := s.otherState.Model()
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/controller/destroy.go
+++ b/apiserver/controller/destroy.go
@@ -14,6 +14,12 @@ import (
 // DestroyController will attempt to destroy the controller. If the args
 // specify the removal of blocks or the destruction of the models, this
 // method will attempt to do so.
+//
+// If the controller has any non-Dead hosted models, then an error with
+// the code params.CodeHasHostedModels will be transmitted, regardless of
+// the value of the DestroyModels parameter. This is to inform the client
+// that it should wait for hosted models to be completely cleaned up
+// before proceeding.
 func (s *ControllerAPI) DestroyController(args params.DestroyControllerArgs) error {
 	controllerEnv, err := s.state.ControllerModel()
 	if err != nil {

--- a/apiserver/params/apierror.go
+++ b/apiserver/params/apierror.go
@@ -67,6 +67,7 @@ const (
 	CodeStopped                   = "stopped"
 	CodeDead                      = "dead"
 	CodeHasAssignedUnits          = "machine has assigned units"
+	CodeHasHostedModels           = "controller has hosted models"
 	CodeMachineHasAttachedStorage = "machine has attached storage"
 	CodeNotProvisioned            = "not provisioned"
 	CodeNoAddressSet              = "no address set"
@@ -151,6 +152,10 @@ func IsCodeDead(err error) bool {
 
 func IsCodeHasAssignedUnits(err error) bool {
 	return ErrCode(err) == CodeHasAssignedUnits
+}
+
+func IsCodeHasHostedModels(err error) bool {
+	return ErrCode(err) == CodeHasHostedModels
 }
 
 func IsCodeMachineHasAttachedStorage(err error) bool {

--- a/cmd/juju/controller/destroy.go
+++ b/cmd/juju/controller/destroy.go
@@ -134,27 +134,77 @@ func (c *destroyCommand) Run(ctx *cmd.Context) error {
 		return errors.Annotate(err, "getting controller environ")
 	}
 
-	// Attempt to destroy the controller.
-	err = api.DestroyController(c.destroyModels)
-	if err != nil {
-		return c.ensureUserFriendlyErrorLog(errors.Annotate(err, "cannot destroy controller"), ctx, api)
-	}
-
-	ctx.Infof("Destroying controller %q", c.ControllerName())
-	if c.destroyModels {
-		ctx.Infof("Waiting for hosted model resources to be reclaimed.")
+	for {
+		// Attempt to destroy the controller.
+		ctx.Infof("Destroying controller")
+		var hasHostedModels bool
+		err = api.DestroyController(c.destroyModels)
+		if err != nil {
+			if params.IsCodeHasHostedModels(err) {
+				hasHostedModels = true
+			} else {
+				return c.ensureUserFriendlyErrorLog(
+					errors.Annotate(err, "cannot destroy controller"),
+					ctx, api,
+				)
+			}
+		}
 
 		updateStatus := newTimedStatusUpdater(ctx, api, controllerDetails.ControllerUUID)
-		for ctrStatus, modelsStatus := updateStatus(0); hasUnDeadModels(modelsStatus); ctrStatus, modelsStatus = updateStatus(2 * time.Second) {
+		ctrStatus, modelsStatus := updateStatus(0)
+		if !c.destroyModels {
+			if err := c.checkNoAliveHostedModels(ctx, modelsStatus); err != nil {
+				return errors.Trace(err)
+			}
+			if hasHostedModels && !hasUnDeadModels(modelsStatus) {
+				// When we called DestroyController before, we were
+				// informed that there were hosted models remaining.
+				// When we checked just now, there were none. We should
+				// try destroying again.
+				continue
+			}
+		}
+
+		// Even if we've not just requested for hosted models to be destroyed,
+		// there may be some being destroyed already. We need to wait for them.
+		ctx.Infof("Waiting for hosted model resources to be reclaimed")
+		for ; hasUnDeadModels(modelsStatus); ctrStatus, modelsStatus = updateStatus(2 * time.Second) {
 			ctx.Infof(fmtCtrStatus(ctrStatus))
 			for _, model := range modelsStatus {
 				ctx.Verbosef(fmtModelStatus(model))
 			}
 		}
-
 		ctx.Infof("All hosted models reclaimed, cleaning up controller machines")
+		return environs.Destroy(c.ControllerName(), controllerEnviron, store)
 	}
-	return environs.Destroy(c.ControllerName(), controllerEnviron, store)
+}
+
+// checkNoAliveHostedModels ensures that the given set of hosted models
+// contains none that are Alive. If there are, an message is printed
+// out to
+func (c *destroyCommand) checkNoAliveHostedModels(ctx *cmd.Context, models []modelData) error {
+	if !hasAliveModels(models) {
+		return nil
+	}
+	// The user did not specify --destroy-all-models,
+	// and there are models still alive.
+	var buf bytes.Buffer
+	for _, model := range models {
+		if model.Life != params.Alive {
+			continue
+		}
+		buf.WriteString(fmtModelStatus(model))
+		buf.WriteRune('\n')
+	}
+	return errors.Errorf(`cannot destroy controller %q
+
+The controller has live hosted models. If you want
+to destroy all hosted models in the controller,
+run this command again with the --destroy-all-models
+flag.
+
+Models:
+%s`, c.ControllerName(), buf.String())
 }
 
 // ensureUserFriendlyErrorLog ensures that error will be logged and displayed
@@ -164,19 +214,13 @@ func (c *destroyCommand) ensureUserFriendlyErrorLog(destroyErr error, ctx *cmd.C
 		return nil
 	}
 	if params.IsCodeOperationBlocked(destroyErr) {
-		logger.Errorf(`there are blocks preventing controller destruction
-To remove all blocks in the controller, please run:
-
-    juju controller remove-blocks
-
-`)
+		logger.Errorf(destroyControllerBlockedMsg)
 		if api != nil {
 			models, err := api.ListBlockedModels()
 			var bytes []byte
 			if err == nil {
 				bytes, err = formatTabularBlockedModels(models)
 			}
-
 			if err != nil {
 				logger.Errorf("Unable to list blocked models: %s", err)
 				return cmd.ErrSilent
@@ -185,11 +229,23 @@ To remove all blocks in the controller, please run:
 		}
 		return cmd.ErrSilent
 	}
+	if params.IsCodeHasHostedModels(destroyErr) {
+		return destroyErr
+	}
 	logger.Errorf(stdFailureMsg, c.ControllerName())
 	return destroyErr
 }
 
-var stdFailureMsg = `failed to destroy controller %q
+const destroyControllerBlockedMsg = `there are blocks preventing controller destruction
+To remove all blocks in the controller, please run:
+
+    juju controller remove-blocks
+
+`
+
+// TODO(axw) this should only be printed out if we couldn't
+// connect to the controller.
+const stdFailureMsg = `failed to destroy controller %q
 
 If the controller is unusable, then you may run
 
@@ -198,6 +254,7 @@ If the controller is unusable, then you may run
 to forcibly destroy the controller. Upon doing so, review
 your model provider console for any resources that need
 to be cleaned up.
+
 `
 
 func formatTabularBlockedModels(value interface{}) ([]byte, error) {

--- a/cmd/juju/controller/destroy.go
+++ b/cmd/juju/controller/destroy.go
@@ -252,7 +252,7 @@ If the controller is unusable, then you may run
     juju kill-controller
 
 to forcibly destroy the controller. Upon doing so, review
-your model provider console for any resources that need
+your cloud provider console for any resources that need
 to be cleaned up.
 
 `

--- a/cmd/juju/controller/kill_test.go
+++ b/cmd/juju/controller/kill_test.go
@@ -79,7 +79,7 @@ func (s *KillSuite) TestKillWithAPIConnection(c *gc.C) {
 
 func (s *KillSuite) TestKillEnvironmentGetFailsWithoutAPIConnection(c *gc.C) {
 	s.apierror = errors.New("connection refused")
-	s.api.err = errors.NotFoundf(`controller "test3"`)
+	s.api.SetErrors(errors.NotFoundf(`controller "test3"`))
 	_, err := s.runKillCommand(c, "test3", "-y")
 	c.Assert(err, gc.ErrorMatches,
 		"getting controller environ: unable to get bootstrap information from client store or API",
@@ -88,7 +88,7 @@ func (s *KillSuite) TestKillEnvironmentGetFailsWithoutAPIConnection(c *gc.C) {
 }
 
 func (s *KillSuite) TestKillEnvironmentGetFailsWithAPIConnection(c *gc.C) {
-	s.api.err = errors.NotFoundf(`controller "test3"`)
+	s.api.SetErrors(errors.NotFoundf(`controller "test3"`))
 	_, err := s.runKillCommand(c, "test3", "-y")
 	c.Assert(err, gc.ErrorMatches,
 		"getting controller environ: getting bootstrap config from API: controller \"test3\" not found",
@@ -97,7 +97,7 @@ func (s *KillSuite) TestKillEnvironmentGetFailsWithAPIConnection(c *gc.C) {
 }
 
 func (s *KillSuite) TestKillDestroysControllerWithAPIError(c *gc.C) {
-	s.api.err = errors.New("some destroy error")
+	s.api.SetErrors(errors.New("some destroy error"))
 	ctx, err := s.runKillCommand(c, "local.test1", "-y")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(testing.Stderr(ctx), jc.Contains, "Unable to destroy controller through the API: some destroy error.  Destroying through provider.")
@@ -237,6 +237,8 @@ func (s *KillSuite) TestControllerStatus(c *gc.C) {
 
 func (s *KillSuite) TestFmtControllerStatus(c *gc.C) {
 	data := controller.CtrData{
+		"uuid",
+		params.Alive,
 		3,
 		20,
 		8,
@@ -247,6 +249,7 @@ func (s *KillSuite) TestFmtControllerStatus(c *gc.C) {
 
 func (s *KillSuite) TestFmtEnvironStatus(c *gc.C) {
 	data := controller.ModelData{
+		"uuid",
 		"owner@local",
 		"envname",
 		params.Dying,
@@ -255,5 +258,5 @@ func (s *KillSuite) TestFmtEnvironStatus(c *gc.C) {
 	}
 
 	out := controller.FmtModelStatus(data)
-	c.Assert(out, gc.Equals, "owner@local/envname (dying), 8 machines, 1 service")
+	c.Assert(out, gc.Equals, "\towner@local/envname (dying), 8 machines, 1 service")
 }

--- a/cmd/juju/controller/killstatus.go
+++ b/cmd/juju/controller/killstatus.go
@@ -14,12 +14,15 @@ import (
 )
 
 type ctrData struct {
+	UUID               string
+	Life               params.Life
 	HostedModelCount   int
 	HostedMachineCount int
 	ServiceCount       int
 }
 
 type modelData struct {
+	UUID  string
 	Owner string
 	Name  string
 	Life  params.Life
@@ -89,6 +92,7 @@ func newData(api destroyControllerAPI, ctrUUID string) (ctrData, []modelData, er
 			continue
 		}
 		modelsData = append(modelsData, modelData{
+			model.UUID,
 			model.Owner,
 			modelName[model.UUID],
 			model.Life,
@@ -102,6 +106,8 @@ func newData(api destroyControllerAPI, ctrUUID string) (ctrData, []modelData, er
 	}
 
 	ctrFinalStatus := ctrData{
+		ctrUUID,
+		ctrStatus.Life,
 		aliveModelCount,
 		hostedMachinesCount,
 		servicesCount,
@@ -113,6 +119,15 @@ func newData(api destroyControllerAPI, ctrUUID string) (ctrData, []modelData, er
 func hasUnDeadModels(models []modelData) bool {
 	for _, model := range models {
 		if model.Life != params.Dead {
+			return true
+		}
+	}
+	return false
+}
+
+func hasAliveModels(models []modelData) bool {
+	for _, model := range models {
+		if model.Life == params.Alive {
 			return true
 		}
 	}
@@ -142,7 +157,7 @@ func fmtCtrStatus(data ctrData) string {
 }
 
 func fmtModelStatus(data modelData) string {
-	out := fmt.Sprintf("%s/%s (%s)", data.Owner, data.Name, data.Life)
+	out := fmt.Sprintf("\t%s/%s (%s)", data.Owner, data.Name, data.Life)
 
 	if machineNo := data.HostedMachineCount; machineNo > 0 {
 		out += fmt.Sprintf(", %d machine%s", machineNo, s(machineNo))

--- a/featuretests/api_undertaker_test.go
+++ b/featuretests/api_undertaker_test.go
@@ -116,12 +116,15 @@ func (s *undertakerSuite) TestHostedProcessDyingEnviron(c *gc.C) {
 	err := undertakerClient.ProcessDyingModel()
 	c.Assert(err, gc.ErrorMatches, "model is not dying")
 
+	factory.NewFactory(otherSt).MakeService(c, nil)
 	env, err := otherSt.Model()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(env.Destroy(), jc.ErrorIsNil)
 	c.Assert(env.Refresh(), jc.ErrorIsNil)
 	c.Assert(env.Life(), gc.Equals, state.Dying)
 
+	err = otherSt.Cleanup()
+	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(undertakerClient.ProcessDyingModel(), jc.ErrorIsNil)
 
 	c.Assert(env.Refresh(), jc.ErrorIsNil)
@@ -155,6 +158,7 @@ func (s *undertakerSuite) TestHostedRemoveEnviron(c *gc.C) {
 	err := undertakerClient.RemoveModel()
 	c.Assert(err, gc.ErrorMatches, "an error occurred, unable to remove model")
 
+	factory.NewFactory(otherSt).MakeService(c, nil)
 	env, err := otherSt.Model()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(env.Destroy(), jc.ErrorIsNil)
@@ -163,6 +167,8 @@ func (s *undertakerSuite) TestHostedRemoveEnviron(c *gc.C) {
 	err = undertakerClient.RemoveModel()
 	c.Assert(err, gc.ErrorMatches, "an error occurred, unable to remove model")
 
+	err = otherSt.Cleanup()
+	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(undertakerClient.ProcessDyingModel(), jc.ErrorIsNil)
 
 	c.Assert(undertakerClient.RemoveModel(), jc.ErrorIsNil)

--- a/featuretests/cmd_juju_controller_test.go
+++ b/featuretests/cmd_juju_controller_test.go
@@ -122,6 +122,7 @@ func (s *cmdControllerSuite) TestControllerDestroy(c *gc.C) {
 		ConfigAttrs: testing.Attrs{"controller": true},
 	})
 	defer st.Close()
+	factory.NewFactory(st).MakeService(c, nil)
 
 	stop := make(chan struct{})
 	done := make(chan struct{})
@@ -134,6 +135,8 @@ func (s *cmdControllerSuite) TestControllerDestroy(c *gc.C) {
 		a := testing.LongAttempt.Start()
 		for a.Next() {
 			err := s.State.Cleanup()
+			c.Check(err, jc.ErrorIsNil)
+			err = st.Cleanup()
 			c.Check(err, jc.ErrorIsNil)
 			err = st.ProcessDyingModel()
 			if errors.Cause(err) != state.ErrModelNotDying {

--- a/state/addmachine.go
+++ b/state/addmachine.go
@@ -549,6 +549,7 @@ func (st *State) baseNewMachineOps(mdoc *machineDoc, machineStatusDoc, instanceS
 		// follow-up.
 		createRequestedNetworksOp(st, globalKey, networks),
 		createMachineBlockDevicesOp(mdoc.Id),
+		addModelMachineRefOp(st, mdoc.Id),
 	}
 	return prereqOps, machineOp
 }

--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -98,6 +98,11 @@ func allCollections() collectionSchema {
 		// Life and its UUID.
 		modelsC: {global: true},
 
+		// This collection holds references to entities owned by a
+		// model. We use this to determine whether or not we can safely
+		// destroy empty models.
+		modelEntityRefsC: {global: true},
+
 		// This collection is holds the parameters for model migrations.
 		modelMigrationsC: {
 			global: true,
@@ -426,6 +431,7 @@ const (
 	modelUserLastConnectionC = "modelUserLastConnection"
 	modelUsersC              = "modelusers"
 	modelsC                  = "models"
+	modelEntityRefsC         = "modelEntityRefs"
 	networkInterfacesC       = "networkinterfaces"
 	networksC                = "networks"
 	openedPortsC             = "openedPorts"

--- a/state/cleanup_test.go
+++ b/state/cleanup_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/storage/provider"
 	"github.com/juju/juju/storage/provider/registry"
+	"github.com/juju/juju/testing/factory"
 )
 
 type CleanupSuite struct {
@@ -74,9 +75,10 @@ func (s *CleanupSuite) TestCleanupDyingServiceUnits(c *gc.C) {
 func (s *CleanupSuite) TestCleanupControllerModels(c *gc.C) {
 	s.assertDoesNotNeedCleanup(c)
 
-	// Create an model.
+	// Create a non-empty hosted model.
 	otherSt := s.Factory.MakeModel(c, nil)
 	defer otherSt.Close()
+	factory.NewFactory(otherSt).MakeService(c, nil)
 	otherEnv, err := otherSt.Model()
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/state/machine.go
+++ b/state/machine.go
@@ -887,6 +887,7 @@ func (m *Machine) Remove() (err error) {
 		annotationRemoveOp(m.st, m.globalKey()),
 		removeRebootDocOp(m.st, m.globalKey()),
 		removeMachineBlockDevicesOp(m.Id()),
+		removeModelMachineRefOp(m.st, m.Id()),
 	}
 	ifacesOps, err := m.removeNetworkInterfacesOps()
 	if err != nil {

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -96,6 +96,11 @@ func (s *MigrationSuite) TestKnownCollections(c *gc.C) {
 		// to machines.
 		assignUnitC,
 
+		// The model entity references collection will be repopulated
+		// after importing the model. It does not need to be migrated
+		// separately.
+		modelEntityRefsC,
+
 		// This has been deprecated in 2.0, and should not contain any data
 		// we actually care about migrating.
 		legacyipaddressesC,
@@ -161,7 +166,7 @@ func (s *MigrationSuite) TestKnownCollections(c *gc.C) {
 
 func (s *MigrationSuite) TestModelDocFields(c *gc.C) {
 	fields := set.NewStrings(
-		// UUID and Mame are constructed from the model config.
+		// UUID and Name are constructed from the model config.
 		"UUID",
 		"Name",
 		// Life will always be alive, or we won't be migrating.

--- a/state/model_test.go
+++ b/state/model_test.go
@@ -251,17 +251,35 @@ func (s *ModelSuite) TestDestroyOtherModel(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-func (s *ModelSuite) TestDestroyControllerModelFails(c *gc.C) {
+func (s *ModelSuite) TestDestroyControllerNonEmptyModelFails(c *gc.C) {
 	st2 := s.Factory.MakeModel(c, nil)
 	defer st2.Close()
+	factory.NewFactory(st2).MakeService(c, nil)
+
 	env, err := s.State.Model()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(env.Destroy(), gc.ErrorMatches, "failed to destroy model: hosting 1 other models")
 }
 
+func (s *ModelSuite) TestDestroyControllerEmptyModel(c *gc.C) {
+	st2 := s.Factory.MakeModel(c, nil)
+	defer st2.Close()
+
+	controllerModel, err := s.State.Model()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(controllerModel.Destroy(), jc.ErrorIsNil)
+	c.Assert(controllerModel.Refresh(), jc.ErrorIsNil)
+	c.Assert(controllerModel.Life(), gc.Equals, state.Dying)
+
+	hostedModel, err := st2.Model()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(hostedModel.Life(), gc.Equals, state.Dead)
+}
+
 func (s *ModelSuite) TestDestroyControllerAndHostedModels(c *gc.C) {
 	st2 := s.Factory.MakeModel(c, nil)
 	defer st2.Close()
+	factory.NewFactory(st2).MakeService(c, nil)
 
 	controllerEnv, err := s.State.Model()
 	c.Assert(err, jc.ErrorIsNil)
@@ -273,6 +291,10 @@ func (s *ModelSuite) TestDestroyControllerAndHostedModels(c *gc.C) {
 
 	assertNeedsCleanup(c, s.State)
 	assertCleanupRuns(c, s.State)
+
+	// Cleanups for hosted model enqueued by controller model cleanups.
+	assertNeedsCleanup(c, st2)
+	assertCleanupRuns(c, st2)
 
 	env2, err := st2.Model()
 	c.Assert(err, jc.ErrorIsNil)
@@ -347,13 +369,52 @@ func (s *ModelSuite) TestDestroyControllerAndHostedModelsWithResources(c *gc.C) 
 	c.Assert(controllerEnv.Life(), gc.Equals, state.Dead)
 }
 
-func (s *ModelSuite) TestDestroyControllerModelRace(c *gc.C) {
-	// Simulate an model being added just before the remove txn is
-	// called.
+func (s *ModelSuite) TestDestroyControllerEmptyModelRace(c *gc.C) {
+	defer s.Factory.MakeModel(c, nil).Close()
+
+	// Simulate an empty model being added just before the
+	// remove txn is called.
 	defer state.SetBeforeHooks(c, s.State, func() {
-		blocker := s.Factory.MakeModel(c, nil)
-		err := blocker.Close()
-		c.Check(err, jc.ErrorIsNil)
+		s.Factory.MakeModel(c, nil).Close()
+	}).Check()
+
+	env, err := s.State.Model()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(env.Destroy(), jc.ErrorIsNil)
+}
+
+func (s *ModelSuite) TestDestroyControllerRemoveEmptyAddNonEmptyModel(c *gc.C) {
+	st2 := s.Factory.MakeModel(c, nil)
+	defer st2.Close()
+
+	// Simulate an empty model being removed, and a new non-empty
+	// model being added, just before the remove txn is called.
+	defer state.SetBeforeHooks(c, s.State, func() {
+		// Destroy the empty model, which should move it right
+		// along to Dead.
+		model, err := st2.Model()
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(model.Destroy(), jc.ErrorIsNil)
+
+		// Add a new, non-empty model. This should still prevent
+		// the controller from being destroyed.
+		st3 := s.Factory.MakeModel(c, nil)
+		defer st3.Close()
+		factory.NewFactory(st3).MakeService(c, nil)
+	}).Check()
+
+	env, err := s.State.Model()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(env.Destroy(), gc.ErrorMatches, "failed to destroy model: hosting 1 other models")
+}
+
+func (s *ModelSuite) TestDestroyControllerNonEmptyModelRace(c *gc.C) {
+	// Simulate an empty model being added just before the
+	// remove txn is called.
+	defer state.SetBeforeHooks(c, s.State, func() {
+		st := s.Factory.MakeModel(c, nil)
+		defer st.Close()
+		factory.NewFactory(st).MakeService(c, nil)
 	}).Check()
 
 	env, err := s.State.Model()
@@ -382,6 +443,59 @@ func (s *ModelSuite) TestDestroyControllerAlreadyDyingNoOp(c *gc.C) {
 	c.Assert(env.Destroy(), jc.ErrorIsNil)
 }
 
+func (s *ModelSuite) TestDestroyModelNonEmpty(c *gc.C) {
+	m, err := s.State.Model()
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Add a service to prevent the model from transitioning directly to Dead.
+	s.Factory.MakeService(c, nil)
+
+	c.Assert(m.Destroy(), jc.ErrorIsNil)
+	c.Assert(m.Refresh(), jc.ErrorIsNil)
+	c.Assert(m.Life(), gc.Equals, state.Dying)
+}
+
+func (s *ModelSuite) TestDestroyModelAddServiceConcurrently(c *gc.C) {
+	st := s.Factory.MakeModel(c, nil)
+	defer st.Close()
+	m, err := st.Model()
+	c.Assert(err, jc.ErrorIsNil)
+
+	defer state.SetBeforeHooks(c, st, func() {
+		factory.NewFactory(st).MakeService(c, nil)
+	}).Check()
+
+	c.Assert(m.Destroy(), jc.ErrorIsNil)
+	c.Assert(m.Refresh(), jc.ErrorIsNil)
+	c.Assert(m.Life(), gc.Equals, state.Dying)
+}
+
+func (s *ModelSuite) TestDestroyModelAddMachineConcurrently(c *gc.C) {
+	st := s.Factory.MakeModel(c, nil)
+	defer st.Close()
+	m, err := st.Model()
+	c.Assert(err, jc.ErrorIsNil)
+
+	defer state.SetBeforeHooks(c, st, func() {
+		factory.NewFactory(st).MakeMachine(c, nil)
+	}).Check()
+
+	c.Assert(m.Destroy(), jc.ErrorIsNil)
+	c.Assert(m.Refresh(), jc.ErrorIsNil)
+	c.Assert(m.Life(), gc.Equals, state.Dying)
+}
+
+func (s *ModelSuite) TestDestroyModelEmpty(c *gc.C) {
+	st := s.Factory.MakeModel(c, nil)
+	defer st.Close()
+	m, err := st.Model()
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(m.Destroy(), jc.ErrorIsNil)
+	c.Assert(m.Refresh(), jc.ErrorIsNil)
+	c.Assert(m.Life(), gc.Equals, state.Dead)
+}
+
 func (s *ModelSuite) TestProcessDyingServerEnvironTransitionDyingToDead(c *gc.C) {
 	s.assertDyingEnvironTransitionDyingToDead(c, s.State)
 }
@@ -393,6 +507,10 @@ func (s *ModelSuite) TestProcessDyingHostedEnvironTransitionDyingToDead(c *gc.C)
 }
 
 func (s *ModelSuite) assertDyingEnvironTransitionDyingToDead(c *gc.C, st *state.State) {
+	// Add a service to prevent the model from transitioning directly to Dead.
+	// Add the service before getting the Model, otherwise we'll have to run
+	// the transaction twice, and hit the hook point too early.
+	svc := factory.NewFactory(st).MakeService(c, nil)
 	env, err := st.Model()
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -402,6 +520,9 @@ func (s *ModelSuite) assertDyingEnvironTransitionDyingToDead(c *gc.C, st *state.
 	defer state.SetAfterHooks(c, st, func() {
 		c.Assert(env.Refresh(), jc.ErrorIsNil)
 		c.Assert(env.Life(), gc.Equals, state.Dying)
+
+		err := svc.Destroy()
+		c.Assert(err, jc.ErrorIsNil)
 
 		c.Assert(st.ProcessDyingModel(), jc.ErrorIsNil)
 
@@ -458,12 +579,15 @@ func (s *ModelSuite) TestProcessDyingEnvironWithMachinesAndServicesNoOp(c *gc.C)
 		assertEnv(state.Dying, 1, 1)
 	}).Check()
 
+	c.Assert(env.Refresh(), jc.ErrorIsNil)
 	c.Assert(env.Destroy(), jc.ErrorIsNil)
 }
 
 func (s *ModelSuite) TestProcessDyingControllerEnvironWithHostedEnvsNoOp(c *gc.C) {
+	// Add a non-empty model to the controller.
 	st := s.Factory.MakeModel(c, nil)
 	defer st.Close()
+	factory.NewFactory(st).MakeService(c, nil)
 
 	controllerEnv, err := s.State.Model()
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/open.go
+++ b/state/open.go
@@ -193,6 +193,7 @@ func (st *State) envSetupOps(cfg *config.Config, modelUUID, serverUUID string, o
 		createConstraintsOp(st, modelGlobalKey, constraints.Value{}),
 		createSettingsOp(modelGlobalKey, cfg.AllAttrs()),
 		incHostedModelCountOp(),
+		createModelEntityRefsOp(st, modelUUID),
 		createModelOp(st, owner, cfg.Name(), modelUUID, serverUUID),
 		createUniqueOwnerModelNameOp(owner, cfg.Name()),
 		modelUserOp,

--- a/state/service.go
+++ b/state/service.go
@@ -266,8 +266,9 @@ func (s *Service) removeOps(asserts bson.D) []txn.Op {
 		removeStorageConstraintsOp(s.globalKey()),
 		removeConstraintsOp(s.st, s.globalKey()),
 		annotationRemoveOp(s.st, s.globalKey()),
-		removeLeadershipSettingsOp(s.Tag().Id()),
+		removeLeadershipSettingsOp(s.Name()),
 		removeStatusOp(s.st, s.globalKey()),
+		removeModelServiceRefOp(s.st, s.Name()),
 	}
 	return ops
 }
@@ -1648,6 +1649,7 @@ func addServiceOps(st *State, args addServiceOpsArgs) []txn.Op {
 		createSettingsOp(settingsKey, args.settings),
 		createSettingsOp(leadershipKey, args.leadershipSettings),
 		createStatusOp(st, globalKey, args.statusDoc),
+		addModelServiceRefOp(st, svc.Name()),
 		{
 			C:      settingsrefsC,
 			Id:     settingsKey,

--- a/state/state.go
+++ b/state/state.go
@@ -136,6 +136,10 @@ func (st *State) RemoveAllModelDocs() error {
 		Id:     id,
 		Remove: true,
 	}, {
+		C:      modelEntityRefsC,
+		Id:     st.ModelUUID(),
+		Remove: true,
+	}, {
 		C:      modelsC,
 		Id:     st.ModelUUID(),
 		Assert: bson.D{{"life", Dead}},

--- a/state/undertaker.go
+++ b/state/undertaker.go
@@ -20,7 +20,6 @@ func (st *State) ProcessDyingModel() (err error) {
 		}
 
 		if model.Life() != Dying {
-			logger.Debugf("%v", model.Life())
 			return nil, errors.Trace(ErrModelNotDying)
 		}
 

--- a/state/undertaker.go
+++ b/state/undertaker.go
@@ -14,42 +14,33 @@ var ErrModelNotDying = errors.New("model is not dying")
 // state. If there are none, the model's life is changed from dying to dead.
 func (st *State) ProcessDyingModel() (err error) {
 	buildTxn := func(attempt int) ([]txn.Op, error) {
-		env, err := st.Model()
+		model, err := st.Model()
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
 
-		if env.Life() != Dying {
+		if model.Life() != Dying {
+			logger.Debugf("%v", model.Life())
 			return nil, errors.Trace(ErrModelNotDying)
 		}
 
 		if st.IsController() {
-			envs, err := st.AllModels()
+			models, err := st.AllModels()
 			if err != nil {
 				return nil, errors.Trace(err)
 			}
-			for _, env := range envs {
-				if env.UUID() != st.ModelUUID() && env.Life() != Dead {
+			for _, model := range models {
+				if model.UUID() != st.ModelUUID() && model.Life() != Dead {
 					return nil, errors.Errorf("one or more hosted models are not yet dead")
 				}
 			}
 		}
 
-		machines, err := st.AllMachines()
-		if err != nil {
+		if err := model.checkEmpty(); err != nil {
 			return nil, errors.Trace(err)
 		}
-		if l := len(machines); l > 0 {
-			return nil, errors.Errorf("model not empty, found %d machine(s)", l)
-		}
-		services, err := st.AllServices()
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		if l := len(services); l > 0 {
-			return nil, errors.Errorf("model not empty, found %d service(s)", l)
-		}
-		return []txn.Op{{
+
+		ops := []txn.Op{{
 			C:      modelsC,
 			Id:     st.ModelUUID(),
 			Assert: isDyingDoc,
@@ -57,7 +48,9 @@ func (st *State) ProcessDyingModel() (err error) {
 				"life":          Dead,
 				"time-of-death": nowToTheSecond(),
 			}},
-		}}, nil
+		}}
+		ops = append(ops, decHostedModelCountOp())
+		return ops, nil
 	}
 
 	if err = st.run(buildTxn); err != nil {


### PR DESCRIPTION
If you run "juju destroy-controller" on a controller
with only empty hosted models, it will now destroy
those empty models without having to specify the
--destroy-all-models flag. The state model has been
improved to make this safe.

We also fix an issue where, if you run "destroy-model"
on all hosted models, and then "destroy-controller"
quickly after, we could previously leak those hosted
models' resources. We will now wait for all hosted
models while destroying the controller.

Fixes https://bugs.launchpad.net/juju-core/+bug/1563615
Fixes https://bugs.launchpad.net/juju-core/+bug/1567228

(Review request: http://reviews.vapour.ws/r/4491/)