### PR TITLE
Backport changes reducing friction on LTS upgrade     

### DIFF
--- a/apiserver/client/client_test.go
+++ b/apiserver/client/client_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/series"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v5"
 	"gopkg.in/juju/charm.v5/charmrepo"
@@ -2867,7 +2868,7 @@ func (s *clientSuite) TestClientAddMachinesDefaultSeries(c *gc.C) {
 	c.Assert(len(machines), gc.Equals, 3)
 	for i, machineResult := range machines {
 		c.Assert(machineResult.Machine, gc.DeepEquals, strconv.Itoa(i))
-		s.checkMachine(c, machineResult.Machine, coretesting.FakeDefaultSeries, apiParams[i].Constraints.String())
+		s.checkMachine(c, machineResult.Machine, series.LatestLts(), apiParams[i].Constraints.String())
 	}
 }
 
@@ -2883,7 +2884,7 @@ func (s *clientSuite) assertAddMachines(c *gc.C) {
 	c.Assert(len(machines), gc.Equals, 3)
 	for i, machineResult := range machines {
 		c.Assert(machineResult.Machine, gc.DeepEquals, strconv.Itoa(i))
-		s.checkMachine(c, machineResult.Machine, coretesting.FakeDefaultSeries, apiParams[i].Constraints.String())
+		s.checkMachine(c, machineResult.Machine, series.LatestLts(), apiParams[i].Constraints.String())
 	}
 }
 
@@ -2966,7 +2967,7 @@ func (s *clientSuite) TestClientAddMachinesWithConstraints(c *gc.C) {
 	c.Assert(len(machines), gc.Equals, 3)
 	for i, machineResult := range machines {
 		c.Assert(machineResult.Machine, gc.DeepEquals, strconv.Itoa(i))
-		s.checkMachine(c, machineResult.Machine, coretesting.FakeDefaultSeries, apiParams[i].Constraints.String())
+		s.checkMachine(c, machineResult.Machine, series.LatestLts(), apiParams[i].Constraints.String())
 	}
 }
 
@@ -3083,7 +3084,7 @@ func (s *clientSuite) TestClientAddMachinesWithInstanceIdSomeErrors(c *gc.C) {
 			c.Assert(machineResult.Error, gc.ErrorMatches, "cannot add a new machine: cannot add a machine with an instance id and no nonce")
 		} else {
 			c.Assert(machineResult.Machine, gc.DeepEquals, strconv.Itoa(i))
-			s.checkMachine(c, machineResult.Machine, coretesting.FakeDefaultSeries, apiParams[i].Constraints.String())
+			s.checkMachine(c, machineResult.Machine, series.LatestLts(), apiParams[i].Constraints.String())
 			instanceId := fmt.Sprintf("1234-%d", i)
 			s.checkInstance(c, machineResult.Machine, instanceId, "foo", hc, addrs)
 		}

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/juju/loggo"
 	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/series"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/params"
@@ -250,7 +251,7 @@ func (s *BootstrapSuite) run(c *gc.C, test bootstrapTest) (restore gitjujutestin
 	)
 
 	if test.version != "" {
-		useVersion := strings.Replace(test.version, "%LTS%", config.LatestLtsSeries(), 1)
+		useVersion := strings.Replace(test.version, "%LTS%", series.LatestLts(), 1)
 		origVersion := version.Current
 		version.Current = version.MustParseBinary(useVersion)
 		restore = restore.Add(func() {
@@ -806,7 +807,7 @@ func (s *BootstrapSuite) setupAutoUploadTest(c *gc.C, vers, series string) envir
 }
 
 func (s *BootstrapSuite) TestAutoUploadAfterFailedSync(c *gc.C) {
-	s.PatchValue(&version.Current.Series, config.LatestLtsSeries())
+	s.PatchValue(&version.Current.Series, series.LatestLts())
 	s.setupAutoUploadTest(c, "1.7.3", "quantal")
 	// Run command and check for that upload has been run for tools matching
 	// the current juju version.

--- a/cmd/juju/commands/expose_test.go
+++ b/cmd/juju/commands/expose_test.go
@@ -4,7 +4,10 @@
 package commands
 
 import (
+	"fmt"
+
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/series"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v5"
 
@@ -44,7 +47,7 @@ func (s *ExposeSuite) TestExpose(c *gc.C) {
 	testcharms.Repo.CharmArchivePath(s.SeriesPath, "dummy")
 	err := runDeploy(c, "local:dummy", "some-service-name")
 	c.Assert(err, jc.ErrorIsNil)
-	curl := charm.MustParseURL("local:trusty/dummy-1")
+	curl := charm.MustParseURL(fmt.Sprintf("local:%s/dummy-1", series.LatestLts()))
 	s.AssertService(c, "some-service-name", curl, 1, 0)
 
 	err = runExpose(c, "some-service-name")
@@ -59,7 +62,7 @@ func (s *ExposeSuite) TestBlockExpose(c *gc.C) {
 	testcharms.Repo.CharmArchivePath(s.SeriesPath, "dummy")
 	err := runDeploy(c, "local:dummy", "some-service-name")
 	c.Assert(err, jc.ErrorIsNil)
-	curl := charm.MustParseURL("local:trusty/dummy-1")
+	curl := charm.MustParseURL(fmt.Sprintf("local:%s/dummy-1", series.LatestLts()))
 	s.AssertService(c, "some-service-name", curl, 1, 0)
 
 	// Block operation

--- a/cmd/juju/commands/removeunit_test.go
+++ b/cmd/juju/commands/removeunit_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/series"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v5"
 
@@ -40,7 +41,7 @@ func (s *RemoveUnitSuite) setupUnitForRemove(c *gc.C) *state.Service {
 	testcharms.Repo.CharmArchivePath(s.SeriesPath, "dummy")
 	err := runDeploy(c, "-n", "2", "local:dummy", "dummy")
 	c.Assert(err, jc.ErrorIsNil)
-	curl := charm.MustParseURL(fmt.Sprintf("local:%s/dummy-1", testing.FakeDefaultSeries))
+	curl := charm.MustParseURL(fmt.Sprintf("local:%s/dummy-1", series.LatestLts()))
 	svc, _ := s.AssertService(c, "dummy", curl, 2, 0)
 	return svc
 }

--- a/cmd/juju/commands/unexpose_test.go
+++ b/cmd/juju/commands/unexpose_test.go
@@ -4,7 +4,10 @@
 package commands
 
 import (
+	"fmt"
+
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/series"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v5"
 
@@ -44,7 +47,7 @@ func (s *UnexposeSuite) TestUnexpose(c *gc.C) {
 	testcharms.Repo.CharmArchivePath(s.SeriesPath, "dummy")
 	err := runDeploy(c, "local:dummy", "some-service-name")
 	c.Assert(err, jc.ErrorIsNil)
-	curl := charm.MustParseURL("local:trusty/dummy-1")
+	curl := charm.MustParseURL(fmt.Sprintf("local:%s/dummy-1", series.LatestLts()))
 	s.AssertService(c, "some-service-name", curl, 1, 0)
 
 	err = runExpose(c, "some-service-name")
@@ -63,7 +66,7 @@ func (s *UnexposeSuite) TestBlockUnexpose(c *gc.C) {
 	testcharms.Repo.CharmArchivePath(s.SeriesPath, "dummy")
 	err := runDeploy(c, "local:dummy", "some-service-name")
 	c.Assert(err, jc.ErrorIsNil)
-	curl := charm.MustParseURL("local:trusty/dummy-1")
+	curl := charm.MustParseURL(fmt.Sprintf("local:%s/dummy-1", series.LatestLts()))
 	s.AssertService(c, "some-service-name", curl, 1, 0)
 
 	// Block operation

--- a/cmd/juju/commands/upgradecharm_test.go
+++ b/cmd/juju/commands/upgradecharm_test.go
@@ -5,11 +5,13 @@ package commands
 
 import (
 	"bytes"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path"
 
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/series"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v5"
 	"gopkg.in/juju/charm.v5/charmrepo"
@@ -73,7 +75,7 @@ func (s *UpgradeCharmErrorsSuite) TestWithInvalidRepository(c *gc.C) {
 	// overwrites it (TearDownTest will revert it again).
 	os.Setenv("JUJU_REPOSITORY", "")
 	err = runUpgradeCharm(c, "riak", "--repository=")
-	c.Assert(err, gc.ErrorMatches, `charm not found in ".*": local:trusty/riak`)
+	c.Assert(err, gc.ErrorMatches, fmt.Sprintf("charm not found in \".*\": local:%s/riak", series.LatestLts()))
 }
 
 func (s *UpgradeCharmErrorsSuite) TestInvalidService(c *gc.C) {
@@ -90,7 +92,7 @@ func (s *UpgradeCharmErrorsSuite) deployService(c *gc.C) {
 func (s *UpgradeCharmErrorsSuite) TestInvalidSwitchURL(c *gc.C) {
 	s.deployService(c)
 	err := runUpgradeCharm(c, "riak", "--switch=blah")
-	c.Assert(err, gc.ErrorMatches, `cannot resolve charm URL "cs:trusty/blah": charm not found`)
+	c.Assert(err, gc.ErrorMatches, fmt.Sprintf("cannot resolve charm URL \"cs:%s/blah\": charm not found", series.LatestLts()))
 	err = runUpgradeCharm(c, "riak", "--switch=cs:missing/one")
 	c.Assert(err, gc.ErrorMatches, `cannot resolve charm URL "cs:missing/one": charm not found`)
 	// TODO(dimitern): add tests with incompatible charms
@@ -254,12 +256,12 @@ func (s *UpgradeCharmSuccessSuite) TestSwitch(c *gc.C) {
 	err = runUpgradeCharm(c, "riak", "--switch=local:myriak")
 	c.Assert(err, jc.ErrorIsNil)
 	curl := s.assertUpgraded(c, 7, false)
-	c.Assert(curl.String(), gc.Equals, "local:trusty/myriak-7")
+	c.Assert(curl.String(), gc.Equals, fmt.Sprintf("local:%s/myriak-7", series.LatestLts()))
 	s.assertLocalRevision(c, 7, myriakPath)
 
 	// Now try the same with explicit revision - should fail.
 	err = runUpgradeCharm(c, "riak", "--switch=local:myriak-7")
-	c.Assert(err, gc.ErrorMatches, `already running specified charm "local:trusty/myriak-7"`)
+	c.Assert(err, gc.ErrorMatches, fmt.Sprintf("already running specified charm \"local:%s/myriak-7\"", series.LatestLts()))
 
 	// Change the revision to 42 and upgrade to it with explicit revision.
 	err = ioutil.WriteFile(path.Join(myriakPath, "revision"), []byte("42"), 0644)
@@ -267,7 +269,7 @@ func (s *UpgradeCharmSuccessSuite) TestSwitch(c *gc.C) {
 	err = runUpgradeCharm(c, "riak", "--switch=local:myriak-42")
 	c.Assert(err, jc.ErrorIsNil)
 	curl = s.assertUpgraded(c, 42, false)
-	c.Assert(curl.String(), gc.Equals, "local:trusty/myriak-42")
+	c.Assert(curl.String(), gc.Equals, fmt.Sprintf("local:%s/myriak-42", series.LatestLts()))
 	s.assertLocalRevision(c, 42, myriakPath)
 }
 

--- a/cmd/juju/commands/upgradejuju_test.go
+++ b/cmd/juju/commands/upgradejuju_test.go
@@ -12,13 +12,13 @@ import (
 	"strings"
 
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/series"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/cmd/envcmd"
-	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/filestorage"
 	"github.com/juju/juju/environs/sync"
 	envtesting "github.com/juju/juju/environs/testing"
@@ -384,7 +384,7 @@ func (s *UpgradeJujuSuite) TestUpgradeJuju(c *gc.C) {
 
 		for _, uploaded := range test.expectUploaded {
 			// Substitute latest LTS for placeholder in expected series for uploaded tools
-			uploaded = strings.Replace(uploaded, "%LTS%", config.LatestLtsSeries(), 1)
+			uploaded = strings.Replace(uploaded, "%LTS%", series.LatestLts(), 1)
 			vers := version.MustParseBinary(uploaded)
 			s.checkToolsUploaded(c, vers, agentVersion)
 		}

--- a/cmd/plugins/juju-metadata/imagemetadata.go
+++ b/cmd/plugins/juju-metadata/imagemetadata.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
+	"github.com/juju/utils/series"
 	"launchpad.net/gnuflag"
 
 	"github.com/juju/juju/cmd/envcmd"
@@ -128,7 +129,7 @@ func (c *ImageMetadataCommand) setParams(context *cmd.Context) error {
 		logger.Infof("no environment found, creating image metadata using user supplied data")
 	}
 	if c.Series == "" {
-		c.Series = config.LatestLtsSeries()
+		c.Series = series.LatestLts()
 	}
 	if c.ImageId == "" {
 		return errors.Errorf("image id must be specified")

--- a/cmd/plugins/juju-metadata/imagemetadata_test.go
+++ b/cmd/plugins/juju-metadata/imagemetadata_test.go
@@ -13,10 +13,10 @@ import (
 
 	"github.com/juju/cmd"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/series"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cmd/envcmd"
-	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/testing"
 )
@@ -72,6 +72,8 @@ var seriesVersions map[string]string = map[string]string{
 	"precise": "12.04",
 	"raring":  "13.04",
 	"trusty":  "14.04",
+	"wily":    "15.10",
+	"xenial":  "16.04",
 }
 
 type expectedMetadata struct {
@@ -169,7 +171,7 @@ func (s *ImageMetadataSuite) TestImageMetadataFilesLatestLts(c *gc.C) {
 	c.Assert(code, gc.Equals, 0)
 	out := testing.Stdout(ctx)
 	expected := expectedMetadata{
-		series: config.LatestLtsSeries(),
+		series: series.LatestLts(),
 		arch:   "arch",
 	}
 	s.assertCommandOutput(c, expected, out, defaultIndexFileName, defaultImageFileName)

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -28,7 +28,7 @@ github.com/juju/schema	git	afe1151cb49d1d7ed3c75592dfc6f38703f2e988	2015-08-07T0
 github.com/juju/syslog	git	6be94e8b718766e9ff7a37342157fe4795da7cfa	2015-02-05T15:59:36Z
 github.com/juju/testing	git	162fafccebf20a4207ab93d63b986c230e3f4d2e	2015-05-29T04:40:43Z
 github.com/juju/txn	git	99ec629d0066a4d73c54d8e021a7fc1dc07df614	2015-06-09T16:58:27Z
-github.com/juju/utils	git	d300cfbfa10388047c779b60e50e7be533cc781d	2016-02-23T05:10:16Z
+github.com/juju/utils	git	bb17b38c753943d4aba04b0592be39afe0c2b561	2016-05-04T17:20:45Z
 github.com/juju/xml	git	eb759a627588d35166bc505fceb51b88500e291e	2015-04-13T13:11:21Z
 golang.org/x/crypto	git	c57d4a71915a248dbad846d60825145062b4c18e	2015-03-27T05:11:19Z
 golang.org/x/net	git	bb64f4dc73d4ab97978d5e1cb34515dcc570361b	2015-05-18T01:39:50Z

--- a/environs/config/config_test.go
+++ b/environs/config/config_test.go
@@ -16,6 +16,7 @@ import (
 	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/proxy"
+	"github.com/juju/utils/series"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v5/charmrepo"
 	"gopkg.in/juju/environschema.v1"
@@ -60,7 +61,7 @@ var sampleConfig = testing.Attrs{
 	"state-port":                1234,
 	"api-port":                  4321,
 	"syslog-port":               2345,
-	"default-series":            config.LatestLtsSeries(),
+	"default-series":            series.LatestLts(),
 }
 
 type configTest struct {
@@ -1408,7 +1409,7 @@ func (s *ConfigSuite) TestConfigAttrs(c *gc.C) {
 		"bootstrap-timeout":         3600,
 		"bootstrap-retry-delay":     30,
 		"bootstrap-addresses-delay": 10,
-		"default-series":            testing.FakeDefaultSeries,
+		"default-series":            series.LatestLts(),
 		"test-mode":                 false,
 	}
 	cfg, err := config.New(config.NoDefaults, attrs)
@@ -1963,22 +1964,6 @@ type specializedCharmRepo struct {
 func (s *specializedCharmRepo) WithTestMode() charmrepo.Interface {
 	s.testMode = true
 	return s
-}
-
-func (s *ConfigSuite) TestLastestLtsSeriesFallback(c *gc.C) {
-	config.ResetCachedLtsSeries()
-	s.PatchValue(config.DistroLtsSeries, func() (string, error) {
-		return "", fmt.Errorf("error")
-	})
-	c.Assert(config.LatestLtsSeries(), gc.Equals, "trusty")
-}
-
-func (s *ConfigSuite) TestLastestLtsSeries(c *gc.C) {
-	config.ResetCachedLtsSeries()
-	s.PatchValue(config.DistroLtsSeries, func() (string, error) {
-		return "series", nil
-	})
-	c.Assert(config.LatestLtsSeries(), gc.Equals, "series")
 }
 
 var caCert = `

--- a/environs/config/export_test.go
+++ b/environs/config/export_test.go
@@ -4,10 +4,5 @@
 package config
 
 var (
-	DistroLtsSeries = &distroLtsSeries
-	ConfigSchema    = configSchema
+	ConfigSchema = configSchema
 )
-
-func ResetCachedLtsSeries() {
-	latestLtsSeries = ""
-}

--- a/environs/jujutest/livetests.go
+++ b/environs/jujutest/livetests.go
@@ -11,6 +11,7 @@ import (
 	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
+	"github.com/juju/utils/series"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v5/charmrepo"
 
@@ -142,7 +143,7 @@ func (t *LiveTests) BootstrapOnce(c *gc.C) {
 	// we could connect to (actual live tests, rather than local-only)
 	cons := constraints.MustParse("mem=2G")
 	if t.CanOpenState {
-		_, err := sync.Upload(t.toolsStorage, "released", nil, coretesting.FakeDefaultSeries)
+		_, err := sync.Upload(t.toolsStorage, "released", nil, series.LatestLts())
 		c.Assert(err, jc.ErrorIsNil)
 	}
 	err := bootstrap.EnsureNotBootstrapped(t.Env)
@@ -453,7 +454,7 @@ func (t *LiveTests) TestBootstrapAndDeploy(c *gc.C) {
 
 	// If the series has not been specified, we expect the most recent Ubuntu LTS release to be used.
 	expectedVersion := version.Current
-	expectedVersion.Series = config.LatestLtsSeries()
+	expectedVersion.Series = series.LatestLts()
 
 	mtools0 := waitAgentTools(c, mw0, expectedVersion)
 

--- a/environs/manual/provisioner_test.go
+++ b/environs/manual/provisioner_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/series"
 	"github.com/juju/utils/shell"
 	gc "gopkg.in/check.v1"
 
@@ -21,7 +22,6 @@ import (
 	envtools "github.com/juju/juju/environs/tools"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/juju/testing"
-	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/version"
 )
 
@@ -44,7 +44,7 @@ func (s *provisionerSuite) getArgs(c *gc.C) manual.ProvisionMachineArgs {
 }
 
 func (s *provisionerSuite) TestProvisionMachine(c *gc.C) {
-	const series = coretesting.FakeDefaultSeries
+	var series = series.LatestLts()
 	const arch = "amd64"
 	const operatingSystem = version.Ubuntu
 
@@ -121,7 +121,7 @@ func (s *provisionerSuite) TestProvisionMachine(c *gc.C) {
 }
 
 func (s *provisionerSuite) TestFinishInstancConfig(c *gc.C) {
-	const series = coretesting.FakeDefaultSeries
+	var series = series.LatestLts()
 	const arch = "amd64"
 	defer fakeSSH{
 		Series:         series,
@@ -145,7 +145,7 @@ func (s *provisionerSuite) TestFinishInstancConfig(c *gc.C) {
 }
 
 func (s *provisionerSuite) TestProvisioningScript(c *gc.C) {
-	const series = coretesting.FakeDefaultSeries
+	var series = series.LatestLts()
 	const arch = "amd64"
 	defer fakeSSH{
 		Series:         series,

--- a/environs/testing/tools.go
+++ b/environs/testing/tools.go
@@ -11,6 +11,7 @@ import (
 
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
+	"github.com/juju/utils/series"
 	"github.com/juju/utils/set"
 	gc "gopkg.in/check.v1"
 
@@ -28,7 +29,7 @@ import (
 )
 
 // toolsLtsSeries records the known Ubuntu LTS series.
-var toolsLtsSeries = []string{"precise", "trusty"}
+var toolsLtsSeries = series.SupportedLts()
 
 // ToolsFixture is used as a fixture to stub out the default tools URL so we
 // don't hit the real internet during tests.
@@ -232,7 +233,7 @@ func uploadFakeTools(stor storage.Storage, toolsDir, stream string) error {
 
 // UploadFakeTools puts fake tools into the supplied storage with a binary
 // version matching version.Current; if version.Current's series is different
-// to coretesting.FakeDefaultSeries, matching fake tools will be uploaded for that
+// to series.LatestLts(), matching fake tools will be uploaded for that
 // series.  This is useful for tests that are kinda casual about specifying
 // their environment.
 func UploadFakeTools(c *gc.C, stor storage.Storage, toolsDir, stream string) {
@@ -253,7 +254,7 @@ func RemoveFakeTools(c *gc.C, stor storage.Storage, toolsDir string) {
 	name := envtools.StorageName(toolsVersion, toolsDir)
 	err := stor.Remove(name)
 	c.Check(err, jc.ErrorIsNil)
-	defaultSeries := coretesting.FakeDefaultSeries
+	defaultSeries := series.LatestLts()
 	if version.Current.Series != defaultSeries {
 		toolsVersion.Series = defaultSeries
 		name := envtools.StorageName(toolsVersion, toolsDir)

--- a/juju/api_test.go
+++ b/juju/api_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/juju/names"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/series"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/api"
@@ -257,7 +258,7 @@ func (s *NewAPIClientSuite) TestWithConfigAndNoInfo(c *gc.C) {
 			"name":                      "myenv",
 			"state-server":              true,
 			"authorized-keys":           "i-am-a-key",
-			"default-series":            config.LatestLtsSeries(),
+			"default-series":            series.LatestLts(),
 			"firewall-mode":             config.FwInstance,
 			"development":               false,
 			"ssl-hostname-verification": true,

--- a/juju/testing/repo.go
+++ b/juju/testing/repo.go
@@ -7,11 +7,11 @@ import (
 
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
+	"github.com/juju/utils/series"
 	"github.com/juju/utils/symlink"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v5"
 
-	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/storage"
 )
@@ -28,13 +28,13 @@ func (s *RepoSuite) SetUpTest(c *gc.C) {
 	s.JujuConnSuite.SetUpTest(c)
 	// Change the environ's config to ensure we're using the one in state,
 	// not the one in the local environments.yaml
-	updateAttrs := map[string]interface{}{"default-series": config.LatestLtsSeries()}
+	updateAttrs := map[string]interface{}{"default-series": series.LatestLts()}
 	err := s.State.UpdateEnvironConfig(updateAttrs, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	s.RepoPath = os.Getenv("JUJU_REPOSITORY")
 	repoPath := c.MkDir()
 	os.Setenv("JUJU_REPOSITORY", repoPath)
-	s.SeriesPath = filepath.Join(repoPath, config.LatestLtsSeries())
+	s.SeriesPath = filepath.Join(repoPath, series.LatestLts())
 	err = os.Mkdir(s.SeriesPath, 0777)
 	c.Assert(err, jc.ErrorIsNil)
 	// Create a symlink "quantal" -> "precise", because most charms

--- a/provider/azure/environ_test.go
+++ b/provider/azure/environ_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/juju/names"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/series"
 	gc "gopkg.in/check.v1"
 	"launchpad.net/gwacl"
 
@@ -1441,7 +1442,7 @@ func (s *environSuite) TestSelectInstanceTypeAndImageUsesForcedImage(c *gc.C) {
 
 	instanceType, image, err := env.selectInstanceTypeAndImage(&instances.InstanceConstraint{
 		Region:      "West US",
-		Series:      coretesting.FakeDefaultSeries,
+		Series:      series.LatestLts(),
 		Constraints: cons,
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -1466,7 +1467,7 @@ func (s *baseEnvironSuite) setupEnvWithDummyMetadata(c *gc.C) *azureEnviron {
 			Endpoint:   "https://management.core.windows.net/",
 		},
 	}
-	s.makeTestMetadata(c, coretesting.FakeDefaultSeries, "North Europe", images)
+	s.makeTestMetadata(c, series.LatestLts(), "North Europe", images)
 	return env
 }
 
@@ -1480,7 +1481,7 @@ func (s *environSuite) TestSelectInstanceTypeAndImageUsesSimplestreamsByDefault(
 	}
 	instanceType, image, err := env.selectInstanceTypeAndImage(&instances.InstanceConstraint{
 		Region:      "North Europe",
-		Series:      coretesting.FakeDefaultSeries,
+		Series:      series.LatestLts(),
 		Constraints: cons,
 	})
 	c.Assert(err, jc.ErrorIsNil)

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -37,6 +37,7 @@ import (
 	"github.com/juju/names"
 	"github.com/juju/schema"
 	gitjujutesting "github.com/juju/testing"
+	"github.com/juju/utils/series"
 	"gopkg.in/juju/environschema.v1"
 
 	"github.com/juju/juju/agent"
@@ -88,7 +89,7 @@ func SampleConfig() testing.Attrs {
 		"state-port":                1234,
 		"api-port":                  4321,
 		"syslog-port":               2345,
-		"default-series":            config.LatestLtsSeries(),
+		"default-series":            series.LatestLts(),
 
 		"secret":       "pork",
 		"state-server": true,

--- a/provider/ec2/ebs_test.go
+++ b/provider/ec2/ebs_test.go
@@ -13,6 +13,7 @@ import (
 	imagetesting "github.com/juju/juju/environs/imagemetadata/testing"
 	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/series"
 	awsec2 "gopkg.in/amz.v3/ec2"
 	"gopkg.in/amz.v3/ec2/ec2test"
 	gc "gopkg.in/check.v1"
@@ -81,7 +82,7 @@ func (s *ebsVolumeSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 	s.PatchValue(&version.Current, version.Binary{
 		Number: testing.FakeVersionNumber,
-		Series: testing.FakeDefaultSeries,
+		Series: series.LatestLts(),
 		Arch:   arch.AMD64,
 	})
 	s.srv.startServer(c)

--- a/provider/ec2/export_test.go
+++ b/provider/ec2/export_test.go
@@ -161,6 +161,8 @@ var TestImagesData = map[string]string{
            "datatype": "image-ids",
            "format": "products:1.0",
            "products": [
+            "com.ubuntu.cloud:server:16.04:amd64",
+            "com.ubuntu.cloud:server:16.04:i386",
             "com.ubuntu.cloud:server:14.04:amd64",
             "com.ubuntu.cloud:server:14.04:i386",
             "com.ubuntu.cloud:server:14.04:amd64",
@@ -179,6 +181,86 @@ var TestImagesData = map[string]string{
 {
  "content_id": "com.ubuntu.cloud:released:aws",
  "products": {
+   "com.ubuntu.cloud:server:16.04:amd64": {
+     "release": "xenial",
+     "version": "16.04",
+     "arch": "amd64",
+     "versions": {
+       "20121218": {
+         "items": {
+           "usee1pi": {
+             "root_store": "instance",
+             "virt": "pv",
+             "region": "us-east-1",
+             "id": "ami-00000111"
+           },
+           "usww1pe": {
+             "root_store": "ssd",
+             "virt": "pv",
+             "region": "eu-west-1",
+             "id": "ami-00000116"
+           },
+           "apne1pe": {
+             "root_store": "ssd",
+             "virt": "pv",
+             "region": "ap-northeast-1",
+             "id": "ami-00000126"
+           },
+           "apne1he": {
+             "root_store": "ssd",
+             "virt": "hvm",
+             "region": "ap-northeast-1",
+             "id": "ami-00000187"
+           },
+           "test1peebs": {
+             "root_store": "ssd",
+             "virt": "pv",
+             "region": "test",
+             "id": "ami-00000133"
+           },
+           "test1pessd": {
+             "root_store": "ebs",
+             "virt": "pv",
+             "region": "test",
+             "id": "ami-00000139"
+           },
+           "test1he": {
+             "root_store": "ssd",
+             "virt": "hvm",
+             "region": "test",
+             "id": "ami-00000135"
+           }
+         },
+         "pubname": "ubuntu-xenial-16.04-amd64-server-20121218",
+         "label": "release"
+       }
+     }
+   },
+   "com.ubuntu.cloud:server:16.04:i386": {
+     "release": "xenial",
+     "version": "16.04",
+     "arch": "i386",
+     "versions": {
+       "20121218": {
+         "items": {
+           "test1pe": {
+             "root_store": "ssd",
+             "virt": "pv",
+             "region": "test",
+             "id": "ami-00000134"
+           },
+           "apne1pe": {
+             "root_store": "ssd",
+             "virt": "pv",
+             "region": "ap-northeast-1",
+             "id": "ami-00000123"
+           }
+         },
+         "pubname": "ubuntu-xenial-16.04-i386-server-20121218",
+         "label": "release"
+       }
+     }
+   },
    "com.ubuntu.cloud:server:14.04:amd64": {
      "release": "trusty",
      "version": "14.04",

--- a/provider/ec2/image_test.go
+++ b/provider/ec2/image_test.go
@@ -4,6 +4,8 @@
 package ec2
 
 import (
+	"fmt"
+
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
 	"github.com/juju/utils/series"
@@ -203,7 +205,7 @@ var findInstanceSpecErrorTests = []struct {
 	}, {
 		series: series.LatestLts(),
 		arches: []string{"arm"},
-		err:    `no "xenial" images in test with arches \[arm\]`,
+		err:    fmt.Sprintf(`no \%q\ images in test with arches \[arm\]`, series.LatestLts()),
 	}, {
 		series: "raring",
 		arches: both,

--- a/provider/ec2/image_test.go
+++ b/provider/ec2/image_test.go
@@ -6,6 +6,7 @@ package ec2
 import (
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
+	"github.com/juju/utils/series"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/constraints"
@@ -46,8 +47,81 @@ var findInstanceSpecTests = []struct {
 	storage []string
 }{
 	{
-		series: testing.FakeDefaultSeries,
-		arches: both,
+		series: "xenial",
+		arches: []string{"amd64"},
+		itype:  "m3.medium",
+		image:  "ami-00000133",
+	}, {
+		series: "quantal",
+		arches: []string{"i386"},
+		itype:  "c1.medium",
+		image:  "ami-01000034",
+	}, {
+		series: "xenial",
+		arches: []string{"amd64"},
+		cons:   "cpu-cores=4",
+		itype:  "m3.xlarge",
+		image:  "ami-00000133",
+	}, {
+		series: "xenial",
+		arches: []string{"amd64"},
+		cons:   "mem=10G",
+		itype:  "m3.xlarge",
+		image:  "ami-00000133",
+	}, {
+		series: "xenial",
+		arches: []string{"amd64"},
+		cons:   "mem=",
+		itype:  "m3.medium",
+		image:  "ami-00000133",
+	}, {
+		series: "xenial",
+		arches: []string{"amd64"},
+		cons:   "cpu-power=",
+		itype:  "m3.medium",
+		image:  "ami-00000133",
+	}, {
+		series: "xenial",
+		arches: []string{"amd64"},
+		cons:   "cpu-power=800",
+		itype:  "m3.xlarge",
+		image:  "ami-00000133",
+	}, {
+		series: "xenial",
+		arches: []string{"amd64"},
+		cons:   "instance-type=m1.medium cpu-power=200",
+		itype:  "m1.medium",
+		image:  "ami-00000133",
+	}, {
+		series: "xenial",
+		arches: []string{"amd64"},
+		cons:   "mem=2G root-disk=16384M",
+		itype:  "m3.medium",
+		image:  "ami-00000133",
+	}, {
+		series:  "xenial",
+		arches:  []string{"amd64"},
+		cons:    "mem=4G root-disk=16384M",
+		itype:   "m3.large",
+		storage: []string{"ssd", "ebs"},
+		image:   "ami-00000133",
+	}, {
+		series:  "xenial",
+		arches:  []string{"amd64"},
+		cons:    "mem=4G root-disk=16384M",
+		itype:   "m3.large",
+		storage: []string{"ebs", "ssd"},
+		image:   "ami-00000139",
+	}, {
+		series:  "xenial",
+		arches:  []string{"amd64"},
+		cons:    "mem=4G root-disk=16384M",
+		itype:   "m3.large",
+		storage: []string{"ebs"},
+		image:   "ami-00000139",
+	}, {
+		series: "trusty",
+		arches: []string{"amd64"},
 		itype:  "m3.medium",
 		image:  "ami-00000033",
 	}, {
@@ -55,54 +129,6 @@ var findInstanceSpecTests = []struct {
 		arches: []string{"i386"},
 		itype:  "c1.medium",
 		image:  "ami-01000034",
-	}, {
-		series: testing.FakeDefaultSeries,
-		arches: both,
-		cons:   "cpu-cores=4",
-		itype:  "m3.xlarge",
-		image:  "ami-00000033",
-	}, {
-		series: testing.FakeDefaultSeries,
-		arches: both,
-		cons:   "cpu-cores=2 arch=i386",
-		itype:  "c1.medium",
-		image:  "ami-00000034",
-	}, {
-		series: testing.FakeDefaultSeries,
-		arches: both,
-		cons:   "mem=10G",
-		itype:  "m3.xlarge",
-		image:  "ami-00000033",
-	}, {
-		series: testing.FakeDefaultSeries,
-		arches: both,
-		cons:   "mem=",
-		itype:  "m3.medium",
-		image:  "ami-00000033",
-	}, {
-		series: testing.FakeDefaultSeries,
-		arches: both,
-		cons:   "cpu-power=",
-		itype:  "m3.medium",
-		image:  "ami-00000033",
-	}, {
-		series: testing.FakeDefaultSeries,
-		arches: both,
-		cons:   "cpu-power=800",
-		itype:  "m3.xlarge",
-		image:  "ami-00000033",
-	}, {
-		series: testing.FakeDefaultSeries,
-		arches: both,
-		cons:   "cpu-power=500 arch=i386",
-		itype:  "c1.medium",
-		image:  "ami-00000034",
-	}, {
-		series: testing.FakeDefaultSeries,
-		arches: []string{"i386"},
-		cons:   "cpu-power=400",
-		itype:  "c1.medium",
-		image:  "ami-00000034",
 	}, {
 		series: "quantal",
 		arches: both,
@@ -116,46 +142,12 @@ var findInstanceSpecTests = []struct {
 		itype:  "cc2.8xlarge",
 		image:  "ami-01000035",
 	}, {
-		series: testing.FakeDefaultSeries,
+		series: "trusty",
 		arches: []string{"i386"},
 		cons:   "instance-type=c1.medium",
 		itype:  "c1.medium",
 		image:  "ami-00000034",
-	}, {
-		series: testing.FakeDefaultSeries,
-		arches: []string{"amd64"},
-		cons:   "instance-type=m1.medium cpu-power=200",
-		itype:  "m1.medium",
-		image:  "ami-00000033",
-	}, {
-		series: testing.FakeDefaultSeries,
-		arches: both,
-		cons:   "mem=2G root-disk=16384M",
-		itype:  "m3.medium",
-		image:  "ami-00000033",
-	}, {
-		series:  testing.FakeDefaultSeries,
-		arches:  both,
-		cons:    "mem=4G root-disk=16384M",
-		itype:   "m3.large",
-		storage: []string{"ssd", "ebs"},
-		image:   "ami-00000033",
-	}, {
-		series:  testing.FakeDefaultSeries,
-		arches:  both,
-		cons:    "mem=4G root-disk=16384M",
-		itype:   "m3.large",
-		storage: []string{"ebs", "ssd"},
-		image:   "ami-00000039",
-	}, {
-		series:  testing.FakeDefaultSeries,
-		arches:  both,
-		cons:    "mem=4G root-disk=16384M",
-		itype:   "m3.large",
-		storage: []string{"ebs"},
-		image:   "ami-00000039",
-	},
-}
+	}}
 
 func (s *specSuite) TestFindInstanceSpec(c *gc.C) {
 	for i, test := range findInstanceSpecTests {
@@ -188,7 +180,7 @@ func (s *specSuite) TestFindInstanceSpecNotSetCpuPowerWhenInstanceTypeSet(c *gc.
 	}
 	instanceConstraint := &instances.InstanceConstraint{
 		Region:      "test",
-		Series:      testing.FakeDefaultSeries,
+		Series:      series.LatestLts(),
 		Constraints: constraints.MustParse("instance-type=t2.medium"),
 	}
 
@@ -209,16 +201,16 @@ var findInstanceSpecErrorTests = []struct {
 		arches: both,
 		err:    `unknown version for series: "bad"`,
 	}, {
-		series: testing.FakeDefaultSeries,
+		series: series.LatestLts(),
 		arches: []string{"arm"},
-		err:    `no "trusty" images in test with arches \[arm\]`,
+		err:    `no "xenial" images in test with arches \[arm\]`,
 	}, {
 		series: "raring",
 		arches: both,
 		cons:   "mem=4G",
 		err:    `no "raring" images in test matching instance types \[m3.large m3.xlarge c1.xlarge m3.2xlarge cc2.8xlarge\]`,
 	}, {
-		series: testing.FakeDefaultSeries,
+		series: series.LatestLts(),
 		arches: both,
 		cons:   "instance-type=m1.small mem=4G",
 		err:    `no instance types in test matching constraints "instance-type=m1.small mem=4096M"`,

--- a/provider/ec2/live_test.go
+++ b/provider/ec2/live_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/series"
 	amzec2 "gopkg.in/amz.v3/ec2"
 	gc "gopkg.in/check.v1"
 
@@ -91,7 +92,7 @@ func (t *LiveTests) SetUpTest(c *gc.C) {
 	t.LiveTests.SetUpTest(c)
 	t.BaseSuite.PatchValue(&version.Current, version.Binary{
 		Number: coretesting.FakeVersionNumber,
-		Series: coretesting.FakeDefaultSeries,
+		Series: series.LatestLts(),
 		Arch:   arch.AMD64,
 	})
 }

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
+	"github.com/juju/utils/series"
 	"github.com/juju/utils/set"
 	"gopkg.in/amz.v3/aws"
 	amzec2 "gopkg.in/amz.v3/ec2"
@@ -200,7 +201,7 @@ func (t *localServerSuite) SetUpTest(c *gc.C) {
 	t.BaseSuite.SetUpTest(c)
 	t.PatchValue(&version.Current, version.Binary{
 		Number: coretesting.FakeVersionNumber,
-		Series: coretesting.FakeDefaultSeries,
+		Series: series.LatestLts(),
 		Arch:   arch.AMD64,
 	})
 	t.SetFeatureFlags(feature.AddressAllocation)
@@ -221,9 +222,94 @@ func (t *localServerSuite) prepareEnviron(c *gc.C) environs.NetworkingEnviron {
 	return netenv
 }
 
-func (t *localServerSuite) TestBootstrapInstanceUserDataAndState(c *gc.C) {
+func (t *localServerSuite) TestSystemdBootstrapInstanceUserDataAndState(c *gc.C) {
+	ver, err := series.SeriesVersion(version.Current.Series)
+	c.Assert(err, jc.ErrorIsNil)
+	if ver < "16" {
+		c.Skip("Skipping systemd test on upstart system")
+	}
 	env := t.Prepare(c)
-	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{})
+	err = bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{})
+	c.Assert(err, jc.ErrorIsNil)
+
+	// check that StateServerInstances returns the id of the bootstrap machine.
+	instanceIds, err := env.StateServerInstances()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(instanceIds, gc.HasLen, 1)
+
+	insts, err := env.AllInstances()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(insts, gc.HasLen, 1)
+	c.Check(insts[0].Id(), gc.Equals, instanceIds[0])
+
+	// check that the user data is configured to start zookeeper
+	// and the machine and provisioning agents.
+	// check that the user data is configured to only configure
+	// authorized SSH keys and set the log output; everything
+	// else happens after the machine is brought up.
+	inst := t.srv.ec2srv.Instance(string(insts[0].Id()))
+	c.Assert(inst, gc.NotNil)
+	addresses, err := insts[0].Addresses()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(addresses, gc.Not(gc.HasLen), 0)
+	userData, err := utils.Gunzip(inst.UserData)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Logf("first instance: UserData: %q", userData)
+	var userDataMap map[interface{}]interface{}
+	err = goyaml.Unmarshal(userData, &userDataMap)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(userDataMap, jc.DeepEquals, map[interface{}]interface{}{
+		"output": map[interface{}]interface{}{
+			"all": "| tee -a /var/log/cloud-init-output.log",
+		},
+		"ssh_authorized_keys": splitAuthKeys(env.Config().AuthorizedKeys()),
+		"runcmd": []interface{}{
+			"set -xe",
+			"install -D -m 644 /dev/null '/etc/systemd/system/juju-clean-shutdown.service'",
+			"printf '%s\\n' '\n[Unit]\nDescription=Stop all network interfaces on shutdown\nDefaultDependencies=false\nAfter=final.target\n\n[Service]\nType=oneshot\nExecStart=/sbin/ifdown -a -v --force\nStandardOutput=tty\nStandardError=tty\n\n[Install]\nWantedBy=final.target\n' > '/etc/systemd/system/juju-clean-shutdown.service'", "/bin/systemctl enable '/etc/systemd/system/juju-clean-shutdown.service'",
+			"install -D -m 644 /dev/null '/var/lib/juju/nonce.txt'",
+			"printf '%s\\n' 'user-admin:bootstrap' > '/var/lib/juju/nonce.txt'",
+		},
+	})
+
+	// check that a new instance will be started with a machine agent
+	inst1, hc := testing.AssertStartInstance(c, env, "1")
+	c.Check(*hc.Arch, gc.Equals, "amd64")
+	c.Check(*hc.Mem, gc.Equals, uint64(3840))
+	c.Check(*hc.CpuCores, gc.Equals, uint64(1))
+	c.Assert(*hc.CpuPower, gc.Equals, uint64(300))
+	inst = t.srv.ec2srv.Instance(string(inst1.Id()))
+	c.Assert(inst, gc.NotNil)
+	userData, err = utils.Gunzip(inst.UserData)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Logf("second instance: UserData: %q", userData)
+	userDataMap = nil
+	err = goyaml.Unmarshal(userData, &userDataMap)
+	c.Assert(err, jc.ErrorIsNil)
+	CheckPackage(c, userDataMap, "curl", true)
+	CheckPackage(c, userDataMap, "mongodb-server", false)
+	CheckScripts(c, userDataMap, "jujud bootstrap-state", false)
+	CheckScripts(c, userDataMap, "/var/lib/juju/agents/machine-1/agent.conf", true)
+	// TODO check for provisioning agent
+
+	err = env.Destroy()
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, err = env.StateServerInstances()
+	c.Assert(err, gc.Equals, environs.ErrNotBootstrapped)
+}
+
+// TestUpstartBoostrapInstanceUserDataAndState is a test for legacy systems
+// using upstart which will be around until trusty is no longer supported.
+// TODO: BBB: remove when trusty is no longer supported
+func (t *localServerSuite) TestUpstartBootstrapInstanceUserDataAndState(c *gc.C) {
+	ver, err := series.SeriesVersion(version.Current.Series)
+	c.Assert(err, jc.ErrorIsNil)
+	if ver > "15" {
+		c.Skip("Skipping upstart test on systemd system")
+	}
+	env := t.Prepare(c)
+	err = bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	// check that StateServerInstances returns the id of the bootstrap machine.
@@ -771,7 +857,7 @@ func (t *localServerSuite) TestPrecheckInstanceValidInstanceType(c *gc.C) {
 	env := t.Prepare(c)
 	cons := constraints.MustParse("instance-type=m1.small root-disk=1G")
 	placement := ""
-	err := env.PrecheckInstance(coretesting.FakeDefaultSeries, cons, placement)
+	err := env.PrecheckInstance(series.LatestLts(), cons, placement)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -779,7 +865,7 @@ func (t *localServerSuite) TestPrecheckInstanceInvalidInstanceType(c *gc.C) {
 	env := t.Prepare(c)
 	cons := constraints.MustParse("instance-type=m1.invalid")
 	placement := ""
-	err := env.PrecheckInstance(coretesting.FakeDefaultSeries, cons, placement)
+	err := env.PrecheckInstance(series.LatestLts(), cons, placement)
 	c.Assert(err, gc.ErrorMatches, `invalid AWS instance type "m1.invalid" specified`)
 }
 
@@ -787,28 +873,28 @@ func (t *localServerSuite) TestPrecheckInstanceUnsupportedArch(c *gc.C) {
 	env := t.Prepare(c)
 	cons := constraints.MustParse("instance-type=cc1.4xlarge arch=i386")
 	placement := ""
-	err := env.PrecheckInstance(coretesting.FakeDefaultSeries, cons, placement)
+	err := env.PrecheckInstance(series.LatestLts(), cons, placement)
 	c.Assert(err, gc.ErrorMatches, `invalid AWS instance type "cc1.4xlarge" and arch "i386" specified`)
 }
 
 func (t *localServerSuite) TestPrecheckInstanceAvailZone(c *gc.C) {
 	env := t.Prepare(c)
 	placement := "zone=test-available"
-	err := env.PrecheckInstance(coretesting.FakeDefaultSeries, constraints.Value{}, placement)
+	err := env.PrecheckInstance(series.LatestLts(), constraints.Value{}, placement)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (t *localServerSuite) TestPrecheckInstanceAvailZoneUnavailable(c *gc.C) {
 	env := t.Prepare(c)
 	placement := "zone=test-unavailable"
-	err := env.PrecheckInstance(coretesting.FakeDefaultSeries, constraints.Value{}, placement)
+	err := env.PrecheckInstance(series.LatestLts(), constraints.Value{}, placement)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (t *localServerSuite) TestPrecheckInstanceAvailZoneUnknown(c *gc.C) {
 	env := t.Prepare(c)
 	placement := "zone=test-unknown"
-	err := env.PrecheckInstance(coretesting.FakeDefaultSeries, constraints.Value{}, placement)
+	err := env.PrecheckInstance(series.LatestLts(), constraints.Value{}, placement)
 	c.Assert(err, gc.ErrorMatches, `invalid availability zone "test-unknown"`)
 }
 
@@ -816,14 +902,14 @@ func (t *localServerSuite) TestValidateImageMetadata(c *gc.C) {
 	env := t.Prepare(c)
 	params, err := env.(simplestreams.MetadataValidator).MetadataLookupParams("test")
 	c.Assert(err, jc.ErrorIsNil)
-	params.Series = coretesting.FakeDefaultSeries
+	params.Series = series.LatestLts()
 	params.Endpoint = "https://ec2.endpoint.com"
 	params.Sources, err = environs.ImageMetadataSources(env)
 	c.Assert(err, jc.ErrorIsNil)
 	image_ids, _, err := imagemetadata.ValidateImageMetadata(params)
 	c.Assert(err, jc.ErrorIsNil)
 	sort.Strings(image_ids)
-	c.Assert(image_ids, gc.DeepEquals, []string{"ami-00000033", "ami-00000034", "ami-00000035", "ami-00000039"})
+	c.Assert(image_ids, gc.DeepEquals, []string{"ami-00000133", "ami-00000134", "ami-00000135", "ami-00000139"})
 }
 
 func (t *localServerSuite) TestGetToolsMetadataSources(c *gc.C) {

--- a/provider/gce/environ_policy_test.go
+++ b/provider/gce/environ_policy_test.go
@@ -6,13 +6,13 @@ package gce_test
 import (
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/series"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/juju/arch"
 	"github.com/juju/juju/provider/gce"
 	"github.com/juju/juju/provider/gce/google"
-	"github.com/juju/juju/testing"
 )
 
 type environPolSuite struct {
@@ -24,7 +24,7 @@ var _ = gc.Suite(&environPolSuite{})
 func (s *environPolSuite) TestPrecheckInstance(c *gc.C) {
 	cons := constraints.Value{}
 	placement := ""
-	err := s.Env.PrecheckInstance(testing.FakeDefaultSeries, cons, placement)
+	err := s.Env.PrecheckInstance(series.LatestLts(), cons, placement)
 
 	c.Check(err, jc.ErrorIsNil)
 }
@@ -36,7 +36,7 @@ func (s *environPolSuite) TestPrecheckInstanceAPI(c *gc.C) {
 
 	cons := constraints.Value{}
 	placement := ""
-	err := s.Env.PrecheckInstance(testing.FakeDefaultSeries, cons, placement)
+	err := s.Env.PrecheckInstance(series.LatestLts(), cons, placement)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(s.FakeConn.Calls, gc.HasLen, 0)
@@ -49,7 +49,7 @@ func (s *environPolSuite) TestPrecheckInstanceFullAPI(c *gc.C) {
 
 	cons := constraints.MustParse("instance-type=n1-standard-1 arch=amd64 root-disk=1G")
 	placement := "zone=home-zone"
-	err := s.Env.PrecheckInstance(testing.FakeDefaultSeries, cons, placement)
+	err := s.Env.PrecheckInstance(series.LatestLts(), cons, placement)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(s.FakeConn.Calls, gc.HasLen, 1)
@@ -60,7 +60,7 @@ func (s *environPolSuite) TestPrecheckInstanceFullAPI(c *gc.C) {
 func (s *environPolSuite) TestPrecheckInstanceValidInstanceType(c *gc.C) {
 	cons := constraints.MustParse("instance-type=n1-standard-1")
 	placement := ""
-	err := s.Env.PrecheckInstance(testing.FakeDefaultSeries, cons, placement)
+	err := s.Env.PrecheckInstance(series.LatestLts(), cons, placement)
 
 	c.Check(err, jc.ErrorIsNil)
 }
@@ -68,7 +68,7 @@ func (s *environPolSuite) TestPrecheckInstanceValidInstanceType(c *gc.C) {
 func (s *environPolSuite) TestPrecheckInstanceInvalidInstanceType(c *gc.C) {
 	cons := constraints.MustParse("instance-type=n1-standard-1.invalid")
 	placement := ""
-	err := s.Env.PrecheckInstance(testing.FakeDefaultSeries, cons, placement)
+	err := s.Env.PrecheckInstance(series.LatestLts(), cons, placement)
 
 	c.Check(err, gc.ErrorMatches, `.*invalid GCE instance type.*`)
 }
@@ -76,7 +76,7 @@ func (s *environPolSuite) TestPrecheckInstanceInvalidInstanceType(c *gc.C) {
 func (s *environPolSuite) TestPrecheckInstanceDiskSize(c *gc.C) {
 	cons := constraints.MustParse("instance-type=n1-standard-1 root-disk=1G")
 	placement := ""
-	err := s.Env.PrecheckInstance(testing.FakeDefaultSeries, cons, placement)
+	err := s.Env.PrecheckInstance(series.LatestLts(), cons, placement)
 
 	c.Check(err, jc.ErrorIsNil)
 }
@@ -84,7 +84,7 @@ func (s *environPolSuite) TestPrecheckInstanceDiskSize(c *gc.C) {
 func (s *environPolSuite) TestPrecheckInstanceUnsupportedArch(c *gc.C) {
 	cons := constraints.MustParse("instance-type=n1-standard-1 arch=i386")
 	placement := ""
-	err := s.Env.PrecheckInstance(testing.FakeDefaultSeries, cons, placement)
+	err := s.Env.PrecheckInstance(series.LatestLts(), cons, placement)
 
 	c.Check(err, jc.ErrorIsNil)
 }
@@ -96,7 +96,7 @@ func (s *environPolSuite) TestPrecheckInstanceAvailZone(c *gc.C) {
 
 	cons := constraints.Value{}
 	placement := "zone=a-zone"
-	err := s.Env.PrecheckInstance(testing.FakeDefaultSeries, cons, placement)
+	err := s.Env.PrecheckInstance(series.LatestLts(), cons, placement)
 
 	c.Check(err, jc.ErrorIsNil)
 }
@@ -108,7 +108,7 @@ func (s *environPolSuite) TestPrecheckInstanceAvailZoneUnavailable(c *gc.C) {
 
 	cons := constraints.Value{}
 	placement := "zone=a-zone"
-	err := s.Env.PrecheckInstance(testing.FakeDefaultSeries, cons, placement)
+	err := s.Env.PrecheckInstance(series.LatestLts(), cons, placement)
 
 	c.Check(err, gc.ErrorMatches, `.*availability zone "a-zone" is DOWN`)
 }
@@ -120,7 +120,7 @@ func (s *environPolSuite) TestPrecheckInstanceAvailZoneUnknown(c *gc.C) {
 
 	cons := constraints.Value{}
 	placement := "zone=a-zone"
-	err := s.Env.PrecheckInstance(testing.FakeDefaultSeries, cons, placement)
+	err := s.Env.PrecheckInstance(series.LatestLts(), cons, placement)
 
 	c.Check(err, jc.Satisfies, errors.IsNotFound)
 }

--- a/provider/joyent/export_test.go
+++ b/provider/joyent/export_test.go
@@ -49,6 +49,7 @@ var indexData = `
 		   "datatype": "image-ids",
 		   "format": "products:1.0",
 		   "products": [
+			"com.ubuntu.cloud:server:16.04:amd64",
 			"com.ubuntu.cloud:server:14.04:amd64",
 			"com.ubuntu.cloud:server:12.10:amd64",
 			"com.ubuntu.cloud:server:13.04:amd64"
@@ -68,6 +69,24 @@ var imagesData = `
   "updated": "Fri, 14 Feb 2014 13:39:35 +0000",
   "datatype": "image-ids",
   "products": {
+    "com.ubuntu.cloud:server:16.04:amd64": {
+      "release": "xenial",
+      "version": "16.04",
+      "arch": "amd64",
+      "versions": {
+        "20140214": {
+          "items": {
+            "11223344-0a0a-ff99-11bb-0a1b2c3d4e5f": {
+              "region": "some-region",
+              "id": "11223344-0a0a-ff99-11bb-0a1b2c3d4e5f",
+              "virt": "kvm"
+            }
+          },
+          "pubname": "ubuntu-xenial-16.04-amd64-server-20140214",
+          "label": "release"
+        }
+      }
+    },
     "com.ubuntu.cloud:server:14.04:amd64": {
       "release": "trusty",
       "version": "14.04",

--- a/provider/maas/environ_whitebox_test.go
+++ b/provider/maas/environ_whitebox_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
+	"github.com/juju/utils/series"
 	"github.com/juju/utils/set"
 	gc "gopkg.in/check.v1"
 	goyaml "gopkg.in/yaml.v1"
@@ -39,7 +40,6 @@ import (
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/provider/common"
 	"github.com/juju/juju/storage"
-	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/version"
 )
 
@@ -1408,7 +1408,7 @@ func (s *environSuite) TestPrecheckInstanceAvailZone(c *gc.C) {
 	s.testMAASObject.TestServer.AddZone("zone1", "the grass is greener in zone1")
 	env := s.makeEnviron()
 	placement := "zone=zone1"
-	err := env.PrecheckInstance(coretesting.FakeDefaultSeries, constraints.Value{}, placement)
+	err := env.PrecheckInstance(series.LatestLts(), constraints.Value{}, placement)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -1473,26 +1473,26 @@ func (s *environSuite) TestPrecheckInstanceAvailZoneUnknown(c *gc.C) {
 	s.testMAASObject.TestServer.AddZone("zone1", "the grass is greener in zone1")
 	env := s.makeEnviron()
 	placement := "zone=zone2"
-	err := env.PrecheckInstance(coretesting.FakeDefaultSeries, constraints.Value{}, placement)
+	err := env.PrecheckInstance(series.LatestLts(), constraints.Value{}, placement)
 	c.Assert(err, gc.ErrorMatches, `invalid availability zone "zone2"`)
 }
 
 func (s *environSuite) TestPrecheckInstanceAvailZonesUnsupported(c *gc.C) {
 	env := s.makeEnviron()
 	placement := "zone=test-unknown"
-	err := env.PrecheckInstance(coretesting.FakeDefaultSeries, constraints.Value{}, placement)
+	err := env.PrecheckInstance(series.LatestLts(), constraints.Value{}, placement)
 	c.Assert(err, jc.Satisfies, errors.IsNotImplemented)
 }
 
 func (s *environSuite) TestPrecheckInvalidPlacement(c *gc.C) {
 	env := s.makeEnviron()
-	err := env.PrecheckInstance(coretesting.FakeDefaultSeries, constraints.Value{}, "notzone=anything")
+	err := env.PrecheckInstance(series.LatestLts(), constraints.Value{}, "notzone=anything")
 	c.Assert(err, gc.ErrorMatches, "unknown placement directive: notzone=anything")
 }
 
 func (s *environSuite) TestPrecheckNodePlacement(c *gc.C) {
 	env := s.makeEnviron()
-	err := env.PrecheckInstance(coretesting.FakeDefaultSeries, constraints.Value{}, "assumed_node_name")
+	err := env.PrecheckInstance(series.LatestLts(), constraints.Value{}, "assumed_node_name")
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/provider/maas/util.go
+++ b/provider/maas/util.go
@@ -10,10 +10,10 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/utils"
+	"github.com/juju/utils/series"
 	goyaml "gopkg.in/yaml.v1"
 
 	"github.com/juju/juju/cloudconfig/cloudinit"
-	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/juju/paths"
 )
@@ -48,7 +48,7 @@ type machineInfo struct {
 	Hostname string `yaml:",omitempty"`
 }
 
-var maasDataDir = paths.MustSucceed(paths.DataDir(config.LatestLtsSeries()))
+var maasDataDir = paths.MustSucceed(paths.DataDir(series.LatestLts()))
 var _MAASInstanceFilename = path.Join(maasDataDir, "MAASmachine.txt")
 
 // cloudinitRunCmd returns the shell command that, when run, will create the

--- a/provider/openstack/export_test.go
+++ b/provider/openstack/export_test.go
@@ -108,6 +108,7 @@ var indexData = `
 		   "datatype": "image-ids",
 		   "format": "products:1.0",
 		   "products": [
+			"com.ubuntu.cloud:server:16.04:amd64",
 			"com.ubuntu.cloud:server:14.04:amd64",
 			"com.ubuntu.cloud:server:14.04:i386",
 			"com.ubuntu.cloud:server:14.04:ppc64el",
@@ -126,6 +127,43 @@ var imagesData = `
 {
  "content_id": "com.ubuntu.cloud:released:openstack",
  "products": {
+   "com.ubuntu.cloud:server:16.04:amd64": {
+     "release": "xenial",
+     "version": "16.04",
+     "arch": "amd64",
+     "versions": {
+       "20161218": {
+         "items": {
+           "inst1": {
+             "root_store": "ebs",
+             "virt": "pv",
+             "region": "some-region",
+             "id": "1"
+           },
+           "inst2": {
+             "root_store": "ebs",
+             "virt": "pv",
+             "region": "another-region",
+             "id": "2"
+           }
+         },
+         "pubname": "ubuntu-xenial-16.04-amd64-server-20121218",
+         "label": "release"
+       },
+       "20161111": {
+         "items": {
+           "inst3": {
+             "root_store": "ebs",
+             "virt": "pv",
+             "region": "some-region",
+             "id": "3"
+           }
+         },
+         "pubname": "ubuntu-xenial-16.04-amd64-server-20161111",
+         "label": "release"
+       }
+     }
+   },
    "com.ubuntu.cloud:server:14.04:amd64": {
      "release": "trusty",
      "version": "14.04",

--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -18,6 +18,7 @@ import (
 	jujuerrors "github.com/juju/errors"
 	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/series"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/goose.v1/client"
 	"gopkg.in/goose.v1/identity"
@@ -933,7 +934,7 @@ func (s *localServerSuite) TestConstraintsMerge(c *gc.C) {
 func (s *localServerSuite) TestFindImageInstanceConstraint(c *gc.C) {
 	imagetesting.PatchOfficialDataSources(&s.CleanupSuite, "")
 	env := s.Open(c)
-	spec, err := openstack.FindInstanceSpec(env, coretesting.FakeDefaultSeries, "amd64", "instance-type=m1.tiny")
+	spec, err := openstack.FindInstanceSpec(env, series.LatestLts(), "amd64", "instance-type=m1.tiny")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(spec.InstanceType.Name, gc.Equals, "m1.tiny")
 }
@@ -941,7 +942,7 @@ func (s *localServerSuite) TestFindImageInstanceConstraint(c *gc.C) {
 func (s *localServerSuite) TestFindImageInvalidInstanceConstraint(c *gc.C) {
 	imagetesting.PatchOfficialDataSources(&s.CleanupSuite, "")
 	env := s.Open(c)
-	_, err := openstack.FindInstanceSpec(env, coretesting.FakeDefaultSeries, "amd64", "instance-type=m1.large")
+	_, err := openstack.FindInstanceSpec(env, series.LatestLts(), "amd64", "instance-type=m1.large")
 	c.Assert(err, gc.ErrorMatches, `no instance types in some-region matching constraints "instance-type=m1.large"`)
 }
 
@@ -949,7 +950,7 @@ func (s *localServerSuite) TestPrecheckInstanceValidInstanceType(c *gc.C) {
 	env := s.Open(c)
 	cons := constraints.MustParse("instance-type=m1.small")
 	placement := ""
-	err := env.PrecheckInstance(coretesting.FakeDefaultSeries, cons, placement)
+	err := env.PrecheckInstance(series.LatestLts(), cons, placement)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -957,28 +958,28 @@ func (s *localServerSuite) TestPrecheckInstanceInvalidInstanceType(c *gc.C) {
 	env := s.Open(c)
 	cons := constraints.MustParse("instance-type=m1.large")
 	placement := ""
-	err := env.PrecheckInstance(coretesting.FakeDefaultSeries, cons, placement)
+	err := env.PrecheckInstance(series.LatestLts(), cons, placement)
 	c.Assert(err, gc.ErrorMatches, `invalid Openstack flavour "m1.large" specified`)
 }
 
 func (t *localServerSuite) TestPrecheckInstanceAvailZone(c *gc.C) {
 	env := t.Prepare(c)
 	placement := "zone=test-available"
-	err := env.PrecheckInstance(coretesting.FakeDefaultSeries, constraints.Value{}, placement)
+	err := env.PrecheckInstance(series.LatestLts(), constraints.Value{}, placement)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (t *localServerSuite) TestPrecheckInstanceAvailZoneUnavailable(c *gc.C) {
 	env := t.Prepare(c)
 	placement := "zone=test-unavailable"
-	err := env.PrecheckInstance(coretesting.FakeDefaultSeries, constraints.Value{}, placement)
+	err := env.PrecheckInstance(series.LatestLts(), constraints.Value{}, placement)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (t *localServerSuite) TestPrecheckInstanceAvailZoneUnknown(c *gc.C) {
 	env := t.Prepare(c)
 	placement := "zone=test-unknown"
-	err := env.PrecheckInstance(coretesting.FakeDefaultSeries, constraints.Value{}, placement)
+	err := env.PrecheckInstance(series.LatestLts(), constraints.Value{}, placement)
 	c.Assert(err, gc.ErrorMatches, `invalid availability zone "test-unknown"`)
 }
 
@@ -986,7 +987,7 @@ func (t *localServerSuite) TestPrecheckInstanceAvailZonesUnsupported(c *gc.C) {
 	t.srv.Nova.SetAvailabilityZones() // no availability zone support
 	env := t.Prepare(c)
 	placement := "zone=test-unknown"
-	err := env.PrecheckInstance(coretesting.FakeDefaultSeries, constraints.Value{}, placement)
+	err := env.PrecheckInstance(series.LatestLts(), constraints.Value{}, placement)
 	c.Assert(err, jc.Satisfies, jujuerrors.IsNotImplemented)
 }
 

--- a/testing/base.go
+++ b/testing/base.go
@@ -122,23 +122,22 @@ func (s *JujuOSEnvSuite) SetFeatureFlags(flag ...string) {
 // NOTE: there will be many tests that fail when you try to change
 // to the IsolationSuite that rely on external things in PATH.
 type BaseSuite struct {
+	oldLtsForTesting string
 	testing.CleanupSuite
 	testing.LoggingSuite
 	JujuOSEnvSuite
 }
-
-var oldLtsForTesting string
 
 func (s *BaseSuite) SetUpSuite(c *gc.C) {
 	wrench.SetEnabled(false)
 	s.CleanupSuite.SetUpSuite(c)
 	s.LoggingSuite.SetUpSuite(c)
 	s.PatchValue(&utils.OutgoingAccessAllowed, false)
-	oldLtsForTesting = series.SetLatestLtsForTesting("xenial")
+	s.oldLtsForTesting = series.SetLatestLtsForTesting("xenial")
 }
 
 func (s *BaseSuite) TearDownSuite(c *gc.C) {
-	_ = series.SetLatestLtsForTesting(oldLtsForTesting)
+	_ = series.SetLatestLtsForTesting(s.oldLtsForTesting)
 	s.LoggingSuite.TearDownSuite(c)
 	s.CleanupSuite.TearDownSuite(c)
 }

--- a/testing/base.go
+++ b/testing/base.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/testing"
 	"github.com/juju/utils"
 	"github.com/juju/utils/featureflag"
+	"github.com/juju/utils/series"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/juju/arch"
@@ -126,14 +127,18 @@ type BaseSuite struct {
 	JujuOSEnvSuite
 }
 
+var oldLtsForTesting string
+
 func (s *BaseSuite) SetUpSuite(c *gc.C) {
 	wrench.SetEnabled(false)
 	s.CleanupSuite.SetUpSuite(c)
 	s.LoggingSuite.SetUpSuite(c)
 	s.PatchValue(&utils.OutgoingAccessAllowed, false)
+	oldLtsForTesting = series.SetLatestLtsForTesting("xenial")
 }
 
 func (s *BaseSuite) TearDownSuite(c *gc.C) {
+	_ = series.SetLatestLtsForTesting(oldLtsForTesting)
 	s.LoggingSuite.TearDownSuite(c)
 	s.CleanupSuite.TearDownSuite(c)
 }

--- a/testing/environ.go
+++ b/testing/environ.go
@@ -11,6 +11,7 @@ import (
 	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
+	"github.com/juju/utils/series"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/environs/config"
@@ -30,8 +31,6 @@ func init() {
 		panic("FakeAuthKeys does not hold a valid authorized key: " + err.Error())
 	}
 }
-
-const FakeDefaultSeries = "trusty"
 
 // FakeVersionNumber is a valid version number that can be used in testing.
 var FakeVersionNumber = version.MustParse("1.99.0")
@@ -55,7 +54,7 @@ func FakeConfig() Attrs {
 		"development":               false,
 		"state-port":                19034,
 		"api-port":                  17777,
-		"default-series":            FakeDefaultSeries,
+		"default-series":            series.LatestLts(),
 	}
 }
 

--- a/testing/factory/factory_test.go
+++ b/testing/factory/factory_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
+	"github.com/juju/utils/series"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v5"
 
@@ -522,7 +523,7 @@ func (s *factorySuite) TestMakeEnvironmentNil(c *gc.C) {
 
 	cfg, err := st.EnvironConfig()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cfg.AllAttrs()["default-series"], gc.Equals, "trusty")
+	c.Assert(cfg.AllAttrs()["default-series"], gc.Equals, series.LatestLts())
 }
 
 func (s *factorySuite) TestMakeEnvironment(c *gc.C) {

--- a/worker/networker/networker_test.go
+++ b/worker/networker/networker_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
+	"github.com/juju/utils/series"
 	"github.com/juju/utils/set"
 	gc "gopkg.in/check.v1"
 
@@ -230,7 +231,7 @@ func (s *networkerSuite) TestNoModprobeWhenRunningInLXC(c *gc.C) {
 
 	// Create a new container.
 	template := state.MachineTemplate{
-		Series: coretesting.FakeDefaultSeries,
+		Series: series.LatestLts(),
 		Jobs:   []state.MachineJob{state.JobHostUnits},
 	}
 	lxcMachine, err := s.State.AddMachineInsideMachine(template, s.stateMachine.Id(), instance.LXC)

--- a/worker/provisioner/container_initialisation_test.go
+++ b/worker/provisioner/container_initialisation_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/juju/utils/featureflag"
 	"github.com/juju/utils/fslock"
 	"github.com/juju/utils/packaging/manager"
+	"github.com/juju/utils/series"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/agent"
@@ -129,7 +130,7 @@ func (s *ContainerSetupSuite) createContainer(c *gc.C, host *state.Machine, ctyp
 
 	// make a container on the host machine
 	template := state.MachineTemplate{
-		Series: coretesting.FakeDefaultSeries,
+		Series: series.LatestLts(),
 		Jobs:   []state.MachineJob{state.JobHostUnits},
 	}
 	container, err := s.State.AddMachineInsideMachine(template, host.Id(), ctype)
@@ -173,7 +174,7 @@ func (s *ContainerSetupSuite) TestContainerProvisionerStarted(c *gc.C) {
 	for _, ctype := range instance.ContainerTypes {
 		// create a machine to host the container.
 		m, err := s.BackingState.AddOneMachine(state.MachineTemplate{
-			Series:      coretesting.FakeDefaultSeries,
+			Series:      series.LatestLts(),
 			Jobs:        []state.MachineJob{state.JobHostUnits},
 			Constraints: s.defaultConstraints,
 		})
@@ -225,7 +226,7 @@ func (s *ContainerSetupSuite) testContainerConstraintsArch(c *gc.C, containerTyp
 
 	// create a machine to host the container.
 	m, err := s.BackingState.AddOneMachine(state.MachineTemplate{
-		Series:      coretesting.FakeDefaultSeries,
+		Series:      series.LatestLts(),
 		Jobs:        []state.MachineJob{state.JobHostUnits},
 		Constraints: s.defaultConstraints,
 	})
@@ -243,7 +244,7 @@ func (s *ContainerSetupSuite) testContainerConstraintsArch(c *gc.C, containerTyp
 func (s *ContainerSetupSuite) TestLxcContainerUsesImageURL(c *gc.C) {
 	// create a machine to host the container.
 	m, err := s.BackingState.AddOneMachine(state.MachineTemplate{
-		Series:      coretesting.FakeDefaultSeries,
+		Series:      series.LatestLts(),
 		Jobs:        []state.MachineJob{state.JobHostUnits},
 		Constraints: s.defaultConstraints,
 	})
@@ -348,7 +349,7 @@ func (s *ContainerSetupSuite) TestContainerInitialised(c *gc.C) {
 
 func (s *ContainerSetupSuite) TestContainerInitLockError(c *gc.C) {
 	m, err := s.BackingState.AddOneMachine(state.MachineTemplate{
-		Series:      coretesting.FakeDefaultSeries,
+		Series:      series.LatestLts(),
 		Jobs:        []state.MachineJob{state.JobHostUnits},
 		Constraints: s.defaultConstraints,
 	})
@@ -532,7 +533,7 @@ func (s *LXCDefaultMTUSuite) SetUpTest(c *gc.C) {
 func (s *LXCDefaultMTUSuite) TestDefaultMTUPropagatedToNewLXCBroker(c *gc.C) {
 	// create a machine to host the container.
 	m, err := s.BackingState.AddOneMachine(state.MachineTemplate{
-		Series:      coretesting.FakeDefaultSeries,
+		Series:      series.LatestLts(),
 		Jobs:        []state.MachineJob{state.JobHostUnits},
 		Constraints: s.defaultConstraints,
 	})

--- a/worker/provisioner/kvm-broker_test.go
+++ b/worker/provisioner/kvm-broker_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/juju/names"
 	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/series"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/agent"
@@ -372,7 +373,7 @@ func (s *kvmProvisionerSuite) TestDoesNotStartEnvironMachines(c *gc.C) {
 	defer stop(c, p)
 
 	// Check that an instance is not provisioned when the machine is created.
-	_, err := s.State.AddMachine(coretesting.FakeDefaultSeries, state.JobHostUnits)
+	_, err := s.State.AddMachine(series.LatestLts(), state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.expectNoEvents(c)
@@ -389,7 +390,7 @@ func (s *kvmProvisionerSuite) TestDoesNotHaveRetryWatcher(c *gc.C) {
 
 func (s *kvmProvisionerSuite) addContainer(c *gc.C) *state.Machine {
 	template := state.MachineTemplate{
-		Series: coretesting.FakeDefaultSeries,
+		Series: series.LatestLts(),
 		Jobs:   []state.MachineJob{state.JobHostUnits},
 	}
 	container, err := s.State.AddMachineInsideMachine(template, "0", instance.KVM)

--- a/worker/provisioner/lxc-broker_test.go
+++ b/worker/provisioner/lxc-broker_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/juju/names"
 	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/series"
 	"github.com/juju/utils/set"
 	gc "gopkg.in/check.v1"
 
@@ -1060,7 +1061,7 @@ func (s *lxcProvisionerSuite) TestDoesNotStartEnvironMachines(c *gc.C) {
 	defer stop(c, p)
 
 	// Check that an instance is not provisioned when the machine is created.
-	_, err := s.State.AddMachine(coretesting.FakeDefaultSeries, state.JobHostUnits)
+	_, err := s.State.AddMachine(series.LatestLts(), state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.expectNoEvents(c)
@@ -1077,7 +1078,7 @@ func (s *lxcProvisionerSuite) TestDoesNotHaveRetryWatcher(c *gc.C) {
 
 func (s *lxcProvisionerSuite) addContainer(c *gc.C) *state.Machine {
 	template := state.MachineTemplate{
-		Series: coretesting.FakeDefaultSeries,
+		Series: series.LatestLts(),
 		Jobs:   []state.MachineJob{state.JobHostUnits},
 	}
 	container, err := s.State.AddMachineInsideMachine(template, "0", instance.LXC)
@@ -1100,7 +1101,7 @@ func (s *lxcProvisionerSuite) maybeUploadTools(c *gc.C) {
 	defaultTools := version.Binary{
 		Number: version.Current.Number,
 		Arch:   arch.HostArch(),
-		Series: coretesting.FakeDefaultSeries,
+		Series: series.LatestLts(),
 	}
 
 	envtesting.AssertUploadFakeToolsVersions(c, stor, "devel", "devel", defaultTools)

--- a/worker/provisioner/provisioner_test.go
+++ b/worker/provisioner/provisioner_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
+	"github.com/juju/utils/series"
 	"github.com/juju/utils/set"
 	gc "gopkg.in/check.v1"
 
@@ -446,14 +447,14 @@ func (s *CommonProvisionerSuite) addMachine() (*state.Machine, error) {
 
 func (s *CommonProvisionerSuite) addMachineWithConstraints(cons constraints.Value) (*state.Machine, error) {
 	return s.BackingState.AddOneMachine(state.MachineTemplate{
-		Series:      coretesting.FakeDefaultSeries,
+		Series:      series.LatestLts(),
 		Jobs:        []state.MachineJob{state.JobHostUnits},
 		Constraints: cons,
 	})
 }
 
 func (s *CommonProvisionerSuite) ensureAvailability(c *gc.C, n int) []*state.Machine {
-	changes, err := s.BackingState.EnsureAvailability(n, s.defaultConstraints, coretesting.FakeDefaultSeries, nil)
+	changes, err := s.BackingState.EnsureAvailability(n, s.defaultConstraints, series.LatestLts(), nil)
 	c.Assert(err, jc.ErrorIsNil)
 	added := make([]*state.Machine, len(changes.Added))
 	for i, mid := range changes.Added {
@@ -882,7 +883,7 @@ func (s *ProvisionerSuite) TestProvisioningDoesNotOccurForLXC(c *gc.C) {
 
 	// make a container on the machine we just created
 	template := state.MachineTemplate{
-		Series: coretesting.FakeDefaultSeries,
+		Series: series.LatestLts(),
 		Jobs:   []state.MachineJob{state.JobHostUnits},
 	}
 	container, err := s.State.AddMachineInsideMachine(template, m.Id(), instance.LXC)
@@ -910,7 +911,7 @@ func (s *ProvisionerSuite) TestProvisioningDoesNotOccurForKVM(c *gc.C) {
 
 	// make a container on the machine we just created
 	template := state.MachineTemplate{
-		Series: coretesting.FakeDefaultSeries,
+		Series: series.LatestLts(),
 		Jobs:   []state.MachineJob{state.JobHostUnits},
 	}
 	container, err := s.State.AddMachineInsideMachine(template, m.Id(), instance.KVM)
@@ -1195,7 +1196,7 @@ func (s *ProvisionerSuite) TestProvisioningMachinesFailsWithEmptySpaces(c *gc.C)
 
 func (s *CommonProvisionerSuite) addMachineWithRequestedVolumes(volumes []state.MachineVolumeParams, cons constraints.Value) (*state.Machine, error) {
 	return s.BackingState.AddOneMachine(state.MachineTemplate{
-		Series:      coretesting.FakeDefaultSeries,
+		Series:      series.LatestLts(),
 		Jobs:        []state.MachineJob{state.JobHostUnits},
 		Constraints: cons,
 		Volumes:     volumes,

--- a/worker/reboot/reboot_test.go
+++ b/worker/reboot/reboot_test.go
@@ -6,6 +6,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
 	"github.com/juju/utils/fslock"
+	"github.com/juju/utils/series"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/api"
@@ -49,7 +50,7 @@ var _ worker.NotifyWatchHandler = (*reboot.Reboot)(nil)
 func (s *rebootSuite) SetUpTest(c *gc.C) {
 	var err error
 	template := state.MachineTemplate{
-		Series: coretesting.FakeDefaultSeries,
+		Series: series.LatestLts(),
 		Jobs:   []state.MachineJob{state.JobHostUnits},
 	}
 	s.JujuConnSuite.SetUpTest(c)


### PR DESCRIPTION
    
    This updates LTS trusty->xenial series declarations.
    Additionally, it modifies DefaultVersions in connsuite to upload tools
    for all supported LTS series as well as the environment series.
    
    Refs https://bugs.launchpad.net/juju-core/+bug/1557747
    Refs https://bugs.launchpad.net/bugs/1571914
    Refs https://bugs.launchpad.net/bugs/1571917
    Refs https://bugs.launchpad.net/bugs/1571932
    Refs https://bugs.launchpad.net/bugs/1571933
    Refs https://bugs.launchpad.net/bugs/1568374
    Refs https://bugs.launchpad.net/bugs/1571916


(Review request: http://reviews.vapour.ws/r/4768/)