### PR TITLE
provider/azure: retry requests on status code 429

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -1,4 +1,4 @@
-github.com/Azure/azure-sdk-for-go	git	9f40dc1ee704920d20418200ddf6ec382456bb0e	2015-10-27T07:30:22Z
+github.com/Azure/azure-sdk-for-go	git	3b480eaaf6b4236d43a3c06cba969da6f53c8b66	2015-11-23T16:56:25Z
 github.com/ajstarks/svgo	git	89e3ac64b5b3e403a5e7c35ea4f98d45db7b4518	2014-10-04T21:11:59Z
 github.com/altoros/gosigma	git	31228935eec685587914528585da4eb9b073c76d	2015-04-08T14:52:32Z
 github.com/bmizerany/pat	git	48be7df2c27e1cec821a3284a683ce6ef90d9052	2014-04-29T04:34:05Z

--- a/provider/azure/environ.go
+++ b/provider/azure/environ.go
@@ -123,25 +123,27 @@ func (env *azureEnviron) initResourceGroup() (*config.Config, error) {
 	resourceGroupsClient := resources.GroupsClient{env.resources}
 
 	logger.Debugf("creating resource group %q", env.resourceGroup)
-	_, err := resourceGroupsClient.CreateOrUpdate(env.resourceGroup, resources.ResourceGroup{
-		Location: to.StringPtr(location),
-		Tags:     toTagsPtr(tags),
-	})
-	if err != nil {
+	if err := env.callAPI(func() (autorest.Response, error) {
+		group, err := resourceGroupsClient.CreateOrUpdate(env.resourceGroup, resources.ResourceGroup{
+			Location: to.StringPtr(location),
+			Tags:     toTagsPtr(tags),
+		})
+		return group.Response, err
+	}); err != nil {
 		return nil, errors.Annotate(err, "creating resource group")
 	}
 
 	// Create an internal network for all VMs in the
 	// resource group to connect to.
 	vnetPtr, err := createInternalVirtualNetwork(
-		env.network, env.resourceGroup, location, tags,
+		env.callAPI, env.network, env.resourceGroup, location, tags,
 	)
 	if err != nil {
 		return nil, errors.Annotate(err, "creating virtual network")
 	}
 
 	_, err = createInternalSubnet(
-		env.network, env.resourceGroup, vnetPtr, location, tags,
+		env.callAPI, env.network, env.resourceGroup, vnetPtr, location, tags,
 	)
 	if err != nil {
 		return nil, errors.Annotate(err, "creating subnet")
@@ -150,7 +152,8 @@ func (env *azureEnviron) initResourceGroup() (*config.Config, error) {
 	// Create a storage account for the resource group.
 	storageAccountsClient := storage.AccountsClient{env.storage}
 	storageAccountName, storageAccountKey, err := createStorageAccount(
-		storageAccountsClient, env.config.storageAccountType,
+		env.callAPI, storageAccountsClient,
+		env.config.storageAccountType,
 		env.resourceGroup, location, tags,
 		env.provider.config.StorageAccountNameGenerator,
 	)
@@ -164,6 +167,7 @@ func (env *azureEnviron) initResourceGroup() (*config.Config, error) {
 }
 
 func createStorageAccount(
+	callAPI callAPIFunc,
 	client storage.AccountsClient,
 	accountType storage.AccountType,
 	resourceGroup string,
@@ -176,15 +180,19 @@ func createStorageAccount(
 	for remaining := maxAttempts; remaining > 0; remaining-- {
 		accountName := accountNameGenerator()
 		logger.Debugf("- checking storage account name %q", accountName)
-		result, err := client.CheckNameAvailability(
-			storage.AccountCheckNameAvailabilityParameters{
-				Name: to.StringPtr(accountName),
-				// Azure is a little inconsistent with when Type is
-				// required. It's required here.
-				Type: to.StringPtr("Microsoft.Storage/storageAccounts"),
-			},
-		)
-		if err != nil {
+		var result storage.CheckNameAvailabilityResult
+		if err := callAPI(func() (autorest.Response, error) {
+			var err error
+			result, err = client.CheckNameAvailability(
+				storage.AccountCheckNameAvailabilityParameters{
+					Name: to.StringPtr(accountName),
+					// Azure is a little inconsistent with when Type is
+					// required. It's required here.
+					Type: to.StringPtr("Microsoft.Storage/storageAccounts"),
+				},
+			)
+			return result.Response, err
+		}); err != nil {
 			return "", "", errors.Annotate(err, "checking account name availability")
 		}
 		if !to.Bool(result.NameAvailable) {
@@ -205,12 +213,20 @@ func createStorageAccount(
 		// TODO(axw) account creation can fail if the account name is
 		// available, but contains profanity. We should retry a set
 		// number of times even if creating fails.
-		if _, err := client.Create(resourceGroup, accountName, createParams); err != nil {
+		if err := callAPI(func() (autorest.Response, error) {
+			result, err := client.Create(resourceGroup, accountName, createParams)
+			return result.Response, err
+		}); err != nil {
 			return "", "", errors.Trace(err)
 		}
+
 		logger.Debugf("- listing storage account keys")
-		listKeysResult, err := client.ListKeys(resourceGroup, accountName)
-		if err != nil {
+		var listKeysResult storage.AccountKeys
+		if err := callAPI(func() (autorest.Response, error) {
+			var err error
+			listKeysResult, err = client.ListKeys(resourceGroup, accountName)
+			return listKeysResult.Response, err
+		}); err != nil {
 			return "", "", errors.Annotate(err, "listing storage account keys")
 		}
 		return accountName, to.String(listKeysResult.Key1), nil
@@ -476,6 +492,7 @@ func (env *azureEnviron) StartInstance(args environs.StartInstanceParams) (*envi
 		storageEndpoint, storageAccountName,
 		networkClient, vmClient,
 		availabilitySetClient, vmExtensionClient,
+		env.callAPI,
 	)
 	if err != nil {
 		logger.Errorf("creating instance failed, destroying: %v", err)
@@ -520,6 +537,7 @@ func createVirtualMachine(
 	vmClient compute.VirtualMachinesClient,
 	availabilitySetClient compute.AvailabilitySetsClient,
 	vmExtensionClient compute.VirtualMachineExtensionsClient,
+	callAPI callAPIFunc,
 ) (compute.VirtualMachine, error) {
 
 	storageProfile, err := newStorageProfile(
@@ -536,8 +554,8 @@ func createVirtualMachine(
 	}
 
 	networkProfile, err := newNetworkProfile(
-		networkClient, vmName, apiPort,
-		internalNetworkSubnet,
+		callAPI, networkClient,
+		vmName, apiPort, internalNetworkSubnet,
 		resourceGroup, location, vmTags,
 	)
 	if err != nil {
@@ -545,7 +563,7 @@ func createVirtualMachine(
 	}
 
 	availabilitySetId, err := createAvailabilitySet(
-		availabilitySetClient,
+		callAPI, availabilitySetClient,
 		vmName, resourceGroup, location,
 		vmTags, envTags,
 		distributionGroupFunc, instancesFunc,
@@ -571,8 +589,12 @@ func createVirtualMachine(
 			},
 		},
 	}
-	vm, err := vmClient.CreateOrUpdate(resourceGroup, vmName, vmArgs)
-	if err != nil {
+	var vm compute.VirtualMachine
+	if err := callAPI(func() (autorest.Response, error) {
+		var err error
+		vm, err = vmClient.CreateOrUpdate(resourceGroup, vmName, vmArgs)
+		return vm.Response, err
+	}); err != nil {
 		return compute.VirtualMachine{}, errors.Annotate(err, "creating virtual machine")
 	}
 
@@ -581,7 +603,7 @@ func createVirtualMachine(
 	switch seriesOS {
 	case os.Windows, os.CentOS:
 		if err := createVMExtension(
-			vmExtensionClient, seriesOS,
+			callAPI, vmExtensionClient, seriesOS,
 			resourceGroup, vmName, location, vmTags,
 		); err != nil {
 			return compute.VirtualMachine{}, errors.Annotate(
@@ -605,6 +627,7 @@ func createVirtualMachine(
 //  - if there are no units assigned to the machine, then use the "juju"
 //    availability set
 func createAvailabilitySet(
+	callAPI callAPIFunc,
 	client compute.AvailabilitySetsClient,
 	vmName, resourceGroup, location string,
 	vmTags, envTags map[string]string,
@@ -666,15 +689,19 @@ func createAvailabilitySet(
 	}
 
 	logger.Debugf("- creating availability set %q", availabilitySetName)
-	availabilitySet, err := client.CreateOrUpdate(
-		resourceGroup, availabilitySetName, compute.AvailabilitySet{
-			Location: to.StringPtr(location),
-			// NOTE(axw) we do *not* want to use vmTags here,
-			// because an availability set is shared by machines.
-			Tags: toTagsPtr(envTags),
-		},
-	)
-	if err != nil {
+	var availabilitySet compute.AvailabilitySet
+	if err := callAPI(func() (autorest.Response, error) {
+		var err error
+		availabilitySet, err = client.CreateOrUpdate(
+			resourceGroup, availabilitySetName, compute.AvailabilitySet{
+				Location: to.StringPtr(location),
+				// NOTE(axw) we do *not* want to use vmTags here,
+				// because an availability set is shared by machines.
+				Tags: toTagsPtr(envTags),
+			},
+		)
+		return availabilitySet.Response, err
+	}); err != nil {
 		return "", errors.Annotatef(
 			err, "creating availability set %q", availabilitySetName,
 		)
@@ -801,7 +828,8 @@ func (env *azureEnviron) StopInstances(ids ...instance.Id) error {
 			continue
 		}
 		if err := deleteInstance(
-			inst.(*azureInstance), computeClient, networkClient, storageClient,
+			inst.(*azureInstance),
+			env.callAPI, computeClient, networkClient, storageClient,
 		); err != nil {
 			return errors.Annotatef(err, "deleting instance %q", inst.Id())
 		}
@@ -813,6 +841,7 @@ func (env *azureEnviron) StopInstances(ids ...instance.Id) error {
 // it owns, and any corresponding network security rules.
 func deleteInstance(
 	inst *azureInstance,
+	callAPI callAPIFunc,
 	computeClient compute.ManagementClient,
 	networkClient network.ManagementClient,
 	storageClient internalazurestorage.Client,
@@ -826,8 +855,12 @@ func deleteInstance(
 	logger.Debugf("deleting instance %q", vmName)
 
 	logger.Debugf("- deleting virtual machine")
-	deleteResult, err := vmClient.Delete(inst.env.resourceGroup, vmName)
-	if err != nil {
+	var deleteResult autorest.Response
+	if err := callAPI(func() (autorest.Response, error) {
+		var err error
+		deleteResult, err = vmClient.Delete(inst.env.resourceGroup, vmName)
+		return deleteResult, err
+	}); err != nil {
 		if deleteResult.Response == nil || deleteResult.StatusCode != http.StatusNotFound {
 			return errors.Annotate(err, "deleting virtual machine")
 		}
@@ -836,14 +869,18 @@ func deleteInstance(
 	// Delete the VM's OS disk VHD.
 	logger.Debugf("- deleting OS VHD")
 	blobClient := storageClient.GetBlobService()
-	if _, err := blobClient.DeleteBlobIfExists(osDiskVHDContainer, vmName); err != nil {
+	if err := callAPI(func() (autorest.Response, error) {
+		_, err := blobClient.DeleteBlobIfExists(osDiskVHDContainer, vmName)
+		return autorest.Response{}, err
+	}); err != nil {
 		return errors.Annotate(err, "deleting OS VHD")
 	}
 
 	// Delete network security rules that refer to the VM.
 	logger.Debugf("- deleting security rules")
 	if err := deleteInstanceNetworkSecurityRules(
-		inst.env.resourceGroup, inst.Id(), nsgClient, securityRuleClient,
+		inst.env.resourceGroup, inst.Id(), nsgClient,
+		securityRuleClient, inst.env.callAPI,
 	); err != nil {
 		return errors.Annotate(err, "deleting network security rules")
 	}
@@ -867,9 +904,12 @@ func deleteInstance(
 			detached = true
 		}
 		if detached {
-			if _, err := nicClient.CreateOrUpdate(
-				inst.env.resourceGroup, to.String(nic.Name), nic,
-			); err != nil {
+			if err := callAPI(func() (autorest.Response, error) {
+				result, err := nicClient.CreateOrUpdate(
+					inst.env.resourceGroup, to.String(nic.Name), nic,
+				)
+				return result.Response, err
+			}); err != nil {
 				return errors.Annotate(err, "detaching public IP addresses")
 			}
 		}
@@ -880,8 +920,12 @@ func deleteInstance(
 	for _, pip := range inst.publicIPAddresses {
 		pipName := to.String(pip.Name)
 		logger.Tracef("deleting public IP %q", pipName)
-		result, err := publicIPClient.Delete(inst.env.resourceGroup, pipName)
-		if err != nil {
+		var result autorest.Response
+		if err := callAPI(func() (autorest.Response, error) {
+			var err error
+			result, err = publicIPClient.Delete(inst.env.resourceGroup, pipName)
+			return result, err
+		}); err != nil {
 			if result.Response == nil || result.StatusCode != http.StatusNotFound {
 				return errors.Annotate(err, "deleting public IP")
 			}
@@ -895,8 +939,12 @@ func deleteInstance(
 	for _, nic := range inst.networkInterfaces {
 		nicName := to.String(nic.Name)
 		logger.Tracef("deleting NIC %q", nicName)
-		result, err := nicClient.Delete(inst.env.resourceGroup, nicName)
-		if err != nil {
+		var result autorest.Response
+		if err := callAPI(func() (autorest.Response, error) {
+			var err error
+			result, err = nicClient.Delete(inst.env.resourceGroup, nicName)
+			return result, err
+		}); err != nil {
 			if result.Response == nil || result.StatusCode != http.StatusNotFound {
 				return errors.Annotate(err, "deleting NIC")
 			}
@@ -970,8 +1018,12 @@ func (env *azureEnviron) allInstances(
 	// unknown instances. StopInstances must delete VMs before NICs and
 	// public IPs, because a VM cannot have less than 1 NIC. Thus, we can
 	// potentially delete a VM but then fail to delete its NIC.
-	nicsResult, err := nicClient.List(resourceGroup)
-	if err != nil {
+	var nicsResult network.InterfaceListResult
+	if err := env.callAPI(func() (autorest.Response, error) {
+		var err error
+		nicsResult, err = nicClient.List(resourceGroup)
+		return nicsResult.Response, err
+	}); err != nil {
 		if nicsResult.Response.Response != nil && nicsResult.StatusCode == http.StatusNotFound {
 			// This will occur if the resource group does not
 			// exist, e.g. in a fresh hosted environment.
@@ -984,8 +1036,12 @@ func (env *azureEnviron) allInstances(
 	}
 
 	// Create an azureInstance for each VM.
-	result, err := vmClient.List(resourceGroup)
-	if err != nil {
+	var result compute.VirtualMachineListResult
+	if err := env.callAPI(func() (autorest.Response, error) {
+		var err error
+		result, err = vmClient.List(resourceGroup)
+		return result.Response, err
+	}); err != nil {
 		return nil, errors.Annotate(err, "listing virtual machines")
 	}
 	vmNames := make(set.Strings)
@@ -1047,8 +1103,12 @@ func (env *azureEnviron) Destroy() error {
 
 func (env *azureEnviron) deleteResourceGroup() error {
 	client := resources.GroupsClient{env.resources}
-	result, err := client.Delete(env.resourceGroup)
-	if err != nil {
+	var result autorest.Response
+	if err := env.callAPI(func() (autorest.Response, error) {
+		var err error
+		result, err = client.Delete(env.resourceGroup)
+		return result, err
+	}); err != nil {
 		if result.Response == nil || result.StatusCode != http.StatusNotFound {
 			return errors.Annotatef(err, "deleting resource group %q", env.resourceGroup)
 		}
@@ -1116,9 +1176,13 @@ func (env *azureEnviron) getInstanceTypesLocked() (map[string]instances.Instance
 	location := env.config.location
 	client := compute.VirtualMachineSizesClient{env.compute}
 
-	result, err := client.List(location)
-	if err != nil {
-		return nil, errors.Trace(err)
+	var result compute.VirtualMachineSizeListResult
+	if err := env.callAPI(func() (autorest.Response, error) {
+		var err error
+		result, err = client.List(location)
+		return result.Response, err
+	}); err != nil {
+		return nil, errors.Annotate(err, "listing VM sizes")
 	}
 	instanceTypes := make(map[string]instances.InstanceType)
 	if result.Value != nil {
@@ -1140,8 +1204,12 @@ func (env *azureEnviron) getInternalSubnetLocked() (*network.Subnet, error) {
 	client := network.SubnetsClient{env.network}
 	vnetName := internalNetworkName
 	subnetName := internalSubnetName
-	subnet, err := client.Get(env.resourceGroup, vnetName, subnetName)
-	if err != nil {
+	var subnet network.Subnet
+	if err := env.callAPI(func() (autorest.Response, error) {
+		var err error
+		subnet, err = client.Get(env.resourceGroup, vnetName, subnetName)
+		return subnet.Response, err
+	}); err != nil {
 		return nil, errors.Annotate(err, "getting internal subnet")
 	}
 	return &subnet, nil
@@ -1173,4 +1241,8 @@ func (env *azureEnviron) AgentMirror() (simplestreams.CloudSpec, error) {
 		// data are the storage endpoints.
 		Endpoint: fmt.Sprintf("https://%s/", env.config.storageEndpoint),
 	}, nil
+}
+
+func (env *azureEnviron) callAPI(f func() (autorest.Response, error)) error {
+	return backoffAPIRequestCaller{env.provider.config.RetryClock}.call(f)
 }

--- a/provider/azure/environ.go
+++ b/provider/azure/environ.go
@@ -123,7 +123,7 @@ func (env *azureEnviron) initResourceGroup() (*config.Config, error) {
 	resourceGroupsClient := resources.GroupsClient{env.resources}
 
 	logger.Debugf("creating resource group %q", env.resourceGroup)
-	_, err := resourceGroupsClient.CreateOrUpdate(env.resourceGroup, resources.Group{
+	_, err := resourceGroupsClient.CreateOrUpdate(env.resourceGroup, resources.ResourceGroup{
 		Location: to.StringPtr(location),
 		Tags:     toTagsPtr(tags),
 	})

--- a/provider/azure/environ.go
+++ b/provider/azure/environ.go
@@ -869,10 +869,7 @@ func deleteInstance(
 	// Delete the VM's OS disk VHD.
 	logger.Debugf("- deleting OS VHD")
 	blobClient := storageClient.GetBlobService()
-	if err := callAPI(func() (autorest.Response, error) {
-		_, err := blobClient.DeleteBlobIfExists(osDiskVHDContainer, vmName)
-		return autorest.Response{}, err
-	}); err != nil {
+	if _, err := blobClient.DeleteBlobIfExists(osDiskVHDContainer, vmName); err != nil {
 		return errors.Annotate(err, "deleting OS VHD")
 	}
 

--- a/provider/azure/environ_test.go
+++ b/provider/azure/environ_test.go
@@ -52,7 +52,7 @@ type environSuite struct {
 	sender        azuretesting.Senders
 
 	tags                          map[string]*string
-	group                         *resources.Group
+	group                         *resources.ResourceGroup
 	vmSizes                       *compute.VirtualMachineSizeListResult
 	storageNameAvailabilityResult *storage.CheckNameAvailabilityResult
 	storageAccount                *storage.Account
@@ -88,7 +88,7 @@ func (s *environSuite) SetUpTest(c *gc.C) {
 		"juju-machine-name": to.StringPtr("machine-0"),
 	}
 
-	s.group = &resources.Group{
+	s.group = &resources.ResourceGroup{
 		Location: to.StringPtr("westus"),
 		Tags:     &envTags,
 	}
@@ -618,7 +618,7 @@ func (s *environSuite) TestBootstrap(c *gc.C) {
 		Name: to.StringPtr("SSHInbound"),
 		Properties: &network.SecurityRulePropertiesFormat{
 			Description:              to.StringPtr("Allow SSH access to all machines"),
-			Protocol:                 network.SecurityRuleProtocolTCP,
+			Protocol:                 network.TCP,
 			SourceAddressPrefix:      to.StringPtr("*"),
 			SourcePortRange:          to.StringPtr("*"),
 			DestinationAddressPrefix: to.StringPtr("*"),

--- a/provider/azure/environprovider.go
+++ b/provider/azure/environprovider.go
@@ -7,6 +7,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/Godeps/_workspace/src/github.com/Azure/go-autorest/autorest"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
+	"github.com/juju/utils/clock"
 
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs"
@@ -35,6 +36,9 @@ type ProviderConfig struct {
 	// StorageAccountNameGenerator is a function returning storage
 	// account names.
 	StorageAccountNameGenerator func() string
+
+	// RetryClock is used when retrying API calls due to rate-limiting.
+	RetryClock clock.Clock
 }
 
 // Validate validates the Azure provider configuration.
@@ -44,6 +48,9 @@ func (cfg ProviderConfig) Validate() error {
 	}
 	if cfg.StorageAccountNameGenerator == nil {
 		return errors.NotValidf("nil StorageAccountNameGenerator")
+	}
+	if cfg.RetryClock == nil {
+		return errors.NotValidf("nil RetryClock")
 	}
 	return nil
 }

--- a/provider/azure/environprovider_test.go
+++ b/provider/azure/environprovider_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/Godeps/_workspace/src/github.com/Azure/go-autorest/autorest"
 	jc "github.com/juju/testing/checkers"
@@ -93,6 +94,9 @@ func newProviders(c *gc.C, config azure.ProviderConfig) (environs.EnvironProvide
 		config.StorageAccountNameGenerator = func() string {
 			return fakeStorageAccount
 		}
+	}
+	if config.RetryClock == nil {
+		config.RetryClock = testing.NewClock(time.Time{})
 	}
 	environProvider, storageProvider, err := azure.NewProviders(config)
 	c.Assert(err, jc.ErrorIsNil)

--- a/provider/azure/init.go
+++ b/provider/azure/init.go
@@ -5,6 +5,7 @@ package azure
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/utils/clock"
 
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/provider/azure/internal/azurestorage"
@@ -31,6 +32,7 @@ func init() {
 	environProvider, storageProvider, err := NewProviders(ProviderConfig{
 		NewStorageClient:            azurestorage.NewClient,
 		StorageAccountNameGenerator: RandomStorageAccountName,
+		RetryClock:                  &clock.WallClock,
 	})
 	if err != nil {
 		panic(err)

--- a/provider/azure/instance.go
+++ b/provider/azure/instance.go
@@ -236,9 +236,9 @@ func (inst *azureInstance) OpenPorts(machineId string, ports []jujunetwork.PortR
 		var protocol network.SecurityRuleProtocol
 		switch ports.Protocol {
 		case "tcp":
-			protocol = network.SecurityRuleProtocolTCP
+			protocol = network.TCP
 		case "udp":
-			protocol = network.SecurityRuleProtocolUDP
+			protocol = network.UDP
 		default:
 			return errors.Errorf("invalid protocol %q", ports.Protocol)
 		}
@@ -348,9 +348,9 @@ func (inst *azureInstance) Ports(machineId string) (ports []jujunetwork.PortRang
 
 		var protocols []string
 		switch rule.Properties.Protocol {
-		case network.SecurityRuleProtocolTCP:
+		case network.TCP:
 			protocols = []string{"tcp"}
-		case network.SecurityRuleProtocolUDP:
+		case network.UDP:
 			protocols = []string{"udp"}
 		default:
 			protocols = []string{"tcp", "udp"}

--- a/provider/azure/instance_test.go
+++ b/provider/azure/instance_test.go
@@ -110,7 +110,7 @@ func makeSecurityRule(name, ipAddress, ports string) network.SecurityRule {
 	return network.SecurityRule{
 		Name: to.StringPtr(name),
 		Properties: &network.SecurityRulePropertiesFormat{
-			Protocol:                 network.SecurityRuleProtocolTCP,
+			Protocol:                 network.TCP,
 			DestinationAddressPrefix: to.StringPtr(ipAddress),
 			DestinationPortRange:     to.StringPtr(ports),
 			Access:                   network.Allow,
@@ -257,7 +257,7 @@ func (s *instanceSuite) TestInstancePorts(c *gc.C) {
 	nsgSender := networkSecurityGroupSender([]network.SecurityRule{{
 		Name: to.StringPtr("machine-0-xyzzy"),
 		Properties: &network.SecurityRulePropertiesFormat{
-			Protocol:             network.SecurityRuleProtocolUDP,
+			Protocol:             network.UDP,
 			DestinationPortRange: to.StringPtr("*"),
 			Access:               network.Allow,
 			Priority:             to.IntPtr(200),
@@ -266,7 +266,7 @@ func (s *instanceSuite) TestInstancePorts(c *gc.C) {
 	}, {
 		Name: to.StringPtr("machine-0-tcpcp"),
 		Properties: &network.SecurityRulePropertiesFormat{
-			Protocol:             network.SecurityRuleProtocolTCP,
+			Protocol:             network.TCP,
 			DestinationPortRange: to.StringPtr("1000-2000"),
 			Access:               network.Allow,
 			Priority:             to.IntPtr(201),
@@ -275,7 +275,7 @@ func (s *instanceSuite) TestInstancePorts(c *gc.C) {
 	}, {
 		Name: to.StringPtr("machine-0-http"),
 		Properties: &network.SecurityRulePropertiesFormat{
-			Protocol:             network.SecurityRuleProtocolAsterisk,
+			Protocol:             network.Asterisk,
 			DestinationPortRange: to.StringPtr("80"),
 			Access:               network.Allow,
 			Priority:             to.IntPtr(202),
@@ -284,7 +284,7 @@ func (s *instanceSuite) TestInstancePorts(c *gc.C) {
 	}, {
 		Name: to.StringPtr("machine-00-ignored"),
 		Properties: &network.SecurityRulePropertiesFormat{
-			Protocol:             network.SecurityRuleProtocolTCP,
+			Protocol:             network.TCP,
 			DestinationPortRange: to.StringPtr("80"),
 			Access:               network.Allow,
 			Priority:             to.IntPtr(202),
@@ -293,7 +293,7 @@ func (s *instanceSuite) TestInstancePorts(c *gc.C) {
 	}, {
 		Name: to.StringPtr("machine-0-ignored"),
 		Properties: &network.SecurityRulePropertiesFormat{
-			Protocol:             network.SecurityRuleProtocolTCP,
+			Protocol:             network.TCP,
 			DestinationPortRange: to.StringPtr("80"),
 			Access:               network.Deny,
 			Priority:             to.IntPtr(202),
@@ -302,7 +302,7 @@ func (s *instanceSuite) TestInstancePorts(c *gc.C) {
 	}, {
 		Name: to.StringPtr("machine-0-ignored"),
 		Properties: &network.SecurityRulePropertiesFormat{
-			Protocol:             network.SecurityRuleProtocolTCP,
+			Protocol:             network.TCP,
 			DestinationPortRange: to.StringPtr("80"),
 			Access:               network.Allow,
 			Priority:             to.IntPtr(202),
@@ -311,7 +311,7 @@ func (s *instanceSuite) TestInstancePorts(c *gc.C) {
 	}, {
 		Name: to.StringPtr("machine-0-ignored"),
 		Properties: &network.SecurityRulePropertiesFormat{
-			Protocol:             network.SecurityRuleProtocolTCP,
+			Protocol:             network.TCP,
 			DestinationPortRange: to.StringPtr("80"),
 			Access:               network.Allow,
 			Priority:             to.IntPtr(199), // internal range
@@ -409,7 +409,7 @@ func (s *instanceSuite) TestInstanceOpenPorts(c *gc.C) {
 	assertRequestBody(c, s.requests[1], &network.SecurityRule{
 		Properties: &network.SecurityRulePropertiesFormat{
 			Description:              to.StringPtr("1000/tcp"),
-			Protocol:                 network.SecurityRuleProtocolTCP,
+			Protocol:                 network.TCP,
 			SourcePortRange:          to.StringPtr("*"),
 			SourceAddressPrefix:      to.StringPtr("*"),
 			DestinationPortRange:     to.StringPtr("1000"),
@@ -424,7 +424,7 @@ func (s *instanceSuite) TestInstanceOpenPorts(c *gc.C) {
 	assertRequestBody(c, s.requests[2], &network.SecurityRule{
 		Properties: &network.SecurityRulePropertiesFormat{
 			Description:              to.StringPtr("1000-2000/udp"),
-			Protocol:                 network.SecurityRuleProtocolUDP,
+			Protocol:                 network.UDP,
 			SourcePortRange:          to.StringPtr("*"),
 			SourceAddressPrefix:      to.StringPtr("*"),
 			DestinationPortRange:     to.StringPtr("1000-2000"),
@@ -460,7 +460,7 @@ func (s *instanceSuite) TestInstanceOpenPortsAlreadyOpen(c *gc.C) {
 	nsgSender := networkSecurityGroupSender([]network.SecurityRule{{
 		Name: to.StringPtr("machine-0-tcp-1000"),
 		Properties: &network.SecurityRulePropertiesFormat{
-			Protocol:             network.SecurityRuleProtocolAsterisk,
+			Protocol:             network.Asterisk,
 			DestinationPortRange: to.StringPtr("1000"),
 			Access:               network.Allow,
 			Priority:             to.IntPtr(202),
@@ -488,7 +488,7 @@ func (s *instanceSuite) TestInstanceOpenPortsAlreadyOpen(c *gc.C) {
 	assertRequestBody(c, s.requests[1], &network.SecurityRule{
 		Properties: &network.SecurityRulePropertiesFormat{
 			Description:              to.StringPtr("1000-2000/udp"),
-			Protocol:                 network.SecurityRuleProtocolUDP,
+			Protocol:                 network.UDP,
 			SourcePortRange:          to.StringPtr("*"),
 			SourceAddressPrefix:      to.StringPtr("*"),
 			DestinationPortRange:     to.StringPtr("1000-2000"),

--- a/provider/azure/networking.go
+++ b/provider/azure/networking.go
@@ -61,7 +61,7 @@ var sshSecurityRule = network.SecurityRule{
 	Name: to.StringPtr("SSHInbound"),
 	Properties: &network.SecurityRulePropertiesFormat{
 		Description:              to.StringPtr("Allow SSH access to all machines"),
-		Protocol:                 network.SecurityRuleProtocolTCP,
+		Protocol:                 network.TCP,
 		SourceAddressPrefix:      to.StringPtr("*"),
 		SourcePortRange:          to.StringPtr("*"),
 		DestinationAddressPrefix: to.StringPtr("*"),
@@ -262,7 +262,7 @@ func newNetworkProfile(
 			Name: to.StringPtr(apiSecurityRuleName),
 			Properties: &network.SecurityRulePropertiesFormat{
 				Description:              to.StringPtr("Allow API access to server machines"),
-				Protocol:                 network.SecurityRuleProtocolTCP,
+				Protocol:                 network.TCP,
 				SourceAddressPrefix:      to.StringPtr("*"),
 				SourcePortRange:          to.StringPtr("*"),
 				DestinationAddressPrefix: to.StringPtr(privateIPAddress),

--- a/provider/azure/networking.go
+++ b/provider/azure/networking.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"path"
 
+	"github.com/Azure/azure-sdk-for-go/Godeps/_workspace/src/github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/azure-sdk-for-go/Godeps/_workspace/src/github.com/Azure/go-autorest/autorest/to"
 	"github.com/Azure/azure-sdk-for-go/arm/compute"
 	"github.com/Azure/azure-sdk-for-go/arm/network"
@@ -73,6 +74,7 @@ var sshSecurityRule = network.SecurityRule{
 }
 
 func createInternalVirtualNetwork(
+	callAPI callAPIFunc,
 	client network.ManagementClient,
 	resourceGroup string,
 	location string,
@@ -88,10 +90,14 @@ func createInternalVirtualNetwork(
 	}
 	logger.Debugf("creating virtual network %q", internalNetworkName)
 	vnetClient := network.VirtualNetworksClient{client}
-	vnet, err := vnetClient.CreateOrUpdate(
-		resourceGroup, internalNetworkName, virtualNetworkParams,
-	)
-	if err != nil {
+	var vnet network.VirtualNetwork
+	if err := callAPI(func() (autorest.Response, error) {
+		var err error
+		vnet, err = vnetClient.CreateOrUpdate(
+			resourceGroup, internalNetworkName, virtualNetworkParams,
+		)
+		return vnet.Response, err
+	}); err != nil {
 		return nil, errors.Annotatef(err, "creating virtual network %q", internalNetworkName)
 	}
 	return &vnet, nil
@@ -105,6 +111,7 @@ func createInternalVirtualNetwork(
 // three places where we modify subnets: at bootstrap, when a new environment is
 // created, and when an environment is destroyed.
 func createInternalSubnet(
+	callAPI callAPIFunc,
 	client network.ManagementClient,
 	resourceGroup string,
 	vnet *network.VirtualNetwork,
@@ -146,10 +153,14 @@ func createInternalSubnet(
 	securityGroupClient := network.SecurityGroupsClient{client}
 	securityGroupName := internalSecurityGroupName
 	logger.Debugf("creating security group %q", securityGroupName)
-	nsg, err := securityGroupClient.CreateOrUpdate(
-		resourceGroup, securityGroupName, securityGroupParams,
-	)
-	if err != nil {
+	var nsg network.SecurityGroup
+	if err := callAPI(func() (autorest.Response, error) {
+		var err error
+		nsg, err = securityGroupClient.CreateOrUpdate(
+			resourceGroup, securityGroupName, securityGroupParams,
+		)
+		return nsg.Response, err
+	}); err != nil {
 		return nil, errors.Annotatef(err, "creating security group %q", securityGroupName)
 	}
 
@@ -164,16 +175,21 @@ func createInternalSubnet(
 	}
 	logger.Debugf("creating subnet %q (%s)", subnetName, nextAddressPrefix)
 	subnetClient := network.SubnetsClient{client}
-	subnet, err := subnetClient.CreateOrUpdate(
-		resourceGroup, internalNetworkName, subnetName, subnetParams,
-	)
-	if err != nil {
+	var subnet network.Subnet
+	if err := callAPI(func() (autorest.Response, error) {
+		var err error
+		subnet, err = subnetClient.CreateOrUpdate(
+			resourceGroup, internalNetworkName, subnetName, subnetParams,
+		)
+		return subnet.Response, err
+	}); err != nil {
 		return nil, errors.Annotatef(err, "creating subnet %q", subnetName)
 	}
 	return &subnet, nil
 }
 
 func newNetworkProfile(
+	callAPI callAPIFunc,
 	client network.ManagementClient,
 	vmName string,
 	apiPort *int,
@@ -195,8 +211,14 @@ func newNetworkProfile(
 		},
 	}
 	publicIPAddressName := vmName + "-public-ip"
-	publicIPAddress, err := pipClient.CreateOrUpdate(resourceGroup, publicIPAddressName, publicIPAddressParams)
-	if err != nil {
+	var publicIPAddress network.PublicIPAddress
+	if err := callAPI(func() (autorest.Response, error) {
+		var err error
+		publicIPAddress, err = pipClient.CreateOrUpdate(
+			resourceGroup, publicIPAddressName, publicIPAddressParams,
+		)
+		return publicIPAddress.Response, err
+	}); err != nil {
 		return nil, errors.Annotatef(err, "creating public IP address for %q", vmName)
 	}
 
@@ -227,8 +249,12 @@ func newNetworkProfile(
 			IPConfigurations: &ipConfigurations,
 		},
 	}
-	primaryNic, err := nicClient.CreateOrUpdate(resourceGroup, primaryNicName, primaryNicParams)
-	if err != nil {
+	var primaryNic network.Interface
+	if err := callAPI(func() (autorest.Response, error) {
+		var err error
+		primaryNic, err = nicClient.CreateOrUpdate(resourceGroup, primaryNicName, primaryNicParams)
+		return primaryNic.Response, err
+	}); err != nil {
 		return nil, errors.Annotatef(err, "creating network interface for %q", vmName)
 	}
 
@@ -238,8 +264,12 @@ func newNetworkProfile(
 		logger.Debugf("- querying network security group")
 		securityGroupClient := network.SecurityGroupsClient{client}
 		securityGroupName := internalSecurityGroupName
-		securityGroup, err := securityGroupClient.Get(resourceGroup, securityGroupName)
-		if err != nil {
+		var securityGroup network.SecurityGroup
+		if err := callAPI(func() (autorest.Response, error) {
+			var err error
+			securityGroup, err = securityGroupClient.Get(resourceGroup, securityGroupName)
+			return securityGroup.Response, err
+		}); err != nil {
 			return nil, errors.Annotate(err, "querying network security group")
 		}
 
@@ -274,10 +304,12 @@ func newNetworkProfile(
 		}
 		logger.Debugf("- creating API network security rule")
 		securityRuleClient := network.SecurityRulesClient{client}
-		_, err = securityRuleClient.CreateOrUpdate(
-			resourceGroup, securityGroupName, apiSecurityRuleName, apiSecurityRule,
-		)
-		if err != nil {
+		if err := callAPI(func() (autorest.Response, error) {
+			result, err := securityRuleClient.CreateOrUpdate(
+				resourceGroup, securityGroupName, apiSecurityRuleName, apiSecurityRule,
+			)
+			return result.Response, err
+		}); err != nil {
 			return nil, errors.Annotate(err, "creating API network security rule")
 		}
 	}

--- a/provider/azure/storage.go
+++ b/provider/azure/storage.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/Azure/azure-sdk-for-go/Godeps/_workspace/src/github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/azure-sdk-for-go/Godeps/_workspace/src/github.com/Azure/go-autorest/autorest/to"
 	"github.com/Azure/azure-sdk-for-go/arm/compute"
 	azurestorage "github.com/Azure/azure-sdk-for-go/storage"
@@ -591,7 +592,12 @@ func (v *azureVolumeSource) updateVirtualMachines(
 			results[i] = vm.err
 			continue
 		}
-		if _, err := vmsClient.CreateOrUpdate(v.env.resourceGroup, to.String(vm.vm.Name), *vm.vm); err != nil {
+		if err := v.env.callAPI(func() (autorest.Response, error) {
+			result, err := vmsClient.CreateOrUpdate(
+				v.env.resourceGroup, to.String(vm.vm.Name), *vm.vm,
+			)
+			return result.Response, err
+		}); err != nil {
 			results[i] = err
 			vm.err = err
 			continue

--- a/provider/azure/utils.go
+++ b/provider/azure/utils.go
@@ -5,9 +5,20 @@ package azure
 
 import (
 	"math/rand"
+	"net/http"
+	"time"
 
+	"github.com/Azure/azure-sdk-for-go/Godeps/_workspace/src/github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/azure-sdk-for-go/Godeps/_workspace/src/github.com/Azure/go-autorest/autorest/to"
+	"github.com/juju/retry"
 	"github.com/juju/utils"
+	"github.com/juju/utils/clock"
+)
+
+const (
+	retryDelay       = 5 * time.Second
+	maxRetryDelay    = 1 * time.Minute
+	maxRetryDuration = 5 * time.Minute
 )
 
 func toTagsPtr(tags map[string]string) *map[string]*string {
@@ -41,4 +52,40 @@ func randomAdminPassword() string {
 		password[i], password[j] = password[j], password[i]
 	}
 	return string(password)
+}
+
+// callAPIFunc is a function type that should wrap any any
+// Azure Resource Manager API calls.
+type callAPIFunc func(func() (autorest.Response, error)) error
+
+// backoffAPIRequestCaller is a type whose "call" method can
+// be used as a callAPIFunc.
+type backoffAPIRequestCaller struct {
+	clock clock.Clock
+}
+
+// call will call the supplied function, with exponential backoff
+// as long as the request returns an http.StatusTooManyRequests
+// status.
+func (c backoffAPIRequestCaller) call(f func() (autorest.Response, error)) error {
+	var resp *http.Response
+	return retry.Call(retry.CallArgs{
+		Func: func() error {
+			autorestResp, err := f()
+			resp = autorestResp.Response
+			return err
+		},
+		IsFatalError: func(err error) bool {
+			return resp == nil || !autorest.ResponseHasStatusCode(resp, http.StatusTooManyRequests)
+		},
+		NotifyFunc: func(err error, attempt int) {
+			logger.Debugf("attempt %d: %v", attempt, err)
+		},
+		Attempts:    -1,
+		Delay:       retryDelay,
+		MaxDelay:    maxRetryDelay,
+		MaxDuration: maxRetryDuration,
+		BackoffFunc: retry.DoubleDelay,
+		Clock:       c.clock,
+	})
 }

--- a/provider/azure/vmextension.go
+++ b/provider/azure/vmextension.go
@@ -1,6 +1,7 @@
 package azure
 
 import (
+	"github.com/Azure/azure-sdk-for-go/Godeps/_workspace/src/github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/azure-sdk-for-go/Godeps/_workspace/src/github.com/Azure/go-autorest/autorest/to"
 	"github.com/Azure/azure-sdk-for-go/arm/compute"
 	"github.com/juju/errors"
@@ -31,6 +32,7 @@ const (
 // createVMExtension creates a CustomScript VM extension for the given VM
 // which will execute the CustomData on the machine as a script.
 func createVMExtension(
+	callAPI callAPIFunc,
 	vmExtensionClient compute.VirtualMachineExtensionsClient,
 	os jujuos.OSType, resourceGroup, vmName, location string, vmTags map[string]string,
 ) error {
@@ -68,8 +70,11 @@ func createVMExtension(
 			Settings:                &extensionSettings,
 		},
 	}
-	_, err := vmExtensionClient.CreateOrUpdate(
-		resourceGroup, vmName, extensionName, extension,
-	)
+	err := callAPI(func() (autorest.Response, error) {
+		result, err := vmExtensionClient.CreateOrUpdate(
+			resourceGroup, vmName, extensionName, extension,
+		)
+		return result.Response, err
+	})
 	return err
 }

--- a/provider/azure/vmextension.go
+++ b/provider/azure/vmextension.go
@@ -54,8 +54,8 @@ func createVMExtension(
 		return errors.NotSupportedf("CustomScript extension for OS %q", os)
 	}
 
-	extensionSettings := map[string]*string{
-		"commandToExecute": to.StringPtr(commandToExecute),
+	extensionSettings := map[string]interface{}{
+		"commandToExecute": commandToExecute,
 	}
 	extension := compute.VirtualMachineExtension{
 		Location: to.StringPtr(location),

--- a/testing/clock.go
+++ b/testing/clock.go
@@ -227,3 +227,22 @@ func (s *StubClock) AfterFunc(d time.Duration, f func()) clock.Timer {
 	s.NextErr() // pop one off
 	return s.ReturnAfterFunc
 }
+
+// AutoAdvancingClock wraps a clock.Clock, calling the Advance
+// function whenever After or AfterFunc are called.
+type AutoAdvancingClock struct {
+	clock.Clock
+	Advance func(time.Duration)
+}
+
+func (c *AutoAdvancingClock) After(d time.Duration) <-chan time.Time {
+	ch := c.Clock.After(d)
+	c.Advance(d)
+	return ch
+}
+
+func (c *AutoAdvancingClock) AfterFunc(d time.Duration, f func()) clock.Timer {
+	t := c.Clock.AfterFunc(d, f)
+	c.Advance(d)
+	return t
+}


### PR DESCRIPTION
If Azure returns status code 429 (TooManyRequests), then that means we're
being rate-limited and we should back off and retry later. The 429
responses do not contain a Retry-After field, so we just use exponential
backoff starting at 5 seconds, going up to 1 minute between retries, with a
maximum of 5 minutes per API request.

Also updated Azure to the latest SDK.

Fixes https://bugs.launchpad.net/juju-core/+bug/1540394

(Review request: http://reviews.vapour.ws/r/4816/)