### PR TITLE
Handle the case where charm urls in bundles do not specify series

### DIFF
--- a/cmd/juju/service/bundle.go
+++ b/cmd/juju/service/bundle.go
@@ -352,7 +352,7 @@ func (h *bundleHandler) addService(id string, p bundlechanges.AddServiceParams, 
 		return err
 	}
 	supportedSeries := charmInfo.Meta.Series
-	series, message, err := charmSeries(p.Series, chID.URL.Series, supportedSeries, false, conf)
+	series, message, err := charmSeries(p.Series, chID.URL.Series, supportedSeries, false, conf, true)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/cmd/juju/service/bundle.go
+++ b/cmd/juju/service/bundle.go
@@ -352,7 +352,7 @@ func (h *bundleHandler) addService(id string, p bundlechanges.AddServiceParams, 
 		return err
 	}
 	supportedSeries := charmInfo.Meta.Series
-	series, message, err := charmSeries(p.Series, chID.URL.Series, supportedSeries, false, conf, true)
+	series, message, err := charmSeries(p.Series, chID.URL.Series, supportedSeries, false, conf, deployFromBundle)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/cmd/juju/service/bundle_resources_test.go
+++ b/cmd/juju/service/bundle_resources_test.go
@@ -47,7 +47,7 @@ func (s *ResourcesBundleSuite) TestDeployBundleResources(c *gc.C) {
 	lines := strings.Split(output, "\n")
 	expectedLines := strings.Split(strings.TrimSpace(`
 added charm cs:trusty/starsay-42
-service starsay deployed (charm: cs:trusty/starsay-42)
+service starsay deployed (charm cs:trusty/starsay-42 with the charm series "trusty")
 added resource install-resource
 added resource store-resource
 added resource upload-resource

--- a/cmd/juju/service/bundle_test.go
+++ b/cmd/juju/service/bundle_test.go
@@ -271,7 +271,7 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleLocalPath(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	expectedOutput := fmt.Sprintf(`
 added charm local:xenial/dummy-1
-service dummy deployed (charm local:xenial/dummy-1 with the user specified series "xenial")
+service dummy deployed (charm local:xenial/dummy-1 with the series "xenial" defined by the bundle)
 added dummy/0 unit to new machine
 deployment of bundle %q completed`, path)
 	c.Assert(output, gc.Equals, strings.TrimSpace(expectedOutput))
@@ -298,7 +298,7 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleNoSeriesInCharmURL(c *gc.C
 	c.Assert(err, jc.ErrorIsNil)
 	expectedOutput := fmt.Sprintf(`
 added charm cs:~who/multi-series-0
-service dummy deployed (charm cs:~who/multi-series-0 with the user specified series "trusty")
+service dummy deployed (charm cs:~who/multi-series-0 with the series "trusty" defined by the bundle)
 deployment of bundle %q completed`, path)
 	c.Assert(output, gc.Equals, strings.TrimSpace(expectedOutput))
 	s.assertCharmsUploaded(c, "cs:~who/multi-series-0")
@@ -531,9 +531,9 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleLocalDeployment(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	expectedOutput := `
 added charm local:trusty/mysql-1
-service mysql deployed (charm local:trusty/mysql-1 with the user specified series "trusty")
+service mysql deployed (charm local:trusty/mysql-1 with the series "trusty" defined by the bundle)
 added charm local:trusty/wordpress-3
-service wordpress deployed (charm local:trusty/wordpress-3 with the user specified series "trusty")
+service wordpress deployed (charm local:trusty/wordpress-3 with the series "trusty" defined by the bundle)
 related wordpress:db and mysql:server
 added mysql/0 unit to new machine
 added mysql/1 unit to new machine
@@ -572,9 +572,9 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleLocalAndCharmStoreCharms(c
 	c.Assert(err, jc.ErrorIsNil)
 	expectedOutput := `
 added charm local:trusty/mysql-1
-service mysql deployed (charm local:trusty/mysql-1 with the user specified series "trusty")
+service mysql deployed (charm local:trusty/mysql-1 with the series "trusty" defined by the bundle)
 added charm cs:trusty/wordpress-42
-service wordpress deployed (charm cs:trusty/wordpress-42 with the user specified series "trusty")
+service wordpress deployed (charm cs:trusty/wordpress-42 with the series "trusty" defined by the bundle)
 related wordpress:db and mysql:server
 added mysql/0 unit to new machine
 added wordpress/0 unit to new machine
@@ -612,7 +612,7 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleServiceOptions(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	expectedOutput := `
 added charm cs:precise/dummy-0
-service customized deployed (charm cs:precise/dummy-0 with the user specified series "precise")
+service customized deployed (charm cs:precise/dummy-0 with the series "precise" defined by the bundle)
 added charm cs:trusty/wordpress-42
 service wordpress deployed (charm cs:trusty/wordpress-42 with the charm series "trusty")
 added customized/0 unit to new machine
@@ -652,7 +652,7 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleServiceConstrants(c *gc.C)
 	c.Assert(err, jc.ErrorIsNil)
 	expectedOutput := `
 added charm cs:precise/dummy-0
-service customized deployed (charm cs:precise/dummy-0 with the user specified series "precise")
+service customized deployed (charm cs:precise/dummy-0 with the series "precise" defined by the bundle)
 added charm cs:trusty/wordpress-42
 service wordpress deployed (charm cs:trusty/wordpress-42 with the charm series "trusty")
 added customized/0 unit to new machine
@@ -695,7 +695,7 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleServiceUpgrade(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	expectedOutput := `
 added charm cs:vivid/upgrade-1
-service up deployed (charm cs:vivid/upgrade-1 with the user specified series "vivid")
+service up deployed (charm cs:vivid/upgrade-1 with the series "vivid" defined by the bundle)
 added charm cs:trusty/wordpress-42
 service wordpress deployed (charm cs:trusty/wordpress-42 with the charm series "trusty")
 added up/0 unit to new machine
@@ -871,9 +871,9 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleMultipleRelations(c *gc.C)
 added charm cs:trusty/mysql-1
 service mysql deployed (charm cs:trusty/mysql-1 with the charm series "trusty")
 added charm cs:trusty/postgres-2
-service pgres deployed (charm cs:trusty/postgres-2 with the user specified series "trusty")
+service pgres deployed (charm cs:trusty/postgres-2 with the series "trusty" defined by the bundle)
 added charm cs:trusty/varnish-3
-service varnish deployed (charm cs:trusty/varnish-3 with the user specified series "trusty")
+service varnish deployed (charm cs:trusty/varnish-3 with the series "trusty" defined by the bundle)
 added charm cs:trusty/wordpress-0
 service wp deployed (charm cs:trusty/wordpress-0 with the charm series "trusty")
 related wp:db and mysql:server
@@ -980,9 +980,9 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleMachinesUnitsPlacement(c *
 	c.Assert(err, jc.ErrorIsNil)
 	expectedOutput := `
 added charm cs:trusty/mysql-2
-service sql deployed (charm cs:trusty/mysql-2 with the user specified series "trusty")
+service sql deployed (charm cs:trusty/mysql-2 with the series "trusty" defined by the bundle)
 added charm cs:trusty/wordpress-0
-service wp deployed (charm cs:trusty/wordpress-0 with the user specified series "trusty")
+service wp deployed (charm cs:trusty/wordpress-0 with the series "trusty" defined by the bundle)
 created new machine 0 for holding wp unit
 created new machine 1 for holding wp unit
 added wp/0 unit to machine 0
@@ -1069,7 +1069,7 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleMachineAttributes(c *gc.C)
 	c.Assert(err, jc.ErrorIsNil)
 	expectedOutput := `
 added charm cs:trusty/django-42
-service django deployed (charm cs:trusty/django-42 with the user specified series "trusty")
+service django deployed (charm cs:trusty/django-42 with the series "trusty" defined by the bundle)
 created new machine 0 for holding django unit
 annotations set for machine 0
 added django/0 unit to machine 0
@@ -1148,7 +1148,7 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleUnitPlacedInService(c *gc.
 	c.Assert(err, jc.ErrorIsNil)
 	expectedOutput := `
 added charm cs:trusty/django-42
-service django deployed (charm cs:trusty/django-42 with the user specified series "trusty")
+service django deployed (charm cs:trusty/django-42 with the series "trusty" defined by the bundle)
 added charm cs:trusty/wordpress-0
 service wordpress deployed (charm cs:trusty/wordpress-0 with the charm series "trusty")
 added wordpress/0 unit to new machine
@@ -1198,9 +1198,9 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleUnitColocationWithUnit(c *
 	c.Assert(err, jc.ErrorIsNil)
 	expectedOutput := `
 added charm cs:trusty/django-42
-service django deployed (charm cs:trusty/django-42 with the user specified series "trusty")
+service django deployed (charm cs:trusty/django-42 with the series "trusty" defined by the bundle)
 added charm cs:trusty/mem-47
-service memcached deployed (charm cs:trusty/mem-47 with the user specified series "trusty")
+service memcached deployed (charm cs:trusty/mem-47 with the series "trusty" defined by the bundle)
 added charm cs:trusty/rails-0
 service ror deployed (charm cs:trusty/rails-0 with the charm series "trusty")
 created new machine 0 for holding memcached and ror units
@@ -1317,9 +1317,9 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleMassiveUnitColocation(c *g
 	c.Assert(err, jc.ErrorIsNil)
 	expectedOutput := `
 added charm cs:trusty/django-42
-service django deployed (charm cs:trusty/django-42 with the user specified series "trusty")
+service django deployed (charm cs:trusty/django-42 with the series "trusty" defined by the bundle)
 added charm cs:trusty/mem-47
-service memcached deployed (charm cs:trusty/mem-47 with the user specified series "trusty")
+service memcached deployed (charm cs:trusty/mem-47 with the series "trusty" defined by the bundle)
 added charm cs:trusty/rails-0
 service ror deployed (charm cs:trusty/rails-0 with the charm series "trusty")
 created new machine 0 for holding django, memcached and ror units
@@ -1386,7 +1386,7 @@ added charm cs:trusty/django-42
 reusing service django (charm: cs:trusty/django-42)
 added charm cs:trusty/mem-47
 reusing service memcached (charm: cs:trusty/mem-47)
-service node deployed (charm cs:trusty/django-42 with the user specified series "trusty")
+service node deployed (charm cs:trusty/django-42 with the series "trusty" defined by the bundle)
 avoid creating other machines to host django and memcached units
 avoid adding new units to service django: 4 units already present
 avoid adding new units to service memcached: 3 units already present
@@ -1451,7 +1451,7 @@ added charm cs:trusty/django-42
 service django deployed (charm cs:trusty/django-42 with the charm series "trusty")
 annotations set for service django
 added charm cs:trusty/mem-47
-service memcached deployed (charm cs:trusty/mem-47 with the user specified series "trusty")
+service memcached deployed (charm cs:trusty/mem-47 with the series "trusty" defined by the bundle)
 created new machine 0 for holding django unit
 annotations set for machine 0
 added django/0 unit to machine 0

--- a/cmd/juju/service/deploy.go
+++ b/cmd/juju/service/deploy.go
@@ -430,7 +430,7 @@ func (c *DeployCommand) deployCharmOrBundle(ctx *cmd.Context, client *api.Client
 		return errors.Errorf("Flags provided but not supported when deploying a charm: %s.", strings.Join(flags, ", "))
 	}
 	// Get the series to use.
-	series, message, err := charmSeries(c.Series, storeCharmOrBundleURL.Series, supportedSeries, c.Force, conf, false)
+	series, message, err := charmSeries(c.Series, storeCharmOrBundleURL.Series, supportedSeries, c.Force, conf, deployFromCharm)
 	if charm.IsUnsupportedSeriesError(err) {
 		return errors.Errorf("%v. Use --force to deploy the charm anyway.", err)
 	}
@@ -466,6 +466,14 @@ const (
 	msgDefaultCharmSeries  = "with the default charm metadata series %q"
 	msgDefaultModelSeries  = "with the configured model default series %q"
 	msgLatestLTSSeries     = "with the latest LTS series %q"
+)
+
+const (
+	// deployFromBundle is passed to charmSeries when deploying from a bundle.
+	deployFromBundle = true
+
+	// deployFromCharm is passed to charmSeries when deploying a charm.
+	deployFromCharm = false
 )
 
 // charmSeries determine what series to use with a charm.

--- a/cmd/juju/service/deploy.go
+++ b/cmd/juju/service/deploy.go
@@ -430,7 +430,7 @@ func (c *DeployCommand) deployCharmOrBundle(ctx *cmd.Context, client *api.Client
 		return errors.Errorf("Flags provided but not supported when deploying a charm: %s.", strings.Join(flags, ", "))
 	}
 	// Get the series to use.
-	series, message, err := charmSeries(c.Series, storeCharmOrBundleURL.Series, supportedSeries, c.Force, conf)
+	series, message, err := charmSeries(c.Series, storeCharmOrBundleURL.Series, supportedSeries, c.Force, conf, false)
 	if charm.IsUnsupportedSeriesError(err) {
 		return errors.Errorf("%v. Use --force to deploy the charm anyway.", err)
 	}
@@ -461,6 +461,7 @@ func (c *DeployCommand) deployCharmOrBundle(ctx *cmd.Context, client *api.Client
 
 const (
 	msgUserRequestedSeries = "with the user specified series %q"
+	msgBundleSeries        = "with the series %q defined by the bundle"
 	msgSingleCharmSeries   = "with the charm series %q"
 	msgDefaultCharmSeries  = "with the default charm metadata series %q"
 	msgDefaultModelSeries  = "with the configured model default series %q"
@@ -469,7 +470,7 @@ const (
 
 // charmSeries determine what series to use with a charm.
 // Order of preference is:
-// - user requested when deploying
+// - user requested or defined by bundle when deploying
 // - default from charm metadata supported series
 // - model default
 // - charm store default
@@ -478,13 +479,18 @@ func charmSeries(
 	supportedSeries []string,
 	force bool,
 	conf *config.Config,
+	fromBundle bool,
 ) (string, string, error) {
 	// User has requested a series and we have a new charm with series in metadata.
 	if requestedSeries != "" && seriesFromCharm == "" {
 		if !force && !isSeriesSupported(requestedSeries, supportedSeries) {
 			return "", "", charm.NewUnsupportedSeriesError(requestedSeries, supportedSeries)
 		}
-		return requestedSeries, msgUserRequestedSeries, nil
+		if fromBundle {
+			return requestedSeries, msgBundleSeries, nil
+		} else {
+			return requestedSeries, msgUserRequestedSeries, nil
+		}
 	}
 
 	// User has requested a series and it's an old charm for a single series.
@@ -493,7 +499,11 @@ func charmSeries(
 			return "", "", charm.NewUnsupportedSeriesError(requestedSeries, []string{seriesFromCharm})
 		}
 		if requestedSeries != "" {
-			return requestedSeries, msgUserRequestedSeries, nil
+			if fromBundle {
+				return requestedSeries, msgBundleSeries, nil
+			} else {
+				return requestedSeries, msgUserRequestedSeries, nil
+			}
 		}
 		return seriesFromCharm, msgSingleCharmSeries, nil
 	}

--- a/cmd/juju/service/deploy_test.go
+++ b/cmd/juju/service/deploy_test.go
@@ -630,9 +630,9 @@ Deploying charm "cs:~bob/trusty/wordpress4-10" with the charm series "trusty".`,
 	deployURL: "cs:~bob/bundle/wordpress-simple1",
 	expectOutput: `
 added charm cs:trusty/mysql-0
-service mysql deployed (charm: cs:trusty/mysql-0)
+service mysql deployed (charm cs:trusty/mysql-0 with the charm series "trusty")
 added charm cs:trusty/wordpress-1
-service wordpress deployed (charm: cs:trusty/wordpress-1)
+service wordpress deployed (charm cs:trusty/wordpress-1 with the charm series "trusty")
 related wordpress:db and mysql:server
 added mysql/0 unit to new machine
 added wordpress/0 unit to new machine

--- a/cmd/juju/service/deploy_test.go
+++ b/cmd/juju/service/deploy_test.go
@@ -537,7 +537,7 @@ func (s *DeploySuite) TestCharmSeries(c *gc.C) {
 			"default-series": test.modelSeries,
 		}))
 		c.Assert(err, jc.ErrorIsNil)
-		series, msg, err := charmSeries(test.requestedSeries, test.seriesFromCharm, test.supportedSeries, test.force, cfg)
+		series, msg, err := charmSeries(test.requestedSeries, test.seriesFromCharm, test.supportedSeries, test.force, cfg, false)
 		if test.err != "" {
 			c.Check(err, gc.ErrorMatches, test.err)
 			continue

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -12,7 +12,7 @@ github.com/joyent/gocommon	git	40c7818502f7c1ebbb13dab185a26e77b746ff40	2014-05-
 github.com/joyent/gosdc	git	2f11feadd2d9891e92296a1077c3e2e56939547d	2014-05-24T00:08:15Z
 github.com/joyent/gosign	git	0da0d5f1342065321c97812b1f4ac0c2b0bab56c	2014-05-24T00:07:34Z
 github.com/juju/blobstore	git	06056004b3d7b54bbb7984d830c537bad00fec21	2015-07-29T11:18:58Z
-github.com/juju/bundlechanges	git	23298895ce762481f0599ccb7c55cfb0c8fa1e15	2016-04-15T14:11:57Z
+github.com/juju/bundlechanges	git	a1fcaa2fc3b55305d064d16cb56bf87541efb8a4	2016-04-18T04:33:00Z
 github.com/juju/cmd	git	ca63dd8ba13f8fbbbe16a917696a7ce68cc3dc0b	2016-03-31T03:26:51Z
 github.com/juju/errors	git	1b5e39b83d1835fa480e0c2ddefb040ee82d58b3	2015-09-16T12:56:42Z
 github.com/juju/go4	git	40d72ab9641a2a8c36a9c46a51e28367115c8e59	2016-02-22T16:32:58Z


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/juju-core/+bug/1571254

For multi-series charms, the URL does not need to include the series. In bundles, this was not handled properly. We re-use the charmSeries() method to determine the series to use, and also improve the logged message to match what is used when deploying single charms.

(Review request: http://reviews.vapour.ws/r/4624/)