### PR TITLE
Bump gomaasapi version

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -19,7 +19,7 @@ github.com/juju/go4	git	40d72ab9641a2a8c36a9c46a51e28367115c8e59	2016-02-22T16:3
 github.com/juju/gojsonpointer	git	afe8b77aa08f272b49e01b82de78510c11f61500	2015-02-04T19:46:29Z
 github.com/juju/gojsonreference	git	f0d24ac5ee330baa21721cdff56d45e4ee42628e	2015-02-04T19:46:33Z
 github.com/juju/gojsonschema	git	e1ad140384f254c82f89450d9a7c8dd38a632838	2015-03-12T17:00:16Z
-github.com/juju/gomaasapi	git	794d847890fea70f4a70be8f9fe5b12e2131824d	2016-04-27T11:49:24Z
+github.com/juju/gomaasapi	git	c1d81f9088b82ff02a590d9525c6d3250e9bb562	2016-04-28T08:35:23Z
 github.com/juju/govmomi	git	4354a88d4b34abe467215f77c2fc1cb9f78b66f7	2015-04-24T01:54:48Z
 github.com/juju/httpprof	git	14bf14c307672fd2456bdbf35d19cf0ccd3cf565	2014-12-17T16:00:36Z
 github.com/juju/httprequest	git	89d547093c45e293599088cc63e805c6f1205dc0	2016-03-02T10:09:58Z


### PR DESCRIPTION
Update to a version of gomaasapi that makes kflavor optional in the MAAS2 schema. 

Fixes: https://bugs.launchpad.net/juju-core/+bug/1575768

(Review request: http://reviews.vapour.ws/r/4727/)