### PR TITLE
provider/openstack: destroy hosted model resources

### DIFF
--- a/juju/testing/instance.go
+++ b/juju/testing/instance.go
@@ -16,7 +16,6 @@ import (
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/imagemetadata"
 	"github.com/juju/juju/environs/simplestreams"
-	"github.com/juju/juju/environs/tags"
 	"github.com/juju/juju/environs/tools"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/mongo"
@@ -176,7 +175,7 @@ func StartInstanceWithParams(
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	instanceConfig.Tags[tags.JujuModel] = env.Config().UUID()
+	instanceConfig.Tags = instancecfg.InstanceTags(env.Config(), nil)
 	params.Tools = possibleTools
 	params.InstanceConfig = instanceConfig
 	return env.StartInstance(params)

--- a/provider/openstack/cinder_test.go
+++ b/provider/openstack/cinder_test.go
@@ -541,7 +541,8 @@ func (s *cinderVolumeSourceSuite) TestGetVolumeEndpointPreferV2(c *gc.C) {
 func (s *cinderVolumeSourceSuite) TestGetVolumeEndpointMissing(c *gc.C) {
 	client := testEndpointResolver{}
 	url, err := openstack.GetVolumeEndpointURL(client, "east")
-	c.Assert(err, gc.ErrorMatches, `endpoint "volume" not found for "east" region`)
+	c.Assert(err, gc.ErrorMatches, `endpoint "volume" in region "east" not found`)
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 	c.Assert(url, gc.IsNil)
 }
 

--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -541,17 +541,17 @@ func (s *localServerSuite) TestStopInstance(c *gc.C) {
 	// group, one group for the entire environment, and another for the
 	// new instance.
 	cUUID := env.Config().ControllerUUID()
-	eUUID := env.Config().UUID()
+	modelUUID := env.Config().UUID()
 	allSecurityGroups := []string{
-		"default", fmt.Sprintf("juju-%v-%v", cUUID, eUUID),
-		fmt.Sprintf("juju-%v-%v-%v", cUUID, eUUID, instanceName),
+		"default", fmt.Sprintf("juju-%v-%v", cUUID, modelUUID),
+		fmt.Sprintf("juju-%v-%v-%v", cUUID, modelUUID, instanceName),
 	}
 	assertSecurityGroups(c, env, allSecurityGroups)
 	err = env.StopInstances(inst.Id())
 	c.Assert(err, jc.ErrorIsNil)
 	// The security group for this instance is now removed.
 	assertSecurityGroups(c, env, []string{
-		"default", fmt.Sprintf("juju-%v-%v", cUUID, eUUID),
+		"default", fmt.Sprintf("juju-%v-%v", cUUID, modelUUID),
 	})
 }
 
@@ -578,10 +578,10 @@ func (s *localServerSuite) TestStopInstanceSecurityGroupNotDeleted(c *gc.C) {
 	instanceName := "100"
 	inst, _ := testing.AssertStartInstance(c, env, instanceName)
 	cUUID := env.Config().ControllerUUID()
-	eUUID := env.Config().UUID()
+	modelUUID := env.Config().UUID()
 	allSecurityGroups := []string{
-		"default", fmt.Sprintf("juju-%v-%v", cUUID, eUUID),
-		fmt.Sprintf("juju-%v-%v-%v", cUUID, eUUID, instanceName),
+		"default", fmt.Sprintf("juju-%v-%v", cUUID, modelUUID),
+		fmt.Sprintf("juju-%v-%v-%v", cUUID, modelUUID, instanceName),
 	}
 	assertSecurityGroups(c, env, allSecurityGroups)
 	err = env.StopInstances(inst.Id())
@@ -598,10 +598,10 @@ func (s *localServerSuite) TestDestroyEnvironmentDeletesSecurityGroupsFWModeInst
 	instanceName := "100"
 	testing.AssertStartInstance(c, env, instanceName)
 	cUUID := env.Config().ControllerUUID()
-	eUUID := env.Config().UUID()
+	modelUUID := env.Config().UUID()
 	allSecurityGroups := []string{
-		"default", fmt.Sprintf("juju-%v-%v", cUUID, eUUID),
-		fmt.Sprintf("juju-%v-%v-%v", cUUID, eUUID, instanceName),
+		"default", fmt.Sprintf("juju-%v-%v", cUUID, modelUUID),
+		fmt.Sprintf("juju-%v-%v-%v", cUUID, modelUUID, instanceName),
 	}
 	assertSecurityGroups(c, env, allSecurityGroups)
 	err = env.Destroy()
@@ -618,10 +618,10 @@ func (s *localServerSuite) TestDestroyEnvironmentDeletesSecurityGroupsFWModeGlob
 	instanceName := "100"
 	testing.AssertStartInstance(c, env, instanceName)
 	cUUID := env.Config().ControllerUUID()
-	eUUID := env.Config().UUID()
+	modelUUID := env.Config().UUID()
 	allSecurityGroups := []string{
-		"default", fmt.Sprintf("juju-%v-%v", cUUID, eUUID),
-		fmt.Sprintf("juju-%v-%v-global", cUUID, eUUID),
+		"default", fmt.Sprintf("juju-%v-%v", cUUID, modelUUID),
+		fmt.Sprintf("juju-%v-%v-global", cUUID, modelUUID),
 	}
 	assertSecurityGroups(c, env, allSecurityGroups)
 	err = env.Destroy()
@@ -646,14 +646,14 @@ func (s *localServerSuite) TestDestroyControllerModel(c *gc.C) {
 	hostedModelInstanceName := "200"
 	testing.AssertStartInstance(c, env, hostedModelInstanceName)
 	cUUID := env.Config().ControllerUUID()
-	eUUID := env.Config().UUID()
+	modelUUID := env.Config().UUID()
 	allControllerSecurityGroups := []string{
 		"default", fmt.Sprintf("juju-%v-%v", cUUID, cUUID),
 		fmt.Sprintf("juju-%v-%v-%v", cUUID, cUUID, controllerInstanceName),
 	}
 	allHostedModelSecurityGroups := []string{
-		"default", fmt.Sprintf("juju-%v-%v", cUUID, eUUID),
-		fmt.Sprintf("juju-%v-%v-%v", cUUID, eUUID, hostedModelInstanceName),
+		"default", fmt.Sprintf("juju-%v-%v", cUUID, modelUUID),
+		fmt.Sprintf("juju-%v-%v-%v", cUUID, modelUUID, hostedModelInstanceName),
 	}
 	assertSecurityGroups(c, controllerEnv, append(
 		allControllerSecurityGroups, allHostedModelSecurityGroups...,
@@ -683,14 +683,14 @@ func (s *localServerSuite) TestDestroyHostedModel(c *gc.C) {
 	hostedModelInstanceName := "200"
 	testing.AssertStartInstance(c, env, hostedModelInstanceName)
 	cUUID := env.Config().ControllerUUID()
-	eUUID := env.Config().UUID()
+	modelUUID := env.Config().UUID()
 	allControllerSecurityGroups := []string{
 		"default", fmt.Sprintf("juju-%v-%v", cUUID, cUUID),
 		fmt.Sprintf("juju-%v-%v-%v", cUUID, cUUID, controllerInstanceName),
 	}
 	allHostedModelSecurityGroups := []string{
-		"default", fmt.Sprintf("juju-%v-%v", cUUID, eUUID),
-		fmt.Sprintf("juju-%v-%v-%v", cUUID, eUUID, hostedModelInstanceName),
+		"default", fmt.Sprintf("juju-%v-%v", cUUID, modelUUID),
+		fmt.Sprintf("juju-%v-%v-%v", cUUID, modelUUID, hostedModelInstanceName),
 	}
 	assertSecurityGroups(c, controllerEnv, append(
 		allControllerSecurityGroups, allHostedModelSecurityGroups...,

--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -19,6 +19,7 @@ import (
 	jujuerrors "github.com/juju/errors"
 	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils"
 	"github.com/juju/utils/arch"
 	"github.com/juju/utils/series"
 	"github.com/juju/utils/ssh"
@@ -518,6 +519,16 @@ func assertSecurityGroups(c *gc.C, env environs.Environ, expected []string) {
 	}
 }
 
+func assertInstanceIds(c *gc.C, env environs.Environ, expected ...instance.Id) {
+	insts, err := env.AllInstances()
+	c.Assert(err, jc.ErrorIsNil)
+	instIds := make([]instance.Id, len(insts))
+	for i, inst := range insts {
+		instIds[i] = inst.Id()
+	}
+	c.Assert(instIds, jc.SameContents, expected)
+}
+
 func (s *localServerSuite) TestStopInstance(c *gc.C) {
 	cfg, err := config.New(config.NoDefaults, s.TestConfig.Merge(coretesting.Attrs{
 		"firewall-mode": config.FwInstance}))
@@ -529,12 +540,19 @@ func (s *localServerSuite) TestStopInstance(c *gc.C) {
 	// Openstack now has three security groups for the server, the default
 	// group, one group for the entire environment, and another for the
 	// new instance.
+	cUUID := env.Config().ControllerUUID()
 	eUUID := env.Config().UUID()
-	assertSecurityGroups(c, env, []string{"default", fmt.Sprintf("juju-%v", eUUID), fmt.Sprintf("juju-%v-%v", eUUID, instanceName)})
+	allSecurityGroups := []string{
+		"default", fmt.Sprintf("juju-%v-%v", cUUID, eUUID),
+		fmt.Sprintf("juju-%v-%v-%v", cUUID, eUUID, instanceName),
+	}
+	assertSecurityGroups(c, env, allSecurityGroups)
 	err = env.StopInstances(inst.Id())
 	c.Assert(err, jc.ErrorIsNil)
 	// The security group for this instance is now removed.
-	assertSecurityGroups(c, env, []string{"default", fmt.Sprintf("juju-%v", eUUID)})
+	assertSecurityGroups(c, env, []string{
+		"default", fmt.Sprintf("juju-%v-%v", cUUID, eUUID),
+	})
 }
 
 // Due to bug #1300755 it can happen that the security group intended for
@@ -559,8 +577,12 @@ func (s *localServerSuite) TestStopInstanceSecurityGroupNotDeleted(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	instanceName := "100"
 	inst, _ := testing.AssertStartInstance(c, env, instanceName)
+	cUUID := env.Config().ControllerUUID()
 	eUUID := env.Config().UUID()
-	allSecurityGroups := []string{"default", fmt.Sprintf("juju-%v", eUUID), fmt.Sprintf("juju-%v-%v", eUUID, instanceName)}
+	allSecurityGroups := []string{
+		"default", fmt.Sprintf("juju-%v-%v", cUUID, eUUID),
+		fmt.Sprintf("juju-%v-%v-%v", cUUID, eUUID, instanceName),
+	}
 	assertSecurityGroups(c, env, allSecurityGroups)
 	err = env.StopInstances(inst.Id())
 	c.Assert(err, jc.ErrorIsNil)
@@ -575,8 +597,12 @@ func (s *localServerSuite) TestDestroyEnvironmentDeletesSecurityGroupsFWModeInst
 	c.Assert(err, jc.ErrorIsNil)
 	instanceName := "100"
 	testing.AssertStartInstance(c, env, instanceName)
+	cUUID := env.Config().ControllerUUID()
 	eUUID := env.Config().UUID()
-	allSecurityGroups := []string{"default", fmt.Sprintf("juju-%v", eUUID), fmt.Sprintf("juju-%v-%v", eUUID, instanceName)}
+	allSecurityGroups := []string{
+		"default", fmt.Sprintf("juju-%v-%v", cUUID, eUUID),
+		fmt.Sprintf("juju-%v-%v-%v", cUUID, eUUID, instanceName),
+	}
 	assertSecurityGroups(c, env, allSecurityGroups)
 	err = env.Destroy()
 	c.Check(err, jc.ErrorIsNil)
@@ -591,12 +617,90 @@ func (s *localServerSuite) TestDestroyEnvironmentDeletesSecurityGroupsFWModeGlob
 	c.Assert(err, jc.ErrorIsNil)
 	instanceName := "100"
 	testing.AssertStartInstance(c, env, instanceName)
+	cUUID := env.Config().ControllerUUID()
 	eUUID := env.Config().UUID()
-	allSecurityGroups := []string{"default", fmt.Sprintf("juju-%v", eUUID), fmt.Sprintf("juju-%v-global", eUUID)}
+	allSecurityGroups := []string{
+		"default", fmt.Sprintf("juju-%v-%v", cUUID, eUUID),
+		fmt.Sprintf("juju-%v-%v-global", cUUID, eUUID),
+	}
 	assertSecurityGroups(c, env, allSecurityGroups)
 	err = env.Destroy()
 	c.Check(err, jc.ErrorIsNil)
 	assertSecurityGroups(c, env, []string{"default"})
+}
+
+func (s *localServerSuite) TestDestroyControllerModel(c *gc.C) {
+	cfg, err := config.New(config.NoDefaults, s.TestConfig.Merge(coretesting.Attrs{
+		"uuid": utils.MustNewUUID().String(),
+	}))
+	c.Assert(err, jc.ErrorIsNil)
+	env, err := environs.New(cfg)
+	c.Assert(err, jc.ErrorIsNil)
+	controllerCfg, err := config.New(config.NoDefaults, s.TestConfig)
+	c.Assert(err, jc.ErrorIsNil)
+	controllerEnv, err := environs.New(controllerCfg)
+	c.Assert(err, jc.ErrorIsNil)
+
+	controllerInstanceName := "100"
+	testing.AssertStartInstance(c, controllerEnv, controllerInstanceName)
+	hostedModelInstanceName := "200"
+	testing.AssertStartInstance(c, env, hostedModelInstanceName)
+	cUUID := env.Config().ControllerUUID()
+	eUUID := env.Config().UUID()
+	allControllerSecurityGroups := []string{
+		"default", fmt.Sprintf("juju-%v-%v", cUUID, cUUID),
+		fmt.Sprintf("juju-%v-%v-%v", cUUID, cUUID, controllerInstanceName),
+	}
+	allHostedModelSecurityGroups := []string{
+		"default", fmt.Sprintf("juju-%v-%v", cUUID, eUUID),
+		fmt.Sprintf("juju-%v-%v-%v", cUUID, eUUID, hostedModelInstanceName),
+	}
+	assertSecurityGroups(c, controllerEnv, append(
+		allControllerSecurityGroups, allHostedModelSecurityGroups...,
+	))
+
+	err = controllerEnv.Destroy()
+	c.Check(err, jc.ErrorIsNil)
+	assertSecurityGroups(c, controllerEnv, []string{"default"})
+	assertInstanceIds(c, env)
+	assertInstanceIds(c, controllerEnv)
+}
+
+func (s *localServerSuite) TestDestroyHostedModel(c *gc.C) {
+	cfg, err := config.New(config.NoDefaults, s.TestConfig.Merge(coretesting.Attrs{
+		"uuid": utils.MustNewUUID().String(),
+	}))
+	c.Assert(err, jc.ErrorIsNil)
+	env, err := environs.New(cfg)
+	c.Assert(err, jc.ErrorIsNil)
+	controllerCfg, err := config.New(config.NoDefaults, s.TestConfig)
+	c.Assert(err, jc.ErrorIsNil)
+	controllerEnv, err := environs.New(controllerCfg)
+	c.Assert(err, jc.ErrorIsNil)
+
+	controllerInstanceName := "100"
+	controllerInstance, _ := testing.AssertStartInstance(c, controllerEnv, controllerInstanceName)
+	hostedModelInstanceName := "200"
+	testing.AssertStartInstance(c, env, hostedModelInstanceName)
+	cUUID := env.Config().ControllerUUID()
+	eUUID := env.Config().UUID()
+	allControllerSecurityGroups := []string{
+		"default", fmt.Sprintf("juju-%v-%v", cUUID, cUUID),
+		fmt.Sprintf("juju-%v-%v-%v", cUUID, cUUID, controllerInstanceName),
+	}
+	allHostedModelSecurityGroups := []string{
+		"default", fmt.Sprintf("juju-%v-%v", cUUID, eUUID),
+		fmt.Sprintf("juju-%v-%v-%v", cUUID, eUUID, hostedModelInstanceName),
+	}
+	assertSecurityGroups(c, controllerEnv, append(
+		allControllerSecurityGroups, allHostedModelSecurityGroups...,
+	))
+
+	err = env.Destroy()
+	c.Check(err, jc.ErrorIsNil)
+	assertSecurityGroups(c, controllerEnv, allControllerSecurityGroups)
+	assertInstanceIds(c, env)
+	assertInstanceIds(c, controllerEnv, controllerInstance.Id())
 }
 
 var instanceGathering = []struct {

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -1333,8 +1333,8 @@ func resourceName(tag names.Tag, envName string) string {
 // machinesFilter returns a nova.Filter matching all machines in the environment.
 func (e *Environ) machinesFilter() *nova.Filter {
 	filter := nova.NewFilter()
-	eUUID := e.Config().UUID()
-	filter.Set(nova.FilterServer, fmt.Sprintf("juju-%s-machine-\\d*", eUUID))
+	modelUUID := e.Config().UUID()
+	filter.Set(nova.FilterServer, fmt.Sprintf("juju-%s-machine-\\d*", modelUUID))
 	return filter
 }
 

--- a/provider/rackspace/firewaller.go
+++ b/provider/rackspace/firewaller.go
@@ -55,8 +55,8 @@ func (c *rackspaceFirewaller) Ports() ([]network.PortRange, error) {
 	return nil, errors.NotSupportedf("Ports")
 }
 
-// DeleteGlobalGroups implements OpenstackFirewaller interface.
-func (c *rackspaceFirewaller) DeleteGlobalGroups() error {
+// DeleteAllGroups implements OpenstackFirewaller interface.
+func (c *rackspaceFirewaller) DeleteAllGroups() error {
 	return nil
 }
 


### PR DESCRIPTION
When calling the Destroy() method of a controller's
Environ, we will also destroy the resources for the
hosted models created/managed by the controller.

Partially fixes https://bugs.launchpad.net/juju-core/+bug/1566011

(Review request: http://reviews.vapour.ws/r/4717/)