### PR TITLE
Fix data race in MAAS 2 storage tests better by using testing.Stub

### DIFF
--- a/provider/maas/maas2_environ_whitebox_test.go
+++ b/provider/maas/maas2_environ_whitebox_test.go
@@ -238,22 +238,30 @@ func (suite *maas2EnvironSuite) TestSpacesError(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "Joe Manginiello")
 }
 
+func collectReleaseArgs(controller *fakeController) []gomaasapi.ReleaseMachinesArgs {
+	args := []gomaasapi.ReleaseMachinesArgs{}
+	for _, call := range controller.Stub.Calls() {
+		if call.FuncName == "ReleaseMachines" {
+			args = append(args, call.Args[0].(gomaasapi.ReleaseMachinesArgs))
+		}
+	}
+	return args
+}
+
 func (suite *maas2EnvironSuite) TestStopInstancesReturnsIfParameterEmpty(c *gc.C) {
-	controller := &fakeController{}
+	controller := newFakeController()
 	err := suite.makeEnviron(c, controller).StopInstances()
 	c.Check(err, jc.ErrorIsNil)
-	c.Assert(controller.releaseMachinesArgs, gc.IsNil)
+	c.Assert(collectReleaseArgs(controller), gc.HasLen, 0)
 }
 
 func (suite *maas2EnvironSuite) TestStopInstancesStopsAndReleasesInstances(c *gc.C) {
 	// Return a cannot complete indicating that test1 is in the wrong state.
 	// The release operation will still release the others and succeed.
-	controller := &fakeController{
-		files: []gomaasapi.File{&fakeFile{name: "agent-prefix-provider-state"}},
-	}
+	controller := newFakeControllerWithFiles(&fakeFile{name: "agent-prefix-provider-state"})
 	err := suite.makeEnviron(c, controller).StopInstances("test1", "test2", "test3")
 	c.Check(err, jc.ErrorIsNil)
-	args := controller.releaseMachinesArgs
+	args := collectReleaseArgs(controller)
 	c.Assert(args, gc.HasLen, 1)
 	c.Assert(args[0].SystemIDs, gc.DeepEquals, []string{"test1", "test2", "test3"})
 }
@@ -261,28 +269,25 @@ func (suite *maas2EnvironSuite) TestStopInstancesStopsAndReleasesInstances(c *gc
 func (suite *maas2EnvironSuite) TestStopInstancesIgnoresConflict(c *gc.C) {
 	// Return a cannot complete indicating that test1 is in the wrong state.
 	// The release operation will still release the others and succeed.
-	controller := &fakeController{
-		releaseMachinesErrors: []error{gomaasapi.NewCannotCompleteError("test1 not allocated")},
-		files: []gomaasapi.File{&fakeFile{name: "agent-prefix-provider-state"}},
-	}
+	controller := newFakeControllerWithFiles(&fakeFile{name: "agent-prefix-provider-state"})
+	controller.SetErrors(gomaasapi.NewCannotCompleteError("test1 not allocated"))
 	err := suite.makeEnviron(c, controller).StopInstances("test1", "test2", "test3")
 	c.Check(err, jc.ErrorIsNil)
-	args := controller.releaseMachinesArgs
+
+	args := collectReleaseArgs(controller)
 	c.Assert(args, gc.HasLen, 1)
 	c.Assert(args[0].SystemIDs, gc.DeepEquals, []string{"test1", "test2", "test3"})
 }
 
 func (suite *maas2EnvironSuite) TestStopInstancesIgnoresMissingNodeAndRecurses(c *gc.C) {
-	controller := &fakeController{
-		releaseMachinesErrors: []error{
-			gomaasapi.NewBadRequestError("no such machine: test1"),
-			gomaasapi.NewBadRequestError("no such machine: test1"),
-		},
-		files: []gomaasapi.File{&fakeFile{name: "agent-prefix-provider-state"}},
-	}
+	controller := newFakeControllerWithFiles(&fakeFile{name: "agent-prefix-provider-state"})
+	controller.SetErrors(
+		gomaasapi.NewBadRequestError("no such machine: test1"),
+		gomaasapi.NewBadRequestError("no such machine: test1"),
+	)
 	err := suite.makeEnviron(c, controller).StopInstances("test1", "test2", "test3")
 	c.Check(err, jc.ErrorIsNil)
-	args := controller.releaseMachinesArgs
+	args := collectReleaseArgs(controller)
 	c.Assert(args, gc.HasLen, 4)
 	c.Assert(args[0].SystemIDs, gc.DeepEquals, []string{"test1", "test2", "test3"})
 	c.Assert(args[1].SystemIDs, gc.DeepEquals, []string{"test1"})
@@ -291,14 +296,12 @@ func (suite *maas2EnvironSuite) TestStopInstancesIgnoresMissingNodeAndRecurses(c
 }
 
 func (suite *maas2EnvironSuite) checkStopInstancesFails(c *gc.C, withError error) {
-	controller := &fakeController{
-		releaseMachinesErrors: []error{withError},
-		files: []gomaasapi.File{&fakeFile{name: "agent-prefix-provider-state"}},
-	}
+	controller := newFakeControllerWithFiles(&fakeFile{name: "agent-prefix-provider-state"})
+	controller.SetErrors(withError)
 	err := suite.makeEnviron(c, controller).StopInstances("test1", "test2", "test3")
 	c.Check(err, gc.ErrorMatches, fmt.Sprintf("cannot release nodes: %s", withError))
 	// Only tries once.
-	c.Assert(controller.releaseMachinesArgs, gc.HasLen, 1)
+	c.Assert(collectReleaseArgs(controller), gc.HasLen, 1)
 }
 
 func (suite *maas2EnvironSuite) TestStopInstancesReturnsUnexpectedMAASError(c *gc.C) {
@@ -669,10 +672,10 @@ func (suite *maas2EnvironSuite) TestWaitForNodeDeploymentError(c *gc.C) {
 		systemID:     "Bruce Sterling",
 		architecture: arch.HostArch(),
 	}
-	suite.injectController(&fakeController{
-		allocateMachine: machine,
-		machines:        []gomaasapi.Machine{machine},
-	})
+	controller := newFakeController()
+	controller.allocateMachine = machine
+	controller.machines = []gomaasapi.Machine{machine}
+	suite.injectController(controller)
 	suite.setupFakeTools(c)
 	env := suite.makeEnviron(c, nil)
 	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{})
@@ -685,10 +688,10 @@ func (suite *maas2EnvironSuite) TestWaitForNodeDeploymentSucceeds(c *gc.C) {
 		architecture: arch.HostArch(),
 		statusName:   "Deployed",
 	}
-	suite.injectController(&fakeController{
-		allocateMachine: machine,
-		machines:        []gomaasapi.Machine{machine},
-	})
+	controller := newFakeController()
+	controller.allocateMachine = machine
+	controller.machines = []gomaasapi.Machine{machine}
+	suite.injectController(controller)
 	suite.setupFakeTools(c)
 	env := suite.makeEnviron(c, nil)
 	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{})

--- a/provider/maas/maas2_environ_whitebox_test.go
+++ b/provider/maas/maas2_environ_whitebox_test.go
@@ -64,11 +64,12 @@ func (suite *maas2EnvironSuite) TestNewEnvironWithController(c *gc.C) {
 }
 
 func (suite *maas2EnvironSuite) TestSupportedArchitectures(c *gc.C) {
-	controller := newFakeController()
-	controller.bootResources = []gomaasapi.BootResource{
-		&fakeBootResource{name: "wily", architecture: "amd64/blah"},
-		&fakeBootResource{name: "wily", architecture: "amd64/something"},
-		&fakeBootResource{name: "xenial", architecture: "arm/somethingelse"},
+	controller := &fakeController{
+		bootResources: []gomaasapi.BootResource{
+			&fakeBootResource{name: "wily", architecture: "amd64/blah"},
+			&fakeBootResource{name: "wily", architecture: "amd64/something"},
+			&fakeBootResource{name: "xenial", architecture: "arm/somethingelse"},
+		},
 	}
 	env := suite.makeEnviron(c, controller)
 	result, err := env.SupportedArchitectures()
@@ -77,7 +78,7 @@ func (suite *maas2EnvironSuite) TestSupportedArchitectures(c *gc.C) {
 }
 
 func (suite *maas2EnvironSuite) TestSupportedArchitecturesError(c *gc.C) {
-	env := suite.makeEnviron(c, newFakeControllerWithErrors(errors.New("Something terrible!")))
+	env := suite.makeEnviron(c, &fakeController{bootResourcesError: errors.New("Something terrible!")})
 	_, err := env.SupportedArchitectures()
 	c.Assert(err, gc.ErrorMatches, "Something terrible!")
 }

--- a/provider/maas/maas2_environ_whitebox_test.go
+++ b/provider/maas/maas2_environ_whitebox_test.go
@@ -64,12 +64,11 @@ func (suite *maas2EnvironSuite) TestNewEnvironWithController(c *gc.C) {
 }
 
 func (suite *maas2EnvironSuite) TestSupportedArchitectures(c *gc.C) {
-	controller := &fakeController{
-		bootResources: []gomaasapi.BootResource{
-			&fakeBootResource{name: "wily", architecture: "amd64/blah"},
-			&fakeBootResource{name: "wily", architecture: "amd64/something"},
-			&fakeBootResource{name: "xenial", architecture: "arm/somethingelse"},
-		},
+	controller := newFakeController()
+	controller.bootResources = []gomaasapi.BootResource{
+		&fakeBootResource{name: "wily", architecture: "amd64/blah"},
+		&fakeBootResource{name: "wily", architecture: "amd64/something"},
+		&fakeBootResource{name: "xenial", architecture: "arm/somethingelse"},
 	}
 	env := suite.makeEnviron(c, controller)
 	result, err := env.SupportedArchitectures()
@@ -78,7 +77,7 @@ func (suite *maas2EnvironSuite) TestSupportedArchitectures(c *gc.C) {
 }
 
 func (suite *maas2EnvironSuite) TestSupportedArchitecturesError(c *gc.C) {
-	env := suite.makeEnviron(c, &fakeController{bootResourcesError: errors.New("Something terrible!")})
+	env := suite.makeEnviron(c, newFakeControllerWithErrors(errors.New("Something terrible!")))
 	_, err := env.SupportedArchitectures()
 	c.Assert(err, gc.ErrorMatches, "Something terrible!")
 }

--- a/provider/maas/maas2_test.go
+++ b/provider/maas/maas2_test.go
@@ -71,8 +71,6 @@ type fakeController struct {
 	allocateMachineError     error
 	allocateMachineArgsCheck func(gomaasapi.AllocateMachineArgs)
 	files                    []gomaasapi.File
-	releaseMachinesErrors    []error
-	releaseMachinesArgs      []gomaasapi.ReleaseMachinesArgs
 }
 
 func newFakeController() *fakeController {

--- a/provider/maas/maas2_test.go
+++ b/provider/maas/maas2_test.go
@@ -121,8 +121,10 @@ func (c *fakeController) AllocateMachine(args gomaasapi.AllocateMachineArgs) (go
 }
 
 func (c *fakeController) BootResources() ([]gomaasapi.BootResource, error) {
-	c.MethodCall(c, "BootResources")
-	return c.bootResources, c.NextErr()
+	if c.bootResourcesError != nil {
+		return nil, c.bootResourcesError
+	}
+	return c.bootResources, nil
 }
 
 func (c *fakeController) Zones() ([]gomaasapi.Zone, error) {

--- a/provider/maas/maas2_test.go
+++ b/provider/maas/maas2_test.go
@@ -121,10 +121,8 @@ func (c *fakeController) AllocateMachine(args gomaasapi.AllocateMachineArgs) (go
 }
 
 func (c *fakeController) BootResources() ([]gomaasapi.BootResource, error) {
-	if c.bootResourcesError != nil {
-		return nil, c.bootResourcesError
-	}
-	return c.bootResources, nil
+	c.MethodCall(c, "BootResources")
+	return c.bootResources, c.NextErr()
 }
 
 func (c *fakeController) Zones() ([]gomaasapi.Zone, error) {


### PR DESCRIPTION
The race was caused by the fake MAAS controller recording information about calls on itself. Use juju/testing Stub to record the calls instead.

I didn't go the whole way and replace all of the different getters on the controller with calls to the stub - for testing things like StartInstance it's handy to have fine-grained control over which methods raise an error. Doing that with SetErrors would require the tests to constrain the implementation too much, because I'd need to insert the right number of nils for successful calls before the call I wanted to fail. That seems fragile.

(Review request: http://reviews.vapour.ws/r/4654/)