### PR TITLE
Change net.IPNet literal to be keyed

### DIFF
--- a/cmd/juju/status/output_summary.go
+++ b/cmd/juju/status/output_summary.go
@@ -135,7 +135,7 @@ func (f *summaryFormatter) trackIp(ip net.IP) {
 		}
 	}
 
-	ipNet := net.IPNet{ip, ip.DefaultMask()}
+	ipNet := net.IPNet{IP: ip, Mask: ip.DefaultMask()}
 	f.ipAddrs = append(f.ipAddrs, ipNet)
 	f.netStrings = append(f.netStrings, ipNet.String())
 }


### PR DESCRIPTION
Unkeyed struct literals are not covered by the go1 compatibility guarantee,
and this one breaks with Go 1.7.