### PR TITLE
delete related resources improvements on ec2.

### DIFF
--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -16,7 +16,6 @@ import (
 	"github.com/juju/utils"
 	"github.com/juju/utils/arch"
 	"github.com/juju/utils/clock"
-	"github.com/juju/utils/set"
 	"gopkg.in/amz.v3/aws"
 	"gopkg.in/amz.v3/ec2"
 	"gopkg.in/amz.v3/s3"
@@ -1393,11 +1392,10 @@ func (e *environ) terminateInstances(ids []instance.Id) error {
 	}
 	ec2inst := e.ec2()
 
-	notFoundIds := []instance.Id{}
 	// TODO (anastasiamac 2016-04-11) Err if instances still have resources hanging around.
 	// LP#1568654
 	defer func() {
-		e.deleteSecurityGroupsForInstances(deleteIDs(ids, notFoundIds))
+		e.deleteSecurityGroupsForInstances(ids)
 	}()
 
 	// TODO (anastasiamac 2016-04-7) instance termination would benefit
@@ -1412,41 +1410,31 @@ func (e *environ) terminateInstances(ids []instance.Id) error {
 			return err
 		}
 	}
+
+	if len(ids) == 1 {
+		if err != nil && ec2ErrCode(err) != "InvalidInstanceID.NotFound" {
+			return err
+		}
+		return nil
+	}
 	// If we get a NotFound error, it means that no instances have been
 	// terminated even if some exist, so try them one by one, ignoring
 	// NotFound errors.
+	deletedIDs := []instance.Id{}
 	for _, id := range ids {
 		_, err = terminateInstancesById(ec2inst, id)
-		if err != nil {
-			if ec2ErrCode(err) != "InvalidInstanceID.NotFound" {
-				return err
-			}
-			notFoundIds = append(notFoundIds, id)
+		if err == nil {
+			deletedIDs = append(deletedIDs, id)
+		}
+		if err != nil && ec2ErrCode(err) != "InvalidInstanceID.NotFound" {
+			ids = deletedIDs
+			return err
 		}
 	}
+	ids = deletedIDs
 	// We will get here if we all of the instances are deleted successfully,
 	// or are not found, which implies they were previously deleted.
 	return nil
-}
-
-var deleteIDs = func(all, unwanted []instance.Id) []instance.Id {
-	if len(unwanted) == 0 {
-		return all
-	}
-
-	removeSet := set.NewStrings()
-	for _, item := range unwanted {
-		removeSet.Add(string(item))
-	}
-
-	result := []instance.Id{}
-	for _, id := range all {
-		if !removeSet.Contains(string(id)) {
-			result = append(result, id)
-		}
-	}
-
-	return result
 }
 
 var terminateInstancesById = func(ec2inst *ec2.EC2, ids ...instance.Id) (*ec2.TerminateInstancesResp, error) {
@@ -1525,74 +1513,6 @@ var deleteSecurityGroupInsistently = func(inst SecurityGroupCleaner, group ec2.S
 		return lastErr
 	}
 	return nil
-}
-
-func (e *environ) terminateInstances(ids []instance.Id) error {
-	if len(ids) == 0 {
-		return nil
-	}
-	ec2inst := e.ec2()
-
-	defer func() {
-		securityGroups, err := e.instanceSecurityGroups(ids)
-		if err != nil {
-			logger.Warningf("cannot determine security groups to delete: %v", err)
-		}
-		// TODO(perrito666) we need to tag global security groups to be able
-		// to tell them apart from future groups that are neither machine
-		// nor environment group.
-		// https://bugs.launchpad.net/juju-core/+bug/1534289
-		jujuGroup := e.jujuGroupName()
-		legacyJujuGroup := e.legacyJujuGroupName()
-
-		for _, deletable := range securityGroups {
-			if deletable.Name != jujuGroup && deletable.Name != legacyJujuGroup {
-				if err := deleteSecurityGroupInsistently(ec2inst, deletable); err != nil {
-					// In ideal world, we would err out here.
-					// However:
-					// 1. We do not know if all instances have been terminated.
-					// If some instances erred out, they may still be using this security group.
-					// In this case, our failure to delete security group is reasonable: it's still in use.
-					// 2. Some security groups may be shared by multiple instances,
-					// for example, global firewalling. We should not delete these.
-					logger.Warningf("provider failure: %v", err)
-				}
-			}
-		}
-	}()
-
-	strs := make([]string, len(ids))
-	for i, id := range ids {
-		strs[i] = string(id)
-	}
-
-	var err error
-	// TODO (anastasiamac 2016-04-7) instance termination would benefit
-	// from retry with exponential delay just like security groups
-	// in defer. Bug#1567179.
-	for a := shortAttempt.Start(); a.Next(); {
-		_, err = ec2inst.TerminateInstances(strs)
-		if err == nil || ec2ErrCode(err) != "InvalidInstanceID.NotFound" {
-			return err
-		}
-	}
-	if len(ids) == 1 {
-		return err
-	}
-	// If we get a NotFound error, it means that no instances have been
-	// terminated even if some exist, so try them one by one, ignoring
-	// NotFound errors.
-	var firstErr error
-	for _, id := range ids {
-		_, err = ec2inst.TerminateInstances([]string{string(id)})
-		if ec2ErrCode(err) == "InvalidInstanceID.NotFound" {
-			err = nil
-		}
-		if err != nil && firstErr == nil {
-			firstErr = err
-		}
-	}
-	return firstErr
 }
 
 func (e *environ) uuid() string {

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -1411,15 +1411,15 @@ func (e *environ) terminateInstances(ids []instance.Id) error {
 		}
 	}
 
+	// We will get here only if we got a NotFound error.
+	// 1. If we attempted to terminate only one instance was, return now.
 	if len(ids) == 1 {
-		if err != nil && ec2ErrCode(err) != "InvalidInstanceID.NotFound" {
-			return err
-		}
+		ids = nil
 		return nil
 	}
-	// If we get a NotFound error, it means that no instances have been
-	// terminated even if some exist, so try them one by one, ignoring
-	// NotFound errors.
+	// 2. If we attempted to terminate several instances and got a NotFound error,
+	// it means that no instances were terminated.
+	// So try each instance individually, ignoring a NotFound error this time.
 	deletedIDs := []instance.Id{}
 	for _, id := range ids {
 		_, err = terminateInstancesById(ec2inst, id)
@@ -1431,9 +1431,9 @@ func (e *environ) terminateInstances(ids []instance.Id) error {
 			return err
 		}
 	}
-	ids = deletedIDs
-	// We will get here if we all of the instances are deleted successfully,
+	// We will get here if all of the instances are deleted successfully,
 	// or are not found, which implies they were previously deleted.
+	ids = deletedIDs
 	return nil
 }
 

--- a/provider/ec2/environ_test.go
+++ b/provider/ec2/environ_test.go
@@ -8,7 +8,6 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/constraints"
-	"github.com/juju/juju/instance"
 	"github.com/juju/juju/network"
 )
 
@@ -153,14 +152,4 @@ func (*Suite) TestPortsToIPPerms(c *gc.C) {
 		ipperms := portsToIPPerms(t.ports)
 		c.Assert(ipperms, gc.DeepEquals, t.expected)
 	}
-}
-
-func (t *Suite) TestDeleteIDsNothingToRemove(c *gc.C) {
-	all := []instance.Id{instance.Id("just-this-one")}
-
-	nilItemsRemoved := deleteIDs(all, nil)
-	c.Assert(nilItemsRemoved, gc.DeepEquals, all)
-
-	emptyItemsRemoved := deleteIDs(all, []instance.Id{})
-	c.Assert(emptyItemsRemoved, gc.DeepEquals, all)
 }

--- a/provider/ec2/environ_test.go
+++ b/provider/ec2/environ_test.go
@@ -8,6 +8,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/constraints"
+	"github.com/juju/juju/instance"
 	"github.com/juju/juju/network"
 )
 
@@ -152,4 +153,14 @@ func (*Suite) TestPortsToIPPerms(c *gc.C) {
 		ipperms := portsToIPPerms(t.ports)
 		c.Assert(ipperms, gc.DeepEquals, t.expected)
 	}
+}
+
+func (t *Suite) TestDeleteIDsNothingToRemove(c *gc.C) {
+	all := []instance.Id{instance.Id("just-this-one")}
+
+	nilItemsRemoved := deleteIDs(all, nil)
+	c.Assert(nilItemsRemoved, gc.DeepEquals, all)
+
+	emptyItemsRemoved := deleteIDs(all, []instance.Id{})
+	c.Assert(emptyItemsRemoved, gc.DeepEquals, all)
 }

--- a/provider/ec2/export_test.go
+++ b/provider/ec2/export_test.go
@@ -43,6 +43,10 @@ func InstanceEC2(inst instance.Instance) *ec2.Instance {
 	return inst.(*ec2Instance).Instance
 }
 
+func TerminatedInstances(e environs.Environ) ([]instance.Instance, error) {
+	return e.(*environ).AllInstancesByState("shutting-down", "terminated")
+}
+
 var (
 	EC2AvailabilityZones        = &ec2AvailabilityZones
 	AvailabilityZoneAllocations = &availabilityZoneAllocations
@@ -99,6 +103,7 @@ var (
 	StorageAttempt                 = &storageAttempt
 	DestroyVolumeAttempt           = &destroyVolumeAttempt
 	DeleteSecurityGroupInsistently = &deleteSecurityGroupInsistently
+	TerminateInstancesById         = &terminateInstancesById
 )
 
 func EC2ErrCode(err error) string {

--- a/provider/ec2/export_test.go
+++ b/provider/ec2/export_test.go
@@ -108,7 +108,6 @@ var (
 	DestroyVolumeAttempt           = &destroyVolumeAttempt
 	DeleteSecurityGroupInsistently = &deleteSecurityGroupInsistently
 	TerminateInstancesById         = &terminateInstancesById
-	DeleteIDs                      = &deleteIDs
 )
 
 func EC2ErrCode(err error) string {

--- a/provider/ec2/export_test.go
+++ b/provider/ec2/export_test.go
@@ -47,6 +47,10 @@ func TerminatedInstances(e environs.Environ) ([]instance.Instance, error) {
 	return e.(*environ).AllInstancesByState("shutting-down", "terminated")
 }
 
+func InstanceSecurityGroups(e environs.Environ, ids []instance.Id, states ...string) ([]ec2.SecurityGroup, error) {
+	return e.(*environ).instanceSecurityGroups(ids, states...)
+}
+
 var (
 	EC2AvailabilityZones        = &ec2AvailabilityZones
 	AvailabilityZoneAllocations = &availabilityZoneAllocations
@@ -104,6 +108,7 @@ var (
 	DestroyVolumeAttempt           = &destroyVolumeAttempt
 	DeleteSecurityGroupInsistently = &deleteSecurityGroupInsistently
 	TerminateInstancesById         = &terminateInstancesById
+	DeleteIDs                      = &deleteIDs
 )
 
 func EC2ErrCode(err error) string {

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -335,19 +335,10 @@ func (t *localServerSuite) TestTerminateInstancesIgnoresNotFound(c *gc.C) {
 	insts, err := env.AllInstances()
 	c.Assert(err, jc.ErrorIsNil)
 	idsToStop := make([]instance.Id, len(insts)+1)
-	expectedWithoutNotFound := make([]instance.Id, len(insts))
 	for i, one := range insts {
 		idsToStop[i] = one.Id()
-		expectedWithoutNotFound[i] = one.Id()
 	}
-
-	notFoundID := instance.Id("i-am-not-found")
-	idsToStop[len(insts)] = notFoundID
-	expectedNotFound := []instance.Id{instance.Id(notFoundID)}
-	t.BaseSuite.PatchValue(ec2.DeleteIDs, func(all, items []instance.Id) []instance.Id {
-		c.Assert(items, jc.SameContents, expectedNotFound)
-		return expectedWithoutNotFound
-	})
+	idsToStop[len(insts)] = instance.Id("i-am-not-found")
 
 	err = env.StopInstances(idsToStop...)
 	// NotFound should be ignored


### PR DESCRIPTION
This proposal minimizes the amount of errors we receive from ec2 when terminating instances and deleting related security groups.

Now we try to delete security groups for ec2 blindly and pessimistically: we disregard if individual instances are successfully terminated or not and try to delete everything. We also only have ability to get all active instances, i.e. pending or running.

What we want is to be able to determine which instances are being terminated or have been terminated and only attempt to delete resources for these instances.

This proposal adds ability to get environment instances by status. This gives us the ability to determine what instances have been successfully terminated, i.e. according to amazon lifecycle diagram [1], terminating and shutting down instances. Next we limit resource deletion to these instances only. Thus,  we minimize the amount of errors we get from attempts at deleting security groups. 

[1]
http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-lifecycle.html

(This was originally reviewed on http://reviews.vapour.ws/r/4489/)

(Review request: http://reviews.vapour.ws/r/4512/)