### PR TITLE
Improve error message when no path specified

### DIFF
--- a/cloud/fallback-public-cloud.yaml
+++ b/cloud/fallback-public-cloud.yaml
@@ -1,4 +1,4 @@
-# DO NOT EDIT, will be overwritten, use “juju update-clouds” to refresh.
+# DO NOT EDIT, will be overwritten, use "juju update-clouds" to refresh.
 clouds:
   aws:
     type: ec2

--- a/cloud/fallback_public_cloud.go
+++ b/cloud/fallback_public_cloud.go
@@ -6,7 +6,7 @@ package cloud
 // Generated code - do not edit.
 
 const fallbackPublicCloudInfo = `
-# DO NOT EDIT, will be overwritten, use “juju update-clouds” to refresh.
+# DO NOT EDIT, will be overwritten, use "juju update-clouds" to refresh.
 clouds:
   aws:
     type: ec2

--- a/cmd/juju/service/upgradecharm.go
+++ b/cmd/juju/service/upgradecharm.go
@@ -185,6 +185,11 @@ func (c *upgradeCharmCommand) Run(ctx *cmd.Context) error {
 		newRef = c.CharmPath
 	}
 	if c.SwitchURL == "" && c.CharmPath == "" {
+		// If the charm we are upgrading is local, then we must
+		// specify a path or switch url to upgrade with.
+		if oldURL.Schema == "local" {
+			return errors.New("upgrading a local charm requires either --path or --switch")
+		}
 		// No new URL specified, but revision might have been.
 		newRef = oldURL.WithRevision(c.Revision).String()
 	}

--- a/cmd/juju/service/upgradecharm_test.go
+++ b/cmd/juju/service/upgradecharm_test.go
@@ -101,6 +101,12 @@ func (s *UpgradeCharmErrorsSuite) TestInvalidSwitchURL(c *gc.C) {
 	// TODO(dimitern): add tests with incompatible charms
 }
 
+func (s *UpgradeCharmErrorsSuite) TestNoPathFails(c *gc.C) {
+	s.deployService(c)
+	err := runUpgradeCharm(c, "riak")
+	c.Assert(err, gc.ErrorMatches, "upgrading a local charm requires either --path or --switch")
+}
+
 func (s *UpgradeCharmErrorsSuite) TestSwitchAndRevisionFails(c *gc.C) {
 	s.deployService(c)
 	err := runUpgradeCharm(c, "riak", "--switch=riak", "--revision=2")


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/juju-core/+bug/1571861

Improve the upgrade experience when no path is specified for local charms.
Also driveby fix for curly quotes.

(Review request: http://reviews.vapour.ws/r/4635/)