### PR TITLE
provider/azure: isolate resource groups

### DIFF
--- a/controller/modelmanager/createmodel_test.go
+++ b/controller/modelmanager/createmodel_test.go
@@ -286,7 +286,7 @@ func (*RestrictedProviderFieldsSuite) TestRestrictedProviderFields(c *gc.C) {
 		provider: "azure",
 		expected: []string{
 			"type", "ca-cert", "state-port", "api-port", "controller-uuid",
-			"location", "endpoint", "storage-endpoint", "controller-resource-group",
+			"location", "endpoint", "storage-endpoint",
 		},
 	}, {
 		provider: "dummy",

--- a/provider/azure/config.go
+++ b/provider/azure/config.go
@@ -39,36 +39,28 @@ const (
 	// account.
 	configAttrStorageAccountKey = "storage-account-key"
 
-	// configAttrControllerResourceGroup is the resource group
-	// corresponding to the controller environment. Each environment needs
-	// to know this because some resources are shared, and live in the
-	// controller environment's resource group.
-	configAttrControllerResourceGroup = "controller-resource-group"
-
 	// resourceNameLengthMax is the maximum length of resource
 	// names in Azure.
 	resourceNameLengthMax = 80
 )
 
 var configFields = schema.Fields{
-	configAttrLocation:                schema.String(),
-	configAttrEndpoint:                schema.String(),
-	configAttrStorageEndpoint:         schema.String(),
-	configAttrAppId:                   schema.String(),
-	configAttrSubscriptionId:          schema.String(),
-	configAttrTenantId:                schema.String(),
-	configAttrAppPassword:             schema.String(),
-	configAttrStorageAccount:          schema.String(),
-	configAttrStorageAccountKey:       schema.String(),
-	configAttrStorageAccountType:      schema.String(),
-	configAttrControllerResourceGroup: schema.String(),
+	configAttrLocation:           schema.String(),
+	configAttrEndpoint:           schema.String(),
+	configAttrStorageEndpoint:    schema.String(),
+	configAttrAppId:              schema.String(),
+	configAttrSubscriptionId:     schema.String(),
+	configAttrTenantId:           schema.String(),
+	configAttrAppPassword:        schema.String(),
+	configAttrStorageAccount:     schema.String(),
+	configAttrStorageAccountKey:  schema.String(),
+	configAttrStorageAccountType: schema.String(),
 }
 
 var configDefaults = schema.Defaults{
-	configAttrStorageAccount:          schema.Omit,
-	configAttrStorageAccountKey:       schema.Omit,
-	configAttrControllerResourceGroup: schema.Omit,
-	configAttrStorageAccountType:      string(storage.StandardLRS),
+	configAttrStorageAccount:     schema.Omit,
+	configAttrStorageAccountKey:  schema.Omit,
+	configAttrStorageAccountType: string(storage.StandardLRS),
 }
 
 var requiredConfigAttributes = []string{
@@ -79,13 +71,11 @@ var requiredConfigAttributes = []string{
 	configAttrLocation,
 	configAttrEndpoint,
 	configAttrStorageEndpoint,
-	configAttrControllerResourceGroup,
 }
 
 var immutableConfigAttributes = []string{
 	configAttrSubscriptionId,
 	configAttrTenantId,
-	configAttrControllerResourceGroup,
 	configAttrStorageAccount,
 	configAttrStorageAccountType,
 }
@@ -93,20 +83,18 @@ var immutableConfigAttributes = []string{
 var internalConfigAttributes = []string{
 	configAttrStorageAccount,
 	configAttrStorageAccountKey,
-	configAttrControllerResourceGroup,
 }
 
 type azureModelConfig struct {
 	*config.Config
-	token                   *azure.ServicePrincipalToken
-	subscriptionId          string
-	location                string // canonicalized
-	endpoint                string
-	storageEndpoint         string
-	storageAccount          string
-	storageAccountKey       string
-	storageAccountType      storage.AccountType
-	controllerResourceGroup string
+	token              *azure.ServicePrincipalToken
+	subscriptionId     string
+	location           string // canonicalized
+	endpoint           string
+	storageEndpoint    string
+	storageAccount     string
+	storageAccountKey  string
+	storageAccountType storage.AccountType
 }
 
 var knownStorageAccountTypes = []string{
@@ -191,7 +179,6 @@ Please choose a model name of no more than %d characters.`,
 	storageAccount, _ := validated[configAttrStorageAccount].(string)
 	storageAccountKey, _ := validated[configAttrStorageAccountKey].(string)
 	storageAccountType := validated[configAttrStorageAccountType].(string)
-	controllerResourceGroup := validated[configAttrControllerResourceGroup].(string)
 
 	if newCfg.FirewallMode() == config.FwGlobal {
 		// We do not currently support the "global" firewall mode.
@@ -229,7 +216,6 @@ Please choose a model name of no more than %d characters.`,
 		storageAccount,
 		storageAccountKey,
 		storage.AccountType(storageAccountType),
-		controllerResourceGroup,
 	}
 
 	return azureConfig, nil

--- a/provider/azure/config_test.go
+++ b/provider/azure/config_test.go
@@ -75,7 +75,6 @@ func (s *configSuite) TestValidateInvalidCredentials(c *gc.C) {
 	s.assertConfigInvalid(c, testing.Attrs{"application-password": ""}, `"application-password" config not specified`)
 	s.assertConfigInvalid(c, testing.Attrs{"tenant-id": ""}, `"tenant-id" config not specified`)
 	s.assertConfigInvalid(c, testing.Attrs{"subscription-id": ""}, `"subscription-id" config not specified`)
-	s.assertConfigInvalid(c, testing.Attrs{"controller-resource-group": ""}, `"controller-resource-group" config not specified`)
 }
 
 func (s *configSuite) TestValidateStorageAccountCantChange(c *gc.C) {
@@ -106,16 +105,15 @@ func (s *configSuite) assertConfigInvalid(c *gc.C, attrs testing.Attrs, expect s
 
 func makeTestModelConfig(c *gc.C, extra ...testing.Attrs) *config.Config {
 	attrs := testing.Attrs{
-		"type":                      "azure",
-		"application-id":            fakeApplicationId,
-		"tenant-id":                 fakeTenantId,
-		"application-password":      "opensezme",
-		"subscription-id":           fakeSubscriptionId,
-		"location":                  "westus",
-		"endpoint":                  "https://api.azurestack.local",
-		"storage-endpoint":          "https://storage.azurestack.local",
-		"controller-resource-group": "arbitrary",
-		"agent-version":             "1.2.3",
+		"type":                 "azure",
+		"application-id":       fakeApplicationId,
+		"tenant-id":            fakeTenantId,
+		"application-password": "opensezme",
+		"subscription-id":      fakeSubscriptionId,
+		"location":             "westus",
+		"endpoint":             "https://api.azurestack.local",
+		"storage-endpoint":     "https://storage.azurestack.local",
+		"agent-version":        "1.2.3",
 	}
 	for _, extra := range extra {
 		attrs = attrs.Merge(extra)

--- a/provider/azure/environ.go
+++ b/provider/azure/environ.go
@@ -115,7 +115,11 @@ func (env *azureEnviron) Bootstrap(
 // see subnet creation).
 func (env *azureEnviron) initResourceGroup() (*config.Config, error) {
 	location := env.config.location
-	tags, _ := env.config.ResourceTags()
+	tags := tags.ResourceTags(
+		names.NewModelTag(env.config.Config.UUID()),
+		names.NewModelTag(env.config.Config.ControllerUUID()),
+		env.config,
+	)
 	resourceGroupsClient := resources.GroupsClient{env.resources}
 
 	logger.Debugf("creating resource group %q", env.resourceGroup)
@@ -386,7 +390,11 @@ func (env *azureEnviron) StartInstance(args environs.StartInstanceParams) (*envi
 	// ensure we obtain all information based on the same configuration.
 	env.mu.Lock()
 	location := env.config.location
-	envTags, _ := env.config.ResourceTags()
+	envTags := tags.ResourceTags(
+		names.NewModelTag(env.config.Config.UUID()),
+		names.NewModelTag(env.config.Config.ControllerUUID()),
+		env.config,
+	)
 	apiPort := env.config.APIPort()
 	vmClient := compute.VirtualMachinesClient{env.compute}
 	availabilitySetClient := compute.AvailabilitySetsClient{env.compute}

--- a/provider/azure/environ.go
+++ b/provider/azure/environ.go
@@ -6,7 +6,6 @@ package azure
 import (
 	"fmt"
 	"net/http"
-	"path"
 	"sort"
 	"strings"
 	"sync"
@@ -55,11 +54,6 @@ type azureEnviron struct {
 	// subscription that corresponds to the environment.
 	resourceGroup string
 
-	// controllerResourceGroup is the name of the Resource Group in the
-	// Azure subscription that corresponds to the Juju controller
-	// environment.
-	controllerResourceGroup string
-
 	// envName is the name of the environment.
 	envName string
 
@@ -86,7 +80,6 @@ func newEnviron(provider *azureEnvironProvider, cfg *config.Config) (*azureEnvir
 	}
 	modelTag := names.NewModelTag(cfg.UUID())
 	env.resourceGroup = resourceGroupName(modelTag, cfg.Name())
-	env.controllerResourceGroup = env.config.controllerResourceGroup
 	env.envName = cfg.Name()
 	return &env, nil
 }
@@ -134,29 +127,17 @@ func (env *azureEnviron) initResourceGroup() (*config.Config, error) {
 		return nil, errors.Annotate(err, "creating resource group")
 	}
 
-	var vnetPtr *network.VirtualNetwork
-	if env.resourceGroup == env.controllerResourceGroup {
-		// Create an internal network for all VMs to connect to.
-		vnetPtr, err = createInternalVirtualNetwork(
-			env.network, env.controllerResourceGroup, location, tags,
-		)
-		if err != nil {
-			return nil, errors.Annotate(err, "creating virtual network")
-		}
-	} else {
-		// We're creating a hosted environment, so we need to fetch
-		// the virtual network to create a subnet below.
-		vnetClient := network.VirtualNetworksClient{env.network}
-		vnet, err := vnetClient.Get(env.controllerResourceGroup, internalNetworkName)
-		if err != nil {
-			return nil, errors.Annotate(err, "getting virtual network")
-		}
-		vnetPtr = &vnet
+	// Create an internal network for all VMs in the
+	// resource group to connect to.
+	vnetPtr, err := createInternalVirtualNetwork(
+		env.network, env.resourceGroup, location, tags,
+	)
+	if err != nil {
+		return nil, errors.Annotate(err, "creating virtual network")
 	}
 
 	_, err = createInternalSubnet(
-		env.network, env.resourceGroup, env.controllerResourceGroup,
-		vnetPtr, location, tags,
+		env.network, env.resourceGroup, vnetPtr, location, tags,
 	)
 	if err != nil {
 		return nil, errors.Annotate(err, "creating subnet")
@@ -238,7 +219,7 @@ func (env *azureEnviron) ControllerInstances() ([]instance.Id, error) {
 	// controllers are tagged with tags.JujuIsController, so just
 	// list the instances in the controller resource group and pick
 	// those ones out.
-	instances, err := env.allInstances(env.controllerResourceGroup, true)
+	instances, err := env.allInstances(env.resourceGroup, true)
 	if err != nil {
 		return nil, err
 	}
@@ -412,7 +393,6 @@ func (env *azureEnviron) StartInstance(args environs.StartInstanceParams) (*envi
 	networkClient := env.network
 	vmImagesClient := compute.VirtualMachineImagesClient{env.compute}
 	vmExtensionClient := compute.VirtualMachineExtensionsClient{env.compute}
-	subscriptionId := env.config.subscriptionId
 	imageStream := env.config.ImageStream()
 	storageEndpoint := env.config.storageEndpoint
 	storageAccountName := env.config.storageAccount
@@ -482,20 +462,13 @@ func (env *azureEnviron) StartInstance(args environs.StartInstanceParams) (*envi
 		apiPortPtr = &apiPort
 	}
 
-	// Construct the network security group ID for the environment.
-	nsgID := path.Join(
-		"/subscriptions", subscriptionId, "resourceGroups",
-		env.resourceGroup, "providers", "Microsoft.Network",
-		"networkSecurityGroups", internalSecurityGroupName,
-	)
-
 	vm, err := createVirtualMachine(
 		env.resourceGroup, location, vmName,
 		vmTags, envTags,
 		instanceSpec, args.InstanceConfig,
 		args.DistributionGroup,
 		env.Instances,
-		apiPortPtr, internalNetworkSubnet, nsgID,
+		apiPortPtr, internalNetworkSubnet,
 		storageEndpoint, storageAccountName,
 		networkClient, vmClient,
 		availabilitySetClient, vmExtensionClient,
@@ -538,7 +511,7 @@ func createVirtualMachine(
 	instancesFunc func([]instance.Id) ([]instance.Instance, error),
 	apiPort *int,
 	internalNetworkSubnet *network.Subnet,
-	nsgID, storageEndpoint, storageAccountName string,
+	storageEndpoint, storageAccountName string,
 	networkClient network.ManagementClient,
 	vmClient compute.VirtualMachinesClient,
 	availabilitySetClient compute.AvailabilitySetsClient,
@@ -560,7 +533,7 @@ func createVirtualMachine(
 
 	networkProfile, err := newNetworkProfile(
 		networkClient, vmName, apiPort,
-		internalNetworkSubnet, nsgID,
+		internalNetworkSubnet,
 		resourceGroup, location, vmTags,
 	)
 	if err != nil {
@@ -1062,15 +1035,9 @@ func (env *azureEnviron) Destroy() error {
 	if err := env.deleteResourceGroup(); err != nil {
 		return errors.Trace(err)
 	}
-	if env.resourceGroup == env.controllerResourceGroup {
-		// This is the controller resource group; once it has been
-		// deleted, there's nothing left.
-		return nil
-	}
-	logger.Debugf("- deleting internal subnet")
-	if err := env.deleteInternalSubnet(); err != nil {
-		return errors.Trace(err)
-	}
+	// Resource groups are self-contained and fully encompass
+	// all environ resources. Once you delete the group, there
+	// is nothing else to do.
 	return nil
 }
 
@@ -1168,8 +1135,8 @@ func (env *azureEnviron) getInstanceTypesLocked() (map[string]instances.Instance
 func (env *azureEnviron) getInternalSubnetLocked() (*network.Subnet, error) {
 	client := network.SubnetsClient{env.network}
 	vnetName := internalNetworkName
-	subnetName := env.resourceGroup
-	subnet, err := client.Get(env.controllerResourceGroup, vnetName, subnetName)
+	subnetName := internalSubnetName
+	subnet, err := client.Get(env.resourceGroup, vnetName, subnetName)
 	if err != nil {
 		return nil, errors.Annotate(err, "getting internal subnet")
 	}

--- a/provider/azure/environprovider.go
+++ b/provider/azure/environprovider.go
@@ -7,7 +7,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/Godeps/_workspace/src/github.com/Azure/go-autorest/autorest"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
-	"github.com/juju/names"
 
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs"
@@ -78,10 +77,10 @@ func (prov *azureEnvironProvider) Open(cfg *config.Config) (environs.Environ, er
 // The result of RestrictedConfigAttributes is the names of attributes that
 // will be copied across to a hosted environment's initial configuration.
 func (prov *azureEnvironProvider) RestrictedConfigAttributes() []string {
+	// TODO(axw) there should be no restricted attributes.
 	return []string{
 		configAttrLocation,
 		configAttrEndpoint,
-		configAttrControllerResourceGroup,
 		configAttrStorageEndpoint,
 	}
 }
@@ -111,13 +110,6 @@ func (prov *azureEnvironProvider) BootstrapConfig(args environs.BootstrapConfigP
 		configAttrLocation:        args.CloudRegion,
 		configAttrEndpoint:        args.CloudEndpoint,
 		configAttrStorageEndpoint: args.CloudStorageEndpoint,
-
-		// Record the UUID that will be used for the controller
-		// model, which contains shared resources.
-		configAttrControllerResourceGroup: resourceGroupName(
-			names.NewModelTag(args.Config.UUID()),
-			args.Config.Name(),
-		),
 	}
 	switch authType := args.Credentials.AuthType(); authType {
 	case cloud.UserPassAuthType:

--- a/provider/azure/environprovider_test.go
+++ b/provider/azure/environprovider_test.go
@@ -40,7 +40,6 @@ func (s *environProviderSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *environProviderSuite) TestBootstrapConfigWithInternalConfig(c *gc.C) {
-	s.testBootstrapConfigWithInternalConfig(c, "controller-resource-group")
 	s.testBootstrapConfigWithInternalConfig(c, "storage-account")
 }
 
@@ -68,11 +67,8 @@ func fakeUserPassCredential() cloud.Credential {
 
 func (s *environProviderSuite) TestBootstrapConfig(c *gc.C) {
 	cfg := makeTestModelConfig(c)
-	cfg, err := cfg.Remove([]string{"controller-resource-group"})
-	c.Assert(err, jc.ErrorIsNil)
-
 	s.sender = azuretesting.Senders{tokenRefreshSender()}
-	cfg, err = s.provider.BootstrapConfig(environs.BootstrapConfigParams{
+	cfg, err := s.provider.BootstrapConfig(environs.BootstrapConfigParams{
 		Config:               cfg,
 		CloudRegion:          "westus",
 		CloudEndpoint:        "https://api.azurestack.local",
@@ -82,11 +78,10 @@ func (s *environProviderSuite) TestBootstrapConfig(c *gc.C) {
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(cfg, gc.NotNil)
 
-	c.Assert(
-		cfg.UnknownAttrs()["controller-resource-group"],
-		gc.Equals,
-		"juju-testenv-model-"+testing.ModelTag.Id(),
-	)
+	attrs := cfg.UnknownAttrs()
+	c.Assert(attrs["location"], gc.Equals, "westus")
+	c.Assert(attrs["endpoint"], gc.Equals, "https://api.azurestack.local")
+	c.Assert(attrs["storage-endpoint"], gc.Equals, "https://storage.azurestack.local")
 }
 
 func newProviders(c *gc.C, config azure.ProviderConfig) (environs.EnvironProvider, storage.Provider) {

--- a/provider/azure/instance.go
+++ b/provider/azure/instance.go
@@ -155,11 +155,8 @@ func (inst *azureInstance) internalNetworkAddress() (jujunetwork.Address, error)
 	inst.env.mu.Lock()
 	subscriptionId := inst.env.config.subscriptionId
 	resourceGroup := inst.env.resourceGroup
-	controllerResourceGroup := inst.env.controllerResourceGroup
 	inst.env.mu.Unlock()
-	internalSubnetId := internalSubnetId(
-		resourceGroup, controllerResourceGroup, subscriptionId,
-	)
+	internalSubnetId := internalSubnetId(resourceGroup, subscriptionId)
 
 	for _, nic := range inst.networkInterfaces {
 		if nic.Properties.IPConfigurations == nil {

--- a/provider/azure/instance_test.go
+++ b/provider/azure/instance_test.go
@@ -369,8 +369,8 @@ func (s *instanceSuite) TestInstanceClosePorts(c *gc.C) {
 func (s *instanceSuite) TestInstanceOpenPorts(c *gc.C) {
 	internalSubnetId := path.Join(
 		"/subscriptions", fakeSubscriptionId,
-		"resourceGroups/arbitrary/providers/Microsoft.Network/virtualnetworks/juju-internal/subnets",
-		"juju-testenv-model-"+testing.ModelTag.Id(),
+		"resourceGroups/juju-testenv-model-deadbeef-0bad-400d-8000-4b1d0d06f00d",
+		"providers/Microsoft.Network/virtualnetworks/juju-internal/subnets/juju-internal",
 	)
 	ipConfiguration := network.InterfaceIPConfiguration{
 		Properties: &network.InterfaceIPConfigurationPropertiesFormat{
@@ -439,8 +439,8 @@ func (s *instanceSuite) TestInstanceOpenPorts(c *gc.C) {
 func (s *instanceSuite) TestInstanceOpenPortsAlreadyOpen(c *gc.C) {
 	internalSubnetId := path.Join(
 		"/subscriptions", fakeSubscriptionId,
-		"resourceGroups/arbitrary/providers/Microsoft.Network/virtualnetworks/juju-internal/subnets",
-		"juju-testenv-model-"+testing.ModelTag.Id(),
+		"resourceGroups/juju-testenv-model-deadbeef-0bad-400d-8000-4b1d0d06f00d",
+		"providers/Microsoft.Network/virtualnetworks/juju-internal/subnets/juju-internal",
 	)
 	ipConfiguration := network.InterfaceIPConfiguration{
 		Properties: &network.InterfaceIPConfigurationPropertiesFormat{

--- a/provider/azure/instance_test.go
+++ b/provider/azure/instance_test.go
@@ -158,7 +158,7 @@ func networkSecurityGroupSender(rules []network.SecurityRule) *azuretesting.Mock
 			SecurityRules: &rules,
 		},
 	})
-	nsgSender.PathPattern = ".*/networkSecurityGroups/juju-internal"
+	nsgSender.PathPattern = ".*/networkSecurityGroups/juju-internal-nsg"
 	return nsgSender
 }
 
@@ -370,7 +370,7 @@ func (s *instanceSuite) TestInstanceOpenPorts(c *gc.C) {
 	internalSubnetId := path.Join(
 		"/subscriptions", fakeSubscriptionId,
 		"resourceGroups/juju-testenv-model-deadbeef-0bad-400d-8000-4b1d0d06f00d",
-		"providers/Microsoft.Network/virtualnetworks/juju-internal/subnets/juju-internal",
+		"providers/Microsoft.Network/virtualnetworks/juju-internal-network/subnets/juju-internal-subnet",
 	)
 	ipConfiguration := network.InterfaceIPConfiguration{
 		Properties: &network.InterfaceIPConfigurationPropertiesFormat{
@@ -440,7 +440,7 @@ func (s *instanceSuite) TestInstanceOpenPortsAlreadyOpen(c *gc.C) {
 	internalSubnetId := path.Join(
 		"/subscriptions", fakeSubscriptionId,
 		"resourceGroups/juju-testenv-model-deadbeef-0bad-400d-8000-4b1d0d06f00d",
-		"providers/Microsoft.Network/virtualnetworks/juju-internal/subnets/juju-internal",
+		"providers/Microsoft.Network/virtualnetworks/juju-internal-network/subnets/juju-internal-subnet",
 	)
 	ipConfiguration := network.InterfaceIPConfiguration{
 		Properties: &network.InterfaceIPConfigurationPropertiesFormat{
@@ -508,7 +508,7 @@ func (s *instanceSuite) TestInstanceOpenPortsNoInternalAddress(c *gc.C) {
 var internalSecurityGroupPath = path.Join(
 	"/subscriptions", fakeSubscriptionId,
 	"resourceGroups", "juju-testenv-model-"+testing.ModelTag.Id(),
-	"providers/Microsoft.Network/networkSecurityGroups/juju-internal",
+	"providers/Microsoft.Network/networkSecurityGroups/juju-internal-nsg",
 )
 
 func securityRulePath(ruleName string) string {

--- a/provider/azure/networking.go
+++ b/provider/azure/networking.go
@@ -24,16 +24,16 @@ const (
 	// Each resource group is given its own network, subnet and network
 	// security group to manage. Each resource group will have its own
 	// private 10.0.0.0/16 network.
-	internalNetworkName = "juju-internal"
+	internalNetworkName = "juju-internal-network"
 
 	// internalSubnetName is the name of the subnet that each machine's
 	// primary NIC is attached to.
-	internalSubnetName = "juju-internal"
+	internalSubnetName = "juju-internal-subnet"
 
 	// internalSecurityGroupName is the name of the network security
 	// group that each machine's primary (internal network) NIC is
 	// attached to.
-	internalSecurityGroupName = "juju-internal"
+	internalSecurityGroupName = "juju-internal-nsg"
 )
 
 const (

--- a/provider/azure/networking.go
+++ b/provider/azure/networking.go
@@ -6,7 +6,6 @@ package azure
 import (
 	"fmt"
 	"net"
-	"net/http"
 	"path"
 
 	"github.com/Azure/azure-sdk-for-go/Godeps/_workspace/src/github.com/Azure/go-autorest/autorest/to"
@@ -20,16 +19,16 @@ import (
 
 const (
 	// internalNetworkName is the name of the virtual network that all
-	// Juju machines are connected to, so that they can communicate
-	// with the controllers, and with each other.
+	// Juju machines within a resource group are connected to.
 	//
-	// Each resource group is given its own subnet and network security
-	// group to manage. The first resource group will be assigned the
-	// subnet address prefix 10.0.0.0/16, the second 10.1.0.0/16, etc.,
-	// which allows for up to 256 enviroments/resource groups. Azure
-	// only supports 100, but this can be extended by contacting support;
-	// we can make the address prefixes configurable if necessary.
+	// Each resource group is given its own network, subnet and network
+	// security group to manage. Each resource group will have its own
+	// private 10.0.0.0/16 network.
 	internalNetworkName = "juju-internal"
+
+	// internalSubnetName is the name of the subnet that each machine's
+	// primary NIC is attached to.
+	internalSubnetName = "juju-internal"
 
 	// internalSecurityGroupName is the name of the network security
 	// group that each machine's primary (internal network) NIC is
@@ -75,14 +74,11 @@ var sshSecurityRule = network.SecurityRule{
 
 func createInternalVirtualNetwork(
 	client network.ManagementClient,
-	controllerResourceGroup string,
+	resourceGroup string,
 	location string,
 	tags map[string]string,
 ) (*network.VirtualNetwork, error) {
-	addressPrefixes := make([]string, 256)
-	for i := range addressPrefixes {
-		addressPrefixes[i] = fmt.Sprintf("10.%d.0.0/16", i)
-	}
+	addressPrefixes := []string{"10.0.0.0/16"}
 	virtualNetworkParams := network.VirtualNetwork{
 		Location: to.StringPtr(location),
 		Tags:     toTagsPtr(tags),
@@ -93,7 +89,7 @@ func createInternalVirtualNetwork(
 	logger.Debugf("creating virtual network %q", internalNetworkName)
 	vnetClient := network.VirtualNetworksClient{client}
 	vnet, err := vnetClient.CreateOrUpdate(
-		controllerResourceGroup, internalNetworkName, virtualNetworkParams,
+		resourceGroup, internalNetworkName, virtualNetworkParams,
 	)
 	if err != nil {
 		return nil, errors.Annotatef(err, "creating virtual network %q", internalNetworkName)
@@ -104,17 +100,13 @@ func createInternalVirtualNetwork(
 // createInternalSubnet creates an internal subnet for the specified resource group,
 // within the specified virtual network.
 //
-// Subnets are tied to the resource group of the virtual network, so we must create
-// them all in the controller resource group. We create the network security group
-// for the subnet in the environment's resource group.
-//
 // NOTE(axw) this method expects an up-to-date VirtualNetwork, and expects that are
 // no concurrent subnet additions to the virtual network. At the moment we have only
 // three places where we modify subnets: at bootstrap, when a new environment is
 // created, and when an environment is destroyed.
 func createInternalSubnet(
 	client network.ManagementClient,
-	resourceGroup, controllerResourceGroup string,
+	resourceGroup string,
 	vnet *network.VirtualNetwork,
 	location string,
 	tags map[string]string,
@@ -154,31 +146,26 @@ func createInternalSubnet(
 	securityGroupClient := network.SecurityGroupsClient{client}
 	securityGroupName := internalSecurityGroupName
 	logger.Debugf("creating security group %q", securityGroupName)
-	_, err := securityGroupClient.CreateOrUpdate(
+	nsg, err := securityGroupClient.CreateOrUpdate(
 		resourceGroup, securityGroupName, securityGroupParams,
 	)
 	if err != nil {
 		return nil, errors.Annotatef(err, "creating security group %q", securityGroupName)
 	}
 
-	// Now create a subnet with the next available address prefix. The
-	// subnet must be created in the controller resource group, as it
-	// must be co-located with the vnet.
-	subnetName := resourceGroup
+	// Now create a subnet with the next available address prefix, and
+	// associate the subnet with the NSG created above.
+	subnetName := internalSubnetName
 	subnetParams := network.Subnet{
 		Properties: &network.SubnetPropertiesFormat{
-			AddressPrefix: to.StringPtr(nextAddressPrefix),
-			// NOTE(axw) we do NOT want to set the network security
-			// group as default for the subnet, because that will
-			// create a dependency from the controller resource
-			// group to environment resource groups. Instead, we
-			// set the NSG on NICs.
+			AddressPrefix:        to.StringPtr(nextAddressPrefix),
+			NetworkSecurityGroup: &network.SubResource{nsg.ID},
 		},
 	}
 	logger.Debugf("creating subnet %q (%s)", subnetName, nextAddressPrefix)
 	subnetClient := network.SubnetsClient{client}
 	subnet, err := subnetClient.CreateOrUpdate(
-		controllerResourceGroup, internalNetworkName, subnetName, subnetParams,
+		resourceGroup, internalNetworkName, subnetName, subnetParams,
 	)
 	if err != nil {
 		return nil, errors.Annotatef(err, "creating subnet %q", subnetName)
@@ -191,7 +178,6 @@ func newNetworkProfile(
 	vmName string,
 	apiPort *int,
 	internalSubnet *network.Subnet,
-	nsgID string,
 	resourceGroup string,
 	location string,
 	tags map[string]string,
@@ -239,11 +225,6 @@ func newNetworkProfile(
 		Tags:     toTagsPtr(tags),
 		Properties: &network.InterfacePropertiesFormat{
 			IPConfigurations: &ipConfigurations,
-			// We set the network security group on the NIC, rather
-			// than the subnet, to avoid having the controller
-			// resource group dependent on the environment resource
-			// group.
-			NetworkSecurityGroup: &network.SubResource{to.StringPtr(nsgID)},
 		},
 	}
 	primaryNic, err := nicClient.CreateOrUpdate(resourceGroup, primaryNicName, primaryNicParams)
@@ -311,20 +292,6 @@ func newNetworkProfile(
 	return &compute.NetworkProfile{&networkInterfaces}, nil
 }
 
-func (env *azureEnviron) deleteInternalSubnet() error {
-	client := network.SubnetsClient{env.network}
-	subnetName := env.resourceGroup
-	result, err := client.Delete(
-		env.controllerResourceGroup, internalNetworkName, subnetName,
-	)
-	if err != nil {
-		if result.Response == nil || result.StatusCode != http.StatusNotFound {
-			return errors.Annotatef(err, "deleting subnet %q", subnetName)
-		}
-	}
-	return nil
-}
-
 // nextSecurityRulePriority returns the next available priority in the given
 // security group within a specified range.
 func nextSecurityRulePriority(group network.SecurityGroup, min, max int) (int, error) {
@@ -390,11 +357,11 @@ func nextSubnetIPAddress(
 
 // internalSubnetId returns the Azure resource ID of the internal network
 // subnet for the specified resource group.
-func internalSubnetId(resourceGroup, controllerResourceGroup, subscriptionId string) string {
+func internalSubnetId(resourceGroup, subscriptionId string) string {
 	return path.Join(
 		"/subscriptions", subscriptionId,
-		"resourceGroups", controllerResourceGroup,
+		"resourceGroups", resourceGroup,
 		"providers/Microsoft.Network/virtualNetworks",
-		internalNetworkName, "subnets", resourceGroup,
+		internalNetworkName, "subnets", internalSubnetName,
 	)
 }


### PR DESCRIPTION
Isolate Juju environs into fully self contained
Azure resource groups. This will enable Juju to
manage models in separate Azure regions, accounts,
etc. Also, it means the Azure provider is no longer
a barrier to managing models in multiple clouds.

Each environment now gets its own juju-internal
network, and a 10.0.0.0/16 subnet within it. The
Juju agents in hosted models will talk to the
controller machines using their public addresses,
as their private addresses are not routable across
models.

There is also a drive-by fix of tagging of environment-
level resources, such as resource groups, networks,
etc. These were previously being tagged with the
values in the "resource-tags" config, but with
juju-model-uuid or juju-controller-uuid. These must
be added so we can later delete hosted models.

(Review request: http://reviews.vapour.ws/r/4672/)