### PR TITLE
environs: add default config value for automatically-retry-hooks

### DIFF
--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -1396,6 +1396,7 @@ func allDefaults() schema.Defaults {
 		"disable-network-management": false,
 		IgnoreMachineAddresses:       false,
 		SetNumaControlPolicyKey:      DefaultNumaControlPolicy,
+		AutomaticallyRetryHooks:      true,
 	}
 	for attr, val := range alwaysOptional {
 		if _, ok := d[attr]; !ok {
@@ -1916,7 +1917,6 @@ data of the store. (default false)`,
 	AutomaticallyRetryHooks: {
 		Description: "Determines whether the uniter should automatically retry failed hooks",
 		Type:        environschema.Tbool,
-		Immutable:   true,
 		Group:       environschema.EnvironGroup,
 	},
 }


### PR DESCRIPTION
Without adding this to allDefaults, it would show some warning when trying to set it from the CLI.

Also it's not meant to be immutable and it has been removed from the immutable list some time ago, but I noticed it still says Immutable: true in the configSchema. It didn't seem to affect it during testing, but removing it is still saner.

http://reviews.vapour.ws/r/4594/