### PR TITLE
container/lxd: fallback to "default" LXD profile

### DIFF
--- a/container/lxd/export_test.go
+++ b/container/lxd/export_test.go
@@ -1,0 +1,10 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// +build go1.3
+
+package lxd
+
+var (
+	NICProperties = nicProperties
+)

--- a/container/lxd/lxd.go
+++ b/container/lxd/lxd.go
@@ -136,9 +136,9 @@ func (manager *containerManager) CreateContainer(
 	if len(networkConfig.Interfaces) > 0 || networkConfig.Device != "" {
 		manager.networkProfile = networkProfile
 		if len(networkConfig.Interfaces) > 0 {
-			err = networkProfileAddInterfaces(manager.client, networkProfile, networkConfig)
+			err = networkProfileAddMultipleInterfaces(manager.client, networkProfile, networkConfig.Interfaces)
 		} else {
-			err = networkProfileAddSingleInterface(manager.client, networkProfile, networkConfig)
+			err = networkProfileAddSingleInterface(manager.client, networkProfile, networkConfig.Device, networkConfig.MTU)
 		}
 		if err != nil {
 			return
@@ -255,13 +255,13 @@ func addNetworkDeviceToProfile(client *lxdclient.Client, profile, parentDevice, 
 	return client.ProfileDeviceAdd(profile, deviceName, "nic", props)
 }
 
-func networkProfileAddSingleInterface(client *lxdclient.Client, profile string, networkConfig *container.NetworkConfig) error {
-	_, err := addNetworkDeviceToProfile(client, profile, networkConfig.Device, "eth0", "", networkConfig.MTU)
+func networkProfileAddSingleInterface(client *lxdclient.Client, profile, deviceName string, mtu int) error {
+	_, err := addNetworkDeviceToProfile(client, profile, deviceName, "eth0", "", mtu)
 	return errors.Trace(err)
 }
 
-func networkProfileAddInterfaces(client *lxdclient.Client, profile string, networkConfig *container.NetworkConfig) error {
-	for _, v := range networkConfig.Interfaces {
+func networkProfileAddMultipleInterfaces(client *lxdclient.Client, profile string, interfaces []network.InterfaceInfo) error {
+	for _, v := range interfaces {
 		if v.InterfaceType == network.LoopbackInterface {
 			continue
 		}

--- a/container/lxd/lxd.go
+++ b/container/lxd/lxd.go
@@ -241,7 +241,7 @@ func addNetworkDeviceToProfile(client *lxdclient.Client, profile, parentDevice, 
 
 func networkProfileAddSingleInterface(client *lxdclient.Client, profile string, networkConfig *container.NetworkConfig) error {
 	_, err := addNetworkDeviceToProfile(client, profile, networkConfig.Device, "eth0", "", networkConfig.MTU)
-	return err
+	return errors.Trace(err)
 }
 
 func networkProfileAddInterfaces(client *lxdclient.Client, profile string, networkConfig *container.NetworkConfig) error {
@@ -257,7 +257,7 @@ func networkProfileAddInterfaces(client *lxdclient.Client, profile string, netwo
 		_, err := addNetworkDeviceToProfile(client, profile, v.ParentInterfaceName, v.InterfaceName, v.MACAddress, v.MTU)
 
 		if err != nil {
-			return err
+			return errors.Trace(err)
 		}
 	}
 
@@ -268,13 +268,13 @@ func createNetworkProfile(client *lxdclient.Client, profile string) error {
 	found, err := client.HasProfile(profile)
 
 	if err != nil {
-		return err
+		return errors.Trace(err)
 	}
 
 	if found {
 		logger.Infof("deleting existing container profile %q", profile)
 		if err := client.ProfileDelete(profile); err != nil {
-			return err
+			return errors.Trace(err)
 		}
 	}
 
@@ -284,7 +284,7 @@ func createNetworkProfile(client *lxdclient.Client, profile string) error {
 		logger.Infof("created new network container profile %q", profile)
 	}
 
-	return err
+	return errors.Trace(err)
 }
 
 func (manager *containerManager) deleteNetworkProfile() {

--- a/container/lxd/lxd_test.go
+++ b/container/lxd/lxd_test.go
@@ -93,3 +93,55 @@ func (t *LxdSuite) TestNotAllContainersAreDeleted(c *gc.C) {
 		c.Assert(err, jc.ErrorIsNil)
 	}
 }
+
+func (t *LxdSuite) TestNICPropertiesWithInvalidParentDevice(c *gc.C) {
+	props, err := lxd.NICProperties("", "eth1", "", 0)
+	c.Assert(props, gc.IsNil)
+	c.Assert(err.Error(), gc.Equals, "invalid parent device")
+}
+
+func (t *LxdSuite) TestNICPropertiesWithInvalidDeviceName(c *gc.C) {
+	props, err := lxd.NICProperties("testbr1", "", "", 0)
+	c.Assert(props, gc.IsNil)
+	c.Assert(err.Error(), gc.Equals, "invalid device name")
+}
+
+func (t *LxdSuite) TestNICPropertiesWithoutMACAddressOrMTUGreaterThanZero(c *gc.C) {
+	props, err := lxd.NICProperties("testbr1", "eth1", "", 0)
+	c.Assert(err, gc.IsNil)
+	c.Assert(props, gc.HasLen, 3)
+	c.Assert(props[0], gc.Equals, "nictype=bridged")
+	c.Assert(props[1], gc.Equals, "parent=testbr1")
+	c.Assert(props[2], gc.Equals, "name=eth1")
+}
+
+func (t *LxdSuite) TestNICPropertiesWithMACAddressButNoMTU(c *gc.C) {
+	props, err := lxd.NICProperties("testbr1", "eth1", "aa:bb:cc:dd:ee:f0", 0)
+	c.Assert(err, gc.IsNil)
+	c.Assert(props, gc.HasLen, 4)
+	c.Assert(props[0], gc.Equals, "nictype=bridged")
+	c.Assert(props[1], gc.Equals, "parent=testbr1")
+	c.Assert(props[2], gc.Equals, "name=eth1")
+	c.Assert(props[3], gc.Equals, "hwaddr=aa:bb:cc:dd:ee:f0")
+}
+
+func (t *LxdSuite) TestNICPropertiesWithoutMACAddressButMTUGreaterThanZero(c *gc.C) {
+	props, err := lxd.NICProperties("testbr1", "eth1", "", 1492)
+	c.Assert(err, gc.IsNil)
+	c.Assert(props, gc.HasLen, 4)
+	c.Assert(props[0], gc.Equals, "nictype=bridged")
+	c.Assert(props[1], gc.Equals, "parent=testbr1")
+	c.Assert(props[2], gc.Equals, "name=eth1")
+	c.Assert(props[3], gc.Equals, "mtu=1492")
+}
+
+func (t *LxdSuite) TestNICPropertiesWithMACAddressAndMTUGreaterThanZero(c *gc.C) {
+	props, err := lxd.NICProperties("testbr1", "eth1", "aa:bb:cc:dd:ee:f0", 1066)
+	c.Assert(err, gc.IsNil)
+	c.Assert(props, gc.HasLen, 5)
+	c.Assert(props[0], gc.Equals, "nictype=bridged")
+	c.Assert(props[1], gc.Equals, "parent=testbr1")
+	c.Assert(props[2], gc.Equals, "name=eth1")
+	c.Assert(props[3], gc.Equals, "hwaddr=aa:bb:cc:dd:ee:f0")
+	c.Assert(props[4], gc.Equals, "mtu=1066")
+}


### PR DESCRIPTION
This was work originally started by Tycho in:

  https://github.com/juju/juju/pull/5136

but updated to consider the case where we have a default bridge from the
provider and we should use that before falling back to LXD's "default"
profile.

Original - PR: https://github.com/juju/juju/pull/5136

73a85aaf creates network profiles based on network configuration
provided to the container type when network spaces are present (e.g. in
maas, etc.). However, in some cases (notably, GCE), there is no network
configuration provided to the container type code, and thus the profile
gets created with no network devices.

Instead, let's fall back to the default network configuration in LXD
when nothing is explicitly provided by juju.

(Review request: http://reviews.vapour.ws/r/4609/)