### PR TITLE
provider/azure: destroy hosted model resources

### DIFF
--- a/environs/open.go
+++ b/environs/open.go
@@ -260,9 +260,12 @@ func Destroy(
 	env Environ,
 	store jujuclient.ControllerRemover,
 ) error {
+	if err := env.Destroy(); err != nil {
+		return errors.Trace(err)
+	}
 	err := store.RemoveController(controllerName)
 	if err != nil && !errors.IsNotFound(err) {
 		return errors.Trace(err)
 	}
-	return errors.Trace(env.Destroy())
+	return nil
 }

--- a/provider/azure/environ.go
+++ b/provider/azure/environ.go
@@ -1127,11 +1127,11 @@ func (env *azureEnviron) deleteControllerManagedResourceGroups() error {
 	// Deleting groups can take a long time, so make sure they are
 	// deleted in parallel.
 	var wg sync.WaitGroup
-	wg.Add(len(*result.Value))
 	errs := make([]error, len(*result.Value))
 	for i, group := range *result.Value {
 		groupName := to.String(group.Name)
 		logger.Debugf("  - deleting resource group %q", groupName)
+		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
 			if err := env.deleteResourceGroup(groupName); err != nil {

--- a/provider/azure/environ.go
+++ b/provider/azure/environ.go
@@ -1088,9 +1088,16 @@ func (env *azureEnviron) allInstances(
 // Destroy is specified in the Environ interface.
 func (env *azureEnviron) Destroy() error {
 	logger.Debugf("destroying model %q", env.envName)
-	logger.Debugf("- deleting resource group")
-	if err := env.deleteResourceGroup(); err != nil {
-		return errors.Trace(err)
+	if cfg := env.Config(); cfg.UUID() == cfg.ControllerUUID() {
+		logger.Debugf("- deleting resource groups")
+		if err := env.deleteControllerManagedResourceGroups(); err != nil {
+			return errors.Trace(err)
+		}
+	} else {
+		logger.Debugf("- deleting resource group %q", env.resourceGroup)
+		if err := env.deleteResourceGroup(env.resourceGroup); err != nil {
+			return errors.Trace(err)
+		}
 	}
 	// Resource groups are self-contained and fully encompass
 	// all environ resources. Once you delete the group, there
@@ -1098,16 +1105,75 @@ func (env *azureEnviron) Destroy() error {
 	return nil
 }
 
-func (env *azureEnviron) deleteResourceGroup() error {
+func (env *azureEnviron) deleteControllerManagedResourceGroups() error {
+	cfg := env.Config()
+	filter := fmt.Sprintf(
+		"tagname eq '%s' and tagvalue eq '%s'",
+		tags.JujuController, cfg.ControllerUUID(),
+	)
+	client := resources.GroupsClient{env.resources}
+	var result resources.ResourceGroupListResult
+	if err := env.callAPI(func() (autorest.Response, error) {
+		var err error
+		result, err = client.List(filter, nil)
+		return result.Response, err
+	}); err != nil {
+		return errors.Annotate(err, "listing resource groups")
+	}
+	if result.Value == nil {
+		return nil
+	}
+
+	// Deleting groups can take a long time, so make sure they are
+	// deleted in parallel.
+	var wg sync.WaitGroup
+	wg.Add(len(*result.Value))
+	errs := make([]error, len(*result.Value))
+	for i, group := range *result.Value {
+		groupName := to.String(group.Name)
+		logger.Debugf("  - deleting resource group %q", groupName)
+		go func(i int) {
+			defer wg.Done()
+			if err := env.deleteResourceGroup(groupName); err != nil {
+				errs[i] = errors.Annotatef(
+					err, "deleting resource group %q", groupName,
+				)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	// If there is just one error, return it. If there are multiple,
+	// then combine their messages.
+	var nonNilErrs []error
+	for _, err := range errs {
+		if err != nil {
+			nonNilErrs = append(nonNilErrs, err)
+		}
+	}
+	switch len(nonNilErrs) {
+	case 0:
+		return nil
+	case 1:
+		return nonNilErrs[0]
+	}
+	combined := make([]string, len(nonNilErrs))
+	for i, err := range nonNilErrs {
+		combined[i] = err.Error()
+	}
+	return errors.New(strings.Join(combined, "; "))
+}
+
+func (env *azureEnviron) deleteResourceGroup(resourceGroup string) error {
 	client := resources.GroupsClient{env.resources}
 	var result autorest.Response
 	if err := env.callAPI(func() (autorest.Response, error) {
 		var err error
-		result, err = client.Delete(env.resourceGroup)
+		result, err = client.Delete(resourceGroup)
 		return result, err
 	}); err != nil {
 		if result.Response == nil || result.StatusCode != http.StatusNotFound {
-			return errors.Annotatef(err, "deleting resource group %q", env.resourceGroup)
+			return errors.Annotatef(err, "deleting resource group %q", resourceGroup)
 		}
 	}
 	return nil

--- a/provider/azure/environ_test.go
+++ b/provider/azure/environ_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/juju/names"
 	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils"
 	"github.com/juju/utils/arch"
 	"github.com/juju/utils/series"
 	gc "gopkg.in/check.v1"
@@ -76,6 +77,7 @@ func (s *environSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 	s.storageClient = azuretesting.MockStorageClient{}
 	s.sender = nil
+	s.requests = nil
 	s.retryClock = mockClock{Clock: testing.NewClock(time.Time{})}
 
 	s.provider, _ = newProviders(c, azure.ProviderConfig{
@@ -870,4 +872,95 @@ func (s *environSuite) TestAgentMirror(c *gc.C) {
 		Region:   "westus",
 		Endpoint: "https://storage.azurestack.local/",
 	})
+}
+
+func (s *environSuite) TestDestroyHostedModel(c *gc.C) {
+	env := s.openEnviron(c, testing.Attrs{"controller-uuid": utils.MustNewUUID().String()})
+	s.sender = azuretesting.Senders{
+		s.makeSender(".*/resourcegroups/juju-testenv-model-"+testing.ModelTag.Id(), nil), // DELETE
+	}
+	err := env.Destroy()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s.requests, gc.HasLen, 1)
+	c.Assert(s.requests[0].Method, gc.Equals, "DELETE")
+}
+
+func (s *environSuite) TestDestroyControllerModel(c *gc.C) {
+	groups := []resources.ResourceGroup{{
+		Name: to.StringPtr("group1"),
+	}, {
+		Name: to.StringPtr("group2"),
+	}}
+	result := resources.ResourceGroupListResult{Value: &groups}
+
+	env := s.openEnviron(c)
+	s.sender = azuretesting.Senders{
+		s.makeSender(".*/resourcegroups", result),        // GET
+		s.makeSender(".*/resourcegroups/group[12]", nil), // DELETE
+		s.makeSender(".*/resourcegroups/group[12]", nil), // DELETE
+	}
+	err := env.Destroy()
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(s.requests, gc.HasLen, 3)
+	c.Assert(s.requests[0].Method, gc.Equals, "GET")
+	c.Assert(s.requests[0].URL.Query().Get("$filter"), gc.Equals, fmt.Sprintf(
+		"tagname eq 'juju-controller-uuid' and tagvalue eq '%s'",
+		testing.ModelTag.Id(),
+	))
+	c.Assert(s.requests[1].Method, gc.Equals, "DELETE")
+	c.Assert(s.requests[2].Method, gc.Equals, "DELETE")
+
+	// Groups are deleted concurrently, so there's no known order.
+	groupsDeleted := []string{
+		path.Base(s.requests[1].URL.Path),
+		path.Base(s.requests[2].URL.Path),
+	}
+	c.Assert(groupsDeleted, jc.SameContents, []string{"group1", "group2"})
+}
+
+func (s *environSuite) TestDestroyControllerModelErrors(c *gc.C) {
+	groups := []resources.ResourceGroup{
+		{Name: to.StringPtr("group1")},
+		{Name: to.StringPtr("group2")},
+	}
+	result := resources.ResourceGroupListResult{Value: &groups}
+
+	errorSender1 := s.makeSender(".*/resourcegroups/group[12]", nil)
+	errorSender1.EmitStatus("foo", http.StatusInternalServerError)
+	errorSender2 := s.makeSender(".*/resourcegroups/group[12]", nil)
+	errorSender2.EmitStatus("bar", http.StatusInternalServerError)
+
+	env := s.openEnviron(c)
+	s.requests = nil
+	s.sender = azuretesting.Senders{
+		s.makeSender(".*/resourcegroups", result), // GET
+		errorSender1,                              // DELETE
+		errorSender2,                              // DELETE
+	}
+	destroyErr := env.Destroy()
+	// checked below, once we know the order of deletions.
+
+	c.Assert(s.requests, gc.HasLen, 3)
+	c.Assert(s.requests[0].Method, gc.Equals, "GET")
+	c.Assert(s.requests[1].Method, gc.Equals, "DELETE")
+	c.Assert(s.requests[2].Method, gc.Equals, "DELETE")
+
+	// Groups are deleted concurrently, so there's no known order.
+	groupsDeleted := []string{
+		path.Base(s.requests[1].URL.Path),
+		path.Base(s.requests[2].URL.Path),
+	}
+	c.Assert(groupsDeleted, jc.SameContents, []string{"group1", "group2"})
+
+	// The errors are guaranteed to be in the order that the names appeared
+	// in the list response.
+	firstErr := "foo"
+	secondErr := "bar"
+	if groupsDeleted[0] == "group2" {
+		firstErr, secondErr = secondErr, firstErr
+	}
+	c.Assert(destroyErr, gc.ErrorMatches,
+		`deleting resource group "group1":.* failed with `+firstErr+`; `+
+			`deleting resource group "group2":.* failed with `+secondErr)
 }


### PR DESCRIPTION
When calling the Destroy() method of a controller's
Environ, we will also destroy the resources for the
hosted models created/managed by the controller.

Also, fix environs.Destroy to only remove the
controllers.yaml entry after destroying the Environ.

Fixes https://bugs.launchpad.net/bugs/1576120

Partially fixes https://bugs.launchpad.net/juju-core/+bug/1566011

(Review request: http://reviews.vapour.ws/r/4740/)