### PR TITLE
1569024: Do case-insensitive region comparison

### DIFF
--- a/cmd/juju/cloud/defaultregion.go
+++ b/cmd/juju/cloud/defaultregion.go
@@ -54,13 +54,13 @@ func (c *setDefaultRegionCommand) Init(args []string) (err error) {
 	return cmd.CheckEmpty(args[2:])
 }
 
-func hasRegion(region string, regions []jujucloud.Region) bool {
+func getRegion(region string, regions []jujucloud.Region) string {
 	for _, r := range regions {
-		if r.Name == region {
-			return true
+		if strings.EqualFold(r.Name, region) {
+			return r.Name
 		}
 	}
-	return false
+	return ""
 }
 
 func (c *setDefaultRegionCommand) Run(ctxt *cmd.Context) error {
@@ -71,7 +71,7 @@ func (c *setDefaultRegionCommand) Run(ctxt *cmd.Context) error {
 	if len(cloudDetails.Regions) == 0 {
 		return errors.Errorf("cloud %s has no regions", c.cloud)
 	}
-	if !hasRegion(c.region, cloudDetails.Regions) {
+	if region := getRegion(c.region, cloudDetails.Regions); region == "" {
 		var regionNames []string
 		for _, r := range cloudDetails.Regions {
 			regionNames = append(regionNames, r.Name)
@@ -80,6 +80,8 @@ func (c *setDefaultRegionCommand) Run(ctxt *cmd.Context) error {
 			nil,
 			fmt.Sprintf("region %q for cloud %s not valid, valid regions are %s",
 				c.region, c.cloud, strings.Join(regionNames, ", ")))
+	} else {
+		c.region = region
 	}
 	var cred *jujucloud.CloudCredential
 	cred, err = c.store.CredentialForCloud(c.cloud)

--- a/cmd/juju/cloud/defaultregion_test.go
+++ b/cmd/juju/cloud/defaultregion_test.go
@@ -83,3 +83,13 @@ func (s *defaultRegionSuite) TestOverwriteDefaultRegion(c *gc.C) {
 	cmd := cloud.NewSetDefaultRegionCommandForTest(store)
 	s.assertSetDefaultRegion(c, cmd, store, "aws", "")
 }
+
+func (s *defaultRegionSuite) TestCaseInsensitiveRegionSpecification(c *gc.C) {
+	store := jujuclienttesting.NewMemStore()
+	store.Credentials["aws"] = jujucloud.CloudCredential{DefaultRegion: "us-east-1"}
+
+	cmd := cloud.NewSetDefaultRegionCommandForTest(store)
+	_, err := testing.RunCommand(c, cmd, "aws", "us-WEST-1")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(store.Credentials["aws"].DefaultRegion, gc.Equals, "us-west-1")
+}

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -573,7 +573,8 @@ func getRegion(cloud *jujucloud.Cloud, cloudName, regionName string) (jujucloud.
 		return cloud.Regions[0], nil
 	}
 	for _, region := range cloud.Regions {
-		if region.Name == regionName {
+		// Do a case-insensitive comparison
+		if strings.EqualFold(region.Name, regionName) {
 			return region, nil
 		}
 	}

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -1090,6 +1090,24 @@ func (s *BootstrapSuite) TestBootstrapProviderDetectRegions(c *gc.C) {
 	c.Assert(errMsg, gc.Matches, `region "not-dummy" in cloud "dummy" not found \(expected one of \["dummy"\]\)alternatively, try "juju update-clouds"`)
 }
 
+func (s *BootstrapSuite) TestBootstrapProviderCaseInsensitiveRegionCheck(c *gc.C) {
+	s.patchVersionAndSeries(c, "raring")
+
+	var prepareParams environs.PrepareParams
+	s.PatchValue(&environsPrepare, func(
+		ctx environs.BootstrapContext,
+		stor jujuclient.ClientStore,
+		params environs.PrepareParams,
+	) (environs.Environ, error) {
+		prepareParams = params
+		return nil, fmt.Errorf("mock-prepare")
+	})
+
+	_, err := coretesting.RunCommand(c, s.newBootstrapCommand(), "ctrl", "dummy/DUMMY")
+	c.Assert(err, gc.ErrorMatches, "mock-prepare")
+	c.Assert(prepareParams.CloudRegion, gc.Equals, "dummy")
+}
+
 func (s *BootstrapSuite) TestBootstrapConfigFile(c *gc.C) {
 	tmpdir := c.MkDir()
 	configFile := filepath.Join(tmpdir, "config.yaml")


### PR DESCRIPTION
When comparing a specified region to the regions
specified for the cloud, use a case insensitive
comparison.

(Review request: http://reviews.vapour.ws/r/4528/)