### PR TITLE
Restore fix status

### DIFF
--- a/api/backups/restore.go
+++ b/api/backups/restore.go
@@ -85,7 +85,7 @@ func (c *Client) RestoreReader(r io.ReadSeeker, meta *params.BackupsMetadataResu
 	backupId, err := c.Upload(r, *meta)
 	if err != nil {
 		finishErr := finishRestore(newClient)
-		logger.Errorf("could not exit restoring status: %v", finishErr)
+		logger.Errorf("could not clean up after failed backup upload: %v", finishErr)
 		return errors.Annotatef(err, "cannot upload backup file")
 	}
 	return c.restore(backupId, newClient)
@@ -140,14 +140,14 @@ func (c *Client) restore(backupId string, newClient ClientConnection) error {
 		}
 		if remoteError != nil || !isUpgradeInProgressErr(err) {
 			finishErr := finishRestore(newClient)
-			logger.Errorf("could not exit restoring status: %v", finishErr)
+			logger.Errorf("could not clean up after failed restore attempt: %v", finishErr)
 			return errors.Annotatef(err, "cannot perform restore: %v", remoteError)
 		}
 	}
 	if !cleanExit {
 		finishErr := finishRestore(newClient)
 		if finishErr != nil {
-			logger.Errorf("could not exit restoring status: %v", finishErr)
+			logger.Errorf("could not clean up failed restore: %v", finishErr)
 		}
 		return errors.Annotatef(err, "cannot perform restore: %v", remoteError)
 	}

--- a/cmd/juju/backups/export_test.go
+++ b/cmd/juju/backups/export_test.go
@@ -76,6 +76,9 @@ func NewRestoreCommandForTest(
 		getEnvironFunc: getEnviron,
 		newAPIClientFunc: func() (RestoreAPI, error) {
 			return api, nil
+		},
+		waitForAgentFunc: func(ctx *cmd.Context, c *modelcmd.ModelCommandBase, controllerName string) error {
+			return nil
 		}}
 	if getEnviron == nil {
 		c.getEnvironFunc = func(controllerNme string, meta *params.BackupsMetadataResult) (environs.Environ, error) {

--- a/cmd/juju/backups/restore.go
+++ b/cmd/juju/backups/restore.go
@@ -17,11 +17,13 @@ import (
 
 	"github.com/juju/juju/api/backups"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/juju/common"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/bootstrap"
 	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/jujuclient"
 )
 
 // NewRestoreCommand returns a command used to restore a backup.
@@ -32,6 +34,7 @@ func NewRestoreCommand() cmd.Command {
 		return restoreCmd.newClient()
 	}
 	restoreCmd.getArchiveFunc = getArchive
+	restoreCmd.waitForAgentFunc = common.WaitForAgentInitialisation
 	return modelcmd.Wrap(restoreCmd)
 }
 
@@ -48,6 +51,7 @@ type restoreCommand struct {
 	newAPIClientFunc func() (RestoreAPI, error)
 	getEnvironFunc   func(string, *params.BackupsMetadataResult) (environs.Environ, error)
 	getArchiveFunc   func(string) (ArchiveReader, *params.BackupsMetadataResult, error)
+	waitForAgentFunc func(ctx *cmd.Context, c *modelcmd.ModelCommandBase, controllerName string) error
 }
 
 // RestoreAPI is used to invoke various API calls.
@@ -145,6 +149,18 @@ func (c *restoreCommand) getEnviron(controllerName string, meta *params.BackupsM
 		return nil, errors.Trace(err)
 	}
 
+	// We may have previous controller metadata. We need to update that so it
+	// will contain the new CA Cert and UUID required to connect to the newly
+	// bootstrapped controller API.
+	details := jujuclient.ControllerDetails{
+		ControllerUUID: cfg.ControllerUUID(),
+		CACert:         meta.CACert,
+	}
+	err = store.UpdateController(controllerName, details)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
 	// Get the local admin user so we can use the password as the admin secret.
 	var adminSecret string
 	account, err := store.AccountByName(controllerName, environs.AdminUser)
@@ -216,7 +232,17 @@ func (c *restoreCommand) rebootstrap(ctx *cmd.Context, meta *params.BackupsMetad
 	if err := BootstrapFunc(modelcmd.BootstrapContext(ctx), env, args); err != nil {
 		return errors.Annotatef(err, "cannot bootstrap new instance")
 	}
-	return nil
+
+	// New controller is bootstrapped, so now record the API address so
+	// we can connect.
+	err = common.SetBootstrapEndpointAddress(c.ClientStore(), c.ControllerName(), env)
+	if err != nil {
+		errors.Trace(err)
+	}
+	// To avoid race conditions when running scripted bootstraps, wait
+	// for the controller's machine agent to be ready to accept commands
+	// before exiting this bootstrap command.
+	return c.waitForAgentFunc(ctx, &c.ModelCommandBase, c.ControllerName())
 }
 
 func (c *restoreCommand) newClient() (*backups.Client, error) {

--- a/cmd/juju/backups/restore_test.go
+++ b/cmd/juju/backups/restore_test.go
@@ -4,7 +4,6 @@
 package backups_test
 
 import (
-	"fmt"
 	"io"
 
 	"github.com/juju/errors"

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -5,10 +5,8 @@ package commands
 
 import (
 	"fmt"
-	"io"
 	"os"
 	"strings"
-	"time"
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
@@ -18,10 +16,7 @@ import (
 	"gopkg.in/juju/charm.v6-unstable"
 	"launchpad.net/gnuflag"
 
-	apiblock "github.com/juju/juju/api/block"
-	"github.com/juju/juju/apiserver/params"
 	jujucloud "github.com/juju/juju/cloud"
-	"github.com/juju/juju/cmd/juju/block"
 	"github.com/juju/juju/cmd/juju/common"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/constraints"
@@ -30,10 +25,8 @@ import (
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/feature"
 	"github.com/juju/juju/instance"
-	"github.com/juju/juju/juju"
 	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/jujuclient"
-	"github.com/juju/juju/network"
 	jujuversion "github.com/juju/juju/version"
 )
 
@@ -529,7 +522,7 @@ to clean up the model.`[1:])
 		return errors.Trace(err)
 	}
 
-	err = c.setBootstrapEndpointAddress(environ)
+	err = common.SetBootstrapEndpointAddress(c.ClientStore(), c.controllerName, environ)
 	if err != nil {
 		return errors.Annotate(err, "saving bootstrap endpoint address")
 	}
@@ -537,7 +530,7 @@ to clean up the model.`[1:])
 	// To avoid race conditions when running scripted bootstraps, wait
 	// for the controller's machine agent to be ready to accept commands
 	// before exiting this bootstrap command.
-	return c.waitForAgentInitialisation(ctx)
+	return common.WaitForAgentInitialisation(ctx, &c.ModelCommandBase, c.controllerName)
 }
 
 // getRegion returns the cloud.Region to use, based on the specified
@@ -586,80 +579,6 @@ func cloudRegionNames(cloud *jujucloud.Cloud) []string {
 	return regionNames
 }
 
-var (
-	bootstrapReadyPollDelay = 1 * time.Second
-	bootstrapReadyPollCount = 60
-	blockAPI                = getBlockAPI
-)
-
-// getBlockAPI returns a block api for listing blocks.
-func getBlockAPI(c *modelcmd.ModelCommandBase) (block.BlockListAPI, error) {
-	root, err := c.NewAPIRoot()
-	if err != nil {
-		return nil, err
-	}
-	return apiblock.NewClient(root), nil
-}
-
-// tryAPI attempts to open the API and makes a trivial call
-// to check if the API is available yet.
-func (c *bootstrapCommand) tryAPI() error {
-	client, err := blockAPI(&c.ModelCommandBase)
-	if err == nil {
-		_, err = client.List()
-		closeErr := client.Close()
-		if closeErr != nil {
-			logger.Debugf("Error closing client: %v", closeErr)
-		}
-	}
-	return err
-}
-
-// waitForAgentInitialisation polls the bootstrapped controller with a read-only
-// command which will fail until the controller is fully initialised.
-// TODO(wallyworld) - add a bespoke command to maybe the admin facade for this purpose.
-func (c *bootstrapCommand) waitForAgentInitialisation(ctx *cmd.Context) error {
-	attempts := utils.AttemptStrategy{
-		Min:   bootstrapReadyPollCount,
-		Delay: bootstrapReadyPollDelay,
-	}
-	var (
-		apiAttempts int
-		err         error
-	)
-
-	apiAttempts = 1
-	for attempt := attempts.Start(); attempt.Next(); apiAttempts++ {
-		err = c.tryAPI()
-		if err == nil {
-			ctx.Infof("Bootstrap complete, %s now available.", c.controllerName)
-			break
-		}
-		// As the API server is coming up, it goes through a number of steps.
-		// Initially the upgrade steps run, but the api server allows some
-		// calls to be processed during the upgrade, but not the list blocks.
-		// Logins are also blocked during space discovery.
-		// It is also possible that the underlying database causes connections
-		// to be dropped as it is initialising, or reconfiguring. These can
-		// lead to EOF or "connection is shut down" error messages. We skip
-		// these too, hoping that things come back up before the end of the
-		// retry poll count.
-		errorMessage := errors.Cause(err).Error()
-		switch {
-		case errors.Cause(err) == io.EOF,
-			strings.HasSuffix(errorMessage, "connection is shut down"),
-			strings.Contains(errorMessage, "spaces are still being discovered"):
-			ctx.Infof("Waiting for API to become available")
-			continue
-		case params.ErrCode(err) == params.CodeUpgradeInProgress:
-			ctx.Infof("Waiting for API to become available: %v", err)
-			continue
-		}
-		break
-	}
-	return errors.Annotatef(err, "unable to contact api server after %d attempts", apiAttempts)
-}
-
 // checkProviderType ensures the provider type is okay.
 func checkProviderType(envType string) error {
 	featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
@@ -685,38 +604,4 @@ func handleBootstrapError(ctx *cmd.Context, err error, cleanup func() error) {
 	if err := cleanup(); err != nil {
 		logger.Errorf("error cleaning up: %v", err)
 	}
-}
-
-var allInstances = func(environ environs.Environ) ([]instance.Instance, error) {
-	return environ.AllInstances()
-}
-
-// setBootstrapEndpointAddress writes the API endpoint address of the
-// bootstrap server into the connection information. This should only be run
-// once directly after Bootstrap. It assumes that there is just one instance
-// in the environment - the bootstrap instance.
-func (c *bootstrapCommand) setBootstrapEndpointAddress(environ environs.Environ) error {
-	instances, err := allInstances(environ)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	length := len(instances)
-	if length == 0 {
-		return errors.Errorf("found no instances, expected at least one")
-	}
-	if length > 1 {
-		logger.Warningf("expected one instance, got %d", length)
-	}
-	bootstrapInstance := instances[0]
-
-	// Don't use c.ConnectionEndpoint as it attempts to contact the state
-	// server if no addresses are found in connection info.
-	netAddrs, err := bootstrapInstance.Addresses()
-	if err != nil {
-		return errors.Annotate(err, "failed to get bootstrap instance addresses")
-	}
-	cfg := environ.Config()
-	apiPort := cfg.APIPort()
-	apiHostPorts := network.AddressesWithPort(netAddrs, apiPort)
-	return juju.UpdateControllerAddresses(c.ClientStore(), c.controllerName, nil, apiHostPorts...)
 }

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -233,8 +233,9 @@ var getBootstrapFuncs = func() BootstrapInterface {
 }
 
 var (
-	environsPrepare = environs.Prepare
-	environsDestroy = environs.Destroy
+	environsPrepare            = environs.Prepare
+	environsDestroy            = environs.Destroy
+	waitForAgentInitialisation = common.WaitForAgentInitialisation
 )
 
 var ambiguousCredentialError = errors.New(`
@@ -530,7 +531,7 @@ to clean up the model.`[1:])
 	// To avoid race conditions when running scripted bootstraps, wait
 	// for the controller's machine agent to be ready to accept commands
 	// before exiting this bootstrap command.
-	return common.WaitForAgentInitialisation(ctx, &c.ModelCommandBase, c.controllerName)
+	return waitForAgentInitialisation(ctx, &c.ModelCommandBase, c.controllerName)
 }
 
 // getRegion returns the cloud.Region to use, based on the specified

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -5,13 +5,11 @@ package commands
 
 import (
 	"fmt"
-	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
-	"time"
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
@@ -24,9 +22,7 @@ import (
 	"github.com/juju/version"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cloud"
-	"github.com/juju/juju/cmd/juju/block"
 	"github.com/juju/juju/cmd/modelcmd"
 	cmdtesting "github.com/juju/juju/cmd/testing"
 	"github.com/juju/juju/constraints"
@@ -49,7 +45,6 @@ import (
 	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/provider/dummy"
-	"github.com/juju/juju/rpc"
 	coretesting "github.com/juju/juju/testing"
 	coretools "github.com/juju/juju/tools"
 	jujuversion "github.com/juju/juju/version"
@@ -59,8 +54,7 @@ type BootstrapSuite struct {
 	coretesting.FakeJujuXDGDataHomeSuite
 	testing.MgoSuite
 	envtesting.ToolsFixture
-	mockBlockClient *mockBlockClient
-	store           *jujuclienttesting.MemStore
+	store *jujuclienttesting.MemStore
 }
 
 var _ = gc.Suite(&BootstrapSuite{})
@@ -101,18 +95,8 @@ func (s *BootstrapSuite) SetUpTest(c *gc.C) {
 
 	s.PatchValue(&envtools.BundleTools, toolstesting.GetMockBundleTools(c))
 
-	s.mockBlockClient = &mockBlockClient{}
-	s.PatchValue(&blockAPI, func(c *modelcmd.ModelCommandBase) (block.BlockListAPI, error) {
-		err := s.mockBlockClient.loginError
-		if err != nil {
-			s.mockBlockClient.loginError = nil
-			return nil, err
-		}
-		if s.mockBlockClient.discoveringSpacesError > 0 {
-			s.mockBlockClient.discoveringSpacesError -= 1
-			return nil, errors.New("spaces are still being discovered")
-		}
-		return s.mockBlockClient, nil
+	s.PatchValue(&waitForAgentInitialisation, func(*cmd.Context, *modelcmd.ModelCommandBase, string) error {
+		return nil
 	})
 
 	// TODO(wallyworld) - add test data when tests are improved
@@ -135,135 +119,6 @@ func (s *BootstrapSuite) newBootstrapCommand() cmd.Command {
 	c := &bootstrapCommand{}
 	c.SetClientStore(s.store)
 	return modelcmd.Wrap(c)
-}
-
-type mockBlockClient struct {
-	retryCount             int
-	numRetries             int
-	discoveringSpacesError int
-	loginError             error
-}
-
-var errOther = errors.New("other error")
-
-func (c *mockBlockClient) List() ([]params.Block, error) {
-	c.retryCount += 1
-	if c.retryCount == 5 {
-		return nil, &rpc.RequestError{Message: params.CodeUpgradeInProgress, Code: params.CodeUpgradeInProgress}
-	}
-	if c.numRetries < 0 {
-		return nil, errOther
-	}
-	if c.retryCount < c.numRetries {
-		return nil, &rpc.RequestError{Message: params.CodeUpgradeInProgress, Code: params.CodeUpgradeInProgress}
-	}
-	return []params.Block{}, nil
-}
-
-func (c *mockBlockClient) Close() error {
-	return nil
-}
-
-func (s *BootstrapSuite) TestBootstrapAPIReadyRetries(c *gc.C) {
-	s.PatchValue(&bootstrapReadyPollDelay, 1*time.Millisecond)
-	s.PatchValue(&bootstrapReadyPollCount, 5)
-	defaultSeriesVersion := jujuversion.Current
-	// Force a dev version by having a non zero build number.
-	// This is because we have not uploaded any tools and auto
-	// upload is only enabled for dev versions.
-	defaultSeriesVersion.Build = 1234
-	s.PatchValue(&jujuversion.Current, defaultSeriesVersion)
-	for _, t := range []struct {
-		numRetries int
-		err        error
-	}{
-		{0, nil}, // agent ready immediately
-		{2, nil}, // agent ready after 2 polls
-		{6, &rpc.RequestError{
-			Message: params.CodeUpgradeInProgress,
-			Code:    params.CodeUpgradeInProgress,
-		}}, // agent ready after 6 polls but that's too long
-		{-1, errOther}, // another error is returned
-	} {
-		resetJujuXDGDataHome(c)
-		dummy.Reset(c)
-		s.store = jujuclienttesting.NewMemStore()
-
-		s.mockBlockClient.numRetries = t.numRetries
-		s.mockBlockClient.retryCount = 0
-		_, err := coretesting.RunCommand(
-			c, s.newBootstrapCommand(),
-			"devcontroller", "dummy", "--auto-upgrade",
-		)
-		c.Check(errors.Cause(err), gc.DeepEquals, t.err)
-		expectedRetries := t.numRetries
-		if t.numRetries <= 0 {
-			expectedRetries = 1
-		}
-		// Only retry maximum of bootstrapReadyPollCount times.
-		if expectedRetries > 5 {
-			expectedRetries = 5
-		}
-		c.Check(s.mockBlockClient.retryCount, gc.Equals, expectedRetries)
-	}
-}
-
-func (s *BootstrapSuite) TestBootstrapAPIReadyWaitsForSpaceDiscovery(c *gc.C) {
-	s.PatchValue(&bootstrapReadyPollDelay, 1*time.Millisecond)
-	s.PatchValue(&bootstrapReadyPollCount, 5)
-	defaultSeriesVersion := jujuversion.Current
-	// Force a dev version by having a non zero build number.
-	// This is because we have not uploaded any tools and auto
-	// upload is only enabled for dev versions.
-	defaultSeriesVersion.Build = 1234
-	s.PatchValue(&jujuversion.Current, defaultSeriesVersion)
-	resetJujuXDGDataHome(c)
-
-	s.mockBlockClient.discoveringSpacesError = 2
-	_, err := coretesting.RunCommand(c, s.newBootstrapCommand(), "devcontroller", "dummy", "--auto-upgrade")
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(s.mockBlockClient.discoveringSpacesError, gc.Equals, 0)
-}
-
-func (s *BootstrapSuite) TestBootstrapAPIReadyRetriesWithOpenEOFErr(c *gc.C) {
-	s.PatchValue(&bootstrapReadyPollDelay, 1*time.Millisecond)
-	s.PatchValue(&bootstrapReadyPollCount, 5)
-	defaultSeriesVersion := jujuversion.Current
-	// Force a dev version by having a non zero build number.
-	// This is because we have not uploaded any tools and auto
-	// upload is only enabled for dev versions.
-	defaultSeriesVersion.Build = 1234
-	s.PatchValue(&jujuversion.Current, defaultSeriesVersion)
-	resetJujuXDGDataHome(c)
-
-	s.mockBlockClient.numRetries = 0
-	s.mockBlockClient.retryCount = 0
-	s.mockBlockClient.loginError = io.EOF
-	_, err := coretesting.RunCommand(c, s.newBootstrapCommand(), "devcontroller", "dummy", "--auto-upgrade")
-	c.Check(err, jc.ErrorIsNil)
-
-	c.Check(s.mockBlockClient.retryCount, gc.Equals, 1)
-}
-
-func (s *BootstrapSuite) TestBootstrapAPIReadyStopsRetriesWithOpenErr(c *gc.C) {
-	s.PatchValue(&bootstrapReadyPollDelay, 1*time.Millisecond)
-	s.PatchValue(&bootstrapReadyPollCount, 5)
-	defaultSeriesVersion := jujuversion.Current
-	// Force a dev version by having a non zero build number.
-	// This is because we have not uploaded any tools and auto
-	// upload is only enabled for dev versions.
-	defaultSeriesVersion.Build = 1234
-	s.PatchValue(&jujuversion.Current, defaultSeriesVersion)
-
-	resetJujuXDGDataHome(c)
-
-	s.mockBlockClient.numRetries = 0
-	s.mockBlockClient.retryCount = 0
-	s.mockBlockClient.loginError = errors.NewUnauthorized(nil, "")
-	_, err := coretesting.RunCommand(c, s.newBootstrapCommand(), "devcontroller", "dummy", "--auto-upgrade")
-	c.Check(err, jc.Satisfies, errors.IsUnauthorized)
-
-	c.Check(s.mockBlockClient.retryCount, gc.Equals, 0)
 }
 
 func (s *BootstrapSuite) TestRunTests(c *gc.C) {

--- a/cmd/juju/common/cloud.go
+++ b/cmd/juju/common/cloud.go
@@ -11,7 +11,7 @@ import (
 	"github.com/juju/juju/environs"
 )
 
-var logger = loggo.GetLogger("juju.cmd.juju.cloud")
+var logger = loggo.GetLogger("juju.cmd.juju.common")
 
 // CloudOrProvider finds and returns cloud or provider.
 func CloudOrProvider(cloudName string, cloudByNameFunc func(string) (*cloud.Cloud, error)) (cloud *cloud.Cloud, err error) {

--- a/cmd/juju/common/controller.go
+++ b/cmd/juju/common/controller.go
@@ -1,0 +1,132 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package common
+
+import (
+	"io"
+	"strings"
+	"time"
+
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+	"github.com/juju/utils"
+
+	apiblock "github.com/juju/juju/api/block"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/juju/block"
+	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/instance"
+	"github.com/juju/juju/juju"
+	"github.com/juju/juju/jujuclient"
+	"github.com/juju/juju/network"
+)
+
+var allInstances = func(environ environs.Environ) ([]instance.Instance, error) {
+	return environ.AllInstances()
+}
+
+// SetBootstrapEndpointAddress writes the API endpoint address of the
+// bootstrap server into the connection information. This should only be run
+// once directly after Bootstrap. It assumes that there is just one instance
+// in the environment - the bootstrap instance.
+func SetBootstrapEndpointAddress(store jujuclient.ControllerStore, controllerName string, environ environs.Environ) error {
+	instances, err := allInstances(environ)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	length := len(instances)
+	if length == 0 {
+		return errors.Errorf("found no instances, expected at least one")
+	}
+	if length > 1 {
+		logger.Warningf("expected one instance, got %d", length)
+	}
+	bootstrapInstance := instances[0]
+
+	// Don't use c.ConnectionEndpoint as it attempts to contact the state
+	// server if no addresses are found in connection info.
+	netAddrs, err := bootstrapInstance.Addresses()
+	if err != nil {
+		return errors.Annotate(err, "failed to get bootstrap instance addresses")
+	}
+	cfg := environ.Config()
+	apiPort := cfg.APIPort()
+	apiHostPorts := network.AddressesWithPort(netAddrs, apiPort)
+	return juju.UpdateControllerAddresses(store, controllerName, nil, apiHostPorts...)
+}
+
+var (
+	bootstrapReadyPollDelay = 1 * time.Second
+	bootstrapReadyPollCount = 60
+	blockAPI                = getBlockAPI
+)
+
+// getBlockAPI returns a block api for listing blocks.
+func getBlockAPI(c *modelcmd.ModelCommandBase) (block.BlockListAPI, error) {
+	root, err := c.NewAPIRoot()
+	if err != nil {
+		return nil, err
+	}
+	return apiblock.NewClient(root), nil
+}
+
+// tryAPI attempts to open the API and makes a trivial call
+// to check if the API is available yet.
+func tryAPI(c *modelcmd.ModelCommandBase) error {
+	client, err := blockAPI(c)
+	if err == nil {
+		_, err = client.List()
+		closeErr := client.Close()
+		if closeErr != nil {
+			logger.Debugf("Error closing client: %v", closeErr)
+		}
+	}
+	return err
+}
+
+// WaitForAgentInitialisation polls the bootstrapped controller with a read-only
+// command which will fail until the controller is fully initialised.
+// TODO(wallyworld) - add a bespoke command to maybe the admin facade for this purpose.
+func WaitForAgentInitialisation(ctx *cmd.Context, c *modelcmd.ModelCommandBase, controllerName string) error {
+	attempts := utils.AttemptStrategy{
+		Min:   bootstrapReadyPollCount,
+		Delay: bootstrapReadyPollDelay,
+	}
+	var (
+		apiAttempts int
+		err         error
+	)
+
+	apiAttempts = 1
+	for attempt := attempts.Start(); attempt.Next(); apiAttempts++ {
+		err = tryAPI(c)
+		if err == nil {
+			ctx.Infof("Bootstrap complete, %s now available.", controllerName)
+			break
+		}
+		// As the API server is coming up, it goes through a number of steps.
+		// Initially the upgrade steps run, but the api server allows some
+		// calls to be processed during the upgrade, but not the list blocks.
+		// Logins are also blocked during space discovery.
+		// It is also possible that the underlying database causes connections
+		// to be dropped as it is initialising, or reconfiguring. These can
+		// lead to EOF or "connection is shut down" error messages. We skip
+		// these too, hoping that things come back up before the end of the
+		// retry poll count.
+		errorMessage := errors.Cause(err).Error()
+		switch {
+		case errors.Cause(err) == io.EOF,
+			strings.HasSuffix(errorMessage, "connection is shut down"),
+			strings.Contains(errorMessage, "spaces are still being discovered"):
+			ctx.Infof("Waiting for API to become available")
+			continue
+		case params.ErrCode(err) == params.CodeUpgradeInProgress:
+			ctx.Infof("Waiting for API to become available: %v", err)
+			continue
+		}
+		break
+	}
+	return errors.Annotatef(err, "unable to contact api server after %d attempts", apiAttempts)
+}

--- a/cmd/juju/common/controller_test.go
+++ b/cmd/juju/common/controller_test.go
@@ -1,0 +1,135 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package common
+
+import (
+	"io"
+	"time"
+
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/juju/block"
+	"github.com/juju/juju/cmd/modelcmd"
+	cmdtesting "github.com/juju/juju/cmd/testing"
+	"github.com/juju/juju/rpc"
+	"github.com/juju/juju/testing"
+	"github.com/juju/juju/version"
+)
+
+var _ = gc.Suite(&controllerSuite{})
+
+type controllerSuite struct {
+	testing.BaseSuite
+	mockBlockClient *mockBlockClient
+}
+
+func (s *controllerSuite) SetUpTest(c *gc.C) {
+	s.mockBlockClient = &mockBlockClient{}
+	s.PatchValue(&blockAPI, func(*modelcmd.ModelCommandBase) (block.BlockListAPI, error) {
+		err := s.mockBlockClient.loginError
+		if err != nil {
+			s.mockBlockClient.loginError = nil
+			return nil, err
+		}
+		if s.mockBlockClient.discoveringSpacesError > 0 {
+			s.mockBlockClient.discoveringSpacesError -= 1
+			return nil, errors.New("spaces are still being discovered")
+		}
+		return s.mockBlockClient, nil
+	})
+}
+
+type mockBlockClient struct {
+	retryCount             int
+	numRetries             int
+	discoveringSpacesError int
+	loginError             error
+}
+
+var errOther = errors.New("other error")
+
+func (c *mockBlockClient) List() ([]params.Block, error) {
+	c.retryCount += 1
+	if c.retryCount == 5 {
+		return nil, &rpc.RequestError{Message: params.CodeUpgradeInProgress, Code: params.CodeUpgradeInProgress}
+	}
+	if c.numRetries < 0 {
+		return nil, errOther
+	}
+	if c.retryCount < c.numRetries {
+		return nil, &rpc.RequestError{Message: params.CodeUpgradeInProgress, Code: params.CodeUpgradeInProgress}
+	}
+	return []params.Block{}, nil
+}
+
+func (c *mockBlockClient) Close() error {
+	return nil
+}
+
+func (s *controllerSuite) TestWaitForAgentAPIReadyRetries(c *gc.C) {
+	s.PatchValue(&bootstrapReadyPollDelay, 1*time.Millisecond)
+	s.PatchValue(&bootstrapReadyPollCount, 5)
+	defaultSeriesVersion := version.Current
+	// Force a dev version by having a non zero build number.
+	// This is because we have not uploaded any tools and auto
+	// upload is only enabled for dev versions.
+	defaultSeriesVersion.Build = 1234
+	s.PatchValue(&version.Current, defaultSeriesVersion)
+	for _, t := range []struct {
+		numRetries int
+		err        error
+	}{
+		{0, nil}, // agent ready immediately
+		{2, nil}, // agent ready after 2 polls
+		{6, &rpc.RequestError{
+			Message: params.CodeUpgradeInProgress,
+			Code:    params.CodeUpgradeInProgress,
+		}}, // agent ready after 6 polls but that's too long
+		{-1, errOther}, // another error is returned
+	} {
+		s.mockBlockClient.numRetries = t.numRetries
+		s.mockBlockClient.retryCount = 0
+		err := WaitForAgentInitialisation(cmdtesting.NullContext(c), nil, "controller")
+		c.Check(errors.Cause(err), gc.DeepEquals, t.err)
+		expectedRetries := t.numRetries
+		if t.numRetries <= 0 {
+			expectedRetries = 1
+		}
+		// Only retry maximum of bootstrapReadyPollCount times.
+		if expectedRetries > 5 {
+			expectedRetries = 5
+		}
+		c.Check(s.mockBlockClient.retryCount, gc.Equals, expectedRetries)
+	}
+}
+
+func (s *controllerSuite) TestWaitForAgentAPIReadyWaitsForSpaceDiscovery(c *gc.C) {
+	s.mockBlockClient.discoveringSpacesError = 2
+	err := WaitForAgentInitialisation(cmdtesting.NullContext(c), nil, "controller")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s.mockBlockClient.discoveringSpacesError, gc.Equals, 0)
+}
+
+func (s *controllerSuite) TestWaitForAgentAPIReadyRetriesWithOpenEOFErr(c *gc.C) {
+	s.mockBlockClient.numRetries = 0
+	s.mockBlockClient.retryCount = 0
+	s.mockBlockClient.loginError = io.EOF
+	err := WaitForAgentInitialisation(cmdtesting.NullContext(c), nil, "controller")
+	c.Check(err, jc.ErrorIsNil)
+
+	c.Check(s.mockBlockClient.retryCount, gc.Equals, 1)
+}
+
+func (s *controllerSuite) TestWaitForAgentAPIReadyStopsRetriesWithOpenErr(c *gc.C) {
+	s.mockBlockClient.numRetries = 0
+	s.mockBlockClient.retryCount = 0
+	s.mockBlockClient.loginError = errors.NewUnauthorized(nil, "")
+	err := WaitForAgentInitialisation(cmdtesting.NullContext(c), nil, "controller")
+	c.Check(err, jc.Satisfies, errors.IsUnauthorized)
+
+	c.Check(s.mockBlockClient.retryCount, gc.Equals, 0)
+}

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -575,11 +575,11 @@ func (a *MachineAgent) newRestoreStateWatcherWorker(st *state.State) (worker.Wor
 // restoreChanged will be called whenever restoreInfo doc changes signaling a new
 // step in the restore process.
 func (a *MachineAgent) restoreChanged(st *state.State) error {
-	rinfo, err := st.RestoreInfoSetter()
+	status, err := st.RestoreInfo().Status()
 	if err != nil {
 		return errors.Annotate(err, "cannot read restore state")
 	}
-	switch rinfo.Status() {
+	switch status {
 	case state.RestorePending:
 		a.PrepareRestore()
 	case state.RestoreInProgress:

--- a/state/backups/backups_linux.go
+++ b/state/backups/backups_linux.go
@@ -197,18 +197,17 @@ func (b *backups) Restore(backupId string, args RestoreArgs) (names.Tag, error) 
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	if err = updateAllMachines(args.PrivateAddress, machines); err != nil {
+	if err := updateAllMachines(args.PrivateAddress, machines); err != nil {
 		return nil, errors.Annotate(err, "cannot update agents")
-	}
-
-	info, err := st.RestoreInfoSetter()
-	if err != nil {
-		return nil, errors.Trace(err)
 	}
 
 	// Mark restoreInfo as Finished so upon restart of the apiserver
 	// the client can reconnect and determine if we where succesful.
+	info := st.RestoreInfo()
 	err = info.SetStatus(state.RestoreFinished)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 
 	return backupMachine, errors.Annotate(err, "failed to set status to finished")
 }

--- a/state/restore_test.go
+++ b/state/restore_test.go
@@ -4,15 +4,14 @@
 package state_test
 
 import (
-	"sync"
-	"time"
+	"fmt"
 
 	jc "github.com/juju/testing/checkers"
+	jujutxn "github.com/juju/txn"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/state"
 	statetesting "github.com/juju/juju/state/testing"
-	coretesting "github.com/juju/juju/testing"
 )
 
 // RestoreInfoSuite is *tremendously* incomplete: this test exists purely to
@@ -25,45 +24,320 @@ import (
 // consistent with the other state code, but that's not for today.
 type RestoreInfoSuite struct {
 	statetesting.StateSuite
+	info *state.RestoreInfo
 }
 
 var _ = gc.Suite(&RestoreInfoSuite{})
 
-func (s *RestoreInfoSuite) TestGetSetter(c *gc.C) {
-	setter, err := s.State.RestoreInfoSetter()
-	c.Assert(err, jc.ErrorIsNil)
-	checkStatus(c, setter, state.UnknownRestoreStatus)
+func (s *RestoreInfoSuite) SetUpTest(c *gc.C) {
+	s.StateSuite.SetUpTest(c)
+	s.info = s.State.RestoreInfo()
 }
 
-func (s *RestoreInfoSuite) TestGetSetterRace(c *gc.C) {
-	trigger := make(chan struct{})
-	test := func() {
-		select {
-		case <-trigger:
-			setter, err := s.State.RestoreInfoSetter()
-			if c.Check(err, jc.ErrorIsNil) {
-				checkStatus(c, setter, state.UnknownRestoreStatus)
-			}
-		case <-time.After(coretesting.LongWait):
-			c.Errorf("test invoked but not triggered")
-		}
-	}
-
-	const count = 100
-	wg := sync.WaitGroup{}
-	wg.Add(count)
-	for i := 0; i < count; i++ {
-		go func() {
-			defer wg.Done()
-			test()
-		}()
-	}
-	close(trigger)
-	wg.Wait()
+func (s *RestoreInfoSuite) TestStartsNotActive(c *gc.C) {
+	s.checkStatus(c, state.RestoreNotActive)
 }
 
-func checkStatus(c *gc.C, setter *state.RestoreInfo, status state.RestoreStatus) {
-	if c.Check(setter, gc.NotNil) {
-		c.Check(setter.Status(), gc.Equals, status)
+func (s *RestoreInfoSuite) TestSetBadStatus(c *gc.C) {
+	err := s.info.SetStatus(state.RestoreStatus("LOLLYGAGGING"))
+	c.Check(err, gc.ErrorMatches, "unknown restore status: LOLLYGAGGING")
+	s.checkStatus(c, state.RestoreNotActive)
+}
+
+//--------------------------------------
+// Whitebox race tests to trigger different paths through the SetStatus
+// code; use arbitrary sample transitions, full set of valid transitions
+// are checked further down.
+func (s *RestoreInfoSuite) TestInsertRaceHarmless(c *gc.C) {
+	defer state.SetBeforeHooks(
+		c, s.State, func() {
+			s.checkSetStatus(c, state.RestorePending)
+		},
+	).Check()
+	s.checkSetStatus(c, state.RestorePending)
+}
+
+func (s *RestoreInfoSuite) TestInsertRaceFailure(c *gc.C) {
+	defer state.SetBeforeHooks(
+		c, s.State, func() {
+			s.checkSetStatus(c, state.RestorePending)
+			s.checkSetStatus(c, state.RestoreInProgress)
+		},
+	).Check()
+	s.checkBadSetStatus(c, state.RestorePending)
+	s.checkStatus(c, state.RestoreInProgress)
+}
+
+func (s *RestoreInfoSuite) TestUpdateRaceHarmless(c *gc.C) {
+	s.setupInProgress(c)
+	defer state.SetBeforeHooks(
+		c, s.State, func() {
+			s.checkSetStatus(c, state.RestoreFinished)
+		},
+	).Check()
+	s.checkSetStatus(c, state.RestoreFinished)
+}
+
+func (s *RestoreInfoSuite) TestUpdateRaceFailure(c *gc.C) {
+	s.setupInProgress(c)
+	defer state.SetBeforeHooks(
+		c, s.State, func() {
+			s.checkSetStatus(c, state.RestoreFailed)
+		},
+	).Check()
+	s.checkBadSetStatus(c, state.RestoreFinished)
+	s.checkStatus(c, state.RestoreFailed)
+}
+
+func (s *RestoreInfoSuite) TestUpdateRaceExhaustion(c *gc.C) {
+	s.setupPending(c)
+	perturb := jujutxn.TestHook{
+		Before: func() {
+			s.checkSetStatus(c, state.RestoreFailed)
+		},
+		After: func() {
+			s.checkSetStatus(c, state.RestorePending)
+		},
 	}
+	defer state.SetTestHooks(
+		c, s.State,
+		perturb,
+		perturb,
+		perturb,
+	).Check()
+	err := s.info.SetStatus(state.RestoreInProgress)
+	c.Check(err, gc.ErrorMatches, "state changing too quickly; try again soon")
+}
+
+//--------------------------------------
+// Test NotActive -> ? transitions
+func (s *RestoreInfoSuite) TestNotActiveSetNotActive(c *gc.C) {
+	s.checkSetStatus(c, state.RestoreNotActive)
+}
+
+func (s *RestoreInfoSuite) TestNotActiveSetPending(c *gc.C) {
+	s.checkSetStatus(c, state.RestorePending)
+}
+
+func (s *RestoreInfoSuite) TestNotActiveSetInProgress(c *gc.C) {
+	s.checkBadSetStatus(c, state.RestoreFinished)
+}
+
+func (s *RestoreInfoSuite) TestNotActiveSetFinished(c *gc.C) {
+	s.checkBadSetStatus(c, state.RestoreFinished)
+}
+
+func (s *RestoreInfoSuite) TestNotActiveSetChecked(c *gc.C) {
+	s.checkBadSetStatus(c, state.RestoreChecked)
+}
+
+func (s *RestoreInfoSuite) TestNotActiveSetFailed(c *gc.C) {
+	s.checkBadSetStatus(c, state.RestoreFailed)
+}
+
+//--------------------------------------
+// Test Pending -> ? transitions
+func (s *RestoreInfoSuite) setupPending(c *gc.C) {
+	s.checkSetStatus(c, state.RestorePending)
+}
+
+func (s *RestoreInfoSuite) TestPendingSetNotActive(c *gc.C) {
+	s.setupPending(c)
+	s.checkBadSetStatus(c, state.RestoreNotActive)
+}
+
+func (s *RestoreInfoSuite) TestPendingSetPending(c *gc.C) {
+	s.setupPending(c)
+	s.checkSetStatus(c, state.RestorePending)
+}
+
+func (s *RestoreInfoSuite) TestPendingSetInProgress(c *gc.C) {
+	s.setupPending(c)
+	s.checkSetStatus(c, state.RestoreInProgress)
+}
+
+func (s *RestoreInfoSuite) TestPendingSetFinished(c *gc.C) {
+	s.setupPending(c)
+	s.checkBadSetStatus(c, state.RestoreFinished)
+}
+
+func (s *RestoreInfoSuite) TestPendingSetChecked(c *gc.C) {
+	s.setupPending(c)
+	s.checkBadSetStatus(c, state.RestoreChecked)
+}
+
+func (s *RestoreInfoSuite) TestPendingSetFailed(c *gc.C) {
+	s.setupPending(c)
+	s.checkSetStatus(c, state.RestoreFailed)
+}
+
+//--------------------------------------
+// Test InProgress -> ? transitions
+func (s *RestoreInfoSuite) setupInProgress(c *gc.C) {
+	s.checkSetStatus(c, state.RestorePending)
+	s.checkSetStatus(c, state.RestoreInProgress)
+}
+
+func (s *RestoreInfoSuite) TestInProgressSetNotActive(c *gc.C) {
+	s.setupInProgress(c)
+	s.checkBadSetStatus(c, state.RestoreNotActive)
+}
+
+func (s *RestoreInfoSuite) TestInProgressSetPending(c *gc.C) {
+	s.setupInProgress(c)
+	s.checkBadSetStatus(c, state.RestorePending)
+}
+
+func (s *RestoreInfoSuite) TestInProgressSetInProgress(c *gc.C) {
+	s.setupInProgress(c)
+	s.checkSetStatus(c, state.RestoreInProgress)
+}
+
+func (s *RestoreInfoSuite) TestInProgressSetFinished(c *gc.C) {
+	s.setupInProgress(c)
+	s.checkSetStatus(c, state.RestoreFinished)
+}
+
+func (s *RestoreInfoSuite) TestInProgressSetChecked(c *gc.C) {
+	s.setupInProgress(c)
+	s.checkBadSetStatus(c, state.RestoreChecked)
+}
+
+func (s *RestoreInfoSuite) TestInProgressSetFailed(c *gc.C) {
+	s.setupInProgress(c)
+	s.checkSetStatus(c, state.RestoreFailed)
+}
+
+//--------------------------------------
+// Test Finished -> ? transitions
+func (s *RestoreInfoSuite) setupFinished(c *gc.C) {
+	s.checkSetStatus(c, state.RestorePending)
+	s.checkSetStatus(c, state.RestoreInProgress)
+	s.checkSetStatus(c, state.RestoreFinished)
+}
+
+func (s *RestoreInfoSuite) TestFinishedSetNotActive(c *gc.C) {
+	s.setupFinished(c)
+	s.checkBadSetStatus(c, state.RestoreNotActive)
+}
+
+func (s *RestoreInfoSuite) TestFinishedSetPending(c *gc.C) {
+	s.setupFinished(c)
+	s.checkBadSetStatus(c, state.RestorePending)
+}
+
+func (s *RestoreInfoSuite) TestFinishedSetInProgress(c *gc.C) {
+	s.setupFinished(c)
+	s.checkBadSetStatus(c, state.RestoreInProgress)
+}
+
+func (s *RestoreInfoSuite) TestFinishedSetFinished(c *gc.C) {
+	s.setupFinished(c)
+	s.checkSetStatus(c, state.RestoreFinished)
+}
+
+func (s *RestoreInfoSuite) TestFinishedSetChecked(c *gc.C) {
+	s.setupFinished(c)
+	s.checkSetStatus(c, state.RestoreChecked)
+}
+
+func (s *RestoreInfoSuite) TestFinishedSetFailed(c *gc.C) {
+	s.setupFinished(c)
+	s.checkSetStatus(c, state.RestoreFailed)
+}
+
+//--------------------------------------
+// Test Checked -> ? transitions
+func (s *RestoreInfoSuite) setupChecked(c *gc.C) {
+	s.checkSetStatus(c, state.RestorePending)
+	s.checkSetStatus(c, state.RestoreInProgress)
+	s.checkSetStatus(c, state.RestoreFinished)
+	s.checkSetStatus(c, state.RestoreChecked)
+}
+
+func (s *RestoreInfoSuite) TestCheckedSetNotActive(c *gc.C) {
+	s.setupChecked(c)
+	s.checkBadSetStatus(c, state.RestoreNotActive)
+}
+
+func (s *RestoreInfoSuite) TestCheckedSetPending(c *gc.C) {
+	s.setupChecked(c)
+	s.checkSetStatus(c, state.RestorePending)
+}
+
+func (s *RestoreInfoSuite) TestCheckedSetInProgress(c *gc.C) {
+	s.setupChecked(c)
+	s.checkBadSetStatus(c, state.RestoreInProgress)
+}
+
+func (s *RestoreInfoSuite) TestCheckedSetFinished(c *gc.C) {
+	s.setupChecked(c)
+	s.checkBadSetStatus(c, state.RestoreFinished)
+}
+
+func (s *RestoreInfoSuite) TestCheckedSetChecked(c *gc.C) {
+	s.setupChecked(c)
+	s.checkSetStatus(c, state.RestoreChecked)
+}
+
+func (s *RestoreInfoSuite) TestCheckedSetFailed(c *gc.C) {
+	s.setupChecked(c)
+	s.checkBadSetStatus(c, state.RestoreFailed)
+}
+
+//--------------------------------------
+// Test Failed -> ? transitions
+func (s *RestoreInfoSuite) setupFailed(c *gc.C) {
+	s.checkSetStatus(c, state.RestorePending)
+	s.checkSetStatus(c, state.RestoreFailed)
+}
+
+func (s *RestoreInfoSuite) TestFailedSetNotActive(c *gc.C) {
+	s.setupFailed(c)
+	s.checkBadSetStatus(c, state.RestoreNotActive)
+}
+
+func (s *RestoreInfoSuite) TestFailedSetPending(c *gc.C) {
+	s.setupFailed(c)
+	s.checkSetStatus(c, state.RestorePending)
+}
+
+func (s *RestoreInfoSuite) TestFailedSetInProgress(c *gc.C) {
+	s.setupFailed(c)
+	s.checkBadSetStatus(c, state.RestoreInProgress)
+}
+
+func (s *RestoreInfoSuite) TestFailedSetFinished(c *gc.C) {
+	s.setupFailed(c)
+	s.checkBadSetStatus(c, state.RestoreFinished)
+}
+
+func (s *RestoreInfoSuite) TestFailedSetChecked(c *gc.C) {
+	s.setupFailed(c)
+	s.checkBadSetStatus(c, state.RestoreChecked)
+}
+
+func (s *RestoreInfoSuite) TestFailedSetFailed(c *gc.C) {
+	s.setupFailed(c)
+	s.checkSetStatus(c, state.RestoreFailed)
+}
+
+//--------------------
+
+func (s *RestoreInfoSuite) checkStatus(c *gc.C, expect state.RestoreStatus) {
+	actual, err := s.info.Status()
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(actual, gc.Equals, expect)
+}
+
+func (s *RestoreInfoSuite) checkSetStatus(c *gc.C, status state.RestoreStatus) {
+	err := s.info.SetStatus(status)
+	c.Check(err, jc.ErrorIsNil)
+	s.checkStatus(c, status)
+}
+
+func (s *RestoreInfoSuite) checkBadSetStatus(c *gc.C, status state.RestoreStatus) {
+	err := s.info.SetStatus(status)
+	expect := fmt.Sprintf("invalid restore transition: [-A-Z]+ => %s", status)
+	c.Check(err, gc.ErrorMatches, expect)
 }


### PR DESCRIPTION
Fixes: https://launchpad.net/bugs/1569467

William fixed the restore status update issue. Restore bootstrap still did not complete. The restore was not writing out the new controller addresses nor ca cert so the client could not connect.

The code to do the above is moved from bootstrap.go to cmd/juju/common so it can be shared between bootstrap and restore.

Tested with lxd provided. Worked once and then a second time the jujud machine agent needed to be restarted by hand before clients could connect. Appears unrelated to restore. A followup can be done to fix any remaining issue found by CI. This fix at the least is a step in the right direction.

(Review request: http://reviews.vapour.ws/r/4720/)