### PR TITLE
provider/lxd: fix off-by-1 LXD subnet calculation

### DIFF
--- a/container/lxd/initialisation.go
+++ b/container/lxd/initialisation.go
@@ -178,7 +178,7 @@ func detectSubnet(ipAddrOutput string) (string, error) {
 		}
 	}
 
-	return fmt.Sprintf("%d", max+1), nil
+	return fmt.Sprintf("%d", max), nil
 }
 
 func editLXDBridgeFile(input string, subnet string) string {

--- a/container/lxd/initialisation_test.go
+++ b/container/lxd/initialisation_test.go
@@ -209,7 +209,7 @@ func (s *InitialiserSuite) TestDetectSubnet(c *gc.C) {
 
 	result, err := detectSubnet(input)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(result, jc.DeepEquals, "4")
+	c.Assert(result, jc.DeepEquals, "3")
 }
 
 func (s *InitialiserSuite) TestDetectSubnetLocal(c *gc.C) {


### PR DESCRIPTION
The call to detectSubnet() was always adding 1 to the network address
that was discovered when parsing the output from `ip addr'. This has the
unfortunate effect of changing the subnet for the LXD bridge after it
has been recorded by Juju. This meant that further container <=>
apiserver communication would break as the original value was recorded
in the agent.conf file.

Fixes [LP:#1569361](https://bugs.launchpad.net/juju-core/+bug/1569361)

(Review request: http://reviews.vapour.ws/r/4538/)