### PR TITLE
Fixed lp:1567676: Cannot set observed machine network config from windows

### DIFF
--- a/state/ipaddresses_test.go
+++ b/state/ipaddresses_test.go
@@ -327,14 +327,6 @@ func (s *ipAddressesStateSuite) TestSetDevicesAddressesFailsWithEmptyDeviceName(
 	s.assertSetDevicesAddressesFailsValidationForArgs(c, args, "empty DeviceName not valid")
 }
 
-func (s *ipAddressesStateSuite) TestSetDevicesAddressesFailsWithInvalidDeviceName(c *gc.C) {
-	args := state.LinkLayerDeviceAddress{
-		CIDRAddress: "0.1.2.3/24",
-		DeviceName:  "bad#name",
-	}
-	s.assertSetDevicesAddressesFailsValidationForArgs(c, args, `DeviceName "bad#name" not valid`)
-}
-
 func (s *ipAddressesStateSuite) TestSetDevicesAddressesFailsWithUnknownDeviceName(c *gc.C) {
 	args := state.LinkLayerDeviceAddress{
 		CIDRAddress:  "0.1.2.3/24",
@@ -393,6 +385,17 @@ func (s *ipAddressesStateSuite) TestSetDevicesAddressesOKWhenCIDRAddressDoesNotM
 	c.Assert(err, jc.ErrorIsNil)
 
 	assertDeviceHasOneAddressWithSubnetCIDREquals("192.168.0.0/16")
+}
+
+func (s *ipAddressesStateSuite) TestSetDevicesAddressesIgnoresInvalidDeviceNames(c *gc.C) {
+	s.addNamedDevice(c, "bad#name")
+	args := state.LinkLayerDeviceAddress{
+		CIDRAddress:  "0.1.2.3/24",
+		DeviceName:   "bad#name",
+		ConfigMethod: state.StaticAddress,
+	}
+	err := s.machine.SetDevicesAddresses(args)
+	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *ipAddressesStateSuite) TestSetDevicesAddressesFailsWhenCIDRAddressMatchesDeadSubnet(c *gc.C) {

--- a/state/ipaddresses_test.go
+++ b/state/ipaddresses_test.go
@@ -387,17 +387,6 @@ func (s *ipAddressesStateSuite) TestSetDevicesAddressesOKWhenCIDRAddressDoesNotM
 	assertDeviceHasOneAddressWithSubnetCIDREquals("192.168.0.0/16")
 }
 
-func (s *ipAddressesStateSuite) TestSetDevicesAddressesAllowsInvalidDeviceNames(c *gc.C) {
-	s.addNamedDevice(c, "invalid#name")
-	args := state.LinkLayerDeviceAddress{
-		CIDRAddress:  "0.1.2.3/24",
-		DeviceName:   "invalid#name",
-		ConfigMethod: state.StaticAddress,
-	}
-	err := s.machine.SetDevicesAddresses(args)
-	c.Assert(err, jc.ErrorIsNil)
-}
-
 func (s *ipAddressesStateSuite) TestSetDevicesAddressesFailsWhenCIDRAddressMatchesDeadSubnet(c *gc.C) {
 	s.addNamedDevice(c, "eth0")
 	subnetCIDR := "10.20.0.0/16"

--- a/state/ipaddresses_test.go
+++ b/state/ipaddresses_test.go
@@ -387,11 +387,11 @@ func (s *ipAddressesStateSuite) TestSetDevicesAddressesOKWhenCIDRAddressDoesNotM
 	assertDeviceHasOneAddressWithSubnetCIDREquals("192.168.0.0/16")
 }
 
-func (s *ipAddressesStateSuite) TestSetDevicesAddressesIgnoresInvalidDeviceNames(c *gc.C) {
-	s.addNamedDevice(c, "bad#name")
+func (s *ipAddressesStateSuite) TestSetDevicesAddressesAllowsInvalidDeviceNames(c *gc.C) {
+	s.addNamedDevice(c, "invalid#name")
 	args := state.LinkLayerDeviceAddress{
 		CIDRAddress:  "0.1.2.3/24",
-		DeviceName:   "bad#name",
+		DeviceName:   "invalid#name",
 		ConfigMethod: state.StaticAddress,
 	}
 	err := s.machine.SetDevicesAddresses(args)

--- a/state/linklayerdevices_test.go
+++ b/state/linklayerdevices_test.go
@@ -71,13 +71,6 @@ func (s *linkLayerDevicesStateSuite) assertSetLinkLayerDevicesFailsForArgs(c *gc
 	return err
 }
 
-func (s *linkLayerDevicesStateSuite) TestSetLinkLayerDevicesInvalidName(c *gc.C) {
-	args := state.LinkLayerDeviceArgs{
-		Name: "bad#name",
-	}
-	s.assertSetLinkLayerDevicesReturnsNotValidError(c, args, `Name "bad#name" not valid`)
-}
-
 func (s *linkLayerDevicesStateSuite) TestSetLinkLayerDevicesSameNameAndParentName(c *gc.C) {
 	args := state.LinkLayerDeviceArgs{
 		Name:       "foo",
@@ -92,15 +85,6 @@ func (s *linkLayerDevicesStateSuite) TestSetLinkLayerDevicesInvalidType(c *gc.C)
 		Type: "bad type",
 	}
 	s.assertSetLinkLayerDevicesReturnsNotValidError(c, args, `Type "bad type" not valid`)
-}
-
-func (s *linkLayerDevicesStateSuite) TestSetLinkLayerDevicesInvalidParentName(c *gc.C) {
-	var wayTooLongName = strings.Repeat("x", 256)
-	args := state.LinkLayerDeviceArgs{
-		Name:       "eth0",
-		ParentName: wayTooLongName,
-	}
-	s.assertSetLinkLayerDevicesReturnsNotValidError(c, args, `ParentName "x{256}" not valid`)
 }
 
 func (s *linkLayerDevicesStateSuite) TestSetLinkLayerDevicesParentNameAsInvalidGlobalKey(c *gc.C) {
@@ -1010,4 +994,24 @@ func (s *linkLayerDevicesStateSuite) TestSetContainerLinkLayerDevices(c *gc.C) {
 		c.Check(containerDevice.IsAutoStart(), jc.IsTrue)
 		c.Check(containerDevice.ParentName(), gc.Matches, `m#0#d#br-bond0(|\.12|\.34)`)
 	}
+}
+
+func (s *linkLayerDevicesStateSuite) TestSetLinkLayerDevicesIgnoresInvalidName(c *gc.C) {
+	args := state.LinkLayerDeviceArgs{
+		Name: "bad#name",
+		Type: state.EthernetDevice,
+	}
+	s.assertSetLinkLayerDevicesSucceedsAndResultMatchesArgs(c, args)
+}
+
+func (s *linkLayerDevicesStateSuite) TestSetLinkLayerDevicesIgnoresInvalidParentName(c *gc.C) {
+	var wayTooLongName = strings.Repeat("x", 256)
+	s.addNamedDevice(c, wayTooLongName)
+
+	args := state.LinkLayerDeviceArgs{
+		Name:       "eth0.42",
+		Type:       state.VLAN_8021QDevice,
+		ParentName: wayTooLongName,
+	}
+	s.assertSetLinkLayerDevicesSucceedsAndResultMatchesArgs(c, args)
 }

--- a/state/linklayerdevices_test.go
+++ b/state/linklayerdevices_test.go
@@ -6,7 +6,6 @@ package state_test
 import (
 	"fmt"
 	"strconv"
-	"strings"
 
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
@@ -994,27 +993,4 @@ func (s *linkLayerDevicesStateSuite) TestSetContainerLinkLayerDevices(c *gc.C) {
 		c.Check(containerDevice.IsAutoStart(), jc.IsTrue)
 		c.Check(containerDevice.ParentName(), gc.Matches, `m#0#d#br-bond0(|\.12|\.34)`)
 	}
-}
-
-func (s *linkLayerDevicesStateSuite) TestSetLinkLayerDevicesAllowsInvalidName(c *gc.C) {
-	args := state.LinkLayerDeviceArgs{
-		Name: "invalid#name",
-		Type: state.EthernetDevice,
-	}
-	s.assertSetLinkLayerDevicesSucceedsAndResultMatchesArgs(c, args)
-}
-
-func (s *linkLayerDevicesStateSuite) TestSetLinkLayerDevicesAllowsInvalidParentName(c *gc.C) {
-	// Windows interface names can contain spaces and be up to 256
-	// (MAX_ADAPTER_NAME_LENGTH) characters long.
-	// Source: http://bit.ly/1pdNNbp
-	var veryLongName = strings.Repeat("x", 500)
-	s.addNamedDevice(c, veryLongName)
-
-	args := state.LinkLayerDeviceArgs{
-		Name:       "eth0.42",
-		Type:       state.VLAN_8021QDevice,
-		ParentName: veryLongName,
-	}
-	s.assertSetLinkLayerDevicesSucceedsAndResultMatchesArgs(c, args)
 }

--- a/state/linklayerdevices_test.go
+++ b/state/linklayerdevices_test.go
@@ -996,22 +996,25 @@ func (s *linkLayerDevicesStateSuite) TestSetContainerLinkLayerDevices(c *gc.C) {
 	}
 }
 
-func (s *linkLayerDevicesStateSuite) TestSetLinkLayerDevicesIgnoresInvalidName(c *gc.C) {
+func (s *linkLayerDevicesStateSuite) TestSetLinkLayerDevicesAllowsInvalidName(c *gc.C) {
 	args := state.LinkLayerDeviceArgs{
-		Name: "bad#name",
+		Name: "invalid#name",
 		Type: state.EthernetDevice,
 	}
 	s.assertSetLinkLayerDevicesSucceedsAndResultMatchesArgs(c, args)
 }
 
-func (s *linkLayerDevicesStateSuite) TestSetLinkLayerDevicesIgnoresInvalidParentName(c *gc.C) {
-	var wayTooLongName = strings.Repeat("x", 256)
-	s.addNamedDevice(c, wayTooLongName)
+func (s *linkLayerDevicesStateSuite) TestSetLinkLayerDevicesAllowsInvalidParentName(c *gc.C) {
+	// Windows interface names can contain spaces and be up to 256
+	// (MAX_ADAPTER_NAME_LENGTH) characters long.
+	// Source: http://bit.ly/1pdNNbp
+	var veryLongName = strings.Repeat("x", 500)
+	s.addNamedDevice(c, veryLongName)
 
 	args := state.LinkLayerDeviceArgs{
 		Name:       "eth0.42",
 		Type:       state.VLAN_8021QDevice,
-		ParentName: wayTooLongName,
+		ParentName: veryLongName,
 	}
 	s.assertSetLinkLayerDevicesSucceedsAndResultMatchesArgs(c, args)
 }

--- a/state/machine_linklayerdevices.go
+++ b/state/machine_linklayerdevices.go
@@ -266,7 +266,10 @@ func (m *Machine) validateSetLinkLayerDeviceArgs(args *LinkLayerDeviceArgs) erro
 		return errors.NotValidf("empty Name")
 	}
 	if !IsValidLinkLayerDeviceName(args.Name) {
-		return errors.NotValidf("Name %q", args.Name)
+		logger.Warningf(
+			"link-layer device %q on machine %q has invalid name (using anyway)",
+			args.Name, m.Id(),
+		)
 	}
 
 	if args.ParentName != "" {
@@ -353,7 +356,10 @@ func (m *Machine) verifyHostMachineParentDeviceExistsAndIsABridgeDevice(hostMach
 
 func (m *Machine) validateParentDeviceNameWhenNotAGlobalKey(args *LinkLayerDeviceArgs) error {
 	if !IsValidLinkLayerDeviceName(args.ParentName) {
-		return errors.NotValidf("ParentName %q", args.ParentName)
+		logger.Warningf(
+			"parent link-layer device %q on machine %q has invalid name (using anyway)",
+			args.ParentName, m.Id(),
+		)
 	}
 	if args.Name == args.ParentName {
 		return errors.NewNotValid(nil, "Name and ParentName must be different")
@@ -638,7 +644,10 @@ func (m *Machine) validateSetDevicesAddressesArgs(args *LinkLayerDeviceAddress) 
 		return errors.NotValidf("empty DeviceName")
 	}
 	if !IsValidLinkLayerDeviceName(args.DeviceName) {
-		return errors.NotValidf("DeviceName %q", args.DeviceName)
+		logger.Warningf(
+			"address %q on machine %q has invalid device name %q (using anyway)",
+			args.CIDRAddress, m.Id(), args.DeviceName,
+		)
 	}
 	if err := m.verifyDeviceAlreadyExists(args.DeviceName); err != nil {
 		return errors.Trace(err)


### PR DESCRIPTION
Link-layer device names are still validated, but now invalid names (e.g. coming
to the Ubuntu controller from a Windows machine) are allowed and logged as a
warning only.

The requirement for valid device names was too strict to begin with, and since
the name is used verbatim anyway I don't expect any issues with this change.

See http://pad.lv/1567676 for more info.

(Review request: http://reviews.vapour.ws/r/4639/)