### PR TITLE
Ignore tests for juju-1 existence on windows

### DIFF
--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -177,6 +177,10 @@ func (s *MainSuite) TestActualRunJujuArgOrder(c *gc.C) {
 }
 
 func (s *MainSuite) TestFirstRun2xFrom1x(c *gc.C) {
+	if runtime.GOOS == "windows" {
+		c.Skip("bug 1564622: There's no 'surprise' upgrade on Windows. bug 1579059: The user should know they installed juju 2.x.")
+	}
+
 	// patch out lookpath to always return a nil error (and thus indicates success).
 	s.PatchValue(&execLookPath, func(s string) (string, error) {
 		c.Assert(s, gc.Equals, "juju-1")
@@ -228,6 +232,9 @@ func (s *MainSuite) TestFirstRun2xFrom1x(c *gc.C) {
 }
 
 func (s *MainSuite) TestNoWarn1xWith2xData(c *gc.C) {
+	if runtime.GOOS == "windows" {
+		c.Skip("bug 1564622: There's no 'surprise' upgrade on Windows. bug 1579059: The user should know they installed juju 2.x.")
+	}
 	// patch out lookpath to always return a nil error (and thus indicates success).
 	s.PatchValue(&execLookPath, func(s string) (string, error) {
 		c.Assert(s, gc.Equals, "juju-1")
@@ -264,6 +271,9 @@ func (s *MainSuite) TestNoWarn1xWith2xData(c *gc.C) {
 }
 
 func (s *MainSuite) TestNoWarnWithNo1xOr2xData(c *gc.C) {
+	if runtime.GOOS == "windows" {
+		c.Skip("bug 1564622: There's no 'surprise' upgrade on Windows. bug 1579059: The user should know they installed juju 2.x.")
+	}
 	// patch out lookpath to always return a nil error (and thus indicates success).
 	s.PatchValue(&execLookPath, func(s string) (string, error) {
 		c.Assert(s, gc.Equals, "juju-1")


### PR DESCRIPTION
AFAICT we added some checks to alert folks on xenial who might have
received an updated juju when performing a dist-upgrade. So if there is
a juju 1.x environment it warns the first time the new juju 2.x command
is run and notifies how to continue working with 1.x. If

It doesn't warn if there's 2x data, and it doesn't warn if there is
neither 1.x or 2.x data.

All checks are predicated on a command juju-1 on the path, which will
only exist on ubuntu (I think). Since this won't work on Windows which
will look for juju.exe, we skip these tests so they don't block
releases.

There may be a more correct solution for windows, but I don't have
windows to build, install, or test on.

Refs https://bugs.launchpad.net/juju-core/+bug/1564622
Refs https://bugs.launchpad.net/juju-core/+bug/1579059

(Review request: http://reviews.vapour.ws/r/4787/)