### PR TITLE
hide most state workers behind Workers interface

### DIFF
--- a/apiserver/common/modelwatcher_test.go
+++ b/apiserver/common/modelwatcher_test.go
@@ -36,10 +36,7 @@ type fakeModelAccessor struct {
 }
 
 func (*fakeModelAccessor) WatchForModelConfigChanges() state.NotifyWatcher {
-	w := apiservertesting.NewFakeNotifyWatcher()
-	// Simulate initial event.
-	w.C <- struct{}{}
-	return w
+	return apiservertesting.NewFakeNotifyWatcher()
 }
 
 func (f *fakeModelAccessor) ModelConfig() (*config.Config, error) {

--- a/apiserver/common/storagecommon/storage_test.go
+++ b/apiserver/common/storagecommon/storage_test.go
@@ -174,11 +174,8 @@ func (s *watchStorageAttachmentSuite) SetUpTest(c *gc.C) {
 	}
 	s.volume = &fakeVolume{tag: names.NewVolumeTag("0")}
 	s.volumeAttachmentWatcher = apiservertesting.NewFakeNotifyWatcher()
-	s.volumeAttachmentWatcher.C <- struct{}{}
 	s.blockDevicesWatcher = apiservertesting.NewFakeNotifyWatcher()
-	s.blockDevicesWatcher.C <- struct{}{}
 	s.storageAttachmentWatcher = apiservertesting.NewFakeNotifyWatcher()
-	s.storageAttachmentWatcher.C <- struct{}{}
 	s.st = &fakeStorage{
 		storageInstance: func(tag names.StorageTag) (state.StorageInstance, error) {
 			return s.storageInstance, nil

--- a/apiserver/common/watch_test.go
+++ b/apiserver/common/watch_test.go
@@ -27,10 +27,7 @@ type fakeAgentEntityWatcher struct {
 }
 
 func (a *fakeAgentEntityWatcher) Watch() state.NotifyWatcher {
-	w := apiservertesting.NewFakeNotifyWatcher()
-	// Simulate initial event.
-	w.C <- struct{}{}
-	return w
+	return apiservertesting.NewFakeNotifyWatcher()
 }
 
 func (*agentEntityWatcherSuite) TestWatch(c *gc.C) {
@@ -100,9 +97,7 @@ var _ = gc.Suite(&multiNotifyWatcherSuite{})
 
 func (*multiNotifyWatcherSuite) TestMultiNotifyWatcher(c *gc.C) {
 	w0 := apiservertesting.NewFakeNotifyWatcher()
-	w0.C <- struct{}{}
 	w1 := apiservertesting.NewFakeNotifyWatcher()
-	w1.C <- struct{}{}
 
 	mw := common.NewMultiNotifyWatcher(w0, w1)
 	defer statetesting.AssertStop(c, mw)
@@ -122,9 +117,7 @@ func (*multiNotifyWatcherSuite) TestMultiNotifyWatcher(c *gc.C) {
 
 func (*multiNotifyWatcherSuite) TestMultiNotifyWatcherStop(c *gc.C) {
 	w0 := apiservertesting.NewFakeNotifyWatcher()
-	w0.C <- struct{}{}
 	w1 := apiservertesting.NewFakeNotifyWatcher()
-	w1.C <- struct{}{}
 
 	mw := common.NewMultiNotifyWatcher(w0, w1)
 	wc := statetesting.NewNotifyWatcherC(c, nopSyncStarter{}, mw)

--- a/apiserver/migrationmaster/state.go
+++ b/apiserver/migrationmaster/state.go
@@ -13,7 +13,7 @@ import (
 type Backend interface {
 	migration.StateExporter
 
-	WatchForModelMigration() (state.NotifyWatcher, error)
+	WatchForModelMigration() state.NotifyWatcher
 	GetModelMigration() (state.ModelMigration, error)
 }
 

--- a/apiserver/watcher_test.go
+++ b/apiserver/watcher_test.go
@@ -87,7 +87,6 @@ func (s *watcherSuite) TestMigrationStatusWatcher(c *gc.C) {
 	apiserver.PatchGetMigrationBackend(s, new(fakeMigrationBackend))
 	apiserver.PatchGetControllerCACert(s, "no worries")
 
-	w.C <- struct{}{}
 	facade := s.getFacade(c, "MigrationStatusWatcher", 1, id).(migrationStatusWatcher)
 	defer c.Check(facade.Stop(), jc.ErrorIsNil)
 	result, err := facade.Next()
@@ -108,7 +107,6 @@ func (s *watcherSuite) TestMigrationStatusWatcherNoMigration(c *gc.C) {
 	s.authorizer.Tag = names.NewMachineTag("12")
 	apiserver.PatchGetMigrationBackend(s, &fakeMigrationBackend{noMigration: true})
 
-	w.C <- struct{}{}
 	facade := s.getFacade(c, "MigrationStatusWatcher", 1, id).(migrationStatusWatcher)
 	defer c.Check(facade.Stop(), jc.ErrorIsNil)
 	result, err := facade.Next()

--- a/state/allwatcher.go
+++ b/state/allwatcher.go
@@ -1008,14 +1008,14 @@ func (b *allWatcherStateBacking) filterEnv(docID interface{}) bool {
 // Watch watches all the collections.
 func (b *allWatcherStateBacking) Watch(in chan<- watcher.Change) {
 	for _, c := range b.collectionByName {
-		b.st.watcher.WatchCollectionWithFilter(c.name, in, b.filterEnv)
+		b.st.workers.TxnWatcher().WatchCollectionWithFilter(c.name, in, b.filterEnv)
 	}
 }
 
 // Unwatch unwatches all the collections.
 func (b *allWatcherStateBacking) Unwatch(in chan<- watcher.Change) {
 	for _, c := range b.collectionByName {
-		b.st.watcher.UnwatchCollection(c.name, in)
+		b.st.workers.TxnWatcher().UnwatchCollection(c.name, in)
 	}
 }
 
@@ -1082,14 +1082,14 @@ func NewAllModelWatcherStateBacking(st *State) Backing {
 // Watch watches all the collections.
 func (b *allModelWatcherStateBacking) Watch(in chan<- watcher.Change) {
 	for _, c := range b.collectionByName {
-		b.st.watcher.WatchCollection(c.name, in)
+		b.st.workers.TxnWatcher().WatchCollection(c.name, in)
 	}
 }
 
 // Unwatch unwatches all the collections.
 func (b *allModelWatcherStateBacking) Unwatch(in chan<- watcher.Change) {
 	for _, c := range b.collectionByName {
-		b.st.watcher.UnwatchCollection(c.name, in)
+		b.st.workers.TxnWatcher().UnwatchCollection(c.name, in)
 	}
 }
 

--- a/state/allwatcher.go
+++ b/state/allwatcher.go
@@ -22,6 +22,7 @@ import (
 // a single model from the State.
 type allWatcherStateBacking struct {
 	st               *State
+	watcher          TxnWatcher
 	collectionByName map[string]allWatcherStateCollection
 }
 
@@ -29,6 +30,7 @@ type allWatcherStateBacking struct {
 // for all models from the State.
 type allModelWatcherStateBacking struct {
 	st               *State
+	watcher          TxnWatcher
 	stPool           *StatePool
 	collectionByName map[string]allWatcherStateCollection
 }
@@ -996,6 +998,7 @@ func newAllWatcherStateBacking(st *State) Backing {
 	)
 	return &allWatcherStateBacking{
 		st:               st,
+		watcher:          st.workers.TxnWatcher(),
 		collectionByName: collections,
 	}
 }
@@ -1008,14 +1011,14 @@ func (b *allWatcherStateBacking) filterEnv(docID interface{}) bool {
 // Watch watches all the collections.
 func (b *allWatcherStateBacking) Watch(in chan<- watcher.Change) {
 	for _, c := range b.collectionByName {
-		b.st.workers.TxnWatcher().WatchCollectionWithFilter(c.name, in, b.filterEnv)
+		b.watcher.WatchCollectionWithFilter(c.name, in, b.filterEnv)
 	}
 }
 
 // Unwatch unwatches all the collections.
 func (b *allWatcherStateBacking) Unwatch(in chan<- watcher.Change) {
 	for _, c := range b.collectionByName {
-		b.st.workers.TxnWatcher().UnwatchCollection(c.name, in)
+		b.watcher.UnwatchCollection(c.name, in)
 	}
 }
 
@@ -1074,6 +1077,7 @@ func NewAllModelWatcherStateBacking(st *State) Backing {
 	)
 	return &allModelWatcherStateBacking{
 		st:               st,
+		watcher:          st.workers.TxnWatcher(),
 		stPool:           NewStatePool(st),
 		collectionByName: collections,
 	}
@@ -1082,14 +1086,14 @@ func NewAllModelWatcherStateBacking(st *State) Backing {
 // Watch watches all the collections.
 func (b *allModelWatcherStateBacking) Watch(in chan<- watcher.Change) {
 	for _, c := range b.collectionByName {
-		b.st.workers.TxnWatcher().WatchCollection(c.name, in)
+		b.watcher.WatchCollection(c.name, in)
 	}
 }
 
 // Unwatch unwatches all the collections.
 func (b *allModelWatcherStateBacking) Unwatch(in chan<- watcher.Change) {
 	for _, c := range b.collectionByName {
-		b.st.workers.TxnWatcher().UnwatchCollection(c.name, in)
+		b.watcher.UnwatchCollection(c.name, in)
 	}
 }
 

--- a/state/backend.go
+++ b/state/backend.go
@@ -1,0 +1,93 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"github.com/juju/errors"
+	"gopkg.in/mgo.v2"
+
+	"github.com/juju/juju/mongo"
+)
+
+// modelBackend collects together some useful internal state methods for
+// accessing mongo and mapping local and global ids to one another.
+//
+// Its primary purpose is to insulate watcher implementations from the
+// other features of state (specifically, to deny access to the .workers
+// field and prevent a class of bug in which it tries to use two
+// different underlying TxnWatchers), but it's probably also useful
+// elsewhere.
+type modelBackend interface {
+	docID(string) string
+	localID(string) string
+	strictLocalID(string) (string, error)
+	getCollection(name string) (mongo.Collection, func())
+
+	// getRawCollection is only here because readSettingsDocInto
+	// needs it -- but I think that's redundant. XXX
+	getRawCollection(name string) (*mgo.Collection, func())
+}
+
+// isLocalID returns a watcher filter func that rejects ids not specific
+// to the supplied modelBackend.
+func isLocalID(st modelBackend) func(interface{}) bool {
+	return func(id interface{}) bool {
+		key, ok := id.(string)
+		if !ok {
+			return false
+		}
+		_, err := st.strictLocalID(key)
+		return err == nil
+	}
+}
+
+// docID generates a globally unique id value
+// where the model uuid is prefixed to the
+// localID.
+func (st *State) docID(localID string) string {
+	return ensureModelUUID(st.ModelUUID(), localID)
+}
+
+// localID returns the local id value by stripping
+// off the model uuid prefix if it is there.
+func (st *State) localID(ID string) string {
+	modelUUID, localID, ok := splitDocID(ID)
+	if !ok || modelUUID != st.ModelUUID() {
+		return ID
+	}
+	return localID
+}
+
+// strictLocalID returns the local id value by removing the
+// model UUID prefix.
+//
+// If there is no prefix matching the State's model, an error is
+// returned.
+func (st *State) strictLocalID(ID string) (string, error) {
+	modelUUID, localID, ok := splitDocID(ID)
+	if !ok || modelUUID != st.ModelUUID() {
+		return "", errors.Errorf("unexpected id: %#v", ID)
+	}
+	return localID, nil
+}
+
+// getCollection fetches a named collection using a new session if the
+// database has previously been logged in to. It returns the
+// collection and a closer function for the session.
+//
+// If the collection stores documents for multiple models, the
+// returned collection will automatically perform model
+// filtering where possible. See modelStateCollection below.
+func (st *State) getCollection(name string) (mongo.Collection, func()) {
+	return st.database.GetCollection(name)
+}
+
+// getRawCollection returns the named mgo Collection. As no automatic
+// model filtering is performed by the returned collection it
+// should be rarely used. getCollection() should be used in almost all
+// cases.
+func (st *State) getRawCollection(name string) (*mgo.Collection, func()) {
+	collection, closer := st.database.GetCollection(name)
+	return collection.Writeable().Underlying(), closer
+}

--- a/state/backend.go
+++ b/state/backend.go
@@ -5,7 +5,6 @@ package state
 
 import (
 	"github.com/juju/errors"
-	"gopkg.in/mgo.v2"
 
 	"github.com/juju/juju/mongo"
 )
@@ -23,10 +22,6 @@ type modelBackend interface {
 	localID(string) string
 	strictLocalID(string) (string, error)
 	getCollection(name string) (mongo.Collection, func())
-
-	// getRawCollection is only here because readSettingsDocInto
-	// needs it -- but I think that's redundant. XXX
-	getRawCollection(name string) (*mgo.Collection, func())
 }
 
 // isLocalID returns a watcher filter func that rejects ids not specific
@@ -81,13 +76,4 @@ func (st *State) strictLocalID(ID string) (string, error) {
 // filtering where possible. See modelStateCollection below.
 func (st *State) getCollection(name string) (mongo.Collection, func()) {
 	return st.database.GetCollection(name)
-}
-
-// getRawCollection returns the named mgo Collection. As no automatic
-// model filtering is performed by the returned collection it
-// should be rarely used. getCollection() should be used in almost all
-// cases.
-func (st *State) getRawCollection(name string) (*mgo.Collection, func()) {
-	collection, closer := st.database.GetCollection(name)
-	return collection.Writeable().Underlying(), closer
 }

--- a/state/blockdevices.go
+++ b/state/blockdevices.go
@@ -53,10 +53,10 @@ func (st *State) WatchBlockDevices(machine names.MachineTag) NotifyWatcher {
 
 // BlockDevices returns the BlockDeviceInfo for the specified machine.
 func (st *State) BlockDevices(machine names.MachineTag) ([]BlockDeviceInfo, error) {
-	return st.blockDevices(machine.Id())
+	return getBlockDevices(st, machine.Id())
 }
 
-func (st *State) blockDevices(machineId string) ([]BlockDeviceInfo, error) {
+func getBlockDevices(st modelBackend, machineId string) ([]BlockDeviceInfo, error) {
 	coll, cleanup := st.getCollection(blockDevicesC)
 	defer cleanup()
 
@@ -75,7 +75,7 @@ func (st *State) blockDevices(machineId string) ([]BlockDeviceInfo, error) {
 // not in the list will be removed.
 func setMachineBlockDevices(st *State, machineId string, newInfo []BlockDeviceInfo) error {
 	buildTxn := func(attempt int) ([]txn.Op, error) {
-		oldInfo, err := st.blockDevices(machineId)
+		oldInfo, err := getBlockDevices(st, machineId)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}

--- a/state/collection.go
+++ b/state/collection.go
@@ -11,6 +11,15 @@ import (
 	"github.com/juju/juju/mongo"
 )
 
+// getRawCollection returns the named mgo Collection. As no automatic
+// model filtering is performed by the returned collection it
+// should be rarely used. getCollection() should be used in almost all
+// cases.
+func (st *State) getRawCollection(name string) (*mgo.Collection, func()) {
+	collection, closer := st.database.GetCollection(name)
+	return collection.Writeable().Underlying(), closer
+}
+
 // modelStateCollection wraps a mongo.Collection, preserving the
 // mongo.Collection interface and its Writeable behaviour. It will
 // automatically modify query selectors and documents so that queries

--- a/state/collection.go
+++ b/state/collection.go
@@ -11,26 +11,6 @@ import (
 	"github.com/juju/juju/mongo"
 )
 
-// getCollection fetches a named collection using a new session if the
-// database has previously been logged in to. It returns the
-// collection and a closer function for the session.
-//
-// If the collection stores documents for multiple models, the
-// returned collection will automatically perform model
-// filtering where possible. See modelStateCollection below.
-func (st *State) getCollection(name string) (mongo.Collection, func()) {
-	return st.database.GetCollection(name)
-}
-
-// getRawCollection returns the named mgo Collection. As no automatic
-// model filtering is performed by the returned collection it
-// should be rarely used. getCollection() should be used in almost all
-// cases.
-func (st *State) getRawCollection(name string) (*mgo.Collection, func()) {
-	collection, closer := st.database.GetCollection(name)
-	return collection.Writeable().Underlying(), closer
-}
-
 // modelStateCollection wraps a mongo.Collection, preserving the
 // mongo.Collection interface and its Writeable behaviour. It will
 // automatically modify query selectors and documents so that queries

--- a/state/leadership.go
+++ b/state/leadership.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/juju/juju/core/leadership"
 	corelease "github.com/juju/juju/core/lease"
-	"github.com/juju/juju/worker/lease"
 )
 
 func removeLeadershipSettingsOp(serviceId string) txn.Op {
@@ -25,13 +24,13 @@ func leadershipSettingsKey(serviceId string) string {
 // LeadershipClaimer returns a leadership.Claimer for units and services in the
 // state's model.
 func (st *State) LeadershipClaimer() leadership.Claimer {
-	return leadershipClaimer{st.leadershipManager}
+	return leadershipClaimer{st.workers.LeadershipManager()}
 }
 
 // LeadershipChecker returns a leadership.Checker for units and services in the
 // state's model.
 func (st *State) LeadershipChecker() leadership.Checker {
-	return leadershipChecker{st.leadershipManager}
+	return leadershipChecker{st.workers.LeadershipManager()}
 }
 
 // HackLeadership stops the state's internal leadership manager to prevent it
@@ -50,8 +49,7 @@ func (st *State) HackLeadership() {
 	// close them all on their own schedule, without panics -- but the failure of
 	// the shared component should successfully goose them all into shutting down,
 	// in parallel, of their own accord.)
-	st.leadershipManager.Kill()
-	st.singularManager.Kill()
+	st.workers.Kill()
 }
 
 // buildTxnWithLeadership returns a transaction source that combines the supplied source
@@ -100,9 +98,9 @@ func (leadershipSecretary) CheckDuration(duration time.Duration) error {
 	return nil
 }
 
-// leadershipChecker implements leadership.Checker by wrapping a lease.Manager.
+// leadershipChecker implements leadership.Checker by wrapping a LeaseManager.
 type leadershipChecker struct {
-	manager *lease.Manager
+	manager LeaseManager
 }
 
 // LeadershipCheck is part of the leadership.Checker interface.
@@ -131,9 +129,9 @@ func (t leadershipToken) Check(out interface{}) error {
 	return errors.Trace(err)
 }
 
-// leadershipClaimer implements leadership.Claimer by wrappping a lease.Manager.
+// leadershipClaimer implements leadership.Claimer by wrappping a LeaseManager.
 type leadershipClaimer struct {
-	manager *lease.Manager
+	manager LeaseManager
 }
 
 // ClaimLeadership is part of the leadership.Claimer interface.

--- a/state/machine.go
+++ b/state/machine.go
@@ -917,16 +917,17 @@ func (m *Machine) Refresh() error {
 
 // AgentPresence returns whether the respective remote agent is alive.
 func (m *Machine) AgentPresence() (bool, error) {
-	b, err := m.st.workers.PresenceWatcher().Alive(m.globalKey())
-	return b, err
+	pwatcher := m.st.workers.PresenceWatcher()
+	return pwatcher.Alive(m.globalKey())
 }
 
 // WaitAgentPresence blocks until the respective agent is alive.
 func (m *Machine) WaitAgentPresence(timeout time.Duration) (err error) {
 	defer errors.DeferredAnnotatef(&err, "waiting for agent of machine %v", m)
 	ch := make(chan presence.Change)
-	m.st.workers.PresenceWatcher().Watch(m.globalKey(), ch)
-	defer m.st.workers.PresenceWatcher().Unwatch(m.globalKey(), ch)
+	pwatcher := m.st.workers.PresenceWatcher()
+	pwatcher.Watch(m.globalKey(), ch)
+	defer pwatcher.Unwatch(m.globalKey(), ch)
 	for i := 0; i < 2; i++ {
 		select {
 		case change := <-ch:
@@ -936,8 +937,8 @@ func (m *Machine) WaitAgentPresence(timeout time.Duration) (err error) {
 		case <-time.After(timeout):
 			// TODO(fwereade): 2016-03-17 lp:1558657
 			return fmt.Errorf("still not alive after timeout")
-		case <-m.st.workers.PresenceWatcher().Dead():
-			return m.st.workers.PresenceWatcher().Err()
+		case <-pwatcher.Dead():
+			return pwatcher.Err()
 		}
 	}
 	panic(fmt.Sprintf("presence reported dead status twice in a row for machine %v", m))

--- a/state/machine.go
+++ b/state/machine.go
@@ -917,7 +917,7 @@ func (m *Machine) Refresh() error {
 
 // AgentPresence returns whether the respective remote agent is alive.
 func (m *Machine) AgentPresence() (bool, error) {
-	b, err := m.st.pwatcher.Alive(m.globalKey())
+	b, err := m.st.workers.PresenceWatcher().Alive(m.globalKey())
 	return b, err
 }
 
@@ -925,8 +925,8 @@ func (m *Machine) AgentPresence() (bool, error) {
 func (m *Machine) WaitAgentPresence(timeout time.Duration) (err error) {
 	defer errors.DeferredAnnotatef(&err, "waiting for agent of machine %v", m)
 	ch := make(chan presence.Change)
-	m.st.pwatcher.Watch(m.globalKey(), ch)
-	defer m.st.pwatcher.Unwatch(m.globalKey(), ch)
+	m.st.workers.PresenceWatcher().Watch(m.globalKey(), ch)
+	defer m.st.workers.PresenceWatcher().Unwatch(m.globalKey(), ch)
 	for i := 0; i < 2; i++ {
 		select {
 		case change := <-ch:
@@ -936,8 +936,8 @@ func (m *Machine) WaitAgentPresence(timeout time.Duration) (err error) {
 		case <-time.After(timeout):
 			// TODO(fwereade): 2016-03-17 lp:1558657
 			return fmt.Errorf("still not alive after timeout")
-		case <-m.st.pwatcher.Dead():
-			return m.st.pwatcher.Err()
+		case <-m.st.workers.PresenceWatcher().Dead():
+			return m.st.workers.PresenceWatcher().Err()
 		}
 	}
 	panic(fmt.Sprintf("presence reported dead status twice in a row for machine %v", m))
@@ -946,7 +946,7 @@ func (m *Machine) WaitAgentPresence(timeout time.Duration) (err error) {
 // SetAgentPresence signals that the agent for machine m is alive.
 // It returns the started pinger.
 func (m *Machine) SetAgentPresence() (*presence.Pinger, error) {
-	presenceCollection := m.st.getPresence()
+	presenceCollection := m.st.getPresenceCollection()
 	p := presence.NewPinger(presenceCollection, m.st.modelTag, m.globalKey())
 	err := p.Start()
 	if err != nil {
@@ -960,7 +960,7 @@ func (m *Machine) SetAgentPresence() (*presence.Pinger, error) {
 	//
 	// TODO: Does not work for multiple controllers. Trigger a sync across all controllers.
 	if m.IsManager() {
-		m.st.pwatcher.Sync()
+		m.st.workers.PresenceWatcher().Sync()
 	}
 	return p, nil
 }

--- a/state/open.go
+++ b/state/open.go
@@ -17,7 +17,6 @@ import (
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/mongo"
-	"github.com/juju/juju/state/watcher"
 	"github.com/juju/juju/status"
 )
 
@@ -249,9 +248,9 @@ func isUnauthorized(err error) bool {
 	return false
 }
 
-// newState creates an incomplete *State, with a configured watcher but no
-// pwatcher, leadershipManager, or controllerTag. You must start() the returned
-// *State before it will function correctly.
+// newState creates an incomplete *State, with no running workers or
+// controllerTag. You must start() the returned *State before it will
+// function correctly.
 func newState(modelTag names.ModelTag, session *mgo.Session, mongoInfo *mongo.MongoInfo, dialOpts mongo.DialOpts, policy Policy) (_ *State, resultErr error) {
 	// Set up database.
 	rawDB := session.DB(jujuDB)
@@ -271,7 +270,6 @@ func newState(modelTag names.ModelTag, session *mgo.Session, mongoInfo *mongo.Mo
 		session:       session,
 		database:      database,
 		policy:        policy,
-		watcher:       watcher.New(rawDB.C(txnLogC)),
 	}, nil
 }
 
@@ -298,19 +296,10 @@ func (st *State) Close() (err error) {
 			errs = append(errs, errors.Annotatef(err, "error stopping %s", name))
 		}
 	}
+	if st.workers != nil {
+		handle("standard workers", st.workers.Stop())
+	}
 
-	handle("transaction watcher", st.watcher.Stop())
-	if st.pwatcher != nil {
-		handle("presence watcher", st.pwatcher.Stop())
-	}
-	if st.leadershipManager != nil {
-		st.leadershipManager.Kill()
-		handle("leadership manager", st.leadershipManager.Wait())
-	}
-	if st.singularManager != nil {
-		st.singularManager.Kill()
-		handle("singular manager", st.singularManager.Wait())
-	}
 	st.mu.Lock()
 	if st.allManager != nil {
 		handle("allwatcher manager", st.allManager.Stop())

--- a/state/settings.go
+++ b/state/settings.go
@@ -285,18 +285,10 @@ func readSettingsDoc(st modelBackend, key string) (*settingsDoc, error) {
 // readSettingsDocInto reads the settings doc with the given key
 // into the provided output structure.
 func readSettingsDocInto(st modelBackend, key string, out interface{}) error {
-	settings, closer := st.getRawCollection(settingsC)
+	settings, closer := st.getCollection(settingsC)
 	defer closer()
 
-	err := settings.FindId(st.docID(key)).One(out)
-
-	// This is required to allow loading of environ settings before the
-	// model UUID migration has been applied to the settings collection.
-	// Without this, an agent's version cannot be read, blocking the upgrade.
-	// XXX(fwereade): is this still required on master?
-	if err == mgo.ErrNotFound && key == modelGlobalKey {
-		err = settings.FindId(modelGlobalKey).One(out)
-	}
+	err := settings.FindId(key).One(out)
 	if err == mgo.ErrNotFound {
 		err = errors.NotFoundf("settings")
 	}

--- a/state/settings.go
+++ b/state/settings.go
@@ -274,7 +274,7 @@ func (c *Settings) Read() error {
 }
 
 // readSettingsDoc reads the settings doc with the given key.
-func readSettingsDoc(st *State, key string) (*settingsDoc, error) {
+func readSettingsDoc(st modelBackend, key string) (*settingsDoc, error) {
 	var doc settingsDoc
 	if err := readSettingsDocInto(st, key, &doc); err != nil {
 		return nil, errors.Trace(err)
@@ -284,7 +284,7 @@ func readSettingsDoc(st *State, key string) (*settingsDoc, error) {
 
 // readSettingsDocInto reads the settings doc with the given key
 // into the provided output structure.
-func readSettingsDocInto(st *State, key string, out interface{}) error {
+func readSettingsDocInto(st modelBackend, key string, out interface{}) error {
 	settings, closer := st.getRawCollection(settingsC)
 	defer closer()
 
@@ -293,6 +293,7 @@ func readSettingsDocInto(st *State, key string, out interface{}) error {
 	// This is required to allow loading of environ settings before the
 	// model UUID migration has been applied to the settings collection.
 	// Without this, an agent's version cannot be read, blocking the upgrade.
+	// XXX(fwereade): is this still required on master?
 	if err == mgo.ErrNotFound && key == modelGlobalKey {
 		err = settings.FindId(modelGlobalKey).One(out)
 	}

--- a/state/singular.go
+++ b/state/singular.go
@@ -51,5 +51,5 @@ func (s singularSecretary) CheckDuration(duration time.Duration) error {
 // SingularClaimer returns a lease.Claimer representing the exclusive right to
 // manage the environment.
 func (st *State) SingularClaimer() lease.Claimer {
-	return st.singularManager
+	return st.workers.SingularManager()
 }

--- a/state/state.go
+++ b/state/state.go
@@ -77,13 +77,16 @@ type State struct {
 	policy        Policy
 
 	// leadershipClient exposes units' service leadership leases
-	// within this environment. It's only used unsafely as far as
-	// I'm aware. XXX create bug
+	// within this environment.
+	// TODO(fwereade) 2016-05-09 lp:1579633
+	// This field is only used unsafely as far as I'm aware -- it's
+	// not goroutine-safe, and the leadership lease manager is using
+	// it permanently.
 	leadershipClient corelease.Client
 
 	// workers is responsible for keeping the various sub-workers
 	// available by starting new ones as they fail. It doesn't do
-	// that yet, but having a type that cllects them together is the
+	// that yet, but having a type that collects them together is the
 	// first step.
 	//
 	// note that the allManager stuff below probably ought to be

--- a/state/state.go
+++ b/state/state.go
@@ -103,6 +103,12 @@ type State struct {
 // StateServingInfo holds information needed by a controller.
 // This type is a copy of the type of the same name from the api/params package.
 // It is replicated here to avoid the state pacakge depending on api/params.
+//
+// NOTE(fwereade): the api/params type exists *purely* for representing
+// this data over the wire, and has a legitimate reason to exist. This
+// type does not: it's non-implementation-specific and shoudl be defined
+// under core/ somewhere, so it can be used both here and in the agent
+// without dragging unnecessary/irrelevant packages into scope.
 type StateServingInfo struct {
 	APIPort      int
 	StatePort    int
@@ -1761,36 +1767,6 @@ func (st *State) AllServices() (services []*Service, err error) {
 		services = append(services, newService(st, &v))
 	}
 	return services, nil
-}
-
-// docID generates a globally unique id value
-// where the model uuid is prefixed to the
-// localID.
-func (st *State) docID(localID string) string {
-	return ensureModelUUID(st.ModelUUID(), localID)
-}
-
-// localID returns the local id value by stripping
-// off the model uuid prefix if it is there.
-func (st *State) localID(ID string) string {
-	modelUUID, localID, ok := splitDocID(ID)
-	if !ok || modelUUID != st.ModelUUID() {
-		return ID
-	}
-	return localID
-}
-
-// strictLocalID returns the local id value by removing the
-// model UUID prefix.
-//
-// If there is no prefix matching the State's model, an error is
-// returned.
-func (st *State) strictLocalID(ID string) (string, error) {
-	modelUUID, localID, ok := splitDocID(ID)
-	if !ok || modelUUID != st.ModelUUID() {
-		return "", errors.Errorf("unexpected id: %#v", ID)
-	}
-	return localID, nil
 }
 
 // InferEndpoints returns the endpoints corresponding to the supplied names.

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -3000,51 +3000,6 @@ func (s *StateSuite) TestRemoveImportingModelDocsImporting(c *gc.C) {
 
 type attrs map[string]interface{}
 
-func (s *StateSuite) TestWatchModelConfig(c *gc.C) {
-	w := s.State.WatchModelConfig()
-	defer statetesting.AssertStop(c, w)
-
-	// TODO(fwereade) just use a NotifyWatcher and NotifyWatcherC to test it.
-	assertNoChange := func() {
-		s.State.StartSync()
-		select {
-		case got := <-w.Changes():
-			c.Fatalf("got unexpected change: %#v", got)
-		case <-time.After(testing.ShortWait):
-		}
-	}
-	assertChange := func(change attrs) {
-		cfg, err := s.State.ModelConfig()
-		c.Assert(err, jc.ErrorIsNil)
-		cfg, err = cfg.Apply(change)
-		c.Assert(err, jc.ErrorIsNil)
-		if change != nil {
-			err = s.State.UpdateModelConfig(change, nil, nil)
-			c.Assert(err, jc.ErrorIsNil)
-		}
-		s.State.StartSync()
-		select {
-		case got, ok := <-w.Changes():
-			c.Assert(ok, jc.IsTrue)
-			c.Assert(got.AllAttrs(), gc.DeepEquals, cfg.AllAttrs())
-		case <-time.After(testing.LongWait):
-			c.Fatalf("did not get change: %#v", change)
-		}
-		assertNoChange()
-	}
-	assertChange(nil)
-	assertChange(attrs{"default-series": "another-series"})
-	assertChange(attrs{"fancy-new-key": "arbitrary-value"})
-}
-
-func (s *StateSuite) TestWatchModelConfigDiesOnStateClose(c *gc.C) {
-	testWatcherDiesWhenStateCloses(c, s.modelTag, func(c *gc.C, st *state.State) waiter {
-		w := st.WatchModelConfig()
-		<-w.Changes()
-		return w
-	})
-}
-
 func (s *StateSuite) TestWatchForModelConfigChanges(c *gc.C) {
 	cur := jujuversion.Current
 	err := statetesting.SetAgentVersion(s.State, cur)
@@ -3072,59 +3027,6 @@ func (s *StateSuite) TestWatchForModelConfigChanges(c *gc.C) {
 	err = statetesting.SetAgentVersion(s.State, newerVersion)
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertNoChange()
-}
-
-func (s *StateSuite) TestWatchModelConfigCorruptConfig(c *gc.C) {
-	cfg, err := s.State.ModelConfig()
-	c.Assert(err, jc.ErrorIsNil)
-
-	// Corrupt the model configuration.
-	settings := s.Session.DB("juju").C("settings")
-	err = settings.UpdateId(state.DocID(s.State, "e"), bson.D{{"$unset", bson.D{{"settings.name", 1}}}})
-	c.Assert(err, jc.ErrorIsNil)
-
-	s.State.StartSync()
-
-	// Start watching the configuration.
-	watcher := s.State.WatchModelConfig()
-	defer watcher.Stop()
-	done := make(chan *config.Config)
-	go func() {
-		select {
-		case cfg, ok := <-watcher.Changes():
-			if !ok {
-				c.Errorf("watcher channel closed")
-			} else {
-				done <- cfg
-			}
-		case <-time.After(5 * time.Second):
-			c.Fatalf("no model configuration observed")
-		}
-	}()
-
-	s.State.StartSync()
-
-	// The invalid configuration must not have been generated.
-	select {
-	case <-done:
-		c.Fatalf("configuration returned too soon")
-	case <-time.After(testing.ShortWait):
-	}
-
-	// Fix the configuration.
-	err = settings.UpdateId(state.DocID(s.State, "e"), bson.D{{"$set", bson.D{{"settings.name", "foo"}}}})
-	c.Assert(err, jc.ErrorIsNil)
-	fixed := cfg.AllAttrs()
-	err = s.State.UpdateModelConfig(fixed, nil, nil)
-	c.Assert(err, jc.ErrorIsNil)
-
-	s.State.StartSync()
-	select {
-	case got := <-done:
-		c.Assert(got.AllAttrs(), gc.DeepEquals, fixed)
-	case <-time.After(5 * time.Second):
-		c.Fatalf("no model configuration observed")
-	}
 }
 
 func (s *StateSuite) TestAddAndGetEquivalence(c *gc.C) {

--- a/state/unit.go
+++ b/state/unit.go
@@ -1078,7 +1078,8 @@ func (u *Unit) SetCharmURL(curl *charm.URL) error {
 
 // AgentPresence returns whether the respective remote agent is alive.
 func (u *Unit) AgentPresence() (bool, error) {
-	return u.st.workers.PresenceWatcher().Alive(u.globalAgentKey())
+	pwatcher := u.st.workers.PresenceWatcher()
+	return pwatcher.Alive(u.globalAgentKey())
 }
 
 // Tag returns a name identifying the unit.
@@ -1098,8 +1099,9 @@ func (u *Unit) UnitTag() names.UnitTag {
 func (u *Unit) WaitAgentPresence(timeout time.Duration) (err error) {
 	defer errors.DeferredAnnotatef(&err, "waiting for agent of unit %q", u)
 	ch := make(chan presence.Change)
-	u.st.workers.PresenceWatcher().Watch(u.globalAgentKey(), ch)
-	defer u.st.workers.PresenceWatcher().Unwatch(u.globalAgentKey(), ch)
+	pwatcher := u.st.workers.PresenceWatcher()
+	pwatcher.Watch(u.globalAgentKey(), ch)
+	defer pwatcher.Unwatch(u.globalAgentKey(), ch)
 	for i := 0; i < 2; i++ {
 		select {
 		case change := <-ch:
@@ -1109,8 +1111,8 @@ func (u *Unit) WaitAgentPresence(timeout time.Duration) (err error) {
 		case <-time.After(timeout):
 			// TODO(fwereade): 2016-03-17 lp:1558657
 			return fmt.Errorf("still not alive after timeout")
-		case <-u.st.workers.PresenceWatcher().Dead():
-			return u.st.workers.PresenceWatcher().Err()
+		case <-pwatcher.Dead():
+			return pwatcher.Err()
 		}
 	}
 	panic(fmt.Sprintf("presence reported dead status twice in a row for unit %q", u))

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -84,10 +84,9 @@ type RelationUnitsWatcher interface {
 
 // newCommonWatcher exists so that all embedders have a place from which
 // to get a single TxnWatcher that will not be replaced in the lifetime
-// of the embedder.
-//
-// Note that the reference to state allows people to get their own
-// references to the watcher, and mess this up --
+// of the embedder (and also to restrict the width of the interface by
+// which they can access the rest of State, by storing st as a
+// modelBackend).
 func newCommonWatcher(st *State) commonWatcher {
 	return commonWatcher{
 		st:      st,

--- a/state/workers.go
+++ b/state/workers.go
@@ -1,0 +1,217 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"time"
+
+	"github.com/juju/errors"
+	"github.com/juju/names"
+	"github.com/juju/utils/clock"
+	"gopkg.in/mgo.v2"
+
+	corelease "github.com/juju/juju/core/lease"
+	"github.com/juju/juju/state/presence"
+	"github.com/juju/juju/state/watcher"
+	"github.com/juju/juju/worker/lease"
+)
+
+// TxnWatcher merely wraps a state/watcher.Watcher for future
+// flexibility, specifically excluding the ability to stop it
+// (which is not needed/wanted by this type's clients)
+type TxnWatcher interface {
+
+	// pseudo-workery bits, ideally to be replaced one day?
+	Err() error
+	Dead() <-chan struct{}
+
+	// horrible hack for goosing it into activity
+	StartSync()
+
+	// single-document watching
+	Watch(coll string, id interface{}, revno int64, ch chan<- watcher.Change)
+	Unwatch(coll string, id interface{}, ch chan<- watcher.Change)
+
+	// collection-watching
+	WatchCollection(coll string, ch chan<- watcher.Change)
+	WatchCollectionWithFilter(coll string, ch chan<- watcher.Change, filter func(interface{}) bool)
+	UnwatchCollection(coll string, ch chan<- watcher.Change)
+}
+
+// PresenceWatcher merely wraps a state/presence.Watcher for future
+// flexibility, specifically excluding the ability to stop it (which
+// is not needed/wanted by this type's clients).
+type PresenceWatcher interface {
+
+	// pseudo-workery bits, ideally to be replaced one day?
+	Err() error
+	Dead() <-chan struct{}
+
+	// horrible hack for goosing it into activity. not clear why
+	// this is used in place of StartSync, but it is.
+	Sync()
+
+	// presence-reading and -watching
+	Alive(key string) (bool, error)
+	Watch(key string, ch chan<- presence.Change)
+	Unwatch(key string, ch chan<- presence.Change)
+}
+
+// LeaseManager combines corelease.Claimer and corelease.Checker for the
+// convenience of leadership/singular-controller logic.
+type LeaseManager interface {
+	corelease.Claimer
+	corelease.Checker
+}
+
+// Workers exposes implementations of various capabilities that have the
+// unhelpful property of being able to fail independently of state
+// itself. It's meant to accommodate future implementations that
+// automatically restart workers (or supply always-failing worker stubs
+// to clients when no worker can be found or created).
+type Workers interface {
+	TxnWatcher() TxnWatcher
+	PresenceWatcher() PresenceWatcher
+	LeadershipManager() LeaseManager
+	SingularManager() LeaseManager
+
+	// Stop stops all the workers and returns any error encountered.
+	Stop() error
+
+	// Kill causes the lease manager workers to start shutting down,
+	// and not to be restarted. See the client (HackLeadership) for
+	// an explanation.
+	Kill()
+}
+
+// dumbWorkersConfig holds information necessary to construct all the
+// standard state workers. It's not set up to restart workers in any
+// way; it just knows enough to launch them once and leave them alone,
+// exactly as we did on State before this change.
+type dumbWorkersConfig struct {
+	modelTag           names.ModelTag
+	clock              clock.Clock
+	leadershipClient   corelease.Client
+	singularClient     corelease.Client
+	presenceCollection *mgo.Collection
+	txnLogCollection   *mgo.Collection
+}
+
+// newDumbWorkers returns a collection of standard state workers that
+// are not robust in any way: if they fail, they fail, and nothing will
+// restart them. It exists as a refectoring step, and should be replaced
+// with a smarter implementation that recreates, retries, and supplies
+// cleanly-  and clearly-failing versions when unable.
+func newDumbWorkers(config dumbWorkersConfig) (_ *dumbWorkers, err error) {
+
+	result := &dumbWorkers{}
+	defer func() {
+		if err != nil {
+			if stopErr := result.Stop(); stopErr != nil {
+				logger.Errorf("while aborting dumbWorkers creation: %v", err)
+			}
+		}
+	}()
+
+	logger.Infof("starting leadership lease manager")
+	leadershipManager, err := lease.NewManager(lease.ManagerConfig{
+		Secretary: leadershipSecretary{},
+		Client:    config.leadershipClient,
+		Clock:     config.clock,
+		MaxSleep:  time.Minute,
+	})
+	if err != nil {
+		return nil, errors.Annotatef(err, "cannot create leadership lease manager")
+	}
+	result.leadershipManager = leadershipManager
+
+	logger.Infof("starting singular lease manager")
+	singularManager, err := lease.NewManager(lease.ManagerConfig{
+		Secretary: singularSecretary{config.modelTag.Id()},
+		Client:    config.singularClient,
+		Clock:     config.clock,
+		MaxSleep:  time.Minute,
+	})
+	if err != nil {
+		return nil, errors.Annotatef(err, "cannot create singular lease manager")
+	}
+	result.singularManager = singularManager
+
+	logger.Infof("starting transaction log watcher")
+	result.txnLogWatcher = watcher.New(config.txnLogCollection)
+
+	logger.Infof("starting presence watcher")
+	result.presenceWatcher = presence.NewWatcher(
+		config.presenceCollection, config.modelTag,
+	)
+	return result, nil
+}
+
+// dumbWorkers holds references to standard state workers.
+type dumbWorkers struct {
+	txnLogWatcher     *watcher.Watcher
+	presenceWatcher   *presence.Watcher
+	leadershipManager *lease.Manager
+	singularManager   *lease.Manager
+}
+
+// Stop is part of the Workers interface.
+func (dw *dumbWorkers) Stop() error {
+	var errs []error
+	handle := func(name string, err error) {
+		if err != nil {
+			errs = append(errs, errors.Annotatef(err, "error stopping %s", name))
+		}
+	}
+
+	if dw.txnLogWatcher != nil {
+		handle("transaction watcher", dw.txnLogWatcher.Stop())
+	}
+	if dw.presenceWatcher != nil {
+		handle("presence watcher", dw.presenceWatcher.Stop())
+	}
+	if dw.leadershipManager != nil {
+		dw.leadershipManager.Kill()
+		handle("leadership manager", dw.leadershipManager.Wait())
+	}
+	if dw.singularManager != nil {
+		dw.singularManager.Kill()
+		handle("singular manager", dw.singularManager.Wait())
+	}
+
+	if len(errs) > 0 {
+		for _, err := range errs[1:] {
+			logger.Errorf("while stopping state workers: %v", err)
+		}
+		return errs[0]
+	}
+	logger.Debugf("stopped state workers without error")
+	return nil
+}
+
+// Kill is part of the Workers interface.
+func (dw *dumbWorkers) Kill() {
+	dw.leadershipManager.Kill()
+	dw.singularManager.Kill()
+}
+
+// TxnWatcher is part of the Workers interface.
+func (dw *dumbWorkers) TxnWatcher() TxnWatcher {
+	return dw.txnLogWatcher
+}
+
+// PresenceWatcher is part of the Workers interface.
+func (dw *dumbWorkers) PresenceWatcher() PresenceWatcher {
+	return dw.presenceWatcher
+}
+
+// LeadershipManager is part of the Workers interface.
+func (dw *dumbWorkers) LeadershipManager() LeaseManager {
+	return dw.leadershipManager
+}
+
+// SingularManager is part of the Workers interface.
+func (dw *dumbWorkers) SingularManager() LeaseManager {
+	return dw.singularManager
+}

--- a/state/workers.go
+++ b/state/workers.go
@@ -114,7 +114,7 @@ func newDumbWorkers(config dumbWorkersConfig) (_ *dumbWorkers, err error) {
 		}
 	}()
 
-	logger.Infof("starting leadership lease manager")
+	logger.Debugf("starting leadership lease manager")
 	leadershipManager, err := lease.NewManager(lease.ManagerConfig{
 		Secretary: leadershipSecretary{},
 		Client:    config.leadershipClient,
@@ -126,7 +126,7 @@ func newDumbWorkers(config dumbWorkersConfig) (_ *dumbWorkers, err error) {
 	}
 	result.leadershipManager = leadershipManager
 
-	logger.Infof("starting singular lease manager")
+	logger.Debugf("starting singular lease manager")
 	singularManager, err := lease.NewManager(lease.ManagerConfig{
 		Secretary: singularSecretary{config.modelTag.Id()},
 		Client:    config.singularClient,
@@ -138,10 +138,10 @@ func newDumbWorkers(config dumbWorkersConfig) (_ *dumbWorkers, err error) {
 	}
 	result.singularManager = singularManager
 
-	logger.Infof("starting transaction log watcher")
+	logger.Debugf("starting transaction log watcher")
 	result.txnLogWatcher = watcher.New(config.txnLogCollection)
 
-	logger.Infof("starting presence watcher")
+	logger.Debugf("starting presence watcher")
 	result.presenceWatcher = presence.NewWatcher(
 		config.presenceCollection, config.modelTag,
 	)


### PR DESCRIPTION
This was meant to be a pure refactoring, to introduce the state.Workers type through which all workers should be accessed (in preparation for a future replacement that restarts failed ones) ...but it grew slightly to include the following behaviour changes:

  * dropped unused ModelConfig watcher
  * ModelMigration existence watcher now fulfils contract
  * apiserver/testing.FakeNotifyWatcher now fulfils contract
  * apiserver/migrationmaster now consumes (newly-implemented) initial watcher event

This also does not address the allWatchery bits, which are constructed lazily and are hence just different enough that I don't want to drag them in at this stage.

(Review request: http://reviews.vapour.ws/r/4784/)