### PR TITLE
Add openstack xenial images for arm64/ppc64el

### DIFF
--- a/provider/openstack/export_test.go
+++ b/provider/openstack/export_test.go
@@ -108,6 +108,8 @@ var indexData = `
 		   "products": [
 			"com.ubuntu.cloud:server:16.04:s390x",
 			"com.ubuntu.cloud:server:16.04:amd64",
+			"com.ubuntu.cloud:server:16.04:arm64",
+			"com.ubuntu.cloud:server:16.04:ppc64el",
 			"com.ubuntu.cloud:server:14.04:s390x",
 			"com.ubuntu.cloud:server:14.04:amd64",
 			"com.ubuntu.cloud:server:14.04:arm64",
@@ -160,6 +162,44 @@ var imagesData = `
            }
          },
          "pubname": "ubuntu-trusty-16.04-amd64-server-20121111",
+         "label": "release"
+       }
+     }
+   },
+   "com.ubuntu.cloud:server:16.04:arm64": {
+     "release": "xenial",
+     "version": "16.04",
+     "arch": "arm64",
+     "versions": {
+       "20121111": {
+         "items": {
+           "inst1604arm64": {
+             "root_store": "ebs",
+             "virt": "pv",
+             "region": "some-region",
+             "id": "id-1604arm64"
+           }
+         },
+         "pubname": "ubuntu-xenial-16.04-arm64-server-20121111",
+         "label": "release"
+       }
+     }
+   },
+   "com.ubuntu.cloud:server:16.04:ppc64el": {
+     "release": "xenial",
+     "version": "16.04",
+     "arch": "ppc64el",
+     "versions": {
+       "20121111": {
+         "items": {
+           "inst1604ppc64el": {
+             "root_store": "ebs",
+             "virt": "pv",
+             "region": "some-region",
+             "id": "id-1604ppc64el"
+           }
+         },
+         "pubname": "ubuntu-xenial-16.04-ppc64el-server-20121111",
          "label": "release"
        }
      }


### PR DESCRIPTION
This adds xenial images for openstack tests on ppc64el and arm64.

Refs https://bugs.launchpad.net/juju-core/+bug/1579062

