### PR TITLE
network: Fix "private|public no address" errors and use better naming.

### DIFF
--- a/apiserver/client/client_test.go
+++ b/apiserver/client/client_test.go
@@ -742,9 +742,9 @@ func (s *clientSuite) TestClientPublicAddressErrors(c *gc.C) {
 	_, err := s.APIState.Client().PublicAddress("wordpress")
 	c.Assert(err, gc.ErrorMatches, `unknown unit or machine "wordpress"`)
 	_, err = s.APIState.Client().PublicAddress("0")
-	c.Assert(err, gc.ErrorMatches, `error fetching address for machine "0": public no address`)
+	c.Assert(err, gc.ErrorMatches, `error fetching address for machine "0": no public address`)
 	_, err = s.APIState.Client().PublicAddress("wordpress/0")
-	c.Assert(err, gc.ErrorMatches, `error fetching address for unit "wordpress/0": public no address`)
+	c.Assert(err, gc.ErrorMatches, `error fetching address for unit "wordpress/0": no public address`)
 }
 
 func (s *clientSuite) TestClientPublicAddressMachine(c *gc.C) {
@@ -785,9 +785,9 @@ func (s *clientSuite) TestClientPrivateAddressErrors(c *gc.C) {
 	_, err := s.APIState.Client().PrivateAddress("wordpress")
 	c.Assert(err, gc.ErrorMatches, `unknown unit or machine "wordpress"`)
 	_, err = s.APIState.Client().PrivateAddress("0")
-	c.Assert(err, gc.ErrorMatches, `error fetching address for machine "0": private no address`)
+	c.Assert(err, gc.ErrorMatches, `error fetching address for machine "0": no private address`)
 	_, err = s.APIState.Client().PrivateAddress("wordpress/0")
-	c.Assert(err, gc.ErrorMatches, `error fetching address for unit "wordpress/0": private no address`)
+	c.Assert(err, gc.ErrorMatches, `error fetching address for unit "wordpress/0": no private address`)
 }
 
 func (s *clientSuite) TestClientPrivateAddress(c *gc.C) {

--- a/apiserver/uniter/uniter.go
+++ b/apiserver/uniter/uniter.go
@@ -287,7 +287,7 @@ func (u *UniterAPIV3) PublicAddress(args params.Entities) (params.StringResults,
 				address, err = unit.PublicAddress()
 				if err == nil {
 					result.Results[i].Result = address.Value
-				} else if network.IsNoAddress(err) {
+				} else if network.IsNoAddressError(err) {
 					err = common.NoAddressSetError(tag, "public")
 				}
 			}
@@ -321,7 +321,7 @@ func (u *UniterAPIV3) PrivateAddress(args params.Entities) (params.StringResults
 				address, err = unit.PrivateAddress()
 				if err == nil {
 					result.Results[i].Result = address.Value
-				} else if network.IsNoAddress(err) {
+				} else if network.IsNoAddressError(err) {
 					err = common.NoAddressSetError(tag, "private")
 				}
 			}
@@ -1585,7 +1585,7 @@ func (u *UniterAPIV3) getOneNetworkConfig(canAccess common.AuthFunc, unitTagArg,
 		)
 
 		privateAddress, err := machine.PrivateAddress()
-		if err != nil && !network.IsNoAddress(err) {
+		if err != nil && !network.IsNoAddressError(err) {
 			return nil, errors.Annotatef(err, "getting machine %q preferred private address", machineID)
 		}
 

--- a/network/network.go
+++ b/network/network.go
@@ -29,15 +29,17 @@ type noAddress struct {
 	errors.Err
 }
 
-// NoAddressf returns an error which satisfies IsNoAddress().
-func NoAddressf(format string, args ...interface{}) error {
-	newErr := errors.NewErr(format+" no address", args...)
+// NoAddressError returns an error which satisfies IsNoAddressError(). The given
+// addressKind specifies what kind of address is missing, usually "private" or
+// "public".
+func NoAddressError(addressKind string) error {
+	newErr := errors.NewErr("no %s address", addressKind)
 	newErr.SetLocation(1)
 	return &noAddress{newErr}
 }
 
-// IsNoAddress reports whether err was created with NoAddressf().
-func IsNoAddress(err error) bool {
+// IsNoAddressError reports whether err was created with NoAddressError().
+func IsNoAddressError(err error) bool {
 	err = errors.Cause(err)
 	_, ok := err.(*noAddress)
 	return ok

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -170,8 +170,8 @@ LXC_BRIDGE="ignored"`[1:])
 }
 
 func (s *NetworkSuite) TestNoAddressError(c *gc.C) {
-	err := network.NoAddressf("boom")
-	c.Assert(err, gc.ErrorMatches, "boom no address")
-	c.Assert(network.IsNoAddress(err), jc.IsTrue)
-	c.Assert(network.IsNoAddress(errors.New("address found")), jc.IsFalse)
+	err := network.NoAddressError("fake")
+	c.Assert(err, gc.ErrorMatches, "no fake address")
+	c.Assert(network.IsNoAddressError(err), jc.IsTrue)
+	c.Assert(network.IsNoAddressError(errors.New("address found")), jc.IsFalse)
 }

--- a/state/backups/restore.go
+++ b/state/backups/restore.go
@@ -234,7 +234,7 @@ func setAgentAddressScript(stateAddr string) string {
 func runMachineUpdate(machine *state.Machine, sshArg string) error {
 	addr, err := machine.PublicAddress()
 	if err != nil {
-		if network.IsNoAddress(err) {
+		if network.IsNoAddressError(err) {
 			return errors.Annotatef(err, "no appropriate public address found")
 		}
 		return errors.Trace(err)

--- a/state/machine.go
+++ b/state/machine.go
@@ -1163,12 +1163,12 @@ func containsAddress(addresses []address, address address) bool {
 }
 
 // PublicAddress returns a public address for the machine. If no address is
-// available it returns an error that satisfies network.IsNoAddress.
+// available it returns an error that satisfies network.IsNoAddressError().
 func (m *Machine) PublicAddress() (network.Address, error) {
 	publicAddress := m.doc.PreferredPublicAddress.networkAddress()
 	var err error
 	if publicAddress.Value == "" {
-		err = network.NoAddressf("public")
+		err = network.NoAddressError("public")
 	}
 	return publicAddress, err
 }
@@ -1215,12 +1215,12 @@ func maybeGetNewAddress(addr address, providerAddresses, machineAddresses []addr
 }
 
 // PrivateAddress returns a private address for the machine. If no address is
-// available it returns an error that satisfies network.IsNoAddress.
+// available it returns an error that satisfies network.IsNoAddressError().
 func (m *Machine) PrivateAddress() (network.Address, error) {
 	privateAddress := m.doc.PreferredPrivateAddress.networkAddress()
 	var err error
 	if privateAddress.Value == "" {
-		err = network.NoAddressf("private")
+		err = network.NoAddressError("private")
 	}
 	return privateAddress, err
 }

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -1858,7 +1858,7 @@ func (s *MachineSuite) TestPublicAddressEmptyAddresses(c *gc.C) {
 	c.Assert(machine.Addresses(), gc.HasLen, 0)
 
 	addr, err := machine.PublicAddress()
-	c.Assert(err, jc.Satisfies, network.IsNoAddress)
+	c.Assert(err, jc.Satisfies, network.IsNoAddressError)
 	c.Assert(addr.Value, gc.Equals, "")
 }
 
@@ -1868,7 +1868,7 @@ func (s *MachineSuite) TestPrivateAddressEmptyAddresses(c *gc.C) {
 	c.Assert(machine.Addresses(), gc.HasLen, 0)
 
 	addr, err := machine.PrivateAddress()
-	c.Assert(err, jc.Satisfies, network.IsNoAddress)
+	c.Assert(err, jc.Satisfies, network.IsNoAddressError)
 	c.Assert(addr.Value, gc.Equals, "")
 }
 

--- a/state/unit_test.go
+++ b/state/unit_test.go
@@ -217,7 +217,7 @@ func (s *UnitSuite) TestPublicAddress(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	_, err = s.unit.PublicAddress()
-	c.Assert(err, jc.Satisfies, network.IsNoAddress)
+	c.Assert(err, jc.Satisfies, network.IsNoAddressError)
 
 	public := network.NewScopedAddress("8.8.8.8", network.ScopePublic)
 	private := network.NewScopedAddress("127.0.0.1", network.ScopeCloudLocal)
@@ -314,7 +314,7 @@ func (s *UnitSuite) TestPrivateAddress(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	_, err = s.unit.PrivateAddress()
-	c.Assert(err, jc.Satisfies, network.IsNoAddress)
+	c.Assert(err, jc.Satisfies, network.IsNoAddressError)
 
 	public := network.NewScopedAddress("8.8.8.8", network.ScopePublic)
 	private := network.NewScopedAddress("127.0.0.1", network.ScopeCloudLocal)

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -81,14 +81,14 @@ func assertMachineAddresses(c *gc.C, machine *Machine, publicAddress, privateAdd
 	if publicAddress != "" {
 		c.Assert(err, jc.ErrorIsNil)
 	} else {
-		c.Assert(err, jc.Satisfies, network.IsNoAddress)
+		c.Assert(err, jc.Satisfies, network.IsNoAddressError)
 	}
 	c.Assert(addr.Value, gc.Equals, publicAddress)
 	privAddr, err := machine.PrivateAddress()
 	if privateAddress != "" {
 		c.Assert(err, jc.ErrorIsNil)
 	} else {
-		c.Assert(err, jc.Satisfies, network.IsNoAddress)
+		c.Assert(err, jc.Satisfies, network.IsNoAddressError)
 	}
 	c.Assert(privAddr.Value, gc.Equals, privateAddress)
 }


### PR DESCRIPTION
This fixes a couple of long standing inproperly formatted error messages
when private and public addresses of a machine are missing.

(Review request: http://reviews.vapour.ws/r/4839/)