### PR TITLE
Try external IPs for controller traffic

### DIFF
--- a/apiserver/deployer/deployer.go
+++ b/apiserver/deployer/deployer.go
@@ -78,13 +78,21 @@ func NewDeployerAPI(
 // ConnectionInfo returns all the address information that the
 // deployer task needs in one call.
 func (d *DeployerAPI) ConnectionInfo() (result params.DeployerConnectionValues, err error) {
-	info, err := d.st.DeployerConnectionInfo()
-	if info != nil {
-		result = params.DeployerConnectionValues{
-			StateAddresses: info.StateAddresses,
-			APIAddresses:   info.APIAddresses,
-		}
+	stateAddrs, err := d.StateAddresses()
+	if err != nil {
+		return result, err
 	}
+
+	apiAddrs, err := d.APIAddresses()
+	if err != nil {
+		return result, err
+	}
+
+	result = params.DeployerConnectionValues{
+		StateAddresses: stateAddrs.Result,
+		APIAddresses:   apiAddrs.Result,
+	}
+
 	return result, err
 }
 

--- a/apiserver/uniter/uniter.go
+++ b/apiserver/uniter/uniter.go
@@ -902,11 +902,16 @@ func (u *UniterAPIV3) CharmArchiveURLs(args params.CharmURLs) (params.StringsRes
 				urlPath, curl)
 			externalHostPort := network.SelectPublicHostPort(server)
 			if externalHostPort != "" {
-				publicArchiveURLs = append(publicArchiveURLs, getArchiveURL(externalHostPort,
-					urlPath, curl))
+				url := getArchiveURL(externalHostPort, urlPath, curl)
+
+				// If the controller only has public IPs, don't add it twice
+				if url != archiveURLs[j] {
+					publicArchiveURLs = append(publicArchiveURLs, url)
+				}
 			}
 		}
-		// Append the public URLs at the end so that internal addresses are tried first
+		// Append the public URLs at the end so that internal addresses for all
+		// controllers are tried first.
 		if len(publicArchiveURLs) > 0 {
 			archiveURLs = append(archiveURLs, publicArchiveURLs...)
 		}

--- a/apiserver/uniter/uniter.go
+++ b/apiserver/uniter/uniter.go
@@ -881,6 +881,14 @@ func (u *UniterAPIV3) CharmArchiveURLs(args params.CharmURLs) (params.StringsRes
 		return params.StringsResults{}, err
 	}
 
+	// Make one list of all IPs for all controllers, then prioritize
+	// internal addresses.
+	mergedHostPorts := []network.HostPort{}
+	for _, server := range apiHostPorts {
+		mergedHostPorts = append(mergedHostPorts, server...)
+	}
+	prioritizedHostPorts := network.PrioritizeInternalHostPorts(mergedHostPorts, false)
+
 	modelUUID := u.st.ModelUUID()
 	result := params.StringsResults{
 		Results: make([]params.StringsResult, len(args.URLs)),
@@ -895,25 +903,9 @@ func (u *UniterAPIV3) CharmArchiveURLs(args params.CharmURLs) (params.StringsRes
 			urlPath = path.Join(urlPath, "model", modelUUID)
 		}
 		urlPath = path.Join(urlPath, "charms")
-		archiveURLs := make([]string, len(apiHostPorts))
-		publicArchiveURLs := []string{}
-		for j, server := range apiHostPorts {
-			archiveURLs[j] = getArchiveURL(network.SelectInternalHostPort(server, false),
-				urlPath, curl)
-			externalHostPort := network.SelectPublicHostPort(server)
-			if externalHostPort != "" {
-				url := getArchiveURL(externalHostPort, urlPath, curl)
-
-				// If the controller only has public IPs, don't add it twice
-				if url != archiveURLs[j] {
-					publicArchiveURLs = append(publicArchiveURLs, url)
-				}
-			}
-		}
-		// Append the public URLs at the end so that internal addresses for all
-		// controllers are tried first.
-		if len(publicArchiveURLs) > 0 {
-			archiveURLs = append(archiveURLs, publicArchiveURLs...)
+		archiveURLs := make([]string, len(prioritizedHostPorts))
+		for j, hp := range prioritizedHostPorts {
+			archiveURLs[j] = getArchiveURL(hp, urlPath, curl)
 		}
 		result.Results[i].Result = archiveURLs
 	}

--- a/apiserver/uniter/uniter_test.go
+++ b/apiserver/uniter/uniter_test.go
@@ -1066,10 +1066,12 @@ func (s *uniterSuite) TestCharmArchiveURLs(c *gc.C) {
 	wordpressURLs := []string{
 		fmt.Sprintf("https://0.1.2.3:1234/model/%s/charms?file=%%2A&url=cs%%3Aquantal%%2Fwordpress-3", coretesting.ModelTag.Id()),
 		fmt.Sprintf("https://1.2.3.5:1234/model/%s/charms?file=%%2A&url=cs%%3Aquantal%%2Fwordpress-3", coretesting.ModelTag.Id()),
+		fmt.Sprintf("https://1.2.3.4:1234/model/%s/charms?file=%%2A&url=cs%%3Aquantal%%2Fwordpress-3", coretesting.ModelTag.Id()),
 	}
 	dummyURLs := []string{
 		fmt.Sprintf("https://0.1.2.3:1234/model/%s/charms?file=%%2A&url=local%%3Aquantal%%2Fdummy-1", coretesting.ModelTag.Id()),
 		fmt.Sprintf("https://1.2.3.5:1234/model/%s/charms?file=%%2A&url=local%%3Aquantal%%2Fdummy-1", coretesting.ModelTag.Id()),
+		fmt.Sprintf("https://1.2.3.4:1234/model/%s/charms?file=%%2A&url=local%%3Aquantal%%2Fdummy-1", coretesting.ModelTag.Id()),
 	}
 
 	c.Assert(result, jc.DeepEquals, params.StringsResults{

--- a/apiserver/uniter/uniter_test.go
+++ b/apiserver/uniter/uniter_test.go
@@ -1065,13 +1065,13 @@ func (s *uniterSuite) TestCharmArchiveURLs(c *gc.C) {
 
 	wordpressURLs := []string{
 		fmt.Sprintf("https://0.1.2.3:1234/model/%s/charms?file=%%2A&url=cs%%3Aquantal%%2Fwordpress-3", coretesting.ModelTag.Id()),
-		fmt.Sprintf("https://1.2.3.5:1234/model/%s/charms?file=%%2A&url=cs%%3Aquantal%%2Fwordpress-3", coretesting.ModelTag.Id()),
 		fmt.Sprintf("https://1.2.3.4:1234/model/%s/charms?file=%%2A&url=cs%%3Aquantal%%2Fwordpress-3", coretesting.ModelTag.Id()),
+		fmt.Sprintf("https://1.2.3.5:1234/model/%s/charms?file=%%2A&url=cs%%3Aquantal%%2Fwordpress-3", coretesting.ModelTag.Id()),
 	}
 	dummyURLs := []string{
 		fmt.Sprintf("https://0.1.2.3:1234/model/%s/charms?file=%%2A&url=local%%3Aquantal%%2Fdummy-1", coretesting.ModelTag.Id()),
-		fmt.Sprintf("https://1.2.3.5:1234/model/%s/charms?file=%%2A&url=local%%3Aquantal%%2Fdummy-1", coretesting.ModelTag.Id()),
 		fmt.Sprintf("https://1.2.3.4:1234/model/%s/charms?file=%%2A&url=local%%3Aquantal%%2Fdummy-1", coretesting.ModelTag.Id()),
+		fmt.Sprintf("https://1.2.3.5:1234/model/%s/charms?file=%%2A&url=local%%3Aquantal%%2Fdummy-1", coretesting.ModelTag.Id()),
 	}
 
 	c.Assert(result, jc.DeepEquals, params.StringsResults{

--- a/state/address.go
+++ b/state/address.go
@@ -150,28 +150,6 @@ func (st *State) APIHostPorts() ([][]network.HostPort, error) {
 	return networkHostsPorts(doc.APIHostPorts), nil
 }
 
-type DeployerConnectionValues struct {
-	StateAddresses []string
-	APIAddresses   []string
-}
-
-// DeployerConnectionInfo returns the address information necessary for the deployer.
-// The function does the expensive operations (getting stuff from mongo) just once.
-func (st *State) DeployerConnectionInfo() (*DeployerConnectionValues, error) {
-	addrs, err := st.controllerAddresses()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	config, err := st.ModelConfig()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	return &DeployerConnectionValues{
-		StateAddresses: appendPort(addrs, config.StatePort()),
-		APIAddresses:   appendPort(addrs, config.APIPort()),
-	}, nil
-}
-
 // address represents the location of a machine, including metadata
 // about what kind of location the address describes.
 //


### PR DESCRIPTION
The unit agent's config file only contained an internal IP for the state server.  This PR uses the same method as is used to populate the machine agent's config.

Charm URLs were also only generated for internal IPs.  This PR will generate URLs for all host ports, with internal addresses prioritized first.

Live tested on AWS and Azure (with https://github.com/juju/juju/pull/5245 before it was reverted)

(Review request: http://reviews.vapour.ws/r/4705/)