### PR TITLE
Authenticate GET requests for the /charms HTTP endpoint.

### DIFF
--- a/apiserver/charms.go
+++ b/apiserver/charms.go
@@ -72,8 +72,7 @@ func (h *charmsHandler) servePost(w http.ResponseWriter, r *http.Request) error 
 }
 
 func (h *charmsHandler) serveGet(w http.ResponseWriter, r *http.Request) error {
-	// TODO (bug #1499338 2015/09/24) authenticate this.
-	st, err := h.ctxt.stateForRequestUnauthenticated(r)
+	st, _, err := h.ctxt.stateForRequestAuthenticatedUser(r)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/apiserver/charms_test.go
+++ b/apiserver/charms_test.go
@@ -111,9 +111,9 @@ func (s *charmsSuite) TestPOSTRequiresAuth(c *gc.C) {
 	s.assertErrorResponse(c, resp, http.StatusUnauthorized, "no credentials provided")
 }
 
-func (s *charmsSuite) TestGETDoesNotRequireAuth(c *gc.C) {
+func (s *charmsSuite) TestGETRequiresAuth(c *gc.C) {
 	resp := s.sendRequest(c, httpRequestParams{method: "GET", url: s.charmsURI(c, "")})
-	s.assertErrorResponse(c, resp, http.StatusBadRequest, "expected url=CharmURL query argument")
+	s.assertErrorResponse(c, resp, http.StatusUnauthorized, "no credentials provided")
 }
 
 func (s *charmsSuite) TestRequiresPOSTorGET(c *gc.C) {


### PR DESCRIPTION
(fixes https://bugs.launchpad.net/juju-core/+bug/1499338)

Apparently we weren't checking for authorized users.  Note that none of the Juju code actually ever makes a GET call to the /charms endpoint.  Either it is a legacy hold-over or meant for external consumption.  Either way, this patch ensures that only model-authenticated users can download charms.

(Review request: http://reviews.vapour.ws/r/4515/)