### PR TITLE
Fix tests related to the default series.

### DIFF
--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -31,6 +31,14 @@ import (
 
 var logger = loggo.GetLogger("juju.environs.local/share")
 
+// FallbackLtsSeries is the latest LTS series we'll use, if we fail to
+// obtain this information from the system.
+var FallbackLtsSeries string = "trusty"
+
+func init() {
+	FallbackLtsSeries = LatestLtsSeries()
+}
+
 const (
 	// FwInstance requests the use of an individual firewall per instance.
 	FwInstance = "instance"
@@ -64,10 +72,6 @@ const (
 	// refreshing the addresses, in seconds. Not too frequent, as we
 	// refresh addresses from the provider each time.
 	DefaultBootstrapSSHAddressesDelay int = 10
-
-	// fallbackLtsSeries is the latest LTS series we'll use, if we fail to
-	// obtain this information from the system.
-	fallbackLtsSeries string = "trusty"
 
 	// DefaultNumaControlPolicy should not be used by default.
 	// Only use numactl if user specifically requests it
@@ -321,7 +325,7 @@ func LatestLtsSeries() string {
 	if latestLtsSeries == "" {
 		series, err := distroLtsSeries()
 		if err != nil {
-			latestLtsSeries = fallbackLtsSeries
+			latestLtsSeries = FallbackLtsSeries
 		} else {
 			latestLtsSeries = series
 		}

--- a/testing/environ.go
+++ b/testing/environ.go
@@ -30,7 +30,7 @@ func init() {
 	}
 }
 
-const FakeDefaultSeries = "trusty"
+var FakeDefaultSeries = config.FallbackLtsSeries
 
 // FakeVersionNumber is a valid version number that can be used in testing.
 var FakeVersionNumber = version.MustParse("1.99.0")


### PR DESCRIPTION
(fixes https://bugs.launchpad.net/juju-core/+bug/1571917)
(fixes https://bugs.launchpad.net/juju-core/+bug/1571932)
(fixes https://bugs.launchpad.net/juju-core/+bug/1568079)

The value of testing/environs.FakeDefaultSeries was hard-coded to "trusty".  This broke when xenial because the current LTS.  If we changed it to "xenial" then it would just break in 2 years for the next one and right now on trusty.

So instead of hard-coding a value, we dynamically set the fallback LTS series for juju and use that value as the FakeDefaultSeries in tests.

(Review request: http://reviews.vapour.ws/r/4678/)