### PR TITLE
worker/provisioner: filter container tools to host

### DIFF
--- a/worker/provisioner/container_initialisation.go
+++ b/worker/provisioner/container_initialisation.go
@@ -316,10 +316,16 @@ func (cs *ContainerSetup) getContainerArtifacts(
 		}
 
 		initialiser = lxd.NewContainerInitialiser(series)
+		namespace := maybeGetManagerConfigNamespaces(managerConfig)
+		manager, err := lxd.NewContainerManager(managerConfig)
+		if err != nil {
+			return nil, nil, nil, err
+		}
 		broker, err = NewLxdBroker(
 			cs.provisioner,
+			manager,
 			cs.config,
-			managerConfig,
+			namespace,
 			cs.enableNAT,
 		)
 		if err != nil {

--- a/worker/provisioner/kvm-broker_test.go
+++ b/worker/provisioner/kvm-broker_test.go
@@ -117,6 +117,10 @@ func (s *kvmBrokerSuite) startInstance(c *gc.C, machineId string) instance.Insta
 	possibleTools := coretools.List{&coretools.Tools{
 		Version: version.MustParseBinary("2.3.4-quantal-amd64"),
 		URL:     "http://tools.testing.invalid/2.3.4-quantal-amd64.tgz",
+	}, {
+		// non-host-arch tools should be filtered out by StartInstance
+		Version: version.MustParseBinary("2.3.4-quantal-arm64"),
+		URL:     "http://tools.testing.invalid/2.3.4-quantal-arm64.tgz",
 	}}
 	callback := func(settableStatus status.Status, info string, data map[string]interface{}) error {
 		return nil

--- a/worker/provisioner/lxc-broker_test.go
+++ b/worker/provisioner/lxc-broker_test.go
@@ -133,6 +133,10 @@ func (s *lxcBrokerSuite) startInstance(c *gc.C, machineId string, volumes []stor
 	possibleTools := coretools.List{&coretools.Tools{
 		Version: version.MustParseBinary("2.3.4-quantal-amd64"),
 		URL:     "http://tools.testing.invalid/2.3.4-quantal-amd64.tgz",
+	}, {
+		// non-host-arch tools should be filtered out by StartInstance
+		Version: version.MustParseBinary("2.3.4-quantal-arm64"),
+		URL:     "http://tools.testing.invalid/2.3.4-quantal-arm64.tgz",
 	}}
 	callback := func(settableStatus status.Status, info string, data map[string]interface{}) error {
 		return nil

--- a/worker/provisioner/lxd-broker_test.go
+++ b/worker/provisioner/lxd-broker_test.go
@@ -1,0 +1,141 @@
+// Copyright 2013-2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package provisioner_test
+
+import (
+	"runtime"
+
+	"github.com/juju/names"
+	gitjujutesting "github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/arch"
+	"github.com/juju/version"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/agent"
+	"github.com/juju/juju/cloudconfig/instancecfg"
+	"github.com/juju/juju/constraints"
+	"github.com/juju/juju/container"
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/feature"
+	"github.com/juju/juju/instance"
+	jujutesting "github.com/juju/juju/juju/testing"
+	coretesting "github.com/juju/juju/testing"
+	coretools "github.com/juju/juju/tools"
+	jujuversion "github.com/juju/juju/version"
+	"github.com/juju/juju/worker/provisioner"
+)
+
+type lxdBrokerSuite struct {
+	coretesting.BaseSuite
+	broker      environs.InstanceBroker
+	agentConfig agent.ConfigSetterWriter
+	api         *fakeAPI
+	manager     *fakeContainerManager
+}
+
+var _ = gc.Suite(&lxdBrokerSuite{})
+
+func (s *lxdBrokerSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+	if runtime.GOOS == "windows" {
+		c.Skip("Skipping lxd tests on windows")
+	}
+	var err error
+	s.agentConfig, err = agent.NewAgentConfig(
+		agent.AgentConfigParams{
+			Paths:             agent.NewPathsWithDefaults(agent.Paths{DataDir: "/not/used/here"}),
+			Tag:               names.NewMachineTag("1"),
+			UpgradedToVersion: jujuversion.Current,
+			Password:          "dummy-secret",
+			Nonce:             "nonce",
+			APIAddresses:      []string{"10.0.0.1:1234"},
+			CACert:            coretesting.CACert,
+			Model:             coretesting.ModelTag,
+		})
+	c.Assert(err, jc.ErrorIsNil)
+	s.api = NewFakeAPI()
+	s.manager = &fakeContainerManager{}
+	s.broker, err = provisioner.NewLxdBroker(s.api, s.manager, s.agentConfig, "namespace", true)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *lxdBrokerSuite) instanceConfig(c *gc.C, machineId string) *instancecfg.InstanceConfig {
+	machineNonce := "fake-nonce"
+	// To isolate the tests from the host's architecture, we override it here.
+	s.PatchValue(&arch.HostArch, func() string { return arch.AMD64 })
+	stateInfo := jujutesting.FakeStateInfo(machineId)
+	apiInfo := jujutesting.FakeAPIInfo(machineId)
+	instanceConfig, err := instancecfg.NewInstanceConfig(machineId, machineNonce, "released", "quantal", "", true, nil, stateInfo, apiInfo)
+	c.Assert(err, jc.ErrorIsNil)
+	return instanceConfig
+}
+
+func (s *lxdBrokerSuite) startInstance(c *gc.C, machineId string) instance.Instance {
+	instanceConfig := s.instanceConfig(c, machineId)
+	cons := constraints.Value{}
+	possibleTools := coretools.List{&coretools.Tools{
+		Version: version.MustParseBinary("2.3.4-quantal-amd64"),
+		URL:     "http://tools.testing.invalid/2.3.4-quantal-amd64.tgz",
+	}, {
+		// non-host-arch tools should be filtered out by StartInstance
+		Version: version.MustParseBinary("2.3.4-quantal-arm64"),
+		URL:     "http://tools.testing.invalid/2.3.4-quantal-arm64.tgz",
+	}}
+	result, err := s.broker.StartInstance(environs.StartInstanceParams{
+		Constraints:    cons,
+		Tools:          possibleTools,
+		InstanceConfig: instanceConfig,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	return result.Instance
+}
+
+func (s *lxdBrokerSuite) TestStartInstance(c *gc.C) {
+	machineId := "1/lxd/0"
+	s.SetFeatureFlags(feature.AddressAllocation)
+	s.startInstance(c, machineId)
+	s.api.CheckCalls(c, []gitjujutesting.StubCall{{
+		FuncName: "ContainerConfig",
+	}, {
+		FuncName: "PrepareContainerInterfaceInfo",
+		Args:     []interface{}{names.NewMachineTag("1-lxd-0")},
+	}})
+	s.manager.CheckCallNames(c, "CreateContainer")
+	call := s.manager.Calls()[0]
+	c.Assert(call.Args[0], gc.FitsTypeOf, &instancecfg.InstanceConfig{})
+	instanceConfig := call.Args[0].(*instancecfg.InstanceConfig)
+	c.Assert(instanceConfig.ToolsList(), gc.HasLen, 1)
+	c.Assert(instanceConfig.ToolsList().Arches(), jc.DeepEquals, []string{"amd64"})
+}
+
+type fakeContainerManager struct {
+	gitjujutesting.Stub
+}
+
+func (m *fakeContainerManager) CreateContainer(instanceConfig *instancecfg.InstanceConfig,
+	series string,
+	network *container.NetworkConfig,
+	storage *container.StorageConfig,
+	callback container.StatusCallback,
+) (instance.Instance, *instance.HardwareCharacteristics, error) {
+	m.MethodCall(m, "CreateContainer", instanceConfig, series, network, storage, callback)
+	return nil, nil, m.NextErr()
+}
+
+func (m *fakeContainerManager) DestroyContainer(id instance.Id) error {
+	m.MethodCall(m, "DestroyContainer", id)
+	return m.NextErr()
+}
+
+func (m *fakeContainerManager) ListContainers() ([]instance.Instance, error) {
+	m.MethodCall(m, "ListContainers")
+	return nil, m.NextErr()
+}
+
+func (m *fakeContainerManager) IsInitialized() bool {
+	m.MethodCall(m, "IsInitialized")
+	m.PopNoErr()
+	return true
+}


### PR DESCRIPTION
In case there are multiple agent architectures available for
starting a container, ensure we filter to the host architecture.
We were doing this for LXC, but not for LXD or KVM. We would
previously have been luck on amd64, since it's always the first
in the list.

Fixes https://bugs.launchpad.net/juju-core/+bug/1572781

(Review request: http://reviews.vapour.ws/r/4671/)