### PR TITLE
Simplestreams image metadata: added a test. 

### DIFF
--- a/environs/simplestreams/simplestreams_test.go
+++ b/environs/simplestreams/simplestreams_test.go
@@ -445,6 +445,12 @@ func (s *simplestreamsSuite) TestStorageVirtFromCollection(c *gc.C) {
 	)
 }
 
+func (s *simplestreamsSuite) TestStorageVirtFromItem(c *gc.C) {
+	s.assertImageMetadata(c,
+		storageVirtTest{"com.ubuntu.cloud:server:14.04:amd64", "20140118", "nzww1pe", "ssd", "hvm"},
+	)
+}
+
 func (s *simplestreamsSuite) assertImageMetadata(c *gc.C, one storageVirtTest) {
 	metadata := s.AssertGetMetadata(c)
 	metadataCatalog := metadata.Products[one.product]

--- a/environs/simplestreams/testing/testing.go
+++ b/environs/simplestreams/testing/testing.go
@@ -443,8 +443,8 @@ var imageData = map[string]string{
     "20140118": {
      "items": {
       "nzww1pe": {
-       "root_store": "ebs",
-       "virt": "pv",
+       "root_store": "ssd",
+       "virt": "hvm",
        "id": "ami-36745463"
       }
      },


### PR DESCRIPTION
Added missing test to double-check that Virt and RootStore are (de)normalised from item level.

(Review request: http://reviews.vapour.ws/r/4798/)