### PR TITLE
Drop --generate from change-user-password

### DIFF
--- a/cmd/juju/user/export_test.go
+++ b/cmd/juju/user/export_test.go
@@ -11,10 +11,6 @@ import (
 	"github.com/juju/juju/jujuclient"
 )
 
-var (
-	RandomPasswordNotify = &randomPasswordNotify
-)
-
 type AddCommand struct {
 	*addCommand
 }


### PR DESCRIPTION
The --generate flag for "change-user-password" is unhelpful: it
generates a random password, but does not tell you what it is. The
password is not stored locally, so once your macaroon has expired,
you won't be able to log back in.

--generate comes from a time when we used to store the passwords
locally, and doesn't really make as much sense now. If users want
to generate random passwords, they should use a password manager,
or learn the method of loci.

Fixes https://bugs.launchpad.net/juju-core/+bug/1571901

(Review request: http://reviews.vapour.ws/r/4634/)