### PR TITLE
Fixed lp:1568925: Address allocation feature flag now ignored on MAAS

### DIFF
--- a/apiserver/provisioner/provisioner.go
+++ b/apiserver/provisioner/provisioner.go
@@ -675,12 +675,16 @@ func (p *ProvisionerAPI) legacyAddressAllocationSupported() (bool, error) {
 // container tags as arguments. If the address allocation feature flag
 // is not enabled, it returns a NotSupported error.
 func (p *ProvisionerAPI) PrepareContainerInterfaceInfo(args params.Entities) (
-	params.MachineNetworkConfigResults, error) {
-	if supported, err := p.legacyAddressAllocationSupported(); supported && err == nil {
+	params.MachineNetworkConfigResults,
+	error,
+) {
+	supported, err := p.legacyAddressAllocationSupported()
+	if err != nil {
+		return params.MachineNetworkConfigResults{}, errors.Trace(err)
+	}
+	if supported {
 		logger.Warningf("address allocation enabled - using legacyPrepareOrGetContainerInterfaceInfo(true)")
 		return p.legacyPrepareOrGetContainerInterfaceInfo(args, true)
-	} else if err != nil {
-		return params.MachineNetworkConfigResults{}, errors.Trace(err)
 	}
 	return p.prepareOrGetContainerInterfaceInfo(args, true)
 }
@@ -689,12 +693,16 @@ func (p *ProvisionerAPI) PrepareContainerInterfaceInfo(args params.Entities) (
 // for a container. It accepts container tags as arguments. If the address
 // allocation feature flag is not enabled, it returns a NotSupported error.
 func (p *ProvisionerAPI) GetContainerInterfaceInfo(args params.Entities) (
-	params.MachineNetworkConfigResults, error) {
-	if supported, err := p.legacyAddressAllocationSupported(); supported && err == nil {
+	params.MachineNetworkConfigResults,
+	error,
+) {
+	supported, err := p.legacyAddressAllocationSupported()
+	if err != nil {
+		return params.MachineNetworkConfigResults{}, errors.Trace(err)
+	}
+	if supported {
 		logger.Warningf("address allocation enabled - using legacyPrepareOrGetContainerInterfaceInfo(false)")
 		return p.legacyPrepareOrGetContainerInterfaceInfo(args, false)
-	} else if err != nil {
-		return params.MachineNetworkConfigResults{}, errors.Trace(err)
 	}
 	return p.prepareOrGetContainerInterfaceInfo(args, false)
 }

--- a/cloudconfig/containerinit/container_userdata.go
+++ b/cloudconfig/containerinit/container_userdata.go
@@ -294,7 +294,7 @@ func shutdownInitCommands(initSystem, series string) ([]string, error) {
 	desc := "juju shutdown job"
 
 	execStart := shutdownCmd
-	if environs.AddressAllocationEnabled() {
+	if environs.AddressAllocationEnabled("") { // we only care the provider is not MAAS here.
 		// Only do the cleanup and replacement of /e/n/i when address
 		// allocation feature flag is enabled.
 		execStart = replaceNetConfCmd + removeCmd + shutdownCmd

--- a/environs/networking.go
+++ b/environs/networking.go
@@ -9,6 +9,7 @@ import (
 	"github.com/juju/juju/feature"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/network"
+	"github.com/juju/juju/provider"
 )
 
 // SupportsNetworking is a convenience helper to check if an environment
@@ -81,8 +82,13 @@ func supportsNetworking(environ Environ) (NetworkingEnviron, bool) {
 	return ne, ok
 }
 
-// AddressAllocationEnabled is a shortcut for checking if the
-// AddressAllocation feature flag is enabled.
-func AddressAllocationEnabled() bool {
+// AddressAllocationEnabled is a shortcut for checking if the AddressAllocation
+// feature flag is enabled. The providerType is used to distinguish between MAAS
+// and other providers that still support the legacy address allocation (EC2 and
+// Dummy) until the support can be removed across the board.
+func AddressAllocationEnabled(providerType string) bool {
+	if providerType == provider.MAAS {
+		return false
+	}
 	return featureflag.Enabled(feature.AddressAllocation)
 }

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -1120,7 +1120,7 @@ func (env *environ) Spaces() ([]network.SpaceInfo, error) {
 
 // SupportsAddressAllocation is specified on environs.Networking.
 func (env *environ) SupportsAddressAllocation(subnetId network.Id) (bool, error) {
-	if !environs.AddressAllocationEnabled() {
+	if !environs.AddressAllocationEnabled("dummy") {
 		return false, errors.NotSupportedf("address allocation")
 	}
 
@@ -1138,7 +1138,7 @@ func (env *environ) SupportsAddressAllocation(subnetId network.Id) (bool, error)
 // AllocateAddress requests an address to be allocated for the
 // given instance on the given subnet.
 func (env *environ) AllocateAddress(instId instance.Id, subnetId network.Id, addr *network.Address, macAddress, hostname string) error {
-	if !environs.AddressAllocationEnabled() {
+	if !environs.AddressAllocationEnabled("dummy") {
 		// Any instId starting with "i-alloc-" when the feature flag is off will
 		// still work, in order to be able to test MAAS 1.8+ environment where
 		// we can use devices for containers.
@@ -1182,7 +1182,7 @@ func (env *environ) AllocateAddress(instId instance.Id, subnetId network.Id, add
 // ReleaseAddress releases a specific address previously allocated with
 // AllocateAddress.
 func (env *environ) ReleaseAddress(instId instance.Id, subnetId network.Id, addr network.Address, macAddress, hostname string) error {
-	if !environs.AddressAllocationEnabled() {
+	if !environs.AddressAllocationEnabled("dummy") {
 		return errors.NotSupportedf("address allocation")
 	}
 

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -1031,6 +1031,7 @@ func (e *environ) NetworkInterfaces(instId instance.Id) ([]network.InterfaceInfo
 			Disabled:      false,
 			NoAutoStart:   false,
 			ConfigType:    network.ConfigDHCP,
+			InterfaceType: network.EthernetInterface,
 			Address:       network.NewScopedAddress(iface.PrivateIPAddress, network.ScopeCloudLocal),
 		}
 	}

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -31,6 +31,7 @@ import (
 	"github.com/juju/juju/environs/tags"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/network"
+	"github.com/juju/juju/provider"
 	"github.com/juju/juju/provider/common"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/tools"
@@ -243,7 +244,7 @@ func (e *environ) SupportsSpaceDiscovery() (bool, error) {
 
 // SupportsAddressAllocation is specified on environs.Networking.
 func (e *environ) SupportsAddressAllocation(_ network.Id) (bool, error) {
-	if !environs.AddressAllocationEnabled() {
+	if !environs.AddressAllocationEnabled(provider.EC2) {
 		return false, errors.NotSupportedf("address allocation")
 	}
 	_, hasDefaultVpc, err := e.defaultVpc()
@@ -905,7 +906,7 @@ func (e *environ) fetchNetworkInterfaceId(ec2Inst *ec2.EC2, instId instance.Id) 
 // AllocateAddress requests an address to be allocated for the given
 // instance on the given subnet. Implements NetworkingEnviron.AllocateAddress.
 func (e *environ) AllocateAddress(instId instance.Id, _ network.Id, addr *network.Address, _, _ string) (err error) {
-	if !environs.AddressAllocationEnabled() {
+	if !environs.AddressAllocationEnabled(provider.EC2) {
 		return errors.NotSupportedf("address allocation")
 	}
 	if addr == nil || addr.Value == "" {
@@ -946,7 +947,7 @@ func (e *environ) AllocateAddress(instId instance.Id, _ network.Id, addr *networ
 // ReleaseAddress releases a specific address previously allocated with
 // AllocateAddress. Implements NetworkingEnviron.ReleaseAddress.
 func (e *environ) ReleaseAddress(instId instance.Id, _ network.Id, addr network.Address, _, _ string) (err error) {
-	if !environs.AddressAllocationEnabled() {
+	if !environs.AddressAllocationEnabled(provider.EC2) {
 		return errors.NotSupportedf("address allocation")
 	}
 

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -1126,6 +1126,7 @@ func (t *localServerSuite) TestNetworkInterfaces(c *gc.C) {
 		Disabled:          false,
 		NoAutoStart:       false,
 		ConfigType:        network.ConfigDHCP,
+		InterfaceType:     network.EthernetInterface,
 		Address:           network.NewScopedAddress(addr, network.ScopeCloudLocal),
 		AvailabilityZones: zones,
 	}}

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -35,6 +35,7 @@ import (
 	"github.com/juju/juju/feature"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/network"
+	"github.com/juju/juju/provider"
 	"github.com/juju/juju/provider/common"
 	"github.com/juju/juju/state/multiwatcher"
 	"github.com/juju/juju/status"
@@ -230,7 +231,7 @@ func (env *maasEnviron) usingMAAS2() bool {
 
 // Bootstrap is specified in the Environ interface.
 func (env *maasEnviron) Bootstrap(ctx environs.BootstrapContext, args environs.BootstrapParams) (*environs.BootstrapResult, error) {
-	if !environs.AddressAllocationEnabled() {
+	if !environs.AddressAllocationEnabled(provider.MAAS) {
 		// When address allocation is not enabled, we should use the
 		// default bridge for both LXC and KVM containers. The bridge
 		// is created as part of the userdata for every node during
@@ -1038,7 +1039,7 @@ func (environ *maasEnviron) StartInstance(args environs.StartInstanceParams) (
 	// Override the network bridge to use for both LXC and KVM
 	// containers on the new instance, if address allocation feature
 	// flag is not enabled.
-	if !environs.AddressAllocationEnabled() {
+	if !environs.AddressAllocationEnabled(provider.MAAS) {
 		if args.InstanceConfig.AgentEnvironment == nil {
 			args.InstanceConfig.AgentEnvironment = make(map[string]string)
 		}
@@ -1402,7 +1403,7 @@ func (environ *maasEnviron) newCloudinitConfig(hostname, forSeries string) (clou
 		cloudcfg.AddScripts("set -xe", runCmd)
 		// Only create the default bridge if we're not using static
 		// address allocation for containers.
-		if !environs.AddressAllocationEnabled() {
+		if !environs.AddressAllocationEnabled(provider.MAAS) {
 			// Address allocated feature flag might be disabled, but
 			// DisableNetworkManagement can still disable the bridge
 			// creation.
@@ -1806,7 +1807,7 @@ func (environ *maasEnviron) AllocateAddress(instId instance.Id, subnetId network
 		return errors.NewNotValid(nil, "invalid address: cannot be nil")
 	}
 
-	if !environs.AddressAllocationEnabled() {
+	if !environs.AddressAllocationEnabled(provider.MAAS) {
 		logger.Tracef("creating device for container %q with MAC %q", hostname, macAddress)
 		deviceID, err := environ.createOrFetchDevice(macAddress, instId, hostname)
 		if err != nil {
@@ -1875,7 +1876,7 @@ func (environ *maasEnviron) AllocateAddress(instId instance.Id, subnetId network
 // ReleaseAddress releases a specific address previously allocated with
 // AllocateAddress.
 func (environ *maasEnviron) ReleaseAddress(instId instance.Id, _ network.Id, addr network.Address, macAddress, hostname string) (err error) {
-	if !environs.AddressAllocationEnabled() {
+	if !environs.AddressAllocationEnabled(provider.MAAS) {
 		logger.Tracef("getting device ID for container %q with MAC %q", macAddress, hostname)
 		deviceID, err := environ.fetchDevice(macAddress)
 		if err != nil {

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -24,7 +24,6 @@ import (
 	"github.com/juju/utils/series"
 	"github.com/juju/utils/set"
 
-	"github.com/juju/juju/agent"
 	"github.com/juju/juju/cloudconfig/cloudinit"
 	"github.com/juju/juju/cloudconfig/instancecfg"
 	"github.com/juju/juju/cloudconfig/providerinit"
@@ -61,18 +60,17 @@ var shortAttempt = utils.AttemptStrategy{
 }
 
 var (
-	ReleaseNodes             = releaseNodes
-	ReserveIPAddressOnDevice = reserveIPAddressOnDevice
-	NewDeviceParams          = newDeviceParams
-	UpdateDeviceHostname     = updateDeviceHostname
-	ReleaseIPAddress         = releaseIPAddress
-	DeploymentStatusCall     = deploymentStatusCall
-	GetCapabilities          = getCapabilities
-	GetMAAS2Controller       = getMAAS2Controller
+	ReleaseNodes         = releaseNodes
+	DeploymentStatusCall = deploymentStatusCall
+	GetCapabilities      = getCapabilities
+	GetMAAS2Controller   = getMAAS2Controller
 )
 
 func getMAAS2Controller(maasServer, apiKey string) (gomaasapi.Controller, error) {
-	return gomaasapi.NewController(gomaasapi.ControllerArgs{maasServer, apiKey})
+	return gomaasapi.NewController(gomaasapi.ControllerArgs{
+		BaseURL: maasServer,
+		APIKey:  apiKey,
+	})
 }
 
 func subnetToSpaceIds(spaces gomaasapi.MAASObject) (map[string]network.Id, error) {
@@ -116,67 +114,6 @@ func subnetToSpaceIds(spaces gomaasapi.MAASObject) (map[string]network.Id, error
 
 func releaseNodes(nodes gomaasapi.MAASObject, ids url.Values) error {
 	_, err := nodes.CallPost("release", ids)
-	return err
-}
-
-func reserveIPAddressOnDevice(devices gomaasapi.MAASObject, deviceID, macAddress string, addr network.Address) (network.Address, error) {
-	device := devices.GetSubObject(deviceID)
-	params := url.Values{}
-	if addr.Value != "" {
-		params.Add("requested_address", addr.Value)
-	}
-	if macAddress != "" {
-		params.Add("mac_address", macAddress)
-	}
-	resp, err := device.CallPost("claim_sticky_ip_address", params)
-	if err != nil {
-		return network.Address{}, errors.Annotatef(
-			err, "failed to reserve sticky IP address for device %q",
-			deviceID,
-		)
-	}
-	respMap, err := resp.GetMap()
-	if err != nil {
-		return network.Address{}, errors.Annotate(err, "failed to parse response")
-	}
-	addresses, err := respMap["ip_addresses"].GetArray()
-	if err != nil {
-		return network.Address{}, errors.Annotatef(err, "failed to parse IP addresses")
-	}
-	if len(addresses) == 0 {
-		return network.Address{}, errors.Errorf(
-			"expected to find a sticky IP address for device %q: MAAS API response contains no IP addresses",
-			deviceID,
-		)
-	}
-	var firstAddress network.Address
-	for _, address := range addresses {
-		value, err := address.GetString()
-		if err != nil {
-			return network.Address{}, errors.Annotatef(err,
-				"failed to parse reserved IP address for device %q",
-				deviceID,
-			)
-		}
-		if ip := net.ParseIP(value); ip == nil {
-			return network.Address{}, errors.Annotatef(err,
-				"failed to parse reserved IP address %q for device %q",
-				value, deviceID,
-			)
-		}
-		if firstAddress.Value == "" {
-			// We only need the first address, but we're logging all we got.
-			firstAddress = network.NewAddress(value)
-		}
-		logger.Debugf("reserved address %q for device %q and MAC %q", value, deviceID, macAddress)
-	}
-	return firstAddress, nil
-}
-
-func releaseIPAddress(ipaddresses gomaasapi.MAASObject, addr network.Address) error {
-	params := url.Values{}
-	params.Add("ip", addr.Value)
-	_, err := ipaddresses.CallPost("release", params)
 	return err
 }
 
@@ -231,21 +168,8 @@ func (env *maasEnviron) usingMAAS2() bool {
 
 // Bootstrap is specified in the Environ interface.
 func (env *maasEnviron) Bootstrap(ctx environs.BootstrapContext, args environs.BootstrapParams) (*environs.BootstrapResult, error) {
-	if !environs.AddressAllocationEnabled(provider.MAAS) {
-		// When address allocation is not enabled, we should use the
-		// default bridge for both LXC and KVM containers. The bridge
-		// is created as part of the userdata for every node during
-		// StartInstance.
-		logger.Infof(
-			"address allocation feature disabled; using %q bridge for all containers",
-			instancecfg.DefaultBridgeName,
-		)
-		args.ContainerBridgeName = instancecfg.DefaultBridgeName
-	} else {
-		logger.Debugf(
-			"address allocation feature enabled; using static IPs for containers: %q",
-			instancecfg.DefaultBridgeName,
-		)
+	if environs.AddressAllocationEnabled(provider.MAAS) {
+		logger.Warningf("address-allocation feature flag is no longer supported on MAAS and is ignored!")
 	}
 
 	result, series, finalizer, err := common.BootstrapInstance(ctx, env, args)
@@ -380,7 +304,7 @@ func (env *maasEnviron) SupportsSpaceDiscovery() (bool, error) {
 
 // SupportsAddressAllocation is specified on environs.Networking.
 func (env *maasEnviron) SupportsAddressAllocation(_ network.Id) (bool, error) {
-	return true, nil
+	return false, errors.NotSupportedf("legacy address allocation")
 }
 
 // allArchitectures2 uses the MAAS2 controller to get architectures from boot
@@ -1036,15 +960,7 @@ func (environ *maasEnviron) StartInstance(args environs.StartInstanceParams) (
 	if err != nil {
 		return nil, err
 	}
-	// Override the network bridge to use for both LXC and KVM
-	// containers on the new instance, if address allocation feature
-	// flag is not enabled.
-	if !environs.AddressAllocationEnabled(provider.MAAS) {
-		if args.InstanceConfig.AgentEnvironment == nil {
-			args.InstanceConfig.AgentEnvironment = make(map[string]string)
-		}
-		args.InstanceConfig.AgentEnvironment[agent.LxcBridge] = instancecfg.DefaultBridgeName
-	}
+
 	if err := instancecfg.FinishInstanceConfig(args.InstanceConfig, environ.Config()); err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -1401,23 +1317,17 @@ func (environ *maasEnviron) newCloudinitConfig(hostname, forSeries string) (clou
 	case os.Ubuntu:
 		cloudcfg.SetSystemUpdate(true)
 		cloudcfg.AddScripts("set -xe", runCmd)
-		// Only create the default bridge if we're not using static
-		// address allocation for containers.
-		if !environs.AddressAllocationEnabled(provider.MAAS) {
-			// Address allocated feature flag might be disabled, but
-			// DisableNetworkManagement can still disable the bridge
-			// creation.
-			if on, set := environ.Config().DisableNetworkManagement(); on && set {
-				logger.Infof(
-					"network management disabled - not using %q bridge for containers",
-					instancecfg.DefaultBridgeName,
-				)
-				break
-			}
-			cloudcfg.AddPackage("bridge-utils")
-			cloudcfg.AddBootTextFile(bridgeScriptPath, bridgeScriptPython, 0755)
-			cloudcfg.AddScripts(setupJujuNetworking())
+		// DisableNetworkManagement can still disable the bridge(s) creation.
+		if on, set := environ.Config().DisableNetworkManagement(); on && set {
+			logger.Infof(
+				"network management disabled - not using %q bridge for containers",
+				instancecfg.DefaultBridgeName,
+			)
+			break
 		}
+		cloudcfg.AddPackage("bridge-utils")
+		cloudcfg.AddBootTextFile(bridgeScriptPath, bridgeScriptPython, 0755)
+		cloudcfg.AddScripts(setupJujuNetworking())
 	}
 	return cloudcfg, nil
 }
@@ -1644,315 +1554,16 @@ func (environ *maasEnviron) Instances(ids []instance.Id) ([]instance.Instance, e
 	return result, nil
 }
 
-// transformDeviceHostname transforms deviceHostname to include hostnameSuffix
-// after the first "." in deviceHostname. Returns errors if deviceHostname does
-// not contain any "." or hostnameSuffix is empty.
-func transformDeviceHostname(deviceID, deviceHostname, hostnameSuffix string) (string, error) {
-	if hostnameSuffix == "" {
-		return "", errors.New("hostname suffix cannot be empty")
-	}
-	parts := strings.SplitN(deviceHostname, ".", 2)
-	if len(parts) != 2 {
-		return "", errors.Errorf("unexpected device %q hostname %q", deviceID, deviceHostname)
-	}
-	return fmt.Sprintf("%s-%s.%s", parts[0], hostnameSuffix, parts[1]), nil
-}
-
-// updateDeviceHostname updates the hostname of a MAAS device to be unique and
-// to contain the given hostnameSuffix.
-func updateDeviceHostname(client *gomaasapi.MAASObject, deviceID, deviceHostname, hostnameSuffix string) (string, error) {
-
-	newHostname, err := transformDeviceHostname(deviceID, deviceHostname, hostnameSuffix)
-	if err != nil {
-		return "", errors.Trace(err)
-	}
-
-	deviceObj := client.GetSubObject("devices").GetSubObject(deviceID)
-	params := make(url.Values)
-	params.Add("hostname", newHostname)
-	if _, err := deviceObj.Update(params); err != nil {
-		return "", errors.Annotatef(err, "updating device %q hostname to %q", deviceID, newHostname)
-	}
-	return newHostname, nil
-}
-
-// newDeviceParams prepares the params to call "devices new" API. Declared
-// separately so it can be mocked out in the test to work around the gomaasapi's
-// testservice limitation.
-func newDeviceParams(macAddress string, instId instance.Id, _ string) url.Values {
-	params := make(url.Values)
-	params.Add("mac_addresses", macAddress)
-	// We create the device without a hostname, to allow MAAS to create a unique
-	// hostname first.
-	params.Add("parent", extractSystemId(instId))
-
-	return params
-}
-
-// newDevice creates a new MAAS device with parent instance instId, using the
-// given macAddress and hostnameSuffix, returning the ID of the new device.
-func (environ *maasEnviron) newDevice(macAddress string, instId instance.Id, hostnameSuffix string) (string, error) {
-	client := environ.getMAASClient()
-	devices := client.GetSubObject("devices")
-	// Make the params in a separate function to make it easier to work
-	// around the limitation of gomaasapi's testservice expecting all 3
-	// arguments (parent, mac_addresses, and hostname) to be filled in.
-	params := NewDeviceParams(macAddress, instId, hostnameSuffix)
-	logger.Tracef(
-		"creating a new MAAS device for MAC %q, parent %q", macAddress, instId,
-	)
-	result, err := devices.CallPost("new", params)
-	if err != nil {
-		return "", errors.Trace(err)
-	}
-
-	resultMap, err := result.GetMap()
-	if err != nil {
-		return "", errors.Trace(err)
-	}
-
-	deviceID, err := resultMap["system_id"].GetString()
-	if err != nil {
-		return "", errors.Trace(err)
-	}
-	deviceHostname, err := resultMap["hostname"].GetString()
-	if err != nil {
-		return deviceID, errors.Trace(err)
-	}
-
-	logger.Tracef("created device %q with MAC %q and hostname %q", deviceID, macAddress, deviceHostname)
-
-	newHostname, err := UpdateDeviceHostname(client, deviceID, deviceHostname, hostnameSuffix)
-	if err != nil {
-		return deviceID, errors.Trace(err)
-	}
-	logger.Tracef("updated device %q hostname to %q", deviceID, newHostname)
-
-	return deviceID, nil
-}
-
-// fetchFullDevice fetches an existing device ID associated with the given
-// macAddress, or returns an error if there is no device.
-func (environ *maasEnviron) fetchFullDevice(macAddress string) (map[string]gomaasapi.JSONObject, error) {
-	if macAddress == "" {
-		return nil, errors.Errorf("given MAC address is empty")
-	}
-
-	client := environ.getMAASClient()
-	devices := client.GetSubObject("devices")
-	params := url.Values{}
-	params.Add("mac_address", macAddress)
-
-	result, err := devices.CallGet("list", params)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	resultArray, err := result.GetArray()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	if len(resultArray) == 0 {
-		return nil, errors.NotFoundf("no device for MAC address %q", macAddress)
-	}
-
-	if len(resultArray) != 1 {
-		return nil, errors.Errorf("unexpected response, expected 1 device got %d", len(resultArray))
-	}
-
-	resultMap, err := resultArray[0].GetMap()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	logger.Tracef("device found as %+v", resultMap)
-	return resultMap, nil
-}
-
-func (environ *maasEnviron) fetchDevice(macAddress string) (string, error) {
-	deviceMap, err := environ.fetchFullDevice(macAddress)
-	if err != nil {
-		return "", errors.Trace(err)
-	}
-
-	deviceID, err := deviceMap["system_id"].GetString()
-	if err != nil {
-		return "", errors.Trace(err)
-	}
-	return deviceID, nil
-}
-
-// createOrFetchDevice returns a device Id associated with a MAC address. If
-// there is not already one it will create one.
-func (environ *maasEnviron) createOrFetchDevice(macAddress string, instId instance.Id, hostname string) (string, error) {
-	device, err := environ.fetchDevice(macAddress)
-	if err == nil {
-		return device, nil
-	}
-	if !errors.IsNotFound(err) {
-		return "", errors.Trace(err)
-	}
-	return environ.newDevice(macAddress, instId, hostname)
-}
-
-// AllocateAddress requests an address to be allocated for the
-// given instance on the given network.
+// AllocateAddress requests an address to be allocated for the given instance on
+// the given network.
 func (environ *maasEnviron) AllocateAddress(instId instance.Id, subnetId network.Id, addr *network.Address, macAddress, hostname string) (err error) {
-	logger.Tracef(
-		"AllocateAddress for instId %q, subnet %q, addr %q, MAC %q, hostname %q",
-		instId, subnetId, addr, macAddress, hostname,
-	)
-	if addr == nil {
-		return errors.NewNotValid(nil, "invalid address: cannot be nil")
-	}
-
-	if !environs.AddressAllocationEnabled(provider.MAAS) {
-		logger.Tracef("creating device for container %q with MAC %q", hostname, macAddress)
-		deviceID, err := environ.createOrFetchDevice(macAddress, instId, hostname)
-		if err != nil {
-			return errors.Annotatef(
-				err,
-				"failed creating MAAS device for container %q with MAC address %q",
-				hostname, macAddress,
-			)
-		}
-		logger.Infof(
-			"created device %q for container %q with MAC address %q on parent node %q",
-			deviceID, hostname, macAddress, instId,
-		)
-		devices := environ.getMAASClient().GetSubObject("devices")
-		newAddr, err := ReserveIPAddressOnDevice(devices, deviceID, macAddress, network.Address{})
-		if err != nil {
-			return errors.Trace(err)
-		}
-		logger.Infof(
-			"reserved sticky IP address %q for device %q with MAC address %q representing container %q",
-			newAddr, deviceID, macAddress, hostname,
-		)
-		*addr = newAddr
-		return nil
-	}
-	defer errors.DeferredAnnotatef(&err, "failed to allocate address %q for instance %q", addr, instId)
-
-	client := environ.getMAASClient()
-	deviceID, err := environ.createOrFetchDevice(macAddress, instId, hostname)
-	if err != nil {
-		return errors.Trace(err)
-	}
-
-	devices := client.GetSubObject("devices")
-	newAddr, err := ReserveIPAddressOnDevice(devices, deviceID, macAddress, *addr)
-	if err == nil {
-		logger.Infof(
-			"allocated address %q for instance %q on device %q (asked for address %q)",
-			addr, instId, deviceID, newAddr,
-		)
-		return nil
-	}
-
-	maasErr, ok := errors.Cause(err).(gomaasapi.ServerError)
-	if !ok {
-		return errors.Trace(err)
-	}
-	// For an "out of range" IP address, maas raises
-	// StaticIPAddressOutOfRange - an error 403
-	// If there are no more addresses we get
-	// StaticIPAddressExhaustion - an error 503
-	// For an address already in use we get
-	// StaticIPAddressUnavailable - an error 404
-	if maasErr.StatusCode == 404 {
-		logger.Tracef("address %q not available for allocation", addr)
-		return environs.ErrIPAddressUnavailable
-	} else if maasErr.StatusCode == 503 {
-		logger.Tracef("no more addresses available on the subnet")
-		return environs.ErrIPAddressesExhausted
-	}
-	// any error other than a 404 or 503 is "unexpected" and should
-	// be returned directly.
-	return errors.Trace(err)
+	return errors.NotSupportedf("AllocateAddress")
 }
 
 // ReleaseAddress releases a specific address previously allocated with
 // AllocateAddress.
 func (environ *maasEnviron) ReleaseAddress(instId instance.Id, _ network.Id, addr network.Address, macAddress, hostname string) (err error) {
-	if !environs.AddressAllocationEnabled(provider.MAAS) {
-		logger.Tracef("getting device ID for container %q with MAC %q", macAddress, hostname)
-		deviceID, err := environ.fetchDevice(macAddress)
-		if err != nil {
-			return errors.Annotatef(
-				err,
-				"getting MAAS device for container %q with MAC address %q",
-				hostname, macAddress,
-			)
-		}
-		logger.Tracef("deleting device %q for container %q", deviceID, hostname)
-		apiDevice := environ.getMAASClient().GetSubObject("devices").GetSubObject(deviceID)
-		if err := apiDevice.Delete(); err != nil {
-			return errors.Annotatef(
-				err,
-				"deleting MAAS device %q for container %q with MAC address %q",
-				deviceID, instId, macAddress,
-			)
-		}
-		logger.Debugf("deleted device %q for container %q with MAC address %q", deviceID, instId, macAddress)
-		return nil
-	}
-
-	defer errors.DeferredAnnotatef(&err, "failed to release IP address %q from instance %q", addr, instId)
-
-	logger.Infof(
-		"releasing address: %q, MAC address: %q, hostname: %q",
-		addr, macAddress, hostname,
-	)
-	// Addresses originally allocated without a device will have macAddress
-	// set to "". We shouldn't look for a device for these addresses.
-	if macAddress != "" {
-		device, err := environ.fetchFullDevice(macAddress)
-		if err == nil {
-			addresses, err := device["ip_addresses"].GetArray()
-			if err != nil {
-				return err
-			}
-			systemId, err := device["system_id"].GetString()
-			if err != nil {
-				return err
-			}
-
-			if len(addresses) == 1 {
-				// With our current usage of devices they will always
-				// have exactly one IP address, but in theory that
-				// could change and this code will continue to work.
-				// The device is only destroyed when we come to release
-				// the last address. Race conditions aside.
-				deviceAPI := environ.getMAASClient().GetSubObject("devices").GetSubObject(systemId)
-				err = deviceAPI.Delete()
-				return err
-			}
-		} else if !errors.IsNotFound(err) {
-			return err
-		}
-		// No device for this IP address, release the address normally.
-	}
-
-	ipaddresses := environ.getMAASClient().GetSubObject("ipaddresses")
-	retries := 0
-	for a := shortAttempt.Start(); a.Next(); {
-		retries++
-		// This can return a 404 error if the address has already been released
-		// or is unknown by maas. However this, like any other error, would be
-		// unexpected - so we don't treat it specially and just return it to
-		// the caller.
-		err = ReleaseIPAddress(ipaddresses, addr)
-		if err == nil {
-			break
-		}
-		logger.Infof("failed to release address %q from instance %q, will retry", addr, instId)
-	}
-	if err != nil {
-		logger.Warningf("failed to release address %q from instance %q after %d attempts: %v", addr, instId, retries, err)
-	}
-	return err
+	return errors.NotSupportedf("ReleaseAddress")
 }
 
 // subnetsFromNode fetches all the subnets for a specific node.

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -34,7 +34,6 @@ import (
 	"github.com/juju/juju/feature"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/network"
-	"github.com/juju/juju/provider"
 	"github.com/juju/juju/provider/common"
 	"github.com/juju/juju/state/multiwatcher"
 	"github.com/juju/juju/status"
@@ -168,7 +167,7 @@ func (env *maasEnviron) usingMAAS2() bool {
 
 // Bootstrap is specified in the Environ interface.
 func (env *maasEnviron) Bootstrap(ctx environs.BootstrapContext, args environs.BootstrapParams) (*environs.BootstrapResult, error) {
-	if environs.AddressAllocationEnabled(provider.MAAS) {
+	if featureflag.Enabled(feature.AddressAllocation) {
 		logger.Warningf("address-allocation feature flag is no longer supported on MAAS and is ignored!")
 	}
 

--- a/provider/maas/environ_test.go
+++ b/provider/maas/environ_test.go
@@ -43,7 +43,6 @@ func (s *environSuite) SetUpSuite(c *gc.C) {
 func (s *environSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 	s.ToolsFixture.SetUpTest(c)
-	s.SetFeatureFlags()
 
 	mockCapabilities := func(client *gomaasapi.MAASObject) (set.Strings, error) {
 		return set.NewStrings("network-deployment-ubuntu"), nil

--- a/provider/maas/environ_whitebox_test.go
+++ b/provider/maas/environ_whitebox_test.go
@@ -8,11 +8,8 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
-	"net/http"
 	"net/url"
 	"regexp"
-	"strings"
 
 	"github.com/juju/errors"
 	"github.com/juju/gomaasapi"
@@ -562,8 +559,9 @@ func (suite *environSuite) TestSupportsNetworking(c *gc.C) {
 func (suite *environSuite) TestSupportsAddressAllocation(c *gc.C) {
 	env := suite.makeEnviron()
 	supported, err := env.SupportsAddressAllocation("")
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(supported, jc.IsTrue)
+	c.Assert(err, gc.ErrorMatches, "legacy address allocation not supported")
+	c.Assert(err, jc.Satisfies, errors.IsNotSupported)
+	c.Assert(supported, jc.IsFalse)
 }
 
 func (suite *environSuite) TestSupportsSpaces(c *gc.C) {
@@ -768,253 +766,17 @@ func (suite *environSuite) TestSubnetsMissingSubnet(c *gc.C) {
 }
 
 func (suite *environSuite) TestAllocateAddress(c *gc.C) {
-	suite.patchDeviceCreation()
-	testInstance := suite.getInstance("node0")
-	subnetId := suite.addSubnet(c, 2, 2, "node0")
 	env := suite.makeEnviron()
-
-	// note that the default test server always succeeds if we provide a
-	// valid instance id and net id
-	err := env.AllocateAddress(testInstance.Id(), network.Id(string(int(subnetId))), &network.Address{Value: "192.168.2.1"}, "foo", "bar")
-	c.Assert(err, jc.ErrorIsNil)
+	err := env.AllocateAddress("", "", nil, "", "")
+	c.Assert(err, gc.ErrorMatches, "AllocateAddress not supported")
+	c.Assert(err, jc.Satisfies, errors.IsNotSupported)
 }
 
-func (suite *environSuite) TestAllocateAddressDevices(c *gc.C) {
-	testInstance := suite.getInstance("node0")
-	subnetId := suite.addSubnet(c, 2, 2, "node0")
+func (suite *environSuite) TestReleaseAddress(c *gc.C) {
 	env := suite.makeEnviron()
-
-	// Work around the lack of support for devices PUT and POST without hostname
-	// set in gomaasapi's testservices
-	newParams := func(macAddress string, instId instance.Id, hostnameSuffix string) url.Values {
-		c.Check(macAddress, gc.Equals, "aa:bb:cc:dd:ee:f0") // passed to AllocateAddress() below
-		c.Check(instId, gc.Equals, testInstance.Id())
-		c.Check(hostnameSuffix, gc.Equals, "juju-machine-0-kvm-5") // passed to AllocateAddress() below
-		params := make(url.Values)
-		params.Add("mac_addresses", macAddress)
-		params.Add("hostname", "auto-generated.maas")
-		params.Add("parent", extractSystemId(instId))
-		return params
-	}
-	suite.PatchValue(&NewDeviceParams, newParams)
-	updateHostname := func(client *gomaasapi.MAASObject, deviceID, deviceHostname, hostnameSuffix string) (string, error) {
-		c.Check(client, gc.NotNil)
-		c.Check(deviceID, gc.Matches, `node-[0-9a-f-]+`)
-		c.Check(deviceHostname, gc.Equals, "auto-generated.maas")  // "generated" above in NewDeviceParams()
-		c.Check(hostnameSuffix, gc.Equals, "juju-machine-0-kvm-5") // passed to AllocateAddress() below
-		return "auto-generated-juju-lxc.maas", nil
-	}
-	suite.PatchValue(&UpdateDeviceHostname, updateHostname)
-
-	// note that the default test server always succeeds if we provide a
-	// valid instance id and net id
-	err := env.AllocateAddress(
-		testInstance.Id(),
-		network.Id(string(int(subnetId))),
-		&network.Address{Value: "192.168.2.1"},
-		"aa:bb:cc:dd:ee:f0",
-		"juju-machine-0-kvm-5",
-	)
-	c.Assert(err, jc.ErrorIsNil)
-
-	devicesArray := suite.getDeviceArray(c)
-	c.Assert(devicesArray, gc.HasLen, 1)
-
-	device, err := devicesArray[0].GetMap()
-	c.Assert(err, jc.ErrorIsNil)
-
-	hostname, err := device["hostname"].GetString()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(hostname, gc.Equals, "auto-generated.maas")
-
-	parent, err := device["parent"].GetString()
-	c.Assert(err, jc.ErrorIsNil)
-	trimmedId := strings.TrimRight(string(testInstance.Id()), "/")
-	split := strings.Split(trimmedId, "/")
-	maasId := split[len(split)-1]
-	c.Assert(parent, gc.Equals, maasId)
-
-	addressesArray, err := device["ip_addresses"].GetArray()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(addressesArray, gc.HasLen, 1)
-	address, err := addressesArray[0].GetString()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(address, gc.Equals, "192.168.2.1")
-
-	macArray, err := device["macaddress_set"].GetArray()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(macArray, gc.HasLen, 1)
-	macMap, err := macArray[0].GetMap()
-	c.Assert(err, jc.ErrorIsNil)
-	mac, err := macMap["mac_address"].GetString()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(mac, gc.Equals, "aa:bb:cc:dd:ee:f0")
-}
-
-func (suite *environSuite) TestTransformDeviceHostname(c *gc.C) {
-	for i, test := range []struct {
-		deviceHostname string
-		hostnameSuffix string
-
-		expectedOutput string
-		expectedError  string
-	}{{
-		deviceHostname: "shiny-town.maas",
-		hostnameSuffix: "juju-machine-1-lxc-2",
-		expectedOutput: "shiny-town-juju-machine-1-lxc-2.maas",
-	}, {
-		deviceHostname: "foo.subdomain.example.com",
-		hostnameSuffix: "suffix",
-		expectedOutput: "foo-suffix.subdomain.example.com",
-	}, {
-		deviceHostname: "bad-food.example.com",
-		hostnameSuffix: "suffix.example.org",
-		expectedOutput: "bad-food-suffix.example.org.example.com",
-	}, {
-		deviceHostname: "strangers-and.freaks",
-		hostnameSuffix: "just-this",
-		expectedOutput: "strangers-and-just-this.freaks",
-	}, {
-		deviceHostname: "no-dot-hostname",
-		hostnameSuffix: "anything",
-		expectedError:  `unexpected device "dev-id" hostname "no-dot-hostname"`,
-	}, {
-		deviceHostname: "anything",
-		hostnameSuffix: "",
-		expectedError:  "hostname suffix cannot be empty",
-	}} {
-		c.Logf(
-			"test #%d: %q + %q -> %q (err: %s)",
-			i, test.deviceHostname, test.hostnameSuffix,
-			test.expectedOutput, test.expectedError,
-		)
-		output, err := transformDeviceHostname("dev-id", test.deviceHostname, test.hostnameSuffix)
-		if test.expectedError != "" {
-			c.Check(err, gc.ErrorMatches, test.expectedError)
-			c.Check(output, gc.Equals, "")
-			continue
-		}
-		c.Check(err, jc.ErrorIsNil)
-		c.Check(output, gc.Equals, test.expectedOutput)
-	}
-}
-
-func (suite *environSuite) patchDeviceCreation() {
-	// Work around the lack of support for devices PUT and POST without hostname
-	// set in gomaasapi's testservices
-	newParams := func(macAddress string, instId instance.Id, _ string) url.Values {
-		params := make(url.Values)
-		params.Add("mac_addresses", macAddress)
-		params.Add("hostname", "auto-generated.maas")
-		params.Add("parent", extractSystemId(instId))
-		return params
-	}
-	suite.PatchValue(&NewDeviceParams, newParams)
-	updateHostname := func(_ *gomaasapi.MAASObject, _, _, _ string) (string, error) {
-		return "auto-generated-juju-lxc.maas", nil
-	}
-	suite.PatchValue(&UpdateDeviceHostname, updateHostname)
-}
-
-func (suite *environSuite) TestAllocateAddressDevicesFailures(c *gc.C) {
-	suite.SetFeatureFlags()
-	testInstance := suite.getInstance("node1")
-	suite.addSubnet(c, 2, 2, "node1")
-	env := suite.makeEnviron()
-	suite.patchDeviceCreation()
-
-	responses := []string{
-		"claim_sticky_ip_address failed",
-		"GetMap of the response failed",
-		"no ip_addresses in response",
-		"unexpected ip_addresses in response",
-		"IP in ip_addresses not a string",
-	}
-	reserveIP := func(_ gomaasapi.MAASObject, deviceID, macAddress string, addr network.Address) (network.Address, error) {
-		c.Check(deviceID, gc.Matches, "node-[a-f0-9]+")
-		c.Check(macAddress, gc.Matches, "aa:bb:cc:dd:ee:f0")
-		c.Check(addr, jc.DeepEquals, network.Address{})
-		nextError := responses[0]
-		return network.Address{}, errors.New(nextError)
-	}
-	suite.PatchValue(&ReserveIPAddressOnDevice, reserveIP)
-
-	for len(responses) > 0 {
-		addr := &network.Address{}
-		err := env.AllocateAddress(
-			testInstance.Id(), network.AnySubnet, addr,
-			"aa:bb:cc:dd:ee:f0", "juju-lxc",
-		)
-		c.Check(err, gc.ErrorMatches, responses[0])
-		responses = responses[1:]
-	}
-}
-
-func (suite *environSuite) getDeviceArray(c *gc.C) []gomaasapi.JSONObject {
-	devicesURL := "/api/1.0/devices/?op=list"
-	resp, err := http.Get(suite.testMAASObject.TestServer.Server.URL + devicesURL)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(resp.StatusCode, gc.Equals, http.StatusOK)
-
-	defer resp.Body.Close()
-	content, err := ioutil.ReadAll(resp.Body)
-	c.Assert(err, jc.ErrorIsNil)
-	result, err := gomaasapi.Parse(gomaasapi.Client{}, content)
-	c.Assert(err, jc.ErrorIsNil)
-
-	devicesArray, err := result.GetArray()
-	c.Assert(err, jc.ErrorIsNil)
-	return devicesArray
-}
-
-func (suite *environSuite) TestReleaseAddressDeletesDevice(c *gc.C) {
-	testInstance := suite.getInstance("node1")
-	subnetId := suite.addSubnet(c, 2, 2, "node1")
-	env := suite.makeEnviron()
-	suite.patchDeviceCreation()
-
-	addr := network.NewAddress("192.168.2.1")
-	err := env.AllocateAddress(testInstance.Id(), network.Id(string(int(subnetId))), &addr, "foo", "juju-lxc")
-	c.Assert(err, jc.ErrorIsNil)
-
-	devicesArray := suite.getDeviceArray(c)
-	c.Assert(devicesArray, gc.HasLen, 1)
-
-	// Since we're mocking out updateDeviceHostname, no need to check if the
-	// hostname was updated (only manually tested for now until we change
-	// gomaasapi).
-
-	err = env.ReleaseAddress(testInstance.Id(), "LAN", addr, "foo", "juju-lxc")
-	c.Assert(err, jc.ErrorIsNil)
-
-	devicesArray = suite.getDeviceArray(c)
-	c.Assert(devicesArray, gc.HasLen, 0)
-}
-
-func (suite *environSuite) TestAllocateAddressInvalidInstance(c *gc.C) {
-	env := suite.makeEnviron()
-	addr := network.Address{Value: "192.168.2.1"}
-	instId := instance.Id("foo")
-	err := env.AllocateAddress(instId, "bar", &addr, "foo", "juju-lxc")
-	expected := fmt.Sprintf("failed to allocate address %q for instance %q.*", addr, instId)
-	c.Assert(err, gc.ErrorMatches, expected)
-}
-
-func (suite *environSuite) TestAllocateAddressIPAddressUnavailable(c *gc.C) {
-	testInstance := suite.getInstance("node1")
-	suite.patchDeviceCreation()
-	env := suite.makeEnviron()
-
-	mockReserve := func(ipaddresses gomaasapi.MAASObject, deviceId, mac string, addr network.Address) (network.Address, error) {
-		return network.Address{}, gomaasapi.ServerError{StatusCode: 404}
-	}
-	suite.PatchValue(&ReserveIPAddressOnDevice, mockReserve)
-
-	ipAddress := network.Address{Value: "192.168.2.1"}
-	err := env.AllocateAddress(testInstance.Id(), "any", &ipAddress, "foo", "bar")
-	c.Assert(errors.Cause(err), gc.Equals, environs.ErrIPAddressUnavailable)
-	expected := fmt.Sprintf("failed to allocate address %q for instance %q.*", ipAddress, testInstance.Id())
-	c.Assert(err, gc.ErrorMatches, expected)
+	err := env.ReleaseAddress("", "", network.Address{}, "", "")
+	c.Assert(err, gc.ErrorMatches, "ReleaseAddress not supported")
+	c.Assert(err, jc.Satisfies, errors.IsNotSupported)
 }
 
 func (s *environSuite) TestPrecheckInstanceAvailZone(c *gc.C) {
@@ -1023,69 +785,6 @@ func (s *environSuite) TestPrecheckInstanceAvailZone(c *gc.C) {
 	placement := "zone=zone1"
 	err := env.PrecheckInstance(coretesting.FakeDefaultSeries, constraints.Value{}, placement)
 	c.Assert(err, jc.ErrorIsNil)
-}
-
-func (suite *environSuite) TestReleaseAddress(c *gc.C) {
-	suite.patchDeviceCreation()
-	testInstance := suite.getInstance("node1")
-	subnetId := suite.addSubnet(c, 2, 2, "node1")
-	env := suite.makeEnviron()
-
-	err := env.AllocateAddress(testInstance.Id(), network.Id(string(int(subnetId))), &network.Address{Value: "192.168.2.1"}, "foo", "bar")
-	c.Assert(err, jc.ErrorIsNil)
-
-	ipAddress := network.Address{Value: "192.168.2.1"}
-	macAddress := "foobar"
-	hostname := "node1"
-	err = env.ReleaseAddress(testInstance.Id(), "bar", ipAddress, macAddress, hostname)
-	c.Assert(err, jc.ErrorIsNil)
-
-	// by releasing again we can test that the first release worked, *and*
-	// the error handling of ReleaseError
-	err = env.ReleaseAddress(testInstance.Id(), "bar", ipAddress, macAddress, hostname)
-	expected := fmt.Sprintf("(?s).*failed to release IP address %q from instance %q.*", ipAddress, testInstance.Id())
-	c.Assert(err, gc.ErrorMatches, expected)
-}
-
-func (suite *environSuite) TestReleaseAddressRetry(c *gc.C) {
-	suite.patchDeviceCreation()
-	// Patch short attempt params.
-	suite.PatchValue(&shortAttempt, utils.AttemptStrategy{
-		Min: 5,
-	})
-	// Patch IP address release call to MAAS.
-	retries := 0
-	enoughRetries := 10
-	suite.PatchValue(&ReleaseIPAddress, func(ipaddresses gomaasapi.MAASObject, addr network.Address) error {
-		retries++
-		if retries < enoughRetries {
-			return errors.New("ouch")
-		}
-		return nil
-	})
-
-	testInstance := suite.getInstance("node1")
-	subnetId := suite.addSubnet(c, 2, 2, "node1")
-	env := suite.makeEnviron()
-
-	err := env.AllocateAddress(testInstance.Id(), network.Id(string(int(subnetId))), &network.Address{Value: "192.168.2.1"}, "foo", "bar")
-	c.Assert(err, jc.ErrorIsNil)
-
-	// ReleaseAddress must fail with 5 retries.
-	ipAddress := network.Address{Value: "192.168.2.1"}
-	macAddress := "foobar"
-	hostname := "myhostname"
-	err = env.ReleaseAddress(testInstance.Id(), "bar", ipAddress, macAddress, hostname)
-	expected := fmt.Sprintf("(?s).*failed to release IP address %q from instance %q: ouch", ipAddress, testInstance.Id())
-	c.Assert(err, gc.ErrorMatches, expected)
-	c.Assert(retries, gc.Equals, 5)
-
-	// Now let it succeed after 3 retries.
-	retries = 0
-	enoughRetries = 3
-	err = env.ReleaseAddress(testInstance.Id(), "bar", ipAddress, macAddress, hostname)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(retries, gc.Equals, 3)
 }
 
 func (s *environSuite) TestPrecheckInstanceAvailZoneUnknown(c *gc.C) {

--- a/worker/provisioner/container_initialisation.go
+++ b/worker/provisioner/container_initialisation.go
@@ -195,7 +195,7 @@ func (cs *ContainerSetup) runInitialiser(containerType instance.ContainerType, i
 
 	// Only tweak default LXC network config when address allocation
 	// feature flag is enabled.
-	if environs.AddressAllocationEnabled() {
+	if environs.AddressAllocationEnabled(cs.config.Value(agent.ProviderType)) {
 		// In order to guarantee stable statically assigned IP addresses
 		// for LXC containers, we need to install a custom version of
 		// /etc/default/lxc-net before we install the lxc package. The

--- a/worker/provisioner/kvm-broker_test.go
+++ b/worker/provisioner/kvm-broker_test.go
@@ -159,10 +159,10 @@ func (s *kvmBrokerSuite) TestStartInstance(c *gc.C) {
 	s.SetFeatureFlags(feature.AddressAllocation)
 	kvm := s.startInstance(c, machineId)
 	s.api.CheckCalls(c, []gitjujutesting.StubCall{{
+		FuncName: "ContainerConfig",
+	}, {
 		FuncName: "PrepareContainerInterfaceInfo",
 		Args:     []interface{}{names.NewMachineTag("1-kvm-0")},
-	}, {
-		FuncName: "ContainerConfig",
 	}})
 	c.Assert(kvm.Id(), gc.Equals, instance.Id("juju-machine-1-kvm-0"))
 	s.assertInstances(c, kvm)
@@ -172,10 +172,10 @@ func (s *kvmBrokerSuite) TestStartInstanceAddressAllocationDisabled(c *gc.C) {
 	machineId := "1/kvm/0"
 	kvm := s.startInstance(c, machineId)
 	s.api.CheckCalls(c, []gitjujutesting.StubCall{{
+		FuncName: "ContainerConfig",
+	}, {
 		FuncName: "PrepareContainerInterfaceInfo",
 		Args:     []interface{}{names.NewMachineTag("1-kvm-0")},
-	}, {
-		FuncName: "ContainerConfig",
 	}})
 	c.Assert(kvm.Id(), gc.Equals, instance.Id("juju-machine-1-kvm-0"))
 	s.assertInstances(c, kvm)

--- a/worker/provisioner/lxc-broker.go
+++ b/worker/provisioner/lxc-broker.go
@@ -93,6 +93,12 @@ func (broker *lxcBroker) StartInstance(args environs.StartInstanceParams) (*envi
 		bridgeDevice = container.DefaultLxcBridge
 	}
 
+	config, err := broker.api.ContainerConfig()
+	if err != nil {
+		lxcLogger.Errorf("failed to get container config: %v", err)
+		return nil, err
+	}
+
 	preparedInfo, err := prepareOrGetContainerInterfaceInfo(
 		broker.api,
 		machineId,
@@ -101,6 +107,7 @@ func (broker *lxcBroker) StartInstance(args environs.StartInstanceParams) (*envi
 		broker.enableNAT,
 		args.NetworkInfo,
 		lxcLogger,
+		config.ProviderType,
 	)
 	if err != nil {
 		// It's not fatal (yet) if we couldn't pre-allocate addresses for the
@@ -132,11 +139,6 @@ func (broker *lxcBroker) StartInstance(args environs.StartInstanceParams) (*envi
 	args.InstanceConfig.MachineContainerType = instance.LXC
 	args.InstanceConfig.Tools = archTools[0]
 
-	config, err := broker.api.ContainerConfig()
-	if err != nil {
-		lxcLogger.Errorf("failed to get container config: %v", err)
-		return nil, err
-	}
 	storageConfig := &container.StorageConfig{
 		AllowMount: config.AllowLXCLoopMounts,
 	}
@@ -193,6 +195,7 @@ func (broker *lxcBroker) MaintainInstance(args environs.StartInstanceParams) err
 		broker.enableNAT,
 		args.NetworkInfo,
 		lxcLogger,
+		broker.agentConfig.Value(agent.ProviderType),
 	)
 	return err
 }
@@ -206,7 +209,8 @@ func (broker *lxcBroker) StopInstances(ids ...instance.Id) error {
 			lxcLogger.Errorf("container did not stop: %v", err)
 			return err
 		}
-		maybeReleaseContainerAddresses(broker.api, id, broker.namespace, lxcLogger)
+		providerType := broker.agentConfig.Value(agent.ProviderType)
+		maybeReleaseContainerAddresses(broker.api, id, broker.namespace, lxcLogger, providerType)
 	}
 	return nil
 }
@@ -677,10 +681,11 @@ func prepareOrGetContainerInterfaceInfo(
 	enableNAT bool,
 	startingNetworkInfo []network.InterfaceInfo,
 	log loggo.Logger,
+	providerType string,
 ) ([]network.InterfaceInfo, error) {
 	maintain := !allocateOrMaintain
 
-	if environs.AddressAllocationEnabled() {
+	if environs.AddressAllocationEnabled(providerType) {
 		if maintain {
 			log.Debugf("running maintenance for container %q", machineID)
 		} else {
@@ -752,8 +757,9 @@ func maybeReleaseContainerAddresses(
 	instanceID instance.Id,
 	namespace string,
 	log loggo.Logger,
+	providerType string,
 ) {
-	if environs.AddressAllocationEnabled() {
+	if environs.AddressAllocationEnabled(providerType) {
 		// The addresser worker will take care of the addresses.
 		return
 	}

--- a/worker/provisioner/lxc-broker_test.go
+++ b/worker/provisioner/lxc-broker_test.go
@@ -187,10 +187,10 @@ func (s *lxcBrokerSuite) TestStartInstance(c *gc.C) {
 	s.SetFeatureFlags(feature.AddressAllocation)
 	lxc := s.startInstance(c, machineId, nil)
 	s.api.CheckCalls(c, []gitjujutesting.StubCall{{
+		FuncName: "ContainerConfig",
+	}, {
 		FuncName: "PrepareContainerInterfaceInfo",
 		Args:     []interface{}{names.NewMachineTag("1-lxc-0")},
-	}, {
-		FuncName: "ContainerConfig",
 	}})
 	c.Assert(lxc.Id(), gc.Equals, instance.Id("juju-machine-1-lxc-0"))
 	c.Assert(s.lxcContainerDir(lxc), jc.IsDirectory)
@@ -203,10 +203,10 @@ func (s *lxcBrokerSuite) TestStartInstanceAddressAllocationDisabled(c *gc.C) {
 	machineId := "1/lxc/0"
 	lxc := s.startInstance(c, machineId, nil)
 	s.api.CheckCalls(c, []gitjujutesting.StubCall{{
+		FuncName: "ContainerConfig",
+	}, {
 		FuncName: "PrepareContainerInterfaceInfo",
 		Args:     []interface{}{names.NewMachineTag("1-lxc-0")},
-	}, {
-		FuncName: "ContainerConfig",
 	}})
 	c.Assert(lxc.Id(), gc.Equals, instance.Id("juju-machine-1-lxc-0"))
 	c.Assert(s.lxcContainerDir(lxc), jc.IsDirectory)
@@ -254,10 +254,10 @@ func (s *lxcBrokerSuite) TestStartInstanceWithStorage(c *gc.C) {
 	machineId := "1/lxc/0"
 	lxc := s.startInstance(c, machineId, []storage.VolumeParams{{Provider: provider.LoopProviderType}})
 	s.api.CheckCalls(c, []gitjujutesting.StubCall{{
+		FuncName: "ContainerConfig",
+	}, {
 		FuncName: "PrepareContainerInterfaceInfo",
 		Args:     []interface{}{names.NewMachineTag("1-lxc-0")},
-	}, {
-		FuncName: "ContainerConfig",
 	}})
 	c.Assert(lxc.Id(), gc.Equals, instance.Id("juju-machine-1-lxc-0"))
 	c.Assert(s.lxcContainerDir(lxc), jc.IsDirectory)
@@ -273,10 +273,10 @@ func (s *lxcBrokerSuite) TestStartInstanceLoopMountsDisallowed(c *gc.C) {
 	machineId := "1/lxc/0"
 	lxc := s.startInstance(c, machineId, []storage.VolumeParams{{Provider: provider.LoopProviderType}})
 	s.api.CheckCalls(c, []gitjujutesting.StubCall{{
+		FuncName: "ContainerConfig",
+	}, {
 		FuncName: "PrepareContainerInterfaceInfo",
 		Args:     []interface{}{names.NewMachineTag("1-lxc-0")},
-	}, {
-		FuncName: "ContainerConfig",
 	}})
 	c.Assert(lxc.Id(), gc.Equals, instance.Id("juju-machine-1-lxc-0"))
 	c.Assert(s.lxcContainerDir(lxc), jc.IsDirectory)
@@ -337,10 +337,10 @@ func (s *lxcBrokerSuite) TestStartInstanceWithBridgeEnviron(c *gc.C) {
 	machineId := "1/lxc/0"
 	lxc := s.startInstance(c, machineId, nil)
 	s.api.CheckCalls(c, []gitjujutesting.StubCall{{
+		FuncName: "ContainerConfig",
+	}, {
 		FuncName: "PrepareContainerInterfaceInfo",
 		Args:     []interface{}{names.NewMachineTag("1-lxc-0")},
-	}, {
-		FuncName: "ContainerConfig",
 	}})
 	c.Assert(lxc.Id(), gc.Equals, instance.Id("juju-machine-1-lxc-0"))
 	c.Assert(s.lxcContainerDir(lxc), jc.IsDirectory)

--- a/worker/provisioner/lxd-broker.go
+++ b/worker/provisioner/lxd-broker.go
@@ -33,11 +33,11 @@ func NewLxdBroker(
 	}
 
 	return &lxdBroker{
-		manager,
-		namespace,
-		api,
-		agentConfig,
-		enableNAT,
+		manager:     manager,
+		namespace:   namespace,
+		api:         api,
+		agentConfig: agentConfig,
+		enableNAT:   enableNAT,
 	}, nil
 }
 
@@ -59,6 +59,12 @@ func (broker *lxdBroker) StartInstance(args environs.StartInstanceParams) (*envi
 		bridgeDevice = lxdclient.DefaultLXDBridge
 	}
 
+	config, err := broker.api.ContainerConfig()
+	if err != nil {
+		lxdLogger.Errorf("failed to get container config: %v", err)
+		return nil, err
+	}
+
 	preparedInfo, err := prepareOrGetContainerInterfaceInfo(
 		broker.api,
 		machineId,
@@ -67,6 +73,7 @@ func (broker *lxdBroker) StartInstance(args environs.StartInstanceParams) (*envi
 		broker.enableNAT,
 		args.NetworkInfo,
 		lxdLogger,
+		config.ProviderType,
 	)
 	if err != nil {
 		// It's not fatal (yet) if we couldn't pre-allocate addresses for the
@@ -81,12 +88,6 @@ func (broker *lxdBroker) StartInstance(args environs.StartInstanceParams) (*envi
 	series := args.Tools.OneSeries()
 	args.InstanceConfig.MachineContainerType = instance.LXD
 	args.InstanceConfig.Tools = args.Tools[0]
-
-	config, err := broker.api.ContainerConfig()
-	if err != nil {
-		lxdLogger.Errorf("failed to get container config: %v", err)
-		return nil, err
-	}
 
 	if err := instancecfg.PopulateInstanceConfig(
 		args.InstanceConfig,
@@ -125,7 +126,8 @@ func (broker *lxdBroker) StopInstances(ids ...instance.Id) error {
 			lxdLogger.Errorf("container did not stop: %v", err)
 			return err
 		}
-		maybeReleaseContainerAddresses(broker.api, id, broker.namespace, lxdLogger)
+		providerType := broker.agentConfig.Value(agent.ProviderType)
+		maybeReleaseContainerAddresses(broker.api, id, broker.namespace, lxdLogger, providerType)
 	}
 	return nil
 }
@@ -158,6 +160,7 @@ func (broker *lxdBroker) MaintainInstance(args environs.StartInstanceParams) err
 		broker.enableNAT,
 		args.NetworkInfo,
 		lxdLogger,
+		broker.agentConfig.Value(agent.ProviderType),
 	)
 	return err
 }


### PR DESCRIPTION
Legacy address-allocation feature flag no longer has effect on the MAAS
provider behavior, even when the flag is enabled. Warning is issued
during bootstrap if the flag is detected.

AWS still supports the legacy address allocation for now, until we can
remove what's left of it.

Includes a fix for the assess-container-networking CI job failing due
to missing InterfaceType.

Heavily live tested on MAAS 1.9 and AWS, both with and without the AC
feature flag, on xenial and trusty, with all container types.

See http://pad.lv/1568925 for more info.

(Review request: http://reviews.vapour.ws/r/4614/)