### PR TITLE
Fixed lp:1564395: Containers come up without any interfaces

### DIFF
--- a/apiserver/common/networkingcommon/types.go
+++ b/apiserver/common/networkingcommon/types.go
@@ -436,7 +436,7 @@ func GetObservedNetworkConfig() ([]params.NetworkConfig, error) {
 
 		if len(addrs) == 0 {
 			observedConfig = append(observedConfig, nicConfig)
-			logger.Warningf("no addresses observed on interface %q", nic.Name)
+			logger.Infof("no addresses observed on interface %q", nic.Name)
 			continue
 		}
 
@@ -458,7 +458,7 @@ func GetObservedNetworkConfig() ([]params.NetworkConfig, error) {
 				logger.Infof("assuming interface %q has observed address %q", nic.Name, ipNet.String())
 			}
 			if ip.To4() == nil {
-				logger.Warningf("skipping observed IPv6 address %q on %q: not fully supported yet", ip, nic.Name)
+				logger.Debugf("skipping observed IPv6 address %q on %q: not fully supported yet", ip, nic.Name)
 				continue
 			}
 

--- a/apiserver/provisioner/provisioner.go
+++ b/apiserver/provisioner/provisioner.go
@@ -790,10 +790,10 @@ func (p *ProvisionerAPI) prepareOrGetContainerInterfaceInfo(args params.Entities
 			}
 			firstAddress := parentAddrs[0]
 			parentDeviceSubnet, err := firstAddress.Subnet()
-			if err != nil || parentDeviceSubnet == nil {
-				err = errors.Errorf(
-					"cannot get subnet %q used by address %q of host machine device %q: %v",
-					firstAddress.SubnetID(), firstAddress.Value(), parentDevice.Name(), err,
+			if err != nil {
+				err = errors.Annotatef(err,
+					"cannot get subnet %q used by address %q of host machine device %q",
+					firstAddress.SubnetCIDR(), firstAddress.Value(), parentDevice.Name(),
 				)
 				result.Results[i].Error = common.ServerError(err)
 				preparedOK = false

--- a/state/ipaddresses_internal_test.go
+++ b/state/ipaddresses_internal_test.go
@@ -64,13 +64,6 @@ func (s *ipAddressesInternalSuite) TestProviderIDDoesNotIncludeModelUUIDWhenSet(
 	c.Assert(result.localProviderID(), gc.Equals, localProviderID)
 }
 
-func (s *ipAddressesInternalSuite) TestSubnetReturnsNoErrorWhenSubnetIDNotSet(c *gc.C) {
-	result := s.newIPAddressWithDummyState(ipAddressDoc{})
-	subnet, err := result.Subnet()
-	c.Check(subnet, gc.IsNil)
-	c.Check(err, jc.ErrorIsNil)
-}
-
 func (s *ipAddressesInternalSuite) TestIPAddressGlobalKeyHelper(c *gc.C) {
 	result := ipAddressGlobalKey("42", "eth0", "0.1.2.3")
 	c.Assert(result, gc.Equals, "m#42#d#eth0#ip#0.1.2.3")
@@ -121,7 +114,7 @@ func (s *ipAddressesInternalSuite) TestRemainingSimpleGetterMethods(c *gc.C) {
 	doc := ipAddressDoc{
 		DeviceName:       "eth0",
 		MachineID:        "42",
-		SubnetID:         "10.20.30.0/24",
+		SubnetCIDR:       "10.20.30.0/24",
 		ConfigMethod:     StaticAddress,
 		Value:            "10.20.30.40",
 		DNSServers:       []string{"ns1.example.com", "ns2.example.org"},
@@ -132,7 +125,7 @@ func (s *ipAddressesInternalSuite) TestRemainingSimpleGetterMethods(c *gc.C) {
 
 	c.Check(result.DeviceName(), gc.Equals, "eth0")
 	c.Check(result.MachineID(), gc.Equals, "42")
-	c.Check(result.SubnetID(), gc.Equals, "10.20.30.0/24")
+	c.Check(result.SubnetCIDR(), gc.Equals, "10.20.30.0/24")
 	c.Check(result.ConfigMethod(), gc.Equals, StaticAddress)
 	c.Check(result.Value(), gc.Equals, "10.20.30.40")
 	c.Check(result.DNSServers(), jc.DeepEquals, []string{"ns1.example.com", "ns2.example.org"})

--- a/state/ipaddresses_test.go
+++ b/state/ipaddresses_test.go
@@ -162,13 +162,16 @@ func (s *ipAddressesStateSuite) TestSubnetMethodReturnsNotFoundErrorWhenMissing(
 	c.Assert(result, gc.IsNil)
 }
 
-func (s *ipAddressesStateSuite) TestSubnetMethodReturnsNoErrorWithEmptySubnetIDForLoopbackOrUnknownSubnets(c *gc.C) {
-	_, addresses := s.addNamedDeviceWithAddresses(c, "eth0", "127.0.1.1/8", "::1/128", "8.8.0.0/16")
+func (s *ipAddressesStateSuite) TestSubnetMethodReturnsNotFoundErrorWithUnknownOrLocalSubnet(c *gc.C) {
+	cidrs := []string{"127.0.0.0/8", "::1/128", "8.8.0.0/16"}
+	_, addresses := s.addNamedDeviceWithAddresses(c, "eth0", cidrs...)
 
-	for _, address := range addresses {
+	for i, address := range addresses {
 		result, err := address.Subnet()
 		c.Check(result, gc.IsNil)
-		c.Check(err, jc.ErrorIsNil)
+		c.Check(err, jc.Satisfies, errors.IsNotFound)
+		expectedError := fmt.Sprintf("subnet %q not found", cidrs[i])
+		c.Check(err, gc.ErrorMatches, expectedError)
 	}
 }
 
@@ -374,13 +377,13 @@ func (s *ipAddressesStateSuite) TestSetDevicesAddressesOKWhenCIDRAddressDoesNotM
 	err := s.machine.SetDevicesAddresses(args)
 	c.Assert(err, jc.ErrorIsNil)
 
-	assertDeviceHasOneAddressWithSubnetIDEquals := func(subnetID string) {
+	assertDeviceHasOneAddressWithSubnetCIDREquals := func(subnetCIDR string) {
 		addresses, err := device.Addresses()
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(addresses, gc.HasLen, 1)
-		c.Assert(addresses[0].SubnetID(), gc.Equals, subnetID)
+		c.Assert(addresses[0].SubnetCIDR(), gc.Equals, subnetCIDR)
 	}
-	assertDeviceHasOneAddressWithSubnetIDEquals("")
+	assertDeviceHasOneAddressWithSubnetCIDREquals("192.168.0.0/16")
 
 	// Add the subnet so it's known and retry setting the same address to verify
 	// SubnetID gets updated.
@@ -389,7 +392,7 @@ func (s *ipAddressesStateSuite) TestSetDevicesAddressesOKWhenCIDRAddressDoesNotM
 	err = s.machine.SetDevicesAddresses(args)
 	c.Assert(err, jc.ErrorIsNil)
 
-	assertDeviceHasOneAddressWithSubnetIDEquals("192.168.0.0/16")
+	assertDeviceHasOneAddressWithSubnetCIDREquals("192.168.0.0/16")
 }
 
 func (s *ipAddressesStateSuite) TestSetDevicesAddressesFailsWhenCIDRAddressMatchesDeadSubnet(c *gc.C) {

--- a/state/machine_linklayerdevices.go
+++ b/state/machine_linklayerdevices.go
@@ -762,10 +762,9 @@ func (m *Machine) maybeAssertSubnetAliveOps(newDoc *ipAddressDoc, opsSoFar []txn
 	}
 
 	// Subnet exists and is still alive, assert that is stays that way.
-	subnetDocID := m.st.docID(newDoc.SubnetCIDR)
 	return append(opsSoFar, txn.Op{
 		C:      subnetsC,
-		Id:     subnetDocID,
+		Id:     m.st.docID(newDoc.SubnetCIDR),
 		Assert: isAliveDoc,
 	}), nil
 }

--- a/state/machine_linklayerdevices.go
+++ b/state/machine_linklayerdevices.go
@@ -754,6 +754,8 @@ func (m *Machine) maybeAssertSubnetAliveOps(newDoc *ipAddressDoc, opsSoFar []txn
 	if errors.IsNotFound(err) {
 		// Subnet is machine-local, no need to assert whether it's alive.
 		return opsSoFar, nil
+	} else if err != nil {
+		return nil, errors.Trace(err)
 	}
 	if err := m.verifySubnetAlive(subnet); err != nil {
 		return nil, errors.Trace(err)


### PR DESCRIPTION
State model for link-layer device addresses have slightly changed to
allow storing addresses linked to an unknown (by the provider) or
machine-local subnets (e.g. 10.0.3.0/24 or 127.0.0.0/8). For subnets
already known, it is still verified whether they are alive first.

This allows to solve the contention between spaces discovery still going
(i.e. not all subnets are known yet) and adding a container.

See http://pad.lv/1564395 for details.
Live tested on MAAS 1.9.1.

(Review request: http://reviews.vapour.ws/r/4626/)