### PR TITLE
Fixed lp:1321442: Support non-default VPC for AWS

### DIFF
--- a/controller/modelmanager/createmodel_test.go
+++ b/controller/modelmanager/createmodel_test.go
@@ -314,7 +314,7 @@ func (*RestrictedProviderFieldsSuite) TestRestrictedProviderFields(c *gc.C) {
 		provider: "ec2",
 		expected: []string{
 			"type", "ca-cert", "state-port", "api-port", "controller-uuid",
-			"region",
+			"region", "vpc-id", "vpc-id-force",
 		},
 	}} {
 		c.Logf("%d: %s provider", i, test.provider)

--- a/provider/ec2/config.go
+++ b/provider/ec2/config.go
@@ -5,6 +5,7 @@ package ec2
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/juju/schema"
 	"gopkg.in/amz.v3/aws"
@@ -33,6 +34,19 @@ var configSchema = environschema.Fields{
 		Description: "The EC2 region to use",
 		Type:        environschema.Tstring,
 	},
+	"vpc-id": {
+		Description: "Use a specific AWS VPC ID (optional). When not specified, Juju requires a default VPC to exist the chosen EC2 account/region.",
+		Example:     "vpc-a1b2c3d4",
+		Type:        environschema.Tstring,
+		Group:       environschema.AccountGroup,
+		Immutable:   true,
+	},
+	"force-vpc-id": {
+		Description: "Force Juju to use the AWS VPC ID specified with vpc-id, when it fails the minimum validation criteria. Not accepted without vpc-id",
+		Type:        environschema.Tbool,
+		Group:       environschema.AccountGroup,
+		Immutable:   true,
+	},
 }
 
 var configFields = func() schema.Fields {
@@ -44,9 +58,11 @@ var configFields = func() schema.Fields {
 }()
 
 var configDefaults = schema.Defaults{
-	"access-key": "",
-	"secret-key": "",
-	"region":     "us-east-1",
+	"access-key":   "",
+	"secret-key":   "",
+	"region":       "us-east-1",
+	"vpc-id":       "",
+	"force-vpc-id": false,
 }
 
 type environConfig struct {
@@ -64,6 +80,14 @@ func (c *environConfig) accessKey() string {
 
 func (c *environConfig) secretKey() string {
 	return c.attrs["secret-key"].(string)
+}
+
+func (c *environConfig) vpcID() string {
+	return c.attrs["vpc-id"].(string)
+}
+
+func (c *environConfig) forceVPCID() bool {
+	return c.attrs["force-vpc-id"].(bool)
 }
 
 func (p environProvider) newConfig(cfg *config.Config) (*environConfig, error) {
@@ -102,14 +126,29 @@ func validateConfig(cfg, old *config.Config) (*environConfig, error) {
 		ecfg.attrs["access-key"] = auth.AccessKey
 		ecfg.attrs["secret-key"] = auth.SecretKey
 	}
+
 	if _, ok := aws.Regions[ecfg.region()]; !ok {
 		return nil, fmt.Errorf("invalid region name %q", ecfg.region())
+	}
+
+	if vpcID := ecfg.vpcID(); vpcID != "" && !strings.HasPrefix(vpcID, "vpc-") {
+		return nil, fmt.Errorf("vpc-id: %q is not a valid AWS VPC ID", vpcID)
+	} else if vpcID == "" && ecfg.forceVPCID() {
+		return nil, fmt.Errorf("cannot use force-vpc-id without specifying vpc-id as well")
 	}
 
 	if old != nil {
 		attrs := old.UnknownAttrs()
 		if region, _ := attrs["region"].(string); ecfg.region() != region {
 			return nil, fmt.Errorf("cannot change region from %q to %q", region, ecfg.region())
+		}
+
+		if vpcID, _ := attrs["vpc-id"].(string); vpcID != ecfg.vpcID() {
+			return nil, fmt.Errorf("cannot change vpc-id from %q to %q", vpcID, ecfg.vpcID())
+		}
+
+		if forceVPCID, _ := attrs["force-vpc-id"].(bool); forceVPCID != ecfg.forceVPCID() {
+			return nil, fmt.Errorf("cannot change force-vpc-id from %v to %v", forceVPCID, ecfg.forceVPCID())
 		}
 	}
 

--- a/provider/ec2/config.go
+++ b/provider/ec2/config.go
@@ -41,7 +41,7 @@ var configSchema = environschema.Fields{
 		Group:       environschema.AccountGroup,
 		Immutable:   true,
 	},
-	"force-vpc-id": {
+	"vpc-id-force": {
 		Description: "Force Juju to use the AWS VPC ID specified with vpc-id, when it fails the minimum validation criteria. Not accepted without vpc-id",
 		Type:        environschema.Tbool,
 		Group:       environschema.AccountGroup,
@@ -62,7 +62,7 @@ var configDefaults = schema.Defaults{
 	"secret-key":   "",
 	"region":       "us-east-1",
 	"vpc-id":       "",
-	"force-vpc-id": false,
+	"vpc-id-force": false,
 }
 
 type environConfig struct {
@@ -87,7 +87,7 @@ func (c *environConfig) vpcID() string {
 }
 
 func (c *environConfig) forceVPCID() bool {
-	return c.attrs["force-vpc-id"].(bool)
+	return c.attrs["vpc-id-force"].(bool)
 }
 
 func (p environProvider) newConfig(cfg *config.Config) (*environConfig, error) {
@@ -134,7 +134,7 @@ func validateConfig(cfg, old *config.Config) (*environConfig, error) {
 	if vpcID := ecfg.vpcID(); vpcID != "" && !strings.HasPrefix(vpcID, "vpc-") {
 		return nil, fmt.Errorf("vpc-id: %q is not a valid AWS VPC ID", vpcID)
 	} else if vpcID == "" && ecfg.forceVPCID() {
-		return nil, fmt.Errorf("cannot use force-vpc-id without specifying vpc-id as well")
+		return nil, fmt.Errorf("cannot use vpc-id-force without specifying vpc-id as well")
 	}
 
 	if old != nil {
@@ -147,8 +147,8 @@ func validateConfig(cfg, old *config.Config) (*environConfig, error) {
 			return nil, fmt.Errorf("cannot change vpc-id from %q to %q", vpcID, ecfg.vpcID())
 		}
 
-		if forceVPCID, _ := attrs["force-vpc-id"].(bool); forceVPCID != ecfg.forceVPCID() {
-			return nil, fmt.Errorf("cannot change force-vpc-id from %v to %v", forceVPCID, ecfg.forceVPCID())
+		if forceVPCID, _ := attrs["vpc-id-force"].(bool); forceVPCID != ecfg.forceVPCID() {
+			return nil, fmt.Errorf("cannot change vpc-id-force from %v to %v", forceVPCID, ecfg.forceVPCID())
 		}
 	}
 

--- a/provider/ec2/config_test.go
+++ b/provider/ec2/config_test.go
@@ -36,7 +36,10 @@ var configTestRegion = aws.Region{
 	EC2Endpoint: "testregion.nowhere:1234",
 }
 
-var testAuth = aws.Auth{"gopher", "long teeth"}
+var testAuth = aws.Auth{
+	AccessKey: "gopher",
+	SecretKey: "long teeth",
+}
 
 // configTest specifies a config parsing test, checking that env when
 // parsed as the ec2 section of a config file matches baseConfigResult
@@ -47,6 +50,8 @@ type configTest struct {
 	change             map[string]interface{}
 	expect             map[string]interface{}
 	region             string
+	vpcID              string
+	forceVPCID         bool
 	accessKey          string
 	secretKey          string
 	firewallMode       string
@@ -90,6 +95,10 @@ func (t configTest) check(c *gc.C) {
 	if t.region != "" {
 		c.Assert(ecfg.region(), gc.Equals, t.region)
 	}
+
+	c.Assert(ecfg.vpcID(), gc.Equals, t.vpcID)
+	c.Assert(ecfg.forceVPCID(), gc.Equals, t.forceVPCID)
+
 	if t.accessKey != "" {
 		c.Assert(ecfg.accessKey(), gc.Equals, t.accessKey)
 		c.Assert(ecfg.secretKey(), gc.Equals, t.secretKey)
@@ -150,6 +159,117 @@ var configTests = []configTest{
 			"region": 666,
 		},
 		err: `.*expected string, got int\(666\)`,
+	}, {
+		config:     attrs{},
+		vpcID:      "",
+		forceVPCID: false,
+	}, {
+		config: attrs{
+			"vpc-id": "invalid",
+		},
+		err:        `.*vpc-id: "invalid" is not a valid AWS VPC ID`,
+		vpcID:      "",
+		forceVPCID: false,
+	}, {
+		config: attrs{
+			"vpc-id": 42,
+		},
+		err:        `.*expected string, got int\(42\)`,
+		vpcID:      "",
+		forceVPCID: false,
+	}, {
+		config: attrs{
+			"force-vpc-id": "nonsense",
+		},
+		err:        `.*expected bool, got string\("nonsense"\)`,
+		vpcID:      "",
+		forceVPCID: false,
+	}, {
+		config: attrs{
+			"vpc-id":       "vpc-anything",
+			"force-vpc-id": 999,
+		},
+		err:        `.*expected bool, got int\(999\)`,
+		vpcID:      "",
+		forceVPCID: false,
+	}, {
+		config: attrs{
+			"vpc-id":       "",
+			"force-vpc-id": true,
+		},
+		err:        `.*cannot use force-vpc-id without specifying vpc-id as well`,
+		vpcID:      "",
+		forceVPCID: true,
+	}, {
+		config: attrs{
+			"vpc-id": "vpc-a1b2c3d4",
+		},
+		vpcID:      "vpc-a1b2c3d4",
+		forceVPCID: false,
+	}, {
+		config: attrs{
+			"vpc-id":       "vpc-some-id",
+			"force-vpc-id": true,
+		},
+		vpcID:      "vpc-some-id",
+		forceVPCID: true,
+	}, {
+		config: attrs{
+			"vpc-id":       "vpc-abcd",
+			"force-vpc-id": false,
+		},
+		vpcID:      "vpc-abcd",
+		forceVPCID: false,
+	}, {
+		config: attrs{
+			"vpc-id":       "vpc-unchanged",
+			"force-vpc-id": true,
+		},
+		change: attrs{
+			"vpc-id":       "vpc-unchanged",
+			"force-vpc-id": false,
+		},
+		err:        `.*cannot change force-vpc-id from true to false`,
+		vpcID:      "vpc-unchanged",
+		forceVPCID: true,
+	}, {
+		config: attrs{
+			"vpc-id": "",
+		},
+		change: attrs{
+			"vpc-id": "vpc-changed",
+		},
+		err:        `.*cannot change vpc-id from "" to "vpc-changed"`,
+		vpcID:      "",
+		forceVPCID: false,
+	}, {
+		config: attrs{
+			"vpc-id": "vpc-initial",
+		},
+		change: attrs{
+			"vpc-id": "",
+		},
+		err:        `.*cannot change vpc-id from "vpc-initial" to ""`,
+		vpcID:      "vpc-initial",
+		forceVPCID: false,
+	}, {
+		config: attrs{
+			"vpc-id": "vpc-old",
+		},
+		change: attrs{
+			"vpc-id": "vpc-new",
+		},
+		err:        `.*cannot change vpc-id from "vpc-old" to "vpc-new"`,
+		vpcID:      "vpc-old",
+		forceVPCID: false,
+	}, {
+		config: attrs{
+			"vpc-id":       "vpc-foo",
+			"force-vpc-id": true,
+		},
+		change:     attrs{},
+		vpcID:      "vpc-foo",
+		forceVPCID: true,
 	}, {
 		config: attrs{
 			"access-key": 666,

--- a/provider/ec2/config_test.go
+++ b/provider/ec2/config_test.go
@@ -179,7 +179,7 @@ var configTests = []configTest{
 		forceVPCID: false,
 	}, {
 		config: attrs{
-			"force-vpc-id": "nonsense",
+			"vpc-id-force": "nonsense",
 		},
 		err:        `.*expected bool, got string\("nonsense"\)`,
 		vpcID:      "",
@@ -187,7 +187,7 @@ var configTests = []configTest{
 	}, {
 		config: attrs{
 			"vpc-id":       "vpc-anything",
-			"force-vpc-id": 999,
+			"vpc-id-force": 999,
 		},
 		err:        `.*expected bool, got int\(999\)`,
 		vpcID:      "",
@@ -195,9 +195,9 @@ var configTests = []configTest{
 	}, {
 		config: attrs{
 			"vpc-id":       "",
-			"force-vpc-id": true,
+			"vpc-id-force": true,
 		},
-		err:        `.*cannot use force-vpc-id without specifying vpc-id as well`,
+		err:        `.*cannot use vpc-id-force without specifying vpc-id as well`,
 		vpcID:      "",
 		forceVPCID: true,
 	}, {
@@ -209,27 +209,27 @@ var configTests = []configTest{
 	}, {
 		config: attrs{
 			"vpc-id":       "vpc-some-id",
-			"force-vpc-id": true,
+			"vpc-id-force": true,
 		},
 		vpcID:      "vpc-some-id",
 		forceVPCID: true,
 	}, {
 		config: attrs{
 			"vpc-id":       "vpc-abcd",
-			"force-vpc-id": false,
+			"vpc-id-force": false,
 		},
 		vpcID:      "vpc-abcd",
 		forceVPCID: false,
 	}, {
 		config: attrs{
 			"vpc-id":       "vpc-unchanged",
-			"force-vpc-id": true,
+			"vpc-id-force": true,
 		},
 		change: attrs{
 			"vpc-id":       "vpc-unchanged",
-			"force-vpc-id": false,
+			"vpc-id-force": false,
 		},
-		err:        `.*cannot change force-vpc-id from true to false`,
+		err:        `.*cannot change vpc-id-force from true to false`,
 		vpcID:      "vpc-unchanged",
 		forceVPCID: true,
 	}, {
@@ -265,7 +265,7 @@ var configTests = []configTest{
 	}, {
 		config: attrs{
 			"vpc-id":       "vpc-foo",
-			"force-vpc-id": true,
+			"vpc-id-force": true,
 		},
 		change:     attrs{},
 		vpcID:      "vpc-foo",

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -254,7 +254,7 @@ func (z *ec2AvailabilityZone) Name() string {
 }
 
 func (z *ec2AvailabilityZone) Available() bool {
-	return z.AvailabilityZoneInfo.State == "available"
+	return z.AvailabilityZoneInfo.State == availableState
 }
 
 // AvailabilityZones returns a slice of availability zones

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -534,7 +534,7 @@ func (e *environ) StartInstance(args environs.StartInstanceParams) (_ *environs.
 		if len(subnetIDsForZone) > 0 {
 			runArgs.SubnetId = subnetIDsForZone[rand.Intn(len(subnetIDsForZone))]
 			logger.Infof(
-				"selected random subnet %d from all matching in zone %q: %v",
+				"selected random subnet %q from all matching in zone %q: %v",
 				runArgs.SubnetId, zone, subnetIDsForZone,
 			)
 		} else if errors.IsNotFound(subnetErr) {

--- a/provider/ec2/environ_test.go
+++ b/provider/ec2/environ_test.go
@@ -8,7 +8,18 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/constraints"
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/simplestreams"
 	"github.com/juju/juju/network"
+	"github.com/juju/juju/state"
+)
+
+// Ensure EC2 provider supports the expected interfaces,
+var (
+	_ environs.NetworkingEnviron = (*environ)(nil)
+	_ simplestreams.HasRegion    = (*environ)(nil)
+	_ state.Prechecker           = (*environ)(nil)
+	_ state.InstanceDistributor  = (*environ)(nil)
 )
 
 type Suite struct{}

--- a/provider/ec2/environ_vpc.go
+++ b/provider/ec2/environ_vpc.go
@@ -16,7 +16,6 @@ import (
 const (
 	activeState           = "active"
 	availableState        = "available"
-	attachedState         = "attached"
 	localRouteGatewayID   = "local"
 	defaultRouteCIDRBlock = "0.0.0.0/0"
 	defaultVPCIDNone      = "none"
@@ -82,7 +81,7 @@ func validateVPC(apiClient vpcAPIClient, vpcID string) error {
 		return errors.Trace(err)
 	}
 
-	if err := checkInternetGatewayIsAttached(gateway); err != nil {
+	if err := checkInternetGatewayIsAvailable(gateway); err != nil {
 		return errors.Trace(err)
 	}
 
@@ -184,8 +183,8 @@ func getVPCInternetGateway(apiClient vpcAPIClient, vpc *ec2.VPC) (*ec2.InternetG
 	return &gateway, nil
 }
 
-func checkInternetGatewayIsAttached(gateway *ec2.InternetGateway) error {
-	if state := gateway.AttachmentState; state != attachedState {
+func checkInternetGatewayIsAvailable(gateway *ec2.InternetGateway) error {
+	if state := gateway.AttachmentState; state != availableState {
 		return errors.NotValidf("VPC with Internet Gateway %q in unexpected state %q", gateway.Id, state)
 	}
 

--- a/provider/ec2/environ_vpc.go
+++ b/provider/ec2/environ_vpc.go
@@ -1,0 +1,241 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package ec2
+
+import (
+	"fmt"
+
+	"github.com/juju/errors"
+	"github.com/juju/utils/set"
+	"gopkg.in/amz.v3/ec2"
+
+	"github.com/juju/juju/network"
+)
+
+type vpcInfo struct {
+	id                              network.Id
+	isDefault                       bool
+	suitableSubnetIDsForControllers []network.Id
+}
+
+// getVPC returns the VPC ID to use and whether it is the default VPC for the
+// region. It uses cachedVPC if set, otherwise populates it, after validation
+// when user-specified vpc-id or force-vpc-id is set.
+func (e *environ) getVPC() (network.Id, bool, error) {
+	// Use the cached info, if available.
+	if e.cachedVPC != nil {
+		vpc := e.cachedVPC
+		return vpc.id, vpc.isDefault, nil
+	}
+
+	// No cache; verify if vpc-id is specified first and validate it.
+	vpcID := e.ecfg().vpcID()
+	forceVPCID := e.ecfg().forceVPCID()
+	region := e.ecfg().region()
+	ec2Client := e.ec2()
+
+	if vpcID == "" {
+		// Expect a default VPC to be available, but verify anyway.
+		return e.getDefaultVPC(ec2Client)
+	}
+
+	// User specified vpc-id (with or without force-vpc-id).
+	var err error
+	e.cachedVPC, err = validateVPC(ec2Client, region, vpcID)
+	if err == nil {
+		// VPC should work, cache it.
+		return e.cachedVPC.id, e.cachedVPC.isDefault, nil
+	}
+
+	if err != nil && errors.IsNotValid(err) && forceVPCID {
+		// VPC is unlikely to work, but the the user insist, so cache it and
+		// warn about the issue.
+		logger.Warningf("using possibly unsuitable VPC %q due to force-vpc-id", vpcID)
+		logger.Warningf("(ignoring VPC validation error: %v)", err)
+		e.cachedVPC = &vpcInfo{
+			id:        network.Id(vpcID),
+			isDefault: false, // cannot be a default VPC if it fails validation.
+		}
+		return e.cachedVPC.id, e.cachedVPC.isDefault, nil
+	}
+
+	return "", false, errors.Annotatef(err, "VPC %q is not suitable for Juju (and force-vpc-id is %v)", vpcID, forceVPCID)
+}
+
+// getDefaultVPC discovers whether the region has a default VPC and returns its ID and
+func (e *environ) getDefaultVPC(ec2Client *ec2.EC2) (network.Id, bool, error) {
+	resp, err := ec2Client.AccountAttributes("default-vpc")
+	if err != nil {
+		return "", false, errors.Trace(err)
+	}
+
+	hasDefault := true // safe assumption for most current EC2 accounts.
+	defaultVPCID := ""
+
+	if len(resp.Attributes) == 0 || len(resp.Attributes[0].Values) == 0 {
+		// No value for the requested "default-vpc" attribute, all bets are off.
+		hasDefault = false
+		defaultVPCID = ""
+	} else {
+		defaultVPCID = resp.Attributes[0].Values[0]
+		if defaultVPCID == none {
+			// Explicitly deleted default VPC.
+			hasDefault = false
+			defaultVPCID = ""
+		}
+	}
+
+	e.cachedVPC = &vpcInfo{
+		id:        network.Id(defaultVPCID),
+		isDefault: hasDefault,
+	}
+	return e.cachedVPC.id, e.cachedVPC.isDefault, nil
+}
+
+// validateVPC requires all arguments to be set and validates that
+// vpcID refers to an existing EC2 VPC (default or non-default) for
+// the chosen region. If vpcID refers to a non-default VPC, a few
+// santiy checks are done in addition to validating the ID exists:
+//
+// 1. The VPC has an Internet Gateway (IGW) attached.
+// 2. There is at least one "public" subnet (with MapPublicIPOnLaunch set)
+//    in the VPC in one of the available (with "state"="available" in EC2
+//    terms) availability zone in the region. The first such subnet's ID
+//    will be used for the controller instance.
+// 3. Either the VPC main route table or the subnet selected above
+//    must have a route to the IGW, so it can access the internet,
+//    in addition to being accessible from the internet
+//
+// If vpcID does not exist, an error satisfying errors.IsNotFound() will be
+// returned. If the VPC exists but is unusable (not meeting the minimum
+// requirements above), an error satisfying errors.IsNotValid() will be
+// returned.
+func validateVPC(ec2Client *ec2.EC2, region, vpcID string) (*vpcInfo, error) {
+	if vpcID == "" || region == "" || ec2Client == nil {
+		return nil, errors.Errorf("invalid arguments: empty VPC ID, region, or nil client")
+	}
+
+	// Get all availability zones for the region with state
+	// "available".
+	vpcFilter := ec2.NewFilter()
+	vpcFilter.Add("vpc-id", vpcID)
+	vpcFilter.Add("state", "available")
+	vpcsResp, err := ec2Client.VPCs(nil, vpcFilter)
+	if err != nil {
+		return nil, errors.Annotatef(err, "cannot get VPC %q", vpcID)
+	}
+	switch numResults := len(vpcsResp.VPCs); numResults {
+	case 0:
+		return nil, errors.NewNotFound(nil, fmt.Sprintf("VPC %q not available or not found", vpcID))
+	case 1:
+		if vpcState := vpcsResp.VPCs[0].State; vpcState != "available" {
+			return nil, errors.Errorf(`expected state "available" for VPC %q, got %q`, vpcID, vpcState)
+		}
+	default:
+		logger.Debugf("DescribeVpcs returned %#v", vpcsResp)
+		return nil, errors.Errorf("expected one result from DescribeVpcs, got %d", numResults)
+	}
+
+	vpc := &vpcInfo{
+		id:        network.Id(vpcsResp.VPCs[0].Id),
+		isDefault: vpcsResp.VPCs[0].IsDefault,
+	}
+	if vpc.isDefault {
+		// Default VPCs already meets juju requirements, no need to check anything else.
+		logger.Infof("specified VPC %q is the default VPC for region %q", vpcID, region)
+		return vpc, nil
+	}
+	vpcID = string(vpc.id)
+	logger.Tracef("non-default VPC %q exists and is potentially usable", vpcID)
+
+	// TODO: Verify the VPC has IGW attached, so instances inside can reach the internet.
+
+	// Get all availability zones for the region with state "available".
+	zoneFilter := ec2.NewFilter()
+	zoneFilter.Add("region-name", region)
+	zoneFilter.Add("state", "available")
+	zonesResp, err := ec2Client.AvailabilityZones(zoneFilter)
+	if err != nil {
+		return nil, errors.Annotatef(err, "cannot get availability zones for region %q", region)
+	}
+	if len(zonesResp.Zones) < 1 {
+		return nil, errors.Errorf(`region %q has no availability zones with state  "available"`, region)
+	}
+
+	usableZones := set.NewStrings()
+	for _, zone := range zonesResp.Zones {
+		// The checks below ensure we get expected results from AWS with the
+		// applied filters.
+		switch {
+		case zone.Region != region:
+			return nil, errors.Errorf(
+				"expected region %q for availability zone %q, got %q",
+				region, zone.Name, zone.Region,
+			)
+		case zone.State != "available":
+			return nil, errors.Errorf(
+				`expected state "available" for availability zone %q, got %q`,
+				zone.Name, zone.State,
+			)
+		default:
+			usableZones.Add(zone.Name)
+		}
+	}
+	logger.Tracef("usable AZs in region %q: %v", region, usableZones.SortedValues())
+
+	// Fetch the available VPC subnets in the discovered usable zones and try to
+	// find at least one public subnet.
+	subnetFilter := ec2.NewFilter()
+	subnetFilter.Add("vpc-id", vpcID)
+	subnetFilter.Add("state", "available")
+	for _, zone := range usableZones.SortedValues() {
+		subnetFilter.Add("availability-zone", zone)
+	}
+	subnetsResp, err := ec2Client.Subnets(nil, subnetFilter)
+	if err != nil {
+		return nil, errors.Annotatef(err, "cannot get subnets in VPC %q", vpcID)
+	}
+
+	potentiallyUsableSubnets := set.NewStrings()
+	for _, subnet := range subnetsResp.Subnets {
+		vpcIDandSubnetID := fmt.Sprintf("VPC %q subnet %q", vpcID, subnet.Id)
+		// The first 3 checks below ensure we get expected results from AWS with
+		// the applied filters.
+		switch {
+		case subnet.VPCId != vpcID:
+			return nil, errors.Errorf("expected VPC %q for subnet %q, got %q", vpcID, subnet.Id, subnet.VPCId)
+		case subnet.State != "available":
+			return nil, errors.Errorf(`expected state "available" for %s, got %q`, vpcIDandSubnetID, subnet.State)
+		case !usableZones.Contains(subnet.AvailZone):
+			return nil, errors.Errorf(
+				"expected AZ among %v for %s, got %q",
+				usableZones.SortedValues(), vpcIDandSubnetID, subnet.AvailZone,
+			)
+
+		case !subnet.MapPublicIPOnLaunch:
+			logger.Debugf("skipping %s without MapPublicIPOnLaunch set", vpcIDandSubnetID)
+			continue
+		default:
+			// So far so good, we still need to verify the subnet has a route to the IGW.
+			logger.Tracef("found potential usable public %s", vpcIDandSubnetID)
+			potentiallyUsableSubnets.Add(subnet.Id)
+		}
+	}
+	logger.Tracef(
+		"found %d public and available subnets in VPC %q: %v",
+		potentiallyUsableSubnets.Size(),
+		vpcID,
+		potentiallyUsableSubnets.SortedValues(),
+	)
+
+	if potentiallyUsableSubnets.IsEmpty() {
+		return nil, errors.NewNotValid(nil, fmt.Sprintf(
+			"no public, available subnets found in VPC %q, suitable for a Juju controller instance",
+			vpcID,
+		))
+	}
+
+	// All good!
+	return vpc, nil
+}

--- a/provider/ec2/environ_vpc.go
+++ b/provider/ec2/environ_vpc.go
@@ -14,9 +14,8 @@ import (
 )
 
 type vpcInfo struct {
-	id                              network.Id
-	isDefault                       bool
-	suitableSubnetIDsForControllers []network.Id
+	id        network.Id
+	isDefault bool
 }
 
 // getVPC returns the VPC ID to use and whether it is the default VPC for the
@@ -25,6 +24,7 @@ type vpcInfo struct {
 func (e *environ) getVPC() (network.Id, bool, error) {
 	// Use the cached info, if available.
 	if e.cachedVPC != nil {
+		logger.Tracef("using cached VPC info %#v", e.cachedVPC)
 		return e.cachedVPC.id, e.cachedVPC.isDefault, nil
 	}
 	ec2Client := e.ec2()
@@ -36,6 +36,7 @@ func (e *environ) getVPC() (network.Id, bool, error) {
 
 	if vpcID == "" {
 		// Expect a default VPC to be available, but verify anyway.
+		logger.Tracef("assuming default VPC exists for region %q", region)
 		return e.getDefaultVPC(ec2Client)
 	}
 
@@ -98,6 +99,7 @@ func (e *environ) getDefaultVPC(ec2Client *ec2.EC2) (network.Id, bool, error) {
 		id:        network.Id(defaultVPCID),
 		isDefault: hasDefault,
 	}
+	logger.Tracef("caching default VPC info %#v", e.cachedVPC)
 	return e.cachedVPC.id, e.cachedVPC.isDefault, nil
 }
 
@@ -243,5 +245,6 @@ func validateVPC(ec2Client *ec2.EC2, region, vpcID string) (*vpcInfo, error) {
 	}
 
 	// All good!
+	logger.Tracef("caching validated VPC info %#v", vpc)
 	return vpc, nil
 }

--- a/provider/ec2/environ_vpc.go
+++ b/provider/ec2/environ_vpc.go
@@ -7,9 +7,10 @@ import (
 	"fmt"
 
 	"github.com/juju/errors"
-	"github.com/juju/juju/network"
 	"github.com/juju/utils/set"
 	"gopkg.in/amz.v3/ec2"
+
+	"github.com/juju/juju/network"
 )
 
 const (
@@ -166,7 +167,7 @@ func findFirstPublicSubnet(subnets []ec2.Subnet) (*ec2.Subnet, error) {
 
 func getVPCInternetGateway(apiClient vpcAPIClient, vpc *ec2.VPC) (*ec2.InternetGateway, error) {
 	filter := ec2.NewFilter()
-	filter.Add("vpc-id", vpc.Id)
+	filter.Add("attachment.vpc-id", vpc.Id)
 	response, err := apiClient.InternetGateways(nil, filter)
 	if err != nil {
 		return nil, errors.Annotatef(err, "unexpected AWS response getting Internet Gateway of VPC %q", vpc.Id)

--- a/provider/ec2/environ_vpc.go
+++ b/provider/ec2/environ_vpc.go
@@ -7,244 +7,321 @@ import (
 	"fmt"
 
 	"github.com/juju/errors"
+	"github.com/juju/juju/network"
 	"github.com/juju/utils/set"
 	"gopkg.in/amz.v3/ec2"
-
-	"github.com/juju/juju/network"
 )
 
-type vpcInfo struct {
-	id        network.Id
-	isDefault bool
+const (
+	activeState           = "active"
+	availableState        = "available"
+	attachedState         = "attached"
+	localRouteGatewayID   = "local"
+	defaultRouteCIDRBlock = "0.0.0.0/0"
+	defaultVPCIDNone      = "none"
+)
+
+// vpcAPIClient defines a subset of the goamz API calls needed to validate a VPC.
+type vpcAPIClient interface {
+	AccountAttributes(attributeNames ...string) (*ec2.AccountAttributesResp, error)
+	VPCs(ids []string, filter *ec2.Filter) (*ec2.VPCsResp, error)
+	Subnets(ids []string, filter *ec2.Filter) (*ec2.SubnetsResp, error)
+	InternetGateways(ids []string, filter *ec2.Filter) (*ec2.InternetGatewaysResp, error)
+	RouteTables(ids []string, filter *ec2.Filter) (*ec2.RouteTablesResp, error)
 }
 
-// getVPC returns the VPC ID to use and whether it is the default VPC for the
-// region. It uses cachedVPC if set, otherwise populates it, after validation
-// when user-specified vpc-id or force-vpc-id is set.
-func (e *environ) getVPC() (network.Id, bool, error) {
-	// Use the cached info, if available.
-	if e.cachedVPC != nil {
-		logger.Tracef("using cached VPC info %#v", e.cachedVPC)
-		return e.cachedVPC.id, e.cachedVPC.isDefault, nil
-	}
-	ec2Client := e.ec2()
-
-	// No cache; verify if vpc-id is specified first and validate it.
-	vpcID := e.ecfg().vpcID()
-	forceVPCID := e.ecfg().forceVPCID()
-	region := e.ecfg().region()
-
-	if vpcID == "" {
-		// Expect a default VPC to be available, but verify anyway.
-		logger.Tracef("assuming default VPC exists for region %q", region)
-		return e.getDefaultVPC(ec2Client)
-	}
-
-	// User specified vpc-id (with or without force-vpc-id).
-	var err error
-	e.cachedVPC, err = validateVPC(ec2Client, region, vpcID)
-	if err == nil {
-		// VPC should work, cache it.
-		return e.cachedVPC.id, e.cachedVPC.isDefault, nil
-	}
-
-	if errors.IsNotValid(err) {
-		if forceVPCID {
-			// VPC is unlikely to work, but the the user insist, so cache it and
-			// warn about the issue.
-			logger.Warningf("specified VPC %q does not meet minimum connectivity requirements (using anyway: force-vpc-id=true)", vpcID)
-			logger.Warningf("ignoring validation error: %v", err)
-			e.cachedVPC = &vpcInfo{
-				id:        network.Id(vpcID),
-				isDefault: false, // cannot be a default VPC if it fails validation.
-			}
-			return e.cachedVPC.id, e.cachedVPC.isDefault, nil
-		}
-		return "", false, errors.Annotatef(
-			err,
-			"specified VPC %q does not meet minimum connectivity requirements",
-			vpcID,
-		)
-	} else if errors.IsNotFound(err) {
-		return "", false, errors.Annotate(err, "cannot find specified vpc-id")
-	}
-
-	return "", false, errors.Annotate(err, "unexpected error verifying the specified vpc-id")
-}
-
-// getDefaultVPC discovers whether the region has a default VPC and returns its ID and
-func (e *environ) getDefaultVPC(ec2Client *ec2.EC2) (network.Id, bool, error) {
-	resp, err := ec2Client.AccountAttributes("default-vpc")
-	if err != nil {
-		return "", false, errors.Trace(err)
-	}
-
-	hasDefault := true // safe assumption for most current EC2 accounts.
-	defaultVPCID := ""
-
-	if len(resp.Attributes) == 0 || len(resp.Attributes[0].Values) == 0 {
-		// No value for the requested "default-vpc" attribute, all bets are off.
-		hasDefault = false
-		defaultVPCID = ""
-	} else {
-		defaultVPCID = resp.Attributes[0].Values[0]
-		if defaultVPCID == none {
-			// Explicitly deleted default VPC.
-			hasDefault = false
-			defaultVPCID = ""
-		}
-	}
-
-	e.cachedVPC = &vpcInfo{
-		id:        network.Id(defaultVPCID),
-		isDefault: hasDefault,
-	}
-	logger.Tracef("caching default VPC info %#v", e.cachedVPC)
-	return e.cachedVPC.id, e.cachedVPC.isDefault, nil
-}
-
-// validateVPC requires all arguments to be set and validates that
-// vpcID refers to an existing EC2 VPC (default or non-default) for
-// the chosen region. If vpcID refers to a non-default VPC, a few
-// santiy checks are done in addition to validating the ID exists:
+// validateVPC requires both arguments to be set and validates that vpcID refers
+// to an existing AWS VPC (default or non-default) for the current region.
+// Returns an error satifying errors.IsNotFound() when the VPC with the given
+// vpcID cannot be found, or when the VPC exists but contains no subnets.
+// Returns an error satisfying errors.IsNotValid() in the following cases:
 //
-// 1. The VPC has an Internet Gateway (IGW) attached.
-// 2. There is at least one "public" subnet (with MapPublicIPOnLaunch set)
-//    in the VPC in one of the available (with "state"="available" in EC2
-//    terms) availability zone in the region. The first such subnet's ID
-//    will be used for the controller instance.
-// 3. Either the VPC main route table or the subnet selected above
-//    must have a route to the IGW, so it can access the internet,
-//    in addition to being accessible from the internet
+// 1. The VPC's state is not "available".
+// 2. The VPC does not have an Internet Gateway (IGW) attached.
+// 3. A main route table is not associated with the VPC.
+// 4. The main route table lacks both a default route via the IGW and a local
+//    route matching the VPC's CIDR block.
+// 5. One or more of the VPC's subnets are not associated with the main route
+//    table of the VPC.
+// 6. None of the the VPC's subnets have the MapPublicIPOnLaunch attribute set.
 //
-// If vpcID does not exist, an error satisfying errors.IsNotFound() will be
-// returned. If the VPC exists but is unusable (not meeting the minimum
-// requirements above), an error satisfying errors.IsNotValid() will be
-// returned.
-func validateVPC(ec2Client *ec2.EC2, region, vpcID string) (*vpcInfo, error) {
-	if vpcID == "" || region == "" || ec2Client == nil {
-		return nil, errors.Errorf("invalid arguments: empty VPC ID, region, or nil client")
+// With the force-vpc-id config setting set to true, the provider can ignore a
+// NotValidError. NotFoundError cannot be ignored, while unexpected API
+// responses and errors could be retried.
+func validateVPC(apiClient vpcAPIClient, vpcID string) error {
+	if vpcID == "" || apiClient == nil {
+		return errors.Errorf("invalid arguments: empty VPC ID or nil client")
 	}
 
-	// Get the VPC by ID and check its state is "available".
-	vpcsResp, err := ec2Client.VPCs([]string{vpcID}, nil)
-	if err != nil && ec2ErrCode(err) == "InvalidVpcID.NotFound" {
-		return nil, errors.NewNotFound(err, "")
-	} else if err != nil {
-		return nil, errors.Trace(err)
-	}
-	switch numResults := len(vpcsResp.VPCs); numResults {
-	case 0:
-		return nil, errors.NotFoundf("VPC")
-	case 1:
-		if vpcState := vpcsResp.VPCs[0].State; vpcState != "available" {
-			return nil, errors.NotValidf("VPC state %q", vpcState)
-		}
-	default:
-		logger.Debugf("DescribeVpcs returned %#v", vpcsResp)
-		return nil, errors.Errorf("expected one result from DescribeVpcs, got %d", numResults)
-	}
-
-	vpc := &vpcInfo{
-		id:        network.Id(vpcsResp.VPCs[0].Id),
-		isDefault: vpcsResp.VPCs[0].IsDefault,
-	}
-	if vpc.isDefault {
-		// Default VPCs already meets juju requirements, no need to check anything else.
-		logger.Infof("specified VPC %q is the default VPC for region %q", vpcID, region)
-		return vpc, nil
-	}
-	vpcID = string(vpc.id)
-	logger.Tracef("non-default VPC %q exists and is potentially usable", vpcID)
-
-	// TODO: Verify the VPC has IGW attached, so instances inside can reach the internet.
-
-	// Get all availability zones for the region with state "available".
-	zoneFilter := ec2.NewFilter()
-	zoneFilter.Add("region-name", region)
-	zoneFilter.Add("state", "available")
-	zonesResp, err := ec2Client.AvailabilityZones(zoneFilter)
+	vpc, err := getVPCByID(apiClient, vpcID)
 	if err != nil {
-		return nil, errors.Annotatef(err, "cannot get availability zones for region %q", region)
-	}
-	if len(zonesResp.Zones) < 1 {
-		return nil, errors.Errorf(`region %q has no availability zones with state "available"`, region)
+		return errors.Trace(err)
 	}
 
-	usableZones := set.NewStrings()
-	for _, zone := range zonesResp.Zones {
-		// The checks below ensure we get expected results from AWS with the
-		// applied filters.
-		switch {
-		case zone.Region != region:
-			return nil, errors.Errorf(
-				"expected region %q for availability zone %q, got %q",
-				region, zone.Name, zone.Region,
-			)
-		case zone.State != "available":
-			return nil, errors.Errorf(
-				`expected state "available" for availability zone %q, got %q`,
-				zone.Name, zone.State,
-			)
-		default:
-			usableZones.Add(zone.Name)
-		}
+	if err := checkVPCIsAvailable(vpc); err != nil {
+		return errors.Trace(err)
 	}
-	logger.Tracef("usable AZs in region %q: %v", region, usableZones.SortedValues())
 
-	// Fetch the available VPC subnets in the discovered usable zones and try to
-	// find at least one public subnet.
-	subnetFilter := ec2.NewFilter()
-	subnetFilter.Add("vpc-id", vpcID)
-	subnetFilter.Add("state", "available")
-	for _, zone := range usableZones.SortedValues() {
-		subnetFilter.Add("availability-zone", zone)
-	}
-	subnetsResp, err := ec2Client.Subnets(nil, subnetFilter)
+	subnets, err := getVPCSubnets(apiClient, vpc)
 	if err != nil {
-		return nil, errors.Annotatef(err, "cannot get subnets in VPC %q", vpcID)
+		return errors.Trace(err)
 	}
 
-	potentiallyUsableSubnets := set.NewStrings()
-	for _, subnet := range subnetsResp.Subnets {
-		vpcIDandSubnetID := fmt.Sprintf("VPC %q subnet %q", vpcID, subnet.Id)
-		// The first 3 checks below ensure we get expected results from AWS with
-		// the applied filters.
-		switch {
-		case subnet.VPCId != vpcID:
-			return nil, errors.Errorf("expected VPC %q for subnet %q, got %q", vpcID, subnet.Id, subnet.VPCId)
-		case subnet.State != "available":
-			return nil, errors.Errorf(`expected state "available" for %s, got %q`, vpcIDandSubnetID, subnet.State)
-		case !usableZones.Contains(subnet.AvailZone):
-			return nil, errors.Errorf(
-				"expected AZ among %v for %s, got %q",
-				usableZones.SortedValues(), vpcIDandSubnetID, subnet.AvailZone,
-			)
-
-		case !subnet.MapPublicIPOnLaunch:
-			logger.Debugf("skipping %s without MapPublicIPOnLaunch set", vpcIDandSubnetID)
-			continue
-		default:
-			// So far so good, we still need to verify the subnet has a route to the IGW.
-			logger.Tracef("found potential usable public %s", vpcIDandSubnetID)
-			potentiallyUsableSubnets.Add(subnet.Id)
-		}
+	publicSubnet, err := findFirstPublicSubnet(subnets)
+	if err != nil {
+		return errors.Trace(err)
 	}
-	logger.Tracef(
-		"found %d public and available subnets in VPC %q: %v",
-		potentiallyUsableSubnets.Size(),
-		vpcID,
-		potentiallyUsableSubnets.SortedValues(),
+	logger.Infof(
+		"found subnet %q (%s) in AZ %q, suitable for a Juju controller instance",
+		publicSubnet.Id, publicSubnet.CIDRBlock, publicSubnet.AvailZone,
 	)
 
-	if potentiallyUsableSubnets.IsEmpty() {
-		return nil, errors.NewNotValid(
-			nil,
-			"no public subnets with state 'available' found to host a Juju controller instance",
-		)
+	gateway, err := getVPCInternetGateway(apiClient, vpc)
+	if err != nil {
+		return errors.Trace(err)
 	}
 
-	// All good!
-	logger.Tracef("caching validated VPC info %#v", vpc)
-	return vpc, nil
+	if err := checkInternetGatewayIsAttached(gateway); err != nil {
+		return errors.Trace(err)
+	}
+
+	routeTables, err := getVPCRouteTables(apiClient, vpc)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	mainRouteTable, err := findVPCMainRouteTable(vpc, routeTables)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	if err := checkVPCRouteTableRoutes(vpc, mainRouteTable, gateway); err != nil {
+		return errors.Trace(err)
+	}
+
+	logger.Infof("VPC %q is suitable for Juju controllers and expose-able workloads", vpc.Id)
+	return nil
+}
+
+func getVPCByID(apiClient vpcAPIClient, vpcID string) (*ec2.VPC, error) {
+	response, err := apiClient.VPCs([]string{vpcID}, nil)
+	if isVPCNotFoundError(err) {
+		return nil, errors.NewNotFound(err, "")
+	} else if err != nil {
+		return nil, errors.Annotatef(err, "unexpected AWS response getting VPC %q", vpcID)
+	}
+
+	if numResults := len(response.VPCs); numResults == 0 {
+		return nil, errors.NotFoundf("VPC %q", vpcID)
+	} else if numResults > 1 {
+		logger.Debugf("VPCs() returned %#v", response)
+		return nil, errors.Errorf("expected 1 result from AWS, got %d", numResults)
+	}
+
+	vpc := response.VPCs[0]
+	return &vpc, nil
+}
+
+func isVPCNotFoundError(err error) bool {
+	return err != nil && ec2ErrCode(err) == "InvalidVpcID.NotFound"
+}
+
+func checkVPCIsAvailable(vpc *ec2.VPC) error {
+	if vpc.State != availableState {
+		return errors.NotValidf("VPC with unexpected state %q", vpc.State)
+	}
+
+	if vpc.IsDefault {
+		logger.Infof("VPC %q is the default VPC for the region", vpc.Id)
+	}
+
+	return nil
+}
+
+func getVPCSubnets(apiClient vpcAPIClient, vpc *ec2.VPC) ([]ec2.Subnet, error) {
+	filter := ec2.NewFilter()
+	filter.Add("vpc-id", vpc.Id)
+	response, err := apiClient.Subnets(nil, filter)
+	if err != nil {
+		return nil, errors.Annotate(err, "unexpected AWS response getting VPC subnets")
+	}
+
+	if len(response.Subnets) == 0 {
+		message := fmt.Sprintf("no subnets found for VPC %q", vpc.Id)
+		return nil, errors.NewNotFound(nil, message)
+	}
+
+	return response.Subnets, nil
+}
+
+func findFirstPublicSubnet(subnets []ec2.Subnet) (*ec2.Subnet, error) {
+	for _, subnet := range subnets {
+		if subnet.MapPublicIPOnLaunch {
+			return &subnet, nil
+		}
+
+	}
+	return nil, errors.NotValidf("VPC without any public subnets")
+}
+
+func getVPCInternetGateway(apiClient vpcAPIClient, vpc *ec2.VPC) (*ec2.InternetGateway, error) {
+	filter := ec2.NewFilter()
+	filter.Add("vpc-id", vpc.Id)
+	response, err := apiClient.InternetGateways(nil, filter)
+	if err != nil {
+		return nil, errors.Annotatef(err, "unexpected AWS response getting Internet Gateway of VPC %q", vpc.Id)
+	}
+
+	if numResults := len(response.InternetGateways); numResults == 0 {
+		return nil, errors.NotValidf("VPC without Internet Gateway")
+	} else if numResults > 1 {
+		logger.Debugf("InternetGateways() returned %#v", response)
+		return nil, errors.Errorf("expected 1 result from AWS, got %d", numResults)
+	}
+
+	gateway := response.InternetGateways[0]
+	return &gateway, nil
+}
+
+func checkInternetGatewayIsAttached(gateway *ec2.InternetGateway) error {
+	if state := gateway.AttachmentState; state != attachedState {
+		errors.NotValidf("VPC Internet Gateway %q in unexpected state %q", gateway.Id, state)
+	}
+
+	return nil
+}
+
+func getVPCRouteTables(apiClient vpcAPIClient, vpc *ec2.VPC) ([]ec2.RouteTable, error) {
+	filter := ec2.NewFilter()
+	filter.Add("vpc-id", vpc.Id)
+	response, err := apiClient.RouteTables(nil, filter)
+	if err != nil {
+		return nil, errors.Annotatef(err, "unexpected AWS response getting VPC %q route tables", vpc.Id)
+	}
+
+	if len(response.Tables) == 0 {
+		return nil, errors.NotValidf("VPC without any route tables")
+	}
+	logger.Tracef("RouteTables() returned %#v", response)
+
+	return response.Tables, nil
+}
+
+func findVPCMainRouteTable(vpc *ec2.VPC, routeTables []ec2.RouteTable) (*ec2.RouteTable, error) {
+	var mainTable *ec2.RouteTable
+	for _, table := range routeTables {
+		if len(table.Associations) < 1 {
+			logger.Tracef("ignoring VPC %q route table %q with no associations", vpc.Id, table.Id)
+			continue
+		}
+
+		for _, association := range table.Associations {
+			if subnetID := association.SubnetId; subnetID != "" {
+				return nil, errors.NotValidf("subnet %q not associated with VPC main route table", subnetID)
+			}
+			if association.IsMain && mainTable == nil {
+				logger.Tracef("main route table of VPC %q has ID %q", vpc.Id, table.Id)
+				mainTable = &table
+			}
+		}
+	}
+
+	if mainTable == nil {
+		return nil, errors.NotValidf("VPC without associated main route table")
+	}
+
+	return mainTable, nil
+}
+
+func checkVPCRouteTableRoutes(vpc *ec2.VPC, routeTable *ec2.RouteTable, gateway *ec2.InternetGateway) error {
+	hasDefaultRoute := false
+	hasLocalRoute := false
+
+	logger.Tracef("checking route table %+v routes", routeTable)
+	for _, route := range routeTable.Routes {
+		if route.State != activeState {
+			logger.Tracef("skipping inactive route %+v", route)
+			continue
+		}
+
+		switch route.DestinationCIDRBlock {
+		case defaultRouteCIDRBlock:
+			if route.GatewayId == gateway.Id {
+				logger.Tracef("default route uses expected gateway %q", gateway.Id)
+				hasDefaultRoute = true
+			}
+		case vpc.CIDRBlock:
+			if route.GatewayId == localRouteGatewayID {
+				logger.Tracef("local route uses expected CIDR %q", vpc.CIDRBlock)
+				hasLocalRoute = true
+			}
+		default:
+			logger.Tracef("route %+v is neither local nor default (skipping)", route)
+		}
+	}
+
+	if hasDefaultRoute && hasLocalRoute {
+		return nil
+	}
+
+	if !hasDefaultRoute {
+		return errors.NotValidf("missing default route via gateway %q", gateway.Id)
+	}
+	return errors.NotValidf("missing local route with destination %q", vpc.CIDRBlock)
+}
+
+func findDefaultVPCID(apiClient vpcAPIClient) (string, error) {
+	response, err := apiClient.AccountAttributes("default-vpc")
+	if err != nil {
+		return "", errors.Annotate(err, "unexpected AWS response getting default-vpc")
+	}
+
+	if len(response.Attributes) == 0 || len(response.Attributes[0].Values) == 0 {
+		// No value for the requested "default-vpc" attribute, all bets are off.
+		return "", errors.NotFoundf("default-vpc account attribute")
+	}
+
+	firstAttributeValue := response.Attributes[0].Values[0]
+	if firstAttributeValue == defaultVPCIDNone {
+		return "", errors.NotFoundf("default VPC")
+	}
+
+	return firstAttributeValue, nil
+}
+
+func getVPCSubnetIDsForAvailabilityZone(apiClient vpcAPIClient, vpcID, zoneName string) ([]string, error) {
+	vpc := &ec2.VPC{Id: vpcID}
+	subnets, err := getVPCSubnets(apiClient, vpc)
+	if err != nil {
+		return nil, errors.Annotatef(err, "cannot get VPC %q subnets", vpcID)
+	}
+
+	matchingSubnetIDs := set.NewStrings()
+	for _, subnet := range subnets {
+		if subnet.AvailZone == zoneName {
+			matchingSubnetIDs.Add(subnet.Id)
+		}
+	}
+
+	if matchingSubnetIDs.IsEmpty() {
+		return nil, errors.NotFoundf("VPC %q subnet in AZ %q", vpcID, zoneName)
+	}
+
+	return matchingSubnetIDs.SortedValues(), nil
+}
+
+func findSubnetIDsForAvailabilityZone(zoneName string, subnetsToZones map[network.Id][]string) ([]string, error) {
+	matchingSubnetIDs := set.NewStrings()
+	for subnetID, zones := range subnetsToZones {
+		zonesSet := set.NewStrings(zones...)
+		if zonesSet.Contains(zoneName) {
+			matchingSubnetIDs.Add(string(subnetID))
+		}
+	}
+
+	if matchingSubnetIDs.IsEmpty() {
+		return nil, errors.NotFoundf("subnets in AZ %q", zoneName)
+	}
+
+	return matchingSubnetIDs.SortedValues(), nil
 }

--- a/provider/ec2/environ_vpc.go
+++ b/provider/ec2/environ_vpc.go
@@ -45,7 +45,7 @@ type vpcAPIClient interface {
 //    table of the VPC.
 // 6. None of the the VPC's subnets have the MapPublicIPOnLaunch attribute set.
 //
-// With the force-vpc-id config setting set to true, the provider can ignore a
+// With the vpc-id-force config setting set to true, the provider can ignore a
 // NotValidError. NotFoundError cannot be ignored, while unexpected API
 // responses and errors could be retried.
 func validateVPC(apiClient vpcAPIClient, vpcID string) error {

--- a/provider/ec2/environ_vpc_test.go
+++ b/provider/ec2/environ_vpc_test.go
@@ -1,0 +1,891 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package ec2
+
+import (
+	"fmt"
+
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	"gopkg.in/amz.v3/ec2"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/network"
+)
+
+type vpcSuite struct {
+	testing.IsolationSuite
+
+	stubAPI *stubVPCAPIClient
+}
+
+var _ = gc.Suite(&vpcSuite{})
+
+func (s *vpcSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+
+	s.stubAPI = &stubVPCAPIClient{Stub: &testing.Stub{}}
+}
+
+// NOTE: validateVPC tests only verify expected error types for all code paths,
+// but do not check passed API arguments or exact error messages, as those are
+// extensively tested separately below.
+
+func (s *vpcSuite) TestValidateVPCWithEmptyVPCIDOrNilAPIClient(c *gc.C) {
+	err := validateVPC(s.stubAPI, "")
+	c.Assert(err, gc.ErrorMatches, "invalid arguments: empty VPC ID or nil client")
+
+	err = validateVPC(nil, anyVPCID)
+	c.Assert(err, gc.ErrorMatches, "invalid arguments: empty VPC ID or nil client")
+
+	s.stubAPI.CheckNoCalls(c)
+}
+
+func (s *vpcSuite) TestValidateVPCWhenVPCIDNotFound(c *gc.C) {
+	s.stubAPI.SetErrors(makeVPCNotFoundError("foo"))
+
+	err := validateVPC(s.stubAPI, anyVPCID)
+	c.Check(err, jc.Satisfies, errors.IsNotFound)
+
+	s.stubAPI.CheckCallNames(c, "VPCs")
+}
+
+func (s *vpcSuite) TestValidateVPCWhenVPCHasNoSubnets(c *gc.C) {
+	s.stubAPI.SetVPCsResponse(1, availableState, notDefaultVPC)
+	s.stubAPI.SetSubnetsResponse(noResults, anyZone, noPublicIPOnLaunch)
+
+	err := validateVPC(s.stubAPI, anyVPCID)
+	c.Check(err, jc.Satisfies, errors.IsNotFound)
+
+	s.stubAPI.CheckCallNames(c, "VPCs", "Subnets")
+}
+func (s *vpcSuite) TestValidateVPCWhenVPCNotAvailable(c *gc.C) {
+	s.stubAPI.PrepareValidateVPCResponses()
+	s.stubAPI.SetVPCsResponse(1, "bad-state", notDefaultVPC)
+
+	s.stubAPI.CallValidateVPCAndCheckCallsUpToExpectingNotValidError(c, "VPCs")
+}
+
+func (s *vpcSuite) TestValidateVPCWhenVPCHasNoPublicSubnets(c *gc.C) {
+	s.stubAPI.PrepareValidateVPCResponses()
+	s.stubAPI.SetSubnetsResponse(1, anyZone, noPublicIPOnLaunch)
+
+	s.stubAPI.CallValidateVPCAndCheckCallsUpToExpectingNotValidError(c, "Subnets")
+}
+
+func (s *vpcSuite) TestValidateVPCWhenVPCHasNoGateway(c *gc.C) {
+	s.stubAPI.PrepareValidateVPCResponses()
+	s.stubAPI.SetGatewaysResponse(noResults, anyState)
+
+	s.stubAPI.CallValidateVPCAndCheckCallsUpToExpectingNotValidError(c, "InternetGateways")
+}
+
+func (s *vpcSuite) TestValidateVPCWhenVPCHasNoAttachedGateway(c *gc.C) {
+	s.stubAPI.PrepareValidateVPCResponses()
+	s.stubAPI.SetGatewaysResponse(1, "pending")
+
+	s.stubAPI.CallValidateVPCAndCheckCallsUpToExpectingNotValidError(c, "InternetGateways")
+}
+
+func (s *vpcSuite) TestValidateVPCWhenVPCHasNoRouteTables(c *gc.C) {
+	s.stubAPI.PrepareValidateVPCResponses()
+	s.stubAPI.SetRouteTablesResponse() // no route tables at all
+
+	s.stubAPI.CallValidateVPCAndCheckCallsUpToExpectingNotValidError(c, "RouteTables")
+}
+
+func (s *vpcSuite) TestValidateVPCWhenVPCHasNoMainRouteTable(c *gc.C) {
+	s.stubAPI.PrepareValidateVPCResponses()
+	s.stubAPI.SetRouteTablesResponse(
+		makeEC2RouteTable(anyTableID, notMainRouteTable, nil, nil),
+	)
+
+	s.stubAPI.CallValidateVPCAndCheckCallsUpToExpectingNotValidError(c, "RouteTables")
+}
+
+func (s *vpcSuite) TestValidateVPCWhenVPCHasMainRouteTableWithoutRoutes(c *gc.C) {
+	s.stubAPI.PrepareValidateVPCResponses()
+	s.stubAPI.SetRouteTablesResponse(
+		makeEC2RouteTable(anyTableID, mainRouteTable, nil, nil),
+	)
+
+	s.stubAPI.CallValidateVPCAndCheckCallsUpToExpectingNotValidError(c, "RouteTables")
+}
+
+func (s *vpcSuite) TestValidateVPCSuccess(c *gc.C) {
+	s.stubAPI.PrepareValidateVPCResponses()
+
+	err := validateVPC(s.stubAPI, anyVPCID)
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.stubAPI.CheckCallNames(c, "VPCs", "Subnets", "InternetGateways", "RouteTables")
+}
+
+func (s *vpcSuite) TestGetVPCByIDWithMissingID(c *gc.C) {
+	s.stubAPI.SetErrors(makeVPCNotFoundError("foo"))
+
+	vpc, err := getVPCByID(s.stubAPI, "foo")
+	c.Assert(err, gc.ErrorMatches, `The vpc ID 'foo' does not exist \(InvalidVpcID.NotFound\)`)
+	c.Check(err, jc.Satisfies, errors.IsNotFound)
+	c.Check(vpc, gc.IsNil)
+
+	s.stubAPI.CheckSingleVPCsCall(c, "foo")
+}
+
+func (s *vpcSuite) TestGetVPCByIDUnexpectedAWSError(c *gc.C) {
+	s.stubAPI.SetErrors(errors.New("AWS failed!"))
+
+	vpc, err := getVPCByID(s.stubAPI, "bar")
+	c.Assert(err, gc.ErrorMatches, `unexpected AWS response getting VPC "bar": AWS failed!`)
+	c.Check(vpc, gc.IsNil)
+
+	s.stubAPI.CheckSingleVPCsCall(c, "bar")
+}
+
+func (s *vpcSuite) TestGetVPCByIDNoResults(c *gc.C) {
+	s.stubAPI.SetVPCsResponse(noResults, anyState, notDefaultVPC)
+
+	vpc, err := getVPCByID(s.stubAPI, "vpc-42")
+	c.Assert(err, gc.ErrorMatches, `VPC "vpc-42" not found`)
+	c.Check(err, jc.Satisfies, errors.IsNotFound)
+	c.Check(vpc, gc.IsNil)
+
+	s.stubAPI.CheckSingleVPCsCall(c, "vpc-42")
+}
+
+func (s *vpcSuite) TestGetVPCByIDMultipleResults(c *gc.C) {
+	s.stubAPI.SetVPCsResponse(5, anyState, notDefaultVPC)
+
+	vpc, err := getVPCByID(s.stubAPI, "vpc-33")
+	c.Assert(err, gc.ErrorMatches, "expected 1 result from AWS, got 5")
+	c.Check(vpc, gc.IsNil)
+
+	s.stubAPI.CheckSingleVPCsCall(c, "vpc-33")
+}
+
+func (s *vpcSuite) TestGetVPCByIDSuccess(c *gc.C) {
+	s.stubAPI.SetVPCsResponse(1, anyState, notDefaultVPC)
+
+	vpc, err := getVPCByID(s.stubAPI, "vpc-1")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(vpc, jc.DeepEquals, &s.stubAPI.vpcsResponse.VPCs[0])
+
+	s.stubAPI.CheckSingleVPCsCall(c, "vpc-1")
+}
+
+func (s *vpcSuite) TestIsVPCNotFoundError(c *gc.C) {
+	c.Check(isVPCNotFoundError(nil), jc.IsFalse)
+
+	nonEC2Error := errors.New("boom")
+	c.Check(isVPCNotFoundError(nonEC2Error), jc.IsFalse)
+
+	ec2Error := makeEC2Error(444, "code", "bad stuff", "req-id")
+	c.Check(isVPCNotFoundError(ec2Error), jc.IsFalse)
+
+	ec2Error = makeVPCNotFoundError("some-id")
+	c.Check(isVPCNotFoundError(ec2Error), jc.IsTrue)
+}
+
+func (s *vpcSuite) TestCheckVPCIsAvailable(c *gc.C) {
+	availableVPC := makeEC2VPC(anyVPCID, availableState)
+	c.Check(checkVPCIsAvailable(availableVPC), jc.ErrorIsNil)
+
+	defaultVPC := makeEC2VPC(anyVPCID, availableState)
+	defaultVPC.IsDefault = true
+	c.Check(checkVPCIsAvailable(defaultVPC), jc.ErrorIsNil)
+
+	notAvailableVPC := makeEC2VPC(anyVPCID, anyState)
+	err := checkVPCIsAvailable(notAvailableVPC)
+	c.Assert(err, gc.ErrorMatches, `VPC with unexpected state "any state" not valid`)
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+}
+
+func (s *vpcSuite) TestGetVPCSubnetUnexpectedAWSError(c *gc.C) {
+	s.stubAPI.SetErrors(errors.New("AWS failed!"))
+
+	anyVPC := makeEC2VPC(anyVPCID, anyState)
+	subnets, err := getVPCSubnets(s.stubAPI, anyVPC)
+	c.Assert(err, gc.ErrorMatches, `unexpected AWS response getting subnets of VPC "vpc-anything": AWS failed!`)
+	c.Check(subnets, gc.IsNil)
+
+	s.stubAPI.CheckSingleSubnetsCall(c, anyVPC)
+}
+
+func (s *vpcSuite) TestGetVPCSubnetsNoResults(c *gc.C) {
+	s.stubAPI.SetSubnetsResponse(noResults, anyZone, noPublicIPOnLaunch)
+
+	anyVPC := makeEC2VPC(anyVPCID, anyState)
+	subnets, err := getVPCSubnets(s.stubAPI, anyVPC)
+	c.Assert(err, gc.ErrorMatches, `no subnets found for VPC "vpc-anything"`)
+	c.Check(err, jc.Satisfies, errors.IsNotFound)
+	c.Check(subnets, gc.IsNil)
+
+	s.stubAPI.CheckSingleSubnetsCall(c, anyVPC)
+}
+
+func (s *vpcSuite) TestGetVPCSubnetsSuccess(c *gc.C) {
+	s.stubAPI.SetSubnetsResponse(3, anyZone, noPublicIPOnLaunch)
+
+	anyVPC := makeEC2VPC(anyVPCID, anyState)
+	subnets, err := getVPCSubnets(s.stubAPI, anyVPC)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(subnets, jc.DeepEquals, s.stubAPI.subnetsResponse.Subnets)
+
+	s.stubAPI.CheckSingleSubnetsCall(c, anyVPC)
+}
+
+func (s *vpcSuite) TestFindFirstPublicSubnetSuccess(c *gc.C) {
+	s.stubAPI.SetSubnetsResponse(3, anyZone, withPublicIPOnLaunch)
+	s.stubAPI.subnetsResponse.Subnets[0].MapPublicIPOnLaunch = false
+
+	subnet, err := findFirstPublicSubnet(s.stubAPI.subnetsResponse.Subnets)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(subnet, jc.DeepEquals, &s.stubAPI.subnetsResponse.Subnets[1])
+}
+
+func (s *vpcSuite) TestFindFirstPublicSubnetNoneFound(c *gc.C) {
+	s.stubAPI.SetSubnetsResponse(3, anyZone, noPublicIPOnLaunch)
+
+	subnet, err := findFirstPublicSubnet(s.stubAPI.subnetsResponse.Subnets)
+	c.Assert(err, gc.ErrorMatches, "VPC without any public subnets not valid")
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+	c.Check(subnet, gc.IsNil)
+}
+
+func (s *vpcSuite) TestGetVPCInternetGatewayNoResults(c *gc.C) {
+	s.stubAPI.SetGatewaysResponse(noResults, anyState)
+
+	anyVPC := makeEC2VPC(anyVPCID, anyState)
+	gateway, err := getVPCInternetGateway(s.stubAPI, anyVPC)
+	c.Assert(err, gc.ErrorMatches, `VPC without Internet Gateway not valid`)
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+	c.Check(gateway, gc.IsNil)
+
+	s.stubAPI.CheckSingleInternetGatewaysCall(c, anyVPC)
+}
+
+func (s *vpcSuite) TestGetVPCInternetGatewayUnexpectedAWSError(c *gc.C) {
+	s.stubAPI.SetErrors(errors.New("AWS failed!"))
+
+	anyVPC := makeEC2VPC(anyVPCID, anyState)
+	gateway, err := getVPCInternetGateway(s.stubAPI, anyVPC)
+	c.Assert(err, gc.ErrorMatches, `unexpected AWS response getting Internet Gateway of VPC "vpc-anything": AWS failed!`)
+	c.Check(gateway, gc.IsNil)
+
+	s.stubAPI.CheckSingleInternetGatewaysCall(c, anyVPC)
+}
+
+func (s *vpcSuite) TestGetVPCInternetGatewayMultipleResults(c *gc.C) {
+	s.stubAPI.SetGatewaysResponse(3, anyState)
+
+	anyVPC := makeEC2VPC(anyVPCID, anyState)
+	gateway, err := getVPCInternetGateway(s.stubAPI, anyVPC)
+	c.Assert(err, gc.ErrorMatches, "expected 1 result from AWS, got 3")
+	c.Check(gateway, gc.IsNil)
+
+	s.stubAPI.CheckSingleInternetGatewaysCall(c, anyVPC)
+}
+
+func (s *vpcSuite) TestGetVPCInternetGatewaySuccess(c *gc.C) {
+	s.stubAPI.SetGatewaysResponse(1, anyState)
+
+	anyVPC := makeEC2VPC(anyVPCID, anyState)
+	gateway, err := getVPCInternetGateway(s.stubAPI, anyVPC)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(gateway, jc.DeepEquals, &s.stubAPI.gatewaysResponse.InternetGateways[0])
+
+	s.stubAPI.CheckSingleInternetGatewaysCall(c, anyVPC)
+}
+
+func (s *vpcSuite) TestCheckInternetGatewayIsAttached(c *gc.C) {
+	attachedIGW := makeEC2InternetGateway(anyGatewayID, attachedState)
+	c.Check(checkInternetGatewayIsAttached(attachedIGW), jc.ErrorIsNil)
+
+	pendingIGW := makeEC2InternetGateway(anyGatewayID, "pending")
+	err := checkInternetGatewayIsAttached(pendingIGW)
+	c.Assert(err, gc.ErrorMatches, `VPC with Internet Gateway "igw-anything" in unexpected state "pending" not valid`)
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+}
+
+func (s *vpcSuite) TestGetVPCRouteTablesNoResults(c *gc.C) {
+	s.stubAPI.SetRouteTablesResponse() // no results
+
+	anyVPC := makeEC2VPC(anyVPCID, anyState)
+	tables, err := getVPCRouteTables(s.stubAPI, anyVPC)
+	c.Assert(err, gc.ErrorMatches, `VPC without any route tables not valid`)
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+	c.Check(tables, gc.IsNil)
+
+	s.stubAPI.CheckSingleRouteTablesCall(c, anyVPC)
+}
+
+func (s *vpcSuite) TestGetVPCRouteTablesUnexpectedAWSError(c *gc.C) {
+	s.stubAPI.SetErrors(errors.New("AWS failed!"))
+
+	anyVPC := makeEC2VPC(anyVPCID, anyState)
+	tables, err := getVPCRouteTables(s.stubAPI, anyVPC)
+	c.Assert(err, gc.ErrorMatches, `unexpected AWS response getting route tables of VPC "vpc-anything": AWS failed!`)
+	c.Check(tables, gc.IsNil)
+
+	s.stubAPI.CheckSingleRouteTablesCall(c, anyVPC)
+}
+
+func (s *vpcSuite) TestGetVPCRouteTablesSuccess(c *gc.C) {
+	givenVPC := makeEC2VPC("vpc-given", anyState)
+	givenVPC.CIDRBlock = "0.1.0.0/16"
+	givenGateway := makeEC2InternetGateway("igw-given", attachedState)
+
+	s.stubAPI.SetRouteTablesResponse(
+		makeEC2RouteTable("rtb-other", notMainRouteTable, []string{"subnet-1", "subnet-2"}, nil),
+		makeEC2RouteTable("rtb-main", mainRouteTable, nil, makeEC2Routes(
+			givenGateway.Id, givenVPC.CIDRBlock, activeState, 3, // 3 extra routes
+		)),
+	)
+
+	tables, err := getVPCRouteTables(s.stubAPI, givenVPC)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(tables, jc.DeepEquals, s.stubAPI.routeTablesResponse.Tables)
+
+	s.stubAPI.CheckSingleRouteTablesCall(c, givenVPC)
+}
+
+func (s *vpcSuite) TestFindVPCMainRouteTableWithMainAndPerSubnetTables(c *gc.C) {
+	givenTables := []ec2.RouteTable{
+		*makeEC2RouteTable("rtb-main", mainRouteTable, nil, nil),
+		*makeEC2RouteTable("rtb-2-subnets", notMainRouteTable, []string{"subnet-1", "subnet-2"}, nil),
+	}
+
+	mainTable, err := findVPCMainRouteTable(givenTables)
+	c.Assert(err, gc.ErrorMatches, `subnet "subnet-1" not associated with VPC "vpc-anything" main route table`)
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+	c.Check(mainTable, gc.IsNil)
+}
+
+func (s *vpcSuite) TestFindVPCMainRouteTableWithOnlyNonAssociatedTables(c *gc.C) {
+	givenTables := []ec2.RouteTable{
+		*makeEC2RouteTable("rtb-1", notMainRouteTable, nil, nil),
+		*makeEC2RouteTable("rtb-2", notMainRouteTable, nil, nil),
+		*makeEC2RouteTable("rtb-3", notMainRouteTable, nil, nil),
+	}
+
+	mainTable, err := findVPCMainRouteTable(givenTables)
+	c.Assert(err, gc.ErrorMatches, "VPC without associated main route table not valid")
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+	c.Check(mainTable, gc.IsNil)
+}
+
+func (s *vpcSuite) TestFindVPCMainRouteTableWithSingleMainTable(c *gc.C) {
+	givenTables := []ec2.RouteTable{
+		*makeEC2RouteTable("rtb-main", mainRouteTable, nil, nil),
+	}
+
+	mainTable, err := findVPCMainRouteTable(givenTables)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(mainTable, jc.DeepEquals, &givenTables[0])
+}
+
+func (s *vpcSuite) TestFindVPCMainRouteTableWithExtraMainTables(c *gc.C) {
+	givenTables := []ec2.RouteTable{
+		*makeEC2RouteTable("rtb-non-associated", notMainRouteTable, nil, nil),
+		*makeEC2RouteTable("rtb-main", mainRouteTable, nil, nil),
+		*makeEC2RouteTable("rtb-main-extra", mainRouteTable, nil, nil),
+	}
+
+	mainTable, err := findVPCMainRouteTable(givenTables)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(mainTable, jc.DeepEquals, &givenTables[1]) // first found counts
+}
+
+func (s *vpcSuite) TestCheckVPCRouteTableRoutesWithNoDefaultRoute(c *gc.C) {
+	vpc, table, gateway := prepareCheckVPCRouteTableRoutesArgs()
+	c.Check(table.Routes, gc.HasLen, 0) // no routes at all
+
+	checkFailed := func() {
+		err := checkVPCRouteTableRoutes(vpc, table, gateway)
+		c.Assert(err, gc.ErrorMatches, `missing default route via gateway "igw-anything" not valid`)
+		c.Check(err, jc.Satisfies, errors.IsNotValid)
+	}
+	checkFailed()
+
+	table.Routes = makeEC2Routes(gateway.Id, vpc.CIDRBlock, "blackhole", 3) // inactive routes only
+	checkFailed()
+
+	table.Routes = makeEC2Routes("", vpc.CIDRBlock, activeState, 1) // local and 1 extra route
+	checkFailed()
+
+	table.Routes = makeEC2Routes("", vpc.CIDRBlock, activeState, 0) // local route only
+	checkFailed()
+}
+
+func (s *vpcSuite) TestCheckVPCRouteTableRoutesWithDefaultButNoLocalRoutes(c *gc.C) {
+	vpc, table, gateway := prepareCheckVPCRouteTableRoutesArgs()
+	table.Routes = makeEC2Routes(gateway.Id, "", activeState, 3) // default and 3 extra routes; no local route
+
+	checkFailed := func() {
+		err := checkVPCRouteTableRoutes(vpc, table, gateway)
+		c.Assert(err, gc.ErrorMatches, `missing local route with destination "0.1.0.0/16" not valid`)
+		c.Check(err, jc.Satisfies, errors.IsNotValid)
+	}
+	checkFailed()
+
+	table.Routes = makeEC2Routes(gateway.Id, "", activeState, 0) // only default route
+	checkFailed()
+}
+
+func (s *vpcSuite) TestCheckVPCRouteTableRoutesSuccess(c *gc.C) {
+	vpc, table, gateway := prepareCheckVPCRouteTableRoutesArgs()
+	table.Routes = makeEC2Routes(gateway.Id, vpc.CIDRBlock, activeState, 3) // default, local and 3 extra routes
+
+	err := checkVPCRouteTableRoutes(vpc, table, gateway)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *vpcSuite) TestFindDefaultVPCIDUnexpectedAWSError(c *gc.C) {
+	s.stubAPI.SetErrors(errors.New("AWS failed!"))
+
+	vpcID, err := findDefaultVPCID(s.stubAPI)
+	c.Assert(err, gc.ErrorMatches, "unexpected AWS response getting default-vpc account attribute: AWS failed!")
+	c.Check(vpcID, gc.Equals, "")
+
+	s.stubAPI.CheckSingleAccountAttributesCall(c, "default-vpc")
+}
+
+func (s *vpcSuite) TestFindDefaultVPCIDNoAttributeOrNoValue(c *gc.C) {
+	s.stubAPI.SetAttributesResponse(nil) // no attributes at all
+
+	checkFailed := func() {
+		vpcID, err := findDefaultVPCID(s.stubAPI)
+		c.Assert(err, gc.ErrorMatches, "default-vpc account attribute not found")
+		c.Check(err, jc.Satisfies, errors.IsNotFound)
+		c.Check(vpcID, gc.Equals, "")
+
+		s.stubAPI.CheckSingleAccountAttributesCall(c, "default-vpc")
+	}
+	checkFailed()
+
+	s.stubAPI.SetAttributesResponse(map[string][]string{
+		"any-attribute": nil, // no values
+	})
+	checkFailed()
+
+	s.stubAPI.SetAttributesResponse(map[string][]string{
+		"not-default-vpc-attribute": []string{"foo", "bar"}, // wrong name
+	})
+	checkFailed()
+
+	s.stubAPI.SetAttributesResponse(map[string][]string{
+		"default-vpc": nil, // name ok, no values
+	})
+	checkFailed()
+
+	s.stubAPI.SetAttributesResponse(map[string][]string{
+		"default-vpc": []string{}, // name ok, empty values
+	})
+	checkFailed()
+}
+
+func (s *vpcSuite) TestFindDefaultVPCIDWithExplicitNoneValue(c *gc.C) {
+	s.stubAPI.SetAttributesResponse(map[string][]string{
+		"default-vpc": []string{"none"},
+	})
+
+	vpcID, err := findDefaultVPCID(s.stubAPI)
+	c.Assert(err, gc.ErrorMatches, "default VPC not found")
+	c.Check(err, jc.Satisfies, errors.IsNotFound)
+	c.Check(vpcID, gc.Equals, "")
+
+	s.stubAPI.CheckSingleAccountAttributesCall(c, "default-vpc")
+}
+
+func (s *vpcSuite) TestFindDefaultVPCIDSuccess(c *gc.C) {
+	s.stubAPI.SetAttributesResponse(map[string][]string{
+		"default-vpc": []string{"vpc-foo", "vpc-bar"},
+	})
+
+	vpcID, err := findDefaultVPCID(s.stubAPI)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(vpcID, gc.Equals, "vpc-foo") // always the first value is used.
+
+	s.stubAPI.CheckSingleAccountAttributesCall(c, "default-vpc")
+}
+
+func (s *vpcSuite) TestGetVPCSubnetIDsForAvailabilityZoneWithSubnetsError(c *gc.C) {
+	s.stubAPI.SetErrors(errors.New("too cloudy"))
+
+	anyVPC := makeEC2VPC(anyVPCID, anyState)
+	subnetIDs, err := getVPCSubnetIDsForAvailabilityZone(s.stubAPI, anyVPC.Id, anyZone)
+	c.Assert(err, gc.ErrorMatches, `cannot get VPC "vpc-anything" subnets: unexpected AWS .*: too cloudy`)
+	c.Check(subnetIDs, gc.IsNil)
+
+	s.stubAPI.CheckSingleSubnetsCall(c, anyVPC)
+}
+
+func (s *vpcSuite) TestGetVPCSubnetIDsForAvailabilityZoneNoSubnetsAtAll(c *gc.C) {
+	s.stubAPI.SetSubnetsResponse(noResults, anyZone, noPublicIPOnLaunch)
+
+	anyVPC := makeEC2VPC(anyVPCID, anyState)
+	subnetIDs, err := getVPCSubnetIDsForAvailabilityZone(s.stubAPI, anyVPC.Id, anyZone)
+	c.Assert(err, gc.ErrorMatches, `VPC "vpc-anything" has no subnets in AZ "any-zone": no subnets found for VPC.*`)
+	c.Check(err, jc.Satisfies, errors.IsNotFound)
+	c.Check(subnetIDs, gc.IsNil)
+
+	s.stubAPI.CheckSingleSubnetsCall(c, anyVPC)
+}
+
+func (s *vpcSuite) TestGetVPCSubnetIDsForAvailabilityZoneNoSubnetsInAZ(c *gc.C) {
+	s.stubAPI.SetSubnetsResponse(3, "other-zone", noPublicIPOnLaunch)
+
+	anyVPC := makeEC2VPC(anyVPCID, anyState)
+	subnetIDs, err := getVPCSubnetIDsForAvailabilityZone(s.stubAPI, anyVPC.Id, "given-zone")
+	c.Assert(err, gc.ErrorMatches, `VPC "vpc-anything" has no subnets in AZ "given-zone"`)
+	c.Check(err, jc.Satisfies, errors.IsNotFound)
+	c.Check(subnetIDs, gc.IsNil)
+
+	s.stubAPI.CheckSingleSubnetsCall(c, anyVPC)
+}
+
+func (s *vpcSuite) TestGetVPCSubnetIDsForAvailabilityZoneSuccess(c *gc.C) {
+	s.stubAPI.SetSubnetsResponse(2, "my-zone", noPublicIPOnLaunch)
+
+	anyVPC := makeEC2VPC(anyVPCID, anyState)
+	subnetIDs, err := getVPCSubnetIDsForAvailabilityZone(s.stubAPI, anyVPC.Id, "my-zone")
+	c.Assert(err, jc.ErrorIsNil)
+	// Result slice of IDs is always sorted.
+	c.Check(subnetIDs, jc.DeepEquals, []string{"subnet-0", "subnet-1"})
+
+	s.stubAPI.CheckSingleSubnetsCall(c, anyVPC)
+}
+
+var fakeSubnetsToZones = map[network.Id][]string{
+	"subnet-foo": []string{"az1", "az2"},
+	"subnet-bar": []string{"az1"},
+	"subnet-oof": []string{"az3"},
+}
+
+func (s *vpcSuite) TestFindSubnetIDsForAvailabilityZoneNoneFound(c *gc.C) {
+	subnetIDs, err := findSubnetIDsForAvailabilityZone("unknown-zone", fakeSubnetsToZones)
+	c.Assert(err, gc.ErrorMatches, `subnets in AZ "unknown-zone" not found`)
+	c.Check(err, jc.Satisfies, errors.IsNotFound)
+	c.Check(subnetIDs, gc.IsNil)
+}
+
+func (s *vpcSuite) TestFindSubnetIDsForAvailabilityOneMatched(c *gc.C) {
+	subnetIDs, err := findSubnetIDsForAvailabilityZone("az3", fakeSubnetsToZones)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(subnetIDs, gc.DeepEquals, []string{"subnet-oof"})
+}
+
+func (s *vpcSuite) TestFindSubnetIDsForAvailabilityMultipleMatched(c *gc.C) {
+	subnetIDs, err := findSubnetIDsForAvailabilityZone("az1", fakeSubnetsToZones)
+	c.Assert(err, jc.ErrorIsNil)
+	// Result slice of IDs is always sorted.
+	c.Check(subnetIDs, gc.DeepEquals, []string{"subnet-bar", "subnet-foo"})
+}
+
+const (
+	notDefaultVPC = false
+	defaultVPC    = true
+
+	notMainRouteTable = false
+	mainRouteTable    = true
+
+	noResults = 0
+
+	anyState     = "any state"
+	anyVPCID     = "vpc-anything"
+	anyGatewayID = "igw-anything"
+	anyTableID   = "rtb-anything"
+	anyZone      = "any-zone"
+
+	noPublicIPOnLaunch   = false
+	withPublicIPOnLaunch = true
+)
+
+type stubVPCAPIClient struct {
+	*testing.Stub
+
+	attributesResponse  *ec2.AccountAttributesResp
+	vpcsResponse        *ec2.VPCsResp
+	subnetsResponse     *ec2.SubnetsResp
+	gatewaysResponse    *ec2.InternetGatewaysResp
+	routeTablesResponse *ec2.RouteTablesResp
+}
+
+func (s *stubVPCAPIClient) SetAttributesResponse(attributeNameToValues map[string][]string) {
+	s.attributesResponse = &ec2.AccountAttributesResp{
+		RequestId:  "fake-request-id",
+		Attributes: make([]ec2.AccountAttribute, 0, len(attributeNameToValues)),
+	}
+
+	for name, values := range attributeNameToValues {
+		attribute := ec2.AccountAttribute{
+			Name:   name,
+			Values: values,
+		}
+		s.attributesResponse.Attributes = append(s.attributesResponse.Attributes, attribute)
+	}
+}
+
+func (s *stubVPCAPIClient) AccountAttributes(attributeNames ...string) (*ec2.AccountAttributesResp, error) {
+	s.Stub.AddCall("AccountAttributes", makeArgsFromStrings(attributeNames...)...)
+	return s.attributesResponse, s.Stub.NextErr()
+}
+
+func (s *stubVPCAPIClient) CheckSingleAccountAttributesCall(c *gc.C, attributeNames ...string) {
+	s.Stub.CheckCallNames(c, "AccountAttributes")
+	s.Stub.CheckCall(c, 0, "AccountAttributes", makeArgsFromStrings(attributeNames...)...)
+	s.Stub.ResetCalls()
+}
+
+func (s *stubVPCAPIClient) SetVPCsResponse(numResults int, state string, isDefault bool) {
+	s.vpcsResponse = &ec2.VPCsResp{
+		RequestId: "fake-request-id",
+		VPCs:      make([]ec2.VPC, numResults),
+	}
+
+	for i := range s.vpcsResponse.VPCs {
+		id := fmt.Sprintf("vpc-%d", i)
+		vpc := makeEC2VPC(id, state)
+		vpc.IsDefault = isDefault
+		s.vpcsResponse.VPCs[i] = *vpc
+	}
+}
+
+func (s *stubVPCAPIClient) VPCs(ids []string, filter *ec2.Filter) (*ec2.VPCsResp, error) {
+	s.Stub.AddCall("VPCs", ids, filter)
+	return s.vpcsResponse, s.Stub.NextErr()
+}
+
+func (s *stubVPCAPIClient) CheckSingleVPCsCall(c *gc.C, vpcID string) {
+	var nilFilter *ec2.Filter
+	s.Stub.CheckCallNames(c, "VPCs")
+	s.Stub.CheckCall(c, 0, "VPCs", []string{vpcID}, nilFilter)
+	s.Stub.ResetCalls()
+}
+
+func (s *stubVPCAPIClient) SetSubnetsResponse(numResults int, zone string, mapPublicIpOnLaunch bool) {
+	s.subnetsResponse = &ec2.SubnetsResp{
+		RequestId: "fake-request-id",
+		Subnets:   make([]ec2.Subnet, numResults),
+	}
+
+	for i := range s.subnetsResponse.Subnets {
+		s.subnetsResponse.Subnets[i] = ec2.Subnet{
+			Id:                  fmt.Sprintf("subnet-%d", i),
+			VPCId:               anyVPCID,
+			State:               anyState,
+			AvailZone:           zone,
+			CIDRBlock:           fmt.Sprintf("0.1.%d.0/20", i),
+			MapPublicIPOnLaunch: mapPublicIpOnLaunch,
+		}
+	}
+}
+
+func (s *stubVPCAPIClient) Subnets(ids []string, filter *ec2.Filter) (*ec2.SubnetsResp, error) {
+	s.Stub.AddCall("Subnets", ids, filter)
+	return s.subnetsResponse, s.Stub.NextErr()
+}
+
+func (s *stubVPCAPIClient) CheckSingleSubnetsCall(c *gc.C, vpc *ec2.VPC) {
+	var nilIDs []string
+	filter := ec2.NewFilter()
+	filter.Add("vpc-id", vpc.Id)
+
+	s.Stub.CheckCallNames(c, "Subnets")
+	s.Stub.CheckCall(c, 0, "Subnets", nilIDs, filter)
+	s.Stub.ResetCalls()
+}
+
+func (s *stubVPCAPIClient) SetGatewaysResponse(numResults int, attachmentState string) {
+	s.gatewaysResponse = &ec2.InternetGatewaysResp{
+		RequestId:        "fake-request-id",
+		InternetGateways: make([]ec2.InternetGateway, numResults),
+	}
+
+	for i := range s.gatewaysResponse.InternetGateways {
+		id := fmt.Sprintf("igw-%d", i)
+		gateway := makeEC2InternetGateway(id, attachmentState)
+		s.gatewaysResponse.InternetGateways[i] = *gateway
+	}
+}
+
+func (s *stubVPCAPIClient) InternetGateways(ids []string, filter *ec2.Filter) (*ec2.InternetGatewaysResp, error) {
+	s.Stub.AddCall("InternetGateways", ids, filter)
+	return s.gatewaysResponse, s.Stub.NextErr()
+}
+
+func (s *stubVPCAPIClient) CheckSingleInternetGatewaysCall(c *gc.C, vpc *ec2.VPC) {
+	var nilIDs []string
+	filter := ec2.NewFilter()
+	filter.Add("attachment.vpc-id", vpc.Id)
+
+	s.Stub.CheckCallNames(c, "InternetGateways")
+	s.Stub.CheckCall(c, 0, "InternetGateways", nilIDs, filter)
+	s.Stub.ResetCalls()
+}
+
+func (s *stubVPCAPIClient) SetRouteTablesResponse(tables ...*ec2.RouteTable) {
+	s.routeTablesResponse = &ec2.RouteTablesResp{
+		RequestId: "fake-request-id",
+		Tables:    make([]ec2.RouteTable, len(tables)),
+	}
+
+	for i := range s.routeTablesResponse.Tables {
+		s.routeTablesResponse.Tables[i] = *tables[i]
+	}
+}
+
+func (s *stubVPCAPIClient) RouteTables(ids []string, filter *ec2.Filter) (*ec2.RouteTablesResp, error) {
+	s.Stub.AddCall("RouteTables", ids, filter)
+	return s.routeTablesResponse, s.Stub.NextErr()
+}
+
+func (s *stubVPCAPIClient) CheckSingleRouteTablesCall(c *gc.C, vpc *ec2.VPC) {
+	var nilIDs []string
+	filter := ec2.NewFilter()
+	filter.Add("vpc-id", vpc.Id)
+
+	s.Stub.CheckCallNames(c, "RouteTables")
+	s.Stub.CheckCall(c, 0, "RouteTables", nilIDs, filter)
+	s.Stub.ResetCalls()
+}
+
+func (s *stubVPCAPIClient) PrepareValidateVPCResponses() {
+	s.SetVPCsResponse(1, availableState, notDefaultVPC)
+	s.vpcsResponse.VPCs[0].CIDRBlock = "0.1.0.0/16"
+	s.SetSubnetsResponse(1, anyZone, withPublicIPOnLaunch)
+	s.SetGatewaysResponse(1, attachedState)
+	onlyDefaultAndLocalRoutes := makeEC2Routes(
+		s.gatewaysResponse.InternetGateways[0].Id,
+		s.vpcsResponse.VPCs[0].CIDRBlock,
+		activeState,
+		0, // no extra routes
+	)
+	s.SetRouteTablesResponse(
+		makeEC2RouteTable(anyTableID, mainRouteTable, nil, onlyDefaultAndLocalRoutes),
+	)
+}
+
+func (s *stubVPCAPIClient) CallValidateVPCAndCheckCallsUpToExpectingNotValidError(c *gc.C, lastExpectedCallName string) {
+	err := validateVPC(s, anyVPCID)
+	c.Assert(err, jc.Satisfies, errors.IsNotValid)
+
+	allCalls := []string{"VPCs", "Subnets", "InternetGateways", "RouteTables"}
+	var expectedCalls []string
+	for i := range allCalls {
+		expectedCalls = append(expectedCalls, allCalls[i])
+		if allCalls[i] == lastExpectedCallName {
+			break
+		}
+	}
+	s.CheckCallNames(c, expectedCalls...)
+}
+
+func makeEC2VPC(vpcID, state string) *ec2.VPC {
+	return &ec2.VPC{
+		Id:    vpcID,
+		State: state,
+	}
+}
+
+func makeEC2InternetGateway(gatewayID, attachmentState string) *ec2.InternetGateway {
+	return &ec2.InternetGateway{
+		Id:              gatewayID,
+		VPCId:           anyVPCID,
+		AttachmentState: attachmentState,
+	}
+}
+
+func makeEC2RouteTable(tableID string, isMain bool, associatedSubnetIDs []string, routes []ec2.Route) *ec2.RouteTable {
+	table := &ec2.RouteTable{
+		Id:     tableID,
+		VPCId:  anyVPCID,
+		Routes: routes,
+	}
+
+	if isMain {
+		table.Associations = []ec2.RouteTableAssociation{{
+			Id:      "rtbassoc-main",
+			TableId: tableID,
+			IsMain:  true,
+		}}
+	} else {
+		table.Associations = make([]ec2.RouteTableAssociation, len(associatedSubnetIDs))
+		for i := range associatedSubnetIDs {
+			table.Associations[i] = ec2.RouteTableAssociation{
+				Id:       fmt.Sprintf("rtbassoc-%d", i),
+				TableId:  tableID,
+				SubnetId: associatedSubnetIDs[i],
+			}
+		}
+	}
+	return table
+}
+
+func makeEC2Routes(defaultRouteGatewayID, localRouteCIDRBlock, state string, numExtraRoutes int) []ec2.Route {
+	var routes []ec2.Route
+
+	if defaultRouteGatewayID != "" {
+		routes = append(routes, ec2.Route{
+			DestinationCIDRBlock: defaultRouteCIDRBlock,
+			GatewayId:            defaultRouteGatewayID,
+			State:                state,
+		})
+	}
+
+	if localRouteCIDRBlock != "" {
+		routes = append(routes, ec2.Route{
+			DestinationCIDRBlock: localRouteCIDRBlock,
+			GatewayId:            localRouteGatewayID,
+			State:                state,
+		})
+	}
+
+	if numExtraRoutes > 0 {
+		for i := 0; i < numExtraRoutes; i++ {
+			routes = append(routes, ec2.Route{
+				DestinationCIDRBlock: fmt.Sprintf("0.1.%d.0/24", i),
+				State:                state,
+			})
+		}
+	}
+
+	return routes
+}
+
+func prepareCheckVPCRouteTableRoutesArgs() (*ec2.VPC, *ec2.RouteTable, *ec2.InternetGateway) {
+	anyVPC := makeEC2VPC(anyVPCID, anyState)
+	anyVPC.CIDRBlock = "0.1.0.0/16"
+	anyTable := makeEC2RouteTable(anyTableID, notMainRouteTable, nil, nil)
+	anyGateway := makeEC2InternetGateway(anyGatewayID, anyState)
+
+	return anyVPC, anyTable, anyGateway
+}
+
+func makeEC2Error(statusCode int, code, message, requestID string) error {
+	return &ec2.Error{
+		StatusCode: statusCode,
+		Code:       code,
+		Message:    message,
+		RequestId:  requestID,
+	}
+}
+
+func makeVPCNotFoundError(vpcID string) error {
+	return makeEC2Error(
+		400,
+		"InvalidVpcID.NotFound",
+		fmt.Sprintf("The vpc ID '%s' does not exist", vpcID),
+		"fake-request-id",
+	)
+}
+
+func makeArgsFromStrings(strings ...string) []interface{} {
+	args := make([]interface{}, len(strings))
+	for i := range strings {
+		args[i] = strings[i]
+	}
+	return args
+}

--- a/provider/ec2/environ_vpc_test.go
+++ b/provider/ec2/environ_vpc_test.go
@@ -605,12 +605,47 @@ const (
 
 type stubVPCAPIClient struct {
 	*testing.Stub
+	vpcAPIClient // embedded mostly for documentation
 
 	attributesResponse  *ec2.AccountAttributesResp
 	vpcsResponse        *ec2.VPCsResp
 	subnetsResponse     *ec2.SubnetsResp
 	gatewaysResponse    *ec2.InternetGatewaysResp
 	routeTablesResponse *ec2.RouteTablesResp
+}
+
+// AccountAttributes implements vpcAPIClient and is used to test finding the
+// default VPC from the "default-vpc"" attribute.
+func (s *stubVPCAPIClient) AccountAttributes(attributeNames ...string) (*ec2.AccountAttributesResp, error) {
+	s.Stub.AddCall("AccountAttributes", makeArgsFromStrings(attributeNames...)...)
+	return s.attributesResponse, s.Stub.NextErr()
+}
+
+// VPCs implements vpcAPIClient and is used to test getting the details of a
+// VPC.
+func (s *stubVPCAPIClient) VPCs(ids []string, filter *ec2.Filter) (*ec2.VPCsResp, error) {
+	s.Stub.AddCall("VPCs", ids, filter)
+	return s.vpcsResponse, s.Stub.NextErr()
+}
+
+// Subnets implements vpcAPIClient and is used to test getting a VPC's subnets.
+func (s *stubVPCAPIClient) Subnets(ids []string, filter *ec2.Filter) (*ec2.SubnetsResp, error) {
+	s.Stub.AddCall("Subnets", ids, filter)
+	return s.subnetsResponse, s.Stub.NextErr()
+}
+
+// InternetGateways implements vpcAPIClient and is used to test getting the
+// attached IGW of a VPC.
+func (s *stubVPCAPIClient) InternetGateways(ids []string, filter *ec2.Filter) (*ec2.InternetGatewaysResp, error) {
+	s.Stub.AddCall("InternetGateways", ids, filter)
+	return s.gatewaysResponse, s.Stub.NextErr()
+}
+
+// RouteTables implements vpcAPIClient and is used to test getting all route
+// tables of a VPC, alond with their routes.
+func (s *stubVPCAPIClient) RouteTables(ids []string, filter *ec2.Filter) (*ec2.RouteTablesResp, error) {
+	s.Stub.AddCall("RouteTables", ids, filter)
+	return s.routeTablesResponse, s.Stub.NextErr()
 }
 
 func (s *stubVPCAPIClient) SetAttributesResponse(attributeNameToValues map[string][]string) {
@@ -627,12 +662,6 @@ func (s *stubVPCAPIClient) SetAttributesResponse(attributeNameToValues map[strin
 		s.attributesResponse.Attributes = append(s.attributesResponse.Attributes, attribute)
 	}
 }
-
-func (s *stubVPCAPIClient) AccountAttributes(attributeNames ...string) (*ec2.AccountAttributesResp, error) {
-	s.Stub.AddCall("AccountAttributes", makeArgsFromStrings(attributeNames...)...)
-	return s.attributesResponse, s.Stub.NextErr()
-}
-
 func (s *stubVPCAPIClient) CheckSingleAccountAttributesCall(c *gc.C, attributeNames ...string) {
 	s.Stub.CheckCallNames(c, "AccountAttributes")
 	s.Stub.CheckCall(c, 0, "AccountAttributes", makeArgsFromStrings(attributeNames...)...)
@@ -651,11 +680,6 @@ func (s *stubVPCAPIClient) SetVPCsResponse(numResults int, state string, isDefau
 		vpc.IsDefault = isDefault
 		s.vpcsResponse.VPCs[i] = *vpc
 	}
-}
-
-func (s *stubVPCAPIClient) VPCs(ids []string, filter *ec2.Filter) (*ec2.VPCsResp, error) {
-	s.Stub.AddCall("VPCs", ids, filter)
-	return s.vpcsResponse, s.Stub.NextErr()
 }
 
 func (s *stubVPCAPIClient) CheckSingleVPCsCall(c *gc.C, vpcID string) {
@@ -683,11 +707,6 @@ func (s *stubVPCAPIClient) SetSubnetsResponse(numResults int, zone string, mapPu
 	}
 }
 
-func (s *stubVPCAPIClient) Subnets(ids []string, filter *ec2.Filter) (*ec2.SubnetsResp, error) {
-	s.Stub.AddCall("Subnets", ids, filter)
-	return s.subnetsResponse, s.Stub.NextErr()
-}
-
 func (s *stubVPCAPIClient) CheckSingleSubnetsCall(c *gc.C, vpc *ec2.VPC) {
 	var nilIDs []string
 	filter := ec2.NewFilter()
@@ -711,11 +730,6 @@ func (s *stubVPCAPIClient) SetGatewaysResponse(numResults int, attachmentState s
 	}
 }
 
-func (s *stubVPCAPIClient) InternetGateways(ids []string, filter *ec2.Filter) (*ec2.InternetGatewaysResp, error) {
-	s.Stub.AddCall("InternetGateways", ids, filter)
-	return s.gatewaysResponse, s.Stub.NextErr()
-}
-
 func (s *stubVPCAPIClient) CheckSingleInternetGatewaysCall(c *gc.C, vpc *ec2.VPC) {
 	var nilIDs []string
 	filter := ec2.NewFilter()
@@ -735,11 +749,6 @@ func (s *stubVPCAPIClient) SetRouteTablesResponse(tables ...*ec2.RouteTable) {
 	for i := range s.routeTablesResponse.Tables {
 		s.routeTablesResponse.Tables[i] = *tables[i]
 	}
-}
-
-func (s *stubVPCAPIClient) RouteTables(ids []string, filter *ec2.Filter) (*ec2.RouteTablesResp, error) {
-	s.Stub.AddCall("RouteTables", ids, filter)
-	return s.routeTablesResponse, s.Stub.NextErr()
 }
 
 func (s *stubVPCAPIClient) CheckSingleRouteTablesCall(c *gc.C, vpc *ec2.VPC) {

--- a/provider/ec2/environ_vpc_test.go
+++ b/provider/ec2/environ_vpc_test.go
@@ -300,11 +300,11 @@ func (s *vpcSuite) TestGetVPCInternetGatewaySuccess(c *gc.C) {
 }
 
 func (s *vpcSuite) TestCheckInternetGatewayIsAttached(c *gc.C) {
-	attachedIGW := makeEC2InternetGateway(anyGatewayID, attachedState)
-	c.Check(checkInternetGatewayIsAttached(attachedIGW), jc.ErrorIsNil)
+	availableIGW := makeEC2InternetGateway(anyGatewayID, availableState)
+	c.Check(checkInternetGatewayIsAvailable(availableIGW), jc.ErrorIsNil)
 
 	pendingIGW := makeEC2InternetGateway(anyGatewayID, "pending")
-	err := checkInternetGatewayIsAttached(pendingIGW)
+	err := checkInternetGatewayIsAvailable(pendingIGW)
 	c.Assert(err, gc.ErrorMatches, `VPC with Internet Gateway "igw-anything" in unexpected state "pending" not valid`)
 	c.Check(err, jc.Satisfies, errors.IsNotValid)
 }
@@ -335,7 +335,7 @@ func (s *vpcSuite) TestGetVPCRouteTablesUnexpectedAWSError(c *gc.C) {
 func (s *vpcSuite) TestGetVPCRouteTablesSuccess(c *gc.C) {
 	givenVPC := makeEC2VPC("vpc-given", anyState)
 	givenVPC.CIDRBlock = "0.1.0.0/16"
-	givenGateway := makeEC2InternetGateway("igw-given", attachedState)
+	givenGateway := makeEC2InternetGateway("igw-given", availableState)
 
 	s.stubAPI.SetRouteTablesResponse(
 		makeEC2RouteTable("rtb-other", notMainRouteTable, []string{"subnet-1", "subnet-2"}, nil),
@@ -756,7 +756,7 @@ func (s *stubVPCAPIClient) PrepareValidateVPCResponses() {
 	s.SetVPCsResponse(1, availableState, notDefaultVPC)
 	s.vpcsResponse.VPCs[0].CIDRBlock = "0.1.0.0/16"
 	s.SetSubnetsResponse(1, anyZone, withPublicIPOnLaunch)
-	s.SetGatewaysResponse(1, attachedState)
+	s.SetGatewaysResponse(1, availableState)
 	onlyDefaultAndLocalRoutes := makeEC2Routes(
 		s.gatewaysResponse.InternetGateways[0].Id,
 		s.vpcsResponse.VPCs[0].CIDRBlock,

--- a/provider/ec2/live_test.go
+++ b/provider/ec2/live_test.go
@@ -167,7 +167,6 @@ func (t *LiveTests) TestInstanceGroups(c *gc.C) {
 	groups := amzec2.SecurityGroupNames(
 		ec2.JujuGroupName(t.Env),
 		ec2.MachineGroupName(t.Env, "98"),
-		ec2.MachineGroupName(t.Env, "99"),
 	)
 	info := make([]amzec2.SecurityGroupInfo, len(groups))
 
@@ -201,7 +200,7 @@ func (t *LiveTests) TestInstanceGroups(c *gc.C) {
 
 	// Create a same-named group for the second instance
 	// before starting it, to check that it's reused correctly.
-	oldMachineGroup := createGroup(c, ec2conn, groups[2].Name, "old machine group")
+	oldMachineGroup := createGroup(c, ec2conn, groups[1].Name, "old machine group")
 
 	inst1, _ := testing.AssertStartInstance(c, t.Env, "99")
 	defer t.Env.StopInstances(inst1.Id())
@@ -240,7 +239,7 @@ func (t *LiveTests) TestInstanceGroups(c *gc.C) {
 	checkSecurityGroupAllowed(c, perms, groups[0])
 
 	// The old machine group should have been reused also.
-	c.Check(groups[2].Id, gc.Equals, oldMachineGroup.Id)
+	c.Check(groups[1].Id, gc.Equals, oldMachineGroup.Id)
 
 	// Check that each instance is part of the correct groups.
 	resp, err := ec2conn.Instances([]string{string(inst0.Id()), string(inst1.Id())}, nil)
@@ -255,9 +254,7 @@ func (t *LiveTests) TestInstanceGroups(c *gc.C) {
 		switch instance.Id(inst.InstanceId) {
 		case inst0.Id():
 			c.Assert(hasSecurityGroup(inst, groups[1]), gc.Equals, true, msg)
-			c.Assert(hasSecurityGroup(inst, groups[2]), gc.Equals, false, msg)
 		case inst1.Id():
-			c.Assert(hasSecurityGroup(inst, groups[2]), gc.Equals, true, msg)
 			c.Assert(hasSecurityGroup(inst, groups[1]), gc.Equals, false, msg)
 		default:
 			c.Errorf("unknown instance found: %v", inst)

--- a/provider/ec2/provider.go
+++ b/provider/ec2/provider.go
@@ -27,7 +27,7 @@ var providerInstance environProvider
 
 // RestrictedConfigAttributes is specified in the EnvironProvider interface.
 func (p environProvider) RestrictedConfigAttributes() []string {
-	return []string{"region", "vpc-id", "force-vpc-id"}
+	return []string{"region", "vpc-id", "vpc-id-force"}
 }
 
 // PrepareForCreateEnvironment is specified in the EnvironProvider interface.
@@ -102,7 +102,7 @@ Juju requirements:
 A default VPC already satisfies all of the requirements above. If you
 still want to use the VPC, try running 'juju bootstrap' again with:
 
-  --config vpc-id=%s --config force-vpc-id=true
+  --config vpc-id=%s --config vpc-id-force=true
 
 to force Juju to bypass the requirements check (NOT recommended unless
 you understand the implications, most importantly: not being able to
@@ -122,7 +122,7 @@ Error details`[1:]
 
 	vpcPossiblyUnsuitableButForcedWarning = `
 WARNING! The specified vpc-id does not satisfy the minimum Juju requirements,
-but will be used anyway because force-vpc-id=true is also specified.
+but will be used anyway because vpc-id-force=true is also specified.
 
 `[1:]
 )

--- a/provider/ec2/provider.go
+++ b/provider/ec2/provider.go
@@ -95,15 +95,17 @@ func (p environProvider) PrepareForBootstrap(
 		}
 	}
 
-	vpcID, isDefault, err := env.getVPC()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	if isDefault {
-		ctx.Infof("Using default VPC %q for region %q", vpcID, env.ecfg().region())
-	} else {
-		ctx.Infof("Using non-default VPC %q in region %q", vpcID, env.ecfg().region())
+	vpcIDFromConfig := env.ecfg().vpcID()
+	if vpcIDFromConfig != "" {
+		vpcID, isDefault, err := env.getVPC()
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		if isDefault {
+			ctx.Infof("Using default VPC %q for region %q", vpcID, env.ecfg().region())
+		} else {
+			ctx.Infof("Using non-default VPC %q in region %q", vpcID, env.ecfg().region())
+		}
 	}
 
 	return e, nil

--- a/provider/ec2/provider.go
+++ b/provider/ec2/provider.go
@@ -106,7 +106,7 @@ func (p environProvider) PrepareForBootstrap(
 			return nil, errors.Trace(err)
 		}
 
-		ctx.Infof("Using VPC %q inr region %q", vpcID, env.ecfg().region())
+		ctx.Infof("Using VPC %q in region %q", vpcID, env.ecfg().region())
 	}
 
 	return e, nil


### PR DESCRIPTION
Added a new optional config setting "vpc-id", which if set changes the AWS VPC to use.
A few minimal checks are done when specified - whether the VPC exists, it has available
subnets, which can host a Juju controller. If those checks fail, power users can still force
Juju to try using the VPC (at their own risk) with another new config setting (a Boolean
 flag): "vpc-id-force".

Live tested on aws/eu-central-1 with a few VPCs (default, one with only public subnets, one
with only private subnets, and one mixed).

See also http://pad.lv/1321442 for more info.

(Review request: http://reviews.vapour.ws/r/4734/)