### PR TITLE
1575332: Add add-cloud to juju help page

### DIFF
--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -78,6 +78,7 @@ See https://jujucharms.com/docs/stable/help for documentation.
 
 Common commands:
 
+    add-cloud           Adds a user-defined cloud to Juju.
     add-credential      Adds or replaces credentials for a cloud.
     add-relation        Adds a relation between two services.
     add-unit            Adds extra units of a deployed service.


### PR DESCRIPTION
I shortened the description from the actual
add-cloud command so that juju help did not
wrap for a terminal width of 80 characters.

(Review request: http://reviews.vapour.ws/r/4721/)