### PR TITLE
Don't record password in "juju register"

### DIFF
--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -461,7 +461,8 @@ func (srv *Server) endpoints() []apihttp.Endpoint {
 	)
 	add("/register",
 		&registerUserHandler{
-			ctxt: httpCtxt,
+			httpCtxt,
+			srv.authCtxt.userAuth.CreateLocalLoginMacaroon,
 		},
 	)
 	add("/", mainAPIHandler)

--- a/apiserver/params/registration.go
+++ b/apiserver/params/registration.go
@@ -3,6 +3,10 @@
 
 package params
 
+import (
+	"gopkg.in/macaroon.v1"
+)
+
 // SecretKeyLoginRequest contains the parameters for completing
 // the registration of a user. The request contains the tag of
 // the user, and an encrypted and authenticated payload that
@@ -53,4 +57,8 @@ type SecretKeyLoginResponsePayload struct {
 
 	// ControllerUUID is the UUID of the Juju controller.
 	ControllerUUID string `json:"controller-uuid"`
+
+	// Macaroon is a time-limited macaroon that can be used for
+	// authenticating as the registered user.
+	Macaroon *macaroon.Macaroon `json:"macaroon"`
 }

--- a/cmd/juju/controller/register.go
+++ b/cmd/juju/controller/register.go
@@ -160,9 +160,13 @@ func (c *registerCommand) Run(ctx *cmd.Context) error {
 	if err := c.store.UpdateController(registrationParams.controllerName, controllerDetails); err != nil {
 		return errors.Trace(err)
 	}
+	macaroonJSON, err := responsePayload.Macaroon.MarshalJSON()
+	if err != nil {
+		return errors.Annotate(err, "marshalling temporary credential to JSON")
+	}
 	accountDetails := jujuclient.AccountDetails{
 		User:     registrationParams.userTag.Canonical(),
-		Password: registrationParams.newPassword,
+		Macaroon: string(macaroonJSON),
 	}
 	accountName := accountDetails.User
 	if err := c.store.UpdateAccount(

--- a/cmd/juju/controller/register_test.go
+++ b/cmd/juju/controller/register_test.go
@@ -20,6 +20,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	"golang.org/x/crypto/nacl/secretbox"
 	gc "gopkg.in/check.v1"
+	"gopkg.in/macaroon.v1"
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/apiserver/params"
@@ -200,12 +201,18 @@ func (s *RegisterSuite) testRegister(c *gc.C) *cmd.Context {
 	secretKey := []byte(strings.Repeat("X", 32))
 	respNonce := []byte(strings.Repeat("X", 24))
 
+	macaroon, err := macaroon.New(nil, "mymacaroon", "tone")
+	c.Assert(err, jc.ErrorIsNil)
+	macaroonJSON, err := macaroon.MarshalJSON()
+	c.Assert(err, jc.ErrorIsNil)
+
 	var requests []*http.Request
 	var requestBodies [][]byte
 	const controllerUUID = "df136476-12e9-11e4-8a70-b2227cce2b54"
 	responsePayloadPlaintext, err := json.Marshal(params.SecretKeyLoginResponsePayload{
 		CACert:         testing.CACert,
 		ControllerUUID: controllerUUID,
+		Macaroon:       macaroon,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	response, err := json.Marshal(params.SecretKeyLoginResponse{
@@ -258,7 +265,7 @@ func (s *RegisterSuite) testRegister(c *gc.C) *cmd.Context {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(account, jc.DeepEquals, &jujuclient.AccountDetails{
 		User:     "bob@local",
-		Password: "hunter2",
+		Macaroon: string(macaroonJSON),
 	})
 	return ctx
 }


### PR DESCRIPTION
When running "juju register", don't store the
password on disk. Instead, the server will
return a macaroon, and that will be stored.

Fixes https://bugs.launchpad.net/juju-core/+bug/1571476

(Review request: http://reviews.vapour.ws/r/4628/)