### PR TITLE
use the right version number for the payloads API

### DIFF
--- a/component/all/payload.go
+++ b/component/all/payload.go
@@ -82,7 +82,7 @@ func (payloads) newListAPIClient(cmd *status.ListCommand) (status.ListAPI, error
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	caller := base.NewFacadeCallerForVersion(apiCaller, payload.ComponentName, 0)
+	caller := base.NewFacadeCallerForVersion(apiCaller, payload.ComponentName, 1)
 
 	listAPI := client.NewPublicClient(&facadeCaller{
 		FacadeCaller: caller,


### PR DESCRIPTION
this fixes https://bugs.launchpad.net/juju-core/+bug/1567518

(Review request: http://reviews.vapour.ws/r/4704/)