### PR TITLE
Try both private *and* public API addresses.

### DIFF
--- a/apiserver/common/addresses.go
+++ b/apiserver/common/addresses.go
@@ -66,9 +66,11 @@ func (api *APIAddresser) APIAddresses() (params.StringsResult, error) {
 	}
 	var addrs = make([]string, 0, len(apiHostPorts))
 	for _, hostPorts := range apiHostPorts {
-		addr := network.SelectInternalHostPort(hostPorts, false)
-		if addr != "" {
-			addrs = append(addrs, addr)
+		ordered := network.PrioritizeInternalHostPorts(hostPorts, false)
+		for _, addr := range ordered {
+			if addr != "" {
+				addrs = append(addrs, addr)
+			}
 		}
 	}
 	return params.StringsResult{

--- a/network/address_test.go
+++ b/network/address_test.go
@@ -723,6 +723,78 @@ func (s *AddressSuite) TestSelectInternalHostPorts(c *gc.C) {
 	}
 }
 
+var prioritizeInternalHostPortsTests = []selectInternalHostPortsTest{{
+	"no addresses gives empty string result",
+	[]network.HostPort{},
+	[]string{},
+	false,
+}, {
+	"a public IPv4 address is selected",
+	[]network.HostPort{
+		{network.NewScopedNamedAddress("8.8.8.8", "public", network.ScopePublic), 9999},
+	},
+	[]string{"8.8.8.8:9999"},
+	false,
+}, {
+	"public IPv6 addresses selected when both IPv4 and IPv6 addresses exist and preferIPv6 is true",
+	[]network.HostPort{
+		{network.NewScopedNamedAddress("8.8.8.8", "public", network.ScopePublic), 9999},
+		{network.NewScopedNamedAddress("2001:db8::1", "public", network.ScopePublic), 8888},
+		{network.NewScopedNamedAddress("2002:db8::1", "public", network.ScopePublic), 9999},
+	},
+	[]string{"[2001:db8::1]:8888", "[2002:db8::1]:9999", "8.8.8.8:9999"},
+	true,
+}, {
+	"a cloud local IPv4 addresses are selected",
+	[]network.HostPort{
+		{network.NewScopedNamedAddress("10.1.0.1", "private", network.ScopeCloudLocal), 8888},
+		{network.NewScopedNamedAddress("8.8.8.8", "public", network.ScopePublic), 123},
+		{network.NewScopedNamedAddress("10.0.0.1", "private", network.ScopeCloudLocal), 1234},
+	},
+	[]string{"10.1.0.1:8888", "10.0.0.1:1234", "8.8.8.8:123"},
+	false,
+}, {
+	"a machine local or link-local address is not selected",
+	[]network.HostPort{
+		{network.NewScopedNamedAddress("127.0.0.1", "machine", network.ScopeMachineLocal), 111},
+		{network.NewScopedNamedAddress("::1", "machine", network.ScopeMachineLocal), 222},
+		{network.NewScopedNamedAddress("fe80::1", "machine", network.ScopeLinkLocal), 333},
+	},
+	[]string{},
+	false,
+}, {
+	"cloud local addresses are preferred to a public addresses",
+	[]network.HostPort{
+		{network.NewScopedNamedAddress("2001:db8::1", "public", network.ScopePublic), 123},
+		{network.NewScopedNamedAddress("fc00::1", "cloud", network.ScopeCloudLocal), 123},
+		{network.NewScopedNamedAddress("8.8.8.8", "public", network.ScopePublic), 123},
+		{network.NewScopedNamedAddress("10.0.0.1", "cloud", network.ScopeCloudLocal), 4444},
+	},
+	[]string{"[fc00::1]:123", "10.0.0.1:4444", "[2001:db8::1]:123", "8.8.8.8:123"},
+	false,
+}, {
+	"IPv4 addresses are used when prefer-IPv6 is set but no IPv6 addresses are available",
+	[]network.HostPort{
+		{network.NewScopedNamedAddress("8.8.8.8", "public", network.ScopePublic), 123},
+		{network.NewScopedNamedAddress("10.0.0.1", "cloud", network.ScopeCloudLocal), 4444},
+	},
+	[]string{"10.0.0.1:4444", "8.8.8.8:123"},
+	true,
+}}
+
+func (s *AddressSuite) TestPrioritizeInternalHostPorts(c *gc.C) {
+	oldValue := network.PreferIPv6()
+	defer func() {
+		network.SetPreferIPv6(oldValue)
+	}()
+	for i, t := range prioritizeInternalHostPortsTests {
+		c.Logf("test %d: %s", i, t.about)
+		network.SetPreferIPv6(t.preferIPv6)
+		prioritized := network.PrioritizeInternalHostPorts(t.addresses, false)
+		c.Check(prioritized, gc.DeepEquals, t.expected)
+	}
+}
+
 var stringTests = []struct {
 	addr network.Address
 	str  string


### PR DESCRIPTION
(fixes https://bugs.launchpad.net/juju-core/+bug/1566431)

We have been trying only the private IP addresses (or falling back to public) when provisioning new instances.  In some situations the private address is not reachable so we must fall back to the public one.  This patch makes that change.

(Review request: http://reviews.vapour.ws/r/4525/)