### PR TITLE
Ports now linked to subnets instead of networks

### DIFF
--- a/api/firewaller/machine_test.go
+++ b/api/firewaller/machine_test.go
@@ -94,44 +94,41 @@ func (s *machineSuite) TestWatchUnits(c *gc.C) {
 	wc.AssertNoChange()
 }
 
-func (s *machineSuite) TestActiveNetworks(c *gc.C) {
-	// No ports opened at first, no networks.
-	nets, err := s.apiMachine.ActiveNetworks()
+func (s *machineSuite) TestActiveSubnets(c *gc.C) {
+	// No ports opened at first, no active subnets.
+	subnets, err := s.apiMachine.ActiveSubnets()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(nets, gc.HasLen, 0)
+	c.Assert(subnets, gc.HasLen, 0)
 
 	// Open a port and check again.
 	err = s.units[0].OpenPort("tcp", 1234)
 	c.Assert(err, jc.ErrorIsNil)
-	nets, err = s.apiMachine.ActiveNetworks()
+	subnets, err = s.apiMachine.ActiveSubnets()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(nets, jc.DeepEquals, []names.NetworkTag{
-		names.NewNetworkTag(network.DefaultPublic),
-	})
+	c.Assert(subnets, jc.DeepEquals, []names.SubnetTag{{}})
 
-	// Remove all ports, no networks.
-	ports, err := s.machines[0].OpenedPorts(network.DefaultPublic)
+	// Remove all ports, no more active subnets.
+	ports, err := s.machines[0].OpenedPorts("")
 	c.Assert(err, jc.ErrorIsNil)
 	err = ports.Remove()
 	c.Assert(err, jc.ErrorIsNil)
-	nets, err = s.apiMachine.ActiveNetworks()
+	subnets, err = s.apiMachine.ActiveSubnets()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(nets, gc.HasLen, 0)
+	c.Assert(subnets, gc.HasLen, 0)
 }
 
 func (s *machineSuite) TestOpenedPorts(c *gc.C) {
-	networkTag := names.NewNetworkTag(network.DefaultPublic)
 	unitTag := s.units[0].Tag().(names.UnitTag)
 
 	// No ports opened at first.
-	ports, err := s.apiMachine.OpenedPorts(networkTag)
+	ports, err := s.apiMachine.OpenedPorts(names.SubnetTag{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ports, gc.HasLen, 0)
 
 	// Open a port and check again.
 	err = s.units[0].OpenPort("tcp", 1234)
 	c.Assert(err, jc.ErrorIsNil)
-	ports, err = s.apiMachine.OpenedPorts(networkTag)
+	ports, err = s.apiMachine.OpenedPorts(names.SubnetTag{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ports, jc.DeepEquals, map[network.PortRange]names.UnitTag{
 		network.PortRange{FromPort: 1234, ToPort: 1234, Protocol: "tcp"}: unitTag,

--- a/api/firewaller/state_test.go
+++ b/api/firewaller/state_test.go
@@ -71,8 +71,8 @@ func (s *stateSuite) TestWatchOpenedPorts(c *gc.C) {
 	defer wc.AssertStops()
 
 	expectChanges := []string{
-		"0:juju-public",
-		"2:juju-public",
+		"0:",
+		"2:",
 	}
 	wc.AssertChangeInSingleEvent(expectChanges...)
 	wc.AssertNoChange()
@@ -97,6 +97,6 @@ func (s *stateSuite) TestWatchOpenedPorts(c *gc.C) {
 	// Open another port range, ensure it's detected.
 	err = s.units[1].OpenPorts("tcp", 8080, 8088)
 	c.Assert(err, jc.ErrorIsNil)
-	wc.AssertChange("1:juju-public")
+	wc.AssertChange("1:")
 	wc.AssertNoChange()
 }

--- a/apiserver/firewaller/firewaller.go
+++ b/apiserver/firewaller/firewaller.go
@@ -152,9 +152,9 @@ func (f *FirewallerAPI) watchOneEnvironOpenedPorts(tag names.Tag) (string, []str
 	return "", nil, watcher.EnsureErr(watch)
 }
 
-// GetMachinePorts returns the port ranges opened on a machine for the
-// specified network as a map mapping port ranges to the tags of the
-// units that opened them.
+// GetMachinePorts returns the port ranges opened on a machine for the specified
+// subnet as a map mapping port ranges to the tags of the units that opened
+// them.
 func (f *FirewallerAPI) GetMachinePorts(args params.MachinePortsParams) (params.MachinePortsResults, error) {
 	result := params.MachinePortsResults{
 		Results: make([]params.MachinePortsResult, len(args.Params)),
@@ -169,17 +169,20 @@ func (f *FirewallerAPI) GetMachinePorts(args params.MachinePortsParams) (params.
 			result.Results[i].Error = common.ServerError(common.ErrPerm)
 			continue
 		}
-		networkTag, err := names.ParseNetworkTag(param.NetworkTag)
-		if err != nil {
-			result.Results[i].Error = common.ServerError(common.ErrPerm)
-			continue
+		var subnetTag names.SubnetTag
+		if param.SubnetTag != "" {
+			subnetTag, err = names.ParseSubnetTag(param.SubnetTag)
+			if err != nil {
+				result.Results[i].Error = common.ServerError(common.ErrPerm)
+				continue
+			}
 		}
 		machine, err := f.getMachine(canAccess, machineTag)
 		if err != nil {
 			result.Results[i].Error = common.ServerError(err)
 			continue
 		}
-		ports, err := machine.OpenedPorts(networkTag.Id())
+		ports, err := machine.OpenedPorts(subnetTag.Id())
 		if err != nil {
 			result.Results[i].Error = common.ServerError(err)
 			continue
@@ -205,9 +208,9 @@ func (f *FirewallerAPI) GetMachinePorts(args params.MachinePortsParams) (params.
 	return result, nil
 }
 
-// GetMachineActiveNetworks returns the tags of the all networks the
-// each given machine has open ports on.
-func (f *FirewallerAPI) GetMachineActiveNetworks(args params.Entities) (params.StringsResults, error) {
+// GetMachineActiveSubnets returns the tags of the all subnets the each given
+// machine has open ports on.
+func (f *FirewallerAPI) GetMachineActiveSubnets(args params.Entities) (params.StringsResults, error) {
 	result := params.StringsResults{
 		Results: make([]params.StringsResult, len(args.Entities)),
 	}
@@ -232,8 +235,11 @@ func (f *FirewallerAPI) GetMachineActiveNetworks(args params.Entities) (params.S
 			continue
 		}
 		for _, port := range ports {
-			networkTag := names.NewNetworkTag(port.NetworkName()).String()
-			result.Results[i].Result = append(result.Results[i].Result, networkTag)
+			var subnetTag string
+			if port.SubnetID() != "" {
+				subnetTag = names.NewSubnetTag(port.SubnetID()).String()
+			}
+			result.Results[i].Result = append(result.Results[i].Result, subnetTag)
 		}
 	}
 	return result, nil

--- a/apiserver/firewaller/firewaller.go
+++ b/apiserver/firewaller/firewaller.go
@@ -208,8 +208,8 @@ func (f *FirewallerAPI) GetMachinePorts(args params.MachinePortsParams) (params.
 	return result, nil
 }
 
-// GetMachineActiveSubnets returns the tags of the all subnets the each given
-// machine has open ports on.
+// GetMachineActiveSubnets returns the tags of the all subnets that each machine
+// (in args) has open ports on.
 func (f *FirewallerAPI) GetMachineActiveSubnets(args params.Entities) (params.StringsResults, error) {
 	result := params.StringsResults{
 		Results: make([]params.StringsResult, len(args.Entities)),
@@ -237,7 +237,9 @@ func (f *FirewallerAPI) GetMachineActiveSubnets(args params.Entities) (params.St
 		for _, port := range ports {
 			subnetID := port.SubnetID()
 			if subnetID != "" && !names.IsValidSubnet(subnetID) {
-				err = errors.NotValidf("%s", ports) // ports for machine "0", subnet "bad" not valid
+				// The error message below will look like e.g. `ports for
+				// machine "0", subnet "bad" not valid`.
+				err = errors.NotValidf("%s", ports)
 				result.Results[i].Error = common.ServerError(err)
 				continue
 			} else if subnetID != "" && names.IsValidSubnet(subnetID) {

--- a/apiserver/firewaller/firewaller_test.go
+++ b/apiserver/firewaller/firewaller_test.go
@@ -96,7 +96,7 @@ func (s *firewallerSuite) TestWatchOpenedPorts(c *gc.C) {
 
 	s.openPorts(c)
 	expectChanges := []string{
-		"0:", // empty subnet is ok (untill can be made required)
+		"0:", // empty subnet is ok (until it can be made mandatory)
 		"0:10.20.30.0/24",
 		"2:",
 	}

--- a/apiserver/params/network.go
+++ b/apiserver/params/network.go
@@ -452,11 +452,11 @@ type MachinePortRange struct {
 	PortRange   PortRange `json:"PortRange"`
 }
 
-// MachinePorts holds a machine and network tags. It's used when
-// referring to opened ports on the machine for a network.
+// MachinePorts holds a machine and subnet tags. It's used when referring to
+// opened ports on the machine for a subnet.
 type MachinePorts struct {
 	MachineTag string `json:"MachineTag"`
-	NetworkTag string `json:"NetworkTag"`
+	SubnetTag  string `json:"SubnetTag"`
 }
 
 // -----

--- a/core/description/interfaces.go
+++ b/core/description/interfaces.go
@@ -136,8 +136,8 @@ type Machine interface {
 	// TODO:
 	// Storage
 
-	NetworkPorts() []NetworkPorts
-	AddNetworkPorts(NetworkPortsArgs) NetworkPorts
+	OpenedPorts() []OpenedPorts
+	AddOpenedPorts(OpenedPortsArgs) OpenedPorts
 
 	// THINKING: Validate() error to make sure the machine has
 	// enough stuff set, like tools, and addresses etc.
@@ -151,10 +151,10 @@ type Machine interface {
 	// machine filesystems
 }
 
-// NetworkPorts represents a collection of port ranges that are open on
-// a particular network. NetworkPorts are always associated with a Machine.
-type NetworkPorts interface {
-	NetworkName() string
+// OpenedPorts represents a collection of port ranges that are open on a
+// particular subnet. OpenedPorts are always associated with a Machine.
+type OpenedPorts interface {
+	SubnetID() string
 	OpenPorts() []PortRange
 }
 

--- a/core/description/machine.go
+++ b/core/description/machine.go
@@ -40,7 +40,7 @@ type machine struct {
 
 	Containers_ []*machine `yaml:"containers"`
 
-	NetworkPorts_ *versionedNetworkPorts `yaml:"network-ports,omitempty"`
+	OpenedPorts_ *versionedOpenedPorts `yaml:"opened-ports,omitempty"`
 
 	Annotations_ `yaml:"annotations,omitempty"`
 
@@ -253,32 +253,32 @@ func (m *machine) AddContainer(args MachineArgs) Machine {
 	return container
 }
 
-// NetworkPorts implements Machine.
-func (m *machine) NetworkPorts() []NetworkPorts {
-	if m.NetworkPorts_ == nil {
+// OpenedPorts implements Machine.
+func (m *machine) OpenedPorts() []OpenedPorts {
+	if m.OpenedPorts_ == nil {
 		return nil
 	}
-	var result []NetworkPorts
-	for _, ports := range m.NetworkPorts_.NetworkPorts_ {
+	var result []OpenedPorts
+	for _, ports := range m.OpenedPorts_.OpenedPorts_ {
 		result = append(result, ports)
 	}
 	return result
 }
 
-// AddNetworkPorts implements Machine.
-func (m *machine) AddNetworkPorts(args NetworkPortsArgs) NetworkPorts {
-	if m.NetworkPorts_ == nil {
-		m.NetworkPorts_ = &versionedNetworkPorts{Version: 1}
+// AddOpenedPorts implements Machine.
+func (m *machine) AddOpenedPorts(args OpenedPortsArgs) OpenedPorts {
+	if m.OpenedPorts_ == nil {
+		m.OpenedPorts_ = &versionedOpenedPorts{Version: 1}
 	}
-	ports := newNetworkPorts(args)
-	m.NetworkPorts_.NetworkPorts_ = append(m.NetworkPorts_.NetworkPorts_, ports)
+	ports := newOpenedPorts(args)
+	m.OpenedPorts_.OpenedPorts_ = append(m.OpenedPorts_.OpenedPorts_, ports)
 	return ports
 }
 
-func (m *machine) setNetworkPorts(networkPortsList []*networkPorts) {
-	m.NetworkPorts_ = &versionedNetworkPorts{
-		Version:       1,
-		NetworkPorts_: networkPortsList,
+func (m *machine) setOpenedPorts(portsList []*openedPorts) {
+	m.OpenedPorts_ = &versionedOpenedPorts{
+		Version:      1,
+		OpenedPorts_: portsList,
 	}
 }
 
@@ -373,7 +373,7 @@ func importMachineV1(source map[string]interface{}) (*machine, error) {
 		"supported-containers": schema.List(schema.String()),
 		"tools":                schema.StringMap(schema.Any()),
 		"containers":           schema.List(schema.StringMap(schema.Any())),
-		"network-ports":        schema.StringMap(schema.Any()),
+		"opened-ports":         schema.StringMap(schema.Any()),
 
 		"provider-addresses":        schema.List(schema.StringMap(schema.Any())),
 		"machine-addresses":         schema.List(schema.StringMap(schema.Any())),
@@ -388,7 +388,7 @@ func importMachineV1(source map[string]interface{}) (*machine, error) {
 		// it isn't strictly necessary, so we allow it to not exist here.
 		"instance":                  schema.Omit,
 		"supported-containers":      schema.Omit,
-		"network-ports":             schema.Omit,
+		"opened-ports":              schema.Omit,
 		"provider-addresses":        schema.Omit,
 		"machine-addresses":         schema.Omit,
 		"preferred-public-address":  schema.Omit,
@@ -502,12 +502,12 @@ func importMachineV1(source map[string]interface{}) (*machine, error) {
 	}
 	result.Containers_ = machines
 
-	if npMap, ok := valid["network-ports"]; ok {
-		networkPortsList, err := importNetworkPorts(npMap.(map[string]interface{}))
+	if portsMap, ok := valid["opened-ports"]; ok {
+		portsList, err := importOpenedPorts(portsMap.(map[string]interface{}))
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		result.setNetworkPorts(networkPortsList)
+		result.setOpenedPorts(portsList)
 	}
 
 	return result, nil

--- a/core/description/model.go
+++ b/core/description/model.go
@@ -272,8 +272,8 @@ func (m *model) Validate() error {
 		if err := machine.Validate(); err != nil {
 			return errors.Trace(err)
 		}
-		for _, np := range machine.NetworkPorts() {
-			for _, pr := range np.OpenPorts() {
+		for _, op := range machine.OpenedPorts() {
+			for _, pr := range op.OpenPorts() {
 				unitsWithOpenPorts.Add(pr.UnitName())
 			}
 		}

--- a/core/description/model_test.go
+++ b/core/description/model_test.go
@@ -206,8 +206,8 @@ func (s *ModelSerializationSuite) TestModelValidationChecksMachinesGood(c *gc.C)
 func (s *ModelSerializationSuite) TestModelValidationChecksOpenPortsUnits(c *gc.C) {
 	model := NewModel(ModelArgs{Owner: names.NewUserTag("owner")})
 	machine := s.addMachineToModel(model, "0")
-	machine.AddNetworkPorts(NetworkPortsArgs{
-		OpenPorts: []PortRangeArgs{
+	machine.AddOpenedPorts(OpenedPortsArgs{
+		OpenedPorts: []PortRangeArgs{
 			{
 				UnitName: "missing/0",
 				FromPort: 8080,

--- a/core/description/ports_test.go
+++ b/core/description/ports_test.go
@@ -18,29 +18,29 @@ func (*PortRangeCheck) AssertPortRange(c *gc.C, pr PortRange, args PortRangeArgs
 	c.Assert(pr.Protocol(), gc.Equals, args.Protocol)
 }
 
-type NetworkPortsSerializationSuite struct {
+type OpenedPortsSerializationSuite struct {
 	SliceSerializationSuite
 	PortRangeCheck
 }
 
-var _ = gc.Suite(&NetworkPortsSerializationSuite{})
+var _ = gc.Suite(&OpenedPortsSerializationSuite{})
 
-func (s *NetworkPortsSerializationSuite) SetUpTest(c *gc.C) {
+func (s *OpenedPortsSerializationSuite) SetUpTest(c *gc.C) {
 	s.SliceSerializationSuite.SetUpTest(c)
-	s.importName = "network-ports"
-	s.sliceName = "network-ports"
+	s.importName = "opened-ports"
+	s.sliceName = "opened-ports"
 	s.importFunc = func(m map[string]interface{}) (interface{}, error) {
-		return importNetworkPorts(m)
+		return importOpenedPorts(m)
 	}
 	s.testFields = func(m map[string]interface{}) {
-		m["network-ports"] = []interface{}{}
+		m["opened-ports"] = []interface{}{}
 	}
 }
 
-func (s *NetworkPortsSerializationSuite) TestNewNetworkPorts(c *gc.C) {
-	args := NetworkPortsArgs{
-		NetworkName: "special",
-		OpenPorts: []PortRangeArgs{
+func (s *OpenedPortsSerializationSuite) TestNewNetworkPorts(c *gc.C) {
+	args := OpenedPortsArgs{
+		SubnetID: "0.1.2.0/24",
+		OpenedPorts: []PortRangeArgs{
 			PortRangeArgs{
 				UnitName: "magic/0",
 				FromPort: 1234,
@@ -56,23 +56,23 @@ func (s *NetworkPortsSerializationSuite) TestNewNetworkPorts(c *gc.C) {
 		},
 	}
 
-	ports := newNetworkPorts(args)
-	c.Assert(ports.NetworkName(), gc.Equals, args.NetworkName)
+	ports := newOpenedPorts(args)
+	c.Assert(ports.SubnetID(), gc.Equals, args.SubnetID)
 	opened := ports.OpenPorts()
 	c.Assert(opened, gc.HasLen, 2)
-	s.AssertPortRange(c, opened[0], args.OpenPorts[0])
-	s.AssertPortRange(c, opened[1], args.OpenPorts[1])
+	s.AssertPortRange(c, opened[0], args.OpenedPorts[0])
+	s.AssertPortRange(c, opened[1], args.OpenedPorts[1])
 }
 
-func (*NetworkPortsSerializationSuite) TestParsingSerializedData(c *gc.C) {
-	initial := &versionedNetworkPorts{
+func (*OpenedPortsSerializationSuite) TestParsingSerializedData(c *gc.C) {
+	initial := &versionedOpenedPorts{
 		Version: 1,
-		NetworkPorts_: []*networkPorts{
-			&networkPorts{
-				NetworkName_: "storage",
-				OpenPorts_: &portRanges{
+		OpenedPorts_: []*openedPorts{
+			&openedPorts{
+				SubnetID_: "fc00::/64",
+				OpenedPorts_: &portRanges{
 					Version: 1,
-					OpenPorts_: []*portRange{
+					OpenedPorts_: []*portRange{
 						&portRange{
 							UnitName_: "magic/0",
 							FromPort_: 1234,
@@ -82,11 +82,11 @@ func (*NetworkPortsSerializationSuite) TestParsingSerializedData(c *gc.C) {
 					},
 				},
 			},
-			&networkPorts{
-				NetworkName_: "workload",
-				OpenPorts_: &portRanges{
+			&openedPorts{
+				SubnetID_: "192.168.0.0/16",
+				OpenedPorts_: &portRanges{
 					Version: 1,
-					OpenPorts_: []*portRange{
+					OpenedPorts_: []*portRange{
 						&portRange{
 							UnitName_: "unicorn/0",
 							FromPort_: 80,
@@ -106,10 +106,10 @@ func (*NetworkPortsSerializationSuite) TestParsingSerializedData(c *gc.C) {
 	err = yaml.Unmarshal(bytes, &source)
 	c.Assert(err, jc.ErrorIsNil)
 
-	imported, err := importNetworkPorts(source)
+	imported, err := importOpenedPorts(source)
 	c.Assert(err, jc.ErrorIsNil)
 
-	c.Assert(imported, jc.DeepEquals, initial.NetworkPorts_)
+	c.Assert(imported, jc.DeepEquals, initial.OpenedPorts_)
 }
 
 type PortRangeSerializationSuite struct {
@@ -122,12 +122,12 @@ var _ = gc.Suite(&PortRangeSerializationSuite{})
 func (s *PortRangeSerializationSuite) SetUpTest(c *gc.C) {
 	s.SliceSerializationSuite.SetUpTest(c)
 	s.importName = "port-range"
-	s.sliceName = "open-ports"
+	s.sliceName = "opened-ports"
 	s.importFunc = func(m map[string]interface{}) (interface{}, error) {
 		return importPortRanges(m)
 	}
 	s.testFields = func(m map[string]interface{}) {
-		m["open-ports"] = []interface{}{}
+		m["opened-ports"] = []interface{}{}
 	}
 }
 
@@ -145,7 +145,7 @@ func (s *PortRangeSerializationSuite) TestNewPortRange(c *gc.C) {
 func (*PortRangeSerializationSuite) TestParsingSerializedData(c *gc.C) {
 	initial := &portRanges{
 		Version: 1,
-		OpenPorts_: []*portRange{
+		OpenedPorts_: []*portRange{
 			&portRange{
 				UnitName_: "magic/0",
 				FromPort_: 1234,
@@ -171,5 +171,5 @@ func (*PortRangeSerializationSuite) TestParsingSerializedData(c *gc.C) {
 	imported, err := importPortRanges(source)
 	c.Assert(err, jc.ErrorIsNil)
 
-	c.Assert(imported, jc.DeepEquals, initial.OpenPorts_)
+	c.Assert(imported, jc.DeepEquals, initial.OpenedPorts_)
 }

--- a/state/allwatcher.go
+++ b/state/allwatcher.go
@@ -922,7 +922,7 @@ func updateUnitPorts(st *State, store *multiwatcherStore, u *Unit) error {
 // backingEntityIdForOpenedPortsKey returns the entity id for the given
 // openedPorts key. Any extra information in the key is discarded.
 func backingEntityIdForOpenedPortsKey(modelUUID, key string) (multiwatcher.EntityId, bool) {
-	parts, err := extractPortsIdParts(key)
+	parts, err := extractPortsIDParts(key)
 	if err != nil {
 		logger.Debugf("cannot parse ports key %q: %v", key, err)
 		return multiwatcher.EntityId{}, false

--- a/state/allwatcher_internal_test.go
+++ b/state/allwatcher_internal_test.go
@@ -2820,7 +2820,7 @@ func testChangeUnitsNonNilPorts(c *gc.C, owner names.UserTag, runChangeTests fun
 			if flag&assignUnit != 0 {
 				c.Assert(err, jc.ErrorIsNil)
 			} else {
-				c.Assert(err, gc.ErrorMatches, `cannot open ports 12345-12345/tcp \("wordpress/0"\) for unit "wordpress/0": .*`)
+				c.Assert(err, gc.ErrorMatches, `cannot open ports 12345-12345/tcp \("wordpress/0"\) for unit "wordpress/0".*`)
 				c.Assert(err, jc.Satisfies, errors.IsNotAssigned)
 			}
 		}

--- a/state/allwatcher_internal_test.go
+++ b/state/allwatcher_internal_test.go
@@ -611,7 +611,7 @@ func (s *allWatcherStateSuite) TestClosingPorts(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = b.Changed(all, watcher.Change{
 		C:  openedPortsC,
-		Id: s.state.docID("m#0#n#juju-public"),
+		Id: s.state.docID("m#0#0.1.2.0/24"),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	entities = all.All()
@@ -2408,7 +2408,7 @@ func testChangeUnits(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, []
 				},
 				change: watcher.Change{
 					C:  openedPortsC,
-					Id: st.docID("m#0#n#juju-public"),
+					Id: st.docID("m#0#"),
 				},
 				expectContents: []multiwatcher.EntityInfo{
 					&multiwatcher.UnitInfo{

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -335,7 +335,7 @@ func (s *MachineSuite) TestDestroyRemovePorts(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = unit.OpenPort("tcp", 8080)
 	c.Assert(err, jc.ErrorIsNil)
-	ports, err := state.GetPorts(s.State, s.machine.Id(), network.DefaultPublic)
+	ports, err := state.GetPorts(s.State, s.machine.Id(), "")
 	c.Assert(ports, gc.NotNil)
 	c.Assert(err, jc.ErrorIsNil)
 	err = unit.UnassignFromMachine()
@@ -347,7 +347,7 @@ func (s *MachineSuite) TestDestroyRemovePorts(c *gc.C) {
 	err = s.machine.Remove()
 	c.Assert(err, jc.ErrorIsNil)
 	// once the machine is destroyed, there should be no ports documents present for it
-	ports, err = state.GetPorts(s.State, s.machine.Id(), network.DefaultPublic)
+	ports, err = state.GetPorts(s.State, s.machine.Id(), "")
 	c.Assert(ports, gc.IsNil)
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -293,8 +293,8 @@ func (e *exporter) newMachine(exParent description.Machine, machine *Machine, in
 		Size:    tools.Size,
 	})
 
-	for _, args := range e.networkPortsArgsForMachine(machine.Id(), portsData) {
-		exMachine.AddNetworkPorts(args)
+	for _, args := range e.openedPortsArgsForMachine(machine.Id(), portsData) {
+		exMachine.AddOpenedPorts(args)
 	}
 
 	exMachine.SetAnnotations(e.getAnnotations(globalKey))
@@ -308,14 +308,14 @@ func (e *exporter) newMachine(exParent description.Machine, machine *Machine, in
 	return exMachine, nil
 }
 
-func (e *exporter) networkPortsArgsForMachine(machineId string, portsData []portsDoc) []description.NetworkPortsArgs {
-	var result []description.NetworkPortsArgs
+func (e *exporter) openedPortsArgsForMachine(machineId string, portsData []portsDoc) []description.OpenedPortsArgs {
+	var result []description.OpenedPortsArgs
 	for _, doc := range portsData {
-		// Don't bother including a network if there are no ports open on it.
+		// Don't bother including a subnet if there are no ports open on it.
 		if doc.MachineID == machineId && len(doc.Ports) > 0 {
-			args := description.NetworkPortsArgs{NetworkName: doc.NetworkName}
+			args := description.OpenedPortsArgs{SubnetID: doc.SubnetID}
 			for _, p := range doc.Ports {
-				args.OpenPorts = append(args.OpenPorts, description.PortRangeArgs{
+				args.OpenedPorts = append(args.OpenedPorts, description.PortRangeArgs{
 					UnitName: p.UnitName,
 					FromPort: p.FromPort,
 					ToPort:   p.ToPort,

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -359,12 +359,12 @@ func (s *MigrationExportSuite) TestUnitsOpenPorts(c *gc.C) {
 	machines := model.Machines()
 	c.Assert(machines, gc.HasLen, 1)
 
-	ports := machines[0].NetworkPorts()
+	ports := machines[0].OpenedPorts()
 	c.Assert(ports, gc.HasLen, 1)
 
-	network := ports[0]
-	c.Assert(network.NetworkName(), gc.Equals, "juju-public")
-	opened := network.OpenPorts()
+	port := ports[0]
+	c.Assert(port.SubnetID(), gc.Equals, "")
+	opened := port.OpenPorts()
 	c.Assert(opened, gc.HasLen, 1)
 	c.Assert(opened[0].UnitName(), gc.Equals, unit.Name())
 }

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -318,13 +318,13 @@ func (i *importer) machine(m description.Machine) error {
 
 func (i *importer) machinePortsOps(m description.Machine) []txn.Op {
 	var result []txn.Op
-	machineId := m.Id()
+	machineID := m.Id()
 
-	for _, ports := range m.NetworkPorts() {
-		networkName := ports.NetworkName()
+	for _, ports := range m.OpenedPorts() {
+		subnetID := ports.SubnetID()
 		doc := &portsDoc{
-			MachineID:   machineId,
-			NetworkName: networkName,
+			MachineID: machineID,
+			SubnetID:  subnetID,
 		}
 		for _, opened := range ports.OpenPorts() {
 			doc.Ports = append(doc.Ports, PortRange{
@@ -336,7 +336,7 @@ func (i *importer) machinePortsOps(m description.Machine) []txn.Op {
 		}
 		result = append(result, txn.Op{
 			C:      openedPortsC,
-			Id:     portsGlobalKey(machineId, networkName),
+			Id:     portsGlobalKey(machineID, subnetID),
 			Assert: txn.DocMissing,
 			Insert: doc,
 		})

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -372,9 +372,9 @@ func (s *MigrationSuite) TestPortsDocFields(c *gc.C) {
 		// ModelUUID shouldn't be exported, and is inherited
 		// from the model definition.
 		"ModelUUID",
-		// MachineId is implicit in the migration structure through containment.
+		// MachineID is implicit in the migration structure through containment.
 		"MachineID",
-		"NetworkName",
+		"SubnetID",
 		"Ports",
 		// TxnRevno isn't migrated.
 		"TxnRevno",

--- a/state/unit.go
+++ b/state/unit.go
@@ -849,9 +849,7 @@ func (u *Unit) OpenPorts(protocol string, fromPort, toPort int) (err error) {
 		return errors.Annotatef(err, "unit %q has no assigned machine", u)
 	}
 
-	// TODO(dimitern) 2014-09-10 bug #1337804: network name is
-	// hard-coded until multiple network support lands
-	machinePorts, err := getOrCreatePorts(u.st, machineId, network.DefaultPublic)
+	machinePorts, err := getOrCreatePorts(u.st, machineId, "")
 	if err != nil {
 		return errors.Annotatef(err, "cannot get or create ports for machine %q", machineId)
 	}
@@ -872,9 +870,7 @@ func (u *Unit) ClosePorts(protocol string, fromPort, toPort int) (err error) {
 		return errors.Annotatef(err, "unit %q has no assigned machine", u)
 	}
 
-	// TODO(dimitern) 2014-09-10 bug #1337804: network name is
-	// hard-coded until multiple network support lands
-	machinePorts, err := getOrCreatePorts(u.st, machineId, network.DefaultPublic)
+	machinePorts, err := getOrCreatePorts(u.st, machineId, "")
 	if err != nil {
 		return errors.Annotatef(err, "cannot get or create ports for machine %q", machineId)
 	}
@@ -900,9 +896,7 @@ func (u *Unit) OpenedPorts() ([]network.PortRange, error) {
 		return nil, errors.Annotatef(err, "unit %q has no assigned machine", u)
 	}
 
-	// TODO(dimitern) 2014-09-10 bug #1337804: network name is
-	// hard-coded until multiple network support lands
-	machinePorts, err := getPorts(u.st, machineId, network.DefaultPublic)
+	machinePorts, err := getPorts(u.st, machineId, "")
 	result := []network.PortRange{}
 	if err == nil {
 		ports := machinePorts.PortsForUnit(u.Name())

--- a/state/unit.go
+++ b/state/unit.go
@@ -834,86 +834,167 @@ func (u *Unit) SetStatus(unitStatus status.Status, info string, data map[string]
 	})
 }
 
-// OpenPorts opens the given port range and protocol for the unit, if
-// it does not conflict with another already opened range on the
-// unit's assigned machine.
-func (u *Unit) OpenPorts(protocol string, fromPort, toPort int) (err error) {
+// OpenPortsOnSubnet opens the given port range and protocol for the unit on the
+// given subnet, which can be empty. When non-empty, subnetID must refer to an
+// existing, alive subnet, otherwise an error is returned. Returns an error if
+// opening the requested range conflicts with another already opened range on
+// the same subnet and and the unit's assigned machine.
+func (u *Unit) OpenPortsOnSubnet(subnetID, protocol string, fromPort, toPort int) (err error) {
 	ports, err := NewPortRange(u.Name(), fromPort, toPort, protocol)
 	if err != nil {
 		return errors.Annotatef(err, "invalid port range %v-%v/%v", fromPort, toPort, protocol)
 	}
-	defer errors.DeferredAnnotatef(&err, "cannot open ports %v for unit %q", ports, u)
+	defer errors.DeferredAnnotatef(&err, "cannot open ports %v for unit %q on subnet %q", ports, u, subnetID)
 
-	machineId, err := u.AssignedMachineId()
+	machineID, err := u.AssignedMachineId()
 	if err != nil {
 		return errors.Annotatef(err, "unit %q has no assigned machine", u)
 	}
 
-	machinePorts, err := getOrCreatePorts(u.st, machineId, "")
+	if err := u.checkSubnetAliveWhenSet(subnetID); err != nil {
+		return errors.Trace(err)
+	}
+
+	machinePorts, err := getOrCreatePorts(u.st, machineID, subnetID)
 	if err != nil {
-		return errors.Annotatef(err, "cannot get or create ports for machine %q", machineId)
+		return errors.Annotate(err, "cannot get or create ports")
 	}
 
 	return machinePorts.OpenPorts(ports)
 }
 
-// ClosePorts closes the given port range and protocol for the unit.
-func (u *Unit) ClosePorts(protocol string, fromPort, toPort int) (err error) {
+func (u *Unit) checkSubnetAliveWhenSet(subnetID string) error {
+	if subnetID == "" {
+		return nil
+	} else if !names.IsValidSubnet(subnetID) {
+		return errors.Errorf("invalid subnet ID %q", subnetID)
+	}
+
+	subnet, err := u.st.Subnet(subnetID)
+	if err != nil && !errors.IsNotFound(err) {
+		return errors.Annotatef(err, "getting subnet %q", subnetID)
+	} else if errors.IsNotFound(err) || subnet.Life() != Alive {
+		return errors.Errorf("subnet %q not found or not alive", subnetID)
+	}
+	return nil
+}
+
+// ClosePortsOnSubnet closes the given port range and protocol for the unit on
+// the given subnet, which can be empty. When non-empty, subnetID must refer to
+// an existing, alive subnet, otherwise an error is returned.
+func (u *Unit) ClosePortsOnSubnet(subnetID, protocol string, fromPort, toPort int) (err error) {
 	ports, err := NewPortRange(u.Name(), fromPort, toPort, protocol)
 	if err != nil {
 		return errors.Annotatef(err, "invalid port range %v-%v/%v", fromPort, toPort, protocol)
 	}
-	defer errors.DeferredAnnotatef(&err, "cannot close ports %v for unit %q", ports, u)
+	defer errors.DeferredAnnotatef(&err, "cannot close ports %v for unit %q on subnet %q", ports, u, subnetID)
 
-	machineId, err := u.AssignedMachineId()
+	machineID, err := u.AssignedMachineId()
 	if err != nil {
 		return errors.Annotatef(err, "unit %q has no assigned machine", u)
 	}
 
-	machinePorts, err := getOrCreatePorts(u.st, machineId, "")
+	if err := u.checkSubnetAliveWhenSet(subnetID); err != nil {
+		return errors.Trace(err)
+	}
+
+	machinePorts, err := getOrCreatePorts(u.st, machineID, subnetID)
 	if err != nil {
-		return errors.Annotatef(err, "cannot get or create ports for machine %q", machineId)
+		return errors.Annotate(err, "cannot get or create ports")
 	}
 
 	return machinePorts.ClosePorts(ports)
 }
 
+// OpenPorts opens the given port range and protocol for the unit, if it does
+// not conflict with another already opened range on the unit's assigned
+// machine.
+//
+// TODO(dimitern): This should be removed once we use OpenPortsOnSubnet across
+// the board, passing subnet IDs explicitly.
+func (u *Unit) OpenPorts(protocol string, fromPort, toPort int) error {
+	return u.OpenPortsOnSubnet("", protocol, fromPort, toPort)
+}
+
+// ClosePorts closes the given port range and protocol for the unit.
+//
+// TODO(dimitern): This should be removed once we use ClosePortsOnSubnet across
+// the board, passing subnet IDs explicitly.
+func (u *Unit) ClosePorts(protocol string, fromPort, toPort int) (err error) {
+	return u.ClosePortsOnSubnet("", protocol, fromPort, toPort)
+}
+
+// OpenPortOnSubnet opens the given port and protocol for the unit on the given
+// subnet, which can be empty. When non-empty, subnetID must refer to an
+// existing, alive subnet, otherwise an error is returned.
+func (u *Unit) OpenPortOnSubnet(subnetID, protocol string, number int) error {
+	return u.OpenPortsOnSubnet(subnetID, protocol, number, number)
+}
+
+// ClosePortOnSubnet closes the given port and protocol for the unit on the given
+// subnet, which can be empty. When non-empty, subnetID must refer to an
+// existing, alive subnet, otherwise an error is returned.
+func (u *Unit) ClosePortOnSubnet(subnetID, protocol string, number int) error {
+	return u.ClosePortsOnSubnet(subnetID, protocol, number, number)
+}
+
 // OpenPort opens the given port and protocol for the unit.
+//
+// TODO(dimitern): This should be removed once we use OpenPort(s)OnSubnet across
+// the board, passing subnet IDs explicitly.
 func (u *Unit) OpenPort(protocol string, number int) error {
-	return u.OpenPorts(protocol, number, number)
+	return u.OpenPortOnSubnet("", protocol, number)
 }
 
 // ClosePort closes the given port and protocol for the unit.
+//
+// TODO(dimitern): This should be removed once we use ClosePortsOnSubnet across
+// the board, passing subnet IDs explicitly.
 func (u *Unit) ClosePort(protocol string, number int) error {
-	return u.ClosePorts(protocol, number, number)
+	return u.ClosePortOnSubnet("", protocol, number)
 }
 
-// OpenedPorts returns a slice containing the open port ranges of the
-// unit.
-func (u *Unit) OpenedPorts() ([]network.PortRange, error) {
-	machineId, err := u.AssignedMachineId()
+// OpenedPortsOnSubnet returns a slice containing the open port ranges of the
+// unit on the given subnet ID, which can be empty. When subnetID is not empty,
+// it must refer to an existing, alive subnet, otherwise an error is returned.
+// Also, when no ports are yet open for the unit on that subnet, no error and
+// empty slice is returned.
+func (u *Unit) OpenedPortsOnSubnet(subnetID string) ([]network.PortRange, error) {
+	machineID, err := u.AssignedMachineId()
 	if err != nil {
 		return nil, errors.Annotatef(err, "unit %q has no assigned machine", u)
 	}
 
-	machinePorts, err := getPorts(u.st, machineId, "")
+	if err := u.checkSubnetAliveWhenSet(subnetID); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	machinePorts, err := getPorts(u.st, machineID, subnetID)
 	result := []network.PortRange{}
-	if err == nil {
-		ports := machinePorts.PortsForUnit(u.Name())
-		for _, port := range ports {
-			result = append(result, network.PortRange{
-				Protocol: port.Protocol,
-				FromPort: port.FromPort,
-				ToPort:   port.ToPort,
-			})
-		}
-	} else {
-		if !errors.IsNotFound(err) {
-			return nil, errors.Annotatef(err, "failed getting ports for unit %q", u)
-		}
+	if errors.IsNotFound(err) {
+		return result, nil
+	} else if err != nil {
+		return nil, errors.Annotatef(err, "failed getting ports for unit %q, subnet %q", u, subnetID)
+	}
+	ports := machinePorts.PortsForUnit(u.Name())
+	for _, port := range ports {
+		result = append(result, network.PortRange{
+			Protocol: port.Protocol,
+			FromPort: port.FromPort,
+			ToPort:   port.ToPort,
+		})
 	}
 	network.SortPortRanges(result)
 	return result, nil
+}
+
+// OpenedPorts returns a slice containing the open port ranges of the
+// unit.
+//
+// TODO(dimitern): This should be removed once we use OpenedPortsOnSubnet across
+// the board, passing subnet IDs explicitly.
+func (u *Unit) OpenedPorts() ([]network.PortRange, error) {
+	return u.OpenedPortsOnSubnet("")
 }
 
 // CharmURL returns the charm URL this unit is currently using.

--- a/state/unit_test.go
+++ b/state/unit_test.go
@@ -961,10 +961,13 @@ func (s *UnitSuite) TestOpenedPortsOnInvalidSubnet(c *gc.C) {
 }
 
 func (s *UnitSuite) TestOpenedPortsOnUnknownSubnet(c *gc.C) {
+	// We're not adding the 127.0.0.0/8 subnet to test the "not found" case.
 	s.testOpenedPorts(c, "127.0.0.0/8", `subnet "127.0.0.0/8" not found or not alive`)
 }
 
 func (s *UnitSuite) TestOpenedPortsOnDeadSubnet(c *gc.C) {
+	// We're adding the 0.1.2.0/24 subnet first and then setting it to Dead to
+	// check the "not alive" case.
 	subnet, err := s.State.AddSubnet(state.SubnetInfo{CIDR: "0.1.2.0/24"})
 	c.Assert(err, jc.ErrorIsNil)
 	err = subnet.EnsureDead()

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -2402,14 +2402,14 @@ func (w *openedPortsWatcher) Changes() <-chan []string {
 }
 
 // transformId converts a global key for a ports document (e.g.
-// "m#42#n#juju-public") into a colon-separated string with the
-// machine id and network name (e.g. "42:juju-public").
-func (w *openedPortsWatcher) transformId(globalKey string) (string, error) {
-	parts, err := extractPortsIdParts(globalKey)
+// "m#42#0.1.2.0/24") into a colon-separated string with the
+// machine and subnet IDs (e.g. "42:0.1.2.0/24").
+func (w *openedPortsWatcher) transformID(globalKey string) (string, error) {
+	parts, err := extractPortsIDParts(globalKey)
 	if err != nil {
 		return "", errors.Trace(err)
 	}
-	return fmt.Sprintf("%s:%s", parts[machineIdPart], parts[networkNamePart]), nil
+	return fmt.Sprintf("%s:%s", parts[machineIDPart], parts[subnetIDPart]), nil
 }
 
 func (w *openedPortsWatcher) initial() (set.Strings, error) {
@@ -2427,10 +2427,10 @@ func (w *openedPortsWatcher) initial() (set.Strings, error) {
 		if doc.TxnRevno != -1 {
 			w.known[id] = doc.TxnRevno
 		}
-		if changeId, err := w.transformId(id); err != nil {
+		if changeID, err := w.transformID(id); err != nil {
 			logger.Errorf(err.Error())
 		} else {
-			portDocs.Add(changeId)
+			portDocs.Add(changeID)
 		}
 	}
 	return portDocs, errors.Trace(iter.Close())
@@ -2477,11 +2477,11 @@ func (w *openedPortsWatcher) merge(ids set.Strings, change watcher.Change) error
 	}
 	if change.Revno == -1 {
 		delete(w.known, localID)
-		if changeId, err := w.transformId(localID); err != nil {
+		if changeID, err := w.transformID(localID); err != nil {
 			logger.Errorf(err.Error())
 		} else {
 			// Report the removed id.
-			ids.Add(changeId)
+			ids.Add(changeID)
 		}
 		return nil
 	}
@@ -2494,11 +2494,11 @@ func (w *openedPortsWatcher) merge(ids set.Strings, change watcher.Change) error
 	knownRevno, isKnown := w.known[localID]
 	w.known[localID] = currentRevno
 	if !isKnown || currentRevno > knownRevno {
-		if changeId, err := w.transformId(localID); err != nil {
+		if changeID, err := w.transformID(localID); err != nil {
 			logger.Errorf(err.Error())
 		} else {
 			// Report the unknown-so-far id.
-			ids.Add(changeId)
+			ids.Add(changeID)
 		}
 	}
 	return nil

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -2373,10 +2373,10 @@ type openedPortsWatcher struct {
 
 var _ Watcher = (*openedPortsWatcher)(nil)
 
-// WatchOpenedPorts starts and returns a StringsWatcher notifying of
-// changes to the openedPorts collection. Reported changes have the
-// following format: "<machine-id>:<network-name>", i.e.
-// "0:juju-public".
+// WatchOpenedPorts starts and returns a StringsWatcher notifying of changes to
+// the openedPorts collection. Reported changes have the following format:
+// "<machine-id>:[<subnet-CIDR>]", i.e. "0:10.20.0.0/16" or "1:" (empty subnet
+// ID is allowed for backwards-compatibility).
 func (st *State) WatchOpenedPorts() StringsWatcher {
 	return newOpenedPortsWatcher(st)
 }
@@ -2402,8 +2402,9 @@ func (w *openedPortsWatcher) Changes() <-chan []string {
 }
 
 // transformId converts a global key for a ports document (e.g.
-// "m#42#0.1.2.0/24") into a colon-separated string with the
-// machine and subnet IDs (e.g. "42:0.1.2.0/24").
+// "m#42#0.1.2.0/24") into a colon-separated string with the machine and subnet
+// IDs (e.g. "42:0.1.2.0/24"). Subnet ID (a.k.a. CIDR) can be empty for
+// backwards-compatibility.
 func (w *openedPortsWatcher) transformID(globalKey string) (string, error) {
 	parts, err := extractPortsIDParts(globalKey)
 	if err != nil {

--- a/worker/firewaller/firewaller.go
+++ b/worker/firewaller/firewaller.go
@@ -168,11 +168,11 @@ func (fw *Firewaller) loop() error {
 				return errors.New("ports watcher closed")
 			}
 			for _, portsGlobalKey := range change {
-				machineTag, networkTag, err := parsePortsKey(portsGlobalKey)
+				machineTag, subnetTag, err := parsePortsKey(portsGlobalKey)
 				if err != nil {
 					return errors.Trace(err)
 				}
-				if err := fw.openedPortsChanged(machineTag, networkTag); err != nil {
+				if err := fw.openedPortsChanged(machineTag, subnetTag); err != nil {
 					return errors.Trace(err)
 				}
 			}
@@ -289,13 +289,13 @@ func (fw *Firewaller) startUnit(unit *firewaller.Unit, machineTag names.MachineT
 		return err
 	}
 
-	// check if the machine has ports open on any networks
-	networkTags, err := m.ActiveNetworks()
+	// check if the machine has ports open on any subnets
+	subnetTags, err := m.ActiveSubnets()
 	if err != nil {
 		return errors.Annotatef(err, "failed getting %q active networks", machineTag)
 	}
-	for _, networkTag := range networkTags {
-		err := fw.openedPortsChanged(machineTag, networkTag)
+	for _, subnetTag := range subnetTags {
+		err := fw.openedPortsChanged(machineTag, subnetTag)
 		if err != nil {
 			return err
 		}
@@ -479,7 +479,7 @@ func (fw *Firewaller) unitsChanged(change *unitsChange) error {
 }
 
 // openedPortsChanged handles port change notifications
-func (fw *Firewaller) openedPortsChanged(machineTag names.MachineTag, networkTag names.NetworkTag) error {
+func (fw *Firewaller) openedPortsChanged(machineTag names.MachineTag, subnetTag names.SubnetTag) error {
 
 	machined, ok := fw.machineds[machineTag]
 	if !ok {
@@ -495,7 +495,7 @@ func (fw *Firewaller) openedPortsChanged(machineTag names.MachineTag, networkTag
 		return err
 	}
 
-	ports, err := m.OpenedPorts(networkTag)
+	ports, err := m.OpenedPorts(subnetTag)
 	if err != nil {
 		return err
 	}
@@ -881,17 +881,21 @@ next:
 	return
 }
 
-// parsePortsKey parses a ports document global key coming from the
-// ports watcher (e.g. "42:juju-public") and returns the machine and
-// network tags from its components (in the last example "machine-42"
-// and "network-juju-public").
-func parsePortsKey(change string) (machineTag names.MachineTag, networkTag names.NetworkTag, err error) {
+// parsePortsKey parses a ports document global key coming from the ports
+// watcher (e.g. "42:0.1.2.0/24") and returns the machine and subnet tags from
+// its components (in the last example "machine-42" and "subnet-0.1.2.0/24").
+func parsePortsKey(change string) (machineTag names.MachineTag, subnetTag names.SubnetTag, err error) {
 	defer errors.DeferredAnnotatef(&err, "invalid ports change %q", change)
 
 	parts := strings.SplitN(change, ":", 2)
 	if len(parts) != 2 {
-		return names.MachineTag{}, names.NetworkTag{}, errors.Errorf("unexpected format")
+		return names.MachineTag{}, names.SubnetTag{}, errors.Errorf("unexpected format")
 	}
-	machineId, networkName := parts[0], parts[1]
-	return names.NewMachineTag(machineId), names.NewNetworkTag(networkName), nil
+	machineID, subnetID := parts[0], parts[1]
+
+	machineTag = names.NewMachineTag(machineID)
+	if subnetID != "" {
+		subnetTag = names.NewSubnetTag(subnetID)
+	}
+	return machineTag, subnetTag, nil
 }


### PR DESCRIPTION
The only remaining place where the legacy networks model is still used,
opened ports, no longer refers to networks but to subnets instead.

This is a prerequisite step to enable removing of all remnants of the
legacy networks and network interfaces code across the board.

Unit ports can now be explicitly opened on a given alive subnet. Nothing
uses that yet, except in tests, but at least paves the way to enable charms
to be explicit about on which subnet (address) a port needs to be opened
(once the uniter to changes accordingly).

Firewaller API server facade now returns errors coming from parsing tags
with invalid format, rather than ErrPerm.

Live tested on EC2 and MAAS 1.9: deploying a unit, opening ports and
ranges, listing opened ports, closing ports, exposing the service,
verifying connectivity on opened ports.

(Review request: http://reviews.vapour.ws/r/4656/)