### PR TITLE
Use device path as VolumeAttachmentInfo.DeviceLink

### DIFF
--- a/provider/maas/volumes.go
+++ b/provider/maas/volumes.go
@@ -307,7 +307,6 @@ func (mi *maas2Instance) volumes(
 			volumeTag,
 			storage.VolumeInfo{
 				VolumeId:   volumeTag.String(),
-				HardwareId: device.Path(),
 				Size:       uint64(device.Size() / humanize.MiByte),
 				Persistent: false,
 			},
@@ -318,7 +317,7 @@ func (mi *maas2Instance) volumes(
 			volumeTag,
 			mTag,
 			storage.VolumeAttachmentInfo{
-				DeviceName: device.Name(),
+				DeviceLink: device.Path(),
 				ReadOnly:   false,
 			},
 		}

--- a/provider/maas/volumes_test.go
+++ b/provider/maas/volumes_test.go
@@ -99,7 +99,6 @@ func (s *volumeSuite) TestInstanceVolumesMAAS2(c *gc.C) {
 	c.Check(volumes, jc.SameContents, []storage.Volume{{
 		names.NewVolumeTag("1"),
 		storage.VolumeInfo{
-			HardwareId: "/dev/disk/by-dname/sdb",
 			VolumeId:   "volume-1",
 			Size:       476893,
 			Persistent: false,
@@ -107,7 +106,6 @@ func (s *volumeSuite) TestInstanceVolumesMAAS2(c *gc.C) {
 	}, {
 		names.NewVolumeTag("2"),
 		storage.VolumeInfo{
-			HardwareId: "/dev/disk/by-dname/sdc",
 			VolumeId:   "volume-2",
 			Size:       238764,
 			Persistent: false,
@@ -118,7 +116,7 @@ func (s *volumeSuite) TestInstanceVolumesMAAS2(c *gc.C) {
 			names.NewVolumeTag("1"),
 			mTag,
 			storage.VolumeAttachmentInfo{
-				DeviceName: "sdb",
+				DeviceLink: "/dev/disk/by-dname/sdb",
 				ReadOnly:   false,
 			},
 		},
@@ -126,7 +124,7 @@ func (s *volumeSuite) TestInstanceVolumesMAAS2(c *gc.C) {
 			names.NewVolumeTag("2"),
 			mTag,
 			storage.VolumeAttachmentInfo{
-				DeviceName: "sdc",
+				DeviceLink: "/dev/disk/by-dname/sdc",
 				ReadOnly:   false,
 			},
 		},


### PR DESCRIPTION
In MAAS2 device.Path() will always be a path starting with
/dev/disk/by-dname/ which doesn't change across machine reboots.

Using this rather than the hardware id and device name that the MAAS 1
code uses after discussing with blake_r and axw.

(Review request: http://reviews.vapour.ws/r/4655/)