### PR TITLE
1564503 - Get arm64 unit tests passing

### DIFF
--- a/provider/openstack/export_test.go
+++ b/provider/openstack/export_test.go
@@ -89,6 +89,8 @@ func NewCinderVolumeSource(s OpenstackStorage) storage.VolumeSource {
 	return &cinderVolumeSource{openstackStorage(s), envName, modelUUID}
 }
 
+// Include images for arches currently supported.  i386 is no longer
+// supported, so it can be excluded.
 var indexData = `
 		{
 		 "index": {

--- a/provider/openstack/export_test.go
+++ b/provider/openstack/export_test.go
@@ -107,7 +107,7 @@ var indexData = `
 			"com.ubuntu.cloud:server:16.04:s390x",
 			"com.ubuntu.cloud:server:14.04:s390x",
 			"com.ubuntu.cloud:server:14.04:amd64",
-			"com.ubuntu.cloud:server:14.04:i386",
+			"com.ubuntu.cloud:server:14.04:arm64",
 			"com.ubuntu.cloud:server:14.04:ppc64el",
 			"com.ubuntu.cloud:server:12.10:amd64",
 			"com.ubuntu.cloud:server:13.04:amd64"
@@ -161,10 +161,10 @@ var imagesData = `
        }
      }
    },
-   "com.ubuntu.cloud:server:14.04:i386": {
+   "com.ubuntu.cloud:server:14.04:arm64": {
      "release": "trusty",
      "version": "14.04",
-     "arch": "i386",
+     "arch": "arm64",
      "versions": {
        "20121111": {
          "items": {
@@ -175,7 +175,7 @@ var imagesData = `
              "id": "33"
            }
          },
-         "pubname": "ubuntu-trusty-14.04-i386-server-20121111",
+         "pubname": "ubuntu-trusty-14.04-arm64-server-20121111",
          "label": "release"
        }
      }

--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -927,7 +927,7 @@ func (s *localServerSuite) TestSupportedArchitectures(c *gc.C) {
 	env := s.Open(c, s.env.Config())
 	a, err := env.SupportedArchitectures()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(a, jc.SameContents, []string{"amd64", "i386", "ppc64el", "s390x"})
+	c.Assert(a, jc.SameContents, []string{"amd64", "arm64", "ppc64el", "s390x"})
 }
 
 func (s *localServerSuite) TestSupportsNetworking(c *gc.C) {
@@ -959,9 +959,9 @@ func (s *localServerSuite) TestConstraintsValidatorVocab(c *gc.C) {
 	env := s.Open(c, s.env.Config())
 	validator, err := env.ConstraintsValidator()
 	c.Assert(err, jc.ErrorIsNil)
-	cons := constraints.MustParse("arch=arm64")
+	cons := constraints.MustParse("arch=i386")
 	_, err = validator.Validate(cons)
-	c.Assert(err, gc.ErrorMatches, "invalid constraint value: arch=arm64\nvalid values are:.*")
+	c.Assert(err, gc.ErrorMatches, "invalid constraint value: arch=i386\nvalid values are:.*")
 	cons = constraints.MustParse("instance-type=foo")
 	_, err = validator.Validate(cons)
 	c.Assert(err, gc.ErrorMatches, "invalid constraint value: instance-type=foo\nvalid values are:.*")

--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -959,6 +959,9 @@ func (s *localServerSuite) TestConstraintsValidatorVocab(c *gc.C) {
 	env := s.Open(c, s.env.Config())
 	validator, err := env.ConstraintsValidator()
 	c.Assert(err, jc.ErrorIsNil)
+
+	// i386 is a valid arch, but is no longer supported.  No image
+	// data was created for it for the test.
 	cons := constraints.MustParse("arch=i386")
 	_, err = validator.Validate(cons)
 	c.Assert(err, gc.ErrorMatches, "invalid constraint value: arch=i386\nvalid values are:.*")


### PR DESCRIPTION
The juju/juju/provider/openstack package is the last
failing package for the arm64 unit tests.  I added in
image data for arm64 to enable the tests to pass.

There is a test which verifies that specifying a valid
arch for which there are no images fails properly.  We
are no longer testing i386, so that is now the arch
that has no tools.

(Review request: http://reviews.vapour.ws/r/4669/)