### PR TITLE
peergrouper refactoring

### DIFF
--- a/worker/peergrouper/desired.go
+++ b/worker/peergrouper/desired.go
@@ -36,7 +36,11 @@ func desiredPeerGroup(info *peerGroupInfo) ([]replicaset.Member, map[*machineTra
 	changed := false
 	members, extra, maxId := info.membersMap()
 	logger.Debugf("calculating desired peer group")
-	logger.Debugf("members: %#v", members)
+	line := "members: ..."
+	for tracker, replMem := range members {
+		line = fmt.Sprintf("%s\n   %#v: rs_id=%d, rs_addr=%s", line, tracker, replMem.Id, replMem.Address)
+	}
+	logger.Debugf(line)
 	logger.Debugf("extra: %#v", extra)
 	logger.Debugf("maxId: %v", maxId)
 

--- a/worker/peergrouper/desired.go
+++ b/worker/peergrouper/desired.go
@@ -236,18 +236,6 @@ func addNewMembers(
 	}
 }
 
-func mongoAddresses(machines map[string]*machineTracker) [][]network.Address {
-	addresses := make([][]network.Address, len(machines))
-	i := 0
-	for _, m := range machines {
-		for _, hp := range m.MongoHostPorts() {
-			addresses[i] = append(addresses[i], hp.Address)
-		}
-		i++
-	}
-	return addresses
-}
-
 func isReady(status replicaset.MemberStatus) bool {
 	return status.Healthy && (status.State == replicaset.PrimaryState ||
 		status.State == replicaset.SecondaryState)

--- a/worker/peergrouper/desired.go
+++ b/worker/peergrouper/desired.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/juju/loggo"
 	"github.com/juju/replicaset"
 
 	"github.com/juju/juju/network"
@@ -16,16 +15,13 @@ import (
 // jujuMachineKey is the key for the tag where we save the member's juju machine id.
 const jujuMachineKey = "juju-machine-id"
 
-var logger = loggo.GetLogger("juju.worker.peergrouper")
-
 // peerGroupInfo holds information that may contribute to
 // a peer group.
 type peerGroupInfo struct {
-	machines        map[string]*machine // id -> machine
+	machineTrackers map[string]*machineTracker // id -> machine
 	statuses        []replicaset.MemberStatus
 	members         []replicaset.Member
 	mongoSpace      network.SpaceName
-	mongoSpaceValid bool
 }
 
 // desiredPeerGroup returns the mongo peer group according to the given
@@ -33,7 +29,7 @@ type peerGroupInfo struct {
 // specifying whether that machine has been configured as voting. It will
 // return a nil member list and error if the current group is already
 // correct, though the voting map will be still be returned in that case.
-func desiredPeerGroup(info *peerGroupInfo) ([]replicaset.Member, map[*machine]bool, error) {
+func desiredPeerGroup(info *peerGroupInfo) ([]replicaset.Member, map[*machineTracker]bool, error) {
 	if len(info.members) == 0 {
 		return nil, nil, fmt.Errorf("current member set is empty")
 	}
@@ -70,20 +66,20 @@ func desiredPeerGroup(info *peerGroupInfo) ([]replicaset.Member, map[*machine]bo
 
 	// Set up initial record of machine votes. Any changes after
 	// this will trigger a peer group election.
-	machineVoting := make(map[*machine]bool)
-	for _, m := range info.machines {
+	machineVoting := make(map[*machineTracker]bool)
+	for _, m := range info.machineTrackers {
 		member := members[m]
 		machineVoting[m] = member != nil && isVotingMember(member)
 	}
-	setVoting := func(m *machine, voting bool) {
+	setVoting := func(m *machineTracker, voting bool) {
 		setMemberVoting(members[m], voting)
 		machineVoting[m] = voting
 		changed = true
 	}
 	adjustVotes(toRemoveVote, toAddVote, setVoting)
 
-	addNewMembers(members, toKeep, maxId, setVoting, info.mongoSpace, info.mongoSpaceValid)
-	if updateAddresses(members, info.machines, info.mongoSpace, info.mongoSpaceValid) {
+	addNewMembers(members, toKeep, maxId, setVoting, info.mongoSpace)
+	if updateAddresses(members, info.machineTrackers, info.mongoSpace) {
 		changed = true
 	}
 	if !changed {
@@ -108,30 +104,34 @@ func isVotingMember(member *replicaset.Member) bool {
 // ready to vote; toKeep holds machines with no desired
 // change to their voting status (this includes machines
 // that are not yet represented in the peer group).
-func possiblePeerGroupChanges(info *peerGroupInfo, members map[*machine]*replicaset.Member) (toRemoveVote, toAddVote, toKeep []*machine) {
+func possiblePeerGroupChanges(
+	info *peerGroupInfo,
+	members map[*machineTracker]*replicaset.Member,
+) (toRemoveVote, toAddVote, toKeep []*machineTracker) {
 	statuses := info.statusesMap(members)
 
 	logger.Debugf("assessing possible peer group changes:")
-	for _, m := range info.machines {
+	for _, m := range info.machineTrackers {
 		member := members[m]
+		wantsVote := m.WantsVote()
 		isVoting := member != nil && isVotingMember(member)
 		switch {
-		case m.wantsVote && isVoting:
-			logger.Debugf("machine %q is already voting", m.id)
+		case wantsVote && isVoting:
+			logger.Debugf("machine %q is already voting", m.Id())
 			toKeep = append(toKeep, m)
-		case m.wantsVote && !isVoting:
+		case wantsVote && !isVoting:
 			if status, ok := statuses[m]; ok && isReady(status) {
-				logger.Debugf("machine %q is a potential voter", m.id)
+				logger.Debugf("machine %q is a potential voter", m.Id())
 				toAddVote = append(toAddVote, m)
 			} else {
-				logger.Debugf("machine %q is not ready (has status: %v)", m.id, ok)
+				logger.Debugf("machine %q is not ready (has status: %v)", m.Id(), ok)
 				toKeep = append(toKeep, m)
 			}
-		case !m.wantsVote && isVoting:
-			logger.Debugf("machine %q is a potential non-voter", m.id)
+		case !wantsVote && isVoting:
+			logger.Debugf("machine %q is a potential non-voter", m.Id())
 			toRemoveVote = append(toRemoveVote, m)
-		case !m.wantsVote && !isVoting:
-			logger.Debugf("machine %q does not want the vote", m.id)
+		case !wantsVote && !isVoting:
+			logger.Debugf("machine %q does not want the vote", m.Id())
 			toKeep = append(toKeep, m)
 		}
 	}
@@ -149,18 +149,15 @@ func possiblePeerGroupChanges(info *peerGroupInfo, members map[*machine]*replica
 // updateAddresses updates the members' addresses from the machines' addresses.
 // It reports whether any changes have been made.
 func updateAddresses(
-	members map[*machine]*replicaset.Member,
-	machines map[string]*machine,
+	members map[*machineTracker]*replicaset.Member,
+	machines map[string]*machineTracker,
 	mongoSpace network.SpaceName,
-	mongoSpaceValid bool,
 ) bool {
 	changed := false
 
 	// Make sure all members' machine addresses are up to date.
 	for _, m := range machines {
-		m.mongoSpace = mongoSpace
-		m.mongoSpaceValid = mongoSpaceValid
-		hp := m.mongoHostPort()
+		hp := m.SelectMongoHostPort(mongoSpace)
 		if hp == "" {
 			continue
 		}
@@ -177,7 +174,7 @@ func updateAddresses(
 // care not to let the total number of votes become even at
 // any time. It calls setVoting to change the voting status
 // of a machine.
-func adjustVotes(toRemoveVote, toAddVote []*machine, setVoting func(*machine, bool)) {
+func adjustVotes(toRemoveVote, toAddVote []*machineTracker, setVoting func(*machineTracker, bool)) {
 	// Remove voting members if they can be replaced by
 	// candidates that are ready. This does not affect
 	// the total number of votes.
@@ -212,17 +209,14 @@ func adjustVotes(toRemoveVote, toAddVote []*machine, setVoting func(*machine, bo
 // maxId upwards. It calls setVoting to set the voting
 // status of each new member.
 func addNewMembers(
-	members map[*machine]*replicaset.Member,
-	toKeep []*machine,
+	members map[*machineTracker]*replicaset.Member,
+	toKeep []*machineTracker,
 	maxId int,
-	setVoting func(*machine, bool),
+	setVoting func(*machineTracker, bool),
 	mongoSpace network.SpaceName,
-	mongoSpaceValid bool,
 ) {
 	for _, m := range toKeep {
-		m.mongoSpace = mongoSpace
-		m.mongoSpaceValid = mongoSpaceValid
-		hasAddress := m.mongoHostPort() != ""
+		hasAddress := m.SelectMongoHostPort(mongoSpace) != ""
 		if members[m] == nil && hasAddress {
 			// This machine was not previously in the members list,
 			// so add it (as non-voting). We maintain the
@@ -230,29 +224,27 @@ func addNewMembers(
 			maxId++
 			member := &replicaset.Member{
 				Tags: map[string]string{
-					jujuMachineKey: m.id,
+					jujuMachineKey: m.Id(),
 				},
 				Id: maxId,
 			}
 			members[m] = member
 			setVoting(m, false)
 		} else if !hasAddress {
-			logger.Debugf("ignoring machine %q with no address", m.id)
+			logger.Debugf("ignoring machine %q with no address", m.Id())
 		}
 	}
 }
 
-func mongoAddresses(machines map[string]*machine) [][]network.Address {
+func mongoAddresses(machines map[string]*machineTracker) [][]network.Address {
 	addresses := make([][]network.Address, len(machines))
-
 	i := 0
 	for _, m := range machines {
-		for _, hp := range m.mongoHostPorts {
+		for _, hp := range m.MongoHostPorts() {
 			addresses[i] = append(addresses[i], hp.Address)
 		}
 		i++
 	}
-
 	return addresses
 }
 
@@ -273,26 +265,30 @@ func setMemberVoting(member *replicaset.Member, voting bool) {
 	}
 }
 
-type byId []*machine
+type byId []*machineTracker
 
 func (l byId) Len() int           { return len(l) }
 func (l byId) Swap(i, j int)      { l[i], l[j] = l[j], l[i] }
-func (l byId) Less(i, j int) bool { return l[i].id < l[j].id }
+func (l byId) Less(i, j int) bool { return l[i].Id() < l[j].Id() }
 
 // membersMap returns the replica-set members inside info keyed
 // by machine. Any members that do not have a corresponding
 // machine are returned in extra.
 // The maximum replica-set id is returned in maxId.
-func (info *peerGroupInfo) membersMap() (members map[*machine]*replicaset.Member, extra []replicaset.Member, maxId int) {
+func (info *peerGroupInfo) membersMap() (
+	members map[*machineTracker]*replicaset.Member,
+	extra []replicaset.Member,
+	maxId int,
+) {
 	maxId = -1
-	members = make(map[*machine]*replicaset.Member)
+	members = make(map[*machineTracker]*replicaset.Member)
 	for key := range info.members {
 		// key is used instead of value to have a loop scoped member value
 		member := info.members[key]
 		mid, ok := member.Tags[jujuMachineKey]
-		var found *machine
+		var found *machineTracker
 		if ok {
-			found = info.machines[mid]
+			found = info.machineTrackers[mid]
 		}
 		if found != nil {
 			members[found] = &member
@@ -309,8 +305,10 @@ func (info *peerGroupInfo) membersMap() (members map[*machine]*replicaset.Member
 // statusesMap returns the statuses inside info keyed by machine.
 // The provided members map holds the members keyed by machine,
 // as returned by membersMap.
-func (info *peerGroupInfo) statusesMap(members map[*machine]*replicaset.Member) map[*machine]replicaset.MemberStatus {
-	statuses := make(map[*machine]replicaset.MemberStatus)
+func (info *peerGroupInfo) statusesMap(
+	members map[*machineTracker]*replicaset.Member,
+) map[*machineTracker]replicaset.MemberStatus {
+	statuses := make(map[*machineTracker]replicaset.MemberStatus)
 	for _, status := range info.statuses {
 		for m, member := range members {
 			if member.Id == status.Id {

--- a/worker/peergrouper/machinetracker.go
+++ b/worker/peergrouper/machinetracker.go
@@ -1,0 +1,191 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package peergrouper
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/mongo"
+	"github.com/juju/juju/network"
+	"github.com/juju/juju/worker/catacomb"
+)
+
+// machineTracker is a worker which reports changes of interest to
+// the peergrouper for a single machine in state.
+type machineTracker struct {
+	catacomb catacomb.Catacomb
+	notifyCh chan struct{}
+	stm      stateMachine
+
+	mu sync.Mutex
+
+	// Outside of the machineTracker implementation itself, these
+	// should always be accessed via the getter methods in order to be
+	// protected by the mutex.
+	id             string
+	wantsVote      bool
+	apiHostPorts   []network.HostPort
+	mongoHostPorts []network.HostPort
+}
+
+func newMachineTracker(stm stateMachine, notifyCh chan struct{}) (*machineTracker, error) {
+	m := &machineTracker{
+		notifyCh:       notifyCh,
+		id:             stm.Id(),
+		stm:            stm,
+		apiHostPorts:   stm.APIHostPorts(),
+		mongoHostPorts: stm.MongoHostPorts(),
+		wantsVote:      stm.WantsVote(),
+	}
+	err := catacomb.Invoke(catacomb.Plan{
+		Site: &m.catacomb,
+		Work: m.loop,
+	})
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return m, nil
+}
+
+// Kill implements Worker.
+func (m *machineTracker) Kill() {
+	m.catacomb.Kill(nil)
+}
+
+// Wait implements Worker.
+func (m *machineTracker) Wait() error {
+	return m.catacomb.Wait()
+}
+
+// Id returns the id of the machine being tracked.
+func (m *machineTracker) Id() string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.id
+}
+
+// WantsVote returns whether the machine wants to vote (according to
+// state).
+func (m *machineTracker) WantsVote() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.wantsVote
+}
+
+// WantsVote returns the MongoDB hostports from state.
+func (m *machineTracker) MongoHostPorts() []network.HostPort {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]network.HostPort, len(m.mongoHostPorts))
+	copy(out, m.mongoHostPorts)
+	return out
+}
+
+// APIHostPorts returns the API server hostports from state.
+func (m *machineTracker) APIHostPorts() []network.HostPort {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]network.HostPort, len(m.apiHostPorts))
+	copy(out, m.apiHostPorts)
+	return out
+}
+
+// SelectMongoHostPort returns the best hostport for the machine for
+// MongoDB use, perhaps using the space provided.
+func (m *machineTracker) SelectMongoHostPort(mongoSpace network.SpaceName) string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if mongoSpace != "" {
+		return mongo.SelectPeerHostPortBySpace(m.mongoHostPorts, mongoSpace)
+	}
+	return mongo.SelectPeerHostPort(m.mongoHostPorts)
+}
+
+func (m *machineTracker) String() string {
+	return m.Id()
+}
+
+func (m *machineTracker) GoString() string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	return fmt.Sprintf("&peergrouper.machine{id: %q, wantsVote: %v, hostPorts: %v}",
+		m.id, m.wantsVote, m.mongoHostPorts)
+}
+
+func (m *machineTracker) loop() error {
+	watcher := m.stm.Watch()
+	if err := m.catacomb.Add(watcher); err != nil {
+		return errors.Trace(err)
+	}
+
+	var notifyCh chan struct{}
+	for {
+		select {
+		case <-m.catacomb.Dying():
+			return m.catacomb.ErrDying()
+		case _, ok := <-watcher.Changes():
+			if !ok {
+				return watcher.Err()
+			}
+			changed, err := m.hasChanged()
+			if err != nil {
+				return errors.Trace(err)
+			}
+			if changed {
+				notifyCh = m.notifyCh
+			}
+		case notifyCh <- struct{}{}:
+			notifyCh = nil
+		}
+	}
+}
+
+func (m *machineTracker) hasChanged() (bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if err := m.stm.Refresh(); err != nil {
+		if errors.IsNotFound(err) {
+			// We want to be robust when the machine
+			// state is out of date with respect to the
+			// controller info, so if the machine
+			// has been removed, just assume that
+			// no change has happened - the machine
+			// loop will be stopped very soon anyway.
+			return false, nil
+		}
+		return false, errors.Trace(err)
+	}
+	changed := false
+	if wantsVote := m.stm.WantsVote(); wantsVote != m.wantsVote {
+		m.wantsVote = wantsVote
+		changed = true
+	}
+	if hps := m.stm.MongoHostPorts(); !hostPortsEqual(hps, m.mongoHostPorts) {
+		m.mongoHostPorts = hps
+		changed = true
+	}
+	if hps := m.stm.APIHostPorts(); !hostPortsEqual(hps, m.apiHostPorts) {
+		m.apiHostPorts = hps
+		changed = true
+	}
+	return changed, nil
+}
+
+func hostPortsEqual(hps1, hps2 []network.HostPort) bool {
+	if len(hps1) != len(hps2) {
+		return false
+	}
+	for i := range hps1 {
+		if hps1[i] != hps2[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/worker/peergrouper/worker_test.go
+++ b/worker/peergrouper/worker_test.go
@@ -578,10 +578,6 @@ func (s *workerSuite) TestMongoSpaceNotOverwritten(c *gc.C) {
 		st.SetMongoSpaceState(state.MongoSpaceUnknown)
 		st.SetOrGetMongoSpaceName("testing")
 
-		// Manually run getMongoSpace - it should do nothing because we already have
-		// a space. If it did re-calculate the space name it will change back to "one".
-		w.getMongoSpace(&peerGroupInfo{})
-
 		// Only space one has all three servers in it
 		c.Assert(st.getMongoSpaceName(), gc.Equals, "testing")
 		c.Assert(st.getMongoSpaceState(), gc.Equals, state.MongoSpaceValid)


### PR DESCRIPTION
This change reworks the peergrouper to make it clearer and eliminate a number of possible data races .
The highlights:

1. The peergrouper now uses a catacomb to manage it's lifetime and that of the watchers it uses and its helper goroutines. All helper goroutines have been converted into workers.

2. The technique of passing of methods with unexpected side-effects between goroutines has been eliminated. Ownership of data between goroutines is now clear. 

3. Access to the machineTracker (formally "machine") data is now protected by a mutex. Previously fields were accessed directly from many places (and goroutines!).

4. Program state that was being stored unnecessarily has been removed (a potential source of future bugs).

5. Many clean ups of poor/risky programming practices (unnecessary side-effects, unclear structures etc).

These changes *may* resolve LP #1453805.



(Review request: http://reviews.vapour.ws/r/4636/)