### PR TITLE
Use the default network config when no juju-specific config is provided

### DIFF
--- a/container/lxd/lxd.go
+++ b/container/lxd/lxd.go
@@ -125,11 +125,14 @@ func (manager *containerManager) CreateContainer(
 		"boot.autostart": "true",
 	}
 
-	networkProfile := fmt.Sprintf("%s-network", name)
+	networkProfile := "default"
+	if len(networkConfig.Interfaces) > 0 {
+		networkProfile = fmt.Sprintf("%s-network", name)
 
-	err = manager.createNetworkProfile(networkProfile, networkConfig)
-	if err != nil {
-		return
+		err = manager.createNetworkProfile(networkProfile, networkConfig)
+		if err != nil {
+			return
+		}
 	}
 
 	spec := lxdclient.InstanceSpec{


### PR DESCRIPTION
73a85aaf creates network profiles based on network configuration provided
to the container type when network spaces are present (e.g. in maas, etc.).
However, in some cases (notably, AWS, GCE), there is no network
configuration provided to the container type code, and thus the profile
gets created with no network devices.

Instead, let's fall back to the default network configuration in LXD when
nothing is explicitly provided by juju.

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>

(Review request: http://reviews.vapour.ws/r/4575/)