### PR TITLE
1567683: filter bridge addresses for lxd instances

### DIFF
--- a/container/factory/network.go
+++ b/container/factory/network.go
@@ -4,8 +4,7 @@
 package factory
 
 import (
-	"github.com/juju/juju/container/kvm"
-	"github.com/juju/juju/container/lxc"
+	"github.com/juju/juju/container"
 	"github.com/juju/juju/instance"
 )
 
@@ -15,9 +14,9 @@ import (
 func DefaultNetworkBridge(cType instance.ContainerType) string {
 	switch cType {
 	case instance.LXC:
-		return lxc.DefaultLxcBridge
+		return container.DefaultLxcBridge
 	case instance.KVM:
-		return kvm.DefaultKvmBridge
+		return container.DefaultKvmBridge
 	default:
 		return ""
 	}

--- a/container/kvm/kvm.go
+++ b/container/kvm/kvm.go
@@ -28,7 +28,6 @@ var (
 	logger = loggo.GetLogger("juju.container.kvm")
 
 	KvmObjectFactory ContainerFactory = &containerFactory{}
-	DefaultKvmBridge                  = "virbr0"
 
 	// In order for Juju to be able to create the hardware characteristics of
 	// the kvm machines it creates, we need to be explicit in our definition

--- a/container/lxc/lxc.go
+++ b/container/lxc/lxc.go
@@ -46,8 +46,6 @@ var (
 )
 
 const (
-	// DefaultLxcBridge is the package created container bridge
-	DefaultLxcBridge = "lxcbr0"
 	// Btrfs is special as we treat it differently for create and clone.
 	Btrfs = "btrfs"
 
@@ -59,7 +57,7 @@ const (
 // DefaultNetworkConfig returns a valid NetworkConfig to use the
 // defaultLxcBridge that is created by the lxc package.
 func DefaultNetworkConfig() *container.NetworkConfig {
-	return container.BridgeNetworkConfig(DefaultLxcBridge, 0, nil)
+	return container.BridgeNetworkConfig(container.DefaultLxcBridge, 0, nil)
 }
 
 // FsCommandOutput calls cmd.Output, this is used as an overloading point so

--- a/container/network.go
+++ b/container/network.go
@@ -12,6 +12,12 @@ const (
 	BridgeNetwork = "bridge"
 	// PhyscialNetwork will have the container use a specified network device.
 	PhysicalNetwork = "physical"
+	// DefaultLxdBridge is the default name for the lxd bridge.
+	DefaultLxdBridge = "lxdbr0"
+	// DefaultLxcBridge is the package created container bridge.
+	DefaultLxcBridge = "lxcbr0"
+	// DefaultKvmBridge is the default bridge for KVM instances.
+	DefaultKvmBridge = "virbr0"
 )
 
 // NetworkConfig defines how the container network will be configured.

--- a/tools/lxdclient/client_instance.go
+++ b/tools/lxdclient/client_instance.go
@@ -262,7 +262,10 @@ func (client *instanceClient) Addresses(name string) ([]network.Address, error) 
 
 	addrs := []network.Address{}
 
-	for _, net := range networks {
+	for name, net := range networks {
+		if name == "lxcbr0" || name == "lxdbr0" {
+			continue
+		}
 		for _, addr := range net.Addresses {
 			if err != nil {
 				return nil, err

--- a/tools/lxdclient/client_instance.go
+++ b/tools/lxdclient/client_instance.go
@@ -12,6 +12,7 @@ import (
 	"github.com/lxc/lxd"
 	"github.com/lxc/lxd/shared"
 
+	"github.com/juju/juju/container"
 	"github.com/juju/juju/network"
 )
 
@@ -263,7 +264,7 @@ func (client *instanceClient) Addresses(name string) ([]network.Address, error) 
 	addrs := []network.Address{}
 
 	for name, net := range networks {
-		if name == "lxcbr0" || name == "lxdbr0" {
+		if name == container.DefaultLxcBridge || name == container.DefaultLxdBridge {
 			continue
 		}
 		for _, addr := range net.Addresses {

--- a/tools/lxdclient/client_instance_test.go
+++ b/tools/lxdclient/client_instance_test.go
@@ -51,7 +51,7 @@ var containerStateSample = lxdshared.ContainerState{
 			Addresses: []lxdshared.ContainerStateNetworkAddress{
 				lxdshared.ContainerStateNetworkAddress{
 					Family:  "inet",
-					Address: "10.0.3.173",
+					Address: "10.0.8.173",
 					Netmask: "24",
 					Scope:   "global",
 				},
@@ -101,6 +101,60 @@ var containerStateSample = lxdshared.ContainerState{
 			State:    "up",
 			Type:     "loopback",
 		},
+		"lxcbr0": lxdshared.ContainerStateNetwork{
+			Addresses: []lxdshared.ContainerStateNetworkAddress{
+				lxdshared.ContainerStateNetworkAddress{
+					Family:  "inet",
+					Address: "10.0.5.12",
+					Netmask: "24",
+					Scope:   "global",
+				},
+				lxdshared.ContainerStateNetworkAddress{
+					Family:  "inet6",
+					Address: "fe80::216:3eff:fe3b:e432",
+					Netmask: "64",
+					Scope:   "link",
+				},
+			},
+			Counters: lxdshared.ContainerStateNetworkCounters{
+				BytesReceived:   0,
+				BytesSent:       500,
+				PacketsReceived: 0,
+				PacketsSent:     6,
+			},
+			Hwaddr:   "5e:9b:b2:af:4c:f2",
+			HostName: "",
+			Mtu:      1500,
+			State:    "up",
+			Type:     "broadcast",
+		},
+		"lxdbr0": lxdshared.ContainerStateNetwork{
+			Addresses: []lxdshared.ContainerStateNetworkAddress{
+				lxdshared.ContainerStateNetworkAddress{
+					Family:  "inet",
+					Address: "10.0.6.17",
+					Netmask: "24",
+					Scope:   "global",
+				},
+				lxdshared.ContainerStateNetworkAddress{
+					Family:  "inet6",
+					Address: "fe80::5c9b:b2ff:feaf:4cf2",
+					Netmask: "64",
+					Scope:   "link",
+				},
+			},
+			Counters: lxdshared.ContainerStateNetworkCounters{
+				BytesReceived:   0,
+				BytesSent:       500,
+				PacketsReceived: 0,
+				PacketsSent:     6,
+			},
+			Hwaddr:   "52:54:00:5c:54:8f",
+			HostName: "",
+			Mtu:      1500,
+			State:    "up",
+			Type:     "broadcast",
+		},
 	},
 	Pid:       46072,
 	Processes: 19,
@@ -117,7 +171,7 @@ func (s *addressesSuite) TestAddresses(c *gc.C) {
 	// and filter out the LinkLocal address [fe80::216:3eff:fe3b:e582]
 	c.Check(addrs, jc.DeepEquals, []network.Address{
 		{
-			Value: "10.0.3.173",
+			Value: "10.0.8.173",
 			Type:  network.IPv4Address,
 			Scope: network.ScopeCloudLocal,
 		},

--- a/tools/lxdclient/remote_test.go
+++ b/tools/lxdclient/remote_test.go
@@ -12,7 +12,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/container/lxc"
+	"github.com/juju/juju/container"
 	"github.com/juju/juju/tools/lxdclient"
 )
 
@@ -430,7 +430,7 @@ type remoteFunctionalSuite struct {
 }
 
 func (s *remoteFunctionalSuite) TestUsingTCP(c *gc.C) {
-	if _, err := net.InterfaceByName(lxc.DefaultLxcBridge); err != nil {
+	if _, err := net.InterfaceByName(container.DefaultLxcBridge); err != nil {
 		c.Skip("network bridge interface not found")
 	}
 	lxdclient.PatchGenerateCertificate(&s.CleanupSuite, testingCert, testingKey)

--- a/worker/provisioner/kvm-broker.go
+++ b/worker/provisioner/kvm-broker.go
@@ -61,7 +61,7 @@ func (broker *kvmBroker) StartInstance(args environs.StartInstanceParams) (*envi
 	// container config.
 	bridgeDevice := broker.agentConfig.Value(agent.LxcBridge)
 	if bridgeDevice == "" {
-		bridgeDevice = kvm.DefaultKvmBridge
+		bridgeDevice = container.DefaultKvmBridge
 	}
 
 	preparedInfo, err := prepareOrGetContainerInterfaceInfo(
@@ -137,7 +137,7 @@ func (broker *kvmBroker) MaintainInstance(args environs.StartInstanceParams) err
 	// Default to using the host network until we can configure.
 	bridgeDevice := broker.agentConfig.Value(agent.LxcBridge)
 	if bridgeDevice == "" {
-		bridgeDevice = kvm.DefaultKvmBridge
+		bridgeDevice = container.DefaultKvmBridge
 	}
 
 	// There's no InterfaceInfo we expect to get below.

--- a/worker/provisioner/lxc-broker.go
+++ b/worker/provisioner/lxc-broker.go
@@ -90,7 +90,7 @@ func (broker *lxcBroker) StartInstance(args environs.StartInstanceParams) (*envi
 	// Default to using the host network until we can configure.
 	bridgeDevice := broker.agentConfig.Value(agent.LxcBridge)
 	if bridgeDevice == "" {
-		bridgeDevice = lxc.DefaultLxcBridge
+		bridgeDevice = container.DefaultLxcBridge
 	}
 
 	preparedInfo, err := prepareOrGetContainerInterfaceInfo(
@@ -181,7 +181,7 @@ func (broker *lxcBroker) MaintainInstance(args environs.StartInstanceParams) err
 	// Default to using the host network until we can configure.
 	bridgeDevice := broker.agentConfig.Value(agent.LxcBridge)
 	if bridgeDevice == "" {
-		bridgeDevice = lxc.DefaultLxcBridge
+		bridgeDevice = container.DefaultLxcBridge
 	}
 
 	// There's no InterfaceInfo we expect to get below.


### PR DESCRIPTION
The lxd provider should not return bridge addresses
from an Instance.Addresses() call.  These will be
filtered out now.

We cannot rely on FilterLXCAddresses as that filters
out addresses based on the current lxc-net config of
the controller.

I also updated the test to use a 10.0.8.* IP for eth0
to match what is currently being suggested as the
network for lxd, so that if there are filtering
problems later on, they might be caught in this test.

(Review request: http://reviews.vapour.ws/r/4504/)