### PR TITLE
apiserver/params: make params.FromNetworkAddresses variadic

### DIFF
--- a/api/instancepoller/machine.go
+++ b/api/instancepoller/machine.go
@@ -170,7 +170,7 @@ func (m *Machine) ProviderAddresses() ([]network.Address, error) {
 	if result.Error != nil {
 		return nil, result.Error
 	}
-	return params.NetworkAddresses(result.Addresses), nil
+	return params.NetworkAddresses(result.Addresses...), nil
 }
 
 // SetProviderAddresses sets the cached provider addresses for the
@@ -180,7 +180,7 @@ func (m *Machine) SetProviderAddresses(addrs ...network.Address) error {
 	args := params.SetMachinesAddresses{
 		MachineAddresses: []params.MachineAddresses{{
 			Tag:       m.tag.String(),
-			Addresses: params.FromNetworkAddresses(addrs),
+			Addresses: params.FromNetworkAddresses(addrs...),
 		}}}
 	err := m.facade.FacadeCall("SetProviderAddresses", args, &result)
 	if err != nil {

--- a/api/instancepoller/machine_test.go
+++ b/api/instancepoller/machine_test.go
@@ -241,7 +241,7 @@ func (s *MachineSuite) TestProviderAddressesSuccess(c *gc.C) {
 	addresses := network.NewAddresses("2001:db8::1", "0.1.2.3")
 	results := params.MachineAddressesResults{
 		Results: []params.MachineAddressesResult{{
-			Addresses: params.FromNetworkAddresses(addresses),
+			Addresses: params.FromNetworkAddresses(addresses...),
 		}}}
 	apiCaller := successAPICaller(c, "ProviderAddresses", entitiesArgs, results, &called)
 	machine := instancepoller.NewMachine(apiCaller, s.tag, params.Alive)
@@ -257,7 +257,7 @@ func (s *MachineSuite) TestSetProviderAddressesSuccess(c *gc.C) {
 	expectArgs := params.SetMachinesAddresses{
 		MachineAddresses: []params.MachineAddresses{{
 			Tag:       "machine-42",
-			Addresses: params.FromNetworkAddresses(addresses),
+			Addresses: params.FromNetworkAddresses(addresses...),
 		}}}
 	results := params.ErrorResults{
 		Results: []params.ErrorResult{{Error: nil}},

--- a/api/machiner/machine.go
+++ b/api/machiner/machine.go
@@ -61,7 +61,7 @@ func (m *Machine) SetMachineAddresses(addresses []network.Address) error {
 	var result params.ErrorResults
 	args := params.SetMachinesAddresses{
 		MachineAddresses: []params.MachineAddresses{
-			{Tag: m.Tag().String(), Addresses: params.FromNetworkAddresses(addresses)},
+			{Tag: m.Tag().String(), Addresses: params.FromNetworkAddresses(addresses...)},
 		},
 	}
 	err := m.st.facade.FacadeCall("SetMachineAddresses", args, &result)

--- a/apiserver/client/client.go
+++ b/apiserver/client/client.go
@@ -258,7 +258,7 @@ func (c *Client) addOneMachine(p params.AddMachineParams) (*state.Machine, error
 		Jobs:        jobs,
 		Nonce:       p.Nonce,
 		HardwareCharacteristics: p.HardwareCharacteristics,
-		Addresses:               params.NetworkAddresses(p.Addrs),
+		Addresses:               params.NetworkAddresses(p.Addrs...),
 		Placement:               placementDirective,
 	}
 	if p.ContainerType == "" {

--- a/apiserver/client/client_test.go
+++ b/apiserver/client/client_test.go
@@ -1168,7 +1168,7 @@ func (s *clientSuite) TestClientAddMachinesWithInstanceIdSomeErrors(c *gc.C) {
 			InstanceId: instance.Id(fmt.Sprintf("1234-%d", i)),
 			Nonce:      "foo",
 			HardwareCharacteristics: hc,
-			Addrs: params.FromNetworkAddresses(addrs),
+			Addrs: params.FromNetworkAddresses(addrs...),
 		}
 	}
 	// This will cause the last add-machine to fail.

--- a/apiserver/client/instanceconfig_test.go
+++ b/apiserver/client/instanceconfig_test.go
@@ -39,7 +39,7 @@ func (s *machineConfigSuite) TestMachineConfig(c *gc.C) {
 		InstanceId: instance.Id("1234"),
 		Nonce:      "foo",
 		HardwareCharacteristics: hc,
-		Addrs: params.FromNetworkAddresses(addrs),
+		Addrs: params.FromNetworkAddresses(addrs...),
 	}
 	machines, err := s.APIState.Client().AddMachines([]params.AddMachineParams{apiParams})
 	c.Assert(err, jc.ErrorIsNil)
@@ -115,7 +115,7 @@ func (s *machineConfigSuite) TestMachineConfigNoTools(c *gc.C) {
 		InstanceId: instance.Id("1234"),
 		Nonce:      "foo",
 		HardwareCharacteristics: hc,
-		Addrs: params.FromNetworkAddresses(addrs),
+		Addrs: params.FromNetworkAddresses(addrs...),
 	}
 	machines, err := s.APIState.Client().AddMachines([]params.AddMachineParams{apiParams})
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/instancepoller/instancepoller.go
+++ b/apiserver/instancepoller/instancepoller.go
@@ -137,7 +137,7 @@ func (a *InstancePollerAPI) ProviderAddresses(args params.Entities) (params.Mach
 		machine, err := a.getOneMachine(arg.Tag, canAccess)
 		if err == nil {
 			addrs := machine.ProviderAddresses()
-			result.Results[i].Addresses = params.FromNetworkAddresses(addrs)
+			result.Results[i].Addresses = params.FromNetworkAddresses(addrs...)
 		}
 		result.Results[i].Error = common.ServerError(err)
 	}
@@ -157,7 +157,7 @@ func (a *InstancePollerAPI) SetProviderAddresses(args params.SetMachinesAddresse
 	for i, arg := range args.MachineAddresses {
 		machine, err := a.getOneMachine(arg.Tag, canAccess)
 		if err == nil {
-			addrsToSet := params.NetworkAddresses(arg.Addresses)
+			addrsToSet := params.NetworkAddresses(arg.Addresses...)
 			err = machine.SetProviderAddresses(addrsToSet...)
 		}
 		result.Results[i].Error = common.ServerError(err)

--- a/apiserver/instancepoller/instancepoller_test.go
+++ b/apiserver/instancepoller/instancepoller_test.go
@@ -410,7 +410,7 @@ func (s *InstancePollerSuite) TestStatusFailure(c *gc.C) {
 
 func (s *InstancePollerSuite) TestProviderAddressesSuccess(c *gc.C) {
 	addrs := network.NewAddresses("0.1.2.3", "127.0.0.1", "8.8.8.8")
-	expectedAddresses := params.FromNetworkAddresses(addrs)
+	expectedAddresses := params.FromNetworkAddresses(addrs...)
 	s.st.SetMachineInfo(c, machineInfo{id: "1", providerAddresses: addrs})
 	s.st.SetMachineInfo(c, machineInfo{id: "2", providerAddresses: nil})
 
@@ -471,7 +471,7 @@ func (s *InstancePollerSuite) TestSetProviderAddressesSuccess(c *gc.C) {
 	result, err := s.api.SetProviderAddresses(params.SetMachinesAddresses{
 		MachineAddresses: []params.MachineAddresses{
 			{Tag: "machine-1", Addresses: nil},
-			{Tag: "machine-2", Addresses: params.FromNetworkAddresses(newAddrs)},
+			{Tag: "machine-2", Addresses: params.FromNetworkAddresses(newAddrs...)},
 			{Tag: "machine-42"},
 			{Tag: "service-unknown"},
 			{Tag: "invalid-tag"},
@@ -513,8 +513,8 @@ func (s *InstancePollerSuite) TestSetProviderAddressesFailure(c *gc.C) {
 
 	result, err := s.api.SetProviderAddresses(params.SetMachinesAddresses{
 		MachineAddresses: []params.MachineAddresses{
-			{Tag: "machine-1", Addresses: nil},
-			{Tag: "machine-2", Addresses: params.FromNetworkAddresses(newAddrs)},
+			{Tag: "machine-1"},
+			{Tag: "machine-2", Addresses: params.FromNetworkAddresses(newAddrs...)},
 			{Tag: "machine-3"},
 		}},
 	)

--- a/apiserver/machine/machiner.go
+++ b/apiserver/machine/machiner.go
@@ -88,7 +88,7 @@ func (api *MachinerAPI) SetMachineAddresses(args params.SetMachinesAddresses) (p
 			var m *state.Machine
 			m, err = api.getMachine(tag)
 			if err == nil {
-				addresses := params.NetworkAddresses(arg.Addresses)
+				addresses := params.NetworkAddresses(arg.Addresses...)
 				err = m.SetMachineAddresses(addresses...)
 			} else if errors.IsNotFound(err) {
 				err = common.ErrPerm

--- a/apiserver/machine/machiner_test.go
+++ b/apiserver/machine/machiner_test.go
@@ -173,9 +173,9 @@ func (s *machinerSuite) TestSetMachineAddresses(c *gc.C) {
 	addresses := network.NewAddresses("127.0.0.1", "8.8.8.8")
 
 	args := params.SetMachinesAddresses{MachineAddresses: []params.MachineAddresses{
-		{Tag: "machine-1", Addresses: params.FromNetworkAddresses(addresses)},
-		{Tag: "machine-0", Addresses: params.FromNetworkAddresses(addresses)},
-		{Tag: "machine-42", Addresses: params.FromNetworkAddresses(addresses)},
+		{Tag: "machine-1", Addresses: params.FromNetworkAddresses(addresses...)},
+		{Tag: "machine-0", Addresses: params.FromNetworkAddresses(addresses...)},
+		{Tag: "machine-42", Addresses: params.FromNetworkAddresses(addresses...)},
 	}}
 
 	result, err := s.machiner.SetMachineAddresses(args)
@@ -202,7 +202,7 @@ func (s *machinerSuite) TestSetEmptyMachineAddresses(c *gc.C) {
 	// Set some addresses so we can ensure they are removed.
 	addresses := network.NewAddresses("127.0.0.1", "8.8.8.8")
 	args := params.SetMachinesAddresses{MachineAddresses: []params.MachineAddresses{
-		{Tag: "machine-1", Addresses: params.FromNetworkAddresses(addresses)},
+		{Tag: "machine-1", Addresses: params.FromNetworkAddresses(addresses...)},
 	}}
 	result, err := s.machiner.SetMachineAddresses(args)
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/machinemanager/machinemanager.go
+++ b/apiserver/machinemanager/machinemanager.go
@@ -146,7 +146,7 @@ func (mm *MachineManagerAPI) addOneMachine(p params.AddMachineParams) (*state.Ma
 		Jobs:        jobs,
 		Nonce:       p.Nonce,
 		HardwareCharacteristics: p.HardwareCharacteristics,
-		Addresses:               params.NetworkAddresses(p.Addrs),
+		Addresses:               params.NetworkAddresses(p.Addrs...),
 		Placement:               placementDirective,
 	}
 	if p.ContainerType == "" {

--- a/apiserver/params/network.go
+++ b/apiserver/params/network.go
@@ -265,7 +265,7 @@ func (addr Address) NetworkAddress() network.Address {
 
 // FromNetworkAddresses is a convenience helper to create a parameter
 // out of the network type, here for a slice of Address.
-func FromNetworkAddresses(naddrs []network.Address) []Address {
+func FromNetworkAddresses(naddrs ...network.Address) []Address {
 	addrs := make([]Address, len(naddrs))
 	for i, naddr := range naddrs {
 		addrs[i] = FromNetworkAddress(naddr)
@@ -275,7 +275,7 @@ func FromNetworkAddresses(naddrs []network.Address) []Address {
 
 // NetworkAddresses is a convenience helper to return the parameter
 // as network type, here for a slice of Address.
-func NetworkAddresses(addrs []Address) []network.Address {
+func NetworkAddresses(addrs ...Address) []network.Address {
 	naddrs := make([]network.Address, len(addrs))
 	for i, addr := range addrs {
 		naddrs[i] = addr.NetworkAddress()

--- a/environs/manual/provisioner.go
+++ b/environs/manual/provisioner.go
@@ -21,7 +21,6 @@ import (
 	"github.com/juju/juju/cloudconfig/sshinit"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/instance"
-	"github.com/juju/juju/network"
 	"github.com/juju/juju/state/multiwatcher"
 )
 
@@ -158,11 +157,9 @@ func gatherMachineParams(hostname string) (*params.AddMachineParams, error) {
 		return nil, err
 	}
 
-	var addrs []network.Address
-	if addr, err := HostAddress(hostname); err != nil {
-		logger.Warningf("failed to compute public address for %q: %v", hostname, err)
-	} else {
-		addrs = append(addrs, addr)
+	addr, err := HostAddress(hostname)
+	if err != nil {
+		return nil, errors.Annotatef(err, "failed to compute public address for %q", hostname)
 	}
 
 	provisioned, err := checkProvisioned(hostname)
@@ -197,7 +194,7 @@ func gatherMachineParams(hostname string) (*params.AddMachineParams, error) {
 		HardwareCharacteristics: hc,
 		InstanceId:              instanceId,
 		Nonce:                   nonce,
-		Addrs:                   params.FromNetworkAddresses(addrs),
+		Addrs:                   params.FromNetworkAddresses(addr),
 		Jobs:                    []multiwatcher.MachineJob{multiwatcher.JobHostUnits},
 	}
 	return machineParams, nil


### PR DESCRIPTION
Simplifies some callers of params.FromNetworkAddresses, and follows the
trend towards variadic arguments in related parts of the code.

(Review request: http://reviews.vapour.ws/r/4847/)