### PR TITLE
cmd/juju/user: only prompt for password once

### DIFF
--- a/cmd/juju/user/login.go
+++ b/cmd/juju/user/login.go
@@ -125,7 +125,9 @@ Run "juju logout" first before attempting to log in as a different user.
 	}
 
 	// Read password from the terminal, and attempt to log in using that.
-	password, err := readAndConfirmPassword(ctx)
+	fmt.Fprint(ctx.Stderr, "password: ")
+	password, err := readPassword(ctx.Stdin)
+	fmt.Fprintln(ctx.Stderr)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/cmd/juju/user/login_test.go
+++ b/cmd/juju/user/login_test.go
@@ -41,7 +41,7 @@ func (s *LoginCommandSuite) run(c *gc.C, stdin string, args ...string) (*cmd.Con
 	}, s.store)
 	ctx := coretesting.Context(c)
 	if stdin == "" {
-		stdin = "sekrit\nsekrit\n"
+		stdin = "sekrit\n"
 	}
 	ctx.Stdin = strings.NewReader(stdin)
 	err := coretesting.InitCommand(cmd, args)
@@ -83,12 +83,11 @@ func (s *LoginCommandSuite) TestInit(c *gc.C) {
 }
 
 func (s *LoginCommandSuite) TestLogin(c *gc.C) {
-	context, args, err := s.run(c, "current-user\nsekrit\nsekrit\n")
+	context, args, err := s.run(c, "current-user\nsekrit\n")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(coretesting.Stdout(context), gc.Equals, "")
 	c.Assert(coretesting.Stderr(context), gc.Equals, `
 username: password: 
-type password again: 
 You are now logged in to "testing" as "current-user@local".
 `[1:],
 	)
@@ -108,7 +107,6 @@ func (s *LoginCommandSuite) TestLoginNewUser(c *gc.C) {
 	c.Assert(coretesting.Stdout(context), gc.Equals, "")
 	c.Assert(coretesting.Stderr(context), gc.Equals, `
 password: 
-type password again: 
 You are now logged in to "testing" as "new-user@local".
 `[1:],
 	)

--- a/featuretests/cmd_juju_login_test.go
+++ b/featuretests/cmd_juju_login_test.go
@@ -55,7 +55,6 @@ func (s *cmdLoginSuite) TestLoginCommand(c *gc.C) {
 	c.Assert(testing.Stdout(context), gc.Equals, "")
 	c.Assert(testing.Stderr(context), gc.Equals, `
 password: 
-type password again: 
 You are now logged in to "kontroll" as "test@local".
 `[1:])
 


### PR DESCRIPTION
Confirmation is needed when setting/changing
the password, not for login.

Fixes https://bugs.launchpad.net/juju-core/+bug/1571478

(Review request: http://reviews.vapour.ws/r/4627/)