### PR TITLE
cloudconfig/containerinit: remove 50-cloud-init.cfg on boot

### DIFF
--- a/cloudconfig/containerinit/container_userdata.go
+++ b/cloudconfig/containerinit/container_userdata.go
@@ -102,6 +102,7 @@ iface {{.InterfaceName}} inet manual{{if .DNSServers}}
 {{end}}`
 
 var networkInterfacesFile = "/etc/network/interfaces.d/00-juju.cfg"
+var networkInterfaces50CloudInitFile = "/etc/network/interfaces.d/50-cloud-init.cfg"
 
 // GenerateNetworkConfig renders a network config for one or more
 // network interfaces, using the given non-nil networkConfig
@@ -159,6 +160,7 @@ func newCloudInitConfigWithNetworks(series string, networkConfig *container.Netw
 
 	cloudConfig.AddBootTextFile(networkInterfacesFile, config, 0644)
 	cloudConfig.AddRunCmd("ifup -a || true")
+	cloudConfig.AddRunCmd(fmt.Sprintf("test -f '%s' && rm -f '%s'", networkInterfacesFile, networkInterfaces50CloudInitFile))
 	return cloudConfig, nil
 }
 

--- a/cloudconfig/containerinit/container_userdata_test.go
+++ b/cloudconfig/containerinit/container_userdata_test.go
@@ -31,9 +31,10 @@ func Test(t *stdtesting.T) {
 type UserDataSuite struct {
 	testing.BaseSuite
 
-	networkInterfacesFile string
-	fakeInterfaces        []network.InterfaceInfo
-	expectedNetConfig     string
+	networkInterfacesFile            string
+	networkInterfaces50CloudInitFile string
+	fakeInterfaces                   []network.InterfaceInfo
+	expectedNetConfig                string
 }
 
 var _ = gc.Suite(&UserDataSuite{})
@@ -41,6 +42,7 @@ var _ = gc.Suite(&UserDataSuite{})
 func (s *UserDataSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 	s.networkInterfacesFile = filepath.Join(c.MkDir(), "interfaces")
+	s.networkInterfaces50CloudInitFile = filepath.Join(c.MkDir(), "50-cloud-init.cfg")
 	s.fakeInterfaces = []network.InterfaceInfo{{
 		InterfaceName:    "eth0",
 		CIDR:             "0.1.2.0/24",
@@ -98,6 +100,7 @@ iface eth2 inet manual
 
 `
 	s.PatchValue(containerinit.NetworkInterfacesFile, s.networkInterfacesFile)
+	s.PatchValue(containerinit.NetworkInterfaces50CloudInitFile, s.networkInterfaces50CloudInitFile)
 }
 
 func (s *UserDataSuite) TestGenerateNetworkConfig(c *gc.C) {
@@ -135,6 +138,7 @@ bootcmd:
   ' > '` + s.networkInterfacesFile + `'
 runcmd:
 - ifup -a || true
+- test -f '` + s.networkInterfacesFile + `' && rm -f '` + s.networkInterfaces50CloudInitFile + `'
 `
 	assertUserData(c, cloudConf, expected)
 }

--- a/cloudconfig/containerinit/export_test.go
+++ b/cloudconfig/containerinit/export_test.go
@@ -5,7 +5,8 @@
 package containerinit
 
 var (
-	NetworkInterfacesFile          = &networkInterfacesFile
-	NewCloudInitConfigWithNetworks = newCloudInitConfigWithNetworks
-	ShutdownInitCommands           = shutdownInitCommands
+	NetworkInterfacesFile            = &networkInterfacesFile
+	NetworkInterfaces50CloudInitFile = &networkInterfaces50CloudInitFile
+	NewCloudInitConfigWithNetworks   = newCloudInitConfigWithNetworks
+	ShutdownInitCommands             = shutdownInitCommands
 )


### PR DESCRIPTION
Juju creates its own network configuration as
/etc/network/interfaces.d/00-juju.cfg but cloud-init also creates its
own as /etc/network/interfaces.d/50-cloud-init.cfg. Add a cloud-init
command to delete the cloud-init version because both configurations
contain a stanza for eth0 and we only want Juju's version.

Fixes [LP:#1566801](https://bugs.launchpad.net/juju-core/+bug/1566801)

(Review request: http://reviews.vapour.ws/r/4743/)