### PR TITLE
Ensure http header digest is correct

### DIFF
--- a/apiserver/backup.go
+++ b/apiserver/backup.go
@@ -5,7 +5,6 @@ package apiserver
 
 import (
 	"encoding/json"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -149,7 +148,7 @@ func (h *backupHandler) parseGETArgs(req *http.Request) (*params.BackupsDownload
 func (h *backupHandler) sendFile(file io.Reader, checksum string, resp http.ResponseWriter) error {
 	// We don't set the Content-Length header, leaving it at -1.
 	resp.Header().Set("Content-Type", params.ContentTypeRaw)
-	resp.Header().Set("Digest", fmt.Sprintf("%s=%s", params.DigestSHA256, params.EncodeChecksum(checksum)))
+	resp.Header().Set("Digest", params.EncodeChecksum(checksum))
 	resp.WriteHeader(http.StatusOK)
 	if _, err := io.Copy(resp, file); err != nil {
 		return errors.Annotate(err, "while streaming archive")

--- a/apiserver/backup.go
+++ b/apiserver/backup.go
@@ -149,7 +149,7 @@ func (h *backupHandler) parseGETArgs(req *http.Request) (*params.BackupsDownload
 func (h *backupHandler) sendFile(file io.Reader, checksum string, resp http.ResponseWriter) error {
 	// We don't set the Content-Length header, leaving it at -1.
 	resp.Header().Set("Content-Type", params.ContentTypeRaw)
-	resp.Header().Set("Digest", fmt.Sprintf("%s=%s", params.DigestSHA, checksum))
+	resp.Header().Set("Digest", fmt.Sprintf("%s=%s", params.DigestSHA256, params.EncodeChecksum(checksum)))
 	resp.WriteHeader(http.StatusOK)
 	if _, err := io.Copy(resp, file); err != nil {
 		return errors.Annotate(err, "while streaming archive")

--- a/apiserver/backup_test.go
+++ b/apiserver/backup_test.go
@@ -5,6 +5,7 @@ package apiserver_test
 
 import (
 	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -235,7 +236,8 @@ func (s *backupsDownloadSuite) TestResponse(c *gc.C) {
 	meta := s.fake.Meta
 
 	c.Check(resp.StatusCode, gc.Equals, http.StatusOK)
-	c.Check(resp.Header.Get("Digest"), gc.Equals, string(params.DigestSHA)+"="+meta.Checksum())
+	expectedChecksum := base64.StdEncoding.EncodeToString([]byte(meta.Checksum()))
+	c.Check(resp.Header.Get("Digest"), gc.Equals, string(params.DigestSHA256)+"="+expectedChecksum)
 	c.Check(resp.Header.Get("Content-Type"), gc.Equals, params.ContentTypeRaw)
 }
 

--- a/apiserver/images.go
+++ b/apiserver/images.go
@@ -67,7 +67,7 @@ func (h *imagesDownloadHandler) processGet(r *http.Request, resp http.ResponseWr
 	// Stream the image to the caller.
 	logger.Debugf("streaming image from state blobstore: %+v", metadata)
 	resp.Header().Set("Content-Type", "application/x-tar-gz")
-	resp.Header().Set("Digest", fmt.Sprintf("%s=%s", params.DigestSHA, metadata.SHA256))
+	resp.Header().Set("Digest", fmt.Sprintf("%s=%s", params.DigestSHA256, params.EncodeChecksum(metadata.SHA256)))
 	resp.Header().Set("Content-Length", fmt.Sprint(metadata.Size))
 	resp.WriteHeader(http.StatusOK)
 	if _, err := io.Copy(resp, imageReader); err != nil {

--- a/apiserver/images.go
+++ b/apiserver/images.go
@@ -67,7 +67,7 @@ func (h *imagesDownloadHandler) processGet(r *http.Request, resp http.ResponseWr
 	// Stream the image to the caller.
 	logger.Debugf("streaming image from state blobstore: %+v", metadata)
 	resp.Header().Set("Content-Type", "application/x-tar-gz")
-	resp.Header().Set("Digest", fmt.Sprintf("%s=%s", params.DigestSHA256, params.EncodeChecksum(metadata.SHA256)))
+	resp.Header().Set("Digest", params.EncodeChecksum(metadata.SHA256))
 	resp.Header().Set("Content-Length", fmt.Sprint(metadata.Size))
 	resp.WriteHeader(http.StatusOK)
 	if _, err := io.Copy(resp, imageReader); err != nil {

--- a/apiserver/images_test.go
+++ b/apiserver/images_test.go
@@ -21,7 +21,6 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"encoding/base64"
 	"github.com/juju/juju/apiserver/params"
 	containertesting "github.com/juju/juju/container/testing"
 	sstesting "github.com/juju/juju/environs/simplestreams/testing"

--- a/apiserver/images_test.go
+++ b/apiserver/images_test.go
@@ -20,6 +20,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"encoding/base64"
 	"github.com/juju/juju/apiserver/params"
 	containertesting "github.com/juju/juju/container/testing"
 	sstesting "github.com/juju/juju/environs/simplestreams/testing"
@@ -206,7 +207,8 @@ func (s *imageSuite) TestDownloadFetchNoSHA256File(c *gc.C) {
 
 func (s *imageSuite) testDownload(c *gc.C, resp *http.Response) []byte {
 	c.Check(resp.StatusCode, gc.Equals, http.StatusOK)
-	c.Check(resp.Header.Get("Digest"), gc.Equals, string(params.DigestSHA)+"="+testImageChecksum)
+	expectedChecksum := base64.StdEncoding.EncodeToString([]byte(testImageChecksum))
+	c.Check(resp.Header.Get("Digest"), gc.Equals, string(params.DigestSHA256)+"="+expectedChecksum)
 	c.Check(resp.Header.Get("Content-Type"), gc.Equals, "application/x-tar-gz")
 	c.Check(resp.Header.Get("Content-Length"), gc.Equals, fmt.Sprintf("%v", len(testImageData)))
 

--- a/apiserver/images_test.go
+++ b/apiserver/images_test.go
@@ -7,6 +7,7 @@ package apiserver_test
 
 import (
 	"crypto/sha256"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"

--- a/apiserver/params/http.go
+++ b/apiserver/params/http.go
@@ -3,7 +3,10 @@
 
 package params
 
-import "encoding/base64"
+import (
+	"encoding/base64"
+	"fmt"
+)
 
 // DigestAlgorithm is one of the values in the IANA registry. See
 // RFC 3230 and 5843.
@@ -28,7 +31,8 @@ const (
 	ContentTypeXJS = "application/x-javascript"
 )
 
-// EncodeChecksum base64 encodes a digest checksum according to RFC 4648.
+// EncodeChecksum base64 encodes a sha256 checksum according to RFC 4648 and
+// returns a value that can be added to the "Digest" http header.
 func EncodeChecksum(checksum string) string {
-	return base64.StdEncoding.EncodeToString([]byte(checksum))
+	return fmt.Sprintf("%s=%s", DigestSHA256, base64.StdEncoding.EncodeToString([]byte(checksum)))
 }

--- a/apiserver/params/http.go
+++ b/apiserver/params/http.go
@@ -3,19 +3,15 @@
 
 package params
 
+import "encoding/base64"
+
 // DigestAlgorithm is one of the values in the IANA registry. See
 // RFC 3230 and 5843.
-//
-// Note that currently Juju does not conform to the standard.
-// It stores a hexadecimal SHA256 value in the Digest header,
-// but the above RFCs specify SHA-256 and a base64-encoded
-// value for this.
-// TODO fix that. https://bugs.launchpad.net/juju-core/+bug/1503992
 type DigestAlgorithm string
 
 const (
 	// DigestSHA is the HTTP digest algorithm value used in juju's HTTP code.
-	DigestSHA DigestAlgorithm = "SHA"
+	DigestSHA256 DigestAlgorithm = "SHA-256"
 
 	// The values used for content-type in juju's direct HTTP code:
 
@@ -31,3 +27,8 @@ const (
 	// ContentTypeXJS is the outdated HTTP content-type value used for javascript.
 	ContentTypeXJS = "application/x-javascript"
 )
+
+// EncodeChecksum base64 encodes a digest checksum according to RFC 4648.
+func EncodeChecksum(checksum string) string {
+	return base64.StdEncoding.EncodeToString([]byte(checksum))
+}


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/juju-core/+bug/1503992

We adjust the Digest header to say "SHA-256" and change the contents so the checksum value is base64 encoded.

(Review request: http://reviews.vapour.ws/r/4585/)