### PR TITLE
cloudconfig: honour full tools list

### DIFF
--- a/cloudconfig/powershell_helpers.go
+++ b/cloudconfig/powershell_helpers.go
@@ -471,6 +471,27 @@ function ExecRetry($command, $retryInterval = 15)
 	$ErrorActionPreference = $currErrorActionPreference
 }
 
+function TryExecAll($commands)
+{
+	$currErrorActionPreference = $ErrorActionPreference
+	$ErrorActionPreference = "Continue"
+
+	foreach ($command in $commands)
+	{
+		try
+		{
+			& $command
+			break
+		}
+		catch [System.Exception]
+		{
+			Write-Error $_.Exception
+		}
+	}
+
+	$ErrorActionPreference = $currErrorActionPreference
+}
+
 Function GUnZip-File{
     Param(
         $infile,

--- a/cloudconfig/powershell_helpers.go
+++ b/cloudconfig/powershell_helpers.go
@@ -471,6 +471,9 @@ function ExecRetry($command, $retryInterval = 15)
 	$ErrorActionPreference = $currErrorActionPreference
 }
 
+# TryExecAll attempts all of the commands in the supplied array until
+# one can be executed without throwing an exception. If none of the
+# commands succeeds, an exception will be raised.
 function TryExecAll($commands)
 {
 	$currErrorActionPreference = $ErrorActionPreference
@@ -481,7 +484,8 @@ function TryExecAll($commands)
 		try
 		{
 			& $command
-			break
+			$ErrorActionPreference = $currErrorActionPreference
+			return
 		}
 		catch [System.Exception]
 		{
@@ -490,6 +494,7 @@ function TryExecAll($commands)
 	}
 
 	$ErrorActionPreference = $currErrorActionPreference
+	throw "All commands failed"
 }
 
 Function GUnZip-File{

--- a/cloudconfig/userdatacfg_test.go
+++ b/cloudconfig/userdatacfg_test.go
@@ -131,6 +131,23 @@ func makeTestConfig(series string, bootstrap bool) *testInstanceConfig {
 	cfg.setSeries(series)
 	if bootstrap {
 		return cfg.setController()
+	} else {
+		// Non-controller machines fetch their tools from
+		// the controller.
+		icfg := (*instancecfg.InstanceConfig)(cfg)
+		toolsList := icfg.ToolsList()
+		for i, tools := range toolsList {
+			tools.URL = fmt.Sprintf(
+				"https://%s/%s/tools/%s",
+				cfg.APIInfo.Addrs[0],
+				testing.ModelTag.Id(),
+				tools.Version,
+			)
+			toolsList[i] = tools
+		}
+		if err := icfg.SetTools(toolsList); err != nil {
+			panic(err)
+		}
 	}
 
 	return cfg
@@ -375,11 +392,11 @@ chown syslog:adm /var/log/juju
 bin='/var/lib/juju/tools/1\.2\.3-quantal-amd64'
 mkdir -p \$bin
 echo 'Fetching tools.*
-curl .* --noproxy "\*" --insecure -o \$bin/tools\.tar\.gz 'https://state-addr\.testing\.invalid:54321/tools/1\.2\.3-quantal-amd64'
+curl .* --noproxy "\*" --insecure -o \$bin/tools\.tar\.gz 'https://state-addr\.testing\.invalid:54321/deadbeef-0bad-400d-8000-4b1d0d06f00d/tools/1\.2\.3-quantal-amd64'
 sha256sum \$bin/tools\.tar\.gz > \$bin/juju1\.2\.3-quantal-amd64\.sha256
 grep '1234' \$bin/juju1\.2\.3-quantal-amd64.sha256 \|\| \(echo "Tools checksum mismatch"; exit 1\)
 tar zxf \$bin/tools.tar.gz -C \$bin
-printf %s '{"version":"1\.2\.3-quantal-amd64","url":"http://foo\.com/tools/released/juju1\.2\.3-quantal-amd64\.tgz","sha256":"1234","size":10}' > \$bin/downloaded-tools\.txt
+printf %s '{"version":"1\.2\.3-quantal-amd64","url":"https://state-addr\.testing\.invalid:54321/deadbeef-0bad-400d-8000-4b1d0d06f00d/tools/1\.2\.3-quantal-amd64","sha256":"1234","size":10}' > \$bin/downloaded-tools\.txt
 mkdir -p '/var/lib/juju/agents/machine-99'
 cat > '/var/lib/juju/agents/machine-99/agent\.conf' << 'EOF'\\n.*\\nEOF
 chmod 0600 '/var/lib/juju/agents/machine-99/agent\.conf'
@@ -424,11 +441,11 @@ chown syslog:adm /var/log/juju
 bin='/var/lib/juju/tools/1\.2\.3-quantal-amd64'
 mkdir -p \$bin
 echo 'Fetching tools.*
-curl .* --noproxy "\*" --insecure -o \$bin/tools\.tar\.gz 'https://state-addr\.testing\.invalid:54321/tools/1\.2\.3-quantal-amd64'
+curl .* --noproxy "\*" --insecure -o \$bin/tools\.tar\.gz 'https://state-addr\.testing\.invalid:54321/deadbeef-0bad-400d-8000-4b1d0d06f00d/tools/1\.2\.3-quantal-amd64'
 sha256sum \$bin/tools\.tar\.gz > \$bin/juju1\.2\.3-quantal-amd64\.sha256
 grep '1234' \$bin/juju1\.2\.3-quantal-amd64.sha256 \|\| \(echo "Tools checksum mismatch"; exit 1\)
 tar zxf \$bin/tools.tar.gz -C \$bin
-printf %s '{"version":"1\.2\.3-quantal-amd64","url":"http://foo\.com/tools/released/juju1\.2\.3-quantal-amd64\.tgz","sha256":"1234","size":10}' > \$bin/downloaded-tools\.txt
+printf %s '{"version":"1\.2\.3-quantal-amd64","url":"https://state-addr\.testing\.invalid:54321/deadbeef-0bad-400d-8000-4b1d0d06f00d/tools/1\.2\.3-quantal-amd64","sha256":"1234","size":10}' > \$bin/downloaded-tools\.txt
 mkdir -p '/var/lib/juju/agents/machine-99'
 cat > '/var/lib/juju/agents/machine-99/agent\.conf' << 'EOF'\\n.*\\nEOF
 chmod 0600 '/var/lib/juju/agents/machine-99/agent\.conf'
@@ -474,7 +491,7 @@ start jujud-machine-2-lxc-1
 		}),
 		inexactMatch: true,
 		expectScripts: `
-curl .* --noproxy "\*" --insecure -o \$bin/tools\.tar\.gz 'https://state-addr\.testing\.invalid:54321/tools/1\.2\.3-quantal-amd64'
+curl .* --noproxy "\*" --insecure -o \$bin/tools\.tar\.gz 'https://state-addr\.testing\.invalid:54321/deadbeef-0bad-400d-8000-4b1d0d06f00d/tools/1\.2\.3-quantal-amd64'
 `,
 	},
 

--- a/cloudconfig/userdatacfg_win.go
+++ b/cloudconfig/userdatacfg_win.go
@@ -223,8 +223,9 @@ func addDownloadToolsCmds(ser string, certificate string, toolsList tools.List) 
 		}
 	}
 
-	// Attempt all of the URLs, one after the other. We retry the whole
-	// lot, rather than retrying individually, to avoid one permanently
+	// Attempt all of the URLs, one after the other, until one succeeds.
+	// If all of the URLs fail, we retry the whole lot. We retry in this
+	// way, rather than retrying individually, to avoid one permanently
 	// bad URL from holding up the download.
 	downloadCmds := make([]string, len(toolsList))
 	for i, tools := range toolsList {

--- a/cloudconfig/windows_userdata_test.go
+++ b/cloudconfig/windows_userdata_test.go
@@ -41,6 +41,27 @@ function ExecRetry($command, $retryInterval = 15)
 	$ErrorActionPreference = $currErrorActionPreference
 }
 
+function TryExecAll($commands)
+{
+	$currErrorActionPreference = $ErrorActionPreference
+	$ErrorActionPreference = "Continue"
+
+	foreach ($command in $commands)
+	{
+		try
+		{
+			& $command
+			break
+		}
+		catch [System.Exception]
+		{
+			Write-Error $_.Exception
+		}
+	}
+
+	$ErrorActionPreference = $currErrorActionPreference
+}
+
 Function GUnZip-File{
     Param(
         $infile,
@@ -664,13 +685,13 @@ mkdir 'C:\Juju\log\juju'
 mkdir $binDir
 $WebClient = New-Object System.Net.WebClient
 [System.Net.ServicePointManager]::ServerCertificateValidationCallback = {$true}
-ExecRetry { $WebClient.DownloadFile('http://foo.com/tools/released/juju1.2.3-win8-amd64.tgz', "$binDir\tools.tar.gz") }
+ExecRetry { TryExecAll @({ $WebClient.DownloadFile('https://state-addr.testing.invalid:54321/deadbeef-0bad-400d-8000-4b1d0d06f00d/tools/1.2.3-win8-amd64', "$binDir\tools.tar.gz"); }) }
 $dToolsHash = Get-FileSHA256 -FilePath "$binDir\tools.tar.gz"
 $dToolsHash > "$binDir\juju1.2.3-win8-amd64.sha256"
 if ($dToolsHash.ToLower() -ne "1234"){ Throw "Tools checksum mismatch"}
 GUnZip-File -infile $binDir\tools.tar.gz -outdir $binDir
 rm "$binDir\tools.tar*"
-Set-Content $binDir\downloaded-tools.txt '{"version":"1.2.3-win8-amd64","url":"http://foo.com/tools/released/juju1.2.3-win8-amd64.tgz","sha256":"1234","size":10}'
+Set-Content $binDir\downloaded-tools.txt '{"version":"1.2.3-win8-amd64","url":"https://state-addr.testing.invalid:54321/deadbeef-0bad-400d-8000-4b1d0d06f00d/tools/1.2.3-win8-amd64","sha256":"1234","size":10}'
 New-Item -Path 'HKLM:\SOFTWARE\juju-core'
 $acl = Get-Acl -Path 'HKLM:\SOFTWARE\juju-core'
 $acl.SetAccessRuleProtection($true, $false)

--- a/cloudconfig/windows_userdata_test.go
+++ b/cloudconfig/windows_userdata_test.go
@@ -41,6 +41,9 @@ function ExecRetry($command, $retryInterval = 15)
 	$ErrorActionPreference = $currErrorActionPreference
 }
 
+# TryExecAll attempts all of the commands in the supplied array until
+# one can be executed without throwing an exception. If none of the
+# commands succeeds, an exception will be raised.
 function TryExecAll($commands)
 {
 	$currErrorActionPreference = $ErrorActionPreference
@@ -51,7 +54,8 @@ function TryExecAll($commands)
 		try
 		{
 			& $command
-			break
+			$ErrorActionPreference = $currErrorActionPreference
+			return
 		}
 		catch [System.Exception]
 		{
@@ -60,6 +64,7 @@ function TryExecAll($commands)
 	}
 
 	$ErrorActionPreference = $currErrorActionPreference
+	throw "All commands failed"
 }
 
 Function GUnZip-File{

--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -87,7 +87,10 @@ func allCollections() collectionSchema {
 
 		// This collection holds a convenient representation of the content of
 		// the simplestreams data source pointing to binaries required by juju.
-		toolsmetadataC: {global: true},
+		//
+		// Tools metadata is per-model, to allow multiple revisions of tools to
+		// be uploaded to different models without affecting other models.
+		toolsmetadataC: {},
 
 		// This collection holds a convenient representation of the content of
 		// the simplestreams data source pointing to Juju GUI archives.

--- a/state/binarystorage/layered.go
+++ b/state/binarystorage/layered.go
@@ -1,0 +1,90 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package binarystorage
+
+import (
+	"io"
+
+	"github.com/juju/errors"
+	"github.com/juju/utils/set"
+)
+
+type layeredStorage []Storage
+
+// NewLayeredStorage wraps multiple Storages such all of their metadata
+// can be listed and fetched. The later entries in the list have lower
+// precedence than the earlier ones. The first entry in the list is always
+// used for mutating operations.
+func NewLayeredStorage(s ...Storage) (Storage, error) {
+	if len(s) <= 1 {
+		return nil, errors.Errorf("expected multiple stores")
+	}
+	return layeredStorage(s), nil
+}
+
+// Add implements Storage.Open.
+//
+// This method operates on the first Storage passed to NewLayeredStorage.
+func (s layeredStorage) Add(r io.Reader, m Metadata) error {
+	return s[0].Add(r, m)
+}
+
+// Open implements Storage.Open.
+//
+// This method calls Open for each Storage passed to NewLayeredStorage in
+// the order given, and returns the first result where the errors does not
+// satisfy errors.IsNotFound.
+func (s layeredStorage) Open(v string) (Metadata, io.ReadCloser, error) {
+	var m Metadata
+	var rc io.ReadCloser
+	var err error
+	for _, s := range s {
+		m, rc, err = s.Open(v)
+		if !errors.IsNotFound(err) {
+			break
+		}
+	}
+	return m, rc, err
+}
+
+// Metadata implements Storage.Metadata.
+//
+// This method calls Metadata for each Storage passed to NewLayeredStorage in
+// the order given, and returns the first result where the errors does not
+// satisfy errors.IsNotFound.
+func (s layeredStorage) Metadata(v string) (Metadata, error) {
+	var m Metadata
+	var err error
+	for _, s := range s {
+		m, err = s.Metadata(v)
+		if !errors.IsNotFound(err) {
+			break
+		}
+	}
+	return m, err
+}
+
+// AllMetadata implements Storage.AllMetadata.
+//
+// This method calls AllMetadata for each Storage passed to NewLayeredStorage
+// in the order given, and accumulates the results. Any results from a Storage
+// that have been returned from a Storage earlier in the list will be ignored.
+func (s layeredStorage) AllMetadata() ([]Metadata, error) {
+	seen := set.NewStrings()
+	var all []Metadata
+	for _, s := range s {
+		sm, err := s.AllMetadata()
+		if err != nil {
+			return nil, err
+		}
+		for _, m := range sm {
+			if seen.Contains(m.Version) {
+				continue
+			}
+			all = append(all, m)
+			seen.Add(m.Version)
+		}
+	}
+	return all, nil
+}

--- a/state/binarystorage/layered.go
+++ b/state/binarystorage/layered.go
@@ -23,7 +23,7 @@ func NewLayeredStorage(s ...Storage) (Storage, error) {
 	return layeredStorage(s), nil
 }
 
-// Add implements Storage.Open.
+// Add implements Storage.Add.
 //
 // This method operates on the first Storage passed to NewLayeredStorage.
 func (s layeredStorage) Add(r io.Reader, m Metadata) error {
@@ -33,7 +33,7 @@ func (s layeredStorage) Add(r io.Reader, m Metadata) error {
 // Open implements Storage.Open.
 //
 // This method calls Open for each Storage passed to NewLayeredStorage in
-// the order given, and returns the first result where the errors does not
+// the order given, and returns the first result where the error does not
 // satisfy errors.IsNotFound.
 func (s layeredStorage) Open(v string) (Metadata, io.ReadCloser, error) {
 	var m Metadata
@@ -51,7 +51,7 @@ func (s layeredStorage) Open(v string) (Metadata, io.ReadCloser, error) {
 // Metadata implements Storage.Metadata.
 //
 // This method calls Metadata for each Storage passed to NewLayeredStorage in
-// the order given, and returns the first result where the errors does not
+// the order given, and returns the first result where the error does not
 // satisfy errors.IsNotFound.
 func (s layeredStorage) Metadata(v string) (Metadata, error) {
 	var m Metadata
@@ -69,7 +69,8 @@ func (s layeredStorage) Metadata(v string) (Metadata, error) {
 //
 // This method calls AllMetadata for each Storage passed to NewLayeredStorage
 // in the order given, and accumulates the results. Any results from a Storage
-// that have been returned from a Storage earlier in the list will be ignored.
+// earlier in the list will take precedence over any others with the same
+// version.
 func (s layeredStorage) AllMetadata() ([]Metadata, error) {
 	seen := set.NewStrings()
 	var all []Metadata

--- a/state/binarystorage/layered_test.go
+++ b/state/binarystorage/layered_test.go
@@ -1,0 +1,184 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package binarystorage_test
+
+import (
+	"io"
+
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/state/binarystorage"
+	coretesting "github.com/juju/juju/testing"
+)
+
+type layeredStorageSuite struct {
+	coretesting.BaseSuite
+	stores []*mockStorage
+	store  binarystorage.Storage
+}
+
+var _ = gc.Suite(&layeredStorageSuite{})
+
+func (s *layeredStorageSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+	s.stores = []*mockStorage{{
+		metadata: []binarystorage.Metadata{{
+			Version: "1.0", Size: 1, SHA256: "foo",
+		}, {
+			Version: "2.0", Size: 2, SHA256: "bar",
+		}},
+	}, {
+		metadata: []binarystorage.Metadata{{
+			Version: "3.0", Size: 3, SHA256: "baz",
+		}, {
+			Version: "1.0", Size: 3, SHA256: "meh",
+		}},
+	}}
+
+	stores := make([]binarystorage.Storage, len(s.stores))
+	for i, store := range s.stores {
+		stores[i] = store
+	}
+	var err error
+	s.store, err = binarystorage.NewLayeredStorage(stores...)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *layeredStorageSuite) TestNewLayeredStorageError(c *gc.C) {
+	_, err := binarystorage.NewLayeredStorage(s.stores[0])
+	c.Assert(err, gc.ErrorMatches, "expected multiple stores")
+}
+
+func (s *layeredStorageSuite) TestAdd(c *gc.C) {
+	r := new(readCloser)
+	m := binarystorage.Metadata{Version: "4.0", Size: 4, SHA256: "qux"}
+	expectedErr := errors.New("wut")
+	s.stores[0].SetErrors(expectedErr)
+	err := s.store.Add(r, m)
+	c.Assert(err, gc.Equals, expectedErr)
+	s.stores[0].CheckCalls(c, []testing.StubCall{{"Add", []interface{}{r, m}}})
+	s.stores[1].CheckNoCalls(c)
+}
+
+func (s *layeredStorageSuite) TestAllMetadata(c *gc.C) {
+	all, err := s.store.AllMetadata()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(all, jc.DeepEquals, []binarystorage.Metadata{
+		{Version: "1.0", Size: 1, SHA256: "foo"},
+		{Version: "2.0", Size: 2, SHA256: "bar"},
+		{Version: "3.0", Size: 3, SHA256: "baz"},
+	})
+	s.stores[0].CheckCallNames(c, "AllMetadata")
+	s.stores[1].CheckCallNames(c, "AllMetadata")
+}
+
+func (s *layeredStorageSuite) TestAllMetadataError(c *gc.C) {
+	expectedErr := errors.New("wut")
+	s.stores[0].SetErrors(expectedErr)
+	_, err := s.store.AllMetadata()
+	c.Assert(err, gc.Equals, expectedErr)
+	s.stores[0].CheckCallNames(c, "AllMetadata")
+	s.stores[1].CheckNoCalls(c)
+}
+
+func (s *layeredStorageSuite) TestMetadata(c *gc.C) {
+	s.stores[0].SetErrors(errors.NotFoundf("metadata"))
+	m, err := s.store.Metadata("3.0")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(m, jc.DeepEquals, s.stores[1].metadata[0])
+	s.stores[0].CheckCalls(c, []testing.StubCall{{
+		"Metadata", []interface{}{"3.0"},
+	}})
+	s.stores[1].CheckCalls(c, []testing.StubCall{{
+		"Metadata", []interface{}{"3.0"},
+	}})
+}
+
+func (s *layeredStorageSuite) TestMetadataEarlyExit(c *gc.C) {
+	m, err := s.store.Metadata("1.0")
+	c.Assert(err, jc.ErrorIsNil)
+	s.stores[0].CheckCalls(c, []testing.StubCall{{
+		"Metadata", []interface{}{"1.0"},
+	}})
+	s.stores[1].CheckNoCalls(c)
+	c.Assert(m, jc.DeepEquals, s.stores[0].metadata[0])
+}
+
+func (s *layeredStorageSuite) TestMetadataFatalError(c *gc.C) {
+	expectedErr := errors.New("wut")
+	s.stores[0].SetErrors(expectedErr)
+	_, err := s.store.Metadata("1.0")
+	c.Assert(err, gc.Equals, expectedErr)
+	s.stores[0].CheckCalls(c, []testing.StubCall{{
+		"Metadata", []interface{}{"1.0"},
+	}})
+	s.stores[1].CheckNoCalls(c)
+}
+
+func (s *layeredStorageSuite) TestOpen(c *gc.C) {
+	s.stores[0].SetErrors(errors.NotFoundf("metadata"))
+	m, rc, err := s.store.Open("3.0")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(m, jc.DeepEquals, s.stores[1].metadata[0])
+	c.Assert(rc, gc.Equals, &s.stores[1].rc)
+	s.stores[0].CheckCalls(c, []testing.StubCall{{
+		"Open", []interface{}{"3.0"},
+	}})
+	s.stores[1].CheckCalls(c, []testing.StubCall{{
+		"Open", []interface{}{"3.0"},
+	}})
+}
+
+func (s *layeredStorageSuite) TestOpenEarlyExit(c *gc.C) {
+	m, rc, err := s.store.Open("1.0")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(m, jc.DeepEquals, s.stores[0].metadata[0])
+	c.Assert(rc, gc.Equals, &s.stores[0].rc)
+	s.stores[0].CheckCalls(c, []testing.StubCall{{
+		"Open", []interface{}{"1.0"},
+	}})
+	s.stores[1].CheckNoCalls(c)
+}
+
+func (s *layeredStorageSuite) TestOpenFatalError(c *gc.C) {
+	expectedErr := errors.New("wut")
+	s.stores[0].SetErrors(expectedErr)
+	_, _, err := s.store.Open("1.0")
+	c.Assert(err, gc.Equals, expectedErr)
+	s.stores[0].CheckCalls(c, []testing.StubCall{{
+		"Open", []interface{}{"1.0"},
+	}})
+	s.stores[1].CheckNoCalls(c)
+}
+
+type mockStorage struct {
+	testing.Stub
+	rc       readCloser
+	metadata []binarystorage.Metadata
+}
+
+func (s *mockStorage) Add(r io.Reader, m binarystorage.Metadata) error {
+	s.MethodCall(s, "Add", r, m)
+	return s.NextErr()
+}
+
+func (s *mockStorage) AllMetadata() ([]binarystorage.Metadata, error) {
+	s.MethodCall(s, "AllMetadata")
+	return s.metadata, s.NextErr()
+}
+
+func (s *mockStorage) Metadata(version string) (binarystorage.Metadata, error) {
+	s.MethodCall(s, "Metadata", version)
+	return s.metadata[0], s.NextErr()
+}
+
+func (s *mockStorage) Open(version string) (binarystorage.Metadata, io.ReadCloser, error) {
+	s.MethodCall(s, "Open", version)
+	return s.metadata[0], &s.rc, s.NextErr()
+}
+
+type readCloser struct{ io.ReadCloser }

--- a/state/binarystorage_test.go
+++ b/state/binarystorage_test.go
@@ -5,6 +5,7 @@ package state_test
 
 import (
 	"fmt"
+	"io/ioutil"
 	"strings"
 
 	"github.com/juju/errors"
@@ -16,8 +17,8 @@ import (
 	"github.com/juju/version"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/blobstore.v2"
-	"gopkg.in/mgo.v2"
 
+	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/binarystorage"
 	"github.com/juju/juju/testing"
@@ -97,8 +98,12 @@ func (s *binaryStorageSuite) TestToolsStorage(c *gc.C) {
 	s.testStorage(c, "toolsmetadata", s.State.ToolsStorage)
 }
 
-func (s *binaryStorageSuite) TestToolsStorageParams(c *gc.C) {
-	s.testStorageParams(c, "toolsmetadata", s.modelUUID, s.st.ToolsStorage)
+func (s *binaryStorageSuite) TestToolsStorageParamsControllerModel(c *gc.C) {
+	s.testStorageParams(c, "toolsmetadata", []string{s.State.ModelUUID()}, s.State.ToolsStorage)
+}
+
+func (s *binaryStorageSuite) TestToolsStorageParamsHostedModel(c *gc.C) {
+	s.testStorageParams(c, "toolsmetadata", []string{s.State.ModelUUID(), s.modelUUID}, s.st.ToolsStorage)
 }
 
 func (s *binaryStorageSuite) TestGUIArchiveStorage(c *gc.C) {
@@ -106,7 +111,7 @@ func (s *binaryStorageSuite) TestGUIArchiveStorage(c *gc.C) {
 }
 
 func (s *binaryStorageSuite) TestGUIArchiveStorageParams(c *gc.C) {
-	s.testStorageParams(c, "guimetadata", s.controllerUUID, s.st.GUIStorage)
+	s.testStorageParams(c, "guimetadata", []string{s.controllerUUID}, s.st.GUIStorage)
 }
 
 func (s *binaryStorageSuite) testStorage(c *gc.C, collName string, openStorage storageOpener) {
@@ -132,18 +137,17 @@ func (s *binaryStorageSuite) testStorage(c *gc.C, collName string, openStorage s
 	c.Assert(nameSet.Contains(collName), jc.IsTrue)
 }
 
-func (s *binaryStorageSuite) testStorageParams(c *gc.C, collName, uuid string, openStorage storageOpener) {
-	var called bool
+func (s *binaryStorageSuite) testStorageParams(c *gc.C, collName string, uuids []string, openStorage storageOpener) {
+	var uuidArgs []string
 	s.PatchValue(state.BinarystorageNew, func(
 		modelUUID string,
 		managedStorage blobstore.ManagedStorage,
-		metadataCollection *mgo.Collection,
+		metadataCollection mongo.Collection,
 		runner jujutxn.Runner,
 	) binarystorage.Storage {
-		called = true
-		c.Assert(modelUUID, gc.Equals, uuid)
+		uuidArgs = append(uuidArgs, modelUUID)
 		c.Assert(managedStorage, gc.NotNil)
-		c.Assert(metadataCollection.Name, gc.Equals, collName)
+		c.Assert(metadataCollection.Name(), gc.Equals, collName)
 		c.Assert(runner, gc.NotNil)
 		return nil
 	})
@@ -151,5 +155,41 @@ func (s *binaryStorageSuite) testStorageParams(c *gc.C, collName, uuid string, o
 	storage, err := openStorage()
 	c.Assert(err, jc.ErrorIsNil)
 	storage.Close()
-	c.Assert(called, jc.IsTrue)
+	c.Assert(uuidArgs, jc.DeepEquals, uuids)
+}
+
+func (s *binaryStorageSuite) TestToolsStorageLayered(c *gc.C) {
+	modelTools, err := s.st.ToolsStorage()
+	c.Assert(err, jc.ErrorIsNil)
+	defer modelTools.Close()
+
+	controllerTools, err := s.State.ToolsStorage()
+	c.Assert(err, jc.ErrorIsNil)
+	defer controllerTools.Close()
+
+	err = modelTools.Add(strings.NewReader("abc"), binarystorage.Metadata{Version: "1.0", Size: 3})
+	c.Assert(err, jc.ErrorIsNil)
+	err = controllerTools.Add(strings.NewReader("defg"), binarystorage.Metadata{Version: "1.0", Size: 4})
+	c.Assert(err, jc.ErrorIsNil)
+	err = controllerTools.Add(strings.NewReader("def"), binarystorage.Metadata{Version: "2.0", Size: 3})
+	c.Assert(err, jc.ErrorIsNil)
+
+	all, err := modelTools.AllMetadata()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(all, jc.DeepEquals, []binarystorage.Metadata{
+		{Version: "1.0", Size: 3},
+		{Version: "2.0", Size: 3},
+	})
+
+	assertContents := func(v, contents string) {
+		_, rc, err := modelTools.Open(v)
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(rc, gc.NotNil)
+		defer rc.Close()
+		data, err := ioutil.ReadAll(rc)
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(string(data), gc.Equals, contents)
+	}
+	assertContents("1.0", "abc")
+	assertContents("2.0", "def")
 }


### PR DESCRIPTION
In order to properly support bringing up machines in a model
with a private network separate from the controller's, we
must attempt to download from all of the tools URLs we have
available. This means we will not only attempting each controller,
but each controller by all of their addresses.

Windows was still only attempting the first URL. This has been
fixed, so that we now attempt all of the URLs and then retry
the whole lot with a delay.

While making the change, it was found that tools catalogues
were not properly model-aware. The collection has been made
model-specific, and we have changed the tools storage to combine
the model and controller stores. This means that if you have
tools in the controller model, you can see them from the hosted
models. Any tools uploaded to a hosted model will take precedence,
and do not affect any other model.

This branch is a precursor to updating the Azure provider so that
hosted models are entirely isolated, and do not share the controller's
private virtual network.

Fixes https://bugs.launchpad.net/juju-core/+bug/1571832

(Review request: http://reviews.vapour.ws/r/4652/)