### PR TITLE
Fixed lp:1580417: Allow changing vpc-id for hosted AWS models

### DIFF
--- a/controller/modelmanager/createmodel_test.go
+++ b/controller/modelmanager/createmodel_test.go
@@ -314,7 +314,7 @@ func (*RestrictedProviderFieldsSuite) TestRestrictedProviderFields(c *gc.C) {
 		provider: "ec2",
 		expected: []string{
 			"type", "ca-cert", "state-port", "api-port", "controller-uuid",
-			"region", "vpc-id", "vpc-id-force",
+			"region", "vpc-id-force",
 		},
 	}} {
 		c.Logf("%d: %s provider", i, test.provider)

--- a/environs/jujutest/tests.go
+++ b/environs/jujutest/tests.go
@@ -57,12 +57,14 @@ func (t *Tests) Open(c *gc.C, cfg *config.Config) environs.Environ {
 // PrepareParams returns the environs.PrepareParams that will be used to call
 // environs.Prepare.
 func (t *Tests) PrepareParams(c *gc.C) environs.PrepareParams {
+	testConfigCopy := t.TestConfig.Merge(nil)
+
 	credential := t.Credential
 	if credential.AuthType() == "" {
 		credential = cloud.NewEmptyCredential()
 	}
 	return environs.PrepareParams{
-		BaseConfig:     t.TestConfig,
+		BaseConfig:     testConfigCopy,
 		Credential:     credential,
 		ControllerName: t.TestConfig["name"].(string),
 		CloudName:      t.TestConfig["type"].(string),

--- a/environs/jujutest/tests.go
+++ b/environs/jujutest/tests.go
@@ -88,7 +88,7 @@ func (t *Tests) PrepareWithParams(c *gc.C, params environs.PrepareParams) enviro
 
 func (t *Tests) AssertPrepareFailsWithConfig(c *gc.C, badConfig coretesting.Attrs, errorMatches string) error {
 	args := t.PrepareParams(c)
-	args.BaseConfig = badConfig
+	args.BaseConfig = coretesting.Attrs(args.BaseConfig).Merge(badConfig)
 
 	e, err := environs.Prepare(envtesting.BootstrapContext(c), t.ControllerStore, args)
 	c.Assert(err, gc.ErrorMatches, errorMatches)

--- a/provider/ec2/config.go
+++ b/provider/ec2/config.go
@@ -35,7 +35,7 @@ var configSchema = environschema.Fields{
 		Type:        environschema.Tstring,
 	},
 	"vpc-id": {
-		Description: "Use a specific AWS VPC ID (optional). When not specified, Juju requires a default VPC to exist the chosen EC2 account/region.",
+		Description: "Use a specific AWS VPC ID (optional). When not specified, Juju requires a default VPC or EC2-Classic features to be available for the account/region.",
 		Example:     "vpc-a1b2c3d4",
 		Type:        environschema.Tstring,
 		Group:       environschema.AccountGroup,

--- a/provider/ec2/config.go
+++ b/provider/ec2/config.go
@@ -130,9 +130,9 @@ func validateConfig(cfg, old *config.Config) (*environConfig, error) {
 		return nil, fmt.Errorf("invalid region name %q", ecfg.region())
 	}
 
-	if vpcID := ecfg.vpcID(); vpcID != "" && !isVPCIDValid(vpcID) {
+	if vpcID := ecfg.vpcID(); isVPCIDSetButInvalid(vpcID) {
 		return nil, fmt.Errorf("vpc-id: %q is not a valid AWS VPC ID", vpcID)
-	} else if vpcID == "" && ecfg.forceVPCID() {
+	} else if !isVPCIDSet(vpcID) && ecfg.forceVPCID() {
 		return nil, fmt.Errorf("cannot use vpc-id-force without specifying vpc-id as well")
 	}
 

--- a/provider/ec2/config.go
+++ b/provider/ec2/config.go
@@ -5,7 +5,6 @@ package ec2
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/juju/schema"
 	"gopkg.in/amz.v3/aws"
@@ -131,7 +130,7 @@ func validateConfig(cfg, old *config.Config) (*environConfig, error) {
 		return nil, fmt.Errorf("invalid region name %q", ecfg.region())
 	}
 
-	if vpcID := ecfg.vpcID(); vpcID != "" && !strings.HasPrefix(vpcID, "vpc-") {
+	if vpcID := ecfg.vpcID(); vpcID != "" && !isVPCIDValid(vpcID) {
 		return nil, fmt.Errorf("vpc-id: %q is not a valid AWS VPC ID", vpcID)
 	} else if vpcID == "" && ecfg.forceVPCID() {
 		return nil, fmt.Errorf("cannot use vpc-id-force without specifying vpc-id as well")

--- a/provider/ec2/config_test.go
+++ b/provider/ec2/config_test.go
@@ -172,6 +172,12 @@ var configTests = []configTest{
 		forceVPCID: false,
 	}, {
 		config: attrs{
+			"vpc-id": "none",
+		},
+		vpcID:      "none",
+		forceVPCID: false,
+	}, {
+		config: attrs{
 			"vpc-id": 42,
 		},
 		err:        `.*expected string, got int\(42\)`,

--- a/provider/ec2/config_test.go
+++ b/provider/ec2/config_test.go
@@ -172,7 +172,7 @@ var configTests = []configTest{
 		forceVPCID: false,
 	}, {
 		config: attrs{
-			"vpc-id": "none",
+			"vpc-id": vpcIDNone,
 		},
 		vpcID:      "none",
 		forceVPCID: false,
@@ -238,6 +238,16 @@ var configTests = []configTest{
 		err:        `.*cannot change vpc-id-force from true to false`,
 		vpcID:      "vpc-unchanged",
 		forceVPCID: true,
+	}, {
+		config: attrs{
+			"vpc-id": "",
+		},
+		change: attrs{
+			"vpc-id": "none",
+		},
+		err:        `.*cannot change vpc-id from "" to "none"`,
+		vpcID:      "",
+		forceVPCID: false,
 	}, {
 		config: attrs{
 			"vpc-id": "",

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -140,6 +140,14 @@ func (e *environ) ec2() *ec2.EC2 {
 	return ec2
 }
 
+func (e *environ) vpcAPIClient() vpcAPIClient {
+	ec2Client := e.ec2()
+	if ec2Client != nil {
+		return ec2Client
+	}
+	return nil
+}
+
 func (e *environ) Name() string {
 	return e.name
 }

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -1684,6 +1684,7 @@ func (e *environ) ensureGroup(name string, perms []ec2.IPPerm) (g ec2.SecurityGr
 	chosenVPCID := e.ecfg().vpcID()
 	inVPCLogSuffix := fmt.Sprintf(" (in VPC %q)", chosenVPCID)
 	if !isVPCIDSet(chosenVPCID) {
+		chosenVPCID = ""
 		inVPCLogSuffix = ""
 	}
 

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -140,14 +140,6 @@ func (e *environ) ec2() *ec2.EC2 {
 	return ec2
 }
 
-func (e *environ) vpcAPIClient() vpcAPIClient {
-	ec2Client := e.ec2()
-	if ec2Client != nil {
-		return ec2Client
-	}
-	return nil
-}
-
 func (e *environ) Name() string {
 	return e.name
 }

--- a/provider/ec2/environ_vpc.go
+++ b/provider/ec2/environ_vpc.go
@@ -280,7 +280,15 @@ func getVPCSubnets(apiClient vpcAPIClient, vpc *ec2.VPC) ([]ec2.Subnet, error) {
 
 func findFirstPublicSubnet(subnets []ec2.Subnet) (*ec2.Subnet, error) {
 	for _, subnet := range subnets {
-		if subnet.MapPublicIPOnLaunch {
+		// TODO(dimitern): goamz's AddDefaultVPCAndSubnets() does not set
+		// MapPublicIPOnLaunch only DefaultForAZ, but in reality the former is
+		// always set when the later is. Until this is fixed in goamz, we check
+		// for both below to allow testing the behavior.
+		if subnet.MapPublicIPOnLaunch || subnet.DefaultForAZ {
+			logger.Debugf(
+				"VPC %q subnet %q has MapPublicIPOnLaunch=%v, DefaultForAZ=%v",
+				subnet.VPCId, subnet.Id, subnet.MapPublicIPOnLaunch, subnet.DefaultForAZ,
+			)
 			return &subnet, nil
 		}
 

--- a/provider/ec2/environ_vpc.go
+++ b/provider/ec2/environ_vpc.go
@@ -491,7 +491,7 @@ func isVPCIDSet(vpcID string) bool {
 	return vpcID != "" && vpcID != vpcIDNone
 }
 
-func validateVPCBeforeBootstrap(apiClient vpcAPIClient, region, vpcID string, forceVPCID bool, ctx environs.BootstrapContext) error {
+func validateBootstrapVPC(apiClient vpcAPIClient, region, vpcID string, forceVPCID bool, ctx environs.BootstrapContext) error {
 	if vpcID == vpcIDNone {
 		ctx.Infof("Using EC2-classic features or default VPC in region %q", region)
 	}

--- a/provider/ec2/environ_vpc.go
+++ b/provider/ec2/environ_vpc.go
@@ -467,6 +467,10 @@ func findSubnetIDsForAvailabilityZone(zoneName string, subnetsToZones map[networ
 	return matchingSubnetIDs.SortedValues(), nil
 }
 
-func isVPCIDValid(vpcID string) bool {
-	return vpcID == vpcIDNone || strings.HasPrefix(vpcID, "vpc-")
+func isVPCIDSetButInvalid(vpcID string) bool {
+	return isVPCIDSet(vpcID) && !strings.HasPrefix(vpcID, "vpc-")
+}
+
+func isVPCIDSet(vpcID string) bool {
+	return vpcID != "" && vpcID != vpcIDNone
 }

--- a/provider/ec2/environ_vpc.go
+++ b/provider/ec2/environ_vpc.go
@@ -494,7 +494,7 @@ func isVPCIDSet(vpcID string) bool {
 func validateVPCBeforeBootstrap(env *environ, ctx environs.BootstrapContext) error {
 	vpcID, forceVPCID := env.ecfg().vpcID(), env.ecfg().forceVPCID()
 	if isVPCIDSet(vpcID) {
-		err := validateVPC(env.ec2(), vpcID)
+		err := validateVPC(env.vpcAPIClient(), vpcID)
 		switch {
 		case isVPCNotUsableError(err):
 			// VPC missing or has no subnets at all.
@@ -520,7 +520,7 @@ func validateVPCBeforeBootstrap(env *environ, ctx environs.BootstrapContext) err
 
 func validateVPCBeforeModelCreation(env *environ) error {
 	if vpcID := env.ecfg().vpcID(); isVPCIDSet(vpcID) {
-		err := validateVPC(env.ec2(), vpcID)
+		err := validateVPC(env.vpcAPIClient(), vpcID)
 		switch {
 		case isVPCNotUsableError(err):
 			// VPC missing or has no subnets at all.

--- a/provider/ec2/environ_vpc.go
+++ b/provider/ec2/environ_vpc.go
@@ -530,6 +530,13 @@ func validateVPCBeforeModelCreation(apiClient vpcAPIClient, modelName, vpcID str
 	case isVPCNotUsableError(err):
 		// VPC missing or has no subnets at all.
 		return errors.Annotate(err, vpcNotUsableForModelErrorPrefix)
+	case isVPCNotRecommendedError(err):
+		// VPC does not meet minumum validation criteria, but that's less
+		// important for hosted models, as the controller is already accessible.
+		logger.Warningf(
+			"Juju will use, but does not recommend using VPC %q: %v",
+			vpcID, err.Error(),
+		)
 	case err != nil:
 		// Anything else unexpected while validating the VPC.
 		return errors.Annotate(err, cannotValidateVPCErrorPrefix)

--- a/provider/ec2/environ_vpc.go
+++ b/provider/ec2/environ_vpc.go
@@ -491,46 +491,50 @@ func isVPCIDSet(vpcID string) bool {
 	return vpcID != "" && vpcID != vpcIDNone
 }
 
-func validateVPCBeforeBootstrap(env *environ, ctx environs.BootstrapContext) error {
-	vpcID, forceVPCID := env.ecfg().vpcID(), env.ecfg().forceVPCID()
-	if isVPCIDSet(vpcID) {
-		err := validateVPC(env.vpcAPIClient(), vpcID)
-		switch {
-		case isVPCNotUsableError(err):
-			// VPC missing or has no subnets at all.
-			return errors.Annotate(err, vpcNotUsableForBootstrapErrorPrefix)
-		case isVPCNotRecommendedError(err):
-			// VPC does not meet minumum validation criteria.
-			if !forceVPCID {
-				return errors.Annotatef(err, vpcNotRecommendedErrorPrefix, vpcID)
-			}
-			ctx.Infof(vpcNotRecommendedButForcedWarning)
-		case err != nil:
-			// Anything else unexpected while validating the VPC.
-			return errors.Annotate(err, cannotValidateVPCErrorPrefix)
-		}
-
-		ctx.Infof("Using VPC %q in region %q", vpcID, env.ecfg().region())
-	} else if vpcID == vpcIDNone {
-		ctx.Infof("Using EC2-classic features or default VPC in region %q", env.ecfg().region())
+func validateVPCBeforeBootstrap(apiClient vpcAPIClient, region, vpcID string, forceVPCID bool, ctx environs.BootstrapContext) error {
+	if vpcID == vpcIDNone {
+		ctx.Infof("Using EC2-classic features or default VPC in region %q", region)
 	}
+	if !isVPCIDSet(vpcID) {
+		return nil
+	}
+
+	err := validateVPC(apiClient, vpcID)
+	switch {
+	case isVPCNotUsableError(err):
+		// VPC missing or has no subnets at all.
+		return errors.Annotate(err, vpcNotUsableForBootstrapErrorPrefix)
+	case isVPCNotRecommendedError(err):
+		// VPC does not meet minumum validation criteria.
+		if !forceVPCID {
+			return errors.Annotatef(err, vpcNotRecommendedErrorPrefix, vpcID)
+		}
+		ctx.Infof(vpcNotRecommendedButForcedWarning)
+	case err != nil:
+		// Anything else unexpected while validating the VPC.
+		return errors.Annotate(err, cannotValidateVPCErrorPrefix)
+	}
+
+	ctx.Infof("Using VPC %q in region %q", vpcID, region)
 
 	return nil
 }
 
-func validateVPCBeforeModelCreation(env *environ) error {
-	if vpcID := env.ecfg().vpcID(); isVPCIDSet(vpcID) {
-		err := validateVPC(env.vpcAPIClient(), vpcID)
-		switch {
-		case isVPCNotUsableError(err):
-			// VPC missing or has no subnets at all.
-			return errors.Annotate(err, vpcNotUsableForModelErrorPrefix)
-		case err != nil:
-			// Anything else unexpected while validating the VPC.
-			return errors.Annotate(err, cannotValidateVPCErrorPrefix)
-		}
-		logger.Infof("Using VPC %q in region %q for model %q", vpcID, env.ecfg().region(), env.Name())
+func validateVPCBeforeModelCreation(apiClient vpcAPIClient, modelName, vpcID string) error {
+	if !isVPCIDSet(vpcID) {
+		return nil
 	}
+
+	err := validateVPC(apiClient, vpcID)
+	switch {
+	case isVPCNotUsableError(err):
+		// VPC missing or has no subnets at all.
+		return errors.Annotate(err, vpcNotUsableForModelErrorPrefix)
+	case err != nil:
+		// Anything else unexpected while validating the VPC.
+		return errors.Annotate(err, cannotValidateVPCErrorPrefix)
+	}
+	logger.Infof("Using VPC %q for model %q", vpcID, modelName)
 
 	return nil
 }

--- a/provider/ec2/environ_vpc.go
+++ b/provider/ec2/environ_vpc.go
@@ -520,7 +520,7 @@ func validateBootstrapVPC(apiClient vpcAPIClient, region, vpcID string, forceVPC
 	return nil
 }
 
-func validateVPCBeforeModelCreation(apiClient vpcAPIClient, modelName, vpcID string) error {
+func validateModelVPC(apiClient vpcAPIClient, modelName, vpcID string) error {
 	if !isVPCIDSet(vpcID) {
 		return nil
 	}

--- a/provider/ec2/environ_vpc.go
+++ b/provider/ec2/environ_vpc.go
@@ -18,7 +18,7 @@ const (
 	availableState        = "available"
 	localRouteGatewayID   = "local"
 	defaultRouteCIDRBlock = "0.0.0.0/0"
-	defaultVPCIDNone      = "none"
+	vpcIDNone             = "none"
 )
 
 var (
@@ -412,7 +412,7 @@ func findDefaultVPCID(apiClient vpcAPIClient) (string, error) {
 	}
 
 	firstAttributeValue := response.Attributes[0].Values[0]
-	if firstAttributeValue == defaultVPCIDNone {
+	if firstAttributeValue == vpcIDNone {
 		return "", errors.NotFoundf("default VPC")
 	}
 

--- a/provider/ec2/environ_vpc.go
+++ b/provider/ec2/environ_vpc.go
@@ -33,7 +33,7 @@ Error details`[1:]
 
 	vpcNotUsableForModelErrorPrefix = `
 Juju cannot use the given vpc-id for the model being added.
-Please, double check the given VPC ID is correct, and that
+Please double check the given VPC ID is correct, and that
 the VPC contains at least one subnet.
 
 Error details`[1:]

--- a/provider/ec2/environ_vpc.go
+++ b/provider/ec2/environ_vpc.go
@@ -5,6 +5,7 @@ package ec2
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/juju/errors"
 	"github.com/juju/utils/set"
@@ -464,4 +465,8 @@ func findSubnetIDsForAvailabilityZone(zoneName string, subnetsToZones map[networ
 	}
 
 	return matchingSubnetIDs.SortedValues(), nil
+}
+
+func isVPCIDValid(vpcID string) bool {
+	return vpcID == vpcIDNone || strings.HasPrefix(vpcID, "vpc-")
 }

--- a/provider/ec2/environ_vpc.go
+++ b/provider/ec2/environ_vpc.go
@@ -290,7 +290,7 @@ func findFirstPublicSubnet(subnets []ec2.Subnet) (*ec2.Subnet, error) {
 	for _, subnet := range subnets {
 		// TODO(dimitern): goamz's AddDefaultVPCAndSubnets() does not set
 		// MapPublicIPOnLaunch only DefaultForAZ, but in reality the former is
-		// always set when the later is. Until this is fixed in goamz, we check
+		// always set when the latter is. Until this is fixed in goamz, we check
 		// for both below to allow testing the behavior.
 		if subnet.MapPublicIPOnLaunch || subnet.DefaultForAZ {
 			logger.Debugf(

--- a/provider/ec2/environ_vpc_test.go
+++ b/provider/ec2/environ_vpc_test.go
@@ -30,7 +30,7 @@ func (s *vpcSuite) SetUpTest(c *gc.C) {
 	s.stubAPI = &stubVPCAPIClient{Stub: &testing.Stub{}}
 }
 
-func (s *vpcSuite) TestValidateVPCBeforeBootstrapUnexpectedError(c *gc.C) {
+func (s *vpcSuite) TestValidateBootstrapVPCUnexpectedError(c *gc.C) {
 	s.stubAPI.SetErrors(errors.New("AWS failed!"))
 
 	err := validateBootstrapVPC(s.stubAPI, "region", anyVPCID, false, envtesting.BootstrapContext(c))

--- a/provider/ec2/environ_vpc_test.go
+++ b/provider/ec2/environ_vpc_test.go
@@ -44,7 +44,7 @@ func (*vpcSuite) checkErrorMatchesCannotVerifyVPC(c *gc.C, err error) {
 	c.Check(err, gc.ErrorMatches, expectedError)
 }
 
-func (s *vpcSuite) TestValidateVPCBeforeModelCreationUnexpectedError(c *gc.C) {
+func (s *vpcSuite) TestValidateModelVPCUnexpectedError(c *gc.C) {
 	s.stubAPI.SetErrors(errors.New("AWS failed!"))
 
 	err := validateModelVPC(s.stubAPI, "model", anyVPCID)
@@ -53,7 +53,7 @@ func (s *vpcSuite) TestValidateVPCBeforeModelCreationUnexpectedError(c *gc.C) {
 	s.stubAPI.CheckCallNames(c, "VPCs")
 }
 
-func (s *vpcSuite) TestValidateVPCBeforeModelCreationVPCNotUsableError(c *gc.C) {
+func (s *vpcSuite) TestValidateModelVPCNotUsableError(c *gc.C) {
 	s.stubAPI.SetErrors(makeVPCNotFoundError("foo"))
 
 	err := validateModelVPC(s.stubAPI, "model", "foo")
@@ -64,7 +64,7 @@ func (s *vpcSuite) TestValidateVPCBeforeModelCreationVPCNotUsableError(c *gc.C) 
 	s.stubAPI.CheckCallNames(c, "VPCs")
 }
 
-func (s *vpcSuite) TestValidateVPCBeforeModelCreationVPCIDNotSetOrNone(c *gc.C) {
+func (s *vpcSuite) TestValidateModelVPCIDNotSetOrNone(c *gc.C) {
 	const emptyVPCID = ""
 	err := validateModelVPC(s.stubAPI, "model", emptyVPCID)
 	c.Check(err, jc.ErrorIsNil)
@@ -169,7 +169,7 @@ func (s *vpcSuite) TestValidateVPCSuccess(c *gc.C) {
 	s.stubAPI.CheckCallNames(c, "VPCs", "Subnets", "InternetGateways", "RouteTables")
 }
 
-func (s *vpcSuite) TestValidateVPCBeforeModelCreationSuccess(c *gc.C) {
+func (s *vpcSuite) TestValidateModelVPCSuccess(c *gc.C) {
 	s.stubAPI.PrepareValidateVPCResponses()
 
 	err := validateModelVPC(s.stubAPI, "model", anyVPCID)
@@ -179,7 +179,7 @@ func (s *vpcSuite) TestValidateVPCBeforeModelCreationSuccess(c *gc.C) {
 	c.Check(c.GetTestLog(), jc.Contains, `INFO juju.provider.ec2 Using VPC "vpc-anything" for model "model"`)
 }
 
-func (s *vpcSuite) TestValidateVPCBeforeModelCreationVPCNotRecommendedStillOK(c *gc.C) {
+func (s *vpcSuite) TestValidateModelVPCNotRecommendedStillOK(c *gc.C) {
 	s.stubAPI.PrepareValidateVPCResponses()
 	s.stubAPI.SetSubnetsResponse(1, anyZone, noPublicIPOnLaunch)
 

--- a/provider/ec2/environ_vpc_test.go
+++ b/provider/ec2/environ_vpc_test.go
@@ -33,7 +33,7 @@ func (s *vpcSuite) SetUpTest(c *gc.C) {
 func (s *vpcSuite) TestValidateVPCBeforeBootstrapUnexpectedError(c *gc.C) {
 	s.stubAPI.SetErrors(errors.New("AWS failed!"))
 
-	err := validateVPCBeforeBootstrap(s.stubAPI, "region", anyVPCID, false, envtesting.BootstrapContext(c))
+	err := validateBootstrapVPC(s.stubAPI, "region", anyVPCID, false, envtesting.BootstrapContext(c))
 	s.checkErrorMatchesCannotVerifyVPC(c, err)
 
 	s.stubAPI.CheckCallNames(c, "VPCs")

--- a/provider/ec2/export_test.go
+++ b/provider/ec2/export_test.go
@@ -57,7 +57,11 @@ var (
 	RunInstances                = &runInstances
 	BlockDeviceNamer            = blockDeviceNamer
 	GetBlockDeviceMappings      = getBlockDeviceMappings
+	IsVPCNotUsableError         = isVPCNotUsableError
+	IsVPCNotRecommendedError    = isVPCNotRecommendedError
 )
+
+const VPCIDNone = vpcIDNone
 
 // BucketStorage returns a storage instance addressing
 // an arbitrary s3 bucket.

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -268,22 +268,61 @@ func (t *localServerSuite) prepareEnviron(c *gc.C) environs.NetworkingEnviron {
 }
 
 func (t *localServerSuite) TestPrepareForBootstrapWithInvalidVPCID(c *gc.C) {
-	badLocalConfigAttrs := localConfigAttrs.Merge(coretesting.Attrs{
-		"vpc-id": "bad",
-	})
+	badVPCIDConfig := coretesting.Attrs{"vpc-id": "bad"}
 
 	expectedError := `invalid EC2 provider config: vpc-id: "bad" is not a valid AWS VPC ID`
-	t.AssertPrepareFailsWithConfig(c, badLocalConfigAttrs, expectedError)
+	t.AssertPrepareFailsWithConfig(c, badVPCIDConfig, expectedError)
+}
+
+func (t *localServerSuite) TestPrepareForBootstrapWithUnknownVPCID(c *gc.C) {
+	unknownVPCIDConfig := coretesting.Attrs{"vpc-id": "vpc-unknown"}
+
+	expectedError := `Juju cannot use the given vpc-id for bootstrapping(.|\n)*Error details: VPC "vpc-unknown" not found`
+	err := t.AssertPrepareFailsWithConfig(c, unknownVPCIDConfig, expectedError)
+	c.Check(err, jc.Satisfies, ec2.IsVPCNotUsableError)
+}
+
+func (t *localServerSuite) TestPrepareForBootstrapWithNotRecommendedVPCID(c *gc.C) {
+	t.makeTestingDefaultVPCUnavailable(c)
+	notRecommendedVPCIDConfig := coretesting.Attrs{"vpc-id": t.srv.defaultVPC.Id}
+
+	expectedError := `The given vpc-id does not meet one or more(.|\n)*Error details: VPC has unexpected state "unavailable"`
+	err := t.AssertPrepareFailsWithConfig(c, notRecommendedVPCIDConfig, expectedError)
+	c.Check(err, jc.Satisfies, ec2.IsVPCNotRecommendedError)
+}
+
+func (t *localServerSuite) makeTestingDefaultVPCUnavailable(c *gc.C) {
+	// For simplicity, here the test server's default VPC is updated to change
+	// its state to unavailable, we just verify the behavior of a "not
+	// recommended VPC".
+	t.srv.defaultVPC.State = "unavailable"
+	err := t.srv.ec2srv.UpdateVPC(*t.srv.defaultVPC)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (t *localServerSuite) TestPrepareForBootstrapWithNotRecommendedButForcedVPCID(c *gc.C) {
+	t.makeTestingDefaultVPCUnavailable(c)
+	params := t.PrepareParams(c)
+	params.BaseConfig["vpc-id"] = t.srv.defaultVPC.Id
+	params.BaseConfig["vpc-id-force"] = true
+
+	t.prepareWithParamsAndBootstrapWithVPCID(c, params, t.srv.defaultVPC.Id)
 }
 
 func (t *localServerSuite) TestPrepareForBootstrapWithEmptyVPCID(c *gc.C) {
-	params := t.PrepareParams(c)
-	params.BaseConfig["vpc-id"] = ""
+	const emptyVPCID = ""
 
+	params := t.PrepareParams(c)
+	params.BaseConfig["vpc-id"] = emptyVPCID
+
+	t.prepareWithParamsAndBootstrapWithVPCID(c, params, emptyVPCID)
+}
+
+func (t *localServerSuite) prepareWithParamsAndBootstrapWithVPCID(c *gc.C, params environs.PrepareParams, expectedVPCID string) {
 	env := t.PrepareWithParams(c, params)
 	unknownAttrs := env.Config().UnknownAttrs()
 	vpcID, ok := unknownAttrs["vpc-id"]
-	c.Check(vpcID, gc.Equals, "")
+	c.Check(vpcID, gc.Equals, expectedVPCID)
 	c.Check(ok, jc.IsTrue)
 
 	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{})
@@ -294,26 +333,14 @@ func (t *localServerSuite) TestPrepareForBootstrapWithVPCIDNone(c *gc.C) {
 	params := t.PrepareParams(c)
 	params.BaseConfig["vpc-id"] = "none"
 
-	env := t.PrepareWithParams(c, params)
-	unknownAttrs := env.Config().UnknownAttrs()
-	vpcID, ok := unknownAttrs["vpc-id"]
-	c.Check(vpcID, gc.Equals, ec2.VPCIDNone)
-	c.Check(ok, jc.IsTrue)
-
-	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, bootstrap.BootstrapParams{})
-	c.Assert(err, jc.ErrorIsNil)
+	t.prepareWithParamsAndBootstrapWithVPCID(c, params, ec2.VPCIDNone)
 }
 
 func (t *localServerSuite) TestPrepareForBootstrapWithDefaultVPCID(c *gc.C) {
+	params := t.PrepareParams(c)
+	params.BaseConfig["vpc-id"] = t.srv.defaultVPC.Id
 
-}
-
-func (t *localServerSuite) TestPrepareForBootstrapWithNotRecommendedVPCID(c *gc.C) {
-
-}
-
-func (t *localServerSuite) TestPrepareForBootstrapWithNotUsableVPCID(c *gc.C) {
-
+	t.prepareWithParamsAndBootstrapWithVPCID(c, params, t.srv.defaultVPC.Id)
 }
 
 func (t *localServerSuite) TestSystemdBootstrapInstanceUserDataAndState(c *gc.C) {

--- a/provider/ec2/provider.go
+++ b/provider/ec2/provider.go
@@ -27,6 +27,8 @@ var providerInstance environProvider
 
 // RestrictedConfigAttributes is specified in the EnvironProvider interface.
 func (p environProvider) RestrictedConfigAttributes() []string {
+	// TODO(dimitern): Both of these shouldn't be restricted for hosted models.
+	// See bug http://pad.lv/1580417 for more information.
 	return []string{"region", "vpc-id-force"}
 }
 

--- a/provider/ec2/provider.go
+++ b/provider/ec2/provider.go
@@ -111,7 +111,7 @@ func (p environProvider) PrepareForBootstrap(
 
 	apiClient, ecfg := env.ec2(), env.ecfg()
 	region, vpcID, forceVPCID := ecfg.region(), ecfg.vpcID(), ecfg.forceVPCID()
-	if err := validateVPCBeforeBootstrap(apiClient, region, vpcID, forceVPCID, ctx); err != nil {
+	if err := validateBootstrapVPC(apiClient, region, vpcID, forceVPCID, ctx); err != nil {
 		return nil, errors.Trace(err)
 	}
 

--- a/provider/ec2/provider.go
+++ b/provider/ec2/provider.go
@@ -40,7 +40,8 @@ func (p environProvider) PrepareForCreateEnvironment(cfg *config.Config) (*confi
 	}
 	env := e.(*environ)
 
-	if err := validateVPCBeforeModelCreation(env); err != nil {
+	apiClient, modelName, vpcID := env.ec2(), env.Name(), env.ecfg().vpcID()
+	if err := validateVPCBeforeModelCreation(apiClient, modelName, vpcID); err != nil {
 		return nil, errors.Trace(err)
 	}
 
@@ -108,7 +109,9 @@ func (p environProvider) PrepareForBootstrap(
 		}
 	}
 
-	if err := validateVPCBeforeBootstrap(env, ctx); err != nil {
+	apiClient, ecfg := env.ec2(), env.ecfg()
+	region, vpcID, forceVPCID := ecfg.region(), ecfg.vpcID(), ecfg.forceVPCID()
+	if err := validateVPCBeforeBootstrap(apiClient, region, vpcID, forceVPCID, ctx); err != nil {
 		return nil, errors.Trace(err)
 	}
 

--- a/provider/ec2/provider.go
+++ b/provider/ec2/provider.go
@@ -27,7 +27,7 @@ var providerInstance environProvider
 
 // RestrictedConfigAttributes is specified in the EnvironProvider interface.
 func (p environProvider) RestrictedConfigAttributes() []string {
-	return []string{"region", "vpc-id", "vpc-id-force"}
+	return []string{"region", "vpc-id-force"}
 }
 
 // PrepareForCreateEnvironment is specified in the EnvironProvider interface.

--- a/provider/ec2/provider.go
+++ b/provider/ec2/provider.go
@@ -96,7 +96,7 @@ func (p environProvider) PrepareForBootstrap(
 	}
 
 	vpcID, forceVPCID := env.ecfg().vpcID(), env.ecfg().forceVPCID()
-	if vpcID != "" {
+	if isVPCIDSet(vpcID) {
 		err := validateVPC(env.ec2(), vpcID)
 		switch {
 		case isVPCNotUsableError(err):
@@ -114,6 +114,8 @@ func (p environProvider) PrepareForBootstrap(
 		}
 
 		ctx.Infof("Using VPC %q in region %q", vpcID, env.ecfg().region())
+	} else if vpcID == vpcIDNone {
+		ctx.Infof("Using EC2-classic features or default VPC in region %q", env.ecfg().region())
 	}
 
 	return e, nil

--- a/provider/ec2/provider.go
+++ b/provider/ec2/provider.go
@@ -41,7 +41,7 @@ func (p environProvider) PrepareForCreateEnvironment(cfg *config.Config) (*confi
 	env := e.(*environ)
 
 	apiClient, modelName, vpcID := env.ec2(), env.Name(), env.ecfg().vpcID()
-	if err := validateVPCBeforeModelCreation(apiClient, modelName, vpcID); err != nil {
+	if err := validateModelVPC(apiClient, modelName, vpcID); err != nil {
 		return nil, errors.Trace(err)
 	}
 

--- a/provider/openstack/firewaller.go
+++ b/provider/openstack/firewaller.go
@@ -282,7 +282,11 @@ func deleteSecurityGroup(novaclient *nova.Client, name, id string) {
 		},
 		Attempts: 30,
 		Delay:    time.Second,
-		Clock:    clock.WallClock,
+		// TODO(dimitern): This should be fixed to take a clock.Clock arg, not
+		// hard-coded WallClock, like in provider/ec2/securitygroups_test.go!
+		// See PR juju:#5197, especially the code around autoAdvancingClock.
+		// LP Bug: http://pad.lv/1580626.
+		Clock: clock.WallClock,
 	})
 	if err != nil {
 		logger.Warningf("cannot delete security group %q. Used by another model?", name)


### PR DESCRIPTION
Follow-up on #5309 which introduced the ability to use a user-specified
VPC ID when bootstrapping, thus fixing http://pad.lv/1321442. This PR
allows passing --config vpc-id=vpc-xyz to `juju add-model` to change the
VPC to use, rather than always use the controller model's VPC.

Additionally, vpc-id now can be set to 'none' for both `juju bootstrap`
and `juju add-model` to explicitly request EC2-Classic or default VPC to
be used, if supported. Validation is performed for the specified VPC ID,
but less strict for add-model than for bootstrap. Also, 'vpc-id-force'
config setting is not accepted for add-model (yet), since having an
accessible controller already allows hosted models' instances to connect
to the API endpoint of controller and report its status.

See bug http://pad.lv/1580417 for details.

Live tested extensively on AWS with a controller and multiple hosted
models, using different vpc-id settings (or none).

(Review request: http://reviews.vapour.ws/r/4824/)