### PR TITLE
Allow users with write access to grant and revoke permission to their models

### DIFF
--- a/apiserver/modelmanager/modelmanager.go
+++ b/apiserver/modelmanager/modelmanager.go
@@ -53,7 +53,7 @@ var _ ModelManager = (*ModelManagerAPI)(nil)
 func newFacade(st *state.State, resources *common.Resources, auth common.Authorizer) (*ModelManagerAPI, error) {
 	return NewModelManagerAPI(NewStateBackend(st), auth)
 }
-``
+
 // NewModelManagerAPI creates a new api server endpoint for managing
 // models.
 func NewModelManagerAPI(st Backend, authorizer common.Authorizer) (*ModelManagerAPI, error) {

--- a/apiserver/modelmanager/modelmanager_test.go
+++ b/apiserver/modelmanager/modelmanager_test.go
@@ -5,7 +5,6 @@ package modelmanager_test
 
 import (
 	"regexp"
-	"time"
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
@@ -262,7 +261,7 @@ func (s *modelManagerSuite) TestCreateModelBadAgentVersion(c *gc.C) {
 func (s *modelManagerSuite) TestListModelsForSelf(c *gc.C) {
 	user := names.NewUserTag("external@remote")
 	s.setAPIUser(c, user)
-	result, err := s.modelmanager.ListModels(params.Entity{user.String()})
+	result, err := s.modelmanager.ListModels(params.Entity{Tag: user.String()})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.UserModels, gc.HasLen, 0)
 }
@@ -272,7 +271,7 @@ func (s *modelManagerSuite) TestListModelsForSelfLocalUser(c *gc.C) {
 	// api server converts it to a fully qualified name.
 	user := names.NewUserTag("local-user")
 	s.setAPIUser(c, names.NewUserTag("local-user@local"))
-	result, err := s.modelmanager.ListModels(params.Entity{user.String()})
+	result, err := s.modelmanager.ListModels(params.Entity{Tag: user.String()})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.UserModels, gc.HasLen, 0)
 }
@@ -286,7 +285,7 @@ func (s *modelManagerSuite) checkModelMatches(c *gc.C, env params.Model, expecte
 func (s *modelManagerSuite) TestListModelsAdminSelf(c *gc.C) {
 	user := s.AdminUserTag(c)
 	s.setAPIUser(c, user)
-	result, err := s.modelmanager.ListModels(params.Entity{user.String()})
+	result, err := s.modelmanager.ListModels(params.Entity{Tag: user.String()})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.UserModels, gc.HasLen, 1)
 	expected, err := s.State.Model()
@@ -298,7 +297,7 @@ func (s *modelManagerSuite) TestListModelsAdminListsOther(c *gc.C) {
 	user := s.AdminUserTag(c)
 	s.setAPIUser(c, user)
 	other := names.NewUserTag("external@remote")
-	result, err := s.modelmanager.ListModels(params.Entity{other.String()})
+	result, err := s.modelmanager.ListModels(params.Entity{Tag: other.String()})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.UserModels, gc.HasLen, 0)
 }
@@ -307,7 +306,7 @@ func (s *modelManagerSuite) TestListModelsDenied(c *gc.C) {
 	user := names.NewUserTag("external@remote")
 	s.setAPIUser(c, user)
 	other := names.NewUserTag("other@remote")
-	_, err := s.modelmanager.ListModels(params.Entity{other.String()})
+	_, err := s.modelmanager.ListModels(params.Entity{Tag: other.String()})
 	c.Assert(err, gc.ErrorMatches, "permission denied")
 }
 
@@ -323,66 +322,55 @@ func (s *modelManagerSuite) TestNonAdminModelManager(c *gc.C) {
 	c.Assert(modelmanager.AuthCheck(c, s.modelmanager, user), jc.IsFalse)
 }
 
+func (s *modelManagerSuite) modifyAccess(c *gc.C, user names.UserTag, action params.ModelAction, access params.ModelAccessPermission, model names.ModelTag) error {
+	args := params.ModifyModelAccessRequest{
+		Changes: []params.ModifyModelAccess{{
+			UserTag:  user.String(),
+			Action:   action,
+			Access:   access,
+			ModelTag: model.String(),
+		}}}
+	result, err := s.modelmanager.ModifyModelAccess(args)
+	c.Assert(err, jc.ErrorIsNil)
+	return result.OneError()
+}
+
+func (s *modelManagerSuite) grant(c *gc.C, user names.UserTag, access params.ModelAccessPermission, model names.ModelTag) error {
+	return s.modifyAccess(c, user, params.GrantModelAccess, access, model)
+}
+
+func (s *modelManagerSuite) revoke(c *gc.C, user names.UserTag, access params.ModelAccessPermission, model names.ModelTag) error {
+	return s.modifyAccess(c, user, params.RevokeModelAccess, access, model)
+}
+
 func (s *modelManagerSuite) TestGrantMissingUserFails(c *gc.C) {
 	s.setAPIUser(c, s.AdminUserTag(c))
 	st := s.Factory.MakeModel(c, nil)
 	defer st.Close()
-	args := params.ModifyModelAccessRequest{
-		Changes: []params.ModifyModelAccess{{
-			UserTag:  names.NewLocalUserTag("foobar").String(),
-			Action:   params.GrantModelAccess,
-			Access:   params.ModelReadAccess,
-			ModelTag: st.ModelTag().String(),
-		}}}
 
-	result, err := s.modelmanager.ModifyModelAccess(args)
-	c.Assert(err, jc.ErrorIsNil)
+	user := names.NewLocalUserTag("foobar")
+	err := s.grant(c, user, params.ModelReadAccess, st.ModelTag())
 	expectedErr := `could not grant model access: user "foobar" does not exist locally: user "foobar" not found`
-	c.Assert(result.OneError(), gc.ErrorMatches, expectedErr)
-	c.Assert(result.Results, gc.HasLen, 1)
-	c.Assert(result.Results[0].Error, gc.ErrorMatches, expectedErr)
+	c.Assert(err, gc.ErrorMatches, expectedErr)
 }
 
 func (s *modelManagerSuite) TestGrantMissingModelFails(c *gc.C) {
 	s.setAPIUser(c, s.AdminUserTag(c))
 	user := s.Factory.MakeModelUser(c, nil)
-	args := params.ModifyModelAccessRequest{
-		Changes: []params.ModifyModelAccess{{
-			UserTag:  user.UserTag().String(),
-			Action:   params.GrantModelAccess,
-			Access:   params.ModelReadAccess,
-			ModelTag: names.NewModelTag("17e4bd2d-3e08-4f3d-b945-087be7ebdce4").String(),
-		}}}
-
-	result, err := s.modelmanager.ModifyModelAccess(args)
-	c.Assert(err, jc.ErrorIsNil)
+	model := names.NewModelTag("17e4bd2d-3e08-4f3d-b945-087be7ebdce4")
+	err := s.grant(c, user.UserTag(), params.ModelReadAccess, model)
 	expectedErr := `model not found`
-	c.Assert(result.OneError(), gc.ErrorMatches, expectedErr)
-	c.Assert(result.Results, gc.HasLen, 1)
-	c.Assert(result.Results[0].Error, gc.ErrorMatches, expectedErr)
+	c.Assert(err, gc.ErrorMatches, expectedErr)
 }
 
 func (s *modelManagerSuite) TestRevokeAdminLeavesReadAccess(c *gc.C) {
 	s.setAPIUser(c, s.AdminUserTag(c))
 	user := s.Factory.MakeModelUser(c, &factory.ModelUserParams{Access: state.ModelAdminAccess})
+
+	err := s.revoke(c, user.UserTag(), params.ModelWriteAccess, user.ModelTag())
+	c.Assert(err, gc.IsNil)
+
 	modelUser, err := s.State.ModelUser(user.UserTag())
-	c.Assert(err, jc.ErrorIsNil)
-
-	args := params.ModifyModelAccessRequest{
-		Changes: []params.ModifyModelAccess{{
-			UserTag:  user.UserTag().String(),
-			Action:   params.RevokeModelAccess,
-			Access:   params.ModelWriteAccess,
-			ModelTag: modelUser.ModelTag().String(),
-		}}}
-
-	result, err := s.modelmanager.ModifyModelAccess(args)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(result.OneError(), gc.IsNil)
-	c.Assert(result.Results, gc.HasLen, 1)
-	c.Assert(result.Results[0].Error, gc.IsNil)
-
-	modelUser, err = s.State.ModelUser(user.UserTag())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(modelUser.ReadOnly(), jc.IsTrue)
 }
@@ -390,22 +378,9 @@ func (s *modelManagerSuite) TestRevokeAdminLeavesReadAccess(c *gc.C) {
 func (s *modelManagerSuite) TestRevokeReadRemovesModelUser(c *gc.C) {
 	s.setAPIUser(c, s.AdminUserTag(c))
 	user := s.Factory.MakeModelUser(c, nil)
-	modelUser, err := s.State.ModelUser(user.UserTag())
-	c.Assert(err, jc.ErrorIsNil)
 
-	args := params.ModifyModelAccessRequest{
-		Changes: []params.ModifyModelAccess{{
-			UserTag:  user.UserTag().String(),
-			Action:   params.RevokeModelAccess,
-			Access:   params.ModelReadAccess,
-			ModelTag: modelUser.ModelTag().String(),
-		}}}
-
-	result, err := s.modelmanager.ModifyModelAccess(args)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(result.OneError(), gc.IsNil)
-	c.Assert(result.Results, gc.HasLen, 1)
-	c.Assert(result.Results[0].Error, gc.IsNil)
+	err := s.revoke(c, user.UserTag(), params.ModelReadAccess, user.ModelTag())
+	c.Assert(err, gc.IsNil)
 
 	_, err = s.State.ModelUser(user.UserTag())
 	c.Assert(errors.IsNotFound(err), jc.IsTrue)
@@ -417,177 +392,141 @@ func (s *modelManagerSuite) TestRevokeModelMissingUser(c *gc.C) {
 	defer st.Close()
 
 	user := names.NewUserTag("bob")
-	args := params.ModifyModelAccessRequest{
-		Changes: []params.ModifyModelAccess{{
-			UserTag:  user.String(),
-			Action:   params.RevokeModelAccess,
-			Access:   params.ModelReadAccess,
-			ModelTag: st.ModelTag().String(),
-		}}}
-
-	result, err := s.modelmanager.ModifyModelAccess(args)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(result.OneError(), gc.ErrorMatches, `could not revoke model access: model user "bob@local" does not exist`)
-	c.Assert(result.Results, gc.HasLen, 1)
-	c.Assert(result.Results[0].Error, gc.NotNil)
+	err := s.revoke(c, user, params.ModelReadAccess, st.ModelTag())
+	c.Assert(err, gc.ErrorMatches, `could not revoke model access: model user "bob@local" does not exist`)
 
 	_, err = st.ModelUser(user)
 	c.Assert(errors.IsNotFound(err), jc.IsTrue)
 }
 
 func (s *modelManagerSuite) TestGrantOnlyGreaterAccess(c *gc.C) {
-	user := s.Factory.MakeUser(c, &factory.UserParams{Name: "foobar"})
+	user := s.Factory.MakeUser(c, &factory.UserParams{Name: "foobar", NoModelUser: true})
 	s.setAPIUser(c, s.AdminUserTag(c))
 	st := s.Factory.MakeModel(c, nil)
 	defer st.Close()
 
-	args := params.ModifyModelAccessRequest{
-		Changes: []params.ModifyModelAccess{{
-			UserTag:  user.UserTag().String(),
-			Action:   params.GrantModelAccess,
-			Access:   params.ModelReadAccess,
-			ModelTag: st.ModelTag().String(),
-		}}}
-
-	result, err := s.modelmanager.ModifyModelAccess(args)
+	err := s.grant(c, user.UserTag(), params.ModelReadAccess, st.ModelTag())
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(result.OneError(), gc.IsNil)
-	c.Assert(result.Results, gc.HasLen, 1)
-	c.Assert(result.Results[0].Error, gc.IsNil)
 
-	result, err = s.modelmanager.ModifyModelAccess(args)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(result.OneError(), gc.ErrorMatches, `user already has "read" access`)
+	err = s.grant(c, user.UserTag(), params.ModelReadAccess, st.ModelTag())
+	c.Assert(err, gc.ErrorMatches, `user already has "read" access`)
+}
+
+func (s *modelManagerSuite) assertNewUser(c *gc.C, modelUser *state.ModelUser, userTag, creatorTag names.UserTag) {
+	c.Assert(modelUser.UserTag(), gc.Equals, userTag)
+	c.Assert(modelUser.CreatedBy(), gc.Equals, creatorTag.Canonical())
+	_, err := modelUser.LastConnection()
+	c.Assert(err, jc.Satisfies, state.IsNeverConnectedError)
 }
 
 func (s *modelManagerSuite) TestGrantModelAddLocalUser(c *gc.C) {
 	user := s.Factory.MakeUser(c, &factory.UserParams{Name: "foobar", NoModelUser: true})
-	s.setAPIUser(c, s.AdminUserTag(c))
+	apiUser := s.AdminUserTag(c)
+	s.setAPIUser(c, apiUser)
 	st := s.Factory.MakeModel(c, nil)
 	defer st.Close()
 
-	args := params.ModifyModelAccessRequest{
-		Changes: []params.ModifyModelAccess{{
-			UserTag:  user.UserTag().String(),
-			Action:   params.GrantModelAccess,
-			Access:   params.ModelReadAccess,
-			ModelTag: st.ModelTag().String(),
-		}}}
-
-	result, err := s.modelmanager.ModifyModelAccess(args)
+	err := s.grant(c, user.UserTag(), params.ModelReadAccess, st.ModelTag())
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(result.OneError(), gc.IsNil)
-	c.Assert(result.Results, gc.HasLen, 1)
-	c.Assert(result.Results[0].Error, gc.IsNil)
 
 	modelUser, err := st.ModelUser(user.UserTag())
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(modelUser.UserName(), gc.Equals, user.UserTag().Canonical())
-	c.Assert(modelUser.CreatedBy(), gc.Equals, "admin@local")
+	s.assertNewUser(c, modelUser, user.UserTag(), apiUser)
 	c.Assert(modelUser.ReadOnly(), jc.IsTrue)
-	lastConn, err := modelUser.LastConnection()
-	c.Assert(err, jc.Satisfies, state.IsNeverConnectedError)
-	c.Assert(lastConn, gc.Equals, time.Time{})
 }
 
 func (s *modelManagerSuite) TestGrantModelAddRemoteUser(c *gc.C) {
-	user := names.NewUserTag("foobar@ubuntuone")
-	s.setAPIUser(c, s.AdminUserTag(c))
+	userTag := names.NewUserTag("foobar@ubuntuone")
+	apiUser := s.AdminUserTag(c)
+	s.setAPIUser(c, apiUser)
 	st := s.Factory.MakeModel(c, nil)
 	defer st.Close()
 
-	args := params.ModifyModelAccessRequest{
-		Changes: []params.ModifyModelAccess{{
-			UserTag:  user.String(),
-			Action:   params.GrantModelAccess,
-			Access:   params.ModelReadAccess,
-			ModelTag: st.ModelTag().String(),
-		}}}
-
-	result, err := s.modelmanager.ModifyModelAccess(args)
+	err := s.grant(c, userTag, params.ModelReadAccess, st.ModelTag())
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(result.OneError(), gc.IsNil)
-	c.Assert(result.Results, gc.HasLen, 1)
-	c.Assert(result.Results[0].Error, gc.IsNil)
 
-	modelUser, err := st.ModelUser(user)
+	modelUser, err := st.ModelUser(userTag)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(modelUser.UserName(), gc.Equals, user.Canonical())
-	c.Assert(modelUser.CreatedBy(), gc.Equals, "admin@local")
+
+	s.assertNewUser(c, modelUser, userTag, apiUser)
 	c.Assert(modelUser.ReadOnly(), jc.IsTrue)
-	lastConn, err := modelUser.LastConnection()
-	c.Assert(err, jc.Satisfies, state.IsNeverConnectedError)
-	c.Assert(lastConn.IsZero(), jc.IsTrue)
 }
 
 func (s *modelManagerSuite) TestGrantModelAddAdminUser(c *gc.C) {
 	user := s.Factory.MakeUser(c, &factory.UserParams{Name: "foobar", NoModelUser: true})
-	s.setAPIUser(c, s.AdminUserTag(c))
+	apiUser := s.AdminUserTag(c)
+	s.setAPIUser(c, apiUser)
 	st := s.Factory.MakeModel(c, nil)
 	defer st.Close()
 
-	args := params.ModifyModelAccessRequest{
-		Changes: []params.ModifyModelAccess{{
-			UserTag:  user.Tag().String(),
-			Action:   params.GrantModelAccess,
-			Access:   params.ModelWriteAccess,
-			ModelTag: st.ModelTag().String(),
-		}}}
-
-	result, err := s.modelmanager.ModifyModelAccess(args)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(result.OneError(), gc.IsNil)
-	c.Assert(result.Results, gc.HasLen, 1)
-	c.Assert(result.Results[0].Error, gc.IsNil)
+	err := s.grant(c, user.UserTag(), params.ModelWriteAccess, st.ModelTag())
 
 	modelUser, err := st.ModelUser(user.UserTag())
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(modelUser.UserName(), gc.Equals, user.UserTag().Canonical())
-	c.Assert(modelUser.CreatedBy(), gc.Equals, "admin@local")
+	s.assertNewUser(c, modelUser, user.UserTag(), apiUser)
 	c.Assert(modelUser.ReadOnly(), jc.IsFalse)
-	lastConn, err := modelUser.LastConnection()
-	c.Assert(err, jc.Satisfies, state.IsNeverConnectedError)
-	c.Assert(lastConn, gc.Equals, time.Time{})
 }
 
 func (s *modelManagerSuite) TestGrantModelIncreaseAccess(c *gc.C) {
-	user := s.Factory.MakeUser(c, &factory.UserParams{Name: "foobar"})
 	s.setAPIUser(c, s.AdminUserTag(c))
 	st := s.Factory.MakeModel(c, nil)
 	defer st.Close()
+	stFactory := factory.NewFactory(st)
+	user := stFactory.MakeModelUser(c, &factory.ModelUserParams{Access: state.ModelReadAccess})
 
-	args := params.ModifyModelAccessRequest{
-		Changes: []params.ModifyModelAccess{{
-			UserTag:  user.Tag().String(),
-			Action:   params.GrantModelAccess,
-			Access:   params.ModelReadAccess,
-			ModelTag: st.ModelTag().String(),
-		}}}
-
-	result, err := s.modelmanager.ModifyModelAccess(args)
+	err := s.grant(c, user.UserTag(), params.ModelWriteAccess, st.ModelTag())
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(result.OneError(), gc.IsNil)
-	c.Assert(result.Results, gc.HasLen, 1)
-	c.Assert(result.Results[0].Error, gc.IsNil)
 
-	args = params.ModifyModelAccessRequest{
-		Changes: []params.ModifyModelAccess{{
-			UserTag:  user.Tag().String(),
-			Action:   params.GrantModelAccess,
-			Access:   params.ModelWriteAccess,
-			ModelTag: st.ModelTag().String(),
-		}}}
-
-	result, err = s.modelmanager.ModifyModelAccess(args)
+	modelUser, err := st.ModelUser(user.UserTag())
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(result.OneError(), gc.IsNil)
-	c.Assert(result.Results, gc.HasLen, 1)
-	c.Assert(result.Results[0].Error, gc.IsNil)
-
-	modelUser, err := s.State.ModelUser(user.UserTag())
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(modelUser.UserName(), gc.Equals, user.UserTag().Canonical())
 	c.Assert(modelUser.Access(), gc.Equals, state.ModelAdminAccess)
+}
+
+func (s *modelManagerSuite) TestGrantToModelNoAccess(c *gc.C) {
+	apiUser := names.NewUserTag("bob@remote")
+	s.setAPIUser(c, apiUser)
+
+	st := s.Factory.MakeModel(c, nil)
+	defer st.Close()
+
+	other := names.NewUserTag("other@remote")
+	err := s.grant(c, other, params.ModelReadAccess, st.ModelTag())
+	c.Assert(err, gc.ErrorMatches, "permission denied")
+}
+
+func (s *modelManagerSuite) TestGrantToModelReadAccess(c *gc.C) {
+	apiUser := names.NewUserTag("bob@remote")
+	s.setAPIUser(c, apiUser)
+
+	st := s.Factory.MakeModel(c, nil)
+	defer st.Close()
+	stFactory := factory.NewFactory(st)
+	stFactory.MakeModelUser(c, &factory.ModelUserParams{
+		User: apiUser.Canonical(), Access: state.ModelReadAccess})
+
+	other := names.NewUserTag("other@remote")
+	err := s.grant(c, other, params.ModelReadAccess, st.ModelTag())
+	c.Assert(err, gc.ErrorMatches, "permission denied")
+}
+
+func (s *modelManagerSuite) TestGrantToModelWriteAccess(c *gc.C) {
+	apiUser := names.NewUserTag("bob@remote")
+	s.setAPIUser(c, apiUser)
+
+	st := s.Factory.MakeModel(c, nil)
+	defer st.Close()
+	stFactory := factory.NewFactory(st)
+	stFactory.MakeModelUser(c, &factory.ModelUserParams{
+		User: apiUser.Canonical(), Access: state.ModelAdminAccess})
+
+	other := names.NewUserTag("other@remote")
+	err := s.grant(c, other, params.ModelReadAccess, st.ModelTag())
+	c.Assert(err, jc.ErrorIsNil)
+
+	modelUser, err := st.ModelUser(other)
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertNewUser(c, modelUser, other, apiUser)
+	c.Assert(modelUser.ReadOnly(), jc.IsTrue)
 }
 
 func (s *modelManagerSuite) TestGrantModelInvalidUserTag(c *gc.C) {
@@ -654,8 +593,6 @@ func (s *modelManagerSuite) TestGrantModelInvalidUserTag(c *gc.C) {
 		result, err := s.modelmanager.ModifyModelAccess(args)
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(result.OneError(), gc.ErrorMatches, expectedErr)
-		c.Assert(result.Results, gc.HasLen, 1)
-		c.Assert(result.Results[0].Error, gc.ErrorMatches, expectedErr)
 	}
 }
 
@@ -667,8 +604,6 @@ func (s *modelManagerSuite) TestModifyModelAccessEmptyArgs(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	expectedErr := `could not modify model access: invalid model access permission ""`
 	c.Assert(result.OneError(), gc.ErrorMatches, expectedErr)
-	c.Assert(result.Results, gc.HasLen, 1)
-	c.Assert(result.Results[0].Error, gc.ErrorMatches, expectedErr)
 }
 
 func (s *modelManagerSuite) TestModifyModelAccessInvalidAction(c *gc.C) {
@@ -686,24 +621,6 @@ func (s *modelManagerSuite) TestModifyModelAccessInvalidAction(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	expectedErr := `unknown action "dance"`
 	c.Assert(result.OneError(), gc.ErrorMatches, expectedErr)
-	c.Assert(result.Results, gc.HasLen, 1)
-	c.Assert(result.Results[0].Error, gc.ErrorMatches, expectedErr)
-}
-
-func (s *modelManagerSuite) TestModifyModelAccessReadOnly(c *gc.C) {
-	user := s.Factory.MakeModelUser(c, &factory.ModelUserParams{Access: state.ModelReadAccess})
-	s.setAPIUser(c, user.UserTag())
-
-	args := params.ModifyModelAccessRequest{
-		Changes: []params.ModifyModelAccess{{
-			UserTag:  "bob@ubuntuone",
-			Action:   params.GrantModelAccess,
-			Access:   params.ModelReadAccess,
-			ModelTag: s.State.ModelTag().String(),
-		}}}
-
-	_, err := s.modelmanager.ModifyModelAccess(args)
-	c.Assert(err, gc.ErrorMatches, "only controller admins can grant or revoke model access")
 }
 
 type fakeProvider struct {

--- a/apiserver/usermanager/usermanager.go
+++ b/apiserver/usermanager/usermanager.go
@@ -31,6 +31,8 @@ type UserManagerAPI struct {
 	authorizer               common.Authorizer
 	createLocalLoginMacaroon func(names.UserTag) (*macaroon.Macaroon, error)
 	check                    *common.BlockChecker
+	apiUser                  names.UserTag
+	isAdmin                  bool
 }
 
 func NewUserManagerAPI(
@@ -40,6 +42,17 @@ func NewUserManagerAPI(
 ) (*UserManagerAPI, error) {
 	if !authorizer.AuthClient() {
 		return nil, common.ErrPerm
+	}
+
+	// Since we know this is a user tag (because AuthClient is true),
+	// we just do the type assertion to the UserTag.
+	apiUser, _ := authorizer.GetAuthTag().(names.UserTag)
+	// Pretty much all of the user manager methods have special casing for admin
+	// users, so look once when we start and remember if the user is an admin.
+	isAdmin, err := st.IsControllerAdministrator(apiUser)
+	logger.Debugf("%s (admin: %v)", apiUser.Canonical(), isAdmin)
+	if err != nil {
+		return nil, errors.Trace(err)
 	}
 
 	resource, ok := resources.Get("createLocalLoginMacaroon").(common.ValueResource)
@@ -55,22 +68,10 @@ func NewUserManagerAPI(
 		state:                    st,
 		authorizer:               authorizer,
 		createLocalLoginMacaroon: createLocalLoginMacaroon,
-		check: common.NewBlockChecker(st),
+		check:   common.NewBlockChecker(st),
+		apiUser: apiUser,
+		isAdmin: isAdmin,
 	}, nil
-}
-
-func (api *UserManagerAPI) permissionCheck(user names.UserTag) error {
-	// TODO(thumper): PERMISSIONS Change this permission check when we have
-	// real permissions. For now, only the owner of the initial environment is
-	// able to add users.
-	initialEnv, err := api.state.ControllerModel()
-	if err != nil {
-		return errors.Trace(err)
-	}
-	if user != initialEnv.Owner() {
-		return errors.Trace(common.ErrPerm)
-	}
-	return nil
 }
 
 // AddUser adds a user with a username, and either a password or
@@ -86,22 +87,17 @@ func (api *UserManagerAPI) AddUser(args params.AddUsers) (params.AddUserResults,
 	if len(args.Users) == 0 {
 		return result, nil
 	}
-	loggedInUser, err := api.getLoggedInUser()
-	if err != nil {
-		return result, errors.Wrap(err, common.ErrPerm)
+	if !api.isAdmin {
+		return result, common.ErrPerm
 	}
-	// TODO(thumper): PERMISSIONS Change this permission check when we have
-	// real permissions. For now, only the owner of the initial model is
-	// able to add users.
-	if err := api.permissionCheck(loggedInUser); err != nil {
-		return result, errors.Trace(err)
-	}
+
 	for i, arg := range args.Users {
 		var user *state.User
+		var err error
 		if arg.Password != "" {
-			user, err = api.state.AddUser(arg.Username, arg.DisplayName, arg.Password, loggedInUser.Id())
+			user, err = api.state.AddUser(arg.Username, arg.DisplayName, arg.Password, api.apiUser.Id())
 		} else {
-			user, err = api.state.AddUserWithSecretKey(arg.Username, arg.DisplayName, loggedInUser.Id())
+			user, err = api.state.AddUserWithSecretKey(arg.Username, arg.DisplayName, api.apiUser.Id())
 		}
 		if err != nil {
 			err = errors.Annotate(err, "failed to create user")
@@ -130,9 +126,8 @@ func (api *UserManagerAPI) AddUser(args params.AddUsers) (params.AddUserResults,
 					break
 				}
 				err = modelmanager.ChangeModelAccess(
-					modelmanager.NewStateBackend(api.state), modelTag, loggedInUser,
-					userTag, params.GrantModelAccess, modelAccess,
-				)
+					modelmanager.NewStateBackend(api.state), modelTag, api.apiUser,
+					userTag, params.GrantModelAccess, modelAccess, api.isAdmin)
 				if err != nil {
 					err = errors.Annotatef(err, "user %q created but model %q not shared", arg.Username, modelTagStr)
 					result.Results[i].Error = common.ServerError(err)
@@ -181,15 +176,8 @@ func (api *UserManagerAPI) enableUserImpl(args params.Entities, action string, m
 	if len(args.Entities) == 0 {
 		return result, nil
 	}
-	loggedInUser, err := api.getLoggedInUser()
-	if err != nil {
-		return result, errors.Wrap(err, common.ErrPerm)
-	}
-	// TODO(thumper): PERMISSIONS Change this permission check when we have
-	// real permissions. For now, only the owner of the initial environment is
-	// able to add users.
-	if err := api.permissionCheck(loggedInUser); err != nil {
-		return result, errors.Trace(err)
+	if !api.isAdmin {
+		return result, common.ErrPerm
 	}
 
 	for i, arg := range args.Entities {
@@ -267,28 +255,20 @@ func (api *UserManagerAPI) SetPassword(args params.EntityPasswords) (params.Erro
 	if len(args.Changes) == 0 {
 		return result, nil
 	}
-	loggedInUser, err := api.getLoggedInUser()
-	if err != nil {
-		return result, common.ErrPerm
-	}
-	adminUser, err := api.checkAdminUser(loggedInUser)
-	if err != nil {
-		return result, common.ServerError(err)
-	}
 	for i, arg := range args.Changes {
-		if err := api.setPassword(loggedInUser, arg, adminUser); err != nil {
+		if err := api.setPassword(arg); err != nil {
 			result.Results[i].Error = common.ServerError(err)
 		}
 	}
 	return result, nil
 }
 
-func (api *UserManagerAPI) setPassword(loggedInUser names.UserTag, arg params.EntityPassword, adminUser bool) error {
+func (api *UserManagerAPI) setPassword(arg params.EntityPassword) error {
 	user, err := api.getUser(arg.Tag)
 	if err != nil {
 		return errors.Trace(err)
 	}
-	if loggedInUser != user.UserTag() && !adminUser {
+	if api.apiUser != user.UserTag() && !api.isAdmin {
 		return errors.Trace(common.ErrPerm)
 	}
 	if arg.Password == "" {
@@ -306,20 +286,12 @@ func (api *UserManagerAPI) CreateLocalLoginMacaroon(args params.Entities) (param
 	results := params.MacaroonResults{
 		Results: make([]params.MacaroonResult, len(args.Entities)),
 	}
-	loggedInUser, err := api.getLoggedInUser()
-	if err != nil {
-		return results, common.ErrPerm
-	}
-	adminUser, err := api.checkAdminUser(loggedInUser)
-	if err != nil {
-		return results, common.ServerError(err)
-	}
 	createLocalLoginMacaroon := func(arg params.Entity) (*macaroon.Macaroon, error) {
 		user, err := api.getUser(arg.Tag)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		if loggedInUser != user.UserTag() && !adminUser {
+		if api.apiUser != user.UserTag() && !api.isAdmin {
 			return nil, errors.Trace(common.ErrPerm)
 		}
 		return api.createLocalLoginMacaroon(user.UserTag())
@@ -333,24 +305,4 @@ func (api *UserManagerAPI) CreateLocalLoginMacaroon(args params.Entities) (param
 		results.Results[i].Result = m
 	}
 	return results, nil
-}
-
-func (api *UserManagerAPI) checkAdminUser(userTag names.UserTag) (bool, error) {
-	err := api.permissionCheck(userTag)
-	switch errors.Cause(err) {
-	case nil:
-		return true, nil
-	case common.ErrPerm:
-		return false, nil
-	}
-	return false, errors.Trace(err)
-}
-
-func (api *UserManagerAPI) getLoggedInUser() (names.UserTag, error) {
-	switch tag := api.authorizer.GetAuthTag().(type) {
-	case names.UserTag:
-		return tag, nil
-	default:
-		return names.UserTag{}, errors.New("authorizer not a user")
-	}
 }

--- a/apiserver/usermanager/usermanager.go
+++ b/apiserver/usermanager/usermanager.go
@@ -50,7 +50,6 @@ func NewUserManagerAPI(
 	// Pretty much all of the user manager methods have special casing for admin
 	// users, so look once when we start and remember if the user is an admin.
 	isAdmin, err := st.IsControllerAdministrator(apiUser)
-	logger.Debugf("%s (admin: %v)", apiUser.Canonical(), isAdmin)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/apiserver/usermanager/usermanager_test.go
+++ b/apiserver/usermanager/usermanager_test.go
@@ -189,7 +189,7 @@ func (s *userManagerSuite) TestBlockAddUser(c *gc.C) {
 }
 
 func (s *userManagerSuite) TestAddUserAsNormalUser(c *gc.C) {
-	alex := s.Factory.MakeUser(c, &factory.UserParams{Name: "alex"})
+	alex := s.Factory.MakeUser(c, &factory.UserParams{Name: "alex", NoModelUser: true})
 	usermanager, err := usermanager.NewUserManagerAPI(
 		s.State, s.resources, apiservertesting.FakeAuthorizer{Tag: alex.Tag()})
 	c.Assert(err, jc.ErrorIsNil)
@@ -341,7 +341,7 @@ func (s *userManagerSuite) TestBlockEnableUser(c *gc.C) {
 }
 
 func (s *userManagerSuite) TestDisableUserAsNormalUser(c *gc.C) {
-	alex := s.Factory.MakeUser(c, &factory.UserParams{Name: "alex"})
+	alex := s.Factory.MakeUser(c, &factory.UserParams{Name: "alex", NoModelUser: true})
 	usermanager, err := usermanager.NewUserManagerAPI(
 		s.State, s.resources, apiservertesting.FakeAuthorizer{Tag: alex.Tag()})
 	c.Assert(err, jc.ErrorIsNil)
@@ -360,7 +360,7 @@ func (s *userManagerSuite) TestDisableUserAsNormalUser(c *gc.C) {
 }
 
 func (s *userManagerSuite) TestEnableUserAsNormalUser(c *gc.C) {
-	alex := s.Factory.MakeUser(c, &factory.UserParams{Name: "alex"})
+	alex := s.Factory.MakeUser(c, &factory.UserParams{Name: "alex", NoModelUser: true})
 	usermanager, err := usermanager.NewUserManagerAPI(
 		s.State, s.resources, apiservertesting.FakeAuthorizer{Tag: alex.Tag()})
 	c.Assert(err, jc.ErrorIsNil)
@@ -504,7 +504,7 @@ func lastLoginPointer(c *gc.C, user *state.User) *time.Time {
 }
 
 func (s *userManagerSuite) TestSetPassword(c *gc.C) {
-	alex := s.Factory.MakeUser(c, &factory.UserParams{Name: "alex"})
+	alex := s.Factory.MakeUser(c, &factory.UserParams{Name: "alex", NoModelUser: true})
 
 	args := params.EntityPasswords{
 		Changes: []params.EntityPassword{{
@@ -523,7 +523,7 @@ func (s *userManagerSuite) TestSetPassword(c *gc.C) {
 }
 
 func (s *userManagerSuite) TestBlockSetPassword(c *gc.C) {
-	alex := s.Factory.MakeUser(c, &factory.UserParams{Name: "alex"})
+	alex := s.Factory.MakeUser(c, &factory.UserParams{Name: "alex", NoModelUser: true})
 
 	args := params.EntityPasswords{
 		Changes: []params.EntityPassword{{
@@ -543,7 +543,7 @@ func (s *userManagerSuite) TestBlockSetPassword(c *gc.C) {
 }
 
 func (s *userManagerSuite) TestSetPasswordForSelf(c *gc.C) {
-	alex := s.Factory.MakeUser(c, &factory.UserParams{Name: "alex"})
+	alex := s.Factory.MakeUser(c, &factory.UserParams{Name: "alex", NoModelUser: true})
 	usermanager, err := usermanager.NewUserManagerAPI(
 		s.State, s.resources, apiservertesting.FakeAuthorizer{Tag: alex.Tag()})
 	c.Assert(err, jc.ErrorIsNil)
@@ -565,8 +565,8 @@ func (s *userManagerSuite) TestSetPasswordForSelf(c *gc.C) {
 }
 
 func (s *userManagerSuite) TestSetPasswordForOther(c *gc.C) {
-	alex := s.Factory.MakeUser(c, &factory.UserParams{Name: "alex"})
-	barb := s.Factory.MakeUser(c, &factory.UserParams{Name: "barb"})
+	alex := s.Factory.MakeUser(c, &factory.UserParams{Name: "alex", NoModelUser: true})
+	barb := s.Factory.MakeUser(c, &factory.UserParams{Name: "barb", NoModelUser: true})
 	usermanager, err := usermanager.NewUserManagerAPI(
 		s.State, s.resources, apiservertesting.FakeAuthorizer{Tag: alex.Tag()})
 	c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
Also found that the user manager had not yet been updated to use state.IsControllerAdmin.

Much test cleanup.

(Review request: http://reviews.vapour.ws/r/4679/)