### PR TITLE
Backporting fix to allow signed custom images.

### DIFF
--- a/cmd/plugins/juju-metadata/validateimagemetadata.go
+++ b/cmd/plugins/juju-metadata/validateimagemetadata.go
@@ -182,9 +182,10 @@ func (c *ValidateImageMetadataCommand) Run(context *cmd.Context) error {
 		if _, err := os.Stat(dir); err != nil {
 			return err
 		}
+		publicKey, _ := simplestreams.UserPublicSigningKey()
 		params.Sources = []simplestreams.DataSource{
-			simplestreams.NewURLDataSource(
-				"local metadata directory", "file://"+dir, utils.VerifySSLHostnames),
+			simplestreams.NewURLSignedDataSource(
+				"local metadata directory", "file://"+dir, publicKey, utils.VerifySSLHostnames),
 		}
 	}
 	params.Stream = c.stream

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -280,7 +280,8 @@ func setPrivateMetadataSources(env environs.Environ, metadataDir string) ([]*ima
 	}
 
 	baseURL := fmt.Sprintf("file://%s", filepath.ToSlash(imageMetadataDir))
-	datasource := simplestreams.NewURLDataSource("bootstrap metadata", baseURL, utils.NoVerifySSLHostnames)
+	publicKey, _ := simplestreams.UserPublicSigningKey()
+	datasource := simplestreams.NewURLSignedDataSource("bootstrap metadata", baseURL, publicKey, utils.NoVerifySSLHostnames)
 
 	// Read the image metadata, as we'll want to upload it to the environment.
 	imageConstraint := imagemetadata.NewImageConstraint(simplestreams.LookupParams{})

--- a/environs/imagemetadata.go
+++ b/environs/imagemetadata.go
@@ -90,7 +90,8 @@ func ImageMetadataSources(env Environ) ([]simplestreams.DataSource, error) {
 		if !config.SSLHostnameVerification() {
 			verify = utils.NoVerifySSLHostnames
 		}
-		sources = append(sources, simplestreams.NewURLDataSource("image-metadata-url", userURL, verify))
+		publicKey, _ := simplestreams.UserPublicSigningKey()
+		sources = append(sources, simplestreams.NewURLSignedDataSource("image-metadata-url", userURL, publicKey, verify))
 	}
 
 	envDataSources, err := environmentDataSources(env)

--- a/environs/tools/tools_test.go
+++ b/environs/tools/tools_test.go
@@ -204,8 +204,8 @@ func (s *SimpleStreamsToolsSuite) TestFindToolsFiltering(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	for i := 0; i < 2*len(sources); i++ {
 		messages = append(messages,
-			jc.SimpleMessage{loggo.TRACE, `fetchData failed for .*`},
-			jc.SimpleMessage{loggo.TRACE, `cannot load index .*`})
+			jc.SimpleMessage{loggo.DEBUG, `fetchData failed for .*`},
+			jc.SimpleMessage{loggo.DEBUG, `cannot load index .*`})
 	}
 	c.Check(tw.Log(), jc.LogMatches, messages)
 }


### PR DESCRIPTION
Without this fix, we cannot validate signed images nor specify signed images for image-metadata-url, bootstrap metadata. 

As a drive-by, added more debug level logs to simplify future diagnose and demoted some noisy log messages to trace level.

(Review request: http://reviews.vapour.ws/r/4775/)