### PR TITLE
State and API functionality for storing SSH host keys

### DIFF
--- a/api/machiner/machine.go
+++ b/api/machiner/machine.go
@@ -137,3 +137,19 @@ func (m *Machine) SetProviderNetworkConfig() error {
 	}
 	return result.OneError()
 }
+
+// SetSSHHostKeys reports the public SSH host keys for the machine to
+// the controller. The keys should be in the same format as the sshd
+// host key files, one entry per key.
+func (m *Machine) SetSSHHostKeys(publicKeys []string) error {
+	args := params.SSHHostKeySet{EntityKeys: []params.SSHHostKeys{{
+		Tag:        m.tag.String(),
+		PublicKeys: publicKeys,
+	}}}
+	var result params.ErrorResults
+	err := m.st.facade.FacadeCall("SetSSHHostKeys", args, &result)
+	if err != nil {
+		return err
+	}
+	return result.OneError()
+}

--- a/api/machiner/machiner_test.go
+++ b/api/machiner/machiner_test.go
@@ -202,3 +202,22 @@ func (s *machinerSuite) TestWatch(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertOneChange()
 }
+
+func (s *machinerSuite) TestSetSSHHostKeys(c *gc.C) {
+	tag := names.NewMachineTag("1")
+
+	// No keys to start.
+	_, err := s.State.GetSSHHostKeys(tag)
+	c.Assert(errors.IsNotFound(err), jc.IsTrue)
+
+	// Set some keys.
+	machine, err := s.machiner.Machine(tag)
+	c.Assert(err, jc.ErrorIsNil)
+	err = machine.SetSSHHostKeys([]string{"rsa", "dsa", "ecdsa"})
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Check keys were written.
+	keysGot, err := s.State.GetSSHHostKeys(tag)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(keysGot, gc.DeepEquals, state.SSHHostKeys{"rsa", "dsa", "ecdsa"})
+}

--- a/apiserver/machine/machiner.go
+++ b/apiserver/machine/machiner.go
@@ -278,3 +278,29 @@ func (api *MachinerAPI) getOneMachineProviderNetworkConfig(m *state.Machine) ([]
 
 	return providerConfig, nil
 }
+
+// SetSSHHostKeys sets the SSH host keys for one or more entities.
+func (api *MachinerAPI) SetSSHHostKeys(args params.SSHHostKeySet) (params.ErrorResults, error) {
+	results := params.ErrorResults{
+		Results: make([]params.ErrorResult, len(args.EntityKeys)),
+	}
+
+	canModify, err := api.getCanModify()
+	if err != nil {
+		return results, err
+	}
+
+	for i, arg := range args.EntityKeys {
+		tag, err := names.ParseMachineTag(arg.Tag)
+		if err != nil {
+			results.Results[i].Error = common.ServerError(common.ErrPerm)
+			continue
+		}
+		err = common.ErrPerm
+		if canModify(tag) {
+			err = api.st.SetSSHHostKeys(tag, state.SSHHostKeys(arg.PublicKeys))
+		}
+		results.Results[i].Error = common.ServerError(err)
+	}
+	return results, nil
+}

--- a/apiserver/params/ssh.go
+++ b/apiserver/params/ssh.go
@@ -1,0 +1,16 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package params
+
+// SSHHostKeySet defines SSH host keys for one or more entities
+// (typically machines).
+type SSHHostKeySet struct {
+	EntityKeys []SSHHostKeys `json:"entity-keys"`
+}
+
+// SSHHostKeys defines the SSH host keys for one entity.
+type SSHHostKeys struct {
+	Tag        string   `json:"tag"`
+	PublicKeys []string `json:"public-keys"`
+}

--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -246,6 +246,7 @@ func allCollections() collectionSchema {
 		instanceDataC:  {},
 		machinesC:      {},
 		rebootC:        {},
+		sshHostKeysC:   {},
 
 		// -----
 
@@ -454,6 +455,7 @@ const (
 	endpointBindingsC        = "endpointbindings"
 	settingsC                = "settings"
 	settingsrefsC            = "settingsrefs"
+	sshHostKeysC             = "sshhostkeys"
 	spacesC                  = "spaces"
 	statusesC                = "statuses"
 	statusesHistoryC         = "statuseshistory"

--- a/state/machine.go
+++ b/state/machine.go
@@ -888,6 +888,7 @@ func (m *Machine) Remove() (err error) {
 		removeRebootDocOp(m.st, m.globalKey()),
 		removeMachineBlockDevicesOp(m.Id()),
 		removeModelMachineRefOp(m.st, m.Id()),
+		removeSSHHostKeyOp(m.st, m.globalKey()),
 	}
 	ifacesOps, err := m.removeNetworkInterfacesOps()
 	if err != nil {

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -108,6 +108,10 @@ func (s *MigrationSuite) TestKnownCollections(c *gc.C) {
 		// This has been deprecated in 2.0, and should not contain any data
 		// we actually care about migrating.
 		legacyipaddressesC,
+
+		// The SSH host keys for each machine will be reported as each
+		// machiner starts up.
+		sshHostKeysC,
 	)
 
 	// THIS SET WILL BE REMOVED WHEN MIGRATIONS ARE COMPLETE

--- a/state/sshhostkeys.go
+++ b/state/sshhostkeys.go
@@ -66,3 +66,13 @@ func (st *State) SetSSHHostKeys(tag names.MachineTag, keys SSHHostKeys) error {
 	})
 	return errors.Annotate(err, "SSH host key update failed")
 }
+
+// removeSSHHostKeyOp returns the operation needed to remove the SSH
+// host key document associated with the given globalKey.
+func removeSSHHostKeyOp(st *State, globalKey string) txn.Op {
+	return txn.Op{
+		C:      sshHostKeysC,
+		Id:     globalKey,
+		Remove: true,
+	}
+}

--- a/state/sshhostkeys.go
+++ b/state/sshhostkeys.go
@@ -1,0 +1,68 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/names"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
+	"gopkg.in/mgo.v2/txn"
+)
+
+// SSHHostKeys holds the public SSH host keys for an entity (almost
+// certainly a machine).
+//
+// The host keys are one line each and are stored in the same format
+// as the SSH authorized_keys and ssh_host_key*.pub files.
+type SSHHostKeys []string
+
+// sshHostKeysDoc represents the MongoDB document that stores the SSH
+// host keys for an entity.
+//
+// Note that the document id hasn't been included because we don't
+// need to read it or (directly) write it.
+type sshHostKeysDoc struct {
+	Keys []string `bson:"keys"`
+}
+
+// GetSSHHostKeys retrieves the SSH host keys stored for an entity.
+///
+// NOTE: Currently only machines are supported. This can be
+// generalised to take other tag types later, if and when we need it.
+func (st *State) GetSSHHostKeys(tag names.MachineTag) (SSHHostKeys, error) {
+	coll, closer := st.getCollection(sshHostKeysC)
+	defer closer()
+
+	var doc sshHostKeysDoc
+	err := coll.FindId(machineGlobalKey(tag.Id())).One(&doc)
+	if err == mgo.ErrNotFound {
+		return nil, errors.NotFoundf("SSH host keys for %s", tag)
+	} else if err != nil {
+		return nil, errors.Annotate(err, "SSH host key lookup failed")
+	}
+	return SSHHostKeys(doc.Keys), nil
+}
+
+// SetSSHHostKeys updates the stored SSH host keys for an entity.
+//
+// See the note for GetSSHHostKeys regarding supported entities.
+func (st *State) SetSSHHostKeys(tag names.MachineTag, keys SSHHostKeys) error {
+	id := machineGlobalKey(tag.Id())
+	doc := sshHostKeysDoc{
+		Keys: keys,
+	}
+	err := st.runTransaction([]txn.Op{
+		{
+			C:      sshHostKeysC,
+			Id:     id,
+			Insert: doc,
+		}, {
+			C:      sshHostKeysC,
+			Id:     id,
+			Update: bson.M{"$set": doc},
+		},
+	})
+	return errors.Annotate(err, "SSH host key update failed")
+}

--- a/state/sshhostkeys_test.go
+++ b/state/sshhostkeys_test.go
@@ -1,0 +1,68 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state_test
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/names"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/testing/factory"
+)
+
+type SSHHostKeysSuite struct {
+	ConnSuite
+	machineTag names.MachineTag
+}
+
+var _ = gc.Suite(new(SSHHostKeysSuite))
+
+func (s *SSHHostKeysSuite) SetUpTest(c *gc.C) {
+	s.ConnSuite.SetUpTest(c)
+	s.machineTag = s.Factory.MakeMachine(c, nil).MachineTag()
+}
+
+func (s *SSHHostKeysSuite) TestGetWithNoKeys(c *gc.C) {
+	checkKeysNotFound(c, s.State, s.machineTag)
+}
+
+func (s *SSHHostKeysSuite) TestSetGet(c *gc.C) {
+	for i := 0; i < 3; i++ {
+		keys := state.SSHHostKeys{"rsa foo", "dsa bar"}
+		err := s.State.SetSSHHostKeys(s.machineTag, keys)
+		c.Assert(err, jc.ErrorIsNil)
+		checkGet(c, s.State, s.machineTag, keys)
+	}
+}
+
+func (s *SSHHostKeysSuite) TestModelIsolation(c *gc.C) {
+	stA := s.State
+	tagA := s.machineTag
+	keysA := state.SSHHostKeys{"rsaA", "dsaA"}
+	c.Assert(stA.SetSSHHostKeys(tagA, keysA), jc.ErrorIsNil)
+
+	stB := s.Factory.MakeModel(c, nil)
+	defer stB.Close()
+	factoryB := factory.NewFactory(stB)
+	tagB := factoryB.MakeMachine(c, nil).MachineTag()
+	keysB := state.SSHHostKeys{"rsaB", "dsaB"}
+	c.Assert(stB.SetSSHHostKeys(tagB, keysB), jc.ErrorIsNil)
+
+	checkGet(c, stA, tagA, keysA)
+	checkGet(c, stB, tagB, keysB)
+}
+
+func checkKeysNotFound(c *gc.C, st *state.State, tag names.MachineTag) {
+	_, err := st.GetSSHHostKeys(tag)
+	c.Check(errors.IsNotFound(err), jc.IsTrue)
+	c.Check(err, gc.ErrorMatches, "SSH host keys for .+ not found")
+}
+
+func checkGet(c *gc.C, st *state.State, tag names.MachineTag, expected state.SSHHostKeys) {
+	keysGot, err := st.GetSSHHostKeys(tag)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(keysGot, gc.DeepEquals, expected)
+}


### PR DESCRIPTION
These changes provide the infrastructure for storing and retrieving SSH host keys to/from state. The implemented APIs will be used by the machiner worker to set the host keys when it starts.

This is part of the fix for LP #1456916.

(Review request: http://reviews.vapour.ws/r/4607/)