### PR TITLE
Fixed lp:1569725: proxyupdater api facade omits NotifyWatcherId from response

### DIFF
--- a/api/proxyupdater/proxyupdater.go
+++ b/api/proxyupdater/proxyupdater.go
@@ -51,7 +51,7 @@ func (api *API) WatchForProxyConfigAndAPIHostPortChanges() (watcher.NotifyWatche
 		return nil, err
 	}
 	if len(results.Results) != 1 {
-		return nil, fmt.Errorf("expected 1 result, got %d", len(results.Results))
+		return nil, errors.Errorf("expected 1 result, got %d", len(results.Results))
 	}
 	result := results.Results[0]
 	if result.Error != nil {
@@ -81,7 +81,7 @@ func (api *API) ProxyConfig() (proxySettings, APTProxySettings proxy.Settings, e
 		return proxySettings, APTProxySettings, err
 	}
 	if len(results.Results) != 1 {
-		return proxySettings, APTProxySettings, errors.NotFoundf("ProxyConfig for %q not found", api.tag)
+		return proxySettings, APTProxySettings, errors.NotFoundf("ProxyConfig for %q", api.tag)
 	}
 	result := results.Results[0]
 	proxySettings = proxySettingsParamToProxySettings(result.ProxySettings)

--- a/api/proxyupdater/proxyupdater_test.go
+++ b/api/proxyupdater/proxyupdater_test.go
@@ -54,7 +54,9 @@ func (s *ProxyUpdaterSuite) TestNilTagFails(c *gc.C) {
 
 func (s *ProxyUpdaterSuite) TestWatchForProxyConfigAndAPIHostPortChanges(c *gc.C) {
 	res := params.NotifyWatchResults{
-		Results: []params.NotifyWatchResult{params.NotifyWatchResult{}},
+		Results: []params.NotifyWatchResult{params.NotifyWatchResult{
+			NotifyWatcherId: "4242",
+		}},
 	}
 	args := []apitesting.CheckArgs{{
 		Facade:  "ProxyUpdater",
@@ -65,7 +67,7 @@ func (s *ProxyUpdaterSuite) TestWatchForProxyConfigAndAPIHostPortChanges(c *gc.C
 
 	watcher, err := api.WatchForProxyConfigAndAPIHostPortChanges()
 	workertest.CleanKill(c, watcher)
-	c.Check(*called, jc.GreaterThan, 0)
+	c.Check(*called, gc.Equals, 2)
 	c.Check(err, jc.ErrorIsNil)
 }
 

--- a/api/proxyupdater/proxyupdater_test.go
+++ b/api/proxyupdater/proxyupdater_test.go
@@ -67,7 +67,7 @@ func (s *ProxyUpdaterSuite) TestWatchForProxyConfigAndAPIHostPortChanges(c *gc.C
 
 	watcher, err := api.WatchForProxyConfigAndAPIHostPortChanges()
 	workertest.CleanKill(c, watcher)
-	c.Check(*called, gc.Equals, 2)
+	c.Check(*called, jc.GreaterThan, 0)
 	c.Check(err, jc.ErrorIsNil)
 }
 

--- a/apiserver/proxyupdater/proxyupdater.go
+++ b/apiserver/proxyupdater/proxyupdater.go
@@ -56,9 +56,7 @@ func (api *ProxyUpdaterAPI) oneWatch() params.NotifyWatchResult {
 			NotifyWatcherId: api.resources.Register(watch),
 		}
 	}
-	result = params.NotifyWatchResult{
-		Error: common.ServerError(watcher.EnsureErr(watch)),
-	}
+	result.Error = common.ServerError(watcher.EnsureErr(watch))
 	return result
 }
 


### PR DESCRIPTION
See http://pad.lv/1569725 for more info.
Live tested on MAAS.

(Review request: http://reviews.vapour.ws/r/4565/)