### PR TITLE
commands/switch: Fixed an issue where unknown controllers were being reported as empty controller names

### DIFF
--- a/cmd/juju/commands/switch.go
+++ b/cmd/juju/commands/switch.go
@@ -139,11 +139,10 @@ func (c *switchCommand) Run(ctx *cmd.Context) (resultErr error) {
 	if newControllerName != "" {
 		// A controller was specified so see if we should use a local version.
 		newControllerName, err = modelcmd.ResolveControllerName(c.Store, newControllerName)
-		if err == nil {
-			newName = modelcmd.JoinModelName(newControllerName, modelName)
-		} else {
-			newName = c.Target
+		if err != nil {
+			return errors.Trace(err)
 		}
+		newName = modelcmd.JoinModelName(newControllerName, modelName)
 	} else {
 		if currentControllerName == "" {
 			return unknownSwitchTargetError(c.Target)

--- a/cmd/juju/commands/switch_test.go
+++ b/cmd/juju/commands/switch_test.go
@@ -82,6 +82,13 @@ func (s *SwitchSimpleSuite) TestNoArgsCurrentController(c *gc.C) {
 	c.Assert(coretesting.Stdout(ctx), gc.Equals, "a-controller\n")
 }
 
+func (s *SwitchSimpleSuite) TestUnknownControllerNameReturnsError(c *gc.C) {
+	s.addController(c, "a-controller")
+	s.currentController = "a-controller"
+	_, err := s.run(c, "another-controller:modela")
+	c.Assert(err, gc.ErrorMatches, "controller another-controller not found")
+}
+
 func (s *SwitchSimpleSuite) TestNoArgsCurrentModel(c *gc.C) {
 	s.addController(c, "a-controller")
 	s.currentController = "a-controller"

--- a/juju/api.go
+++ b/juju/api.go
@@ -141,7 +141,7 @@ func newAPIFromStore(args NewAPIConnectionParams, apiOpen api.OpenFunc) (api.Con
 				args.ModelUUID, apiOpen,
 				stop, delay, args.DialOpts,
 			)
-			if err != nil {
+			if err != nil && errors.Cause(err) != errAborted {
 				// Errors are swallowed by parallel.Try, so we
 				// log the failure here to aid in debugging.
 				logger.Debugf("failed to connect via bootstrap config: %v", err)


### PR DESCRIPTION
Fix for https://bugs.launchpad.net/juju-core/+bug/1575760

Also: Don't log api connection error if the error was aborted as this causes confusion in the log file

(Review request: http://reviews.vapour.ws/r/4729/)