### PR TITLE
Revert "Merge pull request #5099 from frobware/next-lp1569361"

### DIFF
--- a/container/lxd/initialisation.go
+++ b/container/lxd/initialisation.go
@@ -178,7 +178,7 @@ func detectSubnet(ipAddrOutput string) (string, error) {
 		}
 	}
 
-	return fmt.Sprintf("%d", max), nil
+	return fmt.Sprintf("%d", max+1), nil
 }
 
 func editLXDBridgeFile(input string, subnet string) string {

--- a/container/lxd/initialisation_test.go
+++ b/container/lxd/initialisation_test.go
@@ -209,7 +209,7 @@ func (s *InitialiserSuite) TestDetectSubnet(c *gc.C) {
 
 	result, err := detectSubnet(input)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(result, jc.DeepEquals, "3")
+	c.Assert(result, jc.DeepEquals, "4")
 }
 
 func (s *InitialiserSuite) TestDetectSubnetLocal(c *gc.C) {


### PR DESCRIPTION
This reverts commit e305232168efa1b30631c8d43e9145143ced04f8, reversing
changes made to 879933cd3ce528025c8002dbd82c40d8492877fc.

The intent of the detectSubnet() was to look for an unsed subnet so this
change is not incorrect.

(Review request: http://reviews.vapour.ws/r/4566/)