### PR TITLE
environs/bootstrap: inject BuildToolsTarball

### DIFF
--- a/cmd/juju/backups/restore.go
+++ b/cmd/juju/backups/restore.go
@@ -23,6 +23,7 @@ import (
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/bootstrap"
 	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/environs/sync"
 	"github.com/juju/juju/jujuclient"
 )
 
@@ -227,6 +228,7 @@ func (c *restoreCommand) rebootstrap(ctx *cmd.Context, meta *params.BackupsMetad
 	args := bootstrap.BootstrapParams{
 		ModelConstraints:  c.constraints,
 		UploadTools:       c.uploadTools,
+		BuildToolsTarball: sync.BuildToolsTarball,
 		HostedModelConfig: hostedModelConfig,
 	}
 	if err := BootstrapFunc(modelcmd.BootstrapContext(ctx), env, args); err != nil {

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -23,6 +23,7 @@ import (
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/bootstrap"
 	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/environs/sync"
 	"github.com/juju/juju/feature"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/juju/osenv"
@@ -510,6 +511,7 @@ to clean up the model.`[1:])
 		BootstrapImage:       c.BootstrapImage,
 		Placement:            c.Placement,
 		UploadTools:          c.UploadTools,
+		BuildToolsTarball:    sync.BuildToolsTarball,
 		AgentVersion:         c.AgentVersion,
 		MetadataDir:          metadataDir,
 		HostedModelConfig:    hostedModelConfig,

--- a/environs/bootstrap/bootstrap_test.go
+++ b/environs/bootstrap/bootstrap_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/juju/juju/environs/simplestreams"
 	sstesting "github.com/juju/juju/environs/simplestreams/testing"
 	"github.com/juju/juju/environs/storage"
+	"github.com/juju/juju/environs/sync"
 	envtesting "github.com/juju/juju/environs/testing"
 	envtools "github.com/juju/juju/environs/tools"
 	"github.com/juju/juju/juju"
@@ -252,7 +253,11 @@ func (s *bootstrapSuite) TestBootstrapNoToolsNonReleaseStream(c *gc.C) {
 	})
 	env := newEnviron("foo", useDefaultKeys, map[string]interface{}{
 		"agent-stream": "proposed"})
-	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{})
+	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{
+		BuildToolsTarball: func(*version.Number, string) (*sync.BuiltTools, error) {
+			return &sync.BuiltTools{Dir: c.MkDir()}, nil
+		},
+	})
 	// bootstrap.Bootstrap leaves it to the provider to
 	// locate bootstrap tools.
 	c.Assert(err, jc.ErrorIsNil)
@@ -269,7 +274,11 @@ func (s *bootstrapSuite) TestBootstrapNoToolsDevelopmentConfig(c *gc.C) {
 	})
 	env := newEnviron("foo", useDefaultKeys, map[string]interface{}{
 		"development": true})
-	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{})
+	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{
+		BuildToolsTarball: func(*version.Number, string) (*sync.BuiltTools, error) {
+			return &sync.BuiltTools{Dir: c.MkDir()}, nil
+		},
+	})
 	// bootstrap.Bootstrap leaves it to the provider to
 	// locate bootstrap tools.
 	c.Assert(err, jc.ErrorIsNil)

--- a/environs/bootstrap/tools.go
+++ b/environs/bootstrap/tools.go
@@ -73,7 +73,6 @@ func findAvailableTools(
 	arch, series *string,
 	upload, canBuild bool,
 ) (coretools.List, error) {
-	println(canBuild)
 	if upload {
 		// We're forcing an upload: ensure we can do so.
 		if !canBuild {

--- a/environs/bootstrap/tools_test.go
+++ b/environs/bootstrap/tools_test.go
@@ -162,7 +162,7 @@ func (s *toolsSuite) TestFindAvailableToolsError(c *gc.C) {
 		return nil, errors.New("splat")
 	})
 	env := newEnviron("foo", useDefaultKeys, nil)
-	_, err := bootstrap.FindAvailableTools(env, nil, nil, nil, false)
+	_, err := bootstrap.FindAvailableTools(env, nil, nil, nil, false, false)
 	c.Assert(err, gc.ErrorMatches, "splat")
 }
 
@@ -173,7 +173,7 @@ func (s *toolsSuite) TestFindAvailableToolsNoUpload(c *gc.C) {
 	env := newEnviron("foo", useDefaultKeys, map[string]interface{}{
 		"agent-version": "1.17.1",
 	})
-	_, err := bootstrap.FindAvailableTools(env, nil, nil, nil, false)
+	_, err := bootstrap.FindAvailableTools(env, nil, nil, nil, false, false)
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
 
@@ -185,7 +185,7 @@ func (s *toolsSuite) TestFindAvailableToolsForceUpload(c *gc.C) {
 		return nil, errors.NotFoundf("tools")
 	})
 	env := newEnviron("foo", useDefaultKeys, nil)
-	uploadedTools, err := bootstrap.FindAvailableTools(env, nil, nil, nil, true)
+	uploadedTools, err := bootstrap.FindAvailableTools(env, nil, nil, nil, true, true)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(uploadedTools, gc.Not(gc.HasLen), 0)
 	c.Assert(findToolsCalled, gc.Equals, 0)
@@ -207,7 +207,7 @@ func (s *toolsSuite) TestFindAvailableToolsForceUploadInvalidArch(c *gc.C) {
 		return nil, errors.NotFoundf("tools")
 	})
 	env := newEnviron("foo", useDefaultKeys, nil)
-	_, err := bootstrap.FindAvailableTools(env, nil, nil, nil, true)
+	_, err := bootstrap.FindAvailableTools(env, nil, nil, nil, true, true)
 	c.Assert(err, gc.ErrorMatches, `model "foo" of type dummy does not support instances running on "i386"`)
 	c.Assert(findToolsCalled, gc.Equals, 0)
 }
@@ -237,7 +237,7 @@ func (s *toolsSuite) TestFindAvailableToolsSpecificVersion(c *gc.C) {
 	})
 	env := newEnviron("foo", useDefaultKeys, nil)
 	toolsVersion := version.MustParse("10.11.12")
-	result, err := bootstrap.FindAvailableTools(env, &toolsVersion, nil, nil, false)
+	result, err := bootstrap.FindAvailableTools(env, &toolsVersion, nil, nil, false, false)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(findToolsCalled, gc.Equals, 1)
 	c.Assert(result, jc.DeepEquals, tools.List{
@@ -259,7 +259,7 @@ func (s *toolsSuite) TestFindAvailableToolsAutoUpload(c *gc.C) {
 	})
 	env := newEnviron("foo", useDefaultKeys, map[string]interface{}{
 		"agent-stream": "proposed"})
-	availableTools, err := bootstrap.FindAvailableTools(env, nil, nil, nil, false)
+	availableTools, err := bootstrap.FindAvailableTools(env, nil, nil, nil, false, true)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(len(availableTools), jc.GreaterThan, 1)
 	c.Assert(env.supportedArchitecturesCount, gc.Equals, 1)
@@ -298,7 +298,7 @@ func (s *toolsSuite) TestFindAvailableToolsCompleteNoValidate(c *gc.C) {
 		return allTools, nil
 	})
 	env := newEnviron("foo", useDefaultKeys, nil)
-	availableTools, err := bootstrap.FindAvailableTools(env, nil, nil, nil, false)
+	availableTools, err := bootstrap.FindAvailableTools(env, nil, nil, nil, false, false)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(availableTools, gc.HasLen, len(allTools))
 	c.Assert(env.supportedArchitecturesCount, gc.Equals, 0)


### PR DESCRIPTION
We add a BootstrapToolsTarball field to environ/bootstrap
BootstrapParams, so the tools building/uploading behaviour
of bootstrap can be controlled. In the environs/bootstrap
tests we do not call the standard environs/sync function
to build tools, but we inject test functions that do the
minimum (create a temporary directory).

Before the change, environs/bootstrap tests took ~90sec
on my desktop using Go 1.6. After, less than one second.

Fixes https://bugs.launchpad.net/juju-core/+bug/1576911

(Review request: http://reviews.vapour.ws/r/4755/)