### PR TITLE
Fixes cloud lookup to include built-in providers.

### DIFF
--- a/cmd/juju/cloud/addcredential.go
+++ b/cmd/juju/cloud/addcredential.go
@@ -16,6 +16,7 @@ import (
 	"launchpad.net/gnuflag"
 
 	jujucloud "github.com/juju/juju/cloud"
+	"github.com/juju/juju/cmd/juju/common"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/jujuclient"
 )
@@ -98,25 +99,10 @@ func (c *addCredentialCommand) Init(args []string) (err error) {
 	return cmd.CheckEmpty(args[1:])
 }
 
-func cloudOrProvider(cloudName string, cloudByNameFunc func(string) (*jujucloud.Cloud, error)) (cloud *jujucloud.Cloud, err error) {
-	if cloud, err = cloudByNameFunc(cloudName); err != nil {
-		if !errors.IsNotFound(err) {
-			return nil, err
-		}
-		builtInProviders := builtInProviders()
-		if builtIn, ok := builtInProviders[cloudName]; !ok {
-			return nil, errors.NotValidf("cloud %v", cloudName)
-		} else {
-			cloud = &builtIn
-		}
-	}
-	return cloud, nil
-}
-
 func (c *addCredentialCommand) Run(ctxt *cmd.Context) error {
 	// Check that the supplied cloud is valid.
 	var err error
-	if c.cloud, err = cloudOrProvider(c.CloudName, c.cloudByNameFunc); err != nil {
+	if c.cloud, err = common.CloudOrProvider(c.CloudName, c.cloudByNameFunc); err != nil {
 		if !errors.IsNotFound(err) {
 			return err
 		}

--- a/cmd/juju/cloud/defaultcredential.go
+++ b/cmd/juju/cloud/defaultcredential.go
@@ -8,6 +8,7 @@ import (
 	"github.com/juju/errors"
 
 	jujucloud "github.com/juju/juju/cloud"
+	"github.com/juju/juju/cmd/juju/common"
 	"github.com/juju/juju/jujuclient"
 )
 
@@ -61,7 +62,7 @@ func hasCredential(credential string, credentials map[string]jujucloud.Credentia
 }
 
 func (c *setDefaultCredentialCommand) Run(ctxt *cmd.Context) error {
-	if _, err := cloudOrProvider(c.cloud, jujucloud.CloudByName); err != nil {
+	if _, err := common.CloudOrProvider(c.cloud, jujucloud.CloudByName); err != nil {
 		return err
 	}
 	cred, err := c.store.CredentialForCloud(c.cloud)

--- a/cmd/juju/cloud/defaultregion.go
+++ b/cmd/juju/cloud/defaultregion.go
@@ -4,13 +4,14 @@
 package cloud
 
 import (
-	"github.com/juju/cmd"
-	"github.com/juju/errors"
-
 	"fmt"
 	"strings"
 
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+
 	jujucloud "github.com/juju/juju/cloud"
+	"github.com/juju/juju/cmd/juju/common"
 	"github.com/juju/juju/jujuclient"
 )
 
@@ -64,7 +65,7 @@ func getRegion(region string, regions []jujucloud.Region) string {
 }
 
 func (c *setDefaultRegionCommand) Run(ctxt *cmd.Context) error {
-	cloudDetails, err := cloudOrProvider(c.cloud, jujucloud.CloudByName)
+	cloudDetails, err := common.CloudOrProvider(c.cloud, jujucloud.CloudByName)
 	if err != nil {
 		return err
 	}

--- a/cmd/juju/cloud/detectcredentials.go
+++ b/cmd/juju/cloud/detectcredentials.go
@@ -16,6 +16,7 @@ import (
 	"github.com/juju/utils/set"
 
 	jujucloud "github.com/juju/juju/cloud"
+	"github.com/juju/juju/cmd/juju/common"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/jujuclient"
 )
@@ -352,7 +353,7 @@ func (c *detectCredentialsCommand) promptCloudName(out io.Writer, in io.Reader, 
 	if cloudName == "" {
 		return defaultCloudName, nil
 	}
-	cloud, err := c.cloudByNameFunc(cloudName)
+	cloud, err := common.CloudOrProvider(cloudName, c.cloudByNameFunc)
 	if err != nil {
 		return "", err
 	}

--- a/cmd/juju/cloud/detectcredentials_test.go
+++ b/cmd/juju/cloud/detectcredentials_test.go
@@ -173,7 +173,7 @@ func (s *detectCredentialsSuite) TestDetectCredentialDefaultCloud(c *gc.C) {
 }
 
 func (s *detectCredentialsSuite) TestDetectCredentialUnknownCloud(c *gc.C) {
-	s.assertDetectCredential(c, "foo", "", "cloud foo not found")
+	s.assertDetectCredential(c, "foo", "", "cloud foo not valid")
 }
 
 func (s *detectCredentialsSuite) TestDetectCredentialInvalidCloud(c *gc.C) {

--- a/cmd/juju/cloud/listcredentials.go
+++ b/cmd/juju/cloud/listcredentials.go
@@ -15,6 +15,7 @@ import (
 	"launchpad.net/gnuflag"
 
 	jujucloud "github.com/juju/juju/cloud"
+	"github.com/juju/juju/cmd/juju/common"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/jujuclient"
 )
@@ -143,7 +144,7 @@ func (c *listCredentialsCommand) Run(ctxt *cmd.Context) error {
 }
 
 func (c *listCredentialsCommand) removeSecrets(cloudName string, cloudCred *jujucloud.CloudCredential) error {
-	cloud, err := c.cloudByNameFunc(cloudName)
+	cloud, err := common.CloudOrProvider(cloudName, c.cloudByNameFunc)
 	if err != nil {
 		return err
 	}

--- a/cmd/juju/common/cloud.go
+++ b/cmd/juju/common/cloud.go
@@ -1,0 +1,65 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package common
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+
+	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/environs"
+)
+
+var logger = loggo.GetLogger("juju.cmd.juju.cloud")
+
+// CloudOrProvider finds and returns cloud or provider.
+func CloudOrProvider(cloudName string, cloudByNameFunc func(string) (*cloud.Cloud, error)) (cloud *cloud.Cloud, err error) {
+	if cloud, err = cloudByNameFunc(cloudName); err != nil {
+		if !errors.IsNotFound(err) {
+			return nil, err
+		}
+		builtInProviders := BuiltInProviders()
+		if builtIn, ok := builtInProviders[cloudName]; !ok {
+			return nil, errors.NotValidf("cloud %v", cloudName)
+		} else {
+			cloud = &builtIn
+		}
+	}
+	return cloud, nil
+}
+
+// BuiltInProviders returns cloud information for those
+// providers which are built in to Juju.
+func BuiltInProviders() map[string]cloud.Cloud {
+	builtIn := make(map[string]cloud.Cloud)
+	for _, name := range cloud.BuiltInProviderNames {
+		provider, err := environs.Provider(name)
+		if err != nil {
+			// Should never happen but it will on go 1.2
+			// because lxd provider is not built.
+			logger.Warningf("cloud %q not available on this platform", name)
+			continue
+		}
+		var regions []cloud.Region
+		if detector, ok := provider.(environs.CloudRegionDetector); ok {
+			regions, err = detector.DetectRegions()
+			if err != nil && !errors.IsNotFound(err) {
+				logger.Warningf("could not detect regions for %q: %v", name, err)
+			}
+		}
+		aCloud := cloud.Cloud{
+			Type:    name,
+			Regions: regions,
+		}
+		schema := provider.CredentialSchemas()
+		for authType := range schema {
+			if authType == cloud.EmptyAuthType {
+				continue
+			}
+			aCloud.AuthTypes = append(aCloud.AuthTypes, authType)
+		}
+		builtIn[name] = aCloud
+	}
+	return builtIn
+}

--- a/cmd/juju/controller/createmodel.go
+++ b/cmd/juju/controller/createmodel.go
@@ -105,7 +105,7 @@ func (c *createModelCommand) Init(args []string) error {
 			return errors.Errorf("invalid cloud credential %s, expected <cloud>:<credential-name>", c.CredentialSpec)
 		}
 		c.CloudName = parts[0]
-		if cloud, err := cloud.CloudByName(c.CloudName); err != nil {
+		if cloud, err := common.CloudOrProvider(c.CloudName, cloud.CloudByName); err != nil {
 			return errors.Trace(err)
 		} else {
 			c.CloudType = cloud.Type


### PR DESCRIPTION
These commands look up cloud by name. This lookup should also include built-in providers such as lxd, maas and manual.

This PR refactors lookup code and updates all relevant commands to use it. 

(Review request: http://reviews.vapour.ws/r/4579/)