### PR TITLE
Add providerIDs collection and use it for spaces

### DIFF
--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -297,6 +297,7 @@ func allCollections() collectionSchema {
 				Key: []string{"model-uuid", "subnetid"},
 			}},
 		},
+		// TODO(dimitern): End of obsolete networking collections.
 		providerIDsC: {
 			indexes: []mgo.Index{{
 				Key:    []string{"providerid"},

--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -298,13 +298,8 @@ func allCollections() collectionSchema {
 			}},
 		},
 		// TODO(dimitern): End of obsolete networking collections.
-		providerIDsC: {
-			indexes: []mgo.Index{{
-				Key:    []string{"providerid"},
-				Unique: true,
-			}},
-		},
-		spacesC: {},
+		providerIDsC: {},
+		spacesC:      {},
 		subnetsC: {
 			indexes: []mgo.Index{{
 				Key:    []string{"providerid"},

--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -303,13 +303,31 @@ func allCollections() collectionSchema {
 				Unique: true,
 			}},
 		},
-		spacesC:               {},
-		subnetsC:              {},
-		linkLayerDevicesC:     {},
+		spacesC: {},
+		subnetsC: {
+			indexes: []mgo.Index{{
+				Key:    []string{"providerid"},
+				Unique: true,
+				Sparse: true,
+			}},
+		},
+		linkLayerDevicesC: {
+			indexes: []mgo.Index{{
+				Key:    []string{"providerid"},
+				Unique: true,
+				Sparse: true,
+			}},
+		},
 		linkLayerDevicesRefsC: {},
-		ipAddressesC:          {},
-		endpointBindingsC:     {},
-		openedPortsC:          {},
+		ipAddressesC: {
+			indexes: []mgo.Index{{
+				Key:    []string{"providerid"},
+				Unique: true,
+				Sparse: true,
+			}},
+		},
+		endpointBindingsC: {},
+		openedPortsC:      {},
 
 		// -----
 

--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -297,38 +297,19 @@ func allCollections() collectionSchema {
 				Key: []string{"model-uuid", "subnetid"},
 			}},
 		},
-		// TODO(dimitern): End of obsolete networking collections.
-		spacesC: {
+		providerIDsC: {
 			indexes: []mgo.Index{{
 				Key:    []string{"providerid"},
 				Unique: true,
-				Sparse: true,
 			}},
 		},
-		subnetsC: {
-			indexes: []mgo.Index{{
-				Key:    []string{"providerid"},
-				Unique: true,
-				Sparse: true,
-			}},
-		},
-		linkLayerDevicesC: {
-			indexes: []mgo.Index{{
-				Key:    []string{"providerid"},
-				Unique: true,
-				Sparse: true,
-			}},
-		},
+		spacesC:               {},
+		subnetsC:              {},
+		linkLayerDevicesC:     {},
 		linkLayerDevicesRefsC: {},
-		ipAddressesC: {
-			indexes: []mgo.Index{{
-				Key:    []string{"providerid"},
-				Unique: true,
-				Sparse: true,
-			}},
-		},
-		endpointBindingsC: {},
-		openedPortsC:      {},
+		ipAddressesC:          {},
+		endpointBindingsC:     {},
+		openedPortsC:          {},
 
 		// -----
 
@@ -430,6 +411,7 @@ const (
 	modelsC                  = "models"
 	modelEntityRefsC         = "modelEntityRefs"
 	openedPortsC             = "openedPorts"
+	providerIDsC             = "providerIDs"
 	rebootC                  = "reboot"
 	relationScopesC          = "relationscopes"
 	relationsC               = "relations"

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -140,6 +140,7 @@ func (s *MigrationSuite) TestKnownCollections(c *gc.C) {
 
 		// network
 		ipAddressesC,
+		providerIDsC,
 		linkLayerDevicesC,
 		linkLayerDevicesRefsC,
 		subnetsC,

--- a/state/spaces.go
+++ b/state/spaces.go
@@ -111,6 +111,7 @@ func (st *State) AddSpace(name string, providerId network.Id, subnets []string, 
 			C:      providerIDsC,
 			Id:     key,
 			Assert: txn.DocMissing,
+			Insert: providerIdDoc{},
 		})
 	}
 

--- a/state/spaces.go
+++ b/state/spaces.go
@@ -56,7 +56,7 @@ func (s *Space) Name() string {
 // ProviderId returns the provider id of the space. This will be the empty
 // string except on substrates that directly support spaces.
 func (s *Space) ProviderId() network.Id {
-	return network.Id(s.st.localID(s.doc.ProviderId))
+	return network.Id(s.doc.ProviderId)
 }
 
 // Subnets returns all the subnets associated with the Space.
@@ -105,7 +105,6 @@ func (st *State) AddSpace(name string, providerId network.Id, subnets []string, 
 		Insert: spaceDoc,
 	}}
 
-	// XXX should this be first?
 	if providerId != "" {
 		key := fmt.Sprintf("%v:space#%v", st.ModelUUID(), providerId)
 		ops = append(ops, txn.Op{

--- a/state/spaces.go
+++ b/state/spaces.go
@@ -136,19 +136,19 @@ func (st *State) AddSpace(name string, providerId network.Id, subnets []string, 
 				return nil, err
 			}
 		}
+		if err := newSpace.Refresh(); err != nil {
+			if errors.IsNotFound(err) {
+				return nil, errors.Errorf("ProviderId %q not unique", providerId)
+			}
+			return nil, errors.Trace(err)
+		}
+		return nil, errors.Trace(err)
 	} else if err != nil {
 		return nil, err
 	}
 
 	// If the ProviderId was not unique adding the space can fail without an
 	// error. Refreshing catches this by returning NotFoundError.
-	err = newSpace.Refresh()
-	if err != nil {
-		if errors.IsNotFound(err) {
-			return nil, errors.Errorf("ProviderId %q not unique", providerId)
-		}
-		return nil, errors.Trace(err)
-	}
 
 	return newSpace, nil
 }

--- a/state/spaces.go
+++ b/state/spaces.go
@@ -4,8 +4,6 @@
 package state
 
 import (
-	"fmt"
-
 	"github.com/juju/errors"
 	"github.com/juju/names"
 	"gopkg.in/mgo.v2"
@@ -28,9 +26,6 @@ type spaceDoc struct {
 	Name       string `bson:"name"`
 	IsPublic   bool   `bson:"is-public"`
 	ProviderId string `bson:"providerid,omitempty"`
-}
-
-type providerIdDoc struct {
 }
 
 // Life returns whether the space is Alive, Dying or Dead.
@@ -106,13 +101,7 @@ func (st *State) AddSpace(name string, providerId network.Id, subnets []string, 
 	}}
 
 	if providerId != "" {
-		key := fmt.Sprintf("%v:space#%v", st.ModelUUID(), providerId)
-		ops = append(ops, txn.Op{
-			C:      providerIDsC,
-			Id:     key,
-			Assert: txn.DocMissing,
-			Insert: providerIdDoc{},
-		})
+		ops = append(ops, st.networkEntityGlobalKeyOp("space", providerId))
 	}
 
 	for _, subnetId := range subnets {

--- a/state/spaces.go
+++ b/state/spaces.go
@@ -146,10 +146,6 @@ func (st *State) AddSpace(name string, providerId network.Id, subnets []string, 
 	} else if err != nil {
 		return nil, err
 	}
-
-	// If the ProviderId was not unique adding the space can fail without an
-	// error. Refreshing catches this by returning NotFoundError.
-
 	return newSpace, nil
 }
 

--- a/state/state.go
+++ b/state/state.go
@@ -2404,12 +2404,12 @@ func (st *State) setMongoSpaceState(mongoSpaceState MongoSpaceStates) error {
 }
 
 func (st *State) networkEntityGlobalKeyOp(globalKey string, providerId network.Id) txn.Op {
-	key := globalKey + ":" + string(providerId)
+	key := st.docID(globalKey + ":" + string(providerId))
 	return txn.Op{
 		C:      providerIDsC,
-		Id:     st.docID(key),
+		Id:     key,
 		Assert: txn.DocMissing,
-		Insert: providerIdDoc{},
+		Insert: providerIdDoc{ID: key},
 	}
 }
 

--- a/state/state.go
+++ b/state/state.go
@@ -68,6 +68,10 @@ const (
 	singularControllerNamespace = "singular-controller"
 )
 
+type providerIdDoc struct {
+	ID string `bson:"_id"` // format: "<model-uuid>:<global-key>:<provider-id>"
+}
+
 // State represents the state of an model
 // managed by juju.
 type State struct {
@@ -2397,6 +2401,16 @@ func (st *State) setMongoSpaceState(mongoSpaceState MongoSpaceStates) error {
 	}}
 
 	return st.runTransaction(ops)
+}
+
+func (st *State) networkEntityGlobalKeyOp(globalKey string, providerId network.Id) txn.Op {
+	key := globalKey + ":" + string(providerId)
+	return txn.Op{
+		C:      providerIDsC,
+		Id:     st.docID(key),
+		Assert: txn.DocMissing,
+		Insert: providerIdDoc{},
+	}
 }
 
 var tagPrefix = map[byte]string{


### PR DESCRIPTION
Instead of using provider ID mangled by model UUID for uniqueness use a providerIDs collection instead. Only spaces converted to use it so far.

(Review request: http://reviews.vapour.ws/r/4827/)