### PR TITLE
Fix InstanceConfig.SetTools usage

### DIFF
--- a/apiserver/client/instanceconfig_test.go
+++ b/apiserver/client/instanceconfig_test.go
@@ -57,9 +57,9 @@ func (s *machineConfigSuite) TestMachineConfig(c *gc.C) {
 	c.Check(instanceConfig.MongoInfo.Addrs, gc.DeepEquals, mongoAddrs)
 	c.Check(instanceConfig.APIInfo.Addrs, gc.DeepEquals, apiAddrs)
 	toolsURL := fmt.Sprintf("https://%s/model/%s/tools/%s",
-		apiAddrs[0], jujutesting.ModelTag.Id(), instanceConfig.ToolsInfo().Version)
+		apiAddrs[0], jujutesting.ModelTag.Id(), instanceConfig.AgentVersion())
 	c.Assert(instanceConfig.ToolsList().URLs(), jc.DeepEquals, map[version.Binary][]string{
-		instanceConfig.ToolsInfo().Version: []string{toolsURL},
+		instanceConfig.AgentVersion(): []string{toolsURL},
 	})
 	//c.Assert(instanceConfig.ToolsList()[0].URL, gc.Equals, toolsURL)
 	c.Assert(instanceConfig.AgentEnvironment[agent.AllowsSecureConnection], gc.Equals, "true")

--- a/cloudconfig/instancecfg/instancecfg.go
+++ b/cloudconfig/instancecfg/instancecfg.go
@@ -327,6 +327,11 @@ func (cfg *InstanceConfig) ToolsList() coretools.List {
 // SetTools sets the tools that should be tried when provisioning this
 // instance. There must be at least one. Other than the URL, each item
 // must be the same.
+//
+// TODO(axw) 2016-04-19 lp:1572116
+// SetTools should verify that the tools have URLs, since they will
+// be needed for downloading on the instance. We can't do that until
+// all usage-sites are updated to pass through non-empty URLs.
 func (cfg *InstanceConfig) SetTools(toolsList coretools.List) error {
 	if len(toolsList) == 0 {
 		return errors.New("need at least 1 tools")

--- a/cloudconfig/instancecfg/instancecfg_test.go
+++ b/cloudconfig/instancecfg/instancecfg_test.go
@@ -53,6 +53,21 @@ func testInstanceTags(c *gc.C, cfg *config.Config, jobs []multiwatcher.MachineJo
 	c.Assert(tags, jc.DeepEquals, expectTags)
 }
 
+func (*instancecfgSuite) TestAgentVersionZero(c *gc.C) {
+	var icfg instancecfg.InstanceConfig
+	c.Assert(icfg.AgentVersion(), gc.Equals, version.Binary{})
+}
+
+func (*instancecfgSuite) TestAgentVersion(c *gc.C) {
+	var icfg instancecfg.InstanceConfig
+	list := coretools.List{
+		&coretools.Tools{Version: version.MustParseBinary("2.3.4-trusty-amd64")},
+	}
+	err := icfg.SetTools(list)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(icfg.AgentVersion(), gc.Equals, list[0].Version)
+}
+
 func (*instancecfgSuite) TestSetToolsSameVersions(c *gc.C) {
 	var icfg instancecfg.InstanceConfig
 	list := coretools.List{

--- a/cloudconfig/instancecfg/instancecfg_test.go
+++ b/cloudconfig/instancecfg/instancecfg_test.go
@@ -53,6 +53,28 @@ func testInstanceTags(c *gc.C, cfg *config.Config, jobs []multiwatcher.MachineJo
 	c.Assert(tags, jc.DeepEquals, expectTags)
 }
 
+func (*instancecfgSuite) TestSetToolsSameVersions(c *gc.C) {
+	var icfg instancecfg.InstanceConfig
+	list := coretools.List{
+		&coretools.Tools{Version: version.MustParseBinary("2.3.4-trusty-amd64")},
+		&coretools.Tools{Version: version.MustParseBinary("2.3.4-trusty-amd64")},
+	}
+	err := icfg.SetTools(list)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(icfg.ToolsList(), jc.DeepEquals, list)
+}
+
+func (*instancecfgSuite) TestSetToolsDifferentVersions(c *gc.C) {
+	var icfg instancecfg.InstanceConfig
+	list := coretools.List{
+		&coretools.Tools{Version: version.MustParseBinary("2.3.4-trusty-amd64")},
+		&coretools.Tools{Version: version.MustParseBinary("2.3.5-trusty-amd64")},
+	}
+	err := icfg.SetTools(list)
+	c.Assert(err, gc.ErrorMatches, `tools info mismatch.*2\.3\.4.*2\.3\.5.*`)
+	c.Assert(icfg.ToolsList(), gc.HasLen, 0)
+}
+
 func (*instancecfgSuite) TestJujuTools(c *gc.C) {
 	icfg := &instancecfg.InstanceConfig{
 		DataDir: "/path/to/datadir/",

--- a/cloudconfig/userdatacfg.go
+++ b/cloudconfig/userdatacfg.go
@@ -83,7 +83,7 @@ type baseConfigure struct {
 // addAgentInfo adds agent-required information to the agent's directory
 // and returns the agent directory name.
 func (c *baseConfigure) addAgentInfo(tag names.Tag) (agent.Config, error) {
-	acfg, err := c.icfg.AgentConfig(tag, c.icfg.ToolsInfo().Version.Number)
+	acfg, err := c.icfg.AgentConfig(tag, c.icfg.AgentVersion().Number)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -171,14 +171,14 @@ func (c *baseConfigure) toolsSymlinkCommand(toolsDir string) string {
 		return fmt.Sprintf(
 			`cmd.exe /C mklink /D %s %v`,
 			c.conf.ShellRenderer().FromSlash(toolsDir),
-			c.icfg.ToolsInfo().Version,
+			c.icfg.AgentVersion(),
 		)
 	default:
 		// TODO(dfc) ln -nfs, so it doesn't fail if for some reason that
 		// the target already exists.
 		return fmt.Sprintf(
 			"ln -s %v %s",
-			c.icfg.ToolsInfo().Version,
+			c.icfg.AgentVersion(),
 			shquote(toolsDir),
 		)
 	}

--- a/cloudconfig/userdatacfg_win.go
+++ b/cloudconfig/userdatacfg_win.go
@@ -119,10 +119,9 @@ func (w *windowsConfigure) ConfigureJuju() error {
 
 	w.conf.AddScripts(
 		`$dToolsHash = Get-FileSHA256 -FilePath "$binDir\tools.tar.gz"`,
-		fmt.Sprintf(`$dToolsHash > "$binDir\juju%s.sha256"`,
-			w.icfg.ToolsInfo().Version),
+		fmt.Sprintf(`$dToolsHash > "$binDir\juju%s.sha256"`, tools.Version),
 		fmt.Sprintf(`if ($dToolsHash.ToLower() -ne "%s"){ Throw "Tools checksum mismatch"}`,
-			w.icfg.ToolsInfo().SHA256),
+			tools.SHA256),
 		fmt.Sprintf(`GUnZip-File -infile $binDir\tools.tar.gz -outdir $binDir`),
 		`rm "$binDir\tools.tar*"`,
 		fmt.Sprintf(`Set-Content $binDir\downloaded-tools.txt '%s'`, string(toolsJson)),

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -359,9 +359,9 @@ func (s *BootstrapSuite) run(c *gc.C, test bootstrapTest) testing.Restorer {
 
 	opFinalizeBootstrap := (<-opc).(dummy.OpFinalizeBootstrap)
 	c.Check(opFinalizeBootstrap.Env, gc.Equals, "admin")
-	c.Check(opFinalizeBootstrap.InstanceConfig.ToolsInfo(), gc.NotNil)
+	c.Check(opFinalizeBootstrap.InstanceConfig.ToolsList(), gc.Not(gc.HasLen), 0)
 	if test.upload != "" {
-		c.Check(opFinalizeBootstrap.InstanceConfig.ToolsInfo().Version.String(), gc.Equals, test.upload)
+		c.Check(opFinalizeBootstrap.InstanceConfig.AgentVersion().String(), gc.Equals, test.upload)
 	}
 
 	expectedBootstrappedControllerName := bootstrappedControllerName(controllerName)
@@ -913,7 +913,7 @@ func (s *BootstrapSuite) TestAutoUploadAfterFailedSync(c *gc.C) {
 	c.Check((<-opc).(dummy.OpBootstrap).Env, gc.Equals, "admin")
 	icfg := (<-opc).(dummy.OpFinalizeBootstrap).InstanceConfig
 	c.Assert(icfg, gc.NotNil)
-	c.Assert(icfg.ToolsInfo().Version.String(), gc.Equals, "1.7.3.1-raring-"+arch.HostArch())
+	c.Assert(icfg.AgentVersion().String(), gc.Equals, "1.7.3.1-raring-"+arch.HostArch())
 }
 
 func (s *BootstrapSuite) TestAutoUploadOnlyForDev(c *gc.C) {

--- a/provider/azure/environ.go
+++ b/provider/azure/environ.go
@@ -40,6 +40,7 @@ import (
 	"github.com/juju/juju/provider/common"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/multiwatcher"
+	"github.com/juju/juju/tools"
 )
 
 const jujuMachineNameTag = tags.JujuTagPrefix + "machine-name"
@@ -399,18 +400,6 @@ func (env *azureEnviron) StartInstance(args environs.StartInstanceParams) (*envi
 		return nil, errors.New("starting instances with networks is not supported yet")
 	}
 
-	err := instancecfg.FinishInstanceConfig(args.InstanceConfig, env.Config())
-	if err != nil {
-		return nil, err
-	}
-
-	// Pick envtools.  Needed for the custom data (which is what we normally
-	// call userdata).
-	if err := args.InstanceConfig.SetTools(args.Tools); err != nil {
-		return nil, errors.Trace(err)
-	}
-	logger.Infof("picked tools %q", args.InstanceConfig.ToolsInfo().Version)
-
 	// Get the required configuration and config-dependent information
 	// required to create the instance. We take the lock just once, to
 	// ensure we obtain all information based on the same configuration.
@@ -452,6 +441,26 @@ func (env *azureEnviron) StartInstance(args environs.StartInstanceParams) (*envi
 		imageStream,
 	)
 	if err != nil {
+		return nil, err
+	}
+
+	// Pick tools by filtering the available tools down to the architecture of
+	// the image that will be provisioned.
+	selectedTools, err := args.Tools.Match(tools.Filter{
+		Arch: instanceSpec.Image.Arch,
+	})
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	logger.Infof("picked tools %q", selectedTools[0].Version)
+
+	// Finalize the instance config, which we'll render to CustomData below.
+	if err := args.InstanceConfig.SetTools(selectedTools); err != nil {
+		return nil, errors.Trace(err)
+	}
+	if err := instancecfg.FinishInstanceConfig(
+		args.InstanceConfig, env.Config(),
+	); err != nil {
 		return nil, err
 	}
 

--- a/provider/gce/environ_broker_test.go
+++ b/provider/gce/environ_broker_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/utils/arch"
 	jujuos "github.com/juju/utils/os"
 	"github.com/juju/utils/series"
+	"github.com/juju/version"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/params"
@@ -135,7 +136,7 @@ func (s *environBrokerSuite) TestFinishInstanceConfig(c *gc.C) {
 	err := gce.FinishInstanceConfig(s.Env, s.StartInstArgs, s.spec)
 
 	c.Assert(err, jc.ErrorIsNil)
-	c.Check(s.StartInstArgs.InstanceConfig.ToolsInfo(), gc.NotNil)
+	c.Check(s.StartInstArgs.InstanceConfig.AgentVersion(), gc.Not(gc.Equals), version.Binary{})
 }
 
 func (s *environBrokerSuite) TestBuildInstanceSpec(c *gc.C) {

--- a/provider/lxd/environ_broker_test.go
+++ b/provider/lxd/environ_broker_test.go
@@ -35,7 +35,7 @@ func (s *environBrokerSuite) TestStartInstance(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(result.Instance, gc.DeepEquals, s.Instance)
 	c.Check(result.Hardware, gc.DeepEquals, s.HWC)
-	c.Assert(s.StartInstArgs.InstanceConfig.ToolsInfo().Version.Arch, gc.Equals, arch.ARM64)
+	c.Assert(s.StartInstArgs.InstanceConfig.AgentVersion().Arch, gc.Equals, arch.ARM64)
 }
 
 func (s *environBrokerSuite) TestStartInstanceNoTools(c *gc.C) {

--- a/provider/vsphere/environ_broker_test.go
+++ b/provider/vsphere/environ_broker_test.go
@@ -119,7 +119,7 @@ func (s *environBrokerSuite) TestStartInstanceFilterToolByArch(c *gc.C) {
 
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(*res.Hardware.Arch, gc.Equals, arch.AMD64)
-	c.Assert(startInstArgs.InstanceConfig.ToolsInfo().Version.Arch, gc.Equals, arch.AMD64)
+	c.Assert(startInstArgs.InstanceConfig.AgentVersion().Arch, gc.Equals, arch.AMD64)
 }
 
 func (s *environBrokerSuite) TestStartInstanceDefaultConstraintsApplied(c *gc.C) {

--- a/worker/provisioner/lxc-broker_test.go
+++ b/worker/provisioner/lxc-broker_test.go
@@ -307,7 +307,7 @@ func (s *lxcBrokerSuite) TestStartInstanceHostArch(c *gc.C) {
 		StatusCallback: callback,
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(instanceConfig.ToolsInfo().Version.Arch, gc.Equals, arch.PPC64EL)
+	c.Assert(instanceConfig.AgentVersion().Arch, gc.Equals, arch.PPC64EL)
 }
 
 func (s *lxcBrokerSuite) TestStartInstanceToolsArchNotFound(c *gc.C) {


### PR DESCRIPTION
InstanceConfig.SetTools was being strict about requiring tools
to have URLs, which is not the case when using --upload-tools.
It may be worth revisiting this later, but for now we revert
to not checking the URLs.

Also, fix the Azure provider to filter tools by the chosen
architecture. It was working by luck previously because the
first item in the tools list would always be amd64. If we don't
filter, then SetTools rightly throws an error because there are
multiple tools with differing architectures.

Fixes https://bugs.launchpad.net/juju-core/+bug/1571832

(Review request: http://reviews.vapour.ws/r/4640/)