### PR TITLE
Cleaned up help text and some code.

### DIFF
--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -46,7 +46,7 @@ func init() {
 
 var jujuDoc = `
 juju provides easy, intelligent service orchestration on top of cloud
-infrastructure providers such as Amazon EC2, HP Cloud, MaaS, OpenStack, Windows
+infrastructure providers such as Amazon EC2, MaaS, OpenStack, Windows
 Azure, or your local machine.
 
 https://juju.ubuntu.com/
@@ -91,8 +91,6 @@ func NewJujuCommand(ctx *cmd.Context) cmd.Command {
 		helptopics.OpenstackProvider, "openstack")
 	jcmd.AddHelpTopic("ec2-provider", "How to configure an Amazon EC2 provider",
 		helptopics.EC2Provider, "ec2", "aws", "amazon")
-	jcmd.AddHelpTopic("hpcloud-provider", "How to configure an HP Cloud provider",
-		helptopics.HPCloud, "hpcloud", "hp-cloud")
 	jcmd.AddHelpTopic("azure-provider", "How to configure a Windows Azure provider",
 		helptopics.AzureProvider, "azure")
 	jcmd.AddHelpTopic("maas-provider", "How to configure a MAAS provider",

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -315,7 +315,6 @@ var topicNames = []string{
 	"ec2-provider",
 	"global-options",
 	"glossary",
-	"hpcloud-provider",
 	"juju",
 	"juju-systems",
 	"local-provider",

--- a/cmd/juju/helptopics/basics.go
+++ b/cmd/juju/helptopics/basics.go
@@ -8,7 +8,7 @@ Juju -- devops distilled
 https://juju.ubuntu.com/
 
 Juju provides easy, intelligent service orchestration on top of environments
-such as Amazon EC2, HP Cloud, OpenStack, MaaS, or your own local machine.
+such as Amazon EC2, OpenStack, MaaS, or your own local machine.
 
 Basic commands:
   juju init             generate boilerplate configuration for juju environments
@@ -27,7 +27,7 @@ Basic commands:
 Provider information:
   juju help azure-provider       use on Windows Azure
   juju help ec2-provider         use on Amazon EC2
-  juju help hpcloud-provider     use on HP Cloud
   juju help local-provider       use on this computer
+  juju help maas-provider        use on MAAS
   juju help openstack-provider   use on OpenStack
 `

--- a/cmd/juju/helptopics/providers.go
+++ b/cmd/juju/helptopics/providers.go
@@ -7,7 +7,6 @@ const (
 	LocalProvider     = helpProviderStart + helpLocalProvider + helpProviderEnd
 	OpenstackProvider = helpProviderStart + helpOpenstackProvider + helpProviderEnd
 	EC2Provider       = helpProviderStart + helpEC2Provider + helpProviderEnd
-	HPCloud           = helpProviderStart + helpHPCloud + helpProviderEnd
 	AzureProvider     = helpProviderStart + helpAzureProvider + helpProviderEnd
 	MAASProvider      = helpProviderStart + helpMAASProvider + helpProviderEnd
 )
@@ -189,24 +188,6 @@ More information:
   https://juju.ubuntu.com/docs/getting-started.html
   https://juju.ubuntu.com/docs/provider-configuration-ec2.html
   http://askubuntu.com/questions/225513/how-do-i-configure-juju-to-use-amazon-web-services-aws
-`
-
-const helpHPCloud = `
-HP Cloud is an Openstack cloud provider.  To deploy to it, use an openstack
-environment type for Juju, which would look something like this:
-
-  sample_hpcloud:
-    type: openstack
-    tenant-name: "juju-project1"
-    auth-url: https://region-a.geo-1.identity.hpcloudsvc.com:35357/v2.0/
-    auth-mode: userpass
-    username: "xxxyour-hpcloud-usernamexxx"
-    password: "xxxpasswordxxx"
-    region: az-1.region-a.geo-1
-
-See the online help for more information:
-
-  https://juju.ubuntu.com/docs/config-hpcloud.html
 `
 
 const helpAzureProvider = `

--- a/doc/juju-core-release-process.txt
+++ b/doc/juju-core-release-process.txt
@@ -70,7 +70,7 @@ Step 7. TEST!
 
 apt-get update && apt-get install juju-core should install the latest release on your system. 
 
-Test this release by bootstrapping an environment in ec2 (and hp cloud if you have access), and do a basic wordpress + mysql deployment. If you can relate wordpress and mysql, expose wordpress and get to the public address on the wordpress setup screen, this release is a success.
+Test this release by bootstrapping an environment in ec2, and do a basic wordpress + mysql deployment. If you can relate wordpress and mysql, expose wordpress and get to the public address on the wordpress setup screen, this release is a success.
 
 If this step fails then this release is a failure and the release number is unused. Do not reuse release numbers. It is ok to have gaps in the sequence, we've done it before, water is still wet.
 

--- a/doc/simplestreams-metadata.txt
+++ b/doc/simplestreams-metadata.txt
@@ -9,7 +9,7 @@ The necessary information is stored in a json metadata format called simplestrea
 The simplestreams format is used to describe related items in a structural fashion.
 See the Launchpad project lp:simplestreams for more details.
 
-For supported public clouds like Amazon, HP Cloud etc, no action is required by the
+For supported public clouds like Amazon, etc., no action is required by the
 end user so the following information is more for those interested in what happens
 under the covers. Those setting up a private cloud, or who want to change how things
 work (eg use a different Ubuntu image), need to pay closer attention.

--- a/environs/boilerplate_config.go
+++ b/environs/boilerplate_config.go
@@ -14,10 +14,10 @@ import (
 )
 
 var configHeader = `
+
 # This is the Juju config file, which you can use to specify multiple
-# environments in which to deploy. By default Juju ships with AWS
-# (default), HP Cloud, OpenStack, Azure, MaaS, Local and Manual
-# providers. See https://juju.ubuntu.com/docs for more information
+# environments in which to deploy. See https://juju.ubuntu.com/docs
+# for more information
 
 # An environment configuration must always specify at least the
 # following information:

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -52,11 +52,11 @@ var providerInstance environProvider
 
 var makeServiceURL = client.AuthenticatingClient.MakeServiceURL
 
-// Use shortAttempt to poll for short-term events.
-// TODO: This was kept to a long timeout because Nova needs more time than EC2.
-// For example, HP Cloud takes around 9.1 seconds (10 samples) to return a
-// BUILD(spawning) status. But storage delays are handled separately now, and
+// TODO: shortAttempt was kept to a long timeout because Nova needs
+// more time than EC2.  Storage delays are handled separately now, and
 // perhaps other polling attempts can time out faster.
+
+// shortAttempt is used when polling for short-term events in tests.
 var shortAttempt = utils.AttemptStrategy{
 	Total: 15 * time.Second,
 	Delay: 200 * time.Millisecond,
@@ -199,7 +199,7 @@ hpcloud:
     #
     # auth-url: https://region-a.geo-1.identity.hpcloudsvc.com:35357/v2.0/
 
-    # region holds the HP Cloud region (e.g. region-a.geo-1). It
+    # region holds the cloud region (e.g. region-a.geo-1). It
     # defaults to the environment variable OS_REGION_NAME.
     #
     # region: <your region>

--- a/provider/openstack/provider_test.go
+++ b/provider/openstack/provider_test.go
@@ -57,7 +57,7 @@ var addressTests = []struct {
 	networks: []string{"private"},
 	expected: "fc00::1",
 }, {
-	summary:  "private IPv4 plus (HP cloud)",
+	summary:  "private IPv4 plus (what HP cloud used to do)",
 	private:  []nova.IPAddress{{4, "10.0.0.1"}, {4, "8.8.4.4"}},
 	networks: []string{"private"},
 	expected: "8.8.4.4",

--- a/scripts/release-public-tools/release-public-tools.sh
+++ b/scripts/release-public-tools/release-public-tools.sh
@@ -4,10 +4,10 @@
 # Retrieve the published juju-core debs for a specific release.
 # Extract the jujud from the packages.
 # Generate the streams data.
-# Publish to Canonistack, HP, AWS, and Azure.
+# Publish to Canonistack, AWS, and Azure.
 #
 # This script requires that the user has credentials to upload the tools
-# to Canonistack, HP Cloud, AWS, and Azure
+# to Canonistack, AWS, and Azure
 
 set -e
 
@@ -24,13 +24,12 @@ check_deps() {
     which swift || has_deps=0
     which s3cmd || has_deps=0
     test -f ~/.juju/canonistacktoolsrc || has_deps=0
-    test -f ~/.juju/hptoolsrc || has_deps=0
     test -f ~/.juju/awstoolsrc || has_deps=0
     test -f ~/.juju/azuretoolsrc || has_deps=0
     if [[ $has_deps == 0 ]]; then
         echo "Install lftp, python-swiftclient, and s3cmd"
         echo "Your ~/.juju dir must contain rc files to publish:"
-        echo "  canonistacktoolsrc, hptoolsrc, awstoolsrc, azuretoolsrc"
+        echo "  canonistacktoolsrc, awstoolsrc, azuretoolsrc"
         exit 2
     fi
 }
@@ -172,18 +171,6 @@ publish_to_canonistack() {
 }
 
 
-publish_to_hp() {
-    echo "Phase 6.2: Publish to HP Cloud."
-    cd $DESTINATION
-    source ~/.juju/hptoolsrc
-    ${GOPATH}/bin/juju --show-log \
-        sync-tools -e public-tools-hp --dev --source=${DEST_DIST}
-    # Support old tools location so that deployments can upgrade to new tools.
-    cd ${DEST_DIST}
-    swift upload juju-dist tools/*.tgz
-}
-
-
 publish_to_aws() {
     echo "Phase 6.3: Publish to AWS."
     cd $DESTINATION
@@ -256,6 +243,5 @@ generate_streams
 
 echo "Phase 6: Publishing tools."
 publish_to_canonistack
-publish_to_hp
 publish_to_aws
 publish_to_azure

--- a/scripts/win-installer/README.txt
+++ b/scripts/win-installer/README.txt
@@ -4,7 +4,7 @@ This tutorial will show you how to get started with Juju, including installing, 
 
 * An Ubuntu, Windows or OSX machine to install the client on.
 
-* An environment which can provide a new server with an Ubuntu cloud operating system image on-demand. This includes services such as Microsoft Azure, Amazon EC2, HP Cloud, or an OpenStack installation.
+* An environment which can provide a new server with an Ubuntu cloud operating system image on-demand. This includes services such as Microsoft Azure, Amazon EC2, or an OpenStack installation.
 
 * An SSH key-pair. Juju expects to find ssh keys called id_rsa and id_rsa.pub in a .ssh folder in your home directory.
 


### PR DESCRIPTION
- HP Cloud was sunset on 2016-01-01. I've removed any reference to it from the codebase.
- juju help maas-provider was missing from the list of providers when running "juju help"

(Review request: http://reviews.vapour.ws/r/4701/)