### PR TITLE
Try both private *and* public API addresses (part 2).

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -575,7 +575,7 @@ func (c *configInternal) SetAPIHostPorts(servers [][]network.HostPort) {
 	}
 	var addrs []string
 	for _, serverHostPorts := range servers {
-		hps := network.SelectInternalHostPorts(serverHostPorts, false)
+		hps := network.PrioritizeInternalHostPorts(serverHostPorts, false)
 		addrs = append(addrs, hps...)
 	}
 	c.apiDetails.addresses = addrs

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -772,6 +772,7 @@ func (*suite) TestSetAPIHostPorts(c *gc.C) {
 	c.Assert(addrs, gc.DeepEquals, []string{
 		"0.1.0.1:1111",
 		"0.1.0.2:1111",
+		"host.com:1111",
 		"0.2.0.1:2222",
 		"0.2.0.2:2222",
 		"0.4.0.1:4444",

--- a/api/client.go
+++ b/api/client.go
@@ -426,15 +426,14 @@ func (c *Client) ResolveCharm(ref *charm.URL) (*charm.URL, error) {
 }
 
 // UploadTools uploads tools at the specified location to the API server over HTTPS.
-func (c *Client) UploadTools(r io.ReadSeeker, vers version.Binary, additionalSeries ...string) (*tools.Tools, error) {
+func (c *Client) UploadTools(r io.ReadSeeker, vers version.Binary, additionalSeries ...string) (tools.List, error) {
 	endpoint := fmt.Sprintf("/tools?binaryVersion=%s&series=%s", vers, strings.Join(additionalSeries, ","))
 	contentType := "application/x-tar-gz"
 	var resp params.ToolsResult
 	if err := c.httpPost(r, endpoint, contentType, &resp); err != nil {
 		return nil, errors.Trace(err)
 	}
-	// TODO(ericsnow) Match up the URL with the client's connection.
-	return resp.ToolsList[0], nil
+	return resp.ToolsList, nil
 }
 
 func (c *Client) httpPost(content io.ReadSeeker, endpoint, contentType string, response interface{}) error {

--- a/api/client.go
+++ b/api/client.go
@@ -433,7 +433,8 @@ func (c *Client) UploadTools(r io.ReadSeeker, vers version.Binary, additionalSer
 	if err := c.httpPost(r, endpoint, contentType, &resp); err != nil {
 		return nil, errors.Trace(err)
 	}
-	return resp.Tools, nil
+	// TODO(ericsnow) Match up the URL with the client's connection.
+	return resp.ToolsList[0], nil
 }
 
 func (c *Client) httpPost(content io.ReadSeeker, endpoint, contentType string, response interface{}) error {

--- a/api/upgrader/unitupgrader_test.go
+++ b/api/upgrader/unitupgrader_test.go
@@ -114,8 +114,10 @@ func (s *unitUpgraderSuite) TestTools(c *gc.C) {
 	s.rawMachine.SetAgentVersion(current)
 	// UnitUpgrader.Tools returns the *desired* set of tools, not the currently
 	// running set. We want to be upgraded to cur.Version
-	stateTools, err := s.st.Tools(s.rawUnit.Tag().String())
+	stateToolsList, err := s.st.Tools(s.rawUnit.Tag().String())
 	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(stateToolsList, gc.HasLen, 1)
+	stateTools := stateToolsList[0]
 	c.Check(stateTools.Version.Number, gc.DeepEquals, current.Number)
 	c.Assert(stateTools.URL, gc.NotNil)
 }

--- a/api/upgrader/upgrader.go
+++ b/api/upgrader/upgrader.go
@@ -72,7 +72,7 @@ func (st *State) DesiredVersion(tag string) (version.Number, error) {
 
 // Tools returns the agent tools that should run on the given entity,
 // along with a flag whether to disable SSL hostname verification.
-func (st *State) Tools(tag string) (*tools.Tools, error) {
+func (st *State) Tools(tag string) (tools.List, error) {
 	var results params.ToolsResults
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: tag}},
@@ -82,15 +82,19 @@ func (st *State) Tools(tag string) (*tools.Tools, error) {
 		// TODO: Not directly tested
 		return nil, err
 	}
+	// TODO(ericsnow) Remove this restriction.
 	if len(results.Results) != 1 {
 		// TODO: Not directly tested
 		return nil, fmt.Errorf("expected 1 result, got %d", len(results.Results))
 	}
-	result := results.Results[0]
-	if err := result.Error; err != nil {
-		return nil, err
+	var list tools.List
+	for _, result := range results.Results {
+		if err := result.Error; err != nil {
+			return nil, err
+		}
+		list = append(list, result.Tools)
 	}
-	return result.Tools, nil
+	return list, nil
 }
 
 func (st *State) WatchAPIVersion(agentTag string) (watcher.NotifyWatcher, error) {

--- a/api/upgrader/upgrader.go
+++ b/api/upgrader/upgrader.go
@@ -82,19 +82,15 @@ func (st *State) Tools(tag string) (tools.List, error) {
 		// TODO: Not directly tested
 		return nil, err
 	}
-	// TODO(ericsnow) Remove this restriction.
 	if len(results.Results) != 1 {
 		// TODO: Not directly tested
 		return nil, fmt.Errorf("expected 1 result, got %d", len(results.Results))
 	}
-	var list tools.List
-	for _, result := range results.Results {
-		if err := result.Error; err != nil {
-			return nil, err
-		}
-		list = append(list, result.Tools)
+	result := results.Results[0]
+	if err := result.Error; err != nil {
+		return nil, err
 	}
-	return list, nil
+	return result.ToolsList, nil
 }
 
 func (st *State) WatchAPIVersion(agentTag string) (watcher.NotifyWatcher, error) {

--- a/api/upgrader/upgrader_test.go
+++ b/api/upgrader/upgrader_test.go
@@ -95,8 +95,10 @@ func (s *machineUpgraderSuite) TestTools(c *gc.C) {
 	s.rawMachine.SetAgentVersion(current)
 	// Upgrader.Tools returns the *desired* set of tools, not the currently
 	// running set. We want to be upgraded to cur.Version
-	stateTools, err := s.st.Tools(s.rawMachine.Tag().String())
+	stateToolsList, err := s.st.Tools(s.rawMachine.Tag().String())
 	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(stateToolsList, gc.HasLen, 1)
+	stateTools := stateToolsList[0]
 	c.Assert(stateTools.Version, gc.Equals, current)
 	url := fmt.Sprintf("https://%s/model/%s/tools/%s",
 		s.stateAPI.Addr(), coretesting.ModelTag.Id(), current)

--- a/apiserver/client/instanceconfig.go
+++ b/apiserver/client/instanceconfig.go
@@ -66,7 +66,7 @@ func InstanceConfig(st *state.State, machineId, nonce, dataDir string) (*instanc
 	if findToolsResult.Error != nil {
 		return nil, errors.Annotate(findToolsResult.Error, "finding tools")
 	}
-	tools := findToolsResult.List[0]
+	toolsList := findToolsResult.List
 
 	// Get the API connection info; attempt all API addresses.
 	apiHostPorts, err := st.APIHostPorts()
@@ -112,7 +112,7 @@ func InstanceConfig(st *state.State, machineId, nonce, dataDir string) (*instanc
 	if dataDir != "" {
 		icfg.DataDir = dataDir
 	}
-	icfg.Tools = tools
+	icfg.SetTools(toolsList)
 	err = instancecfg.FinishInstanceConfig(icfg, environConfig)
 	if err != nil {
 		return nil, errors.Annotate(err, "finishing instance config")

--- a/apiserver/client/instanceconfig.go
+++ b/apiserver/client/instanceconfig.go
@@ -112,7 +112,9 @@ func InstanceConfig(st *state.State, machineId, nonce, dataDir string) (*instanc
 	if dataDir != "" {
 		icfg.DataDir = dataDir
 	}
-	icfg.SetTools(toolsList)
+	if err := icfg.SetTools(toolsList); err != nil {
+		return nil, errors.Trace(err)
+	}
 	err = instancecfg.FinishInstanceConfig(icfg, environConfig)
 	if err != nil {
 		return nil, errors.Annotate(err, "finishing instance config")

--- a/apiserver/client/instanceconfig_test.go
+++ b/apiserver/client/instanceconfig_test.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/version"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/agent"
@@ -56,8 +57,11 @@ func (s *machineConfigSuite) TestMachineConfig(c *gc.C) {
 	c.Check(instanceConfig.MongoInfo.Addrs, gc.DeepEquals, mongoAddrs)
 	c.Check(instanceConfig.APIInfo.Addrs, gc.DeepEquals, apiAddrs)
 	toolsURL := fmt.Sprintf("https://%s/model/%s/tools/%s",
-		apiAddrs[0], jujutesting.ModelTag.Id(), instanceConfig.Tools.Version)
-	c.Assert(instanceConfig.Tools.URL, gc.Equals, toolsURL)
+		apiAddrs[0], jujutesting.ModelTag.Id(), instanceConfig.ToolsInfo().Version)
+	c.Assert(instanceConfig.ToolsList().URLs(), jc.DeepEquals, map[version.Binary][]string{
+		instanceConfig.ToolsInfo().Version: []string{toolsURL},
+	})
+	//c.Assert(instanceConfig.ToolsList()[0].URL, gc.Equals, toolsURL)
 	c.Assert(instanceConfig.AgentEnvironment[agent.AllowsSecureConnection], gc.Equals, "true")
 }
 

--- a/apiserver/common/addresses.go
+++ b/apiserver/common/addresses.go
@@ -60,9 +60,19 @@ func (api *APIAddresser) WatchAPIHostPorts() (params.NotifyWatchResult, error) {
 
 // APIAddresses returns the list of addresses used to connect to the API.
 func (api *APIAddresser) APIAddresses() (params.StringsResult, error) {
-	apiHostPorts, err := api.getter.APIHostPorts()
+	addrs, err := apiAddresses(api.getter)
 	if err != nil {
 		return params.StringsResult{}, err
+	}
+	return params.StringsResult{
+		Result: addrs,
+	}, nil
+}
+
+func apiAddresses(getter APIHostPortsGetter) ([]string, error) {
+	apiHostPorts, err := getter.APIHostPorts()
+	if err != nil {
+		return nil, err
 	}
 	var addrs = make([]string, 0, len(apiHostPorts))
 	for _, hostPorts := range apiHostPorts {
@@ -73,9 +83,7 @@ func (api *APIAddresser) APIAddresses() (params.StringsResult, error) {
 			}
 		}
 	}
-	return params.StringsResult{
-		Result: addrs,
-	}, nil
+	return addrs, nil
 }
 
 // CACert returns the certificate used to validate the state connection.

--- a/apiserver/common/tools.go
+++ b/apiserver/common/tools.go
@@ -5,7 +5,6 @@ package common
 
 import (
 	"fmt"
-	"math/rand"
 	"sort"
 
 	"github.com/juju/errors"
@@ -26,9 +25,9 @@ var envtoolsFindTools = envtools.FindTools
 
 // ToolsURLGetter is an interface providing the ToolsURL method.
 type ToolsURLGetter interface {
-	// ToolsURL returns a URL for the tools with
+	// ToolsURLs returns URLs for the tools with
 	// the specified binary version.
-	ToolsURL(v version.Binary) (string, error)
+	ToolsURLs(v version.Binary) ([]string, error)
 }
 
 type ModelConfigGetter interface {
@@ -230,14 +229,19 @@ func (f *ToolsFinder) findTools(args params.FindToolsParams) (coretools.List, er
 	// Rewrite the URLs so they point at the API server. If the
 	// tools are not in tools storage, then the API server will
 	// download and cache them if the client requests that version.
-	for _, tools := range list {
-		url, err := f.urlGetter.ToolsURL(tools.Version)
+	var fullList coretools.List
+	for _, baseTools := range list {
+		urls, err := f.urlGetter.ToolsURLs(baseTools.Version)
 		if err != nil {
 			return nil, err
 		}
-		tools.URL = url
+		for _, url := range urls {
+			tools := *baseTools
+			tools.URL = url
+			fullList = append(fullList, &tools)
+		}
 	}
-	return list, nil
+	return fullList, nil
 }
 
 // findMatchingTools searches tools storage and simplestreams for tools matching the
@@ -348,30 +352,21 @@ func NewToolsURLGetter(modelUUID string, a APIHostPortsGetter) *toolsURLGetter {
 	return &toolsURLGetter{modelUUID, a}
 }
 
-func (t *toolsURLGetter) ToolsURL(v version.Binary) (string, error) {
-	apiHostPorts, err := t.apiHostPortsGetter.APIHostPorts()
+func (t *toolsURLGetter) ToolsURLs(v version.Binary) ([]string, error) {
+	addrs, err := apiAddresses(t.apiHostPortsGetter)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-	if len(apiHostPorts) == 0 {
-		return "", errors.New("no API host ports")
+	if len(addrs) == 0 {
+		return nil, errors.Errorf("no suitable API server address to pick from %v")
 	}
-	// TODO(axw) return all known URLs, so clients can try each one.
-	//
-	// The clients currently accept a single URL; we should change
-	// the clients to disregard the URL, and have them download
-	// straight from the API server.
-	//
-	// For now we choose a API server at random, and then select its
-	// cloud-local address. The only user that will care about the URL
-	// is the upgrader, and that is cloud-local.
-	hostPorts := apiHostPorts[rand.Int()%len(apiHostPorts)]
-	apiAddress := network.SelectInternalHostPort(hostPorts, false)
-	if apiAddress == "" {
-		return "", errors.Errorf("no suitable API server address to pick from %v", hostPorts)
+	var urls []string
+	for _, addr := range addrs {
+		serverRoot := fmt.Sprintf("https://%s/model/%s", addr, t.modelUUID)
+		url := ToolsURL(serverRoot, v)
+		urls = append(urls, url)
 	}
-	serverRoot := fmt.Sprintf("https://%s/model/%s", apiAddress, t.modelUUID)
-	return ToolsURL(serverRoot, v), nil
+	return urls, nil
 }
 
 // ToolsURL returns a tools URL pointing the API server

--- a/apiserver/common/tools.go
+++ b/apiserver/common/tools.go
@@ -87,9 +87,9 @@ func (t *ToolsGetter) Tools(args params.Entities) (params.ToolsResults, error) {
 			result.Results[i].Error = ServerError(ErrPerm)
 			continue
 		}
-		agentTools, err := t.oneAgentTools(canRead, tag, agentVersion, toolsStorage)
+		agentToolsList, err := t.oneAgentTools(canRead, tag, agentVersion, toolsStorage)
 		if err == nil {
-			result.Results[i].Tools = agentTools
+			result.Results[i].ToolsList = agentToolsList
 			// TODO(axw) Get rid of this in 1.22, when all upgraders
 			// are known to ignore the flag.
 			result.Results[i].DisableSSLHostnameVerification = true
@@ -113,7 +113,7 @@ func (t *ToolsGetter) getGlobalAgentVersion() (version.Number, error) {
 	return agentVersion, nil
 }
 
-func (t *ToolsGetter) oneAgentTools(canRead AuthFunc, tag names.Tag, agentVersion version.Number, storage binarystorage.Storage) (*coretools.Tools, error) {
+func (t *ToolsGetter) oneAgentTools(canRead AuthFunc, tag names.Tag, agentVersion version.Number, storage binarystorage.Storage) (coretools.List, error) {
 	if !canRead(tag) {
 		return nil, ErrPerm
 	}
@@ -140,7 +140,7 @@ func (t *ToolsGetter) oneAgentTools(canRead AuthFunc, tag names.Tag, agentVersio
 	if err != nil {
 		return nil, err
 	}
-	return list[0], nil
+	return list, nil
 }
 
 // ToolsSetter implements a common Tools method for use by various

--- a/apiserver/common/tools.go
+++ b/apiserver/common/tools.go
@@ -358,7 +358,7 @@ func (t *toolsURLGetter) ToolsURLs(v version.Binary) ([]string, error) {
 		return nil, err
 	}
 	if len(addrs) == 0 {
-		return nil, errors.Errorf("no suitable API server address to pick from %v")
+		return nil, errors.Errorf("no suitable API server address to pick from")
 	}
 	var urls []string
 	for _, addr := range addrs {

--- a/apiserver/common/tools.go
+++ b/apiserver/common/tools.go
@@ -226,7 +226,7 @@ func (f *ToolsFinder) findTools(args params.FindToolsParams) (coretools.List, er
 	if err != nil {
 		return nil, err
 	}
-	// Rewrite the URLs so they point at the API server. If the
+	// Rewrite the URLs so they point at the API servers. If the
 	// tools are not in tools storage, then the API server will
 	// download and cache them if the client requests that version.
 	var fullList coretools.List

--- a/apiserver/common/tools_test.go
+++ b/apiserver/common/tools_test.go
@@ -288,7 +288,7 @@ func (s *toolsSuite) TestFindToolsToolsStorageError(c *gc.C) {
 func (s *toolsSuite) TestToolsURLGetterNoAPIHostPorts(c *gc.C) {
 	g := common.NewToolsURLGetter("my-uuid", mockAPIHostPortsGetter{})
 	_, err := g.ToolsURLs(current)
-	c.Assert(err, gc.ErrorMatches, "no suitable API server address to pick from .*")
+	c.Assert(err, gc.ErrorMatches, "no suitable API server address to pick from")
 }
 
 func (s *toolsSuite) TestToolsURLGetterAPIHostPortsError(c *gc.C) {

--- a/apiserver/common/tools_test.go
+++ b/apiserver/common/tools_test.go
@@ -69,9 +69,10 @@ func (s *toolsSuite) TestTools(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, 3)
 	c.Assert(result.Results[0].Error, gc.IsNil)
-	c.Assert(result.Results[0].Tools, gc.NotNil)
-	c.Assert(result.Results[0].Tools.Version, gc.DeepEquals, current)
-	c.Assert(result.Results[0].Tools.URL, gc.Equals, "tools:"+current.String())
+	c.Assert(result.Results[0].ToolsList, gc.HasLen, 1)
+	tools := result.Results[0].ToolsList[0]
+	c.Assert(tools.Version, gc.DeepEquals, current)
+	c.Assert(tools.URL, gc.Equals, "tools:"+current.String())
 	c.Assert(result.Results[0].DisableSSLHostnameVerification, jc.IsTrue)
 	c.Assert(result.Results[1].Error, gc.DeepEquals, apiservertesting.ErrUnauthorized)
 	c.Assert(result.Results[2].Error, gc.DeepEquals, apiservertesting.NotFoundError("machine 42"))

--- a/apiserver/common/tools_test.go
+++ b/apiserver/common/tools_test.go
@@ -183,14 +183,17 @@ func (s *toolsSuite) TestFindTools(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Error, gc.IsNil)
-	c.Assert(result.List, gc.DeepEquals, coretools.List{
+	c.Check(result.List, jc.DeepEquals, coretools.List{
 		&coretools.Tools{
 			Version: version.MustParseBinary(storageMetadata[0].Version),
 			Size:    storageMetadata[0].Size,
 			SHA256:  storageMetadata[0].SHA256,
 			URL:     "tools:" + storageMetadata[0].Version,
 		},
-		envtoolsList[1],
+		&coretools.Tools{
+			Version: version.MustParseBinary("123.456.1-win81-alpha"),
+			URL:     "tools:123.456.1-win81-alpha",
+		},
 	})
 }
 
@@ -283,13 +286,13 @@ func (s *toolsSuite) TestFindToolsToolsStorageError(c *gc.C) {
 
 func (s *toolsSuite) TestToolsURLGetterNoAPIHostPorts(c *gc.C) {
 	g := common.NewToolsURLGetter("my-uuid", mockAPIHostPortsGetter{})
-	_, err := g.ToolsURL(current)
-	c.Assert(err, gc.ErrorMatches, "no API host ports")
+	_, err := g.ToolsURLs(current)
+	c.Assert(err, gc.ErrorMatches, "no suitable API server address to pick from .*")
 }
 
 func (s *toolsSuite) TestToolsURLGetterAPIHostPortsError(c *gc.C) {
 	g := common.NewToolsURLGetter("my-uuid", mockAPIHostPortsGetter{err: errors.New("oh noes")})
-	_, err := g.ToolsURL(current)
+	_, err := g.ToolsURLs(current)
 	c.Assert(err, gc.ErrorMatches, "oh noes")
 }
 
@@ -299,15 +302,17 @@ func (s *toolsSuite) TestToolsURLGetter(c *gc.C) {
 			network.NewHostPorts(1234, "0.1.2.3"),
 		},
 	})
-	url, err := g.ToolsURL(current)
+	urls, err := g.ToolsURLs(current)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(url, gc.Equals, "https://0.1.2.3:1234/model/my-uuid/tools/"+current.String())
+	c.Check(urls, jc.DeepEquals, []string{
+		"https://0.1.2.3:1234/model/my-uuid/tools/" + current.String(),
+	})
 }
 
 type sprintfURLGetter string
 
-func (s sprintfURLGetter) ToolsURL(v version.Binary) (string, error) {
-	return fmt.Sprintf(string(s), v), nil
+func (s sprintfURLGetter) ToolsURLs(v version.Binary) ([]string, error) {
+	return []string{fmt.Sprintf(string(s), v)}, nil
 }
 
 type mockAPIHostPortsGetter struct {

--- a/apiserver/params/internal.go
+++ b/apiserver/params/internal.go
@@ -397,7 +397,7 @@ type VersionResults struct {
 // ToolsResult holds the tools and possibly error for a given
 // Tools() API call.
 type ToolsResult struct {
-	Tools                          *tools.Tools
+	ToolsList                      tools.List
 	DisableSSLHostnameVerification bool
 	Error                          *Error
 }

--- a/apiserver/tools.go
+++ b/apiserver/tools.go
@@ -74,7 +74,9 @@ func (h *toolsUploadHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			sendError(w, err)
 			return
 		}
-		sendStatusAndJSON(w, http.StatusOK, &params.ToolsResult{Tools: agentTools})
+		sendStatusAndJSON(w, http.StatusOK, &params.ToolsResult{
+			ToolsList: tools.List{agentTools},
+		})
 	default:
 		sendError(w, errors.MethodNotAllowedf("unsupported method: %q", r.Method))
 	}

--- a/apiserver/tools_test.go
+++ b/apiserver/tools_test.go
@@ -72,7 +72,7 @@ func (s *toolsCommonSuite) downloadRequest(c *gc.C, version version.Binary, uuid
 func (s *toolsCommonSuite) assertUploadResponse(c *gc.C, resp *http.Response, agentTools *coretools.Tools) {
 	toolsResponse := s.assertResponse(c, resp, http.StatusOK)
 	c.Check(toolsResponse.Error, gc.IsNil)
-	c.Check(toolsResponse.Tools, gc.DeepEquals, agentTools)
+	c.Check(toolsResponse.ToolsList, jc.DeepEquals, coretools.List{agentTools})
 }
 
 func (s *toolsCommonSuite) assertGetFileResponse(c *gc.C, resp *http.Response, expBody, expContentType string) {

--- a/apiserver/upgrader/unitupgrader.go
+++ b/apiserver/upgrader/unitupgrader.go
@@ -153,7 +153,9 @@ func (u *UnitUpgraderAPI) getMachineTools(tag names.Tag) params.ToolsResult {
 		result.Error = common.ServerError(err)
 		return result
 	}
-	// TODO(ericsnow) Return one for each API server address?
+	// We are okay returning the tools for just the one API server
+	// address since the unit agent won't try to download tools that
+	// are already present on the machine.
 	result.ToolsList = tools.List{machineTools}
 	return result
 }

--- a/apiserver/upgrader/unitupgrader.go
+++ b/apiserver/upgrader/unitupgrader.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/watcher"
+	"github.com/juju/juju/tools"
 )
 
 // UnitUpgraderAPI provides access to the UnitUpgrader API facade.
@@ -152,7 +153,8 @@ func (u *UnitUpgraderAPI) getMachineTools(tag names.Tag) params.ToolsResult {
 		result.Error = common.ServerError(err)
 		return result
 	}
-	result.Tools = machineTools
+	// TODO(ericsnow) Return one for each API server address?
+	result.ToolsList = tools.List{machineTools}
 	return result
 }
 

--- a/apiserver/upgrader/unitupgrader_test.go
+++ b/apiserver/upgrader/unitupgrader_test.go
@@ -171,7 +171,7 @@ func (s *unitUpgraderSuite) TestToolsForAgent(c *gc.C) {
 	assertTools := func() {
 		c.Check(results.Results, gc.HasLen, 1)
 		c.Assert(results.Results[0].Error, gc.IsNil)
-		agentTools := results.Results[0].Tools
+		agentTools := results.Results[0].ToolsList[0]
 		c.Check(agentTools.Version.Number, gc.DeepEquals, jujuversion.Current)
 		c.Assert(agentTools.URL, gc.NotNil)
 	}

--- a/apiserver/upgrader/upgrader_test.go
+++ b/apiserver/upgrader/upgrader_test.go
@@ -168,7 +168,7 @@ func (s *upgraderSuite) TestToolsForAgent(c *gc.C) {
 	assertTools := func() {
 		c.Check(results.Results, gc.HasLen, 1)
 		c.Assert(results.Results[0].Error, gc.IsNil)
-		agentTools := results.Results[0].Tools
+		agentTools := results.Results[0].ToolsList[0]
 		url := fmt.Sprintf("https://%s/model/%s/tools/%s",
 			s.APIState.Addr(), coretesting.ModelTag.Id(), current)
 		c.Check(agentTools.URL, gc.Equals, url)

--- a/cloudconfig/cloudinit/renderscript_test.go
+++ b/cloudconfig/cloudinit/renderscript_test.go
@@ -72,10 +72,12 @@ func (s *configureSuite) getCloudConfig(c *gc.C, controller bool, vers version.B
 		c.Assert(err, jc.ErrorIsNil)
 		icfg.Jobs = []multiwatcher.MachineJob{multiwatcher.JobHostUnits}
 	}
-	icfg.Tools = &tools.Tools{
-		Version: vers,
-		URL:     "http://testing.invalid/tools.tar.gz",
-	}
+	err = icfg.SetTools(tools.List{
+		&tools.Tools{
+			Version: vers,
+			URL:     "http://testing.invalid/tools.tar.gz",
+		},
+	})
 	environConfig := testConfig(c, controller, vers)
 	err = instancecfg.FinishInstanceConfig(icfg, environConfig)
 	c.Assert(err, jc.ErrorIsNil)

--- a/cloudconfig/instancecfg/instancecfg.go
+++ b/cloudconfig/instancecfg/instancecfg.go
@@ -306,6 +306,9 @@ func (cfg *InstanceConfig) HasNetworks() bool {
 // ToolsInfo returns a copy of the info (sans URL) for the configured
 // tools that will be used when provisioning the instance.
 func (cfg *InstanceConfig) ToolsInfo() *coretools.Tools {
+	if cfg.Tools == nil {
+		return nil
+	}
 	copied := *cfg.Tools
 	return &copied
 }

--- a/cloudconfig/instancecfg/instancecfg.go
+++ b/cloudconfig/instancecfg/instancecfg.go
@@ -7,7 +7,9 @@ package instancecfg
 import (
 	"fmt"
 	"net"
+	"net/url"
 	"path"
+	"reflect"
 	"strconv"
 
 	"github.com/juju/errors"
@@ -80,8 +82,13 @@ type InstanceConfig struct {
 	// ensure the agent is running on the correct instance.
 	MachineNonce string
 
-	// Tools is juju tools to be used on the new instance.
-	Tools *coretools.Tools
+	// tools is juju tools to be used on the new instance. The URL is
+	// ignored and instead those from ToolsURLs are used.
+	// URLs may be substituted.
+	tools *coretools.Tools
+
+	// toolsURLs holds all the URLs that will be used for the tools.
+	toolsURLs []*url.URL
 
 	// GUI is the Juju GUI archive to be installed in the new instance.
 	GUI *coretools.GUIArchive
@@ -260,7 +267,7 @@ func (cfg *InstanceConfig) AgentConfig(
 
 // JujuTools returns the directory where Juju tools are stored.
 func (cfg *InstanceConfig) JujuTools() string {
-	return agenttools.SharedToolsDir(cfg.DataDir, cfg.Tools.Version)
+	return agenttools.SharedToolsDir(cfg.DataDir, cfg.ToolsInfo().Version)
 }
 
 // GUITools returns the directory where the Juju GUI release is stored.
@@ -306,20 +313,74 @@ func (cfg *InstanceConfig) HasNetworks() bool {
 // ToolsInfo returns a copy of the info (sans URL) for the configured
 // tools that will be used when provisioning the instance.
 func (cfg *InstanceConfig) ToolsInfo() *coretools.Tools {
-	if cfg.Tools == nil {
+	if cfg.tools == nil {
 		return nil
 	}
-	copied := *cfg.Tools
+	copied := *cfg.tools
 	return &copied
 }
 
+// ToolsList returns the list of tools in the order in which they will
+// be tried.
+func (cfg *InstanceConfig) ToolsList() coretools.List {
+	if cfg.tools == nil {
+		return nil
+	}
+	var list coretools.List
+	for _, url := range cfg.toolsURLs {
+		copied := *cfg.tools
+		copied.URL = url.String()
+		list = append(list, &copied)
+	}
+	return list
+}
+
 // SetTools sets the tools that should be tried when provisioning this
-// instance. There must be at least one.
-//
-// Note: for now only the first tools is used. The rest are ignored.
-func (cfg *InstanceConfig) SetTools(toolsList coretools.List) {
-	// TODO(ericsnow) There may be more than one.
-	cfg.Tools = toolsList[0]
+// instance. There must be at least one. Other than the URL, each item
+// must be the same.
+func (cfg *InstanceConfig) SetTools(toolsList coretools.List) error {
+	if len(toolsList) == 0 {
+		return errors.New("need at least 1 tools")
+	}
+	var tools *coretools.Tools
+	var toolsURLs []*url.URL
+	for _, listed := range toolsList {
+		info, source, err := extractTools(listed)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		toolsURLs = append(toolsURLs, source)
+
+		if tools == nil {
+			tools = info
+			continue
+		}
+		if !reflect.DeepEqual(info, tools) {
+			return errors.Errorf("tools info mismatch")
+		}
+	}
+	cfg.tools = tools
+	cfg.toolsURLs = toolsURLs
+	return nil
+}
+
+func extractTools(tools *coretools.Tools) (*coretools.Tools, *url.URL, error) {
+	if tools == nil {
+		return nil, nil, errors.New("missing tools")
+	}
+	if tools.URL == "" {
+		return nil, nil, errors.Errorf("missing tools URL")
+	}
+
+	info := *tools
+	info.URL = ""
+
+	source, err := url.Parse(tools.URL)
+	if err != nil {
+		return nil, nil, errors.Trace(err)
+	}
+
+	return &info, source, nil
 }
 
 type requiresError string
@@ -348,12 +409,11 @@ func (cfg *InstanceConfig) VerifyConfig() (err error) {
 	if cfg.CloudInitOutputLog == "" {
 		return errors.New("missing cloud-init output log path")
 	}
-	if cfg.Tools == nil {
+	if cfg.tools == nil {
+		// SetTools() has never been called successfully.
 		return errors.New("missing tools")
 	}
-	if cfg.Tools.URL == "" {
-		return errors.New("missing tools URL")
-	}
+	// We don't need to check cfg.toolsURLs since SetTools() does.
 	if cfg.MongoInfo == nil {
 		return errors.New("missing state info")
 	}

--- a/cloudconfig/instancecfg/instancecfg.go
+++ b/cloudconfig/instancecfg/instancecfg.go
@@ -303,6 +303,15 @@ func (cfg *InstanceConfig) HasNetworks() bool {
 	return len(cfg.Networks) > 0 || cfg.Constraints.HaveNetworks()
 }
 
+// SetTools sets the tools that should be tried when provisioning this
+// instance. There must be at least one.
+//
+// Note: for now only the first tools is used. The rest are ignored.
+func (cfg *InstanceConfig) SetTools(toolsList coretools.List) {
+	// TODO(ericsnow) There may be more than one.
+	cfg.Tools = toolsList[0]
+}
+
 type requiresError string
 
 func (e requiresError) Error() string {

--- a/cloudconfig/instancecfg/instancecfg.go
+++ b/cloudconfig/instancecfg/instancecfg.go
@@ -304,9 +304,9 @@ func (cfg *InstanceConfig) HasNetworks() bool {
 }
 
 // ToolsVersion returns the version of the configured tools, if any.
-func (cfg *InstanceConfig) ToolsVersion() string {
+func (cfg *InstanceConfig) ToolsVersion() version.Binary {
 	if cfg.Tools == nil {
-		return ""
+		return version.Binary{}
 	}
 	return cfg.Tools.Version
 }

--- a/cloudconfig/instancecfg/instancecfg.go
+++ b/cloudconfig/instancecfg/instancecfg.go
@@ -303,12 +303,11 @@ func (cfg *InstanceConfig) HasNetworks() bool {
 	return len(cfg.Networks) > 0 || cfg.Constraints.HaveNetworks()
 }
 
-// ToolsVersion returns the version of the configured tools, if any.
-func (cfg *InstanceConfig) ToolsVersion() version.Binary {
-	if cfg.Tools == nil {
-		return version.Binary{}
-	}
-	return cfg.Tools.Version
+// ToolsInfo returns a copy of the info (sans URL) for the configured
+// tools that will be used when provisioning the instance.
+func (cfg *InstanceConfig) ToolsInfo() *coretools.Tools {
+	copied := *cfg.Tools
+	return &copied
 }
 
 // SetTools sets the tools that should be tried when provisioning this

--- a/cloudconfig/instancecfg/instancecfg.go
+++ b/cloudconfig/instancecfg/instancecfg.go
@@ -303,6 +303,14 @@ func (cfg *InstanceConfig) HasNetworks() bool {
 	return len(cfg.Networks) > 0 || cfg.Constraints.HaveNetworks()
 }
 
+// ToolsVersion returns the version of the configured tools, if any.
+func (cfg *InstanceConfig) ToolsVersion() string {
+	if cfg.Tools == nil {
+		return ""
+	}
+	return cfg.Tools.Version
+}
+
 // SetTools sets the tools that should be tried when provisioning this
 // instance. There must be at least one.
 //

--- a/cloudconfig/instancecfg/instancecfg_test.go
+++ b/cloudconfig/instancecfg/instancecfg_test.go
@@ -56,10 +56,15 @@ func testInstanceTags(c *gc.C, cfg *config.Config, jobs []multiwatcher.MachineJo
 func (*instancecfgSuite) TestJujuTools(c *gc.C) {
 	icfg := &instancecfg.InstanceConfig{
 		DataDir: "/path/to/datadir/",
-		Tools: &coretools.Tools{
-			Version: version.MustParseBinary("2.3.4-trusty-amd64"),
-		},
 	}
+	err := icfg.SetTools(coretools.List{
+		&coretools.Tools{
+			Version: version.MustParseBinary("2.3.4-trusty-amd64"),
+			URL:     "/tools/2.3.4-trusty-amd64",
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
 	c.Assert(icfg.JujuTools(), gc.Equals, "/path/to/datadir/tools/2.3.4-trusty-amd64")
 }
 

--- a/cloudconfig/userdatacfg.go
+++ b/cloudconfig/userdatacfg.go
@@ -83,7 +83,7 @@ type baseConfigure struct {
 // addAgentInfo adds agent-required information to the agent's directory
 // and returns the agent directory name.
 func (c *baseConfigure) addAgentInfo(tag names.Tag) (agent.Config, error) {
-	acfg, err := c.icfg.AgentConfig(tag, c.icfg.Tools.Version.Number)
+	acfg, err := c.icfg.AgentConfig(tag, c.icfg.ToolsInfo().Version.Number)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -171,14 +171,14 @@ func (c *baseConfigure) toolsSymlinkCommand(toolsDir string) string {
 		return fmt.Sprintf(
 			`cmd.exe /C mklink /D %s %v`,
 			c.conf.ShellRenderer().FromSlash(toolsDir),
-			c.icfg.Tools.Version,
+			c.icfg.ToolsInfo().Version,
 		)
 	default:
 		// TODO(dfc) ln -nfs, so it doesn't fail if for some reason that
 		// the target already exists.
 		return fmt.Sprintf(
 			"ln -s %v %s",
-			c.icfg.Tools.Version,
+			c.icfg.ToolsInfo().Version,
 			shquote(toolsDir),
 		)
 	}

--- a/cloudconfig/userdatacfg_unix.go
+++ b/cloudconfig/userdatacfg_unix.go
@@ -224,61 +224,16 @@ func (w *unixConfigure) ConfigureJuju() error {
 		w.setDataDirPermissions(),
 	)
 
+	// Make a directory for the tools to live in.
 	w.conf.AddScripts(
 		"bin="+shquote(w.icfg.JujuTools()),
 		"mkdir -p $bin",
 	)
 
-	// Make a directory for the tools to live in, then fetch the
-	// tools and unarchive them into it.
-	if strings.HasPrefix(w.icfg.Tools.URL, fileSchemePrefix) {
-		toolsData, err := ioutil.ReadFile(w.icfg.Tools.URL[len(fileSchemePrefix):])
-		if err != nil {
-			return err
-		}
-		w.conf.AddRunBinaryFile(path.Join(w.icfg.JujuTools(), "tools.tar.gz"), []byte(toolsData), 0644)
-	} else {
-		curlCommand := curlCommand
-		var urls []string
-		if w.icfg.Bootstrap {
-			curlCommand += " --retry 10"
-			if w.icfg.DisableSSLHostnameVerification {
-				curlCommand += " --insecure"
-			}
-			urls = append(urls, w.icfg.Tools.URL)
-		} else {
-			for _, addr := range w.icfg.ApiHostAddrs() {
-				// TODO(axw) encode env UUID in URL when ModelTag
-				// is guaranteed to be available in APIInfo.
-				url := fmt.Sprintf("https://%s/tools/%s", addr, w.icfg.ToolsInfo().Version)
-				urls = append(urls, url)
-			}
-
-			// Don't go through the proxy when downloading tools from the controllers
-			curlCommand += ` --noproxy "*"`
-
-			// Our API server certificates are unusable by curl (invalid subject name),
-			// so we must disable certificate validation. It doesn't actually
-			// matter, because there is no sensitive information being transmitted
-			// and we verify the tools' hash after.
-			curlCommand += " --insecure"
-		}
-		curlCommand += " -o $bin/tools.tar.gz"
-		w.conf.AddRunCmd(cloudinit.LogProgressCmd("Fetching tools: %s <%s>", curlCommand, urls))
-		w.conf.AddRunCmd(toolsDownloadCommand(curlCommand, urls))
+	// Fetch the tools and unarchive them into it.
+	if err := w.addDownloadToolsCmds(); err != nil {
+		return errors.Trace(err)
 	}
-	toolsJson, err := json.Marshal(w.icfg.Tools)
-	if err != nil {
-		return err
-	}
-
-	w.conf.AddScripts(
-		fmt.Sprintf("sha256sum $bin/tools.tar.gz > $bin/juju%s.sha256", w.icfg.ToolsInfo().Version),
-		fmt.Sprintf(`grep '%s' $bin/juju%s.sha256 || (echo "Tools checksum mismatch"; exit 1)`,
-			w.icfg.ToolsInfo().SHA256, w.icfg.ToolsInfo().Version),
-		fmt.Sprintf("tar zxf $bin/tools.tar.gz -C $bin"),
-		fmt.Sprintf("printf %%s %s > $bin/downloaded-tools.txt", shquote(string(toolsJson))),
-	)
 
 	// Don't remove tools tarball until after bootstrap agent
 	// runs, so it has a chance to add it to its catalogue.
@@ -293,7 +248,7 @@ func (w *unixConfigure) ConfigureJuju() error {
 	// be responsible for starting the machine agent itself,
 	// but this would not be backwardly compatible.
 	machineTag := names.NewMachineTag(w.icfg.MachineId)
-	_, err = w.addAgentInfo(machineTag)
+	_, err := w.addAgentInfo(machineTag)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -371,6 +326,68 @@ func (w *unixConfigure) ConfigureJuju() error {
 	}
 
 	return w.addMachineAgentToBoot()
+}
+
+func (w unixConfigure) addDownloadToolsCmds() error {
+	// TODO(ericsnow) Respect the full list.
+	// For now we are okay because each of the handled cases matches
+	// current Juju behavior. However, there are no guarantees that
+	// will hold.
+	tools := w.icfg.ToolsList()[0]
+
+	if strings.HasPrefix(tools.URL, fileSchemePrefix) {
+		toolsData, err := ioutil.ReadFile(tools.URL[len(fileSchemePrefix):])
+		if err != nil {
+			return err
+		}
+		w.conf.AddRunBinaryFile(path.Join(w.icfg.JujuTools(), "tools.tar.gz"), []byte(toolsData), 0644)
+	} else {
+		curlCommand := curlCommand
+		var urls []string
+		if w.icfg.Bootstrap {
+			curlCommand += " --retry 10"
+			if w.icfg.DisableSSLHostnameVerification {
+				curlCommand += " --insecure"
+			}
+			urls = append(urls, tools.URL)
+		} else {
+			for _, addr := range w.icfg.ApiHostAddrs() {
+				// TODO(axw) encode env UUID in URL when ModelTag
+				// is guaranteed to be available in APIInfo.
+				url := fmt.Sprintf("https://%s/tools/%s", addr, w.icfg.ToolsInfo().Version)
+				urls = append(urls, url)
+			}
+
+			// Don't go through the proxy when downloading tools from the controllers
+			curlCommand += ` --noproxy "*"`
+
+			// Our API server certificates are unusable by curl (invalid subject name),
+			// so we must disable certificate validation. It doesn't actually
+			// matter, because there is no sensitive information being transmitted
+			// and we verify the tools' hash after.
+			curlCommand += " --insecure"
+		}
+		curlCommand += " -o $bin/tools.tar.gz"
+		w.conf.AddRunCmd(cloudinit.LogProgressCmd("Fetching tools: %s <%s>", curlCommand, urls))
+		w.conf.AddRunCmd(toolsDownloadCommand(curlCommand, urls))
+	}
+
+	w.conf.AddScripts(
+		fmt.Sprintf("sha256sum $bin/tools.tar.gz > $bin/juju%s.sha256", w.icfg.ToolsInfo().Version),
+		fmt.Sprintf(`grep '%s' $bin/juju%s.sha256 || (echo "Tools checksum mismatch"; exit 1)`,
+			w.icfg.ToolsInfo().SHA256, w.icfg.ToolsInfo().Version),
+		fmt.Sprintf("tar zxf $bin/tools.tar.gz -C $bin"),
+	)
+
+	toolsJson, err := json.Marshal(tools)
+	if err != nil {
+		return err
+	}
+	w.conf.AddScripts(
+		fmt.Sprintf("printf %%s %s > $bin/downloaded-tools.txt", shquote(string(toolsJson))),
+	)
+
+	return nil
 }
 
 // setUpGUI fetches the Juju GUI archive and save it to the controller.

--- a/cloudconfig/userdatacfg_unix.go
+++ b/cloudconfig/userdatacfg_unix.go
@@ -329,7 +329,7 @@ func (w *unixConfigure) ConfigureJuju() error {
 }
 
 func (w unixConfigure) addDownloadToolsCmds() error {
-	// TODO(ericsnow) Respect the full list.
+	// TODO(ericsnow) Respect the full list. (see lp:1571832)
 	// For now we are okay because each of the handled cases matches
 	// current Juju behavior. However, there are no guarantees that
 	// will hold.

--- a/cloudconfig/userdatacfg_unix.go
+++ b/cloudconfig/userdatacfg_unix.go
@@ -102,7 +102,7 @@ func (w *unixConfigure) ConfigureBasic() error {
 	)
 	switch w.os {
 	case os.Ubuntu:
-		if w.icfg.Tools != nil {
+		if w.icfg.ToolsInfo() != nil {
 			initSystem, err := service.VersionInitSystem(w.icfg.Series)
 			if err != nil {
 				return errors.Trace(err)
@@ -250,7 +250,7 @@ func (w *unixConfigure) ConfigureJuju() error {
 			for _, addr := range w.icfg.ApiHostAddrs() {
 				// TODO(axw) encode env UUID in URL when ModelTag
 				// is guaranteed to be available in APIInfo.
-				url := fmt.Sprintf("https://%s/tools/%s", addr, w.icfg.Tools.Version)
+				url := fmt.Sprintf("https://%s/tools/%s", addr, w.icfg.ToolsInfo().Version)
 				urls = append(urls, url)
 			}
 
@@ -273,9 +273,9 @@ func (w *unixConfigure) ConfigureJuju() error {
 	}
 
 	w.conf.AddScripts(
-		fmt.Sprintf("sha256sum $bin/tools.tar.gz > $bin/juju%s.sha256", w.icfg.Tools.Version),
+		fmt.Sprintf("sha256sum $bin/tools.tar.gz > $bin/juju%s.sha256", w.icfg.ToolsInfo().Version),
 		fmt.Sprintf(`grep '%s' $bin/juju%s.sha256 || (echo "Tools checksum mismatch"; exit 1)`,
-			w.icfg.Tools.SHA256, w.icfg.Tools.Version),
+			w.icfg.ToolsInfo().SHA256, w.icfg.ToolsInfo().Version),
 		fmt.Sprintf("tar zxf $bin/tools.tar.gz -C $bin"),
 		fmt.Sprintf("printf %%s %s > $bin/downloaded-tools.txt", shquote(string(toolsJson))),
 	)
@@ -283,7 +283,7 @@ func (w *unixConfigure) ConfigureJuju() error {
 	// Don't remove tools tarball until after bootstrap agent
 	// runs, so it has a chance to add it to its catalogue.
 	defer w.conf.AddRunCmd(
-		fmt.Sprintf("rm $bin/tools.tar.gz && rm $bin/juju%s.sha256", w.icfg.Tools.Version),
+		fmt.Sprintf("rm $bin/tools.tar.gz && rm $bin/juju%s.sha256", w.icfg.ToolsInfo().Version),
 	)
 
 	// We add the machine agent's configuration info

--- a/cloudconfig/userdatacfg_win.go
+++ b/cloudconfig/userdatacfg_win.go
@@ -114,9 +114,9 @@ func (w *windowsConfigure) ConfigureJuju() error {
 	w.conf.AddScripts(
 		`$dToolsHash = Get-FileSHA256 -FilePath "$binDir\tools.tar.gz"`,
 		fmt.Sprintf(`$dToolsHash > "$binDir\juju%s.sha256"`,
-			w.icfg.Tools.Version),
+			w.icfg.ToolsInfo().Version),
 		fmt.Sprintf(`if ($dToolsHash.ToLower() -ne "%s"){ Throw "Tools checksum mismatch"}`,
-			w.icfg.Tools.SHA256),
+			w.icfg.ToolsInfo().SHA256),
 		fmt.Sprintf(`GUnZip-File -infile $binDir\tools.tar.gz -outdir $binDir`),
 		`rm "$binDir\tools.tar*"`,
 		fmt.Sprintf(`Set-Content $binDir\downloaded-tools.txt '%s'`, string(toolsJson)),

--- a/cloudconfig/userdatacfg_win.go
+++ b/cloudconfig/userdatacfg_win.go
@@ -93,7 +93,13 @@ func (w *windowsConfigure) ConfigureJuju() error {
 		return errors.Errorf("bootstrapping is not supported on windows")
 	}
 
-	toolsJson, err := json.Marshal(w.icfg.Tools)
+	// TODO(ericsnow) Respect the full list.
+	// For now we are okay because each of the handled cases matches
+	// current Juju behavior. However, there are no guarantees that
+	// will hold.
+	tools := w.icfg.ToolsList()[0]
+
+	toolsJson, err := json.Marshal(tools)
 	if err != nil {
 		return errors.Annotate(err, "while serializing the tools")
 	}
@@ -105,7 +111,7 @@ func (w *windowsConfigure) ConfigureJuju() error {
 		`mkdir $binDir`,
 	)
 
-	toolsDownloadCmds, err := addDownloadToolsCmds(w.icfg.Series, w.icfg.MongoInfo.CACert, w.icfg.Tools.URL)
+	toolsDownloadCmds, err := addDownloadToolsCmds(w.icfg.Series, w.icfg.MongoInfo.CACert, tools.URL)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/cloudconfig/userdatacfg_win.go
+++ b/cloudconfig/userdatacfg_win.go
@@ -93,7 +93,7 @@ func (w *windowsConfigure) ConfigureJuju() error {
 		return errors.Errorf("bootstrapping is not supported on windows")
 	}
 
-	// TODO(ericsnow) Respect the full list.
+	// TODO(ericsnow) Respect the full list. (see lp:1571832)
 	// For now we are okay because each of the handled cases matches
 	// current Juju behavior. However, there are no guarantees that
 	// will hold.

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -359,9 +359,9 @@ func (s *BootstrapSuite) run(c *gc.C, test bootstrapTest) testing.Restorer {
 
 	opFinalizeBootstrap := (<-opc).(dummy.OpFinalizeBootstrap)
 	c.Check(opFinalizeBootstrap.Env, gc.Equals, "admin")
-	c.Check(opFinalizeBootstrap.InstanceConfig.Tools, gc.NotNil)
+	c.Check(opFinalizeBootstrap.InstanceConfig.ToolsInfo(), gc.NotNil)
 	if test.upload != "" {
-		c.Check(opFinalizeBootstrap.InstanceConfig.Tools.Version.String(), gc.Equals, test.upload)
+		c.Check(opFinalizeBootstrap.InstanceConfig.ToolsInfo().Version.String(), gc.Equals, test.upload)
 	}
 
 	expectedBootstrappedControllerName := bootstrappedControllerName(controllerName)
@@ -913,7 +913,7 @@ func (s *BootstrapSuite) TestAutoUploadAfterFailedSync(c *gc.C) {
 	c.Check((<-opc).(dummy.OpBootstrap).Env, gc.Equals, "admin")
 	icfg := (<-opc).(dummy.OpFinalizeBootstrap).InstanceConfig
 	c.Assert(icfg, gc.NotNil)
-	c.Assert(icfg.Tools.Version.String(), gc.Equals, "1.7.3.1-raring-"+arch.HostArch())
+	c.Assert(icfg.ToolsInfo().Version.String(), gc.Equals, "1.7.3.1-raring-"+arch.HostArch())
 }
 
 func (s *BootstrapSuite) TestAutoUploadOnlyForDev(c *gc.C) {

--- a/cmd/juju/commands/synctools.go
+++ b/cmd/juju/commands/synctools.go
@@ -97,7 +97,7 @@ func (c *syncToolsCommand) Init(args []string) error {
 // api.Client API. This exists to enable mocking.
 type syncToolsAPI interface {
 	FindTools(majorVersion, minorVersion int, series, arch string) (params.FindToolsResult, error)
-	UploadTools(r io.ReadSeeker, v version.Binary, series ...string) (*coretools.Tools, error)
+	UploadTools(r io.ReadSeeker, v version.Binary, series ...string) (coretools.List, error)
 	Close() error
 }
 

--- a/cmd/juju/commands/synctools_test.go
+++ b/cmd/juju/commands/synctools_test.go
@@ -268,7 +268,7 @@ func (s *syncToolsSuite) TestAPIAdapterUploadTools(c *gc.C) {
 		Series: series.HostSeries(),
 	}
 	fake := fakeSyncToolsAPI{
-		uploadTools: func(r io.Reader, v version.Binary, additionalSeries ...string) (*coretools.Tools, error) {
+		uploadTools: func(r io.Reader, v version.Binary, additionalSeries ...string) (coretools.List, error) {
 			data, err := ioutil.ReadAll(r)
 			c.Assert(err, jc.ErrorIsNil)
 			c.Assert(string(data), gc.Equals, "abc")
@@ -295,14 +295,14 @@ func (s *syncToolsSuite) TestAPIAdapterBlockUploadTools(c *gc.C) {
 
 type fakeSyncToolsAPI struct {
 	findTools   func(majorVersion, minorVersion int, series, arch string) (params.FindToolsResult, error)
-	uploadTools func(r io.Reader, v version.Binary, additionalSeries ...string) (*coretools.Tools, error)
+	uploadTools func(r io.Reader, v version.Binary, additionalSeries ...string) (coretools.List, error)
 }
 
 func (f *fakeSyncToolsAPI) FindTools(majorVersion, minorVersion int, series, arch string) (params.FindToolsResult, error) {
 	return f.findTools(majorVersion, minorVersion, series, arch)
 }
 
-func (f *fakeSyncToolsAPI) UploadTools(r io.ReadSeeker, v version.Binary, additionalSeries ...string) (*coretools.Tools, error) {
+func (f *fakeSyncToolsAPI) UploadTools(r io.ReadSeeker, v version.Binary, additionalSeries ...string) (coretools.List, error) {
 	return f.uploadTools(r, v, additionalSeries...)
 }
 

--- a/cmd/juju/commands/upgradejuju_test.go
+++ b/cmd/juju/commands/upgradejuju_test.go
@@ -756,15 +756,6 @@ func (s *UpgradeJujuSuite) TestUpgradeInProgress(c *gc.C) {
 	)
 }
 
-func (s *UpgradeJujuSuite) TestDisallowUploadToolsForNonAdminModels(c *gc.C) {
-	cmd := &upgradeJujuCommand{}
-	err := coretesting.InitCommand(modelcmd.Wrap(cmd), []string{"--upload-tools", "-m", "default"})
-	c.Assert(err, jc.ErrorIsNil)
-
-	err = modelcmd.Wrap(cmd).Run(coretesting.Context(c))
-	c.Check(err, gc.ErrorMatches, "--upload-tools can only be used with the admin model")
-}
-
 func (s *UpgradeJujuSuite) TestBlockUpgradeInProgress(c *gc.C) {
 	fakeAPI := NewFakeUpgradeJujuAPI(c, s.State)
 	fakeAPI.setVersionErr = common.OperationBlockedError("the operation has been blocked")
@@ -902,9 +893,7 @@ func (a *fakeUpgradeJujuAPI) FindTools(majorVersion, minorVersion int, series, a
 	}, nil
 }
 
-func (a *fakeUpgradeJujuAPI) UploadTools(r io.ReadSeeker, vers version.Binary, additionalSeries ...string) (
-	*coretools.Tools, error,
-) {
+func (a *fakeUpgradeJujuAPI) UploadTools(r io.ReadSeeker, vers version.Binary, additionalSeries ...string) (coretools.List, error) {
 	panic("not implemented")
 }
 

--- a/container/kvm/live_test.go
+++ b/container/kvm/live_test.go
@@ -92,10 +92,13 @@ func createContainer(c *gc.C, manager container.Manager, machineId string) insta
 	c.Assert(err, jc.ErrorIsNil)
 	network := container.BridgeNetworkConfig("virbr0", 0, nil)
 
-	instanceConfig.Tools = &tools.Tools{
-		Version: version.MustParseBinary("2.3.4-foo-bar"),
-		URL:     "http://tools.testing.invalid/2.3.4-foo-bar.tgz",
-	}
+	err = instanceConfig.SetTools(tools.List{
+		&tools.Tools{
+			Version: version.MustParseBinary("2.3.4-foo-bar"),
+			URL:     "http://tools.testing.invalid/2.3.4-foo-bar.tgz",
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
 	environConfig := dummyConfig(c)
 	err = instancecfg.FinishInstanceConfig(instanceConfig, environConfig)
 	c.Assert(err, jc.ErrorIsNil)

--- a/container/testing/common.go
+++ b/container/testing/common.go
@@ -37,9 +37,14 @@ func MockMachineConfig(machineId string) (*instancecfg.InstanceConfig, error) {
 	if err != nil {
 		return nil, err
 	}
-	instanceConfig.Tools = &tools.Tools{
-		Version: version.MustParseBinary("2.3.4-quantal-amd64"),
-		URL:     "http://tools.testing.invalid/2.3.4-quantal-amd64.tgz",
+	err = instanceConfig.SetTools(tools.List{
+		&tools.Tools{
+			Version: version.MustParseBinary("2.3.4-quantal-amd64"),
+			URL:     "http://tools.testing.invalid/2.3.4-quantal-amd64.tgz",
+		},
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	return instanceConfig, nil

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -248,7 +248,7 @@ func Bootstrap(ctx environs.BootstrapContext, environ environs.Environ, args Boo
 	if err != nil {
 		return err
 	}
-	instanceConfig.Tools = selectedTools
+	instanceConfig.SetTools(selectedToolsList)
 	instanceConfig.CustomImageMetadata = customImageMetadata
 	instanceConfig.HostedModelConfig = args.HostedModelConfig
 

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -221,7 +221,7 @@ func Bootstrap(ctx environs.BootstrapContext, environ environs.Environ, args Boo
 	// The only time the URL will be blank is if there is only one
 	// in the list. So we can check the first one.
 	if selectedToolsList[0].URL == "" {
-		selectedTools = selectedToolsList[0]
+		selectedTools := selectedToolsList[0]
 		if !args.UploadTools {
 			logger.Warningf("no prepackaged tools available")
 		}

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -248,7 +248,9 @@ func Bootstrap(ctx environs.BootstrapContext, environ environs.Environ, args Boo
 	if err != nil {
 		return err
 	}
-	instanceConfig.SetTools(selectedToolsList)
+	if err := instanceConfig.SetTools(selectedToolsList); err != nil {
+		return errors.Trace(err)
+	}
 	instanceConfig.CustomImageMetadata = customImageMetadata
 	instanceConfig.HostedModelConfig = args.HostedModelConfig
 

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -214,11 +214,14 @@ func Bootstrap(ctx environs.BootstrapContext, environ environs.Environ, args Boo
 	if err != nil {
 		return err
 	}
-	selectedTools, err := setBootstrapTools(environ, matchingTools)
+	selectedToolsList, err := setBootstrapTools(environ, matchingTools)
 	if err != nil {
 		return err
 	}
-	if selectedTools.URL == "" {
+	// The only time the URL will be blank is if there is only one
+	// in the list. So we can check the first one.
+	if selectedToolsList[0].URL == "" {
+		selectedTools = selectedToolsList[0]
 		if !args.UploadTools {
 			logger.Warningf("no prepackaged tools available")
 		}
@@ -376,7 +379,7 @@ func bootstrapImageMetadata(
 
 // setBootstrapTools returns the newest tools from the given tools list,
 // and updates the agent-version configuration attribute.
-func setBootstrapTools(environ environs.Environ, possibleTools coretools.List) (*coretools.Tools, error) {
+func setBootstrapTools(environ environs.Environ, possibleTools coretools.List) (coretools.List, error) {
 	if len(possibleTools) == 0 {
 		return nil, fmt.Errorf("no bootstrap tools available")
 	}
@@ -411,7 +414,7 @@ func setBootstrapTools(environ environs.Environ, possibleTools coretools.List) (
 		}
 	}
 	logger.Infof("picked bootstrap tools version: %s", bootstrapVersion)
-	return toolsList[0], nil
+	return toolsList, nil
 }
 
 // findCompatibleTools finds tools in the list that have the same major, minor

--- a/environs/bootstrap/bootstrap_test.go
+++ b/environs/bootstrap/bootstrap_test.go
@@ -326,7 +326,9 @@ func (s *bootstrapSuite) TestSetBootstrapTools(c *gc.C) {
 		s.PatchValue(&jujuversion.Current, t.currentVersion)
 		bootstrapTools, err := bootstrap.SetBootstrapTools(env, availableTools)
 		c.Assert(err, jc.ErrorIsNil)
-		c.Assert(bootstrapTools.Version.Number, gc.Equals, t.expectedTools)
+		for _, tools := range bootstrapTools {
+			c.Assert(tools.Version.Number, gc.Equals, t.expectedTools)
+		}
 		agentVersion, _ := env.Config().AgentVersion()
 		c.Assert(agentVersion, gc.Equals, t.expectedAgentVersion)
 	}

--- a/environs/tools/tools_test.go
+++ b/environs/tools/tools_test.go
@@ -177,13 +177,14 @@ func (s *SimpleStreamsToolsSuite) TestFindTools(c *gc.C) {
 			c.Check(err, jc.Satisfies, errors.IsNotFound)
 			continue
 		}
-		expect := map[version.Binary]string{}
+		expect := map[version.Binary][]string{}
 		for _, expected := range test.expect {
 			// If the tools exist in custom, that's preferred.
-			var ok bool
-			if expect[expected], ok = custom[expected]; !ok {
-				expect[expected] = public[expected]
+			url, ok := custom[expected]
+			if !ok {
+				url = public[expected]
 			}
+			expect[expected] = append(expect[expected], url)
 		}
 		c.Check(actual.URLs(), gc.DeepEquals, expect)
 	}

--- a/featuretests/api_model_test.go
+++ b/featuretests/api_model_test.go
@@ -128,9 +128,10 @@ func (s *apiEnvironmentSuite) TestUploadToolsOtherEnvironment(c *gc.C) {
 	tgz, checksum := coretesting.TarGz(
 		coretesting.NewTarFile(jujunames.Jujud, 0777, "jujud contents "+vers))
 
-	tool, err := otherClient.UploadTools(bytes.NewReader(tgz), newVersion)
+	toolsList, err := otherClient.UploadTools(bytes.NewReader(tgz), newVersion)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(tool.SHA256, gc.Equals, checksum)
+	c.Assert(toolsList, gc.HasLen, 1)
+	c.Assert(toolsList[0].SHA256, gc.Equals, checksum)
 
 	toolStrg, err := otherState.ToolsStorage()
 	defer toolStrg.Close()

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -134,7 +134,7 @@ type CharmUploader interface {
 // ToolsUploader defines a simple single method interface that is used to
 // upload tools to the target controller
 type ToolsUploader interface {
-	UploadTools(io.ReadSeeker, version.Binary, ...string) (*tools.Tools, error)
+	UploadTools(io.ReadSeeker, version.Binary, ...string) (tools.List, error)
 }
 
 // UploadBinariesConfig provides all the configuration that the UploadBinaries

--- a/migration/migration_test.go
+++ b/migration/migration_test.go
@@ -246,7 +246,7 @@ type fakeUploader struct {
 	charms map[string]string
 }
 
-func (f *fakeUploader) UploadTools(r io.ReadSeeker, v version.Binary, _ ...string) (*tools.Tools, error) {
+func (f *fakeUploader) UploadTools(r io.ReadSeeker, v version.Binary, _ ...string) (tools.List, error) {
 	data, err := ioutil.ReadAll(r)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -254,9 +254,10 @@ func (f *fakeUploader) UploadTools(r io.ReadSeeker, v version.Binary, _ ...strin
 
 	f.tools[v] = string(data)
 
-	return &tools.Tools{
+	uploaded := &tools.Tools{
 		Version: v,
-	}, nil
+	}
+	return tools.List{uploaded}, nil
 }
 
 func (f *fakeUploader) UploadCharm(u *charm.URL, r io.ReadSeeker) (*charm.URL, error) {

--- a/migration/migration_test.go
+++ b/migration/migration_test.go
@@ -276,7 +276,7 @@ func (*noOpUploader) UploadCharm(*charm.URL, io.ReadSeeker) (*charm.URL, error) 
 	return nil, nil
 }
 
-func (*noOpUploader) UploadTools(io.ReadSeeker, version.Binary, ...string) (*tools.Tools, error) {
+func (*noOpUploader) UploadTools(io.ReadSeeker, version.Binary, ...string) (tools.List, error) {
 	return nil, nil
 }
 

--- a/provider/azure/environ.go
+++ b/provider/azure/environ.go
@@ -407,7 +407,7 @@ func (env *azureEnviron) StartInstance(args environs.StartInstanceParams) (*envi
 	// Pick envtools.  Needed for the custom data (which is what we normally
 	// call userdata).
 	args.InstanceConfig.SetTools(args.Tools)
-	logger.Infof("picked tools %q", args.InstanceConfig.ToolsVersion())
+	logger.Infof("picked tools %q", args.InstanceConfig.ToolsInfo().Version)
 
 	// Get the required configuration and config-dependent information
 	// required to create the instance. We take the lock just once, to

--- a/provider/azure/environ.go
+++ b/provider/azure/environ.go
@@ -406,7 +406,7 @@ func (env *azureEnviron) StartInstance(args environs.StartInstanceParams) (*envi
 
 	// Pick envtools.  Needed for the custom data (which is what we normally
 	// call userdata).
-	args.InstanceConfig.Tools = args.Tools[0]
+	args.InstanceConfig.SetTools(args.Tools)
 	logger.Infof("picked tools %q", args.InstanceConfig.Tools)
 
 	// Get the required configuration and config-dependent information

--- a/provider/azure/environ.go
+++ b/provider/azure/environ.go
@@ -406,7 +406,9 @@ func (env *azureEnviron) StartInstance(args environs.StartInstanceParams) (*envi
 
 	// Pick envtools.  Needed for the custom data (which is what we normally
 	// call userdata).
-	args.InstanceConfig.SetTools(args.Tools)
+	if err := args.InstanceConfig.SetTools(args.Tools); err != nil {
+		return nil, errors.Trace(err)
+	}
 	logger.Infof("picked tools %q", args.InstanceConfig.ToolsInfo().Version)
 
 	// Get the required configuration and config-dependent information

--- a/provider/azure/environ.go
+++ b/provider/azure/environ.go
@@ -407,7 +407,7 @@ func (env *azureEnviron) StartInstance(args environs.StartInstanceParams) (*envi
 	// Pick envtools.  Needed for the custom data (which is what we normally
 	// call userdata).
 	args.InstanceConfig.SetTools(args.Tools)
-	logger.Infof("picked tools %q", args.InstanceConfig.Tools)
+	logger.Infof("picked tools %q", args.InstanceConfig.ToolsVersion())
 
 	// Get the required configuration and config-dependent information
 	// required to create the instance. We take the lock just once, to

--- a/provider/cloudsigma/client_test.go
+++ b/provider/cloudsigma/client_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/altoros/gosigma/data"
 	"github.com/altoros/gosigma/mock"
 	"github.com/juju/loggo"
+	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
 	"github.com/juju/version"
 	gc "gopkg.in/check.v1"
@@ -180,13 +181,17 @@ func (s *clientSuite) TestClientNewInstanceInvalidTemplate(c *gc.C) {
 		Constraints: constraints.Value{},
 		InstanceConfig: &instancecfg.InstanceConfig{
 			Bootstrap: true,
-			Tools: &tools.Tools{
-				Version: version.Binary{
-					Series: "trusty",
-				},
-			},
 		},
 	}
+	err = params.InstanceConfig.SetTools(tools.List{
+		&tools.Tools{
+			Version: version.Binary{
+				Series: "trusty",
+			},
+			URL: "https://0.1.2.3:2000/x.y.z.tgz",
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
 	img := &imagemetadata.ImageMetadata{
 		Id: "invalid-id",
 	}
@@ -207,13 +212,17 @@ func (s *clientSuite) TestClientNewInstance(c *gc.C) {
 		Constraints: constraints.Value{},
 		InstanceConfig: &instancecfg.InstanceConfig{
 			Bootstrap: true,
-			Tools: &tools.Tools{
-				Version: version.Binary{
-					Series: "trusty",
-				},
-			},
 		},
 	}
+	err = params.InstanceConfig.SetTools(tools.List{
+		&tools.Tools{
+			Version: version.Binary{
+				Series: "trusty",
+			},
+			URL: "https://0.1.2.3:2000/x.y.z.tgz",
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
 	img := &imagemetadata.ImageMetadata{
 		Id: validImageId,
 	}

--- a/provider/cloudsigma/environinstance.go
+++ b/provider/cloudsigma/environinstance.go
@@ -63,7 +63,9 @@ func (env *environ) StartInstance(args environs.StartInstanceParams) (*environs.
 		return nil, errors.Errorf("chosen architecture %v not present in %v", img.Arch, args.Tools.Arches())
 	}
 
-	args.InstanceConfig.SetTools(tools)
+	if err := args.InstanceConfig.SetTools(tools); err != nil {
+		return nil, errors.Trace(err)
+	}
 	if err := instancecfg.FinishInstanceConfig(args.InstanceConfig, env.Config()); err != nil {
 		return nil, err
 	}

--- a/provider/cloudsigma/environinstance.go
+++ b/provider/cloudsigma/environinstance.go
@@ -63,7 +63,7 @@ func (env *environ) StartInstance(args environs.StartInstanceParams) (*environs.
 		return nil, errors.Errorf("chosen architecture %v not present in %v", img.Arch, args.Tools.Arches())
 	}
 
-	args.InstanceConfig.Tools = tools[0]
+	args.InstanceConfig.SetTools(tools)
 	if err := instancecfg.FinishInstanceConfig(args.InstanceConfig, env.Config()); err != nil {
 		return nil, err
 	}

--- a/provider/cloudsigma/environinstance_test.go
+++ b/provider/cloudsigma/environinstance_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/altoros/gosigma/mock"
 	"github.com/juju/loggo"
+	jc "github.com/juju/testing/checkers"
 	"github.com/juju/version"
 	gc "gopkg.in/check.v1"
 
@@ -166,12 +167,15 @@ func (s *environInstanceSuite) TestStartInstanceError(c *gc.C) {
 		Version: version.Binary{
 			Series: "trusty",
 		},
+		URL: "https://0.1.2.3:2000/x.y.z.tgz",
 	}
+	icfg := &instancecfg.InstanceConfig{
+		Networks: []string{"value"},
+	}
+	err = icfg.SetTools(tools.List{toolsVal})
+	c.Assert(err, jc.ErrorIsNil)
 	res, err = environ.StartInstance(environs.StartInstanceParams{
-		InstanceConfig: &instancecfg.InstanceConfig{
-			Networks: []string{"value"},
-			Tools:    toolsVal,
-		},
+		InstanceConfig: icfg,
 	})
 	c.Check(res, gc.IsNil)
 	c.Check(err, gc.ErrorMatches, "starting instances with networks is not supported yet")
@@ -182,9 +186,12 @@ func (s *environInstanceSuite) TestStartInstanceError(c *gc.C) {
 	c.Check(res, gc.IsNil)
 	c.Check(err, gc.ErrorMatches, "tools not found")
 
+	icfg = &instancecfg.InstanceConfig{}
+	err = icfg.SetTools(tools.List{toolsVal})
+	c.Assert(err, jc.ErrorIsNil)
 	res, err = environ.StartInstance(environs.StartInstanceParams{
 		Tools:          tools.List{toolsVal},
-		InstanceConfig: &instancecfg.InstanceConfig{Tools: toolsVal},
+		InstanceConfig: icfg,
 	})
 	c.Check(res, gc.IsNil)
 	c.Check(err, gc.ErrorMatches, "cannot make user data: series \"\" not valid")

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -527,8 +527,7 @@ func (e *environ) StartInstance(args environs.StartInstanceParams) (_ *environs.
 		logger.Warningf("deprecated instance type specified: %s", spec.InstanceType.Name)
 	}
 
-	// TODO(ericsnow) There may be more than one.
-	args.InstanceConfig.Tools = tools[0]
+	args.InstanceConfig.SetTools(tools)
 	if err := instancecfg.FinishInstanceConfig(args.InstanceConfig, e.Config()); err != nil {
 		return nil, err
 	}

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -527,7 +527,9 @@ func (e *environ) StartInstance(args environs.StartInstanceParams) (_ *environs.
 		logger.Warningf("deprecated instance type specified: %s", spec.InstanceType.Name)
 	}
 
-	args.InstanceConfig.SetTools(tools)
+	if err := args.InstanceConfig.SetTools(tools); err != nil {
+		return nil, errors.Trace(err)
+	}
 	if err := instancecfg.FinishInstanceConfig(args.InstanceConfig, e.Config()); err != nil {
 		return nil, err
 	}

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -527,6 +527,7 @@ func (e *environ) StartInstance(args environs.StartInstanceParams) (_ *environs.
 		logger.Warningf("deprecated instance type specified: %s", spec.InstanceType.Name)
 	}
 
+	// TODO(ericsnow) There may be more than one.
 	args.InstanceConfig.Tools = tools[0]
 	if err := instancecfg.FinishInstanceConfig(args.InstanceConfig, e.Config()); err != nil {
 		return nil, err

--- a/provider/gce/environ_broker.go
+++ b/provider/gce/environ_broker.go
@@ -100,7 +100,9 @@ func (env *environ) finishInstanceConfig(args environs.StartInstanceParams, spec
 		return errors.Errorf("chosen architecture %v not present in %v", spec.Image.Arch, arches)
 	}
 
-	args.InstanceConfig.SetTools(envTools)
+	if err := args.InstanceConfig.SetTools(envTools); err != nil {
+		return errors.Trace(err)
+	}
 	return instancecfg.FinishInstanceConfig(args.InstanceConfig, env.Config())
 }
 

--- a/provider/gce/environ_broker.go
+++ b/provider/gce/environ_broker.go
@@ -100,7 +100,7 @@ func (env *environ) finishInstanceConfig(args environs.StartInstanceParams, spec
 		return errors.Errorf("chosen architecture %v not present in %v", spec.Image.Arch, arches)
 	}
 
-	args.InstanceConfig.Tools = envTools[0]
+	args.InstanceConfig.SetTools(envTools)
 	return instancecfg.FinishInstanceConfig(args.InstanceConfig, env.Config())
 }
 

--- a/provider/gce/environ_broker_test.go
+++ b/provider/gce/environ_broker_test.go
@@ -135,7 +135,7 @@ func (s *environBrokerSuite) TestFinishInstanceConfig(c *gc.C) {
 	err := gce.FinishInstanceConfig(s.Env, s.StartInstArgs, s.spec)
 
 	c.Assert(err, jc.ErrorIsNil)
-	c.Check(s.StartInstArgs.InstanceConfig.Tools, gc.NotNil)
+	c.Check(s.StartInstArgs.InstanceConfig.ToolsInfo(), gc.NotNil)
 }
 
 func (s *environBrokerSuite) TestBuildInstanceSpec(c *gc.C) {

--- a/provider/gce/testing_test.go
+++ b/provider/gce/testing_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/juju/juju/provider/common"
 	"github.com/juju/juju/provider/gce/google"
 	"github.com/juju/juju/testing"
-	"github.com/juju/juju/tools"
+	coretools "github.com/juju/juju/tools"
 )
 
 // These values are fake GCE auth credentials for use in tests.
@@ -118,7 +118,7 @@ func (s *BaseSuiteUnpatched) initEnv(c *gc.C) {
 }
 
 func (s *BaseSuiteUnpatched) initInst(c *gc.C) {
-	tools := []*tools.Tools{{
+	tools := []*coretools.Tools{{
 		Version: version.Binary{Arch: arch.AMD64, Series: "trusty"},
 		URL:     "https://example.org",
 	}}
@@ -128,7 +128,8 @@ func (s *BaseSuiteUnpatched) initInst(c *gc.C) {
 	instanceConfig, err := instancecfg.NewBootstrapInstanceConfig(cons, cons, "trusty", "")
 	c.Assert(err, jc.ErrorIsNil)
 
-	instanceConfig.Tools = tools[0]
+	err = instanceConfig.SetTools(coretools.List(tools))
+	c.Assert(err, jc.ErrorIsNil)
 	instanceConfig.AuthorizedKeys = s.Config.AuthorizedKeys()
 
 	userData, err := providerinit.ComposeUserData(instanceConfig, nil, GCERenderer{})

--- a/provider/joyent/environ_instance.go
+++ b/provider/joyent/environ_instance.go
@@ -109,7 +109,7 @@ func (env *joyentEnviron) StartInstance(args environs.StartInstanceParams) (*env
 		return nil, errors.Errorf("chosen architecture %v not present in %v", spec.Image.Arch, arches)
 	}
 
-	args.InstanceConfig.Tools = tools[0]
+	args.InstanceConfig.SetTools(tools)
 
 	if err := instancecfg.FinishInstanceConfig(args.InstanceConfig, env.Config()); err != nil {
 		return nil, err

--- a/provider/joyent/environ_instance.go
+++ b/provider/joyent/environ_instance.go
@@ -109,7 +109,9 @@ func (env *joyentEnviron) StartInstance(args environs.StartInstanceParams) (*env
 		return nil, errors.Errorf("chosen architecture %v not present in %v", spec.Image.Arch, arches)
 	}
 
-	args.InstanceConfig.SetTools(tools)
+	if err := args.InstanceConfig.SetTools(tools); err != nil {
+		return nil, errors.Trace(err)
+	}
 
 	if err := instancecfg.FinishInstanceConfig(args.InstanceConfig, env.Config()); err != nil {
 		return nil, err

--- a/provider/lxd/environ_broker.go
+++ b/provider/lxd/environ_broker.go
@@ -84,7 +84,7 @@ func (env *environ) finishInstanceConfig(args environs.StartInstanceParams) erro
 	if err := args.InstanceConfig.SetTools(tools); err != nil {
 		return errors.Trace(err)
 	}
-	logger.Debugf("tools: %#v", args.InstanceConfig.Tools)
+	logger.Debugf("tools: %#v", args.InstanceConfig.ToolsList())
 
 	if err := instancecfg.FinishInstanceConfig(args.InstanceConfig, env.ecfg.Config); err != nil {
 		return errors.Trace(err)

--- a/provider/lxd/environ_broker.go
+++ b/provider/lxd/environ_broker.go
@@ -81,7 +81,9 @@ func (env *environ) finishInstanceConfig(args environs.StartInstanceParams) erro
 	if len(tools) == 0 {
 		return errors.Errorf("No tools available for architecture %q", arch.HostArch())
 	}
-	args.InstanceConfig.SetTools(tools)
+	if err := args.InstanceConfig.SetTools(tools); err != nil {
+		return errors.Trace(err)
+	}
 	logger.Debugf("tools: %#v", args.InstanceConfig.Tools)
 
 	if err := instancecfg.FinishInstanceConfig(args.InstanceConfig, env.ecfg.Config); err != nil {

--- a/provider/lxd/environ_broker.go
+++ b/provider/lxd/environ_broker.go
@@ -81,7 +81,7 @@ func (env *environ) finishInstanceConfig(args environs.StartInstanceParams) erro
 	if len(tools) == 0 {
 		return errors.Errorf("No tools available for architecture %q", arch.HostArch())
 	}
-	args.InstanceConfig.Tools = tools[0]
+	args.InstanceConfig.SetTools(tools)
 	logger.Debugf("tools: %#v", args.InstanceConfig.Tools)
 
 	if err := instancecfg.FinishInstanceConfig(args.InstanceConfig, env.ecfg.Config); err != nil {

--- a/provider/lxd/environ_broker_test.go
+++ b/provider/lxd/environ_broker_test.go
@@ -35,7 +35,7 @@ func (s *environBrokerSuite) TestStartInstance(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(result.Instance, gc.DeepEquals, s.Instance)
 	c.Check(result.Hardware, gc.DeepEquals, s.HWC)
-	c.Assert(s.StartInstArgs.InstanceConfig.Tools.Version.Arch, gc.Equals, arch.ARM64)
+	c.Assert(s.StartInstArgs.InstanceConfig.ToolsInfo().Version.Arch, gc.Equals, arch.ARM64)
 }
 
 func (s *environBrokerSuite) TestStartInstanceNoTools(c *gc.C) {

--- a/provider/lxd/testing_test.go
+++ b/provider/lxd/testing_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/testing"
-	"github.com/juju/juju/tools"
+	coretools "github.com/juju/juju/tools"
 	"github.com/juju/juju/tools/lxdclient"
 	"github.com/juju/version"
 )
@@ -141,7 +141,7 @@ func (s *BaseSuiteUnpatched) initEnv(c *gc.C) {
 }
 
 func (s *BaseSuiteUnpatched) initInst(c *gc.C) {
-	tools := []*tools.Tools{
+	tools := []*coretools.Tools{
 		{
 			Version: version.Binary{Arch: arch.AMD64, Series: "trusty"},
 			URL:     "https://example.org/amd",
@@ -159,7 +159,10 @@ func (s *BaseSuiteUnpatched) initInst(c *gc.C) {
 	instanceConfig, err := instancecfg.NewBootstrapInstanceConfig(cons, cons, "trusty", "")
 	c.Assert(err, jc.ErrorIsNil)
 
-	instanceConfig.Tools = tools[0]
+	err = instanceConfig.SetTools(coretools.List{
+		tools[0],
+	})
+	c.Assert(err, jc.ErrorIsNil)
 	instanceConfig.AuthorizedKeys = s.Config.AuthorizedKeys()
 
 	userData, err := providerinit.ComposeUserData(instanceConfig, nil, lxdRenderer{})

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -963,7 +963,7 @@ func (environ *maasEnviron) StartInstance(args environs.StartInstanceParams) (
 	if err := instancecfg.FinishInstanceConfig(args.InstanceConfig, environ.Config()); err != nil {
 		return nil, errors.Trace(err)
 	}
-	series := args.InstanceConfig.Tools.Version.Series
+	series := args.InstanceConfig.ToolsVersion().Series
 
 	cloudcfg, err := environ.newCloudinitConfig(hostname, series)
 	if err != nil {

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -953,7 +953,7 @@ func (environ *maasEnviron) StartInstance(args environs.StartInstanceParams) (
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	args.InstanceConfig.Tools = selectedTools[0]
+	args.InstanceConfig.SetTools(selectedTools)
 
 	hostname, err := inst.hostname()
 	if err != nil {

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -947,6 +947,7 @@ func (environ *maasEnviron) StartInstance(args environs.StartInstanceParams) (
 		return nil, err
 	}
 
+	series := args.Tools.OneSeries()
 	selectedTools, err := args.Tools.Match(tools.Filter{
 		Arch: *hc.Arch,
 	})
@@ -963,7 +964,6 @@ func (environ *maasEnviron) StartInstance(args environs.StartInstanceParams) (
 	if err := instancecfg.FinishInstanceConfig(args.InstanceConfig, environ.Config()); err != nil {
 		return nil, errors.Trace(err)
 	}
-	series := args.InstanceConfig.ToolsVersion().Series
 
 	cloudcfg, err := environ.newCloudinitConfig(hostname, series)
 	if err != nil {

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -954,7 +954,9 @@ func (environ *maasEnviron) StartInstance(args environs.StartInstanceParams) (
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	args.InstanceConfig.SetTools(selectedTools)
+	if err := args.InstanceConfig.SetTools(selectedTools); err != nil {
+		return nil, errors.Trace(err)
+	}
 
 	hostname, err := inst.hostname()
 	if err != nil {

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -929,7 +929,9 @@ func (e *Environ) StartInstance(args environs.StartInstanceParams) (*environs.St
 		return nil, errors.Errorf("chosen architecture %v not present in %v", spec.Image.Arch, arches)
 	}
 
-	args.InstanceConfig.SetTools(tools)
+	if err := args.InstanceConfig.SetTools(tools); err != nil {
+		return nil, errors.Trace(err)
+	}
 
 	if err := instancecfg.FinishInstanceConfig(args.InstanceConfig, e.Config()); err != nil {
 		return nil, err

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -929,7 +929,7 @@ func (e *Environ) StartInstance(args environs.StartInstanceParams) (*environs.St
 		return nil, errors.Errorf("chosen architecture %v not present in %v", spec.Image.Arch, arches)
 	}
 
-	args.InstanceConfig.Tools = tools[0]
+	args.InstanceConfig.SetTools(tools)
 
 	if err := instancecfg.FinishInstanceConfig(args.InstanceConfig, e.Config()); err != nil {
 		return nil, err

--- a/provider/vsphere/environ_broker.go
+++ b/provider/vsphere/environ_broker.go
@@ -74,7 +74,9 @@ func (env *environ) finishMachineConfig(args environs.StartInstanceParams, img *
 		return err
 	}
 
-	args.InstanceConfig.SetTools(envTools)
+	if err := args.InstanceConfig.SetTools(envTools); err != nil {
+		return errors.Trace(err)
+	}
 	return FinishInstanceConfig(args.InstanceConfig, env.Config())
 }
 

--- a/provider/vsphere/environ_broker.go
+++ b/provider/vsphere/environ_broker.go
@@ -74,7 +74,7 @@ func (env *environ) finishMachineConfig(args environs.StartInstanceParams, img *
 		return err
 	}
 
-	args.InstanceConfig.Tools = envTools[0]
+	args.InstanceConfig.SetTools(envTools)
 	return FinishInstanceConfig(args.InstanceConfig, env.Config())
 }
 

--- a/provider/vsphere/environ_broker_test.go
+++ b/provider/vsphere/environ_broker_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/provider/common"
 	"github.com/juju/juju/provider/vsphere"
-	"github.com/juju/juju/tools"
+	coretools "github.com/juju/juju/tools"
 )
 
 type environBrokerSuite struct {
@@ -49,7 +49,7 @@ func (s *environBrokerSuite) PrepareStartInstanceFakes(c *gc.C) {
 }
 
 func (s *environBrokerSuite) CreateStartInstanceArgs(c *gc.C) environs.StartInstanceParams {
-	tools := []*tools.Tools{{
+	tools := []*coretools.Tools{{
 		Version: version.Binary{Arch: arch.AMD64, Series: "trusty"},
 		URL:     "https://example.org",
 	}}
@@ -59,7 +59,10 @@ func (s *environBrokerSuite) CreateStartInstanceArgs(c *gc.C) environs.StartInst
 	instanceConfig, err := instancecfg.NewBootstrapInstanceConfig(cons, cons, "trusty", "")
 	c.Assert(err, jc.ErrorIsNil)
 
-	instanceConfig.Tools = tools[0]
+	err = instanceConfig.SetTools(coretools.List{
+		tools[0],
+	})
+	c.Assert(err, jc.ErrorIsNil)
 	instanceConfig.AuthorizedKeys = s.Config.AuthorizedKeys()
 
 	return environs.StartInstanceParams{
@@ -99,7 +102,7 @@ func (s *environBrokerSuite) TestStartInstanceWithUnsupportedConstraints(c *gc.C
 func (s *environBrokerSuite) TestStartInstanceFilterToolByArch(c *gc.C) {
 	s.PrepareStartInstanceFakes(c)
 	startInstArgs := s.CreateStartInstanceArgs(c)
-	tools := []*tools.Tools{{
+	tools := []*coretools.Tools{{
 		Version: version.Binary{Arch: arch.I386, Series: "trusty"},
 		URL:     "https://example.org",
 	}, {
@@ -108,12 +111,15 @@ func (s *environBrokerSuite) TestStartInstanceFilterToolByArch(c *gc.C) {
 	}}
 	//setting tools to I386, but provider should update them to AMD64, because our fake simplestream server return only AMD 64 image
 	startInstArgs.Tools = tools
-	startInstArgs.InstanceConfig.Tools = tools[0]
+	err := startInstArgs.InstanceConfig.SetTools(coretools.List{
+		tools[0],
+	})
+	c.Assert(err, jc.ErrorIsNil)
 	res, err := s.Env.StartInstance(startInstArgs)
 
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(*res.Hardware.Arch, gc.Equals, arch.AMD64)
-	c.Assert(startInstArgs.InstanceConfig.Tools.Version.Arch, gc.Equals, arch.AMD64)
+	c.Assert(startInstArgs.InstanceConfig.ToolsInfo().Version.Arch, gc.Equals, arch.AMD64)
 }
 
 func (s *environBrokerSuite) TestStartInstanceDefaultConstraintsApplied(c *gc.C) {

--- a/state/backups/backups_linux.go
+++ b/state/backups/backups_linux.go
@@ -108,8 +108,7 @@ func (b *backups) Restore(backupId string, args RestoreArgs) (names.Tag, error) 
 	if !ok {
 		return nil, errors.Errorf("cannot determine state serving info")
 	}
-	// TODO(ericsnow) Include the public address too?
-	APIHostPorts := network.NewHostPorts(ssi.APIPort, args.PrivateAddress)
+	APIHostPorts := network.NewHostPorts(ssi.APIPort, args.PrivateAddress, args.PublicAddress)
 	agentConfig.SetAPIHostPorts([][]network.HostPort{APIHostPorts})
 	if err := agentConfig.Write(); err != nil {
 		return nil, errors.Annotate(err, "cannot write new agent configuration")

--- a/state/backups/backups_linux.go
+++ b/state/backups/backups_linux.go
@@ -108,6 +108,7 @@ func (b *backups) Restore(backupId string, args RestoreArgs) (names.Tag, error) 
 	if !ok {
 		return nil, errors.Errorf("cannot determine state serving info")
 	}
+	// TODO(ericsnow) Include the public address too?
 	APIHostPorts := network.NewHostPorts(ssi.APIPort, args.PrivateAddress)
 	agentConfig.SetAPIHostPorts([][]network.HostPort{APIHostPorts})
 	if err := agentConfig.Write(); err != nil {

--- a/tools/list.go
+++ b/tools/list.go
@@ -60,11 +60,12 @@ func (src List) collect(f func(*Tools) string) []string {
 	return seen.SortedValues()
 }
 
-// URLs returns download URLs for the tools in src, keyed by binary version.
-func (src List) URLs() map[version.Binary]string {
-	result := map[version.Binary]string{}
+// URLs returns download URLs for the tools in src, keyed by binary
+// version. Each version can have more than one URL.
+func (src List) URLs() map[version.Binary][]string {
+	result := map[version.Binary][]string{}
 	for _, tools := range src {
-		result[tools.Version] = tools.URL
+		result[tools.Version] = append(result[tools.Version], tools.URL)
 	}
 	return result
 }

--- a/tools/list_test.go
+++ b/tools/list_test.go
@@ -104,13 +104,13 @@ func (s *ListSuite) TestArches(c *gc.C) {
 
 func (s *ListSuite) TestURLs(c *gc.C) {
 	empty := tools.List{}
-	c.Check(empty.URLs(), gc.DeepEquals, map[version.Binary]string{})
+	c.Check(empty.URLs(), gc.DeepEquals, map[version.Binary][]string{})
 
 	full := tools.List{t100precise, t190quantal, t2001precise}
-	c.Check(full.URLs(), gc.DeepEquals, map[version.Binary]string{
-		t100precise.Version:  t100precise.URL,
-		t190quantal.Version:  t190quantal.URL,
-		t2001precise.Version: t2001precise.URL,
+	c.Check(full.URLs(), gc.DeepEquals, map[version.Binary][]string{
+		t100precise.Version:  []string{t100precise.URL},
+		t190quantal.Version:  []string{t190quantal.URL},
+		t2001precise.Version: []string{t2001precise.URL},
 	})
 }
 

--- a/tools/list_test.go
+++ b/tools/list_test.go
@@ -4,6 +4,8 @@
 package tools_test
 
 import (
+	"strings"
+
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/version"
 	gc "gopkg.in/check.v1"
@@ -106,9 +108,18 @@ func (s *ListSuite) TestURLs(c *gc.C) {
 	empty := tools.List{}
 	c.Check(empty.URLs(), gc.DeepEquals, map[version.Binary][]string{})
 
-	full := tools.List{t100precise, t190quantal, t2001precise}
+	alt := *t100quantal
+	alt.URL = strings.Replace(alt.URL, "testing.invalid", "testing.invalid2", 1)
+	full := tools.List{
+		t100precise,
+		t190quantal,
+		t100quantal,
+		&alt,
+		t2001precise,
+	}
 	c.Check(full.URLs(), gc.DeepEquals, map[version.Binary][]string{
 		t100precise.Version:  []string{t100precise.URL},
+		t100quantal.Version:  []string{t100quantal.URL, alt.URL},
 		t190quantal.Version:  []string{t190quantal.URL},
 		t2001precise.Version: []string{t2001precise.URL},
 	})

--- a/worker/provisioner/kvm-broker.go
+++ b/worker/provisioner/kvm-broker.go
@@ -93,6 +93,7 @@ func (broker *kvmBroker) StartInstance(args environs.StartInstanceParams) (*envi
 
 	series := args.Tools.OneSeries()
 	args.InstanceConfig.MachineContainerType = instance.KVM
+	// TODO(ericsnow) There may be more than one.
 	args.InstanceConfig.Tools = args.Tools[0]
 
 	if err := instancecfg.PopulateInstanceConfig(

--- a/worker/provisioner/kvm-broker.go
+++ b/worker/provisioner/kvm-broker.go
@@ -93,8 +93,7 @@ func (broker *kvmBroker) StartInstance(args environs.StartInstanceParams) (*envi
 
 	series := args.Tools.OneSeries()
 	args.InstanceConfig.MachineContainerType = instance.KVM
-	// TODO(ericsnow) There may be more than one.
-	args.InstanceConfig.Tools = args.Tools[0]
+	args.InstanceConfig.SetTools(args.Tools)
 
 	if err := instancecfg.PopulateInstanceConfig(
 		args.InstanceConfig,

--- a/worker/provisioner/kvm-broker.go
+++ b/worker/provisioner/kvm-broker.go
@@ -93,7 +93,9 @@ func (broker *kvmBroker) StartInstance(args environs.StartInstanceParams) (*envi
 
 	series := args.Tools.OneSeries()
 	args.InstanceConfig.MachineContainerType = instance.KVM
-	args.InstanceConfig.SetTools(args.Tools)
+	if err := args.InstanceConfig.SetTools(args.Tools); err != nil {
+		return nil, errors.Trace(err)
+	}
 
 	if err := instancecfg.PopulateInstanceConfig(
 		args.InstanceConfig,

--- a/worker/provisioner/lxc-broker.go
+++ b/worker/provisioner/lxc-broker.go
@@ -137,8 +137,7 @@ func (broker *lxcBroker) StartInstance(args environs.StartInstanceParams) (*envi
 
 	series := archTools.OneSeries()
 	args.InstanceConfig.MachineContainerType = instance.LXC
-	// TODO(ericsnow) There may be more than one.
-	args.InstanceConfig.Tools = archTools[0]
+	args.InstanceConfig.SetTools(archTools)
 
 	storageConfig := &container.StorageConfig{
 		AllowMount: config.AllowLXCLoopMounts,

--- a/worker/provisioner/lxc-broker.go
+++ b/worker/provisioner/lxc-broker.go
@@ -137,6 +137,7 @@ func (broker *lxcBroker) StartInstance(args environs.StartInstanceParams) (*envi
 
 	series := archTools.OneSeries()
 	args.InstanceConfig.MachineContainerType = instance.LXC
+	// TODO(ericsnow) There may be more than one.
 	args.InstanceConfig.Tools = archTools[0]
 
 	storageConfig := &container.StorageConfig{

--- a/worker/provisioner/lxc-broker.go
+++ b/worker/provisioner/lxc-broker.go
@@ -137,7 +137,9 @@ func (broker *lxcBroker) StartInstance(args environs.StartInstanceParams) (*envi
 
 	series := archTools.OneSeries()
 	args.InstanceConfig.MachineContainerType = instance.LXC
-	args.InstanceConfig.SetTools(archTools)
+	if err := args.InstanceConfig.SetTools(archTools); err != nil {
+		return nil, errors.Trace(err)
+	}
 
 	storageConfig := &container.StorageConfig{
 		AllowMount: config.AllowLXCLoopMounts,

--- a/worker/provisioner/lxc-broker_test.go
+++ b/worker/provisioner/lxc-broker_test.go
@@ -307,7 +307,7 @@ func (s *lxcBrokerSuite) TestStartInstanceHostArch(c *gc.C) {
 		StatusCallback: callback,
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(instanceConfig.Tools.Version.Arch, gc.Equals, arch.PPC64EL)
+	c.Assert(instanceConfig.ToolsInfo().Version.Arch, gc.Equals, arch.PPC64EL)
 }
 
 func (s *lxcBrokerSuite) TestStartInstanceToolsArchNotFound(c *gc.C) {

--- a/worker/provisioner/lxd-broker.go
+++ b/worker/provisioner/lxd-broker.go
@@ -87,7 +87,9 @@ func (broker *lxdBroker) StartInstance(args environs.StartInstanceParams) (*envi
 
 	series := args.Tools.OneSeries()
 	args.InstanceConfig.MachineContainerType = instance.LXD
-	args.InstanceConfig.SetTools(args.Tools)
+	if err := args.InstanceConfig.SetTools(args.Tools); err != nil {
+		return nil, errors.Trace(err)
+	}
 
 	if err := instancecfg.PopulateInstanceConfig(
 		args.InstanceConfig,

--- a/worker/provisioner/lxd-broker.go
+++ b/worker/provisioner/lxd-broker.go
@@ -87,8 +87,7 @@ func (broker *lxdBroker) StartInstance(args environs.StartInstanceParams) (*envi
 
 	series := args.Tools.OneSeries()
 	args.InstanceConfig.MachineContainerType = instance.LXD
-	// TODO(ericsnow) There may be more than one.
-	args.InstanceConfig.Tools = args.Tools[0]
+	args.InstanceConfig.SetTools(args.Tools)
 
 	if err := instancecfg.PopulateInstanceConfig(
 		args.InstanceConfig,

--- a/worker/provisioner/lxd-broker.go
+++ b/worker/provisioner/lxd-broker.go
@@ -87,6 +87,7 @@ func (broker *lxdBroker) StartInstance(args environs.StartInstanceParams) (*envi
 
 	series := args.Tools.OneSeries()
 	args.InstanceConfig.MachineContainerType = instance.LXD
+	// TODO(ericsnow) There may be more than one.
 	args.InstanceConfig.Tools = args.Tools[0]
 
 	if err := instancecfg.PopulateInstanceConfig(

--- a/worker/upgrader/upgrader.go
+++ b/worker/upgrader/upgrader.go
@@ -205,7 +205,7 @@ func (u *Upgrader) loop() error {
 		}
 
 		// Check if tools are available for download.
-		wantTools, err := u.st.Tools(u.tag.String())
+		wantToolsList, err := u.st.Tools(u.tag.String())
 		if err != nil {
 			// Not being able to lookup Tools is considered fatal
 			return err
@@ -215,11 +215,13 @@ func (u *Upgrader) loop() error {
 		// repeatedly (causing the agent to be stopped), as long
 		// as we have got as far as this, we will still be able to
 		// upgrade the agent.
-		err = u.ensureTools(wantTools)
-		if err == nil {
-			return u.newUpgradeReadyError(wantTools.Version)
+		for _, wantTools := range wantToolsList {
+			err = u.ensureTools(wantTools)
+			if err == nil {
+				return u.newUpgradeReadyError(wantTools.Version)
+			}
+			logger.Errorf("failed to fetch tools from %q: %v", wantTools.URL, err)
 		}
-		logger.Errorf("failed to fetch tools from %q: %v", wantTools.URL, err)
 		retry = retryAfter()
 	}
 }


### PR DESCRIPTION
(fixes https://bugs.launchpad.net/juju-core/+bug/1566431)

We have been trying only the private IP addresses (or falling back to public) when upgrading.  We've been updating the agent config in that same way.  In some situations the private address is not reachable so we must fall back to the public one. This patch makes that change.

Note that this change makes a backward-incompatible API change.

(reviews: http://reviews.vapour.ws/r/4576/)