### PR TITLE
mongo/mongotest: test-specific mgo timeouts

### DIFF
--- a/agent/agentbootstrap/bootstrap_test.go
+++ b/agent/agentbootstrap/bootstrap_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/mongo"
+	"github.com/juju/juju/mongo/mongotest"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/state"
@@ -144,7 +145,7 @@ LXC_BRIDGE="ignored"`[1:])
 	adminUser := names.NewLocalUserTag("agent-admin")
 	st, m, err := agentbootstrap.InitializeState(
 		adminUser, cfg, envCfg, hostedModelConfigAttrs, mcfg,
-		mongo.DefaultDialOpts(), environs.NewStatePolicy(),
+		mongotest.DialOpts(), environs.NewStatePolicy(),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	defer st.Close()
@@ -232,7 +233,7 @@ LXC_BRIDGE="ignored"`[1:])
 	info, ok := cfg.MongoInfo()
 	c.Assert(ok, jc.IsTrue)
 	c.Assert(info.Password, gc.Not(gc.Equals), testing.DefaultMongoPassword)
-	st1, err := state.Open(newCfg.Model(), info, mongo.DefaultDialOpts(), environs.NewStatePolicy())
+	st1, err := state.Open(newCfg.Model(), info, mongotest.DialOpts(), environs.NewStatePolicy())
 	c.Assert(err, jc.ErrorIsNil)
 	defer st1.Close()
 }
@@ -254,7 +255,7 @@ func (s *bootstrapSuite) TestInitializeStateWithStateServingInfoNotAvailable(c *
 	c.Assert(available, jc.IsFalse)
 
 	adminUser := names.NewLocalUserTag("agent-admin")
-	_, _, err = agentbootstrap.InitializeState(adminUser, cfg, nil, nil, agentbootstrap.BootstrapMachineConfig{}, mongo.DefaultDialOpts(), environs.NewStatePolicy())
+	_, _, err = agentbootstrap.InitializeState(adminUser, cfg, nil, nil, agentbootstrap.BootstrapMachineConfig{}, mongotest.DialOpts(), environs.NewStatePolicy())
 	// InitializeState will fail attempting to get the api port information
 	c.Assert(err, gc.ErrorMatches, "state serving information not available")
 }
@@ -302,12 +303,12 @@ func (s *bootstrapSuite) TestInitializeStateFailsSecondTime(c *gc.C) {
 	adminUser := names.NewLocalUserTag("agent-admin")
 	st, _, err := agentbootstrap.InitializeState(
 		adminUser, cfg, envCfg, hostedModelConfigAttrs, mcfg,
-		mongo.DefaultDialOpts(), state.Policy(nil),
+		mongotest.DialOpts(), state.Policy(nil),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	st.Close()
 
-	st, _, err = agentbootstrap.InitializeState(adminUser, cfg, envCfg, nil, mcfg, mongo.DefaultDialOpts(), environs.NewStatePolicy())
+	st, _, err = agentbootstrap.InitializeState(adminUser, cfg, envCfg, nil, mcfg, mongotest.DialOpts(), environs.NewStatePolicy())
 	if err == nil {
 		st.Close()
 	}
@@ -351,7 +352,7 @@ func (s *bootstrapSuite) assertCanLogInAsAdmin(c *gc.C, modelTag names.ModelTag,
 		Tag:      nil, // admin user
 		Password: password,
 	}
-	st, err := state.Open(modelTag, info, mongo.DefaultDialOpts(), environs.NewStatePolicy())
+	st, err := state.Open(modelTag, info, mongotest.DialOpts(), environs.NewStatePolicy())
 	c.Assert(err, jc.ErrorIsNil)
 	defer st.Close()
 	_, err = st.Machine("0")

--- a/api/agent/machine_test.go
+++ b/api/agent/machine_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/mongo"
+	"github.com/juju/juju/mongo/mongotest"
 	"github.com/juju/juju/rpc"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/multiwatcher"
@@ -180,7 +181,7 @@ func (s *machineSuite) TestClearReboot(c *gc.C) {
 }
 
 func tryOpenState(modelTag names.ModelTag, info *mongo.MongoInfo) error {
-	st, err := state.Open(modelTag, info, mongo.DefaultDialOpts(), environs.NewStatePolicy())
+	st, err := state.Open(modelTag, info, mongotest.DialOpts(), environs.NewStatePolicy())
 	if err == nil {
 		st.Close()
 	}

--- a/api/provisioner/provisioner_test.go
+++ b/api/provisioner/provisioner_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/juju/juju/feature"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/juju/testing"
-	"github.com/juju/juju/mongo"
+	"github.com/juju/juju/mongo/mongotest"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/status"
@@ -585,7 +585,7 @@ func (s *provisionerSuite) TestContainerManagerConfigKVM(c *gc.C) {
 
 func (s *provisionerSuite) TestContainerManagerConfigLXC(c *gc.C) {
 	args := params.ContainerManagerConfigParams{Type: instance.LXC}
-	st, err := state.Open(s.State.ModelTag(), s.MongoInfo(c), mongo.DefaultDialOpts(), state.Policy(nil))
+	st, err := state.Open(s.State.ModelTag(), s.MongoInfo(c), mongotest.DialOpts(), state.Policy(nil))
 	c.Assert(err, jc.ErrorIsNil)
 	defer st.Close()
 

--- a/apiserver/server_test.go
+++ b/apiserver/server_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/juju/juju/cert"
 	"github.com/juju/juju/environs/config"
 	jujutesting "github.com/juju/juju/juju/testing"
-	"github.com/juju/juju/mongo"
+	"github.com/juju/juju/mongo/mongotest"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/rpc"
 	"github.com/juju/juju/state"
@@ -193,7 +193,7 @@ func (s *serverSuite) TestNewServerDoesNotAccessState(c *gc.C) {
 	proxy := testing.NewTCPProxy(c, mongoInfo.Addrs[0])
 	mongoInfo.Addrs = []string{proxy.Addr()}
 
-	st, err := state.Open(s.State.ModelTag(), mongoInfo, mongo.DefaultDialOpts(), nil)
+	st, err := state.Open(s.State.ModelTag(), mongoInfo, mongotest.DialOpts(), nil)
 	c.Assert(err, gc.IsNil)
 	defer st.Close()
 

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -50,6 +50,7 @@ import (
 	"github.com/juju/juju/juju"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/mongo"
+	"github.com/juju/juju/mongo/mongotest"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/service/upstart"
@@ -93,7 +94,7 @@ func (s *commonMachineSuite) SetUpSuite(c *gc.C) {
 	s.AgentSuite.SetUpSuite(c)
 	s.TestSuite.SetUpSuite(c)
 	s.AgentSuite.PatchValue(&jujuversion.Current, coretesting.FakeVersionNumber)
-	s.AgentSuite.PatchValue(&stateWorkerDialOpts, mongo.DefaultDialOpts())
+	s.AgentSuite.PatchValue(&stateWorkerDialOpts, mongotest.DialOpts())
 }
 
 func (s *commonMachineSuite) TearDownSuite(c *gc.C) {

--- a/cmd/jujud/agent/testing/agent.go
+++ b/cmd/jujud/agent/testing/agent.go
@@ -28,6 +28,7 @@ import (
 	envtools "github.com/juju/juju/environs/tools"
 	"github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/mongo"
+	"github.com/juju/juju/mongo/mongotest"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
 	coretesting "github.com/juju/juju/testing"
@@ -244,7 +245,7 @@ func (s *AgentSuite) AssertCanOpenState(c *gc.C, tag names.Tag, dataDir string) 
 	c.Assert(err, jc.ErrorIsNil)
 	info, ok := config.MongoInfo()
 	c.Assert(ok, jc.IsTrue)
-	st, err := state.Open(config.Model(), info, mongo.DefaultDialOpts(), environs.NewStatePolicy())
+	st, err := state.Open(config.Model(), info, mongotest.DialOpts(), environs.NewStatePolicy())
 	c.Assert(err, jc.ErrorIsNil)
 	st.Close()
 }

--- a/cmd/jujud/bootstrap_test.go
+++ b/cmd/jujud/bootstrap_test.go
@@ -49,6 +49,7 @@ import (
 	"github.com/juju/juju/juju"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/mongo"
+	"github.com/juju/juju/mongo/mongotest"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/state"
@@ -270,7 +271,7 @@ func (s *BootstrapSuite) TestGUIArchiveSuccess(c *gc.C) {
 			CACert: testing.CACert,
 		},
 		Password: testPassword,
-	}, mongo.DefaultDialOpts(), environs.NewStatePolicy())
+	}, mongotest.DialOpts(), environs.NewStatePolicy())
 	c.Assert(err, jc.ErrorIsNil)
 	defer st.Close()
 
@@ -383,7 +384,7 @@ func (s *BootstrapSuite) TestInitializeEnvironment(c *gc.C) {
 			CACert: testing.CACert,
 		},
 		Password: testPassword,
-	}, mongo.DefaultDialOpts(), environs.NewStatePolicy())
+	}, mongotest.DialOpts(), environs.NewStatePolicy())
 	c.Assert(err, jc.ErrorIsNil)
 	defer st.Close()
 	machines, err := st.AllMachines()
@@ -445,7 +446,7 @@ func (s *BootstrapSuite) TestInitializeEnvironmentToolsNotFound(c *gc.C) {
 			CACert: testing.CACert,
 		},
 		Password: testPassword,
-	}, mongo.DefaultDialOpts(), environs.NewStatePolicy())
+	}, mongotest.DialOpts(), environs.NewStatePolicy())
 	c.Assert(err, jc.ErrorIsNil)
 	defer st.Close()
 
@@ -476,7 +477,7 @@ func (s *BootstrapSuite) TestSetConstraints(c *gc.C) {
 			CACert: testing.CACert,
 		},
 		Password: testPassword,
-	}, mongo.DefaultDialOpts(), environs.NewStatePolicy())
+	}, mongotest.DialOpts(), environs.NewStatePolicy())
 	c.Assert(err, jc.ErrorIsNil)
 	defer st.Close()
 
@@ -517,7 +518,7 @@ func (s *BootstrapSuite) TestDefaultMachineJobs(c *gc.C) {
 			CACert: testing.CACert,
 		},
 		Password: testPassword,
-	}, mongo.DefaultDialOpts(), environs.NewStatePolicy())
+	}, mongotest.DialOpts(), environs.NewStatePolicy())
 	c.Assert(err, jc.ErrorIsNil)
 	defer st.Close()
 	m, err := st.Machine("0")
@@ -542,7 +543,7 @@ func (s *BootstrapSuite) TestConfiguredMachineJobs(c *gc.C) {
 			CACert: testing.CACert,
 		},
 		Password: testPassword,
-	}, mongo.DefaultDialOpts(), environs.NewStatePolicy())
+	}, mongotest.DialOpts(), environs.NewStatePolicy())
 	c.Assert(err, jc.ErrorIsNil)
 	defer st.Close()
 	m, err := st.Machine("0")
@@ -551,7 +552,7 @@ func (s *BootstrapSuite) TestConfiguredMachineJobs(c *gc.C) {
 }
 
 func testOpenState(c *gc.C, info *mongo.MongoInfo, expectErrType error) {
-	st, err := state.Open(testing.ModelTag, info, mongo.DefaultDialOpts(), environs.NewStatePolicy())
+	st, err := state.Open(testing.ModelTag, info, mongotest.DialOpts(), environs.NewStatePolicy())
 	if st != nil {
 		st.Close()
 	}
@@ -583,7 +584,7 @@ func (s *BootstrapSuite) TestInitialPassword(c *gc.C) {
 	// Check we can log in to mongo as admin.
 	// TODO(dfc) does passing nil for the admin user name make your skin crawl ? mine too.
 	info.Tag, info.Password = nil, testPassword
-	st, err := state.Open(testing.ModelTag, info, mongo.DefaultDialOpts(), environs.NewStatePolicy())
+	st, err := state.Open(testing.ModelTag, info, mongotest.DialOpts(), environs.NewStatePolicy())
 	c.Assert(err, jc.ErrorIsNil)
 	defer st.Close()
 
@@ -610,7 +611,7 @@ func (s *BootstrapSuite) TestInitialPassword(c *gc.C) {
 
 	stateinfo, ok := machineConf1.MongoInfo()
 	c.Assert(ok, jc.IsTrue)
-	st, err = state.Open(testing.ModelTag, stateinfo, mongo.DefaultDialOpts(), environs.NewStatePolicy())
+	st, err = state.Open(testing.ModelTag, stateinfo, mongotest.DialOpts(), environs.NewStatePolicy())
 	c.Assert(err, jc.ErrorIsNil)
 	defer st.Close()
 
@@ -819,7 +820,7 @@ func (s *BootstrapSuite) testToolsMetadata(c *gc.C, exploded bool) {
 			CACert: testing.CACert,
 		},
 		Password: testPassword,
-	}, mongo.DefaultDialOpts(), environs.NewStatePolicy())
+	}, mongotest.DialOpts(), environs.NewStatePolicy())
 	c.Assert(err, jc.ErrorIsNil)
 	defer st.Close()
 	expectedSeries := make(set.Strings)
@@ -945,7 +946,7 @@ func assertWrittenToState(c *gc.C, metadata cloudimagemetadata.Metadata) {
 			CACert: testing.CACert,
 		},
 		Password: testPassword,
-	}, mongo.DefaultDialOpts(), environs.NewStatePolicy())
+	}, mongotest.DialOpts(), environs.NewStatePolicy())
 	c.Assert(err, jc.ErrorIsNil)
 	defer st.Close()
 
@@ -1129,7 +1130,7 @@ func (s *BootstrapSuite) TestDefaultStoragePools(c *gc.C) {
 			CACert: testing.CACert,
 		},
 		Password: testPassword,
-	}, mongo.DefaultDialOpts(), environs.NewStatePolicy())
+	}, mongotest.DialOpts(), environs.NewStatePolicy())
 	c.Assert(err, jc.ErrorIsNil)
 	defer st.Close()
 

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -40,6 +40,7 @@ import (
 	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/mongo"
+	"github.com/juju/juju/mongo/mongotest"
 	"github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/binarystorage"
@@ -375,7 +376,7 @@ func newState(environ environs.Environ, mongoInfo *mongo.MongoInfo) (*state.Stat
 	modelTag := names.NewModelTag(config.UUID())
 
 	mongoInfo.Password = password
-	opts := mongo.DefaultDialOpts()
+	opts := mongotest.DialOpts()
 	st, err := state.Open(modelTag, mongoInfo, opts, environs.NewStatePolicy())
 	if errors.IsUnauthorized(errors.Cause(err)) {
 		// We try for a while because we might succeed in

--- a/mongo/mongotest/opts.go
+++ b/mongo/mongotest/opts.go
@@ -1,0 +1,23 @@
+package mongotest
+
+import (
+	"time"
+
+	"github.com/juju/juju/mongo"
+)
+
+const (
+	DialTimeout   = 5 * time.Minute
+	SocketTimeout = DialTimeout
+)
+
+// DialOpts returns mongo.DialOpts suitable for use in tests that operate
+// against a real MongoDB server. The timeouts are chosen to avoid failures
+// caused by slow I/O; we do not expect the timeouts to be reached under
+// normal circumstances.
+func DialOpts() mongo.DialOpts {
+	return mongo.DialOpts{
+		Timeout:       DialTimeout,
+		SocketTimeout: SocketTimeout,
+	}
+}

--- a/mongo/open.go
+++ b/mongo/open.go
@@ -58,6 +58,10 @@ type DialOpts struct {
 
 // DefaultDialOpts returns a DialOpts representing the default
 // parameters for contacting a controller.
+//
+// NOTE(axw) these options are inappropriate for tests in CI,
+// as CI tends to run on machines with slow I/O (or thrashed
+// I/O with limited IOPs). For tests, use mongotest.DialOpts().
 func DefaultDialOpts() DialOpts {
 	return DialOpts{
 		Timeout:       defaultDialTimeout,

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -51,6 +51,7 @@ import (
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/mongo"
+	"github.com/juju/juju/mongo/mongotest"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/provider/common"
 	"github.com/juju/juju/state"
@@ -736,7 +737,7 @@ func (e *environ) Bootstrap(ctx environs.BootstrapContext, args environs.Bootstr
 		// It is set just below.
 		st, err := state.Initialize(
 			names.NewUserTag("admin@local"), info, cfg,
-			mongo.DefaultDialOpts(), estate.statePolicy)
+			mongotest.DialOpts(), estate.statePolicy)
 		if err != nil {
 			panic(err)
 		}

--- a/state/backups/restore_test.go
+++ b/state/backups/restore_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/mongo/mongotest"
 	"github.com/juju/juju/state"
 	statetesting "github.com/juju/juju/state/testing"
 	coretesting "github.com/juju/juju/testing"
@@ -263,7 +264,7 @@ func (r *RestoreSuite) TestNewConnection(c *gc.C) {
 	st := statetesting.Initialize(c, names.NewLocalUserTag("test-admin"), nil, nil)
 	c.Assert(st.Close(), jc.ErrorIsNil)
 
-	r.PatchValue(&mongoDefaultDialOpts, statetesting.NewDialOpts)
+	r.PatchValue(&mongoDefaultDialOpts, mongotest.DialOpts)
 	r.PatchValue(&environsNewStatePolicy, func() state.Policy { return nil })
 	st, err = newStateConnection(st.ModelTag(), statetesting.NewMongoInfo())
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/initialize_test.go
+++ b/state/initialize_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/mongo/mongotest"
 	"github.com/juju/juju/state"
 	statetesting "github.com/juju/juju/state/testing"
 	"github.com/juju/juju/testing"
@@ -43,7 +44,7 @@ func (s *InitializeSuite) openState(c *gc.C, modelTag names.ModelTag) {
 	st, err := state.Open(
 		modelTag,
 		statetesting.NewMongoInfo(),
-		statetesting.NewDialOpts(),
+		mongotest.DialOpts(),
 		state.Policy(nil),
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -64,7 +65,7 @@ func (s *InitializeSuite) TestInitialize(c *gc.C) {
 	uuid := cfg.UUID()
 	initial := cfg.AllAttrs()
 	owner := names.NewLocalUserTag("initialize-admin")
-	st, err := state.Initialize(owner, statetesting.NewMongoInfo(), cfg, statetesting.NewDialOpts(), nil)
+	st, err := state.Initialize(owner, statetesting.NewMongoInfo(), cfg, mongotest.DialOpts(), nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(st, gc.NotNil)
 	modelTag := st.ModelTag()
@@ -114,7 +115,7 @@ func (s *InitializeSuite) TestDoubleInitializeConfig(c *gc.C) {
 	owner := names.NewLocalUserTag("initialize-admin")
 
 	mgoInfo := statetesting.NewMongoInfo()
-	dialOpts := statetesting.NewDialOpts()
+	dialOpts := mongotest.DialOpts()
 	st, err := state.Initialize(owner, mgoInfo, cfg, dialOpts, state.Policy(nil))
 	c.Assert(err, jc.ErrorIsNil)
 	err = st.Close()
@@ -135,7 +136,7 @@ func (s *InitializeSuite) TestModelConfigWithAdminSecret(c *gc.C) {
 	bad, err := good.Apply(badUpdateAttrs)
 	owner := names.NewLocalUserTag("initialize-admin")
 
-	_, err = state.Initialize(owner, statetesting.NewMongoInfo(), bad, statetesting.NewDialOpts(), state.Policy(nil))
+	_, err = state.Initialize(owner, statetesting.NewMongoInfo(), bad, mongotest.DialOpts(), state.Policy(nil))
 	c.Assert(err, gc.ErrorMatches, "admin-secret should never be written to the state")
 
 	// admin-secret blocks UpdateModelConfig.
@@ -161,7 +162,7 @@ func (s *InitializeSuite) TestModelConfigWithoutAgentVersion(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	owner := names.NewLocalUserTag("initialize-admin")
 
-	_, err = state.Initialize(owner, statetesting.NewMongoInfo(), bad, statetesting.NewDialOpts(), state.Policy(nil))
+	_, err = state.Initialize(owner, statetesting.NewMongoInfo(), bad, mongotest.DialOpts(), state.Policy(nil))
 	c.Assert(err, gc.ErrorMatches, "agent-version must always be set in state")
 
 	st := statetesting.Initialize(c, owner, good, nil)

--- a/state/internal_test.go
+++ b/state/internal_test.go
@@ -10,6 +10,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/mongo"
+	"github.com/juju/juju/mongo/mongotest"
 	"github.com/juju/juju/testing"
 )
 
@@ -47,10 +48,7 @@ func (s *internalStateSuite) SetUpTest(c *gc.C) {
 			CACert: testing.CACert,
 		},
 	}
-	// Copied from NewDialOpts (due to import loops).
-	dialopts := mongo.DialOpts{
-		Timeout: testing.LongWait,
-	}
+	dialopts := mongotest.DialOpts()
 	st, err := Initialize(s.owner, info, testing.ModelConfig(c), dialopts, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	s.state = st

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/instance"
+	"github.com/juju/juju/mongo/mongotest"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/testing"
@@ -645,7 +646,7 @@ func (s *MachineSuite) TestTag(c *gc.C) {
 
 func (s *MachineSuite) TestSetMongoPassword(c *gc.C) {
 	info := testing.NewMongoInfo()
-	st, err := state.Open(s.modelTag, info, testing.NewDialOpts(), state.Policy(nil))
+	st, err := state.Open(s.modelTag, info, mongotest.DialOpts(), state.Policy(nil))
 	c.Assert(err, jc.ErrorIsNil)
 	defer func() {
 		// Remove the admin password so that the test harness can reset the state.
@@ -676,7 +677,7 @@ func (s *MachineSuite) TestSetMongoPassword(c *gc.C) {
 
 	// Check that we can log in with the correct password.
 	info.Password = "foo"
-	st1, err := state.Open(s.modelTag, info, testing.NewDialOpts(), state.Policy(nil))
+	st1, err := state.Open(s.modelTag, info, mongotest.DialOpts(), state.Policy(nil))
 	c.Assert(err, jc.ErrorIsNil)
 	defer st1.Close()
 

--- a/state/open.go
+++ b/state/open.go
@@ -80,7 +80,7 @@ func open(tag names.ModelTag, info *mongo.MongoInfo, opts mongo.DialOpts, policy
 		tag = ssInfo.ModelTag
 	}
 
-	st, err := newState(tag, session, info, policy)
+	st, err := newState(tag, session, info, opts, policy)
 	if err != nil {
 		session.Close()
 		return nil, errors.Trace(err)
@@ -252,7 +252,7 @@ func isUnauthorized(err error) bool {
 // newState creates an incomplete *State, with a configured watcher but no
 // pwatcher, leadershipManager, or controllerTag. You must start() the returned
 // *State before it will function correctly.
-func newState(modelTag names.ModelTag, session *mgo.Session, mongoInfo *mongo.MongoInfo, policy Policy) (_ *State, resultErr error) {
+func newState(modelTag names.ModelTag, session *mgo.Session, mongoInfo *mongo.MongoInfo, dialOpts mongo.DialOpts, policy Policy) (_ *State, resultErr error) {
 	// Set up database.
 	rawDB := session.DB(jujuDB)
 	database, err := allCollections().Load(rawDB, modelTag.Id())
@@ -265,12 +265,13 @@ func newState(modelTag names.ModelTag, session *mgo.Session, mongoInfo *mongo.Mo
 
 	// Create State.
 	return &State{
-		modelTag:  modelTag,
-		mongoInfo: mongoInfo,
-		session:   session,
-		database:  database,
-		policy:    policy,
-		watcher:   watcher.New(rawDB.C(txnLogC)),
+		modelTag:      modelTag,
+		mongoInfo:     mongoInfo,
+		mongoDialOpts: dialOpts,
+		session:       session,
+		database:      database,
+		policy:        policy,
+		watcher:       watcher.New(rawDB.C(txnLogC)),
 	}, nil
 }
 

--- a/state/state.go
+++ b/state/state.go
@@ -74,6 +74,7 @@ type State struct {
 	modelTag      names.ModelTag
 	controllerTag names.ModelTag
 	mongoInfo     *mongo.MongoInfo
+	mongoDialOpts mongo.DialOpts
 	session       *mgo.Session
 	database      Database
 	policy        Policy
@@ -194,7 +195,7 @@ func (st *State) removeAllModelDocs(modelAssertion bson.D) error {
 // ForModel returns a connection to mongo for the specified model. The
 // connection uses the same credentials and policy as the existing connection.
 func (st *State) ForModel(env names.ModelTag) (*State, error) {
-	newState, err := open(env, st.mongoInfo, mongo.DefaultDialOpts(), st.policy)
+	newState, err := open(env, st.mongoInfo, st.mongoDialOpts, st.policy)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/mongo"
+	"github.com/juju/juju/mongo/mongotest"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/multiwatcher"
@@ -133,14 +134,14 @@ func (s *StateSuite) TestStrictLocalIDWithNoPrefix(c *gc.C) {
 func (s *StateSuite) TestDialAgain(c *gc.C) {
 	// Ensure idempotent operations on Dial are working fine.
 	for i := 0; i < 2; i++ {
-		st, err := state.Open(s.modelTag, statetesting.NewMongoInfo(), statetesting.NewDialOpts(), state.Policy(nil))
+		st, err := state.Open(s.modelTag, statetesting.NewMongoInfo(), mongotest.DialOpts(), state.Policy(nil))
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(st.Close(), gc.IsNil)
 	}
 }
 
 func (s *StateSuite) TestOpenAcceptsMissingModelTag(c *gc.C) {
-	st, err := state.Open(names.ModelTag{}, statetesting.NewMongoInfo(), statetesting.NewDialOpts(), state.Policy(nil))
+	st, err := state.Open(names.ModelTag{}, statetesting.NewMongoInfo(), mongotest.DialOpts(), state.Policy(nil))
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(st.ModelTag(), gc.Equals, s.modelTag)
@@ -150,7 +151,7 @@ func (s *StateSuite) TestOpenAcceptsMissingModelTag(c *gc.C) {
 func (s *StateSuite) TestOpenRequiresExtantModelTag(c *gc.C) {
 	uuid := utils.MustNewUUID()
 	tag := names.NewModelTag(uuid.String())
-	st, err := state.Open(tag, statetesting.NewMongoInfo(), statetesting.NewDialOpts(), state.Policy(nil))
+	st, err := state.Open(tag, statetesting.NewMongoInfo(), mongotest.DialOpts(), state.Policy(nil))
 	if !c.Check(st, gc.IsNil) {
 		c.Check(st.Close(), jc.ErrorIsNil)
 	}
@@ -159,7 +160,7 @@ func (s *StateSuite) TestOpenRequiresExtantModelTag(c *gc.C) {
 }
 
 func (s *StateSuite) TestOpenSetsModelTag(c *gc.C) {
-	st, err := state.Open(s.modelTag, statetesting.NewMongoInfo(), statetesting.NewDialOpts(), state.Policy(nil))
+	st, err := state.Open(s.modelTag, statetesting.NewMongoInfo(), mongotest.DialOpts(), state.Policy(nil))
 	c.Assert(err, jc.ErrorIsNil)
 	defer st.Close()
 
@@ -3170,7 +3171,7 @@ func (s *StateSuite) TestAddAndGetEquivalence(c *gc.C) {
 }
 
 func tryOpenState(modelTag names.ModelTag, info *mongo.MongoInfo) error {
-	st, err := state.Open(modelTag, info, statetesting.NewDialOpts(), state.Policy(nil))
+	st, err := state.Open(modelTag, info, mongotest.DialOpts(), state.Policy(nil))
 	if err == nil {
 		err = st.Close()
 	}
@@ -3884,7 +3885,7 @@ type waiter interface {
 // interact with the closed state, causing it to return an
 // unexpected error (often "Closed explictly").
 func testWatcherDiesWhenStateCloses(c *gc.C, modelTag names.ModelTag, startWatcher func(c *gc.C, st *state.State) waiter) {
-	st, err := state.Open(modelTag, statetesting.NewMongoInfo(), statetesting.NewDialOpts(), state.Policy(nil))
+	st, err := state.Open(modelTag, statetesting.NewMongoInfo(), mongotest.DialOpts(), state.Policy(nil))
 	c.Assert(err, jc.ErrorIsNil)
 	watcher := startWatcher(c, st)
 	err = st.Close()
@@ -3932,7 +3933,7 @@ func (s *StateSuite) TestReopenWithNoMachines(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(info, jc.DeepEquals, expected)
 
-	st, err := state.Open(s.modelTag, statetesting.NewMongoInfo(), statetesting.NewDialOpts(), state.Policy(nil))
+	st, err := state.Open(s.modelTag, statetesting.NewMongoInfo(), mongotest.DialOpts(), state.Policy(nil))
 	c.Assert(err, jc.ErrorIsNil)
 	defer st.Close()
 
@@ -4673,7 +4674,7 @@ func (s *SetAdminMongoPasswordSuite) TestSetAdminMongoPassword(c *gc.C) {
 		},
 	}
 	cfg := testing.ModelConfig(c)
-	st, err := state.Initialize(owner, mongoInfo, cfg, statetesting.NewDialOpts(), nil)
+	st, err := state.Initialize(owner, mongoInfo, cfg, mongotest.DialOpts(), nil)
 	c.Assert(err, jc.ErrorIsNil)
 	defer st.Close()
 

--- a/state/testing/conn.go
+++ b/state/testing/conn.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/mongo"
+	"github.com/juju/juju/mongo/mongotest"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/testing"
 )
@@ -23,7 +24,7 @@ func Initialize(c *gc.C, owner names.UserTag, cfg *config.Config, policy state.P
 		cfg = testing.ModelConfig(c)
 	}
 	mgoInfo := NewMongoInfo()
-	dialOpts := NewDialOpts()
+	dialOpts := mongotest.DialOpts()
 
 	st, err := state.Initialize(owner, mgoInfo, cfg, dialOpts, policy)
 	c.Assert(err, jc.ErrorIsNil)
@@ -38,14 +39,6 @@ func NewMongoInfo() *mongo.MongoInfo {
 			Addrs:  []string{jujutesting.MgoServer.Addr()},
 			CACert: testing.CACert,
 		},
-	}
-}
-
-// NewDialOpts returns configuration parameters for
-// connecting to the testing controller.
-func NewDialOpts() mongo.DialOpts {
-	return mongo.DialOpts{
-		Timeout: testing.LongWait,
 	}
 }
 

--- a/worker/upgradesteps/worker_test.go
+++ b/worker/upgradesteps/worker_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/instance"
-	"github.com/juju/juju/mongo"
+	"github.com/juju/juju/mongo/mongotest"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/multiwatcher"
 	statetesting "github.com/juju/juju/state/testing"
@@ -409,7 +409,7 @@ func (s *UpgradeSuite) runUpgradeWorker(c *gc.C, jobs ...multiwatcher.MachineJob
 
 func (s *UpgradeSuite) openStateForUpgrade() (*state.State, error) {
 	mongoInfo := s.State.MongoConnectionInfo()
-	st, err := state.Open(s.State.ModelTag(), mongoInfo, mongo.DefaultDialOpts(), environs.NewStatePolicy())
+	st, err := state.Open(s.State.ModelTag(), mongoInfo, mongotest.DialOpts(), environs.NewStatePolicy())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Introduce a new package which contains a
function that returns test-specific dial
options for mgo. The tests will use a long
timeout to avoid I/O bottlenecks causing
test failures. This happens quite frequently
in CI.

Also, modify State.ForModel to use the same
dial options used when opening the initial
State.

Hopefully Fixes https://bugs.launchpad.net/juju-core/+bug/1501398

(Review request: http://reviews.vapour.ws/r/4765/)