### PR TITLE
query actions by name

### DIFF
--- a/api/action/client.go
+++ b/api/action/client.go
@@ -49,6 +49,14 @@ func (c *Client) Enqueue(arg params.Actions) (params.ActionResults, error) {
 	return results, err
 }
 
+// FindActionsByNames takes a list of action names and returns actions for
+// every name.
+func (c *Client) FindActionsByNames(arg params.FindActionsByNames) (params.ActionsByNames, error) {
+	results := params.ActionsByNames{}
+	err := c.facade.FacadeCall("FindActionsByNames", arg, &results)
+	return results, err
+}
+
 // ListAll takes a list of Entities representing ActionReceivers and returns
 // all of the Actions that have been queued or run by each of those
 // Entities.

--- a/apiserver/action/action_test.go
+++ b/apiserver/action/action_test.go
@@ -204,13 +204,14 @@ func (s *actionSuite) TestFindActionsByName(c *gc.C) {
 	c.Assert(err, gc.Equals, nil)
 	c.Assert(r.Results, gc.HasLen, len(arg.Actions))
 
-	actions, err := s.action.FindActionsByNames(params.FindActionsByNames{ActionNames: []string{"snapshot", "juju-run"}})
+	actionNames := []string{"snapshot", "juju-run"}
+	actions, err := s.action.FindActionsByNames(params.FindActionsByNames{ActionNames: actionNames})
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(len(actions.Actions), gc.Equals, 2)
-	for _, actions := range actions.Actions {
-		c.Assert(actions.Name, gc.Matches, "snapshot|juju-run")
+	for i, actions := range actions.Actions {
 		for _, action := range actions.Actions {
+			c.Assert(action.Action.Name, gc.Equals, actionNames[i])
 			c.Assert(action.Action.Name, gc.Matches, actions.Name)
 		}
 	}

--- a/apiserver/action/action_test.go
+++ b/apiserver/action/action_test.go
@@ -184,6 +184,38 @@ func (s *actionSuite) TestFindActionTagsByPrefix(c *gc.C) {
 	c.Assert(entities[0].Tag, gc.Equals, actionTag.String())
 }
 
+func (s *actionSuite) TestFindActionsByName(c *gc.C) {
+	machine := s.JujuConnSuite.Factory.MakeMachine(c, &jujuFactory.MachineParams{
+		Series: "quantal",
+		Jobs:   []state.MachineJob{state.JobHostUnits},
+	})
+	dummyUnit := s.JujuConnSuite.Factory.MakeUnit(c, &jujuFactory.UnitParams{
+		Service: s.dummy,
+		Machine: machine,
+	})
+	// NOTE: full testing with multiple matches has been moved to state package.
+	arg := params.Actions{Actions: []params.Action{
+		{Receiver: s.wordpressUnit.Tag().String(), Name: "fakeaction", Parameters: map[string]interface{}{}},
+		{Receiver: dummyUnit.Tag().String(), Name: "snapshot", Parameters: map[string]interface{}{"outfile": "lol"}},
+		{Receiver: s.wordpressUnit.Tag().String(), Name: "juju-run", Parameters: map[string]interface{}{"command": "boo", "timeout": 5}},
+		{Receiver: s.mysqlUnit.Tag().String(), Name: "juju-run", Parameters: map[string]interface{}{"command": "boo", "timeout": 5}},
+	}}
+	r, err := s.action.Enqueue(arg)
+	c.Assert(err, gc.Equals, nil)
+	c.Assert(r.Results, gc.HasLen, len(arg.Actions))
+
+	actions, err := s.action.FindActionsByNames(params.FindActionsByNames{ActionNames: []string{"snapshot", "juju-run"}})
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(len(actions.Actions), gc.Equals, 2)
+	for _, actions := range actions.Actions {
+		c.Assert(actions.Name, gc.Matches, "snapshot|juju-run")
+		for _, action := range actions.Actions {
+			c.Assert(action.Action.Name, gc.Matches, actions.Name)
+		}
+	}
+}
+
 func (s *actionSuite) TestEnqueue(c *gc.C) {
 	// Make sure no Actions already exist on wordpress Unit.
 	actions, err := s.wordpressUnit.Actions()

--- a/apiserver/params/actions.go
+++ b/apiserver/params/actions.go
@@ -75,6 +75,37 @@ type ActionsByReceiver struct {
 	Error    *Error         `json:"error,omitempty"`
 }
 
+// ActionsQueryResults holds a slice of responses from the Actions
+// query.
+type ActionsQueryResults struct {
+	Results []ActionsQueryResult `json:"results,omitempty"`
+}
+
+// ActionsQueryResult holds the name and parameters of an query result.
+type ActionsQueryResult struct {
+	Receiver string       `json:"receiver,omitempty"`
+	Action   ActionResult `json:"action,omitempty"`
+	Error    *Error       `json:"error,omitempty"`
+}
+
+// ActionsByNames wrap a slice of Actions for API calls.
+type ActionsByNames struct {
+	Actions []ActionsByName `json:"actions,omitempty"`
+}
+
+// ActionsByName is a bulk API call wrapper containing actions
+// as results.
+type ActionsByName struct {
+	Name    string         `json:"name,omitempty"`
+	Actions []ActionResult `json:"actions,omitempty"`
+	Error   *Error         `json:"error,omitempty"`
+}
+
+// FindActionsByName finds actions given an action name.
+type FindActionsByNames struct {
+	ActionNames []string `json:"names,omitempty"`
+}
+
 // ActionExecutionResults holds a slice of ActionExecutionResult for a
 // bulk action API call
 type ActionExecutionResults struct {

--- a/cmd/juju/action/action.go
+++ b/cmd/juju/action/action.go
@@ -53,6 +53,10 @@ type APIClient interface {
 	// FindActionTagsByPrefix takes a list of string prefixes and finds
 	// corresponding ActionTags that match that prefix.
 	FindActionTagsByPrefix(params.FindTags) (params.FindTagsResults, error)
+
+	// FindActionsByNames takes a list of names and finds a corresponding list of
+	// Actions for every name.
+	FindActionsByNames(params.FindActionsByNames) (params.ActionsByNames, error)
 }
 
 // ActionCommandBase is the base type for action sub-commands.

--- a/cmd/juju/action/package_test.go
+++ b/cmd/juju/action/package_test.go
@@ -130,6 +130,7 @@ type fakeAPIClient struct {
 	enqueuedActions    params.Actions
 	actionsByReceivers []params.ActionsByReceiver
 	actionTagMatches   params.FindTagsResults
+	actionsByNames     params.ActionsByNames
 	charmActions       *charm.Actions
 	apiErr             error
 }
@@ -208,4 +209,8 @@ func (c *fakeAPIClient) Actions(args params.Entities) (params.ActionResults, err
 
 func (c *fakeAPIClient) FindActionTagsByPrefix(arg params.FindTags) (params.FindTagsResults, error) {
 	return c.actionTagMatches, c.apiErr
+}
+
+func (c *fakeAPIClient) FindActionsByNames(args params.FindActionsByNames) (params.ActionsByNames, error) {
+	return c.actionsByNames, c.apiErr
 }

--- a/cmd/juju/action/showoutput_test.go
+++ b/cmd/juju/action/showoutput_test.go
@@ -278,6 +278,7 @@ timing:
 					t.withAPITimeout,
 					t.withTags,
 					t.withAPIResponse,
+					params.ActionsByNames{},
 					t.withAPIError),
 				t.expectedErr,
 				t.expectedOutput,
@@ -310,6 +311,7 @@ func makeFakeClient(
 	delay, timeout time.Duration,
 	tags params.FindTagsResults,
 	response []params.ActionResult,
+	actionsByNames params.ActionsByNames,
 	errStr string,
 ) *fakeAPIClient {
 	client := &fakeAPIClient{
@@ -317,6 +319,7 @@ func makeFakeClient(
 		timeout:          time.NewTimer(timeout),
 		actionTagMatches: tags,
 		actionResults:    response,
+		actionsByNames:   actionsByNames,
 	}
 	if errStr != "" {
 		client.apiErr = errors.New(errStr)

--- a/cmd/juju/commands/run.go
+++ b/cmd/juju/commands/run.go
@@ -64,6 +64,8 @@ the unit.
 in the model.  If you specify --all you cannot provide additional
 targets.
 
+Since juju run creates actions, you can query for commands started with
+juju run by calling "juju show-action-status --name juju-run".
 `
 
 func (c *runCommand) Info() *cmd.Info {

--- a/cmd/juju/commands/run.go
+++ b/cmd/juju/commands/run.go
@@ -64,8 +64,8 @@ the unit.
 in the model.  If you specify --all you cannot provide additional
 targets.
 
-Since juju run creates actions, you can query for commands started with
-juju run by calling "juju show-action-status --name juju-run".
+Since juju run creates actions, you can query for the status of commands
+started with juju run by calling "juju show-action-status --name juju-run".
 `
 
 func (c *runCommand) Info() *cmd.Info {

--- a/state/action.go
+++ b/state/action.go
@@ -321,6 +321,21 @@ func (st *State) FindActionTagsByPrefix(prefix string) []names.ActionTag {
 	return results
 }
 
+// FindActionsByName finds Actions with the given name.
+func (st *State) FindActionsByName(name string) ([]Action, error) {
+	var results []Action
+	var doc actionDoc
+
+	actions, closer := st.getCollection(actionsC)
+	defer closer()
+
+	iter := actions.Find(bson.D{{"name", name}}).Iter()
+	for iter.Next(&doc) {
+		results = append(results, newAction(st, doc))
+	}
+	return results, errors.Trace(iter.Close())
+}
+
 // EnqueueAction
 func (st *State) EnqueueAction(receiver names.Tag, actionName string, payload map[string]interface{}) (Action, error) {
 	if len(actionName) == 0 {

--- a/state/action_test.go
+++ b/state/action_test.go
@@ -493,6 +493,32 @@ func (s *ActionSuite) TestFindActionTagsByPrefix(c *gc.C) {
 	}
 }
 
+func (s *ActionSuite) TestFindActionsByName(c *gc.C) {
+	actions := []struct {
+		Name       string
+		Parameters map[string]interface{}
+	}{
+		{Name: "action-1", Parameters: map[string]interface{}{}},
+		{Name: "fake", Parameters: map[string]interface{}{"yeah": true, "take": nil}},
+		{Name: "action-1", Parameters: map[string]interface{}{"yeah": true, "take": nil}},
+		{Name: "action-9", Parameters: map[string]interface{}{"district": 9}},
+		{Name: "blarney", Parameters: map[string]interface{}{"conversation": []string{"what", "now"}}},
+	}
+
+	for _, action := range actions {
+		_, err := s.State.EnqueueAction(s.unit.Tag(), action.Name, action.Parameters)
+		c.Assert(err, gc.Equals, nil)
+	}
+
+	results, err := s.State.FindActionsByName("action-1")
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(len(results), gc.Equals, 2)
+	for _, result := range results {
+		c.Check(result.Name(), gc.Equals, "action-1")
+	}
+}
+
 func (s *ActionSuite) TestActionsWatcherEmitsInitialChanges(c *gc.C) {
 	// LP-1391914 :: idPrefixWatcher fails watcher contract to send
 	// initial Change event

--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -351,7 +351,7 @@ func allCollections() collectionSchema {
 		// These collections hold information associated with actions.
 		actionsC: {
 			indexes: []mgo.Index{{
-				Key: []string{"name"},
+				Key: []string{"model-uuid", "name"},
 			}},
 		},
 		actionNotificationsC: {},

--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -349,7 +349,11 @@ func allCollections() collectionSchema {
 		// -----
 
 		// These collections hold information associated with actions.
-		actionsC:             {},
+		actionsC: {
+			indexes: []mgo.Index{{
+				Key: []string{"name"},
+			}},
+		},
 		actionNotificationsC: {},
 
 		// -----


### PR DESCRIPTION
Under review here: http://reviews.vapour.ws/r/4393/

This patch allows us to query actions using the name. This is particularly useful for seeing actions queued by juju-run, through calling juju show-action-status --name juju-run.

Of course it is potentially useful on its own as well. 