### PR TITLE
Improve spaces discovery by using bulk calls for CreateSpaces/AddSubnets

### DIFF
--- a/apiserver/common/networkingcommon/subnets.go
+++ b/apiserver/common/networkingcommon/subnets.go
@@ -65,7 +65,7 @@ func (cache *addSubnetsCache) validateSpace(spaceTag string) (*names.SpaceTag, e
 	// Otherwise we need the cache to validate.
 	if cache.allSpaces == nil {
 		// Not yet cached.
-		logger.Debugf("caching known spaces")
+		logger.Tracef("caching known spaces")
 
 		allSpaces, err := cache.api.AllSpaces()
 		if err != nil {
@@ -119,7 +119,7 @@ func (cache *addSubnetsCache) cacheZones() error {
 		}
 		cache.allZones.Add(zone.Name)
 	}
-	logger.Debugf(
+	logger.Tracef(
 		"%d known and %d available zones cached: %v",
 		cache.allZones.Size(), cache.availableZones.Size(), cache.allZones.SortedValues(),
 	)
@@ -198,7 +198,7 @@ func (cache *addSubnetsCache) cacheSubnets() error {
 	if err != nil {
 		return errors.Annotate(err, "cannot get provider subnets")
 	}
-	logger.Debugf("got %d subnets to cache from the provider", len(subnetInfo))
+	logger.Tracef("got %d subnets to cache from the provider", len(subnetInfo))
 
 	if len(subnetInfo) > 0 {
 		// Trying to avoid reallocations.
@@ -211,7 +211,7 @@ func (cache *addSubnetsCache) cacheSubnets() error {
 		subnet := subnetInfo[i]
 		cidr := subnet.CIDR
 		providerId := string(subnet.ProviderId)
-		logger.Debugf(
+		logger.Tracef(
 			"caching subnet with CIDR %q, ProviderId %q, Zones: %q",
 			cidr, providerId, subnet.AvailabilityZones,
 		)
@@ -249,7 +249,7 @@ func (cache *addSubnetsCache) cacheSubnets() error {
 
 		cache.allSubnets = append(cache.allSubnets, subnet)
 	}
-	logger.Debugf("%d provider subnets cached", len(cache.allSubnets))
+	logger.Tracef("%d provider subnets cached", len(cache.allSubnets))
 	if len(cache.allSubnets) == 0 {
 		// Cached an empty list.
 		return errors.Errorf("no subnets defined")
@@ -479,11 +479,11 @@ func AllZones(api NetworkBacking) (params.ZoneResults, error) {
 		if err != nil {
 			return results, errors.Annotate(err, "cannot update known zones")
 		}
-		logger.Debugf(
+		logger.Tracef(
 			"updated the list of known zones from the model: %s", zonesAsString(zones),
 		)
 	} else {
-		logger.Debugf("using cached list of known zones: %s", zonesAsString(zones))
+		logger.Tracef("using cached list of known zones: %s", zonesAsString(zones))
 	}
 
 	results.Results = make([]params.ZoneResult, len(zones))

--- a/worker/discoverspaces/discoverspaces.go
+++ b/worker/discoverspaces/discoverspaces.go
@@ -217,7 +217,10 @@ func (dw *discoverspacesWorker) handleSubnets() error {
 			}
 			zones := subnet.AvailabilityZones
 			if len(zones) == 0 {
-				logger.Debugf("provider does not specify zones for subnet %q; using 'default' zone as fallback")
+				logger.Tracef(
+					"provider does not specify zones for subnet %q; using 'default' zone as fallback",
+					subnet.CIDR,
+				)
 				zones = []string{"default"}
 			}
 			addSubnetsArgs.Subnets = append(addSubnetsArgs.Subnets, params.AddSubnetParams{

--- a/worker/discoverspaces/discoverspaces.go
+++ b/worker/discoverspaces/discoverspaces.go
@@ -63,7 +63,7 @@ func (config Config) Validate() error {
 	return nil
 }
 
-var logger = loggo.GetLogger("juju.discoverspaces")
+var logger = loggo.GetLogger("juju.worker.discoverspaces")
 
 type discoverspacesWorker struct {
 	catacomb catacomb.Catacomb
@@ -174,6 +174,8 @@ func (dw *discoverspacesWorker) handleSubnets() error {
 
 	// TODO(mfoord): we need to delete spaces and subnets that no longer
 	// exist, so long as they're not in use.
+	var createSpacesArgs params.CreateSpacesParams
+	var addSubnetsArgs params.AddSubnetsParams
 	for _, space := range providerSpaces {
 		// Check if the space is already in state, in which case we know
 		// its name.
@@ -200,56 +202,95 @@ func (dw *discoverspacesWorker) handleSubnets() error {
 			spaceNames.Add(spaceName)
 			spaceTag = names.NewSpaceTag(spaceName)
 			// We need to create the space.
-			args := params.CreateSpacesParams{
-				Spaces: []params.CreateSpaceParams{{
-					Public:     false,
-					SpaceTag:   spaceTag.String(),
-					ProviderId: string(space.ProviderId),
-				}}}
-			result, err := facade.CreateSpaces(args)
-			if err != nil {
-				logger.Errorf("error creating space %v", err)
-				return errors.Trace(err)
-			}
-			if len(result.Results) != 1 {
-				return errors.Errorf("unexpected number of results from CreateSpaces, should be 1: %v", result)
-			}
-			if result.Results[0].Error != nil {
-				return errors.Errorf("error from CreateSpaces: %v", result.Results[0].Error)
-			}
+			createSpacesArgs.Spaces = append(createSpacesArgs.Spaces, params.CreateSpaceParams{
+				Public:     false,
+				SpaceTag:   spaceTag.String(),
+				ProviderId: string(space.ProviderId),
+			})
 		}
 		// TODO(mfoord): currently no way of removing subnets, or
 		// changing the space they're in, so we can only add ones we
 		// don't already know about.
-		logger.Debugf("Created space %v with %v subnets", spaceTag.String(), len(space.Subnets))
 		for _, subnet := range space.Subnets {
 			if stateSubnetIds.Contains(string(subnet.ProviderId)) {
 				continue
 			}
 			zones := subnet.AvailabilityZones
 			if len(zones) == 0 {
+				logger.Debugf("provider does not specify zones for subnet %q; using 'default' zone as fallback")
 				zones = []string{"default"}
 			}
-			args := params.AddSubnetsParams{
-				Subnets: []params.AddSubnetParams{{
-					SubnetProviderId: string(subnet.ProviderId),
-					SpaceTag:         spaceTag.String(),
-					Zones:            zones,
-				}}}
-			logger.Tracef("Adding subnet %v", subnet.CIDR)
-			result, err := facade.AddSubnets(args)
-			if err != nil {
-				logger.Errorf("invalid creating subnet %v", err)
-				return errors.Trace(err)
-			}
-			if len(result.Results) != 1 {
-				return errors.Errorf("unexpected number of results from AddSubnets, should be 1: %v", result)
-			}
-			if result.Results[0].Error != nil {
-				logger.Errorf("error creating subnet %v", result.Results[0].Error)
-				return errors.Errorf("error creating subnet %v", result.Results[0].Error)
-			}
+			addSubnetsArgs.Subnets = append(addSubnetsArgs.Subnets, params.AddSubnetParams{
+				SubnetProviderId: string(subnet.ProviderId),
+				SpaceTag:         spaceTag.String(),
+				Zones:            zones,
+			})
 		}
 	}
+
+	if err := dw.createSpacesFromArgs(createSpacesArgs); err != nil {
+		return errors.Trace(err)
+	}
+
+	if err := dw.addSubnetsFromArgs(addSubnetsArgs); err != nil {
+		return errors.Trace(err)
+	}
+
+	return nil
+}
+
+func (dw *discoverspacesWorker) createSpacesFromArgs(createSpacesArgs params.CreateSpacesParams) error {
+	facade := dw.config.Facade
+
+	expectedNumCreated := len(createSpacesArgs.Spaces)
+	if expectedNumCreated > 0 {
+		result, err := facade.CreateSpaces(createSpacesArgs)
+		if err != nil {
+			return errors.Annotate(err, "creating spaces failed")
+		}
+		if len(result.Results) != expectedNumCreated {
+			return errors.Errorf(
+				"unexpected response from CreateSpaces: expected %d results, got %d",
+				expectedNumCreated, len(result.Results),
+			)
+		}
+		for _, res := range result.Results {
+			if res.Error != nil {
+				return errors.Annotate(res.Error, "creating space failed")
+			}
+		}
+		logger.Debugf("discovered and imported %d spaces: %v", expectedNumCreated, createSpacesArgs)
+	} else {
+		logger.Debugf("no unknown spaces discovered for import")
+	}
+
+	return nil
+}
+
+func (dw *discoverspacesWorker) addSubnetsFromArgs(addSubnetsArgs params.AddSubnetsParams) error {
+	facade := dw.config.Facade
+
+	expectedNumAdded := len(addSubnetsArgs.Subnets)
+	if expectedNumAdded > 0 {
+		result, err := facade.AddSubnets(addSubnetsArgs)
+		if err != nil {
+			return errors.Annotate(err, "adding subnets failed")
+		}
+		if len(result.Results) != expectedNumAdded {
+			return errors.Errorf(
+				"unexpected response from AddSubnets: expected %d results, got %d",
+				expectedNumAdded, len(result.Results),
+			)
+		}
+		for _, res := range result.Results {
+			if res.Error != nil {
+				return errors.Annotate(res.Error, "adding subnet failed")
+			}
+		}
+		logger.Debugf("discovered and imported %d subnets: %v", expectedNumAdded, addSubnetsArgs)
+	} else {
+		logger.Debugf("no unknown subnets discovered for import")
+	}
+
 	return nil
 }

--- a/worker/discoverspaces/worker_test.go
+++ b/worker/discoverspaces/worker_test.go
@@ -4,6 +4,7 @@
 package discoverspaces_test
 
 import (
+	"sync/atomic"
 	"time"
 
 	"github.com/juju/names"
@@ -31,7 +32,31 @@ type WorkerSuite struct {
 	testing.JujuConnSuite
 
 	APIConnection api.Connection
-	API           *apidiscoverspaces.API
+	API           *checkingFacade
+
+	numCreateSpaceCalls uint32
+	numAddSubnetsCalls  uint32
+}
+
+type checkingFacade struct {
+	apidiscoverspaces.API
+
+	createSpacesCallback func()
+	addSubnetsCallback   func()
+}
+
+func (cf *checkingFacade) CreateSpaces(args params.CreateSpacesParams) (results params.ErrorResults, err error) {
+	if cf.createSpacesCallback != nil {
+		cf.createSpacesCallback()
+	}
+	return cf.API.CreateSpaces(args)
+}
+
+func (cf *checkingFacade) AddSubnets(args params.AddSubnetsParams) (params.ErrorResults, error) {
+	if cf.addSubnetsCallback != nil {
+		cf.addSubnetsCallback()
+	}
+	return cf.API.AddSubnets(args)
 }
 
 var _ = gc.Suite(&WorkerSuite{})
@@ -43,7 +68,17 @@ func (s *WorkerSuite) SetUpTest(c *gc.C) {
 	s.AssertConfigParameterUpdated(c, "broken", "")
 
 	s.APIConnection, _ = s.OpenAPIAsNewMachine(c, state.JobManageModel)
-	s.API = s.APIConnection.DiscoverSpaces()
+
+	realAPI := s.APIConnection.DiscoverSpaces()
+	s.API = &checkingFacade{
+		API: *realAPI,
+		createSpacesCallback: func() {
+			atomic.AddUint32(&s.numCreateSpaceCalls, 1)
+		},
+		addSubnetsCallback: func() {
+			atomic.AddUint32(&s.numAddSubnetsCalls, 1)
+		},
+	}
 }
 
 func (s *WorkerSuite) TearDownTest(c *gc.C) {
@@ -104,13 +139,19 @@ func (s *WorkerSuite) TestWorkerSupportsSpaceDiscoveryFalse(c *gc.C) {
 
 func (s *WorkerSuite) TestWorkerDiscoversSpaces(c *gc.C) {
 	dummy.SetSupportsSpaceDiscovery(true)
-	s.unlockCheck(c, s.assertDiscoveredSpaces)
+	s.unlockCheck(c, func(*gc.C) {
+		s.assertDiscoveredSpaces(c)
+		s.assertNumCalls(c, 1, 1)
+	})
 }
 
 func (s *WorkerSuite) TestWorkerIdempotent(c *gc.C) {
 	dummy.SetSupportsSpaceDiscovery(true)
 	s.unlockCheck(c, s.assertDiscoveredSpaces)
-	s.unlockCheck(c, s.assertDiscoveredSpaces)
+	s.unlockCheck(c, func(*gc.C) {
+		s.assertDiscoveredSpaces(c)
+		s.assertNumCalls(c, 2, 2)
+	})
 }
 
 func (s *WorkerSuite) TestWorkerIgnoresExistingSpacesAndSubnets(c *gc.C) {
@@ -242,4 +283,9 @@ func (s *WorkerSuite) assertDiscoveredSpaces(c *gc.C) {
 			c.Check(subnet.CIDR(), gc.Equals, expectedSubnet.CIDR)
 		}
 	}
+}
+
+func (s *WorkerSuite) assertNumCalls(c *gc.C, expectedNumCreateSpaceCalls, expectedNumAddSubnetsCalls int) {
+	c.Check(atomic.LoadUint32(&s.numCreateSpaceCalls), gc.Equals, uint32(expectedNumCreateSpaceCalls))
+	c.Check(atomic.LoadUint32(&s.numAddSubnetsCalls), gc.Equals, uint32(expectedNumAddSubnetsCalls))
 }


### PR DESCRIPTION
Instead of calling CreateSpaces() and AddSubnets() for each discovered
entity, the worker now takes full advantage of the server-side subnets
cache, which was designed with the reducing the number of calls to the
provider to validate subnets, zones, spaces.

Tested both at unit level and live on MAAS 1.9.1.

(Review request: http://reviews.vapour.ws/r/4653/)