### PR TITLE
Controller agents ignore jobmanagenetworking

### DIFF
--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -887,6 +887,8 @@ func (a *MachineAgent) startStateWorkers(st *state.State) (worker.Worker, error)
 		switch job {
 		case state.JobHostUnits:
 			// Implemented elsewhere with workers that use the API.
+		case state.JobManageNetworking:
+			// Not used by state workers.
 		case state.JobManageModel:
 			useMultipleCPUs()
 			a.startWorkerAfterUpgrade(runner, "model worker manager", func() (worker.Worker, error) {

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -535,7 +535,8 @@ func (s *MachineSuite) TestManageModel(c *gc.C) {
 		Series: "quantal", // to match the charm created below
 	}
 	envtesting.AssertUploadFakeToolsVersions(c, s.DefaultToolsStorage, s.Environ.Config().AgentStream(), s.Environ.Config().AgentStream(), usefulVersion)
-	m, _, _ := s.primeAgent(c, state.JobManageModel)
+	// Prime agent with manage networking in additon to manage model to ensure the former is ignored.
+	m, _, _ := s.primeAgent(c, state.JobManageModel, state.JobManageNetworking)
 	op := make(chan dummy.Operation, 200)
 	dummy.Listen(op)
 


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/juju-core/+bug/1569196

When converting a machine to a controller, if the machine has been configured with JobManageNetworking, the agent startup would fail as that job type is not used by state server workers.

(Review request: http://reviews.vapour.ws/r/4537/)