### PR TITLE
Clearer error message when bootstrapping against MAAS2 with the feature flag off

### DIFF
--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -319,11 +319,12 @@ func (env *maasEnviron) SetConfig(cfg *config.Config) error {
 	// and 2.0. MAAS 1.9 uses the 1.0 api version and 2.0 uses the 2.0 api
 	// version.
 	apiVersion := apiVersion2
+	maas2Enabled := featureflag.Enabled(feature.MAAS2)
 	controller, err := GetMAAS2Controller(ecfg.maasServer(), ecfg.maasOAuth())
 	switch {
-	case !featureflag.Enabled(feature.MAAS2) && err == nil:
+	case !maas2Enabled && err == nil:
 		return errors.NewNotSupported(nil, "MAAS 2 is not supported unless the 'maas2' feature flag is set")
-	case !featureflag.Enabled(feature.MAAS2) || (err != nil && gomaasapi.IsUnsupportedVersionError(err)):
+	case !maas2Enabled || gomaasapi.IsUnsupportedVersionError(err):
 		apiVersion = apiVersion1
 		authClient, err := gomaasapi.NewAuthenticatedClient(ecfg.maasServer(), ecfg.maasOAuth(), apiVersion1)
 		if err != nil {

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -318,11 +318,11 @@ func (env *maasEnviron) SetConfig(cfg *config.Config) error {
 	// and 2.0. MAAS 1.9 uses the 1.0 api version and 2.0 uses the 2.0 api
 	// version.
 	apiVersion := apiVersion2
-	var controller gomaasapi.Controller
-	if featureflag.Enabled(feature.MAAS2) {
-		controller, err = GetMAAS2Controller(ecfg.maasServer(), ecfg.maasOAuth())
-	}
-	if !featureflag.Enabled(feature.MAAS2) || err != nil && gomaasapi.IsUnsupportedVersionError(err) {
+	controller, err := GetMAAS2Controller(ecfg.maasServer(), ecfg.maasOAuth())
+	switch {
+	case !featureflag.Enabled(feature.MAAS2) && err == nil:
+		return errors.NewNotSupported(nil, "MAAS 2 is not supported unless the 'maas2' feature flag is set")
+	case !featureflag.Enabled(feature.MAAS2) || (err != nil && gomaasapi.IsUnsupportedVersionError(err)):
 		apiVersion = apiVersion1
 		authClient, err := gomaasapi.NewAuthenticatedClient(ecfg.maasServer(), ecfg.maasOAuth(), apiVersion1)
 		if err != nil {
@@ -336,9 +336,9 @@ func (env *maasEnviron) SetConfig(cfg *config.Config) error {
 		if !caps.Contains(capNetworkDeploymentUbuntu) {
 			return errors.NotSupportedf("MAAS 1.9 or more recent is required")
 		}
-	} else if err != nil {
+	case err != nil:
 		return errors.Trace(err)
-	} else {
+	default:
 		env.maasController = controller
 	}
 	env.apiVersion = apiVersion

--- a/provider/maas/maas2_environ_whitebox_test.go
+++ b/provider/maas/maas2_environ_whitebox_test.go
@@ -33,6 +33,9 @@ func (suite *maas2EnvironSuite) getEnvWithServer(c *gc.C) (*maasEnviron, error) 
 	testServer := gomaasapi.NewSimpleServer()
 	testServer.AddGetResponse("/api/2.0/version/", http.StatusOK, maas2VersionResponse)
 	testServer.AddGetResponse("/api/2.0/users/?op=whoami", http.StatusOK, "{}")
+	// Weirdly, rather than returning a 404 when the version is
+	// unknown, MAAS2 returns some HTML (the login page).
+	testServer.AddGetResponse("/api/1.0/version/", http.StatusOK, "<html></html>")
 	testServer.Start()
 	suite.AddCleanup(func(*gc.C) { testServer.Close() })
 	testAttrs := coretesting.Attrs{}


### PR DESCRIPTION
The MAAS 2 API returns a 200 and some HTML when you request the /1.0/version endpoint. This meant that the version checking wasn't working - boostrapping against MAAS 2 with the feature flag off would give a cryptic "ERROR Requested map, got <nil>" error.

Now it says: 
ERROR MAAS 2 is not supported unless the 'maas2' feature flag is set

(Review request: http://reviews.vapour.ws/r/4595/)