### PR TITLE
provider/azure: honour agent mirrors

### DIFF
--- a/environs/simplestreams/simplestreams.go
+++ b/environs/simplestreams/simplestreams.go
@@ -44,8 +44,14 @@ type CloudSpec struct {
 
 // equals returns true if spec == other, allowing for endpoints
 // with or without a trailing "/".
-func (spec *CloudSpec) equals(other *CloudSpec) bool {
-	if spec.Region != other.Region {
+func (spec *CloudSpec) equals(other *CloudSpec) (res bool) {
+	// TODO(axw) 2016-04-11 #1568715
+	// This is a hack to enable the new Azure provider to
+	// work with the old simplestreams format. We should
+	// update how the publishing is done so that we generate
+	// with both the old Title Case style, and the new
+	// lowercasewithoutwhitespace style.
+	if canonicalRegionName(spec.Region) != canonicalRegionName(other.Region) {
 		return false
 	}
 	specEndpoint := spec.Endpoint
@@ -57,6 +63,11 @@ func (spec *CloudSpec) equals(other *CloudSpec) bool {
 		otherEndpoint += "/"
 	}
 	return specEndpoint == otherEndpoint
+}
+
+func canonicalRegionName(region string) string {
+	region = strings.Replace(region, " ", "", -1)
+	return strings.ToLower(region)
 }
 
 // EmptyCloudSpec is used when we want all records regardless of cloud to be loaded.

--- a/environs/tools/tools.go
+++ b/environs/tools/tools.go
@@ -65,6 +65,20 @@ func makeToolsConstraint(cloudSpec simplestreams.CloudSpec, stream string, major
 // Define some boolean parameter values.
 const DoNotAllowRetry = false
 
+// HasAgentMirror is an optional interface that an Environ may
+// implement to support agent/tools mirror lookup.
+//
+// TODO(axw) 2016-04-11 #1568715
+// This exists only because we currently lack
+// image simplestreams usable by the new Azure
+// Resource Manager provider. When we have that,
+// we can use "HasRegion" everywhere.
+type HasAgentMirror interface {
+	// AgentMirror returns the CloudSpec to use for looking up agent
+	// binaries.
+	AgentMirror() (simplestreams.CloudSpec, error)
+}
+
 // FindTools returns a List containing all tools in the given stream, with a given
 // major.minor version number available in the cloud instance, filtered by filter.
 // If minorVersion = -1, then only majorVersion is considered.
@@ -74,8 +88,13 @@ func FindTools(env environs.Environ, majorVersion, minorVersion int, stream stri
 	filter coretools.Filter) (list coretools.List, err error) {
 
 	var cloudSpec simplestreams.CloudSpec
-	if inst, ok := env.(simplestreams.HasRegion); ok {
-		if cloudSpec, err = inst.Region(); err != nil {
+	switch env := env.(type) {
+	case simplestreams.HasRegion:
+		if cloudSpec, err = env.Region(); err != nil {
+			return nil, err
+		}
+	case HasAgentMirror:
+		if cloudSpec, err = env.AgentMirror(); err != nil {
 			return nil, err
 		}
 	}

--- a/provider/azure/environ.go
+++ b/provider/azure/environ.go
@@ -32,6 +32,7 @@ import (
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/instances"
+	"github.com/juju/juju/environs/simplestreams"
 	"github.com/juju/juju/environs/tags"
 	"github.com/juju/juju/instance"
 	jujunetwork "github.com/juju/juju/network"
@@ -1174,4 +1175,20 @@ func (env *azureEnviron) getStorageClient() (internalazurestorage.Client, error)
 		return nil, errors.Annotate(err, "getting storage client")
 	}
 	return client, nil
+}
+
+// AgentMirror is specified in the tools.HasAgentMirror interface.
+//
+// TODO(axw) 2016-04-11 #1568715
+// When we have image simplestreams, we should rename this to "Region",
+// to implement simplestreams.HasRegion.
+func (env *azureEnviron) AgentMirror() (simplestreams.CloudSpec, error) {
+	env.mu.Lock()
+	defer env.mu.Unlock()
+	return simplestreams.CloudSpec{
+		Region: env.config.location,
+		// The endpoints published in simplestreams
+		// data are the storage endpoints.
+		Endpoint: fmt.Sprintf("https://%s/", env.config.storageEndpoint),
+	}, nil
 }

--- a/provider/azure/environ_test.go
+++ b/provider/azure/environ_test.go
@@ -29,8 +29,10 @@ import (
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/imagemetadata"
+	"github.com/juju/juju/environs/simplestreams"
 	"github.com/juju/juju/environs/tags"
 	envtesting "github.com/juju/juju/environs/testing"
+	envtools "github.com/juju/juju/environs/tools"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/provider/azure"
@@ -752,4 +754,15 @@ func (s *environSuite) constraintsValidator(c *gc.C) constraints.Validator {
 	validator, err := env.ConstraintsValidator()
 	c.Assert(err, jc.ErrorIsNil)
 	return validator
+}
+
+func (s *environSuite) TestAgentMirror(c *gc.C) {
+	env := s.openEnviron(c)
+	c.Assert(env, gc.Implements, new(envtools.HasAgentMirror))
+	cloudSpec, err := env.(envtools.HasAgentMirror).AgentMirror()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cloudSpec, gc.Equals, simplestreams.CloudSpec{
+		Region:   "westus",
+		Endpoint: "https://storage.azurestack.local/",
+	})
 }


### PR DESCRIPTION
We stopped implementing HasRegion when we moved over
to the Azure Resource Manager API, because we don't
(yet) have usable image simplestreams metadata. This
interface is also required to support agent mirrors,
though.

We introduce a new interface, HasAgentMirror, which may
be implemented instead of HasRegion; it will only be
used when looking up agent simplestreams metadata.
This is a temporary change, which we will replace with
an implementation of HasRegion for Azure when the image
metadata is available.

Fixes https://bugs.launchpad.net/juju-core/+bug/1551779

(Review request: http://reviews.vapour.ws/r/4511/)