### PR TITLE
Fix bug 1566130 awaiting error resolution for "install" hook

### DIFF
--- a/worker/uniter/uniter.go
+++ b/worker/uniter/uniter.go
@@ -325,7 +325,10 @@ func (u *Uniter) loop(unitTag names.UnitTag) (err error) {
 			case resolver.ErrTerminate:
 				err = u.terminate()
 			case resolver.ErrRestart:
+				// make sure we update the two values used above in
+				// creating LocalState.
 				charmURL = localState.CharmURL
+				charmModifiedVersion = localState.CharmModifiedVersion
 				// leave err assigned, causing loop to break
 			default:
 				// We need to set conflicted from here, because error


### PR DESCRIPTION
We need to copy  the charmURL and charmModifiedVersion here, since these values will be used in the next run of the loop.

Fixes https://bugs.launchpad.net/juju-core/+bug/1566130

(Review request: http://reviews.vapour.ws/r/4645/)