### PR TITLE
Use the provider ids collection for Subnets

### DIFF
--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -297,6 +297,7 @@ func allCollections() collectionSchema {
 				Key: []string{"model-uuid", "subnetid"},
 			}},
 		},
+		// TODO(dimitern): End of obsolete networking collections.
 		providerIDsC: {
 			indexes: []mgo.Index{{
 				Key:    []string{"providerid"},

--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -298,13 +298,8 @@ func allCollections() collectionSchema {
 			}},
 		},
 		// TODO(dimitern): End of obsolete networking collections.
-		providerIDsC: {
-			indexes: []mgo.Index{{
-				Key:    []string{"providerid"},
-				Unique: true,
-			}},
-		},
-		spacesC: {},
+		providerIDsC: {},
+		spacesC:      {},
 		subnetsC: {
 			indexes: []mgo.Index{{
 				Key:    []string{"providerid"},

--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -300,13 +300,7 @@ func allCollections() collectionSchema {
 		// TODO(dimitern): End of obsolete networking collections.
 		providerIDsC: {},
 		spacesC:      {},
-		subnetsC: {
-			indexes: []mgo.Index{{
-				Key:    []string{"providerid"},
-				Unique: true,
-				Sparse: true,
-			}},
-		},
+		subnetsC:     {},
 		linkLayerDevicesC: {
 			indexes: []mgo.Index{{
 				Key:    []string{"providerid"},

--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -301,6 +301,8 @@ func allCollections() collectionSchema {
 		providerIDsC: {},
 		spacesC:      {},
 		subnetsC:     {},
+		// TODO(mfoord): remove providerid indices here and switch to
+		// using providerIDsC to track unique provider ids.
 		linkLayerDevicesC: {
 			indexes: []mgo.Index{{
 				Key:    []string{"providerid"},

--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -303,13 +303,31 @@ func allCollections() collectionSchema {
 				Unique: true,
 			}},
 		},
-		spacesC:               {},
-		subnetsC:              {},
-		linkLayerDevicesC:     {},
+		spacesC: {},
+		subnetsC: {
+			indexes: []mgo.Index{{
+				Key:    []string{"providerid"},
+				Unique: true,
+				Sparse: true,
+			}},
+		},
+		linkLayerDevicesC: {
+			indexes: []mgo.Index{{
+				Key:    []string{"providerid"},
+				Unique: true,
+				Sparse: true,
+			}},
+		},
 		linkLayerDevicesRefsC: {},
-		ipAddressesC:          {},
-		endpointBindingsC:     {},
-		openedPortsC:          {},
+		ipAddressesC: {
+			indexes: []mgo.Index{{
+				Key:    []string{"providerid"},
+				Unique: true,
+				Sparse: true,
+			}},
+		},
+		endpointBindingsC: {},
+		openedPortsC:      {},
 
 		// -----
 

--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -297,38 +297,19 @@ func allCollections() collectionSchema {
 				Key: []string{"model-uuid", "subnetid"},
 			}},
 		},
-		// TODO(dimitern): End of obsolete networking collections.
-		spacesC: {
+		providerIDsC: {
 			indexes: []mgo.Index{{
 				Key:    []string{"providerid"},
 				Unique: true,
-				Sparse: true,
 			}},
 		},
-		subnetsC: {
-			indexes: []mgo.Index{{
-				Key:    []string{"providerid"},
-				Unique: true,
-				Sparse: true,
-			}},
-		},
-		linkLayerDevicesC: {
-			indexes: []mgo.Index{{
-				Key:    []string{"providerid"},
-				Unique: true,
-				Sparse: true,
-			}},
-		},
+		spacesC:               {},
+		subnetsC:              {},
+		linkLayerDevicesC:     {},
 		linkLayerDevicesRefsC: {},
-		ipAddressesC: {
-			indexes: []mgo.Index{{
-				Key:    []string{"providerid"},
-				Unique: true,
-				Sparse: true,
-			}},
-		},
-		endpointBindingsC: {},
-		openedPortsC:      {},
+		ipAddressesC:          {},
+		endpointBindingsC:     {},
+		openedPortsC:          {},
 
 		// -----
 
@@ -430,6 +411,7 @@ const (
 	modelsC                  = "models"
 	modelEntityRefsC         = "modelEntityRefs"
 	openedPortsC             = "openedPorts"
+	providerIDsC             = "providerIDs"
 	rebootC                  = "reboot"
 	relationScopesC          = "relationscopes"
 	relationsC               = "relations"

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -140,6 +140,7 @@ func (s *MigrationSuite) TestKnownCollections(c *gc.C) {
 
 		// network
 		ipAddressesC,
+		providerIDsC,
 		linkLayerDevicesC,
 		linkLayerDevicesRefsC,
 		subnetsC,

--- a/state/spaces.go
+++ b/state/spaces.go
@@ -111,6 +111,7 @@ func (st *State) AddSpace(name string, providerId network.Id, subnets []string, 
 			C:      providerIDsC,
 			Id:     key,
 			Assert: txn.DocMissing,
+			Insert: providerIdDoc{},
 		})
 	}
 

--- a/state/spaces.go
+++ b/state/spaces.go
@@ -56,7 +56,7 @@ func (s *Space) Name() string {
 // ProviderId returns the provider id of the space. This will be the empty
 // string except on substrates that directly support spaces.
 func (s *Space) ProviderId() network.Id {
-	return network.Id(s.st.localID(s.doc.ProviderId))
+	return network.Id(s.doc.ProviderId)
 }
 
 // Subnets returns all the subnets associated with the Space.
@@ -105,7 +105,6 @@ func (st *State) AddSpace(name string, providerId network.Id, subnets []string, 
 		Insert: spaceDoc,
 	}}
 
-	// XXX should this be first?
 	if providerId != "" {
 		key := fmt.Sprintf("%v:space#%v", st.ModelUUID(), providerId)
 		ops = append(ops, txn.Op{

--- a/state/spaces.go
+++ b/state/spaces.go
@@ -136,19 +136,19 @@ func (st *State) AddSpace(name string, providerId network.Id, subnets []string, 
 				return nil, err
 			}
 		}
+		if err := newSpace.Refresh(); err != nil {
+			if errors.IsNotFound(err) {
+				return nil, errors.Errorf("ProviderId %q not unique", providerId)
+			}
+			return nil, errors.Trace(err)
+		}
+		return nil, errors.Trace(err)
 	} else if err != nil {
 		return nil, err
 	}
 
 	// If the ProviderId was not unique adding the space can fail without an
 	// error. Refreshing catches this by returning NotFoundError.
-	err = newSpace.Refresh()
-	if err != nil {
-		if errors.IsNotFound(err) {
-			return nil, errors.Errorf("ProviderId %q not unique", providerId)
-		}
-		return nil, errors.Trace(err)
-	}
 
 	return newSpace, nil
 }

--- a/state/spaces.go
+++ b/state/spaces.go
@@ -4,8 +4,6 @@
 package state
 
 import (
-	"fmt"
-
 	"github.com/juju/errors"
 	"github.com/juju/names"
 	"gopkg.in/mgo.v2"
@@ -28,9 +26,6 @@ type spaceDoc struct {
 	Name       string `bson:"name"`
 	IsPublic   bool   `bson:"is-public"`
 	ProviderId string `bson:"providerid,omitempty"`
-}
-
-type providerIdDoc struct {
 }
 
 // Life returns whether the space is Alive, Dying or Dead.
@@ -106,13 +101,7 @@ func (st *State) AddSpace(name string, providerId network.Id, subnets []string, 
 	}}
 
 	if providerId != "" {
-		key := fmt.Sprintf("%v:space#%v", st.ModelUUID(), providerId)
-		ops = append(ops, txn.Op{
-			C:      providerIDsC,
-			Id:     key,
-			Assert: txn.DocMissing,
-			Insert: providerIdDoc{},
-		})
+		ops = append(ops, st.networkEntityGlobalKeyOp("space", providerId))
 	}
 
 	for _, subnetId := range subnets {

--- a/state/spaces.go
+++ b/state/spaces.go
@@ -146,10 +146,6 @@ func (st *State) AddSpace(name string, providerId network.Id, subnets []string, 
 	} else if err != nil {
 		return nil, err
 	}
-
-	// If the ProviderId was not unique adding the space can fail without an
-	// error. Refreshing catches this by returning NotFoundError.
-
 	return newSpace, nil
 }
 

--- a/state/state.go
+++ b/state/state.go
@@ -1641,100 +1641,6 @@ func (st *State) DeadIPAddresses() ([]*IPAddress, error) {
 	return fetchIPAddresses(st, isDeadDoc)
 }
 
-// AddSubnet creates and returns a new subnet
-func (st *State) AddSubnet(args SubnetInfo) (subnet *Subnet, err error) {
-	defer errors.DeferredAnnotatef(&err, "adding subnet %q", args.CIDR)
-
-	subnetID := st.docID(args.CIDR)
-	var modelLocalProviderID string
-	if args.ProviderId != "" {
-		modelLocalProviderID = st.docID(string(args.ProviderId))
-	}
-
-	subDoc := subnetDoc{
-		DocID:             subnetID,
-		ModelUUID:         st.ModelUUID(),
-		Life:              Alive,
-		CIDR:              args.CIDR,
-		VLANTag:           args.VLANTag,
-		ProviderId:        modelLocalProviderID,
-		AllocatableIPHigh: args.AllocatableIPHigh,
-		AllocatableIPLow:  args.AllocatableIPLow,
-		AvailabilityZone:  args.AvailabilityZone,
-		SpaceName:         args.SpaceName,
-	}
-	subnet = &Subnet{doc: subDoc, st: st}
-	err = subnet.Validate()
-	if err != nil {
-		return nil, err
-	}
-	ops := []txn.Op{
-		assertModelActiveOp(st.ModelUUID()),
-		{
-			C:      subnetsC,
-			Id:     subnetID,
-			Assert: txn.DocMissing,
-			Insert: subDoc,
-		},
-	}
-
-	err = st.runTransaction(ops)
-	switch err {
-	case txn.ErrAborted:
-		if err := checkModelActive(st); err != nil {
-			return nil, errors.Trace(err)
-		}
-		if _, err = st.Subnet(args.CIDR); err == nil {
-			return nil, errors.AlreadyExistsf("subnet %q", args.CIDR)
-		} else if err != nil {
-			return nil, errors.Trace(err)
-		}
-	case nil:
-		// If the ProviderId was not unique adding the subnet can fail without
-		// an error. Refreshing catches this by returning NotFoundError.
-		err = subnet.Refresh()
-		if err != nil {
-			if errors.IsNotFound(err) {
-				return nil, errors.Errorf("ProviderId %q not unique", args.ProviderId)
-			}
-			return nil, errors.Trace(err)
-		}
-		return subnet, nil
-	}
-	return nil, errors.Trace(err)
-}
-
-func (st *State) Subnet(cidr string) (*Subnet, error) {
-	subnets, closer := st.getCollection(subnetsC)
-	defer closer()
-
-	doc := &subnetDoc{}
-	err := subnets.FindId(cidr).One(doc)
-	if err == mgo.ErrNotFound {
-		return nil, errors.NotFoundf("subnet %q", cidr)
-	}
-	if err != nil {
-		return nil, errors.Annotatef(err, "cannot get subnet %q", cidr)
-	}
-	return &Subnet{st, *doc}, nil
-}
-
-// AllSubnets returns all known subnets in the model.
-func (st *State) AllSubnets() (subnets []*Subnet, err error) {
-	subnetsCollection, closer := st.getCollection(subnetsC)
-	defer closer()
-
-	docs := []subnetDoc{}
-	err = subnetsCollection.Find(nil).All(&docs)
-	if err != nil {
-		return nil, errors.Annotatef(err, "cannot get all subnets")
-	}
-	for _, doc := range docs {
-		subnets = append(subnets, &Subnet{st, doc})
-	}
-	return subnets, nil
-}
-
 // Service returns a service state by name.
 func (st *State) Service(name string) (service *Service, err error) {
 	services, closer := st.getCollection(servicesC)
@@ -2404,13 +2310,17 @@ func (st *State) setMongoSpaceState(mongoSpaceState MongoSpaceStates) error {
 }
 
 func (st *State) networkEntityGlobalKeyOp(globalKey string, providerId network.Id) txn.Op {
-	key := st.docID(globalKey + ":" + string(providerId))
+	key := st.networkEntityGlobalKey(globalKey, providerId)
 	return txn.Op{
 		C:      providerIDsC,
 		Id:     key,
 		Assert: txn.DocMissing,
 		Insert: providerIdDoc{ID: key},
 	}
+}
+
+func (st *State) networkEntityGlobalKey(globalKey string, providerId network.Id) string {
+	return st.docID(globalKey + ":" + string(providerId))
 }
 
 var tagPrefix = map[byte]string{

--- a/state/state.go
+++ b/state/state.go
@@ -2404,12 +2404,12 @@ func (st *State) setMongoSpaceState(mongoSpaceState MongoSpaceStates) error {
 }
 
 func (st *State) networkEntityGlobalKeyOp(globalKey string, providerId network.Id) txn.Op {
-	key := globalKey + ":" + string(providerId)
+	key := st.docID(globalKey + ":" + string(providerId))
 	return txn.Op{
 		C:      providerIDsC,
-		Id:     st.docID(key),
+		Id:     key,
 		Assert: txn.DocMissing,
-		Insert: providerIdDoc{},
+		Insert: providerIdDoc{ID: key},
 	}
 }
 

--- a/state/state.go
+++ b/state/state.go
@@ -68,6 +68,10 @@ const (
 	singularControllerNamespace = "singular-controller"
 )
 
+type providerIdDoc struct {
+	ID string `bson:"_id"` // format: "<model-uuid>:<global-key>:<provider-id>"
+}
+
 // State represents the state of an model
 // managed by juju.
 type State struct {
@@ -2397,6 +2401,16 @@ func (st *State) setMongoSpaceState(mongoSpaceState MongoSpaceStates) error {
 	}}
 
 	return st.runTransaction(ops)
+}
+
+func (st *State) networkEntityGlobalKeyOp(globalKey string, providerId network.Id) txn.Op {
+	key := globalKey + ":" + string(providerId)
+	return txn.Op{
+		C:      providerIDsC,
+		Id:     st.docID(key),
+		Assert: txn.DocMissing,
+		Insert: providerIdDoc{},
+	}
 }
 
 var tagPrefix = map[byte]string{

--- a/state/subnets.go
+++ b/state/subnets.go
@@ -425,6 +425,7 @@ func (st *State) AddSubnet(args SubnetInfo) (subnet *Subnet, err error) {
 	return subnet, nil
 }
 
+// Subnet returns the subnet specified by the cidr.
 func (st *State) Subnet(cidr string) (*Subnet, error) {
 	subnets, closer := st.getCollection(subnetsC)
 	defer closer()


### PR DESCRIPTION
Instead of storing a model local provider id subnets now use the providerIDs collection.

(Review request: http://reviews.vapour.ws/r/4838/)