### PR TITLE
Fix to not display "deployed under previous agreement" for local charms.

### DIFF
--- a/cmd/juju/service/deploy.go
+++ b/cmd/juju/service/deploy.go
@@ -607,7 +607,7 @@ func (c *DeployCommand) deployCharm(args deployCharmArgs) (rErr error) {
 		}
 	}()
 
-	if len(charmInfo.Meta.Terms) > 0 {
+	if args.id.URL != nil && args.id.URL.Schema != "local" && len(charmInfo.Meta.Terms) > 0 {
 		args.ctx.Infof("Deployment under prior agreement to terms: %s",
 			strings.Join(charmInfo.Meta.Terms, " "))
 	}

--- a/cmd/juju/service/deploy_test.go
+++ b/cmd/juju/service/deploy_test.go
@@ -709,6 +709,17 @@ Deployment under prior agreement to terms: term1/1 term3/1
 	c.Assert(err, jc.ErrorIsNil)
 }
 
+func (s *DeploySuite) TestDeployLocalWithTerms(c *gc.C) {
+	ch := testcharms.Repo.ClonedDirPath(s.CharmsPath, "terms1")
+	output, err := runDeployCommand(c, ch, "--series", "trusty")
+	c.Assert(err, jc.ErrorIsNil)
+	// should not produce any output
+	c.Assert(output, gc.Equals, "")
+
+	curl := charm.MustParseURL("local:trusty/terms1-1")
+	s.AssertService(c, "terms1", curl, 1, 0)
+}
+
 func (s *DeployCharmStoreSuite) TestDeployWithTermsNotSigned(c *gc.C) {
 	s.termsDischargerError = &httpbakery.Error{
 		Message: "term agreement required: term/1 term/2",


### PR DESCRIPTION


(Review request: http://reviews.vapour.ws/r/4683/)