### PR TITLE
Restart the presence pinger if it dies

### DIFF
--- a/api/highavailability/client_test.go
+++ b/api/highavailability/client_test.go
@@ -27,12 +27,12 @@ type clientSuite struct {
 
 var _ = gc.Suite(&clientSuite{})
 
-type Killer interface {
-	Kill() error
+type KillerForTesting interface {
+	KillForTesting() error
 }
 
-func assertKill(c *gc.C, killer Killer) {
-	c.Assert(killer.Kill(), gc.IsNil)
+func assertKill(c *gc.C, killer KillerForTesting) {
+	c.Assert(killer.KillForTesting(), gc.IsNil)
 }
 
 func setAgentPresence(c *gc.C, s *jujutesting.JujuConnSuite, machineId string) *presence.Pinger {

--- a/apiserver/highavailability/highavailability_test.go
+++ b/apiserver/highavailability/highavailability_test.go
@@ -38,14 +38,14 @@ type clientSuite struct {
 	commontesting.BlockHelper
 }
 
-type Killer interface {
-	Kill() error
+type KillerForTesting interface {
+	KillForTesting() error
 }
 
 var _ = gc.Suite(&clientSuite{})
 
-func assertKill(c *gc.C, killer Killer) {
-	c.Assert(killer.Kill(), gc.IsNil)
+func assertKill(c *gc.C, killer KillerForTesting) {
+	c.Assert(killer.KillForTesting(), gc.IsNil)
 }
 
 var (

--- a/apiserver/package_test.go
+++ b/apiserver/package_test.go
@@ -6,14 +6,16 @@ package apiserver_test
 import (
 	stdtesting "testing"
 
-	"github.com/juju/testing"
+	//"github.com/juju/testing"
 
 	coretesting "github.com/juju/juju/testing"
 )
 
 func TestPackage(t *stdtesting.T) {
-	if testing.RaceEnabled {
-		t.Skip("skipping package under -race, see LP 1518806")
-	}
+	/*
+		if testing.RaceEnabled {
+			t.Skip("skipping package under -race, see LP 1518806")
+		}
+	*/
 	coretesting.MgoTestPackage(t)
 }

--- a/apiserver/package_test.go
+++ b/apiserver/package_test.go
@@ -6,16 +6,14 @@ package apiserver_test
 import (
 	stdtesting "testing"
 
-	//"github.com/juju/testing"
+	"github.com/juju/testing"
 
 	coretesting "github.com/juju/juju/testing"
 )
 
 func TestPackage(t *stdtesting.T) {
-	/*
-		if testing.RaceEnabled {
-			t.Skip("skipping package under -race, see LP 1518806")
-		}
-	*/
+	if testing.RaceEnabled {
+		t.Skip("skipping package under -race, see LP 1518806")
+	}
 	coretesting.MgoTestPackage(t)
 }

--- a/apiserver/presence/package_test.go
+++ b/apiserver/presence/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package presence_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/apiserver/presence/pinger.go
+++ b/apiserver/presence/pinger.go
@@ -17,7 +17,7 @@ import (
 
 // Pinger exposes some methods implemented by state/presence.Pinger.
 type Pinger interface {
-	// Stop requests the pinger to stop, but does not wait.
+	// Stop kills the pinger, then waits for it to exit.
 	Stop() error
 	// Wait waits for the pinger to stop.
 	Wait() error

--- a/apiserver/presence/pinger.go
+++ b/apiserver/presence/pinger.go
@@ -1,0 +1,183 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package presence
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/juju/errors"
+	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/catacomb"
+	"github.com/juju/loggo"
+	"github.com/juju/names"
+	"github.com/juju/utils/clock"
+)
+
+// Pinger exposes some methods implemented by state/presence.Pinger.
+type Pinger interface {
+	// Stop requests the pinger to stop, but does not wait.
+	Stop() error
+	// Wait waits for the pinger to stop.
+	Wait() error
+}
+
+// Config contains the information necessary to drive a Worker.
+type Config struct {
+
+	// Identity records the entity whose connectedness is being
+	// affirmed by this worker. It's used to create a logger that
+	// can let us see which agent's pinger is actually failing.
+	Identity names.Tag
+
+	// Start starts a new, running Pinger or returns an error.
+	Start func() (Pinger, error)
+
+	// Clock is used to throttle failed Start attempts.
+	Clock clock.Clock
+
+	// RetryDelay controls by how much we throttle failed Start
+	// attempts. Note that we only apply the delay when a Start
+	// fails; if a Pinger ran, however briefly, we'll try to restart
+	// it immediately, so as to minimise the changes of erroneously
+	// causing agent-lost to be reported.
+	RetryDelay time.Duration
+}
+
+// Validate returns an error if Config cannot be expected to drive a
+// Worker.
+func (config Config) Validate() error {
+	if config.Identity == nil {
+		return errors.NotValidf("nil Identity")
+	}
+	if config.Start == nil {
+		return errors.NotValidf("nil Start")
+	}
+	if config.Clock == nil {
+		return errors.NotValidf("nil Clock")
+	}
+	if config.RetryDelay <= 0 {
+		return errors.NotValidf("non-positive RetryDelay")
+	}
+	return nil
+}
+
+// New returns a Worker backed by Config. The caller is responsible for
+// Kill()ing the Worker and handling any errors returned from Wait();
+// but as it happens it's designed to be an apiserver/common.Resource,
+// and never to exit unless Kill()ed, so in practice Stop(), which will
+// call Kill() and Wait() internally, is Good Enough.
+func New(config Config) (*Worker, error) {
+	if err := config.Validate(); err != nil {
+		return nil, errors.Trace(err)
+	}
+	name := fmt.Sprintf("juju.apiserver.presence.%s", config.Identity)
+	w := &Worker{
+		config: config,
+		logger: loggo.GetLogger(name),
+	}
+	ready := make(chan struct{})
+	err := catacomb.Invoke(catacomb.Plan{
+		Site: &w.catacomb,
+		Work: func() error {
+			// Run once to prime presence before diving into the loop.
+			pinger := w.startPinger()
+			if ready != nil {
+				close(ready)
+				ready = nil
+			}
+			if pinger != nil {
+				w.waitOnPinger(pinger)
+			}
+			return w.loop()
+		},
+	})
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	<-ready
+	return w, nil
+}
+
+// Worker creates a Pinger as configured, and recreates it as it fails
+// until the Worker is stopped; at which point it shuts down any extant
+// Pinger before returning.
+type Worker struct {
+	catacomb catacomb.Catacomb
+	config   Config
+	logger   loggo.Logger
+}
+
+// Kill is part of the worker.Worker interface.
+func (w *Worker) Kill() {
+	w.catacomb.Kill(nil)
+}
+
+// Wait is part of the worker.Worker interface.
+func (w *Worker) Wait() error {
+	return w.catacomb.Wait()
+}
+
+// Stop is part of the apiserver/common.Resource interface.
+//
+// It's not a very good idea -- see comments on lp:1572237 -- but we're
+// only addressing the proximate cause of the issue here.
+func (w *Worker) Stop() error {
+	return worker.Stop(w)
+}
+
+// loop runs Pingers until w is stopped.
+func (w *Worker) loop() error {
+	var delay time.Duration
+	clock := w.config.Clock
+	for {
+		select {
+		case <-w.catacomb.Dying():
+			return w.catacomb.ErrDying()
+		case <-clock.After(delay):
+			delay = 0
+			pinger := w.startPinger()
+			if pinger == nil {
+				// Failed to start.
+				delay = w.config.RetryDelay
+				continue
+			}
+			w.waitOnPinger(pinger)
+		}
+	}
+}
+
+// startPinger starts a single Pinger. It returns nil if the pinger
+// could not be started.
+func (w *Worker) startPinger() Pinger {
+	w.logger.Debugf("starting pinger...")
+	pinger, err := w.config.Start()
+	if err != nil {
+		w.logger.Errorf("pinger failed to start: %v", err)
+		return nil
+	}
+	w.logger.Debugf("pinger started")
+	return pinger
+}
+
+// waitOnPinger waits indefinitely for the given Pinger to complete,
+// stopping it only when the Worker is Kill()ed.
+func (w *Worker) waitOnPinger(pinger Pinger) {
+	// Start a goroutine that waits for the Worker to be stopped,
+	// and then stops the Pinger.  Note also that we ignore errors
+	// out of Stop(): they will be caught by the Pinger anyway, and
+	// we'll see them come out of Wait() below.
+	go func() {
+		<-w.catacomb.Dying()
+		pinger.Stop()
+	}()
+
+	// Now, just wait for the Pinger to stop. It might be caused by
+	// the Worker's death, or it might have failed on its own; in
+	// any case, errors are worth recording, but we don't need to
+	// respond in any way because that's loop()'s responsibility.
+	if err := pinger.Wait(); err != nil {
+		w.logger.Errorf("pinger failed: %v", err)
+	}
+}

--- a/apiserver/presence/pinger_test.go
+++ b/apiserver/presence/pinger_test.go
@@ -1,0 +1,328 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package presence_test
+
+import (
+	"time"
+
+	"github.com/juju/errors"
+	"github.com/juju/names"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/clock"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/presence"
+	coretesting "github.com/juju/juju/testing"
+)
+
+type WorkerSuite struct {
+	testing.IsolationSuite
+
+	stub   *testing.Stub
+	pinger *stubPinger
+	clock  *stubClock
+	cfg    presence.Config
+}
+
+var _ = gc.Suite(&WorkerSuite{})
+
+func (s *WorkerSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+
+	s.stub = &testing.Stub{}
+	s.pinger = &stubPinger{Stub: s.stub}
+	s.clock = &stubClock{StubClock: coretesting.NewStubClock(s.stub)}
+	s.cfg = presence.Config{
+		Identity:   names.NewMachineTag("1"),
+		Start:      s.start,
+		Clock:      s.clock,
+		RetryDelay: time.Nanosecond,
+	}
+}
+
+func (s *WorkerSuite) start() (presence.Pinger, error) {
+	s.stub.AddCall("start")
+	if err := s.stub.NextErr(); err != nil {
+		return nil, errors.Trace(err)
+	}
+	return s.pinger, nil
+}
+
+func (s *WorkerSuite) TestConfigValidateOkay(c *gc.C) {
+	cfg := presence.Config{
+		Identity:   names.NewMachineTag("1"),
+		Start:      func() (presence.Pinger, error) { return nil, nil },
+		Clock:      struct{ clock.Clock }{},
+		RetryDelay: time.Second,
+	}
+
+	err := cfg.Validate()
+
+	c.Check(err, jc.ErrorIsNil)
+}
+
+func (s *WorkerSuite) TestConfigValidateNothingUsed(c *gc.C) {
+	cfg := presence.Config{
+		Identity:   names.NewMachineTag("1"),
+		Start:      s.start,
+		Clock:      coretesting.NewStubClock(s.stub),
+		RetryDelay: time.Second,
+	}
+
+	err := cfg.Validate()
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.stub.CheckNoCalls(c)
+}
+
+func (s *WorkerSuite) TestConfigValidateZeroValue(c *gc.C) {
+	var cfg presence.Config
+
+	err := cfg.Validate()
+
+	c.Check(err, gc.NotNil)
+}
+
+func (s *WorkerSuite) TestConfigValidateMissingIdentity(c *gc.C) {
+	cfg := presence.Config{
+		Start:      func() (presence.Pinger, error) { return nil, nil },
+		Clock:      struct{ clock.Clock }{},
+		RetryDelay: time.Second,
+	}
+
+	err := cfg.Validate()
+
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+	c.Check(err, gc.ErrorMatches, `.*nil Identity.*`)
+}
+
+func (s *WorkerSuite) TestConfigValidateMissingStart(c *gc.C) {
+	cfg := presence.Config{
+		Identity:   names.NewMachineTag("1"),
+		Clock:      struct{ clock.Clock }{},
+		RetryDelay: time.Second,
+	}
+
+	err := cfg.Validate()
+
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+	c.Check(err, gc.ErrorMatches, `.*nil Start.*`)
+}
+
+func (s *WorkerSuite) TestConfigValidateMissingClock(c *gc.C) {
+	cfg := presence.Config{
+		Identity:   names.NewMachineTag("1"),
+		Start:      func() (presence.Pinger, error) { return nil, nil },
+		RetryDelay: time.Second,
+	}
+
+	err := cfg.Validate()
+
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+	c.Check(err, gc.ErrorMatches, `.*nil Clock.*`)
+}
+
+func (s *WorkerSuite) TestConfigValidateMissingRetryDelay(c *gc.C) {
+	cfg := presence.Config{
+		Identity: names.NewMachineTag("1"),
+		Start:    func() (presence.Pinger, error) { return nil, nil },
+		Clock:    struct{ clock.Clock }{},
+	}
+
+	err := cfg.Validate()
+
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+	c.Check(err, gc.ErrorMatches, `.*non-positive RetryDelay.*`)
+}
+
+func (s *WorkerSuite) TestNewRunOnceBeforeLoop(c *gc.C) {
+	waitChan := make(chan struct{})
+	s.clock.notify = waitChan
+
+	w, err := presence.New(s.cfg)
+	c.Assert(err, jc.ErrorIsNil)
+	defer w.Stop()
+	<-waitChan
+
+	s.stub.CheckCallNames(c,
+		"start",
+		"Wait",
+		"After",
+	)
+}
+
+func (s *WorkerSuite) TestNewFailStart(c *gc.C) {
+	waitChan := make(chan struct{})
+	s.clock.notify = waitChan
+	failure := errors.New("<failure>")
+	s.stub.SetErrors(failure)
+
+	w, err := presence.New(s.cfg)
+	c.Assert(err, jc.ErrorIsNil)
+	defer w.Stop()
+	<-waitChan
+
+	s.stub.CheckCallNames(c,
+		"start",
+		"After", // continued on
+	)
+}
+
+func (s *WorkerSuite) TestNewFailWait(c *gc.C) {
+	waitChan := make(chan struct{})
+	s.clock.notify = waitChan
+	failure := errors.New("<failure>")
+	s.stub.SetErrors(nil, failure)
+
+	w, err := presence.New(s.cfg)
+	c.Assert(err, jc.ErrorIsNil)
+	defer w.Stop()
+	<-waitChan
+
+	s.stub.CheckCallNames(c,
+		"start",
+		"Wait",
+		"After", // continued on
+	)
+}
+
+func (s *WorkerSuite) TestNewLoop(c *gc.C) {
+	waitChan := make(chan struct{})
+	block := make(chan struct{})
+	s.clock.setAfter(4)
+	count := 0
+	s.cfg.Start = func() (presence.Pinger, error) {
+		pinger, err := s.start()
+		c.Logf("%d", count)
+		if count > 3 {
+			s.pinger.notify = waitChan
+			s.pinger.waitBlock = block
+		}
+		count += 1
+		return pinger, err
+	}
+
+	w, err := presence.New(s.cfg)
+	c.Assert(err, jc.ErrorIsNil)
+	defer w.Stop()
+	defer close(block)
+	<-waitChan
+
+	s.stub.CheckCallNames(c,
+		"start", "Wait", "After",
+		"start", "Wait", "After",
+		"start", "Wait", "After",
+		"start", "Wait", "After",
+		"start", "Wait",
+	)
+}
+
+func (s *WorkerSuite) TestNewRetry(c *gc.C) {
+	failure := errors.New("<failure>")
+	s.stub.SetErrors(
+		nil, nil, nil,
+		failure, nil,
+		failure, nil,
+		nil, failure, nil,
+		nil, nil,
+		failure, // never reached
+	)
+	waitChan := make(chan struct{})
+	block := make(chan struct{})
+	s.clock.setAfter(5)
+	delay := time.Nanosecond
+	s.cfg.RetryDelay = delay
+	count := 0
+	s.cfg.Start = func() (presence.Pinger, error) {
+		pinger, err := s.start()
+		if count > 4 {
+			s.pinger.notify = waitChan
+			s.pinger.waitBlock = block
+		}
+		count += 1
+		return pinger, err
+	}
+
+	w, err := presence.New(s.cfg)
+	c.Assert(err, jc.ErrorIsNil)
+	defer w.Stop()
+	defer close(block)
+	<-waitChan
+
+	s.stub.CheckCallNames(c,
+		"start", "Wait", "After",
+		"start", "After",
+		"start", "After",
+		"start", "Wait", "After",
+		"start", "Wait", "After",
+		"start", "Wait",
+	)
+	var noWait time.Duration
+	s.stub.CheckCall(c, 2, "After", noWait)
+	s.stub.CheckCall(c, 4, "After", delay)
+	s.stub.CheckCall(c, 6, "After", delay)
+	s.stub.CheckCall(c, 9, "After", noWait)
+	s.stub.CheckCall(c, 12, "After", noWait)
+}
+
+func (s *WorkerSuite) TestNewInvalidConfig(c *gc.C) {
+	var cfg presence.Config
+
+	_, err := presence.New(cfg)
+
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+}
+
+type stubPinger struct {
+	*testing.Stub
+
+	waitBlock chan struct{}
+	notify    chan struct{}
+}
+
+func (s *stubPinger) Stop() error {
+	s.AddCall("Stop")
+	if err := s.NextErr(); err != nil {
+		return errors.Trace(err)
+	}
+	return nil
+}
+
+func (s *stubPinger) Wait() error {
+	s.AddCall("Wait")
+	if err := s.NextErr(); err != nil {
+		return errors.Trace(err)
+	}
+
+	if s.notify != nil {
+		s.notify <- struct{}{}
+	}
+	if s.waitBlock != nil {
+		<-s.waitBlock
+	}
+	return nil
+}
+
+type stubClock struct {
+	*coretesting.StubClock
+
+	notify chan struct{}
+}
+
+func (s *stubClock) setAfter(numCalls int) {
+	after := make(chan time.Time, numCalls)
+	for i := 0; i < numCalls; i++ {
+		after <- time.Now()
+	}
+	s.ReturnAfter = after
+}
+
+func (s *stubClock) After(d time.Duration) <-chan time.Time {
+	after := s.StubClock.After(d)
+	if s.notify != nil {
+		s.notify <- struct{}{}
+	}
+	return after
+}

--- a/apiserver/presence/pinger_test.go
+++ b/apiserver/presence/pinger_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/juju/juju/apiserver/presence"
 	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/worker/workertest"
 )
 
 type WorkerSuite struct {
@@ -95,7 +96,7 @@ func (s *WorkerSuite) TestConfigValidateMissingIdentity(c *gc.C) {
 	err := cfg.Validate()
 
 	c.Check(err, jc.Satisfies, errors.IsNotValid)
-	c.Check(err, gc.ErrorMatches, `.*nil Identity.*`)
+	c.Check(err, gc.ErrorMatches, `nil Identity not valid`)
 }
 
 func (s *WorkerSuite) TestConfigValidateMissingStart(c *gc.C) {
@@ -108,7 +109,7 @@ func (s *WorkerSuite) TestConfigValidateMissingStart(c *gc.C) {
 	err := cfg.Validate()
 
 	c.Check(err, jc.Satisfies, errors.IsNotValid)
-	c.Check(err, gc.ErrorMatches, `.*nil Start.*`)
+	c.Check(err, gc.ErrorMatches, `nil Start not valid`)
 }
 
 func (s *WorkerSuite) TestConfigValidateMissingClock(c *gc.C) {
@@ -121,7 +122,7 @@ func (s *WorkerSuite) TestConfigValidateMissingClock(c *gc.C) {
 	err := cfg.Validate()
 
 	c.Check(err, jc.Satisfies, errors.IsNotValid)
-	c.Check(err, gc.ErrorMatches, `.*nil Clock.*`)
+	c.Check(err, gc.ErrorMatches, `nil Clock not valid`)
 }
 
 func (s *WorkerSuite) TestConfigValidateMissingRetryDelay(c *gc.C) {
@@ -134,7 +135,7 @@ func (s *WorkerSuite) TestConfigValidateMissingRetryDelay(c *gc.C) {
 	err := cfg.Validate()
 
 	c.Check(err, jc.Satisfies, errors.IsNotValid)
-	c.Check(err, gc.ErrorMatches, `.*non-positive RetryDelay.*`)
+	c.Check(err, gc.ErrorMatches, `non-positive RetryDelay not valid`)
 }
 
 func (s *WorkerSuite) TestNewRunOnceBeforeLoop(c *gc.C) {
@@ -143,7 +144,7 @@ func (s *WorkerSuite) TestNewRunOnceBeforeLoop(c *gc.C) {
 
 	w, err := presence.New(s.cfg)
 	c.Assert(err, jc.ErrorIsNil)
-	defer w.Stop()
+	defer workertest.CleanKill(c, w)
 	<-waitChan
 
 	s.stub.CheckCallNames(c,
@@ -161,7 +162,7 @@ func (s *WorkerSuite) TestNewFailStart(c *gc.C) {
 
 	w, err := presence.New(s.cfg)
 	c.Assert(err, jc.ErrorIsNil)
-	defer w.Stop()
+	defer workertest.CleanKill(c, w)
 	<-waitChan
 
 	s.stub.CheckCallNames(c,
@@ -178,7 +179,7 @@ func (s *WorkerSuite) TestNewFailWait(c *gc.C) {
 
 	w, err := presence.New(s.cfg)
 	c.Assert(err, jc.ErrorIsNil)
-	defer w.Stop()
+	defer workertest.CleanKill(c, w)
 	<-waitChan
 
 	s.stub.CheckCallNames(c,
@@ -206,7 +207,7 @@ func (s *WorkerSuite) TestNewLoop(c *gc.C) {
 
 	w, err := presence.New(s.cfg)
 	c.Assert(err, jc.ErrorIsNil)
-	defer w.Stop()
+	defer workertest.CleanKill(c, w)
 	defer close(block)
 	<-waitChan
 
@@ -247,7 +248,7 @@ func (s *WorkerSuite) TestNewRetry(c *gc.C) {
 
 	w, err := presence.New(s.cfg)
 	c.Assert(err, jc.ErrorIsNil)
-	defer w.Stop()
+	defer workertest.CleanKill(c, w)
 	defer close(block)
 	<-waitChan
 

--- a/apiserver/root.go
+++ b/apiserver/root.go
@@ -42,11 +42,10 @@ type objectKey struct {
 // after it has logged in. It contains an rpc.MethodFinder which it
 // uses to dispatch Api calls appropriately.
 type apiHandler struct {
-	state            *state.State
-	rpcConn          *rpc.Conn
-	resources        *common.Resources
-	entity           state.Entity
-	mongoUnavailable *uint32
+	state     *state.State
+	rpcConn   *rpc.Conn
+	resources *common.Resources
+	entity    state.Entity
 	// An empty modelUUID means that the user has logged in through the
 	// root of the API server rather than the /model/:model-uuid/api
 	// path, logins processed with v2 or later will only offer the
@@ -59,11 +58,10 @@ var _ = (*apiHandler)(nil)
 // newApiHandler returns a new apiHandler.
 func newApiHandler(srv *Server, st *state.State, rpcConn *rpc.Conn, reqNotifier *requestNotifier, modelUUID string) (*apiHandler, error) {
 	r := &apiHandler{
-		state:            st,
-		resources:        common.NewResources(),
-		rpcConn:          rpcConn,
-		modelUUID:        modelUUID,
-		mongoUnavailable: &srv.mongoUnavailable,
+		state:     st,
+		resources: common.NewResources(),
+		rpcConn:   rpcConn,
+		modelUUID: modelUUID,
 	}
 	if err := r.resources.RegisterNamed("machineID", common.StringResource(srv.tag.Id())); err != nil {
 		return nil, errors.Trace(err)

--- a/cmd/juju/status/status_test.go
+++ b/cmd/juju/status/status_test.go
@@ -101,7 +101,7 @@ type context struct {
 
 func (ctx *context) reset(c *gc.C) {
 	for _, up := range ctx.pingers {
-		err := up.Kill()
+		err := up.KillForTesting()
 		c.Check(err, jc.ErrorIsNil)
 	}
 }

--- a/cmd/juju/status/status_test.go
+++ b/cmd/juju/status/status_test.go
@@ -114,7 +114,7 @@ func (ctx *context) run(c *gc.C, steps []stepper) {
 	}
 }
 
-func (ctx *context) setAgentPresence(c *gc.C, p presence.Presencer) *presence.Pinger {
+func (ctx *context) setAgentPresence(c *gc.C, p presence.Agent) *presence.Pinger {
 	pinger, err := p.SetAgentPresence()
 	c.Assert(err, jc.ErrorIsNil)
 	ctx.st.StartSync()

--- a/state/machine.go
+++ b/state/machine.go
@@ -33,9 +33,6 @@ import (
 type Machine struct {
 	st  *State
 	doc machineDoc
-	presence.Presencer
-	status.StatusHistoryGetter
-	status.InstanceStatusHistoryGetter
 }
 
 // MachineJob values define responsibilities that machines may be

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -754,7 +754,7 @@ func (s *MachineSuite) TestMachineWaitAgentPresence(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(alive, jc.IsTrue)
 
-	err = pinger.Kill()
+	err = pinger.KillForTesting()
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.State.StartSync()

--- a/state/presence/presence.go
+++ b/state/presence/presence.go
@@ -418,7 +418,7 @@ func (w *Watcher) sync() error {
 				}
 				seq := k + i
 				dead[seq] = true
-				logger.Infof("found seq=%d dead", seq)
+				logger.Tracef("found seq=%d dead", seq)
 			}
 		}
 	}
@@ -472,7 +472,7 @@ func (w *Watcher) sync() error {
 				if cur > 0 || dead[seq] {
 					continue
 				}
-				logger.Infof("found seq=%d alive with key %q", seq, being.Key)
+				logger.Tracef("found seq=%d alive with key %q", seq, being.Key)
 				for _, ch := range w.watches[being.Key] {
 					w.pending = append(w.pending, event{ch, being.Key, true})
 				}
@@ -682,7 +682,7 @@ func (p *Pinger) prepare() error {
 // ping records updates the current time slot with the
 // sequence in use by the pinger.
 func (p *Pinger) ping() (err error) {
-	logger.Infof("pinging %q with seq=%d", p.beingKey, p.beingSeq)
+	logger.Tracef("pinging %q with seq=%d", p.beingKey, p.beingSeq)
 	defer func() {
 		// If the session is killed from underneath us, it panics when we
 		// try to copy it, so deal with that here.

--- a/state/presence/presence.go
+++ b/state/presence/presence.go
@@ -23,7 +23,13 @@ import (
 
 var logger = loggo.GetLogger("juju.state.presence")
 
-type Presencer interface {
+// Agent shouldn't really live here -- it's not used in this package,
+// and is implemented by a couple of state types for the convenience of
+// the apiserver -- but one of the methods returns a concrete *Pinger,
+// and that ties it down here quite effectively (until we want to take
+// on the task of cleaning it up and promoting it to core, which might
+// well never happen).
+type Agent interface {
 	AgentPresence() (bool, error)
 	SetAgentPresence() (*Pinger, error)
 	WaitAgentPresence(time.Duration) error
@@ -394,6 +400,7 @@ func (w *Watcher) sync() error {
 	}
 
 	// Learn about all enforced deaths.
+	// TODO(ericsnow) Remove this once KillForTesting() goes away.
 	dead := make(map[int64]bool)
 	for i := range ping {
 		for key, value := range ping[i].Dead {
@@ -411,7 +418,7 @@ func (w *Watcher) sync() error {
 				}
 				seq := k + i
 				dead[seq] = true
-				logger.Tracef("found seq=%d dead", seq)
+				logger.Infof("found seq=%d dead", seq)
 			}
 		}
 	}
@@ -465,7 +472,7 @@ func (w *Watcher) sync() error {
 				if cur > 0 || dead[seq] {
 					continue
 				}
-				logger.Tracef("found seq=%d alive with key %q", seq, being.Key)
+				logger.Infof("found seq=%d alive with key %q", seq, being.Key)
 				for _, ch := range w.watches[being.Key] {
 					w.pending = append(w.pending, event{ch, being.Key, true})
 				}
@@ -547,6 +554,12 @@ func (p *Pinger) Start() error {
 	return nil
 }
 
+// Wait returns when the Pinger has stopped, and returns the first error
+// it encountered.
+func (p *Pinger) Wait() error {
+	return p.tomb.Wait()
+}
+
 // Stop stops p's periodical ping.
 // Watchers will not notice p has stopped pinging until the
 // previous ping times out.
@@ -564,8 +577,9 @@ func (p *Pinger) Stop() error {
 
 }
 
-// Kill stops p's periodical ping and immediately reports that it is dead.
-func (p *Pinger) Kill() error {
+// KillForTesting stops p's periodical ping and immediately reports that it is dead.
+// TODO(ericsnow) We should be able to drop this and the two kill* methods.
+func (p *Pinger) KillForTesting() error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	if p.started {
@@ -668,14 +682,11 @@ func (p *Pinger) prepare() error {
 // ping records updates the current time slot with the
 // sequence in use by the pinger.
 func (p *Pinger) ping() (err error) {
-	logger.Tracef("pinging %q with seq=%d", p.beingKey, p.beingSeq)
+	logger.Infof("pinging %q with seq=%d", p.beingKey, p.beingSeq)
 	defer func() {
 		// If the session is killed from underneath us, it panics when we
 		// try to copy it, so deal with that here.
 		if v := recover(); v != nil {
-			if v == "Session already closed" {
-				return
-			}
 			err = fmt.Errorf("%v", v)
 		}
 	}()

--- a/state/presence/presence_test.go
+++ b/state/presence/presence_test.go
@@ -158,7 +158,7 @@ func (s *PresenceSuite) TestWorkflow(c *gc.C) {
 	// Changes while the channel is out are not observed.
 	w.Unwatch("a", cha)
 	assertNoChange(c, cha)
-	pa.Kill()
+	pa.KillForTesting()
 	w.Sync()
 	pa = presence.NewPinger(s.presence, s.modelTag, "a")
 	pa.Start()
@@ -187,8 +187,8 @@ func (s *PresenceSuite) TestWorkflow(c *gc.C) {
 	assertNoChange(c, chb)
 
 	// pb is running, pa isn't.
-	c.Assert(pa.Kill(), gc.IsNil)
-	c.Assert(pb.Kill(), gc.IsNil)
+	c.Assert(pa.KillForTesting(), gc.IsNil)
+	c.Assert(pb.KillForTesting(), gc.IsNil)
 
 	w.StartSync()
 	assertChange(c, cha, presence.Change{"a", false})
@@ -215,7 +215,7 @@ func (s *PresenceSuite) TestScale(c *gc.C) {
 
 	c.Logf("Killing odd ones...")
 	for i := 1; i < N; i += 2 {
-		c.Assert(ps[i].Kill(), gc.IsNil)
+		c.Assert(ps[i].KillForTesting(), gc.IsNil)
 	}
 
 	c.Logf("Checking who's still alive...")
@@ -259,7 +259,7 @@ func (s *PresenceSuite) TestExpiry(c *gc.C) {
 	assertChange(c, ch, presence.Change{"a", false})
 
 	// Already dead so killing isn't noticed.
-	p.Kill()
+	p.KillForTesting()
 	w.StartSync()
 	assertNoChange(c, ch)
 }
@@ -382,7 +382,7 @@ func (s *PresenceSuite) TestPingerPeriodAndResilience(c *gc.C) {
 	// Start and kill p2, which will temporarily
 	// invalidate p1 and set the key as dead.
 	c.Assert(p2.Start(), gc.IsNil)
-	c.Assert(p2.Kill(), gc.IsNil)
+	c.Assert(p2.KillForTesting(), gc.IsNil)
 
 	w.Sync()
 	assertAlive(c, w, "a", false)
@@ -512,7 +512,7 @@ func (s *PresenceSuite) TestTwoEnvironments(c *gc.C) {
 	assertNoChange(c, ch1)
 	assertChange(c, ch2, presence.Change{"a", true})
 
-	err := p1.Kill()
+	err := p1.KillForTesting()
 	c.Assert(err, jc.ErrorIsNil)
 	presence.FakeTimeSlot(1)
 	w1.StartSync()
@@ -520,7 +520,7 @@ func (s *PresenceSuite) TestTwoEnvironments(c *gc.C) {
 	assertChange(c, ch1, presence.Change{"a", false})
 	assertNoChange(c, ch2)
 
-	err = p2.Kill()
+	err = p2.KillForTesting()
 	c.Assert(err, jc.ErrorIsNil)
 	presence.FakeTimeSlot(2)
 	w1.StartSync()

--- a/state/unit.go
+++ b/state/unit.go
@@ -102,8 +102,6 @@ type unitDoc struct {
 type Unit struct {
 	st  *State
 	doc unitDoc
-	presence.Presencer
-	status.StatusHistoryGetter
 }
 
 func newUnit(st *State, udoc *unitDoc) *Unit {

--- a/state/unit_test.go
+++ b/state/unit_test.go
@@ -890,7 +890,7 @@ func (s *UnitSuite) TestUnitWaitAgentPresence(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(alive, jc.IsTrue)
 
-	err = pinger.Kill()
+	err = pinger.KillForTesting()
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.State.StartSync()

--- a/testing/clock.go
+++ b/testing/clock.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/juju/testing"
 	"github.com/juju/utils/clock"
 )
 
@@ -193,4 +194,36 @@ func (a byTime) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
 // removeFromSlice removes item at the specified index from the slice.
 func removeFromSlice(sl []alarm, index int) []alarm {
 	return append(sl[:index], sl[index+1:]...)
+}
+
+type StubClock struct {
+	*testing.Stub
+
+	ReturnNow       time.Time
+	ReturnAfter     <-chan time.Time
+	ReturnAfterFunc clock.Timer
+}
+
+func NewStubClock(stub *testing.Stub) *StubClock {
+	return &StubClock{
+		Stub: stub,
+	}
+}
+
+func (s *StubClock) Now() time.Time {
+	s.AddCall("Now")
+	s.NextErr() // pop one off
+	return s.ReturnNow
+}
+
+func (s *StubClock) After(d time.Duration) <-chan time.Time {
+	s.AddCall("After", d)
+	s.NextErr() // pop one off
+	return s.ReturnAfter
+}
+
+func (s *StubClock) AfterFunc(d time.Duration, f func()) clock.Timer {
+	s.AddCall("AfterFunc", d, f)
+	s.NextErr() // pop one off
+	return s.ReturnAfterFunc
 }


### PR DESCRIPTION
Taken from: #5267

Changed a few tests to call KillForTesting, rather than Kill so the unit tests would pass:
api/highavailability/client_test.go
apiserver/highavailability/highavailability_test.go
cmd/juju/status/status_test.go

(Review request: http://reviews.vapour.ws/r/4695/)