### PR TITLE
Update testing stream data for openstack

### DIFF
--- a/cmd/juju/commands/add_sshkeys.go
+++ b/cmd/juju/commands/add_sshkeys.go
@@ -37,7 +37,7 @@ Examples:
 For ease of use it is possible to use shell substitution to pass the key 
 to the command:
 
-    juju add-ssh-key $(cat ~/mykey.pub)
+juju add-ssh-key "$(cat ~/mykey.pub)"
 
 See also: 
     list-ssh-key

--- a/provider/openstack/export_test.go
+++ b/provider/openstack/export_test.go
@@ -104,6 +104,8 @@ var indexData = `
 		   "datatype": "image-ids",
 		   "format": "products:1.0",
 		   "products": [
+			"com.ubuntu.cloud:server:16.04:s390x",
+			"com.ubuntu.cloud:server:14.04:s390x",
 			"com.ubuntu.cloud:server:14.04:amd64",
 			"com.ubuntu.cloud:server:14.04:i386",
 			"com.ubuntu.cloud:server:14.04:ppc64el",
@@ -243,6 +245,56 @@ var imagesData = `
            }
          },
          "pubname": "ubuntu-raring-13.04-amd64-server-20121218",
+         "label": "release"
+       }
+     }
+   },
+   "com.ubuntu.cloud:server:14.04:s390x": {
+     "release": "trusty",
+     "version": "14.04",
+     "arch": "s390x",
+     "versions": {
+       "20121218": {
+         "items": {
+           "inst5": {
+             "root_store": "ebs",
+             "virt": "pv",
+             "region": "some-region",
+             "id": "id-y"
+           },
+           "inst6": {
+             "root_store": "ebs",
+             "virt": "pv",
+             "region": "another-region",
+             "id": "id-z"
+           }
+         },
+         "pubname": "ubuntu-trusty-14.04-s390x-server-20121218",
+         "label": "release"
+       }
+     }
+   },
+   "com.ubuntu.cloud:server:16.04:s390x": {
+     "release": "xenial",
+     "version": "16.04",
+     "arch": "s390x",
+     "versions": {
+       "20121218": {
+         "items": {
+           "inst5": {
+             "root_store": "ebs",
+             "virt": "pv",
+             "region": "some-region",
+             "id": "id-y"
+           },
+           "inst6": {
+             "root_store": "ebs",
+             "virt": "pv",
+             "region": "another-region",
+             "id": "id-z"
+           }
+         },
+         "pubname": "ubuntu-xenial-16.04-s390x-server-20121218",
          "label": "release"
        }
      }

--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -927,7 +927,7 @@ func (s *localServerSuite) TestSupportedArchitectures(c *gc.C) {
 	env := s.Open(c, s.env.Config())
 	a, err := env.SupportedArchitectures()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(a, jc.SameContents, []string{"amd64", "i386", "ppc64el"})
+	c.Assert(a, jc.SameContents, []string{"amd64", "i386", "ppc64el", "s390x"})
 }
 
 func (s *localServerSuite) TestSupportsNetworking(c *gc.C) {


### PR DESCRIPTION
This adds s390x support to the openstack tests.

These test updates make the tests pass on s390x. However I am unclear on whether we should be supporting trusty s390x or only xenial. Possibly host guest variations might require it here. Leaving it in unless otherwise decided in review.
 
Refs https://bugs.launchpad.net/juju-core/+bug/1565044

(Review request: http://reviews.vapour.ws/r/4661/)