### PR TITLE
state: Don't use model UUID for GridFS namespace

### DIFF
--- a/state/backups/storage.go
+++ b/state/backups/storage.go
@@ -270,7 +270,7 @@ func (b *storageDBWrapper) runTransaction(ops []txn.Op) error {
 
 // blobStorage returns a ManagedStorage matching the env storage and the blobDB.
 func (b *storageDBWrapper) blobStorage(blobDB string) blobstore.ManagedStorage {
-	dataStore := blobstore.NewGridFS(blobDB, b.modelUUID, b.session)
+	dataStore := blobstore.NewGridFS(blobDB, blobDB, b.session)
 	return blobstore.NewManagedStorage(b.db, dataStore)
 }
 

--- a/state/binarystorage.go
+++ b/state/binarystorage.go
@@ -29,7 +29,7 @@ func (st *State) GUIStorage() (binarystorage.StorageCloser, error) {
 
 func newStorage(st *State, uuid, metadataCollection string) binarystorage.StorageCloser {
 	session := st.session.Clone()
-	rs := blobstore.NewGridFS(blobstoreDB, uuid, session)
+	rs := blobstore.NewGridFS(blobstoreDB, blobstoreDB, session)
 	db := session.DB(jujuDB)
 	c := db.C(metadataCollection)
 	txnRunner := jujutxn.NewRunner(jujutxn.RunnerParams{Database: db})

--- a/state/binarystorage/binarystorage_test.go
+++ b/state/binarystorage/binarystorage_test.go
@@ -50,7 +50,7 @@ func (s *binaryStorageSuite) SetUpTest(c *gc.C) {
 	var err error
 	s.session, err = s.mongo.Dial()
 	c.Assert(err, jc.ErrorIsNil)
-	rs := blobstore.NewGridFS("blobstore", "my-uuid", s.session)
+	rs := blobstore.NewGridFS("blobstore", "blobstore", s.session)
 	catalogue := s.session.DB("catalogue")
 	s.managedStorage = blobstore.NewManagedStorage(catalogue, rs)
 	s.metadataCollection = catalogue.C("binarymetadata")

--- a/state/storage/storage.go
+++ b/state/storage/storage.go
@@ -53,7 +53,7 @@ type stateStorage struct {
 
 func (s stateStorage) blobstore() (*mgo.Session, blobstore.ManagedStorage) {
 	session := s.session.Copy()
-	rs := blobstore.NewGridFS(blobstoreDB, s.modelUUID, session)
+	rs := blobstore.NewGridFS(blobstoreDB, blobstoreDB, session)
 	db := session.DB(metadataDB)
 	return session, blobstore.NewManagedStorage(db, rs)
 }

--- a/state/storage/storage_test.go
+++ b/state/storage/storage_test.go
@@ -42,7 +42,7 @@ func (s *StorageSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 	s.MgoSuite.SetUpTest(c)
 
-	rs := blobstore.NewGridFS("blobstore", testUUID, s.Session)
+	rs := blobstore.NewGridFS("blobstore", "blobstore", s.Session)
 	db := s.Session.DB("juju")
 	s.managedStorage = blobstore.NewManagedStorage(db, rs)
 	s.storage = storage.NewStorage(testUUID, s.Session)


### PR DESCRIPTION
In most uses of GridFS within Juju, the model UUID was being used as the GridFS namespace. This meant that if the same resource was written out through multiple models, it would only be accessible via the first model (due to deduping). A fixed namespace is now used to allow sharing of resources with identical content across models.

Fixes LP #1569054.

Note that due to the change in the underlyin gstorage locations, this revision will break upgrades from previous 2.0 pre-releases.

(Review request: http://reviews.vapour.ws/r/4523/)