### PR TITLE
Install mongo tools on xenial

### DIFF
--- a/cmd/jujud/upgrade_mongo.go
+++ b/cmd/jujud/upgrade_mongo.go
@@ -632,6 +632,9 @@ func satisfyPrerequisites(operatingsystem string) error {
 	if err := pacman.Install(mongo.JujuMongoPackage); err != nil {
 		return errors.Annotatef(err, "cannot install %v", mongo.JujuMongoPackage)
 	}
+	if err := pacman.Install(mongo.JujuMongoToolsPackage); err != nil {
+		return errors.Annotatef(err, "cannot install %v", mongo.JujuMongoToolsPackage)
+	}
 	return nil
 }
 

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -49,6 +49,10 @@ const (
 	// installing mongo.
 	JujuMongoPackage = "juju-mongodb3.2"
 
+	// JujuMongoTooldPackage is the mongo package Juju uses when
+	// installing mongo tools to get mongodump etc.
+	JujuMongoToolsPackage = "juju-mongo-tools3.2"
+
 	// MMAPV1 is the default storage engine in mongo db up to 3.x
 	MMAPV1 StorageEngine = "mmapv1"
 
@@ -610,10 +614,10 @@ func packagesForSeries(series string) ([]string, []string) {
 	case "precise", "quantal", "raring", "saucy", "centos7":
 		return []string{"mongodb-server"}, []string{}
 	case "trusty", "wily", "xenial":
-		return []string{JujuMongoPackage}, []string{"juju-mongodb"}
+		return []string{JujuMongoPackage, JujuMongoToolsPackage}, []string{"juju-mongodb"}
 	default:
 		// y and onwards
-		return []string{JujuMongoPackage}, []string{}
+		return []string{JujuMongoPackage, JujuMongoToolsPackage}, []string{}
 	}
 }
 

--- a/mongo/mongo_test.go
+++ b/mongo/mongo_test.go
@@ -330,14 +330,15 @@ func (s *MongoSuite) TestInstallMongod(c *gc.C) {
 
 	tests := []installs{
 		{"precise", [][]string{{"--target-release", "precise-updates/cloud-tools", "mongodb-server"}}},
-		{"trusty", [][]string{{"juju-mongodb3.2"}}},
-		{"wily", [][]string{{"juju-mongodb3.2"}}},
-		{"xenial", [][]string{{"juju-mongodb3.2"}}},
+		{"trusty", [][]string{{"juju-mongodb3.2"}, {"juju-mongo-tools3.2"}}},
+		{"wily", [][]string{{"juju-mongodb3.2"}, {"juju-mongo-tools3.2"}}},
+		{"xenial", [][]string{{"juju-mongodb3.2"}, {"juju-mongo-tools3.2"}}},
 	}
 
 	testing.PatchExecutableAsEchoArgs(c, s, "add-apt-repository")
 	testing.PatchExecutableAsEchoArgs(c, s, "apt-get")
 	for _, test := range tests {
+		c.Logf("install for series %v", test.series)
 		dataDir := c.MkDir()
 		s.patchSeries(test.series)
 		err := mongo.EnsureServer(makeEnsureServerParams(dataDir))


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/juju-core/+bug/1576270

We need to install both mongo and the tools separately now for 3.2

The upgrade_mogo change is for completeness - that tool will need to be deleted at some point as we will not need to upgrade mongo.

(Review request: http://reviews.vapour.ws/r/4739/)