### PR TITLE
util/stringforwarder: tweak exit criteria

### DIFF
--- a/utils/stringforwarder/stringforwarder.go
+++ b/utils/stringforwarder/stringforwarder.go
@@ -75,7 +75,7 @@ func (f *StringForwarder) loop(callback func(string)) {
 		for !f.stopped && f.current == nil {
 			f.cond.Wait()
 		}
-		if f.stopped {
+		if f.current == nil {
 			return
 		}
 		f.invokeCallback(callback, *f.current)


### PR DESCRIPTION
Don't stop the loop if there's a queued message.

Fixes https://bugs.launchpad.net/juju-core/+bug/1570883

(Review request: http://reviews.vapour.ws/r/4770/)