### PR TITLE
apiserver: Per model directory for charm get cache

### DIFF
--- a/apiserver/charms.go
+++ b/apiserver/charms.go
@@ -412,7 +412,12 @@ func (h *charmsHandler) processGet(r *http.Request, st *state.State) (string, st
 
 	// Prepare the bundle directories.
 	name := charm.Quote(curlString)
-	charmArchivePath := filepath.Join(h.dataDir, "charm-get-cache", name+".zip")
+	charmArchivePath := filepath.Join(
+		h.dataDir,
+		"charm-get-cache",
+		st.ModelUUID(),
+		name+".zip",
+	)
 
 	// Check if the charm archive is already in the cache.
 	if _, err := os.Stat(charmArchivePath); os.IsNotExist(err) {

--- a/apiserver/charms_test.go
+++ b/apiserver/charms_test.go
@@ -476,7 +476,7 @@ func (s *charmsSuite) TestGetReturnsManifest(c *gc.C) {
 
 func (s *charmsSuite) TestGetUsesCache(c *gc.C) {
 	// Add a fake charm archive in the cache directory.
-	cacheDir := filepath.Join(s.DataDir(), "charm-get-cache")
+	cacheDir := filepath.Join(s.DataDir(), "charm-get-cache", s.State.ModelUUID())
 	err := os.MkdirAll(cacheDir, 0755)
 	c.Assert(err, jc.ErrorIsNil)
 


### PR DESCRIPTION
Fixes LP #1541482.

Local charms in different models of the same controller were sharing the same cache filename when they had the same charm URL. This was causing charm hash mismatches when units downloaded a charm and received a different version to what was expected.

Also simplified temp file cleanup during charm download.
