### PR TITLE
Fix cloud-init double encode

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -19,7 +19,7 @@ github.com/juju/go4	git	40d72ab9641a2a8c36a9c46a51e28367115c8e59	2016-02-22T16:3
 github.com/juju/gojsonpointer	git	afe8b77aa08f272b49e01b82de78510c11f61500	2015-02-04T19:46:29Z
 github.com/juju/gojsonreference	git	f0d24ac5ee330baa21721cdff56d45e4ee42628e	2015-02-04T19:46:33Z
 github.com/juju/gojsonschema	git	e1ad140384f254c82f89450d9a7c8dd38a632838	2015-03-12T17:00:16Z
-github.com/juju/gomaasapi	git	bfc992bc23c7a6a4bc50e79d03eebf97d25ee459	2016-04-13T23:27:20Z
+github.com/juju/gomaasapi	git	ced989b2fd2a6b29f84581bc098050088b9a4418	2016-04-15T00:57:29Z
 github.com/juju/govmomi	git	4354a88d4b34abe467215f77c2fc1cb9f78b66f7	2015-04-24T01:54:48Z
 github.com/juju/httpprof	git	14bf14c307672fd2456bdbf35d19cf0ccd3cf565	2014-12-17T16:00:36Z
 github.com/juju/httprequest	git	89d547093c45e293599088cc63e805c6f1205dc0	2016-03-02T10:09:58Z

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -900,7 +900,7 @@ func (environ *maasEnviron) startNode(node gomaasapi.MAASObject, series string, 
 }
 
 func (environ *maasEnviron) startNode2(node maas2Instance, series string, userdata []byte) (*maas2Instance, error) {
-	err := node.machine.Start(gomaasapi.StartArgs{DistroSeries: series, UserData: userdata})
+	err := node.machine.Start(gomaasapi.StartArgs{DistroSeries: series, UserData: string(userdata)})
 	if err != nil {
 		return nil, errors.Trace(err)
 	}


### PR DESCRIPTION
Updating to the latest gomaasapi fixes the issue of double base-64 encoding of userdata for cloud-init.

(Review request: http://reviews.vapour.ws/r/4611/)