### PR TITLE
worker/metrics/*: cleanup

### DIFF
--- a/worker/metrics/collect/export_test.go
+++ b/worker/metrics/collect/export_test.go
@@ -34,7 +34,7 @@ var _ runner.Context = (*hookContext)(nil)
 
 type handlerSetterStopper interface {
 	SetHandler(spool.ConnectionHandler)
-	Stop()
+	Stop() error
 }
 
 func NewSocketListenerFnc(listener handlerSetterStopper) func(string, spool.ConnectionHandler) (stopper, error) {

--- a/worker/metrics/collect/handler_test.go
+++ b/worker/metrics/collect/handler_test.go
@@ -171,8 +171,9 @@ func (l *mockListener) trigger() (*mockConnection, error) {
 }
 
 // Stop implements the stopper interface.
-func (l *mockListener) Stop() {
+func (l *mockListener) Stop() error {
 	l.AddCall("Stop")
+	return nil
 }
 
 func (l *mockListener) SetHandler(handler spool.ConnectionHandler) {

--- a/worker/metrics/collect/manifold.go
+++ b/worker/metrics/collect/manifold.go
@@ -79,7 +79,7 @@ var (
 )
 
 type stopper interface {
-	Stop()
+	Stop() error
 }
 
 // ManifoldConfig identifies the resource names upon which the collect manifold

--- a/worker/metrics/sender/sender.go
+++ b/worker/metrics/sender/sender.go
@@ -24,7 +24,7 @@ const (
 )
 
 type stopper interface {
-	Stop()
+	Stop() error
 }
 
 type sender struct {
@@ -47,8 +47,7 @@ func (s *sender) Do(stop <-chan struct{}) error {
 func (s *sender) sendMetrics(reader spool.MetricReader) error {
 	batches, err := reader.Read()
 	if err != nil {
-		logger.Warningf("failed to open the metric reader: %v", err)
-		return errors.Trace(err)
+		return errors.Annotate(err, "failed to open the metric reader")
 	}
 	var sendBatches []params.MetricBatchParam
 	for _, batch := range batches {
@@ -56,20 +55,19 @@ func (s *sender) sendMetrics(reader spool.MetricReader) error {
 	}
 	results, err := s.client.AddMetricBatches(sendBatches)
 	if err != nil {
-		logger.Warningf("could not send metrics: %v", err)
-		return errors.Trace(err)
+		return errors.Annotate(err, "could not send metrics")
 	}
 	for batchUUID, resultErr := range results {
 		// if we fail to send any metric batch we log a warning with the assumption that
 		// the unsent metric batches remain in the spool directory and will be sent to the
 		// controller when the network partition is restored.
 		if _, ok := resultErr.(*params.Error); ok || params.IsCodeAlreadyExists(resultErr) {
-			err = reader.Remove(batchUUID)
+			err := reader.Remove(batchUUID)
 			if err != nil {
-				logger.Warningf("could not remove batch %q from spool: %v", batchUUID, err)
+				logger.Errorf("could not remove batch %q from spool: %v", batchUUID, err)
 			}
 		} else {
-			logger.Warningf("failed to send batch %q: %v", batchUUID, resultErr)
+			logger.Errorf("failed to send batch %q: %v", batchUUID, resultErr)
 		}
 	}
 	return nil
@@ -87,8 +85,7 @@ func (s *sender) Handle(c net.Conn) (err error) {
 		c.Close()
 	}()
 	// TODO(fwereade): 2016-03-17 lp:1558657
-	err = c.SetDeadline(time.Now().Add(spool.DefaultTimeout))
-	if err != nil {
+	if err := c.SetDeadline(time.Now().Add(spool.DefaultTimeout)); err != nil {
 		return errors.Annotate(err, "failed to set the deadline")
 	}
 	reader, err := s.factory.Reader()

--- a/worker/metrics/sender/sender_test.go
+++ b/worker/metrics/sender/sender_test.go
@@ -153,7 +153,7 @@ func (s *senderSuite) TestSendingFails(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	stopCh := make(chan struct{})
 	err = metricSender.Do(stopCh)
-	c.Assert(err, gc.ErrorMatches, "something went wrong")
+	c.Assert(err, gc.ErrorMatches, "could not send metrics: something went wrong")
 
 	c.Assert(apiSender.batches, gc.HasLen, 1)
 

--- a/worker/metrics/spool/listener.go
+++ b/worker/metrics/spool/listener.go
@@ -47,41 +47,27 @@ func NewSocketListener(socketPath string, handler ConnectionHandler) (*socketLis
 
 // Stop closes the listener and releases all resources
 // used by the socketListener.
-func (l *socketListener) Stop() {
+func (l *socketListener) Stop() error {
 	l.t.Kill(nil)
 	err := l.listener.Close()
 	if err != nil {
 		logger.Errorf("failed to close the collect-metrics listener: %v", err)
 	}
-	err = l.t.Wait()
-	if err != nil {
-		logger.Errorf("failed waiting for all goroutines to finish: %v", err)
-	}
+	return l.t.Wait()
 }
 
-func (l *socketListener) loop() (_err error) {
-	defer func() {
-		select {
-		case <-l.t.Dying():
-			_err = nil
-		default:
-		}
-	}()
+func (l *socketListener) loop() error {
 	for {
 		conn, err := l.listener.Accept()
 		if err != nil {
 			return errors.Trace(err)
 		}
-		go func() error {
-			err := l.handler.Handle(conn)
-			if err != nil {
-				// log the error and continue
+		go func() {
+			if err := l.handler.Handle(conn); err != nil {
 				logger.Errorf("request handling failed: %v", err)
 			}
-			return nil
 		}()
 	}
-	return
 }
 
 // NewPeriodicWorker returns a periodic worker, that will call a stop function

--- a/worker/metrics/spool/listener_test.go
+++ b/worker/metrics/spool/listener_test.go
@@ -20,7 +20,7 @@ import (
 var _ = gc.Suite(&listenerSuite{})
 
 type stopper interface {
-	Stop()
+	Stop() error
 }
 
 type listenerSuite struct {


### PR DESCRIPTION
Debugging for LP 1581157

Various cleanups to 

- stop logging _and_ returning errors
- stop logging errors at warning level
- simplify loop() to hopefully make it more robust.

(Review request: http://reviews.vapour.ws/r/4823/)