### PR TITLE
utils/stringforwarder: remove time sensitivity

### DIFF
--- a/tools/lxdclient/client_image_test.go
+++ b/tools/lxdclient/client_image_test.go
@@ -277,9 +277,12 @@ func (s *imageSuite) TestEnsureImageExistsNotPresentInFirstRemote(c *gc.C) {
 }
 
 func (s *imageSuite) TestEnsureImageExistsCallbackIncludesSourceURL(c *gc.C) {
-	calls := make(chan string, 20)
+	calls := make(chan string, 1)
 	callback := func(message string) {
-		calls <- message
+		select {
+		case calls <- message:
+		default:
+		}
 	}
 	connector := MakeConnector(s.Stub, s.remoteWithTrusty)
 	raw := &stubClient{

--- a/utils/stringforwarder/stringforwarder.go
+++ b/utils/stringforwarder/stringforwarder.go
@@ -3,88 +3,91 @@
 
 package stringforwarder
 
-import (
-	"sync"
-	"sync/atomic"
-)
+import "sync"
 
 // StringForwarder is a goroutine-safe type that pipes messages from the
-// its Forward() method, sending them to callback.  The send is non-blocking and
-// will discard messages if the last message has not finished processing.
-// The number of discarded messages is tracked and returned when the forwarder
-// is stopped.
+// its Forward() method, sending them to callback.  The send will not be
+// blocked by the callback, but will instead discard messages if there
+// is an incomplete callback in progress. The number of discarded messages
+// is tracked and returned when the forwarder is stopped.
 type StringForwarder struct {
-	messages     chan string
-	done         chan struct{}
+	mu           sync.Mutex
+	cond         *sync.Cond
+	current      *string
+	stopped      bool
 	discardCount uint64
-	mu           *sync.Mutex
 }
 
 // New returns a new StringForwarder that sends messages to the callback,
-// function, dropping messages if the receiver is not ready.
+// function, dropping messages if the receiver has not yet consumed the
+// last message.
 func New(callback func(string)) *StringForwarder {
 	if callback == nil {
-		// Nothing to forward to, so no need to start the loop(). We'll
-		// just count the discardCount.
-		return &StringForwarder{mu: &sync.Mutex{}}
+		// Nothing to forward to, so no need to start the loop().
+		// We'll just count the discardCount.
+		return &StringForwarder{stopped: true}
 	}
-
-	messages := make(chan string)
-	done := make(chan struct{})
-	forwarder := &StringForwarder{
-		messages:     messages,
-		done:         done,
-		mu:           &sync.Mutex{},
-		discardCount: 0,
-	}
-	started := make(chan struct{})
-	go forwarder.loop(started, callback)
-	<-started
+	forwarder := &StringForwarder{}
+	forwarder.cond = sync.NewCond(&forwarder.mu)
+	go forwarder.loop(callback)
 	return forwarder
 }
 
-// Forward makes a non-blocking send of the message to the callback function.
-// If the message is not received, it will increment the count of discarded
-// messages. Forward is safe to call from multiple goroutines at once.
+// Forward sends the message to be processed by the callback function,
+// discarding the message if another message is currently being processed.
+// The number of discarded messages is recorded for reporting by the Stop
+// method.
+//
+// Forward is safe to call from multiple goroutines at once.
 // Note that if this StringForwarder was created with a nil callback, all
 // messages will be discarded.
 func (f *StringForwarder) Forward(msg string) {
-	select {
-	case f.messages <- msg:
-	default:
-		atomic.AddUint64(&f.discardCount, 1)
+	f.mu.Lock()
+	if f.stopped || f.current != nil {
+		f.discardCount++
+	} else {
+		f.current = &msg
+		f.cond.Signal()
 	}
+	f.mu.Unlock()
 }
 
 // Stop cleans up the goroutine running behind StringForwarder and returns the
 // count of discarded messages. Stop is thread-safe and may be called multiple
 // times - after the first time, it simply returns the current discard count.
 func (f *StringForwarder) Stop() uint64 {
+	var count uint64
 	f.mu.Lock()
-	if f.done != nil {
-		close(f.done)
-		f.done = nil
+	if !f.stopped {
+		f.stopped = true
+		f.cond.Signal()
 	}
+	count = f.discardCount
 	f.mu.Unlock()
-	return atomic.LoadUint64(&f.discardCount)
+	return count
 }
 
-// loop pipes messages from the messages channel into the callback function. It
-// closes started to signal that it has begun, and will clean itself up when
-// done is closed.
-func (f *StringForwarder) loop(started chan struct{}, callback func(string)) {
-	// Grab a copy of done so we can notice it is closed, even though
-	// StringForwarder.Stop() will set it to nil.
+// loop invokes forwarded messages with the given callback until stopped.
+func (f *StringForwarder) loop(callback func(string)) {
 	f.mu.Lock()
-	done := f.done
-	f.mu.Unlock()
-	close(started)
+	defer f.mu.Unlock()
 	for {
-		select {
-		case msg := <-f.messages:
-			callback(msg)
-		case <-done:
+		for !f.stopped && f.current == nil {
+			f.cond.Wait()
+		}
+		if f.stopped {
 			return
 		}
+		f.invokeCallback(callback, *f.current)
+		f.current = nil
 	}
+}
+
+// invokeCallback invokes the given callback with a message,
+// unlocking the forwarder's mutex for the duration of the
+// callback.
+func (f *StringForwarder) invokeCallback(callback func(string), msg string) {
+	f.mu.Unlock()
+	defer f.mu.Lock()
+	callback(msg)
 }

--- a/utils/stringforwarder/stringforwarder_test.go
+++ b/utils/stringforwarder/stringforwarder_test.go
@@ -132,3 +132,19 @@ func (*StringForwarderSuite) TestRace(c *gc.C) {
 	count := forwarder.Stop()
 	c.Check(count, jc.GreaterThan, uint64(0))
 }
+
+func (*StringForwarderSuite) TestSchedulerSensitivity(c *gc.C) {
+	var wg sync.WaitGroup
+	f := func() {
+		defer wg.Done()
+		forwarder := stringforwarder.New(noopCallback)
+		forwarder.Forward("msg")
+		n := forwarder.Stop()
+		c.Check(n, gc.Equals, uint64(0))
+	}
+	for i := 0; i < 1000; i++ {
+		wg.Add(1)
+		go f()
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
The StringForwarder was sensitive to goroutine
scheduling timing, which makes testing it unreliable.

This diff makes the StringForwarder immune to
scheduler timings by changing (clarifying?) the
contract of Forward slightly: it will not be blocked
by the callback, but it will block until the message
is forwarded to the loop, unless there is another
message currently being handled, or if the forwarder
is stopped.

The added test fails reliably for me without the
accompanying changes when run under the race detector.
No races are detected (there aren't any data races),
but the race detector causes enough overhead to
manifest the issue.

Fixes https://bugs.launchpad.net/juju-core/+bug/1570883

(Review request: http://reviews.vapour.ws/r/4756/)