### PR TITLE
Add hostkeyreporter worker

### DIFF
--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -36,6 +36,7 @@ var facadeVersions = map[string]int{
 	"FilesystemAttachmentsWatcher": 2,
 	"Firewaller":                   2,
 	"HighAvailability":             2,
+	"HostKeyReporter":              1,
 	"ImageManager":                 2,
 	"ImageMetadata":                2,
 	"InstancePoller":               2,

--- a/api/hostkeyreporter/facade.go
+++ b/api/hostkeyreporter/facade.go
@@ -1,0 +1,41 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Package hostkeyreporter implements the client-side API facade used
+// by the hostkeyreporter worker.
+package hostkeyreporter
+
+import (
+	"github.com/juju/names"
+
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/apiserver/params"
+)
+
+// Facade provides access to the HostKeyReporter API facade.
+type Facade struct {
+	caller base.FacadeCaller
+}
+
+// NewFacade creates a new client-side HostKeyReporter facade.
+func NewFacade(caller base.APICaller) *Facade {
+	return &Facade{
+		caller: base.NewFacadeCaller(caller, "HostKeyReporter"),
+	}
+}
+
+// ReportKeys reports the public SSH host keys for a machine to the
+// controller. The keys should be in the same format as the sshd host
+// key files, one entry per key.
+func (f *Facade) ReportKeys(machineId string, publicKeys []string) error {
+	args := params.SSHHostKeySet{EntityKeys: []params.SSHHostKeys{{
+		Tag:        names.NewMachineTag(machineId).String(),
+		PublicKeys: publicKeys,
+	}}}
+	var result params.ErrorResults
+	err := f.caller.FacadeCall("ReportKeys", args, &result)
+	if err != nil {
+		return err
+	}
+	return result.OneError()
+}

--- a/api/hostkeyreporter/facade_test.go
+++ b/api/hostkeyreporter/facade_test.go
@@ -1,0 +1,89 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package hostkeyreporter_test
+
+import (
+	"errors"
+
+	"github.com/juju/names"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	basetesting "github.com/juju/juju/api/base/testing"
+	"github.com/juju/juju/api/hostkeyreporter"
+	"github.com/juju/juju/apiserver/params"
+)
+
+type facadeSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&facadeSuite{})
+
+func (s *facadeSuite) TestReportKeys(c *gc.C) {
+	stub := new(testing.Stub)
+	apiCaller := basetesting.APICallerFunc(func(
+		objType string, version int,
+		id, request string,
+		args, response interface{},
+	) error {
+		c.Check(objType, gc.Equals, "HostKeyReporter")
+		c.Check(version, gc.Equals, 0)
+		c.Check(id, gc.Equals, "")
+		stub.AddCall(request, args)
+		*response.(*params.ErrorResults) = params.ErrorResults{
+			Results: []params.ErrorResult{{
+				(*params.Error)(nil),
+			}},
+		}
+		return nil
+	})
+	facade := hostkeyreporter.NewFacade(apiCaller)
+
+	err := facade.ReportKeys("42", []string{"rsa", "dsa"})
+	c.Assert(err, jc.ErrorIsNil)
+
+	stub.CheckCalls(c, []testing.StubCall{{
+		"ReportKeys", []interface{}{params.SSHHostKeySet{
+			EntityKeys: []params.SSHHostKeys{{
+				Tag:        names.NewMachineTag("42").String(),
+				PublicKeys: []string{"rsa", "dsa"},
+			}},
+		}},
+	}})
+}
+
+func (s *facadeSuite) TestCallError(c *gc.C) {
+	apiCaller := basetesting.APICallerFunc(func(
+		objType string, version int,
+		id, request string,
+		args, response interface{},
+	) error {
+		return errors.New("blam")
+	})
+	facade := hostkeyreporter.NewFacade(apiCaller)
+
+	err := facade.ReportKeys("42", []string{"rsa", "dsa"})
+	c.Assert(err, gc.ErrorMatches, "blam")
+}
+
+func (s *facadeSuite) TestInnerError(c *gc.C) {
+	apiCaller := basetesting.APICallerFunc(func(
+		objType string, version int,
+		id, request string,
+		args, response interface{},
+	) error {
+		*response.(*params.ErrorResults) = params.ErrorResults{
+			Results: []params.ErrorResult{{
+				&params.Error{Message: "blam"},
+			}},
+		}
+		return nil
+	})
+	facade := hostkeyreporter.NewFacade(apiCaller)
+
+	err := facade.ReportKeys("42", []string{"rsa", "dsa"})
+	c.Assert(err, gc.ErrorMatches, "blam")
+}

--- a/api/hostkeyreporter/package_test.go
+++ b/api/hostkeyreporter/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package hostkeyreporter_test
+
+import (
+	stdtesting "testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *stdtesting.T) {
+	gc.TestingT(t)
+}

--- a/api/machiner/machine.go
+++ b/api/machiner/machine.go
@@ -137,19 +137,3 @@ func (m *Machine) SetProviderNetworkConfig() error {
 	}
 	return result.OneError()
 }
-
-// SetSSHHostKeys reports the public SSH host keys for the machine to
-// the controller. The keys should be in the same format as the sshd
-// host key files, one entry per key.
-func (m *Machine) SetSSHHostKeys(publicKeys []string) error {
-	args := params.SSHHostKeySet{EntityKeys: []params.SSHHostKeys{{
-		Tag:        m.tag.String(),
-		PublicKeys: publicKeys,
-	}}}
-	var result params.ErrorResults
-	err := m.st.facade.FacadeCall("SetSSHHostKeys", args, &result)
-	if err != nil {
-		return err
-	}
-	return result.OneError()
-}

--- a/api/machiner/machiner_test.go
+++ b/api/machiner/machiner_test.go
@@ -202,22 +202,3 @@ func (s *machinerSuite) TestWatch(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertOneChange()
 }
-
-func (s *machinerSuite) TestSetSSHHostKeys(c *gc.C) {
-	tag := names.NewMachineTag("1")
-
-	// No keys to start.
-	_, err := s.State.GetSSHHostKeys(tag)
-	c.Assert(errors.IsNotFound(err), jc.IsTrue)
-
-	// Set some keys.
-	machine, err := s.machiner.Machine(tag)
-	c.Assert(err, jc.ErrorIsNil)
-	err = machine.SetSSHHostKeys([]string{"rsa", "dsa", "ecdsa"})
-	c.Assert(err, jc.ErrorIsNil)
-
-	// Check keys were written.
-	keysGot, err := s.State.GetSSHHostKeys(tag)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(keysGot, gc.DeepEquals, state.SSHHostKeys{"rsa", "dsa", "ecdsa"})
-}

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -27,6 +27,7 @@ import (
 	_ "github.com/juju/juju/apiserver/diskmanager"
 	_ "github.com/juju/juju/apiserver/firewaller"
 	_ "github.com/juju/juju/apiserver/highavailability"
+	_ "github.com/juju/juju/apiserver/hostkeyreporter"
 	_ "github.com/juju/juju/apiserver/imagemanager"
 	_ "github.com/juju/juju/apiserver/imagemetadata"
 	_ "github.com/juju/juju/apiserver/instancepoller"

--- a/apiserver/hostkeyreporter/facade.go
+++ b/apiserver/hostkeyreporter/facade.go
@@ -1,0 +1,65 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Package hostkeyreporter implements the API facade used by the
+// hostkeyreporter worker.
+package hostkeyreporter
+
+import (
+	"github.com/juju/names"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/state"
+)
+
+func init() {
+	common.RegisterStandardFacade("HostKeyReporter", 1, newFacade)
+}
+
+// Backend defines the State API used by the hostkeyreporter facade.
+type Backend interface {
+	SetSSHHostKeys(names.MachineTag, state.SSHHostKeys) error
+}
+
+// Facade implements the API required by the hostkeyreporter worker.
+type Facade struct {
+	backend      Backend
+	getCanModify common.GetAuthFunc
+}
+
+// New returns a new API facade for the hostkeyreporter worker.
+func New(backend Backend, _ *common.Resources, authorizer common.Authorizer) (*Facade, error) {
+	return &Facade{
+		backend: backend,
+		getCanModify: func() (common.AuthFunc, error) {
+			return authorizer.AuthOwner, nil
+		},
+	}, nil
+}
+
+// ReportKeys sets the SSH host keys for one or more entities.
+func (facade *Facade) ReportKeys(args params.SSHHostKeySet) (params.ErrorResults, error) {
+	results := params.ErrorResults{
+		Results: make([]params.ErrorResult, len(args.EntityKeys)),
+	}
+
+	canModify, err := facade.getCanModify()
+	if err != nil {
+		return results, err
+	}
+
+	for i, arg := range args.EntityKeys {
+		tag, err := names.ParseMachineTag(arg.Tag)
+		if err != nil {
+			results.Results[i].Error = common.ServerError(common.ErrPerm)
+			continue
+		}
+		err = common.ErrPerm
+		if canModify(tag) {
+			err = facade.backend.SetSSHHostKeys(tag, state.SSHHostKeys(arg.PublicKeys))
+		}
+		results.Results[i].Error = common.ServerError(err)
+	}
+	return results, nil
+}

--- a/apiserver/hostkeyreporter/facade_test.go
+++ b/apiserver/hostkeyreporter/facade_test.go
@@ -1,0 +1,75 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package hostkeyreporter_test
+
+import (
+	"github.com/juju/names"
+	jujutesting "github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/hostkeyreporter"
+	"github.com/juju/juju/apiserver/params"
+	apiservertesting "github.com/juju/juju/apiserver/testing"
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/testing"
+)
+
+type facadeSuite struct {
+	testing.BaseSuite
+	backend    *mockBackend
+	authorizer *apiservertesting.FakeAuthorizer
+	facade     *hostkeyreporter.Facade
+}
+
+var _ = gc.Suite(&facadeSuite{})
+
+func (s *facadeSuite) SetUpTest(c *gc.C) {
+	s.backend = new(mockBackend)
+	s.authorizer = new(apiservertesting.FakeAuthorizer)
+	facade, err := hostkeyreporter.New(s.backend, nil, s.authorizer)
+	c.Assert(err, jc.ErrorIsNil)
+	s.facade = facade
+}
+
+func (s *facadeSuite) TestReportKeys(c *gc.C) {
+	s.authorizer.Tag = names.NewMachineTag("1")
+
+	args := params.SSHHostKeySet{
+		EntityKeys: []params.SSHHostKeys{
+			{
+				Tag:        names.NewMachineTag("0").String(),
+				PublicKeys: []string{"rsa0", "dsa0"},
+			}, {
+				Tag:        names.NewMachineTag("1").String(),
+				PublicKeys: []string{"rsa1", "dsa1"},
+			},
+		},
+	}
+	result, err := s.facade.ReportKeys(args)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(result, gc.DeepEquals, params.ErrorResults{
+		Results: []params.ErrorResult{
+			{Error: apiservertesting.ErrUnauthorized},
+			{nil},
+		},
+	})
+	s.backend.stub.CheckCalls(c, []jujutesting.StubCall{{
+		"SetSSHHostKeys",
+		[]interface{}{
+			names.NewMachineTag("1"),
+			state.SSHHostKeys{"rsa1", "dsa1"},
+		},
+	}})
+}
+
+type mockBackend struct {
+	stub jujutesting.Stub
+}
+
+func (backend *mockBackend) SetSSHHostKeys(tag names.MachineTag, keys state.SSHHostKeys) error {
+	backend.stub.AddCall("SetSSHHostKeys", tag, keys)
+	return nil
+}

--- a/apiserver/hostkeyreporter/package_test.go
+++ b/apiserver/hostkeyreporter/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package hostkeyreporter_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/apiserver/hostkeyreporter/shim.go
+++ b/apiserver/hostkeyreporter/shim.go
@@ -1,0 +1,14 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package hostkeyreporter
+
+import (
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/state"
+)
+
+// newFacade wraps New to express the supplied *state.State as a Backend.
+func newFacade(st *state.State, res *common.Resources, auth common.Authorizer) (*Facade, error) {
+	return New(st, res, auth)
+}

--- a/apiserver/machine/machiner.go
+++ b/apiserver/machine/machiner.go
@@ -278,29 +278,3 @@ func (api *MachinerAPI) getOneMachineProviderNetworkConfig(m *state.Machine) ([]
 
 	return providerConfig, nil
 }
-
-// SetSSHHostKeys sets the SSH host keys for one or more entities.
-func (api *MachinerAPI) SetSSHHostKeys(args params.SSHHostKeySet) (params.ErrorResults, error) {
-	results := params.ErrorResults{
-		Results: make([]params.ErrorResult, len(args.EntityKeys)),
-	}
-
-	canModify, err := api.getCanModify()
-	if err != nil {
-		return results, err
-	}
-
-	for i, arg := range args.EntityKeys {
-		tag, err := names.ParseMachineTag(arg.Tag)
-		if err != nil {
-			results.Results[i].Error = common.ServerError(common.ErrPerm)
-			continue
-		}
-		err = common.ErrPerm
-		if canModify(tag) {
-			err = api.st.SetSSHHostKeys(tag, state.SSHHostKeys(arg.PublicKeys))
-		}
-		results.Results[i].Error = common.ServerError(err)
-	}
-	return results, nil
-}

--- a/apiserver/machine/machiner_test.go
+++ b/apiserver/machine/machiner_test.go
@@ -4,7 +4,6 @@
 package machine_test
 
 import (
-	"github.com/juju/errors"
 	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -370,34 +369,4 @@ func (s *machinerSuite) TestSetProviderNetworkConfigPermissions(c *gc.C) {
 			{Error: apiservertesting.ErrUnauthorized},
 		},
 	})
-}
-
-func (s *machinerSuite) TestSetSSHHostKeys(c *gc.C) {
-	args := params.SSHHostKeySet{
-		EntityKeys: []params.SSHHostKeys{
-			{
-				Tag:        s.machine0.Tag().String(),
-				PublicKeys: []string{"rsa0", "dsa0"},
-			}, {
-				Tag:        s.machine1.Tag().String(),
-				PublicKeys: []string{"rsa1", "dsa1"},
-			},
-		},
-	}
-	result, err := s.machiner.SetSSHHostKeys(args)
-	c.Assert(err, jc.ErrorIsNil)
-
-	c.Assert(result, gc.DeepEquals, params.ErrorResults{
-		Results: []params.ErrorResult{
-			{Error: apiservertesting.ErrUnauthorized},
-			{nil},
-		},
-	})
-
-	_, err = s.State.GetSSHHostKeys(s.machine0.MachineTag())
-	c.Assert(errors.IsNotFound(err), jc.IsTrue)
-
-	keys, err := s.State.GetSSHHostKeys(s.machine1.MachineTag())
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(keys, gc.DeepEquals, state.SSHHostKeys{"rsa1", "dsa1"})
 }

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -443,6 +443,7 @@ func (a *MachineAgent) makeEngineCreator(previousAgentVersion version.Number) fu
 		manifolds := machine.Manifolds(machine.ManifoldsConfig{
 			PreviousAgentVersion: previousAgentVersion,
 			Agent:                agent.APIHostPortsSetter{Agent: a},
+			RootDir:              a.rootDir,
 			AgentConfigChanged:   a.configChangedVal,
 			UpgradeStepsLock:     a.upgradeComplete,
 			UpgradeCheckLock:     a.initialUpgradeCheckComplete,

--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -23,6 +23,7 @@ import (
 	"github.com/juju/juju/worker/diskmanager"
 	"github.com/juju/juju/worker/fortress"
 	"github.com/juju/juju/worker/gate"
+	"github.com/juju/juju/worker/hostkeyreporter"
 	"github.com/juju/juju/worker/identityfilewriter"
 	"github.com/juju/juju/worker/logger"
 	"github.com/juju/juju/worker/logsender"
@@ -52,6 +53,11 @@ type ManifoldsConfig struct {
 	// AgentConfigChanged is set whenever the machine agent's config
 	// is updated.
 	AgentConfigChanged *voyeur.Value
+
+	// RootDir is the root directory that any worker that needs to
+	// access local filesystems should use as a base. In actual use it
+	// will be "" but it may be overriden in tests.
+	RootDir string
 
 	// PreviousAgentVersion passes through the version the machine
 	// agent was running before the current restart.
@@ -383,6 +389,14 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 			NewFacade:     machineactions.NewFacade,
 			NewWorker:     machineactions.NewMachineActionsWorker,
 		})),
+
+		hostKeyReporterName: ifFullyUpgraded(hostkeyreporter.Manifold(hostkeyreporter.ManifoldConfig{
+			AgentName:     agentName,
+			APICallerName: apiCallerName,
+			RootDir:       config.RootDir,
+			NewFacade:     hostkeyreporter.NewFacade,
+			NewWorker:     hostkeyreporter.NewWorker,
+		})),
 	}
 }
 
@@ -428,4 +442,5 @@ const (
 	toolsVersionCheckerName  = "tools-version-checker"
 	apiConfigWatcherName     = "api-config-watcher"
 	machineActionName        = "machine-action-runner"
+	hostKeyReporterName      = "host-key-reporter"
 )

--- a/cmd/jujud/agent/machine/manifolds_test.go
+++ b/cmd/jujud/agent/machine/manifolds_test.go
@@ -47,6 +47,7 @@ func (*ManifoldsSuite) TestManifoldNames(c *gc.C) {
 		"api-caller",
 		"api-config-watcher",
 		"disk-manager",
+		"host-key-reporter",
 		"log-sender",
 		"logging-config-updater",
 		"machine-action-runner",

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -110,7 +110,7 @@ func (s *MigrationSuite) TestKnownCollections(c *gc.C) {
 		legacyipaddressesC,
 
 		// The SSH host keys for each machine will be reported as each
-		// machiner starts up.
+		// machine agent starts up.
 		sshHostKeysC,
 	)
 

--- a/worker/hostkeyreporter/manifold.go
+++ b/worker/hostkeyreporter/manifold.go
@@ -1,0 +1,88 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package hostkeyreporter
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/juju/agent"
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/dependency"
+	"github.com/juju/names"
+)
+
+// ManifoldConfig defines the names of the manifolds on which the
+// hostkeyreporter worker depends.
+type ManifoldConfig struct {
+	AgentName     string
+	APICallerName string
+	RootDir       string
+
+	NewFacade func(base.APICaller) (Facade, error)
+	NewWorker func(Config) (worker.Worker, error)
+}
+
+// validate is called by start to check for bad configuration.
+func (config ManifoldConfig) validate() error {
+	if config.AgentName == "" {
+		return errors.NotValidf("empty AgentName")
+	}
+	if config.APICallerName == "" {
+		return errors.NotValidf("empty APICallerName")
+	}
+	if config.NewFacade == nil {
+		return errors.NotValidf("nil NewFacade")
+	}
+	if config.NewWorker == nil {
+		return errors.NotValidf("nil NewWorker")
+	}
+	return nil
+}
+
+// start is a StartFunc for a Worker manifold.
+func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, error) {
+	if err := config.validate(); err != nil {
+		return nil, errors.Trace(err)
+	}
+	var agent agent.Agent
+	if err := context.Get(config.AgentName, &agent); err != nil {
+		return nil, errors.Trace(err)
+	}
+	var apiCaller base.APICaller
+	if err := context.Get(config.APICallerName, &apiCaller); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	tag := agent.CurrentConfig().Tag()
+	if _, ok := tag.(names.MachineTag); !ok {
+		return nil, errors.New("hostkeyreporter may only be used with a machine agent")
+	}
+
+	facade, err := config.NewFacade(apiCaller)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	worker, err := config.NewWorker(Config{
+		Facade:    facade,
+		MachineId: tag.Id(),
+		RootDir:   config.RootDir,
+	})
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return worker, nil
+}
+
+// Manifold returns a dependency manifold that runs the migration
+// worker.
+func Manifold(config ManifoldConfig) dependency.Manifold {
+	return dependency.Manifold{
+		Inputs: []string{
+			config.AgentName,
+			config.APICallerName,
+		},
+		Start: config.start,
+	}
+}

--- a/worker/hostkeyreporter/manifold.go
+++ b/worker/hostkeyreporter/manifold.go
@@ -4,12 +4,15 @@
 package hostkeyreporter
 
 import (
+	"runtime"
+
 	"github.com/juju/errors"
+	"github.com/juju/names"
+
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/dependency"
-	"github.com/juju/names"
 )
 
 // ManifoldConfig defines the names of the manifolds on which the
@@ -42,6 +45,11 @@ func (config ManifoldConfig) validate() error {
 
 // start is a StartFunc for a Worker manifold.
 func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, error) {
+	if runtime.GOOS == "windows" {
+		logger.Debugf("no SSH host keys to report on Windows machines")
+		return nil, dependency.ErrUninstall
+	}
+
 	if err := config.validate(); err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/worker/hostkeyreporter/package_test.go
+++ b/worker/hostkeyreporter/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package hostkeyreporter_test
+
+import (
+	stdtesting "testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *stdtesting.T) {
+	gc.TestingT(t)
+}

--- a/worker/hostkeyreporter/shim.go
+++ b/worker/hostkeyreporter/shim.go
@@ -1,0 +1,23 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package hostkeyreporter
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/juju/api/base"
+	apihostkeyreporter "github.com/juju/juju/api/hostkeyreporter"
+	"github.com/juju/juju/worker"
+)
+
+func NewFacade(apiCaller base.APICaller) (Facade, error) {
+	return apihostkeyreporter.NewFacade(apiCaller), nil
+}
+
+func NewWorker(config Config) (worker.Worker, error) {
+	worker, err := New(config)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return worker, nil
+}

--- a/worker/hostkeyreporter/shim.go
+++ b/worker/hostkeyreporter/shim.go
@@ -5,6 +5,7 @@ package hostkeyreporter
 
 import (
 	"github.com/juju/errors"
+
 	"github.com/juju/juju/api/base"
 	apihostkeyreporter "github.com/juju/juju/api/hostkeyreporter"
 	"github.com/juju/juju/worker"

--- a/worker/hostkeyreporter/worker.go
+++ b/worker/hostkeyreporter/worker.go
@@ -82,6 +82,7 @@ func (w *hostkeyreporter) run() error {
 	if err != nil {
 		return errors.Trace(err)
 	}
+	logger.Debugf("%d SSH host keys reported for machine %s", len(keys), w.config.MachineId)
 	return dependency.ErrUninstall
 }
 

--- a/worker/hostkeyreporter/worker.go
+++ b/worker/hostkeyreporter/worker.go
@@ -1,0 +1,107 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package hostkeyreporter
+
+import (
+	"io/ioutil"
+	"path/filepath"
+
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	"launchpad.net/tomb"
+
+	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/dependency"
+)
+
+var logger = loggo.GetLogger("juju.worker.hostkeyreporter")
+
+// Facade exposes controller functionality to a Worker.
+type Facade interface {
+	ReportKeys(machineId string, publicKeys []string) error
+}
+
+// Config defines the parameters of the hostkeyreporter worker.
+type Config struct {
+	Facade    Facade
+	MachineId string
+	RootDir   string
+}
+
+// Validate returns an error if Config cannot drive a hostkeyreporter.
+func (config Config) Validate() error {
+	if config.Facade == nil {
+		return errors.NotValidf("nil Facade")
+	}
+	if config.MachineId == "" {
+		return errors.NotValidf("empty MachineId")
+	}
+	return nil
+}
+
+// New returns a Worker backed by config, or an error.
+func New(config Config) (worker.Worker, error) {
+	if err := config.Validate(); err != nil {
+		return nil, errors.Trace(err)
+	}
+	w := &hostkeyreporter{config: config}
+	go func() {
+		defer w.tomb.Done()
+		w.tomb.Kill(w.run())
+	}()
+	return w, nil
+}
+
+// Worker waits for a model migration to be active, then locks down the
+// configured fortress and implements the migration.
+type hostkeyreporter struct {
+	tomb   tomb.Tomb
+	config Config
+}
+
+// Kill implements worker.Worker.
+func (w *hostkeyreporter) Kill() {
+	w.tomb.Kill(nil)
+}
+
+// Wait implements worker.Worker.
+func (w *hostkeyreporter) Wait() error {
+	return w.tomb.Wait()
+}
+
+func (w *hostkeyreporter) run() error {
+	keys, err := w.readSSHKeys()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if len(keys) < 1 {
+		return errors.New("no SSH host keys found")
+	}
+	err = w.config.Facade.ReportKeys(w.config.MachineId, keys)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return dependency.ErrUninstall
+}
+
+func (w *hostkeyreporter) readSSHKeys() ([]string, error) {
+	filenames, err := filepath.Glob(w.sshDir() + "/ssh_host_*_key.pub")
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	keys := make([]string, 0, len(filenames))
+	for _, filename := range filenames {
+		key, err := ioutil.ReadFile(filename)
+		if err != nil {
+			logger.Warningf("unable to read SSH host key (skipping): %v", err)
+			continue
+		}
+		keys = append(keys, string(key))
+	}
+	return keys, nil
+}
+
+func (w *hostkeyreporter) sshDir() string {
+	return filepath.Join(w.config.RootDir, "etc", "ssh")
+}

--- a/worker/hostkeyreporter/worker.go
+++ b/worker/hostkeyreporter/worker.go
@@ -5,6 +5,7 @@ package hostkeyreporter
 
 import (
 	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/juju/errors"
@@ -87,7 +88,15 @@ func (w *hostkeyreporter) run() error {
 }
 
 func (w *hostkeyreporter) readSSHKeys() ([]string, error) {
-	filenames, err := filepath.Glob(w.sshDir() + "/ssh_host_*_key.pub")
+	sshDir := w.sshDir()
+	if _, err := os.Stat(sshDir); os.IsNotExist(err) {
+		logger.Warningf("%s doesn't exist - giving up", sshDir)
+		return nil, dependency.ErrUninstall
+	} else if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	filenames, err := filepath.Glob(sshDir + "/ssh_host_*_key.pub")
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/worker/hostkeyreporter/worker_test.go
+++ b/worker/hostkeyreporter/worker_test.go
@@ -1,0 +1,110 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package hostkeyreporter_test
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	jujutesting "github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/worker/dependency"
+	"github.com/juju/juju/worker/hostkeyreporter"
+	"github.com/juju/juju/worker/workertest"
+)
+
+type Suite struct {
+	jujutesting.IsolationSuite
+
+	dir    string
+	stub   *jujutesting.Stub
+	facade *stubFacade
+	config hostkeyreporter.Config
+}
+
+var _ = gc.Suite(&Suite{})
+
+func (s *Suite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+
+	// Generate some dummy key files
+	s.dir = c.MkDir()
+	sshDir := filepath.Join(s.dir, "etc", "ssh")
+	err := os.MkdirAll(sshDir, 0755)
+	c.Assert(err, jc.ErrorIsNil)
+	writeKey := func(keyType string) {
+		baseName := fmt.Sprintf("ssh_host_%s_key.pub", keyType)
+		fileName := filepath.Join(sshDir, baseName)
+		err := ioutil.WriteFile(fileName, []byte(keyType), 0644)
+		c.Assert(err, jc.ErrorIsNil)
+	}
+	writeKey("dsa")
+	writeKey("rsa")
+	writeKey("ecdsa")
+
+	s.stub = new(jujutesting.Stub)
+	s.facade = newStubFacade(s.stub)
+	s.config = hostkeyreporter.Config{
+		Facade:    s.facade,
+		MachineId: "42",
+		RootDir:   s.dir,
+	}
+}
+
+func (s *Suite) TestInvalidConfig(c *gc.C) {
+	s.config.MachineId = ""
+	_, err := hostkeyreporter.New(s.config)
+	c.Check(err, gc.ErrorMatches, "empty MachineId .+")
+	c.Check(s.stub.Calls(), gc.HasLen, 0)
+}
+
+func (s *Suite) TestNoKeys(c *gc.C) {
+	// Pass an empty directory so the keys created in setup won't be
+	// there.
+	s.config.RootDir = c.MkDir()
+
+	w, err := hostkeyreporter.New(s.config)
+	c.Assert(err, jc.ErrorIsNil)
+	err = workertest.CheckKilled(c, w)
+	c.Check(err, gc.ErrorMatches, "no SSH host keys found")
+}
+
+func (s *Suite) TestReportKeysError(c *gc.C) {
+	s.facade.reportErr = errors.New("blam")
+	w, err := hostkeyreporter.New(s.config)
+	c.Assert(err, jc.ErrorIsNil)
+	err = workertest.CheckKilled(c, w)
+	c.Check(err, gc.ErrorMatches, "blam")
+}
+
+func (s *Suite) TestSuccess(c *gc.C) {
+	w, err := hostkeyreporter.New(s.config)
+	c.Assert(err, jc.ErrorIsNil)
+	err = workertest.CheckKilled(c, w)
+	c.Check(err, gc.Equals, dependency.ErrUninstall)
+	s.stub.CheckCalls(c, []jujutesting.StubCall{{
+		"ReportKeys", []interface{}{"42", []string{"dsa", "ecdsa", "rsa"}},
+	}})
+}
+
+func newStubFacade(stub *jujutesting.Stub) *stubFacade {
+	return &stubFacade{
+		stub: stub,
+	}
+}
+
+type stubFacade struct {
+	stub      *jujutesting.Stub
+	reportErr error
+}
+
+func (c *stubFacade) ReportKeys(machineId string, publicKeys []string) error {
+	c.stub.AddCall("ReportKeys", machineId, publicKeys)
+	return c.reportErr
+}


### PR DESCRIPTION
This change introduces a new hostkeyreporter manifold and integrates it into the machine agent. It reads the machine's SSH host keys and reports them to the controller via an API call.

The change also includes some reorganisation of the API facade used by the worker. Originally the machiner was going to handle this functionality but I decided a separate worker was more appropriate.

Part of the fix for LP #1456916

(Review request: http://reviews.vapour.ws/r/4681/)