### PR TITLE
Forwardport for image metadata (de)normalisation.

### DIFF
--- a/environs/instances/image.go
+++ b/environs/instances/image.go
@@ -61,6 +61,7 @@ type InstanceSpec struct {
 // which instances can be run. The InstanceConstraint is used to filter allInstanceTypes and then a suitable image
 // compatible with the matching instance types is returned.
 func FindInstanceSpec(possibleImages []Image, ic *InstanceConstraint, allInstanceTypes []InstanceType) (*InstanceSpec, error) {
+	logger.Debugf("instance constraints %+v", ic)
 	if len(possibleImages) == 0 {
 		return nil, fmt.Errorf("no %q images in %s with arches %s",
 			ic.Series, ic.Region, ic.Arches)

--- a/environs/simplestreams/simplestreams.go
+++ b/environs/simplestreams/simplestreams.go
@@ -123,6 +123,8 @@ type CloudMetadata struct {
 	ContentId  string                        `json:"content_id"`
 	RegionName string                        `json:"region,omitempty"`
 	Endpoint   string                        `json:"endpoint,omitempty"`
+	Storage    string                        `json:"root_store,omitempty"`
+	VirtType   string                        `json:"virt,omitempty"`
 }
 
 type MetadataCatalog struct {
@@ -131,6 +133,8 @@ type MetadataCatalog struct {
 	Arch       string `json:"arch,omitempty"`
 	RegionName string `json:"region,omitempty"`
 	Endpoint   string `json:"endpoint,omitempty"`
+	Storage    string `json:"root_store,omitempty"`
+	VirtType   string `json:"virt,omitempty"`
 
 	// Items is a mapping from version to an ItemCollection,
 	// where the version is the date the items were produced,
@@ -146,6 +150,8 @@ type ItemCollection struct {
 	Version    string                 `json:"version,omitempty"`
 	RegionName string                 `json:"region,omitempty"`
 	Endpoint   string                 `json:"endpoint,omitempty"`
+	Storage    string                 `json:"root_store,omitempty"`
+	VirtType   string                 `json:"virt,omitempty"`
 }
 
 // These structs define the model used for metadata indices.
@@ -1051,6 +1057,10 @@ func UserPublicSigningKey() (string, error) {
 	signingKeyFile := filepath.Join(agent.DefaultPaths.ConfDir, SimplestreamsPublicKeyFile)
 	b, err := ioutil.ReadFile(signingKeyFile)
 	if os.IsNotExist(err) {
+		// TODO (anastasiamac 2016-05-07)
+		// We should not swallow this error
+		// but propagate it up to the caller.
+		// Bug #1579279
 		return "", nil
 	}
 	if err != nil {

--- a/environs/simplestreams/simplestreams_test.go
+++ b/environs/simplestreams/simplestreams_test.go
@@ -367,7 +367,7 @@ func (s *simplestreamsSuite) TestGetMetadataNoMatching(c *gc.C) {
 
 func (s *simplestreamsSuite) TestMetadataCatalog(c *gc.C) {
 	metadata := s.AssertGetMetadata(c)
-	c.Check(len(metadata.Products), gc.Equals, 3)
+	c.Check(len(metadata.Products), gc.Equals, 6)
 	c.Check(len(metadata.Aliases), gc.Equals, 1)
 	metadataCatalog := metadata.Products["com.ubuntu.cloud:server:12.04:amd64"]
 	c.Check(len(metadataCatalog.Items), gc.Equals, 2)
@@ -423,6 +423,37 @@ func (s *simplestreamsSuite) TestDealiasing(c *gc.C) {
 	ti := ic.Items["usww3he"].(*sstesting.TestItem)
 	c.Check(ti.RegionName, gc.Equals, "us-west-3")
 	c.Check(ti.Endpoint, gc.Equals, "https://ec2.us-west-3.amazonaws.com")
+}
+
+type storageVirtTest struct {
+	product, coll, item, storage, virt string
+}
+
+func (s *simplestreamsSuite) TestStorageVirtFromTopLevel(c *gc.C) {
+	s.assertImageMetadata(c,
+		storageVirtTest{"com.ubuntu.cloud:server:13.04:amd64", "20160318", "nzww1pe", "ebs", "pv"},
+	)
+}
+
+func (s *simplestreamsSuite) TestStorageVirtFromCatalog(c *gc.C) {
+	s.assertImageMetadata(c,
+		storageVirtTest{"com.ubuntu.cloud:server:14.10:amd64", "20160218", "nzww1pe", "ebs", "pv"},
+	)
+}
+
+func (s *simplestreamsSuite) TestStorageVirtFromCollection(c *gc.C) {
+	s.assertImageMetadata(c,
+		storageVirtTest{"com.ubuntu.cloud:server:12.10:amd64", "20160118", "nzww1pe", "ebs", "pv"},
+	)
+}
+
+func (s *simplestreamsSuite) assertImageMetadata(c *gc.C, one storageVirtTest) {
+	metadata := s.AssertGetMetadata(c)
+	metadataCatalog := metadata.Products[one.product]
+	ic := metadataCatalog.Items[one.coll]
+	ti := ic.Items[one.item].(*sstesting.TestItem)
+	c.Check(ti.Storage, gc.Equals, one.storage)
+	c.Check(ti.VirtType, gc.Equals, one.virt)
 }
 
 var getMirrorTests = []struct {

--- a/environs/simplestreams/testing/testing.go
+++ b/environs/simplestreams/testing/testing.go
@@ -434,7 +434,8 @@ var imageData = map[string]string{
  "region": "nz-east-1",
  "endpoint": "https://anywhere",
  "root_store": "ebs",
- "virt": "pv", "products": {
+ "virt": "pv", 
+ "products": {
   "com.ubuntu.cloud:server:14.04:amd64": {
    "release": "trusty",
    "version": "14.04",

--- a/environs/simplestreams/testing/testing.go
+++ b/environs/simplestreams/testing/testing.go
@@ -101,7 +101,11 @@ var imageData = map[string]string{
 		   "format": "products:1.0",
 		   "products": [
 			"com.ubuntu.cloud:server:12.04:amd64",
-			"com.ubuntu.cloud:server:12.04:arm"
+ 			"com.ubuntu.cloud:server:12.10:amd64",
+ 			"com.ubuntu.cloud:server:13.04:amd64",
+ 			"com.ubuntu.cloud:server:14.04:amd64",
+ 			"com.ubuntu.cloud:server:14.10:amd64",
+ 			"com.ubuntu.cloud:server:12.04:arm"
 		   ],
 		   "path": "streams/v1/image_metadata.json"
 		  },
@@ -429,7 +433,8 @@ var imageData = map[string]string{
  "content_id": "com.ubuntu.cloud:released:aws",
  "region": "nz-east-1",
  "endpoint": "https://anywhere",
- "products": {
+ "root_store": "ebs",
+ "virt": "pv", "products": {
   "com.ubuntu.cloud:server:14.04:amd64": {
    "release": "trusty",
    "version": "14.04",
@@ -444,6 +449,58 @@ var imageData = map[string]string{
       }
      },
      "pubname": "ubuntu-trusty-14.04-amd64-server-20140118",
+     "label": "release"
+    }
+   }
+  },
+  "com.ubuntu.cloud:server:13.04:amd64": {
+   "release": "raring",
+   "version": "13.04",
+   "arch": "amd64",
+   "versions": {
+    "20160318": {
+     "items": {
+      "nzww1pe": {
+       "id": "ami-36745463"
+      }
+     },
+     "pubname": "ubuntu-utopic-13.04-amd64-server-20160318",
+     "label": "release"
+    }
+   }
+  },
+  "com.ubuntu.cloud:server:14.10:amd64": {
+   "release": "utopic",
+   "version": "14.10",
+   "arch": "amd64",
+   "root_store": "ebs",
+   "virt": "pv",
+   "versions": {
+    "20160218": {
+     "items": {
+      "nzww1pe": {
+       "id": "ami-36745463"
+      }
+     },
+     "pubname": "ubuntu-utopic-14.10-amd64-server-20160218",
+     "label": "release"
+    }
+   }
+  },
+  "com.ubuntu.cloud:server:12.10:amd64": {
+   "release": "quantal",
+   "version": "12.10",
+   "arch": "amd64",
+   "versions": {
+    "20160118": {
+     "items": {
+      "nzww1pe": {
+       "id": "ami-36745463"
+      }
+     },
+     "root_store": "ebs",
+     "virt": "pv",
+     "pubname": "ubuntu-quantal-12.10-amd64-server-20160118",
      "label": "release"
     }
    }

--- a/provider/ec2/image.go
+++ b/provider/ec2/image.go
@@ -24,11 +24,13 @@ func filterImages(images []*imagemetadata.ImageMetadata, ic *instances.InstanceC
 	for _, image := range images {
 		imagesByStorage[image.Storage] = append(imagesByStorage[image.Storage], image)
 	}
+	logger.Debugf("images by storage type %+v", imagesByStorage)
 	// If a storage constraint has been specified, use that or else default to ssd.
 	storageTypes := []string{ssdStorage}
 	if ic != nil && len(ic.Storage) > 0 {
 		storageTypes = ic.Storage
 	}
+	logger.Debugf("filtering storage types %+v", storageTypes)
 	// Return the first set of images for which we have a storage type match.
 	for _, storageType := range storageTypes {
 		if len(imagesByStorage[storageType]) > 0 {
@@ -45,7 +47,7 @@ func findInstanceSpec(
 	allImageMetadata []*imagemetadata.ImageMetadata,
 	ic *instances.InstanceConstraint,
 ) (*instances.InstanceSpec, error) {
-
+	logger.Debugf("received %d image(s)", len(allImageMetadata))
 	// If the instance type is set, don't also set a default CPU power
 	// as this is implied.
 	cons := ic.Constraints
@@ -53,6 +55,7 @@ func findInstanceSpec(
 		ic.Constraints.CpuPower = instances.CpuPower(defaultCpuPower)
 	}
 	suitableImages := filterImages(allImageMetadata, ic)
+	logger.Debugf("found %d suitable image(s)", len(suitableImages))
 	images := instances.ImageMetadataToImages(suitableImages)
 
 	// Make a copy of the known EC2 instance types, filling in the cost for the specified region.


### PR DESCRIPTION
Image metadata allows to specify virtualisation type and storage (aka root store) at a root level.

There is a new generation images streams that can also have this information at higher grouping, for example in products file against items.

This PR ensures that these properties if specified are propagated and denormalised where needed.

(Review request: http://reviews.vapour.ws/r/4788/)