### PR TITLE
Upgrade status history features to fix #1530840

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -26,6 +26,7 @@ import (
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/downloader"
 	"github.com/juju/juju/network"
+	"github.com/juju/juju/status"
 	"github.com/juju/juju/tools"
 )
 
@@ -49,18 +50,26 @@ func (c *Client) Status(patterns []string) (*params.FullStatus, error) {
 // StatusHistory retrieves the last <size> results of
 // <kind:combined|agent|workload|machine|machineinstance|container|containerinstance> status
 // for <name> unit
-func (c *Client) StatusHistory(kind params.HistoryKind, name string, size int) (*params.StatusHistoryResults, error) {
+func (c *Client) StatusHistory(kind status.HistoryKind, name string, filter status.StatusHistoryFilter) (*params.StatusHistoryResult, error) {
 	var results params.StatusHistoryResults
-	args := params.StatusHistoryArgs{
-		Kind: kind,
-		Size: size,
+	args := params.StatusHistoryRequest{
+		Kind: string(kind),
+		Filter: params.StatusHistoryFilter{
+			Size:  filter.Size,
+			Date:  filter.Date,
+			Delta: filter.Delta,
+		},
 		Name: name,
 	}
-	err := c.facade.FacadeCall("StatusHistory", args, &results)
+	bulkArgs := params.StatusHistoryRequests{Requests: []params.StatusHistoryRequest{args}}
+	err := c.facade.FacadeCall("StatusHistory", bulkArgs, &results)
 	if err != nil {
-		return &params.StatusHistoryResults{}, errors.Trace(err)
+		return &params.StatusHistoryResult{}, errors.Trace(err)
 	}
-	return &results, nil
+	if len(results.Results) != 1 {
+		return &params.StatusHistoryResult{}, errors.Errorf("expected 1 result got %d", len(results.Results))
+	}
+	return &results.Results[0], nil
 }
 
 // Resolved clears errors on a unit.

--- a/api/client.go
+++ b/api/client.go
@@ -50,7 +50,7 @@ func (c *Client) Status(patterns []string) (*params.FullStatus, error) {
 // StatusHistory retrieves the last <size> results of
 // <kind:combined|agent|workload|machine|machineinstance|container|containerinstance> status
 // for <name> unit
-func (c *Client) StatusHistory(kind status.HistoryKind, name string, filter status.StatusHistoryFilter) (*params.StatusHistoryResult, error) {
+func (c *Client) StatusHistory(kind status.HistoryKind, tag names.Tag, filter status.StatusHistoryFilter) (status.History, error) {
 	var results params.StatusHistoryResults
 	args := params.StatusHistoryRequest{
 		Kind: string(kind),
@@ -59,17 +59,41 @@ func (c *Client) StatusHistory(kind status.HistoryKind, name string, filter stat
 			Date:  filter.Date,
 			Delta: filter.Delta,
 		},
-		Name: name,
+		Tag: tag,
 	}
 	bulkArgs := params.StatusHistoryRequests{Requests: []params.StatusHistoryRequest{args}}
 	err := c.facade.FacadeCall("StatusHistory", bulkArgs, &results)
 	if err != nil {
-		return &params.StatusHistoryResult{}, errors.Trace(err)
+		return status.History{}, errors.Trace(err)
 	}
 	if len(results.Results) != 1 {
-		return &params.StatusHistoryResult{}, errors.Errorf("expected 1 result got %d", len(results.Results))
+		return status.History{}, errors.Errorf("expected 1 result got %d", len(results.Results))
 	}
-	return &results.Results[0], nil
+	if results.Results[0].Error != nil {
+		return status.History{}, errors.Annotatef(results.Results[0].Error, "while processing the request")
+	}
+	history := make(status.History, len(results.Results[0].History.Statuses))
+	if results.Results[0].History.Error != nil {
+		return status.History{}, results.Results[0].History.Error
+	}
+	for i, h := range results.Results[0].History.Statuses {
+		history[i] = status.DetailedStatus{
+			Status:  status.Status(h.Status),
+			Info:    h.Info,
+			Data:    h.Data,
+			Since:   h.Since,
+			Kind:    status.HistoryKind(h.Kind),
+			Version: h.Version,
+			// TODO(perrito666) make sure these are still used.
+			Life: h.Life,
+			Err:  h.Err,
+		}
+		// TODO(perrito666) https://launchpad.net/bugs/1577589
+		if !history[i].Kind.Valid() {
+			logger.Warningf("history returned an unknown status kind %q", h.Kind)
+		}
+	}
+	return history, nil
 }
 
 // Resolved clears errors on a unit.

--- a/api/instancepoller/machine.go
+++ b/api/instancepoller/machine.go
@@ -142,7 +142,7 @@ func (m *Machine) InstanceStatus() (params.StatusResult, error) {
 func (m *Machine) SetInstanceStatus(status status.Status, message string, data map[string]interface{}) error {
 	var result params.ErrorResults
 	args := params.SetStatus{Entities: []params.EntityStatusArgs{
-		{Tag: m.tag.String(), Status: status, Info: message, Data: data},
+		{Tag: m.tag.String(), Status: status.String(), Info: message, Data: data},
 	}}
 	err := m.facade.FacadeCall("SetInstanceStatus", args, &result)
 	if err != nil {

--- a/api/instancepoller/machine_test.go
+++ b/api/instancepoller/machine_test.go
@@ -208,14 +208,14 @@ func (s *MachineSuite) TestInstanceStatusSuccess(c *gc.C) {
 	var called int
 	results := params.StatusResults{
 		Results: []params.StatusResult{{
-			Status: status.StatusProvisioning,
+			Status: status.StatusProvisioning.String(),
 		}},
 	}
 	apiCaller := successAPICaller(c, "InstanceStatus", entitiesArgs, results, &called)
 	machine := instancepoller.NewMachine(apiCaller, s.tag, params.Alive)
 	statusResult, err := machine.InstanceStatus()
 	c.Check(err, jc.ErrorIsNil)
-	c.Check(statusResult.Status, gc.DeepEquals, status.StatusProvisioning)
+	c.Check(statusResult.Status, gc.DeepEquals, status.StatusProvisioning.String())
 	c.Check(called, gc.Equals, 1)
 }
 

--- a/api/machiner/machine.go
+++ b/api/machiner/machine.go
@@ -46,7 +46,7 @@ func (m *Machine) SetStatus(status status.Status, info string, data map[string]i
 	var result params.ErrorResults
 	args := params.SetStatus{
 		Entities: []params.EntityStatusArgs{
-			{Tag: m.tag.String(), Status: status, Info: info, Data: data},
+			{Tag: m.tag.String(), Status: status.String(), Info: info, Data: data},
 		},
 	}
 	err := m.st.facade.FacadeCall("SetStatus", args, &result)

--- a/api/provisioner/machine.go
+++ b/api/provisioner/machine.go
@@ -100,7 +100,8 @@ func (m *Machine) InstanceStatus() (status.Status, string, error) {
 	if result.Error != nil {
 		return "", "", result.Error
 	}
-	return result.Status, result.Info, nil
+	// TODO(perrito666) add status validation.
+	return status.Status(result.Status), result.Info, nil
 }
 
 // SetStatus sets the status of the machine.
@@ -135,7 +136,8 @@ func (m *Machine) Status() (status.Status, string, error) {
 	if result.Error != nil {
 		return "", "", result.Error
 	}
-	return result.Status, result.Info, nil
+	// TODO(perrito666) add status validation.
+	return status.Status(result.Status), result.Info, nil
 }
 
 // EnsureDead sets the machine lifecycle to Dead if it is Alive or

--- a/api/provisioner/machine.go
+++ b/api/provisioner/machine.go
@@ -74,7 +74,7 @@ func (m *Machine) ProvisioningInfo() (*params.ProvisioningInfo, error) {
 func (m *Machine) SetInstanceStatus(status status.Status, message string, data map[string]interface{}) error {
 	var result params.ErrorResults
 	args := params.SetStatus{Entities: []params.EntityStatusArgs{
-		{Tag: m.tag.String(), Status: status, Info: message, Data: data},
+		{Tag: m.tag.String(), Status: status.String(), Info: message, Data: data},
 	}}
 	err := m.st.facade.FacadeCall("SetInstanceStatus", args, &result)
 	if err != nil {
@@ -109,7 +109,7 @@ func (m *Machine) SetStatus(status status.Status, info string, data map[string]i
 	var result params.ErrorResults
 	args := params.SetStatus{
 		Entities: []params.EntityStatusArgs{
-			{Tag: m.tag.String(), Status: status, Info: info, Data: data},
+			{Tag: m.tag.String(), Status: status.String(), Info: info, Data: data},
 		},
 	}
 	err := m.st.facade.FacadeCall("SetStatus", args, &result)

--- a/api/provisioner/provisioner_test.go
+++ b/api/provisioner/provisioner_test.go
@@ -10,6 +10,7 @@ package provisioner_test
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/juju/errors"
 	"github.com/juju/names"
@@ -175,7 +176,14 @@ func (s *provisionerSuite) TestGetSetStatusWithData(c *gc.C) {
 func (s *provisionerSuite) TestMachinesWithTransientErrors(c *gc.C) {
 	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
-	err = machine.SetStatus(status.StatusError, "blah", map[string]interface{}{"transient": true})
+	now := time.Now()
+	sInfo := status.StatusInfo{
+		Status:  status.StatusError,
+		Message: "blah",
+		Data:    map[string]interface{}{"transient": true},
+		Since:   &now,
+	}
+	err = machine.SetStatus(sInfo)
 	c.Assert(err, jc.ErrorIsNil)
 	machines, info, err := s.provisioner.MachinesWithTransientErrors()
 	c.Assert(err, jc.ErrorIsNil)

--- a/api/statushistory/pruner.go
+++ b/api/statushistory/pruner.go
@@ -4,6 +4,8 @@
 package statushistory
 
 import (
+	"time"
+
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/apiserver/params"
 )
@@ -22,9 +24,10 @@ func NewFacade(caller base.APICaller) *Facade {
 }
 
 // Prune calls "StatusHistory.Prune"
-func (s *Facade) Prune(maxLogsPerEntity int) error {
+func (s *Facade) Prune(maxHistoryTime time.Duration, maxHistoryMB int) error {
 	p := params.StatusHistoryPruneArgs{
-		MaxLogsPerEntity: maxLogsPerEntity,
+		MaxHistoryTime: maxHistoryTime,
+		MaxHistoryMB:   maxHistoryMB,
 	}
 	return s.facade.FacadeCall("Prune", p, nil)
 }

--- a/api/undertaker/undertaker.go
+++ b/api/undertaker/undertaker.go
@@ -58,7 +58,7 @@ func (c *Client) RemoveModel() error {
 func (c *Client) SetStatus(status status.Status, message string, data map[string]interface{}) error {
 	args := params.SetStatus{
 		Entities: []params.EntityStatusArgs{
-			{c.modelTag.String(), status, message, data},
+			{c.modelTag.String(), status.String(), message, data},
 		},
 	}
 	var results params.ErrorResults

--- a/api/uniter/service.go
+++ b/api/uniter/service.go
@@ -174,7 +174,7 @@ func (s *Service) SetStatus(unitName string, serviceStatus status.Status, info s
 		Entities: []params.EntityStatusArgs{
 			{
 				Tag:    tag.String(),
-				Status: serviceStatus,
+				Status: serviceStatus.String(),
 				Info:   info,
 				Data:   data,
 			},

--- a/api/uniter/service_test.go
+++ b/api/uniter/service_test.go
@@ -156,7 +156,14 @@ func (s *serviceSuite) TestServiceStatus(c *gc.C) {
 	c.Assert(stat.Status, gc.Not(gc.Equals), status.StatusActive)
 	c.Assert(stat.Message, gc.Not(gc.Equals), message)
 
-	err = s.wordpressService.SetStatus(status.StatusActive, message, map[string]interface{}{})
+	now := time.Now()
+	sInfo := status.StatusInfo{
+		Status:  status.StatusActive,
+		Message: message,
+		Data:    map[string]interface{}{},
+		Since:   &now,
+	}
+	err = s.wordpressService.SetStatus(sInfo)
 	c.Check(err, jc.ErrorIsNil)
 
 	stat, err = s.wordpressService.Status()

--- a/api/uniter/service_test.go
+++ b/api/uniter/service_test.go
@@ -170,7 +170,7 @@ func (s *serviceSuite) TestServiceStatus(c *gc.C) {
 	s.claimLeadership(c, s.wordpressUnit, s.wordpressService)
 	result, err = s.apiService.Status(s.wordpressUnit.Name())
 	c.Check(err, jc.ErrorIsNil)
-	c.Check(result.Service.Status, gc.Equals, status.StatusActive)
+	c.Check(result.Service.Status, gc.Equals, status.StatusActive.String())
 }
 
 func (s *serviceSuite) claimLeadership(c *gc.C, unit *state.Unit, service *state.Service) {

--- a/api/uniter/unit.go
+++ b/api/uniter/unit.go
@@ -62,7 +62,7 @@ func (u *Unit) SetUnitStatus(unitStatus status.Status, info string, data map[str
 	var result params.ErrorResults
 	args := params.SetStatus{
 		Entities: []params.EntityStatusArgs{
-			{Tag: u.tag.String(), Status: unitStatus, Info: info, Data: data},
+			{Tag: u.tag.String(), Status: unitStatus.String(), Info: info, Data: data},
 		},
 	}
 	err := u.st.facade.FacadeCall("SetUnitStatus", args, &result)
@@ -99,7 +99,7 @@ func (u *Unit) SetAgentStatus(agentStatus status.Status, info string, data map[s
 	var result params.ErrorResults
 	args := params.SetStatus{
 		Entities: []params.EntityStatusArgs{
-			{Tag: u.tag.String(), Status: agentStatus, Info: info, Data: data},
+			{Tag: u.tag.String(), Status: agentStatus.String(), Info: info, Data: data},
 		},
 	}
 	setStatusFacadeCall := "SetAgentStatus"

--- a/api/uniter/unit_test.go
+++ b/api/uniter/unit_test.go
@@ -123,7 +123,13 @@ func (s *unitSuite) TestSetUnitStatus(c *gc.C) {
 }
 
 func (s *unitSuite) TestUnitStatus(c *gc.C) {
-	err := s.wordpressUnit.SetStatus(status.StatusMaintenance, "blah", nil)
+	now := time.Now()
+	sInfo := status.StatusInfo{
+		Status:  status.StatusMaintenance,
+		Message: "blah",
+		Since:   &now,
+	}
+	err := s.wordpressUnit.SetStatus(sInfo)
 	c.Assert(err, jc.ErrorIsNil)
 
 	result, err := s.apiUnit.UnitStatus()

--- a/api/uniter/unit_test.go
+++ b/api/uniter/unit_test.go
@@ -131,7 +131,7 @@ func (s *unitSuite) TestUnitStatus(c *gc.C) {
 	c.Assert(result.Since, gc.NotNil)
 	result.Since = nil
 	c.Assert(result, gc.DeepEquals, params.StatusResult{
-		Status: status.StatusMaintenance,
+		Status: status.StatusMaintenance.String(),
 		Info:   "blah",
 		Data:   map[string]interface{}{},
 	})

--- a/apiserver/authentication/user.go
+++ b/apiserver/authentication/user.go
@@ -76,6 +76,7 @@ func (u *UserAuthenticator) Authenticate(
 // for invalid users.
 func (u *UserAuthenticator) CreateLocalLoginMacaroon(tag names.UserTag) (*macaroon.Macaroon, error) {
 
+	// TODO(perrito666) 2016-05-02 lp:1558657
 	expiryTime := u.Clock.Now().Add(localLoginExpiryTime)
 
 	// Ensure that the private key that we generate and store will be

--- a/apiserver/client/api_test.go
+++ b/apiserver/client/api_test.go
@@ -164,7 +164,7 @@ var scenarioStatus = &params.FullStatus{
 				Data:   make(map[string]interface{}),
 			},
 			InstanceStatus: params.DetailedStatus{
-				Status: status.StatusPending,
+				Status: status.StatusPending.String(),
 				Data:   make(map[string]interface{}),
 			},
 			Series:     "quantal",
@@ -181,7 +181,7 @@ var scenarioStatus = &params.FullStatus{
 				Data:   make(map[string]interface{}),
 			},
 			InstanceStatus: params.DetailedStatus{
-				Status: status.StatusPending,
+				Status: status.StatusPending.String(),
 				Data:   make(map[string]interface{}),
 			},
 			Series:     "quantal",
@@ -198,7 +198,7 @@ var scenarioStatus = &params.FullStatus{
 				Data:   make(map[string]interface{}),
 			},
 			InstanceStatus: params.DetailedStatus{
-				Status: status.StatusPending,
+				Status: status.StatusPending.String(),
 				Data:   make(map[string]interface{}),
 			},
 			Series:     "quantal",

--- a/apiserver/client/api_test.go
+++ b/apiserver/client/api_test.go
@@ -108,11 +108,17 @@ func defaultPassword(e apiAuthenticator) string {
 }
 
 type setStatuser interface {
-	SetStatus(statuSettable status.Status, info string, data map[string]interface{}) error
+	SetStatus(status.StatusInfo) error
 }
 
 func setDefaultStatus(c *gc.C, entity setStatuser) {
-	err := entity.SetStatus(status.StatusStarted, "", nil)
+	now := time.Now()
+	s := status.StatusInfo{
+		Status:  status.StatusStarted,
+		Message: "",
+		Since:   &now,
+	}
+	err := entity.SetStatus(s)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -431,7 +437,14 @@ func (s *baseSuite) setUpScenario(c *gc.C) (entities []names.Tag) {
 				"remote-unit": "logging/0",
 				"foo":         "bar",
 			}
-			err := wu.SetAgentStatus(status.StatusError, "blam", sd)
+			now := time.Now()
+			sInfo := status.StatusInfo{
+				Status:  status.StatusError,
+				Message: "blam",
+				Data:    sd,
+				Since:   &now,
+			}
+			err := wu.SetAgentStatus(sInfo)
 			c.Assert(err, jc.ErrorIsNil)
 		}
 

--- a/apiserver/client/client_test.go
+++ b/apiserver/client/client_test.go
@@ -517,7 +517,13 @@ func (s *clientSuite) testClientUnitResolved(c *gc.C, retry bool, expectedResolv
 	s.setUpScenario(c)
 	u, err := s.State.Unit("wordpress/0")
 	c.Assert(err, jc.ErrorIsNil)
-	err = u.SetAgentStatus(status.StatusError, "gaaah", nil)
+	now := time.Now()
+	sInfo := status.StatusInfo{
+		Status:  status.StatusError,
+		Message: "gaaah",
+		Since:   &now,
+	}
+	err = u.SetAgentStatus(sInfo)
 	c.Assert(err, jc.ErrorIsNil)
 	// Code under test:
 	err = s.APIState.Client().Resolved("wordpress/0", retry)
@@ -543,7 +549,13 @@ func (s *clientSuite) setupResolved(c *gc.C) *state.Unit {
 	s.setUpScenario(c)
 	u, err := s.State.Unit("wordpress/0")
 	c.Assert(err, jc.ErrorIsNil)
-	err = u.SetAgentStatus(status.StatusError, "gaaah", nil)
+	now := time.Now()
+	sInfo := status.StatusInfo{
+		Status:  status.StatusError,
+		Message: "gaaah",
+		Since:   &now,
+	}
+	err = u.SetAgentStatus(sInfo)
 	c.Assert(err, jc.ErrorIsNil)
 	return u
 }
@@ -1399,7 +1411,13 @@ func (s *clientRepoSuite) TestResolveCharm(c *gc.C) {
 func (s *clientSuite) TestRetryProvisioning(c *gc.C) {
 	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
-	err = machine.SetStatus(status.StatusError, "error", nil)
+	now := time.Now()
+	sInfo := status.StatusInfo{
+		Status:  status.StatusError,
+		Message: "error",
+		Since:   &now,
+	}
+	err = machine.SetStatus(sInfo)
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = s.APIState.Client().RetryProvisioning(machine.Tag().(names.MachineTag))
 	c.Assert(err, jc.ErrorIsNil)
@@ -1414,7 +1432,13 @@ func (s *clientSuite) TestRetryProvisioning(c *gc.C) {
 func (s *clientSuite) setupRetryProvisioning(c *gc.C) *state.Machine {
 	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
-	err = machine.SetStatus(status.StatusError, "error", nil)
+	now := time.Now()
+	sInfo := status.StatusInfo{
+		Status:  status.StatusError,
+		Message: "error",
+		Since:   &now,
+	}
+	err = machine.SetStatus(sInfo)
 	c.Assert(err, jc.ErrorIsNil)
 	return machine
 }

--- a/apiserver/client/status.go
+++ b/apiserver/client/status.go
@@ -13,6 +13,7 @@ import (
 	"gopkg.in/juju/charm.v6-unstable"
 	"gopkg.in/juju/charm.v6-unstable/hooks"
 
+	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
@@ -21,86 +22,78 @@ import (
 	"github.com/juju/juju/worker/uniter/operation"
 )
 
-func agentStatusFromStatusInfo(s []status.StatusInfo, kind params.HistoryKind) []params.DetailedStatus {
+func agentStatusFromStatusInfo(s []status.StatusInfo, kind status.HistoryKind) []params.DetailedStatus {
 	result := []params.DetailedStatus{}
 	for _, v := range s {
 		result = append(result, params.DetailedStatus{
-			Status: v.Status,
+			Status: string(v.Status),
 			Info:   v.Message,
 			Data:   v.Data,
 			Since:  v.Since,
-			Kind:   kind,
+			Kind:   string(kind),
 		})
 	}
 	return result
 
 }
 
-type sortableStatuses []params.DetailedStatus
+type byTime []params.DetailedStatus
 
-func (s sortableStatuses) Len() int {
+func (s byTime) Len() int {
 	return len(s)
 }
-func (s sortableStatuses) Swap(i, j int) {
+func (s byTime) Swap(i, j int) {
 	s[i], s[j] = s[j], s[i]
 }
-func (s sortableStatuses) Less(i, j int) bool {
+func (s byTime) Less(i, j int) bool {
 	return s[i].Since.Before(*s[j].Since)
 }
 
 // unitStatusHistory returns a list of status history entries for unit agents or workloads.
-func (c *Client) unitStatusHistory(unitName string, size int, kind params.HistoryKind) ([]params.DetailedStatus, error) {
+func (c *Client) unitStatusHistory(unitName string, filter status.StatusHistoryFilter, kind status.HistoryKind) ([]params.DetailedStatus, error) {
 	unit, err := c.api.stateAccessor.Unit(unitName)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 	statuses := []params.DetailedStatus{}
-	if kind == params.KindUnit || kind == params.KindWorkload {
-		unitStatuses, err := unit.StatusHistory(size)
+	if kind == status.KindUnit || kind == status.KindWorkload {
+		unitStatuses, err := unit.StatusHistory(filter)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		statuses = agentStatusFromStatusInfo(unitStatuses, params.KindWorkload)
+		statuses = agentStatusFromStatusInfo(unitStatuses, status.KindWorkload)
 
 	}
-	if kind == params.KindUnit || kind == params.KindUnitAgent {
-		agentStatuses, err := unit.AgentHistory().StatusHistory(size)
+	if kind == status.KindUnit || kind == status.KindUnitAgent {
+		agentStatuses, err := unit.AgentHistory().StatusHistory(filter)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		statuses = append(statuses, agentStatusFromStatusInfo(agentStatuses, params.KindUnitAgent)...)
+		statuses = append(statuses, agentStatusFromStatusInfo(agentStatuses, status.KindUnitAgent)...)
 	}
 
-	sort.Sort(sortableStatuses(statuses))
-	if kind == params.KindUnit {
-		if len(statuses) > size {
-			statuses = statuses[len(statuses)-size:]
+	sort.Sort(byTime(statuses))
+	if kind == status.KindUnit && filter.Size > 0 {
+		if len(statuses) > filter.Size {
+			statuses = statuses[len(statuses)-filter.Size:]
 		}
 	}
 
 	return statuses, nil
 }
 
-// machineInstanceStatusHistory returns status history for the instance of a given machine.
-func (c *Client) machineInstanceStatusHistory(machineName string, size int, kind params.HistoryKind) ([]params.DetailedStatus, error) {
-	machine, err := c.api.stateAccessor.Machine(machineName)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	sInfo, err := machine.InstanceStatusHistory(size)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	return agentStatusFromStatusInfo(sInfo, kind), nil
-}
-
 // machineStatusHistory returns status history for the given machine.
-func (c *Client) machineStatusHistory(machineName string, size int, kind params.HistoryKind) ([]params.DetailedStatus, error) {
+func (c *Client) machineStatusHistory(machineName string, filter status.StatusHistoryFilter, kind status.HistoryKind) ([]params.DetailedStatus, error) {
 	machine, err := c.api.stateAccessor.Machine(machineName)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	sInfo, err := machine.StatusHistory(size)
+	var sInfo []status.StatusInfo
+	if kind == status.KindMachineInstance || kind == status.KindContainerInstance {
+		sInfo, err = machine.InstanceStatusHistory(filter)
+	} else {
+		sInfo, err = machine.StatusHistory(filter)
+	}
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -108,47 +101,44 @@ func (c *Client) machineStatusHistory(machineName string, size int, kind params.
 }
 
 // StatusHistory returns a slice of past statuses for several entities.
-func (c *Client) StatusHistory(args params.StatusHistoryArgs) (params.StatusHistoryResults, error) {
-	if args.Size < 1 {
-		return params.StatusHistoryResults{}, errors.Errorf("invalid history size: %d", args.Size)
+func (c *Client) StatusHistory(request params.StatusHistoryRequests) params.StatusHistoryResults {
+	results := params.StatusHistoryResults{}
+	for _, request := range request.Requests {
+		filter := status.StatusHistoryFilter{
+			Size:  request.Filter.Size,
+			Date:  request.Filter.Date,
+			Delta: request.Filter.Delta,
+		}
+		if err := filter.Validate(); err != nil {
+			history := params.StatusHistoryResult{
+				Error: common.ServerError(errors.Annotate(err, "validating status history request filtering options")),
+			}
+			results.Results = append(results.Results, history)
+			continue
+		}
+
+		var (
+			err  error
+			hist []params.DetailedStatus
+		)
+		kind := status.HistoryKind(request.Kind)
+		if kind == status.KindUnit || kind == status.KindWorkload || kind == status.KindUnitAgent {
+			hist, err = c.unitStatusHistory(request.Name, filter, kind)
+		} else {
+			hist, err = c.machineStatusHistory(request.Name, filter, kind)
+		}
+
+		if err == nil {
+			sort.Sort(byTime(hist))
+		}
+
+		results.Results = append(results.Results,
+			params.StatusHistoryResult{
+				History: params.History{Statuses: hist},
+				Error:   common.ServerError(errors.Annotatef(err, "fetching unit status history for %q", request.Name)),
+			})
 	}
-	history := params.StatusHistoryResults{}
-	statuses := []params.DetailedStatus{}
-	var err error
-	switch args.Kind {
-	case params.KindUnit, params.KindWorkload, params.KindUnitAgent:
-		statuses, err = c.unitStatusHistory(args.Name, args.Size, args.Kind)
-		if err != nil {
-			return params.StatusHistoryResults{}, errors.Annotatef(err, "fetching unit status history for %q", args.Name)
-		}
-	case params.KindMachineInstance:
-		mIStatuses, err := c.machineInstanceStatusHistory(args.Name, args.Size, params.KindMachineInstance)
-		if err != nil {
-			return params.StatusHistoryResults{}, errors.Annotate(err, "fetching machine instance status history")
-		}
-		statuses = mIStatuses
-	case params.KindMachine:
-		mStatuses, err := c.machineStatusHistory(args.Name, args.Size, params.KindMachine)
-		if err != nil {
-			return params.StatusHistoryResults{}, errors.Annotate(err, "fetching juju agent status history for machine")
-		}
-		statuses = mStatuses
-	case params.KindContainerInstance:
-		cIStatuses, err := c.machineStatusHistory(args.Name, args.Size, params.KindContainerInstance)
-		if err != nil {
-			return params.StatusHistoryResults{}, errors.Annotate(err, "fetching container status history")
-		}
-		statuses = cIStatuses
-	case params.KindContainer:
-		cStatuses, err := c.machineStatusHistory(args.Name, args.Size, params.KindContainer)
-		if err != nil {
-			return params.StatusHistoryResults{}, errors.Annotate(err, "fetching juju agent status history for container")
-		}
-		statuses = cStatuses
-	}
-	history.Statuses = statuses
-	sort.Sort(sortableStatuses(history.Statuses))
-	return history, nil
+	return results
 }
 
 // FullStatus gives the information needed for juju status over the api
@@ -591,7 +581,7 @@ func (context *statusContext) processService(service *state.Service) params.Serv
 			processedStatus.Err = err
 			return processedStatus
 		}
-		processedStatus.Status.Status = serviceStatus.Status
+		processedStatus.Status.Status = serviceStatus.Status.String()
 		processedStatus.Status.Info = serviceStatus.Message
 		processedStatus.Status.Data = serviceStatus.Data
 		processedStatus.Status.Since = serviceStatus.Since
@@ -719,7 +709,7 @@ func populateStatusFromGetter(agent *params.DetailedStatus, getter status.Status
 // of a status getter.
 func populateStatusFromStatusInfoAndErr(agent *params.DetailedStatus, statusInfo status.StatusInfo, err error) {
 	agent.Err = err
-	agent.Status = statusInfo.Status
+	agent.Status = statusInfo.Status.String()
 	agent.Info = statusInfo.Message
 	agent.Data = filterStatusData(statusInfo.Data)
 	agent.Since = statusInfo.Since
@@ -739,7 +729,9 @@ func processMachine(machine *state.Machine) (out params.DetailedStatus) {
 	if out.Err != nil {
 		return
 	}
-	if out.Status == status.StatusPending || out.Status == status.StatusAllocating {
+	// TODO(perrito666) add status validation.
+	outSt := status.Status(out.Status)
+	if outSt == status.StatusPending || outSt == status.StatusAllocating {
 		// The status is pending - there's no point
 		// in enquiring about the agent liveness.
 		return
@@ -764,7 +756,8 @@ func processUnitStatus(unit *state.Unit) (agentStatus, workloadStatus params.Det
 }
 
 func canBeLost(unitStatus *params.UnitStatus) bool {
-	switch unitStatus.AgentStatus.Status {
+	// TODO(perrito666) add status validation.
+	switch status.Status(unitStatus.AgentStatus.Status) {
 	case status.StatusAllocating:
 		return false
 	case status.StatusExecuting:
@@ -773,7 +766,9 @@ func canBeLost(unitStatus *params.UnitStatus) bool {
 	// TODO(fwereade/wallyworld): we should have an explicit place in the model
 	// to tell us when we've hit this point, instead of piggybacking on top of
 	// status and/or status history.
-	isInstalled := unitStatus.WorkloadStatus.Status != status.StatusMaintenance || unitStatus.WorkloadStatus.Info != status.MessageInstalling
+	// TODO(perrito666) add status validation.
+	wlStatus := status.Status(unitStatus.WorkloadStatus.Status)
+	isInstalled := wlStatus != status.StatusMaintenance || unitStatus.WorkloadStatus.Info != status.MessageInstalling
 	return isInstalled
 }
 
@@ -795,11 +790,14 @@ func processUnitLost(unit *state.Unit, unitStatus *params.UnitStatus) {
 		// If the unit is in error, it would be bad to throw away
 		// the error information as when the agent reconnects, that
 		// error information would then be lost.
-		if unitStatus.WorkloadStatus.Status != status.StatusError {
-			unitStatus.WorkloadStatus.Status = status.StatusUnknown
+		// TODO(perrito666) add status validation.
+		wlStatus := status.Status(unitStatus.WorkloadStatus.Status)
+
+		if wlStatus != status.StatusError {
+			unitStatus.WorkloadStatus.Status = status.StatusUnknown.String()
 			unitStatus.WorkloadStatus.Info = fmt.Sprintf("agent is lost, sorry! See 'juju status-history %s'", unit.Name())
 		}
-		unitStatus.AgentStatus.Status = status.StatusLost
+		unitStatus.AgentStatus.Status = status.StatusLost.String()
 		unitStatus.AgentStatus.Info = "agent is not communicating with the server"
 	}
 }

--- a/apiserver/common/getstatus.go
+++ b/apiserver/common/getstatus.go
@@ -49,7 +49,7 @@ func (s *StatusGetter) getEntityStatus(tag names.Tag) params.StatusResult {
 	switch getter := entity.(type) {
 	case status.StatusGetter:
 		statusInfo, err := getter.Status()
-		result.Status = statusInfo.Status
+		result.Status = statusInfo.Status.String()
 		result.Info = statusInfo.Message
 		result.Data = statusInfo.Data
 		result.Since = statusInfo.Since
@@ -171,7 +171,7 @@ func (s *ServiceStatusGetter) Status(args params.Entities) (params.ServiceStatus
 			result.Results[i].Error = ServerError(err)
 			continue
 		}
-		result.Results[i].Service.Status = serviceStatus.Status
+		result.Results[i].Service.Status = serviceStatus.Status.String()
 		result.Results[i].Service.Info = serviceStatus.Message
 		result.Results[i].Service.Data = serviceStatus.Data
 		result.Results[i].Service.Since = serviceStatus.Since
@@ -179,7 +179,7 @@ func (s *ServiceStatusGetter) Status(args params.Entities) (params.ServiceStatus
 		result.Results[i].Units = make(map[string]params.StatusResult, len(unitStatuses))
 		for uTag, r := range unitStatuses {
 			ur := params.StatusResult{
-				Status: r.Status,
+				Status: r.Status.String(),
 				Info:   r.Message,
 				Data:   r.Data,
 				Since:  r.Since,
@@ -191,11 +191,11 @@ func (s *ServiceStatusGetter) Status(args params.Entities) (params.ServiceStatus
 }
 
 // EntityStatusFromState converts a state.StatusInfo into a params.EntityStatus.
-func EntityStatusFromState(status status.StatusInfo) params.EntityStatus {
+func EntityStatusFromState(statusInfo status.StatusInfo) params.EntityStatus {
 	return params.EntityStatus{
-		status.Status,
-		status.Message,
-		status.Data,
-		status.Since,
+		statusInfo.Status,
+		statusInfo.Message,
+		statusInfo.Data,
+		statusInfo.Since,
 	}
 }

--- a/apiserver/common/getstatus.go
+++ b/apiserver/common/getstatus.go
@@ -193,9 +193,9 @@ func (s *ServiceStatusGetter) Status(args params.Entities) (params.ServiceStatus
 // EntityStatusFromState converts a state.StatusInfo into a params.EntityStatus.
 func EntityStatusFromState(statusInfo status.StatusInfo) params.EntityStatus {
 	return params.EntityStatus{
-		statusInfo.Status,
-		statusInfo.Message,
-		statusInfo.Data,
-		statusInfo.Since,
+		Status: statusInfo.Status,
+		Info:   statusInfo.Message,
+		Data:   statusInfo.Data,
+		Since:  statusInfo.Since,
 	}
 }

--- a/apiserver/common/getstatus_test.go
+++ b/apiserver/common/getstatus_test.go
@@ -70,7 +70,7 @@ func (s *statusGetterSuite) TestGetMachineStatus(c *gc.C) {
 	c.Assert(result.Results, gc.HasLen, 1)
 	machineStatus := result.Results[0]
 	c.Assert(machineStatus.Error, gc.IsNil)
-	c.Assert(machineStatus.Status, gc.Equals, status.StatusPending)
+	c.Assert(machineStatus.Status, gc.Equals, status.StatusPending.String())
 }
 
 func (s *statusGetterSuite) TestGetUnitStatus(c *gc.C) {
@@ -87,7 +87,7 @@ func (s *statusGetterSuite) TestGetUnitStatus(c *gc.C) {
 	c.Assert(result.Results, gc.HasLen, 1)
 	unitStatus := result.Results[0]
 	c.Assert(unitStatus.Error, gc.IsNil)
-	c.Assert(unitStatus.Status, gc.Equals, status.StatusMaintenance)
+	c.Assert(unitStatus.Status, gc.Equals, status.StatusMaintenance.String())
 }
 
 func (s *statusGetterSuite) TestGetServiceStatus(c *gc.C) {
@@ -101,7 +101,7 @@ func (s *statusGetterSuite) TestGetServiceStatus(c *gc.C) {
 	c.Assert(result.Results, gc.HasLen, 1)
 	serviceStatus := result.Results[0]
 	c.Assert(serviceStatus.Error, gc.IsNil)
-	c.Assert(serviceStatus.Status, gc.Equals, status.StatusMaintenance)
+	c.Assert(serviceStatus.Status, gc.Equals, status.StatusMaintenance.String())
 }
 
 func (s *statusGetterSuite) TestBulk(c *gc.C) {
@@ -118,7 +118,7 @@ func (s *statusGetterSuite) TestBulk(c *gc.C) {
 	c.Assert(result.Results, gc.HasLen, 3)
 	c.Assert(result.Results[0].Error, jc.Satisfies, params.IsCodeUnauthorized)
 	c.Assert(result.Results[1].Error, gc.IsNil)
-	c.Assert(result.Results[1].Status, gc.Equals, status.StatusPending)
+	c.Assert(result.Results[1].Status, gc.Equals, status.StatusPending.String())
 	c.Assert(result.Results[2].Error, gc.ErrorMatches, `"bad-tag" is not a valid tag`)
 }
 
@@ -224,13 +224,13 @@ func (s *serviceStatusGetterSuite) TestGetUnitStatusIsLeader(c *gc.C) {
 	r := result.Results[0]
 	c.Assert(r.Error, gc.IsNil)
 	c.Assert(r.Service.Error, gc.IsNil)
-	c.Assert(r.Service.Status, gc.Equals, status.StatusMaintenance)
+	c.Assert(r.Service.Status, gc.Equals, status.StatusMaintenance.String())
 	units := r.Units
 	c.Assert(units, gc.HasLen, 1)
 	unitStatus, ok := units[unit.Name()]
 	c.Assert(ok, jc.IsTrue)
 	c.Assert(unitStatus.Error, gc.IsNil)
-	c.Assert(unitStatus.Status, gc.Equals, status.StatusMaintenance)
+	c.Assert(unitStatus.Status, gc.Equals, status.StatusMaintenance.String())
 }
 
 func (s *serviceStatusGetterSuite) TestBulk(c *gc.C) {

--- a/apiserver/common/setstatus.go
+++ b/apiserver/common/setstatus.go
@@ -5,6 +5,7 @@ package common
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/juju/errors"
 	"github.com/juju/names"
@@ -100,8 +101,15 @@ func (s *ServiceStatusSetter) SetStatus(args params.SetStatus) (params.ErrorResu
 			result.Results[i].Error = ServerError(err)
 			continue
 		}
-
-		if err := service.SetStatus(status.Status(arg.Status), arg.Info, arg.Data); err != nil {
+		// TODO(perrito666) 2016-05-02 lp:1558657
+		now := time.Now()
+		sInfo := status.StatusInfo{
+			Status:  status.Status(arg.Status),
+			Message: arg.Info,
+			Data:    arg.Data,
+			Since:   &now,
+		}
+		if err := service.SetStatus(sInfo); err != nil {
 			result.Results[i].Error = ServerError(err)
 		}
 
@@ -126,7 +134,7 @@ func NewStatusSetter(st state.EntityFinder, getCanModify GetAuthFunc) *StatusSet
 	}
 }
 
-func (s *StatusSetter) setEntityStatus(tag names.Tag, entityStatus status.Status, info string, data map[string]interface{}) error {
+func (s *StatusSetter) setEntityStatus(tag names.Tag, entityStatus status.Status, info string, data map[string]interface{}, updated *time.Time) error {
 	entity, err := s.st.FindEntity(tag)
 	if err != nil {
 		return err
@@ -135,7 +143,13 @@ func (s *StatusSetter) setEntityStatus(tag names.Tag, entityStatus status.Status
 	case *state.Service:
 		return ErrPerm
 	case status.StatusSetter:
-		return entity.SetStatus(entityStatus, info, data)
+		sInfo := status.StatusInfo{
+			Status:  entityStatus,
+			Message: info,
+			Data:    data,
+			Since:   updated,
+		}
+		return entity.SetStatus(sInfo)
 	default:
 		return NotSupportedError(tag, fmt.Sprintf("setting status, %T", entity))
 	}
@@ -153,6 +167,8 @@ func (s *StatusSetter) SetStatus(args params.SetStatus) (params.ErrorResults, er
 	if err != nil {
 		return params.ErrorResults{}, err
 	}
+	// TODO(perrito666) 2016-05-02 lp:1558657
+	now := time.Now()
 	for i, arg := range args.Entities {
 		tag, err := names.ParseTag(arg.Tag)
 		if err != nil {
@@ -161,7 +177,7 @@ func (s *StatusSetter) SetStatus(args params.SetStatus) (params.ErrorResults, er
 		}
 		err = ErrPerm
 		if canModify(tag) {
-			err = s.setEntityStatus(tag, arg.Status, arg.Info, arg.Data)
+			err = s.setEntityStatus(tag, status.Status(arg.Status), arg.Info, arg.Data, &now)
 		}
 		result.Results[i].Error = ServerError(err)
 	}
@@ -196,7 +212,15 @@ func (s *StatusSetter) updateEntityStatusData(tag names.Tag, data map[string]int
 	if len(newData) > 0 && existingStatusInfo.Status != status.StatusError {
 		return fmt.Errorf("%s is not in an error state", names.ReadableString(tag))
 	}
-	return entity.SetStatus(existingStatusInfo.Status, existingStatusInfo.Message, newData)
+	// TODO(perrito666) 2016-05-02 lp:1558657
+	now := time.Now()
+	sInfo := status.StatusInfo{
+		Status:  existingStatusInfo.Status,
+		Message: existingStatusInfo.Message,
+		Data:    newData,
+		Since:   &now,
+	}
+	return entity.SetStatus(sInfo)
 }
 
 // UpdateStatus updates the status data of each given entity.

--- a/apiserver/common/setstatus_test.go
+++ b/apiserver/common/setstatus_test.go
@@ -38,7 +38,7 @@ func (s *statusSetterSuite) TestUnauthorized(c *gc.C) {
 	s.badTag = tag
 	result, err := s.setter.SetStatus(params.SetStatus{[]params.EntityStatusArgs{{
 		Tag:    tag.String(),
-		Status: status.StatusExecuting,
+		Status: status.StatusExecuting.String(),
 	}}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, 1)
@@ -48,7 +48,7 @@ func (s *statusSetterSuite) TestUnauthorized(c *gc.C) {
 func (s *statusSetterSuite) TestNotATag(c *gc.C) {
 	result, err := s.setter.SetStatus(params.SetStatus{[]params.EntityStatusArgs{{
 		Tag:    "not a tag",
-		Status: status.StatusExecuting,
+		Status: status.StatusExecuting.String(),
 	}}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, 1)
@@ -58,7 +58,7 @@ func (s *statusSetterSuite) TestNotATag(c *gc.C) {
 func (s *statusSetterSuite) TestNotFound(c *gc.C) {
 	result, err := s.setter.SetStatus(params.SetStatus{[]params.EntityStatusArgs{{
 		Tag:    names.NewMachineTag("42").String(),
-		Status: status.StatusDown,
+		Status: status.StatusDown.String(),
 	}}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, 1)
@@ -69,7 +69,7 @@ func (s *statusSetterSuite) TestSetMachineStatus(c *gc.C) {
 	machine := s.Factory.MakeMachine(c, nil)
 	result, err := s.setter.SetStatus(params.SetStatus{[]params.EntityStatusArgs{{
 		Tag:    machine.Tag().String(),
-		Status: status.StatusStarted,
+		Status: status.StatusStarted.String(),
 	}}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, 1)
@@ -91,7 +91,7 @@ func (s *statusSetterSuite) TestSetUnitStatus(c *gc.C) {
 	}})
 	result, err := s.setter.SetStatus(params.SetStatus{[]params.EntityStatusArgs{{
 		Tag:    unit.Tag().String(),
-		Status: status.StatusActive,
+		Status: status.StatusActive.String(),
 	}}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, 1)
@@ -113,7 +113,7 @@ func (s *statusSetterSuite) TestSetServiceStatus(c *gc.C) {
 	}})
 	result, err := s.setter.SetStatus(params.SetStatus{[]params.EntityStatusArgs{{
 		Tag:    service.Tag().String(),
-		Status: status.StatusActive,
+		Status: status.StatusActive.String(),
 	}}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, 1)
@@ -130,10 +130,10 @@ func (s *statusSetterSuite) TestBulk(c *gc.C) {
 	s.badTag = names.NewMachineTag("42")
 	result, err := s.setter.SetStatus(params.SetStatus{[]params.EntityStatusArgs{{
 		Tag:    s.badTag.String(),
-		Status: status.StatusActive,
+		Status: status.StatusActive.String(),
 	}, {
 		Tag:    "bad-tag",
-		Status: status.StatusActive,
+		Status: status.StatusActive.String(),
 	}}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, 2)
@@ -162,7 +162,7 @@ func (s *serviceStatusSetterSuite) TestUnauthorized(c *gc.C) {
 	s.badTag = tag
 	result, err := s.setter.SetStatus(params.SetStatus{[]params.EntityStatusArgs{{
 		Tag:    tag.String(),
-		Status: status.StatusActive,
+		Status: status.StatusActive.String(),
 	}}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, 1)
@@ -172,7 +172,7 @@ func (s *serviceStatusSetterSuite) TestUnauthorized(c *gc.C) {
 func (s *serviceStatusSetterSuite) TestNotATag(c *gc.C) {
 	result, err := s.setter.SetStatus(params.SetStatus{[]params.EntityStatusArgs{{
 		Tag:    "not a tag",
-		Status: status.StatusActive,
+		Status: status.StatusActive.String(),
 	}}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, 1)
@@ -182,7 +182,7 @@ func (s *serviceStatusSetterSuite) TestNotATag(c *gc.C) {
 func (s *serviceStatusSetterSuite) TestNotFound(c *gc.C) {
 	result, err := s.setter.SetStatus(params.SetStatus{[]params.EntityStatusArgs{{
 		Tag:    names.NewUnitTag("foo/0").String(),
-		Status: status.StatusActive,
+		Status: status.StatusActive.String(),
 	}}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, 1)
@@ -193,7 +193,7 @@ func (s *serviceStatusSetterSuite) TestSetMachineStatus(c *gc.C) {
 	machine := s.Factory.MakeMachine(c, nil)
 	result, err := s.setter.SetStatus(params.SetStatus{[]params.EntityStatusArgs{{
 		Tag:    machine.Tag().String(),
-		Status: status.StatusActive,
+		Status: status.StatusActive.String(),
 	}}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, 1)
@@ -210,7 +210,7 @@ func (s *serviceStatusSetterSuite) TestSetServiceStatus(c *gc.C) {
 	}})
 	result, err := s.setter.SetStatus(params.SetStatus{[]params.EntityStatusArgs{{
 		Tag:    service.Tag().String(),
-		Status: status.StatusActive,
+		Status: status.StatusActive.String(),
 	}}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, 1)
@@ -226,7 +226,7 @@ func (s *serviceStatusSetterSuite) TestSetUnitStatusNotLeader(c *gc.C) {
 	}})
 	result, err := s.setter.SetStatus(params.SetStatus{[]params.EntityStatusArgs{{
 		Tag:    unit.Tag().String(),
-		Status: status.StatusActive,
+		Status: status.StatusActive.String(),
 	}}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, 1)
@@ -249,7 +249,7 @@ func (s *serviceStatusSetterSuite) TestSetUnitStatusIsLeader(c *gc.C) {
 		time.Minute)
 	result, err := s.setter.SetStatus(params.SetStatus{[]params.EntityStatusArgs{{
 		Tag:    unit.Tag().String(),
-		Status: status.StatusActive,
+		Status: status.StatusActive.String(),
 	}}})
 
 	c.Assert(err, jc.ErrorIsNil)
@@ -268,13 +268,13 @@ func (s *serviceStatusSetterSuite) TestBulk(c *gc.C) {
 	machine := s.Factory.MakeMachine(c, nil)
 	result, err := s.setter.SetStatus(params.SetStatus{[]params.EntityStatusArgs{{
 		Tag:    s.badTag.String(),
-		Status: status.StatusActive,
+		Status: status.StatusActive.String(),
 	}, {
 		Tag:    machine.Tag().String(),
-		Status: status.StatusActive,
+		Status: status.StatusActive.String(),
 	}, {
 		Tag:    "bad-tag",
-		Status: status.StatusActive,
+		Status: status.StatusActive.String(),
 	}}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, 3)

--- a/apiserver/instancepoller/export_test.go
+++ b/apiserver/instancepoller/export_test.go
@@ -3,9 +3,7 @@
 
 package instancepoller
 
-import (
-	"github.com/juju/juju/state"
-)
+import "github.com/juju/juju/state"
 
 type Patcher interface {
 	PatchValue(ptr, value interface{})

--- a/apiserver/instancepoller/instancepoller.go
+++ b/apiserver/instancepoller/instancepoller.go
@@ -167,7 +167,7 @@ func (a *InstancePollerAPI) InstanceStatus(args params.Entities) (params.StatusR
 		if err == nil {
 			var statusInfo status.StatusInfo
 			statusInfo, err = machine.InstanceStatus()
-			result.Results[i].Status = statusInfo.Status
+			result.Results[i].Status = statusInfo.Status.String()
 			result.Results[i].Info = statusInfo.Message
 			result.Results[i].Data = statusInfo.Data
 			result.Results[i].Since = statusInfo.Since

--- a/apiserver/instancepoller/instancepoller_test.go
+++ b/apiserver/instancepoller/instancepoller_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/clock"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/common"
@@ -34,6 +35,8 @@ type InstancePollerSuite struct {
 
 	mixedEntities     params.Entities
 	mixedErrorResults params.ErrorResults
+
+	clock clock.Clock
 }
 
 var _ = gc.Suite(&InstancePollerSuite{})
@@ -51,7 +54,8 @@ func (s *InstancePollerSuite) SetUpTest(c *gc.C) {
 	instancepoller.PatchState(s, s.st)
 
 	var err error
-	s.api, err = instancepoller.NewInstancePollerAPI(nil, s.resources, s.authoriser)
+	s.clock = coretesting.NewClock(time.Now())
+	s.api, err = instancepoller.NewInstancePollerAPI(nil, s.resources, s.authoriser, s.clock)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.machineEntities = params.Entities{
@@ -94,7 +98,7 @@ func (s *InstancePollerSuite) SetUpTest(c *gc.C) {
 func (s *InstancePollerSuite) TestNewInstancePollerAPIRequiresEnvironManager(c *gc.C) {
 	anAuthoriser := s.authoriser
 	anAuthoriser.EnvironManager = false
-	api, err := instancepoller.NewInstancePollerAPI(nil, s.resources, anAuthoriser)
+	api, err := instancepoller.NewInstancePollerAPI(nil, s.resources, anAuthoriser, s.clock)
 	c.Assert(api, gc.IsNil)
 	c.Assert(err, gc.ErrorMatches, "permission denied")
 }
@@ -587,36 +591,41 @@ func (s *InstancePollerSuite) TestSetInstanceStatusSuccess(c *gc.C) {
 
 	result, err := s.api.SetInstanceStatus(params.SetStatus{
 		Entities: []params.EntityStatusArgs{
-			{Tag: "machine-1", Status: status.Status("")},
-			{Tag: "machine-2", Status: status.Status("new status")},
-			{Tag: "machine-42", Status: status.Status("")},
-			{Tag: "service-unknown", Status: status.Status("")},
-			{Tag: "invalid-tag", Status: status.Status("")},
-			{Tag: "unit-missing-1", Status: status.Status("")},
-			{Tag: "", Status: status.Status("")},
-			{Tag: "42", Status: status.Status("")},
+			{Tag: "machine-1", Status: ""},
+			{Tag: "machine-2", Status: "new status"},
+			{Tag: "machine-42", Status: ""},
+			{Tag: "service-unknown", Status: ""},
+			{Tag: "invalid-tag", Status: ""},
+			{Tag: "unit-missing-1", Status: ""},
+			{Tag: "", Status: ""},
+			{Tag: "42", Status: ""},
 		}},
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, s.mixedErrorResults)
 
+	now := s.clock.Now()
 	s.st.CheckFindEntityCall(c, 0, "1")
-	s.st.CheckCall(c, 1, "SetInstanceStatus", status.Status(""))
+	s.st.CheckCall(c, 1, "SetInstanceStatus", status.StatusInfo{Status: status.Status(""), Since: &now})
 	s.st.CheckFindEntityCall(c, 2, "2")
-	s.st.CheckCall(c, 3, "SetInstanceStatus", status.Status("new status"))
+	s.st.CheckCall(c, 3, "SetInstanceStatus", status.StatusInfo{Status: status.Status("new status"), Since: &now})
 	s.st.CheckFindEntityCall(c, 4, "42")
 
 	// Ensure machines were updated.
 	machine, err := s.st.Machine("1")
 	c.Assert(err, jc.ErrorIsNil)
+	// TODO (perrito666) there should not be an empty StatusInfo here,
+	// this is certainly a smell.
 	setStatus, err := machine.InstanceStatus()
 	c.Assert(err, jc.ErrorIsNil)
+	setStatus.Since = nil
 	c.Assert(setStatus, gc.DeepEquals, status.StatusInfo{})
 
 	machine, err = s.st.Machine("2")
 	c.Assert(err, jc.ErrorIsNil)
 	setStatus, err = machine.InstanceStatus()
 	c.Assert(err, jc.ErrorIsNil)
+	setStatus.Since = nil
 	c.Assert(setStatus, gc.DeepEquals, status.StatusInfo{Status: "new status"})
 }
 
@@ -632,9 +641,9 @@ func (s *InstancePollerSuite) TestSetInstanceStatusFailure(c *gc.C) {
 
 	result, err := s.api.SetInstanceStatus(params.SetStatus{
 		Entities: []params.EntityStatusArgs{
-			{Tag: "machine-1", Status: status.Status("new")},
-			{Tag: "machine-2", Status: status.Status("invalid")},
-			{Tag: "machine-3", Status: status.Status("")},
+			{Tag: "machine-1", Status: "new"},
+			{Tag: "machine-2", Status: "invalid"},
+			{Tag: "machine-3", Status: ""},
 		}},
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -642,7 +651,8 @@ func (s *InstancePollerSuite) TestSetInstanceStatusFailure(c *gc.C) {
 
 	s.st.CheckFindEntityCall(c, 0, "1")
 	s.st.CheckFindEntityCall(c, 1, "2")
-	s.st.CheckCall(c, 2, "SetInstanceStatus", status.Status("invalid"))
+	now := s.clock.Now()
+	s.st.CheckCall(c, 2, "SetInstanceStatus", status.StatusInfo{Status: "invalid", Since: &now})
 	s.st.CheckFindEntityCall(c, 3, "3")
 }
 

--- a/apiserver/instancepoller/instancepoller_test.go
+++ b/apiserver/instancepoller/instancepoller_test.go
@@ -356,7 +356,7 @@ func (s *InstancePollerSuite) TestStatusSuccess(c *gc.C) {
 	c.Assert(result, jc.DeepEquals, params.StatusResults{
 		Results: []params.StatusResult{
 			{
-				Status: status.StatusError,
+				Status: status.StatusError.String(),
 				Info:   s1.Message,
 				Data:   s1.Data,
 				Since:  s1.Since,
@@ -536,8 +536,8 @@ func (s *InstancePollerSuite) TestInstanceStatusSuccess(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, params.StatusResults{
 		Results: []params.StatusResult{
-			{Status: status.Status("foo")},
-			{Status: status.Status("")},
+			{Status: "foo"},
+			{Status: ""},
 			{Error: apiservertesting.NotFoundError("machine 42")},
 			{Error: apiservertesting.ServerError(`"service-unknown" is not a valid machine tag`)},
 			{Error: apiservertesting.ServerError(`"invalid-tag" is not a valid tag`)},

--- a/apiserver/instancepoller/mock_test.go
+++ b/apiserver/instancepoller/mock_test.go
@@ -277,7 +277,7 @@ func (m *mockMachine) InstanceStatus() (status.StatusInfo, error) {
 }
 
 // SetInstanceStatus implements StateMachine.
-func (m *mockMachine) SetInstanceStatus(instanceStatus status.Status, info string, data map[string]interface{}) error {
+func (m *mockMachine) SetInstanceStatus(instanceStatus status.StatusInfo) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -285,11 +285,7 @@ func (m *mockMachine) SetInstanceStatus(instanceStatus status.Status, info strin
 	if err := m.NextErr(); err != nil {
 		return err
 	}
-	m.instanceStatus = status.StatusInfo{
-		Status:  instanceStatus,
-		Message: info,
-		Data:    data,
-	}
+	m.instanceStatus = instanceStatus
 	return nil
 }
 

--- a/apiserver/instancepoller/state.go
+++ b/apiserver/instancepoller/state.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/juju/status"
 )
 
+// StateMachine represents a machine from state package.
 type StateMachine interface {
 	state.Entity
 

--- a/apiserver/instancepoller/state.go
+++ b/apiserver/instancepoller/state.go
@@ -19,7 +19,7 @@ type StateMachine interface {
 	ProviderAddresses() []network.Address
 	SetProviderAddresses(...network.Address) error
 	InstanceStatus() (status.StatusInfo, error)
-	SetInstanceStatus(status.Status, string, map[string]interface{}) error
+	SetInstanceStatus(status.StatusInfo) error
 	String() string
 	Refresh() error
 	Life() state.Life

--- a/apiserver/machine/machiner_test.go
+++ b/apiserver/machine/machiner_test.go
@@ -4,6 +4,8 @@
 package machine_test
 
 import (
+	"time"
+
 	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -55,16 +57,27 @@ func (s *machinerSuite) TestMachinerFailsWithNonMachineAgentUser(c *gc.C) {
 }
 
 func (s *machinerSuite) TestSetStatus(c *gc.C) {
-	err := s.machine0.SetStatus(status.StatusStarted, "blah", nil)
+	now := time.Now()
+	sInfo := status.StatusInfo{
+		Status:  status.StatusStarted,
+		Message: "blah",
+		Since:   &now,
+	}
+	err := s.machine0.SetStatus(sInfo)
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.machine1.SetStatus(status.StatusStopped, "foo", nil)
+	sInfo = status.StatusInfo{
+		Status:  status.StatusStopped,
+		Message: "foo",
+		Since:   &now,
+	}
+	err = s.machine1.SetStatus(sInfo)
 	c.Assert(err, jc.ErrorIsNil)
 
 	args := params.SetStatus{
 		Entities: []params.EntityStatusArgs{
-			{Tag: "machine-1", Status: status.StatusError, Info: "not really"},
-			{Tag: "machine-0", Status: status.StatusStopped, Info: "foobar"},
-			{Tag: "machine-42", Status: status.StatusStarted, Info: "blah"},
+			{Tag: "machine-1", Status: status.StatusError.String(), Info: "not really"},
+			{Tag: "machine-0", Status: status.StatusStopped.String(), Info: "foobar"},
+			{Tag: "machine-42", Status: status.StatusStarted.String(), Info: "blah"},
 		}}
 	result, err := s.machiner.SetStatus(args)
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/params/internal.go
+++ b/apiserver/params/internal.go
@@ -339,12 +339,12 @@ type EntityStatus struct {
 	Since  *time.Time
 }
 
-// EntityStatus holds parameters for setting the status of a single entity.
+// EntityStatusArgs holds parameters for setting the status of a single entity.
 type EntityStatusArgs struct {
-	Tag    string
-	Status status.Status
-	Info   string
-	Data   map[string]interface{}
+	Tag    string                 `json:"tag"`
+	Status status.Status          `json:"status"`
+	Info   string                 `json:"info"`
+	Data   map[string]interface{} `json:"data"`
 }
 
 // SetStatus holds the parameters for making a SetStatus/UpdateStatus call.

--- a/apiserver/params/internal.go
+++ b/apiserver/params/internal.go
@@ -341,10 +341,10 @@ type EntityStatus struct {
 
 // EntityStatusArgs holds parameters for setting the status of a single entity.
 type EntityStatusArgs struct {
-	Tag    string                 `json:"tag"`
-	Status status.Status          `json:"status"`
-	Info   string                 `json:"info"`
-	Data   map[string]interface{} `json:"data"`
+	Tag    string                 `json:"Tag"`
+	Status string                 `json:"Status"`
+	Info   string                 `json:"Info"`
+	Data   map[string]interface{} `json:"Data"`
 }
 
 // SetStatus holds the parameters for making a SetStatus/UpdateStatus call.

--- a/apiserver/params/status.go
+++ b/apiserver/params/status.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/state/multiwatcher"
-	"github.com/juju/juju/status"
 )
 
 // StatusParams holds parameters for the Status call.
@@ -107,26 +106,51 @@ func (epStatus *EndpointStatus) String() string {
 
 // DetailedStatus holds status info about a machine or unit agent.
 type DetailedStatus struct {
-	Status  status.Status
-	Info    string
-	Data    map[string]interface{}
-	Since   *time.Time
-	Kind    HistoryKind
-	Version string
-	Life    string
-	Err     error
+	Status  string                 `json:"Status"`
+	Info    string                 `json:"Info"`
+	Data    map[string]interface{} `json:"Data"`
+	Since   *time.Time             `json:"Since"`
+	Kind    string                 `json:"Kind"`
+	Version string                 `json:"Version"`
+	Life    string                 `json:"Life"`
+	Err     error                  `json:"Err"`
 }
 
-// StatusHistoryArgs holds the parameters to filter a status history query.
-type StatusHistoryArgs struct {
-	Kind HistoryKind
-	Size int
-	Name string
+// History holds many DetailedStatus,
+type History struct {
+	Statuses []DetailedStatus `json:"Statuses"`
+	Error    *Error           `json:"Error,omitempty"`
 }
 
-// StatusHistoryResults holds a slice of statuses.
+// StatusHistoryFilter holds arguments that can be use to filter a status history backlog.
+type StatusHistoryFilter struct {
+	Size  int            `json:"Size"`
+	Date  *time.Time     `json:"Date"`
+	Delta *time.Duration `json:"Delta"`
+}
+
+// StatusHistoryRequest holds the parameters to filter a status history query.
+type StatusHistoryRequest struct {
+	Kind   string              `json:"HistoryKind"`
+	Size   int                 `json:"Size"`
+	Filter StatusHistoryFilter `json:"Filter"`
+	Name   string              `json:"Name"`
+}
+
+// StatusHistoryRequests holds a slice of StatusHistoryArgs
+type StatusHistoryRequests struct {
+	Requests []StatusHistoryRequest `json:"Requests"`
+}
+
+// StatusHistoryResult holds a slice of statuses.
+type StatusHistoryResult struct {
+	History History `json:"History"`
+	Error   *Error  `json:"Error,omitempty"`
+}
+
+// StatusHistoryResults holds a slice of StatusHistoryResult.
 type StatusHistoryResults struct {
-	Statuses []DetailedStatus
+	Results []StatusHistoryResult `json:"Results"`
 }
 
 // StatusHistoryPruneArgs holds arguments for status history
@@ -141,7 +165,7 @@ type StatusResult struct {
 	Error  *Error
 	Id     string
 	Life   Life
-	Status status.Status
+	Status string
 	Info   string
 	Data   map[string]interface{}
 	Since  *time.Time
@@ -163,27 +187,6 @@ type ServiceStatusResult struct {
 type ServiceStatusResults struct {
 	Results []ServiceStatusResult
 }
-
-// HistoryKind represents the possible types of
-// status history entries.
-type HistoryKind string
-
-const (
-	// KindUnit represents agent and workload combined.
-	KindUnit HistoryKind = "unit"
-	// KindUnitAgent represent a unit agent status history entry.
-	KindUnitAgent HistoryKind = "juju-unit"
-	// KindWorkload represents a charm workload status history entry.
-	KindWorkload HistoryKind = "workload"
-	// KindMachineInstance represents an entry for a machine instance.
-	KindMachineInstance = "machine"
-	// KindMachine represents an entry for a machine agent.
-	KindMachine = "juju-machine"
-	// KindContainerInstance represents an entry for a container instance.
-	KindContainerInstance = "container"
-	// KindContainer represents an entry for a container agent.
-	KindContainer = "juju-container"
-)
 
 // Life describes the lifecycle state of an entity ("alive", "dying" or "dead").
 type Life multiwatcher.Life

--- a/apiserver/params/status.go
+++ b/apiserver/params/status.go
@@ -8,6 +8,7 @@ package params
 import (
 	"time"
 
+	"github.com/juju/names"
 	"gopkg.in/juju/charm.v6-unstable"
 
 	"github.com/juju/juju/instance"
@@ -134,7 +135,7 @@ type StatusHistoryRequest struct {
 	Kind   string              `json:"HistoryKind"`
 	Size   int                 `json:"Size"`
 	Filter StatusHistoryFilter `json:"Filter"`
-	Name   string              `json:"Name"`
+	Tag    names.Tag           `json:"Tag"`
 }
 
 // StatusHistoryRequests holds a slice of StatusHistoryArgs
@@ -156,7 +157,8 @@ type StatusHistoryResults struct {
 // StatusHistoryPruneArgs holds arguments for status history
 // prunning process.
 type StatusHistoryPruneArgs struct {
-	MaxLogsPerEntity int
+	MaxHistoryTime time.Duration `json:"MaxHistoryTime"`
+	MaxHistoryMB   int           `json:"MaxHistoryMB"`
 }
 
 // StatusResult holds an entity status, extra information, or an

--- a/apiserver/provisioner/provisioner.go
+++ b/apiserver/provisioner/provisioner.go
@@ -340,10 +340,10 @@ func (p *ProvisionerAPI) MachinesWithTransientErrors() (params.StatusResults, er
 		if err != nil {
 			continue
 		}
-		result.Status = status.Status(statusInfo.Status)
+		result.Status = statusInfo.Status.String()
 		result.Info = statusInfo.Message
 		result.Data = statusInfo.Data
-		if result.Status != status.StatusError {
+		if statusInfo.Status != status.StatusError {
 			continue
 		}
 		// Transient errors are marked as such in the status data.
@@ -1296,7 +1296,7 @@ func (p *ProvisionerAPI) InstanceStatus(args params.Entities) (params.StatusResu
 		if err == nil {
 			var statusInfo status.StatusInfo
 			statusInfo, err = machine.InstanceStatus()
-			result.Results[i].Status = statusInfo.Status
+			result.Results[i].Status = statusInfo.Status.String()
 			result.Results[i].Info = statusInfo.Message
 			result.Results[i].Data = statusInfo.Data
 			result.Results[i].Since = statusInfo.Since

--- a/apiserver/provisioner/provisioner.go
+++ b/apiserver/provisioner/provisioner.go
@@ -6,6 +6,7 @@ package provisioner
 import (
 	"fmt"
 	"math/rand"
+	"time"
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
@@ -1325,7 +1326,15 @@ func (p *ProvisionerAPI) SetInstanceStatus(args params.SetStatus) (params.ErrorR
 		}
 		machine, err := p.getMachine(canAccess, mTag)
 		if err == nil {
-			err = machine.SetInstanceStatus(arg.Status, arg.Info, arg.Data)
+			// TODO(perrito666) 2016-05-02 lp:1558657
+			now := time.Now()
+			s := status.StatusInfo{
+				Status:  status.Status(arg.Status),
+				Message: arg.Info,
+				Data:    arg.Data,
+				Since:   &now,
+			}
+			err = machine.SetInstanceStatus(s)
 		}
 		result.Results[i].Error = common.ServerError(err)
 	}

--- a/apiserver/provisioner/provisioner_test.go
+++ b/apiserver/provisioner/provisioner_test.go
@@ -583,9 +583,9 @@ func (s *withoutControllerSuite) TestStatus(c *gc.C) {
 	}
 	c.Assert(result, gc.DeepEquals, params.StatusResults{
 		Results: []params.StatusResult{
-			{Status: status.StatusStarted, Info: "blah", Data: map[string]interface{}{}},
-			{Status: status.StatusStopped, Info: "foo", Data: map[string]interface{}{}},
-			{Status: status.StatusError, Info: "not really", Data: map[string]interface{}{"foo": "bar"}},
+			{Status: status.StatusStarted.String(), Info: "blah", Data: map[string]interface{}{}},
+			{Status: status.StatusStopped.String(), Info: "foo", Data: map[string]interface{}{}},
+			{Status: status.StatusError.String(), Info: "not really", Data: map[string]interface{}{"foo": "bar"}},
 			{Error: apiservertesting.NotFoundError("machine 42")},
 			{Error: apiservertesting.ErrUnauthorized},
 			{Error: apiservertesting.ErrUnauthorized},

--- a/apiserver/provisioner/provisioner_test.go
+++ b/apiserver/provisioner/provisioner_test.go
@@ -6,6 +6,7 @@ package provisioner_test
 import (
 	"fmt"
 	stdtesting "testing"
+	"time"
 
 	"github.com/juju/errors"
 	"github.com/juju/names"
@@ -327,22 +328,38 @@ func (s *withoutControllerSuite) TestRemove(c *gc.C) {
 }
 
 func (s *withoutControllerSuite) TestSetStatus(c *gc.C) {
-	err := s.machines[0].SetStatus(status.StatusStarted, "blah", nil)
+	now := time.Now()
+	sInfo := status.StatusInfo{
+		Status:  status.StatusStarted,
+		Message: "blah",
+		Since:   &now,
+	}
+	err := s.machines[0].SetStatus(sInfo)
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.machines[1].SetStatus(status.StatusStopped, "foo", nil)
+	sInfo = status.StatusInfo{
+		Status:  status.StatusStopped,
+		Message: "foo",
+		Since:   &now,
+	}
+	err = s.machines[1].SetStatus(sInfo)
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.machines[2].SetStatus(status.StatusError, "not really", nil)
+	sInfo = status.StatusInfo{
+		Status:  status.StatusError,
+		Message: "not really",
+		Since:   &now,
+	}
+	err = s.machines[2].SetStatus(sInfo)
 	c.Assert(err, jc.ErrorIsNil)
 
 	args := params.SetStatus{
 		Entities: []params.EntityStatusArgs{
-			{Tag: s.machines[0].Tag().String(), Status: status.StatusError, Info: "not really",
+			{Tag: s.machines[0].Tag().String(), Status: status.StatusError.String(), Info: "not really",
 				Data: map[string]interface{}{"foo": "bar"}},
-			{Tag: s.machines[1].Tag().String(), Status: status.StatusStopped, Info: "foobar"},
-			{Tag: s.machines[2].Tag().String(), Status: status.StatusStarted, Info: "again"},
-			{Tag: "machine-42", Status: status.StatusStarted, Info: "blah"},
-			{Tag: "unit-foo-0", Status: status.StatusStopped, Info: "foobar"},
-			{Tag: "service-bar", Status: status.StatusStopped, Info: "foobar"},
+			{Tag: s.machines[1].Tag().String(), Status: status.StatusStopped.String(), Info: "foobar"},
+			{Tag: s.machines[2].Tag().String(), Status: status.StatusStarted.String(), Info: "again"},
+			{Tag: "machine-42", Status: status.StatusStarted.String(), Info: "blah"},
+			{Tag: "unit-foo-0", Status: status.StatusStopped.String(), Info: "foobar"},
+			{Tag: "service-bar", Status: status.StatusStopped.String(), Info: "foobar"},
 		}}
 	result, err := s.provisioner.SetStatus(args)
 	c.Assert(err, jc.ErrorIsNil)
@@ -364,18 +381,45 @@ func (s *withoutControllerSuite) TestSetStatus(c *gc.C) {
 }
 
 func (s *withoutControllerSuite) TestMachinesWithTransientErrors(c *gc.C) {
-	err := s.machines[0].SetStatus(status.StatusStarted, "blah", nil)
+	now := time.Now()
+	sInfo := status.StatusInfo{
+		Status:  status.StatusStarted,
+		Message: "blah",
+		Since:   &now,
+	}
+	err := s.machines[0].SetStatus(sInfo)
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.machines[1].SetStatus(status.StatusError, "transient error",
-		map[string]interface{}{"transient": true, "foo": "bar"})
+	sInfo = status.StatusInfo{
+		Status:  status.StatusError,
+		Message: "transient error",
+		Data:    map[string]interface{}{"transient": true, "foo": "bar"},
+		Since:   &now,
+	}
+	err = s.machines[1].SetStatus(sInfo)
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.machines[2].SetStatus(status.StatusError, "error", map[string]interface{}{"transient": false})
+	sInfo = status.StatusInfo{
+		Status:  status.StatusError,
+		Message: "error",
+		Data:    map[string]interface{}{"transient": false},
+		Since:   &now,
+	}
+	err = s.machines[2].SetStatus(sInfo)
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.machines[3].SetStatus(status.StatusError, "error", nil)
+	sInfo = status.StatusInfo{
+		Status:  status.StatusError,
+		Message: "error",
+		Since:   &now,
+	}
+	err = s.machines[3].SetStatus(sInfo)
 	c.Assert(err, jc.ErrorIsNil)
 	// Machine 4 is provisioned but error not reset yet.
-	err = s.machines[4].SetStatus(status.StatusError, "transient error",
-		map[string]interface{}{"transient": true, "foo": "bar"})
+	sInfo = status.StatusInfo{
+		Status:  status.StatusError,
+		Message: "transient error",
+		Data:    map[string]interface{}{"transient": true, "foo": "bar"},
+		Since:   &now,
+	}
+	err = s.machines[4].SetStatus(sInfo)
 	c.Assert(err, jc.ErrorIsNil)
 	hwChars := instance.MustParseHardware("arch=i386", "mem=4G")
 	err = s.machines[4].SetProvisioned("i-am", "fake_nonce", &hwChars)
@@ -398,14 +442,36 @@ func (s *withoutControllerSuite) TestMachinesWithTransientErrorsPermission(c *gc
 	anAuthorizer.Tag = names.NewMachineTag("1")
 	aProvisioner, err := provisioner.NewProvisionerAPI(s.State, s.resources,
 		anAuthorizer)
-	err = s.machines[0].SetStatus(status.StatusStarted, "blah", nil)
+	now := time.Now()
+	sInfo := status.StatusInfo{
+		Status:  status.StatusStarted,
+		Message: "blah",
+		Since:   &now,
+	}
+	err = s.machines[0].SetStatus(sInfo)
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.machines[1].SetStatus(status.StatusError, "transient error",
-		map[string]interface{}{"transient": true, "foo": "bar"})
+	sInfo = status.StatusInfo{
+		Status:  status.StatusError,
+		Message: "transient error",
+		Data:    map[string]interface{}{"transient": true, "foo": "bar"},
+		Since:   &now,
+	}
+	err = s.machines[1].SetStatus(sInfo)
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.machines[2].SetStatus(status.StatusError, "error", map[string]interface{}{"transient": false})
+	sInfo = status.StatusInfo{
+		Status:  status.StatusError,
+		Message: "error",
+		Data:    map[string]interface{}{"transient": false},
+		Since:   &now,
+	}
+	err = s.machines[2].SetStatus(sInfo)
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.machines[3].SetStatus(status.StatusError, "error", nil)
+	sInfo = status.StatusInfo{
+		Status:  status.StatusError,
+		Message: "error",
+		Since:   &now,
+	}
+	err = s.machines[3].SetStatus(sInfo)
 	c.Assert(err, jc.ErrorIsNil)
 
 	result, err := aProvisioner.MachinesWithTransientErrors()
@@ -555,11 +621,28 @@ func (s *withoutControllerSuite) TestModelConfigNonManager(c *gc.C) {
 }
 
 func (s *withoutControllerSuite) TestStatus(c *gc.C) {
-	err := s.machines[0].SetStatus(status.StatusStarted, "blah", nil)
+	now := time.Now()
+	sInfo := status.StatusInfo{
+		Status:  status.StatusStarted,
+		Message: "blah",
+		Since:   &now,
+	}
+	err := s.machines[0].SetStatus(sInfo)
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.machines[1].SetStatus(status.StatusStopped, "foo", nil)
+	sInfo = status.StatusInfo{
+		Status:  status.StatusStopped,
+		Message: "foo",
+		Since:   &now,
+	}
+	err = s.machines[1].SetStatus(sInfo)
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.machines[2].SetStatus(status.StatusError, "not really", map[string]interface{}{"foo": "bar"})
+	sInfo = status.StatusInfo{
+		Status:  status.StatusError,
+		Message: "not really",
+		Data:    map[string]interface{}{"foo": "bar"},
+		Since:   &now,
+	}
+	err = s.machines[2].SetStatus(sInfo)
 	c.Assert(err, jc.ErrorIsNil)
 
 	args := params.Entities{Entities: []params.Entity{

--- a/apiserver/service/service_test.go
+++ b/apiserver/service/service_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"regexp"
 	"sync"
+	"time"
 
 	"github.com/juju/errors"
 	"github.com/juju/names"
@@ -2140,7 +2141,13 @@ func (s *serviceSuite) TestDestroyPrincipalUnits(c *gc.C) {
 	for i := range units {
 		unit, err := wordpress.AddUnit()
 		c.Assert(err, jc.ErrorIsNil)
-		err = unit.SetAgentStatus(status.StatusIdle, "", nil)
+		now := time.Now()
+		sInfo := status.StatusInfo{
+			Status:  status.StatusIdle,
+			Message: "",
+			Since:   &now,
+		}
+		err = unit.SetAgentStatus(sInfo)
 		c.Assert(err, jc.ErrorIsNil)
 		units[i] = unit
 	}
@@ -2217,7 +2224,13 @@ func (s *serviceSuite) setupDestroyPrincipalUnits(c *gc.C) []*state.Unit {
 	for i := range units {
 		unit, err := wordpress.AddUnit()
 		c.Assert(err, jc.ErrorIsNil)
-		err = unit.SetAgentStatus(status.StatusIdle, "", nil)
+		now := time.Now()
+		sInfo := status.StatusInfo{
+			Status:  status.StatusIdle,
+			Message: "",
+			Since:   &now,
+		}
+		err = unit.SetAgentStatus(sInfo)
 		c.Assert(err, jc.ErrorIsNil)
 		units[i] = unit
 	}

--- a/apiserver/statushistory/pruner.go
+++ b/apiserver/statushistory/pruner.go
@@ -28,10 +28,11 @@ func NewAPI(st *state.State, _ *common.Resources, auth common.Authorizer) (*API,
 }
 
 // Prune endpoint removes status history entries until
-// only the N newest records per unit remain.
+// only the ones newer than now - p.MaxHistoryTime remain and
+// the history is smaller than p.MaxHistoryMB.
 func (api *API) Prune(p params.StatusHistoryPruneArgs) error {
 	if !api.authorizer.AuthModelManager() {
 		return common.ErrPerm
 	}
-	return state.PruneStatusHistory(api.st, p.MaxLogsPerEntity)
+	return state.PruneStatusHistory(api.st, p.MaxHistoryTime, p.MaxHistoryMB)
 }

--- a/apiserver/undertaker/mock_test.go
+++ b/apiserver/undertaker/mock_test.go
@@ -146,10 +146,10 @@ func (m *mockModel) Destroy() error {
 	return nil
 }
 
-func (m *mockModel) SetStatus(status status.Status, info string, data map[string]interface{}) error {
-	m.status = status
-	m.statusInfo = info
-	m.statusData = data
+func (m *mockModel) SetStatus(sInfo status.StatusInfo) error {
+	m.status = sInfo.Status
+	m.statusInfo = sInfo.Message
+	m.statusData = sInfo.Data
 	return nil
 }
 

--- a/apiserver/undertaker/undertaker_test.go
+++ b/apiserver/undertaker/undertaker_test.go
@@ -161,7 +161,7 @@ func (s *undertakerSuite) TestSetStatus(c *gc.C) {
 
 	results, err := hostedAPI.SetStatus(params.SetStatus{
 		Entities: []params.EntityStatusArgs{{
-			mock.env.Tag().String(), status.StatusDestroying,
+			mock.env.Tag().String(), status.StatusDestroying.String(),
 			"woop", map[string]interface{}{"da": "ta"},
 		}},
 	})
@@ -177,7 +177,7 @@ func (s *undertakerSuite) TestSetStatusControllerPermissions(c *gc.C) {
 	_, hostedAPI := s.setupStateAndAPI(c, true, "hostedenv")
 	results, err := hostedAPI.SetStatus(params.SetStatus{
 		Entities: []params.EntityStatusArgs{{
-			"model-6ada782f-bcd4-454b-a6da-d1793fbcb35e", status.StatusDestroying,
+			"model-6ada782f-bcd4-454b-a6da-d1793fbcb35e", status.StatusDestroying.String(),
 			"woop", map[string]interface{}{"da": "ta"},
 		}},
 	})
@@ -190,7 +190,7 @@ func (s *undertakerSuite) TestSetStatusNonControllerPermissions(c *gc.C) {
 	_, hostedAPI := s.setupStateAndAPI(c, false, "hostedenv")
 	results, err := hostedAPI.SetStatus(params.SetStatus{
 		Entities: []params.EntityStatusArgs{{
-			"model-6ada782f-bcd4-454b-a6da-d1793fbcb35e", status.StatusDestroying,
+			"model-6ada782f-bcd4-454b-a6da-d1793fbcb35e", status.StatusDestroying.String(),
 			"woop", map[string]interface{}{"da": "ta"},
 		}},
 	})

--- a/apiserver/uniter/uniter_test.go
+++ b/apiserver/uniter/uniter_test.go
@@ -134,16 +134,27 @@ func (s *uniterSuite) TestUniterFailsWithNonUnitAgentUser(c *gc.C) {
 }
 
 func (s *uniterSuite) TestSetStatus(c *gc.C) {
-	err := s.wordpressUnit.SetAgentStatus(status.StatusExecuting, "blah", nil)
+	now := time.Now()
+	sInfo := status.StatusInfo{
+		Status:  status.StatusExecuting,
+		Message: "blah",
+		Since:   &now,
+	}
+	err := s.wordpressUnit.SetAgentStatus(sInfo)
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.mysqlUnit.SetAgentStatus(status.StatusExecuting, "foo", nil)
+	sInfo = status.StatusInfo{
+		Status:  status.StatusExecuting,
+		Message: "foo",
+		Since:   &now,
+	}
+	err = s.mysqlUnit.SetAgentStatus(sInfo)
 	c.Assert(err, jc.ErrorIsNil)
 
 	args := params.SetStatus{
 		Entities: []params.EntityStatusArgs{
-			{Tag: "unit-mysql-0", Status: status.StatusError, Info: "not really"},
-			{Tag: "unit-wordpress-0", Status: status.StatusRebooting, Info: "foobar"},
-			{Tag: "unit-foo-42", Status: status.StatusActive, Info: "blah"},
+			{Tag: "unit-mysql-0", Status: status.StatusError.String(), Info: "not really"},
+			{Tag: "unit-wordpress-0", Status: status.StatusRebooting.String(), Info: "foobar"},
+			{Tag: "unit-foo-42", Status: status.StatusActive.String(), Info: "blah"},
 		}}
 	result, err := s.uniter.SetStatus(args)
 	c.Assert(err, jc.ErrorIsNil)
@@ -168,16 +179,27 @@ func (s *uniterSuite) TestSetStatus(c *gc.C) {
 }
 
 func (s *uniterSuite) TestSetAgentStatus(c *gc.C) {
-	err := s.wordpressUnit.SetAgentStatus(status.StatusExecuting, "blah", nil)
+	now := time.Now()
+	sInfo := status.StatusInfo{
+		Status:  status.StatusExecuting,
+		Message: "blah",
+		Since:   &now,
+	}
+	err := s.wordpressUnit.SetAgentStatus(sInfo)
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.mysqlUnit.SetAgentStatus(status.StatusExecuting, "foo", nil)
+	sInfo = status.StatusInfo{
+		Status:  status.StatusExecuting,
+		Message: "foo",
+		Since:   &now,
+	}
+	err = s.mysqlUnit.SetAgentStatus(sInfo)
 	c.Assert(err, jc.ErrorIsNil)
 
 	args := params.SetStatus{
 		Entities: []params.EntityStatusArgs{
-			{Tag: "unit-mysql-0", Status: status.StatusError, Info: "not really"},
-			{Tag: "unit-wordpress-0", Status: status.StatusExecuting, Info: "foobar"},
-			{Tag: "unit-foo-42", Status: status.StatusRebooting, Info: "blah"},
+			{Tag: "unit-mysql-0", Status: status.StatusError.String(), Info: "not really"},
+			{Tag: "unit-wordpress-0", Status: status.StatusExecuting.String(), Info: "foobar"},
+			{Tag: "unit-foo-42", Status: status.StatusRebooting.String(), Info: "blah"},
 		}}
 	result, err := s.uniter.SetAgentStatus(args)
 	c.Assert(err, jc.ErrorIsNil)
@@ -202,16 +224,27 @@ func (s *uniterSuite) TestSetAgentStatus(c *gc.C) {
 }
 
 func (s *uniterSuite) TestSetUnitStatus(c *gc.C) {
-	err := s.wordpressUnit.SetStatus(status.StatusActive, "blah", nil)
+	now := time.Now()
+	sInfo := status.StatusInfo{
+		Status:  status.StatusActive,
+		Message: "blah",
+		Since:   &now,
+	}
+	err := s.wordpressUnit.SetStatus(sInfo)
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.mysqlUnit.SetStatus(status.StatusTerminated, "foo", nil)
+	sInfo = status.StatusInfo{
+		Status:  status.StatusTerminated,
+		Message: "foo",
+		Since:   &now,
+	}
+	err = s.mysqlUnit.SetStatus(sInfo)
 	c.Assert(err, jc.ErrorIsNil)
 
 	args := params.SetStatus{
 		Entities: []params.EntityStatusArgs{
-			{Tag: "unit-mysql-0", Status: status.StatusError, Info: "not really"},
-			{Tag: "unit-wordpress-0", Status: status.StatusTerminated, Info: "foobar"},
-			{Tag: "unit-foo-42", Status: status.StatusActive, Info: "blah"},
+			{Tag: "unit-mysql-0", Status: status.StatusError.String(), Info: "not really"},
+			{Tag: "unit-wordpress-0", Status: status.StatusTerminated.String(), Info: "foobar"},
+			{Tag: "unit-foo-42", Status: status.StatusActive.String(), Info: "blah"},
 		}}
 	result, err := s.uniter.SetUnitStatus(args)
 	c.Assert(err, jc.ErrorIsNil)
@@ -2049,9 +2082,20 @@ func (s *uniterSuite) TestStorageAttachments(c *gc.C) {
 }
 
 func (s *uniterSuite) TestUnitStatus(c *gc.C) {
-	err := s.wordpressUnit.SetStatus(status.StatusMaintenance, "blah", nil)
+	now := time.Now()
+	sInfo := status.StatusInfo{
+		Status:  status.StatusMaintenance,
+		Message: "blah",
+		Since:   &now,
+	}
+	err := s.wordpressUnit.SetStatus(sInfo)
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.mysqlUnit.SetStatus(status.StatusTerminated, "foo", nil)
+	sInfo = status.StatusInfo{
+		Status:  status.StatusTerminated,
+		Message: "foo",
+		Since:   &now,
+	}
+	err = s.mysqlUnit.SetStatus(sInfo)
 	c.Assert(err, jc.ErrorIsNil)
 
 	args := params.Entities{

--- a/apiserver/uniter/uniter_test.go
+++ b/apiserver/uniter/uniter_test.go
@@ -2076,7 +2076,7 @@ func (s *uniterSuite) TestUnitStatus(c *gc.C) {
 	c.Assert(result, gc.DeepEquals, params.StatusResults{
 		Results: []params.StatusResult{
 			{Error: apiservertesting.ErrUnauthorized},
-			{Status: status.StatusMaintenance, Info: "blah", Data: map[string]interface{}{}},
+			{Status: status.StatusMaintenance.String(), Info: "blah", Data: map[string]interface{}{}},
 			{Error: apiservertesting.ErrUnauthorized},
 			{Error: apiservertesting.ErrUnauthorized},
 			{Error: apiservertesting.ServerError(`"invalid" is not a valid tag`)},

--- a/cert/cert.go
+++ b/cert/cert.go
@@ -87,6 +87,7 @@ func NewCA(envName, UUID string, expiry time.Time) (certPEM, keyPEM string, err 
 	if err != nil {
 		return "", "", err
 	}
+	// TODO(perrito666) 2016-05-02 lp:1558657
 	now := time.Now()
 
 	// A serial number can be up to 20 octets in size.
@@ -129,6 +130,7 @@ func NewCA(envName, UUID string, expiry time.Time) (certPEM, keyPEM string, err 
 // NewServer generates a certificate/key pair suitable for use by a server, with an
 // expiry time of 10 years.
 func NewDefaultServer(caCertPEM, caKeyPEM string, hostnames []string) (certPEM, keyPEM string, err error) {
+	// TODO(perrito666) 2016-05-02 lp:1558657
 	expiry := time.Now().UTC().AddDate(10, 0, 0)
 	return newLeaf(caCertPEM, caKeyPEM, expiry, hostnames, []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth})
 }
@@ -167,6 +169,7 @@ func newLeaf(caCertPEM, caKeyPEM string, expiry time.Time, hostnames []string, e
 	if err != nil {
 		return "", "", fmt.Errorf("cannot generate key: %v", err)
 	}
+	// TODO(perrito666) 2016-05-02 lp:1558657
 	now := time.Now()
 	template := &x509.Certificate{
 		SerialNumber: new(big.Int),

--- a/charmstore/latest.go
+++ b/charmstore/latest.go
@@ -18,6 +18,7 @@ const jujuMetadataHTTPHeader = "Juju-Metadata"
 // use in any further requests.  Note that this map may be non-empty even if
 // this method returns an error (and the macaroons should be stored).
 func LatestCharmInfo(client Client, charms []CharmID, modelUUID string) ([]CharmInfoResult, error) {
+	// TODO(perrito666) 2016-05-02 lp:1558657
 	now := time.Now().UTC()
 	// Do a bulk call to get the revision info for all charms.
 	logger.Infof("retrieving revision information for %d charms", len(charms))

--- a/cloudconfig/providerinit/providerinit_test.go
+++ b/cloudconfig/providerinit/providerinit_test.go
@@ -172,6 +172,7 @@ func (s *CloudInitSuite) TestFinishBootstrapConfig(c *gc.C) {
 	_, _, err = cert.ParseCertAndKey(srvCertPEM, srvKeyPEM)
 	c.Check(err, jc.ErrorIsNil)
 
+	// TODO(perrito666) 2016-05-02 lp:1558657
 	err = cert.Verify(srvCertPEM, testing.CACert, time.Now())
 	c.Assert(err, jc.ErrorIsNil)
 	err = cert.Verify(srvCertPEM, testing.CACert, time.Now().AddDate(9, 0, 0))

--- a/cloudconfig/userdatacfg_unix.go
+++ b/cloudconfig/userdatacfg_unix.go
@@ -275,6 +275,7 @@ func (w *unixConfigure) ConfigureJuju() error {
 		var metadataDir string
 		if len(w.icfg.CustomImageMetadata) > 0 {
 			metadataDir = path.Join(w.icfg.DataDir, "simplestreams")
+			// TODO(perrito666) 2016-05-02 lp:1558657
 			index, products, err := imagemetadata.MarshalImageMetadataJSON(w.icfg.CustomImageMetadata, nil, time.Now())
 			if err != nil {
 				return err

--- a/cmd/juju/commands/resolved_test.go
+++ b/cmd/juju/commands/resolved_test.go
@@ -4,6 +4,8 @@
 package commands
 
 import (
+	"time"
+
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -93,10 +95,17 @@ func (s *ResolvedSuite) TestResolved(c *gc.C) {
 	err := runDeploy(c, "-n", "5", ch, "dummy", "--series", "quantal")
 	c.Assert(err, jc.ErrorIsNil)
 
+	// lp:1558657
+	now := time.Now()
 	for _, name := range []string{"dummy/2", "dummy/3", "dummy/4"} {
 		u, err := s.State.Unit(name)
 		c.Assert(err, jc.ErrorIsNil)
-		err = u.SetAgentStatus(status.StatusError, "lol borken", nil)
+		sInfo := status.StatusInfo{
+			Status:  status.StatusError,
+			Message: "lol borken",
+			Since:   &now,
+		}
+		err = u.SetAgentStatus(sInfo)
 		c.Assert(err, jc.ErrorIsNil)
 	}
 
@@ -121,10 +130,17 @@ func (s *ResolvedSuite) TestBlockResolved(c *gc.C) {
 	err := runDeploy(c, "-n", "5", ch, "dummy", "--series", "quantal")
 	c.Assert(err, jc.ErrorIsNil)
 
+	// lp:1558657
+	now := time.Now()
 	for _, name := range []string{"dummy/2", "dummy/3", "dummy/4"} {
 		u, err := s.State.Unit(name)
 		c.Assert(err, jc.ErrorIsNil)
-		err = u.SetAgentStatus(status.StatusError, "lol borken", nil)
+		sInfo := status.StatusInfo{
+			Status:  status.StatusError,
+			Message: "lol borken",
+			Since:   &now,
+		}
+		err = u.SetAgentStatus(sInfo)
 		c.Assert(err, jc.ErrorIsNil)
 	}
 

--- a/cmd/juju/common/format_test.go
+++ b/cmd/juju/common/format_test.go
@@ -125,6 +125,7 @@ type userFriendlyDurationSuite struct {
 var _ = gc.Suite(&userFriendlyDurationSuite{})
 
 func (*userFriendlyDurationSuite) TestFormat(c *gc.C) {
+	// lp:1558657
 	now := time.Now()
 	for _, test := range []struct {
 		other    time.Time

--- a/cmd/juju/controller/listmodels.go
+++ b/cmd/juju/controller/listmodels.go
@@ -142,6 +142,7 @@ func (c *modelsCommand) Run(ctx *cmd.Context) error {
 		return errors.Annotate(err, "cannot get model details")
 	}
 
+	// TODO(perrito666) 2016-05-02 lp:1558657
 	now := time.Now()
 	modelInfo := make([]common.ModelInfo, 0, len(models))
 	for _, info := range paramsModelInfo {

--- a/cmd/juju/model/show.go
+++ b/cmd/juju/model/show.go
@@ -99,6 +99,7 @@ func (c *showModelCommand) Run(ctx *cmd.Context) (err error) {
 }
 
 func (c *showModelCommand) apiModelInfoToModelInfoMap(modelInfo []params.ModelInfo) (map[string]common.ModelInfo, error) {
+	// TODO(perrito666) 2016-05-02 lp:1558657
 	now := time.Now()
 	output := make(map[string]common.ModelInfo)
 	for _, info := range modelInfo {

--- a/cmd/juju/model/users.go
+++ b/cmd/juju/model/users.go
@@ -87,6 +87,7 @@ func (c *usersCommand) Run(ctx *cmd.Context) (err error) {
 	if err != nil {
 		return err
 	}
+	// TODO(perrito666) 2016-05-02 lp:1558657
 	return c.out.Write(ctx, common.ModelUserInfoFromParams(result, time.Now()))
 }
 

--- a/cmd/juju/status/formatter.go
+++ b/cmd/juju/status/formatter.go
@@ -128,9 +128,10 @@ func (sf *statusFormatter) formatService(name string, service params.ServiceStat
 }
 
 func (sf *statusFormatter) getServiceStatusInfo(service params.ServiceStatus) statusInfoContents {
+	// TODO(perrito66) add status validation.
 	info := statusInfoContents{
 		Err:     service.Status.Err,
-		Current: service.Status.Status,
+		Current: status.Status(service.Status.Status),
 		Message: service.Status.Info,
 		Version: service.Status.Version,
 	}
@@ -180,9 +181,10 @@ func (sf *statusFormatter) formatUnit(info unitFormatInfo) unitStatus {
 }
 
 func (sf *statusFormatter) getStatusInfoContents(inst params.DetailedStatus) statusInfoContents {
+	// TODO(perrito66) add status validation.
 	info := statusInfoContents{
 		Err:     inst.Err,
-		Current: inst.Status,
+		Current: status.Status(inst.Status),
 		Message: inst.Info,
 		Version: inst.Version,
 		Life:    inst.Life,
@@ -194,9 +196,10 @@ func (sf *statusFormatter) getStatusInfoContents(inst params.DetailedStatus) sta
 }
 
 func (sf *statusFormatter) getWorkloadStatusInfo(unit params.UnitStatus) statusInfoContents {
+	// TODO(perrito66) add status validation.
 	info := statusInfoContents{
 		Err:     unit.WorkloadStatus.Err,
-		Current: unit.WorkloadStatus.Status,
+		Current: status.Status(unit.WorkloadStatus.Status),
 		Message: unit.WorkloadStatus.Info,
 		Version: unit.WorkloadStatus.Version,
 	}
@@ -207,9 +210,10 @@ func (sf *statusFormatter) getWorkloadStatusInfo(unit params.UnitStatus) statusI
 }
 
 func (sf *statusFormatter) getAgentStatusInfo(unit params.UnitStatus) statusInfoContents {
+	// TODO(perrito66) add status validation.
 	info := statusInfoContents{
 		Err:     unit.AgentStatus.Err,
-		Current: unit.AgentStatus.Status,
+		Current: status.Status(unit.AgentStatus.Status),
 		Message: unit.AgentStatus.Info,
 		Version: unit.AgentStatus.Version,
 	}
@@ -220,7 +224,8 @@ func (sf *statusFormatter) getAgentStatusInfo(unit params.UnitStatus) statusInfo
 }
 
 func (sf *statusFormatter) updateUnitStatusInfo(unit *params.UnitStatus, serviceName string) {
-	if unit.WorkloadStatus.Status == status.StatusError {
+	// TODO(perrito66) add status validation.
+	if status.Status(unit.WorkloadStatus.Status) == status.StatusError {
 		if relation, ok := sf.relations[getRelationIdFromData(unit)]; ok {
 			// Append the details of the other endpoint on to the status info string.
 			if ep, ok := findOtherEndpoint(relation.Endpoints, serviceName); ok {

--- a/cmd/juju/status/status_test.go
+++ b/cmd/juju/status/status_test.go
@@ -2467,7 +2467,14 @@ func (sm startMissingMachine) step(c *gc.C, ctx *context) {
 	_, hc := testing.AssertStartInstanceWithConstraints(c, ctx.env, m.Id(), cons)
 	err = m.SetProvisioned("i-missing", "fake_nonce", hc)
 	c.Assert(err, jc.ErrorIsNil)
-	err = m.SetInstanceStatus(status.StatusUnknown, "missing", nil)
+	// lp:1558657
+	now := time.Now()
+	s := status.StatusInfo{
+		Status:  status.StatusUnknown,
+		Message: "missing",
+		Since:   &now,
+	}
+	err = m.SetInstanceStatus(s)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -2706,7 +2713,15 @@ type setUnitStatus struct {
 func (sus setUnitStatus) step(c *gc.C, ctx *context) {
 	u, err := ctx.st.Unit(sus.unitName)
 	c.Assert(err, jc.ErrorIsNil)
-	err = u.SetStatus(sus.status, sus.statusInfo, sus.statusData)
+	// lp:1558657
+	now := time.Now()
+	s := status.StatusInfo{
+		Status:  sus.status,
+		Message: sus.statusInfo,
+		Data:    sus.statusData,
+		Since:   &now,
+	}
+	err = u.SetStatus(s)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -2720,7 +2735,15 @@ type setAgentStatus struct {
 func (sus setAgentStatus) step(c *gc.C, ctx *context) {
 	u, err := ctx.st.Unit(sus.unitName)
 	c.Assert(err, jc.ErrorIsNil)
-	err = u.SetAgentStatus(sus.status, sus.statusInfo, sus.statusData)
+	// lp:1558657
+	now := time.Now()
+	sInfo := status.StatusInfo{
+		Status:  sus.status,
+		Message: sus.statusInfo,
+		Data:    sus.statusData,
+		Since:   &now,
+	}
+	err = u.SetAgentStatus(sInfo)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -2735,9 +2758,21 @@ func (uc setUnitCharmURL) step(c *gc.C, ctx *context) {
 	curl := charm.MustParseURL(uc.charm)
 	err = u.SetCharmURL(curl)
 	c.Assert(err, jc.ErrorIsNil)
-	err = u.SetStatus(status.StatusActive, "", nil)
+	// lp:1558657
+	now := time.Now()
+	s := status.StatusInfo{
+		Status:  status.StatusActive,
+		Message: "",
+		Since:   &now,
+	}
+	err = u.SetStatus(s)
 	c.Assert(err, jc.ErrorIsNil)
-	err = u.SetAgentStatus(status.StatusIdle, "", nil)
+	sInfo := status.StatusInfo{
+		Status:  status.StatusIdle,
+		Message: "",
+		Since:   &now,
+	}
+	err = u.SetAgentStatus(sInfo)
 	c.Assert(err, jc.ErrorIsNil)
 
 }
@@ -2800,9 +2835,16 @@ type setMachineStatus struct {
 }
 
 func (sms setMachineStatus) step(c *gc.C, ctx *context) {
+	// lp:1558657
+	now := time.Now()
 	m, err := ctx.st.Machine(sms.machineId)
 	c.Assert(err, jc.ErrorIsNil)
-	err = m.SetStatus(sms.status, sms.statusInfo, nil)
+	sInfo := status.StatusInfo{
+		Status:  sms.status,
+		Message: sms.statusInfo,
+		Since:   &now,
+	}
+	err = m.SetStatus(sInfo)
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/cmd/juju/user/info.go
+++ b/cmd/juju/user/info.go
@@ -134,6 +134,7 @@ func (c *infoCommand) Run(ctx *cmd.Context) (err error) {
 
 func (c *infoCommandBase) apiUsersToUserInfoSlice(users []params.UserInfo) []UserInfo {
 	var output []UserInfo
+	// TODO(perrito666) 2016-05-02 lp:1558657
 	var now = time.Now()
 	for _, info := range users {
 		outInfo := UserInfo{

--- a/cmd/juju/user/list_test.go
+++ b/cmd/juju/user/list_test.go
@@ -39,6 +39,7 @@ func (f *fakeUserListAPI) UserInfo(usernames []string, all usermanager.IncludeDi
 	if len(usernames) > 0 {
 		return nil, errors.Errorf("expected no usernames, got %d", len(usernames))
 	}
+	// lp:1558657
 	now := time.Now().UTC().Round(time.Second)
 	last1 := time.Date(2014, 1, 1, 0, 0, 0, 0, time.UTC)
 	// The extra two seconds here are needed to make sure

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -997,7 +997,7 @@ func (a *MachineAgent) startModelWorkers(uuid string) (worker.Worker, error) {
 		Clock:                       clock.WallClock,
 		RunFlagDuration:             time.Minute,
 		CharmRevisionUpdateInterval: 24 * time.Hour,
-		EntityStatusHistoryCount:    100,
+		EntityStatusHistoryCount:    5000,
 		EntityStatusHistoryInterval: 5 * time.Minute,
 		SpacesImportedGate:          a.discoverSpacesComplete,
 	})

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -997,9 +997,13 @@ func (a *MachineAgent) startModelWorkers(uuid string) (worker.Worker, error) {
 		Clock:                       clock.WallClock,
 		RunFlagDuration:             time.Minute,
 		CharmRevisionUpdateInterval: 24 * time.Hour,
-		EntityStatusHistoryCount:    5000,
-		EntityStatusHistoryInterval: 5 * time.Minute,
-		SpacesImportedGate:          a.discoverSpacesComplete,
+		// TODO(perrito666) the status history pruning numbers need
+		// to be adjusting, after collecting user data from large install
+		// bases, to numbers allowing a rich and useful back history.
+		StatusHistoryPrunerMaxHistoryTime: 336 * time.Hour, // 2 weeks
+		StatusHistoryPrunerMaxHistoryMB:   5120,            // 5G
+		StatusHistoryPrunerInterval:       5 * time.Minute,
+		SpacesImportedGate:                a.discoverSpacesComplete,
 	})
 	if err := dependency.Install(engine, manifolds); err != nil {
 		if err := worker.Stop(engine); err != nil {

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -453,7 +453,14 @@ func (s *MachineSuite) TestHostUnits(c *gc.C) {
 
 	// "start the agent" for u0 to prevent short-circuited remove-on-destroy;
 	// check that it's kept deployed despite being Dying.
-	err = u0.SetAgentStatus(status.StatusIdle, "", nil)
+	// lp:1558657
+	now := time.Now()
+	sInfo := status.StatusInfo{
+		Status:  status.StatusIdle,
+		Message: "",
+		Since:   &now,
+	}
+	err = u0.SetAgentStatus(sInfo)
 	c.Assert(err, jc.ErrorIsNil)
 	err = u0.Destroy()
 	c.Assert(err, jc.ErrorIsNil)

--- a/cmd/jujud/agent/model/manifolds.go
+++ b/cmd/jujud/agent/model/manifolds.go
@@ -71,10 +71,11 @@ type ManifoldsConfig struct {
 	// revision worker will check for new revisions of known charms.
 	CharmRevisionUpdateInterval time.Duration
 
-	// EntityStatusHistory* values control status-history pruning
-	// behaviour per entity.
-	EntityStatusHistoryCount    uint
-	EntityStatusHistoryInterval time.Duration
+	// StatusHistoryPruner* values control status-history pruning
+	// behaviour.
+	StatusHistoryPrunerMaxHistoryTime time.Duration
+	StatusHistoryPrunerMaxHistoryMB   uint
+	StatusHistoryPrunerInterval       time.Duration
 
 	// SpacesImportedGate will be unlocked when spaces are known to
 	// have been imported.
@@ -236,9 +237,10 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 			APICallerName: apiCallerName,
 		})),
 		statusHistoryPrunerName: ifNotDead(statushistorypruner.Manifold(statushistorypruner.ManifoldConfig{
-			APICallerName:    apiCallerName,
-			MaxLogsPerEntity: config.EntityStatusHistoryCount,
-			PruneInterval:    config.EntityStatusHistoryInterval,
+			APICallerName:  apiCallerName,
+			MaxHistoryTime: config.StatusHistoryPrunerMaxHistoryTime,
+			MaxHistoryMB:   config.StatusHistoryPrunerMaxHistoryMB,
+			PruneInterval:  config.StatusHistoryPrunerInterval,
 			// TODO(fwereade): 2016-03-17 lp:1558657
 			NewTimer: worker.NewTimer,
 		})),

--- a/container/lxc/clonetemplate.go
+++ b/container/lxc/clonetemplate.go
@@ -171,6 +171,7 @@ func EnsureCloneTemplate(
 		return nil, err
 	}
 
+	// TODO(perrito666) 2016-05-02 lp:1558657
 	tailWriter := &logTail{tick: time.Now()}
 	consoleTailer := tailer.NewTailer(console, tailWriter, nil)
 	defer consoleTailer.Stop()
@@ -179,6 +180,7 @@ func EnsureCloneTemplate(
 	// if no output check to see if stopped
 	// If we have no output and still running, something has probably gone wrong
 	for lxcContainer.IsRunning() {
+		// TODO(perrito666) 2016-05-02 lp:1558657
 		if tailWriter.lastTick().Before(time.Now().Add(-TemplateStopTimeout)) {
 			logger.Infof("not heard anything from the template log for five minutes")
 			callback(status.StatusProvisioningError, "Container creation failed: template container has not stopped", nil)
@@ -201,6 +203,7 @@ func (t *logTail) Write(data []byte) (int, error) {
 	logger.Tracef(string(data))
 	t.mutex.Lock()
 	defer t.mutex.Unlock()
+	// TODO(perrito666) 2016-05-02 lp:1558657
 	t.tick = time.Now()
 	return len(data), nil
 }

--- a/container/lxc/lxc.go
+++ b/container/lxc/lxc.go
@@ -183,6 +183,7 @@ func (manager *containerManager) CreateContainer(
 	}
 
 	// Log how long the start took
+	// TODO(perrito666) 2016-05-02 lp:1558657
 	defer func(start time.Time) {
 		if err == nil {
 			logger.Tracef("container %q started: %v", inst.Id(), time.Now().Sub(start))

--- a/environs/imagemetadata/generate.go
+++ b/environs/imagemetadata/generate.go
@@ -103,6 +103,7 @@ type MetadataFile struct {
 func writeMetadata(metadata []*ImageMetadata, cloudSpec []simplestreams.CloudSpec,
 	metadataStore storage.Storage) error {
 
+	// TODO(perrito666) 2016-05-02 lp:1558657
 	index, products, err := MarshalImageMetadataJSON(metadata, cloudSpec, time.Now())
 	if err != nil {
 		return err

--- a/environs/open.go
+++ b/environs/open.go
@@ -238,6 +238,7 @@ func ensureCertificate(cfg *config.Config) (*config.Config, string, error) {
 		return nil, "", errors.Errorf("controller configuration with a certificate but no CA private key")
 	}
 
+	// TODO(perrito666) 2016-05-02 lp:1558657
 	caCert, caKey, err := cert.NewCA(cfg.Name(), cfg.UUID(), time.Now().UTC().AddDate(10, 0, 0))
 	if err != nil {
 		return nil, "", errors.Trace(err)

--- a/environs/tools/simplestreams.go
+++ b/environs/tools/simplestreams.go
@@ -432,6 +432,7 @@ func metadataUnchanged(stor storage.Storage, stream string, generatedMetadata []
 // streamMetadata contains all known metadata so that the correct index files can be written.
 // Only product files for the specified streams are written.
 func WriteMetadata(stor storage.Storage, streamMetadata map[string][]*ToolsMetadata, streams []string, writeMirrors ShouldWriteMirrors) error {
+	// TODO(perrito666) 2016-05-02 lp:1558657
 	updated := time.Now()
 	index, legacyIndex, products, err := MarshalToolsMetadataJSON(streamMetadata, updated)
 	if err != nil {

--- a/environs/tools/testing/testing.go
+++ b/environs/tools/testing/testing.go
@@ -234,6 +234,7 @@ func generateMetadata(c *gc.C, stream string, versions ...version.Binary) []meta
 	var streamMetadata = map[string][]*tools.ToolsMetadata{
 		stream: metadata,
 	}
+	// TODO(perrito666) 2016-05-02 lp:1558657
 	index, legacyIndex, products, err := tools.MarshalToolsMetadataJSON(streamMetadata, time.Now())
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/featuretests/cmd_juju_controller_test.go
+++ b/featuretests/cmd_juju_controller_test.go
@@ -126,7 +126,13 @@ func (s *cmdControllerSuite) TestListDeadModels(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = m.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
-	err = m.SetStatus(status.StatusDestroying, "", nil)
+	now := time.Now()
+	sInfo := status.StatusInfo{
+		Status:  status.StatusDestroying,
+		Message: "",
+		Since:   &now,
+	}
+	err = m.SetStatus(sInfo)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Dead models still show up in the list. It's a lie to pretend they

--- a/provider/azure/environ_test.go
+++ b/provider/azure/environ_test.go
@@ -328,6 +328,7 @@ func prepareForBootstrap(
 }
 
 func tokenRefreshSender() *azuretesting.MockSender {
+	// lp:1558657
 	tokenRefreshSender := azuretesting.NewSenderWithValue(&autorestazure.Token{
 		AccessToken: "access-token",
 		ExpiresOn:   fmt.Sprint(time.Now().Add(time.Hour).Unix()),

--- a/provider/gce/google/raw.go
+++ b/provider/gce/google/raw.go
@@ -326,6 +326,7 @@ var doOpCall = func(call opDoer) (*compute.Operation, error) {
 // status. It follows the given attempt strategy (e.g. wait time between
 // attempts) and may time out.
 func (rc *rawConn) waitOperation(projectID string, op *compute.Operation, attempts utils.AttemptStrategy) error {
+	// TODO(perrito666) 2016-05-02 lp:1558657
 	started := time.Now()
 	logger.Infof("GCE operation %q, waiting...", op.Name)
 	for a := attempts.Start(); a.Next(); {
@@ -340,6 +341,7 @@ func (rc *rawConn) waitOperation(projectID string, op *compute.Operation, attemp
 		}
 	}
 	if op.Status != StatusDone {
+		// lp:1558657
 		err := errors.Errorf("timed out after %d seconds", time.Now().Sub(started)/time.Second)
 		return waitError{op, err}
 	}

--- a/provider/openstack/storage.go
+++ b/provider/openstack/storage.go
@@ -65,6 +65,7 @@ func (s *openstackstorage) Get(file string) (io.ReadCloser, error) {
 
 func (s *openstackstorage) URL(name string) (string, error) {
 	// 10 years should be good enough.
+	// TODO(perrito666) 2016-05-02 lp:1558657
 	expires := time.Now().AddDate(10, 0, 0)
 	return s.swift.SignedURL(s.containerName, name, expires)
 }

--- a/resource/resourcetesting/resource.go
+++ b/resource/resourcetesting/resource.go
@@ -63,6 +63,7 @@ func NewPlaceholderResource(c *gc.C, name, serviceID string) resource.Resource {
 func newResource(c *gc.C, name, serviceID, username, content string) resource.Resource {
 	var timestamp time.Time
 	if username != "" {
+		// TODO(perrito666) 2016-05-02 lp:1558657
 		timestamp = time.Now().UTC()
 	}
 	res := resource.Resource{

--- a/resource/state/state.go
+++ b/resource/state/state.go
@@ -52,6 +52,7 @@ func NewState(raw RawState) *State {
 			storage:      storage,
 			newPendingID: newPendingID,
 			currentTimestamp: func() time.Time {
+				// TODO(perrito666) 2016-05-02 lp:1558657
 				return time.Now().UTC()
 			},
 		},

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -442,6 +442,7 @@ func (conn *Conn) readBody(resp interface{}, isRequest bool) error {
 }
 
 func (conn *Conn) handleRequest(hdr *Header) error {
+	// TODO(perrito666) 2016-05-02 lp:1558657
 	startTime := time.Now()
 	req, err := conn.bindRequest(hdr)
 	if err != nil {

--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -374,7 +374,7 @@ func allCollections() collectionSchema {
 		statusesC:           {},
 		statusesHistoryC: {
 			indexes: []mgo.Index{{
-				Key: []string{"model-uuid", "globalkey"},
+				Key: []string{"model-uuid", "globalkey", "updated"},
 			}},
 		},
 

--- a/state/allwatcher_internal_test.go
+++ b/state/allwatcher_internal_test.go
@@ -204,7 +204,13 @@ func (s *allWatcherBaseSuite) setUpScenario(c *gc.C, st *State, units int) (enti
 
 		err = m.SetProvisioned(instance.Id("i-"+m.Tag().String()), "fake_nonce", nil)
 		c.Assert(err, jc.ErrorIsNil)
-		err = m.SetStatus(status.StatusError, m.Tag().String(), nil)
+		now := time.Now()
+		sInfo := status.StatusInfo{
+			Status:  status.StatusError,
+			Message: m.Tag().String(),
+			Since:   &now,
+		}
+		err = m.SetStatus(sInfo)
 		c.Assert(err, jc.ErrorIsNil)
 		hc, err := m.HardwareCharacteristics()
 		c.Assert(err, jc.ErrorIsNil)
@@ -992,7 +998,13 @@ func (s *allWatcherStateSuite) TestStateWatcherTwoModels(c *gc.C) {
 				m, err := st.Machine("0")
 				c.Assert(err, jc.ErrorIsNil)
 
-				err = m.SetStatus("error", "pete tong", nil)
+				now := time.Now()
+				sInfo := status.StatusInfo{
+					Status:  status.StatusError,
+					Message: "pete tong",
+					Since:   &now,
+				}
+				err = m.SetStatus(sInfo)
 				c.Assert(err, jc.ErrorIsNil)
 			},
 		}, {
@@ -1732,7 +1744,13 @@ func testChangeMachines(c *gc.C, runChangeTests func(*gc.C, []changeTestFunc)) {
 		func(c *gc.C, st *State) changeTestCase {
 			m, err := st.AddMachine("quantal", JobHostUnits)
 			c.Assert(err, jc.ErrorIsNil)
-			err = m.SetStatus(status.StatusError, "failure", nil)
+			now := time.Now()
+			sInfo := status.StatusInfo{
+				Status:  status.StatusError,
+				Message: "failure",
+				Since:   &now,
+			}
+			err = m.SetStatus(sInfo)
 			c.Assert(err, jc.ErrorIsNil)
 
 			return changeTestCase{
@@ -1847,7 +1865,13 @@ func testChangeMachines(c *gc.C, runChangeTests func(*gc.C, []changeTestFunc)) {
 		func(c *gc.C, st *State) changeTestCase {
 			m, err := st.AddMachine("quantal", JobHostUnits)
 			c.Assert(err, jc.ErrorIsNil)
-			err = m.SetStatus(status.StatusStarted, "", nil)
+			now := time.Now()
+			sInfo := status.StatusInfo{
+				Status:  status.StatusStarted,
+				Message: "",
+				Since:   &now,
+			}
+			err = m.SetStatus(sInfo)
 			c.Assert(err, jc.ErrorIsNil)
 
 			return changeTestCase{
@@ -2286,7 +2310,13 @@ func testChangeUnits(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, []
 			c.Assert(err, jc.ErrorIsNil)
 			err = u.OpenPorts("tcp", 5555, 5558)
 			c.Assert(err, jc.ErrorIsNil)
-			err = u.SetAgentStatus(status.StatusError, "failure", nil)
+			now := time.Now()
+			sInfo := status.StatusInfo{
+				Status:  status.StatusError,
+				Message: "failure",
+				Since:   &now,
+			}
+			err = u.SetAgentStatus(sInfo)
 			c.Assert(err, jc.ErrorIsNil)
 
 			return changeTestCase{
@@ -2485,7 +2515,13 @@ func testChangeUnits(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, []
 			privateAddress := network.NewScopedAddress("private", network.ScopeCloudLocal)
 			err = m.SetProviderAddresses(publicAddress, privateAddress)
 			c.Assert(err, jc.ErrorIsNil)
-			err = u.SetAgentStatus(status.StatusError, "failure", nil)
+			now := time.Now()
+			sInfo := status.StatusInfo{
+				Status:  status.StatusError,
+				Message: "failure",
+				Since:   &now,
+			}
+			err = u.SetAgentStatus(sInfo)
 			c.Assert(err, jc.ErrorIsNil)
 
 			return changeTestCase{
@@ -2570,7 +2606,13 @@ func testChangeUnits(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, []
 			wordpress := AddTestingService(c, st, "wordpress", AddTestingCharm(c, st, "wordpress"), owner)
 			u, err := wordpress.AddUnit()
 			c.Assert(err, jc.ErrorIsNil)
-			err = u.SetAgentStatus(status.StatusIdle, "", nil)
+			now := time.Now()
+			sInfo := status.StatusInfo{
+				Status:  status.StatusIdle,
+				Message: "",
+				Since:   &now,
+			}
+			err = u.SetAgentStatus(sInfo)
 			c.Assert(err, jc.ErrorIsNil)
 
 			return changeTestCase{
@@ -2617,9 +2659,20 @@ func testChangeUnits(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, []
 			wordpress := AddTestingService(c, st, "wordpress", AddTestingCharm(c, st, "wordpress"), owner)
 			u, err := wordpress.AddUnit()
 			c.Assert(err, jc.ErrorIsNil)
-			err = u.SetAgentStatus(status.StatusIdle, "", nil)
+			now := time.Now()
+			sInfo := status.StatusInfo{
+				Status:  status.StatusIdle,
+				Message: "",
+				Since:   &now,
+			}
+			err = u.SetAgentStatus(sInfo)
 			c.Assert(err, jc.ErrorIsNil)
-			err = u.SetStatus(status.StatusMaintenance, "doing work", nil)
+			sInfo = status.StatusInfo{
+				Status:  status.StatusMaintenance,
+				Message: "doing work",
+				Since:   &now,
+			}
+			err = u.SetStatus(sInfo)
 			c.Assert(err, jc.ErrorIsNil)
 
 			return changeTestCase{
@@ -2666,11 +2719,18 @@ func testChangeUnits(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, []
 			wordpress := AddTestingService(c, st, "wordpress", AddTestingCharm(c, st, "wordpress"), owner)
 			u, err := wordpress.AddUnit()
 			c.Assert(err, jc.ErrorIsNil)
-			err = u.SetAgentStatus(status.StatusError, "hook error", map[string]interface{}{
-				"1st-key": "one",
-				"2nd-key": 2,
-				"3rd-key": true,
-			})
+			now := time.Now()
+			sInfo := status.StatusInfo{
+				Status:  status.StatusError,
+				Message: "hook error",
+				Data: map[string]interface{}{
+					"1st-key": "one",
+					"2nd-key": 2,
+					"3rd-key": true,
+				},
+				Since: &now,
+			}
+			err = u.SetAgentStatus(sInfo)
 			c.Assert(err, jc.ErrorIsNil)
 
 			return changeTestCase{
@@ -2719,7 +2779,13 @@ func testChangeUnits(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, []
 			wordpress := AddTestingService(c, st, "wordpress", AddTestingCharm(c, st, "wordpress"), owner)
 			u, err := wordpress.AddUnit()
 			c.Assert(err, jc.ErrorIsNil)
-			err = u.SetStatus(status.StatusActive, "", nil)
+			now := time.Now()
+			sInfo := status.StatusInfo{
+				Status:  status.StatusActive,
+				Message: "",
+				Since:   &now,
+			}
+			err = u.SetStatus(sInfo)
 			c.Assert(err, jc.ErrorIsNil)
 
 			return changeTestCase{

--- a/state/backups/storage.go
+++ b/state/backups/storage.go
@@ -458,6 +458,7 @@ func (s *backupsMetadataStorage) SetStored(id string) error {
 	dbWrap := newStorageDBWrapper(s.db, storageMetaName, s.modelUUID)
 	defer dbWrap.Close()
 
+	// TODO(perrito666) 2016-05-02 lp:1558657
 	err := setStorageStoredTime(dbWrap, id, time.Now())
 	return errors.Trace(err)
 }

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/juju/juju/core/lease"
 	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/network"
+	"github.com/juju/juju/status"
 	"github.com/juju/juju/testcharms"
 )
 
@@ -498,4 +499,17 @@ func AssertEndpointBindingsNotFoundForService(c *gc.C, service *Service) {
 
 func LeadershipLeases(st *State) map[string]lease.Info {
 	return st.leadershipClient.Leases()
+}
+
+// ProbablyUpdateUnitStatusHistory will try to add a status history entry using a date
+// padded back by <delta> time.
+func ProbablyUpdateUnitStatusHistory(st *State, u *Unit, histStatus status.Status, message string, delta time.Duration) {
+	now := time.Now().Add(-delta)
+	doc := statusDoc{
+		Status:     histStatus,
+		StatusInfo: message,
+		StatusData: map[string]interface{}{},
+		Updated:    now.UnixNano(),
+	}
+	probablyUpdateStatusHistory(st, u.globalKey(), doc)
 }

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/juju/juju/core/lease"
 	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/network"
-	"github.com/juju/juju/status"
 	"github.com/juju/juju/testcharms"
 )
 
@@ -499,17 +498,4 @@ func AssertEndpointBindingsNotFoundForService(c *gc.C, service *Service) {
 
 func LeadershipLeases(st *State) map[string]lease.Info {
 	return st.leadershipClient.Leases()
-}
-
-// ProbablyUpdateUnitStatusHistory will try to add a status history entry using a date
-// padded back by <delta> time.
-func ProbablyUpdateUnitStatusHistory(st *State, u *Unit, histStatus status.Status, message string, delta time.Duration) {
-	now := time.Now().Add(-delta)
-	doc := statusDoc{
-		Status:     histStatus,
-		StatusInfo: message,
-		StatusData: map[string]interface{}{},
-		Updated:    now.UnixNano(),
-	}
-	probablyUpdateStatusHistory(st, u.globalKey(), doc)
 }

--- a/state/filesystem.go
+++ b/state/filesystem.go
@@ -275,8 +275,8 @@ func (f *filesystem) Status() (status.StatusInfo, error) {
 }
 
 // SetStatus is required to implement StatusSetter.
-func (f *filesystem) SetStatus(fsStatus status.Status, info string, data map[string]interface{}) error {
-	return f.st.SetFilesystemStatus(f.FilesystemTag(), fsStatus, info, data)
+func (f *filesystem) SetStatus(fsStatus status.StatusInfo) error {
+	return f.st.SetFilesystemStatus(f.FilesystemTag(), fsStatus.Status, fsStatus.Message, fsStatus.Data, fsStatus.Since)
 }
 
 // Filesystem is required to implement FilesystemAttachment.
@@ -1140,7 +1140,7 @@ func (st *State) FilesystemStatus(tag names.FilesystemTag) (status.StatusInfo, e
 }
 
 // SetFilesystemStatus sets the status of the specified filesystem.
-func (st *State) SetFilesystemStatus(tag names.FilesystemTag, fsStatus status.Status, info string, data map[string]interface{}) error {
+func (st *State) SetFilesystemStatus(tag names.FilesystemTag, fsStatus status.Status, info string, data map[string]interface{}, updated *time.Time) error {
 	switch fsStatus {
 	case status.StatusAttaching, status.StatusAttached, status.StatusDetaching, status.StatusDetached, status.StatusDestroying:
 	case status.StatusError:
@@ -1168,5 +1168,6 @@ func (st *State) SetFilesystemStatus(tag names.FilesystemTag, fsStatus status.St
 		status:    fsStatus,
 		message:   info,
 		rawData:   data,
+		updated:   updated,
 	})
 }

--- a/state/machine.go
+++ b/state/machine.go
@@ -1001,12 +1001,18 @@ func (m *Machine) SetInstanceStatus(instanceStatus status.Status, info string, d
 
 }
 
-// InstanceStatusHistory returns a slice of at most <size> StatusInfo items
+// InstanceStatusHistory returns a slice of at most filter.Size StatusInfo items
+// or items as old as filter.Date or items newer than now - filter.Delta time
 // representing past statuses for this machine instance.
 // Instance represents the provider underlying [v]hardware or container where
 // this juju machine is deployed.
-func (u *Machine) InstanceStatusHistory(size int) ([]status.StatusInfo, error) {
-	return statusHistory(u.st, u.globalInstanceKey(), size)
+func (m *Machine) InstanceStatusHistory(filter status.StatusHistoryFilter) ([]status.StatusInfo, error) {
+	args := &statusHistoryArgs{
+		st:        m.st,
+		globalKey: m.globalInstanceKey(),
+		filter:    filter,
+	}
+	return statusHistory(args)
 }
 
 // AvailabilityZone returns the provier-specific instance availability
@@ -1540,10 +1546,16 @@ func (m *Machine) SetStatus(machineStatus status.Status, info string, data map[s
 	})
 }
 
-// StatusHistory returns a slice of at most <size> StatusInfo items
+// StatusHistory returns a slice of at most filter.Size StatusInfo items
+// or items as old as filter.Date or items newer than now - filter.Delta time
 // representing past statuses for this machine.
-func (m *Machine) StatusHistory(size int) ([]status.StatusInfo, error) {
-	return statusHistory(m.st, m.globalKey(), size)
+func (m *Machine) StatusHistory(filter status.StatusHistoryFilter) ([]status.StatusInfo, error) {
+	args := &statusHistoryArgs{
+		st:        m.st,
+		globalKey: m.globalKey(),
+		filter:    filter,
+	}
+	return statusHistory(args)
 }
 
 // Clean returns true if the machine does not have any deployed units or containers.

--- a/state/machine.go
+++ b/state/machine.go
@@ -990,13 +990,14 @@ func (m *Machine) InstanceStatus() (status.StatusInfo, error) {
 }
 
 // SetInstanceStatus sets the provider specific instance status for a machine.
-func (m *Machine) SetInstanceStatus(instanceStatus status.Status, info string, data map[string]interface{}) (err error) {
+func (m *Machine) SetInstanceStatus(sInfo status.StatusInfo) (err error) {
 	return setStatus(m.st, setStatusParams{
 		badge:     "instance",
 		globalKey: m.globalInstanceKey(),
-		status:    instanceStatus,
-		message:   info,
-		rawData:   data,
+		status:    sInfo.Status,
+		message:   sInfo.Message,
+		rawData:   sInfo.Data,
+		updated:   sInfo.Since,
 	})
 
 }
@@ -1516,12 +1517,12 @@ func (m *Machine) Status() (status.StatusInfo, error) {
 }
 
 // SetStatus sets the status of the machine.
-func (m *Machine) SetStatus(machineStatus status.Status, info string, data map[string]interface{}) error {
-	switch machineStatus {
+func (m *Machine) SetStatus(statusInfo status.StatusInfo) error {
+	switch statusInfo.Status {
 	case status.StatusStarted, status.StatusStopped:
 	case status.StatusError:
-		if info == "" {
-			return errors.Errorf("cannot set status %q without info", machineStatus)
+		if statusInfo.Message == "" {
+			return errors.Errorf("cannot set status %q without info", statusInfo.Status)
 		}
 	case status.StatusPending:
 		// If a machine is not yet provisioned, we allow its status
@@ -1533,16 +1534,17 @@ func (m *Machine) SetStatus(machineStatus status.Status, info string, data map[s
 		}
 		fallthrough
 	case status.StatusDown:
-		return errors.Errorf("cannot set status %q", machineStatus)
+		return errors.Errorf("cannot set status %q", statusInfo.Status)
 	default:
-		return errors.Errorf("cannot set invalid status %q", machineStatus)
+		return errors.Errorf("cannot set invalid status %q", statusInfo.Status)
 	}
 	return setStatus(m.st, setStatusParams{
 		badge:     "machine",
 		globalKey: m.globalKey(),
-		status:    machineStatus,
-		message:   info,
-		rawData:   data,
+		status:    statusInfo.Status,
+		message:   statusInfo.Message,
+		rawData:   statusInfo.Data,
+		updated:   statusInfo.Since,
 	})
 }
 
@@ -1649,8 +1651,15 @@ func (m *Machine) markInvalidContainers() error {
 			}
 			if statusInfo.Status == status.StatusPending {
 				containerType := ContainerTypeFromId(containerId)
-				container.SetStatus(
-					status.StatusError, "unsupported container", map[string]interface{}{"type": containerType})
+				// TODO(perrito666) 2016-05-02 lp:1558657
+				now := time.Now()
+				s := status.StatusInfo{
+					Status:  status.StatusError,
+					Message: "unsupported container",
+					Data:    map[string]interface{}{"type": containerType},
+					Since:   &now,
+				}
+				container.SetStatus(s)
 			} else {
 				logger.Errorf("unsupported container %v has unexpected status %v", containerId, statusInfo.Status)
 			}

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -5,6 +5,7 @@ package state_test
 
 import (
 	"sort"
+	"time"
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
@@ -967,7 +968,13 @@ func (s *MachineSuite) TestMachineSetInstanceStatus(c *gc.C) {
 	err := s.machine.SetProvisioned("umbrella/0", "fake_nonce", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = s.machine.SetInstanceStatus(status.StatusRunning, "alive", map[string]interface{}{})
+	now := time.Now()
+	sInfo := status.StatusInfo{
+		Status:  status.StatusRunning,
+		Message: "alive",
+		Since:   &now,
+	}
+	err = s.machine.SetInstanceStatus(sInfo)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Reload machine and check result.
@@ -1214,7 +1221,13 @@ func (s *MachineSuite) TestWatchPrincipalUnits(c *gc.C) {
 	wc.AssertNoChange()
 
 	// Change the unit; no change.
-	err = mysql0.SetAgentStatus(status.StatusIdle, "", nil)
+	now := time.Now()
+	sInfo := status.StatusInfo{
+		Status:  status.StatusIdle,
+		Message: "",
+		Since:   &now,
+	}
+	err = mysql0.SetAgentStatus(sInfo)
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertNoChange()
 
@@ -1243,7 +1256,12 @@ func (s *MachineSuite) TestWatchPrincipalUnits(c *gc.C) {
 	wc.AssertNoChange()
 
 	// Change the subordinate; no change.
-	err = logging0.SetAgentStatus(status.StatusIdle, "", nil)
+	sInfo = status.StatusInfo{
+		Status:  status.StatusIdle,
+		Message: "",
+		Since:   &now,
+	}
+	err = logging0.SetAgentStatus(sInfo)
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertNoChange()
 
@@ -1318,7 +1336,13 @@ func (s *MachineSuite) TestWatchUnits(c *gc.C) {
 	wc.AssertNoChange()
 
 	// Change the unit; no change.
-	err = mysql0.SetAgentStatus(status.StatusIdle, "", nil)
+	now := time.Now()
+	sInfo := status.StatusInfo{
+		Status:  status.StatusIdle,
+		Message: "",
+		Since:   &now,
+	}
+	err = mysql0.SetAgentStatus(sInfo)
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertNoChange()
 
@@ -1348,7 +1372,12 @@ func (s *MachineSuite) TestWatchUnits(c *gc.C) {
 	wc.AssertNoChange()
 
 	// Change the subordinate; no change.
-	err = logging0.SetAgentStatus(status.StatusIdle, "", nil)
+	sInfo = status.StatusInfo{
+		Status:  status.StatusIdle,
+		Message: "",
+		Since:   &now,
+	}
+	err = logging0.SetAgentStatus(sInfo)
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertNoChange()
 

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -59,7 +59,7 @@ func (s *MigrationSuite) setRandSequenceValue(c *gc.C, name string) int {
 func (s *MigrationSuite) primeStatusHistory(c *gc.C, entity statusSetter, statusVal status.Status, count int) {
 	primeStatusHistory(c, entity, statusVal, count, func(i int) map[string]interface{} {
 		return map[string]interface{}{"index": count - i}
-	})
+	}, 0)
 }
 
 func (s *MigrationSuite) makeServiceWithLeader(c *gc.C, serviceName string, count int, leader int) {

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -28,9 +28,9 @@ type MigrationImportSuite struct {
 var _ = gc.Suite(&MigrationImportSuite{})
 
 func (s *MigrationImportSuite) checkStatusHistory(c *gc.C, exported, imported status.StatusHistoryGetter, size int) {
-	exportedHistory, err := exported.StatusHistory(size)
+	exportedHistory, err := exported.StatusHistory(status.StatusHistoryFilter{Size: size})
 	c.Assert(err, jc.ErrorIsNil)
-	importedHistory, err := imported.StatusHistory(size)
+	importedHistory, err := imported.StatusHistory(status.StatusHistoryFilter{Size: size})
 	c.Assert(err, jc.ErrorIsNil)
 	for i := 0; i < size; i++ {
 		c.Check(importedHistory[i].Status, gc.Equals, exportedHistory[i].Status)

--- a/state/model.go
+++ b/state/model.go
@@ -306,21 +306,22 @@ func (m *Model) Status() (status.StatusInfo, error) {
 }
 
 // SetStatus sets the status of the model.
-func (m *Model) SetStatus(modelStatus status.Status, info string, data map[string]interface{}) error {
+func (m *Model) SetStatus(sInfo status.StatusInfo) error {
 	st, closeState, err := m.getState()
 	if err != nil {
 		return errors.Trace(err)
 	}
 	defer closeState()
-	if !status.ValidModelStatus(modelStatus) {
-		return errors.Errorf("cannot set invalid status %q", modelStatus)
+	if !status.ValidModelStatus(sInfo.Status) {
+		return errors.Errorf("cannot set invalid status %q", sInfo.Status)
 	}
 	return setStatus(st, setStatusParams{
 		badge:     "model",
 		globalKey: m.globalKey(),
-		status:    modelStatus,
-		message:   info,
-		rawData:   data,
+		status:    sInfo.Status,
+		message:   sInfo.Message,
+		rawData:   sInfo.Data,
+		updated:   sInfo.Since,
 	})
 }
 

--- a/state/presence/presence.go
+++ b/state/presence/presence.go
@@ -386,6 +386,7 @@ func (w *Watcher) sync() error {
 			return errors.Trace(err)
 		}
 	}
+	// TODO(perrito666) 2016-05-02 lp:1558657
 	s := timeSlot(time.Now(), w.delta)
 	slot := docIDInt64(w.modelUUID, s)
 	previousSlot := docIDInt64(w.modelUUID, s-period)
@@ -618,6 +619,7 @@ func (p *Pinger) killStopped() error {
 	if err := p.prepare(); err != nil {
 		return err
 	}
+	// TODO(perrito666) 2016-05-02 lp:1558657
 	slot := timeSlot(time.Now(), p.delta)
 	udoc := bson.D{
 		{"$set", bson.D{{"slot", slot}}},
@@ -700,6 +702,7 @@ func (p *Pinger) ping() (err error) {
 		}
 		p.delta = delta
 	}
+	// TODO(perrito666) 2016-05-02 lp:1558657
 	slot := timeSlot(time.Now(), p.delta)
 	if slot == p.lastSlot {
 		// Never, ever, ping the same slot twice.
@@ -737,8 +740,10 @@ func clockDelta(c *mgo.Collection) (time.Duration, error) {
 		if supportsMasterLocalTime {
 			// Try isMaster.localTime, which is present since MongoDB 2.2
 			// and does not require admin privileges.
+			// TODO(perrito666) 2016-05-02 lp:1558657
 			before = time.Now()
 			err := db.Run("isMaster", &isMaster)
+			// TODO(perrito666) 2016-05-02 lp:1558657
 			after = time.Now()
 			if err != nil {
 				return 0, errors.Trace(err)
@@ -763,8 +768,10 @@ func clockDelta(c *mgo.Collection) (time.Duration, error) {
 			// eval could take a relatively long time to acquire
 			// the lock and thus cause a retry on the callDelay
 			// check below on a busy server.
+			// TODO(perrito666) 2016-05-02 lp:1558657
 			before = time.Now()
 			err := db.Run(bson.D{{"$eval", "function() { return new Date(); }"}}, &server)
+			// TODO(perrito666) 2016-05-02 lp:1558657
 			after = time.Now()
 			if err != nil {
 				return 0, errors.Trace(err)

--- a/state/resources_mongo.go
+++ b/state/resources_mongo.go
@@ -208,6 +208,7 @@ func newResolvePendingResourceOps(pending storedResource, exists bool) []txn.Op 
 		Remove: true,
 	}}
 
+	// TODO(perrito666) 2016-05-02 lp:1558657
 	csRes := charmStoreResource{
 		Resource:   newRes.Resource.Resource,
 		id:         newRes.ID,

--- a/state/service.go
+++ b/state/service.go
@@ -1566,10 +1566,16 @@ func (s *Service) SetStatus(serviceStatus status.Status, info string, data map[s
 	})
 }
 
-// StatusHistory returns a slice of at most <size> StatusInfo items
+// StatusHistory returns a slice of at most filter.Size StatusInfo items
+// or items as old as filter.Date or items newer than now - filter.Delta time
 // representing past statuses for this service.
-func (s *Service) StatusHistory(size int) ([]status.StatusInfo, error) {
-	return statusHistory(s.st, s.globalKey(), size)
+func (s *Service) StatusHistory(filter status.StatusHistoryFilter) ([]status.StatusInfo, error) {
+	args := &statusHistoryArgs{
+		st:        s.st,
+		globalKey: s.globalKey(),
+		filter:    filter,
+	}
+	return statusHistory(args)
 }
 
 // ServiceAndUnitsStatus returns the status for this service and all its units.

--- a/state/service.go
+++ b/state/service.go
@@ -1553,16 +1553,17 @@ func (s *Service) Status() (status.StatusInfo, error) {
 }
 
 // SetStatus sets the status for the service.
-func (s *Service) SetStatus(serviceStatus status.Status, info string, data map[string]interface{}) error {
-	if !status.ValidWorkloadStatus(serviceStatus) {
-		return errors.Errorf("cannot set invalid status %q", serviceStatus)
+func (s *Service) SetStatus(statusInfo status.StatusInfo) error {
+	if !status.ValidWorkloadStatus(statusInfo.Status) {
+		return errors.Errorf("cannot set invalid status %q", statusInfo.Status)
 	}
 	return setStatus(s.st, setStatusParams{
 		badge:     "service",
 		globalKey: s.globalKey(),
-		status:    serviceStatus,
-		message:   info,
-		rawData:   data,
+		status:    statusInfo.Status,
+		message:   statusInfo.Message,
+		rawData:   statusInfo.Data,
+		updated:   statusInfo.Since,
 	})
 }
 

--- a/state/service_test.go
+++ b/state/service_test.go
@@ -6,6 +6,7 @@ package state_test
 import (
 	"fmt"
 	"sort"
+	"time"
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
@@ -2073,15 +2074,26 @@ func (s *ServiceSuite) TestMetricCredentialsOnDying(c *gc.C) {
 func (s *ServiceSuite) testStatus(c *gc.C, status1, status2, expected status.Status) {
 	u1, err := s.mysql.AddUnit()
 	c.Assert(err, jc.ErrorIsNil)
-	err = u1.SetStatus(status1, "status 1", nil)
+	now := time.Now()
+	sInfo := status.StatusInfo{
+		Status:  status1,
+		Message: "status 1",
+		Since:   &now,
+	}
+	err = u1.SetStatus(sInfo)
 	c.Assert(err, jc.ErrorIsNil)
 
 	u2, err := s.mysql.AddUnit()
 	c.Assert(err, jc.ErrorIsNil)
+	sInfo = status.StatusInfo{
+		Status:  status2,
+		Message: "status 2",
+		Since:   &now,
+	}
 	if status2 == status.StatusError {
-		err = u2.SetAgentStatus(status2, "status 2", nil)
+		err = u2.SetAgentStatus(sInfo)
 	} else {
-		err = u2.SetStatus(status2, "status 2", nil)
+		err = u2.SetStatus(sInfo)
 	}
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -56,7 +56,13 @@ var alternatePassword = "bar-12345678901234567890"
 // asserting the behaviour of a given method in each state, and the unit quick-
 // remove change caused many of these to fail.
 func preventUnitDestroyRemove(c *gc.C, u *state.Unit) {
-	err := u.SetAgentStatus(status.StatusIdle, "", nil)
+	now := time.Now()
+	sInfo := status.StatusInfo{
+		Status:  status.StatusIdle,
+		Message: "",
+		Since:   &now,
+	}
+	err := u.SetAgentStatus(sInfo)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -494,7 +500,13 @@ func (s *MultiEnvStateSuite) TestWatchTwoEnvironments(c *gc.C) {
 				m, err := st.Machine("0")
 				c.Assert(err, jc.ErrorIsNil)
 
-				err = m.SetStatus("error", "some status", nil)
+				now := time.Now()
+				sInfo := status.StatusInfo{
+					Status:  status.StatusError,
+					Message: "some status",
+					Since:   &now,
+				}
+				err = m.SetStatus(sInfo)
 				c.Assert(err, jc.ErrorIsNil)
 			},
 		}, {

--- a/state/status.go
+++ b/state/status.go
@@ -117,23 +117,20 @@ type setStatusParams struct {
 	// token, if present, must accept an *[]txn.Op passed to its Check method,
 	// and will prevent any change if it becomes invalid.
 	token leadership.Token
+
+	// udpated, the time the status was set.
+	updated *time.Time
 }
 
 // setStatus inteprets the supplied params as documented on the type.
 func setStatus(st *State, params setStatusParams) (err error) {
 	defer errors.DeferredAnnotatef(&err, "cannot set status")
 
-	// TODO(fwereade): this can/should probably be recording the time the
-	// status was *set*, not the time it happened to arrive in state.
-	// We should almost certainly be accepting StatusInfo in the exposed
-	// SetStatus methods, for symetry with the Status methods.
-	// TODO(fwereade): 2016-03-17 lp:1558657
-	now := time.Now().UnixNano()
 	doc := statusDoc{
 		Status:     params.status,
 		StatusInfo: params.message,
 		StatusData: escapeKeys(params.rawData),
-		Updated:    now,
+		Updated:    params.updated.UnixNano(),
 	}
 	probablyUpdateStatusHistory(st, params.globalKey, doc)
 
@@ -241,6 +238,7 @@ func statusHistory(args *statusHistoryArgs) ([]status.StatusInfo, error) {
 	baseQuery := bson.M{"globalkey": args.globalKey}
 	if filter.Delta != nil {
 		delta := *filter.Delta
+		// TODO(perrito666) 2016-05-02 lp:1558657
 		updated := time.Now().Add(-delta)
 		baseQuery = bson.M{"updated": bson.M{"$gt": updated.UnixNano()}, "globalkey": args.globalKey}
 	}
@@ -272,68 +270,73 @@ func statusHistory(args *statusHistoryArgs) ([]status.StatusInfo, error) {
 }
 
 // PruneStatusHistory removes status history entries until
-// only the maxLogsPerEntity newest records per unit remain.
-func PruneStatusHistory(st *State, maxLogsPerEntity int) error {
-	history, closer := st.getCollection(statusesHistoryC)
+// only logs newer than <maxLogTime> remain and also ensures
+// that the collection is smaller than <maxLogsMB> after the
+// deletion.
+func PruneStatusHistory(st *State, maxHistoryTime time.Duration, maxHistoryMB int) error {
+	if maxHistoryMB < 0 {
+		return errors.NotValidf("non-positive maxHistoryMB")
+	}
+	if maxHistoryTime < 0 {
+		return errors.NotValidf("non-positive maxHistoryTime")
+	}
+	if maxHistoryMB == 0 && maxHistoryTime == 0 {
+		return errors.NotValidf("backlog size and time constraints are both 0")
+	}
+	history, closer := st.getRawCollection(statusesHistoryC)
 	defer closer()
 
-	historyW := history.Writeable()
-
-	// TODO(fwereade): This is a very strange implementation.
-	//
-	// It goes to a lot of effort to keep a *different* span of history for
-	// each entity -- which effectively hides interaction history older than
-	// the recorded span of the most-frequently-updated object.
-	//
-	// It would be much less surprising -- and much more efficient -- to keep
-	// either a fixed total number of records, or a fixed total span of history,
-	// -- but either way we should be deleting only the oldest records at any
-	// given time.
-	globalKeys, err := getEntitiesWithStatuses(historyW)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	for _, globalKey := range globalKeys {
-		keepUpTo, ok, err := getOldestTimeToKeep(historyW, globalKey, maxLogsPerEntity)
-		if err != nil {
-			return errors.Trace(err)
-		}
-		if !ok {
-			continue
-		}
-		_, err = historyW.RemoveAll(bson.D{
-			{"globalkey", globalKey},
-			{"updated", bson.M{"$lt": keepUpTo}},
+	// Status Record Age
+	// TODO(perrito666): 2016-04-26 lp:1558657
+	if maxHistoryTime > 0 {
+		t := time.Now().Add(-maxHistoryTime)
+		_, err := history.RemoveAll(bson.D{
+			{"updated", bson.M{"$lt": t.UnixNano()}},
 		})
 		if err != nil {
 			return errors.Trace(err)
 		}
 	}
-	return nil
-}
-
-// getOldestTimeToKeep returns the create time for the oldest
-// status log to be kept.
-func getOldestTimeToKeep(coll mongo.Collection, globalKey string, size int) (int64, bool, error) {
+	if maxHistoryMB == 0 {
+		return nil
+	}
+	// Collection Size
+	collMB, err := getCollectionMB(history)
+	if err != nil {
+		return errors.Annotate(err, "retrieving status history collection size")
+	}
+	if collMB <= maxHistoryMB {
+		return nil
+	}
+	// TODO(perrito666) explore if there would be any beneffit from having the
+	// size limit be per model
+	count, err := history.Count()
+	if err == mgo.ErrNotFound || count <= 0 {
+		return nil
+	}
+	if err != nil {
+		return errors.Annotate(err, "counting status history records")
+	}
+	// We are making the assumption that status sizes can be averaged for
+	// large numbers and we will get a reasonable approach on the size.
+	// Note: Capped collections are not used for this because they, currently
+	// at least, lack a way to be resized and the size is expected to change
+	// as real life data of the history usage is gathered.
+	sizePerStatus := float64(collMB) / float64(count)
+	if sizePerStatus == 0 {
+		return errors.New("unexpected result calculating status history entry size")
+	}
+	deleteStatuses := count - int(float64(collMB-maxHistoryMB)/sizePerStatus)
 	result := historicalStatusDoc{}
-	err := coll.Find(bson.D{{"globalkey", globalKey}}).Sort("-updated").Skip(size - 1).One(&result)
-	if err == mgo.ErrNotFound {
-		return -1, false, nil
-	}
+	err = history.Find(nil).Sort("-updated").Skip(deleteStatuses).One(&result)
 	if err != nil {
-		return -1, false, errors.Trace(err)
+		return errors.Trace(err)
 	}
-	return result.Updated, true, nil
-
-}
-
-// getEntitiesWithStatuses returns the ids for all entities that
-// have history entries
-func getEntitiesWithStatuses(coll mongo.Collection) ([]string, error) {
-	var globalKeys []string
-	err := coll.Find(nil).Distinct("globalkey", &globalKeys)
+	_, err = history.RemoveAll(bson.D{
+		{"updated", bson.M{"$lt": result.Updated}},
+	})
 	if err != nil {
-		return nil, errors.Trace(err)
+		return errors.Trace(err)
 	}
-	return globalKeys, nil
+	return nil
 }

--- a/state/status_filesystem_test.go
+++ b/state/status_filesystem_test.go
@@ -4,6 +4,8 @@
 package state_test
 
 import (
+	"time"
+
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -58,23 +60,42 @@ func (s *FilesystemStatusSuite) checkInitialStatus(c *gc.C) {
 }
 
 func (s *FilesystemStatusSuite) TestSetErrorStatusWithoutInfo(c *gc.C) {
-	err := s.filesystem.SetStatus(status.StatusError, "", nil)
+	now := time.Now()
+	sInfo := status.StatusInfo{
+		Status:  status.StatusError,
+		Message: "",
+		Since:   &now,
+	}
+	err := s.filesystem.SetStatus(sInfo)
 	c.Check(err, gc.ErrorMatches, `cannot set status "error" without info`)
 
 	s.checkInitialStatus(c)
 }
 
 func (s *FilesystemStatusSuite) TestSetUnknownStatus(c *gc.C) {
-	err := s.filesystem.SetStatus(status.Status("vliegkat"), "orville", nil)
+	now := time.Now()
+	sInfo := status.StatusInfo{
+		Status:  status.Status("vliegkat"),
+		Message: "orville",
+		Since:   &now,
+	}
+	err := s.filesystem.SetStatus(sInfo)
 	c.Assert(err, gc.ErrorMatches, `cannot set invalid status "vliegkat"`)
 
 	s.checkInitialStatus(c)
 }
 
 func (s *FilesystemStatusSuite) TestSetOverwritesData(c *gc.C) {
-	err := s.filesystem.SetStatus(status.StatusAttaching, "blah", map[string]interface{}{
-		"pew.pew": "zap",
-	})
+	now := time.Now()
+	sInfo := status.StatusInfo{
+		Status:  status.StatusAttaching,
+		Message: "blah",
+		Data: map[string]interface{}{
+			"pew.pew": "zap",
+		},
+		Since: &now,
+	}
+	err := s.filesystem.SetStatus(sInfo)
 	c.Check(err, jc.ErrorIsNil)
 
 	s.checkGetSetStatus(c)
@@ -85,11 +106,18 @@ func (s *FilesystemStatusSuite) TestGetSetStatusAlive(c *gc.C) {
 }
 
 func (s *FilesystemStatusSuite) checkGetSetStatus(c *gc.C) {
-	err := s.filesystem.SetStatus(status.StatusAttaching, "blah", map[string]interface{}{
-		"$foo.bar.baz": map[string]interface{}{
-			"pew.pew": "zap",
+	now := time.Now()
+	sInfo := status.StatusInfo{
+		Status:  status.StatusAttaching,
+		Message: "blah",
+		Data: map[string]interface{}{
+			"$foo.bar.baz": map[string]interface{}{
+				"pew.pew": "zap",
+			},
 		},
-	})
+		Since: &now,
+	}
+	err := s.filesystem.SetStatus(sInfo)
 	c.Check(err, jc.ErrorIsNil)
 
 	filesystem, err := s.State.Filesystem(s.filesystem.FilesystemTag())
@@ -135,7 +163,13 @@ func (s *FilesystemStatusSuite) TestGetSetStatusDead(c *gc.C) {
 func (s *FilesystemStatusSuite) TestGetSetStatusGone(c *gc.C) {
 	s.obliterateFilesystem(c, s.filesystem.FilesystemTag())
 
-	err := s.filesystem.SetStatus(status.StatusAttaching, "not really", nil)
+	now := time.Now()
+	sInfo := status.StatusInfo{
+		Status:  status.StatusAttaching,
+		Message: "not really",
+		Since:   &now,
+	}
+	err := s.filesystem.SetStatus(sInfo)
 	c.Check(err, gc.ErrorMatches, `cannot set status: filesystem not found`)
 
 	statusInfo, err := s.filesystem.Status()
@@ -144,7 +178,13 @@ func (s *FilesystemStatusSuite) TestGetSetStatusGone(c *gc.C) {
 }
 
 func (s *FilesystemStatusSuite) TestSetStatusPendingUnprovisioned(c *gc.C) {
-	err := s.filesystem.SetStatus(status.StatusPending, "still", nil)
+	now := time.Now()
+	sInfo := status.StatusInfo{
+		Status:  status.StatusPending,
+		Message: "still",
+		Since:   &now,
+	}
+	err := s.filesystem.SetStatus(sInfo)
 	c.Check(err, jc.ErrorIsNil)
 }
 
@@ -153,6 +193,12 @@ func (s *FilesystemStatusSuite) TestSetStatusPendingProvisioned(c *gc.C) {
 		FilesystemId: "fs-id",
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.filesystem.SetStatus(status.StatusPending, "", nil)
+	now := time.Now()
+	sInfo := status.StatusInfo{
+		Status:  status.StatusPending,
+		Message: "",
+		Since:   &now,
+	}
+	err = s.filesystem.SetStatus(sInfo)
 	c.Check(err, gc.ErrorMatches, `cannot set status "pending"`)
 }

--- a/state/status_history_test.go
+++ b/state/status_history_test.go
@@ -4,11 +4,14 @@
 package state_test
 
 import (
+	"time"
+
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/state"
 	statetesting "github.com/juju/juju/state/testing"
+	"github.com/juju/juju/status"
 	"github.com/juju/juju/testing/factory"
 )
 
@@ -48,7 +51,7 @@ func (s *StatusHistorySuite) TestPruneStatusHistory(c *gc.C) {
 	err := state.PruneStatusHistory(s.State, 30)
 	c.Assert(err, jc.ErrorIsNil)
 
-	history, err := units[0].StatusHistory(50)
+	history, err := units[0].StatusHistory(status.StatusHistoryFilter{Size: 50})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(history, gc.HasLen, 11)
 	checkInitialWorkloadStatus(c, history[10])
@@ -56,39 +59,107 @@ func (s *StatusHistorySuite) TestPruneStatusHistory(c *gc.C) {
 		checkPrimedUnitStatus(c, statusInfo, 9-i)
 	}
 
-	history, err = units[1].StatusHistory(50)
+	history, err = units[1].StatusHistory(status.StatusHistoryFilter{Size: 50})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(history, gc.HasLen, 30)
 	for i, statusInfo := range history {
 		checkPrimedUnitStatus(c, statusInfo, 49-i)
 	}
 
-	history, err = units[2].StatusHistory(50)
+	history, err = units[2].StatusHistory(status.StatusHistoryFilter{Size: 50})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(history, gc.HasLen, 30)
 	for i, statusInfo := range history {
 		checkPrimedUnitStatus(c, statusInfo, 99-i)
 	}
 
-	history, err = agents[0].StatusHistory(50)
+	history, err = agents[0].StatusHistory(status.StatusHistoryFilter{Size: 50})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(history, gc.HasLen, 30)
 	for i, statusInfo := range history {
 		checkPrimedUnitAgentStatus(c, statusInfo, 99-i)
 	}
 
-	history, err = agents[1].StatusHistory(50)
+	history, err = agents[1].StatusHistory(status.StatusHistoryFilter{Size: 50})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(history, gc.HasLen, 30)
 	for i, statusInfo := range history {
 		checkPrimedUnitAgentStatus(c, statusInfo, 49-i)
 	}
 
-	history, err = agents[2].StatusHistory(50)
+	history, err = agents[2].StatusHistory(status.StatusHistoryFilter{Size: 50})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(history, gc.HasLen, 11)
 	checkInitialUnitAgentStatus(c, history[10])
 	for i, statusInfo := range history[:10] {
 		checkPrimedUnitAgentStatus(c, statusInfo, 9-i)
 	}
+}
+
+func (s *StatusHistorySuite) TestStatusHistoryFiltersByDateAndDelta(c *gc.C) {
+	service := s.Factory.MakeService(c, nil)
+	unit := s.Factory.MakeUnit(c, &factory.UnitParams{Service: service})
+
+	twoDaysBack := time.Hour * 48
+	threeDaysBack := time.Hour * 72
+	err := unit.SetStatus(status.StatusActive, "current status", nil)
+	c.Assert(err, jc.ErrorIsNil)
+	state.ProbablyUpdateUnitStatusHistory(s.State, unit, status.StatusActive, "2 days ago", twoDaysBack)
+	state.ProbablyUpdateUnitStatusHistory(s.State, unit, status.StatusActive, "3 days ago", threeDaysBack)
+	history, err := unit.StatusHistory(status.StatusHistoryFilter{Size: 50})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(history, gc.HasLen, 4)
+	c.Assert(history[0].Message, gc.Equals, "current status")
+	c.Assert(history[1].Message, gc.Equals, "Waiting for agent initialization to finish")
+	c.Assert(history[2].Message, gc.Equals, "2 days ago")
+	c.Assert(history[3].Message, gc.Equals, "3 days ago")
+	now := time.Now().Add(10 * time.Second) // lets add some padding to prevent races here.
+
+	// logs up to one day back, using delta.
+	oneDayBack := time.Hour * 24
+	history, err = unit.StatusHistory(status.StatusHistoryFilter{Delta: &oneDayBack})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(history, gc.HasLen, 2)
+	c.Assert(history[0].Message, gc.Equals, "current status")
+	c.Assert(history[1].Message, gc.Equals, "Waiting for agent initialization to finish")
+
+	// logs up to one day back, using date.
+	yesterday := now.Add(-(time.Hour * 24))
+	history, err = unit.StatusHistory(status.StatusHistoryFilter{Date: &yesterday})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(history, gc.HasLen, 2)
+	c.Assert(history[0].Message, gc.Equals, "current status")
+	c.Assert(history[1].Message, gc.Equals, "Waiting for agent initialization to finish")
+
+	// Logs up to two days ago, using delta.
+	history, err = unit.StatusHistory(status.StatusHistoryFilter{Delta: &twoDaysBack})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(history, gc.HasLen, 2)
+	c.Assert(history[0].Message, gc.Equals, "current status")
+	c.Assert(history[1].Message, gc.Equals, "Waiting for agent initialization to finish")
+
+	// Logs up to two days ago, using date.
+	twoDaysAgo := now.Add(-twoDaysBack)
+	history, err = unit.StatusHistory(status.StatusHistoryFilter{Date: &twoDaysAgo})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(history, gc.HasLen, 2)
+	c.Assert(history[0].Message, gc.Equals, "current status")
+	c.Assert(history[1].Message, gc.Equals, "Waiting for agent initialization to finish")
+
+	// Logs up to three days ago, using delta.
+	history, err = unit.StatusHistory(status.StatusHistoryFilter{Delta: &threeDaysBack})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(history, gc.HasLen, 3)
+	c.Assert(history[0].Message, gc.Equals, "current status")
+	c.Assert(history[1].Message, gc.Equals, "Waiting for agent initialization to finish")
+	c.Assert(history[2].Message, gc.Equals, "2 days ago")
+
+	// Logs up to three days ago, using date.
+	threeDaysAgo := now.Add(-threeDaysBack)
+	history, err = unit.StatusHistory(status.StatusHistoryFilter{Date: &threeDaysAgo})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(history, gc.HasLen, 3)
+	c.Assert(history[0].Message, gc.Equals, "current status")
+	c.Assert(history[1].Message, gc.Equals, "Waiting for agent initialization to finish")
+	c.Assert(history[2].Message, gc.Equals, "2 days ago")
 }

--- a/state/status_history_test.go
+++ b/state/status_history_test.go
@@ -21,7 +21,30 @@ type StatusHistorySuite struct {
 
 var _ = gc.Suite(&StatusHistorySuite{})
 
-func (s *StatusHistorySuite) TestPruneStatusHistory(c *gc.C) {
+func (s *StatusHistorySuite) TestPruneStatusHistoryBySize(c *gc.C) {
+	service := s.Factory.MakeService(c, nil)
+	unit := s.Factory.MakeUnit(c, &factory.UnitParams{Service: service})
+	primeUnitStatusHistory(c, unit, 20000, 0)
+
+	history, err := unit.StatusHistory(status.StatusHistoryFilter{Size: 25000})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Logf("%d\n", len(history))
+	c.Assert(history, gc.HasLen, 20001)
+
+	err = state.PruneStatusHistory(s.State, 0, 1)
+	c.Assert(err, jc.ErrorIsNil)
+
+	history, err = unit.StatusHistory(status.StatusHistoryFilter{Size: 25000})
+	c.Assert(err, jc.ErrorIsNil)
+	historyLen := len(history)
+	// When writing this test, the size was 6670 for about 0,00015 MB per entry
+	// but that is a size that can most likely change so I wont risk a flaky test
+	// here, enough to say that if this size suddenly is no longer less than
+	// half its good reason for suspicion.
+	c.Assert(historyLen, jc.LessThan, 10000)
+}
+
+func (s *StatusHistorySuite) TestPruneStatusHistoryByDate(c *gc.C) {
 
 	// NOTE: the behaviour is bad, and the test is ugly. I'm just verifying
 	// the existing logic here.
@@ -41,50 +64,67 @@ func (s *StatusHistorySuite) TestPruneStatusHistory(c *gc.C) {
 		agents[i] = units[i].Agent()
 	}
 
-	primeUnitStatusHistory(c, units[0], 10)
-	primeUnitStatusHistory(c, units[1], 50)
-	primeUnitStatusHistory(c, units[2], 100)
-	primeUnitAgentStatusHistory(c, agents[0], 100)
-	primeUnitAgentStatusHistory(c, agents[1], 50)
-	primeUnitAgentStatusHistory(c, agents[2], 10)
-
-	err := state.PruneStatusHistory(s.State, 30)
-	c.Assert(err, jc.ErrorIsNil)
+	primeUnitStatusHistory(c, units[0], 10, 0)
+	primeUnitStatusHistory(c, units[0], 10, 24*time.Hour)
+	primeUnitStatusHistory(c, units[1], 50, 0)
+	primeUnitStatusHistory(c, units[1], 50, 24*time.Hour)
+	primeUnitStatusHistory(c, units[2], 100, 0)
+	primeUnitStatusHistory(c, units[2], 100, 24*time.Hour)
+	primeUnitAgentStatusHistory(c, agents[0], 100, 0)
+	primeUnitAgentStatusHistory(c, agents[0], 100, 24*time.Hour)
+	primeUnitAgentStatusHistory(c, agents[1], 50, 0)
+	primeUnitAgentStatusHistory(c, agents[1], 50, 24*time.Hour)
+	primeUnitAgentStatusHistory(c, agents[2], 10, 0)
+	primeUnitAgentStatusHistory(c, agents[2], 10, 24*time.Hour)
 
 	history, err := units[0].StatusHistory(status.StatusHistoryFilter{Size: 50})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(history, gc.HasLen, 21)
+	checkInitialWorkloadStatus(c, history[10])
+	for i, statusInfo := range history[:10] {
+		checkPrimedUnitStatus(c, statusInfo, 9-i, 0)
+	}
+	for i, statusInfo := range history[11:20] {
+		checkPrimedUnitStatus(c, statusInfo, 9-i, 24*time.Hour)
+	}
+
+	err = state.PruneStatusHistory(s.State, 10*time.Hour, 1024)
+	c.Assert(err, jc.ErrorIsNil)
+
+	history, err = units[0].StatusHistory(status.StatusHistoryFilter{Size: 50})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(history, gc.HasLen, 11)
 	checkInitialWorkloadStatus(c, history[10])
 	for i, statusInfo := range history[:10] {
-		checkPrimedUnitStatus(c, statusInfo, 9-i)
+		checkPrimedUnitStatus(c, statusInfo, 9-i, 0)
 	}
 
-	history, err = units[1].StatusHistory(status.StatusHistoryFilter{Size: 50})
+	history, err = units[1].StatusHistory(status.StatusHistoryFilter{Size: 100})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(history, gc.HasLen, 30)
-	for i, statusInfo := range history {
-		checkPrimedUnitStatus(c, statusInfo, 49-i)
+	c.Assert(history, gc.HasLen, 51)
+	for i, statusInfo := range history[:50] {
+		checkPrimedUnitStatus(c, statusInfo, 49-i, 0)
 	}
 
-	history, err = units[2].StatusHistory(status.StatusHistoryFilter{Size: 50})
+	history, err = units[2].StatusHistory(status.StatusHistoryFilter{Size: 200})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(history, gc.HasLen, 30)
-	for i, statusInfo := range history {
-		checkPrimedUnitStatus(c, statusInfo, 99-i)
+	c.Assert(history, gc.HasLen, 101)
+	for i, statusInfo := range history[:100] {
+		checkPrimedUnitStatus(c, statusInfo, 99-i, 0)
 	}
 
-	history, err = agents[0].StatusHistory(status.StatusHistoryFilter{Size: 50})
+	history, err = agents[0].StatusHistory(status.StatusHistoryFilter{Size: 200})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(history, gc.HasLen, 30)
-	for i, statusInfo := range history {
-		checkPrimedUnitAgentStatus(c, statusInfo, 99-i)
+	c.Assert(history, gc.HasLen, 101)
+	for i, statusInfo := range history[:100] {
+		checkPrimedUnitAgentStatus(c, statusInfo, 99-i, 0)
 	}
 
-	history, err = agents[1].StatusHistory(status.StatusHistoryFilter{Size: 50})
+	history, err = agents[1].StatusHistory(status.StatusHistoryFilter{Size: 100})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(history, gc.HasLen, 30)
-	for i, statusInfo := range history {
-		checkPrimedUnitAgentStatus(c, statusInfo, 49-i)
+	c.Assert(history, gc.HasLen, 51)
+	for i, statusInfo := range history[:50] {
+		checkPrimedUnitAgentStatus(c, statusInfo, 49-i, 0)
 	}
 
 	history, err = agents[2].StatusHistory(status.StatusHistoryFilter{Size: 50})
@@ -92,20 +132,40 @@ func (s *StatusHistorySuite) TestPruneStatusHistory(c *gc.C) {
 	c.Assert(history, gc.HasLen, 11)
 	checkInitialUnitAgentStatus(c, history[10])
 	for i, statusInfo := range history[:10] {
-		checkPrimedUnitAgentStatus(c, statusInfo, 9-i)
+		checkPrimedUnitAgentStatus(c, statusInfo, 9-i, 0)
 	}
 }
 
 func (s *StatusHistorySuite) TestStatusHistoryFiltersByDateAndDelta(c *gc.C) {
+	// TODO(perrito666) setup should be extracted into a fixture and the
+	// 6 or 7 test cases each get their own method.
 	service := s.Factory.MakeService(c, nil)
 	unit := s.Factory.MakeUnit(c, &factory.UnitParams{Service: service})
 
 	twoDaysBack := time.Hour * 48
 	threeDaysBack := time.Hour * 72
-	err := unit.SetStatus(status.StatusActive, "current status", nil)
+	now := time.Now()
+	twoDaysAgo := now.Add(-twoDaysBack)
+	threeDaysAgo := now.Add(-threeDaysBack)
+	sInfo := status.StatusInfo{
+		Status:  status.StatusActive,
+		Message: "current status",
+		Since:   &now,
+	}
+	err := unit.SetStatus(sInfo)
 	c.Assert(err, jc.ErrorIsNil)
-	state.ProbablyUpdateUnitStatusHistory(s.State, unit, status.StatusActive, "2 days ago", twoDaysBack)
-	state.ProbablyUpdateUnitStatusHistory(s.State, unit, status.StatusActive, "3 days ago", threeDaysBack)
+	sInfo = status.StatusInfo{
+		Status:  status.StatusActive,
+		Message: "2 days ago",
+		Since:   &twoDaysAgo,
+	}
+	unit.SetStatus(sInfo)
+	sInfo = status.StatusInfo{
+		Status:  status.StatusActive,
+		Message: "3 days ago",
+		Since:   &threeDaysAgo,
+	}
+	unit.SetStatus(sInfo)
 	history, err := unit.StatusHistory(status.StatusHistoryFilter{Size: 50})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(history, gc.HasLen, 4)
@@ -113,7 +173,7 @@ func (s *StatusHistorySuite) TestStatusHistoryFiltersByDateAndDelta(c *gc.C) {
 	c.Assert(history[1].Message, gc.Equals, "Waiting for agent initialization to finish")
 	c.Assert(history[2].Message, gc.Equals, "2 days ago")
 	c.Assert(history[3].Message, gc.Equals, "3 days ago")
-	now := time.Now().Add(10 * time.Second) // lets add some padding to prevent races here.
+	now = now.Add(10 * time.Second) // lets add some padding to prevent races here.
 
 	// logs up to one day back, using delta.
 	oneDayBack := time.Hour * 24
@@ -139,7 +199,7 @@ func (s *StatusHistorySuite) TestStatusHistoryFiltersByDateAndDelta(c *gc.C) {
 	c.Assert(history[1].Message, gc.Equals, "Waiting for agent initialization to finish")
 
 	// Logs up to two days ago, using date.
-	twoDaysAgo := now.Add(-twoDaysBack)
+
 	history, err = unit.StatusHistory(status.StatusHistoryFilter{Date: &twoDaysAgo})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(history, gc.HasLen, 2)
@@ -155,7 +215,6 @@ func (s *StatusHistorySuite) TestStatusHistoryFiltersByDateAndDelta(c *gc.C) {
 	c.Assert(history[2].Message, gc.Equals, "2 days ago")
 
 	// Logs up to three days ago, using date.
-	threeDaysAgo := now.Add(-threeDaysBack)
 	history, err = unit.StatusHistory(status.StatusHistoryFilter{Date: &threeDaysAgo})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(history, gc.HasLen, 3)

--- a/state/status_machine_test.go
+++ b/state/status_machine_test.go
@@ -4,6 +4,8 @@
 package state_test
 
 import (
+	"time"
+
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -37,30 +39,55 @@ func (s *MachineStatusSuite) checkInitialStatus(c *gc.C) {
 }
 
 func (s *MachineStatusSuite) TestSetErrorStatusWithoutInfo(c *gc.C) {
-	err := s.machine.SetStatus(status.StatusError, "", nil)
+	now := time.Now()
+	sInfo := status.StatusInfo{
+		Status:  status.StatusError,
+		Message: "",
+		Since:   &now,
+	}
+	err := s.machine.SetStatus(sInfo)
 	c.Check(err, gc.ErrorMatches, `cannot set status "error" without info`)
 
 	s.checkInitialStatus(c)
 }
 
 func (s *MachineStatusSuite) TestSetDownStatus(c *gc.C) {
-	err := s.machine.SetStatus(status.StatusDown, "", nil)
+	now := time.Now()
+	sInfo := status.StatusInfo{
+		Status:  status.StatusDown,
+		Message: "",
+		Since:   &now,
+	}
+	err := s.machine.SetStatus(sInfo)
 	c.Check(err, gc.ErrorMatches, `cannot set status "down"`)
 
 	s.checkInitialStatus(c)
 }
 
 func (s *MachineStatusSuite) TestSetUnknownStatus(c *gc.C) {
-	err := s.machine.SetStatus(status.Status("vliegkat"), "orville", nil)
+	now := time.Now()
+	sInfo := status.StatusInfo{
+		Status:  status.Status("vliegkat"),
+		Message: "orville",
+		Since:   &now,
+	}
+	err := s.machine.SetStatus(sInfo)
 	c.Assert(err, gc.ErrorMatches, `cannot set invalid status "vliegkat"`)
 
 	s.checkInitialStatus(c)
 }
 
 func (s *MachineStatusSuite) TestSetOverwritesData(c *gc.C) {
-	err := s.machine.SetStatus(status.StatusStarted, "blah", map[string]interface{}{
-		"pew.pew": "zap",
-	})
+	now := time.Now()
+	sInfo := status.StatusInfo{
+		Status:  status.StatusStarted,
+		Message: "blah",
+		Data: map[string]interface{}{
+			"pew.pew": "zap",
+		},
+		Since: &now,
+	}
+	err := s.machine.SetStatus(sInfo)
 	c.Check(err, jc.ErrorIsNil)
 
 	s.checkGetSetStatus(c)
@@ -71,11 +98,18 @@ func (s *MachineStatusSuite) TestGetSetStatusAlive(c *gc.C) {
 }
 
 func (s *MachineStatusSuite) checkGetSetStatus(c *gc.C) {
-	err := s.machine.SetStatus(status.StatusStarted, "blah", map[string]interface{}{
-		"$foo.bar.baz": map[string]interface{}{
-			"pew.pew": "zap",
+	now := time.Now()
+	sInfo := status.StatusInfo{
+		Status:  status.StatusStarted,
+		Message: "blah",
+		Data: map[string]interface{}{
+			"$foo.bar.baz": map[string]interface{}{
+				"pew.pew": "zap",
+			},
 		},
-	})
+		Since: &now,
+	}
+	err := s.machine.SetStatus(sInfo)
 	c.Check(err, jc.ErrorIsNil)
 
 	machine, err := s.State.Machine(s.machine.Id())
@@ -116,7 +150,13 @@ func (s *MachineStatusSuite) TestGetSetStatusGone(c *gc.C) {
 	err = s.machine.Remove()
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = s.machine.SetStatus(status.StatusStarted, "not really", nil)
+	now := time.Now()
+	sInfo := status.StatusInfo{
+		Status:  status.StatusStarted,
+		Message: "not really",
+		Since:   &now,
+	}
+	err = s.machine.SetStatus(sInfo)
 	c.Check(err, gc.ErrorMatches, `cannot set status: machine not found`)
 
 	statusInfo, err := s.machine.Status()
@@ -125,13 +165,25 @@ func (s *MachineStatusSuite) TestGetSetStatusGone(c *gc.C) {
 }
 
 func (s *MachineStatusSuite) TestSetStatusPendingProvisioned(c *gc.C) {
-	err := s.machine.SetStatus(status.StatusPending, "", nil)
+	now := time.Now()
+	sInfo := status.StatusInfo{
+		Status:  status.StatusPending,
+		Message: "",
+		Since:   &now,
+	}
+	err := s.machine.SetStatus(sInfo)
 	c.Check(err, gc.ErrorMatches, `cannot set status "pending"`)
 }
 
 func (s *MachineStatusSuite) TestSetStatusPendingUnprovisioned(c *gc.C) {
 	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
-	err = machine.SetStatus(status.StatusPending, "", nil)
+	now := time.Now()
+	sInfo := status.StatusInfo{
+		Status:  status.StatusPending,
+		Message: "",
+		Since:   &now,
+	}
+	err = machine.SetStatus(sInfo)
 	c.Check(err, jc.ErrorIsNil)
 }

--- a/state/status_unit_test.go
+++ b/state/status_unit_test.go
@@ -130,7 +130,7 @@ func (s *UnitStatusSuite) TestSetUnitStatusSince(c *gc.C) {
 }
 
 func (s *UnitStatusSuite) TestStatusHistoryInitial(c *gc.C) {
-	history, err := s.unit.StatusHistory(1)
+	history, err := s.unit.StatusHistory(status.StatusHistoryFilter{Size: 1})
 	c.Check(err, jc.ErrorIsNil)
 	c.Assert(history, gc.HasLen, 1)
 
@@ -140,7 +140,7 @@ func (s *UnitStatusSuite) TestStatusHistoryInitial(c *gc.C) {
 func (s *UnitStatusSuite) TestStatusHistoryShort(c *gc.C) {
 	primeUnitStatusHistory(c, s.unit, 5)
 
-	history, err := s.unit.StatusHistory(10)
+	history, err := s.unit.StatusHistory(status.StatusHistoryFilter{Size: 10})
 	c.Check(err, jc.ErrorIsNil)
 	c.Assert(history, gc.HasLen, 6)
 
@@ -154,7 +154,7 @@ func (s *UnitStatusSuite) TestStatusHistoryShort(c *gc.C) {
 func (s *UnitStatusSuite) TestStatusHistoryLong(c *gc.C) {
 	primeUnitStatusHistory(c, s.unit, 25)
 
-	history, err := s.unit.StatusHistory(15)
+	history, err := s.unit.StatusHistory(status.StatusHistoryFilter{Size: 15})
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(history, gc.HasLen, 15)
 	for i, statusInfo := range history {

--- a/state/status_unitagent_test.go
+++ b/state/status_unitagent_test.go
@@ -171,7 +171,7 @@ func (s *StatusUnitAgentSuite) TestSetAgentStatusSince(c *gc.C) {
 }
 
 func (s *StatusUnitAgentSuite) TestStatusHistoryInitial(c *gc.C) {
-	history, err := s.agent.StatusHistory(1)
+	history, err := s.agent.StatusHistory(status.StatusHistoryFilter{Size: 1})
 	c.Check(err, jc.ErrorIsNil)
 	c.Assert(history, gc.HasLen, 1)
 
@@ -181,7 +181,7 @@ func (s *StatusUnitAgentSuite) TestStatusHistoryInitial(c *gc.C) {
 func (s *StatusUnitAgentSuite) TestStatusHistoryShort(c *gc.C) {
 	primeUnitAgentStatusHistory(c, s.agent, 5)
 
-	history, err := s.agent.StatusHistory(10)
+	history, err := s.agent.StatusHistory(status.StatusHistoryFilter{Size: 10})
 	c.Check(err, jc.ErrorIsNil)
 	c.Assert(history, gc.HasLen, 6)
 
@@ -195,7 +195,7 @@ func (s *StatusUnitAgentSuite) TestStatusHistoryShort(c *gc.C) {
 func (s *StatusUnitAgentSuite) TestStatusHistoryLong(c *gc.C) {
 	primeUnitAgentStatusHistory(c, s.agent, 25)
 
-	history, err := s.agent.StatusHistory(15)
+	history, err := s.agent.StatusHistory(status.StatusHistoryFilter{Size: 15})
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(history, gc.HasLen, 15)
 	for i, statusInfo := range history {

--- a/state/unit.go
+++ b/state/unit.go
@@ -786,9 +786,15 @@ func (u *Unit) AgentStatus() (status.StatusInfo, error) {
 }
 
 // StatusHistory returns a slice of at most <size> StatusInfo items
+// or items as old as <date> or items newer than now - <delta> time
 // representing past statuses for this unit.
-func (u *Unit) StatusHistory(size int) ([]status.StatusInfo, error) {
-	return statusHistory(u.st, u.globalKey(), size)
+func (u *Unit) StatusHistory(filter status.StatusHistoryFilter) ([]status.StatusInfo, error) {
+	args := &statusHistoryArgs{
+		st:        u.st,
+		globalKey: u.globalKey(),
+		filter:    filter,
+	}
+	return statusHistory(args)
 }
 
 // Status returns the status of the unit.

--- a/state/unit_test.go
+++ b/state/unit_test.go
@@ -682,7 +682,13 @@ func (s *UnitSuite) TestSetCharmURLRetriesWithDifferentURL(c *gc.C) {
 
 func (s *UnitSuite) TestDestroySetStatusRetry(c *gc.C) {
 	defer state.SetRetryHooks(c, s.State, func() {
-		err := s.unit.SetAgentStatus(status.StatusIdle, "", nil)
+		now := time.Now()
+		sInfo := status.StatusInfo{
+			Status:  status.StatusIdle,
+			Message: "",
+			Since:   &now,
+		}
+		err := s.unit.SetAgentStatus(sInfo)
 		c.Assert(err, jc.ErrorIsNil)
 	}, func() {
 		assertLife(c, s.unit, state.Dying)
@@ -800,7 +806,13 @@ func (s *UnitSuite) TestCannotShortCircuitDestroyWithAgentStatus(c *gc.C) {
 		c.Logf("test %d: %s", i, test.status)
 		unit, err := s.service.AddUnit()
 		c.Assert(err, jc.ErrorIsNil)
-		err = unit.SetAgentStatus(test.status, test.info, nil)
+		now := time.Now()
+		sInfo := status.StatusInfo{
+			Status:  test.status,
+			Message: test.info,
+			Since:   &now,
+		}
+		err = unit.SetAgentStatus(sInfo)
 		c.Assert(err, jc.ErrorIsNil)
 		err = unit.Destroy()
 		c.Assert(err, jc.ErrorIsNil)
@@ -906,7 +918,13 @@ func (s *UnitSuite) TestResolve(c *gc.C) {
 	err = s.unit.Resolve(true)
 	c.Assert(err, gc.ErrorMatches, `unit "wordpress/0" is not in an error state`)
 
-	err = s.unit.SetAgentStatus(status.StatusError, "gaaah", nil)
+	now := time.Now()
+	sInfo := status.StatusInfo{
+		Status:  status.StatusError,
+		Message: "gaaah",
+		Since:   &now,
+	}
+	err = s.unit.SetAgentStatus(sInfo)
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.unit.Resolve(false)
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/unitagent.go
+++ b/state/unitagent.go
@@ -55,24 +55,25 @@ func (u *UnitAgent) Status() (status.StatusInfo, error) {
 
 // SetStatus sets the status of the unit agent. The optional values
 // allow to pass additional helpful status data.
-func (u *UnitAgent) SetStatus(unitAgentStatus status.Status, info string, data map[string]interface{}) (err error) {
-	switch unitAgentStatus {
+func (u *UnitAgent) SetStatus(unitAgentStatus status.StatusInfo) (err error) {
+	switch unitAgentStatus.Status {
 	case status.StatusIdle, status.StatusExecuting, status.StatusRebooting, status.StatusFailed:
 	case status.StatusError:
-		if info == "" {
-			return errors.Errorf("cannot set status %q without info", unitAgentStatus)
+		if unitAgentStatus.Message == "" {
+			return errors.Errorf("cannot set status %q without info", unitAgentStatus.Status)
 		}
 	case status.StatusAllocating, status.StatusLost:
-		return errors.Errorf("cannot set status %q", unitAgentStatus)
+		return errors.Errorf("cannot set status %q", unitAgentStatus.Status)
 	default:
-		return errors.Errorf("cannot set invalid status %q", unitAgentStatus)
+		return errors.Errorf("cannot set invalid status %q", unitAgentStatus.Status)
 	}
 	return setStatus(u.st, setStatusParams{
 		badge:     "agent",
 		globalKey: u.globalKey(),
-		status:    unitAgentStatus,
-		message:   info,
-		rawData:   data,
+		status:    unitAgentStatus.Status,
+		message:   unitAgentStatus.Message,
+		rawData:   unitAgentStatus.Data,
+		updated:   unitAgentStatus.Since,
 	})
 }
 

--- a/state/unitagent.go
+++ b/state/unitagent.go
@@ -76,10 +76,16 @@ func (u *UnitAgent) SetStatus(unitAgentStatus status.Status, info string, data m
 	})
 }
 
-// StatusHistory returns a slice of at most <size> StatusInfo items
+// StatusHistory returns a slice of at most filter.Size StatusInfo items
+// or items as old as filter.Date or items newer than now - filter.Delta time
 // representing past statuses for this agent.
-func (u *UnitAgent) StatusHistory(size int) ([]status.StatusInfo, error) {
-	return statusHistory(u.st, u.globalKey(), size)
+func (u *UnitAgent) StatusHistory(filter status.StatusHistoryFilter) ([]status.StatusInfo, error) {
+	args := &statusHistoryArgs{
+		st:        u.st,
+		globalKey: u.globalKey(),
+		filter:    filter,
+	}
+	return statusHistory(args)
 }
 
 // unitAgentGlobalKey returns the global database key for the named unit.

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -86,6 +86,7 @@ func AddFilesystemStatus(st *State) error {
 			if err != nil {
 				return errors.Annotate(err, "deciding filesystem status")
 			}
+			// TODO(perrito666) 2016-05-02 lp:1558657
 			ops = append(ops, createStatusOp(st, filesystem.globalKey(), statusDoc{
 				Status:  status,
 				Updated: time.Now().UnixNano(),

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -4,6 +4,8 @@
 package state
 
 import (
+	"time"
+
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -271,7 +273,13 @@ func (s *upgradesSuite) TestAddFilesystemStatusDoesNotOverwrite(c *gc.C) {
 	_, _, filesystem, cleanup := setupMachineBoundStorageTests(c, s.state)
 	defer cleanup()
 
-	err := filesystem.SetStatus(status.StatusDestroying, "", nil)
+	now := time.Now()
+	sInfo := status.StatusInfo{
+		Status:  status.StatusDestroying,
+		Message: "",
+		Since:   &now,
+	}
+	err := filesystem.SetStatus(sInfo)
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertAddFilesystemStatus(c, filesystem, status.StatusDestroying)
 }

--- a/state/volume.go
+++ b/state/volume.go
@@ -242,8 +242,8 @@ func (v *volume) Status() (status.StatusInfo, error) {
 }
 
 // SetStatus is required to implement StatusSetter.
-func (v *volume) SetStatus(volumeStatus status.Status, info string, data map[string]interface{}) error {
-	return v.st.SetVolumeStatus(v.VolumeTag(), volumeStatus, info, data)
+func (v *volume) SetStatus(volumeStatus status.StatusInfo) error {
+	return v.st.SetVolumeStatus(v.VolumeTag(), volumeStatus.Status, volumeStatus.Message, volumeStatus.Data, volumeStatus.Since)
 }
 
 // Volume is required to implement VolumeAttachment.
@@ -1033,7 +1033,7 @@ func (st *State) VolumeStatus(tag names.VolumeTag) (status.StatusInfo, error) {
 }
 
 // SetVolumeStatus sets the status of the specified volume.
-func (st *State) SetVolumeStatus(tag names.VolumeTag, volumeStatus status.Status, info string, data map[string]interface{}) error {
+func (st *State) SetVolumeStatus(tag names.VolumeTag, volumeStatus status.Status, info string, data map[string]interface{}, updated *time.Time) error {
 	switch volumeStatus {
 	case status.StatusAttaching, status.StatusAttached, status.StatusDetaching, status.StatusDetached, status.StatusDestroying:
 	case status.StatusError:
@@ -1061,5 +1061,6 @@ func (st *State) SetVolumeStatus(tag names.VolumeTag, volumeStatus status.Status
 		status:    volumeStatus,
 		message:   info,
 		rawData:   data,
+		updated:   updated,
 	})
 }

--- a/status/package_test.go
+++ b/status/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package status_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/status/status.go
+++ b/status/status.go
@@ -30,7 +30,7 @@ type StatusInfo struct {
 
 // StatusSetter represents a type whose status can be set.
 type StatusSetter interface {
-	SetStatus(status Status, info string, data map[string]interface{}) error
+	SetStatus(StatusInfo) error
 }
 
 // StatusGetter represents a type whose status can be read.

--- a/status/status.go
+++ b/status/status.go
@@ -3,7 +3,9 @@
 
 package status
 
-import "time"
+import (
+	"time"
+)
 
 // Status used to represent the status of an entity, but has recently become
 // and applies to "workloads" as well, which we don't currently model, for no
@@ -12,6 +14,11 @@ import "time"
 // Status values currently apply to machine (agents), unit (agents), unit
 // (workloads), service (workloads), volumes, filesystems, and models.
 type Status string
+
+// String returns a string representation of the Status.
+func (s Status) String() string {
+	return string(s)
+}
 
 // StatusInfo holds a Status and associated information.
 type StatusInfo struct {
@@ -34,16 +41,6 @@ type StatusGetter interface {
 // InstanceStatusGetter represents a type whose instance status can be read.
 type InstanceStatusGetter interface {
 	InstanceStatus() (StatusInfo, error)
-}
-
-// StatusHistoryGetter instances can fetch their status history.
-type StatusHistoryGetter interface {
-	StatusHistory(size int) ([]StatusInfo, error)
-}
-
-// InstanceStatusHistoryGetter instances can fetch their instance status history.
-type InstanceStatusHistoryGetter interface {
-	InstanceStatusHistory(size int) ([]StatusInfo, error)
 }
 
 const (

--- a/status/status_history.go
+++ b/status/status_history.go
@@ -1,0 +1,173 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package status
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/juju/errors"
+)
+
+// StatusHistoryFilter holds arguments that can be use to filter a status history backlog.
+type StatusHistoryFilter struct {
+	Size  int
+	Date  *time.Time
+	Delta *time.Duration
+}
+
+// Validate checks that the minimum requirements of a StatusHistoryFilter are met.
+func (f *StatusHistoryFilter) Validate() error {
+	s := f.Size > 0
+	t := f.Date != nil
+	d := f.Delta != nil
+	if !s && !t && !d {
+		return errors.NotValidf("no criteria provided:")
+	}
+	if (s && t) || (s && d) || (t && d) {
+		return errors.NotValidf("more than one criteria provided:")
+	}
+	return nil
+}
+
+// StatusHistoryGetter instances can fetch their status history.
+type StatusHistoryGetter interface {
+	StatusHistory(filter StatusHistoryFilter) ([]StatusInfo, error)
+}
+
+// InstanceStatusHistoryGetter instances can fetch their instance status history.
+type InstanceStatusHistoryGetter interface {
+	InstanceStatusHistory(filter StatusHistoryFilter) ([]StatusInfo, error)
+}
+
+// DetailedStatus holds status info about a machine or unit agent.
+type DetailedStatus struct {
+	Status  Status
+	Info    string
+	Data    map[string]interface{}
+	Since   *time.Time
+	Kind    HistoryKind
+	Version string
+	Life    string
+	Err     error
+}
+
+// History holds many DetailedStatus,
+type History []DetailedStatus
+
+// push will take an input DetailedStatus and put it as element
+// 0 of the current history pushing all other elements by 1
+// and return the last element, now out of the slice.
+func (h *History) push(new DetailedStatus) DetailedStatus {
+	ch := *h
+	old := ch[0]
+	for i := 0; i < len(ch)-1; i++ {
+		ch[i] = ch[i+1]
+	}
+	ch[len(ch)-1] = new
+	return old
+}
+
+// SquashLogs will find repetitions of N consequent status log entries into just
+// one appearance of them and information about repetition.
+func (h *History) SquashLogs(cycleSize int) History {
+	statuses := *h
+	if len(statuses) <= cycleSize {
+		return statuses
+	}
+	buffer := History{}
+	for i := 0; i < cycleSize; i++ {
+		buffer = append(buffer, statuses[i])
+	}
+	result := []DetailedStatus{}
+	now := time.Now()
+	var repeat int
+	var i int
+	repeatStatus := DetailedStatus{
+		Status: StatusIdle,
+		Info:   "",
+		Since:  &now,
+	}
+
+	for i = cycleSize; i < len(statuses); {
+		if i+cycleSize > len(statuses) {
+			break
+		}
+		subset := statuses[i : i+cycleSize]
+		repetition := true
+		for j := range subset {
+			if subset[j].Status != buffer[j].Status || subset[j].Info != buffer[j].Info {
+				repetition = false
+			}
+		}
+		if repetition {
+			repeat++
+			i = i + cycleSize
+			continue
+		}
+		if repeat > 0 {
+			rstatus := fmt.Sprintf("last %d statuses repeated %d times", cycleSize, repeat)
+			repeat = 0
+			repeatStatus.Info = rstatus
+			for j := 0; j < cycleSize; j++ {
+				result = append(result, buffer.push(subset[j]))
+			}
+			result = append(result, repeatStatus)
+			i = i + cycleSize
+			continue
+		}
+		result = append(result, buffer.push(statuses[i]))
+		i++
+	}
+	for j := 0; j < cycleSize; j++ {
+		result = append(result, buffer[j])
+	}
+	if repeat > 0 {
+		rstatus := fmt.Sprintf("last %d statuses repeated %d times", cycleSize, repeat)
+		repeatStatus.Info = rstatus
+		result = append(result, repeatStatus)
+	}
+	if i < len(statuses)-1 {
+		result = append(result, statuses[i+1:]...)
+	}
+
+	return result
+}
+
+// HistoryKind represents the possible types of
+// status history entries.
+type HistoryKind string
+
+const (
+	// KindUnit represents agent and workload combined.
+	KindUnit HistoryKind = "unit"
+	// KindUnitAgent represent a unit agent status history entry.
+	KindUnitAgent HistoryKind = "juju-unit"
+	// KindWorkload represents a charm workload status history entry.
+	KindWorkload HistoryKind = "workload"
+	// KindMachineInstance represents an entry for a machine instance.
+	KindMachineInstance = "machine"
+	// KindMachine represents an entry for a machine agent.
+	KindMachine = "juju-machine"
+	// KindContainerInstance represents an entry for a container instance.
+	KindContainerInstance = "container"
+	// KindContainer represents an entry for a container agent.
+	KindContainer = "juju-container"
+)
+
+// String returns a string representation of the HistoryKind.
+func (k HistoryKind) String() string {
+	return string(k)
+}
+
+// Valid will return true if the current kind is a valid one.
+func (k HistoryKind) Valid() bool {
+	switch k {
+	case KindUnit, KindUnitAgent, KindWorkload,
+		KindMachineInstance, KindMachine,
+		KindContainerInstance, KindContainer:
+		return true
+	}
+	return false
+}

--- a/status/status_history.go
+++ b/status/status_history.go
@@ -22,11 +22,16 @@ func (f *StatusHistoryFilter) Validate() error {
 	s := f.Size > 0
 	t := f.Date != nil
 	d := f.Delta != nil
-	if !s && !t && !d {
-		return errors.NotValidf("no criteria provided:")
-	}
-	if (s && t) || (s && d) || (t && d) {
-		return errors.NotValidf("more than one criteria provided:")
+
+	switch {
+	case !(s || t || d):
+		return errors.NotValidf("empty struct")
+	case s && t:
+		return errors.NotValidf("Size and Date together")
+	case s && d:
+		return errors.NotValidf("Size and Delta together")
+	case t && d:
+		return errors.NotValidf("Date and Delta together")
 	}
 	return nil
 }
@@ -49,8 +54,9 @@ type DetailedStatus struct {
 	Since   *time.Time
 	Kind    HistoryKind
 	Version string
-	Life    string
-	Err     error
+	// TODO(perrito666) make sure this is not used and remove.
+	Life string
+	Err  error
 }
 
 // History holds many DetailedStatus,
@@ -81,6 +87,7 @@ func (h *History) SquashLogs(cycleSize int) History {
 		buffer = append(buffer, statuses[i])
 	}
 	result := []DetailedStatus{}
+	// TODO(perrito666) 2016-05-02 lp:1558657
 	now := time.Now()
 	var repeat int
 	var i int

--- a/status/status_test.go
+++ b/status/status_test.go
@@ -1,0 +1,107 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package status_test
+
+import (
+	"time"
+
+	"github.com/juju/juju/status"
+	"github.com/juju/testing"
+	gc "gopkg.in/check.v1"
+)
+
+type statusHistorySuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&statusHistorySuite{})
+
+func (h *statusHistorySuite) TestStatusSquashing(c *gc.C) {
+	since := time.Now()
+	statuses := status.History{
+		{
+			Status: status.StatusActive,
+			Info:   "unique status one",
+			Since:  &since,
+		},
+		{
+			Status: status.StatusActive,
+			Info:   "unique status two",
+			Since:  &since,
+		},
+		{
+			Status: status.StatusActive,
+			Info:   "unique status three",
+			Since:  &since,
+		},
+		{
+			Status: status.StatusExecuting,
+			Info:   "repeated status one",
+			Since:  &since,
+		},
+		{
+			Status: status.StatusIdle,
+			Info:   "repeated status two",
+			Since:  &since,
+		},
+		{
+			Status: status.StatusExecuting,
+			Info:   "repeated status one",
+			Since:  &since,
+		},
+		{
+			Status: status.StatusIdle,
+			Info:   "repeated status two",
+			Since:  &since,
+		},
+		{
+			Status: status.StatusExecuting,
+			Info:   "repeated status one",
+			Since:  &since,
+		},
+		{
+			Status: status.StatusIdle,
+			Info:   "repeated status two",
+			Since:  &since,
+		},
+	}
+	newStatuses := statuses.SquashLogs(2)
+	c.Assert(newStatuses, gc.HasLen, 6)
+
+	newStatuses[5].Since = &since
+	expectedStatuses := status.History{
+		{
+			Status: status.StatusActive,
+			Info:   "unique status one",
+			Since:  &since,
+		},
+		{
+			Status: status.StatusActive,
+			Info:   "unique status two",
+			Since:  &since,
+		},
+		{
+			Status: status.StatusActive,
+			Info:   "unique status three",
+			Since:  &since,
+		},
+		{
+			Status: status.StatusExecuting,
+			Info:   "repeated status one",
+			Since:  &since,
+		},
+		{
+			Status: status.StatusIdle,
+			Info:   "repeated status two",
+			Since:  &since,
+		},
+		{
+			Status: status.StatusIdle,
+			Info:   "last 2 statuses repeated 2 times",
+			Since:  &since,
+		},
+	}
+
+	c.Assert(newStatuses, gc.DeepEquals, expectedStatuses)
+}

--- a/testing/factory/factory.go
+++ b/testing/factory/factory.go
@@ -404,7 +404,14 @@ func (factory *Factory) MakeService(c *gc.C, params *ServiceParams) *state.Servi
 	c.Assert(err, jc.ErrorIsNil)
 
 	if params.Status != nil {
-		err = service.SetStatus(params.Status.Status, params.Status.Message, params.Status.Data)
+		now := time.Now()
+		s := status.StatusInfo{
+			Status:  params.Status.Status,
+			Message: params.Status.Message,
+			Data:    params.Status.Data,
+			Since:   &now,
+		}
+		err = service.SetStatus(s)
 		c.Assert(err, jc.ErrorIsNil)
 	}
 
@@ -460,7 +467,14 @@ func (factory *Factory) MakeUnitReturningPassword(c *gc.C, params *UnitParams) (
 	c.Assert(err, jc.ErrorIsNil)
 
 	if params.Status != nil {
-		err = unit.SetStatus(params.Status.Status, params.Status.Message, params.Status.Data)
+		now := time.Now()
+		s := status.StatusInfo{
+			Status:  params.Status.Status,
+			Message: params.Status.Message,
+			Data:    params.Status.Data,
+			Since:   &now,
+		}
+		err = unit.SetStatus(s)
 		c.Assert(err, jc.ErrorIsNil)
 	}
 

--- a/worker/deployer/deployer_test.go
+++ b/worker/deployer/deployer_test.go
@@ -77,7 +77,13 @@ func (s *deployerSuite) TestDeployRecallRemovePrincipals(c *gc.C) {
 	s.waitFor(c, isDeployed(ctx, u0.Name(), u1.Name()))
 
 	// Cause a unit to become Dying, and check no change.
-	err = u1.SetAgentStatus(status.StatusIdle, "", nil)
+	now := time.Now()
+	sInfo := status.StatusInfo{
+		Status:  status.StatusIdle,
+		Message: "",
+		Since:   &now,
+	}
+	err = u1.SetAgentStatus(sInfo)
 	c.Assert(err, jc.ErrorIsNil)
 	err = u1.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
@@ -120,7 +126,13 @@ func (s *deployerSuite) TestRemoveNonAlivePrincipals(c *gc.C) {
 	// note: this is not a sane state; for the unit to have a status it must
 	// have been deployed. But it's instructive to check that the right thing
 	// would happen if it were possible to have a dying unit in this situation.
-	err = u1.SetAgentStatus(status.StatusIdle, "", nil)
+	now := time.Now()
+	sInfo := status.StatusInfo{
+		Status:  status.StatusIdle,
+		Message: "",
+		Since:   &now,
+	}
+	err = u1.SetAgentStatus(sInfo)
 	c.Assert(err, jc.ErrorIsNil)
 	err = u1.Destroy()
 	c.Assert(err, jc.ErrorIsNil)

--- a/worker/instancepoller/machine_test.go
+++ b/worker/instancepoller/machine_test.go
@@ -340,7 +340,7 @@ func (m *testMachine) InstanceId() (instance.Id, error) {
 
 // This is stubbed out for testing.
 var MachineStatus = func(m *testMachine) (params.StatusResult, error) {
-	return params.StatusResult{Status: m.status}, nil
+	return params.StatusResult{Status: m.status.String()}, nil
 }
 
 func (m *testMachine) Status() (params.StatusResult, error) {
@@ -354,7 +354,7 @@ func (m *testMachine) IsManual() (bool, error) {
 func (m *testMachine) InstanceStatus() (params.StatusResult, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	return params.StatusResult{Status: status.Status(m.instStatus)}, nil
+	return params.StatusResult{Status: m.instStatus.String()}, nil
 }
 
 func (m *testMachine) SetInstanceStatus(machineStatus status.Status, info string, data map[string]interface{}) error {

--- a/worker/instancepoller/updater.go
+++ b/worker/instancepoller/updater.go
@@ -190,7 +190,8 @@ func machineLoop(context machineContext, m machine, changed <-chan struct{}) err
 				if statusInfo, err := m.Status(); err != nil {
 					logger.Warningf("cannot get current machine status for machine %v: %v", m.Id(), err)
 				} else {
-					machineStatus = statusInfo.Status
+					// TODO(perrito666) add status validation.
+					machineStatus = status.Status(statusInfo.Status)
 				}
 			}
 			// the extra condition below (checking allocating/pending) is here to improve user experience
@@ -252,8 +253,9 @@ func pollInstanceInfo(context machineContext, m machine) (instInfo instanceInfo,
 		logger.Warningf("cannot get current instance status for machine %v: %v", m.Id(), err)
 		instInfo.status = instance.InstanceStatus{status.StatusUnknown, ""}
 	} else {
+		// TODO(perrito666) add status validation.
 		currentInstStatus := instance.InstanceStatus{
-			Status:  instStat.Status,
+			Status:  status.Status(instStat.Status),
 			Message: instStat.Info,
 		}
 		if instInfo.status != currentInstStatus {

--- a/worker/instancepoller/updater_test.go
+++ b/worker/instancepoller/updater_test.go
@@ -97,7 +97,7 @@ func (s *updaterSuite) TestManualMachinesIgnored(c *gc.C) {
 		// Signal that we're in Status.
 		waitStatus <- struct{}{}
 		return params.StatusResult{
-			Status: status.StatusPending,
+			Status: status.StatusPending.String(),
 			Info:   "",
 			Data:   map[string]interface{}{},
 			Since:  nil,

--- a/worker/instancepoller/worker_test.go
+++ b/worker/instancepoller/worker_test.go
@@ -96,7 +96,7 @@ func (s *workerSuite) TestWorker(c *gc.C) {
 			}
 			instanceStatus, err := m.InstanceStatus()
 			c.Logf("instance message is: %q", instanceStatus.Info)
-			c.Assert(instanceStatus.Status, gc.Equals, status.StatusPending)
+			c.Assert(instanceStatus.Status, gc.Equals, status.StatusPending.String())
 			stm, err := s.State.Machine(m.Id())
 			c.Assert(err, jc.ErrorIsNil)
 			return len(stm.Addresses()) == 0
@@ -123,7 +123,7 @@ func (s *workerSuite) TestWorker(c *gc.C) {
 			}
 			// Machines in second half still have no addresses, nor status.
 			instanceStatus, err := m.InstanceStatus()
-			c.Assert(instanceStatus.Status, gc.Equals, status.StatusPending)
+			c.Assert(instanceStatus.Status, gc.Equals, status.StatusPending.String())
 			stm, err := s.State.Machine(m.Id())
 			c.Assert(err, jc.ErrorIsNil)
 			return len(stm.Addresses()) == 0

--- a/worker/provisioner/provisioner_test.go
+++ b/worker/provisioner/provisioner_test.go
@@ -1375,7 +1375,14 @@ func (s *ProvisionerSuite) TestProvisionerRetriesTransientErrors(c *gc.C) {
 			case <-thatsAllFolks:
 				return
 			case <-time.After(coretesting.ShortWait):
-				err := m3.SetStatus(status.StatusError, "info", map[string]interface{}{"transient": true})
+				now := time.Now()
+				sInfo := status.StatusInfo{
+					Status:  status.StatusError,
+					Message: "info",
+					Data:    map[string]interface{}{"transient": true},
+					Since:   &now,
+				}
+				err := m3.SetStatus(sInfo)
 				c.Assert(err, jc.ErrorIsNil)
 			}
 		}

--- a/worker/statushistorypruner/manifold.go
+++ b/worker/statushistorypruner/manifold.go
@@ -17,9 +17,10 @@ import (
 // ManifoldConfig describes the resources and configuration on which the
 // statushistorypruner worker depends.
 type ManifoldConfig struct {
-	APICallerName    string
-	MaxLogsPerEntity uint
-	PruneInterval    time.Duration
+	APICallerName  string
+	MaxHistoryTime time.Duration
+	MaxHistoryMB   uint
+	PruneInterval  time.Duration
 	// TODO(fwereade): 2016-03-17 lp:1558657
 	NewTimer worker.NewTimerFunc
 }
@@ -36,10 +37,11 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 
 			facade := statushistory.NewFacade(apiCaller)
 			prunerConfig := Config{
-				Facade:           facade,
-				MaxLogsPerEntity: config.MaxLogsPerEntity,
-				PruneInterval:    config.PruneInterval,
-				NewTimer:         config.NewTimer,
+				Facade:         facade,
+				MaxHistoryTime: config.MaxHistoryTime,
+				MaxHistoryMB:   config.MaxHistoryMB,
+				PruneInterval:  config.PruneInterval,
+				NewTimer:       config.NewTimer,
 			}
 			w, err := New(prunerConfig)
 			if err != nil {

--- a/worker/storageprovisioner/filesystem_ops.go
+++ b/worker/storageprovisioner/filesystem_ops.go
@@ -43,7 +43,7 @@ func createFilesystems(ctx *context, ops map[names.FilesystemTag]*createFilesyst
 			}
 			statuses = append(statuses, params.EntityStatusArgs{
 				Tag:    filesystemParams[i].Tag.String(),
-				Status: status.StatusError,
+				Status: status.StatusError.String(),
 				Info:   err.Error(),
 			})
 			logger.Debugf(
@@ -62,7 +62,7 @@ func createFilesystems(ctx *context, ops map[names.FilesystemTag]*createFilesyst
 		for i, result := range results {
 			statuses = append(statuses, params.EntityStatusArgs{
 				Tag:    filesystemParams[i].Tag.String(),
-				Status: status.StatusAttaching,
+				Status: status.StatusAttaching.String(),
 			})
 			entityStatus := &statuses[len(statuses)-1]
 			if result.Error != nil {
@@ -73,7 +73,7 @@ func createFilesystems(ctx *context, ops map[names.FilesystemTag]*createFilesyst
 				// that we will retry. When we distinguish between
 				// transient and permanent errors, we will set the
 				// status to "error" for permanent errors.
-				entityStatus.Status = status.StatusPending
+				entityStatus.Status = status.StatusPending.String()
 				entityStatus.Info = result.Error.Error()
 				logger.Debugf(
 					"failed to create %s: %v",
@@ -147,7 +147,7 @@ func attachFilesystems(ctx *context, ops map[params.MachineStorageId]*attachFile
 			p := filesystemAttachmentParams[i]
 			statuses = append(statuses, params.EntityStatusArgs{
 				Tag:    p.Filesystem.String(),
-				Status: status.StatusAttached,
+				Status: status.StatusAttached.String(),
 			})
 			entityStatus := &statuses[len(statuses)-1]
 			if result.Error != nil {
@@ -162,7 +162,7 @@ func attachFilesystems(ctx *context, ops map[params.MachineStorageId]*attachFile
 				// indicate that we will retry. When we distinguish
 				// between transient and permanent errors, we will
 				// set the status to "error" for permanent errors.
-				entityStatus.Status = status.StatusAttaching
+				entityStatus.Status = status.StatusAttaching.String()
 				entityStatus.Info = result.Error.Error()
 				logger.Debugf(
 					"failed to attach %s to %s: %v",
@@ -213,7 +213,7 @@ func destroyFilesystems(ctx *context, ops map[names.FilesystemTag]*destroyFilesy
 			}
 			statuses = append(statuses, params.EntityStatusArgs{
 				Tag:    filesystemParams[i].Tag.String(),
-				Status: status.StatusError,
+				Status: status.StatusError.String(),
 				Info:   err.Error(),
 			})
 			logger.Debugf(
@@ -247,7 +247,7 @@ func destroyFilesystems(ctx *context, ops map[names.FilesystemTag]*destroyFilesy
 			reschedule = append(reschedule, ops[tag])
 			statuses = append(statuses, params.EntityStatusArgs{
 				Tag:    tag.String(),
-				Status: status.StatusDestroying,
+				Status: status.StatusDestroying.String(),
 				Info:   err.Error(),
 			})
 		}
@@ -293,7 +293,7 @@ func detachFilesystems(ctx *context, ops map[params.MachineStorageId]*detachFile
 				// attachment, we'll have to check if
 				// there are any other attachments
 				// before saying the status "detached".
-				Status: status.StatusDetached,
+				Status: status.StatusDetached.String(),
 			})
 			id := params.MachineStorageId{
 				MachineTag:    p.Machine.String(),
@@ -302,7 +302,7 @@ func detachFilesystems(ctx *context, ops map[params.MachineStorageId]*detachFile
 			entityStatus := &statuses[len(statuses)-1]
 			if err != nil {
 				reschedule = append(reschedule, ops[id])
-				entityStatus.Status = status.StatusDetaching
+				entityStatus.Status = status.StatusDetaching.String()
 				entityStatus.Info = err.Error()
 				logger.Debugf(
 					"failed to detach %s from %s: %v",

--- a/worker/storageprovisioner/volume_ops.go
+++ b/worker/storageprovisioner/volume_ops.go
@@ -39,7 +39,7 @@ func createVolumes(ctx *context, ops map[names.VolumeTag]*createVolumeOp) error 
 			}
 			statuses = append(statuses, params.EntityStatusArgs{
 				Tag:    volumeParams[i].Tag.String(),
-				Status: status.StatusError,
+				Status: status.StatusError.String(),
 				Info:   err.Error(),
 			})
 			logger.Debugf(
@@ -58,7 +58,7 @@ func createVolumes(ctx *context, ops map[names.VolumeTag]*createVolumeOp) error 
 		for i, result := range results {
 			statuses = append(statuses, params.EntityStatusArgs{
 				Tag:    volumeParams[i].Tag.String(),
-				Status: status.StatusAttaching,
+				Status: status.StatusAttaching.String(),
 			})
 			entityStatus := &statuses[len(statuses)-1]
 			if result.Error != nil {
@@ -69,7 +69,7 @@ func createVolumes(ctx *context, ops map[names.VolumeTag]*createVolumeOp) error 
 				// that we will retry. When we distinguish between
 				// transient and permanent errors, we will set the
 				// status to "error" for permanent errors.
-				entityStatus.Status = status.StatusPending
+				entityStatus.Status = status.StatusPending.String()
 				entityStatus.Info = result.Error.Error()
 				logger.Debugf(
 					"failed to create %s: %v",
@@ -80,7 +80,7 @@ func createVolumes(ctx *context, ops map[names.VolumeTag]*createVolumeOp) error 
 			}
 			volumes = append(volumes, *result.Volume)
 			if result.VolumeAttachment != nil {
-				entityStatus.Status = status.StatusAttached
+				entityStatus.Status = status.StatusAttached.String()
 				volumeAttachments = append(volumeAttachments, *result.VolumeAttachment)
 			}
 		}
@@ -148,7 +148,7 @@ func attachVolumes(ctx *context, ops map[params.MachineStorageId]*attachVolumeOp
 			p := volumeAttachmentParams[i]
 			statuses = append(statuses, params.EntityStatusArgs{
 				Tag:    p.Volume.String(),
-				Status: status.StatusAttached,
+				Status: status.StatusAttached.String(),
 			})
 			entityStatus := &statuses[len(statuses)-1]
 			if result.Error != nil {
@@ -163,7 +163,7 @@ func attachVolumes(ctx *context, ops map[params.MachineStorageId]*attachVolumeOp
 				// indicate that we will retry. When we distinguish
 				// between transient and permanent errors, we will
 				// set the status to "error" for permanent errors.
-				entityStatus.Status = status.StatusAttaching
+				entityStatus.Status = status.StatusAttaching.String()
 				entityStatus.Info = result.Error.Error()
 				logger.Debugf(
 					"failed to attach %s to %s: %v",
@@ -213,7 +213,7 @@ func destroyVolumes(ctx *context, ops map[names.VolumeTag]*destroyVolumeOp) erro
 			}
 			statuses = append(statuses, params.EntityStatusArgs{
 				Tag:    volumeParams[i].Tag.String(),
-				Status: status.StatusError,
+				Status: status.StatusError.String(),
 				Info:   err.Error(),
 			})
 			logger.Debugf(
@@ -247,7 +247,7 @@ func destroyVolumes(ctx *context, ops map[names.VolumeTag]*destroyVolumeOp) erro
 			reschedule = append(reschedule, ops[tag])
 			statuses = append(statuses, params.EntityStatusArgs{
 				Tag:    tag.String(),
-				Status: status.StatusDestroying,
+				Status: status.StatusDestroying.String(),
 				Info:   err.Error(),
 			})
 		}
@@ -290,7 +290,7 @@ func detachVolumes(ctx *context, ops map[params.MachineStorageId]*detachVolumeOp
 				// attachment, we'll have to check if
 				// there are any other attachments
 				// before saying the status "detached".
-				Status: status.StatusDetached,
+				Status: status.StatusDetached.String(),
 			})
 			id := params.MachineStorageId{
 				MachineTag:    p.Machine.String(),
@@ -299,7 +299,7 @@ func detachVolumes(ctx *context, ops map[params.MachineStorageId]*detachVolumeOp
 			entityStatus := &statuses[len(statuses)-1]
 			if err != nil {
 				reschedule = append(reschedule, ops[id])
-				entityStatus.Status = status.StatusDetaching
+				entityStatus.Status = status.StatusDetaching.String()
 				entityStatus.Info = err.Error()
 				logger.Debugf(
 					"failed to detach %s from %s: %v",

--- a/worker/unitassigner/unitassigner.go
+++ b/worker/unitassigner/unitassigner.go
@@ -77,7 +77,7 @@ func (u unitAssignerHandler) Handle(_ <-chan struct{}, ids []string) error {
 		for unit, err := range failures {
 			args.Entities[x] = params.EntityStatusArgs{
 				Tag:    unit,
-				Status: status.StatusError,
+				Status: status.StatusError.String(),
 				Info:   err.Error(),
 			}
 			x++

--- a/worker/unitassigner/unitassigner_test.go
+++ b/worker/unitassigner/unitassigner_test.go
@@ -63,7 +63,7 @@ func (testsuite) TestHandleError(c *gc.C) {
 	c.Assert(entities, gc.HasLen, 1)
 	c.Assert(entities[0], gc.DeepEquals, params.EntityStatusArgs{
 		Tag:    "unit-foo-0",
-		Status: status.StatusError,
+		Status: status.StatusError.String(),
 		Info:   e.Error(),
 	})
 }

--- a/worker/uniter/runner/context/context_test.go
+++ b/worker/uniter/runner/context/context_test.go
@@ -143,7 +143,13 @@ func (s *InterfaceSuite) TestUnitStatusCaching(c *gc.C) {
 	c.Check(unitStatus.Data, gc.DeepEquals, map[string]interface{}{})
 
 	// Change remote state.
-	err = s.unit.SetStatus(status.StatusActive, "it works", nil)
+	now := time.Now()
+	sInfo := status.StatusInfo{
+		Status:  status.StatusActive,
+		Message: "it works",
+		Since:   &now,
+	}
+	err = s.unit.SetStatus(sInfo)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Local view is unchanged.

--- a/worker/uniter/util_test.go
+++ b/worker/uniter/util_test.go
@@ -1061,7 +1061,13 @@ func (s verifyWaitingUpgradeError) step(c *gc.C, ctx *context) {
 			// to reset the error status, we can avoid a race in which a subsequent
 			// fixUpgradeError lands just before the restarting uniter retries the
 			// upgrade; and thus puts us in an unexpected state for future steps.
-			err := ctx.unit.SetAgentStatus(status.StatusIdle, "", nil)
+			now := time.Now()
+			sInfo := status.StatusInfo{
+				Status:  status.StatusIdle,
+				Message: "",
+				Since:   &now,
+			}
+			err := ctx.unit.SetAgentStatus(sInfo)
 			c.Check(err, jc.ErrorIsNil)
 		}},
 		startUniter{},


### PR DESCRIPTION
* Added backlog filters using dates and deltas in days.
* Added capability for Instance statuses to be declared as ephemeral so they wont be stored in history but only shown in status.
* Added status output squashing for repeated groups of 2 and 3 logs.

(Review request: http://reviews.vapour.ws/r/4518/)