### PR TITLE
lxd: check lxd versions

### DIFF
--- a/tools/lxdclient/client.go
+++ b/tools/lxdclient/client.go
@@ -119,6 +119,20 @@ func newRawClient(remote Remote) (*lxd.Client, error) {
 		return nil, errors.Trace(err)
 	}
 
+	status, err := client.ServerStatus()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	versionParts := strings.Split(status.Environment.ServerVersion, ".")
+	if len(versionParts) != 3 ||
+		versionParts[0] < "2" ||
+		versionParts[1] < "0" ||
+		versionParts[1] < "0" {
+
+		return nil, errors.Errorf("lxd version %s, juju needs 2.0.0", status.Environment.ServerVersion)
+	}
+
 	/* If this is the LXD provider on the localhost, let's do an extra
 	 * check to make sure that lxdbr0 is configured.
 	 */

--- a/tools/lxdclient/client.go
+++ b/tools/lxdclient/client.go
@@ -130,7 +130,7 @@ func newRawClient(remote Remote) (*lxd.Client, error) {
 		versionParts[1] < "0" ||
 		versionParts[1] < "0" {
 
-		return nil, errors.Errorf("lxd version %s, juju needs 2.0.0", status.Environment.ServerVersion)
+		return nil, errors.Errorf("lxd version %s, juju needs at least 2.0.0", status.Environment.ServerVersion)
 	}
 
 	/* If this is the LXD provider on the localhost, let's do an extra

--- a/tools/lxdclient/client_test.go
+++ b/tools/lxdclient/client_test.go
@@ -188,6 +188,13 @@ func (cs *ConnectSuite) TestRemoteConnectError(c *gc.C) {
 	c.Assert(errors.Cause(err), gc.Equals, testerr)
 }
 
+func (cs *ConnectSuite) TestVersionCheck(c *gc.C) {
+	c.Assert(isSupportedLxdVersion("2.0.0"), jc.IsTrue)
+	c.Assert(isSupportedLxdVersion("2.0.0.rc4"), jc.IsFalse)
+	c.Assert(isSupportedLxdVersion("0.19"), jc.IsFalse)
+	c.Assert(isSupportedLxdVersion("2.0.1"), jc.IsTrue)
+}
+
 var testerr = errors.Errorf("boo!")
 
 func fakeNewClientFromInfo(info lxd.ConnectInfo) (*lxd.Client, error) {


### PR DESCRIPTION
Some versions of LXD broke the API, and the current 2.0 API that juju is
complied with is not backwards compatible with these LXD versions. Let's
just refuse to bootstrap on any LXD that isn't 2.0.0 or greater.

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>

(Review request: http://reviews.vapour.ws/r/4615/)