### PR TITLE
Skip some LXD tests on wily

### DIFF
--- a/provider/lxd/config_test.go
+++ b/provider/lxd/config_test.go
@@ -330,6 +330,9 @@ func (s *configSuite) TestNewModelConfig(c *gc.C) {
 		c.Skip("LXD not running locally")
 	}
 
+	// TODO(redir): Remove after wily or in yakkety.
+	skipIfWily(c)
+
 	for i, test := range newConfigTests {
 		c.Logf("test %d: %s", i, test.info)
 
@@ -436,6 +439,9 @@ func (s *configSuite) TestSetConfig(c *gc.C) {
 	if !s.IsRunningLocally(c) {
 		c.Skip("LXD not running locally")
 	}
+
+	// TODO(redir): Remove after wily or in yakkety.
+	skipIfWily(c)
 
 	for i, test := range changeConfigTests {
 		c.Logf("test %d: %s", i, test.info)

--- a/provider/lxd/provider_test.go
+++ b/provider/lxd/provider_test.go
@@ -6,14 +6,35 @@
 package lxd_test
 
 import (
+	"fmt"
+
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/series"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs"
 	envtesting "github.com/juju/juju/environs/testing"
 	"github.com/juju/juju/provider/lxd"
+	"github.com/juju/juju/tools/lxdclient"
 )
+
+// This is a quick hack to make wily pass with it's default, but unsupported,
+// version of LXD. Wily is supported until 2016-7-??. AFAIU LXD will not be
+// backported to wily... so we have this:|
+// TODO(redir): Remove after wiley or in yakkety.
+func skipIfWily(c *gc.C) {
+	if series.HostSeries() == "wily" {
+		cfg, _ := lxdclient.Config{}.WithDefaults()
+		_, err := lxdclient.Connect(cfg)
+		// We try to create a client here. On wily this should fail, because
+		// the default 0.20 lxd version should make juju/tools/lxdclient return
+		// an error.
+		if err != nil {
+			c.Skip(fmt.Sprintf("Skipping LXD tests because %s", err))
+		}
+	}
+}
 
 var (
 	_ = gc.Suite(&providerSuite{})
@@ -70,6 +91,9 @@ func (s *ProviderFunctionalSuite) SetUpTest(c *gc.C) {
 	if !s.IsRunningLocally(c) {
 		c.Skip("LXD not running locally")
 	}
+
+	// TODO(redir): Remove after wily or in yakkety.
+	skipIfWily(c)
 
 	s.BaseSuite.SetUpTest(c)
 


### PR DESCRIPTION
Wily ships with LXD 0.20 by default. It is not supported and LXD 2.0.0
won't be backported. This commit causes some tests to skip on wily, so
we don't block builds until it is EOL.

Refs https://bugs.launchpad.net/juju-core/+bug/1579173

(Review request: http://reviews.vapour.ws/r/4795/)