### PR TITLE
provider/azure: isolate resource groups

### DIFF
--- a/controller/modelmanager/createmodel_test.go
+++ b/controller/modelmanager/createmodel_test.go
@@ -286,7 +286,7 @@ func (*RestrictedProviderFieldsSuite) TestRestrictedProviderFields(c *gc.C) {
 		provider: "azure",
 		expected: []string{
 			"type", "ca-cert", "state-port", "api-port", "controller-uuid",
-			"location", "endpoint", "storage-endpoint", "controller-resource-group",
+			"location", "endpoint", "storage-endpoint",
 		},
 	}, {
 		provider: "dummy",

--- a/provider/azure/config.go
+++ b/provider/azure/config.go
@@ -39,36 +39,28 @@ const (
 	// account.
 	configAttrStorageAccountKey = "storage-account-key"
 
-	// configAttrControllerResourceGroup is the resource group
-	// corresponding to the controller environment. Each environment needs
-	// to know this because some resources are shared, and live in the
-	// controller environment's resource group.
-	configAttrControllerResourceGroup = "controller-resource-group"
-
 	// resourceNameLengthMax is the maximum length of resource
 	// names in Azure.
 	resourceNameLengthMax = 80
 )
 
 var configFields = schema.Fields{
-	configAttrLocation:                schema.String(),
-	configAttrEndpoint:                schema.String(),
-	configAttrStorageEndpoint:         schema.String(),
-	configAttrAppId:                   schema.String(),
-	configAttrSubscriptionId:          schema.String(),
-	configAttrTenantId:                schema.String(),
-	configAttrAppPassword:             schema.String(),
-	configAttrStorageAccount:          schema.String(),
-	configAttrStorageAccountKey:       schema.String(),
-	configAttrStorageAccountType:      schema.String(),
-	configAttrControllerResourceGroup: schema.String(),
+	configAttrLocation:           schema.String(),
+	configAttrEndpoint:           schema.String(),
+	configAttrStorageEndpoint:    schema.String(),
+	configAttrAppId:              schema.String(),
+	configAttrSubscriptionId:     schema.String(),
+	configAttrTenantId:           schema.String(),
+	configAttrAppPassword:        schema.String(),
+	configAttrStorageAccount:     schema.String(),
+	configAttrStorageAccountKey:  schema.String(),
+	configAttrStorageAccountType: schema.String(),
 }
 
 var configDefaults = schema.Defaults{
-	configAttrStorageAccount:          schema.Omit,
-	configAttrStorageAccountKey:       schema.Omit,
-	configAttrControllerResourceGroup: schema.Omit,
-	configAttrStorageAccountType:      string(storage.StandardLRS),
+	configAttrStorageAccount:     schema.Omit,
+	configAttrStorageAccountKey:  schema.Omit,
+	configAttrStorageAccountType: string(storage.StandardLRS),
 }
 
 var requiredConfigAttributes = []string{
@@ -79,13 +71,11 @@ var requiredConfigAttributes = []string{
 	configAttrLocation,
 	configAttrEndpoint,
 	configAttrStorageEndpoint,
-	configAttrControllerResourceGroup,
 }
 
 var immutableConfigAttributes = []string{
 	configAttrSubscriptionId,
 	configAttrTenantId,
-	configAttrControllerResourceGroup,
 	configAttrStorageAccount,
 	configAttrStorageAccountType,
 }
@@ -93,20 +83,18 @@ var immutableConfigAttributes = []string{
 var internalConfigAttributes = []string{
 	configAttrStorageAccount,
 	configAttrStorageAccountKey,
-	configAttrControllerResourceGroup,
 }
 
 type azureModelConfig struct {
 	*config.Config
-	token                   *azure.ServicePrincipalToken
-	subscriptionId          string
-	location                string // canonicalized
-	endpoint                string
-	storageEndpoint         string
-	storageAccount          string
-	storageAccountKey       string
-	storageAccountType      storage.AccountType
-	controllerResourceGroup string
+	token              *azure.ServicePrincipalToken
+	subscriptionId     string
+	location           string // canonicalized
+	endpoint           string
+	storageEndpoint    string
+	storageAccount     string
+	storageAccountKey  string
+	storageAccountType storage.AccountType
 }
 
 var knownStorageAccountTypes = []string{
@@ -191,7 +179,6 @@ Please choose a model name of no more than %d characters.`,
 	storageAccount, _ := validated[configAttrStorageAccount].(string)
 	storageAccountKey, _ := validated[configAttrStorageAccountKey].(string)
 	storageAccountType := validated[configAttrStorageAccountType].(string)
-	controllerResourceGroup := validated[configAttrControllerResourceGroup].(string)
 
 	if newCfg.FirewallMode() == config.FwGlobal {
 		// We do not currently support the "global" firewall mode.
@@ -229,7 +216,6 @@ Please choose a model name of no more than %d characters.`,
 		storageAccount,
 		storageAccountKey,
 		storage.AccountType(storageAccountType),
-		controllerResourceGroup,
 	}
 
 	return azureConfig, nil

--- a/provider/azure/config_test.go
+++ b/provider/azure/config_test.go
@@ -75,7 +75,6 @@ func (s *configSuite) TestValidateInvalidCredentials(c *gc.C) {
 	s.assertConfigInvalid(c, testing.Attrs{"application-password": ""}, `"application-password" config not specified`)
 	s.assertConfigInvalid(c, testing.Attrs{"tenant-id": ""}, `"tenant-id" config not specified`)
 	s.assertConfigInvalid(c, testing.Attrs{"subscription-id": ""}, `"subscription-id" config not specified`)
-	s.assertConfigInvalid(c, testing.Attrs{"controller-resource-group": ""}, `"controller-resource-group" config not specified`)
 }
 
 func (s *configSuite) TestValidateStorageAccountCantChange(c *gc.C) {
@@ -106,16 +105,15 @@ func (s *configSuite) assertConfigInvalid(c *gc.C, attrs testing.Attrs, expect s
 
 func makeTestModelConfig(c *gc.C, extra ...testing.Attrs) *config.Config {
 	attrs := testing.Attrs{
-		"type":                      "azure",
-		"application-id":            fakeApplicationId,
-		"tenant-id":                 fakeTenantId,
-		"application-password":      "opensezme",
-		"subscription-id":           fakeSubscriptionId,
-		"location":                  "westus",
-		"endpoint":                  "https://api.azurestack.local",
-		"storage-endpoint":          "https://storage.azurestack.local",
-		"controller-resource-group": "arbitrary",
-		"agent-version":             "1.2.3",
+		"type":                 "azure",
+		"application-id":       fakeApplicationId,
+		"tenant-id":            fakeTenantId,
+		"application-password": "opensezme",
+		"subscription-id":      fakeSubscriptionId,
+		"location":             "westus",
+		"endpoint":             "https://api.azurestack.local",
+		"storage-endpoint":     "https://storage.azurestack.local",
+		"agent-version":        "1.2.3",
 	}
 	for _, extra := range extra {
 		attrs = attrs.Merge(extra)

--- a/provider/azure/environ_test.go
+++ b/provider/azure/environ_test.go
@@ -51,11 +51,13 @@ type environSuite struct {
 	sender        azuretesting.Senders
 
 	tags                          map[string]*string
+	group                         *resources.Group
 	vmSizes                       *compute.VirtualMachineSizeListResult
 	storageNameAvailabilityResult *storage.CheckNameAvailabilityResult
 	storageAccount                *storage.Account
 	storageAccountKeys            *storage.AccountKeys
 	vnet                          *network.VirtualNetwork
+	nsg                           *network.SecurityGroup
 	subnet                        *network.Subnet
 	ubuntuServerSKUs              []compute.VirtualMachineImageResource
 	publicIPAddress               *network.PublicIPAddress
@@ -77,9 +79,17 @@ func (s *environSuite) SetUpTest(c *gc.C) {
 		NewStorageClient: s.storageClient.NewClient,
 	})
 
-	emptyTags := make(map[string]*string)
+	envTags := map[string]*string{
+		"juju-model-uuid":      to.StringPtr(testing.ModelTag.Id()),
+		"juju-controller-uuid": to.StringPtr(testing.ModelTag.Id()),
+	}
 	s.tags = map[string]*string{
 		"juju-machine-name": to.StringPtr("machine-0"),
+	}
+
+	s.group = &resources.Group{
+		Location: to.StringPtr("westus"),
+		Tags:     &envTags,
 	}
 
 	vmSizes := []compute.VirtualMachineSize{{
@@ -99,6 +109,7 @@ func (s *environSuite) SetUpTest(c *gc.C) {
 	s.storageAccount = &storage.Account{
 		Name: to.StringPtr("my-storage-account"),
 		Type: to.StringPtr("Standard_LRS"),
+		Tags: &envTags,
 		Properties: &storage.AccountProperties{
 			PrimaryEndpoints: &storage.Endpoints{
 				Blob: to.StringPtr(fmt.Sprintf("https://%s.blob.storage.azurestack.local/", fakeStorageAccount)),
@@ -110,25 +121,32 @@ func (s *environSuite) SetUpTest(c *gc.C) {
 		Key1: to.StringPtr("key-1"),
 	}
 
-	addressPrefixes := make([]string, 256)
-	for i := range addressPrefixes {
-		addressPrefixes[i] = fmt.Sprintf("10.%d.0.0/16", i)
-	}
+	addressPrefixes := []string{"10.0.0.0/16"}
 	s.vnet = &network.VirtualNetwork{
-		ID:       to.StringPtr("juju-internal"),
-		Name:     to.StringPtr("juju-internal"),
+		ID:       to.StringPtr("juju-internal-network"),
+		Name:     to.StringPtr("juju-internal-network"),
 		Location: to.StringPtr("westus"),
-		Tags:     &emptyTags,
+		Tags:     &envTags,
 		Properties: &network.VirtualNetworkPropertiesFormat{
 			AddressSpace: &network.AddressSpace{&addressPrefixes},
 		},
 	}
 
+	s.nsg = &network.SecurityGroup{
+		ID: to.StringPtr(path.Join(
+			"/subscriptions", fakeSubscriptionId,
+			"resourceGroups", "juju-testenv-model-"+testing.ModelTag.Id(),
+			"providers/Microsoft.Network/networkSecurityGroups/juju-internal-nsg",
+		)),
+		Tags: &envTags,
+	}
+
 	s.subnet = &network.Subnet{
 		ID:   to.StringPtr("subnet-id"),
-		Name: to.StringPtr("juju-testenv-model-deadbeef-0bad-400d-8000-4b1d0d06f00d"),
+		Name: to.StringPtr("juju-internal-subnet"),
 		Properties: &network.SubnetPropertiesFormat{
-			AddressPrefix: to.StringPtr("10.0.0.0/16"),
+			AddressPrefix:        to.StringPtr("10.0.0.0/16"),
+			NetworkSecurityGroup: &network.SubResource{s.nsg.ID},
 		},
 	}
 
@@ -174,14 +192,6 @@ func (s *environSuite) SetUpTest(c *gc.C) {
 		Value: &oldNetworkInterfaces,
 	}
 
-	// nsgID is the name of the internal network security group. This NSG
-	// is created when the environment is created.
-	nsgID := path.Join(
-		"/subscriptions", fakeSubscriptionId,
-		"resourceGroups", "juju-testenv-model-"+testing.ModelTag.Id(),
-		"providers/Microsoft.Network/networkSecurityGroups/juju-internal",
-	)
-
 	// The newly created IP/NIC.
 	newIPConfigurations := []network.InterfaceIPConfiguration{{
 		ID:   to.StringPtr("ip-configuration-1-id"),
@@ -199,8 +209,7 @@ func (s *environSuite) SetUpTest(c *gc.C) {
 		Location: to.StringPtr("westus"),
 		Tags:     &s.tags,
 		Properties: &network.InterfacePropertiesFormat{
-			IPConfigurations:     &newIPConfigurations,
-			NetworkSecurityGroup: &network.SubResource{to.StringPtr(nsgID)},
+			IPConfigurations: &newIPConfigurations,
 		},
 	}
 
@@ -208,7 +217,7 @@ func (s *environSuite) SetUpTest(c *gc.C) {
 		ID:       to.StringPtr("juju-availability-set-id"),
 		Name:     to.StringPtr("juju"),
 		Location: to.StringPtr("westus"),
-		Tags:     &emptyTags,
+		Tags:     &envTags,
 	}
 
 	sshPublicKeys := []compute.SSHPublicKey{{
@@ -304,10 +313,8 @@ func prepareForBootstrap(
 	// Opening the environment should not incur network communication,
 	// so we don't set s.sender until after opening.
 	cfg := makeTestModelConfig(c, attrs...)
-	cfg, err := cfg.Remove([]string{"controller-resource-group"})
-	c.Assert(err, jc.ErrorIsNil)
 	*sender = azuretesting.Senders{tokenRefreshSender()}
-	cfg, err = provider.BootstrapConfig(environs.BootstrapConfigParams{
+	cfg, err := provider.BootstrapConfig(environs.BootstrapConfigParams{
 		Config:               cfg,
 		CloudRegion:          "westus",
 		CloudEndpoint:        "https://management.azure.com",
@@ -333,10 +340,10 @@ func tokenRefreshSender() *azuretesting.MockSender {
 func (s *environSuite) initResourceGroupSenders() azuretesting.Senders {
 	resourceGroupName := "juju-testenv-model-deadbeef-0bad-400d-8000-4b1d0d06f00d"
 	return azuretesting.Senders{
-		s.makeSender(".*/resourcegroups/"+resourceGroupName, &resources.Group{}),
-		s.makeSender(".*/virtualnetworks/juju-internal", s.vnet),
-		s.makeSender(".*/networkSecurityGroups/juju-internal", &network.SecurityGroup{}),
-		s.makeSender(".*/virtualnetworks/juju-internal/subnets/"+resourceGroupName, &s.subnet),
+		s.makeSender(".*/resourcegroups/"+resourceGroupName, s.group),
+		s.makeSender(".*/virtualnetworks/juju-internal-network", s.vnet),
+		s.makeSender(".*/networkSecurityGroups/juju-internal-nsg", s.nsg),
+		s.makeSender(".*/virtualnetworks/juju-internal-network/subnets/juju-internal-subnet", s.subnet),
 		s.makeSender(".*/checkNameAvailability", s.storageNameAvailabilityResult),
 		s.makeSender(".*/storageAccounts/.*", s.storageAccount),
 		s.makeSender(".*/storageAccounts/.*/listKeys", s.storageAccountKeys),
@@ -346,7 +353,7 @@ func (s *environSuite) initResourceGroupSenders() azuretesting.Senders {
 func (s *environSuite) startInstanceSenders(controller bool) azuretesting.Senders {
 	senders := azuretesting.Senders{
 		s.vmSizesSender(),
-		s.makeSender(".*/subnets/juju-testenv-model-deadbeef-0bad-400d-8000-4b1d0d06f00d", s.subnet),
+		s.makeSender(".*/subnets/juju-internal-subnet", s.subnet),
 		s.makeSender(".*/Canonical/.*/UbuntuServer/skus", s.ubuntuServerSKUs),
 		s.makeSender(".*/publicIPAddresses/machine-0-public-ip", s.publicIPAddress),
 		s.makeSender(".*/networkInterfaces", s.oldNetworkInterfaces),
@@ -354,10 +361,10 @@ func (s *environSuite) startInstanceSenders(controller bool) azuretesting.Sender
 	}
 	if controller {
 		senders = append(senders,
-			s.makeSender(".*/networkSecurityGroups/juju-internal", &network.SecurityGroup{
+			s.makeSender(".*/networkSecurityGroups/juju-internal-nsg", &network.SecurityGroup{
 				Properties: &network.SecurityGroupPropertiesFormat{},
 			}),
-			s.makeSender(".*/networkSecurityGroups/juju-internal", &network.SecurityGroup{}),
+			s.makeSender(".*/networkSecurityGroups/juju-internal-nsg", &network.SecurityGroup{}),
 		)
 	}
 	senders = append(senders,
@@ -599,11 +606,7 @@ func (s *environSuite) TestBootstrap(c *gc.C) {
 	c.Assert(s.requests[5].Method, gc.Equals, "PUT")  // create storage account
 	c.Assert(s.requests[6].Method, gc.Equals, "POST") // get storage account keys
 
-	emptyTags := map[string]*string{}
-	assertRequestBody(c, s.requests[0], &resources.Group{
-		Location: to.StringPtr("westus"),
-		Tags:     &emptyTags,
-	})
+	assertRequestBody(c, s.requests[0], &s.group)
 
 	s.vnet.ID = nil
 	s.vnet.Name = nil
@@ -625,7 +628,7 @@ func (s *environSuite) TestBootstrap(c *gc.C) {
 	}}
 	assertRequestBody(c, s.requests[2], &network.SecurityGroup{
 		Location: to.StringPtr("westus"),
-		Tags:     &emptyTags,
+		Tags:     s.nsg.Tags,
 		Properties: &network.SecurityGroupPropertiesFormat{
 			SecurityRules: &securityRules,
 		},
@@ -642,7 +645,7 @@ func (s *environSuite) TestBootstrap(c *gc.C) {
 
 	assertRequestBody(c, s.requests[5], &storage.AccountCreateParameters{
 		Location: to.StringPtr("westus"),
-		Tags:     &emptyTags,
+		Tags:     s.storageAccount.Tags,
 		Properties: &storage.AccountPropertiesCreateParameters{
 			AccountType: "Standard_LRS",
 		},
@@ -694,17 +697,17 @@ func (s *environSuite) TestStopInstances(c *gc.C) {
 		s.publicIPAddressesSender(
 			makePublicIPAddress("pip-0", "machine-0", "1.2.3.4"),
 		),
-		s.makeSender(".*/virtualMachines/machine-0", nil),                                             // DELETE
-		s.makeSender(".*/networkSecurityGroups/juju-internal", nsg),                                   // GET
-		s.makeSender(".*/networkSecurityGroups/juju-internal/securityRules/machine-0-80", nil),        // DELETE
-		s.makeSender(".*/networkSecurityGroups/juju-internal/securityRules/machine-0-1000-2000", nil), // DELETE
-		s.makeSender(".*/networkInterfaces/nic-0", nic0),                                              // PUT
-		s.makeSender(".*/publicIPAddresses/pip-0", nil),                                               // DELETE
-		s.makeSender(".*/networkInterfaces/nic-0", nil),                                               // DELETE
-		s.makeSender(".*/virtualMachines/machine-1", nil),                                             // DELETE
-		s.makeSender(".*/networkSecurityGroups/juju-internal", nsg),                                   // GET
-		s.makeSender(".*/networkInterfaces/nic-1", nil),                                               // DELETE
-		s.makeSender(".*/networkInterfaces/nic-2", nil),                                               // DELETE
+		s.makeSender(".*/virtualMachines/machine-0", nil),                                                 // DELETE
+		s.makeSender(".*/networkSecurityGroups/juju-internal-nsg", nsg),                                   // GET
+		s.makeSender(".*/networkSecurityGroups/juju-internal-nsg/securityRules/machine-0-80", nil),        // DELETE
+		s.makeSender(".*/networkSecurityGroups/juju-internal-nsg/securityRules/machine-0-1000-2000", nil), // DELETE
+		s.makeSender(".*/networkInterfaces/nic-0", nic0),                                                  // PUT
+		s.makeSender(".*/publicIPAddresses/pip-0", nil),                                                   // DELETE
+		s.makeSender(".*/networkInterfaces/nic-0", nil),                                                   // DELETE
+		s.makeSender(".*/virtualMachines/machine-1", nil),                                                 // DELETE
+		s.makeSender(".*/networkSecurityGroups/juju-internal-nsg", nsg),                                   // GET
+		s.makeSender(".*/networkInterfaces/nic-1", nil),                                                   // DELETE
+		s.makeSender(".*/networkInterfaces/nic-2", nil),                                                   // DELETE
 	}
 	err := env.StopInstances("machine-0", "machine-1", "machine-2")
 	c.Assert(err, jc.ErrorIsNil)

--- a/provider/azure/environprovider.go
+++ b/provider/azure/environprovider.go
@@ -7,7 +7,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/Godeps/_workspace/src/github.com/Azure/go-autorest/autorest"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
-	"github.com/juju/names"
 
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs"
@@ -78,10 +77,10 @@ func (prov *azureEnvironProvider) Open(cfg *config.Config) (environs.Environ, er
 // The result of RestrictedConfigAttributes is the names of attributes that
 // will be copied across to a hosted environment's initial configuration.
 func (prov *azureEnvironProvider) RestrictedConfigAttributes() []string {
+	// TODO(axw) there should be no restricted attributes.
 	return []string{
 		configAttrLocation,
 		configAttrEndpoint,
-		configAttrControllerResourceGroup,
 		configAttrStorageEndpoint,
 	}
 }
@@ -111,13 +110,6 @@ func (prov *azureEnvironProvider) BootstrapConfig(args environs.BootstrapConfigP
 		configAttrLocation:        args.CloudRegion,
 		configAttrEndpoint:        args.CloudEndpoint,
 		configAttrStorageEndpoint: args.CloudStorageEndpoint,
-
-		// Record the UUID that will be used for the controller
-		// model, which contains shared resources.
-		configAttrControllerResourceGroup: resourceGroupName(
-			names.NewModelTag(args.Config.UUID()),
-			args.Config.Name(),
-		),
 	}
 	switch authType := args.Credentials.AuthType(); authType {
 	case cloud.UserPassAuthType:

--- a/provider/azure/environprovider_test.go
+++ b/provider/azure/environprovider_test.go
@@ -40,7 +40,6 @@ func (s *environProviderSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *environProviderSuite) TestBootstrapConfigWithInternalConfig(c *gc.C) {
-	s.testBootstrapConfigWithInternalConfig(c, "controller-resource-group")
 	s.testBootstrapConfigWithInternalConfig(c, "storage-account")
 }
 
@@ -68,11 +67,8 @@ func fakeUserPassCredential() cloud.Credential {
 
 func (s *environProviderSuite) TestBootstrapConfig(c *gc.C) {
 	cfg := makeTestModelConfig(c)
-	cfg, err := cfg.Remove([]string{"controller-resource-group"})
-	c.Assert(err, jc.ErrorIsNil)
-
 	s.sender = azuretesting.Senders{tokenRefreshSender()}
-	cfg, err = s.provider.BootstrapConfig(environs.BootstrapConfigParams{
+	cfg, err := s.provider.BootstrapConfig(environs.BootstrapConfigParams{
 		Config:               cfg,
 		CloudRegion:          "westus",
 		CloudEndpoint:        "https://api.azurestack.local",
@@ -82,11 +78,10 @@ func (s *environProviderSuite) TestBootstrapConfig(c *gc.C) {
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(cfg, gc.NotNil)
 
-	c.Assert(
-		cfg.UnknownAttrs()["controller-resource-group"],
-		gc.Equals,
-		"juju-testenv-model-"+testing.ModelTag.Id(),
-	)
+	attrs := cfg.UnknownAttrs()
+	c.Assert(attrs["location"], gc.Equals, "westus")
+	c.Assert(attrs["endpoint"], gc.Equals, "https://api.azurestack.local")
+	c.Assert(attrs["storage-endpoint"], gc.Equals, "https://storage.azurestack.local")
 }
 
 func newProviders(c *gc.C, config azure.ProviderConfig) (environs.EnvironProvider, storage.Provider) {

--- a/provider/azure/instance.go
+++ b/provider/azure/instance.go
@@ -155,11 +155,8 @@ func (inst *azureInstance) internalNetworkAddress() (jujunetwork.Address, error)
 	inst.env.mu.Lock()
 	subscriptionId := inst.env.config.subscriptionId
 	resourceGroup := inst.env.resourceGroup
-	controllerResourceGroup := inst.env.controllerResourceGroup
 	inst.env.mu.Unlock()
-	internalSubnetId := internalSubnetId(
-		resourceGroup, controllerResourceGroup, subscriptionId,
-	)
+	internalSubnetId := internalSubnetId(resourceGroup, subscriptionId)
 
 	for _, nic := range inst.networkInterfaces {
 		if nic.Properties.IPConfigurations == nil {

--- a/provider/azure/instance_test.go
+++ b/provider/azure/instance_test.go
@@ -158,7 +158,7 @@ func networkSecurityGroupSender(rules []network.SecurityRule) *azuretesting.Mock
 			SecurityRules: &rules,
 		},
 	})
-	nsgSender.PathPattern = ".*/networkSecurityGroups/juju-internal"
+	nsgSender.PathPattern = ".*/networkSecurityGroups/juju-internal-nsg"
 	return nsgSender
 }
 
@@ -369,8 +369,8 @@ func (s *instanceSuite) TestInstanceClosePorts(c *gc.C) {
 func (s *instanceSuite) TestInstanceOpenPorts(c *gc.C) {
 	internalSubnetId := path.Join(
 		"/subscriptions", fakeSubscriptionId,
-		"resourceGroups/arbitrary/providers/Microsoft.Network/virtualnetworks/juju-internal/subnets",
-		"juju-testenv-model-"+testing.ModelTag.Id(),
+		"resourceGroups/juju-testenv-model-deadbeef-0bad-400d-8000-4b1d0d06f00d",
+		"providers/Microsoft.Network/virtualnetworks/juju-internal-network/subnets/juju-internal-subnet",
 	)
 	ipConfiguration := network.InterfaceIPConfiguration{
 		Properties: &network.InterfaceIPConfigurationPropertiesFormat{
@@ -439,8 +439,8 @@ func (s *instanceSuite) TestInstanceOpenPorts(c *gc.C) {
 func (s *instanceSuite) TestInstanceOpenPortsAlreadyOpen(c *gc.C) {
 	internalSubnetId := path.Join(
 		"/subscriptions", fakeSubscriptionId,
-		"resourceGroups/arbitrary/providers/Microsoft.Network/virtualnetworks/juju-internal/subnets",
-		"juju-testenv-model-"+testing.ModelTag.Id(),
+		"resourceGroups/juju-testenv-model-deadbeef-0bad-400d-8000-4b1d0d06f00d",
+		"providers/Microsoft.Network/virtualnetworks/juju-internal-network/subnets/juju-internal-subnet",
 	)
 	ipConfiguration := network.InterfaceIPConfiguration{
 		Properties: &network.InterfaceIPConfigurationPropertiesFormat{
@@ -508,7 +508,7 @@ func (s *instanceSuite) TestInstanceOpenPortsNoInternalAddress(c *gc.C) {
 var internalSecurityGroupPath = path.Join(
 	"/subscriptions", fakeSubscriptionId,
 	"resourceGroups", "juju-testenv-model-"+testing.ModelTag.Id(),
-	"providers/Microsoft.Network/networkSecurityGroups/juju-internal",
+	"providers/Microsoft.Network/networkSecurityGroups/juju-internal-nsg",
 )
 
 func securityRulePath(ruleName string) string {


### PR DESCRIPTION
Isolate Juju environs into fully self contained
Azure resource groups. This will enable Juju to
manage models in separate Azure regions, accounts,
etc. Also, it means the Azure provider is no longer
a barrier to managing models in multiple clouds.

Each environment now gets its own juju-internal
network, and a 10.0.0.0/16 subnet within it. The
Juju agents in hosted models will talk to the
controller machines using their public addresses,
as their private addresses are not routable across
models.

There is also a drive-by fix of tagging of environment-
level resources, such as resource groups, networks,
etc. These were previously being tagged with the
values in the "resource-tags" config, but with
juju-model-uuid or juju-controller-uuid. These must
be added so we can later delete hosted models.

(Revert the revert of #5245)

(Review request: http://reviews.vapour.ws/r/4714/)