### PR TITLE
Update gomaasapi to fix nil reference panic

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -19,7 +19,7 @@ github.com/juju/go4	git	40d72ab9641a2a8c36a9c46a51e28367115c8e59	2016-02-22T16:3
 github.com/juju/gojsonpointer	git	afe8b77aa08f272b49e01b82de78510c11f61500	2015-02-04T19:46:29Z
 github.com/juju/gojsonreference	git	f0d24ac5ee330baa21721cdff56d45e4ee42628e	2015-02-04T19:46:33Z
 github.com/juju/gojsonschema	git	e1ad140384f254c82f89450d9a7c8dd38a632838	2015-03-12T17:00:16Z
-github.com/juju/gomaasapi	git	6c205e4903e3de24f91d685175255de9b1bcb06b	2016-04-18T12:19:23Z
+github.com/juju/gomaasapi	git	9ec917cdad9e610c7573973393b08ca98d6e0886	2016-04-25T09:27:20Z
 github.com/juju/govmomi	git	4354a88d4b34abe467215f77c2fc1cb9f78b66f7	2015-04-24T01:54:48Z
 github.com/juju/httpprof	git	14bf14c307672fd2456bdbf35d19cf0ccd3cf565	2014-12-17T16:00:36Z
 github.com/juju/httprequest	git	89d547093c45e293599088cc63e805c6f1205dc0	2016-03-02T10:09:58Z
@@ -32,7 +32,7 @@ github.com/juju/ratelimit	git	aa5bb718d4d435629821789cb90970319f57bfe5	2015-03-3
 github.com/juju/replicaset	git	fb7294cf57a1e2f08a57691f1246d129a87ab7e8	2015-05-08T02:21:43Z
 github.com/juju/retry	git	62c62032529169c7ec02fa48f93349604c345e1f	2015-10-29T02:48:21Z
 github.com/juju/romulus	git	df735617fa6a358e42bb71ff74b3c3ba4faf9f5f	2016-04-19T16:05:42Z
-github.com/juju/schema	git	1e25943f8c6fd6815282d6f1ac87091d21e14e19	2016-03-01T11:16:46Z
+github.com/juju/schema	git	075de04f9b7d7580d60a1e12a0b3f50bb18e6998	2016-04-20T04:42:03Z
 github.com/juju/testing	git	162fafccebf20a4207ab93d63b986c230e3f4d2e	2016-04-04T09:43:17Z
 github.com/juju/txn	git	99ec629d0066a4d73c54d8e021a7fc1dc07df614	2015-06-09T16:58:27Z
 github.com/juju/usso	git	68a59c96c178fbbad65926e7f93db50a2cd14f33	2016-04-01T10:44:24Z

--- a/provider/maas/maas2_test.go
+++ b/provider/maas/maas2_test.go
@@ -436,7 +436,7 @@ type fakeBlockDevice struct {
 	gomaasapi.BlockDevice
 	name string
 	path string
-	size int
+	size uint64
 }
 
 func (bd fakeBlockDevice) Name() string {
@@ -447,6 +447,6 @@ func (bd fakeBlockDevice) Path() string {
 	return bd.path
 }
 
-func (bd fakeBlockDevice) Size() int {
+func (bd fakeBlockDevice) Size() uint64 {
 	return bd.size
 }


### PR DESCRIPTION
This fixes the panic in https://bugs.launchpad.net/juju-core/+bug/1573659 - interface nil values were being returned as typed nils and so the nil check for link.Subnet() in maas2NetworkInterfaces wasn't working as intended.

Confirmed that with this change I can now bootstrap to a machine with an unconfigured NIC such that link.Subnet() is nil.

(Review request: http://reviews.vapour.ws/r/4696/)