### PR TITLE
Add tags to maas2instance.hardwareCharacteristics

### DIFF
--- a/provider/maas/maas2_test.go
+++ b/provider/maas/maas2_test.go
@@ -192,6 +192,11 @@ type fakeMachine struct {
 	memory        int
 	architecture  string
 	interfaceSet  []gomaasapi.Interface
+	tags          []string
+}
+
+func (m *fakeMachine) Tags() []string {
+	return m.tags
 }
 
 func (m *fakeMachine) CPUCount() int {

--- a/provider/maas/maas2instance.go
+++ b/provider/maas/maas2instance.go
@@ -43,13 +43,14 @@ func (mi *maas2Instance) hardwareCharacteristics() (*instance.HardwareCharacteri
 	nodeMemoryMB := uint64(mi.machine.Memory())
 	// zone can't error on the maas2Instance implementaation.
 	zone, _ := mi.zone()
+	tags := mi.machine.Tags()
 	hc := &instance.HardwareCharacteristics{
 		Arch:             &nodeArch,
 		CpuCores:         &nodeCpuCount,
 		Mem:              &nodeMemoryMB,
 		AvailabilityZone: &zone,
+		Tags:             &tags,
 	}
-	// TODO (mfoord): also need machine tags
 	return hc, nil
 }
 

--- a/provider/maas/maas2instance_test.go
+++ b/provider/maas/maas2instance_test.go
@@ -71,17 +71,25 @@ func (s *maas2InstanceSuite) TestHostname(c *gc.C) {
 }
 
 func (s *maas2InstanceSuite) TestHardwareCharacteristics(c *gc.C) {
-	machine := &fakeMachine{cpuCount: 3, memory: 4, architecture: "foo/bam", zoneName: "bar"}
+	machine := &fakeMachine{
+		cpuCount:     3,
+		memory:       4,
+		architecture: "foo/bam",
+		zoneName:     "bar",
+		tags:         []string{"foo", "bar"},
+	}
 	thing := &maas2Instance{machine}
 	arch := "foo"
 	cpu := uint64(3)
 	mem := uint64(4)
 	zone := "bar"
+	tags := []string{"foo", "bar"}
 	expected := &instance.HardwareCharacteristics{
 		Arch:             &arch,
 		CpuCores:         &cpu,
 		Mem:              &mem,
 		AvailabilityZone: &zone,
+		Tags:             &tags,
 	}
 	result, err := thing.hardwareCharacteristics()
 	c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
Add machine tags to the maas2Instance type.

(Review request: http://reviews.vapour.ws/r/4630/)