### PR TITLE
Don't close retry channel, but be paranoid about it getting closed in the consumer

### DIFF
--- a/worker/uniter/remotestate/watcher.go
+++ b/worker/uniter/remotestate/watcher.go
@@ -411,13 +411,19 @@ func (w *RemoteStateWatcher) loop(unitTag names.UnitTag) (err error) {
 				return errors.Trace(err)
 			}
 
-		case id := <-w.commandChannel:
+		case id, ok := <-w.commandChannel:
+			if !ok {
+				return errors.New("commandChannel closed")
+			}
 			logger.Debugf("command enqueued: %v", id)
 			if err := w.commandsChanged(id); err != nil {
 				return err
 			}
 
-		case <-w.retryHookChannel:
+		case _, ok := <-w.retryHookChannel:
+			if !ok {
+				return errors.New("retryHookChannel closed")
+			}
 			logger.Debugf("retry hook timer triggered")
 			if err := w.retryHookTimerTriggered(); err != nil {
 				return err

--- a/worker/uniter/uniter.go
+++ b/worker/uniter/uniter.go
@@ -219,10 +219,9 @@ func (u *Uniter) loop(unitTag names.UnitTag) (err error) {
 		Clock: u.clock,
 	})
 	defer func() {
-		// Stop any send that might be pending
-		// before closing the channel
+		// Whenever we exit the uniter we want to stop a potentially
+		// running timer so it doesn't trigger for nothing.
 		retryHookTimer.Reset()
-		close(retryHookChan)
 	}()
 
 	restartWatcher := func() error {


### PR DESCRIPTION
As seen [here](http://data.vapour.ws/juju-ci/products/version-3930/run-unit-tests-win2012-amd64-go1_6/build-48/consoleText), we would bounce a lot on the `retryHookChan` until the `ErrDying()` channel signaled.

We don't have to close the channel since it will be cleaned by the GC. We also don't *have* to try and stop the timer, but it makes more sense to do it anyway.

(Review request: http://reviews.vapour.ws/r/4736/)