### PR TITLE
Fix tls on windows deployments

### DIFF
--- a/cloudconfig/userdatacfg_win.go
+++ b/cloudconfig/userdatacfg_win.go
@@ -217,6 +217,7 @@ func addDownloadToolsCmds(ser string, certificate string, toolsList tools.List) 
 		cmds = []string{
 			`$WebClient = New-Object System.Net.WebClient`,
 			`[System.Net.ServicePointManager]::ServerCertificateValidationCallback = {$true}`,
+			`[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12`,
 		}
 		getDownloadFileCmd = func(url string) string {
 			return fmt.Sprintf(`$WebClient.DownloadFile('%s', "$binDir\tools.tar.gz");`, url)

--- a/cloudconfig/windows_userdata_test.go
+++ b/cloudconfig/windows_userdata_test.go
@@ -690,6 +690,7 @@ mkdir 'C:\Juju\log\juju'
 mkdir $binDir
 $WebClient = New-Object System.Net.WebClient
 [System.Net.ServicePointManager]::ServerCertificateValidationCallback = {$true}
+[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12
 ExecRetry { TryExecAll @({ $WebClient.DownloadFile('https://state-addr.testing.invalid:54321/deadbeef-0bad-400d-8000-4b1d0d06f00d/tools/1.2.3-win8-amd64', "$binDir\tools.tar.gz"); }) }
 $dToolsHash = Get-FileSHA256 -FilePath "$binDir\tools.tar.gz"
 $dToolsHash > "$binDir\juju1.2.3-win8-amd64.sha256"


### PR DESCRIPTION
I waited a bit before releasing this because it doesn't seem to be working on 2008r2. However, it does fix 2016 and 2012 and that should be fine for CI right now.




(Review request: http://reviews.vapour.ws/r/4780/)