### PR TITLE
New HA controllers use better constraints

### DIFF
--- a/apiserver/highavailability/highavailability.go
+++ b/apiserver/highavailability/highavailability.go
@@ -148,13 +148,12 @@ func EnableHASingle(st *state.State, spec params.ControllersSpec) (params.Contro
 		controllerId := controllerIds[0]
 		controller, err := st.Machine(strconv.Itoa(controllerId))
 		if err != nil {
-			return params.ControllersChanges{}, errors.Annotatef(err, "reading controller machine id %v", controllerId)
+			return params.ControllersChanges{}, errors.Annotatef(err, "reading controller id %v", controllerId)
 		}
 		spec.Constraints, err = controller.Constraints()
 		if err != nil {
-			return params.ControllersChanges{}, errors.Annotatef(err, "reading constraints for controller machine id %v", controllerId)
+			return params.ControllersChanges{}, errors.Annotatef(err, "reading constraints for controller id %v", controllerId)
 		}
-		spec.Constraints, err = controller.Constraints()
 	}
 
 	changes, err := st.EnableHA(spec.NumControllers, spec.Constraints, series, spec.Placement)

--- a/apiserver/highavailability/highavailability_test.go
+++ b/apiserver/highavailability/highavailability_test.go
@@ -49,8 +49,9 @@ func assertKill(c *gc.C, killer Killer) {
 }
 
 var (
-	emptyCons     = constraints.Value{}
-	defaultSeries = ""
+	emptyCons      = constraints.Value{}
+	controllerCons = constraints.MustParse("mem=16G cpu-cores=16")
+	defaultSeries  = ""
 )
 
 func (s *clientSuite) SetUpTest(c *gc.C) {
@@ -67,7 +68,11 @@ func (s *clientSuite) SetUpTest(c *gc.C) {
 	s.haServer, err = highavailability.NewHighAvailabilityAPI(s.State, s.resources, s.authoriser)
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = s.State.AddMachine("quantal", state.JobManageModel)
+	_, err = s.State.AddMachines(state.MachineTemplate{
+		Series:      "quantal",
+		Jobs:        []state.MachineJob{state.JobManageModel},
+		Constraints: controllerCons,
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	// We have to ensure the agents are alive, or EnableHA will
 	// create more to replace them.
@@ -179,9 +184,32 @@ func (s *clientSuite) TestEnableHAConstraints(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(machines, gc.HasLen, 3)
 	expectedCons := []constraints.Value{
-		{},
+		controllerCons,
 		constraints.MustParse("mem=4G"),
 		constraints.MustParse("mem=4G"),
+	}
+	for i, m := range machines {
+		cons, err := m.Constraints()
+		c.Assert(err, jc.ErrorIsNil)
+		c.Check(cons, gc.DeepEquals, expectedCons[i])
+	}
+}
+
+func (s *clientSuite) TestEnableHAEmptyConstraints(c *gc.C) {
+	enableHAResult, err := s.enableHA(c, 3, emptyCons, defaultSeries, nil)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(enableHAResult.Maintained, gc.DeepEquals, []string{"machine-0"})
+	c.Assert(enableHAResult.Added, gc.DeepEquals, []string{"machine-1", "machine-2"})
+	c.Assert(enableHAResult.Removed, gc.HasLen, 0)
+	c.Assert(enableHAResult.Converted, gc.HasLen, 0)
+
+	machines, err := s.State.AllMachines()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(machines, gc.HasLen, 3)
+	expectedCons := []constraints.Value{
+		controllerCons,
+		controllerCons,
+		controllerCons,
 	}
 	for i, m := range machines {
 		cons, err := m.Constraints()
@@ -220,7 +248,7 @@ func (s *clientSuite) TestEnableHAPlacement(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(machines, gc.HasLen, 3)
 	expectedCons := []constraints.Value{
-		{},
+		controllerCons,
 		constraints.MustParse("mem=4G"),
 		constraints.MustParse("mem=4G"),
 	}
@@ -234,8 +262,12 @@ func (s *clientSuite) TestEnableHAPlacement(c *gc.C) {
 }
 
 func (s *clientSuite) TestEnableHAPlacementTo(c *gc.C) {
-	_, err := s.State.AddMachine("quantal", state.JobHostUnits)
-	c.Assert(err, jc.ErrorIsNil)
+	machine1Cons := constraints.MustParse("mem=8G")
+	_, err := s.State.AddMachines(state.MachineTemplate{
+		Series:      "quantal",
+		Jobs:        []state.MachineJob{state.JobHostUnits},
+		Constraints: machine1Cons,
+	})
 	s.pingers = append(s.pingers, s.setAgentPresence(c, "1"))
 
 	_, err = s.State.AddMachine("quantal", state.JobHostUnits)
@@ -253,7 +285,11 @@ func (s *clientSuite) TestEnableHAPlacementTo(c *gc.C) {
 	machines, err := s.State.AllMachines()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(machines, gc.HasLen, 3)
-	expectedCons := []constraints.Value{{}, {}, {}}
+	expectedCons := []constraints.Value{
+		controllerCons,
+		machine1Cons,
+		{},
+	}
 	expectedPlacement := []string{"", "", ""}
 	for i, m := range machines {
 		cons, err := m.Constraints()

--- a/apiserver/highavailability/highavailability_test.go
+++ b/apiserver/highavailability/highavailability_test.go
@@ -206,15 +206,10 @@ func (s *clientSuite) TestEnableHAEmptyConstraints(c *gc.C) {
 	machines, err := s.State.AllMachines()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(machines, gc.HasLen, 3)
-	expectedCons := []constraints.Value{
-		controllerCons,
-		controllerCons,
-		controllerCons,
-	}
-	for i, m := range machines {
+	for _, m := range machines {
 		cons, err := m.Constraints()
 		c.Assert(err, jc.ErrorIsNil)
-		c.Check(cons, gc.DeepEquals, expectedCons[i])
+		c.Check(cons, gc.DeepEquals, controllerCons)
 	}
 }
 


### PR DESCRIPTION
Fixes: https://pad.lv/1561315

When enable HA makes new controllers, and the user has not specified any constraints, we use the constraints off the original controller (if the user had specified bootstrap constraints, there would be what is used).

(Review request: http://reviews.vapour.ws/r/4584/)