### PR TITLE
Increase TLS CA and server key length to 2048 bits.

### DIFF
--- a/cert/cert.go
+++ b/cert/cert.go
@@ -19,7 +19,7 @@ import (
 	"github.com/juju/errors"
 )
 
-var KeyBits = 1024
+var KeyBits = 2048
 
 // ParseCert parses the given PEM-formatted X509 certificate.
 func ParseCert(certPEM string) (*x509.Certificate, error) {

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/api"
+	"github.com/juju/juju/cert"
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/environs"
@@ -99,6 +100,7 @@ func (s *JujuConnSuite) SetUpSuite(c *gc.C) {
 	s.MgoSuite.SetUpSuite(c)
 	s.FakeJujuXDGDataHomeSuite.SetUpSuite(c)
 	s.PatchValue(&utils.OutgoingAccessAllowed, false)
+	s.PatchValue(&cert.KeyBits, 1024) // Use a shorter key for a faster TLS handshake.
 }
 
 func (s *JujuConnSuite) TearDownSuite(c *gc.C) {


### PR DESCRIPTION
Fixes [LP:#1569086](https://bugs.launchpad.net/juju-core/+bug/1569086).

(Review request: http://reviews.vapour.ws/r/4526/)