### PR TITLE
Skip TestFirstRun2xFrom1xOnUbuntu on Windows

### DIFF
--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -175,6 +175,11 @@ func (s *MainSuite) TestActualRunJujuArgOrder(c *gc.C) {
 }
 
 func (s *MainSuite) TestFirstRun2xFrom1xOnUbuntu(c *gc.C) {
+	if runtime.GOOS == "windows" {
+		// This test can't work on Windows and shouldn't need to
+		c.Skip("test doesn't work on Windows because Juju's 1.x and 2.x config directory are the same")
+	}
+
 	// Code should only run on ubuntu series, so patch out the series for
 	// when non-ubuntu OSes run this test.
 	s.PatchValue(&series.HostSeries, func() string { return "trusty" })


### PR DESCRIPTION
This test can't work on Windows because the Juju config directories are the same for 1.x and 2.x on Windows and the code being tested requires that they be different. Given that the section of code being tested doesn't need to run under Windows the test can be skipped.

Fixes LP #1580314.

(Review request: http://reviews.vapour.ws/r/4804/)