### PR TITLE
run: convert end lines from windows so they get rendered properly

### DIFF
--- a/cmd/juju/commands/run.go
+++ b/cmd/juju/commands/run.go
@@ -156,7 +156,7 @@ func ConvertActionResults(result params.ActionResult, query actionQuery) map[str
 	// We always want to have a string for stdout, but only show stderr,
 	// code and error if they are there.
 	if res, ok := result.Output["Stdout"].(string); ok {
-		values["Stdout"] = res
+		values["Stdout"] = strings.Replace(res, "\r\n", "\n", -1)
 		if res, ok := result.Output["StdoutEncoding"].(string); ok && res != "" {
 			values["Stdout.encoding"] = res
 		}
@@ -164,7 +164,7 @@ func ConvertActionResults(result params.ActionResult, query actionQuery) map[str
 		values["Stdout"] = ""
 	}
 	if res, ok := result.Output["Stderr"].(string); ok && res != "" {
-		values["Stderr"] = res
+		values["Stderr"] = strings.Replace(res, "\r\n", "\n", -1)
 		if res, ok := result.Output["StderrEncoding"].(string); ok && res != "" {
 			values["Stderr.encoding"] = res
 		}


### PR DESCRIPTION
Not much to see here, but we noticed this problem while using run.

(Review request: http://reviews.vapour.ws/r/4593/)