### PR TITLE
Restart the presence pinger if it dies.

### DIFF
--- a/apiserver/package_test.go
+++ b/apiserver/package_test.go
@@ -6,14 +6,16 @@ package apiserver_test
 import (
 	stdtesting "testing"
 
-	"github.com/juju/testing"
+	//"github.com/juju/testing"
 
 	coretesting "github.com/juju/juju/testing"
 )
 
 func TestPackage(t *stdtesting.T) {
-	if testing.RaceEnabled {
-		t.Skip("skipping package under -race, see LP 1518806")
-	}
+	/*
+		if testing.RaceEnabled {
+			t.Skip("skipping package under -race, see LP 1518806")
+		}
+	*/
 	coretesting.MgoTestPackage(t)
 }

--- a/apiserver/presence/package_test.go
+++ b/apiserver/presence/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package presence_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/apiserver/presence/pinger.go
+++ b/apiserver/presence/pinger.go
@@ -1,3 +1,6 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
 package presence
 
 import (

--- a/apiserver/presence/pinger.go
+++ b/apiserver/presence/pinger.go
@@ -121,9 +121,13 @@ func (w *Worker) loop() error {
 		case <-w.catacomb.Dying():
 			return w.catacomb.ErrDying()
 		case <-clock.After(delay):
+			// runPinger() returns only once the pinger has finished
+			// or has failed to start. So either it ran or it didn't.
 			if w.runPinger() {
+				// Finished.
 				delay = 0
 			} else {
+				// Failed to start.
 				delay = w.config.RetryDelay
 			}
 		}

--- a/apiserver/presence/pinger.go
+++ b/apiserver/presence/pinger.go
@@ -14,8 +14,9 @@ import (
 
 // Pinger exposes some methods implemented by state/presence.Pinger.
 type Pinger interface {
-	HardStop() error
-	SoftStop() error
+	// Stop requests the pinger to stop, but does not wait.
+	Stop() error
+	// Wait waits for the pinger to stop.
 	Wait() error
 }
 
@@ -147,7 +148,7 @@ func (w *Worker) runPinger() (startedSuccessfully bool) {
 	// we'll see them come out of Wait() below.
 	go func() {
 		<-w.catacomb.Dying()
-		pinger.SoftStop()
+		pinger.Stop()
 	}()
 
 	// Now, just wait for the Pinger to stop. It might be caused by

--- a/apiserver/presence/pinger.go
+++ b/apiserver/presence/pinger.go
@@ -1,0 +1,161 @@
+package presence
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/juju/errors"
+	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/catacomb"
+	"github.com/juju/loggo"
+	"github.com/juju/names"
+	"github.com/juju/utils/clock"
+)
+
+// Pinger exposes some methods implemented by state/presence.Pinger.
+type Pinger interface {
+	HardStop() error
+	SoftStop() error
+	Wait() error
+}
+
+// Config contains the information necessary to drive a Worker.
+type Config struct {
+
+	// Identity records the entity whose connectedness is being
+	// affirmed by this worker. It's used to create a logger that
+	// can let us see which agent's pinger is actually failing.
+	Identity names.Tag
+
+	// Start starts a new, running Pinger or returns an error.
+	Start func() (Pinger, error)
+
+	// Clock is used to throttle failed Start attempts.
+	Clock clock.Clock
+
+	// RetryDelay controls by how much we throttle failed Start
+	// attempts. Note that we only apply the delay when a Start
+	// fails; if a Pinger ran, however briefly, we'll try to restart
+	// it immediately, so as to minimise the changes of erroneously
+	// causing agent-lost to be reported.
+	RetryDelay time.Duration
+}
+
+// Validate returns an error if Config cannot be expected to drive a
+// Worker.
+func (config Config) Validate() error {
+	if config.Identity == nil {
+		return errors.NotValidf("nil Identity")
+	}
+	if config.Start == nil {
+		return errors.NotValidf("nil Start")
+	}
+	if config.Clock == nil {
+		return errors.NotValidf("nil Clock")
+	}
+	if config.RetryDelay <= 0 {
+		return errors.NotValidf("non-positive RetryDelay")
+	}
+	return nil
+}
+
+// New returns a Worker backed by Config. The caller is responsible for
+// Kill()ing the Worker and handling any errors returned from Wait();
+// but as it happens it's designed to be an apiserver/common.Resource,
+// and never to exit unless Kill()ed, so in practice Stop(), which will
+// call Kill() and Wait() internally, is Good Enough.
+func New(config Config) (*Worker, error) {
+	if err := config.Validate(); err != nil {
+		return nil, errors.Trace(err)
+	}
+	name := fmt.Sprintf("juju.apiserver.presence.%s", config.Identity)
+	w := &Worker{
+		config: config,
+		logger: loggo.GetLogger(name),
+	}
+	err := catacomb.Invoke(catacomb.Plan{
+		Site: &w.catacomb,
+		Work: w.loop,
+	})
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	//<-time.After(500 * time.Millisecond)
+	return w, nil
+}
+
+// Worker creates a Pinger as configured, and recreates it as it fails
+// until the Worker is stopped; at which point it shuts down any extant
+// Pinger before returning.
+type Worker struct {
+	catacomb catacomb.Catacomb
+	config   Config
+	logger   loggo.Logger
+}
+
+// Kill is part of the worker.Worker interface.
+func (w *Worker) Kill() {
+	w.catacomb.Kill(nil)
+}
+
+// Wait is part of the worker.Worker interface.
+func (w *Worker) Wait() error {
+	return w.catacomb.Wait()
+}
+
+// Stop is part of the apiserver/common.Resource interface.
+//
+// It's not a very good idea -- see comments on lp:1572237 -- but we're
+// only addressing the proximate cause of the issue here.
+func (w *Worker) Stop() error {
+	return worker.Stop(w)
+}
+
+// loop runs Pingers until w is stopped.
+func (w *Worker) loop() error {
+	var delay time.Duration
+	clock := w.config.Clock
+	for {
+		select {
+		case <-w.catacomb.Dying():
+			return w.catacomb.ErrDying()
+		case <-clock.After(delay):
+			if w.runPinger() {
+				delay = 0
+			} else {
+				delay = w.config.RetryDelay
+			}
+		}
+	}
+}
+
+// runPinger runs a single Pinger indefinitely, stopping it only when
+// the Worker is Kill()ed; returning true only when the Pinger itself
+// has stopped for any reason (and false if it could not be started).
+func (w *Worker) runPinger() (startedSuccessfully bool) {
+	w.logger.Debugf("starting pinger...")
+	pinger, err := w.config.Start()
+	if err != nil {
+		w.logger.Errorf("pinger failed to start: %v", err)
+		return false
+	}
+	w.logger.Debugf("pinger started")
+
+	// Start a goroutine that waits for the Worker to be stopped,
+	// and then stops the Pinger.  Note also that we ignore errors
+	// out of Stop(): they will be caught by the Pinger anyway, and
+	// we'll see them come out of Wait() below.
+	go func() {
+		<-w.catacomb.Dying()
+		pinger.SoftStop()
+	}()
+
+	// Now, just wait for the Pinger to stop. It might be caused by
+	// the Worker's death, or it might have failed on its own; in
+	// any case, errors are worth recording, but we don't need to
+	// respond in any way because that's loop()'s responsibility.
+	if err := pinger.Wait(); err != nil {
+		w.logger.Errorf("pinger failed: %v", err)
+	}
+	return true
+}

--- a/apiserver/presence/pinger.go
+++ b/apiserver/presence/pinger.go
@@ -83,7 +83,10 @@ func New(config Config) (*Worker, error) {
 		Work: func() error {
 			// Run once to prime presence before diving into the loop.
 			pinger := w.startPinger()
-			close(ready)
+			if ready != nil {
+				close(ready)
+				ready = nil
+			}
 			if pinger != nil {
 				w.waitOnPinger(pinger)
 			}

--- a/apiserver/presence/pinger_test.go
+++ b/apiserver/presence/pinger_test.go
@@ -22,6 +22,8 @@ type WorkerSuite struct {
 
 	stub   *testing.Stub
 	pinger *stubPinger
+	clock  *stubClock
+	cfg    presence.Config
 }
 
 var _ = gc.Suite(&WorkerSuite{})
@@ -31,6 +33,13 @@ func (s *WorkerSuite) SetUpTest(c *gc.C) {
 
 	s.stub = &testing.Stub{}
 	s.pinger = &stubPinger{Stub: s.stub}
+	s.clock = &stubClock{StubClock: coretesting.NewStubClock(s.stub)}
+	s.cfg = presence.Config{
+		Identity:   names.NewMachineTag("1"),
+		Start:      s.start,
+		Clock:      s.clock,
+		RetryDelay: time.Nanosecond,
+	}
 }
 
 func (s *WorkerSuite) start() (presence.Pinger, error) {
@@ -128,8 +137,149 @@ func (s *WorkerSuite) TestConfigValidateMissingRetryDelay(c *gc.C) {
 	c.Check(err, gc.ErrorMatches, `.*non-positive RetryDelay.*`)
 }
 
+func (s *WorkerSuite) TestNewRunOnceBeforeLoop(c *gc.C) {
+	waitChan := make(chan struct{})
+	s.clock.notify = waitChan
+
+	w, err := presence.New(s.cfg)
+	c.Assert(err, jc.ErrorIsNil)
+	defer w.Stop()
+	<-waitChan
+
+	s.stub.CheckCallNames(c,
+		"start",
+		"Wait",
+		"After",
+	)
+}
+
+func (s *WorkerSuite) TestNewFailStart(c *gc.C) {
+	waitChan := make(chan struct{})
+	s.clock.notify = waitChan
+	failure := errors.New("<failure>")
+	s.stub.SetErrors(failure)
+
+	w, err := presence.New(s.cfg)
+	c.Assert(err, jc.ErrorIsNil)
+	defer w.Stop()
+	<-waitChan
+
+	s.stub.CheckCallNames(c,
+		"start",
+		"After", // continued on
+	)
+}
+
+func (s *WorkerSuite) TestNewFailWait(c *gc.C) {
+	waitChan := make(chan struct{})
+	s.clock.notify = waitChan
+	failure := errors.New("<failure>")
+	s.stub.SetErrors(nil, failure)
+
+	w, err := presence.New(s.cfg)
+	c.Assert(err, jc.ErrorIsNil)
+	defer w.Stop()
+	<-waitChan
+
+	s.stub.CheckCallNames(c,
+		"start",
+		"Wait",
+		"After", // continued on
+	)
+}
+
+func (s *WorkerSuite) TestNewLoop(c *gc.C) {
+	waitChan := make(chan struct{})
+	block := make(chan struct{})
+	s.clock.setAfter(4)
+	count := 0
+	s.cfg.Start = func() (presence.Pinger, error) {
+		pinger, err := s.start()
+		c.Logf("%d", count)
+		if count > 3 {
+			s.pinger.notify = waitChan
+			s.pinger.waitBlock = block
+		}
+		count += 1
+		return pinger, err
+	}
+
+	w, err := presence.New(s.cfg)
+	c.Assert(err, jc.ErrorIsNil)
+	defer w.Stop()
+	defer close(block)
+	<-waitChan
+
+	s.stub.CheckCallNames(c,
+		"start", "Wait", "After",
+		"start", "Wait", "After",
+		"start", "Wait", "After",
+		"start", "Wait", "After",
+		"start", "Wait",
+	)
+}
+
+func (s *WorkerSuite) TestNewRetry(c *gc.C) {
+	failure := errors.New("<failure>")
+	s.stub.SetErrors(
+		nil, nil, nil,
+		failure, nil,
+		failure, nil,
+		nil, failure, nil,
+		nil, nil,
+		failure, // never reached
+	)
+	waitChan := make(chan struct{})
+	block := make(chan struct{})
+	s.clock.setAfter(5)
+	delay := time.Nanosecond
+	s.cfg.RetryDelay = delay
+	count := 0
+	s.cfg.Start = func() (presence.Pinger, error) {
+		pinger, err := s.start()
+		if count > 4 {
+			s.pinger.notify = waitChan
+			s.pinger.waitBlock = block
+		}
+		count += 1
+		return pinger, err
+	}
+
+	w, err := presence.New(s.cfg)
+	c.Assert(err, jc.ErrorIsNil)
+	defer w.Stop()
+	defer close(block)
+	<-waitChan
+
+	s.stub.CheckCallNames(c,
+		"start", "Wait", "After",
+		"start", "After",
+		"start", "After",
+		"start", "Wait", "After",
+		"start", "Wait", "After",
+		"start", "Wait",
+	)
+	var noWait time.Duration
+	s.stub.CheckCall(c, 2, "After", noWait)
+	s.stub.CheckCall(c, 4, "After", delay)
+	s.stub.CheckCall(c, 6, "After", delay)
+	s.stub.CheckCall(c, 9, "After", noWait)
+	s.stub.CheckCall(c, 12, "After", noWait)
+}
+
+func (s *WorkerSuite) TestNewInvalidConfig(c *gc.C) {
+	var cfg presence.Config
+
+	_, err := presence.New(cfg)
+
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+}
+
 type stubPinger struct {
 	*testing.Stub
+
+	waitBlock chan struct{}
+	notify    chan struct{}
 }
 
 func (s *stubPinger) Stop() error {
@@ -145,5 +295,34 @@ func (s *stubPinger) Wait() error {
 	if err := s.NextErr(); err != nil {
 		return errors.Trace(err)
 	}
+
+	if s.notify != nil {
+		s.notify <- struct{}{}
+	}
+	if s.waitBlock != nil {
+		<-s.waitBlock
+	}
 	return nil
+}
+
+type stubClock struct {
+	*coretesting.StubClock
+
+	notify chan struct{}
+}
+
+func (s *stubClock) setAfter(numCalls int) {
+	after := make(chan time.Time, numCalls)
+	for i := 0; i < numCalls; i++ {
+		after <- time.Now()
+	}
+	s.ReturnAfter = after
+}
+
+func (s *stubClock) After(d time.Duration) <-chan time.Time {
+	after := s.StubClock.After(d)
+	if s.notify != nil {
+		s.notify <- struct{}{}
+	}
+	return after
 }

--- a/apiserver/presence/pinger_test.go
+++ b/apiserver/presence/pinger_test.go
@@ -1,0 +1,149 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package presence_test
+
+import (
+	"time"
+
+	"github.com/juju/errors"
+	"github.com/juju/names"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/clock"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/presence"
+	coretesting "github.com/juju/juju/testing"
+)
+
+type WorkerSuite struct {
+	testing.IsolationSuite
+
+	stub   *testing.Stub
+	pinger *stubPinger
+}
+
+var _ = gc.Suite(&WorkerSuite{})
+
+func (s *WorkerSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+
+	s.stub = &testing.Stub{}
+	s.pinger = &stubPinger{Stub: s.stub}
+}
+
+func (s *WorkerSuite) start() (presence.Pinger, error) {
+	s.stub.AddCall("start")
+	if err := s.stub.NextErr(); err != nil {
+		return nil, errors.Trace(err)
+	}
+	return s.pinger, nil
+}
+
+func (s *WorkerSuite) TestConfigValidateOkay(c *gc.C) {
+	cfg := presence.Config{
+		Identity:   names.NewMachineTag("1"),
+		Start:      func() (presence.Pinger, error) { return nil, nil },
+		Clock:      struct{ clock.Clock }{},
+		RetryDelay: time.Second,
+	}
+
+	err := cfg.Validate()
+
+	c.Check(err, jc.ErrorIsNil)
+}
+
+func (s *WorkerSuite) TestConfigValidateNothingUsed(c *gc.C) {
+	cfg := presence.Config{
+		Identity:   names.NewMachineTag("1"),
+		Start:      s.start,
+		Clock:      coretesting.NewStubClock(s.stub),
+		RetryDelay: time.Second,
+	}
+
+	err := cfg.Validate()
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.stub.CheckNoCalls(c)
+}
+
+func (s *WorkerSuite) TestConfigValidateZeroValue(c *gc.C) {
+	var cfg presence.Config
+
+	err := cfg.Validate()
+
+	c.Check(err, gc.NotNil)
+}
+
+func (s *WorkerSuite) TestConfigValidateMissingIdentity(c *gc.C) {
+	cfg := presence.Config{
+		Start:      func() (presence.Pinger, error) { return nil, nil },
+		Clock:      struct{ clock.Clock }{},
+		RetryDelay: time.Second,
+	}
+
+	err := cfg.Validate()
+
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+	c.Check(err, gc.ErrorMatches, `.*nil Identity.*`)
+}
+
+func (s *WorkerSuite) TestConfigValidateMissingStart(c *gc.C) {
+	cfg := presence.Config{
+		Identity:   names.NewMachineTag("1"),
+		Clock:      struct{ clock.Clock }{},
+		RetryDelay: time.Second,
+	}
+
+	err := cfg.Validate()
+
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+	c.Check(err, gc.ErrorMatches, `.*nil Start.*`)
+}
+
+func (s *WorkerSuite) TestConfigValidateMissingClock(c *gc.C) {
+	cfg := presence.Config{
+		Identity:   names.NewMachineTag("1"),
+		Start:      func() (presence.Pinger, error) { return nil, nil },
+		RetryDelay: time.Second,
+	}
+
+	err := cfg.Validate()
+
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+	c.Check(err, gc.ErrorMatches, `.*nil Clock.*`)
+}
+
+func (s *WorkerSuite) TestConfigValidateMissingRetryDelay(c *gc.C) {
+	cfg := presence.Config{
+		Identity: names.NewMachineTag("1"),
+		Start:    func() (presence.Pinger, error) { return nil, nil },
+		Clock:    struct{ clock.Clock }{},
+	}
+
+	err := cfg.Validate()
+
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+	c.Check(err, gc.ErrorMatches, `.*non-positive RetryDelay.*`)
+}
+
+type stubPinger struct {
+	*testing.Stub
+}
+
+func (s *stubPinger) Stop() error {
+	s.AddCall("Stop")
+	if err := s.NextErr(); err != nil {
+		return errors.Trace(err)
+	}
+	return nil
+}
+
+func (s *stubPinger) Wait() error {
+	s.AddCall("Wait")
+	if err := s.NextErr(); err != nil {
+		return errors.Trace(err)
+	}
+	return nil
+}

--- a/apiserver/root.go
+++ b/apiserver/root.go
@@ -42,11 +42,10 @@ type objectKey struct {
 // after it has logged in. It contains an rpc.MethodFinder which it
 // uses to dispatch Api calls appropriately.
 type apiHandler struct {
-	state            *state.State
-	rpcConn          *rpc.Conn
-	resources        *common.Resources
-	entity           state.Entity
-	mongoUnavailable *uint32
+	state     *state.State
+	rpcConn   *rpc.Conn
+	resources *common.Resources
+	entity    state.Entity
 	// An empty modelUUID means that the user has logged in through the
 	// root of the API server rather than the /model/:model-uuid/api
 	// path, logins processed with v2 or later will only offer the
@@ -59,11 +58,10 @@ var _ = (*apiHandler)(nil)
 // newApiHandler returns a new apiHandler.
 func newApiHandler(srv *Server, st *state.State, rpcConn *rpc.Conn, reqNotifier *requestNotifier, modelUUID string) (*apiHandler, error) {
 	r := &apiHandler{
-		state:            st,
-		resources:        common.NewResources(),
-		rpcConn:          rpcConn,
-		modelUUID:        modelUUID,
-		mongoUnavailable: &srv.mongoUnavailable,
+		state:     st,
+		resources: common.NewResources(),
+		rpcConn:   rpcConn,
+		modelUUID: modelUUID,
 	}
 	if err := r.resources.RegisterNamed("machineID", common.StringResource(srv.tag.Id())); err != nil {
 		return nil, errors.Trace(err)

--- a/cmd/juju/status/status_test.go
+++ b/cmd/juju/status/status_test.go
@@ -114,7 +114,7 @@ func (ctx *context) run(c *gc.C, steps []stepper) {
 	}
 }
 
-func (ctx *context) setAgentPresence(c *gc.C, p presence.Presencer) *presence.Pinger {
+func (ctx *context) setAgentPresence(c *gc.C, p presence.Agent) *presence.Pinger {
 	pinger, err := p.SetAgentPresence()
 	c.Assert(err, jc.ErrorIsNil)
 	ctx.st.StartSync()

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -180,7 +180,7 @@ func (s *commonMachineSuite) primeAgentWithMachine(c *gc.C, m *state.Machine, ve
 	pinger, err := m.SetAgentPresence()
 	c.Assert(err, jc.ErrorIsNil)
 	s.AddCleanup(func(c *gc.C) {
-		err := pinger.SoftStop()
+		err := pinger.Stop()
 		c.Check(err, jc.ErrorIsNil)
 	})
 	return s.configureMachine(c, m.Id(), vers)

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -180,7 +180,7 @@ func (s *commonMachineSuite) primeAgentWithMachine(c *gc.C, m *state.Machine, ve
 	pinger, err := m.SetAgentPresence()
 	c.Assert(err, jc.ErrorIsNil)
 	s.AddCleanup(func(c *gc.C) {
-		err := pinger.Stop()
+		err := pinger.SoftStop()
 		c.Check(err, jc.ErrorIsNil)
 	})
 	return s.configureMachine(c, m.Id(), vers)

--- a/state/machine.go
+++ b/state/machine.go
@@ -34,9 +34,6 @@ import (
 type Machine struct {
 	st  *State
 	doc machineDoc
-	presence.Presencer
-	status.StatusHistoryGetter
-	status.InstanceStatusHistoryGetter
 }
 
 // MachineJob values define responsibilities that machines may be

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -763,7 +763,7 @@ func (s *MachineSuite) TestMachineWaitAgentPresence(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(alive, jc.IsTrue)
 
-	err = pinger.Kill()
+	err = pinger.KillForTesting()
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.State.StartSync()

--- a/state/presence/presence.go
+++ b/state/presence/presence.go
@@ -400,6 +400,7 @@ func (w *Watcher) sync() error {
 	}
 
 	// Learn about all enforced deaths.
+	// TODO(ericsnow) Remove this once KillForTesting() goes away.
 	dead := make(map[int64]bool)
 	for i := range ping {
 		for key, value := range ping[i].Dead {
@@ -559,10 +560,10 @@ func (p *Pinger) Wait() error {
 	return p.tomb.Wait()
 }
 
-// SoftStop stops p's periodical ping.
+// Stop stops p's periodical ping.
 // Watchers will not notice p has stopped pinging until the
 // previous ping times out.
-func (p *Pinger) SoftStop() error {
+func (p *Pinger) Stop() error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	if p.started {
@@ -576,8 +577,9 @@ func (p *Pinger) SoftStop() error {
 
 }
 
-// HardStop stops p's periodical ping and immediately reports that it is dead.
-func (p *Pinger) HardStop() error {
+// KillForTesting stops p's periodical ping and immediately reports that it is dead.
+// TODO(ericsnow) We should be able to drop this and the two kill* methods.
+func (p *Pinger) KillForTesting() error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	if p.started {

--- a/state/presence/presence_test.go
+++ b/state/presence/presence_test.go
@@ -158,7 +158,7 @@ func (s *PresenceSuite) TestWorkflow(c *gc.C) {
 	// Changes while the channel is out are not observed.
 	w.Unwatch("a", cha)
 	assertNoChange(c, cha)
-	pa.Kill()
+	pa.KillForTesting()
 	w.Sync()
 	pa = presence.NewPinger(s.presence, s.modelTag, "a")
 	pa.Start()
@@ -187,8 +187,8 @@ func (s *PresenceSuite) TestWorkflow(c *gc.C) {
 	assertNoChange(c, chb)
 
 	// pb is running, pa isn't.
-	c.Assert(pa.Kill(), gc.IsNil)
-	c.Assert(pb.Kill(), gc.IsNil)
+	c.Assert(pa.KillForTesting(), gc.IsNil)
+	c.Assert(pb.KillForTesting(), gc.IsNil)
 
 	w.StartSync()
 	assertChange(c, cha, presence.Change{"a", false})
@@ -215,7 +215,7 @@ func (s *PresenceSuite) TestScale(c *gc.C) {
 
 	c.Logf("Killing odd ones...")
 	for i := 1; i < N; i += 2 {
-		c.Assert(ps[i].Kill(), gc.IsNil)
+		c.Assert(ps[i].KillForTesting(), gc.IsNil)
 	}
 
 	c.Logf("Checking who's still alive...")
@@ -259,7 +259,7 @@ func (s *PresenceSuite) TestExpiry(c *gc.C) {
 	assertChange(c, ch, presence.Change{"a", false})
 
 	// Already dead so killing isn't noticed.
-	p.Kill()
+	p.KillForTesting()
 	w.StartSync()
 	assertNoChange(c, ch)
 }
@@ -382,7 +382,7 @@ func (s *PresenceSuite) TestPingerPeriodAndResilience(c *gc.C) {
 	// Start and kill p2, which will temporarily
 	// invalidate p1 and set the key as dead.
 	c.Assert(p2.Start(), gc.IsNil)
-	c.Assert(p2.Kill(), gc.IsNil)
+	c.Assert(p2.KillForTesting(), gc.IsNil)
 
 	w.Sync()
 	assertAlive(c, w, "a", false)
@@ -512,7 +512,7 @@ func (s *PresenceSuite) TestTwoEnvironments(c *gc.C) {
 	assertNoChange(c, ch1)
 	assertChange(c, ch2, presence.Change{"a", true})
 
-	err := p1.Kill()
+	err := p1.KillForTesting()
 	c.Assert(err, jc.ErrorIsNil)
 	presence.FakeTimeSlot(1)
 	w1.StartSync()
@@ -520,7 +520,7 @@ func (s *PresenceSuite) TestTwoEnvironments(c *gc.C) {
 	assertChange(c, ch1, presence.Change{"a", false})
 	assertNoChange(c, ch2)
 
-	err = p2.Kill()
+	err = p2.KillForTesting()
 	c.Assert(err, jc.ErrorIsNil)
 	presence.FakeTimeSlot(2)
 	w1.StartSync()

--- a/state/unit.go
+++ b/state/unit.go
@@ -102,8 +102,6 @@ type unitDoc struct {
 type Unit struct {
 	st  *State
 	doc unitDoc
-	presence.Presencer
-	status.StatusHistoryGetter
 }
 
 func newUnit(st *State, udoc *unitDoc) *Unit {

--- a/state/unit_test.go
+++ b/state/unit_test.go
@@ -890,7 +890,7 @@ func (s *UnitSuite) TestUnitWaitAgentPresence(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(alive, jc.IsTrue)
 
-	err = pinger.Kill()
+	err = pinger.KillForTesting()
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.State.StartSync()

--- a/testing/clock.go
+++ b/testing/clock.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/juju/testing"
 	"github.com/juju/utils/clock"
 )
 
@@ -193,4 +194,36 @@ func (a byTime) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
 // removeFromSlice removes item at the specified index from the slice.
 func removeFromSlice(sl []alarm, index int) []alarm {
 	return append(sl[:index], sl[index+1:]...)
+}
+
+type StubClock struct {
+	*testing.Stub
+
+	ReturnNow       time.Time
+	ReturnAfter     <-chan time.Time
+	ReturnAfterFunc clock.Timer
+}
+
+func NewStubClock(stub *testing.Stub) *StubClock {
+	return &StubClock{
+		Stub: stub,
+	}
+}
+
+func (s *StubClock) Now() time.Time {
+	s.AddCall("Now")
+	s.NextErr() // pop one off
+	return s.ReturnNow
+}
+
+func (s *StubClock) After(d time.Duration) <-chan time.Time {
+	s.AddCall("After", d)
+	s.NextErr() // pop one off
+	return s.ReturnAfter
+}
+
+func (s *StubClock) AfterFunc(d time.Duration, f func()) clock.Timer {
+	s.AddCall("AfterFunc", d, f)
+	s.NextErr() // pop one off
+	return s.ReturnAfterFunc
 }


### PR DESCRIPTION
(fixes https://bugs.launchpad.net/juju-core/+bug/1572237)

The code that runs in each loop of the presence pinger (in state/presence/presence.go) has the potential to return an error.  When that happens the pinger loop stops.  Since there's nothing that restarts the pinger, this patch adds a worker that restarts the pinger in the worker's loop.  Credit goes to William for the solution.  We talked it though and I feel comfortable with it.  I'm just tidying up the patch for him. :)

Note that the tests in apiserver/presence are still incomplete.  I'll be pushing them up as I get them written.

(Review request: http://reviews.vapour.ws/r/4692/)