### PR TITLE
1572746: Document -m <controller>:<model> syntax

### DIFF
--- a/cmd/modelcmd/modelcommand.go
+++ b/cmd/modelcmd/modelcommand.go
@@ -275,7 +275,7 @@ func (w *modelCommandWrapper) Run(ctx *cmd.Context) error {
 
 func (w *modelCommandWrapper) SetFlags(f *gnuflag.FlagSet) {
 	if !w.skipFlags {
-		f.StringVar(&w.modelName, "m", "", "Model to operate in")
+		f.StringVar(&w.modelName, "m", "", "Model to operate in. Accepts [<controller name>:]<model name>")
 		f.StringVar(&w.modelName, "model", "", "")
 	}
 	w.ModelCommand.SetFlags(f)


### PR DESCRIPTION
Commands that take the -m flag for specifying the model
can take the format <controller name>:<model name>, but
this wasn't documented anywhere.  Added it in this PR.

(Review request: http://reviews.vapour.ws/r/4686/)