### PR TITLE
Use proper base64 encoding in windows userdata

### DIFF
--- a/cloudconfig/userdatacfg_win.go
+++ b/cloudconfig/userdatacfg_win.go
@@ -202,7 +202,7 @@ func addDownloadToolsCmds(ser string, certificate string, toolsList tools.List) 
 		if err != nil {
 			return nil, err
 		}
-		caCert := base64.URLEncoding.EncodeToString(parsedCert.Raw)
+		caCert := base64.StdEncoding.EncodeToString(parsedCert.Raw)
 		cmds = []string{fmt.Sprintf(`$cacert = "%s"`, caCert),
 			`$cert_bytes = $cacert | %{ ,[System.Text.Encoding]::UTF8.GetBytes($_) }`,
 			`$cert = new-object System.Security.Cryptography.X509Certificates.X509Certificate2(,$cert_bytes)`,


### PR DESCRIPTION
I think this was a type first time I merged it in.

Turns out the difference is not that big and it actually worked for a couple of test deployments, but it started failing later on. Tests to cover this are coming soon in another PR where there will be a substantial refactoring on how we handle userdata in windows.

(Review request: http://reviews.vapour.ws/r/4762/)