### PR TITLE
pass --sslPEMKeyPassword=ignored to mongo rather than --sslPEMKeyPass…

### DIFF
--- a/mongo/service.go
+++ b/mongo/service.go
@@ -142,7 +142,9 @@ func newConf(dataDir, dbDir, mongoPath string, port, oplogSizeMB int, wantNumaCt
 		" --dbpath " + utils.ShQuote(dbDir) +
 		" --sslOnNormalPorts" +
 		" --sslPEMKeyFile " + utils.ShQuote(sslKeyPath(dataDir)) +
-		" --sslPEMKeyPassword ignored" +
+		// --sslPEMKeyPassword has to have its argument passed with = thanks to
+		// https://bugs.launchpad.net/juju-core/+bug/1581284.
+		" --sslPEMKeyPassword=ignored" +
 		" --port " + fmt.Sprint(port) +
 		" --syslog" +
 		" --journal" +

--- a/mongo/service_test.go
+++ b/mongo/service_test.go
@@ -41,7 +41,7 @@ func (s *serviceSuite) TestNewConf(c *gc.C) {
 			" --dbpath '/var/lib/juju/db'" +
 			" --sslOnNormalPorts" +
 			" --sslPEMKeyFile '/var/lib/juju/server.pem'" +
-			" --sslPEMKeyPassword ignored" +
+			" --sslPEMKeyPassword=ignored" +
 			" --port 12345" +
 			" --syslog" +
 			" --journal" +


### PR DESCRIPTION
…word ignored

Only the former is accepted when mongo is built with boost 1.59 or newer, as is
the case on yakkety.

See bug #1581284