### PR TITLE
cmd/juju/commands: don't exit from Main()

### DIFF
--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -718,6 +718,7 @@ func (s *BootstrapSuite) TestBootstrapWithAutoUpgrade(c *gc.C) {
 func (s *BootstrapSuite) TestAutoSyncLocalSource(c *gc.C) {
 	sourceDir := createToolsSource(c, vAll)
 	s.PatchValue(&jujuversion.Current, version.MustParse("1.2.0"))
+	series.SetLatestLtsForTesting("trusty")
 	resetJujuXDGDataHome(c)
 
 	// Bootstrap the controller with the valid source.

--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -104,11 +104,12 @@ var x = []byte("\x96\x8c\x99\x8a\x9c\x94\x96\x91\x98\xdf\x9e\x92\x9e\x85\x96\x91
 // Main registers subcommands for the juju executable, and hands over control
 // to the cmd package. This function is not redundant with main, because it
 // provides an entry point for testing with arbitrary command line arguments.
-func Main(args []string) {
+// This function returns the exit code, for main to pass to os.Exit.
+func Main(args []string) int {
 	ctx, err := cmd.DefaultContext()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
-		os.Exit(2)
+		return 2
 	}
 
 	if shouldWarnJuju1x() {
@@ -117,7 +118,7 @@ func Main(args []string) {
 
 	if err = juju.InitJujuXDGDataHome(); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %s\n", err)
-		os.Exit(2)
+		return 2
 	}
 
 	for i := range x {
@@ -125,11 +126,11 @@ func Main(args []string) {
 	}
 	if len(args) == 2 && args[1] == string(x[0:2]) {
 		os.Stdout.Write(x[2:])
-		os.Exit(0)
+		return 0
 	}
 
 	jcmd := NewJujuCommand(ctx)
-	os.Exit(cmd.Main(jcmd, ctx, args[1:]))
+	return cmd.Main(jcmd, ctx, args[1:])
 }
 
 func warnJuju1x() {
@@ -147,7 +148,7 @@ func warnJuju1x() {
     Welcome to Juju %s. If you meant to use Juju %s you can continue using it
     with the command %s e.g. '%s switch'.
     See https://jujucharms.com/docs/stable/introducing-2 for more details.
-    `[1:], jujuversion.Current, ver, juju1xCmdName, juju1xCmdName)
+`[1:], jujuversion.Current, ver, juju1xCmdName, juju1xCmdName)
 }
 
 var execCommand = exec.Command

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -211,7 +211,8 @@ func (s *MainSuite) TestFirstRun2xFrom1x(c *gc.C) {
 	stdout, err := os.OpenFile(filepath.Join(oldhome, "stdout"), os.O_RDWR|os.O_CREATE, 0600)
 	c.Assert(err, jc.ErrorIsNil)
 
-	runMain(stderr, stdout, []string{"juju", "version"})
+	rc := runMain(stderr, stdout, []string{"juju", "version"})
+	c.Check(rc, gc.Equals, 0)
 
 	_, err = stderr.Seek(0, 0)
 	c.Assert(err, jc.ErrorIsNil)
@@ -252,7 +253,8 @@ func (s *MainSuite) TestNoWarn1xWith2xData(c *gc.C) {
 	stdout, err := os.OpenFile(filepath.Join(oldhome, "stdout"), os.O_RDWR|os.O_CREATE, 0600)
 	c.Assert(err, jc.ErrorIsNil)
 
-	runMain(stderr, stdout, []string{"juju", "version"})
+	rc := runMain(stderr, stdout, []string{"juju", "version"})
+	c.Check(rc, gc.Equals, 0)
 
 	_, err = stderr.Seek(0, 0)
 	c.Assert(err, jc.ErrorIsNil)
@@ -286,7 +288,8 @@ func (s *MainSuite) TestNoWarnWithNo1xOr2xData(c *gc.C) {
 	stdout, err := os.OpenFile(filepath.Join(outdir, "stdout"), os.O_RDWR|os.O_CREATE, 0600)
 	c.Assert(err, jc.ErrorIsNil)
 
-	runMain(stderr, stdout, []string{"juju", "version"})
+	rc := runMain(stderr, stdout, []string{"juju", "version"})
+	c.Check(rc, gc.Equals, 0)
 
 	_, err = stderr.Seek(0, 0)
 	c.Assert(err, jc.ErrorIsNil)
@@ -295,7 +298,7 @@ func (s *MainSuite) TestNoWarnWithNo1xOr2xData(c *gc.C) {
 	c.Assert(string(output), gc.Equals, "")
 }
 
-func runMain(stderr, stdout *os.File, args []string) {
+func runMain(stderr, stdout *os.File, args []string) int {
 	// we don't use patchvalue here because we need these reset as soon as we
 	// leave this function, so we don't interfere with test output later.
 	origErr := os.Stderr
@@ -305,7 +308,7 @@ func runMain(stderr, stdout *os.File, args []string) {
 	os.Stderr = stderr
 	os.Stdout = stdout
 
-	Main(args)
+	return Main(args)
 }
 
 // This is a test helper that only runs after getting executed by

--- a/cmd/juju/commands/package_test.go
+++ b/cmd/juju/commands/package_test.go
@@ -5,6 +5,7 @@ package commands
 
 import (
 	"flag"
+	"os"
 	"runtime"
 	stdtesting "testing"
 
@@ -29,6 +30,6 @@ func TestPackage(t *stdtesting.T) {
 // tool itself.
 func TestRunMain(t *stdtesting.T) {
 	if *cmdtesting.FlagRunMain {
-		Main(flag.Args())
+		os.Exit(Main(flag.Args()))
 	}
 }

--- a/cmd/juju/commands/ssh_test.go
+++ b/cmd/juju/commands/ssh_test.go
@@ -38,6 +38,7 @@ type SSHCommonSuite struct {
 
 func (s *SSHCommonSuite) SetUpTest(c *gc.C) {
 	s.JujuConnSuite.SetUpTest(c)
+	ssh.ClearClientKeys()
 	s.PatchValue(&getJujuExecutable, func() (string, error) { return "juju", nil })
 
 	s.bin = c.MkDir()

--- a/cmd/juju/main.go
+++ b/cmd/juju/main.go
@@ -24,5 +24,5 @@ func init() {
 }
 
 func main() {
-	commands.Main(os.Args)
+	os.Exit(commands.Main(os.Args))
 }


### PR DESCRIPTION
Don't exit from Main(), exit from main().
We were cutting test runs short, skipping
a bunch of unit tests.

Also a small change to fix isolation of
SCP tests from SSH client key changes made
in other tests.

Fixes https://bugs.launchpad.net/juju-core/+bug/1578456

(Review request: http://reviews.vapour.ws/r/4773/)