### PR TITLE
New SSHClient facade

### DIFF
--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -70,6 +70,7 @@ var facadeVersions = map[string]int{
 	"ServiceScaler":                1,
 	"Singular":                     1,
 	"Spaces":                       2,
+	"SSHClient":                    1,
 	"StatusHistory":                2,
 	"Storage":                      2,
 	"StorageProvisioner":           2,

--- a/api/sshclient/facade.go
+++ b/api/sshclient/facade.go
@@ -1,0 +1,88 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package sshclient
+
+import (
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/apiserver/params"
+)
+
+// NewFacade returns a new Facade based on an existing API connection.
+func NewFacade(caller base.APICaller) *Facade {
+	return &Facade{base.NewFacadeCaller(caller, "SSHClient")}
+}
+
+type Facade struct {
+	caller base.FacadeCaller
+}
+
+// PublicAddress returns the public address for the SSH target
+// provided. The target may be provided as a machine ID or unit name.
+func (facade *Facade) PublicAddress(target string) (string, error) {
+	addr, err := facade.addressCall("PublicAddress", target)
+	return addr, errors.Trace(err)
+}
+
+// PrivateAddress returns the private address for the SSH target
+// provided. The target may be provided as a machine ID or unit name.
+func (facade *Facade) PrivateAddress(target string) (string, error) {
+	addr, err := facade.addressCall("PrivateAddress", target)
+	return addr, errors.Trace(err)
+}
+
+func (facade *Facade) addressCall(callName, target string) (string, error) {
+	var out params.SSHAddressResults
+	err := facade.caller.FacadeCall(callName, targetToArg(target), &out)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	if len(out.Results) != 1 {
+		return "", countError(len(out.Results))
+	}
+	if err := out.Results[0].Error; err != nil {
+		return "", errors.Trace(err)
+	}
+	return out.Results[0].Address, nil
+}
+
+// PublicKeys returns the SSH public host keys for the SSH target
+// provided. The target may be provided as a machine ID or unit name.
+func (facade *Facade) PublicKeys(target string) ([]string, error) {
+	var out params.SSHPublicKeysResults
+	err := facade.caller.FacadeCall("PublicKeys", targetToArg(target), &out)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if len(out.Results) != 1 {
+		return nil, countError(len(out.Results))
+	}
+	if err := out.Results[0].Error; err != nil {
+		return nil, errors.Trace(err)
+	}
+	return out.Results[0].PublicKeys, nil
+}
+
+// Proxy returns whether SSH connections should be proxied through the
+// controller hosts for the associated model.
+func (facade *Facade) Proxy() (bool, error) {
+	var out params.SSHProxyResult
+	err := facade.caller.FacadeCall("Proxy", nil, &out)
+	if err != nil {
+		return false, errors.Trace(err)
+	}
+	return out.UseProxy, nil
+}
+
+func targetToArg(target string) params.SSHTargets {
+	return params.SSHTargets{
+		Targets: []params.SSHTarget{{target}},
+	}
+}
+
+// countError complains about malformed results.
+func countError(count int) error {
+	return errors.Errorf("expected 1 result, got %d", count)
+}

--- a/api/sshclient/facade_test.go
+++ b/api/sshclient/facade_test.go
@@ -5,6 +5,7 @@ package sshclient_test
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/names"
 	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -32,18 +33,20 @@ func (s *FacadeSuite) TestAddress(c *gc.C) {
 		return nil
 	})
 	facade := sshclient.NewFacade(apiCaller)
-	expectedTarget := []interface{}{params.SSHTargets{[]params.SSHTarget{{"foo/0"}}}}
+	expectedArg := []interface{}{params.Entities{[]params.Entity{{
+		names.NewUnitTag("foo/0").String(),
+	}}}}
 
 	public, err := facade.PublicAddress("foo/0")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(public, gc.Equals, "1.1.1.1")
-	stub.CheckCalls(c, []jujutesting.StubCall{{"SSHClient.PublicAddress", expectedTarget}})
+	stub.CheckCalls(c, []jujutesting.StubCall{{"SSHClient.PublicAddress", expectedArg}})
 	stub.ResetCalls()
 
 	private, err := facade.PrivateAddress("foo/0")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(private, gc.Equals, "1.1.1.1")
-	stub.CheckCalls(c, []jujutesting.StubCall{{"SSHClient.PrivateAddress", expectedTarget}})
+	stub.CheckCalls(c, []jujutesting.StubCall{{"SSHClient.PrivateAddress", expectedArg}})
 }
 
 func (s *FacadeSuite) TestAddressError(c *gc.C) {
@@ -133,7 +136,9 @@ func (s *FacadeSuite) TestPublicKeys(c *gc.C) {
 	c.Check(keys, gc.DeepEquals, []string{"rsa", "dsa"})
 	stub.CheckCalls(c, []jujutesting.StubCall{{
 		"SSHClient.PublicKeys",
-		[]interface{}{params.SSHTargets{[]params.SSHTarget{{"foo/0"}}}},
+		[]interface{}{params.Entities{[]params.Entity{{
+			Tag: names.NewUnitTag("foo/0").String(),
+		}}}},
 	}})
 }
 

--- a/api/sshclient/facade_test.go
+++ b/api/sshclient/facade_test.go
@@ -1,0 +1,220 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package sshclient_test
+
+import (
+	"github.com/juju/errors"
+	jujutesting "github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	apitesting "github.com/juju/juju/api/base/testing"
+	"github.com/juju/juju/api/sshclient"
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/params"
+)
+
+type FacadeSuite struct {
+	jujutesting.IsolationSuite
+}
+
+var _ = gc.Suite(&FacadeSuite{})
+
+func (s *FacadeSuite) TestAddress(c *gc.C) {
+	var stub jujutesting.Stub
+	apiCaller := apitesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		stub.AddCall(objType+"."+request, arg)
+		c.Check(id, gc.Equals, "")
+		*result.(*params.SSHAddressResults) = params.SSHAddressResults{
+			Results: []params.SSHAddressResult{{Address: "1.1.1.1"}},
+		}
+		return nil
+	})
+	facade := sshclient.NewFacade(apiCaller)
+	expectedTarget := []interface{}{params.SSHTargets{[]params.SSHTarget{{"foo/0"}}}}
+
+	public, err := facade.PublicAddress("foo/0")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(public, gc.Equals, "1.1.1.1")
+	stub.CheckCalls(c, []jujutesting.StubCall{{"SSHClient.PublicAddress", expectedTarget}})
+	stub.ResetCalls()
+
+	private, err := facade.PrivateAddress("foo/0")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(private, gc.Equals, "1.1.1.1")
+	stub.CheckCalls(c, []jujutesting.StubCall{{"SSHClient.PrivateAddress", expectedTarget}})
+}
+
+func (s *FacadeSuite) TestAddressError(c *gc.C) {
+	apiCaller := apitesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		return errors.New("boom")
+	})
+	facade := sshclient.NewFacade(apiCaller)
+
+	public, err := facade.PublicAddress("foo/0")
+	c.Check(public, gc.Equals, "")
+	c.Check(err, gc.ErrorMatches, "boom")
+
+	private, err := facade.PrivateAddress("foo/0")
+	c.Check(private, gc.Equals, "")
+	c.Check(err, gc.ErrorMatches, "boom")
+}
+
+func (s *FacadeSuite) TestAddressTargetError(c *gc.C) {
+	apiCaller := apitesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		*result.(*params.SSHAddressResults) = params.SSHAddressResults{
+			Results: []params.SSHAddressResult{{Error: common.ServerError(errors.New("boom"))}},
+		}
+		return nil
+	})
+	facade := sshclient.NewFacade(apiCaller)
+
+	public, err := facade.PublicAddress("foo/0")
+	c.Check(public, gc.Equals, "")
+	c.Check(err, gc.ErrorMatches, "boom")
+
+	private, err := facade.PrivateAddress("foo/0")
+	c.Check(private, gc.Equals, "")
+	c.Check(err, gc.ErrorMatches, "boom")
+}
+
+func (s *FacadeSuite) TestAddressMissingResults(c *gc.C) {
+	apiCaller := apitesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		return nil
+	})
+	facade := sshclient.NewFacade(apiCaller)
+	expectedErr := "expected 1 result, got 0"
+
+	public, err := facade.PublicAddress("foo/0")
+	c.Check(public, gc.Equals, "")
+	c.Check(err, gc.ErrorMatches, expectedErr)
+
+	private, err := facade.PrivateAddress("foo/0")
+	c.Check(private, gc.Equals, "")
+	c.Check(err, gc.ErrorMatches, expectedErr)
+}
+
+func (s *FacadeSuite) TestAddressExtraResults(c *gc.C) {
+	apiCaller := apitesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		*result.(*params.SSHAddressResults) = params.SSHAddressResults{
+			Results: []params.SSHAddressResult{
+				{Address: "1.1.1.1"},
+				{Address: "2.2.2.2"},
+			},
+		}
+		return nil
+	})
+	facade := sshclient.NewFacade(apiCaller)
+	expectedErr := "expected 1 result, got 2"
+
+	public, err := facade.PublicAddress("foo/0")
+	c.Check(public, gc.Equals, "")
+	c.Check(err, gc.ErrorMatches, expectedErr)
+
+	private, err := facade.PrivateAddress("foo/0")
+	c.Check(private, gc.Equals, "")
+	c.Check(err, gc.ErrorMatches, expectedErr)
+}
+
+func (s *FacadeSuite) TestPublicKeys(c *gc.C) {
+	var stub jujutesting.Stub
+	apiCaller := apitesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		stub.AddCall(objType+"."+request, arg)
+		c.Check(id, gc.Equals, "")
+		*result.(*params.SSHPublicKeysResults) = params.SSHPublicKeysResults{
+			Results: []params.SSHPublicKeysResult{{PublicKeys: []string{"rsa", "dsa"}}},
+		}
+		return nil
+	})
+	facade := sshclient.NewFacade(apiCaller)
+	keys, err := facade.PublicKeys("foo/0")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(keys, gc.DeepEquals, []string{"rsa", "dsa"})
+	stub.CheckCalls(c, []jujutesting.StubCall{{
+		"SSHClient.PublicKeys",
+		[]interface{}{params.SSHTargets{[]params.SSHTarget{{"foo/0"}}}},
+	}})
+}
+
+func (s *FacadeSuite) TestPublicKeysError(c *gc.C) {
+	apiCaller := apitesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		return errors.New("boom")
+	})
+	facade := sshclient.NewFacade(apiCaller)
+	keys, err := facade.PublicKeys("foo/0")
+	c.Check(keys, gc.IsNil)
+	c.Check(err, gc.ErrorMatches, "boom")
+}
+
+func (s *FacadeSuite) TestPublicKeysTargetError(c *gc.C) {
+	var stub jujutesting.Stub
+	apiCaller := apitesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		stub.AddCall(objType+"."+request, arg)
+		c.Check(id, gc.Equals, "")
+		*result.(*params.SSHPublicKeysResults) = params.SSHPublicKeysResults{
+			Results: []params.SSHPublicKeysResult{{Error: common.ServerError(errors.New("boom"))}},
+		}
+		return nil
+	})
+	facade := sshclient.NewFacade(apiCaller)
+	keys, err := facade.PublicKeys("foo/0")
+	c.Check(keys, gc.IsNil)
+	c.Check(err, gc.ErrorMatches, "boom")
+}
+
+func (s *FacadeSuite) TestPublicKeysMissingResults(c *gc.C) {
+	apiCaller := apitesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		return nil
+	})
+	facade := sshclient.NewFacade(apiCaller)
+	keys, err := facade.PublicKeys("foo/0")
+	c.Check(keys, gc.IsNil)
+	c.Check(err, gc.ErrorMatches, "expected 1 result, got 0")
+}
+
+func (s *FacadeSuite) TestPublicKeysExtraResults(c *gc.C) {
+	apiCaller := apitesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		*result.(*params.SSHPublicKeysResults) = params.SSHPublicKeysResults{
+			Results: []params.SSHPublicKeysResult{
+				{PublicKeys: []string{"rsa"}},
+				{PublicKeys: []string{"rsa"}},
+			},
+		}
+		return nil
+	})
+	facade := sshclient.NewFacade(apiCaller)
+	keys, err := facade.PublicKeys("foo/0")
+	c.Check(keys, gc.IsNil)
+	c.Check(err, gc.ErrorMatches, "expected 1 result, got 2")
+}
+
+func (s *FacadeSuite) TestProxy(c *gc.C) {
+	checkProxy(c, true)
+	checkProxy(c, false)
+}
+
+func checkProxy(c *gc.C, useProxy bool) {
+	var stub jujutesting.Stub
+	apiCaller := apitesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		stub.AddCall(objType+"."+request, arg)
+		*result.(*params.SSHProxyResult) = params.SSHProxyResult{
+			UseProxy: useProxy,
+		}
+		return nil
+	})
+	facade := sshclient.NewFacade(apiCaller)
+	result, err := facade.Proxy()
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(result, gc.Equals, useProxy)
+	stub.CheckCalls(c, []jujutesting.StubCall{{"SSHClient.Proxy", []interface{}{nil}}})
+}
+
+func (s *FacadeSuite) TestProxyError(c *gc.C) {
+	apiCaller := apitesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		return errors.New("boom")
+	})
+	facade := sshclient.NewFacade(apiCaller)
+	_, err := facade.Proxy()
+	c.Check(err, gc.ErrorMatches, "boom")
+}

--- a/api/sshclient/package_test.go
+++ b/api/sshclient/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package sshclient_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -56,6 +56,7 @@ import (
 	_ "github.com/juju/juju/apiserver/servicescaler"
 	_ "github.com/juju/juju/apiserver/singular"
 	_ "github.com/juju/juju/apiserver/spaces"
+	_ "github.com/juju/juju/apiserver/sshclient"
 	_ "github.com/juju/juju/apiserver/statushistory"
 	_ "github.com/juju/juju/apiserver/storage"
 	_ "github.com/juju/juju/apiserver/storageprovisioner"

--- a/apiserver/params/ssh.go
+++ b/apiserver/params/ssh.go
@@ -20,17 +20,6 @@ type SSHProxyResult struct {
 	UseProxy bool `json:"use-proxy"`
 }
 
-// SSHTargets is used to specify one or more SSH destinations for
-// various APIs on the SSHClient facade.
-type SSHTargets struct {
-	Targets []SSHTarget `json:"targets"`
-}
-
-// SSHTarget specifies a single SSH target (see SSHTargets).
-type SSHTarget struct {
-	Target string `json:"target"`
-}
-
 // SSHAddressResults defines the response from various APIs on the
 // SSHClient facade.
 type SSHAddressResults struct {

--- a/apiserver/params/ssh.go
+++ b/apiserver/params/ssh.go
@@ -40,8 +40,8 @@ type SSHAddressResults struct {
 // SSHAddressResult defines a single SSH address result (see
 // SSHAddressResults).
 type SSHAddressResult struct {
-	Error   *Error `json:"error"`
-	Address string `json:"address"`
+	Error   *Error `json:"error,omitempty"`
+	Address string `json:"address,omitempty"`
 }
 
 // SSHPublicKeysResults is used to return SSH public host keys for one
@@ -53,6 +53,6 @@ type SSHPublicKeysResults struct {
 // SSHPublicKeysResult is used to return the SSH public host keys for
 // one SSH target (see SSHPublicKeysResults).
 type SSHPublicKeysResult struct {
-	Error      *Error   `json:"error"`
-	PublicKeys []string `json:"public-keys"`
+	Error      *Error   `json:"error,omitempty"`
+	PublicKeys []string `json:"public-keys,omitempty"`
 }

--- a/apiserver/params/ssh.go
+++ b/apiserver/params/ssh.go
@@ -14,3 +14,45 @@ type SSHHostKeys struct {
 	Tag        string   `json:"tag"`
 	PublicKeys []string `json:"public-keys"`
 }
+
+// SSHProxyResult defines the response from the SSHClient.Proxy API.
+type SSHProxyResult struct {
+	UseProxy bool `json:"use-proxy"`
+}
+
+// SSHTargets is used to specify one or more SSH destinations for
+// various APIs on the SSHClient facade.
+type SSHTargets struct {
+	Targets []SSHTarget `json:"targets"`
+}
+
+// SSHTarget specifies a single SSH target (see SSHTargets).
+type SSHTarget struct {
+	Target string `json:"target"`
+}
+
+// SSHAddressResults defines the response from various APIs on the
+// SSHClient facade.
+type SSHAddressResults struct {
+	Results []SSHAddressResult `json:"results"`
+}
+
+// SSHAddressResult defines a single SSH address result (see
+// SSHAddressResults).
+type SSHAddressResult struct {
+	Error   *Error `json:"error"`
+	Address string `json:"address"`
+}
+
+// SSHPublicKeysResults is used to return SSH public host keys for one
+// or more target for the SSHClient.PublicKeys API.
+type SSHPublicKeysResults struct {
+	Results []SSHPublicKeysResult `json:"results"`
+}
+
+// SSHPublicKeysResult is used to return the SSH public host keys for
+// one SSH target (see SSHPublicKeysResults).
+type SSHPublicKeysResult struct {
+	Error      *Error   `json:"error"`
+	PublicKeys []string `json:"public-keys"`
+}

--- a/apiserver/sshclient/facade.go
+++ b/apiserver/sshclient/facade.go
@@ -28,30 +28,28 @@ func New(backend Backend, _ *common.Resources, authorizer common.Authorizer) (*F
 	return &Facade{backend: backend}, nil
 }
 
-// PublicAddress reports the best public network address for one or
-// more SSH targets. Targets may be provided as either a machine ID or
-// unit name.
-func (facade *Facade) PublicAddress(args params.SSHTargets) (params.SSHAddressResults, error) {
+// PublicAddress reports the preferred public network address for one
+// or more entities. Machines and units are suppored.
+func (facade *Facade) PublicAddress(args params.Entities) (params.SSHAddressResults, error) {
 	getter := func(m SSHMachine) (network.Address, error) { return m.PublicAddress() }
 	return facade.getAddresses(args, getter)
 }
 
-// PrivateAddress reports the best private network address for one or
-// more SSH targets. Targets may be provided as either a machine ID or
-// unit name.
-func (facade *Facade) PrivateAddress(args params.SSHTargets) (params.SSHAddressResults, error) {
+// PrivateAddress reports the preferred private network address for one or
+// more entities. Machines and units are supported.
+func (facade *Facade) PrivateAddress(args params.Entities) (params.SSHAddressResults, error) {
 	getter := func(m SSHMachine) (network.Address, error) { return m.PrivateAddress() }
 	return facade.getAddresses(args, getter)
 }
 
-func (facade *Facade) getAddresses(args params.SSHTargets, getter func(SSHMachine) (network.Address, error)) (
+func (facade *Facade) getAddresses(args params.Entities, getter func(SSHMachine) (network.Address, error)) (
 	params.SSHAddressResults, error,
 ) {
 	out := params.SSHAddressResults{
-		Results: make([]params.SSHAddressResult, len(args.Targets)),
+		Results: make([]params.SSHAddressResult, len(args.Entities)),
 	}
-	for i, target := range args.Targets {
-		machine, err := facade.backend.GetMachineForTarget(target.Target)
+	for i, entity := range args.Entities {
+		machine, err := facade.backend.GetMachineForEntity(entity.Tag)
 		if err != nil {
 			out.Results[i].Error = common.ServerError(common.ErrPerm)
 		} else {
@@ -66,15 +64,14 @@ func (facade *Facade) getAddresses(args params.SSHTargets, getter func(SSHMachin
 	return out, nil
 }
 
-// PublicKeys returns the public SSH hosts for one or more SSH
-// targets. Targets may be provided as either a machine ID or unit
-// name.
-func (facade *Facade) PublicKeys(args params.SSHTargets) (params.SSHPublicKeysResults, error) {
+// PublicKeys returns the public SSH hosts for one or more
+// entities. Machines and units are supported.
+func (facade *Facade) PublicKeys(args params.Entities) (params.SSHPublicKeysResults, error) {
 	out := params.SSHPublicKeysResults{
-		Results: make([]params.SSHPublicKeysResult, len(args.Targets)),
+		Results: make([]params.SSHPublicKeysResult, len(args.Entities)),
 	}
-	for i, target := range args.Targets {
-		machine, err := facade.backend.GetMachineForTarget(target.Target)
+	for i, entity := range args.Entities {
+		machine, err := facade.backend.GetMachineForEntity(entity.Tag)
 		if err != nil {
 			out.Results[i].Error = common.ServerError(common.ErrPerm)
 		} else {

--- a/apiserver/sshclient/facade.go
+++ b/apiserver/sshclient/facade.go
@@ -1,0 +1,100 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Package sshclient implements the API endpoint required for Juju
+// clients that wish to make SSH connections to Juju managed machines.
+package sshclient
+
+import (
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/network"
+)
+
+func init() {
+	common.RegisterStandardFacade("SSHClient", 1, newFacade)
+}
+
+// Facade implements the API required by the sshclient worker.
+type Facade struct {
+	backend Backend
+}
+
+// New returns a new API facade for the sshclient worker.
+func New(backend Backend, _ *common.Resources, authorizer common.Authorizer) (*Facade, error) {
+	if !authorizer.AuthClient() {
+		return nil, common.ErrPerm
+	}
+	return &Facade{backend: backend}, nil
+}
+
+// PublicAddress reports the best public network address for one or
+// more SSH targets. Targets may be provided as either a machine ID or
+// unit name.
+func (facade *Facade) PublicAddress(args params.SSHTargets) (params.SSHAddressResults, error) {
+	getter := func(m SSHMachine) (network.Address, error) { return m.PublicAddress() }
+	return facade.getAddresses(args, getter)
+}
+
+// PrivateAddress reports the best private network address for one or
+// more SSH targets. Targets may be provided as either a machine ID or
+// unit name.
+func (facade *Facade) PrivateAddress(args params.SSHTargets) (params.SSHAddressResults, error) {
+	getter := func(m SSHMachine) (network.Address, error) { return m.PrivateAddress() }
+	return facade.getAddresses(args, getter)
+}
+
+func (facade *Facade) getAddresses(args params.SSHTargets, getter func(SSHMachine) (network.Address, error)) (
+	params.SSHAddressResults, error,
+) {
+	out := params.SSHAddressResults{
+		Results: make([]params.SSHAddressResult, len(args.Targets)),
+	}
+	for i, target := range args.Targets {
+		machine, err := facade.backend.GetMachineForTarget(target.Target)
+		if err != nil {
+			out.Results[i].Error = common.ServerError(common.ErrPerm)
+		} else {
+			address, err := getter(machine)
+			if err != nil {
+				out.Results[i].Error = common.ServerError(err)
+			} else {
+				out.Results[i].Address = address.Value
+			}
+		}
+	}
+	return out, nil
+}
+
+// PublicKeys returns the public SSH hosts for one or more SSH
+// targets. Targets may be provided as either a machine ID or unit
+// name.
+func (facade *Facade) PublicKeys(args params.SSHTargets) (params.SSHPublicKeysResults, error) {
+	out := params.SSHPublicKeysResults{
+		Results: make([]params.SSHPublicKeysResult, len(args.Targets)),
+	}
+	for i, target := range args.Targets {
+		machine, err := facade.backend.GetMachineForTarget(target.Target)
+		if err != nil {
+			out.Results[i].Error = common.ServerError(common.ErrPerm)
+		} else {
+			keys, err := facade.backend.GetSSHHostKeys(machine.MachineTag())
+			if err != nil {
+				out.Results[i].Error = common.ServerError(err)
+			} else {
+				out.Results[i].PublicKeys = []string(keys)
+			}
+		}
+	}
+	return out, nil
+}
+
+// Proxy returns whether SSH connections should be proxied through the
+// controller hosts for the model associated with the API connection.
+func (facade *Facade) Proxy() (params.SSHProxyResult, error) {
+	config, err := facade.backend.ModelConfig()
+	if err != nil {
+		return params.SSHProxyResult{}, err
+	}
+	return params.SSHProxyResult{UseProxy: config.ProxySSH()}, nil
+}

--- a/apiserver/sshclient/facade_test.go
+++ b/apiserver/sshclient/facade_test.go
@@ -1,0 +1,216 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package sshclient_test
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/names"
+	jujutesting "github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/apiserver/sshclient"
+	apiservertesting "github.com/juju/juju/apiserver/testing"
+	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/network"
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/testing"
+)
+
+type facadeSuite struct {
+	testing.BaseSuite
+	backend    *mockBackend
+	authorizer *apiservertesting.FakeAuthorizer
+	facade     *sshclient.Facade
+}
+
+var _ = gc.Suite(&facadeSuite{})
+
+func (s *facadeSuite) SetUpTest(c *gc.C) {
+	s.backend = new(mockBackend)
+	s.authorizer = new(apiservertesting.FakeAuthorizer)
+	s.authorizer.Tag = names.NewUserTag("igor")
+	facade, err := sshclient.New(s.backend, nil, s.authorizer)
+	c.Assert(err, jc.ErrorIsNil)
+	s.facade = facade
+}
+
+func (s *facadeSuite) TestFailsWhenMachine(c *gc.C) {
+	s.authorizer.Tag = names.NewMachineTag("0")
+	_, err := sshclient.New(s.backend, nil, s.authorizer)
+	c.Assert(err, gc.Equals, common.ErrPerm)
+}
+
+func (s *facadeSuite) TestFailsWhenUnit(c *gc.C) {
+	s.authorizer.Tag = names.NewUnitTag("foo/0")
+	_, err := sshclient.New(s.backend, nil, s.authorizer)
+	c.Assert(err, gc.Equals, common.ErrPerm)
+}
+
+func (s *facadeSuite) TestPublicAddress(c *gc.C) {
+	args := params.SSHTargets{
+		Targets: []params.SSHTarget{
+			{Target: "0"},
+			{Target: "foo/0"},
+			{Target: "other/1"},
+		},
+	}
+	results, err := s.facade.PublicAddress(args)
+
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(results, gc.DeepEquals, params.SSHAddressResults{
+		Results: []params.SSHAddressResult{
+			{Address: "1.1.1.1"},
+			{Address: "3.3.3.3"},
+			{Error: apiservertesting.ErrUnauthorized},
+		},
+	})
+	s.backend.stub.CheckCalls(c, []jujutesting.StubCall{
+		{"GetMachineForTarget", []interface{}{"0"}},
+		{"GetMachineForTarget", []interface{}{"foo/0"}},
+		{"GetMachineForTarget", []interface{}{"other/1"}},
+	})
+}
+
+func (s *facadeSuite) TestPrivateAddress(c *gc.C) {
+	args := params.SSHTargets{
+		Targets: []params.SSHTarget{
+			{Target: "other/1"},
+			{Target: "0"},
+			{Target: "foo/0"},
+		},
+	}
+	results, err := s.facade.PrivateAddress(args)
+
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(results, gc.DeepEquals, params.SSHAddressResults{
+		Results: []params.SSHAddressResult{
+			{Error: apiservertesting.ErrUnauthorized},
+			{Address: "2.2.2.2"},
+			{Address: "4.4.4.4"},
+		},
+	})
+	s.backend.stub.CheckCalls(c, []jujutesting.StubCall{
+		{"GetMachineForTarget", []interface{}{"other/1"}},
+		{"GetMachineForTarget", []interface{}{"0"}},
+		{"GetMachineForTarget", []interface{}{"foo/0"}},
+	})
+}
+
+func (s *facadeSuite) TestPublicKeys(c *gc.C) {
+	args := params.SSHTargets{
+		Targets: []params.SSHTarget{
+			{Target: "0"},
+			{Target: "other/1"},
+			{Target: "foo/0"},
+		},
+	}
+	results, err := s.facade.PublicKeys(args)
+
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(results, gc.DeepEquals, params.SSHPublicKeysResults{
+		Results: []params.SSHPublicKeysResult{
+			{PublicKeys: []string{"rsa0", "dsa0"}},
+			{Error: apiservertesting.ErrUnauthorized},
+			{PublicKeys: []string{"rsa1", "dsa1"}},
+		},
+	})
+	s.backend.stub.CheckCalls(c, []jujutesting.StubCall{
+		{"GetMachineForTarget", []interface{}{"0"}},
+		{"GetSSHHostKeys", []interface{}{names.NewMachineTag("0")}},
+		{"GetMachineForTarget", []interface{}{"other/1"}},
+		{"GetMachineForTarget", []interface{}{"foo/0"}},
+		{"GetSSHHostKeys", []interface{}{names.NewMachineTag("1")}},
+	})
+}
+
+func (s *facadeSuite) TestProxyTrue(c *gc.C) {
+	s.backend.proxySSH = true
+	result, err := s.facade.Proxy()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(result.UseProxy, jc.IsTrue)
+	s.backend.stub.CheckCalls(c, []jujutesting.StubCall{
+		{"ModelConfig", []interface{}{}},
+	})
+}
+
+func (s *facadeSuite) TestProxyFalse(c *gc.C) {
+	s.backend.proxySSH = false
+	result, err := s.facade.Proxy()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(result.UseProxy, jc.IsFalse)
+	s.backend.stub.CheckCalls(c, []jujutesting.StubCall{
+		{"ModelConfig", []interface{}{}},
+	})
+}
+
+type mockBackend struct {
+	stub     jujutesting.Stub
+	proxySSH bool
+}
+
+func (backend *mockBackend) ModelConfig() (*config.Config, error) {
+	backend.stub.AddCall("ModelConfig")
+	attrs := testing.FakeConfig()
+	attrs["proxy-ssh"] = backend.proxySSH
+	conf, err := config.New(config.NoDefaults, attrs)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return conf, nil
+}
+
+func (backend *mockBackend) GetMachineForTarget(target string) (sshclient.SSHMachine, error) {
+	backend.stub.AddCall("GetMachineForTarget", target)
+	switch target {
+	case "0":
+		return &mockMachine{
+			tag:            names.NewMachineTag("0"),
+			publicAddress:  "1.1.1.1",
+			privateAddress: "2.2.2.2",
+		}, nil
+	case "foo/0":
+		return &mockMachine{
+			tag:            names.NewMachineTag("1"),
+			publicAddress:  "3.3.3.3",
+			privateAddress: "4.4.4.4",
+		}, nil
+	}
+	return nil, errors.New("unknown target")
+}
+
+func (backend *mockBackend) GetSSHHostKeys(tag names.MachineTag) (state.SSHHostKeys, error) {
+	backend.stub.AddCall("GetSSHHostKeys", tag)
+	switch tag {
+	case names.NewMachineTag("0"):
+		return state.SSHHostKeys{"rsa0", "dsa0"}, nil
+	case names.NewMachineTag("1"):
+		return state.SSHHostKeys{"rsa1", "dsa1"}, nil
+	}
+	return nil, errors.New("machine not found")
+}
+
+type mockMachine struct {
+	tag            names.MachineTag
+	publicAddress  string
+	privateAddress string
+}
+
+func (m *mockMachine) MachineTag() names.MachineTag {
+	return m.tag
+}
+
+func (m *mockMachine) PublicAddress() (network.Address, error) {
+	return network.Address{
+		Value: m.publicAddress,
+	}, nil
+}
+
+func (m *mockMachine) PrivateAddress() (network.Address, error) {
+	return network.Address{
+		Value: m.privateAddress,
+	}, nil
+}

--- a/apiserver/sshclient/package_test.go
+++ b/apiserver/sshclient/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package sshclient_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/apiserver/sshclient/shim.go
+++ b/apiserver/sshclient/shim.go
@@ -1,0 +1,67 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package sshclient
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/names"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/network"
+	"github.com/juju/juju/state"
+)
+
+// Backend defines the State API used by the sshclient facade.
+type Backend interface {
+	ModelConfig() (*config.Config, error)
+	GetMachineForTarget(target string) (SSHMachine, error)
+	GetSSHHostKeys(names.MachineTag) (state.SSHHostKeys, error)
+}
+
+// SSHMachine specifies the methods on State.Machine of interest to
+// the SSHClient facade.
+type SSHMachine interface {
+	MachineTag() names.MachineTag
+	PublicAddress() (network.Address, error)
+	PrivateAddress() (network.Address, error)
+}
+
+// newFacade wraps New to express the supplied *state.State as a Backend.
+func newFacade(st *state.State, res *common.Resources, auth common.Authorizer) (*Facade, error) {
+	return New(&backend{st}, res, auth)
+}
+
+type backend struct {
+	*state.State
+}
+
+// GetMachineForTarget takes a machine ID or unit name and returns the
+// associated SSHMachine.
+func (b *backend) GetMachineForTarget(target string) (SSHMachine, error) {
+	switch {
+	case names.IsValidMachine(target):
+		machine, err := b.State.Machine(target)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		return machine, nil
+	case names.IsValidUnit(target):
+		unit, err := b.State.Unit(target)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		machineId, err := unit.AssignedMachineId()
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		machine, err := b.State.Machine(machineId)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		return machine, nil
+	default:
+		return nil, errors.Errorf("unsupported target: %q", target)
+	}
+}


### PR DESCRIPTION
This include the server and client side facades to be used by Juju clients wishing to SSH to Juju managed machines. In addition to supporting the pre-existing SSH related functionality on the Client facade, support has been added for retrieving SSH host keys.

Part of the fix for LP #1456916

(Review request: http://reviews.vapour.ws/r/4713/)