### PR TITLE
Fixed lp:1564397 - do not rm /e/n/if-up.d/ntpdate

### DIFF
--- a/provider/maas/add-juju-bridge.py
+++ b/provider/maas/add-juju-bridge.py
@@ -357,7 +357,6 @@ def main(args):
     print("**** Original configuration")
     print_shell_cmd("cat {}".format(args.filename))
     print_shell_cmd("ifconfig -a")
-    print_shell_cmd("rm /etc/network/if-up.d/ntpdate")
     print_shell_cmd("ifdown --exclude=lo --interfaces={} {}".format(args.filename, ifquery))
 
     print("**** Activating new configuration")

--- a/provider/maas/bridgescript.go
+++ b/provider/maas/bridgescript.go
@@ -369,7 +369,6 @@ def main(args):
     print("**** Original configuration")
     print_shell_cmd("cat {}".format(args.filename))
     print_shell_cmd("ifconfig -a")
-    print_shell_cmd("rm /etc/network/if-up.d/ntpdate")
     print_shell_cmd("ifdown --exclude=lo --interfaces={} {}".format(args.filename, ifquery))
 
     print("**** Activating new configuration")


### PR DESCRIPTION
See http://pad.lv/1564397 for more info.
Live tested on MAAS 1.9.1 with both trusty and xenial machines / lxd containers.

(Review request: http://reviews.vapour.ws/r/4641/)