### PR TITLE
1568390 - Specify a mongo fallback for wily too

### DIFF
--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -603,9 +603,7 @@ func packagesForSeries(series string) ([]string, []string) {
 	switch series {
 	case "precise", "quantal", "raring", "saucy", "centos7":
 		return []string{"mongodb-server"}, []string{}
-	case "trusty":
-		return []string{JujuMongoPackage}, []string{"juju-mongodb"}
-	case "xenial":
+	case "trusty", "wily", "xenial":
 		return []string{JujuMongoPackage}, []string{"juju-mongodb"}
 	default:
 		// y and onwards

--- a/mongo/mongo_test.go
+++ b/mongo/mongo_test.go
@@ -413,6 +413,7 @@ func (s *MongoSuite) TestInstallMongodFallsBack(c *gc.C) {
 		c.Check(strings.TrimSpace(string(args)), gc.Equals, test.cmd)
 
 		err = os.Remove(outputFile)
+		c.Assert(err, jc.ErrorIsNil)
 	}
 }
 

--- a/mongo/mongo_test.go
+++ b/mongo/mongo_test.go
@@ -12,6 +12,7 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strconv"
 	"strings"
 
@@ -335,6 +336,7 @@ func (s *MongoSuite) TestInstallMongod(c *gc.C) {
 		{"raring", [][]string{{"--target-release", "mongodb-server"}}},
 		{"saucy", [][]string{{"--target-release", "mongodb-server"}}},
 		{"trusty", [][]string{{"juju-mongodb3.2"}}},
+		{"wily", [][]string{{"juju-mongodb3.2"}}},
 		{"xenial", [][]string{{"juju-mongodb3.2"}}},
 	}
 
@@ -350,6 +352,67 @@ func (s *MongoSuite) TestInstallMongod(c *gc.C) {
 			match := append(expectedArgs.AptGetBase, cmd...)
 			testing.AssertEchoArgs(c, "apt-get", match...)
 		}
+	}
+}
+
+var fakeInstallScript = `#!/bin/bash
+if [ $# -lt 1 ]
+then
+        echo "Install fail - not enough arguments"
+        exit 1
+fi
+
+# The package name is the last argument
+package=${@: -1}
+echo $package >> %s
+
+if [ $package == "juju-mongodb" ]
+then
+        echo "Installed successfully!"
+        exit 0
+fi
+
+if [ $package == "mongodb-server" ]
+then
+        echo "Installed successfully!"
+        exit 0
+fi
+
+echo "Unable to locate package $package"
+exit 100
+`
+
+func (s *MongoSuite) TestInstallMongodFallsBack(c *gc.C) {
+	if runtime.GOOS == "windows" {
+		c.Skip("Skipping TestInstallMongodFallsBack as mongo is not installed on windows")
+	}
+
+	type installs struct {
+		series string
+		cmd    string
+	}
+
+	tests := []installs{
+		{"precise", "mongodb-server"},
+		{"trusty", "juju-mongodb3.2\njuju-mongodb"},
+		{"wily", "juju-mongodb3.2\njuju-mongodb"},
+		{"xenial", "juju-mongodb3.2\njuju-mongodb"},
+	}
+
+	dataDir := c.MkDir()
+	outputFile := filepath.Join(dataDir, "apt-get-args")
+	testing.PatchExecutable(c, s, "apt-get", fmt.Sprintf(fakeInstallScript, outputFile))
+	for _, test := range tests {
+		c.Logf("Testing mongo install for series: %s", test.series)
+		s.patchSeries(test.series)
+		err := mongo.EnsureServer(makeEnsureServerParams(dataDir))
+		c.Assert(err, jc.ErrorIsNil)
+
+		args, err := ioutil.ReadFile(outputFile)
+		c.Assert(err, jc.ErrorIsNil)
+		c.Check(strings.TrimSpace(string(args)), gc.Equals, test.cmd)
+
+		err = os.Remove(outputFile)
 	}
 }
 


### PR DESCRIPTION
The addition of a fallback package for mongo didn't
specify a fallback for wily, so users couldn't bootstrap
a wily controller.

The test added were tested on ubuntu and centos.  This
change should land after the utils dependency is updated
to pull in https://github.com/juju/utils/pull/204

The utils change eliminates retries if a package fails
to install because it doesn't exist.

(Review request: http://reviews.vapour.ws/r/4503/)