### PR TITLE
Pass feature flags through to jujud bootstrap-state.

### DIFF
--- a/cloudconfig/userdatacfg_test.go
+++ b/cloudconfig/userdatacfg_test.go
@@ -728,7 +728,7 @@ func (*cloudinitSuite) TestCloudInitConfigure(c *gc.C) {
 	}
 }
 
-func (*cloudinitSuite) TestCloudInitConfigureBootstrapLogging(c *gc.C) {
+func (*cloudinitSuite) bootstrapConfigScripts(c *gc.C) []string {
 	loggo.GetLogger("").SetLogLevel(loggo.INFO)
 	envConfig := minimalModelConfig(c)
 	instConfig := makeBootstrapConfig("quantal").maybeSetModelConfig(envConfig)
@@ -752,10 +752,22 @@ func (*cloudinitSuite) TestCloudInitConfigureBootstrapLogging(c *gc.C) {
 			c.Logf("scripts[%d]: %q", i, script)
 		}
 	}
+	return scripts
+}
+
+func (s *cloudinitSuite) TestCloudInitConfigureBootstrapLogging(c *gc.C) {
+	scripts := s.bootstrapConfigScripts(c)
 	expected := "jujud bootstrap-state --data-dir '.*' --model-config '.*'" +
 		" --hosted-model-config '[^']*'" +
 		" --instance-id '.*' --bootstrap-constraints 'mem=4096M'" +
 		" --constraints 'mem=2048M' --show-log"
+	assertScriptMatch(c, scripts, expected, false)
+}
+
+func (s *cloudinitSuite) TestCloudInitConfigureBootstrapFeatureFlags(c *gc.C) {
+	s.SetFeatureFlags("special", "foo")
+	scripts := s.bootstrapConfigScripts(c)
+	expected := "JUJU_DEV_FEATURE_FLAGS=foo,special .*/jujud bootstrap-state .*"
 	assertScriptMatch(c, scripts, expected, false)
 }
 

--- a/cloudconfig/userdatacfg_unix.go
+++ b/cloudconfig/userdatacfg_unix.go
@@ -20,6 +20,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names"
+	"github.com/juju/utils/featureflag"
 	"github.com/juju/utils/os"
 	"github.com/juju/utils/proxy"
 	goyaml "gopkg.in/yaml.v2"
@@ -28,6 +29,7 @@ import (
 	"github.com/juju/juju/cloudconfig/cloudinit"
 	"github.com/juju/juju/environs/imagemetadata"
 	"github.com/juju/juju/environs/simplestreams"
+	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/service"
 	"github.com/juju/juju/service/systemd"
 	"github.com/juju/juju/service/upstart"
@@ -349,9 +351,13 @@ func (w *unixConfigure) ConfigureJuju() error {
 		if loggo.GetLogger("").LogLevel() == loggo.DEBUG {
 			loggingOption = " --debug"
 		}
+		featureFlags := featureflag.AsEnvironmentValue()
+		if featureFlags != "" {
+			featureFlags = fmt.Sprintf("%s=%s ", osenv.JujuFeatureFlagEnvKey, featureFlags)
+		}
 		w.conf.AddScripts(
 			// The bootstrapping is always run with debug on.
-			w.icfg.JujuTools() + "/jujud bootstrap-state" +
+			featureFlags + w.icfg.JujuTools() + "/jujud bootstrap-state" +
 				" --data-dir " + shquote(w.icfg.DataDir) +
 				" --model-config " + shquote(base64yaml(w.icfg.Config.AllAttrs())) +
 				" --hosted-model-config " + shquote(base64yaml(w.icfg.HostedModelConfig)) +


### PR DESCRIPTION
The feature flags are passed to the agents through the agent config, but they were never passed to the bootstrap-state command. Now that we have a feature flag (maas2) that is needed during the bootstrap phase, this is a problem.

(Review request: http://reviews.vapour.ws/r/4603/)