### PR TITLE
Ensure parent device is set when address-allocation FF is enabled

### DIFF
--- a/container/lxd/export_test.go
+++ b/container/lxd/export_test.go
@@ -6,5 +6,6 @@
 package lxd
 
 var (
-	NICDevice = nicDevice
+	NICDevice      = nicDevice
+	NetworkDevices = networkDevices
 )

--- a/container/lxd/lxd.go
+++ b/container/lxd/lxd.go
@@ -249,7 +249,14 @@ func networkDevices(networkConfig *container.NetworkConfig) (lxdclient.Devices, 
 			if v.InterfaceType != network.EthernetInterface {
 				return nil, errors.Errorf("interface type %q not supported", v.InterfaceType)
 			}
-			device, err := nicDevice(v.InterfaceName, v.ParentInterfaceName, v.MACAddress, v.MTU)
+			parentDevice := v.ParentInterfaceName
+			if parentDevice == "" {
+				// This happens on AWS when the
+				// address-allocation feature flag is
+				// enabled.
+				parentDevice = networkConfig.Device
+			}
+			device, err := nicDevice(v.InterfaceName, parentDevice, v.MACAddress, v.MTU)
 			if err != nil {
 				return nil, errors.Trace(err)
 			}


### PR DESCRIPTION
The CI test 'functional-container-networking-lxd' fails when the
address-allocation feature flag is enabled. Although we have a list of
interfaces to write for the LXD container configuration the setup in
this case (address-allocation enabled) does not have a suitable parent
device defined, hence the message "invalid parent device" when looking
at the juju status output.

Fixes [LP:#1581627](https://bugs.launchpad.net/juju-core/+bug/1581627)

(Review request: http://reviews.vapour.ws/r/4844/)