### PR TITLE
state: do not use n concurrent mgo sockets in a length n loop

### DIFF
--- a/state/singular_test.go
+++ b/state/singular_test.go
@@ -49,7 +49,7 @@ func (s *SingularSuite) TestClaimBadHolder(c *gc.C) {
 func (s *SingularSuite) TestClaimBadDuration(c *gc.C) {
 	claimer := s.State.SingularClaimer()
 	err := claimer.Claim(s.modelTag.Id(), "machine-123", 0)
-	c.Check(err, gc.ErrorMatches, `cannot claim lease for 0: non-positive`)
+	c.Check(err, gc.ErrorMatches, `cannot claim lease for 0s?: non-positive`)
 }
 
 func (s *SingularSuite) TestClaim(c *gc.C) {

--- a/state/state.go
+++ b/state/state.go
@@ -166,30 +166,53 @@ func (st *State) removeAllModelDocs(modelAssertion bson.D) error {
 		if info.global {
 			continue
 		}
-		coll, closer := st.getCollection(name)
-		defer closer()
-
-		var ids []bson.M
-		err := coll.Find(nil).Select(bson.D{{"_id", 1}}).All(&ids)
+		if info.rawAccess {
+			if err := st.removeAllInCollectionRaw(name); err != nil {
+				return errors.Trace(err)
+			}
+			continue
+		}
+		// TODO(rog): 2016-05-06 lp:1579010
+		// We can end up with an enormous transaction here,
+		// because we'll have one operation for each document in the
+		// whole model.
+		var err error
+		ops, err = st.appendRemoveAllInCollectionOps(ops, name)
 		if err != nil {
 			return errors.Trace(err)
 		}
-		for _, id := range ids {
-			if info.rawAccess {
-				if err := coll.Writeable().RemoveId(id["_id"]); err != nil {
-					return errors.Trace(err)
-				}
-			} else {
-				ops = append(ops, txn.Op{
-					C:      name,
-					Id:     id["_id"],
-					Remove: true,
-				})
-			}
-		}
 	}
-
 	return st.runTransaction(ops)
+}
+
+// removeAllInCollectionRaw removes all the documents from the given
+// named collection.
+func (st *State) removeAllInCollectionRaw(name string) error {
+	coll, closer := st.getCollection(name)
+	defer closer()
+	_, err := coll.Writeable().RemoveAll(nil)
+	return errors.Trace(err)
+}
+
+// appendRemoveAllInCollectionOps appends to ops operations to
+// remove all the documents in the given named collection.
+func (st *State) appendRemoveAllInCollectionOps(ops []txn.Op, name string) ([]txn.Op, error) {
+	coll, closer := st.getCollection(name)
+	defer closer()
+
+	var ids []bson.M
+	err := coll.Find(nil).Select(bson.D{{"_id", 1}}).All(&ids)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	for _, id := range ids {
+		ops = append(ops, txn.Op{
+			C:      name,
+			Id:     id["_id"],
+			Remove: true,
+		})
+	}
+	return ops, nil
 }
 
 // ForModel returns a connection to mongo for the specified model. The

--- a/state/state_leader_test.go
+++ b/state/state_leader_test.go
@@ -54,7 +54,7 @@ func (s *LeadershipSuite) TestClaimValidatesUnitName(c *gc.C) {
 
 func (s *LeadershipSuite) TestClaimValidateDuration(c *gc.C) {
 	err := s.claimer.ClaimLeadership("service", "u/0", 0)
-	c.Check(err, gc.ErrorMatches, `cannot claim lease for 0: non-positive`)
+	c.Check(err, gc.ErrorMatches, `cannot claim lease for 0s?: non-positive`)
 	c.Check(err, jc.Satisfies, errors.IsNotValid)
 }
 


### PR DESCRIPTION
Two places where the defer close was done in a loop, causing more sessions to be created at the same time than necessary; since each one requires a separate socket and those are a limited resource, it seems better to close earlier.

Also add a couple of fixes for the fact that the latest Go prints a 0-length duration as "0s" not "0".

(Review request: http://reviews.vapour.ws/r/4783/)