### PR TITLE
provider/gce: support environschema Schema

### DIFF
--- a/environs/interface.go
+++ b/environs/interface.go
@@ -4,6 +4,8 @@
 package environs
 
 import (
+	"gopkg.in/juju/environschema.v1"
+
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/constraints"
 	"github.com/juju/juju/environs/config"
@@ -54,6 +56,17 @@ type EnvironProvider interface {
 	SecretAttrs(cfg *config.Config) (map[string]string, error)
 
 	ProviderCredentials
+}
+
+// ProviderSchema can be implemented by a provider to provide
+// access to its configuration schema. Once all providers implement
+// this, it will be included in the EnvironProvider type and the
+// information made available over the API.
+type ProviderSchema interface {
+	// Schema returns the schema for the provider. It should
+	// include all fields defined in environs/config, conventionally
+	// by calling config.Schema.
+	Schema() environschema.Fields
 }
 
 // BootstrapConfigParams contains the parameters for EnvironProvider.BootstrapConfig.

--- a/provider/gce/config.go
+++ b/provider/gce/config.go
@@ -6,6 +6,7 @@ package gce
 import (
 	"github.com/juju/errors"
 	"github.com/juju/schema"
+	"gopkg.in/juju/environschema.v1"
 
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/provider/gce/google"
@@ -31,15 +32,67 @@ const (
 	cfgImageEndpoint = "image-endpoint"
 )
 
-// configFields is the spec for each GCE config value's type.
-var configFields = schema.Fields{
-	cfgPrivateKey:    schema.String(),
-	cfgClientID:      schema.String(),
-	cfgClientEmail:   schema.String(),
-	cfgRegion:        schema.String(),
-	cfgProjectID:     schema.String(),
-	cfgImageEndpoint: schema.String(),
+var configSchema = environschema.Fields{
+	cfgPrivateKey: {
+		Type: environschema.Tstring,
+		Description: cfgPrivateKey + ` is the private key that matches the public key
+associated with the GCE account.`,
+		EnvVar:    google.OSEnvPrivateKey,
+		Group:     environschema.AccountGroup,
+		Secret:    true,
+		Mandatory: true,
+	},
+	cfgClientID: {
+		Type:        environschema.Tstring,
+		Description: cfgClientID + ` is the GCE account's OAuth ID.`,
+		EnvVar:      google.OSEnvClientID,
+		Group:       environschema.AccountGroup,
+		Mandatory:   true,
+	},
+	cfgClientEmail: {
+		Type:        environschema.Tstring,
+		Description: cfgClientEmail + ` is the email address associated with the GCE account.`,
+		EnvVar:      google.OSEnvClientEmail,
+		Group:       environschema.AccountGroup,
+		Mandatory:   true,
+	},
+	cfgProjectID: {
+		Type:        environschema.Tstring,
+		Description: cfgProjectID + ` is the project ID to use in all GCE API requests`,
+		EnvVar:      google.OSEnvProjectID,
+		Group:       environschema.AccountGroup,
+		Mandatory:   true,
+	},
+	cfgRegion: {
+		Type:        environschema.Tstring,
+		Description: cfgRegion + ` is the GCE region in which to operate`,
+		EnvVar:      google.OSEnvRegion,
+	},
+	cfgImageEndpoint: {
+		Type:        environschema.Tstring,
+		Description: cfgImageEndpoint + ` identifies where the provider should look for cloud images (i.e. for simplestreams)`,
+		EnvVar:      google.OSEnvImageEndpoint,
+	},
 }
+
+var osEnvFields = func() map[string]string {
+	m := make(map[string]string)
+	for name, f := range configSchema {
+		if f.EnvVar != "" {
+			m[f.EnvVar] = name
+		}
+	}
+	return m
+}()
+
+// configFields is the spec for each GCE config value's type.
+var configFields = func() schema.Fields {
+	fs, _, err := configSchema.ValidationSchema()
+	if err != nil {
+		panic(err)
+	}
+	return fs
+}()
 
 // TODO(ericsnow) Do we need custom defaults for "image-metadata-url" or
 // "agent-metadata-url"? The defaults are the official ones (e.g.
@@ -51,10 +104,6 @@ var configDefaults = schema.Defaults{
 	cfgRegion:        "us-central1",
 }
 
-var configSecretFields = []string{
-	cfgPrivateKey,
-}
-
 var configImmutableFields = []string{
 	cfgPrivateKey,
 	cfgClientID,
@@ -64,109 +113,73 @@ var configImmutableFields = []string{
 	cfgImageEndpoint,
 }
 
-var configAuthFields = []string{
-	cfgPrivateKey,
-	cfgProjectID,
-	cfgClientID,
-	cfgClientEmail,
-}
-
-// osEnvFields is the mapping from GCE env vars to config keys.
-var osEnvFields = map[string]string{
-	google.OSEnvPrivateKey:    cfgPrivateKey,
-	google.OSEnvClientID:      cfgClientID,
-	google.OSEnvClientEmail:   cfgClientEmail,
-	google.OSEnvRegion:        cfgRegion,
-	google.OSEnvProjectID:     cfgProjectID,
-	google.OSEnvImageEndpoint: cfgImageEndpoint,
-}
-
-// handleInvalidField converts a google.InvalidConfigValue into a new
-// error, translating a {provider/gce/google}.OSEnvVar* value into a
-// GCE config key in the new error.
-func handleInvalidField(err error) error {
-	vErr := err.(*google.InvalidConfigValue)
-	if strValue, ok := vErr.Value.(string); ok && strValue == "" {
-		key := osEnvFields[vErr.Key]
-		return errors.Errorf("%s: must not be empty", key)
-	}
-	return err
-}
-
 type environConfig struct {
-	*config.Config
+	config      *config.Config
 	attrs       map[string]interface{}
-	credentials *google.Credentials
+	credentials google.Credentials
+	conn        google.ConnectionConfig
 }
 
-// newConfig builds a new environConfig from the provided Config and
-// returns it.
-func newConfig(cfg *config.Config) *environConfig {
-	return &environConfig{
-		Config: cfg,
-		attrs:  cfg.UnknownAttrs(),
-	}
-}
-
-// newValidConfig builds a new environConfig from the provided Config
-// and returns it. This includes applying the provided defaults
-// values, if any. The resulting config values are validated.
-func newValidConfig(cfg *config.Config, defaults map[string]interface{}) (*environConfig, error) {
-	credentials, err := parseCredentials(cfg)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	handled, err := applyCredentials(cfg, credentials)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	cfg = handled
-
+// newConfig builds a new environConfig from the provided Config
+// filling in default values, if any. It returns an error if the
+// resulting configuration is not valid.
+func newConfig(cfg, old *config.Config) (*environConfig, error) {
 	// Ensure that the provided config is valid.
-	if err := config.Validate(cfg, nil); err != nil {
+	if err := config.Validate(cfg, old); err != nil {
 		return nil, errors.Trace(err)
 	}
-
-	// Apply the defaults and coerce/validate the custom config attrs.
-	validated, err := cfg.ValidateUnknownAttrs(configFields, defaults)
+	attrs, err := cfg.ValidateUnknownAttrs(configFields, configDefaults)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	validCfg, err := cfg.Apply(validated)
+	// We don't allow an empty string for any attribute.
+	for attr, value := range attrs {
+		if value == "" {
+			return nil, errors.Errorf("%s: must not be empty", attr)
+		}
+	}
+	newCfg, err := cfg.Apply(attrs)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-
-	// Build the config.
-	ecfg := newConfig(validCfg)
-	ecfg.credentials = credentials
-
-	// Do final validation.
-	if err := ecfg.validate(); err != nil {
+	credentials, err := parseCredentials(attrs)
+	if err != nil {
 		return nil, errors.Trace(err)
 	}
-
+	ecfg := &environConfig{
+		config:      newCfg,
+		attrs:       attrs,
+		credentials: *credentials,
+		conn: google.ConnectionConfig{
+			Region:    attrs[cfgRegion].(string),
+			ProjectID: attrs[cfgProjectID].(string),
+		},
+	}
+	// Verify that the connection object is valid.
+	if err := ecfg.conn.Validate(); err != nil {
+		return nil, errors.Trace(handleInvalidFieldError(err))
+	}
+	if old == nil {
+		return ecfg, nil
+	}
+	// There's an old configuration. Validate it so that any
+	// default values are correctly coerced for when we
+	// check the old values later.
+	oldEcfg, err := newConfig(old, nil)
+	if err != nil {
+		return nil, errors.Annotatef(err, "invalid base config")
+	}
+	for _, attr := range configImmutableFields {
+		oldv, newv := oldEcfg.attrs[attr], ecfg.attrs[attr]
+		if oldv != newv {
+			return nil, errors.Errorf("%s: cannot change from %v to %v", attr, oldv, newv)
+		}
+	}
 	return ecfg, nil
 }
 
-func (c *environConfig) privateKey() string {
-	return c.attrs[cfgPrivateKey].(string)
-}
-
-func (c *environConfig) clientID() string {
-	return c.attrs[cfgClientID].(string)
-}
-
-func (c *environConfig) clientEmail() string {
-	return c.attrs[cfgClientEmail].(string)
-}
-
 func (c *environConfig) region() string {
-	return c.attrs[cfgRegion].(string)
-}
-
-func (c *environConfig) projectID() string {
-	return c.attrs[cfgProjectID].(string)
+	return c.conn.Region
 }
 
 // imageEndpoint identifies where the provider should look for
@@ -175,122 +188,45 @@ func (c *environConfig) imageEndpoint() string {
 	return c.attrs[cfgImageEndpoint].(string)
 }
 
-// auth build a new Credentials based on the config and returns it.
-func (c *environConfig) auth() *google.Credentials {
-	if c.credentials == nil {
-		c.credentials = &google.Credentials{
-			ClientID:    c.clientID(),
-			ClientEmail: c.clientEmail(),
-			PrivateKey:  []byte(c.privateKey()),
-		}
-	}
-	return c.credentials
-}
-
-// newConnection build a ConnectionConfig based on the config and returns it.
-func (c *environConfig) newConnection() google.ConnectionConfig {
-	return google.ConnectionConfig{
-		Region:    c.region(),
-		ProjectID: c.projectID(),
-	}
-}
-
-// secret gathers the "secret" config values and returns them.
+// secret returns the secret configuration values.
 func (c *environConfig) secret() map[string]string {
-	secretAttrs := make(map[string]string, len(configSecretFields))
-	for _, key := range configSecretFields {
-		secretAttrs[key] = c.attrs[key].(string)
+	secretAttrs := make(map[string]string)
+	for attr, val := range c.attrs {
+		if configSchema[attr].Secret {
+			secretAttrs[attr] = val.(string)
+		}
 	}
 	return secretAttrs
 }
 
-// validate checks GCE-specific config values.
-func (c environConfig) validate() error {
-	// All fields must be populated, even with just the default.
-	for field := range configFields {
-		if dflt, ok := configDefaults[field]; ok && dflt == "" {
-			continue
-		}
-		if c.attrs[field].(string) == "" {
-			return errors.Errorf("%s: must not be empty", field)
-		}
-	}
-
-	// Check sanity of GCE fields.
-	if err := c.auth().Validate(); err != nil {
-		return errors.Trace(handleInvalidField(err))
-	}
-	if err := c.newConnection().Validate(); err != nil {
-		return errors.Trace(handleInvalidField(err))
-	}
-
-	return nil
-}
-
-// update applies changes from the provided config to the env config.
-// Changes to any immutable attributes result in an error.
-func (c *environConfig) update(cfg *config.Config) error {
-	// Validate the updates. newValidConfig does not modify the "known"
-	// config attributes so it is safe to call Validate here first.
-	if err := config.Validate(cfg, c.Config); err != nil {
-		return errors.Trace(err)
-	}
-
-	updates, err := newValidConfig(cfg, configDefaults)
-	if err != nil {
-		return errors.Trace(err)
-	}
-
-	// Check that no immutable fields have changed.
-	attrs := updates.UnknownAttrs()
-	for _, field := range configImmutableFields {
-		if attrs[field] != c.attrs[field] {
-			return errors.Errorf("%s: cannot change from %v to %v", field, c.attrs[field], attrs[field])
-		}
-	}
-
-	// Apply the updates.
-	c.Config = cfg
-	c.attrs = cfg.UnknownAttrs()
-	return nil
-}
-
 // parseCredentials extracts the OAuth2 info from the config from the
 // individual fields (falling back on the JSON file).
-func parseCredentials(cfg *config.Config) (*google.Credentials, error) {
-	attrs := cfg.UnknownAttrs()
+func parseCredentials(attrs map[string]interface{}) (*google.Credentials, error) {
 	values := make(map[string]string)
-	for _, field := range configAuthFields {
-		if existing, ok := attrs[field].(string); ok && existing != "" {
-			for key, candidate := range osEnvFields {
-				if field == candidate {
-					values[key] = existing
-					break
-				}
-			}
+	for attr, val := range attrs {
+		f := configSchema[attr]
+		if f.Group == environschema.AccountGroup && f.EnvVar != "" {
+			values[f.EnvVar] = val.(string)
 		}
 	}
-	return google.NewCredentials(values)
+	creds, err := google.NewCredentials(values)
+	if err != nil {
+		return nil, handleInvalidFieldError(err)
+	}
+	return creds, nil
 }
 
-func applyCredentials(cfg *config.Config, creds *google.Credentials) (*config.Config, error) {
-	updates := make(map[string]interface{})
-	for k, v := range creds.Values() {
-		if v == "" {
-			continue
-		}
-		if field, ok := osEnvFields[k]; ok {
-			for _, authField := range configAuthFields {
-				if field == authField {
-					updates[field] = v
-					break
-				}
-			}
-		}
+// handleInvalidFieldError converts a google.InvalidConfigValue into a new
+// error, translating a {provider/gce/google}.OSEnvVar* value into a
+// GCE config key in the new error.
+func handleInvalidFieldError(err error) error {
+	vErr, ok := errors.Cause(err).(*google.InvalidConfigValueError)
+	if !ok {
+		return err
 	}
-	updated, err := cfg.Apply(updates)
-	if err != nil {
-		return nil, errors.Trace(err)
+	vErr.Key = osEnvFields[vErr.Key]
+	if vErr.Value == "" {
+		return errors.Errorf("%s: must not be empty", vErr.Key)
 	}
-	return updated, nil
+	return err
 }

--- a/provider/gce/environ_test.go
+++ b/provider/gce/environ_test.go
@@ -54,14 +54,6 @@ func (s *environSuite) TestSetConfigFake(c *gc.C) {
 	c.Check(s.FakeConn.Calls, gc.HasLen, 0)
 }
 
-func (s *environSuite) TestSetConfigMissing(c *gc.C) {
-	gce.UnsetEnvConfig(s.Env)
-
-	err := s.Env.SetConfig(s.Config)
-
-	c.Check(err, gc.ErrorMatches, "cannot set config on uninitialized env")
-}
-
 func (s *environSuite) TestConfig(c *gc.C) {
 	cfg := s.Env.Config()
 

--- a/provider/gce/export_test.go
+++ b/provider/gce/export_test.go
@@ -36,10 +36,6 @@ func ParseAvailabilityZones(env *environ, args environs.StartInstanceParams) ([]
 	return env.parseAvailabilityZones(args)
 }
 
-func UnsetEnvConfig(env *environ) {
-	env.ecfg = nil
-}
-
 func ExposeEnvConfig(env *environ) *environConfig {
 	return env.ecfg
 }

--- a/provider/gce/google/config.go
+++ b/provider/gce/google/config.go
@@ -72,15 +72,14 @@ func NewCredentials(values map[string]string) (*Credentials, error) {
 			return nil, errors.NotSupportedf("key %q", k)
 		}
 	}
-
-	if err := creds.Validate(); err == nil {
-		jk, err := creds.buildJSONKey()
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		creds.JSONKey = jk
+	if err := creds.Validate(); err != nil {
+		return nil, errors.Trace(err)
 	}
-
+	jk, err := creds.buildJSONKey()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	creds.JSONKey = jk
 	return &creds, nil
 }
 
@@ -173,7 +172,7 @@ func (gc Credentials) Validate() error {
 		return NewMissingConfigValue(OSEnvClientEmail, "ClientEmail")
 	}
 	if _, err := mail.ParseAddress(gc.ClientEmail); err != nil {
-		return NewInvalidConfigValue(OSEnvClientEmail, gc.ClientEmail, err)
+		return NewInvalidConfigValueError(OSEnvClientEmail, gc.ClientEmail, err)
 	}
 	if len(gc.PrivateKey) == 0 {
 		return NewMissingConfigValue(OSEnvPrivateKey, "PrivateKey")
@@ -193,7 +192,7 @@ type ConnectionConfig struct {
 }
 
 // Validate checks the connection's fields for invalid values.
-// If the values are not valid, it returns a config.InvalidConfigValue
+// If the values are not valid, it returns a config.InvalidConfigValueError
 // error with the key set to the corresponding OS environment variable
 // name.
 //

--- a/provider/gce/google/config_connection_test.go
+++ b/provider/gce/google/config_connection_test.go
@@ -32,8 +32,8 @@ func (*connConfigSuite) TestValidateMissingRegion(c *gc.C) {
 	}
 	err := cfg.Validate()
 
-	c.Assert(err, gc.FitsTypeOf, &google.InvalidConfigValue{})
-	c.Check(err.(*google.InvalidConfigValue).Key, gc.Equals, "GCE_REGION")
+	c.Assert(err, gc.FitsTypeOf, &google.InvalidConfigValueError{})
+	c.Check(err.(*google.InvalidConfigValueError).Key, gc.Equals, "GCE_REGION")
 }
 
 func (*connConfigSuite) TestValidateMissingProjectID(c *gc.C) {
@@ -42,6 +42,6 @@ func (*connConfigSuite) TestValidateMissingProjectID(c *gc.C) {
 	}
 	err := cfg.Validate()
 
-	c.Assert(err, gc.FitsTypeOf, &google.InvalidConfigValue{})
-	c.Check(err.(*google.InvalidConfigValue).Key, gc.Equals, "GCE_PROJECT_ID")
+	c.Assert(err, gc.FitsTypeOf, &google.InvalidConfigValueError{})
+	c.Check(err.(*google.InvalidConfigValueError).Key, gc.Equals, "GCE_PROJECT_ID")
 }

--- a/provider/gce/google/errors.go
+++ b/provider/gce/google/errors.go
@@ -9,74 +9,49 @@ import (
 	"github.com/juju/errors"
 )
 
-// InvalidConfigValue indicates that one of the config values failed validation.
-type InvalidConfigValue struct {
+// InvalidConfigValueError indicates that one of the config values failed validation.
+type InvalidConfigValueError struct {
 	errors.Err
-	cause error
 
 	// Key is the OS env var corresponding to the field with the bad value.
 	Key string
 
 	// Value is the invalid value.
 	Value interface{}
-
-	// Reason is the underlying error.
-	Reason error
 }
 
-// IsInvalidConfigValue returns whether or not the provided error is
-// an InvalidConfigValue (or caused by one).
-func IsInvalidConfigValue(err error) bool {
-	if _, ok := err.(*InvalidConfigValue); ok {
-		return true
-	}
-	err = errors.Cause(err)
-	_, ok := err.(InvalidConfigValue)
+// IsInvalidConfigValueError returns whether or not the cause of
+// the provided error is a *InvalidConfigValueError.
+func IsInvalidConfigValueError(err error) bool {
+	_, ok := errors.Cause(err).(*InvalidConfigValueError)
 	return ok
 }
 
-// NewInvalidConfigValue returns a new InvalidConfigValue for the given
+// NewInvalidConfigValueError returns a new InvalidConfigValueError for the given
 // info. If the provided reason is an error then Reason is set to that
 // error. Otherwise a non-nil value is treated as a string and Reason is
 // set to a non-nil value that wraps it.
-func NewInvalidConfigValue(key string, value, reason interface{}) error {
-	var underlying error
-	switch reason := reason.(type) {
-	case error:
-		underlying = reason
-	default:
-		if reason != nil {
-			underlying = errors.Errorf("%v", reason)
-		}
+func NewInvalidConfigValueError(key, value string, reason error) error {
+	err := &InvalidConfigValueError{
+		Err:   *errors.Mask(reason).(*errors.Err),
+		Key:   key,
+		Value: value,
 	}
-	err := &InvalidConfigValue{
-		cause:  errors.NewNotValid(underlying, "GCE config value"),
-		Key:    key,
-		Value:  value,
-		Reason: underlying,
-	}
-	err.Err = errors.NewErr("config value")
 	err.Err.SetLocation(1)
+	return err
+}
+
+// Cause implements errors.Causer.Cause.
+func (err *InvalidConfigValueError) Cause() error {
 	return err
 }
 
 // NewMissingConfigValue returns a new error for a missing config field.
 func NewMissingConfigValue(key, field string) error {
-	return NewInvalidConfigValue(key, "", "missing "+field)
-}
-
-// Cause implements errors.causer. This is necessary so that
-// errors.IsNotValid works.
-func (err *InvalidConfigValue) Cause() error {
-	return err.cause
-}
-
-// Underlying implements errors.wrapper.
-func (err InvalidConfigValue) Underlying() error {
-	return err.cause
+	return NewInvalidConfigValueError(key, "", errors.New("missing "+field))
 }
 
 // Error implements error.
-func (err InvalidConfigValue) Error() string {
-	return fmt.Sprintf("invalid config value (%s) for %q: %v", err.Value, err.Key, err.Reason)
+func (err InvalidConfigValueError) Error() string {
+	return fmt.Sprintf("invalid config value (%s) for %q: %v", err.Value, err.Key, &err.Err)
 }

--- a/provider/gce/testing_test.go
+++ b/provider/gce/testing_test.go
@@ -189,7 +189,7 @@ func (s *BaseSuiteUnpatched) initNet(c *gc.C) {
 
 func (s *BaseSuiteUnpatched) setConfig(c *gc.C, cfg *config.Config) {
 	s.Config = cfg
-	ecfg, err := newValidConfig(cfg, configDefaults)
+	ecfg, err := newConfig(cfg, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	s.EnvConfig = ecfg
 	uuid := cfg.UUID()


### PR DESCRIPTION
We change the logic so that it derives as much information
as reasonable from the config schema, and simplify
the logic somewhat by canonicalising all required
config info in one place (newConfig).

We also fix provider/gce/google so that NewCredentials returns
an error if validation fails, and fix the error returned from it
so it can be traced.

Also change the return from RestrictedConfigAttributes to remove
fields that should not be restricted (it's OK to have different models
with different client ids).

(Review request: http://reviews.vapour.ws/r/4840/)