### PR TITLE
Setup Go 1.6 and LXD 2.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ ifeq ($(shell ifconfig lxdbr0 | grep -q "inet addr" && echo true),true)
 	@echo run "sudo scripts/setup-lxd.sh" to reconfigure IPv4 networking
 else
 	@echo Setting up IPv4 networking for LXD
-	@sudo scripts/setup-lxd.sh
+	@sudo scripts/setup-lxd.sh || true
 endif
 
 

--- a/scripts/setup-lxd.sh
+++ b/scripts/setup-lxd.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+set -ex
+
+# Do the manual steps a user has to run on a fresh system to get an lxd
+# bridge so the juju lxd provider can function. Taken from changes made
+# to cloud-init to do approximately this.
+
+debconf-communicate << EOF
+set lxd/setup-bridge true
+set lxd/bridge-domain lxd
+set lxd/bridge-name lxdbr0
+set lxd/bridge-ipv4 true
+set lxd/bridge-ipv4-address 10.0.8.1
+set lxd/bridge-ipv4-dhcp-first 10.0.8.2
+set lxd/bridge-ipv4-dhcp-last 10.0.8.254
+set lxd/bridge-ipv4-dhcp-leases 252
+set lxd/bridge-ipv4-netmask 24
+set lxd/bridge-ipv4-nat true
+set lxd/bridge-ipv6 false
+EOF
+
+rm -rf /etc/default/lxd-bridge
+
+dpkg-reconfigure lxd --frontend=noninteractive
+
+# Must run a command for systemd socket activation to start the service
+lxc finger


### PR DESCRIPTION
This branch address several problems running the test suite caused by a stale Makefile.
the landing bot cannot use xenial +LXD or trusty + golang 1.6 because the Makefile
targets do not support recent series and golangs.

1. make install-dependencies installs the wrong dependencies for most series and archs.
  * Updated the archs to match those supported by golang 1.6
  * Install golang-1.6 or higher. MHD's golang packages  point golang to a specific
    version like golang-1.6. There is only ever one golang package in an archive,
    and it may point to an older Go. We need to be clear that we require golang-1.6
    (This will last a few years. Maybe we only 1.6 and nothing higher)
  * Juju2 doesn't use juju-local.
  * wily is officially old because it needs to get its golang-1.6 from our PPA

2. LXD does not "just work" with juju. It needs to be configured with IPv4.
  * The new script was written by mgz for the juju dep8 package tests. This script
    is proven to setup LXD for Juju in a non-interactive terminal
  * The new makefile target will only execute setup-lxd.sh when the lxdbr0 bridge
    does not have IPv4 addresses. It is safe to run the target repeatedly. Developers
    who want to reconfigure a lxdbr0 that already supports IPv4 can run the script
    directly.

Once Makefile supports LXD and golang 1.6 the merge bot can be switched to xenial
and several hacks can be removed to test arm64, s390x, and ppc64el.

(Review request: http://reviews.vapour.ws/r/4726/)