### PR TITLE
Fix mongo set up so it works with ha

### DIFF
--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -90,16 +90,15 @@ var (
 
 	// The following are defined as variables to allow the tests to
 	// intercept calls to the functions.
-	useMultipleCPUs          = utils.UseMultipleCPUs
-	maybeInitiateMongoServer = peergrouper.MaybeInitiateMongoServer
-	ensureMongoAdminUser     = mongo.EnsureAdminUser
-	modelManifolds           = model.Manifolds
-	newSingularRunner        = singular.New
-	peergrouperNew           = peergrouper.New
-	newCertificateUpdater    = certupdater.NewCertificateUpdater
-	newMetadataUpdater       = imagemetadataworker.NewWorker
-	newUpgradeMongoWorker    = mongoupgrader.New
-	reportOpenedState        = func(io.Closer) {}
+	useMultipleCPUs       = utils.UseMultipleCPUs
+	ensureMongoAdminUser  = mongo.EnsureAdminUser
+	modelManifolds        = model.Manifolds
+	newSingularRunner     = singular.New
+	peergrouperNew        = peergrouper.New
+	newCertificateUpdater = certupdater.NewCertificateUpdater
+	newMetadataUpdater    = imagemetadataworker.NewWorker
+	newUpgradeMongoWorker = mongoupgrader.New
+	reportOpenedState     = func(io.Closer) {}
 )
 
 // Variable to override in tests, default is true

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -128,7 +128,6 @@ func (s *commonMachineSuite) SetUpTest(c *gc.C) {
 	})
 
 	s.fakeEnsureMongo = agenttesting.InstallFakeEnsureMongo(s)
-	s.AgentSuite.PatchValue(&maybeInitiateMongoServer, s.fakeEnsureMongo.MaybeInitiateMongo)
 }
 
 func (s *commonMachineSuite) assertChannelActive(c *gc.C, aChannel chan struct{}, intent string) {
@@ -201,7 +200,7 @@ func (s *commonMachineSuite) configureMachine(c *gc.C, machineId string, vers ve
 	inst, md := jujutesting.AssertStartInstance(c, s.Environ, machineId)
 	c.Assert(m.SetProvisioned(inst.Id(), agent.BootstrapNonce, md), jc.ErrorIsNil)
 
-	// Add an address for the tests in case the maybeInitiateMongoServer
+	// Add an address for the tests in case the initiateMongoServer
 	// codepath is exercised.
 	s.setFakeMachineAddresses(c, m)
 
@@ -1495,45 +1494,6 @@ func (s *MachineSuite) TestMachineAgentIgnoreAddressesContainer(c *gc.C) {
 	s.waitStopped(c, state.JobHostUnits, a, doneCh)
 }
 
-func (s *MachineSuite) TestMachineAgentUpgradeMongo(c *gc.C) {
-	m, agentConfig, _ := s.primeAgent(c, state.JobManageModel)
-	agentConfig.SetUpgradedToVersion(version.MustParse("1.18.0"))
-	err := agentConfig.Write()
-	c.Assert(err, jc.ErrorIsNil)
-	err = s.State.MongoSession().DB("admin").RemoveUser(m.Tag().String())
-	c.Assert(err, jc.ErrorIsNil)
-
-	s.fakeEnsureMongo.ServiceInstalled = true
-	s.fakeEnsureMongo.ReplicasetInitiated = false
-
-	s.AgentSuite.PatchValue(&ensureMongoAdminUser, func(p mongo.EnsureAdminUserParams) (bool, error) {
-		err := s.State.MongoSession().DB("admin").AddUser(p.User, p.Password, false)
-		c.Assert(err, jc.ErrorIsNil)
-		return true, nil
-	})
-
-	stateOpened := make(chan interface{}, 1)
-	s.AgentSuite.PatchValue(&reportOpenedState, func(st io.Closer) {
-		select {
-		case stateOpened <- st:
-		default:
-		}
-	})
-
-	// Start the machine agent, and wait for state to be opened.
-	a := s.newAgent(c, m)
-	done := make(chan error)
-	go func() { done <- a.Run(nil) }()
-	defer a.Stop() // in case of failure
-	select {
-	case st := <-stateOpened:
-		c.Assert(st, gc.NotNil)
-	case <-time.After(coretesting.LongWait):
-		c.Fatalf("state not opened")
-	}
-	s.waitStopped(c, state.JobManageModel, a, done)
-}
-
 func (s *MachineSuite) TestMachineAgentSetsPrepareRestore(c *gc.C) {
 	// Start the machine agent.
 	m, _, _ := s.primeAgent(c, state.JobHostUnits)
@@ -1745,7 +1705,6 @@ func (s *MachineSuite) TestReplicasetInitForNewController(c *gc.C) {
 	}
 
 	s.fakeEnsureMongo.ServiceInstalled = false
-	s.fakeEnsureMongo.ReplicasetInitiated = true
 
 	m, _, _ := s.primeAgent(c, state.JobManageModel)
 	a := s.newAgent(c, m)
@@ -1843,7 +1802,7 @@ func (s *mongoSuite) testStateWorkerDialSetsWriteMajority(c *gc.C, configureRepl
 			DialInfo:       info,
 			MemberHostPort: inst.Addr(),
 		}
-		err = peergrouper.MaybeInitiateMongoServer(args)
+		err = peergrouper.InitiateMongoServer(args)
 		c.Assert(err, jc.ErrorIsNil)
 		expectedWMode = "majority"
 	} else {

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -1532,8 +1532,6 @@ func (s *MachineSuite) TestMachineAgentUpgradeMongo(c *gc.C) {
 		c.Fatalf("state not opened")
 	}
 	s.waitStopped(c, state.JobManageModel, a, done)
-	c.Assert(s.fakeEnsureMongo.EnsureCount, gc.Equals, 1)
-	c.Assert(s.fakeEnsureMongo.InitiateCount, gc.Equals, 1)
 }
 
 func (s *MachineSuite) TestMachineAgentSetsPrepareRestore(c *gc.C) {
@@ -1739,42 +1737,6 @@ func (s *MachineSuite) setUpNewModel(c *gc.C) (newSt *state.State, closer func()
 		err := newSt.Close()
 		c.Check(err, jc.ErrorIsNil)
 	}
-}
-
-func (s *MachineSuite) TestReplicasetInitiation(c *gc.C) {
-	if runtime.GOOS == "windows" {
-		c.Skip("controllers on windows aren't supported")
-	}
-
-	s.fakeEnsureMongo.ReplicasetInitiated = false
-
-	m, _, _ := s.primeAgent(c, state.JobManageModel)
-	a := s.newAgent(c, m)
-	agentConfig := a.CurrentConfig()
-
-	err := a.ensureMongoServer(agentConfig)
-	c.Assert(err, jc.ErrorIsNil)
-
-	c.Assert(s.fakeEnsureMongo.EnsureCount, gc.Equals, 1)
-	c.Assert(s.fakeEnsureMongo.InitiateCount, gc.Equals, 1)
-}
-
-func (s *MachineSuite) TestReplicasetAlreadyInitiated(c *gc.C) {
-	if runtime.GOOS == "windows" {
-		c.Skip("controllers on windows aren't supported")
-	}
-
-	s.fakeEnsureMongo.ReplicasetInitiated = true
-
-	m, _, _ := s.primeAgent(c, state.JobManageModel)
-	a := s.newAgent(c, m)
-	agentConfig := a.CurrentConfig()
-
-	err := a.ensureMongoServer(agentConfig)
-	c.Assert(err, jc.ErrorIsNil)
-
-	c.Assert(s.fakeEnsureMongo.EnsureCount, gc.Equals, 1)
-	c.Assert(s.fakeEnsureMongo.InitiateCount, gc.Equals, 0)
 }
 
 func (s *MachineSuite) TestReplicasetInitForNewController(c *gc.C) {

--- a/cmd/jujud/agent/testing/agent.go
+++ b/cmd/jujud/agent/testing/agent.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/juju/cmd"
-	"github.com/juju/errors"
 	"github.com/juju/names"
 	"github.com/juju/replicaset"
 	gitjujutesting "github.com/juju/testing"
@@ -45,8 +44,7 @@ type patchingSuite interface {
 // out replicaset.CurrentConfig and cmdutil.EnsureMongoServer.
 func InstallFakeEnsureMongo(suite patchingSuite) *FakeEnsureMongo {
 	f := &FakeEnsureMongo{
-		ServiceInstalled:    true,
-		ReplicasetInitiated: true,
+		ServiceInstalled: true,
 	}
 	suite.PatchValue(&mongo.IsServiceInstalled, f.IsServiceInstalled)
 	suite.PatchValue(&replicaset.CurrentConfig, f.CurrentConfig)
@@ -57,15 +55,14 @@ func InstallFakeEnsureMongo(suite patchingSuite) *FakeEnsureMongo {
 // FakeEnsureMongo provides test fakes for the functions used to
 // initialise MongoDB.
 type FakeEnsureMongo struct {
-	EnsureCount         int
-	InitiateCount       int
-	DataDir             string
-	OplogSize           int
-	Info                state.StateServingInfo
-	InitiateParams      peergrouper.InitiateMongoParams
-	Err                 error
-	ServiceInstalled    bool
-	ReplicasetInitiated bool
+	EnsureCount      int
+	InitiateCount    int
+	DataDir          string
+	OplogSize        int
+	Info             state.StateServingInfo
+	InitiateParams   peergrouper.InitiateMongoParams
+	Err              error
+	ServiceInstalled bool
 }
 
 func (f *FakeEnsureMongo) IsServiceInstalled() (bool, error) {
@@ -73,14 +70,11 @@ func (f *FakeEnsureMongo) IsServiceInstalled() (bool, error) {
 }
 
 func (f *FakeEnsureMongo) CurrentConfig(*mgo.Session) (*replicaset.Config, error) {
-	if f.ReplicasetInitiated {
-		// Return a dummy replicaset config that's good enough to
-		// indicate that the replicaset is initiated.
-		return &replicaset.Config{
-			Members: []replicaset.Member{{}},
-		}, nil
-	}
-	return nil, errors.NotFoundf("replicaset")
+	// Return a dummy replicaset config that's good enough to
+	// indicate that the replicaset is initiated.
+	return &replicaset.Config{
+		Members: []replicaset.Member{{}},
+	}, nil
 }
 
 func (f *FakeEnsureMongo) EnsureMongo(args mongo.EnsureServerParams) error {
@@ -96,16 +90,6 @@ func (f *FakeEnsureMongo) EnsureMongo(args mongo.EnsureServerParams) error {
 		SystemIdentity: args.SystemIdentity,
 	}
 	return f.Err
-}
-
-func (f *FakeEnsureMongo) MaybeInitiateMongo(p peergrouper.InitiateMongoParams) error {
-	return f.InitiateMongo(p, false)
-}
-
-func (f *FakeEnsureMongo) InitiateMongo(p peergrouper.InitiateMongoParams, force bool) error {
-	f.InitiateCount++
-	f.InitiateParams = p
-	return nil
 }
 
 // agentSuite is a fixture to be used by agent test suites.

--- a/cmd/jujud/agent/testing/agent.go
+++ b/cmd/jujud/agent/testing/agent.go
@@ -92,6 +92,12 @@ func (f *FakeEnsureMongo) EnsureMongo(args mongo.EnsureServerParams) error {
 	return f.Err
 }
 
+func (f *FakeEnsureMongo) InitiateMongo(p peergrouper.InitiateMongoParams) error {
+	f.InitiateCount++
+	f.InitiateParams = p
+	return nil
+}
+
 // agentSuite is a fixture to be used by agent test suites.
 type AgentSuite struct {
 	oldRestartDelay time.Duration

--- a/cmd/jujud/bootstrap.go
+++ b/cmd/jujud/bootstrap.go
@@ -363,7 +363,7 @@ func (c *BootstrapCommand) startMongo(addrs []network.Address, agentConfig agent
 	return initiateMongoServer(peergrouper.InitiateMongoParams{
 		DialInfo:       dialInfo,
 		MemberHostPort: peerHostPort,
-	}, true)
+	})
 }
 
 // populateDefaultStoragePools creates the default storage pools.

--- a/cmd/jujud/bootstrap.go
+++ b/cmd/jujud/bootstrap.go
@@ -225,20 +225,6 @@ func (c *BootstrapCommand) Run(_ *cmd.Context) error {
 		return fmt.Errorf("cannot write agent config: %v", err)
 	}
 
-	err = c.ChangeConfig(func(config agent.ConfigSetter) error {
-		// We'll try for mongo 3.2 first and fallback to
-		// mongo 2.4 if the newer binaries are not available.
-		if mongo.BinariesAvailable(mongo.Mongo32wt) {
-			config.SetMongoVersion(mongo.Mongo32wt)
-		} else {
-			config.SetMongoVersion(mongo.Mongo24)
-		}
-		return nil
-	})
-	if err != nil {
-		return errors.Annotate(err, "cannot set mongo version")
-	}
-
 	agentConfig = c.CurrentConfig()
 
 	// Create system-identity file

--- a/cmd/jujud/bootstrap_test.go
+++ b/cmd/jujud/bootstrap_test.go
@@ -116,6 +116,7 @@ func (s *BootstrapSuite) SetUpTest(c *gc.C) {
 	s.logDir = c.MkDir()
 	s.mongoOplogSize = "1234"
 	s.fakeEnsureMongo = agenttesting.InstallFakeEnsureMongo(s)
+	s.PatchValue(&initiateMongoServer, s.fakeEnsureMongo.InitiateMongo)
 
 	// Create fake tools.tar.gz and downloaded-tools.txt.
 	current := version.Binary{

--- a/cmd/jujud/bootstrap_test.go
+++ b/cmd/jujud/bootstrap_test.go
@@ -116,7 +116,6 @@ func (s *BootstrapSuite) SetUpTest(c *gc.C) {
 	s.logDir = c.MkDir()
 	s.mongoOplogSize = "1234"
 	s.fakeEnsureMongo = agenttesting.InstallFakeEnsureMongo(s)
-	s.PatchValue(&initiateMongoServer, s.fakeEnsureMongo.InitiateMongo)
 
 	// Create fake tools.tar.gz and downloaded-tools.txt.
 	current := version.Binary{

--- a/cmd/jujud/upgrade_mongo.go
+++ b/cmd/jujud/upgrade_mongo.go
@@ -101,7 +101,7 @@ type mongoService func() error
 type mongoEnsureService func(string, int, int, bool, mongo.Version, bool) error
 type mongoDialInfo func(mongo.Info, mongo.DialOpts) (*mgo.DialInfo, error)
 
-type initiateMongoServerFunc func(peergrouper.InitiateMongoParams, bool) error
+type initiateMongoServerFunc func(peergrouper.InitiateMongoParams) error
 
 type replicaAddFunc func(mgoSession, ...replicaset.Member) error
 type replicaRemoveFunc func(mgoSession, ...string) error
@@ -516,7 +516,7 @@ func (u *UpgradeMongoCommand) maybeUpgrade26to3x(dataDir string) error {
 		err = u.initiateMongoServer(peergrouper.InitiateMongoParams{
 			DialInfo:       dialInfo,
 			MemberHostPort: peerHostPort,
-		}, true)
+		})
 		if err != nil {
 			return errors.Annotate(err, "cannot initiate replicaset")
 		}

--- a/cmd/jujud/upgrade_mongo_test.go
+++ b/cmd/jujud/upgrade_mongo_test.go
@@ -278,7 +278,7 @@ func (f *fakeRunCommand) mongoDialInfo(info mongo.Info, opts mongo.DialOpts) (*m
 	f.ranCommands = append(f.ranCommands, ran)
 	return &mgo.DialInfo{}, nil
 }
-func (f *fakeRunCommand) initiateMongoServer(args peergrouper.InitiateMongoParams, force bool) error {
+func (f *fakeRunCommand) initiateMongoServer(args peergrouper.InitiateMongoParams) error {
 	ran := []string{"peergrouper.InitiateMongoServer"}
 	f.ranCommands = append(f.ranCommands, ran)
 	return nil

--- a/cmd/jujud/util/util.go
+++ b/cmd/jujud/util/util.go
@@ -193,8 +193,6 @@ func NewEnsureServerParams(agentConfig agent.Config) (mongo.EnsureServerParams, 
 		DataDir:              agentConfig.DataDir(),
 		OplogSize:            oplogSize,
 		SetNumaControlPolicy: numaCtlPolicy,
-
-		Version: agentConfig.MongoVersion(),
 	}
 	return params, nil
 }

--- a/featuretests/dblog_test.go
+++ b/featuretests/dblog_test.go
@@ -129,7 +129,7 @@ func (s *debugLogDbSuite) SetUpSuite(c *gc.C) {
 		DialInfo:       info,
 		MemberHostPort: mongod.Addr(),
 	}
-	err := peergrouper.MaybeInitiateMongoServer(args)
+	err := peergrouper.InitiateMongoServer(args)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.AgentSuite.SetUpSuite(c)

--- a/featuretests/initiate_replset_test.go
+++ b/featuretests/initiate_replset_test.go
@@ -18,9 +18,6 @@ type InitiateSuite struct {
 
 var _ = gc.Suite(&InitiateSuite{})
 
-// TODO(natefinch) add a test that InitiateMongoServer works when
-// we support upgrading of existing environments.
-
 func (s *InitiateSuite) TestInitiateReplicaSet(c *gc.C) {
 	var err error
 	inst := &gitjujutesting.MgoInstance{Params: []string{"--replSet", "juju"}}
@@ -34,25 +31,11 @@ func (s *InitiateSuite) TestInitiateReplicaSet(c *gc.C) {
 		MemberHostPort: inst.Addr(),
 	}
 
-	err = peergrouper.MaybeInitiateMongoServer(args)
+	err = peergrouper.InitiateMongoServer(args)
 	c.Assert(err, jc.ErrorIsNil)
 
-	// This would return a mgo.QueryError if a ReplicaSet
-	// configuration already existed but we tried to create
-	// one with replicaset.Initiate again.
-	// ErrReplicaSetAlreadyInitiated is not a failure but an
-	// indication that we tried to initiate an initiated rs
-	err = peergrouper.MaybeInitiateMongoServer(args)
-	c.Assert(err, gc.Equals, peergrouper.ErrReplicaSetAlreadyInitiated)
-
-	// Make sure running InitiateMongoServer without forcing will behave
-	// in the same way as MaybeInitiateMongoServer
-	err = peergrouper.InitiateMongoServer(args, false)
-	c.Assert(err, gc.Equals, peergrouper.ErrReplicaSetAlreadyInitiated)
-
-	// Assert that passing Force to initiate will re-create the replicaset
-	// even though it exists already
-	err = peergrouper.InitiateMongoServer(args, true)
+	// Calling initiate again will re-create the replicaset even though it exists already
+	err = peergrouper.InitiateMongoServer(args)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// TODO test login

--- a/mongo/oplog_test.go
+++ b/mongo/oplog_test.go
@@ -232,7 +232,7 @@ func (s *oplogSuite) startMongoWithReplicaset(c *gc.C) (*jujutesting.MgoInstance
 		DialInfo:       info,
 		MemberHostPort: inst.Addr(),
 	}
-	err = peergrouper.MaybeInitiateMongoServer(args)
+	err = peergrouper.InitiateMongoServer(args)
 	c.Assert(err, jc.ErrorIsNil)
 
 	return inst, s.dialMongo(c, inst)

--- a/state/backups/restore.go
+++ b/state/backups/restore.go
@@ -40,7 +40,7 @@ func resetReplicaSet(dialInfo *mgo.DialInfo, memberHostPort string) error {
 		User:           dialInfo.Username,
 		Password:       dialInfo.Password,
 	}
-	return peergrouper.InitiateMongoServer(params, true)
+	return peergrouper.InitiateMongoServer(params)
 }
 
 var filesystemRoot = getFilesystemRoot

--- a/worker/peergrouper/initiate.go
+++ b/worker/peergrouper/initiate.go
@@ -35,18 +35,12 @@ type InitiateMongoParams struct {
 	Password string
 }
 
-// MaybeInitiateMongoServer is a convenience function for initiating a mongo
-// replicaset only if it is not already initiated.
-func MaybeInitiateMongoServer(p InitiateMongoParams) error {
-	return InitiateMongoServer(p, false)
-}
-
 // InitiateMongoServer checks for an existing mongo configuration.
 // If no existing configuration is found one is created using Initiate.
 // If force flag is true, the configuration will be started anyway.
-func InitiateMongoServer(p InitiateMongoParams, force bool) error {
+func InitiateMongoServer(p InitiateMongoParams) error {
 	logger.Debugf("Initiating mongo replicaset; dialInfo %#v; memberHostport %q; user %q; password %q", p.DialInfo, p.MemberHostPort, p.User, p.Password)
-	defer logger.Infof("finished MaybeInitiateMongoServer")
+	defer logger.Infof("finished InitiateMongoServer")
 
 	if len(p.DialInfo.Addrs) > 1 {
 		logger.Infof("more than one member; replica set must be already initiated")
@@ -54,19 +48,12 @@ func InitiateMongoServer(p InitiateMongoParams, force bool) error {
 	}
 	p.DialInfo.Direct = true
 
-	// TODO(rog) remove this code when we no longer need to upgrade
-	// from pre-HA-capable environments.
-	if p.User != "" {
-		p.DialInfo.Username = p.User
-		p.DialInfo.Password = p.Password
-	}
-
 	// Initiate may fail while mongo is initialising, so we retry until
 	// we successfully populate the replicaset config.
 	var err error
 	for attempt := initiateAttemptStrategy.Start(); attempt.Next(); {
-		err = attemptInitiateMongoServer(p.DialInfo, p.MemberHostPort, force)
-		if err == nil || err == ErrReplicaSetAlreadyInitiated {
+		err = attemptInitiateMongoServer(p.DialInfo, p.MemberHostPort)
+		if err == nil {
 			logger.Infof("replica set initiated")
 			return err
 		}
@@ -77,43 +64,14 @@ func InitiateMongoServer(p InitiateMongoParams, force bool) error {
 	return errors.Annotatef(err, "cannot initiate replica set")
 }
 
-// ErrReplicaSetAlreadyInitiated is returned with attemptInitiateMongoServer is called
-// on a mongo with an existing relicaset, it helps to assert which of the two valid
-// paths was taking when calling MaybeInitiateMongoServer/InitiateMongoServer which
-// is useful for testing purposes and also when debugging cases of faulty replica sets
-var ErrReplicaSetAlreadyInitiated = errors.New("replicaset is already initiated")
-
-func isNotUnreachableError(err error) bool {
-	return err.Error() != "no reachable servers"
-}
-
 // attemptInitiateMongoServer attempts to initiate the replica set.
-func attemptInitiateMongoServer(dialInfo *mgo.DialInfo, memberHostPort string, force bool) error {
+func attemptInitiateMongoServer(dialInfo *mgo.DialInfo, memberHostPort string) error {
 	session, err := mgo.DialWithInfo(dialInfo)
 	if err != nil {
 		return errors.Annotatef(err, "cannot dial mongo to initiate replicaset")
 	}
 	defer session.Close()
 	session.SetSocketTimeout(mongo.SocketTimeout)
-
-	if !force {
-		bInfo, err := session.BuildInfo()
-		if err != nil && isNotUnreachableError(err) {
-			return errors.Annotate(err, "cannot determine mongo build information")
-		}
-		var cfg *replicaset.Config
-		if err != nil || !bInfo.VersionAtLeast(3) {
-			cfg, err = replicaset.CurrentConfig(session)
-			if err != nil && err != mgo.ErrNotFound {
-				return errors.Errorf("cannot get replica set configuration: %v", err)
-			}
-		}
-
-		if cfg != nil && len(cfg.Members) > 0 {
-			logger.Infof("replica set configuration found: %#v", cfg)
-			return ErrReplicaSetAlreadyInitiated
-		}
-	}
 
 	return replicaset.Initiate(
 		session,

--- a/worker/peergrouper/initiate.go
+++ b/worker/peergrouper/initiate.go
@@ -37,7 +37,6 @@ type InitiateMongoParams struct {
 
 // InitiateMongoServer checks for an existing mongo configuration.
 // If no existing configuration is found one is created using Initiate.
-// If force flag is true, the configuration will be started anyway.
 func InitiateMongoServer(p InitiateMongoParams) error {
 	logger.Debugf("Initiating mongo replicaset; dialInfo %#v; memberHostport %q; user %q; password %q", p.DialInfo, p.MemberHostPort, p.User, p.Password)
 	defer logger.Infof("finished InitiateMongoServer")


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/juju-core/+bug/1569097

The jujud bootstrap command writes mongo version to agent.conf. However, when starting new machines for HA, the agent.conf does not have the mongo version set since we are not bootstrapping.

The mongo version handing is changed so that it is not done by bootstrap by instead when the machine agent starts. We also remove a bunch of legacy code which complicated mongo set up and only existed to upgrade old pre-HA environments (1.16 and earlier).

Tested with LXD. Ran ensure-ha -n 3 and verified that the new state servers eventually were recorded as has-vote.


(Review request: http://reviews.vapour.ws/r/4529/)