### PR TITLE
container/lxd: drop the need for a discrete LXD profile per container launched

### DIFF
--- a/container/lxd/export_test.go
+++ b/container/lxd/export_test.go
@@ -6,5 +6,5 @@
 package lxd
 
 var (
-	NICProperties = nicProperties
+	NICDevice = nicDevice
 )

--- a/container/lxd/lxd.go
+++ b/container/lxd/lxd.go
@@ -11,7 +11,6 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names"
-	"github.com/lxc/lxd"
 
 	"github.com/juju/juju/cloudconfig/containerinit"
 	"github.com/juju/juju/cloudconfig/instancecfg"
@@ -26,6 +25,8 @@ var (
 	logger = loggo.GetLogger("juju.container.lxd")
 )
 
+const lxdDefaultProfileName = "default"
+
 // XXX: should we allow managing containers on other hosts? this is
 // functionality LXD gives us and from discussion juju would use eventually for
 // the local provider, so the APIs probably need to be changed to pass extra
@@ -34,8 +35,6 @@ type containerManager struct {
 	name string
 	// A cached client.
 	client *lxdclient.Client
-	// Custom network profile
-	networkProfile string
 }
 
 // containerManager implements container.Manager.
@@ -84,7 +83,6 @@ func (manager *containerManager) CreateContainer(
 
 	defer func() {
 		if err != nil {
-			manager.deleteNetworkProfile()
 			callback(status.StatusProvisioningError, fmt.Sprintf("Creating container: %v", err), nil)
 		}
 	}()
@@ -127,40 +125,32 @@ func (manager *containerManager) CreateContainer(
 		"boot.autostart": "true",
 	}
 
-	networkProfile := fmt.Sprintf("%s-network", name)
+	nics, err := networkDevices(networkConfig)
+	if err != nil {
+		return
+	}
 
-	if len(networkConfig.Interfaces) > 0 || networkConfig.Device != "" {
-		if err = createNetworkProfile(manager.client, networkProfile); err != nil {
-			return
-		}
+	profiles := []string{}
 
-		manager.networkProfile = networkProfile
-		if len(networkConfig.Interfaces) > 0 {
-			err = networkProfileAddMultipleInterfaces(manager.client, networkProfile, networkConfig.Interfaces)
-		} else {
-			err = networkProfileAddSingleInterface(manager.client, networkProfile, networkConfig.Device, networkConfig.MTU)
-		}
-		if err != nil {
-			return
-		}
+	if len(nics) == 0 {
+		logger.Infof("instance %q configured with %q profile", name, lxdDefaultProfileName)
+		profiles = append(profiles, lxdDefaultProfileName)
 	} else {
-		networkProfile = "default"
+		logger.Infof("instance %q configured with %v network devices", name, nics)
 	}
 
 	spec := lxdclient.InstanceSpec{
 		Name:     name,
 		Image:    manager.client.ImageNameForSeries(series),
 		Metadata: metadata,
-		Profiles: []string{
-			networkProfile,
-		},
+		Devices:  nics,
+		Profiles: profiles,
 	}
 
 	logger.Infof("starting instance %q (image %q)...", spec.Name, spec.Image)
 	callback(status.StatusProvisioning, "Starting container", nil)
 	_, err = manager.client.AddInstance(spec)
 	if err != nil {
-		manager.client.ProfileDelete(networkProfile)
 		return
 	}
 
@@ -177,7 +167,6 @@ func (manager *containerManager) DestroyContainer(id instance.Id) error {
 			return err
 		}
 	}
-	manager.deleteNetworkProfile()
 	return errors.Trace(manager.client.RemoveInstances(manager.name, string(id)))
 }
 
@@ -220,95 +209,59 @@ func HasLXDSupport() bool {
 	return true
 }
 
-func nicProperties(parentDevice, deviceName, hwAddr string, mtu int) ([]string, error) {
-	var props = []string{"nictype=bridged"}
+func nicDevice(deviceName, parentDevice, hwAddr string, mtu int) (lxdclient.Device, error) {
+	device := make(lxdclient.Device)
 
-	if parentDevice == "" {
-		return nil, errors.Errorf("invalid parent device")
-	} else {
-		props = append(props, fmt.Sprintf("parent=%v", parentDevice))
-	}
+	device["type"] = "nic"
+	device["nictype"] = "bridged"
 
 	if deviceName == "" {
 		return nil, errors.Errorf("invalid device name")
 	} else {
-		props = append(props, fmt.Sprintf("name=%v", deviceName))
+		device["name"] = deviceName
+	}
+
+	if parentDevice == "" {
+		return nil, errors.Errorf("invalid parent device name")
+	} else {
+		device["parent"] = parentDevice
 	}
 
 	if hwAddr != "" {
-		props = append(props, fmt.Sprintf("hwaddr=%v", hwAddr))
+		device["hwaddr"] = hwAddr
 	}
 
 	if mtu > 0 {
-		props = append(props, fmt.Sprintf("mtu=%v", mtu))
+		device["mtu"] = fmt.Sprintf("%v", mtu)
 	}
 
-	return props, nil
+	return device, nil
 }
 
-func addNetworkDeviceToProfile(client *lxdclient.Client, profile, parentDevice, deviceName, hwAddr string, mtu int) (*lxd.Response, error) {
-	props, err := nicProperties(parentDevice, deviceName, hwAddr, mtu)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	logger.Infof("adding nic device %q with properties %+v to profile %q", deviceName, props, profile)
-	return client.ProfileDeviceAdd(profile, deviceName, "nic", props)
-}
+func networkDevices(networkConfig *container.NetworkConfig) (lxdclient.Devices, error) {
+	nics := make(lxdclient.Devices)
 
-func networkProfileAddSingleInterface(client *lxdclient.Client, profile, deviceName string, mtu int) error {
-	_, err := addNetworkDeviceToProfile(client, profile, deviceName, "eth0", "", mtu)
-	return errors.Trace(err)
-}
-
-func networkProfileAddMultipleInterfaces(client *lxdclient.Client, profile string, interfaces []network.InterfaceInfo) error {
-	for _, v := range interfaces {
-		if v.InterfaceType == network.LoopbackInterface {
-			continue
+	if len(networkConfig.Interfaces) > 0 {
+		for _, v := range networkConfig.Interfaces {
+			if v.InterfaceType == network.LoopbackInterface {
+				continue
+			}
+			if v.InterfaceType != network.EthernetInterface {
+				return nil, errors.Errorf("interface type %q not supported", v.InterfaceType)
+			}
+			device, err := nicDevice(v.InterfaceName, v.ParentInterfaceName, v.MACAddress, v.MTU)
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			nics[v.InterfaceName] = device
 		}
-
-		if v.InterfaceType != network.EthernetInterface {
-			return errors.Errorf("interface type %q not supported", v.InterfaceType)
-		}
-
-		_, err := addNetworkDeviceToProfile(client, profile, v.ParentInterfaceName, v.InterfaceName, v.MACAddress, v.MTU)
-
+	} else if networkConfig.Device != "" {
+		device, err := nicDevice("eth0", networkConfig.Device, "", networkConfig.MTU)
 		if err != nil {
-			return errors.Trace(err)
+			return nil, errors.Trace(err)
 		}
+		nics["eth0"] = device
 	}
 
-	return nil
-}
-
-func createNetworkProfile(client *lxdclient.Client, profile string) error {
-	found, err := client.HasProfile(profile)
-
-	if err != nil {
-		return errors.Trace(err)
-	}
-
-	if found {
-		logger.Infof("deleting existing container profile %q", profile)
-		if err := client.ProfileDelete(profile); err != nil {
-			return errors.Trace(err)
-		}
-	}
-
-	err = client.CreateProfile(profile, nil)
-
-	if err == nil {
-		logger.Infof("created new network container profile %q", profile)
-	}
-
-	return errors.Trace(err)
-}
-
-func (manager *containerManager) deleteNetworkProfile() {
-	if manager.client != nil && manager.networkProfile != "" {
-		logger.Infof("deleting container network profile %q", manager.networkProfile)
-		if err := manager.client.ProfileDelete(manager.networkProfile); err != nil {
-			logger.Warningf("discarding profile delete error: %v", err)
-		}
-		manager.networkProfile = ""
-	}
+	return nics, nil
 }

--- a/container/lxd/lxd_test.go
+++ b/container/lxd/lxd_test.go
@@ -94,54 +94,66 @@ func (t *LxdSuite) TestNotAllContainersAreDeleted(c *gc.C) {
 	}
 }
 
-func (t *LxdSuite) TestNICPropertiesWithInvalidParentDevice(c *gc.C) {
-	props, err := lxd.NICProperties("", "eth1", "", 0)
-	c.Assert(props, gc.IsNil)
-	c.Assert(err.Error(), gc.Equals, "invalid parent device")
-}
-
-func (t *LxdSuite) TestNICPropertiesWithInvalidDeviceName(c *gc.C) {
-	props, err := lxd.NICProperties("testbr1", "", "", 0)
-	c.Assert(props, gc.IsNil)
+func (t *LxdSuite) TestNICDeviceWithInvalidDeviceName(c *gc.C) {
+	device, err := lxd.NICDevice("", "br-eth1", "", 0)
+	c.Assert(device, gc.IsNil)
 	c.Assert(err.Error(), gc.Equals, "invalid device name")
 }
 
-func (t *LxdSuite) TestNICPropertiesWithoutMACAddressOrMTUGreaterThanZero(c *gc.C) {
-	props, err := lxd.NICProperties("testbr1", "eth1", "", 0)
-	c.Assert(err, gc.IsNil)
-	c.Assert(props, gc.HasLen, 3)
-	c.Assert(props[0], gc.Equals, "nictype=bridged")
-	c.Assert(props[1], gc.Equals, "parent=testbr1")
-	c.Assert(props[2], gc.Equals, "name=eth1")
+func (t *LxdSuite) TestNICDeviceWithInvalidParentDeviceName(c *gc.C) {
+	device, err := lxd.NICDevice("eth0", "", "", 0)
+	c.Assert(device, gc.IsNil)
+	c.Assert(err.Error(), gc.Equals, "invalid parent device name")
 }
 
-func (t *LxdSuite) TestNICPropertiesWithMACAddressButNoMTU(c *gc.C) {
-	props, err := lxd.NICProperties("testbr1", "eth1", "aa:bb:cc:dd:ee:f0", 0)
+func (t *LxdSuite) TestNICDeviceWithoutMACAddressOrMTUGreaterThanZero(c *gc.C) {
+	device, err := lxd.NICDevice("eth1", "br-eth1", "", 0)
 	c.Assert(err, gc.IsNil)
-	c.Assert(props, gc.HasLen, 4)
-	c.Assert(props[0], gc.Equals, "nictype=bridged")
-	c.Assert(props[1], gc.Equals, "parent=testbr1")
-	c.Assert(props[2], gc.Equals, "name=eth1")
-	c.Assert(props[3], gc.Equals, "hwaddr=aa:bb:cc:dd:ee:f0")
+	expected := lxdclient.Device{
+		"name":    "eth1",
+		"nictype": "bridged",
+		"parent":  "br-eth1",
+		"type":    "nic",
+	}
+	c.Assert(device, gc.DeepEquals, expected)
 }
 
-func (t *LxdSuite) TestNICPropertiesWithoutMACAddressButMTUGreaterThanZero(c *gc.C) {
-	props, err := lxd.NICProperties("testbr1", "eth1", "", 1492)
+func (t *LxdSuite) TestNICDeviceWithMACAddressButNoMTU(c *gc.C) {
+	device, err := lxd.NICDevice("eth1", "br-eth1", "aa:bb:cc:dd:ee:f0", 0)
 	c.Assert(err, gc.IsNil)
-	c.Assert(props, gc.HasLen, 4)
-	c.Assert(props[0], gc.Equals, "nictype=bridged")
-	c.Assert(props[1], gc.Equals, "parent=testbr1")
-	c.Assert(props[2], gc.Equals, "name=eth1")
-	c.Assert(props[3], gc.Equals, "mtu=1492")
+	expected := lxdclient.Device{
+		"hwaddr":  "aa:bb:cc:dd:ee:f0",
+		"name":    "eth1",
+		"nictype": "bridged",
+		"parent":  "br-eth1",
+		"type":    "nic",
+	}
+	c.Assert(device, gc.DeepEquals, expected)
 }
 
-func (t *LxdSuite) TestNICPropertiesWithMACAddressAndMTUGreaterThanZero(c *gc.C) {
-	props, err := lxd.NICProperties("testbr1", "eth1", "aa:bb:cc:dd:ee:f0", 1066)
+func (t *LxdSuite) TestNICDeviceWithoutMACAddressButMTUGreaterThanZero(c *gc.C) {
+	device, err := lxd.NICDevice("eth1", "br-eth1", "", 1492)
 	c.Assert(err, gc.IsNil)
-	c.Assert(props, gc.HasLen, 5)
-	c.Assert(props[0], gc.Equals, "nictype=bridged")
-	c.Assert(props[1], gc.Equals, "parent=testbr1")
-	c.Assert(props[2], gc.Equals, "name=eth1")
-	c.Assert(props[3], gc.Equals, "hwaddr=aa:bb:cc:dd:ee:f0")
-	c.Assert(props[4], gc.Equals, "mtu=1066")
+	expected := lxdclient.Device{
+		"mtu":     "1492",
+		"name":    "eth1",
+		"nictype": "bridged",
+		"parent":  "br-eth1",
+		"type":    "nic",
+	}
+	c.Assert(device, gc.DeepEquals, expected)
+}
+
+func (t *LxdSuite) TestNICDeviceWithMACAddressAndMTUGreaterThanZero(c *gc.C) {
+	device, err := lxd.NICDevice("eth1", "br-eth1", "aa:bb:cc:dd:ee:f0", 9000)
+	c.Assert(err, gc.IsNil)
+	expected := lxdclient.Device{
+		"hwaddr":  "aa:bb:cc:dd:ee:f0",
+		"mtu":     "9000",
+		"name":    "eth1",
+		"nictype": "bridged",
+		"parent":  "br-eth1",
+		"type":    "nic",
+	}
+	c.Assert(device, gc.DeepEquals, expected)
 }

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -42,7 +42,7 @@ github.com/juju/webbrowser	git	54b8c57083b4afb7dc75da7f13e2967b2606a507	2016-03-
 github.com/juju/xml	git	eb759a627588d35166bc505fceb51b88500e291e	2015-04-13T13:11:21Z
 github.com/juju/zip	git	f6b1e93fa2e29a1d7d49b566b2b51efb060c982a	2016-02-05T10:52:21Z
 github.com/julienschmidt/httprouter	git	77a895ad01ebc98a4dc95d8355bc825ce80a56f6	2015-10-13T22:55:20Z
-github.com/lxc/lxd	git	62f62e9d6e0da14947023f99764eac29c26cef8d	2016-03-28T00:14:48Z
+github.com/lxc/lxd	git	ba236f15fd862ffe588ed9349ea8bf0ff87f68d4	2016-05-09T16:40:25Z
 github.com/mattn/go-runewidth	git	d96d1bd051f2bd9e7e43d602782b37b93b1b5666	2015-11-18T07:21:59Z
 golang.org/x/crypto	git	aedad9a179ec1ea11b7064c57cbc6dc30d7724ec	2015-08-30T18:06:42Z
 golang.org/x/net	git	ea47fc708ee3e20177f3ca3716217c4ab75942cb	2015-08-29T23:03:18Z

--- a/tools/lxdclient/instance.go
+++ b/tools/lxdclient/instance.go
@@ -76,6 +76,9 @@ type InstanceSpec struct {
 	// Metadata is the instance metadata.
 	Metadata map[string]string
 
+	// Devices to be added at container initialisation time
+	Devices
+
 	// TODO(ericsnow) Other possible fields:
 	// Disks
 	// Networks


### PR DESCRIPTION
We were previously creating a new LXD profile for each container that was started. If you started 100 containers you would see 100 discrete profiles listed when using $(lxc profile list). This is a poor user experience. This change creates the network devices when the container is initialised and because they are attached directly to the container's configuration no discrete profile is required.

Fixes [LP:#1580964](https://bugs.launchpad.net/juju-core/+bug/1580964)

(Review request: http://reviews.vapour.ws/r/4826/)